### PR TITLE
Normalize WordPress test failure sidecar

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -11,6 +11,37 @@ Homeboy core may pass `HOMEBOY_COMPONENT_SHAPE=core-dev` for registered componen
 
 The core-dev runner expects WordPress core's own dependencies and config. It installs missing npm/composer dependencies, builds `src/` into `build/`, and runs PHPUnit through core's `vendor/bin/phpunit`. If `wp-tests-config.php` is missing, set `HOMEBOY_WP_TESTS_DB_NAME`, `HOMEBOY_WP_TESTS_DB_USER`, `HOMEBOY_WP_TESTS_DB_PASSWORD`, and optionally `HOMEBOY_WP_TESTS_DB_HOST` so the runner can write it from the sample config.
 
+## Test failure sidecar
+
+When Homeboy sets `HOMEBOY_TEST_FAILURES_FILE`, the WordPress PHPUnit runners write a JSON sidecar with parsed failure details. Existing Homeboy analysis fields are preserved, and each failure also includes normalized sidecar fields for cross-runner consumers:
+
+```json
+{
+  "total": 4,
+  "passed": 3,
+  "failures": [
+    {
+      "test_name": "Vendor\\Package\\ExampleTest::test_example",
+      "test_file": "tests/ExampleTest.php",
+      "error_type": "AssertionFailedError",
+      "message": "Failed asserting that false is true.",
+      "source_file": "src/Example.php",
+      "source_line": 42,
+      "test_id": "Vendor\\Package\\ExampleTest::test_example",
+      "suite": "phpunit",
+      "file": "src/Example.php",
+      "line": 42,
+      "failure_type": "AssertionFailedError",
+      "fingerprint": "...",
+      "stdout_excerpt": "Vendor\\Package\\ExampleTest::test_example\nFailed asserting that false is true.",
+      "stderr_excerpt": ""
+    }
+  ]
+}
+```
+
+`file` and `line` point to the parsed source location when available, falling back to the test file and line `0`. `fingerprint` is a stable SHA-256 grouping key based on the test id, normalized location, failure type, and first message line.
+
 ## Validation dependencies
 
 Some WordPress plugins are intentionally layered on top of other local plugins.

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,11 +10,12 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh"
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh"
     ],
     "test": [
       "bash scripts/test/host-smoke-runner-smoke.sh",
       "bash scripts/test/test-runner-file-routing-smoke.sh",
+      "bash scripts/test/parse-test-failures-sidecar-smoke.sh",
       "bash scripts/test/playground-process-cleanup-smoke.sh",
       "bash scripts/test/playground-cleanup-noise-smoke.sh",
       "bash scripts/test/playground-no-test-files-smoke.sh",

--- a/wordpress/scripts/test/parse-test-failures-sidecar-smoke.sh
+++ b/wordpress/scripts/test/parse-test-failures-sidecar-smoke.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-sidecar.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PHPUNIT_OUTPUT="$TMP_DIR/phpunit-output.txt"
+FAILURES_FILE="$TMP_DIR/failures.json"
+
+cat > "$PHPUNIT_OUTPUT" <<'EOF'
+There was 1 failure:
+
+1) DataMachine\Tests\Unit\Abilities\FileAbilitiesTest::test_list_files_rejects_both_scopes
+Failed asserting that 'Flow step 8-6 not found' contains "Cannot provide both".
+
+/tmp/plugin/inc/Abilities/FileAbilities.php:94
+/tmp/plugin/tests/Unit/Abilities/FileAbilitiesTest.php:31
+
+FAILURES!
+Tests: 4, Assertions: 9, Failures: 1.
+EOF
+
+HOMEBOY_TEST_FAILURES_FILE="$FAILURES_FILE" \
+    bash "$SCRIPT_DIR/parse-test-failures.sh" "$PHPUNIT_OUTPUT" "/tmp/plugin"
+
+python3 - "$FAILURES_FILE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+assert payload["total"] == 4, payload
+assert payload["passed"] == 3, payload
+failures = payload["failures"]
+assert len(failures) == 1, failures
+failure = failures[0]
+
+expected = {
+    "test_id": "DataMachine\\Tests\\Unit\\Abilities\\FileAbilitiesTest::test_list_files_rejects_both_scopes",
+    "suite": "phpunit",
+    "file": "inc/Abilities/FileAbilities.php",
+    "line": 94,
+    "message": "Failed asserting that 'Flow step 8-6 not found' contains \"Cannot provide both\".",
+    "failure_type": "AssertionFailedError",
+}
+
+for key, value in expected.items():
+    assert failure.get(key) == value, f"{key}: {failure.get(key)!r} != {value!r}"
+
+assert failure["test_name"] == failure["test_id"]
+assert failure["error_type"] == failure["failure_type"]
+assert failure["source_file"] == failure["file"]
+assert failure["source_line"] == failure["line"]
+assert len(failure.get("fingerprint", "")) == 64
+assert "FileAbilitiesTest::test_list_files" in failure.get("stdout_excerpt", "")
+assert failure.get("stderr_excerpt") == ""
+
+print("wordpress parse-test-failures sidecar smoke passed")
+PY

