### PR TITLE
wordpress: add Playground as opt-in test backend (Phase 1 of #214)

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -147,10 +147,8 @@ backend. It boots a WordPress Playground instance, mounts the plugin, and
 runs PHPUnit inside PHP-WASM. No host PHP or MySQL is required.
 
 **Limitations (Phase 1):**
-- Database tables are not created (`WP_TESTS_SKIP_INSTALL=1`). Tests using
-  `WP_UnitTestCase` factory methods (user/post creation) will fail with
-  "no such table" errors.
 - WordPress version is pinned to match the wp-phpunit package (currently 6.9.x).
+- Custom `db.php` drop-ins may conflict with Playground's built-in SQLite integration.
 
 ### Database Options
 

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -125,6 +125,33 @@ The WordPress test framework provides factories for creating test data:
 | `HOMEBOY_SKIP_TESTS` | Skip PHPUnit tests | `0` |
 | `HOMEBOY_DEBUG` | Show debug output | `0` |
 
+### Test Backend
+
+The extension supports two test execution backends:
+
+| Backend | Description | Default |
+|---------|-------------|---------|
+| `host` | PHPUnit with host PHP + wp-phpunit + SQLite/MySQL | Yes |
+| `playground` | PHPUnit inside WordPress Playground (PHP-WASM + SQLite) | No |
+
+```bash
+# Switch a component to Playground backend
+homeboy component set my-plugin test_backend playground
+
+# Switch back to host backend
+homeboy component set my-plugin test_backend host
+```
+
+The Playground backend is **opt-in** and does not affect the default host
+backend. It boots a WordPress Playground instance, mounts the plugin, and
+runs PHPUnit inside PHP-WASM. No host PHP or MySQL is required.
+
+**Limitations (Phase 1):**
+- Database tables are not created (`WP_TESTS_SKIP_INSTALL=1`). Tests using
+  `WP_UnitTestCase` factory methods (user/post creation) will fail with
+  "no such table" errors.
+- WordPress version is pinned to match the wp-phpunit package (currently 6.9.x).
+
 ### Database Options
 
 The extension supports MySQL or SQLite for tests. The default is **`auto`**: the
@@ -172,7 +199,12 @@ Files that can be safely removed after migration:
 ```
 wordpress/
 ├── scripts/
-│   ├── test-runner.sh      # Main test orchestration
+│   ├── test/
+│   │   ├── test-runner.sh              # Main test orchestration (host backend)
+│   │   ├── test-runner-playground.sh   # Playground backend runner
+│   │   ├── generate-config.sh          # WordPress config generation
+│   │   ├── parse-test-results.sh       # Result parsing for homeboy core
+│   │   └── parse-test-failures.sh      # Failure parsing for homeboy core
 │   ├── build.sh            # Production build script
 │   ├── lint.sh             # Standalone linting
 │   └── generate-config.sh  # WordPress config generation
@@ -182,7 +214,7 @@ wordpress/
 ├── phpcs.xml.dist          # PHPCS configuration
 ├── .eslintrc.json          # ESLint configuration
 ├── composer.json           # PHP dependencies
-└── package.json            # Node dependencies
+└── package.json            # Node dependencies (ESLint + @wp-playground/cli)
 ```
 
 ## Blocking vs Advisory

--- a/wordpress/TEST_INFRASTRUCTURE_PLAN.md
+++ b/wordpress/TEST_INFRASTRUCTURE_PLAN.md
@@ -465,8 +465,8 @@ SQLite) instead of host PHP. Does not replace the host backend.
 | Add backend dispatch in test-runner.sh | scripts/test/test-runner.sh | ✅ Complete |
 | Update setup.sh for Playground deps | scripts/build/setup.sh | ✅ Complete |
 | Update README with backend docs | README.md | ✅ Complete |
-| In-process WP install (replace `system()` call) | — | 🔲 Blocked |
-| PHPUnit stdout forwarding | — | 🔲 Upstream gap |
+| In-process WP install (replace `system()` call) | — | ✅ Complete |
+| PHPUnit stdout forwarding | — | ✅ Complete |
 | db.php drop-in support (MDI test) | — | 🔲 Pending |
 
 **Architecture:**
@@ -491,23 +491,18 @@ SQLite) instead of host PHP. Does not replace the host backend.
 
 **Known Gaps (Phase 1):**
 
-1. **No DB tables.** `WP_TESTS_SKIP_INSTALL=1` is required because Playground's
-   PHP-WASM cannot spawn subprocesses via `system()`. The wp-phpunit `install.php`
-   is normally run as a child PHP process. Tests using `WP_UnitTestCase` factory
-   methods fail with "no such table". Fix: rewrite install.php as an in-process
-   include (set `$argv` before `require_once`).
-
-2. **No PHPUnit stdout.** The `wp-playground-cli php` subcommand does not forward
-   PHP's stdout to the host terminal when the process exits non-zero. Workaround:
-   results are written to a host-mounted log file and parsed after the run.
-
-3. **WP version pinning.** The `--wp` flag must match the wp-phpunit package
+1. **WP version pinning.** The `--wp` flag must match the wp-phpunit package
    version (currently 6.9.x). Mismatch causes missing class errors in the
    wp-phpunit bootstrap.
 
