### PR TITLE
feat(wordpress): support core-dev component shape

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -1,5 +1,16 @@
 # WordPress Extension
 
+## Component Shapes
+
+The WordPress extension supports two component shapes:
+
+- `standalone` / default — WordPress plugins and themes. Tests run through WordPress Playground with the component mounted under `wp-content/plugins/<slug>` or the existing theme/plugin path assumptions.
+- `core-dev` — a `wordpress-develop` checkout. Tests, lint, and build dispatch to WordPress core's native tooling instead of mounting the checkout into Playground.
+
+Homeboy core may pass `HOMEBOY_COMPONENT_SHAPE=core-dev` for registered components. For direct script execution and smoke tests, the extension also detects `wordpress-develop` by the marker set `wp-config-sample.php`, `src/wp-includes/version.php`, and `tests/phpunit/`.
+
+The core-dev runner expects WordPress core's own dependencies and config. It installs missing npm/composer dependencies, builds `src/` into `build/`, and runs PHPUnit through core's `vendor/bin/phpunit`. If `wp-tests-config.php` is missing, set `HOMEBOY_WP_TESTS_DB_NAME`, `HOMEBOY_WP_TESTS_DB_USER`, `HOMEBOY_WP_TESTS_DB_PASSWORD`, and optionally `HOMEBOY_WP_TESTS_DB_HOST` so the runner can write it from the sample config.
+
 ## Validation dependencies
 
 Some WordPress plugins are intentionally layered on top of other local plugins.

