### PR TITLE
chore(runners): use core runtime helpers

### DIFF
--- a/nodejs/scripts/bench/bench-runner.sh
+++ b/nodejs/scripts/bench/bench-runner.sh
@@ -24,29 +24,21 @@ if ((BASH_VERSINFO[0] < 4)); then
     exit 1
 fi
 
-FAILED_STEP=""
-FAILURE_OUTPUT=""
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/resolve-context.sh
 source "${SCRIPT_DIR}/../lib/resolve-context.sh"
 homeboy_resolve_context
 homeboy_require_package_json
 
-print_failure_summary() {
-    if [ -n "$FAILED_STEP" ]; then
-        echo ""
-        echo "============================================"
-        echo "BENCH FAILED: $FAILED_STEP"
-        echo "============================================"
-        if [ -n "$FAILURE_OUTPUT" ]; then
-            echo ""
-            echo "Error details:"
-            echo "$FAILURE_OUTPUT"
-        fi
-    fi
-}
-trap print_failure_summary EXIT
+FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
+# shellcheck source=/dev/null
+if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
+    source "$FAILURE_TRAP_HELPER"
+    homeboy_init_failure_trap
+else
+    FAILED_STEP=""
+    FAILURE_OUTPUT=""
+fi
 
 ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-10}"
 RESULTS_FILE="${HOMEBOY_BENCH_RESULTS_FILE:-${PROJECT_PATH}/.node-bench-results.json}"

--- a/nodejs/scripts/build/build-runner.sh
+++ b/nodejs/scripts/build/build-runner.sh
@@ -27,9 +27,6 @@ if ((BASH_VERSINFO[0] < 4)); then
     exit 1
 fi
 
-FAILED_STEP=""
-FAILURE_OUTPUT=""
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/resolve-context.sh
 source "${SCRIPT_DIR}/../lib/resolve-context.sh"
@@ -37,20 +34,15 @@ homeboy_resolve_context
 homeboy_require_package_json
 homeboy_detect_package_manager
 
-print_failure_summary() {
-    if [ -n "$FAILED_STEP" ]; then
-        echo ""
-        echo "============================================"
-        echo "BUILD FAILED: $FAILED_STEP"
-        echo "============================================"
-        if [ -n "$FAILURE_OUTPUT" ]; then
-            echo ""
-            echo "Error details:"
-            echo "$FAILURE_OUTPUT"
-        fi
-    fi
-}
-trap print_failure_summary EXIT
+FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
+# shellcheck source=/dev/null
+if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
+    source "$FAILURE_TRAP_HELPER"
+    homeboy_init_failure_trap
+else
+    FAILED_STEP=""
+    FAILURE_OUTPUT=""
+fi
 
 # Resolve the build command.
 BUILD_CMD=""

--- a/nodejs/scripts/lint/lint-runner.sh
+++ b/nodejs/scripts/lint/lint-runner.sh
@@ -26,9 +26,6 @@ if ((BASH_VERSINFO[0] < 4)); then
     exit 1
 fi
 
-FAILED_STEP=""
-FAILURE_OUTPUT=""
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/resolve-context.sh
 source "${SCRIPT_DIR}/../lib/resolve-context.sh"
@@ -36,20 +33,15 @@ homeboy_resolve_context
 homeboy_require_package_json
 homeboy_detect_package_manager
 
-print_failure_summary() {
-    if [ -n "$FAILED_STEP" ]; then
-        echo ""
-        echo "============================================"
-        echo "LINT FAILED: $FAILED_STEP"
-        echo "============================================"
-        if [ -n "$FAILURE_OUTPUT" ]; then
-            echo ""
-            echo "Error details:"
-            echo "$FAILURE_OUTPUT"
-        fi
-    fi
-}
-trap print_failure_summary EXIT
+FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
+# shellcheck source=/dev/null
+if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
+    source "$FAILURE_TRAP_HELPER"
+    homeboy_init_failure_trap
+else
+    FAILED_STEP=""
+    FAILURE_OUTPUT=""
+fi
 
 FIX_MODE="${HOMEBOY_FIX_ONLY:-0}"
 FINDINGS_FILE="${HOMEBOY_LINT_FINDINGS_FILE:-${PROJECT_PATH}/.node-lint-findings.json}"

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -29,9 +29,6 @@ if ((BASH_VERSINFO[0] < 4)); then
     exit 1
 fi
 
