### PR TITLE
feat(wordpress): wp_config_defines setting for per-component wp-config additions (closes #247)

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -126,6 +126,23 @@ if type homeboy_export_validation_dependency_paths &>/dev/null; then
 fi
 DEPENDENCY_PATHS="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
 
+# Extract `wp_config_defines` from the merged settings JSON. The component
+# declares its own additional wp-config defines under
+# `extensions.wordpress.settings.wp_config_defines`; homeboy core merges
+# them into HOMEBOY_SETTINGS_JSON and the runner appends them to
+# wp-tests-config.php during pg_run_boot_stage().
+#
+# Default to an empty object when unset/malformed — pg_run_boot_stage
+# treats {} as "no extra defines" (no-op for components that don't need
+# the seam, which is the canonical case).
+WP_CONFIG_DEFINES_JSON="{}"
+if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.wp_config_defines // {}' 2>/dev/null || echo "{}")
+    if [ -n "$extracted" ]; then
+        WP_CONFIG_DEFINES_JSON="$extracted"
+    fi
+fi
+
 ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-10}"
 
 # ---------------------------------------------------------------------------
@@ -213,6 +230,11 @@ if [ ! -f "$TEMPLATE" ]; then
 fi
 
 WRAPPER_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/pg-bench-runner.XXXXXX")
+# Use ASCII SOH (\x01) as the sed delimiter for the JSON substitution so
+# embedded `|` / `/` / `,` in user-supplied wp_config_defines values don't
+# need escaping. The other placeholders use `|` (their values never contain
+# a pipe in practice — slugs, integers, and POSIX paths only).
+WP_CONFIG_DEFINES_DELIM=$(printf '\1')
 sed \
     -e "s|{{PLUGIN_SLUG}}|${PLUGIN_SLUG}|g" \
     -e "s|{{COMPONENT_ID}}|${COMPONENT_ID}|g" \
@@ -222,6 +244,7 @@ sed \
     -e "s|{{INSTANCE_ID}}|${INSTANCE_ID}|g" \
     -e "s|{{CONCURRENCY}}|${CONCURRENCY}|g" \
     -e "s|{{RESULT_SUFFIX}}|${RESULT_SUFFIX}|g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     "$TEMPLATE" > "$WRAPPER_TMPFILE"
 
 echo "Running performance benchmarks via WordPress Playground..."

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -83,7 +83,18 @@ require_once '/homeboy-extension/scripts/lib/playground-bootstrap.php';
 pg_install_diagnostics_handlers();
 
 // Stages 1-4: shared boot path, identical to test runner.
-$config_path = pg_run_boot_stage();
+//
+// Component-declared wp-config defines are forwarded as a JSON-encoded
+// associative array via the {{WP_CONFIG_DEFINES_JSON}} placeholder. The
+// dispatcher reads the `wp_config_defines` setting from the merged
+// settings JSON and passes it through; an empty object ("{}") is the
+// no-op case. Decode here and hand to pg_run_boot_stage().
+$wp_config_defines_raw = '{{WP_CONFIG_DEFINES_JSON}}';
+$wp_config_defines = json_decode($wp_config_defines_raw, true);
+if (!is_array($wp_config_defines)) {
+    $wp_config_defines = [];
+}
+$config_path = pg_run_boot_stage(['extra_defines' => $wp_config_defines]);
 pg_run_install_stage(['config_path' => $config_path]);
 pg_run_load_deps_stage(['dep_mounts' => '{{PLAYGROUND_DEP_MOUNTS}}']);
 pg_run_load_component_stage(['plugin_path' => $plugin_path]);

