### PR TITLE
feat(rust): add lint and test scripts for CI support

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -12,6 +12,12 @@
     "fingerprint": "scripts/fingerprint.sh",
     "refactor": "scripts/refactor.sh"
   },
+  "lint": {
+    "extension_script": "scripts/lint-runner.sh"
+  },
+  "test": {
+    "extension_script": "scripts/test-runner.sh"
+  },
   "audit": {
     "feature_patterns": [
       "#\\[derive\\(.*Subcommand.*\\)\\]\\s*(?:pub\\s+)?enum\\s+(\\w+)",

--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Rust lint runner for homeboy lint.
+#
+# Runs cargo fmt --check and cargo clippy as lint steps.
+# Supports the standard homeboy extension env vars:
+#   HOMEBOY_EXTENSION_PATH  — path to this extension
+#   HOMEBOY_COMPONENT_PATH  — path to the Rust project
+#   HOMEBOY_AUTO_FIX        — if "1", run cargo fmt (fix mode) instead of --check
+#   HOMEBOY_SUMMARY_MODE    — if "1", show compact output
+#   HOMEBOY_LINT_GLOB       — file glob (currently unused for Rust — cargo operates on crates)
+#   HOMEBOY_LINT_FILE       — single file (currently unused for Rust)
+#   HOMEBOY_ERRORS_ONLY     — if "1", only show errors (suppresses warnings in clippy)
+#   HOMEBOY_STEP            — comma-separated steps to run (fmt, clippy)
+#   HOMEBOY_SKIP            — comma-separated steps to skip
+#   HOMEBOY_DEBUG           — if "1", show debug output
+
+FAILED_STEP=""
+FAILURE_OUTPUT=""
+
+# Step filtering
+should_run_step() {
+    local step_name="$1"
+    if [ -n "${HOMEBOY_STEP:-}" ]; then
+        echo ",${HOMEBOY_STEP}," | grep -q ",${step_name}," && return 0 || return 1
+    fi
+    if [ -n "${HOMEBOY_SKIP:-}" ]; then
+        echo ",${HOMEBOY_SKIP}," | grep -q ",${step_name}," && return 1 || return 0
+    fi
+    return 0
+}
+
+print_failure_summary() {
+    if [ -n "$FAILED_STEP" ]; then
+        echo ""
+        echo "============================================"
+        echo "BUILD FAILED: $FAILED_STEP"
+        echo "============================================"
+        if [ -n "$FAILURE_OUTPUT" ]; then
+            echo ""
+            echo "Error details:"
+            echo "$FAILURE_OUTPUT"
+        fi
+    fi
+}
+trap print_failure_summary EXIT
+
+# Determine project path
+if [ -n "${HOMEBOY_COMPONENT_PATH:-}" ]; then
+    PROJECT_PATH="${HOMEBOY_COMPONENT_PATH}"
+else
+    PROJECT_PATH="$(pwd)"
+fi
+
+if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "DEBUG: Rust Lint Environment:"
+    echo "HOMEBOY_EXTENSION_PATH=${HOMEBOY_EXTENSION_PATH:-NOT_SET}"
+    echo "HOMEBOY_COMPONENT_PATH=${HOMEBOY_COMPONENT_PATH:-NOT_SET}"
+    echo "HOMEBOY_AUTO_FIX=${HOMEBOY_AUTO_FIX:-NOT_SET}"
+    echo "HOMEBOY_SUMMARY_MODE=${HOMEBOY_SUMMARY_MODE:-NOT_SET}"
+    echo "HOMEBOY_ERRORS_ONLY=${HOMEBOY_ERRORS_ONLY:-NOT_SET}"
+    echo "PROJECT_PATH=${PROJECT_PATH}"
+fi
+
+# Verify this is a Rust project
+if [ ! -f "${PROJECT_PATH}/Cargo.toml" ]; then
+    echo "Error: No Cargo.toml found at ${PROJECT_PATH}"
+    echo "Not a Rust project — cannot run lint."
+    exit 1
+fi
+
+echo "Running Rust lint checks..."
+
+# ── Step 1: cargo fmt ──
+if should_run_step "fmt"; then
+    if [ "${HOMEBOY_AUTO_FIX:-}" = "1" ]; then
+        echo ""
+        echo "Running cargo fmt (fix mode)..."
+        set +e
+        FMT_OUTPUT=$(cargo fmt --manifest-path "${PROJECT_PATH}/Cargo.toml" 2>&1)
+        FMT_EXIT=$?
+        set -e
+
+        if [ $FMT_EXIT -eq 0 ]; then
+            echo "cargo fmt: applied formatting fixes"
+        else
+            echo "cargo fmt failed:"
+            echo "$FMT_OUTPUT"
+            FAILED_STEP="cargo fmt"
+            FAILURE_OUTPUT="$FMT_OUTPUT"
+            exit 1
+        fi
+    else
+        echo ""
+        echo "Running cargo fmt --check..."
+        set +e
+        FMT_OUTPUT=$(cargo fmt --manifest-path "${PROJECT_PATH}/Cargo.toml" --check 2>&1)
+        FMT_EXIT=$?
+        set -e
+
+        if [ $FMT_EXIT -eq 0 ]; then
+            echo "cargo fmt: passed"
+        else
+            if [ "${HOMEBOY_SUMMARY_MODE:-}" = "1" ]; then
+                # Count files with formatting issues
+                FILE_COUNT=$(echo "$FMT_OUTPUT" | grep -c "^Diff in" || true)
+                echo ""
+                echo "============================================"
+                echo "FMT SUMMARY: ${FILE_COUNT} files need formatting"
+                echo "============================================"
+                echo ""
+                echo "Fix: homeboy lint <component> --fix"
+            else
+                echo ""
+                echo "$FMT_OUTPUT"
+            fi
+            FAILED_STEP="cargo fmt --check"
+            FAILURE_OUTPUT="$(echo "$FMT_OUTPUT" | tail -20)"
+            exit 1
+        fi
+    fi
+else
+    echo "Skipping cargo fmt (step filter)"
+fi
+
+# ── Step 2: cargo clippy ──
+if should_run_step "clippy"; then
+    echo ""
+    echo "Running cargo clippy..."
+
+    CLIPPY_ARGS=(
+        clippy
+        --manifest-path "${PROJECT_PATH}/Cargo.toml"
+        --all-targets
+    )
+
+    # In fix mode, apply clippy suggestions
+    if [ "${HOMEBOY_AUTO_FIX:-}" = "1" ]; then
+        CLIPPY_ARGS+=(--fix --allow-dirty --allow-staged)
+    fi
+
+    CLIPPY_ARGS+=(--)
+
+    if [ "${HOMEBOY_ERRORS_ONLY:-}" = "1" ]; then
+        CLIPPY_ARGS+=(-D warnings)
+    else
+        CLIPPY_ARGS+=(-W clippy::all)
+    fi
+
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: cargo ${CLIPPY_ARGS[*]}"
+    fi
+
+    CLIPPY_TMPFILE=$(mktemp)
+
+    set +e
+    cargo "${CLIPPY_ARGS[@]}" 2>&1 | tee "$CLIPPY_TMPFILE"
+    CLIPPY_EXIT=${PIPESTATUS[0]}
+    set -e
+
+    CLIPPY_OUTPUT=$(cat "$CLIPPY_TMPFILE")
+    rm -f "$CLIPPY_TMPFILE"
+
+    if [ $CLIPPY_EXIT -eq 0 ]; then
+        echo "cargo clippy: passed"
+    else
+        if [ "${HOMEBOY_SUMMARY_MODE:-}" = "1" ]; then
+            WARNING_COUNT=$(echo "$CLIPPY_OUTPUT" | grep -c "^warning\[" || true)
+            ERROR_COUNT=$(echo "$CLIPPY_OUTPUT" | grep -c "^error\[" || true)
+            echo ""
+            echo "============================================"
+            echo "CLIPPY SUMMARY: ${ERROR_COUNT} errors, ${WARNING_COUNT} warnings"
+            echo "============================================"
+        fi
+        FAILED_STEP="cargo clippy"
+        FAILURE_OUTPUT="$(echo "$CLIPPY_OUTPUT" | grep -E "^(error|warning)\[" | head -20)"
+        exit 1
+    fi
+else
+    echo "Skipping cargo clippy (step filter)"
+fi
+
+echo ""
+echo "Rust lint checks passed"

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Rust test runner for homeboy test.
+#
+# Runs cargo test with standard homeboy extension env vars:
+#   HOMEBOY_EXTENSION_PATH  — path to this extension
+#   HOMEBOY_COMPONENT_PATH  — path to the Rust project
+#   HOMEBOY_SKIP_LINT       — if "1", skip the pre-test lint step
+#   HOMEBOY_AUTO_FIX        — if "1", auto-fix before testing
+#   HOMEBOY_STEP            — comma-separated steps to run (lint, test)
+#   HOMEBOY_SKIP            — comma-separated steps to skip
+#   HOMEBOY_DEBUG           — if "1", show debug output
+#
+# Passthrough args after -- are forwarded to cargo test.
+
+FAILED_STEP=""
+FAILURE_OUTPUT=""
+
+# Step filtering
+should_run_step() {
+    local step_name="$1"
+    if [ -n "${HOMEBOY_STEP:-}" ]; then
+        echo ",${HOMEBOY_STEP}," | grep -q ",${step_name}," && return 0 || return 1
+    fi
+    if [ -n "${HOMEBOY_SKIP:-}" ]; then
+        echo ",${HOMEBOY_SKIP}," | grep -q ",${step_name}," && return 1 || return 0
+    fi
+    return 0
+}
+
+print_failure_summary() {
+    if [ -n "$FAILED_STEP" ]; then
+        echo ""
+        echo "============================================"
+        echo "BUILD FAILED: $FAILED_STEP"
+        echo "============================================"
+        if [ -n "$FAILURE_OUTPUT" ]; then
+            echo ""
+            echo "Error details:"
+            echo "$FAILURE_OUTPUT"
+        fi
+    fi
+}
+trap print_failure_summary EXIT
+
+# Determine project path
+if [ -n "${HOMEBOY_COMPONENT_PATH:-}" ]; then
+    PROJECT_PATH="${HOMEBOY_COMPONENT_PATH}"
+else
+    PROJECT_PATH="$(pwd)"
+fi
+
+EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "DEBUG: Rust Test Environment:"
+    echo "HOMEBOY_EXTENSION_PATH=${HOMEBOY_EXTENSION_PATH:-NOT_SET}"
+    echo "HOMEBOY_COMPONENT_PATH=${HOMEBOY_COMPONENT_PATH:-NOT_SET}"
+    echo "HOMEBOY_SKIP_LINT=${HOMEBOY_SKIP_LINT:-NOT_SET}"
+    echo "HOMEBOY_AUTO_FIX=${HOMEBOY_AUTO_FIX:-NOT_SET}"
+    echo "PROJECT_PATH=${PROJECT_PATH}"
+    echo "Passthrough args: $*"
+fi
+
+# Verify this is a Rust project
+if [ ! -f "${PROJECT_PATH}/Cargo.toml" ]; then
+    echo "Error: No Cargo.toml found at ${PROJECT_PATH}"
+    echo "Not a Rust project — cannot run tests."
+    exit 1
+fi
+
+echo "Running Rust tests..."
+
+# ── Step 1: Pre-test lint (unless skipped) ──
+if should_run_step "lint" && [ "${HOMEBOY_SKIP_LINT:-}" != "1" ]; then
+    LINT_RUNNER="${EXTENSION_PATH}/scripts/lint-runner.sh"
+    if [ -f "$LINT_RUNNER" ]; then
+        echo ""
+        echo "Running pre-test lint checks..."
+        HOMEBOY_SUMMARY_MODE=1 bash "$LINT_RUNNER"
+        echo ""
+    fi
+elif ! should_run_step "lint"; then
+    echo "Skipping lint (step filter)"
+else
+    echo "Skipping lint (--skip-lint)"
+fi
+
+# ── Step 2: cargo test ──
+if ! should_run_step "test"; then
+    echo "Skipping tests (step filter)"
+    exit 0
+fi
+
+echo "Running cargo test..."
+
+TEST_ARGS=(
+    test
+    --manifest-path "${PROJECT_PATH}/Cargo.toml"
+)
+
+if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "DEBUG: cargo ${TEST_ARGS[*]} $*"
+fi
+
+TEST_TMPFILE=$(mktemp)
+
+set +e
+cargo "${TEST_ARGS[@]}" "$@" 2>&1 | tee "$TEST_TMPFILE"
+TEST_EXIT=${PIPESTATUS[0]}
+set -e
+
+TEST_OUTPUT=$(cat "$TEST_TMPFILE")
+rm -f "$TEST_TMPFILE"
+
+if [ $TEST_EXIT -eq 0 ]; then
+    # Extract test summary line
+    SUMMARY=$(echo "$TEST_OUTPUT" | grep -E "^test result:" | tail -1 || true)
+    if [ -n "$SUMMARY" ]; then
+        echo ""
+        echo "$SUMMARY"
+    fi
+    echo ""
+    echo "Rust tests passed"
+else
+    # Extract failure details
+    SUMMARY=$(echo "$TEST_OUTPUT" | grep -E "^test result:" | tail -1 || true)
+    FAILURES=$(echo "$TEST_OUTPUT" | grep -E "^---- .* ----$|^test .* FAILED$" || true)
+
+    if [ -n "$SUMMARY" ]; then
+        echo ""
+        echo "$SUMMARY"
+    fi
+
+    FAILED_STEP="cargo test"
+    FAILURE_OUTPUT="$(echo "$FAILURES" | head -20)"
+    exit $TEST_EXIT
+fi
+
+# Detect zero-test runs — only warn if NO test result line shows passed tests.
+# Cargo runs multiple test binaries (unit, integration, doc-tests); some may
+# legitimately have 0 tests while others have hundreds.
+TOTAL_PASSED=$(echo "$TEST_OUTPUT" | grep -oP '\d+ passed' | awk '{s+=$1} END {print s+0}')
+if [ "$TOTAL_PASSED" -eq 0 ]; then
+    TEST_FILE_COUNT=$(find "$PROJECT_PATH" -name "*test*" -name "*.rs" -not -path "*/target/*" 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$TEST_FILE_COUNT" -gt 0 ]; then
+        echo ""
+        echo "============================================"
+        echo "WARNING: cargo test ran 0 tests"
+        echo "============================================"
+        echo ""
+        echo "Found ${TEST_FILE_COUNT} test files but no tests were executed."
+        echo "This may indicate a configuration issue."
+    fi
+fi


### PR DESCRIPTION
## Summary

- Adds `lint-runner.sh` — runs `cargo fmt --check` + `cargo clippy` with full homeboy env var support
- Adds `test-runner.sh` — runs `cargo test` with pre-test lint, passthrough args, and zero-test detection
- Updates `rust.json` manifest with `lint.extension_script` and `test.extension_script` entries

## What this enables

Rust projects can now use `homeboy lint` and `homeboy test` through the Rust extension:

```bash
homeboy lint homeboy --path /path/to/checkout
homeboy test homeboy --path /path/to/checkout
homeboy test homeboy --skip-lint -- --test-threads=1
```

And via `homeboy-action` in CI:

```yaml
- uses: Extra-Chill/homeboy-action@v1
  with:
    extension: rust
    commands: lint,test
```

## Supported features

| Feature | Lint | Test |
|---------|------|------|
| `--fix` / `HOMEBOY_AUTO_FIX` | `cargo fmt` + `cargo clippy --fix` | Pass-through to lint |
| `--summary` / `HOMEBOY_SUMMARY_MODE` | Compact fmt/clippy summaries | — |
| `--errors-only` / `HOMEBOY_ERRORS_ONLY` | `-D warnings` for clippy | — |
| `--skip-lint` / `HOMEBOY_SKIP_LINT` | — | Skips pre-test lint |
| Step filtering (`HOMEBOY_STEP` / `HOMEBOY_SKIP`) | `fmt`, `clippy` | `lint`, `test` |
| Passthrough args (`$@`) | — | Forwarded to `cargo test` |
| Debug mode (`HOMEBOY_DEBUG`) | Full command logging | Full command logging |

## Smoke-tested

Tested against homeboy's own codebase:
- **Lint**: correctly detected `cargo fmt` drift (formatting issues in multiple files)
- **Test**: all 512 tests pass, no false-positive zero-test warning