### PR TITLE
feat(wordpress-bench): surface bootstrap stage timings as __bootstrap scenario

### DIFF
--- a/wordpress/scripts/bench/playground-bench-bootstrap-metrics-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-bootstrap-metrics-smoke.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Bootstrap-stage timings smoke test (homeboy-extensions#255).
+#
+# Runs the bench-noop fixture and asserts the synthetic `__bootstrap`
+# scenario is emitted with the expected shape:
+#   - scenarios[0].id == "__bootstrap" (ordering: must be first)
+#   - scenarios[0].iterations == 1
+#   - scenarios[0].metrics has boot_ms, install_ms, load_deps_ms, load_component_ms
+#   - all four metric values are positive floats (> 0)
+#   - subsequent fixture scenarios still appear correctly
+#
+# This locks in the contract that bootstrap stage timings are measured
+# once per bench-runner invocation (Playground boots once, runs every
+# workload inside the booted process) and surfaced as a single-iteration
+# scenario for cross-run / cross-rig comparison via homeboy core's
+# baseline + regression-detection machinery.
+#
+# Manual integration test, not part of CI. Run after changes to:
+#   - scripts/lib/playground-bootstrap.php (pg_stage_begin/ok/durations_ms)
+#   - scripts/bench/playground-bench-runner.php (the synthetic-scenario emit)
+#
+# Usage: bash wordpress/scripts/bench/playground-bench-bootstrap-metrics-smoke.sh
+# Exit:  0 = bootstrap metrics round-trip, non-zero = regression
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-noop"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    echo "Install: brew install jq (macOS) or your package manager." >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-bootstrap-metrics-smoke.XXXXXX")
+
+cleanup() {
+    rm -f "$RESULTS_TMPFILE"
+}
+trap cleanup EXIT
+
+echo "============================================"
+echo "Bootstrap stage timings smoke test (#255)"
+echo "============================================"
+echo "Fixture:    $FIXTURE_DIR"
+echo "Iterations: 3 (per workload; bootstrap is always 1)"
+echo ""
+
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS=3 \
+HOMEBOY_COMPONENT_ID=bench-noop \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+echo ""
+echo "--- Results envelope ---"
+cat "$RESULTS_TMPFILE"
+echo ""
+
+# --- Assertion 1: scenarios[0].id == "__bootstrap" (ordering matters) ---
+first_id=$(jq -r '.scenarios[0].id' "$RESULTS_TMPFILE")
+if [ "$first_id" != "__bootstrap" ]; then
+    echo "ERROR: expected scenarios[0].id == '__bootstrap', got '$first_id'" >&2
+    exit 1
+fi
+echo "✓ scenarios[0].id == '__bootstrap'"
+
+# --- Assertion 2: scenarios[0].iterations == 1 ---
+first_iters=$(jq -r '.scenarios[0].iterations' "$RESULTS_TMPFILE")
+if [ "$first_iters" != "1" ]; then
+    echo "ERROR: expected scenarios[0].iterations == 1, got '$first_iters'" >&2
+    exit 1
+fi
+echo "✓ scenarios[0].iterations == 1"
+
+# --- Assertion 3: all four bootstrap metric keys present + positive floats ---
+for metric in boot_ms install_ms load_deps_ms load_component_ms; do
+    val=$(jq -r ".scenarios[0].metrics.${metric} // \"missing\"" "$RESULTS_TMPFILE")
+    if [ "$val" = "missing" ] || [ "$val" = "null" ]; then
+        echo "ERROR: scenarios[0].metrics.${metric} missing" >&2
+        exit 1
+    fi
+    # jq compare: > 0 against the raw numeric value.
+    is_positive=$(jq -r ".scenarios[0].metrics.${metric} > 0" "$RESULTS_TMPFILE")
+    if [ "$is_positive" != "true" ]; then
+        echo "ERROR: scenarios[0].metrics.${metric} = $val, expected > 0" >&2
+        exit 1
+    fi
+    echo "✓ scenarios[0].metrics.${metric} = ${val} (> 0)"
+done
+
+# --- Assertion 4: subsequent fixture scenarios still appear ---
+# bench-noop fixture has 2 workloads (noop + array-fill-1k); plus __bootstrap = 3.
+scenario_count=$(jq -r '.scenarios | length' "$RESULTS_TMPFILE")
+if [ "$scenario_count" -ne 3 ]; then
+    echo "ERROR: expected 3 scenarios (__bootstrap + 2 fixtures), got $scenario_count" >&2
+    exit 1
+fi
+echo "✓ scenarios length == 3 (__bootstrap + 2 fixtures)"
+
+# --- Assertion 5: fixture scenarios carry their original metric shape ---
+# Spot-check scenario[1] has the standard p50_ms key (not bootstrap-shape).
+fixture_p50=$(jq -r '.scenarios[1].metrics.p50_ms // "missing"' "$RESULTS_TMPFILE")
+if [ "$fixture_p50" = "missing" ] || [ "$fixture_p50" = "null" ]; then
+    echo "ERROR: scenarios[1] missing p50_ms (workload metric shape lost)" >&2
+    exit 1
+fi
+echo "✓ scenarios[1].metrics.p50_ms present (workload shape preserved)"
+
+echo ""
+echo "============================================"
+echo "✓ Bootstrap metrics smoke test PASSED"
+echo "============================================"

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -294,6 +294,33 @@ try {
 // ---------------------------------------------------------------------------
 pg_stage_begin('emit_results');
 try {
+    // Surface bootstrap stage timings as a synthetic `__bootstrap`
+    // scenario (homeboy-extensions#255). Boot is once-per-run (the
+    // wp-playground-cli process boots once and runs every workload
+    // inside the booted process), so iterations=1 reflects reality —
+    // distribution math (p50/p95/p99) doesn't apply to N=1 measurements.
+    //
+    // Cross-run distribution comes from running the bench harness
+    // multiple times (e.g. CI on different commits), not from
+    // iterations within a single run. Reusing BenchScenario keeps
+    // baseline / regression-detection / cross-rig diff machinery
+    // working with no schema change. The `__` prefix on the scenario
+    // id makes the synthetic nature obvious in reports.
+    $bootstrap_durations = pg_stage_durations_ms();
+    $bootstrap_metrics = [];
+    foreach (['boot', 'install', 'load_deps', 'load_component'] as $stage) {
+        if (isset($bootstrap_durations[$stage])) {
+            $bootstrap_metrics["{$stage}_ms"] = $bootstrap_durations[$stage];
+        }
+    }
+    if (!empty($bootstrap_metrics)) {
+        array_unshift($scenarios, [
+            'id' => '__bootstrap',
+            'iterations' => 1,
+            'metrics' => $bootstrap_metrics,
+        ]);
+    }
+
     $results_path = "$plugin_path/.pg-bench-results{{RESULT_SUFFIX}}.json";
     $envelope = [
         'component_id' => '{{COMPONENT_ID}}',

--- a/wordpress/scripts/bench/playground-bench-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-smoke.sh
@@ -67,7 +67,9 @@ echo "--- Results envelope ---"
 cat "$RESULTS_TMPFILE"
 echo ""
 
-# Asserts: the envelope round-trips both fixtures with all six metric keys.
+# Asserts: the envelope round-trips both fixtures with all six metric keys,
+# plus the synthetic `__bootstrap` scenario emitted by the bench runner
+# (homeboy-extensions#255).
 # Plain bash so the smoke has no extra deps.
 require_field() {
     local field="$1"
@@ -80,16 +82,18 @@ require_field() {
 require_field "component_id"
 require_field "iterations"
 require_field "scenarios"
+require_field "__bootstrap"
 require_field "noop"
 require_field "array-fill-1k"
 for metric in mean_ms p50_ms p95_ms p99_ms min_ms max_ms; do
     require_field "$metric"
 done
 
-# Both fixture workloads should be present — count `"id":` occurrences.
+# Three scenarios expected: __bootstrap + the two fixture workloads.
+# Count `"id":` occurrences.
 scenario_count=$(grep -c '"id":' "$RESULTS_TMPFILE" || true)
-if [ "$scenario_count" -ne 2 ]; then
-    echo "ERROR: expected 2 scenarios, got $scenario_count" >&2
+if [ "$scenario_count" -ne 3 ]; then
+    echo "ERROR: expected 3 scenarios (__bootstrap + 2 fixtures), got $scenario_count" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/lib/playground-bootstrap.php
+++ b/wordpress/scripts/lib/playground-bootstrap.php
@@ -65,20 +65,65 @@ function pg_log($msg) {
 }
 
 /**
+ * Module-scope stage timing storage.
+ *
+ * Stores `hrtime(true)` start times in `_starts_ns` keyed by stage name,
+ * and successful-stage durations in `_durations_ms` keyed by stage name
+ * (float milliseconds). Stages that begin but never `ok` (i.e. failed)
+ * are absent from `_durations_ms` — only successful stages have
+ * meaningful timings.
+ *
+ * Exposed via pg_stage_durations_ms() to the bench runner, which
+ * surfaces them as a synthetic `__bootstrap` scenario in the
+ * BenchResults envelope (homeboy-extensions#255).
+ */
+function &pg_stage_timings_ref(): array {
+    static $timings = ['_starts_ns' => [], '_durations_ms' => []];
+    return $timings;
+}
+
+/**
  * Mark the start of a bootstrap stage.
  *
  * Updates the global $current_stage so the shutdown handler can attribute
  * fatal errors to the right stage even when an exit happens mid-stage.
+ * Also records `hrtime(true)` for later duration calculation.
  */
 function pg_stage_begin($stage) {
     global $current_stage;
     $current_stage = $stage;
+    $timings = &pg_stage_timings_ref();
+    $timings['_starts_ns'][$stage] = hrtime(true);
     pg_log("STAGE_BEGIN:$stage");
 }
 
-/** Mark a stage as completed cleanly. */
+/**
+ * Mark a stage as completed cleanly.
+ *
+ * Computes and stores the elapsed duration in milliseconds, but only if
+ * a matching pg_stage_begin() was recorded — defensive against any
+ * caller emitting a STAGE_OK without a paired BEGIN.
+ */
 function pg_stage_ok($stage) {
+    $timings = &pg_stage_timings_ref();
+    if (isset($timings['_starts_ns'][$stage])) {
+        $elapsed_ns = hrtime(true) - $timings['_starts_ns'][$stage];
+        $timings['_durations_ms'][$stage] = $elapsed_ns / 1_000_000;
+    }
     pg_log("STAGE_OK:$stage");
+}
+
+/**
+ * Return successful-stage durations in milliseconds.
+ *
+ * Result shape: ['boot' => 1234.56, 'install' => 234.5, ...].
+ * Only stages that completed via pg_stage_ok() are included; stages
+ * that failed (pg_stage_fail / fatal shutdown) are absent because
+ * their timings would be misleading.
+ */
+function pg_stage_durations_ms(): array {
+    $timings = &pg_stage_timings_ref();
+    return $timings['_durations_ms'];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Surface `boot`/`install`/`load_deps`/`load_component` stage durations as a synthetic `__bootstrap` scenario in `BenchResults`.
- Stage timings recorded via `hrtime(true)` in `pg_stage_begin` / `pg_stage_ok`, exposed via the new `pg_stage_durations_ms()` accessor.
- No schema change. No new dispatcher arguments. No version bump.
- Closes #255.

## Architecture

Picked **Option B** (synthetic `__bootstrap` scenario) per the issue body's recommendation. Reuses the existing `BenchScenario` shape end-to-end, so homeboy core's baseline / regression-detection / cross-rig diff machinery sees bootstrap timings the same way it sees any other scenario — no special-casing required.

`iterations: 1` because `bench-runner-playground.sh` spawns `wp-playground-cli php` **once per bench invocation**, not once per iteration. The four bootstrap stages run once at startup; the per-iteration loop runs inside the already-booted Playground process. Distribution math (p50/p95/p99) doesn't apply to N=1, so the metrics map carries simple `boot_ms` / `install_ms` / `load_deps_ms` / `load_component_ms` values. Cross-run distribution comes from running the bench harness multiple times across commits/rigs, not from iterations within a single run.

`__` prefix on the scenario id makes the synthetic nature obvious in reports and gives report-rendering code a stable hook to render bootstrap timings in their own section if/when that's worth doing later. `array_unshift` places it first in `scenarios[]` so it leads the diff table.

Stages that begin but never `ok` (i.e. failed) are absent from `pg_stage_durations_ms()` — only successful stages have meaningful timings. The four-stage allowlist in the runner means a failing stage simply omits its key from `bootstrap_metrics`; the synthetic scenario is suppressed entirely if all four are missing.

`pg_stage_begin` / `pg_stage_ok` signatures are unchanged. The test runner (`scripts/test/playground-runner.php`) shares the same bootstrap helpers and pays nothing extra — the new `pg_stage_durations_ms()` accessor is opt-in and only the bench runner calls it.

## Tests

**New:** `wordpress/scripts/bench/playground-bench-bootstrap-metrics-smoke.sh` — 5 assertions:

1. `scenarios[0].id == "__bootstrap"` (ordering: must be first)
2. `scenarios[0].iterations == 1`
3. All four bootstrap metric keys (`boot_ms`, `install_ms`, `load_deps_ms`, `load_component_ms`) present and `> 0`
4. Total scenario count is 3 (`__bootstrap` + 2 fixture workloads)
5. Fixture scenarios still carry their original metric shape (`p50_ms` etc.) — workload metrics not contaminated by the synthetic scenario

**Updated:** `playground-bench-smoke.sh` — bumped scenario-count assertion from 2 to 3 and added `__bootstrap` to required fields.

**All existing smokes pass:** `playground-bench-smoke.sh`, `playground-bench-env-smoke.sh`, `playground-bench-shared-state-smoke.sh`, `playground-bench-wp-config-defines-smoke.sh`. The `playground-dropin-smoke.sh` failure is pre-existing on `main` (unrelated fixture issue) — bootstrap stages all complete successfully (`STAGE_OK:boot/install/load_deps/load_component`), confirming the test runner path is unaffected.

## Live verify

Ran the bench against the `bench-noop` fixture on this branch:

```json
{
  "id": "__bootstrap",
  "iterations": 1,
  "metrics": {
    "boot_ms": 11.8165,
    "install_ms": 729.673916,
    "load_deps_ms": 0.086042,
    "load_component_ms": 0.82825
  }
}
```

Substantive numbers — `install_ms` (~500-730ms) dominates, which matches expectations (wp-phpunit's `install.php` boots WordPress and creates SQLite tables in-process). `boot_ms` (~11ms) is PHP-WASM render + composer autoload. `load_deps_ms` and `load_component_ms` are sub-millisecond for this minimal fixture, which is also expected — bench-noop has no declared dependencies and the fixture plugin is a stub.

Numbers are stable across runs (variance dominated by `install_ms`, ~500-730ms range observed).

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the PHP changes, the new smoke script, and the existing-smoke update from the issue spec; Chris reviewed and live-verified.

Closes #255
