### PR TITLE
fix(wordpress): split lint profiles by file role

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,13 +10,14 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/playground-process-cleanup-smoke.sh"
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh"
     ],
     "test": [
       "bash scripts/test/host-smoke-runner-smoke.sh",
       "bash scripts/test/playground-process-cleanup-smoke.sh",
       "bash scripts/test/playground-cleanup-noise-smoke.sh",
-      "bash scripts/test/playground-no-test-files-smoke.sh"
+      "bash scripts/test/playground-no-test-files-smoke.sh",
+      "bash scripts/lint/wordpress-lint-role-smoke.sh"
     ]
   }
 }

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -49,6 +49,28 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "HOMEBOY_CATEGORY=${HOMEBOY_CATEGORY:-NOT_SET}"
 fi
 
+wordpress_lint_role_for_path() {
+    local rel_path="$1"
+
+    case "$rel_path" in
+        scoper.inc.php|scoper.php|*.scoper.inc.php)
+            printf '%s\n' 'scoper_config'
+            ;;
+        tools/*|bin/*)
+            printf '%s\n' 'tooling'
+            ;;
+        tests/*-smoke.php|tests/smoke-*.php|*/smoke-*.php|*/*-smoke.php)
+            printf '%s\n' 'smoke_harness'
+            ;;
+        tests/*Test.php|tests/*TestCase.php|*/tests/*Test.php|*/tests/*TestCase.php)
+            printf '%s\n' 'phpunit_test'
+            ;;
+        *)
+            printf '%s\n' 'production'
+            ;;
+    esac
+}
+
 # Category to sniff mappings
 declare -A CATEGORY_SNIFFS
 CATEGORY_SNIFFS["security"]="WordPress.Security.EscapeOutput,WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput,WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders"
@@ -161,6 +183,18 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "Plugin path: $PLUGIN_PATH"
     echo "Lint files: ${LINT_FILES[*]}"
     echo "Fix-only: ${HOMEBOY_FIX_ONLY:-0}"
+fi
+
+WORDPRESS_LINT_ROLE="production"
+if [ -n "${HOMEBOY_WORDPRESS_LINT_ROLE:-}" ]; then
+    WORDPRESS_LINT_ROLE="$HOMEBOY_WORDPRESS_LINT_ROLE"
+elif [ -n "${HOMEBOY_LINT_FILE:-}" ]; then
+    WORDPRESS_LINT_ROLE=$(wordpress_lint_role_for_path "$HOMEBOY_LINT_FILE")
+fi
+export HOMEBOY_WORDPRESS_LINT_ROLE="$WORDPRESS_LINT_ROLE"
+
+if [ "$WORDPRESS_LINT_ROLE" != "production" ]; then
+    echo "WordPress lint role: ${WORDPRESS_LINT_ROLE}"
 fi
 
 PHPCS_BIN="${EXTENSION_PATH}/vendor/bin/phpcs"
@@ -528,6 +562,12 @@ fixable_count=0
 # Build base phpcs arguments
 phpcs_base_args=(--standard="$PHPCS_CONFIG")
 phpcs_base_args+=(--ignore='*/vendor/*,*/vendor_prefixed/*,*/node_modules/*,*/build/*,*/dist/*')
+
+if [ "$WORDPRESS_LINT_ROLE" = "scoper_config" ]; then
+    phpcs_base_args+=(--sniffs=Generic.PHP.Syntax)
+elif [ "$WORDPRESS_LINT_ROLE" = "tooling" ]; then
+    phpcs_base_args+=(--exclude=WordPress.WP.AlternativeFunctions,WordPress.PHP.DevelopmentFunctions,WordPress.Security.EscapeOutput)
+fi
 
 # Auto-detect parallelism from available CPU cores
 if [ -z "${PARALLEL_PROCS:-}" ]; then

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -24,6 +24,46 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "HOMEBOY_PHPSTAN_LEVEL=${HOMEBOY_PHPSTAN_LEVEL:-NOT_SET}"
 fi
 
+wordpress_lint_role_for_path() {
+    local rel_path="$1"
+
+    case "$rel_path" in
+        scoper.inc.php|scoper.php|*.scoper.inc.php)
+            printf '%s\n' 'scoper_config'
+            ;;
+        tools/*|bin/*)
+            printf '%s\n' 'tooling'
+            ;;
+        tests/*-smoke.php|tests/smoke-*.php|*/smoke-*.php|*/*-smoke.php)
+            printf '%s\n' 'smoke_harness'
+            ;;
+        tests/*Test.php|tests/*TestCase.php|*/tests/*Test.php|*/tests/*TestCase.php)
+            printf '%s\n' 'phpunit_test'
+            ;;
+        *)
+            printf '%s\n' 'production'
+            ;;
+    esac
+}
+
+run_scoped_syntax_check() {
+    local rel_path="$1"
+    local target="${PLUGIN_PATH}/${rel_path}"
+
+    if [ ! -f "$target" ] || [[ "$target" != *.php ]]; then
+        return 0
+    fi
+
+    if php -l "$target" > /dev/null 2>&1; then
+        echo "PHPStan skipped for ${HOMEBOY_WORDPRESS_LINT_ROLE}; PHP syntax check passed"
+        return 0
+    fi
+
+    echo "PHPStan skipped for ${HOMEBOY_WORDPRESS_LINT_ROLE}, but PHP syntax check failed: ${rel_path}"
+    php -l "$target" 2>&1 | grep -v "^$" | sed 's/^/  /'
+    return 1
+}
+
 # Critical PHPStan error identifiers that indicate guaranteed runtime fatals.
 # These must NEVER be skipped, even with --skip-checks or HOMEBOY_SKIP_PHPSTAN=1.
 # Skipping these allows code that will crash on first request to reach production.
@@ -57,6 +97,21 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Extension path: $EXTENSION_PATH"
     echo "DEBUG: Plugin path: $PLUGIN_PATH"
 fi
+
+WORDPRESS_LINT_ROLE="${HOMEBOY_WORDPRESS_LINT_ROLE:-production}"
+if [ "$WORDPRESS_LINT_ROLE" = "production" ] && [ -n "${HOMEBOY_LINT_FILE:-}" ]; then
+    WORDPRESS_LINT_ROLE=$(wordpress_lint_role_for_path "$HOMEBOY_LINT_FILE")
+fi
+export HOMEBOY_WORDPRESS_LINT_ROLE="$WORDPRESS_LINT_ROLE"
+
+case "$WORDPRESS_LINT_ROLE" in
+    scoper_config|smoke_harness|phpunit_test)
+        if [ -n "${HOMEBOY_LINT_FILE:-}" ]; then
+            run_scoped_syntax_check "$HOMEBOY_LINT_FILE"
+            exit $?
+        fi
+        ;;
+esac
 
 PHPSTAN_BIN="${EXTENSION_PATH}/vendor/bin/phpstan"
 PHPSTAN_CONFIG="${EXTENSION_PATH}/phpstan.neon.dist"

--- a/wordpress/scripts/lint/wordpress-lint-role-smoke.sh
+++ b/wordpress/scripts/lint/wordpress-lint-role-smoke.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/lint-runner.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+EXTENSION_DIR="${TMPDIR}/extension"
+COMPONENT_DIR="${TMPDIR}/component"
+PHPCS_ARGS_FILE="${TMPDIR}/phpcs-args.txt"
+PHPSTAN_CALLS_FILE="${TMPDIR}/phpstan-calls.txt"
+RESOLVE_CONTEXT_HELPER="${TMPDIR}/resolve-context.sh"
+DETECT_COMPONENT_HELPER="${TMPDIR}/detect-component.sh"
+DEPENDENCY_HELPER="${TMPDIR}/validation-dependencies.sh"
+
+mkdir -p \
+    "${EXTENSION_DIR}/vendor/bin" \
+    "${EXTENSION_DIR}/scripts/lint" \
+    "${EXTENSION_DIR}/scripts/lib" \
+    "${COMPONENT_DIR}/tools" \
+    "${COMPONENT_DIR}/tests"
+
+touch "${EXTENSION_DIR}/phpcs.xml.dist" "${EXTENSION_DIR}/phpstan.neon.dist"
+ln -s "${SCRIPT_DIR}/phpstan-runner.sh" "${EXTENSION_DIR}/scripts/lint/phpstan-runner.sh"
+
+cat > "${COMPONENT_DIR}/scoper.inc.php" <<'PHP'
+<?php
+return [
+    'prefix' => 'Example\\Vendor',
+];
+PHP
+
+cat > "${COMPONENT_DIR}/tools/build-autoloader.php" <<'PHP'
+<?php
+fwrite(STDOUT, "building\n");
+PHP
+
+cat > "${COMPONENT_DIR}/tests/BFBConversionUnitTest.php" <<'PHP'
+<?php
+class BFBConversionUnitTest extends WP_UnitTestCase {}
+PHP
+
+cat > "${COMPONENT_DIR}/tests/smoke-content-normalization.php" <<'PHP'
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+PHP
+
+cat > "$RESOLVE_CONTEXT_HELPER" <<'SH'
+homeboy_resolve_context() {
+    EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+    COMPONENT_PATH="$HOMEBOY_COMPONENT_PATH"
+    PLUGIN_PATH="$HOMEBOY_COMPONENT_PATH"
+    COMPONENT_ID="${HOMEBOY_COMPONENT_ID:-role-smoke}"
+}
+SH
+
+cat > "$DETECT_COMPONENT_HELPER" <<'SH'
+homeboy_detect_component() {
+    HOMEBOY_COMPONENT_TYPE="plugin"
+    HOMEBOY_COMPONENT_MAIN_FILE="role-smoke.php"
+    HOMEBOY_COMPONENT_TEXT_DOMAIN="role-smoke"
+    return 0
+}
+SH
+
+cat > "$DEPENDENCY_HELPER" <<'SH'
+homeboy_resolve_validation_dependency_paths() {
+    return 0
+}
+SH
+
+cat > "${EXTENSION_DIR}/scripts/lib/runner-steps.sh" <<'SH'
+should_run_step() {
+    return 0
+}
+SH
+
+cat > "${EXTENSION_DIR}/vendor/bin/phpcs" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$PHPCS_ARGS_FILE"
+if [[ "$*" == *"--report=json"* ]]; then
+    printf '%s\n' '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{}}'
+fi
+SH
+chmod +x "${EXTENSION_DIR}/vendor/bin/phpcs"
+
+cat > "${EXTENSION_DIR}/vendor/bin/phpstan" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+count=0
+[ -f "$PHPSTAN_CALLS_FILE" ] && count=$(cat "$PHPSTAN_CALLS_FILE")
+count=$((count + 1))
+printf '%s\n' "$count" > "$PHPSTAN_CALLS_FILE"
+printf '%s\n' '{"totals":{"errors":0,"file_errors":0},"files":{},"errors":[]}'
+SH
+chmod +x "${EXTENSION_DIR}/vendor/bin/phpstan"
+
+assert_contains() {
+    local needle="$1"
+    local haystack_file="$2"
+    local message="$3"
+
+    if ! grep -F -- "$needle" "$haystack_file" >/dev/null; then
+        echo "FAIL: $message" >&2
+        echo "Contents of $haystack_file:" >&2
+        cat "$haystack_file" >&2
+        exit 1
+    fi
+}
+
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+    local message="$3"
+
+    if [ "$expected" != "$actual" ]; then
+        echo "FAIL: $message" >&2
+        echo "Expected: $expected" >&2
+        echo "Actual:   $actual" >&2
+        exit 1
+    fi
+}
+
+run_lint_file() {
+    local rel_file="$1"
+
+    : > "$PHPCS_ARGS_FILE"
+    printf '0\n' > "$PHPSTAN_CALLS_FILE"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+    HOMEBOY_COMPONENT_ID="role-smoke" \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+    HOMEBOY_RUNTIME_DETECT_COMPONENT="$DETECT_COMPONENT_HELPER" \
+    HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+    PHPCS_ARGS_FILE="$PHPCS_ARGS_FILE" \
+    PHPSTAN_CALLS_FILE="$PHPSTAN_CALLS_FILE" \
+    HOMEBOY_SUMMARY_MODE=1 \
+    HOMEBOY_LINT_FILE="$rel_file" \
+    bash "$RUNNER" >/dev/null
+}
+
+run_lint_file 'scoper.inc.php'
+assert_contains '--sniffs=Generic.PHP.Syntax' "$PHPCS_ARGS_FILE" 'scoper config uses syntax-only PHPCS role'
+assert_equals '0' "$(cat "$PHPSTAN_CALLS_FILE")" 'scoper config skips PHPStan runtime autoload analysis'
+
+run_lint_file 'tools/build-autoloader.php'
+assert_contains '--exclude=WordPress.WP.AlternativeFunctions,WordPress.PHP.DevelopmentFunctions,WordPress.Security.EscapeOutput' "$PHPCS_ARGS_FILE" 'tooling role excludes WordPress runtime-only PHPCS sniffs'
+assert_equals '1' "$(cat "$PHPSTAN_CALLS_FILE")" 'tooling role keeps PHPStan static analysis'
+
+run_lint_file 'tests/BFBConversionUnitTest.php'
+assert_equals '0' "$(cat "$PHPSTAN_CALLS_FILE")" 'WordPress PHPUnit test role skips unsupported host PHPStan context'
+
+run_lint_file 'tests/smoke-content-normalization.php'
+assert_equals '0' "$(cat "$PHPSTAN_CALLS_FILE")" 'standalone smoke harness role skips unsupported dynamic bootstrap PHPStan context'
+
+echo "WordPress lint role smoke passed"


### PR DESCRIPTION
## Summary
- Add scoped file-role detection to the WordPress lint runner for php-scoper configs, CLI tooling, standalone smoke harnesses, and WordPress PHPUnit tests.
- Keep the production plugin lint profile unchanged while narrowing non-runtime files to syntax-only PHPStan skips or tooling-appropriate PHPCS exclusions.
- Add a focused smoke test that pins role routing and wire it into the WordPress extension self-checks.

## Changes
- `scoper.inc.php` uses syntax-only PHPCS and skips PHPStan runtime autoload analysis with a `php -l` safety check.
- `tools/**` keeps PHPStan but excludes WordPress runtime-only PHPCS sniffs for WP_Filesystem, debug `var_export()`, and escaped request-output requirements.
- `tests/*-smoke.php` and PHPUnit-style `tests/*Test.php` files skip host PHPStan analysis with syntax validation so dynamic smoke bootstrap and Playground-backed WP tests do not produce false runtime-profile failures.

## Tests
- `bash scripts/lint/phpstan-scoped-smoke.sh && bash scripts/lint/wordpress-lint-role-smoke.sh`
- `homeboy lint wordpress --path /Users/chubes/Developer/homeboy-extensions/wordpress`
- `homeboy test wordpress --path /Users/chubes/Developer/homeboy-extensions/wordpress`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@cleanup-test-tooling-lint --file scoper.inc.php`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@cleanup-test-tooling-lint --file tools/build-autoloader.php`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@cleanup-test-tooling-lint --file tests/BFBConversionUnitTest.php`
- `homeboy lint block-format-bridge --path /Users/chubes/Developer/block-format-bridge@cleanup-test-tooling-lint --file tests/smoke-content-normalization.php`

## Remaining limitations / follow-ups
- This intentionally handles scoped single-file lint roles first. Full-tree lint still uses the production profile for production paths and existing broad excludes for generated/vendor directories.
- Smoke and PHPUnit tests retain PHPCS signal but skip host PHPStan until the WordPress profile has richer PHPUnit/dynamic-bootstrap stubs.

Closes #331

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the lint-runner role split, writing the focused smoke coverage, and running verification against the BFB repro cases. Chris remains responsible for review and merge decisions.