--- a/wordpress/scripts/bench/playground-bench-wp-config-defines-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-wp-config-defines-smoke.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# wp_config_defines bench harness end-to-end smoke test.
+#
+# Runs the fixture at wordpress/tests/fixtures/wp-config-defines/ through
+# the bench dispatcher with a synthetic HOMEBOY_SETTINGS_JSON containing
+# wp_config_defines, and asserts:
+#   - Each declared constant is defined in the Playground PHP runtime.
+#   - PHP type round-trips: string stays string, int stays int, true stays bool.
+#   - The defines land in wp-tests-config.php (not in the runner template
+#     where they'd evaporate before WordPress boot).
+#
+# Manual integration test, not part of CI. Run after changes to:
+#   - playground-bootstrap.php::pg_run_boot_stage() (extra_defines handling)
+#   - bench-runner-playground.sh / test-runner-playground.sh (settings
+#     extraction + sed substitution)
+#   - playground-bench-runner.php / playground-runner.php (placeholder
+#     decoding + boot-stage call)
+#
+# Usage: bash wordpress/scripts/bench/playground-bench-wp-config-defines-smoke.sh
+# Exit:  0 = round-trips with type preservation, non-zero = regression
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/wp-config-defines"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-defines-smoke.XXXXXX")
+SHARED_STATE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bench-defines-smoke.XXXXXX")
+
+cleanup() {
+    rm -f "$RESULTS_TMPFILE"
+    rm -rf "$SHARED_STATE_DIR"
+}
+trap cleanup EXIT
+
+ITERATIONS=2
+
+# Synthesize the merged settings JSON the dispatcher would normally
+# receive from homeboy core. Real components declare this under
+# extensions.wordpress.settings.wp_config_defines in their homeboy.json.
+SETTINGS_JSON=$(cat <<'JSON'
+{
+  "wp_config_defines": {
+    "WP_CONFIG_FIXTURE_STRING": "hello",
+    "WP_CONFIG_FIXTURE_INT": 42,
+    "WP_CONFIG_FIXTURE_BOOL": true
+  }
+}
+JSON
+)
+
+echo "============================================"
+echo "Playground bench wp_config_defines smoke test"
+echo "============================================"
+echo "Fixture:       $FIXTURE_DIR"
+echo "Shared state:  $SHARED_STATE_DIR"
+echo "Settings:      $SETTINGS_JSON"
+echo ""
+
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS="$ITERATIONS" \
+HOMEBOY_BENCH_SHARED_STATE="$SHARED_STATE_DIR" \
+HOMEBOY_BENCH_INSTANCE_ID=0 \
+HOMEBOY_BENCH_CONCURRENCY=1 \
+HOMEBOY_COMPONENT_ID=wp-config-defines \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+echo ""
+echo "--- Results envelope ---"
+cat "$RESULTS_TMPFILE"
+echo ""
+
+READ_BACK_LOG="${SHARED_STATE_DIR}/defines-read-back.log"
+if [ ! -f "$READ_BACK_LOG" ]; then
+    echo "ERROR: workload did not write defines-read-back.log" >&2
+    echo "       (constants may not be reaching the workload)" >&2
+    exit 1
+fi
+
+echo ""
+echo "--- Read-back log ---"
+cat "$READ_BACK_LOG"
+echo ""
+
+# Assert each declared constant round-trips with the right value.
+if ! grep -q "string='hello'" "$READ_BACK_LOG"; then
+    echo "ERROR: WP_CONFIG_FIXTURE_STRING did not round-trip with value 'hello'" >&2
+    exit 1
+fi
+if ! grep -q 'int=42' "$READ_BACK_LOG"; then
+    echo "ERROR: WP_CONFIG_FIXTURE_INT did not round-trip with value 42" >&2
+    exit 1
+fi
+if ! grep -q 'bool=true' "$READ_BACK_LOG"; then
+    echo "ERROR: WP_CONFIG_FIXTURE_BOOL did not round-trip with value true" >&2
+    exit 1
+fi
+
+# Type preservation — the whole point of var_export().
+if ! grep -q 'string_type=string' "$READ_BACK_LOG"; then
+    echo "ERROR: WP_CONFIG_FIXTURE_STRING wrong runtime type" >&2
+    exit 1
+fi
+if ! grep -q 'int_type=integer' "$READ_BACK_LOG"; then
+    echo "ERROR: WP_CONFIG_FIXTURE_INT wrong runtime type (got string instead of integer?)" >&2
+    exit 1
+fi
+if ! grep -q 'bool_type=boolean' "$READ_BACK_LOG"; then
+    echo "ERROR: WP_CONFIG_FIXTURE_BOOL wrong runtime type (got string instead of boolean?)" >&2
+    exit 1
+fi
+
+echo "============================================"
+echo "✓ wp_config_defines smoke test PASSED"
+echo "  All three constants round-trip with type preservation."
+echo "============================================"

