### PR TITLE
fix: add_pub_crate incorrectly matches keywords inside doc comments

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",

--- a/rust/scripts/refactor.py
+++ b/rust/scripts/refactor.py
@@ -673,6 +673,9 @@ def add_pub_crate(source: str, kind: str) -> str:
 
     for i, line in enumerate(lines):
         trimmed = line.lstrip()
+        # Skip doc comments and attributes — keywords inside these are not declarations
+        if trimmed.startswith("///") or trimmed.startswith("//!") or trimmed.startswith("#["):
+            continue
         for pat in patterns:
             m = re.search(pat, trimmed)
             if m:


### PR DESCRIPTION
## Summary

- Fix `add_pub_crate()` inserting `pub(crate)` before doc comment lines when the comment text contains a Rust keyword (e.g., `/// Call this fn to process`)
- Skip `///`, `//!`, and `#[` lines before searching for declaration keywords
- Bump Rust extension version to 1.4.1

## Bug

```rust
/// Call this fn to process items.
fn process_items() { }
```

**Before (broken):** `pub(crate) /// Call this fn to process items.`
**After (fixed):** `pub(crate) fn process_items() { }`

Found during `conventions.rs` decomposition — `signatures.rs` had to be manually corrected after the move.