### PR TITLE
refactor(extension): share runner step filtering

### DIFF
--- a/rust/scripts/lib/runner-steps.sh
+++ b/rust/scripts/lib/runner-steps.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Shared step filtering contract for extension runner scripts.
+#
+# Reads HOMEBOY_STEP / HOMEBOY_SKIP as comma-separated step names and exposes
+# should_run_step <name> with the same semantics as Homeboy core's
+# RunnerStepFilter:
+# - HOMEBOY_STEP present => only listed steps run
+# - HOMEBOY_SKIP present => listed steps are skipped
+# - empty step name => runs by default
+
+should_run_step() {
+    local step_name="${1:-}"
+    step_name="$(printf '%s' "$step_name" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+
+    if [ -z "$step_name" ]; then
+        return 0
+    fi
+
+    if [ -n "${HOMEBOY_STEP:-}" ]; then
+        case ",${HOMEBOY_STEP}," in
+            *",${step_name},"*) ;;
+            *) return 1 ;;
+        esac
+    fi
+
+    if [ -n "${HOMEBOY_SKIP:-}" ]; then
+        case ",${HOMEBOY_SKIP}," in
+            *",${step_name},"*) return 1 ;;
+        esac
+    fi
+
+    return 0
+}

--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -19,17 +19,9 @@ set -euo pipefail
 FAILED_STEP=""
 FAILURE_OUTPUT=""
 
