### PR TITLE
feat: annotation sidecar JSON for CI inline review

### DIFF
--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -115,6 +115,30 @@ if should_run_step "fmt"; then
                 echo ""
                 echo "$FMT_OUTPUT"
             fi
+
+            # Write annotations sidecar for fmt issues
+            # Parse "Diff in /path/to/file.rs at line N:" format
+            if [ -n "${HOMEBOY_ANNOTATIONS_DIR:-}" ] && [ -d "${HOMEBOY_ANNOTATIONS_DIR}" ]; then
+                echo "$FMT_OUTPUT" | awk -v comp_path="${PROJECT_PATH}/" '
+                    /^Diff in .+ at line [0-9]+:/ {
+                        file = $3
+                        line = $6
+                        sub(/:$/, "", line)
+                        # Strip component path prefix
+                        sub(comp_path, "", file)
+                        gsub(/"/, "\\\"", file)
+                        annotations = annotations (annotations ? ",\n" : "") \
+                            "  {\"file\": \"" file "\", \"line\": " line ", \"message\": \"File needs formatting (run homeboy lint --fix)\", \"source\": \"rustfmt\", \"severity\": \"warning\", \"code\": \"formatting\"}"
+                    }
+                    END {
+                        if (annotations) {
+                            print "[\n" annotations "\n]"
+                        }
+                    }
+                ' > "${HOMEBOY_ANNOTATIONS_DIR}/rustfmt.json" 2>/dev/null || true
+                [ -s "${HOMEBOY_ANNOTATIONS_DIR}/rustfmt.json" ] || rm -f "${HOMEBOY_ANNOTATIONS_DIR}/rustfmt.json"
+            fi
+
             FAILED_STEP="cargo fmt --check"
             FAILURE_OUTPUT="$(echo "$FMT_OUTPUT" | tail -20)"
             exit 1
@@ -161,6 +185,48 @@ if should_run_step "clippy"; then
 
     CLIPPY_OUTPUT=$(cat "$CLIPPY_TMPFILE")
     rm -f "$CLIPPY_TMPFILE"
+
+    # Write annotations sidecar JSON for CI inline comments
+    # Parse clippy's "warning: message\n  --> file:line:col" format
+    if [ -n "${HOMEBOY_ANNOTATIONS_DIR:-}" ] && [ -d "${HOMEBOY_ANNOTATIONS_DIR}" ]; then
+        # Use awk to pair "warning/error" lines with their "--> file:line:col" location
+        echo "$CLIPPY_OUTPUT" | awk '
+            /^(warning|error)(\[.+\])?: / {
+                severity = ($1 == "error" || $1 ~ /^error/) ? "error" : "warning"
+                # Extract code from brackets: warning[clippy::foo] or error[E0001]
+                code = ""
+                if (match($0, /\[([^\]]+)\]/, m)) { code = m[1] }
+                # Message is everything after "warning: " or "error: " or "error[...]: "
+                msg = $0
+                sub(/^(warning|error)(\[[^\]]+\])?: /, "", msg)
+                next_is_location = 1
+                next
+            }
+            next_is_location && /^\s+-->/ {
+                # Parse "  --> src/foo.rs:42:10"
+                loc = $2
+                split(loc, parts, ":")
+                file = parts[1]
+                line = parts[2]
+                if (file != "" && line != "") {
+                    # Escape quotes in message for JSON
+                    gsub(/"/, "\\\"", msg)
+                    annotations = annotations (annotations ? ",\n" : "") \
+                        "  {\"file\": \"" file "\", \"line\": " line ", \"message\": \"" msg "\", \"source\": \"clippy\", \"severity\": \"" severity "\", \"code\": \"" code "\"}"
+                }
+                next_is_location = 0
+                next
+            }
+            { next_is_location = 0 }
+            END {
+                if (annotations) {
+                    print "[\n" annotations "\n]"
+                }
+            }
+        ' > "${HOMEBOY_ANNOTATIONS_DIR}/clippy.json" 2>/dev/null || true
+        # Remove empty file if no annotations were written
+        [ -s "${HOMEBOY_ANNOTATIONS_DIR}/clippy.json" ] || rm -f "${HOMEBOY_ANNOTATIONS_DIR}/clippy.json"
+    fi
 
     if [ $CLIPPY_EXIT -eq 0 ]; then
         echo "cargo clippy: passed"

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -310,6 +310,37 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
         echo ""
         echo "$summary"
     fi
