### PR TITLE
feat: add test_mapping config to Rust and WordPress extensions

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -39,6 +39,14 @@
       "Config)\\b": { "doc_comment": true, "block_fields": true },
       "Manifest)\\b": { "doc_comment": true, "block_fields": true }
     },
+    "test_mapping": {
+      "source_dirs": ["src"],
+      "test_dirs": ["tests"],
+      "test_file_pattern": "tests/{dir}/{name}_test.{ext}",
+      "method_prefix": "test_",
+      "inline_tests": true,
+      "critical_patterns": ["core/", "commands/"]
+    },
     "doc_targets": {
       "Subcommands": {
         "file": "cli-reference.md",

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -194,6 +194,14 @@
       "wp_register_ability": { "doc_comment": true, "block_fields": false },
       "registerTool": { "doc_comment": true, "block_fields": false }
     },
+    "test_mapping": {
+      "source_dirs": ["inc"],
+      "test_dirs": ["tests/Unit"],
+      "test_file_pattern": "tests/Unit/{dir}/{name}Test.{ext}",
+      "method_prefix": "test_",
+      "inline_tests": false,
+      "critical_patterns": ["Abilities/", "Core/"]
+    },
     "doc_targets": {
       "Post Types": {
         "file": "features.md",


### PR DESCRIPTION
Adds test_mapping configuration to both extension manifests for the new Phase 4f test coverage analysis in homeboy audit (homeboy #388). Defines source-to-test file mapping conventions for each language.