### PR TITLE
feat: add field_pattern for struct/class property extraction (#818)

### DIFF
--- a/rust/grammar.toml
+++ b/rust/grammar.toml
@@ -358,6 +358,12 @@ imports = []
 
 fallback_default = 'Default::default()'
 
+# Struct field extraction — enables field-level assertions in generated tests.
+# field_pattern: regex with two captures: (1) field name, (2) field type
+# field_visibility_pattern: regex that matches public field declarations
+field_pattern = '^\s*(?:pub(?:\(crate\))?\s+)?(\w+)\s*:\s*(.+?),?\s*$'
+field_visibility_pattern = '^\s*pub\b'
+
 # ── empty: produce a value where .is_empty() == true ──
 [[contract.type_constructors]]
 hint = 'empty'

--- a/wordpress/grammar.toml
+++ b/wordpress/grammar.toml
@@ -445,6 +445,18 @@ imports = []
 
 fallback_default = 'null'
 
+# Class property extraction — enables field-level assertions in generated tests.
+# Matches PHP property declarations like:
+#   public string $name;
+#   protected ?int $count = 0;
+#   private array $items = [];
+# PHP has type before name: capture group 1 = type, group 2 = name
+# field_name_group / field_type_group tell core which group is which
+field_pattern = '^\s*(?:public|protected|private)\s+(?:readonly\s+)?(\??\w+)\s+\$(\w+)'
+field_name_group = 2
+field_type_group = 1
+field_visibility_pattern = '^\s*public\b'
+
 # ── empty: produce a value where empty($x) == true ──
 [[contract.type_constructors]]
 hint = 'empty'


### PR DESCRIPTION
Adds field_pattern, field_name_group, field_type_group, and field_visibility_pattern to both Rust and PHP grammars. Companion to homeboy#874.