### PR TITLE
feat: emit explicit fix plan sidecars for lint and test

### DIFF
--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -333,6 +333,11 @@ print(json.dumps(results))
         run_fixer "phpcs-ignore" "$PHPCS_IGNORE_FIXER" "$lint_target" --phpcs-binary="$PHPCS_BIN" --phpcs-standard="$PHPCS_CONFIG"
     done
 
+    # Write fix plan sidecar for planning flows (same shape as fix results)
+    if [ -n "${HOMEBOY_FIX_PLAN_FILE:-}" ]; then
+        echo "$FIX_RESULTS_JSON" > "${HOMEBOY_FIX_PLAN_FILE}"
+    fi
+
     # Write fix results sidecar for homeboy to consume
     if [ -n "${HOMEBOY_FIX_RESULTS_FILE:-}" ]; then
         echo "$FIX_RESULTS_JSON" > "${HOMEBOY_FIX_RESULTS_FILE}"

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -757,19 +757,25 @@ if [ "${MYSQL_AUTO_CREATED:-}" = "1" ]; then
     mysql "${_mysql_cleanup[@]}" -e "DROP DATABASE IF EXISTS \`${MYSQL_DATABASE}\`" 2>/dev/null || true
 fi
 
-# Write test infrastructure fix results to HOMEBOY_FIX_RESULTS_FILE sidecar.
-# lint-runner.sh may have already written lint fixes to this file; we merge
-# test-runner's infrastructure fixes (removed files, removed deps) into it.
-if [ -n "${HOMEBOY_FIX_RESULTS_FILE:-}" ] && [ ${#TEST_FIX_ENTRIES[@]} -gt 0 ]; then
-    if [ -f "${HOMEBOY_FIX_RESULTS_FILE}" ] && [ -s "${HOMEBOY_FIX_RESULTS_FILE}" ]; then
+# Write test infrastructure fix plan/results sidecars.
+# lint-runner.sh may have already written lint fixes to these files; we merge
+# test-runner's infrastructure fixes (removed files, removed deps) into them.
+write_or_merge_fix_sidecar() {
+    local target_file="$1"
+
+    if [ -z "${target_file:-}" ] || [ ${#TEST_FIX_ENTRIES[@]} -eq 0 ]; then
+        return 0
+    fi
+
+    if [ -f "${target_file}" ] && [ -s "${target_file}" ]; then
         # Merge: read existing array, append our entries, write back
-        EXISTING=$(cat "${HOMEBOY_FIX_RESULTS_FILE}")
+        EXISTING=$(cat "${target_file}")
         MERGED="${EXISTING%]}"  # strip trailing ]
         for ENTRY in "${TEST_FIX_ENTRIES[@]}"; do
             MERGED+=", ${ENTRY}"
         done
         MERGED+="]"
-        echo "${MERGED}" > "${HOMEBOY_FIX_RESULTS_FILE}"
+        echo "${MERGED}" > "${target_file}"
     else
         # No existing file — write fresh array
         JSON="["
@@ -783,6 +789,9 @@ if [ -n "${HOMEBOY_FIX_RESULTS_FILE:-}" ] && [ ${#TEST_FIX_ENTRIES[@]} -gt 0 ]; 
             fi
         done
         JSON+="]"
-        echo "${JSON}" > "${HOMEBOY_FIX_RESULTS_FILE}"
+        echo "${JSON}" > "${target_file}"
     fi
-fi
+}
+
+write_or_merge_fix_sidecar "${HOMEBOY_FIX_PLAN_FILE:-}"
+write_or_merge_fix_sidecar "${HOMEBOY_FIX_RESULTS_FILE:-}"


### PR DESCRIPTION
## Summary
- add `HOMEBOY_FIX_PLAN_FILE` support to the WordPress lint runner
- add `HOMEBOY_FIX_PLAN_FILE` support to the WordPress test runner and merge test infrastructure entries into both plan and applied-fix sidecars
- keep the plan sidecar shape aligned with existing fix results so core can consume plan data without a new parser contract

## Why
- gives `homeboy refactor ci` an explicit planning artifact for lint/test instead of relying only on inferred sandbox side effects
- separates proposed fixes from applied fixes with a clean contract:
  - `HOMEBOY_FIX_PLAN_FILE` = proposed fixes
  - `HOMEBOY_FIX_RESULTS_FILE` = applied fixes