### PR TITLE
feat(nodejs): bench/test/lint/build runners

### DIFF
--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -130,10 +130,20 @@
     }
   },
   "build": {
+    "extension_script": "scripts/build/build-runner.sh",
     "cleanup_paths": [
       "node_modules",
       "dist"
     ]
+  },
+  "lint": {
+    "extension_script": "scripts/lint/lint-runner.sh"
+  },
+  "test": {
+    "extension_script": "scripts/test/test-runner.sh"
+  },
+  "bench": {
+    "extension_script": "scripts/bench/bench-runner.sh"
   },
   "actions": [
     {

--- a/nodejs/scripts/bench/bench-runner.mjs
+++ b/nodejs/scripts/bench/bench-runner.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+// Node.js bench harness — workload discovery, iteration loop, percentile
+// math, and BenchResults envelope serialization.
+//
+// CONTRACT
+//
+// Driven by env vars set by bench-runner.sh:
+//   HOMEBOY_COMPONENT_PATH       — project root
+//   HOMEBOY_COMPONENT_ID         — component id (goes into envelope)
+//   HOMEBOY_BENCH_ITERATIONS     — iterations per workload
+//   HOMEBOY_BENCH_RESULTS_FILE   — where to write the envelope
+//
+// Discovers `bench/**/*.bench.{ts,mjs,js}` under the project root.
+// Each workload file must export a default async function:
+//
+//     // bench/cold-boot.bench.ts
+//     export default async function () {
+//         await launchAppAndWaitForReady();
+//     }
+//
+// One file = one scenario. Wall-clock measured with performance.now()
+// around the function call. peak_bytes captured via process.memoryUsage().rss
+// max across iterations. One warmup iteration per workload is discarded
+// (matches WP runner — JIT/module-cache settle time).
+//
+// PERCENTILE METHOD
+//
+// R-7 (Excel-style) linear interpolation, bit-for-bit match with the
+// WP runner's pg_bench_percentile() so cross-substrate numbers compose.
+//
+// OUTPUT
+//
+// Writes the BenchResults JSON envelope (homeboy/src/core/extension/
+// bench/parsing.rs::BenchResults shape) to HOMEBOY_BENCH_RESULTS_FILE.
+
+import { readdir, writeFile, mkdir } from 'node:fs/promises';
+import { resolve, relative, basename, dirname } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { pathToFileURL } from 'node:url';
+
+const PROJECT_PATH = process.env.HOMEBOY_COMPONENT_PATH;
+const COMPONENT_ID = process.env.HOMEBOY_COMPONENT_ID;
+const RESULTS_FILE = process.env.HOMEBOY_BENCH_RESULTS_FILE;
+const ITERATIONS = Math.max(1, Number(process.env.HOMEBOY_BENCH_ITERATIONS) || 10);
+const WARMUP = 1;
+const DEBUG = process.env.HOMEBOY_DEBUG === '1';
+
+if (!PROJECT_PATH || !COMPONENT_ID || !RESULTS_FILE) {
+    console.error('FATAL: missing required env vars (PROJECT_PATH/COMPONENT_ID/RESULTS_FILE)');
+    process.exit(2);
+}
+
+// R-7 percentile — matches pg_bench_percentile() in the WP runner.
+function percentile(sortedMs, p) {
+    const n = sortedMs.length;
+    if (n === 0) return 0;
+    if (n === 1) return sortedMs[0];
+    const rank = p * (n - 1);
+    const lo = Math.floor(rank);
+    const hi = Math.ceil(rank);
+    if (lo === hi) return sortedMs[lo];
+    const frac = rank - lo;
+    return sortedMs[lo] * (1 - frac) + sortedMs[hi] * frac;
+}
+
+// "ColdBoot.bench.ts" → "cold-boot". Matches WP runner's slug rule.
+function scenarioId(file) {
+    return basename(file)
+        .replace(/\.bench\.(ts|mjs|cjs|js)$/, '')
+        .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+async function discoverWorkloads(dir) {
+    const found = [];
+    async function walk(d) {
+        let entries;
+        try {
+            entries = await readdir(d, { withFileTypes: true });
+        } catch {
+            return;
+        }
+        for (const entry of entries) {
+            const full = resolve(d, entry.name);
+            if (entry.isDirectory()) {
+                if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+                await walk(full);
+            } else if (/\.bench\.(ts|mjs|cjs|js)$/.test(entry.name)) {
+                found.push(full);
+            }
+        }
+    }
+    await walk(dir);
+    return found.sort();
+}
+
+async function runWorkload(file) {
+    let mod;
+    try {
+        mod = await import(pathToFileURL(file).href);
+    } catch (err) {
+        return { error: `import failed: ${err.message}` };
+    }
+
+    const fn = mod.default;
+    if (typeof fn !== 'function') {
+        return { skipped: true, reason: 'no default export (expected an async function)' };
+    }
+
+    // Warmup pass — discarded.
+    for (let i = 0; i < WARMUP; i++) {
+        try {
+            await fn();
+        } catch (err) {
+            return { error: `warmup iteration threw: ${err.message}` };
+        }
+    }
+
+    const timings = [];
+    let peakRss = 0;
+    for (let i = 0; i < ITERATIONS; i++) {
+        const start = performance.now();
+        try {
+            await fn();
+        } catch (err) {
+            return { error: `iteration ${i + 1}/${ITERATIONS} threw: ${err.message}` };
+        }
+        timings.push(performance.now() - start);
+        const rss = process.memoryUsage().rss;
+        if (rss > peakRss) peakRss = rss;
+    }
+
+    timings.sort((a, b) => a - b);
+    return { timings, peakRss };
+}
+
+async function main() {
+    const benchDir = resolve(PROJECT_PATH, 'bench');
+    const files = await discoverWorkloads(benchDir);
+
+    if (DEBUG) console.error(`DEBUG: discovered ${files.length} workloads under ${benchDir}`);
+
+    const scenarios = [];
+    let hadError = false;
+
+    for (const file of files) {
+        const id = scenarioId(file);
+        const rel = relative(PROJECT_PATH, file);
+        process.stdout.write(`WORKLOAD_BEGIN: ${id} (${basename(file)})\n`);
+
+        const result = await runWorkload(file);
+
+        if (result.error) {
+            console.error(`WORKLOAD_ERROR: ${id} — ${result.error}`);
+            hadError = true;
+            continue;
+        }
+        if (result.skipped) {
+            console.error(`WORKLOAD_SKIP: ${id} — ${result.reason}`);
+            continue;
+        }
+
+        const t = result.timings;
+        scenarios.push({
+            id,
+            file: rel,
+            iterations: t.length,
+            metrics: {
+                mean_ms: t.reduce((a, b) => a + b, 0) / t.length,
+                p50_ms: percentile(t, 0.50),
+                p95_ms: percentile(t, 0.95),
+                p99_ms: percentile(t, 0.99),
+                min_ms: t[0],
+                max_ms: t[t.length - 1],
+            },
+            memory: { peak_bytes: result.peakRss },
+        });
+
+        process.stdout.write(
+            `WORKLOAD_DONE:  ${id}  p50=${percentile(t, 0.50).toFixed(2)}ms  p95=${percentile(t, 0.95).toFixed(2)}ms\n`
+        );
+    }
+
+    const envelope = {
+        component_id: COMPONENT_ID,
+        iterations: ITERATIONS,
+        scenarios,
+    };
+
+    await mkdir(dirname(RESULTS_FILE), { recursive: true });
+    await writeFile(RESULTS_FILE, JSON.stringify(envelope, null, 2));
+
+    if (DEBUG) console.error(`DEBUG: results written to ${RESULTS_FILE}`);
+
+    if (hadError) process.exit(1);
+}
+
+main().catch((err) => {
+    console.error('BENCH_FATAL:', err.stack || err.message);
+    process.exit(1);
+});

--- a/nodejs/scripts/bench/bench-runner.sh
+++ b/nodejs/scripts/bench/bench-runner.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Node.js bench runner for `homeboy bench`.
+#
+# Discovers `bench/**/*.bench.{ts,mjs,js}` workloads under the component
+# root, runs each via the bench-runner.mjs harness, and writes the
+# BenchResults JSON envelope homeboy core expects.
+#
+# Standard env vars (set by homeboy core):
+#   HOMEBOY_EXTENSION_PATH       — path to this extension
+#   HOMEBOY_COMPONENT_PATH       — path to the Node.js project
+#   HOMEBOY_COMPONENT_ID         — component identifier
+#   HOMEBOY_BENCH_ITERATIONS     — iterations per workload (default 10)
+#   HOMEBOY_BENCH_RESULTS_FILE   — where core wants the envelope written
+#   HOMEBOY_DEBUG                — verbose output
+
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
+    case "$(uname -s)" in
+        Darwin) echo "  brew install bash" >&2 ;;
+    esac
+    exit 1
+fi
+
+FAILED_STEP=""
+FAILURE_OUTPUT=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/resolve-context.sh
+source "${SCRIPT_DIR}/../lib/resolve-context.sh"
+homeboy_resolve_context
+homeboy_require_package_json
+
+print_failure_summary() {
+    if [ -n "$FAILED_STEP" ]; then
+        echo ""
+        echo "============================================"
+        echo "BENCH FAILED: $FAILED_STEP"
+        echo "============================================"
+        if [ -n "$FAILURE_OUTPUT" ]; then
+            echo ""
+            echo "Error details:"
+            echo "$FAILURE_OUTPUT"
+        fi
+    fi
+}
+trap print_failure_summary EXIT
+
+ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-10}"
+RESULTS_FILE="${HOMEBOY_BENCH_RESULTS_FILE:-${PROJECT_PATH}/.node-bench-results.json}"
+BENCH_DIR="${PROJECT_PATH}/bench"
+
+# No workloads → emit an empty-but-valid envelope so core's parser doesn't
+# treat the absence as a crash. Same shape as the WP runner's no-tests-bench
+# path.
+if [ ! -d "$BENCH_DIR" ]; then
+    echo ""
+    echo "⚠ No bench/ directory found at ${BENCH_DIR}"
+    echo "  Skipping bench run — nothing to measure."
+    echo ""
+    cat > "$RESULTS_FILE" <<EMPTY
+{"component_id":"${COMPONENT_ID}","iterations":0,"scenarios":[]}
+EMPTY
+    exit 0
+fi
+
+# Locate a tsx-capable runner. tsx unifies .ts/.mjs/.js workload loading
+# so workload authors don't have to think about transpilation. We look for
+# tsx in the component's own node_modules first (so it pins to whatever
+# version the project uses), then fall back to npx.
+TSX_BIN=""
+if [ -x "${PROJECT_PATH}/node_modules/.bin/tsx" ]; then
+    TSX_BIN="${PROJECT_PATH}/node_modules/.bin/tsx"
+elif command -v tsx >/dev/null 2>&1; then
+    TSX_BIN="tsx"
+elif command -v npx >/dev/null 2>&1; then
+    TSX_BIN="npx --yes tsx"
+else
+    FAILED_STEP="tsx not available"
+    FAILURE_OUTPUT="Install tsx: npm i -D tsx (in ${PROJECT_PATH}) or globally."
+    exit 1
+fi
+
+export HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_FILE"
+export HOMEBOY_COMPONENT_ID="$COMPONENT_ID"
+export HOMEBOY_COMPONENT_PATH="$PROJECT_PATH"
+export HOMEBOY_BENCH_ITERATIONS="$ITERATIONS"
+
+echo "Running Node.js benchmarks..."
+echo "  Component: ${COMPONENT_ID} (${PROJECT_PATH})"
+echo "  Iterations: ${ITERATIONS}"
+
+cd "$PROJECT_PATH"
+
+set +e
+# shellcheck disable=SC2086 # word-splitting is intentional for npx --yes tsx
+$TSX_BIN "${SCRIPT_DIR}/bench-runner.mjs"
+runner_exit=$?
+set -e
+
+if [ $runner_exit -ne 0 ]; then
+    FAILED_STEP="bench-runner.mjs exited with code $runner_exit"
+    exit $runner_exit
+fi
+
+if [ ! -f "$RESULTS_FILE" ]; then
+    FAILED_STEP="Bench completed but no results file at $RESULTS_FILE"
+    exit 1
+fi
+
+echo ""
+echo "Node.js bench run complete."

--- a/nodejs/scripts/build/build-runner.sh
+++ b/nodejs/scripts/build/build-runner.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Node.js build runner for `homeboy build`.
+#
+# Detection order:
+#   1. HOMEBOY_NODE_BUILD_COMMAND env var (full override)
+#   2. nx.json present + scripts.build → `nx run-many --target=build` if a
+#      multi-package build is implied; otherwise `npm run build`
+#   3. turbo.json present → `turbo run build`
+#   4. package.json scripts.build → `{npm,pnpm,yarn} run build`
+#   5. Fail with a clear "no build defined" message (don't guess `tsc`)
+#
+# Standard env vars:
+#   HOMEBOY_EXTENSION_PATH       — path to this extension
+#   HOMEBOY_COMPONENT_PATH       — path to the Node.js project
+#   HOMEBOY_NODE_BUILD_COMMAND   — override
+#   HOMEBOY_DEBUG                — verbose
+
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
+    exit 1
+fi
+
+FAILED_STEP=""
+FAILURE_OUTPUT=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/resolve-context.sh
+source "${SCRIPT_DIR}/../lib/resolve-context.sh"
+homeboy_resolve_context
+homeboy_require_package_json
+homeboy_detect_package_manager
+
+print_failure_summary() {
+    if [ -n "$FAILED_STEP" ]; then
+        echo ""
+        echo "============================================"
+        echo "BUILD FAILED: $FAILED_STEP"
+        echo "============================================"
+        if [ -n "$FAILURE_OUTPUT" ]; then
+            echo ""
+            echo "Error details:"
+            echo "$FAILURE_OUTPUT"
+        fi
+    fi
+}
+trap print_failure_summary EXIT
+
+# Resolve the build command.
+BUILD_CMD=""
+if [ -n "${HOMEBOY_NODE_BUILD_COMMAND:-}" ]; then
+    BUILD_CMD="$HOMEBOY_NODE_BUILD_COMMAND"
+elif [ -f "${PROJECT_PATH}/nx.json" ]; then
+    # Nx monorepo. If `build` is a registered target it should run via nx
+    # so the dep graph is honored. Prefer scripts.build if defined (lets
+    # the project author choose the exact `nx ...` invocation), else
+    # default to `nx run-many`.
+    if homeboy_has_npm_script "build"; then
+        BUILD_CMD="$PKG_RUN build"
+    else
+        BUILD_CMD="$PKG_EXEC nx run-many --target=build --all"
+    fi
+elif [ -f "${PROJECT_PATH}/turbo.json" ]; then
+    if homeboy_has_npm_script "build"; then
+        BUILD_CMD="$PKG_RUN build"
+    else
+        BUILD_CMD="$PKG_EXEC turbo run build"
+    fi
+elif homeboy_has_npm_script "build"; then
+    BUILD_CMD="$PKG_RUN build"
+else
+    FAILED_STEP="No build defined"
+    FAILURE_OUTPUT="No scripts.build in package.json and no nx.json/turbo.json detected. Set HOMEBOY_NODE_BUILD_COMMAND or add a scripts.build entry."
+    exit 1
+fi
+
+if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "DEBUG: build command: $BUILD_CMD" >&2
+fi
+
+echo "Running Node.js build..."
+echo "  Component: ${COMPONENT_ID} (${PROJECT_PATH})"
+echo "  Command:   ${BUILD_CMD}"
+echo ""
+
+cd "$PROJECT_PATH"
+
+OUTPUT_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-node-build.XXXXXX")
+set +e
+# shellcheck disable=SC2086
+$BUILD_CMD "$@" 2>&1 | tee "$OUTPUT_FILE"
+BUILD_EXIT=${PIPESTATUS[0]}
+set -e
+
+if [ $BUILD_EXIT -ne 0 ]; then
+    FAILED_STEP="Build failed (exit $BUILD_EXIT)"
+    FAILURE_OUTPUT="$(tail -20 "$OUTPUT_FILE")"
+fi
+
+rm -f "$OUTPUT_FILE"
+exit $BUILD_EXIT

--- a/nodejs/scripts/lib/resolve-context.sh
+++ b/nodejs/scripts/lib/resolve-context.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# Shared execution context resolution for Node.js extension scripts.
+#
+# Resolves EXTENSION_PATH, COMPONENT_PATH, and PROJECT_PATH from Homeboy
+# environment variables, with a fallback for direct execution.
+#
+# Usage: source this file after setting SCRIPT_DIR, then call:
+#   homeboy_resolve_context
+#
+# After calling, these variables are set:
+#   EXTENSION_PATH  — path to the Node.js extension
+#   COMPONENT_PATH  — path to the component being processed
+#   PROJECT_PATH    — alias for COMPONENT_PATH (Node.js convention)
+#   COMPONENT_ID    — component identifier (basename if not provided)
+#
+# Requires SCRIPT_DIR to be set by the calling script:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+homeboy_resolve_context() {
+    if [ -n "${HOMEBOY_EXTENSION_PATH:-}" ]; then
+        EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH}"
+        COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
+        PROJECT_PATH="$COMPONENT_PATH"
+        COMPONENT_ID="${HOMEBOY_COMPONENT_ID:-$(basename "$COMPONENT_PATH")}"
+    else
+        # Direct invocation — walk up to find nodejs.json.
+        if [ -z "${SCRIPT_DIR:-}" ]; then
+            echo "Error: SCRIPT_DIR must be set before calling homeboy_resolve_context" >&2
+            return 1
+        fi
+
+        local _search_dir="$SCRIPT_DIR"
+        EXTENSION_PATH=""
+        for _i in 1 2 3 4; do
+            _search_dir="$(dirname "$_search_dir")"
+            if [ -f "${_search_dir}/nodejs.json" ]; then
+                EXTENSION_PATH="$_search_dir"
+                break
+            fi
+        done
+        if [ -z "$EXTENSION_PATH" ]; then
+            EXTENSION_PATH="$(dirname "$(dirname "$SCRIPT_DIR")")"
+        fi
+
+        COMPONENT_PATH="$(pwd)"
+        PROJECT_PATH="$COMPONENT_PATH"
+        COMPONENT_ID="$(basename "$COMPONENT_PATH")"
+    fi
+
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: Context resolved — extension=$EXTENSION_PATH, component=$PROJECT_PATH" >&2
+    fi
+}
+
+# Verify the resolved component is actually a Node.js project.
+# Walks up to find package.json (so monorepo subpackages also pass).
+homeboy_require_package_json() {
+    local _dir="${1:-$PROJECT_PATH}"
+    while [ "$_dir" != "/" ] && [ "$_dir" != "." ]; do
+        if [ -f "$_dir/package.json" ]; then
+            return 0
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+    echo "Error: No package.json found at or above ${PROJECT_PATH}" >&2
+    echo "Not a Node.js project — cannot run." >&2
+    return 1
+}
+
+# Detect which package manager the project uses, in priority order:
+# pnpm-lock.yaml → pnpm; yarn.lock → yarn; package-lock.json → npm; default npm.
+# Sets PKG_MANAGER and PKG_RUN ("pnpm run", "yarn", "npm run", "npx").
+homeboy_detect_package_manager() {
+    local _dir="${1:-$PROJECT_PATH}"
+    if [ -f "$_dir/pnpm-lock.yaml" ]; then
+        PKG_MANAGER="pnpm"
+        PKG_RUN="pnpm run"
+        PKG_EXEC="pnpm exec"
+    elif [ -f "$_dir/yarn.lock" ]; then
+        PKG_MANAGER="yarn"
+        PKG_RUN="yarn"
+        PKG_EXEC="yarn"
+    else
+        PKG_MANAGER="npm"
+        PKG_RUN="npm run"
+        PKG_EXEC="npx"
+    fi
+
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: Package manager: $PKG_MANAGER" >&2
+    fi
+}
+
+# Check whether a script name is defined in package.json.
+# Returns 0 if defined, 1 otherwise. Uses node so we don't depend on jq.
+homeboy_has_npm_script() {
+    local _script="$1"
+    local _pkg="${2:-$PROJECT_PATH/package.json}"
+    [ -f "$_pkg" ] || return 1
+    node -e "
+        const pkg = require('$_pkg');
+        process.exit(pkg.scripts && pkg.scripts['$_script'] ? 0 : 1);
+    " 2>/dev/null
+}

