### PR TITLE
fix(wordpress): route changed smoke files to host backend

### DIFF
--- a/wordpress/scripts/test/host-smoke-runner-smoke.sh
+++ b/wordpress/scripts/test/host-smoke-runner-smoke.sh
@@ -63,6 +63,16 @@ assert_not_contains "${TMPDIR}/direct-single.out" "HOST_SMOKE_BEGIN:tests/alpha-
 assert_contains "${TMPDIR}/direct-single.out" "HOST_SMOKE_BEGIN:tests/nested/bravo-smoke.php"
 assert_contains "${TMPDIR}/direct-single.out" "HOST_SMOKE_SUMMARY:passed=1 failed=0"
 
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component-pass" \
+HOMEBOY_COMPONENT_PATH="$component_pass" \
+HOMEBOY_WORDPRESS_HOST_SMOKE_FILES=$'tests/nested/bravo-smoke.php\ntests/alpha-smoke.php' \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner-host-smoke.sh" > "${TMPDIR}/direct-selected-list.out"
+
+assert_contains "${TMPDIR}/direct-selected-list.out" "HOST_SMOKE_BEGIN:tests/nested/bravo-smoke.php"
+assert_contains "${TMPDIR}/direct-selected-list.out" "HOST_SMOKE_BEGIN:tests/alpha-smoke.php"
+assert_contains "${TMPDIR}/direct-selected-list.out" "HOST_SMOKE_SUMMARY:passed=2 failed=0"
+
 component_fail="${TMPDIR}/component-fail"
 make_component "$component_fail"
 cat > "$component_fail/tests/zzz-smoke.php" <<'PHP'

--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -34,6 +34,11 @@ cat > "${component}/tests/import-agent-ability-smoke.php" <<'PHP'
 fwrite( STDOUT, "standalone smoke ran\n" );
 PHP
 
+cat > "${component}/tests/queue-routing-smoke.php" <<'PHP'
+<?php
+fwrite( STDOUT, "queue routing smoke ran\n" );
+PHP
+
 cat > "${component}/tests/Unit/ImportAgentAbilityTest.php" <<'PHP'
 <?php
 // PHPUnit-shaped file; the playground backend owns execution.
@@ -49,6 +54,7 @@ cat > "${TMPDIR}/stubs/playground.sh" <<'SH'
 set -euo pipefail
 echo "PLAYGROUND_STUB"
 echo "SELECTED=${HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE:-}"
+printf 'CHANGED=%s\n' "${HOMEBOY_CHANGED_TEST_FILES:-}"
 printf 'ARGS=%s\n' "$*"
 SH
 chmod +x "${TMPDIR}/stubs/playground.sh"
@@ -68,11 +74,36 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_RUNTIME_TEST_RUNNER_PLAYGROUND="${TMPDIR}/stubs/playground.sh" \
+HOMEBOY_CHANGED_TEST_FILES=$'tests/import-agent-ability-smoke.php\ntests/queue-routing-smoke.php' \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/changed-smoke-files.out"
+
+assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_BEGIN:tests/import-agent-ability-smoke.php"
+assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_BEGIN:tests/queue-routing-smoke.php"
+assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_SUMMARY:passed=2 failed=0"
+assert_not_contains "${TMPDIR}/changed-smoke-files.out" "PLAYGROUND_STUB"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_RUNTIME_TEST_RUNNER_PLAYGROUND="${TMPDIR}/stubs/playground.sh" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/Unit/ImportAgentAbilityTest.php --filter ImportAgent > "${TMPDIR}/phpunit-file.out"
 
 assert_contains "${TMPDIR}/phpunit-file.out" "PLAYGROUND_STUB"
 assert_contains "${TMPDIR}/phpunit-file.out" "SELECTED=tests/Unit/ImportAgentAbilityTest.php"
 assert_contains "${TMPDIR}/phpunit-file.out" "ARGS=--filter ImportAgent"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_RUNTIME_TEST_RUNNER_PLAYGROUND="${TMPDIR}/stubs/playground.sh" \
