### PR TITLE
Fix WordPress lint runner tool resolution

### DIFF
--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -18,6 +18,25 @@ echo "Setting up WordPress extension..."
 if [ -f "composer.json" ]; then
     echo "Installing PHP dependencies..."
     composer install --quiet --no-interaction
+
+    if [ -x "vendor/bin/phpcs" ]; then
+        echo "Registering PHPCS standards..."
+        phpcs_paths=()
+        for path in \
+            "${EXTENSION_PATH}/vendor/wp-coding-standards/wpcs" \
+            "${EXTENSION_PATH}/vendor/phpcsstandards/phpcsextra" \
+            "${EXTENSION_PATH}/vendor/phpcsstandards/phpcsutils" \
+            "${EXTENSION_PATH}/HomeboyWordPress"; do
+            if [ -d "$path" ]; then
+                phpcs_paths+=("$path")
+            fi
+        done
+
+        if [ "${#phpcs_paths[@]}" -gt 0 ]; then
+            installed_paths=$(IFS=','; printf '%s' "${phpcs_paths[*]}")
+            vendor/bin/phpcs --config-set installed_paths "$installed_paths" --quiet > /dev/null 2>&1
+        fi
+    fi
 fi
 
 # Install npm dependencies (Playground CLI, ESLint).

--- a/wordpress/scripts/lib/runner-steps.sh
+++ b/wordpress/scripts/lib/runner-steps.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Shared step filtering for extension runners.
+#
+# HOMEBOY_STEP is a comma-separated allowlist. When set, only listed steps run.
+# HOMEBOY_SKIP is a comma-separated denylist. Denylist wins when both are set.
+
+homeboy_step_list_contains() {
+    local list="$1"
+    local needle="$2"
+    local item
+
+    IFS=',' read -ra _homeboy_step_items <<< "$list"
+    for item in "${_homeboy_step_items[@]}"; do
+        item="${item//[[:space:]]/}"
+        if [ "$item" = "$needle" ]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+should_run_step() {
+    local step="$1"
+
+    if [ -n "${HOMEBOY_SKIP:-}" ] && homeboy_step_list_contains "${HOMEBOY_SKIP}" "$step"; then
+        return 1
+    fi
+
+    if [ -n "${HOMEBOY_STEP:-}" ]; then
+        homeboy_step_list_contains "${HOMEBOY_STEP}" "$step"
+        return $?
+    fi
+
+    return 0
+}

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -89,7 +89,10 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "Fix-only: ${HOMEBOY_FIX_ONLY:-0}"
 fi
 
-ESLINT_BIN="${EXTENSION_PATH}/node_extensions/.bin/eslint"
+ESLINT_BIN="${EXTENSION_PATH}/node_modules/.bin/eslint"
+if [ ! -f "$ESLINT_BIN" ]; then
+    ESLINT_BIN="${EXTENSION_PATH}/node_extensions/.bin/eslint"
+fi
 ESLINT_CONFIG="${EXTENSION_PATH}/.eslintrc.json"
 
 # Validate tools exist

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -182,6 +182,24 @@ if [ ! -f "$PHPCS_CONFIG" ]; then
     exit 1
 fi
 
+# Composer's PHPCS installer can be bypassed in linked extension installs. Keep
+# the runner self-healing so WordPress-Extra and HomeboyWordPress always resolve.
+PHPCS_STANDARD_PATHS=()
+for phpcs_standard_path in \
+    "${EXTENSION_PATH}/vendor/wp-coding-standards/wpcs" \
+    "${EXTENSION_PATH}/vendor/phpcsstandards/phpcsextra" \
+    "${EXTENSION_PATH}/vendor/phpcsstandards/phpcsutils" \
+    "${EXTENSION_PATH}/HomeboyWordPress"; do
+    if [ -d "$phpcs_standard_path" ]; then
+        PHPCS_STANDARD_PATHS+=("$phpcs_standard_path")
+    fi
+done
+
+if [ "${#PHPCS_STANDARD_PATHS[@]}" -gt 0 ]; then
+    PHPCS_INSTALLED_PATHS=$(IFS=','; printf '%s' "${PHPCS_STANDARD_PATHS[*]}")
+    "$PHPCS_BIN" --config-set installed_paths "$PHPCS_INSTALLED_PATHS" --quiet > /dev/null 2>&1 || true
+fi
+
 # Auto-detect text domain from plugin/theme header (shared helper)
 DETECT_COMPONENT_HELPER="${HOMEBOY_RUNTIME_DETECT_COMPONENT:-${SCRIPT_DIR}/../lib/detect-component.sh}"
 # shellcheck source=../lib/detect-component.sh

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -93,7 +93,7 @@ generate_dependency_config() {
     local has_dependencies=0
     local has_baseline=0
 
-    tmpfile=$(homeboy_mktemp 'phpstan-dependencies.XXXXXX')
+    tmpfile=$(homeboy_mktemp 'phpstan-dependencies.XXXXXX.neon')
 
     {
         printf '%s\n' 'includes:'
@@ -271,7 +271,7 @@ PHPSTAN_TMPCONFIG=""
 generate_phpstan_config() {
     local max_processes="${1:-}"
     local tmpfile
-    tmpfile=$(homeboy_mktemp 'phpstan.XXXXXX')
+    tmpfile=$(homeboy_mktemp 'phpstan.XXXXXX.neon')
     {
         printf 'includes:\n'
         printf '    - %s\n' "${PHPSTAN_BASE_CONFIG}"


### PR DESCRIPTION
## Summary
- Register WordPress PHPCS standards during setup and self-heal runner config so `WordPress-Extra` and `HomeboyWordPress` resolve in linked installs.
- Restore the local runner step-filter helper and fix ESLint binary lookup for npm-installed dependencies.
- Give generated PHPStan temp configs a `.neon` suffix for PHPStan 2 compatibility.

## Testing
- `bash -n wordpress/scripts/build/setup.sh wordpress/scripts/lint/lint-runner.sh wordpress/scripts/lint/eslint-runner.sh wordpress/scripts/lint/phpstan-runner.sh wordpress/scripts/lib/runner-steps.sh`
- `git diff --check`
- `bash scripts/build/setup.sh`
- Targeted PHPCS runner passes against `extrachill-artist-platform` and skips filtered steps correctly.
- ESLint runner reaches ESLint and reports existing JS findings instead of missing the binary.
- PHPStan runner reaches PHPStan and reports existing project findings instead of rejecting temp config extensions.

Closes #251
Closes #252
Closes #253