### PR TITLE
feat(wordpress): write lint findings sidecar for categorized issues

### DIFF
--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -516,6 +516,66 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
             }
         ' "$PLUGIN_PATH" "${HOMEBOY_ANNOTATIONS_DIR}" 2>/dev/null || true
     fi
+
+    # Write lint findings sidecar for homeboy baseline and categorized issues.
+    # Transforms PHPCS JSON report into the LintFinding format homeboy expects:
+    #   [{id: "file::source::line", message: "...", category: "..."}]
+    # Category is derived from the top-level PHPCS source namespace.
+    if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
+        echo "$json_output" | php -r '
+            $json = json_decode(file_get_contents("php://stdin"), true);
+            if (!$json || empty($json["files"])) {
+                file_put_contents($argv[2], "[]");
+                exit;
+            }
+            $componentPath = $argv[1] ?? "";
+            $categoryMap = [
+                "WordPress.Security" => "security",
+                "WordPress.WP.I18n" => "i18n",
+                "WordPress.PHP.YodaConditions" => "yoda",
+                "WordPress.WhiteSpace" => "whitespace",
+                "WordPress.DB" => "database",
+                "WordPress.WP.AlternativeFunctions" => "wp-alternatives",
+                "WordPress.WP.GlobalVariablesOverride" => "globals",
+                "WordPress.CodeAnalysis" => "code-analysis",
+                "WordPress.NamingConventions" => "naming",
+                "WordPress.PHP.StrictComparisons" => "strict-comparisons",
+                "WordPress.PHP.StrictInArray" => "strict-comparisons",
+                "Generic.CodeAnalysis" => "code-analysis",
+                "Generic.PHP" => "php",
+                "Generic.Formatting" => "formatting",
+                "Squiz" => "formatting",
+                "PEAR" => "formatting",
+                "PSR" => "formatting",
+                "PHPCompatibility" => "compatibility",
+            ];
+            $findings = [];
+            foreach ($json["files"] as $filePath => $data) {
+                $relPath = $filePath;
+                if ($componentPath && strpos($filePath, $componentPath) === 0) {
+                    $relPath = ltrim(substr($filePath, strlen($componentPath)), "/");
+                }
+                foreach ($data["messages"] ?? [] as $msg) {
+                    $source = $msg["source"] ?? "unknown";
+                    $line = $msg["line"] ?? 0;
+                    // Derive category from source namespace
+                    $category = "other";
+                    foreach ($categoryMap as $prefix => $cat) {
+                        if (strpos($source, $prefix) === 0) {
+                            $category = $cat;
+                            break;
+                        }
+                    }
+                    $findings[] = [
+                        "id" => $relPath . "::" . $source . "::" . $line,
+                        "message" => ($msg["message"] ?? "Unknown") . " (" . $source . ")",
+                        "category" => $category,
+                    ];
+                }
+            }
+            file_put_contents($argv[2], json_encode($findings, JSON_UNESCAPED_SLASHES) . "\n");
+        ' "$PLUGIN_PATH" "${HOMEBOY_LINT_FINDINGS_FILE}" 2>/dev/null || true
+    fi
 fi
 
 # Summary mode: show summary header + top violations, skip full report


### PR DESCRIPTION
## Summary

Adds `HOMEBOY_LINT_FINDINGS_FILE` sidecar writing to the WordPress extension's lint runner. This is the extension-side piece that enables homeboy-action's new categorized lint auto-issues.

- Transforms PHPCS JSON report into homeboy's `LintFinding` format: `[{id, message, category}]`
- Category mapping covers all common WordPress coding standards sniff families
- Written after PHPCS JSON parsing, before both summary and full report modes

## How it works

```
PHPCS JSON output                     LintFinding sidecar
┌─────────────────────┐              ┌───────────────────────────────────┐
│ files:               │              │ [                                 │
│   "src/Foo.php":     │  transform   │   {                               │
│     messages:        │ ──────────►  │     "id": "src/Foo.php::WP...::42"│
│       source: "WP.." │              │     "message": "Missing esc...",  │
│       line: 42       │              │     "category": "security"        │
│       message: "..."│              │   }                               │
└─────────────────────┘              │ ]                                 │
                                     └───────────────────────────────────┘
```

### Category mapping

| PHPCS source prefix | Category |
|---|---|
| `WordPress.Security` | `security` |
| `WordPress.WP.I18n` | `i18n` |
| `WordPress.PHP.YodaConditions` | `yoda` |
| `WordPress.WhiteSpace` | `whitespace` |
| `WordPress.DB` | `database` |
| `WordPress.WP.AlternativeFunctions` | `wp-alternatives` |
| `WordPress.CodeAnalysis` | `code-analysis` |
| `WordPress.NamingConventions` | `naming` |
| `PHPCompatibility` | `compatibility` |
| Everything else | `other` |

## Context

Part of the categorized auto-issues initiative:
- **homeboy-action#97** — Extends the auto-issue system to handle lint/test (merged or pending)
- **data-machine#856** — Adoption tracking issue

Without this sidecar, `lint_findings` in homeboy's JSON output is always `[]` for WordPress, and the auto-issue system falls back to generic aggregate issues. With it, lint issues get properly categorized.