### PR TITLE
feat(wordpress): PHPStan level 7 + include tests + fix baseline integration

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -72,14 +72,47 @@ code 1.
 
 - **PHPCS** — `phpcs.xml.dist` applies WordPress Coding Standards (PSR-4
   adjustments applied). Text domain is auto-detected from the plugin
-  header.
-- **PHPStan** — `phpstan.neon.dist` runs static analysis with WordPress +
-  WP-CLI + WooCommerce stubs. Critical-only by default.
+  header. When PHPCS reports auto-fixable findings, the runner surfaces a
+  prominent CTA showing the exact `homeboy refactor` command to clean
+  them up.
+- **PHPStan** — `phpstan.neon.dist` runs static analysis at **level 7**
+  with WordPress + WP-CLI + WooCommerce stubs. Level 7 unlocks argument
+  type flow analysis (catches `false` / `null` leaking into strict-typed
+  callees). `missingType.*` identifiers are suppressed by default to keep
+  the signal-to-noise ratio high. Tests are analyzed alongside source.
 - **ESLint** — runs only when JS/JSX/TS/TSX files exist in the component.
   WordPress ESLint config.
 
 Components must not ship local `phpcs.xml`, `phpstan.neon`, or `.eslintrc`
-— the extension owns the standards.
+— the extension owns the standards. The one exception is PHPStan
+baselines (see below).
+
+### PHPStan baselines
+
+Components with a lot of pre-existing findings can capture a baseline to
+keep the harness green while fixing findings incrementally. Generate one
+from inside the component directory:
+
+```bash
+path/to/extension/vendor/bin/phpstan analyse \
+    --configuration=path/to/extension/phpstan.neon.dist \
+    --level=7 --memory-limit=2G \
+    --generate-baseline=phpstan-baseline.neon \
+    .
+```
+
+Commit the resulting `phpstan-baseline.neon` at the component root. The
+runner detects it and pulls it into the analysis via `includes:`. New
+code must not add new findings — existing findings are grandfathered in,
+and new ones fail the run. Delete the baseline to ratchet toward full
+cleanup.
+
+### Level override
+
+`HOMEBOY_PHPSTAN_LEVEL=8 homeboy test <component>` bumps one-off without
+changing the default. `HOMEBOY_SKIP_PHPSTAN=1` runs a critical-only
+check that still blocks `function.notFound` / `class.notFound` (guaranteed
+runtime fatals) regardless of the skip.
 
 ## Debug output
 

--- a/wordpress/phpstan.neon.dist
+++ b/wordpress/phpstan.neon.dist
@@ -13,6 +13,24 @@ parameters:
         -
             message: '#Constant [A-Z_]+_(PATH|URL|VERSION|DIR|FILE) not found#'
 
+        # missingType.* family: level 7 requires explicit iterable value types
+        # and return types on every function/method. WP plugins follow WP core's
+        # loose array conventions and rarely annotate `array<string, mixed>` on
+        # every hook callback. Suppressing these keeps the signal-to-noise ratio
+        # high: level 7's real value is argument.type / property.nonObject /
+        # return.type flow analysis (e.g. "false flows into strtotime(string)"),
+        # not "you didn't type this array literal." Teams that want strict
+        # iterable typing can override by dropping these identifiers locally.
+        # See homeboy-extensions#225 for the analysis that led to this config.
+        -
+            identifier: missingType.iterableValue
+        -
+            identifier: missingType.return
+        -
+            identifier: missingType.parameter
+        -
+            identifier: missingType.generics
+
     scanFiles:
         - vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
         - vendor/php-stubs/wp-cli-stubs/wp-cli-commands-stubs.php
@@ -20,17 +38,30 @@ parameters:
         - vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
         - vendor/php-stubs/woocommerce-stubs/woocommerce-packages-stubs.php
 
-    level: 5
+    # Level 7 unlocks argument type flow analysis (union narrowing, false/null
+    # leakage into strict-typed callees). Levels 5 and 6 miss the exact class
+    # of bug in [WordPress/wordpress-develop#11387](https://github.com/WordPress/wordpress-develop/pull/11387) —
+    # `max()` called on a possibly-empty array. Level 7 catches it on the
+    # callsite as `Parameter #1 ...$arg1 of function max expects non-empty-array`.
+    # Components with a lot of pre-existing findings can capture a baseline at
+    # `<component>/phpstan-baseline.neon`; the harness auto-detects and includes
+    # it so the level bump doesn't block in-flight work.
+    level: 7
 
     paths:
         - %currentWorkingDirectory%
 
