### PR TITLE
fix(wordpress): scope lint profile to runtime files

### DIFF
--- a/tests/wordpress-lint-context-smoke.sh
+++ b/tests/wordpress-lint-context-smoke.sh
@@ -20,7 +20,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 COMPONENT_DIR="$TMP_DIR/example-plugin"
 FAKE_EXTENSION="$TMP_DIR/fake-wordpress-extension"
-mkdir -p "$COMPONENT_DIR" "$FAKE_EXTENSION/vendor/bin" "$FAKE_EXTENSION/HomeboyWordPress"
+mkdir -p "$COMPONENT_DIR/tools" "$COMPONENT_DIR/tests" "$COMPONENT_DIR/vendor_prefixed/example" "$FAKE_EXTENSION/vendor/bin" "$FAKE_EXTENSION/HomeboyWordPress"
 
 cat > "$COMPONENT_DIR/example-plugin.php" <<'PHP'
 <?php
@@ -32,6 +32,34 @@ PHP
 
 touch "$FAKE_EXTENSION/vendor/bin/phpcs" "$FAKE_EXTENSION/vendor/bin/phpcbf" "$FAKE_EXTENSION/phpcs.xml.dist"
 
+cat > "$COMPONENT_DIR/scoper.inc.php" <<'PHP'
+<?php
+return [
+    'prefix' => 'Example\\Vendor',
+];
+PHP
+
+cat > "$COMPONENT_DIR/tools/build-autoloader.php" <<'PHP'
+<?php
+file_put_contents(__DIR__ . '/autoload.php', '<?php return [];');
+PHP
+
+cat > "$COMPONENT_DIR/tests/smoke-example.php" <<'PHP'
+<?php
+require_once __DIR__ . '/../example-plugin.php';
+echo "ok\n";
+PHP
+
+cat > "$COMPONENT_DIR/tests/ExampleUnitTest.php" <<'PHP'
+<?php
+class ExampleUnitTest extends WP_UnitTestCase {}
+PHP
+
+cat > "$COMPONENT_DIR/vendor_prefixed/example/generated.php" <<'PHP'
+<?php
+class Example_Generated {}
+PHP
+
 HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
@@ -42,7 +70,29 @@ assert_contains "$TMP_DIR/lint.out" "Linting passed"
 
 assert_contains "$RUNNER" 'homeboy_resolve_context --component-alias PLUGIN_PATH'
 assert_contains "$RUNNER" "*/vendor_prefixed/*"
+assert_contains "$RUNNER" "*/tools/*"
+assert_contains "$RUNNER" "*/scoper.inc.php"
 assert_contains "$PHPSTAN_RUNNER" "*/vendor_prefixed/*"
+assert_contains "$PHPSTAN_RUNNER" "*/tools/*"
+assert_contains "$PHPSTAN_RUNNER" "scoper.inc.php"
 assert_contains "$PHPSTAN_CONFIG" "*/vendor_prefixed/*"
+assert_contains "$PHPSTAN_CONFIG" "*/tools/*"
+assert_contains "$PHPSTAN_CONFIG" "*/scoper.inc.php"
+
+for non_runtime_file in \
+    scoper.inc.php \
+    tools/build-autoloader.php \
+    tests/smoke-example.php \
+    tests/ExampleUnitTest.php \
+    vendor_prefixed/example/generated.php; do
+    HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
+    HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+    HOMEBOY_COMPONENT_ID="example-plugin" \
+    HOMEBOY_LINT_FILE="$non_runtime_file" \
+        bash "$RUNNER" > "$TMP_DIR/non-runtime.out" 2>&1
+
+    assert_contains "$TMP_DIR/non-runtime.out" "Skipping production WordPress lint profile for non-runtime file scope"
+    assert_contains "$TMP_DIR/non-runtime.out" "Linting passed"
+done
 
 echo "wordpress lint context smoke passed"

--- a/wordpress/phpcs.xml.dist
+++ b/wordpress/phpcs.xml.dist
@@ -38,6 +38,8 @@
     <exclude-pattern>/node_modules/*</exclude-pattern>
     <exclude-pattern>/build/*</exclude-pattern>
     <exclude-pattern>/dist/*</exclude-pattern>
+    <exclude-pattern>/tools/*</exclude-pattern>
+    <exclude-pattern>/scoper.inc.php</exclude-pattern>
     <exclude-pattern>/tests/*</exclude-pattern>
 
     <!-- Text domain is auto-detected from plugin header by test-runner.sh -->

--- a/wordpress/phpstan.neon.dist
+++ b/wordpress/phpstan.neon.dist
@@ -63,6 +63,8 @@ parameters:
         - */node_modules/*
         - */build/*
         - */dist/*
+        - */tools/*
+        - */scoper.inc.php
 
     parallel:
         maximumNumberOfProcesses: 2

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -163,6 +163,86 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "Fix-only: ${HOMEBOY_FIX_ONLY:-0}"
 fi
 
