### PR TITLE
feat: handle HOMEBOY_CHANGED_TEST_FILES for scoped test runs

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -215,6 +215,36 @@ TEST_ARGS=(
     --manifest-path "${PROJECT_PATH}/Cargo.toml"
 )
 
+# Scoped test selection: if HOMEBOY_CHANGED_TEST_FILES is set, derive
+# cargo test filter from the changed test file paths.
+# Cargo test accepts positional test name patterns after --.
+# We extract module paths from file paths (e.g., src/commands/audit.rs → commands::audit).
+SCOPE_FILTER_ARGS=()
+if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
+    while IFS= read -r test_file; do
+        [ -z "$test_file" ] && continue
+        # Convert file path to Rust module path for cargo test filtering
+        # e.g., src/commands/audit.rs → commands::audit
+        #        src/utils/baseline.rs → utils::baseline
+        #        tests/integration.rs  → integration
+        module_path="${test_file#src/}"          # strip leading src/
+        module_path="${module_path#tests/}"      # strip leading tests/
+        module_path="${module_path%.rs}"          # strip .rs extension
+        module_path="${module_path%/mod}"         # strip /mod suffix
+        module_path="${module_path//\//::\:}"     # replace / with ::
+        if [ -n "$module_path" ]; then
+            SCOPE_FILTER_ARGS+=("$module_path")
+        fi
+    done <<< "${HOMEBOY_CHANGED_TEST_FILES}"
+
+    if [ ${#SCOPE_FILTER_ARGS[@]} -gt 0 ]; then
+        # Join module paths with | for regex-style OR matching
+        FILTER=$(IFS='|'; echo "${SCOPE_FILTER_ARGS[*]}")
+        TEST_ARGS+=(-- "$FILTER")
+        echo "Scoped to changed files: ${FILTER}"
+    fi
+fi
+
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: cargo ${TEST_ARGS[*]} $*"
 fi

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -565,6 +565,29 @@ phpunit_args=(
     "${TEST_DIR}"
 )
 
+# Scoped test selection: if HOMEBOY_CHANGED_TEST_FILES is set, build a
+# PHPUnit --filter regex from the changed test file basenames.
+# e.g., tests/Unit/Foo/BarBazTest.php → BarBazTest
+if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
+    FILTER_CLASSES=()
+    while IFS= read -r test_file; do
+        [ -z "$test_file" ] && continue
+        # Only PHP files
+        [[ "$test_file" != *.php ]] && continue
+        # Extract basename without extension (e.g., BarBazTest)
+        class_name="$(basename "$test_file" .php)"
+        [ -n "$class_name" ] && FILTER_CLASSES+=("$class_name")
+    done <<< "${HOMEBOY_CHANGED_TEST_FILES}"
+
+    if [ ${#FILTER_CLASSES[@]} -gt 0 ]; then
+        # Deduplicate and sort
+        UNIQUE_CLASSES=($(printf '%s\n' "${FILTER_CLASSES[@]}" | sort -u))
+        FILTER_REGEX=$(IFS='|'; echo "(${UNIQUE_CLASSES[*]})")
+        phpunit_args+=(--filter "$FILTER_REGEX")
+        echo "Scoped to changed test files: ${FILTER_REGEX}"
+    fi
+fi
+
 # Coverage collection (opt-in via HOMEBOY_COVERAGE=1)
 COVERAGE_CLOVER=""
 if [ "${HOMEBOY_COVERAGE:-}" = "1" ]; then


### PR DESCRIPTION
## Summary

- Rust and WordPress extensions now read `HOMEBOY_CHANGED_TEST_FILES` env var for scoped test selection
- Each extension converts the file list to its runner's native scoping mechanism

## Context

Homeboy core previously generated PHPUnit-specific `--filter=` args in `test.rs` — language-specific code that doesn't belong in core. Now core passes the changed file list via env var, and each extension handles scoping in its own way.

Refs Extra-Chill/homeboy#653

## Changes

### `rust/scripts/test-runner.sh`
- Reads `HOMEBOY_CHANGED_TEST_FILES`, converts file paths to Rust module paths (e.g., `src/commands/audit.rs` → `commands::audit`)
- Passes module paths as positional filter to `cargo test -- module1|module2`

### `wordpress/scripts/test/test-runner.sh`
- Reads `HOMEBOY_CHANGED_TEST_FILES`, extracts PHP class names from basenames
- Generates PHPUnit `--filter (BarBazTest|FooTest)` argument