### PR TITLE
feat(wordpress): preserve bench workload metrics

### DIFF
--- a/wordpress/scripts/bench/playground-bench-custom-metrics-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-custom-metrics-smoke.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Workload-provided custom metrics smoke test (homeboy-extensions#265).
+#
+# Runs a fixture workload that returns:
+#   ['metrics' => ['rows' => 10], 'metadata' => ['phase' => 'warm']]
+# and asserts the runner folds those values into the scenario's BenchResults
+# metrics object without changing the historical duration metric keys.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-custom-metrics"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    echo "Install: brew install jq (macOS) or your package manager." >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-custom-metrics-smoke.XXXXXX")
+
+cleanup() {
+    rm -f "$RESULTS_TMPFILE"
+}
+trap cleanup EXIT
+
+echo "============================================"
+echo "Playground bench custom metrics smoke test"
+echo "============================================"
+echo "Fixture:    $FIXTURE_DIR"
+echo "Iterations: 3 (per workload)"
+echo ""
+
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS=3 \
+HOMEBOY_COMPONENT_ID=bench-custom-metrics \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+echo ""
+echo "--- Results envelope ---"
+cat "$RESULTS_TMPFILE"
+echo ""
+
+scenario_count=$(jq -r '.scenarios | length' "$RESULTS_TMPFILE")
+if [ "$scenario_count" -ne 3 ]; then
+    echo "ERROR: expected 3 scenarios (__bootstrap + 2 fixture workloads), got $scenario_count" >&2
+    exit 1
+fi
+echo "✓ scenarios length == 3 (__bootstrap + 2 fixture workloads)"
+
+custom='.scenarios[] | select(.id == "custom-metrics")'
+
+for metric in mean_ms p50_ms p95_ms p99_ms min_ms max_ms; do
+    value=$(jq -r "$custom | .metrics.${metric} // \"missing\"" "$RESULTS_TMPFILE")
+    if [ "$value" = "missing" ] || [ "$value" = "null" ]; then
+        echo "ERROR: custom-metrics missing historical duration metric ${metric}" >&2
+        exit 1
+    fi
+done
+echo "✓ historical duration metric keys preserved"
+
+for metric in rows_mean rows_p50 rows_p95 rows_p99 rows_min rows_max; do
+    value=$(jq -r "$custom | .metrics.${metric} // \"missing\"" "$RESULTS_TMPFILE")
+    if [ "$value" = "missing" ] || [ "$value" = "null" ]; then
+        echo "ERROR: custom-metrics missing custom metric ${metric}" >&2
+        exit 1
+    fi
+    if [ "$value" != "10" ]; then
+        echo "ERROR: custom-metrics ${metric} expected 10, got ${value}" >&2
+        exit 1
+    fi
+done
+echo "✓ custom rows metric aggregated into mean/p50/p95/p99/min/max"
+
+for metric in changed_files_mean changed_files_p50 changed_files_p95 changed_files_p99 changed_files_min changed_files_max; do
+    value=$(jq -r "$custom | .metrics.${metric} // \"missing\"" "$RESULTS_TMPFILE")
+    if [ "$value" != "3" ]; then
+        echo "ERROR: custom-metrics ${metric} expected 3, got ${value}" >&2
+        exit 1
+    fi
+done
+echo "✓ custom changed_files metric aggregated into mean/p50/p95/p99/min/max"
+
+ignored=$(jq -r "$custom | .metrics.ignored_label_mean // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$ignored" != "missing" ]; then
+    echo "ERROR: non-numeric metric ignored_label was emitted as ${ignored}" >&2
+    exit 1
+fi
+echo "✓ non-numeric custom metric values ignored"
+
+phase=$(jq -r "$custom | .metadata.phase // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$phase" != "warm" ]; then
+    echo "ERROR: expected metadata.phase == warm, got ${phase}" >&2
+    exit 1
+fi
+echo "✓ latest metadata attached to scenario"
+
+legacy_has_metadata=$(jq -r '.scenarios[] | select(.id == "legacy-array") | has("metadata")' "$RESULTS_TMPFILE")
+if [ "$legacy_has_metadata" != "false" ]; then
+    echo "ERROR: legacy-array scenario unexpectedly emitted metadata" >&2
+    exit 1
+fi
+
+legacy_metric=$(jq -r '.scenarios[] | select(.id == "legacy-array") | .metrics.kind_mean // "missing"' "$RESULTS_TMPFILE")
+if [ "$legacy_metric" != "missing" ]; then
+    echo "ERROR: legacy array key was treated as a custom metric" >&2
+    exit 1
+fi
+echo "✓ legacy arrays without metrics key are ignored"
+
+echo ""
+echo "============================================"
+echo "✓ Custom metrics smoke test PASSED"
+echo "============================================"

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -34,7 +34,10 @@
  *
  * The runner times wall-clock around the callable, captures peak memory
  * after, and aggregates per-iteration measurements into p50/p95/p99/mean/
- * min/max for the BenchResults envelope.
+ * min/max for the BenchResults envelope. Workloads may also return
+ * `['metrics' => ['rows' => 10], 'metadata' => ['phase' => 'warm']]`;
+ * numeric custom metrics are aggregated with the same percentile machinery
+ * and the latest metadata payload is attached to the scenario.
  *
  * OUTPUT CONTRACT
  *
@@ -209,6 +212,57 @@ function pg_bench_percentile(array $sorted_ms, float $p): float {
     return $sorted_ms[$lo] * (1 - $frac) + $sorted_ms[$hi] * $frac;
 }
 
+/**
+ * Aggregate a numeric sample set into the flat BenchMetrics key shape.
+ *
+ * `$suffix` should include any unit (for example `_ms` for duration metrics)
+ * and may be empty for unitless workload-provided counters.
+ */
+function pg_bench_aggregate_metric(array $samples, string $prefix, string $suffix = ''): array {
+    sort($samples);
+    $count = count($samples);
+    $sum = array_sum($samples);
+    $mean = $count > 0 ? $sum / $count : 0.0;
+    $key_prefix = $prefix === '' ? '' : $prefix . '_';
+
+    return [
+        "{$key_prefix}mean{$suffix}" => $mean,
+        "{$key_prefix}p50{$suffix}" => pg_bench_percentile($samples, 0.50),
+        "{$key_prefix}p95{$suffix}" => pg_bench_percentile($samples, 0.95),
+        "{$key_prefix}p99{$suffix}" => pg_bench_percentile($samples, 0.99),
+        "{$key_prefix}min{$suffix}" => $count > 0 ? $samples[0] : 0.0,
+        "{$key_prefix}max{$suffix}" => $count > 0 ? $samples[$count - 1] : 0.0,
+    ];
+}
+
+/** Record custom metrics/metadata from a workload return payload. */
+function pg_bench_record_workload_result($result, array &$custom_metric_samples, &$latest_metadata): void {
+    if (!is_array($result)) {
+        return;
+    }
+
+    if (array_key_exists('metadata', $result)) {
+        $latest_metadata = $result['metadata'];
+    }
+
+    if (!isset($result['metrics']) || !is_array($result['metrics'])) {
+        return;
+    }
+
+    foreach ($result['metrics'] as $metric => $value) {
+        if (!is_string($metric) || $metric === '' || !is_numeric($value)) {
+            continue;
+        }
+
+        $sample = (float) $value;
+        if (!is_finite($sample)) {
+            continue;
+        }
+
+        $custom_metric_samples[$metric][] = $sample;
+    }
+}
+
 /** Slugify a workload basename into a scenario id ("BulkImport.php" → "bulk-import"). */
 function pg_bench_scenario_id(string $basename): string {
     $name = preg_replace('/\.php$/i', '', $basename);
@@ -252,6 +306,9 @@ try {
         }
 
         $timings_ms = [];
+        $custom_metric_samples = [];
+        $latest_metadata = null;
+        $has_metadata = false;
         $peak_memory = 0;
 
         // Reset PHP's peak-memory counter so the workload's footprint is
@@ -267,35 +324,40 @@ try {
         for ($i = 0; $i < $total_iterations; $i++) {
             $is_warmup = $i < $warmup_iterations;
             $start_ns = hrtime(true);
-            $callable();
+            $workload_result = $callable();
             $elapsed_ns = hrtime(true) - $start_ns;
             if (!$is_warmup) {
                 $timings_ms[] = $elapsed_ns / 1_000_000;
+                if (is_array($workload_result) && array_key_exists('metadata', $workload_result)) {
+                    $has_metadata = true;
+                }
+                pg_bench_record_workload_result($workload_result, $custom_metric_samples, $latest_metadata);
             }
         }
 
         $peak_memory = memory_get_peak_usage(true);
 
-        sort($timings_ms);
-        $count = count($timings_ms);
-        $sum = array_sum($timings_ms);
-        $mean = $count > 0 ? $sum / $count : 0.0;
+        $metrics = pg_bench_aggregate_metric($timings_ms, '', '_ms');
 
-        $scenarios[] = [
+        ksort($custom_metric_samples);
+        foreach ($custom_metric_samples as $metric => $samples) {
+            $metrics += pg_bench_aggregate_metric($samples, $metric);
+        }
+
+        $scenario = [
             'id' => $scenario_id,
             'file' => $relative_file,
             'source' => $source,
             'iterations' => $iterations_per_workload,
-            'metrics' => [
-                'mean_ms' => $mean,
-                'p50_ms' => pg_bench_percentile($timings_ms, 0.50),
-                'p95_ms' => pg_bench_percentile($timings_ms, 0.95),
-                'p99_ms' => pg_bench_percentile($timings_ms, 0.99),
-                'min_ms' => $count > 0 ? $timings_ms[0] : 0.0,
-                'max_ms' => $count > 0 ? $timings_ms[$count - 1] : 0.0,
-            ],
+            'metrics' => $metrics,
             'memory' => ['peak_bytes' => $peak_memory],
         ];
+
+        if ($has_metadata) {
+            $scenario['metadata'] = $latest_metadata;
+        }
+
+        $scenarios[] = $scenario;
 
         pg_log(sprintf(
             "WORKLOAD_OK: %s p50=%.2fms p95=%.2fms p99=%.2fms",

--- a/wordpress/tests/fixtures/bench-custom-metrics/bench-custom-metrics.php
+++ b/wordpress/tests/fixtures/bench-custom-metrics/bench-custom-metrics.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Plugin Name: Bench Custom Metrics Fixture
+ * Description: Minimal plugin used to smoke-test workload-provided bench metrics.
+ */

--- a/wordpress/tests/fixtures/bench-custom-metrics/tests/bench/custom-metrics.php
+++ b/wordpress/tests/fixtures/bench-custom-metrics/tests/bench/custom-metrics.php
@@ -1,0 +1,14 @@
+<?php
+/** Workload that emits custom metrics + metadata for the bench runner. */
+return function (): array {
+    return [
+        'metrics' => [
+            'rows' => 10,
+            'changed_files' => 3,
+            'ignored_label' => 'not numeric',
+        ],
+        'metadata' => [
+            'phase' => 'warm',
+        ],
+    ];
+};

--- a/wordpress/tests/fixtures/bench-custom-metrics/tests/bench/legacy-array.php
+++ b/wordpress/tests/fixtures/bench-custom-metrics/tests/bench/legacy-array.php
@@ -1,0 +1,5 @@
+<?php
+/** Legacy workload return arrays without a metrics key remain metadata-free. */
+return function (): array {
+    return ['kind' => 'legacy'];
+};


### PR DESCRIPTION
## Summary
- Preserve structured workload return payloads from WordPress bench workloads.
- Aggregate numeric `metrics` samples into the existing BenchResults metric shape.
- Attach the latest `metadata` payload to the scenario without changing legacy duration metrics.

Closes #265

## Tests
- `php -l wordpress/scripts/bench/playground-bench-runner.php`
- `php -l wordpress/tests/fixtures/bench-custom-metrics/tests/bench/custom-metrics.php`
- `php -l wordpress/tests/fixtures/bench-custom-metrics/tests/bench/legacy-array.php`
- `php -l wordpress/tests/fixtures/bench-custom-metrics/bench-custom-metrics.php`
- `bash wordpress/scripts/bench/playground-bench-smoke.sh`
- `bash wordpress/scripts/bench/playground-bench-custom-metrics-smoke.sh`
- `bash wordpress/scripts/bench/playground-bench-bootstrap-metrics-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing WordPress bench custom metric support and tests under Chris's review.
