### PR TITLE
feat(nodejs): add trace runner support

### DIFF
--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -146,6 +146,9 @@
   "bench": {
     "extension_script": "scripts/bench/bench-runner.sh"
   },
+  "trace": {
+    "extension_script": "scripts/trace/trace-runner.sh"
+  },
   "actions": [
     {
       "id": "release.package",

--- a/nodejs/scripts/trace/nodejs-trace-runner-smoke.sh
+++ b/nodejs/scripts/trace/nodejs-trace-runner-smoke.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+MANIFEST="${EXTENSION_DIR}/nodejs.json"
+RUNNER="${SCRIPT_DIR}/trace-runner.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-trace.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+assert_json() {
+    local file="$1"
+    local script="$2"
+    node -e "const fs = require('fs'); const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); ${script}" "$file"
+}
+
+make_project() {
+    local name="$1"
+    local project_dir="$TMP_DIR/$name"
+    mkdir -p "$project_dir"
+    printf '{"name":"%s","scripts":{}}\n' "$name" > "$project_dir/package.json"
+    printf '%s\n' "$project_dir"
+}
+
+run_trace() {
+    local project_dir="$1"
+    local scenario="$2"
+    local results_file="$3"
+    local artifact_dir="$4"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_PATH="$project_dir" \
+    HOMEBOY_COMPONENT_ID="node-trace-smoke" \
+    HOMEBOY_TRACE_SCENARIO="$scenario" \
+    HOMEBOY_TRACE_RESULTS_FILE="$results_file" \
+    HOMEBOY_TRACE_ARTIFACT_DIR="$artifact_dir" \
+    HOMEBOY_RUN_DIR="$(dirname "$results_file")" \
+        bash "$RUNNER"
+}
+
+node - "$MANIFEST" "$RUNNER" <<'NODE'
+const fs = require('fs');
+const [manifestPath, runnerPath] = process.argv.slice(2);
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const runner = fs.readFileSync(runnerPath, 'utf8');
+if (manifest.trace?.extension_script !== 'scripts/trace/trace-runner.sh') {
+  throw new Error('trace runner path is not declared in nodejs.json');
+}
+for (const token of [
+  'HOMEBOY_TRACE_RESULTS_FILE',
+  'HOMEBOY_TRACE_SCENARIO',
+  'HOMEBOY_TRACE_LIST_ONLY',
+  'HOMEBOY_TRACE_ARTIFACT_DIR',
+  'HOMEBOY_RUN_DIR',
+]) {
+  if (!runner.includes(token)) throw new Error(`runner missing env contract token ${token}`);
+}
+NODE
+
+LIST_PROJECT="$(make_project list-mode)"
+mkdir -p "$LIST_PROJECT/traces" "$LIST_PROJECT/scripts/trace"
+printf 'console.log("first")\n' > "$LIST_PROJECT/traces/first.trace.mjs"
+printf 'console.log("second")\n' > "$LIST_PROJECT/scripts/trace/second.mjs"
+LIST_RESULTS="$TMP_DIR/list-results.json"
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$LIST_PROJECT" \
+HOMEBOY_COMPONENT_ID="node-trace-smoke" \
+HOMEBOY_TRACE_LIST_ONLY="1" \
+HOMEBOY_TRACE_RESULTS_FILE="$LIST_RESULTS" \
+    bash "$RUNNER" >/dev/null
+assert_json "$LIST_RESULTS" '
+if (data.status !== "pass") throw new Error("list envelope did not pass");
+const ids = data.scenarios.map((scenario) => scenario.id).sort();
+if (ids.join(",") !== "first,second") throw new Error(`unexpected scenarios: ${ids.join(",")}`);
+if (!data.scenarios.find((scenario) => scenario.id === "first" && scenario.source === "traces/first.trace.mjs")) throw new Error("missing traces/*.trace.mjs source");
+if (!data.scenarios.find((scenario) => scenario.id === "second" && scenario.source === "scripts/trace/second.mjs")) throw new Error("missing scripts/trace/*.mjs source");
+'
+
+TRACE_PROJECT="$(make_project traces-scenario)"
+mkdir -p "$TRACE_PROJECT/traces"
+cat > "$TRACE_PROJECT/traces/pass.trace.mjs" <<'EOF'
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+mkdirSync(process.env.HOMEBOY_TRACE_ARTIFACT_DIR, { recursive: true });
+writeFileSync(join(process.env.HOMEBOY_TRACE_ARTIFACT_DIR, 'trace.txt'), 'artifact');
+writeFileSync(process.env.HOMEBOY_TRACE_RESULTS_FILE, JSON.stringify({
+  component_id: process.env.HOMEBOY_COMPONENT_ID,
+  scenario_id: process.env.HOMEBOY_TRACE_SCENARIO,
+  status: 'pass',
+  summary: 'custom result',
+  timeline: [],
+  assertions: [],
+  artifacts: [{ label: 'trace', path: 'trace.txt' }],
+}, null, 2));
+EOF
+TRACE_RESULTS="$TMP_DIR/trace-results.json"
+TRACE_ARTIFACTS="$TMP_DIR/trace-artifacts"
+run_trace "$TRACE_PROJECT" "pass" "$TRACE_RESULTS" "$TRACE_ARTIFACTS" >/dev/null
+if [ ! -f "$TRACE_ARTIFACTS/trace.txt" ]; then
+    echo "expected scenario artifact to be written" >&2
+    exit 1
+fi
+assert_json "$TRACE_RESULTS" '
+if (data.status !== "pass") throw new Error("named traces scenario did not pass");
+if (data.summary !== "custom result") throw new Error("runner overwrote scenario result envelope");
+if (data.artifacts[0].path !== "trace.txt") throw new Error("artifact path not preserved");
+'
+
+SCRIPT_PROJECT="$(make_project scripts-scenario)"
+mkdir -p "$SCRIPT_PROJECT/scripts/trace"
+cat > "$SCRIPT_PROJECT/scripts/trace/fallback.mjs" <<'EOF'
+import { writeFileSync } from 'node:fs';
+writeFileSync(process.env.HOMEBOY_TRACE_RESULTS_FILE, JSON.stringify({
+  component_id: process.env.HOMEBOY_COMPONENT_ID,
+  scenario_id: process.env.HOMEBOY_TRACE_SCENARIO,
+  status: 'pass',
+  summary: 'fallback result',
+  timeline: [],
+  assertions: [],
+  artifacts: [],
+}, null, 2));
+EOF
+SCRIPT_RESULTS="$TMP_DIR/script-results.json"
+run_trace "$SCRIPT_PROJECT" "fallback" "$SCRIPT_RESULTS" "$TMP_DIR/script-artifacts" >/dev/null
+assert_json "$SCRIPT_RESULTS" '
+if (data.status !== "pass") throw new Error("scripts/trace fallback did not pass");
+if (data.summary !== "fallback result") throw new Error("scripts/trace result missing");
+'
+
+NPM_PROJECT="$(make_project npm-scenario)"
+cat > "$NPM_PROJECT/package.json" <<'EOF'
+{"name":"npm-scenario","scripts":{"trace":"node trace-script.mjs"}}
+EOF
+cat > "$NPM_PROJECT/trace-script.mjs" <<'EOF'
+import { writeFileSync } from 'node:fs';
+const scenario = process.argv.at(-1);
+writeFileSync(process.env.HOMEBOY_TRACE_RESULTS_FILE, JSON.stringify({
+  component_id: process.env.HOMEBOY_COMPONENT_ID,
+  scenario_id: scenario,
+  status: 'pass',
+  summary: 'npm trace result',
+  timeline: [],
+  assertions: [],
+  artifacts: [],
+}, null, 2));
+EOF
+NPM_RESULTS="$TMP_DIR/npm-results.json"
+run_trace "$NPM_PROJECT" "npm-only" "$NPM_RESULTS" "$TMP_DIR/npm-artifacts" >/dev/null
+assert_json "$NPM_RESULTS" '
+if (data.status !== "pass") throw new Error("npm trace fallback did not pass");
+if (data.scenario_id !== "npm-only") throw new Error("npm trace did not receive scenario id");
+'
+
+MISSING_PROJECT="$(make_project missing-scenario)"
+MISSING_RESULTS="$TMP_DIR/missing-results.json"
+set +e
+MISSING_OUTPUT="$(run_trace "$MISSING_PROJECT" "missing" "$MISSING_RESULTS" "$TMP_DIR/missing-artifacts" 2>&1)"
+MISSING_EXIT=$?
+set -e
+if [ "$MISSING_EXIT" -eq 0 ]; then
+    echo "expected missing scenario to fail" >&2
+    exit 1
+fi
+if [[ "$MISSING_OUTPUT" != *"Trace scenario not found: missing"* ]]; then
+    echo "expected clear missing scenario error" >&2
+    echo "$MISSING_OUTPUT" >&2
+    exit 1
+fi
+assert_json "$MISSING_RESULTS" '
+if (data.status !== "error") throw new Error("missing scenario should write error envelope");
+if (!data.failure.includes("traces/missing.trace.mjs")) throw new Error("missing scenario failure lacks searched paths");
+'
+
+FAIL_PROJECT="$(make_project failing-scenario)"
+mkdir -p "$FAIL_PROJECT/traces"
+cat > "$FAIL_PROJECT/traces/fail.trace.mjs" <<'EOF'
+process.exit(7);
+EOF
+FAIL_RESULTS="$TMP_DIR/fail-results.json"
+set +e
+FAIL_OUTPUT="$(run_trace "$FAIL_PROJECT" "fail" "$FAIL_RESULTS" "$TMP_DIR/fail-artifacts" 2>&1)"
+FAIL_EXIT=$?
+set -e
+if [ "$FAIL_EXIT" -ne 7 ]; then
+    echo "expected failing scenario exit 7, got $FAIL_EXIT" >&2
+    echo "$FAIL_OUTPUT" >&2
+    exit 1
+fi
+assert_json "$FAIL_RESULTS" '
+if (data.status !== "error") throw new Error("non-zero scenario should write error envelope");
+if (!data.failure.includes("exited with code 7")) throw new Error("non-zero failure summary missing exit code");
+'
+
+echo "Node.js trace runner smoke passed."

--- a/nodejs/scripts/trace/trace-runner.sh
+++ b/nodejs/scripts/trace/trace-runner.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Node.js trace runner for `homeboy trace`.
+#
+# Dispatches project-owned black-box trace scenarios and writes the trace JSON
+# envelope Homeboy core expects.
+#
+# Standard env vars:
+#   HOMEBOY_EXTENSION_PATH        — path to this extension
+#   HOMEBOY_COMPONENT_PATH        — path to the Node.js project
+#   HOMEBOY_COMPONENT_ID          — component identifier
+#   HOMEBOY_TRACE_RESULTS_FILE    — where to write the TraceResults envelope
+#   HOMEBOY_TRACE_SCENARIO        — scenario id to run
+#   HOMEBOY_TRACE_LIST_ONLY       — when 1, emit scenario inventory only
+#   HOMEBOY_TRACE_ARTIFACT_DIR    — artifact directory for scenario output
+#   HOMEBOY_RUN_DIR               — run-scoped working directory
+#   HOMEBOY_DEBUG                 — verbose output
+
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
+    case "$(uname -s)" in
+        Darwin) echo "  brew install bash" >&2 ;;
+    esac
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+# shellcheck source=/dev/null
+source "$RESOLVE_CONTEXT_HELPER"
+homeboy_resolve_context
+# shellcheck source=../lib/node-helpers.sh
+source "${SCRIPT_DIR}/../lib/node-helpers.sh"
+homeboy_require_package_json
+homeboy_detect_package_manager
+
+RESULTS_FILE="${HOMEBOY_TRACE_RESULTS_FILE:-${PROJECT_PATH}/.node-trace-results.json}"
+SCENARIO="${HOMEBOY_TRACE_SCENARIO:-}"
+LIST_ONLY="${HOMEBOY_TRACE_LIST_ONLY:-0}"
+RUN_DIR="${HOMEBOY_RUN_DIR:-$(dirname "$RESULTS_FILE")}"
+ARTIFACT_DIR="${HOMEBOY_TRACE_ARTIFACT_DIR:-${RUN_DIR}/artifacts}"
+
+export HOMEBOY_TRACE_RESULTS_FILE="$RESULTS_FILE"
+export HOMEBOY_TRACE_ARTIFACT_DIR="$ARTIFACT_DIR"
+export HOMEBOY_RUN_DIR="$RUN_DIR"
+export HOMEBOY_COMPONENT_ID="$COMPONENT_ID"
+export HOMEBOY_COMPONENT_PATH="$PROJECT_PATH"
+
+mkdir -p "$(dirname "$RESULTS_FILE")" "$RUN_DIR" "$ARTIFACT_DIR"
+
+if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "DEBUG: [trace:nodejs] extension=$EXTENSION_PATH" >&2
+    echo "DEBUG: [trace:nodejs] project=$PROJECT_PATH" >&2
+    echo "DEBUG: [trace:nodejs] component_id=$COMPONENT_ID" >&2
+    echo "DEBUG: [trace:nodejs] scenario=${SCENARIO:-<unset>}" >&2
+    echo "DEBUG: [trace:nodejs] results=$RESULTS_FILE" >&2
+    echo "DEBUG: [trace:nodejs] artifacts=$ARTIFACT_DIR" >&2
+    echo "DEBUG: [trace:nodejs] list_only=$LIST_ONLY" >&2
+fi
+
+write_trace_envelope() {
+    local status="$1"
+    local scenario_id="$2"
+    local summary="$3"
+    local failure="${4:-}"
+
+    node - "$RESULTS_FILE" "$COMPONENT_ID" "$scenario_id" "$status" "$summary" "$failure" <<'NODE'
+const fs = require('fs');
+const [resultsFile, componentId, scenarioId, status, summary, failure] = process.argv.slice(2);
+const envelope = {
+  component_id: componentId,
+  scenario_id: scenarioId,
+  status,
+  summary,
+  timeline: [],
+  assertions: [],
+  artifacts: [],
+};
+if (failure) envelope.failure = failure;
+fs.mkdirSync(require('path').dirname(resultsFile), { recursive: true });
+fs.writeFileSync(resultsFile, JSON.stringify(envelope, null, 2));
+NODE
+}
+
+write_list_envelope() {
+    local scenario_file="$1"
+    node - "$RESULTS_FILE" "$COMPONENT_ID" "$scenario_file" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const [resultsFile, componentId, scenarioFile] = process.argv.slice(2);
+const scenarios = fs.readFileSync(scenarioFile, 'utf8')
+  .split(/\r?\n/)
+  .filter(Boolean)
+  .map((line) => {
+    const [id, source] = line.split('\t');
+    return { id, source };
+  });
+fs.mkdirSync(path.dirname(resultsFile), { recursive: true });
+fs.writeFileSync(resultsFile, JSON.stringify({
+  component_id: componentId,
+  scenario_id: '__list__',
+  status: 'pass',
+  scenarios,
+  timeline: [],
+  assertions: [],
+  artifacts: [],
+}, null, 2));
+NODE
+}
+
+discover_trace_scenarios() {
+    local -A seen=()
+    local file scenario_id source
+
+    if [ -d "${PROJECT_PATH}/traces" ]; then
+        while IFS= read -r file; do
+            scenario_id="$(basename "$file" .trace.mjs)"
+            source="traces/$(basename "$file")"
+            if [ -z "${seen[$scenario_id]:-}" ]; then
+                seen[$scenario_id]=1
+                printf '%s\t%s\n' "$scenario_id" "$source"
+            fi
+        done < <(find "${PROJECT_PATH}/traces" -maxdepth 1 -type f -name '*.trace.mjs' 2>/dev/null | sort)
+    fi
+
+    if [ -d "${PROJECT_PATH}/scripts/trace" ]; then
+        while IFS= read -r file; do
+            scenario_id="$(basename "$file" .mjs)"
+            source="scripts/trace/$(basename "$file")"
+            if [ -z "${seen[$scenario_id]:-}" ]; then
+                seen[$scenario_id]=1
+                printf '%s\t%s\n' "$scenario_id" "$source"
+            fi
+        done < <(find "${PROJECT_PATH}/scripts/trace" -maxdepth 1 -type f -name '*.mjs' 2>/dev/null | sort)
+    fi
+}
+
+resolve_trace_scenario() {
+    local scenario_id="$1"
+    local trace_file="${PROJECT_PATH}/traces/${scenario_id}.trace.mjs"
+    local script_file="${PROJECT_PATH}/scripts/trace/${scenario_id}.mjs"
+
+    if [ -f "$trace_file" ]; then
+        printf 'node\t%s\t%s\n' "$trace_file" "traces/${scenario_id}.trace.mjs"
+        return 0
+    fi
+
+    if [ -f "$script_file" ]; then
+        printf 'node\t%s\t%s\n' "$script_file" "scripts/trace/${scenario_id}.mjs"
+        return 0
+    fi
+
+    if homeboy_has_npm_script "trace"; then
+        printf 'npm\t%s\t%s\n' "trace" "package.json scripts.trace"
+        return 0
+    fi
+
+    return 1
+}
+
+if [ "$LIST_ONLY" = "1" ]; then
+    SCENARIO_LIST_FILE="$(mktemp "${TMPDIR:-/tmp}/homeboy-node-trace-scenarios.XXXXXX")"
+    trap 'rm -f "$SCENARIO_LIST_FILE"' EXIT
+    discover_trace_scenarios > "$SCENARIO_LIST_FILE"
+    write_list_envelope "$SCENARIO_LIST_FILE"
+    echo "Discovered $(wc -l < "$SCENARIO_LIST_FILE" | tr -d ' ') Node.js trace scenarios."
+    exit 0
+fi
+
+if [ -z "$SCENARIO" ]; then
+    write_trace_envelope "error" "" "No trace scenario specified" "Set HOMEBOY_TRACE_SCENARIO to the scenario id to run."
+    echo "ERROR: HOMEBOY_TRACE_SCENARIO is required" >&2
+    exit 2
+fi
+
+if ! RESOLVED="$(resolve_trace_scenario "$SCENARIO")"; then
+    write_trace_envelope "error" "$SCENARIO" "Trace scenario not found" "No project-owned trace scenario matched '${SCENARIO}'. Checked traces/${SCENARIO}.trace.mjs, scripts/trace/${SCENARIO}.mjs, and package.json scripts.trace."
+    echo "ERROR: Trace scenario not found: ${SCENARIO}" >&2
+    exit 2
+fi
+
+IFS=$'\t' read -r RUN_KIND RUN_TARGET RUN_SOURCE <<< "$RESOLVED"
+
+echo "Running Node.js trace scenario..."
+echo "  Component: ${COMPONENT_ID} (${PROJECT_PATH})"
+echo "  Scenario:  ${SCENARIO}"
+echo "  Source:    ${RUN_SOURCE}"
+echo "  Artifacts: ${ARTIFACT_DIR}"
+echo ""
+
+cd "$PROJECT_PATH"
+set +e
+case "$RUN_KIND" in
+    node)
+        node "$RUN_TARGET"
+        TRACE_EXIT=$?
+        ;;
+    npm)
+        # shellcheck disable=SC2086 # word-splitting is intentional for package-manager command.
+        $PKG_RUN trace -- "$SCENARIO"
+        TRACE_EXIT=$?
+        ;;
+    *)
+        echo "ERROR: unknown trace runner kind: $RUN_KIND" >&2
+        TRACE_EXIT=2
+        ;;
+esac
+set -e
+
+if [ ! -f "$RESULTS_FILE" ]; then
+    if [ $TRACE_EXIT -eq 0 ]; then
+        write_trace_envelope "pass" "$SCENARIO" "Trace completed"
+    else
+        write_trace_envelope "error" "$SCENARIO" "Trace scenario failed" "Scenario '${SCENARIO}' exited with code ${TRACE_EXIT}."
+    fi
+fi
+
+if [ $TRACE_EXIT -ne 0 ]; then
+    echo "ERROR: Trace scenario failed with exit code ${TRACE_EXIT}" >&2
+    exit $TRACE_EXIT
+fi
+
+echo ""
+echo "Node.js trace scenario complete."


