### PR TITLE
fix(wordpress): handle absolute PHPStan scope paths

### DIFF
--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -222,6 +222,19 @@ homeboy_phpstan_relpath() {
     printf '%s\n' "$path"
 }
 
+homeboy_phpstan_abspath() {
+    local path="$1"
+
+    case "$path" in
+        /*)
+            printf '%s\n' "$path"
+            ;;
+        *)
+            printf '%s\n' "${PLUGIN_PATH}/${path#./}"
+            ;;
+    esac
+}
+
 homeboy_phpstan_runtime_file() {
     local rel_path="$1"
 
@@ -237,21 +250,26 @@ homeboy_phpstan_runtime_file() {
 resolve_phpstan_targets() {
     local matched=()
     local target
+    local target_path
+    local target_rel
 
     if [ -n "${HOMEBOY_LINT_FILE:-}" ]; then
-        target="${PLUGIN_PATH}/${HOMEBOY_LINT_FILE}"
-        if [ -f "$target" ] && [[ "$target" == *.php ]] && homeboy_phpstan_runtime_file "$(homeboy_phpstan_relpath "$target")"; then
-            matched+=("$target")
+        target_path=$(homeboy_phpstan_abspath "$HOMEBOY_LINT_FILE")
+        target_rel=$(homeboy_phpstan_relpath "$target_path")
+        if [ -f "$target_path" ] && [[ "$target_path" == *.php ]] && homeboy_phpstan_runtime_file "$target_rel"; then
+            matched+=("$target_path")
         fi
     elif [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
         (
             cd "$PLUGIN_PATH"
             eval 'for f in '"${HOMEBOY_LINT_GLOB}"'; do [ -e "$f" ] && printf "%s\0" "$f"; done'
         ) | while IFS= read -r -d '' target; do
-            if [ -f "${PLUGIN_PATH}/${target}" ] && [[ "$target" == *.php ]] && homeboy_phpstan_runtime_file "$target"; then
-                printf '%s\0' "${PLUGIN_PATH}/${target}"
-            elif [ -d "${PLUGIN_PATH}/${target}" ]; then
-                find "${PLUGIN_PATH}/${target}" -type f -name '*.php' \
+            target_path=$(homeboy_phpstan_abspath "$target")
+            target_rel=$(homeboy_phpstan_relpath "$target_path")
+            if [ -f "$target_path" ] && [[ "$target_path" == *.php ]] && homeboy_phpstan_runtime_file "$target_rel"; then
+                printf '%s\0' "$target_path"
+            elif [ -d "$target_path" ]; then
+                find "$target_path" -type f -name '*.php' \
                     -not -path "*/vendor/*" \
                     -not -path "*/vendor_prefixed/*" \
                     -not -path "*/node_extensions/*" \

--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -13,11 +13,12 @@ CALLS_FILE="${TMPDIR}/phpstan-calls.txt"
 DEPENDENCY_HELPER="${TMPDIR}/validation-dependencies.sh"
 CONFIG_CAPTURE="${TMPDIR}/phpstan-config-capture.neon"
 AUTOLOAD_CAPTURE="${TMPDIR}/phpstan-autoload-capture.php"
+OUTPUT_FILE="${TMPDIR}/phpstan-output.txt"
 
 mkdir -p "${EXTENSION_DIR}/vendor/bin" "${COMPONENT_DIR}/tests" "${COMPONENT_DIR}/assets" "${COMPONENT_DIR}/includes" "${COMPONENT_DIR}/vendor_prefixed"
 touch "${EXTENSION_DIR}/phpstan.neon.dist"
 touch "${COMPONENT_DIR}/main.php" "${COMPONENT_DIR}/tests/FooTest.php" "${COMPONENT_DIR}/assets/app.js"
-touch "${COMPONENT_DIR}/includes/interface-example.php" "${COMPONENT_DIR}/vendor_prefixed/autoload.php"
+touch "${COMPONENT_DIR}/includes/interface-example.php" "${COMPONENT_DIR}/includes/extra.php" "${COMPONENT_DIR}/vendor_prefixed/autoload.php"
 
 cat > "$DEPENDENCY_HELPER" <<'SH'
 homeboy_resolve_validation_dependency_paths() {
@@ -45,6 +46,7 @@ chmod +x "${EXTENSION_DIR}/vendor/bin/phpstan"
 
 run_phpstan() {
     : > "$ARGS_FILE"
+    : > "$OUTPUT_FILE"
     printf '0\n' > "$CALLS_FILE"
     HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
     HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
@@ -55,7 +57,7 @@ run_phpstan() {
     PHPSTAN_CONFIG_CAPTURE="$CONFIG_CAPTURE" \
     PHPSTAN_AUTOLOAD_CAPTURE="$AUTOLOAD_CAPTURE" \
     HOMEBOY_SUMMARY_MODE=1 \
-    "$RUNNER" >/dev/null
+    "$RUNNER" >"$OUTPUT_FILE"
 }
 
 assert_contains() {
@@ -122,10 +124,17 @@ assert_file_contains "$CONFIG_CAPTURE" "${COMPONENT_DIR}/main.php" "scoped conte
 assert_file_not_contains "$CONFIG_CAPTURE" "${COMPONENT_DIR}/tests" "scoped context excludes test declarations"
 assert_file_contains "$AUTOLOAD_CAPTURE" "${COMPONENT_DIR}/vendor_prefixed/autoload.php" "composite autoload loads prefixed vendor autoloader"
 
-HOMEBOY_LINT_GLOB='{main.php,assets/app.js,tests/FooTest.php}' run_phpstan
+HOMEBOY_LINT_GLOB='{main.php,assets/app.js,includes/extra.php}' run_phpstan
 assert_contains "${COMPONENT_DIR}/main.php" "glob scope includes matching PHP source file"
-assert_contains "${COMPONENT_DIR}/tests/FooTest.php" "glob scope includes matching PHP test file"
+assert_contains "${COMPONENT_DIR}/includes/extra.php" "glob scope includes matching PHP runtime file"
 assert_not_contains "assets/app.js" "glob scope ignores non-PHP files"
+assert_file_contains "$OUTPUT_FILE" "PHPStan scoped lint: analyzing 2 PHP file(s)" "relative glob scope reports analyzed PHP files"
+
+HOMEBOY_LINT_GLOB="{${COMPONENT_DIR}/main.php,${COMPONENT_DIR}/assets/app.js,${COMPONENT_DIR}/includes/extra.php}" run_phpstan
+assert_contains "${COMPONENT_DIR}/main.php" "absolute glob scope includes matching PHP source file"
+assert_contains "${COMPONENT_DIR}/includes/extra.php" "absolute glob scope includes matching PHP runtime file"
+assert_not_contains "assets/app.js" "absolute glob scope ignores non-PHP files"
+assert_file_contains "$OUTPUT_FILE" "PHPStan scoped lint: analyzing 2 PHP file(s)" "absolute glob scope reports analyzed PHP files"
 
 : > "$ARGS_FILE"
 printf '0\n' > "$CALLS_FILE"


### PR DESCRIPTION
## Summary
- Normalize scoped PHPStan targets before checking files/directories, so `HOMEBOY_LINT_GLOB` works with both relative and absolute paths.
- Extend the scoped PHPStan smoke to cover relative glob paths, absolute glob paths, and the expected analyzed-file status output.

## Tests
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- `bash -n wordpress/scripts/lint/phpstan-runner.sh wordpress/scripts/lint/phpstan-scoped-smoke.sh wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- `bash wordpress/scripts/lint/autofixable-exit-smoke.sh`

Closes #326

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the scoped PHPStan path normalization fix, updated the focused smoke coverage, and ran verification commands for Chris to review.
