### PR TITLE
fix(wordpress): prevent wp_not_installed() from killing PHPUnit process

### DIFF
--- a/wordpress/tests/bootstrap.php
+++ b/wordpress/tests/bootstrap.php
@@ -137,8 +137,29 @@ if ($component_type === 'theme') {
     });
 }
 
+// Prevent wp_not_installed() from killing the process.
+//
+// When wp-settings.php loads, it calls wp_not_installed() which checks
+// is_blog_installed(). With the SQLite database driver, this check can
+// return false even after install.php has run (the lightweight driver
+// doesn't fully satisfy all the queries is_blog_installed() makes).
+// When is_blog_installed() returns false, wp_not_installed() calls
+// wp_redirect() + die() — silently terminating the PHPUnit process
+// before any tests run, producing zero output with exit code 0.
+//
+// Defining WP_INSTALLING makes wp_installing() return true, which
+// causes wp_not_installed() to bail out early (line 943 of load.php:
+// "if ( is_blog_installed() || wp_installing() ) { return; }").
+if (!defined('WP_INSTALLING')) {
+    define('WP_INSTALLING', true);
+}
+
 // Start up the WP testing environment
 require_once $_tests_dir . '/includes/bootstrap.php';
+
+// Turn off installing mode so tests run against a normally-loaded WordPress.
+// wp_installing() uses a static variable, so this call overrides the constant.
+wp_installing(false);
 
 // Clean WordPress output buffers so PHPUnit's result printer works.
 // The WP bootstrap starts ob_start() during initialization which captures


### PR DESCRIPTION
## Summary

Fixes the WordPress test bootstrap silently suppressing all PHPUnit output (#60).

## Root Cause

When `wp-settings.php` loads during bootstrap, it calls `wp_not_installed()` which checks `is_blog_installed()`. With the SQLite database driver, this check returns `false` even after `install.php` has run — the lightweight driver doesn't satisfy all queries `is_blog_installed()` makes (specifically the `siteurl` option lookup).

When `is_blog_installed()` returns false, `wp_not_installed()` calls `wp_redirect('/wp-admin/install.php')` + `die()`, silently terminating the entire PHPUnit process before any tests are discovered. This produces zero test output with exit code 0.

**Call chain:** `wp-settings.php:178` → `wp_not_installed()` → `is_blog_installed()` → returns false → `wp_redirect()` + `die()` 💀

## Fix

Two lines added to `tests/bootstrap.php`:

1. **Before** the WP test bootstrap: `define('WP_INSTALLING', true)` — this makes `wp_installing()` return true, which causes `wp_not_installed()` to bail out early
2. **After** the WP test bootstrap: `wp_installing(false)` — turns off installing mode so tests run against a normally-loaded WordPress

## Before / After

```bash
# BEFORE — zero output, exit 0:
phpunit --bootstrap=extensions/wordpress/tests/bootstrap.php \
  --no-configuration --verbose tests/SanityTest.php
# (nothing)

# AFTER — tests discovered and run:
phpunit --bootstrap=extensions/wordpress/tests/bootstrap.php \
  --no-configuration --verbose tests/SanityTest.php
# OK (1 test, 1 assertion)
```

## Related

- Closes #60
- Related: homeboy#369 (args passthrough — this was the root cause of zero test output)