### PR TITLE
feat: add field_assertion_template for Rust and PHP

### DIFF
--- a/rust/grammar.toml
+++ b/rust/grammar.toml
@@ -363,6 +363,7 @@ fallback_default = 'Default::default()'
 # field_visibility_pattern: regex that matches public field declarations
 field_pattern = '^\s*(?:pub(?:\(crate\))?\s+)?(\w+)\s*:\s*(.+?),?\s*$'
 field_visibility_pattern = '^\s*pub\b'
+field_assertion_template = '{indent}assert_eq!(inner.{field_name}, {expected_value});'
 
 # ── empty: produce a value where .is_empty() == true ──
 [[contract.type_constructors]]

--- a/wordpress/grammar.toml
+++ b/wordpress/grammar.toml
@@ -456,6 +456,7 @@ field_pattern = '^\s*(?:public|protected|private)\s+(?:readonly\s+)?(\??\w+)\s+\
 field_name_group = 2
 field_type_group = 1
 field_visibility_pattern = '^\s*public\b'
+field_assertion_template = "{indent}$this->assertSame( {expected_value}, $result->{field_name} );"
 
 # ── empty: produce a value where empty($x) == true ──
 [[contract.type_constructors]]


### PR DESCRIPTION
Companion to homeboy#875. Moves assert syntax from core to grammar.