### PR TITLE
Run Composer tests when WordPress PHPUnit discovery is empty

### DIFF
--- a/wordpress/scripts/test/playground-no-test-files-smoke.sh
+++ b/wordpress/scripts/test/playground-no-test-files-smoke.sh
@@ -8,6 +8,9 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 EXTENSION_PATH="${TMPDIR}/extension"
 PLUGIN_PATH="${TMPDIR}/component"
+BIN_PATH="${TMPDIR}/bin"
+mkdir -p "${BIN_PATH}"
+export PATH="${BIN_PATH}:${PATH}"
 mkdir -p "${EXTENSION_PATH}/node_modules/.bin" "${PLUGIN_PATH}/tests"
 
 RUNNER_SRC="$(cat "${SCRIPT_DIR}/playground-runner.php")"
@@ -25,6 +28,14 @@ LOG
 exit 1
 SH
 chmod +x "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli"
+
+cat > "${BIN_PATH}/composer" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "composer:$PWD:$*" >> "${HOMEBOY_COMPOSER_CALLS_FILE}"
+echo "Composer smoke script ran"
+SH
+chmod +x "${BIN_PATH}/composer"
 
 assert_contains() {
     local haystack="$1"
@@ -63,6 +74,31 @@ assert_contains "$skip_output" "Skipping PHPUnit tests: no files matched the Wor
 assert_contains "$skip_output" "ending in Test.php or starting with test-."
 assert_not_contains "$skip_output" "UNCLASSIFIED PLAYGROUND FAILURE"
 
+cat > "${PLUGIN_PATH}/composer.json" <<'JSON'
+{
+  "scripts": {
+    "test": "php tests/smoke.php"
+  }
+}
+JSON
+COMPOSER_CALLS_FILE="${TMPDIR}/composer-calls.log"
+set +e
+composer_output=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" HOMEBOY_COMPONENT_ID="example" HOMEBOY_COMPOSER_CALLS_FILE="$COMPOSER_CALLS_FILE" bash "$RUNNER" 2>&1)
+composer_status=$?
+set -e
+
+if [ "$composer_status" -ne 0 ]; then
+    echo "Expected no-files run with composer scripts.test to run composer and pass; got $composer_status" >&2
+    echo "$composer_output" >&2
+    exit 1
+fi
+assert_contains "$composer_output" "NO PHPUNIT TEST FILES DISCOVERED"
+assert_contains "$composer_output" "Running Composer test script..."
+assert_contains "$composer_output" "Backend: composer-script"
+assert_contains "$composer_output" "Composer smoke script ran"
+assert_contains "$(cat "$COMPOSER_CALLS_FILE")" "composer:${PLUGIN_PATH}:test"
+rm -f "${PLUGIN_PATH}/composer.json"
+
 touch "${PLUGIN_PATH}/phpunit.xml.dist"
 set +e
 failure_output=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" HOMEBOY_COMPONENT_ID="example" bash "$RUNNER" 2>&1)
@@ -100,4 +136,4 @@ assert_not_contains "$RUNNER_SRC" "wp_abilities_api_categories_init"
 assert_not_contains "$RUNNER_SRC" "WP_Abilities_Registry::get_instance()"
 assert_contains "$BOOTSTRAP_SRC" "\$cfg['activate'] ?? true"
 
-echo "Playground no-test-files smoke passed (28 assertions)"
+echo "Playground no-test-files smoke passed (34 assertions)"

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -117,8 +117,41 @@ if [ ! -f "$PLAYGROUND_CLI" ]; then
     exit 1
 fi
 
+component_has_composer_test_script() {
+    [ -f "${PLUGIN_PATH}/composer.json" ] || return 1
+
+    php -r '
+        $composer = json_decode(file_get_contents($argv[1]), true);
+        exit(is_array($composer) && isset($composer["scripts"]["test"]) ? 0 : 1);
+    ' "${PLUGIN_PATH}/composer.json" 2>/dev/null
+}
+
+run_composer_test_script() {
+    echo ""
+    echo "Running Composer test script..."
+    echo "  Plugin: ${PLUGIN_SLUG} (${PLUGIN_PATH})"
+    echo "  Backend: composer-script"
+
+    if ! command -v composer >/dev/null 2>&1; then
+        echo "ERROR: composer.json declares scripts.test, but composer is not available on PATH." >&2
+        FAILED_STEP="Composer test script setup"
+        return 1
+    fi
+
+    if [ "${#PASSTHROUGH_ARGS[@]}" -gt 0 ]; then
+        ( cd "${PLUGIN_PATH}" && composer test -- "${PASSTHROUGH_ARGS[@]}" )
+    else
+        ( cd "${PLUGIN_PATH}" && composer test )
+    fi
+}
+
 TEST_DIR="${PLUGIN_PATH}/tests"
 if [ ! -d "$TEST_DIR" ]; then
+    if component_has_composer_test_script; then
+        run_composer_test_script
+        exit $?
+    fi
+
     echo ""
     echo "⚠ Warning: No tests directory found at ${TEST_DIR}"
     echo "  Skipping PHPUnit tests."
@@ -446,6 +479,12 @@ fi
 # discovery cannot become a false green.
 if echo "$PHPUNIT_OUTPUT" | grep -q "^NO_TEST_FILES"; then
     dump_diagnostics "NO PHPUNIT TEST FILES DISCOVERED"
+    if component_has_composer_test_script; then
+        rm -f "$RESULT_FILE"
+        run_composer_test_script
+        exit $?
+    fi
+
     if [ -f "${PLUGIN_PATH}/phpunit.xml" ] || [ -f "${PLUGIN_PATH}/phpunit.xml.dist" ]; then
         echo ""
         echo "PHPUnit config exists, but no files matched the WordPress runner discovery contract."


### PR DESCRIPTION
## Summary

- Add a WordPress Playground test-runner fallback for components that declare `composer.json` `scripts.test` but have no PHPUnit-discoverable files.
- Keep the existing PHPUnit path unchanged when PHPUnit files are discovered.
- Cover the fallback in the no-test-files smoke test.

## Why

Small WordPress plugin/substrate repos can have a valid pure-PHP smoke-test contract without adopting PHPUnit file naming. Homeboy should run that explicit Composer test contract instead of reporting a successful no-op after PHPUnit discovery finds nothing.

Fixes https://github.com/Extra-Chill/homeboy/issues/2051

## Verification

- `bash wordpress/scripts/test/playground-no-test-files-smoke.sh`
- Temporarily linked this worktree as the local `wordpress` extension and ran `homeboy test --path /Users/chubes/Developer/agents-api@chore-homeboy-ci`; the runner detected empty PHPUnit discovery, switched to `Backend: composer-script`, and executed the existing Agents API smoke suite successfully.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the WordPress runner fallback, adding smoke-test coverage, and running local validation. Chris remains responsible for review and merge.