+HOMEBOY_CHANGED_TEST_FILES=$'tests/import-agent-ability-smoke.php\ntests/Unit/ImportAgentAbilityTest.php' \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/changed-mixed-files.out"
+
+assert_contains "${TMPDIR}/changed-mixed-files.out" "PLAYGROUND_STUB"
+assert_contains "${TMPDIR}/changed-mixed-files.out" "CHANGED=tests/import-agent-ability-smoke.php"
+assert_not_contains "${TMPDIR}/changed-mixed-files.out" "HOST_SMOKE_BEGIN:tests/import-agent-ability-smoke.php"
 
 set +e
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \

--- a/wordpress/scripts/test/test-runner-host-smoke.sh
+++ b/wordpress/scripts/test/test-runner-host-smoke.sh
@@ -15,6 +15,33 @@ homeboy_resolve_context --component-alias PLUGIN_PATH
 PHP_BIN="${HOMEBOY_PHP_BIN:-php}"
 TEST_DIR="${PLUGIN_PATH}/tests"
 TARGET_SMOKE_FILE="${HOMEBOY_WORDPRESS_HOST_SMOKE_FILE:-}"
+TARGET_SMOKE_FILES="${HOMEBOY_WORDPRESS_HOST_SMOKE_FILES:-}"
+
+homeboy_wordpress_host_smoke_abs() {
+    local raw_path="$1"
+    local abs_path
+
+    if [ "${raw_path#/}" != "$raw_path" ]; then
+        abs_path="$raw_path"
+    else
+        abs_path="${PLUGIN_PATH}/${raw_path}"
+    fi
+
+    if [ ! -f "$abs_path" ]; then
+        echo "ERROR: requested host smoke file not found: ${raw_path}" >&2
+        return 2
+    fi
+
+    case "$abs_path" in
+        "${PLUGIN_PATH}"/tests/*-smoke.php)
+            printf '%s\n' "$abs_path"
+            ;;
+        *)
+            echo "ERROR: requested host smoke file must match tests/**/*-smoke.php: ${raw_path}" >&2
+            return 2
+            ;;
+    esac
+}
 
 echo "Running host PHP smoke tests..."
 echo "  Component: ${COMPONENT_ID:-$(basename "$PLUGIN_PATH")} (${PLUGIN_PATH})"
@@ -26,25 +53,20 @@ if [ ! -d "$TEST_DIR" ]; then
     exit 0
 fi
 
-if [ -n "$TARGET_SMOKE_FILE" ]; then
-    if [ "${TARGET_SMOKE_FILE#/}" != "$TARGET_SMOKE_FILE" ]; then
-        target_abs="$TARGET_SMOKE_FILE"
-    else
-        target_abs="${PLUGIN_PATH}/${TARGET_SMOKE_FILE}"
-    fi
-    if [ ! -f "$target_abs" ]; then
-        echo "ERROR: requested host smoke file not found: ${TARGET_SMOKE_FILE}" >&2
+if [ -n "$TARGET_SMOKE_FILES" ]; then
+    smoke_files=()
+    while IFS= read -r smoke_file; do
+        [ -z "$smoke_file" ] && continue
+        if ! smoke_abs="$(homeboy_wordpress_host_smoke_abs "$smoke_file")"; then
+            exit 2
+        fi
+        smoke_files+=("$smoke_abs")
+    done <<< "$TARGET_SMOKE_FILES"
+elif [ -n "$TARGET_SMOKE_FILE" ]; then
+    if ! target_abs="$(homeboy_wordpress_host_smoke_abs "$TARGET_SMOKE_FILE")"; then
         exit 2
     fi
