### PR TITLE
fix: auto-detect PHP version from Requires PHP header for PHPStan

### DIFF
--- a/wordpress/scripts/lib/detect-component.sh
+++ b/wordpress/scripts/lib/detect-component.sh
@@ -14,6 +14,7 @@
 #   HOMEBOY_COMPONENT_NAME             — Plugin Name / Theme Name value
 #   HOMEBOY_COMPONENT_TEXT_DOMAIN      — Text Domain value (may be empty)
 #   HOMEBOY_COMPONENT_VERSION          — Version value (may be empty)
+#   HOMEBOY_COMPONENT_REQUIRES_PHP     — minimum PHP version (may be empty)
 #   HOMEBOY_COMPONENT_REQUIRES_PLUGINS — comma-separated plugin slugs (may be empty)
 
 homeboy_detect_component() {
@@ -24,6 +25,7 @@ homeboy_detect_component() {
     HOMEBOY_COMPONENT_NAME=""
     HOMEBOY_COMPONENT_TEXT_DOMAIN=""
     HOMEBOY_COMPONENT_VERSION=""
+    HOMEBOY_COMPONENT_REQUIRES_PHP=""
     HOMEBOY_COMPONENT_REQUIRES_PLUGINS=""
 
     # Check for theme first (style.css with "Theme Name:")
@@ -34,6 +36,7 @@ homeboy_detect_component() {
             HOMEBOY_COMPONENT_NAME=$(grep -m1 "Theme Name:" "${component_path}/style.css" | sed 's/.*Theme Name:[[:space:]]*//' | sed 's/[[:space:]]*$//' | tr -d '\r')
             HOMEBOY_COMPONENT_TEXT_DOMAIN=$(grep -m1 "Text Domain:" "${component_path}/style.css" | sed 's/.*Text Domain:[[:space:]]*//' | tr -d ' \r')
             HOMEBOY_COMPONENT_VERSION=$(grep -m1 "Version:" "${component_path}/style.css" | sed 's/.*Version:[[:space:]]*//' | tr -d ' \r')
+            HOMEBOY_COMPONENT_REQUIRES_PHP=$(grep -m1 "Requires PHP:" "${component_path}/style.css" 2>/dev/null | sed 's/.*Requires PHP:[[:space:]]*//' | tr -d ' \r')
             HOMEBOY_COMPONENT_REQUIRES_PLUGINS=$(grep -m1 "Requires Plugins:" "${component_path}/style.css" 2>/dev/null | sed 's/.*Requires Plugins:[[:space:]]*//' | sed 's/[[:space:]]*$//' | tr -d '\r')
             return 0
         fi
@@ -49,6 +52,7 @@ homeboy_detect_component() {
         HOMEBOY_COMPONENT_NAME=$(grep -m1 "Plugin Name:" "$main_file" | sed 's/.*Plugin Name:[[:space:]]*//' | sed 's/[[:space:]]*$//' | tr -d '\r')
         HOMEBOY_COMPONENT_TEXT_DOMAIN=$(grep -m1 "Text Domain:" "$main_file" | sed 's/.*Text Domain:[[:space:]]*//' | tr -d ' \r')
         HOMEBOY_COMPONENT_VERSION=$(grep -m1 "Version:" "$main_file" | sed 's/.*Version:[[:space:]]*//' | tr -d ' \r')
+        HOMEBOY_COMPONENT_REQUIRES_PHP=$(grep -m1 "Requires PHP:" "$main_file" 2>/dev/null | sed 's/.*Requires PHP:[[:space:]]*//' | tr -d ' \r')
         HOMEBOY_COMPONENT_REQUIRES_PLUGINS=$(grep -m1 "Requires Plugins:" "$main_file" 2>/dev/null | sed 's/.*Requires Plugins:[[:space:]]*//' | sed 's/[[:space:]]*$//' | tr -d '\r')
         return 0
     fi

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -193,13 +193,18 @@ if [ -n "$TEXT_DOMAIN" ] && [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Detected text domain: $TEXT_DOMAIN"
 fi
 
-# Auto-detect PHP version from composer.json (overrides phpcs.xml.dist default)
-# Priority: HOMEBOY_PHP_VERSION env var > composer.json require.php > phpcs.xml.dist default
+# Auto-detect PHP version for PHPCS and PHPStan.
+# Priority: HOMEBOY_PHP_VERSION env var > Requires PHP header > composer.json require.php > default
 PHP_VERSION=""
 if [ -n "${HOMEBOY_PHP_VERSION:-}" ]; then
     PHP_VERSION="${HOMEBOY_PHP_VERSION}"
     if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
         echo "DEBUG: PHP version from env: $PHP_VERSION"
+    fi
+elif [ -n "${HOMEBOY_COMPONENT_REQUIRES_PHP:-}" ]; then
+    PHP_VERSION="${HOMEBOY_COMPONENT_REQUIRES_PHP}"
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: PHP version from Requires PHP header: $PHP_VERSION"
     fi
 elif [ -f "${PLUGIN_PATH}/composer.json" ] && command -v php &> /dev/null; then
     PHP_VERSION=$(php -r '
@@ -216,7 +221,9 @@ elif [ -f "${PLUGIN_PATH}/composer.json" ] && command -v php &> /dev/null; then
     fi
 fi
 
+# Export for child scripts (phpstan-runner.sh reads this)
 if [ -n "$PHP_VERSION" ]; then
+    export HOMEBOY_PHP_VERSION="$PHP_VERSION"
     echo "PHP compatibility target: ${PHP_VERSION}-"
 fi
 

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -225,21 +225,48 @@ elif [ "$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)" -le 2 ]
     PHPSTAN_MAX_PROCESSES="1"
 fi
 
-# If we need to override parallel processes, generate a temp neon config that
-# includes the main config and overrides the parallel setting.
+# Convert a PHP version string (e.g. "8.2", "8.2.1") to PHPStan's integer format (e.g. 80200, 80201).
+# PHPStan phpVersion format: major * 10000 + minor * 100 + patch
+php_version_to_phpstan_int() {
+    local version="$1"
+    local major minor patch
+    IFS='.' read -r major minor patch <<< "$version"
+    major="${major:-0}"
+    minor="${minor:-0}"
+    patch="${patch:-0}"
+    echo $(( major * 10000 + minor * 100 + patch ))
+}
+
+# Detect PHP version from HOMEBOY_PHP_VERSION (set by lint-runner or the user).
+PHPSTAN_PHP_VERSION=""
+if [ -n "${HOMEBOY_PHP_VERSION:-}" ]; then
+    PHPSTAN_PHP_VERSION=$(php_version_to_phpstan_int "${HOMEBOY_PHP_VERSION}")
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: PHPStan phpVersion: ${PHPSTAN_PHP_VERSION} (from ${HOMEBOY_PHP_VERSION})"
+    fi
+    echo "PHPStan PHP version target: ${HOMEBOY_PHP_VERSION} (${PHPSTAN_PHP_VERSION})"
+fi
+
+# Generate a temp neon config that includes the main config and overrides
+# parallel settings and/or phpVersion as needed.
 PHPSTAN_TMPCONFIG=""
 generate_phpstan_config() {
-    local max_processes="$1"
+    local max_processes="${1:-}"
     local tmpfile
     tmpfile=$(homeboy_mktemp 'phpstan-XXXXXX.neon')
-    cat > "$tmpfile" <<NEON
-includes:
-    - ${PHPSTAN_BASE_CONFIG}
-
-parameters:
-    parallel:
-        maximumNumberOfProcesses: ${max_processes}
-NEON
+    {
+        printf 'includes:\n'
+        printf '    - %s\n' "${PHPSTAN_BASE_CONFIG}"
+        printf '\n'
+        printf 'parameters:\n'
+        if [ -n "$max_processes" ]; then
+            printf '    parallel:\n'
+            printf '        maximumNumberOfProcesses: %s\n' "${max_processes}"
+        fi
+        if [ -n "$PHPSTAN_PHP_VERSION" ]; then
+            printf '    phpVersion: %s\n' "${PHPSTAN_PHP_VERSION}"
+        fi
+    } > "$tmpfile"
     echo "$tmpfile"
 }
 
@@ -249,7 +276,8 @@ cleanup_phpstan_config() {
 }
 trap 'cleanup_phpstan_config; cleanup_composite_autoload; cleanup_dependency_config' EXIT
 
-if [ -n "$PHPSTAN_MAX_PROCESSES" ]; then
+# Generate a temp config when we need to override parallel processes or phpVersion.
+if [ -n "$PHPSTAN_MAX_PROCESSES" ] || [ -n "$PHPSTAN_PHP_VERSION" ]; then
     PHPSTAN_TMPCONFIG=$(generate_phpstan_config "$PHPSTAN_MAX_PROCESSES")
     # Replace the --configuration arg with our temp config
     phpstan_args=(analyse)
@@ -266,8 +294,8 @@ if [ -n "$PHPSTAN_MAX_PROCESSES" ]; then
     phpstan_args+=("$PLUGIN_PATH")
 fi
 
-# Add the path to analyze (only when not already set by thread-override block above)
-if [ -z "$PHPSTAN_MAX_PROCESSES" ]; then
+# Add the path to analyze (only when not already set by override block above)
+if [ -z "$PHPSTAN_MAX_PROCESSES" ] && [ -z "$PHPSTAN_PHP_VERSION" ]; then
     phpstan_args+=("$PLUGIN_PATH")
 fi
 


### PR DESCRIPTION
## Summary
- Parse `Requires PHP:` from plugin/theme headers and pass it to PHPStan as `phpVersion`, eliminating 15+ false parse errors on PHP 8.2+ syntax (readonly properties, enums, intersection types)
- Zero config per-repo — works automatically for every WordPress plugin and theme

Fixes #178

## Changes

### `detect-component.sh`
- Extract `HOMEBOY_COMPONENT_REQUIRES_PHP` from plugin/theme headers (same pattern as existing header extractions)

### `lint-runner.sh`
- Add `Requires PHP:` header as second priority in the PHP version detection chain
- Priority: `HOMEBOY_PHP_VERSION` env → **`Requires PHP:` header** → `composer.json require.php` → default
- Export `HOMEBOY_PHP_VERSION` so child scripts (phpstan-runner) inherit it

### `phpstan-runner.sh`
- Add `php_version_to_phpstan_int()` to convert `8.2` → `80200` (PHPStan's integer format)
- Read `HOMEBOY_PHP_VERSION` env var and inject `phpVersion` into the generated neon config
- Works for all code paths: initial run, thread override, and single-threaded retry

## How it flows

```
Plugin header: "Requires PHP: 8.2"
        ↓
detect-component.sh → HOMEBOY_COMPONENT_REQUIRES_PHP="8.2"
        ↓
lint-runner.sh → PHP_VERSION="8.2" → export HOMEBOY_PHP_VERSION="8.2"
        ↓
phpstan-runner.sh → phpVersion: 80200 (in generated neon)
        ↓
PHPStan correctly parses PHP 8.2 syntax ✓
```