### PR TITLE
fix: decompose import resolver — detect functions, constants, and glob imports

### DIFF
--- a/rust/scripts/refactor/imports.py
+++ b/rust/scripts/refactor/imports.py
@@ -142,19 +142,34 @@ def resolve_imports(moved_items: list[dict], source_content: str, source_path: s
     # Collect all use statements from source
     source_uses = [l.strip() for l in source_lines if l.strip().startswith("use ")]
 
-    # Collect all type definitions in source file (for same-module type refs)
-    source_types = set()
+    # Collect all definitions in source file (types, functions, constants).
+    # These are items that were in scope for the moved code when it lived
+    # in the source file — the destination file needs imports for any it references.
+    source_definitions = set()
     for line in source_lines:
         trimmed = line.strip()
-        for prefix in ("pub struct ", "pub(crate) struct ", "struct ",
-                        "pub enum ", "pub(crate) enum ", "enum ",
-                        "pub type ", "pub(crate) type ", "type ",
-                        "pub trait ", "pub(crate) trait ", "trait "):
-            if trimmed.startswith(prefix):
-                rest = trimmed[len(prefix):]
-                name = re.split(r'[{(<;:\s]', rest)[0].strip()
+        # Strip visibility
+        rest = trimmed
+        for vis in ("pub(crate) ", "pub(super) ", "pub "):
+            if rest.startswith(vis):
+                rest = rest[len(vis):]
+                break
+        # Strip function modifiers (async, unsafe) but NOT const —
+        # const can be both a modifier (`const fn`) and a keyword (`const X`).
+        for modifier in ("async ", "unsafe "):
+            if rest.startswith(modifier):
+                rest = rest[len(modifier):]
+        for keyword in ("struct ", "enum ", "type ", "trait ", "fn ",
+                        "const ", "static "):
+            if rest.startswith(keyword):
+                after = rest[len(keyword):]
+                # For `const fn`, extract the function name after `fn`
+                if keyword == "const " and after.startswith("fn "):
+                    after = after[3:]
+                name = re.split(r'[{(<;:\s]', after)[0].strip()
                 if name:
-                    source_types.add(name)
+                    source_definitions.add(name)
+                break
 
     # Combined source of all moved items
     combined_source = '\n'.join(item.get("source", "") for item in moved_items)
@@ -175,25 +190,62 @@ def resolve_imports(moved_items: list[dict], source_content: str, source_path: s
             fixed = fix_import_path(use_stmt, source_path, dest_path)
             needed.append(fixed)
 
-    # Phase 2: Add imports for same-module types referenced by moved items (#339)
+    # Phase 2: Add imports for same-module definitions referenced by moved items (#339)
+    # This covers types, functions, and constants that were in scope because
+    # the moved code lived in the same file.
     source_mod = module_stem(source_path)
     same_parent = module_parent(source_path) == module_parent(dest_path)
 
-    for type_name in source_types:
-        if type_name in moved_item_names:
-            continue  # Type is being moved too, no import needed
-        # Check if the moved items reference this type
-        if re.search(r'\b' + re.escape(type_name) + r'\b', combined_source):
-            # Need to add an import for this type
+    for def_name in source_definitions:
+        if def_name in moved_item_names:
+            continue  # Item is being moved too, no import needed
+        # Check if the moved items reference this definition
+        if re.search(r'\b' + re.escape(def_name) + r'\b', combined_source):
+            # Need to add an import for this definition
             if same_parent:
-                import_line = f"use super::{source_mod}::{type_name};"
+                import_line = f"use super::{source_mod}::{def_name};"
             else:
                 # Different parent — use crate-level path
                 source_mod_path = file_to_module_path(source_path)
-                import_line = f"use crate::{source_mod_path}::{type_name};"
+                import_line = f"use crate::{source_mod_path}::{def_name};"
             # Check it's not already covered by existing use statements
-            already_covered = any(type_name in extract_use_names(u) for u in needed)
+            already_covered = any(def_name in extract_use_names(u) for u in needed)
             if not already_covered:
                 needed.append(import_line)
+
+    # Phase 3: Carry forward glob imports when moved code has unresolved references.
+    # When the source has `use foo::*;`, we can't statically resolve what symbols
+    # it provides. But if the moved code references identifiers that aren't covered
+    # by Phase 1 (explicit use statements) or Phase 2 (same-module definitions),
+    # the glob import is likely providing them.
+    glob_uses = [u for u in source_uses if u.rstrip(';').strip().endswith("::*")]
+    if glob_uses:
+        # Collect all names already covered by Phase 1 + Phase 2
+        covered_names = set()
+        for use_stmt in needed:
+            covered_names.update(extract_use_names(use_stmt))
+        covered_names.update(moved_item_names)
+        covered_names.update(source_definitions)
+
+        # Find identifiers in the moved code that look like they could be
+        # unresolved references (uppercase constants or PascalCase types
+        # are the most common glob-provided symbols)
+        all_idents = set(re.findall(r'\b([A-Z][A-Z_0-9]+|[A-Z][a-zA-Z0-9]+)\b', combined_source))
+        # Remove Rust keywords and known types
+        rust_builtins = {"Some", "None", "Ok", "Err", "Self", "Vec", "String",
+                         "Option", "Result", "Box", "Arc", "Rc", "HashMap",
+                         "HashSet", "Path", "PathBuf", "BTreeMap", "BTreeSet",
+                         "Cow", "Pin", "Future", "Iterator", "Display", "Debug",
+                         "Default", "Clone", "Copy", "Send", "Sync", "Sized",
+                         "From", "Into", "AsRef", "AsMut", "Deref", "Drop",
+                         "Fn", "FnMut", "FnOnce", "ToOwned", "ToString",
+                         "TRUE", "FALSE", "NULL"}
+        unresolved = all_idents - covered_names - rust_builtins
+
+        if unresolved:
+            for glob_use in glob_uses:
+                fixed = fix_import_path(glob_use, source_path, dest_path)
+                if fixed not in needed:
+                    needed.append(fixed)
 
     return {"needed_imports": needed, "warnings": warnings}

--- a/rust/scripts/refactor/test_imports.py
+++ b/rust/scripts/refactor/test_imports.py
@@ -1,0 +1,278 @@
+"""Tests for import resolution in decompose refactoring."""
+
+import unittest
+from .imports import resolve_imports, extract_use_names, fix_import_path
+
+
+class TestExtractUseNames(unittest.TestCase):
+    def test_simple_import(self):
+        self.assertEqual(extract_use_names("use std::path::Path;"), ["Path"])
+
+    def test_grouped_import(self):
+        names = extract_use_names("use std::path::{Path, PathBuf};")
+        self.assertIn("Path", names)
+        self.assertIn("PathBuf", names)
+
+    def test_alias_import(self):
+        self.assertEqual(extract_use_names("use foo::Bar as Baz;"), ["Baz"])
+
+    def test_glob_import(self):
+        # Glob imports don't produce terminal names
+        self.assertEqual(extract_use_names("use super::settings::*;"), [])
+
+
+class TestResolveImportsPhase2Functions(unittest.TestCase):
+    """Phase 2 should detect functions and constants, not just types."""
+
+    def test_detects_function_reference(self):
+        source = """use std::path::Path;
+
+pub(super) fn find_next_section_start(lines: &[&str]) -> Option<usize> {
+    lines.iter().position(|l| l.starts_with("## "))
+}
+
+pub(super) fn find_section_end(lines: &[&str], start: usize) -> usize {
+    start + 1
+}
+
+pub fn count_entries(content: &str) -> usize {
+    0
+}
+"""
+        moved_items = [{
+            "name": "count_entries",
+            "kind": "fn",
+            "source": """pub fn count_entries(content: &str) -> usize {
+    let start = find_next_section_start(&lines);
+    let end = find_section_end(&lines, start);
+    0
+}""",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/release/changelog/sections.rs",
+            "src/core/release/changelog/sections/unreleased.rs",
+        )
+        imports = result["needed_imports"]
+        import_text = "\n".join(imports)
+        self.assertIn("find_next_section_start", import_text)
+        self.assertIn("find_section_end", import_text)
+
+    def test_detects_constant_reference(self):
+        source = """const MAX_SIZE: usize = 100;
+
+pub fn check_size(n: usize) -> bool {
+    n < MAX_SIZE
+}
+"""
+        moved_items = [{
+            "name": "check_size",
+            "kind": "fn",
+            "source": "pub fn check_size(n: usize) -> bool { n < MAX_SIZE }",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/engine.rs",
+            "src/core/engine/check.rs",
+        )
+        imports = result["needed_imports"]
+        import_text = "\n".join(imports)
+        self.assertIn("MAX_SIZE", import_text)
+
+    def test_does_not_import_moved_item(self):
+        source = """pub fn helper() {}
+pub fn main_fn() { helper(); }
+"""
+        # Both items are being moved — no import needed for helper
+        moved_items = [
+            {"name": "helper", "kind": "fn", "source": "pub fn helper() {}"},
+            {"name": "main_fn", "kind": "fn", "source": "pub fn main_fn() { helper(); }"},
+        ]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/foo.rs",
+            "src/core/foo/bar.rs",
+        )
+        imports = result["needed_imports"]
+        # helper is being moved too, so no import should be generated for it
+        self.assertFalse(any("helper" in i for i in imports))
+
+
+class TestResolveImportsPhase3Globs(unittest.TestCase):
+    """Phase 3 should carry forward glob imports for unresolved references."""
+
+    def test_carries_glob_for_unresolved_constant(self):
+        source = """use super::settings::*;
+
+pub fn validate_content(lines: &[&str]) -> bool {
+    KEEP_A_CHANGELOG_SUBSECTIONS.iter().any(|h| lines[0].starts_with(h))
+}
+"""
+        moved_items = [{
+            "name": "validate_content",
+            "kind": "fn",
+            "source": """pub fn validate_content(lines: &[&str]) -> bool {
+    KEEP_A_CHANGELOG_SUBSECTIONS.iter().any(|h| lines[0].starts_with(h))
+}""",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/release/changelog/sections.rs",
+            "src/core/release/changelog/sections/normalize.rs",
+        )
+        imports = result["needed_imports"]
+        import_text = "\n".join(imports)
+        # The glob import should be carried forward since
+        # KEEP_A_CHANGELOG_SUBSECTIONS is unresolved
+        self.assertIn("settings::*", import_text)
+
+    def test_no_glob_when_all_resolved(self):
+        source = """use super::settings::*;
+
+const MY_CONST: usize = 42;
+
+pub fn uses_local() -> usize {
+    MY_CONST
+}
+"""
+        moved_items = [{
+            "name": "uses_local",
+            "kind": "fn",
+            "source": "pub fn uses_local() -> usize { MY_CONST }",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/foo.rs",
+            "src/core/foo/bar.rs",
+        )
+        imports = result["needed_imports"]
+        # MY_CONST is a local definition, so it's resolved by Phase 2.
+        # The glob import should NOT be carried.
+        self.assertFalse(any("::*" in i for i in imports))
+
+
+class TestResolveImportsRealWorldRegression(unittest.TestCase):
+    """Regression test for the changelog sections decomposition bug.
+
+    When sections.rs was decomposed, the extracted unreleased.rs called
+    find_next_section_start() and find_section_end() without importing them,
+    and normalize_heading_label.rs referenced KEEP_A_CHANGELOG_SUBSECTIONS
+    which came from a glob import (use super::settings::*).
+    """
+
+    def test_changelog_unreleased_extraction(self):
+        """Reproduces: unreleased.rs missing imports for parent functions."""
+        source = """use crate::engine::text;
+use super::settings::*;
+
+pub(super) fn find_next_section_start(lines: &[&str], aliases: &[String]) -> Option<usize> {
+    lines.iter().position(|line| is_matching_next_section_heading(line, aliases))
+}
+
+pub(super) fn find_section_end(lines: &[&str], start: usize) -> usize {
+    start + 1
+}
+
+pub fn count_unreleased_entries(content: &str, aliases: &[String]) -> usize {
+    let lines: Vec<&str> = content.lines().collect();
+    let start = match find_next_section_start(&lines, aliases) {
+        Some(idx) => idx,
+        None => return 0,
+    };
+    let end = find_section_end(&lines, start);
+    lines[start + 1..end].iter().filter(|l| l.trim().starts_with("- ")).count()
+}
+"""
+        moved_items = [{
+            "name": "count_unreleased_entries",
+            "kind": "fn",
+            "source": """pub fn count_unreleased_entries(content: &str, aliases: &[String]) -> usize {
+    let lines: Vec<&str> = content.lines().collect();
+    let start = match find_next_section_start(&lines, aliases) {
+        Some(idx) => idx,
+        None => return 0,
+    };
+    let end = find_section_end(&lines, start);
+    lines[start + 1..end].iter().filter(|l| l.trim().starts_with("- ")).count()
+}""",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/release/changelog/sections.rs",
+            "src/core/release/changelog/sections/unreleased.rs",
+        )
+        imports = result["needed_imports"]
+        import_text = "\n".join(imports)
+
+        # These functions stay in sections.rs — the extracted code must import them
+        self.assertIn("find_next_section_start", import_text,
+                       "Extracted code calls find_next_section_start but no import generated")
+        self.assertIn("find_section_end", import_text,
+                       "Extracted code calls find_section_end but no import generated")
+
+    def test_changelog_normalize_extraction_glob(self):
+        """Reproduces: normalize_heading_label.rs missing glob-provided constant."""
+        source = """use crate::engine::text;
+use super::settings::*;
+
+pub(crate) fn validate_section_content(body_lines: &[&str]) -> SectionContentStatus {
+    let mut has_subsection_headers = false;
+    for line in body_lines {
+        let trimmed = line.trim();
+        if KEEP_A_CHANGELOG_SUBSECTIONS.iter().any(|h| trimmed.starts_with(h)) {
+            has_subsection_headers = true;
+        }
+    }
+    SectionContentStatus::Empty
+}
+"""
+        moved_items = [{
+            "name": "validate_section_content",
+            "kind": "fn",
+            "source": """pub(crate) fn validate_section_content(body_lines: &[&str]) -> SectionContentStatus {
+    let mut has_subsection_headers = false;
+    for line in body_lines {
+        let trimmed = line.trim();
+        if KEEP_A_CHANGELOG_SUBSECTIONS.iter().any(|h| trimmed.starts_with(h)) {
+            has_subsection_headers = true;
+        }
+    }
+    SectionContentStatus::Empty
+}""",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/release/changelog/sections.rs",
+            "src/core/release/changelog/sections/normalize_heading_label.rs",
+        )
+        imports = result["needed_imports"]
+        import_text = "\n".join(imports)
+
+        # KEEP_A_CHANGELOG_SUBSECTIONS comes from `use super::settings::*;`
+        # The glob import must be carried forward
+        self.assertIn("settings::*", import_text,
+                       "Glob import should be carried for unresolved KEEP_A_CHANGELOG_SUBSECTIONS")
+
+
+class TestFixImportPath(unittest.TestCase):
+    def test_same_parent_keeps_super(self):
+        result = fix_import_path(
+            "use super::settings::*;",
+            "src/core/changelog/sections.rs",
+            "src/core/changelog/sections/types.rs",
+        )
+        # Different parent, super:: should be resolved
+        self.assertIn("settings", result)
+
+    def test_different_parent_resolves_super(self):
+        result = fix_import_path(
+            "use super::settings::CONST;",
+            "src/core/changelog/sections.rs",
+            "src/core/other/foo.rs",
+        )
+        self.assertIn("crate::", result)
+        self.assertIn("settings", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Fix Phase 2** import resolution to detect functions and constants, not just types
- **Add Phase 3** to carry forward glob imports (`use foo::*`) when extracted code has unresolved references
- **Add test suite** with 13 tests including regression tests for the exact bug

## Problem

PR #796 in homeboy auto-decomposed `sections.rs` into submodules. The extracted files had broken imports:

```
                    sections.rs (source)
                    ├─ use super::settings::*;     ← glob import
                    ├─ find_next_section_start()    ← fn definition
                    ├─ find_section_end()           ← fn definition
                    └─ count_unreleased_entries()   ← EXTRACTED →
                    
                    sections/unreleased.rs (dest)
                    ├─ ❌ find_next_section_start  (unresolved!)
                    └─ ❌ find_section_end          (unresolved!)
                    
                    sections/normalize_heading_label.rs (dest)
                    └─ ❌ KEEP_A_CHANGELOG_SUBSECTIONS  (unresolved! from glob)
```

**Root cause**: The import resolver's Phase 2 only detected **types** (struct, enum, trait, type) as same-module references. Functions and constants were silently ignored. Additionally, glob imports were never analyzed.

## Fix

### Phase 2: Expanded definition detection

| Before | After |
|---|---|
| `struct`, `enum`, `type`, `trait` | `struct`, `enum`, `type`, `trait`, **`fn`**, **`const`**, **`static`** |
| — | Handles `const fn` (const as modifier vs keyword) |
| — | Handles `async fn`, `unsafe fn`, `pub(super) fn`, etc. |

### Phase 3: Glob import forwarding (new)

When the source has `use foo::*;` and the extracted code contains uppercase identifiers (`SCREAMING_CASE` constants or `PascalCase` types) that aren't resolved by Phases 1-2, the glob import is carried forward to the destination file.

A curated set of Rust builtins (`Vec`, `String`, `Option`, `Result`, `Some`, `None`, etc.) is excluded from the unresolved check to avoid false positives.

## Testing

13 new tests in `test_imports.py`:

- **TestExtractUseNames** (4): simple, grouped, alias, glob
- **TestResolveImportsPhase2Functions** (3): function refs, constant refs, moved-item dedup
- **TestResolveImportsPhase3Globs** (2): glob carry-forward, glob skip when resolved
- **TestResolveImportsRealWorldRegression** (2): exact reproduction of the changelog bug
- **TestFixImportPath** (2): super path preservation and resolution