### PR TITLE
fix(wordpress): preserve PHPStan context for scoped lint

### DIFF
--- a/tests/wordpress-lint-context-smoke.sh
+++ b/tests/wordpress-lint-context-smoke.sh
@@ -45,4 +45,91 @@ assert_contains "$RUNNER" "*/vendor_prefixed/*"
 assert_contains "$PHPSTAN_RUNNER" "*/vendor_prefixed/*"
 assert_contains "$PHPSTAN_CONFIG" "*/vendor_prefixed/*"
 
+mkdir -p "$COMPONENT_DIR/includes" "$COMPONENT_DIR/vendor_prefixed/Example/Vendor"
+
+cat > "$COMPONENT_DIR/includes/interface-example-adapter.php" <<'PHP'
+<?php
+interface Example_Adapter {}
+PHP
+
+cat > "$COMPONENT_DIR/includes/class-example-adapter.php" <<'PHP'
+<?php
+class Example_Adapter_Impl implements Example_Adapter {}
+PHP
+
+cat > "$COMPONENT_DIR/vendor_prefixed/Example/Vendor/class-prefixed-dependency.php" <<'PHP'
+<?php
+namespace Example\Vendor;
+class Prefixed_Dependency {}
+PHP
+
+cat > "$COMPONENT_DIR/vendor_prefixed/autoload.php" <<'PHP'
+<?php
+// Fake scoped Composer autoloader.
+PHP
+
+cat > "$FAKE_EXTENSION/phpstan.neon.dist" <<'NEON'
+parameters:
+    level: 7
+NEON
+
+cat > "$FAKE_EXTENSION/vendor/bin/phpstan" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+config=""
+autoload_file=""
+targets=()
+for arg in "$@"; do
+    case "$arg" in
+        --configuration=*) config="${arg#--configuration=}" ;;
+        --autoload-file=*) autoload_file="${arg#--autoload-file=}" ;;
+        --*) ;;
+        analyse) ;;
+        *) targets+=("$arg") ;;
+    esac
+done
+
+if [ -z "$config" ] || [ ! -f "$config" ]; then
+    echo "missing generated PHPStan config" >&2
+    exit 1
+fi
+
+if [ "${#targets[@]}" -ne 1 ] || [ "${targets[0]}" != "${EXPECTED_TARGET}" ]; then
+    printf 'unexpected PHPStan targets: %s\n' "${targets[*]:-<none>}" >&2
+    exit 1
+fi
+
+grep -Fq "$EXPECTED_INTERFACE" "$config" || {
+    echo "scoped config did not include sibling production file context" >&2
+    exit 1
+}
+
+grep -Fq "$EXPECTED_VENDOR_PREFIXED" "$config" || {
+    echo "scoped config did not include vendor_prefixed dependency context" >&2
+    exit 1
+}
+
+if [ -z "$autoload_file" ] || ! grep -Fq "$EXPECTED_VENDOR_PREFIXED_AUTOLOAD" "$autoload_file"; then
+    echo "composite autoload did not include vendor_prefixed autoloader" >&2
+    exit 1
+fi
+
+printf 'PHPStan fake passed\n'
+BASH
+chmod +x "$FAKE_EXTENSION/vendor/bin/phpstan"
+
+EXPECTED_TARGET="$COMPONENT_DIR/includes/class-example-adapter.php" \
+EXPECTED_INTERFACE="$COMPONENT_DIR/includes/interface-example-adapter.php" \
+EXPECTED_VENDOR_PREFIXED="$COMPONENT_DIR/vendor_prefixed" \
+EXPECTED_VENDOR_PREFIXED_AUTOLOAD="$COMPONENT_DIR/vendor_prefixed/autoload.php" \
+HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="example-plugin" \
+HOMEBOY_LINT_FILE="includes/class-example-adapter.php" \
+    bash "$PHPSTAN_RUNNER" > "$TMP_DIR/phpstan-scoped.out" 2>&1
+
+assert_contains "$TMP_DIR/phpstan-scoped.out" "PHPStan scoped lint: analyzing 1 PHP file(s) from requested scope"
+assert_contains "$TMP_DIR/phpstan-scoped.out" "PHPStan fake passed"
+
 echo "wordpress lint context smoke passed"

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -64,6 +64,7 @@ PHPSTAN_BASE_CONFIG="$PHPSTAN_CONFIG"
 COMPONENT_BASELINE="${PLUGIN_PATH}/phpstan-baseline.neon"
 COMPOSITE_AUTOLOAD=""
 DEPENDENCY_CONFIG=""
