### PR TITLE
feat(wordpress): add post:deploy hooks for plugin activation and cache flush

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -99,6 +99,12 @@
       "wp-test"
     ]
   },
+  "hooks": {
+    "post:deploy": [
+      "wp plugin is-installed {{component_id}} --path={{base_path}} --allow-root 2>/dev/null && wp plugin activate {{component_id}} --path={{base_path}} --allow-root 2>/dev/null || true",
+      "wp cache flush --path={{base_path}} --allow-root 2>/dev/null || true"
+    ]
+  },
   "deploy": {
     "verifications": [
       {


### PR DESCRIPTION
## Summary

Add `post:deploy` hooks to the WordPress module manifest for automatic plugin activation and cache flushing after deploy.

## Hooks Added

1. **Plugin activation** — `wp plugin is-installed` check ensures this only runs for plugins (safe for themes). If the component is an installed plugin, it gets activated.
2. **Cache flush** — `wp cache flush` runs after every deploy to clear stale object cache.

Both commands are non-fatal (`|| true`) so failures don't affect the deploy result.

## Requires

Homeboy >=0.48.1 with remote hook execution support (Extra-Chill/homeboy#178).