### PR TITLE
fix(wordpress): route standalone smoke files

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,10 +10,11 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/playground-process-cleanup-smoke.sh"
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/playground-process-cleanup-smoke.sh"
     ],
     "test": [
       "bash scripts/test/host-smoke-runner-smoke.sh",
+      "bash scripts/test/test-runner-file-routing-smoke.sh",
       "bash scripts/test/playground-process-cleanup-smoke.sh",
       "bash scripts/test/playground-cleanup-noise-smoke.sh",
       "bash scripts/test/playground-no-test-files-smoke.sh"

--- a/wordpress/scripts/test/host-smoke-runner-smoke.sh
+++ b/wordpress/scripts/test/host-smoke-runner-smoke.sh
@@ -53,6 +53,16 @@ assert_contains "${TMPDIR}/direct-pass.out" "HOST_SMOKE_BEGIN:tests/alpha-smoke.
 assert_contains "${TMPDIR}/direct-pass.out" "HOST_SMOKE_BEGIN:tests/nested/bravo-smoke.php"
 assert_contains "${TMPDIR}/direct-pass.out" "HOST_SMOKE_SUMMARY:passed=2 failed=0"
 
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component-pass" \
+HOMEBOY_COMPONENT_PATH="$component_pass" \
+HOMEBOY_WORDPRESS_HOST_SMOKE_FILE="tests/nested/bravo-smoke.php" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner-host-smoke.sh" > "${TMPDIR}/direct-single.out"
+
+assert_not_contains "${TMPDIR}/direct-single.out" "HOST_SMOKE_BEGIN:tests/alpha-smoke.php"
+assert_contains "${TMPDIR}/direct-single.out" "HOST_SMOKE_BEGIN:tests/nested/bravo-smoke.php"
+assert_contains "${TMPDIR}/direct-single.out" "HOST_SMOKE_SUMMARY:passed=1 failed=0"
+
 component_fail="${TMPDIR}/component-fail"
 make_component "$component_fail"
 cat > "$component_fail/tests/zzz-smoke.php" <<'PHP'

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -61,9 +61,9 @@ pg_install_diagnostics_handlers();
 
 $tests_dir = '/homeboy-extension/vendor/wp-phpunit/wp-phpunit';
 $plugin_path = '/wordpress/wp-content/plugins/{{PLUGIN_SLUG}}';
-$changed_test_files = json_decode('{{CHANGED_TEST_FILES_JSON}}', true);
-if (!is_array($changed_test_files)) {
-    $changed_test_files = [];
+$selected_test_file = base64_decode('{{PHPUNIT_TEST_FILE_B64}}', true);
+if (!is_string($selected_test_file)) {
+    $selected_test_file = '';
 }
 
 // Stage: boot — render wp-tests-config.php + load composer autoload.
@@ -191,9 +191,15 @@ try {
     $test_files = pg_discover_tests($directories, $suffixes, $prefixes, $excludes);
     $test_files = pg_filter_changed_test_files($test_files, '{{CHANGED_TEST_FILES_JSON}}', $plugin_path);
 
-    if (!empty($changed_test_files)) {
-        $test_files = pg_filter_changed_tests($test_files, $changed_test_files, $plugin_path, $suffixes, $prefixes);
-        pg_log("NOTICE:changed test scope applied; selected=" . count($test_files));
+    if ($selected_test_file !== '') {
+        $selected_abs = $plugin_path . '/' . ltrim($selected_test_file, '/');
+        if (!in_array($selected_abs, $test_files, true)) {
+            pg_log("NO_TEST_FILES");
+            pg_log("NOTICE:requested PHPUnit test file not discovered: $selected_test_file");
+            pg_stage_ok('discover_tests');
+            exit(1);
+        }
+        $test_files = [$selected_abs];
     }
 
     pg_log("DISCOVERY: dirs=" . implode(',', $directories)
@@ -387,50 +393,6 @@ function pg_discover_tests(array $directories, array $suffixes, array $prefixes,
     // Stable ordering so re-runs show the same failure order.
     sort($found);
     return array_values(array_unique($found));
-}
-
-/**
- * Filter discovered PHPUnit files to Homeboy's changed-test scope.
- *
- * Homeboy may include standalone smoke scripts in HOMEBOY_CHANGED_TEST_FILES;
- * those are intentionally ignored here because the Playground runner only
- * executes PHPUnit test cases. The host-smoke backend owns smoke execution.
- */
-function pg_filter_changed_tests(array $discovered, array $changed_files, $plugin_path, array $suffixes, array $prefixes) {
-    $allowed = [];
-    foreach ($changed_files as $rel) {
-        $rel = trim(str_replace('\\', '/', (string) $rel));
-        if ($rel === '' || strpos($rel, '..') !== false) {
-            continue;
-        }
-
-        $base = basename($rel);
-        $matches_phpunit = false;
-        foreach ($suffixes as $suffix) {
-            if ($suffix !== '' && substr($base, -strlen($suffix)) === $suffix) {
-                $matches_phpunit = true;
-                break;
-            }
-        }
-        if (!$matches_phpunit) {
-            foreach ($prefixes as $prefix) {
-                if ($prefix !== '' && strpos($base, $prefix) === 0) {
-                    $matches_phpunit = true;
-                    break;
-                }
-            }
-        }
-        if (!$matches_phpunit) {
-            pg_log("NOTICE:changed test scope skipped non-PHPUnit file: $rel");
-            continue;
-        }
-
-        $allowed[rtrim($plugin_path, '/') . '/' . ltrim($rel, '/')] = true;
-    }
-
-    return array_values(array_filter($discovered, function ($path) use ($allowed) {
-        return isset($allowed[$path]);
-    }));
 }
 
 // ---------------------------------------------------------------------------

--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq "$expected" "$file"; then
+        echo "Expected $file to contain: $expected" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local file="$1"
+    local unexpected="$2"
+    if grep -Fq "$unexpected" "$file"; then
+        echo "Expected $file not to contain: $unexpected" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+component="${TMPDIR}/component"
+mkdir -p "${component}/tests/Unit" "${TMPDIR}/stubs"
+
+cat > "${component}/tests/import-agent-ability-smoke.php" <<'PHP'
+<?php
+fwrite( STDOUT, "standalone smoke ran\n" );
+PHP
+
+cat > "${component}/tests/Unit/ImportAgentAbilityTest.php" <<'PHP'
+<?php
+// PHPUnit-shaped file; the playground backend owns execution.
+PHP
+
+cat > "${component}/tests/helper.php" <<'PHP'
+<?php
+// Not a standalone smoke script or PHPUnit test case.
+PHP
+
+cat > "${TMPDIR}/stubs/playground.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "PLAYGROUND_STUB"
+echo "SELECTED=${HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE:-}"
+printf 'ARGS=%s\n' "$*"
+SH
+chmod +x "${TMPDIR}/stubs/playground.sh"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/import-agent-ability-smoke.php > "${TMPDIR}/smoke-file.out"
+
+assert_contains "${TMPDIR}/smoke-file.out" "HOST_SMOKE_BEGIN:tests/import-agent-ability-smoke.php"
+assert_contains "${TMPDIR}/smoke-file.out" "standalone smoke ran"
+assert_not_contains "${TMPDIR}/smoke-file.out" "PLAYGROUND_STUB"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_RUNTIME_TEST_RUNNER_PLAYGROUND="${TMPDIR}/stubs/playground.sh" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/Unit/ImportAgentAbilityTest.php --filter ImportAgent > "${TMPDIR}/phpunit-file.out"
+
+assert_contains "${TMPDIR}/phpunit-file.out" "PLAYGROUND_STUB"
+assert_contains "${TMPDIR}/phpunit-file.out" "SELECTED=tests/Unit/ImportAgentAbilityTest.php"
+assert_contains "${TMPDIR}/phpunit-file.out" "ARGS=--filter ImportAgent"
+
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/helper.php > "${TMPDIR}/unclassified.out" 2>&1
+status=$?
+set -e
+
+if [ "$status" -ne 2 ]; then
+    echo "Expected unclassified file to exit 2, got $status" >&2
+    sed 's/^/  /' "${TMPDIR}/unclassified.out" >&2
+    exit 1
+fi
+assert_contains "${TMPDIR}/unclassified.out" "ERROR: cannot classify requested WordPress test file: tests/helper.php"
+
+echo "Test runner file routing smoke passed"

--- a/wordpress/scripts/test/test-runner-host-smoke.sh
+++ b/wordpress/scripts/test/test-runner-host-smoke.sh
@@ -14,6 +14,7 @@ homeboy_resolve_context --component-alias PLUGIN_PATH
 
 PHP_BIN="${HOMEBOY_PHP_BIN:-php}"
 TEST_DIR="${PLUGIN_PATH}/tests"
+TARGET_SMOKE_FILE="${HOMEBOY_WORDPRESS_HOST_SMOKE_FILE:-}"
 
 echo "Running host PHP smoke tests..."
 echo "  Component: ${COMPONENT_ID:-$(basename "$PLUGIN_PATH")} (${PLUGIN_PATH})"
@@ -25,7 +26,28 @@ if [ ! -d "$TEST_DIR" ]; then
     exit 0
 fi
 
-mapfile -t smoke_files < <(find "$TEST_DIR" -type f -name '*-smoke.php' | sort)
+if [ -n "$TARGET_SMOKE_FILE" ]; then
+    if [ "${TARGET_SMOKE_FILE#/}" != "$TARGET_SMOKE_FILE" ]; then
+        target_abs="$TARGET_SMOKE_FILE"
+    else
+        target_abs="${PLUGIN_PATH}/${TARGET_SMOKE_FILE}"
+    fi
+    if [ ! -f "$target_abs" ]; then
+        echo "ERROR: requested host smoke file not found: ${TARGET_SMOKE_FILE}" >&2
+        exit 2
+    fi
+    case "$target_abs" in
+        "${PLUGIN_PATH}"/tests/*-smoke.php)
+            smoke_files=("$target_abs")
+            ;;
+        *)
+            echo "ERROR: requested host smoke file must match tests/**/*-smoke.php: ${TARGET_SMOKE_FILE}" >&2
+            exit 2
+            ;;
+    esac
+else
+    mapfile -t smoke_files < <(find "$TEST_DIR" -type f -name '*-smoke.php' | sort)
+fi
 
 if [ "${#smoke_files[@]}" -eq 0 ]; then
     echo ""

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -79,6 +79,27 @@ else
 fi
 
 SETTINGS_JSON="${HOMEBOY_SETTINGS_JSON:-}"
+SELECTED_TEST_FILE="${HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE:-}"
+PASSTHROUGH_ARGS=()
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --file)
+            shift
+            if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
+                echo "ERROR: --file requires a path" >&2
+                exit 2
+            fi
+            SELECTED_TEST_FILE="$1"
+            ;;
+        --file=*)
+            SELECTED_TEST_FILE="${1#--file=}"
+            ;;
+        *)
+            PASSTHROUGH_ARGS+=("$1")
+            ;;
+    esac
+    shift
+done
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: [playground] Extension path: $EXTENSION_PATH"
@@ -167,6 +188,29 @@ if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
     ' 2>/dev/null || printf '[]')
 fi
 
+SELECTED_TEST_FILE_REL=""
+if [ -n "$SELECTED_TEST_FILE" ]; then
+    if [ "${SELECTED_TEST_FILE#/}" != "$SELECTED_TEST_FILE" ]; then
+        selected_abs="$SELECTED_TEST_FILE"
+    else
+        selected_abs="${PLUGIN_PATH}/${SELECTED_TEST_FILE}"
+    fi
+    if [ ! -f "$selected_abs" ]; then
+        echo "ERROR: requested PHPUnit test file not found: ${SELECTED_TEST_FILE}" >&2
+        exit 2
+    fi
+    case "$selected_abs" in
+        "${PLUGIN_PATH}"/tests/*.php)
+            SELECTED_TEST_FILE_REL="${selected_abs#"${PLUGIN_PATH}/"}"
+            ;;
+        *)
+            echo "ERROR: requested PHPUnit test file must live under tests/: ${SELECTED_TEST_FILE}" >&2
+            exit 2
+            ;;
+    esac
+fi
+SELECTED_TEST_FILE_B64=$(printf '%s' "$SELECTED_TEST_FILE_REL" | base64 | tr -d '\n')
+
 # PLUGIN_SLUG is the wp-content/plugins/ path segment Playground uses to
 # mount the component-under-test. When homeboy core tells us the canonical
 # component id (HOMEBOY_COMPONENT_ID), use it — basename($PLUGIN_PATH)
@@ -253,6 +297,7 @@ WP_CONFIG_DEFINES_DELIM=$(printf '\1')
 sed \
     -e "s|{{PLUGIN_SLUG}}|${PLUGIN_SLUG}|g" \
     -e "s|{{PLAYGROUND_DEP_MOUNTS}}|${PLAYGROUND_DEP_MOUNTS}|g" \
+    -e "s|{{PHPUNIT_TEST_FILE_B64}}|${SELECTED_TEST_FILE_B64}|g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{CHANGED_TEST_FILES_JSON}}${WP_CONFIG_DEFINES_DELIM}${CHANGED_TEST_FILES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -27,6 +27,8 @@ if ((BASH_VERSINFO[0] < 4)); then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOST_SMOKE_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_HOST_SMOKE:-${SCRIPT_DIR}/test-runner-host-smoke.sh}"
+PLAYGROUND_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_PLAYGROUND:-${SCRIPT_DIR}/test-runner-playground.sh}"
 
 # Resolve execution context and export env vars that the Playground runner expects.
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
@@ -46,6 +48,28 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
 fi
 TEST_BACKEND="${HOMEBOY_WORDPRESS_TEST_BACKEND:-${TEST_BACKEND:-playground}}"
 
+TARGET_FILE=""
+PASSTHROUGH_ARGS=()
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --file)
+            shift
+            if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
+                echo "ERROR: --file requires a path" >&2
+                exit 2
+            fi
+            TARGET_FILE="$1"
+            ;;
+        --file=*)
+            TARGET_FILE="${1#--file=}"
+            ;;
+        *)
+            PASSTHROUGH_ARGS+=("$1")
+            ;;
+    esac
+    shift
+done
+
 COMPONENT_SHAPE="${HOMEBOY_COMPONENT_SHAPE:-}"
 if [ -z "$COMPONENT_SHAPE" ]; then
     DETECT_COMPONENT_HELPER="${HOMEBOY_RUNTIME_DETECT_COMPONENT:-${SCRIPT_DIR}/../lib/detect-component.sh}"
@@ -56,17 +80,64 @@ if [ -z "$COMPONENT_SHAPE" ]; then
     fi
 fi
 
+if [ -n "$TARGET_FILE" ]; then
+    if [ "${TARGET_FILE#/}" != "$TARGET_FILE" ]; then
+        target_abs="$TARGET_FILE"
+    else
+        target_abs="${PLUGIN_PATH}/${TARGET_FILE}"
+    fi
+
+    if [ ! -f "$target_abs" ]; then
+        echo "ERROR: requested test file not found: ${TARGET_FILE}" >&2
+        exit 2
+    fi
+
+    case "$target_abs" in
+        "${PLUGIN_PATH}"/*)
+            target_rel="${target_abs#"${PLUGIN_PATH}/"}"
+            ;;
+        *)
+            echo "ERROR: requested test file is outside the component: ${TARGET_FILE}" >&2
+            exit 2
+            ;;
+    esac
+
+    target_base="$(basename "$target_rel")"
+    case "$target_rel" in
+        tests/*.php|tests/*/*.php|tests/*/*/*.php|tests/*/*/*/*.php)
+            case "$target_base" in
+                *-smoke.php)
+                    HOMEBOY_WORDPRESS_HOST_SMOKE_FILE="$target_rel" exec bash "$HOST_SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
+                    ;;
+                *Test.php|test-*.php)
+                    HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE="$target_rel" exec bash "$PLAYGROUND_RUNNER" "${PASSTHROUGH_ARGS[@]}"
+                    ;;
+                *)
+                    echo "ERROR: cannot classify requested WordPress test file: ${target_rel}" >&2
+                    echo "  Standalone smoke files must match tests/**/*-smoke.php." >&2
+                    echo "  PHPUnit files must match tests/**/*Test.php or tests/**/test-*.php." >&2
+                    exit 2
+                    ;;
+            esac
+            ;;
+        *)
+            echo "ERROR: requested WordPress test file must live under tests/: ${target_rel}" >&2
+            exit 2
+            ;;
+    esac
+fi
+
 case "$COMPONENT_SHAPE" in
     core-dev)
