### PR TITLE
feat(wordpress): emit browser bench target metadata

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -251,6 +251,91 @@ load_component → discover_tests → load_tests → run_tests`. The bash runner
 parses these markers to classify failures; see `test-runner-playground.sh`
 for the full classification table.
 
+## Browser bench target handoff
+
+Browser benchmarks are a two-extension handoff, not a second WordPress bench
+runner. The WordPress extension prepares/describes the WordPress target; the
+Node extension browser helper owns Playwright, browser metrics, screenshots, and
+browser artifacts.
+
+When a component enables `bench_browser_target`, the WordPress bench runner writes
+this file:
+
+```text
+${HOMEBOY_BENCH_SHARED_STATE}/browser-target.json
+```
+
+Minimum component setting:
+
+```json
+{
+  "extensions": {
+    "wordpress": {
+      "settings": {
+        "bench_browser_target": { "enabled": true }
+      }
+    }
+  }
+}
+```
+
+The v1 file shape is:
+
+```json
+{
+  "schemaVersion": 1,
+  "kind": "wordpress",
+  "lifecycle": {
+    "server": "external",
+    "keepAlive": "caller"
+  },
+  "baseUrl": "http://127.0.0.1:8888/",
+  "adminUrl": "http://127.0.0.1:8888/wp-admin/",
+  "login": {
+    "method": "credentials",
+    "username": "admin",
+    "password": "..."
+  },
+  "metadata": {
+    "wpVersion": "6.9",
+    "componentId": "my-plugin",
+    "pluginSlug": "my-plugin",
+    "benchSiteMode": "installed"
+  },
+  "artifactPolicy": {
+    "publishRaw": false,
+    "secretFields": ["login.password", "login.url"]
+  }
+}
+```
+
+Use `baseUrl` / `adminUrl` when an installed or persisted site is already served
+by the caller. If `baseUrl` is omitted, the target file is **metadata only**:
+the current Playground PHP runner runs `wp-playground-cli php` and exits after
+workloads complete, so it does not keep a browser-usable HTTP server alive for a
+later Playwright phase.
+
+Credentials may be supplied directly or via an environment variable indirection:
+
+```json
+{
+  "bench_browser_target": {
+    "enabled": true,
+    "baseUrl": "http://127.0.0.1:8888/",
+    "login": {
+      "method": "credentials",
+      "username": "admin",
+      "password_env": "WP_BROWSER_PASSWORD"
+    }
+  }
+}
+```
+
+The raw `browser-target.json` file is a handoff artifact, not a report artifact.
+It can contain credentials or auto-login URLs; runners must not print it to logs
+or publish it with benchmark results without redacting the fields listed in
+`artifactPolicy.secretFields`.
+
 ## Known gaps
 
 - **WP version is pinned.** Currently `--wp=6.9`. Mismatched pins produce

--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -38,6 +38,7 @@ FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 BENCH_HELPER_SH="${HOMEBOY_RUNTIME_BENCH_HELPER_SH:-${HOME}/.homeboy/runtime/bench-helper.sh}"
 BENCH_HELPER_PHP_HOST="${HOMEBOY_RUNTIME_BENCH_HELPER_PHP:-${HOME}/.homeboy/runtime/bench-helper.php}"
 BENCH_HELPER_PHP_GUEST="/homeboy-runtime/bench-helper.php"
+BENCH_BROWSER_TARGET_HELPER="${SCRIPT_DIR}/browser-target.sh"
 PHP_PREFLIGHT_HELPER="${SCRIPT_DIR}/../lib/php-preflight.sh"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
 PLAYGROUND_PATHS_HELPER="${SCRIPT_DIR}/../lib/playground-paths.sh"
@@ -73,6 +74,8 @@ if [ ! -f "$BENCH_HELPER_PHP_HOST" ]; then
     echo "ERROR: Homeboy PHP bench helper not found at ${BENCH_HELPER_PHP_HOST}" >&2
     exit 2
 fi
+# shellcheck source=browser-target.sh
+source "$BENCH_BROWSER_TARGET_HELPER"
 
 # PLUGIN_SLUG is the wp-content/plugins/ path segment Playground uses to
 # mount the component-under-test. The historical default was
@@ -339,6 +342,11 @@ else
     if [ -z "$PLAYGROUND_WORDPRESS_INSTALL_MODE" ]; then
         PLAYGROUND_WORDPRESS_INSTALL_MODE="download-and-install"
     fi
+fi
+
+if ! homeboy_wordpress_emit_browser_target "${HOMEBOY_SETTINGS_JSON:-{}}" "$SHARED_STATE_HOST" "$COMPONENT_ID" "$PLUGIN_SLUG" "$BENCH_SITE_MODE"; then
+    FAILED_STEP="Browser bench target setup"
+    exit 1
 fi
 
 BLUEPRINT_TMPFILE=""

--- a/wordpress/scripts/bench/browser-target.sh
+++ b/wordpress/scripts/bench/browser-target.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Emit the WordPress -> browser-runner handoff file for bench workflows.
+#
+# The WordPress extension owns WordPress setup and target description. Browser
+# automation itself belongs to the Node extension/Playwright helper, which can
+# consume ${HOMEBOY_BENCH_SHARED_STATE}/browser-target.json after this runner
+# prepares it.
+
+homeboy_wordpress_browser_target_enabled() {
+    local settings_json="$1"
+
+    if [ -z "$settings_json" ] || [ "$settings_json" = "{}" ]; then
+        return 1
+    fi
+
+    printf '%s' "$settings_json" | jq -e '
+        .bench_browser_target as $target
+        | ($target == true) or (($target | type) == "object" and ($target.enabled // false) == true)
+    ' >/dev/null 2>&1
+}
+
+homeboy_wordpress_emit_browser_target() {
+    local settings_json="$1"
+    local shared_state_host="$2"
+    local component_id="$3"
+    local plugin_slug="$4"
+    local bench_site_mode="$5"
+
+    if ! homeboy_wordpress_browser_target_enabled "$settings_json"; then
+        return 0
+    fi
+
+    if [ -z "$shared_state_host" ]; then
+        echo "Error: bench_browser_target.enabled requires HOMEBOY_BENCH_SHARED_STATE so browser-target.json has a stable handoff directory." >&2
+        return 1
+    fi
+
+    mkdir -p "$shared_state_host"
+
+    local target_path="${shared_state_host}/browser-target.json"
+    local tmp_path="${target_path}.tmp"
+
+    # Resolve optional secret indirection without logging the value. The target
+    # file is a handoff artifact, not a report artifact; callers must redact it
+    # before publishing bench outputs.
+    local password=""
+    local password_env=""
+    password_env=$(printf '%s' "$settings_json" | jq -r '
+        .bench_browser_target
+        | if type == "object" then (.login.password_env // .login.passwordEnv // "") else "" end
+    ' 2>/dev/null || true)
+    if [ -n "$password_env" ]; then
+        if [[ ! "$password_env" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            echo "Error: bench_browser_target.login.password_env must be a valid environment variable name." >&2
+            return 1
+        fi
+        if [ -z "${!password_env+x}" ]; then
+            echo "Error: bench_browser_target.login.password_env references unset environment variable '${password_env}'." >&2
+            return 1
+        fi
+        password="${!password_env}"
+    fi
+
+    printf '%s' "$settings_json" | jq \
+        --arg component_id "$component_id" \
+        --arg plugin_slug "$plugin_slug" \
+        --arg bench_site_mode "$bench_site_mode" \
+        --arg password "$password" '
+        def target_config:
+            if .bench_browser_target == true then {} else (.bench_browser_target // {}) end;
+
+        (target_config) as $target
+        | ($target.baseUrl // $target.base_url // "") as $base_url
+        | ($target.adminUrl // $target.admin_url // (if $base_url != "" then ($base_url | sub("/*$"; "/")) + "wp-admin/" else "" end)) as $admin_url
+        | ($target.login // {"method": "none"}) as $login_raw
+        | {
+            schemaVersion: 1,
+            kind: "wordpress",
+            lifecycle: {
+                server: (if $base_url == "" then "not_started" else "external" end),
+                keepAlive: (if $base_url == "" then "none" else "caller" end),
+                note: (if $base_url == "" then "The Playground PHP bench runner does not keep an HTTP server alive after bench execution; provide baseUrl for an already-running target or use this as metadata only." else "The browser helper connects to the provided URL; the caller owns server lifetime." end)
+            },
+            baseUrl: $base_url,
+            adminUrl: $admin_url,
+            login: (
+                if (($login_raw | type) == "object") then
+                    ($login_raw
+                        | if (.password_env // .passwordEnv // "") != "" and $password != "" then . + {password: $password} else . end
+                        | del(.password_env, .passwordEnv))
+                else
+                    {"method": "none"}
+                end
+            ),
+            metadata: {
+                wpVersion: "6.9",
+                componentId: $component_id,
+                pluginSlug: $plugin_slug,
+                benchSiteMode: $bench_site_mode
+            },
+            artifactPolicy: {
+                publishRaw: false,
+                secretFields: ["login.password", "login.url"]
+            }
+        }
+    ' > "$tmp_path"
+
+    mv "$tmp_path" "$target_path"
+    echo "Browser bench target: ${target_path}"
+}

--- a/wordpress/scripts/bench/playground-bench-browser-target-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-browser-target-smoke.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Browser-target handoff smoke test.
+#
+# Exercises the WordPress bench browser-target helper directly. This keeps the
+# smoke focused on the shared-state handoff shape without booting Playground or
+# pretending the PHP bench runner owns Playwright/browser lifecycle.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=browser-target.sh
+source "${SCRIPT_DIR}/browser-target.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    exit 1
+fi
+
+SHARED_STATE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bench-browser-target-smoke.XXXXXX")
+cleanup() {
+    rm -rf "$SHARED_STATE_DIR"
+}
+trap cleanup EXIT
+
+export BROWSER_TARGET_PASSWORD="super-secret-smoke-password"
+
+SETTINGS_JSON=$(cat <<'JSON'
+{
+  "bench_browser_target": {
+    "enabled": true,
+    "baseUrl": "http://127.0.0.1:8888/",
+    "login": {
+      "method": "credentials",
+      "username": "admin",
+      "password_env": "BROWSER_TARGET_PASSWORD"
+    }
+  }
+}
+JSON
+)
+
+echo "============================================"
+echo "Playground bench browser-target smoke test"
+echo "============================================"
+echo "Shared state: $SHARED_STATE_DIR"
+echo ""
+
+helper_output=$(homeboy_wordpress_emit_browser_target "$SETTINGS_JSON" "$SHARED_STATE_DIR" "browser-fixture" "browser-fixture" "installed")
+TARGET_FILE="${SHARED_STATE_DIR}/browser-target.json"
+
+if [ ! -s "$TARGET_FILE" ]; then
+    echo "ERROR: browser-target.json missing or empty" >&2
+    exit 1
+fi
+
+if [[ "$helper_output" == *"$BROWSER_TARGET_PASSWORD"* ]]; then
+    echo "ERROR: helper output leaked the browser target password" >&2
+    exit 1
+fi
+
+assert_json() {
+    local filter="$1"
+    local expected="$2"
+    local actual
+    actual=$(jq -r "$filter" "$TARGET_FILE")
+    if [ "$actual" != "$expected" ]; then
+        echo "ERROR: expected $filter => $expected, got $actual" >&2
+        echo "--- browser-target.json ---" >&2
+        jq . "$TARGET_FILE" >&2
+        exit 1
+    fi
+}
+
+assert_json '.schemaVersion' '1'
+assert_json '.kind' 'wordpress'
+assert_json '.baseUrl' 'http://127.0.0.1:8888/'
+assert_json '.adminUrl' 'http://127.0.0.1:8888/wp-admin/'
+assert_json '.lifecycle.server' 'external'
+assert_json '.lifecycle.keepAlive' 'caller'
+assert_json '.login.method' 'credentials'
+assert_json '.login.username' 'admin'
+assert_json '.login.password' "$BROWSER_TARGET_PASSWORD"
+assert_json '.metadata.componentId' 'browser-fixture'
+assert_json '.metadata.pluginSlug' 'browser-fixture'
+assert_json '.metadata.benchSiteMode' 'installed'
+assert_json '.artifactPolicy.publishRaw' 'false'
+
+if jq -e 'has("password_env") or has("passwordEnv") or (.login | has("password_env") or has("passwordEnv"))' "$TARGET_FILE" >/dev/null; then
+    echo "ERROR: password env indirection leaked into browser-target.json" >&2
+    exit 1
+fi
+
+echo "--- browser-target.json ---"
+jq '(.login.password) = "<redacted>"' "$TARGET_FILE"
+echo ""
+echo "============================================"
+echo "✓ Browser-target handoff smoke test PASSED"
+echo "============================================"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -499,6 +499,13 @@
       "description": "WordPress bench boot shape. 'fresh' preserves the historical wp-phpunit install stage. 'installed' requires HOMEBOY_BENCH_SHARED_STATE, mounts its wordpress/ subdirectory at /wordpress before Playground install, prepares that persisted site on the first run, skips wp-phpunit install.php, and boots the site with wp-load.php for warm installed-site runs."
     },
     {
+      "id": "bench_browser_target",
+      "label": "Bench browser target handoff",
+      "type": "object",
+      "default": {},
+      "description": "Optional browser bench target descriptor. Set {\"enabled\": true} to write HOMEBOY_BENCH_SHARED_STATE/browser-target.json. Include baseUrl/adminUrl for an already-running site; otherwise the file is metadata-only because the Playground PHP bench runner exits after workloads complete. Login supports method plus username/password or password_env; raw target files are handoff artifacts and must not be published in reports."
+    },
+    {
       "id": "playground_wordpress_install_mode",
       "label": "Playground WordPress install mode",
       "type": "string",


### PR DESCRIPTION
## Summary
- Define the WordPress browser bench target handoff contract in the testing docs.
- Add a `bench_browser_target` setting that writes `HOMEBOY_BENCH_SHARED_STATE/browser-target.json` when enabled.
- Keep the boundary narrow: WordPress emits target metadata; future Node/browser helpers own Playwright and browser artifacts.

## Changes
- Adds `wordpress/scripts/bench/browser-target.sh` for isolated target-file construction.
- Wires the Playground bench runner to emit the target before workloads run when the setting is enabled.
- Adds a focused smoke for target shape, password-env resolution, and secret-safe logging.
- Documents that the current Playground PHP runner does not keep an HTTP server alive; `baseUrl` targets are caller-owned, and no-URL targets are metadata-only.

## Tests
- `bash wordpress/scripts/bench/playground-bench-browser-target-smoke.sh`
- `bash -n wordpress/scripts/bench/browser-target.sh wordpress/scripts/bench/bench-runner-playground.sh wordpress/scripts/bench/playground-bench-browser-target-smoke.sh`
- `php -r '$json = json_decode(file_get_contents("wordpress/wordpress.json"), true); if (!is_array($json)) { fwrite(STDERR, json_last_error_msg() . PHP_EOL); exit(1); } echo "wordpress.json ok\n";'`
- `homeboy audit homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@design-wordpress-browser-target --changed-since origin/main`

`homeboy lint homeboy-extensions --path ... --changed-since origin/main` could not run because the aggregate `homeboy-extensions` component has no extension configured; focused shell syntax + smoke coverage passed.

Closes #369

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the browser-target handoff helper, runner wiring, docs, and smoke test; Chris remains responsible for review and merge.