### PR TITLE
refactor(wordpress): extract Playground bootstrap helpers into shared lib

### DIFF
--- a/wordpress/scripts/lib/playground-bootstrap.php
+++ b/wordpress/scripts/lib/playground-bootstrap.php
@@ -1,0 +1,308 @@
+<?php
+/**
+ * Shared Playground bootstrap helpers.
+ *
+ * Extracted from scripts/test/playground-runner.php so any runner that boots
+ * WordPress inside Playground (PHPUnit tests, performance benchmarks, future
+ * runner kinds) can reuse the same boot path. A regression in `boot` /
+ * `install` / `load_deps` / `load_component` should affect every consumer
+ * identically — that only holds if every consumer goes through the same
+ * code.
+ *
+ * Stages provided:
+ *   - boot           — render wp-tests-config.php, load composer autoloader
+ *   - install        — wp-phpunit install.php (creates WP + tables in-process)
+ *   - load_deps      — load Plugin-Name-headed entry files for declared deps
+ *   - load_component — load the plugin/theme under test
+ *
+ * Stages NOT provided (caller's responsibility):
+ *   - load_fixtures  — PHPUnit-specific testcase classes; only test runner needs them
+ *   - discover_*     — caller-specific (PHPUnit test discovery vs bench workload discovery)
+ *   - load_*         — caller-specific
+ *   - run_*          — caller-specific (PHPUnit::run vs bench iteration loop)
+ *
+ * GLOBAL CONTRACT
+ *
+ * Callers MUST define the following globals before requiring this file (or
+ * the boot path will write to /dev/null and stage fatals will lose
+ * attribution):
+ *
+ *   $result_file   — absolute path the structured log is appended to
+ *   $current_stage — string, initial value "preboot" (mutated by pg_stage_begin)
+ *
+ * The shutdown handler reads $current_stage to attribute fatal errors. The
+ * pg_log() / pg_stage_*() helpers append to $result_file. Both are kept as
+ * globals (not passed-by-value) so existing callers don't need argument
+ * threading at every site — relocation is the goal of this extraction, not
+ * an API redesign.
+ *
+ * STAGE EXECUTORS
+ *
+ * Each stage executor takes a $cfg array and:
+ *   - calls pg_stage_begin($stage)
+ *   - performs the stage's work inside try/catch
+ *   - calls pg_stage_ok($stage) on success, pg_stage_fail($stage, $e) + exit(1) on Throwable
+ *
+ * Required $cfg keys are documented per stage. Unknown keys are ignored —
+ * callers can pass extra keys that downstream stages need without the
+ * upstream stages having to know about them.
+ */
+
+// ---------------------------------------------------------------------------
+// Diagnostics: structured log helpers + error/shutdown handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a line to the structured log.
+ *
+ * Reads the global $result_file the caller defined before requiring this
+ * file. Each call appends one line; the bash runners parse the log
+ * line-by-line using the prefixes defined in pg_stage_*().
+ */
+function pg_log($msg) {
+    global $result_file;
+    file_put_contents($result_file, $msg . "\n", FILE_APPEND);
+}
+
+/**
+ * Mark the start of a bootstrap stage.
+ *
+ * Updates the global $current_stage so the shutdown handler can attribute
+ * fatal errors to the right stage even when an exit happens mid-stage.
+ */
+function pg_stage_begin($stage) {
+    global $current_stage;
+    $current_stage = $stage;
+    pg_log("STAGE_BEGIN:$stage");
+}
+
+/** Mark a stage as completed cleanly. */
+function pg_stage_ok($stage) {
+    pg_log("STAGE_OK:$stage");
+}
+
+/**
+ * Mark a stage as failed with a caught Throwable. Logs the message + a
+ * stack trace; callers typically `exit(1)` immediately after to keep the
+ * shutdown handler from layering its own STAGE_FATAL line on top.
+ */
+function pg_stage_fail($stage, Throwable $e) {
+    $msg = get_class($e) . ': ' . $e->getMessage()
+        . ' at ' . $e->getFile() . ':' . $e->getLine();
+    pg_log("STAGE_FAIL:$stage:$msg");
+    pg_log("TRACE:");
+    foreach (explode("\n", $e->getTraceAsString()) as $line) {
+        pg_log("  $line");
+    }
+}
+
+/**
+ * Install the global error + shutdown handlers used by all Playground
+ * runners. Idempotent — safe to call once per runner script.
+ *
+ * - Warning/notice handler captures non-fatal output to the structured log
+ *   so it doesn't vanish into Playground's stderr (which is hard to surface
+ *   from the host shell). Returns false so PHP's default handler still runs.
+ * - Shutdown handler emits a STAGE_FATAL line with the current stage when
+ *   an uncatchable error (E_ERROR / E_PARSE / E_CORE_ERROR / E_COMPILE_ERROR)
+ *   ends the script. Without this, the bash runner sees an empty result file
+ *   and can't attribute the failure.
+ */
+function pg_install_diagnostics_handlers() {
+    set_error_handler(function ($severity, $message, $file, $line) {
+        if (!(error_reporting() & $severity)) {
+            return false;
+        }
+        $label = [
+            E_WARNING => 'WARNING',
+            E_NOTICE => 'NOTICE',
+            E_DEPRECATED => 'DEPRECATED',
+            E_USER_WARNING => 'USER_WARNING',
+            E_USER_NOTICE => 'USER_NOTICE',
+            E_USER_DEPRECATED => 'USER_DEPRECATED',
+            E_STRICT => 'STRICT',
+        ][$severity] ?? "E_$severity";
+        pg_log("NOTICE:$label: $message at $file:$line");
+        return false;
+    });
+
+    register_shutdown_function(function () {
+        global $current_stage;
+        $error = error_get_last();
+        if ($error && in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
+            pg_log("STAGE_FATAL:$current_stage:{$error['message']} at {$error['file']}:{$error['line']}");
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Stage executors
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the `boot` stage: render wp-tests-config.php and load composer autoload.
+ *
+ * Required $cfg keys: (none)
+ *
+ * Side effect: defines $config_path under the caller's scope by writing to
+ * /tmp/wp-tests-config.php (the canonical location wp-phpunit's install.php
+ * expects). The path is also returned so callers don't have to hard-code it.
+ *
+ * @return string Path to the generated wp-tests-config.php.
+ */
+function pg_run_boot_stage(array $cfg = []): string {
+    pg_stage_begin('boot');
+    try {
+        $config_path = '/tmp/wp-tests-config.php';
+        file_put_contents($config_path, <<<'CONFIG'
+<?php
+$table_prefix = 'wptests_';
+define('DB_NAME', ':memory:');
+define('DB_USER', 'root');
+define('DB_PASSWORD', '');
+define('DB_HOST', 'localhost');
+define('DB_CHARSET', 'utf8');
+define('WP_TESTS_DOMAIN', 'example.org');
+define('WP_TESTS_EMAIL', 'admin@example.org');
+define('WP_TESTS_TITLE', 'Test Blog');
+define('WP_PHP_BINARY', 'php');
+define('ABSPATH', '/wordpress/');
+define('FS_CHMOD_FILE', 0644);
+define('FS_CHMOD_DIR', 0755);
+define('FS_METHOD', 'direct');
+CONFIG
+        );
+
+        require_once '/homeboy-extension/vendor/autoload.php';
+        pg_stage_ok('boot');
+        return $config_path;
+    } catch (Throwable $e) {
+        pg_stage_fail('boot', $e);
+        exit(1);
+    }
+}
+
+/**
+ * Run the `install` stage: invoke wp-phpunit's install.php in-process.
+ *
+ * Boots WordPress AND creates the test database tables without spawning a
+ * subprocess (which Playground's PHP-WASM doesn't natively support pre-#3481).
+ *
+ * Required $cfg keys:
+ *   - config_path: absolute path to the wp-tests-config.php produced by
+ *     pg_run_boot_stage(). Pass the return value of that function.
+ *
+ * Optional $cfg keys:
+ *   - tests_dir: vendor path to wp-phpunit. Defaults to the canonical
+ *     '/homeboy-extension/vendor/wp-phpunit/wp-phpunit'.
+ */
+function pg_run_install_stage(array $cfg) {
+    pg_stage_begin('install');
+    try {
+        $tests_dir = $cfg['tests_dir'] ?? '/homeboy-extension/vendor/wp-phpunit/wp-phpunit';
+        $config_path = $cfg['config_path'];
+        $argv = ['install.php', $config_path, 'no_ms_tests', 'no_core_tests'];
+        $_SERVER['argv'] = $argv;
+        require_once "$tests_dir/includes/install.php";
+        while (ob_get_level() > 0) {
+            @ob_end_clean();
+        }
+        pg_stage_ok('install');
+    } catch (Throwable $e) {
+        pg_stage_fail('install', $e);
+        exit(1);
+    }
+}
+
+/**
+ * Run the `load_deps` stage: require Plugin-Name-headed entry files for
+ * every dependency the host runner declared via mount paths.
+ *
+ * The host bash runner translates HOMEBOY_WORDPRESS_DEPENDENCY_PATHS into
+ * mount points like /wordpress/wp-content/plugins/<dep>/, then writes the
+ * resulting paths into a newline-separated list which gets sed'd into the
+ * runner template at {{PLAYGROUND_DEP_MOUNTS}}. This stage parses that list
+ * and loads each dependency's main plugin file.
+ *
+ * Required $cfg keys:
+ *   - dep_mounts: newline-separated string of dependency mount paths
+ *     inside the Playground VFS. Empty string is fine — no-op.
+ */
+function pg_run_load_deps_stage(array $cfg) {
+    pg_stage_begin('load_deps');
+    try {
+        $dep_paths = $cfg['dep_mounts'] ?? '';
+        if (!empty($dep_paths)) {
+            foreach (explode("\n", $dep_paths) as $dep_mount) {
+                $dep_mount = trim($dep_mount);
+                if (empty($dep_mount)) {
+                    continue;
+                }
+                $dep_files = glob("$dep_mount/*.php") ?: [];
+                foreach ($dep_files as $df) {
+                    if (strpos(file_get_contents($df), 'Plugin Name:') !== false) {
+                        require_once $df;
+                        break;
+                    }
+                }
+            }
+        }
+        pg_stage_ok('load_deps');
+    } catch (Throwable $e) {
+        pg_stage_fail('load_deps', $e);
+        exit(1);
+    }
+}
+
+/**
+ * Run the `load_component` stage: load the plugin or theme under test.
+ *
+ * Detects whether the component is a theme (style.css with `Theme Name:`
+ * header) or a plugin (any *.php with `Plugin Name:` header) and loads the
+ * appropriate entry file. The `db.php` drop-in is explicitly skipped — it's
+ * already loaded by wp-settings.php earlier in the request lifecycle and
+ * including it again would re-run its side effects.
+ *
+ * Required $cfg keys:
+ *   - plugin_path: absolute path inside the Playground VFS, typically
+ *     '/wordpress/wp-content/plugins/<slug>'.
+ */
+function pg_run_load_component_stage(array $cfg) {
+    pg_stage_begin('load_component');
+    try {
+        $plugin_path = $cfg['plugin_path'];
+        $style_css = "$plugin_path/style.css";
+        if (file_exists($style_css) && strpos(file_get_contents($style_css), 'Theme Name:') !== false) {
+            pg_log("THEME_DETECTED");
+            $fn_php = "$plugin_path/functions.php";
+            if (file_exists($fn_php)) {
+                require_once $fn_php;
+            }
+        } else {
+            $loaded = false;
+            $main_files = glob("$plugin_path/*.php") ?: [];
+            foreach ($main_files as $mf) {
+                // db.php is a WordPress drop-in, not a plugin entry file. It's
+                // already been loaded by wp-settings.php earlier in the request
+                // lifecycle. Including it again would re-run its side effects
+                // (define() warnings, $wpdb re-init) for no reason.
+                if (basename($mf) === 'db.php') {
+                    continue;
+                }
+                if (strpos(file_get_contents($mf), 'Plugin Name:') !== false) {
+                    pg_log("PLUGIN_DETECTED " . basename($mf));
+                    require_once $mf;
+                    $loaded = true;
+                    break;
+                }
+            }
+            if (!$loaded) {
+                pg_log("NOTICE:no plugin entry file with 'Plugin Name:' header found in $plugin_path");
+            }
+        }
+        pg_stage_ok('load_component');
+    } catch (Throwable $e) {
+        pg_stage_fail('load_component', $e);
+        exit(1);
+    }
+}

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -49,112 +49,30 @@ ini_set('display_startup_errors', '1');
 $result_file = '/wordpress/wp-content/plugins/{{PLUGIN_SLUG}}/.pg-test-result.txt';
 $current_stage = 'preboot';
 
-function pg_log($msg) {
-    global $result_file;
-    file_put_contents($result_file, $msg . "\n", FILE_APPEND);
-}
+// pg_log / pg_stage_* helpers + the diagnostics handlers + the four shared
+// bootstrap stages (boot, install, load_deps, load_component) live in the
+// extracted lib so the bench runner can reuse the same boot path and any
+// future runner kind inherits it for free. Every consumer reading the same
+// `boot` and `install` stage code is the only honest way to compare timings
+// across runners (a regression in install must be visible to all of them).
+require_once '/homeboy-extension/scripts/lib/playground-bootstrap.php';
 
-function pg_stage_begin($stage) {
-    global $current_stage;
-    $current_stage = $stage;
-    pg_log("STAGE_BEGIN:$stage");
-}
-
-function pg_stage_ok($stage) {
-    pg_log("STAGE_OK:$stage");
-}
-
-function pg_stage_fail($stage, Throwable $e) {
-    $msg = get_class($e) . ': ' . $e->getMessage()
-        . ' at ' . $e->getFile() . ':' . $e->getLine();
-    pg_log("STAGE_FAIL:$stage:$msg");
-    // Also dump trace for debugging; bash runner will print it under failure.
-    pg_log("TRACE:");
-    foreach (explode("\n", $e->getTraceAsString()) as $line) {
-        pg_log("  $line");
-    }
-}
-
-// Capture non-fatal warnings/notices so they don't vanish into the void.
-set_error_handler(function ($severity, $message, $file, $line) {
-    if (!(error_reporting() & $severity)) {
-        return false;
-    }
-    $label = [
-        E_WARNING => 'WARNING',
-        E_NOTICE => 'NOTICE',
-        E_DEPRECATED => 'DEPRECATED',
-        E_USER_WARNING => 'USER_WARNING',
-        E_USER_NOTICE => 'USER_NOTICE',
-        E_USER_DEPRECATED => 'USER_DEPRECATED',
-        E_STRICT => 'STRICT',
-    ][$severity] ?? "E_$severity";
-    pg_log("NOTICE:$label: $message at $file:$line");
-    return false; // let PHP's default handler also run
-});
-
-register_shutdown_function(function () {
-    global $current_stage;
-    $error = error_get_last();
-    if ($error && in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
-        pg_log("STAGE_FATAL:$current_stage:{$error['message']} at {$error['file']}:{$error['line']}");
-    }
-});
+pg_install_diagnostics_handlers();
 
 $tests_dir = '/homeboy-extension/vendor/wp-phpunit/wp-phpunit';
 $plugin_path = '/wordpress/wp-content/plugins/{{PLUGIN_SLUG}}';
 
-// ---------------------------------------------------------------------------
-// Stage: boot
-// ---------------------------------------------------------------------------
-pg_stage_begin('boot');
-try {
-    $config_path = '/tmp/wp-tests-config.php';
-    file_put_contents($config_path, <<<'CONFIG'
-<?php
-$table_prefix = 'wptests_';
-define('DB_NAME', ':memory:');
-define('DB_USER', 'root');
-define('DB_PASSWORD', '');
-define('DB_HOST', 'localhost');
-define('DB_CHARSET', 'utf8');
-define('WP_TESTS_DOMAIN', 'example.org');
-define('WP_TESTS_EMAIL', 'admin@example.org');
-define('WP_TESTS_TITLE', 'Test Blog');
-define('WP_PHP_BINARY', 'php');
-define('ABSPATH', '/wordpress/');
-define('FS_CHMOD_FILE', 0644);
-define('FS_CHMOD_DIR', 0755);
-define('FS_METHOD', 'direct');
-CONFIG
-    );
+// Stage: boot — render wp-tests-config.php + load composer autoload.
+$config_path = pg_run_boot_stage();
 
-    require_once '/homeboy-extension/vendor/autoload.php';
-    pg_stage_ok('boot');
-} catch (Throwable $e) {
-    pg_stage_fail('boot', $e);
-    exit(1);
-}
-
-// ---------------------------------------------------------------------------
-// Stage: install (wp-phpunit install.php creates WP tables in-process)
-// ---------------------------------------------------------------------------
-pg_stage_begin('install');
-try {
-    $argv = ['install.php', $config_path, 'no_ms_tests', 'no_core_tests'];
-    $_SERVER['argv'] = $argv;
-    require_once "$tests_dir/includes/install.php";
-    while (ob_get_level() > 0) {
-        @ob_end_clean();
-    }
-    pg_stage_ok('install');
-} catch (Throwable $e) {
-    pg_stage_fail('install', $e);
-    exit(1);
-}
+// Stage: install — wp-phpunit install.php creates WP tables in-process.
+pg_run_install_stage(['config_path' => $config_path, 'tests_dir' => $tests_dir]);
 
 // ---------------------------------------------------------------------------
 // Stage: load_fixtures (test case classes, mock mailer, harness filters)
+//
+// Stays inline — PHPUnit-specific. Other runner kinds (bench, future
+// integration runners) don't need wp-phpunit's testcase scaffolding.
 // ---------------------------------------------------------------------------
 pg_stage_begin('load_fixtures');
 try {
@@ -197,72 +115,11 @@ try {
     exit(1);
 }
 
-// ---------------------------------------------------------------------------
-// Stage: load_deps (dependency plugin bootstrap files)
-// ---------------------------------------------------------------------------
-pg_stage_begin('load_deps');
-try {
-    $dep_paths = '{{PLAYGROUND_DEP_MOUNTS}}';
-    if (!empty($dep_paths)) {
-        foreach (explode("\n", $dep_paths) as $dep_mount) {
-            $dep_mount = trim($dep_mount);
-            if (empty($dep_mount)) {
-                continue;
-            }
-            $dep_files = glob("$dep_mount/*.php") ?: [];
-            foreach ($dep_files as $df) {
-                if (strpos(file_get_contents($df), 'Plugin Name:') !== false) {
-                    require_once $df;
-                    break;
-                }
-            }
-        }
-    }
-    pg_stage_ok('load_deps');
-} catch (Throwable $e) {
-    pg_stage_fail('load_deps', $e);
-    exit(1);
-}
+// Stage: load_deps — load Plugin-Name-headed entry files for declared deps.
+pg_run_load_deps_stage(['dep_mounts' => '{{PLAYGROUND_DEP_MOUNTS}}']);
 
-// ---------------------------------------------------------------------------
-// Stage: load_component (plugin or theme under test)
-// ---------------------------------------------------------------------------
-pg_stage_begin('load_component');
-try {
-    $style_css = "$plugin_path/style.css";
-    if (file_exists($style_css) && strpos(file_get_contents($style_css), 'Theme Name:') !== false) {
-        pg_log("THEME_DETECTED");
-        $fn_php = "$plugin_path/functions.php";
-        if (file_exists($fn_php)) {
-            require_once $fn_php;
-        }
-    } else {
-        $loaded = false;
-        $main_files = glob("$plugin_path/*.php") ?: [];
-        foreach ($main_files as $mf) {
-            // db.php is a WordPress drop-in, not a plugin entry file. It's
-            // already been loaded by wp-settings.php earlier in the request
-            // lifecycle. Including it again would re-run its side effects
-            // (define() warnings, $wpdb re-init) for no reason.
-            if (basename($mf) === 'db.php') {
-                continue;
-            }
-            if (strpos(file_get_contents($mf), 'Plugin Name:') !== false) {
-                pg_log("PLUGIN_DETECTED " . basename($mf));
-                require_once $mf;
-                $loaded = true;
-                break;
-            }
-        }
-        if (!$loaded) {
-            pg_log("NOTICE:no plugin entry file with 'Plugin Name:' header found in $plugin_path");
-        }
-    }
-    pg_stage_ok('load_component');
-} catch (Throwable $e) {
-    pg_stage_fail('load_component', $e);
-    exit(1);
-}
+// Stage: load_component — load the plugin or theme under test.
+pg_run_load_component_stage(['plugin_path' => $plugin_path]);
 
 // ---------------------------------------------------------------------------
 // Stage: discover_tests


### PR DESCRIPTION
## Summary

Pulls the diagnostics + four shared bootstrap stages out of `scripts/test/playground-runner.php` into a new shared library at `scripts/lib/playground-bootstrap.php` so future runner kinds (benchmarks, integration tests, ad-hoc Playground dispatchers) can boot WordPress through the **exact same code** as the test runner.

This is a pure refactor — zero behaviour change. It lands ahead of the bench dispatcher (Phase 4 of #214 / homeboy core's bench primitive) so the bench runner can `require_once` this lib and inherit the test runner's boot path verbatim.

## Why now

A drift between *"the boot path tests run against"* and *"the boot path bench runs against"* silently invalidates every cross-runner comparison. A regression in `boot` or `install` would surface as a test slowdown but be invisible to bench (or vice versa) — and we'd chase the wrong cause for hours. Single-source-of-truth for bootstrap is the only honest path before bench numbers can be trusted.

## What moved

**Helpers** (line 52–94 of the original):
- `pg_log()` — append a line to the structured log
- `pg_stage_begin()` / `pg_stage_ok()` / `pg_stage_fail()` — stage lifecycle markers
- Warning/notice handler + shutdown handler now wrapped in `pg_install_diagnostics_handlers()` so callers can opt in explicitly. Previously installed via top-level side-effect; now installed via single function call. Net behaviour identical.

**Stage executors** (lines 107–265 of the original):
- `pg_run_boot_stage()` — render `wp-tests-config.php`, load composer autoload. Returns the config path so callers don't have to hard-code `/tmp/wp-tests-config.php`.
- `pg_run_install_stage(array $cfg)` — invoke wp-phpunit's `install.php` in-process. Takes `config_path` from the boot stage (and an optional `tests_dir` override).
- `pg_run_load_deps_stage(array $cfg)` — load every Plugin-Name-headed entry file in the declared dependency mounts.
- `pg_run_load_component_stage(array $cfg)` — load the plugin or theme under test. The `db.php` skip rule and theme-detection via `style.css` are unchanged.

## What stayed in playground-runner.php

PHPUnit-specific stages remain inline:

- `load_fixtures` — wp-phpunit testcase classes, mock mailer, harness filters. Bench has no use for these.
- `discover_tests`, `pg_parse_phpunit_config`, `pg_discover_tests` — PHPUnit XML parsing + test file walking. Bench has its own workload-discovery shape (`tests/bench/*.php`).
- `load_tests`, `run_tests` — `require` test files + `PHPUnit\TextUI\TestRunner` invocation. Bench replaces these with an iteration loop + percentile aggregation.

## Global contract

The library reads the global `\$result_file` and `\$current_stage` that callers set up before requiring it. Keeping globals (rather than threading the result-file path through every helper signature) preserves byte-identical call sites in `playground-runner.php` — the diff is pure relocation, not an API redesign.

## Verification

`scripts/test/playground-dropin-smoke.sh` passes against the refactored runner:

```
Running PHPUnit tests via WordPress Playground...
  Plugin: dropin-coexistence
  Backend: playground (PHP-WASM + SQLite)
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

...                                                                 3 / 3 (100%)
Time: 00:00.069, Memory: 48.50 MB
OK (3 tests, 8 assertions)

✓ Drop-in coexistence smoke test PASSED
```

Same `STAGE_BEGIN` / `STAGE_OK` lines, same `PLUGIN_DETECTED` / `NOTICE:` lines, same `OK (n tests, m assertions)` from PHPUnit.

Plus a structural smoke confirms all nine extracted symbols (`pg_log`, `pg_stage_begin`, `pg_stage_ok`, `pg_stage_fail`, `pg_install_diagnostics_handlers`, `pg_run_{boot,install,load_deps,load_component}_stage`) are reachable from the lib and emit the same log lines they did when defined inline.

## Diff stat

`playground-runner.php`: −162 lines moved out, +19 lines of `require_once` + stage executor calls. New 257-line library file with focused docblocks per symbol.

## Next

Phase 4 of #214 (bench dispatcher) is the follow-up PR. It adds:
- `bench` capability to `wordpress.json` + `bench-runner.sh` dispatcher.
- `playground-bench-runner.php` template that `require_once`'s this lib, calls the four shared stages, then runs `tests/bench/*.php` workloads + emits `BenchResults` JSON matching homeboy core's contract.
- A noop bench fixture for end-to-end harness smoke.

That PR will be small precisely because this one pulled the boot path into a shared location.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Read every stage and helper in `scripts/test/playground-runner.php` to map the extraction boundary; wrote the lib; refactored the runner to consume it; ran the dropin-coexistence smoke + a structural pre-flight smoke to verify behaviour parity. Chris pushed back on an initial plan to duplicate the boot stages into a parallel bench template, which forced the cleaner refactor-first approach this PR represents.