### PR TITLE
wordpress: playground test discovery — recursive + phpunit.xml.dist-aware (Phase 2 of #214)

### DIFF
--- a/wordpress/TEST_INFRASTRUCTURE_PLAN.md
+++ b/wordpress/TEST_INFRASTRUCTURE_PLAN.md
@@ -468,7 +468,7 @@ SQLite) instead of host PHP. Does not replace the host backend.
 | In-process WP install (replace `system()` call) | — | ✅ Complete |
 | PHPUnit stdout forwarding | — | ✅ Complete |
 | Structured stage logging + diagnostics | scripts/test/playground-runner.php, test-runner-playground.sh | ✅ Complete (Phase 2) |
-| Parse extension phpunit.xml.dist in runner | — | 🔲 Pending |
+| Parse extension phpunit.xml.dist + recursive discovery | scripts/test/playground-runner.php | ✅ Complete (Phase 2) |
 | db.php drop-in support (MDI test) | — | 🔲 Pending |
 
 **Diagnostics contract (Phase 2):**
@@ -525,12 +525,18 @@ with the playground's own exit code.
    integration) can be mounted into the Playground VFS, but Playground's built-in
    SQLite integration may conflict. Needs per-case testing.
 
-3. **No host bootstrap, no phpunit.xml.dist parsing.** The Playground backend
-   does not use `tests/bootstrap.php` or the extension's `phpunit.xml.dist`.
-   It runs `install.php` in-process and discovers test files via hand-rolled
-   glob (`test-*.php`, `*Test.php`). Any customizations in the host bootstrap
-   or phpunit config (e.g., additional `tests_add_filter` calls, custom
-   suites, coverage rules) won't apply. Tracked as a follow-up task above.
+3. **No host bootstrap.** The Playground backend does not use `tests/bootstrap.php`.
+   It runs `install.php` in-process and loads test case classes directly. Any
+   customizations in the host bootstrap (e.g., additional `tests_add_filter`
+   calls) won't apply.
+
+4. **Partial phpunit.xml.dist consumption.** The runner reads the extension's
+   `phpunit.xml.dist` for `<testsuite><directory>` entries (with optional
+   `suffix` / `prefix` attributes) and `<testsuite><exclude>` entries. Other
+   elements (coverage config, bootstrap attribute, `<php>` env vars, groups,
+   listeners, extensions) are intentionally not honored — they either refer
+   to host-filesystem paths that have no meaning in the VFS, or they describe
+   behavior our template already provides.
 
 **References:**
 - Issue: Extra-Chill/homeboy-extensions#214

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -259,14 +259,45 @@ try {
 
 // ---------------------------------------------------------------------------
 // Stage: discover_tests
+//
+// Recursively scans $plugin_path/tests for files matching the configured
+// suffix/prefix patterns. This mirrors PHPUnit's own behavior when given a
+// <directory> element in phpunit.xml.dist — it recurses and applies the
+// suffix/prefix filters from the element's attributes.
+//
+// Configuration source priority:
+//   1. Extension's /homeboy-extension/phpunit.xml.dist, if readable and parseable
+//   2. Hardcoded defaults: suffix=Test.php, prefix=test- (covers both PHPUnit
+//      native + WordPress conventions so projects don't have to choose)
+//
+// This is deliberately narrower than parsing the full PHPUnit XML schema.
+// The extension's XML is simple and static; we only consume the pieces that
+// affect test discovery (directories, suffixes, prefixes, excludes). Bootstrap,
+// coverage, env vars etc. don't translate from host filesystem to VFS anyway.
 // ---------------------------------------------------------------------------
 pg_stage_begin('discover_tests');
 try {
     $test_dir = "$plugin_path/tests";
-    $test_files = array_merge(
-        glob("$test_dir/test-*.php") ?: [],
-        glob("$test_dir/*Test.php") ?: []
+    if (!is_dir($test_dir)) {
+        pg_log("NO_TEST_FILES");
+        pg_log("NOTICE:tests directory not found at $test_dir");
+        pg_stage_ok('discover_tests');
+        exit(1);
+    }
+
+    [$directories, $suffixes, $prefixes, $excludes] = pg_parse_phpunit_config(
+        '/homeboy-extension/phpunit.xml.dist',
+        $test_dir
     );
+
+    $test_files = pg_discover_tests($directories, $suffixes, $prefixes, $excludes);
+
+    pg_log("DISCOVERY: dirs=" . implode(',', $directories)
+        . " suffixes=" . implode(',', $suffixes)
+        . " prefixes=" . implode(',', $prefixes)
+        . " excludes=" . count($excludes)
+        . " found=" . count($test_files));
+
     if (empty($test_files)) {
         pg_log("NO_TEST_FILES");
         pg_stage_ok('discover_tests');
@@ -276,6 +307,169 @@ try {
 } catch (Throwable $e) {
     pg_stage_fail('discover_tests', $e);
     exit(1);
+}
+
+/**
+ * Parse the extension's phpunit.xml.dist for test-discovery directives.
+ *
+ * Returns [directories, suffixes, prefixes, excludes]. Absolute paths only:
+ * any relative `<directory>` entry in the XML is resolved against
+ * $plugin_path/tests (the component under test, NOT the extension's own
+ * vendor dir — the XML's path semantics are "relative to the plugin being
+ * tested").
+ *
+ * Falls back to sensible defaults if the XML is missing or unparseable.
+ * Logs the reason to NOTICE so users can see which path was taken.
+ *
+ * @return array{0: string[], 1: string[], 2: string[], 3: string[]}
+ */
+function pg_parse_phpunit_config($xml_path, $test_dir_default) {
+    $directories = [$test_dir_default];
+    $suffixes = ['Test.php'];
+    $prefixes = ['test-'];
+    $excludes = [];
+
+    if (!is_readable($xml_path)) {
+        pg_log("NOTICE:phpunit.xml.dist not readable at $xml_path; using defaults");
+        return [$directories, $suffixes, $prefixes, $excludes];
+    }
+
+    // libxml_use_internal_errors + simplexml so a malformed XML doesn't
+    // explode inside the runner — fall back to defaults and keep going.
+    $prev_internal_errors = libxml_use_internal_errors(true);
+    $xml = @simplexml_load_file($xml_path);
+    $load_errors = libxml_get_errors();
+    libxml_clear_errors();
+    libxml_use_internal_errors($prev_internal_errors);
+
+    if ($xml === false) {
+        $first_err = $load_errors ? trim($load_errors[0]->message) : 'unknown';
+        pg_log("NOTICE:phpunit.xml.dist parse failed ($first_err); using defaults");
+        return [$directories, $suffixes, $prefixes, $excludes];
+    }
+
+    $config_dirs = [];
+    $config_suffixes = [];
+    $config_prefixes = [];
+    $plugin_base = dirname($test_dir_default); // plugin root
+
+    // <testsuites><testsuite><directory suffix="..." prefix="...">path</directory>
+    foreach ($xml->xpath('//testsuite/directory') ?: [] as $dir) {
+        $raw_path = trim((string) $dir);
+        if ($raw_path === '') {
+            continue;
+        }
+        // Resolve relative to the plugin root (PHPUnit's own convention is
+        // "relative to the config file", but we're using the extension's
+        // config against a different plugin, so "plugin root" is the
+        // semantically correct base here).
+        $abs = $raw_path[0] === '/' ? $raw_path : "$plugin_base/$raw_path";
+        $config_dirs[] = rtrim($abs, '/');
+
+        // Optional suffix/prefix attributes (comma-separated per PHPUnit docs,
+        // though the native schema only supports single values — we accept
+        // both for ergonomics).
+        if (isset($dir['suffix'])) {
+            foreach (explode(',', (string) $dir['suffix']) as $s) {
+                $s = trim($s);
+                if ($s !== '') {
+                    $config_suffixes[] = $s;
+                }
+            }
+        }
+        if (isset($dir['prefix'])) {
+            foreach (explode(',', (string) $dir['prefix']) as $p) {
+                $p = trim($p);
+                if ($p !== '') {
+                    $config_prefixes[] = $p;
+                }
+            }
+        }
+    }
+
+    // <testsuites><testsuite><exclude>path</exclude>
+    foreach ($xml->xpath('//testsuite/exclude') ?: [] as $ex) {
+        $raw = trim((string) $ex);
+        if ($raw === '') {
+            continue;
+        }
+        $abs = $raw[0] === '/' ? $raw : "$plugin_base/$raw";
+        $excludes[] = rtrim($abs, '/');
+    }
+
+    if (!empty($config_dirs)) {
+        $directories = $config_dirs;
+        pg_log("NOTICE:phpunit.xml.dist loaded from $xml_path");
+    }
+    if (!empty($config_suffixes)) {
+        $suffixes = $config_suffixes;
+    }
+    if (!empty($config_prefixes)) {
+        $prefixes = $config_prefixes;
+    }
+
+    return [$directories, $suffixes, $prefixes, $excludes];
+}
+
+/**
+ * Recursively find test files under the given directories.
+ *
+ * A file matches if its basename ends with any of the $suffixes OR starts
+ * with any of the $prefixes. Files under any path in $excludes are skipped.
+ *
+ * Uses SplFileInfo + RecursiveIteratorIterator so nested structures like
+ * tests/Unit/FooTest.php and tests/Integration/BarTest.php are picked up,
+ * which was the Phase 1 gap this discovery rewrite fixes.
+ */
+function pg_discover_tests(array $directories, array $suffixes, array $prefixes, array $excludes) {
+    $found = [];
+    foreach ($directories as $dir) {
+        if (!is_dir($dir)) {
+            pg_log("NOTICE:test directory does not exist: $dir");
+            continue;
+        }
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::LEAVES_ONLY
+        );
+        foreach ($iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+            $path = $file->getPathname();
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+            // Exclude paths: any directory prefix match disqualifies.
+            foreach ($excludes as $ex) {
+                if (strpos($path, $ex) === 0) {
+                    continue 2;
+                }
+            }
+            $base = $file->getBasename();
+            $matches = false;
+            foreach ($suffixes as $s) {
+                if ($s !== '' && substr($base, -strlen($s)) === $s) {
+                    $matches = true;
+                    break;
+                }
+            }
+            if (!$matches) {
+                foreach ($prefixes as $p) {
+                    if ($p !== '' && strpos($base, $p) === 0) {
+                        $matches = true;
+                        break;
+                    }
+                }
+            }
+            if ($matches) {
+                $found[] = $path;
+            }
+        }
+    }
+    // Stable ordering so re-runs show the same failure order.
+    sort($found);
+    return array_values(array_unique($found));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces Phase 1's flat `glob("$tests/test-*.php")` with a recursive directory walk so nested `tests/Unit/FooTest.php` / `tests/Integration/BarTest.php` layouts actually get discovered.
- Reads the extension's own `phpunit.xml.dist` for `<testsuite><directory>` (with optional `suffix` / `prefix` attributes) and `<testsuite><exclude>` entries, with graceful fallback when the file is missing or malformed.
- Second of three PRs in the Phase 2 series. Builds on the diagnostics helpers that landed in #216. PR #218 (db.php drop-in coexistence) will stack on top of this next.

## Note on PR chain

Originally opened as PR #217 stacked on `phase-2-playground-improvements`. GitHub auto-closed it when that base branch was deleted after #216 merged. This is the re-opened version, rebased onto `main`, identical content.

## The bug it fixes

Phase 1 discovery was a flat glob — one directory level only. A plugin with this layout (typical of anything using PHPUnit suites):

```
tests/
├── test-top.php              ← ran
├── Unit/
│   └── WidgetTest.php       ← silently skipped
└── Integration/
    └── ApiTest.php          ← silently skipped
```

…would pass CI with `OK (1 test)`. Not `FAILURES!` — `OK`. The false-green surface area here is everything that runs outside a single directory. That's most real plugins.

## How it works

### `pg_discover_tests()` (template helper)

Walks each configured root with `RecursiveIteratorIterator` + `RecursiveDirectoryIterator`. Matches files whose basename **ends with** any configured suffix (default `Test.php`) OR **starts with** any configured prefix (default `test-`). Skips anything under a configured exclude path. Returns a stable-sorted unique list so re-runs produce the same failure order.

### `pg_parse_phpunit_config()` (template helper)

Reads `/homeboy-extension/phpunit.xml.dist` from the VFS — the extension mounts itself at `/homeboy-extension` already — and extracts the pieces that actually affect test discovery:

| XML element | Consumed? | Why |
|---|---|---|
| `<testsuite><directory>path</directory>` | ✅ | Scan root, relative to plugin root. |
| `<directory suffix="...">` / `prefix="..."` | ✅ | Overrides discovery defaults. Comma-separated accepted. |
| `<testsuite><exclude>path</exclude>` | ✅ | Skip path during recursion. |
| `bootstrap="tests/bootstrap.php"` attribute | ❌ | Our template IS the bootstrap. |
| `<php><env>` entries | ❌ | Point at host-filesystem paths with no VFS meaning. |
| `<coverage>` / groups / listeners / extensions | ❌ | Not wired through. |

If the file is missing, unreadable, or malformed, falls back to defaults with a clear `NOTICE:` line explaining why. The `TEST_INFRASTRUCTURE_PLAN.md` now lists consumed vs. ignored elements explicitly.

## Verification matrix

| Scenario | Before | After |
|----------|--------|-------|
| Flat `tests/` (original fixture, 2 files) | 2/2 OK | 2/2 OK (back-compat) |
| Nested `tests/Unit/` + `tests/Integration/` (3 files) | **1/3 false green** | 3/3 OK |
| Missing `phpunit.xml.dist` | 1/3 false green | 3/3 OK + `NOTICE:not readable; using defaults` |
| Malformed `phpunit.xml.dist` | 1/3 false green | 3/3 OK + `NOTICE:parse failed (...); using defaults` |
| `<exclude>tests/fixtures</exclude>` | n/a (fixtures ran + threw) | 1/1 (fixtures correctly skipped) |
| Deliberate failing assertion | exit 1 | exit 1 (unchanged) |
| Plugin with parse error (#216 regression check) | exit 1 + stage trace | exit 1 + stage trace (unchanged) |

## Interesting thing discovered during research

The **host backend** passes `--no-configuration` to PHPUnit and a raw directory argument, which means it ALSO doesn't consume `phpunit.xml.dist` at runtime. The XML is really just an artifact of the Phase 1 architecture. This PR makes the Playground backend at least partially config-aware while the host stays hardcoded. The bigger cleanup (actually route the host backend through the same config parser) is out of scope here — noted in `TEST_INFRASTRUCTURE_PLAN.md` as a known asymmetry.

## Files

| File | Change |
|------|--------|
| `wordpress/scripts/test/playground-runner.php` | +200/-10 — `pg_discover_tests()`, `pg_parse_phpunit_config()`, replaced flat glob |
| `wordpress/TEST_INFRASTRUCTURE_PLAN.md` | Phase 5 table + gap list updated |

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code
- **Used for:** Agent reproduced the nested-discovery false-green against a custom fixture, empirically verified the host backend also ignores `phpunit.xml.dist` at runtime (which reframed the PR scope away from "match host behavior" toward "consume extension XML + recursive discovery"), implemented the recursive walker + XML parser, and verified all seven scenarios against live Playground runs. Chris directed the three-PR sequencing and approved the scope reframe.