### PR TITLE
feat(rust): add generate_module_index command

### DIFF
--- a/rust/scripts/refactor/__main__.py
+++ b/rust/scripts/refactor/__main__.py
@@ -14,6 +14,7 @@ from .imports import resolve_imports
 from .visibility import adjust_visibility
 from .rewrite import rewrite_caller_imports
 from .struct_fields import propagate_struct_fields
+from .module_index import generate_module_index
 
 
 def handle_parse_items(data: dict) -> dict:
@@ -59,6 +60,13 @@ def handle_propagate_struct_fields(data: dict) -> dict:
     return propagate_struct_fields(data)
 
 
+def handle_generate_module_index(data: dict) -> dict:
+    return generate_module_index(
+        data.get("submodules", []),
+        data.get("remaining_content", ""),
+    )
+
+
 COMMANDS = {
     "parse_items": handle_parse_items,
     "resolve_imports": handle_resolve_imports,
@@ -66,6 +74,7 @@ COMMANDS = {
     "adjust_visibility": handle_adjust_visibility,
     "rewrite_caller_imports": handle_rewrite_caller_imports,
     "propagate_struct_fields": handle_propagate_struct_fields,
+    "generate_module_index": handle_generate_module_index,
 }
 
 

--- a/rust/scripts/refactor/module_index.py
+++ b/rust/scripts/refactor/module_index.py
@@ -1,0 +1,78 @@
+"""Module index generation for Rust.
+
+Generates `mod.rs` content when decompose splits a file into a directory of modules.
+"""
+
+from typing import List, Union
+
+
+def generate_module_index(
+    submodules: Union[List[str], List[dict]], 
+    remaining_content: str = ""
+) -> dict:
+    """Generate a Rust mod.rs file that wires up submodules and re-exports their public API.
+
+    Args:
+        submodules: Either a list of module names (strings) or list of dicts with 
+                    'name' and 'pub_items' keys. When just names, uses glob re-exports.
+        remaining_content: Any remaining content from the original file (impl blocks, etc.)
+
+    Returns:
+        dict with 'content' key containing the mod.rs file content
+    """
+    lines = []
+
+    # Normalize input to list of dicts
+    subs = []
+    for sub in submodules:
+        if isinstance(sub, str):
+            subs.append({"name": sub, "pub_items": None})
+        else:
+            subs.append(sub)
+
+    # Module declarations
+    for sub in subs:
+        name = sub.get("name", "") if isinstance(sub, dict) else str(sub)
+        if not name:
+            continue
+        lines.append(f"mod {name};")
+
+    if lines:
+        lines.append("")  # Blank line after mod declarations
+
+    # Re-exports
+    for sub in subs:
+        name = sub.get("name", "") if isinstance(sub, dict) else str(sub)
+        if not name:
+            continue
+
+        pub_items = sub.get("pub_items") if isinstance(sub, dict) else None
+
+        if pub_items and isinstance(pub_items, list) and len(pub_items) > 0:
+            # Explicit re-exports
+            if len(pub_items) == 1:
+                lines.append(f"pub use {name}::{pub_items[0]};")
+            elif len(pub_items) <= 3:
+                items_str = ", ".join(pub_items)
+                lines.append(f"pub use {name}::{{{items_str}}};")
+            else:
+                lines.append(f"pub use {name}::{{")
+                for item in sorted(pub_items):
+                    lines.append(f"    {item},")
+                lines.append("};")
+        else:
+            # Glob re-export (safest for unknown visibility)
+            lines.append(f"pub use {name}::*;")
+
+    # Add remaining content (impl blocks, private items, etc.)
+    if remaining_content and remaining_content.strip():
+        if lines:
+            lines.append("")  # Blank line separator
+        lines.append(remaining_content.rstrip())
+
+    # Ensure trailing newline
+    content = "\n".join(lines)
+    if content and not content.endswith("\n"):
+        content += "\n"
+
+    return {"content": content}


### PR DESCRIPTION
## Summary

Adds a new `generate_module_index` command to the Rust refactor extension that generates `mod.rs` content when decompose splits a file into a directory of modules.

## How it works

Given a list of submodule names, generates:
1. Module declarations (`mod foo;`)
2. Glob re-exports (`pub use foo::*;`)
3. Remaining content from original file (impl blocks, private items)

## Example

Input:
```json
{
  "submodules": ["types", "helpers"],
  "remaining_content": "// impl blocks..."
}
```

Output:
```rust
mod types;
mod helpers;

pub use types::*;
pub use helpers::*;

// impl blocks...
```

## Related

- Extra-Chill/homeboy#656 (mod.rs generation tracking issue)
- Extra-Chill/homeboy#658 (impl dedupe fix - prerequisite)