### PR TITLE
fix(wordpress): support smoke tests on macOS

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -212,7 +212,7 @@ if [ ! -f "$TEMPLATE" ]; then
     exit 1
 fi
 
-WRAPPER_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/pg-bench-runner.XXXXXX.php")
+WRAPPER_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/pg-bench-runner.XXXXXX")
 sed \
     -e "s|{{PLUGIN_SLUG}}|${PLUGIN_SLUG}|g" \
     -e "s|{{COMPONENT_ID}}|${COMPONENT_ID}|g" \

--- a/wordpress/scripts/bench/playground-bench-shared-state-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-shared-state-smoke.sh
@@ -43,7 +43,7 @@ if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
     exit 1
 fi
 
-RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-shared-smoke.XXXXXX.json")
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-shared-smoke.XXXXXX")
 SHARED_STATE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bench-shared-smoke.XXXXXX")
 
 cleanup() {

--- a/wordpress/scripts/bench/playground-bench-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-smoke.sh
@@ -41,7 +41,7 @@ if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
     exit 1
 fi
 
-RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-smoke-results.XXXXXX.json")
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-smoke-results.XXXXXX")
 
 echo "============================================"
 echo "Playground bench harness smoke test"

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -72,6 +72,17 @@ RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/
 source "${RESOLVE_CONTEXT_HELPER}"
 homeboy_resolve_context
 
+homeboy_mktemp() {
+    local template="$1"
+    local tmpdir="${HOMEBOY_CACHE_DIR:-${TMPDIR:-/tmp}}"
+
+    if [ -d "$tmpdir" ] && [ -w "$tmpdir" ]; then
+        mktemp "${tmpdir%/}/${template}" 2>/dev/null && return 0
+    fi
+
+    mktemp 2>/dev/null
+}
+
 # Merge additional findings (e.g. PHPStan) into the HOMEBOY_LINT_FINDINGS_FILE.
 # Appends entries from a JSON array file into the existing findings sidecar,
 # so the identity-based baseline ratchet sees findings from all linters.
@@ -765,7 +776,7 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
     # Create temp file for PHPStan findings if baseline sidecar is active
     _PHPSTAN_FINDINGS_TMPFILE=""
     if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
-        _PHPSTAN_FINDINGS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/phpstan-findings-XXXXXX.json")
+        _PHPSTAN_FINDINGS_TMPFILE=$(homeboy_mktemp 'phpstan-findings.XXXXXX')
     fi
 
     # Run PHPStan (warn-only - does not affect exit code)
@@ -855,7 +866,7 @@ run_phpstan() {
 # Create temp file for PHPStan findings if baseline sidecar is active
 _PHPSTAN_FINDINGS_TMPFILE=""
 if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
-    _PHPSTAN_FINDINGS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/phpstan-findings-XXXXXX.json")
+    _PHPSTAN_FINDINGS_TMPFILE=$(homeboy_mktemp 'phpstan-findings.XXXXXX')
 fi
 
 # Run PHPStan (warn-only - does not affect exit code)

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -71,7 +71,7 @@ homeboy_mktemp() {
     local tmpdir="${HOMEBOY_CACHE_DIR:-${TMPDIR:-/tmp}}"
 
     if [ -d "$tmpdir" ] && [ -w "$tmpdir" ]; then
-        mktemp "${tmpdir}/${template}" 2>/dev/null && return 0
+        mktemp "${tmpdir%/}/${template}" 2>/dev/null && return 0
     fi
 
     mktemp 2>/dev/null
@@ -93,7 +93,7 @@ generate_dependency_config() {
     local has_dependencies=0
     local has_baseline=0
 
-    tmpfile=$(homeboy_mktemp 'phpstan-dependencies-XXXXXX.neon')
+    tmpfile=$(homeboy_mktemp 'phpstan-dependencies.XXXXXX')
 
     {
         printf '%s\n' 'includes:'
@@ -186,7 +186,7 @@ generate_composite_autoload() {
     local tmpfile
     local component_autoload="${PLUGIN_PATH}/vendor/autoload.php"
 
-    tmpfile=$(homeboy_mktemp 'homeboy-phpstan-autoload-XXXXXX.php')
+    tmpfile=$(homeboy_mktemp 'homeboy-phpstan-autoload.XXXXXX')
 
     {
         printf '%s\n' '<?php'
@@ -271,7 +271,7 @@ PHPSTAN_TMPCONFIG=""
 generate_phpstan_config() {
     local max_processes="${1:-}"
     local tmpfile
-    tmpfile=$(homeboy_mktemp 'phpstan-XXXXXX.neon')
+    tmpfile=$(homeboy_mktemp 'phpstan.XXXXXX')
     {
         printf 'includes:\n'
         printf '    - %s\n' "${PHPSTAN_BASE_CONFIG}"
@@ -366,7 +366,7 @@ prepare_phpstan_retry_config() {
 if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
     set +e
     # Capture stderr separately to show PHPStan errors if it fails
-    stderr_file=$(homeboy_mktemp 'phpstan-stderr-XXXXXX.log')
+    stderr_file=$(homeboy_mktemp 'phpstan-stderr.XXXXXX')
     json_output=$("$PHPSTAN_BIN" "${phpstan_args[@]}" --error-format=json 2>"$stderr_file")
     json_exit=$?
     stderr_output=$(cat "$stderr_file")
@@ -384,7 +384,7 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
         # → COMPONENT_BASELINE include chain (no --baseline CLI flag in PHPStan 2.x).
         [ -f "$COMPOSITE_AUTOLOAD" ] && retry_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
         retry_args+=(.)
-        stderr_file=$(homeboy_mktemp 'phpstan-stderr-XXXXXX.log')
+        stderr_file=$(homeboy_mktemp 'phpstan-stderr.XXXXXX')
         # PHPStan --debug mode has a known interaction with --autoload-file
         # where running from a CWD different than the analysed path causes
         # analysis to stop after the first file (exit 0 with no results).
@@ -645,7 +645,7 @@ fi
 if [ "$PHPSTAN_CRITICAL_ONLY" -eq 1 ]; then
     echo "Running PHPStan critical-only check (style checks skipped)..."
     set +e
-    stderr_file=$(homeboy_mktemp 'phpstan-stderr-XXXXXX.log')
+    stderr_file=$(homeboy_mktemp 'phpstan-stderr.XXXXXX')
     json_output=$("$PHPSTAN_BIN" "${phpstan_args[@]}" --error-format=json 2>"$stderr_file")
     full_exit=$?
     stderr_output=$(cat "$stderr_file")
@@ -717,8 +717,8 @@ set +e
 # inspecting stderr alone misses the failure signature. We print the captured
 # streams below once the exit code is known — this keeps things simple and
 # avoids race conditions with `tee` in process substitution.
-stdout_file=$(homeboy_mktemp 'phpstan-stdout-XXXXXX.log')
-stderr_file=$(homeboy_mktemp 'phpstan-stderr-XXXXXX.log')
+stdout_file=$(homeboy_mktemp 'phpstan-stdout.XXXXXX')
+stderr_file=$(homeboy_mktemp 'phpstan-stderr.XXXXXX')
 "$PHPSTAN_BIN" "${phpstan_args[@]}" >"$stdout_file" 2>"$stderr_file"
 full_exit=$?
 stdout_output=$(cat "$stdout_file")
@@ -744,8 +744,8 @@ if [ "$full_exit" -ne 0 ] && \
     [ -f "$COMPOSITE_AUTOLOAD" ] && retry_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
     retry_args+=(.)
     set +e
-    retry_stdout_file=$(homeboy_mktemp 'phpstan-stdout-XXXXXX.log')
-    retry_stderr_file=$(homeboy_mktemp 'phpstan-stderr-XXXXXX.log')
+    retry_stdout_file=$(homeboy_mktemp 'phpstan-stdout.XXXXXX')
+    retry_stderr_file=$(homeboy_mktemp 'phpstan-stderr.XXXXXX')
     # PHPStan --debug + --autoload-file + CWD != analysed path causes analysis
     # to stop after the first file. Work around by running from inside
     # $PLUGIN_PATH and passing `.` as the positional path argument.

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -202,7 +202,7 @@ if [ ! -f "$TEMPLATE" ]; then
     exit 1
 fi
 
-WRAPPER_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/pg-runner.XXXXXX.php")
+WRAPPER_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/pg-runner.XXXXXX")
 sed \
     -e "s|{{PLUGIN_SLUG}}|${PLUGIN_SLUG}|g" \
     -e "s|{{PLAYGROUND_DEP_MOUNTS}}|${PLAYGROUND_DEP_MOUNTS}|g" \


### PR DESCRIPTION
## Summary
- Replace WordPress extension `mktemp` templates that put suffixes after `XXXXXX`, which fails on BSD/macOS `mktemp`.
- Add a shared lint-runner temp-file helper and reuse suffix-free templates for PHPStan sidecar files.
- Treat standalone `tests/smoke-*.php` scripts as a first-class fallback when PHPUnit discovers/runs zero tests.
- Let `parse-test-results.sh` consume stdin as well as a file path, matching how the Playground runner invokes it.

## Testing
- `bash -n wordpress/scripts/lint/lint-runner.sh wordpress/scripts/lint/phpstan-runner.sh wordpress/scripts/test/test-runner-playground.sh wordpress/scripts/test/parse-test-results.sh wordpress/scripts/bench/bench-runner-playground.sh wordpress/scripts/bench/playground-bench-shared-state-smoke.sh wordpress/scripts/bench/playground-bench-smoke.sh`
- `git diff --check`
- Ran the patched lint runner against Extra-Chill/data-machine-code#59: PHPCS passed, PHPStan passed, linting passed.
- Exercised the smoke fallback with a fake Playground CLI that emits `NO_TEST_FILES`; it ran DMC's six `tests/smoke-*.php` scripts successfully and wrote `{ total: 6, passed: 6, failed: 0, runner: "smoke" }`.

## Context
This blocks Homeboy release checks on macOS. Repro:

```sh
mktemp "$TMPDIR/phpstan-findings-XXXXXX.json"
```

On BSD `mktemp`, the replacement `X`s must terminate the template. Separately, DMC and similar components intentionally carry standalone smoke scripts rather than PHPUnit classes; the WordPress runner should understand that shape instead of forcing per-repo wrapper tests.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Reproduced the macOS `mktemp` failure, patched the WordPress extension scripts, added smoke-script fallback behavior, and ran shell/runner validation. Chris remains responsible for review and merge.