### PR TITLE
fix(wordpress): preserve PHPStan temp config suffixes

### DIFF
--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -68,9 +68,37 @@ DEPENDENCY_CONFIG=""
 homeboy_mktemp() {
     local template="$1"
     local tmpdir="${HOMEBOY_CACHE_DIR:-${TMPDIR:-/tmp}}"
+    local tmpfile=""
+    local basefile=""
+    local prefix=""
+    local suffix=""
 
     if [ -d "$tmpdir" ] && [ -w "$tmpdir" ]; then
-        mktemp "${tmpdir%/}/${template}" 2>/dev/null && return 0
+        tmpfile=$(mktemp "${tmpdir%/}/${template}" 2>/dev/null || true)
+        if [ -n "$tmpfile" ] && [[ "$tmpfile" != *XXXXXX* ]]; then
+            printf '%s\n' "$tmpfile"
+            return 0
+        fi
+
+        # BSD mktemp leaves XXXXXX literal when the random token is not the
+        # final path segment. PHPStan 2 requires generated config files to keep
+        # their .neon suffix, so create a unique base first and rename it.
+        [ -n "$tmpfile" ] && rm -f "$tmpfile"
+        if [[ "$template" == *XXXXXX* ]]; then
+            prefix="${template%%XXXXXX*}"
+            suffix="${template#*XXXXXX}"
+            if [ -n "$suffix" ]; then
+                basefile=$(mktemp "${tmpdir%/}/${prefix}XXXXXX" 2>/dev/null || true)
+                if [ -n "$basefile" ]; then
+                    tmpfile="${basefile}${suffix}"
+                    if [ ! -e "$tmpfile" ] && mv "$basefile" "$tmpfile"; then
+                        printf '%s\n' "$tmpfile"
+                        return 0
+                    fi
+                    rm -f "$basefile"
+                fi
+            fi
+        fi
     fi
 
     mktemp 2>/dev/null

--- a/wordpress/tests/phpstan-temp-config-suffix-smoke.sh
+++ b/wordpress/tests/phpstan-temp-config-suffix-smoke.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PHPSTAN_RUNNER="${ROOT_DIR}/scripts/lint/phpstan-runner.sh"
+
+assert() {
+    local condition="$1"
+    local message="$2"
+    if ! eval "$condition"; then
+        echo "FAIL: ${message}" >&2
+        exit 1
+    fi
+}
+
+assert_path_for_template() {
+    local template="$1"
+    local expected_suffix="$2"
+    local path
+
+    path=$(homeboy_mktemp "$template")
+    assert "[ -f \"\$path\" ]" "${template} should create a temp file"
+    assert "[[ \"\$path\" == *\"${expected_suffix}\" ]]" "${template} should preserve ${expected_suffix} suffix: ${path}"
+    assert "[[ \"\$path\" != *XXXXXX* ]]" "${template} should not leave literal XXXXXX: ${path}"
+    rm -f "$path"
+}
+
+function_body=$(awk '/^homeboy_mktemp\(\)/,/^}$/' "$PHPSTAN_RUNNER")
+eval "$function_body"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+export TMPDIR="$tmpdir"
+unset HOMEBOY_CACHE_DIR
+
+assert_path_for_template 'phpstan.XXXXXX.neon' '.neon'
+assert_path_for_template 'phpstan-dependencies.XXXXXX.neon' '.neon'
+
+grep -q "phpstan\.XXXXXX\.neon" "$PHPSTAN_RUNNER"
+grep -q "phpstan-dependencies\.XXXXXX\.neon" "$PHPSTAN_RUNNER"
+
+echo "phpstan temp config suffix smoke passed"


### PR DESCRIPTION
## Summary
- Preserve `.neon` suffixes when the WordPress PHPStan runner creates generated config files on platforms where `mktemp` does not support suffixes after `XXXXXX`.
- Add a focused smoke test for the generated PHPStan config temp paths.

## Repro / root cause
PHPStan 2 rejects generated configuration files without a recognized extension:

```text
In Loader.php line 90:
  Unknown file extension '/var/folders/.../T/tmp.*'.
```

The runner already requested templates like `phpstan.XXXXXX.neon`, but BSD/macOS `mktemp` can leave `XXXXXX` literal when the random token is not the final path segment. The helper then fell back to plain `mktemp`, producing extensionless config files that PHPStan rejects when passed to `--configuration`.

## Fix
- Detect failed/literal `XXXXXX` results from `mktemp`.
- For suffixed templates, create a unique base temp file first and rename it to the same random path with the requested suffix.
- Keep the existing plain `mktemp` fallback for non-config temp files and unusual environments.

## Tests
- `bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- `git diff --check`
- `bash -n wordpress/scripts/lint/phpstan-runner.sh wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- `shellcheck wordpress/scripts/lint/phpstan-runner.sh wordpress/tests/phpstan-temp-config-suffix-smoke.sh` *(not available locally: `command not found`)*
- Live smoke: temporarily linked the local Homeboy `wordpress` extension to this worktree and ran `homeboy lint data-machine-code --path /Users/chubes/Developer/data-machine-code`. It got past the PHPStan temp-extension loader failure and then failed later on existing `data-machine-code` PHPStan findings.

Closes #253

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the `mktemp` suffix portability issue, implementing the shell helper fix and smoke test, and running focused/local verification for human review.
