### PR TITLE
fix(wordpress): resolve Playground extension mount paths

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -40,6 +40,7 @@ BENCH_HELPER_PHP_HOST="${HOMEBOY_RUNTIME_BENCH_HELPER_PHP:-${HOME}/.homeboy/runt
 BENCH_HELPER_PHP_GUEST="/homeboy-runtime/bench-helper.php"
 PHP_PREFLIGHT_HELPER="${SCRIPT_DIR}/../lib/php-preflight.sh"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
+PLAYGROUND_PATHS_HELPER="${SCRIPT_DIR}/../lib/playground-paths.sh"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context --component-alias PLUGIN_PATH
@@ -51,6 +52,8 @@ fi
 if [ -f "$DEPENDENCY_HELPER" ]; then
     source "$DEPENDENCY_HELPER"
 fi
+# shellcheck source=../lib/playground-paths.sh
+source "$PLAYGROUND_PATHS_HELPER"
 # shellcheck source=/dev/null
 if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
     source "$FAILURE_TRAP_HELPER"
@@ -268,7 +271,8 @@ if [ -f "$PLUGIN_DB_PHP" ]; then
     MOUNT_ARGS+=("--mount" "${PLUGIN_DB_PHP}:/wordpress/wp-content/db.php")
 fi
 
-MOUNT_ARGS+=("--mount" "${EXTENSION_PATH}:/homeboy-extension")
+EXTENSION_MOUNT_PATH="$(homeboy_playground_resolve_mount_path "$EXTENSION_PATH")"
+MOUNT_ARGS+=("--mount" "${EXTENSION_MOUNT_PATH}:/homeboy-extension")
 MOUNT_ARGS+=("--mount" "${BENCH_HELPER_PHP_HOST}:${BENCH_HELPER_PHP_GUEST}")
 
 # Rig-private workloads are host paths supplied by homeboy core through a

--- a/wordpress/scripts/lib/playground-paths.sh
+++ b/wordpress/scripts/lib/playground-paths.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Resolve a host path before mounting it into WordPress Playground. Playground's
+# PHP-WASM VFS does not reliably expose symlinked mount roots unless the host
+# path is resolved first.
+homeboy_playground_resolve_mount_path() {
+    local host_path="$1"
+
+    if [ -d "$host_path" ]; then
+        (cd "$host_path" && pwd -P)
+        return
+    fi
+
+    local parent
+    local basename
+    parent="$(dirname "$host_path")"
+    basename="$(basename "$host_path")"
+
+    if [ -d "$parent" ]; then
+        printf '%s/%s\n' "$(cd "$parent" && pwd -P)" "$basename"
+        return
+    fi
+
+    printf '%s\n' "$host_path"
+}

