### PR TITLE
fix(wordpress): log playground install diagnostics

### DIFF
--- a/wordpress/scripts/lib/playground-bootstrap.php
+++ b/wordpress/scripts/lib/playground-bootstrap.php
@@ -66,6 +66,22 @@ function pg_log($msg) {
 }
 
 /**
+ * Return compact bootstrap context for diagnostics emitted from inside WP hooks.
+ */
+function pg_diagnostic_context(): string {
+    global $current_stage;
+
+    $hook = function_exists('current_filter') ? current_filter() : null;
+    if (!is_string($hook) || $hook === '') {
+        $hook = 'none';
+    }
+
+    $installing = function_exists('wp_installing') && wp_installing() ? 'true' : 'false';
+
+    return 'stage=' . ($current_stage ?: 'unknown') . ' hook=' . $hook . ' wp_installing=' . $installing;
+}
+
+/**
  * Module-scope stage timing storage.
  *
  * Stores `hrtime(true)` start times in `_starts_ns` keyed by stage name,
@@ -168,7 +184,7 @@ function pg_install_diagnostics_handlers() {
             E_USER_DEPRECATED => 'USER_DEPRECATED',
             E_STRICT => 'STRICT',
         ][$severity] ?? "E_$severity";
-        pg_log("NOTICE:$label: $message at $file:$line");
+        pg_log("NOTICE:$label: $message at $file:$line context=" . pg_diagnostic_context());
         return false;
     });
 
@@ -431,6 +447,11 @@ function pg_run_load_component_stage(array $cfg) {
                 }
                 if (strpos(file_get_contents($mf), 'Plugin Name:') !== false) {
                     pg_log("PLUGIN_DETECTED " . basename($mf));
+                    pg_log(
+                        'PLUGIN_LOAD_CONTEXT ' . basename($mf)
+                        . ' activate=' . ((($cfg['activate'] ?? true) !== false) ? 'true' : 'false')
+                        . ' ' . pg_diagnostic_context()
+                    );
                     require_once $mf;
                     if (($cfg['activate'] ?? true) !== false) {
                         pg_activate_plugin_file($mf);
@@ -467,9 +488,12 @@ function pg_activate_plugin_file(string $plugin_file): void {
 
     $plugin_basename = plugin_basename($plugin_file);
     pg_log("PLUGIN_ACTIVATE $plugin_basename");
+    pg_log("PLUGIN_ACTIVATE_BEGIN $plugin_basename " . pg_diagnostic_context());
 
     do_action("activate_$plugin_basename", false);
     do_action('activated_plugin', $plugin_basename, false);
+
+    pg_log("PLUGIN_ACTIVATE_OK $plugin_basename " . pg_diagnostic_context());
 }
 
 /**

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -18,6 +18,9 @@
  *   STAGE_FATAL:<stage>:<msg>    - uncatchable fatal (from shutdown handler)
  *   NOTICE:<msg>                 - PHP warning/notice that escaped silencing
  *   PLUGIN_DETECTED <basename>   - loaded plugin entry file
+ *   PLUGIN_LOAD_CONTEXT <...>    - load stage/hook/installing/activation context
+ *   PLUGIN_ACTIVATE_BEGIN <...>  - post-install activation hook dispatch begins
+ *   PLUGIN_ACTIVATE_OK <...>     - post-install activation hook dispatch ended
  *   THEME_DETECTED               - loaded theme (style.css + functions.php)
  *   NO_TEST_FILES                - discovery found no candidates
  *   RUNNING <n> TEST FILES       - starting PHPUnit
@@ -38,6 +41,12 @@
  * The bash runner's job: if playground_exit != 0 AND no STAGE_FAIL/FATAL/
  * SOME TESTS FAILED line exists, surface the raw stdout/stderr — something
  * crashed before we could even write to the result file.
+ *
+ * Plugin lifecycle contract: plugin files are loaded during WordPress bootstrap
+ * with activation disabled, while wp_installing() may still be true and test DB
+ * tables may not be ready. Runtime callbacks must guard install-time table
+ * access. Activation hooks are dispatched later by the runner after the
+ * wp-phpunit install stage has created the test tables.
  */
 
 // Report everything. Warnings/notices inside WP bootstrap have historically

--- a/wordpress/scripts/test/playground-schema-scope-smoke.php
+++ b/wordpress/scripts/test/playground-schema-scope-smoke.php
@@ -8,6 +8,8 @@ $current_stage = 'preboot';
 $assertions = 0;
 $actions = array();
 $options = array();
