### PR TITLE
feat(wordpress): detect mock-over-fixture test smells

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -197,6 +197,25 @@ for teams that want full enforcement.
 [wp-perf-1803]: https://github.com/WordPress/performance/pull/1803
 [strict-rules]: https://github.com/phpstan/phpstan-strict-rules
 
+### Test-smell preflight
+
+Before Playground boots PHPUnit, the runner scans `tests/**/*.php` for the
+high-confidence `wp.test.mock_over_fixture` smell: a test method that creates
+`$query = new WP_Query()` and then manually assigns result-state fields such
+as `->posts`, `->post_count`, or `->found_posts`.
+
+That pattern mocks WordPress query internals even though the WordPress test
+fixture layer can build the state directly. Prefer real fixtures:
+
+```php
+$post_id = self::factory()->post->create( array( 'post_date' => $date ) );
+query_posts( array( 'posts__in' => array( $post_id ), 'fields' => 'ids' ) );
+```
+
+Use `WP_Query` with real query args when a local query object is required.
+If a test intentionally exercises impossible query state, suppress the single
+case with `// homeboy-ignore wp.test.mock_over_fixture` near the setup.
+
 ## Debug output
 
 The Playground runner writes a structured log to

--- a/wordpress/scripts/audit/wp-test-smells.py
+++ b/wordpress/scripts/audit/wp-test-smells.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""WordPress test-smell detector for Homeboy's WordPress extension.
+
+The detector is intentionally narrow: it flags test methods that instantiate
+WP_Query and then manually assign result fields that WordPress test fixtures can
+populate through query_posts() or a real WP_Query call.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SMELL_CODE = "wp.test.mock_over_fixture"
+QUERY_FIELDS = ("posts", "post_count", "found_posts")
+IGNORE_RE = re.compile(r"homeboy-ignore\s+wp\.test\.mock_over_fixture")
+TEST_METHOD_RE = re.compile(
+    r"(?P<sig>(?:public|protected|private)?\s*(?:static\s+)?function\s+(?P<name>test\w*)\s*\([^)]*\)\s*)\{",
+    re.MULTILINE,
+)
+NEW_QUERY_RE = re.compile(r"\$(?P<var>\w+)\s*=\s*new\s+\\?WP_Query\s*\(")
+
+
+@dataclass(frozen=True)
+class Finding:
+    file: str
+    line: int
+    method: str
+    variable: str
+    fields: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "code": SMELL_CODE,
+            "file": self.file,
+            "line": self.line,
+            "method": self.method,
+            "variable": self.variable,
+            "fields": list(self.fields),
+            "message": message_for(self),
+        }
+
+
+def line_number(content: str, offset: int) -> int:
+    return content.count("\n", 0, offset) + 1
+
+
+def extract_braced_body(content: str, open_brace: int) -> tuple[str, int] | None:
+    depth = 0
+    in_single = False
+    in_double = False
+    escape = False
+
+    for pos in range(open_brace, len(content)):
+        ch = content[pos]
+        if escape:
+            escape = False
+            continue
+        if ch == "\\" and (in_single or in_double):
+            escape = True
+            continue
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            continue
+        if ch == '"' and not in_single:
+            in_double = not in_double
+            continue
+        if in_single or in_double:
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return content[open_brace + 1 : pos], pos
+    return None
+
+
+def has_ignore(body: str, query_start: int) -> bool:
+    prefix = body[max(0, query_start - 500) : query_start]
+    return bool(IGNORE_RE.search(prefix) or IGNORE_RE.search(body))
+
+
+def assigned_query_fields(body: str, var_name: str) -> tuple[str, ...]:
+    fields: list[str] = []
+    for field in QUERY_FIELDS:
+        if re.search(r"\$" + re.escape(var_name) + r"\s*->\s*" + field + r"\s*=", body):
+            fields.append(field)
+    return tuple(fields)
+
+
+def scan_file(path: Path, root: Path) -> list[Finding]:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        content = path.read_text(encoding="utf-8", errors="ignore")
+
+    if "WP_Query" not in content:
+        return []
+    if "homeboy-ignore-file wp.test.mock_over_fixture" in content:
+        return []
+
+    findings: list[Finding] = []
+    rel = path.relative_to(root).as_posix()
+
+    for method_match in TEST_METHOD_RE.finditer(content):
+        open_brace = content.find("{", method_match.start("sig"))
+        if open_brace < 0:
+            continue
+        extracted = extract_braced_body(content, open_brace)
+        if not extracted:
+            continue
+        body, _ = extracted
+        for query_match in NEW_QUERY_RE.finditer(body):
+            if has_ignore(body, query_match.start()):
+                continue
+            var_name = query_match.group("var")
+            fields = assigned_query_fields(body, var_name)
+            if not fields:
+                continue
+            findings.append(
+                Finding(
+                    file=rel,
+                    line=line_number(content, open_brace + 1 + query_match.start()),
+                    method=method_match.group("name"),
+                    variable=var_name,
+                    fields=fields,
+                )
+            )
+
+    return findings
+
+
+def iter_test_files(root: Path) -> list[Path]:
+    tests_dir = root / "tests"
+    if not tests_dir.is_dir():
+        return []
+    return sorted(p for p in tests_dir.rglob("*.php") if p.is_file())
+
+
+def message_for(finding: Finding) -> str:
+    fields = ", ".join(f"->{field}" for field in finding.fields)
+    return (
+        f"{SMELL_CODE}: {finding.method}() builds ${finding.variable} = new WP_Query() "
+        f"and manually assigns {fields}. Prefer real fixtures: create posts with "
+        "self::factory()->post->create(), then call query_posts([...]) or instantiate "
+        "WP_Query with query args so WordPress populates posts/post_count/found_posts."
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Detect WordPress test mock-over-fixture smells.")
+    parser.add_argument("component_path", nargs="?", default=".")
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    args = parser.parse_args()
+
+    root = Path(args.component_path).resolve()
+    findings: list[Finding] = []
+    for path in iter_test_files(root):
+        findings.extend(scan_file(path, root))
+
+    if args.json_output:
+        print(json.dumps({"findings": [f.as_dict() for f in findings]}, indent=2))
+    elif findings:
+        print("")
+        print("============================================")
+        print("ERROR: WordPress test smell detected")
+        print("============================================")
+        for finding in findings:
+            print(f"{finding.file}:{finding.line}: {message_for(finding)}")
+        print("")
+        print("Fix: use WordPress test factories and query APIs instead of manual WP_Query state.")
+        print("Suppress only intentional cases with: // homeboy-ignore wp.test.mock_over_fixture")
+        print("")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -108,6 +108,11 @@ if type homeboy_php_preflight &>/dev/null; then
     homeboy_php_preflight "$PLUGIN_PATH"
 fi
 
+WP_TEST_SMELLS="${EXTENSION_PATH}/scripts/audit/wp-test-smells.py"
+if [ -f "$WP_TEST_SMELLS" ]; then
+    python3 "$WP_TEST_SMELLS" "$PLUGIN_PATH"
+fi
+
 if [ -n "${COMPONENT_ID:-}" ]; then
     export HOMEBOY_COMPONENT_ID="$COMPONENT_ID"
     export HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH"

--- a/wordpress/tests/wp-test-smells-smoke.sh
+++ b/wordpress/tests/wp-test-smells-smoke.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DETECTOR="${EXTENSION_DIR}/scripts/audit/wp-test-smells.py"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "${TMPDIR}/tests/phpunit/tests/date" "${TMPDIR}/tests/phpunit/tests/query"
+
+cat > "${TMPDIR}/tests/phpunit/tests/date/getFeedBuildDate.php" <<'PHP'
+<?php
+class Tests_Date_Get_Feed_Build_Date extends WP_UnitTestCase {
+    public function test_feed_build_date_uses_latest_post() {
+        $id = self::factory()->post->create( array( 'post_date' => '2026-04-26 10:00:00' ) );
+        $wp_query = new WP_Query();
+        $wp_query->posts = array( $id );
+        $wp_query->post_count = 1;
+    }
+}
+PHP
+
+cat > "${TMPDIR}/tests/phpunit/tests/query/realFixture.php" <<'PHP'
+<?php
+class Tests_Query_Real_Fixture extends WP_UnitTestCase {
+    public function test_query_posts_fixture() {
+        $id = self::factory()->post->create();
+        query_posts( array( 'posts__in' => array( $id ), 'fields' => 'ids' ) );
+        $this->assertSame( array( $id ), $GLOBALS['wp_query']->posts );
+    }
+
+    public function test_real_query_args_are_ok() {
+        $query = new WP_Query( array( 'post_type' => 'post' ) );
+        $this->assertIsArray( $query->posts );
+    }
+}
+PHP
+
+set +e
+json_output="$(python3 "$DETECTOR" --json "$TMPDIR")"
+status=$?
+set -e
+
+if [ "$status" -ne 1 ]; then
+    echo "Expected detector to exit 1 for mock-over-fixture fixture, got $status" >&2
+    exit 1
+fi
+
+printf '%s' "$json_output" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+findings = data["findings"]
+assert len(findings) == 1, findings
+finding = findings[0]
+assert finding["code"] == "wp.test.mock_over_fixture", finding
+assert finding["file"] == "tests/phpunit/tests/date/getFeedBuildDate.php", finding
+assert finding["method"] == "test_feed_build_date_uses_latest_post", finding
+assert finding["variable"] == "wp_query", finding
+assert finding["fields"] == ["posts", "post_count"], finding
+assert "self::factory()->post->create" in finding["message"], finding
+assert "query_posts" in finding["message"], finding
+'
+
+rm "${TMPDIR}/tests/phpunit/tests/date/getFeedBuildDate.php"
+
+python3 "$DETECTOR" --json "$TMPDIR" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+assert data["findings"] == [], data
+'
+
+cat > "${TMPDIR}/tests/phpunit/tests/query/suppressed.php" <<'PHP'
+<?php
+class Tests_Query_Suppressed extends WP_UnitTestCase {
+    public function test_intentional_impossible_query_state() {
+        // homeboy-ignore wp.test.mock_over_fixture
+        $query = new WP_Query();
+        $query->posts = array( 123 );
+        $query->found_posts = 1;
+    }
+}
+PHP
+
+python3 "$DETECTOR" --json "$TMPDIR" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+assert data["findings"] == [], data
+'
+
+echo "wp-test-smells smoke passed"


### PR DESCRIPTION
## Summary
- Adds a WordPress test-smell preflight for the high-confidence `wp.test.mock_over_fixture` case from #227.
- Fails `homeboy test` before Playground boots PHPUnit when a test manually builds `WP_Query` result state instead of using WordPress fixtures/query APIs.

## Changes
- Adds `wordpress/scripts/audit/wp-test-smells.py`, scoped to `tests/**/*.php` and test methods only.
- Flags `new WP_Query()` followed by manual `->posts`, `->post_count`, or `->found_posts` assignment on the same query variable.
- Documents the real-fixture alternative and the narrow suppression comment for intentional impossible-state tests.
- Wires the preflight into the WordPress Playground test runner.

## Tests
- `wordpress/tests/wp-test-smells-smoke.sh`
- `python3 -m py_compile wordpress/scripts/audit/wp-test-smells.py`
- `bash -n wordpress/scripts/test/test-runner-playground.sh`
- `bash -n wordpress/tests/wp-test-smells-smoke.sh`
- Manual negative probe against an existing normal WordPress test fixture

Closes #227

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the detector, smoke fixture, runner wiring, and documentation; Chris remains responsible for review and merge decisions.
