### PR TITLE
fix: database_type default should be 'auto' not 'sqlite'

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -323,8 +323,8 @@
       "id": "database_type",
       "label": "Database Type",
       "type": "string",
-      "default": "sqlite",
-      "description": "Database backend for tests. Valid values: 'sqlite' (in-memory, fastest) or 'mysql' (for production parity)"
+      "default": "auto",
+      "description": "Database backend for tests. 'auto' (default) tries MySQL first, falls back to SQLite. Use 'mysql' or 'sqlite' to force a specific backend."
     },
     {
       "id": "mysql_host",


### PR DESCRIPTION
## Summary

Fixes #84. Changes the `database_type` test setting default from `"sqlite"` to `"auto"`.

## Problem

The manifest hardcoded `"sqlite"`, which overrode the test-runner's auto-detection logic. Machines with MySQL (all our VPSes) were still using the SQLite shim, hitting constant MySQL-incompatibility bugs.

## Fix

One-line change in `wordpress.json` — `"default": "sqlite"` → `"default": "auto"`. Updated description to reflect the auto-detection behavior.