+    # Tests are analyzed by default so findings like "test passes $result:
+    # array|false|string to strtotime(string)" (homeboy-extensions#225) surface
+    # locally instead of in reviewer comments. Components with test fixtures
+    # that extend WP_UnitTestCase or rely on test-only globals can opt out
+    # per-file with @phpstan-ignore-next-line or per-directory via component-
+    # level excludePaths in their own phpstan.neon.
     excludePaths:
         - */vendor/*
         - */node_modules/*
         - */build/*
         - */dist/*
-        - */tests/*
 
     parallel:
         maximumNumberOfProcesses: 2

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -9,7 +9,7 @@ source "${DEPENDENCY_HELPER}"
 # Standalone PHP static analysis script using PHPStan
 # Supports summary mode via HOMEBOY_SUMMARY_MODE=1
 # Supports skip via HOMEBOY_SKIP_PHPSTAN=1
-# Supports level override via HOMEBOY_PHPSTAN_LEVEL (default: 5)
+# Supports level override via HOMEBOY_PHPSTAN_LEVEL (default: 7, matches phpstan.neon.dist)
 # NOTE: PHPStan always analyzes the full codebase (ignores HOMEBOY_LINT_GLOB)
 # because it needs the complete type graph to detect collateral damage from
 # changes (broken call sites, type mismatches in untouched files, etc.)
@@ -91,12 +91,22 @@ fi
 generate_dependency_config() {
     local tmpfile
     local has_dependencies=0
+    local has_baseline=0
 
     tmpfile=$(homeboy_mktemp 'phpstan-dependencies-XXXXXX.neon')
 
     {
         printf '%s\n' 'includes:'
         printf '    - %s\n' "$PHPSTAN_CONFIG"
+        # Component baseline: PHPStan 2.x removed the `--baseline` CLI flag, so
+        # the baseline file must be pulled in via `includes:` in the neon. We
+        # do this here (rather than via --baseline) so every invocation path
+        # (summary, full, retry) picks it up automatically through the single
+        # config include chain.
+        if [ -f "$COMPONENT_BASELINE" ]; then
+            printf '    - %s\n' "$COMPONENT_BASELINE"
+            has_baseline=1
+        fi
         printf '%s\n' ''
         printf '%s\n' 'parameters:'
         printf '%s\n' '    scanDirectories:'
@@ -108,7 +118,7 @@ generate_dependency_config() {
         done < <(homeboy_resolve_validation_dependency_paths "$PLUGIN_PATH")
     } > "$tmpfile"
 
-    if [ "$has_dependencies" -eq 1 ]; then
+    if [ "$has_dependencies" -eq 1 ] || [ "$has_baseline" -eq 1 ]; then
         printf '%s\n' "$tmpfile"
     else
         rm -f "$tmpfile"
@@ -148,19 +158,27 @@ echo "Running PHPStan static analysis..."
 phpstan_args=(analyse)
 phpstan_args+=(--configuration="$PHPSTAN_BASE_CONFIG")
 
-# Level override (default: 5)
-PHPSTAN_LEVEL="${HOMEBOY_PHPSTAN_LEVEL:-5}"
+# Level resolution:
+#   - HOMEBOY_PHPSTAN_LEVEL env override wins (for ad-hoc bumps / CI matrix runs).
+#   - Otherwise, default to 7 which matches the `level:` key in phpstan.neon.dist.
+#
+# Previously this script hardcoded 5 as a fallback, which shadowed the neon
+# config whenever the env var wasn't set (`--level` on CLI overrides neon).
+# That made config-driven level changes invisible to the harness. The fallback
+# must now track what the neon declares (level 7, set in homeboy-extensions#225).
+# Keep them in sync when bumping further.
+PHPSTAN_LEVEL="${HOMEBOY_PHPSTAN_LEVEL:-7}"
 phpstan_args+=(--level="$PHPSTAN_LEVEL")
 
 # Memory limit (default: 2G)
 phpstan_args+=(--memory-limit=2G)
 
-# Include component baseline if it exists
-if [ -f "$COMPONENT_BASELINE" ]; then
-    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
-        echo "DEBUG: Using component baseline: $COMPONENT_BASELINE"
-    fi
-    phpstan_args+=(--baseline="$COMPONENT_BASELINE")
+# Component baseline: if <component>/phpstan-baseline.neon exists, it's pulled
+# in via `includes:` in the generated dependency/autoload neon (see
+# generate_dependency_config). PHPStan 2.x removed the `--baseline` CLI flag,
+# so inclusion via neon is the only supported path.
+if [ -f "$COMPONENT_BASELINE" ] && [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "DEBUG: Component baseline will be pulled in via includes: $COMPONENT_BASELINE"
 fi
 
 # Include component/dependency autoloaders if they exist
@@ -284,9 +302,9 @@ if [ -n "$PHPSTAN_MAX_PROCESSES" ] || [ -n "$PHPSTAN_PHP_VERSION" ]; then
     phpstan_args+=(--configuration="$PHPSTAN_TMPCONFIG")
     phpstan_args+=(--level="$PHPSTAN_LEVEL")
     phpstan_args+=(--memory-limit=2G)
-    if [ -f "$COMPONENT_BASELINE" ]; then
-        phpstan_args+=(--baseline="$COMPONENT_BASELINE")
-    fi
+    # Baseline is pulled in via neon includes (PHPSTAN_TMPCONFIG includes
+    # PHPSTAN_BASE_CONFIG which includes COMPONENT_BASELINE when present),
+    # so there's no --baseline CLI flag to pass (removed in PHPStan 2.x).
     if [ -f "$COMPOSITE_AUTOLOAD" ]; then
         phpstan_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
     fi
@@ -362,7 +380,8 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
         echo "Parallel worker failure detected, retrying single-process (--debug)..."
         prepare_phpstan_retry_config > /dev/null
         retry_args=(analyse --configuration="$PHPSTAN_TMPCONFIG" --level="$PHPSTAN_LEVEL" --memory-limit=2G --no-progress --debug)
-        [ -f "$COMPONENT_BASELINE" ] && retry_args+=(--baseline="$COMPONENT_BASELINE")
+        # Baseline is pulled in via PHPSTAN_TMPCONFIG → PHPSTAN_BASE_CONFIG
+        # → COMPONENT_BASELINE include chain (no --baseline CLI flag in PHPStan 2.x).
         [ -f "$COMPOSITE_AUTOLOAD" ] && retry_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
         retry_args+=(.)
         stderr_file=$(homeboy_mktemp 'phpstan-stderr-XXXXXX.log')
@@ -721,7 +740,7 @@ if [ "$full_exit" -ne 0 ] && \
     echo "Parallel worker failure detected, retrying single-process (--debug)..."
     prepare_phpstan_retry_config > /dev/null
     retry_args=(analyse --configuration="$PHPSTAN_TMPCONFIG" --level="$PHPSTAN_LEVEL" --memory-limit=2G --no-progress --debug)
-    [ -f "$COMPONENT_BASELINE" ] && retry_args+=(--baseline="$COMPONENT_BASELINE")
+    # Baseline pulled in via PHPSTAN_TMPCONFIG include chain, same as summary-mode retry.
     [ -f "$COMPOSITE_AUTOLOAD" ] && retry_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
     retry_args+=(.)
     set +e


### PR DESCRIPTION
## Summary

Closes #225. Makes the WordPress extension's PHPStan harness catch the class of type-flow bug that [WordPress/wordpress-develop#11387](https://github.com/WordPress/wordpress-develop/pull/11387) is fixing (`max()` called on a possibly-empty array → `ValueError` on PHP 8.x, plus `false` leaking into strict-typed callees) **locally**, before a human reviewer has to flag it. Also fixes two latent runner bugs that would have made the config change invisible.

## Investigation

Full write-up is on [#225](https://github.com/Extra-Chill/homeboy-extensions/issues/225#issuecomment-4313383733). Abbreviated:

| Level | Errors on `intelligence` | Signal quality |
|---|---|---|
| 5 (current) | 87 | Baseline — misses `max()` on possibly-empty array |
| 6 | 570 | Level 5 + 498 `missingType.*` noise. Zero new signal. Net loss. |
| 7 | 793 | Level 6 + **223 real argument.type + property.nonObject findings** |
| **7 with `missingType.*` suppressed** | **337** | The sweet spot — actionable signal, no boilerplate |

Verified against a synthetic fixture mirroring pre-fix `get_feed_build_date()`:

**Before (level 5):** `[OK] No errors`
**After (level 7):** `Parameter #1 ...$arg1 of function max expects non-empty-array, array given. [argument.type]`

That is the exact bug the PR under review is fixing. The harness now catches it at the callsite before the PR ships.

## Changes

### Config (`wordpress/phpstan.neon.dist`)

1. **`level: 5` → `level: 7`.** Unlocks argument type flow analysis.
2. **Suppress `missingType.iterableValue` / `missingType.return` / `missingType.parameter` / `missingType.generics`.** These are \"you didn't annotate array<string, mixed>\" boilerplate — zero bug-finding value on WP-convention code. Teams that want strict iterable typing can override locally.
3. **Remove `*/tests/*` from `excludePaths`.** Tests analyzed alongside source. Per-file opt-out via `@phpstan-ignore-next-line`.

### Runner (`wordpress/scripts/lint/phpstan-runner.sh`)

4. **Level fallback hardcoded to 5 → bumped to 7.** The runner was appending `--level=${HOMEBOY_PHPSTAN_LEVEL:-5}` on every invocation, and `--level` on the CLI overrides neon's `level:` key. That meant the neon config's level was invisible whenever the env var wasn't set — my config-only bump to level 7 would have silently done nothing. Fallback now tracks what the neon declares. Keep in sync on future bumps.

5. **PHPStan 2.x removed the `--baseline` CLI flag.** The runner passed `--baseline=<component>/phpstan-baseline.neon` in four places. All four failed with `The \"--baseline\" option does not exist` on the bundled PHPStan 2.1.40, silently falling through every time a component tried to use a baseline. Fixed by moving baseline inclusion into the generated dependency-config neon via `includes:` (the PHPStan 2.x-supported path). End-to-end verified:

   ```
   Without baseline (intelligence, level 7):  378 errors
   With baseline:                              43 errors
   ```

   The 43 remaining are findings PHPStan itself declined to put in the baseline at generation time (\"Some errors could not be put into baseline\" — upstream limitation on certain type-variance cases), not a regression.

### Docs (`wordpress/docs/TESTING.md`)

6. Expanded PHPStan section: level-7 story, baseline-generation command, `HOMEBOY_PHPSTAN_LEVEL` override, and the previously-undocumented `HOMEBOY_SKIP_PHPSTAN=1` critical-only mode (still blocks `function.notFound` / `class.notFound` even when \"skipped\").

## Net diff

```
 wordpress/docs/TESTING.md                | 41 +++++++++++++++++++++++---
 wordpress/phpstan.neon.dist              | 35 +++++++++++++++++++++--
 wordpress/scripts/lint/phpstan-runner.sh | 49 ++++++++++++++++++++++----------
 3 files changed, 104 insertions(+), 21 deletions(-)
```

## Migration notes for in-flight work

The level bump will produce findings on every component on first run after this PR. Workflow:

1. Run `homeboy test <component>` once, observe the finding count.
2. Generate a baseline: `vendor/bin/phpstan analyse --configuration=<ext>/phpstan.neon.dist --level=7 --memory-limit=2G --generate-baseline=phpstan-baseline.neon .` from the component root.
3. Commit `phpstan-baseline.neon`.
4. New code won't add new findings; existing findings are grandfathered.
5. Delete `phpstan-baseline.neon` whenever you want to ratchet toward full cleanup.

## Out of scope, filed separately

- **`php-stubs/wordpress-stubs` narrative-only `@return string|false`.** Upstream stub quality issue — narrative docblocks document the `false` return but lack machine-readable `@phpstan-return string|false`. Will file upstream. Non-blocking — level 7 still catches the direct `max()` bug from #11387.
- **Level 8 / level 9.** Worth exploring once level 7 is established and baselines are proven in the wild.

## Related

- Issue: #225
- Umbrella: #228
- Core contract: Extra-Chill/homeboy#1459
- Case study: https://github.com/WordPress/wordpress-develop/pull/11387

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Built the synthetic repro fixture mirroring the pre-PR `get_feed_build_date()` pattern, ran PHPStan at levels 5/6/7/8/9 against both the fixture and the live `intelligence` plugin to quantify signal vs. noise, identified the two latent runner bugs (`--level=5` fallback shadow, `--baseline` CLI flag removed in PHPStan 2.x) by tracing why the config change initially appeared to have no effect, verified baseline integration end-to-end (378 → 43 errors), wrote the commit message and PR body. Every number in the tables above was measured on this machine.