### PR TITLE
wordpress: playground db.php drop-in coexistence — fixture + smoke test (Phase 2 of #214)

### DIFF
--- a/wordpress/TEST_INFRASTRUCTURE_PLAN.md
+++ b/wordpress/TEST_INFRASTRUCTURE_PLAN.md
@@ -469,7 +469,7 @@ SQLite) instead of host PHP. Does not replace the host backend.
 | PHPUnit stdout forwarding | — | ✅ Complete |
 | Structured stage logging + diagnostics | scripts/test/playground-runner.php, test-runner-playground.sh | ✅ Complete (Phase 2) |
 | Parse extension phpunit.xml.dist + recursive discovery | scripts/test/playground-runner.php | ✅ Complete (Phase 2) |
-| db.php drop-in support (MDI test) | — | 🔲 Pending |
+| db.php drop-in coexistence + smoke test | scripts/test/test-runner-playground.sh, tests/fixtures/dropin-coexistence/, scripts/test/playground-dropin-smoke.sh, docs/PLAYGROUND_DROPIN.md | ✅ Complete (Phase 2) |
 
 **Diagnostics contract (Phase 2):**
 
@@ -515,28 +515,32 @@ with the playground's own exit code.
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-**Known Gaps (remaining after Phase 2 diagnostics):**
+**Known Gaps (remaining after Phase 2):**
 
 1. **WP version pinning.** The `--wp` flag must match the wp-phpunit package
    version (currently 6.9.x). Mismatch causes missing class errors in the
    wp-phpunit bootstrap.
 
-2. **db.php drop-in support.** Custom `db.php` drop-ins (e.g., markdown-database-
-   integration) can be mounted into the Playground VFS, but Playground's built-in
-   SQLite integration may conflict. Needs per-case testing.
-
-3. **No host bootstrap.** The Playground backend does not use `tests/bootstrap.php`.
+2. **No host bootstrap.** The Playground backend does not use `tests/bootstrap.php`.
    It runs `install.php` in-process and loads test case classes directly. Any
    customizations in the host bootstrap (e.g., additional `tests_add_filter`
    calls) won't apply.
 
-4. **Partial phpunit.xml.dist consumption.** The runner reads the extension's
+3. **Partial phpunit.xml.dist consumption.** The runner reads the extension's
    `phpunit.xml.dist` for `<testsuite><directory>` entries (with optional
    `suffix` / `prefix` attributes) and `<testsuite><exclude>` entries. Other
    elements (coverage config, bootstrap attribute, `<php>` env vars, groups,
    listeners, extensions) are intentionally not honored — they either refer
    to host-filesystem paths that have no meaning in the VFS, or they describe
    behavior our template already provides.
+
+4. **db.php drop-in coexistence depends on Playground upstream.** The
+   mechanism relies on Playground's internal SQLite mu-plugin voluntarily
+   stepping aside when `/wordpress/wp-content/db.php` exists. If upstream
+   removes or changes that guard, the coexistence model breaks.
+   `scripts/test/playground-dropin-smoke.sh` catches this regression via the
+   `test_playground_mu_plugin_stepped_aside` assertion. See
+   `docs/PLAYGROUND_DROPIN.md` for the full mechanism.
 
 **References:**
 - Issue: Extra-Chill/homeboy-extensions#214

