### PR TITLE
fix(wordpress): tune audit detector context

### DIFF
--- a/wordpress/docs/audit-core-contract-gaps.md
+++ b/wordpress/docs/audit-core-contract-gaps.md
@@ -1,0 +1,74 @@
+# WordPress Audit Core Contract Gaps
+
+The WordPress extension owns PHP and WordPress semantics. Homeboy core should stay language-agnostic and expose generic audit contracts that extensions can configure.
+
+## Supported Today
+
+The extension now uses the generic knobs Homeboy already exposes:
+
+- `audit.detector_rules.lifecycle_path_globs` for non-production guard contexts such as tests, smokes, shims, stubs, and fallback files.
+- `audit.detector_rules.utility_suffixes` for PHP role suffixes that should not be forced into a sibling class convention.
+- `audit.detector_rules.convention_exception_globs` for procedural helper files such as `register-*.php` and `*-functions.php`.
+- A narrower `wordpress-constant-backed-slug-literal` pattern that only reports comparison contexts, not array keys or event/protocol names.
+
+## Missing Generic Core Contract
+
+Some WordPress/PHP false-positive shapes need generic core hooks before the extension can express them fully.
+
+### Comment-Based Dead-Guard Contexts
+
+Core `dead_guard` can exempt paths and known lifecycle callbacks, but not source comments near a guard. The extension needs a generic comment-context exemption, for example:
+
+```json
+{
+  "audit": {
+    "detector_rules": {
+      "dead_guard_context_comment_patterns": [
+        "(?i)pure-php smoke tests run without wordpress loaded",
+        "(?i)fallback when wordpress is not loaded"
+      ]
+    }
+  }
+}
+```
+
+Expected core behavior: when a guard is on or near a matching comment block, treat it as contextual and do not emit `dead_guard` even if the guarded symbol is known in production runtime metadata.
+
+### Role-Aware Convention Families
+
+Core can mark suffixes as utility-like after a directory convention is inferred, but it cannot yet split convention inference by extension-owned file roles before method/signature comparison. The extension needs a generic role classifier, for example:
+
+```json
+{
+  "audit": {
+    "detector_rules": {
+      "file_roles": [
+        { "role": "procedural_helper", "path_globs": ["**/register-*.php", "**/*-functions.php"] },
+        { "role": "contract", "type_suffixes": ["Interface", "Contract", "Store"] },
+        { "role": "lock", "type_suffixes": ["Lock"] },
+        { "role": "value", "type_suffixes": ["Value", "Result", "Payload", "Package"] }
+      ],
+      "convention_group_key": ["directory", "role"]
+    }
+  }
+}
+```
+
+Expected core behavior: convention discovery, missing-method checks, naming checks, and signature consistency compare files only within compatible role families. That keeps procedural helpers out of class conventions, store contracts out of lock implementations, and package result/value objects out of one constructor-signature convention.
+
+### Requested Detector Context Filters
+
+Core requested detectors currently support language, extension, and path filters. If the slug-literal detector needs to recover broader matching later, it needs generic match-context filters, for example:
+
+```json
+{
+  "id": "wordpress-constant-backed-slug-literal",
+  "exclude_match_context_patterns": [
+    "['\"]{value}['\"]\\s*=>",
+    "do_action\\s*\\(\\s*['\"]{value}['\"]",
+    "apply_filters\\s*\\(\\s*['\"]{value}['\"]"
+  ]
+}
+```
+
+Expected core behavior: collect candidate matches normally, then drop matches whose surrounding source span satisfies an extension-owned context-exclusion regex.

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,7 +10,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh"
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh tests/audit-detector-config-smoke.sh"
     ],
     "test": [
       "bash scripts/test/host-smoke-runner-smoke.sh",
@@ -22,7 +22,8 @@
       "bash scripts/trace/trace-runner-smoke.sh",
       "bash scripts/lint/wordpress-lint-role-smoke.sh",
       "bash scripts/lint/vendor-prefixed-exclusion-smoke.sh",
-      "bash scripts/lint/eslint-no-files-smoke.sh"
+      "bash scripts/lint/eslint-no-files-smoke.sh",
+      "bash tests/audit-detector-config-smoke.sh"
     ]
   }
 }

