### PR TITLE
Enrich WordPress lint findings sidecar

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -43,3 +43,26 @@ Each dependency entry may be either:
 
 - a registered Homeboy component ID
 - an absolute path to another local plugin checkout
+
+## Lint findings sidecar
+
+When `HOMEBOY_LINT_FINDINGS_FILE` is set, the WordPress lint runner writes a
+JSON array of lint finding records for Homeboy baseline and observation storage.
+PHPCS, ESLint, and PHPStan findings are merged into the same sidecar.
+
+The sidecar contract is version 1. Records preserve the original minimal fields
+(`id`, `message`, `category`, and `fixable` when known) and include normalized
+fields where each tool reports them:
+
+- `id` — stable finding identity using `file::code::line`.
+- `file` — component-relative path when the file is inside the component.
+- `line` / `column` — 1-based location when reported by the linter.
+- `severity` — normalized `error` or `warning`.
+- `source` — linter name, such as `phpcs`, `eslint`, or `phpstan`.
+- `code` — tool-specific rule, sniff, or identifier.
+- `category` — broad grouping used by Homeboy reports.
+- `message` — human-readable linter message, including the tool code.
+- `fixable` — whether the linter reports an automatic fix for the finding.
+- `fingerprint` — stable SHA-1 hash of the finding `id`.
+- `excerpt` — source line text when the file is readable locally; otherwise
+  `null`.

--- a/tests/wordpress-eslint-scope-smoke.sh
+++ b/tests/wordpress-eslint-scope-smoke.sh
@@ -32,6 +32,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 COMPONENT_DIR="$TMP_DIR/example-plugin"
 FAKE_EXTENSION="$TMP_DIR/fake-wordpress-extension"
 ESLINT_ARGS_FILE="$TMP_DIR/eslint-args.txt"
+FINDINGS_FILE="$TMP_DIR/eslint-findings.json"
 
 mkdir -p "$COMPONENT_DIR/inc" "$COMPONENT_DIR/assets" "$COMPONENT_DIR/docs" "$FAKE_EXTENSION/node_modules/.bin"
 
@@ -70,6 +71,12 @@ cat > "$FAKE_EXTENSION/node_modules/.bin/eslint" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "$ESLINT_ARGS_FILE"
 for arg in "$@"; do
+    if [ "$arg" = "--format" ]; then
+        printf '[{"filePath":"%s/assets/bad.js","errorCount":1,"warningCount":0,"fixableErrorCount":1,"fixableWarningCount":0,"messages":[{"ruleId":"no-undef","severity":2,"message":"bad is not defined","line":1,"column":7,"fix":{"range":[0,3],"text":"good"}}]}]\n' "$ESLINT_COMPONENT_DIR"
+        exit 1
+    fi
+done
+for arg in "$@"; do
     case "$arg" in
         */assets/bad.js|assets/bad.js)
             echo "simulated eslint failure" >&2
@@ -84,6 +91,7 @@ HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
 ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
+ESLINT_COMPONENT_DIR="$COMPONENT_DIR" \
 HOMEBOY_LINT_FILE='docs/example.md' \
     bash "$RUNNER" > "$TMP_DIR/single-md.out" 2>&1
 
@@ -97,6 +105,7 @@ HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
 ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
+ESLINT_COMPONENT_DIR="$COMPONENT_DIR" \
 HOMEBOY_LINT_GLOB='{example-plugin.php,inc/runtime.php}' \
     bash "$RUNNER" > "$TMP_DIR/php-only.out" 2>&1
 
@@ -111,6 +120,7 @@ HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
 ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
+ESLINT_COMPONENT_DIR="$COMPONENT_DIR" \
 HOMEBOY_LINT_GLOB='{example-plugin.php,assets/admin.js,inc/runtime.php,assets/view.ts}' \
     bash "$RUNNER" > "$TMP_DIR/mixed.out" 2>&1
 
@@ -126,6 +136,7 @@ HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
 ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
+ESLINT_COMPONENT_DIR="$COMPONENT_DIR" \
 HOMEBOY_LINT_FILE='assets/admin.js' \
     bash "$RUNNER" > "$TMP_DIR/js-success.out" 2>&1
 
