### PR TITLE
fix(wordpress): scanFiles wordpress-stubs so host-smoke shims cannot shadow real WP signatures

### DIFF
--- a/wordpress/phpstan.neon.dist
+++ b/wordpress/phpstan.neon.dist
@@ -31,7 +31,34 @@ parameters:
         -
             identifier: missingType.generics
 
+    # Pull `wordpress-stubs.php` into the project symbol graph as a `scanFiles:`
+    # entry, in addition to szepeviktor's `bootstrapFiles:` registration.
+    # Both mechanisms ship the same WP function/class signatures, but PHPStan
+    # resolves them with very different precedence:
+    #
+    #   - `bootstrapFiles:` declarations lose to project-source declarations.
+    #     A `function get_post_types($args = array()) {}` shim defined inside
+    #     `if ( ! function_exists('get_post_types') )` in a host-smoke test
+    #     file shadows the canonical 3-arg WP signature, producing false
+    #     `arguments.count` errors on real plugin code.
+    #
+    #   - `scanFiles:` declarations are scanned alongside project source and
+    #     win during signature resolution, so the real WP arity always
+    #     governs analysis regardless of what test scaffolding redefines.
+    #
+    # Host-smoke files redefining WP functions inside `function_exists` guards
+    # is idiomatic for isolated PHP test runs (the runner's own
+    # `homeboy_wordpress_runtime_lint_file()` already classifies `tests/*` as
+    # non-runtime). Pulling the WP stubs into the project symbol graph here
+    # keeps both patterns compatible without forcing plugins to refactor
+    # their tests or disable WP API analysis. See homeboy-extensions#393.
+    #
+    # `stubFiles:` was tried first but did not win against project-source
+    # declarations in the presence of szepeviktor's `bootstrapFiles:` entry
+    # for the same file — `scanFiles:` is the path that actually fixes the
+    # symbol-resolution shadowing.
     scanFiles:
+        - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
         - vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
         - vendor/php-stubs/wp-cli-stubs/wp-cli-commands-stubs.php
         - vendor/php-stubs/wp-cli-stubs/wp-cli-i18n-stubs.php

