### PR TITLE
feat(wordpress): bench_env passthrough for host-shell vars into Playground

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -159,6 +159,26 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     fi
 fi
 
+# Extract `bench_env` from the merged settings JSON. Components declare
+# host-shell env vars that should propagate into Playground PHP-WASM under
+# `extensions.wordpress.settings.bench_env` in their homeboy.json:
+#
+#   { "bench_env": { "BENCH_CORPUS_SIZE": "1000", "BENCH_SEED": "42" } }
+#
+# Workloads then read them via `getenv('BENCH_CORPUS_SIZE')` as if they
+# had been set on the host shell. Without this seam, host env vars don't
+# cross the wp-playground-cli sandbox boundary — workloads' getenv() calls
+# return false regardless of what the parent shell set.
+#
+# Default `{}` is the no-op case for components that don't need the seam.
+BENCH_ENV_JSON="{}"
+if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.bench_env // {}' 2>/dev/null || echo "{}")
+    if [ -n "$extracted" ]; then
+        BENCH_ENV_JSON="$extracted"
+    fi
+fi
+
 ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-10}"
 
 # ---------------------------------------------------------------------------
@@ -261,6 +281,7 @@ sed \
     -e "s|{{CONCURRENCY}}|${CONCURRENCY}|g" \
     -e "s|{{RESULT_SUFFIX}}|${RESULT_SUFFIX}|g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     "$TEMPLATE" > "$WRAPPER_TMPFILE"
 
 echo "Running performance benchmarks via WordPress Playground..."

--- a/wordpress/scripts/bench/playground-bench-env-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-env-smoke.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# bench_env passthrough smoke test.
+#
+# Runs the fixture at wordpress/tests/fixtures/bench-env/ through the
+# bench dispatcher with a synthetic HOMEBOY_SETTINGS_JSON containing
+# bench_env, and asserts:
+#   - The declared env vars are readable via getenv() inside Playground.
+#   - $_ENV contains them too (for code that reads $_ENV directly).
+#   - Values arrive as strings (PHP env-var convention).
+#
+# Manual integration test, not part of CI. Run after changes to:
+#   - playground-bench-runner.php (the putenv() loop)
+#   - bench-runner-playground.sh (the BENCH_ENV_JSON extraction + sed)
+#   - playground-runner.php (test-runner mirror)
+#   - test-runner-playground.sh (test-runner mirror)
+#
+# Usage: bash wordpress/scripts/bench/playground-bench-env-smoke.sh
+# Exit:  0 = round-trips, non-zero = regression
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-env"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-env-smoke.XXXXXX")
+SHARED_STATE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bench-env-smoke.XXXXXX")
+
+cleanup() {
+    rm -f "$RESULTS_TMPFILE"
+    rm -rf "$SHARED_STATE_DIR"
+}
+trap cleanup EXIT
+
+ITERATIONS=2
+
+# Synthesize the merged settings JSON the dispatcher would receive from
+# homeboy core. Real components declare this under
+# extensions.wordpress.settings.bench_env in their homeboy.json.
+SETTINGS_JSON=$(cat <<'JSON'
+{
+  "bench_env": {
+    "BENCH_ENV_FIXTURE_STR": "hello",
+    "BENCH_ENV_FIXTURE_NUM": "42"
+  }
+}
+JSON
+)
+
+echo "============================================"
+echo "Playground bench bench_env smoke test"
+echo "============================================"
+echo "Fixture:       $FIXTURE_DIR"
+echo "Shared state:  $SHARED_STATE_DIR"
+echo "Settings:      $SETTINGS_JSON"
+echo ""
+
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS="$ITERATIONS" \
+HOMEBOY_BENCH_SHARED_STATE="$SHARED_STATE_DIR" \
+HOMEBOY_BENCH_INSTANCE_ID=0 \
+HOMEBOY_BENCH_CONCURRENCY=1 \
+HOMEBOY_COMPONENT_ID=bench-env \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+READ_BACK_LOG="${SHARED_STATE_DIR}/env-read-back.log"
+if [ ! -f "$READ_BACK_LOG" ]; then
+    echo "ERROR: workload did not write env-read-back.log" >&2
+    exit 1
+fi
+
+echo ""
+echo "--- Read-back log ---"
+cat "$READ_BACK_LOG"
+echo ""
+
+# Assert each declared env var is readable via getenv().
+if ! grep -q "\"BENCH_ENV_FIXTURE_STR_getenv\":\"'hello'\"" "$READ_BACK_LOG"; then
+    echo "ERROR: BENCH_ENV_FIXTURE_STR did not round-trip via getenv()" >&2
+    exit 1
+fi
+if ! grep -q "\"BENCH_ENV_FIXTURE_NUM_getenv\":\"'42'\"" "$READ_BACK_LOG"; then
+    echo "ERROR: BENCH_ENV_FIXTURE_NUM did not round-trip via getenv()" >&2
+    exit 1
+fi
+if ! grep -q "\"BENCH_ENV_FIXTURE_STR_in_env\":\"yes\"" "$READ_BACK_LOG"; then
+    echo "ERROR: BENCH_ENV_FIXTURE_STR not in \$_ENV" >&2
+    exit 1
+fi
+if ! grep -q "\"BENCH_ENV_FIXTURE_STR_env_value\":\"hello\"" "$READ_BACK_LOG"; then
+    echo "ERROR: \$_ENV['BENCH_ENV_FIXTURE_STR'] wrong value" >&2
+    exit 1
+fi
+
+echo "============================================"
+echo "✓ bench_env smoke test PASSED"
+echo "  All declared env vars round-trip through getenv() and \$_ENV."
+echo "============================================"

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -95,6 +95,34 @@ if (!is_array($wp_config_defines)) {
     $wp_config_defines = [];
 }
 $config_path = pg_run_boot_stage(['extra_defines' => $wp_config_defines]);
