### PR TITLE
fix(test): stop replaying full failure output in Rust test runner

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 
 FAILED_STEP=""
 FAILURE_OUTPUT=""
+FAILURE_REPLAY_MODE="full"
 
 # Step filtering
 should_run_step() {
@@ -35,7 +36,10 @@ print_failure_summary() {
         echo "============================================"
         echo "BUILD FAILED: $FAILED_STEP"
         echo "============================================"
-        if [ -n "$FAILURE_OUTPUT" ]; then
+        if [ "$FAILURE_REPLAY_MODE" = "none" ]; then
+            echo ""
+            echo "See test output above (not replayed)."
+        elif [ -n "$FAILURE_OUTPUT" ]; then
             echo ""
             echo "Error details:"
             echo "$FAILURE_OUTPUT"
@@ -132,7 +136,7 @@ if [ "${HOMEBOY_COVERAGE:-}" = "1" ]; then
             FAILURES=$(echo "$TEST_OUTPUT" | grep -E "^---- .* ----$|^test .* FAILED$" || true)
             if [ -n "$SUMMARY" ]; then echo ""; echo "$SUMMARY"; fi
             FAILED_STEP="cargo tarpaulin"
-            FAILURE_OUTPUT="$(echo "$FAILURES" | head -20)"
+            FAILURE_REPLAY_MODE="none"
             rm -f "$COVERAGE_JSON_FILE"
             exit $TEST_EXIT
         fi
@@ -259,7 +263,7 @@ else
     fi
 
     FAILED_STEP="cargo test"
-    FAILURE_OUTPUT="$(echo "$FAILURES" | head -20)"
+    FAILURE_REPLAY_MODE="none"
     exit $TEST_EXIT
 fi
 


### PR DESCRIPTION
## Summary
- add replay-mode control to the Rust test runner failure trap
- on `cargo test` and `cargo tarpaulin` failures, disable replay and emit only `BUILD FAILED` plus a pointer to output already shown above
- keep existing summary-line extraction while removing duplicate large-suite output replay

## Why
`homeboy test` already streams test output live. Replaying failure details again on exit duplicates large test logs and pushes actionable summary lines out of terminal scrollback.