### PR TITLE
feat: method body hashes in fingerprint for duplication detection

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",

--- a/rust/scripts/fingerprint.sh
+++ b/rust/scripts/fingerprint.sh
@@ -116,6 +116,54 @@ for m in re.finditer(r'use\s+((?:crate|super|self)\S+::\{[^}]+\});', content):
 seen = set()
 imports = [i for i in imports if i not in seen and not seen.add(i)]
 
+# --- Method Hashes (for duplication detection) ---
+# Extract function bodies, normalize whitespace, hash with SHA-256.
+# Only hashes top-level functions (not methods inside impl blocks).
+import hashlib
+
+method_hashes = {}
+# Find top-level fn declarations (zero indentation)
+lines = content.split('\n')
+i = 0
+while i < len(lines):
+    line = lines[i]
+    # Skip indented lines (methods inside impl/struct/etc.)
+    if line and line[0] in (' ', '\t'):
+        i += 1
+        continue
+    # Match fn declaration at start of line (with optional pub/async/unsafe/const)
+    fn_match = re.match(r'(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?fn\s+(\w+)', line)
+    if not fn_match:
+        i += 1
+        continue
+    fn_name = fn_match.group(1)
+    if fn_name.startswith('test_') or fn_name == 'tests':
+        i += 1
+        continue
+    # Find the opening brace
+    brace_depth = 0
+    found_open = False
+    body_lines = []
+    j = i
+    while j < len(lines):
+        for ch in lines[j]:
+            if ch == '{':
+                brace_depth += 1
+                found_open = True
+            elif ch == '}':
+                brace_depth -= 1
+        body_lines.append(lines[j])
+        if found_open and brace_depth == 0:
+            break
+        j += 1
+    if body_lines:
+        # Normalize: join, collapse whitespace, strip
+        body_text = ' '.join(body_lines)
+        normalized = re.sub(r'\s+', ' ', body_text).strip()
+        body_hash = hashlib.sha256(normalized.encode()).hexdigest()[:16]
+        method_hashes[fn_name] = body_hash
+    i = j + 1
+
 result = {
     'methods': methods,
     'type_name': type_name,
@@ -123,6 +171,7 @@ result = {
     'registrations': registrations,
     'namespace': namespace,
     'imports': imports,
+    'method_hashes': method_hashes,
 }
 
 print(json.dumps(result))


### PR DESCRIPTION
## Summary

- Extend Rust fingerprint script to emit `method_hashes` — a map of function name → SHA-256 hash of the normalized body
- Enables `homeboy audit` Phase 4c (duplication detection) to identify identical functions across files
- Bump Rust extension to v1.5.0

## How it works

1. Find top-level `fn` declarations (zero indentation, excludes test functions)
2. Extract the full function body using brace matching
3. Normalize: join lines, collapse all whitespace to single space, strip
4. Hash with SHA-256 (truncated to 16 hex chars for compactness)
5. Emit as `method_hashes: {"fn_name": "hash"}` in fingerprint JSON

## Live test on homeboy

Found 4 real duplicates:
- `default_true` in `defaults.rs` ↔ `project.rs`
- `cache_path`, `is_disabled_by_config`, `now_unix` in `extension_update_check.rs` ↔ `update_check.rs`