### PR TITLE
fix: include css, ts, js, json in WordPress file_extensions

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -5,7 +5,7 @@
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",
   "provides": {
-    "file_extensions": ["php"],
+    "file_extensions": ["php", "css", "ts", "tsx", "js", "jsx", "json"],
     "capabilities": ["fingerprint"]
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Adds `css`, `ts`, `tsx`, `js`, `jsx`, `json` to the WordPress extension's `file_extensions` so `homeboy refactor rename` scans all relevant files — not just PHP
- Without this, CSS selectors and JS querySelector strings are silently skipped during renames, breaking styles and interactivity

Fixes #47