### PR TITLE
feat(wordpress): add php -l syntax validation gate

### DIFF
--- a/wordpress/scripts/validation/validate-syntax.sh
+++ b/wordpress/scripts/validation/validate-syntax.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Post-write PHP syntax validation for homeboy's validate_write gate.
+#
+# Runs `php -l` on all PHP source files in the project root, excluding
+# vendor/, node_modules/, and common non-source directories.
+#
+# Called by homeboy after `audit --fix --write` or `refactor` applies changes.
+# Runs from the project root (CWD = component source path).
+#
+# Exit 0 = all files pass syntax check
+# Exit 1 = at least one syntax error found (homeboy will rollback)
+
+set -uo pipefail
+
+ROOT="${PWD}"
+errors=0
+error_output=""
+
+while IFS= read -r -d '' php_file; do
+    if result=$(php -l "$php_file" 2>&1); then
+        : # syntax OK
+    else
+        errors=$((errors + 1))
+        error_output+="${result}"$'\n'
+    fi
+done < <(find "$ROOT" \
+    -name '*.php' \
+    -not -path '*/vendor/*' \
+    -not -path '*/node_modules/*' \
+    -not -path '*/.git/*' \
+    -print0)
+
+if [ "$errors" -gt 0 ]; then
+    echo "PHP syntax validation failed: ${errors} file(s) with errors" >&2
+    echo "$error_output" >&2
+    exit 1
+fi
+
+echo "PHP syntax OK"
+exit 0

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -6,12 +6,13 @@
   "author": "Extra Chill",
   "provides": {
     "file_extensions": ["php", "css", "ts", "tsx", "js", "jsx", "json"],
-    "capabilities": ["fingerprint", "refactor", "crossref"]
+    "capabilities": ["fingerprint", "refactor", "crossref", "validate"]
   },
   "scripts": {
     "fingerprint": "scripts/fingerprint.sh",
     "refactor": "scripts/refactor.py",
-    "crossref": "scripts/test/crossref.php"
+    "crossref": "scripts/test/crossref.php",
+    "validate": "scripts/validation/validate-syntax.sh"
   },
   "platform": {
     "config_schema": "wordpress",


### PR DESCRIPTION
## Summary

- Adds `scripts/validation/validate-syntax.sh` — runs `php -l` on all PHP source files (excludes vendor/node_modules)
- Registers it as `scripts.validate` in `wordpress.json`
- Adds `validate` to the extension's capabilities list

This enables homeboy's `validate_write` gate for PHP projects. After `audit --fix --write` or `refactor` commands modify PHP files, homeboy automatically runs this script. If any file has a syntax error, **all changes are rolled back**.

## Testing

- ✅ Catches syntax errors (tested with intentionally broken PHP)
- ✅ Passes clean on Data Machine (~300 PHP files, 16s runtime)
- ✅ `audit --fix --write --only stale_doc_reference` ran successfully with gate active

## Performance

~16s on a 300-file WordPress plugin. Runs once per convergence iteration (up to 3x). Acceptable for a safety gate.