### PR TITLE
fix(wordpress): fail lint runner on reported issues

### DIFF
--- a/wordpress/scripts/lint/autofixable-exit-smoke.sh
+++ b/wordpress/scripts/lint/autofixable-exit-smoke.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/lint-runner.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+EXTENSION_DIR="${TMPDIR}/extension"
+COMPONENT_DIR="${TMPDIR}/component"
+OUTPUT_FILE="${TMPDIR}/lint-output.txt"
+FINDINGS_FILE="${TMPDIR}/lint-findings.json"
+
+mkdir -p "${EXTENSION_DIR}/vendor/bin" "${COMPONENT_DIR}"
+touch "${EXTENSION_DIR}/phpcs.xml.dist"
+
+cat > "${COMPONENT_DIR}/plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Autofixable Lint Fixture
+ * Text Domain: autofixable-lint-fixture
+ */
+
+$alpha   = 1;
+$beta = 2;
+PHP
+
+cat > "${EXTENSION_DIR}/vendor/bin/phpcs" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+for arg in "$@"; do
+    if [ "$arg" = "--config-set" ]; then
+        exit 0
+    fi
+done
+
+for arg in "$@"; do
+    if [ "$arg" = "--report=json" ]; then
+        cat <<'JSON'
+{"totals":{"errors":0,"warnings":1,"fixable":1},"files":{"/tmp/component/plugin.php":{"errors":0,"warnings":1,"messages":[{"message":"Equals sign not aligned with surrounding assignments","source":"Generic.Formatting.MultipleStatementAlignment.NotSameWarning","severity":5,"fixable":true,"type":"WARNING","line":8,"column":7}]}}}
+JSON
+        exit 1
+    fi
+done
+
+cat <<'TXT'
+FILE: plugin.php
+----------------------------------------------------------------------
+FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
+----------------------------------------------------------------------
+ 8 | WARNING | Equals sign not aligned with surrounding assignments
+----------------------------------------------------------------------
+TXT
+exit 1
+SH
+chmod +x "${EXTENSION_DIR}/vendor/bin/phpcs"
+
+run_lint() {
+    local mode="$1"
+    : > "$OUTPUT_FILE"
+    rm -f "$FINDINGS_FILE"
+
+    set +e
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+    HOMEBOY_COMPONENT_ID="autofixable-fixture" \
+    HOMEBOY_LINT_FINDINGS_FILE="$FINDINGS_FILE" \
+    HOMEBOY_STEP="phpcs" \
+    HOMEBOY_SUMMARY_MODE="$mode" \
+        "$RUNNER" >"$OUTPUT_FILE" 2>&1
+    local exit_code=$?
+    set -e
+
+    if [ "$exit_code" -eq 0 ]; then
+        echo "FAIL: lint runner should fail when PHPCS reports an auto-fixable warning (summary=${mode})" >&2
+        sed 's/^/  /' "$OUTPUT_FILE" >&2
+        exit 1
+    fi
+
+    if ! grep -Fq "AUTO-FIXABLE: 1 lint finding(s) can be fixed automatically." "$OUTPUT_FILE"; then
+        echo "FAIL: auto-fixable CTA missing (summary=${mode})" >&2
+        sed 's/^/  /' "$OUTPUT_FILE" >&2
+        exit 1
+    fi
+
+    if ! grep -Fq "Run:  homeboy refactor --from lint --write autofixable-fixture" "$OUTPUT_FILE"; then
+        echo "FAIL: refactor command missing (summary=${mode})" >&2
+        sed 's/^/  /' "$OUTPUT_FILE" >&2
+        exit 1
+    fi
+
+    if ! grep -Fq "Auto-fixable findings remain; run the refactor command above before pushing." "$OUTPUT_FILE"; then
+        echo "FAIL: aggregate failure message missing (summary=${mode})" >&2
+        sed 's/^/  /' "$OUTPUT_FILE" >&2
+        exit 1
+    fi
+
+    if ! grep -Fq '"fixable":true' "$FINDINGS_FILE"; then
+        echo "FAIL: lint findings sidecar should preserve fixable=true (summary=${mode})" >&2
+        [ -f "$FINDINGS_FILE" ] && sed 's/^/  /' "$FINDINGS_FILE" >&2
+        exit 1
+    fi
+}
+
+run_lint 1
+run_lint 0
+
+echo "autofixable lint exit smoke passed"

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -507,6 +507,7 @@ fi
 
 # Validation
 echo "Validating with PHPCS..."
