### PR TITLE
fix: unit test template should not assert is_ok() on () return

### DIFF
--- a/rust/grammar.toml
+++ b/rust/grammar.toml
@@ -578,8 +578,7 @@ unit = """
     #[test]
     fn {test_name}() {
 {param_setup}
-        let result = {fn_name}({param_args});
-        assert!(result.is_ok(), "expected Ok for: {condition}");
+        {fn_name}({param_args});
     }
 """
 


### PR DESCRIPTION
## Summary

Fixes a compilation error in auto-generated tests for functions returning `()` (#818).

## Problem

The Rust grammar's `unit` test template was:
```rust
let result = {fn_name}({param_args});
assert!(result.is_ok(), "expected Ok for: {condition}");
```

`()` does not have an `is_ok()` method. Every unit-returning function got a non-compiling test.

## Fix

Changed to just call the function (same pattern as `no_panic`):
```rust
{fn_name}({param_args});
```

If the function panics, the test fails. If it doesn't, it passes. This is the correct behavior for unit-returning functions.