### PR TITLE
feat(wordpress): add trace runner support

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,14 +10,15 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/playground-process-cleanup-smoke.sh"
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh"
     ],
     "test": [
       "bash scripts/test/host-smoke-runner-smoke.sh",
       "bash scripts/test/test-runner-file-routing-smoke.sh",
       "bash scripts/test/playground-process-cleanup-smoke.sh",
       "bash scripts/test/playground-cleanup-noise-smoke.sh",
-      "bash scripts/test/playground-no-test-files-smoke.sh"
+      "bash scripts/test/playground-no-test-files-smoke.sh",
+      "bash scripts/trace/trace-runner-smoke.sh"
     ]
   }
 }

--- a/wordpress/scripts/trace/trace-runner-smoke.sh
+++ b/wordpress/scripts/trace/trace-runner-smoke.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RUNNER="${EXTENSION_PATH}/scripts/trace/trace-runner.sh"
+
+SMOKE_ASSERTIONS=0
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    SMOKE_ASSERTIONS=$((SMOKE_ASSERTIONS + 1))
+    case "$haystack" in
+        *"$needle"*) ;;
+        *)
+            echo "FAIL: ${label} missing ${needle}" >&2
+            echo "$haystack" >&2
+            exit 1
+            ;;
+    esac
+}
+
+assert_file() {
+    local path="$1"
+    local label="$2"
+    SMOKE_ASSERTIONS=$((SMOKE_ASSERTIONS + 1))
+    if [ ! -f "$path" ]; then
+        echo "FAIL: ${label} missing file ${path}" >&2
+        exit 1
+    fi
+}
+
+assert_json_field() {
+    local path="$1"
+    local expr="$2"
+    local label="$3"
+    SMOKE_ASSERTIONS=$((SMOKE_ASSERTIONS + 1))
+    if ! php -r '
+        $path = $argv[1];
+        $expr = $argv[2];
+        $data = json_decode(file_get_contents($path), true);
+        if (!is_array($data)) { exit(2); }
+        if ($expr === "status-pass" && ($data["status"] ?? null) === "pass") { exit(0); }
+        if ($expr === "has-artifacts" && !empty($data["artifacts"]) && is_array($data["artifacts"])) { exit(0); }
+        if ($expr === "has-timeline" && !empty($data["timeline"]) && is_array($data["timeline"])) { exit(0); }
+        exit(1);
+    ' "$path" "$expr"; then
+        echo "FAIL: ${label} failed JSON assertion ${expr}" >&2
+        exit 1
+    fi
+}
+
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wordpress-trace.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p "$fixture/traces" "$fixture/tests/traces" "$fixture/scripts/trace"
+
+cat >"$fixture/traces/php-scenario.trace.php" <<'PHP'
+<?php
+$artifact_dir = getenv( 'HOMEBOY_TRACE_ARTIFACT_DIR' );
+$results_file = getenv( 'HOMEBOY_TRACE_RESULTS_FILE' );
+$artifact = $artifact_dir . '/php-artifact.txt';
+file_put_contents( $artifact, 'php artifact' . PHP_EOL );
+file_put_contents(
+    $results_file,
+    json_encode(
+        array(
+            'component_id' => getenv( 'HOMEBOY_COMPONENT_ID' ),
+            'scenario_id'  => getenv( 'HOMEBOY_TRACE_SCENARIO' ),
+            'status'       => 'pass',
+            'summary'      => 'PHP trace scenario passed',
+            'timeline'     => array(
+                array(
+                    't_ms'   => 0,
+                    'source' => 'php',
+                    'event'  => 'scenario.start',
+                    'data'   => array(
+                        'component_path' => getenv( 'HOMEBOY_COMPONENT_PATH' ),
+                        'wp_cli'         => getenv( 'HOMEBOY_WP_CLI' ) ?: '',
+                    ),
+                ),
+            ),
+            'assertions'   => array(
+                array(
+                    'id'      => 'env-present',
+                    'status'  => getenv( 'HOMEBOY_COMPONENT_PATH' ) ? 'pass' : 'fail',
+                    'message' => 'component path env is available',
+                ),
+            ),
+            'artifacts'    => array(
+                array(
+                    'label' => 'php artifact',
+                    'path'  => $artifact,
+                ),
+            ),
+        ),
+        JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+    ) . PHP_EOL
+);
+PHP
+
+cat >"$fixture/tests/traces/test-scenario.trace.php" <<'PHP'
+<?php
+file_put_contents( getenv( 'HOMEBOY_TRACE_RESULTS_FILE' ), '{"status":"pass","timeline":[],"assertions":[],"artifacts":[]}' . PHP_EOL );
+PHP
+
+cat >"$fixture/scripts/trace/shell-scenario.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+artifact="$HOMEBOY_TRACE_ARTIFACT_DIR/shell-artifact.txt"
+printf 'shell artifact\n' >"$artifact"
+cat >"$HOMEBOY_TRACE_RESULTS_FILE" <<JSON
+{
+  "component_id": "${HOMEBOY_COMPONENT_ID}",
+  "scenario_id": "${HOMEBOY_TRACE_SCENARIO}",
+  "status": "pass",
+  "summary": "Shell trace scenario passed",
+  "timeline": [
+    {"t_ms": 0, "source": "shell", "event": "scenario.start", "data": {"run_dir": "${HOMEBOY_RUN_DIR}"}}
+  ],
+  "assertions": [
+    {"id": "artifact-dir", "status": "pass", "message": "artifact dir is available"}
+  ],
+  "artifacts": [
+    {"label": "shell artifact", "path": "${artifact}"}
+  ]
+}
+JSON
+SH
+chmod +x "$fixture/scripts/trace/shell-scenario.sh"
+
+manifest="$(php -r '$json = json_decode(file_get_contents($argv[1]), true); echo $json["trace"]["extension_script"] ?? "";' "${EXTENSION_PATH}/wordpress.json")"
+assert_contains "$manifest" "scripts/trace/trace-runner.sh" "manifest trace extension script"
+
+list_output="$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" HOMEBOY_COMPONENT_PATH="$fixture" HOMEBOY_COMPONENT_ID="trace-fixture" HOMEBOY_TRACE_LIST_ONLY=1 bash "$RUNNER")"
+assert_contains "$list_output" '"component_id": "trace-fixture"' "list mode envelope component"
+assert_contains "$list_output" '"id": "php-scenario"' "list mode PHP scenario"
+assert_contains "$list_output" '"source": "traces/php-scenario.trace.php"' "list mode PHP source"
+assert_contains "$list_output" '"id": "test-scenario"' "list mode tests PHP scenario"
+assert_contains "$list_output" '"id": "shell-scenario"' "list mode shell scenario"
+assert_contains "$list_output" '"source": "scripts/trace/shell-scenario.sh"' "list mode shell source"
+
+run_dir="$fixture/run"
+php_results="$run_dir/php-results.json"
+shell_results="$run_dir/shell-results.json"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_PATH="$fixture" \
+HOMEBOY_COMPONENT_ID="trace-fixture" \
+HOMEBOY_TRACE_SCENARIO="php-scenario" \
+HOMEBOY_TRACE_RESULTS_FILE="$php_results" \
+HOMEBOY_TRACE_ARTIFACT_DIR="$run_dir/artifacts/php" \
+HOMEBOY_RUN_DIR="$run_dir" \
+bash "$RUNNER"
+
+assert_file "$php_results" "PHP scenario results"
+assert_file "$run_dir/artifacts/php/php-artifact.txt" "PHP scenario artifact"
+assert_file "$run_dir/artifacts/php/php-scenario.stdout.txt" "PHP stdout artifact"
+assert_file "$run_dir/artifacts/php/php-scenario.stderr.txt" "PHP stderr artifact"
+assert_file "$run_dir/artifacts/php/php-scenario.exit-code.txt" "PHP exit artifact"
+assert_json_field "$php_results" "status-pass" "PHP scenario status"
+assert_json_field "$php_results" "has-artifacts" "PHP scenario artifacts"
+assert_json_field "$php_results" "has-timeline" "PHP scenario timeline"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_PATH="$fixture" \
+HOMEBOY_COMPONENT_ID="trace-fixture" \
+HOMEBOY_TRACE_SCENARIO="shell-scenario" \
+HOMEBOY_TRACE_RESULTS_FILE="$shell_results" \
+HOMEBOY_TRACE_ARTIFACT_DIR="$run_dir/artifacts/shell" \
+HOMEBOY_RUN_DIR="$run_dir" \
+bash "$RUNNER"
+
+assert_file "$shell_results" "Shell scenario results"
+assert_file "$run_dir/artifacts/shell/shell-artifact.txt" "Shell scenario artifact"
+assert_file "$run_dir/artifacts/shell/shell-scenario.stdout.txt" "Shell stdout artifact"
+assert_file "$run_dir/artifacts/shell/shell-scenario.stderr.txt" "Shell stderr artifact"
+assert_file "$run_dir/artifacts/shell/shell-scenario.exit-code.txt" "Shell exit artifact"
+assert_json_field "$shell_results" "status-pass" "Shell scenario status"
+assert_json_field "$shell_results" "has-artifacts" "Shell scenario artifacts"
+assert_json_field "$shell_results" "has-timeline" "Shell scenario timeline"
+
+echo "WordPress trace runner smoke passed (${SMOKE_ASSERTIONS} assertions)."