-FAILED_STEP=""
-FAILURE_OUTPUT=""
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/resolve-context.sh
 source "${SCRIPT_DIR}/../lib/resolve-context.sh"
@@ -39,47 +36,21 @@ homeboy_resolve_context
 homeboy_require_package_json
 homeboy_detect_package_manager
 
-# Source the homeboy runtime helper if available — provides the canonical
-# homeboy_write_test_results function. Path provided by core via
-# HOMEBOY_RUNTIME_WRITE_TEST_RESULTS; fall back to inline writer if not set
-# (direct invocation outside homeboy).
 WRITE_TEST_RESULTS_HELPER="${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-}"
 if [ -n "$WRITE_TEST_RESULTS_HELPER" ] && [ -f "$WRITE_TEST_RESULTS_HELPER" ]; then
     # shellcheck source=/dev/null
     source "$WRITE_TEST_RESULTS_HELPER"
-else
-    # Inline fallback that matches the canonical writer's contract.
-    homeboy_write_test_results() {
-        local total="${1:-0}" passed="${2:-0}" failed="${3:-0}" skipped="${4:-0}" partial="${5:-}"
-        if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
-            if [ -n "$partial" ]; then
-                cat > "$HOMEBOY_TEST_RESULTS_FILE" <<JSONEOF
-{"total":${total},"passed":${passed},"failed":${failed},"skipped":${skipped},"partial":"${partial}"}
-JSONEOF
-            else
-                cat > "$HOMEBOY_TEST_RESULTS_FILE" <<JSONEOF
-{"total":${total},"passed":${passed},"failed":${failed},"skipped":${skipped}}
-JSONEOF
-            fi
-        fi
-        echo "[test-results] Total: ${total}, Passed: ${passed}, Failed: ${failed}, Skipped: ${skipped}${partial:+ ($partial)}" >&2
-    }
 fi
 
-print_failure_summary() {
-    if [ -n "$FAILED_STEP" ]; then
-        echo ""
-        echo "============================================"
-        echo "TEST FAILED: $FAILED_STEP"
-        echo "============================================"
-        if [ -n "$FAILURE_OUTPUT" ]; then
-            echo ""
-            echo "Error details:"
-            echo "$FAILURE_OUTPUT"
-        fi
-    fi
-}
-trap print_failure_summary EXIT
+FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
+# shellcheck source=/dev/null
+if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
+    source "$FAILURE_TRAP_HELPER"
+    homeboy_init_failure_trap
+else
+    FAILED_STEP=""
+    FAILURE_OUTPUT=""
+fi
 
 # Resolve the test command.
 if [ -n "${HOMEBOY_NODE_TEST_COMMAND:-}" ]; then
@@ -183,7 +154,9 @@ if [ $PARSED -eq 0 ]; then
     PARTIAL_LABEL="unknown-runner"
 fi
 
-homeboy_write_test_results "$TOTAL" "$PASSED" "$FAILED" "$SKIPPED" "$PARTIAL_LABEL"
+if type homeboy_write_test_results >/dev/null 2>&1; then
+    homeboy_write_test_results "$TOTAL" "$PASSED" "$FAILED" "$SKIPPED" "$PARTIAL_LABEL"
+fi
 
 if [ $TEST_EXIT -ne 0 ]; then
     FAILED_STEP="Tests failed (exit $TEST_EXIT)"

--- a/rust/scripts/bench/bench-runner.sh
+++ b/rust/scripts/bench/bench-runner.sh
@@ -53,25 +53,16 @@ if ((BASH_VERSINFO[0] < 4)); then
     exit 1
 fi
 
-FAILED_STEP=""
-FAILURE_OUTPUT=""
-
-print_failure_summary() {
-    if [ -n "$FAILED_STEP" ]; then
-        echo "" >&2
-        echo "============================================" >&2
-        echo "BENCH FAILED: $FAILED_STEP" >&2
-        echo "============================================" >&2
-        if [ -n "$FAILURE_OUTPUT" ]; then
-            echo "" >&2
-            echo "Error details:" >&2
-            echo "$FAILURE_OUTPUT" >&2
-        fi
-    fi
-}
-trap print_failure_summary EXIT
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
+# shellcheck source=/dev/null
+if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
+    source "$FAILURE_TRAP_HELPER"
+    homeboy_init_failure_trap
+else
+    FAILED_STEP=""
+    FAILURE_OUTPUT=""
+fi
 
 # Resolve context (matches test-runner.sh shape).
 if [ -n "${HOMEBOY_COMPONENT_PATH:-}" ]; then
