### PR TITLE
fix(swift): harden script test runner

### DIFF
--- a/swift/scripts/test-runner.sh
+++ b/swift/scripts/test-runner.sh
@@ -20,8 +20,9 @@ else
     # Called directly
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     EXTENSION_PATH="$(dirname "$SCRIPT_DIR")"
-    COMPONENT_PATH="$(pwd)"
+    COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
     COMPONENT_ID="$(basename "$COMPONENT_PATH")"
+    SETTINGS_JSON="${HOMEBOY_SETTINGS_JSON:-}"
 fi
 
 echo "Running Swift tests for: $COMPONENT_ID"
@@ -32,7 +33,11 @@ fi
 # Parse test type from settings
 TEST_TYPE="script"
 if [ -n "${SETTINGS_JSON:-}" ] && [ "$SETTINGS_JSON" != "{}" ]; then
-    TEST_TYPE=$(printf '%s' "$SETTINGS_JSON" | jq -r '.test_type // "script"')
+    if command -v jq >/dev/null 2>&1; then
+        TEST_TYPE=$(printf '%s' "$SETTINGS_JSON" | jq -r '.test_type // "script"')
+    elif printf '%s' "$SETTINGS_JSON" | grep -q '"test_type"[[:space:]]*:[[:space:]]*"xcodebuild"'; then
+        TEST_TYPE="xcodebuild"
+    fi
 fi
 
 # Look for tests directory in component

--- a/swift/tests/script-runner-smoke.sh
+++ b/swift/tests/script-runner-smoke.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SWIFT_DIR="$ROOT_DIR/swift"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq "$expected" "$file"; then
+        echo "Expected $file to contain: $expected" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+FIXTURE="$TMP_DIR/minimal-swift"
+mkdir -p "$FIXTURE/tests"
+cat > "$FIXTURE/tests/ContractTests.swift" <<'SWIFT'
+import Foundation
+
+let fixturesPath = CommandLine.arguments.dropFirst().first ?? ""
+guard fixturesPath.hasSuffix("tests") else {
+    fatalError("expected tests directory argument, got: \(fixturesPath)")
+}
+
+print("contract ok")
+SWIFT
+
+HOMEBOY_COMPONENT_PATH="$FIXTURE" bash "$SWIFT_DIR/scripts/test-runner.sh" > "$TMP_DIR/pass.out"
+assert_contains "$TMP_DIR/pass.out" "Running: ContractTests.swift"
+assert_contains "$TMP_DIR/pass.out" "contract ok"
+assert_contains "$TMP_DIR/pass.out" "Results: 1/1 tests passed"
+
+HOMEBOY_COMPONENT_PATH="$FIXTURE" HOMEBOY_SETTINGS_JSON='{"test_type":"script"}' bash "$SWIFT_DIR/scripts/test-runner.sh" > "$TMP_DIR/settings.out"
+assert_contains "$TMP_DIR/settings.out" "Results: 1/1 tests passed"
+
+NO_TESTS="$TMP_DIR/no-tests"
+mkdir -p "$NO_TESTS"
+if HOMEBOY_COMPONENT_PATH="$NO_TESTS" bash "$SWIFT_DIR/scripts/test-runner.sh" > "$TMP_DIR/missing.out" 2>&1; then
+    echo "Expected missing tests directory to fail" >&2
+    exit 1
+fi
+assert_contains "$TMP_DIR/missing.out" "Error: No tests/ directory found"
+
+echo "swift script runner smoke passed"


### PR DESCRIPTION
## Summary
- Makes direct Swift runner invocation honor `HOMEBOY_COMPONENT_PATH`.
- Keeps script mode as the default and tolerates missing `jq` when parsing settings.
- Adds a smoke fixture for `tests/ContractTests.swift` plus the missing-tests failure path.

## Tests
- `bash swift/tests/script-runner-smoke.sh`
- `HOMEBOY_COMPONENT_PATH="/Users/chubes/Developer/homeboy-desktop" bash swift/scripts/test-runner.sh`

Closes #282

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation, test drafting, and local verification; Chris to review before merge.