### PR TITLE
fix: exclude prefixed vendor dirs from lint and auto-fix (#403)

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,7 +10,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh"
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh"
     ],
     "test": [
       "bash scripts/test/host-smoke-runner-smoke.sh",
@@ -20,7 +20,8 @@
       "bash scripts/test/playground-cleanup-noise-smoke.sh",
       "bash scripts/test/playground-no-test-files-smoke.sh",
       "bash scripts/trace/trace-runner-smoke.sh",
-      "bash scripts/lint/wordpress-lint-role-smoke.sh"
+      "bash scripts/lint/wordpress-lint-role-smoke.sh",
+      "bash scripts/lint/vendor-prefixed-exclusion-smoke.sh"
     ]
   }
 }

--- a/wordpress/phpcs.xml.dist
+++ b/wordpress/phpcs.xml.dist
@@ -34,13 +34,17 @@
     <config name="testVersion" value="7.4-"/>
 
     <!-- Exclude common non-source directories -->
-    <exclude-pattern>/vendor/*</exclude-pattern>
-    <exclude-pattern>/node_modules/*</exclude-pattern>
-    <exclude-pattern>/build/*</exclude-pattern>
-    <exclude-pattern>/dist/*</exclude-pattern>
-    <exclude-pattern>/tools/*</exclude-pattern>
-    <exclude-pattern>/scoper.inc.php</exclude-pattern>
-    <exclude-pattern>/tests/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/vendor_prefixed/*</exclude-pattern>
+    <exclude-pattern>*/vendor-prefixed/*</exclude-pattern>
+    <exclude-pattern>*/vendor_scoped/*</exclude-pattern>
+    <exclude-pattern>*/vendor-scoped/*</exclude-pattern>
+    <exclude-pattern>*/node_modules/*</exclude-pattern>
+    <exclude-pattern>*/dist/*</exclude-pattern>
+    <exclude-pattern>*/build/*</exclude-pattern>
+    <exclude-pattern>*/tools/*</exclude-pattern>
+    <exclude-pattern>*/scoper.inc.php</exclude-pattern>
+    <exclude-pattern>*/tests/*</exclude-pattern>
 
     <!-- Text domain is auto-detected from plugin header by test-runner.sh -->
 

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -30,8 +30,12 @@ homeboy_resolve_context --component-alias PLUGIN_PATH
 js_file_count=$(find "$PLUGIN_PATH" -type f \( -name "*.js" -o -name "*.jsx" -o -name "*.ts" -o -name "*.tsx" \) \
     -not -path "*/node_extensions/*" \
     -not -path "*/vendor/*" \
-    -not -path "*/build/*" \
+    -not -path "*/vendor_prefixed/*" \
+    -not -path "*/vendor-prefixed/*" \
+    -not -path "*/vendor_scoped/*" \
+    -not -path "*/vendor-scoped/*" \
     -not -path "*/dist/*" \
+    -not -path "*/build/*" \
     -not -name "*.min.js" \
     2>/dev/null | wc -l | tr -d ' ')
 

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -209,7 +209,7 @@ homeboy_wordpress_runtime_lint_file() {
     local lint_role
 
     case "$rel_path" in
-        vendor_prefixed/*|vendor/*)
+        vendor/*|vendor_prefixed/*|vendor-prefixed/*|vendor_scoped/*|vendor-scoped/*|node_modules/*|dist/*|build/*)
             return 1
             ;;
     esac
@@ -607,7 +607,16 @@ print(json.dumps(results))
                     syntax_errors=$((syntax_errors + 1))
                     syntax_error_files+=("$php_file")
                 fi
-            done < <(find "$lint_target" -name '*.php' -not -path '*/vendor/*' -not -path '*/node_modules/*' -print0)
+            done < <(find "$lint_target" -name '*.php' \
+                -not -path '*/vendor/*' \
+                -not -path '*/vendor_prefixed/*' \
+                -not -path '*/vendor-prefixed/*' \
+                -not -path '*/vendor_scoped/*' \
+                -not -path '*/vendor-scoped/*' \
+                -not -path '*/node_modules/*' \
+                -not -path '*/dist/*' \
+                -not -path '*/build/*' \
+                -print0)
         elif [ -f "$lint_target" ]; then
             if ! php -l "$lint_target" > /dev/null 2>&1; then
                 syntax_errors=$((syntax_errors + 1))
@@ -649,7 +658,7 @@ fixable_count=0
 
 # Build base phpcs arguments
 phpcs_base_args=(--standard="$PHPCS_CONFIG")
-phpcs_base_args+=(--ignore='*/vendor/*,*/vendor_prefixed/*,*/node_modules/*,*/build/*,*/dist/*,*/tools/*,*/scoper.inc.php')
+phpcs_base_args+=(--ignore='*/vendor/*,*/vendor_prefixed/*,*/vendor-prefixed/*,*/vendor_scoped/*,*/vendor-scoped/*,*/node_modules/*,*/dist/*,*/build/*,*/tools/*,*/scoper.inc.php')
 
 if [ "$WORDPRESS_LINT_ROLE" = "scoper_config" ]; then
     phpcs_base_args+=(--sniffs=Generic.PHP.Syntax)

