### PR TITLE
wordpress: playground diagnostics — structured stage logging + classified failures (Phase 2 of #214)

### DIFF
--- a/wordpress/TEST_INFRASTRUCTURE_PLAN.md
+++ b/wordpress/TEST_INFRASTRUCTURE_PLAN.md
@@ -467,7 +467,33 @@ SQLite) instead of host PHP. Does not replace the host backend.
 | Update README with backend docs | README.md | ✅ Complete |
 | In-process WP install (replace `system()` call) | — | ✅ Complete |
 | PHPUnit stdout forwarding | — | ✅ Complete |
+| Structured stage logging + diagnostics | scripts/test/playground-runner.php, test-runner-playground.sh | ✅ Complete (Phase 2) |
+| Parse extension phpunit.xml.dist in runner | — | 🔲 Pending |
 | db.php drop-in support (MDI test) | — | 🔲 Pending |
+
+**Diagnostics contract (Phase 2):**
+
+The template writes a structured log (`.pg-test-result.txt`) with these line patterns:
+
+| Line | Meaning |
+|------|---------|
+| `STAGE_BEGIN:<stage>` | Entered a bootstrap phase |
+| `STAGE_OK:<stage>` | Phase completed cleanly |
+| `STAGE_FAIL:<stage>:<msg>` | Throwable caught during phase |
+| `STAGE_FATAL:<stage>:<msg>` | Uncatchable fatal (shutdown handler) |
+| `NOTICE:<msg>` | PHP warning/notice (not swallowed) |
+| `PLUGIN_DETECTED <file>` / `THEME_DETECTED` | Component load success |
+| `NO_TEST_FILES` | Discovery found nothing |
+| `ALL TESTS PASSED` / `SOME TESTS FAILED` | PHPUnit outcome |
+
+Stages (in execution order): `boot` → `install` → `load_fixtures` → `load_deps`
+→ `load_component` → `discover_tests` → `load_tests` → `run_tests`.
+
+The bash runner classifies failures in priority order: bootstrap stage failure
+→ PHPUnit assertion failure → pre-runner PHP crash (parse/fatal on stderr) →
+unclassified non-zero exit. Unclassified non-zero exits used to silently
+report success; they now dump the structured log + raw stdout/stderr and exit
+with the playground's own exit code.
 
 **Architecture:**
 
@@ -489,7 +515,7 @@ SQLite) instead of host PHP. Does not replace the host backend.
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-**Known Gaps (Phase 1):**
+**Known Gaps (remaining after Phase 2 diagnostics):**
 
 1. **WP version pinning.** The `--wp` flag must match the wp-phpunit package
    version (currently 6.9.x). Mismatch causes missing class errors in the
@@ -499,10 +525,12 @@ SQLite) instead of host PHP. Does not replace the host backend.
    integration) can be mounted into the Playground VFS, but Playground's built-in
    SQLite integration may conflict. Needs per-case testing.
 
-3. **No host bootstrap.** The Playground backend does not use `tests/bootstrap.php`.
-    It runs `install.php` in-process and loads test case classes directly. Any
-   customizations in the host bootstrap (e.g., additional `tests_add_filter` calls)
-   won't apply.
+3. **No host bootstrap, no phpunit.xml.dist parsing.** The Playground backend
+   does not use `tests/bootstrap.php` or the extension's `phpunit.xml.dist`.
+   It runs `install.php` in-process and discovers test files via hand-rolled
+   glob (`test-*.php`, `*Test.php`). Any customizations in the host bootstrap
+   or phpunit config (e.g., additional `tests_add_filter` calls, custom
+   suites, coverage rules) won't apply. Tracked as a follow-up task above.
 
 **References:**
 - Issue: Extra-Chill/homeboy-extensions#214

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -1,26 +1,116 @@
 <?php
