### PR TITLE
test(wordpress): cover scoped eslint file filtering

### DIFF
--- a/tests/wordpress-eslint-scope-smoke.sh
+++ b/tests/wordpress-eslint-scope-smoke.sh
@@ -33,7 +33,7 @@ COMPONENT_DIR="$TMP_DIR/example-plugin"
 FAKE_EXTENSION="$TMP_DIR/fake-wordpress-extension"
 ESLINT_ARGS_FILE="$TMP_DIR/eslint-args.txt"
 
-mkdir -p "$COMPONENT_DIR/inc" "$COMPONENT_DIR/assets" "$FAKE_EXTENSION/node_modules/.bin"
+mkdir -p "$COMPONENT_DIR/inc" "$COMPONENT_DIR/assets" "$COMPONENT_DIR/docs" "$FAKE_EXTENSION/node_modules/.bin"
 
 cat > "$COMPONENT_DIR/example-plugin.php" <<'PHP'
 <?php
@@ -58,6 +58,10 @@ cat > "$COMPONENT_DIR/assets/view.ts" <<'TS'
 const examplePluginView: boolean = true;
 TS
 
+cat > "$COMPONENT_DIR/docs/example.md" <<'MD'
+# Example docs
+MD
+
 cat > "$FAKE_EXTENSION/.eslintrc.json" <<'JSON'
 {}
 JSON
@@ -65,8 +69,29 @@ JSON
 cat > "$FAKE_EXTENSION/node_modules/.bin/eslint" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "$ESLINT_ARGS_FILE"
+for arg in "$@"; do
+    case "$arg" in
+        */assets/bad.js|assets/bad.js)
+            echo "simulated eslint failure" >&2
+            exit 1
+            ;;
+    esac
+done
 SH
 chmod +x "$FAKE_EXTENSION/node_modules/.bin/eslint"
+
+HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="example-plugin" \
+ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
+HOMEBOY_LINT_FILE='docs/example.md' \
+    bash "$RUNNER" > "$TMP_DIR/single-md.out" 2>&1
+
+if [ -f "$ESLINT_ARGS_FILE" ]; then
+    echo "ESLint should not run for single-file Markdown scope" >&2
+    cat "$ESLINT_ARGS_FILE" >&2
+    exit 1
+fi
 
 HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
@@ -94,5 +119,42 @@ assert_contains "$ESLINT_ARGS_FILE" "assets/admin.js"
 assert_contains "$ESLINT_ARGS_FILE" "assets/view.ts"
 assert_not_contains "$ESLINT_ARGS_FILE" "example-plugin.php"
 assert_not_contains "$ESLINT_ARGS_FILE" "inc/runtime.php"
+
+rm -f "$ESLINT_ARGS_FILE"
+
+HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="example-plugin" \
+ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
+HOMEBOY_LINT_FILE='assets/admin.js' \
+    bash "$RUNNER" > "$TMP_DIR/js-success.out" 2>&1
+
+assert_contains "$TMP_DIR/js-success.out" "Linting single file: assets/admin.js"
+assert_contains "$TMP_DIR/js-success.out" "ESLint linting passed"
+assert_contains "$ESLINT_ARGS_FILE" "assets/admin.js"
+
+cat > "$COMPONENT_DIR/assets/bad.js" <<'JS'
+const bad = true;
+JS
+
+set +e
+HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="example-plugin" \
+ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
+HOMEBOY_LINT_FILE='assets/bad.js' \
+    bash "$RUNNER" > "$TMP_DIR/js-failure.out" 2>&1
+failure_status=$?
+set -e
+
+if [ "$failure_status" -eq 0 ]; then
+    echo "Expected ESLint failure to propagate for JS file scope" >&2
+    cat "$TMP_DIR/js-failure.out" >&2
+    exit 1
+fi
+
+assert_contains "$TMP_DIR/js-failure.out" "Linting single file: assets/bad.js"
+assert_contains "$TMP_DIR/js-failure.out" "ESLint linting failed"
+assert_contains "$ESLINT_ARGS_FILE" "assets/bad.js"
 
 echo "wordpress eslint scope smoke passed"

--- a/wordpress/scripts/lint/eslint-glob-filter-smoke.sh
+++ b/wordpress/scripts/lint/eslint-glob-filter-smoke.sh
@@ -63,7 +63,7 @@ HOMEBOY_LINT_GLOB="{${component_dir}/inc/Thing.php,${component_dir}/assets/app.j
 ESLINT_LOG="$eslint_log" \
     bash "${EXTENSION_PATH}/scripts/lint/eslint-runner.sh" > "${TMPDIR}/mixed.out"
 
-assert_contains "${TMPDIR}/mixed.out" "Linting 1 JS files matching"
+assert_contains "${TMPDIR}/mixed.out" "Linting 1 JS/TS files matching"
 assert_contains "$eslint_log" "${component_dir}/assets/app.js"
 assert_not_contains "$eslint_log" "${component_dir}/inc/Thing.php"
 


### PR DESCRIPTION
## Summary
- Adds regression coverage for scoped WordPress ESLint runs so non-JS files are skipped before ESLint is invoked.
- Updates the existing glob smoke expectation to match the current JS/TS skip message.

## Behavior
- Single-file Markdown scope exits cleanly without invoking ESLint.
- Changed-glob scopes containing only PHP/Markdown files exit cleanly without invoking ESLint.
- Mixed changed-glob scopes pass only JS/TS files to ESLint.
- JS success and failure paths still execute ESLint and preserve its exit behavior.

## Tests
- bash wordpress/scripts/lint/eslint-glob-filter-smoke.sh
- bash tests/wordpress-eslint-scope-smoke.sh
- bash wordpress/scripts/lint/autofixable-exit-smoke.sh
- bash wordpress/scripts/lint/phpstan-scoped-smoke.sh
- bash wordpress/scripts/test/test-runner-file-routing-smoke.sh

Homeboy changed-since gates were attempted, but this local registry cannot run them for the monorepo root component: Component 'homeboy-extensions' has no extensions configured.

Closes #344

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Added targeted regression coverage, ran focused validation, and prepared this PR. Chris remains responsible for review and merge decisions.