### PR TITLE
fix: add dependency-aware validation to WordPress extension

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -1,1 +1,34 @@
 # WordPress Extension
+
+## Validation dependencies
+
+Some WordPress plugins are intentionally layered on top of other local plugins.
+The WordPress extension can load those local dependencies during validation so
+PHPStan, the autoload preflight check, and PHPUnit all run with the expected
+plugin graph instead of in false isolation.
+
+Configure dependencies in the component's WordPress extension settings:
+
+```json
+{
+  "extensions": {
+    "wordpress": {
+      "settings": {
+        "validation_dependencies": "data-machine"
+      }
+    }
+  }
+}
+```
+
+Supported value shapes:
+
+- single component ID: `data-machine`
+- comma-separated list: `data-machine, other-plugin`
+- newline-separated list
+- JSON-array string: `["data-machine", "other-plugin"]`
+
+Each dependency entry may be either:
+
+- a registered Homeboy component ID
+- an absolute path to another local plugin checkout

--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+homeboy_get_validation_dependencies_raw() {
+    local settings_json="${HOMEBOY_SETTINGS_JSON:-}"
+
+    if [ -z "$settings_json" ] || [ "$settings_json" = "{}" ]; then
+        return 0
+    fi
+
+    printf '%s' "$settings_json" | jq -r '.validation_dependencies // .depends_on // empty' 2>/dev/null || true
+}
+
+homeboy_normalize_validation_dependencies() {
+    local raw="${1:-}"
+
+    if [ -z "$raw" ] || [ "$raw" = "null" ]; then
+        return 0
+    fi
+
+    if printf '%s' "$raw" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        printf '%s' "$raw" | jq -r '.[]'
+        return 0
+    fi
+
+    if printf '%s' "$raw" | jq -e 'type == "string"' >/dev/null 2>&1; then
+        raw=$(printf '%s' "$raw" | jq -r '.')
+    fi
+
+    raw=${raw//,/\n}
+
+    while IFS= read -r entry; do
+        entry="${entry#${entry%%[![:space:]]*}}"
+        entry="${entry%${entry##*[![:space:]]}}"
+        [ -n "$entry" ] && printf '%s\n' "$entry"
+    done <<< "$raw"
+}
+
+homeboy_resolve_validation_dependency_path() {
+    local dependency="${1:-}"
+
+    [ -z "$dependency" ] && return 1
+
+    if [ -d "$dependency" ]; then
+        printf '%s\n' "$dependency"
+        return 0
+    fi
+
+    if command -v homeboy >/dev/null 2>&1; then
+        local resolved
+        resolved=$(homeboy component show "$dependency" 2>/dev/null | jq -r '.data.entity.local_path // empty' 2>/dev/null || true)
+        if [ -n "$resolved" ] && [ -d "$resolved" ]; then
+            printf '%s\n' "$resolved"
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+homeboy_resolve_validation_dependency_paths() {
+    local plugin_path="${1:-}"
+    local raw
+    raw=$(homeboy_get_validation_dependencies_raw)
+
+    [ -z "$raw" ] && return 0
+
+    while IFS= read -r dependency; do
+        [ -z "$dependency" ] && continue
+
+        local resolved
+        resolved=$(homeboy_resolve_validation_dependency_path "$dependency" || true)
+
+        if [ -z "$resolved" ]; then
+            echo "Warning: Could not resolve WordPress validation dependency '$dependency'" >&2
+            continue
+        fi
+
+        if [ -n "$plugin_path" ] && [ "$resolved" = "$plugin_path" ]; then
+            continue
+        fi
+
+        printf '%s\n' "$resolved"
+    done < <(homeboy_normalize_validation_dependencies "$raw")
+}
+
+homeboy_export_validation_dependency_paths() {
+    local plugin_path="${1:-}"
+    local resolved_paths
+    resolved_paths=$(homeboy_resolve_validation_dependency_paths "$plugin_path" || true)
+
+    export HOMEBOY_WORDPRESS_DEPENDENCY_PATHS="$resolved_paths"
+}

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
+# shellcheck source=../lib/validation-dependencies.sh
+source "${DEPENDENCY_HELPER}"
+
 # Standalone PHP static analysis script using PHPStan
 # Supports summary mode via HOMEBOY_SUMMARY_MODE=1
 # Supports skip via HOMEBOY_SKIP_PHPSTAN=1
@@ -34,7 +39,6 @@ if [ -n "${HOMEBOY_EXTENSION_PATH:-}" ]; then
     COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-.}"
     PLUGIN_PATH="$COMPONENT_PATH"
 else
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     EXTENSION_PATH="$(dirname "$(dirname "$SCRIPT_DIR")")"
     COMPONENT_PATH="$(pwd)"
     PLUGIN_PATH="$COMPONENT_PATH"
@@ -47,7 +51,24 @@ fi
 
 PHPSTAN_BIN="${EXTENSION_PATH}/vendor/bin/phpstan"
 PHPSTAN_CONFIG="${EXTENSION_PATH}/phpstan.neon.dist"
+PHPSTAN_BASE_CONFIG="$PHPSTAN_CONFIG"
 COMPONENT_BASELINE="${PLUGIN_PATH}/phpstan-baseline.neon"
+COMPOSITE_AUTOLOAD=""
+DEPENDENCY_CONFIG=""
+
+homeboy_mktemp() {
+    local template="$1"
+    local candidate_dir
+
+    for candidate_dir in "${TMPDIR:-}" /root/tmp /var/tmp /tmp; do
+        [ -z "$candidate_dir" ] && continue
+        if [ -d "$candidate_dir" ] && [ -w "$candidate_dir" ]; then
+            mktemp "${candidate_dir}/${template}" 2>/dev/null && return 0
+        fi
+    done
+
+    mktemp 2>/dev/null
+}
 
 # Validate PHPStan exists (soft failure - not all installations have it)
 if [ ! -f "$PHPSTAN_BIN" ]; then
@@ -58,6 +79,44 @@ fi
 if [ ! -f "$PHPSTAN_CONFIG" ]; then
     echo "Warning: phpstan.neon.dist not found at $PHPSTAN_CONFIG, skipping static analysis"
     exit 0
+fi
+
+generate_dependency_config() {
+    local tmpfile
+    local has_dependencies=0
+
+    tmpfile=$(homeboy_mktemp 'phpstan-dependencies-XXXXXX.neon')
+
+    {
+        printf '%s\n' 'includes:'
+        printf '    - %s\n' "$PHPSTAN_CONFIG"
+        printf '%s\n' ''
+        printf '%s\n' 'parameters:'
+        printf '%s\n' '    scanDirectories:'
+
+        while IFS= read -r dependency_path; do
+            [ -z "$dependency_path" ] && continue
+            has_dependencies=1
+            printf '        - %s\n' "$dependency_path"
+        done < <(homeboy_resolve_validation_dependency_paths "$PLUGIN_PATH")
+    } > "$tmpfile"
+
+    if [ "$has_dependencies" -eq 1 ]; then
+        printf '%s\n' "$tmpfile"
+    else
+        rm -f "$tmpfile"
+        printf '%s\n' ''
+    fi
+}
+
+cleanup_dependency_config() {
+    [ -n "$DEPENDENCY_CONFIG" ] && rm -f "$DEPENDENCY_CONFIG"
+    DEPENDENCY_CONFIG=""
+}
+
+DEPENDENCY_CONFIG=$(generate_dependency_config)
+if [ -n "$DEPENDENCY_CONFIG" ] && [ -f "$DEPENDENCY_CONFIG" ]; then
+    PHPSTAN_BASE_CONFIG="$DEPENDENCY_CONFIG"
 fi
 
 # Check if component has PHP files
@@ -80,7 +139,7 @@ echo "Running PHPStan static analysis..."
 
 # Build PHPStan arguments
 phpstan_args=(analyse)
-phpstan_args+=(--configuration="$PHPSTAN_CONFIG")
+phpstan_args+=(--configuration="$PHPSTAN_BASE_CONFIG")
 
 # Level override (default: 5)
 PHPSTAN_LEVEL="${HOMEBOY_PHPSTAN_LEVEL:-5}"
@@ -97,13 +156,53 @@ if [ -f "$COMPONENT_BASELINE" ]; then
     phpstan_args+=(--baseline="$COMPONENT_BASELINE")
 fi
 
-# Include component autoloader if it exists
-COMPONENT_AUTOLOAD="${PLUGIN_PATH}/vendor/autoload.php"
-if [ -f "$COMPONENT_AUTOLOAD" ]; then
+# Include component/dependency autoloaders if they exist
+generate_composite_autoload() {
+    local tmpfile
+    local component_autoload="${PLUGIN_PATH}/vendor/autoload.php"
+
+    tmpfile=$(homeboy_mktemp 'homeboy-phpstan-autoload-XXXXXX.php')
+
+    {
+        printf '%s\n' '<?php'
+        printf '%s\n' '$autoloadFiles = ['
+
+        while IFS= read -r dependency_path; do
+            [ -z "$dependency_path" ] && continue
+            local dependency_autoload="${dependency_path}/vendor/autoload.php"
+            if [ -f "$dependency_autoload" ]; then
+                printf '    %s,\n' "$(printf '%s' "$dependency_autoload" | jq -Rsa .)"
+            fi
+        done < <(homeboy_resolve_validation_dependency_paths "$PLUGIN_PATH")
+
+        if [ -f "$component_autoload" ]; then
+            printf '    %s,\n' "$(printf '%s' "$component_autoload" | jq -Rsa .)"
+        fi
+
+        printf '%s\n' '];'
+        printf '%s\n' 'foreach ($autoloadFiles as $autoloadFile) {'
+        printf '%s\n' '    if (is_string($autoloadFile) && $autoloadFile !== "" && file_exists($autoloadFile)) {'
+        printf '%s\n' '        require_once $autoloadFile;'
+        printf '%s\n' '    }'
+        printf '%s\n' '}'
+    } > "$tmpfile"
+
+    printf '%s\n' "$tmpfile"
+}
+
+cleanup_composite_autoload() {
+    [ -n "$COMPOSITE_AUTOLOAD" ] && rm -f "$COMPOSITE_AUTOLOAD"
+    COMPOSITE_AUTOLOAD=""
+}
+
+COMPOSITE_AUTOLOAD=$(generate_composite_autoload)
+
+if [ -f "$COMPOSITE_AUTOLOAD" ]; then
     if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
-        echo "DEBUG: Using component autoloader: $COMPONENT_AUTOLOAD"
+        echo "DEBUG: Using composite autoloader: $COMPOSITE_AUTOLOAD"
+        echo "DEBUG: Using PHPStan config: $PHPSTAN_BASE_CONFIG"
     fi
-    phpstan_args+=(--autoload-file="$COMPONENT_AUTOLOAD")
+    phpstan_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
 fi
 
 # No progress bar for cleaner output
@@ -125,10 +224,10 @@ PHPSTAN_TMPCONFIG=""
 generate_phpstan_config() {
     local max_processes="$1"
     local tmpfile
-    tmpfile=$(mktemp "${TMPDIR:-/tmp}/phpstan-XXXXXX.neon" 2>/dev/null || mktemp)
+    tmpfile=$(homeboy_mktemp 'phpstan-XXXXXX.neon')
     cat > "$tmpfile" <<NEON
 includes:
-    - ${PHPSTAN_CONFIG}
+    - ${PHPSTAN_BASE_CONFIG}
 
 parameters:
     parallel:
@@ -141,7 +240,7 @@ cleanup_phpstan_config() {
     [ -n "$PHPSTAN_TMPCONFIG" ] && rm -f "$PHPSTAN_TMPCONFIG"
     PHPSTAN_TMPCONFIG=""
 }
-trap cleanup_phpstan_config EXIT
+trap 'cleanup_phpstan_config; cleanup_composite_autoload; cleanup_dependency_config' EXIT
 
 if [ -n "$PHPSTAN_MAX_PROCESSES" ]; then
     PHPSTAN_TMPCONFIG=$(generate_phpstan_config "$PHPSTAN_MAX_PROCESSES")
@@ -153,8 +252,8 @@ if [ -n "$PHPSTAN_MAX_PROCESSES" ]; then
     if [ -f "$COMPONENT_BASELINE" ]; then
         phpstan_args+=(--baseline="$COMPONENT_BASELINE")
     fi
-    if [ -f "$COMPONENT_AUTOLOAD" ]; then
-        phpstan_args+=(--autoload-file="$COMPONENT_AUTOLOAD")
+    if [ -f "$COMPOSITE_AUTOLOAD" ]; then
+        phpstan_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
     fi
     phpstan_args+=(--no-progress)
     phpstan_args+=("$PLUGIN_PATH")
@@ -193,7 +292,7 @@ is_parallel_worker_failure() {
 if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
     set +e
     # Capture stderr separately to show PHPStan errors if it fails
-    stderr_file=$(mktemp)
+    stderr_file=$(homeboy_mktemp 'phpstan-stderr-XXXXXX.log')
     json_output=$("$PHPSTAN_BIN" "${phpstan_args[@]}" --error-format=json 2>"$stderr_file")
     json_exit=$?
     stderr_output=$(cat "$stderr_file")
@@ -206,9 +305,9 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
         PHPSTAN_TMPCONFIG=$(generate_phpstan_config 1)
         retry_args=(analyse --configuration="$PHPSTAN_TMPCONFIG" --level="$PHPSTAN_LEVEL" --memory-limit=2G --no-progress)
         [ -f "$COMPONENT_BASELINE" ] && retry_args+=(--baseline="$COMPONENT_BASELINE")
-        [ -f "$COMPONENT_AUTOLOAD" ] && retry_args+=(--autoload-file="$COMPONENT_AUTOLOAD")
+        [ -f "$COMPOSITE_AUTOLOAD" ] && retry_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
         retry_args+=("$PLUGIN_PATH")
-        stderr_file=$(mktemp)
+        stderr_file=$(homeboy_mktemp 'phpstan-stderr-XXXXXX.log')
         json_output=$("$PHPSTAN_BIN" "${retry_args[@]}" --error-format=json 2>"$stderr_file")
         json_exit=$?
         stderr_output=$(cat "$stderr_file")
@@ -338,7 +437,7 @@ fi
 
 # Full report mode (default)
 set +e
-stderr_file=$(mktemp)
+stderr_file=$(homeboy_mktemp 'phpstan-stderr-XXXXXX.log')
 "$PHPSTAN_BIN" "${phpstan_args[@]}" 2>"$stderr_file"
 full_exit=$?
 stderr_output=$(cat "$stderr_file")
@@ -352,7 +451,7 @@ if [ "$full_exit" -ne 0 ] && echo "$stderr_output" | grep -qi "parallel worker";
     PHPSTAN_TMPCONFIG=$(generate_phpstan_config 1)
     retry_args=(analyse --configuration="$PHPSTAN_TMPCONFIG" --level="$PHPSTAN_LEVEL" --memory-limit=2G --no-progress)
     [ -f "$COMPONENT_BASELINE" ] && retry_args+=(--baseline="$COMPONENT_BASELINE")
-    [ -f "$COMPONENT_AUTOLOAD" ] && retry_args+=(--autoload-file="$COMPONENT_AUTOLOAD")
+    [ -f "$COMPOSITE_AUTOLOAD" ] && retry_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
     retry_args+=("$PLUGIN_PATH")
     "$PHPSTAN_BIN" "${retry_args[@]}"
     full_exit=$?

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -13,8 +13,11 @@ TEST_FIX_ENTRIES=()
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/../lib/runner-steps.sh}"
+DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
 # shellcheck source=../lib/runner-steps.sh
 source "${RUNNER_STEPS_HELPER}"
+# shellcheck source=../lib/validation-dependencies.sh
+source "${DEPENDENCY_HELPER}"
 
 print_failure_summary() {
     if [ -n "$FAILED_STEP" ]; then
@@ -415,6 +418,7 @@ else
         echo "DEBUG: Using project test directory: $TEST_DIR"
     fi
 fi
+homeboy_export_validation_dependency_paths "$PLUGIN_PATH"
 export WP_TESTS_DIR="$WP_TESTS_DIR"
 export ABSPATH="$ABSPATH"
 

--- a/wordpress/scripts/validation/autoload-check.sh
+++ b/wordpress/scripts/validation/autoload-check.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
+# shellcheck source=../lib/validation-dependencies.sh
+source "${DEPENDENCY_HELPER}"
+
 # Autoload validation for WordPress components (plugins and themes)
 # Catches class loading errors before tests run
 
@@ -8,12 +13,12 @@ set -euo pipefail
 if [ -n "${HOMEBOY_EXTENSION_PATH:-}" ]; then
     EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH}"
 else
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     EXTENSION_PATH="$(dirname "$SCRIPT_DIR")"
 fi
 
 # Determine component path
 PLUGIN_PATH="${HOMEBOY_PLUGIN_PATH:-${HOMEBOY_COMPONENT_PATH:-$(pwd)}}"
+homeboy_export_validation_dependency_paths "$PLUGIN_PATH"
 
 # Export for PHP script
 export HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH"

--- a/wordpress/scripts/validation/validate-autoload.php
+++ b/wordpress/scripts/validation/validate-autoload.php
@@ -6,6 +6,14 @@
 
 $extension_path = getenv('HOMEBOY_EXTENSION_PATH') ?: dirname(__DIR__);
 $plugin_path = getenv('HOMEBOY_PLUGIN_PATH') ?: getenv('HOMEBOY_COMPONENT_PATH') ?: getcwd();
+$dependency_paths = array_values(
+    array_filter(
+        array_map(
+            'trim',
+            explode("\n", (string) getenv('HOMEBOY_WORDPRESS_DEPENDENCY_PATHS'))
+        )
+    )
+);
 
 // WordPress paths from wp-phpunit
 $wp_tests_dir = $extension_path . '/vendor/wp-phpunit/wp-phpunit';
@@ -427,6 +435,8 @@ if (!defined('WP_DEBUG')) {
 
 // Handle based on component type
 if ($component['type'] === 'theme') {
+    load_dependency_plugins($dependency_paths);
+
     // Add theme-specific stubs
     if (!function_exists('get_template_directory')) {
         function get_template_directory() {
@@ -467,6 +477,7 @@ if ($component['type'] === 'theme') {
     }
 } else {
     // Plugin loading
+    load_dependency_plugins($dependency_paths);
     require_once $component['file'];
     echo "Plugin loaded successfully.\n";
 }
@@ -505,4 +516,16 @@ function find_component_main_file($path) {
         }
     }
     return null;
+}
+
+function load_dependency_plugins(array $dependency_paths) {
+    foreach ($dependency_paths as $dependency_path) {
+        $dependency = find_component_main_file($dependency_path);
+
+        if (!$dependency || 'plugin' !== $dependency['type'] || empty($dependency['file'])) {
+            continue;
+        }
+
+        require_once $dependency['file'];
+    }
 }

--- a/wordpress/tests/bootstrap.php
+++ b/wordpress/tests/bootstrap.php
@@ -44,6 +44,15 @@ if (!defined('WP_TESTS_NETWORK_TITLE')) {
 // Define plugin constants for tests
 define('TESTS_PLUGIN_DIR', $_plugin_path);
 
+$_dependency_paths = array_values(
+	array_filter(
+		array_map(
+			'trim',
+			explode("\n", (string) getenv('HOMEBOY_WORDPRESS_DEPENDENCY_PATHS'))
+		)
+	)
+);
+
 // Define WP_CORE_DIR
 if (!defined('WP_CORE_DIR')) {
     define('WP_CORE_DIR', $_core_dir);
@@ -64,6 +73,52 @@ if (false !== $_phpunit_polyfills_path) {
 // Load WordPress test functions
 require_once "{$_tests_dir}/includes/functions.php";
 
+function homeboy_find_component_main_file( string $path ): ?array {
+	$style_css = $path . '/style.css';
+	if ( file_exists( $style_css ) && false !== strpos( file_get_contents( $style_css ), 'Theme Name:' ) ) {
+		$functions_php = $path . '/functions.php';
+		if ( file_exists( $functions_php ) ) {
+			return array(
+				'type' => 'theme',
+				'file' => $functions_php,
+			);
+		}
+
+		return array(
+			'type' => 'theme',
+			'file' => null,
+		);
+	}
+
+	$files = glob( $path . '/*.php' );
+	if ( false === $files ) {
+		return null;
+	}
+
+	foreach ( $files as $file ) {
+		$content = file_get_contents( $file );
+		if ( false !== $content && false !== strpos( $content, 'Plugin Name:' ) ) {
+			return array(
+				'type' => 'plugin',
+				'file' => $file,
+			);
+		}
+	}
+
+	return null;
+}
+
+function homeboy_load_dependency_components( array $dependency_paths ): void {
+	foreach ( $dependency_paths as $dependency_path ) {
+		$component = homeboy_find_component_main_file( $dependency_path );
+		if ( ! $component || 'plugin' !== $component['type'] || empty( $component['file'] ) ) {
+			continue;
+		}
+
+		require_once $component['file'];
+	}
+}
+
 // Detect component type and find appropriate file to load
 $component_type = null;
 $component_file = null;
@@ -78,14 +133,10 @@ if (file_exists($style_css) && strpos(file_get_contents($style_css), 'Theme Name
     }
 } else {
     // Check if it's a plugin
-    $files = glob($_plugin_path . '/*.php');
-    foreach ($files as $file) {
-        $content = file_get_contents($file);
-        if (strpos($content, 'Plugin Name:') !== false) {
-            $component_type = 'plugin';
-            $component_file = $file;
-            break;
-        }
+    $component = homeboy_find_component_main_file($_plugin_path);
+    if ($component && 'plugin' === $component['type']) {
+        $component_type = 'plugin';
+        $component_file = $component['file'];
     }
 }
 
@@ -116,6 +167,10 @@ if (getenv('HOMEBOY_DEBUG') === '1') {
 
 // Load component at the appropriate WordPress hook
 if ($component_type === 'theme') {
+    tests_add_filter('plugins_loaded', function() use ($_dependency_paths) {
+        homeboy_load_dependency_components($_dependency_paths);
+    });
+
     // Load themes on after_setup_theme hook
     tests_add_filter('after_setup_theme', function() use ($component_file, $_plugin_path) {
         if ($component_file) {
@@ -132,7 +187,8 @@ if ($component_type === 'theme') {
     });
 } else {
     // Load plugins on plugins_loaded hook
-    tests_add_filter('plugins_loaded', function() use ($component_file) {
+    tests_add_filter('plugins_loaded', function() use ($component_file, $_dependency_paths) {
+        homeboy_load_dependency_components($_dependency_paths);
         require_once $component_file;
     });
 }

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -314,6 +314,13 @@
   },
   "settings": [
     {
+      "id": "validation_dependencies",
+      "label": "Validation Dependencies",
+      "type": "string",
+      "default": "",
+      "description": "Local component IDs or paths to load during PHPStan, autoload validation, and PHPUnit. Accepts comma-separated, newline-separated, or JSON-array string values."
+    },
+    {
       "id": "user",
       "label": "WP-CLI User",
       "type": "string",


### PR DESCRIPTION
## Summary
- add a `validation_dependencies` WordPress extension setting for local plugin/component dependencies
- load declared dependencies during PHPStan, autoload preflight, and PHPUnit so sibling plugin classes are available during validation
- document the new setting and accept component IDs, absolute paths, comma/newline lists, or JSON-array strings

## Testing
- bash -n wordpress/scripts/lib/validation-dependencies.sh
- bash -n wordpress/scripts/lint/phpstan-runner.sh
- bash -n wordpress/scripts/test/test-runner.sh
- bash -n wordpress/scripts/validation/autoload-check.sh
- php -l wordpress/tests/bootstrap.php
- php -l wordpress/scripts/validation/validate-autoload.php
- HOMEBOY_EXTENSION_PATH=/var/lib/datamachine/workspace/homeboy-extensions/wordpress HOMEBOY_COMPONENT_PATH=/var/lib/datamachine/workspace/data-machine-socials HOMEBOY_SETTINGS_JSON='{\"validation_dependencies\":\"data-machine\"}' HOMEBOY_SUMMARY_MODE=1 TMPDIR=/root/tmp bash /var/lib/datamachine/workspace/homeboy-extensions/wordpress/scripts/lint/phpstan-runner.sh

## Notes
- autoload preflight still correctly fails when the target component itself is missing its own `vendor/autoload.php`
- `/tmp` is full on this VPS, so the PHPStan runner now falls back to a writable temp directory instead of failing before analysis starts
- fixes #138