### PR TITLE
fix: comprehensive decompose import resolution v2

### DIFF
--- a/rust/scripts/refactor/imports.py
+++ b/rust/scripts/refactor/imports.py
@@ -12,7 +12,13 @@ from typing import Optional
 
 
 def extract_use_names(use_stmt: str) -> list[str]:
-    """Extract terminal name(s) from a Rust use statement."""
+    """Extract terminal name(s) from a Rust use statement.
+
+    For grouped imports with `self` (e.g., `use crate::foo::{self, Bar}`),
+    `self` brings the parent path's last segment into scope as a name.
+    So `use crate::engine::local_files::{self, FileSystem}` makes
+    `local_files` available as a name — we include it.
+    """
     names = []
     body = use_stmt.strip()
     if body.startswith("use "):
@@ -24,15 +30,23 @@ def extract_use_names(use_stmt: str) -> list[str]:
     if brace_start != -1:
         brace_end = body.find('}')
         if brace_end != -1:
+            path_prefix = body[:brace_start].rstrip(':').rstrip()
             inner = body[brace_start + 1:brace_end]
+            has_self = False
             for segment in inner.split(','):
                 name = segment.strip()
                 if name == "self":
+                    has_self = True
                     continue
                 if " as " in name:
                     names.append(name.split(" as ")[1].strip())
                 else:
                     names.append(name)
+            # `self` brings the last path segment into scope as a name
+            if has_self and "::" in path_prefix:
+                module_name = path_prefix.rsplit("::", 1)[-1]
+                if module_name:
+                    names.append(module_name)
     else:
         # Simple import
         last = body.rsplit("::", 1)[-1].strip()
@@ -42,6 +56,40 @@ def extract_use_names(use_stmt: str) -> list[str]:
             names.append(last)
 
     return names
+
+
+def _dest_is_child_of_source(source_path: str, dest_path: str) -> bool:
+    """Check if dest is a child module of source (decompose pattern).
+
+    When decomposing `src/core/big.rs` into `src/core/big/helpers.rs`,
+    the destination is inside the source module's directory. In Rust terms,
+    `super::` from the dest file points to the source module.
+
+    Examples:
+        _dest_is_child_of_source("src/core/big.rs", "src/core/big/helpers.rs") -> True
+        _dest_is_child_of_source("src/core/big.rs", "src/other/helpers.rs") -> False
+    """
+    source_stem = os.path.splitext(source_path)[0]  # "src/core/big"
+    dest_dir = os.path.dirname(dest_path)  # "src/core/big"
+    # Normalize: source_stem should match dest_dir for the decompose case
+    return os.path.normpath(source_stem) == os.path.normpath(dest_dir)
+
+
+def _is_self_group_import(use_stmt: str) -> bool:
+    """Check if a use statement is a grouped import containing `self`."""
+    body = use_stmt.strip().rstrip(';')
+    if not body.startswith("use "):
+        return False
+    path = body[4:].strip()
+    brace_start = path.find('{')
+    if brace_start == -1:
+        return False
+    brace_end = path.find('}')
+    if brace_end == -1:
+        return False
+    inner = path[brace_start + 1:brace_end]
+    items = [s.strip() for s in inner.split(',')]
+    return "self" in items
 
 
 def module_stem(file_path: str) -> str:
@@ -101,8 +149,11 @@ def resolve_super_path(path: str, source_path: str) -> Optional[str]:
 def fix_import_path(use_stmt: str, source_path: str, dest_path: str) -> str:
     """Fix a use statement's path relative to the destination file.
 
-    When both source and dest are in the same parent module, `super::` paths
-    remain correct. When they differ, we need to adjust.
+    Three cases:
+    1. Same parent module — `super::` paths remain correct.
+    2. Decompose (dest is child of source) — `super::` from source becomes
+       `super::super::` from dest (one extra level).
+    3. Different parents — resolve `super::` to absolute `crate::` paths.
     """
     source_parent = module_parent(source_path)
     dest_parent = module_parent(dest_path)
@@ -111,18 +162,25 @@ def fix_import_path(use_stmt: str, source_path: str, dest_path: str) -> str:
         # Same parent — super:: paths are still valid
         return use_stmt
 
-    # Different parents — convert super:: paths to crate:: paths
     trimmed = use_stmt.strip().rstrip(';')
     if not trimmed.startswith("use "):
         return use_stmt
 
     path_part = trimmed[4:].strip()
 