+fixable_count=0
 
 # Build base phpcs arguments
 phpcs_base_args=(--standard="$PHPCS_CONFIG")
@@ -684,6 +685,7 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
                         "id" => $relPath . "::" . $source . "::" . $line,
                         "message" => ($msg["message"] ?? "Unknown") . " (" . $source . ")",
                         "category" => $category,
+                        "fixable" => (bool) ($msg["fixable"] ?? false),
                     ];
                 }
             }
@@ -797,7 +799,8 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
         _PHPSTAN_FINDINGS_TMPFILE=$(homeboy_mktemp 'phpstan-findings.XXXXXX')
     fi
 
-    # Run PHPStan (warn-only - does not affect exit code)
+    # Run PHPStan after PHPCS/ESLint so the caller gets the full lint signal
+    # before the aggregate exit code is computed.
     PHPSTAN_PASSED=1
     run_phpstan_summary || PHPSTAN_PASSED=0
 
@@ -809,13 +812,16 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
         rm -f "$_PHPSTAN_FINDINGS_TMPFILE"
     fi
 
-    # Always exit 0 (warn-only mode) - lint issues are warnings, not failures
     if [ "$PHPCS_PASSED" -eq 1 ] && [ "$ESLINT_PASSED" -eq 1 ] && [ "$PHPSTAN_PASSED" -eq 1 ]; then
         echo "Linting passed"
+        exit 0
     else
         echo "Linting found issues (see above)"
+        if [ "${fixable_count:-0}" -gt 0 ] 2>/dev/null; then
+            echo "Auto-fixable findings remain; run the refactor command above before pushing."
+        fi
+        exit 1
     fi
-    exit 0
 fi
 
 # Full report mode (default)
@@ -887,7 +893,8 @@ if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
     _PHPSTAN_FINDINGS_TMPFILE=$(homeboy_mktemp 'phpstan-findings.XXXXXX')
 fi
 
-# Run PHPStan (warn-only - does not affect exit code)
+# Run PHPStan after PHPCS/ESLint so the caller gets the full lint signal
+# before the aggregate exit code is computed.
 PHPSTAN_PASSED=1
 run_phpstan || PHPSTAN_PASSED=0
 
@@ -897,12 +904,15 @@ if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ] && [ -n "$_PHPSTAN_FINDINGS_TMPFILE"
     rm -f "$_PHPSTAN_FINDINGS_TMPFILE"
 fi
 
-# Always exit 0 (warn-only mode) - lint issues are warnings, not failures
 if [ "$PHPCS_PASSED" -eq 1 ] && [ "$ESLINT_PASSED" -eq 1 ] && [ "$PHPSTAN_PASSED" -eq 1 ]; then
     echo ""
     echo "Linting passed"
+    exit 0
 else
     echo ""
     echo "Linting found issues (see above)"
+    if [ "${fixable_count:-0}" -gt 0 ] 2>/dev/null; then
+        echo "Auto-fixable findings remain; run the refactor command above before pushing."
+    fi
+    exit 1
 fi
-exit 0


### PR DESCRIPTION
## Summary

- Make the WordPress lint runner return a failing exit code when its validation phases report issues instead of masking them after printing the warning summary.
- Preserve the existing auto-fixable CTA and add the PHPCS `fixable` flag to the lint findings sidecar so the core harness can consume it later.

## Changes

- Aggregates PHPCS, ESLint, and PHPStan phase results in summary and full-report modes, then exits non-zero when any phase reports issues.
- Adds an explicit reminder when auto-fixable findings remain after lint validation.
- Adds `wordpress/scripts/lint/autofixable-exit-smoke.sh`, which uses a fake PHPCS fixture to prove an auto-fixable warning fails both summary/test-style and full lint modes while preserving the refactor CTA and sidecar `fixable=true` metadata.

## Tests

- `wordpress/scripts/lint/autofixable-exit-smoke.sh`
- `wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `wordpress/scripts/test/playground-discovery-smoke.sh`
- `tests/runtime-helpers-smoke.sh`
- `git diff --check`

Not run: Playground-backed smokes that require `@wp-playground/cli`; this worktree has no `wordpress/node_modules` installed, so those scripts stop with `ERROR: @wp-playground/cli not installed.`

## Closes/Refs

- Closes #229
- Refs #228

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the WordPress lint-runner exit-code change, adding the regression smoke fixture, and running local verification. Chris remains responsible for review and merge.
