### PR TITLE
fix: HOMEBOY_FIX_ONLY is the single auto-fix contract (#1145)

### DIFF
--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -7,7 +7,10 @@ set -euo pipefail
 # Supports the standard homeboy extension env vars:
 #   HOMEBOY_EXTENSION_PATH  — path to this extension
 #   HOMEBOY_COMPONENT_PATH  — path to the Rust project
-#   HOMEBOY_AUTO_FIX        — if "1", run cargo fmt (fix mode) instead of --check
+#   HOMEBOY_FIX_ONLY        — if "1", run cargo fmt + clippy --fix + cargo fix,
+#                             then exit without the validation pass (the engine
+#                             runs validation separately). Sent by
+#                             `homeboy refactor --from lint --write`.
 #   HOMEBOY_SUMMARY_MODE    — if "1", show compact output
 #   HOMEBOY_CHANGED_SINCE   — git ref to scope fmt check to changed files only
 #   HOMEBOY_LINT_GLOB       — file glob (currently unused for Rust — cargo operates on crates)
@@ -51,7 +54,7 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Rust Lint Environment:"
     echo "HOMEBOY_EXTENSION_PATH=${HOMEBOY_EXTENSION_PATH:-NOT_SET}"
     echo "HOMEBOY_COMPONENT_PATH=${HOMEBOY_COMPONENT_PATH:-NOT_SET}"
-    echo "HOMEBOY_AUTO_FIX=${HOMEBOY_AUTO_FIX:-NOT_SET}"
+    echo "HOMEBOY_FIX_ONLY=${HOMEBOY_FIX_ONLY:-NOT_SET}"
     echo "HOMEBOY_SUMMARY_MODE=${HOMEBOY_SUMMARY_MODE:-NOT_SET}"
     echo "HOMEBOY_ERRORS_ONLY=${HOMEBOY_ERRORS_ONLY:-NOT_SET}"
     echo "PROJECT_PATH=${PROJECT_PATH}"
@@ -68,7 +71,7 @@ echo "Running Rust lint checks..."
 
 # ── Step 1: cargo fmt ──
 if should_run_step "fmt"; then
-    if [ "${HOMEBOY_AUTO_FIX:-}" = "1" ]; then
+    if [ "${HOMEBOY_FIX_ONLY:-}" = "1" ]; then
         echo ""
         echo "Running cargo fmt (fix mode)..."
         set +e
@@ -182,8 +185,8 @@ if should_run_step "clippy"; then
         --all-targets
     )
 
-    # In fix mode, apply clippy suggestions
-    if [ "${HOMEBOY_AUTO_FIX:-}" = "1" ]; then
+    # In fix-only mode, apply clippy suggestions
+    if [ "${HOMEBOY_FIX_ONLY:-}" = "1" ]; then
         CLIPPY_ARGS+=(--fix --allow-dirty --allow-staged)
     fi
 
@@ -274,7 +277,7 @@ fi
 # Only in fix mode — applies compiler suggestions for dead_code, unused_imports,
 # unused_variables, etc. These are the warnings that `cargo check` reports.
 if should_run_step "fix"; then
-    if [ "${HOMEBOY_AUTO_FIX:-}" = "1" ]; then
+    if [ "${HOMEBOY_FIX_ONLY:-}" = "1" ]; then
         echo ""
         echo "Running cargo fix (compiler warnings)..."
 
@@ -289,7 +292,7 @@ if should_run_step "fix"; then
         if [ $FIX_EXIT -eq 0 ]; then
             echo "cargo fix: applied compiler warning fixes"
         else
-            # cargo fix failure is non-fatal in fix mode — some warnings
+            # cargo fix failure is non-fatal in fix-only mode — some warnings
             # can't be auto-fixed (e.g., dead_code on pub items).
             echo "cargo fix: exited non-zero (${FIX_EXIT}), continuing"
             if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -299,7 +302,7 @@ if should_run_step "fix"; then
         fi
     else
         echo ""
-        echo "Skipping cargo fix (only runs in fix mode)"
+        echo "Skipping cargo fix (only runs in fix-only mode)"
     fi
 else
     echo "Skipping cargo fix (step filter)"

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -7,7 +7,9 @@ set -euo pipefail
 #   HOMEBOY_EXTENSION_PATH  — path to this extension
 #   HOMEBOY_COMPONENT_PATH  — path to the Rust project
 #   HOMEBOY_SKIP_LINT       — if "1", skip the pre-test lint step