--- a/wordpress/scripts/lib/playground-bootstrap.php
+++ b/wordpress/scripts/lib/playground-bootstrap.php
@@ -144,6 +144,27 @@ function pg_install_diagnostics_handlers() {
  *
  * Required $cfg keys: (none)
  *
+ * Optional $cfg keys:
+ *   - extra_defines: associative array of `CONSTANT => value` appended to
+ *     wp-tests-config.php as additional `define()` statements. Lets a
+ *     component declare its own wp-config-level constants without shipping
+ *     a custom drop-in or duplicating boot logic. Values preserve their
+ *     PHP type (booleans, integers, nulls, strings) via `var_export()`,
+ *     so `["MY_FLAG" => true]` renders as `define('MY_FLAG', true)` and
+ *     not `define('MY_FLAG', 'true')`.
+ *
+ *     The dispatcher (test-runner-playground.sh / bench-runner-playground.sh)
+ *     extracts these from the component's settings JSON (the
+ *     `wp_config_defines` setting on the wordpress extension) and forwards
+ *     them through the runner template via a sed substitution placeholder.
+ *
+ *     Reserved constant names (DB_NAME, ABSPATH, table_prefix, etc — anything
+ *     defined unconditionally in the canonical config above) cannot be
+ *     overridden because PHP's `define()` is single-assignment. A component
+ *     attempting to override one will get a PHP NOTICE for the duplicate
+ *     define and the canonical value wins. Components that need to vary
+ *     these should be filing a separate gap, not working around this seam.
+ *
  * Side effect: defines $config_path under the caller's scope by writing to
  * /tmp/wp-tests-config.php (the canonical location wp-phpunit's install.php
  * expects). The path is also returned so callers don't have to hard-code it.
