### PR TITLE
fix(wordpress): tighten PHPStan API stubs

### DIFF
--- a/wordpress/phpstan.neon.dist
+++ b/wordpress/phpstan.neon.dist
@@ -38,6 +38,9 @@ parameters:
         - vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
         - vendor/php-stubs/woocommerce-stubs/woocommerce-packages-stubs.php
 
+    stubFiles:
+        - stubs/wordpress-api-overrides.stub.php
+
     # Level 7 unlocks argument type flow analysis (union narrowing, false/null
     # leakage into strict-typed callees). Levels 5 and 6 miss the exact class
     # of bug in [WordPress/wordpress-develop#11387](https://github.com/WordPress/wordpress-develop/pull/11387) —

--- a/wordpress/stubs/wordpress-api-overrides.stub.php
+++ b/wordpress/stubs/wordpress-api-overrides.stub.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Homeboy's WordPress PHPStan profile models the APIs most commonly used by
+ * plugins. These overrides cover gaps in upstream generated stubs without
+ * changing runtime behaviour.
+ */
+
+class WP_CLI {
+	/**
+	 * @param mixed $message
+	 * @return void
+	 * @phpstan-impure
+	 */
+	public static function log( $message ) {}
+
+	/**
+	 * @param mixed $message
+	 * @return void
+	 * @phpstan-impure
+	 */
+	public static function success( $message ) {}
+
+	/**
+	 * @param mixed $message
+	 * @return void
+	 * @phpstan-impure
+	 */
+	public static function warning( $message ) {}
+
+	/**
+	 * @param mixed $message
+	 * @param bool|int $exit
+	 * @return null
+	 * @phpstan-impure
+	 */
+	public static function error( $message, $exit = true ) {}
+}
+
+/**
+ * @property int $ID
+ * @property string $post_author
+ * @property string $post_date
+ * @property string $post_date_gmt
+ * @property string $post_content
+ * @property string $post_title
+ * @property string $post_excerpt
+ * @property string $post_status
+ * @property string $comment_status
+ * @property string $ping_status
+ * @property string $post_password
+ * @property string $post_name
+ * @property string $to_ping
+ * @property string $pinged
+ * @property string $post_modified
+ * @property string $post_modified_gmt
+ * @property string $post_content_filtered
+ * @property int $post_parent
+ * @property string $guid
+ * @property int $menu_order
+ * @property string $post_type
+ * @property string $post_mime_type
+ * @property string $comment_count
+ * @property string $filter
+ */
+class WP_Post {
+	/**
+	 * @param mixed $post
+	 */
+	public function __construct( $post = null ) {}
+}
+
+/**
+ * @param non-empty-string $hook_name
+ * @param mixed $value
+ * @param mixed ...$args
+ * @return mixed
+ */
+function apply_filters( $hook_name, $value, ...$args ) {}
+
+/**
+ * @param non-empty-string $hook_name
+ * @param callable $callback
+ * @return true
+ */
+function add_filter( $hook_name, $callback, int $priority = 10, int $accepted_args = 1 ) {}
+
+/**
+ * @param non-empty-string $hook_name
+ * @param callable $callback
+ * @return true
+ */
+function add_action( $hook_name, $callback, int $priority = 10, int $accepted_args = 1 ) {}
+
+/**
+ * @param non-empty-string $hook_name
+ * @param callable $callback
+ */
+function remove_filter( $hook_name, $callback, int $priority = 10 ): bool {}
+
+/**
+ * @param string $capability
+ * @param mixed ...$args
+ */
+function current_user_can( $capability, ...$args ): bool {}
+
+/**
+ * @param mixed $value
+ * @return string|false
+ */
+function wp_json_encode( $value, int $flags = 0, int $depth = 512 ) {}
+
+/**
+ * @param int|WP_Post|null $post
+ * @param 'OBJECT'|'ARRAY_A'|'ARRAY_N' $output
+ * @param 'raw'|'edit'|'db'|'display' $filter
+ * @return WP_Post|array<string|int, mixed>|null
+ */
+function get_post( $post = null, $output = OBJECT, $filter = 'raw' ) {}

