### PR TITLE
fix(wordpress): stream PHPUnit output instead of swallowing it

### DIFF
--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -417,15 +417,17 @@ phpunit_args=(
     "${TEST_DIR}"
 )
 
-set +e
-phpunit_output=$("${MODULE_PATH}/vendor/bin/phpunit" "${phpunit_args[@]}" "$@" 2>&1)
-phpunit_exit=$?
-set -e
+PHPUNIT_TMPFILE=$(mktemp)
 
-echo "$phpunit_output"
+set +e
+"${MODULE_PATH}/vendor/bin/phpunit" "${phpunit_args[@]}" "$@" 2>&1 | tee "$PHPUNIT_TMPFILE"
+phpunit_exit=${PIPESTATUS[0]}
+set -e
 
 if [ $phpunit_exit -ne 0 ]; then
     FAILED_STEP="PHPUnit tests"
-    FAILURE_OUTPUT=$(echo "$phpunit_output" | tail -30)
+    FAILURE_OUTPUT=$(tail -30 "$PHPUNIT_TMPFILE")
+    rm -f "$PHPUNIT_TMPFILE"
     exit $phpunit_exit
 fi
+rm -f "$PHPUNIT_TMPFILE"


### PR DESCRIPTION
## Summary

Fix PHPUnit test results being completely invisible when running through homeboy.

## Root Cause

Line 421 captured all PHPUnit output into a shell variable via command substitution:
```bash
phpunit_output=$("${MODULE_PATH}/vendor/bin/phpunit" ... 2>&1)
```

This prevented real-time streaming — nothing hit stdout while PHPUnit ran. The `echo "$phpunit_output"` on line 425 dumped it all at once, but by then homeboy's output capture missed it.

## Fix

Replace variable capture with `tee` to a temp file:
```bash
"${MODULE_PATH}/vendor/bin/phpunit" ... 2>&1 | tee "$PHPUNIT_TMPFILE"
phpunit_exit=${PIPESTATUS[0]}
```

- PHPUnit output streams to stdout in real-time (visible to homeboy)
- `tee` writes a copy to a temp file for the failure summary (`tail -30`)
- `PIPESTATUS[0]` captures PHPUnit's exit code through the pipe

Closes #36