### PR TITLE
fix(nodejs): preserve Nx Vitest timeout context

### DIFF
--- a/nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh
+++ b/nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-nx-vitest.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PROJECT_DIR="${TMPDIR}/project"
+mkdir -p "$PROJECT_DIR"
+
+cat > "${PROJECT_DIR}/package.json" <<'JSON'
+{
+  "scripts": {
+    "test": "node fake-nx-vitest-timeout.mjs"
+  }
+}
+JSON
+
+cat > "${PROJECT_DIR}/fake-nx-vitest-timeout.mjs" <<'JS'
+console.log(`
+ NX   Running target test:vite for project playground-wordpress
+
+ FAIL src/test/version-detect.spec.ts > Test WP version detection > detects WP trunk at runtime
+Error: Test timed out in 30000ms.
+
+Failed tasks:
+- playground-wordpress:test:vite
+`);
+process.exit(1);
+JS
+
+cat > "${TMPDIR}/write-results.sh" <<'SH'
+homeboy_write_test_results() {
+    local total="$1"
+    local passed="$2"
+    local failed="$3"
+    local skipped="$4"
+    local partial="${5:-}"
+
+    node - "$HOMEBOY_TEST_RESULTS_FILE" "$total" "$passed" "$failed" "$skipped" "$partial" <<'JS'
+const fs = require('node:fs');
+const [file, total, passed, failed, skipped, partial] = process.argv.slice(2);
+const payload = {
+  total: Number(total),
+  passed: Number(passed),
+  failed: Number(failed),
+  skipped: Number(skipped)
+};
+if (partial) {
+  payload.partial = partial;
+}
+fs.writeFileSync(file, JSON.stringify(payload, null, 2));
+JS
+}
+SH
+
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_COMPONENT_ID="node-nx-vitest-smoke" \
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="${TMPDIR}/write-results.sh" \
+HOMEBOY_TEST_RESULTS_FILE="${TMPDIR}/test-results.json" \
+HOMEBOY_TEST_FAILURES_FILE="${TMPDIR}/test-failures.json" \
+bash "${SCRIPT_DIR}/test-runner.sh" > "${TMPDIR}/runner.out" 2>&1
+RUNNER_EXIT=$?
+set -e
+
+if [ "$RUNNER_EXIT" -eq 0 ]; then
+    echo "Expected runner to fail for fake Vitest timeout" >&2
+    cat "${TMPDIR}/runner.out" >&2
+    exit 1
+fi
+
+node - "${TMPDIR}/test-results.json" "${TMPDIR}/test-failures.json" <<'JS'
+const fs = require('node:fs');
+const assert = require('node:assert/strict');
+
+const results = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+assert.equal(results.total, 1);
+assert.equal(results.passed, 0);
+assert.equal(results.failed, 1);
+assert.equal(results.skipped, 0);
+assert.equal(results.partial, 'vitest-timeout');
+
+const failures = JSON.parse(fs.readFileSync(process.argv[3], 'utf8'));
+assert.equal(failures.total, 1);
+assert.equal(failures.passed, 0);
+assert.equal(failures.failures.length, 1);
+assert.equal(
+  failures.failures[0].test_name,
+  'Test WP version detection > detects WP trunk at runtime'
+);
+assert.equal(failures.failures[0].test_file, 'src/test/version-detect.spec.ts');
+assert.equal(failures.failures[0].error_type, 'vitest_timeout');
+assert.match(failures.failures[0].message, /Test timed out in 30000ms/);
+assert.match(failures.failures[0].message, /Nx task: playground-wordpress:test:vite/);
+JS
+
+if grep -q 'unknown-runner' "${TMPDIR}/test-results.json"; then
+    echo "Nx/Vitest timeout should not be labelled unknown-runner" >&2
+    cat "${TMPDIR}/test-results.json" >&2
+    exit 1
+fi
+
+echo "nodejs Nx/Vitest timeout smoke passed"

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -21,6 +21,7 @@ set -euo pipefail
 #   HOMEBOY_EXTENSION_PATH       — path to this extension
 #   HOMEBOY_COMPONENT_PATH       — path to the Node.js project
 #   HOMEBOY_TEST_RESULTS_FILE    — where to write TestResults envelope
+#   HOMEBOY_TEST_FAILURES_FILE   — where to write parsed failure details
 #   HOMEBOY_NODE_TEST_COMMAND    — override the test command entirely
 #   HOMEBOY_CHANGED_TEST_FILES   — newline-separated test files selected by core
 #   HOMEBOY_DEBUG                — verbose
@@ -110,6 +111,55 @@ PASSED=0
 FAILED=0
 SKIPPED=0
 PARTIAL_LABEL=""
