### PR TITLE
fix(wordpress): skip non-js scoped ESLint files

### DIFF
--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -70,13 +70,22 @@ elif [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
     MATCHED_FILES=()
     eval 'for f in '"${HOMEBOY_LINT_GLOB}"'; do [ -e "$f" ] && MATCHED_FILES+=("$f"); done'
 
-    if [ ${#MATCHED_FILES[@]} -eq 0 ]; then
-        echo "No JS files match pattern: ${HOMEBOY_LINT_GLOB}"
+    JS_MATCHED_FILES=()
+    for f in "${MATCHED_FILES[@]}"; do
+        case "$f" in
+            *.js|*.jsx|*.ts|*.tsx)
+                JS_MATCHED_FILES+=("$f")
+                ;;
+        esac
+    done
+
+    if [ ${#JS_MATCHED_FILES[@]} -eq 0 ]; then
+        echo "No JS/TS files match pattern: ${HOMEBOY_LINT_GLOB}"
         exit 0
     fi
 
-    echo "Linting ${#MATCHED_FILES[@]} files matching: ${HOMEBOY_LINT_GLOB}"
-    LINT_FILES=("${MATCHED_FILES[@]}")
+    echo "Linting ${#JS_MATCHED_FILES[@]} JS/TS files matching: ${HOMEBOY_LINT_GLOB}"
+    LINT_FILES=("${JS_MATCHED_FILES[@]}")
     cd - > /dev/null
 else
     echo "Running JavaScript linting..."

--- a/wordpress/scripts/lint/eslint-scoped-glob-smoke.sh
+++ b/wordpress/scripts/lint/eslint-scoped-glob-smoke.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/eslint-runner.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+EXTENSION_DIR="${TMPDIR}/extension"
+COMPONENT_DIR="${TMPDIR}/component"
+ARGS_FILE="${TMPDIR}/eslint-args.txt"
+CALLS_FILE="${TMPDIR}/eslint-calls.txt"
+OUTPUT_FILE="${TMPDIR}/eslint-output.txt"
+
+mkdir -p "${EXTENSION_DIR}/node_modules/.bin" "${COMPONENT_DIR}/includes" "${COMPONENT_DIR}/assets"
+touch "${EXTENSION_DIR}/.eslintrc.json"
+touch "${COMPONENT_DIR}/plugin.php" "${COMPONENT_DIR}/includes/Admin.php" "${COMPONENT_DIR}/assets/app.js"
+
+cat > "${EXTENSION_DIR}/node_modules/.bin/eslint" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+count=0
+[ -f "${ESLINT_CALLS_FILE}" ] && count=$(cat "${ESLINT_CALLS_FILE}")
+count=$((count + 1))
+printf '%s\n' "$count" > "${ESLINT_CALLS_FILE}"
+printf '%s\n' "$@" > "${ESLINT_ARGS_FILE}"
+
+for arg in "$@"; do
+    if [ "$arg" = "json" ]; then
+        printf '%s\n' '[]'
+        exit 0
+    fi
+done
+
+exit 0
+SH
+chmod +x "${EXTENSION_DIR}/node_modules/.bin/eslint"
+
+run_eslint() {
+    local glob="$1"
+
+    : > "$ARGS_FILE"
+    printf '0\n' > "$CALLS_FILE"
+    : > "$OUTPUT_FILE"
+
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+    HOMEBOY_COMPONENT_ID="eslint-scoped-glob-smoke" \
+    HOMEBOY_LINT_GLOB="$glob" \
+    HOMEBOY_SUMMARY_MODE=1 \
+    ESLINT_ARGS_FILE="$ARGS_FILE" \
+    ESLINT_CALLS_FILE="$CALLS_FILE" \
+        "$RUNNER" >"$OUTPUT_FILE" 2>&1
+}
+
+assert_contains() {
+    local needle="$1"
+    local file="$2"
+    local message="$3"
+
+    if ! grep -F -- "$needle" "$file" >/dev/null; then
+        echo "FAIL: $message" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1"
+    local file="$2"
+    local message="$3"
+
+    if grep -F -- "$needle" "$file" >/dev/null; then
+        echo "FAIL: $message" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+run_eslint '{plugin.php,includes/Admin.php}'
+
+if [ "$(cat "$CALLS_FILE")" != "0" ]; then
+    echo "FAIL: PHP-only scoped glob should not invoke ESLint" >&2
+    sed 's/^/  /' "$ARGS_FILE" >&2
+    exit 1
+fi
+assert_contains "No JS/TS files match pattern" "$OUTPUT_FILE" "PHP-only scoped glob should print a clear skip message"
+
+run_eslint '{plugin.php,assets/app.js,includes/Admin.php}'
+
+if [ "$(cat "$CALLS_FILE")" != "1" ]; then
+    echo "FAIL: mixed scoped glob should invoke ESLint once in summary mode" >&2
+    sed 's/^/  /' "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+assert_contains "assets/app.js" "$ARGS_FILE" "mixed scoped glob should pass JS files to ESLint"
+assert_not_contains "plugin.php" "$ARGS_FILE" "mixed scoped glob should not pass root PHP file to ESLint"
+assert_not_contains "includes/Admin.php" "$ARGS_FILE" "mixed scoped glob should not pass nested PHP file to ESLint"
+assert_contains "Linting 1 JS/TS files matching" "$OUTPUT_FILE" "mixed scoped glob should report filtered JS/TS count"
+
+echo "ESLint scoped glob smoke passed"


### PR DESCRIPTION
## Summary
- Filter scoped ESLint glob matches to JS/TS extensions before invoking ESLint.
- Exit cleanly with a clear skip message when a scoped glob only matches non-JS/TS files.
- Add smoke coverage for PHP-only and mixed PHP/JS scoped glob runs.

## Behavior
- PHP-only changed-file scopes now skip ESLint instead of passing PHP files to the JS parser.
- Mixed changed-file scopes still run ESLint, but only with matching JS/TS files.
- Unscoped lint behavior is unchanged.

## Tests
- `bash wordpress/scripts/lint/eslint-scoped-glob-smoke.sh`
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `bash -n wordpress/scripts/lint/eslint-runner.sh && bash -n wordpress/scripts/lint/eslint-scoped-glob-smoke.sh`
- `bash wordpress/scripts/lint/autofixable-exit-smoke.sh`
- `homeboy audit homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-eslint-scoped-non-js --changed-since origin/main`

`homeboy lint homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-eslint-scoped-non-js --changed-since origin/main` was attempted but local component config rejected it because `homeboy-extensions` has no extensions configured.

Closes #325

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the scoped ESLint glob filter, added smoke coverage, and ran focused verification. Chris remains responsible for reviewing and merging the change.
