### PR TITLE
fix(wordpress): load playground test plugins during bootstrap

### DIFF
--- a/wordpress/scripts/lib/playground-bootstrap.php
+++ b/wordpress/scripts/lib/playground-bootstrap.php
@@ -432,7 +432,9 @@ function pg_run_load_component_stage(array $cfg) {
                 if (strpos(file_get_contents($mf), 'Plugin Name:') !== false) {
                     pg_log("PLUGIN_DETECTED " . basename($mf));
                     require_once $mf;
-                    pg_activate_plugin_file($mf);
+                    if (($cfg['activate'] ?? true) !== false) {
+                        pg_activate_plugin_file($mf);
+                    }
                     $loaded = true;
                     break;
                 }

--- a/wordpress/scripts/test/playground-no-test-files-smoke.sh
+++ b/wordpress/scripts/test/playground-no-test-files-smoke.sh
@@ -10,6 +10,9 @@ EXTENSION_PATH="${TMPDIR}/extension"
 PLUGIN_PATH="${TMPDIR}/component"
 mkdir -p "${EXTENSION_PATH}/node_modules/.bin" "${PLUGIN_PATH}/tests"
 
+RUNNER_SRC="$(cat "${SCRIPT_DIR}/playground-runner.php")"
+BOOTSTRAP_SRC="$(cat "${SCRIPT_DIR}/../lib/playground-bootstrap.php")"
+
 cat > "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -76,4 +79,9 @@ assert_contains "$failure_output" "PHPUnit config exists, but no files matched t
 assert_not_contains "$failure_output" "UNCLASSIFIED PLAYGROUND FAILURE"
 assert_not_contains "$failure_output" "Skipping PHPUnit tests: no files matched"
 
-echo "Playground no-test-files smoke passed (9 assertions)"
+assert_contains "$RUNNER_SRC" "tests_add_filter('muplugins_loaded'"
+assert_contains "$RUNNER_SRC" "'activate' => false"
+assert_contains "$RUNNER_SRC" "pg_run_install_stage(['config_path' => \$config_path, 'tests_dir' => \$tests_dir]);"
+assert_contains "$BOOTSTRAP_SRC" "\$cfg['activate'] ?? true"
+
+echo "Playground no-test-files smoke passed (13 assertions)"

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -98,8 +98,21 @@ if (is_array($bench_env)) {
     }
 }
 
+// Load the component during WordPress bootstrap, not after wp-settings.php has
+// finished. Plugins that register hooks for core bootstrap events (for example
+// wp_abilities_api_init) need to be present before those events fire.
+require_once "$tests_dir/includes/functions.php";
+tests_add_filter('muplugins_loaded', function () use ($plugin_path) {
+    pg_run_load_deps_stage(['dep_mounts' => '{{PLAYGROUND_DEP_MOUNTS}}']);
+    pg_run_load_component_stage(['plugin_path' => $plugin_path, 'activate' => false]);
+});
+
 // Stage: install — wp-phpunit install.php creates WP tables in-process.
 pg_run_install_stage(['config_path' => $config_path, 'tests_dir' => $tests_dir]);
+
+// Run activation hooks after wp-phpunit has created database tables. The plugin
+// file was already required during muplugins_loaded, so require_once is a no-op.
+pg_run_load_component_stage(['plugin_path' => $plugin_path]);
 
 // ---------------------------------------------------------------------------
 // Stage: load_fixtures (test case classes, mock mailer, harness filters)
@@ -147,12 +160,6 @@ try {
     pg_stage_fail('load_fixtures', $e);
     exit(1);
 }
-
-// Stage: load_deps — load Plugin-Name-headed entry files for declared deps.
-pg_run_load_deps_stage(['dep_mounts' => '{{PLAYGROUND_DEP_MOUNTS}}']);
-
-// Stage: load_component — load the plugin or theme under test.
-pg_run_load_component_stage(['plugin_path' => $plugin_path]);
 
 // ---------------------------------------------------------------------------
 // Stage: discover_tests


### PR DESCRIPTION
## Summary
- Load Playground test components during WordPress bootstrap so plugins can attach to bootstrap-time hooks such as wp_abilities_api_init.
- Delay activation-hook execution until after wp-phpunit has created core database tables.
- Extend the Playground no-test-files smoke to pin the bootstrap/activation ordering contract.

## Tests
- bash wordpress/scripts/test/playground-no-test-files-smoke.sh
- php -l wordpress/scripts/test/playground-runner.php
- php -l wordpress/scripts/lib/playground-bootstrap.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the Data Machine CI failure, drafted the runner fix and smoke coverage; Chris reviewed through the local verification flow.
