### PR TITLE
feat(wordpress): bench shared-state + concurrency contract

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -149,6 +149,29 @@ fi
 
 MOUNT_ARGS+=("--mount" "${EXTENSION_PATH}:/homeboy-extension")
 
+# Shared-state mount: when homeboy core passes HOMEBOY_BENCH_SHARED_STATE,
+# we mount the host directory into Playground's VFS at a stable path
+# (/bench-shared-state) and expose that path to the workload via the
+# template. This is the on-disk substrate for concurrent-writer and
+# crash-recovery workloads — see homeboy#1508.
+SHARED_STATE_HOST="${HOMEBOY_BENCH_SHARED_STATE:-}"
+SHARED_STATE_GUEST=""
+if [ -n "$SHARED_STATE_HOST" ]; then
+    if [ ! -d "$SHARED_STATE_HOST" ]; then
+        # Homeboy core creates this dir before invocation, but if a caller
+        # invokes the dispatcher directly we still want to be helpful.
+        mkdir -p "$SHARED_STATE_HOST"
+    fi
+    SHARED_STATE_GUEST="/bench-shared-state"
+    MOUNT_ARGS+=("--mount" "${SHARED_STATE_HOST}:${SHARED_STATE_GUEST}")
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: [bench:playground] Shared state: ${SHARED_STATE_HOST} → ${SHARED_STATE_GUEST}"
+    fi
+fi
+
+INSTANCE_ID="${HOMEBOY_BENCH_INSTANCE_ID:-0}"
+CONCURRENCY="${HOMEBOY_BENCH_CONCURRENCY:-1}"
+
 PLAYGROUND_DEP_MOUNTS=""
 if [ -n "$DEPENDENCY_PATHS" ]; then
     while IFS= read -r dep_path; do
@@ -166,8 +189,20 @@ fi
 # - .pg-bench-result.txt:   pg_log / pg_stage_* structured stage log,
 #                           used to surface bootstrap failures the same way
 #                           test runner does.
-RESULT_JSON="${PLUGIN_PATH}/.pg-bench-results.json"
-RESULT_LOG="${PLUGIN_PATH}/.pg-bench-result.txt"
+#
+# When homeboy core spawns N parallel instances (concurrency > 1) the same
+# plugin path is mounted into N concurrent Playground processes — without
+# per-instance namespacing the workers would race on these two files. Use
+# the instance suffix when CONCURRENCY > 1; keep the legacy filename for
+# single-instance so direct invocations and existing diagnostics paths
+# stay unchanged.
+if [ "${CONCURRENCY}" != "1" ]; then
+    RESULT_SUFFIX=".i${INSTANCE_ID}"
+else
+    RESULT_SUFFIX=""
+fi
+RESULT_JSON="${PLUGIN_PATH}/.pg-bench-results${RESULT_SUFFIX}.json"
+RESULT_LOG="${PLUGIN_PATH}/.pg-bench-result${RESULT_SUFFIX}.txt"
 rm -f "$RESULT_JSON" "$RESULT_LOG"
 
 TEMPLATE="${SCRIPT_DIR}/playground-bench-runner.php"
@@ -183,12 +218,19 @@ sed \
     -e "s|{{COMPONENT_ID}}|${COMPONENT_ID}|g" \
     -e "s|{{ITERATIONS}}|${ITERATIONS}|g" \
     -e "s|{{PLAYGROUND_DEP_MOUNTS}}|${PLAYGROUND_DEP_MOUNTS}|g" \
+    -e "s|{{SHARED_STATE_PATH}}|${SHARED_STATE_GUEST}|g" \
+    -e "s|{{INSTANCE_ID}}|${INSTANCE_ID}|g" \
+    -e "s|{{CONCURRENCY}}|${CONCURRENCY}|g" \
+    -e "s|{{RESULT_SUFFIX}}|${RESULT_SUFFIX}|g" \
     "$TEMPLATE" > "$WRAPPER_TMPFILE"
 
 echo "Running performance benchmarks via WordPress Playground..."
 echo "  Plugin: ${PLUGIN_SLUG} (${PLUGIN_PATH})"
 echo "  Iterations: ${ITERATIONS}"
 echo "  Backend: playground (PHP-WASM + SQLite)"
