### PR TITLE
feat(nodejs): add trace probe helpers

### DIFF
--- a/nodejs/scripts/trace/README.md
+++ b/nodejs/scripts/trace/README.md
@@ -1,0 +1,43 @@
+# Node.js Trace Helpers
+
+Node.js trace workloads can import reusable helpers from the directory exposed as
+`HOMEBOY_TRACE_HELPER_DIR` by `trace-runner.sh`.
+
+```js
+import { pathToFileURL } from 'node:url';
+
+const helperDir = process.env.HOMEBOY_TRACE_HELPER_DIR;
+const { createTraceRecorder } = await import(pathToFileURL(`${helperDir}/timeline.mjs`).href);
+const { pollHttp, pollJsonFile, pollProcess, parseLogLines } = await import(pathToFileURL(`${helperDir}/probes.mjs`).href);
+
+const recorder = createTraceRecorder();
+const onEvent = recorder.recordEvent.bind(recorder);
+
+await pollHttp('http://127.0.0.1:3000/', {
+    readyStatus: [200, 399],
+    timeoutMs: 30000,
+    intervalMs: 250,
+    requestTimeoutMs: 1000,
+    onEvent,
+});
+
+await recorder.writeTraceResults({ summary: 'Trace completed' });
+```
+
+## Helper Modules
+
+- `timeline.mjs` — `createTraceRecorder()` writes timeline JSONL, assertions, artifacts, and the final trace envelope.
+- `process.mjs` — process launch, cleanup, exit waiting, and process-tree capture helpers.
+- `desktop.mjs` — best-effort desktop observation helpers for local trace evidence.
+- `probes.mjs` — app-agnostic polling and bridge helpers for common trace observations.
+
+## Probe Helpers
+
+- `pollHttp(url, options)` emits `http.first_response`, `http.status`, `http.ready`, and `http.timeout` events.
+- `pollJsonFile(filePath, options)` tolerates missing files and mid-write JSON parse failures, then emits configured events once their predicates match.
+- `pollProcess(pattern, options)` matches process command lines by string or regex and emits `process.seen`, `process.gone`, or `process.timeout`.
+- `parseLogLines(text, patterns, onEvent)` turns text lines into timeline events using regex patterns.
+- `installConsoleBridge(page, options)` attaches to a Playwright/Puppeteer-style `page.on('console')` interface and records prefixed console messages.
+- `withObservationWindow(promise, timeoutMs, options)` bounds helper observations so trace workloads do not run forever.
+
+Keep workload-specific semantics in the workload. These helpers should stay generic: no Studio, WordPress, Electron, or browser-specific assumptions beyond the optional page-like console bridge interface.

--- a/nodejs/scripts/trace/fixtures/helper.trace.mjs
+++ b/nodejs/scripts/trace/fixtures/helper.trace.mjs
@@ -1,12 +1,25 @@
 import { pathToFileURL } from 'node:url';
+import { EventEmitter } from 'node:events';
+import { createServer } from 'node:http';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 const helperDir = process.env.HOMEBOY_TRACE_HELPER_DIR;
 const { createTraceRecorder } = await import(pathToFileURL(`${helperDir}/timeline.mjs`).href);
 const { launchProcess, waitForExit, captureProcessTree } = await import(pathToFileURL(`${helperDir}/process.mjs`).href);
 const { observeVisibleWindows } = await import(pathToFileURL(`${helperDir}/desktop.mjs`).href);
+const {
+    installConsoleBridge,
+    parseLogLines,
+    pollHttp,
+    pollJsonFile,
+    pollProcess,
+    withObservationWindow,
+} = await import(pathToFileURL(`${helperDir}/probes.mjs`).href);
 
 const recorder = createTraceRecorder();
 await recorder.recordEvent('scenario', 'helper.start', { helperDir: Boolean(helperDir) });