@@ -142,6 +153,8 @@ HOMEBOY_EXTENSION_PATH="$FAKE_EXTENSION" \
 HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
 HOMEBOY_COMPONENT_ID="example-plugin" \
 ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
+ESLINT_COMPONENT_DIR="$COMPONENT_DIR" \
+HOMEBOY_LINT_FINDINGS_FILE="$FINDINGS_FILE" \
 HOMEBOY_LINT_FILE='assets/bad.js' \
     bash "$RUNNER" > "$TMP_DIR/js-failure.out" 2>&1
 failure_status=$?
@@ -156,5 +169,28 @@ fi
 assert_contains "$TMP_DIR/js-failure.out" "Linting single file: assets/bad.js"
 assert_contains "$TMP_DIR/js-failure.out" "ESLint linting failed"
 assert_contains "$ESLINT_ARGS_FILE" "assets/bad.js"
+
+python3 - "$FINDINGS_FILE" <<'PY'
+import json
+import sys
+
+findings = json.load(open(sys.argv[1], encoding="utf-8"))
+assert len(findings) == 1, findings
+finding = findings[0]
+expected = {
+    "file": "assets/bad.js",
+    "line": 1,
+    "column": 7,
+    "severity": "error",
+    "source": "eslint",
+    "code": "eslint.no-undef",
+    "category": "eslint",
+    "fixable": True,
+    "excerpt": "const bad = true;",
+}
+for key, value in expected.items():
+    assert finding.get(key) == value, (key, finding)
+assert finding.get("fingerprint"), finding
+PY
 
 echo "wordpress eslint scope smoke passed"

--- a/wordpress/scripts/lint/autofixable-exit-smoke.sh
+++ b/wordpress/scripts/lint/autofixable-exit-smoke.sh
@@ -37,9 +37,7 @@ done
 
 for arg in "$@"; do
     if [ "$arg" = "--report=json" ]; then
-        cat <<'JSON'
-{"totals":{"errors":0,"warnings":1,"fixable":1},"files":{"/tmp/component/plugin.php":{"errors":0,"warnings":1,"messages":[{"message":"Equals sign not aligned with surrounding assignments","source":"Generic.Formatting.MultipleStatementAlignment.NotSameWarning","severity":5,"fixable":true,"type":"WARNING","line":8,"column":7}]}}}
-JSON
+        printf '{"totals":{"errors":0,"warnings":1,"fixable":1},"files":{"%s":{"errors":0,"warnings":1,"messages":[{"message":"Equals sign not aligned with surrounding assignments","source":"Generic.Formatting.MultipleStatementAlignment.NotSameWarning","severity":5,"fixable":true,"type":"WARNING","line":8,"column":7}]}}}\n' "${COMPONENT_PATH}/plugin.php"
         exit 1
     fi
 done
