### PR TITLE
feat(rust): add bench capability dispatching cargo bench-* binaries

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -19,6 +19,9 @@
   "test": {
     "extension_script": "scripts/test-runner.sh"
   },
+  "bench": {
+    "extension_script": "scripts/bench/bench-runner.sh"
+  },
   "audit": {
     "feature_patterns": [
       "#\\[derive\\(.*Subcommand.*\\)\\]\\s*(?:pub\\s+)?enum\\s+(\\w+)",

--- a/rust/scripts/bench/bench-runner.sh
+++ b/rust/scripts/bench/bench-runner.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Rust bench runner for `homeboy bench`.
+#
+# Discovers bench binaries declared in the component's Cargo.toml
+# (`[[bin]]` entries with `name = "bench-*"` or `src/bin/bench-*.rs`
+# files) and executes each via `cargo run --release --bin bench-<id>`.
+# Aggregates per-binary timing JSON into the BenchResults envelope
+# homeboy core expects.
+#
+# CONTRACT (component side)
+#
+# Each bench binary must:
+#   1. Read iteration count from env var HOMEBOY_BENCH_ITERATIONS
+#      (default 10 if unset).
+#   2. Run its measured workload that many times, timing each iteration
+#      with std::time::Instant.
+#   3. Emit a single JSON object to stdout (last line of output) with shape:
+#
+#        {
+#          "timings_ns": [12345, 12678, 12112, ...],
+#          "peak_rss_bytes": 41943040
+#        }
+#
+#      timings_ns: array of per-iteration nanosecond durations
+#                  (length must equal HOMEBOY_BENCH_ITERATIONS)
+#      peak_rss_bytes: optional, max RSS across iterations
+#
+#   4. Exit 0 on success, non-zero on failure. Stderr is captured for
+#      diagnostics but ignored for results.
+#
+# A reference workload helper crate (homeboy-bench-rs) is planned to
+# eliminate the boilerplate, but the contract above is the source of truth —
+# components without a helper dep can implement it directly in ~20 lines.
+#
+# CONTRACT (homeboy core side)
+#
+# Standard env vars set by core:
+#   HOMEBOY_EXTENSION_PATH       — path to this extension
+#   HOMEBOY_COMPONENT_PATH       — path to the Rust project root (Cargo.toml)
+#   HOMEBOY_COMPONENT_ID         — component identifier
+#   HOMEBOY_BENCH_ITERATIONS     — iterations per workload (default 10)
+#   HOMEBOY_BENCH_RESULTS_FILE   — where core wants the envelope written
+#   HOMEBOY_DEBUG                — verbose output
+
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
+    case "$(uname -s)" in
+        Darwin) echo "  brew install bash" >&2 ;;
+    esac
+    exit 1
+fi
+
+FAILED_STEP=""
+FAILURE_OUTPUT=""
+
+print_failure_summary() {
+    if [ -n "$FAILED_STEP" ]; then
+        echo "" >&2
+        echo "============================================" >&2
+        echo "BENCH FAILED: $FAILED_STEP" >&2
+        echo "============================================" >&2
+        if [ -n "$FAILURE_OUTPUT" ]; then
+            echo "" >&2
+            echo "Error details:" >&2
+            echo "$FAILURE_OUTPUT" >&2
+        fi
+    fi
+}
+trap print_failure_summary EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Resolve context (matches test-runner.sh shape).
+if [ -n "${HOMEBOY_COMPONENT_PATH:-}" ]; then
+    PROJECT_PATH="${HOMEBOY_COMPONENT_PATH}"
+    COMPONENT_ID="${HOMEBOY_COMPONENT_ID:-$(basename "$PROJECT_PATH")}"
+else
+    PROJECT_PATH="$(pwd)"
+    COMPONENT_ID="$(basename "$PROJECT_PATH")"
+fi
+
+EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-10}"
+RESULTS_FILE="${HOMEBOY_BENCH_RESULTS_FILE:-${PROJECT_PATH}/.rust-bench-results.json}"
+
+if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "DEBUG: [bench:rust] extension=$EXTENSION_PATH" >&2
+    echo "DEBUG: [bench:rust] project=$PROJECT_PATH" >&2
+    echo "DEBUG: [bench:rust] component_id=$COMPONENT_ID" >&2
+    echo "DEBUG: [bench:rust] iterations=$ITERATIONS" >&2
+    echo "DEBUG: [bench:rust] results=$RESULTS_FILE" >&2
+fi
+
+if [ ! -f "${PROJECT_PATH}/Cargo.toml" ]; then
+    FAILED_STEP="not a Rust project"
+    FAILURE_OUTPUT="No Cargo.toml at ${PROJECT_PATH}"
+    exit 1
+fi
+
+# Verify cargo is available.
+if ! command -v cargo >/dev/null 2>&1; then
+    FAILED_STEP="cargo not on PATH"
+    FAILURE_OUTPUT="Install Rust toolchain: https://rustup.rs"
+    exit 1
+fi
+
+# ── Discover bench binaries ────────────────────────────────────────
+#
+# A bench workload is a Cargo binary whose name starts with `bench-`.
+# Cargo recognizes binaries in two places:
+#   1. [[bin]] entries in Cargo.toml
+#   2. src/bin/<name>.rs (auto-discovered)
+# Both manifest paths are supported.
+
+discover_bench_bins() {
+    local _bins=()
+
+    # 1. Auto-discovered: src/bin/bench-*.rs
+    if [ -d "${PROJECT_PATH}/src/bin" ]; then
+        while IFS= read -r f; do
+            local _name
+            _name="$(basename "$f" .rs)"
+            if [[ "$_name" == bench-* ]]; then
+                _bins+=("$_name")
+            fi
+        done < <(find "${PROJECT_PATH}/src/bin" -maxdepth 1 -name 'bench-*.rs' -type f 2>/dev/null | sort)
+    fi
+
+    # 2. Explicit [[bin]] entries with name = "bench-*"
+    # Use cargo metadata for robust parsing (handles workspaces, etc.).
+    if command -v jq >/dev/null 2>&1; then
+        while IFS= read -r _name; do
+            [ -n "$_name" ] || continue
+            # Avoid duplicates from method 1.
+            local _seen=0
+            for _existing in "${_bins[@]:-}"; do
+                if [ "$_existing" = "$_name" ]; then _seen=1; break; fi
+            done
+            [ "$_seen" = "0" ] && _bins+=("$_name")
+        done < <(cargo metadata --no-deps --format-version=1 --manifest-path="${PROJECT_PATH}/Cargo.toml" 2>/dev/null \
+            | jq -r '.packages[].targets[] | select(.kind[0] == "bin") | select(.name | startswith("bench-")) | .name')
+    fi
+
+    printf '%s\n' "${_bins[@]:-}"
+}
+
+mapfile -t BENCH_BINS < <(discover_bench_bins)
+
+if [ "${#BENCH_BINS[@]}" -eq 0 ]; then
+    echo "" >&2
+    echo "⚠ No bench binaries found at ${PROJECT_PATH}" >&2
+    echo "  Bench binaries must be named 'bench-*' and live at" >&2
+    echo "  src/bin/bench-*.rs or be declared as [[bin]] entries in Cargo.toml." >&2
+    echo "" >&2
+    cat > "$RESULTS_FILE" <<EMPTY
+{"component_id":"${COMPONENT_ID}","iterations":0,"scenarios":[]}
+EMPTY
+    exit 0
+fi
+
+echo "Running Rust benchmarks..."
+echo "  Component: ${COMPONENT_ID} (${PROJECT_PATH})"
+echo "  Iterations: ${ITERATIONS}"
+echo "  Discovered: ${#BENCH_BINS[@]} bench binaries"
+
+# ── Run each bench binary ──────────────────────────────────────────
+
+# Build all bench binaries up front so the per-binary loop only pays
+# cargo's metadata-resolution cost, not a fresh compile each time.
+echo ""
+echo "Building bench binaries (release)..."
+BUILD_ARGS=(build --release --manifest-path="${PROJECT_PATH}/Cargo.toml")
+for _bin in "${BENCH_BINS[@]}"; do
+    BUILD_ARGS+=(--bin "$_bin")
+done
+if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    cargo "${BUILD_ARGS[@]}"
+else
+    cargo "${BUILD_ARGS[@]}" 2>&1 | tail -5 || {
+        FAILED_STEP="cargo build"
+        exit 1
+    }
+fi
+
+SCENARIOS_JSON_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$SCENARIOS_JSON_TMPDIR"; print_failure_summary' EXIT
+
+OVERALL_OK=1
+SCENARIOS_PATHS=()
+for _bin in "${BENCH_BINS[@]}"; do
+    # scenario id = bin name minus "bench-" prefix
+    _scenario_id="${_bin#bench-}"
+    _scenario_file="${SCENARIOS_JSON_TMPDIR}/${_scenario_id}.json"
+
+    echo ""
+    echo "WORKLOAD_BEGIN: ${_scenario_id} (${_bin})"
+
+    set +e
+    HOMEBOY_BENCH_ITERATIONS="$ITERATIONS" \
+        cargo run --release --quiet --manifest-path="${PROJECT_PATH}/Cargo.toml" \
+        --bin "$_bin" > "${_scenario_file}.raw" 2> "${_scenario_file}.err"
+    _exit=$?
+    set -e
+
+    if [ "$_exit" -ne 0 ]; then
+        echo "WORKLOAD_ERROR: ${_scenario_id} — cargo exit $_exit" >&2
+        if [ -s "${_scenario_file}.err" ]; then
+            echo "  stderr:" >&2
+            sed 's/^/    /' "${_scenario_file}.err" >&2
+        fi
+        OVERALL_OK=0
+        continue
+    fi
+
+    # Last non-empty stdout line is the JSON payload (lets bench
+    # binaries emit progress lines without breaking the contract).
+    _payload="$(grep -v '^[[:space:]]*$' "${_scenario_file}.raw" | tail -n 1)"
+
+    if [ -z "$_payload" ]; then
+        echo "WORKLOAD_ERROR: ${_scenario_id} — no JSON output on stdout" >&2
+        OVERALL_OK=0
+        continue
+    fi
+
+    echo "$_payload" > "$_scenario_file"
+    SCENARIOS_PATHS+=("${_scenario_id}=${_scenario_file}")
+
+    # Quick visual confirmation (best-effort, requires jq).
+    if command -v jq >/dev/null 2>&1; then
+        _count="$(jq -r '.timings_ns | length' "$_scenario_file" 2>/dev/null || echo "?")"
+        echo "WORKLOAD_DONE:  ${_scenario_id} (${_count} iterations measured)"
+    else
+        echo "WORKLOAD_DONE:  ${_scenario_id}"
+    fi
+done
+
+# ── Build the BenchResults envelope ────────────────────────────────
+#
+# Use python3 for the JSON math: jq doesn't have a clean way to do
+# percentile interpolation, and we want bit-for-bit parity with the
+# WP and Node runners' R-7 method.
+
+if ! command -v python3 >/dev/null 2>&1; then
+    FAILED_STEP="python3 not on PATH"
+    FAILURE_OUTPUT="bench-runner.sh requires python3 for percentile math"
+    exit 1
+fi
+
+python3 - <<PYTHON_AGGREGATE "$RESULTS_FILE" "$COMPONENT_ID" "$ITERATIONS" "${SCENARIOS_PATHS[@]:-}"
+import json, os, sys
+
+results_file = sys.argv[1]
+component_id = sys.argv[2]
+iterations   = int(sys.argv[3])
+scenario_kvs = sys.argv[4:]
+
+def percentile_r7(sorted_ms, p):
+    n = len(sorted_ms)
+    if n == 0: return 0.0
+    if n == 1: return sorted_ms[0]
+    rank = p * (n - 1)
+    lo, hi = int(rank), -(-int(rank * 10 ** 9) // 10 ** 9)  # ceil
+    hi = min(int(rank) + (1 if rank > int(rank) else 0), n - 1)
+    if lo == hi: return sorted_ms[lo]
+    frac = rank - lo
+    return sorted_ms[lo] * (1 - frac) + sorted_ms[hi] * frac
+
+scenarios = []
+for kv in scenario_kvs:
+    if not kv: continue
+    sid, path = kv.split("=", 1)
+    with open(path) as f:
+        payload = json.load(f)
+
+    timings_ns = payload.get("timings_ns", [])
+    timings_ms = sorted(t / 1_000_000.0 for t in timings_ns)
+    n = len(timings_ms)
+
+    if n == 0:
+        sys.stderr.write(f"WORKLOAD_WARN: {sid} emitted no timings\n")
+        continue
+
+    metrics = {
+        "mean_ms": sum(timings_ms) / n,
+        "p50_ms":  percentile_r7(timings_ms, 0.50),
+        "p95_ms":  percentile_r7(timings_ms, 0.95),
+        "p99_ms":  percentile_r7(timings_ms, 0.99),
+        "min_ms":  timings_ms[0],
+        "max_ms":  timings_ms[-1],
+    }
+
+    scenario = {
+        "id": sid,
+        "iterations": n,
+        "metrics": metrics,
+    }
+    if "peak_rss_bytes" in payload:
+        scenario["memory"] = {"peak_bytes": int(payload["peak_rss_bytes"])}
+
+    scenarios.append(scenario)
+
+envelope = {
+    "component_id": component_id,
+    "iterations":   iterations,
+    "scenarios":    scenarios,
+}
+
+os.makedirs(os.path.dirname(results_file) or ".", exist_ok=True)
+with open(results_file, "w") as f:
+    json.dump(envelope, f, indent=2)
+
+print(f"\nResults: {len(scenarios)} scenario(s) written to {results_file}")
+PYTHON_AGGREGATE
+
+if [ "$OVERALL_OK" -ne 1 ]; then
+    FAILED_STEP="one or more bench binaries failed"
+    exit 1
+fi
+
+if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "DEBUG: [bench:rust] envelope written to $RESULTS_FILE" >&2
+fi

--- a/rust/scripts/bench/rust-bench-smoke.sh
+++ b/rust/scripts/bench/rust-bench-smoke.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Rust bench harness end-to-end smoke test.
+#
+# Runs the fixture at rust/tests/fixtures/bench-noop/ through the bench
+# dispatcher and asserts that:
+#   - The dispatcher exits 0 with a populated BenchResults JSON envelope.
+#   - Both fixture workloads (bench-noop, bench-busy) appear as scenarios.
+#   - Every scenario carries the six metric keys homeboy core expects
+#     (mean_ms, p50_ms, p95_ms, p99_ms, min_ms, max_ms).
+#   - Iteration count matches HOMEBOY_BENCH_ITERATIONS.
+#
+# Manual integration test, not part of CI. Run after changes to:
+#   - bench-runner.sh (the dispatcher)
+#   - rust.json (capability registration)
+#   - the bench contract (component-side timings_ns/peak_rss_bytes shape)
+#
+# Usage: bash rust/scripts/bench/rust-bench-smoke.sh
+# Exit:  0 = harness round-trips end-to-end, non-zero = regression
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-noop"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "ERROR: cargo not on PATH (install via https://rustup.rs)" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for smoke assertions" >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/rust-bench-smoke-results.XXXXXX")
+
+# shellcheck disable=SC2064
+trap "rm -f '$RESULTS_TMPFILE'" EXIT
+
+echo "============================================"
+echo "Rust bench harness smoke test"
+echo "============================================"
+echo "Fixture:    $FIXTURE_DIR"
+echo "Iterations: 5 (per workload)"
+echo "Output:     $RESULTS_TMPFILE"
+echo
+
+ITERATIONS=5
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_COMPONENT_ID="bench-noop-fixture" \
+HOMEBOY_BENCH_ITERATIONS="$ITERATIONS" \
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+echo
+echo "── Validating envelope shape ──"
+
+assert() {
+    local _label="$1"
+    local _actual="$2"
+    local _expected="$3"
+    if [ "$_actual" = "$_expected" ]; then
+        echo "  ✓ $_label: $_actual"
+    else
+        echo "  ✗ $_label: got '$_actual', expected '$_expected'" >&2
+        exit 1
+    fi
+}
+
+assert "component_id"  "$(jq -r '.component_id' "$RESULTS_TMPFILE")"  "bench-noop-fixture"
+assert "iterations"    "$(jq -r '.iterations' "$RESULTS_TMPFILE")"    "$ITERATIONS"
+
+SCENARIO_COUNT="$(jq -r '.scenarios | length' "$RESULTS_TMPFILE")"
+if [ "$SCENARIO_COUNT" -lt 2 ]; then
+    echo "  ✗ scenarios: expected ≥ 2, got $SCENARIO_COUNT" >&2
+    cat "$RESULTS_TMPFILE" >&2
+    exit 1
+fi
+echo "  ✓ scenarios: $SCENARIO_COUNT"
+
+# Every scenario must have the six standard metric keys.
+for _required_key in mean_ms p50_ms p95_ms p99_ms min_ms max_ms; do
+    MISSING="$(jq -r --arg k "$_required_key" '.scenarios[] | select(.metrics[$k] == null) | .id' "$RESULTS_TMPFILE")"
+    if [ -n "$MISSING" ]; then
+        echo "  ✗ missing metric '$_required_key' in scenario(s): $MISSING" >&2
+        exit 1
+    fi
+    echo "  ✓ all scenarios have $_required_key"
+done
+
+# Every scenario's iteration count must match.
+MISMATCH="$(jq -r --argjson n "$ITERATIONS" '.scenarios[] | select(.iterations != $n) | .id' "$RESULTS_TMPFILE")"
+if [ -n "$MISMATCH" ]; then
+    echo "  ✗ scenario iteration count mismatch: $MISMATCH" >&2
+    exit 1
+fi
+echo "  ✓ all scenarios report iterations=$ITERATIONS"
+
+# All p95 values must be > 0 (sanity check that timing actually happened).
+ZERO_TIMINGS="$(jq -r '.scenarios[] | select(.metrics.p95_ms <= 0) | .id' "$RESULTS_TMPFILE")"
+if [ -n "$ZERO_TIMINGS" ]; then
+    echo "  ✗ scenario(s) with p95_ms <= 0 (no work timed): $ZERO_TIMINGS" >&2
+    exit 1
+fi
+echo "  ✓ all scenarios have p95_ms > 0"
+
+# bench-busy should be slower than bench-noop (sanity check on relative ordering).
+NOOP_P95="$(jq -r '.scenarios[] | select(.id == "noop") | .metrics.p95_ms' "$RESULTS_TMPFILE")"
+BUSY_P95="$(jq -r '.scenarios[] | select(.id == "busy") | .metrics.p95_ms' "$RESULTS_TMPFILE")"
+if [ -n "$NOOP_P95" ] && [ -n "$BUSY_P95" ]; then
+    if (( $(awk "BEGIN { print ($BUSY_P95 > $NOOP_P95) }") )); then
+        echo "  ✓ relative ordering sane: busy ($BUSY_P95 ms) > noop ($NOOP_P95 ms)"
+    else
+        echo "  ✗ unexpected ordering: busy ($BUSY_P95 ms) <= noop ($NOOP_P95 ms)" >&2
+        exit 1
+    fi
+fi
+
+echo
+echo "============================================"
+echo "✓ Smoke test passed"
+echo "============================================"

--- a/rust/tests/fixtures/bench-noop/.gitignore
+++ b/rust/tests/fixtures/bench-noop/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/rust/tests/fixtures/bench-noop/Cargo.toml
+++ b/rust/tests/fixtures/bench-noop/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "bench-noop-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+# Test fixture for the homeboy bench harness. Two bench binaries discoverable
+# via the `bench-*` naming convention. See ../../scripts/bench/bench-runner.sh.
+
+[[bin]]
+name = "bench-noop"
+path = "src/bin/bench-noop.rs"
+
+[[bin]]
+name = "bench-busy"
+path = "src/bin/bench-busy.rs"
+
+[profile.release]
+# Default release settings — the bench harness builds with --release so this
+# matches what real components will pay.
+opt-level = 3
+lto = false

--- a/rust/tests/fixtures/bench-noop/src/bin/bench-busy.rs
+++ b/rust/tests/fixtures/bench-noop/src/bin/bench-busy.rs
@@ -1,0 +1,45 @@
+//! Busy bench fixture — measurable workload.
+//!
+//! Does enough work per iteration that the timings_ns values land
+//! comfortably above timer resolution and noticeably above bench-noop's
+//! floor. Exercise the harness's percentile math on a non-degenerate
+//! distribution.
+//!
+//! Same contract as bench-noop.rs.
+
+use std::env;
+use std::hint::black_box;
+use std::time::Instant;
+
+fn bench_main() -> u64 {
+    // Sum integers 0..10_000 with black_box around each input to defeat
+    // const-folding. ~10us per iteration on modern hardware — well above
+    // timer noise without making the smoke slow.
+    let mut acc: u64 = 0;
+    for i in 0..10_000u64 {
+        acc = acc.wrapping_add(black_box(i));
+    }
+    acc
+}
+
+fn main() {
+    let iterations: usize = env::var("HOMEBOY_BENCH_ITERATIONS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10);
+
+    let mut timings = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let start = Instant::now();
+        let _ = bench_main();
+        timings.push(start.elapsed().as_nanos() as u64);
+    }
+
+    let timings_csv: String = timings
+        .iter()
+        .map(|t| t.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    println!("{{\"timings_ns\":[{}]}}", timings_csv);
+}

--- a/rust/tests/fixtures/bench-noop/src/bin/bench-noop.rs
+++ b/rust/tests/fixtures/bench-noop/src/bin/bench-noop.rs
@@ -1,0 +1,47 @@
+//! Noop bench fixture — measures the harness floor.
+//!
+//! Exercises the contract end-to-end without doing anything substantive
+//! per iteration. Useful for asserting that the dispatcher round-trips
+//! a valid envelope; per-iteration timings will be in the nanoseconds-to-
+//! low-microseconds range (compiler optimization-dependent).
+//!
+//! Contract (must match scripts/bench/bench-runner.sh):
+//!   - Read iteration count from $HOMEBOY_BENCH_ITERATIONS (default 10).
+//!   - Time each iteration with std::time::Instant.
+//!   - Emit a single JSON object on the last stdout line:
+//!         {"timings_ns": [u64, ...], "peak_rss_bytes": u64}
+
+use std::env;
+use std::hint::black_box;
+use std::time::Instant;
+
+fn bench_main() -> u64 {
+    // black_box on a constant prevents the compiler from optimizing the
+    // call away entirely. The work itself is intentionally trivial — this
+    // fixture measures harness overhead, not workload work.
+    black_box(1u64).wrapping_add(black_box(2u64))
+}
+
+fn main() {
+    let iterations: usize = env::var("HOMEBOY_BENCH_ITERATIONS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10);
+
+    let mut timings = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let start = Instant::now();
+        let _ = bench_main();
+        timings.push(start.elapsed().as_nanos() as u64);
+    }
+
+    // Render JSON manually — fixture has no serde dep on purpose. Real
+    // components will likely use serde, but the contract doesn't require it.
+    let timings_csv: String = timings
+        .iter()
+        .map(|t| t.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    println!("{{\"timings_ns\":[{}]}}", timings_csv);
+}


### PR DESCRIPTION
## Summary

Adds `bench` capability to the rust extension. Closes [#257](https://github.com/Extra-Chill/homeboy-extensions/issues/257). Mirrors the wordpress + nodejs extensions' shape: thin bash dispatcher, JSON envelope contract, R-7 percentile math for cross-substrate parity.

This is the third capability slot on the rust extension (`lint` + `test` + `bench`), and the third bench-capable extension overall — the homeboy bench primitive is now proven as language-agnostic across compiled-native (Rust), interpreted (PHP-WASM via Playground), and JIT (Node.js).

## Component-side contract

Each bench workload is a Cargo binary named `bench-<id>`, discovered via `[[bin]]` entries in `Cargo.toml` or `src/bin/bench-*.rs`. The binary:

1. Reads iteration count from `HOMEBOY_BENCH_ITERATIONS` (default 10).
2. Runs its measured workload that many times, timing each iteration with `std::time::Instant`.
3. Emits a single JSON object on the last stdout line:

   ```json
   {"timings_ns": [12345, 12678, ...], "peak_rss_bytes": 41943040}
   ```

   `timings_ns` length must equal `HOMEBOY_BENCH_ITERATIONS`; `peak_rss_bytes` is optional.

Component-side iteration loop chosen over per-iteration cargo invocations to amortize cargo's metadata-resolution overhead (~50ms/invocation even when fully cached).

## Dispatcher

`scripts/bench/bench-runner.sh`:

- Discovers `bench-*` binaries via `cargo metadata --no-deps` (jq) AND `src/bin/bench-*.rs` glob — covers both manifest entries and auto-discovered binaries.
- Batch-builds all discovered binaries with a single `cargo build --release --bin bench-X --bin bench-Y` so the per-workload `cargo run` only pays metadata-resolution cost.
- Captures stdout from each binary, takes the last non-empty line as the JSON payload (lets binaries emit progress lines without breaking the contract).
- Aggregates into `BenchResults` envelope via `python3` (R-7 percentile math, bit-for-bit parity with the existing PHP `pg_bench_percentile()` and Node `percentile()` runners).

## Validation

### Smoke harness — `scripts/bench/rust-bench-smoke.sh`

End-to-end check against `tests/fixtures/bench-noop/` (two-binary fixture: `bench-noop` measures harness floor, `bench-busy` does measurable work). Asserts:

- Envelope shape: `component_id`, `iterations`, `scenarios` populated.
- Six required metric keys per scenario: `mean_ms`, `p50_ms`, `p95_ms`, `p99_ms`, `min_ms`, `max_ms`.
- All scenarios report iteration count matching `HOMEBOY_BENCH_ITERATIONS`.
- All `p95_ms > 0` (sanity that timing actually happened).
- Relative ordering: `bench-busy` p95 > `bench-noop` p95 (~200x ratio observed).

Smoke passes 12/12 assertions. Real numbers from the run: noop 42ns p95, busy 8.7us p95.

### Live-verify — full dogfood against `homeboy` crate

Paired with [Extra-Chill/homeboy#XXXX](https://github.com/Extra-Chill/homeboy/pull/1574) (`feat-audit-self-bench`) which adds a `bench-audit-self` workload to the homeboy crate. End-to-end run:

```
HOMEBOY_EXTENSION_PATH=.../homeboy-extensions/rust \
HOMEBOY_COMPONENT_PATH=.../homeboy \
HOMEBOY_BENCH_ITERATIONS=3 \
HOMEBOY_BENCH_RESULTS_FILE=/tmp/results.json \
  bash rust/scripts/bench/bench-runner.sh
```

Result envelope:

```json
{
  "component_id": "homeboy",
  "iterations": 3,
  "scenarios": [{
    "id": "audit-self",
    "iterations": 3,
    "metrics": {
      "mean_ms": 60832.35,
      "p50_ms":  59734.94,
      "p95_ms":  62919.41,
      "p99_ms":  63202.48,
      "min_ms":  59488.86,
      "max_ms":  63273.24
    }
  }]
}
```

`homeboy audit homeboy` median ~60s, p95 ~63s — substantive numbers ready for a bench-pair workflow targeting audit perf.

## Dependencies

- `cargo` (any modern Rust toolchain) — required.
- `python3` — required for percentile math.
- `jq` — optional, used for `cargo metadata` parsing of explicit `[[bin]]` entries. Falls back to `src/bin/` glob discovery if absent.

`python3` was preferred over `jq` for the math because R-7 interpolation is awkward in jq and the existing PHP/Node runners use direct numeric code; `python3` keeps the same shape.

## What's NOT in this PR

- **Reference workload helper crate (`homeboy-bench-rs`)** — components currently implement the contract directly (~20 lines of std-only Rust per workload, see fixture). A helper crate to eliminate the boilerplate is a future follow-up; the contract works without it.
- **Criterion / divan integration** — listed as out-of-scope in #257. The `bench-*` binary contract is the v1 surface; component-side adapters that delegate to criterion/divan can come later as separate workloads.
- **Compile-time benchmarking** — different problem, listed as out-of-scope.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted dispatcher, smoke harness, fixture binaries, and PR body from issue #257 spec; Chris reviewed and live-verified the dogfood end-to-end.

Closes #257
