### PR TITLE
feat(wordpress): declare deploy safety policy

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -121,6 +121,22 @@
     ]
   },
   "deploy": {
+    "protected_path_suffixes": [
+      "/plugins",
+      "/themes",
+      "/mu-plugins",
+      "/wp-content",
+      "/wp-content/uploads",
+      "/wp-content/plugins",
+      "/wp-content/themes",
+      "/wp-content/mu-plugins"
+    ],
+    "owner_hints": [
+      {
+        "path_contains": "wp-content/",
+        "suggested_owner": "www-data:www-data"
+      }
+    ],
     "remote_path_inference": [
       {
         "when_file_contains": { "file": "{{dir_name}}.php", "text": "Plugin Name:" },


### PR DESCRIPTION
## Summary
- Declares WordPress deploy-protected path suffixes in the extension manifest.
- Adds a WordPress remote-owner hint for wp-content deploy paths so Homeboy core no longer hardcodes WordPress ownership warnings.

## Tests
- php -r 'json_decode(file_get_contents("wordpress/wordpress.json"), true, 512, JSON_THROW_ON_ERROR); echo "ok\n";'

Supports Extra-Chill/homeboy#1946

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the WordPress deploy policy metadata; Chris remains responsible for review and merge.