### PR TITLE
feat(wordpress): support persisted bench site scenarios

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -200,11 +200,56 @@ if [ "$BENCH_WORKLOADS_JSON" = "null" ] && [ -n "${HOMEBOY_BENCH_WORKLOADS:-}" ]
     BENCH_WORKLOADS_JSON=$(jq -Rn --arg value "$HOMEBOY_BENCH_WORKLOADS" '$value')
 fi
 
+# Extract `bench_site_mode` from the merged settings JSON. Default `fresh`
+# preserves the historical wp-phpunit install path. `installed` mounts a
+# persisted /wordpress tree from HOMEBOY_BENCH_SHARED_STATE, lets Playground
+# prepare that tree on the first run, and has the PHP runner boot wp-load.php
+# instead of re-running wp-phpunit install.php on warm runs.
+BENCH_SITE_MODE="${HOMEBOY_BENCH_SITE_MODE:-fresh}"
+if [ -z "${HOMEBOY_BENCH_SITE_MODE:-}" ] && [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.bench_site_mode // "fresh"' 2>/dev/null || echo "fresh")
+    if [ -n "$extracted" ] && [ "$extracted" != "null" ]; then
+        BENCH_SITE_MODE="$extracted"
+    fi
+fi
+case "$BENCH_SITE_MODE" in
+    fresh|installed)
+        ;;
+    *)
+        echo "Error: bench_site_mode must be 'fresh' or 'installed' (got '$BENCH_SITE_MODE')" >&2
+        FAILED_STEP="Bench site mode setup"
+        exit 1
+        ;;
+esac
+
+# Optional Playground blueprint JSON. Non-empty objects are written to a host
+# tempfile and passed to wp-playground-cli --blueprint so cold-boot scenarios
+# can measure plugin/theme installation as part of Playground bootstrap.
+PLAYGROUND_BLUEPRINT_JSON="{}"
+if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.playground_blueprint // {}' 2>/dev/null || echo "{}")
+    if [ -n "$extracted" ] && [ "$extracted" != "null" ]; then
+        PLAYGROUND_BLUEPRINT_JSON="$extracted"
+    fi
+fi
+
+# Optional direct pass-through for Playground's own install-mode flag. Most
+# components should use bench_site_mode; this is a narrow escape hatch for
+# runner-level experiments without teaching homeboy core about Playground.
+PLAYGROUND_WORDPRESS_INSTALL_MODE=""
+if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.playground_wordpress_install_mode // empty' 2>/dev/null || true)
+    if [ -n "$extracted" ] && [ "$extracted" != "null" ]; then
+        PLAYGROUND_WORDPRESS_INSTALL_MODE="$extracted"
+    fi
+fi
+
 ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-10}"
 
 # ---------------------------------------------------------------------------
 # Build VFS mount args (mirrors test-runner-playground.sh shape)
 # ---------------------------------------------------------------------------
+MOUNT_BEFORE_INSTALL_ARGS=()
 MOUNT_ARGS=()
 MOUNT_ARGS+=("--mount" "${PLUGIN_PATH}:/wordpress/wp-content/plugins/${PLUGIN_SLUG}")
 
@@ -265,6 +310,36 @@ if [ -n "$SHARED_STATE_HOST" ]; then
     if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
         echo "DEBUG: [bench:playground] Shared state: ${SHARED_STATE_HOST} → ${SHARED_STATE_GUEST}"
     fi
+fi
+
+if [ "$BENCH_SITE_MODE" = "installed" ]; then
+    if [ -z "$SHARED_STATE_HOST" ]; then
+        echo "Error: bench_site_mode=installed requires HOMEBOY_BENCH_SHARED_STATE so /wordpress can persist across runs." >&2
+        FAILED_STEP="Installed-site bench setup"
+        exit 1
+    fi
+    SITE_STATE_HOST="${SHARED_STATE_HOST}/wordpress"
+    mkdir -p "$SITE_STATE_HOST"
+    MOUNT_BEFORE_INSTALL_ARGS+=("--mount-before-install" "${SITE_STATE_HOST}:/wordpress")
+    if [ -z "$PLAYGROUND_WORDPRESS_INSTALL_MODE" ]; then
+        if [ -f "${SITE_STATE_HOST}/wp-load.php" ]; then
+            PLAYGROUND_WORDPRESS_INSTALL_MODE="install-from-existing-files-if-needed"
+        else
+            PLAYGROUND_WORDPRESS_INSTALL_MODE="download-and-install"
+        fi
+    fi
+else
+    if [ -z "$PLAYGROUND_WORDPRESS_INSTALL_MODE" ]; then
+        PLAYGROUND_WORDPRESS_INSTALL_MODE="download-and-install"
+    fi
+fi
+
+BLUEPRINT_TMPFILE=""
+BLUEPRINT_ARGS=()
+if printf '%s' "$PLAYGROUND_BLUEPRINT_JSON" | jq -e 'type == "object" and length > 0' >/dev/null 2>&1; then
+    BLUEPRINT_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/pg-blueprint.XXXXXX.json")
+    printf '%s' "$PLAYGROUND_BLUEPRINT_JSON" > "$BLUEPRINT_TMPFILE"
+    BLUEPRINT_ARGS+=("--blueprint" "$BLUEPRINT_TMPFILE")
 fi
 
 INSTANCE_ID="${HOMEBOY_BENCH_INSTANCE_ID:-0}"