--- a/wordpress/docs/PLAYGROUND_DROPIN.md
+++ b/wordpress/docs/PLAYGROUND_DROPIN.md
@@ -1,0 +1,177 @@
+# Playground backend: db.php drop-in coexistence
+
+The Playground test backend supports plugins that ship their own `db.php`
+drop-in (WordPress's mechanism for swapping out `$wpdb`). This document
+explains the mechanism, shows how to verify it end-to-end, and documents the
+upstream Playground behavior this integration relies on.
+
+## Summary
+
+**Plugins with a `db.php` drop-in do not need any special configuration.**
+The Playground backend detects `<plugin>/db.php` and mounts it to
+`/wordpress/wp-content/db.php` inside the VFS. Playground's built-in SQLite
+integration then voluntarily steps aside and lets the drop-in own `$wpdb`.
+
+Concretely:
+
+```
+plugin/
+├── main-plugin.php     # Plugin entry
+├── db.php              # Drop-in — gets mounted to /wp-content/db.php
+└── tests/
+    └── SomeTest.php    # Runs with plugin's db.php in charge of $wpdb
+```
+
+The runner handles the mount. You just place `db.php` in the plugin root.
+
+## How coexistence works
+
+WordPress Playground normally ships an mu-plugin at
+`/internal/shared/mu-plugins/sqlite-database-integration.php` that wires up
+`$wpdb` to its bundled SQLite implementation. The first few lines of that
+mu-plugin are a guard:
+
+```php
+// Do not preload this if WordPress comes with a custom db.php file.
+if ( file_exists( '/wordpress/wp-content/db.php' ) ) {
+    return;
+}
+```
+
+So the load order during a Playground request is:
+
+1. **WordPress core** (`wp-settings.php`) calls `require_wp_db()`, which
+   checks for `/wordpress/wp-content/db.php` and, if present, `require_once`s
+   it. The drop-in sets `$wpdb` and defines any constants it needs.
+2. **Playground's SQLite mu-plugin** loads, sees the drop-in exists, and
+   returns immediately. `$wpdb` stays as whatever the drop-in set it to.
+3. **WordPress** finishes booting with the drop-in's `$wpdb` in charge.
+
+No `--skip-sqlite-setup` flag is needed. The runner does not pass it and
+you should not either — if you pass `--skip-sqlite-setup` AND mount a
+drop-in that relies on Playground's bundled SQLite classes, the
+`/internal/shared/sqlite-database-integration/` directory is still available
+on the VFS (mu-plugins are config, the library is filesystem), so the drop-in
+still works. But the full WordPress install path tries to initialize MySQL
+and fails early. Skip-sqlite-setup is for a different use case (host-MySQL
+testing), not for drop-in coexistence.
+
+## The drop-in can reuse Playground's bundled SQLite
+
+This is the killer feature. Playground's SQLite implementation lives at
+`/internal/shared/sqlite-database-integration/` in the VFS and is readable
+from the drop-in:
+
+```php
+<?php
+// Your plugin's db.php
+
+$sqlite = '/internal/shared/sqlite-database-integration';
+if ( ! file_exists( $sqlite . '/wp-includes/sqlite/db.php' ) ) {
+    return; // fall back to MySQL
+}
+
+if ( ! defined( 'DB_ENGINE' ) ) {
+    define( 'DB_ENGINE', 'sqlite' );
+}
+
+// Delegate to Playground's implementation — this sets $wpdb = WP_SQLite_DB.
+require_once $sqlite . '/wp-includes/sqlite/db.php';
+
+// ...then wrap $wpdb, subclass it, or replace it entirely with your own.
+```
+
+This is the pattern [markdown-database-integration](https://github.com/Automattic/markdown-database-integration)
+uses in production: delegate to Playground's bundled SQLite for the query
+engine, then substitute a custom `$wpdb` subclass that adds markdown
+mirroring on top.
+
+## Verifying with the fixture
+
+A reference fixture lives at `wordpress/tests/fixtures/dropin-coexistence/`:
+
+```
+tests/fixtures/dropin-coexistence/
+├── plugin.php                          # Inert plugin entry
+├── db.php                              # Reference drop-in (delegates to bundled SQLite)
+└── tests/
+    └── DropInCoexistenceTest.php      # Asserts coexistence end-to-end
+```
+
+The smoke-test runner script runs this fixture and checks all three
+invariants:
+
+```bash
+bash wordpress/scripts/test/playground-dropin-smoke.sh
+```
+
+Expected output:
+
+```
+OK (3 tests, 8 assertions)
+✓ Drop-in coexistence smoke test PASSED
+```
+
+The three assertions cover:
+
+1. **Drop-in actually loaded.** `HOMEBOY_DROPIN_FIXTURE_LOADED` is defined
+   only by `db.php`. If undefined, WordPress never `require_once`d the
+   drop-in — check the mount.
+2. **`$wpdb` works end-to-end.** `wp_insert_post` + `get_post` round-trip
+   real data through the drop-in's `$wpdb`.
+3. **Playground's mu-plugin stepped aside.** `SQLITE_DB_DROPIN_VERSION` is
+   defined at the top of Playground's mu-plugin body. If it IS defined, the
+   mu-plugin's guard failed and the drop-in was silently overwritten.
+
+Run the smoke test after:
+
+- Changes to `scripts/test/test-runner-playground.sh` (the bash dispatcher)
+- Changes to `scripts/test/playground-runner.php` (the template)
+- Upgrading `@wp-playground/cli` (upstream may change the mu-plugin guard)
+
+## Upstream contract
+
+This whole mechanism depends on the guard at the top of
+`/internal/shared/mu-plugins/sqlite-database-integration.php`. If a future
+Playground release removes or changes that guard, the coexistence model
+breaks. The `test_playground_mu_plugin_stepped_aside` assertion in the
+fixture catches that regression.
+
+Source of the guard:
+[WordPress/wordpress-playground — packages/playground/wordpress-builds/...](https://github.com/WordPress/wordpress-playground)
+(look for the mu-plugin that's auto-generated from the SQLite integration
+during build).
+
+## Limitations
+
+- **WordPress install flow.** Playground's default install flow assumes
+  SQLite is available. If your drop-in cannot serve the install flow (e.g.,
+  it needs external state to be set up first), the tests will die with
+  "Error connecting to the database" before the test runner starts. Fix:
+  make sure the drop-in can serve a cold-boot install, which typically
+  means it must delegate to Playground's bundled SQLite for the initial
+  schema.
+
+- **WP version pinning.** The `--wp=6.9` flag in the Playground runner must
+  match the `wp-phpunit` package version. Don't forget to update both when
+  bumping WordPress. A mismatch often manifests as missing `WP_UnitTestCase`
+  factory methods, not as a database error — the drop-in will load fine but
+  wp-phpunit bootstrap will fail.
+
+- **MDI-specific note.** Markdown Database Integration's production drop-in
+  assumes its own plugin directory is at
+  `wp-content/plugins/markdown-database-integration/` (to load its classes).
+  When testing MDI through the Playground backend, the MDI plugin itself is
+  mounted to that location by `test-runner-playground.sh`. You don't have
+  to configure anything special for this common case.
+
+## Related
+
+- Issue [#214](https://github.com/Extra-Chill/homeboy-extensions/issues/214)
+  (Playground backend umbrella)
+- PR [#215](https://github.com/Extra-Chill/homeboy-extensions/pull/215)
+  (Phase 1: initial Playground backend)
+- PR [#216](https://github.com/Extra-Chill/homeboy-extensions/pull/216)
+  (Phase 2: structured diagnostics)
+- PR [#217](https://github.com/Extra-Chill/homeboy-extensions/pull/217)
+  (Phase 2: phpunit.xml.dist-aware recursive discovery)

--- a/wordpress/scripts/test/playground-dropin-smoke.sh
+++ b/wordpress/scripts/test/playground-dropin-smoke.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Playground backend db.php drop-in coexistence smoke test.
+#
+# Runs the fixture at wordpress/tests/fixtures/dropin-coexistence/ through the
+# Playground backend and asserts that a custom db.php drop-in can coexist
+# with Playground's built-in SQLite integration.
+#
+# This is a manual integration test, not part of the normal CI matrix. Run it
+# after changes to:
+#   - test-runner-playground.sh (the bash dispatcher)
+#   - playground-runner.php (the template)
+#   - anything touching the db.php mount logic
+#
+# Usage: bash wordpress/scripts/test/playground-dropin-smoke.sh
+# Exit:  0 = coexistence works, non-zero = regression
+#
+# Background: see wordpress/docs/PLAYGROUND_DROPIN.md
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/dropin-coexistence"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+echo "============================================"
+echo "Playground drop-in coexistence smoke test"
+echo "============================================"
+echo "Fixture: $FIXTURE_DIR"
+echo ""
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+    HOMEBOY_COMPONENT_ID="dropin-coexistence-fixture" \
+    bash "${SCRIPT_DIR}/test-runner-playground.sh"
+
+exit_code=$?
+if [ $exit_code -eq 0 ]; then
+    echo ""
+    echo "============================================"
+    echo "✓ Drop-in coexistence smoke test PASSED"
+    echo "============================================"
+else
+    echo ""
+    echo "============================================"
+    echo "✗ Drop-in coexistence smoke test FAILED (exit $exit_code)"
+    echo "============================================"
+    echo "See docs/PLAYGROUND_DROPIN.md for the expected mechanism."
+fi
+
+exit $exit_code

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -240,6 +240,13 @@ try {
         $loaded = false;
         $main_files = glob("$plugin_path/*.php") ?: [];
         foreach ($main_files as $mf) {
+            // db.php is a WordPress drop-in, not a plugin entry file. It's
+            // already been loaded by wp-settings.php earlier in the request
+            // lifecycle. Including it again would re-run its side effects
+            // (define() warnings, $wpdb re-init) for no reason.
+            if (basename($mf) === 'db.php') {
+                continue;
+            }
             if (strpos(file_get_contents($mf), 'Plugin Name:') !== false) {
                 pg_log("PLUGIN_DETECTED " . basename($mf));
                 require_once $mf;

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -147,9 +147,35 @@ if [ -n "$DEPENDENCY_PATHS" ]; then
     done <<< "$DEPENDENCY_PATHS"
 fi
 
+# ---------------------------------------------------------------------------
+# db.php drop-in coexistence with Playground's built-in SQLite
+#
+# Playground ships an internal mu-plugin at
+# /internal/shared/mu-plugins/sqlite-database-integration.php that normally
+# wires up WordPress to its bundled SQLite implementation. That mu-plugin
+# begins with a self-deactivation guard:
+#
+#     if ( file_exists( '/wordpress/wp-content/db.php' ) ) {
+#         return;
+#     }
+#
+# So when we mount a plugin's db.php drop-in at /wordpress/wp-content/db.php,
+# the mu-plugin voluntarily steps aside and the drop-in owns $wpdb. No
+# --skip-sqlite-setup flag is required. The drop-in can still *reuse*
+# Playground's bundled SQLite classes (available at
+# /internal/shared/sqlite-database-integration/) — that's what
+# markdown-database-integration's db.php does.
+#
+# See docs/PLAYGROUND_DROPIN.md for the full coexistence model and a minimal
+# example drop-in that verifies the plumbing end-to-end.
+# ---------------------------------------------------------------------------
 PLUGIN_DB_PHP="${PLUGIN_PATH}/db.php"
 if [ -f "$PLUGIN_DB_PHP" ]; then
     MOUNT_ARGS+=("--mount" "${PLUGIN_DB_PHP}:/wordpress/wp-content/db.php")
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: [playground] Plugin db.php drop-in detected at $PLUGIN_DB_PHP"
+        echo "DEBUG: [playground] Playground's built-in SQLite mu-plugin will step aside"
+    fi
 fi
 
 MOUNT_ARGS+=("--mount" "${EXTENSION_PATH}:/homeboy-extension")

--- a/wordpress/tests/fixtures/dropin-coexistence/db.php
+++ b/wordpress/tests/fixtures/dropin-coexistence/db.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Plugin Name: Drop-in Coexistence Fixture (db.php)
+ *
+ * Reference db.php drop-in for the Playground backend's coexistence smoke test.
+ *
+ * How coexistence works in Playground:
+ *
+ *   1. Playground ships an internal mu-plugin at
+ *      /internal/shared/mu-plugins/sqlite-database-integration.php that
+ *      normally wires up $wpdb to its bundled SQLite implementation.
+ *
+ *   2. That mu-plugin begins with a self-deactivation guard:
+ *          if ( file_exists( '/wordpress/wp-content/db.php' ) ) { return; }
+ *
+ *   3. When we mount a plugin's db.php at /wordpress/wp-content/db.php (the
+ *      Playground backend runner does this automatically when it sees a
+ *      db.php in the plugin root), the guard fires and the mu-plugin steps
+ *      aside. The drop-in then owns $wpdb for the whole request lifecycle.
+ *
+ *   4. The drop-in is still free to reuse Playground's bundled SQLite
+ *      implementation — it lives at /internal/shared/sqlite-database-integration
+ *      and is readable at runtime. That's the pattern
+ *      markdown-database-integration uses in production.
+ *
+ * This fixture delegates to Playground's bundled SQLite so the rest of the
+ * WordPress test suite (wp_insert_post, wp_get_user, etc.) continues to
+ * work end-to-end. A real drop-in (MDI) would substitute its own $wpdb
+ * subclass at the end.
+ *
+ * @package Homeboy\WordPress\Tests\Fixtures
+ */
+
+// Signal that this drop-in ran. The accompanying test class asserts this.
+if ( ! defined( 'HOMEBOY_DROPIN_FIXTURE_LOADED' ) ) {
+    define( 'HOMEBOY_DROPIN_FIXTURE_LOADED', true );
+}
+
+$sqlite = '/internal/shared/sqlite-database-integration';
+if ( ! file_exists( $sqlite . '/wp-includes/sqlite/db.php' ) ) {
+    // Playground's bundled SQLite is not available. Leave $wpdb alone so
+    // WordPress can fall back to its default (MySQL attempt will fail loudly
+    // rather than silently). This is the failure mode we want to surface.
+    return;
+}
+
+if ( ! defined( 'DATABASE_TYPE' ) ) {
+    define( 'DATABASE_TYPE', 'sqlite' );
+}
+if ( ! defined( 'DB_ENGINE' ) ) {
+    define( 'DB_ENGINE', 'sqlite' );
+}
+
+// Delegate to Playground's drop-in. It sets up $wpdb = new WP_SQLite_DB(...).
+require_once $sqlite . '/wp-includes/sqlite/db.php';

--- a/wordpress/tests/fixtures/dropin-coexistence/plugin.php
+++ b/wordpress/tests/fixtures/dropin-coexistence/plugin.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Plugin Name: Drop-in Coexistence Fixture
+ * Description: Fixture plugin for the Playground backend's db.php drop-in coexistence smoke test. Not for production use.
+ * Version: 1.0.0
+ *
+ * @package Homeboy\WordPress\Tests\Fixtures
+ */
+
+// The fixture is deliberately inert at the plugin-entry layer. All the
+// coexistence logic lives in the sibling db.php file. The test class in
+// tests/ asserts that the drop-in ran and $wpdb still functions end-to-end.

--- a/wordpress/tests/fixtures/dropin-coexistence/tests/DropInCoexistenceTest.php
+++ b/wordpress/tests/fixtures/dropin-coexistence/tests/DropInCoexistenceTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Integration test: custom db.php drop-in coexists with Playground's built-in
+ * SQLite integration.
+ *
+ * Runs via: wordpress/scripts/test/playground-dropin-smoke.sh
+ *
+ * @package Homeboy\WordPress\Tests\Fixtures
+ */
+
+class DropInCoexistenceTest extends WP_UnitTestCase {
+
+    /**
+     * The fixture's db.php defines HOMEBOY_DROPIN_FIXTURE_LOADED. If this
+     * constant is missing, WordPress never actually loaded the drop-in —
+     * either the file isn't at /wp-content/db.php or Playground's internal
+     * SQLite mu-plugin stopped stepping aside.
+     */
+    public function test_dropin_was_loaded() {
+        $this->assertTrue(
+            defined( 'HOMEBOY_DROPIN_FIXTURE_LOADED' ) && HOMEBOY_DROPIN_FIXTURE_LOADED,
+            'Plugin-provided db.php drop-in did not execute during bootstrap. '
+            . 'Check: (1) db.php mounted at /wordpress/wp-content/db.php, '
+            . '(2) Playground mu-plugin guard still intact upstream.'
+        );
+    }
+
+    /**
+     * Proves $wpdb still serves real WordPress writes after the drop-in
+     * installed itself. If this regresses, the drop-in hooked itself in
+     * before wp-settings completed DB setup (which happens for several
+     * misconfigurations of the MDI-style 'reuse internal SQLite' pattern).
+     */
+    public function test_wpdb_can_insert_and_read() {
+        $post_id = wp_insert_post( array(
+            'post_title'   => 'Drop-in smoke',
+            'post_status'  => 'publish',
+            'post_content' => 'Lorem ipsum',
+        ) );
+
+        $this->assertIsInt( $post_id );
+        $this->assertGreaterThan( 0, $post_id );
+
+        $post = get_post( $post_id );
+        $this->assertNotNull( $post );
+        $this->assertSame( 'Drop-in smoke', $post->post_title );
+        $this->assertSame( 'publish', $post->post_status );
+    }
+
+    /**
+     * Proves that Playground's internal SQLite mu-plugin voluntarily stepped
+     * aside. We verify this indirectly: WP_SQLite_DB is available (so the
+     * bundled implementation IS on the VFS) but DATABASE_TYPE was set by our
+     * drop-in, not by the mu-plugin's early-exit path.
+     *
+     * The mu-plugin defines SQLITE_DB_DROPIN_VERSION on its own path. Our
+     * drop-in does NOT. So seeing that constant undefined (or defined by the
+     * fixture itself if someone extends it) is the signal that the
+     * mu-plugin's body never executed.
+     */
+    public function test_playground_mu_plugin_stepped_aside() {
+        // WP_SQLite_DB exists because we loaded it ourselves from the VFS
+        // in db.php. That's expected.
+        $this->assertTrue( class_exists( 'WP_SQLite_DB' ), 'Bundled SQLite implementation should be reachable from the VFS.' );
+
+        // SQLITE_DB_DROPIN_VERSION is defined at the TOP of the Playground
+        // mu-plugin's body. If the mu-plugin's guard fired, the body never
+        // ran, so the constant stays undefined.
+        $this->assertFalse(
+            defined( 'SQLITE_DB_DROPIN_VERSION' ),
+            'SQLITE_DB_DROPIN_VERSION is defined, which means Playground\'s '
+            . 'SQLite mu-plugin DID execute. The wp-content/db.php guard is '
+            . 'not firing — the drop-in would have been silently overwritten.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Third and final Phase 2 PR. Verifies that a plugin's `db.php` drop-in (the MDI pattern) coexists with Playground's built-in SQLite integration, and ships the fixture + smoke test that will catch regressions.

## Note on PR chain

Originally opened as PR #218 stacked on `phase-2-pr2-xml-discovery`. GitHub auto-closed it when that base branch was deleted after #219 (replacement for #217) merged. This is the re-opened version, rebased onto `main`, identical content.

Builds on #216 (diagnostics) and #219 (phpunit.xml.dist-aware discovery), both already merged.

## The discovery

Playground's internal SQLite mu-plugin at `/internal/shared/mu-plugins/sqlite-database-integration.php` starts with a self-deactivation guard:

```php
// Do not preload this if WordPress comes with a custom db.php file.
if ( file_exists( '/wordpress/wp-content/db.php' ) ) {
    return;
}
```

So when `test-runner-playground.sh` mounts a plugin's `db.php` at `/wordpress/wp-content/db.php` — which it already did in Phase 1 — the mu-plugin steps aside and the drop-in owns `$wpdb`. **No `--skip-sqlite-setup`, no `--mount-before-install` tricks. The coexistence is native.**

I spent an hour trying to force it with `--skip-sqlite-setup` before finding the guard. That dead-end is not in the final commit — only the mechanism that actually works.

## What ships

### Reference fixture — `wordpress/tests/fixtures/dropin-coexistence/`

- `plugin.php` — inert plugin entry
- `db.php` — reference drop-in that delegates to Playground's bundled SQLite at `/internal/shared/sqlite-database-integration/` (the MDI production pattern in miniature). Defines `HOMEBOY_DROPIN_FIXTURE_LOADED` so tests can prove it ran.
- `tests/DropInCoexistenceTest.php` — three assertions, one per invariant the mechanism depends on.

### Smoke test — `wordpress/scripts/test/playground-dropin-smoke.sh`

Runs the fixture via the Playground backend end-to-end. Exit code is the verdict.

```bash
bash wordpress/scripts/test/playground-dropin-smoke.sh
# OK (3 tests, 8 assertions)
# ✓ Drop-in coexistence smoke test PASSED
```

### Documentation — `wordpress/docs/PLAYGROUND_DROPIN.md`

Full mechanism, usage, limitations, upstream contract.

### Template fix — skip `db.php` in plugin-entry detection

`playground-runner.php`'s plugin-entry loop globs `*.php` files and `require_once`s whichever has a `Plugin Name:` header. `db.php` has that header but it's a drop-in, already loaded by WP core. Skip it explicitly so it doesn't get double-included.

### Inline documentation — `test-runner-playground.sh`

~20-line block comment explaining the coexistence model at the `db.php` mount site.

## The three assertions

| Assertion | What it proves | What it catches |
|-----------|----------------|-----------------|
| `test_dropin_was_loaded` | `HOMEBOY_DROPIN_FIXTURE_LOADED` is defined | Bash runner regression — mount didn't land |
| `test_wpdb_can_insert_and_read` | `wp_insert_post` + `get_post` round-trip | Drop-in is wired in but not serving |
| `test_playground_mu_plugin_stepped_aside` | `SQLITE_DB_DROPIN_VERSION` is UNDEFINED after `wp-settings.php` | Upstream Playground removed/changed the guard — coexistence model broke |

The third one is the canary. Playground's mu-plugin defines `SQLITE_DB_DROPIN_VERSION` at the top of its body. If the guard fires, the body never runs, constant stays undefined. If the constant IS defined, the drop-in was silently overwritten.

## Files

| File | Change |
|------|--------|
| `wordpress/scripts/test/test-runner-playground.sh` | +27 — inline block comment + debug log line |
| `wordpress/scripts/test/playground-runner.php` | +7 — skip `db.php` in plugin-entry loop |
| `wordpress/scripts/test/playground-dropin-smoke.sh` | **new** — 62 lines |
| `wordpress/tests/fixtures/dropin-coexistence/` | **new** — fixture tree |
| `wordpress/docs/PLAYGROUND_DROPIN.md` | **new** — 177 lines |
| `wordpress/TEST_INFRASTRUCTURE_PLAN.md` | Phase 2 status table + known-gaps list |

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code
- **Used for:** Agent drove the whole investigation — reproduced the naive failure mode, discovered upstream Playground's mu-plugin guard by grepping the VFS at runtime, ruled out a `--skip-sqlite-setup` blind alley before it reached the commit, designed the three-assertion fixture to catch each concrete regression path, wrote the doc, and verified the full regression matrix against live `wp-playground-cli`. Chris approved the three-PR Phase 2 sequence.