### PR TITLE
fix(wordpress): remove duplicate test config

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -120,14 +120,6 @@
       "DEPLOY_OWNER=$(stat -c '%U:%G' {{install_dir}} 2>/dev/null || stat -f '%Su:%Sg' {{install_dir}} 2>/dev/null) && case \"$DEPLOY_OWNER\" in root:root) echo 'WARNING: {{install_dir}} is owned by root:root. PHP-FPM (www-data) may not be able to read plugin files.' && echo '  Fix: homeboy component set {{component_id}} remote_owner www-data:www-data' ;; esac || true"
     ]
   },
-  "test": {
-    "drift": {
-      "source_dirs": ["src", "inc", "lib"],
-      "test_dirs": ["tests"],
-      "file_extensions": ["php"],
-      "inline_tests": false
-    }
-  },
   "deploy": {
     "remote_path_inference": [
       {
@@ -351,6 +343,12 @@
     "extension_script": "scripts/lint/lint-runner.sh"
   },
   "test": {
+    "drift": {
+      "source_dirs": ["src", "inc", "lib"],
+      "test_dirs": ["tests"],
+      "file_extensions": ["php"],
+      "inline_tests": false
+    },
     "extension_script": "scripts/test/test-runner.sh"
   },
   "bench": {


### PR DESCRIPTION
## Summary
- Merge the WordPress extension's drift test settings into the existing `test` block.
- Removes the duplicate top-level `test` key that made `wordpress.json` invalid for Homeboy's strict parser.

## Tests
- `php -r 'json_decode(file_get_contents("wordpress/wordpress.json"), true); if (json_last_error()) exit(1);'`
- `HOME=$(mktemp -d) homeboy extension install /Users/chubes/Developer/homeboy-extensions@fix-wordpress-extension-duplicate-test/wordpress --id wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the CI parse failure, made the minimal JSON config fix, and validated local extension install.
