### PR TITLE
fix(wordpress): classify Playground bootstrap crashes

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -230,7 +230,16 @@ if [ -f "$PLUGIN_DB_PHP" ]; then
     MOUNT_ARGS+=("--mount" "${PLUGIN_DB_PHP}:/wordpress/wp-content/db.php")
 fi
 
+PLAYGROUND_BOOTSTRAP_PHP="${EXTENSION_PATH}/scripts/lib/playground-bootstrap.php"
+if [ ! -f "$PLAYGROUND_BOOTSTRAP_PHP" ]; then
+    echo "Error: Playground bootstrap helper not found at $PLAYGROUND_BOOTSTRAP_PHP" >&2
+    echo "This is a Homeboy WordPress extension installation/update problem, not a component bench failure." >&2
+    FAILED_STEP="Playground bootstrap helper setup"
+    exit 2
+fi
+
 MOUNT_ARGS+=("--mount" "${EXTENSION_PATH}:/homeboy-extension")
+MOUNT_ARGS+=("--mount" "${PLAYGROUND_BOOTSTRAP_PHP}:/homeboy-extension/scripts/lib/playground-bootstrap.php")
 
 # Rig-private workloads are host paths supplied by homeboy core through a
 # PATH-style list. Mount each file into Playground and let the PHP runner tag
@@ -416,7 +425,7 @@ if echo "$BENCH_LOG" | grep -qE '^STAGE_(FAIL|FATAL):'; then
     FAILURE_OUTPUT="$FAILED_STAGE_LINE"
     dump_diagnostics "BOOTSTRAP FAILURE: $FAILED_STAGE_DETAIL"
     rm -f "$RESULT_LOG"
-    exit ${playground_exit:-1}
+    exit 2
 fi
 
 # Case 2: PHP crashed before the runner could write to the result file.
@@ -425,7 +434,7 @@ if [ $playground_exit -ne 0 ] && echo "$BENCH_STDOUT" | grep -qE '^(PHP Parse er
     FAILURE_OUTPUT=$(echo "$BENCH_STDOUT" | grep -E '^(PHP Parse error|Parse error:|PHP Fatal error|Fatal error:)' | head -5)
     dump_diagnostics "PHP CRASH"
     rm -f "$RESULT_LOG" "$RESULT_JSON"
-    exit $playground_exit
+    exit 2
 fi
 
 # Case 3: playground exited non-zero, no structured failure visible.
@@ -433,7 +442,7 @@ if [ $playground_exit -ne 0 ]; then
     FAILED_STEP="Playground exited with code $playground_exit (unclassified)"
     dump_diagnostics "UNCLASSIFIED PLAYGROUND FAILURE (exit=$playground_exit)"
     rm -f "$RESULT_LOG" "$RESULT_JSON"
-    exit $playground_exit
+    exit 2
 fi
 
 # Case 4: the JSON envelope wasn't written. That's a runner bug.
@@ -441,7 +450,7 @@ if [ ! -f "$RESULT_JSON" ]; then
     dump_diagnostics "BENCH RUN COMPLETED BUT WROTE NO RESULTS"
     FAILED_STEP="Bench completed but no .pg-bench-results.json emitted"
     rm -f "$RESULT_LOG"
-    exit 1
+    exit 2
 fi
 
 # Surface non-fatal NOTICEs even on success — they're often the early

--- a/wordpress/scripts/test/playground-bootstrap-mount-smoke.sh
+++ b/wordpress/scripts/test/playground-bootstrap-mount-smoke.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+assert_contains() {
+    local file="$1"
+    local needle="$2"
+    if ! grep -Fq -- "$needle" "$file"; then
+        echo "FAIL: expected $file to contain: $needle" >&2
+        exit 1
+    fi
+}
+
+TEST_RUNNER="$SCRIPT_DIR/test-runner-playground.sh"
+BENCH_RUNNER="$EXTENSION_PATH/scripts/bench/bench-runner-playground.sh"
+
+for runner in "$TEST_RUNNER" "$BENCH_RUNNER"; do
+    assert_contains "$runner" 'PLAYGROUND_BOOTSTRAP_PHP="${EXTENSION_PATH}/scripts/lib/playground-bootstrap.php"'
+    assert_contains "$runner" 'This is a Homeboy WordPress extension installation/update problem'
+    assert_contains "$runner" 'exit 2'
+    assert_contains "$runner" ':/homeboy-extension/scripts/lib/playground-bootstrap.php'
+done
+
+assert_contains "$TEST_RUNNER" 'FAILED_STEP="Playground PHP crash (before runner took control)"'
+assert_contains "$BENCH_RUNNER" 'FAILED_STEP="Playground PHP crash (before bench runner took control)"'
+
+echo "PASS: Playground bootstrap mount and infrastructure exit contract is pinned."

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -216,7 +216,16 @@ if [ -f "$PLUGIN_DB_PHP" ]; then
     fi
 fi
 
