### PR TITLE
fix(nodejs): run selected changed tests

### DIFF
--- a/nodejs/scripts/test/nodejs-changed-scope-smoke.sh
+++ b/nodejs/scripts/test/nodejs-changed-scope-smoke.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-scope.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PROJECT_DIR="${TMPDIR}/project"
+mkdir -p "$PROJECT_DIR/tests"
+
+cat > "${PROJECT_DIR}/package.json" <<'JSON'
+{
+  "scripts": {
+    "test": "node test-recorder.mjs"
+  }
+}
+JSON
+
+cat > "${PROJECT_DIR}/test-recorder.mjs" <<'JS'
+import { writeFileSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+writeFileSync('received-args.json', JSON.stringify(args));
+
+if (args.join('\n') !== 'tests/mcp-config.test.ts\ntests/mcp.test.ts') {
+  console.error(`Unexpected test args: ${JSON.stringify(args)}`);
+  process.exit(1);
+}
+
+console.log('# tests 2');
+console.log('# pass 2');
+console.log('# fail 0');
+JS
+
+touch "${PROJECT_DIR}/tests/mcp-config.test.ts" "${PROJECT_DIR}/tests/mcp.test.ts"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_COMPONENT_ID="node-scope-smoke" \
+HOMEBOY_CHANGED_TEST_FILES=$'tests/mcp-config.test.ts\ntests/mcp.test.ts' \
+bash "${SCRIPT_DIR}/test-runner.sh" > "${TMPDIR}/runner.out"
+
+if ! grep -q 'Scope:     2 selected test file(s)' "${TMPDIR}/runner.out"; then
+    echo "Expected selected-scope line in runner output" >&2
+    cat "${TMPDIR}/runner.out" >&2
+    exit 1
+fi
+
+if [ "$(cat "${PROJECT_DIR}/received-args.json")" != '["tests/mcp-config.test.ts","tests/mcp.test.ts"]' ]; then
+    echo "Runner did not receive selected test files" >&2
+    cat "${PROJECT_DIR}/received-args.json" >&2
+    exit 1
+fi
+
+echo "nodejs changed-scope smoke passed"

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 #   HOMEBOY_COMPONENT_PATH       — path to the Node.js project
 #   HOMEBOY_TEST_RESULTS_FILE    — where to write TestResults envelope
 #   HOMEBOY_NODE_TEST_COMMAND    — override the test command entirely
+#   HOMEBOY_CHANGED_TEST_FILES   — newline-separated test files selected by core
 #   HOMEBOY_DEBUG                — verbose
 
 if ((BASH_VERSINFO[0] < 4)); then
@@ -70,9 +71,20 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: test command: $TEST_CMD" >&2
 fi
 
+RUNNER_ARGS=("$@")
+if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
+    while IFS= read -r selected_test_file; do
+        [ -n "$selected_test_file" ] || continue
+        RUNNER_ARGS+=("$selected_test_file")
+    done <<< "$HOMEBOY_CHANGED_TEST_FILES"
+fi
+
 echo "Running Node.js tests..."
 echo "  Component: ${COMPONENT_ID} (${PROJECT_PATH})"
 echo "  Command:   ${TEST_CMD}"
+if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
+    echo "  Scope:     ${#RUNNER_ARGS[@]} selected test file(s)"
+fi
 echo ""
 
 cd "$PROJECT_PATH"
@@ -80,7 +92,7 @@ cd "$PROJECT_PATH"
 OUTPUT_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-node-test.XXXXXX")
 set +e
 # shellcheck disable=SC2086 # word-splitting is intentional here
-$TEST_CMD "$@" 2>&1 | tee "$OUTPUT_FILE"
+$TEST_CMD "${RUNNER_ARGS[@]}" 2>&1 | tee "$OUTPUT_FILE"
 TEST_EXIT=${PIPESTATUS[0]}
 set -e
 


### PR DESCRIPTION
## Summary
- Teaches the Node.js test runner to append `HOMEBOY_CHANGED_TEST_FILES` to the underlying test command.
- Adds a focused smoke proving changed-since selected files reach the npm test script instead of only appearing in Homeboy's structured scope output.

## Tests
- `bash nodejs/scripts/test/nodejs-changed-scope-smoke.sh`
- `bash -n nodejs/scripts/test/test-runner.sh nodejs/scripts/test/nodejs-changed-scope-smoke.sh`

Attempted but not applicable:
- `homeboy lint homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@fix-nodejs-changed-tests --changed-since origin/main --summary` failed because the `homeboy-extensions` component has no configured extension. The focused shell smoke covers this runner path directly.

Refs Extra-Chill/homeboy#1975.
Related: Extra-Chill/homeboy#1976.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the Node runner scope fix, focused smoke, and PR description. Chris provided the product direction and upstream-first requirement.