-    case "$target_abs" in
-        "${PLUGIN_PATH}"/tests/*-smoke.php)
-            smoke_files=("$target_abs")
-            ;;
-        *)
-            echo "ERROR: requested host smoke file must match tests/**/*-smoke.php: ${TARGET_SMOKE_FILE}" >&2
-            exit 2
-            ;;
-    esac
+    smoke_files=("$target_abs")
 else
     mapfile -t smoke_files < <(find "$TEST_DIR" -type f -name '*-smoke.php' | sort)
 fi

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -80,6 +80,70 @@ if [ -z "$COMPONENT_SHAPE" ]; then
     fi
 fi
 
+homeboy_wordpress_rel_test_file() {
+    local raw_path="$1"
+    local abs_path
+
+    if [ -z "$raw_path" ]; then
+        return 1
+    fi
+
+    if [ "${raw_path#/}" != "$raw_path" ]; then
+        abs_path="$raw_path"
+    else
+        abs_path="${PLUGIN_PATH}/${raw_path}"
+    fi
+
+    if [ ! -f "$abs_path" ]; then
+        return 1
+    fi
+
+    case "$abs_path" in
+        "${PLUGIN_PATH}"/*)
+            printf '%s\n' "${abs_path#"${PLUGIN_PATH}/"}"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+homeboy_wordpress_is_standalone_smoke() {
+    local rel_path="$1"
+    case "$rel_path" in
+        tests/*-smoke.php|tests/*/*-smoke.php|tests/*/*/*-smoke.php|tests/*/*/*/*-smoke.php)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+if [ -z "$TARGET_FILE" ] && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
+    changed_smoke_files=()
+    changed_non_smoke_count=0
+
+    while IFS= read -r changed_file; do
+        [ -z "$changed_file" ] && continue
+
+        if ! changed_rel="$(homeboy_wordpress_rel_test_file "$changed_file")"; then
+            changed_non_smoke_count=$((changed_non_smoke_count + 1))
+            continue
+        fi
+
+        if homeboy_wordpress_is_standalone_smoke "$changed_rel"; then
+            changed_smoke_files+=("$changed_rel")
+        else
+            changed_non_smoke_count=$((changed_non_smoke_count + 1))
+        fi
+    done <<< "$HOMEBOY_CHANGED_TEST_FILES"
+
+    if [ "${#changed_smoke_files[@]}" -gt 0 ] && [ "$changed_non_smoke_count" -eq 0 ]; then
+        HOMEBOY_WORDPRESS_HOST_SMOKE_FILES="$(printf '%s\n' "${changed_smoke_files[@]}")" exec bash "$HOST_SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
+    fi
+fi
+
 if [ -n "$TARGET_FILE" ]; then
     if [ "${TARGET_FILE#/}" != "$TARGET_FILE" ]; then
         target_abs="$TARGET_FILE"


### PR DESCRIPTION
## Summary
- Route changed-since selections containing only standalone WordPress smoke scripts to the host-smoke backend.
- Preserve Playground routing for mixed selections and PHPUnit-shaped files.

## What changed
- Added router classification for HOMEBOY_CHANGED_TEST_FILES when every selected file matches tests/**/*-smoke.php.
- Added plural selected-file support to the host-smoke runner so executed files match Homeboy selected_files.
- Expanded routing smokes to cover changed-since smoke-only and mixed smoke/PHPUnit selections.

## Tests
- bash -n wordpress/scripts/test/test-runner.sh && bash -n wordpress/scripts/test/test-runner-host-smoke.sh && bash wordpress/scripts/test/test-runner-file-routing-smoke.sh && bash wordpress/scripts/test/host-smoke-runner-smoke.sh
- homeboy test data-machine --path /Users/chubes/Developer/data-machine@untangle-adjacent-handler-tool-source --changed-since origin/main

Closes #345

## AI assistance
- AI assistance: Yes
- Tool(s): OpenCode (GPT-5.5)
- Used for: Implemented the routing fix, added focused smoke coverage, and ran local verification. Chris remains responsible for review and merge.