### PR TITLE
fix(wordpress): add hook callbacks to internal_calls in fingerprinter

### DIFF
--- a/wordpress/scripts/fingerprint.sh
+++ b/wordpress/scripts/fingerprint.sh
@@ -385,6 +385,12 @@ for m in re.finditer(r'\b([a-z_]\w*)\s*\(', content):
                 'extract', 'var_dump', 'print_r', 'var_export'}
     if name not in skip_php and not name.startswith('test'):
         internal_calls.add(name)
+# Hook callbacks are called by WordPress core via the hook system —
+# they ARE referenced, just not by direct function calls in this file.
+# Adding them to internal_calls ensures dead code detection sees them
+# as referenced when the file that registers the hook is fingerprinted.
+internal_calls.update(hook_callbacks)
+
 internal_calls = sorted(internal_calls)
 
 # --- Unused Parameters (#114) ---


### PR DESCRIPTION
## Summary

**One-line fix** that eliminates the majority of false `unreferenced_export` audit findings for WordPress plugins.

## Problem

The fingerprinter already extracts hook callbacks (methods registered via `add_action`/`add_filter`) into a `hook_callbacks` field, but only used them to suppress unused parameter warnings. The dead code analyzer never saw these methods as referenced — they weren't in `internal_calls`.

## Fix

Add `hook_callbacks` to `internal_calls` so dead code detection recognizes these methods as called (by WordPress core, via the hook system).

```python
# Before: hook_callbacks only used for unused param suppression
internal_calls = sorted(internal_calls)

# After: hook_callbacks ARE calls — WordPress core invokes them
internal_calls.update(hook_callbacks)
internal_calls = sorted(internal_calls)
```

## Expected impact

The fingerprinter already matches:
- `add_action('hook', [$this, 'method'])`
- `add_action('hook', [self::class, 'method'])`
- `add_action('hook', 'function_name')`
- `add_filter(...)` (same patterns)
- `register_activation_hook(...)`
- Ability `execute_callback` / `permission_callback` arrays

All of these will now be recognized as referenced in the dead code analyzer, eliminating the corresponding `unreferenced_export` findings.