### PR TITLE
fix(wordpress): plugin slug honors HOMEBOY_COMPONENT_ID instead of basename

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -76,8 +76,24 @@ else
     COMPONENT_ID="$(basename "$PLUGIN_PATH")"
 fi
 
-PLUGIN_SLUG="$(basename "$PLUGIN_PATH")"
-COMPONENT_ID="${COMPONENT_ID:-$PLUGIN_SLUG}"
+# PLUGIN_SLUG is the wp-content/plugins/ path segment Playground uses to
+# mount the component-under-test. The historical default was
+# `basename($PLUGIN_PATH)`, which works for canonical plugin checkouts
+# whose directory name equals the plugin slug. It breaks for git-worktree
+# checkouts (`<repo>@<branch-slug>` convention) and for any workspace where
+# the on-disk directory name diverges from the canonical slug — the wrong
+# wp-content/plugins/ path makes plugin-internal asset URLs, intra-plugin
+# require_once paths, and `Requires Plugins:` resolution all fail.
+#
+# When homeboy core tells us the canonical component id (HOMEBOY_COMPONENT_ID),
+# use it. Fall back to basename only when no id is set (direct invocation
+# from a CWD that isn't a registered component).
+if [ -n "${COMPONENT_ID:-}" ]; then
+    PLUGIN_SLUG="$COMPONENT_ID"
+else
+    PLUGIN_SLUG="$(basename "$PLUGIN_PATH")"
+    COMPONENT_ID="$PLUGIN_SLUG"
+fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: [bench:playground] Extension path: $EXTENSION_PATH"

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -147,7 +147,17 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     fi
 fi
 
-PLUGIN_SLUG="$(basename "$PLUGIN_PATH")"
+# PLUGIN_SLUG is the wp-content/plugins/ path segment Playground uses to
+# mount the component-under-test. When homeboy core tells us the canonical
+# component id (HOMEBOY_COMPONENT_ID), use it — basename($PLUGIN_PATH)
+# breaks for git-worktree checkouts (`<repo>@<branch-slug>`) and any
+# workspace where the on-disk directory name diverges from the canonical
+# slug. See bench-runner-playground.sh for the full rationale.
+if [ -n "${COMPONENT_ID:-}" ]; then
+    PLUGIN_SLUG="$COMPONENT_ID"
+else
+    PLUGIN_SLUG="$(basename "$PLUGIN_PATH")"
+fi
 MOUNT_ARGS=()
 
 MOUNT_ARGS+=("--mount" "${PLUGIN_PATH}:/wordpress/wp-content/plugins/${PLUGIN_SLUG}")


### PR DESCRIPTION
## Summary

- Dispatcher's `PLUGIN_SLUG` (the wp-content/plugins/ path segment Playground mounts the component-under-test at) now uses `HOMEBOY_COMPONENT_ID` when set, falling back to `basename($PLUGIN_PATH)` only when no id is available (direct invocation from a CWD that isn't a registered component).
- Mirrors the fix across both bench and test dispatchers — same VFS-mount semantics, same gap.

## Why

`basename($PLUGIN_PATH)` works fine for canonical plugin checkouts whose directory name equals the plugin slug. It **breaks** for git-worktree checkouts using the `<repo>@<branch-slug>` convention from data-machine-code's workspace primitive (and the worktree workflow documented in AGENTS.md across the ecosystem).

Concrete repro: a worktree of `markdown-database-integration` at branch `feat/bench-harness` lives at `/Users/.../markdown-database-integration@feat-bench-harness`. Before this fix, `homeboy bench` from inside that worktree would mount the plugin at `wp-content/plugins/markdown-database-integration@feat-bench-harness/` — which breaks:

- Cross-plugin path probes. MDI's `db.php` drop-in probes `__DIR__/plugins/markdown-database-integration/inc/...` for its own classes; the wrong slug means it can't find them.
- `Requires Plugins:` header resolution. Canonical slug declared in the header doesn't match the on-disk directory basename.
- Any code that hardcodes the canonical plugin slug for asset URLs, REST namespaces, etc.

`__DIR__`-relative requires within the same plugin still work (they track the mount), so the gap is silent until something cross-plugin touches the slug.

## Behaviour

```bash
# Before this fix
homeboy bench markdown-database-integration  # from worktree
# → mount: /Users/.../markdown-database-integration@feat-bench-harness:/wordpress/wp-content/plugins/markdown-database-integration@feat-bench-harness
# → PLUGIN_SLUG = "markdown-database-integration@feat-bench-harness"
# → MDI db.php fails: "/wordpress/wp-content/plugins/markdown-database-integration/inc/class-wp-markdown-storage.php" not found
```

```bash
# After this fix
homeboy bench markdown-database-integration  # from worktree
# → mount: /Users/.../markdown-database-integration@feat-bench-harness:/wordpress/wp-content/plugins/markdown-database-integration
# → PLUGIN_SLUG = "markdown-database-integration" (the canonical id)
# → MDI db.php finds /wordpress/wp-content/plugins/markdown-database-integration/inc/... cleanly
```

The fallback path (basename) is preserved unchanged for the no-`HOMEBOY_COMPONENT_ID` case (direct dispatcher invocation outside a homeboy session).

## Plumbing

- `wordpress/scripts/bench/bench-runner-playground.sh` — line 79 ladder.
- `wordpress/scripts/test/test-runner-playground.sh` — line 150 ladder.

`COMPONENT_ID` is already populated upstream of the slug derivation in both dispatchers (from `HOMEBOY_COMPONENT_ID` env, then a CWD basename fallback), so the change is purely "use the value we already have."

## Tests

Manual repro: ran `homeboy bench markdown-database-integration` from the MDI worktree at `markdown-database-integration@feat-bench-harness` before and after. Before: `STAGE_FATAL` on db.php trying to load `/wordpress/wp-content/plugins/markdown-database-integration/inc/class-wp-markdown-storage.php` (not found because the actual mount was at `markdown-database-integration@feat-bench-harness`). After: dispatcher mounts at the canonical slug; MDI's db.php loads its classes; bootstrap completes through `load_component`.

No new fixture — this is fixing existing behaviour, not adding a new contract. The bench-noop / bench-shared-state / wp-config-defines fixtures all continue to work because their on-disk basename equals their canonical id (no worktree).

## Out of scope

- No CHANGELOG / version bumps. Homeboy owns release versioning.
- No core homeboy change. The dispatcher already receives the canonical id via `HOMEBOY_COMPONENT_ID`; this is wordpress-extension-only.
- Direct invocation from a CWD that isn't a registered component still uses basename. That's the documented fallback contract; not changing it.

## Related

- #248 (wp_config_defines) — same MDI bench cook, same upstream-first pattern.
- Automattic/markdown-database-integration#75 (the downstream MDI bench harness this unblocks).

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the dispatcher edits. Chris reviewed the upstream-first framing — fix the slug bug instead of working around it by symlinking or renaming the worktree.