+const onEvent = recorder.recordEvent.bind(recorder);
 
 const child = launchProcess('node', {
     args: ['-e', 'setTimeout(() => process.exit(0), 50)'],
@@ -18,6 +31,68 @@ await captureProcessTree(child.pid, 'process-tree.txt', { recorder });
 const exit = await waitForExit(child);
 await recorder.recordEvent('process', 'process.exit', exit);
 recorder.recordAssertion('dummy-process-exited', exit.code === 0 ? 'pass' : 'fail', `dummy process exited with ${exit.code}`);
+
+const jsonPath = join(process.env.HOMEBOY_TRACE_ARTIFACT_DIR, 'state.json');
+const jsonPoll = pollJsonFile(jsonPath, {
+    select: (json) => json.site,
+    intervalMs: 20,
+    timeoutMs: 1000,
+    events: [
+        { name: 'json.site_seen', when: (value) => Boolean(value?.name), data: (value) => value },
+        { name: 'json.port_known', when: (value) => Number(value?.port) > 0, data: (value) => ({ port: value.port }), terminal: true },
+    ],
+    onEvent,
+});
+await writeFile(jsonPath, '{');
+setTimeout(() => {
+    void writeFile(jsonPath, JSON.stringify({ site: { name: 'demo', port: 9876 } }));
+}, 30);
+const jsonResult = await jsonPoll;
+recorder.recordAssertion('json-poll-port-known', jsonResult.status === 'matched' && jsonResult.event === 'json.port_known' ? 'pass' : 'fail', `json poll returned ${jsonResult.status}`);
+
+let requestCount = 0;
+const server = createServer((_, res) => {
+    requestCount += 1;
+    res.statusCode = requestCount === 1 ? 502 : 200;
+    res.end('ok');
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+try {
+    const { port } = server.address();
+    const httpResult = await pollHttp(`http://127.0.0.1:${port}/`, {
+        readyStatus: 200,
+        intervalMs: 20,
+        requestTimeoutMs: 500,
+        timeoutMs: 1000,
+        onEvent,
+    });
+    recorder.recordAssertion('http-poll-ready', httpResult.status === 'ready' && httpResult.http_status === 200 ? 'pass' : 'fail', `http poll returned ${httpResult.status}`);
+} finally {
+    await new Promise((resolve) => server.close(resolve));
+}
+
+const sleeper = launchProcess('node', {
+    args: ['-e', 'setTimeout(() => process.exit(0), 300)'],
+    shell: false,
+});
+const processResult = await pollProcess(/setTimeout\(\(\) => process\.exit\(0\), 300\)/, {
+    intervalMs: 20,
+    timeoutMs: 1000,
+    onEvent,
+});
+recorder.recordAssertion('process-poll-seen', processResult.status === 'seen' ? 'pass' : 'fail', `process poll returned ${processResult.status}`);
+await waitForExit(sleeper);
+
+await parseLogLines('ready on 127.0.0.1:1234\nignored', [
+    { event: 'log.port_known', pattern: /ready on (?<host>[^:]+):(?<port>\d+)/, data: (match) => ({ host: match.groups.host, port: Number(match.groups.port) }) },
+], onEvent);
+
+const observed = await withObservationWindow(new Promise((resolve) => setTimeout(() => resolve('done'), 20)), 100, { onEvent });
+recorder.recordAssertion('observation-window-resolved', observed === 'done' ? 'pass' : 'fail', 'observation window resolved before timeout');
+
+const page = new EventEmitter();
+installConsoleBridge(page, { prefix: 'trace:', onEvent });
+page.emit('console', { text: () => 'trace:{"event":"bridge-ok"}' });
 
 const windows = await observeVisibleWindows();
 recorder.recordAssertion(

--- a/nodejs/scripts/trace/lib/probes.mjs
+++ b/nodejs/scripts/trace/lib/probes.mjs
@@ -1,0 +1,253 @@
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export async function withObservationWindow(promise, timeoutMs, options = {}) {
+    let timeout;
+    const timeoutPromise = new Promise((resolve, reject) => {
+        timeout = setTimeout(() => {
+            const result = { status: 'timeout', timeout_ms: timeoutMs };
+            emit(options.onTimeout || options.onEvent, 'observation', 'observation.timeout', result);
+            if (options.rejectOnTimeout) {
+                reject(new Error(`Observation timed out after ${timeoutMs}ms`));
+                return;
+            }
+            resolve(result);
+        }, timeoutMs);
+    });
+
+    try {
+        return await Promise.race([promise, timeoutPromise]);
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+export async function pollHttp(url, options = {}) {
+    const source = options.source || 'http';
+    const intervalMs = options.intervalMs ?? 250;
+    const timeoutMs = options.timeoutMs ?? 30000;
+    const requestTimeoutMs = options.requestTimeoutMs ?? 5000;
+    const readyStatus = normalizeReadyStatus(options.readyStatus ?? [200, 399]);
+    const deadline = Date.now() + timeoutMs;
+    let first = true;
+    let lastStatus;
+    let lastError;
+
+    while (Date.now() <= deadline) {
+        const response = await httpStatus(url, requestTimeoutMs);
+
+        if (response.ok) {
+            const data = { url, status: response.status };
+            if (first) await emit(options.onEvent, source, 'http.first_response', data);
+            if (first || response.status !== lastStatus) await emit(options.onEvent, source, 'http.status', data);
+            lastStatus = response.status;
+            if (isReadyStatus(response.status, readyStatus)) {
+                await emit(options.onEvent, source, 'http.ready', data);
+                return { status: 'ready', http_status: response.status };
+            }
+        } else {
+            lastError = response.error;
+            if (first) await emit(options.onEvent, source, 'http.first_error', { url, error: response.error });
+        }
+
+        first = false;
+        await sleep(intervalMs);
+    }
+
+    await emit(options.onEvent, source, 'http.timeout', { url, last_status: lastStatus ?? null, last_error: lastError ?? null });
+    return { status: 'timeout', http_status: lastStatus ?? null, error: lastError ?? null };
+}
+
+export async function pollJsonFile(filePath, options = {}) {
+    const source = options.source || 'json-file';
+    const intervalMs = options.intervalMs ?? 250;
+    const timeoutMs = options.timeoutMs ?? 30000;
+    const select = options.select || ((json) => json);
+    const eventSpecs = options.events || [];
+    const terminalEvents = new Set(options.terminalEvents || eventSpecs.filter((event) => event.terminal).map((event) => event.name));
+    const emitted = new Set();
+    const deadline = Date.now() + timeoutMs;
+    let lastValue;
+    let sawFile = false;
+
+    while (Date.now() <= deadline) {
+        const parsed = await readJsonIfAvailable(filePath);
+        if (parsed.status === 'ok') {
+            if (!sawFile) {
+                sawFile = true;
+                await emit(options.onEvent, source, 'json.file_seen', { path: filePath });
+            }
+            lastValue = select(parsed.json);
+            for (const spec of eventSpecs) {
+                if (!spec || emitted.has(spec.name)) continue;
+                if (spec.when(lastValue, parsed.json)) {
+                    emitted.add(spec.name);
+                    const data = typeof spec.data === 'function' ? spec.data(lastValue, parsed.json) : { value: lastValue };
+                    await emit(options.onEvent, source, spec.name, data);
+                    if (terminalEvents.has(spec.name)) return { status: 'matched', event: spec.name, value: lastValue };
+                }
+            }
+        } else if (parsed.status === 'parse_error') {
+            await emit(options.onEvent, source, 'json.parse_error', { path: filePath, error: parsed.error });
+        }
+
+        await sleep(intervalMs);
+    }
+
+    await emit(options.onEvent, source, 'json.timeout', { path: filePath, value: lastValue ?? null });
+    return { status: 'timeout', value: lastValue ?? null };
+}
+
+export async function pollProcess(pattern, options = {}) {
+    const source = options.source || 'process';
+    const intervalMs = options.intervalMs ?? 250;
+    const timeoutMs = options.timeoutMs ?? 30000;
+    const matcher = makeMatcher(pattern);
+    const deadline = Date.now() + timeoutMs;
+    let seen = false;
+    let lastMatch = null;
+
+    while (Date.now() <= deadline) {
+        let processes = [];
+        try {
+            processes = await listProcesses();
+        } catch (err) {
+            await emit(options.onEvent, source, 'process.error', { error: err.message });
+        }
+        const match = processes.find((row) => row.pid !== process.pid && matcher(row.command));
+
+        if (match && !seen) {
+            seen = true;
+            lastMatch = match;
+            await emit(options.onEvent, source, 'process.seen', match);
+            if ((options.until || 'seen') === 'seen') return { status: 'seen', process: match };
+        }
+
+        if (!match && seen && (options.until || 'seen') === 'gone') {
+            await emit(options.onEvent, source, 'process.gone', lastMatch || {});
+            return { status: 'gone', process: lastMatch };
+        }
+
+        await sleep(intervalMs);
+    }
+
+    await emit(options.onEvent, source, 'process.timeout', { pattern: String(pattern), seen });
+    return { status: 'timeout', process: lastMatch };
+}
+
+export async function parseLogLines(text, patterns, onEvent, options = {}) {
+    const source = options.source || 'log';
+    const lines = String(text || '').split(/\r?\n/).filter(Boolean);
+    const emitted = [];
+
+    for (const line of lines) {
+        for (const pattern of patterns || []) {
+            const match = line.match(pattern.match || pattern.regex || pattern.pattern);
+            if (!match) continue;
+            const data = typeof pattern.data === 'function' ? pattern.data(match, line) : { line };
+            const event = pattern.event || pattern.name;
+            emitted.push(await emit(onEvent, pattern.source || source, event, data));
+            if (pattern.once) break;
+        }
+    }
+
+    return emitted;
+}
+
+export function installConsoleBridge(page, options = {}) {
+    const prefix = options.prefix || 'trace:';
+    const source = options.source || 'browser';
+    const handler = async (message) => {
+        const text = typeof message.text === 'function' ? message.text() : String(message);
+        if (!text.startsWith(prefix)) return;
+        const raw = text.slice(prefix.length).trim();
+        let data = { message: raw };
+        try {
+            const parsed = JSON.parse(raw);
+            data = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : { value: parsed };
+        } catch {
+            // Plain console messages are valid bridge payloads.
+        }
+        await emit(options.onEvent, source, options.event || 'console.bridge', data);
+    };
+
+    if (typeof page.on !== 'function') throw new Error('installConsoleBridge requires a page-like object with on(event, handler)');
+    page.on('console', handler);
+    return handler;
+}
+
+async function emit(onEvent, source, event, data = {}) {
+    if (!onEvent) return { source, event, data };
+    const normalized = data && typeof data === 'object' && !Array.isArray(data) ? data : { value: data };
+    return await onEvent(source, event, normalized);
+}
+
+function normalizeReadyStatus(value) {
+    if (Array.isArray(value) && value.length === 2 && value.every((item) => Number.isFinite(Number(item)))) {
+        return { min: Number(value[0]), max: Number(value[1]) };
+    }
+    if (Array.isArray(value)) return new Set(value.map(Number));
+    return new Set([Number(value)]);
+}
+
+function isReadyStatus(status, readyStatus) {
+    if (readyStatus instanceof Set) return readyStatus.has(status);
+    return status >= readyStatus.min && status <= readyStatus.max;
+}
+
+function httpStatus(url, timeoutMs) {
+    return new Promise((resolve) => {
+        const parsed = new URL(url);
+        const transport = parsed.protocol === 'https:' ? httpsRequest : httpRequest;
+        const req = transport(parsed, { method: 'GET', timeout: timeoutMs }, (res) => {
+            res.resume();
+            res.on('end', () => resolve({ ok: true, status: res.statusCode || 0 }));
+        });
+        req.on('timeout', () => {
+            req.destroy(new Error(`request timed out after ${timeoutMs}ms`));
+        });
+        req.on('error', (err) => resolve({ ok: false, error: err.message }));
+        req.end();
+    });
+}
+
+async function readJsonIfAvailable(filePath) {
+    try {
+        const text = await readFile(filePath, 'utf8');
+        return { status: 'ok', json: JSON.parse(text) };
+    } catch (err) {
+        if (err.code === 'ENOENT') return { status: 'missing' };
+        if (err instanceof SyntaxError) return { status: 'parse_error', error: err.message };
+        return { status: 'error', error: err.message };
+    }
+}
+
+async function listProcesses() {
+    const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,etime=,args='], { maxBuffer: 1024 * 1024 });
+    return stdout.split(/\r?\n/).filter(Boolean).map(parsePsLine).filter(Boolean);
+}
+
+function parsePsLine(line) {
+    const match = line.trim().match(/^(\d+)\s+(\S+)\s+(.+)$/);
+    if (!match) return null;
+    return { pid: Number(match[1]), elapsed: match[2], command: match[3] };
+}
+
+function makeMatcher(pattern) {
+    if (pattern instanceof RegExp) {
+        return (value) => {
+            pattern.lastIndex = 0;
+            return pattern.test(value);
+        };
+    }
+    return (value) => value.includes(String(pattern));
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/nodejs/scripts/trace/nodejs-trace-runner-smoke.sh
+++ b/nodejs/scripts/trace/nodejs-trace-runner-smoke.sh
@@ -135,7 +135,18 @@ if (data.status !== "pass") throw new Error("helper scenario should pass");
 if (data.summary !== "helper scenario passed") throw new Error("helper summary missing");
 if (!data.timeline.find((event) => event.event === "process.launch")) throw new Error("process launch event missing");
 if (!data.timeline.find((event) => event.event === "process.tree.captured")) throw new Error("process tree event missing");
+if (!data.timeline.find((event) => event.event === "json.parse_error")) throw new Error("json parse error event missing");
+if (!data.timeline.find((event) => event.event === "json.port_known" && event.data.port === 9876)) throw new Error("json port event missing");
+if (!data.timeline.find((event) => event.event === "http.first_response" && event.data.status === 502)) throw new Error("http first response event missing");
+if (!data.timeline.find((event) => event.event === "http.ready" && event.data.status === 200)) throw new Error("http ready event missing");
+if (!data.timeline.find((event) => event.event === "process.seen")) throw new Error("process seen event missing");
+if (!data.timeline.find((event) => event.event === "log.port_known" && event.data.port === 1234)) throw new Error("log parse event missing");
+if (!data.timeline.find((event) => event.event === "console.bridge" && event.data.event === "bridge-ok")) throw new Error("console bridge event missing");
 if (!data.assertions.find((assertion) => assertion.id === "dummy-process-exited" && assertion.status === "pass")) throw new Error("process assertion missing");
+if (!data.assertions.find((assertion) => assertion.id === "json-poll-port-known" && assertion.status === "pass")) throw new Error("json poll assertion missing");
+if (!data.assertions.find((assertion) => assertion.id === "http-poll-ready" && assertion.status === "pass")) throw new Error("http poll assertion missing");
+if (!data.assertions.find((assertion) => assertion.id === "process-poll-seen" && assertion.status === "pass")) throw new Error("process poll assertion missing");
+if (!data.assertions.find((assertion) => assertion.id === "observation-window-resolved" && assertion.status === "pass")) throw new Error("observation window assertion missing");
 if (!data.artifacts.find((artifact) => artifact.path === "process-tree.txt")) throw new Error("process tree artifact missing from envelope");
 if (!data.artifacts.find((artifact) => artifact.path === "trace.jsonl")) throw new Error("timeline artifact missing from envelope");
 '


### PR DESCRIPTION
## Summary
- Add reusable app-agnostic Node.js trace probe helpers for HTTP readiness, JSON file polling, process polling, log parsing, console bridging, and bounded observation windows.

## Changes
- Introduces `nodejs/scripts/trace/lib/probes.mjs` as a small composable helper module for rig-owned trace workloads.
- Documents trace helper imports and usage in `nodejs/scripts/trace/README.md`.
- Expands the existing helper trace fixture and runner smoke to validate probe events through the normal trace runner envelope.

## Tests
- `bash nodejs/scripts/trace/nodejs-trace-runner-smoke.sh`
- `bash -n nodejs/scripts/trace/trace-runner.sh`
- `node --check nodejs/scripts/trace/lib/probes.mjs && node --check nodejs/scripts/trace/fixtures/helper.trace.mjs`
- `git diff --check`
- `homeboy test nodejs --path /Users/chubes/Developer/homeboy-extensions@feat-trace-probe-helpers/nodejs` *(blocked: Homeboy reports component `nodejs` has no extensions configured)*
- `homeboy lint nodejs --path /Users/chubes/Developer/homeboy-extensions@feat-trace-probe-helpers/nodejs` *(blocked: Homeboy reports component `nodejs` has no extensions configured)*

Closes #385
Closes #383
Closes #384

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented trace probe helpers, tests, and PR drafting. Chris remains responsible for review and merge.