--- a/nodejs/scripts/lint/lint-runner.sh
+++ b/nodejs/scripts/lint/lint-runner.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Node.js lint runner for `homeboy lint`.
+#
+# Detection order:
+#   1. HOMEBOY_NODE_LINT_COMMAND env var (full override)
+#   2. package.json scripts.lint (`{npm,pnpm,yarn} run lint`)
+#   3. Built-in default: `npx eslint .` if eslint config is present
+#   4. No-op if no lint surface detected (emit empty findings array)
+#
+# In fix mode (HOMEBOY_FIX_ONLY=1), prefers `lint:fix` script if defined,
+# otherwise falls back to `eslint . --fix`.
+#
+# Output: writes a LintFinding[] JSON array to HOMEBOY_LINT_FINDINGS_FILE.
+# Each finding has `id`, `message`, `category` (matches LintFinding struct
+# in homeboy/src/core/extension/lint/baseline.rs).
+#
+# We try to consume ESLint's machine-readable JSON output (--format=json)
+# when ESLint is the runner. For arbitrary `npm run lint` scripts the user
+# wired up, we fall back to "exit code is the truth, findings array stays
+# empty unless we recognize the format."
+
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
+    exit 1
+fi
+
+FAILED_STEP=""
+FAILURE_OUTPUT=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/resolve-context.sh
+source "${SCRIPT_DIR}/../lib/resolve-context.sh"
+homeboy_resolve_context
+homeboy_require_package_json
+homeboy_detect_package_manager
+
+print_failure_summary() {
+    if [ -n "$FAILED_STEP" ]; then
+        echo ""
+        echo "============================================"
+        echo "LINT FAILED: $FAILED_STEP"
+        echo "============================================"
+        if [ -n "$FAILURE_OUTPUT" ]; then
+            echo ""
+            echo "Error details:"
+            echo "$FAILURE_OUTPUT"
+        fi
+    fi
+}
+trap print_failure_summary EXIT
+
+FIX_MODE="${HOMEBOY_FIX_ONLY:-0}"
+FINDINGS_FILE="${HOMEBOY_LINT_FINDINGS_FILE:-${PROJECT_PATH}/.node-lint-findings.json}"
+
+# Detect if eslint is available locally (vendored in node_modules) — that's
+# our preferred runner because we can ask for JSON output.
+ESLINT_BIN=""
+if [ -x "${PROJECT_PATH}/node_modules/.bin/eslint" ]; then
+    ESLINT_BIN="${PROJECT_PATH}/node_modules/.bin/eslint"
+fi
+
+# Detect if an eslint config exists somewhere reasonable.
+HAS_ESLINT_CONFIG=0
+for cfg in "eslint.config.js" "eslint.config.mjs" "eslint.config.cjs" \
+           ".eslintrc.js" ".eslintrc.cjs" ".eslintrc.json" ".eslintrc.yml" ".eslintrc.yaml"; do
+    if [ -f "${PROJECT_PATH}/${cfg}" ]; then
+        HAS_ESLINT_CONFIG=1
+        break
+    fi
+done
+
+# Resolve the lint command.
+USE_ESLINT_JSON=0
+if [ -n "${HOMEBOY_NODE_LINT_COMMAND:-}" ]; then
+    LINT_CMD="$HOMEBOY_NODE_LINT_COMMAND"
+elif [ "$FIX_MODE" = "1" ] && homeboy_has_npm_script "lint:fix"; then
+    LINT_CMD="$PKG_RUN lint:fix"
+elif homeboy_has_npm_script "lint"; then
+    LINT_CMD="$PKG_RUN lint"
+    [ "$FIX_MODE" = "1" ] && LINT_CMD="$LINT_CMD -- --fix"
+elif [ $HAS_ESLINT_CONFIG -eq 1 ]; then
+    if [ -n "$ESLINT_BIN" ]; then
+        if [ "$FIX_MODE" = "1" ]; then
+            LINT_CMD="$ESLINT_BIN . --fix"
+        else
+            LINT_CMD="$ESLINT_BIN . --format=json"
+            USE_ESLINT_JSON=1
+        fi
+    else
+        # eslint config exists but isn't installed locally — bail with a
+        # clear message rather than silently npx-installing it.
+        FAILED_STEP="eslint config found but eslint not installed"
+        FAILURE_OUTPUT="Run: npm i -D eslint (or your package manager equivalent) in ${PROJECT_PATH}"
+        echo "[]" > "$FINDINGS_FILE"
+        exit 1
+    fi
+else
+    # Nothing to lint — emit empty findings, exit clean.
+    echo ""
+    echo "⚠ No lint surface detected (no scripts.lint, no eslint config)."
+    echo "  Skipping lint — emitting empty findings."
+    echo ""
+    echo "[]" > "$FINDINGS_FILE"
+    exit 0
+fi
+
+if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "DEBUG: lint command: $LINT_CMD" >&2
+    echo "DEBUG: fix mode: $FIX_MODE" >&2
+fi
+
+echo "Running Node.js lint..."
+echo "  Component: ${COMPONENT_ID} (${PROJECT_PATH})"
+echo "  Command:   ${LINT_CMD}"
+[ "$FIX_MODE" = "1" ] && echo "  Mode:      fix"
+echo ""
+
+cd "$PROJECT_PATH"
+
+OUTPUT_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-node-lint.XXXXXX")
+set +e
+if [ $USE_ESLINT_JSON -eq 1 ]; then
+    # Capture JSON-only stream; let stderr surface to the user.
+    # shellcheck disable=SC2086
+    $LINT_CMD > "$OUTPUT_FILE" 2>&1
+    LINT_EXIT=$?
+else
+    # shellcheck disable=SC2086
+    $LINT_CMD "$@" 2>&1 | tee "$OUTPUT_FILE"
+    LINT_EXIT=${PIPESTATUS[0]}
+fi
+set -e
+
+# ── Parse findings ──
+# When we ran eslint with --format=json we have machine-readable output.
+# Otherwise, we fall back to "exit code is the truth" with empty findings.
+if [ $USE_ESLINT_JSON -eq 1 ] && [ -s "$OUTPUT_FILE" ]; then
+    # ESLint JSON: array of {filePath, messages: [{ruleId, message, line, column, severity}, ...]}
+    # severity: 1=warning, 2=error. We surface errors as findings; warnings
+    # only if HOMEBOY_LINT_INCLUDE_WARNINGS=1 (matches Rust extension's
+    # ratchet-friendly default).
+    INCLUDE_WARNINGS="${HOMEBOY_LINT_INCLUDE_WARNINGS:-0}"
+    node - "$OUTPUT_FILE" "$FINDINGS_FILE" "$INCLUDE_WARNINGS" <<'NODEJS'
+const fs = require('node:fs');
+const [, , inputFile, outputFile, includeWarningsFlag] = process.argv;
+const includeWarnings = includeWarningsFlag === '1';
+
+let raw;
+try {
+    raw = fs.readFileSync(inputFile, 'utf8').trim();
+} catch (err) {
+    fs.writeFileSync(outputFile, '[]');
+    process.exit(0);
+}
+
+// ESLint may print non-JSON banner on stderr-merged output; find first '[' and
+// last ']' as a recovery path.
+let jsonStr = raw;
+if (!jsonStr.startsWith('[')) {
+    const start = jsonStr.indexOf('[');
+    const end = jsonStr.lastIndexOf(']');
+    if (start >= 0 && end > start) jsonStr = jsonStr.slice(start, end + 1);
+}
+
+let report;
+try {
+    report = JSON.parse(jsonStr);
+} catch {
+    fs.writeFileSync(outputFile, '[]');
+    process.exit(0);
+}
+
+const findings = [];
+for (const file of report) {
+    for (const msg of file.messages || []) {
+        if (!includeWarnings && msg.severity !== 2) continue;
+        const rule = msg.ruleId || 'parse-error';
+        const loc = `${file.filePath}:${msg.line || 0}:${msg.column || 0}`;
+        findings.push({
+            // Stable fingerprint id: rule + path + 1-based line. Matches
+            // baseline expectations — same finding twice deduplicates.
+            id: `eslint:${rule}:${loc}`,
+            message: msg.message || '(no message)',
+            category: msg.severity === 2 ? 'error' : 'warning',
+        });
+    }
+}
+
+fs.writeFileSync(outputFile, JSON.stringify(findings, null, 2));
+NODEJS
+else
+    # Unknown runner output — emit empty findings, rely on exit code.
+    echo "[]" > "$FINDINGS_FILE"
+fi
+
+rm -f "$OUTPUT_FILE"
+
+if [ "$FIX_MODE" = "1" ]; then
+    # In fix mode the engine runs validation separately. Just report exit.
+    exit $LINT_EXIT
+fi
+
+if [ $LINT_EXIT -ne 0 ]; then
+    FAILED_STEP="Lint reported errors (exit $LINT_EXIT)"
+fi
+
+exit $LINT_EXIT

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Node.js test runner for `homeboy test`.
+#
+# Runs `npm test` (or pnpm/yarn equivalent) and parses the result count
+# into the canonical TestResults JSON envelope homeboy core expects.
+#
+# Detection order for "what runs":
+#   1. HOMEBOY_NODE_TEST_COMMAND env var (full override)
+#   2. package.json scripts.test (`{npm,pnpm,yarn} run test`)
+#   3. Built-in default: `node --test` (Node 18+ test runner)
+#
+# Result-count parsing strategy: tee the runner output to a tempfile,
+# detect known runner formats (vitest, jest, node:test, mocha-tap), and
+# emit homeboy's TestResults envelope. Unknown formats fall back to
+# {total: ?, passed: ?, failed: 0|1 based on exit code, partial: "unknown-runner"}.
+# Exit code remains the primary signal — the JSON is decoration.
+#
+# Standard env vars:
+#   HOMEBOY_EXTENSION_PATH       — path to this extension
+#   HOMEBOY_COMPONENT_PATH       — path to the Node.js project
+#   HOMEBOY_TEST_RESULTS_FILE    — where to write TestResults envelope
+#   HOMEBOY_NODE_TEST_COMMAND    — override the test command entirely
+#   HOMEBOY_DEBUG                — verbose
+
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
+    exit 1
+fi
+
+FAILED_STEP=""
+FAILURE_OUTPUT=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/resolve-context.sh
+source "${SCRIPT_DIR}/../lib/resolve-context.sh"
+homeboy_resolve_context
+homeboy_require_package_json
+homeboy_detect_package_manager
+
+# Source the homeboy runtime helper if available — provides the canonical
+# homeboy_write_test_results function. Path provided by core via
+# HOMEBOY_RUNTIME_WRITE_TEST_RESULTS; fall back to inline writer if not set
+# (direct invocation outside homeboy).
+WRITE_TEST_RESULTS_HELPER="${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-}"
+if [ -n "$WRITE_TEST_RESULTS_HELPER" ] && [ -f "$WRITE_TEST_RESULTS_HELPER" ]; then
+    # shellcheck source=/dev/null
+    source "$WRITE_TEST_RESULTS_HELPER"
+else
+    # Inline fallback that matches the canonical writer's contract.
+    homeboy_write_test_results() {
+        local total="${1:-0}" passed="${2:-0}" failed="${3:-0}" skipped="${4:-0}" partial="${5:-}"
+        if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
+            if [ -n "$partial" ]; then
+                cat > "$HOMEBOY_TEST_RESULTS_FILE" <<JSONEOF
+{"total":${total},"passed":${passed},"failed":${failed},"skipped":${skipped},"partial":"${partial}"}
+JSONEOF
+            else
+                cat > "$HOMEBOY_TEST_RESULTS_FILE" <<JSONEOF
+{"total":${total},"passed":${passed},"failed":${failed},"skipped":${skipped}}
+JSONEOF
+            fi
+        fi
+        echo "[test-results] Total: ${total}, Passed: ${passed}, Failed: ${failed}, Skipped: ${skipped}${partial:+ ($partial)}" >&2
+    }
+fi
+
+print_failure_summary() {
+    if [ -n "$FAILED_STEP" ]; then
+        echo ""
+        echo "============================================"
+        echo "TEST FAILED: $FAILED_STEP"
+        echo "============================================"
+        if [ -n "$FAILURE_OUTPUT" ]; then
+            echo ""
+            echo "Error details:"
+            echo "$FAILURE_OUTPUT"
+        fi
+    fi
+}
+trap print_failure_summary EXIT
+
+# Resolve the test command.
+if [ -n "${HOMEBOY_NODE_TEST_COMMAND:-}" ]; then
+    TEST_CMD="$HOMEBOY_NODE_TEST_COMMAND"
+elif homeboy_has_npm_script "test"; then
+    TEST_CMD="$PKG_RUN test"
+else
+    # Node 18+ ships a built-in test runner. This is the right default
+    # for tiny projects without an explicit script.
+    TEST_CMD="node --test"
+fi
+
+if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "DEBUG: test command: $TEST_CMD" >&2
+fi
+
+echo "Running Node.js tests..."
+echo "  Component: ${COMPONENT_ID} (${PROJECT_PATH})"
+echo "  Command:   ${TEST_CMD}"
+echo ""
+
+cd "$PROJECT_PATH"
+
+OUTPUT_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-node-test.XXXXXX")
+set +e
+# shellcheck disable=SC2086 # word-splitting is intentional here
+$TEST_CMD "$@" 2>&1 | tee "$OUTPUT_FILE"
+TEST_EXIT=${PIPESTATUS[0]}
+set -e
+
+OUTPUT="$(cat "$OUTPUT_FILE")"
+rm -f "$OUTPUT_FILE"
+
+# ── Parse result counts by runner detection ──
+# Runners we recognize, in priority order. Each match block sets
+# total/passed/failed/skipped and PARTIAL_LABEL if recognition is
+# heuristic. First match wins.
+
+PARSED=0
+TOTAL=0
+PASSED=0
+FAILED=0
+SKIPPED=0
+PARTIAL_LABEL=""
+
+# Vitest summary lines look like:
+#   Test Files  3 passed (3)
+#   Tests       42 passed | 1 skipped (43)
+if [ $PARSED -eq 0 ] && echo "$OUTPUT" | grep -qE "^[[:space:]]*Tests[[:space:]]+[0-9]+ (passed|failed|skipped)"; then
+    LINE=$(echo "$OUTPUT" | grep -E "^[[:space:]]*Tests[[:space:]]+[0-9]" | tail -1)
+    PASSED=$(echo "$LINE" | grep -oE "[0-9]+ passed" | grep -oE "[0-9]+" | head -1 || echo 0)
+    FAILED=$(echo "$LINE" | grep -oE "[0-9]+ failed" | grep -oE "[0-9]+" | head -1 || echo 0)
+    SKIPPED=$(echo "$LINE" | grep -oE "[0-9]+ skipped" | grep -oE "[0-9]+" | head -1 || echo 0)
+    TOTAL=$(echo "$LINE" | grep -oE "\([0-9]+\)" | tr -d '()' | tail -1 || echo 0)
+    [ -z "$TOTAL" ] && TOTAL=$((PASSED + FAILED + SKIPPED))
+    PARSED=1
+fi
+
+# Jest summary lines:
+#   Tests:       1 failed, 41 passed, 42 total
+if [ $PARSED -eq 0 ] && echo "$OUTPUT" | grep -qE "^Tests:[[:space:]]+.*[0-9]+ total"; then
+    LINE=$(echo "$OUTPUT" | grep -E "^Tests:" | tail -1)
+    PASSED=$(echo "$LINE" | grep -oE "[0-9]+ passed" | grep -oE "[0-9]+" | head -1 || echo 0)
+    FAILED=$(echo "$LINE" | grep -oE "[0-9]+ failed" | grep -oE "[0-9]+" | head -1 || echo 0)
+    SKIPPED=$(echo "$LINE" | grep -oE "[0-9]+ skipped" | grep -oE "[0-9]+" | head -1 || echo 0)
+    TOTAL=$(echo "$LINE" | grep -oE "[0-9]+ total" | grep -oE "[0-9]+" | head -1 || echo 0)
+    PARSED=1
+fi
+
+# node --test TAP-ish summary:
+#   # tests 42
+#   # pass  41
+#   # fail  1
+#   # skipped 0
+if [ $PARSED -eq 0 ] && echo "$OUTPUT" | grep -qE "^# tests[[:space:]]+[0-9]+"; then
+    TOTAL=$(echo "$OUTPUT" | grep -oE "^# tests[[:space:]]+[0-9]+" | grep -oE "[0-9]+" | head -1 || echo 0)
+    PASSED=$(echo "$OUTPUT" | grep -oE "^# pass[[:space:]]+[0-9]+" | grep -oE "[0-9]+" | head -1 || echo 0)
+    FAILED=$(echo "$OUTPUT" | grep -oE "^# fail[[:space:]]+[0-9]+" | grep -oE "[0-9]+" | head -1 || echo 0)
+    SKIPPED=$(echo "$OUTPUT" | grep -oE "^# skipped[[:space:]]+[0-9]+" | grep -oE "[0-9]+" | head -1 || echo 0)
+    PARSED=1
+fi
+
+# Mocha TAP plan + ok counts:
+#   1..42
+#   ok 1 ...
+if [ $PARSED -eq 0 ] && echo "$OUTPUT" | grep -qE "^1\.\.[0-9]+"; then
+    TOTAL=$(echo "$OUTPUT" | grep -oE "^1\.\.[0-9]+" | head -1 | sed 's/^1\.\.//' || echo 0)
+    PASSED=$(echo "$OUTPUT" | grep -cE "^ok [0-9]" || true)
+    FAILED=$(echo "$OUTPUT" | grep -cE "^not ok [0-9]" || true)
+    SKIPPED=$(echo "$OUTPUT" | grep -cE "# (SKIP|skip)" || true)
+    PARSED=1
+fi
+
+# Unknown runner — fall back to exit-code semantics.
+if [ $PARSED -eq 0 ]; then
+    if [ $TEST_EXIT -eq 0 ]; then
+        TOTAL=0; PASSED=0; FAILED=0; SKIPPED=0
+    else
+        TOTAL=1; PASSED=0; FAILED=1; SKIPPED=0
+    fi
+    PARTIAL_LABEL="unknown-runner"
+fi
+
+homeboy_write_test_results "$TOTAL" "$PASSED" "$FAILED" "$SKIPPED" "$PARTIAL_LABEL"
+
+if [ $TEST_EXIT -ne 0 ]; then
+    FAILED_STEP="Tests failed (exit $TEST_EXIT)"
+    # Show the last 20 lines as failure context — full output already streamed above.
+    FAILURE_OUTPUT="$(echo "$OUTPUT" | tail -20)"
+fi
+
+exit $TEST_EXIT


