### PR TITLE
fix(wordpress): allow leading whitespace on top-level namespace/class/use (#1134)

### DIFF
--- a/wordpress/grammar.toml
+++ b/wordpress/grammar.toml
@@ -30,7 +30,10 @@ close = '}'
 
 [patterns.namespace]
 # Matches: namespace DataMachine\Abilities;
-regex = '^namespace\s+([\w\\\\]+)\s*;'
+# Allows optional leading whitespace — PHP accepts indented top-level
+# namespace declarations (e.g. after a docblock), and `context = top_level`
+# already guarantees brace depth 0.
+regex = '^\s*namespace\s+([\w\\\\]+)\s*;'
 context = "top_level"
 skip_comments = true
 skip_strings = true
@@ -41,7 +44,8 @@ name = 1
 [patterns.class]
 # Matches: class Foo, abstract class Bar, final class Baz
 # Also: interface Qux, trait Quux
-regex = '^(?:abstract\s+)?(?:final\s+)?(class|trait|interface)\s+(\w+)(?:\s+extends\s+([\w\\\\]+))?'
+# Allows optional leading whitespace for the same reason as namespace.
+regex = '^\s*(?:abstract\s+)?(?:final\s+)?(class|trait|interface)\s+(\w+)(?:\s+extends\s+([\w\\\\]+))?'
 context = "top_level"
 skip_comments = true
 skip_strings = true
@@ -66,7 +70,8 @@ params = 3
 
 [patterns.import]
 # Matches: use App\Models\User; use App\Models\User as UserModel;
-regex = '^use\s+([\w\\\\]+)(?:\s+as\s+\w+)?\s*;'
+# Allows optional leading whitespace (valid PHP, see namespace note).
+regex = '^\s*use\s+([\w\\\\]+)(?:\s+as\s+\w+)?\s*;'
 context = "top_level"
 skip_comments = true
 skip_strings = true

--- a/wordpress/scripts/fingerprint.sh
+++ b/wordpress/scripts/fingerprint.sh
@@ -60,10 +60,12 @@ methods = [m for m in methods if m not in seen and not seen.add(m)]
 type_name = None
 type_kind = None
 type_names = []
+# Allow optional leading whitespace — valid PHP accepts indented top-level
+# class/interface/trait declarations (see #1134 for namespace equivalent).
 for kind, pattern in [
-    ('class', r'^(?:abstract\s+|final\s+)?class\s+(\w+)'),
-    ('interface', r'^interface\s+(\w+)'),
-    ('trait', r'^trait\s+(\w+)'),
+    ('class', r'^\s*(?:abstract\s+|final\s+)?class\s+(\w+)'),
+    ('interface', r'^\s*interface\s+(\w+)'),
+    ('trait', r'^\s*trait\s+(\w+)'),
 ]:
     match = re.search(pattern, content, re.MULTILINE)
     if match:
@@ -73,16 +75,16 @@ for kind, pattern in [
 
 # Collect all class/interface/trait names in the file
 for pattern in [
-    r'^(?:abstract\s+|final\s+)?class\s+(\w+)',
-    r'^interface\s+(\w+)',
-    r'^trait\s+(\w+)',
+    r'^\s*(?:abstract\s+|final\s+)?class\s+(\w+)',
+    r'^\s*interface\s+(\w+)',
+    r'^\s*trait\s+(\w+)',
 ]:
     type_names.extend(m.group(1) for m in re.finditer(pattern, content, re.MULTILINE))
 
 # --- Extends ---
 # Extract the parent class separately (anchored to actual declaration)
 extends = None
-ext_match = re.search(r'^(?:abstract\s+|final\s+)?class\s+\w+\s+extends\s+([\w\\\\]+)', content, re.MULTILINE)
+ext_match = re.search(r'^\s*(?:abstract\s+|final\s+)?class\s+\w+\s+extends\s+([\w\\\\]+)', content, re.MULTILINE)
 if ext_match:
     extends = ext_match.group(1).split('\\\\')[-1]
 
@@ -91,7 +93,7 @@ if ext_match:
 implements = []
 
 # implements (can be comma-separated, on a class/interface declaration line)
-impl_match = re.search(r'^(?:abstract\s+|final\s+)?(?:class|interface)\s+\w+(?:\s+extends\s+[\w\\\\]+)?\s+implements\s+([\w\\\\,\s]+?)(?:\s*\{)', content, re.MULTILINE)
+impl_match = re.search(r'^\s*(?:abstract\s+|final\s+)?(?:class|interface)\s+\w+(?:\s+extends\s+[\w\\\\]+)?\s+implements\s+([\w\\\\,\s]+?)(?:\s*\{)', content, re.MULTILINE)
 if impl_match:
     for iface in impl_match.group(1).split(','):
         iface = iface.strip()


### PR DESCRIPTION
Companion to [homeboy#1147](https://github.com/Extra-Chill/homeboy/pull/1147).

## What

The PHP grammar and fallback fingerprint script both anchored namespace, class/interface/trait, and use-statement patterns to `^` without tolerating leading whitespace. Indented top-level declarations (valid PHP, and used in data-machine after docblocks — e.g. `inc/Engine/AI/Tools/Global/AgentMemory.php`) dropped out of fingerprinting entirely. That surfaced as a spurious `namespace_mismatch` finding on every CI run (Extra-Chill/homeboy#1134, re-files as Extra-Chill/data-machine#682).

`context = "top_level"` already constrains the match to brace depth 0, so `^\s*` is safe — it just allows the real variance in how developers format these declarations.

## Changes

### `wordpress/grammar.toml`
- `[patterns.namespace]` — prepend `\s*`
- `[patterns.class]` — prepend `\s*`
- `[patterns.import]` — prepend `\s*`

### `wordpress/scripts/fingerprint.sh` (Python fallback)
- `class`/`interface`/`trait` primary type detection
- `type_names` collection
- `extends` extraction
- `implements` extraction

## Verification

Tested against the homeboy core fingerprint engine with the reproducer from data-machine:

```php
<?php
/**
 * Docblock.
 */

	namespace DataMachine\Engine\AI\Tools\Global;

class AgentMemory {}
```

Before: `fp.namespace = None` → false `namespace_mismatch` finding.
After: `fp.namespace = "DataMachine\\Engine\\AI\\Tools\\Global"`.

Relates to Extra-Chill/homeboy#1134.