### PR TITLE
fix(wordpress): seed lint runner plugin path

### DIFF
--- a/tests/wordpress-lint-context-smoke.sh
+++ b/tests/wordpress-lint-context-smoke.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNNER="$ROOT_DIR/wordpress/scripts/lint/lint-runner.sh"
+PHPSTAN_RUNNER="$ROOT_DIR/wordpress/scripts/lint/phpstan-runner.sh"
+PHPSTAN_CONFIG="$ROOT_DIR/wordpress/phpstan.neon.dist"
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq -- "$expected" "$file"; then
+        echo "Expected $file to contain: $expected" >&2
+        exit 1
+    fi
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+COMPONENT_DIR="$TMP_DIR/example-plugin"
+FAKE_EXTENSION="$TMP_DIR/fake-wordpress-extension"
+mkdir -p "$COMPONENT_DIR" "$FAKE_EXTENSION/vendor/bin" "$FAKE_EXTENSION/HomeboyWordPress"
+
+cat > "$COMPONENT_DIR/example-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Example Plugin
+ * Text Domain: example-plugin
+ */
+PHP
+
+touch "$FAKE_EXTENSION/vendor/bin/phpcs" "$FAKE_EXTENSION/vendor/bin/phpcbf" "$FAKE_EXTENSION/phpcs.xml.dist"
+
+NOOP_RESOLVER="$TMP_DIR/noop-resolve-context.sh"
+cat > "$NOOP_RESOLVER" <<'SH'
+homeboy_resolve_context() {
+    return 0
+}
+SH
+
+HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="example-plugin" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$NOOP_RESOLVER" \
+HOMEBOY_STEP="none" \
+    bash "$RUNNER" > "$TMP_DIR/lint.out" 2>&1
+
+assert_contains "$TMP_DIR/lint.out" "Linting passed"
+
+assert_contains "$RUNNER" 'PLUGIN_PATH="${HOMEBOY_PLUGIN_PATH:-$COMPONENT_PATH}"'
+assert_contains "$RUNNER" "*/vendor_prefixed/*"
+assert_contains "$PHPSTAN_RUNNER" "*/vendor_prefixed/*"
+assert_contains "$PHPSTAN_CONFIG" "*/vendor_prefixed/*"
+
+echo "wordpress lint context smoke passed"

--- a/wordpress/phpstan.neon.dist
+++ b/wordpress/phpstan.neon.dist
@@ -59,6 +59,7 @@ parameters:
     # level excludePaths in their own phpstan.neon.
     excludePaths:
         - */vendor/*
+        - */vendor_prefixed/*
         - */node_modules/*
         - */build/*
         - */dist/*

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -35,6 +35,15 @@ RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/../lib/runner
 # shellcheck source=../lib/runner-steps.sh
 source "${RUNNER_STEPS_HELPER}"
 
+# Seed context from Homeboy before any strict-mode access. The shared resolver
+# may be overridden by the runtime, but the lint runner still needs a safe local
+# fallback for direct invocation and older runtime helper shapes.
+EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:-$(dirname "$(dirname "$SCRIPT_DIR")")}"
+COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-${HOMEBOY_PROJECT_PATH:-$(pwd)}}"
+PLUGIN_PATH="${HOMEBOY_PLUGIN_PATH:-$COMPONENT_PATH}"
+COMPONENT_ID="${HOMEBOY_COMPONENT_ID:-$(basename "$COMPONENT_PATH")}"
+export EXTENSION_PATH COMPONENT_PATH PLUGIN_PATH COMPONENT_ID
+
 # Debug environment variables (only shown when HOMEBOY_DEBUG=1)
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Environment variables:"
@@ -71,6 +80,7 @@ RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/
 # shellcheck source=../lib/resolve-context.sh
 source "${RESOLVE_CONTEXT_HELPER}"
 homeboy_resolve_context
+export EXTENSION_PATH COMPONENT_PATH PLUGIN_PATH COMPONENT_ID
 
 COMPONENT_SHAPE="${HOMEBOY_COMPONENT_SHAPE:-}"
 if [ -z "$COMPONENT_SHAPE" ]; then
@@ -525,6 +535,7 @@ fixable_count=0
 
 # Build base phpcs arguments
 phpcs_base_args=(--standard="$PHPCS_CONFIG")
+phpcs_base_args+=(--ignore='*/vendor/*,*/vendor_prefixed/*,*/node_modules/*,*/build/*,*/dist/*')
 
 # Auto-detect parallelism from available CPU cores
 if [ -z "${PARALLEL_PROCS:-}" ]; then

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -155,7 +155,13 @@ resolve_phpstan_targets() {
             if [ -f "${PLUGIN_PATH}/${target}" ] && [[ "$target" == *.php ]]; then
                 printf '%s\0' "${PLUGIN_PATH}/${target}"
             elif [ -d "${PLUGIN_PATH}/${target}" ]; then
-                find "${PLUGIN_PATH}/${target}" -type f -name '*.php' -print0
+                find "${PLUGIN_PATH}/${target}" -type f -name '*.php' \
+                    -not -path "*/vendor/*" \
+                    -not -path "*/vendor_prefixed/*" \
+                    -not -path "*/node_extensions/*" \
+                    -not -path "*/build/*" \
+                    -not -path "*/dist/*" \
+                    -print0
             fi
         done
         return
@@ -185,6 +191,7 @@ if [ "$PHPSTAN_SCOPED" -eq 1 ]; then
 else
     php_file_count=$(find "$PLUGIN_PATH" -type f -name "*.php" \
         -not -path "*/vendor/*" \
+        -not -path "*/vendor_prefixed/*" \
         -not -path "*/node_extensions/*" \
         -not -path "*/build/*" \
         -not -path "*/dist/*" \


### PR DESCRIPTION
## Summary
- Fixes the WordPress lint runner so Homeboy-provided component paths are available before strict-mode PLUGIN_PATH access.
- Excludes generated vendor_prefixed trees from PHPCS and PHPStan lint targets.

## Changes
- Seed and export EXTENSION_PATH, COMPONENT_PATH, PLUGIN_PATH, and COMPONENT_ID before debug output and helper overrides.
- Add vendor_prefixed exclusions to PHPCS/PHPStan paths and PHPStan config.
- Add a smoke test for a runtime resolver that does not populate PLUGIN_PATH.

## Tests
- bash tests/wordpress-lint-context-smoke.sh
- bash tests/runtime-helpers-smoke.sh
- bash wordpress/scripts/lint/autofixable-exit-smoke.sh

Closes #296

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Debugging the lint-runner context failure, implementing the shell fix, adding smoke coverage, and verifying the changed scripts.