### PR TITLE
fix: atomic swap deploy with backup-before-replace for plugins and themes

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -134,15 +134,15 @@
       {
         "path_pattern": "/wp-content/plugins/",
         "staging_path": "/tmp/homeboy-staging",
-        "install_command": "cd {{siteRoot}} && plugin_slug=$(basename {{targetDir}}) && ([ -d {{targetDir}} ] && echo 'WARNING: Removing existing plugin directory' && rm -rf {{targetDir}} || true) && {{cliPath}} plugin install {{stagingArtifact}} --force --url={{domain}} {{allowRootFlag}} && zip_root=$(unzip -qql {{stagingArtifact}} | head -1 | awk '{print $4}' | cut -d/ -f1) && if [ \"$zip_root\" != \"$plugin_slug\" ] && [ -d \"wp-content/plugins/$zip_root\" ] && [ ! -d {{targetDir}} ]; then echo \"Renaming extracted folder $zip_root to $plugin_slug\" && mv \"wp-content/plugins/$zip_root\" {{targetDir}}; fi",
-        "cleanup_command": "rm -f {{stagingArtifact}}",
+        "install_command": "cd {{siteRoot}} && plugin_slug=$(basename {{targetDir}}) && rm -rf {{targetDir}}.bak && ([ -d {{targetDir}} ] && echo 'Backing up existing plugin to {{targetDir}}.bak' && mv {{targetDir}} {{targetDir}}.bak || true) && ({{cliPath}} plugin install {{stagingArtifact}} --force --url={{domain}} {{allowRootFlag}} && zip_root=$(unzip -qql {{stagingArtifact}} | head -1 | awk '{print $4}' | cut -d/ -f1) && if [ \"$zip_root\" != \"$plugin_slug\" ] && [ -d \"wp-content/plugins/$zip_root\" ] && [ ! -d {{targetDir}} ]; then echo \"Renaming extracted folder $zip_root to $plugin_slug\" && mv \"wp-content/plugins/$zip_root\" {{targetDir}}; fi) || (echo 'ERROR: Plugin install failed — restoring backup' && rm -rf {{targetDir}} && ([ -d {{targetDir}}.bak ] && mv {{targetDir}}.bak {{targetDir}} || true) && exit 1)",
+        "cleanup_command": "rm -f {{stagingArtifact}} && rm -rf {{targetDir}}.bak",
         "skip_permissions_fix": true
       },
       {
         "path_pattern": "/wp-content/themes/",
         "staging_path": "/tmp/homeboy-staging",
-        "install_command": "cd {{siteRoot}} && theme_slug=$(basename {{targetDir}}) && ([ -d {{targetDir}} ] && echo 'WARNING: Removing existing theme directory' && rm -rf {{targetDir}} || true) && {{cliPath}} theme install {{stagingArtifact}} --force --url={{domain}} {{allowRootFlag}} && zip_root=$(unzip -qql {{stagingArtifact}} | head -1 | awk '{print $4}' | cut -d/ -f1) && if [ \"$zip_root\" != \"$theme_slug\" ] && [ -d \"wp-content/themes/$zip_root\" ] && [ ! -d {{targetDir}} ]; then echo \"Renaming extracted folder $zip_root to $theme_slug\" && mv \"wp-content/themes/$zip_root\" {{targetDir}}; fi",
-        "cleanup_command": "rm -f {{stagingArtifact}}",
+        "install_command": "cd {{siteRoot}} && theme_slug=$(basename {{targetDir}}) && rm -rf {{targetDir}}.bak && ([ -d {{targetDir}} ] && echo 'Backing up existing theme to {{targetDir}}.bak' && mv {{targetDir}} {{targetDir}}.bak || true) && ({{cliPath}} theme install {{stagingArtifact}} --force --url={{domain}} {{allowRootFlag}} && zip_root=$(unzip -qql {{stagingArtifact}} | head -1 | awk '{print $4}' | cut -d/ -f1) && if [ \"$zip_root\" != \"$theme_slug\" ] && [ -d \"wp-content/themes/$zip_root\" ] && [ ! -d {{targetDir}} ]; then echo \"Renaming extracted folder $zip_root to $theme_slug\" && mv \"wp-content/themes/$zip_root\" {{targetDir}}; fi) || (echo 'ERROR: Theme install failed — restoring backup' && rm -rf {{targetDir}} && ([ -d {{targetDir}}.bak ] && mv {{targetDir}}.bak {{targetDir}} || true) && exit 1)",
+        "cleanup_command": "rm -f {{stagingArtifact}} && rm -rf {{targetDir}}.bak",
         "skip_permissions_fix": true
       }
     ],


### PR DESCRIPTION
## Summary

Replaces the destructive delete-then-install deploy pattern with backup-before-replace for both WordPress plugins and themes.

## Before (dangerous)

```
rm -rf targetDir          ← old version gone forever
wp plugin install ZIP     ← if this fails, site is down
```

## After (safe)

```
mv targetDir targetDir.bak     ← backup old version
wp plugin install ZIP          ← install new version
  ├─ SUCCESS → cleanup removes .bak
  └─ FAILURE → rm broken install, mv .bak back to targetDir
```

## What changed

`wordpress.json` deploy overrides for both `/wp-content/plugins/` and `/wp-content/themes/`:

1. **Backup** — `mv targetDir targetDir.bak` instead of `rm -rf targetDir`
2. **Rollback on failure** — `|| (rm -rf targetDir && mv targetDir.bak targetDir && exit 1)`
3. **Cleanup** — `rm -rf targetDir.bak` added to `cleanup_command` (only runs after success)
4. **Stale backup cleanup** — `rm -rf targetDir.bak` at start clears any leftover from a previous failed deploy

Follows the same pattern used by the sweatpants extension (`mv sweatpants sweatpants.old`).

Closes #181