### PR TITLE
feat: add dead code fields to Rust and WordPress fingerprints

### DIFF
--- a/rust/scripts/fingerprint.sh
+++ b/rust/scripts/fingerprint.sh
@@ -260,6 +260,157 @@ while i < len(lines):
         structural_hashes[fn_name] = struct_hash
     i = j + 1
 
+# --- Public API ---
+# Public functions/methods exported from this file.
+public_api = []
+for m in re.finditer(r'^pub(?:\([^)]*\))?\s+(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?fn\s+(\w+)', content, re.MULTILINE):
+    name = m.group(1)
+    if not name.startswith('test_') and name != 'tests':
+        public_api.append(name)
+# Deduplicate
+seen = set()
+public_api = [p for p in public_api if p not in seen and not seen.add(p)]
+
+# --- Internal Calls ---
+# Function/method calls within this file (for cross-file reference analysis).
+# Matches: function_name( and self.method_name( and Type::method_name(
+internal_calls = set()
+# Free function calls: word followed by (
+for m in re.finditer(r'\b(\w+)\s*\(', content):
+    name = m.group(1)
+    # Skip keywords, macros (already captured), and common non-function patterns
+    skip_calls = {'if', 'while', 'for', 'match', 'loop', 'return', 'Some', 'None',
+                  'Ok', 'Err', 'Box', 'Vec', 'Arc', 'Rc', 'String', 'println',
+                  'eprintln', 'format', 'write', 'writeln', 'panic', 'assert',
+                  'assert_eq', 'assert_ne', 'todo', 'unimplemented', 'unreachable',
+                  'dbg', 'cfg', 'include', 'include_str', 'concat', 'env',
+                  'compile_error', 'stringify', 'vec', 'hashmap', 'bail', 'ensure',
+                  'anyhow', 'matches', 'debug_assert', 'debug_assert_eq',
+                  'allow', 'deny', 'warn', 'derive', 'serde', 'test',
+                  'inline', 'must_use', 'doc', 'feature'}
+    if name not in skip_calls and not name.startswith('test_'):
+        internal_calls.add(name)
+# Method calls: .method_name( and ::method_name(
+for m in re.finditer(r'[.:](\w+)\s*\(', content):
+    name = m.group(1)
+    if name not in skip_calls and not name.startswith('test_'):
+        internal_calls.add(name)
+internal_calls = sorted(internal_calls)
+
+# --- Unused Parameters ---
+# For each function, extract parameter names and check if they appear in the body.
+unused_parameters = []
+lines = content.split('\n')
+i = 0
+while i < len(lines):
+    line = lines[i]
+    # Only top-level functions (zero indentation)
+    if line and line[0] in (' ', '\t'):
+        i += 1
+        continue
+    fn_match = re.match(r'(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?fn\s+(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*(?:\([^)]*\)[^)]*)*)\)', line)
+    if not fn_match:
+        # Try multi-line signature (params continue on next lines)
+        fn_match_start = re.match(r'(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?fn\s+(\w+)\s*(?:<[^>]*>)?\s*\(', line)
+        if fn_match_start:
+            fn_name = fn_match_start.group(1)
+            # Collect lines until we find the closing )
+            sig_lines = [line]
+            j = i + 1
+            paren_depth = line.count('(') - line.count(')')
+            while j < len(lines) and paren_depth > 0:
+                sig_lines.append(lines[j])
+                paren_depth += lines[j].count('(') - lines[j].count(')')
+                j += 1
+            full_sig = ' '.join(sig_lines)
+            params_match = re.search(r'fn\s+\w+\s*(?:<[^>]*>)?\s*\(([^)]*(?:\([^)]*\)[^)]*)*)\)', full_sig)
+            if params_match:
+                params_str = params_match.group(1)
+            else:
+                i += 1
+                continue
+        else:
+            i += 1
+            continue
+    else:
+        fn_name = fn_match.group(1)
+        params_str = fn_match.group(2)
+
+    if fn_name.startswith('test_') or fn_name == 'tests':
+        i += 1
+        continue
+
+    # Parse parameter names from the signature
+    param_names = []
+    for param in re.finditer(r'(\w+)\s*:', params_str):
+        pname = param.group(1)
+        # Skip 'self', 'mut' (as in &mut self), and type-only params
+        if pname not in ('self', 'mut', 'Self'):
+            param_names.append(pname)
+
+    if not param_names:
+        i += 1
+        continue
+
+    # Extract function body
+    brace_depth = 0
+    found_open = False
+    body_lines = []
+    j = i
+    while j < len(lines):
+        for ch in lines[j]:
+            if ch == '{':
+                brace_depth += 1
+                found_open = True
+            elif ch == '}':
+                brace_depth -= 1
+        if found_open:
+            body_lines.append(lines[j])
+        if found_open and brace_depth == 0:
+            break
+        j += 1
+
+    if body_lines:
+        # Join body, then strip the signature (everything before the first {)
+        # so parameter names in the signature don't cause false negatives.
+        full_body = '\n'.join(body_lines)
+        brace_pos = full_body.find('{')
+        if brace_pos >= 0:
+            body_only = full_body[brace_pos + 1:]
+        else:
+            body_only = full_body
+        for pname in param_names:
+            # Skip params prefixed with _ (intentionally unused)
+            if pname.startswith('_'):
+                continue
+            # Check if the parameter name appears anywhere in the body
+            # Use word boundary to avoid false positives (e.g., 'id' in 'width')
+            if not re.search(r'\b' + re.escape(pname) + r'\b', body_only):
+                unused_parameters.append({'function': fn_name, 'param': pname})
+
+    i = j + 1
+
+# --- Dead Code Markers ---
+# Find #[allow(dead_code)] annotations and the item they apply to.
+dead_code_markers = []
+lines = content.split('\n')
+for line_num, line in enumerate(lines, 1):
+    stripped = line.strip()
+    if stripped == '#[allow(dead_code)]':
+        # The next non-attribute, non-empty line should be the item
+        for k in range(line_num, min(line_num + 5, len(lines))):
+            next_line = lines[k].strip()
+            if next_line and not next_line.startswith('#[') and not next_line.startswith('//'):
+                # Extract item name
+                item_match = re.match(r'(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?(?:static\s+)?(?:fn|struct|enum|type|trait|const|static|mod)\s+(\w+)', next_line)
+                if item_match:
+                    dead_code_markers.append({
+                        'item': item_match.group(1),
+                        'line': line_num,
+                        'marker_type': 'allow_dead_code',
+                    })
+                break
+
 result = {
     'methods': methods,
     'type_name': type_name,
@@ -269,6 +420,10 @@ result = {
     'imports': imports,
     'method_hashes': method_hashes,
     'structural_hashes': structural_hashes,
+    'unused_parameters': unused_parameters,
+    'dead_code_markers': dead_code_markers,
+    'internal_calls': internal_calls,
+    'public_api': public_api,
 }
 
 print(json.dumps(result))

--- a/wordpress/scripts/fingerprint.sh
+++ b/wordpress/scripts/fingerprint.sh
@@ -283,6 +283,103 @@ for m in re.finditer(r'^function\s+(\w+)\s*\([^)]*\)(?:\s*:\s*[\w\\\\|?]+)?\s*',
         struct_normalized = structural_normalize_php(struct_text)
         structural_hashes[fn_name] = hashlib.sha256(struct_normalized.encode()).hexdigest()[:16]
 
+# --- Public API ---
+# Public methods exported from this file.
+public_api = [m for m in methods if visibility.get(m) == 'public']
+
+# --- Internal Calls ---
+# Function/method calls within this file (for cross-file reference analysis).
+internal_calls = set()
+dollar = chr(36)
+# Method calls: this->method( and self::method( and static::method( and ClassName::method(
+for m in re.finditer(r'(?:' + dollar_esc + r'this->|self::|static::|[A-Z]\w*::)(\w+)\s*\(', content):
+    name = m.group(1)
+    if not name.startswith('test'):
+        internal_calls.add(name)
+# Free function calls: function_name(
+for m in re.finditer(r'\b([a-z_]\w*)\s*\(', content):
+    name = m.group(1)
+    skip_php = {'if', 'while', 'for', 'foreach', 'switch', 'match', 'catch',
+                'return', 'echo', 'print', 'isset', 'unset', 'empty', 'list',
+                'array', 'function', 'class', 'interface', 'trait', 'new',
+                'require', 'require_once', 'include', 'include_once',
+                'define', 'defined', 'die', 'exit', 'eval', 'compact',
+                'extract', 'var_dump', 'print_r', 'var_export'}
+    if name not in skip_php and not name.startswith('test'):
+        internal_calls.add(name)
+internal_calls = sorted(internal_calls)
+
+# --- Unused Parameters ---
+# For each method/function, extract parameter names and check if they appear in the body.
+unused_parameters = []
+
+def check_unused_params(fn_name, params_str, body_text):
+    # Parse parameter names from the signature
+    param_names = []
+    for pm in re.finditer(dollar_esc + r'(\w+)', params_str):
+        pname = pm.group(1)
+        if pname != 'this':
+            param_names.append(pname)
+    for pname in param_names:
+        # Skip params prefixed with _ (intentionally unused)
+        if pname.startswith('_'):
+            continue
+        # Check if the param variable appears in the body (after the signature)
+        # Use dollar_esc (\\$) for regex to match literal $ not end-of-string
+        if not re.search(dollar_esc + re.escape(pname) + r'\b', body_text):
+            unused_parameters.append({'function': fn_name, 'param': pname})
+
+# Class methods
+for m in re.finditer(
+    r'(?:public|protected|private|static|abstract)\s+(?:static\s+)?function\s+(\w+)\s*\(([^)]*)\)(?:\s*:\s*[\w\\\\|?]+)?\s*',
+    content
+):
+    fn_name = m.group(1)
+    if fn_name.startswith('test'):
+        continue
+    params_str = m.group(2)
+    body = extract_body(content, m.end() - 1)
+    if body and len(body) > 2:
+        check_unused_params(fn_name, params_str, body)
+
+# Standalone functions
+for m in re.finditer(r'^function\s+(\w+)\s*\(([^)]*)\)(?:\s*:\s*[\w\\\\|?]+)?\s*', content, re.MULTILINE):
+    fn_name = m.group(1)
+    params_str = m.group(2)
+    body = extract_body(content, m.end() - 1)
+    if body and len(body) > 2:
+        check_unused_params(fn_name, params_str, body)
+
+# --- Dead Code Markers ---
+# Find @codeCoverageIgnore, @phpstan-ignore, and similar suppression markers.
+dead_code_markers = []
+lines_arr = content.split('\n')
+for line_num, line in enumerate(lines_arr, 1):
+    stripped = line.strip()
+    marker_type = None
+    if '@codeCoverageIgnore' in stripped:
+        marker_type = 'coverage_ignore'
+    elif '@phpstan-ignore' in stripped:
+        marker_type = 'phpstan_ignore'
+    elif 'SuppressWarnings' in stripped:
+        marker_type = 'suppress_warnings'
+    if marker_type:
+        # Find the next function/class/method declaration
+        for k in range(line_num, min(line_num + 5, len(lines_arr))):
+            next_line = lines_arr[k].strip()
+            if next_line and not next_line.startswith('*') and not next_line.startswith('//') and not next_line.startswith('/*'):
+                item_match = re.match(
+                    r'(?:public|protected|private|static|abstract|final)?\s*(?:static\s+)?(?:function|class|interface|trait)\s+(\w+)',
+                    next_line
+                )
+                if item_match:
+                    dead_code_markers.append({
+                        'item': item_match.group(1),
+                        'line': line_num,
+                        'marker_type': marker_type,
+                    })
+                break
+
 result = {
     'methods': methods,
     'type_name': type_name,
@@ -296,6 +393,10 @@ result = {
     'visibility': visibility,
     'properties': properties,
     'hooks': hooks,
+    'unused_parameters': unused_parameters,
+    'dead_code_markers': dead_code_markers,
+    'internal_calls': internal_calls,
+    'public_api': public_api,
 }
 
 print(json.dumps(result))


### PR DESCRIPTION
## Summary

Both Rust and WordPress fingerprint scripts now emit 4 new fields for dead code detection in `homeboy audit`.

### New fields

| Field | Type | Description |
|-------|------|-------------|
| `unused_parameters` | `[{function, param}]` | Function params declared but never used in body |
| `dead_code_markers` | `[{item, line, marker_type}]` | Suppression annotations |
| `internal_calls` | `[string]` | Function/method names called within the file |
| `public_api` | `[string]` | Public functions exported from the file |

### Rust extension changes

- Detects `#[allow(dead_code)]` markers with item name + line number
- Unused param detection strips signature from body before checking (prevents false negatives)
- Internal calls filter out keywords, macros, and attribute names
- `pub fn` declarations listed as public API

### WordPress extension changes

- Detects `@codeCoverageIgnore`, `@phpstan-ignore`, `SuppressWarnings` markers
- Unused param detection uses `dollar_esc` (`\\$`) for regex to match literal `$` (not regex end-of-string anchor)
- Captures `$this->method()`, `self::method()`, `static::method()`, and free function calls
- Public-visibility methods listed as public API
- All `$` signs use `chr(36)` / `dollar_esc` pattern to avoid bash interpolation inside the `python3 -c "..."` block

### Dependencies

Requires homeboy core: Extra-Chill/homeboy#387