### PR TITLE
feat(wordpress): support generic npm build scripts

### DIFF
--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -257,7 +257,7 @@ install_frontend_dependencies() {
     fi
 }
 
-# Build frontend assets (Gutenberg blocks via @wordpress/scripts, or Vite)
+# Build frontend assets (Gutenberg blocks via @wordpress/scripts, Vite, or generic npm build)
 build_frontend_assets() {
     print_status "Checking for frontend build requirements..."
 
@@ -275,8 +275,11 @@ build_frontend_assets() {
     elif grep -q '"vite"' "package.json"; then
         build_tool="vite"
         print_status "Detected Vite build tool"
+    elif node -e "const p=require('./package.json'); process.exit(p.scripts && p.scripts.build ? 0 : 1)" 2>/dev/null; then
+        build_tool="npm"
+        print_status "Detected npm build script"
     else
-        print_status "No recognized build tool found, skipping frontend build"
+        print_status "No build script found, skipping frontend build"
         return 0
     fi
 


### PR DESCRIPTION
## Summary

- `build_frontend_assets()` now triggers for projects with a `"build"` script in `package.json`, even without `@wordpress/scripts` or `vite`
- Enables the theme to generate `root.css` from `@extrachill/tokens` during `homeboy build` without pulling in unnecessary build tool dependencies
- Consistent with how `build_nested_packages()` already handles nested `package.json` files (it checks for `"build"` script, not specific tools)

## Context

The Extra Chill theme needs a build step that runs `npm install` (to get `@extrachill/tokens`) then `npm run build` (to generate CSS from the token package). Previously this was impossible without adding `@wordpress/scripts` or `vite` as a dummy dependency just to pass the detection gate.