### PR DESCRIPTION
## Summary

Wires the four standard homeboy verb dispatchers (`bench`, `test`, `lint`, `build`) for the Node.js extension. All four follow the same env-var contract as the WordPress extension's runners and emit homeboy core's canonical JSON envelopes, so any Node project plugs into matrix iteration, baseline storage, regression detection, and the autofix/refactor surface with no core changes.

The driving use case: `homeboy bench studio` and `homeboy bench wordpress-playground` for cross-repo perf work on `dev/combined-fixes`. With this PR, every Node monorepo (Studio, Playground, kimaki, lintcn, tuistory, …) becomes a first-class homeboy component.

## What lands

```
nodejs/
├── nodejs.json                    # +10 lines: lint/test/bench/build extension_script entries
└── scripts/
    ├── lib/
    │   └── resolve-context.sh     # shared: context resolve, pkg manager, has-script check
    ├── bench/
    │   ├── bench-runner.sh        # entry: tsx detection, env wiring, error trap
    │   └── bench-runner.mjs       # harness: discovery, iteration loop, R-7 percentiles
    ├── test/
    │   └── test-runner.sh         # vitest/jest/node:test/mocha-tap detection
    ├── lint/
    │   └── lint-runner.sh         # eslint --format=json → LintFinding[]
    └── build/
        └── build-runner.sh        # nx / turbo / scripts.build detection
```