--- a/wordpress/scripts/test/parse-test-failures.php
+++ b/wordpress/scripts/test/parse-test-failures.php
@@ -7,13 +7,17 @@
  * 'header' and 'body_lines' keys. This file converts them into TestFailure
  * structures matching homeboy's TestAnalysisInput schema.
  *
- * Output fields per failure:
- * - test_name: fully qualified test method name
+ * Output fields per failure preserve the legacy Homeboy analysis keys and add
+ * normalized sidecar keys consumed by cross-runner tooling:
+ * - test_name/test_id: fully qualified test method name
  * - test_file: test file path (from stack trace)
- * - error_type: exception/error class name
+ * - error_type/failure_type: exception/error class name
  * - message: error message
- * - source_file: deepest non-test frame source file
- * - source_line: source line number
+ * - source_file/source_line: deepest non-test frame source location
+ * - suite: test framework/suite label
+ * - file/line: normalized primary failure location
+ * - fingerprint: stable hash for grouping equivalent failures
+ * - stdout_excerpt/stderr_excerpt: bounded captured output excerpts
  *
  * Usage: php parse-test-failures.php <phpunit_output_file> [component_path]
  */
@@ -152,14 +156,54 @@ foreach ( $blocks as $block ) {
 		}
 	}
 
+	$file           = $source_file ?: $test_file;
+	$line           = $source_line ?: 0;
+	$stdout_excerpt = make_output_excerpt( array_merge( [ $header ], $body ) );
+	$fingerprint    = make_failure_fingerprint( $test_name, $file, $line, $error_type, $message );
+
 	$failures[] = [
-		'test_name'   => $test_name,
-		'test_file'   => $test_file,
-		'error_type'  => $error_type,
-		'message'     => $message,
-		'source_file' => $source_file,
-		'source_line' => $source_line,
+		'test_name'      => $test_name,
+		'test_file'      => $test_file,
+		'error_type'     => $error_type,
+		'message'        => $message,
+		'source_file'    => $source_file,
+		'source_line'    => $source_line,
+		'test_id'        => $test_name,
+		'suite'          => 'phpunit',
+		'file'           => $file,
+		'line'           => $line,
+		'failure_type'   => $error_type,
+		'fingerprint'    => $fingerprint,
+		'stdout_excerpt' => $stdout_excerpt,
+		'stderr_excerpt' => '',
 	];
+}
+
+/**
+ * Create a stable grouping key from the normalized failure identity.
+ */
+function make_failure_fingerprint( string $test_name, string $file, int $line, string $error_type, string $message ): string {
+	$first_message_line = strtok( $message, "\n" );
+	if ( $first_message_line === false ) {
+		$first_message_line = '';
+	}
+
+	return hash( 'sha256', implode( "\0", [ $test_name, $file, (string) $line, $error_type, $first_message_line ] ) );
+}
+
+/**
+ * Keep failure excerpts compact enough for sidecar consumers and PR comments.
+ *
+ * @param array $lines Raw output lines for one failure block.
+ */
+function make_output_excerpt( array $lines ): string {
+	$excerpt = trim( implode( "\n", array_slice( $lines, 0, 40 ) ) );
+
+	if ( strlen( $excerpt ) > 4000 ) {
+		$excerpt = substr( $excerpt, 0, 3997 ) . '...';
+	}
+
+	return $excerpt;
 }
 
 // ============================================================================

