### PR TITLE
feat: add fingerprint metadata to grammars

### DIFF
--- a/rust/grammar.toml
+++ b/rust/grammar.toml
@@ -24,6 +24,36 @@ multiline = []
 open = '{'
 close = '}'
 
+[fingerprint]
+keywords = [
+  'as', 'async', 'await', 'break', 'const', 'continue', 'crate', 'dyn', 'else', 'enum', 'extern',
+  'false', 'fn', 'for', 'if', 'impl', 'in', 'let', 'loop', 'match', 'mod', 'move', 'mut', 'pub',
+  'ref', 'return', 'self', 'Self', 'static', 'struct', 'super', 'trait', 'true', 'type',
+  'unsafe', 'use', 'where', 'while', 'yield',
+  'Some', 'None', 'Ok', 'Err', 'Result', 'Option', 'Vec', 'String', 'Box', 'Arc', 'Rc', 'HashMap',
+  'HashSet', 'bool', 'u8', 'u16', 'u32', 'u64', 'u128', 'usize', 'i8', 'i16', 'i32', 'i64',
+  'i128', 'isize', 'f32', 'f64', 'str', 'char',
+]
+skip_calls = [
+  'if', 'while', 'for', 'match', 'loop', 'return', 'Some', 'None', 'Ok', 'Err', 'Box', 'Vec',
+  'Arc', 'Rc', 'String', 'println', 'eprintln', 'format', 'write', 'writeln', 'panic', 'assert',
+  'assert_eq', 'assert_ne', 'todo', 'unimplemented', 'unreachable', 'dbg', 'cfg', 'include',
+  'include_str', 'concat', 'env', 'compile_error', 'stringify', 'vec', 'hashmap', 'bail',
+  'ensure', 'anyhow', 'matches', 'debug_assert', 'debug_assert_eq', 'allow', 'deny', 'warn',
+  'derive', 'serde', 'test', 'inline', 'must_use', 'doc', 'feature', 'pub', 'crate', 'super',
+]
+registration_concepts = ['macro_invocation']
+registration_skip_names = [
+  'println', 'eprintln', 'format', 'vec', 'assert', 'assert_eq', 'assert_ne', 'panic', 'todo',
+  'unimplemented', 'cfg', 'derive', 'include', 'include_str', 'include_bytes', 'concat',
+  'stringify', 'env', 'option_env', 'compile_error', 'write', 'writeln', 'matches', 'dbg',
+  'debug_assert', 'debug_assert_eq', 'debug_assert_ne', 'unreachable', 'cfg_if', 'lazy_static',
+  'thread_local', 'once_cell', 'macro_rules', 'serde_json', 'if_chain', 'bail', 'anyhow',
+  'ensure', 'Ok', 'Err', 'Some', 'None', 'Box', 'Arc', 'Rc', 'RefCell', 'Mutex', 'map',
+  'hashmap', 'btreemap', 'hashset',
+]
+registration_skip_prefixes = ['test']
+
 # ===========================================================================
 # Patterns — each key is a concept name used by features
 # ===========================================================================

--- a/wordpress/grammar.toml
+++ b/wordpress/grammar.toml
@@ -24,6 +24,43 @@ multiline = []
 open = '{'
 close = '}'
 
+[fingerprint]
+keywords = [
+  'abstract', 'and', 'array', 'as', 'break', 'callable', 'case', 'catch', 'class', 'clone',
+  'const', 'continue', 'declare', 'default', 'do', 'echo', 'else', 'elseif', 'empty',
+  'enddeclare', 'endfor', 'endforeach', 'endif', 'endswitch', 'endwhile', 'eval', 'exit',
+  'extends', 'final', 'finally', 'fn', 'for', 'foreach', 'function', 'global', 'goto', 'if',
+  'implements', 'include', 'include_once', 'instanceof', 'insteadof', 'interface', 'isset',
+  'list', 'match', 'namespace', 'new', 'or', 'print', 'private', 'protected', 'public',
+  'readonly', 'require', 'require_once', 'return', 'static', 'switch', 'throw', 'trait', 'try',
+  'unset', 'use', 'var', 'while', 'xor', 'yield', 'null', 'true', 'false', 'self', 'parent',
+  'int', 'float', 'string', 'bool', 'void', 'mixed', 'object', 'iterable', 'never',
+]
+skip_calls = [
+  'if', 'while', 'for', 'foreach', 'switch', 'match', 'catch', 'return', 'echo', 'print',
+  'isset', 'unset', 'empty', 'list', 'array', 'function', 'class', 'interface', 'trait', 'new',
+  'require', 'require_once', 'include', 'include_once', 'define', 'defined', 'die', 'exit',
+  'eval', 'compact', 'extract', 'var_dump', 'print_r', 'var_export',
+]
+contract_method_names = [
+  'execute', 'checkPermission', 'check_permission', '__construct', '__destruct', '__get', '__set',
+  '__isset', '__unset', '__call', '__callStatic', '__toString', '__invoke', '__clone', '__sleep',
+  '__wakeup', '__serialize', '__unserialize', '__set_state', '__debugInfo',
+]
+contract_type_hints = [
+  'WP_REST_Request', 'WP_REST_Response', 'WP_REST_Server', 'WP_Post', 'WP_User', 'WP_Term',
+  'WP_Comment', 'WP_Site', 'WP_Network', 'WP_Query', 'WP_Block', 'WP_Block_Type', 'WP_Error',
+  'WP_Http_Response', 'WP_HTTP_Requests_Response', 'WP_CLI_Command', 'WP_List_Table',
+]
+registration_concepts = [
+  'register_post_type', 'register_taxonomy', 'register_rest_route', 'register_block_type',
+  'add_action', 'add_filter', 'add_shortcode', 'wp_cli_command', 'wp_register_ability',
+]
+
+[fingerprint.hook_concepts]
+do_action = 'action'
+apply_filters = 'filter'
+
 # ===========================================================================
 # Patterns — each key is a concept name used by features
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Adds fingerprint metadata blocks to the Rust and WordPress grammars so Homeboy core can consume language/framework policy from extensions.
- Moves keyword preservation, call skipping, registration concepts, WordPress hook concepts, and framework contract hints into grammar-owned config.

## Tests
- Installed local Rust and WordPress extensions from this branch with the Homeboy feature binary and listed them successfully.
- git diff --check

Refs Extra-Chill/homeboy#1948

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the grammar metadata migration and verification commands; Chris reviews and owns the change.