### PR TITLE
fix(wordpress): prepare Playground test schema

### DIFF
--- a/wordpress/scripts/lib/playground-bootstrap.php
+++ b/wordpress/scripts/lib/playground-bootstrap.php
@@ -381,6 +381,7 @@ function pg_run_load_deps_stage(array $cfg) {
                 foreach ($dep_files as $df) {
                     if (strpos(file_get_contents($df), 'Plugin Name:') !== false) {
                         require_once $df;
+                        pg_activate_plugin_file($df);
                         break;
                     }
                 }
@@ -431,6 +432,7 @@ function pg_run_load_component_stage(array $cfg) {
                 if (strpos(file_get_contents($mf), 'Plugin Name:') !== false) {
                     pg_log("PLUGIN_DETECTED " . basename($mf));
                     require_once $mf;
+                    pg_activate_plugin_file($mf);
                     $loaded = true;
                     break;
                 }
@@ -444,4 +446,94 @@ function pg_run_load_component_stage(array $cfg) {
         pg_stage_fail('load_component', $e);
         exit(1);
     }
+}
+
+/**
+ * Run activation hooks for a plugin entry file after loading it.
+ *
+ * The Playground backend boots WordPress from wp-phpunit and then requires the
+ * plugin file directly. Direct loading registers `register_activation_hook()`
+ * callbacks, but it does not fire them. Running the corresponding activation
+ * action gives plugins the same schema-preparation seam their normal PHPUnit
+ * bootstrap relies on without routing through wp-admin redirects.
+ */
+function pg_activate_plugin_file(string $plugin_file): void {
+    if (!function_exists('plugin_basename') || !function_exists('do_action')) {
+        pg_log("NOTICE:cannot activate plugin entry before WordPress plugin API is available: $plugin_file");
+        return;
+    }
+
+    $plugin_basename = plugin_basename($plugin_file);
+    pg_log("PLUGIN_ACTIVATE $plugin_basename");
+
+    do_action("activate_$plugin_basename", false);
+    do_action('activated_plugin', $plugin_basename, false);
+}
+
+/**
+ * Restrict discovered PHPUnit files to HOMEBOY_CHANGED_TEST_FILES.
+ *
+ * Homeboy core passes changed test files as component-relative paths. The
+ * Playground runner discovers tests in the VFS, so compare normalized
+ * component-relative paths and keep the broad discovery path as the fallback
+ * when no scoped list was supplied.
+ */
+function pg_filter_changed_test_files(array $test_files, string $changed_files_json, string $plugin_path): array {
+    $decoded = json_decode($changed_files_json, true);
+    if (!is_array($decoded) || empty($decoded)) {
+        return $test_files;
+    }
+
+    $wanted = [];
+    foreach ($decoded as $entry) {
+        if (!is_scalar($entry)) {
+            continue;
+        }
+        $normalized = pg_normalize_changed_test_file((string) $entry, $plugin_path);
+        if ($normalized !== '') {
+            $wanted[$normalized] = true;
+        }
+    }
+
+    if (empty($wanted)) {
+        pg_log('NOTICE:HOMEBOY_CHANGED_TEST_FILES did not contain usable test paths');
+        return [];
+    }
+
+    $filtered = [];
+    foreach ($test_files as $file) {
+        $relative = pg_component_relative_path((string) $file, $plugin_path);
+        if (isset($wanted[$relative])) {
+            $filtered[] = $file;
+        }
+    }
+
+    pg_log('SCOPED_TEST_FILES requested=' . count($wanted) . ' matched=' . count($filtered));
+    return $filtered;
+}
+
+function pg_normalize_changed_test_file(string $path, string $plugin_path): string {
+    $path = trim(str_replace('\\', '/', $path));
+    if ($path === '') {
+        return '';
+    }
+
+    return pg_component_relative_path($path, $plugin_path);
+}
+
+function pg_component_relative_path(string $path, string $plugin_path): string {
+    $path = trim(str_replace('\\', '/', $path));
+    $plugin_path = rtrim(str_replace('\\', '/', $plugin_path), '/');
+
+    if (strpos($path, $plugin_path . '/') === 0) {
+        $path = substr($path, strlen($plugin_path) + 1);
+    } elseif (strpos($path, '/tests/') !== false) {
+        $path = substr($path, strpos($path, '/tests/') + 1);
+    }
+
+    while (strpos($path, './') === 0) {
+        $path = substr($path, 2);
+    }
+
+    return ltrim($path, '/');
 }

--- a/wordpress/scripts/test/playground-changed-scope-smoke.sh
+++ b/wordpress/scripts/test/playground-changed-scope-smoke.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUNNER="${SCRIPT_DIR}/playground-runner.php"
+RUNNER="${SCRIPT_DIR}/test-runner-playground.sh"
+TEMPLATE="${SCRIPT_DIR}/playground-runner.php"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
 
 assert_contains() {
     local file="$1"
@@ -14,13 +17,83 @@ assert_contains() {
     fi
 }
 
+assert_contains "$TEMPLATE" "{{CHANGED_TEST_FILES_JSON}}"
+assert_contains "$TEMPLATE" "pg_filter_changed_tests"
+assert_contains "$TEMPLATE" "changed test scope skipped non-PHPUnit file"
+assert_contains "$RUNNER" "CHANGED_TEST_FILES_JSON"
 assert_contains "$RUNNER" "{{CHANGED_TEST_FILES_JSON}}"
-assert_contains "$RUNNER" "pg_filter_changed_tests"
-assert_contains "$RUNNER" "changed test scope skipped non-PHPUnit file"
-assert_contains "${SCRIPT_DIR}/test-runner-playground.sh" "CHANGED_TEST_FILES_JSON"
-assert_contains "${SCRIPT_DIR}/test-runner-playground.sh" "{{CHANGED_TEST_FILES_JSON}}"
 
-php -l "$RUNNER" >/dev/null
-bash -n "${SCRIPT_DIR}/test-runner-playground.sh"
+EXTENSION_PATH="${TMPDIR}/extension"
+PLUGIN_PATH="${TMPDIR}/component"
+mkdir -p "${EXTENSION_PATH}/node_modules/.bin" "${PLUGIN_PATH}/tests"
+
+cat > "${PLUGIN_PATH}/tests/OnlyTest.php" <<'PHP'
+<?php
+class OnlyTest extends WP_UnitTestCase {}
+PHP
+cat > "${PLUGIN_PATH}/tests/OtherTest.php" <<'PHP'
+<?php
+class OtherTest extends WP_UnitTestCase {}
+PHP
+
+cat > "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+wrapper=""
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--mount" ]; then
+        mount_arg="$2"
+        if [[ "$mount_arg" == *":/runner.php" ]]; then
+            wrapper="${mount_arg%:/runner.php}"
+        fi
+        shift 2
+        continue
+    fi
+    shift
+done
+
+if [ -z "$wrapper" ] || [ ! -f "$wrapper" ]; then
+    echo "runner wrapper mount not found" >&2
+    exit 1
+fi
+
+if ! grep -Fq '["tests/OnlyTest.php"]' "$wrapper"; then
+    echo "changed-test JSON was not substituted into wrapper" >&2
+    exit 1
+fi
+if grep -Fq '{{CHANGED_TEST_FILES_JSON}}' "$wrapper"; then
+    echo "changed-test placeholder leaked into wrapper" >&2
+    exit 1
+fi
+
+cat > "${HOMEBOY_PLUGIN_PATH}/.pg-test-result.txt" <<'LOG'
+STAGE_BEGIN:discover_tests
+DISCOVERY: dirs=/wordpress/wp-content/plugins/example/tests suffixes=Test.php prefixes=test- excludes=0 found=2
+SCOPED_TEST_FILES requested=1 matched=1
+STAGE_OK:discover_tests
+STAGE_BEGIN:run_tests
+RUNNING 1 TEST FILES
+ALL TESTS PASSED
+TESTS: 1 FAILURES: 0 ERRORS: 0
+STAGE_OK:run_tests
+LOG
+SH
+chmod +x "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli"
+
+php -l "$TEMPLATE" >/dev/null
+bash -n "$RUNNER"
+
+output=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
+    HOMEBOY_COMPONENT_ID="example" \
+    HOMEBOY_CHANGED_TEST_FILES='tests/OnlyTest.php' \
+    bash "$RUNNER" 2>&1)
+
+if [[ "$output" != *"Playground test run complete."* ]]; then
+    echo "Expected successful scoped Playground run" >&2
+    echo "$output" >&2
+    exit 1
+fi
 
 echo "Playground changed-scope smoke passed"

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -30,8 +30,8 @@
  *   install          - wp-phpunit install.php (creates WP + tables)
  *   load_fixtures    - test case classes, mock mailer, harness filters
  *   load_deps        - dependency plugin bootstrap files (if any)
- *   load_component   - plugin/theme under test
- *   discover_tests   - glob test files
+ *   load_component   - plugin/theme under test + plugin activation hook
+ *   discover_tests   - glob test files, then apply changed-file scope
  *   load_tests       - require_once each test file
  *   run_tests        - PHPUnit execution
  *
@@ -189,6 +189,7 @@ try {
     );
 
     $test_files = pg_discover_tests($directories, $suffixes, $prefixes, $excludes);
+    $test_files = pg_filter_changed_test_files($test_files, '{{CHANGED_TEST_FILES_JSON}}', $plugin_path);
 
     if (!empty($changed_test_files)) {
         $test_files = pg_filter_changed_tests($test_files, $changed_test_files, $plugin_path, $suffixes, $prefixes);

--- a/wordpress/scripts/test/playground-schema-scope-smoke.php
+++ b/wordpress/scripts/test/playground-schema-scope-smoke.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Smoke coverage for Playground plugin activation and changed-test scoping.
+ */
+
+$result_file = tempnam( sys_get_temp_dir(), 'pg-schema-scope-' );
+$current_stage = 'preboot';
+$assertions = 0;
+$actions = array();
+$options = array();
+
+function assert_true_smoke( $condition, $message ) {
+    global $assertions;
+    ++$assertions;
+    if ( ! $condition ) {
+        throw new RuntimeException( $message );
+    }
+}
+
+function add_action( $hook, $callback ) {
+    global $actions;
+    $actions[ $hook ][] = $callback;
+}
+
+function do_action( $hook, ...$args ) {
+    global $actions;
+    foreach ( $actions[ $hook ] ?? array() as $callback ) {
+        call_user_func_array( $callback, $args );
+    }
+}
+
+function plugin_basename( $file ) {
+    return basename( dirname( $file ) ) . '/' . basename( $file );
+}
+
+function register_activation_hook( $file, $callback ) {
+    add_action( 'activate_' . plugin_basename( $file ), $callback );
+}
+
+function update_option( $name, $value ) {
+    global $options;
+    $options[ $name ] = $value;
+}
+
+class Smoke_WPDB {
+    public $prefix = 'wptests_';
+    public $queries = array();
+
+    public function query( $sql ) {
+        $this->queries[] = $sql;
+        return true;
+    }
+}
+
+$wpdb = new Smoke_WPDB();
+
+require_once dirname( __DIR__ ) . '/lib/playground-bootstrap.php';
+
+$fixture_path = dirname( __DIR__, 2 ) . '/tests/fixtures/playground-schema-scope';
+pg_run_load_component_stage( array( 'plugin_path' => $fixture_path ) );
+
+assert_true_smoke(
+    isset( $GLOBALS['options']['homeboy_playground_schema_scope_activated'] ),
+    'Plugin activation hook did not update its activation option.'
+);
+assert_true_smoke(
+    count( $GLOBALS['wpdb']->queries ) === 1,
+    'Plugin activation hook did not run the schema query exactly once.'
+);
+assert_true_smoke(
+    strpos( $GLOBALS['wpdb']->queries[0], 'CREATE TABLE wptests_playground_schema_scope' ) !== false,
+    'Plugin activation hook did not create the expected prefixed table.'
+);
+
+$all_test_files = array(
+    $fixture_path . '/tests/SchemaScopeRunsTest.php',
+    $fixture_path . '/tests/UnselectedScopeTest.php',
+);
+$filtered = pg_filter_changed_test_files(
+    $all_test_files,
+    json_encode( array( 'tests/SchemaScopeRunsTest.php' ) ),
+    $fixture_path
+);
+
+assert_true_smoke( count( $filtered ) === 1, 'Changed-test scope did not reduce the file list to one test.' );
+assert_true_smoke(
+    basename( $filtered[0] ) === 'SchemaScopeRunsTest.php',
+    'Changed-test scope kept the wrong test file.'
+);
+
+$vfs_filtered = pg_filter_changed_test_files(
+    array( '/wordpress/wp-content/plugins/example/tests/SchemaScopeRunsTest.php' ),
+    json_encode( array( '/Users/example/plugin/tests/SchemaScopeRunsTest.php' ) ),
+    '/wordpress/wp-content/plugins/example'
+);
+assert_true_smoke( count( $vfs_filtered ) === 1, 'Changed-test scope did not normalize absolute host paths.' );
+
+@unlink( $result_file );
+echo "Playground schema/scope smoke passed ($assertions assertions)\n";

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -156,6 +156,9 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     fi
 fi
 
+# Homeboy core sends changed test paths as newline-delimited component-relative
+# paths. Playground PHP cannot reliably read host env directly, so substitute a
+# JSON array into the runner template and let it filter VFS-discovered tests.
 CHANGED_TEST_FILES_JSON="[]"
 if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
     CHANGED_TEST_FILES_JSON=$(printf '%s' "${HOMEBOY_CHANGED_TEST_FILES}" | php -r '

--- a/wordpress/tests/fixtures/playground-schema-scope/playground-schema-scope.php
+++ b/wordpress/tests/fixtures/playground-schema-scope/playground-schema-scope.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Plugin Name: Playground Schema Scope Fixture
+ * Description: Fixture plugin for Playground activation and changed-test scope smokes.
+ * Version: 1.0.0
+ *
+ * @package Homeboy\WordPress\Tests\Fixtures
+ */
+
+register_activation_hook( __FILE__, 'homeboy_playground_schema_scope_activate' );
+
+function homeboy_playground_schema_scope_activate() {
+    global $wpdb;
+
+    $table = $wpdb->prefix . 'playground_schema_scope';
+    $wpdb->query( "CREATE TABLE $table (id INTEGER PRIMARY KEY, label TEXT NOT NULL)" );
+    update_option( 'homeboy_playground_schema_scope_activated', 'yes' );
+}

--- a/wordpress/tests/fixtures/playground-schema-scope/tests/SchemaScopeRunsTest.php
+++ b/wordpress/tests/fixtures/playground-schema-scope/tests/SchemaScopeRunsTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Fixture test selected by HOMEBOY_CHANGED_TEST_FILES.
+ *
+ * @package Homeboy\WordPress\Tests\Fixtures
+ */
+
+class SchemaScopeRunsTest extends WP_UnitTestCase {
+
+    public function test_activation_schema_exists() {
+        global $wpdb;
+
+        $this->assertSame( 'yes', get_option( 'homeboy_playground_schema_scope_activated' ) );
+        $this->assertSame(
+            $wpdb->prefix . 'playground_schema_scope',
+            $wpdb->get_var( "SELECT name FROM sqlite_master WHERE type='table' AND name='{$wpdb->prefix}playground_schema_scope'" )
+        );
+    }
+}

--- a/wordpress/tests/fixtures/playground-schema-scope/tests/UnselectedScopeTest.php
+++ b/wordpress/tests/fixtures/playground-schema-scope/tests/UnselectedScopeTest.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Fixture test that must be filtered out by HOMEBOY_CHANGED_TEST_FILES.
+ *
+ * @package Homeboy\WordPress\Tests\Fixtures
+ */
+
+class UnselectedScopeTest extends WP_UnitTestCase {
+
+    public function test_unselected_file_would_fail_if_loaded() {
+        $this->fail( 'Changed-test scope did not filter this file out.' );
+    }
+}


### PR DESCRIPTION
## Summary
- Fire WordPress plugin activation hooks after Playground loads dependency and component plugin entry files so activation-created schema exists before PHPUnit runs.
- Thread `HOMEBOY_CHANGED_TEST_FILES` into the Playground PHP runner and filter discovered VFS test files to the changed scope.
- Add focused fixture/smoke coverage for activation-created custom tables and changed-test-file scoping.

## Tests
- `php wordpress/scripts/test/playground-schema-scope-smoke.php`
- `bash wordpress/scripts/test/playground-changed-scope-smoke.sh`
- `bash wordpress/scripts/test/playground-no-test-files-smoke.sh`
- `php -l wordpress/scripts/lib/playground-bootstrap.php`
- `php -l wordpress/scripts/test/playground-runner.php`
- `php -l wordpress/scripts/test/playground-schema-scope-smoke.php`
- `php -l wordpress/tests/fixtures/playground-schema-scope/playground-schema-scope.php && php -l wordpress/tests/fixtures/playground-schema-scope/tests/SchemaScopeRunsTest.php && php -l wordpress/tests/fixtures/playground-schema-scope/tests/UnselectedScopeTest.php`
- `bash -n wordpress/scripts/test/test-runner-playground.sh`
- `bash -n wordpress/scripts/test/playground-changed-scope-smoke.sh`

Not run: full Playground backend, because this worktree does not have `wordpress/node_modules/.bin/wp-playground-cli` installed. The added shell smoke stubs that CLI boundary and the PHP smoke exercises the runner helpers directly.

Closes #327

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Playground runner/schema fix, added fixture smoke coverage, and ran focused verification. Chris remains responsible for review and merge.