### PR TITLE
fix(rust): add preflight checks for cargo-dist and jq in package.sh

### DIFF
--- a/rust/scripts/package.sh
+++ b/rust/scripts/package.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Verify cargo-dist is installed before attempting to package.
+# Without this check, the command fails silently and the release pipeline
+# reports a cryptic "Failed to parse package artifacts" JSON error.
+if ! command -v dist &>/dev/null && ! command -v cargo-dist &>/dev/null; then
+    echo "Error: cargo-dist is not installed." >&2
+    echo "Install with: cargo install cargo-dist" >&2
+    echo "Or skip packaging by removing the rust extension's release.package action." >&2
+    exit 1
+fi
+
+# Verify jq is available for artifact parsing
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required for parsing dist output but is not installed." >&2
+    exit 1
+fi
+
 dist build --output-format=json > dist-manifest.json
 
 jq -c '[.upload_files[] | {path: ., type: (if endswith(".rb") then "homebrew" else "binary" end), platform: null}]' dist-manifest.json


### PR DESCRIPTION
## Summary

The rust extension's `package.sh` now checks that `cargo-dist` and `jq` are installed before running. Previously it failed silently with no stdout, which caused homeboy's release pipeline to report a cryptic JSON parse error on every release.

Now you get:
```
Error: cargo-dist is not installed.
Install with: cargo install cargo-dist
```

Companion PR: Extra-Chill/homeboy#365 (improves the executor's error handling for this case)