### PR TITLE
fix(nodejs): preserve bench artifacts

### DIFF
--- a/nodejs/scripts/bench/bench-runner.mjs
+++ b/nodejs/scripts/bench/bench-runner.mjs
@@ -14,9 +14,10 @@
 //
 // Discovers `bench/**/*.bench.{ts,mjs,js}` under the project root.
 // Each workload file must export a default async function. The function may
-// return `{ metrics: Record<string, number> }` to report workload-owned custom
-// metrics, which are averaged across measured iterations and merged beside the
-// dispatcher-owned timing metrics.
+// return `{ metrics: Record<string, number>, artifacts: Record<string, object> }`
+// to report workload-owned custom metrics and artifacts. Metrics are averaged
+// across measured iterations and merged beside the dispatcher-owned timing
+// metrics; artifacts are preserved under the scenario in the results envelope.
 //
 //     // bench/cold-boot.bench.ts
 //     export default async function () {
@@ -93,31 +94,72 @@ function parseWarmupIterations(value) {
 
 function validateWorkloadResult(value, iterationLabel) {
     if (value === undefined) {
-        return {};
+        return { metrics: {}, artifacts: {} };
     }
 
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
         throw new Error(`${iterationLabel} returned invalid result shape (expected undefined or an object)`);
     }
 
-    const { metrics } = value;
-    if (metrics === undefined) {
-        return {};
-    }
+    const { metrics, artifacts } = value;
 
-    if (!metrics || typeof metrics !== 'object' || Array.isArray(metrics)) {
+    if (metrics !== undefined && (!metrics || typeof metrics !== 'object' || Array.isArray(metrics))) {
         throw new Error(`${iterationLabel} returned invalid metrics shape (expected an object)`);
     }
 
-    const validated = {};
-    for (const [key, metricValue] of Object.entries(metrics)) {
+    const validatedMetrics = {};
+    for (const [key, metricValue] of Object.entries(metrics || {})) {
         if (TIMING_METRIC_KEYS.has(key)) {
             throw new Error(`${iterationLabel} returned metric "${key}", which is owned by the bench dispatcher`);
         }
         if (typeof metricValue !== 'number' || !Number.isFinite(metricValue)) {
             throw new Error(`${iterationLabel} returned metric "${key}" with non-finite numeric value`);
         }
-        validated[key] = metricValue;
+        validatedMetrics[key] = metricValue;
+    }
+
+    return {
+        metrics: validatedMetrics,
+        artifacts: validateWorkloadArtifacts(artifacts, iterationLabel),
+    };
+}
+
+function validateWorkloadArtifacts(artifacts, iterationLabel) {
+    if (artifacts === undefined) {
+        return {};
+    }
+
+    if (!artifacts || typeof artifacts !== 'object' || Array.isArray(artifacts)) {
+        throw new Error(`${iterationLabel} returned invalid artifacts shape (expected an object)`);
+    }
+
+    const validated = {};
+    for (const [key, artifact] of Object.entries(artifacts)) {
+        if (typeof artifact === 'string') {
+            if (artifact.length === 0) {
+                throw new Error(`${iterationLabel} returned artifact "${key}" with empty path`);
+            }
+            validated[key] = { path: artifact };
+            continue;
+        }
+
+        if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) {
+            throw new Error(`${iterationLabel} returned artifact "${key}" with invalid shape (expected string path or object)`);
+        }
+        if (typeof artifact.path !== 'string' || artifact.path.length === 0) {
+            throw new Error(`${iterationLabel} returned artifact "${key}" without a non-empty string path`);
+        }
+        if (artifact.kind !== undefined && typeof artifact.kind !== 'string') {
+            throw new Error(`${iterationLabel} returned artifact "${key}" with non-string kind`);
+        }
+        if (artifact.label !== undefined && typeof artifact.label !== 'string') {
+            throw new Error(`${iterationLabel} returned artifact "${key}" with non-string label`);
+        }
+
+        const normalized = { path: artifact.path };
+        if (artifact.kind !== undefined) normalized.kind = artifact.kind;
+        if (artifact.label !== undefined) normalized.label = artifact.label;
+        validated[key] = normalized;
     }
 
     return validated;
@@ -137,6 +179,10 @@ function aggregateCustomMetrics(iterationMetrics) {
     return Object.fromEntries(
         [...sums.entries()].map(([key, sum]) => [key, sum / counts.get(key)])
     );
+}
+
+function aggregateArtifacts(iterationArtifacts) {
+    return Object.assign({}, ...iterationArtifacts);
 }
 
 async function discoverWorkloads(dir) {
@@ -186,11 +232,14 @@ async function runWorkload(file) {
 
     const timings = [];
     const customMetrics = [];
+    const customArtifacts = [];
     let peakRss = 0;
     for (let i = 0; i < ITERATIONS; i++) {
         const start = performance.now();
         try {
-            customMetrics.push(validateWorkloadResult(await fn(), `iteration ${i + 1}/${ITERATIONS}`));
+            const workloadResult = validateWorkloadResult(await fn(), `iteration ${i + 1}/${ITERATIONS}`);
+            customMetrics.push(workloadResult.metrics);
+            customArtifacts.push(workloadResult.artifacts);
         } catch (err) {
             return { error: `iteration ${i + 1}/${ITERATIONS} threw: ${err.message}` };
         }
@@ -200,7 +249,12 @@ async function runWorkload(file) {
     }
 
     timings.sort((a, b) => a - b);
-    return { timings, peakRss, customMetrics: aggregateCustomMetrics(customMetrics) };
+    return {
+        timings,
+        peakRss,
+        customMetrics: aggregateCustomMetrics(customMetrics),
+        customArtifacts: aggregateArtifacts(customArtifacts),
+    };
 }
 
 async function main() {
@@ -267,14 +321,18 @@ async function main() {
             max_ms: t[t.length - 1],
         };
 
-        scenarios.push({
+        const scenario = {
             id,
             file: rel,
             source,
             iterations: t.length,
             metrics: { ...timingMetrics, ...result.customMetrics },
             memory: { peak_bytes: result.peakRss },
-        });
+        };
+        if (Object.keys(result.customArtifacts).length > 0) {
+            scenario.artifacts = result.customArtifacts;
+        }
+        scenarios.push(scenario);
 
         process.stdout.write(
             `WORKLOAD_DONE:  ${id}  p50=${homeboyBenchPercentile(t, 0.50).toFixed(2)}ms  p95=${homeboyBenchPercentile(t, 0.95).toFixed(2)}ms\n`

--- a/nodejs/scripts/bench/nodejs-bench-artifacts-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-bench-artifacts-smoke.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-bench-artifacts.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+HELPER_JS="$TMP_DIR/bench-helper.mjs"
+cat > "$HELPER_JS" <<'EOF'
+import { basename } from 'node:path';
+import { writeFile } from 'node:fs/promises';
+
+export function homeboyBenchPercentile(values, percentile) {
+  if (values.length === 0) return 0;
+  if (values.length === 1) return values[0];
+  const index = (values.length - 1) * percentile;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return values[lower];
+  return values[lower] + (values[upper] - values[lower]) * (index - lower);
+}
+
+export function homeboyBenchScenarioId(file, suffixPattern) {
+  return basename(file).replace(suffixPattern, '');
+}
+
+export async function homeboyWriteBenchResults(file, componentId, iterations, scenarios) {
+  await writeFile(file, JSON.stringify({ component_id: componentId, iterations, scenarios }, null, 2));
+}
+EOF
+
+assert_json() {
+    local file="$1"
+    local script="$2"
+    node -e "const fs = require('fs'); const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); ${script}" "$file"
+}
+
+make_project() {
+    local name="$1"
+    local project_dir="$TMP_DIR/$name"
+    mkdir -p "$project_dir/bench"
+    printf '{"name":"%s"}\n' "$name" > "$project_dir/package.json"
+    printf '%s\n' "$project_dir"
+}
+
+run_runner() {
+    local project_dir="$1"
+    local results_file="$2"
+    HOMEBOY_RUNTIME_BENCH_HELPER_JS="$HELPER_JS" \
+    HOMEBOY_COMPONENT_PATH="$project_dir" \
+    HOMEBOY_COMPONENT_ID="node-bench-artifacts-smoke" \
+    HOMEBOY_BENCH_ITERATIONS="1" \
+    HOMEBOY_BENCH_WARMUP_ITERATIONS="0" \
+    HOMEBOY_BENCH_RESULTS_FILE="$results_file" \
+        node "$SCRIPT_DIR/bench-runner.mjs"
+}
+
+METRICS_ONLY_PROJECT="$(make_project metrics-only)"
+cat > "$METRICS_ONLY_PROJECT/bench/metrics.bench.mjs" <<'EOF'
+export default async function () {
+  return { metrics: { success_rate: 1 } };
+}
+EOF
+
+METRICS_ONLY_RESULTS="$TMP_DIR/metrics-only-results.json"
+run_runner "$METRICS_ONLY_PROJECT" "$METRICS_ONLY_RESULTS" >/dev/null
+assert_json "$METRICS_ONLY_RESULTS" '
+const scenario = data.scenarios[0];
+if (scenario.metrics.success_rate !== 1) throw new Error("metrics-only workload lost custom metric");
+if (Object.prototype.hasOwnProperty.call(scenario, "artifacts")) throw new Error("metrics-only workload should not emit artifacts");
+'
+
+ARTIFACT_PROJECT="$(make_project artifacts)"
+cat > "$ARTIFACT_PROJECT/bench/artifacts.bench.mjs" <<'EOF'
+export default async function () {
+  return {
+    metrics: { success_rate: 1 },
+    artifacts: {
+      raw_result: { path: '/tmp/result.json', kind: 'json', label: 'Raw result' },
+      site_path: { path: '/tmp/site', kind: 'directory', label: 'Generated site' },
+      bare_path: '/tmp/bare.txt',
+    },
+  };
+}
+EOF
+
+ARTIFACT_RESULTS="$TMP_DIR/artifact-results.json"
+run_runner "$ARTIFACT_PROJECT" "$ARTIFACT_RESULTS" >/dev/null
+assert_json "$ARTIFACT_RESULTS" '
+const artifacts = data.scenarios[0].artifacts;
+if (!artifacts) throw new Error("scenario artifacts missing");
+if (artifacts.raw_result.path !== "/tmp/result.json") throw new Error("raw_result path missing");
+if (artifacts.raw_result.kind !== "json") throw new Error("raw_result kind missing");
+if (artifacts.raw_result.label !== "Raw result") throw new Error("raw_result label missing");
+if (artifacts.site_path.kind !== "directory") throw new Error("site_path kind missing");
+if (artifacts.bare_path.path !== "/tmp/bare.txt") throw new Error("bare path was not normalized");
+'
+
+INVALID_PROJECT="$(make_project invalid-artifact)"
+cat > "$INVALID_PROJECT/bench/invalid.bench.mjs" <<'EOF'
+export default async function () {
+  return { artifacts: { raw_result: { kind: 'json' } } };
+}
+EOF
+
+set +e
+INVALID_OUTPUT="$(run_runner "$INVALID_PROJECT" "$TMP_DIR/invalid-results.json" 2>&1)"
+INVALID_EXIT=$?
+set -e
+if [ "$INVALID_EXIT" -eq 0 ]; then
+    echo "expected invalid artifact workload to fail" >&2
+    exit 1
+fi
+if [[ "$INVALID_OUTPUT" != *'artifact "raw_result" without a non-empty string path'* ]]; then
+    echo "expected clear invalid artifact error" >&2
+    echo "$INVALID_OUTPUT" >&2
+    exit 1
+fi
+
+echo "Node.js bench artifacts smoke passed."

--- a/nodejs/scripts/bench/nodejs-bench-custom-metrics-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-bench-custom-metrics-smoke.sh
@@ -5,6 +5,30 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-bench-metrics.XXXXXX")"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
+HELPER_JS="$TMP_DIR/bench-helper.mjs"
+cat > "$HELPER_JS" <<'EOF'
+import { basename } from 'node:path';
+import { writeFile } from 'node:fs/promises';
+
+export function homeboyBenchPercentile(values, percentile) {
+  if (values.length === 0) return 0;
+  if (values.length === 1) return values[0];
+  const index = (values.length - 1) * percentile;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return values[lower];
+  return values[lower] + (values[upper] - values[lower]) * (index - lower);
+}
+
+export function homeboyBenchScenarioId(file, suffixPattern) {
+  return basename(file).replace(suffixPattern, '');
+}
+
+export async function homeboyWriteBenchResults(file, componentId, iterations, scenarios) {
+  await writeFile(file, JSON.stringify({ component_id: componentId, iterations, scenarios }, null, 2));
+}
+EOF
+
 assert_json() {
     local file="$1"
     local script="$2"
@@ -14,7 +38,8 @@ assert_json() {
 run_runner() {
     local project_dir="$1"
     local results_file="$2"
-    HOMEBOY_COMPONENT_PATH="$project_dir" \
+    HOMEBOY_RUNTIME_BENCH_HELPER_JS="$HELPER_JS" \
+        HOMEBOY_COMPONENT_PATH="$project_dir" \
         HOMEBOY_COMPONENT_ID="node-bench-smoke" \
         HOMEBOY_BENCH_ITERATIONS="3" \
         HOMEBOY_BENCH_RESULTS_FILE="$results_file" \


### PR DESCRIPTION
## Summary
- Preserve workload-returned `artifacts` in Node.js bench scenario results.
- Validate artifact payloads clearly, including bare string path normalization to `{ path }`.
- Add focused artifact propagation smoke coverage and repair the adjacent custom-metrics smoke helper setup.

## Tests
- `node --check nodejs/scripts/bench/bench-runner.mjs`
- `nodejs/scripts/bench/nodejs-bench-artifacts-smoke.sh`
- `nodejs/scripts/bench/nodejs-bench-custom-metrics-smoke.sh`
- `nodejs/scripts/bench/nodejs-bench-warmup-smoke.sh`
- `homeboy audit homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@feat-nodejs-bench-artifacts --changed-since origin/main`
- `homeboy lint homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@feat-nodejs-bench-artifacts` is unavailable because the component has no extensions configured.

Closes #316

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Node.js runner artifact propagation, smoke coverage, verification, and PR drafting. Chris remains responsible for review and merge.
