### PR TITLE
fix(wordpress): quiet stale Playground temp ENOENT noise

### DIFF
--- a/wordpress/scripts/lib/playground-cleanup-noise.sh
+++ b/wordpress/scripts/lib/playground-cleanup-noise.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Filter the known @wp-playground/cli stale-temp cleanup race where a temp path
+# disappears after discovery but before the CLI can lstat it. Real cleanup
+# failures still pass through so release gates keep useful diagnostics.
+homeboy_filter_playground_cleanup_noise() {
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        cat
+        return
+    fi
+
+    awk '
+        /^Failed to find stale Playground temp dirs: Error: ENOENT: no such file or directory, lstat / { next }
+        { print }
+    '
+}

--- a/wordpress/scripts/test/playground-cleanup-noise-smoke.sh
+++ b/wordpress/scripts/test/playground-cleanup-noise-smoke.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../lib/playground-cleanup-noise.sh"
+
+# shellcheck source=../lib/playground-cleanup-noise.sh
+source "$HELPER"
+
+assertions=0
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+    local message="$3"
+    assertions=$((assertions + 1))
+
+    if [ "$expected" != "$actual" ]; then
+        echo "FAIL: ${message}" >&2
+        echo "Expected: ${expected}" >&2
+        echo "Actual:   ${actual}" >&2
+        exit 1
+    fi
+}
+
+benign_line="Failed to find stale Playground temp dirs: Error: ENOENT: no such file or directory, lstat '/private/var/folders/example/T/phpcs-child123'"
+real_find_failure="Failed to find stale Playground temp dirs: Error: EACCES: permission denied, scandir '/private/var/folders/example/T'"
+delete_failure="Failed to delete stale Playground temp dir: /private/var/folders/example/T/phpcs-child123 Error: EBUSY: resource busy or locked"
+normal_line="Running PHPUnit tests via WordPress Playground..."
+
+filtered=$(printf '%s\n%s\n%s\n%s\n' "$normal_line" "$benign_line" "$real_find_failure" "$delete_failure" | homeboy_filter_playground_cleanup_noise)
+expected=$(printf '%s\n%s\n%s' "$normal_line" "$real_find_failure" "$delete_failure")
+assert_equals "$expected" "$filtered" "filters only the ENOENT lstat stale-temp race"
+
+debug_filtered=$(printf '%s\n' "$benign_line" | HOMEBOY_DEBUG=1 homeboy_filter_playground_cleanup_noise)
+assert_equals "$benign_line" "$debug_filtered" "debug mode preserves the benign cleanup race line"
+
+echo "Playground cleanup noise smoke passed (${assertions} assertions)"

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -45,6 +45,7 @@ FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
 PHP_PREFLIGHT_HELPER="${SCRIPT_DIR}/../lib/php-preflight.sh"
 PLAYGROUND_PATHS_HELPER="${SCRIPT_DIR}/../lib/playground-paths.sh"
+CLEANUP_NOISE_HELPER="${SCRIPT_DIR}/../lib/playground-cleanup-noise.sh"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context --component-alias PLUGIN_PATH
@@ -62,6 +63,8 @@ if [ -f "$PHP_PREFLIGHT_HELPER" ]; then
 fi
 # shellcheck source=../lib/playground-paths.sh
 source "$PLAYGROUND_PATHS_HELPER"
+# shellcheck source=../lib/playground-cleanup-noise.sh
+source "$CLEANUP_NOISE_HELPER"
 # shellcheck source=/dev/null
 if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
     source "$FAILURE_TRAP_HELPER"
@@ -258,7 +261,7 @@ set +e
     --wp=6.9 \
     --verbosity=normal \
     -- /runner.php \
-    2>&1 | tee "$PHPUNIT_TMPFILE"
+    2>&1 | homeboy_filter_playground_cleanup_noise | tee "$PHPUNIT_TMPFILE"
 playground_exit=${PIPESTATUS[0]}
 set -e
 


### PR DESCRIPTION
## Summary
- Quiet the known WordPress Playground stale-temp cleanup ENOENT race during Playground-backed test runs.
- Keep non-ENOENT stale-temp discovery failures and stale-temp delete failures visible.

## Repro / Root Cause
`@wp-playground/cli` performs stale temp-dir discovery before running PHP. A temp path can disappear between directory discovery and the CLI's `lstat`, producing this warning during unrelated test gates:

```text
Failed to find stale Playground temp dirs: Error: ENOENT: no such file or directory, lstat '.../phpcs-child...'
```

That race is harmless, but the line looks like the test failure root cause.

## Fix
- Add a small Playground cleanup-noise filter used by the WordPress Playground test runner.
- Drop only the exact ENOENT/lstat stale-temp discovery race in normal mode.
- Preserve the line in `HOMEBOY_DEBUG=1` and preserve real cleanup diagnostics like permission errors or failed deletes.

## Tests
- `bash wordpress/scripts/test/playground-cleanup-noise-smoke.sh`
- `bash -n wordpress/scripts/lib/playground-cleanup-noise.sh wordpress/scripts/test/test-runner-playground.sh wordpress/scripts/test/playground-cleanup-noise-smoke.sh`

`homeboy lint homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@fix-stale-temp-cleanup-noise` is not applicable because the root component has no extension configured.

Closes #319

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the narrow cleanup-noise filter, adding the focused smoke test, and running validation.
