### PR TITLE
feat(rust): add cargo fix step + format script

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "fingerprint": "scripts/fingerprint.sh",
-    "refactor": "scripts/refactor.sh"
+    "refactor": "scripts/refactor.sh",
+    "format": "scripts/format.sh"
   },
   "lint": {
     "extension_script": "scripts/lint-runner.sh"

--- a/rust/scripts/format.sh
+++ b/rust/scripts/format.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Rust formatter for homeboy's post-write formatting.
+# Called by engine::format_write after refactor --write applies code.
+
+if [ -n "${HOMEBOY_COMPONENT_PATH:-}" ]; then
+    PROJECT_PATH="${HOMEBOY_COMPONENT_PATH}"
+else
+    PROJECT_PATH="$(pwd)"
+fi
+
+if [ ! -f "${PROJECT_PATH}/Cargo.toml" ]; then
+    echo "No Cargo.toml found — skipping format"
+    exit 0
+fi
+
+cargo fmt --manifest-path "${PROJECT_PATH}/Cargo.toml" 2>&1

--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -270,5 +270,40 @@ else
     echo "Skipping cargo clippy (step filter)"
 fi
 
+# ── Step 3: cargo fix (compiler warnings) ──
+# Only in fix mode — applies compiler suggestions for dead_code, unused_imports,
+# unused_variables, etc. These are the warnings that `cargo check` reports.
+if should_run_step "fix"; then
+    if [ "${HOMEBOY_AUTO_FIX:-}" = "1" ]; then
+        echo ""
+        echo "Running cargo fix (compiler warnings)..."
+
+        set +e
+        FIX_OUTPUT=$(cargo fix \
+            --manifest-path "${PROJECT_PATH}/Cargo.toml" \
+            --allow-dirty --allow-staged \
+            --lib --bins 2>&1)
+        FIX_EXIT=$?
+        set -e
+
+        if [ $FIX_EXIT -eq 0 ]; then
+            echo "cargo fix: applied compiler warning fixes"
+        else
+            # cargo fix failure is non-fatal in fix mode — some warnings
+            # can't be auto-fixed (e.g., dead_code on pub items).
+            echo "cargo fix: exited non-zero (${FIX_EXIT}), continuing"
+            if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+                echo "DEBUG: cargo fix output:"
+                echo "$FIX_OUTPUT"
+            fi
+        fi
+    else
+        echo ""
+        echo "Skipping cargo fix (only runs in fix mode)"
+    fi
+else
+    echo "Skipping cargo fix (step filter)"
+fi
+
 echo ""
 echo "Rust lint checks passed"


### PR DESCRIPTION
## Summary

- **Lint runner**: adds step 3 — \`cargo fix\` in fix mode to auto-fix compiler warnings (\`dead_code\`, \`unused_imports\`, \`unused_variables\`)
- **Format script**: new \`scripts/format.sh\` for homeboy's \`engine::format_write\` module (runs \`cargo fmt\` after refactor --write)
- **Manifest**: registers \`scripts.format\` in \`rust.json\`

## Why

Compiler warnings are 9 of the 686 audit findings (#810). \`cargo fix\` handles most of them automatically. Adding it to the lint runner's fix mode means the autofix pipeline can clear these without human intervention.

The format script supports homeboy/homeboy#817 — after \`refactor --write\` generates code, the format module looks for an extension-provided \`scripts.format\` and runs it.

## Changes

| File | Change |
|---|---|
| \`rust/scripts/lint-runner.sh\` | Add step 3: \`cargo fix\` when \`HOMEBOY_AUTO_FIX=1\` |
| \`rust/scripts/format.sh\` | New: runs \`cargo fmt\` for post-write formatting |
| \`rust/rust.json\` | Register \`scripts.format\` in manifest |