## bench-runner

Discovers `bench/**/*.bench.{ts,mjs,cjs,js}` under the component root. Each workload exports a default async function:

```javascript
// bench/cold-boot.bench.mjs
export default async function () {
    await launchStudioAndWaitForReady();
}
```

The harness keeps the substrate warm across iterations (one `tsx` process per `homeboy bench` invocation, not per iteration), runs one warmup pass per workload to settle JIT/module cache, then computes mean / p50 / p95 / p99 / min / max from the remaining samples. Percentile math is R-7 (Excel-style linear interpolation) — bit-for-bit match with the WP runner's `pg_bench_percentile()` so cross-substrate numbers compose.

Output matches `BenchResults` (`homeboy/src/core/extension/bench/parsing.rs`) — `deny_unknown_fields` on the top-level rejects anything off-spec, so an envelope drift breaks loud and fast.

## test-runner

Resolution order: `HOMEBOY_NODE_TEST_COMMAND` → `scripts.test` → built-in `node --test`. Parses output for the four common formats:

| Runner | Detection | Counts |
|---|---|---|
| **vitest** | `^Tests\s+\d+ (passed\|failed\|skipped)` | passed / failed / skipped / total |
| **jest** | `^Tests:\s+.*\d+ total` | full breakdown |
| **node:test** | `^# tests \d+` TAP-ish | tests / pass / fail / skipped |
| **mocha (TAP)** | `^1\.\.N` plan + `ok` count | parsed |