--- a/wordpress/scripts/lint/php-fixers/fixer-helpers.php
+++ b/wordpress/scripts/lint/php-fixers/fixer-helpers.php
@@ -4,7 +4,7 @@
  */
 
 /**
- * Process PHP files in a path, excluding vendor/node_extensions/build directories.
+ * Process PHP files in a path, excluding generated dependency/build directories.
  *
  * @param string   $path     File or directory path.
  * @param callable $callback Function to process each file, receives filepath, returns fix count.
@@ -14,15 +14,13 @@ function fixer_process_path($path, callable $callback) {
     $total_fixes = 0;
     $files_fixed = 0;
 
-    $excluded_dirs = ['vendor', 'node_extensions', 'build'];
-
     if (is_dir($path)) {
         $iterator = new RecursiveIteratorIterator(
             new RecursiveCallbackFilterIterator(
                 new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS),
-                function ($file, $key, $iterator) use ($excluded_dirs) {
+                function ($file, $key, $iterator) {
                     if ($iterator->hasChildren()) {
-                        return !in_array($file->getFilename(), $excluded_dirs, true);
+                        return !fixer_path_is_excluded($file->getPathname());
                     }
                     return $file->getExtension() === 'php';
                 }
@@ -44,4 +42,27 @@ function fixer_process_path($path, callable $callback) {
     }
 
     return ['total_fixes' => $total_fixes, 'files_fixed' => $files_fixed];
+}
+
+function fixer_path_is_excluded($path) {
+    $path = str_replace('\\', '/', $path);
+    $excluded_dirs = [
+        'vendor',
+        'vendor_prefixed',
+        'vendor-prefixed',
+        'vendor_scoped',
+        'vendor-scoped',
+        'node_extensions',
+        'node_modules',
+        'dist',
+        'build',
+    ];
+
+    foreach (explode('/', trim($path, '/')) as $segment) {
+        if (in_array($segment, $excluded_dirs, true)) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/wordpress/scripts/lint/php-fixers/reserved-param-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/reserved-param-fixer.php
@@ -763,7 +763,7 @@ function verify_no_stale_named_args($path, $manifest) {
     foreach ($search_patterns as $old_arg => $info) {
         // Search for "old_arg:" pattern (named argument syntax)
         $cmd = sprintf(
-            'grep -rn --include="*.php" "%s\s*:" %s 2>/dev/null | grep -v vendor/ | grep -v node_modules/',
+            'grep -rn --include="*.php" "%s\s*:" %s 2>/dev/null',
             preg_quote($old_arg, '/'),
             escapeshellarg($path)
         );
@@ -777,6 +777,10 @@ function verify_no_stale_named_args($path, $manifest) {
             // Quick heuristic: check if this looks like a named argument context
             // (inside a function call, preceded by ( or ,)
             if (preg_match('/\b' . preg_quote($old_arg, '/') . '\s*:/', $line)) {
+                if (preg_match('/^(.+?):\d+:/', $line, $m) && fixer_path_is_excluded($m[1])) {
+                    continue;
+                }
+
                 // Exclude function declarations, array keys, ternary, switch cases, goto labels
                 if (preg_match('/function\s/', $line)) {
                     continue;

--- a/wordpress/scripts/lint/php-fixers/unused-param-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/unused-param-fixer.php
@@ -1153,8 +1153,7 @@ function find_call_sites_in_codebase($func_name, $scan_root, $current_filepath) 
             $file     = $m[1];
             $line_num = (int) $m[2];
 
-            // Skip vendor/node_modules/build.
-            if (preg_match('/(vendor|node_modules|build)\//', $file)) {
+            if (fixer_path_is_excluded($file)) {
                 continue;
             }
 

--- a/wordpress/scripts/lint/vendor-prefixed-exclusion-smoke.sh
+++ b/wordpress/scripts/lint/vendor-prefixed-exclusion-smoke.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RUNNER="${SCRIPT_DIR}/lint-runner.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+COMPONENT_DIR="${TMPDIR}/component"
+LINT_OUTPUT="${TMPDIR}/lint-output.txt"
+FIX_OUTPUT="${TMPDIR}/fix-output.txt"
+
+mkdir -p "${COMPONENT_DIR}/vendor_prefixed"
+
+cat > "${COMPONENT_DIR}/plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Vendor Prefixed Exclusion Fixture
+ * Text Domain: vendor-prefixed-exclusion-fixture
+ */
+PHP
+
+cat > "${COMPONENT_DIR}/vendor_prefixed/bad.php" <<'PHP'
+<?php
+if ( $value == 1 ) {
+    echo "vendor";
+}
+PHP
+
+before_hash=$(shasum "${COMPONENT_DIR}/vendor_prefixed/bad.php" | cut -d ' ' -f 1)
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="vendor-prefixed-fixture" \
+HOMEBOY_STEP=phpcs \
+HOMEBOY_SUMMARY_MODE=1 \
+    bash "$RUNNER" > "$LINT_OUTPUT" 2>&1
+
+if ! grep -Fq "PHPCS linting passed" "$LINT_OUTPUT"; then
+    echo "FAIL: PHPCS should ignore vendor_prefixed/ during lint" >&2
+    sed 's/^/  /' "$LINT_OUTPUT" >&2
+    exit 1
+fi
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="vendor-prefixed-fixture" \
+HOMEBOY_FIX_ONLY=1 \
+HOMEBOY_STEP=phpcs \
+    bash "$RUNNER" > "$FIX_OUTPUT" 2>&1
+
+after_hash=$(shasum "${COMPONENT_DIR}/vendor_prefixed/bad.php" | cut -d ' ' -f 1)
+
+if [ "$before_hash" != "$after_hash" ]; then
+    echo "FAIL: auto-fix modified vendor_prefixed/" >&2
+    sed 's/^/  /' "$FIX_OUTPUT" >&2
+    exit 1
+fi
+
+echo "vendor_prefixed lint exclusion smoke passed"

