### PR TITLE
feat(nodejs): allow bench workloads to return custom metrics

### DIFF
--- a/nodejs/scripts/bench/bench-runner.mjs
+++ b/nodejs/scripts/bench/bench-runner.mjs
@@ -12,7 +12,10 @@
 //   HOMEBOY_BENCH_LIST_ONLY      — when 1, emit scenario inventory only
 //
 // Discovers `bench/**/*.bench.{ts,mjs,js}` under the project root.
-// Each workload file must export a default async function:
+// Each workload file must export a default async function. The function may
+// return `{ metrics: Record<string, number> }` to report workload-owned custom
+// metrics, which are averaged across measured iterations and merged beside the
+// dispatcher-owned timing metrics.
 //
 //     // bench/cold-boot.bench.ts
 //     export default async function () {
@@ -47,6 +50,15 @@ const LIST_ONLY = process.env.HOMEBOY_BENCH_LIST_ONLY === '1';
 const WARMUP = 1;
 const DEBUG = process.env.HOMEBOY_DEBUG === '1';
 
+const TIMING_METRIC_KEYS = new Set([
+    'mean_ms',
+    'p50_ms',
+    'p95_ms',
+    'p99_ms',
+    'min_ms',
+    'max_ms',
+]);
+
 if (!PROJECT_PATH || !COMPONENT_ID || !RESULTS_FILE) {
     console.error('FATAL: missing required env vars (PROJECT_PATH/COMPONENT_ID/RESULTS_FILE)');
     process.exit(2);
@@ -73,6 +85,54 @@ function scenarioId(file) {
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/^-+|-+$/g, '');
+}
+
+function validateWorkloadResult(value, iterationLabel) {
+    if (value === undefined) {
+        return {};
+    }
+
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error(`${iterationLabel} returned invalid result shape (expected undefined or an object)`);
+    }
+
+    const { metrics } = value;
+    if (metrics === undefined) {
+        return {};
+    }
+
+    if (!metrics || typeof metrics !== 'object' || Array.isArray(metrics)) {
+        throw new Error(`${iterationLabel} returned invalid metrics shape (expected an object)`);
+    }
+
+    const validated = {};
+    for (const [key, metricValue] of Object.entries(metrics)) {
+        if (TIMING_METRIC_KEYS.has(key)) {
+            throw new Error(`${iterationLabel} returned metric "${key}", which is owned by the bench dispatcher`);
+        }
+        if (typeof metricValue !== 'number' || !Number.isFinite(metricValue)) {
+            throw new Error(`${iterationLabel} returned metric "${key}" with non-finite numeric value`);
+        }
+        validated[key] = metricValue;
+    }
+
+    return validated;
+}
+
+function aggregateCustomMetrics(iterationMetrics) {
+    const sums = new Map();
+    const counts = new Map();
+
+    for (const metrics of iterationMetrics) {
+        for (const [key, value] of Object.entries(metrics)) {
+            sums.set(key, (sums.get(key) || 0) + value);
+            counts.set(key, (counts.get(key) || 0) + 1);
+        }
+    }
+
+    return Object.fromEntries(
+        [...sums.entries()].map(([key, sum]) => [key, sum / counts.get(key)])
+    );
 }
 
 async function discoverWorkloads(dir) {
@@ -114,18 +174,19 @@ async function runWorkload(file) {
     // Warmup pass — discarded.
     for (let i = 0; i < WARMUP; i++) {
         try {
-            await fn();
+            validateWorkloadResult(await fn(), `warmup iteration ${i + 1}/${WARMUP}`);
         } catch (err) {
             return { error: `warmup iteration threw: ${err.message}` };
         }
     }
 
     const timings = [];
+    const customMetrics = [];
     let peakRss = 0;
     for (let i = 0; i < ITERATIONS; i++) {
         const start = performance.now();
         try {
-            await fn();
+            customMetrics.push(validateWorkloadResult(await fn(), `iteration ${i + 1}/${ITERATIONS}`));
         } catch (err) {
             return { error: `iteration ${i + 1}/${ITERATIONS} threw: ${err.message}` };
         }
@@ -135,7 +196,7 @@ async function runWorkload(file) {
     }
 
     timings.sort((a, b) => a - b);
-    return { timings, peakRss };
+    return { timings, peakRss, customMetrics: aggregateCustomMetrics(customMetrics) };
 }
 
 async function main() {
@@ -193,19 +254,21 @@ async function main() {
         }
 
         const t = result.timings;
+        const timingMetrics = {
+            mean_ms: t.reduce((a, b) => a + b, 0) / t.length,
+            p50_ms: percentile(t, 0.50),
+            p95_ms: percentile(t, 0.95),
+            p99_ms: percentile(t, 0.99),
+            min_ms: t[0],
+            max_ms: t[t.length - 1],
+        };
+
         scenarios.push({
             id,
             file: rel,
             source,
             iterations: t.length,
-            metrics: {
-                mean_ms: t.reduce((a, b) => a + b, 0) / t.length,
-                p50_ms: percentile(t, 0.50),
-                p95_ms: percentile(t, 0.95),
-                p99_ms: percentile(t, 0.99),
-                min_ms: t[0],
-                max_ms: t[t.length - 1],
-            },
+            metrics: { ...timingMetrics, ...result.customMetrics },
             memory: { peak_bytes: result.peakRss },
         });
 

--- a/nodejs/scripts/bench/nodejs-bench-custom-metrics-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-bench-custom-metrics-smoke.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-bench-metrics.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+assert_json() {
+    local file="$1"
+    local script="$2"
+    node -e "const fs = require('fs'); const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); ${script}" "$file"
+}
+
+run_runner() {
+    local project_dir="$1"
+    local results_file="$2"
+    HOMEBOY_COMPONENT_PATH="$project_dir" \
+        HOMEBOY_COMPONENT_ID="node-bench-smoke" \
+        HOMEBOY_BENCH_ITERATIONS="3" \
+        HOMEBOY_BENCH_RESULTS_FILE="$results_file" \
+        node "$SCRIPT_DIR/bench-runner.mjs"
+}
+
+make_project() {
+    local name="$1"
+    local project_dir="$TMP_DIR/$name"
+    mkdir -p "$project_dir/bench"
+    printf '{"name":"%s"}\n' "$name" > "$project_dir/package.json"
+    printf '%s\n' "$project_dir"
+}
+
+VOID_PROJECT="$(make_project void-return)"
+cat > "$VOID_PROJECT/bench/void.bench.mjs" <<'EOF'
+export default async function () {}
+EOF
+
+VOID_RESULTS="$TMP_DIR/void-results.json"
+run_runner "$VOID_PROJECT" "$VOID_RESULTS" >/dev/null
+assert_json "$VOID_RESULTS" '
+if (data.scenarios.length !== 1) throw new Error("expected one void scenario");
+const metrics = data.scenarios[0].metrics;
+for (const key of ["mean_ms", "p50_ms", "p95_ms", "p99_ms", "min_ms", "max_ms"]) {
+  if (typeof metrics[key] !== "number") throw new Error(`missing timing metric ${key}`);
+}
+if (Object.prototype.hasOwnProperty.call(metrics, "turn_count")) throw new Error("void workload emitted custom metric");
+'
+
+CUSTOM_PROJECT="$(make_project custom-metrics)"
+cat > "$CUSTOM_PROJECT/bench/custom.bench.mjs" <<'EOF'
+let i = 0;
+export default async function () {
+  i += 1;
+  return { metrics: { turn_count: i, score: i + 1 }, artifacts: { ignored: "for-now" } };
+}
+EOF
+
+CUSTOM_RESULTS="$TMP_DIR/custom-results.json"
+run_runner "$CUSTOM_PROJECT" "$CUSTOM_RESULTS" >/dev/null
+assert_json "$CUSTOM_RESULTS" '
+const metrics = data.scenarios[0].metrics;
+if (metrics.turn_count !== 3) throw new Error(`expected mean turn_count 3, got ${metrics.turn_count}`);
+if (metrics.score !== 4) throw new Error(`expected mean score 4, got ${metrics.score}`);
+if (typeof metrics.p95_ms !== "number") throw new Error("timing metrics missing beside custom metrics");
+'
+
+INVALID_PROJECT="$(make_project invalid-metric)"
+cat > "$INVALID_PROJECT/bench/invalid.bench.mjs" <<'EOF'
+export default async function () {
+  return { metrics: { turn_count: "three" } };
+}
+EOF
+
+set +e
+INVALID_OUTPUT="$(run_runner "$INVALID_PROJECT" "$TMP_DIR/invalid-results.json" 2>&1)"
+INVALID_EXIT=$?
+set -e
+if [ "$INVALID_EXIT" -eq 0 ]; then
+    echo "expected non-number metric workload to fail" >&2
+    exit 1
+fi
+if [[ "$INVALID_OUTPUT" != *'metric "turn_count" with non-finite numeric value'* ]]; then
+    echo "expected clear non-number metric error" >&2
+    echo "$INVALID_OUTPUT" >&2
+    exit 1
+fi
+
+COLLISION_PROJECT="$(make_project collision-metric)"
+cat > "$COLLISION_PROJECT/bench/collision.bench.mjs" <<'EOF'
+export default async function () {
+  return { metrics: { p95_ms: 123 } };
+}
+EOF
+
+set +e
+COLLISION_OUTPUT="$(run_runner "$COLLISION_PROJECT" "$TMP_DIR/collision-results.json" 2>&1)"
+COLLISION_EXIT=$?
+set -e
+if [ "$COLLISION_EXIT" -eq 0 ]; then
+    echo "expected timing metric collision workload to fail" >&2
+    exit 1
+fi
+if [[ "$COLLISION_OUTPUT" != *'metric "p95_ms", which is owned by the bench dispatcher'* ]]; then
+    echo "expected clear timing metric collision error" >&2
+    echo "$COLLISION_OUTPUT" >&2
+    exit 1
+fi
+
+echo "Node.js bench custom metrics smoke passed."


### PR DESCRIPTION
## Summary

- Extends the Node.js bench workload contract so workloads can return custom numeric metrics alongside dispatcher-owned timing metrics.
- Preserves existing timing-only workloads and keeps timing metric names reserved to the dispatcher.

## Changes

- Validates workload return values from warmup and measured iterations.
- Aggregates returned custom metric values across measured iterations using a simple mean.
- Rejects non-finite/non-number metric values and custom metric keys that collide with timing metrics.
- Tolerates `artifacts` in the return object but ignores it until core has a first-class artifact contract.
- Adds a focused smoke covering void returns, custom metrics, invalid metric values, and timing-key collisions.

## Tests

```bash
$ bash nodejs/scripts/bench/nodejs-bench-custom-metrics-smoke.sh
Node.js bench custom metrics smoke passed.
```

```bash
$ node --check nodejs/scripts/bench/bench-runner.mjs
# no output
```

```bash
$ bash -n nodejs/scripts/bench/nodejs-bench-custom-metrics-smoke.sh nodejs/scripts/bench/bench-runner.sh
# no output
```

```bash
$ HOMEBOY_EXTENSION_PATH="$PWD/nodejs" HOMEBOY_COMPONENT_PATH="$tmpdir" HOMEBOY_COMPONENT_ID="node-bench-runner-fixture" HOMEBOY_BENCH_ITERATIONS=2 HOMEBOY_BENCH_RESULTS_FILE="$tmpdir/results.json" /opt/homebrew/bin/bash nodejs/scripts/bench/bench-runner.sh
Running Node.js benchmarks...
  Component: node-bench-runner-fixture (.../homeboy-node-bench-runner.lh746G)
  Iterations: 2
WORKLOAD_BEGIN: custom (custom.bench.mjs)
WORKLOAD_DONE:  custom  p50=0.00ms  p95=0.01ms

Node.js bench run complete.
{"scenario":"custom","turn_count":3,"has_p95":true}
```

Attempted `homeboy lint nodejs --path nodejs` and `homeboy test --skip-lint --changed-since origin/main`; both fail before running checks because this repo's `nodejs` / `homeboy-extensions` components have no configured Homeboy extension in the local registry.

## Closes #294

Closes #294.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Node.js bench runner contract change, smoke coverage, local verification, and PR preparation. Chris remains responsible for review and merge.