@@ -243,7 +234,13 @@ else
 fi
 
 SCENARIOS_JSON_TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$SCENARIOS_JSON_TMPDIR"; print_failure_summary' EXIT
+cleanup_scenarios() {
+    rm -rf "$SCENARIOS_JSON_TMPDIR"
+    if type homeboy_print_failure_summary >/dev/null 2>&1; then
+        homeboy_print_failure_summary
+    fi
+}
+trap cleanup_scenarios EXIT
 
 OVERALL_OK=1
 SCENARIOS_PATHS=()

--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -20,28 +20,19 @@ set -euo pipefail
 #   HOMEBOY_SKIP            — comma-separated steps to skip
 #   HOMEBOY_DEBUG           — if "1", show debug output
 
-FAILED_STEP=""
-FAILURE_OUTPUT=""
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/lib/runner-steps.sh}"
+FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 # shellcheck source=./lib/runner-steps.sh
 source "${RUNNER_STEPS_HELPER}"
-
-print_failure_summary() {
-    if [ -n "$FAILED_STEP" ]; then
-        echo ""
-        echo "============================================"
-        echo "BUILD FAILED: $FAILED_STEP"
-        echo "============================================"
-        if [ -n "$FAILURE_OUTPUT" ]; then
-            echo ""
-            echo "Error details:"
-            echo "$FAILURE_OUTPUT"
-        fi
-    fi
-}
-trap print_failure_summary EXIT
+# shellcheck source=/dev/null
+if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
+    source "$FAILURE_TRAP_HELPER"
+    homeboy_init_failure_trap
+else
+    FAILED_STEP=""
+    FAILURE_OUTPUT=""
+fi
 
 # Determine project path
 if [ -n "${HOMEBOY_COMPONENT_PATH:-}" ]; then

--- a/rust/scripts/parse-test-results.sh
+++ b/rust/scripts/parse-test-results.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Parse cargo test output and write test results JSON to HOMEBOY_TEST_RESULTS_FILE.
+# Parse cargo test output and ask Homeboy's runtime helper to write test results.
 #
 # Cargo output pattern (one per test binary):
 #   test result: ok. 551 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out;
@@ -18,10 +18,16 @@ fi
 
 OUTPUT=$(cat "$OUTPUT_FILE")
 
+WRITE_TEST_RESULTS_HELPER="${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-}"
+if [ -n "$WRITE_TEST_RESULTS_HELPER" ] && [ -f "$WRITE_TEST_RESULTS_HELPER" ]; then
+    # shellcheck source=/dev/null
+    source "$WRITE_TEST_RESULTS_HELPER"
+fi
+
 # Aggregate all "test result:" lines
-TOTAL_PASSED=$(echo "$OUTPUT" | grep -oP '\d+ passed' | awk '{s+=$1} END {print s+0}')
-TOTAL_FAILED=$(echo "$OUTPUT" | grep -oP '\d+ failed' | awk '{s+=$1} END {print s+0}')
-TOTAL_IGNORED=$(echo "$OUTPUT" | grep -oP '\d+ ignored' | awk '{s+=$1} END {print s+0}')
+TOTAL_PASSED=$( { echo "$OUTPUT" | grep -Eo '[0-9]+ passed' || true; } | awk '{s+=$1} END {print s+0}' )
+TOTAL_FAILED=$( { echo "$OUTPUT" | grep -Eo '[0-9]+ failed' || true; } | awk '{s+=$1} END {print s+0}' )
+TOTAL_IGNORED=$( { echo "$OUTPUT" | grep -Eo '[0-9]+ ignored' || true; } | awk '{s+=$1} END {print s+0}' )
 
 TOTAL=$((TOTAL_PASSED + TOTAL_FAILED + TOTAL_IGNORED))
 
@@ -30,17 +36,7 @@ if [ "$TOTAL" -eq 0 ]; then
     exit 0
 fi
 