-error_reporting(E_ALL & ~E_WARNING & ~E_NOTICE & ~E_DEPRECATED);
+/**
+ * Playground test runner template.
+ *
+ * This file is rendered by scripts/test/test-runner-playground.sh via sed
+ * substitution of {{PLUGIN_SLUG}} and {{PLAYGROUND_DEP_MOUNTS}} before being
+ * mounted into the Playground VFS as /runner.php.
+ *
+ * DIAGNOSTICS CONTRACT
+ *
+ * The result file (/wordpress/wp-content/plugins/<slug>/.pg-test-result.txt)
+ * is the structured log the host-side bash runner parses. Every line takes
+ * one of these forms:
+ *
+ *   STAGE_BEGIN:<stage>          - entering a bootstrap phase
+ *   STAGE_OK:<stage>             - phase completed cleanly
+ *   STAGE_FAIL:<stage>:<msg>     - caught Throwable during phase
+ *   STAGE_FATAL:<stage>:<msg>    - uncatchable fatal (from shutdown handler)
+ *   NOTICE:<msg>                 - PHP warning/notice that escaped silencing
+ *   PLUGIN_DETECTED <basename>   - loaded plugin entry file
+ *   THEME_DETECTED               - loaded theme (style.css + functions.php)
+ *   NO_TEST_FILES                - discovery found no candidates
+ *   RUNNING <n> TEST FILES       - starting PHPUnit
+ *   ALL TESTS PASSED             - result.wasSuccessful() == true
+ *   SOME TESTS FAILED            - result.wasSuccessful() == false
+ *   TESTS: <n> FAILURES: <n> ERRORS: <n>
+ *
+ * Stages (in execution order):
+ *   boot             - composer autoload + config write
+ *   install          - wp-phpunit install.php (creates WP + tables)
+ *   load_fixtures    - test case classes, mock mailer, harness filters
+ *   load_deps        - dependency plugin bootstrap files (if any)
+ *   load_component   - plugin/theme under test
+ *   discover_tests   - glob test files
+ *   load_tests       - require_once each test file
+ *   run_tests        - PHPUnit execution
+ *
+ * The bash runner's job: if playground_exit != 0 AND no STAGE_FAIL/FATAL/
+ * SOME TESTS FAILED line exists, surface the raw stdout/stderr — something
+ * crashed before we could even write to the result file.
+ */
+
+// Report everything. Warnings/notices inside WP bootstrap have historically
+// been the silent failure mode — the old ~E_WARNING mask hid real problems.
+error_reporting(E_ALL);
+ini_set('display_errors', '1');
+ini_set('display_startup_errors', '1');
 
 $result_file = '/wordpress/wp-content/plugins/{{PLUGIN_SLUG}}/.pg-test-result.txt';
+$current_stage = 'preboot';
 
