### PR TITLE
fix: improve lint safety — PHPStan-safe noops, param rename guardrails, critical-only checks, text domain fixer

### DIFF
--- a/wordpress/phpstan.neon.dist
+++ b/wordpress/phpstan.neon.dist
@@ -2,6 +2,11 @@ includes:
     - vendor/szepeviktor/phpstan-wordpress/extension.neon
 
 parameters:
+    # Don't treat unmatched ignoreErrors patterns as failures.
+    # These are config hygiene issues, not component code problems.
+    # Reporting them as errors creates false failure signals (see #137).
+    reportUnmatchedIgnoredErrors: false
+
     ignoreErrors:
         -
             identifier: return.void

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -131,6 +131,7 @@ READDIR_FIXER="${EXTENSION_PATH}/scripts/lint/php-fixers/readdir-fixer.php"
 COMMENTED_CODE_FIXER="${EXTENSION_PATH}/scripts/lint/php-fixers/commented-code-fixer.php"
 WP_ALTERNATIVES_FIXER="${EXTENSION_PATH}/scripts/lint/php-fixers/wp-alternatives-fixer.php"
 WP_FILESYSTEM_FIXER="${EXTENSION_PATH}/scripts/lint/php-fixers/wp-filesystem-fixer.php"
+TEXT_DOMAIN_FIXER="${EXTENSION_PATH}/scripts/lint/php-fixers/text-domain-fixer.php"
 PHPCS_IGNORE_FIXER="${EXTENSION_PATH}/scripts/lint/php-fixers/phpcs-ignore-fixer.php"
 PHPCS_CONFIG="${EXTENSION_PATH}/phpcs.xml.dist"
 
@@ -263,6 +264,12 @@ print(json.dumps(results))
         run_fixer "commented-code" "$COMMENTED_CODE_FIXER" "$lint_target"
         run_fixer "wp-alternatives" "$WP_ALTERNATIVES_FIXER" "$lint_target"
         run_fixer "wp-filesystem" "$WP_FILESYSTEM_FIXER" "$lint_target"
+
+        # Text domain fixer: replace wrong text domains in i18n function calls.
+        # Needs --text-domain arg if detected from plugin header.
+        if [ -n "$TEXT_DOMAIN" ]; then
+            run_fixer "text-domain" "$TEXT_DOMAIN_FIXER" "$lint_target" --text-domain="$TEXT_DOMAIN"
+        fi
     done
 
     # Run reserved keyword parameter name fixer ($default -> $default_value, etc.)

