### PR TITLE
fix(nodejs): import bench list file helpers

### DIFF
--- a/nodejs/scripts/bench/bench-runner.mjs
+++ b/nodejs/scripts/bench/bench-runner.mjs
@@ -37,8 +37,8 @@
 // Writes the BenchResults JSON envelope (homeboy/src/core/extension/
 // bench/parsing.rs::BenchResults shape) to HOMEBOY_BENCH_RESULTS_FILE.
 
-import { readdir } from 'node:fs/promises';
-import { resolve, relative, basename, delimiter } from 'node:path';
+import { mkdir, readdir, writeFile } from 'node:fs/promises';
+import { resolve, relative, basename, delimiter, dirname } from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { pathToFileURL } from 'node:url';
 


### PR DESCRIPTION
## Summary
- Import the `mkdir`, `writeFile`, and `dirname` helpers used by the Node.js bench runner's list-only path.
- Unblocks `homeboy bench list` for Node.js components and rig-declared Node workloads.

## Tests
- `node --check nodejs/scripts/bench/bench-runner.mjs`
- Verified with Homeboy PR #1804 by temporarily pointing the installed `nodejs` extension at this worktree:
  - `./target/release/homeboy bench list --rig studio-bfb`
  - `./target/release/homeboy bench list --rig studio-agent-sdk`
- `homeboy audit homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@fix-nodejs-bench-list-imports --changed-since origin/main`

## Notes
- `homeboy lint homeboy-extensions --path ... --changed-since origin/main` is currently unavailable because the component has no configured lint extension.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing and patching the Node.js bench list-only import failure; Chris remains responsible for review and merge.