### PR TITLE
feat: language grammar files for structural regex engine

### DIFF
--- a/rust/grammar.toml
+++ b/rust/grammar.toml
@@ -1,0 +1,160 @@
+# Rust Language Grammar for Homeboy
+#
+# Defines structural patterns for Rust source files.
+# Used by: audit, scaffold, drift, transform, refactor
+#
+# This grammar is loaded by utils/grammar.rs and consumed by all features
+# that need to understand Rust source structure.
+
+[language]
+id = "rust"
+extensions = ["rs"]
+
+[comments]
+line = ["//"]
+block = [["/*", "*/"]]
+doc = ["///", "//!"]
+
+[strings]
+quotes = ['"']
+escape = "\\"
+multiline = []
+
+[blocks]
+open = '{'
+close = '}'
+
+# ===========================================================================
+# Patterns — each key is a concept name used by features
+# ===========================================================================
+
+[patterns.function]
+# Matches: pub fn foo(), pub(crate) async fn bar(), fn baz()
+regex = '^\s*(pub(?:\(crate\))?\s+)?(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?fn\s+(\w+)\s*\(([^)]*)\)'
+context = "any"
+skip_comments = true
+skip_strings = true
+
+[patterns.function.captures]
+visibility = 1
+name = 2
+params = 3
+
+[patterns.struct]
+# Matches: pub struct Foo, enum Bar, pub(crate) trait Baz
+regex = '^\s*(pub(?:\(crate\))?\s+)?(struct|enum|trait)\s+(\w+)'
+context = "top_level"
+skip_comments = true
+skip_strings = true
+
+[patterns.struct.captures]
+visibility = 1
+kind = 2
+name = 3
+
+[patterns.import]
+# Matches: use std::path::Path; use crate::error::{Error, Result};
+regex = '^use\s+([\w:]+(?:::\{[^}]+\})?)\s*;'
+context = "top_level"
+skip_comments = true
+skip_strings = true
+
+[patterns.import.captures]
+path = 1
+
+[patterns.impl_block]
+# Matches: impl Foo, impl<T> Bar, impl Trait for Baz
+regex = '^\s*impl(?:<[^>]*>)?\s+(?:(\w+)\s+for\s+)?(\w+)'
+context = "any"
+skip_comments = true
+skip_strings = true
+
+[patterns.impl_block.captures]
+trait_name = 1
+type_name = 2
+
+[patterns.macro_invocation]
+# Matches: entity_crud!(Component, ...), log_status!("test", ...)
+regex = '(\w+)!\s*\('
+context = "any"
+skip_comments = true
+skip_strings = true
+
+[patterns.macro_invocation.captures]
+name = 1
+
+[patterns.attribute]
+# Matches: #[derive(Debug)], #[cfg(test)], #[test]
+regex = '#\[(\w+)(?:\(([^)]*)\))?\]'
+context = "any"
+skip_comments = true
+skip_strings = true
+
+[patterns.attribute.captures]
+name = 1
+args = 2
+
+[patterns.type_alias]
+# Matches: pub type Result<T> = std::result::Result<T, Error>;
+regex = '^\s*(pub(?:\(crate\))?\s+)?type\s+(\w+)'
+context = "top_level"
+skip_comments = true
+skip_strings = true
+
+[patterns.type_alias.captures]
+visibility = 1
+name = 2
+
+[patterns.const_static]
+# Matches: pub const FOO: &str = ...; pub static BAR: ...
+regex = '^\s*(pub(?:\(crate\))?\s+)?(const|static)\s+(\w+)\s*:'
+context = "any"
+skip_comments = true
+skip_strings = true
+
+[patterns.const_static.captures]
+visibility = 1
+kind = 2
+name = 3
+
+[patterns.mod_declaration]
+# Matches: pub mod foo; mod bar;
+regex = '^\s*(pub(?:\(crate\))?\s+)?mod\s+(\w+)\s*[;{]'
+context = "top_level"
+skip_comments = true
+skip_strings = true
+
+[patterns.mod_declaration.captures]
+visibility = 1
+name = 2
+
+[patterns.test_attribute]
+# Matches: #[test] — specifically for identifying test functions
+regex = '#\[test\]'
+context = "any"
+skip_comments = true
+skip_strings = true
+
+[patterns.cfg_test]
+# Matches: #[cfg(test)] — for identifying test modules
+regex = '#\[cfg\(test\)\]'
+context = "any"
+skip_comments = true
+skip_strings = true
+
+[patterns.derive]
+# Matches: #[derive(Debug, Clone, Serialize)]
+regex = '#\[derive\(([^)]+)\)\]'
+context = "any"
+skip_comments = true
+skip_strings = true
+
+[patterns.derive.captures]
+traits = 1
+
+[patterns.dead_code_marker]
+# Matches: #[allow(dead_code)]
+regex = '#\[allow\(dead_code\)\]'
+context = "any"
+skip_comments = true
+skip_strings = true