--- a/wordpress/tests/audit-detector-config-smoke.sh
+++ b/wordpress/tests/audit-detector-config-smoke.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXTENSION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST_PATH="${1:-${EXTENSION_DIR}/wordpress.json}"
+FIXTURE_DIR="${EXTENSION_DIR}/tests/fixtures/audit-detector-config"
+
+python3 - "$MANIFEST_PATH" "$FIXTURE_DIR" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+fixture_dir = Path(sys.argv[2])
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+rules = manifest["audit"]["detector_rules"]
+
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+utility_suffixes = set(rules.get("utility_suffixes", []))
+for suffix in ["Contract", "Interface", "Store", "Lock", "Result", "Value", "Package"]:
+    require(suffix in utility_suffixes, f"missing PHP role utility suffix: {suffix}")
+
+exception_globs = set(rules.get("convention_exception_globs", []))
+require("**/register-*.php" in exception_globs, "procedural register helpers must be convention-exempt")
+require("**/*-functions.php" in exception_globs, "procedural functions files must be convention-exempt")
+
+lifecycle_globs = set(rules.get("lifecycle_path_globs", []))
+for pattern in ["**/*-smoke.php", "**/*-fallback.php", "**/*-shim.php", "**/*-stub.php"]:
+    require(pattern in lifecycle_globs, f"missing contextual dead-guard path glob: {pattern}")
+
+literal_rule = next(
+    rule for rule in rules["requested_detectors"] if rule["id"] == "wordpress-constant-backed-slug-literal"
+)
+literal_pattern = literal_rule["literal_pattern"].replace("{value}", re.escape("tool_call"))
+literal_regex = re.compile(literal_pattern, re.MULTILINE)
+fixture = (fixture_dir / "src/Runtime/class-demo-event.php").read_text(encoding="utf-8")
+matches = [match.group(0) for match in literal_regex.finditer(fixture)]
+
+require(any("===" in match for match in matches), "constant-backed slug detector should still flag comparisons")
+require(not any(match.strip() == "'tool_call'" for match in matches), "detector must not match a bare literal everywhere")
+require("'tool_call' =>" in fixture, "fixture should include array/protocol key literal")
+require("do_action( 'tool_call'" in fixture, "fixture should include event-name literal")
+
+for relative in [
+    "src/Registry/register-agents.php",
+    "src/Contracts/class-demo-message-store.php",
+    "src/Runtime/class-demo-message-result.php",
+    "tests/runtime-smoke.php",
+]:
+    require((fixture_dir / relative).exists(), f"missing audit detector fixture: {relative}")
+
+print("wordpress audit detector config smoke passed")
+PY

