### PR TITLE
fix(wordpress): remove auto-activate from post:deploy hook

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -109,7 +109,6 @@
   },
   "hooks": {
     "post:deploy": [
-      "wp plugin is-installed {{component_id}} --path={{base_path}} --allow-root 2>/dev/null && wp plugin activate {{component_id}} --path={{base_path}} --allow-root 2>/dev/null || true",
       "wp cache flush --path={{base_path}} --allow-root 2>/dev/null || true"
     ]
   },


### PR DESCRIPTION
## Summary

- **Removes `wp plugin activate` from the `post:deploy` hook** — deploy should copy files, not change activation state
- Fixes multisite installs where a plugin is active on subsites but not the main site — the old hook would incorrectly activate on the main site after every deploy
- `wp plugin install --force` (used in deploy overrides) already preserves activation state, so the activate call was always unnecessary

Closes #63