### PR TITLE
feat: emit type_names in fingerprint output

### DIFF
--- a/rust/scripts/fingerprint.sh
+++ b/rust/scripts/fingerprint.sh
@@ -510,6 +510,7 @@ for line_num, line in enumerate(lines, 1):
 result = {
     'methods': methods,
     'type_name': type_name,
+    'type_names': pub_types,
     'extends': extends,
     'implements': implements,
     'registrations': registrations,

--- a/wordpress/scripts/fingerprint.sh
+++ b/wordpress/scripts/fingerprint.sh
@@ -59,6 +59,7 @@ methods = [m for m in methods if m not in seen and not seen.add(m)]
 # from interface convention expectations (#115).
 type_name = None
 type_kind = None
+type_names = []
 for kind, pattern in [
     ('class', r'^(?:abstract\s+|final\s+)?class\s+(\w+)'),
     ('interface', r'^interface\s+(\w+)'),
@@ -69,6 +70,14 @@ for kind, pattern in [
         type_name = match.group(1)
         type_kind = kind
         break
+
+# Collect all class/interface/trait names in the file
+for pattern in [
+    r'^(?:abstract\s+|final\s+)?class\s+(\w+)',
+    r'^interface\s+(\w+)',
+    r'^trait\s+(\w+)',
+]:
+    type_names.extend(m.group(1) for m in re.finditer(pattern, content, re.MULTILINE))
 
 # --- Extends ---
 # Extract the parent class separately (anchored to actual declaration)
@@ -474,6 +483,7 @@ for line_num, line in enumerate(lines_arr, 1):
 result = {
     'methods': methods,
     'type_name': type_name,
+    'type_names': type_names,
     'type_kind': type_kind,
     'extends': extends,
     'implements': implements,


### PR DESCRIPTION
## Summary

Companion to Extra-Chill/homeboy PR (naming mismatch false positives fix, #554).

Adds `type_names` field to fingerprint JSON output in both Rust and WordPress extension scripts. This provides **all** public type names found in a file, so the convention checker can determine if any type matches the naming convention — not just the first one.

## Changes

**Rust** (`rust/scripts/fingerprint.sh`):
- Emits `type_names: pub_types` (already extracted as `pub_types` on line 267)

**WordPress** (`wordpress/scripts/fingerprint.sh`):
- Collects all class/interface/trait names via `re.finditer`
- Emits `type_names` in output JSON