### PR TITLE
Preserve Node.js bench scenario metadata

### DIFF
--- a/nodejs/scripts/bench/bench-runner.mjs
+++ b/nodejs/scripts/bench/bench-runner.mjs
@@ -14,10 +14,10 @@
 //
 // Discovers `bench/**/*.bench.{ts,mjs,js}` under the project root.
 // Each workload file must export a default async function. The function may
-// return `{ metrics: Record<string, number>, artifacts: Record<string, object> }`
-// to report workload-owned custom metrics and artifacts. Metrics are averaged
-// across measured iterations and merged beside the dispatcher-owned timing
-// metrics; artifacts are preserved under the scenario in the results envelope.
+// return `{ metrics, artifacts, metadata }` to report workload-owned custom
+// metrics, artifacts, and scenario labels. Metrics are averaged across measured
+// iterations and merged beside the dispatcher-owned timing metrics; artifacts
+// and metadata are preserved under the scenario in the results envelope.
 //
 //     // bench/cold-boot.bench.ts
 //     export default async function () {
@@ -94,14 +94,14 @@ function parseWarmupIterations(value) {
 
 function validateWorkloadResult(value, iterationLabel) {
     if (value === undefined) {
-        return { metrics: {}, artifacts: {} };
+        return { metrics: {}, artifacts: {}, metadata: {} };
     }
 
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
         throw new Error(`${iterationLabel} returned invalid result shape (expected undefined or an object)`);
     }
 
-    const { metrics, artifacts } = value;
+    const { metrics, artifacts, metadata } = value;
 
     if (metrics !== undefined && (!metrics || typeof metrics !== 'object' || Array.isArray(metrics))) {
         throw new Error(`${iterationLabel} returned invalid metrics shape (expected an object)`);
@@ -121,7 +121,24 @@ function validateWorkloadResult(value, iterationLabel) {
     return {
         metrics: validatedMetrics,
         artifacts: validateWorkloadArtifacts(artifacts, iterationLabel),
+        metadata: validateWorkloadMetadata(metadata, iterationLabel),
     };
+}
+
+function validateWorkloadMetadata(metadata, iterationLabel) {
+    if (metadata === undefined) {
+        return {};
+    }
+
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+        throw new Error(`${iterationLabel} returned invalid metadata shape (expected an object)`);
+    }
+
+    try {
+        return JSON.parse(JSON.stringify(metadata));
+    } catch (err) {
+        throw new Error(`${iterationLabel} returned metadata that is not JSON-serializable: ${err.message}`);
+    }
 }
 
 function validateWorkloadArtifacts(artifacts, iterationLabel) {
@@ -185,6 +202,10 @@ function aggregateArtifacts(iterationArtifacts) {
     return Object.assign({}, ...iterationArtifacts);
 }
 
+function aggregateMetadata(iterationMetadata) {
+    return Object.assign({}, ...iterationMetadata);
+}
+
 async function discoverWorkloads(dir) {
     const found = [];
     async function walk(d) {
@@ -233,6 +254,7 @@ async function runWorkload(file) {
     const timings = [];
     const customMetrics = [];
     const customArtifacts = [];
+    const customMetadata = [];
     let peakRss = 0;
     for (let i = 0; i < ITERATIONS; i++) {
         const start = performance.now();
@@ -240,6 +262,7 @@ async function runWorkload(file) {
             const workloadResult = validateWorkloadResult(await fn(), `iteration ${i + 1}/${ITERATIONS}`);
             customMetrics.push(workloadResult.metrics);
             customArtifacts.push(workloadResult.artifacts);
+            customMetadata.push(workloadResult.metadata);
         } catch (err) {
             return { error: `iteration ${i + 1}/${ITERATIONS} threw: ${err.message}` };
         }
@@ -254,6 +277,7 @@ async function runWorkload(file) {
         peakRss,
         customMetrics: aggregateCustomMetrics(customMetrics),
         customArtifacts: aggregateArtifacts(customArtifacts),
+        customMetadata: aggregateMetadata(customMetadata),
     };
 }
 
@@ -331,6 +355,9 @@ async function main() {
         };
         if (Object.keys(result.customArtifacts).length > 0) {
             scenario.artifacts = result.customArtifacts;
+        }
+        if (Object.keys(result.customMetadata).length > 0) {
+            scenario.metadata = result.customMetadata;
         }
         scenarios.push(scenario);
 

--- a/tests/nodejs-bench-metadata-smoke.sh
+++ b/tests/nodejs-bench-metadata-smoke.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+BENCH_HELPER="${HOMEBOY_RUNTIME_BENCH_HELPER_JS:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/bench-helper.mjs}"
+
+if [ ! -f "$BENCH_HELPER" ]; then
+    echo "Missing required file: $BENCH_HELPER" >&2
+    exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PROJECT_DIR="$TMP_DIR/project"
+RESULTS_FILE="$TMP_DIR/results.json"
+mkdir -p "$PROJECT_DIR/bench"
+
+cat > "$PROJECT_DIR/bench/prompt-variant.bench.mjs" <<'EOF'
+export default async function () {
+    return {
+        metrics: { custom_metric: 7 },
+        metadata: {
+            prompt_variant: 'studio-code',
+            prompt_file: 'file:///tmp/prompts/site-build/studio-code.md',
+            prompt_category: 'site-build',
+        },
+    };
+}
+EOF
+
+HOMEBOY_RUNTIME_BENCH_HELPER_JS="$BENCH_HELPER" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_COMPONENT_ID="nodejs-metadata-smoke" \
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_FILE" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
+    node "$ROOT_DIR/nodejs/scripts/bench/bench-runner.mjs" >/dev/null
+
+node --input-type=module - "$RESULTS_FILE" <<'NODE'
+import { readFileSync } from 'node:fs';
+
+const results = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+const scenario = results.scenarios?.[0];
+if (!scenario) {
+    throw new Error('missing scenario');
+}
+if (scenario.metadata?.prompt_variant !== 'studio-code') {
+    throw new Error(`prompt_variant was not persisted: ${JSON.stringify(scenario.metadata)}`);
+}
+if (scenario.metadata?.prompt_file !== 'file:///tmp/prompts/site-build/studio-code.md') {
+    throw new Error(`prompt_file was not persisted: ${JSON.stringify(scenario.metadata)}`);
+}
+if (scenario.metadata?.prompt_category !== 'site-build') {
+    throw new Error(`prompt_category was not persisted: ${JSON.stringify(scenario.metadata)}`);
+}
+if (scenario.metrics?.custom_metric !== 7) {
+    throw new Error(`custom metrics regressed: ${JSON.stringify(scenario.metrics)}`);
+}
+NODE
+
+echo "nodejs bench metadata smoke passed"


### PR DESCRIPTION
## Summary
- Allow Node.js bench workloads to return non-numeric scenario `metadata` alongside metrics and artifacts.
- Preserve workload metadata in the BenchResults scenario envelope so Homeboy can persist it in run scenario metadata.
- Add a smoke test covering prompt variant/file/category metadata passthrough.

## Tests
- `node --check nodejs/scripts/bench/bench-runner.mjs`
- `bash tests/nodejs-bench-metadata-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Node.js bench metadata contract change and smoke test; Chris remains responsible for review and validation.