-# Write JSON to file if requested
-if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
-    cat > "$HOMEBOY_TEST_RESULTS_FILE" << JSONEOF
-{
-  "total": ${TOTAL},
-  "passed": ${TOTAL_PASSED},
-  "failed": ${TOTAL_FAILED},
-  "skipped": ${TOTAL_IGNORED}
-}
-JSONEOF
+# Write JSON to file if requested by core.
+if type homeboy_write_test_results >/dev/null 2>&1; then
+    homeboy_write_test_results "$TOTAL" "$TOTAL_PASSED" "$TOTAL_FAILED" "$TOTAL_IGNORED"
 fi
-
-# Print summary to stderr for visibility
-echo "[test-results] Total: ${TOTAL}, Passed: ${TOTAL_PASSED}, Failed: ${TOTAL_FAILED}, Skipped: ${TOTAL_IGNORED}" >&2

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -16,32 +16,20 @@ set -euo pipefail
 #
 # Passthrough args after -- are forwarded to cargo test.
 
-FAILED_STEP=""
-FAILURE_OUTPUT=""
-FAILURE_REPLAY_MODE="full"
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/lib/runner-steps.sh}"
+FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 # shellcheck source=./lib/runner-steps.sh
 source "${RUNNER_STEPS_HELPER}"
-
-print_failure_summary() {
-    if [ -n "$FAILED_STEP" ]; then
-        echo ""
-        echo "============================================"
-        echo "BUILD FAILED: $FAILED_STEP"
-        echo "============================================"
-        if [ "$FAILURE_REPLAY_MODE" = "none" ]; then
-            echo ""
-            echo "See test output above (not replayed)."
-        elif [ -n "$FAILURE_OUTPUT" ]; then
-            echo ""
-            echo "Error details:"
-            echo "$FAILURE_OUTPUT"
-        fi
-    fi
-}
-trap print_failure_summary EXIT
+# shellcheck source=/dev/null
+if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
+    source "$FAILURE_TRAP_HELPER"
+    homeboy_init_failure_trap
+else
+    FAILED_STEP=""
+    FAILURE_OUTPUT=""
+    FAILURE_REPLAY_MODE="full"
+fi
 
 # Determine project path
 if [ -n "${HOMEBOY_COMPONENT_PATH:-}" ]; then
@@ -295,7 +283,7 @@ fi
 # Detect zero-test runs — only warn if NO test result line shows passed tests.
 # Cargo runs multiple test binaries (unit, integration, doc-tests); some may
 # legitimately have 0 tests while others have hundreds.
