### PR TITLE
fix: skip ESLint cleanly when plugin has no JS files (#405)

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,7 +10,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh"
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh"
     ],
     "test": [
       "bash scripts/test/host-smoke-runner-smoke.sh",
@@ -21,7 +21,8 @@
       "bash scripts/test/playground-no-test-files-smoke.sh",
       "bash scripts/trace/trace-runner-smoke.sh",
       "bash scripts/lint/wordpress-lint-role-smoke.sh",
-      "bash scripts/lint/vendor-prefixed-exclusion-smoke.sh"
+      "bash scripts/lint/vendor-prefixed-exclusion-smoke.sh",
+      "bash scripts/lint/eslint-no-files-smoke.sh"
     ]
   }
 }

--- a/wordpress/scripts/lint/eslint-no-files-smoke.sh
+++ b/wordpress/scripts/lint/eslint-no-files-smoke.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RUNNER="${SCRIPT_DIR}/eslint-runner.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+COMPONENT_DIR="${TMPDIR}/component"
+LINT_OUTPUT="${TMPDIR}/lint-output.txt"
+
+mkdir -p "$COMPONENT_DIR"
+
+cat > "${COMPONENT_DIR}/plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: ESLint No Files Fixture
+ * Text Domain: eslint-no-files-fixture
+ */
+PHP
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="eslint-no-files-fixture" \
+    bash "$RUNNER" > "$LINT_OUTPUT" 2>&1
+
+if ! grep -Fq "No JavaScript files found, skipping ESLint." "$LINT_OUTPUT"; then
+    echo "FAIL: ESLint runner should skip cleanly when no JavaScript files exist" >&2
+    sed 's/^/  /' "$LINT_OUTPUT" >&2
+    exit 1
+fi
+
+echo "eslint no-files smoke passed"

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -40,9 +40,7 @@ js_file_count=$(find "$PLUGIN_PATH" -type f \( -name "*.js" -o -name "*.jsx" -o 
     2>/dev/null | wc -l | tr -d ' ')
 
 if [ "$js_file_count" -eq 0 ]; then
-    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
-        echo "DEBUG: No JavaScript files found, skipping ESLint"
-    fi
+    echo "No JavaScript files found, skipping ESLint."
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
- Fixes #405.
- Makes the ESLint runner's zero-JS early exit explicit by always printing a successful skip message.
- Adds `wordpress/scripts/lint/eslint-no-files-smoke.sh` and wires it into the WordPress extension lint/test self-checks.

## eslint-runner.sh diff

Before:
```sh
if [ \"$js_file_count\" -eq 0 ]; then
    if [ \"${HOMEBOY_DEBUG:-}\" = \"1\" ]; then
        echo \"DEBUG: No JavaScript files found, skipping ESLint\"
    fi
    exit 0
fi
```

After:
```sh
if [ \"$js_file_count\" -eq 0 ]; then
    echo \"No JavaScript files found, skipping ESLint.\"
    exit 0
fi
```

## Verification
- `bash scripts/lint/eslint-no-files-smoke.sh`
- `bash -n scripts/lint/eslint-runner.sh`
- `homeboy test`
- `homeboy lint`

## Context
This is the third in a sequence of homeboy-extensions polish PRs from the orphan-tag cleanup fleet, after #402 docs and #404 vendor-prefixed exclusion.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the wrapper-level ESLint skip message, drafted the regression smoke test, wired self-checks, and ran verification. Chris remains responsible for review and merge.