### PR TITLE
fix: SQLite query filter + SQL_CALC_FOUND_ROWS emulation

### DIFF
--- a/wordpress/sqlitedb/db.php
+++ b/wordpress/sqlitedb/db.php
@@ -28,6 +28,9 @@ class SQLite_DB extends wpdb {
     /** @var PDO|null */
     public $pdo = null;
 
+    /** @var int|null Rows found by last SQL_CALC_FOUND_ROWS query (for FOUND_ROWS() emulation). */
+    private ?int $found_rows_result = null;
+
     public function __construct($dbuser, $dbpassword, $dbname, $dbhost) {
         // Initialize as PDO-backed DB handle to support SQLite in tests
         if ($dbname === ':memory:') {
@@ -432,11 +435,38 @@ class SQLite_DB extends wpdb {
             return parent::query( $query );
         }
 
+        // Apply the 'query' filter — required for wpdb::remove_placeholder_escape()
+        // which converts hash placeholders back to '%' for LIKE queries.
+        $query = apply_filters( 'query', $query );
+
+        if ( ! $query ) {
+            $this->insert_id = 0;
+            return false;
+        }
+
         $this->last_error = '';
         $this->last_result = array();
         $this->num_rows = 0;
         $this->rows_affected = 0;
         $this->insert_id = 0;
+
+        // Handle SELECT FOUND_ROWS() — return the count from previous SQL_CALC_FOUND_ROWS query.
+        if ( preg_match( '/^\s*SELECT\s+FOUND_ROWS\s*\(\s*\)/i', trim( $query ) ) ) {
+            $count = $this->found_rows_result ?? 0;
+            $row = new \stdClass();
+            $row->{'FOUND_ROWS()'} = $count;
+            $this->last_result = array( $row );
+            $this->num_rows    = 1;
+            $this->num_queries++;
+            return 1;
+        }
+
+        // Handle SQL_CALC_FOUND_ROWS — strip the keyword and run a parallel COUNT query.
+        $has_calc_found_rows = false;
+        if ( stripos( $query, 'SQL_CALC_FOUND_ROWS' ) !== false ) {
+            $has_calc_found_rows = true;
+            $query = preg_replace( '/\bSQL_CALC_FOUND_ROWS\b/i', '', $query );
+        }
 
         // Translate MySQL transaction/session commands to SQLite equivalents.
         // WP_UnitTestCase calls these in set_up()/tear_down() for test isolation.
@@ -557,6 +587,25 @@ class SQLite_DB extends wpdb {
             $this->num_rows = count($rows);
             $this->result = $stmt;
             $this->num_queries++;
+
+            // Emulate SQL_CALC_FOUND_ROWS by running a COUNT(*) version of the query.
+            if ( $has_calc_found_rows ) {
+                $count_query = preg_replace(
+                    '/^\s*SELECT\s+.*?\s+FROM\b/is',
+                    'SELECT COUNT(*) FROM',
+                    $query
+                );
+                // Strip ORDER BY and LIMIT clauses for the count query.
+                $count_query = preg_replace( '/\s+ORDER\s+BY\s+.*$/is', '', $count_query );
+                $count_query = preg_replace( '/\s+LIMIT\s+\d+.*$/is', '', $count_query );
+                try {
+                    $count_stmt = $this->pdo->query( $count_query );
+                    $this->found_rows_result = $count_stmt ? (int) $count_stmt->fetchColumn() : count( $rows );
+                } catch ( PDOException $e ) {
+                    // Fallback to result count if COUNT query fails.
+                    $this->found_rows_result = count( $rows );
+                }
+            }
 
             return $this->num_rows;
 


### PR DESCRIPTION
## Summary
- Add `apply_filters('query', $query)` call to `SQLite_DB::query()` — required for `wpdb::remove_placeholder_escape()` which converts hash placeholders back to `%` for LIKE queries
- Add `SQL_CALC_FOUND_ROWS` stripping and `SELECT FOUND_ROWS()` emulation — MySQL-specific extensions that SQLite silently fails on

## Root Cause
`wpdb::prepare()` replaces `%` with hash placeholders during preparation, then the `query` filter (priority 0) converts them back before execution. The parent `wpdb::query()` calls `apply_filters('query', $query)` but our `SQLite_DB::query()` override was skipping it entirely. This caused **all LIKE queries using `wpdb::prepare()` to return zero results**.

`SQL_CALC_FOUND_ROWS` is a MySQL extension used by `WP_Query` for pagination. SQLite silently fails on it, returning empty result sets. Now it's stripped and a parallel `COUNT(*)` query provides the `FOUND_ROWS()` value.

## Impact
Fixes all tests that depend on:
- `WP_Query` search (`'s'` parameter)
- `WP_Query` pagination (`found_posts`)
- Any `LIKE` query through `$wpdb->prepare()`

Discovered while running the Data Machine test suite (~530 tests). This fix unblocked ~20 previously failing tests across QueueValidator, LocalSearch, PostQuery, and other test classes.