### PR TITLE
fix(wordpress): add skip_test_patterns for test mapping

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -205,7 +205,19 @@
       "test_file_pattern": "tests/Unit/{dir}/{name}Test.{ext}",
       "method_prefix": "test_",
       "inline_tests": false,
-      "critical_patterns": ["Abilities/", "Core/"]
+      "critical_patterns": ["Abilities/", "Core/"],
+      "skip_test_patterns": [
+        ".js",
+        ".jsx",
+        ".ts",
+        ".tsx",
+        ".css",
+        ".scss",
+        ".json",
+        "/assets/",
+        "/Admin/Pages/",
+        "/Admin/Settings/"
+      ]
     },
     "doc_targets": {
       "Post Types": {


### PR DESCRIPTION
Exclude JS/JSX/CSS files and admin UI registration classes from PHP test file mapping. These were generating ~147 false missing_test_file findings.