### PR TITLE
fix(test): smart PHPUnit exit code handling when all tests pass

### DIFF
--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -350,6 +350,9 @@ elif [ "$DATABASE_TYPE" = "mysql" ]; then
         "$MYSQL_HOST" "$MYSQL_DATABASE" "$MYSQL_USER" "$MYSQL_PASSWORD"
 fi
 
+# Track whether lint reported issues (separate from test outcome)
+LINT_HAD_ISSUES=0
+
 # Run linting using external lint-runner.sh with summary mode
 run_lint() {
     local lint_runner="${EXTENSION_PATH}/scripts/lint/lint-runner.sh"
@@ -358,8 +361,15 @@ run_lint() {
         return 0
     fi
 
-    # Run linting in summary mode (lint-runner.sh always exits 0 - warn-only mode)
-    HOMEBOY_SUMMARY_MODE=1 HOMEBOY_AUTO_FIX="${HOMEBOY_AUTO_FIX:-}" bash "$lint_runner"
+    # Capture lint output to detect issues (lint-runner.sh always exits 0 in summary mode)
+    local lint_output
+    lint_output=$(HOMEBOY_SUMMARY_MODE=1 HOMEBOY_AUTO_FIX="${HOMEBOY_AUTO_FIX:-}" bash "$lint_runner" 2>&1)
+    echo "$lint_output"
+
+    # Detect if lint reported issues
+    if echo "$lint_output" | grep -q "linting failed\|Linting found issues"; then
+        LINT_HAD_ISSUES=1
+    fi
     echo ""
 }
 
@@ -579,16 +589,39 @@ if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] && [ -f "$PARSE_FAILURES" ]; then
 fi
 
 if [ $phpunit_exit -ne 0 ]; then
-    FAILED_STEP="PHPUnit tests"
-    FAILURE_REPLAY_MODE="none"
-    rm -f "$PHPUNIT_TMPFILE"
-    # Clean up auto-created test database
-    if [ "${MYSQL_AUTO_CREATED:-}" = "1" ]; then
-        _mysql_cleanup=(-h "$MYSQL_HOST" -u "$MYSQL_USER")
-        [ -n "${MYSQL_PASSWORD:-}" ] && _mysql_cleanup+=(-p"$MYSQL_PASSWORD")
-        mysql "${_mysql_cleanup[@]}" -e "DROP DATABASE IF EXISTS \`${MYSQL_DATABASE}\`" 2>/dev/null || true
+    # Check parsed test results to determine if this is a real test failure
+    # or if PHPUnit exited non-zero for other reasons (deprecation notices,
+    # warnings, risky tests). If test_counts show 0 failures, the exit code
+    # is misleading — tests actually passed.
+    ACTUAL_TEST_FAILURES=0
+    if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "${HOMEBOY_TEST_RESULTS_FILE}" ]; then
+        ACTUAL_TEST_FAILURES=$(jq -r '.failed // 0' "${HOMEBOY_TEST_RESULTS_FILE}" 2>/dev/null || echo "0")
     fi
-    exit $phpunit_exit
+
+    if [ "$ACTUAL_TEST_FAILURES" -eq 0 ] 2>/dev/null; then
+        # PHPUnit exited non-zero but no test failures detected.
+        # This happens with deprecation notices, risky tests, or
+        # when lint failures pollute the exit code.
+        echo ""
+        echo "============================================"
+        echo "NOTE: PHPUnit exited with code $phpunit_exit but all tests passed"
+        echo "============================================"
+        echo "PHPUnit may have reported deprecation notices or warnings."
+        echo "Treating as passed (0 test failures detected)."
+        echo ""
+        # Don't set FAILED_STEP — let the script continue to coverage/cleanup
+    else
+        FAILED_STEP="PHPUnit tests"
+        FAILURE_REPLAY_MODE="none"
+        rm -f "$PHPUNIT_TMPFILE"
+        # Clean up auto-created test database
+        if [ "${MYSQL_AUTO_CREATED:-}" = "1" ]; then
+            _mysql_cleanup=(-h "$MYSQL_HOST" -u "$MYSQL_USER")
+            [ -n "${MYSQL_PASSWORD:-}" ] && _mysql_cleanup+=(-p"$MYSQL_PASSWORD")
+            mysql "${_mysql_cleanup[@]}" -e "DROP DATABASE IF EXISTS \`${MYSQL_DATABASE}\`" 2>/dev/null || true
+        fi
+        exit $phpunit_exit
+    fi
 fi
 
 # Detect zero-test runs — PHPUnit exits 0 but ran no tests.


### PR DESCRIPTION
## Summary

- When PHPUnit exits non-zero but parsed results show 0 test failures, no longer exits early with `BUILD FAILED: PHPUnit tests`
- Prints a note explaining PHPUnit exited non-zero but all tests passed (deprecation notices, warnings)
- Tracks lint issues separately via `LINT_HAD_ISSUES` flag for future lint/test status separation
- Captures lint output to detect "linting failed" / "Linting found issues" messages

## Companion PR

Core-side fix in Extra-Chill/homeboy#594 — determines test status from parsed `test_counts` instead of raw script exit code.

Fixes Extra-Chill/homeboy#592