-#   HOMEBOY_AUTO_FIX        — if "1", auto-fix before testing
+#   HOMEBOY_FIX_ONLY        — if "1", propagates to the nested lint-runner so
+#                             the pre-test lint step runs in fix mode. Sent by
+#                             `homeboy refactor --from test --write`.
 #   HOMEBOY_STEP            — comma-separated steps to run (lint, test)
 #   HOMEBOY_SKIP            — comma-separated steps to skip
 #   HOMEBOY_DEBUG           — if "1", show debug output
@@ -55,7 +57,7 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "HOMEBOY_EXTENSION_PATH=${HOMEBOY_EXTENSION_PATH:-NOT_SET}"
     echo "HOMEBOY_COMPONENT_PATH=${HOMEBOY_COMPONENT_PATH:-NOT_SET}"
     echo "HOMEBOY_SKIP_LINT=${HOMEBOY_SKIP_LINT:-NOT_SET}"
-    echo "HOMEBOY_AUTO_FIX=${HOMEBOY_AUTO_FIX:-NOT_SET}"
+    echo "HOMEBOY_FIX_ONLY=${HOMEBOY_FIX_ONLY:-NOT_SET}"
     echo "PROJECT_PATH=${PROJECT_PATH}"
     echo "Passthrough args: $*"
 fi

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -2,8 +2,11 @@
 set -euo pipefail
 
 # Standalone JavaScript linting script using ESLint
-# Supports auto-fix mode via HOMEBOY_AUTO_FIX=1
+# Supports fix-only mode via HOMEBOY_FIX_ONLY=1 (sent by `homeboy refactor`)
 # Supports summary mode via HOMEBOY_SUMMARY_MODE=1
+#
+# HOMEBOY_FIX_ONLY=1 is the single auto-fix contract: the runner executes
+# ESLint --fix and exits before the validation pass (#1145).
 
 # Debug environment variables (only shown when HOMEBOY_DEBUG=1)
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -11,7 +14,7 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "HOMEBOY_EXTENSION_PATH=${HOMEBOY_EXTENSION_PATH:-NOT_SET}"
     echo "HOMEBOY_COMPONENT_ID=${HOMEBOY_COMPONENT_ID:-NOT_SET}"
     echo "HOMEBOY_COMPONENT_PATH=${HOMEBOY_COMPONENT_PATH:-NOT_SET}"
-    echo "HOMEBOY_AUTO_FIX=${HOMEBOY_AUTO_FIX:-NOT_SET}"
+    echo "HOMEBOY_FIX_ONLY=${HOMEBOY_FIX_ONLY:-NOT_SET}"
     echo "HOMEBOY_SUMMARY_MODE=${HOMEBOY_SUMMARY_MODE:-NOT_SET}"
     echo "HOMEBOY_ERRORS_ONLY=${HOMEBOY_ERRORS_ONLY:-NOT_SET}"
 fi
@@ -83,7 +86,7 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "Extension path: $EXTENSION_PATH"
     echo "Plugin path: $PLUGIN_PATH"
     echo "Lint files: ${LINT_FILES[*]}"
-    echo "Auto-fix: ${HOMEBOY_AUTO_FIX:-0}"
+    echo "Fix-only: ${HOMEBOY_FIX_ONLY:-0}"
 fi
 
 ESLINT_BIN="${EXTENSION_PATH}/node_extensions/.bin/eslint"
@@ -125,8 +128,9 @@ fi
 # Run from plugin directory to ensure jsconfig.json is found by import resolver
 cd "$PLUGIN_PATH"
 
-# Auto-fix mode
-if [[ "${HOMEBOY_AUTO_FIX:-}" == "1" ]]; then
+# Fix-only mode: run ESLint --fix and exit before the validation pass.
+# Sent by `homeboy refactor --from lint --write` — the engine validates separately.
+if [[ "${HOMEBOY_FIX_ONLY:-}" == "1" ]]; then
     echo "Running ESLint auto-fix..."
     set +e
     "$ESLINT_BIN" "${eslint_base_args[@]}" --fix "${LINT_FILES[@]}"
@@ -137,7 +141,10 @@ if [[ "${HOMEBOY_AUTO_FIX:-}" == "1" ]]; then
         echo ""
         echo "WARNING: Some ESLint errors could not be auto-fixed."
     fi
+
     echo ""
