### PR TITLE
Fix Node.js build runner fallback paths

### DIFF
--- a/nodejs/scripts/build/build-runner-shell-smoke.sh
+++ b/nodejs/scripts/build/build-runner-shell-smoke.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+if [ -z "${BASH_VERSION:-}" ]; then
+    exec bash "$0" "$@"
+fi
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -22,6 +27,7 @@ function assert(condition, message) {
 assert(manifest.build.extension_script === 'scripts/build/build-runner.sh', 'build runner path is stable');
 assert(manifest.build.command_template === 'bash {{script}}', 'build runner executes through bash');
 assert(runner.startsWith('#!/usr/bin/env bash'), 'build runner declares bash shebang');
+assert(runner.includes('exec bash "$0" "$@"'), 'build runner re-execs bash when invoked by sh');
 assert(runner.includes('set -euo pipefail'), 'build runner uses bash pipefail mode');
 assert(runner.includes('BASH_SOURCE[0]'), 'build runner uses bash BASH_SOURCE');
 assert(runner.includes('PIPESTATUS[0]'), 'build runner uses bash PIPESTATUS');

--- a/nodejs/scripts/build/build-runner.sh
+++ b/nodejs/scripts/build/build-runner.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+if [ -z "${BASH_VERSION:-}" ]; then
+    exec bash "$0" "$@"
+fi
+
 set -euo pipefail
 
 # Node.js build runner for `homeboy build`.

--- a/nodejs/scripts/lib/resolve-context.sh
+++ b/nodejs/scripts/lib/resolve-context.sh
@@ -73,11 +73,11 @@ homeboy_require_package_json() {
 # Sets PKG_MANAGER and PKG_RUN ("pnpm run", "yarn", "npm run", "npx").
 homeboy_detect_package_manager() {
     local _dir="${1:-$PROJECT_PATH}"
-    if [ -f "$_dir/pnpm-lock.yaml" ]; then
+    if [ -f "$_dir/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
         PKG_MANAGER="pnpm"
         PKG_RUN="pnpm run"
         PKG_EXEC="pnpm exec"
-    elif [ -f "$_dir/yarn.lock" ]; then
+    elif [ -f "$_dir/yarn.lock" ] && command -v yarn >/dev/null 2>&1; then
         PKG_MANAGER="yarn"
         PKG_RUN="yarn"
         PKG_EXEC="yarn"


### PR DESCRIPTION
## Summary
- Re-execs the Node.js build runner under Bash when Homeboy invokes it through `sh` despite the Bash-oriented runner.
- Makes the shell smoke test safe under `sh` too.
- Falls back to npm when a lockfile-specific package manager is not installed locally.

## Verification
- `bash nodejs/scripts/build/build-runner-shell-smoke.sh`
- `sh nodejs/scripts/build/build-runner-shell-smoke.sh`
- `HOMEBOY_NODE_BUILD_COMMAND='npm --version' sh nodejs/scripts/build/build-runner.sh` against IBE
- `sh nodejs/scripts/build/build-runner.sh` against the IBE worktree, which ran `npm run build` successfully

Fixes Extra-Chill/homeboy#1602.