### PR TITLE
feat(wordpress): add component env detector

### DIFF
--- a/wordpress/scripts/env/detect.sh
+++ b/wordpress/scripts/env/detect.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+
+def header_value(path, key):
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            for index, line in enumerate(handle):
+                if index >= 100:
+                    break
+                marker = key + ":"
+                if marker in line:
+                    value = line.split(marker, 1)[1].strip()
+                    if value:
+                        return value
+    except OSError:
+        return None
+    return None
+
+
+root = Path.cwd()
+php = None
+
+style = root / "style.css"
+if style.exists() and header_value(style, "Theme Name"):
+    php = header_value(style, "Requires PHP")
+
+if php is None:
+    for candidate in sorted(root.glob("*.php")):
+        if not header_value(candidate, "Plugin Name"):
+            continue
+        php = header_value(candidate, "Requires PHP")
+        break
+
+output = {}
+if php:
+    output["php"] = php
+
+print(json.dumps(output, separators=(",", ":")))
+PY

--- a/wordpress/tests/component-env-detector-smoke.sh
+++ b/wordpress/tests/component-env-detector-smoke.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DETECTOR="${EXTENSION_DIR}/scripts/env/detect.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_json_php() {
+    local expected="$1"
+    local actual="$2"
+    python3 - "$expected" "$actual" <<'PY'
+import json
+import sys
+
+expected = sys.argv[1]
+data = json.loads(sys.argv[2])
+if expected:
+    assert data == {"php": expected}, data
+else:
+    assert data == {}, data
+PY
+}
+
+mkdir -p "${TMPDIR}/plugin"
+cat > "${TMPDIR}/plugin/demo.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Demo Plugin
+ * Requires PHP: 8.1
+ */
+PHP
+
+actual="$(cd "${TMPDIR}/plugin" && "$DETECTOR")"
+assert_json_php "8.1" "$actual"
+
+mkdir -p "${TMPDIR}/theme"
+cat > "${TMPDIR}/theme/style.css" <<'CSS'
+/*
+Theme Name: Demo Theme
+Requires PHP: 8.2
+*/
+CSS
+
+actual="$(cd "${TMPDIR}/theme" && "$DETECTOR")"
+assert_json_php "8.2" "$actual"
+
+mkdir -p "${TMPDIR}/no-requires"
+cat > "${TMPDIR}/no-requires/demo.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Demo Plugin
+ */
+PHP
+
+actual="$(cd "${TMPDIR}/no-requires" && "$DETECTOR")"
+assert_json_php "" "$actual"
+
+echo "component env detector smoke passed"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -14,6 +14,9 @@
     "crossref": "scripts/test/crossref.php",
     "validate": "scripts/validation/validate-syntax.sh"
   },
+  "component_env": {
+    "detect_script": "scripts/env/detect.sh"
+  },
   "platform": {
     "config_schema": "wordpress",
     "discovery": {


### PR DESCRIPTION
## Summary
- Adds the WordPress implementation of Homeboy's new extension-owned component environment detector.
- Keeps WordPress `Requires PHP` header parsing in the WordPress extension instead of Homeboy core.

## Changes
- Declares `component_env.detect_script` in `wordpress/wordpress.json`.
- Adds `wordpress/scripts/env/detect.sh`, which detects plugin/theme headers and emits `{"php":"..."}` JSON when `Requires PHP` is present.
- Adds a smoke test covering plugin, theme, and no-header cases.

## Tests
- `wordpress/tests/component-env-detector-smoke.sh`
- `bash -n wordpress/scripts/env/detect.sh wordpress/tests/component-env-detector-smoke.sh`
- `homeboy audit homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@add-wordpress-component-env-detector --changed-since origin/main`

Refs Extra-Chill/homeboy#1779

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the WordPress detector script, manifest wiring, and smoke coverage; Chris retains responsibility for review and merge.