+FAILED_TEST_NAME=""
+FAILED_TEST_FILE=""
+FAILED_ERROR_TYPE=""
+FAILED_MESSAGE=""
+
+extract_failed_nx_task() {
+    echo "$OUTPUT" | awk '
+        /^Failed tasks:[[:space:]]*$/ { in_failed_tasks = 1; next }
+        in_failed_tasks && /^[[:space:]]*-[[:space:]]+/ {
+            sub(/^[[:space:]]*-[[:space:]]+/, "")
+            print
+            exit
+        }
+        in_failed_tasks && NF == 0 { next }
+        in_failed_tasks { exit }
+    '
+}
+
+extract_vitest_failure_line() {
+    echo "$OUTPUT" | grep -E "^[[:space:]]*FAIL[[:space:]]+.*[[:space:]]>[[:space:]]" | head -1 || true
+}
+
+write_node_failure_json() {
+    [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] || return 0
+    [ -n "$FAILED_TEST_NAME" ] || return 0
+
+    node - "$HOMEBOY_TEST_FAILURES_FILE" "$FAILED_TEST_NAME" "$FAILED_TEST_FILE" "$FAILED_ERROR_TYPE" "$FAILED_MESSAGE" "$TOTAL" "$PASSED" <<'JS'
+const fs = require('node:fs');
+
+const [file, testName, testFile, errorType, message, total, passed] = process.argv.slice(2);
+const parsedTotal = Number.parseInt(total || '0', 10) || 0;
+const parsedPassed = Number.parseInt(passed || '0', 10) || 0;
+
+fs.writeFileSync(file, JSON.stringify({
+  total: parsedTotal,
+  passed: parsedPassed,
+  failures: [
+    {
+      test_name: testName,
+      test_file: testFile,
+      error_type: errorType,
+      message,
+      source_file: testFile,
+      source_line: 0
+    }
+  ]
+}, null, 2));
+JS
+}
 
 # Vitest summary lines look like:
 #   Test Files  3 passed (3)
@@ -121,6 +171,35 @@ if [ $PARSED -eq 0 ] && echo "$OUTPUT" | grep -qE "^[[:space:]]*Tests[[:space:]]
     SKIPPED=$(echo "$LINE" | grep -oE "[0-9]+ skipped" | grep -oE "[0-9]+" | head -1 || echo 0)
     TOTAL=$(echo "$LINE" | grep -oE "\([0-9]+\)" | tr -d '()' | tail -1 || echo 0)
     [ -z "$TOTAL" ] && TOTAL=$((PASSED + FAILED + SKIPPED))
+    PARSED=1
+fi
+
+# Nx wraps the underlying runner output and prints the failed target separately:
+#   FAIL src/test/version-detect.spec.ts > Suite > test name
+#   Error: Test timed out in 30000ms.
+#   Failed tasks:
+#   - playground-wordpress:test:vite
+# When Vitest times out before writing its final summary, preserve the test
+# failure instead of falling back to an opaque `unknown-runner` infrastructure
+# failure.
+if [ $PARSED -eq 0 ] && echo "$OUTPUT" | grep -qE "^[[:space:]]*FAIL[[:space:]]+.*[[:space:]]>[[:space:]]" && echo "$OUTPUT" | grep -q "Test timed out in"; then
+    VITEST_FAILURE_LINE="$(extract_vitest_failure_line)"
+    NX_FAILED_TASK="$(extract_failed_nx_task)"
+
+    FAILED_TEST_FILE="$(echo "$VITEST_FAILURE_LINE" | sed -E 's/^[[:space:]]*FAIL[[:space:]]+([^[:space:]]+).*$/\1/')"
+    FAILED_TEST_NAME="$(echo "$VITEST_FAILURE_LINE" | sed -E 's/^[[:space:]]*FAIL[[:space:]]+[^>]+>[[:space:]]*//')"
+    FAILED_ERROR_TYPE="vitest_timeout"
+    FAILED_MESSAGE="$(echo "$OUTPUT" | grep -E "Test timed out in [0-9]+ms" | head -1 | sed -E 's/^[[:space:]]*Error:[[:space:]]*//')"
+
+    if [ -n "$NX_FAILED_TASK" ]; then
+        FAILED_MESSAGE="${FAILED_MESSAGE} (Nx task: ${NX_FAILED_TASK})"
+    fi
+
+    TOTAL=1
+    PASSED=0
+    FAILED=1
+    SKIPPED=0
+    PARTIAL_LABEL="vitest-timeout"
     PARSED=1
 fi
 
@@ -172,6 +251,8 @@ fi
 if type homeboy_write_test_results >/dev/null 2>&1; then
     homeboy_write_test_results "$TOTAL" "$PASSED" "$FAILED" "$SKIPPED" "$PARTIAL_LABEL"
 fi
+
+write_node_failure_json
 
 if [ $TEST_EXIT -ne 0 ]; then
     FAILED_STEP="Tests failed (exit $TEST_EXIT)"


### PR DESCRIPTION
## Summary

- Preserve Nx-wrapped Vitest timeout context in the Node test runner instead of falling back to `unknown-runner`.
- Emit a structured Homeboy test-failures envelope with the failed file, test name, timeout message, and Nx target.

## Changes

- Detect Vitest timeout lines when Nx does not produce the final Vitest summary.
- Parse the first `Failed tasks:` entry into the failure message as `Nx task: ...`.
- Write `HOMEBOY_TEST_FAILURES_FILE` for parsed Node failures so Homeboy core can surface `failed_tests` / analysis context.
- Add a focused smoke fixture for an Nx/Vitest timeout.

## Tests

- `nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh`
- `nodejs/scripts/test/nodejs-changed-scope-smoke.sh`
- `for script in nodejs/scripts/test/*smoke.sh; do bash "$script"; done`
- `bash -n nodejs/scripts/test/test-runner.sh nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh`
- `git diff --check`
- `homeboy audit homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@fix-nx-result-fidelity --changed-since origin/main`

`homeboy lint homeboy-extensions --path ...` is not runnable for this component because `homeboy-extensions` has no lint extension configured. `shellcheck` is not installed locally.

Refs Extra-Chill/homeboy#1997.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Node runner parser change, added the focused smoke, and ran the validation commands above. Chris remains responsible for review and merge.