+
+    # Write annotations sidecar JSON for CI inline comments
+    if [ -n "${HOMEBOY_ANNOTATIONS_DIR:-}" ] && [ -d "${HOMEBOY_ANNOTATIONS_DIR}" ]; then
+        echo "$json_output" | php -r '
+            $json = json_decode(file_get_contents("php://stdin"), true);
+            if (!$json || empty($json["files"])) exit;
+            $componentPath = $argv[1] ?? "";
+            $annotations = [];
+            foreach ($json["files"] as $filePath => $data) {
+                $displayPath = $filePath;
+                if ($componentPath && strpos($filePath, $componentPath) === 0) {
+                    $displayPath = ltrim(substr($filePath, strlen($componentPath)), "/");
+                }
+                foreach ($data["messages"] ?? [] as $msg) {
+                    $annotations[] = [
+                        "file" => $displayPath,
+                        "line" => $msg["line"] ?? 0,
+                        "message" => $msg["message"] ?? "Unknown",
+                        "source" => "phpcs",
+                        "severity" => ($msg["type"] ?? "ERROR") === "ERROR" ? "error" : "warning",
+                        "code" => $msg["source"] ?? "unknown",
+                        "fixable" => $msg["fixable"] ?? false,
+                    ];
+                }
+            }
+            $outDir = $argv[2] ?? "";
+            if ($outDir && !empty($annotations)) {
+                file_put_contents($outDir . "/phpcs.json", json_encode($annotations, JSON_PRETTY_PRINT) . "\n");
+            }
+        ' "$PLUGIN_PATH" "${HOMEBOY_ANNOTATIONS_DIR}" 2>/dev/null || true
+    fi
 fi
 
 # Summary mode: show summary header + top violations, skip full report

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 # Supports summary mode via HOMEBOY_SUMMARY_MODE=1
 # Supports skip via HOMEBOY_SKIP_PHPSTAN=1
 # Supports level override via HOMEBOY_PHPSTAN_LEVEL (default: 5)
+# NOTE: PHPStan always analyzes the full codebase (ignores HOMEBOY_LINT_GLOB)
+# because it needs the complete type graph to detect collateral damage from
+# changes (broken call sites, type mismatches in untouched files, etc.)
 
 # Debug environment variables (only shown when HOMEBOY_DEBUG=1)
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -281,6 +284,37 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
             echo "ERRORS (raw):"
             echo "$json_output"
         fi
+    fi
+
+    # Write annotations sidecar JSON for CI inline comments
+    if [ -n "${HOMEBOY_ANNOTATIONS_DIR:-}" ] && [ -d "${HOMEBOY_ANNOTATIONS_DIR}" ] && [ -n "$json_output" ]; then
+        echo "$json_output" | php -r '
+            $json = json_decode(file_get_contents("php://stdin"), true);
+            if (!$json || empty($json["files"])) exit;
+            $componentPath = $argv[1] ?? "";
+            $level = $argv[2] ?? "5";
+            $annotations = [];
+            foreach ($json["files"] as $filePath => $data) {
+                $displayPath = $filePath;
+                if ($componentPath && strpos($filePath, $componentPath) === 0) {
+                    $displayPath = ltrim(substr($filePath, strlen($componentPath)), "/");
+                }
+                foreach ($data["messages"] ?? [] as $msg) {
+                    $annotations[] = [
+                        "file" => $displayPath,
+                        "line" => $msg["line"] ?? 0,
+                        "message" => $msg["message"] ?? "Unknown",
+                        "source" => "phpstan",
+                        "severity" => "error",
+                        "code" => $msg["identifier"] ?? "unknown",
+                    ];
+                }
+            }
+            $outDir = $argv[3] ?? "";
+            if ($outDir && !empty($annotations)) {
+                file_put_contents($outDir . "/phpstan.json", json_encode($annotations, JSON_PRETTY_PRINT) . "\n");
+            }
+        ' "$PLUGIN_PATH" "$PHPSTAN_LEVEL" "${HOMEBOY_ANNOTATIONS_DIR}" 2>/dev/null || true
     fi
 
     # Fallback: show stderr if PHPStan failed without producing JSON


### PR DESCRIPTION
## Summary

Extensions now write structured annotation JSON sidecar files to `HOMEBOY_ANNOTATIONS_DIR` when the env var is set. The homeboy-action reads these to post inline PR review comments.

### Changes

- **wordpress/lint-runner.sh** — writes `phpcs.json` with file/line/message/severity/code from PHPCS JSON report
- **wordpress/phpstan-runner.sh** — writes `phpstan.json` from PHPStan JSON output. Added comment documenting that PHPStan always runs full codebase (ignores `HOMEBOY_LINT_GLOB`) to catch collateral damage
- **rust/lint-runner.sh** — writes `clippy.json` (parsed from clippy's `warning/error → --> file:line:col` format) and `rustfmt.json` (parsed from `Diff in file at line N:` format)

### Annotation JSON format

```json
[
  {
    "file": "inc/Foo.php",
    "line": 42,
    "message": "Missing Yoda condition",
    "source": "phpcs",
    "severity": "error",
    "code": "WordPress.PHP.YodaConditions.NotYoda"
  }
]
```

### Design decisions

- **PHPStan always full codebase** — even in `--changed-since` PR mode, PHPStan needs the complete type graph to detect broken call sites and type mismatches in untouched files. PHPCS stays scoped to changed files (formatting is file-local).
- **Opt-in via env var** — annotations only written when `HOMEBOY_ANNOTATIONS_DIR` is set and points to a valid directory. No impact on existing usage.
- **Fail-safe** — all annotation writes wrapped in `|| true` so a sidecar write failure never breaks the lint run.

Companion PR: Extra-Chill/homeboy-action#10 (inline PR review step)