### PR TITLE
wordpress: playground db.php drop-in coexistence — fixture + smoke test (Phase 2 of #214)

### DIFF
--- a/wordpress/TEST_INFRASTRUCTURE_PLAN.md
+++ b/wordpress/TEST_INFRASTRUCTURE_PLAN.md
@@ -467,7 +467,33 @@ SQLite) instead of host PHP. Does not replace the host backend.
 | Update README with backend docs | README.md | ✅ Complete |
 | In-process WP install (replace `system()` call) | — | ✅ Complete |
 | PHPUnit stdout forwarding | — | ✅ Complete |
+| Structured stage logging + diagnostics | scripts/test/playground-runner.php, test-runner-playground.sh | ✅ Complete (Phase 2) |
+| Parse extension phpunit.xml.dist in runner | — | 🔲 Pending |
 | db.php drop-in support (MDI test) | — | 🔲 Pending |
+
+**Diagnostics contract (Phase 2):**
+
+The template writes a structured log (`.pg-test-result.txt`) with these line patterns:
+
+| Line | Meaning |
+|------|---------|
+| `STAGE_BEGIN:<stage>` | Entered a bootstrap phase |
+| `STAGE_OK:<stage>` | Phase completed cleanly |
+| `STAGE_FAIL:<stage>:<msg>` | Throwable caught during phase |
+| `STAGE_FATAL:<stage>:<msg>` | Uncatchable fatal (shutdown handler) |
+| `NOTICE:<msg>` | PHP warning/notice (not swallowed) |
+| `PLUGIN_DETECTED <file>` / `THEME_DETECTED` | Component load success |
+| `NO_TEST_FILES` | Discovery found nothing |
+| `ALL TESTS PASSED` / `SOME TESTS FAILED` | PHPUnit outcome |
+
+Stages (in execution order): `boot` → `install` → `load_fixtures` → `load_deps`
+→ `load_component` → `discover_tests` → `load_tests` → `run_tests`.
+
+The bash runner classifies failures in priority order: bootstrap stage failure
+→ PHPUnit assertion failure → pre-runner PHP crash (parse/fatal on stderr) →
+unclassified non-zero exit. Unclassified non-zero exits used to silently
+report success; they now dump the structured log + raw stdout/stderr and exit
+with the playground's own exit code.
 
 **Architecture:**
 
@@ -489,7 +515,7 @@ SQLite) instead of host PHP. Does not replace the host backend.
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-**Known Gaps (Phase 1):**
+**Known Gaps (remaining after Phase 2 diagnostics):**
 
 1. **WP version pinning.** The `--wp` flag must match the wp-phpunit package
    version (currently 6.9.x). Mismatch causes missing class errors in the
@@ -499,10 +525,12 @@ SQLite) instead of host PHP. Does not replace the host backend.
    integration) can be mounted into the Playground VFS, but Playground's built-in
    SQLite integration may conflict. Needs per-case testing.
 
-3. **No host bootstrap.** The Playground backend does not use `tests/bootstrap.php`.
-    It runs `install.php` in-process and loads test case classes directly. Any
-   customizations in the host bootstrap (e.g., additional `tests_add_filter` calls)
-   won't apply.
+3. **No host bootstrap, no phpunit.xml.dist parsing.** The Playground backend
+   does not use `tests/bootstrap.php` or the extension's `phpunit.xml.dist`.
+   It runs `install.php` in-process and discovers test files via hand-rolled
+   glob (`test-*.php`, `*Test.php`). Any customizations in the host bootstrap
+   or phpunit config (e.g., additional `tests_add_filter` calls, custom
+   suites, coverage rules) won't apply. Tracked as a follow-up task above.
 
 **References:**
 - Issue: Extra-Chill/homeboy-extensions#214

--- a/wordpress/TEST_INFRASTRUCTURE_PLAN.md
+++ b/wordpress/TEST_INFRASTRUCTURE_PLAN.md
@@ -468,7 +468,7 @@ SQLite) instead of host PHP. Does not replace the host backend.
 | In-process WP install (replace `system()` call) | — | ✅ Complete |
 | PHPUnit stdout forwarding | — | ✅ Complete |
 | Structured stage logging + diagnostics | scripts/test/playground-runner.php, test-runner-playground.sh | ✅ Complete (Phase 2) |
-| Parse extension phpunit.xml.dist in runner | — | 🔲 Pending |
+| Parse extension phpunit.xml.dist + recursive discovery | scripts/test/playground-runner.php | ✅ Complete (Phase 2) |
 | db.php drop-in support (MDI test) | — | 🔲 Pending |
 
 **Diagnostics contract (Phase 2):**
@@ -525,12 +525,18 @@ with the playground's own exit code.
    integration) can be mounted into the Playground VFS, but Playground's built-in
    SQLite integration may conflict. Needs per-case testing.
 
-3. **No host bootstrap, no phpunit.xml.dist parsing.** The Playground backend
-   does not use `tests/bootstrap.php` or the extension's `phpunit.xml.dist`.
-   It runs `install.php` in-process and discovers test files via hand-rolled
-   glob (`test-*.php`, `*Test.php`). Any customizations in the host bootstrap
-   or phpunit config (e.g., additional `tests_add_filter` calls, custom
-   suites, coverage rules) won't apply. Tracked as a follow-up task above.
+3. **No host bootstrap.** The Playground backend does not use `tests/bootstrap.php`.
+   It runs `install.php` in-process and loads test case classes directly. Any
+   customizations in the host bootstrap (e.g., additional `tests_add_filter`
+   calls) won't apply.
+
+4. **Partial phpunit.xml.dist consumption.** The runner reads the extension's
+   `phpunit.xml.dist` for `<testsuite><directory>` entries (with optional
+   `suffix` / `prefix` attributes) and `<testsuite><exclude>` entries. Other
+   elements (coverage config, bootstrap attribute, `<php>` env vars, groups,
+   listeners, extensions) are intentionally not honored — they either refer
+   to host-filesystem paths that have no meaning in the VFS, or they describe
+   behavior our template already provides.
 
 **References:**
 - Issue: Extra-Chill/homeboy-extensions#214

--- a/wordpress/TEST_INFRASTRUCTURE_PLAN.md
+++ b/wordpress/TEST_INFRASTRUCTURE_PLAN.md
@@ -469,7 +469,7 @@ SQLite) instead of host PHP. Does not replace the host backend.
 | PHPUnit stdout forwarding | — | ✅ Complete |
 | Structured stage logging + diagnostics | scripts/test/playground-runner.php, test-runner-playground.sh | ✅ Complete (Phase 2) |
 | Parse extension phpunit.xml.dist + recursive discovery | scripts/test/playground-runner.php | ✅ Complete (Phase 2) |
-| db.php drop-in support (MDI test) | — | 🔲 Pending |
+| db.php drop-in coexistence + smoke test | scripts/test/test-runner-playground.sh, tests/fixtures/dropin-coexistence/, scripts/test/playground-dropin-smoke.sh, docs/PLAYGROUND_DROPIN.md | ✅ Complete (Phase 2) |
 
 **Diagnostics contract (Phase 2):**
 
@@ -515,28 +515,32 @@ with the playground's own exit code.
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-**Known Gaps (remaining after Phase 2 diagnostics):**
+**Known Gaps (remaining after Phase 2):**
 
 1. **WP version pinning.** The `--wp` flag must match the wp-phpunit package
    version (currently 6.9.x). Mismatch causes missing class errors in the
    wp-phpunit bootstrap.
 
-2. **db.php drop-in support.** Custom `db.php` drop-ins (e.g., markdown-database-
-   integration) can be mounted into the Playground VFS, but Playground's built-in
-   SQLite integration may conflict. Needs per-case testing.
-
-3. **No host bootstrap.** The Playground backend does not use `tests/bootstrap.php`.
+2. **No host bootstrap.** The Playground backend does not use `tests/bootstrap.php`.
    It runs `install.php` in-process and loads test case classes directly. Any
    customizations in the host bootstrap (e.g., additional `tests_add_filter`
    calls) won't apply.
 
-4. **Partial phpunit.xml.dist consumption.** The runner reads the extension's
+3. **Partial phpunit.xml.dist consumption.** The runner reads the extension's
    `phpunit.xml.dist` for `<testsuite><directory>` entries (with optional
    `suffix` / `prefix` attributes) and `<testsuite><exclude>` entries. Other
    elements (coverage config, bootstrap attribute, `<php>` env vars, groups,
    listeners, extensions) are intentionally not honored — they either refer
    to host-filesystem paths that have no meaning in the VFS, or they describe
    behavior our template already provides.
