### PR TITLE
fix: decompose fixer visibility upgrade and trait import carry-over

### DIFF
--- a/rust/scripts/refactor/imports.py
+++ b/rust/scripts/refactor/imports.py
@@ -264,6 +264,39 @@ def resolve_imports(moved_items: list[dict], source_content: str, source_path: s
                         if fixed not in needed:
                             needed.append(fixed)
 
+    # Phase 1b: Carry trait-like imports conservatively.
+    # Traits used for method dispatch (e.g., `use std::io::Read;` enabling `.read()`)
+    # are invisible in Phase 1 because the trait name never appears literally in the code.
+    # Conservative heuristic: carry imports with PascalCase terminal names that weren't
+    # already picked up by Phase 1 and don't appear as explicit types in the moved code.
+    # This catches trait imports while being safe — the worst case is an unused import
+    # (which `cargo fix` or rustfmt can clean up), vs a missing trait import which breaks compilation.
+    already_carried = set()
+    for use_stmt in needed:
+        already_carried.update(extract_use_names(use_stmt))
+
+    for use_stmt in source_uses:
+        if use_stmt in needed:
+            continue
+        names = extract_use_names(use_stmt)
+        for name in names:
+            if name in already_carried or name in moved_item_names:
+                continue
+            # PascalCase heuristic: starts with uppercase, contains lowercase
+            # (excludes SCREAMING_CASE constants which are not traits)
+            if not name or not name[0].isupper() or name.isupper():
+                continue
+            # If the name appears literally in the moved code, Phase 1 already
+            # handled it (or it's a type, not a trait). Skip.
+            if re.search(r'\b' + re.escape(name) + r'\b', combined_source):
+                continue
+            # This is likely a trait import needed for method dispatch — carry it
+            fixed = fix_import_path(use_stmt, source_path, dest_path)
+            if fixed not in needed:
+                needed.append(fixed)
+                already_carried.update(extract_use_names(fixed))
+            break  # This use_stmt is handled, move to next
+
     # Phase 2: Add imports for same-module definitions referenced by moved items (#339)
     # This covers types, functions, and constants that were in scope because
     # the moved code lived in the same file.

--- a/rust/scripts/refactor/test_imports.py
+++ b/rust/scripts/refactor/test_imports.py
@@ -1,8 +1,9 @@
-"""Tests for import resolution in decompose refactoring."""
+"""Tests for import resolution and visibility in decompose refactoring."""
 
 import unittest
 from .imports import resolve_imports, extract_use_names, fix_import_path
 from .module_index import generate_module_index
+from .visibility import adjust_visibility
 
 
 class TestExtractUseNames(unittest.TestCase):
@@ -436,6 +437,231 @@ pub fn remaining_fn() {}
         self.assertIn("mod helpers;", content)
         self.assertIn("pub use helpers::*;", content)
         self.assertIn("pub fn remaining() {}", content)
+
+
+class TestVisibilityDecompose(unittest.TestCase):
+    """Visibility adjuster must upgrade pub(crate) → pub in decompose case."""
+
+    def test_pub_crate_upgraded_to_pub_in_decompose(self):
+        """When decomposing, pub(crate) items need pub so glob re-export works."""
+        items = [{
+            "source": "pub(crate) fn do_thing() -> bool {\n    true\n}",
+            "visibility": "pub(crate)",
+            "kind": "function",
+        }]
+        result = adjust_visibility(
+            items,
+            "src/core/big.rs",
+            "src/core/big/helpers.rs",
+        )
+        adjusted = result["items"]
+        self.assertEqual(len(adjusted), 1)
+        self.assertTrue(adjusted[0]["changed"])
+        self.assertEqual(adjusted[0]["new_visibility"], "pub")
+        self.assertIn("pub fn do_thing()", adjusted[0]["source"])
+        self.assertNotIn("pub(crate)", adjusted[0]["source"])
+
+    def test_pub_crate_struct_upgraded_in_decompose(self):
+        """pub(crate) structs also need upgrading."""
+        items = [{
+            "source": "pub(crate) struct Config {\n    pub name: String,\n}",
+            "visibility": "pub(crate)",
+            "kind": "struct",
+        }]
+        result = adjust_visibility(
+            items,
+            "src/core/engine.rs",
+            "src/core/engine/config.rs",
+        )
+        adjusted = result["items"]
+        self.assertTrue(adjusted[0]["changed"])
+        self.assertEqual(adjusted[0]["new_visibility"], "pub")
+        self.assertIn("pub struct Config", adjusted[0]["source"])
+
+    def test_pub_crate_NOT_upgraded_in_regular_move(self):
+        """In a regular move (not decompose), pub(crate) stays unchanged."""
+        items = [{
+            "source": "pub(crate) fn helper() {}",
+            "visibility": "pub(crate)",
+            "kind": "function",
+        }]
+        result = adjust_visibility(
+            items,
+            "src/core/foo.rs",
+            "src/core/bar.rs",
+        )
+        adjusted = result["items"]
+        self.assertFalse(adjusted[0]["changed"])
+        self.assertEqual(adjusted[0]["new_visibility"], "pub(crate)")
+
+    def test_private_still_gets_pub_crate_in_decompose(self):
+        """Private items still get pub(crate) even during decompose."""
+        items = [{
+            "source": "fn internal() {}",
+            "visibility": "",
+            "kind": "function",
+        }]
+        result = adjust_visibility(
+            items,
+            "src/core/big.rs",
+            "src/core/big/helpers.rs",
+        )
+        adjusted = result["items"]
+        self.assertTrue(adjusted[0]["changed"])
+        self.assertEqual(adjusted[0]["new_visibility"], "pub(crate)")
+
+    def test_impl_blocks_unchanged_in_decompose(self):
+        """impl blocks have no visibility of their own."""
+        items = [{
+            "source": "impl Foo {\n    pub fn bar() {}\n}",
+            "visibility": "",
+            "kind": "impl",
+        }]
+        result = adjust_visibility(
+            items,
+            "src/core/big.rs",
+            "src/core/big/helpers.rs",
+        )
+        adjusted = result["items"]
+        self.assertFalse(adjusted[0]["changed"])
+
+    def test_pub_items_unchanged_in_decompose(self):
+        """Already pub items don't need upgrading."""
+        items = [{
+            "source": "pub fn already_public() {}",
+            "visibility": "pub",
+            "kind": "function",
+        }]
+        result = adjust_visibility(
+            items,
+            "src/core/big.rs",
+            "src/core/big/helpers.rs",
+        )
+        adjusted = result["items"]
+        self.assertFalse(adjusted[0]["changed"])
+        self.assertEqual(adjusted[0]["new_visibility"], "pub")
+
+
+class TestStandaloneTraitImports(unittest.TestCase):
+    """Phase 1b: standalone trait imports (not in {self, Trait} groups) must be carried."""
+
+    def test_standalone_trait_import_carried(self):
+        """use crate::foo::MyTrait; should be carried when trait methods are used."""
+        source = """use crate::engine::local_files::FileSystem;
+
+pub fn read_file(path: &str) -> String {
+    let fs = get_filesystem();
+    fs.read(path).unwrap()
+}
+"""
+        moved_items = [{
+            "name": "read_file",
+            "kind": "fn",
+            "source": """pub fn read_file(path: &str) -> String {
+    let fs = get_filesystem();
+    fs.read(path).unwrap()
+}""",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/big.rs",
+            "src/core/big/helpers.rs",
+        )
+        imports = result["needed_imports"]
+        import_text = "\n".join(imports)
+        # FileSystem is PascalCase, not used literally in moved code,
+        # so Phase 1b should carry it as a trait import
+        self.assertIn("FileSystem", import_text)
+
+    def test_screaming_case_not_treated_as_trait(self):
+        """SCREAMING_CASE constants should not be carried as trait imports."""
+        source = """use crate::constants::MAX_RETRIES;
+
+pub fn try_connect() -> bool {
+    true
+}
+"""
+        moved_items = [{
+            "name": "try_connect",
+            "kind": "fn",
+            "source": "pub fn try_connect() -> bool { true }",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/big.rs",
+            "src/core/big/helpers.rs",
+        )
+        imports = result["needed_imports"]
+        import_text = "\n".join(imports)
+        # SCREAMING_CASE should NOT be treated as a trait
+        self.assertNotIn("MAX_RETRIES", import_text)
+
+    def test_type_used_literally_not_double_carried(self):
+        """If a PascalCase name IS used literally, Phase 1 handles it — no double carry."""
+        source = """use crate::types::Config;
+
+pub fn build_config() -> Config {
+    Config::default()
+}
+"""
+        moved_items = [{
+            "name": "build_config",
+            "kind": "fn",
+            "source": """pub fn build_config() -> Config {
+    Config::default()
+}""",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/big.rs",
+            "src/core/big/helpers.rs",
+        )
+        imports = result["needed_imports"]
+        # Should appear exactly once (from Phase 1, not duplicated by Phase 1b)
+        config_imports = [i for i in imports if "Config" in i]
+        self.assertEqual(len(config_imports), 1)
+
+    def test_multiple_trait_imports_carried(self):
+        """Multiple standalone trait imports should all be carried."""
+        source = """use std::io::Read;
+use std::io::Write;
+use std::path::Path;
+
+pub fn copy_data(input: &mut impl Read, output: &mut impl Write) {
+    let mut buf = [0u8; 1024];
+    loop {
+        let n = input.read(&mut buf).unwrap();
+        if n == 0 { break; }
+        output.write_all(&buf[..n]).unwrap();
+    }
+}
+"""
+        # Note: Read and Write appear in `impl Read` and `impl Write` in the
+        # function signature, so Phase 1 would catch them. Let's test the case
+        # where they DON'T appear literally.
+        moved_items = [{
+            "name": "copy_data",
+            "kind": "fn",
+            "source": """pub fn copy_data(input: &mut dyn Any, output: &mut dyn Any) {
+    let mut buf = [0u8; 1024];
+    loop {
+        let n = input.read(&mut buf).unwrap();
+        if n == 0 { break; }
+        output.write_all(&buf[..n]).unwrap();
+    }
+}""",
+        }]
+        result = resolve_imports(
+            moved_items, source,
+            "src/core/big.rs",
+            "src/core/big/helpers.rs",
+        )
+        imports = result["needed_imports"]
+        import_text = "\n".join(imports)
+        # Path IS used literally (via Path::new etc), so Phase 1 won't catch it
+        # unless it's in the source. Read and Write are not used literally.
+        self.assertIn("Read", import_text)
+        self.assertIn("Write", import_text)
 
 
 if __name__ == "__main__":

--- a/rust/scripts/refactor/visibility.py
+++ b/rust/scripts/refactor/visibility.py
@@ -1,27 +1,66 @@
-"""Visibility adjustment — add pub(crate) to items crossing module boundaries."""
+"""Visibility adjustment — adjust item visibility when crossing module boundaries.
 
+Handles two cases:
+- Private items → pub(crate) when moving to a different module
+- pub(crate) items → pub when decomposing into submodules (so pub use submod::* works)
+"""
+
+import os
 import re
+
+
+def _dest_is_child_of_source(source_path: str, dest_path: str) -> bool:
+    """Check if dest is a child module of source (decompose pattern).
+
+    When decomposing `src/core/big.rs` into `src/core/big/helpers.rs`,
+    the destination is inside the source module's directory.
+
+    Examples:
+        _dest_is_child_of_source("src/core/big.rs", "src/core/big/helpers.rs") -> True
+        _dest_is_child_of_source("src/core/big.rs", "src/other/helpers.rs") -> False
+    """
+    source_stem = os.path.splitext(source_path)[0]  # "src/core/big"
+    dest_dir = os.path.dirname(dest_path)  # "src/core/big"
+    return os.path.normpath(source_stem) == os.path.normpath(dest_dir)
 
 
 def adjust_visibility(items: list[dict], source_path: str, dest_path: str) -> dict:
     """Adjust visibility of items for cross-module use."""
     adjusted = []
+    is_decompose = _dest_is_child_of_source(source_path, dest_path)
 
     for item in items:
         source = item.get("source", "")
         vis = item.get("visibility", "")
         kind = item.get("kind", "")
 
-        # If item is private (no visibility) and moving to a different module,
-        # change to pub(crate) so it remains accessible
-        if vis == "" and kind != "impl":
-            # Find the declaration line and add pub(crate)
+        if kind == "impl":
+            # impl blocks don't have their own visibility
+            adjusted.append({
+                "source": source,
+                "changed": False,
+                "original_visibility": vis,
+                "new_visibility": vis,
+            })
+        elif vis == "":
+            # Private items → pub(crate) so they remain accessible
             new_source = add_pub_crate(source, kind)
             adjusted.append({
                 "source": new_source,
                 "changed": True,
                 "original_visibility": "",
                 "new_visibility": "pub(crate)",
+            })
+        elif vis == "pub(crate)" and is_decompose:
+            # Decompose case: pub(crate) → pub so `pub use submod::*` can
+            # re-export them. Without this, the glob re-export is invisible
+            # because pub(crate) items can't be re-exported through pub use.
+            new_source = upgrade_pub_crate_to_pub(source, kind)
+            adjusted.append({
+                "source": new_source,
+                "changed": True,
+                "original_visibility": "pub(crate)",
+                "new_visibility": "pub",
             })
         else:
             adjusted.append({
@@ -67,5 +106,31 @@ def add_pub_crate(source: str, kind: str) -> str:
                 rest = trimmed
                 lines[i] = f"{prefix}pub(crate) {rest}"
                 return '\n'.join(lines)
+
+    return source
+
+
+def upgrade_pub_crate_to_pub(source: str, kind: str) -> str:
+    """Upgrade pub(crate) to pub on an item's declaration.
+
+    When items move to submodules during decompose, pub(crate) is too
+    restrictive for `pub use submod::*` to re-export them. They need
+    full `pub` visibility within the submodule so the parent mod.rs
+    can re-export them.
+    """
+    lines = source.split('\n')
+
+    for i, line in enumerate(lines):
+        trimmed = line.lstrip()
+        # Skip doc comments and attributes
+        if trimmed.startswith("///") or trimmed.startswith("//!") or trimmed.startswith("#["):
+            continue
+        # Match pub(crate) at the start of the declaration line
+        if trimmed.startswith("pub(crate) "):
+            indent = len(line) - len(trimmed)
+            prefix = line[:indent]
+            rest = trimmed[len("pub(crate) "):]
+            lines[i] = f"{prefix}pub {rest}"
+            return '\n'.join(lines)
 
     return source


### PR DESCRIPTION
## Summary

Fixes two critical bugs in the decompose fixer that caused non-compiling Rust code (broken main 3 times):

- **visibility.py**: `pub(crate)` items weren't upgraded to `pub` when decomposing into submodules. Since `mod.rs` uses `pub use submod::*`, the glob re-export can't see `pub(crate)` items — they need full `pub`. Now detects the decompose case via path relationship and upgrades accordingly.
- **imports.py**: Standalone trait imports (e.g. `use crate::engine::local_files::FileSystem;`) were dropped when the trait name didn't appear literally in moved code. Traits used for method dispatch (`.read()`, `.write()`) are invisible to the existing name-matching logic. Added Phase 1b that conservatively carries PascalCase imports not used as explicit types — worst case is an unused import (which `cargo fix` cleans up), vs a missing trait import which breaks compilation.

## Testing

- 33 tests pass, including 6 new visibility tests and 4 new standalone trait import tests
- Tests cover: decompose upgrade, regular move unchanged, impl blocks, already-pub items, screaming case exclusion, no-double-carry, multiple traits

Fixes Extra-Chill/homeboy#986