### PR TITLE
feat(wordpress): declare cli auto flags

### DIFF
--- a/wordpress/tests/wp-cli-auto-flags-smoke.sh
+++ b/wordpress/tests/wp-cli-auto-flags-smoke.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MANIFEST_PATH="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/wordpress.json}"
+
+python3 - "$MANIFEST_PATH" <<'PY'
+import json
+import sys
+
+manifest_path = sys.argv[1]
+with open(manifest_path, encoding="utf-8") as handle:
+    manifest = json.load(handle)
+
+auto_flags = manifest.get("cli", {}).get("auto_flags", [])
+expected = {
+    "when": {"server_user": "root"},
+    "flag": "--allow-root",
+}
+
+if expected not in auto_flags:
+    raise SystemExit("wordpress cli.auto_flags must declare root => --allow-root")
+
+print("wordpress cli auto_flags smoke passed")
+PY

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -287,6 +287,14 @@
     "settings_flags": {
       "user": "--user={{value}}"
     },
+    "auto_flags": [
+      {
+        "when": {
+          "server_user": "root"
+        },
+        "flag": "--allow-root"
+      }
+    ],
     "help": {
       "project_id_help": "Project ID (use 'homeboy project list'). For multisite: project:subtarget",
       "args_help": "WP-CLI command and arguments (space-separated, not quoted)",


### PR DESCRIPTION
## Summary
- Moves WordPress' root-user WP-CLI behavior into the extension manifest using Homeboy's new `cli.auto_flags` support.
- Keeps `--allow-root` owned by the WordPress extension instead of Homeboy core.

## Changes
- Adds `cli.auto_flags` to `wordpress/wordpress.json` with `server_user: root` -> `--allow-root`.
- Adds a lightweight manifest smoke test to pin the WordPress rule.

## Tests
- `wordpress/tests/wp-cli-auto-flags-smoke.sh`
- `homeboy lint homeboy-extensions --path "/Users/chubes/Developer/homeboy-extensions@wordpress-cli-auto-flags"` could not run because the local Homeboy component has no extensions configured; the repo-local manifest smoke above passed.

Refs Extra-Chill/homeboy#1781
Refs Extra-Chill/homeboy#1791

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated the WordPress extension manifest, added a focused smoke test, and ran verification. Chris remains responsible for review and merge.