@@ -332,6 +407,7 @@ sed \
     -e "s|{{CONCURRENCY}}|${CONCURRENCY}|g" \
     -e "s|{{LIST_ONLY}}|${LIST_ONLY_PHP}|g" \
     -e "s|{{RESULT_SUFFIX}}|${RESULT_SUFFIX}|g" \
+    -e "s|{{BENCH_SITE_MODE}}|${BENCH_SITE_MODE}|g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_WORKLOADS_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_WORKLOADS_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
@@ -342,24 +418,33 @@ echo "Running performance benchmarks via WordPress Playground..."
 echo "  Plugin: ${PLUGIN_SLUG} (${PLUGIN_PATH})"
 echo "  Iterations: ${ITERATIONS}"
 echo "  Backend: playground (PHP-WASM + SQLite)"
+echo "  Site mode: ${BENCH_SITE_MODE}"
 if [ "$LIST_ONLY" = "1" ]; then
     echo "  Mode: list only"
 fi
 if [ -n "$SHARED_STATE_GUEST" ]; then
     echo "  Shared state: ${SHARED_STATE_HOST} (instance ${INSTANCE_ID}/${CONCURRENCY})"
 fi
+if [ -n "$BLUEPRINT_TMPFILE" ]; then
+    echo "  Playground blueprint: enabled"
+fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "  Wrapper: $WRAPPER_TMPFILE"
+    echo "  Mount-before-install args: ${MOUNT_BEFORE_INSTALL_ARGS[*]}"
     echo "  Mount args: ${MOUNT_ARGS[*]}"
+    echo "  WordPress install mode: ${PLAYGROUND_WORDPRESS_INSTALL_MODE}"
 fi
 
 BENCH_TMPFILE=$(mktemp)
 
 set +e
 "$PLAYGROUND_CLI" php \
+    "${MOUNT_BEFORE_INSTALL_ARGS[@]}" \
     "${MOUNT_ARGS[@]}" \
     "--mount" "${WRAPPER_TMPFILE}:/runner.php" \
+    "${BLUEPRINT_ARGS[@]}" \
+    "--wordpress-install-mode=${PLAYGROUND_WORDPRESS_INSTALL_MODE}" \
     --wp=6.9 \
     --verbosity=normal \
     -- /runner.php \
@@ -367,7 +452,7 @@ set +e
 playground_exit=${PIPESTATUS[0]}
 set -e
 
-rm -f "$WRAPPER_TMPFILE"
+rm -f "$WRAPPER_TMPFILE" "$BLUEPRINT_TMPFILE"
 
 BENCH_LOG=""
 if [ -f "$RESULT_LOG" ]; then

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -9,7 +9,7 @@
  *
  * BOOT PATH
  *
- * Reuses the four shared bootstrap stages from
+ * Reuses the shared bootstrap stages from
  * /homeboy-extension/scripts/lib/playground-bootstrap.php so bench measures
  * the *same* WordPress that tests run against. A regression in `boot` or
  * `install` is therefore visible to both runners simultaneously — the only
@@ -100,7 +100,13 @@ $wp_config_defines = json_decode($wp_config_defines_raw, true);
 if (!is_array($wp_config_defines)) {
     $wp_config_defines = [];
 }
-$config_path = pg_run_boot_stage(['extra_defines' => $wp_config_defines]);
+$bench_site_mode = '{{BENCH_SITE_MODE}}';
+$installed_site_mode = $bench_site_mode === 'installed';
+
+$config_path = pg_run_boot_stage([
+    'extra_defines' => $wp_config_defines,
+    'skip_test_config' => $installed_site_mode,
+]);
 
 // Component-declared bench env vars. Host shell env doesn't propagate
 // across the wp-playground-cli sandbox boundary, so workloads' getenv()
