### PR TITLE
fix(wordpress-tests): align mysql default database with CI service

### DIFF
--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -244,13 +244,13 @@ elif [ "$DATABASE_TYPE" = "mysql" ]; then
         if [ -n "${HOMEBOY_EXTENSION_PATH:-}" ]; then
             # Use Homeboy settings
             MYSQL_HOST=$(printf '%s' "$SETTINGS_JSON" | jq -r '.mysql_host // "127.0.0.1"')
-            MYSQL_DATABASE=$(printf '%s' "$SETTINGS_JSON" | jq -r '.mysql_database // "wordpress_test"')
+            MYSQL_DATABASE=$(printf '%s' "$SETTINGS_JSON" | jq -r '.mysql_database // "homeboy_wptests"')
             MYSQL_USER=$(printf '%s' "$SETTINGS_JSON" | jq -r '.mysql_user // "root"')
             MYSQL_PASSWORD=$(printf '%s' "$SETTINGS_JSON" | jq -r '.mysql_password // ""')
         else
             # Use defaults when called directly
             MYSQL_HOST="127.0.0.1"
-            MYSQL_DATABASE="wordpress_test"
+            MYSQL_DATABASE="homeboy_wptests"
             MYSQL_USER="root"
             MYSQL_PASSWORD=""
         fi

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -337,7 +337,7 @@
       "id": "mysql_database",
       "label": "MySQL Database",
       "type": "string",
-      "default": "wordpress_test",
+      "default": "homeboy_wptests",
       "description": "MySQL database name (when using mysql database type)"
     },
     {


### PR DESCRIPTION
## Summary
- change WordPress extension MySQL default database from `wordpress_test` to `homeboy_wptests`
- keep host default at `127.0.0.1` (from previous fix) for TCP-safe CI behavior

## Why
In CI, the MySQL service is provisioned with `homeboy_wptests`. WordPress tests were bootstrapping against `wordpress_test`, causing `db_select_fail` despite a healthy connection.

Aligning defaults removes that mismatch in explicit mysql mode.