-TOTAL_PASSED=$(echo "$TEST_OUTPUT" | grep -oP '\d+ passed' | awk '{s+=$1} END {print s+0}')
+TOTAL_PASSED=$( { echo "$TEST_OUTPUT" | grep -Eo '[0-9]+ passed' || true; } | awk '{s+=$1} END {print s+0}' )
 if [ "$TOTAL_PASSED" -eq 0 ]; then
     TEST_FILE_COUNT=$(find "$PROJECT_PATH" -name "*test*" -name "*.rs" -not -path "*/target/*" 2>/dev/null | wc -l | tr -d ' ')
     if [ "$TEST_FILE_COUNT" -gt 0 ]; then

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/failure-trap.sh}"
+WRITE_TEST_RESULTS_HELPER="${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/write-test-results.sh}"
+
+assert_file() {
+    local path="$1"
+    if [ ! -f "$path" ]; then
+        echo "Missing required file: $path" >&2
+        exit 1
+    fi
+}
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq "$expected" "$file"; then
+        echo "Expected $file to contain: $expected" >&2
+        echo "Actual contents:" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local file="$1"
+    local unexpected="$2"
+    if grep -Fq "$unexpected" "$file"; then
+        echo "Expected $file not to contain: $unexpected" >&2
+        echo "Actual contents:" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+assert_file "$FAILURE_TRAP_HELPER"
+assert_file "$WRITE_TEST_RESULTS_HELPER"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+WORDPRESS_OUTPUT="$TMP_DIR/phpunit.txt"
+WORDPRESS_RESULTS="$TMP_DIR/wordpress-results.json"
+cat > "$WORDPRESS_OUTPUT" <<'EOF'
+Tests: 12, Assertions: 30, Errors: 1, Failures: 2, Warnings: 1, Skipped: 3, Incomplete: 1, Risky: 1.
+EOF
+
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WRITE_TEST_RESULTS_HELPER" \
+HOMEBOY_TEST_RESULTS_FILE="$WORDPRESS_RESULTS" \
+    bash "$ROOT_DIR/wordpress/scripts/test/parse-test-results.sh" "$WORDPRESS_OUTPUT" >/dev/null
+assert_contains "$WORDPRESS_RESULTS" '"total": 12'
+assert_contains "$WORDPRESS_RESULTS" '"passed": 3'
+assert_contains "$WORDPRESS_RESULTS" '"failed": 3'
+assert_contains "$WORDPRESS_RESULTS" '"skipped": 6'
+assert_not_contains "$WORDPRESS_RESULTS" '"partial"'
+
+WORDPRESS_PARTIAL_OUTPUT="$TMP_DIR/phpunit-partial.txt"
+WORDPRESS_PARTIAL_RESULTS="$TMP_DIR/wordpress-partial-results.json"
+cat > "$WORDPRESS_PARTIAL_OUTPUT" <<'EOF'
+ ✔ First test
+ ✔ Second test
+ ✘ Third test
+EOF
+
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WRITE_TEST_RESULTS_HELPER" \
+HOMEBOY_TEST_RESULTS_FILE="$WORDPRESS_PARTIAL_RESULTS" \
+    bash "$ROOT_DIR/wordpress/scripts/test/parse-test-results.sh" "$WORDPRESS_PARTIAL_OUTPUT" >/dev/null
+assert_contains "$WORDPRESS_PARTIAL_RESULTS" '"total": 3'
+assert_contains "$WORDPRESS_PARTIAL_RESULTS" '"passed": 2'
+assert_contains "$WORDPRESS_PARTIAL_RESULTS" '"failed": 1'
+assert_contains "$WORDPRESS_PARTIAL_RESULTS" '"partial": "testdox-fallback"'
+
+RUST_OUTPUT="$TMP_DIR/cargo-test.txt"
+RUST_RESULTS="$TMP_DIR/rust-results.json"
+cat > "$RUST_OUTPUT" <<'EOF'
+test result: ok. 10 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out;
+test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out;
+EOF
+
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WRITE_TEST_RESULTS_HELPER" \
+HOMEBOY_TEST_RESULTS_FILE="$RUST_RESULTS" \
+    bash "$ROOT_DIR/rust/scripts/parse-test-results.sh" "$RUST_OUTPUT" >/dev/null
+assert_contains "$RUST_RESULTS" '"total": 17'
+assert_contains "$RUST_RESULTS" '"passed": 14'
+assert_contains "$RUST_RESULTS" '"failed": 1'
+assert_contains "$RUST_RESULTS" '"skipped": 2'
+
+RUST_EMPTY_OUTPUT="$TMP_DIR/cargo-test-empty.txt"
+RUST_EMPTY_RESULTS="$TMP_DIR/rust-empty-results.json"
+printf 'compiler output without a cargo summary\n' > "$RUST_EMPTY_OUTPUT"
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WRITE_TEST_RESULTS_HELPER" \
+HOMEBOY_TEST_RESULTS_FILE="$RUST_EMPTY_RESULTS" \
+    bash "$ROOT_DIR/rust/scripts/parse-test-results.sh" "$RUST_EMPTY_OUTPUT" >/dev/null
+if [ -e "$RUST_EMPTY_RESULTS" ]; then
+    echo "Rust parser should not write a sidecar when no test summary exists" >&2
+    exit 1
+fi
+
+NODE_PROJECT="$TMP_DIR/node-project"
+mkdir -p "$NODE_PROJECT"
+cat > "$NODE_PROJECT/package.json" <<'EOF'
+{"name":"runtime-helper-smoke","scripts":{}}
+EOF
+
+set +e
+HOMEBOY_RUNTIME_FAILURE_TRAP="$FAILURE_TRAP_HELPER" \
+HOMEBOY_EXTENSION_PATH="$ROOT_DIR/nodejs" \
+HOMEBOY_COMPONENT_PATH="$NODE_PROJECT" \
+HOMEBOY_COMPONENT_ID="runtime-helper-smoke" \
+    bash "$ROOT_DIR/nodejs/scripts/build/build-runner.sh" >"$TMP_DIR/node-build.out" 2>&1
+NODE_EXIT=$?
+set -e
+if [ "$NODE_EXIT" -eq 0 ]; then
+    echo "Expected node build runner to fail without scripts.build" >&2
+    exit 1
+fi
+assert_contains "$TMP_DIR/node-build.out" 'BUILD FAILED: No build defined'
+assert_contains "$TMP_DIR/node-build.out" 'Error details:'
+
+if grep -R "print_failure_summary()" \
+    "$ROOT_DIR/nodejs/scripts" \
+    "$ROOT_DIR/rust/scripts" \
+    "$ROOT_DIR/wordpress/scripts/test" \
+    "$ROOT_DIR/wordpress/scripts/bench" >/dev/null; then
+    echo "Runner scripts should not define local print_failure_summary functions" >&2
+    exit 1
+fi
+
+if grep -R "homeboy_write_test_results()" \
+    "$ROOT_DIR/nodejs/scripts" \
+    "$ROOT_DIR/rust/scripts" \
+    "$ROOT_DIR/wordpress/scripts/test" >/dev/null; then
+    echo "Extension scripts should not define local homeboy_write_test_results functions" >&2
+    exit 1
+fi
+
+echo "runtime helper smoke passed"

