### PR TITLE
refactor(bench): use shared Homeboy helpers

### DIFF
--- a/nodejs/scripts/bench/bench-runner.mjs
+++ b/nodejs/scripts/bench/bench-runner.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// Node.js bench harness — workload discovery, iteration loop, percentile
-// math, and BenchResults envelope serialization.
+// Node.js bench harness — workload discovery and iteration loop. Shared
+// percentile math and BenchResults envelope helpers come from Homeboy core.
 //
 // CONTRACT
 //
@@ -37,10 +37,22 @@
 // Writes the BenchResults JSON envelope (homeboy/src/core/extension/
 // bench/parsing.rs::BenchResults shape) to HOMEBOY_BENCH_RESULTS_FILE.
 
-import { readdir, writeFile, mkdir } from 'node:fs/promises';
-import { resolve, relative, basename, dirname, delimiter } from 'node:path';
+import { readdir } from 'node:fs/promises';
+import { resolve, relative, basename, delimiter } from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { pathToFileURL } from 'node:url';
+
+const helperPath = process.env.HOMEBOY_RUNTIME_BENCH_HELPER_JS;
+if (!helperPath) {
+    console.error('FATAL: HOMEBOY_RUNTIME_BENCH_HELPER_JS is required');
+    process.exit(2);
+}
+
+const {
+    homeboyBenchPercentile,
+    homeboyBenchScenarioId,
+    homeboyWriteBenchResults,
+} = await import(pathToFileURL(helperPath).href);
 
 const PROJECT_PATH = process.env.HOMEBOY_COMPONENT_PATH;
 const COMPONENT_ID = process.env.HOMEBOY_COMPONENT_ID;
