### PR TITLE
feat(wordpress): multi-line comment style sniff (closes #239)

### DIFF
--- a/wordpress/HomeboyWordPress/Sniffs/Commenting/MultiLineInlineCommentSniff.php
+++ b/wordpress/HomeboyWordPress/Sniffs/Commenting/MultiLineInlineCommentSniff.php
@@ -1,0 +1,396 @@
+<?php
+/**
+ * Enforces WordPress Inline Documentation Standards section 5.2:
+ *
+ * 1. Multi-line comments must use slash-star block style, not consecutive `//` lines.
+ * 2. Multi-line prose comments must start with a single asterisk, not a double
+ *    asterisk (which is reserved for DocBlocks).
+ *
+ * @link https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#5-2-multi-line-comments
+ *
+ * @package HomeboyWordPress
+ */
+
+namespace HomeboyWordPress\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Custom sniff implementing WordPress inline-docs section 5.2 rules.
+ *
+ * Two independent detections live under this sniff so they can be excluded
+ * separately via `<exclude name="...ConsecutiveSingleLine"/>` etc.:
+ *
+ *  - ConsecutiveSingleLine     2+ adjacent `//` lines that should be a block comment.
+ *  - DoubleAsteriskNonDocBlock A double-asterisk block used for prose, not a declaration.
+ */
+class MultiLineInlineCommentSniff implements Sniff {
+
+	/**
+	 * Minimum run length to trigger Detection A. Default 2.
+	 *
+	 * @var int
+	 */
+	public $minimumRunLength = 2;
+
+	/**
+	 * Tokens that, when they immediately follow a `/**` block, mean the block is
+	 * a legitimate DocBlock (so Detection B should NOT fire).
+	 *
+	 * Mirrors the lookahead used by Squiz.Commenting.BlockComment plus the WP
+	 * handbook's list of declaration contexts (function, class, method, property,
+	 * const, require/include).
+	 *
+	 * @var array<int|string,bool>
+	 */
+	private $docBlockContextTokens = array();
+
+	/**
+	 * Returns the tokens this sniff registers for.
+	 *
+	 * @return array<int|string>
+	 */
+	public function register() {
+		// Build the DocBlock-context lookup once.
+		$this->docBlockContextTokens                   = Tokens::$scopeModifiers;
+		$this->docBlockContextTokens[ T_FUNCTION ]     = true;
+		$this->docBlockContextTokens[ T_CLASS ]        = true;
+		$this->docBlockContextTokens[ T_INTERFACE ]    = true;
+		$this->docBlockContextTokens[ T_TRAIT ]        = true;
+		$this->docBlockContextTokens[ T_ENUM ]         = true;
+		$this->docBlockContextTokens[ T_FINAL ]        = true;
+		$this->docBlockContextTokens[ T_STATIC ]       = true;
+		$this->docBlockContextTokens[ T_ABSTRACT ]     = true;
+		$this->docBlockContextTokens[ T_CONST ]        = true;
+		$this->docBlockContextTokens[ T_VAR ]          = true;
+		$this->docBlockContextTokens[ T_REQUIRE ]      = true;
+		$this->docBlockContextTokens[ T_REQUIRE_ONCE ] = true;
+		$this->docBlockContextTokens[ T_INCLUDE ]      = true;
+		$this->docBlockContextTokens[ T_INCLUDE_ONCE ] = true;
+		if ( defined( 'T_READONLY' ) ) {
+			$this->docBlockContextTokens[ T_READONLY ] = true;
+		}
+
+		return array(
+			T_COMMENT,
+			T_DOC_COMMENT_OPEN_TAG,
+		);
+	}
+
+	/**
+	 * Dispatches to Detection A or B based on the token kind.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the stack.
+	 *
+	 * @return int|void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		if ( T_DOC_COMMENT_OPEN_TAG === $tokens[ $stackPtr ]['code'] ) {
+			$this->processDoubleAsterisk( $phpcsFile, $stackPtr );
+			return;
+		}
+
+		/*
+		 * T_COMMENT — only `//` runs are interesting here. Block comments also
+		 * arrive as T_COMMENT but are already the desired output style.
+		 */
+		$content = $tokens[ $stackPtr ]['content'];
+		if ( substr( $content, 0, 2 ) !== '//' ) {
+			return;
+		}
+
+		return $this->processConsecutiveSingleLine( $phpcsFile, $stackPtr );
+	}
+
+	/**
+	 * Detection A — flag a run of 2+ adjacent `//` lines.
+	 *
+	 * Returns the position to skip to so PHPCS doesn't re-process the same run.
+	 *
+	 * @param File $phpcsFile File being scanned.
+	 * @param int  $stackPtr  Position of the first `//` comment in the run.
+	 *
+	 * @return int
+	 */
+	private function processConsecutiveSingleLine( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// Skip end-of-line trailing comments (`$x = 1; // explanation`).
+		if ( $this->isTrailingComment( $phpcsFile, $stackPtr ) ) {
+			return ( $stackPtr + 1 );
+		}
+
+		// Skip annotation lines that happen to start the run.
+		if ( $this->isAnnotationLine( $tokens[ $stackPtr ]['content'] ) ) {
+			return ( $stackPtr + 1 );
+		}
+
+		// Walk forward collecting consecutive `//` tokens on adjacent lines.
+		$run        = array( $stackPtr );
+		$lastLine   = $tokens[ $stackPtr ]['line'];
+		$ptr        = $stackPtr;
+		$tokenCount = count( $tokens );
+
+		for ( $ptr = ( $stackPtr + 1 ); $ptr < $tokenCount; $ptr++ ) {
+			$code = $tokens[ $ptr ]['code'];
+
+			if ( T_WHITESPACE === $code ) {
+				continue;
+			}
+
+			if ( T_COMMENT !== $code ) {
+				break;
+			}
+
+			$candidateContent = $tokens[ $ptr ]['content'];
+			if ( substr( $candidateContent, 0, 2 ) !== '//' ) {
+				break;
+			}
+
+			if ( ( $tokens[ $ptr ]['line'] - 1 ) !== $lastLine ) {
+				break;
+			}
+
+			if ( $this->isTrailingComment( $phpcsFile, $ptr ) ) {
+				break;
+			}
+
+			if ( $this->isAnnotationLine( $candidateContent ) ) {
+				break;
+			}
+
+			$run[]    = $ptr;
+			$lastLine = $tokens[ $ptr ]['line'];
+		}
+
+		if ( count( $run ) < $this->minimumRunLength ) {
+			return ( end( $run ) + 1 );
+		}
+
+		/*
+		 * Heuristic: leave commented-out code alone — Squiz.PHP.CommentedOutCode
+		 * already covers it. Only skip if EVERY line in the run looks like code.
+		 */
+		if ( $this->runLooksLikeCommentedOutCode( $tokens, $run ) ) {
+			return ( end( $run ) + 1 );
+		}
+
+		$error = 'Multi-line comments should use /* */ block style per WP inline docs §5.2; found %d consecutive // lines.';
+		$data  = array( count( $run ) );
+		$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'ConsecutiveSingleLine', $data );
+
+		if ( true === $fix ) {
+			$this->fixConsecutiveSingleLine( $phpcsFile, $run );
+		}
+
+		return ( end( $run ) + 1 );
+	}
+
+	/**
+	 * Detection B — flag `/**` blocks that aren't preceding a declaration.
+	 *
+	 * Lookahead pattern cribbed from Squiz.Commenting.BlockCommentSniff::process().
+	 *
+	 * @param File $phpcsFile File being scanned.
+	 * @param int  $stackPtr  Position of the T_DOC_COMMENT_OPEN_TAG.
+	 *
+	 * @return void
+	 */
+	private function processDoubleAsterisk( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// Walk forward past whitespace, comments, and attribute groups.
+		$nextToken = $stackPtr;
+		do {
+			$nextToken = $phpcsFile->findNext( Tokens::$emptyTokens, ( $nextToken + 1 ), null, true );
+			if ( false === $nextToken ) {
+				break;
+			}
+
+			if ( defined( 'T_ATTRIBUTE' ) && T_ATTRIBUTE === $tokens[ $nextToken ]['code'] ) {
+				$nextToken = $tokens[ $nextToken ]['attribute_closer'];
+				continue;
+			}
+
+			break;
+		} while ( true );
+
+		if ( false !== $nextToken && isset( $this->docBlockContextTokens[ $tokens[ $nextToken ]['code'] ] ) === true ) {
+			// Legitimate DocBlock — leave it alone.
+			return;
+		}
+
+		// File-level DocBlock immediately after `<?php` is a legitimate use too.
+		$prevToken = $phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+		if ( false !== $prevToken && T_OPEN_TAG === $tokens[ $prevToken ]['code'] ) {
+			return;
+		}
+
+		$error = 'Multi-line prose comments must use /* (single asterisk), not /** (reserved for DocBlocks). See WP inline docs §5.2.';
+		$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'DoubleAsteriskNonDocBlock' );
+
+		if ( true === $fix ) {
+			$phpcsFile->fixer->replaceToken( $stackPtr, '/*' );
+		}
+	}
+
+	/**
+	 * Whether the comment at $stackPtr sits on the same line as preceding code.
+	 *
+	 * @param File $phpcsFile File being scanned.
+	 * @param int  $stackPtr  Token position.
+	 *
+	 * @return bool
+	 */
+	private function isTrailingComment( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+		$line   = $tokens[ $stackPtr ]['line'];
+
+		for ( $i = ( $stackPtr - 1 ); $i >= 0; $i-- ) {
+			if ( $tokens[ $i ]['line'] !== $line ) {
+				return false;
+			}
+
+			if ( T_WHITESPACE === $tokens[ $i ]['code'] ) {
+				continue;
+			}
+
+			if ( T_OPEN_TAG === $tokens[ $i ]['code'] ) {
+				return false;
+			}
+
+			// Any other token on the same line means this is a trailing comment.
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether a comment line is a tooling annotation that must not be rewritten.
+	 *
+	 * @param string $content Raw comment token content (still has leading `//`).
+	 *
+	 * @return bool
+	 */
+	private function isAnnotationLine( $content ) {
+		$trimmed = ltrim( $content, '/' );
+		$trimmed = ltrim( $trimmed );
+
+		if ( '' === $trimmed ) {
+			return false;
+		}
+
+		$lower = strtolower( $trimmed );
+
+		if ( strpos( $lower, 'phpcs:' ) === 0 ) {
+			return true;
+		}
+
+		if ( strpos( $lower, 'translators:' ) === 0 ) {
+			return true;
+		}
+
+		/*
+		 * `//phpstan-ignore-line`, `//psalm-suppress`, etc. — no space after `//`.
+		 * Match against the raw token content, not the trimmed body.
+		 */
+		$rawLower = strtolower( $content );
+		if ( strpos( $rawLower, '//phpstan-' ) === 0 || strpos( $rawLower, '// phpstan-' ) === 0 ) {
+			return true;
+		}
+
+		if ( strpos( $rawLower, '//psalm-' ) === 0 || strpos( $rawLower, '// psalm-' ) === 0 ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Heuristic: every line in the run looks like commented-out PHP code.
+	 *
+	 * Defers to Squiz.PHP.CommentedOutCode for the actual finding.
+	 *
+	 * @param array<int,array<string,mixed>> $tokens The full token list.
+	 * @param array<int,int>                 $run    Token positions in the run.
+	 *
+	 * @return bool
+	 */
+	private function runLooksLikeCommentedOutCode( array $tokens, array $run ) {
+		$signals = array( ';', '{', '}', '<?php', '->', '::', '=>' );
+
+		foreach ( $run as $ptr ) {
+			$body = ltrim( $tokens[ $ptr ]['content'], '/' );
+			$body = trim( $body );
+
+			$matched = false;
+			foreach ( $signals as $signal ) {
+				if ( strpos( $body, $signal ) !== false ) {
+					$matched = true;
+					break;
+				}
+			}
+
+			if ( false === $matched ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Replaces a run of `//` comments with a `/* ... *\/` block, preserving indent.
+	 *
+	 * @param File           $phpcsFile File being fixed.
+	 * @param array<int,int> $run       Token positions of the comments in the run.
+	 *
+	 * @return void
+	 */
+	private function fixConsecutiveSingleLine( File $phpcsFile, array $run ) {
+		$tokens = $phpcsFile->getTokens();
+		$eol    = $phpcsFile->eolChar;
+
+		$firstPtr = $run[0];
+		$indent   = '';
+		if ( $firstPtr > 0 && T_WHITESPACE === $tokens[ $firstPtr - 1 ]['code'] ) {
+			$prev = $tokens[ $firstPtr - 1 ]['content'];
+			// `content` for an indent whitespace token is the run of leading spaces/tabs.
+			$lastNl = strrpos( $prev, "\n" );
+			if ( false !== $lastNl ) {
+				$indent = substr( $prev, $lastNl + 1 );
+			} else {
+				$indent = $prev;
+			}
+		}
+
+		$bodyLines = array();
+		foreach ( $run as $ptr ) {
+			$line = $tokens[ $ptr ]['content'];
+			// Strip trailing newline; we'll re-emit with $eol.
+			$line = rtrim( $line, "\r\n" );
+			// Strip the leading `//` and one optional space.
+			$line        = preg_replace( '#^//[ \t]?#', '', $line );
+			$bodyLines[] = $line;
+		}
+
+		$replacement = '/*' . $eol;
+		foreach ( $bodyLines as $line ) {
+			$replacement .= $indent . ' * ' . $line . $eol;
+		}
+		$replacement .= $indent . ' */' . $eol;
+
+		$phpcsFile->fixer->beginChangeset();
+		$phpcsFile->fixer->replaceToken( $firstPtr, $replacement );
+		for ( $i = 1, $n = count( $run ); $i < $n; $i++ ) {
+			$phpcsFile->fixer->replaceToken( $run[ $i ], '' );
+		}
+		$phpcsFile->fixer->endChangeset();
+	}
+}

--- a/wordpress/HomeboyWordPress/Tests/Commenting/MultiLineInlineCommentUnitTest.inc
+++ b/wordpress/HomeboyWordPress/Tests/Commenting/MultiLineInlineCommentUnitTest.inc
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Unit-test fixture for HomeboyWordPress.Commenting.MultiLineInlineComment.
+ *
+ * Each labelled section exercises one rule path. Expected violation lines
+ * are tracked in MultiLineInlineCommentUnitTest.php.
+ *
+ * @package HomeboyWordPress
+ */
+
+/* Section: PASS — single-line // is fine on its own. */
+// This is one comment on a single line.
+$single = 1;
+
+$trailing = 2; // EOL trailing comment is allowed even on multiple statements.
+$another  = 3; // Trailing on consecutive lines is still trailing, not a run.
+
+/* Section: PASS — tooling annotations are skipped. */
+// phpcs:disable WordPress.Security.NonceVerification.Missing
+// phpcs:enable WordPress.Security.NonceVerification.Missing
+// translators: %s is the user name.
+//phpstan-ignore-next-line
+//psalm-suppress UnusedVariable
+
+/* Section: FAIL A — 2-line consecutive // run. */
+// First prose line that should be a block comment.
+// Second prose line that joins it.
+$two_line = 'fail A 2-line';
+
+/* Section: FAIL A — 4-line run mirrors WP-develop #11387 review finding 3. */
+// Use a query where have_posts() is true but wp_list_pluck()
+// returns an empty array because the posts array contains scalar
+// values (neither objects nor arrays). Confirms the bug surface
+// from WordPress/wordpress-develop#11387 review finding 3.
+$four_line = 'fail A 4-line';
+
+function legitimate_function_with_docblock() {
+	return true;
+}
+
+/**
+ * Legitimate function DocBlock — must NOT trigger Detection B.
+ *
+ * @return bool
+ */
+function declared_after_docblock() {
+	/** Detection B fail: prose double-asterisk single-line inside body. */
+	$inside = 1;
+
+	/**
+	 * Detection B fail: multi-line prose double-asterisk between statements.
+	 * Should be a single-asterisk block comment per inline-docs section 5.2.
+	 */
+	$between = 2;
+
+	return ( $inside === 1 && $between === 2 );
+}

--- a/wordpress/HomeboyWordPress/Tests/Commenting/MultiLineInlineCommentUnitTest.inc.fixed
+++ b/wordpress/HomeboyWordPress/Tests/Commenting/MultiLineInlineCommentUnitTest.inc.fixed
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Unit-test fixture for HomeboyWordPress.Commenting.MultiLineInlineComment.
+ *
+ * Each labelled section exercises one rule path. Expected violation lines
+ * are tracked in MultiLineInlineCommentUnitTest.php.
+ *
+ * @package HomeboyWordPress
+ */
+
+/* Section: PASS — single-line // is fine on its own. */
+// This is one comment on a single line.
+$single = 1;
+
+$trailing = 2; // EOL trailing comment is allowed even on multiple statements.
+$another  = 3; // Trailing on consecutive lines is still trailing, not a run.
+
+/* Section: PASS — tooling annotations are skipped. */
+// phpcs:disable WordPress.Security.NonceVerification.Missing
+// phpcs:enable WordPress.Security.NonceVerification.Missing
+// translators: %s is the user name.
+//phpstan-ignore-next-line
+//psalm-suppress UnusedVariable
+
+/* Section: FAIL A — 2-line consecutive // run. */
+/*
+ * First prose line that should be a block comment.
+ * Second prose line that joins it.
+ */
+$two_line = 'fail A 2-line';
+
+/* Section: FAIL A — 4-line run mirrors WP-develop #11387 review finding 3. */
+/*
+ * Use a query where have_posts() is true but wp_list_pluck()
+ * returns an empty array because the posts array contains scalar
+ * values (neither objects nor arrays). Confirms the bug surface
+ * from WordPress/wordpress-develop#11387 review finding 3.
+ */
+$four_line = 'fail A 4-line';
+
+function legitimate_function_with_docblock() {
+	return true;
+}
+
+/**
+ * Legitimate function DocBlock — must NOT trigger Detection B.
+ *
+ * @return bool
+ */
+function declared_after_docblock() {
+	/* Detection B fail: prose double-asterisk single-line inside body. */
+	$inside = 1;
+
+	/*
+	 * Detection B fail: multi-line prose double-asterisk between statements.
+	 * Should be a single-asterisk block comment per inline-docs section 5.2.
+	 */
+	$between = 2;
+
+	return ( $inside === 1 && $between === 2 );
+}

--- a/wordpress/HomeboyWordPress/Tests/Commenting/MultiLineInlineCommentUnitTest.php
+++ b/wordpress/HomeboyWordPress/Tests/Commenting/MultiLineInlineCommentUnitTest.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Unit test for HomeboyWordPress.Commenting.MultiLineInlineComment.
+ *
+ * Drives PHPCS as a subprocess against the .inc fixture, asserts the JSON
+ * report shape, then runs phpcbf and diffs the output against the .fixed
+ * fixture.
+ *
+ * Why a subprocess test instead of `AbstractSniffUnitTest`:
+ * the repo's PHPUnit harness runs inside WordPress Playground (PHP-WASM) where
+ * `proc_open` is available but PHPCS' bundled test bootstrap is not loaded.
+ * Driving the installed `vendor/bin/phpcs` binary gives identical fidelity
+ * with much less coupling.
+ *
+ * @package HomeboyWordPress
+ */
+
+declare( strict_types=1 );
+
+namespace HomeboyWordPress\Tests\Commenting;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \HomeboyWordPress\Sniffs\Commenting\MultiLineInlineCommentSniff
+ */
+final class MultiLineInlineCommentUnitTest extends TestCase {
+
+	/**
+	 * Path to the fixture under test.
+	 *
+	 * @var string
+	 */
+	private $fixture;
+
+	/**
+	 * Path to the expected post-fixer output.
+	 *
+	 * @var string
+	 */
+	private $fixtureFixed;
+
+	/**
+	 * Path to the phpcs binary in the extension's vendor dir.
+	 *
+	 * @var string
+	 */
+	private $phpcsBin;
+
+	/**
+	 * Path to the phpcbf binary in the extension's vendor dir.
+	 *
+	 * @var string
+	 */
+	private $phpcbfBin;
+
+	/**
+	 * Path to the standard's ruleset.
+	 *
+	 * @var string
+	 */
+	private $standardPath;
+
+	protected function setUp(): void {
+		// Tests/Commenting -> Tests -> HomeboyWordPress -> wordpress.
+		$root               = dirname( __DIR__, 3 );
+		$standardRoot       = dirname( __DIR__, 2 );
+		$this->fixture      = __DIR__ . '/MultiLineInlineCommentUnitTest.inc';
+		$this->fixtureFixed = __DIR__ . '/MultiLineInlineCommentUnitTest.inc.fixed';
+		$this->phpcsBin     = $root . '/vendor/bin/phpcs';
+		$this->phpcbfBin    = $root . '/vendor/bin/phpcbf';
+		$this->standardPath = $standardRoot;
+
+		if ( ! is_executable( $this->phpcsBin ) ) {
+			$this->markTestSkipped( 'phpcs binary not found at ' . $this->phpcsBin );
+		}
+	}
+
+	/**
+	 * Detection A — both runs (2-line and 4-line) report on their first line,
+	 * with one error per run. Detection B — three findings inside the function
+	 * body. No findings on annotation lines, single `//`, EOL trailing
+	 * comments, or the legitimate function DocBlock.
+	 */
+	public function test_violation_lines_match_expectations(): void {
+		$report = $this->runPhpcsJson( $this->fixture );
+
+		$findings = $this->extractFindings( $report );
+
+		$expected = array(
+			26 => 'ConsecutiveSingleLine',
+			31 => 'ConsecutiveSingleLine',
+			47 => 'DoubleAsteriskNonDocBlock',
+			50 => 'DoubleAsteriskNonDocBlock',
+		);
+
+		$actualLines = array_keys( $findings );
+		sort( $actualLines );
+		$expectedLines = array_keys( $expected );
+		sort( $expectedLines );
+
+		$this->assertSame(
+			$expectedLines,
+			$actualLines,
+			'Violation lines do not match. Got: ' . json_encode( $findings )
+		);
+
+		foreach ( $expected as $line => $code ) {
+			$this->assertStringContainsString(
+				$code,
+				$findings[ $line ],
+				sprintf( 'Line %d should report %s, got %s', $line, $code, $findings[ $line ] )
+			);
+		}
+	}
+
+	/**
+	 * Auto-fixer (phpcbf) must produce byte-identical output to the
+	 * `.inc.fixed` fixture.
+	 */
+	public function test_fixer_produces_expected_output(): void {
+		// `tempnam` creates a file with no extension, but PHPCS filters by
+		// extension (`--extensions=inc,php`). Rename to `.php` so the file is
+		// scanned regardless of extension overrides.
+		$rawTmp = tempnam( sys_get_temp_dir(), 'mlinline-fix-' );
+		$tmp    = $rawTmp . '.php';
+		rename( $rawTmp, $tmp );
+		copy( $this->fixture, $tmp );
+
+		// Force `inc` extension so the file is scanned even when a project
+		// `phpcs.xml.dist` restricts the default to `.php`.
+		$cmd = sprintf(
+			'%s --standard=%s --sniffs=HomeboyWordPress.Commenting.MultiLineInlineComment --extensions=inc,php %s 2>&1',
+			escapeshellarg( $this->phpcbfBin ),
+			escapeshellarg( $this->standardPath ),
+			escapeshellarg( $tmp )
+		);
+
+		// phpcbf exit codes: 0 = clean (or `--no-cache` reported as fixed), 1
+		// = files fixed (the expected case), 2+ = config/runtime error.
+		exec( $cmd, $out, $rc );
+
+		$this->assertLessThan(
+			2,
+			$rc,
+			"phpcbf failed (rc=$rc):\n" . implode( "\n", $out ) . "\nCMD: $cmd"
+		);
+
+		$got      = file_get_contents( $tmp );
+		$expected = file_get_contents( $this->fixtureFixed );
+
+		unlink( $tmp );
+
+		$this->assertSame(
+			$expected,
+			$got,
+			"Fixer output differs from .inc.fixed fixture.\nCMD: $cmd\nphpcbf rc=$rc\nphpcbf output:\n" . implode( "\n", $out )
+		);
+	}
+
+	/**
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function runPhpcsJson( string $file ): array {
+		$cmd = sprintf(
+			'%s --standard=%s --sniffs=HomeboyWordPress.Commenting.MultiLineInlineComment --extensions=inc,php --report=json %s',
+			escapeshellarg( $this->phpcsBin ),
+			escapeshellarg( $this->standardPath ),
+			escapeshellarg( $file )
+		);
+
+		exec( $cmd, $out, $rc );
+		// phpcs exit codes: 0 = clean, 1 = warnings, 2 = errors found (the
+		// expected case for this fixture). 3 = config/runtime error.
+		$this->assertLessThan( 3, $rc, "phpcs failed (rc=$rc): \n" . implode( "\n", $out ) );
+
+		$json = json_decode( implode( "\n", $out ), true );
+		$this->assertIsArray( $json, 'phpcs --report=json returned non-JSON output: ' . implode( "\n", $out ) );
+
+		return $json;
+	}
+
+	/**
+	 * Flatten phpcs JSON report into [ line => "Source: message" ].
+	 *
+	 * @param array<string,mixed> $report
+	 *
+	 * @return array<int,string>
+	 */
+	private function extractFindings( array $report ): array {
+		$out = array();
+		foreach ( $report['files'] ?? array() as $file ) {
+			foreach ( $file['messages'] ?? array() as $message ) {
+				$out[ (int) $message['line'] ] = $message['source'] . ': ' . $message['message'];
+			}
+		}
+		ksort( $out );
+		return $out;
+	}
+}

--- a/wordpress/HomeboyWordPress/ruleset.xml
+++ b/wordpress/HomeboyWordPress/ruleset.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         name="HomeboyWordPress"
+         xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd">
+    <description><![CDATA[
+        Custom PHPCS sniffs for the homeboy-extensions WordPress module.
+        Implements WordPress handbook rules that aren't covered by upstream PHPCS or WPCS.
+
+        Sniffs:
+          - HomeboyWordPress.Commenting.MultiLineInlineComment.ConsecutiveSingleLine
+              Flags 2+ consecutive `//` lines that should be a slash-star block.
+          - HomeboyWordPress.Commenting.MultiLineInlineComment.DoubleAsteriskNonDocBlock
+              Flags `/**` blocks used for prose (must use a single asterisk per
+              WP inline-docs section 5.2; double asterisk is reserved for DocBlocks).
+
+        Opt-in usage. The host phpcs.xml.dist registers this standard with
+        severity 0 so the rule is silent by default. Promote per-error-code in
+        your own ruleset:
+
+            <rule ref="HomeboyWordPress.Commenting.MultiLineInlineComment.ConsecutiveSingleLine">
+                <severity>5</severity>
+            </rule>
+
+        Or run on demand without touching the host ruleset:
+
+            phpcs --sniffs=HomeboyWordPress.Commenting.MultiLineInlineComment <files>
+    ]]></description>
+</ruleset>

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -114,6 +114,49 @@ changing the default. `HOMEBOY_SKIP_PHPSTAN=1` runs a critical-only
 check that still blocks `function.notFound` / `class.notFound` (guaranteed
 runtime fatals) regardless of the skip.
 
+### Multi-line comment style (opt-in)
+
+Custom sniff `HomeboyWordPress.Commenting.MultiLineInlineComment` enforces
+[WordPress Inline Documentation Standards section 5.2][wp-docs-5.2]:
+
+- **`ConsecutiveSingleLine`** — flags 2+ adjacent `//` lines that should be
+  a `/* ... */` block comment. Auto-fixable.
+- **`DoubleAsteriskNonDocBlock`** — flags `/**` blocks used for prose, not
+  for declarations. The double-asterisk form is reserved for DocBlocks per
+  WP handbook; bare prose should start with a single asterisk. Auto-fixable.
+
+Both detections skip `// phpcs:`, `// translators:`, `//phpstan-`, `//psalm-`
+annotations, end-of-line trailing comments, and runs that look entirely like
+commented-out code (deferred to `Squiz.PHP.CommentedOutCode`).
+
+The sniff is **registered but off by default** to avoid a flag-day on
+existing projects. Three ways to opt in:
+
+1. Promote a single error code in your project ruleset:
+
+   ```xml
+   <rule ref="HomeboyWordPress.Commenting.MultiLineInlineComment.ConsecutiveSingleLine">
+       <severity>5</severity>
+   </rule>
+   ```
+
+2. Promote the whole sniff:
+
+   ```xml
+   <rule ref="HomeboyWordPress.Commenting.MultiLineInlineComment">
+       <severity>5</severity>
+   </rule>
+   ```
+
+3. Run on demand without touching the host ruleset:
+
+   ```bash
+   vendor/bin/phpcs --sniffs=HomeboyWordPress.Commenting.MultiLineInlineComment src/
+   vendor/bin/phpcbf --sniffs=HomeboyWordPress.Commenting.MultiLineInlineComment src/
+   ```
+
+[wp-docs-5.2]: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#5-2-multi-line-comments
+
 ### Strict `empty()` / `isset()` enforcement (opt-in)
 
 By default, PHPStan at level 7 already catches the *provably wrong* uses

--- a/wordpress/phpcs.xml.dist
+++ b/wordpress/phpcs.xml.dist
@@ -20,6 +20,16 @@
         <exclude name="Squiz.Functions.MultiLineFunctionDeclaration"/>
     </rule>
 
+    <!--
+        Custom homeboy-extensions sniffs (WP handbook rules not covered by WPCS).
+        Registered but opt-in: severity 0 keeps the rule off by default. Promote
+        a specific error code via the snippet at the top of HomeboyWordPress/ruleset.xml
+        in your project ruleset, or run on demand via the phpcs sniffs flag.
+    -->
+    <rule ref="HomeboyWordPress">
+        <severity>0</severity>
+    </rule>
+
     <!-- PHP 7.4+ compatibility -->
     <config name="testVersion" value="7.4-"/>
 

--- a/wordpress/phpunit.xml.dist
+++ b/wordpress/phpunit.xml.dist
@@ -7,6 +7,9 @@
         <testsuite name="WordPress Extension Tests">
             <directory>tests/</directory>
         </testsuite>
+        <testsuite name="HomeboyWordPress Sniff Tests">
+            <directory suffix="UnitTest.php">HomeboyWordPress/Tests/</directory>
+        </testsuite>
     </testsuites>
 
     <php>


### PR DESCRIPTION
## Summary

Adds `HomeboyWordPress.Commenting.MultiLineInlineComment` — a custom PHPCS sniff implementing [WordPress Inline Documentation Standards section 5.2][wp-docs-5.2]. Two independent detections under one sniff so they can be promoted/excluded separately.

[wp-docs-5.2]: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#5-2-multi-line-comments

- **`ConsecutiveSingleLine`** — flags 2+ adjacent `//` lines that should be a slash-star block comment. Auto-fixable: rewrites the run to `/* * line * line */` preserving the original indent.
- **`DoubleAsteriskNonDocBlock`** — flags `/**` blocks used for prose, not for declarations. Auto-fixable: replaces opening `/**` with `/*`. Lookahead pattern cribbed from `Squiz.Commenting.BlockCommentSniff::process()` to recognise legitimate DocBlock contexts (function, class, method, property, const, require/include, file-level after `<?php`).

Both detections skip `// phpcs:`, `// translators:`, `//phpstan-`, `//psalm-` annotations, end-of-line trailing comments, and runs that look entirely like commented-out code (deferred to `Squiz.PHP.CommentedOutCode`).

The sniff is **registered but off by default** (severity 0) so existing projects don't see a flag-day. Three opt-in paths documented.

## What changed (per-file)

| File | Change |
|---|---|
| `wordpress/HomeboyWordPress/ruleset.xml` | NEW — declares the custom standard. Description block walks through opt-in usage. |
| `wordpress/HomeboyWordPress/Sniffs/Commenting/MultiLineInlineCommentSniff.php` | NEW — the sniff. Registers on `T_COMMENT` + `T_DOC_COMMENT_OPEN_TAG`, dispatches to Detection A or B, both fixable. |
| `wordpress/HomeboyWordPress/Tests/Commenting/MultiLineInlineCommentUnitTest.inc` | NEW — fixture exercising every pass case (single `//`, EOL trailing, annotations, legitimate DocBlocks) and every fail case (2-line + 4-line `//` runs, single-line + multi-line `/**` prose). The 4-line run mirrors review finding #3 from [WordPress/wordpress-develop#11387][wp-pr]. |
| `wordpress/HomeboyWordPress/Tests/Commenting/MultiLineInlineCommentUnitTest.inc.fixed` | NEW — golden post-`phpcbf` output. |
| `wordpress/HomeboyWordPress/Tests/Commenting/MultiLineInlineCommentUnitTest.php` | NEW — PHPUnit test driving `vendor/bin/phpcs` and `vendor/bin/phpcbf` as subprocesses. Asserts violation lines + codes via `--report=json`, diffs fixer output against the `.fixed` fixture. Subprocess-driven instead of `AbstractSniffUnitTest` because the repo's PHPUnit harness runs in WordPress Playground (PHP-WASM) where the bundled PHPCS test bootstrap isn't loaded. |
| `wordpress/phpcs.xml.dist` | Registers the standard with `<severity>0</severity>` so the rule is silent by default but discoverable via `phpcs -e`. |
| `wordpress/phpunit.xml.dist` | Adds `HomeboyWordPress Sniff Tests` testsuite pointing at `HomeboyWordPress/Tests/`. The original `WordPress Extension Tests` testsuite (Playground-bound) is unchanged. |
| `wordpress/docs/TESTING.md` | New section: opt-in usage with three patterns (per-error-code, whole-sniff, on-demand). |

[wp-pr]: https://github.com/WordPress/wordpress-develop/pull/11387

## Acceptance criteria checklist

- ✅ New sniff registered in the project's PHPCS standard with two error codes (`ConsecutiveSingleLine`, `DoubleAsteriskNonDocBlock`).
- ✅ **Detection A** fires on 2+ consecutive `//` lines (configurable via `$minimumRunLength`, default 2).
- ✅ **Detection B** fires on `/**` blocks that aren't followed by a declaration token.
- ✅ Both detections skip the annotation patterns (`// phpcs:`, `// translators:`, `//phpstan-`, `//psalm-`), EOL trailing comments, and commented-out code (deferred to `Squiz.PHP.CommentedOutCode`).
- ✅ Both provide auto-fixers; tests assert byte-identical output against `.inc.fixed`.
- ✅ Test fixtures cover pass cases + fail cases for both detections, including the exact 4-line pattern from [WordPress/wordpress-develop#11387][wp-pr] review finding #3.
- ✅ Documented opt-in path in `wordpress/docs/TESTING.md`. Starts opt-in (severity 0); promote later once the ecosystem cleans up.

## How to verify locally

```bash
cd wordpress
composer install

# 1. Sniff is registered.
vendor/bin/phpcs --standard=phpcs.xml.dist -e | grep -i Homeboy
# → HomeboyWordPress (1 sniff)
#     HomeboyWordPress.Commenting.MultiLineInlineComment

# 2. Default lint is silent (no findings under default ruleset).
vendor/bin/phpcs --standard=phpcs.xml.dist HomeboyWordPress | grep MultiLineInline || echo "no findings"

# 3. Run on demand against the fixture.
vendor/bin/phpcs --standard=HomeboyWordPress \
    --sniffs=HomeboyWordPress.Commenting.MultiLineInlineComment \
    --extensions=inc,php \
    HomeboyWordPress/Tests/Commenting/MultiLineInlineCommentUnitTest.inc
# → 4 errors on lines 26, 31, 47, 50

# 4. PHPUnit: 2 tests, 9 assertions.
vendor/bin/phpunit --testsuite "HomeboyWordPress Sniff Tests"
```

## Notes for reviewers

- The wordpress extension currently can't dogfood its own runner via `homeboy lint` — see [Extra-Chill/homeboy#1505](https://github.com/Extra-Chill/homeboy/issues/1505) (filed during this work). Linting/fixing the new code therefore went through `vendor/bin/phpcs` + `vendor/bin/phpcbf` + `scripts/lint/php-fixers/yoda-fixer.php` directly. Once homeboy#1505 lands, this sniff (and the rest of `HomeboyWordPress/`) will be lintable through `homeboy lint` like any consumer.
- The sniff itself dogfoods the rule it enforces — it has zero `ConsecutiveSingleLine` or `DoubleAsteriskNonDocBlock` findings against itself.
- WPCS ships zero coverage for this — the sibling `Squiz.Commenting.BlockComment.SingleLine` sniff goes the *opposite* direction, and `Generic.Commenting.DocComment` only checks DocBlock structure, not site-of-use.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Sonnet 4.5)
- **Used for:** Full implementation — sniff logic, test harness, fixtures, ruleset wiring, docs. Reviewed by Chris.