### PR TITLE
fix(wordpress): support host smoke test backend

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -131,20 +131,24 @@ The extension supports two test execution backends:
 
 | Backend | Description | Default |
 |---------|-------------|---------|
-| `host` | PHPUnit with host PHP + wp-phpunit + SQLite/MySQL | Yes |
-| `playground` | PHPUnit inside WordPress Playground (PHP-WASM + SQLite) | No |
+| `playground` | PHPUnit inside WordPress Playground (PHP-WASM + SQLite) | Yes |
+| `host-smoke` / `host` | Standalone `tests/**/*-smoke.php` scripts under host PHP | No |
 
 ```bash
 # Switch a component to Playground backend
 homeboy component set my-plugin test_backend playground
 
-# Switch back to host backend
-homeboy component set my-plugin test_backend host
+# Run standalone host PHP smoke scripts instead
+homeboy component set my-plugin test_backend host-smoke
 ```
 
-The Playground backend is **opt-in** and does not affect the default host
-backend. It boots a WordPress Playground instance, mounts the plugin, and
-runs PHPUnit inside PHP-WASM. No host PHP or MySQL is required.
+The Playground backend is the default. It boots a WordPress Playground
+instance, mounts the plugin, and runs PHPUnit inside PHP-WASM. No host PHP or
+MySQL is required.
+
+The host-smoke backend is for pure PHP smoke suites that do not need WordPress.
+It discovers `tests/**/*-smoke.php`, runs each file in its own host PHP process,
+and fails fast with the failing script name.
 
 **Limitations (Phase 1):**
 - WordPress version is pinned to match the wp-phpunit package (currently 6.9.x).
@@ -198,7 +202,8 @@ Files that can be safely removed after migration:
 wordpress/
 ├── scripts/
 │   ├── test/
-│   │   ├── test-runner.sh              # Main test orchestration (host backend)
+│   │   ├── test-runner.sh              # Main test router
+│   │   ├── test-runner-host-smoke.sh   # Host PHP smoke-script backend
 │   │   ├── test-runner-playground.sh   # Playground backend runner
 │   │   ├── generate-config.sh          # WordPress config generation
 │   │   ├── parse-test-results.sh       # Result parsing for homeboy core

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -1,9 +1,9 @@
 # Testing
 
 The WordPress extension runs PHPUnit inside [WordPress Playground][playground]
-(PHP-WASM + embedded SQLite). There is no host PHP, MySQL, or WordPress
-installation to configure. Components only need a `tests/` directory with
-PHPUnit test files.
+(PHP-WASM + embedded SQLite) by default. There is no host PHP, MySQL, or
+WordPress installation to configure. Components only need a `tests/` directory
+with PHPUnit test files.
 
 [playground]: https://www.npmjs.com/package/@wp-playground/cli
 
