### PR TITLE
Add feature_context rules and richer doc templates

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -19,31 +19,37 @@
       "Config)\\b": "Config Structures",
       "Manifest)\\b": "Manifest Structures"
     },
+    "feature_context": {
+      "Subcommand": { "doc_comment": true, "block_fields": true },
+      "Args)\\s*\\{": { "doc_comment": true, "block_fields": true },
+      "Config)\\b": { "doc_comment": true, "block_fields": true },
+      "Manifest)\\b": { "doc_comment": true, "block_fields": true }
+    },
     "doc_targets": {
       "Subcommands": {
         "file": "cli-reference.md",
         "heading": "## Subcommands",
-        "template": "- `{name}` — defined in `{source_file}` (line {line})"
+        "template": "### `{name}`\n\n{description}\n\n{fields}"
       },
       "CLI Commands": {
         "file": "cli-reference.md",
         "heading": "## Commands",
-        "template": "- `{name}` — `{source_file}` (line {line})"
+        "template": "- `{name}` — {description}"
       },
       "Command Arguments": {
         "file": "cli-reference.md",
         "heading": "## Command Arguments",
-        "template": "- `{name}` — `{source_file}` (line {line})"
+        "template": "### `{name}`\n\n{description}\n\n{fields}"
       },
       "Config Structures": {
         "file": "architecture.md",
         "heading": "## Configuration",
-        "template": "- `{name}` — `{source_file}` (line {line})"
+        "template": "### `{name}`\n\n{description}\n\n{fields}"
       },
       "Manifest Structures": {
         "file": "architecture.md",
         "heading": "## Manifests",
-        "template": "- `{name}` — `{source_file}` (line {line})"
+        "template": "### `{name}`\n\n{description}\n\n{fields}"
       }
     }
   },

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -179,6 +179,14 @@
       "WP_CLI::add_command": "WP-CLI Commands",
       "registerTool": "AI Tools"
     },
+    "feature_context": {
+      "register_post_type": { "doc_comment": true, "block_fields": false },
+      "register_taxonomy": { "doc_comment": true, "block_fields": false },
+      "register_rest_route": { "doc_comment": true, "block_fields": false },
+      "WP_CLI::add_command": { "doc_comment": true, "block_fields": false },
+      "wp_register_ability": { "doc_comment": true, "block_fields": false },
+      "registerTool": { "doc_comment": true, "block_fields": false }
+    },
     "doc_targets": {
       "Post Types": {
         "file": "features.md",


### PR DESCRIPTION
## Summary

Add `feature_context` extraction rules and update `doc_targets` templates for richer generated documentation. Companion to homeboy PR #310.

### Rust extension
- `feature_context` enables `doc_comment` + `block_fields` for all audit patterns
- Templates updated to use `{description}` and `{fields}` — generates docs with struct fields, enum variants, and their doc comments

### WordPress extension
- `feature_context` enables `doc_comment` for key patterns (register_post_type, register_rest_route, WP_CLI::add_command, wp_register_ability, registerTool)

## Testing

- JSON validated
- Rust config tested on homeboy: 88/90 features extract fields with doc comments