+if [ -n "$SHARED_STATE_GUEST" ]; then
+    echo "  Shared state: ${SHARED_STATE_HOST} (instance ${INSTANCE_ID}/${CONCURRENCY})"
+fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "  Wrapper: $WRAPPER_TMPFILE"

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -58,8 +58,25 @@ ini_set('display_errors', '1');
 ini_set('display_startup_errors', '1');
 
 $plugin_path = '/wordpress/wp-content/plugins/{{PLUGIN_SLUG}}';
-$result_file = "$plugin_path/.pg-bench-result.txt";
+$result_file = "$plugin_path/.pg-bench-result{{RESULT_SUFFIX}}.txt";
 $current_stage = 'preboot';
+
+// Multi-instance + shared-state context (homeboy#1508).
+//
+// Workloads can opt in to concurrent-writer or crash-recovery patterns
+// by reading these constants. They're always defined; on single-instance
+// runs without --shared-state HOMEBOY_BENCH_SHARED_STATE === '' so a
+// workload can do `if (HOMEBOY_BENCH_SHARED_STATE !== '') { ... }` to
+// branch.
+if (!defined('HOMEBOY_BENCH_SHARED_STATE')) {
+    define('HOMEBOY_BENCH_SHARED_STATE', '{{SHARED_STATE_PATH}}');
+}
+if (!defined('HOMEBOY_BENCH_INSTANCE_ID')) {
+    define('HOMEBOY_BENCH_INSTANCE_ID', (int) '{{INSTANCE_ID}}');
+}
+if (!defined('HOMEBOY_BENCH_CONCURRENCY')) {
+    define('HOMEBOY_BENCH_CONCURRENCY', (int) '{{CONCURRENCY}}');
+}
 
 require_once '/homeboy-extension/scripts/lib/playground-bootstrap.php';
 