@@ -21,9 +21,10 @@ HOMEBOY_DEBUG=1 homeboy test <component-id>
 ```
 
 Tests run through `scripts/test/test-runner.sh`, which dispatches to the
-Playground runner (`test-runner-playground.sh` + `playground-runner.php`).
-The runner mounts the component under `/wordpress/wp-content/plugins/<slug>`,
-boots WordPress in-process, discovers test files, and runs PHPUnit.
+configured backend. The default Playground runner (`test-runner-playground.sh`
+and `playground-runner.php`) mounts the component under
+`/wordpress/wp-content/plugins/<slug>`, boots WordPress in-process, discovers
+test files, and runs PHPUnit.
 
 ## Requirements
 
@@ -37,6 +38,20 @@ A component needs:
 A component **must not** carry its own `tests/bootstrap.php` or
 `phpunit.xml` — the extension owns bootstrap. Local PHPUnit configs are
 rejected with a clear error.
+
+## Host smoke backend
+
+Pure PHP smoke suites can opt out of Playground and run directly under host
+PHP:
+
+```bash
+homeboy component set <component-id> test_backend host-smoke
+```
+
+The host-smoke backend discovers `tests/**/*-smoke.php`, runs each script in a
+separate `php` process, emits `HOST_SMOKE_*` markers, and fails fast with the
+failing script name. It does not bootstrap WordPress, connect to MySQL, or start
+Playground.
 
 ## Dependencies
 

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -6,5 +6,17 @@
       "file": "wordpress.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
-  ]
+  ],
+  "self_checks": {
+    "lint": [
+      "jq empty wordpress.json",
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/playground-process-cleanup-smoke.sh"
+    ],
+    "test": [
+      "bash scripts/test/host-smoke-runner-smoke.sh",
+      "bash scripts/test/playground-process-cleanup-smoke.sh",
+      "bash scripts/test/playground-cleanup-noise-smoke.sh",
+      "bash scripts/test/playground-no-test-files-smoke.sh"
+    ]
+  }
 }

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -3,11 +3,12 @@ set -euo pipefail
 
 # Setup script for WordPress Homeboy extension.
 #
-# Installs npm dependencies (including @wp-playground/cli for the Playground
-# test backend) and PHP dev dependencies (PHPCS, PHPStan for linting).
+# Installs npm dependencies (including @wp-playground/cli for the default
+# Playground test backend) and PHP dev dependencies (PHPCS, PHPStan for linting).
 #
-# The legacy wp-phpunit dependency was removed in Phase 3 (#214) — test
-# execution now runs entirely inside WordPress Playground.
+# The legacy wp-phpunit dependency was removed in Phase 3 (#214) — WordPress
+# PHPUnit execution now runs inside Playground. The host-smoke backend is only
+# for standalone PHP smoke scripts.
 
 EXTENSION_PATH="$(pwd)"
 
@@ -48,4 +49,5 @@ if [ -f "package.json" ]; then
 fi
 
 echo "WordPress extension setup complete."
-echo "Test backend: Playground (PHP-WASM + embedded SQLite)"
+echo "Default test backend: Playground (PHP-WASM + embedded SQLite)"
+echo "Host smoke backend: set test_backend=host-smoke for standalone tests/**/*-smoke.php"

--- a/wordpress/scripts/lib/playground-process-cleanup.sh
+++ b/wordpress/scripts/lib/playground-process-cleanup.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Scoped cleanup for Playground worker processes spawned during this runner
+# invocation. The runner snapshots existing workers before `wp-playground-cli`
+# starts, then terminates only new `playground-server-child.mjs` PIDs that are
+# still alive when the runner exits or finishes.
+
+homeboy_playground_list_workers() {
+    if command -v pgrep >/dev/null 2>&1; then
+        pgrep -f 'playground-server-child\.mjs' 2>/dev/null | sort -n || true
+        return
+    fi
+
+    ps -eo pid=,args= 2>/dev/null | awk '/playground-server-child\.mjs/ && !/awk/ { print $1 }' | sort -n || true
+}
+
+homeboy_playground_snapshot_workers() {
+    homeboy_playground_list_workers | tr '\n' ' '
+}
+
+homeboy_playground_cleanup_new_workers() {
+    local before_snapshot="$1"
+    local after_pid
+    local stale_pids=()
+
+    while IFS= read -r after_pid; do
+        [ -z "$after_pid" ] && continue
+        case " ${before_snapshot} " in
+            *" ${after_pid} "*) ;;
+            *) stale_pids+=("$after_pid") ;;
+        esac
+    done < <(homeboy_playground_list_workers)
+
+    if [ "${#stale_pids[@]}" -eq 0 ]; then
+        return 0
+    fi
+
+    echo "Cleaning up Playground worker(s) left by this run: ${stale_pids[*]}" >&2
+    kill "${stale_pids[@]}" 2>/dev/null || true
+    sleep 1
+
+    local remaining=()
+    local pid
+    for pid in "${stale_pids[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            remaining+=("$pid")
+        fi
+    done
+
+    if [ "${#remaining[@]}" -gt 0 ]; then
+        echo "Force-cleaning Playground worker(s): ${remaining[*]}" >&2
+        kill -9 "${remaining[@]}" 2>/dev/null || true
+    fi
+}

--- a/wordpress/scripts/test/host-smoke-runner-smoke.sh
+++ b/wordpress/scripts/test/host-smoke-runner-smoke.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq "$expected" "$file"; then
+        echo "Expected $file to contain: $expected" >&2
+        echo "Actual contents:" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local file="$1"
+    local unexpected="$2"
+    if grep -Fq "$unexpected" "$file"; then
+        echo "Expected $file not to contain: $unexpected" >&2
+        echo "Actual contents:" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+make_component() {
+    local target="$1"
+    mkdir -p "$target/tests/nested"
+    cat > "$target/tests/alpha-smoke.php" <<'PHP'
+<?php
+fwrite( STDOUT, "alpha ok\n" );
+PHP
+    cat > "$target/tests/nested/bravo-smoke.php" <<'PHP'
+<?php
+fwrite( STDOUT, "bravo ok\n" );
+PHP
+}
+
+component_pass="${TMPDIR}/component-pass"
+make_component "$component_pass"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component-pass" \
+HOMEBOY_COMPONENT_PATH="$component_pass" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner-host-smoke.sh" > "${TMPDIR}/direct-pass.out"
+
+assert_contains "${TMPDIR}/direct-pass.out" "HOST_SMOKE_BEGIN:tests/alpha-smoke.php"
+assert_contains "${TMPDIR}/direct-pass.out" "HOST_SMOKE_BEGIN:tests/nested/bravo-smoke.php"
+assert_contains "${TMPDIR}/direct-pass.out" "HOST_SMOKE_SUMMARY:passed=2 failed=0"
+
+component_fail="${TMPDIR}/component-fail"
+make_component "$component_fail"
+cat > "$component_fail/tests/zzz-smoke.php" <<'PHP'
+<?php
+fwrite( STDERR, "zzz failed\n" );
+exit( 7 );
+PHP
+
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component-fail" \
+HOMEBOY_COMPONENT_PATH="$component_fail" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner-host-smoke.sh" > "${TMPDIR}/direct-fail.out" 2>&1
+exit_code=$?
+set -e
+
+if [ "$exit_code" -ne 7 ]; then
+    echo "Expected failing smoke runner to exit 7, got $exit_code" >&2
+    sed 's/^/  /' "${TMPDIR}/direct-fail.out" >&2
+    exit 1
+fi
+assert_contains "${TMPDIR}/direct-fail.out" "HOST_SMOKE_FAIL:tests/zzz-smoke.php:exit=7"
+assert_contains "${TMPDIR}/direct-fail.out" "Host smoke test failed: tests/zzz-smoke.php"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component-pass" \
+HOMEBOY_COMPONENT_PATH="$component_pass" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_SETTINGS_JSON='{"test_backend":"host-smoke"}' \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/router-host-smoke.out"
+assert_contains "${TMPDIR}/router-host-smoke.out" "Backend: host-smoke"
+assert_not_contains "${TMPDIR}/router-host-smoke.out" "Backend: playground"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component-pass" \
+HOMEBOY_COMPONENT_PATH="$component_pass" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_SETTINGS_JSON='{"test_backend":"host"}' \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/router-host-alias.out"
+assert_contains "${TMPDIR}/router-host-alias.out" "Backend: host-smoke"
+
+echo "Host smoke runner smoke passed"

--- a/wordpress/scripts/test/playground-process-cleanup-smoke.sh
+++ b/wordpress/scripts/test/playground-process-cleanup-smoke.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../lib/playground-process-cleanup.sh"
+
+# shellcheck source=../lib/playground-process-cleanup.sh
+source "$HELPER"
+
+spawn_fake_worker() {
+    bash -c 'exec -a playground-server-child.mjs sleep 60' &
+    FAKE_WORKER_PID=$!
+}
+
+cleanup_pids=()
+cleanup() {
+    local pid
+    for pid in "${cleanup_pids[@]:-}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+}
+trap cleanup EXIT
+
+spawn_fake_worker
+protected_pid=$FAKE_WORKER_PID
+cleanup_pids+=("$protected_pid")
+sleep 0.2
+
+before_snapshot=$(homeboy_playground_snapshot_workers)
+case " ${before_snapshot} " in
+    *" ${protected_pid} "*) ;;
+    *)
+        echo "Expected protected fake worker to appear in snapshot" >&2
+        echo "Snapshot: ${before_snapshot}" >&2
+        exit 1
+        ;;
+esac
+
+spawn_fake_worker
+new_pid=$FAKE_WORKER_PID
+cleanup_pids+=("$new_pid")
+sleep 0.2
+
+homeboy_playground_cleanup_new_workers "$before_snapshot" >/tmp/homeboy-playground-cleanup-smoke.out 2>&1
+sleep 0.2
+
+if kill -0 "$new_pid" 2>/dev/null; then
+    echo "Expected cleanup to terminate new fake worker $new_pid" >&2
+    cat /tmp/homeboy-playground-cleanup-smoke.out >&2
+    exit 1
+fi
+
+if ! kill -0 "$protected_pid" 2>/dev/null; then
+    echo "Expected cleanup to preserve pre-existing fake worker $protected_pid" >&2
+    cat /tmp/homeboy-playground-cleanup-smoke.out >&2
+    exit 1
+fi
+
+if ! grep -Fq "Cleaning up Playground worker(s) left by this run" /tmp/homeboy-playground-cleanup-smoke.out; then
+    echo "Expected cleanup diagnostic" >&2
+    cat /tmp/homeboy-playground-cleanup-smoke.out >&2
+    exit 1
+fi
+
+echo "Playground process cleanup smoke passed"

--- a/wordpress/scripts/test/test-runner-host-smoke.sh
+++ b/wordpress/scripts/test/test-runner-host-smoke.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Host PHP smoke runner for WordPress components that carry standalone smoke
+# scripts instead of PHPUnit suites. This backend intentionally does not boot
+# WordPress, MySQL, or Playground.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+
+# shellcheck source=/dev/null
+source "$RESOLVE_CONTEXT_HELPER"
+homeboy_resolve_context --component-alias PLUGIN_PATH
+
+PHP_BIN="${HOMEBOY_PHP_BIN:-php}"
+TEST_DIR="${PLUGIN_PATH}/tests"
+
+echo "Running host PHP smoke tests..."
+echo "  Component: ${COMPONENT_ID:-$(basename "$PLUGIN_PATH")} (${PLUGIN_PATH})"
+echo "  Backend: host-smoke"
+
+if [ ! -d "$TEST_DIR" ]; then
+    echo ""
+    echo "Skipping host smoke tests: no tests directory found at ${TEST_DIR}"
+    exit 0
+fi
+
+mapfile -t smoke_files < <(find "$TEST_DIR" -type f -name '*-smoke.php' | sort)
+
+if [ "${#smoke_files[@]}" -eq 0 ]; then
+    echo ""
+    echo "Skipping host smoke tests: no files matched ${TEST_DIR}/**/*-smoke.php"
+    exit 0
+fi
+
+echo "  Files: ${#smoke_files[@]}"
+echo ""
+
+passed=0
+for smoke_file in "${smoke_files[@]}"; do
+    rel_path="${smoke_file#"${PLUGIN_PATH}/"}"
+    echo "HOST_SMOKE_BEGIN:${rel_path}"
+    if "$PHP_BIN" "$smoke_file"; then
+        echo "HOST_SMOKE_OK:${rel_path}"
+        passed=$((passed + 1))
+    else
+        exit_code=$?
+        echo "HOST_SMOKE_FAIL:${rel_path}:exit=${exit_code}"
+        echo ""
+        echo "Host smoke test failed: ${rel_path}"
+        exit "$exit_code"
+    fi
+done
+
+echo ""
+echo "HOST_SMOKE_SUMMARY:passed=${passed} failed=0"
+echo "Host smoke test run complete."

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -46,6 +46,7 @@ DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/v
 PHP_PREFLIGHT_HELPER="${SCRIPT_DIR}/../lib/php-preflight.sh"
 PLAYGROUND_PATHS_HELPER="${SCRIPT_DIR}/../lib/playground-paths.sh"
 CLEANUP_NOISE_HELPER="${SCRIPT_DIR}/../lib/playground-cleanup-noise.sh"
+PROCESS_CLEANUP_HELPER="${SCRIPT_DIR}/../lib/playground-process-cleanup.sh"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context --component-alias PLUGIN_PATH
@@ -65,6 +66,8 @@ fi
 source "$PLAYGROUND_PATHS_HELPER"
 # shellcheck source=../lib/playground-cleanup-noise.sh
 source "$CLEANUP_NOISE_HELPER"
+# shellcheck source=../lib/playground-process-cleanup.sh
+source "$PROCESS_CLEANUP_HELPER"
 # shellcheck source=/dev/null
 if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
     source "$FAILURE_TRAP_HELPER"
@@ -253,6 +256,11 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
 fi
 
 PHPUNIT_TMPFILE=$(mktemp)
+PLAYGROUND_WORKERS_BEFORE=$(homeboy_playground_snapshot_workers)
+cleanup_playground_workers() {
+    homeboy_playground_cleanup_new_workers "$PLAYGROUND_WORKERS_BEFORE"
+}
+trap cleanup_playground_workers EXIT
 
 set +e
 "$PLAYGROUND_CLI" php \
@@ -264,6 +272,8 @@ set +e
     2>&1 | homeboy_filter_playground_cleanup_noise | tee "$PHPUNIT_TMPFILE"
 playground_exit=${PIPESTATUS[0]}
 set -e
+cleanup_playground_workers
+trap - EXIT
 
 rm -f "$WRAPPER_TMPFILE"
 

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 # Test runner router for WordPress Homeboy extension.
 #
-# Plugin/theme tests run inside WordPress Playground. Core-dev checkouts
-# (wordpress-develop) dispatch to WordPress core's native PHPUnit runner.
+# Plugin/theme tests run inside WordPress Playground by default. Core-dev
+# checkouts (wordpress-develop) dispatch to WordPress core's native PHPUnit
+# runner. Pure host-PHP smoke suites can opt into the host-smoke backend.
 
 # Bash 4.0+ required — lint-runner.sh (called during test runs) uses
 # associative arrays which are bash 4+ only. Fail early with a clear
@@ -39,6 +40,12 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Component path: ${COMPONENT_PATH:-$(pwd)}"
 fi
 
+TEST_BACKEND=""
+if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    TEST_BACKEND=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.test_backend // .testing.backend // empty' 2>/dev/null || true)
+fi
+TEST_BACKEND="${HOMEBOY_WORDPRESS_TEST_BACKEND:-${TEST_BACKEND:-playground}}"
+
 COMPONENT_SHAPE="${HOMEBOY_COMPONENT_SHAPE:-}"
 if [ -z "$COMPONENT_SHAPE" ]; then
     DETECT_COMPONENT_HELPER="${HOMEBOY_RUNTIME_DETECT_COMPONENT:-${SCRIPT_DIR}/../lib/detect-component.sh}"
@@ -54,6 +61,18 @@ case "$COMPONENT_SHAPE" in
         exec bash "${SCRIPT_DIR}/test-runner-core-dev.sh" "$@"
         ;;
     *)
-        exec bash "${SCRIPT_DIR}/test-runner-playground.sh" "$@"
+        case "$TEST_BACKEND" in
+            host|host-smoke)
+                exec bash "${SCRIPT_DIR}/test-runner-host-smoke.sh" "$@"
+                ;;
+            ""|playground)
+                exec bash "${SCRIPT_DIR}/test-runner-playground.sh" "$@"
+                ;;
+            *)
+                echo "ERROR: Unsupported WordPress test backend: ${TEST_BACKEND}" >&2
+                echo "Supported backends: playground, host, host-smoke" >&2
+                exit 2
+                ;;
+        esac
         ;;
 esac

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -356,9 +356,16 @@
   },
   "testing": {
     "backend": "playground",
-    "description": "All tests run inside WordPress Playground (PHP-WASM + embedded SQLite). Zero host setup required."
+    "description": "Plugin/theme PHPUnit runs inside WordPress Playground by default. Pure PHP smoke suites can opt into the host-smoke backend."
   },
   "settings": [
+    {
+      "id": "test_backend",
+      "label": "Test backend",
+      "type": "string",
+      "default": "playground",
+      "description": "WordPress test backend. Use 'playground' for PHPUnit inside WordPress Playground, or 'host-smoke' / 'host' for standalone tests/**/*-smoke.php scripts run under host PHP without WordPress bootstrap."
+    },
     {
       "id": "validation_dependencies",
       "label": "Validation Dependencies",


### PR DESCRIPTION
## Summary
- Adds a supported WordPress `host-smoke` test backend for standalone `tests/**/*-smoke.php` suites that do not need WordPress, MySQL, or Playground.
- Adds WordPress extension package self-checks so `homeboy lint wordpress --path <repo>/wordpress` and `homeboy test wordpress --path <repo>/wordpress` are the canonical package verification commands.
- Cleans up Playground worker processes spawned by the current test run so failed or aborted runs do not leave `playground-server-child.mjs` processes behind.

## Changes
- Added `test_backend` extension setting with `playground` as the default and `host` / `host-smoke` routed to the new host PHP smoke runner.
- Added `test-runner-host-smoke.sh`, which discovers smoke scripts recursively, runs each file in a separate host PHP process, emits `HOST_SMOKE_*` markers, and fails fast with the failing script name.
- Added `wordpress/homeboy.json` `self_checks.lint` / `self_checks.test` entries. These use Homeboy core's package self-check contract from Extra-Chill/homeboy#1861, available in Homeboy vNext / installed `homeboy 0.121.1` during verification.
- Added scoped Playground process cleanup by snapshotting existing workers before `wp-playground-cli` starts and terminating only new workers left by the current run.
- Updated WordPress testing docs and setup messaging to frame standalone PHP smoke scripts as a supported Homeboy WordPress test backend, not a project-local CI loop.

## Tests
- `homeboy test wordpress --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-runner-host-smokes/wordpress`
- `homeboy lint wordpress --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-runner-host-smokes/wordpress`
- `bash wordpress/scripts/test/host-smoke-runner-smoke.sh`
- `bash wordpress/scripts/test/playground-process-cleanup-smoke.sh`
- `bash wordpress/scripts/test/playground-cleanup-noise-smoke.sh`
- `bash wordpress/scripts/test/playground-no-test-files-smoke.sh`
- `jq empty wordpress/wordpress.json`
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/test-runner-playground.sh wordpress/scripts/test/test-runner-host-smoke.sh wordpress/scripts/lib/playground-process-cleanup.sh wordpress/scripts/test/host-smoke-runner-smoke.sh wordpress/scripts/test/playground-process-cleanup-smoke.sh`
- `git diff --check`

Closes Extra-Chill/homeboy-extensions#322

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the WordPress runner host-smoke path / Playground cleanup and drafting tests; Chris reviewed and ran verification.
