### PR TITLE
Add extension-owned write validation and formatting

### DIFF
--- a/go/go.json
+++ b/go/go.json
@@ -1,16 +1,18 @@
 {
   "name": "Go",
   "id": "go",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "icon": "g.circle.fill",
   "description": "Go CLI integration for services, bridges, and binaries",
   "author": "Extra Chill",
   "provides": {
     "file_extensions": ["go", "mod", "sum"],
-    "capabilities": ["fingerprint"]
+    "capabilities": ["fingerprint", "format", "validate"]
   },
   "scripts": {
-    "fingerprint": "scripts/fingerprint.sh"
+    "fingerprint": "scripts/fingerprint.sh",
+    "validate": "scripts/validate.sh",
+    "format": "scripts/format.sh"
   },
   "build": {
     "script_names": [

--- a/go/scripts/format.sh
+++ b/go/scripts/format.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Go formatter for homeboy's post-write formatting gate.
+
+if [ ! -f ./go.mod ]; then
+    echo "No go.mod found — skipping format"
+    exit 0
+fi
+
+go fmt ./... 2>&1

--- a/go/scripts/validate.sh
+++ b/go/scripts/validate.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Go validator for homeboy's post-write validation gate.
+
+if [ ! -f ./go.mod ]; then
+    echo "No go.mod found — skipping validation"
+    exit 0
+fi
+
+go vet ./... 2>&1

--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -1,9 +1,17 @@
 {
   "name": "Node.js",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "icon": "server.rack",
   "description": "Node.js project type — discovery, audit grammar, and npm release lifecycle",
   "author": "Extra Chill",
+  "provides": {
+    "file_extensions": ["js", "jsx", "ts", "tsx", "mjs", "cjs", "json"],
+    "capabilities": ["format", "validate"]
+  },
+  "scripts": {
+    "validate": "scripts/validate.sh",
+    "format": "scripts/format.sh"
+  },
   "platform": {
     "discovery": {
       "find_command": "find /home -name 'package.json' -type f 2>/dev/null | xargs grep -l '\"name\"' 2>/dev/null",

--- a/nodejs/scripts/format.sh
+++ b/nodejs/scripts/format.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Node.js formatter for homeboy's post-write formatting gate.
+# Mirrors the former core fallback: use project-local Prettier when available.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/lib/resolve-context.sh}"
+# shellcheck source=/dev/null
+source "$RESOLVE_CONTEXT_HELPER"
+homeboy_resolve_context
+# shellcheck source=lib/node-helpers.sh
+source "${SCRIPT_DIR}/lib/node-helpers.sh"
+
+if ! homeboy_require_package_json; then
+    echo "No package.json found — skipping format"
+    exit 0
+fi
+homeboy_detect_package_manager
+
+if [ ! -x "${PROJECT_PATH}/node_modules/.bin/prettier" ]; then
+    echo "No project-local Prettier found — skipping format"
+    exit 0
+fi
+
+cd "$PROJECT_PATH"
+$PKG_EXEC prettier --write . 2>&1

--- a/nodejs/scripts/validate.sh
+++ b/nodejs/scripts/validate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Node.js validator for homeboy's post-write validation gate.
+# Mirrors the former core TypeScript fallback: run tsc only when tsconfig exists.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/lib/resolve-context.sh}"
+# shellcheck source=/dev/null
+source "$RESOLVE_CONTEXT_HELPER"
+homeboy_resolve_context
+# shellcheck source=lib/node-helpers.sh
+source "${SCRIPT_DIR}/lib/node-helpers.sh"
+
+if ! homeboy_require_package_json; then
+    echo "No package.json found — skipping validation"
+    exit 0
+fi
+homeboy_detect_package_manager
+
+if [ ! -f "${PROJECT_PATH}/tsconfig.json" ]; then
+    echo "No tsconfig.json found — skipping validation"
+    exit 0
+fi
+
+cd "$PROJECT_PATH"
+$PKG_EXEC tsc --noEmit 2>&1

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,16 +1,17 @@
 {
   "name": "Rust",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",
   "provides": {
     "file_extensions": ["rs"],
-    "capabilities": ["fingerprint", "refactor"]
+    "capabilities": ["fingerprint", "refactor", "format", "validate"]
   },
   "scripts": {
     "fingerprint": "scripts/fingerprint.sh",
     "refactor": "scripts/refactor.sh",
+    "validate": "scripts/validate.sh",
     "format": "scripts/format.sh"
   },
   "lint": {

--- a/rust/scripts/validate.sh
+++ b/rust/scripts/validate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Rust validator for homeboy's post-write validation gate.
+# Includes tests so generated or edited #[cfg(test)] code is checked before success.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/lib/resolve-context.sh}"
+# shellcheck source=/dev/null
+source "$RESOLVE_CONTEXT_HELPER"
+homeboy_resolve_context
+
+if [ ! -f "${PROJECT_PATH}/Cargo.toml" ]; then
+    echo "No Cargo.toml found — skipping validation"
+    exit 0
+fi
+
+cargo check --tests --manifest-path "${PROJECT_PATH}/Cargo.toml" 2>&1

--- a/wordpress/scripts/format.sh
+++ b/wordpress/scripts/format.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WordPress/PHP formatter for homeboy's post-write formatting gate.
+# Prefer the component's PHPCBF when present; otherwise use the extension's bundled PHPCBF.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/.." && pwd)"
+COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-$PWD}"
+
+if [ -x "${COMPONENT_PATH}/vendor/bin/phpcbf" ]; then
+    cd "$COMPONENT_PATH"
+    "${COMPONENT_PATH}/vendor/bin/phpcbf" "$COMPONENT_PATH" 2>&1
+    exit $?
+fi
+
+if [ -x "${EXTENSION_PATH}/vendor/bin/phpcbf" ]; then
+    cd "$COMPONENT_PATH"
+    "${EXTENSION_PATH}/vendor/bin/phpcbf" "$COMPONENT_PATH" 2>&1
+    exit $?
+fi
+
+echo "No PHPCBF found — skipping format"
+exit 0

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "2.39.2",
+  "version": "2.40.0",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",
@@ -12,7 +12,8 @@
     "fingerprint": "scripts/fingerprint.sh",
     "refactor": "scripts/refactor.py",
     "crossref": "scripts/test/crossref.php",
-    "validate": "scripts/validation/validate-syntax.sh"
+    "validate": "scripts/validation/validate-syntax.sh",
+    "format": "scripts/format.sh"
   },
   "component_env": {
     "detect_script": "scripts/env/detect.sh"


### PR DESCRIPTION
## Summary
- Add extension-owned post-write validate/format scripts for Rust, Node.js, Go, and WordPress where Homeboy core previously supplied fallbacks.
- Wire manifests to `scripts.validate` and `scripts.format` and bump affected extension versions.
- Keep behavior intentionally close to the removed Homeboy core fallbacks: Rust `cargo check --tests`, Node `tsc --noEmit`/Prettier when configured, Go `go vet`/`go fmt`, WordPress PHPCBF.

## Tests
- `bash -n rust/scripts/validate.sh nodejs/scripts/validate.sh nodejs/scripts/format.sh go/scripts/validate.sh go/scripts/format.sh wordpress/scripts/format.sh`
- `python3 -m json.tool` on edited manifests
- Node skip smoke with and without `package.json`
- Rust/Go skip smoke without marker files
- WordPress formatter smoke on empty component directory

## Related
- Supports Extra-Chill/homeboy#2268
- Supports Extra-Chill/homeboy#2242

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.