### PR TITLE
fix: macOS portability — grep -P and bash gate (#1144, #1146)

### DIFF
--- a/wordpress/scripts/test/parse-test-results.sh
+++ b/wordpress/scripts/test/parse-test-results.sh
@@ -29,9 +29,17 @@ FAILED=0
 SKIPPED=0
 PARTIAL=""
 
+# Portable helper: extract the number after a label like "Tests: 42"
+# Usage: extract_count "label" "text"
+# Uses sed instead of grep -P (Perl regex) for macOS compatibility.
+extract_count() {
+    echo "$2" | sed -n "s/.*$1 *\([0-9][0-9]*\).*/\1/p" | head -1
+}
+
 # Pattern 1: "OK (N tests, N assertions)"
 if echo "$OUTPUT" | grep -qE 'OK \([0-9]+ test'; then
-    TOTAL=$(echo "$OUTPUT" | grep -oP 'OK \(\K[0-9]+' || echo "0")
+    TOTAL=$(echo "$OUTPUT" | sed -n 's/.*OK (\([0-9][0-9]*\) test.*/\1/p' | head -1)
+    TOTAL="${TOTAL:-0}"
     PASSED="$TOTAL"
     FAILED=0
     SKIPPED=0
@@ -40,14 +48,21 @@ if echo "$OUTPUT" | grep -qE 'OK \([0-9]+ test'; then
 elif echo "$OUTPUT" | grep -qE '^Tests: [0-9]+'; then
     SUMMARY_LINE=$(echo "$OUTPUT" | grep -E '^Tests: [0-9]+' | tail -1)
 
-    TOTAL=$(echo "$SUMMARY_LINE" | grep -oP 'Tests: \K[0-9]+' || echo "0")
+    TOTAL=$(extract_count "Tests:" "$SUMMARY_LINE")
+    TOTAL="${TOTAL:-0}"
 
-    ERRORS=$(echo "$SUMMARY_LINE" | grep -oP 'Errors: \K[0-9]+' || echo "0")
-    FAILURES=$(echo "$SUMMARY_LINE" | grep -oP 'Failures: \K[0-9]+' || echo "0")
-    WARNINGS=$(echo "$SUMMARY_LINE" | grep -oP 'Warnings: \K[0-9]+' || echo "0")
-    SKIP_COUNT=$(echo "$SUMMARY_LINE" | grep -oP 'Skipped: \K[0-9]+' || echo "0")
-    INCOMPLETE=$(echo "$SUMMARY_LINE" | grep -oP 'Incomplete: \K[0-9]+' || echo "0")
-    RISKY=$(echo "$SUMMARY_LINE" | grep -oP 'Risky: \K[0-9]+' || echo "0")
+    ERRORS=$(extract_count "Errors:" "$SUMMARY_LINE")
+    ERRORS="${ERRORS:-0}"
+    FAILURES=$(extract_count "Failures:" "$SUMMARY_LINE")
+    FAILURES="${FAILURES:-0}"
+    WARNINGS=$(extract_count "Warnings:" "$SUMMARY_LINE")
+    WARNINGS="${WARNINGS:-0}"
+    SKIP_COUNT=$(extract_count "Skipped:" "$SUMMARY_LINE")
+    SKIP_COUNT="${SKIP_COUNT:-0}"
+    INCOMPLETE=$(extract_count "Incomplete:" "$SUMMARY_LINE")
+    INCOMPLETE="${INCOMPLETE:-0}"
+    RISKY=$(extract_count "Risky:" "$SUMMARY_LINE")
+    RISKY="${RISKY:-0}"
 
     FAILED=$((ERRORS + FAILURES))
     SKIPPED=$((SKIP_COUNT + INCOMPLETE + RISKY + WARNINGS))

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -1,6 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bash 4.0+ required — lint-runner.sh (called during test runs) uses
+# associative arrays which are bash 4+ only. Fail early with a clear
+# message rather than producing misleading cascading errors.
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "============================================" >&2
+    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
+    echo "============================================" >&2
+    case "$(uname -s)" in
+        Darwin)
+            echo "macOS ships bash 3.2. Fix: brew install bash" >&2
+            echo "Then restart your terminal (Homebrew bash takes priority on PATH)." >&2
+            ;;
+        *)
+            echo "Update bash via your package manager." >&2
+            ;;
+    esac
+    exit 1
+fi
+
 FAILED_STEP=""
 FAILURE_OUTPUT=""
 FAILURE_REPLAY_MODE="full"
@@ -268,8 +287,10 @@ if [ "$DATABASE_TYPE" = "auto" ]; then
         done
 
         if [ -n "$WP_CONFIG_PATH" ]; then
+            # Extract a define() value from wp-config.php.
+            # Uses sed instead of grep -P for macOS (BSD grep) compatibility.
             _extract_wp_define() {
-                grep -oP "define\s*\(\s*['\"]$1['\"]\s*,\s*['\"]\\K[^'\"]*" "$WP_CONFIG_PATH" 2>/dev/null | head -1
+                sed -n "s/.*define\s*(\s*['\"]$1['\"]\s*,\s*['\"]\([^'\"]*\).*/\1/p" "$WP_CONFIG_PATH" 2>/dev/null | head -1
             }
             WP_DB_HOST=$(_extract_wp_define DB_HOST)
             WP_DB_USER=$(_extract_wp_define DB_USER)


### PR DESCRIPTION
## Summary

Two macOS portability fixes for the WordPress extension test scripts.

### #1144 — Replace `grep -P` with portable `sed`

macOS ships BSD grep which doesn't support `-P` (Perl regex). All 9 occurrences of `grep -oP` across two files replaced with portable `sed` equivalents:

**`parse-test-results.sh`** — 8 occurrences:
- Extracting counts from PHPUnit output (`Tests: N`, `Errors: N`, etc.)
- New `extract_count()` helper using `sed -n` for all label→number extractions
- `OK (N tests)` pattern also rewritten with `sed`

**`test-runner.sh`** — 1 occurrence:
- `_extract_wp_define()` used `grep -oP` with `\K` (Perl lookbehind reset) to extract wp-config.php define values
- Rewritten with `sed -n` substitution

### #1146 — Bash 4+ gate in test-runner.sh

`test-runner.sh` calls `lint-runner.sh` which uses `declare -A` (associative arrays, bash 4+ only). Without a gate, bash 3.2 on macOS produces cascading failures that look like project issues ("Tests failed, exit code 1") rather than the real cause ("bash too old").

Added the same `BASH_VERSINFO` gate pattern already used by `lint-runner.sh`, with a clear error message and macOS-specific fix instructions (`brew install bash`).

## Testing

- All `sed` patterns tested against PHPUnit output formats documented in `parse-test-results.sh` header
- Bash gate tested: `BASH_VERSINFO[0]=3` triggers clean exit with instructions

Closes Extra-Chill/homeboy#1144, closes Extra-Chill/homeboy#1146