### PR TITLE
docs(wordpress): document phpstan-strict-rules opt-in for strict empty() enforcement

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -114,6 +114,46 @@ changing the default. `HOMEBOY_SKIP_PHPSTAN=1` runs a critical-only
 check that still blocks `function.notFound` / `class.notFound` (guaranteed
 runtime fatals) regardless of the skip.
 
+### Strict `empty()` / `isset()` enforcement (opt-in)
+
+By default, PHPStan at level 7 already catches the *provably wrong* uses
+of `empty()` / `isset()` via built-in rules (`empty.variable`,
+`empty.offset`, `isset.variable`, `isset.offset`, `isset.property`).
+That covers every case where PHPStan can prove the check is redundant
+or a bug.
+
+Teams that want to **ban all uses of `empty()`** — matching the
+[WordPress/performance plugin's stance][wp-perf-1803] — can opt in to
+[`phpstan/phpstan-strict-rules`][strict-rules] locally. Install it per
+component:
+
+```bash
+composer require --dev phpstan/phpstan-strict-rules
+```
+
+Then add a component-local `phpstan.neon` pointing at the strict rules:
+
+```neon
+includes:
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
+```
+
+This enables `empty.notAllowed` plus ~20 other strict rules
+(`disallowedLooseComparison`, `booleansInConditions`, `uselessCast`,
+`noVariableVariables`, etc.). Generating a baseline first is strongly
+recommended — real-world components typically light up with hundreds to
+thousands of findings across the whole strict set.
+
+This is not shipped as a default because the strict-rules package
+activates a broad set of toggles that can't be disabled from the
+consumer config (`checkDynamicProperties`, `reportMaybesInMethodSignatures`,
+etc.), producing an order-of-magnitude finding explosion on most
+codebases. Opt-in keeps the default honest while leaving the door open
+for teams that want full enforcement.
+
+[wp-perf-1803]: https://github.com/WordPress/performance/pull/1803
+[strict-rules]: https://github.com/phpstan/phpstan-strict-rules
+
 ## Debug output
 
 The Playground runner writes a structured log to


### PR DESCRIPTION
## Summary

Closes #233. Trivial docs addition — one subsection in `wordpress/docs/TESTING.md` describing how teams can opt in to full `empty()` / `isset()` style enforcement via `phpstan/phpstan-strict-rules`, matching the stance the [WordPress/performance plugin took][wp-perf-1803].

[wp-perf-1803]: https://github.com/WordPress/performance/pull/1803

## Why this exists

PR #232 shipped PHPStan level 7, which already catches the *provably wrong* uses of `empty()` / `isset()` via built-in rules:

| Rule | Finding count on `intelligence` |
|---|---|
| `empty.variable` | 45 |
| `empty.offset` | 13 |
| `isset.variable` | 30 |
| `isset.offset` | 46 |
| `isset.property` | 45 |
| **Total** | **179** |

That covers the [Weston-concern category][case-study] from the umbrella case study. Teams who want to go further and ban **all** uses of `empty()` need the style-preference rule (`empty.notAllowed`), which ships in the opt-in `phpstan-strict-rules` package.

[case-study]: https://github.com/WordPress/wordpress-develop/pull/11387

## Why not ship it as default

Measured on `intelligence`:

- Level 7 default: **337** findings — actionable.
- Level 7 + full strict-rules include: **30,083** findings — 9,624 `empty.notAllowed` plus ~20,000 transitive strict-rule findings (`disallowedLooseComparison`, `checkDynamicProperties`, `reportMaybesInMethodSignatures`, etc., none of which can be disabled from the consumer config).

90x finding explosion is the wrong default. Opt-in keeps the default honest while documenting the path for teams that want strict enforcement.

## Diff

```
 wordpress/docs/TESTING.md | 40 +++++++++++++++++++++++++++++++++++++++
 1 file changed, 40 insertions(+)
```

Pure docs — zero code changes.

## Related

- Issue: #233
- Replaces the overscoped approach in closed #226
- Umbrella: #228
- Upstream precedent: WordPress/performance#1803

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Drafted the opt-in subsection including the \`composer require\` command, sample \`phpstan.neon\` snippet, and measured rationale (30,083 vs 337 findings on \`intelligence\` — numbers captured during the #226 investigation). Cited upstream precedent to the WordPress/performance PR and linked the \`phpstan-strict-rules\` package.