### PR TITLE
feat(wordpress): filter bench workloads

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -110,8 +110,17 @@ if [ ! -f "$PLAYGROUND_CLI" ]; then
     exit 1
 fi
 
+BENCH_WORKLOADS_FILTER_PROVIDED=0
+if [ -n "${HOMEBOY_BENCH_WORKLOADS:-}" ]; then
+    BENCH_WORKLOADS_FILTER_PROVIDED=1
+elif [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    if printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -e 'has("bench_workloads") and (.bench_workloads != null)' >/dev/null 2>&1; then
+        BENCH_WORKLOADS_FILTER_PROVIDED=1
+    fi
+fi
+
 BENCH_DIR="${PLUGIN_PATH}/tests/bench"
-if [ ! -d "$BENCH_DIR" ] && [ -z "${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}" ]; then
+if [ ! -d "$BENCH_DIR" ] && [ -z "${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}" ] && [ "$BENCH_WORKLOADS_FILTER_PROVIDED" != "1" ]; then
     echo ""
     echo "⚠ No tests/bench directory found at ${BENCH_DIR}"
     echo "  Skipping bench run — nothing to measure."
@@ -177,6 +186,27 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     if [ -n "$extracted" ]; then
         BENCH_ENV_JSON="$extracted"
     fi
+fi
+
+# Extract `bench_workloads` from the merged settings JSON. Components can
+# restrict a bench run to specific workload IDs under
+# `extensions.wordpress.settings.bench_workloads` in their homeboy.json:
+#
+#   { "bench_workloads": ["boot-timing", "read-heavy"] }
+#   { "bench_workloads": "boot-timing,read-heavy" }
+#
+# Direct runner invocations can use HOMEBOY_BENCH_WORKLOADS with the same
+# comma-separated string shape. The PHP runner normalizes both forms after
+# discovery so omitted workloads never enter the BenchResults envelope.
+BENCH_WORKLOADS_JSON="null"
+if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c 'if has("bench_workloads") then .bench_workloads else null end' 2>/dev/null || echo "null")
+    if [ -n "$extracted" ] && [ "$extracted" != "null" ]; then
+        BENCH_WORKLOADS_JSON="$extracted"
+    fi
+fi
+if [ "$BENCH_WORKLOADS_JSON" = "null" ] && [ -n "${HOMEBOY_BENCH_WORKLOADS:-}" ]; then
+    BENCH_WORKLOADS_JSON=$(jq -Rn --arg value "$HOMEBOY_BENCH_WORKLOADS" '$value')
 fi
 
 ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-10}"
@@ -306,6 +336,7 @@ sed \
     -e "s|{{RESULT_SUFFIX}}|${RESULT_SUFFIX}|g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_WORKLOADS_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_WORKLOADS_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{EXTRA_WORKLOADS_LIST}}${WP_CONFIG_DEFINES_DELIM}${EXTRA_WORKLOADS_LIST}${WP_CONFIG_DEFINES_DELIM}g" \
     "$TEMPLATE" > "$WRAPPER_TMPFILE"
 

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -127,6 +127,51 @@ pg_run_install_stage(['config_path' => $config_path]);
 pg_run_load_deps_stage(['dep_mounts' => '{{PLAYGROUND_DEP_MOUNTS}}']);
 pg_run_load_component_stage(['plugin_path' => $plugin_path]);
 
+/** Slugify a workload basename into a scenario id ("BulkImport.php" → "bulk-import"). */
+function pg_bench_scenario_id(string $basename): string {
+    $name = preg_replace('/\.php$/i', '', $basename);
+    $name = preg_replace('/([a-z0-9])([A-Z])/', '$1-$2', $name);
+    $name = strtolower($name);
+    $name = preg_replace('/[^a-z0-9]+/', '-', $name);
+    return trim($name, '-');
+}
+
+/**
+ * Normalize the optional bench_workloads setting into scenario IDs.
+ *
+ * Accepts either a JSON array (`["boot-timing"]`) or a comma-separated
+ * string (`"boot-timing,read-heavy"`). Values are slugified the same way
+ * workload basenames are, so callers can pass `Boot Timing` or
+ * `boot-timing` and hit the same workload ID.
+ */
+function pg_bench_normalize_workload_filter(string $raw): array {
+    if ($raw === '' || $raw === 'null') {
+        return [];
+    }
+
+    $decoded = json_decode($raw, true);
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        throw new RuntimeException('bench_workloads must be a JSON array or comma-separated string');
+    }
+    if ($decoded === null || $decoded === '') {
+        return [];
+    }
+
+    $values = is_array($decoded) ? $decoded : explode(',', (string) $decoded);
+    $normalized = [];
+    foreach ($values as $value) {
+        if (!is_scalar($value)) {
+            throw new RuntimeException('bench_workloads entries must be strings');
+        }
+        $id = pg_bench_scenario_id((string) $value);
+        if ($id !== '' && !in_array($id, $normalized, true)) {
+            $normalized[] = $id;
+        }
+    }
+
+    return $normalized;
+}
+
 // ---------------------------------------------------------------------------
 // Stage: discover_workloads — find every tests/bench/*.php file.
 //