@@ -154,7 +175,7 @@ function pg_run_boot_stage(array $cfg = []): string {
     pg_stage_begin('boot');
     try {
         $config_path = '/tmp/wp-tests-config.php';
-        file_put_contents($config_path, <<<'CONFIG'
+        $config = <<<'CONFIG'
 <?php
 $table_prefix = 'wptests_';
 define('DB_NAME', ':memory:');
@@ -170,8 +191,29 @@ define('ABSPATH', '/wordpress/');
 define('FS_CHMOD_FILE', 0644);
 define('FS_CHMOD_DIR', 0755);
 define('FS_METHOD', 'direct');
-CONFIG
-        );
+CONFIG;
+
+        $extra_defines = $cfg['extra_defines'] ?? [];
+        if (!empty($extra_defines) && is_array($extra_defines)) {
+            $config .= "\n\n// Component-declared wp_config_defines.\n";
+            foreach ($extra_defines as $name => $value) {
+                if (!is_string($name) || !preg_match('/^[A-Z_][A-Z0-9_]*$/i', $name)) {
+                    pg_log("NOTICE: skipping invalid wp_config_defines key: " . var_export($name, true));
+                    continue;
+                }
+                // var_export preserves PHP type — true/false/int/null/string
+                // all round-trip cleanly. Arrays and objects round-trip too,
+                // though wp-config rarely needs them.
+                $config .= sprintf(
+                    "if (!defined('%s')) { define('%s', %s); }\n",
+                    $name,
+                    $name,
+                    var_export($value, true)
+                );
+            }
+        }
+
+        file_put_contents($config_path, $config);
 
         require_once '/homeboy-extension/vendor/autoload.php';
         pg_stage_ok('boot');

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -63,7 +63,16 @@ $tests_dir = '/homeboy-extension/vendor/wp-phpunit/wp-phpunit';
 $plugin_path = '/wordpress/wp-content/plugins/{{PLUGIN_SLUG}}';
 
 // Stage: boot — render wp-tests-config.php + load composer autoload.
-$config_path = pg_run_boot_stage();
+//
+// Component-declared wp-config defines flow through the
+// {{WP_CONFIG_DEFINES_JSON}} placeholder. Empty object is the no-op
+// default for components that don't need the seam.
+$wp_config_defines_raw = '{{WP_CONFIG_DEFINES_JSON}}';
+$wp_config_defines = json_decode($wp_config_defines_raw, true);
+if (!is_array($wp_config_defines)) {
+    $wp_config_defines = [];
+}
+$config_path = pg_run_boot_stage(['extra_defines' => $wp_config_defines]);
 
 // Stage: install — wp-phpunit install.php creates WP tables in-process.
 pg_run_install_stage(['config_path' => $config_path, 'tests_dir' => $tests_dir]);

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -134,6 +134,19 @@ if type homeboy_export_validation_dependency_paths &>/dev/null; then
 fi
 DEPENDENCY_PATHS="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
 
+# Extract `wp_config_defines` from the merged settings JSON. The component
+# declares its own additional wp-config defines under
+# `extensions.wordpress.settings.wp_config_defines`; homeboy core merges
+# them into HOMEBOY_SETTINGS_JSON and the runner appends them to
+# wp-tests-config.php during pg_run_boot_stage().
+WP_CONFIG_DEFINES_JSON="{}"
+if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.wp_config_defines // {}' 2>/dev/null || echo "{}")
+    if [ -n "$extracted" ]; then
+        WP_CONFIG_DEFINES_JSON="$extracted"
+    fi
+fi
+
 PLUGIN_SLUG="$(basename "$PLUGIN_PATH")"
 MOUNT_ARGS=()
 
@@ -203,9 +216,13 @@ if [ ! -f "$TEMPLATE" ]; then
 fi
 
 WRAPPER_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/pg-runner.XXXXXX")
+# ASCII SOH delimiter for the JSON substitution — values may contain `|`
+# safely without shell escaping.
+WP_CONFIG_DEFINES_DELIM=$(printf '\1')
 sed \
     -e "s|{{PLUGIN_SLUG}}|${PLUGIN_SLUG}|g" \
     -e "s|{{PLAYGROUND_DEP_MOUNTS}}|${PLAYGROUND_DEP_MOUNTS}|g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     "$TEMPLATE" > "$WRAPPER_TMPFILE"
 
 echo "Running PHPUnit tests via WordPress Playground..."

--- a/wordpress/tests/fixtures/wp-config-defines/tests/bench/read-back-defines.php
+++ b/wordpress/tests/fixtures/wp-config-defines/tests/bench/read-back-defines.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * wp-config-defines smoke workload — reads back constants the dispatcher
+ * injected via the wp_config_defines setting and proves type preservation.
+ *
+ * The fixture's homeboy.json declares:
+ *
+ *     extensions.wordpress.settings.wp_config_defines = {
+ *         "WP_CONFIG_FIXTURE_STRING": "hello",
+ *         "WP_CONFIG_FIXTURE_INT": 42,
+ *         "WP_CONFIG_FIXTURE_BOOL": true
+ *     }
+ *
+ * After pg_run_boot_stage() runs, those should be defined as PHP constants
+ * with their original types (var_export round-trip).
+ *
+ * Writes the read-back values to <shared-state>/defines-read-back.log so
+ * the smoke script can grep for them outside Playground.
+ */
+return function (): array {
+    $shared = defined('HOMEBOY_BENCH_SHARED_STATE') ? HOMEBOY_BENCH_SHARED_STATE : '';
+
+    $values = [
+        'string' => defined('WP_CONFIG_FIXTURE_STRING') ? WP_CONFIG_FIXTURE_STRING : '<undefined>',
+        'int' => defined('WP_CONFIG_FIXTURE_INT') ? WP_CONFIG_FIXTURE_INT : '<undefined>',
+        'bool' => defined('WP_CONFIG_FIXTURE_BOOL') ? WP_CONFIG_FIXTURE_BOOL : '<undefined>',
+    ];
+
+    $types = [
+        'string' => defined('WP_CONFIG_FIXTURE_STRING') ? gettype(WP_CONFIG_FIXTURE_STRING) : '<undefined>',
+        'int' => defined('WP_CONFIG_FIXTURE_INT') ? gettype(WP_CONFIG_FIXTURE_INT) : '<undefined>',
+        'bool' => defined('WP_CONFIG_FIXTURE_BOOL') ? gettype(WP_CONFIG_FIXTURE_BOOL) : '<undefined>',
+    ];
+
+    if ($shared !== '') {
+        $log_path = $shared . '/defines-read-back.log';
+        $line = sprintf(
+            "string=%s int=%s bool=%s string_type=%s int_type=%s bool_type=%s\n",
+            var_export($values['string'], true),
+            var_export($values['int'], true),
+            var_export($values['bool'], true),
+            $types['string'],
+            $types['int'],
+            $types['bool']
+        );
+        file_put_contents($log_path, $line, FILE_APPEND | LOCK_EX);
+    }
+
+    return [
+        'kind' => 'wp-config-defines-read-back',
+        'values' => $values,
+        'types' => $types,
+    ];
+};

--- a/wordpress/tests/fixtures/wp-config-defines/wp-config-defines.php
+++ b/wordpress/tests/fixtures/wp-config-defines/wp-config-defines.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Plugin Name: WP Config Defines Fixture
+ * Description: Smoke fixture for the wp_config_defines setting end-to-end. Components declare extra wp-config-level constants under extensions.wordpress.settings.wp_config_defines in their homeboy.json; the dispatcher merges them via HOMEBOY_SETTINGS_JSON and the runner appends them to wp-tests-config.php during boot.
+ *
+ * The accompanying tests/bench workload reads back the constants and
+ * proves they round-trip with PHP type preservation: a string stays a
+ * string, an int stays an int, true stays true.
+ *
+ * Pair fixture for bench-noop / bench-shared-state — adds the
+ * wp_config_defines contract to the canonical bench surface.
+ */

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -341,6 +341,13 @@
       "type": "string",
       "default": "",
       "description": "WordPress user for WP-CLI commands (email, login, or ID). When configured, automatically appended as --user flag."
+    },
+    {
+      "id": "wp_config_defines",
+      "label": "wp-config additions",
+      "type": "object",
+      "default": {},
+      "description": "Map of CONSTANT_NAME => value appended to the Playground wp-tests-config.php as additional define() statements. Lets a component declare wp-config-level constants (mode flags, debug toggles, custom paths) without shipping a custom drop-in. Values preserve PHP type via var_export() — booleans, integers, and nulls round-trip cleanly. Reserved canonical names (DB_NAME, ABSPATH, etc.) cannot be overridden."
     }
   ]
 }


