### PR TITLE
feat(swift): add manifest discovery and audit grammar

### DIFF
--- a/swift/swift.json
+++ b/swift/swift.json
@@ -4,11 +4,38 @@
   "icon": "swift",
   "description": "Swift testing infrastructure for macOS, iOS, and Swift CLI projects",
   "author": "Extra Chill",
-  "executable": {
-    "runtime": {
-      "setup_command": "bash {{extension_path}}/scripts/setup.sh",
-      "ready_check": "which swift",
-      "run_command": "bash {{extension_path}}/scripts/test-runner.sh"
+  "provides": {
+    "file_extensions": ["swift", "xcodeproj", "xcworkspace", "yml"]
+  },
+  "platform": {
+    "discovery": {
+      "find_command": "find /Users /home /var/www /srv -maxdepth 6 \\( -name 'project.yml' -o -name '*.xcodeproj' -o -name '*.xcworkspace' -o -name '*.swift' \\) 2>/dev/null | sed -E 's#/(Sources|Tests|tests|[^/]+\\.xcodeproj|[^/]+\\.xcworkspace|[^/]+\\.swift).*##' | sort -u | head -20",
+      "base_path_transform": "identity",
+      "display_name_command": "basename {{basePath}}"
+    }
+  },
+  "audit": {
+    "feature_patterns": [
+      "class\\s+(\\w+)",
+      "struct\\s+(\\w+)",
+      "enum\\s+(\\w+)",
+      "protocol\\s+(\\w+)",
+      "func\\s+(\\w+)\\s*\\("
+    ],
+    "feature_labels": {
+      "class\\s+": "Classes",
+      "struct\\s+": "Structs",
+      "enum\\s+": "Enums",
+      "protocol\\s+": "Protocols",
+      "func\\s+": "Functions"
+    },
+    "test_mapping": {
+      "source_dirs": [".", "Sources"],
+      "test_dirs": ["tests", "Tests"],
+      "test_file_pattern": "{dir}/{name}Tests.{ext}",
+      "method_prefix": "test",
+      "inline_tests": false,
+      "critical_patterns": ["Sources/", "App/", "Homeboy/"]
     }
   },
   "settings": [
@@ -19,5 +46,12 @@
       "default": "script",
       "description": "Test type: 'script' (swift scripts) or 'xcodebuild' (XCTest)"
     }
-  ]
+  ],
+  "executable": {
+    "runtime": {
+      "setup_command": "bash {{extension_path}}/scripts/setup.sh",
+      "ready_check": "which swift",
+      "run_command": "bash {{extension_path}}/scripts/test-runner.sh"
+    }
+  }
 }

--- a/swift/tests/swift-extension-smoke.sh
+++ b/swift/tests/swift-extension-smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="$ROOT_DIR/swift/swift.json"
+
+python3 - "$MANIFEST" <<'PY'
+import json
+import sys
+
+manifest_path = sys.argv[1]
+with open(manifest_path, encoding="utf-8") as handle:
+    manifest = json.load(handle)
+
+def assert_true(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+provides = manifest.get("provides", {})
+extensions = provides.get("file_extensions", [])
+for ext in ["swift", "xcodeproj", "xcworkspace", "yml"]:
+    assert_true(ext in extensions, f"missing file extension: {ext}")
+
+discovery = manifest.get("platform", {}).get("discovery", {})
+find_command = discovery.get("find_command", "")
+assert_true("project.yml" in find_command, "discovery should include project.yml")
+assert_true("*.xcodeproj" in find_command, "discovery should include xcodeproj")
+assert_true("*.xcworkspace" in find_command, "discovery should include xcworkspace")
+assert_true("*.swift" in find_command, "discovery should include Swift sources")
+assert_true(discovery.get("base_path_transform") == "identity", "unexpected base path transform")
+
+audit = manifest.get("audit", {})
+patterns = audit.get("feature_patterns", [])
+for pattern in ["class\\s+(\\w+)", "struct\\s+(\\w+)", "enum\\s+(\\w+)", "protocol\\s+(\\w+)", "func\\s+(\\w+)\\s*\\("]:
+    assert_true(pattern in patterns, f"missing feature pattern: {pattern}")
+
+labels = audit.get("feature_labels", {})
+for label in ["Classes", "Structs", "Enums", "Protocols", "Functions"]:
+    assert_true(label in labels.values(), f"missing feature label: {label}")
+
+mapping = audit.get("test_mapping", {})
+assert_true("tests" in mapping.get("test_dirs", []), "missing lowercase tests dir")
+assert_true("Tests" in mapping.get("test_dirs", []), "missing uppercase Tests dir")
+assert_true(mapping.get("test_file_pattern") == "{dir}/{name}Tests.{ext}", "unexpected test file pattern")
+
+for key in ["lint", "scripts"]:
+    assert_true(key not in manifest, f"#{key} belongs to a later PR")
+
+print("swift manifest smoke passed")
+PY


### PR DESCRIPTION
## Summary
- Adds Swift/Xcode project discovery metadata to the Swift extension manifest.
- Adds Swift audit feature patterns, labels, and basic test mapping for `tests` / `Tests` layouts.
- Adds a smoke test that validates the manifest contract without requiring Xcode or xcodegen.

## Tests
- `python3 -m json.tool swift/swift.json >/dev/null`
- `bash swift/tests/swift-extension-smoke.sh`

Closes #280

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation, test drafting, and local verification; Chris to review before merge.