@@ -170,6 +215,33 @@ try {
     }
 
     sort($workload_files);
+
+    $requested_workloads = pg_bench_normalize_workload_filter('{{BENCH_WORKLOADS_JSON}}');
+    if (!empty($requested_workloads)) {
+        $requested_lookup = array_fill_keys($requested_workloads, true);
+        $available_workloads = [];
+        $filtered_workload_files = [];
+
+        foreach ($workload_files as $workload_file) {
+            $scenario_id = pg_bench_scenario_id(basename($workload_file));
+            $available_workloads[] = $scenario_id;
+            if (isset($requested_lookup[$scenario_id])) {
+                $filtered_workload_files[] = $workload_file;
+            }
+        }
+
+        if (empty($filtered_workload_files)) {
+            throw new RuntimeException(sprintf(
+                'bench_workloads matched no workloads. Requested: %s. Available: %s',
+                implode(', ', $requested_workloads),
+                empty($available_workloads) ? '(none)' : implode(', ', $available_workloads)
+            ));
+        }
+
+        $workload_files = $filtered_workload_files;
+        pg_log('WORKLOAD_FILTER: requested=' . implode(',', $requested_workloads) . ' matched=' . count($workload_files));
+    }
+
     if (empty($workload_files)) {
         pg_log("NO_WORKLOAD_FILES");
     }
@@ -207,15 +279,6 @@ function pg_bench_percentile(array $sorted_ms, float $p): float {
     }
     $frac = $rank - $lo;
     return $sorted_ms[$lo] * (1 - $frac) + $sorted_ms[$hi] * $frac;
-}
-
-/** Slugify a workload basename into a scenario id ("BulkImport.php" → "bulk-import"). */
-function pg_bench_scenario_id(string $basename): string {
-    $name = preg_replace('/\.php$/i', '', $basename);
-    $name = preg_replace('/([a-z0-9])([A-Z])/', '$1-$2', $name);
-    $name = strtolower($name);
-    $name = preg_replace('/[^a-z0-9]+/', '-', $name);
-    return trim($name, '-');
 }
 
 pg_stage_begin('run_workloads');