-# Step filtering
-should_run_step() {
-    local step_name="$1"
-    if [ -n "${HOMEBOY_STEP:-}" ]; then
-        echo ",${HOMEBOY_STEP}," | grep -q ",${step_name}," && return 0 || return 1
-    fi
-    if [ -n "${HOMEBOY_SKIP:-}" ]; then
-        echo ",${HOMEBOY_SKIP}," | grep -q ",${step_name}," && return 1 || return 0
-    fi
-    return 0
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/runner-steps.sh
+source "${SCRIPT_DIR}/lib/runner-steps.sh"
 
 print_failure_summary() {
     if [ -n "$FAILED_STEP" ]; then

--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -20,8 +20,9 @@ FAILED_STEP=""
 FAILURE_OUTPUT=""
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/lib/runner-steps.sh}"
 # shellcheck source=./lib/runner-steps.sh
-source "${SCRIPT_DIR}/lib/runner-steps.sh"
+source "${RUNNER_STEPS_HELPER}"
 
 print_failure_summary() {
     if [ -n "$FAILED_STEP" ]; then

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -19,8 +19,9 @@ FAILURE_OUTPUT=""
 FAILURE_REPLAY_MODE="full"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/lib/runner-steps.sh}"
 # shellcheck source=./lib/runner-steps.sh
-source "${SCRIPT_DIR}/lib/runner-steps.sh"
+source "${RUNNER_STEPS_HELPER}"
 
 print_failure_summary() {
     if [ -n "$FAILED_STEP" ]; then

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -18,17 +18,9 @@ FAILED_STEP=""
 FAILURE_OUTPUT=""
 FAILURE_REPLAY_MODE="full"
 
-# Step filtering
-should_run_step() {
-    local step_name="$1"
-    if [ -n "${HOMEBOY_STEP:-}" ]; then
-        echo ",${HOMEBOY_STEP}," | grep -q ",${step_name}," && return 0 || return 1
-    fi
-    if [ -n "${HOMEBOY_SKIP:-}" ]; then
-        echo ",${HOMEBOY_SKIP}," | grep -q ",${step_name}," && return 1 || return 0
-    fi
-    return 0
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/runner-steps.sh
+source "${SCRIPT_DIR}/lib/runner-steps.sh"
 
 print_failure_summary() {
     if [ -n "$FAILED_STEP" ]; then
@@ -55,7 +47,7 @@ else
     PROJECT_PATH="$(pwd)"
 fi
 
-EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Rust Test Environment:"

--- a/wordpress/scripts/lib/runner-steps.sh
+++ b/wordpress/scripts/lib/runner-steps.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Shared step filtering contract for extension runner scripts.
+#
+# Reads HOMEBOY_STEP / HOMEBOY_SKIP as comma-separated step names and exposes
+# should_run_step <name> with the same semantics as Homeboy core's
+# RunnerStepFilter:
+# - HOMEBOY_STEP present => only listed steps run
+# - HOMEBOY_SKIP present => listed steps are skipped
+# - empty step name => runs by default
+
+should_run_step() {
+    local step_name="${1:-}"
+    step_name="$(printf '%s' "$step_name" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+
+    if [ -z "$step_name" ]; then
+        return 0
+    fi
+
+    if [ -n "${HOMEBOY_STEP:-}" ]; then
+        case ",${HOMEBOY_STEP}," in
+            *",${step_name},"*) ;;
+            *) return 1 ;;
+        esac
+    fi
+
+    if [ -n "${HOMEBOY_SKIP:-}" ]; then
+        case ",${HOMEBOY_SKIP}," in
+            *",${step_name},"*) return 1 ;;
+        esac
+    fi
+
+    return 0
+}

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -26,17 +26,9 @@ fi
 # Supports summary mode via HOMEBOY_SUMMARY_MODE=1
 # Supports step filtering via HOMEBOY_STEP/HOMEBOY_SKIP (steps: phpcs, eslint, phpstan)
 
-# Step filtering helper (matches test-runner.sh pattern)
-should_run_step() {
-    local step_name="$1"
-    if [ -n "${HOMEBOY_STEP:-}" ]; then
-        echo ",${HOMEBOY_STEP}," | grep -q ",${step_name}," && return 0 || return 1
-    fi
-    if [ -n "${HOMEBOY_SKIP:-}" ]; then
-        echo ",${HOMEBOY_SKIP}," | grep -q ",${step_name}," && return 1 || return 0
-    fi
-    return 0
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/runner-steps.sh
+source "${SCRIPT_DIR}/../lib/runner-steps.sh"
 
 # Debug environment variables (only shown when HOMEBOY_DEBUG=1)
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -75,7 +67,6 @@ if [ -n "${HOMEBOY_EXTENSION_PATH:-}" ]; then
     COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-.}"
     PLUGIN_PATH="$COMPONENT_PATH"
 else
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     EXTENSION_PATH="$(dirname "$SCRIPT_DIR")"
     COMPONENT_PATH="$(pwd)"
     PLUGIN_PATH="$COMPONENT_PATH"

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -27,8 +27,9 @@ fi
 # Supports step filtering via HOMEBOY_STEP/HOMEBOY_SKIP (steps: phpcs, eslint, phpstan)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/../lib/runner-steps.sh}"
 # shellcheck source=../lib/runner-steps.sh
-source "${SCRIPT_DIR}/../lib/runner-steps.sh"
+source "${RUNNER_STEPS_HELPER}"
 
 # Debug environment variables (only shown when HOMEBOY_DEBUG=1)
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -5,19 +5,9 @@ FAILED_STEP=""
 FAILURE_OUTPUT=""
 FAILURE_REPLAY_MODE="full"
 
-# Step filtering: HOMEBOY_STEP=phpunit,lint runs only those steps.
-# HOMEBOY_SKIP=lint,phpstan skips those steps.
-# Step names: lint, phpcs, eslint, phpstan, autoload-check, phpunit
-should_run_step() {
-    local step_name="$1"
-    if [ -n "${HOMEBOY_STEP:-}" ]; then
-        echo ",${HOMEBOY_STEP}," | grep -q ",${step_name}," && return 0 || return 1
-    fi
-    if [ -n "${HOMEBOY_SKIP:-}" ]; then
-        echo ",${HOMEBOY_SKIP}," | grep -q ",${step_name}," && return 1 || return 0
-    fi
-    return 0
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/runner-steps.sh
+source "${SCRIPT_DIR}/../lib/runner-steps.sh"
 
 print_failure_summary() {
     if [ -n "$FAILED_STEP" ]; then
@@ -81,7 +71,6 @@ if [ -n "${HOMEBOY_EXTENSION_PATH:-}" ]; then
 else
     # Called directly (e.g., from composer test in component directory)
     # Derive paths and use defaults
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     EXTENSION_PATH="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
     # Assume we're in a component directory (composer test context)

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -6,8 +6,9 @@ FAILURE_OUTPUT=""
 FAILURE_REPLAY_MODE="full"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/../lib/runner-steps.sh}"
 # shellcheck source=../lib/runner-steps.sh
-source "${SCRIPT_DIR}/../lib/runner-steps.sh"
+source "${RUNNER_STEPS_HELPER}"
 
 print_failure_summary() {
     if [ -n "$FAILED_STEP" ]; then


### PR DESCRIPTION
## Summary
- switch Rust and WordPress runner scripts to prefer Homeboy core's `HOMEBOY_RUNTIME_RUNNER_STEPS` helper path
- keep a local helper fallback during rollout so older Homeboy binaries do not break installed extensions
- preserve the existing `HOMEBOY_STEP` / `HOMEBOY_SKIP` contract while reducing inline step-filter duplication

## Testing
- `bash -n rust/scripts/lint-runner.sh`
- `bash -n rust/scripts/test-runner.sh`
- `bash -n wordpress/scripts/lint/lint-runner.sh`
- `bash -n wordpress/scripts/test/test-runner.sh`
- `HOMEBOY_RUNTIME_RUNNER_STEPS=\"$(pwd)/rust/scripts/lib/runner-steps.sh\" HOMEBOY_STEP=lint bash -c 'source rust/scripts/lib/runner-steps.sh && should_run_step lint'`
- `HOMEBOY_RUNTIME_RUNNER_STEPS=\"$(pwd)/wordpress/scripts/lib/runner-steps.sh\" HOMEBOY_SKIP=phpstan bash -c 'source wordpress/scripts/lib/runner-steps.sh && ! should_run_step phpstan'`

## Depends on
- Homeboy core helper PR: https://github.com/Extra-Chill/homeboy/pull/517