@@ -101,6 +99,29 @@ run_lint() {
         [ -f "$FINDINGS_FILE" ] && sed 's/^/  /' "$FINDINGS_FILE" >&2
         exit 1
     fi
+
+    python3 - "$FINDINGS_FILE" <<'PY'
+import json
+import sys
+
+findings = json.load(open(sys.argv[1], encoding="utf-8"))
+assert len(findings) == 1, findings
+finding = findings[0]
+expected = {
+    "file": "plugin.php",
+    "line": 8,
+    "column": 7,
+    "severity": "warning",
+    "source": "phpcs",
+    "code": "Generic.Formatting.MultipleStatementAlignment.NotSameWarning",
+    "category": "formatting",
+    "fixable": True,
+}
+for key, value in expected.items():
+    assert finding.get(key) == value, (key, finding)
+assert finding.get("fingerprint"), finding
+assert finding.get("excerpt") == "$beta = 2;", finding
+PY
 }
 
 run_lint 1

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -171,6 +171,63 @@ json_output=$("$ESLINT_BIN" "${eslint_base_args[@]}" --format json "${LINT_FILES
 json_exit=$?
 set -e
 
+# Write ESLint lint findings sidecar for homeboy baseline and drill-down.
+# The top-level lint runner passes a temp file here, then merges it with PHPCS
+# and PHPStan findings. Direct ESLint runs may write HOMEBOY_LINT_FINDINGS_FILE.
+ESLINT_FINDINGS_FILE="${_HOMEBOY_ESLINT_FINDINGS_FILE:-${HOMEBOY_LINT_FINDINGS_FILE:-}}"
+if [ -n "$ESLINT_FINDINGS_FILE" ] && [ -n "$json_output" ] && command -v node &> /dev/null; then
+    node -e '
+        const fs = require("fs");
+        const path = require("path");
+
+        const data = JSON.parse(process.argv[1]);
+        const componentPath = process.argv[2] || "";
+        const outputFile = process.argv[3];
+        const readExcerpt = (filePath, line) => {
+            if (!filePath || !line) return null;
+            try {
+                return fs.readFileSync(filePath, "utf8").split(/\r?\n/)[line - 1] ?? null;
+            } catch (_) {
+                return null;
+            }
+        };
+        const relPath = (filePath) => {
+            if (componentPath && filePath.startsWith(componentPath)) {
+                return filePath.slice(componentPath.length).replace(/^\/+/, "");
+            }
+            return filePath;
+        };
+        const findings = [];
+        for (const file of data) {
+            const filePath = file.filePath || "";
+            const fileRelPath = relPath(filePath);
+            for (const msg of file.messages || []) {
+                const rule = msg.ruleId || "unknown";
+                const code = `eslint.${rule}`;
+                const line = msg.line || 0;
+                const column = msg.column ?? null;
+                const id = `${fileRelPath}::${code}::${line}`;
+                const message = `${msg.message || "Unknown"} (${code})`;
+                findings.push({
+                    id,
+                    file: fileRelPath,
+                    line,
+                    column,
+                    severity: msg.severity === 1 ? "warning" : "error",
+                    source: "eslint",
+                    code,
+                    category: "eslint",
+                    message,
+                    fixable: Boolean(msg.fix),
+                    fingerprint: require("crypto").createHash("sha1").update(id).digest("hex"),
+                    excerpt: readExcerpt(filePath, line),
+                });
+            }
+        }
+        fs.writeFileSync(outputFile, JSON.stringify(findings) + "\n");
+    ' "$json_output" "$PLUGIN_PATH" "$ESLINT_FINDINGS_FILE" 2>/dev/null || true
+fi
+
 # Parse JSON and print summary header (only if issues exist)
 if [ -n "$json_output" ] && command -v node &> /dev/null; then
     summary=$(node -e '

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -762,33 +762,61 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
                 "PHPCompatibility" => "compatibility",
             ];
             $findings = [];
+            $readExcerpt = static function ($path, $line) {
+                if (!$path || !$line || !is_readable($path)) {
+                    return null;
+                }
+
+                $lines = @file($path, FILE_IGNORE_NEW_LINES);
+                return $lines[$line - 1] ?? null;
+            };
             foreach ($json["files"] as $filePath => $data) {
                 $relPath = $filePath;
                 if ($componentPath && strpos($filePath, $componentPath) === 0) {
                     $relPath = ltrim(substr($filePath, strlen($componentPath)), "/");
                 }
                 foreach ($data["messages"] ?? [] as $msg) {
-                    $source = $msg["source"] ?? "unknown";
+                    $code = $msg["source"] ?? "unknown";
                     $line = $msg["line"] ?? 0;
+                    $column = $msg["column"] ?? null;
+                    $id = $relPath . "::" . $code . "::" . $line;
+                    $message = ($msg["message"] ?? "Unknown") . " (" . $code . ")";
                     // Derive category from source namespace
                     $category = "other";
                     foreach ($categoryMap as $prefix => $cat) {
-                        if (strpos($source, $prefix) === 0) {
+                        if (strpos($code, $prefix) === 0) {
                             $category = $cat;
                             break;
                         }
                     }
                     $findings[] = [
-                        "id" => $relPath . "::" . $source . "::" . $line,
-                        "message" => ($msg["message"] ?? "Unknown") . " (" . $source . ")",
+                        "id" => $id,
+                        "file" => $relPath,
+                        "line" => $line,
+                        "column" => $column,
+                        "severity" => strtolower($msg["type"] ?? "error"),
+                        "source" => "phpcs",
+                        "code" => $code,
                         "category" => $category,
+                        "message" => $message,
                         "fixable" => (bool) ($msg["fixable"] ?? false),
+                        "fingerprint" => sha1($id),
+                        "excerpt" => $readExcerpt($filePath, $line),
                     ];
                 }
             }
             file_put_contents($argv[2], json_encode($findings, JSON_UNESCAPED_SLASHES) . "\n");
         ' "$PLUGIN_PATH" "${HOMEBOY_LINT_FINDINGS_FILE}" 2>/dev/null || true
     fi
+fi
+
+# Create temp files for per-tool findings before ESLint/PHPStan run. PHPCS writes
+# directly to HOMEBOY_LINT_FINDINGS_FILE; the other tools are merged later.
+_ESLINT_FINDINGS_TMPFILE=""
+_PHPSTAN_FINDINGS_TMPFILE=""
+if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
+    _ESLINT_FINDINGS_TMPFILE=$(homeboy_mktemp 'eslint-findings.XXXXXX')
+    _PHPSTAN_FINDINGS_TMPFILE=$(homeboy_mktemp 'phpstan-findings.XXXXXX')
 fi
 
 # Summary mode: show summary header + top violations, skip full report
@@ -850,7 +878,8 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
     elif [ -f "$ESLINT_RUNNER" ]; then
         echo ""
         set +e
-        bash "$ESLINT_RUNNER"
+        _HOMEBOY_ESLINT_FINDINGS_FILE="${_ESLINT_FINDINGS_TMPFILE:-}" \
+            bash "$ESLINT_RUNNER"
         ESLINT_EXIT=$?
         set -e
 
@@ -890,20 +919,18 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
         return 0
     }
 
-    # Create temp file for PHPStan findings if baseline sidecar is active
-    _PHPSTAN_FINDINGS_TMPFILE=""
-    if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
-        _PHPSTAN_FINDINGS_TMPFILE=$(homeboy_mktemp 'phpstan-findings.XXXXXX')
-    fi
-
     # Run PHPStan after PHPCS/ESLint so the caller gets the full lint signal
     # before the aggregate exit code is computed.
     PHPSTAN_PASSED=1
     run_phpstan_summary || PHPSTAN_PASSED=0
 
-    # Merge PHPCS + PHPStan findings into the final baseline sidecar.
-    # PHPCS writes directly to HOMEBOY_LINT_FINDINGS_FILE; PHPStan writes
-    # to the temp file. Merge both so the identity-based ratchet sees all errors.
+    # Merge PHPCS + ESLint + PHPStan findings into the final baseline sidecar.
+    # PHPCS writes directly to HOMEBOY_LINT_FINDINGS_FILE; other tools write
+    # to temp files. Merge all so the identity-based ratchet sees all errors.
+    if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ] && [ -n "$_ESLINT_FINDINGS_TMPFILE" ] && [ -f "$_ESLINT_FINDINGS_TMPFILE" ]; then
+        merge_findings_into_sidecar "$_ESLINT_FINDINGS_TMPFILE"
+        rm -f "$_ESLINT_FINDINGS_TMPFILE"
+    fi
     if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ] && [ -n "$_PHPSTAN_FINDINGS_TMPFILE" ] && [ -f "$_PHPSTAN_FINDINGS_TMPFILE" ]; then
         merge_findings_into_sidecar "$_PHPSTAN_FINDINGS_TMPFILE"
         rm -f "$_PHPSTAN_FINDINGS_TMPFILE"