--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -32,11 +32,9 @@ set -euo pipefail
 # 4. Reads the host-visible .pg-bench-results.json (written through the
 #    mount) and copies it to $HOMEBOY_BENCH_RESULTS_FILE for homeboy core.
 
-FAILED_STEP=""
-FAILURE_OUTPUT=""
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 PHP_PREFLIGHT_HELPER="${SCRIPT_DIR}/../lib/php-preflight.sh"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
 # shellcheck source=../lib/php-preflight.sh
@@ -47,21 +45,14 @@ fi
 if [ -f "$DEPENDENCY_HELPER" ]; then
     source "$DEPENDENCY_HELPER"
 fi
-
-print_failure_summary() {
-    if [ -n "$FAILED_STEP" ]; then
-        echo ""
-        echo "============================================"
-        echo "BENCH FAILED: $FAILED_STEP"
-        echo "============================================"
-        if [ -n "$FAILURE_OUTPUT" ]; then
-            echo ""
-            echo "Error details:"
-            echo "$FAILURE_OUTPUT"
-        fi
-    fi
-}
-trap print_failure_summary EXIT
+# shellcheck source=/dev/null
+if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
+    source "$FAILURE_TRAP_HELPER"
+    homeboy_init_failure_trap
+else
+    FAILED_STEP=""
+    FAILURE_OUTPUT=""
+fi
 
 # Component resolution — same priority order as test-runner-playground.sh
 # so bench gets the same component-discovery semantics for free.

--- a/wordpress/scripts/test/parse-test-results.sh
+++ b/wordpress/scripts/test/parse-test-results.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Parse PHPUnit output and write test results JSON to HOMEBOY_TEST_RESULTS_FILE.
+# Parse PHPUnit output and ask Homeboy's runtime helper to write test results.
 #
 # PHPUnit output patterns:
 #   OK (481 tests, 1234 assertions)
@@ -12,7 +12,7 @@
 #
 # Usage: parse-test-results.sh <phpunit-output-file>
 #
-# Writes JSON to HOMEBOY_TEST_RESULTS_FILE if set. Always prints summary to stderr.
+# Writes JSON to HOMEBOY_TEST_RESULTS_FILE when the runtime helper is provided.
 
 set -euo pipefail
 
@@ -22,6 +22,12 @@ if [ -z "$OUTPUT_FILE" ] || [ ! -f "$OUTPUT_FILE" ]; then
 fi
 
 OUTPUT=$(cat "$OUTPUT_FILE")
+
+WRITE_TEST_RESULTS_HELPER="${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-}"
+if [ -n "$WRITE_TEST_RESULTS_HELPER" ] && [ -f "$WRITE_TEST_RESULTS_HELPER" ]; then
+    # shellcheck source=/dev/null
+    source "$WRITE_TEST_RESULTS_HELPER"
+fi
 
 TOTAL=0
 PASSED=0
@@ -88,33 +94,7 @@ else
     exit 0
 fi
 