--- a/wordpress/scripts/lint/php-fixers/reserved-param-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/reserved-param-fixer.php
@@ -36,7 +36,14 @@ if (!file_exists($path)) {
 // Structure: [ 'methodName' => [ 'old_param' => 'new_param', ... ], ... ]
 $GLOBALS['rename_manifest'] = [];
 
-// Pass 1: Rename parameters in declarations + bodies, build manifest
+// Safety: track which methods were skipped because they're public/protected
+// and could have external callers we can't verify.
+$GLOBALS['rename_skipped'] = [];
+
+// Pass 1: Rename parameters in declarations + bodies, build manifest.
+// Public/protected methods are SKIPPED (report-only) unless all call sites
+// can be verified within the scanned path. Private methods and standalone
+// functions are always safe to rename.
 $result = fixer_process_path($path, 'process_file_pass1');
 
 // Pass 2: Update named argument call sites across all files
@@ -44,6 +51,13 @@ $callsite_fixes = 0;
 if (!empty($GLOBALS['rename_manifest'])) {
     $callsite_result = fixer_process_path($path, 'process_file_pass2');
     $callsite_fixes = $callsite_result['total_fixes'];
+}
+
+// Pass 3: Verification — check for stale named argument call sites.
+// If any old-name patterns remain after Pass 2, warn loudly.
+$stale_warnings = [];
+if (!empty($GLOBALS['rename_manifest'])) {
+    $stale_warnings = verify_no_stale_named_args($path, $GLOBALS['rename_manifest']);
 }
 
 $total = $result['total_fixes'] + $callsite_fixes;
@@ -58,6 +72,22 @@ if ($total > 0) {
     echo "Reserved param fixer: Fixed " . implode(', ', $parts) . "\n";
 } else {
     echo "Reserved param fixer: No fixable parameters found\n";
+}
+
+// Report skipped public/protected methods
+if (!empty($GLOBALS['rename_skipped'])) {
+    echo "  Skipped (public/protected, report-only): " . count($GLOBALS['rename_skipped']) . "\n";
+    foreach ($GLOBALS['rename_skipped'] as $skip_info) {
+        echo "    - {$skip_info['method']}: \${$skip_info['old_param']} → \${$skip_info['new_param']} (has external callers)\n";
+    }
+}
+
+// Report stale named argument warnings
+if (!empty($stale_warnings)) {
+    echo "  WARNING: Found stale named argument call sites after rename:\n";
+    foreach ($stale_warnings as $warning) {
+        echo "    - {$warning}\n";
+    }
 }
 
 exit(0);
@@ -101,7 +131,93 @@ function get_reserved_param_map() {
 }
 
 /**
+ * Detect the visibility of a method from tokens preceding T_FUNCTION.
+ *
+ * @return string|null 'public', 'protected', 'private', or null (standalone function).
+ */
+function detect_method_visibility($tokens, $func_token_idx) {
+    for ($j = $func_token_idx - 1; $j >= 0; $j--) {
+        if (!is_array($tokens[$j])) {
+            break;
+        }
+        $code = $tokens[$j][0];
+        if ($code === T_PUBLIC) {
+            return 'public';
+        }
+        if ($code === T_PROTECTED) {
+            return 'protected';
+        }
+        if ($code === T_PRIVATE) {
+            return 'private';
+        }
+        if (in_array($code, [T_STATIC, T_ABSTRACT, T_FINAL, T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+            continue;
+        }
+        break;
+    }
+    return null;
+}
+
+/**
+ * Check if a method is inside a class that extends or implements something.
+ * Methods in such classes may be called from parent/child contexts with
+ * named arguments that we can't see.
+ */
+function is_in_inheriting_class($tokens, $position) {
+    $count = count($tokens);
+    // Scan forward from start, tracking class declarations.
+    $class_stack = [];
+    $brace_depth = 0;
+
+    for ($i = 0; $i < $count; $i++) {
+        if (is_array($tokens[$i])) {
+            if ($tokens[$i][0] === T_CLASS) {
+                $has_extends    = false;
+                $has_implements = false;
+                for ($j = $i + 1; $j < $count; $j++) {
+                    if (!is_array($tokens[$j]) && $tokens[$j] === '{') {
+                        break;
+                    }
+                    if (is_array($tokens[$j]) && $tokens[$j][0] === T_EXTENDS) {
+                        $has_extends = true;
+                    }
+                    if (is_array($tokens[$j]) && $tokens[$j][0] === T_IMPLEMENTS) {
+                        $has_implements = true;
+                    }
+                }
+                $class_stack[] = [
+                    'depth'      => $brace_depth,
+                    'inherits'   => $has_extends || $has_implements,
+                ];
+            }
+        } else {
+            if ($tokens[$i] === '{') {
+                $brace_depth++;
+            } elseif ($tokens[$i] === '}') {
+                $brace_depth--;
+                while (!empty($class_stack) && end($class_stack)['depth'] >= $brace_depth) {
+                    array_pop($class_stack);
+                }
+            }
+        }
+
+        if ($i === $position) {
+            return !empty($class_stack) && end($class_stack)['inherits'];
+        }
+    }
+
+    return false;
+}
+
+/**
  * Pass 1: Process a single PHP file — rename declarations + bodies, record manifest.
+ *
+ * Safety rules:
+ * - Private methods: always safe to rename (callers are in the same file).
+ * - Standalone functions (no class): safe to rename within the scanned path.
+ * - Public/protected methods in classes that extend/implement: SKIP (report-only).
+ *   These may have callers in parent/child classes or external code that use
+ *   PHP 8 named arguments with the old parameter name.
  */
 function process_file_pass1($filepath) {
     $content = file_get_contents($filepath);
@@ -144,6 +260,24 @@ function process_file_pass1($filepath) {
         // Extract parameter names from the parameter list
         $renames = find_reserved_params($tokens, $paren_open, $paren_close);
         if (empty($renames)) {
+            continue;
+        }
+
+        // Safety check: skip public/protected methods in inheriting classes.
+        // These could be called with named arguments from code we can't see
+        // (parent classes, child classes, external consumers).
+        $visibility = detect_method_visibility($tokens, $i);
+        if (in_array($visibility, ['public', 'protected'], true) && is_in_inheriting_class($tokens, $i)) {
+            // Report-only: record what we would have renamed, but don't touch the code.
+            foreach ($renames as $old_var => $new_var) {
+                $method_display = $func_name ?? '(closure)';
+                $GLOBALS['rename_skipped'][] = [
+                    'method'    => $method_display,
+                    'old_param' => substr($old_var, 1),
+                    'new_param' => substr($new_var, 1),
+                    'file'      => $filepath,
+                ];
+            }
             continue;
         }
 
@@ -595,4 +729,71 @@ function find_matching_brace($tokens, $open, $count) {
         }
     }
     return null;
+}
+
+/**
+ * Verify no stale named argument call sites remain after Pass 2.
+ *
+ * Scans all PHP files in the path for patterns like "old_name:" that match
+ * renamed parameters. Returns a list of warning strings for any stale sites found.
+ *
+ * @param string $path     Root path to scan.
+ * @param array  $manifest The rename manifest from Pass 1.
+ * @return array List of warning strings.
+ */
+function verify_no_stale_named_args($path, $manifest) {
+    $warnings = [];
+
+    // Build list of old arg names to search for
+    $search_patterns = [];
+    foreach ($manifest as $method_name => $renames) {
+        foreach ($renames as $old_arg => $new_arg) {
+            $search_patterns[$old_arg] = [
+                'method'  => $method_name,
+                'new_arg' => $new_arg,
+            ];
+        }
+    }
+
+    if (empty($search_patterns)) {
+        return $warnings;
+    }
+
+    // Use grep to find potential stale call sites
+    foreach ($search_patterns as $old_arg => $info) {
+        // Search for "old_arg:" pattern (named argument syntax)
+        $cmd = sprintf(
+            'grep -rn --include="*.php" "%s\s*:" %s 2>/dev/null | grep -v vendor/ | grep -v node_modules/',
+            preg_quote($old_arg, '/'),
+            escapeshellarg($path)
+        );
+
+        $output = shell_exec($cmd);
+        if ($output === null || trim($output) === '') {
+            continue;
+        }
+
+        foreach (explode("\n", trim($output)) as $line) {
+            // Quick heuristic: check if this looks like a named argument context
+            // (inside a function call, preceded by ( or ,)
+            if (preg_match('/\b' . preg_quote($old_arg, '/') . '\s*:/', $line)) {
+                // Exclude function declarations, array keys, ternary, switch cases, goto labels
+                if (preg_match('/function\s/', $line)) {
+                    continue;
+                }
+                if (preg_match("/['\"]" . preg_quote($old_arg, '/') . "['\"]/", $line)) {
+                    continue; // String literal, not a named arg
+                }
+                if (preg_match('/^\s*\/\//', $line)) {
+                    continue; // Comment line
+                }
+                // Extract file:line for the warning
+                if (preg_match('/^(.+?:\d+):/', $line, $m)) {
+                    $warnings[] = "{$m[1]} — potential stale named arg '{$old_arg}:' (renamed to '{$info['new_arg']}:' for method {$info['method']})";
+                }
+            }
+        }
+    }
+
+    return $warnings;
 }

--- a/wordpress/scripts/lint/php-fixers/text-domain-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/text-domain-fixer.php
@@ -1,0 +1,300 @@
+#!/usr/bin/env php
+<?php
+/**
+ * WordPress Text Domain Fixer
+ *
+ * Fixes WordPress.WP.I18n.TextDomainMismatch errors by replacing incorrect
+ * text domain strings in i18n function calls with the correct domain from
+ * the plugin's header.
+ *
+ * This is fully deterministic: the correct text domain is declared in the
+ * plugin header ("Text Domain: slug"), and every i18n call in that plugin
+ * should use it. No human judgment needed.
+ *
+ * Handles all WordPress i18n functions:
+ *   __(), _e(), _x(), _ex(), _n(), _nx(), _n_noop(), _nx_noop(),
+ *   esc_html__(), esc_html_e(), esc_html_x(),
+ *   esc_attr__(), esc_attr_e(), esc_attr_x()
+ *
+ * Usage: php text-domain-fixer.php <path> [--text-domain=<domain>]
+ */
+
+require_once __DIR__ . '/fixer-helpers.php';
+
+if ($argc < 2) {
+    echo "Usage: php text-domain-fixer.php <path> [--text-domain=<domain>]\n";
+    exit(1);
+}
+
+$target_path = $argv[1];
+
+if (!file_exists($target_path)) {
+    echo "Error: Path not found: $target_path\n";
+    exit(1);
+}
+
+// Parse optional arguments.
+$text_domain = null;
+for ($i = 2; $i < $argc; $i++) {
+    if (strpos($argv[$i], '--text-domain=') === 0) {
+        $text_domain = substr($argv[$i], strlen('--text-domain='));
+    }
+}
+
+// Auto-detect text domain from plugin header if not provided.
+if ($text_domain === null) {
+    $text_domain = detect_text_domain($target_path);
+}
+
+if ($text_domain === null || $text_domain === '') {
+    echo "Error: Could not detect text domain. Use --text-domain=<domain> or add 'Text Domain:' to your plugin header.\n";
+    exit(1);
+}
+
+echo "Text domain: $text_domain\n";
+
+// Process files
+$GLOBALS['correct_domain'] = $text_domain;
+$result = fixer_process_path($target_path, 'fix_text_domain_in_file');
+
+if ($result['total_fixes'] > 0) {
+    echo "Text domain fixer: Fixed {$result['total_fixes']} text domain(s) in {$result['files_fixed']} file(s)\n";
+} else {
+    echo "Text domain fixer: No text domain mismatches found\n";
+}
+
+exit(0);
+
+/**
+ * Detect the correct text domain from the plugin header.
+ *
+ * Searches for the main plugin file (contains "Plugin Name:" in header)
+ * and extracts the "Text Domain:" value.
+ *
+ * @param string $path File or directory path.
+ * @return string|null The text domain, or null if not found.
+ */
+function detect_text_domain($path) {
+    $search_dir = is_dir($path) ? $path : dirname($path);
+
+    // Look for plugin files in the root of the path (maxdepth 1).
+    $candidates = glob($search_dir . '/*.php');
+    if ($candidates === false) {
+        return null;
+    }
+
+    foreach ($candidates as $file) {
+        $header = file_get_contents($file, false, null, 0, 8192);
+        if ($header === false) {
+            continue;
+        }
+
+        // Must have "Plugin Name:" to be a plugin header file.
+        if (stripos($header, 'Plugin Name:') === false) {
+            continue;
+        }
+
+        // Extract "Text Domain: slug" from the header.
+        if (preg_match('/Text\s+Domain:\s*(\S+)/i', $header, $m)) {
+            return trim($m[1]);
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Fix text domain mismatches in a single PHP file.
+ *
+ * @param string $filepath Path to the PHP file.
+ * @return int Number of fixes applied.
+ */
+function fix_text_domain_in_file($filepath) {
+    $content = file_get_contents($filepath);
+    if ($content === false) {
+        return 0;
+    }
+
+    $correct_domain = $GLOBALS['correct_domain'];
+
+    // WordPress i18n functions that take a text domain as the LAST argument.
+    // Group 1: domain is the 2nd arg  — __(), _e()
+    // Group 2: domain is the 3rd arg  — _x(), _ex(), _n_noop()
+    // Group 3: domain is the 4th arg  — _n()
+    // Group 4: domain is the 5th arg  — _nx(), _nx_noop()
+    // Group 5: domain is the 2nd arg  — esc_html__(), esc_html_e(), esc_attr__(), esc_attr_e()
+    // Group 6: domain is the 3rd arg  — esc_html_x(), esc_attr_x()
+    //
+    // Rather than tracking arg positions, we use a simpler approach:
+    // For all these functions, the text domain is ALWAYS the LAST string argument.
+    // We find the function call, locate the last string argument, and check if
+    // it matches the correct domain.
+
+    // Pattern matches i18n function calls.
+    // We use token-based parsing for accuracy.
+    $tokens = @token_get_all($content);
+    if ($tokens === false) {
+        return 0;
+    }
+
+    $i18n_functions = [
+        '__', '_e', '_x', '_ex', '_n', '_nx', '_n_noop', '_nx_noop',
+        'esc_html__', 'esc_html_e', 'esc_html_x',
+        'esc_attr__', 'esc_attr_e', 'esc_attr_x',
+    ];
+    $i18n_set = array_flip($i18n_functions);
+
+    $count  = count($tokens);
+    $fixes  = 0;
+
+    for ($i = 0; $i < $count; $i++) {
+        if (!is_array($tokens[$i]) || $tokens[$i][0] !== T_STRING) {
+            continue;
+        }
+
+        $func_name = $tokens[$i][1];
+        if (!isset($i18n_set[$func_name])) {
+            continue;
+        }
+
+        // Make sure this is a function call (followed by '(')
+        $paren_idx = find_next_non_ws($tokens, $i + 1, $count);
+        if ($paren_idx === null || is_array($tokens[$paren_idx]) || $tokens[$paren_idx] !== '(') {
+            continue;
+        }
+
+        // Make sure this is not a function declaration
+        $prev_idx = find_prev_non_ws($tokens, $i - 1);
+        if ($prev_idx !== null && is_array($tokens[$prev_idx]) && $tokens[$prev_idx][0] === T_FUNCTION) {
+            continue;
+        }
+
+        // Find the closing paren
+        $close_paren = find_close_paren($tokens, $paren_idx, $count);
+        if ($close_paren === null) {
+            continue;
+        }
+
+        // Find the last string literal argument (the text domain).
+        // Walk backward from close paren to find the last T_CONSTANT_ENCAPSED_STRING.
+        $domain_token_idx = find_last_string_arg($tokens, $paren_idx, $close_paren);
+        if ($domain_token_idx === null) {
+            continue;
+        }
+
+        // Extract the current domain value (strip quotes).
+        $current_value = $tokens[$domain_token_idx][1];
+        $quote_char    = $current_value[0]; // ' or "
+        $current_domain = substr($current_value, 1, -1);
+
+        // Skip if already correct.
+        if ($current_domain === $correct_domain) {
+            continue;
+        }
+
+        // Skip if this doesn't look like a text domain (contains variables, expressions, etc.)
+        if (strpos($current_domain, '$') !== false || strpos($current_domain, '{') !== false) {
+            continue;
+        }
+
+        // Replace with the correct domain.
+        $tokens[$domain_token_idx][1] = $quote_char . $correct_domain . $quote_char;
+        $fixes++;
+    }
+
+    if ($fixes === 0) {
+        return 0;
+    }
+
+    // Rebuild content from tokens.
+    $new_content = '';
+    foreach ($tokens as $token) {
+        $new_content .= is_array($token) ? $token[1] : $token;
+    }
+
+    file_put_contents($filepath, $new_content);
+    return $fixes;
+}
+
+/**
+ * Find the last string literal argument in a function call.
+ *
+ * Walks backward from the closing paren, skipping whitespace and looking
+ * for a T_CONSTANT_ENCAPSED_STRING that appears after a comma (i.e., it's
+ * the last argument, not part of a concatenation or array).
+ *
+ * @return int|null Token index of the last string argument, or null.
+ */
+function find_last_string_arg($tokens, $paren_open, $paren_close) {
+    // Walk backward from close paren to find the last string literal.
+    for ($i = $paren_close - 1; $i > $paren_open; $i--) {
+        if (is_array($tokens[$i]) && $tokens[$i][0] === T_WHITESPACE) {
+            continue;
+        }
+
+        if (is_array($tokens[$i]) && $tokens[$i][0] === T_CONSTANT_ENCAPSED_STRING) {
+            // Verify this string is preceded by a comma (it's a separate argument,
+            // not part of a concatenation).
+            $prev = find_prev_non_ws($tokens, $i - 1);
+            if ($prev !== null && !is_array($tokens[$prev]) && $tokens[$prev] === ',') {
+                return $i;
+            }
+            // If preceded by '(' it's the only/first argument — could be domain
+            // for functions like __('text', 'domain') where we want the second arg.
+            // In this case, walk further back to check.
+        }
+
+        // If we hit something that's not whitespace or a string, stop.
+        // The last argument isn't a simple string literal.
+        if (!is_array($tokens[$i]) || $tokens[$i][0] !== T_WHITESPACE) {
+            break;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Find the next non-whitespace token.
+ */
+function find_next_non_ws($tokens, $start, $count) {
+    for ($i = $start; $i < $count; $i++) {
+        if (is_array($tokens[$i]) && $tokens[$i][0] === T_WHITESPACE) {
+            continue;
+        }
+        return $i;
+    }
+    return null;
+}
+
+/**
+ * Find the previous non-whitespace token.
+ */
+function find_prev_non_ws($tokens, $start) {
+    for ($i = $start; $i >= 0; $i--) {
+        if (is_array($tokens[$i]) && $tokens[$i][0] === T_WHITESPACE) {
+            continue;
+        }
+        return $i;
+    }
+    return null;
+}
+
+/**
+ * Find matching closing parenthesis.
+ */
+function find_close_paren($tokens, $open, $count) {
+    $depth = 1;
+    for ($i = $open + 1; $i < $count; $i++) {
+        $tok = is_array($tokens[$i]) ? null : $tokens[$i];
+        if ($tok === '(') {
+            $depth++;
+        } elseif ($tok === ')') {
+            $depth--;
+            if ($depth === 0) {
+                return $i;
+            }
+        }
+    }
+    return null;
+}

--- a/wordpress/scripts/lint/php-fixers/unused-param-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/unused-param-fixer.php
@@ -12,7 +12,8 @@
  * Phase 2: Runs PHPCS to find UnusedFunctionParameter violations
  *
  * Phase 3: Cross-references each violation against the callback map to decide:
- *          - Contract-mandated param (callback/interface) → prefix with underscore
+ *          - Contract-mandated param (callback/interface) → insert unset() noop
+ *            (satisfies both PHPCS and PHPStan without expr.resultUnused noise)
  *          - Genuinely dead param (private, traceable callers) → remove from
  *            signature AND all call sites
  *          - Include-scope param ($data used by included templates) → skip
@@ -262,9 +263,14 @@ foreach ($by_file as $filepath => $file_violations) {
             $indent = detect_body_indent($lines, $insert_after + 1);
 
             // Build noop lines for each unused param.
+            // Use unset() as a PHPStan-safe noop that also satisfies PHPCS.
+            // Unlike bare "$param;" which triggers PHPStan expr.resultUnused,
+            // unset() is a real language construct that PHPStan recognizes as
+            // intentional. For contract-mandated callback parameters, this
+            // communicates "we received this but don't need it."
             $noop_lines = [];
             foreach ($info['params'] as $param) {
-                $noop_lines[] = $indent . $param . ';';
+                $noop_lines[] = $indent . 'unset( ' . $param . ' );';
                 $stats['noop_inserted']++;
             }
 

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -25,12 +25,27 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "HOMEBOY_PHPSTAN_LEVEL=${HOMEBOY_PHPSTAN_LEVEL:-NOT_SET}"
 fi
 
-# Skip if explicitly requested
+# Critical PHPStan error identifiers that indicate guaranteed runtime fatals.
+# These must NEVER be skipped, even with --skip-checks or HOMEBOY_SKIP_PHPSTAN=1.
+# Skipping these allows code that will crash on first request to reach production.
+CRITICAL_PHPSTAN_IDENTIFIERS="function.notFound|class.notFound"
+
+# Skip mode: when PHPStan is explicitly skipped, we still run a critical-only check.
+# This catches guaranteed runtime fatals (undefined functions/classes) while
+# respecting the user's intent to skip style-level static analysis.
+PHPSTAN_CRITICAL_ONLY=0
 if [[ "${HOMEBOY_SKIP_PHPSTAN:-}" == "1" ]]; then
-    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
-        echo "DEBUG: Skipping PHPStan (HOMEBOY_SKIP_PHPSTAN=1)"
+    if [[ "${HOMEBOY_SKIP_ALL_CHECKS:-}" == "1" ]]; then
+        # Explicit nuclear option — skip everything including critical checks.
+        # This is dangerous and should only be used in emergencies.
+        echo "WARNING: Skipping ALL PHPStan checks including fatal-class detection (HOMEBOY_SKIP_ALL_CHECKS=1)"
+        echo "         This may allow code with undefined functions/classes to pass validation."
+        exit 0
     fi
-    exit 0
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: PHPStan skipped but running critical-only check for fatal-class errors"
+    fi
+    PHPSTAN_CRITICAL_ONLY=1
 fi
 
 # Determine execution context
@@ -323,6 +338,10 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
 
             $level = $argv[1] ?? "5";
             $componentPath = $argv[2] ?? "";
+            $criticalOnly = ($argv[3] ?? "0") === "1";
+            $criticalPattern = $argv[4] ?? "function.notFound|class.notFound";
+
+            $criticalIdentifiers = explode("|", $criticalPattern);
 
             $totals = $json["totals"] ?? [];
             $errorCount = $totals["file_errors"] ?? 0;
@@ -330,24 +349,63 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
 
             if ($errorCount === 0) exit;
 
+            // When in critical-only mode, filter to just fatal-class errors
+            $filteredFiles = [];
+            $filteredErrorCount = 0;
+
+            foreach ($json["files"] ?? [] as $filePath => $data) {
+                $filteredMessages = [];
+                foreach ($data["messages"] ?? [] as $msg) {
+                    $identifier = $msg["identifier"] ?? "unknown";
+                    if ($criticalOnly) {
+                        $isCritical = false;
+                        foreach ($criticalIdentifiers as $crit) {
+                            if ($identifier === trim($crit)) {
+                                $isCritical = true;
+                                break;
+                            }
+                        }
+                        if (!$isCritical) continue;
+                    }
+                    $filteredMessages[] = $msg;
+                    $filteredErrorCount++;
+                }
+                if (!empty($filteredMessages)) {
+                    $filteredFiles[$filePath] = $filteredMessages;
+                }
+            }
+
+            if ($criticalOnly && $filteredErrorCount === 0) {
+                // No critical errors — skip output entirely
+                exit;
+            }
+
+            $displayErrorCount = $criticalOnly ? $filteredErrorCount : $errorCount;
+            $displayFileCount = $criticalOnly ? count($filteredFiles) : $fileCount;
+
             // Summary header
             echo "============================================\n";
-            echo "PHPSTAN SUMMARY: " . $errorCount . " errors at level " . $level . "\n";
-            echo "Files with issues: " . $fileCount . "\n";
+            if ($criticalOnly) {
+                echo "PHPSTAN CRITICAL: " . $displayErrorCount . " fatal-class error(s) found\n";
+                echo "These indicate guaranteed runtime fatals and cannot be skipped.\n";
+            } else {
+                echo "PHPSTAN SUMMARY: " . $displayErrorCount . " errors at level " . $level . "\n";
+            }
+            echo "Files with issues: " . $displayFileCount . "\n";
             echo "============================================\n";
 
             // Error details section
             echo "\nERRORS:\n";
             $identifiers = [];
 
-            foreach ($json["files"] ?? [] as $filePath => $data) {
+            foreach ($filteredFiles as $filePath => $messages) {
                 // Strip component path prefix for cleaner output
                 $displayPath = $filePath;
                 if ($componentPath && strpos($filePath, $componentPath) === 0) {
                     $displayPath = ltrim(substr($filePath, strlen($componentPath)), "/");
                 }
 
-                foreach ($data["messages"] ?? [] as $msg) {
+                foreach ($messages as $msg) {
                     $line = $msg["line"] ?? "?";
                     $message = $msg["message"] ?? "Unknown error";
                     $identifier = $msg["identifier"] ?? "unknown";
@@ -372,7 +430,13 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
                     if ($count >= 10) break;
                 }
             }
-        ' "$PHPSTAN_LEVEL" "$PLUGIN_PATH" 2>/dev/null)
+
+            // In critical-only mode, signal the caller that critical errors were found
+            // by writing a marker that the shell can check
+            if ($criticalOnly && $filteredErrorCount > 0) {
+                echo "\nCRITICAL_ERRORS_FOUND=" . $filteredErrorCount . "\n";
+            }
+        ' "$PHPSTAN_LEVEL" "$PLUGIN_PATH" "$PHPSTAN_CRITICAL_ONLY" "$CRITICAL_PHPSTAN_IDENTIFIERS" 2>/dev/null)
 
         if [ -n "$parsed_output" ]; then
             echo ""
@@ -424,6 +488,21 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
     fi
 
     # Exit with appropriate code
+    if [ "$PHPSTAN_CRITICAL_ONLY" -eq 1 ]; then
+        # In critical-only mode, only fail if critical errors were found
+        if echo "$parsed_output" | grep -q "CRITICAL_ERRORS_FOUND="; then
+            echo ""
+            echo "PHPStan critical check FAILED — fatal-class errors detected"
+            echo "These errors indicate undefined functions or classes that will crash at runtime."
+            echo "Fix these before releasing, even with --skip-checks."
+            exit 1
+        else
+            echo ""
+            echo "PHPStan critical check passed (style checks skipped)"
+            exit 0
+        fi
+    fi
+
     if [ "$json_exit" -eq 0 ]; then
         echo ""
         echo "PHPStan analysis passed"
@@ -436,6 +515,77 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
 fi
 
 # Full report mode (default)
+# In critical-only mode, we use JSON output to filter for fatal-class errors.
+# In normal mode, we show the full PHPStan text report.
+if [ "$PHPSTAN_CRITICAL_ONLY" -eq 1 ]; then
+    echo "Running PHPStan critical-only check (style checks skipped)..."
+    set +e
+    stderr_file=$(homeboy_mktemp 'phpstan-stderr-XXXXXX.log')
+    json_output=$("$PHPSTAN_BIN" "${phpstan_args[@]}" --error-format=json 2>"$stderr_file")
+    full_exit=$?
+    stderr_output=$(cat "$stderr_file")
+    rm -f "$stderr_file"
+    set -e
+
+    # Check for critical errors in JSON output
+    if [ -n "$json_output" ] && command -v php &> /dev/null; then
+        critical_count=$(echo "$json_output" | php -r '
+            $json = json_decode(file_get_contents("php://stdin"), true);
+            if (!$json) { echo "0"; exit; }
+            $criticalPattern = $argv[1] ?? "function.notFound|class.notFound";
+            $criticalIds = explode("|", $criticalPattern);
+            $count = 0;
+            foreach ($json["files"] ?? [] as $data) {
+                foreach ($data["messages"] ?? [] as $msg) {
+                    $id = $msg["identifier"] ?? "";
+                    foreach ($criticalIds as $crit) {
+                        if ($id === trim($crit)) { $count++; break; }
+                    }
+                }
+            }
+            echo $count;
+        ' "$CRITICAL_PHPSTAN_IDENTIFIERS" 2>/dev/null || echo "0")
+
+        if [ "$critical_count" -gt 0 ]; then
+            echo ""
+            echo "============================================"
+            echo "PHPSTAN CRITICAL: $critical_count fatal-class error(s) found"
+            echo "These indicate guaranteed runtime fatals and cannot be skipped."
+            echo "============================================"
+            # Show the critical errors
+            echo "$json_output" | php -r '
+                $json = json_decode(file_get_contents("php://stdin"), true);
+                if (!$json) exit;
+                $criticalPattern = $argv[1] ?? "function.notFound|class.notFound";
+                $componentPath = $argv[2] ?? "";
+                $criticalIds = explode("|", $criticalPattern);
+                foreach ($json["files"] ?? [] as $filePath => $data) {
+                    $displayPath = $filePath;
+                    if ($componentPath && strpos($filePath, $componentPath) === 0) {
+                        $displayPath = ltrim(substr($filePath, strlen($componentPath)), "/");
+                    }
+                    foreach ($data["messages"] ?? [] as $msg) {
+                        $id = $msg["identifier"] ?? "";
+                        $isCritical = false;
+                        foreach ($criticalIds as $crit) {
+                            if ($id === trim($crit)) { $isCritical = true; break; }
+                        }
+                        if (!$isCritical) continue;
+                        echo "  " . $displayPath . ":" . ($msg["line"] ?? "?") . "\n";
+                        echo "    " . ($msg["message"] ?? "Unknown") . "\n";
+                        echo "    [" . $id . "]\n\n";
+                    }
+                }
+            ' "$CRITICAL_PHPSTAN_IDENTIFIERS" "$PLUGIN_PATH" 2>/dev/null
+            echo "Fix these before releasing, even with --skip-checks."
+            exit 1
+        fi
+    fi
+
+    echo "PHPStan critical check passed (style checks skipped)"
+    exit 0
+fi
+
 set +e
 stderr_file=$(homeboy_mktemp 'phpstan-stderr-XXXXXX.log')
 "$PHPSTAN_BIN" "${phpstan_args[@]}" 2>"$stderr_file"


### PR DESCRIPTION
## Summary

Addresses the 4 highest-impact open issues plus a bonus fix for #137. All changes are in the WordPress extension's lint/fix pipeline.

## Changes

### #140 — PHPStan-safe noop pattern
- **Before:** Unused-param fixer inserted bare `$param;` statements for contract-mandated params → triggered PHPStan `expr.resultUnused`
- **After:** Uses `unset( $param );` — a real language construct that PHPStan recognizes as intentional, no more cross-tool noise

### #112 — Reserved-param rename safety guardrails
- **Before:** Renamed reserved params in ALL methods including public/protected in inheriting classes → could break PHP 8 named argument call sites in parent/child classes
- **After:**
  - Skips public/protected methods in classes with `extends`/`implements` (report-only mode)
  - Adds Pass 3 verification: greps for stale named argument patterns after rename and warns if any found
  - Private methods and standalone functions remain fully auto-fixed (safe scope)

### #111 — Critical-only PHPStan mode
- **Before:** `HOMEBOY_SKIP_PHPSTAN=1` skipped ALL analysis including `function.notFound`/`class.notFound` → allowed code with guaranteed runtime fatals to pass validation
- **After:**
  - Skip mode now runs a "critical-only" check that filters for fatal-class identifiers
  - `function.notFound` and `class.notFound` ALWAYS block, even with skip flags
  - New `HOMEBOY_SKIP_ALL_CHECKS=1` escape hatch for true emergencies (with loud warning)
  - Both summary and full report modes support critical-only filtering

### #137 — PHPStan ignored-pattern noise
- Set `reportUnmatchedIgnoredErrors: false` in `phpstan.neon.dist`
- Unmatched ignore patterns are now config hygiene warnings, not component code failures

### #110 — Text domain fixer (new)
- New `text-domain-fixer.php` for deterministic i18n text domain correction
- Auto-detects correct domain from plugin header (`Text Domain:` field)
- Token-based parsing handles all 14 WordPress i18n functions
- Wired into `lint-runner.sh` auto-fix pipeline (runs with `--text-domain` when detected)

## Closes
Closes #140, closes #112, closes #111, closes #110, closes #137