### PR TITLE
fix(wordpress): load runtime context for scoped PHPStan

### DIFF
--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -119,6 +119,9 @@ generate_dependency_config() {
     local tmpfile
     local has_dependencies=0
     local has_baseline=0
+    local has_component_context=0
+    local context_path
+    local scan_file_count=0
 
     tmpfile=$(homeboy_mktemp 'phpstan-dependencies.XXXXXX.neon')
 
@@ -143,14 +146,60 @@ generate_dependency_config() {
             has_dependencies=1
             printf '        - %s\n' "$dependency_path"
         done < <(homeboy_resolve_validation_dependency_paths "$PLUGIN_PATH")
+
+        if [ -n "${HOMEBOY_LINT_FILE:-}" ] || [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
+            while IFS= read -r context_path; do
+                [ -z "$context_path" ] && continue
+                has_component_context=1
+                printf '        - %s\n' "$context_path"
+            done < <(homeboy_resolve_phpstan_context_directories "$PLUGIN_PATH")
+
+            while IFS= read -r context_path; do
+                [ -z "$context_path" ] && continue
+                if [ "$scan_file_count" -eq 0 ]; then
+                    printf '%s\n' '    scanFiles:'
+                fi
+                scan_file_count=$((scan_file_count + 1))
+                has_component_context=1
+                printf '        - %s\n' "$context_path"
+            done < <(homeboy_resolve_phpstan_context_files "$PLUGIN_PATH")
+        fi
     } > "$tmpfile"
 
-    if [ "$has_dependencies" -eq 1 ] || [ "$has_baseline" -eq 1 ]; then
+    if [ "$has_dependencies" -eq 1 ] || [ "$has_baseline" -eq 1 ] || [ "$has_component_context" -eq 1 ]; then
         printf '%s\n' "$tmpfile"
     else
         rm -f "$tmpfile"
         printf '%s\n' ''
     fi
+}
+
+homeboy_resolve_phpstan_context_directories() {
+    local component_path="$1"
+    local candidate
+
+    find "$component_path" -mindepth 1 -maxdepth 1 -type d \
+        -not -name 'vendor' \
+        -not -name 'vendor_prefixed' \
+        -not -name 'node_modules' \
+        -not -name 'build' \
+        -not -name 'dist' \
+        -not -name 'tests' \
+        -print 2>/dev/null | while IFS= read -r candidate; do
+            if find "$candidate" -type f -name '*.php' -print -quit 2>/dev/null | grep -q .; then
+                printf '%s\n' "$candidate"
+            fi
+        done
+
+    if [ -d "${component_path}/vendor_prefixed" ]; then
+        printf '%s\n' "${component_path}/vendor_prefixed"
+    fi
+}
+
+homeboy_resolve_phpstan_context_files() {
+    local component_path="$1"
+
+    find "$component_path" -mindepth 1 -maxdepth 1 -type f -name '*.php' -print 2>/dev/null
 }
 
 cleanup_dependency_config() {
@@ -270,6 +319,7 @@ fi
 generate_composite_autoload() {
     local tmpfile
     local component_autoload="${PLUGIN_PATH}/vendor/autoload.php"
+    local component_prefixed_autoload="${PLUGIN_PATH}/vendor_prefixed/autoload.php"
 
     tmpfile=$(homeboy_mktemp 'homeboy-phpstan-autoload.XXXXXX')
 
@@ -280,13 +330,21 @@ generate_composite_autoload() {
         while IFS= read -r dependency_path; do
             [ -z "$dependency_path" ] && continue
             local dependency_autoload="${dependency_path}/vendor/autoload.php"
+            local dependency_prefixed_autoload="${dependency_path}/vendor_prefixed/autoload.php"
             if [ -f "$dependency_autoload" ]; then
                 printf '    %s,\n' "$(printf '%s' "$dependency_autoload" | jq -Rsa .)"
+            fi
+            if [ -f "$dependency_prefixed_autoload" ]; then
+                printf '    %s,\n' "$(printf '%s' "$dependency_prefixed_autoload" | jq -Rsa .)"
             fi
         done < <(homeboy_resolve_validation_dependency_paths "$PLUGIN_PATH")
 
         if [ -f "$component_autoload" ]; then
             printf '    %s,\n' "$(printf '%s' "$component_autoload" | jq -Rsa .)"
+        fi
+
+        if [ -f "$component_prefixed_autoload" ]; then
+            printf '    %s,\n' "$(printf '%s' "$component_prefixed_autoload" | jq -Rsa .)"
         fi
 
         printf '%s\n' '];'

--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -11,10 +11,13 @@ COMPONENT_DIR="${TMPDIR}/component"
 ARGS_FILE="${TMPDIR}/phpstan-args.txt"
 CALLS_FILE="${TMPDIR}/phpstan-calls.txt"
 DEPENDENCY_HELPER="${TMPDIR}/validation-dependencies.sh"
+CONFIG_CAPTURE="${TMPDIR}/phpstan-config-capture.neon"
+AUTOLOAD_CAPTURE="${TMPDIR}/phpstan-autoload-capture.php"
 
-mkdir -p "${EXTENSION_DIR}/vendor/bin" "${COMPONENT_DIR}/tests" "${COMPONENT_DIR}/assets"
+mkdir -p "${EXTENSION_DIR}/vendor/bin" "${COMPONENT_DIR}/tests" "${COMPONENT_DIR}/assets" "${COMPONENT_DIR}/includes" "${COMPONENT_DIR}/vendor_prefixed"
 touch "${EXTENSION_DIR}/phpstan.neon.dist"
 touch "${COMPONENT_DIR}/main.php" "${COMPONENT_DIR}/tests/FooTest.php" "${COMPONENT_DIR}/assets/app.js"
+touch "${COMPONENT_DIR}/includes/interface-example.php" "${COMPONENT_DIR}/vendor_prefixed/autoload.php"
 
 cat > "$DEPENDENCY_HELPER" <<'SH'
 homeboy_resolve_validation_dependency_paths() {
@@ -26,6 +29,12 @@ cat > "${EXTENSION_DIR}/vendor/bin/phpstan" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" > "${PHPSTAN_ARGS_FILE}"
+for arg in "$@"; do
+    case "$arg" in
+        --configuration=*) cp "${arg#--configuration=}" "${PHPSTAN_CONFIG_CAPTURE}" ;;
+        --autoload-file=*) cp "${arg#--autoload-file=}" "${PHPSTAN_AUTOLOAD_CAPTURE}" ;;
+    esac
+done
 count=0
 [ -f "${PHPSTAN_CALLS_FILE}" ] && count=$(cat "${PHPSTAN_CALLS_FILE}")
 count=$((count + 1))
@@ -43,6 +52,8 @@ run_phpstan() {
     HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
     PHPSTAN_ARGS_FILE="$ARGS_FILE" \
     PHPSTAN_CALLS_FILE="$CALLS_FILE" \
+    PHPSTAN_CONFIG_CAPTURE="$CONFIG_CAPTURE" \
+    PHPSTAN_AUTOLOAD_CAPTURE="$AUTOLOAD_CAPTURE" \
     HOMEBOY_SUMMARY_MODE=1 \
     "$RUNNER" >/dev/null
 }
@@ -67,9 +78,49 @@ assert_not_contains() {
     fi
 }
 
+assert_file_contains() {
+    local file="$1"
+    local needle="$2"
+    local message="$3"
+    if ! grep -F -- "$needle" "$file" >/dev/null; then
+        echo "FAIL: $message" >&2
+        echo "File: $file" >&2
+        cat "$file" >&2
+        exit 1
+    fi
+}
+
+assert_file_not_contains() {
+    local file="$1"
+    local needle="$2"
+    local message="$3"
+    if grep -F -- "$needle" "$file" >/dev/null; then
+        echo "FAIL: $message" >&2
+        echo "File: $file" >&2
+        cat "$file" >&2
+        exit 1
+    fi
+}
+
 HOMEBOY_LINT_FILE="main.php" run_phpstan
 assert_contains "${COMPONENT_DIR}/main.php" "single-file scope passes the requested PHP file to PHPStan"
 assert_not_contains "$COMPONENT_DIR " "single-file scope does not pass the whole component root"
+
+if [ ! -f "$CONFIG_CAPTURE" ]; then
+    echo "FAIL: scoped PHPStan run should generate a context config" >&2
+    exit 1
+fi
+
+if [ ! -f "$AUTOLOAD_CAPTURE" ]; then
+    echo "FAIL: scoped PHPStan run should generate a composite autoload file" >&2
+    exit 1
+fi
+
+assert_file_contains "$CONFIG_CAPTURE" "${COMPONENT_DIR}/includes" "scoped context scans plugin production declarations"
+assert_file_contains "$CONFIG_CAPTURE" "${COMPONENT_DIR}/vendor_prefixed" "scoped context scans prefixed vendor declarations"
+assert_file_contains "$CONFIG_CAPTURE" "${COMPONENT_DIR}/main.php" "scoped context scans top-level plugin files"
+assert_file_not_contains "$CONFIG_CAPTURE" "${COMPONENT_DIR}/tests" "scoped context excludes test declarations"
+assert_file_contains "$AUTOLOAD_CAPTURE" "${COMPONENT_DIR}/vendor_prefixed/autoload.php" "composite autoload loads prefixed vendor autoloader"
 
 HOMEBOY_LINT_GLOB='{main.php,assets/app.js,tests/FooTest.php}' run_phpstan
 assert_contains "${COMPONENT_DIR}/main.php" "glob scope includes matching PHP source file"
@@ -84,6 +135,8 @@ HOMEBOY_COMPONENT_ID="phpstan-smoke" \
 HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
 PHPSTAN_ARGS_FILE="$ARGS_FILE" \
 PHPSTAN_CALLS_FILE="$CALLS_FILE" \
+PHPSTAN_CONFIG_CAPTURE="$CONFIG_CAPTURE" \
+PHPSTAN_AUTOLOAD_CAPTURE="$AUTOLOAD_CAPTURE" \
 HOMEBOY_SUMMARY_MODE=1 \
 HOMEBOY_LINT_FILE="assets/app.js" \
 "$RUNNER" >/dev/null


### PR DESCRIPTION
## Summary

- Fixes scoped WordPress PHPStan runs so single-file analysis can resolve normal plugin sibling declarations and bundled `vendor_prefixed` classes.
- Keeps `--file` / `--glob` target narrowing intact while adding declaration/autoload context that matches production plugin runtime.

## Changes

- Add scoped-run PHPStan context discovery for production plugin directories, top-level plugin PHP files, and `vendor_prefixed` packages.
- Load component and validation-dependency `vendor_prefixed/autoload.php` files in the composite PHPStan autoloader.
- Extend the scoped PHPStan smoke to assert the generated context config and prefixed autoloader coverage.

## Tests

- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `bash tests/wordpress-lint-context-smoke.sh`
- `bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- `bash -n wordpress/scripts/lint/phpstan-runner.sh wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- Patched runner against BFB repro files: missing sibling/prefixed `interface.notFound`, `class.notFound`, and `function.notFound` findings are removed; remaining findings are target-file analysis issues.

Closes #332
Closes #333

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the scoped PHPStan context fix, adding focused smoke coverage, and running local verification. Chris remains responsible for review and merge.
