### PR TITLE
fix(rust): normalize test method names in fingerprint + skip_test_patterns

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -45,7 +45,8 @@
       "test_file_pattern": "tests/{dir}/{name}_test.{ext}",
       "method_prefix": "test_",
       "inline_tests": true,
-      "critical_patterns": ["core/", "commands/"]
+      "critical_patterns": ["core/"],
+      "skip_test_patterns": ["commands/"]
     },
     "doc_targets": {
       "Subcommands": {

--- a/rust/scripts/fingerprint.sh
+++ b/rust/scripts/fingerprint.sh
@@ -247,14 +247,19 @@ for fn in functions:
 
 # --- Test Methods ---
 # Functions inside #[cfg(test)] or with #[test] attribute.
-# Included in the methods list with their test_ prefix so test_coverage
-# can see them.
+# Included in the methods list with the test_ prefix so test_coverage
+# can identify them. Functions that already start with test_ keep their
+# name; others get prefixed (e.g. 'dedup_works' -> 'test_dedup_works').
 test_methods = []
 for fn in functions:
-    if fn.is_test and fn.name not in seen:
-        methods.append(fn.name)
-        seen.add(fn.name)
-        test_methods.append(fn.name)
+    if fn.is_test:
+        # Normalize: ensure test methods always carry the test_ prefix
+        # so test_coverage.rs can distinguish them from source methods.
+        prefixed = fn.name if fn.name.startswith('test_') else f'test_{fn.name}'
+        if prefixed not in seen:
+            methods.append(prefixed)
+            seen.add(prefixed)
+            test_methods.append(prefixed)
 
 # --- Type name ---
 # Primary struct or enum in the file (first pub struct/enum, or first struct/enum)


### PR DESCRIPTION
## Summary
- Fixes Rust fingerprint script to normalize test method names: functions inside `#[cfg(test)]` that don't start with `test_` now get the prefix added (e.g. `dedup_works` → `test_dedup_works`)
- Adds `skip_test_patterns` to test mapping config: `commands/` moved from `critical_patterns` to `skip_test_patterns` since command modules use integration tests, not unit test companions

## Why
The fingerprint script was adding raw function names from `#[cfg(test)]` modules to the methods list. `test_coverage.rs` then treated names like `dedup_works` as source methods needing test coverage, generating false `missing_test_method` findings. With the prefix normalization, test_coverage correctly identifies them as test methods.

The `commands/` skip pattern prevents audit from generating `missing_test_file` and `missing_test_method` findings for command modules that are covered by integration tests rather than per-file unit test companions.

## Companion PR
- homeboy: audit precision improvements (visibility filtering, trivial method expansion, skip_test_patterns support) — will be PRed separately