+SCOPED_CONTEXT_CONFIG=""
 
 homeboy_mktemp() {
     local template="$1"
@@ -158,6 +159,57 @@ cleanup_dependency_config() {
     DEPENDENCY_CONFIG=""
 }
 
+generate_scoped_context_config() {
+    local tmpfile
+    local context_file
+    local has_context_files=0
+    local has_scan_directories=0
+
+    tmpfile=$(homeboy_mktemp 'phpstan-scoped-context.XXXXXX.neon')
+
+    {
+        printf '%s\n' 'includes:'
+        printf '    - %s\n' "$PHPSTAN_BASE_CONFIG"
+        printf '%s\n' ''
+        printf '%s\n' 'parameters:'
+
+        while IFS= read -r -d '' context_file; do
+            if [ "$has_context_files" -eq 0 ]; then
+                printf '%s\n' '    scanFiles:'
+                has_context_files=1
+            fi
+            printf '        - %s\n' "$(printf '%s' "$context_file" | jq -Rsa .)"
+        done < <(find "$PLUGIN_PATH" -type f -name '*.php' \
+            -not -path "*/vendor/*" \
+            -not -path "*/vendor_prefixed/*" \
+            -not -path "*/node_extensions/*" \
+            -not -path "*/node_modules/*" \
+            -not -path "*/build/*" \
+            -not -path "*/dist/*" \
+            -not -path "*/tests/*" \
+            -not -path "*/tools/*" \
+            -print0)
+
+        if [ -d "${PLUGIN_PATH}/vendor_prefixed" ]; then
+            printf '%s\n' '    scanDirectories:'
+            printf '        - %s\n' "$(printf '%s' "${PLUGIN_PATH}/vendor_prefixed" | jq -Rsa .)"
+            has_scan_directories=1
+        fi
+    } > "$tmpfile"
+
+    if [ "$has_context_files" -eq 1 ] || [ "$has_scan_directories" -eq 1 ]; then
+        printf '%s\n' "$tmpfile"
+    else
+        rm -f "$tmpfile"
+        printf '%s\n' ''
+    fi
+}
+
+cleanup_scoped_context_config() {
+    [ -n "$SCOPED_CONTEXT_CONFIG" ] && rm -f "$SCOPED_CONTEXT_CONFIG"
+    SCOPED_CONTEXT_CONFIG=""
+}
+
 DEPENDENCY_CONFIG=$(generate_dependency_config)
 if [ -n "$DEPENDENCY_CONFIG" ] && [ -f "$DEPENDENCY_CONFIG" ]; then
     PHPSTAN_BASE_CONFIG="$DEPENDENCY_CONFIG"
@@ -210,6 +262,11 @@ if [ -n "${HOMEBOY_LINT_FILE:-}" ] || [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
     if [ "${#PHPSTAN_TARGETS[@]}" -eq 0 ]; then
         echo "PHPStan scoped lint: no PHP files in requested scope, skipping static analysis"
         exit 0
+    fi
+
+    SCOPED_CONTEXT_CONFIG=$(generate_scoped_context_config)
+    if [ -n "$SCOPED_CONTEXT_CONFIG" ] && [ -f "$SCOPED_CONTEXT_CONFIG" ]; then
+        PHPSTAN_BASE_CONFIG="$SCOPED_CONTEXT_CONFIG"
     fi
 fi
 
@@ -270,6 +327,7 @@ fi
 generate_composite_autoload() {
     local tmpfile
     local component_autoload="${PLUGIN_PATH}/vendor/autoload.php"
+    local component_prefixed_autoload="${PLUGIN_PATH}/vendor_prefixed/autoload.php"
 
     tmpfile=$(homeboy_mktemp 'homeboy-phpstan-autoload.XXXXXX')
 
@@ -287,6 +345,10 @@ generate_composite_autoload() {
 
         if [ -f "$component_autoload" ]; then
             printf '    %s,\n' "$(printf '%s' "$component_autoload" | jq -Rsa .)"
+        fi
+
+        if [ -f "$component_prefixed_autoload" ]; then
+            printf '    %s,\n' "$(printf '%s' "$component_prefixed_autoload" | jq -Rsa .)"
         fi
 
         printf '%s\n' '];'
@@ -377,7 +439,7 @@ cleanup_phpstan_config() {
     [ -n "$PHPSTAN_TMPCONFIG" ] && rm -f "$PHPSTAN_TMPCONFIG"
     PHPSTAN_TMPCONFIG=""
 }
-trap 'cleanup_phpstan_config; cleanup_composite_autoload; cleanup_dependency_config' EXIT
+trap 'cleanup_phpstan_config; cleanup_composite_autoload; cleanup_dependency_config; cleanup_scoped_context_config' EXIT
 
 # Generate a temp config when we need to override parallel processes or phpVersion.
 if [ -n "$PHPSTAN_MAX_PROCESSES" ] || [ -n "$PHPSTAN_PHP_VERSION" ]; then


### PR DESCRIPTION
## Summary
- Preserves plugin declaration context when WordPress PHPStan lint is scoped to `--file` / `--glob`.
- Loads bundled `vendor_prefixed/autoload.php` as dependency context so scoped vendor classes resolve without analyzing generated dependencies as first-party findings.

## Changes
- Generates a temporary scoped PHPStan config that keeps the requested target list narrow while adding production PHP files as `scanFiles` context.
- Adds `vendor_prefixed/` as scan-directory context and includes `vendor_prefixed/autoload.php` in the composite autoloader when present.
- Extends the WordPress lint context smoke to assert sibling production declarations and prefixed autoload context are present in scoped mode.

## Tests
- `bash tests/wordpress-lint-context-smoke.sh`
- `bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- BFB repro against `/Users/chubes/Developer/block-format-bridge@cleanup-production-lint` for:
  - `includes/class-bfb-html-adapter.php` — passed
  - `includes/class-bfb-markdown-adapter.php` — no sibling/prefixed missing-symbol findings; only remaining output is real `cast.string`
  - `includes/rest.php` — passed

Closes #333

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the scoped PHPStan context fix, regression smoke coverage, and verification commands. Chris remains responsible for review and merge.