--- a/wordpress/scripts/validation/validate-syntax.sh
+++ b/wordpress/scripts/validation/validate-syntax.sh
@@ -3,7 +3,7 @@
 # Post-write PHP syntax validation for homeboy's validate_write gate.
 #
 # Runs `php -l` on all PHP source files in the project root, excluding
-# vendor/, node_modules/, and common non-source directories.
+# vendor/, prefixed vendor dirs, node_modules/, and common non-source directories.
 #
 # Called by homeboy after `audit --fix --write` or `refactor` applies changes.
 # Runs from the project root (CWD = component source path).
@@ -27,7 +27,13 @@ while IFS= read -r -d '' php_file; do
 done < <(find "$ROOT" \
     -name '*.php' \
     -not -path '*/vendor/*' \
+    -not -path '*/vendor_prefixed/*' \
+    -not -path '*/vendor-prefixed/*' \
+    -not -path '*/vendor_scoped/*' \
+    -not -path '*/vendor-scoped/*' \
     -not -path '*/node_modules/*' \
+    -not -path '*/dist/*' \
+    -not -path '*/build/*' \
     -not -path '*/.git/*' \
     -print0)
 


### PR DESCRIPTION
## Summary
- Excludes scoped vendor directory conventions from the WordPress PHPCS ruleset and runtime lint ignores.
- Applies the same generated-directory exclusions to auto-fix traversal, post-fix syntax validation, and JS file discovery.
- Adds a regression smoke proving `vendor_prefixed/` is ignored by lint and left untouched by fix-only mode.

Fixes #403.

## Exclude-pattern diff
Before:
```xml
<exclude-pattern>/vendor/*</exclude-pattern>
<exclude-pattern>/node_modules/*</exclude-pattern>
<exclude-pattern>/build/*</exclude-pattern>
<exclude-pattern>/dist/*</exclude-pattern>
```

After:
```xml
<exclude-pattern>*/vendor/*</exclude-pattern>
<exclude-pattern>*/vendor_prefixed/*</exclude-pattern>
<exclude-pattern>*/vendor-prefixed/*</exclude-pattern>
<exclude-pattern>*/vendor_scoped/*</exclude-pattern>
<exclude-pattern>*/vendor-scoped/*</exclude-pattern>
<exclude-pattern>*/node_modules/*</exclude-pattern>
<exclude-pattern>*/dist/*</exclude-pattern>
<exclude-pattern>*/build/*</exclude-pattern>
```

## Fleet context
- chubes4/block-format-bridge#98 hit the destructive path: `homeboy lint --fix` mangled 89 files under `vendor_prefixed/` and dropped PHPUnit from 22/22 to 17/22.
- chubes4/html-to-blocks-converter#237 did not have a prefixed vendor directory, so its auto-fix sweep stayed contained.
- Once this lands and downstream installs pull the new WordPress ruleset/fixers, bfb#98 should revert the `vendor_prefixed/` churn and rebase.

## Verification
- `bash scripts/lint/vendor-prefixed-exclusion-smoke.sh`
- `bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh`
- `homeboy test`
- `homeboy lint`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WordPress lint and auto-fix exclusion paths, drafted the code/test changes, ran verification, and prepared this PR body for Chris to review.