### PR TITLE
feat(wordpress): declare remote path inference rules

### DIFF
--- a/tests/wordpress-remote-path-inference-smoke.sh
+++ b/tests/wordpress-remote-path-inference-smoke.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="$ROOT_DIR/wordpress/wordpress.json"
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq -- "$expected" "$file"; then
+        echo "Expected $file to contain: $expected" >&2
+        exit 1
+    fi
+}
+
+php -r 'json_decode(file_get_contents($argv[1]), true, 512, JSON_THROW_ON_ERROR);' "$MANIFEST"
+
+assert_contains "$MANIFEST" '"remote_path_inference"'
+assert_contains "$MANIFEST" '"file": "{{dir_name}}.php"'
+assert_contains "$MANIFEST" '"file": "{{id}}.php"'
+assert_contains "$MANIFEST" '"text": "Plugin Name:"'
+assert_contains "$MANIFEST" '"remote_path": "wp-content/plugins/{{dir_name}}"'
+assert_contains "$MANIFEST" '"file": "style.css"'
+assert_contains "$MANIFEST" '"text": "Theme Name:"'
+assert_contains "$MANIFEST" '"remote_path": "wp-content/themes/{{dir_name}}"'
+
+echo "wordpress remote path inference smoke passed"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -118,6 +118,20 @@
     ]
   },
   "deploy": {
+    "remote_path_inference": [
+      {
+        "when_file_contains": { "file": "{{dir_name}}.php", "text": "Plugin Name:" },
+        "remote_path": "wp-content/plugins/{{dir_name}}"
+      },
+      {
+        "when_file_contains": { "file": "{{id}}.php", "text": "Plugin Name:" },
+        "remote_path": "wp-content/plugins/{{dir_name}}"
+      },
+      {
+        "when_file_contains": { "file": "style.css", "text": "Theme Name:" },
+        "remote_path": "wp-content/themes/{{dir_name}}"
+      }
+    ],
     "verifications": [
       {
         "path_pattern": "/wp-content/plugins/",


### PR DESCRIPTION
## Summary
- Moves WordPress plugin/theme remote-path knowledge into the WordPress extension manifest.
- Adds a smoke test that pins the manifest contract Homeboy core consumes.

## Changes
- Adds deploy remote path inference rules for plugin headers in {{dir_name}}.php / {{id}}.php.
- Adds deploy remote path inference rule for theme headers in style.css.
- Adds wordpress-remote-path-inference smoke coverage.

## Tests
- bash tests/wordpress-lint-context-smoke.sh
- bash tests/runtime-helpers-smoke.sh
- bash tests/wordpress-remote-path-inference-smoke.sh

Refs Extra-Chill/homeboy#1783

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the manifest change and smoke test; Chris remains responsible for review and merge.