+homeboy_lint_relpath() {
+    local path="$1"
+    path="${path#$PLUGIN_PATH/}"
+    path="${path#./}"
+    printf '%s\n' "$path"
+}
+
+homeboy_wordpress_runtime_lint_file() {
+    local rel_path="$1"
+
+    case "$rel_path" in
+        scoper.inc.php|tools/*|tests/smoke-*.php|tests/*UnitTest.php|tests/*Test.php|vendor_prefixed/*|vendor/*)
+            return 1
+            ;;
+    esac
+
+    return 0
+}
+
+homeboy_php_syntax_check() {
+    local syntax_errors=0
+    local lint_target php_file rel_path
+
+    for lint_target in "$@"; do
+        if [ -d "$lint_target" ]; then
+            while IFS= read -r -d '' php_file; do
+                rel_path=$(homeboy_lint_relpath "$php_file")
+                if ! homeboy_wordpress_runtime_lint_file "$rel_path"; then
+                    if ! php -l "$php_file" > /dev/null 2>&1; then
+                        php -l "$php_file" || true
+                        syntax_errors=$((syntax_errors + 1))
+                    fi
+                fi
+            done < <(find "$lint_target" -type f -name '*.php' -print0)
+        elif [ -f "$lint_target" ] && [[ "$lint_target" == *.php ]]; then
+            if ! php -l "$lint_target" > /dev/null 2>&1; then
+                php -l "$lint_target" || true
+                syntax_errors=$((syntax_errors + 1))
+            fi
+        fi
+    done
+
+    if [ "$syntax_errors" -gt 0 ]; then
+        echo "PHP syntax check failed for ${syntax_errors} non-runtime file(s)"
+        return 1
+    fi
+
+    return 0
+}
+
+# The WordPress lint profile targets production plugin/theme runtime files. Keep
+# php-scoper config, build tooling, smoke harnesses, PHPUnit tests, and generated
+# vendored code out of that profile; syntax checking is enough for those roles.
+if [ -n "${HOMEBOY_LINT_FILE:-}" ] || [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
+    RUNTIME_LINT_FILES=()
+    NON_RUNTIME_LINT_FILES=()
+
+    for lint_target in "${LINT_FILES[@]}"; do
+        rel_target=$(homeboy_lint_relpath "$lint_target")
+        if [ -f "$lint_target" ] && ! homeboy_wordpress_runtime_lint_file "$rel_target"; then
+            NON_RUNTIME_LINT_FILES+=("$lint_target")
+        else
+            RUNTIME_LINT_FILES+=("$lint_target")
+        fi
+    done
+
+    if [ "${#NON_RUNTIME_LINT_FILES[@]}" -gt 0 ]; then
+        echo "Non-runtime WordPress lint profile: syntax-checking ${#NON_RUNTIME_LINT_FILES[@]} file(s)"
+        homeboy_php_syntax_check "${NON_RUNTIME_LINT_FILES[@]}"
+    fi
+
+    if [ "${#RUNTIME_LINT_FILES[@]}" -eq 0 ]; then
+        echo "Skipping production WordPress lint profile for non-runtime file scope"
+        echo "Linting passed"
+        exit 0
+    fi
+
+    LINT_FILES=("${RUNTIME_LINT_FILES[@]}")
+fi
+
 PHPCS_BIN="${EXTENSION_PATH}/vendor/bin/phpcs"
 PHPCBF_BIN="${EXTENSION_PATH}/vendor/bin/phpcbf"
 YODA_FIXER="${EXTENSION_PATH}/scripts/lint/php-fixers/yoda-fixer.php"
@@ -527,7 +607,7 @@ fixable_count=0
 
 # Build base phpcs arguments
 phpcs_base_args=(--standard="$PHPCS_CONFIG")
-phpcs_base_args+=(--ignore='*/vendor/*,*/vendor_prefixed/*,*/node_modules/*,*/build/*,*/dist/*')
+phpcs_base_args+=(--ignore='*/vendor/*,*/vendor_prefixed/*,*/node_modules/*,*/build/*,*/dist/*,*/tools/*,*/scoper.inc.php')
 
 # Auto-detect parallelism from available CPU cores
 if [ -z "${PARALLEL_PROCS:-}" ]; then

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -166,13 +166,32 @@ fi
 PHPSTAN_TARGETS=("$PLUGIN_PATH")
 PHPSTAN_SCOPED=0
 
+homeboy_phpstan_relpath() {
+    local path="$1"
+    path="${path#$PLUGIN_PATH/}"
+    path="${path#./}"
+    printf '%s\n' "$path"
+}
+
+homeboy_phpstan_runtime_file() {
+    local rel_path="$1"
+
+    case "$rel_path" in
+        scoper.inc.php|tools/*|tests/smoke-*.php|tests/*UnitTest.php|tests/*Test.php|vendor_prefixed/*|vendor/*)
+            return 1
+            ;;
+    esac
+
+    return 0
+}
+
 resolve_phpstan_targets() {
     local matched=()
     local target
 
     if [ -n "${HOMEBOY_LINT_FILE:-}" ]; then
         target="${PLUGIN_PATH}/${HOMEBOY_LINT_FILE}"
-        if [ -f "$target" ] && [[ "$target" == *.php ]]; then
+        if [ -f "$target" ] && [[ "$target" == *.php ]] && homeboy_phpstan_runtime_file "$(homeboy_phpstan_relpath "$target")"; then
             matched+=("$target")
         fi
     elif [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
@@ -180,7 +199,7 @@ resolve_phpstan_targets() {
             cd "$PLUGIN_PATH"
             eval 'for f in '"${HOMEBOY_LINT_GLOB}"'; do [ -e "$f" ] && printf "%s\0" "$f"; done'
         ) | while IFS= read -r -d '' target; do
-            if [ -f "${PLUGIN_PATH}/${target}" ] && [[ "$target" == *.php ]]; then
+            if [ -f "${PLUGIN_PATH}/${target}" ] && [[ "$target" == *.php ]] && homeboy_phpstan_runtime_file "$target"; then
                 printf '%s\0' "${PLUGIN_PATH}/${target}"
             elif [ -d "${PLUGIN_PATH}/${target}" ]; then
                 find "${PLUGIN_PATH}/${target}" -type f -name '*.php' \
@@ -189,6 +208,9 @@ resolve_phpstan_targets() {
                     -not -path "*/node_extensions/*" \
                     -not -path "*/build/*" \
                     -not -path "*/dist/*" \
+                    -not -path "*/tools/*" \
+                    -not -path "*/tests/*" \
+                    -not -name "scoper.inc.php" \
                     -print0
             fi
         done
@@ -223,6 +245,8 @@ else
         -not -path "*/node_extensions/*" \
         -not -path "*/build/*" \
         -not -path "*/dist/*" \
+        -not -path "*/tools/*" \
+        -not -name "scoper.inc.php" \
         -not -path "*/tests/*" \
         2>/dev/null | wc -l | tr -d ' ')
 fi


### PR DESCRIPTION
## Summary
- Keeps php-scoper config, build tooling, smoke harnesses, PHPUnit tests, and generated/vendor-prefixed files out of the production WordPress lint profile.
- Preserves basic PHP syntax checking for scoped non-runtime files so malformed PHP still fails quickly.

## Changes
- Adds scoped file-role detection to the WordPress lint runner and PHPStan runner.
- Excludes `tools/**` and `scoper.inc.php` from full-component PHPCS/PHPStan scans alongside existing generated/test exclusions.
- Expands the WordPress lint context smoke with concrete non-runtime examples matching the BFB/h2bc false-positive cases.

## Tests
- `bash tests/wordpress-lint-context-smoke.sh`
- `bash tests/runtime-helpers-smoke.sh`
- `bash tests/wordpress-remote-path-inference-smoke.sh`
- `bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- `bash wordpress/tests/component-env-detector-smoke.sh`
- `bash wordpress/tests/wp-test-smells-smoke.sh`
- `bash wordpress/tests/wp-cli-auto-flags-smoke.sh`
- `bash -n wordpress/scripts/lint/lint-runner.sh wordpress/scripts/lint/phpstan-runner.sh tests/wordpress-lint-context-smoke.sh`
- BFB repros: `scoper.inc.php`, `tools/build-autoloader.php`, `tests/BFBConversionUnitTest.php`

Closes #331

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the scoped lint-profile boundary, expanded smoke coverage, and ran local verification; Chris remains responsible for review and merge.