### PR TITLE
fix(swift): align manifest smoke with combined capabilities

### DIFF
--- a/swift/tests/swift-extension-smoke.sh
+++ b/swift/tests/swift-extension-smoke.sh
@@ -43,8 +43,10 @@ assert_true("tests" in mapping.get("test_dirs", []), "missing lowercase tests di
 assert_true("Tests" in mapping.get("test_dirs", []), "missing uppercase Tests dir")
 assert_true(mapping.get("test_file_pattern") == "{dir}/{name}Tests.{ext}", "unexpected test file pattern")
 
-for key in ["lint", "scripts"]:
-    assert_true(key not in manifest, f"#{key} belongs to a later PR")
+capabilities = provides.get("capabilities", [])
+assert_true("validate" in capabilities, "missing validate capability")
+assert_true(manifest.get("scripts", {}).get("validate") == "scripts/validate.sh", "missing validate script")
+assert_true(manifest.get("lint", {}).get("extension_script") == "scripts/lint-runner.sh", "missing lint runner")
 
 print("swift manifest smoke passed")
 PY


### PR DESCRIPTION
## Summary
- Updates the Swift manifest smoke to assert the merged validate and lint capabilities instead of treating them as absent future work.

## Tests
- `python3 -m json.tool swift/swift.json >/dev/null`
- `bash swift/tests/swift-extension-smoke.sh`
- `bash swift/tests/script-runner-smoke.sh`
- `bash swift/tests/validate-runner-smoke.sh`
- `bash swift/tests/lint-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Follow-up smoke-test fix after merging the Swift extension slices.