--- a/wordpress/scripts/test/playground-extension-mount-smoke.sh
+++ b/wordpress/scripts/test/playground-extension-mount-smoke.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Playground extension mount smoke test.
+#
+# Verifies a symlinked Homeboy WordPress extension path is resolved before it is
+# mounted, so files under /homeboy-extension are visible inside PHP-WASM.
+#
+# Usage: bash wordpress/scripts/test/playground-extension-mount-smoke.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PLAYGROUND_CLI="${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli"
+PLAYGROUND_PATHS_HELPER="${SCRIPT_DIR}/../lib/playground-paths.sh"
+
+# shellcheck source=../lib/playground-paths.sh
+source "$PLAYGROUND_PATHS_HELPER"
+
+if [ ! -f "$PLAYGROUND_CLI" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-extension-link.XXXXXX")"
+RUNNER_TMPFILE=""
+cleanup() {
+    rm -rf "$TMP_ROOT"
+    if [ -n "$RUNNER_TMPFILE" ]; then
+        rm -f "$RUNNER_TMPFILE"
+    fi
+}
+trap cleanup EXIT
+
+LINK_PATH="${TMP_ROOT}/wordpress-extension"
+ln -s "$EXTENSION_PATH" "$LINK_PATH"
+
+RESOLVED_PATH="$(homeboy_playground_resolve_mount_path "$LINK_PATH")"
+if [ "$RESOLVED_PATH" = "$LINK_PATH" ]; then
+    echo "ERROR: expected symlink path to resolve before mounting" >&2
+    exit 1
+fi
+
+if [ ! -f "${RESOLVED_PATH}/scripts/lib/playground-bootstrap.php" ]; then
+    echo "ERROR: resolved extension path does not contain playground-bootstrap.php: ${RESOLVED_PATH}" >&2
+    exit 1
+fi
+
+RUNNER_TMPFILE="$(mktemp "${TMPDIR:-/tmp}/pg-extension-mount.XXXXXX.php")"
+cat > "$RUNNER_TMPFILE" <<'PHP'
+<?php
+$path = '/homeboy-extension/scripts/lib/playground-bootstrap.php';
+echo 'exists=' . ( file_exists( $path ) ? 'yes' : 'no' ) . PHP_EOL;
+PHP
+
+echo "============================================"
+echo "Playground extension mount smoke test"
+echo "============================================"
+echo "Symlink:  $LINK_PATH"
+echo "Resolved: $RESOLVED_PATH"
+echo ""
+
+OUTPUT=$("$PLAYGROUND_CLI" php \
+    --mount "${RESOLVED_PATH}:/homeboy-extension" \
+    --mount "${RUNNER_TMPFILE}:/runner.php" \
+    --wp=6.9 \
+    --verbosity=quiet \
+    -- /runner.php)
+
+printf '%s\n' "$OUTPUT"
+
+if ! printf '%s\n' "$OUTPUT" | grep -q 'exists=yes'; then
+    echo "ERROR: expected playground-bootstrap.php to be visible in Playground VFS" >&2
+    exit 1
+fi
+
+echo "============================================"
+echo "✓ Playground extension mount smoke test PASSED"
+echo "============================================"

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -44,6 +44,7 @@ RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/../lib/runner
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
 PHP_PREFLIGHT_HELPER="${SCRIPT_DIR}/../lib/php-preflight.sh"
+PLAYGROUND_PATHS_HELPER="${SCRIPT_DIR}/../lib/playground-paths.sh"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context --component-alias PLUGIN_PATH
@@ -59,6 +60,8 @@ fi
 if [ -f "$PHP_PREFLIGHT_HELPER" ]; then
     source "$PHP_PREFLIGHT_HELPER"
 fi
+# shellcheck source=../lib/playground-paths.sh
+source "$PLAYGROUND_PATHS_HELPER"
 # shellcheck source=/dev/null
 if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
     source "$FAILURE_TRAP_HELPER"
@@ -201,7 +204,8 @@ if [ -f "$PLUGIN_DB_PHP" ]; then
     fi
 fi
 
-MOUNT_ARGS+=("--mount" "${EXTENSION_PATH}:/homeboy-extension")
+EXTENSION_MOUNT_PATH="$(homeboy_playground_resolve_mount_path "$EXTENSION_PATH")"
+MOUNT_ARGS+=("--mount" "${EXTENSION_MOUNT_PATH}:/homeboy-extension")
 
 PLAYGROUND_DEP_MOUNTS=""
 if [ -n "$DEPENDENCY_PATHS" ]; then


### PR DESCRIPTION
## Summary
- Resolve the WordPress extension path before mounting it into WordPress Playground so linked/symlinked Homeboy extension installs expose `/homeboy-extension` correctly.

## Changes
- Added a shared Playground mount-path helper that resolves directory symlinks portably with `pwd -P`.
- Updated both the Playground test runner and bench runner to mount the resolved extension path.
- Added a focused smoke test that mounts a symlinked extension root and verifies `playground-bootstrap.php` is visible inside PHP-WASM.

## Tests
- `bash -n wordpress/scripts/lib/playground-paths.sh wordpress/scripts/test/test-runner-playground.sh wordpress/scripts/bench/bench-runner-playground.sh wordpress/scripts/test/playground-extension-mount-smoke.sh`
- `bash wordpress/scripts/test/playground-extension-mount-smoke.sh`
- `bash wordpress/scripts/test/playground-dropin-smoke.sh`
- `bash wordpress/scripts/bench/playground-bench-smoke.sh`
- Symlinked runner repro: `HOMEBOY_EXTENSION_PATH=<symlink> bash wordpress/scripts/test/test-runner-playground.sh`
- Symlinked bench repro: `HOMEBOY_EXTENSION_PATH=<symlink> bash wordpress/scripts/bench/bench-runner.sh`

Blocked check:
- `homeboy test data-machine --path /Users/chubes/Developer/data-machine@feat-ai-request-metadata-guardrails` currently fails before the extension runner with `validation.invalid_json` because that worktree's `homeboy.json` has a duplicate `test` field.
- `homeboy lint homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-playground-linked-extension` fails because the repo is not configured as a Homeboy component with lint extensions.

Closes #313

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Implemented the runner path-resolution fix, added the smoke coverage, and ran validation. Chris remains responsible for review and merge decisions.