+
+// Component-declared bench env vars. Host shell env doesn't propagate
+// across the wp-playground-cli sandbox boundary, so workloads' getenv()
+// calls return false for anything the parent shell set. The dispatcher
+// extracts the `bench_env` setting from HOMEBOY_SETTINGS_JSON and the
+// runner calls putenv() for each entry here, before workload discovery,
+// so getenv() resolves correctly inside workloads.
+//
+// Empty object is the no-op case — components that don't declare
+// bench_env see no behavioural change.
+$bench_env_raw = '{{BENCH_ENV_JSON}}';
+$bench_env = json_decode($bench_env_raw, true);
+if (is_array($bench_env)) {
+    foreach ($bench_env as $name => $value) {
+        if (is_string($name) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name)) {
+            // putenv() takes "NAME=value" — coerce the value to string,
+            // var_export-style for non-scalars (workloads expect string
+            // input to getenv() per PHP convention).
+            $string_value = is_scalar($value) ? (string) $value : json_encode($value);
+            putenv($name . '=' . $string_value);
+            // Also populate $_ENV so workloads using $_ENV['NAME'] work.
+            $_ENV[$name] = $string_value;
+        } else {
+            pg_log("NOTICE: skipping invalid bench_env key: " . var_export($name, true));
+        }
+    }
+}
+
 pg_run_install_stage(['config_path' => $config_path]);
 pg_run_load_deps_stage(['dep_mounts' => '{{PLAYGROUND_DEP_MOUNTS}}']);
 pg_run_load_component_stage(['plugin_path' => $plugin_path]);

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -74,6 +74,26 @@ if (!is_array($wp_config_defines)) {
 }
 $config_path = pg_run_boot_stage(['extra_defines' => $wp_config_defines]);
 
+// Component-declared bench env vars (used by both bench and test runners
+// — name kept consistent across both runner kinds for symmetry). Host
+// shell env doesn't cross the wp-playground-cli sandbox boundary; the
+// dispatcher extracts `bench_env` from HOMEBOY_SETTINGS_JSON and we
+// putenv() each entry here before test fixtures load. Empty object is
+// the no-op case.
+$bench_env_raw = '{{BENCH_ENV_JSON}}';
+$bench_env = json_decode($bench_env_raw, true);
+if (is_array($bench_env)) {
+    foreach ($bench_env as $name => $value) {
+        if (is_string($name) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name)) {
+            $string_value = is_scalar($value) ? (string) $value : json_encode($value);
+            putenv($name . '=' . $string_value);
+            $_ENV[$name] = $string_value;
+        } else {
+            pg_log("NOTICE: skipping invalid bench_env key: " . var_export($name, true));
+        }
+    }
+}
+
 // Stage: install — wp-phpunit install.php creates WP tables in-process.
 pg_run_install_stage(['config_path' => $config_path, 'tests_dir' => $tests_dir]);
 

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -147,6 +147,21 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     fi
 fi
 
