### PR TITLE
fix(wordpress): scope PHPStan lint targets

### DIFF
--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -10,9 +10,8 @@ source "${DEPENDENCY_HELPER}"
 # Supports summary mode via HOMEBOY_SUMMARY_MODE=1
 # Supports skip via HOMEBOY_SKIP_PHPSTAN=1
 # Supports level override via HOMEBOY_PHPSTAN_LEVEL (default: 7, matches phpstan.neon.dist)
-# NOTE: PHPStan always analyzes the full codebase (ignores HOMEBOY_LINT_GLOB)
-# because it needs the complete type graph to detect collateral damage from
-# changes (broken call sites, type mismatches in untouched files, etc.)
+# Respects scoped lint via HOMEBOY_LINT_FILE / HOMEBOY_LINT_GLOB. Unscoped lint
+# still analyzes the full component so CI keeps the full type-graph signal.
 
 # Debug environment variables (only shown when HOMEBOY_DEBUG=1)
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -136,14 +135,62 @@ if [ -n "$DEPENDENCY_CONFIG" ] && [ -f "$DEPENDENCY_CONFIG" ]; then
     PHPSTAN_BASE_CONFIG="$DEPENDENCY_CONFIG"
 fi
 
-# Check if component has PHP files
-php_file_count=$(find "$PLUGIN_PATH" -type f -name "*.php" \
-    -not -path "*/vendor/*" \
-    -not -path "*/node_extensions/*" \
-    -not -path "*/build/*" \
-    -not -path "*/dist/*" \
-    -not -path "*/tests/*" \
-    2>/dev/null | wc -l | tr -d ' ')
+PHPSTAN_TARGETS=("$PLUGIN_PATH")
+PHPSTAN_SCOPED=0
+
+resolve_phpstan_targets() {
+    local matched=()
+    local target
+
+    if [ -n "${HOMEBOY_LINT_FILE:-}" ]; then
+        target="${PLUGIN_PATH}/${HOMEBOY_LINT_FILE}"
+        if [ -f "$target" ] && [[ "$target" == *.php ]]; then
+            matched+=("$target")
+        fi
+    elif [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
+        (
+            cd "$PLUGIN_PATH"
+            eval 'for f in '"${HOMEBOY_LINT_GLOB}"'; do [ -e "$f" ] && printf "%s\0" "$f"; done'
+        ) | while IFS= read -r -d '' target; do
+            if [ -f "${PLUGIN_PATH}/${target}" ] && [[ "$target" == *.php ]]; then
+                printf '%s\0' "${PLUGIN_PATH}/${target}"
+            elif [ -d "${PLUGIN_PATH}/${target}" ]; then
+                find "${PLUGIN_PATH}/${target}" -type f -name '*.php' -print0
+            fi
+        done
+        return
+    fi
+
+    if [ "${#matched[@]}" -gt 0 ]; then
+        printf '%s\0' "${matched[@]}"
+    fi
+}
+
+if [ -n "${HOMEBOY_LINT_FILE:-}" ] || [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
+    PHPSTAN_SCOPED=1
+    PHPSTAN_TARGETS=()
+    while IFS= read -r -d '' phpstan_target; do
+        PHPSTAN_TARGETS+=("$phpstan_target")
+    done < <(resolve_phpstan_targets)
+
+    if [ "${#PHPSTAN_TARGETS[@]}" -eq 0 ]; then
+        echo "PHPStan scoped lint: no PHP files in requested scope, skipping static analysis"
+        exit 0
+    fi
+fi
+
+# Check if the selected PHPStan target set has PHP files.
+if [ "$PHPSTAN_SCOPED" -eq 1 ]; then
+    php_file_count="${#PHPSTAN_TARGETS[@]}"
+else
+    php_file_count=$(find "$PLUGIN_PATH" -type f -name "*.php" \
+        -not -path "*/vendor/*" \
+        -not -path "*/node_extensions/*" \
+        -not -path "*/build/*" \
+        -not -path "*/dist/*" \
+        -not -path "*/tests/*" \
+        2>/dev/null | wc -l | tr -d ' ')
+fi
 
 if [ "$php_file_count" -eq 0 ]; then
     if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -153,6 +200,9 @@ if [ "$php_file_count" -eq 0 ]; then
 fi
 
 echo "Running PHPStan static analysis..."
+if [ "$PHPSTAN_SCOPED" -eq 1 ]; then
+    echo "PHPStan scoped lint: analyzing ${#PHPSTAN_TARGETS[@]} PHP file(s) from requested scope"
+fi
 
 # Build PHPStan arguments
 phpstan_args=(analyse)
@@ -309,12 +359,12 @@ if [ -n "$PHPSTAN_MAX_PROCESSES" ] || [ -n "$PHPSTAN_PHP_VERSION" ]; then
         phpstan_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
     fi
     phpstan_args+=(--no-progress)
-    phpstan_args+=("$PLUGIN_PATH")
+    phpstan_args+=("${PHPSTAN_TARGETS[@]}")
 fi
 
 # Add the path to analyze (only when not already set by override block above)
 if [ -z "$PHPSTAN_MAX_PROCESSES" ] && [ -z "$PHPSTAN_PHP_VERSION" ]; then
-    phpstan_args+=("$PLUGIN_PATH")
+    phpstan_args+=("${PHPSTAN_TARGETS[@]}")
 fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -362,6 +412,18 @@ prepare_phpstan_retry_config() {
     printf '%s\n' "$PHPSTAN_TMPCONFIG"
 }
 
+add_phpstan_retry_targets() {
+    if [ "$PHPSTAN_SCOPED" -eq 1 ]; then
+        local target rel_target
+        for target in "${PHPSTAN_TARGETS[@]}"; do
+            rel_target="${target#$PLUGIN_PATH/}"
+            retry_args+=("$rel_target")
+        done
+    else
+        retry_args+=(.)
+    fi
+}
+
 # Summary mode: get JSON output and parse it
 if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
     set +e
@@ -383,7 +445,7 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
         # Baseline is pulled in via PHPSTAN_TMPCONFIG → PHPSTAN_BASE_CONFIG
         # → COMPONENT_BASELINE include chain (no --baseline CLI flag in PHPStan 2.x).
         [ -f "$COMPOSITE_AUTOLOAD" ] && retry_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
-        retry_args+=(.)
+        add_phpstan_retry_targets
         stderr_file=$(homeboy_mktemp 'phpstan-stderr.XXXXXX')
         # PHPStan --debug mode has a known interaction with --autoload-file
         # where running from a CWD different than the analysed path causes
@@ -742,7 +804,7 @@ if [ "$full_exit" -ne 0 ] && \
     retry_args=(analyse --configuration="$PHPSTAN_TMPCONFIG" --level="$PHPSTAN_LEVEL" --memory-limit=2G --no-progress --debug)
     # Baseline pulled in via PHPSTAN_TMPCONFIG include chain, same as summary-mode retry.
     [ -f "$COMPOSITE_AUTOLOAD" ] && retry_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
-    retry_args+=(.)
+    add_phpstan_retry_targets
     set +e
     retry_stdout_file=$(homeboy_mktemp 'phpstan-stdout.XXXXXX')
     retry_stderr_file=$(homeboy_mktemp 'phpstan-stderr.XXXXXX')

--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/phpstan-runner.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+EXTENSION_DIR="${TMPDIR}/extension"
+COMPONENT_DIR="${TMPDIR}/component"
+ARGS_FILE="${TMPDIR}/phpstan-args.txt"
+CALLS_FILE="${TMPDIR}/phpstan-calls.txt"
+DEPENDENCY_HELPER="${TMPDIR}/validation-dependencies.sh"
+
+mkdir -p "${EXTENSION_DIR}/vendor/bin" "${COMPONENT_DIR}/tests" "${COMPONENT_DIR}/assets"
+touch "${EXTENSION_DIR}/phpstan.neon.dist"
+touch "${COMPONENT_DIR}/main.php" "${COMPONENT_DIR}/tests/FooTest.php" "${COMPONENT_DIR}/assets/app.js"
+
+cat > "$DEPENDENCY_HELPER" <<'SH'
+homeboy_resolve_validation_dependency_paths() {
+    return 0
+}
+SH
+
+cat > "${EXTENSION_DIR}/vendor/bin/phpstan" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "${PHPSTAN_ARGS_FILE}"
+count=0
+[ -f "${PHPSTAN_CALLS_FILE}" ] && count=$(cat "${PHPSTAN_CALLS_FILE}")
+count=$((count + 1))
+printf '%s\n' "$count" > "${PHPSTAN_CALLS_FILE}"
+printf '%s\n' '{"totals":{"errors":0,"file_errors":0},"files":{}}'
+SH
+chmod +x "${EXTENSION_DIR}/vendor/bin/phpstan"
+
+run_phpstan() {
+    : > "$ARGS_FILE"
+    printf '0\n' > "$CALLS_FILE"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+    HOMEBOY_COMPONENT_ID="phpstan-smoke" \
+    HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+    PHPSTAN_ARGS_FILE="$ARGS_FILE" \
+    PHPSTAN_CALLS_FILE="$CALLS_FILE" \
+    HOMEBOY_SUMMARY_MODE=1 \
+    "$RUNNER" >/dev/null
+}
+
+assert_contains() {
+    local needle="$1"
+    local message="$2"
+    if ! grep -F -- "$needle" "$ARGS_FILE" >/dev/null; then
+        echo "FAIL: $message" >&2
+        echo "Args: $(cat "$ARGS_FILE")" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1"
+    local message="$2"
+    if grep -F -- "$needle" "$ARGS_FILE" >/dev/null; then
+        echo "FAIL: $message" >&2
+        echo "Args: $(cat "$ARGS_FILE")" >&2
+        exit 1
+    fi
+}
+
+HOMEBOY_LINT_FILE="main.php" run_phpstan
+assert_contains "${COMPONENT_DIR}/main.php" "single-file scope passes the requested PHP file to PHPStan"
+assert_not_contains "$COMPONENT_DIR " "single-file scope does not pass the whole component root"
+
+HOMEBOY_LINT_GLOB='{main.php,assets/app.js,tests/FooTest.php}' run_phpstan
+assert_contains "${COMPONENT_DIR}/main.php" "glob scope includes matching PHP source file"
+assert_contains "${COMPONENT_DIR}/tests/FooTest.php" "glob scope includes matching PHP test file"
+assert_not_contains "assets/app.js" "glob scope ignores non-PHP files"
+
+: > "$ARGS_FILE"
+printf '0\n' > "$CALLS_FILE"
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="phpstan-smoke" \
+HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+PHPSTAN_ARGS_FILE="$ARGS_FILE" \
+PHPSTAN_CALLS_FILE="$CALLS_FILE" \
+HOMEBOY_SUMMARY_MODE=1 \
+HOMEBOY_LINT_FILE="assets/app.js" \
+"$RUNNER" >/dev/null
+
+if [ "$(cat "$CALLS_FILE")" != "0" ]; then
+    echo "FAIL: non-PHP single-file scope should skip PHPStan" >&2
+    exit 1
+fi
+
+echo "PHPStan scoped lint smoke passed"


### PR DESCRIPTION
## Summary
- Make the WordPress PHPStan runner honor `HOMEBOY_LINT_FILE` and `HOMEBOY_LINT_GLOB` instead of always analyzing the full component.
- Keep full-component PHPStan for unscoped lint runs, preserving CI/full-preflight signal.
- Add a smoke test that pins single-file, glob, and non-PHP scoped behavior.

## Tests
- `wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `bash -n wordpress/scripts/lint/phpstan-runner.sh`
- `bash -n wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- Temp overlay of the patched WordPress extension against BFB: `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@test-bfb-conversion-smoke --file tests/BFBConversionUnitTest.php --summary`

Closes #260.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented scoped PHPStan target resolution, added smoke coverage, and ran targeted verification; Chris remains responsible for review and merge.