Unknown formats fall back to `partial: "unknown-runner"` with exit-code-derived counts. Exit code is the primary signal; the JSON is decoration.

## lint-runner

Resolution order: `HOMEBOY_NODE_LINT_COMMAND` → `lint:fix` script in fix mode → `scripts.lint` → built-in `eslint . --format=json` if config is present → no-op with empty findings if nothing to lint.

When ESLint is the runner, parses JSON output into `LintFinding[]` matching `homeboy/src/core/extension/lint/baseline.rs::LintFinding`. The finding `id` is `eslint:<rule>:<file>:<line>:<col>` so baselines are stable across runs. Errors surface by default; warnings only with `HOMEBOY_LINT_INCLUDE_WARNINGS=1`. Honors `HOMEBOY_FIX_ONLY` for `homeboy refactor --from lint --write` integration.

## build-runner

Resolution order: `HOMEBOY_NODE_BUILD_COMMAND` → `nx.json` (prefers `scripts.build` if defined, else `nx run-many --target=build --all`) → `turbo.json` (same shape) → plain `scripts.build` → fail with a clear message. Refuses to guess `tsc` because guessing the wrong build is worse than reporting "no build defined."

## Verified end-to-end

Smoke-tested on a synthetic two-workload Node fixture against `homeboy bench` from a linked install:

```
homeboy bench fixture --iterations 5 --baseline   → captured ✅
homeboy bench fixture (after 4x slowdown)         → regression: true, p95_delta_ms: +0.24 ✅
homeboy bench fixture --ratchet (50% speedup)     → accepted, baseline updated ✅
```

Output JSON validates against the `BenchResults` parser. Hints (`Save bench baseline:` / `Regression threshold: 5%. Raise it with…`) flow from core unchanged.

## Out of scope (follow-ups)

- **Playwright detection** in the test runner. Studio's tests use Playwright + Vitest; Vitest is detected, Playwright currently lands in `partial: "unknown-runner"`. Easy follow-up: Playwright has a stable JSON reporter shape.
- **Smoke fixture in `nodejs/tests/`**. The WP extension ships `wordpress/tests/fixtures/bench-noop` for CI smoke. Should add the equivalent here.
- **Percentile math in core.** Currently extensions compute percentiles before serializing (matches WP for cross-substrate parity). Moving to "extensions emit raw timings, core computes percentiles" is a clean win that eliminates per-extension duplication. Worth its own PR.
- **Stricter linter coverage**. `npm run lint` running prettier or stylelint emits `[]` findings + relies on exit code. Could extend with format-specific parsers.
- **Configurable bench warmup count.** Hardcoded to 1 iteration; should be a flag for substrates with longer settle times (Studio cold-boot might want 2-3).

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Agent drafted all five scripts after reading the WordPress extension's bench/test/lint runners, homeboy core's `ExtensionRunner` contract, the `BenchResults` / `LintFinding` / `TestResults` parsers, and the existing `nodejs.json`. Chris directed the layer split (percentile math stays per-extension for this PR; moving to core is a follow-up), Playwright detection deferred to follow-up, and the no-shim conventions on detection ordering. End-to-end smoke against a real fixture verified before committing.