### PR TITLE
chore: bump wordpress to 2.5.0, rust to 1.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-rust/scripts/__pycache__/
+**/__pycache__/

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",


### PR DESCRIPTION
## Summary
- Bumps WordPress extension 2.4.0 → 2.5.0 for fingerprint enhancements (extends, visibility, properties, hooks fields) and refactor strategy detection shipped in #55 and #56
- Bumps Rust extension 1.6.0 → 1.7.0 for propagate_struct_fields refactor command shipped in #56
- Generalizes `__pycache__` gitignore pattern and removes tracked cache files