--- a/wordpress/tests/fixtures/audit-detector-config/src/Contracts/class-demo-message-store.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Contracts/class-demo-message-store.php
@@ -1,0 +1,5 @@
+<?php
+
+interface Demo_Message_Store {
+	public function get( string $id ): ?array;
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Registry/register-agents.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Registry/register-agents.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Procedural registration helpers are not class-shape convention members.
+ */
+
+register_agent( 'demo-agent' );

--- a/wordpress/tests/fixtures/audit-detector-config/src/Runtime/class-demo-event.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Runtime/class-demo-event.php
@@ -1,0 +1,15 @@
+<?php
+
+final class Demo_Event {
+	public const TOOL_CALL = 'tool_call';
+
+	public function dispatch(): array {
+		do_action( 'tool_call', $this );
+
+		return array(
+			'tool_call' => true,
+			'type'      => 'tool_call',
+			'matches'   => self::TOOL_CALL === 'tool_call',
+		);
+	}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Runtime/class-demo-message-result.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Runtime/class-demo-message-result.php
@@ -1,0 +1,5 @@
+<?php
+
+final class Demo_Message_Result {
+	public function __construct( public readonly array $payload ) {}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/tests/runtime-smoke.php
+++ b/wordpress/tests/fixtures/audit-detector-config/tests/runtime-smoke.php
@@ -1,0 +1,7 @@
+<?php
+// Pure-PHP smoke tests run without WordPress loaded.
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value ) {
+		return json_encode( $value );
+	}
+}

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "2.40.0",
+  "version": "2.40.1",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",
@@ -191,6 +191,65 @@
   "audit": {
     "setup_references": "scripts/audit/setup-references.sh",
     "detector_rules": {
+      "lifecycle_path_globs": [
+        "**/tests/**/*.php",
+        "**/test/**/*.php",
+        "**/fixtures/**/*.php",
+        "**/fixture/**/*.php",
+        "**/smoke/**/*.php",
+        "**/*-smoke.php",
+        "**/*_smoke.php",
+        "**/*-fallback.php",
+        "**/*_fallback.php",
+        "**/*-shim.php",
+        "**/*_shim.php",
+        "**/*-stub.php",
+        "**/*_stub.php"
+      ],
+      "utility_suffixes": [
+        "Adapter",
+        "Builder",
+        "Collection",
+        "Contract",
+        "Contracts",
+        "DTO",
+        "Data",
+        "Error",
+        "Exception",
+        "Factory",
+        "Fallback",
+        "Helper",
+        "Helpers",
+        "Hydrator",
+        "Interface",
+        "Lock",
+        "Package",
+        "Payload",
+        "Provider",
+        "Registry",
+        "Repository",
+        "Request",
+        "Resolver",
+        "Response",
+        "Result",
+        "Serializer",
+        "Shim",
+        "Store",
+        "Stub",
+        "Transformer",
+        "Value",
+        "Validator"
+      ],
+      "convention_exception_globs": [
+        "**/register-*.php",
+        "**/*-register.php",
+        "**/bootstrap.php",
+        "**/*-bootstrap.php",
+        "**/*_bootstrap.php",
+        "**/functions.php",
+        "**/*-functions.php",
+        "**/*_functions.php"
+      ],
       "known_symbols": {
         "header_versions": [
           {
@@ -286,7 +345,7 @@
           "source_pattern": "(?s)\\b(?:final\\s+|abstract\\s+)?class\\s+(?P<class>[A-Za-z_][A-Za-z0-9_]*)\\b.*?\\b(?:(?:public|protected|private)\\s+)?const\\s+(?P<const>[A-Z][A-Z0-9_]*)\\s*=\\s*['\\\"](?P<value>[a-z][a-z0-9]*(?:[-_/:][a-z0-9]+)+)['\\\"]",
           "value_capture": "value",
           "label": "{class}::{const}",
-          "literal_pattern": "['\\\"]{value}['\\\"]",
+          "literal_pattern": "(?m)(?:[=!]==?\\s*['\\\"]{value}['\\\"]|['\\\"]{value}['\\\"]\\s*[=!]==?)",
           "description": "Raw slug literal `{value}` at line {line} duplicates constant {label}",
           "suggestion": "Use {label} instead of repeating the literal slug so the constant remains the source of truth."
         },


### PR DESCRIPTION
## Summary
- Add WordPress/PHP audit metadata for contextual dead guards, utility role suffixes, and procedural helper convention exemptions.
- Narrow constant-backed slug literal detection to comparison contexts so event names and array/protocol keys do not get treated as constant-governed values.
- Add audit detector fixtures/smoke coverage and document the remaining generic Homeboy core contracts needed for deeper role-aware convention grouping.

Fixes #408.
Refs Extra-Chill/homeboy#2309.

## Tests
- `jq empty wordpress.json homeboy.json`
- `bash tests/audit-detector-config-smoke.sh`
- `homeboy lint wordpress --path /Users/chubes/Developer/homeboy-extensions/wordpress`
- `homeboy test wordpress --path /Users/chubes/Developer/homeboy-extensions/wordpress`

## Core dependency
- Extension-side config now consumes the currently supported generic hooks: `lifecycle_path_globs`, `utility_suffixes`, and `convention_exception_globs`.
- Full resolution of Extra-Chill/homeboy#2309 still needs core support for comment-based `dead_guard` exemptions and role-aware convention grouping/signature comparison before inference. The proposed generic contract is documented in `wordpress/docs/audit-core-contract-gaps.md`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the WordPress extension audit config, fixtures, smoke test, and core-contract documentation; Chris remains responsible for review and merge.