### PR TITLE
fix: include PHPStan findings in lint baseline ratchet

### DIFF
--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -68,6 +68,32 @@ RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/
 source "${RESOLVE_CONTEXT_HELPER}"
 homeboy_resolve_context
 
+# Merge additional findings (e.g. PHPStan) into the HOMEBOY_LINT_FINDINGS_FILE.
+# Appends entries from a JSON array file into the existing findings sidecar,
+# so the identity-based baseline ratchet sees findings from all linters.
+merge_findings_into_sidecar() {
+    local extra_file="$1"
+    local target="${HOMEBOY_LINT_FINDINGS_FILE:-}"
+    [ -z "$target" ] && return 0
+    [ ! -f "$extra_file" ] && return 0
+
+    # If the target doesn't exist yet, just copy the extra file
+    if [ ! -f "$target" ]; then
+        cp "$extra_file" "$target"
+        return 0
+    fi
+
+    # Merge both JSON arrays into one
+    if command -v php &> /dev/null; then
+        php -r '
+            $existing = json_decode(file_get_contents($argv[1]), true) ?: [];
+            $extra = json_decode(file_get_contents($argv[2]), true) ?: [];
+            $merged = array_merge($existing, $extra);
+            file_put_contents($argv[1], json_encode($merged, JSON_UNESCAPED_SLASHES) . "\n");
+        ' "$target" "$extra_file" 2>/dev/null || true
+    fi
+}
+
 # Determine lint target (file, glob, or full component)
 # Use array to properly handle paths with spaces
 LINT_FILES=("$PLUGIN_PATH")
@@ -666,7 +692,8 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
 
         echo ""
         set +e
-        HOMEBOY_SUMMARY_MODE=1 bash "$phpstan_runner"
+        _HOMEBOY_PHPSTAN_FINDINGS_FILE="${_PHPSTAN_FINDINGS_TMPFILE:-}" \
+            HOMEBOY_SUMMARY_MODE=1 bash "$phpstan_runner"
         local phpstan_exit=$?
         set -e
 
@@ -676,9 +703,23 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
         return 0
     }
 
+    # Create temp file for PHPStan findings if baseline sidecar is active
+    _PHPSTAN_FINDINGS_TMPFILE=""
+    if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
+        _PHPSTAN_FINDINGS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/phpstan-findings-XXXXXX.json")
+    fi
+
     # Run PHPStan (warn-only - does not affect exit code)
     PHPSTAN_PASSED=1
     run_phpstan_summary || PHPSTAN_PASSED=0
+
+    # Merge PHPCS + PHPStan findings into the final baseline sidecar.
+    # PHPCS writes directly to HOMEBOY_LINT_FINDINGS_FILE; PHPStan writes
+    # to the temp file. Merge both so the identity-based ratchet sees all errors.
+    if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ] && [ -n "$_PHPSTAN_FINDINGS_TMPFILE" ] && [ -f "$_PHPSTAN_FINDINGS_TMPFILE" ]; then
+        merge_findings_into_sidecar "$_PHPSTAN_FINDINGS_TMPFILE"
+        rm -f "$_PHPSTAN_FINDINGS_TMPFILE"
+    fi
 
     # Always exit 0 (warn-only mode) - lint issues are warnings, not failures
     if [ "$PHPCS_PASSED" -eq 1 ] && [ "$ESLINT_PASSED" -eq 1 ] && [ "$PHPSTAN_PASSED" -eq 1 ]; then
@@ -740,7 +781,8 @@ run_phpstan() {
 
     echo ""
     set +e
-    HOMEBOY_SUMMARY_MODE=1 bash "$phpstan_runner"
+    _HOMEBOY_PHPSTAN_FINDINGS_FILE="${_PHPSTAN_FINDINGS_TMPFILE:-}" \
+        HOMEBOY_SUMMARY_MODE=1 bash "$phpstan_runner"
     local phpstan_exit=$?
     set -e
 
@@ -751,9 +793,21 @@ run_phpstan() {
     return 0
 }
 
+# Create temp file for PHPStan findings if baseline sidecar is active
+_PHPSTAN_FINDINGS_TMPFILE=""
+if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
+    _PHPSTAN_FINDINGS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/phpstan-findings-XXXXXX.json")
+fi
+
 # Run PHPStan (warn-only - does not affect exit code)
 PHPSTAN_PASSED=1
 run_phpstan || PHPSTAN_PASSED=0
+
+# Merge PHPCS + PHPStan findings into the final baseline sidecar
+if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ] && [ -n "$_PHPSTAN_FINDINGS_TMPFILE" ] && [ -f "$_PHPSTAN_FINDINGS_TMPFILE" ]; then
+    merge_findings_into_sidecar "$_PHPSTAN_FINDINGS_TMPFILE"
+    rm -f "$_PHPSTAN_FINDINGS_TMPFILE"
+fi
 
 # Always exit 0 (warn-only mode) - lint issues are warnings, not failures
 if [ "$PHPCS_PASSED" -eq 1 ] && [ "$ESLINT_PASSED" -eq 1 ] && [ "$PHPSTAN_PASSED" -eq 1 ]; then

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -472,6 +472,39 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
         ' "$PLUGIN_PATH" "$PHPSTAN_LEVEL" "${HOMEBOY_ANNOTATIONS_DIR}" 2>/dev/null || true
     fi
 
