### PR TITLE
feat(swift): add CLT-safe validation runner

### DIFF
--- a/swift/scripts/validate.sh
+++ b/swift/scripts/validate.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${HOMEBOY_COMPONENT_PATH:-}" ]; then
+    COMPONENT_PATH="$HOMEBOY_COMPONENT_PATH"
+else
+    COMPONENT_PATH="$(pwd)"
+fi
+
+echo "Validating Swift project: $(basename "$COMPONENT_PATH")"
+
+if ! command -v swiftc >/dev/null 2>&1; then
+    echo "Error: swiftc not found. Install Swift or Xcode Command Line Tools."
+    exit 1
+fi
+
+SWIFT_FILES=()
+while IFS= read -r swift_file; do
+    SWIFT_FILES+=("$swift_file")
+done < <(
+    find "$COMPONENT_PATH" \
+        \( -path '*/.build/*' -o -path '*/DerivedData/*' -o -path '*/.swiftpm/*' \) -prune \
+        -o -name '*.swift' -type f -print
+)
+
+if [ ${#SWIFT_FILES[@]} -eq 0 ]; then
+    echo "Warning: No Swift files found in $COMPONENT_PATH"
+    exit 0
+fi
+
+for swift_file in "${SWIFT_FILES[@]}"; do
+    swiftc -parse "$swift_file"
+done
+
+if [ -f "$COMPONENT_PATH/project.yml" ] && ! command -v xcodegen >/dev/null 2>&1; then
+    echo "Warning: project.yml found, but xcodegen is not installed; skipping project generation check."
+fi
+
+WORKSPACE=$(find "$COMPONENT_PATH" -maxdepth 1 -name '*.xcworkspace' -print -quit)
+PROJECT=$(find "$COMPONENT_PATH" -maxdepth 1 -name '*.xcodeproj' -print -quit)
+
+if [ -n "$WORKSPACE" ] || [ -n "$PROJECT" ]; then
+    DEVELOPER_DIR="$(xcode-select -p 2>/dev/null || true)"
+    if [ -z "$DEVELOPER_DIR" ] || [[ "$DEVELOPER_DIR" != *".app/Contents/Developer" ]]; then
+        echo "Warning: Xcode project/workspace found, but full Xcode is not active; skipping xcodebuild -list."
+        echo "Current developer directory: ${DEVELOPER_DIR:-unavailable}"
+    elif [ -n "$WORKSPACE" ]; then
+        xcodebuild -list -workspace "$WORKSPACE" >/dev/null
+    else
+        xcodebuild -list -project "$PROJECT" >/dev/null
+    fi
+fi
+
+echo "Swift validation passed"

--- a/swift/swift.json
+++ b/swift/swift.json
@@ -4,6 +4,12 @@
   "icon": "swift",
   "description": "Swift testing infrastructure for macOS, iOS, and Swift CLI projects",
   "author": "Extra Chill",
+  "provides": {
+    "capabilities": ["validate"]
+  },
+  "scripts": {
+    "validate": "scripts/validate.sh"
+  },
   "executable": {
     "runtime": {
       "setup_command": "bash {{extension_path}}/scripts/setup.sh",

--- a/swift/tests/validate-runner-smoke.sh
+++ b/swift/tests/validate-runner-smoke.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SWIFT_DIR="$ROOT_DIR/swift"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq "$expected" "$file"; then
+        echo "Expected $file to contain: $expected" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+MINIMAL="$TMP_DIR/minimal"
+mkdir -p "$MINIMAL"
+cat > "$MINIMAL/App.swift" <<'SWIFT'
+struct AppModel {
+    let title: String
+}
+SWIFT
+
+HOMEBOY_COMPONENT_PATH="$MINIMAL" bash "$SWIFT_DIR/scripts/validate.sh" > "$TMP_DIR/minimal.out"
+assert_contains "$TMP_DIR/minimal.out" "Swift validation passed"
+
+XCODEGEN="$TMP_DIR/xcodegen"
+mkdir -p "$XCODEGEN/Homeboy" "$XCODEGEN/Homeboy.xcodeproj"
+cat > "$XCODEGEN/project.yml" <<'YAML'
+name: Homeboy
+targets:
+  Homeboy:
+    type: application
+    platform: macOS
+    sources: Homeboy
+YAML
+cat > "$XCODEGEN/Homeboy/App.swift" <<'SWIFT'
+struct AppModel {
+    let title: String
+}
+SWIFT
+
+HOMEBOY_COMPONENT_PATH="$XCODEGEN" bash "$SWIFT_DIR/scripts/validate.sh" > "$TMP_DIR/xcodegen.out"
+assert_contains "$TMP_DIR/xcodegen.out" "Swift validation passed"
+if ! command -v xcodegen >/dev/null 2>&1; then
+    assert_contains "$TMP_DIR/xcodegen.out" "project.yml found, but xcodegen is not installed"
+fi
+
+BAD="$TMP_DIR/bad"
+mkdir -p "$BAD"
+cat > "$BAD/Broken.swift" <<'SWIFT'
+struct Broken {
+    let value: String =
+}
+SWIFT
+
+if HOMEBOY_COMPONENT_PATH="$BAD" bash "$SWIFT_DIR/scripts/validate.sh" > "$TMP_DIR/bad.out" 2>&1; then
+    echo "Expected invalid Swift syntax to fail" >&2
+    exit 1
+fi
+assert_contains "$TMP_DIR/bad.out" "error:"
+
+echo "swift validate runner smoke passed"


### PR DESCRIPTION
## Summary
- Adds a Swift validation capability wired through `scripts.validate`.
- Parses Swift files with `swiftc -parse` while pruning common build artifact directories.
- Warns instead of failing when `project.yml` needs xcodegen or Xcode projects are present on a CLT-only machine.

## Tests
- `python3 -m json.tool swift/swift.json >/dev/null`
- `bash swift/tests/validate-runner-smoke.sh`
- `HOMEBOY_COMPONENT_PATH="/Users/chubes/Developer/homeboy-desktop" bash swift/scripts/validate.sh` confirmed the known `ExtensionViewModel.swift` syntax blocker is caught.

Closes #283

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation, test drafting, and local verification; Chris to review before merge.