### PR TITLE
fix(wordpress): keep component context for scoped PHPStan

### DIFF
--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -119,6 +119,7 @@ generate_dependency_config() {
     local tmpfile
     local has_dependencies=0
     local has_baseline=0
+    local has_component_context=0
 
     tmpfile=$(homeboy_mktemp 'phpstan-dependencies.XXXXXX.neon')
 
@@ -138,6 +139,11 @@ generate_dependency_config() {
         printf '%s\n' 'parameters:'
         printf '%s\n' '    scanDirectories:'
 
+        if [ -n "${HOMEBOY_LINT_FILE:-}" ] || [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
+            has_component_context=1
+            printf '        - %s\n' "$PLUGIN_PATH"
+        fi
+
         while IFS= read -r dependency_path; do
             [ -z "$dependency_path" ] && continue
             has_dependencies=1
@@ -145,7 +151,7 @@ generate_dependency_config() {
         done < <(homeboy_resolve_validation_dependency_paths "$PLUGIN_PATH")
     } > "$tmpfile"
 
-    if [ "$has_dependencies" -eq 1 ] || [ "$has_baseline" -eq 1 ]; then
+    if [ "$has_dependencies" -eq 1 ] || [ "$has_baseline" -eq 1 ] || [ "$has_component_context" -eq 1 ]; then
         printf '%s\n' "$tmpfile"
     else
         rm -f "$tmpfile"

--- a/wordpress/tests/phpstan-scoped-component-context-smoke.sh
+++ b/wordpress/tests/phpstan-scoped-component-context-smoke.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PHPSTAN_RUNNER="${ROOT_DIR}/scripts/lint/phpstan-runner.sh"
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq -- "$expected" "$file"; then
+        echo "Expected $file to contain: $expected" >&2
+        echo "Actual contents:" >&2
+        cat "$file" >&2
+        exit 1
+    fi
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+COMPONENT_DIR="${TMP_DIR}/html-to-blocks-converter"
+FAKE_EXTENSION="${TMP_DIR}/fake-wordpress-extension"
+CAPTURE_FILE="${TMP_DIR}/phpstan-capture.txt"
+
+mkdir -p "${COMPONENT_DIR}/includes" "${FAKE_EXTENSION}/vendor/bin"
+
+cat > "${COMPONENT_DIR}/html-to-blocks-converter.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: HTML To Blocks Converter
+ */
+PHP
+
+cat > "${COMPONENT_DIR}/includes/class-html-element.php" <<'PHP'
+<?php
+
+class HTML_To_Blocks_HTML_Element {}
+PHP
+
+cat > "${COMPONENT_DIR}/includes/class-transform-registry.php" <<'PHP'
+<?php
+
+class HTML_To_Blocks_Transform_Registry {
+    public function register( HTML_To_Blocks_HTML_Element $element ): void {}
+}
+PHP
+
+cat > "${FAKE_EXTENSION}/phpstan.neon.dist" <<'NEON'
+parameters:
+    level: 7
+NEON
+
+cat > "${FAKE_EXTENSION}/vendor/bin/phpstan" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+config=""
+targets=()
+for arg in "$@"; do
+    case "$arg" in
+        --configuration=*) config="${arg#--configuration=}" ;;
+        *.php) targets+=("$arg") ;;
+    esac
+done
+
+{
+    echo "config=${config}"
+    echo "target_count=${#targets[@]}"
+    printf 'target=%s\n' "${targets[@]}"
+    echo "---config---"
+    cat "$config"
+} > "$PHPSTAN_CAPTURE"
+
+if [ "${#targets[@]}" -ne 1 ]; then
+    echo "Expected scoped PHPStan to analyze one target, got ${#targets[@]}" >&2
+    exit 1
+fi
+
+if [ "${targets[0]}" != "${HOMEBOY_COMPONENT_PATH}/includes/class-transform-registry.php" ]; then
+    echo "Expected scoped PHPStan target to remain the requested file" >&2
+    exit 1
+fi
+
+if ! grep -Fq -- "- ${HOMEBOY_COMPONENT_PATH}" "$config"; then
+    echo "Expected scoped PHPStan config to scan the component for sibling declarations" >&2
+    exit 1
+fi
+
+exit 0
+SH
+chmod +x "${FAKE_EXTENSION}/vendor/bin/phpstan"
+
+HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="html-to-blocks-converter" \
+HOMEBOY_LINT_FILE="includes/class-transform-registry.php" \
+HOMEBOY_CACHE_DIR="$TMP_DIR" \
+PHPSTAN_CAPTURE="$CAPTURE_FILE" \
+    bash "$PHPSTAN_RUNNER" > "${TMP_DIR}/phpstan.out" 2>&1
+
+assert_contains "${TMP_DIR}/phpstan.out" "PHPStan scoped lint: analyzing 1 PHP file(s) from requested scope"
+assert_contains "$CAPTURE_FILE" "target_count=1"
+assert_contains "$CAPTURE_FILE" "target=${COMPONENT_DIR}/includes/class-transform-registry.php"
+assert_contains "$CAPTURE_FILE" "- ${COMPONENT_DIR}"
+
+echo "phpstan scoped component context smoke passed"


### PR DESCRIPTION
## Summary
- Preserve PHPStan single-file reporting while restoring sibling plugin declaration discovery for scoped WordPress lint runs.
- Add a smoke test that pins the generated scoped config and target contract.

## Changes
- Adds the component root to generated PHPStan `scanDirectories` when `HOMEBOY_LINT_FILE` or `HOMEBOY_LINT_GLOB` is active.
- Keeps the PHPStan positional analysis target narrowed to the requested file(s).
- Adds a fake-PHPStan smoke fixture covering sibling declarations like html-to-blocks-converter's global classes.

## Tests
- `bash wordpress/tests/phpstan-scoped-component-context-smoke.sh`
- `bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- `bash tests/wordpress-lint-context-smoke.sh`
- `bash -n wordpress/scripts/lint/phpstan-runner.sh`
- `bash -n wordpress/tests/phpstan-scoped-component-context-smoke.sh`
- Direct runner check against `/Users/chubes/Developer/html-to-blocks-converter` for `includes/class-transform-registry.php`; sibling `class.notFound` noise is gone, leaving real type findings only.

Closes #332

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the scoped PHPStan config fix, added the smoke test, and ran focused verification. Chris remains responsible for review and merge.