### PR TITLE
feat: add code coverage collection to test runners

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -87,10 +87,121 @@ else
     echo "Skipping lint (--skip-lint)"
 fi
 
-# ── Step 2: cargo test ──
+# ── Step 2: cargo test (with optional coverage) ──
 if ! should_run_step "test"; then
     echo "Skipping tests (step filter)"
     exit 0
+fi
+
+# Coverage mode: use cargo-tarpaulin if HOMEBOY_COVERAGE=1
+if [ "${HOMEBOY_COVERAGE:-}" = "1" ]; then
+    if command -v cargo-tarpaulin &>/dev/null; then
+        echo "Running cargo tarpaulin (test + coverage)..."
+
+        COVERAGE_JSON_FILE=$(mktemp --suffix=.json)
+        TARPAULIN_ARGS=(
+            tarpaulin
+            --manifest-path "${PROJECT_PATH}/Cargo.toml"
+            --out Json
+            --output-dir "$(dirname "$COVERAGE_JSON_FILE")"
+        )
+
+        if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+            echo "DEBUG: cargo ${TARPAULIN_ARGS[*]} $*"
+        fi
+
+        TEST_TMPFILE=$(mktemp)
+
+        set +e
+        cargo "${TARPAULIN_ARGS[@]}" "$@" 2>&1 | tee "$TEST_TMPFILE"
+        TEST_EXIT=${PIPESTATUS[0]}
+        set -e
+
+        TEST_OUTPUT=$(cat "$TEST_TMPFILE")
+        rm -f "$TEST_TMPFILE"
+
+        if [ $TEST_EXIT -ne 0 ]; then
+            SUMMARY=$(echo "$TEST_OUTPUT" | grep -E "^test result:" | tail -1 || true)
+            FAILURES=$(echo "$TEST_OUTPUT" | grep -E "^---- .* ----$|^test .* FAILED$" || true)
+            if [ -n "$SUMMARY" ]; then echo ""; echo "$SUMMARY"; fi
+            FAILED_STEP="cargo tarpaulin"
+            FAILURE_OUTPUT="$(echo "$FAILURES" | head -20)"
+            rm -f "$COVERAGE_JSON_FILE"
+            exit $TEST_EXIT
+        fi
+
+        # Parse tarpaulin JSON output for coverage summary
+        # Tarpaulin writes to tarpaulin-report.json in output-dir
+        TARPAULIN_REPORT="$(dirname "$COVERAGE_JSON_FILE")/tarpaulin-report.json"
+        if [ -f "$TARPAULIN_REPORT" ]; then
+            # Extract coverage from tarpaulin JSON
+            COVERAGE_DATA=$(python3 -c "
+import json, sys, os
+with open('$TARPAULIN_REPORT') as f:
+    data = json.load(f)
+files = []
+total_lines = 0
+covered_lines = 0
+source_dir = '${PROJECT_PATH}/'
+for fpath, traces in data.get('files', {}).items():
+    rel = fpath.replace(source_dir, '') if fpath.startswith(source_dir) else fpath
+    flines = len(traces)
+    fcovered = sum(1 for t in traces if t.get('hits', 0) > 0)
+    total_lines += flines
+    covered_lines += fcovered
+    pct = round((fcovered / flines) * 100, 2) if flines > 0 else 100
+    files.append({'file': rel, 'lines': flines, 'covered': fcovered, 'line_pct': pct})
+files.sort(key=lambda x: x['line_pct'])
+line_pct = round((covered_lines / total_lines) * 100, 2) if total_lines > 0 else 0
+result = {
+    'totals': {
+        'lines': {'total': total_lines, 'covered': covered_lines, 'pct': line_pct},
+        'methods': {'total': 0, 'covered': 0, 'pct': 0},
+        'classes': {'total': 0, 'covered': 0, 'pct': 0}
+    },
+    'files': files
+}
+print(json.dumps(result, indent=2))
+" 2>/dev/null || true)
+
+            if [ -n "$COVERAGE_DATA" ]; then
+                LINE_PCT=$(echo "$COVERAGE_DATA" | jq -r '.totals.lines.pct')
+                LINE_TOTAL=$(echo "$COVERAGE_DATA" | jq -r '.totals.lines.total')
+                LINE_COVERED=$(echo "$COVERAGE_DATA" | jq -r '.totals.lines.covered')
+                echo ""
+                echo "============================================"
+                echo "COVERAGE SUMMARY"
+                echo "============================================"
+                echo "  Lines: ${LINE_PCT}% (${LINE_COVERED}/${LINE_TOTAL})"
+                echo ""
+
+                if [ -n "${HOMEBOY_COVERAGE_FILE:-}" ]; then
+                    echo "$COVERAGE_DATA" > "$HOMEBOY_COVERAGE_FILE"
+                fi
+
+                if [ -n "${HOMEBOY_COVERAGE_MIN:-}" ]; then
+                    BELOW=$(echo "$LINE_PCT < ${HOMEBOY_COVERAGE_MIN}" | bc -l 2>/dev/null || echo "0")
+                    if [ "$BELOW" = "1" ]; then
+                        echo "COVERAGE FAILED: ${LINE_PCT}% is below minimum ${HOMEBOY_COVERAGE_MIN}%"
+                        FAILED_STEP="Coverage threshold (${LINE_PCT}% < ${HOMEBOY_COVERAGE_MIN}%)"
+                        rm -f "$TARPAULIN_REPORT" "$COVERAGE_JSON_FILE"
+                        exit 1
+                    fi
+                fi
+            fi
+
+            rm -f "$TARPAULIN_REPORT" "$COVERAGE_JSON_FILE"
+        fi
+
+        echo "Rust tests passed (with coverage)"
+        exit 0
+    else
+        echo ""
+        echo "WARNING: Coverage requested but cargo-tarpaulin not found."
+        echo "  Install: cargo install cargo-tarpaulin"
+        echo "  Falling back to cargo test without coverage."
+        echo ""
+    fi
 fi
 
 echo "Running cargo test..."

--- a/wordpress/scripts/test/parse-coverage.php
+++ b/wordpress/scripts/test/parse-coverage.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Parse a Clover XML coverage report and output JSON summary.
+ *
+ * Usage: php parse-coverage.php <clover.xml> [source_dir]
+ *
+ * Output: JSON object with total coverage and per-file breakdown.
+ * Writes to stdout. Exit code 0 on success, 1 on error.
+ */
+
+if ($argc < 2) {
+    fwrite(STDERR, "Usage: php parse-coverage.php <clover.xml> [source_dir]\n");
+    exit(1);
+}
+
+$clover_file = $argv[1];
+$source_dir  = isset($argv[2]) ? rtrim($argv[2], '/') . '/' : '';
+
+if (!file_exists($clover_file)) {
+    fwrite(STDERR, "Error: Clover file not found: {$clover_file}\n");
+    exit(1);
+}
+
+$xml = @simplexml_load_file($clover_file);
+if ($xml === false) {
+    fwrite(STDERR, "Error: Failed to parse Clover XML\n");
+    exit(1);
+}
+
+$total_statements   = 0;
+$covered_statements = 0;
+$total_methods      = 0;
+$covered_methods    = 0;
+$total_classes       = 0;
+$covered_classes     = 0;
+$files               = [];
+
+foreach ($xml->project->package as $package) {
+    foreach ($package->file as $file) {
+        process_file($file, $source_dir, $files, $total_statements, $covered_statements, $total_methods, $covered_methods, $total_classes, $covered_classes);
+    }
+}
+
+// Also handle files not in packages
+foreach ($xml->project->file as $file) {
+    process_file($file, $source_dir, $files, $total_statements, $covered_statements, $total_methods, $covered_methods, $total_classes, $covered_classes);
+}
+
+$line_pct   = $total_statements > 0 ? round(($covered_statements / $total_statements) * 100, 2) : 0;
+$method_pct = $total_methods > 0 ? round(($covered_methods / $total_methods) * 100, 2) : 0;
+$class_pct  = $total_classes > 0 ? round(($covered_classes / $total_classes) * 100, 2) : 0;
+
+// Sort files by coverage ascending (worst first)
+usort($files, function ($a, $b) {
+    return $a['line_pct'] <=> $b['line_pct'];
+});
+
+$result = [
+    'totals' => [
+        'lines'   => [
+            'total'   => $total_statements,
+            'covered' => $covered_statements,
+            'pct'     => $line_pct,
+        ],
+        'methods' => [
+            'total'   => $total_methods,
+            'covered' => $covered_methods,
+            'pct'     => $method_pct,
+        ],
+        'classes' => [
+            'total'   => $total_classes,
+            'covered' => $covered_classes,
+            'pct'     => $class_pct,
+        ],
+    ],
+    'files'  => $files,
+];
+
+echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+
+function process_file($file, $source_dir, &$files, &$total_statements, &$covered_statements, &$total_methods, &$covered_methods, &$total_classes, &$covered_classes) {
+    $metrics = $file->metrics;
+    if (!$metrics) {
+        return;
+    }
+
+    $file_path = (string) $file['name'];
+
+    // Strip source_dir prefix for relative paths
+    if ($source_dir && strpos($file_path, $source_dir) === 0) {
+        $file_path = substr($file_path, strlen($source_dir));
+    }
+
+    $stmts   = (int) $metrics['statements'];
+    $covered = (int) $metrics['coveredstatements'];
+    $methods = (int) $metrics['methods'];
+    $cov_m   = (int) $metrics['coveredmethods'];
+    $classes = (int) $metrics['classes'] ?? 0;
+    $cov_c   = (int) $metrics['coveredclasses'] ?? 0;
+
+    $total_statements   += $stmts;
+    $covered_statements += $covered;
+    $total_methods      += $methods;
+    $covered_methods    += $cov_m;
+    $total_classes       += $classes;
+    $covered_classes     += $cov_c;
+
+    $line_pct = $stmts > 0 ? round(($covered / $stmts) * 100, 2) : 100;
+
+    $files[] = [
+        'file'     => $file_path,
+        'lines'    => $stmts,
+        'covered'  => $covered,
+        'line_pct' => $line_pct,
+    ];
+}

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -450,6 +450,25 @@ phpunit_args=(
     "${TEST_DIR}"
 )
 
+# Coverage collection (opt-in via HOMEBOY_COVERAGE=1)
+COVERAGE_CLOVER=""
+if [ "${HOMEBOY_COVERAGE:-}" = "1" ]; then
+    # Check for coverage driver (xdebug or pcov)
+    if php -r 'exit(extension_loaded("pcov") || extension_loaded("xdebug") ? 0 : 1);' 2>/dev/null; then
+        COVERAGE_CLOVER=$(mktemp --suffix=.xml)
+        phpunit_args+=(--coverage-clover "$COVERAGE_CLOVER")
+        echo "Coverage collection enabled (output: clover XML)"
+    else
+        echo ""
+        echo "WARNING: Coverage requested but no coverage driver found."
+        echo "  Install one of: pcov (recommended), xdebug"
+        echo "  Ubuntu: sudo apt install php-pcov"
+        echo "  macOS:  pecl install pcov"
+        echo "  Skipping coverage collection."
+        echo ""
+    fi
+fi
+
 PHPUNIT_TMPFILE=$(mktemp)
 
 set +e
@@ -509,6 +528,51 @@ if [ -z "$(echo "$PHPUNIT_OUTPUT" | grep -E 'PHPUnit|test|assert|OK|ERRORS|FAILU
     echo ""
     FAILED_STEP="PHPUnit tests (no output)"
     exit 1
+fi
+
+# Parse and report coverage results
+if [ -n "${COVERAGE_CLOVER:-}" ] && [ -f "$COVERAGE_CLOVER" ]; then
+    COVERAGE_PARSER="${EXTENSION_PATH}/scripts/test/parse-coverage.php"
+    COVERAGE_JSON=$(php "$COVERAGE_PARSER" "$COVERAGE_CLOVER" "${PLUGIN_PATH}/" 2>/dev/null || true)
+
+    if [ -n "$COVERAGE_JSON" ]; then
+        # Print summary to stdout
+        LINE_PCT=$(echo "$COVERAGE_JSON" | jq -r '.totals.lines.pct')
+        LINE_TOTAL=$(echo "$COVERAGE_JSON" | jq -r '.totals.lines.total')
+        LINE_COVERED=$(echo "$COVERAGE_JSON" | jq -r '.totals.lines.covered')
+        METHOD_PCT=$(echo "$COVERAGE_JSON" | jq -r '.totals.methods.pct')
+        echo ""
+        echo "============================================"
+        echo "COVERAGE SUMMARY"
+        echo "============================================"
+        echo "  Lines:   ${LINE_PCT}% (${LINE_COVERED}/${LINE_TOTAL})"
+        echo "  Methods: ${METHOD_PCT}%"
+        echo ""
+
+        # Write coverage JSON to file for homeboy core to read
+        if [ -n "${HOMEBOY_COVERAGE_FILE:-}" ]; then
+            echo "$COVERAGE_JSON" > "$HOMEBOY_COVERAGE_FILE"
+        fi
+
+        # Check minimum threshold
+        if [ -n "${HOMEBOY_COVERAGE_MIN:-}" ]; then
+            BELOW=$(echo "$LINE_PCT < ${HOMEBOY_COVERAGE_MIN}" | bc -l 2>/dev/null || echo "0")
+            if [ "$BELOW" = "1" ]; then
+                echo "COVERAGE FAILED: ${LINE_PCT}% is below minimum ${HOMEBOY_COVERAGE_MIN}%"
+                FAILED_STEP="Coverage threshold (${LINE_PCT}% < ${HOMEBOY_COVERAGE_MIN}%)"
+                rm -f "$COVERAGE_CLOVER"
+                # Clean up auto-created test database
+                if [ "${MYSQL_AUTO_CREATED:-}" = "1" ]; then
+                    mysql -u root -e "DROP DATABASE IF EXISTS \`${MYSQL_DATABASE}\`" 2>/dev/null || true
+                fi
+                exit 1
+            fi
+        fi
+    else
+        echo "WARNING: Failed to parse coverage report"
+    fi
+
+    rm -f "$COVERAGE_CLOVER"
 fi
 
 # Clean up auto-created test database


### PR DESCRIPTION
## Summary

Adds opt-in code coverage collection to both WordPress and Rust test runners.

- **WordPress**: When `HOMEBOY_COVERAGE=1`, adds `--coverage-clover` to PHPUnit. New `parse-coverage.php` parses clover XML into JSON. Graceful fallback when pcov/xdebug not available.
- **Rust**: When `HOMEBOY_COVERAGE=1`, uses `cargo-tarpaulin`. Falls back to regular `cargo test` when tarpaulin not installed.
- **Shared**: Both write to `HOMEBOY_COVERAGE_FILE`, both enforce `HOMEBOY_COVERAGE_MIN` threshold, both produce identical JSON format.

### Environment variables

| Var | Set by | Purpose |
|---|---|---|
| `HOMEBOY_COVERAGE` | homeboy core | `1` to enable collection |
| `HOMEBOY_COVERAGE_FILE` | homeboy core | Path to write JSON results |
| `HOMEBOY_COVERAGE_MIN` | homeboy core | Minimum % threshold (fail if below) |

### Coverage JSON format

```json
{
  "totals": {
    "lines": { "total": 500, "covered": 350, "pct": 70.0 },
    "methods": { "total": 50, "covered": 40, "pct": 80.0 },
    "classes": { "total": 10, "covered": 8, "pct": 80.0 }
  },
  "files": [
    { "file": "inc/Steps/StepA.php", "lines": 50, "covered": 10, "line_pct": 20.0 }
  ]
}
```

Relates to Extra-Chill/homeboy#372