+# Extract `bench_env` from the merged settings JSON. Components declare
+# host-shell env vars that should propagate into Playground PHP-WASM under
+# `extensions.wordpress.settings.bench_env`. The dispatcher passes them
+# to the runner template; the template calls putenv() for each entry
+# before fixtures load, so test code's getenv() calls resolve correctly.
+# See bench-runner-playground.sh for the full rationale (host shell env
+# doesn't cross the wp-playground-cli sandbox boundary by default).
+BENCH_ENV_JSON="{}"
+if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.bench_env // {}' 2>/dev/null || echo "{}")
+    if [ -n "$extracted" ]; then
+        BENCH_ENV_JSON="$extracted"
+    fi
+fi
+
 # PLUGIN_SLUG is the wp-content/plugins/ path segment Playground uses to
 # mount the component-under-test. When homeboy core tells us the canonical
 # component id (HOMEBOY_COMPONENT_ID), use it — basename($PLUGIN_PATH)
@@ -233,6 +248,7 @@ sed \
     -e "s|{{PLUGIN_SLUG}}|${PLUGIN_SLUG}|g" \
     -e "s|{{PLAYGROUND_DEP_MOUNTS}}|${PLAYGROUND_DEP_MOUNTS}|g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     "$TEMPLATE" > "$WRAPPER_TMPFILE"
 
 echo "Running PHPUnit tests via WordPress Playground..."

--- a/wordpress/tests/fixtures/bench-env/bench-env.php
+++ b/wordpress/tests/fixtures/bench-env/bench-env.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Plugin Name: Bench Env Fixture
+ * Description: Smoke fixture for the bench_env setting end-to-end. Components declare host-shell env vars to forward into Playground PHP-WASM under extensions.wordpress.settings.bench_env in their homeboy.json; the dispatcher merges them via HOMEBOY_SETTINGS_JSON and the runner putenv()'s each entry before fixtures load.
+ *
+ * The accompanying tests/bench workload reads back the env var via
+ * getenv() and writes its value to a shared-state log so the smoke
+ * script can grep for it outside Playground.
+ *
+ * Pair fixture for bench-noop / bench-shared-state / wp-config-defines.
+ */

--- a/wordpress/tests/fixtures/bench-env/tests/bench/read-back-env.php
+++ b/wordpress/tests/fixtures/bench-env/tests/bench/read-back-env.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * bench_env smoke workload — reads back env vars the dispatcher injected
+ * via the bench_env setting and asserts they're visible to getenv().
+ *
+ * The fixture's homeboy.json (or a synthetic HOMEBOY_SETTINGS_JSON in
+ * the smoke script) declares:
+ *
+ *     extensions.wordpress.settings.bench_env = {
+ *         "BENCH_ENV_FIXTURE_STR": "hello",
+ *         "BENCH_ENV_FIXTURE_NUM": "42"
+ *     }
+ *
+ * After the runner template's putenv() loop runs, those should be
+ * readable via getenv() inside the workload.
+ *
+ * Writes the read-back values to <shared-state>/env-read-back.log so the
+ * smoke script can grep for them outside Playground.
+ */
+return function (): array {
+    $shared = defined('HOMEBOY_BENCH_SHARED_STATE') ? HOMEBOY_BENCH_SHARED_STATE : '';
+
+    $values = [
+        'BENCH_ENV_FIXTURE_STR_getenv' => var_export(getenv('BENCH_ENV_FIXTURE_STR'), true),
+        'BENCH_ENV_FIXTURE_NUM_getenv' => var_export(getenv('BENCH_ENV_FIXTURE_NUM'), true),
+        'BENCH_ENV_FIXTURE_STR_in_env' => array_key_exists('BENCH_ENV_FIXTURE_STR', $_ENV) ? 'yes' : 'no',
+        'BENCH_ENV_FIXTURE_STR_env_value' => $_ENV['BENCH_ENV_FIXTURE_STR'] ?? '<missing>',
+    ];
+
+    if ($shared !== '') {
+        $log_path = $shared . '/env-read-back.log';
+        $line = json_encode($values) . "\n";
+        file_put_contents($log_path, $line, FILE_APPEND | LOCK_EX);
+    }
+
+    return [
+        'kind' => 'bench-env-read-back',
+        'values' => $values,
+    ];
+};

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -348,6 +348,13 @@
       "type": "object",
       "default": {},
       "description": "Map of CONSTANT_NAME => value appended to the Playground wp-tests-config.php as additional define() statements. Lets a component declare wp-config-level constants (mode flags, debug toggles, custom paths) without shipping a custom drop-in. Values preserve PHP type via var_export() — booleans, integers, and nulls round-trip cleanly. Reserved canonical names (DB_NAME, ABSPATH, etc.) cannot be overridden."
