### PR TITLE
fix(wordpress): exclude non-runtime files from full PHPStan lint

### DIFF
--- a/tests/wordpress-lint-context-smoke.sh
+++ b/tests/wordpress-lint-context-smoke.sh
@@ -182,4 +182,60 @@ HOMEBOY_LINT_FILE="includes/class-example-adapter.php" \
 assert_contains "$TMP_DIR/phpstan-scoped.out" "PHPStan scoped lint: analyzing 1 PHP file(s) from requested scope"
 assert_contains "$TMP_DIR/phpstan-scoped.out" "PHPStan fake passed"
 
+cat > "$FAKE_EXTENSION/vendor/bin/phpstan" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+targets=()
+for arg in "$@"; do
+    case "$arg" in
+        --*) ;;
+        analyse) ;;
+        *) targets+=("$arg") ;;
+    esac
+done
+
+if [ "${#targets[@]}" -lt 1 ]; then
+    echo "expected full-component PHPStan targets" >&2
+    exit 1
+fi
+
+for target in "${targets[@]}"; do
+    case "$target" in
+        *scoper.inc.php|*/tools/*|*/tests/*|*/vendor_prefixed/*|*/vendor/*)
+            printf 'non-runtime target reached PHPStan: %s\n' "$target" >&2
+            exit 1
+            ;;
+    esac
+done
+
+for expected in "$EXPECTED_PLUGIN_FILE" "$EXPECTED_INTERFACE" "$EXPECTED_RUNTIME_CLASS"; do
+    found=0
+    for target in "${targets[@]}"; do
+        if [ "$target" = "$expected" ]; then
+            found=1
+            break
+        fi
+    done
+    if [ "$found" -ne 1 ]; then
+        printf 'expected runtime target missing: %s\n' "$expected" >&2
+        printf 'targets: %s\n' "${targets[*]}" >&2
+        exit 1
+    fi
+done
+
+printf 'PHPStan full fake passed with %s target(s)\n' "${#targets[@]}"
+BASH
+chmod +x "$FAKE_EXTENSION/vendor/bin/phpstan"
+
+EXPECTED_PLUGIN_FILE="$COMPONENT_DIR/example-plugin.php" \
+EXPECTED_INTERFACE="$COMPONENT_DIR/includes/interface-example-adapter.php" \
+EXPECTED_RUNTIME_CLASS="$COMPONENT_DIR/includes/class-example-adapter.php" \
+HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="example-plugin" \
+    bash "$PHPSTAN_RUNNER" > "$TMP_DIR/phpstan-full.out" 2>&1
+
+assert_contains "$TMP_DIR/phpstan-full.out" "PHPStan full fake passed"
+
 echo "wordpress lint context smoke passed"

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -174,7 +174,7 @@ homeboy_wordpress_runtime_lint_file() {
     local rel_path="$1"
 
     case "$rel_path" in
-        scoper.inc.php|tools/*|tests/smoke-*.php|tests/*UnitTest.php|tests/*Test.php|vendor_prefixed/*|vendor/*)
+        scoper.inc.php|tools/*|tests/*|vendor_prefixed/*|vendor/*)
             return 1
             ;;
     esac

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -264,7 +264,7 @@ if [ -n "$DEPENDENCY_CONFIG" ] && [ -f "$DEPENDENCY_CONFIG" ]; then
     PHPSTAN_BASE_CONFIG="$DEPENDENCY_CONFIG"
 fi
 
-PHPSTAN_TARGETS=("$PLUGIN_PATH")
+PHPSTAN_TARGETS=()
 PHPSTAN_SCOPED=0
 
 homeboy_phpstan_relpath() {
@@ -291,7 +291,7 @@ homeboy_phpstan_runtime_file() {
     local rel_path="$1"
 
     case "$rel_path" in
-        scoper.inc.php|tools/*|tests/smoke-*.php|tests/*UnitTest.php|tests/*Test.php|vendor_prefixed/*|vendor/*)
+        scoper.inc.php|tools/*|tests/*|vendor_prefixed/*|vendor/*)
             return 1
             ;;
     esac
@@ -341,6 +341,25 @@ resolve_phpstan_targets() {
     fi
 }
 
+resolve_phpstan_full_targets() {
+    local target_path
+    local target_rel
+
+    while IFS= read -r -d '' target_path; do
+        target_rel=$(homeboy_phpstan_relpath "$target_path")
+        if homeboy_phpstan_runtime_file "$target_rel"; then
+            printf '%s\0' "$target_path"
+        fi
+    done < <(find "$PLUGIN_PATH" -type f -name '*.php' \
+        -not -path "*/vendor/*" \
+        -not -path "*/vendor_prefixed/*" \
+        -not -path "*/node_extensions/*" \
+        -not -path "*/node_modules/*" \
+        -not -path "*/build/*" \
+        -not -path "*/dist/*" \
+        -print0)
+}
+
 if [ -n "${HOMEBOY_LINT_FILE:-}" ] || [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
     PHPSTAN_SCOPED=1
     PHPSTAN_TARGETS=()
@@ -357,23 +376,14 @@ if [ -n "${HOMEBOY_LINT_FILE:-}" ] || [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
     if [ -n "$SCOPED_CONTEXT_CONFIG" ] && [ -f "$SCOPED_CONTEXT_CONFIG" ]; then
         PHPSTAN_BASE_CONFIG="$SCOPED_CONTEXT_CONFIG"
     fi
+else
+    while IFS= read -r -d '' phpstan_target; do
+        PHPSTAN_TARGETS+=("$phpstan_target")
+    done < <(resolve_phpstan_full_targets)
 fi
 
 # Check if the selected PHPStan target set has PHP files.
-if [ "$PHPSTAN_SCOPED" -eq 1 ]; then
-    php_file_count="${#PHPSTAN_TARGETS[@]}"
-else
-    php_file_count=$(find "$PLUGIN_PATH" -type f -name "*.php" \
-        -not -path "*/vendor/*" \
-        -not -path "*/vendor_prefixed/*" \
-        -not -path "*/node_extensions/*" \
-        -not -path "*/build/*" \
-        -not -path "*/dist/*" \
-        -not -path "*/tools/*" \
-        -not -name "scoper.inc.php" \
-        -not -path "*/tests/*" \
-        2>/dev/null | wc -l | tr -d ' ')
-fi
+php_file_count="${#PHPSTAN_TARGETS[@]}"
 
 if [ "$php_file_count" -eq 0 ]; then
     if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then


### PR DESCRIPTION
## Summary
- Keep full-component WordPress PHPStan lint scoped to runtime PHP files instead of passing the component root to PHPStan.
- Treat the full `tests/` tree as non-runtime for the production lint profile, matching the scoped file behaviour for smoke harnesses and PHPUnit tests.
- Extend the lint context smoke so fake PHPStan fails if full-component lint receives scoper config, tools, tests, vendor, or generated prefixed vendor paths.

## Changes
- Adds runtime-only full target discovery in `phpstan-runner.sh`.
- Reuses the same non-runtime role boundary for scoped lint and full PHPStan target discovery.
- Adds a full-component PHPStan target assertion to `tests/wordpress-lint-context-smoke.sh`.

## Tests
- `bash tests/wordpress-lint-context-smoke.sh`
- `bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- `bash -n wordpress/scripts/lint/phpstan-runner.sh wordpress/scripts/lint/lint-runner.sh tests/wordpress-lint-context-smoke.sh`
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- Reproduction: temporarily linked the local WordPress extension to this worktree and ran `homeboy lint intelligence --path /Users/chubes/Developer/intelligence@chore-full-lint-smoke-drift --summary`. PHPStan findings dropped from the issue's 859 smoke-heavy findings to 220 production-source findings; `tests/**` findings no longer appeared.

Closes #374

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing and validating the WordPress lint full-component smoke harness PHPStan exclusion; Chris remains responsible for review.
