### PR TITLE
feat(swift): fingerprint source symbols

### DIFF
--- a/swift/scripts/fingerprint.py
+++ b/swift/scripts/fingerprint.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Lightweight Swift source fingerprinting for homeboy audit."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+
+
+DECL_RE = re.compile(
+    r"^\s*(?:(?:@[A-Za-z_][\w.]*(?:\([^\n)]*\))?)\s*)*"
+    r"(?P<mods>(?:(?:public|private|fileprivate|internal|open|final|static|class|actor)\s+)*)"
+    r"(?P<kind>class|struct|enum|protocol|actor)\s+"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
+    r"(?P<tail>[^\n{]*)",
+    re.MULTILINE,
+)
+
+EXT_RE = re.compile(
+    r"^\s*(?:(?:public|private|fileprivate|internal|open)\s+)*extension\s+"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_.]*)"
+    r"(?P<tail>[^\n{]*)",
+    re.MULTILINE,
+)
+
+FUNC_RE = re.compile(
+    r"^\s*(?:(?:@[A-Za-z_][\w.]*(?:\([^\n)]*\))?)\s*)*"
+    r"(?P<mods>(?:(?:public|private|fileprivate|internal|open|static|class|override|mutating|nonmutating|async|rethrows|final)\s+)*)"
+    r"func\s+(?P<name>`?[A-Za-z_][A-Za-z0-9_]*`?)\s*(?:<[^\n{]*>)?\s*\(",
+    re.MULTILINE,
+)
+
+INIT_RE = re.compile(
+    r"^\s*(?:(?:@[A-Za-z_][\w.]*(?:\([^\n)]*\))?)\s*)*"
+    r"(?P<mods>(?:(?:public|private|fileprivate|internal|open|required|convenience|override)\s+)*)"
+    r"init(?:\?|!)?\s*\(",
+    re.MULTILINE,
+)
+
+PROPERTY_RE = re.compile(
+    r"^\s*(?:(?:@[A-Za-z_][\w.]*(?:\([^\n)]*\))?)\s*)*"
+    r"(?P<mods>(?:(?:public|private|fileprivate|internal|open|static|class|lazy|weak|unowned|@Published|@State|@Binding|@ObservedObject|@StateObject|@EnvironmentObject)\s+)*)"
+    r"(?P<kind>let|var)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\b",
+    re.MULTILINE,
+)
+
+IMPORT_RE = re.compile(r"^\s*import\s+([A-Za-z_][A-Za-z0-9_.]*)", re.MULTILINE)
+CALL_RE = re.compile(r"(?:\b|\.)([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+SKIP_CALLS = {
+    "if",
+    "for",
+    "while",
+    "switch",
+    "guard",
+    "return",
+    "print",
+    "String",
+    "Int",
+    "Double",
+    "Float",
+    "Bool",
+    "Array",
+    "Dictionary",
+    "Set",
+    "Optional",
+    "Task",
+    "DispatchQueue",
+    "fatalError",
+    "assert",
+    "precondition",
+    "super",
+    "Self",
+}
+
+
+def load_input() -> tuple[str, str]:
+    raw = sys.stdin.read()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw, ""
+
+    if isinstance(data, dict):
+        return str(data.get("content", "")), str(data.get("file_path", ""))
+    return raw, ""
+
+
+def strip_comments(content: str) -> str:
+    content = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    return re.sub(r"//.*", "", content)
+
+
+def dedupe(items):
+    seen = set()
+    result = []
+    for item in items:
+        key = json.dumps(item, sort_keys=True) if isinstance(item, dict) else item
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(item)
+    return result
+
+
+def visibility_from_mods(mods: str) -> str:
+    tokens = set(mods.split())
+    if "open" in tokens:
+        return "open"
+    if "public" in tokens:
+        return "public"
+    if "private" in tokens:
+        return "private"
+    if "fileprivate" in tokens:
+        return "fileprivate"
+    return "internal"
+
+
+def protocols_from_tail(tail: str) -> list[str]:
+    if ":" not in tail:
+        return []
+    inherited = tail.split(":", 1)[1]
+    inherited = re.sub(r"\bwhere\b.*", "", inherited).strip()
+    return [part.strip().split(".")[-1] for part in inherited.split(",") if part.strip()]
+
+
+def line_number(content: str, offset: int) -> int:
+    return content.count("\n", 0, offset) + 1
+
+
+def item_source(content: str, offset: int) -> str:
+    brace_start = content.find("{", offset)
+    line_end = content.find("\n", offset)
+    if line_end == -1:
+        line_end = len(content)
+    if brace_start == -1 or brace_start > line_end:
+        return content[offset:line_end]
+
+    depth = 0
+    for index in range(brace_start, len(content)):
+        char = content[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return content[offset : index + 1]
+
+    return content[offset:line_end]
+
+
+def method_hash(content: str, offset: int) -> str:
+    line_start = content.rfind("\n", 0, offset) + 1
+    snippet = item_source(content, line_start)
+    normalized = re.sub(r"\s+", " ", snippet).strip()
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
+def main() -> None:
+    content, file_path = load_input()
+    code = strip_comments(content)
+
+    declarations = []
+    type_names = []
+    implements = []
+    extends = None
+    for match in DECL_RE.finditer(code):
+        kind = match.group("kind")
+        name = match.group("name")
+        tail = match.group("tail") or ""
+        protocols = protocols_from_tail(tail)
+        declarations.append(
+            {
+                "kind": kind,
+                "name": name,
+                "visibility": visibility_from_mods(match.group("mods") or ""),
+                "line": line_number(code, match.start()),
+                "implements": protocols,
+            }
+        )
+        type_names.append(name)
+        implements.extend(protocols)
+        if kind == "class" and protocols and extends is None:
+            extends = protocols[0]
+
+    extensions = []
+    for match in EXT_RE.finditer(code):
+        protocols = protocols_from_tail(match.group("tail") or "")
+        name = match.group("name").split(".")[-1]
+        extensions.append(
+            {
+                "name": name,
+                "visibility": visibility_from_mods(match.group(0)),
+                "line": line_number(code, match.start()),
+                "implements": protocols,
+            }
+        )
+        implements.extend(protocols)
+
+    methods = []
+    visibility = {}
+    method_hashes = {}
+    structural_hashes = {}
+    public_api = []
+    for match in FUNC_RE.finditer(code):
+        name = match.group("name").strip("`")
+        if name.startswith("test"):
+            continue
+        methods.append(name)
+        vis = visibility_from_mods(match.group("mods") or "")
+        visibility[name] = vis
+        item_hash = method_hash(code, match.start())
+        method_hashes[name] = item_hash
+        structural_hashes[name] = item_hash
+        if vis in {"open", "public"}:
+            public_api.append(name)
+
+    init_count = 0
+    for match in INIT_RE.finditer(code):
+        init_count += 1
+        name = "init" if init_count == 1 else f"init_{init_count}"
+        methods.append(name)
+        vis = visibility_from_mods(match.group("mods") or "")
+        visibility[name] = vis
+        if vis in {"open", "public"}:
+            public_api.append(name)
+
+    properties = []
+    for match in PROPERTY_RE.finditer(code):
+        name = match.group("name")
+        properties.append(f"{match.group('kind')} {name}")
+        vis = visibility_from_mods(match.group("mods") or "")
+        if vis in {"open", "public"}:
+            public_api.append(name)
+
+    imports = IMPORT_RE.findall(code)
+    internal_calls = sorted({m.group(1) for m in CALL_RE.finditer(code) if m.group(1) not in SKIP_CALLS})
+
+    namespace = None
+    if file_path:
+        namespace = "/".join(file_path.split("/")[:-1]) or None
+
+    result = {
+        "methods": dedupe(methods),
+        "type_name": type_names[0] if type_names else None,
+        "type_names": dedupe(type_names),
+        "type_declarations": declarations,
+        "extensions": dedupe(extensions),
+        "extends": extends,
+        "implements": dedupe(implements),
+        "registrations": [],
+        "namespace": namespace,
+        "imports": dedupe(imports),
+        "properties": dedupe(properties),
+        "method_hashes": method_hashes,
+        "structural_hashes": structural_hashes,
+        "visibility": visibility,
+        "unused_parameters": [],
+        "dead_code_markers": [],
+        "internal_calls": internal_calls,
+        "public_api": dedupe(public_api),
+        "symbols": {
+            "classes": [d["name"] for d in declarations if d["kind"] == "class"],
+            "structs": [d["name"] for d in declarations if d["kind"] == "struct"],
+            "enums": [d["name"] for d in declarations if d["kind"] == "enum"],
+            "protocols": [d["name"] for d in declarations if d["kind"] == "protocol"],
+            "actors": [d["name"] for d in declarations if d["kind"] == "actor"],
+            "extensions": [e["name"] for e in extensions],
+            "functions": dedupe(methods),
+            "properties": dedupe(properties),
+        },
+    }
+
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/swift/scripts/fingerprint.sh
+++ b/swift/scripts/fingerprint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Swift fingerprint script for homeboy audit.
+#
+# Input (JSON on stdin):
+#   {"file_path": "App/Model.swift", "content": "..."}
+#
+# Output (JSON on stdout): structural symbols used by homeboy audit.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "$SCRIPT_DIR/fingerprint.py"

--- a/swift/swift.json
+++ b/swift/swift.json
@@ -6,9 +6,10 @@
   "author": "Extra Chill",
   "provides": {
     "file_extensions": ["swift", "xcodeproj", "xcworkspace", "yml"],
-    "capabilities": ["validate"]
+    "capabilities": ["fingerprint", "validate"]
   },
   "scripts": {
+    "fingerprint": "scripts/fingerprint.sh",
     "validate": "scripts/validate.sh"
   },
   "platform": {

--- a/swift/tests/fingerprint-smoke.sh
+++ b/swift/tests/fingerprint-smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SWIFT_DIR="$ROOT_DIR/swift"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat > "$TMP_DIR/input.json" <<'JSON'
+{
+  "file_path": "HomeboyDesktop/App/Models/AuditViewModel.swift",
+  "content": "import SwiftUI\nimport Combine\n\npublic protocol AuditRunnable {\n    func runAudit()\n}\n\nfinal class AuditViewModel: ObservableObject, AuditRunnable {\n    @Published var status: String = \"idle\"\n    private let runner: AuditRunner\n\n    init(runner: AuditRunner) {\n        self.runner = runner\n    }\n\n    public func runAudit() {\n        refreshStatus()\n    }\n\n    private func refreshStatus() {\n        status = \"running\"\n    }\n}\n\nstruct AuditRunner {\n    let command: String\n}\n\nenum AuditState {\n    case idle\n    case running\n}\n\nextension AuditViewModel: Identifiable {\n    var id: String { status }\n}\n"
+}
+JSON
+
+bash "$SWIFT_DIR/scripts/fingerprint.sh" < "$TMP_DIR/input.json" > "$TMP_DIR/fingerprint.json"
+
+python3 - "$TMP_DIR/fingerprint.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+
+def assert_true(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+symbols = data["symbols"]
+assert_true("AuditViewModel" in symbols["classes"], "missing class symbol")
+assert_true("AuditRunner" in symbols["structs"], "missing struct symbol")
+assert_true("AuditState" in symbols["enums"], "missing enum symbol")
+assert_true("AuditRunnable" in symbols["protocols"], "missing protocol symbol")
+assert_true("AuditViewModel" in symbols["extensions"], "missing extension symbol")
+assert_true("runAudit" in data["methods"], "missing public function")
+assert_true("refreshStatus" in data["methods"], "missing private function")
+assert_true("init" in data["methods"], "missing initializer")
+assert_true("var status" in data["properties"], "missing property")
+assert_true(data["type_name"] == "AuditRunnable", "unexpected primary type")
+assert_true("ObservableObject" in data["implements"], "missing class protocol")
+assert_true("Identifiable" in data["implements"], "missing extension protocol")
+assert_true(data["namespace"] == "HomeboyDesktop/App/Models", "unexpected namespace")
+assert_true("SwiftUI" in data["imports"], "missing import")
+assert_true(data["visibility"]["runAudit"] == "public", "missing function visibility")
+assert_true("runAudit" in data["public_api"], "missing public API function")
+assert_true("refreshStatus" in data["internal_calls"], "missing internal call")
+assert_true(data["method_hashes"].get("runAudit"), "missing method hash")
+
+print("swift fingerprint smoke passed")
+PY

--- a/swift/tests/swift-extension-smoke.sh
+++ b/swift/tests/swift-extension-smoke.sh
@@ -44,7 +44,9 @@ assert_true("Tests" in mapping.get("test_dirs", []), "missing uppercase Tests di
 assert_true(mapping.get("test_file_pattern") == "{dir}/{name}Tests.{ext}", "unexpected test file pattern")
 
 capabilities = provides.get("capabilities", [])
+assert_true("fingerprint" in capabilities, "missing fingerprint capability")
 assert_true("validate" in capabilities, "missing validate capability")
+assert_true(manifest.get("scripts", {}).get("fingerprint") == "scripts/fingerprint.sh", "missing fingerprint script")
 assert_true(manifest.get("scripts", {}).get("validate") == "scripts/validate.sh", "missing validate script")
 assert_true(manifest.get("lint", {}).get("extension_script") == "scripts/lint-runner.sh", "missing lint runner")
 assert_true(manifest.get("test", {}).get("extension_script") == "scripts/test-runner.sh", "missing test runner")


### PR DESCRIPTION
## Summary
- Add a Swift fingerprint capability and runner that parses source text directly, without Xcode.
- Capture Swift declarations, extensions, functions, initializers, properties, imports, conformances, call references, and method hashes for `homeboy audit`.
- Add smoke coverage proving Swift symbols are emitted from a representative source file.

## Tests
- `bash swift/tests/swift-extension-smoke.sh`
- `bash swift/tests/fingerprint-smoke.sh`
- `bash swift/tests/validate-runner-smoke.sh`
- `bash swift/tests/lint-runner-smoke.sh`
- `bash swift/tests/script-runner-smoke.sh`
- `homeboy audit homeboy-desktop --path /Users/chubes/Developer/homeboy-desktop@verify-main` now scans 106 files and no longer reports the 95 skipped Swift source files.

Refs Extra-Chill/homeboy-desktop#27

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the Swift fingerprint runner, smoke tests, and live audit verification; Chris remains responsible for review and merge.