-    if path_part.startswith("super::"):
-        # Resolve the super:: relative to the source file
-        resolved = resolve_super_path(path_part, source_path)
-        if resolved:
-            return f"use {resolved};"
+    if not path_part.startswith("super::"):
+        # Not a super:: path — crate:: paths are always valid
+        return use_stmt
+
+    # Decompose case: dest is one level deeper than source.
+    # `super::X` from source becomes `super::super::X` from dest.
+    if _dest_is_child_of_source(source_path, dest_path):
+        return f"use super::{path_part};"
+
+    # General case: different parents — resolve to absolute crate:: path
+    resolved = resolve_super_path(path_part, source_path)
+    if resolved:
+        return f"use {resolved};"
 
     return use_stmt
 
@@ -189,12 +247,34 @@ def resolve_imports(moved_items: list[dict], source_content: str, source_path: s
             # Fix the import path relative to destination (#341)
             fixed = fix_import_path(use_stmt, source_path, dest_path)
             needed.append(fixed)
+        elif _is_self_group_import(use_stmt):
+            # For `use foo::{self, Trait}` where `self` brings a module into scope:
+            # if the module name (from `self`) is used via path syntax (e.g., `local_files::local()`),
+            # carry the ENTIRE grouped import — the trait companions are needed for method dispatch.
+            body = use_stmt.strip()
+            if body.startswith("use "):
+                path = body[4:].rstrip(';').strip()
+                brace_idx = path.find('{')
+                if brace_idx != -1:
+                    prefix = path[:brace_idx].rstrip(':').rstrip()
+                    module_name = prefix.rsplit("::", 1)[-1] if "::" in prefix else prefix
+                    # Check if the module is used as a path qualifier (e.g., `module_name::something`)
+                    if module_name and re.search(r'\b' + re.escape(module_name) + r'::', combined_source):
+                        fixed = fix_import_path(use_stmt, source_path, dest_path)
+                        if fixed not in needed:
+                            needed.append(fixed)
 
     # Phase 2: Add imports for same-module definitions referenced by moved items (#339)
     # This covers types, functions, and constants that were in scope because
     # the moved code lived in the same file.
     source_mod = module_stem(source_path)
-    same_parent = module_parent(source_path) == module_parent(dest_path)
+    source_parent = module_parent(source_path)
+    dest_parent = module_parent(dest_path)
+    same_parent = source_parent == dest_parent
+
+    # Check if dest is a child of source (decompose case: foo.rs -> foo/bar.rs)
+    # In this case, `super::` from dest points to source's module.
+    dest_is_child = _dest_is_child_of_source(source_path, dest_path)
 
     for def_name in source_definitions:
         if def_name in moved_item_names:
@@ -202,7 +282,11 @@ def resolve_imports(moved_items: list[dict], source_content: str, source_path: s
         # Check if the moved items reference this definition
         if re.search(r'\b' + re.escape(def_name) + r'\b', combined_source):
             # Need to add an import for this definition
-            if same_parent:
+            if dest_is_child:
+                # Decompose case: dest is inside source's module directory.
+                # `super::` from dest points directly to the source module.
+                import_line = f"use super::{def_name};"
+            elif same_parent:
                 import_line = f"use super::{source_mod}::{def_name};"
             else:
                 # Different parent — use crate-level path

--- a/rust/scripts/refactor/module_index.py
+++ b/rust/scripts/refactor/module_index.py
@@ -65,10 +65,30 @@ def generate_module_index(
             lines.append(f"pub use {name}::*;")
 
     # Add remaining content (impl blocks, private items, etc.)
+    # Inner doc comments (//!) must appear before any mod/use declarations
+    # in Rust, so we extract them and prepend them.
     if remaining_content and remaining_content.strip():
-        if lines:
-            lines.append("")  # Blank line separator
-        lines.append(remaining_content.rstrip())
+        remaining_lines = remaining_content.rstrip().split('\n')
+        doc_comments = []
+        other_lines = []
+        in_doc_prefix = True
+        for rline in remaining_lines:
+            stripped = rline.strip()
+            if in_doc_prefix and stripped.startswith("//!"):
+                doc_comments.append(rline)
+            else:
+                in_doc_prefix = False
+                other_lines.append(rline)
+
+        if doc_comments:
+            # Doc comments go at the very top, before mod declarations
+            doc_block = doc_comments + [""]
+            lines = doc_block + lines
+
+        if other_lines and '\n'.join(other_lines).strip():
+            if lines:
+                lines.append("")  # Blank line separator
+            lines.append('\n'.join(other_lines).rstrip())
 
     # Ensure trailing newline
     content = "\n".join(lines)

--- a/rust/scripts/refactor/test_imports.py
+++ b/rust/scripts/refactor/test_imports.py
@@ -2,6 +2,7 @@
 
 import unittest
 from .imports import resolve_imports, extract_use_names, fix_import_path
+from .module_index import generate_module_index
 
 
 class TestExtractUseNames(unittest.TestCase):
@@ -19,6 +20,17 @@ class TestExtractUseNames(unittest.TestCase):
     def test_glob_import(self):
         # Glob imports don't produce terminal names
         self.assertEqual(extract_use_names("use super::settings::*;"), [])
+
+    def test_self_group_import_extracts_module_name(self):
+        """use foo::{self, Bar} should extract both 'foo' (from self) and 'Bar'."""
+        names = extract_use_names("use crate::engine::local_files::{self, FileSystem};")
+        self.assertIn("local_files", names)
+        self.assertIn("FileSystem", names)
+
+    def test_self_group_import_without_companions(self):
+        """use foo::{self} should extract the module name."""
+        names = extract_use_names("use crate::engine::local_files::{self};")
+        self.assertIn("local_files", names)
 
 
 class TestResolveImportsPhase2Functions(unittest.TestCase):
@@ -83,7 +95,6 @@ pub fn check_size(n: usize) -> bool {
         source = """pub fn helper() {}
 pub fn main_fn() { helper(); }
 """
-        # Both items are being moved — no import needed for helper
         moved_items = [
             {"name": "helper", "kind": "fn", "source": "pub fn helper() {}"},
             {"name": "main_fn", "kind": "fn", "source": "pub fn main_fn() { helper(); }"},
@@ -94,8 +105,27 @@ pub fn main_fn() { helper(); }
             "src/core/foo/bar.rs",
         )
         imports = result["needed_imports"]
-        # helper is being moved too, so no import should be generated for it
         self.assertFalse(any("helper" in i for i in imports))
+
+    def test_decompose_uses_super_not_crate(self):
+        """When dest is a child of source, Phase 2 should use super:: not crate::."""
+        source = """pub fn stay_here() {}
+pub fn move_me() { stay_here(); }
+"""
+        moved_items = [{
+            "name": "move_me",
+            "kind": "fn",
+            "source": "pub fn move_me() { stay_here(); }",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/big.rs",
+            "src/core/big/helpers.rs",
+        )
+        imports = result["needed_imports"]
+        import_text = "\n".join(imports)
+        self.assertIn("use super::stay_here;", import_text)
+        self.assertNotIn("crate::", import_text)
 
 
 class TestResolveImportsPhase3Globs(unittest.TestCase):
@@ -122,8 +152,6 @@ pub fn validate_content(lines: &[&str]) -> bool {
         )
         imports = result["needed_imports"]
         import_text = "\n".join(imports)
-        # The glob import should be carried forward since
-        # KEEP_A_CHANGELOG_SUBSECTIONS is unresolved
         self.assertIn("settings::*", import_text)
 
     def test_no_glob_when_all_resolved(self):
@@ -146,22 +174,71 @@ pub fn uses_local() -> usize {
             "src/core/foo/bar.rs",
         )
         imports = result["needed_imports"]
-        # MY_CONST is a local definition, so it's resolved by Phase 2.
-        # The glob import should NOT be carried.
         self.assertFalse(any("::*" in i for i in imports))
 
 
-class TestResolveImportsRealWorldRegression(unittest.TestCase):
-    """Regression test for the changelog sections decomposition bug.
+class TestTraitImports(unittest.TestCase):
+    """Trait imports must be carried when self-imported module methods need them."""
 
-    When sections.rs was decomposed, the extracted unreleased.rs called
-    find_next_section_start() and find_section_end() without importing them,
-    and normalize_heading_label.rs referenced KEEP_A_CHANGELOG_SUBSECTIONS
-    which came from a glob import (use super::settings::*).
-    """
+    def test_self_group_carries_trait_for_method_dispatch(self):
+        """use foo::{self, Trait} should be carried when foo::method() is used."""
+        source = """use crate::engine::local_files::{self, FileSystem};
+
+pub fn read_version(path: &str) -> String {
+    let content = local_files::local().read(path).unwrap();
+    content
+}
+"""
+        moved_items = [{
+            "name": "read_version",
+            "kind": "fn",
+            "source": """pub fn read_version(path: &str) -> String {
+    let content = local_files::local().read(path).unwrap();
+    content
+}""",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/release/version.rs",
+            "src/core/release/version/helpers.rs",
+        )
+        imports = result["needed_imports"]
+        import_text = "\n".join(imports)
+        # The entire {self, FileSystem} import should be carried
+        # because local_files:: is used as a path qualifier
+        self.assertIn("local_files", import_text)
+        self.assertIn("FileSystem", import_text)
+
+    def test_simple_module_import_carried_for_path_usage(self):
+        """use crate::foo should be carried when foo::bar() is used."""
+        source = """use crate::engine::text;
+
+pub fn extract(content: &str) -> String {
+    text::extract_first(content, "pattern").unwrap()
+}
+"""
+        moved_items = [{
+            "name": "extract",
+            "kind": "fn",
+            "source": """pub fn extract(content: &str) -> String {
+    text::extract_first(content, "pattern").unwrap()
+}""",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/big.rs",
+            "src/core/big/helpers.rs",
+        )
+        imports = result["needed_imports"]
+        import_text = "\n".join(imports)
+        self.assertIn("text", import_text)
+
+
+class TestResolveImportsRealWorldRegression(unittest.TestCase):
+    """Regression tests for real decomposition failures from PR #797."""
 
     def test_changelog_unreleased_extraction(self):
-        """Reproduces: unreleased.rs missing imports for parent functions."""
+        """unreleased.rs missing imports for parent functions."""
         source = """use crate::engine::text;
 use super::settings::*;
 
@@ -203,15 +280,13 @@ pub fn count_unreleased_entries(content: &str, aliases: &[String]) -> usize {
         )
         imports = result["needed_imports"]
         import_text = "\n".join(imports)
-
-        # These functions stay in sections.rs — the extracted code must import them
-        self.assertIn("find_next_section_start", import_text,
-                       "Extracted code calls find_next_section_start but no import generated")
-        self.assertIn("find_section_end", import_text,
-                       "Extracted code calls find_section_end but no import generated")
+        self.assertIn("find_next_section_start", import_text)
+        self.assertIn("find_section_end", import_text)
+        # Decompose case: should use super:: not crate::
+        self.assertIn("use super::", import_text)
 
     def test_changelog_normalize_extraction_glob(self):
-        """Reproduces: normalize_heading_label.rs missing glob-provided constant."""
+        """normalize_heading_label.rs missing glob-provided constant."""
         source = """use crate::engine::text;
 use super::settings::*;
 
@@ -247,11 +322,46 @@ pub(crate) fn validate_section_content(body_lines: &[&str]) -> SectionContentSta
         )
         imports = result["needed_imports"]
         import_text = "\n".join(imports)
+        self.assertIn("settings::*", import_text)
 
-        # KEEP_A_CHANGELOG_SUBSECTIONS comes from `use super::settings::*;`
-        # The glob import must be carried forward
-        self.assertIn("settings::*", import_text,
-                       "Glob import should be carried for unresolved KEEP_A_CHANGELOG_SUBSECTIONS")
+    def test_version_local_files_trait(self):
+        """version/default_pattern_for_file.rs missing FileSystem trait import."""
+        source = """use crate::engine::local_files::{self, FileSystem};
+use crate::engine::text;
+
+pub fn read_local_version(local_path: &str, target: &VersionTarget) -> Option<String> {
+    let full_path = format!("{}/{}", local_path, target.file);
+    let content = local_files::local().read(std::path::Path::new(&full_path)).ok()?;
+    text::extract_first(&content, &target.pattern)
+}
+
+pub fn get_all_versions(component: &Component) -> Vec<String> {
+    let target = component.version_targets.as_ref().unwrap().first().unwrap();
+    let full_path = format!("{}/{}", component.local_path, target.file);
+    let content = local_files::local().read(std::path::Path::new(&full_path)).unwrap();
+    vec![content]
+}
+"""
+        moved_items = [{
+            "name": "get_all_versions",
+            "kind": "fn",
+            "source": """pub fn get_all_versions(component: &Component) -> Vec<String> {
+    let target = component.version_targets.as_ref().unwrap().first().unwrap();
+    let full_path = format!("{}/{}", component.local_path, target.file);
+    let content = local_files::local().read(std::path::Path::new(&full_path)).unwrap();
+    vec![content]
+}""",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/release/version.rs",
+            "src/core/release/version/default_pattern_for_file.rs",
+        )
+        imports = result["needed_imports"]
+        import_text = "\n".join(imports)
+        # Must carry the {self, FileSystem} import for local_files::local().read()
+        self.assertIn("local_files", import_text)
+        self.assertIn("FileSystem", import_text)
 
 
 class TestFixImportPath(unittest.TestCase):
@@ -259,12 +369,22 @@ class TestFixImportPath(unittest.TestCase):
         result = fix_import_path(
             "use super::settings::*;",
             "src/core/changelog/sections.rs",
+            "src/core/changelog/other.rs",
+        )
+        # Same parent — super:: stays
+        self.assertEqual(result, "use super::settings::*;")
+
+    def test_decompose_adds_extra_super(self):
+        """When dest is child of source, super:: gains one more level."""
+        result = fix_import_path(
+            "use super::settings::*;",
+            "src/core/changelog/sections.rs",
             "src/core/changelog/sections/types.rs",
         )
-        # Different parent, super:: should be resolved
-        self.assertIn("settings", result)
+        # Decompose: super:: from source -> super::super:: from dest
+        self.assertIn("super::super::settings::*", result)
 
-    def test_different_parent_resolves_super(self):
+    def test_different_parent_resolves_to_crate(self):
         result = fix_import_path(
             "use super::settings::CONST;",
             "src/core/changelog/sections.rs",
@@ -272,6 +392,50 @@ class TestFixImportPath(unittest.TestCase):
         )
         self.assertIn("crate::", result)
         self.assertIn("settings", result)
+
+    def test_crate_path_unchanged(self):
+        result = fix_import_path(
+            "use crate::engine::text;",
+            "src/core/big.rs",
+            "src/core/big/helpers.rs",
+        )
+        # crate:: paths are always valid
+        self.assertEqual(result, "use crate::engine::text;")
+
+
+class TestModuleIndex(unittest.TestCase):
+    """Module index generation must put doc comments before mod declarations."""
+
+    def test_doc_comments_precede_mod_declarations(self):
+        remaining = """//! This module handles big things.
+//!
+//! It's very important.
+
+use std::path::Path;
+
+pub fn remaining_fn() {}
+"""
+        result = generate_module_index(
+            [{"name": "helpers", "pub_items": []}, {"name": "types", "pub_items": []}],
+            remaining,
+        )
+        content = result["content"]
+        lines = content.split('\n')
+        # Find positions
+        first_doc = next(i for i, l in enumerate(lines) if l.strip().startswith("//!"))
+        first_mod = next(i for i, l in enumerate(lines) if l.strip().startswith("mod "))
+        self.assertLess(first_doc, first_mod,
+                         "Doc comments must appear before mod declarations")
+
+    def test_no_doc_comments_works_normally(self):
+        result = generate_module_index(
+            [{"name": "helpers", "pub_items": []}],
+            "pub fn remaining() {}",
+        )
+        content = result["content"]
+        self.assertIn("mod helpers;", content)
+        self.assertIn("pub use helpers::*;", content)
+        self.assertIn("pub fn remaining() {}", content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Systematically fix **all** import resolution failures observed in homeboy PR #797. Every fix has a regression test reproducing the exact real-world failure.

## Changes

### 1. Trait imports via self-group detection

**Problem:** `use crate::engine::local_files::{self, FileSystem}` wasn't carried when moved code called `local_files::local().read()`. The `self` keyword brings the module into scope but we were skipping it, and `FileSystem` (the trait) doesn't appear literally in the code.

**Fix:**
- `extract_use_names` now resolves `self` to the parent path's last segment (`local_files`)
- Phase 1 carries entire `{self, Trait}` grouped imports when the module name is used as a path qualifier (`foo::bar()`)

### 2. Decompose-aware `super::` path handling

**Problem:** Phase 2 generated `use crate::core::release::version::find_version_pattern_in_extension;` (absolute path) when the dest file is one directory deeper than source. This works but is noisy and sometimes the crate path doesn't resolve correctly.

**Fix:**
- `_dest_is_child_of_source()` detects the decompose pattern (`foo.rs` → `foo/helpers.rs`)
- Phase 2 emits `use super::def_name;` for decompose case (cleaner, always correct)
- `fix_import_path` adds extra `super::` level: source's `super::X` becomes `super::super::X` from dest

### 3. Doc comment ordering in `module_index.py`

**Problem:** Generated `mod.rs` placed inner doc comments (`//!`) after `mod` and `pub use` declarations → Rust error E0753.

**Fix:** Extract doc comments from remaining content and prepend them before module declarations.

## Testing

**23 tests** (was 13), all passing. New coverage:

| Test class | Tests | Covers |
|---|---|---|
| `TestExtractUseNames` | 6 | self-group module name extraction |
| `TestTraitImports` | 2 | self-group carry for method dispatch, simple module path |
| `TestResolveImportsPhase2` | 4 | decompose uses `super::` not `crate::` |
| `TestFixImportPath` | 4 | decompose extra super level, crate path passthrough |
| `TestModuleIndex` | 2 | doc comments before mod declarations |
| `TestRealWorldRegression` | 3 | changelog, version/local_files |
| `TestPhase3Globs` | 2 | glob carry/skip |

Closes #149