### PR TITLE
feat: add behavioral test gen grammars for Rust and PHP (#818)

### DIFF
--- a/rust/grammar.toml
+++ b/rust/grammar.toml
@@ -257,75 +257,301 @@ panic_patterns = [
 ]
 
 # ===========================================================================
+# Type defaults — zero/default value expressions for test input construction.
+# Each entry has: pattern (regex matched against param type), value (code expr),
+# and optional imports (extra `use` statements needed by the value).
+# Patterns are tried in order; first match wins.
+# ===========================================================================
+
+[[contract.type_defaults]]
+pattern = '^&str$'
+value = '""'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^&\[u8\]$'
+value = 'Vec::<u8>::new()'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^&\[.*\]$'
+value = 'Vec::new()'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^&Path$'
+value = 'Path::new("")'
+imports = ['use std::path::Path;']
+
+[[contract.type_defaults]]
+pattern = '^&PathBuf$'
+value = 'PathBuf::new()'
+imports = ['use std::path::PathBuf;']
+
+[[contract.type_defaults]]
+pattern = '^PathBuf$'
+value = 'PathBuf::new()'
+imports = ['use std::path::PathBuf;']
+
+[[contract.type_defaults]]
+pattern = '^String$'
+value = 'String::new()'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^&String$'
+value = 'String::new()'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^bool$'
+value = 'false'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^usize$|^u8$|^u16$|^u32$|^u64$|^u128$'
+value = '0'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^isize$|^i8$|^i16$|^i32$|^i64$|^i128$'
+value = '0'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^f32$|^f64$'
+value = '0.0'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^char$'
+value = "'a'"
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^Vec<.*>$'
+value = 'Vec::new()'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^HashMap<.*>$'
+value = 'HashMap::new()'
+imports = ['use std::collections::HashMap;']
+
+[[contract.type_defaults]]
+pattern = '^HashSet<.*>$'
+value = 'HashSet::new()'
+imports = ['use std::collections::HashSet;']
+
+[[contract.type_defaults]]
+pattern = '^Option<.*>$'
+value = 'None'
+imports = []
+
+# ===========================================================================
+# Type constructors — behavioral value expressions for condition-driven setup.
+# Core produces semantic hints (e.g., "empty", "nonexistent_path"); this section
+# maps (hint, type_pattern) → language-specific code expression.
+# ===========================================================================
+
+fallback_default = 'Default::default()'
+
+[[contract.type_constructors]]
+hint = 'empty'
+pattern = '^&?\[.*\]$|^Vec<.*>$'
+value = 'Vec::new()'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'empty'
+pattern = '^&str$|^String$|^&String$'
+value = '""'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'empty'
+pattern = '^HashMap<.*>$'
+value = 'HashMap::new()'
+imports = ['use std::collections::HashMap;']
+
+[[contract.type_constructors]]
+hint = 'empty'
+pattern = '^HashSet<.*>$'
+value = 'HashSet::new()'
+imports = ['use std::collections::HashSet;']
+
+[[contract.type_constructors]]
+hint = 'non_empty'
+pattern = '^&?\[.*\]$|^Vec<.*>$'
+value = 'vec![Default::default()]'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'non_empty'
+pattern = '^&str$|^String$|^&String$'
+value = '"test_{param_name}"'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'none'
+pattern = '^Option<.*>$'
+value = 'None'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'some_default'
+pattern = '^Option<.*>$'
+value = 'Some(Default::default())'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'nonexistent_path'
+pattern = '(?i)path'
+value = 'Path::new("/tmp/nonexistent_test_path_818")'
+imports = ['use std::path::Path;']
+
+[[contract.type_constructors]]
+hint = 'existent_path'
+pattern = '(?i)path'
+value = 'tempfile::tempdir().unwrap()'
+call_arg = '{param_name}.path()'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'true'
+pattern = '^bool$'
+value = 'true'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'false'
+pattern = '^bool$'
+value = 'false'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'zero'
+pattern = '^u\w+$|^i\w+$|^f\w+$'
+value = '0'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'positive'
+pattern = '^u\w+$|^i\w+$|^f\w+$'
+value = '1'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'contains'
+pattern = '^&str$|^String$|^&String$'
+value = '"{hint_arg}"'
+imports = []
+
+# ===========================================================================
+# Assertion templates — language-specific assertion code for behavioral tests.
+# Core selects an assertion key; this section provides the code template.
+# Variables: {condition}, {expected_value}, {variant}
+# ===========================================================================
+
+[contract.assertion_templates]
+result_ok = '        assert!(result.is_ok(), "expected Ok for: {condition}");'
+result_ok_value = """        let inner = result.unwrap();
+        // Branch returns Ok({expected_value}) when: {condition}
+        let _ = inner; // TODO: assert specific value for "{expected_value}\""""
+result_err = '        assert!(result.is_err(), "expected Err for: {condition}");'
+result_err_value = """        let err = result.unwrap_err();
+        // Branch returns Err({expected_value}) when: {condition}
+        let err_msg = format!("{:?}", err);
+        let _ = err_msg; // TODO: assert error contains "{expected_value}\""""
+option_some = '        assert!(result.is_some(), "expected Some for: {condition}");'
+option_some_value = """        let inner = result.expect("expected Some for: {condition}");
+        // Branch returns Some({expected_value})
+        let _ = inner; // TODO: assert value matches "{expected_value}\""""
+option_none = '        assert!(result.is_none(), "expected None for: {condition}");'
+bool_true = '        assert!(result, "expected true when: {condition}");'
+bool_false = '        assert!(!result, "expected false when: {condition}");'
+collection_empty = '        assert!(result.is_empty(), "expected empty collection for: {condition}");'
+collection_non_empty = '        assert!(!result.is_empty(), "expected non-empty collection for: {condition}");'
+
+# ===========================================================================
 # Test templates — Rust source code templates for test plan rendering.
-# Variables: {test_name}, {fn_name}, {param_names}, {return_shape},
-#            {variant}, {expected_value}, {ok_type}, {err_type},
-#            {some_type}, {condition}, {is_method}, {is_pure}
+#
+# Variables:
+#   {test_name}      — generated test function name
+#   {fn_name}        — function under test
+#   {param_setup}    — `let` bindings for each parameter (condition-aware)
+#   {param_args}     — comma-separated call arguments (condition-aware)
+#   {param_names}    — comma-separated parameter names (raw)
+#   {assertion_code} — behavioral assertion derived from branch return + condition
+#   {return_shape}   — "result", "option", "bool", "unit", "collection", etc.
+#   {extra_imports}  — `use` statements needed by parameter defaults
+#   {variant}        — return variant: "ok", "err", "some", "none", "true", "false"
+#   {expected_value} — description of the branch return value
+#   {ok_type}, {err_type}, {some_type} — generic type parameters
+#   {condition}      — human-readable branch condition
+#   {is_method}      — "true" if function has a receiver
+#   {is_pure}        — "true" if function has no side effects
 # ===========================================================================
 
 [contract.test_templates]
 
-# Result<T,E> — Ok branch
+# Result<T,E> — Ok branch (uses behavioral assertion)
 result_ok = """
     #[test]
     fn {test_name}() {
-        // Branch: {condition}
-        // Expected: Ok({expected_value})
-        let result = {fn_name}({param_names});
-        assert!(result.is_ok(), "expected Ok for: {condition}");
+{param_setup}
+        let result = {fn_name}({param_args});
+{assertion_code}
     }
 """
 
-# Result<T,E> — Err branch
+# Result<T,E> — Err branch (uses behavioral assertion)
 result_err = """
     #[test]
     fn {test_name}() {
-        // Branch: {condition}
-        // Expected: Err
-        let result = {fn_name}({param_names});
-        assert!(result.is_err(), "expected Err for: {condition}");
+{param_setup}
+        let result = {fn_name}({param_args});
+{assertion_code}
     }
 """
 
-# Option<T> — Some branch
+# Option<T> — Some branch (uses behavioral assertion)
 option_some = """
     #[test]
     fn {test_name}() {
-        // Branch: {condition}
-        // Expected: Some({expected_value})
-        let result = {fn_name}({param_names});
-        assert!(result.is_some(), "expected Some for: {condition}");
+{param_setup}
+        let result = {fn_name}({param_args});
+{assertion_code}
     }
 """
 
-# Option<T> — None branch
+# Option<T> — None branch (uses behavioral assertion)
 option_none = """
     #[test]
     fn {test_name}() {
-        // Branch: {condition}
-        // Expected: None
-        let result = {fn_name}({param_names});
-        assert!(result.is_none(), "expected None for: {condition}");
+{param_setup}
+        let result = {fn_name}({param_args});
+{assertion_code}
     }
 """
 
-# bool — true branch
+# bool — true branch (uses behavioral assertion)
 bool_true = """
     #[test]
     fn {test_name}() {
-        // Branch: {condition}
-        let result = {fn_name}({param_names});
-        assert!(result, "expected true for: {condition}");
+{param_setup}
+        let result = {fn_name}({param_args});
+{assertion_code}
     }
 """
 
-# bool — false branch
+# bool — false branch (uses behavioral assertion)
 bool_false = """
     #[test]
     fn {test_name}() {
-        // Branch: {condition}
-        let result = {fn_name}({param_names});
-        assert!(!result, "expected false for: {condition}");
+{param_setup}
+        let result = {fn_name}({param_args});
+{assertion_code}
     }
 """
 
@@ -333,8 +559,8 @@ bool_false = """
 unit = """
     #[test]
     fn {test_name}() {
-        // Should not panic
-        {fn_name}({param_names});
+{param_setup}
+        {fn_name}({param_args});
     }
 """
 
@@ -342,9 +568,8 @@ unit = """
 no_panic = """
     #[test]
     fn {test_name}() {
-        // No branches detected — verify basic invocation doesn't panic.
-        // TODO: add specific assertions once contract extraction improves.
-        let _ = {fn_name}({param_names});
+{param_setup}
+        let _ = {fn_name}({param_args});
     }
 """
 
@@ -352,20 +577,19 @@ no_panic = """
 effects = """
     #[test]
     fn {test_name}() {
-        // Verify expected effects: {effects}
-        // This test documents the function's side effects.
-        // TODO: add effect-specific assertions (mock fs, capture output, etc.)
-        let _ = {fn_name}({param_names});
+        // Expected effects: {effects}
+{param_setup}
+        let _ = {fn_name}({param_args});
     }
 """
 
-# Collection return — verify non-empty or specific length
+# Collection return — uses behavioral assertion
 collection = """
     #[test]
     fn {test_name}() {
-        // Branch: {condition}
-        let result = {fn_name}({param_names});
-        assert!(!result.is_empty(), "expected non-empty collection for: {condition}");
+{param_setup}
+        let result = {fn_name}({param_args});
+{assertion_code}
     }
 """
 
@@ -373,8 +597,7 @@ collection = """
 default = """
     #[test]
     fn {test_name}() {
-        // Branch: {condition}
-        let _result = {fn_name}({param_names});
-        // TODO: add specific assertion for return value
+{param_setup}
+        let _result = {fn_name}({param_args});
     }
 """

--- a/wordpress/grammar.toml
+++ b/wordpress/grammar.toml
@@ -216,3 +216,483 @@ skip_strings = false
 
 [patterns.add_shortcode.captures]
 name = 1
+
+# ===========================================================================
+# Contract — function body analysis for test generation & effect detection
+# ===========================================================================
+
+[contract]
+# PHP return type separator: function foo(): ReturnType
+return_type_separator = ":"
+# PHP parameter format: Type $name (or just $name for untyped)
+param_format = "type_dollar_name"
+
+# Side effect detection patterns
+[contract.effects]
+file_read = [
+  'file_get_contents\s*\(',
+  'fopen\s*\(',
+  'fread\s*\(',
+  'file\s*\(',
+  'readfile\s*\(',
+  'wp_filesystem',
+  'get_option\s*\(',
+  'get_transient\s*\(',
+  'get_post_meta\s*\(',
+  'get_user_meta\s*\(',
+]
+file_write = [
+  'file_put_contents\s*\(',
+  'fwrite\s*\(',
+  'fclose\s*\(',
+  'update_option\s*\(',
+  'set_transient\s*\(',
+  'update_post_meta\s*\(',
+  'update_user_meta\s*\(',
+  'wp_insert_post\s*\(',
+  'wp_update_post\s*\(',
+  '\$wpdb->insert\s*\(',
+  '\$wpdb->update\s*\(',
+  '\$wpdb->replace\s*\(',
+]
+file_delete = [
+  'unlink\s*\(',
+  'rmdir\s*\(',
+  'delete_option\s*\(',
+  'delete_transient\s*\(',
+  'delete_post_meta\s*\(',
+  'wp_delete_post\s*\(',
+  '\$wpdb->delete\s*\(',
+]
+process_spawn = [
+  'exec\s*\(',
+  'shell_exec\s*\(',
+  'system\s*\(',
+  'passthru\s*\(',
+  'proc_open\s*\(',
+  'WP_CLI::runcommand\s*\(',
+]
+mutation = [
+  '->save\s*\(',
+  '->store\s*\(',
+  '->persist\s*\(',
+  '\[\]\s*=',
+  'array_push\s*\(',
+  'array_splice\s*\(',
+  'unset\s*\(',
+]
+network = [
+  'wp_remote_get\s*\(',
+  'wp_remote_post\s*\(',
+  'wp_remote_request\s*\(',
+  'wp_safe_remote_get\s*\(',
+  'wp_safe_remote_post\s*\(',
+  'curl_exec\s*\(',
+  'curl_init\s*\(',
+  '\$http->',
+]
+logging = [
+  'error_log\s*\(',
+  'wp_die\s*\(',
+  'trigger_error\s*\(',
+  'WP_CLI::log\s*\(',
+  'WP_CLI::success\s*\(',
+  'WP_CLI::warning\s*\(',
+  'WP_CLI::error\s*\(',
+]
+
+# Guard clause patterns
+guard_patterns = [
+  'if\s*\(.*\)\s*\{\s*return\s+',
+  'if\s*\(\s*empty\s*\(',
+  'if\s*\(\s*!\s*\$',
+  'if\s*\(\s*is_wp_error\s*\(',
+  'if\s*\(\s*!\s*is_',
+  'if\s*\(\s*null\s*===',
+  'if\s*\(\s*\$\w+\s*===\s*null',
+]
+
+# Return variant patterns
+[contract.return_patterns]
+ok = ['return\s+new\s+WP_REST_Response\b']
+err = ['return\s+new\s+WP_Error\b', 'throw\s+new\s+\\\\?Exception', 'throw\s+new\s+\\\\?\w+Exception']
+some = ['return\s+\$\w+\s*;']
+none = ['\breturn\s+null\s*;']
+true = ['\breturn\s+true\s*;']
+false = ['\breturn\s+false\s*;']
+
+# Error propagation patterns
+error_propagation = [
+  'throw\s+',
+  'wp_die\s*\(',
+]
+
+# Return type shape detection (matched against the return type after ":")
+[contract.return_shapes]
+bool = ['^\s*bool\s*$']
+collection = ['^\s*array\s*$', '^\s*iterable\s*$', 'Collection']
+option = ['^\s*\?', '^\s*null\|', '\|null\s*$']
+result = ['WP_Error\s*\|', '\|\s*WP_Error', 'WP_REST_Response']
+
+# Panic path patterns
+panic_patterns = [
+  'wp_die\s*\(',
+  'exit\s*[\(;]',
+  'die\s*\(',
+  'throw\s+new\s+',
+  'trigger_error\s*\(.+E_USER_ERROR',
+]
+
+# ===========================================================================
+# Type defaults — zero/default value expressions for PHP test input construction
+# ===========================================================================
+
+[[contract.type_defaults]]
+pattern = '^string$'
+value = "''"
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^\?string$'
+value = 'null'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^int$'
+value = '0'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^\?int$'
+value = 'null'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^float$'
+value = '0.0'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^bool$'
+value = 'false'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^array$'
+value = '[]'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^\?array$'
+value = 'null'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^void$'
+value = ''
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^callable$'
+value = "function() {}"
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^\\\\?Closure$'
+value = "function() {}"
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^mixed$'
+value = 'null'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^\?object$'
+value = 'null'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^object$'
+value = 'new \\stdClass()'
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^\\\\?WP_REST_Request$'
+value = "new \\WP_REST_Request()"
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^\\\\?WP_Post$'
+value = "get_post( self::factory()->post->create() )"
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^\\\\?WP_User$'
+value = "get_userdata( self::factory()->user->create() )"
+imports = []
+
+[[contract.type_defaults]]
+pattern = '^\?'
+value = 'null'
+imports = []
+
+# ===========================================================================
+# Type constructors — behavioral value expressions for condition-driven setup.
+# Core produces semantic hints (e.g., "empty", "nonexistent_path"); this section
+# maps (hint, type_pattern) → PHP-specific code expression.
+# ===========================================================================
+
+fallback_default = 'null'
+
+# ── empty: produce a value where empty($x) == true ──
+[[contract.type_constructors]]
+hint = 'empty'
+pattern = '^array$|^\?array$'
+value = '[]'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'empty'
+pattern = '^string$|^\?string$'
+value = "''"
+imports = []
+
+# ── non_empty: produce a value where !empty($x) ──
+[[contract.type_constructors]]
+hint = 'non_empty'
+pattern = '^array$|^\?array$'
+value = "[ 'test_value' ]"
+imports = []
+
+[[contract.type_constructors]]
+hint = 'non_empty'
+pattern = '^string$|^\?string$'
+value = "'test_{param_name}'"
+imports = []
+
+# ── none / some_default: nullable variants ──
+[[contract.type_constructors]]
+hint = 'none'
+pattern = '^\?'
+value = 'null'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'some_default'
+pattern = '^\?string$'
+value = "'test_value'"
+imports = []
+
+[[contract.type_constructors]]
+hint = 'some_default'
+pattern = '^\?int$'
+value = '1'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'some_default'
+pattern = '^\?array$'
+value = "[ 'test' ]"
+imports = []
+
+[[contract.type_constructors]]
+hint = 'some_default'
+pattern = '^\?object$'
+value = 'new \stdClass()'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'some_default'
+pattern = '^\?'
+value = 'new \stdClass()'
+imports = []
+
+# ── path existence ──
+[[contract.type_constructors]]
+hint = 'nonexistent_path'
+pattern = '^string$|^\?string$'
+value = "'/tmp/nonexistent_test_path_818'"
+imports = []
+
+[[contract.type_constructors]]
+hint = 'existent_path'
+pattern = '^string$|^\?string$'
+value = "sys_get_temp_dir() . '/homeboy_test_' . uniqid()"
+imports = []
+
+# ── boolean values ──
+[[contract.type_constructors]]
+hint = 'true'
+pattern = '^bool$'
+value = 'true'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'false'
+pattern = '^bool$'
+value = 'false'
+imports = []
+
+# ── numeric values ──
+[[contract.type_constructors]]
+hint = 'zero'
+pattern = '^int$|^\?int$|^float$|^\?float$'
+value = '0'
+imports = []
+
+[[contract.type_constructors]]
+hint = 'positive'
+pattern = '^int$|^\?int$|^float$|^\?float$'
+value = '1'
+imports = []
+
+# ── string content ──
+[[contract.type_constructors]]
+hint = 'contains'
+pattern = '^string$|^\?string$'
+value = "'{hint_arg}'"
+imports = []
+
+# ===========================================================================
+# Assertion templates — PHPUnit-specific assertion code for behavioral tests.
+# Core selects an assertion key; this section provides the code template.
+# Variables: {condition}, {expected_value}, {variant}
+# ===========================================================================
+
+[contract.assertion_templates]
+result_ok = "        $this->assertNotWPError( $result, 'Expected success for: {condition}' );"
+result_ok_value = """        $this->assertNotWPError( $result, 'Expected success for: {condition}' );
+        // Branch returns success ({expected_value}) when: {condition}"""
+result_err = "        $this->assertWPError( $result, 'Expected WP_Error for: {condition}' );"
+result_err_value = """        $this->assertWPError( $result, 'Expected WP_Error for: {condition}' );
+        // Branch returns error ({expected_value}) when: {condition}
+        $this->assertSame( '{expected_value}', $result->get_error_code() );"""
+option_some = "        $this->assertNotNull( $result, 'Expected non-null for: {condition}' );"
+option_some_value = """        $this->assertNotNull( $result, 'Expected non-null for: {condition}' );
+        // Branch returns ({expected_value}) when: {condition}"""
+option_none = "        $this->assertNull( $result, 'Expected null for: {condition}' );"
+bool_true = "        $this->assertTrue( $result, 'Expected true when: {condition}' );"
+bool_false = "        $this->assertFalse( $result, 'Expected false when: {condition}' );"
+collection_empty = "        $this->assertIsArray( $result );\n        $this->assertEmpty( $result, 'Expected empty array for: {condition}' );"
+collection_non_empty = "        $this->assertIsArray( $result );\n        $this->assertNotEmpty( $result, 'Expected non-empty array for: {condition}' );"
+
+# ===========================================================================
+# Test templates — PHPUnit source code templates for test plan rendering
+#
+# Variables:
+#   {test_name}      — generated test method name
+#   {fn_name}        — method under test
+#   {param_setup}    — variable assignments (condition-aware)
+#   {param_args}     — comma-separated call arguments (condition-aware)
+#   {param_names}    — comma-separated parameter names (raw)
+#   {assertion_code} — behavioral assertion from assertion_templates
+#   {return_shape}   — "result", "option", "bool", "unit", "collection", etc.
+#   {extra_imports}  — extra use/require statements
+#   {variant}        — return variant
+#   {expected_value} — description of branch return value
+#   {condition}      — human-readable branch condition
+#   {is_method}      — "true" if function has a receiver
+# ===========================================================================
+
+[contract.test_templates]
+
+# Return true branch (uses behavioral assertion)
+bool_true = """
+    public function {test_name}() {
+{param_setup}
+        $result = $this->instance->{fn_name}({param_args});
+{assertion_code}
+    }
+"""
+
+# Return false branch (uses behavioral assertion)
+bool_false = """
+    public function {test_name}() {
+{param_setup}
+        $result = $this->instance->{fn_name}({param_args});
+{assertion_code}
+    }
+"""
+
+# Nullable — Some/non-null branch (uses behavioral assertion)
+option_some = """
+    public function {test_name}() {
+{param_setup}
+        $result = $this->instance->{fn_name}({param_args});
+{assertion_code}
+    }
+"""
+
+# Nullable — null branch (uses behavioral assertion)
+option_none = """
+    public function {test_name}() {
+{param_setup}
+        $result = $this->instance->{fn_name}({param_args});
+{assertion_code}
+    }
+"""
+
+# WP_Error / exception — success branch (uses behavioral assertion)
+result_ok = """
+    public function {test_name}() {
+{param_setup}
+        $result = $this->instance->{fn_name}({param_args});
+{assertion_code}
+    }
+"""
+
+# WP_Error / exception — error branch (uses behavioral assertion)
+result_err = """
+    public function {test_name}() {
+{param_setup}
+        $result = $this->instance->{fn_name}({param_args});
+{assertion_code}
+    }
+"""
+
+# Unit/void return — just verify no exception
+unit = """
+    public function {test_name}() {
+{param_setup}
+        $this->instance->{fn_name}({param_args});
+        $this->addToAssertionCount(1);
+    }
+"""
+
+# No branches detected — basic invocation test
+no_panic = """
+    public function {test_name}() {
+{param_setup}
+        $result = $this->instance->{fn_name}({param_args});
+        $this->assertNotNull( $result );
+    }
+"""
+
+# Effect verification
+effects = """
+    public function {test_name}() {
+        // Expected effects: {effects}
+{param_setup}
+        $this->instance->{fn_name}({param_args});
+        $this->addToAssertionCount(1);
+    }
+"""
+
+# Collection return (uses behavioral assertion)
+collection = """
+    public function {test_name}() {
+{param_setup}
+        $result = $this->instance->{fn_name}({param_args});
+{assertion_code}
+    }
+"""
+
+# Generic value return — fallback
+default = """
+    public function {test_name}() {
+{param_setup}
+        $result = $this->instance->{fn_name}({param_args});
+        $this->assertNotNull( $result );
+    }
+"""


### PR DESCRIPTION
## Summary

Companion PR to [homeboy#871](https://github.com/Extra-Chill/homeboy/pull/871) — adds the language-specific grammar entries that the behavioral inference engine resolves against.

### What changed

Two new grammar sections in both **Rust** and **WordPress/PHP**:

**`[contract.type_constructors]`** — maps semantic hints from core to language-specific code:

| Hint | Rust | PHP |
|------|------|-----|
| `empty` (array) | `Vec::new()` | `[]` |
| `empty` (string) | `""` | `''` |
| `non_empty` (array) | `vec![Default::default()]` | `[ 'test_value' ]` |
| `none` | `None` | `null` |
| `some_default` | `Some(Default::default())` | `'test_value'` / `1` / `new \stdClass()` |
| `nonexistent_path` | `Path::new("/tmp/...")` | `'/tmp/...'` |
| `true` / `false` | `true` / `false` | `true` / `false` |
| `zero` / `positive` | `0` / `1` | `0` / `1` |
| `contains` | `"{hint_arg}"` | `'{hint_arg}'` |

**`[contract.assertion_templates]`** — maps assertion keys to language-specific assertions:

| Key | Rust | PHP |
|-----|------|-----|
| `result_ok_value` | `result.unwrap()` | `$this->assertNotWPError()` |
| `result_err_value` | `result.unwrap_err()` | `$this->assertWPError()` + error code |
| `option_none` | `assert!(result.is_none())` | `$this->assertNull()` |
| `bool_true` | `assert!(result)` | `$this->assertTrue()` |
| `collection_empty` | `assert!(result.is_empty())` | `$this->assertEmpty()` |

Also updated test_templates to use `{assertion_code}` variable.

### Architecture

```
Core (homeboy)               Grammar (this repo)
──────────────               ───────────────────
condition → hint              hint + type → code
  "is_empty()" → "empty"       "empty" + "array" → "[]"
                                "empty" + "Vec<>" → "Vec::new()"

return → assertion_key        key → assertion code
  Ok("skipped") →               "result_ok_value" →
  "result_ok_value"               "$this->assertNotWPError()"
```

Core is 100% language-agnostic. Adding a new language (JS, Go, Swift) is just adding these sections to its grammar.toml.