### PR TITLE
feat(wordpress): declare manifest routing metadata

### DIFF
--- a/wordpress/grammar.toml
+++ b/wordpress/grammar.toml
@@ -9,6 +9,7 @@
 [language]
 id = "php"
 extensions = ["php"]
+import_parser = "php"
 
 [comments]
 line = ["//", "#"]

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -427,7 +427,17 @@
     ]
   },
   "lint": {
-    "extension_script": "scripts/lint/lint-runner.sh"
+    "extension_script": "scripts/lint/lint-runner.sh",
+    "changed_file_routes": [
+      {
+        "extensions": ["php"],
+        "step": "phpcs,phpstan"
+      },
+      {
+        "extensions": ["js", "jsx", "ts", "tsx"],
+        "step": "eslint"
+      }
+    ]
   },
   "test": {
     "drift": {


### PR DESCRIPTION
## Summary
- Adds WordPress lint changed-file routing metadata so PHP files route to PHPCS/PHPStan and JS/TS files route to ESLint from the extension manifest.
- Marks the WordPress grammar as using the PHP import parser so Homeboy core no longer needs a WordPress-specific parser fallback.

## Tests
- `python3 -c 'import json, pathlib; json.loads(pathlib.Path("wordpress/wordpress.json").read_text())'`

## Related
- Companion change for Extra-Chill/homeboy#1944.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the manifest metadata changes and drafting this PR description; Chris remains responsible for review and testing.