### PR DESCRIPTION
Closes #247.

## Summary

- Adds a new `wp_config_defines` setting to the wordpress extension. Components declare extra `wp-config` constants under `extensions.wordpress.settings.wp_config_defines` in their `homeboy.json`; the dispatcher merges them into `HOMEBOY_SETTINGS_JSON`, and the Playground runner appends them to `wp-tests-config.php` during `pg_run_boot_stage()`.
- Closes the seam that was forcing thin substrate components (e.g. the MDI bench substrates in Automattic/markdown-database-integration#75) to ship a custom `db.php` just to define a single mode constant. With this in place, a substrate that only varies a `define()` ships one shared drop-in (or none) and declares the variation in `homeboy.json`.
- Adds a `wp-config-defines` fixture and an end-to-end smoke (`playground-bench-wp-config-defines-smoke.sh`) that asserts string / int / bool defines round-trip with **PHP type preservation** (booleans stay `bool`, ints stay `int`, strings stay `string`). Verified locally — all three pass.

## Behaviour

```json
{
  "extensions": {
    "wordpress": {
      "settings": {
        "wp_config_defines": {
          "MARKDOWN_DB_MODE": "primary",
          "WP_DEBUG": true,
          "MY_FEATURE_FLAG": 42
        }
      }
    }
  }
}
```

`pg_run_boot_stage(['extra_defines' => $defines])` appends `if (!defined('NAME')) { define('NAME', value); }` lines to the canonical config, using `var_export()` to preserve type. Reserved canonical names (`DB_NAME`, `ABSPATH`, `WP_PHP_BINARY`, etc.) cannot be overridden because the canonical defines run unconditionally first and the component-side overrides are guarded — PHP's single-assignment rule wins. Invalid keys (non-string or strings not matching `/^[A-Z_][A-Z0-9_]*$/i`) log a `NOTICE` and are skipped.

Default is `{}` (empty object). Components that don't declare the setting are unaffected — `pg_run_boot_stage` skips the `extra_defines` block when the array is empty.

## Why this matters

The fix-upstream-first rule. Without this seam, every consumer that needs to vary a wp-config constant across cells ships a workaround. Two workarounds is a pattern; three is convention. This is the fix that lets the MDI bench harness ship without a shim — and lets future substrate-matrix components (cache-substrate, debug-flag matrices, multisite-on-vs-off, custom upload paths) avoid re-rolling the same dance.

## Plumbing

- `wordpress.json` — declares the new `wp_config_defines` setting (type `object`, default `{}`).
- `scripts/lib/playground-bootstrap.php` — `pg_run_boot_stage()` accepts an `extra_defines` cfg key; appends sanitized `define()` lines via `var_export()`.
- `scripts/bench/bench-runner-playground.sh` — extracts `wp_config_defines` from `HOMEBOY_SETTINGS_JSON` via `jq -c`, sed-substitutes into the template using ASCII SOH (`\x01`) as the delimiter so embedded `|` / `/` / `,` in user values doesn't need escaping.
- `scripts/test/test-runner-playground.sh` — same extraction + substitution as bench, mirrored across the test runner so PHPUnit consumers get the seam too.
- `scripts/bench/playground-bench-runner.php` — decodes the `{{WP_CONFIG_DEFINES_JSON}}` placeholder, hands the array to `pg_run_boot_stage`.
- `scripts/test/playground-runner.php` — same.
- `tests/fixtures/wp-config-defines/` — fixture plugin + workload that reads back the constants and writes their values + types to a shared-state log.
- `scripts/bench/playground-bench-wp-config-defines-smoke.sh` — runs the fixture with synthetic `HOMEBOY_SETTINGS_JSON`, asserts round-trip + type preservation.

## Smoke results

```
--- Read-back log ---
string='hello' int=42 bool=true string_type=string int_type=integer bool_type=boolean
string='hello' int=42 bool=true string_type=string int_type=integer bool_type=boolean
string='hello' int=42 bool=true string_type=string int_type=integer bool_type=boolean

============================================
✓ wp_config_defines smoke test PASSED
  All three constants round-trip with type preservation.
============================================
```

## Out of scope

- No core `homeboy` change. This is wordpress-extension-only — the existing settings merge in `core/extension/execution.rs::build_settings_json_from_manifest` already preserves arrays and objects, so the new setting flows through as-is.
- No CHANGELOG / version bumps. Homeboy owns release versioning.
- No CI hook for the smoke. It's a manual integration test, run after changes to the dispatcher / template / boot stage. Same posture as `playground-bench-shared-state-smoke.sh` and `playground-dropin-smoke.sh`.

## Related

- #247 (this issue, closed by this PR)
- Automattic/markdown-database-integration#75 (the downstream MDI bench harness this unblocks)
- #243 (the bench shared-state contract that this builds on top of — same dispatcher, same template, same fixture shape)

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the dispatcher edits, the runner template placeholder wiring, the `pg_run_boot_stage` `extra_defines` extension, the fixture, and the smoke script. Chris reviewed the upstream-first framing that motivated this PR (no shim in MDI's bench harness, fix the seam upstream).