### PR TITLE
feat(wordpress): declare deploy safety policy

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -121,6 +121,22 @@
     ]
   },
   "deploy": {
+    "protected_path_suffixes": [
+      "/plugins",
+      "/themes",
+      "/mu-plugins",
+      "/wp-content",
+      "/wp-content/uploads",
+      "/wp-content/plugins",
+      "/wp-content/themes",
+      "/wp-content/mu-plugins"
+    ],
+    "owner_hints": [
+      {
+        "path_contains": "wp-content/",
+        "suggested_owner": "www-data:www-data"
+      }
+    ],
     "remote_path_inference": [
       {
         "when_file_contains": { "file": "{{dir_name}}.php", "text": "Plugin Name:" },


### PR DESCRIPTION
## Summary
- Declares WordPress-specific deploy protected path suffixes in the WordPress extension manifest.
- Adds the WordPress remote owner hint so Homeboy core can stay framework-neutral while preserving deploy warnings.

## Tests
- php -r 'json_decode(file_get_contents("wordpress/wordpress.json"), true, 512, JSON_THROW_ON_ERROR); echo "ok\n";'

Refs Extra-Chill/homeboy#1946.

## AI assistance
- AI assistance: Yes
- Tool(s): OpenCode (GPT-5.5)
- Used for: Drafted the manifest change and ran validation; Chris remains responsible for review and merge.