### PR TITLE
fix(npm): harden scripts against stdout pollution breaking JSON parse

### DIFF
--- a/npm/scripts/build-npm.sh
+++ b/npm/scripts/build-npm.sh
@@ -36,7 +36,20 @@ else
   echo "No build script defined in package.json, skipping build" >&2
 fi
 
-PACK_TARBALL=$(npm pack --json | jq -r '.[0].filename // empty')
+# npm pack --json can emit lifecycle script output (prepack, prepare, etc.) to
+# stdout before the JSON array. Capture the full output, then extract only the
+# JSON portion so jq doesn't choke on leading non-JSON text.
+PACK_OUTPUT=$(npm pack --json)
+PACK_JSON=$(echo "${PACK_OUTPUT}" | sed -n '/^\[/,$p')
+
+if [[ -z "${PACK_JSON}" ]]; then
+  echo "npm pack --json did not produce valid JSON output" >&2
+  echo "Raw output:" >&2
+  echo "${PACK_OUTPUT}" >&2
+  exit 1
+fi
+
+PACK_TARBALL=$(echo "${PACK_JSON}" | jq -r '.[0].filename // empty')
 
 if [[ -z "${PACK_TARBALL}" || ! -f "${PACK_TARBALL}" ]]; then
   echo "npm pack did not produce a tarball" >&2

--- a/npm/scripts/publish-npm.sh
+++ b/npm/scripts/publish-npm.sh
@@ -37,14 +37,14 @@ fi
 PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME" version --registry "$REGISTRY" 2>/dev/null || echo "")
 
 if [[ "$CURRENT_VERSION" == "$PUBLISHED_VERSION" ]]; then
-  echo "Version $CURRENT_VERSION of $PACKAGE_NAME already published, skipping..."
+  echo "Version $CURRENT_VERSION of $PACKAGE_NAME already published, skipping..." >&2
   exit 0
 fi
 
-echo "Publishing $PACKAGE_NAME@$CURRENT_VERSION to $REGISTRY (access: $ACCESS)..."
+echo "Publishing $PACKAGE_NAME@$CURRENT_VERSION to $REGISTRY (access: $ACCESS)..." >&2
 
 publish_args=(--access "$ACCESS" --registry "$REGISTRY")
 
-npm publish "${publish_args[@]}"
+npm publish "${publish_args[@]}" >&2
 
-echo "Successfully published $PACKAGE_NAME@$CURRENT_VERSION"
+echo "Successfully published $PACKAGE_NAME@$CURRENT_VERSION" >&2

--- a/npm/scripts/validate-npm.sh
+++ b/npm/scripts/validate-npm.sh
@@ -17,9 +17,9 @@ has_validate=$(node -e "
 " 2>/dev/null || echo "no")
 
 if [[ "$has_validate" == "yes" ]]; then
-  echo "Running npm run validate..."
-  npm run validate
+  echo "Running npm run validate..." >&2
+  npm run validate >&2
 else
-  echo "No validate script defined, running npm pack --dry-run..."
-  npm pack --dry-run
+  echo "No validate script defined, running npm pack --dry-run..." >&2
+  npm pack --dry-run >&2
 fi


### PR DESCRIPTION
## Summary

- **build-npm.sh**: `npm pack --json` emits lifecycle script output (`prepack`, `prepare`, etc.) to stdout before the JSON array, which breaks homeboy core's `serde_json::from_str()` in the `release.package` step. Now captures full output and extracts only the JSON portion via `sed`, with clear error reporting if no JSON is found.
- **publish-npm.sh** & **validate-npm.sh**: Redirected all human-readable echo/npm output to stderr for consistency — stdout stays clean for machine-readable output.

## Root Cause

`npm pack --json` doesn't suppress lifecycle script stdout. When a package has `prepack`/`prepare` scripts, their output appears before the JSON array:

```
> @extrachill/tokens@0.6.0 prepack
> echo building...

building...
[
  { "filename": "extrachill-tokens-0.6.0.tgz", ... }
]
```

The previous `npm pack --json | jq` pipeline would fail because jq can't parse leading non-JSON text, and with `set -euo pipefail` the script would exit before emitting artifact JSON.

## Testing

Verified with test packages that have `prepack` lifecycle scripts — stdout now contains only the artifact JSON in all cases (with and without lifecycle scripts).

Fixes #199