--- a/wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh
+++ b/wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PHPSTAN_RUNNER="${ROOT_DIR}/scripts/lint/phpstan-runner.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+COMPONENT_DIR="${TMPDIR}/component"
+OUTPUT_FILE="${TMPDIR}/phpstan-output.txt"
+
+mkdir -p "${COMPONENT_DIR}/inc"
+
+cat > "${COMPONENT_DIR}/inc/issue-375.php" <<'PHP'
+<?php
+
+function homeboy_issue_375_filter_callback( $value, WP_Post $post ) {
+	return $value;
+}
+
+function homeboy_issue_375_action_callback( WP_Post $post, array $context ): void {
+	new WP_Post();
+	new WP_Post( (object) array( 'ID' => 123 ) );
+
+	WP_CLI::log( 'Inspecting ' . $post->post_type );
+	WP_CLI::success( 'Post excerpt: ' . $post->post_excerpt );
+	WP_CLI::warning( 'Modified at ' . $post->post_modified_gmt );
+
+	apply_filters( 'homeboy_issue_375_filter', $post->post_title, $post, array( 'source' => 'smoke' ) );
+	add_filter( 'homeboy_issue_375_filter', 'homeboy_issue_375_filter_callback', 10, 2 );
+	add_action( 'homeboy_issue_375_action', 'homeboy_issue_375_action_callback', 10, 2 );
+	remove_filter( 'homeboy_issue_375_filter', 'homeboy_issue_375_filter_callback', 10 );
+
+	current_user_can( 'edit_post', $post->ID );
+	wp_json_encode( array( 'post_type' => $post->post_type ) );
+	get_post();
+}
+PHP
+
+if [ ! -x "${ROOT_DIR}/vendor/bin/phpstan" ]; then
+	echo "FAIL: PHPStan is not installed. Run composer install in ${ROOT_DIR}." >&2
+	exit 1
+fi
+
+set +e
+HOMEBOY_EXTENSION_PATH="$ROOT_DIR" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="phpstan-wordpress-api-stubs" \
+HOMEBOY_SUMMARY_MODE=1 \
+HOMEBOY_PHPSTAN_THREADS=1 \
+"$PHPSTAN_RUNNER" >"$OUTPUT_FILE" 2>&1
+exit_code=$?
+set -e
+
+if [ "$exit_code" -ne 0 ]; then
+	echo "FAIL: representative WordPress/WP-CLI API calls should pass PHPStan" >&2
+	cat "$OUTPUT_FILE" >&2
+	exit 1
+fi
+
+if grep -E 'staticMethod\.resultUnused|arguments\.count|property\.notFound' "$OUTPUT_FILE" >/dev/null; then
+	echo "FAIL: representative false-positive identifiers are still present" >&2
+	cat "$OUTPUT_FILE" >&2
+	exit 1
+fi
+
+echo "PHPStan WordPress API stubs smoke passed"


### PR DESCRIPTION
## Summary
- Adds WordPress PHPStan stub overrides for common WordPress/WP-CLI APIs that are valid in plugin code but were reported as false positives.
- Covers WP-CLI side-effect output calls, hook helper signatures, selected runtime helpers, and common `WP_Post` properties/constructor shapes.
- Adds a focused PHPStan smoke fixture that exercises the representative false-positive cases from the issue.

## Changes
- Registers `wordpress/stubs/wordpress-api-overrides.stub.php` through `stubFiles` in the WordPress PHPStan profile.
- Marks `WP_CLI::log()`, `success()`, `warning()`, and `error()` as impure side-effecting methods.
- Models variadic/optional WordPress helper signatures for `apply_filters()`, `add_filter()`, `add_action()`, `remove_filter()`, `current_user_can()`, `wp_json_encode()`, and zero-arg `get_post()`.
- Models common `WP_Post` public properties and both no-arg/object constructor usage.

## Tests
- `bash wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh` — passed
- `bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh` — passed
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh` — passed
- `for test_script in wordpress/tests/*.sh wordpress/scripts/lint/phpstan-scoped-smoke.sh; do bash "$test_script"; done` — passed
- `php -l wordpress/stubs/wordpress-api-overrides.stub.php` — passed
- `bash -n wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh` — passed

Targeted validation against Intelligence files:
- `inc/search/class-intelligence-provider-tool-resolver.php` — patched runner passed, no `arguments.count` false positive for `apply_filters()`.
- `inc/read/class-intelligence-read-local.php` — patched runner passed, no `property.notFound` false positive for `WP_Post::$post_type`.
- `inc/cli/class-intelligence-youtube-command.php` — patched runner no longer reports `staticMethod.resultUnused`; remaining output was pre-existing `class.notFound` for `Intelligence_YouTubeAbility` context.
- `inc/cli/class-intelligence-wiki-command.php` could not be used as a truth signal because PHPStan stops on current parse errors at lines 1115/1118 before output-method analysis.

Closes #375.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing and validating WordPress PHPStan stub/profile false-positive fixes; Chris remains responsible for review.
