### PR TITLE
fix(rust): avoid grep in test result parser

### DIFF
--- a/rust/scripts/parse-test-results-smoke.sh
+++ b/rust/scripts/parse-test-results-smoke.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Smoke-test the Rust test-result parser without GNU grep assumptions.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/rust-parse-results-output.XXXXXX")
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/rust-parse-results-json.XXXXXX")
+HELPER_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/rust-write-test-results.XXXXXX")
+
+# shellcheck disable=SC2064
+trap "rm -f '$OUTPUT_TMPFILE' '$RESULTS_TMPFILE' '$HELPER_TMPFILE'" EXIT
+
+cat > "$OUTPUT_TMPFILE" <<'EOF'
+running 3 tests
+test result: ok. 2 passed; 1 failed; 3 ignored; 0 measured; 0 filtered out;
+test result: ok. 5 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out;
+EOF
+
+cat > "$HELPER_TMPFILE" <<'EOF'
+homeboy_write_test_results() {
+    cat > "$HOMEBOY_TEST_RESULTS_FILE" <<JSON
+{"total":$1,"passed":$2,"failed":$3,"skipped":$4}
+JSON
+}
+EOF
+
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$HELPER_TMPFILE" \
+HOMEBOY_TEST_RESULTS_FILE="$RESULTS_TMPFILE" \
+    bash "$SCRIPT_DIR/parse-test-results.sh" "$OUTPUT_TMPFILE"
+
+python3 - "$RESULTS_TMPFILE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+
+expected = {"total": 12, "passed": 7, "failed": 1, "skipped": 4}
+if data != expected:
+    raise SystemExit(f"unexpected parser output: {data!r} != {expected!r}")
+PY
+
+echo "Rust test-result parser smoke passed"

--- a/rust/scripts/parse-test-results.sh
+++ b/rust/scripts/parse-test-results.sh
@@ -16,8 +16,6 @@ if [ -z "$OUTPUT_FILE" ] || [ ! -f "$OUTPUT_FILE" ]; then
     exit 0
 fi
 
-OUTPUT=$(cat "$OUTPUT_FILE")
-
 WRITE_TEST_RESULTS_HELPER="${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-}"
 if [ -n "$WRITE_TEST_RESULTS_HELPER" ] && [ -f "$WRITE_TEST_RESULTS_HELPER" ]; then
     # shellcheck source=/dev/null
@@ -25,9 +23,9 @@ if [ -n "$WRITE_TEST_RESULTS_HELPER" ] && [ -f "$WRITE_TEST_RESULTS_HELPER" ]; t
 fi
 
 # Aggregate all "test result:" lines
-TOTAL_PASSED=$( { echo "$OUTPUT" | grep -Eo '[0-9]+ passed' || true; } | awk '{s+=$1} END {print s+0}' )
-TOTAL_FAILED=$( { echo "$OUTPUT" | grep -Eo '[0-9]+ failed' || true; } | awk '{s+=$1} END {print s+0}' )
-TOTAL_IGNORED=$( { echo "$OUTPUT" | grep -Eo '[0-9]+ ignored' || true; } | awk '{s+=$1} END {print s+0}' )
+TOTAL_PASSED=$(awk '{ for (i = 1; i < NF; i++) if ($i ~ /^[0-9]+$/ && $(i + 1) ~ /^passed;?$/) s += $i } END { print s + 0 }' "$OUTPUT_FILE")
+TOTAL_FAILED=$(awk '{ for (i = 1; i < NF; i++) if ($i ~ /^[0-9]+$/ && $(i + 1) ~ /^failed;?$/) s += $i } END { print s + 0 }' "$OUTPUT_FILE")
+TOTAL_IGNORED=$(awk '{ for (i = 1; i < NF; i++) if ($i ~ /^[0-9]+$/ && $(i + 1) ~ /^ignored;?$/) s += $i } END { print s + 0 }' "$OUTPUT_FILE")
 
 TOTAL=$((TOTAL_PASSED + TOTAL_FAILED + TOTAL_IGNORED))
 


### PR DESCRIPTION
## Summary
- Remove grep from the Rust test-result parser so the post-processing path does not depend on GNU-only flags.
- Add a focused smoke test that exercises multi-line Cargo result aggregation through the runtime helper contract.

## Tests
- `rust/scripts/parse-test-results-smoke.sh`
- `HOMEBOY_RUNTIME_RUNNER_STEPS=/Users/chubes/.config/homeboy/runtime/runner-steps.sh HOMEBOY_RUNTIME_FAILURE_TRAP=/Users/chubes/.config/homeboy/runtime/failure-trap.sh HOMEBOY_RUNTIME_WRITE_TEST_RESULTS=/Users/chubes/.config/homeboy/runtime/write-test-results.sh HOMEBOY_EXTENSION_PATH=/Users/chubes/Developer/homeboy-extensions@fix-rust-runner-grep-portability/rust HOMEBOY_COMPONENT_PATH=/Users/chubes/Developer/homeboy@fix-missing-import-test-scope HOMEBOY_COMPONENT_ID=homeboy HOMEBOY_SKIP_LINT=1 HOMEBOY_TEST_RESULTS_FILE=/tmp/homeboy-rust-test-results.json bash rust/scripts/test-runner.sh -- --help`

Closes #297

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Runner portability fix, tests, and validation. Chris remains responsible for review and merge.