--- a/wordpress/scripts/trace/trace-runner.sh
+++ b/wordpress/scripts/trace/trace-runner.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Trace runner router for WordPress Homeboy extension.
+#
+# Project-owned scenarios live in the component under one of:
+# - traces/<scenario>.trace.php
+# - tests/traces/<scenario>.trace.php
+# - scripts/trace/<scenario>.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+# shellcheck source=/dev/null
+source "$RESOLVE_CONTEXT_HELPER"
+homeboy_resolve_context --component-alias PLUGIN_PATH
+
+export HOMEBOY_COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-$COMPONENT_PATH}"
+export HOMEBOY_TRACE_COMPONENT_PATH="${HOMEBOY_TRACE_COMPONENT_PATH:-$HOMEBOY_COMPONENT_PATH}"
+export HOMEBOY_COMPONENT_ID="${HOMEBOY_COMPONENT_ID:-$COMPONENT_ID}"
+export HOMEBOY_PROJECT_PATH="${HOMEBOY_PROJECT_PATH:-$PROJECT_PATH}"
+
+homeboy_wordpress_find_root() {
+    if [ -n "${HOMEBOY_WORDPRESS_ROOT:-}" ] && [ -d "$HOMEBOY_WORDPRESS_ROOT" ]; then
+        printf '%s\n' "$HOMEBOY_WORDPRESS_ROOT"
+        return 0
+    fi
+
+    local cursor="${HOMEBOY_COMPONENT_PATH}"
+    while [ "$cursor" != "/" ] && [ -n "$cursor" ]; do
+        if [ -f "$cursor/wp-config.php" ] || [ -d "$cursor/wp-includes" ]; then
+            printf '%s\n' "$cursor"
+            return 0
+        fi
+        cursor="$(dirname "$cursor")"
+    done
+
+    if [ -d "/wordpress" ]; then
+        printf '%s\n' "/wordpress"
+        return 0
+    fi
+
+    return 1
+}
+
+homeboy_wordpress_export_context() {
+    local wp_root=""
+    if wp_root="$(homeboy_wordpress_find_root)"; then
+        export HOMEBOY_WORDPRESS_ROOT="$wp_root"
+    fi
+
+    if [ -z "${HOMEBOY_WP_CLI:-}" ] && command -v wp >/dev/null 2>&1; then
+        if [ -n "${HOMEBOY_WORDPRESS_ROOT:-}" ]; then
+            export HOMEBOY_WP_CLI="wp --path=${HOMEBOY_WORDPRESS_ROOT}"
+        else
+            export HOMEBOY_WP_CLI="wp"
+        fi
+    fi
+}
+
+homeboy_trace_emit_scenario() {
+    local id="$1"
+    local source="$2"
+
+    printf '%s\t%s\n' "$id" "$source"
+}
+
+homeboy_trace_discover() {
+    local seen="|"
+    local file id rel
+
+    shopt -s nullglob
+    for file in \
+        "${HOMEBOY_COMPONENT_PATH}"/traces/*.trace.php \
+        "${HOMEBOY_COMPONENT_PATH}"/tests/traces/*.trace.php \
+        "${HOMEBOY_COMPONENT_PATH}"/scripts/trace/*.sh; do
+        rel="${file#"${HOMEBOY_COMPONENT_PATH}/"}"
+        case "$rel" in
+            traces/*.trace.php)
+                id="${rel#traces/}"
+                id="${id%.trace.php}"
+                ;;
+            tests/traces/*.trace.php)
+                id="${rel#tests/traces/}"
+                id="${id%.trace.php}"
+                ;;
+            scripts/trace/*.sh)
+                id="${rel#scripts/trace/}"
+                id="${id%.sh}"
+                ;;
+            *)
+                continue
+                ;;
+        esac
+
+        case "$seen" in
+            *"|${id}|"*) continue ;;
+        esac
+        seen="${seen}${id}|"
+
+        homeboy_trace_emit_scenario "$id" "$rel"
+    done
+    shopt -u nullglob
+}
+
+homeboy_trace_list_json() {
+    php -r '
+        $scenarios = array();
+        foreach (file("php://stdin", FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+            $parts = explode("\t", $line, 2);
+            if (count($parts) !== 2) {
+                continue;
+            }
+            $scenarios[] = array(
+                "id" => $parts[0],
+                "source" => $parts[1],
+            );
+        }
+        $data = array(
+            "component_id" => getenv("HOMEBOY_COMPONENT_ID") ?: basename(getenv("HOMEBOY_COMPONENT_PATH") ?: getcwd()),
+            "scenario_id" => "__list__",
+            "status" => "pass",
+            "scenarios" => $scenarios,
+            "timeline" => array(),
+            "assertions" => array(),
+            "artifacts" => array(),
+        );
+        echo json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+    '
+}
+
+homeboy_trace_resolve_scenario() {
+    local scenario="$1"
+    local candidate
+
+    for candidate in \
+        "traces/${scenario}.trace.php" \
+        "tests/traces/${scenario}.trace.php" \
+        "scripts/trace/${scenario}.sh"; do
+        if [ -f "${HOMEBOY_COMPONENT_PATH}/${candidate}" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+homeboy_trace_write_failure() {
+    local status="$1"
+    local summary="$2"
+
+    if [ -z "${HOMEBOY_TRACE_RESULTS_FILE:-}" ]; then
+        return 0
+    fi
+
+    php -r '
+        $path = getenv("HOMEBOY_TRACE_RESULTS_FILE");
+        $data = array(
+            "component_id" => getenv("HOMEBOY_COMPONENT_ID") ?: basename(getenv("HOMEBOY_COMPONENT_PATH") ?: getcwd()),
+            "scenario_id" => getenv("HOMEBOY_TRACE_SCENARIO") ?: "unknown",
+            "status" => $argv[1],
+            "summary" => $argv[2],
+            "timeline" => array(),
+            "assertions" => array(
+                array(
+                    "id" => "runner",
+                    "status" => $argv[1],
+                    "message" => $argv[2],
+                ),
+            ),
+            "artifacts" => array(),
+        );
+        file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+    ' "$status" "$summary"
+}
+
+if [ "${HOMEBOY_TRACE_LIST_ONLY:-}" = "1" ]; then
+    homeboy_trace_discover | homeboy_trace_list_json
+    exit 0
+fi
+
+if [ -z "${HOMEBOY_TRACE_SCENARIO:-}" ]; then
+    echo "ERROR: HOMEBOY_TRACE_SCENARIO is required" >&2
+    exit 2
+fi
+
+if ! scenario_rel="$(homeboy_trace_resolve_scenario "$HOMEBOY_TRACE_SCENARIO")"; then
+    echo "ERROR: WordPress trace scenario not found: ${HOMEBOY_TRACE_SCENARIO}" >&2
+    echo "Searched traces/*.trace.php, tests/traces/*.trace.php, scripts/trace/*.sh under ${HOMEBOY_COMPONENT_PATH}" >&2
+    exit 2
+fi
+
+export HOMEBOY_TRACE_ARTIFACT_DIR="${HOMEBOY_TRACE_ARTIFACT_DIR:-${HOMEBOY_RUN_DIR:-${HOMEBOY_COMPONENT_PATH}/.homeboy}/trace-artifacts}"
+export HOMEBOY_RUN_DIR="${HOMEBOY_RUN_DIR:-$(dirname "$HOMEBOY_TRACE_ARTIFACT_DIR")}"
+export HOMEBOY_TRACE_RESULTS_FILE="${HOMEBOY_TRACE_RESULTS_FILE:-${HOMEBOY_RUN_DIR}/trace-${HOMEBOY_TRACE_SCENARIO}.json}"
+
+mkdir -p "$HOMEBOY_TRACE_ARTIFACT_DIR" "$(dirname "$HOMEBOY_TRACE_RESULTS_FILE")"
+homeboy_wordpress_export_context
+
+stdout_file="${HOMEBOY_TRACE_ARTIFACT_DIR}/${HOMEBOY_TRACE_SCENARIO}.stdout.txt"
+stderr_file="${HOMEBOY_TRACE_ARTIFACT_DIR}/${HOMEBOY_TRACE_SCENARIO}.stderr.txt"
+exit_file="${HOMEBOY_TRACE_ARTIFACT_DIR}/${HOMEBOY_TRACE_SCENARIO}.exit-code.txt"
+
+scenario_abs="${HOMEBOY_COMPONENT_PATH}/${scenario_rel}"
+set +e
+case "$scenario_rel" in
+    *.php)
+        php "$scenario_abs" >"$stdout_file" 2>"$stderr_file"
+        status=$?
+        ;;
+    *.sh)
+        bash "$scenario_abs" >"$stdout_file" 2>"$stderr_file"
+        status=$?
+        ;;
+    *)
+        echo "ERROR: unsupported WordPress trace scenario file: ${scenario_rel}" >&2
+        status=2
+        ;;
+esac
+set -e
+
+printf '%s\n' "$status" >"$exit_file"
+
+if [ "$status" -ne 0 ]; then
+    homeboy_trace_write_failure "fail" "WordPress trace scenario exited with status ${status}"
+    exit "$status"
+fi
+
+if [ ! -s "$HOMEBOY_TRACE_RESULTS_FILE" ]; then
+    homeboy_trace_write_failure "fail" "WordPress trace scenario completed without writing HOMEBOY_TRACE_RESULTS_FILE"
+    exit 1
+fi
+
+exit 0

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -354,6 +354,9 @@
   "bench": {
     "extension_script": "scripts/bench/bench-runner.sh"
   },
+  "trace": {
+    "extension_script": "scripts/trace/trace-runner.sh"
+  },
   "testing": {
     "backend": "playground",
     "description": "Plugin/theme PHPUnit runs inside WordPress Playground by default. Pure PHP smoke suites can opt into the host-smoke backend."


### PR DESCRIPTION
## Summary
- Add the WordPress `trace.extension_script` capability and route it to a new generic trace runner.
- Support project-owned PHP and shell scenarios under `traces/`, `tests/traces/`, and `scripts/trace/`.
- Add a focused smoke that proves list mode, PHP/shell envelope writes, and artifact capture.

## Runner contract
- List mode emits the Homeboy trace list JSON envelope with scenario `id` and `source` fields.
- Run mode exports `HOMEBOY_TRACE_RESULTS_FILE`, `HOMEBOY_TRACE_SCENARIO`, `HOMEBOY_TRACE_ARTIFACT_DIR`, `HOMEBOY_RUN_DIR`, component path/id aliases, `HOMEBOY_TRACE_COMPONENT_PATH`, and WordPress context env when resolvable.
- Scenario stdout, stderr, and exit code are captured under the artifact directory.
- WP-CLI is exposed through `HOMEBOY_WP_CLI` when `wp` is available, with `--path` included when a WordPress root can be resolved.

## Tests
- `jq empty wordpress/wordpress.json`
- `bash -n wordpress/scripts/trace/trace-runner.sh wordpress/scripts/trace/trace-runner-smoke.sh`
- `bash wordpress/scripts/trace/trace-runner-smoke.sh`
- `bash wordpress/scripts/test/host-smoke-runner-smoke.sh`
- `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `bash wordpress/scripts/test/playground-process-cleanup-smoke.sh`
- `bash wordpress/scripts/test/playground-cleanup-noise-smoke.sh`
- `bash wordpress/scripts/test/playground-no-test-files-smoke.sh`

`homeboy lint homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@feat-wordpress-trace-runner --changed-since origin/main` is currently blocked before checks run because the local `homeboy-extensions` component has no extensions configured.

Closes #355

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5; `openai/gpt-5.5`)
- **Used for:** Implemented the WordPress trace runner, manifest wiring, focused smoke coverage, and PR preparation. Chris remains responsible for review and merge decisions.