@@ -943,7 +970,8 @@ if ! should_run_step "eslint"; then
 elif [ -f "$ESLINT_RUNNER" ]; then
     echo ""
     set +e
-    bash "$ESLINT_RUNNER"
+    _HOMEBOY_ESLINT_FINDINGS_FILE="${_ESLINT_FINDINGS_TMPFILE:-}" \
+        bash "$ESLINT_RUNNER"
     ESLINT_EXIT=$?
     set -e
 
@@ -984,18 +1012,16 @@ run_phpstan() {
     return 0
 }
 
-# Create temp file for PHPStan findings if baseline sidecar is active
-_PHPSTAN_FINDINGS_TMPFILE=""
-if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
-    _PHPSTAN_FINDINGS_TMPFILE=$(homeboy_mktemp 'phpstan-findings.XXXXXX')
-fi
-
 # Run PHPStan after PHPCS/ESLint so the caller gets the full lint signal
 # before the aggregate exit code is computed.
 PHPSTAN_PASSED=1
 run_phpstan || PHPSTAN_PASSED=0
 
-# Merge PHPCS + PHPStan findings into the final baseline sidecar
+# Merge PHPCS + ESLint + PHPStan findings into the final baseline sidecar
+if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ] && [ -n "$_ESLINT_FINDINGS_TMPFILE" ] && [ -f "$_ESLINT_FINDINGS_TMPFILE" ]; then
+    merge_findings_into_sidecar "$_ESLINT_FINDINGS_TMPFILE"
+    rm -f "$_ESLINT_FINDINGS_TMPFILE"
+fi
 if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ] && [ -n "$_PHPSTAN_FINDINGS_TMPFILE" ] && [ -f "$_PHPSTAN_FINDINGS_TMPFILE" ]; then
     merge_findings_into_sidecar "$_PHPSTAN_FINDINGS_TMPFILE"
     rm -f "$_PHPSTAN_FINDINGS_TMPFILE"

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -849,6 +849,14 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
             }
             $componentPath = $argv[1] ?? "";
             $findings = [];
