### PR TITLE
fix(swift): advertise script test runner

### DIFF
--- a/swift/swift.json
+++ b/swift/swift.json
@@ -54,6 +54,9 @@
   "lint": {
     "extension_script": "scripts/lint-runner.sh"
   },
+  "test": {
+    "extension_script": "scripts/test-runner.sh"
+  },
   "executable": {
     "runtime": {
       "setup_command": "bash {{extension_path}}/scripts/setup.sh",

--- a/swift/tests/swift-extension-smoke.sh
+++ b/swift/tests/swift-extension-smoke.sh
@@ -47,6 +47,7 @@ capabilities = provides.get("capabilities", [])
 assert_true("validate" in capabilities, "missing validate capability")
 assert_true(manifest.get("scripts", {}).get("validate") == "scripts/validate.sh", "missing validate script")
 assert_true(manifest.get("lint", {}).get("extension_script") == "scripts/lint-runner.sh", "missing lint runner")
+assert_true(manifest.get("test", {}).get("extension_script") == "scripts/test-runner.sh", "missing test runner")
 
 print("swift manifest smoke passed")
 PY


### PR DESCRIPTION
## Summary
- Wires the existing Swift script runner through `test.extension_script` so Homeboy recognizes Swift components as testable.
- Extends the manifest smoke to assert the test runner contract.

## Tests
- `python3 -m json.tool swift/swift.json >/dev/null`
- `bash swift/tests/swift-extension-smoke.sh`
- `bash swift/tests/script-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Follow-up manifest wiring after `homeboy review` showed Swift had no advertised test support.