### PR TITLE
fix(wordpress): respect scoped lint and test files

### DIFF
--- a/wordpress/scripts/lint/eslint-glob-filter-smoke.sh
+++ b/wordpress/scripts/lint/eslint-glob-filter-smoke.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq "$expected" "$file"; then
+        echo "Expected $file to contain: $expected" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local file="$1"
+    local unexpected="$2"
+    if grep -Fq "$unexpected" "$file"; then
+        echo "Expected $file not to contain: $unexpected" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+component_dir="${TMPDIR}/component"
+mkdir -p "${component_dir}/inc" "${component_dir}/assets" "${EXTENSION_PATH}/node_modules/.bin"
+touch "${EXTENSION_PATH}/.eslintrc.json"
+printf '%s\n' '<?php' > "${component_dir}/inc/Thing.php"
+printf '%s\n' 'const answer = 42;' > "${component_dir}/assets/app.js"
+
+eslint_log="${TMPDIR}/eslint-args.txt"
+cat > "${EXTENSION_PATH}/node_modules/.bin/eslint" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${ESLINT_LOG}"
+printf '[]\n'
+SH
+chmod +x "${EXTENSION_PATH}/node_modules/.bin/eslint"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component_dir" \
+HOMEBOY_COMPONENT_TEXT_DOMAIN="component" \
+HOMEBOY_SUMMARY_MODE=1 \
+HOMEBOY_LINT_GLOB="{${component_dir}/inc/Thing.php}" \
+ESLINT_LOG="$eslint_log" \
+    bash "${EXTENSION_PATH}/scripts/lint/eslint-runner.sh" > "${TMPDIR}/php-only.out"
+
+if [ -f "$eslint_log" ]; then
+    echo "Expected ESLint not to run for PHP-only glob" >&2
+    exit 1
+fi
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component_dir" \
+HOMEBOY_COMPONENT_TEXT_DOMAIN="component" \
+HOMEBOY_SUMMARY_MODE=1 \
+HOMEBOY_LINT_GLOB="{${component_dir}/inc/Thing.php,${component_dir}/assets/app.js}" \
+ESLINT_LOG="$eslint_log" \
+    bash "${EXTENSION_PATH}/scripts/lint/eslint-runner.sh" > "${TMPDIR}/mixed.out"
+
+assert_contains "${TMPDIR}/mixed.out" "Linting 1 JS files matching"
+assert_contains "$eslint_log" "${component_dir}/assets/app.js"
+assert_not_contains "$eslint_log" "${component_dir}/inc/Thing.php"
+
+echo "ESLint glob filter smoke passed"

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -68,15 +68,30 @@ elif [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
     cd "$PLUGIN_PATH"
 
     MATCHED_FILES=()
+    set +e
     eval 'for f in '"${HOMEBOY_LINT_GLOB}"'; do [ -e "$f" ] && MATCHED_FILES+=("$f"); done'
+    glob_exit=$?
+    set -e
+    if [ "$glob_exit" -ne 0 ] && [ ${#MATCHED_FILES[@]} -eq 0 ]; then
+        MATCHED_FILES=()
+    fi
 
-    if [ ${#MATCHED_FILES[@]} -eq 0 ]; then
+    JS_FILES=()
+    for matched_file in "${MATCHED_FILES[@]}"; do
+        case "$matched_file" in
+            *.js|*.jsx|*.ts|*.tsx)
+                JS_FILES+=("$matched_file")
+                ;;
+        esac
+    done
+
+    if [ ${#JS_FILES[@]} -eq 0 ]; then
         echo "No JS files match pattern: ${HOMEBOY_LINT_GLOB}"
         exit 0
     fi
 
-    echo "Linting ${#MATCHED_FILES[@]} files matching: ${HOMEBOY_LINT_GLOB}"
-    LINT_FILES=("${MATCHED_FILES[@]}")
+    echo "Linting ${#JS_FILES[@]} JS files matching: ${HOMEBOY_LINT_GLOB}"
+    LINT_FILES=("${JS_FILES[@]}")
     cd - > /dev/null
 else
     echo "Running JavaScript linting..."

--- a/wordpress/scripts/test/playground-changed-scope-smoke.sh
+++ b/wordpress/scripts/test/playground-changed-scope-smoke.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/playground-runner.php"
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq "$expected" "$file"; then
+        echo "Expected $file to contain: $expected" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+assert_contains "$RUNNER" "{{CHANGED_TEST_FILES_JSON}}"
+assert_contains "$RUNNER" "pg_filter_changed_tests"
+assert_contains "$RUNNER" "changed test scope skipped non-PHPUnit file"
+assert_contains "${SCRIPT_DIR}/test-runner-playground.sh" "CHANGED_TEST_FILES_JSON"
+assert_contains "${SCRIPT_DIR}/test-runner-playground.sh" "{{CHANGED_TEST_FILES_JSON}}"
+
+php -l "$RUNNER" >/dev/null
+bash -n "${SCRIPT_DIR}/test-runner-playground.sh"
+
+echo "Playground changed-scope smoke passed"

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -61,6 +61,10 @@ pg_install_diagnostics_handlers();
 
 $tests_dir = '/homeboy-extension/vendor/wp-phpunit/wp-phpunit';
 $plugin_path = '/wordpress/wp-content/plugins/{{PLUGIN_SLUG}}';
+$changed_test_files = json_decode('{{CHANGED_TEST_FILES_JSON}}', true);
+if (!is_array($changed_test_files)) {
+    $changed_test_files = [];
+}
 
 // Stage: boot — render wp-tests-config.php + load composer autoload.
 //
@@ -185,6 +189,11 @@ try {
     );
 
     $test_files = pg_discover_tests($directories, $suffixes, $prefixes, $excludes);
+
+    if (!empty($changed_test_files)) {
+        $test_files = pg_filter_changed_tests($test_files, $changed_test_files, $plugin_path, $suffixes, $prefixes);
+        pg_log("NOTICE:changed test scope applied; selected=" . count($test_files));
+    }
 
     pg_log("DISCOVERY: dirs=" . implode(',', $directories)
         . " suffixes=" . implode(',', $suffixes)
@@ -377,6 +386,50 @@ function pg_discover_tests(array $directories, array $suffixes, array $prefixes,
     // Stable ordering so re-runs show the same failure order.
     sort($found);
     return array_values(array_unique($found));
+}
+
+/**
+ * Filter discovered PHPUnit files to Homeboy's changed-test scope.
+ *
+ * Homeboy may include standalone smoke scripts in HOMEBOY_CHANGED_TEST_FILES;
+ * those are intentionally ignored here because the Playground runner only
+ * executes PHPUnit test cases. The host-smoke backend owns smoke execution.
+ */
+function pg_filter_changed_tests(array $discovered, array $changed_files, $plugin_path, array $suffixes, array $prefixes) {
+    $allowed = [];
+    foreach ($changed_files as $rel) {
+        $rel = trim(str_replace('\\', '/', (string) $rel));
+        if ($rel === '' || strpos($rel, '..') !== false) {
+            continue;
+        }
+
+        $base = basename($rel);
+        $matches_phpunit = false;
+        foreach ($suffixes as $suffix) {
+            if ($suffix !== '' && substr($base, -strlen($suffix)) === $suffix) {
+                $matches_phpunit = true;
+                break;
+            }
+        }
+        if (!$matches_phpunit) {
+            foreach ($prefixes as $prefix) {
+                if ($prefix !== '' && strpos($base, $prefix) === 0) {
+                    $matches_phpunit = true;
+                    break;
+                }
+            }
+        }
+        if (!$matches_phpunit) {
+            pg_log("NOTICE:changed test scope skipped non-PHPUnit file: $rel");
+            continue;
+        }
+
+        $allowed[rtrim($plugin_path, '/') . '/' . ltrim($rel, '/')] = true;
+    }
+
+    return array_values(array_filter($discovered, function ($path) use ($allowed) {
+        return isset($allowed[$path]);
+    }));
 }
 
 // ---------------------------------------------------------------------------

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -156,6 +156,14 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     fi
 fi
 
+CHANGED_TEST_FILES_JSON="[]"
+if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
+    CHANGED_TEST_FILES_JSON=$(printf '%s' "${HOMEBOY_CHANGED_TEST_FILES}" | php -r '
+        $files = array_values(array_filter(array_map("trim", explode("\n", stream_get_contents(STDIN)))));
+        echo json_encode($files, JSON_UNESCAPED_SLASHES);
+    ' 2>/dev/null || printf '[]')
+fi
+
 # PLUGIN_SLUG is the wp-content/plugins/ path segment Playground uses to
 # mount the component-under-test. When homeboy core tells us the canonical
 # component id (HOMEBOY_COMPONENT_ID), use it — basename($PLUGIN_PATH)
@@ -244,6 +252,7 @@ sed \
     -e "s|{{PLAYGROUND_DEP_MOUNTS}}|${PLAYGROUND_DEP_MOUNTS}|g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{CHANGED_TEST_FILES_JSON}}${WP_CONFIG_DEFINES_DELIM}${CHANGED_TEST_FILES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     "$TEMPLATE" > "$WRAPPER_TMPFILE"
 
 echo "Running PHPUnit tests via WordPress Playground..."


### PR DESCRIPTION
## Summary
- Filter ESLint changed-file globs down to actual JS/TS files so PHP-only changes do not fail in ESLint.
- Pass Homeboy's changed-test scope into the Playground runner and filter discovered PHPUnit files to the selected scope.
- Add focused smoke coverage for both routing contracts.

## Tests
- `bash wordpress/scripts/lint/eslint-glob-filter-smoke.sh`
- `bash wordpress/scripts/test/playground-changed-scope-smoke.sh`
- `bash -n wordpress/scripts/lint/eslint-runner.sh && bash -n wordpress/scripts/test/test-runner-playground.sh`
- `php -l wordpress/scripts/test/playground-runner.php`

Closes #325.
Refs #339.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the scoped runner fixes and smoke coverage; Chris directed the upstream-first debugging path and remains responsible for review/merge.