+    },
+    {
+      "id": "bench_env",
+      "label": "Bench env passthrough",
+      "type": "object",
+      "default": {},
+      "description": "Map of NAME => value forwarded into Playground PHP-WASM as environment variables. Workloads (bench) and test fixtures (test runner) read them via getenv() / $_ENV. Required because host shell env doesn't cross the wp-playground-cli sandbox boundary; without this seam, getenv('MY_KNOB') returns false regardless of what the parent shell set. Values are coerced to strings (via json_encode for non-scalars) per PHP env-var convention. Component declares static defaults; matrix drivers can synthesize HOMEBOY_SETTINGS_JSON inline to override per-cell."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a `bench_env` setting to the wordpress extension. Components declare host-shell env vars under `extensions.wordpress.settings.bench_env` in `homeboy.json`; the dispatcher reads from `HOMEBOY_SETTINGS_JSON`, sed-substitutes into the runner template at `{{BENCH_ENV_JSON}}`, and the template calls `putenv()` (+ mirrors into `$_ENV`) before workload discovery / fixture load.
- Workloads then read the values via `getenv()` / `$_ENV` exactly as if they had been set on the host shell.
- Mirrors across both bench AND test runners — same shape, both need the seam.
- Adds a `bench-env` fixture and smoke script that asserts string + numeric env vars round-trip through both `getenv()` and `$_ENV`.

## Why

Host shell env vars don't cross the `wp-playground-cli` sandbox boundary. `BENCH_CORPUS_SIZE=1000 homeboy bench <component>` silently ignores the var inside Playground — `getenv('BENCH_CORPUS_SIZE')` returns `false` regardless of what the parent shell set.

Concrete repro that caught this: the MDI bench harness ([Automattic/markdown-database-integration#76](https://github.com/Automattic/markdown-database-integration/pull/76)) documented `BENCH_CORPUS_SIZE` as the corpus-size knob. Operators ran `BENCH_CORPUS_SIZE=10000 bash run-matrix.sh` expecting 10x scale. Every run produced corpus=100 numbers because the env var never reached PHP. Surfaced when bulk-import wall time at "10x corpus" matched the 1x baseline within 2%.

Verified directly with a debug fixture: `BENCH_CORPUS_SIZE=12345` set in the parent shell → `getenv('BENCH_CORPUS_SIZE')` returns `false`, `$_ENV` has 10 entries (Playground internals only), `array_key_exists('BENCH_CORPUS_SIZE', $_ENV)` returns no.

## Behaviour

```json
{
  "extensions": {
    "wordpress": {
      "settings": {
        "bench_env": {
          "BENCH_CORPUS_SIZE": "1000",
          "BENCH_SEED": "42",
          "BENCH_FIXTURES_DIR": "/wordpress/wp-content/plugins/my-comp/tests/fixtures"
        }
      }
    }
  }
}
```

The runner template's putenv() loop runs before workload discovery, so the first thing a workload sees is a populated environment.

```php
return function (): array {
    $size = (int) getenv('BENCH_CORPUS_SIZE');     // 1000
    $seed = (int) getenv('BENCH_SEED');            // 42
    // ...
};
```

For matrix drivers that vary knobs per-cell, synthesize `HOMEBOY_SETTINGS_JSON` inline (the same pattern used today for `wp_config_defines`):

```bash
HOMEBOY_SETTINGS_JSON='{"bench_env":{"BENCH_CORPUS_SIZE":"'$SIZE'"}}' \
  homeboy --output results/$cell.json bench <component> --iterations 10
```

## Validation

- **Invalid keys** (non-string, or strings not matching `/^[A-Za-z_][A-Za-z0-9_]*$/`) log a `NOTICE` and are skipped. Catches typos without failing the run.
- **Non-scalar values** are `json_encode`d before `putenv()` (PHP env-var convention is string-only). Workloads receive a string they can `json_decode` if needed.
- **Empty object `{}`** is the no-op default — components that don't declare `bench_env` see zero behavioural change.

## Plumbing

- `wordpress/wordpress.json` — declares the new `bench_env` setting (type `object`, default `{}`).
- `wordpress/scripts/bench/bench-runner-playground.sh` — extracts `bench_env` from `HOMEBOY_SETTINGS_JSON` via `jq -c`, sed-substitutes into the template using ASCII SOH (`\x01`) as delimiter (same pattern as `wp_config_defines` from #248).
- `wordpress/scripts/test/test-runner-playground.sh` — same extraction + substitution mirrored across the test runner.
- `wordpress/scripts/bench/playground-bench-runner.php` — decodes `{{BENCH_ENV_JSON}}` placeholder, loops `putenv()` + `$_ENV`, runs before discover_workloads stage.
- `wordpress/scripts/test/playground-runner.php` — same loop mirrored for test fixtures, runs after pg_run_boot_stage and before pg_run_install_stage so wp-phpunit fixtures see the env.
- `wordpress/tests/fixtures/bench-env/` — fixture plugin + workload that reads back the env vars and writes their values + presence-in-$_ENV to a shared-state log.
- `wordpress/scripts/bench/playground-bench-env-smoke.sh` — runs the fixture with synthetic `HOMEBOY_SETTINGS_JSON`, asserts each var round-trips through both `getenv()` and `$_ENV`.

## Smoke results

```
--- Read-back log ---
{"BENCH_ENV_FIXTURE_STR_getenv":"'hello'","BENCH_ENV_FIXTURE_NUM_getenv":"'42'","BENCH_ENV_FIXTURE_STR_in_env":"yes","BENCH_ENV_FIXTURE_STR_env_value":"hello"}

============================================
✓ bench_env smoke test PASSED
  All declared env vars round-trip through getenv() and \$_ENV.
============================================
```

## Why this matters beyond MDI

Anything that wants to vary workload knobs across cells (corpus size, seed, iteration shape, fixture path, mode flag, anything that's runtime-tuning rather than wp-config setup) hits the same gap. Without `bench_env`, the only way to inject runtime knobs into Playground was through `wp_config_defines` — which works but conflates wp-config setup (DB names, debug flags, paths) with workload tuning. Two distinct concerns, two distinct settings now.

## Out of scope

- No CHANGELOG / version bumps. Homeboy owns release versioning.
- No core homeboy change. The dispatcher already receives the merged settings JSON via `HOMEBOY_SETTINGS_JSON`; this is wordpress-extension-only.
- No CLI flag (`--bench-env KEY=VAL`). Settings-side declaration covers the use case today; if a CLI flag becomes useful later it's an additive change.

## Related

- #248 (wp_config_defines) — same dispatcher seam, same upstream-first pattern.
- #249 (PLUGIN_SLUG honors COMPONENT_ID) — same MDI bench cook.
- Automattic/markdown-database-integration#76 (the downstream bench harness this fixes — `BENCH_CORPUS_SIZE` will actually work now).

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the dispatcher edits, the runner template putenv() loop (bench + test mirror), the fixture, and the smoke script. Chris reviewed the upstream-first framing — fix the seam upstream so MDI's run-matrix.sh doesn't end up with a workaround that calcifies (baking corpus size into wp_config_defines was the obvious workaround that would have conflated two distinct concerns).