--- a/wordpress/scripts/bench/playground-bench-workloads-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-workloads-smoke.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# bench_workloads filter smoke test.
+#
+# Runs the bench-noop fixture through the Playground bench dispatcher and
+# asserts the optional workload filter:
+#   - leaves default discovery unchanged when absent;
+#   - accepts a comma-separated string setting;
+#   - accepts a JSON-array setting;
+#   - accepts HOMEBOY_BENCH_WORKLOADS for direct runner invocations;
+#   - fails loudly when the filter matches no discovered workload.
+#
+# Manual integration test, not part of CI. Run after changes to:
+#   - bench-runner-playground.sh (settings extraction + template fill)
+#   - playground-bench-runner.php (workload discovery/filtering)
+#
+# Usage: bash wordpress/scripts/bench/playground-bench-workloads-smoke.sh
+# Exit:  0 = workload filtering round-trips, non-zero = regression
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-noop"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    echo "Install: brew install jq (macOS) or your package manager." >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-workloads-smoke-results.XXXXXX")
+FAILURE_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-workloads-smoke-failure.XXXXXX")
+
+cleanup() {
+    rm -f "$RESULTS_TMPFILE" "$FAILURE_TMPFILE"
+}
+trap cleanup EXIT
+
+run_bench_case() {
+    local label="$1"
+    local settings_json="$2"
+    local env_workloads="$3"
+    local expected_ids="$4"
+
+    rm -f "$RESULTS_TMPFILE"
+
+    echo "--- Case: $label ---"
+    HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+    HOMEBOY_BENCH_ITERATIONS=1 \
+    HOMEBOY_COMPONENT_ID=bench-noop \
+    HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_SETTINGS_JSON="$settings_json" \
+    HOMEBOY_BENCH_WORKLOADS="$env_workloads" \
+        bash "${SCRIPT_DIR}/bench-runner.sh"
+
+    if [ ! -s "$RESULTS_TMPFILE" ]; then
+        echo "ERROR: results file empty or missing for case '$label'" >&2
+        exit 1
+    fi
+
+    local actual_ids
+    actual_ids=$(jq -r '[.scenarios[] | select(.id != "__bootstrap") | .id] | join(",")' "$RESULTS_TMPFILE")
+    if [ "$actual_ids" != "$expected_ids" ]; then
+        echo "ERROR: case '$label' expected workload IDs '$expected_ids', got '$actual_ids'" >&2
+        cat "$RESULTS_TMPFILE" >&2
+        exit 1
+    fi
+    echo "✓ workload IDs: $actual_ids"
+}
+
+echo "============================================"
+echo "Playground bench workload filter smoke test"
+echo "============================================"
+echo "Fixture:    $FIXTURE_DIR"
+echo "Iterations: 1 (per selected workload)"
+echo ""
+
+run_bench_case \
+    "no filter runs all workloads" \
+    "{}" \
+    "" \
+    "array-fill-1k,noop"
+
+run_bench_case \
+    "comma-separated setting runs one workload" \
+    '{"bench_workloads":"noop"}' \
+    "" \
+    "noop"
+
+run_bench_case \
+    "JSON-array setting runs selected workloads in discovery order" \
+    '{"bench_workloads":["noop","array-fill-1k"]}' \
+    "" \
+    "array-fill-1k,noop"
+
+run_bench_case \
+    "HOMEBOY_BENCH_WORKLOADS fallback runs one workload" \
+    "{}" \
+    "array-fill-1k" \
+    "array-fill-1k"
+
+echo "--- Case: unknown filter fails clearly ---"
+rm -f "$RESULTS_TMPFILE" "$FAILURE_TMPFILE"
+set +e
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_COMPONENT_ID=bench-noop \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_SETTINGS_JSON='{"bench_workloads":["missing-workload"]}' \
+    bash "${SCRIPT_DIR}/bench-runner.sh" >"$FAILURE_TMPFILE" 2>&1
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+    echo "ERROR: unknown workload filter unexpectedly succeeded" >&2
+    cat "$FAILURE_TMPFILE" >&2
+    exit 1
+fi
+if ! grep -q "bench_workloads matched no workloads" "$FAILURE_TMPFILE"; then
+    echo "ERROR: unknown workload failure did not explain the filter miss" >&2
+    cat "$FAILURE_TMPFILE" >&2
+    exit 1
+fi
+if ! grep -q "missing-workload" "$FAILURE_TMPFILE" || ! grep -q "array-fill-1k" "$FAILURE_TMPFILE"; then
+    echo "ERROR: unknown workload failure did not include requested and available IDs" >&2
+    cat "$FAILURE_TMPFILE" >&2
+    exit 1
+fi
+echo "✓ unknown workload fails clearly"
+
+echo ""
+echo "============================================"
+echo "✓ bench_workloads smoke test PASSED"
+echo "============================================"


### PR DESCRIPTION
## Summary
- Add a first-class `bench_workloads` filter for the WordPress Playground bench runner.
- Accept comma-separated strings or JSON arrays, normalize entries to workload scenario IDs, and omit non-selected workloads from the `BenchResults` envelope.
- Fail loudly when a requested filter matches no discovered workloads.

## Tests
- `bash wordpress/scripts/bench/playground-bench-workloads-smoke.sh`
- `bash wordpress/scripts/bench/playground-bench-smoke.sh`
- `php -l wordpress/scripts/bench/playground-bench-runner.php`
- `bash -n wordpress/scripts/bench/bench-runner-playground.sh wordpress/scripts/bench/playground-bench-workloads-smoke.sh`

Closes #266

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing WordPress bench workload filtering and tests under Chris's review.