-        exec bash "${SCRIPT_DIR}/test-runner-core-dev.sh" "$@"
+        exec bash "${SCRIPT_DIR}/test-runner-core-dev.sh" "${PASSTHROUGH_ARGS[@]}"
         ;;
     *)
         case "$TEST_BACKEND" in
             host|host-smoke)
-                exec bash "${SCRIPT_DIR}/test-runner-host-smoke.sh" "$@"
+                exec bash "$HOST_SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
                 ;;
             ""|playground)
-                exec bash "${SCRIPT_DIR}/test-runner-playground.sh" "$@"
+                exec bash "$PLAYGROUND_RUNNER" "${PASSTHROUGH_ARGS[@]}"
                 ;;
             *)
                 echo "ERROR: Unsupported WordPress test backend: ${TEST_BACKEND}" >&2


### PR DESCRIPTION
## Summary
- Route `homeboy test --file tests/*-smoke.php` through the host smoke runner instead of the broad Playground PHPUnit harness.
- Preserve PHPUnit-shaped `--file` routing by passing the selected file into the Playground runner and narrowing discovery to that file.
- Fail clearly when a requested WordPress test file cannot be classified as standalone smoke or PHPUnit.

## Tests
- `bash wordpress/scripts/test/host-smoke-runner-smoke.sh`
- `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/test-runner-host-smoke.sh wordpress/scripts/test/test-runner-playground.sh wordpress/scripts/test/playground-runner.php wordpress/scripts/test/test-runner-file-routing-smoke.sh wordpress/scripts/test/host-smoke-runner-smoke.sh`
- `bash wordpress/scripts/test/playground-discovery-smoke.sh`
- `php -l wordpress/scripts/test/playground-runner.php`
- `homeboy lint wordpress --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-standalone-smoke-file/wordpress --summary`
- `homeboy test wordpress --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-standalone-smoke-file/wordpress --skip-lint --summary`
- Direct repro through patched runner: `tests/import-agent-ability-smoke.php` ran as a single host smoke file and passed 22 assertions.

Closes #339

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Implemented the targeted WordPress test runner routing fix, added focused shell smoke coverage, and ran validation. Chris remains responsible for review and merge.