--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -51,7 +51,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 # Extension path from Homeboy environment (required)
-EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH}"
+EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 
 # Output functions
 print_status() {
@@ -68,6 +68,30 @@ print_error() {
 
 print_warning() {
     echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+is_core_dev_project() {
+    [ "${HOMEBOY_COMPONENT_SHAPE:-}" = "core-dev" ] && return 0
+    [ -f "wp-config-sample.php" ] && [ -f "src/wp-includes/version.php" ] && [ -d "tests/phpunit" ]
+}
+
+build_core_dev_project() {
+    print_status "WordPress core-dev build"
+
+    if [ "${HOMEBOY_CORE_DEV_DRY_RUN:-}" = "1" ]; then
+        print_status "core-dev build runner selected: $(pwd)"
+        return 0
+    fi
+
+    if [ ! -d node_modules ]; then
+        command -v npm >/dev/null 2>&1 || { print_error "npm is required to build wordpress-develop"; exit 1; }
+        print_status "Installing npm dependencies..."
+        npm install
+    fi
+
+    print_status "Running WordPress core build..."
+    npm run build
+    print_success "WordPress core build completed"
 }
 
 # Check for required tools
@@ -664,6 +688,11 @@ main() {
     echo ""
 
     FRONTEND_BUILD_FAILED=0
+
+    if is_core_dev_project; then
+        build_core_dev_project
+        return 0
+    fi
 
     check_dependencies
     detect_project

--- a/wordpress/scripts/lib/detect-component.sh
+++ b/wordpress/scripts/lib/detect-component.sh
@@ -2,14 +2,14 @@
 
 # Shared component detection for WordPress extension scripts.
 #
-# Detects whether a component is a plugin or theme and extracts
+# Detects whether a component is WordPress core-dev, a plugin, or a theme and extracts
 # metadata from the header (Plugin Name, Text Domain, Version, etc.)
 #
 # Usage: source this file, then call:
 #   homeboy_detect_component <path>
 #
 # After calling, these variables are set:
-#   HOMEBOY_COMPONENT_TYPE             — "plugin" or "theme" or ""
+#   HOMEBOY_COMPONENT_TYPE             — "core-dev" or "plugin" or "theme" or ""
 #   HOMEBOY_COMPONENT_MAIN_FILE        — path to the main plugin/theme file
 #   HOMEBOY_COMPONENT_NAME             — Plugin Name / Theme Name value
 #   HOMEBOY_COMPONENT_TEXT_DOMAIN      — Text Domain value (may be empty)
@@ -27,6 +27,17 @@ homeboy_detect_component() {
     HOMEBOY_COMPONENT_VERSION=""
     HOMEBOY_COMPONENT_REQUIRES_PHP=""
     HOMEBOY_COMPONENT_REQUIRES_PLUGINS=""
+
+    # wordpress-develop is the WordPress source tree itself. It should use
+    # core's native test/lint/build tooling, not the plugin/theme Playground path.
+    if [ -f "${component_path}/wp-config-sample.php" ] \
+        && [ -f "${component_path}/src/wp-includes/version.php" ] \
+        && [ -d "${component_path}/tests/phpunit" ]; then
+        HOMEBOY_COMPONENT_TYPE="core-dev"
+        HOMEBOY_COMPONENT_MAIN_FILE="${component_path}/src/wp-includes/version.php"
+        HOMEBOY_COMPONENT_NAME="WordPress Core Development"
+        return 0
+    fi
 
     # Check for theme first (style.css with "Theme Name:")
     if [ -f "${component_path}/style.css" ]; then

--- a/wordpress/scripts/lint/lint-runner-core-dev.sh
+++ b/wordpress/scripts/lint/lint-runner-core-dev.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Native lint runner for wordpress-develop / WordPress core source checkouts.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+# shellcheck source=../lib/resolve-context.sh
+source "${RESOLVE_CONTEXT_HELPER}"
+homeboy_resolve_context
+
+CORE_PATH="$PLUGIN_PATH"
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+if [ ! -f "${CORE_PATH}/wp-config-sample.php" ] \
+    || [ ! -f "${CORE_PATH}/src/wp-includes/version.php" ] \
+    || [ ! -d "${CORE_PATH}/tests/phpunit" ]; then
+    fail "core-dev lint runner expected wordpress-develop markers"
+fi
+
+if [ "${HOMEBOY_CORE_DEV_DRY_RUN:-}" = "1" ]; then
+    echo "core-dev lint runner selected: ${CORE_PATH}"
+    exit 0
+fi
+
+cd "$CORE_PATH"
+
+PHPCS_BIN="${CORE_PATH}/vendor/bin/phpcs"
+PHPCS_CONFIG="${CORE_PATH}/.phpcs.xml.dist"
+PHPSTAN_BIN="${CORE_PATH}/vendor/bin/phpstan"
+PHPSTAN_CONFIG="${CORE_PATH}/phpstan.neon.dist"
+CHANGED_SINCE="${HOMEBOY_CHANGED_SINCE:-origin/trunk}"
+
+mapfile -t CHANGED_PHP_FILES < <(
+    git diff --name-only "$CHANGED_SINCE" -- '*.php' 2>/dev/null \
+        | grep -Ev '^(vendor|node_modules|build)/' || true
+)
+mapfile -t CHANGED_JS_FILES < <(
+    git diff --name-only "$CHANGED_SINCE" -- '*.js' '*.jsx' '*.ts' '*.tsx' 2>/dev/null \
+        | grep -Ev '^(vendor|node_modules|build)/' || true
+)
+
+if [ "${#CHANGED_PHP_FILES[@]}" -eq 0 ]; then
+    echo "No changed PHP files vs ${CHANGED_SINCE}; skipping PHPCS/PHPStan."
+else
+    if [ -x "$PHPCS_BIN" ] && [ -f "$PHPCS_CONFIG" ]; then
+        echo "Running WordPress core PHPCS on ${#CHANGED_PHP_FILES[@]} changed PHP file(s)..."
+        "$PHPCS_BIN" --standard="$PHPCS_CONFIG" "${CHANGED_PHP_FILES[@]}" || true
+    else
+        echo "Warning: WordPress core PHPCS config or binary missing; skipping PHPCS."
+    fi
+
+    if [ -x "$PHPSTAN_BIN" ] && [ -f "$PHPSTAN_CONFIG" ]; then
+        phpstan_args=(analyse --configuration="$PHPSTAN_CONFIG" --memory-limit=2G)
+        if [ "${HOMEBOY_STRICT_TYPES:-}" = "1" ]; then
+            phpstan_args+=(--level=max)
+        fi
+        phpstan_args+=("${CHANGED_PHP_FILES[@]}")
+        echo "Running WordPress core PHPStan on ${#CHANGED_PHP_FILES[@]} changed PHP file(s)..."
+        "$PHPSTAN_BIN" "${phpstan_args[@]}" || true
+    else
+        echo "Warning: WordPress core PHPStan config or binary missing; skipping PHPStan."
+    fi
+fi
+
+if [ "${#CHANGED_JS_FILES[@]}" -gt 0 ] && [ -f package.json ] && command -v npm >/dev/null 2>&1; then
+    echo "Changed JS/TS files detected; running WordPress core JS lint script."
+    npm run lint:js -- "${CHANGED_JS_FILES[@]}" || true
+fi
+
+echo "Core-dev lint run complete."

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -72,6 +72,20 @@ RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/
 source "${RESOLVE_CONTEXT_HELPER}"
 homeboy_resolve_context
 
+COMPONENT_SHAPE="${HOMEBOY_COMPONENT_SHAPE:-}"
+if [ -z "$COMPONENT_SHAPE" ]; then
+    DETECT_COMPONENT_HELPER="${HOMEBOY_RUNTIME_DETECT_COMPONENT:-${SCRIPT_DIR}/../lib/detect-component.sh}"
+    # shellcheck source=../lib/detect-component.sh
+    source "${DETECT_COMPONENT_HELPER}"
+    if homeboy_detect_component "$PLUGIN_PATH"; then
+        COMPONENT_SHAPE="$HOMEBOY_COMPONENT_TYPE"
+    fi
+fi
+
+if [ "$COMPONENT_SHAPE" = "core-dev" ]; then
+    exec bash "${SCRIPT_DIR}/lint-runner-core-dev.sh" "$@"
+fi
+
 homeboy_mktemp() {
     local template="$1"
     local tmpdir="${HOMEBOY_CACHE_DIR:-${TMPDIR:-/tmp}}"

--- a/wordpress/scripts/test/core-dev-shape-smoke.sh
+++ b/wordpress/scripts/test/core-dev-shape-smoke.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+FIXTURE="${EXTENSION_PATH}/tests/fixtures/wordpress-develop-core-dev"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq "$expected" "$file"; then
+        echo "Expected $file to contain: $expected" >&2
+        echo "Actual contents:" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+assert_equals() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "$actual" != "$expected" ]; then
+        echo "Expected $label to be '$expected', got '$actual'" >&2
+        exit 1
+    fi
+}
+
+source "${EXTENSION_PATH}/scripts/lib/detect-component.sh"
+homeboy_detect_component "$FIXTURE"
+assert_equals "$HOMEBOY_COMPONENT_TYPE" "core-dev" "component type"
+assert_equals "$HOMEBOY_COMPONENT_NAME" "WordPress Core Development" "component name"
+assert_contains <(printf '%s\n' "$HOMEBOY_COMPONENT_MAIN_FILE") "src/wp-includes/version.php"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="wordpress-develop" \
+HOMEBOY_COMPONENT_PATH="$FIXTURE" \
+HOMEBOY_COMPONENT_SHAPE="core-dev" \
+HOMEBOY_CORE_DEV_DRY_RUN=1 \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/test-explicit.out"
+assert_contains "${TMPDIR}/test-explicit.out" "core-dev test runner selected"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="wordpress-develop" \
+HOMEBOY_COMPONENT_PATH="$FIXTURE" \
+HOMEBOY_CORE_DEV_DRY_RUN=1 \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/test-detected.out"
+assert_contains "${TMPDIR}/test-detected.out" "core-dev test runner selected"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="wordpress-develop" \
+HOMEBOY_COMPONENT_PATH="$FIXTURE" \
+HOMEBOY_COMPONENT_SHAPE="core-dev" \
+HOMEBOY_CORE_DEV_DRY_RUN=1 \
+    bash "${EXTENSION_PATH}/scripts/lint/lint-runner.sh" > "${TMPDIR}/lint.out"
+assert_contains "${TMPDIR}/lint.out" "core-dev lint runner selected"
+
+(
+    cd "$FIXTURE"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_ID="wordpress-develop" \
+    HOMEBOY_COMPONENT_SHAPE="core-dev" \
+    HOMEBOY_CORE_DEV_DRY_RUN=1 \
+        bash "${EXTENSION_PATH}/scripts/build/build.sh" > "${TMPDIR}/build.out"
+)
+assert_contains "${TMPDIR}/build.out" "core-dev build runner selected"
+
+echo "core-dev shape smoke passed"

--- a/wordpress/scripts/test/test-runner-core-dev.sh
+++ b/wordpress/scripts/test/test-runner-core-dev.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Native test runner for wordpress-develop / WordPress core source checkouts.
+# This runner intentionally does not use Playground: core-dev checkouts are the
+# ecosystem itself and rely on WordPress core's own PHPUnit bootstrap.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+# shellcheck source=../lib/resolve-context.sh
+source "${RESOLVE_CONTEXT_HELPER}"
+homeboy_resolve_context
+
+CORE_PATH="$PLUGIN_PATH"
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+is_core_dev_checkout() {
+    [ -f "${CORE_PATH}/wp-config-sample.php" ] \
+        && [ -f "${CORE_PATH}/src/wp-includes/version.php" ] \
+        && [ -d "${CORE_PATH}/tests/phpunit" ]
+}
+
+ensure_core_dev_checkout() {
+    if ! is_core_dev_checkout; then
+        fail "core-dev runner expected wordpress-develop markers: wp-config-sample.php, src/wp-includes/version.php, tests/phpunit/"
+    fi
+}
+
+newer_than_build() {
+    [ -d "${CORE_PATH}/build" ] || return 0
+    find "${CORE_PATH}/src" -type f -newer "${CORE_PATH}/build" 2>/dev/null | grep -q .
+}
+
+ensure_dependencies() {
+    cd "$CORE_PATH"
+
+    if [ ! -d node_modules ]; then
+        command -v npm >/dev/null 2>&1 || fail "npm is required to install wordpress-develop dependencies"
+        echo "Installing npm dependencies for wordpress-develop..."
+        npm install
+    fi
+
+    if [ ! -d vendor ]; then
+        command -v composer >/dev/null 2>&1 || fail "composer is required to install wordpress-develop PHP dependencies"
+        echo "Installing Composer dependencies for wordpress-develop..."
+        composer install --no-interaction
+    fi
+
+    if [ ! -d build ] || newer_than_build; then
+        command -v npm >/dev/null 2>&1 || fail "npm is required to build wordpress-develop"
+        echo "Building wordpress-develop..."
+        npm run build
+    fi
+}
+
+write_wp_tests_config_from_env() {
+    local config="${CORE_PATH}/wp-tests-config.php"
+    [ -f "$config" ] && return 0
+
+    local sample="${CORE_PATH}/wp-tests-config-sample.php"
+    [ -f "$sample" ] || sample="${CORE_PATH}/wp-config-sample.php"
+    [ -f "$sample" ] || fail "wp-tests-config.php missing and no sample config found"
+
+    local db_name="${HOMEBOY_WP_TESTS_DB_NAME:-${WP_TESTS_DB_NAME:-}}"
+    local db_user="${HOMEBOY_WP_TESTS_DB_USER:-${WP_TESTS_DB_USER:-}}"
+    local db_pass="${HOMEBOY_WP_TESTS_DB_PASSWORD:-${WP_TESTS_DB_PASSWORD:-}}"
+    local db_host="${HOMEBOY_WP_TESTS_DB_HOST:-${WP_TESTS_DB_HOST:-localhost}}"
+
+    if [ -z "$db_name" ] || [ -z "$db_user" ]; then
+        cat >&2 <<'EOF'
+Error: wp-tests-config.php is missing.
+
+Create it in the wordpress-develop checkout, or set:
+  HOMEBOY_WP_TESTS_DB_NAME
+  HOMEBOY_WP_TESTS_DB_USER
+  HOMEBOY_WP_TESTS_DB_PASSWORD
+  HOMEBOY_WP_TESTS_DB_HOST (optional, defaults to localhost)
+EOF
+        exit 1
+    fi
+
+    php -r '
+        $sample = file_get_contents($argv[1]);
+        $replacements = [
+            "youremptytestdbnamehere" => $argv[3],
+            "yourusernamehere" => $argv[4],
+            "yourpasswordhere" => $argv[5],
+            "localhost" => $argv[6],
+        ];
+        file_put_contents($argv[2], strtr($sample, $replacements));
+    ' "$sample" "$config" "$db_name" "$db_user" "$db_pass" "$db_host"
+}
+
+ensure_core_dev_checkout
+
+if [ "${HOMEBOY_CORE_DEV_DRY_RUN:-}" = "1" ]; then
+    echo "core-dev test runner selected: ${CORE_PATH}"
+    exit 0
+fi
+
+ensure_dependencies
+write_wp_tests_config_from_env
+
+cd "$CORE_PATH"
+
+PHPUNIT_BIN="${CORE_PATH}/vendor/bin/phpunit"
+[ -x "$PHPUNIT_BIN" ] || fail "PHPUnit not found at ${PHPUNIT_BIN}; run composer install"
+
+PHPUNIT_CONFIG="tests/phpunit/phpunit.xml.dist"
+if [ ! -f "$PHPUNIT_CONFIG" ]; then
+    PHPUNIT_CONFIG="phpunit.xml.dist"
+fi
+[ -f "$PHPUNIT_CONFIG" ] || fail "No WordPress core PHPUnit config found"
+
+PHPUNIT_ARGS=(-c "$PHPUNIT_CONFIG")
+if [ "${HOMEBOY_WORDPRESS_MULTISITE:-}" = "1" ] && [ -f "tests/phpunit/multisite.xml" ]; then
+    PHPUNIT_ARGS=(-c "tests/phpunit/multisite.xml")
+fi
+if [ -n "${HOMEBOY_TEST_FILTER:-}" ]; then
+    PHPUNIT_ARGS+=(--filter "${HOMEBOY_TEST_FILTER}")
+fi
+if [ -n "${HOMEBOY_TEST_GROUP:-}" ]; then
+    PHPUNIT_ARGS+=(--group "${HOMEBOY_TEST_GROUP}")
+fi
+PHPUNIT_ARGS+=("$@")
+
+echo "Running WordPress core PHPUnit tests..."
+set +e
+PHPUNIT_OUTPUT=$("$PHPUNIT_BIN" "${PHPUNIT_ARGS[@]}" 2>&1)
+PHPUNIT_EXIT=$?
+set -e
+
+printf '%s\n' "$PHPUNIT_OUTPUT"
+
+PARSE_RESULTS="${EXTENSION_PATH}/scripts/test/parse-test-results.sh"
+PARSE_FAILURES="${EXTENSION_PATH}/scripts/test/parse-test-failures.sh"
+if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$PARSE_RESULTS" ]; then
+    printf '%s\n' "$PHPUNIT_OUTPUT" | bash "$PARSE_RESULTS" || true
+fi
+if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] && [ -f "$PARSE_FAILURES" ]; then
+    printf '%s\n' "$PHPUNIT_OUTPUT" | bash "$PARSE_FAILURES" "$CORE_PATH" || true
+fi
+
+exit "$PHPUNIT_EXIT"

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -3,11 +3,8 @@ set -euo pipefail
 
 # Test runner router for WordPress Homeboy extension.
 #
-# All test execution runs inside WordPress Playground (PHP-WASM + embedded SQLite).
-# The legacy host-PHP backend (wp-phpunit, FakeMySQL, SQLite_DB, MySQL/SQLite
-# auto-detection) was retired in Phase 3 of the Playground migration (#214).
-#
-# This script resolves execution context and dispatches to the Playground runner.
+# Plugin/theme tests run inside WordPress Playground. Core-dev checkouts
+# (wordpress-develop) dispatch to WordPress core's native PHPUnit runner.
 
 # Bash 4.0+ required — lint-runner.sh (called during test runs) uses
 # associative arrays which are bash 4+ only. Fail early with a clear
@@ -54,5 +51,21 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Component path: ${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
 fi
 
-# Dispatch to Playground runner — single code path.
-exec bash "${SCRIPT_DIR}/test-runner-playground.sh" "$@"
+COMPONENT_SHAPE="${HOMEBOY_COMPONENT_SHAPE:-}"
+if [ -z "$COMPONENT_SHAPE" ]; then
+    DETECT_COMPONENT_HELPER="${HOMEBOY_RUNTIME_DETECT_COMPONENT:-${SCRIPT_DIR}/../lib/detect-component.sh}"
+    # shellcheck source=../lib/detect-component.sh
+    source "${DETECT_COMPONENT_HELPER}"
+    if homeboy_detect_component "${HOMEBOY_COMPONENT_PATH:-$(pwd)}"; then
+        COMPONENT_SHAPE="$HOMEBOY_COMPONENT_TYPE"
+    fi
+fi
+
+case "$COMPONENT_SHAPE" in
+    core-dev)
+        exec bash "${SCRIPT_DIR}/test-runner-core-dev.sh" "$@"
+        ;;
+    *)
+        exec bash "${SCRIPT_DIR}/test-runner-playground.sh" "$@"
+        ;;
+esac

--- a/wordpress/tests/fixtures/wordpress-develop-core-dev/.phpcs.xml.dist
+++ b/wordpress/tests/fixtures/wordpress-develop-core-dev/.phpcs.xml.dist
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Core Fixture" />

--- a/wordpress/tests/fixtures/wordpress-develop-core-dev/package.json
+++ b/wordpress/tests/fixtures/wordpress-develop-core-dev/package.json
@@ -1,0 +1,1 @@
+{"name":"wordpress-develop-core-dev-fixture","private":true,"scripts":{"build":"echo build"}}

--- a/wordpress/tests/fixtures/wordpress-develop-core-dev/phpstan.neon.dist
+++ b/wordpress/tests/fixtures/wordpress-develop-core-dev/phpstan.neon.dist
@@ -1,0 +1,2 @@
+parameters:
+    level: 7

--- a/wordpress/tests/fixtures/wordpress-develop-core-dev/src/wp-includes/version.php
+++ b/wordpress/tests/fixtures/wordpress-develop-core-dev/src/wp-includes/version.php
@@ -1,0 +1,2 @@
+<?php
+$wp_version = '6.9-alpha';

--- a/wordpress/tests/fixtures/wordpress-develop-core-dev/tests/phpunit/includes/bootstrap.php
+++ b/wordpress/tests/fixtures/wordpress-develop-core-dev/tests/phpunit/includes/bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Fixture marker for wordpress-develop core-dev detection.

--- a/wordpress/tests/fixtures/wordpress-develop-core-dev/tests/phpunit/phpunit.xml.dist
+++ b/wordpress/tests/fixtures/wordpress-develop-core-dev/tests/phpunit/phpunit.xml.dist
@@ -1,0 +1,7 @@
+<phpunit bootstrap="includes/bootstrap.php">
+    <testsuites>
+        <testsuite name="fixture">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/wordpress/tests/fixtures/wordpress-develop-core-dev/wp-config-sample.php
+++ b/wordpress/tests/fixtures/wordpress-develop-core-dev/wp-config-sample.php
@@ -1,0 +1,5 @@
+<?php
+define( 'DB_NAME', 'youremptytestdbnamehere' );
+define( 'DB_USER', 'yourusernamehere' );
+define( 'DB_PASSWORD', 'yourpasswordhere' );
+define( 'DB_HOST', 'localhost' );


### PR DESCRIPTION
## Summary
- Adds WordPress `core-dev` component-shape support for `wordpress-develop` checkouts.
- Keeps WordPress-specific shape handling inside the WordPress extension, consuming `HOMEBOY_COMPONENT_SHAPE=core-dev` without adding core Homeboy knowledge here.

## Changes
- Detects `wordpress-develop` marker sets (`wp-config-sample.php`, `src/wp-includes/version.php`, `tests/phpunit/`) as `core-dev`.
- Routes test, lint, and build entrypoints to native core-dev runners instead of plugin/theme Playground packaging.
- Adds a fixture-backed smoke test covering explicit env-shape routing and local marker autodetection.
- Documents the WordPress extension's supported component shapes.

## Tests
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/test-runner-core-dev.sh wordpress/scripts/lint/lint-runner.sh wordpress/scripts/lint/lint-runner-core-dev.sh wordpress/scripts/build/build.sh wordpress/scripts/test/core-dev-shape-smoke.sh`
- `bash wordpress/scripts/test/core-dev-shape-smoke.sh`
- `bash tests/runtime-helpers-smoke.sh`
- `git diff --check`

`homeboy lint/test` were also attempted for the root and `wordpress` component paths, but this checkout is not registered with extension config locally, so Homeboy rejected those invocations before runner execution.

Closes #231

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the extension-side implementation, fixture smoke coverage, docs, and PR description for Chris to review.
