### PR TITLE
fix(wordpress): resolve transitive validation dependencies

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -239,12 +239,29 @@ homeboy_resolve_validation_dependency_paths() {
 
     [ -z "$all_deps" ] && return 0
 
-    # Deduplicate (settings deps come after header deps, so they win on path resolution)
-    # Track resolved paths to avoid duplicates
+    # Deduplicate resolved paths and dependency tokens while walking transitive
+    # Requires Plugins headers. WordPress enforces those transitive requirements
+    # at runtime, so PHPStan needs the same dependency graph when scanning a
+    # dependency's implementation classes.
     local -A seen_paths=()
+    local -A seen_dependencies=()
+    local -a dependency_queue=()
+    local dependency_index=0
 
     while IFS= read -r dependency; do
+        [ -n "$dependency" ] && dependency_queue+=("$dependency")
+    done <<< "$all_deps"
+
+    while [ "$dependency_index" -lt "${#dependency_queue[@]}" ]; do
+        dependency="${dependency_queue[$dependency_index]}"
+        dependency_index=$((dependency_index + 1))
+
         [ -z "$dependency" ] && continue
+
+        if [ -n "${seen_dependencies[$dependency]+x}" ]; then
+            continue
+        fi
+        seen_dependencies["$dependency"]=1
 
         local resolved
         resolved=$(homeboy_resolve_validation_dependency_path "$dependency" || true)
@@ -265,7 +282,14 @@ homeboy_resolve_validation_dependency_paths() {
         seen_paths["$resolved"]=1
 
         printf '%s\n' "$resolved"
-    done <<< "$all_deps"
+
+        while IFS= read -r transitive_dependency; do
+            [ -z "$transitive_dependency" ] && continue
+            if [ -z "${seen_dependencies[$transitive_dependency]+x}" ]; then
+                dependency_queue+=("$transitive_dependency")
+            fi
+        done < <(homeboy_get_requires_plugins_from_header "$resolved" || true)
+    done
 }
 
 homeboy_export_validation_dependency_paths() {

--- a/wordpress/tests/validation-dependencies-smoke.sh
+++ b/wordpress/tests/validation-dependencies-smoke.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../scripts/lib/validation-dependencies.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+COMPONENT_DIR="${TMPDIR}/intelligence"
+DATA_MACHINE_DIR="${TMPDIR}/data-machine"
+AGENTS_API_DIR="${TMPDIR}/agents-api"
+BIN_DIR="${TMPDIR}/bin"
+
+mkdir -p "$COMPONENT_DIR" "$DATA_MACHINE_DIR" "$AGENTS_API_DIR" "$BIN_DIR"
+
+cat > "${COMPONENT_DIR}/intelligence.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Intelligence
+ * Requires Plugins: data-machine
+ */
+PHP
+
+cat > "${DATA_MACHINE_DIR}/data-machine.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Data Machine
+ * Requires Plugins: agents-api
+ */
+PHP
+
+cat > "${AGENTS_API_DIR}/agents-api.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Agents API
+ */
+PHP
+
+cat > "${BIN_DIR}/homeboy" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "component" ] && [ "\${2:-}" = "show" ]; then
+    case "\${3:-}" in
+        data-machine)
+            printf '{"data":{"entity":{"local_path":"%s"}}}\n' '${DATA_MACHINE_DIR}'
+            ;;
+        agents-api)
+            printf '{"data":{"entity":{"local_path":"%s"}}}\n' '${AGENTS_API_DIR}'
+            ;;
+        *)
+            printf '{"data":{"entity":{}}}\n'
+            ;;
+    esac
+fi
+SH
+chmod +x "${BIN_DIR}/homeboy"
+
+source "$HELPER"
+
+resolved=$(PATH="${BIN_DIR}:$PATH" homeboy_resolve_validation_dependency_paths "$COMPONENT_DIR")
+
+if ! grep -F -- "$DATA_MACHINE_DIR" <<< "$resolved" >/dev/null; then
+    echo "FAIL: direct Requires Plugins dependency was not resolved" >&2
+    printf '%s\n' "$resolved" >&2
+    exit 1
+fi
+
+if ! grep -F -- "$AGENTS_API_DIR" <<< "$resolved" >/dev/null; then
+    echo "FAIL: transitive Requires Plugins dependency was not resolved" >&2
+    printf '%s\n' "$resolved" >&2
+    exit 1
+fi
+
+echo "Validation dependency smoke passed"


### PR DESCRIPTION
## Summary
- Walk WordPress `Requires Plugins` headers transitively when resolving validation dependencies.
- Keeps scoped PHPStan dependency context aligned with runtime plugin requirements, e.g. `intelligence -> data-machine -> agents-api`.
- Adds a smoke test covering transitive validation dependency resolution.

## Verification
- `wordpress/tests/validation-dependencies-smoke.sh`
- `wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `bash -n wordpress/scripts/lib/validation-dependencies.sh wordpress/tests/validation-dependencies-smoke.sh`
- `HOMEBOY_EXTENSION_PATH=/Users/chubes/Developer/homeboy-extensions@fix-transitive-wordpress-phpstan-deps/wordpress HOMEBOY_COMPONENT_PATH=/Users/chubes/Developer/intelligence@release-0-23-3 HOMEBOY_COMPONENT_ID=intelligence HOMEBOY_LINT_FILE=inc/storage/register.php HOMEBOY_SUMMARY_MODE=1 HOMEBOY_PHP_VERSION=8.1 wordpress/scripts/lint/phpstan-runner.sh`

Fixes Extra-Chill/homeboy#2078.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the scoped PHPStan dependency graph failure, drafted the resolver/test changes, and ran local verification. Chris remains responsible for review and merge.