+    echo "Fix-only mode: skipping validation (run 'homeboy lint' separately to validate)"
+    exit 0
 fi
 
 # Get JSON report for summary

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -22,9 +22,13 @@ if ((BASH_VERSINFO[0] < 4)); then
 fi
 
 # Standalone PHP linting script using PHPCS/PHPCBF
-# Supports auto-fix mode via HOMEBOY_AUTO_FIX=1
+# Supports fix-only mode via HOMEBOY_FIX_ONLY=1 (sent by `homeboy refactor`)
 # Supports summary mode via HOMEBOY_SUMMARY_MODE=1
 # Supports step filtering via HOMEBOY_STEP/HOMEBOY_SKIP (steps: phpcs, eslint, phpstan)
+#
+# HOMEBOY_FIX_ONLY=1 is the single auto-fix contract: the runner executes
+# fixers (phpcbf + custom) and skips its own validation pass. All auto-fix
+# flows go through `homeboy refactor --from lint --write` (#1145).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/../lib/runner-steps.sh}"
@@ -37,7 +41,7 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "HOMEBOY_EXTENSION_PATH=${HOMEBOY_EXTENSION_PATH:-NOT_SET}"
     echo "HOMEBOY_COMPONENT_ID=${HOMEBOY_COMPONENT_ID:-NOT_SET}"
     echo "HOMEBOY_COMPONENT_PATH=${HOMEBOY_COMPONENT_PATH:-NOT_SET}"
-    echo "HOMEBOY_AUTO_FIX=${HOMEBOY_AUTO_FIX:-NOT_SET}"
+    echo "HOMEBOY_FIX_ONLY=${HOMEBOY_FIX_ONLY:-NOT_SET}"
     echo "HOMEBOY_SUMMARY_MODE=${HOMEBOY_SUMMARY_MODE:-NOT_SET}"
     echo "HOMEBOY_SNIFFS=${HOMEBOY_SNIFFS:-NOT_SET}"
     echo "HOMEBOY_EXCLUDE_SNIFFS=${HOMEBOY_EXCLUDE_SNIFFS:-NOT_SET}"
@@ -129,7 +133,7 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "Extension path: $EXTENSION_PATH"
     echo "Plugin path: $PLUGIN_PATH"
     echo "Lint files: ${LINT_FILES[*]}"
-    echo "Auto-fix: ${HOMEBOY_AUTO_FIX:-0}"
+    echo "Fix-only: ${HOMEBOY_FIX_ONLY:-0}"
 fi
 
 PHPCS_BIN="${EXTENSION_PATH}/vendor/bin/phpcs"
@@ -227,8 +231,9 @@ if [ -n "$PHP_VERSION" ]; then
     echo "PHP compatibility target: ${PHP_VERSION}-"
 fi
 
-# Auto-fix mode: run custom fixers, then phpcbf, then phpcs
-if [[ "${HOMEBOY_AUTO_FIX:-}" == "1" ]]; then
+# Fix-only mode: run custom fixers, then phpcbf, then exit before validation.
+# Sent by `homeboy refactor --from lint --write` — the engine validates separately.
+if [[ "${HOMEBOY_FIX_ONLY:-}" == "1" ]]; then
     # --- Fix results sidecar ---
     # Track what each fixer does so homeboy can report structured fix output.
     # Each fixer prints "NAME fixer: Fixed N thing(s) in N file(s)" on success.
@@ -463,13 +468,12 @@ print(json.dumps(results))
     fi
     echo "Syntax OK — all PHP files pass php -l"
 