-4. **db.php drop-in support.** Custom `db.php` drop-ins (e.g., markdown-database-
+2. **db.php drop-in support.** Custom `db.php` drop-ins (e.g., markdown-database-
    integration) can be mounted into the Playground VFS, but Playground's built-in
    SQLite integration may conflict. Needs per-case testing.
+
+3. **No host bootstrap.** The Playground backend does not use `tests/bootstrap.php`.
+    It runs `install.php` in-process and loads test case classes directly. Any
+   customizations in the host bootstrap (e.g., additional `tests_add_filter` calls)
+   won't apply.
 
 **References:**
 - Issue: Extra-Chill/homeboy-extensions#214

--- a/wordpress/TEST_INFRASTRUCTURE_PLAN.md
+++ b/wordpress/TEST_INFRASTRUCTURE_PLAN.md
@@ -452,6 +452,67 @@ composer test
 | PHPUnit only when tests exist | ✅ Complete |
 | Per-component reporting | ✅ Complete |
 
+### 🔧 Phase 5: Playground Backend (IN PROGRESS — Phase 1 of #214)
+
+Opt-in backend that runs PHPUnit inside WordPress Playground (PHP-WASM + embedded
+SQLite) instead of host PHP. Does not replace the host backend.
+
+| Task | File | Status |
+|------|------|--------|
+| Add `test_backend` setting to wordpress.json | wordpress.json | ✅ Complete |
+| Add `@wp-playground/cli` to package.json | package.json | ✅ Complete |
+| Create test-runner-playground.sh | scripts/test/test-runner-playground.sh | ✅ Complete |
+| Add backend dispatch in test-runner.sh | scripts/test/test-runner.sh | ✅ Complete |
+| Update setup.sh for Playground deps | scripts/build/setup.sh | ✅ Complete |
+| Update README with backend docs | README.md | ✅ Complete |
+| In-process WP install (replace `system()` call) | — | 🔲 Blocked |
+| PHPUnit stdout forwarding | — | 🔲 Upstream gap |
+| db.php drop-in support (MDI test) | — | 🔲 Pending |
+
+**Architecture:**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                  test-runner.sh (router)                         │
+│  Reads test_backend from settings JSON                          │
+│  ├── "host"      → runs existing host-PHP PHPUnit path          │
+│  └── "playground" → exec test-runner-playground.sh              │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                  test-runner-playground.sh
+                              │
+┌─────────────────────────────────────────────────────────────────┐
+│  1. Generate PHP wrapper (env vars + bootstrap + PHPUnit)       │
+│  2. Build mount list (plugin + deps + extension)                │
+│  3. Run via: wp-playground-cli php --mount ... -- /runner.php   │
+│  4. Capture results via host-mounted .pg-test-result.txt        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Known Gaps (Phase 1):**
+
+1. **No DB tables.** `WP_TESTS_SKIP_INSTALL=1` is required because Playground's
+   PHP-WASM cannot spawn subprocesses via `system()`. The wp-phpunit `install.php`
+   is normally run as a child PHP process. Tests using `WP_UnitTestCase` factory
+   methods fail with "no such table". Fix: rewrite install.php as an in-process
+   include (set `$argv` before `require_once`).
+
+2. **No PHPUnit stdout.** The `wp-playground-cli php` subcommand does not forward
+   PHP's stdout to the host terminal when the process exits non-zero. Workaround:
+   results are written to a host-mounted log file and parsed after the run.
+
+3. **WP version pinning.** The `--wp` flag must match the wp-phpunit package
+   version (currently 6.9.x). Mismatch causes missing class errors in the
+   wp-phpunit bootstrap.
+
+4. **db.php drop-in support.** Custom `db.php` drop-ins (e.g., markdown-database-
+   integration) can be mounted into the Playground VFS, but Playground's built-in
+   SQLite integration may conflict. Needs per-case testing.
+
+**References:**
+- Issue: Extra-Chill/homeboy-extensions#214
+- Playground CLI: https://www.npmjs.com/package/@wp-playground/cli
+
 ---
 
 ## 13. Benefits Summary

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -6,6 +6,7 @@
     "lint:js": "eslint --ext .js,.jsx,.ts,.tsx"
   },
   "devDependencies": {
+    "@wp-playground/cli": "^3.1.20",
     "@wordpress/eslint-plugin": "^24.2.0",
     "eslint": "^8.57.0"
   },

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -6,18 +6,24 @@ EXTENSION_PATH="$(pwd)"
 
 echo "Setting up WordPress test infrastructure..."
 
-# Install PHP dependencies
+# Install PHP dependencies (host backend: wp-phpunit, phpcs, phpunit)
 cd "$EXTENSION_PATH"
 composer install --quiet --no-interaction
 
-# Install npm dependencies for ESLint
+# Install npm dependencies (ESLint + Playground CLI)
 if [ -f "package.json" ]; then
-    echo "Installing ESLint dependencies..."
+    echo "Installing npm dependencies (ESLint + @wp-playground/cli)..."
     npm install --quiet --no-fund --no-audit 2>&1 || {
-        echo "Warning: npm install failed, ESLint linting will be skipped"
+        echo "Warning: npm install failed, ESLint and Playground backend will be unavailable"
     }
 fi
 
 echo "WordPress test infrastructure installed successfully"