### PR DESCRIPTION
## Summary
- Add the Node.js `trace` extension capability and route it to `scripts/trace/trace-runner.sh`.
- Dispatch black-box project-owned scenarios from `traces/<scenario>.trace.mjs`, `scripts/trace/<scenario>.mjs`, or `npm run trace -- <scenario>`.
- Add focused shell smoke coverage for discovery, dispatch, fallback, artifacts, missing scenarios, and non-zero failures.

## Runner contract
- Supports `HOMEBOY_TRACE_RESULTS_FILE`, `HOMEBOY_TRACE_SCENARIO`, `HOMEBOY_TRACE_LIST_ONLY`, `HOMEBOY_TRACE_ARTIFACT_DIR`, and `HOMEBOY_RUN_DIR`.
- Creates the artifact directory before scenario execution.
- Writes a valid trace JSON envelope for list mode, successful scenarios without their own envelope, missing scenarios, and non-zero scenario exits.

## Tests
- `bash nodejs/scripts/trace/nodejs-trace-runner-smoke.sh`
- `bash nodejs/scripts/build/build-runner-shell-smoke.sh`
- `bash -n nodejs/scripts/trace/trace-runner.sh`
- `bash -n nodejs/scripts/trace/nodejs-trace-runner-smoke.sh`
- `git diff --check`

`homeboy lint homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@feat-node-trace-runner --changed-since origin/main` is currently unsupported in this local registry because the `homeboy-extensions` component has no extension configured, so focused shell smokes and syntax checks were run instead.

Closes #353

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Implemented the trace runner and focused smoke tests from the issue contract; Chris remains responsible for review and merge decisions.