--- a/wordpress/stubs/wordpress-api-overrides.stub.php
+++ b/wordpress/stubs/wordpress-api-overrides.stub.php
@@ -38,39 +38,6 @@ class WP_CLI {
 }
 
 /**
- * @property int $ID
- * @property string $post_author
- * @property string $post_date
- * @property string $post_date_gmt
- * @property string $post_content
- * @property string $post_title
- * @property string $post_excerpt
- * @property string $post_status
- * @property string $comment_status
- * @property string $ping_status
- * @property string $post_password
- * @property string $post_name
- * @property string $to_ping
- * @property string $pinged
- * @property string $post_modified
- * @property string $post_modified_gmt
- * @property string $post_content_filtered
- * @property int $post_parent
- * @property string $guid
- * @property int $menu_order
- * @property string $post_type
- * @property string $post_mime_type
- * @property string $comment_count
- * @property string $filter
- */
-class WP_Post {
-	/**
-	 * @param mixed $post
-	 */
-	public function __construct( $post = null ) {}
-}
-
-/**
  * @param non-empty-string $hook_name
  * @param mixed $value
  * @param mixed ...$args

--- a/wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh
+++ b/wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh
@@ -19,7 +19,6 @@ function homeboy_issue_375_filter_callback( $value, WP_Post $post ) {
 }
 
 function homeboy_issue_375_action_callback( WP_Post $post, array $context ): void {
-	new WP_Post();
 	new WP_Post( (object) array( 'ID' => 123 ) );
 
 	WP_CLI::log( 'Inspecting ' . $post->post_type );
@@ -34,6 +33,36 @@ function homeboy_issue_375_action_callback( WP_Post $post, array $context ): voi
 	current_user_can( 'edit_post', $post->ID );
 	wp_json_encode( array( 'post_type' => $post->post_type ) );
 	get_post();
+}
+
+// Regression guard for issue #393 — host-smoke files in the same component
+// must not shadow real WP signatures. Calling get_post_types() with the
+// canonical 2-arg shape `(array, string)` should pass PHPStan even when a
+// `function_exists`-guarded shim with a narrower arity sits beside it.
+function homeboy_issue_393_caller(): array {
+	$post_types = get_post_types(
+		array(
+			'public'              => true,
+			'exclude_from_search' => false,
+		),
+		'names'
+	);
+	return array_values( $post_types );
+}
+PHP
+
+# Fake host-smoke stub that historically shadowed wordpress-stubs.php through
+# `bootstrapFiles:` precedence and produced false `arguments.count` errors.
+# The runtime config now pulls wordpress-stubs into `scanFiles:` so the real
+# 3-arg WP signature wins regardless of this redefinition. See issue #393.
+mkdir -p "${COMPONENT_DIR}/tests"
+cat > "${COMPONENT_DIR}/tests/issue-393-host-smoke.php" <<'PHP'
+<?php
+
+if ( ! function_exists( 'get_post_types' ) ) {
+	function get_post_types( $args = array() ) {
+		return array();
+	}
 }
 PHP
 


### PR DESCRIPTION
## Summary

Closes #393.

Host-smoke test files redefine WP functions inside `if ( ! function_exists() )` guards (idiomatic for isolated PHP test runs) but PHPStan parses both branches of the guard statically and treats those declarations as authoritative — out-prioritizing the canonical WP signatures that szepeviktor's `bootstrapFiles:` ships. Result: false `arguments.count` errors on plugin code calling real WP APIs.

Concrete repro from issue #393 (data-machine#1713): a 2-arg `get_post_types( array, 'names' )` was flagged as "0-1 required" because `tests/bfb-substrate-bundle-smoke.php:125` declared a 1-arg `function get_post_types( \$args = array() )`.

## Fix

Promote `vendor/php-stubs/wordpress-stubs/wordpress-stubs.php` from szepeviktor's `bootstrapFiles:` to this profile's `scanFiles:` list. PHPStan resolves `scanFiles:` declarations with higher precedence than project source, so the real WP arity always wins regardless of what test scaffolding redefines.

`stubFiles:` was tried first but did not win when the same file was also loaded as `bootstrapFiles:` upstream. `scanFiles:` is the path that actually fixes the shadowing.

## Side effect

`WP_Post::__construct( \$post = null )` in `stubs/wordpress-api-overrides.stub.php` previously relaxed the real 1-arg WP signature to 0-arg. With wordpress-stubs in `scanFiles:` the real signature wins. Bare `new WP_Post()` is now a real (correct) PHPStan error. Removed the override and the corresponding line in the issue-375 smoke that asserted bare-construct works — that was always bad practice anyway.

## Regression guard

Extends `wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh` with an issue-393 case: a runtime caller using the canonical 2-arg `get_post_types` shape sits beside a host-smoke fake declaring the 1-arg shim. Asserts `arguments.count` no longer fires.

## Verification

- `wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh` → ✓ passes (with new regression guard)
- `wordpress/tests/phpstan-temp-config-suffix-smoke.sh` → ✓ passes
- `wordpress/tests/wp-cli-runtime-dispatch-fingerprint-smoke.sh` → ✓ passes
- data-machine PR #1713 (`fix-local-search-array-items` worktree) `homeboy lint` → `delta: 0`, `status: passed` (was: 1 finding, failed)

## Blast radius

Plugins that relied on `WP_Post::__construct( \$post = null )` being 0-arg in their PHPStan analysis will now see a real `arguments.count` error. That's correct behavior — bare `new WP_Post()` is unsafe, the previous override was masking a real type problem. None observed in current org components (greppped data-machine, data-machine-events).

All other plugins benefit immediately: any `arguments.count` false positive caused by host-smoke fake shims will resolve on next lint run.