### PR TITLE
feat(wordpress): detect and warn about conflicting local test infrastructure

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",


### PR DESCRIPTION
## Summary

Expands the wordpress module's `test-runner.sh` to detect and warn about conflicting local test infrastructure that duplicates what Homeboy provides.

### New detections

- **`vendor/bin/phpunit`** — Local PHPUnit binary that may conflict with the module's version
- **`composer.json` require-dev** — phpunit/phpunit dependency that's redundant when using Homeboy

### Auto-fix support (`homeboy test --fix`)

All conflict warnings now support auto-cleanup via `HOMEBOY_AUTO_FIX=1`:

| Conflict | Auto-fix action |
|----------|----------------|
| `vendor/bin/phpunit` | `composer remove --dev phpunit/phpunit` |
| phpunit in require-dev | `composer remove --dev phpunit/phpunit` |
| `tests/bootstrap.php` | `rm` |
| `phpunit.xml` | `rm` |
| `phpunit.xml.dist` | `rm` |

### Context

Discovered when the Spawn plugin had its own PHPUnit 10 alongside the Homeboy wordpress module (PHPUnit 9). Components managed by Homeboy should rely on Homeboy for test infrastructure.

Bumps wordpress module version to 1.4.0.

Closes #20