### PR TITLE
fix(ci): align release matrix with extensions on disk

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -18,14 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         component:
-          - github
-          - homebrew
-          - kimaki
+          - go
           - nodejs
-          - openclaw
-          - plasma-shield
           - rust
-          - sweatpants
           - swift
           - wordpress
     steps:


### PR DESCRIPTION
## Summary

Followup to #240. After the purge merged, the release matrix in `.github/workflows/homeboy.yml` was still listing the six deleted extension slugs (`github`, `homebrew`, `sweatpants`, `kimaki`, `openclaw`, `plasma-shield`). The auto-release run on the merge commit dispatched release jobs for those slugs anyway — they exited cleanly because `homeboy-action` no-ops on missing component dirs, but the wasted parallel jobs are noise.

This PR also adds `go` to the matrix. The `go` extension has been on disk since #157-ish but was never wired into the release pipeline — its `go.json` is stuck at v1.0.0 with no path to a release.

## After

```yaml
matrix:
  component:
    - go
    - nodejs
    - rust
    - swift
    - wordpress
```

Five surviving project-type primitives, in alphabetical order. Matches the inventory documented in the README.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** spotting that the post-merge release run still dispatched jobs for the deleted slugs (despite reporting success after homeboy-action retried), and drafting the matrix update.