+PLAYGROUND_BOOTSTRAP_PHP="${EXTENSION_PATH}/scripts/lib/playground-bootstrap.php"
+if [ ! -f "$PLAYGROUND_BOOTSTRAP_PHP" ]; then
+    echo "Error: Playground bootstrap helper not found at $PLAYGROUND_BOOTSTRAP_PHP" >&2
+    echo "This is a Homeboy WordPress extension installation/update problem, not a component test failure." >&2
+    FAILED_STEP="Playground bootstrap helper setup"
+    exit 2
+fi
+
 MOUNT_ARGS+=("--mount" "${EXTENSION_PATH}:/homeboy-extension")
+MOUNT_ARGS+=("--mount" "${PLAYGROUND_BOOTSTRAP_PHP}:/homeboy-extension/scripts/lib/playground-bootstrap.php")
 
 PLAYGROUND_DEP_MOUNTS=""
 if [ -n "$DEPENDENCY_PATHS" ]; then
@@ -349,7 +358,7 @@ if echo "$PHPUNIT_OUTPUT" | grep -qE '^STAGE_(FAIL|FATAL):'; then
     FAILURE_OUTPUT="$FAILED_STAGE_LINE"
     dump_diagnostics "BOOTSTRAP FAILURE: $FAILED_STAGE_DETAIL"
     rm -f "$RESULT_FILE"
-    exit ${playground_exit:-1}
+    exit 2
 fi
 
 # Case 2: PHPUnit ran, some tests failed.
@@ -378,7 +387,7 @@ if [ $playground_exit -ne 0 ] && echo "$PHPUNIT_STDOUT" | grep -qE '^(PHP Parse 
     FAILURE_OUTPUT=$(echo "$PHPUNIT_STDOUT" | grep -E '^(PHP Parse error|Parse error:|PHP Fatal error|Fatal error:)' | head -5)
     dump_diagnostics "PHP CRASH"
     rm -f "$RESULT_FILE"
-    exit $playground_exit
+    exit 2
 fi
 
 # Case 5: playground exited non-zero and we still can't classify it.
@@ -387,7 +396,7 @@ if [ $playground_exit -ne 0 ]; then
     FAILED_STEP="Playground exited with code $playground_exit (unclassified)"
     dump_diagnostics "UNCLASSIFIED PLAYGROUND FAILURE (exit=$playground_exit)"
     rm -f "$RESULT_FILE"
-    exit $playground_exit
+    exit 2
 fi
 
 # Case 6: no output at all (not even a result file). Shouldn't happen on a


### PR DESCRIPTION
## Summary
- Fail fast when the WordPress extension install is missing `scripts/lib/playground-bootstrap.php`, before Playground starts.
- Explicitly mount the bootstrap helper file into the Playground VFS so `/homeboy-extension/scripts/lib/playground-bootstrap.php` resolves reliably.
- Return exit `2` for Playground bootstrap/runner crashes while preserving exit `1` for normal PHPUnit failures.

## Tests
- `bash -n wordpress/scripts/test/test-runner-playground.sh`
- `bash -n wordpress/scripts/bench/bench-runner-playground.sh`
- `bash wordpress/scripts/test/playground-bootstrap-mount-smoke.sh`

Refs Extra-Chill/homeboy#1618.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner classification/mount changes and smoke coverage; Chris remains responsible for review and merge.