-function log_msg($msg) {
+function pg_log($msg) {
     global $result_file;
     file_put_contents($result_file, $msg . "\n", FILE_APPEND);
 }
 
-register_shutdown_function(function() {
-    global $result_file;
+function pg_stage_begin($stage) {
+    global $current_stage;
+    $current_stage = $stage;
+    pg_log("STAGE_BEGIN:$stage");
+}
+
+function pg_stage_ok($stage) {
+    pg_log("STAGE_OK:$stage");
+}
+
+function pg_stage_fail($stage, Throwable $e) {
+    $msg = get_class($e) . ': ' . $e->getMessage()
+        . ' at ' . $e->getFile() . ':' . $e->getLine();
+    pg_log("STAGE_FAIL:$stage:$msg");
+    // Also dump trace for debugging; bash runner will print it under failure.
+    pg_log("TRACE:");
+    foreach (explode("\n", $e->getTraceAsString()) as $line) {
+        pg_log("  $line");
+    }
+}
+
+// Capture non-fatal warnings/notices so they don't vanish into the void.
+set_error_handler(function ($severity, $message, $file, $line) {
+    if (!(error_reporting() & $severity)) {
+        return false;
+    }
+    $label = [
+        E_WARNING => 'WARNING',
+        E_NOTICE => 'NOTICE',
+        E_DEPRECATED => 'DEPRECATED',
+        E_USER_WARNING => 'USER_WARNING',
+        E_USER_NOTICE => 'USER_NOTICE',
+        E_USER_DEPRECATED => 'USER_DEPRECATED',
+        E_STRICT => 'STRICT',
+    ][$severity] ?? "E_$severity";
+    pg_log("NOTICE:$label: $message at $file:$line");
+    return false; // let PHP's default handler also run
+});
+
+register_shutdown_function(function () {
+    global $current_stage;
     $error = error_get_last();
-    if ($error && $error['type'] === E_ERROR) {
-        file_put_contents($result_file, "FATAL: {$error['message']}\n", FILE_APPEND);
+    if ($error && in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
+        pg_log("STAGE_FATAL:$current_stage:{$error['message']} at {$error['file']}:{$error['line']}");
     }
 });
 
 $tests_dir = '/homeboy-extension/vendor/wp-phpunit/wp-phpunit';
 $plugin_path = '/wordpress/wp-content/plugins/{{PLUGIN_SLUG}}';
 
-$config_path = '/tmp/wp-tests-config.php';
-file_put_contents($config_path, <<<'CONFIG'
+// ---------------------------------------------------------------------------
+// Stage: boot
+// ---------------------------------------------------------------------------
+pg_stage_begin('boot');
+try {
+    $config_path = '/tmp/wp-tests-config.php';
+    file_put_contents($config_path, <<<'CONFIG'
 <?php
 $table_prefix = 'wptests_';
 define('DB_NAME', ':memory:');
@@ -37,113 +127,205 @@ define('FS_CHMOD_FILE', 0644);
 define('FS_CHMOD_DIR', 0755);
 define('FS_METHOD', 'direct');
 CONFIG
-);
+    );
 
-require_once '/homeboy-extension/vendor/autoload.php';
-log_msg("BOOT OK");
-
-$argv = ['install.php', $config_path, 'no_ms_tests', 'no_core_tests'];
-$_SERVER['argv'] = $argv;
-
-log_msg("INSTALLING");
-require_once "$tests_dir/includes/install.php";
-log_msg("INSTALLED");
-
-while (ob_get_level() > 0) @ob_end_clean();
-
-global $phpmailer;
-require_once "$tests_dir/includes/mock-mailer.php";
-$phpmailer = new MockPHPMailer(true);
-
-require_once "$tests_dir/includes/functions.php";
-$GLOBALS['_wp_die_disabled'] = false;
-tests_add_filter('wp_die_handler', '_wp_die_handler_filter');
-tests_add_filter('wp_rest_server_class', '_wp_rest_server_class_filter');
-tests_add_filter('async_update_translation', '__return_false');
-tests_add_filter('automatic_updater_disabled', '__return_true');
-
-require_once "$tests_dir/includes/phpunit6/compat.php";
-require_once "$tests_dir/includes/phpunit-adapter-testcase.php";
-require_once "$tests_dir/includes/abstract-testcase.php";
-require_once "$tests_dir/includes/testcase.php";
-require_once "$tests_dir/includes/testcase-rest-api.php";
-require_once "$tests_dir/includes/testcase-rest-controller.php";
-require_once "$tests_dir/includes/testcase-rest-post-type-controller.php";
-require_once "$tests_dir/includes/testcase-xmlrpc.php";
-require_once "$tests_dir/includes/testcase-ajax.php";
-require_once "$tests_dir/includes/testcase-canonical.php";
-require_once "$tests_dir/includes/testcase-xml.php";
-require_once "$tests_dir/includes/exceptions.php";
-require_once "$tests_dir/includes/utils.php";
-require_once "$tests_dir/includes/spy-rest-server.php";
-require_once "$tests_dir/includes/class-wp-rest-test-search-handler.php";
-require_once "$tests_dir/includes/class-wp-rest-test-configurable-controller.php";
-require_once "$tests_dir/includes/class-wp-fake-block-type.php";
-require_once "$tests_dir/includes/class-wp-fake-hasher.php";
-require_once "$tests_dir/includes/class-wp-sitemaps-test-provider.php";
-require_once "$tests_dir/includes/class-wp-sitemaps-empty-test-provider.php";
-require_once "$tests_dir/includes/class-wp-sitemaps-large-test-provider.php";
-
-log_msg("TEST_CLASSES_LOADED");
-
-$dep_paths = '{{PLAYGROUND_DEP_MOUNTS}}';
-if (!empty($dep_paths)) {
-    foreach (explode("\n", $dep_paths) as $dep_mount) {
-        $dep_mount = trim($dep_mount);
-        if (empty($dep_mount)) continue;
-        $dep_files = glob("$dep_mount/*.php");
-        foreach ($dep_files as $df) {
-            if (strpos(file_get_contents($df), 'Plugin Name:') !== false) {
-                require_once $df;
-                break;
-            }
-        }
-    }
-}
-
-$style_css = "$plugin_path/style.css";
-if (file_exists($style_css) && strpos(file_get_contents($style_css), 'Theme Name:') !== false) {
-    log_msg("THEME_DETECTED");
-    $fn_php = "$plugin_path/functions.php";
-    if (file_exists($fn_php)) require_once $fn_php;
-} else {
-    $main_files = glob("$plugin_path/*.php");
-    foreach ($main_files as $mf) {
-        if (strpos(file_get_contents($mf), 'Plugin Name:') !== false) {
-            log_msg("PLUGIN_DETECTED " . basename($mf));
-            require_once $mf;
-            break;
-        }
-    }
-}
-
-$test_dir = "$plugin_path/tests";
-$test_files = array_merge(
-    glob("$test_dir/test-*.php") ?: [],
-    glob("$test_dir/*Test.php") ?: []
-);
-if (empty($test_files)) {
-    log_msg("NO_TEST_FILES");
+    require_once '/homeboy-extension/vendor/autoload.php';
+    pg_stage_ok('boot');
+} catch (Throwable $e) {
+    pg_stage_fail('boot', $e);
     exit(1);
 }
 
+// ---------------------------------------------------------------------------
+// Stage: install (wp-phpunit install.php creates WP tables in-process)
+// ---------------------------------------------------------------------------
+pg_stage_begin('install');
+try {
+    $argv = ['install.php', $config_path, 'no_ms_tests', 'no_core_tests'];
+    $_SERVER['argv'] = $argv;
+    require_once "$tests_dir/includes/install.php";
+    while (ob_get_level() > 0) {
+        @ob_end_clean();
+    }
+    pg_stage_ok('install');
+} catch (Throwable $e) {
+    pg_stage_fail('install', $e);
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Stage: load_fixtures (test case classes, mock mailer, harness filters)
+// ---------------------------------------------------------------------------
+pg_stage_begin('load_fixtures');
+try {
+    global $phpmailer;
+    require_once "$tests_dir/includes/mock-mailer.php";
+    $phpmailer = new MockPHPMailer(true);
+
+    require_once "$tests_dir/includes/functions.php";
+    $GLOBALS['_wp_die_disabled'] = false;
+    tests_add_filter('wp_die_handler', '_wp_die_handler_filter');
+    tests_add_filter('wp_rest_server_class', '_wp_rest_server_class_filter');
+    tests_add_filter('async_update_translation', '__return_false');
+    tests_add_filter('automatic_updater_disabled', '__return_true');
+
+    require_once "$tests_dir/includes/phpunit6/compat.php";
+    require_once "$tests_dir/includes/phpunit-adapter-testcase.php";
+    require_once "$tests_dir/includes/abstract-testcase.php";
+    require_once "$tests_dir/includes/testcase.php";
+    require_once "$tests_dir/includes/testcase-rest-api.php";
+    require_once "$tests_dir/includes/testcase-rest-controller.php";
+    require_once "$tests_dir/includes/testcase-rest-post-type-controller.php";
+    require_once "$tests_dir/includes/testcase-xmlrpc.php";
+    require_once "$tests_dir/includes/testcase-ajax.php";
+    require_once "$tests_dir/includes/testcase-canonical.php";
+    require_once "$tests_dir/includes/testcase-xml.php";
+    require_once "$tests_dir/includes/exceptions.php";
+    require_once "$tests_dir/includes/utils.php";
+    require_once "$tests_dir/includes/spy-rest-server.php";
+    require_once "$tests_dir/includes/class-wp-rest-test-search-handler.php";
+    require_once "$tests_dir/includes/class-wp-rest-test-configurable-controller.php";
+    require_once "$tests_dir/includes/class-wp-fake-block-type.php";
+    require_once "$tests_dir/includes/class-wp-fake-hasher.php";
+    require_once "$tests_dir/includes/class-wp-sitemaps-test-provider.php";
+    require_once "$tests_dir/includes/class-wp-sitemaps-empty-test-provider.php";
+    require_once "$tests_dir/includes/class-wp-sitemaps-large-test-provider.php";
+
+    pg_stage_ok('load_fixtures');
+} catch (Throwable $e) {
+    pg_stage_fail('load_fixtures', $e);
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Stage: load_deps (dependency plugin bootstrap files)
+// ---------------------------------------------------------------------------
+pg_stage_begin('load_deps');
+try {
+    $dep_paths = '{{PLAYGROUND_DEP_MOUNTS}}';
+    if (!empty($dep_paths)) {
+        foreach (explode("\n", $dep_paths) as $dep_mount) {
+            $dep_mount = trim($dep_mount);
+            if (empty($dep_mount)) {
+                continue;
+            }
+            $dep_files = glob("$dep_mount/*.php") ?: [];
+            foreach ($dep_files as $df) {
+                if (strpos(file_get_contents($df), 'Plugin Name:') !== false) {
+                    require_once $df;
+                    break;
+                }
+            }
+        }
+    }
+    pg_stage_ok('load_deps');
+} catch (Throwable $e) {
+    pg_stage_fail('load_deps', $e);
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Stage: load_component (plugin or theme under test)
+// ---------------------------------------------------------------------------
+pg_stage_begin('load_component');
+try {
+    $style_css = "$plugin_path/style.css";
+    if (file_exists($style_css) && strpos(file_get_contents($style_css), 'Theme Name:') !== false) {
+        pg_log("THEME_DETECTED");
+        $fn_php = "$plugin_path/functions.php";
+        if (file_exists($fn_php)) {
+            require_once $fn_php;
+        }
+    } else {
+        $loaded = false;
+        $main_files = glob("$plugin_path/*.php") ?: [];
+        foreach ($main_files as $mf) {
+            if (strpos(file_get_contents($mf), 'Plugin Name:') !== false) {
+                pg_log("PLUGIN_DETECTED " . basename($mf));
+                require_once $mf;
+                $loaded = true;
+                break;
+            }
+        }
+        if (!$loaded) {
+            pg_log("NOTICE:no plugin entry file with 'Plugin Name:' header found in $plugin_path");
+        }
+    }
+    pg_stage_ok('load_component');
+} catch (Throwable $e) {
+    pg_stage_fail('load_component', $e);
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Stage: discover_tests
+// ---------------------------------------------------------------------------
+pg_stage_begin('discover_tests');
+try {
+    $test_dir = "$plugin_path/tests";
+    $test_files = array_merge(
+        glob("$test_dir/test-*.php") ?: [],
+        glob("$test_dir/*Test.php") ?: []
+    );
+    if (empty($test_files)) {
+        pg_log("NO_TEST_FILES");
+        pg_stage_ok('discover_tests');
+        exit(1);
+    }
+    pg_stage_ok('discover_tests');
+} catch (Throwable $e) {
+    pg_stage_fail('discover_tests', $e);
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Stage: load_tests (parse each test file, track which file defines which class)
+// ---------------------------------------------------------------------------
+pg_stage_begin('load_tests');
 $suite = new PHPUnit\Framework\TestSuite('Playground Tests');
 $before_classes = get_declared_classes();
-foreach ($test_files as $tf) {
-    require_once $tf;
+try {
+    foreach ($test_files as $tf) {
+        require_once $tf;
+    }
+} catch (Throwable $e) {
+    pg_stage_fail('load_tests', $e);
+    exit(1);
 }
 $after_classes = get_declared_classes();
 $new_classes = array_diff($after_classes, $before_classes);
 foreach ($new_classes as $class_name) {
-    $ref = new ReflectionClass($class_name);
-    if (!$ref->isAbstract() && $ref->isSubclassOf('PHPUnit\\Framework\\TestCase')) {
-        $suite->addTestSuite($class_name);
+    try {
+        $ref = new ReflectionClass($class_name);
+        if (!$ref->isAbstract() && $ref->isSubclassOf('PHPUnit\\Framework\\TestCase')) {
+            $suite->addTestSuite($class_name);
+        }
+    } catch (Throwable $e) {
+        pg_log("NOTICE:reflection failed for $class_name: " . $e->getMessage());
     }
 }
+pg_stage_ok('load_tests');
 
-log_msg("RUNNING " . count($test_files) . " TEST FILES");
-$runner = new PHPUnit\TextUI\TestRunner();
-$result = $runner->run($suite, ['colors' => 'never', 'testdox' => true, 'verbose' => false]);
-log_msg($result->wasSuccessful() ? "ALL TESTS PASSED" : "SOME TESTS FAILED");
-log_msg("TESTS: " . $result->count() . " FAILURES: " . count($result->failures()) . " ERRORS: " . count($result->errors()));
-exit($result->wasSuccessful() ? 0 : 1);
+// ---------------------------------------------------------------------------
+// Stage: run_tests
+// ---------------------------------------------------------------------------
+pg_stage_begin('run_tests');
+pg_log("RUNNING " . count($test_files) . " TEST FILES");
+try {
+    $runner = new PHPUnit\TextUI\TestRunner();
+    $result = $runner->run($suite, [
+        'colors' => 'never',
+        'testdox' => true,
+        'verbose' => false,
+        // PHPUnit 9.6 reads $arguments['extensions'] unconditionally (line 1074
+        // in TestRunner.php). Omit it and you get two warnings per run.
+        'extensions' => [],
+    ]);
+    pg_log($result->wasSuccessful() ? "ALL TESTS PASSED" : "SOME TESTS FAILED");
+    pg_log("TESTS: " . $result->count() . " FAILURES: " . count($result->failures()) . " ERRORS: " . count($result->errors()));
+    pg_stage_ok('run_tests');
+    exit($result->wasSuccessful() ? 0 : 1);
+} catch (Throwable $e) {
+    pg_stage_fail('run_tests', $e);
+    exit(1);
+}

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -231,67 +231,128 @@ if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] && [ -f "$PARSE_FAILURES" ]; then
     fi
 fi
 
-if [ $playground_exit -ne 0 ]; then
-    if echo "$PHPUNIT_OUTPUT" | grep -q "SOME TESTS FAILED"; then
-        FAILED_STEP="PHPUnit tests (playground backend)"
-        FAILURE_REPLAY_MODE="none"
-        rm -f "$RESULT_FILE"
-        exit $playground_exit
-    elif echo "$PHPUNIT_STDOUT" | grep -qE 'FAILURES|ERRORS'; then
-        FAILED_STEP="PHPUnit tests (playground backend)"
-        FAILURE_REPLAY_MODE="none"
-        rm -f "$RESULT_FILE"
-        exit $playground_exit
-    elif echo "$PHPUNIT_OUTPUT" | grep -q "FATAL:"; then
-        FAILED_STEP="Playground bootstrap"
-        FAILURE_OUTPUT=$(echo "$PHPUNIT_OUTPUT" | grep "FATAL:")
-        rm -f "$RESULT_FILE"
-        exit $playground_exit
-    else
+# ----------------------------------------------------------------------------
+# Failure classification
+#
+# The playground-runner.php template writes a structured log to $RESULT_FILE
+# with these patterns (see playground-runner.php docblock for full contract):
+#
+#   STAGE_BEGIN:<stage>       - entered a bootstrap phase
+#   STAGE_OK:<stage>          - phase completed
+#   STAGE_FAIL:<stage>:<msg>  - caught Throwable during phase
+#   STAGE_FATAL:<stage>:<msg> - uncatchable fatal (shutdown handler)
+#   SOME TESTS FAILED         - PHPUnit ran, some assertions failed
+#   ALL TESTS PASSED          - PHPUnit ran, all assertions passed
+#
+# Classification order (first match wins):
+#   1. STAGE_FATAL/STAGE_FAIL in result file  -> bootstrap failure, show stage+msg
+#   2. SOME TESTS FAILED in result file       -> PHPUnit assertion failures
+#   3. Parse/fatal patterns in stdout         -> PHP crashed before writing log
+#   4. playground_exit != 0 with no log       -> unknown crash, dump raw output
+#   5. NO_TEST_FILES in result file           -> discovery found nothing
+#   6. Zero-test PHPUnit run                  -> suite empty
+# ----------------------------------------------------------------------------
+
+dump_diagnostics() {
+    local label="$1"
+    echo ""
+    echo "============================================"
+    echo "$label"
+    echo "============================================"
+    if [ -n "$PHPUNIT_OUTPUT" ]; then
         echo ""
-        echo "============================================"
-        echo "NOTE: Playground exited with code $playground_exit"
-        echo "============================================"
-        if [ -n "$PHPUNIT_OUTPUT" ]; then
-            echo "Last log: $(echo "$PHPUNIT_OUTPUT" | tail -1)"
-        else
-            echo "No result file produced. Playground may have crashed during boot."
-        fi
+        echo "--- Structured log ($RESULT_FILE) ---"
+        echo "$PHPUNIT_OUTPUT"
     fi
+    if [ -n "$PHPUNIT_STDOUT" ]; then
+        echo ""
+        echo "--- Playground stdout/stderr ---"
+        echo "$PHPUNIT_STDOUT"
+    fi
+}
+
+# Case 1: bootstrap failure captured in the structured log (STAGE_FAIL/STAGE_FATAL).
+if echo "$PHPUNIT_OUTPUT" | grep -qE '^STAGE_(FAIL|FATAL):'; then
+    FAILED_STAGE_LINE=$(echo "$PHPUNIT_OUTPUT" | grep -E '^STAGE_(FAIL|FATAL):' | head -1)
+    # Extract "<stage>:<msg>" (strip "STAGE_FAIL:" or "STAGE_FATAL:" prefix)
+    FAILED_STAGE_DETAIL=$(echo "$FAILED_STAGE_LINE" | sed -E 's/^STAGE_(FAIL|FATAL)://')
+    FAILED_STEP="Playground bootstrap (${FAILED_STAGE_DETAIL%%:*} stage)"
+    FAILURE_OUTPUT="$FAILED_STAGE_LINE"
+    dump_diagnostics "BOOTSTRAP FAILURE: $FAILED_STAGE_DETAIL"
+    rm -f "$RESULT_FILE"
+    exit ${playground_exit:-1}
 fi
 
+# Case 2: PHPUnit ran, some tests failed.
+if echo "$PHPUNIT_OUTPUT" | grep -q "SOME TESTS FAILED"; then
+    FAILED_STEP="PHPUnit tests (playground backend)"
+    FAILURE_REPLAY_MODE="none"
+    rm -f "$RESULT_FILE"
+    exit ${playground_exit:-1}
+fi
+
+# Case 3: PHPUnit emitted FAILURES/ERRORS on stdout (belt-and-suspenders for
+# the rare path where the result file was written but SOME TESTS FAILED line
+# was somehow dropped).
+if [ $playground_exit -ne 0 ] && echo "$PHPUNIT_STDOUT" | grep -qE '^(FAILURES|ERRORS)!'; then
+    FAILED_STEP="PHPUnit tests (playground backend)"
+    FAILURE_REPLAY_MODE="none"
+    rm -f "$RESULT_FILE"
+    exit $playground_exit
+fi
+
+# Case 4: PHP crashed before our template could write to the result file.
+# Parse/fatal errors from Playground go to stderr (captured in $PHPUNIT_STDOUT
+# via the tee'd pipe) — surface them clearly instead of failing silently.
+if [ $playground_exit -ne 0 ] && echo "$PHPUNIT_STDOUT" | grep -qE '^(PHP Parse error|Parse error:|PHP Fatal error|Fatal error:)'; then
+    FAILED_STEP="Playground PHP crash (before runner took control)"
+    FAILURE_OUTPUT=$(echo "$PHPUNIT_STDOUT" | grep -E '^(PHP Parse error|Parse error:|PHP Fatal error|Fatal error:)' | head -5)
+    dump_diagnostics "PHP CRASH"
+    rm -f "$RESULT_FILE"
+    exit $playground_exit
+fi
+
+# Case 5: playground exited non-zero and we still can't classify it.
+# Don't exit 0 here — that's the bug the old code had.
+if [ $playground_exit -ne 0 ]; then
+    FAILED_STEP="Playground exited with code $playground_exit (unclassified)"
+    dump_diagnostics "UNCLASSIFIED PLAYGROUND FAILURE (exit=$playground_exit)"
+    rm -f "$RESULT_FILE"
+    exit $playground_exit
+fi
+
+# Case 6: no output at all (not even a result file). Shouldn't happen on a
+# clean exit, but guard anyway.
 if [ -z "$PHPUNIT_OUTPUT" ] && [ -z "$PHPUNIT_STDOUT" ]; then
-    echo ""
-    echo "============================================"
-    echo "WARNING: No test output captured (playground)"
-    echo "============================================"
-    echo ""
+    dump_diagnostics "NO OUTPUT CAPTURED"
     FAILED_STEP="PHPUnit tests (no output, playground)"
     rm -f "$RESULT_FILE"
     exit 1
 fi
 
-if echo "$PHPUNIT_OUTPUT" | grep -q "NO_TEST_FILES"; then
-    echo ""
-    echo "============================================"
-    echo "WARNING: No test files discovered"
-    echo "============================================"
-    echo ""
+# Case 7: discovery found zero test files.
+if echo "$PHPUNIT_OUTPUT" | grep -q "^NO_TEST_FILES"; then
+    dump_diagnostics "NO TEST FILES DISCOVERED"
     FAILED_STEP="PHPUnit tests (no test files, playground)"
     rm -f "$RESULT_FILE"
     exit 1
 fi
 
-# Detect zero-test runs from PHPUnit stdout
+# Case 8: PHPUnit ran but executed zero tests (class didn't extend TestCase,
+# all tests excluded, etc.).
 if echo "$PHPUNIT_STDOUT" | grep -qE 'No tests executed|OK \(0 tests'; then
-    echo ""
-    echo "============================================"
-    echo "WARNING: PHPUnit ran 0 tests (playground)"
-    echo "============================================"
-    echo ""
+    dump_diagnostics "ZERO TESTS EXECUTED"
     FAILED_STEP="PHPUnit tests (zero tests executed, playground)"
     rm -f "$RESULT_FILE"
     exit 1
+fi
+
+# Surface any non-fatal NOTICEs captured during bootstrap even on success —
+# warnings inside WP setup have historically masked real problems.
+if echo "$PHPUNIT_OUTPUT" | grep -q "^NOTICE:"; then
+    echo ""
+    echo "--- Bootstrap notices (non-fatal) ---"
+    echo "$PHPUNIT_OUTPUT" | grep "^NOTICE:"
 fi
 
 rm -f "$RESULT_FILE"


### PR DESCRIPTION
## Summary

- Fixes the silent-exit-0 bug in the Playground backend: a plugin with a parse error in its main file used to exit 0 with 'Playground test run complete.' while tests never ran.
- Adds a structured diagnostics contract between `playground-runner.php` and `test-runner-playground.sh` so every failure mode is classified and surfaced instead of falling through to a generic 'NOTE: exited with code N'.
- First of three follow-up PRs to #215 (Phase 1). Remaining two: parse extension's own `phpunit.xml.dist` in the runner, and MDI `db.php` drop-in integration test.

## The bug

Sequence that made it silent:

1. Plugin has a parse error in its entry file.
2. `wp-playground-cli` catches the `ParseError`, prints to stderr, exits 255.
3. `test-runner-playground.sh` checks the result file for 'SOME TESTS FAILED' / 'FATAL:' — none present.
4. Checks stdout for 'FAILURES|ERRORS' — none present.
5. Falls through to an `else` branch that prints a 'NOTE' but **does not propagate the non-zero exit**.
6. Script exits 0. CI reports green. Tests never ran.

Reproduced against `/tmp/test-plugin-parse/` (plugin with `function broken( {` in entry file). Before this PR: `exit=0`. After: `exit=1` with clear stage identification.

## Changes

### Template (`playground-runner.php`)

- Every bootstrap phase wrapped in `try { ... } catch (Throwable $e)` and logged with structured stage markers: `STAGE_BEGIN:<name>`, `STAGE_OK:<name>`, `STAGE_FAIL:<name>:<msg>`, plus a full `TRACE:` dump under failures.
- Shutdown handler upgraded to log `STAGE_FATAL:<last_stage>:<msg>` for uncatchable fatals (`E_PARSE`, `E_CORE_ERROR`, `E_COMPILE_ERROR`) — tagged with the stage we were in when PHP died.
- Stopped silencing `E_WARNING` / `E_NOTICE` / `E_DEPRECATED`. `set_error_handler()` logs them as `NOTICE:` lines; the bash runner surfaces them even on success. Warnings inside WP bootstrap have historically masked real problems.
- `PHPUnit\TextUI\TestRunner::run()` now receives `extensions => []` to silence two 'Undefined array key' warnings that PHPUnit 9.6 emitted per run.
- Eight stages, defined and documented in a header comment: `boot` → `install` → `load_fixtures` → `load_deps` → `load_component` → `discover_tests` → `load_tests` → `run_tests`.

### Runner (`test-runner-playground.sh`)

Replaces the single-fallthrough matcher with explicit priority-ordered classification:

1. `STAGE_FAIL` / `STAGE_FATAL` in result file → bootstrap failure, show which stage + the exception message.
2. `SOME TESTS FAILED` → PHPUnit assertion failures (preserves existing replay-mode behavior).
3. `FAILURES!` / `ERRORS!` on stdout with non-zero exit → belt-and-suspenders for PHPUnit failures the result file somehow missed.
4. `PHP Parse error` / `PHP Fatal error` on stderr with non-zero exit → PHP crashed before our template took control.
5. **Unclassified non-zero exit** → dump structured log + raw stdout/stderr, exit with the playground's own code (this is what used to silently exit 0).
6. No output at all → dump diagnostics, exit 1.
7. `NO_TEST_FILES` → discovery found nothing.
8. 'No tests executed' / 'OK (0 tests' → zero-test PHPUnit run.

`dump_diagnostics()` helper prints both the structured log and raw stdout/stderr under failure, which is what you actually need to debug.

### Documentation

- `TEST_INFRASTRUCTURE_PLAN.md` § Phase 5 gains a diagnostics contract table and marks this workstream complete.

## Test matrix

All four scenarios verified end-to-end against the fixture (`/tmp/test-plugin-*`):

| Scenario | Before | After |
|----------|--------|-------|
| Healthy plugin | OK, 2 unexplained PHPUnit warnings | OK, warnings fixed |
| Plugin with parse error in entry file | **Silent exit 0** (the bug) | Exit 1, `STAGE_FAIL:load_component:ParseError: ...` with trace |
| Plugin with uncaught exception in entry file | `FATAL:` message captured | `STAGE_FAIL:load_component:Exception: ...` with trace |
| Plugin with deliberately failing assertion | Exit 1, PHPUnit output | Exit 1, PHPUnit output (unchanged) |
| Plugin where a test throws RuntimeException | Exit 2 (PHPUnit error) | Exit 2 (unchanged — PHPUnit's own convention) |

## Files

| File | Change |
|------|--------|
| `wordpress/scripts/test/playground-runner.php` | Structured stages + error handling |
| `wordpress/scripts/test/test-runner-playground.sh` | Priority-ordered classification + dump_diagnostics |
| `wordpress/TEST_INFRASTRUCTURE_PLAN.md` | Phase 5 section: diagnostics contract + remaining gaps |

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code
- **Used for:** Agent reproduced the silent-exit-0 bug against a plugin with a parse error, designed the structured-stage redesign, implemented the template + bash runner changes, and verified five failure modes end-to-end. Chris reviewed the Phase 2 plan (reframed PR 3 to parse the extension's own `phpunit.xml.dist` rather than per-plugin config, which then subsumed the original discovery-patterns PR) and directed the three-PR sequencing.