### PR TITLE
refactor(test): modularize PHPUnit failure parsing and fix testdox duplicates

### DIFF
--- a/wordpress/scripts/test/parse-test-failures.php
+++ b/wordpress/scripts/test/parse-test-failures.php
@@ -2,7 +2,12 @@
 /**
  * Parse PHPUnit output into structured failure data for homeboy test --analyze.
  *
- * Reads PHPUnit output from a file, extracts individual test failures with:
+ * Orchestrator that delegates to format-specific parsers (standard, testdox)
+ * and uses shared error classification. Each parser returns raw blocks with
+ * 'header' and 'body_lines' keys. This file converts them into TestFailure
+ * structures matching homeboy's TestAnalysisInput schema.
+ *
+ * Output fields per failure:
  * - test_name: fully qualified test method name
  * - test_file: test file path (from stack trace)
  * - error_type: exception/error class name
@@ -10,303 +15,151 @@
  * - source_file: deepest non-test frame source file
  * - source_line: source line number
  *
- * Outputs JSON matching homeboy's TestAnalysisInput schema.
- *
  * Usage: php parse-test-failures.php <phpunit_output_file> [component_path]
  */
 
-if ($argc < 2) {
-    fwrite(STDERR, "Usage: php parse-test-failures.php <phpunit_output_file> [component_path]\n");
-    exit(1);
+require_once __DIR__ . '/parsers/classify-error.php';
+require_once __DIR__ . '/parsers/standard.php';
+require_once __DIR__ . '/parsers/testdox.php';
+
+if ( $argc < 2 ) {
+	fwrite( STDERR, "Usage: php parse-test-failures.php <phpunit_output_file> [component_path]\n" );
+	exit( 1 );
 }
 
-$output_file = $argv[1];
-$component_path = $argc >= 3 ? rtrim($argv[2], '/') . '/' : '';
+$output_file    = $argv[1];
+$component_path = $argc >= 3 ? rtrim( $argv[2], '/' ) . '/' : '';
 
-if (!file_exists($output_file)) {
-    fwrite(STDERR, "File not found: $output_file\n");
-    exit(1);
+if ( ! file_exists( $output_file ) ) {
+	fwrite( STDERR, "File not found: $output_file\n" );
+	exit( 1 );
 }
 
-$raw = file_get_contents($output_file);
-$lines = explode("\n", $raw);
-
-$failures = [];
-$total = 0;
-$passed = 0;
+$raw   = file_get_contents( $output_file );
+$lines = explode( "\n", $raw );
 
 // ============================================================================
 // Phase 1: Extract test counts from summary line
 // ============================================================================
 
+$total  = 0;
+$passed = 0;
+
 // Success: "OK (N tests, N assertions)"
-if (preg_match('/OK \((\d+) tests?/', $raw, $m)) {
-    $total = (int) $m[1];
-    $passed = $total;
+if ( preg_match( '/OK \((\d+) tests?/', $raw, $m ) ) {
+	$total  = (int) $m[1];
+	$passed = $total;
 }
 // Failure: "Tests: N, Assertions: N, Errors: N, Failures: N, Skipped: N."
-elseif (preg_match('/^Tests:\s*(\d+)/m', $raw, $m)) {
-    $total = (int) $m[1];
-    $errors = 0;
-    $failed_count = 0;
-    $skipped = 0;
-    if (preg_match('/Errors:\s*(\d+)/', $raw, $em)) $errors = (int) $em[1];
-    if (preg_match('/Failures:\s*(\d+)/', $raw, $fm)) $failed_count = (int) $fm[1];
-    if (preg_match('/Skipped:\s*(\d+)/', $raw, $sm)) $skipped = (int) $sm[1];
-    $passed = max(0, $total - $errors - $failed_count - $skipped);
+elseif ( preg_match( '/^Tests:\s*(\d+)/m', $raw, $m ) ) {
+	$total        = (int) $m[1];
+	$errors       = 0;
+	$failed_count = 0;
+	$skipped      = 0;
+	if ( preg_match( '/Errors:\s*(\d+)/', $raw, $em ) ) {
+		$errors = (int) $em[1];
+	}
+	if ( preg_match( '/Failures:\s*(\d+)/', $raw, $fm ) ) {
+		$failed_count = (int) $fm[1];
+	}
+	if ( preg_match( '/Skipped:\s*(\d+)/', $raw, $sm ) ) {
+		$skipped = (int) $sm[1];
+	}
+	$passed = max( 0, $total - $errors - $failed_count - $skipped );
 }
 
 // ============================================================================
-// Phase 2: Find failure/error blocks
+// Phase 2: Parse failure blocks — try each parser until one produces results
 // ============================================================================
-// PHPUnit formats failures as numbered blocks:
-//
-//   1) Namespace\ClassTest::testMethod
-//   Error message here
-//   possibly multiple lines
-//
-//   /path/to/file.php:42
-//   /path/to/other.php:10
-//
-//   2) Namespace\ClassTest::testOther
-//   ...
-//
-// Fatal errors appear as:
-//   1) Namespace\ClassTest::testMethod
-//   Cannot redeclare function_name() (previously declared in /path:42) in /path:42
-//
-// Sections are delimited by "There was N error(s):" / "There was N failure(s):"
-// or by "ERRORS!" / "FAILURES!" banners.
 
-// Split into failure blocks. Each block starts with "N) " at line start.
-$in_failure_section = false;
-$current_block = null;
-$blocks = [];
+$blocks = parse_standard_blocks( $lines );
 
-for ($i = 0; $i < count($lines); $i++) {
-    $line = $lines[$i];
-
-    // Detect start of failure/error listing sections
-    if (preg_match('/^There (?:was|were) \d+ (?:error|failure)/i', $line)) {
-        $in_failure_section = true;
-        continue;
-    }
-
-    // Detect end markers
-    if (preg_match('/^(ERRORS!|FAILURES!)/', $line)) {
-        $in_failure_section = false;
-        // Save last block
-        if ($current_block !== null) {
-            $blocks[] = $current_block;
-            $current_block = null;
-        }
-        continue;
-    }
-
-    // Summary line ends all blocks
-    if (preg_match('/^Tests:\s*\d+/', $line)) {
-        if ($current_block !== null) {
-            $blocks[] = $current_block;
-            $current_block = null;
-        }
-        $in_failure_section = false;
-        continue;
-    }
-
-    if (!$in_failure_section) {
-        continue;
-    }
-
-    // New numbered block: "N) Namespace\ClassTest::testMethod"
-    if (preg_match('/^\d+\)\s+(.+)$/', $line, $m)) {
-        // Save previous block
-        if ($current_block !== null) {
-            $blocks[] = $current_block;
-        }
-        $current_block = [
-            'header' => trim($m[1]),
-            'body_lines' => [],
-        ];
-        continue;
-    }
-
-    // Accumulate body lines for current block
-    if ($current_block !== null) {
-        $current_block['body_lines'][] = $line;
-    }
-}
-
-// Don't forget last block
-if ($current_block !== null) {
-    $blocks[] = $current_block;
+if ( empty( $blocks ) ) {
+	$blocks = parse_testdox_blocks( $lines );
 }
 
 // ============================================================================
-// Phase 3: Parse each block into a TestFailure
+// Phase 3: Convert raw blocks into TestFailure structures
 // ============================================================================
 
-foreach ($blocks as $block) {
-    $header = $block['header'];
-    $body = $block['body_lines'];
+$failures = [];
 
-    // Parse test name from header
-    // Format: "Namespace\ClassTest::testMethod" or "Namespace\ClassTest::testMethod with data set #0"
-    $test_name = $header;
-    if (strpos($test_name, ' with data set') !== false) {
-        $test_name = substr($test_name, 0, strpos($test_name, ' with data set'));
-    }
+foreach ( $blocks as $block ) {
+	$header = $block['header'];
+	$body   = $block['body_lines'];
 
-    // Build message from body lines (non-empty, non-trace lines)
-    $message_lines = [];
-    $trace_lines = [];
-    $in_trace = false;
+	// Parse test name from header
+	// Format: "Namespace\ClassTest::testMethod" or with " with data set #0"
+	$test_name = $header;
+	if ( strpos( $test_name, ' with data set' ) !== false ) {
+		$test_name = substr( $test_name, 0, strpos( $test_name, ' with data set' ) );
+	}
 
-    foreach ($body as $bline) {
-        $trimmed = trim($bline);
+	// Separate message lines from trace lines
+	$message_lines = [];
+	$trace_lines   = [];
+	$in_trace      = false;
 
-        // Skip empty lines between message and trace
-        if ($trimmed === '') {
-            if (!empty($message_lines) && !$in_trace) {
-                // Could be transitioning to trace section
-                continue;
-            }
-            continue;
-        }
+	foreach ( $body as $bline ) {
+		$trimmed = trim( $bline );
 
-        // Stack trace lines start with a path
-        if (preg_match('#^(/[^\s:]+\.php):(\d+)$#', $trimmed) ||
-            preg_match('#^(/[^\s:]+\.php:\d+)$#', $trimmed)) {
-            $in_trace = true;
-            $trace_lines[] = $trimmed;
-            continue;
-        }
+		if ( $trimmed === '' ) {
+			continue;
+		}
 
-        // Also match indented trace format "at /path/to/file.php:42"
-        if (preg_match('#^\s*at\s+(/[^\s:]+\.php):(\d+)#', $bline)) {
-            $in_trace = true;
-            $trace_lines[] = $trimmed;
-            continue;
-        }
+		// Stack trace lines: "/path/to/file.php:42"
+		if ( preg_match( '#^(/[^\s:]+\.php):(\d+)$#', $trimmed ) ||
+			preg_match( '#^(/[^\s:]+\.php:\d+)$#', $trimmed ) ) {
+			$in_trace      = true;
+			$trace_lines[] = $trimmed;
+			continue;
+		}
 
-        if (!$in_trace) {
-            $message_lines[] = $trimmed;
-        }
-    }
+		// Indented trace: "at /path/to/file.php:42"
+		if ( preg_match( '#^\s*at\s+(/[^\s:]+\.php):(\d+)#', $bline ) ) {
+			$in_trace      = true;
+			$trace_lines[] = $trimmed;
+			continue;
+		}
 
-    $message = implode("\n", $message_lines);
+		if ( ! $in_trace ) {
+			$message_lines[] = $trimmed;
+		}
+	}
 
-    // Trim trailing empty content from message
-    $message = rtrim($message);
+	$message = rtrim( implode( "\n", $message_lines ) );
 
-    // ---- Detect error type ----
-    $error_type = 'Error';
+	// Classify error type using shared logic
+	$error_type = classify_error_type( $message );
 
-    // Check for fatal error patterns
-    if (preg_match('/^(Fatal error|PHP Fatal error):/i', $message)) {
-        $error_type = 'FatalError';
-    }
-    // "Cannot redeclare ..." is a fatal error
-    elseif (preg_match('/^Cannot redeclare\b/', $message)) {
-        $error_type = 'FatalError';
-    }
-    // PHPUnit assertion failures
-    elseif (preg_match('/^Failed asserting/', $message)) {
-        $error_type = 'AssertionFailedError';
-    }
-    // "Call to undefined method" — Error
-    elseif (preg_match('/^Call to undefined method/', $message)) {
-        $error_type = 'Error';
-    }
-    // "Call to undefined function" — Error
-    elseif (preg_match('/^Call to undefined function/', $message)) {
-        $error_type = 'Error';
-    }
-    // "Class .* not found"
-    elseif (preg_match('/^Class .* not found/', $message)) {
-        $error_type = 'Error';
-    }
-    // "Argument #N ... must be of type X, Y given"
-    elseif (preg_match('/must be of type/', $message)) {
-        $error_type = 'TypeError';
-    }
-    // "Return value .* must be of type"
-    elseif (preg_match('/Return value .* must be of type/', $message)) {
-        $error_type = 'TypeError';
-    }
-    // PHPUnit mock errors
-    elseif (preg_match('/Trying to configure method .* which cannot be configured/', $message)) {
-        $error_type = 'MockError';
-    }
-    elseif (preg_match('/does not allow named arguments/', $message)) {
-        $error_type = 'MockError';
-    }
-    // Check message for explicit exception class prefix like "ErrorException:"
-    elseif (preg_match('/^(\w+(?:\\\\\w+)*(?:Error|Exception)):\s/', $message, $em)) {
-        $error_type = $em[1];
-    }
+	// Extract source/test files from trace
+	$source_info = extract_source_from_trace( $trace_lines, $component_path );
+	$source_file = $source_info['source_file'];
+	$source_line = $source_info['source_line'];
+	$test_file   = $source_info['test_file'];
 
-    // ---- Extract source file from trace (deepest non-test frame) ----
-    $source_file = '';
-    $source_line = 0;
-    $test_file = '';
+	// Fallback: guess test file from test name
+	if ( empty( $test_file ) ) {
+		$test_file = guess_test_file_from_name( $test_name );
+	}
 
-    foreach ($trace_lines as $tline) {
-        if (preg_match('#^(/[^\s:]+\.php):(\d+)#', $tline, $tm)) {
-            $file = $tm[1];
-            $line_num = (int) $tm[2];
+	// Fallback: extract source from message (fatal errors)
+	if ( empty( $source_file ) ) {
+		$msg_source = extract_source_from_message( $message, $component_path );
+		if ( $msg_source ) {
+			$source_file = $msg_source['source_file'];
+			$source_line = $msg_source['source_line'];
+		}
+	}
 
-            // Strip component_path prefix for relative paths
-            $rel_file = $file;
-            if ($component_path && strpos($file, $component_path) === 0) {
-                $rel_file = substr($file, strlen($component_path));
-            }
-
-            // Test files contain /tests/ in their path
-            if (strpos($file, '/tests/') !== false || strpos($file, 'Test.php') !== false) {
-                if (empty($test_file)) {
-                    $test_file = $rel_file;
-                }
-            } else {
-                // Non-test file — this is a source file
-                // We want the deepest (first) non-test frame
-                if (empty($source_file)) {
-                    $source_file = $rel_file;
-                    $source_line = $line_num;
-                }
-            }
-        }
-    }
-
-    // If no test file found from trace, try to extract from the test_name
-    if (empty($test_file) && preg_match('/^(.+)::/', $test_name, $nm)) {
-        $class_fqn = $nm[1];
-        // Convert namespace to path guess: Namespace\SubTest -> tests/Namespace/SubTest.php
-        $test_file = 'tests/' . str_replace('\\', '/', $class_fqn) . '.php';
-    }
-
-    // Also try extracting source from the message itself for fatal errors
-    // e.g., "Cannot redeclare func() (previously declared in /path/to/file.php:42)"
-    if (empty($source_file) && preg_match('#in (/[^\s:]+\.php):(\d+)#', $message, $mm)) {
-        $file = $mm[1];
-        $line_num = (int) $mm[2];
-        $rel_file = $file;
-        if ($component_path && strpos($file, $component_path) === 0) {
-            $rel_file = substr($file, strlen($component_path));
-        }
-        if (strpos($file, '/tests/') === false && strpos($file, 'Test.php') === false) {
-            $source_file = $rel_file;
-            $source_line = $line_num;
-        }
-    }
-
-    $failures[] = [
-        'test_name' => $test_name,
-        'test_file' => $test_file,
-        'error_type' => $error_type,
-        'message' => $message,
-        'source_file' => $source_file,
-        'source_line' => $source_line,
-    ];
+	$failures[] = [
+		'test_name'   => $test_name,
+		'test_file'   => $test_file,
+		'error_type'  => $error_type,
+		'message'     => $message,
+		'source_file' => $source_file,
+		'source_line' => $source_line,
+	];
 }
 
 // ============================================================================
@@ -314,9 +167,9 @@ foreach ($blocks as $block) {
 // ============================================================================
 
 $output = [
-    'failures' => $failures,
-    'total' => $total,
-    'passed' => $passed,
+	'failures' => $failures,
+	'total'    => $total,
+	'passed'   => $passed,
 ];
 
-echo json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+echo json_encode( $output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n";

--- a/wordpress/scripts/test/parsers/classify-error.php
+++ b/wordpress/scripts/test/parsers/classify-error.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Shared error type classification for PHPUnit test failures.
+ *
+ * Given an error message, returns a category string that homeboy core
+ * uses to cluster failures by root cause.
+ *
+ * Categories: FatalError, AssertionFailedError, TypeError, MockError, Error
+ */
+
+/**
+ * Classify an error message into a type category.
+ *
+ * @param string $message The error message from a test failure.
+ * @return string The error type category.
+ */
+function classify_error_type( string $message ): string {
+	// Fatal errors
+	if ( preg_match( '/^(Fatal error|PHP Fatal error):/i', $message ) ) {
+		return 'FatalError';
+	}
+	if ( preg_match( '/^Cannot redeclare\b/', $message ) ) {
+		return 'FatalError';
+	}
+
+	// PHPUnit assertion failures
+	if ( preg_match( '/^Failed asserting/', $message ) ) {
+		return 'AssertionFailedError';
+	}
+
+	// Type errors
+	if ( preg_match( '/must be of type/', $message ) ) {
+		return 'TypeError';
+	}
+	if ( preg_match( '/Return value .* must be of type/', $message ) ) {
+		return 'TypeError';
+	}
+
+	// Mock configuration errors
+	if ( preg_match( '/Trying to configure method .* which cannot be configured/', $message ) ) {
+		return 'MockError';
+	}
+	if ( preg_match( '/does not allow named arguments/', $message ) ) {
+		return 'MockError';
+	}
+
+	// Undefined method/function
+	if ( preg_match( '/^Call to undefined method/', $message ) ) {
+		return 'Error';
+	}
+	if ( preg_match( '/^Call to undefined function/', $message ) ) {
+		return 'Error';
+	}
+
+	// Class not found
+	if ( preg_match( '/^Class .* not found/', $message ) ) {
+		return 'Error';
+	}
+
+	// Explicit exception class in message (e.g. "ErrorException: ...")
+	if ( preg_match( '/^(\w+(?:\\\\\w+)*(?:Error|Exception)):\s/', $message, $em ) ) {
+		return $em[1];
+	}
+
+	// Unexpected notice / _doing_it_wrong
+	if ( preg_match( '/^Unexpected .* notice/', $message ) ) {
+		return 'UnexpectedNotice';
+	}
+
+	return 'Error';
+}
+
+/**
+ * Extract source file and test file from stack trace lines.
+ *
+ * @param array  $trace_lines     Array of trace line strings (e.g. "/path/to/file.php:42").
+ * @param string $component_path  Component path prefix to strip for relative paths.
+ * @return array{source_file: string, source_line: int, test_file: string}
+ */
+function extract_source_from_trace( array $trace_lines, string $component_path = '' ): array {
+	$source_file = '';
+	$source_line = 0;
+	$test_file   = '';
+
+	foreach ( $trace_lines as $tline ) {
+		if ( preg_match( '#^(/[^\s:]+\.php):(\d+)#', $tline, $tm ) ) {
+			$file     = $tm[1];
+			$line_num = (int) $tm[2];
+
+			// Strip component_path prefix for relative paths
+			$rel_file = $file;
+			if ( $component_path && strpos( $file, $component_path ) === 0 ) {
+				$rel_file = substr( $file, strlen( $component_path ) );
+			}
+
+			// Test files contain /tests/ in their path
+			if ( strpos( $file, '/tests/' ) !== false || strpos( $file, 'Test.php' ) !== false ) {
+				if ( empty( $test_file ) ) {
+					$test_file = $rel_file;
+				}
+			} else {
+				// Non-test file — deepest (first) non-test frame
+				if ( empty( $source_file ) ) {
+					$source_file = $rel_file;
+					$source_line = $line_num;
+				}
+			}
+		}
+	}
+
+	return [
+		'source_file' => $source_file,
+		'source_line' => $source_line,
+		'test_file'   => $test_file,
+	];
+}
+
+/**
+ * Try to extract source file info from the error message itself.
+ * Useful for fatal errors: "Cannot redeclare func() (previously declared in /path:42)"
+ *
+ * @param string $message        The error message.
+ * @param string $component_path Component path prefix.
+ * @return array{source_file: string, source_line: int}|null Null if nothing found.
+ */
+function extract_source_from_message( string $message, string $component_path = '' ): ?array {
+	if ( preg_match( '#in (/[^\s:]+\.php):(\d+)#', $message, $mm ) ) {
+		$file     = $mm[1];
+		$line_num = (int) $mm[2];
+		$rel_file = $file;
+		if ( $component_path && strpos( $file, $component_path ) === 0 ) {
+			$rel_file = substr( $file, strlen( $component_path ) );
+		}
+		if ( strpos( $file, '/tests/' ) === false && strpos( $file, 'Test.php' ) === false ) {
+			return [
+				'source_file' => $rel_file,
+				'source_line' => $line_num,
+			];
+		}
+	}
+	return null;
+}
+
+/**
+ * Guess test file path from a fully qualified test name.
+ *
+ * @param string $test_name e.g. "DataMachine\Tests\Unit\Abilities\FileAbilities::test_method"
+ * @return string e.g. "tests/DataMachine/Tests/Unit/Abilities/FileAbilities.php"
+ */
+function guess_test_file_from_name( string $test_name ): string {
+	if ( preg_match( '/^(.+)::/', $test_name, $nm ) ) {
+		$class_fqn = $nm[1];
+		return 'tests/' . str_replace( '\\', '/', $class_fqn ) . '.php';
+	}
+	return '';
+}

--- a/wordpress/scripts/test/parsers/standard.php
+++ b/wordpress/scripts/test/parsers/standard.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Standard PHPUnit output parser.
+ *
+ * Parses the numbered failure block format:
+ *
+ *   There was 1 failure:
+ *
+ *   1) Namespace\ClassTest::testMethod
+ *   Failed asserting that ...
+ *
+ *   /path/to/file.php:42
+ *   /path/to/other.php:10
+ *
+ *   FAILURES!
+ *   Tests: 10, Assertions: 20, Failures: 1.
+ *
+ * Returns an array of raw blocks with 'header' and 'body_lines' keys.
+ * The orchestrator handles converting blocks into TestFailure structures.
+ */
+
+require_once __DIR__ . '/classify-error.php';
+
+/**
+ * Parse standard PHPUnit output for failure blocks.
+ *
+ * @param array $lines Array of output lines.
+ * @return array Array of failure blocks, each with 'header' (string) and 'body_lines' (array).
+ */
+function parse_standard_blocks( array $lines ): array {
+	$in_failure_section = false;
+	$current_block      = null;
+	$blocks             = [];
+
+	for ( $i = 0; $i < count( $lines ); $i++ ) {
+		$line = $lines[ $i ];
+
+		// Detect start of failure/error listing sections
+		if ( preg_match( '/^There (?:was|were) \d+ (?:error|failure)/i', $line ) ) {
+			$in_failure_section = true;
+			continue;
+		}
+
+		// Detect end markers
+		if ( preg_match( '/^(ERRORS!|FAILURES!)/', $line ) ) {
+			$in_failure_section = false;
+			if ( $current_block !== null ) {
+				$blocks[]      = $current_block;
+				$current_block = null;
+			}
+			continue;
+		}
+
+		// Summary line ends all blocks
+		if ( preg_match( '/^Tests:\s*\d+/', $line ) ) {
+			if ( $current_block !== null ) {
+				$blocks[]      = $current_block;
+				$current_block = null;
+			}
+			$in_failure_section = false;
+			continue;
+		}
+
+		if ( ! $in_failure_section ) {
+			continue;
+		}
+
+		// New numbered block: "N) Namespace\ClassTest::testMethod"
+		if ( preg_match( '/^\d+\)\s+(.+)$/', $line, $m ) ) {
+			if ( $current_block !== null ) {
+				$blocks[] = $current_block;
+			}
+			$current_block = [
+				'header'     => trim( $m[1] ),
+				'body_lines' => [],
+			];
+			continue;
+		}
+
+		// Accumulate body lines for current block
+		if ( $current_block !== null ) {
+			$current_block['body_lines'][] = $line;
+		}
+	}
+
+	// Don't forget last block
+	if ( $current_block !== null ) {
+		$blocks[] = $current_block;
+	}
+
+	return $blocks;
+}

--- a/wordpress/scripts/test/parsers/testdox.php
+++ b/wordpress/scripts/test/parsers/testdox.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * PHPUnit testdox output parser.
+ *
+ * Parses the --testdox inline failure format:
+ *
+ *   File Abilities (DataMachine\Tests\Unit\Abilities\FileAbilities)
+ *    ✔ List files ability registered
+ *    ✘ List files rejects both scopes
+ *      │
+ *      │ Failed asserting that 'Flow step 8-6 not found' contains "Cannot provide both".
+ *      │
+ *      │ /path/to/tests/FileAbilitiesTest.php:94
+ *      │
+ *
+ * Returns blocks in the same format as the standard parser: array of
+ * {'header': 'FQCN::method', 'body_lines': [...]} for the orchestrator.
+ */
+
+require_once __DIR__ . '/classify-error.php';
+
+/**
+ * Parse testdox-formatted PHPUnit output for failure blocks.
+ *
+ * @param array $lines Array of output lines.
+ * @return array Array of failure blocks, each with 'header' (string) and 'body_lines' (array).
+ */
+function parse_testdox_blocks( array $lines ): array {
+	$blocks             = [];
+	$current_class_fqcn = '';
+	$current_failure    = null;
+	$seen_summary       = false;
+
+	for ( $i = 0; $i < count( $lines ); $i++ ) {
+		$line = $lines[ $i ];
+
+		// Stop parsing once we hit any summary/repeat section.
+		// PHPUnit 9 testdox prints a "Summary of non-successful tests:" section
+		// that repeats all failures. The test runner shell script may also repeat
+		// output in its "Error details:" section. We must stop at the first
+		// boundary to avoid duplicates.
+		if ( $seen_summary ) {
+			break;
+		}
+
+		// PHPUnit's testdox summary section (repeats failures)
+		if ( preg_match( '/^Summary of non-successful tests:/', $line ) ) {
+			if ( $current_failure !== null ) {
+				$blocks[]        = $current_failure;
+				$current_failure = null;
+			}
+			$seen_summary = true;
+			continue;
+		}
+
+		// "Time: ..." line marks end of the main test output
+		if ( preg_match( '/^Time:\s/', $line ) ) {
+			if ( $current_failure !== null ) {
+				$blocks[]        = $current_failure;
+				$current_failure = null;
+			}
+			$seen_summary = true;
+			continue;
+		}
+
+		// FAILURES!/ERRORS! banners
+		if ( preg_match( '/^(FAILURES!|ERRORS!)$/', $line ) ) {
+			if ( $current_failure !== null ) {
+				$blocks[]        = $current_failure;
+				$current_failure = null;
+			}
+			$seen_summary = true;
+			continue;
+		}
+
+		// Tests: summary line
+		if ( preg_match( '/^Tests:\s*\d+/', $line ) ) {
+			if ( $current_failure !== null ) {
+				$blocks[]        = $current_failure;
+				$current_failure = null;
+			}
+			$seen_summary = true;
+			continue;
+		}
+
+		// Class header: "ClassName (Namespace\ClassName)"
+		// e.g. "File Abilities (DataMachine\Tests\Unit\Abilities\FileAbilities)"
+		if ( preg_match( '/^(\S.*?)\s+\(([A-Z][\w\\\\]+)\)\s*$/', $line, $m ) ) {
+			if ( $current_failure !== null ) {
+				$blocks[]        = $current_failure;
+				$current_failure = null;
+			}
+			$current_class_fqcn = $m[2];
+			continue;
+		}
+
+		// Failed test line: " ✘ Test method name" (Unicode cross mark)
+		if ( preg_match( '/^\s+[\x{2718}\x{2717}x]\s+(.+)$/u', $line, $m ) ) {
+			if ( $current_failure !== null ) {
+				$blocks[] = $current_failure;
+			}
+
+			$test_label = trim( $m[1] );
+
+			// Convert testdox label to method name:
+			// "List files rejects both scopes" → "test_list_files_rejects_both_scopes"
+			$method_name = 'test_' . preg_replace( '/\s+/', '_', strtolower( $test_label ) );
+
+			$header = $current_class_fqcn
+				? $current_class_fqcn . '::' . $method_name
+				: $method_name;
+
+			$current_failure = [
+				'header'     => $header,
+				'body_lines' => [],
+			];
+			continue;
+		}
+
+		// Accumulate body lines for current failure (lines with │ prefix)
+		if ( $current_failure !== null ) {
+			if ( preg_match( '/^\s+\x{2502}\s?(.*)$/u', $line, $m ) ) {
+				$current_failure['body_lines'][] = $m[1];
+				continue;
+			}
+
+			// Passing test (✔) or new class header ends current failure
+			if ( preg_match( '/^\s+[\x{2714}\x{2713}]/u', $line ) ||
+				preg_match( '/^(\S.*?)\s+\(([A-Z][\w\\\\]+)\)\s*$/', $line ) ) {
+				$blocks[]        = $current_failure;
+				$current_failure = null;
+				// Re-process this line
+				$i--;
+				continue;
+			}
+		}
+	}
+
+	// Don't forget last failure
+	if ( $current_failure !== null ) {
+		$blocks[] = $current_failure;
+	}
+
+	return $blocks;
+}


### PR DESCRIPTION
## Summary
- split `parse-test-failures.php` into a modular parser architecture
- add dedicated parsers for standard PHPUnit output and `--testdox` output
- add shared classification utilities for error typing and source extraction
- stop testdox parsing at summary boundaries to prevent duplicate failure extraction

## Why
The previous monolithic parser was hard to maintain and only reliably handled one output style. In `--testdox` mode, failure lines could be repeated in summary sections, causing duplicate failures and noisy analysis clusters.

## Validation
- manual parser run against real FileAbilities failing output returns 7 failures (no duplicates)
- `homeboy test data-machine --skip-lint --analyze -- --filter='FileAbilities'` now returns structured `analysis` clusters end-to-end