+
+4. **db.php drop-in coexistence depends on Playground upstream.** The
+   mechanism relies on Playground's internal SQLite mu-plugin voluntarily
+   stepping aside when `/wordpress/wp-content/db.php` exists. If upstream
+   removes or changes that guard, the coexistence model breaks.
+   `scripts/test/playground-dropin-smoke.sh` catches this regression via the
+   `test_playground_mu_plugin_stepped_aside` assertion. See
+   `docs/PLAYGROUND_DROPIN.md` for the full mechanism.
 
 **References:**
 - Issue: Extra-Chill/homeboy-extensions#214

--- a/wordpress/docs/PLAYGROUND_DROPIN.md
+++ b/wordpress/docs/PLAYGROUND_DROPIN.md
@@ -1,0 +1,177 @@
+# Playground backend: db.php drop-in coexistence
+
+The Playground test backend supports plugins that ship their own `db.php`
+drop-in (WordPress's mechanism for swapping out `$wpdb`). This document
+explains the mechanism, shows how to verify it end-to-end, and documents the
+upstream Playground behavior this integration relies on.
+
+## Summary
+
+**Plugins with a `db.php` drop-in do not need any special configuration.**
+The Playground backend detects `<plugin>/db.php` and mounts it to
+`/wordpress/wp-content/db.php` inside the VFS. Playground's built-in SQLite
+integration then voluntarily steps aside and lets the drop-in own `$wpdb`.
+
+Concretely:
+
+```
+plugin/
+├── main-plugin.php     # Plugin entry
+├── db.php              # Drop-in — gets mounted to /wp-content/db.php
+└── tests/
+    └── SomeTest.php    # Runs with plugin's db.php in charge of $wpdb
+```
+
+The runner handles the mount. You just place `db.php` in the plugin root.
+
+## How coexistence works
+
+WordPress Playground normally ships an mu-plugin at
+`/internal/shared/mu-plugins/sqlite-database-integration.php` that wires up
+`$wpdb` to its bundled SQLite implementation. The first few lines of that
+mu-plugin are a guard:
+
+```php
+// Do not preload this if WordPress comes with a custom db.php file.
+if ( file_exists( '/wordpress/wp-content/db.php' ) ) {
+    return;
+}
+```
+
+So the load order during a Playground request is:
+
+1. **WordPress core** (`wp-settings.php`) calls `require_wp_db()`, which
+   checks for `/wordpress/wp-content/db.php` and, if present, `require_once`s
+   it. The drop-in sets `$wpdb` and defines any constants it needs.
+2. **Playground's SQLite mu-plugin** loads, sees the drop-in exists, and
+   returns immediately. `$wpdb` stays as whatever the drop-in set it to.
+3. **WordPress** finishes booting with the drop-in's `$wpdb` in charge.
+
+No `--skip-sqlite-setup` flag is needed. The runner does not pass it and
+you should not either — if you pass `--skip-sqlite-setup` AND mount a
+drop-in that relies on Playground's bundled SQLite classes, the
+`/internal/shared/sqlite-database-integration/` directory is still available
+on the VFS (mu-plugins are config, the library is filesystem), so the drop-in
+still works. But the full WordPress install path tries to initialize MySQL
+and fails early. Skip-sqlite-setup is for a different use case (host-MySQL
+testing), not for drop-in coexistence.
+
+## The drop-in can reuse Playground's bundled SQLite
+
+This is the killer feature. Playground's SQLite implementation lives at
+`/internal/shared/sqlite-database-integration/` in the VFS and is readable
+from the drop-in:
+
+```php
+<?php
+// Your plugin's db.php
+
+$sqlite = '/internal/shared/sqlite-database-integration';
+if ( ! file_exists( $sqlite . '/wp-includes/sqlite/db.php' ) ) {
+    return; // fall back to MySQL
+}
+
+if ( ! defined( 'DB_ENGINE' ) ) {
+    define( 'DB_ENGINE', 'sqlite' );
+}
+
+// Delegate to Playground's implementation — this sets $wpdb = WP_SQLite_DB.
+require_once $sqlite . '/wp-includes/sqlite/db.php';
+
+// ...then wrap $wpdb, subclass it, or replace it entirely with your own.
+```
+
+This is the pattern [markdown-database-integration](https://github.com/Automattic/markdown-database-integration)
+uses in production: delegate to Playground's bundled SQLite for the query
+engine, then substitute a custom `$wpdb` subclass that adds markdown
+mirroring on top.
+
+## Verifying with the fixture
+
+A reference fixture lives at `wordpress/tests/fixtures/dropin-coexistence/`:
+
+```
+tests/fixtures/dropin-coexistence/
+├── plugin.php                          # Inert plugin entry
+├── db.php                              # Reference drop-in (delegates to bundled SQLite)
+└── tests/
+    └── DropInCoexistenceTest.php      # Asserts coexistence end-to-end
+```
+
+The smoke-test runner script runs this fixture and checks all three
+invariants:
+
+```bash
+bash wordpress/scripts/test/playground-dropin-smoke.sh
+```
+
+Expected output:
+
+```
+OK (3 tests, 8 assertions)
+✓ Drop-in coexistence smoke test PASSED
+```
+
+The three assertions cover:
+
+1. **Drop-in actually loaded.** `HOMEBOY_DROPIN_FIXTURE_LOADED` is defined
+   only by `db.php`. If undefined, WordPress never `require_once`d the
+   drop-in — check the mount.
+2. **`$wpdb` works end-to-end.** `wp_insert_post` + `get_post` round-trip
+   real data through the drop-in's `$wpdb`.
+3. **Playground's mu-plugin stepped aside.** `SQLITE_DB_DROPIN_VERSION` is
+   defined at the top of Playground's mu-plugin body. If it IS defined, the
+   mu-plugin's guard failed and the drop-in was silently overwritten.
+
+Run the smoke test after:
+
+- Changes to `scripts/test/test-runner-playground.sh` (the bash dispatcher)
+- Changes to `scripts/test/playground-runner.php` (the template)
+- Upgrading `@wp-playground/cli` (upstream may change the mu-plugin guard)
+
+## Upstream contract
+
+This whole mechanism depends on the guard at the top of
+`/internal/shared/mu-plugins/sqlite-database-integration.php`. If a future
+Playground release removes or changes that guard, the coexistence model
+breaks. The `test_playground_mu_plugin_stepped_aside` assertion in the
+fixture catches that regression.
+
+Source of the guard:
+[WordPress/wordpress-playground — packages/playground/wordpress-builds/...](https://github.com/WordPress/wordpress-playground)
+(look for the mu-plugin that's auto-generated from the SQLite integration
+during build).
+
+## Limitations
+
+- **WordPress install flow.** Playground's default install flow assumes
+  SQLite is available. If your drop-in cannot serve the install flow (e.g.,
+  it needs external state to be set up first), the tests will die with
+  "Error connecting to the database" before the test runner starts. Fix:
+  make sure the drop-in can serve a cold-boot install, which typically
+  means it must delegate to Playground's bundled SQLite for the initial
+  schema.
+
+- **WP version pinning.** The `--wp=6.9` flag in the Playground runner must
+  match the `wp-phpunit` package version. Don't forget to update both when
+  bumping WordPress. A mismatch often manifests as missing `WP_UnitTestCase`
+  factory methods, not as a database error — the drop-in will load fine but
+  wp-phpunit bootstrap will fail.
+
+- **MDI-specific note.** Markdown Database Integration's production drop-in
+  assumes its own plugin directory is at
+  `wp-content/plugins/markdown-database-integration/` (to load its classes).
+  When testing MDI through the Playground backend, the MDI plugin itself is
+  mounted to that location by `test-runner-playground.sh`. You don't have
+  to configure anything special for this common case.
+
+## Related
+
+- Issue [#214](https://github.com/Extra-Chill/homeboy-extensions/issues/214)
+  (Playground backend umbrella)
+- PR [#215](https://github.com/Extra-Chill/homeboy-extensions/pull/215)
+  (Phase 1: initial Playground backend)
+- PR [#216](https://github.com/Extra-Chill/homeboy-extensions/pull/216)
+  (Phase 2: structured diagnostics)
+- PR [#217](https://github.com/Extra-Chill/homeboy-extensions/pull/217)
+  (Phase 2: phpunit.xml.dist-aware recursive discovery)

--- a/wordpress/scripts/test/playground-dropin-smoke.sh
+++ b/wordpress/scripts/test/playground-dropin-smoke.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Playground backend db.php drop-in coexistence smoke test.
+#
+# Runs the fixture at wordpress/tests/fixtures/dropin-coexistence/ through the
+# Playground backend and asserts that a custom db.php drop-in can coexist
+# with Playground's built-in SQLite integration.
+#
+# This is a manual integration test, not part of the normal CI matrix. Run it
+# after changes to:
+#   - test-runner-playground.sh (the bash dispatcher)
+#   - playground-runner.php (the template)
+#   - anything touching the db.php mount logic
+#
+# Usage: bash wordpress/scripts/test/playground-dropin-smoke.sh
+# Exit:  0 = coexistence works, non-zero = regression
+#
+# Background: see wordpress/docs/PLAYGROUND_DROPIN.md
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/dropin-coexistence"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+echo "============================================"
+echo "Playground drop-in coexistence smoke test"
+echo "============================================"
+echo "Fixture: $FIXTURE_DIR"
+echo ""
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+    HOMEBOY_COMPONENT_ID="dropin-coexistence-fixture" \
+    bash "${SCRIPT_DIR}/test-runner-playground.sh"
+
+exit_code=$?
+if [ $exit_code -eq 0 ]; then
+    echo ""
+    echo "============================================"
+    echo "✓ Drop-in coexistence smoke test PASSED"
+    echo "============================================"
+else
+    echo ""
+    echo "============================================"
+    echo "✗ Drop-in coexistence smoke test FAILED (exit $exit_code)"
+    echo "============================================"
+    echo "See docs/PLAYGROUND_DROPIN.md for the expected mechanism."
+fi
+
+exit $exit_code

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -1,26 +1,116 @@
 <?php
-error_reporting(E_ALL & ~E_WARNING & ~E_NOTICE & ~E_DEPRECATED);
+/**
+ * Playground test runner template.
+ *
+ * This file is rendered by scripts/test/test-runner-playground.sh via sed
+ * substitution of {{PLUGIN_SLUG}} and {{PLAYGROUND_DEP_MOUNTS}} before being
+ * mounted into the Playground VFS as /runner.php.
+ *
+ * DIAGNOSTICS CONTRACT
+ *
+ * The result file (/wordpress/wp-content/plugins/<slug>/.pg-test-result.txt)
+ * is the structured log the host-side bash runner parses. Every line takes
+ * one of these forms:
+ *
+ *   STAGE_BEGIN:<stage>          - entering a bootstrap phase
+ *   STAGE_OK:<stage>             - phase completed cleanly
+ *   STAGE_FAIL:<stage>:<msg>     - caught Throwable during phase
+ *   STAGE_FATAL:<stage>:<msg>    - uncatchable fatal (from shutdown handler)
+ *   NOTICE:<msg>                 - PHP warning/notice that escaped silencing
+ *   PLUGIN_DETECTED <basename>   - loaded plugin entry file
+ *   THEME_DETECTED               - loaded theme (style.css + functions.php)
+ *   NO_TEST_FILES                - discovery found no candidates
+ *   RUNNING <n> TEST FILES       - starting PHPUnit
+ *   ALL TESTS PASSED             - result.wasSuccessful() == true
+ *   SOME TESTS FAILED            - result.wasSuccessful() == false
+ *   TESTS: <n> FAILURES: <n> ERRORS: <n>
+ *
+ * Stages (in execution order):
+ *   boot             - composer autoload + config write
+ *   install          - wp-phpunit install.php (creates WP + tables)
+ *   load_fixtures    - test case classes, mock mailer, harness filters
+ *   load_deps        - dependency plugin bootstrap files (if any)
+ *   load_component   - plugin/theme under test
+ *   discover_tests   - glob test files
+ *   load_tests       - require_once each test file
+ *   run_tests        - PHPUnit execution
+ *
+ * The bash runner's job: if playground_exit != 0 AND no STAGE_FAIL/FATAL/
+ * SOME TESTS FAILED line exists, surface the raw stdout/stderr — something
+ * crashed before we could even write to the result file.
+ */
+
+// Report everything. Warnings/notices inside WP bootstrap have historically
+// been the silent failure mode — the old ~E_WARNING mask hid real problems.
+error_reporting(E_ALL);
+ini_set('display_errors', '1');
+ini_set('display_startup_errors', '1');
 
 $result_file = '/wordpress/wp-content/plugins/{{PLUGIN_SLUG}}/.pg-test-result.txt';
+$current_stage = 'preboot';
 
-function log_msg($msg) {
+function pg_log($msg) {
     global $result_file;
     file_put_contents($result_file, $msg . "\n", FILE_APPEND);
 }
 
-register_shutdown_function(function() {
-    global $result_file;
+function pg_stage_begin($stage) {
+    global $current_stage;
+    $current_stage = $stage;
+    pg_log("STAGE_BEGIN:$stage");
+}
+
+function pg_stage_ok($stage) {
+    pg_log("STAGE_OK:$stage");
+}
+
+function pg_stage_fail($stage, Throwable $e) {
+    $msg = get_class($e) . ': ' . $e->getMessage()
+        . ' at ' . $e->getFile() . ':' . $e->getLine();
+    pg_log("STAGE_FAIL:$stage:$msg");
+    // Also dump trace for debugging; bash runner will print it under failure.
+    pg_log("TRACE:");
+    foreach (explode("\n", $e->getTraceAsString()) as $line) {
+        pg_log("  $line");
+    }
+}
+
+// Capture non-fatal warnings/notices so they don't vanish into the void.
+set_error_handler(function ($severity, $message, $file, $line) {
+    if (!(error_reporting() & $severity)) {
+        return false;
+    }
+    $label = [
+        E_WARNING => 'WARNING',
+        E_NOTICE => 'NOTICE',
+        E_DEPRECATED => 'DEPRECATED',
+        E_USER_WARNING => 'USER_WARNING',
+        E_USER_NOTICE => 'USER_NOTICE',
+        E_USER_DEPRECATED => 'USER_DEPRECATED',
+        E_STRICT => 'STRICT',
+    ][$severity] ?? "E_$severity";
+    pg_log("NOTICE:$label: $message at $file:$line");
+    return false; // let PHP's default handler also run
+});
+
+register_shutdown_function(function () {
+    global $current_stage;
     $error = error_get_last();
-    if ($error && $error['type'] === E_ERROR) {
-        file_put_contents($result_file, "FATAL: {$error['message']}\n", FILE_APPEND);
+    if ($error && in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
+        pg_log("STAGE_FATAL:$current_stage:{$error['message']} at {$error['file']}:{$error['line']}");
     }
 });
 
 $tests_dir = '/homeboy-extension/vendor/wp-phpunit/wp-phpunit';
 $plugin_path = '/wordpress/wp-content/plugins/{{PLUGIN_SLUG}}';
 
-$config_path = '/tmp/wp-tests-config.php';
-file_put_contents($config_path, <<<'CONFIG'
+// ---------------------------------------------------------------------------
+// Stage: boot
+// ---------------------------------------------------------------------------
+pg_stage_begin('boot');
+try {
+    $config_path = '/tmp/wp-tests-config.php';
+    file_put_contents($config_path, <<<'CONFIG'
 <?php
 $table_prefix = 'wptests_';
 define('DB_NAME', ':memory:');
@@ -37,113 +127,205 @@ define('FS_CHMOD_FILE', 0644);
 define('FS_CHMOD_DIR', 0755);
 define('FS_METHOD', 'direct');
 CONFIG
-);
+    );
 
-require_once '/homeboy-extension/vendor/autoload.php';
-log_msg("BOOT OK");
-
-$argv = ['install.php', $config_path, 'no_ms_tests', 'no_core_tests'];
-$_SERVER['argv'] = $argv;
-
-log_msg("INSTALLING");
-require_once "$tests_dir/includes/install.php";
-log_msg("INSTALLED");
-
-while (ob_get_level() > 0) @ob_end_clean();
-
-global $phpmailer;
-require_once "$tests_dir/includes/mock-mailer.php";
-$phpmailer = new MockPHPMailer(true);
-
-require_once "$tests_dir/includes/functions.php";
-$GLOBALS['_wp_die_disabled'] = false;
-tests_add_filter('wp_die_handler', '_wp_die_handler_filter');
-tests_add_filter('wp_rest_server_class', '_wp_rest_server_class_filter');
-tests_add_filter('async_update_translation', '__return_false');
-tests_add_filter('automatic_updater_disabled', '__return_true');
-
-require_once "$tests_dir/includes/phpunit6/compat.php";
-require_once "$tests_dir/includes/phpunit-adapter-testcase.php";
-require_once "$tests_dir/includes/abstract-testcase.php";
-require_once "$tests_dir/includes/testcase.php";
-require_once "$tests_dir/includes/testcase-rest-api.php";
-require_once "$tests_dir/includes/testcase-rest-controller.php";
-require_once "$tests_dir/includes/testcase-rest-post-type-controller.php";
-require_once "$tests_dir/includes/testcase-xmlrpc.php";
-require_once "$tests_dir/includes/testcase-ajax.php";
-require_once "$tests_dir/includes/testcase-canonical.php";
-require_once "$tests_dir/includes/testcase-xml.php";
-require_once "$tests_dir/includes/exceptions.php";
-require_once "$tests_dir/includes/utils.php";
-require_once "$tests_dir/includes/spy-rest-server.php";
-require_once "$tests_dir/includes/class-wp-rest-test-search-handler.php";
-require_once "$tests_dir/includes/class-wp-rest-test-configurable-controller.php";
-require_once "$tests_dir/includes/class-wp-fake-block-type.php";
-require_once "$tests_dir/includes/class-wp-fake-hasher.php";
-require_once "$tests_dir/includes/class-wp-sitemaps-test-provider.php";
-require_once "$tests_dir/includes/class-wp-sitemaps-empty-test-provider.php";
-require_once "$tests_dir/includes/class-wp-sitemaps-large-test-provider.php";
-
-log_msg("TEST_CLASSES_LOADED");
-
-$dep_paths = '{{PLAYGROUND_DEP_MOUNTS}}';
-if (!empty($dep_paths)) {
-    foreach (explode("\n", $dep_paths) as $dep_mount) {
-        $dep_mount = trim($dep_mount);
-        if (empty($dep_mount)) continue;
-        $dep_files = glob("$dep_mount/*.php");
-        foreach ($dep_files as $df) {
-            if (strpos(file_get_contents($df), 'Plugin Name:') !== false) {
-                require_once $df;
-                break;
-            }
-        }
-    }
-}
-
-$style_css = "$plugin_path/style.css";
-if (file_exists($style_css) && strpos(file_get_contents($style_css), 'Theme Name:') !== false) {
-    log_msg("THEME_DETECTED");
-    $fn_php = "$plugin_path/functions.php";
-    if (file_exists($fn_php)) require_once $fn_php;
-} else {
-    $main_files = glob("$plugin_path/*.php");
-    foreach ($main_files as $mf) {
-        if (strpos(file_get_contents($mf), 'Plugin Name:') !== false) {
-            log_msg("PLUGIN_DETECTED " . basename($mf));
-            require_once $mf;
-            break;
-        }
-    }
-}
-
-$test_dir = "$plugin_path/tests";
-$test_files = array_merge(
-    glob("$test_dir/test-*.php") ?: [],
-    glob("$test_dir/*Test.php") ?: []
-);
-if (empty($test_files)) {
-    log_msg("NO_TEST_FILES");
+    require_once '/homeboy-extension/vendor/autoload.php';
+    pg_stage_ok('boot');
+} catch (Throwable $e) {
+    pg_stage_fail('boot', $e);
     exit(1);
 }
 
+// ---------------------------------------------------------------------------
+// Stage: install (wp-phpunit install.php creates WP tables in-process)
+// ---------------------------------------------------------------------------
+pg_stage_begin('install');
+try {
+    $argv = ['install.php', $config_path, 'no_ms_tests', 'no_core_tests'];
+    $_SERVER['argv'] = $argv;
+    require_once "$tests_dir/includes/install.php";
+    while (ob_get_level() > 0) {
+        @ob_end_clean();
+    }
+    pg_stage_ok('install');
+} catch (Throwable $e) {
+    pg_stage_fail('install', $e);
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Stage: load_fixtures (test case classes, mock mailer, harness filters)
+// ---------------------------------------------------------------------------
+pg_stage_begin('load_fixtures');
+try {
+    global $phpmailer;
+    require_once "$tests_dir/includes/mock-mailer.php";
+    $phpmailer = new MockPHPMailer(true);
+
+    require_once "$tests_dir/includes/functions.php";
+    $GLOBALS['_wp_die_disabled'] = false;
+    tests_add_filter('wp_die_handler', '_wp_die_handler_filter');
+    tests_add_filter('wp_rest_server_class', '_wp_rest_server_class_filter');
+    tests_add_filter('async_update_translation', '__return_false');
+    tests_add_filter('automatic_updater_disabled', '__return_true');
+
+    require_once "$tests_dir/includes/phpunit6/compat.php";
+    require_once "$tests_dir/includes/phpunit-adapter-testcase.php";
+    require_once "$tests_dir/includes/abstract-testcase.php";
+    require_once "$tests_dir/includes/testcase.php";
+    require_once "$tests_dir/includes/testcase-rest-api.php";
+    require_once "$tests_dir/includes/testcase-rest-controller.php";
+    require_once "$tests_dir/includes/testcase-rest-post-type-controller.php";
+    require_once "$tests_dir/includes/testcase-xmlrpc.php";
+    require_once "$tests_dir/includes/testcase-ajax.php";
+    require_once "$tests_dir/includes/testcase-canonical.php";
+    require_once "$tests_dir/includes/testcase-xml.php";
+    require_once "$tests_dir/includes/exceptions.php";
+    require_once "$tests_dir/includes/utils.php";
+    require_once "$tests_dir/includes/spy-rest-server.php";
+    require_once "$tests_dir/includes/class-wp-rest-test-search-handler.php";
+    require_once "$tests_dir/includes/class-wp-rest-test-configurable-controller.php";
+    require_once "$tests_dir/includes/class-wp-fake-block-type.php";
+    require_once "$tests_dir/includes/class-wp-fake-hasher.php";
+    require_once "$tests_dir/includes/class-wp-sitemaps-test-provider.php";
+    require_once "$tests_dir/includes/class-wp-sitemaps-empty-test-provider.php";
+    require_once "$tests_dir/includes/class-wp-sitemaps-large-test-provider.php";
+
+    pg_stage_ok('load_fixtures');
+} catch (Throwable $e) {
+    pg_stage_fail('load_fixtures', $e);
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Stage: load_deps (dependency plugin bootstrap files)
+// ---------------------------------------------------------------------------
+pg_stage_begin('load_deps');
+try {
+    $dep_paths = '{{PLAYGROUND_DEP_MOUNTS}}';
+    if (!empty($dep_paths)) {
+        foreach (explode("\n", $dep_paths) as $dep_mount) {
+            $dep_mount = trim($dep_mount);
+            if (empty($dep_mount)) {
+                continue;
+            }
+            $dep_files = glob("$dep_mount/*.php") ?: [];
+            foreach ($dep_files as $df) {
+                if (strpos(file_get_contents($df), 'Plugin Name:') !== false) {
+                    require_once $df;
+                    break;
+                }
+            }
+        }
+    }
+    pg_stage_ok('load_deps');
+} catch (Throwable $e) {
+    pg_stage_fail('load_deps', $e);
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Stage: load_component (plugin or theme under test)
+// ---------------------------------------------------------------------------
+pg_stage_begin('load_component');
+try {
+    $style_css = "$plugin_path/style.css";
+    if (file_exists($style_css) && strpos(file_get_contents($style_css), 'Theme Name:') !== false) {
+        pg_log("THEME_DETECTED");
+        $fn_php = "$plugin_path/functions.php";
+        if (file_exists($fn_php)) {
+            require_once $fn_php;
+        }
+    } else {
+        $loaded = false;
+        $main_files = glob("$plugin_path/*.php") ?: [];
+        foreach ($main_files as $mf) {
+            if (strpos(file_get_contents($mf), 'Plugin Name:') !== false) {
+                pg_log("PLUGIN_DETECTED " . basename($mf));
+                require_once $mf;
+                $loaded = true;
+                break;
+            }
+        }
+        if (!$loaded) {
+            pg_log("NOTICE:no plugin entry file with 'Plugin Name:' header found in $plugin_path");
+        }
+    }
+    pg_stage_ok('load_component');
+} catch (Throwable $e) {
+    pg_stage_fail('load_component', $e);
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Stage: discover_tests
+// ---------------------------------------------------------------------------
+pg_stage_begin('discover_tests');
+try {
+    $test_dir = "$plugin_path/tests";
+    $test_files = array_merge(
+        glob("$test_dir/test-*.php") ?: [],
+        glob("$test_dir/*Test.php") ?: []
+    );
+    if (empty($test_files)) {
+        pg_log("NO_TEST_FILES");
+        pg_stage_ok('discover_tests');
+        exit(1);
+    }
+    pg_stage_ok('discover_tests');
+} catch (Throwable $e) {
+    pg_stage_fail('discover_tests', $e);
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Stage: load_tests (parse each test file, track which file defines which class)
+// ---------------------------------------------------------------------------
+pg_stage_begin('load_tests');
 $suite = new PHPUnit\Framework\TestSuite('Playground Tests');
 $before_classes = get_declared_classes();
-foreach ($test_files as $tf) {
-    require_once $tf;
+try {
+    foreach ($test_files as $tf) {
+        require_once $tf;
+    }
+} catch (Throwable $e) {
+    pg_stage_fail('load_tests', $e);
+    exit(1);
 }
 $after_classes = get_declared_classes();
 $new_classes = array_diff($after_classes, $before_classes);
 foreach ($new_classes as $class_name) {
-    $ref = new ReflectionClass($class_name);
-    if (!$ref->isAbstract() && $ref->isSubclassOf('PHPUnit\\Framework\\TestCase')) {
-        $suite->addTestSuite($class_name);
+    try {
+        $ref = new ReflectionClass($class_name);
+        if (!$ref->isAbstract() && $ref->isSubclassOf('PHPUnit\\Framework\\TestCase')) {
+            $suite->addTestSuite($class_name);
+        }
+    } catch (Throwable $e) {
+        pg_log("NOTICE:reflection failed for $class_name: " . $e->getMessage());
     }
 }
+pg_stage_ok('load_tests');
 
-log_msg("RUNNING " . count($test_files) . " TEST FILES");
-$runner = new PHPUnit\TextUI\TestRunner();
-$result = $runner->run($suite, ['colors' => 'never', 'testdox' => true, 'verbose' => false]);
-log_msg($result->wasSuccessful() ? "ALL TESTS PASSED" : "SOME TESTS FAILED");
-log_msg("TESTS: " . $result->count() . " FAILURES: " . count($result->failures()) . " ERRORS: " . count($result->errors()));
-exit($result->wasSuccessful() ? 0 : 1);
+// ---------------------------------------------------------------------------
+// Stage: run_tests
+// ---------------------------------------------------------------------------
+pg_stage_begin('run_tests');
+pg_log("RUNNING " . count($test_files) . " TEST FILES");
+try {
+    $runner = new PHPUnit\TextUI\TestRunner();
+    $result = $runner->run($suite, [
+        'colors' => 'never',
+        'testdox' => true,
+        'verbose' => false,
+        // PHPUnit 9.6 reads $arguments['extensions'] unconditionally (line 1074
+        // in TestRunner.php). Omit it and you get two warnings per run.
+        'extensions' => [],
+    ]);
+    pg_log($result->wasSuccessful() ? "ALL TESTS PASSED" : "SOME TESTS FAILED");
+    pg_log("TESTS: " . $result->count() . " FAILURES: " . count($result->failures()) . " ERRORS: " . count($result->errors()));
+    pg_stage_ok('run_tests');
+    exit($result->wasSuccessful() ? 0 : 1);
+} catch (Throwable $e) {
+    pg_stage_fail('run_tests', $e);
+    exit(1);
+}

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -259,14 +259,45 @@ try {
 
 // ---------------------------------------------------------------------------
 // Stage: discover_tests
+//
+// Recursively scans $plugin_path/tests for files matching the configured
+// suffix/prefix patterns. This mirrors PHPUnit's own behavior when given a
+// <directory> element in phpunit.xml.dist — it recurses and applies the
+// suffix/prefix filters from the element's attributes.
+//
+// Configuration source priority:
+//   1. Extension's /homeboy-extension/phpunit.xml.dist, if readable and parseable
+//   2. Hardcoded defaults: suffix=Test.php, prefix=test- (covers both PHPUnit
+//      native + WordPress conventions so projects don't have to choose)
+//
+// This is deliberately narrower than parsing the full PHPUnit XML schema.
+// The extension's XML is simple and static; we only consume the pieces that
+// affect test discovery (directories, suffixes, prefixes, excludes). Bootstrap,
+// coverage, env vars etc. don't translate from host filesystem to VFS anyway.
 // ---------------------------------------------------------------------------
 pg_stage_begin('discover_tests');
 try {
     $test_dir = "$plugin_path/tests";
-    $test_files = array_merge(
-        glob("$test_dir/test-*.php") ?: [],
-        glob("$test_dir/*Test.php") ?: []
+    if (!is_dir($test_dir)) {
+        pg_log("NO_TEST_FILES");
+        pg_log("NOTICE:tests directory not found at $test_dir");
+        pg_stage_ok('discover_tests');
+        exit(1);
+    }
+
+    [$directories, $suffixes, $prefixes, $excludes] = pg_parse_phpunit_config(
+        '/homeboy-extension/phpunit.xml.dist',
+        $test_dir
     );
+
+    $test_files = pg_discover_tests($directories, $suffixes, $prefixes, $excludes);
+
+    pg_log("DISCOVERY: dirs=" . implode(',', $directories)
+        . " suffixes=" . implode(',', $suffixes)
+        . " prefixes=" . implode(',', $prefixes)
+        . " excludes=" . count($excludes)
+        . " found=" . count($test_files));
+
     if (empty($test_files)) {
         pg_log("NO_TEST_FILES");
         pg_stage_ok('discover_tests');
@@ -276,6 +307,169 @@ try {
 } catch (Throwable $e) {
     pg_stage_fail('discover_tests', $e);
     exit(1);
+}
+
+/**
+ * Parse the extension's phpunit.xml.dist for test-discovery directives.
+ *
+ * Returns [directories, suffixes, prefixes, excludes]. Absolute paths only:
+ * any relative `<directory>` entry in the XML is resolved against
+ * $plugin_path/tests (the component under test, NOT the extension's own
+ * vendor dir — the XML's path semantics are "relative to the plugin being
+ * tested").
+ *
+ * Falls back to sensible defaults if the XML is missing or unparseable.
+ * Logs the reason to NOTICE so users can see which path was taken.
+ *
+ * @return array{0: string[], 1: string[], 2: string[], 3: string[]}
+ */
+function pg_parse_phpunit_config($xml_path, $test_dir_default) {
+    $directories = [$test_dir_default];
+    $suffixes = ['Test.php'];
+    $prefixes = ['test-'];
+    $excludes = [];
+
+    if (!is_readable($xml_path)) {
+        pg_log("NOTICE:phpunit.xml.dist not readable at $xml_path; using defaults");
+        return [$directories, $suffixes, $prefixes, $excludes];
+    }
+
+    // libxml_use_internal_errors + simplexml so a malformed XML doesn't
+    // explode inside the runner — fall back to defaults and keep going.
+    $prev_internal_errors = libxml_use_internal_errors(true);
+    $xml = @simplexml_load_file($xml_path);
+    $load_errors = libxml_get_errors();
+    libxml_clear_errors();
+    libxml_use_internal_errors($prev_internal_errors);
+
+    if ($xml === false) {
+        $first_err = $load_errors ? trim($load_errors[0]->message) : 'unknown';
+        pg_log("NOTICE:phpunit.xml.dist parse failed ($first_err); using defaults");
+        return [$directories, $suffixes, $prefixes, $excludes];
+    }
+
+    $config_dirs = [];
+    $config_suffixes = [];
+    $config_prefixes = [];
+    $plugin_base = dirname($test_dir_default); // plugin root
+
+    // <testsuites><testsuite><directory suffix="..." prefix="...">path</directory>
+    foreach ($xml->xpath('//testsuite/directory') ?: [] as $dir) {
+        $raw_path = trim((string) $dir);
+        if ($raw_path === '') {
+            continue;
+        }
+        // Resolve relative to the plugin root (PHPUnit's own convention is
+        // "relative to the config file", but we're using the extension's
+        // config against a different plugin, so "plugin root" is the
+        // semantically correct base here).
+        $abs = $raw_path[0] === '/' ? $raw_path : "$plugin_base/$raw_path";
+        $config_dirs[] = rtrim($abs, '/');
+
+        // Optional suffix/prefix attributes (comma-separated per PHPUnit docs,
+        // though the native schema only supports single values — we accept
+        // both for ergonomics).
+        if (isset($dir['suffix'])) {
+            foreach (explode(',', (string) $dir['suffix']) as $s) {
+                $s = trim($s);
+                if ($s !== '') {
+                    $config_suffixes[] = $s;
+                }
+            }
+        }
+        if (isset($dir['prefix'])) {
+            foreach (explode(',', (string) $dir['prefix']) as $p) {
+                $p = trim($p);
+                if ($p !== '') {
+                    $config_prefixes[] = $p;
+                }
+            }
+        }
+    }
+
+    // <testsuites><testsuite><exclude>path</exclude>
+    foreach ($xml->xpath('//testsuite/exclude') ?: [] as $ex) {
+        $raw = trim((string) $ex);
+        if ($raw === '') {
+            continue;
+        }
+        $abs = $raw[0] === '/' ? $raw : "$plugin_base/$raw";
+        $excludes[] = rtrim($abs, '/');
+    }
+
+    if (!empty($config_dirs)) {
+        $directories = $config_dirs;
+        pg_log("NOTICE:phpunit.xml.dist loaded from $xml_path");
+    }
+    if (!empty($config_suffixes)) {
+        $suffixes = $config_suffixes;
+    }
+    if (!empty($config_prefixes)) {
+        $prefixes = $config_prefixes;
+    }
+
+    return [$directories, $suffixes, $prefixes, $excludes];
+}
+
+/**
+ * Recursively find test files under the given directories.
+ *
+ * A file matches if its basename ends with any of the $suffixes OR starts
+ * with any of the $prefixes. Files under any path in $excludes are skipped.
+ *
+ * Uses SplFileInfo + RecursiveIteratorIterator so nested structures like
+ * tests/Unit/FooTest.php and tests/Integration/BarTest.php are picked up,
+ * which was the Phase 1 gap this discovery rewrite fixes.
+ */
+function pg_discover_tests(array $directories, array $suffixes, array $prefixes, array $excludes) {
+    $found = [];
+    foreach ($directories as $dir) {
+        if (!is_dir($dir)) {
+            pg_log("NOTICE:test directory does not exist: $dir");
+            continue;
+        }
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::LEAVES_ONLY
+        );
+        foreach ($iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+            $path = $file->getPathname();
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+            // Exclude paths: any directory prefix match disqualifies.
+            foreach ($excludes as $ex) {
+                if (strpos($path, $ex) === 0) {
+                    continue 2;
+                }
+            }
+            $base = $file->getBasename();
+            $matches = false;
+            foreach ($suffixes as $s) {
+                if ($s !== '' && substr($base, -strlen($s)) === $s) {
+                    $matches = true;
+                    break;
+                }
+            }
+            if (!$matches) {
+                foreach ($prefixes as $p) {
+                    if ($p !== '' && strpos($base, $p) === 0) {
+                        $matches = true;
+                        break;
+                    }
+                }
+            }
+            if ($matches) {
+                $found[] = $path;
+            }
+        }
+    }
+    // Stable ordering so re-runs show the same failure order.
+    sort($found);
+    return array_values(array_unique($found));
 }
 
 // ---------------------------------------------------------------------------

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -240,6 +240,13 @@ try {
         $loaded = false;
         $main_files = glob("$plugin_path/*.php") ?: [];
         foreach ($main_files as $mf) {
+            // db.php is a WordPress drop-in, not a plugin entry file. It's
+            // already been loaded by wp-settings.php earlier in the request
+            // lifecycle. Including it again would re-run its side effects
+            // (define() warnings, $wpdb re-init) for no reason.
+            if (basename($mf) === 'db.php') {
+                continue;
+            }
             if (strpos(file_get_contents($mf), 'Plugin Name:') !== false) {
                 pg_log("PLUGIN_DETECTED " . basename($mf));
                 require_once $mf;

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -147,9 +147,35 @@ if [ -n "$DEPENDENCY_PATHS" ]; then
     done <<< "$DEPENDENCY_PATHS"
 fi
 
+# ---------------------------------------------------------------------------
+# db.php drop-in coexistence with Playground's built-in SQLite
+#
+# Playground ships an internal mu-plugin at
+# /internal/shared/mu-plugins/sqlite-database-integration.php that normally
+# wires up WordPress to its bundled SQLite implementation. That mu-plugin
+# begins with a self-deactivation guard:
+#
+#     if ( file_exists( '/wordpress/wp-content/db.php' ) ) {
+#         return;
+#     }
+#
+# So when we mount a plugin's db.php drop-in at /wordpress/wp-content/db.php,
+# the mu-plugin voluntarily steps aside and the drop-in owns $wpdb. No
+# --skip-sqlite-setup flag is required. The drop-in can still *reuse*
+# Playground's bundled SQLite classes (available at
+# /internal/shared/sqlite-database-integration/) — that's what
+# markdown-database-integration's db.php does.
+#
+# See docs/PLAYGROUND_DROPIN.md for the full coexistence model and a minimal
+# example drop-in that verifies the plumbing end-to-end.
+# ---------------------------------------------------------------------------
 PLUGIN_DB_PHP="${PLUGIN_PATH}/db.php"
 if [ -f "$PLUGIN_DB_PHP" ]; then
     MOUNT_ARGS+=("--mount" "${PLUGIN_DB_PHP}:/wordpress/wp-content/db.php")
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: [playground] Plugin db.php drop-in detected at $PLUGIN_DB_PHP"
+        echo "DEBUG: [playground] Playground's built-in SQLite mu-plugin will step aside"
+    fi
 fi
 
 MOUNT_ARGS+=("--mount" "${EXTENSION_PATH}:/homeboy-extension")

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -231,67 +231,128 @@ if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] && [ -f "$PARSE_FAILURES" ]; then
     fi
 fi
 
-if [ $playground_exit -ne 0 ]; then
-    if echo "$PHPUNIT_OUTPUT" | grep -q "SOME TESTS FAILED"; then
-        FAILED_STEP="PHPUnit tests (playground backend)"
-        FAILURE_REPLAY_MODE="none"
-        rm -f "$RESULT_FILE"
-        exit $playground_exit
-    elif echo "$PHPUNIT_STDOUT" | grep -qE 'FAILURES|ERRORS'; then
-        FAILED_STEP="PHPUnit tests (playground backend)"
-        FAILURE_REPLAY_MODE="none"
-        rm -f "$RESULT_FILE"
-        exit $playground_exit
-    elif echo "$PHPUNIT_OUTPUT" | grep -q "FATAL:"; then
-        FAILED_STEP="Playground bootstrap"
-        FAILURE_OUTPUT=$(echo "$PHPUNIT_OUTPUT" | grep "FATAL:")
-        rm -f "$RESULT_FILE"
-        exit $playground_exit
-    else
+# ----------------------------------------------------------------------------
+# Failure classification
+#
+# The playground-runner.php template writes a structured log to $RESULT_FILE
+# with these patterns (see playground-runner.php docblock for full contract):
+#
+#   STAGE_BEGIN:<stage>       - entered a bootstrap phase
+#   STAGE_OK:<stage>          - phase completed
+#   STAGE_FAIL:<stage>:<msg>  - caught Throwable during phase
+#   STAGE_FATAL:<stage>:<msg> - uncatchable fatal (shutdown handler)
+#   SOME TESTS FAILED         - PHPUnit ran, some assertions failed
+#   ALL TESTS PASSED          - PHPUnit ran, all assertions passed
+#
+# Classification order (first match wins):
+#   1. STAGE_FATAL/STAGE_FAIL in result file  -> bootstrap failure, show stage+msg
+#   2. SOME TESTS FAILED in result file       -> PHPUnit assertion failures
+#   3. Parse/fatal patterns in stdout         -> PHP crashed before writing log
+#   4. playground_exit != 0 with no log       -> unknown crash, dump raw output
+#   5. NO_TEST_FILES in result file           -> discovery found nothing
+#   6. Zero-test PHPUnit run                  -> suite empty
+# ----------------------------------------------------------------------------
+
+dump_diagnostics() {
+    local label="$1"
+    echo ""
+    echo "============================================"
+    echo "$label"
+    echo "============================================"
+    if [ -n "$PHPUNIT_OUTPUT" ]; then
         echo ""
-        echo "============================================"
-        echo "NOTE: Playground exited with code $playground_exit"
-        echo "============================================"
-        if [ -n "$PHPUNIT_OUTPUT" ]; then
-            echo "Last log: $(echo "$PHPUNIT_OUTPUT" | tail -1)"
-        else
-            echo "No result file produced. Playground may have crashed during boot."
-        fi
+        echo "--- Structured log ($RESULT_FILE) ---"
+        echo "$PHPUNIT_OUTPUT"
     fi
+    if [ -n "$PHPUNIT_STDOUT" ]; then
+        echo ""
+        echo "--- Playground stdout/stderr ---"
+        echo "$PHPUNIT_STDOUT"
+    fi
+}
+
+# Case 1: bootstrap failure captured in the structured log (STAGE_FAIL/STAGE_FATAL).
+if echo "$PHPUNIT_OUTPUT" | grep -qE '^STAGE_(FAIL|FATAL):'; then
+    FAILED_STAGE_LINE=$(echo "$PHPUNIT_OUTPUT" | grep -E '^STAGE_(FAIL|FATAL):' | head -1)
+    # Extract "<stage>:<msg>" (strip "STAGE_FAIL:" or "STAGE_FATAL:" prefix)
+    FAILED_STAGE_DETAIL=$(echo "$FAILED_STAGE_LINE" | sed -E 's/^STAGE_(FAIL|FATAL)://')
+    FAILED_STEP="Playground bootstrap (${FAILED_STAGE_DETAIL%%:*} stage)"
+    FAILURE_OUTPUT="$FAILED_STAGE_LINE"
+    dump_diagnostics "BOOTSTRAP FAILURE: $FAILED_STAGE_DETAIL"
+    rm -f "$RESULT_FILE"
+    exit ${playground_exit:-1}
 fi
 
+# Case 2: PHPUnit ran, some tests failed.
+if echo "$PHPUNIT_OUTPUT" | grep -q "SOME TESTS FAILED"; then
+    FAILED_STEP="PHPUnit tests (playground backend)"
+    FAILURE_REPLAY_MODE="none"
+    rm -f "$RESULT_FILE"
+    exit ${playground_exit:-1}
+fi
+
+# Case 3: PHPUnit emitted FAILURES/ERRORS on stdout (belt-and-suspenders for
+# the rare path where the result file was written but SOME TESTS FAILED line
+# was somehow dropped).
+if [ $playground_exit -ne 0 ] && echo "$PHPUNIT_STDOUT" | grep -qE '^(FAILURES|ERRORS)!'; then
+    FAILED_STEP="PHPUnit tests (playground backend)"
+    FAILURE_REPLAY_MODE="none"
+    rm -f "$RESULT_FILE"
+    exit $playground_exit
+fi
+
+# Case 4: PHP crashed before our template could write to the result file.
+# Parse/fatal errors from Playground go to stderr (captured in $PHPUNIT_STDOUT
+# via the tee'd pipe) — surface them clearly instead of failing silently.
+if [ $playground_exit -ne 0 ] && echo "$PHPUNIT_STDOUT" | grep -qE '^(PHP Parse error|Parse error:|PHP Fatal error|Fatal error:)'; then
+    FAILED_STEP="Playground PHP crash (before runner took control)"
+    FAILURE_OUTPUT=$(echo "$PHPUNIT_STDOUT" | grep -E '^(PHP Parse error|Parse error:|PHP Fatal error|Fatal error:)' | head -5)
+    dump_diagnostics "PHP CRASH"
+    rm -f "$RESULT_FILE"
+    exit $playground_exit
+fi
+
+# Case 5: playground exited non-zero and we still can't classify it.
+# Don't exit 0 here — that's the bug the old code had.
+if [ $playground_exit -ne 0 ]; then
+    FAILED_STEP="Playground exited with code $playground_exit (unclassified)"
+    dump_diagnostics "UNCLASSIFIED PLAYGROUND FAILURE (exit=$playground_exit)"
+    rm -f "$RESULT_FILE"
+    exit $playground_exit
+fi
+
+# Case 6: no output at all (not even a result file). Shouldn't happen on a
+# clean exit, but guard anyway.
 if [ -z "$PHPUNIT_OUTPUT" ] && [ -z "$PHPUNIT_STDOUT" ]; then
-    echo ""
-    echo "============================================"
-    echo "WARNING: No test output captured (playground)"
-    echo "============================================"
-    echo ""
+    dump_diagnostics "NO OUTPUT CAPTURED"
     FAILED_STEP="PHPUnit tests (no output, playground)"
     rm -f "$RESULT_FILE"
     exit 1
 fi
 
-if echo "$PHPUNIT_OUTPUT" | grep -q "NO_TEST_FILES"; then
-    echo ""
-    echo "============================================"
-    echo "WARNING: No test files discovered"
-    echo "============================================"
-    echo ""
+# Case 7: discovery found zero test files.
+if echo "$PHPUNIT_OUTPUT" | grep -q "^NO_TEST_FILES"; then
+    dump_diagnostics "NO TEST FILES DISCOVERED"
     FAILED_STEP="PHPUnit tests (no test files, playground)"
     rm -f "$RESULT_FILE"
     exit 1
 fi
 
-# Detect zero-test runs from PHPUnit stdout
+# Case 8: PHPUnit ran but executed zero tests (class didn't extend TestCase,
+# all tests excluded, etc.).
 if echo "$PHPUNIT_STDOUT" | grep -qE 'No tests executed|OK \(0 tests'; then
-    echo ""
-    echo "============================================"
-    echo "WARNING: PHPUnit ran 0 tests (playground)"
-    echo "============================================"
-    echo ""
+    dump_diagnostics "ZERO TESTS EXECUTED"
     FAILED_STEP="PHPUnit tests (zero tests executed, playground)"
     rm -f "$RESULT_FILE"
     exit 1
+fi
+
+# Surface any non-fatal NOTICEs captured during bootstrap even on success —
+# warnings inside WP setup have historically masked real problems.
+if echo "$PHPUNIT_OUTPUT" | grep -q "^NOTICE:"; then
+    echo ""
+    echo "--- Bootstrap notices (non-fatal) ---"
+    echo "$PHPUNIT_OUTPUT" | grep "^NOTICE:"
 fi
 
 rm -f "$RESULT_FILE"

--- a/wordpress/tests/fixtures/dropin-coexistence/db.php
+++ b/wordpress/tests/fixtures/dropin-coexistence/db.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Plugin Name: Drop-in Coexistence Fixture (db.php)
+ *
+ * Reference db.php drop-in for the Playground backend's coexistence smoke test.
+ *
+ * How coexistence works in Playground:
+ *
+ *   1. Playground ships an internal mu-plugin at
+ *      /internal/shared/mu-plugins/sqlite-database-integration.php that
+ *      normally wires up $wpdb to its bundled SQLite implementation.
+ *
+ *   2. That mu-plugin begins with a self-deactivation guard:
+ *          if ( file_exists( '/wordpress/wp-content/db.php' ) ) { return; }
+ *
+ *   3. When we mount a plugin's db.php at /wordpress/wp-content/db.php (the
+ *      Playground backend runner does this automatically when it sees a
+ *      db.php in the plugin root), the guard fires and the mu-plugin steps
+ *      aside. The drop-in then owns $wpdb for the whole request lifecycle.
+ *
+ *   4. The drop-in is still free to reuse Playground's bundled SQLite
+ *      implementation — it lives at /internal/shared/sqlite-database-integration
+ *      and is readable at runtime. That's the pattern
+ *      markdown-database-integration uses in production.
+ *
+ * This fixture delegates to Playground's bundled SQLite so the rest of the
+ * WordPress test suite (wp_insert_post, wp_get_user, etc.) continues to
+ * work end-to-end. A real drop-in (MDI) would substitute its own $wpdb
+ * subclass at the end.
+ *
+ * @package Homeboy\WordPress\Tests\Fixtures
+ */
+
+// Signal that this drop-in ran. The accompanying test class asserts this.
+if ( ! defined( 'HOMEBOY_DROPIN_FIXTURE_LOADED' ) ) {
+    define( 'HOMEBOY_DROPIN_FIXTURE_LOADED', true );
+}
+
+$sqlite = '/internal/shared/sqlite-database-integration';
+if ( ! file_exists( $sqlite . '/wp-includes/sqlite/db.php' ) ) {
+    // Playground's bundled SQLite is not available. Leave $wpdb alone so
+    // WordPress can fall back to its default (MySQL attempt will fail loudly
+    // rather than silently). This is the failure mode we want to surface.
+    return;
+}
+
+if ( ! defined( 'DATABASE_TYPE' ) ) {
+    define( 'DATABASE_TYPE', 'sqlite' );
+}
+if ( ! defined( 'DB_ENGINE' ) ) {
+    define( 'DB_ENGINE', 'sqlite' );
+}
+
+// Delegate to Playground's drop-in. It sets up $wpdb = new WP_SQLite_DB(...).
+require_once $sqlite . '/wp-includes/sqlite/db.php';

--- a/wordpress/tests/fixtures/dropin-coexistence/plugin.php
+++ b/wordpress/tests/fixtures/dropin-coexistence/plugin.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Plugin Name: Drop-in Coexistence Fixture
+ * Description: Fixture plugin for the Playground backend's db.php drop-in coexistence smoke test. Not for production use.
+ * Version: 1.0.0
+ *
+ * @package Homeboy\WordPress\Tests\Fixtures
+ */
+
+// The fixture is deliberately inert at the plugin-entry layer. All the
+// coexistence logic lives in the sibling db.php file. The test class in
+// tests/ asserts that the drop-in ran and $wpdb still functions end-to-end.

--- a/wordpress/tests/fixtures/dropin-coexistence/tests/DropInCoexistenceTest.php
+++ b/wordpress/tests/fixtures/dropin-coexistence/tests/DropInCoexistenceTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Integration test: custom db.php drop-in coexists with Playground's built-in
+ * SQLite integration.
+ *
+ * Runs via: wordpress/scripts/test/playground-dropin-smoke.sh
+ *
+ * @package Homeboy\WordPress\Tests\Fixtures
+ */
+
+class DropInCoexistenceTest extends WP_UnitTestCase {
+
+    /**
+     * The fixture's db.php defines HOMEBOY_DROPIN_FIXTURE_LOADED. If this
+     * constant is missing, WordPress never actually loaded the drop-in —
+     * either the file isn't at /wp-content/db.php or Playground's internal
+     * SQLite mu-plugin stopped stepping aside.
+     */
+    public function test_dropin_was_loaded() {
+        $this->assertTrue(
+            defined( 'HOMEBOY_DROPIN_FIXTURE_LOADED' ) && HOMEBOY_DROPIN_FIXTURE_LOADED,
+            'Plugin-provided db.php drop-in did not execute during bootstrap. '
+            . 'Check: (1) db.php mounted at /wordpress/wp-content/db.php, '
+            . '(2) Playground mu-plugin guard still intact upstream.'
+        );
+    }
+
+    /**
+     * Proves $wpdb still serves real WordPress writes after the drop-in
+     * installed itself. If this regresses, the drop-in hooked itself in
+     * before wp-settings completed DB setup (which happens for several
+     * misconfigurations of the MDI-style 'reuse internal SQLite' pattern).
+     */
+    public function test_wpdb_can_insert_and_read() {
+        $post_id = wp_insert_post( array(
+            'post_title'   => 'Drop-in smoke',
+            'post_status'  => 'publish',
+            'post_content' => 'Lorem ipsum',
+        ) );
+
+        $this->assertIsInt( $post_id );
+        $this->assertGreaterThan( 0, $post_id );
+
+        $post = get_post( $post_id );
+        $this->assertNotNull( $post );
+        $this->assertSame( 'Drop-in smoke', $post->post_title );
+        $this->assertSame( 'publish', $post->post_status );
+    }
+
+    /**
+     * Proves that Playground's internal SQLite mu-plugin voluntarily stepped
+     * aside. We verify this indirectly: WP_SQLite_DB is available (so the
+     * bundled implementation IS on the VFS) but DATABASE_TYPE was set by our
+     * drop-in, not by the mu-plugin's early-exit path.
+     *
+     * The mu-plugin defines SQLITE_DB_DROPIN_VERSION on its own path. Our
+     * drop-in does NOT. So seeing that constant undefined (or defined by the
+     * fixture itself if someone extends it) is the signal that the
+     * mu-plugin's body never executed.
+     */
+    public function test_playground_mu_plugin_stepped_aside() {
+        // WP_SQLite_DB exists because we loaded it ourselves from the VFS
+        // in db.php. That's expected.
+        $this->assertTrue( class_exists( 'WP_SQLite_DB' ), 'Bundled SQLite implementation should be reachable from the VFS.' );
+
+        // SQLITE_DB_DROPIN_VERSION is defined at the TOP of the Playground
+        // mu-plugin's body. If the mu-plugin's guard fired, the body never
+        // ran, so the constant stays undefined.
+        $this->assertFalse(
+            defined( 'SQLITE_DB_DROPIN_VERSION' ),
+            'SQLITE_DB_DROPIN_VERSION is defined, which means Playground\'s '
+            . 'SQLite mu-plugin DID execute. The wp-content/db.php guard is '
+            . 'not firing — the drop-in would have been silently overwritten.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Third and final Phase 2 PR on top of #216 (diagnostics) and #217 (phpunit.xml.dist-aware discovery). Verifies that a plugin's `db.php` drop-in (the MDI pattern) coexists with Playground's built-in SQLite integration, and ships the fixture + smoke test that will catch regressions.

## Base branch

This PR targets `phase-2-pr2-xml-discovery` (the branch for #217), not `main`. Merge order: #216 → #217 → this.

## The discovery

Playground's internal SQLite mu-plugin at `/internal/shared/mu-plugins/sqlite-database-integration.php` starts with a self-deactivation guard:

```php
// Do not preload this if WordPress comes with a custom db.php file.
if ( file_exists( '/wordpress/wp-content/db.php' ) ) {
    return;
}
```

So when `test-runner-playground.sh` mounts a plugin's `db.php` at `/wordpress/wp-content/db.php` — which it already did in Phase 1 — the mu-plugin steps aside and the drop-in owns `$wpdb`. **No `--skip-sqlite-setup`, no `--mount-before-install` tricks. The coexistence is native.**

I spent an hour trying to force it with `--skip-sqlite-setup` before finding the guard. That dead-end is not in the final commit — only the mechanism that actually works.

## What ships

### Reference fixture — `wordpress/tests/fixtures/dropin-coexistence/`

- `plugin.php` — inert plugin entry
- `db.php` — reference drop-in that delegates to Playground's bundled SQLite at `/internal/shared/sqlite-database-integration/` (the MDI production pattern in miniature). Defines `HOMEBOY_DROPIN_FIXTURE_LOADED` so tests can prove it ran.
- `tests/DropInCoexistenceTest.php` — three assertions, one per invariant the mechanism depends on.

### Smoke test — `wordpress/scripts/test/playground-dropin-smoke.sh`

Runs the fixture via the Playground backend end-to-end. Exit code is the verdict.

```bash
bash wordpress/scripts/test/playground-dropin-smoke.sh
# OK (3 tests, 8 assertions)
# ✓ Drop-in coexistence smoke test PASSED
```

Intended for manual runs after:
- Changes to the Playground backend (dispatcher or template).
- `@wp-playground/cli` upgrades (which could silently remove the upstream mu-plugin guard).

### Documentation — `wordpress/docs/PLAYGROUND_DROPIN.md`

Full mechanism, usage, limitations, upstream contract. Cross-links to #215/#216/#217.

### Template fix — skip `db.php` in plugin-entry detection

`playground-runner.php`'s plugin-entry loop globs `*.php` files and `require_once`s whichever has a `Plugin Name:` header. `db.php` has that header but it's a drop-in, already loaded by WP core. Skip it explicitly so it doesn't get double-included (which produces a confusing `define()` redeclare warning).

### Inline documentation — `test-runner-playground.sh`

Adds a ~20-line block comment explaining the coexistence model right where the `db.php` mount happens. Future maintainers don't have to go spelunking through `/internal/shared/mu-plugins/` to understand why the current code works.

## The three assertions

Each catches a concrete regression path:

| Assertion | What it proves | What it catches |
|-----------|----------------|-----------------|
| `test_dropin_was_loaded` | `HOMEBOY_DROPIN_FIXTURE_LOADED` is defined | Bash runner regression — mount didn't land |
| `test_wpdb_can_insert_and_read` | `wp_insert_post` + `get_post` round-trip | Drop-in is wired in but not serving (broken delegate, `$wpdb` half-initialized, etc.) |
| `test_playground_mu_plugin_stepped_aside` | `SQLITE_DB_DROPIN_VERSION` is UNDEFINED after `wp-settings.php` | Upstream Playground removed/changed the guard — coexistence model broke |

The third one is the canary. Playground's mu-plugin defines `SQLITE_DB_DROPIN_VERSION` at the top of its body. If the guard fires, the body never runs, constant stays undefined. If the constant IS defined, the drop-in was silently overwritten and all tests downstream of `$wpdb` are lying about reality.

## Verification matrix

| Scenario | Result |
|----------|--------|
| Healthy plugin (no drop-in) | Default SQLite path, unchanged |
| Nested discovery (PR #217 regression check) | 3/3 tests found + passed |
| Parse-error plugin (PR #216 regression check) | exit 1 with `STAGE_FAIL:load_component` |
| Drop-in fixture (new) | 3/3 tests passed, 8 assertions |

## Files

| File | Change |
|------|--------|
| `wordpress/scripts/test/test-runner-playground.sh` | +27 — inline block comment + debug log line |
| `wordpress/scripts/test/playground-runner.php` | +7 — skip `db.php` in plugin-entry loop |
| `wordpress/scripts/test/playground-dropin-smoke.sh` | **new** — 62 lines |
| `wordpress/tests/fixtures/dropin-coexistence/` | **new** — fixture tree |
| `wordpress/docs/PLAYGROUND_DROPIN.md` | **new** — 177 lines |
| `wordpress/TEST_INFRASTRUCTURE_PLAN.md` | Phase 2 status table + known-gaps list |

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code
- **Used for:** Agent drove the whole investigation end-to-end — reproduced the naive failure mode, discovered upstream Playground's mu-plugin guard by grepping the VFS at runtime (the answer wasn't in any docs, only in the mu-plugin source), ruled out a `--skip-sqlite-setup` blind alley before it reached the commit, designed the three-assertion fixture to catch each concrete regression path, wrote the doc, and verified the full regression matrix against live `wp-playground-cli`. Chris approved the three-PR Phase 2 sequence and the PR 2/3 scope reframes.