-    # In fix-only mode, skip the validation pass — the caller will validate separately.
-    # This saves ~35s on large codebases by avoiding a redundant PHPCS scan.
-    if [[ "${HOMEBOY_FIX_ONLY:-}" == "1" ]]; then
-        echo ""
-        echo "Fix-only mode: skipping validation (run 'homeboy lint' separately to validate)"
-        exit 0
-    fi
+    # Fix-only mode always skips the validation pass — `homeboy refactor`
+    # validates separately via the diagnose phase. Saves ~35s on large
+    # codebases by avoiding a redundant PHPCS scan.
+    echo ""
+    echo "Fix-only mode: skipping validation (run 'homeboy lint' separately to validate)"
+    exit 0
 fi
 
 # Validation

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -406,7 +406,7 @@ run_lint() {
 
     # Capture lint output to detect issues (lint-runner.sh always exits 0 in summary mode)
     local lint_output
-    lint_output=$(HOMEBOY_SUMMARY_MODE=1 HOMEBOY_AUTO_FIX="${HOMEBOY_AUTO_FIX:-}" bash "$lint_runner" 2>&1)
+    lint_output=$(HOMEBOY_SUMMARY_MODE=1 HOMEBOY_FIX_ONLY="${HOMEBOY_FIX_ONLY:-}" bash "$lint_runner" 2>&1)
     echo "$lint_output"
 
     # Detect if lint reported issues
@@ -481,7 +481,7 @@ if [ -f "$LOCAL_BOOTSTRAP" ]; then
     echo "⚠ Warning: Local bootstrap.php found and will be IGNORED"
     echo "  Location: $LOCAL_BOOTSTRAP"
     echo "  Homeboy WordPress extension provides complete test infrastructure."
-    if [ "${HOMEBOY_AUTO_FIX:-}" = "1" ]; then
+    if [ "${HOMEBOY_FIX_ONLY:-}" = "1" ]; then
         echo "  → Auto-fix: Removing $LOCAL_BOOTSTRAP"
         rm -f "$LOCAL_BOOTSTRAP"
         echo "  ✓ Removed"
@@ -497,7 +497,7 @@ if [ -f "$LOCAL_PHPUNIT_XML" ]; then
     echo "⚠ Warning: Local phpunit.xml found in tests/ and will be IGNORED"
     echo "  Location: $LOCAL_PHPUNIT_XML"
     echo "  Homeboy WordPress extension provides PHPUnit configuration."
-    if [ "${HOMEBOY_AUTO_FIX:-}" = "1" ]; then
+    if [ "${HOMEBOY_FIX_ONLY:-}" = "1" ]; then
         echo "  → Auto-fix: Removing $LOCAL_PHPUNIT_XML"
         rm -f "$LOCAL_PHPUNIT_XML"
         echo "  ✓ Removed"
@@ -512,7 +512,7 @@ if [ -f "$LOCAL_PHPUNIT_XML_ROOT" ]; then
     echo ""
     echo "⚠ Warning: Local phpunit.xml found in root and will be IGNORED"
     echo "  Location: $LOCAL_PHPUNIT_XML_ROOT"
-    if [ "${HOMEBOY_AUTO_FIX:-}" = "1" ]; then
+    if [ "${HOMEBOY_FIX_ONLY:-}" = "1" ]; then
         echo "  → Auto-fix: Removing $LOCAL_PHPUNIT_XML_ROOT"
         rm -f "$LOCAL_PHPUNIT_XML_ROOT"
         echo "  ✓ Removed"
@@ -527,7 +527,7 @@ if [ -f "$LOCAL_PHPUNIT_XML_DIST_ROOT" ]; then
     echo ""
     echo "⚠ Warning: Local phpunit.xml.dist found in root and will be IGNORED"
     echo "  Location: $LOCAL_PHPUNIT_XML_DIST_ROOT"
-    if [ "${HOMEBOY_AUTO_FIX:-}" = "1" ]; then
+    if [ "${HOMEBOY_FIX_ONLY:-}" = "1" ]; then
         echo "  → Auto-fix: Removing $LOCAL_PHPUNIT_XML_DIST_ROOT"
         rm -f "$LOCAL_PHPUNIT_XML_DIST_ROOT"
         echo "  ✓ Removed"
@@ -546,14 +546,14 @@ if [ -f "$LOCAL_PHPUNIT_BIN" ]; then
     echo "  Location: $LOCAL_PHPUNIT_BIN"
     echo "  Homeboy WordPress extension provides PHPUnit through its own vendor directory."
     echo "  Having two PHPUnit versions can cause version mismatches and confusing failures."
-    if [ "${HOMEBOY_AUTO_FIX:-}" = "1" ]; then
+    if [ "${HOMEBOY_FIX_ONLY:-}" = "1" ]; then
         echo "  → Auto-fix: Removing local phpunit from require-dev and vendor..."
         (cd "$PLUGIN_PATH" && composer remove --dev phpunit/phpunit 2>/dev/null || true)
         echo "  ✓ Removed"
         TEST_FIX_ENTRIES+=("{\"file\": \"composer.json\", \"rule\": \"test-infra-cleanup\", \"action\": \"remove-phpunit-dep\"}")
     else
         echo "  Fix: composer remove --dev phpunit/phpunit (in $PLUGIN_PATH)"
-        echo "  Or run: homeboy test ${COMPONENT_ID:-} --fix"
+        echo "  Or run: homeboy refactor ${COMPONENT_ID:-} --from test --write"
     fi
     echo ""
 fi
@@ -564,14 +564,14 @@ if [ ! -f "$LOCAL_PHPUNIT_BIN" ] && [ -f "${PLUGIN_PATH}/composer.json" ]; then
         echo ""
         echo "⚠ Warning: phpunit/phpunit found in composer.json require-dev"
         echo "  Homeboy WordPress extension provides PHPUnit — the local dependency is redundant."
-        if [ "${HOMEBOY_AUTO_FIX:-}" = "1" ]; then
+        if [ "${HOMEBOY_FIX_ONLY:-}" = "1" ]; then
             echo "  → Auto-fix: Removing phpunit from require-dev..."
             (cd "$PLUGIN_PATH" && composer remove --dev phpunit/phpunit 2>/dev/null || true)
             echo "  ✓ Removed"
             TEST_FIX_ENTRIES+=("{\"file\": \"composer.json\", \"rule\": \"test-infra-cleanup\", \"action\": \"remove-phpunit-dep\"}")
         else
             echo "  Fix: composer remove --dev phpunit/phpunit (in $PLUGIN_PATH)"
-            echo "  Or run: homeboy test ${COMPONENT_ID:-} --fix"
+            echo "  Or run: homeboy refactor ${COMPONENT_ID:-} --from test --write"
         fi
         echo ""
     fi


### PR DESCRIPTION
Companion to [homeboy#1148](https://github.com/Extra-Chill/homeboy/pull/1148).

## The bug

When homeboy core invokes a runner with `HOMEBOY_FIX_ONLY=1` (sent by `refactor --from lint/test --write`), the runner's auto-fix block never executes because it's gated on a different env var (`HOMEBOY_AUTO_FIX=1`). Findings are detected, 0 fixes applied.

## The fix

**Rip `HOMEBOY_AUTO_FIX` out entirely.** `HOMEBOY_FIX_ONLY=1` is now the single env-var contract. When set, the runner:

1. Runs its fixers (phpcbf + custom PHP fixers, ESLint `--fix`, `cargo fmt` + `clippy --fix` + `cargo fix`)
2. Exits before the validation pass — the engine validates separately via the diagnose phase

All auto-fix flows go through `homeboy refactor`. No other entry point.

## Why drop `HOMEBOY_AUTO_FIX` entirely?

The old `homeboy lint --fix` / `homeboy test --fix` entry points are gone — subsumed by the refactor engine. Nothing in homeboy core sets `HOMEBOY_AUTO_FIX` anymore, so supporting it in the runners is dead code that just creates confusion (as #1145 proved).

## Files changed

### `wordpress/scripts/lint/lint-runner.sh`
- Fix block gates on `HOMEBOY_FIX_ONLY`.
- Redundant inner `HOMEBOY_FIX_ONLY` exit check collapsed into the outer gate.

### `wordpress/scripts/lint/eslint-runner.sh`
- Fix block gates on `HOMEBOY_FIX_ONLY`.
- **New behavior**: exits before validation (matches PHP runner semantics).

### `wordpress/scripts/test/test-runner.sh`
- All 6 test-infra cleanup branches gate on `HOMEBOY_FIX_ONLY`.
- Nested lint invocation forwards `HOMEBOY_FIX_ONLY` instead of `HOMEBOY_AUTO_FIX`.
- User-facing error messages now suggest `homeboy refactor … --from test --write` instead of the removed `homeboy test --fix` form.

### `rust/scripts/lint-runner.sh`
- `cargo fmt`, `clippy --fix`, and `cargo fix` all gate on `HOMEBOY_FIX_ONLY`.

### `rust/scripts/test-runner.sh`
- Docstring + debug output reference `HOMEBOY_FIX_ONLY`.
- (No behavior change — this runner only forwards env vars to the nested lint-runner.)

## Verification

```
$ for f in lint-runner.sh eslint-runner.sh test-runner.sh (wordpress) \
           lint-runner.sh test-runner.sh (rust); do
    bash -n "$f"; echo "$f: OK"
done
# all pass
```

End-to-end validation: `homeboy refactor <component> --from lint --write` against a dirty component should produce `edit_count > 0` and phpcbf output.

Relates to Extra-Chill/homeboy#1145.