### PR TITLE
feat: write test results JSON for homeboy test baseline

### DIFF
--- a/rust/scripts/parse-test-results.sh
+++ b/rust/scripts/parse-test-results.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Parse cargo test output and write test results JSON to HOMEBOY_TEST_RESULTS_FILE.
+#
+# Cargo output pattern (one per test binary):
+#   test result: ok. 551 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out;
+#   test result: FAILED. 540 passed; 11 failed; 2 ignored; 0 measured; 0 filtered out;
+#
+# Multiple test result lines are aggregated (unit + integration + doc-tests).
+#
+# Usage: parse-test-results.sh <cargo-output-file>
+
+set -euo pipefail
+
+OUTPUT_FILE="${1:-}"
+if [ -z "$OUTPUT_FILE" ] || [ ! -f "$OUTPUT_FILE" ]; then
+    exit 0
+fi
+
+OUTPUT=$(cat "$OUTPUT_FILE")
+
+# Aggregate all "test result:" lines
+TOTAL_PASSED=$(echo "$OUTPUT" | grep -oP '\d+ passed' | awk '{s+=$1} END {print s+0}')
+TOTAL_FAILED=$(echo "$OUTPUT" | grep -oP '\d+ failed' | awk '{s+=$1} END {print s+0}')
+TOTAL_IGNORED=$(echo "$OUTPUT" | grep -oP '\d+ ignored' | awk '{s+=$1} END {print s+0}')
+
+TOTAL=$((TOTAL_PASSED + TOTAL_FAILED + TOTAL_IGNORED))
+
+# If no test result lines found, exit silently
+if [ "$TOTAL" -eq 0 ]; then
+    exit 0
+fi
+
+# Write JSON to file if requested
+if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
+    cat > "$HOMEBOY_TEST_RESULTS_FILE" << JSONEOF
+{
+  "total": ${TOTAL},
+  "passed": ${TOTAL_PASSED},
+  "failed": ${TOTAL_FAILED},
+  "skipped": ${TOTAL_IGNORED}
+}
+JSONEOF
+fi
+
+# Print summary to stderr for visibility
+echo "[test-results] Total: ${TOTAL}, Passed: ${TOTAL_PASSED}, Failed: ${TOTAL_FAILED}, Skipped: ${TOTAL_IGNORED}" >&2

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -120,6 +120,14 @@ if [ "${HOMEBOY_COVERAGE:-}" = "1" ]; then
         TEST_OUTPUT=$(cat "$TEST_TMPFILE")
         rm -f "$TEST_TMPFILE"
 
+        # Parse test results for baseline (tarpaulin path)
+        if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
+            RESULTS_TMPFILE=$(mktemp)
+            echo "$TEST_OUTPUT" > "$RESULTS_TMPFILE"
+            bash "${EXTENSION_PATH}/scripts/parse-test-results.sh" "$RESULTS_TMPFILE" 2>/dev/null || true
+            rm -f "$RESULTS_TMPFILE"
+        fi
+
         if [ $TEST_EXIT -ne 0 ]; then
             SUMMARY=$(echo "$TEST_OUTPUT" | grep -E "^test result:" | tail -1 || true)
             FAILURES=$(echo "$TEST_OUTPUT" | grep -E "^---- .* ----$|^test .* FAILED$" || true)
@@ -224,6 +232,14 @@ set -e
 
 TEST_OUTPUT=$(cat "$TEST_TMPFILE")
 rm -f "$TEST_TMPFILE"
+
+# Parse test results for baseline (runs before success/failure branching)
+if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
+    RESULTS_TMPFILE=$(mktemp)
+    echo "$TEST_OUTPUT" > "$RESULTS_TMPFILE"
+    bash "${EXTENSION_PATH}/scripts/parse-test-results.sh" "$RESULTS_TMPFILE" 2>/dev/null || true
+    rm -f "$RESULTS_TMPFILE"
+fi
 
 if [ $TEST_EXIT -eq 0 ]; then
     # Extract test summary line

