### PR TITLE
feat(test): declare drift selection config

### DIFF
--- a/go/go.json
+++ b/go/go.json
@@ -27,7 +27,13 @@
     "extension_script": "scripts/lint-runner.sh"
   },
   "test": {
-    "extension_script": "scripts/test-runner.sh"
+    "extension_script": "scripts/test-runner.sh",
+    "drift": {
+      "source_dirs": ["."],
+      "test_dirs": ["."],
+      "file_extensions": ["go"],
+      "inline_tests": false
+    }
   },
   "cli": {
     "tool": "go",

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -17,7 +17,13 @@
     "extension_script": "scripts/lint-runner.sh"
   },
   "test": {
-    "extension_script": "scripts/test-runner.sh"
+    "extension_script": "scripts/test-runner.sh",
+    "drift": {
+      "source_dirs": ["src"],
+      "test_dirs": ["tests"],
+      "file_extensions": ["rs"],
+      "inline_tests": true
+    }
   },
   "bench": {
     "extension_script": "scripts/bench/bench-runner.sh"

--- a/swift/swift.json
+++ b/swift/swift.json
@@ -56,7 +56,13 @@
     "extension_script": "scripts/lint-runner.sh"
   },
   "test": {
-    "extension_script": "scripts/test-runner.sh"
+    "extension_script": "scripts/test-runner.sh",
+    "drift": {
+      "source_dirs": [".", "Sources"],
+      "test_dirs": ["tests", "Tests"],
+      "file_extensions": ["swift"],
+      "inline_tests": false
+    }
   },
   "executable": {
     "runtime": {

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -117,6 +117,14 @@
       "DEPLOY_OWNER=$(stat -c '%U:%G' {{install_dir}} 2>/dev/null || stat -f '%Su:%Sg' {{install_dir}} 2>/dev/null) && case \"$DEPLOY_OWNER\" in root:root) echo 'WARNING: {{install_dir}} is owned by root:root. PHP-FPM (www-data) may not be able to read plugin files.' && echo '  Fix: homeboy component set {{component_id}} remote_owner www-data:www-data' ;; esac || true"
     ]
   },
+  "test": {
+    "drift": {
+      "source_dirs": ["src", "inc", "lib"],
+      "test_dirs": ["tests"],
+      "file_extensions": ["php"],
+      "inline_tests": false
+    }
+  },
   "deploy": {
     "remote_path_inference": [
       {


### PR DESCRIPTION
## Summary
- Add explicit `test.drift` metadata to shipped extensions so Homeboy core can resolve changed-test/drift selection without language hardcodes.
- Preserve the existing Rust and WordPress drift behavior while making Go and Swift support declarative too.

## Changes
- Adds Rust drift config for `src/**/*.rs` and `tests/**/*.rs` with inline tests enabled.
- Adds WordPress drift config matching the prior PHP defaults: `src`, `inc`, and `lib` sources with `tests/**/*.php` tests.
- Adds Go and Swift drift config so those extensions can participate without core changes.

## Tests
- `python3 -m json.tool rust/rust.json >/dev/null && python3 -m json.tool wordpress/wordpress.json >/dev/null && python3 -m json.tool go/go.json >/dev/null && python3 -m json.tool swift/swift.json >/dev/null`

Refs Extra-Chill/homeboy#1782

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added manifest config, validated JSON, and drafted this PR. Chris remains responsible for review and merge decisions.