+            $readExcerpt = static function ($path, $line) {
+                if (!$path || !$line || !is_readable($path)) {
+                    return null;
+                }
+
+                $lines = @file($path, FILE_IGNORE_NEW_LINES);
+                return $lines[$line - 1] ?? null;
+            };
             foreach ($json["files"] as $filePath => $data) {
                 $relPath = $filePath;
                 if ($componentPath && strpos($filePath, $componentPath) === 0) {
@@ -857,11 +865,22 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
                 foreach ($data["messages"] ?? [] as $msg) {
                     $identifier = $msg["identifier"] ?? "unknown";
                     $line = $msg["line"] ?? 0;
-                    $message = $msg["message"] ?? "Unknown";
+                    $code = "phpstan." . $identifier;
+                    $id = $relPath . "::" . $code . "::" . $line;
+                    $message = ($msg["message"] ?? "Unknown") . " (" . $code . ")";
                     $findings[] = [
-                        "id" => $relPath . "::phpstan." . $identifier . "::" . $line,
-                        "message" => $message . " (phpstan." . $identifier . ")",
+                        "id" => $id,
+                        "file" => $relPath,
+                        "line" => $line,
+                        "column" => null,
+                        "severity" => "error",
+                        "source" => "phpstan",
+                        "code" => $code,
                         "category" => "phpstan",
+                        "message" => $message,
+                        "fixable" => false,
+                        "fingerprint" => sha1($id),
+                        "excerpt" => $readExcerpt($filePath, $line),
                     ];
                 }
             }

--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -14,10 +14,12 @@ DEPENDENCY_HELPER="${TMPDIR}/validation-dependencies.sh"
 CONFIG_CAPTURE="${TMPDIR}/phpstan-config-capture.neon"
 AUTOLOAD_CAPTURE="${TMPDIR}/phpstan-autoload-capture.php"
 OUTPUT_FILE="${TMPDIR}/phpstan-output.txt"
+FINDINGS_FILE="${TMPDIR}/phpstan-findings.json"
 
 mkdir -p "${EXTENSION_DIR}/vendor/bin" "${COMPONENT_DIR}/tests" "${COMPONENT_DIR}/assets" "${COMPONENT_DIR}/includes" "${COMPONENT_DIR}/vendor_prefixed"
 touch "${EXTENSION_DIR}/phpstan.neon.dist"
-touch "${COMPONENT_DIR}/main.php" "${COMPONENT_DIR}/tests/FooTest.php" "${COMPONENT_DIR}/assets/app.js"
+printf '%s\n' '<?php missing_function();' > "${COMPONENT_DIR}/main.php"
+touch "${COMPONENT_DIR}/tests/FooTest.php" "${COMPONENT_DIR}/assets/app.js"
 touch "${COMPONENT_DIR}/includes/interface-example.php" "${COMPONENT_DIR}/includes/extra.php" "${COMPONENT_DIR}/vendor_prefixed/autoload.php"
 
 cat > "$DEPENDENCY_HELPER" <<'SH'
@@ -40,6 +42,10 @@ count=0
 [ -f "${PHPSTAN_CALLS_FILE}" ] && count=$(cat "${PHPSTAN_CALLS_FILE}")
 count=$((count + 1))
 printf '%s\n' "$count" > "${PHPSTAN_CALLS_FILE}"
+if [ "${PHPSTAN_EMIT_ERROR:-}" = "1" ]; then
+    printf '{"totals":{"errors":1,"file_errors":1},"files":{"%s/main.php":{"errors":1,"messages":[{"message":"Call to an undefined function missing_function().","line":1,"identifier":"function.notFound"}]}}}\n' "${HOMEBOY_COMPONENT_PATH}"
+    exit 1
+fi
 printf '%s\n' '{"totals":{"errors":0,"file_errors":0},"files":{}}'
 SH
 chmod +x "${EXTENSION_DIR}/vendor/bin/phpstan"
@@ -154,5 +160,52 @@ if [ "$(cat "$CALLS_FILE")" != "0" ]; then
     echo "FAIL: non-PHP single-file scope should skip PHPStan" >&2
     exit 1
 fi
+
+: > "$ARGS_FILE"
+printf '0\n' > "$CALLS_FILE"
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="phpstan-smoke" \
+HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+PHPSTAN_ARGS_FILE="$ARGS_FILE" \
+PHPSTAN_CALLS_FILE="$CALLS_FILE" \
+PHPSTAN_CONFIG_CAPTURE="$CONFIG_CAPTURE" \
+PHPSTAN_AUTOLOAD_CAPTURE="$AUTOLOAD_CAPTURE" \
+PHPSTAN_EMIT_ERROR=1 \
+_HOMEBOY_PHPSTAN_FINDINGS_FILE="$FINDINGS_FILE" \
+HOMEBOY_SUMMARY_MODE=1 \
+"$RUNNER" >"$OUTPUT_FILE"
+phpstan_error_status=$?
+set -e
+
+if [ "$phpstan_error_status" -eq 0 ]; then
+    echo "FAIL: PHPStan error fixture should fail" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+python3 - "$FINDINGS_FILE" <<'PY'
+import json
+import sys
+
+findings = json.load(open(sys.argv[1], encoding="utf-8"))
+assert len(findings) == 1, findings
+finding = findings[0]
+expected = {
+    "file": "main.php",
+    "line": 1,
+    "column": None,
+    "severity": "error",
+    "source": "phpstan",
+    "code": "phpstan.function.notFound",
+    "category": "phpstan",
+    "fixable": False,
+    "excerpt": "<?php missing_function();",
+}
+for key, value in expected.items():
+    assert finding.get(key) == value, (key, finding)
+assert finding.get("fingerprint"), finding
+PY
 
 echo "PHPStan scoped lint smoke passed"


### PR DESCRIPTION
## Summary
- Enrich the WordPress lint sidecar records for PHPCS and PHPStan with normalized location, severity, source/code, fingerprint, and excerpt fields while preserving existing minimal keys.
- Add ESLint findings sidecar output and merge it with PHPCS/PHPStan findings in the WordPress lint runner.
- Document the WordPress lint sidecar v1 contract and extend smoke coverage for PHPCS, ESLint, and PHPStan normalized fields.

## Tests
- `bash wordpress/scripts/lint/autofixable-exit-smoke.sh`
- `bash tests/wordpress-eslint-scope-smoke.sh`
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `bash wordpress/scripts/lint/eslint-glob-filter-smoke.sh`
- `bash tests/wordpress-lint-context-smoke.sh`
- `bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- `bash wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh`
- `bash -n wordpress/scripts/lint/lint-runner.sh`
- `bash -n wordpress/scripts/lint/eslint-runner.sh`
- `bash -n wordpress/scripts/lint/phpstan-runner.sh`
- `bash -n tests/wordpress-eslint-scope-smoke.sh wordpress/scripts/lint/autofixable-exit-smoke.sh wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `git diff --check`

## Notes
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@lint-sidecar-contract` and `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@lint-sidecar-contract` were attempted, but this monorepo component has no Homeboy extensions configured, so both commands fail at component validation before running checks.

## Follow-up
- Extend the same normalized sidecar contract to Node, Rust, Swift, and Go lint runners.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the WordPress lint runner sidecar implementation, documentation, and smoke test updates; Chris remains responsible for review and validation.