### PR TITLE
feat(bench): run rig-declared extra workloads

### DIFF
--- a/nodejs/scripts/bench/bench-runner.mjs
+++ b/nodejs/scripts/bench/bench-runner.mjs
@@ -34,7 +34,7 @@
 // bench/parsing.rs::BenchResults shape) to HOMEBOY_BENCH_RESULTS_FILE.
 
 import { readdir, writeFile, mkdir } from 'node:fs/promises';
-import { resolve, relative, basename, dirname } from 'node:path';
+import { resolve, relative, basename, dirname, delimiter } from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { pathToFileURL } from 'node:url';
 
@@ -138,16 +138,22 @@ async function runWorkload(file) {
 
 async function main() {
     const benchDir = resolve(PROJECT_PATH, 'bench');
-    const files = await discoverWorkloads(benchDir);
+    const inTreeFiles = (await discoverWorkloads(benchDir)).map((file) => ({ file, source: 'in_tree' }));
+    const extraFiles = (process.env.HOMEBOY_BENCH_EXTRA_WORKLOADS || '')
+        .split(delimiter)
+        .filter(Boolean)
+        .map((file) => ({ file: resolve(PROJECT_PATH, file), source: 'rig' }));
+    const files = [...inTreeFiles, ...extraFiles].sort((a, b) => a.file.localeCompare(b.file));
 
     if (DEBUG) console.error(`DEBUG: discovered ${files.length} workloads under ${benchDir}`);
 
     const scenarios = [];
     let hadError = false;
 
-    for (const file of files) {
+    for (const workload of files) {
+        const { file, source } = workload;
         const id = scenarioId(file);
-        const rel = relative(PROJECT_PATH, file);
+        const rel = source === 'in_tree' ? relative(PROJECT_PATH, file) : file;
         process.stdout.write(`WORKLOAD_BEGIN: ${id} (${basename(file)})\n`);
 
         const result = await runWorkload(file);
@@ -166,6 +172,7 @@ async function main() {
         scenarios.push({
             id,
             file: rel,
+            source,
             iterations: t.length,
             metrics: {
                 mean_ms: t.reduce((a, b) => a + b, 0) / t.length,

--- a/nodejs/scripts/bench/bench-runner.sh
+++ b/nodejs/scripts/bench/bench-runner.sh
@@ -52,9 +52,9 @@ RESULTS_FILE="${HOMEBOY_BENCH_RESULTS_FILE:-${PROJECT_PATH}/.node-bench-results.
 BENCH_DIR="${PROJECT_PATH}/bench"
 
 # No workloads → emit an empty-but-valid envelope so core's parser doesn't
-# treat the absence as a crash. Same shape as the WP runner's no-tests-bench
-# path.
-if [ ! -d "$BENCH_DIR" ]; then
+# treat the absence as a crash. Rig-declared extra workloads can run without
+# an in-tree bench directory, so only skip when both sources are absent.
+if [ ! -d "$BENCH_DIR" ] && [ -z "${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}" ]; then
     echo ""
     echo "⚠ No bench/ directory found at ${BENCH_DIR}"
     echo "  Skipping bench run — nothing to measure."
@@ -86,6 +86,7 @@ export HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_FILE"
 export HOMEBOY_COMPONENT_ID="$COMPONENT_ID"
 export HOMEBOY_COMPONENT_PATH="$PROJECT_PATH"
 export HOMEBOY_BENCH_ITERATIONS="$ITERATIONS"
+export HOMEBOY_BENCH_EXTRA_WORKLOADS="${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}"
 
 echo "Running Node.js benchmarks..."
 echo "  Component: ${COMPONENT_ID} (${PROJECT_PATH})"

--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -111,7 +111,7 @@ if [ ! -f "$PLAYGROUND_CLI" ]; then
 fi
 
 BENCH_DIR="${PLUGIN_PATH}/tests/bench"
-if [ ! -d "$BENCH_DIR" ]; then
+if [ ! -d "$BENCH_DIR" ] && [ -z "${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}" ]; then
     echo ""
     echo "⚠ No tests/bench directory found at ${BENCH_DIR}"
     echo "  Skipping bench run — nothing to measure."
@@ -202,6 +202,30 @@ fi
 
 MOUNT_ARGS+=("--mount" "${EXTENSION_PATH}:/homeboy-extension")
 
+# Rig-private workloads are host paths supplied by homeboy core through a
+# PATH-style list. Mount each file into Playground and let the PHP runner tag
+# them as `source: rig` in the BenchResults envelope.
+EXTRA_WORKLOADS_LIST=""
+if [ -n "${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}" ]; then
+    EXTRA_WORKLOAD_INDEX=0
+    IFS=':' read -r -a EXTRA_WORKLOAD_HOSTS <<< "${HOMEBOY_BENCH_EXTRA_WORKLOADS}"
+    for extra_workload_host in "${EXTRA_WORKLOAD_HOSTS[@]}"; do
+        [ -n "$extra_workload_host" ] || continue
+        if [ ! -f "$extra_workload_host" ]; then
+            echo "Error: rig bench workload not found: $extra_workload_host" >&2
+            FAILED_STEP="Rig bench workload setup"
+            exit 1
+        fi
+        extra_workload_guest="/bench-extra-workloads/${EXTRA_WORKLOAD_INDEX}-$(basename "$extra_workload_host")"
+        MOUNT_ARGS+=("--mount" "${extra_workload_host}:${extra_workload_guest}")
+        if [ -n "$EXTRA_WORKLOADS_LIST" ]; then
+            EXTRA_WORKLOADS_LIST+=":"
+        fi
+        EXTRA_WORKLOADS_LIST+="$extra_workload_guest"
+        EXTRA_WORKLOAD_INDEX=$((EXTRA_WORKLOAD_INDEX + 1))
+    done
+fi
+
 # Shared-state mount: when homeboy core passes HOMEBOY_BENCH_SHARED_STATE,
 # we mount the host directory into Playground's VFS at a stable path
 # (/bench-shared-state) and expose that path to the workload via the
@@ -282,6 +306,7 @@ sed \
     -e "s|{{RESULT_SUFFIX}}|${RESULT_SUFFIX}|g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{EXTRA_WORKLOADS_LIST}}${WP_CONFIG_DEFINES_DELIM}${EXTRA_WORKLOADS_LIST}${WP_CONFIG_DEFINES_DELIM}g" \
     "$TEMPLATE" > "$WRAPPER_TMPFILE"
 
 echo "Running performance benchmarks via WordPress Playground..."

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -138,25 +138,43 @@ pg_run_load_component_stage(['plugin_path' => $plugin_path]);
 // ---------------------------------------------------------------------------
 pg_stage_begin('discover_workloads');
 $workload_files = [];
+$workload_sources = [];
 try {
     $bench_dir = "$plugin_path/tests/bench";
-    if (!is_dir($bench_dir)) {
-        pg_log("NO_WORKLOAD_FILES");
-        pg_stage_ok('discover_workloads');
-    } else {
+    if (is_dir($bench_dir)) {
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($bench_dir, RecursiveDirectoryIterator::SKIP_DOTS),
             RecursiveIteratorIterator::LEAVES_ONLY
         );
         foreach ($iterator as $file) {
             if ($file->isFile() && $file->getExtension() === 'php') {
-                $workload_files[] = $file->getPathname();
+                $path = $file->getPathname();
+                $workload_files[] = $path;
+                $workload_sources[$path] = 'in_tree';
             }
         }
-        sort($workload_files);
-        pg_log("DISCOVERY: dir=$bench_dir found=" . count($workload_files));
-        pg_stage_ok('discover_workloads');
     }
+
+    $extra_workload_list = '{{EXTRA_WORKLOADS_LIST}}';
+    $extra_workloads = $extra_workload_list === '' ? [] : explode(':', $extra_workload_list);
+    foreach ($extra_workloads as $path) {
+        if (!is_string($path) || $path === '') {
+            continue;
+        }
+        if (!is_file($path) || strtolower(pathinfo($path, PATHINFO_EXTENSION)) !== 'php') {
+            pg_log("NOTICE: skipping invalid rig bench workload: " . var_export($path, true));
+            continue;
+        }
+        $workload_files[] = $path;
+        $workload_sources[$path] = 'rig';
+    }
+
+    sort($workload_files);
+    if (empty($workload_files)) {
+        pg_log("NO_WORKLOAD_FILES");
+    }
+    pg_log("DISCOVERY: dir=$bench_dir in_tree=" . count(array_filter($workload_sources, fn($source) => $source === 'in_tree')) . " rig=" . count(array_filter($workload_sources, fn($source) => $source === 'rig')));
+    pg_stage_ok('discover_workloads');
 } catch (Throwable $e) {
     pg_stage_fail('discover_workloads', $e);
     exit(1);
@@ -214,7 +232,10 @@ try {
         $basename = basename($workload_file);
         $scenario_id = pg_bench_scenario_id($basename);
         // Path relative to the plugin root for the BenchResults envelope.
-        $relative_file = substr($workload_file, strlen($plugin_path) + 1);
+        $source = $workload_sources[$workload_file] ?? 'in_tree';
+        $relative_file = $source === 'in_tree'
+            ? substr($workload_file, strlen($plugin_path) + 1)
+            : $workload_file;
 
         pg_log("WORKLOAD_BEGIN: $scenario_id ($basename)");
 
@@ -263,6 +284,7 @@ try {
         $scenarios[] = [
             'id' => $scenario_id,
             'file' => $relative_file,
+            'source' => $source,
             'iterations' => $iterations_per_workload,
             'metrics' => [
                 'mean_ms' => $mean,


### PR DESCRIPTION
## Summary
- Teach the WordPress Playground bench dispatcher to mount `HOMEBOY_BENCH_EXTRA_WORKLOADS` into the Playground VFS and tag those scenarios as `source: rig`.
- Teach the Node.js bench dispatcher to union rig-declared workloads with in-tree discovery and tag scenario sources.
- Preserve the no-workloads empty-envelope path unless rig workloads are present.

## Tests
- `HOMEBOY_COMPONENT_PATH=<tmp/project> HOMEBOY_COMPONENT_ID=demo HOMEBOY_BENCH_RESULTS_FILE=<tmp>/bench.json HOMEBOY_BENCH_ITERATIONS=2 HOMEBOY_BENCH_EXTRA_WORKLOADS=<tmp>/rig-cold.bench.mjs node nodejs/scripts/bench/bench-runner.mjs`
- `bash -n wordpress/scripts/bench/bench-runner-playground.sh && bash -n nodejs/scripts/bench/bench-runner.sh && node --check nodejs/scripts/bench/bench-runner.mjs`
- `php -l wordpress/scripts/bench/playground-bench-runner.php`

## Notes
- Complements Extra-Chill/homeboy#1596, which adds the core rig-spec field and runner env propagation for Extra-Chill/homeboy#1576.
- Rust remains intentionally unsupported for out-of-tree workloads because Cargo bench binaries are crate-bound and need a separate out-of-tree workspace design.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented dispatcher support and smoke verification; Chris remains responsible for review and merge.