-echo "WP_TESTS_DIR: $EXTENSION_PATH/vendor/wp-phpunit/wp-phpunit/tests/phpunit"
-echo "ABSPATH: $EXTENSION_PATH/vendor/wp-phpunit/wp-phpunit/wordpress"
+echo ""
+echo "Host backend (default):"
+echo "  WP_TESTS_DIR: $EXTENSION_PATH/vendor/wp-phpunit/wp-phpunit/tests/phpunit"
+echo "  ABSPATH: cached WordPress (downloaded on first run)"
+echo ""
+echo "Playground backend (opt-in):"
+echo "  CLI: $EXTENSION_PATH/node_modules/.bin/wp-playground"
+echo "  Activate: homeboy component set <id> test_backend playground"

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -1,0 +1,148 @@
+<?php
+error_reporting(E_ALL & ~E_WARNING & ~E_NOTICE & ~E_DEPRECATED);
+
+$result_file = '/wordpress/wp-content/plugins/{{PLUGIN_SLUG}}/.pg-test-result.txt';
+
+function log_msg($msg) {
+    global $result_file;
+    file_put_contents($result_file, $msg . "\n", FILE_APPEND);
+}
+
+register_shutdown_function(function() {
+    global $result_file;
+    $error = error_get_last();
+    if ($error && $error['type'] === E_ERROR) {
+        file_put_contents($result_file, "FATAL: {$error['message']}\n", FILE_APPEND);
+    }
+});
+
+$tests_dir = '/homeboy-extension/vendor/wp-phpunit/wp-phpunit';
+$plugin_path = '/wordpress/wp-content/plugins/{{PLUGIN_SLUG}}';
+
+file_put_contents("$tests_dir/wp-tests-config.php", <<<'CONFIG'
+<?php
+$table_prefix = 'wptests_';
+define('DB_NAME', ':memory:');
+define('DB_USER', 'root');
+define('DB_PASSWORD', '');
+define('DB_HOST', 'localhost');
+define('DB_CHARSET', 'utf8');
+define('WP_TESTS_DOMAIN', 'example.org');
+define('WP_TESTS_EMAIL', 'admin@example.org');
+define('WP_TESTS_TITLE', 'Test Blog');
+define('WP_PHP_BINARY', 'php');
+define('ABSPATH', '/wordpress/');
+define('FS_CHMOD_FILE', 0644);
+define('FS_CHMOD_DIR', 0755);
+define('FS_METHOD', 'direct');
+CONFIG
+);
+
+require_once '/homeboy-extension/vendor/autoload.php';
+log_msg("BOOT OK");
+
+$argv = ['install.php', "$tests_dir/wp-tests-config.php", 'no_ms_tests', 'no_core_tests'];
+$_SERVER['argv'] = $argv;
+
+log_msg("INSTALLING");
+require_once "$tests_dir/includes/install.php";
+log_msg("INSTALLED");
+
+while (ob_get_level() > 0) @ob_end_clean();
+
+global $phpmailer;
+require_once "$tests_dir/includes/mock-mailer.php";
+$phpmailer = new MockPHPMailer(true);
+
+require_once "$tests_dir/includes/functions.php";
+$GLOBALS['_wp_die_disabled'] = false;
+tests_add_filter('wp_die_handler', '_wp_die_handler_filter');
+tests_add_filter('wp_rest_server_class', '_wp_rest_server_class_filter');
+tests_add_filter('async_update_translation', '__return_false');
+tests_add_filter('automatic_updater_disabled', '__return_true');
+
+require_once "$tests_dir/includes/phpunit6/compat.php";
+require_once "$tests_dir/includes/phpunit-adapter-testcase.php";
+require_once "$tests_dir/includes/abstract-testcase.php";
+require_once "$tests_dir/includes/testcase.php";
+require_once "$tests_dir/includes/testcase-rest-api.php";
+require_once "$tests_dir/includes/testcase-rest-controller.php";
+require_once "$tests_dir/includes/testcase-rest-post-type-controller.php";
+require_once "$tests_dir/includes/testcase-xmlrpc.php";
+require_once "$tests_dir/includes/testcase-ajax.php";
+require_once "$tests_dir/includes/testcase-canonical.php";
+require_once "$tests_dir/includes/testcase-xml.php";
+require_once "$tests_dir/includes/exceptions.php";
+require_once "$tests_dir/includes/utils.php";
+require_once "$tests_dir/includes/spy-rest-server.php";
+require_once "$tests_dir/includes/class-wp-rest-test-search-handler.php";
+require_once "$tests_dir/includes/class-wp-rest-test-configurable-controller.php";
+require_once "$tests_dir/includes/class-wp-fake-block-type.php";
+require_once "$tests_dir/includes/class-wp-fake-hasher.php";
+require_once "$tests_dir/includes/class-wp-sitemaps-test-provider.php";
+require_once "$tests_dir/includes/class-wp-sitemaps-empty-test-provider.php";
+require_once "$tests_dir/includes/class-wp-sitemaps-large-test-provider.php";
+
+log_msg("TEST_CLASSES_LOADED");
+
+$dep_paths = '{{PLAYGROUND_DEP_MOUNTS}}';
+if (!empty($dep_paths)) {
+    foreach (explode("\n", $dep_paths) as $dep_mount) {
+        $dep_mount = trim($dep_mount);
+        if (empty($dep_mount)) continue;
+        $dep_files = glob("$dep_mount/*.php");
+        foreach ($dep_files as $df) {
+            if (strpos(file_get_contents($df), 'Plugin Name:') !== false) {
+                require_once $df;
+                break;
+            }
+        }
+    }
+}
+
+$style_css = "$plugin_path/style.css";
+if (file_exists($style_css) && strpos(file_get_contents($style_css), 'Theme Name:') !== false) {
+    log_msg("THEME_DETECTED");
+    $fn_php = "$plugin_path/functions.php";
+    if (file_exists($fn_php)) require_once $fn_php;
+} else {
+    $main_files = glob("$plugin_path/*.php");
+    foreach ($main_files as $mf) {
+        if (strpos(file_get_contents($mf), 'Plugin Name:') !== false) {
+            log_msg("PLUGIN_DETECTED " . basename($mf));
+            require_once $mf;
+            break;
+        }
+    }
+}
+
+$test_dir = "$plugin_path/tests";
+$test_files = array_merge(
+    glob("$test_dir/test-*.php") ?: [],
+    glob("$test_dir/*Test.php") ?: []
+);
+if (empty($test_files)) {
+    log_msg("NO_TEST_FILES");
+    exit(1);
+}
+
+$suite = new PHPUnit\Framework\TestSuite('Playground Tests');
+$before_classes = get_declared_classes();
+foreach ($test_files as $tf) {
+    require_once $tf;
+}
+$after_classes = get_declared_classes();
+$new_classes = array_diff($after_classes, $before_classes);
+foreach ($new_classes as $class_name) {
+    $ref = new ReflectionClass($class_name);
+    if (!$ref->isAbstract() && $ref->isSubclassOf('PHPUnit\\Framework\\TestCase')) {
+        $suite->addTestSuite($class_name);
+    }
+}
+
+log_msg("RUNNING " . count($test_files) . " TEST FILES");
+$runner = new PHPUnit\TextUI\TestRunner();
+$result = $runner->run($suite, ['colors' => 'never', 'testdox' => true, 'verbose' => false]);
+log_msg($result->wasSuccessful() ? "ALL TESTS PASSED" : "SOME TESTS FAILED");
+log_msg("TESTS: " . $result->count() . " FAILURES: " . count($result->failures()) . " ERRORS: " . count($result->errors()));
+exit($result->wasSuccessful() ? 0 : 1);

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -19,7 +19,8 @@ register_shutdown_function(function() {
 $tests_dir = '/homeboy-extension/vendor/wp-phpunit/wp-phpunit';
 $plugin_path = '/wordpress/wp-content/plugins/{{PLUGIN_SLUG}}';
 
-file_put_contents("$tests_dir/wp-tests-config.php", <<<'CONFIG'
+$config_path = '/tmp/wp-tests-config.php';
+file_put_contents($config_path, <<<'CONFIG'
 <?php
 $table_prefix = 'wptests_';
 define('DB_NAME', ':memory:');
@@ -41,7 +42,7 @@ CONFIG
 require_once '/homeboy-extension/vendor/autoload.php';
 log_msg("BOOT OK");
 
-$argv = ['install.php', "$tests_dir/wp-tests-config.php", 'no_ms_tests', 'no_core_tests'];
+$argv = ['install.php', $config_path, 'no_ms_tests', 'no_core_tests'];
 $_SERVER['argv'] = $argv;
 
 log_msg("INSTALLING");

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -12,12 +12,14 @@ set -euo pipefail
 #
 # HOW IT WORKS:
 #
-# 1. Generates a PHP wrapper script that:
+# 1. Fills in the static PHP template (playground-runner.php) with the plugin
+#    slug and dependency mount paths via sed substitution.
+#
+#    The template:
 #    - Generates wp-tests-config.php inside the wp-phpunit VFS
-#    - Sets env vars (WP_TESTS_DIR, ABSPATH, HOMEBOY_*)
-#    - Loads the wp-phpunit bootstrap with WP_TESTS_SKIP_INSTALL=1
-#      (Playground's PHP-WASM cannot spawn subprocesses via system(),
-#       so the WP install step is skipped)
+#    - Runs install.php IN-PROCESS (set $argv, require_once) which boots
+#      WordPress AND creates DB tables without needing system()
+#    - Loads wp-phpunit test case classes directly (no host bootstrap)
 #    - Discovers and runs test files via PHPUnit's programmatic API
 #
 # 2. Mounts host directories into Playground's VFS:
@@ -26,17 +28,15 @@ set -euo pipefail
 #    - Extension dir     → /homeboy-extension
 #    - Custom db.php     → /wordpress/wp-content/db.php (if present)
 #
-# 3. Runs the wrapper via `wp-playground-cli php`
+# 3. Runs the filled template via `wp-playground-cli php`
 #
 # KNOWN GAPS (Phase 1):
-#   - DB tables are not created (WP_TESTS_SKIP_INSTALL=1). Tests that
-#     use WP_UnitTestCase factory methods (user/post creation) will fail
-#     with "no such table". Future work: in-process WP install.
-#   - PHPUnit stdout is not forwarded by the Playground CLI's php
-#     subcommand. Results are captured via a host-mounted log file.
 #   - WP version is pinned to match wp-phpunit package (6.9.x).
+#   - db.php drop-in support needs per-case testing (Playground's built-in
+#     SQLite integration may conflict with custom drop-ins like MDI).
 #
-# See TEST_INFRASTRUCTURE_PLAN.md §17 for the full gap analysis.
+# The host bootstrap (tests/bootstrap.php) is NOT used by this backend.
+# install.php is included in-process which avoids the system() subprocess.
 
 FAILED_STEP=""
 FAILURE_OUTPUT=""
@@ -169,108 +169,18 @@ fi
 RESULT_FILE="${PLUGIN_PATH}/.pg-test-result.txt"
 rm -f "$RESULT_FILE"
 
-WRAPPER_SCRIPT=$(cat <<PHPWRAPPER
-<?php
-error_reporting(E_ALL & ~E_WARNING & ~E_NOTICE);
+TEMPLATE="${SCRIPT_DIR}/playground-runner.php"
+if [ ! -f "$TEMPLATE" ]; then
+    echo "Error: playground-runner.php template not found at $TEMPLATE"
+    FAILED_STEP="Playground setup"
+    exit 1
+fi
 
-\$out = '/wordpress/wp-content/plugins/${PLUGIN_SLUG}/.pg-test-result.txt';
-function log_msg(\$msg) { global \$out; file_put_contents(\$out, \$msg . "\\n", FILE_APPEND); }
-register_shutdown_function(function() {
-    global \$out;
-    \$error = error_get_last();
-    if (\$error && \$error['type'] === E_ERROR) {
-        file_put_contents(\$out, "FATAL: {\$error['message']}\\n", FILE_APPEND);
-    }
-});
-
-\$tests_dir = '/homeboy-extension/vendor/wp-phpunit/wp-phpunit';
-\$plugin_path = '/wordpress/wp-content/plugins/${PLUGIN_SLUG}';
-
-file_put_contents("\$tests_dir/wp-tests-config.php", <<<'CONFIG'
-<?php
-\\\$table_prefix = 'wptests_';
-define('DB_NAME', ':memory:');
-define('DB_USER', 'root');
-define('DB_PASSWORD', '');
-define('DB_HOST', 'localhost');
-define('DB_CHARSET', 'utf8');
-define('WP_TESTS_DOMAIN', 'example.org');
-define('WP_TESTS_EMAIL', 'admin@example.org');
-define('WP_TESTS_TITLE', 'Test Blog');
-define('WP_PHP_BINARY', 'php');
-define('ABSPATH', '/wordpress/');
-define('FS_CHMOD_FILE', 0644);
-define('FS_CHMOD_DIR', 0755);
-define('FS_METHOD', 'direct');
-define('WP_INSTALLING', true);
-CONFIG
-);
-
-require_once '/homeboy-extension/vendor/autoload.php';
-log_msg("BOOT OK");
-
-putenv("WP_TESTS_DIR=\$tests_dir");
-putenv("ABSPATH=/wordpress");
-putenv("WP_TESTS_SKIP_INSTALL=1");
-putenv("HOMEBOY_COMPONENT_ID=${COMPONENT_ID}");
-putenv("HOMEBOY_COMPONENT_PATH=\$plugin_path");
-putenv("HOMEBOY_PLUGIN_PATH=\$plugin_path");
-putenv("HOMEBOY_WORDPRESS_DEPENDENCY_PATHS=${PLAYGROUND_DEP_MOUNTS}");
-
-require_once "\$tests_dir/includes/functions.php";
-
-\\\$component_file = null;
-\\\$files = glob("\\\$plugin_path/*.php");
-foreach (\\\$files as \\\$f) {
-    if (strpos(file_get_contents(\\\$f), 'Plugin Name:') !== false) {
-        \\\$component_file = \\\$f;
-        break;
-    }
-}
-if (\\\$component_file) {
-    tests_add_filter('muplugins_loaded', function() use (\\\$component_file) {
-        require_once \\\$component_file;
-    });
-}
-
-log_msg("LOADING BOOTSTRAP");
-require_once "\$tests_dir/includes/bootstrap.php";
-log_msg("BOOTSTRAP OK");
-
-wp_installing(false);
-while (ob_get_level() > 0) @ob_end_clean();
-
-log_msg("DISCOVERING TESTS");
-\\\$test_dir = "\$plugin_path/tests";
-\\\$test_files = array_merge(
-    glob("\\\$test_dir/test-*.php") ?: [],
-    glob("\\\$test_dir/*Test.php") ?: []
-);
-if (empty(\\\$test_files)) {
-    log_msg("NO TEST FILES FOUND");
-    exit(1);
-}
-
-\\\$suite = new PHPUnit\\Framework\\TestSuite('Playground Tests');
-foreach (\\\$test_files as \\\$tf) {
-    require_once \\\$tf;
-    \\\$class_name = basename(\\\$tf, '.php');
-    if (class_exists(\\\$class_name)) {
-        \\\$suite->addTestSuite(\\\$class_name);
-    }
-}
-
-log_msg("RUNNING " . count(\\\$test_files) . " TEST FILES");
-\\\$runner = new PHPUnit\\TextUI\\TestRunner();
-\\\$result = \\\$runner->run(\\\$suite, ['colors' => 'never', 'testdox' => true, 'verbose' => false]);
-log_msg(\\\$result->wasSuccessful() ? "ALL TESTS PASSED" : "SOME TESTS FAILED");
-log_msg("TESTS: " . \\\$result->count() . " FAILURES: " . count(\\\$result->failures()) . " ERRORS: " . count(\\\$result->errors()));
-exit(\\\$result->wasSuccessful() ? 0 : 1);
-PHPWRAPPER
-)
-
-WRAPPER_TMPFILE=$(mktemp --suffix=.php)
-echo "$WRAPPER_SCRIPT" > "$WRAPPER_TMPFILE"
+WRAPPER_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/pg-runner.XXXXXX.php")
+sed \
+    -e "s|{{PLUGIN_SLUG}}|${PLUGIN_SLUG}|g" \
+    -e "s|{{PLAYGROUND_DEP_MOUNTS}}|${PLAYGROUND_DEP_MOUNTS}|g" \
+    "$TEMPLATE" > "$WRAPPER_TMPFILE"
 
 echo "Running PHPUnit tests via WordPress Playground..."
 echo "  Plugin: ${PLUGIN_SLUG} (${PLUGIN_PATH})"
@@ -281,6 +191,8 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "  Mount args: ${MOUNT_ARGS[*]}"
 fi
 
+PHPUNIT_TMPFILE=$(mktemp)
+
 set +e
 "$PLAYGROUND_CLI" php \
     "${MOUNT_ARGS[@]}" \
@@ -288,8 +200,8 @@ set +e
     --wp=6.9 \
     --verbosity=normal \
     -- /runner.php \
-    2>&1
-playground_exit=$?
+    2>&1 | tee "$PHPUNIT_TMPFILE"
+playground_exit=${PIPESTATUS[0]}
 set -e
 
 rm -f "$WRAPPER_TMPFILE"
@@ -297,19 +209,35 @@ rm -f "$WRAPPER_TMPFILE"
 PHPUNIT_OUTPUT=""
 if [ -f "$RESULT_FILE" ]; then
     PHPUNIT_OUTPUT=$(cat "$RESULT_FILE")
-    echo ""
-    echo "--- Playground test results ---"
-    echo "$PHPUNIT_OUTPUT"
-    echo ""
 fi
 
+# Also capture PHPUnit stdout from the tee'd output
+PHPUNIT_STDOUT=$(cat "$PHPUNIT_TMPFILE")
+rm -f "$PHPUNIT_TMPFILE"
+
+# Parse test results for homeboy core (best-effort, non-blocking)
 PARSE_RESULTS="${EXTENSION_PATH}/scripts/test/parse-test-results.sh"
-if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$PARSE_RESULTS" ] && [ -n "$PHPUNIT_OUTPUT" ]; then
-    echo "$PHPUNIT_OUTPUT" | bash "$PARSE_RESULTS" || true
+PARSE_FAILURES="${EXTENSION_PATH}/scripts/test/parse-test-failures.sh"
+if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$PARSE_RESULTS" ]; then
+    if [ -n "$PHPUNIT_STDOUT" ]; then
+        echo "$PHPUNIT_STDOUT" | bash "$PARSE_RESULTS" || true
+    elif [ -n "$PHPUNIT_OUTPUT" ]; then
+        echo "$PHPUNIT_OUTPUT" | bash "$PARSE_RESULTS" || true
+    fi
+fi
+if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] && [ -f "$PARSE_FAILURES" ]; then
+    if [ -n "$PHPUNIT_STDOUT" ]; then
+        echo "$PHPUNIT_STDOUT" | bash "$PARSE_FAILURES" "${PLUGIN_PATH:-}" || true
+    fi
 fi
 
 if [ $playground_exit -ne 0 ]; then
     if echo "$PHPUNIT_OUTPUT" | grep -q "SOME TESTS FAILED"; then
+        FAILED_STEP="PHPUnit tests (playground backend)"
+        FAILURE_REPLAY_MODE="none"
+        rm -f "$RESULT_FILE"
+        exit $playground_exit
+    elif echo "$PHPUNIT_STDOUT" | grep -qE 'FAILURES|ERRORS'; then
         FAILED_STEP="PHPUnit tests (playground backend)"
         FAILURE_REPLAY_MODE="none"
         rm -f "$RESULT_FILE"
@@ -332,7 +260,7 @@ if [ $playground_exit -ne 0 ]; then
     fi
 fi
 
-if [ -z "$PHPUNIT_OUTPUT" ]; then
+if [ -z "$PHPUNIT_OUTPUT" ] && [ -z "$PHPUNIT_STDOUT" ]; then
     echo ""
     echo "============================================"
     echo "WARNING: No test output captured (playground)"
@@ -343,13 +271,25 @@ if [ -z "$PHPUNIT_OUTPUT" ]; then
     exit 1
 fi
 
-if echo "$PHPUNIT_OUTPUT" | grep -q "NO TEST FILES FOUND"; then
+if echo "$PHPUNIT_OUTPUT" | grep -q "NO_TEST_FILES"; then
     echo ""
     echo "============================================"
     echo "WARNING: No test files discovered"
     echo "============================================"
     echo ""
     FAILED_STEP="PHPUnit tests (no test files, playground)"
+    rm -f "$RESULT_FILE"
+    exit 1
+fi
+
+# Detect zero-test runs from PHPUnit stdout
+if echo "$PHPUNIT_STDOUT" | grep -qE 'No tests executed|OK \(0 tests'; then
+    echo ""
+    echo "============================================"
+    echo "WARNING: PHPUnit ran 0 tests (playground)"
+    echo "============================================"
+    echo ""
+    FAILED_STEP="PHPUnit tests (zero tests executed, playground)"
     rm -f "$RESULT_FILE"
     exit 1
 fi

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Playground test runner for WordPress Homeboy extension.
+#
+# Boots a WordPress Playground instance (PHP-WASM + embedded SQLite),
+# mounts the component under test, runs PHPUnit inside it, and emits
+# the same JSON result shape as test-runner.sh.
+#
+# This is the "playground" backend — opt-in, not the default.
+# The host backend (test-runner.sh) remains the default.
+#
+# HOW IT WORKS:
+#
+# 1. Generates a PHP wrapper script that:
+#    - Generates wp-tests-config.php inside the wp-phpunit VFS
+#    - Sets env vars (WP_TESTS_DIR, ABSPATH, HOMEBOY_*)
+#    - Loads the wp-phpunit bootstrap with WP_TESTS_SKIP_INSTALL=1
+#      (Playground's PHP-WASM cannot spawn subprocesses via system(),
+#       so the WP install step is skipped)
+#    - Discovers and runs test files via PHPUnit's programmatic API
+#
+# 2. Mounts host directories into Playground's VFS:
+#    - Plugin under test → /wordpress/wp-content/plugins/<slug>
+#    - Dependencies      → /wordpress/wp-content/plugins/<dep>
+#    - Extension dir     → /homeboy-extension
+#    - Custom db.php     → /wordpress/wp-content/db.php (if present)
+#
+# 3. Runs the wrapper via `wp-playground-cli php`
+#
+# KNOWN GAPS (Phase 1):
+#   - DB tables are not created (WP_TESTS_SKIP_INSTALL=1). Tests that
+#     use WP_UnitTestCase factory methods (user/post creation) will fail
+#     with "no such table". Future work: in-process WP install.
+#   - PHPUnit stdout is not forwarded by the Playground CLI's php
+#     subcommand. Results are captured via a host-mounted log file.
+#   - WP version is pinned to match wp-phpunit package (6.9.x).
+#
+# See TEST_INFRASTRUCTURE_PLAN.md §17 for the full gap analysis.
+
+FAILED_STEP=""
+FAILURE_OUTPUT=""
+FAILURE_REPLAY_MODE="full"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/../lib/runner-steps.sh}"
+DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
+PHP_PREFLIGHT_HELPER="${SCRIPT_DIR}/../lib/php-preflight.sh"
+# shellcheck source=../lib/runner-steps.sh
+if [ -f "$RUNNER_STEPS_HELPER" ]; then
+    source "$RUNNER_STEPS_HELPER"
+fi
+# shellcheck source=../lib/validation-dependencies.sh
+if [ -f "$DEPENDENCY_HELPER" ]; then
+    source "$DEPENDENCY_HELPER"
+fi
+# shellcheck source=../lib/php-preflight.sh
+if [ -f "$PHP_PREFLIGHT_HELPER" ]; then
+    source "$PHP_PREFLIGHT_HELPER"
+fi
+
+print_failure_summary() {
+    if [ -n "$FAILED_STEP" ]; then
+        echo ""
+        echo "============================================"
+        echo "BUILD FAILED: $FAILED_STEP"
+        echo "============================================"
+        if [ "$FAILURE_REPLAY_MODE" = "none" ]; then
+            echo ""
+            echo "See PHPUnit output above (not replayed)."
+        elif [ -n "$FAILURE_OUTPUT" ]; then
+            echo ""
+            echo "Error details:"
+            echo "$FAILURE_OUTPUT"
+        fi
+    fi
+}
+trap print_failure_summary EXIT
+
+SETTINGS_JSON="${HOMEBOY_SETTINGS_JSON:-}"
+
+if [ -n "${HOMEBOY_COMPONENT_PATH:-}" ]; then
+    PLUGIN_PATH="${HOMEBOY_COMPONENT_PATH}"
+    COMPONENT_ID="${HOMEBOY_COMPONENT_ID:-}"
+elif [ -n "${HOMEBOY_PROJECT_PATH:-}" ]; then
+    PLUGIN_PATH="${HOMEBOY_PROJECT_PATH}"
+    COMPONENT_ID=""
+else
+    PLUGIN_PATH="$(pwd)"
+    COMPONENT_ID="$(basename "$PLUGIN_PATH")"
+fi
+
+if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "DEBUG: [playground] Extension path: $EXTENSION_PATH"
+    echo "DEBUG: [playground] Plugin path: $PLUGIN_PATH"
+    echo "DEBUG: [playground] Component ID: ${COMPONENT_ID:-none}"
+fi
+
+PLAYGROUND_CLI="${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli"
+if [ ! -f "$PLAYGROUND_CLI" ]; then
+    echo "Error: @wp-playground/cli not found at $PLAYGROUND_CLI"
+    echo ""
+    echo "Install it with: cd ${EXTENSION_PATH} && npm install"
+    echo "Or switch backends: homeboy component set <id> test_backend host"
+    FAILED_STEP="Playground CLI setup"
+    exit 1
+fi
+
+TEST_DIR="${PLUGIN_PATH}/tests"
+if [ ! -d "$TEST_DIR" ]; then
+    echo ""
+    echo "⚠ Warning: No tests directory found at ${TEST_DIR}"
+    echo "  Skipping PHPUnit tests."
+    echo ""
+    exit 0
+fi
+
+if type homeboy_php_preflight &>/dev/null; then
+    homeboy_php_preflight "$PLUGIN_PATH"
+fi
+
+if [ -n "${COMPONENT_ID:-}" ]; then
+    export HOMEBOY_COMPONENT_ID="$COMPONENT_ID"
+    export HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH"
+    export HOMEBOY_PLUGIN_PATH="$PLUGIN_PATH"
+else
+    export HOMEBOY_PROJECT_PATH="$PLUGIN_PATH"
+    export HOMEBOY_PLUGIN_PATH="$PLUGIN_PATH"
+fi
+
+if type homeboy_export_validation_dependency_paths &>/dev/null; then
+    homeboy_export_validation_dependency_paths "$PLUGIN_PATH"
+fi
+DEPENDENCY_PATHS="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
+
+PLUGIN_SLUG="$(basename "$PLUGIN_PATH")"
+MOUNT_ARGS=()
+
+MOUNT_ARGS+=("--mount" "${PLUGIN_PATH}:/wordpress/wp-content/plugins/${PLUGIN_SLUG}")
+
+if [ -n "$DEPENDENCY_PATHS" ]; then
+    while IFS= read -r dep_path; do
+        [ -z "$dep_path" ] && continue
+        dep_slug="$(basename "$dep_path")"
+        MOUNT_ARGS+=("--mount" "${dep_path}:/wordpress/wp-content/plugins/${dep_slug}")
+    done <<< "$DEPENDENCY_PATHS"
+fi
+
+PLUGIN_DB_PHP="${PLUGIN_PATH}/db.php"
+if [ -f "$PLUGIN_DB_PHP" ]; then
+    MOUNT_ARGS+=("--mount" "${PLUGIN_DB_PHP}:/wordpress/wp-content/db.php")
+fi
+
+MOUNT_ARGS+=("--mount" "${EXTENSION_PATH}:/homeboy-extension")
+
+PLAYGROUND_DEP_MOUNTS=""
+if [ -n "$DEPENDENCY_PATHS" ]; then
+    while IFS= read -r dep_path; do
+        [ -z "$dep_path" ] && continue
+        dep_slug="$(basename "$dep_path")"
+        if [ -n "$PLAYGROUND_DEP_MOUNTS" ]; then
+            PLAYGROUND_DEP_MOUNTS+="\\n"
+        fi
+        PLAYGROUND_DEP_MOUNTS+="/wordpress/wp-content/plugins/${dep_slug}"
+    done <<< "$DEPENDENCY_PATHS"
+fi
+
+RESULT_FILE="${PLUGIN_PATH}/.pg-test-result.txt"
+rm -f "$RESULT_FILE"
+
+WRAPPER_SCRIPT=$(cat <<PHPWRAPPER
+<?php
+error_reporting(E_ALL & ~E_WARNING & ~E_NOTICE);
+
+\$out = '/wordpress/wp-content/plugins/${PLUGIN_SLUG}/.pg-test-result.txt';
+function log_msg(\$msg) { global \$out; file_put_contents(\$out, \$msg . "\\n", FILE_APPEND); }
+register_shutdown_function(function() {
+    global \$out;
+    \$error = error_get_last();
+    if (\$error && \$error['type'] === E_ERROR) {
+        file_put_contents(\$out, "FATAL: {\$error['message']}\\n", FILE_APPEND);
+    }
+});
+
+\$tests_dir = '/homeboy-extension/vendor/wp-phpunit/wp-phpunit';
+\$plugin_path = '/wordpress/wp-content/plugins/${PLUGIN_SLUG}';
+
+file_put_contents("\$tests_dir/wp-tests-config.php", <<<'CONFIG'
+<?php
+\\\$table_prefix = 'wptests_';
+define('DB_NAME', ':memory:');
+define('DB_USER', 'root');
+define('DB_PASSWORD', '');
+define('DB_HOST', 'localhost');
+define('DB_CHARSET', 'utf8');
+define('WP_TESTS_DOMAIN', 'example.org');
+define('WP_TESTS_EMAIL', 'admin@example.org');
+define('WP_TESTS_TITLE', 'Test Blog');
+define('WP_PHP_BINARY', 'php');
+define('ABSPATH', '/wordpress/');
+define('FS_CHMOD_FILE', 0644);
+define('FS_CHMOD_DIR', 0755);
+define('FS_METHOD', 'direct');
+define('WP_INSTALLING', true);
+CONFIG
+);
+
+require_once '/homeboy-extension/vendor/autoload.php';
+log_msg("BOOT OK");
+
+putenv("WP_TESTS_DIR=\$tests_dir");
+putenv("ABSPATH=/wordpress");
+putenv("WP_TESTS_SKIP_INSTALL=1");
+putenv("HOMEBOY_COMPONENT_ID=${COMPONENT_ID}");
+putenv("HOMEBOY_COMPONENT_PATH=\$plugin_path");
+putenv("HOMEBOY_PLUGIN_PATH=\$plugin_path");
+putenv("HOMEBOY_WORDPRESS_DEPENDENCY_PATHS=${PLAYGROUND_DEP_MOUNTS}");
+
+require_once "\$tests_dir/includes/functions.php";
+
+\\\$component_file = null;
+\\\$files = glob("\\\$plugin_path/*.php");
+foreach (\\\$files as \\\$f) {
+    if (strpos(file_get_contents(\\\$f), 'Plugin Name:') !== false) {
+        \\\$component_file = \\\$f;
+        break;
+    }
+}
+if (\\\$component_file) {
+    tests_add_filter('muplugins_loaded', function() use (\\\$component_file) {
+        require_once \\\$component_file;
+    });
+}
+
+log_msg("LOADING BOOTSTRAP");
+require_once "\$tests_dir/includes/bootstrap.php";
+log_msg("BOOTSTRAP OK");
+
+wp_installing(false);
+while (ob_get_level() > 0) @ob_end_clean();
+
+log_msg("DISCOVERING TESTS");
+\\\$test_dir = "\$plugin_path/tests";
+\\\$test_files = array_merge(
+    glob("\\\$test_dir/test-*.php") ?: [],
+    glob("\\\$test_dir/*Test.php") ?: []
+);
+if (empty(\\\$test_files)) {
+    log_msg("NO TEST FILES FOUND");
+    exit(1);
+}
+
+\\\$suite = new PHPUnit\\Framework\\TestSuite('Playground Tests');
+foreach (\\\$test_files as \\\$tf) {
+    require_once \\\$tf;
+    \\\$class_name = basename(\\\$tf, '.php');
+    if (class_exists(\\\$class_name)) {
+        \\\$suite->addTestSuite(\\\$class_name);
+    }
+}
+
+log_msg("RUNNING " . count(\\\$test_files) . " TEST FILES");
+\\\$runner = new PHPUnit\\TextUI\\TestRunner();
+\\\$result = \\\$runner->run(\\\$suite, ['colors' => 'never', 'testdox' => true, 'verbose' => false]);
+log_msg(\\\$result->wasSuccessful() ? "ALL TESTS PASSED" : "SOME TESTS FAILED");
+log_msg("TESTS: " . \\\$result->count() . " FAILURES: " . count(\\\$result->failures()) . " ERRORS: " . count(\\\$result->errors()));
+exit(\\\$result->wasSuccessful() ? 0 : 1);
+PHPWRAPPER
+)
+
+WRAPPER_TMPFILE=$(mktemp --suffix=.php)
+echo "$WRAPPER_SCRIPT" > "$WRAPPER_TMPFILE"
+
+echo "Running PHPUnit tests via WordPress Playground..."
+echo "  Plugin: ${PLUGIN_SLUG} (${PLUGIN_PATH})"
+echo "  Backend: playground (PHP-WASM + SQLite)"
+
+if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "  Wrapper: $WRAPPER_TMPFILE"
+    echo "  Mount args: ${MOUNT_ARGS[*]}"
+fi
+
+set +e
+"$PLAYGROUND_CLI" php \
+    "${MOUNT_ARGS[@]}" \
+    "--mount" "${WRAPPER_TMPFILE}:/runner.php" \
+    --wp=6.9 \
+    --verbosity=normal \
+    -- /runner.php \
+    2>&1
+playground_exit=$?
+set -e
+
+rm -f "$WRAPPER_TMPFILE"
+
+PHPUNIT_OUTPUT=""
+if [ -f "$RESULT_FILE" ]; then
+    PHPUNIT_OUTPUT=$(cat "$RESULT_FILE")
+    echo ""
+    echo "--- Playground test results ---"
+    echo "$PHPUNIT_OUTPUT"
+    echo ""
+fi
+
+PARSE_RESULTS="${EXTENSION_PATH}/scripts/test/parse-test-results.sh"
+if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$PARSE_RESULTS" ] && [ -n "$PHPUNIT_OUTPUT" ]; then
+    echo "$PHPUNIT_OUTPUT" | bash "$PARSE_RESULTS" || true
+fi
+
+if [ $playground_exit -ne 0 ]; then
+    if echo "$PHPUNIT_OUTPUT" | grep -q "SOME TESTS FAILED"; then
+        FAILED_STEP="PHPUnit tests (playground backend)"
+        FAILURE_REPLAY_MODE="none"
+        rm -f "$RESULT_FILE"
+        exit $playground_exit
+    elif echo "$PHPUNIT_OUTPUT" | grep -q "FATAL:"; then
+        FAILED_STEP="Playground bootstrap"
+        FAILURE_OUTPUT=$(echo "$PHPUNIT_OUTPUT" | grep "FATAL:")
+        rm -f "$RESULT_FILE"
+        exit $playground_exit
+    else
+        echo ""
+        echo "============================================"
+        echo "NOTE: Playground exited with code $playground_exit"
+        echo "============================================"
+        if [ -n "$PHPUNIT_OUTPUT" ]; then
+            echo "Last log: $(echo "$PHPUNIT_OUTPUT" | tail -1)"
+        else
+            echo "No result file produced. Playground may have crashed during boot."
+        fi
+    fi
+fi
+
+if [ -z "$PHPUNIT_OUTPUT" ]; then
+    echo ""
+    echo "============================================"
+    echo "WARNING: No test output captured (playground)"
+    echo "============================================"
+    echo ""
+    FAILED_STEP="PHPUnit tests (no output, playground)"
+    rm -f "$RESULT_FILE"
+    exit 1
+fi
+
+if echo "$PHPUNIT_OUTPUT" | grep -q "NO TEST FILES FOUND"; then
+    echo ""
+    echo "============================================"
+    echo "WARNING: No test files discovered"
+    echo "============================================"
+    echo ""
+    FAILED_STEP="PHPUnit tests (no test files, playground)"
+    rm -f "$RESULT_FILE"
+    exit 1
+fi
+
+rm -f "$RESULT_FILE"
+
+echo ""
+echo "Playground test run complete."

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -98,6 +98,7 @@ if [ -n "${HOMEBOY_EXTENSION_PATH:-}" ]; then
 
     # Parse settings from JSON using jq
     if [ -n "$SETTINGS_JSON" ] && [ "$SETTINGS_JSON" != "{}" ]; then
+        TEST_BACKEND=$(printf '%s' "$SETTINGS_JSON" | jq -r '.test_backend // "host"')
         DATABASE_TYPE=$(printf '%s' "$SETTINGS_JSON" | jq -r '.database_type // "auto"')
         # MySQL settings (explicit configuration takes priority over ambient discovery)
         SETTINGS_MYSQL_HOST=$(printf '%s' "$SETTINGS_JSON" | jq -r '.mysql_host // ""')
@@ -105,11 +106,20 @@ if [ -n "${HOMEBOY_EXTENSION_PATH:-}" ]; then
         SETTINGS_MYSQL_USER=$(printf '%s' "$SETTINGS_JSON" | jq -r '.mysql_user // ""')
         SETTINGS_MYSQL_PASSWORD=$(printf '%s' "$SETTINGS_JSON" | jq -r '.mysql_password // ""')
     else
+        TEST_BACKEND="host"
         DATABASE_TYPE="auto"
         SETTINGS_MYSQL_HOST=""
         SETTINGS_MYSQL_DATABASE=""
         SETTINGS_MYSQL_USER=""
         SETTINGS_MYSQL_PASSWORD=""
+    fi
+
+    # Dispatch to Playground backend if configured
+    if [ "$TEST_BACKEND" = "playground" ]; then
+        echo "Test backend: playground (WordPress Playground, PHP-WASM + SQLite)"
+        export HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH"
+        export HOMEBOY_SETTINGS_JSON="${SETTINGS_JSON:-}"
+        exec bash "${SCRIPT_DIR}/test-runner-playground.sh" "$@"
     fi
 else
     # Called directly (e.g., from composer test in component directory)
@@ -121,6 +131,7 @@ else
     PLUGIN_PATH="$COMPONENT_PATH"
     COMPONENT_ID="$(basename "$COMPONENT_PATH")"  # Derive component ID from directory name
     DATABASE_TYPE="auto"  # Auto-detect MySQL, fall back to SQLite
+    TEST_BACKEND="host"   # Default to host backend when called directly
 
     # Set component environment variables for bootstrap
     export HOMEBOY_COMPONENT_ID="$COMPONENT_ID"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -343,11 +343,18 @@
       "description": "WordPress user for WP-CLI commands (email, login, or ID). When configured, automatically appended as --user flag."
     },
     {
+      "id": "test_backend",
+      "label": "Test Backend",
+      "type": "string",
+      "default": "host",
+      "description": "Test execution backend. 'host' (default) runs PHPUnit with host PHP + wp-phpunit. 'playground' runs inside WordPress Playground (PHP-WASM + embedded SQLite)."
+    },
+    {
       "id": "database_type",
       "label": "Database Type",
       "type": "string",
       "default": "auto",
-      "description": "Database backend for tests. 'auto' (default) tries MySQL first, falls back to SQLite. Use 'mysql' or 'sqlite' to force a specific backend."
+      "description": "Database backend for tests (host backend only). 'auto' tries MySQL first, falls back to SQLite. Ignored when test_backend is 'playground'."
     },
     {
       "id": "mysql_host",


### PR DESCRIPTION
## Summary

- Adds WordPress Playground (PHP-WASM + embedded SQLite) as an **opt-in** test execution backend alongside the existing host-PHP path
- Default backend remains `host` — no behavior change for existing users
- Activated via `homeboy component set <id> test_backend playground`

## Changes

| File | Change |
|------|--------|
| `wordpress.json` | New `test_backend` setting (host \| playground, default host) |
| `package.json` | Added `@wp-playground/cli` dependency |
| `scripts/test/test-runner-playground.sh` | New Playground backend runner |
| `scripts/test/test-runner.sh` | Router dispatches by backend setting |
| `scripts/build/setup.sh` | Installs both host and Playground deps |
| `README.md` | Test Backend section with opt-in instructions |
| `TEST_INFRASTRUCTURE_PLAN.md` | Phase 5 section with gap analysis |

## How the Playground backend works

1. Generates a PHP wrapper that sets up env vars, generates `wp-tests-config.php` inside the VFS, and bootstraps WordPress + PHPUnit
2. Mounts host directories into Playground's VFS (plugin, dependencies, extension dir, custom `db.php`)
3. Runs via `wp-playground-cli php --mount ... -- /runner.php`
4. Captures results via a host-mounted `.pg-test-result.txt` log file

## Known gaps (documented, not blocking)

1. **No DB tables** — `WP_TESTS_SKIP_INSTALL=1` because `system()` is unavailable in PHP-WASM. Tests using `WP_UnitTestCase` factory methods fail. Fix: in-process WP install (set `$argv` before `require_once install.php`)
2. **No PHPUnit stdout** — Playground CLI's `php` subcommand doesn't forward stdout. Workaround: host-mounted log file
3. **WP version pinning** — `--wp=6.9` must match wp-phpunit package version
4. **db.php drop-in support** — can be mounted but conflicts with Playground's built-in SQLite integration need per-case testing

Closes #214 (Phase 1)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Agent drafted all code changes and performed live testing against Playground CLI. Chris reviewed, directed the testing strategy, and identified the `system()` subprocess gap.