### PR TITLE
fix(rust): skip unused parameter detection for trait method declarations

### DIFF
--- a/rust/scripts/fingerprint.sh
+++ b/rust/scripts/fingerprint.sh
@@ -455,11 +455,15 @@ for fn in functions:
                 param_names.append(pname)
     if not param_names:
         continue
-    # Check if params appear in the body (excluding the signature)
+    # Check if params appear in the body (excluding the signature).
+    # Skip trait declarations (no body — line ends with ;, not {}).
     if fn.body_lines:
         full_body = '\n'.join(fn.body_lines)
         brace_pos = full_body.find('{')
-        body_only = full_body[brace_pos + 1:] if brace_pos >= 0 else full_body
+        if brace_pos < 0:
+            # No body (trait method declaration) — can't determine usage
+            continue
+        body_only = full_body[brace_pos + 1:]
         for pname in param_names:
             if pname.startswith('_'):
                 continue


### PR DESCRIPTION
## Summary

- Trait method declarations (no body, end with `;`) were falsely reported as having unused parameters
- Fix: check for opening brace `{` before analyzing parameter usage — skip declarations without bodies
- Eliminates 3 remaining `unused_parameter` false positives

Companion to #105 which fixed 62 false positives from type path segments.
Combined: **66 → 0 unused_parameter false positives**.