### PR TITLE
fix(wordpress): classify empty PHPUnit discovery

### DIFF
--- a/wordpress/scripts/test/playground-no-test-files-smoke.sh
+++ b/wordpress/scripts/test/playground-no-test-files-smoke.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/test-runner-playground.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+EXTENSION_PATH="${TMPDIR}/extension"
+PLUGIN_PATH="${TMPDIR}/component"
+mkdir -p "${EXTENSION_PATH}/node_modules/.bin" "${PLUGIN_PATH}/tests"
+
+cat > "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+cat > "${HOMEBOY_PLUGIN_PATH}/.pg-test-result.txt" <<'LOG'
+STAGE_BEGIN:discover_tests
+DISCOVERY: dirs=/wordpress/wp-content/plugins/example/tests suffixes=Test.php prefixes=test- excludes=0 found=0
+NO_TEST_FILES
+STAGE_OK:discover_tests
+LOG
+exit 1
+SH
+chmod +x "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli"
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        echo "Expected output to contain: $needle" >&2
+        echo "Actual output:" >&2
+        echo "$haystack" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1"
+    local needle="$2"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        echo "Expected output not to contain: $needle" >&2
+        echo "Actual output:" >&2
+        echo "$haystack" >&2
+        exit 1
+    fi
+}
+
+set +e
+skip_output=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" HOMEBOY_COMPONENT_ID="example" bash "$RUNNER" 2>&1)
+skip_status=$?
+set -e
+
+if [ "$skip_status" -ne 0 ]; then
+    echo "Expected no-files run without component PHPUnit config to skip with exit 0; got $skip_status" >&2
+    echo "$skip_output" >&2
+    exit 1
+fi
+assert_contains "$skip_output" "NO PHPUNIT TEST FILES DISCOVERED"
+assert_contains "$skip_output" "Skipping PHPUnit tests: no files matched the WordPress runner discovery contract."
+assert_contains "$skip_output" "ending in Test.php or starting with test-."
+assert_not_contains "$skip_output" "UNCLASSIFIED PLAYGROUND FAILURE"
+
+touch "${PLUGIN_PATH}/phpunit.xml.dist"
+set +e
+failure_output=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" HOMEBOY_COMPONENT_ID="example" bash "$RUNNER" 2>&1)
+failure_status=$?
+set -e
+
+if [ "$failure_status" -eq 0 ]; then
+    echo "Expected no-files run with component PHPUnit config to fail" >&2
+    echo "$failure_output" >&2
+    exit 1
+fi
+assert_contains "$failure_output" "NO PHPUNIT TEST FILES DISCOVERED"
+assert_contains "$failure_output" "PHPUnit config exists, but no files matched the WordPress runner discovery contract."
+assert_not_contains "$failure_output" "UNCLASSIFIED PLAYGROUND FAILURE"
+assert_not_contains "$failure_output" "Skipping PHPUnit tests: no files matched"
+
+echo "Playground no-test-files smoke passed (9 assertions)"

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -306,8 +306,8 @@ fi
 #   1. STAGE_FATAL/STAGE_FAIL in result file  -> bootstrap failure, show stage+msg
 #   2. SOME TESTS FAILED in result file       -> PHPUnit assertion failures
 #   3. Parse/fatal patterns in stdout         -> PHP crashed before writing log
-#   4. playground_exit != 0 with no log       -> unknown crash, dump raw output
-#   5. NO_TEST_FILES in result file           -> discovery found nothing
+#   4. NO_TEST_FILES in result file           -> discovery found nothing
+#   5. playground_exit != 0 with no log       -> unknown crash, dump raw output
 #   6. Zero-test PHPUnit run                  -> suite empty
 # ----------------------------------------------------------------------------
 
@@ -370,7 +370,30 @@ if [ $playground_exit -ne 0 ] && echo "$PHPUNIT_STDOUT" | grep -qE '^(PHP Parse 
     exit $playground_exit
 fi
 
