### PR TITLE
fix(lint): expand yoda and short-ternary fixers to cover real-world patterns

### DIFF
--- a/wordpress/scripts/lint/php-fixers/short-ternary-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/short-ternary-fixer.php
@@ -3,8 +3,11 @@
 /**
  * Short Ternary Fixer
  *
- * Expands short ternary operators `$var ?: $default` to `$var ? $var : $default`.
- * Only handles simple variable cases to avoid double evaluation issues with function calls.
+ * Expands short ternary operators `expr ?: $default` to `expr ? expr : $default`.
+ * Handles variables, array access, property access, method calls, and function calls.
+ *
+ * Note: For function/method call expressions, the expansion results in double evaluation.
+ * This is accepted as the standard WordPress/WPCS pattern for removing short ternaries.
  *
  * WordPress/Universal coding standards disallow short ternary operators.
  *
@@ -36,7 +39,10 @@ if ($result['total_fixes'] > 0) {
 exit(0);
 
 /**
- * Process a single PHP file.
+ * Process a single PHP file using regex-based ?:-detection + token-based expansion.
+ *
+ * Strategy: find ?: positions via simple string scan, then use token analysis
+ * to extract the left-side expression and expand it.
  */
 function process_file($filepath) {
     $content = file_get_contents($filepath);
@@ -54,17 +60,29 @@ function process_file($filepath) {
     $i = 0;
     $count = count($tokens);
 
+    // Track expression start candidates as we walk forward.
+    // When we see ?: we look back to find the start of the expression.
     while ($i < $count) {
         $token = $tokens[$i];
 
-        // Look for simple expression followed by ?:
-        if (is_simple_left_side($token)) {
-            $result = try_fix_short_ternary($tokens, $i, $count);
-            if ($result !== null) {
-                $new_content .= $result['replacement'];
-                $i = $result['end_index'] + 1;
-                $fixes++;
-                continue;
+        // Detect ?: pattern: '?' followed by ':' (with optional whitespace)
+        if ($token === '?') {
+            $peek = $i + 1;
+            $ws_between = '';
+            while ($peek < $count && is_whitespace($tokens[$peek])) {
+                $ws_between .= $tokens[$peek][1];
+                $peek++;
+            }
+
+            if ($peek < $count && $tokens[$peek] === ':') {
+                // Found ?: — try to extract the left expression from new_content
+                $result = expand_short_ternary($new_content, $tokens, $peek, $count);
+                if ($result !== null) {
+                    $new_content = $result['new_content'];
+                    $i = $result['resume_index'];
+                    $fixes++;
+                    continue;
+                }
             }
         }
 
@@ -80,117 +98,266 @@ function process_file($filepath) {
 }
 
 /**
- * Check if token starts a simple left side (variable or array access).
- */
-function is_simple_left_side($token) {
-    return is_array($token) && $token[0] === T_VARIABLE;
-}
-
-/**
- * Try to fix a short ternary expression.
+ * Expand a short ternary by extracting the left expression from already-emitted content.
  *
- * Handles: $var ?: $default
- * Becomes: $var ? $var : $default
- *
- * Also handles: $arr['key'] ?: $default
+ * @param string $emitted   Content emitted so far (will be modified to include expansion).
+ * @param array  $tokens    Token array.
+ * @param int    $colon_idx Index of the ':' token in the ?: pattern.
+ * @param int    $count     Total token count.
+ * @return array|null ['new_content' => string, 'resume_index' => int] or null.
  */
-function try_fix_short_ternary($tokens, $i, $count) {
-    $j = $i;
-
-    // Capture the left side (variable + optional array access)
-    $left_side = '';
-    $left_side .= $tokens[$j][1];
-    $j++;
-
-    // Handle array access
-    while ($j < $count) {
-        // Skip whitespace
-        $ws = '';
-        while ($j < $count && is_whitespace($tokens[$j])) {
-            $ws .= $tokens[$j][1];
-            $j++;
-        }
-
-        if ($j >= $count) {
-            break;
-        }
-
-        // Check for array access
-        if ($tokens[$j] === '[') {
-            $left_side .= $ws;
-            $bracket = capture_brackets($tokens, $j, $count);
-            if ($bracket === null) {
-                return null;
-            }
-            $left_side .= $bracket['content'];
-            $j = $bracket['end_index'] + 1;
-            continue;
-        }
-
-        // Check for method call or property access - skip (side effects)
-        if (is_array($tokens[$j]) && in_array($tokens[$j][0], [T_OBJECT_OPERATOR, T_NULLSAFE_OBJECT_OPERATOR], true)) {
-            return null;
-        }
-
-        // Check for function call - skip (side effects)
-        if ($tokens[$j] === '(') {
-            return null;
-        }
-
-        break;
-    }
-
-    // Skip whitespace before ?:
-    $ws_before_op = '';
-    while ($j < $count && is_whitespace($tokens[$j])) {
-        $ws_before_op .= $tokens[$j][1];
-        $j++;
-    }
-
-    if ($j >= $count) {
+function expand_short_ternary($emitted, $tokens, $colon_idx, $count) {
+    // Extract the left-side expression from already-emitted content.
+    // We need to find where the expression starts by walking backward through $emitted.
+    $expr = extract_trailing_expression($emitted);
+    if ($expr === null || $expr['expression'] === '') {
         return null;
     }
 
-    // Check for ? (first part of ?:)
-    if ($tokens[$j] !== '?') {
-        return null;
-    }
-    $j++;
+    $left_expr = $expr['expression'];
+    $prefix = $expr['prefix'];
 
-    // Check for : immediately after ? (this is the short ternary pattern)
-    // There might be whitespace between ? and :
-    $ws_between = '';
-    while ($j < $count && is_whitespace($tokens[$j])) {
-        $ws_between .= $tokens[$j][1];
-        $j++;
-    }
-
-    if ($j >= $count || $tokens[$j] !== ':') {
-        return null;
-    }
-    $j++;
-
-    // This is a short ternary! Expand it.
-    // $left ?: becomes $left ? $left :
-
-    // Capture whitespace after :
+    // Skip whitespace after ':'
+    $j = $colon_idx + 1;
     $ws_after_colon = '';
     while ($j < $count && is_whitespace($tokens[$j])) {
         $ws_after_colon .= $tokens[$j][1];
         $j++;
     }
 
-    // The rest is the default value - we don't need to capture it
-    // We just need to output up to and including the colon
+    // Capture trailing whitespace before ?: (already in emitted, strip it from left_expr)
+    $left_trimmed = rtrim($left_expr);
+    $ws_before_qmark = substr($left_expr, strlen($left_trimmed));
+    $left_expr = $left_trimmed;
 
-    // Build replacement: left_side ? left_side :
-    $replacement = $left_side . $ws_before_op . '? ' . $left_side . ' :' . $ws_after_colon;
+    if ($ws_before_qmark === '') {
+        $ws_before_qmark = ' ';
+    }
 
-    // end_index should be just before the default value
+    // Build expanded ternary: prefix + left_expr + ? left_expr : + rest
+    $expanded = $prefix . $left_expr . $ws_before_qmark . '? ' . $left_expr . ' :' . $ws_after_colon;
+
     return [
-        'replacement' => $replacement,
-        'end_index' => $j - 1,
+        'new_content' => $expanded,
+        'resume_index' => $j,
     ];
+}
+
+/**
+ * Extract trailing expression from emitted content string.
+ *
+ * Walks backward through the string to find a complete PHP expression.
+ * Handles: variables, array access, property chains, method calls, function calls,
+ * and chained combinations of all.
+ *
+ * @param string $emitted The content emitted so far.
+ * @return array|null ['prefix' => string, 'expression' => string] or null.
+ */
+function extract_trailing_expression($emitted) {
+    $len = strlen($emitted);
+    if ($len === 0) {
+        return null;
+    }
+
+    // Find the end of the expression (skip trailing whitespace)
+    $end = $len - 1;
+    while ($end >= 0 && ($emitted[$end] === ' ' || $emitted[$end] === "\t")) {
+        $end--;
+    }
+
+    if ($end < 0) {
+        return null;
+    }
+
+    $trailing_ws = substr($emitted, $end + 1);
+    $pos = $end;
+
+    // Walk backward to capture the expression
+    $pos = walk_back_expression($emitted, $pos);
+
+    if ($pos === null || $pos === $end) {
+        return null;
+    }
+
+    $expr_start = $pos + 1;
+    $expression = substr($emitted, $expr_start, $end - $expr_start + 1) . $trailing_ws;
+    $prefix = substr($emitted, 0, $expr_start);
+
+    // Validate: expression must start with $ or a function/class name
+    $trimmed = ltrim($expression);
+    if ($trimmed === '' || (!preg_match('/^[\$a-zA-Z_\\\\]/', $trimmed))) {
+        return null;
+    }
+
+    return [
+        'prefix' => $prefix,
+        'expression' => $expression,
+    ];
+}
+
+/**
+ * Walk backward through a string to find the start of a PHP expression.
+ *
+ * @param string $str The string to walk through.
+ * @param int    $pos Current position (at end of expression).
+ * @return int|null Position just before the expression starts, or null on failure.
+ */
+function walk_back_expression($str, $pos) {
+    if ($pos < 0) {
+        return null;
+    }
+
+    $original_pos = $pos;
+
+    // Handle closing paren — balanced walk back for function call args
+    if ($str[$pos] === ')') {
+        $pos = find_matching_open($str, $pos, '(', ')');
+        if ($pos === null) {
+            return null;
+        }
+        $pos--; // Move before the '('
+
+        // Skip whitespace before '('
+        while ($pos >= 0 && ($str[$pos] === ' ' || $str[$pos] === "\t")) {
+            $pos--;
+        }
+
+        if ($pos < 0) {
+            return null;
+        }
+
+        // The thing before '(' should be a function/method name or closing bracket/paren
+        // Recurse to capture it
+        return walk_back_expression($str, $pos);
+    }
+
+    // Handle closing bracket — array access
+    if ($str[$pos] === ']') {
+        $pos = find_matching_open($str, $pos, '[', ']');
+        if ($pos === null) {
+            return null;
+        }
+        $pos--; // Move before the '['
+
+        // Skip whitespace before '['
+        while ($pos >= 0 && ($str[$pos] === ' ' || $str[$pos] === "\t")) {
+            $pos--;
+        }
+
+        if ($pos < 0) {
+            return $pos;
+        }
+
+        // Recurse to capture what's before the bracket
+        return walk_back_expression($str, $pos);
+    }
+
+    // Handle identifier (variable name, function name, property name, class name)
+    if (preg_match('/[a-zA-Z0-9_]/', $str[$pos])) {
+        while ($pos >= 0 && preg_match('/[a-zA-Z0-9_]/', $str[$pos])) {
+            $pos--;
+        }
+
+        // Check for $ prefix (variable)
+        if ($pos >= 0 && $str[$pos] === '$') {
+            $pos--;
+
+            // Check for -> or ?-> before $this or other var (shouldn't happen, but guard)
+            $check = $pos;
+            while ($check >= 0 && ($str[$check] === ' ' || $str[$check] === "\t")) {
+                $check--;
+            }
+
+            // Check for -> or ?->
+            if ($check >= 1 && $str[$check - 1] === '-' && $str[$check] === '>') {
+                $pos = $check - 2;
+                while ($pos >= 0 && ($str[$pos] === ' ' || $str[$pos] === "\t")) {
+                    $pos--;
+                }
+                return walk_back_expression($str, $pos);
+            }
+
+            // Check for ?->
+            if ($check >= 2 && $str[$check - 2] === '?' && $str[$check - 1] === '-' && $str[$check] === '>') {
+                $pos = $check - 3;
+                while ($pos >= 0 && ($str[$pos] === ' ' || $str[$pos] === "\t")) {
+                    $pos--;
+                }
+                return walk_back_expression($str, $pos);
+            }
+
+            return $pos;
+        }
+
+        // Non-variable identifier: function name, property name, class name, constant
+        // Check what precedes it
+
+        $check = $pos;
+        while ($check >= 0 && ($str[$check] === ' ' || $str[$check] === "\t")) {
+            $check--;
+        }
+
+        // Check for -> (property/method access)
+        if ($check >= 1 && $str[$check - 1] === '-' && $str[$check] === '>') {
+            $pos = $check - 2;
+            while ($pos >= 0 && ($str[$pos] === ' ' || $str[$pos] === "\t")) {
+                $pos--;
+            }
+            return walk_back_expression($str, $pos);
+        }
+
+        // Check for ?-> (nullsafe operator)
+        if ($check >= 2 && $str[$check - 2] === '?' && $str[$check - 1] === '-' && $str[$check] === '>') {
+            $pos = $check - 3;
+            while ($pos >= 0 && ($str[$pos] === ' ' || $str[$pos] === "\t")) {
+                $pos--;
+            }
+            return walk_back_expression($str, $pos);
+        }
+
+        // Check for :: (static access)
+        if ($check >= 1 && $str[$check - 1] === ':' && $str[$check] === ':') {
+            $pos = $check - 2;
+            // Capture the class name before ::
+            while ($pos >= 0 && preg_match('/[a-zA-Z0-9_\\\\]/', $str[$pos])) {
+                $pos--;
+            }
+            return $pos;
+        }
+
+        // Standalone function name or keyword — this is the start of the expression
+        return $pos;
+    }
+
+    // Nothing we recognize
+    return null;
+}
+
+/**
+ * Find matching opening bracket/paren by walking backward.
+ *
+ * @param string $str   The string.
+ * @param int    $pos   Position of closing bracket.
+ * @param string $open  Opening character.
+ * @param string $close Closing character.
+ * @return int|null Position of matching opening bracket, or null.
+ */
+function find_matching_open($str, $pos, $open, $close) {
+    $depth = 1;
+    $pos--;
+
+    while ($pos >= 0 && $depth > 0) {
+        if ($str[$pos] === $close) {
+            $depth++;
+        } elseif ($str[$pos] === $open) {
+            $depth--;
+        }
+        if ($depth > 0) {
+            $pos--;
+        }
+    }
+
+    return $depth === 0 ? $pos : null;
 }
 
 /**
@@ -198,39 +365,6 @@ function try_fix_short_ternary($tokens, $i, $count) {
  */
 function is_whitespace($token) {
     return is_array($token) && $token[0] === T_WHITESPACE;
-}
-
-/**
- * Capture bracket content.
- */
-function capture_brackets($tokens, $start, $count) {
-    if ($tokens[$start] !== '[') {
-        return null;
-    }
-
-    $content = '[';
-    $depth = 1;
-    $j = $start + 1;
-
-    while ($j < $count && $depth > 0) {
-        $token = $tokens[$j];
-        if ($token === '[') {
-            $depth++;
-        } elseif ($token === ']') {
-            $depth--;
-        }
-        $content .= token_to_string($token);
-        $j++;
-    }
-
-    if ($depth !== 0) {
-        return null;
-    }
-
-    return [
-        'content' => $content,
-        'end_index' => $j - 1,
-    ];
 }
 
 /**

--- a/wordpress/scripts/lint/php-fixers/yoda-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/yoda-fixer.php
@@ -184,6 +184,10 @@ function is_preceded_by_double_colon($tokens, $index) {
  * - $var === 'literal'
  * - $arr['key'] === 'literal'
  * - $arr['key']['nested'] === 'literal'
+ * - $this->property === 'literal'
+ * - $obj->prop->sub === 'literal'
+ * - $var === self::CONSTANT
+ * - $this->prop === static::CONSTANT
  *
  * @param array $tokens Token array.
  * @param int   $i      Current index (at variable token).
@@ -193,27 +197,32 @@ function is_preceded_by_double_colon($tokens, $index) {
 function try_fix_yoda($tokens, $i, $count) {
     $j = $i;
 
-    // Capture the left side expression (variable + optional array access)
+    // Capture the left side expression (variable + optional array/property access)
     $left_side = '';
     $left_side .= $tokens[$j][1]; // The variable
     $j++;
 
-    // Check for array access: $var['key'] or $var['key']['nested']
+    // Check for array access and property access chains:
+    // $var['key'], $var['key']['nested'], $this->prop, $obj->prop->sub,
+    // $arr['key']->prop, etc.
     while ($j < $count) {
-        // Skip inline whitespace between variable and bracket
-        $ws_before_bracket = '';
+        // Peek ahead for whitespace without consuming
+        $ws_start = $j;
+        $ws_before = '';
         while ($j < $count && is_inline_whitespace($tokens[$j])) {
-            $ws_before_bracket .= $tokens[$j][1];
+            $ws_before .= $tokens[$j][1];
             $j++;
         }
 
         if ($j >= $count) {
+            // Restore position — whitespace belongs to the caller
+            $j = $ws_start;
             break;
         }
 
         // Check for array access
         if ($tokens[$j] === '[') {
-            $left_side .= $ws_before_bracket;
+            $left_side .= $ws_before;
             $bracket_content = capture_bracket_content($tokens, $j, $count);
             if ($bracket_content === null) {
                 return null; // Malformed bracket
@@ -223,12 +232,46 @@ function try_fix_yoda($tokens, $i, $count) {
             continue;
         }
 
-        // Check for object operator - skip these (too complex)
+        // Check for property access (-> or ?->)
         if (is_array($tokens[$j]) && in_array($tokens[$j][0], [T_OBJECT_OPERATOR, T_NULLSAFE_OBJECT_OPERATOR], true)) {
+            $left_side .= $ws_before;
+            $left_side .= $tokens[$j][1]; // -> or ?->
+            $j++;
+
+            // Skip whitespace after operator
+            while ($j < $count && is_inline_whitespace($tokens[$j])) {
+                $left_side .= $tokens[$j][1];
+                $j++;
+            }
+
+            if ($j >= $count) {
+                return null;
+            }
+
+            // Expect property name (T_STRING) or variable (T_VARIABLE for dynamic)
+            if (is_array($tokens[$j]) && in_array($tokens[$j][0], [T_STRING, T_VARIABLE], true)) {
+                $left_side .= $tokens[$j][1];
+                $j++;
+
+                // Skip method calls — too complex / side effects
+                $peek = $j;
+                while ($peek < $count && is_inline_whitespace($tokens[$peek])) {
+                    $peek++;
+                }
+                if ($peek < $count && $tokens[$peek] === '(') {
+                    return null;
+                }
+
+                continue;
+            }
+
+            // Unexpected token after ->
             return null;
         }
 
-        // Not array access, restore position and break
+        // Not array access or property access — restore position so caller
+        // captures the whitespace as ws_after_left
+        $j = $ws_start;
         break;
     }
 
@@ -261,11 +304,13 @@ function try_fix_yoda($tokens, $i, $count) {
         return null;
     }
 
-    // Check for simple literal on right side
-    if (!is_simple_literal($tokens[$j])) {
+    // Try to capture the right side: simple literal OR class constant
+    $right_side = try_capture_right_side($tokens, $j, $count);
+    if ($right_side === null) {
         return null;
     }
-    $literal_str = $tokens[$j][1];
+    $literal_str = $right_side['content'];
+    $j = $right_side['end_index'];
 
     // Check next token to ensure we're not in a complex expression
     $k = $j + 1;
@@ -292,6 +337,90 @@ function try_fix_yoda($tokens, $i, $count) {
         'replacement' => $replacement,
         'end_index' => $j,
     ];
+}
+
+/**
+ * Try to capture the right side of a comparison.
+ *
+ * Supports:
+ * - Simple literals: 'string', 123, true, false, null
+ * - Class constants: self::CONST, static::CONST, ClassName::CONST
+ *
+ * @param array $tokens Token array.
+ * @param int   $j      Current index.
+ * @param int   $count  Total token count.
+ * @return array|null ['content' => string, 'end_index' => int] or null.
+ */
+function try_capture_right_side($tokens, $j, $count) {
+    // Try simple literal first
+    if (is_simple_literal($tokens[$j])) {
+        return [
+            'content' => $tokens[$j][1],
+            'end_index' => $j,
+        ];
+    }
+
+    // Try class constant: self::X, static::X, parent::X, ClassName::X
+    if (is_array($tokens[$j]) && is_class_reference($tokens[$j])) {
+        $content = $tokens[$j][1];
+        $k = $j + 1;
+
+        // Expect ::
+        if ($k < $count && is_array($tokens[$k]) && $tokens[$k][0] === T_DOUBLE_COLON) {
+            $content .= $tokens[$k][1];
+            $k++;
+
+            // Expect constant name (T_STRING) — NOT a variable (self::$var is a property)
+            if ($k < $count && is_array($tokens[$k]) && $tokens[$k][0] === T_STRING) {
+                $content .= $tokens[$k][1];
+
+                // Make sure it's not followed by ( which would be a method call
+                $peek = $k + 1;
+                while ($peek < $count && is_inline_whitespace($tokens[$peek])) {
+                    $peek++;
+                }
+                if ($peek < $count && $tokens[$peek] === '(') {
+                    return null; // self::method() — not a constant
+                }
+
+                return [
+                    'content' => $content,
+                    'end_index' => $k,
+                ];
+            }
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Check if token is a class reference (self, static, parent, or a class name).
+ */
+function is_class_reference($token) {
+    if (!is_array($token)) {
+        return false;
+    }
+
+    // self, parent, static
+    if (in_array($token[0], [T_STRING, T_STATIC], true)) {
+        $lower = strtolower($token[1]);
+        if (in_array($lower, ['self', 'static', 'parent'], true)) {
+            return true;
+        }
+    }
+
+    // ClassName (T_STRING that starts with uppercase)
+    if ($token[0] === T_STRING && preg_match('/^[A-Z]/', $token[1])) {
+        return true;
+    }
+
+    // PHP 8+ fully qualified names
+    if (defined('T_NAME_FULLY_QUALIFIED') && in_array($token[0], [T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED], true)) {
+        return true;
+    }
+
+    return false;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Yoda fixer**: now handles property access chains (`$this->prop === self::CONST`), mixed array+property chains (`$arr['key']->DATA_TYPE === 'bigint'`), and class constants as right-side values. Previously only handled simple `$var === 'literal'`.
- **Short ternary fixer**: rewritten with backward expression extraction to handle function calls (`get_bloginfo('name') ?: 'default'`), method chains, and chained calls. Previously only handled simple `$var ?: default`.

## Problem
Running `homeboy lint --fix` on data-machine reported "No fixable expressions found" for both fixers, despite PHPCS flagging 17 YodaConditions and 13 DisallowShortTernary violations. All violations involved patterns the fixers didn't support.

## Testing
- Tested against data-machine codebase: all 17 Yoda + 13 short ternary violations now auto-fixed
- PHPCS verification: zero violations remain for both sniffs after running fixers
- Yoda: correct whitespace preservation, method calls still skipped (side effects)
- Short ternary: correct expression boundary detection for all patterns (variables, function calls, method chains, array access)