### PR TITLE
feat(wordpress): surface auto-fixable lint findings as prominent CTA

### DIFF
--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -553,6 +553,24 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
         echo "$summary"
     fi
 
+    # Prominent auto-fix nudge: when PHPCS reports auto-fixable findings, surface
+    # a dedicated call-to-action block so developers see them before pushing.
+    # This closes the behavior gap where warnings fire but the warn-only exit 0
+    # lets auto-fixable findings slip through to reviewers (homeboy-extensions#229).
+    fixable_count=$(echo "$json_output" | php -r '
+        $json = json_decode(file_get_contents("php://stdin"), true);
+        echo (int) ($json["totals"]["fixable"] ?? 0);
+    ' 2>/dev/null || echo "0")
+
+    if [ -n "$fixable_count" ] && [ "$fixable_count" -gt 0 ] 2>/dev/null; then
+        fix_target="${HOMEBOY_COMPONENT_ID:-${HOMEBOY_PROJECT_ID:-<component>}}"
+        echo ""
+        echo "============================================"
+        echo "AUTO-FIXABLE: ${fixable_count} lint finding(s) can be fixed automatically."
+        echo "  Run:  homeboy refactor --from lint --write ${fix_target}"
+        echo "============================================"
+    fi
+
     # Write annotations sidecar JSON for CI inline comments
     if [ -n "${HOMEBOY_ANNOTATIONS_DIR:-}" ] && [ -d "${HOMEBOY_ANNOTATIONS_DIR}" ]; then
         echo "$json_output" | php -r '


### PR DESCRIPTION
## Summary

Part A of #229. When PHPCS reports auto-fixable findings, surface a prominent \"AUTO-FIXABLE\" block with the exact \`homeboy refactor\` command to clean them up. Closes the behavior gap where the harness silently accepted auto-fixable findings (including formatting warnings like \`Generic.Formatting.MultipleStatementAlignment\`) because the warn-only exit 0 never forced developers to run the fixer before pushing.

## Problem

Case study: [WordPress/wordpress-develop#11387](https://github.com/WordPress/wordpress-develop/pull/11387). Weston's review flagged aligned-equals as a required fix. That finding is auto-fixable by phpcbf, which the harness already ships and exposes via \`homeboy refactor --from lint --write\`. So **why did it slip through to review?**

Investigation on closed #224 established:

- The sniff (\`Generic.Formatting.MultipleStatementAlignment\`) is active via \`WordPress-Extra\`.
- PHPCS emits it as \`NotSameWarning\` — a **warning**, not an error.
- \`lint-runner.sh\` runs in warn-only mode (\`exit 0\` regardless) per lines 765 / 853.
- The summary header has a \`Fixable: N\` line, but it's buried mid-block and doesn't tell you what to do about it.

Net: developer runs \`homeboy test\`, sees \`Linting found issues (see above)\`, notes the exit 0, pushes. Reviewer catches it.

## Fix

Add a dedicated block after the LINT SUMMARY header, rendered only when \`totals.fixable > 0\`:

\`\`\`
============================================
AUTO-FIXABLE: 8 lint finding(s) can be fixed automatically.
  Run:  homeboy refactor --from lint --write <component>
============================================
\`\`\`

## Verification

End-to-end test against a synthetic misaligned-equals fixture (mirrors the aligned-equals commit on #11387):

**Before (input with single-space-aligned \`=\` signs):**
\`\`\`
============================================
LINT SUMMARY: 5 errors, 3 warnings
Fixable: 8 | Files with issues: 1 of 1
============================================
TOP VIOLATIONS:
  Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed           5
  Generic.Formatting.MultipleStatementAlignment.NotSameWarning     3
\`\`\`

**After:**
\`\`\`
============================================
LINT SUMMARY: 5 errors, 3 warnings
Fixable: 8 | Files with issues: 1 of 1
============================================

============================================
AUTO-FIXABLE: 8 lint finding(s) can be fixed automatically.
  Run:  homeboy refactor --from lint --write test-fixture
============================================

TOP VIOLATIONS:
  Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed           5
  Generic.Formatting.MultipleStatementAlignment.NotSameWarning     3
\`\`\`

**Negative test** (clean file, same invocation):
\`\`\`
PHPCS linting passed
Linting passed
\`\`\`
Block renders nothing. No noise when there's nothing to fix.

Verified in both summary mode (\`HOMEBOY_SUMMARY_MODE=1\`, the \`homeboy test\` default) and full-report mode (direct \`composer lint\`).

## Scope

Minimal — +18 LOC, zero deletions, zero config changes. Uses data PHPCS already emits (\`totals.fixable\` in JSON report). No new dependencies.

Parts B (opt-in fail-on-fixable policy) and C (hoist \`fixable_count\` into the cross-extension core contract) of #229 will land separately once Extra-Chill/homeboy#1459 defines the phase output schema.

## Related

- Issue: #229 (Part A)
- Replaces: closed #224 (sniff was already enabled — the real gap was behavioral)
- Umbrella: #228
- Core contract: Extra-Chill/homeboy#1459
- Case study: https://github.com/WordPress/wordpress-develop/pull/11387

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Investigating the lint harness end-to-end against a reproducible fixture, identifying the specific behavior gap (warnings fire but don't fail / don't surface CTA), drafting the 18-line change, verifying both summary/non-summary paths, writing the commit message and PR body. The misaligned/aligned fixtures were synthesized to match the exact rule class from #11387.