-# Case 5: playground exited non-zero and we still can't classify it.
+# Case 5: discovery found zero PHPUnit files. Repos without component PHPUnit
+# config may intentionally rely on smoke scripts outside this runner's contract.
+# If a component declares PHPUnit config, keep failing loudly so misconfigured
+# discovery cannot become a false green.
+if echo "$PHPUNIT_OUTPUT" | grep -q "^NO_TEST_FILES"; then
+    dump_diagnostics "NO PHPUNIT TEST FILES DISCOVERED"
+    if [ -f "${PLUGIN_PATH}/phpunit.xml" ] || [ -f "${PLUGIN_PATH}/phpunit.xml.dist" ]; then
+        echo ""
+        echo "PHPUnit config exists, but no files matched the WordPress runner discovery contract."
+        echo "  Check phpunit.xml(.dist), tests/ directory layout, and Test.php/test- naming."
+        FAILED_STEP="PHPUnit tests (configured suite discovered no test files, playground)"
+        rm -f "$RESULT_FILE"
+        exit 1
+    fi
+
+    echo ""
+    echo "Skipping PHPUnit tests: no files matched the WordPress runner discovery contract."
+    echo "  Contract: files under ${TEST_DIR} ending in Test.php or starting with test-."
+    echo "  Add matching PHPUnit files or a component phpunit.xml(.dist) if this suite should run here."
+    rm -f "$RESULT_FILE"
+    exit 0
+fi
+
+# Case 6: playground exited non-zero and we still can't classify it.
 # Don't exit 0 here — that's the bug the old code had.
 if [ $playground_exit -ne 0 ]; then
     FAILED_STEP="Playground exited with code $playground_exit (unclassified)"
@@ -379,19 +402,11 @@ if [ $playground_exit -ne 0 ]; then
     exit $playground_exit
 fi
 
-# Case 6: no output at all (not even a result file). Shouldn't happen on a
+# Case 7: no output at all (not even a result file). Shouldn't happen on a
 # clean exit, but guard anyway.
 if [ -z "$PHPUNIT_OUTPUT" ] && [ -z "$PHPUNIT_STDOUT" ]; then
     dump_diagnostics "NO OUTPUT CAPTURED"
     FAILED_STEP="PHPUnit tests (no output, playground)"
-    rm -f "$RESULT_FILE"
-    exit 1
-fi
-
-# Case 7: discovery found zero test files.
-if echo "$PHPUNIT_OUTPUT" | grep -q "^NO_TEST_FILES"; then
-    dump_diagnostics "NO TEST FILES DISCOVERED"
-    FAILED_STEP="PHPUnit tests (no test files, playground)"
     rm -f "$RESULT_FILE"
     exit 1
 fi


### PR DESCRIPTION
## Summary
- Classify Playground `NO_TEST_FILES` before the generic non-zero exit fallback.
- Treat components with no matching PHPUnit files and no component PHPUnit config as an explicit skip/no-op.
- Preserve a targeted failure when `phpunit.xml` or `phpunit.xml.dist` exists but discovery finds no matching files.

## Repro / root cause
`playground-runner.php` writes `NO_TEST_FILES` and exits non-zero when discovery finds zero PHPUnit files. `test-runner-playground.sh` checked generic non-zero exits before it checked `NO_TEST_FILES`, so an intentional discovery result became `UNCLASSIFIED PLAYGROUND FAILURE`.

## Behavior change
- Repos like `data-machine-code`, which use smoke scripts rather than PHPUnit files, now get a clear skip message explaining the discovery contract.
- Repos that declare component PHPUnit config still fail loudly if no files match, so a misconfigured PHPUnit suite does not become a false green.

## Tests
- `bash wordpress/scripts/test/playground-no-test-files-smoke.sh`
- `bash wordpress/scripts/test/playground-discovery-smoke.sh`
- `bash -n wordpress/scripts/test/test-runner-playground.sh`
- `bash -n wordpress/scripts/test/playground-no-test-files-smoke.sh`
- Live smoke: ran patched `test-runner-playground.sh` against `/Users/chubes/Developer/data-machine-code`; it reported `NO PHPUNIT TEST FILES DISCOVERED` and exited successfully instead of `UNCLASSIFIED PLAYGROUND FAILURE`.

Two broader Playground smokes were not run because this worktree does not have `wordpress/node_modules/.bin/wp-playground-cli`; they reported the missing dependency before executing.

Closes #318

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the runner classification fix, adding the smoke coverage, and running focused validation. Chris remains responsible for review and merge.