+    # Write PHPStan lint findings sidecar for homeboy baseline ratchet.
+    # Transforms PHPStan JSON into the same LintFinding format PHPCS uses:
+    #   [{id: "file::identifier::line", message: "...", category: "phpstan"}]
+    # The lint-runner merges these with PHPCS findings into the final baseline.
+    if [ -n "${_HOMEBOY_PHPSTAN_FINDINGS_FILE:-}" ] && [ -n "$json_output" ]; then
+        echo "$json_output" | php -r '
+            $json = json_decode(file_get_contents("php://stdin"), true);
+            if (!$json || empty($json["files"])) {
+                file_put_contents($argv[2], "[]");
+                exit;
+            }
+            $componentPath = $argv[1] ?? "";
+            $findings = [];
+            foreach ($json["files"] as $filePath => $data) {
+                $relPath = $filePath;
+                if ($componentPath && strpos($filePath, $componentPath) === 0) {
+                    $relPath = ltrim(substr($filePath, strlen($componentPath)), "/");
+                }
+                foreach ($data["messages"] ?? [] as $msg) {
+                    $identifier = $msg["identifier"] ?? "unknown";
+                    $line = $msg["line"] ?? 0;
+                    $message = $msg["message"] ?? "Unknown";
+                    $findings[] = [
+                        "id" => $relPath . "::phpstan." . $identifier . "::" . $line,
+                        "message" => $message . " (phpstan." . $identifier . ")",
+                        "category" => "phpstan",
+                    ];
+                }
+            }
+            file_put_contents($argv[2], json_encode($findings, JSON_UNESCAPED_SLASHES) . "\n");
+        ' "$PLUGIN_PATH" "${_HOMEBOY_PHPSTAN_FINDINGS_FILE}" 2>/dev/null || true
+    fi
+
     # Fallback: show stderr if PHPStan failed without producing JSON
     if [ "$json_exit" -ne 0 ] && [ -z "$json_output" ] && [ -n "$stderr_output" ]; then
         echo ""


### PR DESCRIPTION
## Summary

Fixes the PHPStan ratchet masking bug described in Extra-Chill/homeboy#909.

**The bug:** PHPStan findings were never written to `HOMEBOY_LINT_FINDINGS_FILE` — only PHPCS findings went into the sidecar. The identity-based baseline ratchet in homeboy core never saw PHPStan errors. When a PR simultaneously removed old errors (by deleting files) and introduced new ones (e.g. `Class not found`), the count stayed flat and the native PHPStan baseline passed.

**The fix:**
- **phpstan-runner.sh**: Writes PHPStan findings to `_HOMEBOY_PHPSTAN_FINDINGS_FILE` in the standard `LintFinding` format (`{id: "file::phpstan.identifier::line", message: "...", category: "phpstan"}`)
- **lint-runner.sh**: Creates a temp file for PHPStan findings, passes it to the phpstan-runner, then merges both PHPCS and PHPStan findings into the final `HOMEBOY_LINT_FINDINGS_FILE` via `merge_findings_into_sidecar()`

This ensures the identity-based ratchet in homeboy core sees all errors from all linters. A new PHPStan error will be flagged as a regression even if an old one was resolved in the same PR.

## Architecture

```
┌─────────────────────┐     ┌──────────────────────┐
│ PHPCS findings      │     │ PHPStan findings      │
│ → LINT_FINDINGS_FILE│     │ → temp file           │
└────────┬────────────┘     └─────────┬────────────┘
         │                            │
         └──────────┬─────────────────┘
                    ▼
         merge_findings_into_sidecar()
                    │
                    ▼
         HOMEBOY_LINT_FINDINGS_FILE
         (merged PHPCS + PHPStan)
                    │
                    ▼
         homeboy core baseline ratchet
         (identity-based comparison)
```

Fixes Extra-Chill/homeboy#909