--- a/wordpress/scripts/test/parse-test-results.sh
+++ b/wordpress/scripts/test/parse-test-results.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Parse PHPUnit output and write test results JSON to HOMEBOY_TEST_RESULTS_FILE.
+#
+# PHPUnit output patterns:
+#   OK (481 tests, 1234 assertions)
+#   Tests: 533, Assertions: 2100, Failures: 49.
+#   Tests: 533, Assertions: 2100, Errors: 10, Failures: 39, Skipped: 3.
+#   Tests: 533, Assertions: 2100, Errors: 10, Failures: 39, Warnings: 2, Skipped: 3, Incomplete: 1.
+#
+# Usage: parse-test-results.sh <phpunit-output-file>
+#
+# Writes JSON to HOMEBOY_TEST_RESULTS_FILE if set. Always prints summary to stderr.
+
+set -euo pipefail
+
+OUTPUT_FILE="${1:-}"
+if [ -z "$OUTPUT_FILE" ] || [ ! -f "$OUTPUT_FILE" ]; then
+    exit 0
+fi
+
+OUTPUT=$(cat "$OUTPUT_FILE")
+
+TOTAL=0
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+# Pattern 1: "OK (N tests, N assertions)"
+if echo "$OUTPUT" | grep -qE 'OK \([0-9]+ test'; then
+    TOTAL=$(echo "$OUTPUT" | grep -oP 'OK \(\K[0-9]+' || echo "0")
+    PASSED="$TOTAL"
+    FAILED=0
+    SKIPPED=0
+
+# Pattern 2: "Tests: N, Assertions: N, ..." (failure/mixed output)
+elif echo "$OUTPUT" | grep -qE '^Tests: [0-9]+'; then
+    SUMMARY_LINE=$(echo "$OUTPUT" | grep -E '^Tests: [0-9]+' | tail -1)
+
+    TOTAL=$(echo "$SUMMARY_LINE" | grep -oP 'Tests: \K[0-9]+' || echo "0")
+
+    ERRORS=$(echo "$SUMMARY_LINE" | grep -oP 'Errors: \K[0-9]+' || echo "0")
+    FAILURES=$(echo "$SUMMARY_LINE" | grep -oP 'Failures: \K[0-9]+' || echo "0")
+    WARNINGS=$(echo "$SUMMARY_LINE" | grep -oP 'Warnings: \K[0-9]+' || echo "0")
+    SKIP_COUNT=$(echo "$SUMMARY_LINE" | grep -oP 'Skipped: \K[0-9]+' || echo "0")
+    INCOMPLETE=$(echo "$SUMMARY_LINE" | grep -oP 'Incomplete: \K[0-9]+' || echo "0")
+    RISKY=$(echo "$SUMMARY_LINE" | grep -oP 'Risky: \K[0-9]+' || echo "0")
+
+    FAILED=$((ERRORS + FAILURES))
+    SKIPPED=$((SKIP_COUNT + INCOMPLETE + RISKY + WARNINGS))
+    PASSED=$((TOTAL - FAILED - SKIPPED))
+
+    # Guard against negative passed count
+    if [ "$PASSED" -lt 0 ]; then
+        PASSED=0
+    fi
+else
+    # No recognizable output — exit silently
+    exit 0
+fi
+
+# Write JSON to file if requested
+if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
+    cat > "$HOMEBOY_TEST_RESULTS_FILE" << JSONEOF
+{
+  "total": ${TOTAL},
+  "passed": ${PASSED},
+  "failed": ${FAILED},
+  "skipped": ${SKIPPED}
+}
+JSONEOF
+fi
+
+# Print summary to stderr for visibility
+echo "[test-results] Total: ${TOTAL}, Passed: ${PASSED}, Failed: ${FAILED}, Skipped: ${SKIPPED}" >&2

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -479,6 +479,8 @@ set -e
 if [ $phpunit_exit -ne 0 ]; then
     FAILED_STEP="PHPUnit tests"
     FAILURE_OUTPUT=$(tail -30 "$PHPUNIT_TMPFILE")
+    # Parse test results for baseline (even on failure)
+    bash "${EXTENSION_PATH}/scripts/test/parse-test-results.sh" "$PHPUNIT_TMPFILE" 2>/dev/null || true
     rm -f "$PHPUNIT_TMPFILE"
     # Clean up auto-created test database
     if [ "${MYSQL_AUTO_CREATED:-}" = "1" ]; then
@@ -528,6 +530,15 @@ if [ -z "$(echo "$PHPUNIT_OUTPUT" | grep -E 'PHPUnit|test|assert|OK|ERRORS|FAILU
     echo ""
     FAILED_STEP="PHPUnit tests (no output)"
     exit 1
+fi
+
+# Parse test results for baseline
+if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
+    # Write PHPUNIT_OUTPUT to a temp file for the parser
+    RESULTS_TMPFILE=$(mktemp)
+    echo "$PHPUNIT_OUTPUT" > "$RESULTS_TMPFILE"
+    bash "${EXTENSION_PATH}/scripts/test/parse-test-results.sh" "$RESULTS_TMPFILE" 2>/dev/null || true
+    rm -f "$RESULTS_TMPFILE"
 fi
 
 # Parse and report coverage results


### PR DESCRIPTION
## Summary

Extension-side support for `homeboy test --baseline` ratchet (homeboy PR #420, Issue #411).

Both WordPress and Rust test runners now parse their output and write structured test counts to `HOMEBOY_TEST_RESULTS_FILE` when the env var is set by homeboy core.

## Changes

### New: `wordpress/scripts/test/parse-test-results.sh`

Parses PHPUnit summary output:
- `OK (481 tests, 1234 assertions)` → 481 passed, 0 failed
- `Tests: 533, Assertions: 2100, Errors: 10, Failures: 39, Skipped: 3.` → 481 passed, 49 failed, 3 skipped

Handles all PHPUnit result fields: Errors, Failures, Warnings, Skipped, Incomplete, Risky.

### New: `rust/scripts/parse-test-results.sh`

Parses cargo test summary output:
- `test result: ok. 551 passed; 0 failed; 2 ignored;` → aggregated across multiple test binaries

### Modified: `wordpress/scripts/test/test-runner.sh`

- **Failure path**: Parse results from `$PHPUNIT_TMPFILE` before deleting it
- **Success path**: Parse results from `$PHPUNIT_OUTPUT` after validation, before coverage

### Modified: `rust/scripts/test-runner.sh`

- **Regular path**: Parse results after capturing `$TEST_OUTPUT`, before success/failure branching
- **Tarpaulin path**: Parse results after capturing output, before failure check

## Output format

```json
{
  "total": 533,
  "passed": 481,
  "failed": 49,
  "skipped": 3
}
```

Written to `$HOMEBOY_TEST_RESULTS_FILE` (temp file created by homeboy core). Same pattern as `$HOMEBOY_COVERAGE_FILE`.

## Testing

Manually tested all parsers against real PHPUnit and cargo output patterns (pass, fail, mixed, multi-binary).

## Dependencies

- Companion PR: https://github.com/Extra-Chill/homeboy/pull/420