--- a/wordpress/grammar.toml
+++ b/wordpress/grammar.toml
@@ -1,0 +1,218 @@
+# PHP Language Grammar for Homeboy (WordPress Extension)
+#
+# Defines structural patterns for PHP source files.
+# Used by: audit, scaffold, drift, transform, refactor
+#
+# This grammar is loaded by utils/grammar.rs and consumed by all features
+# that need to understand PHP source structure.
+
+[language]
+id = "php"
+extensions = ["php"]
+
+[comments]
+line = ["//", "#"]
+block = [["/*", "*/"]]
+doc = ["/**"]
+
+[strings]
+quotes = ['"', "'"]
+escape = "\\"
+multiline = []
+
+[blocks]
+open = '{'
+close = '}'
+
+# ===========================================================================
+# Patterns — each key is a concept name used by features
+# ===========================================================================
+
+[patterns.namespace]
+# Matches: namespace DataMachine\Abilities;
+regex = '^namespace\s+([\w\\\\]+)\s*;'
+context = "top_level"
+skip_comments = true
+skip_strings = true
+
+[patterns.namespace.captures]
+name = 1
+
+[patterns.class]
+# Matches: class Foo, abstract class Bar, final class Baz
+# Also: interface Qux, trait Quux
+regex = '^(?:abstract\s+)?(?:final\s+)?(class|trait|interface)\s+(\w+)(?:\s+extends\s+([\w\\\\]+))?'
+context = "top_level"
+skip_comments = true
+skip_strings = true
+
+[patterns.class.captures]
+kind = 1
+name = 2
+extends = 3
+
+[patterns.method]
+# Matches: public function foo(), protected static function bar($x)
+# Also: function standalone_function()
+regex = '((?:(?:public|protected|private|static|abstract|final)\s+)*)function\s+(\w+)\s*\(([^)]*)\)'
+context = "any"
+skip_comments = true
+skip_strings = true
+
+[patterns.method.captures]
+modifiers = 1
+name = 2
+params = 3
+
+[patterns.import]
+# Matches: use App\Models\User; use App\Models\User as UserModel;
+regex = '^use\s+([\w\\\\]+)(?:\s+as\s+\w+)?\s*;'
+context = "top_level"
+skip_comments = true
+skip_strings = true
+
+[patterns.import.captures]
+path = 1
+
+[patterns.trait_use]
+# Matches: use SomeTrait; (inside class body — in_block context)
+regex = '^\s+use\s+([\w\\\\]+)\s*[;{]'
+context = "in_block"
+skip_comments = true
+skip_strings = true
+
+[patterns.trait_use.captures]
+name = 1
+
+[patterns.property]
+# Matches: public string $name; protected ?int $count = 0;
+regex = '(public|protected|private)\s+(?:static\s+)?(?:readonly\s+)?(?:([\w\\\\|?]+)\s+)?\$(\w+)'
+context = "in_block"
+skip_comments = true
+skip_strings = true
+
+[patterns.property.captures]
+visibility = 1
+type_hint = 2
+name = 3
+
+[patterns.implements]
+# Matches: class Foo implements Bar, Baz
+regex = '(?:class|interface)\s+\w+(?:\s+extends\s+[\w\\\\]+)?\s+implements\s+([\w\\\\,\s]+?)(?:\s*\{)'
+context = "top_level"
+skip_comments = true
+skip_strings = true
+
+[patterns.implements.captures]
+interfaces = 1
+
+[patterns.const]
+# Matches: const FOO = 'bar'; public const BAZ = 1;
+regex = '(?:public|protected|private)?\s*const\s+(\w+)\s*='
+context = "any"
+skip_comments = true
+skip_strings = true
+
+[patterns.const.captures]
+name = 1
+
+# --- WordPress-specific patterns ---
+
+[patterns.register_post_type]
+regex = "register_post_type\\s*\\(\\s*['\"]([\\w-]+)['\"]"
+context = "any"
+skip_comments = true
+skip_strings = false
+
+[patterns.register_post_type.captures]
+name = 1
+
+[patterns.register_taxonomy]
+regex = "register_taxonomy\\s*\\(\\s*['\"]([\\w-]+)['\"]"
+context = "any"
+skip_comments = true
+skip_strings = false
+
+[patterns.register_taxonomy.captures]
+name = 1
+
+[patterns.register_rest_route]
+regex = "register_rest_route\\s*\\([^,]+,\\s*['\"]([^'\"]+)['\"]"
+context = "any"
+skip_comments = true
+skip_strings = false
+
+[patterns.register_rest_route.captures]
+name = 1
+
+[patterns.add_action]
+regex = "add_action\\s*\\(\\s*['\"]([\\w-]+)['\"]"
+context = "any"
+skip_comments = true
+skip_strings = false
+
+[patterns.add_action.captures]
+name = 1
+
+[patterns.add_filter]
+regex = "add_filter\\s*\\(\\s*['\"]([\\w-]+)['\"]"
+context = "any"
+skip_comments = true
+skip_strings = false
+
+[patterns.add_filter.captures]
+name = 1
+
+[patterns.do_action]
+regex = "do_action(?:_ref_array)?\\s*\\(\\s*['\"]([^'\"]+)['\"]"
+context = "any"
+skip_comments = true
+skip_strings = false
+
+[patterns.do_action.captures]
+name = 1
+
+[patterns.apply_filters]
+regex = "apply_filters(?:_ref_array)?\\s*\\(\\s*['\"]([^'\"]+)['\"]"
+context = "any"
+skip_comments = true
+skip_strings = false
+
+[patterns.apply_filters.captures]
+name = 1
+
+[patterns.wp_cli_command]
+regex = "WP_CLI::add_command\\s*\\(\\s*['\"]([^'\"]+)['\"]"
+context = "any"
+skip_comments = true
+skip_strings = false
+
+[patterns.wp_cli_command.captures]
+name = 1
+
+[patterns.wp_register_ability]
+regex = "wp_register_ability\\s*\\(\\s*['\"]([^'\"]+)['\"]"
+context = "any"
+skip_comments = true
+skip_strings = false
+
+[patterns.wp_register_ability.captures]
+name = 1
+
+[patterns.register_block_type]
+regex = "register_block_type\\s*\\(\\s*['\"]([\\w-]+/[\\w-]+)['\"]"
+context = "any"
+skip_comments = true
+skip_strings = false
+
+[patterns.register_block_type.captures]
+name = 1
+
+[patterns.add_shortcode]
+regex = "add_shortcode\\s*\\(\\s*['\"]([\\w-]+)['\"]"
+context = "any"
+skip_comments = true
+skip_strings = false
+
+[patterns.add_shortcode.captures]
+name = 1


### PR DESCRIPTION
## Summary

Adds `grammar.toml` files to both Rust and WordPress extensions, consumed by homeboy's new `utils/grammar.rs` structural regex engine (homeboy#432).

## Rust Grammar (`rust/grammar.toml`)

13 patterns covering Rust source structure:
- **Core**: function, struct/enum/trait, import, impl_block, mod_declaration
- **Attributes**: attribute, test_attribute, cfg_test, derive, dead_code_marker
- **Other**: macro_invocation, type_alias, const_static

## PHP Grammar (`wordpress/grammar.toml`)

17 patterns covering PHP + WordPress structure:
- **Core PHP**: namespace, class/trait/interface, method, import, trait_use, property, implements, const
- **WordPress**: register_post_type, register_taxonomy, register_rest_route, add_action, add_filter, do_action, apply_filters, wp_cli_command, wp_register_ability, register_block_type, add_shortcode

Both grammars define comment syntax, string literal rules, and block delimiters for structure-aware matching.

## How it works

The grammar files are loaded by `utils/grammar.rs` in homeboy core. Features like audit, scaffold, drift, and transform query the grammar for structural concepts instead of hardcoding language-specific regex patterns.

Related: homeboy#432