### PR TITLE
feat(wordpress): audit reference dependencies — resolve WP core + plugin deps

### DIFF
--- a/wordpress/scripts/audit/setup-references.sh
+++ b/wordpress/scripts/audit/setup-references.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Audit reference dependency setup for WordPress extension.
+#
+# Resolves WordPress core + plugin dependencies and exports
+# HOMEBOY_AUDIT_REFERENCE_PATHS so homeboy's audit can include them
+# in cross-reference analysis (dead code detection).
+#
+# Usage:
+#   source scripts/audit/setup-references.sh
+#   homeboy audit <component>
+#
+# Or in CI:
+#   eval "$(bash scripts/audit/setup-references.sh --export)"
+#
+# This reuses the same WordPress core cache as the test runner.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=../lib/validation-dependencies.sh
+source "$EXTENSION_PATH/scripts/lib/validation-dependencies.sh"
+
+# Resolve plugin path from homeboy context
+PLUGIN_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
+if [ ! -d "$PLUGIN_PATH" ]; then
+    echo "Warning: Plugin path not found: $PLUGIN_PATH" >&2
+    exit 0
+fi
+
+# Determine WordPress version from composer.lock or fallback
+WP_VERSION=""
+if [ -f "${EXTENSION_PATH}/composer.lock" ]; then
+    WP_VERSION=$(grep -A5 '"name": "wp-phpunit/wp-phpunit"' "${EXTENSION_PATH}/composer.lock" \
+        | grep '"version"' | head -1 \
+        | sed 's/.*"version": "\([^"]*\)".*/\1/' || true)
+fi
+if [ -z "$WP_VERSION" ]; then
+    WP_VERSION=$(composer show wp-phpunit/wp-phpunit --working-dir="${EXTENSION_PATH}" 2>/dev/null \
+        | grep '^versions' | awk '{print $NF}' || echo "6.9.1")
+fi
+
+# WordPress core cache directory (shared with test runner)
+WP_CACHE_BASE="${HOMEBOY_CACHE_DIR:-${HOME}/.cache/homeboy}/wordpress"
+WP_CACHE_DIR="${WP_CACHE_BASE}/${WP_VERSION}"
+WP_CORE_PATH="${WP_CACHE_DIR}/wordpress"
+
+# Download WordPress if not cached
+if [ ! -f "${WP_CORE_PATH}/wp-includes/version.php" ]; then
+    echo "Downloading WordPress ${WP_VERSION} for audit references..." >&2
+    mkdir -p "${WP_CACHE_DIR}"
+
+    WP_DOWNLOAD_URL="https://wordpress.org/wordpress-${WP_VERSION}.tar.gz"
+
+    if command -v curl &> /dev/null; then
+        if ! curl -sL "$WP_DOWNLOAD_URL" | tar xz -C "${WP_CACHE_DIR}"; then
+            echo "Warning: Failed to download WordPress ${WP_VERSION}" >&2
+            exit 0
+        fi
+    elif command -v wget &> /dev/null; then
+        if ! wget -qO- "$WP_DOWNLOAD_URL" | tar xz -C "${WP_CACHE_DIR}"; then
+            echo "Warning: Failed to download WordPress ${WP_VERSION}" >&2
+            exit 0
+        fi
+    else
+        echo "Warning: Neither curl nor wget available for WordPress download" >&2
+        exit 0
+    fi
+    echo "WordPress ${WP_VERSION} cached at ${WP_CORE_PATH}" >&2
+fi
+
+# Build reference paths: WordPress core + plugin dependencies
+REFERENCE_PATHS="${WP_CORE_PATH}"
+
+# Resolve plugin dependencies via validation-dependencies.sh
+DEP_PATHS=$(homeboy_resolve_validation_dependency_paths "$PLUGIN_PATH" 2>/dev/null || true)
+if [ -n "$DEP_PATHS" ]; then
+    while IFS= read -r dep_path; do
+        [ -n "$dep_path" ] && [ -d "$dep_path" ] && REFERENCE_PATHS="${REFERENCE_PATHS}"$'\n'"${dep_path}"
+    done <<< "$DEP_PATHS"
+fi
+
+export HOMEBOY_AUDIT_REFERENCE_PATHS="$REFERENCE_PATHS"
+
+# Count paths for logging
+PATH_COUNT=$(echo "$REFERENCE_PATHS" | wc -l | tr -d ' ')
+echo "Audit reference dependencies: ${PATH_COUNT} path(s) resolved (WP ${WP_VERSION})" >&2
+
+# If --export flag passed, print the export statement for eval
+if [ "${1:-}" = "--export" ]; then
+    # Escape newlines for shell export
+    printf 'export HOMEBOY_AUDIT_REFERENCE_PATHS=%q\n' "$REFERENCE_PATHS"
+fi

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -156,6 +156,7 @@
     }
   },
   "audit": {
+    "setup_references": "scripts/audit/setup-references.sh",
     "ignore_claim_patterns": [
       "/wp-json/**",
       "/*-auth/**",


### PR DESCRIPTION
## Summary

- **Add audit reference setup script** — downloads/caches WordPress core and resolves plugin dependencies so homeboy's audit can include them in cross-reference analysis (dead code detection).
- **Reuses existing infrastructure** — same WP core cache as the test runner, same dependency resolution via `validation-dependencies.sh`.

## What it does

When `homeboy audit data-machine` runs:

1. Homeboy reads `audit.setup_references` from the extension manifest
2. Runs `scripts/audit/setup-references.sh --export`
3. Script downloads WP core (cached), resolves plugin deps, exports `HOMEBOY_AUDIT_REFERENCE_PATHS`
4. Audit fingerprints WP core + deps, includes them in dead code cross-reference set
5. Functions called via `add_action`, `add_filter`, inherited methods, etc. are recognized as referenced

## Impact on data-machine audit

Current state: ~7,400 findings, ~95% false positives from WordPress hook callbacks, callback parameter contracts, and base class methods.

Expected after: most `unreferenced_export` and `unused_parameter` findings for WordPress-registered callbacks will be eliminated because the audit can see that WordPress core calls those functions.

## Files changed (2)

| File | Change |
|------|--------|
| `wordpress/scripts/audit/setup-references.sh` | **New** — download WP core, resolve deps, export `HOMEBOY_AUDIT_REFERENCE_PATHS` |
| `wordpress/wordpress.json` | Add `audit.setup_references` field |

## Companion PR

Homeboy core: Extra-Chill/homeboy#809 — adds `setup_references` manifest field, `fingerprint_reference_paths()`, env var reading, and command-level setup script execution.