@@ -129,7 +135,11 @@ if (is_array($bench_env)) {
     }
 }
 
-pg_run_install_stage(['config_path' => $config_path]);
+if ($installed_site_mode) {
+    pg_run_load_wordpress_stage();
+} else {
+    pg_run_install_stage(['config_path' => $config_path]);
+}
 pg_run_load_deps_stage(['dep_mounts' => '{{PLAYGROUND_DEP_MOUNTS}}']);
 pg_run_load_component_stage(['plugin_path' => $plugin_path]);
 
@@ -487,7 +497,7 @@ try {
     // id makes the synthetic nature obvious in reports.
     $bootstrap_durations = pg_stage_durations_ms();
     $bootstrap_metrics = [];
-    foreach (['boot', 'install', 'load_deps', 'load_component'] as $stage) {
+    foreach (['boot', 'install', 'load_wordpress', 'load_deps', 'load_component'] as $stage) {
         if (isset($bootstrap_durations[$stage])) {
             $bootstrap_metrics["{$stage}_ms"] = $bootstrap_durations[$stage];
         }

--- a/wordpress/scripts/bench/playground-bench-site-mode-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-site-mode-smoke.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Installed-site + Playground blueprint bench smoke test.
+#
+# Runs the bench-site-mode fixture twice against the same shared-state
+# directory. The first run prepares a persisted /wordpress tree and applies a
+# blueprint. The second run reuses that installed site and asserts the bench
+# runner skips wp-phpunit install.php in favour of wp-load.php.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-site-mode"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-site-mode-smoke.XXXXXX")
+SHARED_STATE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bench-site-mode-smoke.XXXXXX")
+
+cleanup() {
+    rm -f "$RESULTS_TMPFILE"
+    rm -rf "$SHARED_STATE_DIR"
+}
+trap cleanup EXIT
+
+SETTINGS_JSON=$(cat <<'JSON'
+{
+  "bench_site_mode": "installed",
+  "playground_blueprint": {
+    "steps": [
+      {
+        "step": "setSiteOptions",
+        "options": {
+          "blogname": "Blueprint Bench Smoke"
+        }
+      }
+    ]
+  }
+}
+JSON
+)
+
+run_fixture() {
+    HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+    HOMEBOY_BENCH_ITERATIONS=1 \
+    HOMEBOY_BENCH_SHARED_STATE="$SHARED_STATE_DIR" \
+    HOMEBOY_BENCH_INSTANCE_ID=0 \
+    HOMEBOY_BENCH_CONCURRENCY=1 \
+    HOMEBOY_COMPONENT_ID=bench-site-mode \
+    HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+        bash "${SCRIPT_DIR}/bench-runner.sh"
+}
+
+echo "============================================"
+echo "Playground bench installed-site smoke test"
+echo "============================================"
+echo "Fixture:       $FIXTURE_DIR"
+echo "Shared state:  $SHARED_STATE_DIR"
+echo ""
+
+run_fixture
+run_fixture
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+echo ""
+echo "--- Results envelope ---"
+cat "$RESULTS_TMPFILE"
+echo ""
+
+bootstrap_keys=$(jq -r '.scenarios[0].metrics | keys | join(",")' "$RESULTS_TMPFILE")
+if [[ "$bootstrap_keys" != *"load_wordpress_ms"* ]]; then
+    echo "ERROR: expected load_wordpress_ms in bootstrap metrics, got: $bootstrap_keys" >&2
+    exit 1
+fi
+if [[ "$bootstrap_keys" == *"install_ms"* ]]; then
+    echo "ERROR: installed-site mode should not emit install_ms, got: $bootstrap_keys" >&2
+    exit 1
+fi
+
+READ_BACK_LOG="${SHARED_STATE_DIR}/site-mode-read-back.log"
+if [ ! -f "$READ_BACK_LOG" ]; then
+    echo "ERROR: workload did not write site-mode-read-back.log" >&2
+    exit 1
+fi
+
+echo ""
+echo "--- Read-back log ---"
+cat "$READ_BACK_LOG"
+echo ""
+
+if ! grep -q 'site_title=Blueprint Bench Smoke' "$READ_BACK_LOG"; then
+    echo "ERROR: blueprint site option did not reach workload" >&2
+    exit 1
+fi
+
+if [ ! -f "${SHARED_STATE_DIR}/wordpress/wp-load.php" ]; then
+    echo "ERROR: installed-site mode did not persist /wordpress into shared state" >&2
+    exit 1
+fi
+
+echo "============================================"
+echo "✓ installed-site + blueprint smoke test PASSED"
+echo "============================================"

--- a/wordpress/scripts/lib/playground-bootstrap.php
+++ b/wordpress/scripts/lib/playground-bootstrap.php
@@ -12,6 +12,7 @@
  * Stages provided:
  *   - boot           — render wp-tests-config.php, load composer autoloader
  *   - install        — wp-phpunit install.php (creates WP + tables in-process)
+ *   - load_wordpress — wp-load.php for already-installed persisted sites
  *   - load_deps      — load Plugin-Name-headed entry files for declared deps
  *   - load_component — load the plugin/theme under test
  *
@@ -214,11 +215,37 @@ function pg_install_diagnostics_handlers() {
  * /tmp/wp-tests-config.php (the canonical location wp-phpunit's install.php
  * expects). The path is also returned so callers don't have to hard-code it.
  *
- * @return string Path to the generated wp-tests-config.php.
+ *   - skip_test_config: when true, do not write the wp-phpunit config or
+ *     define the canonical test DB constants. Extra defines are applied to
+ *     the current process directly so installed-site runs can boot the
+ *     persisted site's own wp-config.php without test-config pollution.
+ *
+ * @return string|null Path to the generated wp-tests-config.php, or null when skipped.
  */
-function pg_run_boot_stage(array $cfg = []): string {
+function pg_run_boot_stage(array $cfg = []): ?string {
     pg_stage_begin('boot');
     try {
+        $extra_defines = $cfg['extra_defines'] ?? [];
+        $skip_test_config = !empty($cfg['skip_test_config']);
+
+        if ($skip_test_config) {
+            if (!empty($extra_defines) && is_array($extra_defines)) {
+                foreach ($extra_defines as $name => $value) {
+                    if (!is_string($name) || !preg_match('/^[A-Z_][A-Z0-9_]*$/i', $name)) {
+                        pg_log("NOTICE: skipping invalid wp_config_defines key: " . var_export($name, true));
+                        continue;
+                    }
+                    if (!defined($name)) {
+                        define($name, $value);
+                    }
+                }
+            }
+
+            require_once '/homeboy-extension/vendor/autoload.php';
+            pg_stage_ok('boot');
+            return null;
+        }
+
         $config_path = '/tmp/wp-tests-config.php';
         $config = <<<'CONFIG'
 <?php
@@ -238,7 +265,6 @@ define('FS_CHMOD_DIR', 0755);
 define('FS_METHOD', 'direct');
 CONFIG;
 
-        $extra_defines = $cfg['extra_defines'] ?? [];
         if (!empty($extra_defines) && is_array($extra_defines)) {
             $config .= "\n\n// Component-declared wp_config_defines.\n";
             foreach ($extra_defines as $name => $value) {
@@ -297,6 +323,32 @@ function pg_run_install_stage(array $cfg) {
         pg_stage_ok('install');
     } catch (Throwable $e) {
         pg_stage_fail('install', $e);
+        exit(1);
+    }
+}
+
+/**
+ * Run the `load_wordpress` stage: boot an already-installed WordPress site.
+ *
+ * Installed-site bench mode lets Playground prepare `/wordpress` before the
+ * runner starts (usually from a shared-state mount), then this stage loads the
+ * persisted site's own wp-config.php/wp-settings.php instead of running the
+ * wp-phpunit installer again.
+ */
+function pg_run_load_wordpress_stage(array $cfg = []) {
+    pg_stage_begin('load_wordpress');
+    try {
+        $wp_load_path = $cfg['wp_load_path'] ?? '/wordpress/wp-load.php';
+        if (!file_exists($wp_load_path)) {
+            throw new RuntimeException("wp-load.php not found at $wp_load_path");
+        }
+        require_once $wp_load_path;
+        while (ob_get_level() > 0) {
+            @ob_end_clean();
+        }
+        pg_stage_ok('load_wordpress');
+    } catch (Throwable $e) {
+        pg_stage_fail('load_wordpress', $e);
         exit(1);
     }
 }

--- a/wordpress/tests/fixtures/bench-site-mode/bench-site-mode.php
+++ b/wordpress/tests/fixtures/bench-site-mode/bench-site-mode.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Plugin Name: Bench Site Mode Fixture
+ * Description: Fixture for installed-site and blueprint bench smoke tests.
+ */

--- a/wordpress/tests/fixtures/bench-site-mode/tests/bench/read-site-option.php
+++ b/wordpress/tests/fixtures/bench-site-mode/tests/bench/read-site-option.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Reads a normal WordPress option so smoke tests can prove the runner booted
+ * WordPress through the requested site mode.
+ */
+return function (): array {
+    $site_title = function_exists('get_bloginfo') ? get_bloginfo('name') : '(wordpress not loaded)';
+
+    if (defined('HOMEBOY_BENCH_SHARED_STATE') && HOMEBOY_BENCH_SHARED_STATE !== '') {
+        file_put_contents(
+            HOMEBOY_BENCH_SHARED_STATE . '/site-mode-read-back.log',
+            'site_title=' . $site_title . "\n",
+            FILE_APPEND
+        );
+    }
+
+    return [
+        'metrics' => ['title_length' => strlen($site_title)],
+        'metadata' => ['site_title' => $site_title],
+    ];
+};

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -355,6 +355,27 @@
       "type": "object",
       "default": {},
       "description": "Map of NAME => value forwarded into Playground PHP-WASM as environment variables. Workloads (bench) and test fixtures (test runner) read them via getenv() / $_ENV. Required because host shell env doesn't cross the wp-playground-cli sandbox boundary; without this seam, getenv('MY_KNOB') returns false regardless of what the parent shell set. Values are coerced to strings (via json_encode for non-scalars) per PHP env-var convention. Component declares static defaults; matrix drivers can synthesize HOMEBOY_SETTINGS_JSON inline to override per-cell."
+    },
+    {
+      "id": "playground_blueprint",
+      "label": "Playground blueprint",
+      "type": "object",
+      "default": {},
+      "description": "Blueprint JSON passed to wp-playground-cli --blueprint before bench workloads run. Use this for cold-boot scenarios that need plugins, themes, site options, or seeded content installed during Playground bootstrap. Empty object means stock WordPress."
+    },
+    {
+      "id": "bench_site_mode",
+      "label": "Bench site mode",
+      "type": "string",
+      "default": "fresh",
+      "description": "WordPress bench boot shape. 'fresh' preserves the historical wp-phpunit install stage. 'installed' requires HOMEBOY_BENCH_SHARED_STATE, mounts its wordpress/ subdirectory at /wordpress before Playground install, prepares that persisted site on the first run, skips wp-phpunit install.php, and boots the site with wp-load.php for warm installed-site runs."
+    },
+    {
+      "id": "playground_wordpress_install_mode",
+      "label": "Playground WordPress install mode",
+      "type": "string",
+      "default": "",
+      "description": "Optional pass-through for wp-playground-cli --wordpress-install-mode. Leave empty unless a bench needs a non-default Playground install policy; bench_site_mode chooses the normal default for fresh versus installed runs."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds WordPress bench support for Playground blueprints so cold-boot scenarios can include plugin/theme/site setup before workloads run.
- Adds an installed-site bench mode that persists `/wordpress` under shared state, skips the wp-phpunit install stage, and boots warm runs through `wp-load.php`.
- Adds a focused smoke fixture that verifies blueprint options, persisted site reuse, and `load_wordpress_ms` bootstrap metrics.

## Changes
- New WordPress extension settings: `playground_blueprint`, `bench_site_mode`, and `playground_wordpress_install_mode`.
- `bench-runner-playground.sh` now writes non-empty blueprint JSON to a temp file for `wp-playground-cli --blueprint` and mounts shared-state `/wordpress` before install for installed-site runs.
- `playground-bootstrap.php` now supports booting without test config pollution and adds a `load_wordpress` stage for persisted sites.

## Tests
- `php -l wordpress/scripts/lib/playground-bootstrap.php && php -l wordpress/scripts/bench/playground-bench-runner.php && php -l wordpress/tests/fixtures/bench-site-mode/bench-site-mode.php && php -l wordpress/tests/fixtures/bench-site-mode/tests/bench/read-site-option.php`
- `bash -n wordpress/scripts/bench/bench-runner-playground.sh && bash -n wordpress/scripts/bench/playground-bench-site-mode-smoke.sh`
- `bash wordpress/scripts/bench/playground-bench-bootstrap-metrics-smoke.sh`
- `bash wordpress/scripts/bench/playground-bench-site-mode-smoke.sh`
- `git diff --check`

Closes #256.
Closes #267.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the WordPress bench runner settings, smoke fixture, validation runs, and PR drafting. Chris reviewed and remains responsible for the change.