### PR TITLE
fix(rust): narrow cfg(test) module detection

### DIFF
--- a/rust/scripts/refactor.py
+++ b/rust/scripts/refactor.py
@@ -269,12 +269,14 @@ def find_test_module(content: str) -> Optional[tuple[int, int, str]]:
     """Find the #[cfg(test)] mod tests block, return (start, end, source)."""
     lines = content.split('\n')
 
-    # Look for #[cfg(test)] followed by mod tests
+    # Look for #[cfg(test)] followed specifically by mod tests / mod test.
+    # Do not treat arbitrary cfg(test) modules as the canonical test module,
+    # or we risk hiding unrelated test-only helper items from top-level parsing.
     for i in range(len(lines)):
         if '#[cfg(test)]' in lines[i]:
-            # Look ahead for mod tests or mod <name>
+            # Look ahead for the conventional test module only.
             for j in range(i + 1, min(i + 3, len(lines))):
-                if re.match(r'\s*mod\s+\w+\s*\{', lines[j]):
+                if re.match(r'\s*mod\s+tests?\s*\{', lines[j]):
                     end = find_matching_brace(lines, j)
                     return (i, end, '\n'.join(lines[i:end + 1]))
 


### PR DESCRIPTION
## Summary
- narrow the Rust refactor parser so `#[cfg(test)]` only treats `mod test` / `mod tests` as the canonical test module
- stop excluding arbitrary `#[cfg(test)] mod helpers { ... }`-style modules from top-level item parsing
- improve generic parser precision for extension-backed duplicate/refactor fallback flows used by Homeboy audit autofix

## Notes
- This is the companion extension PR for Extra-Chill/homeboy#514
- The goal is generic parser correctness, not a Homeboy-specific special case