### PR TITLE
fix(wordpress): handle absolute PHPStan scopes

### DIFF
--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -166,12 +166,23 @@ fi
 PHPSTAN_TARGETS=("$PLUGIN_PATH")
 PHPSTAN_SCOPED=0
 
+resolve_phpstan_scope_path() {
+    local target="$1"
+
+    if [[ "$target" = /* ]]; then
+        printf '%s\n' "$target"
+    else
+        printf '%s\n' "${PLUGIN_PATH}/${target}"
+    fi
+}
+
 resolve_phpstan_targets() {
     local matched=()
     local target
+    local resolved_target
 
     if [ -n "${HOMEBOY_LINT_FILE:-}" ]; then
-        target="${PLUGIN_PATH}/${HOMEBOY_LINT_FILE}"
+        target=$(resolve_phpstan_scope_path "$HOMEBOY_LINT_FILE")
         if [ -f "$target" ] && [[ "$target" == *.php ]]; then
             matched+=("$target")
         fi
@@ -180,10 +191,11 @@ resolve_phpstan_targets() {
             cd "$PLUGIN_PATH"
             eval 'for f in '"${HOMEBOY_LINT_GLOB}"'; do [ -e "$f" ] && printf "%s\0" "$f"; done'
         ) | while IFS= read -r -d '' target; do
-            if [ -f "${PLUGIN_PATH}/${target}" ] && [[ "$target" == *.php ]]; then
-                printf '%s\0' "${PLUGIN_PATH}/${target}"
-            elif [ -d "${PLUGIN_PATH}/${target}" ]; then
-                find "${PLUGIN_PATH}/${target}" -type f -name '*.php' \
+            resolved_target=$(resolve_phpstan_scope_path "$target")
+            if [ -f "$resolved_target" ] && [[ "$resolved_target" == *.php ]]; then
+                printf '%s\0' "$resolved_target"
+            elif [ -d "$resolved_target" ]; then
+                find "$resolved_target" -type f -name '*.php' \
                     -not -path "*/vendor/*" \
                     -not -path "*/vendor_prefixed/*" \
                     -not -path "*/node_extensions/*" \

--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -71,10 +71,18 @@ HOMEBOY_LINT_FILE="main.php" run_phpstan
 assert_contains "${COMPONENT_DIR}/main.php" "single-file scope passes the requested PHP file to PHPStan"
 assert_not_contains "$COMPONENT_DIR " "single-file scope does not pass the whole component root"
 
+HOMEBOY_LINT_FILE="${COMPONENT_DIR}/tests/FooTest.php" run_phpstan
+assert_contains "${COMPONENT_DIR}/tests/FooTest.php" "absolute single-file scope passes the requested PHP file to PHPStan"
+assert_not_contains "${COMPONENT_DIR}/${COMPONENT_DIR}" "absolute single-file scope is not prefixed with the component root"
+
 HOMEBOY_LINT_GLOB='{main.php,assets/app.js,tests/FooTest.php}' run_phpstan
 assert_contains "${COMPONENT_DIR}/main.php" "glob scope includes matching PHP source file"
 assert_contains "${COMPONENT_DIR}/tests/FooTest.php" "glob scope includes matching PHP test file"
 assert_not_contains "assets/app.js" "glob scope ignores non-PHP files"
+
+HOMEBOY_LINT_GLOB="${COMPONENT_DIR}/tests/*.php" run_phpstan
+assert_contains "${COMPONENT_DIR}/tests/FooTest.php" "absolute glob scope includes matching PHP test file"
+assert_not_contains "${COMPONENT_DIR}/${COMPONENT_DIR}" "absolute glob scope is not prefixed with the component root"
 
 : > "$ARGS_FILE"
 printf '0\n' > "$CALLS_FILE"


### PR DESCRIPTION
## Summary
- Normalize PHPStan scoped lint targets so absolute paths pass through unchanged while plugin-relative paths still resolve under the component root.
- Extend the scoped PHPStan smoke to cover relative and absolute file/glob inputs.

## Tests
- bash wordpress/scripts/lint/phpstan-scoped-smoke.sh
- bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh
- bash -n wordpress/scripts/lint/phpstan-runner.sh
- bash -n wordpress/scripts/lint/phpstan-scoped-smoke.sh

Closes #326

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the scoped path normalization fix, added smoke coverage, and ran focused verification. Chris remains responsible for review and merge.