### PR TITLE
fix: run reserved-param-fixer on full plugin path for cross-file safety

### DIFF
--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -250,10 +250,7 @@ if [[ "${HOMEBOY_AUTO_FIX:-}" == "1" ]]; then
             php "$LOOP_COUNT_FIXER" "$lint_target"
         fi
 
-        # Run reserved keyword parameter name fixer ($default -> $default_value, etc.)
-        if [ -f "$RESERVED_PARAM_FIXER" ]; then
-            php "$RESERVED_PARAM_FIXER" "$lint_target"
-        fi
+        # Reserved param fixer runs OUTSIDE this loop (needs cross-file manifest)
 
         # Run unused parameter fixer (noop references for callbacks, removal for dead params)
         # This fixer runs PHPCS internally so needs the binary and standard paths
@@ -292,6 +289,15 @@ if [[ "${HOMEBOY_AUTO_FIX:-}" == "1" ]]; then
             php "$WP_FILESYSTEM_FIXER" "$lint_target"
         fi
     done
+
+    # Run reserved keyword parameter name fixer ($default -> $default_value, etc.)
+    # MUST run on full plugin path (not per-file) because its two-pass architecture
+    # builds a rename manifest in Pass 1 (declarations) and applies it to call sites
+    # in Pass 2 (named arguments). Per-file invocation loses the manifest between
+    # processes, leaving call sites with stale parameter names.
+    if [ -f "$RESERVED_PARAM_FIXER" ]; then
+        php "$RESERVED_PARAM_FIXER" "$PLUGIN_PATH"
+    fi
 
     # Run phpcbf for remaining auto-fixable issues
     if [ -f "$PHPCBF_BIN" ]; then


### PR DESCRIPTION
## Summary
- Moves reserved-param-fixer outside the per-file lint loop to always run on `$PLUGIN_PATH`
- Fixes the root cause of data-machine #672 (fatal bootstrap crash from stale named argument `class:` after `$class` → `$class_name` rename)

## Root Cause
The two-pass architecture builds a rename manifest in Pass 1 (declarations) and uses it in Pass 2 (call sites). When `lint-runner.sh` invokes fixers per-file (`HOMEBOY_LINT_GLOB` mode), each file gets its own PHP process — the manifest dies between files, so Pass 2 never sees the call sites in other files.

## Fix
Run the reserved-param-fixer on `$PLUGIN_PATH` (full codebase) instead of `$lint_target` (individual file). This ensures both passes see all declarations and call sites in a single process.

## Testing
- Reproduced the bug with separate trait + caller files in per-file mode (caller NOT fixed)
- Verified the fix with directory mode (both files fixed correctly)
- Verified idempotency (second run reports "No fixable parameters found")
- Verified no regressions against data-machine codebase