### PR TITLE
Fix PHPUnit test discovery — drop broken XML config

### DIFF
--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -444,7 +444,8 @@ echo "Running PHPUnit tests..."
 
 phpunit_args=(
     --bootstrap="${MODULE_PATH}/tests/bootstrap.php"
-    --configuration="${MODULE_PATH}/phpunit.xml.dist"
+    --no-configuration
+    --colors=auto
     --testdox
     "${TEST_DIR}"
 )


### PR DESCRIPTION
## Summary

Fixes Extra-Chill/homeboy#215 — `homeboy test` runs PHPUnit but discovers zero tests, exits 0 silently.

## Root Cause

The PHPUnit invocation passed `--configuration=${MODULE_PATH}/phpunit.xml.dist` which defines:

```xml
<testsuite>
    <directory>tests/</directory>
</testsuite>
```

That `tests/` resolves relative to the **XML file's location** (the module directory), NOT the component directory. The module's `tests/` only contains `bootstrap.php` — no test classes.

When PHPUnit receives both `--configuration` (with testsuites) and a positional path argument (the component's `tests/`), it finds zero tests in the intersection and exits 0.

The XML also has:
- Unresolved `{{modulePath}}` template placeholders in `<php>` env vars
- Coverage paths relative to the module directory (wrong)

## Fix

Replace `--configuration` with `--no-configuration` + `--colors=auto`. The `--bootstrap` flag and positional test directory already provide everything PHPUnit needs. `--no-configuration` also prevents auto-discovery of local XML files (which the module already warns against).

## Before / After

**Before:** Bootstrap runs ("Installing...", "Running as single site..."), then PHPUnit exits 0 with zero output.

**After:** PHPUnit scans the component's `tests/` directory directly and discovers test files.