### PR TITLE
feat(swift): add optional lint runner

### DIFF
--- a/swift/scripts/lint-runner.sh
+++ b/swift/scripts/lint-runner.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${HOMEBOY_COMPONENT_PATH:-}" ]; then
+    COMPONENT_PATH="$HOMEBOY_COMPONENT_PATH"
+else
+    COMPONENT_PATH="$(pwd)"
+fi
+
+echo "Running Swift lint for: $(basename "$COMPONENT_PATH")"
+
+if command -v swiftlint >/dev/null 2>&1; then
+    swiftlint lint --path "$COMPONENT_PATH"
+elif command -v swiftformat >/dev/null 2>&1; then
+    swiftformat "$COMPONENT_PATH" --lint
+else
+    echo "Swift lint skipped: install SwiftLint or SwiftFormat to enable Swift linting."
+fi

--- a/swift/swift.json
+++ b/swift/swift.json
@@ -4,6 +4,9 @@
   "icon": "swift",
   "description": "Swift testing infrastructure for macOS, iOS, and Swift CLI projects",
   "author": "Extra Chill",
+  "lint": {
+    "extension_script": "scripts/lint-runner.sh"
+  },
   "executable": {
     "runtime": {
       "setup_command": "bash {{extension_path}}/scripts/setup.sh",

--- a/swift/tests/lint-runner-smoke.sh
+++ b/swift/tests/lint-runner-smoke.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SWIFT_DIR="$ROOT_DIR/swift"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FIXTURE="$TMP_DIR/minimal-swift"
+mkdir -p "$FIXTURE"
+cat > "$FIXTURE/App.swift" <<'SWIFT'
+struct AppModel {
+    let title: String
+}
+SWIFT
+
+HOMEBOY_COMPONENT_PATH="$FIXTURE" bash "$SWIFT_DIR/scripts/lint-runner.sh" > "$TMP_DIR/lint.out"
+
+if ! command -v swiftlint >/dev/null 2>&1 && ! command -v swiftformat >/dev/null 2>&1; then
+    if ! grep -Fq "Swift lint skipped" "$TMP_DIR/lint.out"; then
+        echo "Expected skipped message when Swift lint tools are unavailable" >&2
+        sed 's/^/  /' "$TMP_DIR/lint.out" >&2
+        exit 1
+    fi
+fi
+
+echo "swift lint runner smoke passed"


### PR DESCRIPTION
## Summary
- Adds a Swift lint runner wired through `lint.extension_script`.
- Uses SwiftLint when available, falls back to `swiftformat --lint`, and skips cleanly when neither tool is installed.
- Adds a smoke test for the local no-tool skip path.

## Tests
- `python3 -m json.tool swift/swift.json >/dev/null`
- `bash swift/tests/lint-runner-smoke.sh`
- `HOMEBOY_COMPONENT_PATH="/Users/chubes/Developer/homeboy-desktop" bash swift/scripts/lint-runner.sh`

Closes #281

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation, test drafting, and local verification; Chris to review before merge.