@@ -62,29 +74,6 @@ const TIMING_METRIC_KEYS = new Set([
 if (!PROJECT_PATH || !COMPONENT_ID || !RESULTS_FILE) {
     console.error('FATAL: missing required env vars (PROJECT_PATH/COMPONENT_ID/RESULTS_FILE)');
     process.exit(2);
-}
-
-// R-7 percentile — matches pg_bench_percentile() in the WP runner.
-function percentile(sortedMs, p) {
-    const n = sortedMs.length;
-    if (n === 0) return 0;
-    if (n === 1) return sortedMs[0];
-    const rank = p * (n - 1);
-    const lo = Math.floor(rank);
-    const hi = Math.ceil(rank);
-    if (lo === hi) return sortedMs[lo];
-    const frac = rank - lo;
-    return sortedMs[lo] * (1 - frac) + sortedMs[hi] * frac;
-}
-
-// "ColdBoot.bench.ts" → "cold-boot". Matches WP runner's slug rule.
-function scenarioId(file) {
-    return basename(file)
-        .replace(/\.bench\.(ts|mjs|cjs|js)$/, '')
-        .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '');
 }
 
 function validateWorkloadResult(value, iterationLabel) {
@@ -212,7 +201,7 @@ async function main() {
 
     if (LIST_ONLY) {
         const scenarios = files.map(({ file, source }) => ({
-            id: scenarioId(file),
+            id: homeboyBenchScenarioId(file, /\.bench\.(ts|mjs|cjs|js)$/),
             file: source === 'in_tree' ? relative(PROJECT_PATH, file) : file,
             source,
             iterations: 0,
@@ -237,7 +226,7 @@ async function main() {
 
     for (const workload of files) {
         const { file, source } = workload;
-        const id = scenarioId(file);
+        const id = homeboyBenchScenarioId(file, /\.bench\.(ts|mjs|cjs|js)$/);
         const rel = source === 'in_tree' ? relative(PROJECT_PATH, file) : file;
         process.stdout.write(`WORKLOAD_BEGIN: ${id} (${basename(file)})\n`);
 
@@ -256,9 +245,9 @@ async function main() {
         const t = result.timings;
         const timingMetrics = {
             mean_ms: t.reduce((a, b) => a + b, 0) / t.length,
-            p50_ms: percentile(t, 0.50),
-            p95_ms: percentile(t, 0.95),
-            p99_ms: percentile(t, 0.99),
+            p50_ms: homeboyBenchPercentile(t, 0.50),
+            p95_ms: homeboyBenchPercentile(t, 0.95),
+            p99_ms: homeboyBenchPercentile(t, 0.99),
             min_ms: t[0],
             max_ms: t[t.length - 1],
         };
@@ -273,18 +262,11 @@ async function main() {
         });
 
         process.stdout.write(
-            `WORKLOAD_DONE:  ${id}  p50=${percentile(t, 0.50).toFixed(2)}ms  p95=${percentile(t, 0.95).toFixed(2)}ms\n`
+            `WORKLOAD_DONE:  ${id}  p50=${homeboyBenchPercentile(t, 0.50).toFixed(2)}ms  p95=${homeboyBenchPercentile(t, 0.95).toFixed(2)}ms\n`
         );
     }
 
-    const envelope = {
-        component_id: COMPONENT_ID,
-        iterations: ITERATIONS,
-        scenarios,
-    };
-
-    await mkdir(dirname(RESULTS_FILE), { recursive: true });
-    await writeFile(RESULTS_FILE, JSON.stringify(envelope, null, 2));
+    await homeboyWriteBenchResults(RESULTS_FILE, COMPONENT_ID, ITERATIONS, scenarios);
 
     if (DEBUG) console.error(`DEBUG: results written to ${RESULTS_FILE}`);
 

--- a/nodejs/scripts/bench/bench-runner.sh
+++ b/nodejs/scripts/bench/bench-runner.sh
@@ -31,6 +31,7 @@ homeboy_resolve_context
 homeboy_require_package_json
 
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
+BENCH_HELPER_SH="${HOMEBOY_RUNTIME_BENCH_HELPER_SH:-${HOME}/.homeboy/runtime/bench-helper.sh}"
 # shellcheck source=/dev/null
 if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
     source "$FAILURE_TRAP_HELPER"
@@ -38,6 +39,13 @@ if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
 else
     FAILED_STEP=""
     FAILURE_OUTPUT=""
+fi
+# shellcheck source=/dev/null
+if [ -f "$BENCH_HELPER_SH" ]; then
+    source "$BENCH_HELPER_SH"
+else
+    echo "ERROR: Homeboy bench helper not found at ${BENCH_HELPER_SH}" >&2
+    exit 2
 fi
 
 ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-10}"
@@ -52,9 +60,7 @@ if [ ! -d "$BENCH_DIR" ] && [ -z "${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}" ]; then
     echo "⚠ No bench/ directory found at ${BENCH_DIR}"
     echo "  Skipping bench run — nothing to measure."
     echo ""
-    cat > "$RESULTS_FILE" <<EMPTY
-{"component_id":"${COMPONENT_ID}","iterations":0,"scenarios":[]}
-EMPTY
+    homeboy_write_empty_bench_results "$COMPONENT_ID" 0 "$RESULTS_FILE"
     exit 0
 fi
 
@@ -76,6 +82,7 @@ else
 fi
 
 export HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_FILE"
+export HOMEBOY_RUNTIME_BENCH_HELPER_JS="${HOMEBOY_RUNTIME_BENCH_HELPER_JS:-${HOME}/.homeboy/runtime/bench-helper.mjs}"
 export HOMEBOY_COMPONENT_ID="$COMPONENT_ID"
 export HOMEBOY_COMPONENT_PATH="$PROJECT_PATH"
 export HOMEBOY_BENCH_ITERATIONS="$ITERATIONS"

--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -35,6 +35,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
+BENCH_HELPER_SH="${HOMEBOY_RUNTIME_BENCH_HELPER_SH:-${HOME}/.homeboy/runtime/bench-helper.sh}"
+BENCH_HELPER_PHP_HOST="${HOMEBOY_RUNTIME_BENCH_HELPER_PHP:-${HOME}/.homeboy/runtime/bench-helper.php}"
+BENCH_HELPER_PHP_GUEST="/homeboy-runtime/bench-helper.php"
 PHP_PREFLIGHT_HELPER="${SCRIPT_DIR}/../lib/php-preflight.sh"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
 # shellcheck source=../lib/php-preflight.sh
@@ -52,6 +55,17 @@ if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
 else
     FAILED_STEP=""
     FAILURE_OUTPUT=""
+fi
+# shellcheck source=/dev/null
+if [ -f "$BENCH_HELPER_SH" ]; then
+    source "$BENCH_HELPER_SH"
+else
+    echo "ERROR: Homeboy bench helper not found at ${BENCH_HELPER_SH}" >&2
+    exit 2
+fi
+if [ ! -f "$BENCH_HELPER_PHP_HOST" ]; then
+    echo "ERROR: Homeboy PHP bench helper not found at ${BENCH_HELPER_PHP_HOST}" >&2
+    exit 2
 fi
 
 # Component resolution — same priority order as test-runner-playground.sh
@@ -119,9 +133,7 @@ if [ ! -d "$BENCH_DIR" ] && [ -z "${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}" ] && [ "$B
     # Emit an empty-but-valid BenchResults so homeboy core's parser
     # doesn't see a missing file and treat the run as a crash.
     if [ -n "${HOMEBOY_BENCH_RESULTS_FILE:-}" ]; then
-        cat > "${HOMEBOY_BENCH_RESULTS_FILE}" <<EMPTY
-{"component_id":"${COMPONENT_ID}","iterations":0,"scenarios":[]}
-EMPTY
+        homeboy_write_empty_bench_results "$COMPONENT_ID" 0 "${HOMEBOY_BENCH_RESULTS_FILE}"
     fi
     exit 0
 fi
@@ -267,6 +279,7 @@ if [ -f "$PLUGIN_DB_PHP" ]; then
 fi
 
 MOUNT_ARGS+=("--mount" "${EXTENSION_PATH}:/homeboy-extension")
+MOUNT_ARGS+=("--mount" "${BENCH_HELPER_PHP_HOST}:${BENCH_HELPER_PHP_GUEST}")
 
 # Rig-private workloads are host paths supplied by homeboy core through a
 # PATH-style list. Mount each file into Playground and let the PHP runner tag
@@ -407,6 +420,7 @@ sed \
     -e "s|{{CONCURRENCY}}|${CONCURRENCY}|g" \
     -e "s|{{LIST_ONLY}}|${LIST_ONLY_PHP}|g" \
     -e "s|{{RESULT_SUFFIX}}|${RESULT_SUFFIX}|g" \
+    -e "s|{{BENCH_HELPER_PHP}}|${BENCH_HELPER_PHP_GUEST}|g" \
     -e "s|{{BENCH_SITE_MODE}}|${BENCH_SITE_MODE}|g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON}${WP_CONFIG_DEFINES_DELIM}g" \

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -85,6 +85,7 @@ if (!defined('HOMEBOY_BENCH_LIST_ONLY')) {
 }
 
 require_once '/homeboy-extension/scripts/lib/playground-bootstrap.php';
+require_once '{{BENCH_HELPER_PHP}}';
 
 pg_install_diagnostics_handlers();
 
@@ -143,15 +144,6 @@ if ($installed_site_mode) {
 pg_run_load_deps_stage(['dep_mounts' => '{{PLAYGROUND_DEP_MOUNTS}}']);
 pg_run_load_component_stage(['plugin_path' => $plugin_path]);
 
-/** Slugify a workload basename into a scenario id ("BulkImport.php" → "bulk-import"). */
-function pg_bench_scenario_id(string $basename): string {
-    $name = preg_replace('/\.php$/i', '', $basename);
-    $name = preg_replace('/([a-z0-9])([A-Z])/', '$1-$2', $name);
-    $name = strtolower($name);
-    $name = preg_replace('/[^a-z0-9]+/', '-', $name);
-    return trim($name, '-');
-}
-
 /**
  * Normalize the optional bench_workloads setting into scenario IDs.
  *
@@ -179,7 +171,7 @@ function pg_bench_normalize_workload_filter(string $raw): array {
         if (!is_scalar($value)) {
             throw new RuntimeException('bench_workloads entries must be strings');
         }
-        $id = pg_bench_scenario_id((string) $value);
+        $id = homeboy_bench_scenario_id((string) $value);
         if ($id !== '' && !in_array($id, $normalized, true)) {
             $normalized[] = $id;
         }
@@ -239,7 +231,7 @@ try {
         $filtered_workload_files = [];
 
         foreach ($workload_files as $workload_file) {
-            $scenario_id = pg_bench_scenario_id(basename($workload_file));
+            $scenario_id = homeboy_bench_scenario_id(basename($workload_file));
             $available_workloads[] = $scenario_id;
             if (isset($requested_lookup[$scenario_id])) {
                 $filtered_workload_files[] = $workload_file;
@@ -273,31 +265,6 @@ try {
 // ---------------------------------------------------------------------------
 
 /**
- * Compute percentile (linear interpolation) over a sorted ascending array.
- *
- * Uses the same definition homeboy core's parser expects (R-7 / Excel-style):
- * given p in [0, 1], the position is p * (N - 1) and the value is the
- * linear interpolation between the floor and ceil indices.
- */
-function pg_bench_percentile(array $sorted_ms, float $p): float {
-    $n = count($sorted_ms);
-    if ($n === 0) {
-        return 0.0;
-    }
-    if ($n === 1) {
-        return $sorted_ms[0];
-    }
-    $rank = $p * ($n - 1);
-    $lo = (int) floor($rank);
-    $hi = (int) ceil($rank);
-    if ($lo === $hi) {
-        return $sorted_ms[$lo];
-    }
-    $frac = $rank - $lo;
-    return $sorted_ms[$lo] * (1 - $frac) + $sorted_ms[$hi] * $frac;
-}
-
-/**
  * Aggregate a numeric sample set into the flat BenchMetrics key shape.
  *
  * `$suffix` should include any unit (for example `_ms` for duration metrics)
@@ -312,9 +279,9 @@ function pg_bench_aggregate_metric(array $samples, string $prefix, string $suffi
 
     return [
         "{$key_prefix}mean{$suffix}" => $mean,
-        "{$key_prefix}p50{$suffix}" => pg_bench_percentile($samples, 0.50),
-        "{$key_prefix}p95{$suffix}" => pg_bench_percentile($samples, 0.95),
-        "{$key_prefix}p99{$suffix}" => pg_bench_percentile($samples, 0.99),
+        "{$key_prefix}p50{$suffix}" => homeboy_bench_percentile($samples, 0.50),
+        "{$key_prefix}p95{$suffix}" => homeboy_bench_percentile($samples, 0.95),
+        "{$key_prefix}p99{$suffix}" => homeboy_bench_percentile($samples, 0.99),
         "{$key_prefix}min{$suffix}" => $count > 0 ? $samples[0] : 0.0,
         "{$key_prefix}max{$suffix}" => $count > 0 ? $samples[$count - 1] : 0.0,
     ];
@@ -360,7 +327,7 @@ if ($iterations_per_workload < 1) {
 if (HOMEBOY_BENCH_LIST_ONLY) {
     foreach ($workload_files as $workload_file) {
         $basename = basename($workload_file);
-        $scenario_id = pg_bench_scenario_id($basename);
+        $scenario_id = homeboy_bench_scenario_id($basename);
         $source = $workload_sources[$workload_file] ?? 'in_tree';
         $relative_file = $source === 'in_tree'
             ? substr($workload_file, strlen($plugin_path) + 1)
@@ -377,11 +344,7 @@ if (HOMEBOY_BENCH_LIST_ONLY) {
         ];
     }
 
-    file_put_contents("$plugin_path/.pg-bench-results{{RESULT_SUFFIX}}.json", json_encode([
-        'component_id' => '{{COMPONENT_ID}}',
-        'iterations' => 0,
-        'scenarios' => $scenarios,
-    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    homeboy_write_bench_results("$plugin_path/.pg-bench-results{{RESULT_SUFFIX}}.json", '{{COMPONENT_ID}}', 0, $scenarios);
     pg_log('LIST_ONLY: scenarios=' . count($scenarios));
     exit(0);
 }
@@ -389,7 +352,7 @@ if (HOMEBOY_BENCH_LIST_ONLY) {
 try {
     foreach ($workload_files as $workload_file) {
         $basename = basename($workload_file);
-        $scenario_id = pg_bench_scenario_id($basename);
+        $scenario_id = homeboy_bench_scenario_id($basename);
         // Path relative to the plugin root for the BenchResults envelope.
         $source = $workload_sources[$workload_file] ?? 'in_tree';
         $relative_file = $source === 'in_tree'
@@ -467,9 +430,9 @@ try {
         pg_log(sprintf(
             "WORKLOAD_OK: %s p50=%.2fms p95=%.2fms p99=%.2fms",
             $scenario_id,
-            pg_bench_percentile($timings_ms, 0.50),
-            pg_bench_percentile($timings_ms, 0.95),
-            pg_bench_percentile($timings_ms, 0.99)
+            homeboy_bench_percentile($timings_ms, 0.50),
+            homeboy_bench_percentile($timings_ms, 0.95),
+            homeboy_bench_percentile($timings_ms, 0.99)
         ));
     }
     pg_stage_ok('run_workloads');
@@ -511,18 +474,7 @@ try {
     }
 
     $results_path = "$plugin_path/.pg-bench-results{{RESULT_SUFFIX}}.json";
-    $envelope = [
-        'component_id' => '{{COMPONENT_ID}}',
-        'iterations' => $iterations_per_workload,
-        'scenarios' => $scenarios,
-    ];
-    $json = json_encode($envelope, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-    if ($json === false) {
-        throw new RuntimeException("json_encode failed: " . json_last_error_msg());
-    }
-    if (file_put_contents($results_path, $json) === false) {
-        throw new RuntimeException("failed to write $results_path");
-    }
+    homeboy_write_bench_results($results_path, '{{COMPONENT_ID}}', $iterations_per_workload, $scenarios);
     pg_log("RESULTS_EMITTED: $results_path (" . count($scenarios) . " scenarios)");
     pg_stage_ok('emit_results');
 } catch (Throwable $e) {


### PR DESCRIPTION
## Summary
- Migrates Node and WordPress bench runners onto Homeboy's shared runtime bench helpers.
- Removes duplicated percentile math, scenario slugging, and BenchResults envelope writing from runner scripts.

## Changes
- Node runner imports `HOMEBOY_RUNTIME_BENCH_HELPER_JS` for percentile, scenario ID, and result writing helpers.
- Node and WordPress shell entrypoints use `HOMEBOY_RUNTIME_BENCH_HELPER_SH` for empty-valid BenchResults envelopes.
- WordPress Playground runner mounts `HOMEBOY_RUNTIME_BENCH_HELPER_PHP` and uses it for scenario IDs, R-7 percentiles, and envelope serialization.

## Tests
- `HOMEBOY_RUNTIME_BENCH_HELPER_JS=/Users/chubes/Developer/homeboy@bench-helper-contract/src/core/extension/runtime/bench-helper.mjs HOMEBOY_RUNTIME_BENCH_HELPER_SH=/Users/chubes/Developer/homeboy@bench-helper-contract/src/core/extension/runtime/bench-helper.sh bash nodejs/scripts/bench/nodejs-bench-custom-metrics-smoke.sh`
- `HOMEBOY_RUNTIME_BENCH_HELPER_JS=/Users/chubes/Developer/homeboy@bench-helper-contract/src/core/extension/runtime/bench-helper.mjs HOMEBOY_RUNTIME_BENCH_HELPER_SH=/Users/chubes/Developer/homeboy@bench-helper-contract/src/core/extension/runtime/bench-helper.sh HOMEBOY_RUNTIME_BENCH_HELPER_PHP=/Users/chubes/Developer/homeboy@bench-helper-contract/src/core/extension/runtime/bench-helper.php bash wordpress/scripts/bench/playground-bench-smoke.sh`
- `php -l wordpress/scripts/bench/playground-bench-runner.php && bash -n wordpress/scripts/bench/bench-runner-playground.sh && node --check nodejs/scripts/bench/bench-runner.mjs`
- `git diff --check`

Refs Extra-Chill/homeboy#1780
Depends on Extra-Chill/homeboy#1790

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner migration, fixed the remaining stale WordPress helper callsites, and ran the Node/WordPress bench smokes. Chris remains responsible for review and merge.