-# Write JSON to file if requested
-if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
-    if [ -n "${PARTIAL:-}" ]; then
-        cat > "$HOMEBOY_TEST_RESULTS_FILE" << JSONEOF
-{
-  "total": ${TOTAL},
-  "passed": ${PASSED},
-  "failed": ${FAILED},
-  "skipped": ${SKIPPED},
-  "partial": "${PARTIAL}"
-}
-JSONEOF
-    else
-        cat > "$HOMEBOY_TEST_RESULTS_FILE" << JSONEOF
-{
-  "total": ${TOTAL},
-  "passed": ${PASSED},
-  "failed": ${FAILED},
-  "skipped": ${SKIPPED}
-}
-JSONEOF
-    fi
-fi
-
-# Print summary to stderr for visibility
-if [ -n "${PARTIAL:-}" ]; then
-    echo "[test-results] Total: ${TOTAL}, Passed: ${PASSED}, Failed: ${FAILED}, Skipped: ${SKIPPED} (${PARTIAL}: PHPUnit crashed before printing summary)" >&2
-else
-    echo "[test-results] Total: ${TOTAL}, Passed: ${PASSED}, Failed: ${FAILED}, Skipped: ${SKIPPED}" >&2
+# Write JSON to file if requested by core.
+if type homeboy_write_test_results >/dev/null 2>&1; then
+    homeboy_write_test_results "$TOTAL" "$PASSED" "$FAILED" "$SKIPPED" "$PARTIAL"
 fi

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -38,13 +38,10 @@ set -euo pipefail
 # The host bootstrap (tests/bootstrap.php) is NOT used by this backend.
 # install.php is included in-process which avoids the system() subprocess.
 
-FAILED_STEP=""
-FAILURE_OUTPUT=""
-FAILURE_REPLAY_MODE="full"
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/../lib/runner-steps.sh}"
+FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
 PHP_PREFLIGHT_HELPER="${SCRIPT_DIR}/../lib/php-preflight.sh"
 # shellcheck source=../lib/runner-steps.sh
@@ -59,24 +56,15 @@ fi
 if [ -f "$PHP_PREFLIGHT_HELPER" ]; then
     source "$PHP_PREFLIGHT_HELPER"
 fi
-
-print_failure_summary() {
-    if [ -n "$FAILED_STEP" ]; then
-        echo ""
-        echo "============================================"
-        echo "BUILD FAILED: $FAILED_STEP"
-        echo "============================================"
-        if [ "$FAILURE_REPLAY_MODE" = "none" ]; then
-            echo ""
-            echo "See PHPUnit output above (not replayed)."
-        elif [ -n "$FAILURE_OUTPUT" ]; then
-            echo ""
-            echo "Error details:"
-            echo "$FAILURE_OUTPUT"
-        fi
-    fi
-}
-trap print_failure_summary EXIT
+# shellcheck source=/dev/null
+if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
+    source "$FAILURE_TRAP_HELPER"
+    homeboy_init_failure_trap
+else
+    FAILED_STEP=""
+    FAILURE_OUTPUT=""
+    FAILURE_REPLAY_MODE="full"
+fi
 
 SETTINGS_JSON="${HOMEBOY_SETTINGS_JSON:-}"
 


### PR DESCRIPTION
## Summary
- Adopt Homeboy core's runtime helpers for shared failure banners and test-result sidecar writing.
- Remove duplicated runner-local failure traps and test JSON writers while preserving extension-specific parsing/classification logic.

## Changes
- Source `HOMEBOY_RUNTIME_FAILURE_TRAP` across Node.js, Rust, and WordPress runner scripts and initialize the shared trap when core provides it.
- Source `HOMEBOY_RUNTIME_WRITE_TEST_RESULTS` in Node.js, Rust, and WordPress test result paths instead of writing JSON locally.
- Make Rust cargo test summary parsing portable on macOS by replacing `grep -P` with extended grep.
- Add `tests/runtime-helpers-smoke.sh` to cover helper-backed WordPress/Rust sidecar writing, the Node failure banner, and stale duplicate-definition checks.

## Tests
- `bash tests/runtime-helpers-smoke.sh`
- `for f in **/*.sh; do bash -n "$f" || exit 1; done`
- `git diff --check`
- `homeboy test homeboy-extensions` (not applicable: aggregate component has no extensions configured)
- `homeboy audit homeboy-extensions --path .` (fails on pre-existing WordPress fixer audit findings unrelated to this change)

Closes #276
Closes #277

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the helper adoption cleanup, added focused smoke coverage, and ran local validation. Chris remains responsible for review and merge.