--- a/wordpress/scripts/test/test-runner-core-dev.sh
+++ b/wordpress/scripts/test/test-runner-core-dev.sh
@@ -136,13 +136,17 @@ set -e
 
 printf '%s\n' "$PHPUNIT_OUTPUT"
 
+PHPUNIT_OUTPUT_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wordpress-core-phpunit.XXXXXX")
+printf '%s\n' "$PHPUNIT_OUTPUT" > "$PHPUNIT_OUTPUT_FILE"
+trap 'rm -f "$PHPUNIT_OUTPUT_FILE"' EXIT
+
 PARSE_RESULTS="${EXTENSION_PATH}/scripts/test/parse-test-results.sh"
 PARSE_FAILURES="${EXTENSION_PATH}/scripts/test/parse-test-failures.sh"
 if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$PARSE_RESULTS" ]; then
-    printf '%s\n' "$PHPUNIT_OUTPUT" | bash "$PARSE_RESULTS" || true
+    bash "$PARSE_RESULTS" "$PHPUNIT_OUTPUT_FILE" || true
 fi
 if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] && [ -f "$PARSE_FAILURES" ]; then
-    printf '%s\n' "$PHPUNIT_OUTPUT" | bash "$PARSE_FAILURES" "$CORE_PATH" || true
+    bash "$PARSE_FAILURES" "$PHPUNIT_OUTPUT_FILE" "$CORE_PATH" || true
 fi
 
 exit "$PHPUNIT_EXIT"

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -374,23 +374,23 @@ fi
 
 # Also capture PHPUnit stdout from the tee'd output
 PHPUNIT_STDOUT=$(cat "$PHPUNIT_TMPFILE")
-rm -f "$PHPUNIT_TMPFILE"
 
 # Parse test results for homeboy core (best-effort, non-blocking)
 PARSE_RESULTS="${EXTENSION_PATH}/scripts/test/parse-test-results.sh"
 PARSE_FAILURES="${EXTENSION_PATH}/scripts/test/parse-test-failures.sh"
 if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$PARSE_RESULTS" ]; then
     if [ -n "$PHPUNIT_STDOUT" ]; then
-        echo "$PHPUNIT_STDOUT" | bash "$PARSE_RESULTS" || true
+        bash "$PARSE_RESULTS" "$PHPUNIT_TMPFILE" || true
     elif [ -n "$PHPUNIT_OUTPUT" ]; then
-        echo "$PHPUNIT_OUTPUT" | bash "$PARSE_RESULTS" || true
+        bash "$PARSE_RESULTS" "$RESULT_FILE" || true
     fi
 fi
 if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] && [ -f "$PARSE_FAILURES" ]; then
     if [ -n "$PHPUNIT_STDOUT" ]; then
-        echo "$PHPUNIT_STDOUT" | bash "$PARSE_FAILURES" "${PLUGIN_PATH:-}" || true
+        bash "$PARSE_FAILURES" "$PHPUNIT_TMPFILE" "${PLUGIN_PATH:-}" || true
     fi
 fi
+rm -f "$PHPUNIT_TMPFILE"
 
 # ----------------------------------------------------------------------------
 # Failure classification


### PR DESCRIPTION
## Summary
- Normalizes WordPress PHPUnit `HOMEBOY_TEST_FAILURES_FILE` records with `test_id`, `suite`, `file`, `line`, `failure_type`, `fingerprint`, and output excerpt fields while preserving the existing Homeboy analysis fields.
- Fixes WordPress PHPUnit result/failure parser invocation so runners pass captured output files instead of piping into file-only parsers.
- Documents the sidecar shape and adds a WordPress smoke test to lock the normalized contract.

Refs #388.

## Tests
- `wordpress/scripts/test/parse-test-failures-sidecar-smoke.sh`
- `php -l wordpress/scripts/test/parse-test-failures.php wordpress/scripts/test/parsers/classify-error.php wordpress/scripts/test/parsers/standard.php wordpress/scripts/test/parsers/testdox.php`
- `wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `wordpress/scripts/test/core-dev-shape-smoke.sh`
- `homeboy test --changed-since HEAD` from `wordpress/`
- `homeboy lint --changed-since HEAD` from `wordpress/`

## Follow-up
- This PR intentionally ships the WordPress first wave. Node, Rust, Swift, and Go sidecar normalization remain for follow-up work under #388.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the WordPress sidecar normalization implementation, smoke test, docs, and validation commands for Chris to review.