+$current_hook = null;
+$wp_installing = true;
 
 function assert_true_smoke( $condition, $message ) {
     global $assertions;
@@ -23,10 +25,21 @@ function add_action( $hook, $callback ) {
 }
 
 function do_action( $hook, ...$args ) {
-    global $actions;
+    global $actions, $current_hook;
+    $previous_hook = $current_hook;
+    $current_hook = $hook;
     foreach ( $actions[ $hook ] ?? array() as $callback ) {
         call_user_func_array( $callback, $args );
     }
+    $current_hook = $previous_hook;
+}
+
+function current_filter() {
+    return $GLOBALS['current_hook'];
+}
+
+function wp_installing() {
+    return $GLOBALS['wp_installing'];
 }
 
 function plugin_basename( $file ) {
@@ -57,7 +70,34 @@ $wpdb = new Smoke_WPDB();
 require_once dirname( __DIR__ ) . '/lib/playground-bootstrap.php';
 
 $fixture_path = dirname( __DIR__, 2 ) . '/tests/fixtures/playground-schema-scope';
+pg_run_load_component_stage( array( 'plugin_path' => $fixture_path, 'activate' => false ) );
+
+$install_load_log = file_get_contents( $result_file );
+assert_true_smoke(
+    strpos( $install_load_log, 'PLUGIN_LOAD_CONTEXT playground-schema-scope.php activate=false stage=load_component hook=none wp_installing=true' ) !== false,
+    'Install-time plugin load context was not logged.'
+);
+assert_true_smoke(
+    strpos( $install_load_log, 'PLUGIN_ACTIVATE_BEGIN' ) === false,
+    'Activation diagnostics should not be logged when activation is disabled during install-time load.'
+);
+
+$GLOBALS['wp_installing'] = false;
 pg_run_load_component_stage( array( 'plugin_path' => $fixture_path ) );
+
+$activation_log = file_get_contents( $result_file );
+assert_true_smoke(
+    strpos( $activation_log, 'PLUGIN_LOAD_CONTEXT playground-schema-scope.php activate=true stage=load_component hook=none wp_installing=false' ) !== false,
+    'Post-install plugin load context was not logged.'
+);
+assert_true_smoke(
+    strpos( $activation_log, 'PLUGIN_ACTIVATE_BEGIN playground-schema-scope/playground-schema-scope.php stage=load_component hook=none wp_installing=false' ) !== false,
+    'Post-install activation begin context was not logged.'
+);
+assert_true_smoke(
+    strpos( $activation_log, 'PLUGIN_ACTIVATE_OK playground-schema-scope/playground-schema-scope.php stage=load_component hook=none wp_installing=false' ) !== false,
+    'Post-install activation completion context was not logged.'
+);
 
 assert_true_smoke(
     isset( $GLOBALS['options']['homeboy_playground_schema_scope_activated'] ),


### PR DESCRIPTION
## Summary

- Adds structured Playground runner diagnostics for install-time plugin loading and post-install activation boundaries.
- Documents the runner lifecycle contract so plugin authors can distinguish runtime callbacks during `wp_installing()` from activation hooks after wp-phpunit creates tables.

## Changes

- Adds compact diagnostic context (`stage`, `hook`, `wp_installing`) to PHP warning/notice log lines.
- Logs `PLUGIN_LOAD_CONTEXT`, `PLUGIN_ACTIVATE_BEGIN`, and `PLUGIN_ACTIVATE_OK` lines around plugin load and activation dispatch.
- Extends the schema/scope smoke to verify install-time load context, disabled activation during bootstrap load, and post-install activation context.

## Tests

- `php wordpress/scripts/test/playground-schema-scope-smoke.php`
- `php -l wordpress/scripts/lib/playground-bootstrap.php`
- `php -l wordpress/scripts/test/playground-runner.php`
- `php -l wordpress/scripts/test/playground-schema-scope-smoke.php`
- `bash wordpress/scripts/test/playground-no-test-files-smoke.sh`
- `bash wordpress/tests/playground-test-discovery-smoke.sh`
- `git diff --check`
- `homeboy audit homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-install-diagnostics --changed-since origin/main`

Note: `homeboy lint homeboy-extensions --path ... --file ...` is currently blocked because the registered `homeboy-extensions` component has no extensions configured locally. A broader Playground smoke sweep also hit existing environment/smoke issues (`wp-playground-cli` not installed for integration smokes and a stale `pg_filter_changed_tests` expectation), so this PR relies on the focused diagnostics smokes above.

Closes #348

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing WordPress runner install-time diagnostics and focused smoke coverage; Chris reviewed/tested before merge.