@@ -238,7 +255,7 @@ try {
 // ---------------------------------------------------------------------------
 pg_stage_begin('emit_results');
 try {
-    $results_path = "$plugin_path/.pg-bench-results.json";
+    $results_path = "$plugin_path/.pg-bench-results{{RESULT_SUFFIX}}.json";
     $envelope = [
         'component_id' => '{{COMPONENT_ID}}',
         'iterations' => $iterations_per_workload,

--- a/wordpress/scripts/bench/playground-bench-shared-state-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-shared-state-smoke.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Shared-state bench harness end-to-end smoke test.
+#
+# Runs the fixture at wordpress/tests/fixtures/bench-shared-state/ through
+# the bench dispatcher with HOMEBOY_BENCH_SHARED_STATE set, and asserts:
+#   - The dispatcher exits 0 with a populated BenchResults JSON envelope.
+#   - The shared-counter workload wrote N lines to <shared>/counter.log
+#     (N = iterations + 1 warmup = 5 + 1 = 6 by default).
+#   - HOMEBOY_BENCH_INSTANCE_ID and HOMEBOY_BENCH_CONCURRENCY round-trip.
+#
+# Single-instance only. Multi-instance smoke is exercised by homeboy core
+# spawning the dispatcher N times — that's tested at the homeboy CLI level
+# via `homeboy bench bench-shared-state --concurrency 2 --shared-state ...`.
+#
+# Manual integration test, not part of CI. Run after changes to:
+#   - bench-runner-playground.sh (shared-state mount + env wiring)
+#   - playground-bench-runner.php (constant defines)
+#
+# Usage: bash wordpress/scripts/bench/playground-bench-shared-state-smoke.sh
+# Exit:  0 = harness round-trips end-to-end, non-zero = regression
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-shared-state"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-shared-smoke.XXXXXX.json")
+SHARED_STATE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bench-shared-smoke.XXXXXX")
+
+cleanup() {
+    rm -f "$RESULTS_TMPFILE"
+    rm -rf "$SHARED_STATE_DIR"
+}
+trap cleanup EXIT
+
+ITERATIONS=5
+
+echo "============================================"
+echo "Playground bench shared-state smoke test"
+echo "============================================"
+echo "Fixture:       $FIXTURE_DIR"
+echo "Shared state:  $SHARED_STATE_DIR"
+echo "Iterations:    $ITERATIONS (per workload)"
+echo ""
+
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS="$ITERATIONS" \
+HOMEBOY_BENCH_SHARED_STATE="$SHARED_STATE_DIR" \
+HOMEBOY_BENCH_INSTANCE_ID=0 \
+HOMEBOY_BENCH_CONCURRENCY=1 \
+HOMEBOY_COMPONENT_ID=bench-shared-state \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+echo ""
+echo "--- Results envelope ---"
+cat "$RESULTS_TMPFILE"
+echo ""
+
+# Assert the workload ran end-to-end and wrote to shared state.
+COUNTER_LOG="${SHARED_STATE_DIR}/counter.log"
+if [ ! -f "$COUNTER_LOG" ]; then
+    echo "ERROR: workload did not write counter.log to shared state" >&2
+    echo "       (HOMEBOY_BENCH_SHARED_STATE may not be wired into the template)" >&2
+    exit 1
+fi
+
+LINE_COUNT=$(wc -l < "$COUNTER_LOG" | tr -d ' ')
+# iterations + 1 warmup = 6 expected
+EXPECTED=$((ITERATIONS + 1))
+if [ "$LINE_COUNT" -ne "$EXPECTED" ]; then
+    echo "ERROR: expected $EXPECTED lines in counter.log, got $LINE_COUNT" >&2
+    cat "$COUNTER_LOG" >&2
+    exit 1
+fi
+
+# Every line should report instance=0 (this smoke is single-instance) and
+# concurrency=1, proving the constants round-trip from the bash env vars
+# through sed substitution into the PHP runtime.
+if ! grep -q "instance=0 concurrency=1" "$COUNTER_LOG"; then
+    echo "ERROR: counter.log lines do not carry expected instance/concurrency tag" >&2
+    cat "$COUNTER_LOG" >&2
+    exit 1
+fi
+
+if ! grep -q '"shared-counter"' "$RESULTS_TMPFILE"; then
+    echo "ERROR: shared-counter scenario missing from results envelope" >&2
+    exit 1
+fi
+
+echo "============================================"
+echo "✓ Bench shared-state smoke test PASSED"
+echo "  Counter log: $LINE_COUNT lines"
+echo "============================================"

--- a/wordpress/tests/fixtures/bench-shared-state/bench-shared-state.php
+++ b/wordpress/tests/fixtures/bench-shared-state/bench-shared-state.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Plugin Name: Bench Shared-State Fixture
+ * Description: Smoke fixture for homeboy bench --shared-state and --concurrency.
+ *
+ * Has no plugin behaviour beyond loading. The accompanying tests/bench/
+ * workloads exercise the shared-state contract (HOMEBOY_BENCH_SHARED_STATE,
+ * HOMEBOY_BENCH_INSTANCE_ID, HOMEBOY_BENCH_CONCURRENCY) end-to-end. Pair
+ * fixture for bench-noop — same shape, plus the multi-instance contract.
+ */

--- a/wordpress/tests/fixtures/bench-shared-state/tests/bench/shared-counter.php
+++ b/wordpress/tests/fixtures/bench-shared-state/tests/bench/shared-counter.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Shared-counter bench workload — exercises the shared-state contract.
+ *
+ * Increments a counter file under HOMEBOY_BENCH_SHARED_STATE on every
+ * iteration, tagging each line with the instance id. After the run,
+ * `cat <shared-state>/counter.log` shows interleaved writes from every
+ * iteration of every parallel instance.
+ *
+ * What this proves end-to-end:
+ *
+ * - HOMEBOY_BENCH_SHARED_STATE is defined and points at a writable path
+ *   that survives across iterations.
+ * - HOMEBOY_BENCH_INSTANCE_ID is defined and distinct per parallel
+ *   instance (so workloads can attribute writes / contention to a
+ *   specific worker).
+ * - HOMEBOY_BENCH_CONCURRENCY is defined and matches the --concurrency
+ *   homeboy core was invoked with.
+ * - File-locking semantics: if two Playground processes hit the same
+ *   counter.log concurrently, file_put_contents(... LOCK_EX | FILE_APPEND)
+ *   must serialize them without losing writes. Lost writes show up as
+ *   missing line numbers in the log — what the MDI #47 / #70 bug class
+ *   would surface.
+ */
+return function (): array {
+    $shared = HOMEBOY_BENCH_SHARED_STATE;
+    if ($shared === '') {
+        // Single-instance / no-shared-state run — no-op.
+        return ['kind' => 'shared-counter', 'wrote' => false];
+    }
+
+    $instance = HOMEBOY_BENCH_INSTANCE_ID;
+    $concurrency = HOMEBOY_BENCH_CONCURRENCY;
+
+    $log_path = $shared . '/counter.log';
+    $line = sprintf(
+        "%s instance=%d concurrency=%d pid=%d\n",
+        microtime(true),
+        $instance,
+        $concurrency,
+        getmypid()
+    );
+    // LOCK_EX so concurrent instances serialize cleanly. The whole point
+    // of the workload is to stress this — drop the lock and you'll see
+    // truncated lines under concurrency > 1.
+    file_put_contents($log_path, $line, FILE_APPEND | LOCK_EX);
+
+    return [
+        'kind' => 'shared-counter',
+        'wrote' => true,
+        'instance' => $instance,
+    ];
+};


### PR DESCRIPTION
## Summary

Honors the new homeboy core contract from Extra-Chill/homeboy#1512: shared-state directory mounted into Playground's VFS, plus per-instance environment for parallel concurrent-writer / crash-recovery workloads.

Stacks on Extra-Chill/homeboy#1512 — the homeboy CLI flags don't reach the dispatcher without that PR's env-var threading, and the dispatcher edits here don't surface the new contract without the CLI.

## Behaviour

When homeboy core invokes the dispatcher with `HOMEBOY_BENCH_SHARED_STATE` set, the bash dispatcher mounts the host directory into Playground at `/bench-shared-state` and threads three constants into the PHP runtime via the existing sed-substitution template:

- `HOMEBOY_BENCH_SHARED_STATE` — guest path (or `''` when shared state isn't set).
- `HOMEBOY_BENCH_INSTANCE_ID` — `0..N-1` from homeboy core's parallel loop.
- `HOMEBOY_BENCH_CONCURRENCY` — `N` from `--concurrency`.

When `CONCURRENCY > 1`, per-instance result filenames are namespaced (`.pg-bench-results.i<n>.json`, `.pg-bench-result.i<n>.txt`) so concurrent Playground processes hitting the same plugin mount don't race on the same file. Single-instance keeps the legacy filenames.

## CLI surface

No new flags here — homeboy core owns the CLI. The dispatcher reads the env vars homeboy sets and substitutes them into the runner template alongside the existing `{{PLUGIN_SLUG}}`, `{{ITERATIONS}}`, etc.

## Fixture

New `wordpress/tests/fixtures/bench-shared-state/` plugin with a `shared-counter` workload. On each iteration it appends a line to `<shared-state>/counter.log` tagged with instance id, concurrency, microtime, and pid. After a multi-instance run the log shows interleaved writes from every iteration of every parallel instance — the substrate for both the contention-stress and the durability classes.

`shared-counter.php` deliberately uses `LOCK_EX | FILE_APPEND` so concurrent processes serialize cleanly. Drop the lock and you'll see truncated lines under concurrency > 1 — that's the MDI #47 / #70 bug class the workload is designed to surface.

## Tests

New `playground-bench-shared-state-smoke.sh` exercises the contract end-to-end. Single-instance only — multi-instance smoke is exercised at the homeboy CLI level once the core PR merges. The single-instance smoke covers the env-var → sed → PHP-runtime path that the core's concurrency loop just multiplies.

Verified locally:
- ✓ existing `playground-bench-smoke.sh` (bench-noop) — unchanged behavior.
- ✓ new `playground-bench-shared-state-smoke.sh` — 6 lines (5 iterations + 1 warmup) appear in `counter.log` with the expected `instance=0 concurrency=1` tag.

## Out of scope

- Real multi-instance smoke (would require a fully-linked homeboy install with the bench-shared-state fixture registered as a component). Tracked at the homeboy core PR.
- MDI's actual concurrent-writers / crash-recovery workloads (Automattic/markdown-database-integration#75) — they consume this contract once both PRs land.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the dispatcher edits, the PHP template constant defines, the fixture, and the smoke test. Chris reviewed before landing.