### PR TITLE
feat: granular audit_feature_patterns for WordPress module

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -235,9 +235,13 @@
     "register_taxonomy\\(\\s*['\"]([\\w-]+)['\"]",
     "register_block_type\\(\\s*['\"]([\\w-]+/[\\w-]+)['\"]",
     "register_setting\\(\\s*['\"]([\\w-]+)['\"]",
-    "register_rest_route\\(\\s*['\"]([\\w-]+/v\\d+)['\"]",
+    "register_rest_route\\([^)]*?,\\s*['\"](/[^'\"]+)['\"]",
     "add_shortcode\\(\\s*['\"]([\\w-]+)['\"]",
     "wp_register_script\\(\\s*['\"]([\\w-]+)['\"]",
-    "wp_register_style\\(\\s*['\"]([\\w-]+)['\"]"
+    "wp_register_style\\(\\s*['\"]([\\w-]+)['\"]",
+    "wp_register_ability\\(\\s*['\"]([^'\"]+)['\"]",
+    "wp_register_ability_category\\(\\s*['\"]([^'\"]+)['\"]",
+    "WP_CLI::add_command\\(\\s*['\"]([^'\"]+)['\"]",
+    "\\$this->registerTool\\(\\s*['\"][^'\"]+['\"]\\s*,\\s*['\"]([^'\"]+)['\"]"
   ]
 }


### PR DESCRIPTION
## What

Expanded `audit_feature_patterns` from 8 to 12 patterns, making feature detection actually useful.

## Changes

**Improved:**
- `register_rest_route` — now captures individual **route paths** (`/flows`, `/chat/sessions`) instead of just the namespace (`datamachine/v1`)

**New patterns:**
- `wp_register_ability()` — WordPress Abilities API registrations
- `wp_register_ability_category()` — Ability category registrations  
- `WP_CLI::add_command()` — CLI command registrations
- `\$this->registerTool()` — Chat tool registrations

## Results

Against data-machine with homeboy v0.45.3:
- **Before:** 0 features detected (namespace-level only, and `datamachine/v1` was in docs)
- **After:** 72 undocumented features detected — abilities, REST routes, chat tools, and CLI commands

## Why this matters

This turns `homeboy docs audit` into a real implementation gap detector. Any registered feature not mentioned in docs surfaces automatically. Works for:
- Finding undocumented API endpoints
- Catching abilities that need docs
- Tracking CLI commands across versions
- Identifying chat tools that users don't know about

## Requires

homeboy v0.45.3+ (PR #112 — full source scan + multi-line matching)