### PR TITLE
fix(wordpress): emit runtime dispatch metadata

### DIFF
--- a/wordpress/grammar.toml
+++ b/wordpress/grammar.toml
@@ -195,6 +195,15 @@ skip_strings = false
 [patterns.wp_cli_command.captures]
 name = 1
 
+[patterns.runtime_dispatched_type]
+regex = "WP_CLI::add_command\\s*\\(\\s*['\"][^'\"]+['\"]\\s*,\\s*\\\\?([A-Za-z_]\\w*(?:\\\\[A-Za-z_]\\w*)*)::class"
+context = "any"
+skip_comments = true
+skip_strings = false
+
+[patterns.runtime_dispatched_type.captures]
+name = 1
+
 [patterns.wp_register_ability]
 regex = "wp_register_ability\\s*\\(\\s*['\"]([^'\"]+)['\"]"
 context = "any"

--- a/wordpress/scripts/fingerprint.sh
+++ b/wordpress/scripts/fingerprint.sh
@@ -172,6 +172,28 @@ for pat in reg_patterns:
 seen = set()
 registrations = [r for r in registrations if r not in seen and not seen.add(r)]
 
+# --- Runtime-dispatched Types ---
+# Extract types/classes registered with runtime dispatchers. Homeboy core
+# consumes this as generic metadata; WordPress-specific syntax stays here.
+runtime_dispatched_types = []
+bs_re = re.escape(chr(92))
+wp_cli_class_pattern = (
+    r'WP_CLI::add_command\s*\(\s*[\x27\x22][^\x27\x22]+[\x27\x22]\s*,\s*'
+    + bs_re
+    + r'?([A-Za-z_]\w*(?:'
+    + bs_re
+    + r'[A-Za-z_]\w*)*)::class'
+)
+for m in re.finditer(
+    wp_cli_class_pattern,
+    content,
+):
+    runtime_dispatched_types.append(m.group(1).lstrip(chr(92)))
+
+# Deduplicate
+seen = set()
+runtime_dispatched_types = [t for t in runtime_dispatched_types if t not in seen and not seen.add(t)]
+
 # --- Hook Callbacks (#118, #1149) ---
 # Extract functions/methods registered as WordPress hook/callback targets.
 # These are externally invoked by the WordPress runtime (hook system, REST
@@ -626,6 +648,7 @@ result = {
     'properties': properties,
     'hooks': hooks,
     'hook_callbacks': hook_callbacks,
+    'runtime_dispatched_types': runtime_dispatched_types,
     'unused_parameters': unused_parameters,
     'dead_code_markers': dead_code_markers,
     'internal_calls': internal_calls,

--- a/wordpress/tests/wp-cli-runtime-dispatch-fingerprint-smoke.sh
+++ b/wordpress/tests/wp-cli-runtime-dispatch-fingerprint-smoke.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FINGERPRINT_SCRIPT="$SCRIPT_DIR/scripts/fingerprint.sh"
+
+python3 - "$FINGERPRINT_SCRIPT" <<'PY'
+import json
+import subprocess
+import sys
+
+fingerprint_script = sys.argv[1]
+
+
+def fingerprint(content):
+    payload = json.dumps({"file_path": "inc/Cli/Bootstrap.php", "content": content})
+    result = subprocess.run(
+        [fingerprint_script],
+        input=payload,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+registered = fingerprint(
+    r'''<?php
+namespace DataMachine\Cli;
+
+WP_CLI::add_command( 'datamachine email', Commands\EmailCommand::class );
+'''
+)
+
+assert registered["runtime_dispatched_types"] == ["Commands\\EmailCommand"], registered
+assert "datamachine email" in registered["registrations"], registered
+
+docblock_only = fingerprint(
+    r'''<?php
+namespace DataMachine\Cli\Commands;
+
+class EmailCommand {
+    /**
+     * Test the IMAP connection.
+     *
+     * @subcommand test-connection
+     */
+    public function test_connection( array $args, array $assoc_args ): void {}
+}
+'''
+)
+
+assert docblock_only["runtime_dispatched_types"] == [], docblock_only
+
+print("wordpress wp-cli runtime dispatch fingerprint smoke passed")
+PY


### PR DESCRIPTION
## Summary
- Adds WordPress grammar and fingerprint metadata for WP-CLI runtime-dispatched command classes.
- Keeps WP_CLI::add_command parsing in the WordPress extension instead of Homeboy core.
- Adds a smoke test proving class registration is emitted and docblock-only subcommands are not.

## Tests
- bash wordpress/tests/wp-cli-runtime-dispatch-fingerprint-smoke.sh
- php JSON parse not applicable for this branch

Supports Extra-Chill/homeboy#1945

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the WordPress metadata emitter and smoke test; Chris remains responsible for review and merge.