### PR TITLE
fix: add testdox fallback parser for crashed PHPUnit runs

### DIFF
--- a/wordpress/scripts/test/parse-test-results.sh
+++ b/wordpress/scripts/test/parse-test-results.sh
@@ -7,6 +7,9 @@
 #   Tests: 533, Assertions: 2100, Errors: 10, Failures: 39, Skipped: 3.
 #   Tests: 533, Assertions: 2100, Errors: 10, Failures: 39, Warnings: 2, Skipped: 3, Incomplete: 1.
 #
+# Fallback: when PHPUnit crashes mid-run (e.g., a test calls exit()), the summary
+# line is never printed. In --testdox mode, we count ✔/✘ marks as a fallback.
+#
 # Usage: parse-test-results.sh <phpunit-output-file>
 #
 # Writes JSON to HOMEBOY_TEST_RESULTS_FILE if set. Always prints summary to stderr.
@@ -24,6 +27,7 @@ TOTAL=0
 PASSED=0
 FAILED=0
 SKIPPED=0
+PARTIAL=""
 
 # Pattern 1: "OK (N tests, N assertions)"
 if echo "$OUTPUT" | grep -qE 'OK \([0-9]+ test'; then
@@ -53,6 +57,17 @@ elif echo "$OUTPUT" | grep -qE '^Tests: [0-9]+'; then
     if [ "$PASSED" -lt 0 ]; then
         PASSED=0
     fi
+
+# Pattern 3 (fallback): count testdox ✔/✘ marks when PHPUnit crashed mid-run.
+# PHPUnit prints " ✔ Test name" for passes, " ✘ Test name" for failures in
+# --testdox mode. If we see these but no summary line, PHPUnit died before
+# printing its summary (e.g., a test called exit()). Count what we have.
+elif echo "$OUTPUT" | grep -qE '^ [✔✘]'; then
+    PASSED=$(echo "$OUTPUT" | grep -cE '^ ✔' || echo "0")
+    FAILED=$(echo "$OUTPUT" | grep -cE '^ ✘' || echo "0")
+    TOTAL=$((PASSED + FAILED))
+    SKIPPED=0
+    PARTIAL="testdox-fallback"
 else
     # No recognizable output — exit silently
     exit 0
@@ -60,7 +75,18 @@ fi
 
 # Write JSON to file if requested
 if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
-    cat > "$HOMEBOY_TEST_RESULTS_FILE" << JSONEOF
+    if [ -n "${PARTIAL:-}" ]; then
+        cat > "$HOMEBOY_TEST_RESULTS_FILE" << JSONEOF
+{
+  "total": ${TOTAL},
+  "passed": ${PASSED},
+  "failed": ${FAILED},
+  "skipped": ${SKIPPED},
+  "partial": "${PARTIAL}"
+}
+JSONEOF
+    else
+        cat > "$HOMEBOY_TEST_RESULTS_FILE" << JSONEOF
 {
   "total": ${TOTAL},
   "passed": ${PASSED},
@@ -68,7 +94,12 @@ if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
   "skipped": ${SKIPPED}
 }
 JSONEOF
+    fi
 fi
 
 # Print summary to stderr for visibility
-echo "[test-results] Total: ${TOTAL}, Passed: ${PASSED}, Failed: ${FAILED}, Skipped: ${SKIPPED}" >&2
+if [ -n "${PARTIAL:-}" ]; then
+    echo "[test-results] Total: ${TOTAL}, Passed: ${PASSED}, Failed: ${FAILED}, Skipped: ${SKIPPED} (${PARTIAL}: PHPUnit crashed before printing summary)" >&2
+else
+    echo "[test-results] Total: ${TOTAL}, Passed: ${PASSED}, Failed: ${FAILED}, Skipped: ${SKIPPED}" >&2
+fi


### PR DESCRIPTION
## Summary

- When PHPUnit crashes mid-suite (e.g., a test calls `exit()`), no summary line is printed
- The parser previously exited silently with no results file, leaving homeboy to report `BUILD FAILED`
- Add **Pattern 3**: count testdox `✔`/`✘` marks as a fallback when standard summary lines are absent

## How it works

```
# Standard patterns (existing):
OK (481 tests, 1234 assertions)           → Pattern 1
Tests: 533, Assertions: 2100, Failures: 49 → Pattern 2

# New fallback (when PHPUnit died before printing summary):
 ✔ Test name                               → Pattern 3 (count marks)
 ✘ Other test name
```

The results file includes a `"partial": "testdox-fallback"` field so consumers know counts came from fallback parsing. The stderr summary also notes the crash.

## Context

Discovered while investigating `homeboy#592`. The root cause was a data-machine test calling `WP_CLI::error()` → `exit(1)`, which killed PHPUnit at test 538/710. This extension fix ensures homeboy correctly reports pass/fail counts even when PHPUnit crashes, instead of silently producing no results.

Ref: homeboy#592, Extra-Chill/data-machine#728