### PR TITLE
fix(wordpress): keep extension test paths out of component discovery

### DIFF
--- a/wordpress/scripts/test/playground-discovery-smoke.sh
+++ b/wordpress/scripts/test/playground-discovery-smoke.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/playground-runner.php"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "${TMPDIR}/component/tests"
+cat > "${TMPDIR}/phpunit.xml.dist" <<'XML'
+<phpunit>
+    <testsuites>
+        <testsuite name="Component Tests">
+            <directory>tests/</directory>
+        </testsuite>
+        <testsuite name="Extension Self Tests">
+            <directory suffix="UnitTest.php">HomeboyWordPress/Tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>
+XML
+
+php -d display_errors=1 -r '
+$runner = $argv[1];
+$xml_path = $argv[2];
+$test_dir = $argv[3];
+$source = file_get_contents($runner);
+
+function extract_function_source($source, $name) {
+    $needle = "function {$name}";
+    $start = strpos($source, $needle);
+    if ($start === false) {
+        fwrite(STDERR, "Missing function {$name}\n");
+        exit(1);
+    }
+    $brace = strpos($source, "{", $start);
+    $depth = 0;
+    $len = strlen($source);
+    for ($i = $brace; $i < $len; $i++) {
+        if ($source[$i] === "{") {
+            $depth++;
+        } elseif ($source[$i] === "}") {
+            $depth--;
+            if ($depth === 0) {
+                return substr($source, $start, $i - $start + 1);
+            }
+        }
+    }
+    fwrite(STDERR, "Unterminated function {$name}\n");
+    exit(1);
+}
+
+$logs = [];
+function pg_log($message) {
+    global $logs;
+    $logs[] = $message;
+}
+
+eval(extract_function_source($source, "pg_is_component_phpunit_directory"));
+eval(extract_function_source($source, "pg_parse_phpunit_config"));
+
+[$dirs, $suffixes, $prefixes, $excludes] = pg_parse_phpunit_config($xml_path, $test_dir);
+
+$expected_dir = dirname($test_dir) . "/tests";
+$bad_dir = dirname($test_dir) . "/HomeboyWordPress/Tests";
+
+$assertions = 0;
+$assert = function ($condition, $message) use (&$assertions) {
+    $assertions++;
+    if (!$condition) {
+        fwrite(STDERR, "FAIL: {$message}\n");
+        exit(1);
+    }
+};
+
+$assert(in_array($expected_dir, $dirs, true), "keeps component tests directory");
+$assert(!in_array($bad_dir, $dirs, true), "does not project extension tests into component root");
+$assert($suffixes === ["Test.php"], "ignored extension-only suffixes");
+$assert(pg_is_component_phpunit_directory("tests/Unit"), "accepts nested component tests directory");
+$assert(!pg_is_component_phpunit_directory("HomeboyWordPress/Tests"), "rejects extension internal directory");
+
+echo "Playground discovery smoke passed ({$assertions} assertions)\n";
+' "$RUNNER" "${TMPDIR}/phpunit.xml.dist" "${TMPDIR}/component/tests"

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -160,6 +160,7 @@ pg_run_load_component_stage(['plugin_path' => $plugin_path]);
 //
 // Configuration source priority:
 //   1. Extension's /homeboy-extension/phpunit.xml.dist, if readable and parseable
+//      for component test directories
 //   2. Hardcoded defaults: suffix=Test.php, prefix=test- (covers both PHPUnit
 //      native + WordPress conventions so projects don't have to choose)
 //
@@ -206,10 +207,10 @@ try {
  * Parse the extension's phpunit.xml.dist for test-discovery directives.
  *
  * Returns [directories, suffixes, prefixes, excludes]. Absolute paths only:
- * any relative `<directory>` entry in the XML is resolved against
- * $plugin_path/tests (the component under test, NOT the extension's own
- * vendor dir — the XML's path semantics are "relative to the plugin being
- * tested").
+ * relative `<directory>` entries under tests/ are resolved against the
+ * component under test. Extension-internal suites (for example
+ * HomeboyWordPress/Tests) are ignored so extension self-tests do not leak into
+ * every component run.
  *
  * Falls back to sensible defaults if the XML is missing or unparseable.
  * Logs the reason to NOTICE so users can see which path was taken.
@@ -250,6 +251,9 @@ function pg_parse_phpunit_config($xml_path, $test_dir_default) {
     foreach ($xml->xpath('//testsuite/directory') ?: [] as $dir) {
         $raw_path = trim((string) $dir);
         if ($raw_path === '') {
+            continue;
+        }
+        if (!pg_is_component_phpunit_directory($raw_path)) {
             continue;
         }
         // Resolve relative to the plugin root (PHPUnit's own convention is
@@ -302,6 +306,16 @@ function pg_parse_phpunit_config($xml_path, $test_dir_default) {
     }
 
     return [$directories, $suffixes, $prefixes, $excludes];
+}
+
+/**
+ * Whether a phpunit.xml `<directory>` entry belongs to the component under test.
+ */
+function pg_is_component_phpunit_directory($raw_path) {
+    $normalized = str_replace('\\', '/', trim($raw_path));
+    $normalized = trim($normalized, '/');
+
+    return $normalized === 'tests' || strpos($normalized, 'tests/') === 0;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Ignore extension-internal `phpunit.xml.dist` directories like `HomeboyWordPress/Tests` when discovering tests for a component under test.
- Add a smoke test that pins the parser contract so extension self-test paths are not projected into component roots.

## Tests
- `wordpress/scripts/test/playground-discovery-smoke.sh`
- `php -l wordpress/scripts/test/playground-runner.php`
- Temp overlay of the patched WordPress extension against BFB: `homeboy test block-format-bridge --path /Users/chubes/Developer/block-format-bridge@ci-homeboy-test-workflow --summary`

Closes #261.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the discovery filter, added the smoke test, and ran targeted verification; Chris remains responsible for review and merge.
