### PR TITLE
feat: Fingerprint scripts for Rust and WordPress extensions

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,9 +1,16 @@
 {
   "name": "Rust",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",
+  "provides": {
+    "file_extensions": ["rs"],
+    "capabilities": ["fingerprint"]
+  },
+  "scripts": {
+    "fingerprint": "scripts/fingerprint.sh"
+  },
   "audit": {
     "feature_patterns": [
       "#\\[derive\\(.*Subcommand.*\\)\\]\\s*(?:pub\\s+)?enum\\s+(\\w+)",

--- a/rust/scripts/fingerprint.sh
+++ b/rust/scripts/fingerprint.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Rust fingerprint script for homeboy audit.
+#
+# Input (JSON on stdin):
+#   {"file_path": "src/commands/deploy.rs", "content": "..."}
+#
+# Output (JSON on stdout):
+#   {"methods": [...], "type_name": "...", "implements": [...],
+#    "registrations": [], "namespace": "...", "imports": [...]}
+#
+# Extracts structural information from Rust source files using text matching.
+# Does not require a Rust parser — uses grep/sed for speed.
+
+set -euo pipefail
+
+# Read stdin into variable
+INPUT=$(cat)
+
+# Extract content from JSON — use python3 for reliable JSON parsing
+CONTENT=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys, re
+
+data = json.load(sys.stdin)
+content = data['content']
+file_path = data['file_path']
+
+# Strip #[cfg(test)] mod tests { ... } block to exclude test functions.
+# Find the last #[cfg(test)] and remove everything from there to end of file.
+cfg_test = re.search(r'#\[cfg\(test\)\]', content)
+if cfg_test:
+    content = content[:cfg_test.start()]
+
+# --- Methods ---
+# Match fn declarations: pub fn name, fn name, pub async fn name, pub(crate) fn name
+methods = []
+for m in re.finditer(r'(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+(\w+)', content):
+    name = m.group(1)
+    # Skip test functions and test modules
+    if name.startswith('test_') or name == 'tests':
+        continue
+    methods.append(name)
+
+# Deduplicate while preserving order
+seen = set()
+methods = [m for m in methods if m not in seen and not seen.add(m)]
+
+# --- Type name ---
+# Primary struct or enum in the file (first pub struct/enum, or first struct/enum)
+type_name = None
+pub_types = re.findall(r'pub\s+(?:struct|enum)\s+(\w+)', content)
+all_types = re.findall(r'(?:pub\s+)?(?:struct|enum)\s+(\w+)', content)
+if pub_types:
+    type_name = pub_types[0]
+elif all_types:
+    type_name = all_types[0]
+
+# --- Implements ---
+# Match impl blocks: impl Trait for Type, impl<T> Trait for Type
+implements = []
+for m in re.finditer(r'impl(?:<[^>]*>)?\s+(\w+(?:::\w+)*)\s+for\s+\w+', content):
+    trait_name = m.group(1)
+    # Use just the last segment for common traits
+    implements.append(trait_name.split('::')[-1])
+# Deduplicate
+seen = set()
+implements = [i for i in implements if i not in seen and not seen.add(i)]
+
+# --- Registrations ---
+# Match macro invocations that look like registration patterns
+registrations = []
+for m in re.finditer(r'(\w+)!\s*\(', content):
+    macro_name = m.group(1)
+    # Skip common non-registration macros
+    skip = {'println', 'eprintln', 'format', 'vec', 'assert', 'assert_eq',
+            'assert_ne', 'panic', 'todo', 'unimplemented', 'cfg', 'derive',
+            'include', 'include_str', 'include_bytes', 'concat', 'stringify',
+            'env', 'option_env', 'compile_error', 'write', 'writeln',
+            'matches', 'dbg', 'debug_assert', 'debug_assert_eq',
+            'debug_assert_ne', 'unreachable', 'cfg_if', 'lazy_static',
+            'thread_local', 'once_cell', 'macro_rules', 'serde_json',
+            'if_chain', 'bail', 'anyhow', 'ensure', 'Ok', 'Err',
+            'Some', 'None', 'Box', 'Arc', 'Rc', 'RefCell', 'Mutex',
+            'map', 'hashmap', 'btreemap', 'hashset'}
+    if macro_name not in skip and not macro_name.startswith('test'):
+        registrations.append(macro_name)
+# Deduplicate
+seen = set()
+registrations = [r for r in registrations if r not in seen and not seen.add(r)]
+
+# --- Namespace ---
+# Infer from use crate:: patterns — most common prefix
+crate_uses = re.findall(r'use\s+crate::(\w+)', content)
+if crate_uses:
+    # Count frequency of first path segment
+    from collections import Counter
+    counts = Counter(crate_uses)
+    most_common = counts.most_common(1)[0][0]
+    namespace = f'crate::{most_common}'
+else:
+    # Try to infer from file path
+    parts = file_path.replace('.rs', '').split('/')
+    if len(parts) > 1:
+        namespace = 'crate::' + '::'.join(parts[1:-1]) if len(parts) > 2 else 'crate::' + parts[-1]
+    else:
+        namespace = None
+
+# --- Imports ---
+# Collect all use statements
+imports = []
+for m in re.finditer(r'use\s+((?:crate|super|self|std|serde|clap|regex|chrono|tokio|anyhow)\S+);', content):
+    imports.append(m.group(1))
+# Also match use with braces: use crate::foo::{bar, baz};
+for m in re.finditer(r'use\s+((?:crate|super|self)\S+::\{[^}]+\});', content):
+    imports.append(m.group(1))
+# Deduplicate
+seen = set()
+imports = [i for i in imports if i not in seen and not seen.add(i)]
+
+result = {
+    'methods': methods,
+    'type_name': type_name,
+    'implements': implements,
+    'registrations': registrations,
+    'namespace': namespace,
+    'imports': imports,
+}
+
+print(json.dumps(result))
+")
+
+echo "$CONTENT"

--- a/wordpress/scripts/fingerprint.sh
+++ b/wordpress/scripts/fingerprint.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# WordPress/PHP fingerprint script for homeboy audit.
+#
+# Input (JSON on stdin):
+#   {"file_path": "inc/Abilities/Foo.php", "content": "..."}
+#
+# Output (JSON on stdout):
+#   {"methods": [...], "type_name": "...", "implements": [...],
+#    "registrations": [], "namespace": "...", "imports": [...]}
+#
+# Extracts structural information from PHP source files using text matching.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+printf '%s' "$INPUT" | python3 -c "
+import json, sys, re
+
+data = json.load(sys.stdin)
+content = data['content']
+file_path = data['file_path']
+
+# --- Methods ---
+# Match PHP method declarations: public function name, protected function name,
+# private function name, static function name, abstract function name
+methods = []
+for m in re.finditer(
+    r'(?:public|protected|private|static|abstract)\s+(?:static\s+)?function\s+(\w+)',
+    content
+):
+    name = m.group(1)
+    # Skip test methods
+    if name.startswith('test_') or name.startswith('test'):
+        continue
+    methods.append(name)
+
+# Also match standalone function declarations (not in a class)
+for m in re.finditer(r'^function\s+(\w+)', content, re.MULTILINE):
+    methods.append(m.group(1))
+
+# Deduplicate preserving order
+seen = set()
+methods = [m for m in methods if m not in seen and not seen.add(m)]
+
+# --- Type name ---
+# Primary class, interface, or trait in the file
+type_name = None
+# Prefer class, then interface, then trait
+for pattern in [
+    r'class\s+(\w+)',
+    r'interface\s+(\w+)',
+    r'trait\s+(\w+)',
+]:
+    match = re.search(pattern, content)
+    if match:
+        type_name = match.group(1)
+        break
+
+# --- Implements ---
+# Match: class Foo extends Bar implements Baz, Qux
+implements = []
+# extends
+ext_match = re.search(r'class\s+\w+\s+extends\s+([\w\\\\]+)', content)
+if ext_match:
+    implements.append(ext_match.group(1).split('\\\\')[-1])
+
+# implements (can be comma-separated)
+impl_match = re.search(r'implements\s+([\w\\\\,\s]+?)(?:\s*\{)', content)
+if impl_match:
+    for iface in impl_match.group(1).split(','):
+        iface = iface.strip()
+        if iface:
+            implements.append(iface.split('\\\\')[-1])
+
+# use Trait inside class body
+for m in re.finditer(r'^\s+use\s+([\w\\\\]+)\s*[;{]', content, re.MULTILINE):
+    trait_name = m.group(1).split('\\\\')[-1]
+    implements.append(trait_name)
+
+# Deduplicate
+seen = set()
+implements = [i for i in implements if i not in seen and not seen.add(i)]
+
+# --- Registrations ---
+# Match WordPress registration function calls
+registrations = []
+reg_patterns = [
+    r'register_post_type\s*\(\s*[\'\"]([\w-]+)',
+    r'register_taxonomy\s*\(\s*[\'\"]([\w-]+)',
+    r'register_block_type\s*\(\s*[\'\"]([\w/-]+)',
+    r'register_setting\s*\(\s*[\'\"]([\w-]+)',
+    r'register_rest_route\s*\([^,]+,\s*[\'\"]([^\'\"]+)',
+    r'add_shortcode\s*\(\s*[\'\"]([\w-]+)',
+    r'add_action\s*\(\s*[\'\"]([\w-]+)',
+    r'add_filter\s*\(\s*[\'\"]([\w-]+)',
+    r'wp_register_script\s*\(\s*[\'\"]([\w-]+)',
+    r'wp_register_style\s*\(\s*[\'\"]([\w-]+)',
+    r'wp_register_ability\s*\(\s*[\'\"]([^\'\"]+)',
+    r'wp_register_ability_category\s*\(\s*[\'\"]([^\'\"]+)',
+    r'WP_CLI::add_command\s*\(\s*[\'\"]([^\'\"]+)',
+    r'\\\$this->registerTool\s*\(\s*[\'\"][^\'\"]+[\'\"]\\s*,\\s*[\'\"]([^\'\"]+)',
+]
+for pat in reg_patterns:
+    for m in re.finditer(pat, content):
+        registrations.append(m.group(1))
+# Deduplicate
+seen = set()
+registrations = [r for r in registrations if r not in seen and not seen.add(r)]
+
+# --- Namespace ---
+# Match PHP namespace declaration
+ns_match = re.search(r'namespace\s+([\w\\\\]+)\s*;', content)
+if ns_match:
+    namespace = ns_match.group(1)
+else:
+    namespace = None
+
+# --- Imports ---
+# Match PHP use statements (at file/namespace level, not trait use inside class)
+imports = []
+for m in re.finditer(r'^use\s+([\w\\\\]+)(?:\s+as\s+\w+)?;', content, re.MULTILINE):
+    imports.append(m.group(1))
+# Deduplicate
+seen = set()
+imports = [i for i in imports if i not in seen and not seen.add(i)]
+
+result = {
+    'methods': methods,
+    'type_name': type_name,
+    'implements': implements,
+    'registrations': registrations,
+    'namespace': namespace,
+    'imports': imports,
+}
+
+print(json.dumps(result))
+"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,9 +1,16 @@
 {
   "name": "WordPress",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",
+  "provides": {
+    "file_extensions": ["php"],
+    "capabilities": ["fingerprint"]
+  },
+  "scripts": {
+    "fingerprint": "scripts/fingerprint.sh"
+  },
   "platform": {
     "config_schema": "wordpress",
     "discovery": {


### PR DESCRIPTION
## Summary

Adds `scripts/fingerprint.sh` to both the **Rust** and **WordPress** extensions, enabling `homeboy audit` to discover conventions, detect outliers, and compute alignment scores for Rust and PHP codebases.

## What changed

### Rust extension (1.2.0 → 1.3.0)
- Added `provides.file_extensions: ["rs"]` and `capabilities: ["fingerprint"]`
- Added `scripts.fingerprint: "scripts/fingerprint.sh"`
- Script extracts: methods, type_name, implements, registrations, namespace, imports
- Strips `#[cfg(test)]` blocks before extraction
- Infers namespace from `use crate::` patterns

### WordPress extension (2.1.0 → 2.2.0)
- Added `provides.file_extensions: ["php"]` and `capabilities: ["fingerprint"]`
- Added `scripts.fingerprint: "scripts/fingerprint.sh"`
- Script extracts: PHP methods, classes/interfaces/traits, namespace declarations
- Detects WordPress registration patterns (post types, taxonomies, REST routes, abilities, WP-CLI commands)
- Handles `extends`, `implements`, and trait `use` inside classes

## Testing

### Rust — tested against Homeboy itself:
```
files_scanned: 99
conventions_detected: 1 (Commands — src/commands/*)
alignment_score: 76.7%
outliers: 7 (missing imports, namespace mismatches)
```

### WordPress — tested against Data Machine:
- `RequestBuilder.php` → methods: [build, restructure_tools], namespace: DataMachine\Engine\AI
- `JobAbilities.php` → 11 methods, 2 implements, 10 imports, namespace: DataMachine\Abilities

## Closes

- homeboy-extensions#45