### PR TITLE
fix: use HOMEBOY_COMPONENT_ID for build artifact naming

### DIFF
--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -131,6 +131,13 @@ extract_metadata() {
         PROJECT_VERSION=$(grep -i "Version:" "$PROJECT_MAIN_FILE" | head -1 | sed 's/.*Version:[ ]*\([0-9\.]*\).*/\1/')
     fi
 
+    # When invoked by homeboy, use the component ID for artifact naming so the
+    # zip matches the deploy system's artifact_pattern (build/{component_id}.zip).
+    # Falls back to the auto-detected PROJECT_NAME for standalone usage.
+    if [ -n "$HOMEBOY_COMPONENT_ID" ]; then
+        PROJECT_NAME="$HOMEBOY_COMPONENT_ID"
+    fi
+
     if [ -z "$PROJECT_NAME" ]; then
         print_error "Could not extract project name"
         exit 1


### PR DESCRIPTION
## Summary

Companion to Extra-Chill/homeboy#232 — fixes deploy artifact name mismatch (homeboy #227).

## Change

When `HOMEBOY_COMPONENT_ID` is set (passed by homeboy since the companion PR), the build script uses it for zip artifact naming instead of the auto-detected directory/filename. This ensures `build/{component_id}.zip` matches the deploy system's `artifact_pattern`.

Falls back to existing behavior (directory name for themes, plugin filename for plugins) when running standalone.

## Files changed

- `wordpress/scripts/build/build.sh` — use `HOMEBOY_COMPONENT_ID` when available