### PR TITLE
fix(wordpress): split audit roles + curate dead-guard known symbols (#410, #411)

### DIFF
--- a/wordpress/docs/audit-core-contract-gaps.md
+++ b/wordpress/docs/audit-core-contract-gaps.md
@@ -4,20 +4,91 @@ The WordPress extension owns PHP and WordPress semantics. Homeboy core should st
 
 ## Supported Today
 
-The extension now uses the generic knobs Homeboy already exposes:
+The extension uses these generic knobs Homeboy already exposes:
 
 - `audit.detector_rules.lifecycle_path_globs` for non-production guard contexts such as tests, smokes, shims, stubs, and fallback files.
-- `audit.detector_rules.utility_suffixes` for PHP role suffixes that should not be forced into a sibling class convention.
-- `audit.detector_rules.convention_exception_globs` for procedural helper files such as `register-*.php` and `*-functions.php`.
+- `audit.detector_rules.utility_suffixes` for PHP role suffixes that should not be forced into a sibling class convention when a dominant naming suffix exists.
+- `audit.detector_rules.convention_exception_globs` for procedural helper files such as `register-*.php` and `*-functions.php`, plus PHP role-suffix file globs (`class-*-store.php`, `class-*-registry.php`, `class-*-result.php`, etc.) that fully exempt those files from missing-method/registration/interface checks.
 - A narrower `wordpress-constant-backed-slug-literal` pattern that only reports comparison contexts, not array keys or event/protocol names.
 
-## Missing Generic Core Contract
+## Role-Aware Convention Grouping (`convention_tag_globs`)
 
-Some WordPress/PHP false-positive shapes need generic core hooks before the extension can express them fully.
+Homeboy core supports `audit.detector_rules.convention_tag_globs` on `main`. This is the contract the WordPress extension uses to separate unrelated PHP roles within the same directory. Each rule attaches an opaque tag to file globs:
+
+```json
+{
+  "audit": {
+    "detector_rules": {
+      "convention_tag_globs": [
+        {
+          "tag": "wordpress:php-role:contract",
+          "globs": [
+            "**/class-*-store.php",
+            "**/class-*-adopter.php",
+            "**/class-*-resolver.php"
+          ]
+        },
+        {
+          "tag": "wordpress:php-role:registry",
+          "globs": ["**/class-*-registry.php"]
+        }
+      ]
+    }
+  }
+}
+```
+
+Core does not interpret the tag string. It uses tag membership as part of the convention group key, so files with different tags inside the same directory land in different convention groups. That keeps store contracts, registries, adopter interfaces, result/diff objects, factories, and value objects out of one shared method/signature convention.
+
+Extensions own the role taxonomy. Tags are namespaced (`wordpress:php-role:*`) so multiple extensions in the same component never collide.
+
+### v0.157.0 Compatibility Note
+
+Core `v0.157.0` ships without `convention_tag_globs`. Unknown fields in extension audit config deserialize cleanly there (no `deny_unknown_fields`), so this configuration is forward-compatible: it is silently ignored by `v0.157.0` and lights up automatically once the consuming host upgrades to a release containing `fd422975 fix: separate audit conventions with opaque tags`.
+
+For `v0.157.0`, the extension also ships expanded `convention_exception_globs` covering the same role-suffix paths. That suppresses missing-method, missing-registration, and missing-interface false positives on contract/registry/result/etc. files. Two limits of that fallback:
+
+- Convention-exempt files still feed namespace, import, and signature-consistency comparisons inside the merged directory group, so cross-role constructor-signature drift can still surface on `v0.157.0` for directories that mix value objects and result/registry types.
+- File counts inside any tagged role group can drop below the two-file minimum on `v0.157.0`, but only because tag-based splitting is unavailable. Once the host upgrades, the same files reorganize cleanly under their tags.
+
+The "right" fix lives in core. Until the host upgrades, the extension's combination of `convention_tag_globs` (forward-compat) plus `convention_exception_globs` (today) is the closest faithful approximation that does not push PHP knowledge into Homeboy core.
+
+## Known-Symbol Curation for Dual-Context Code
+
+Core `dead_guard` flags any `function_exists`/`class_exists`/`defined` guard whose symbol the extension declared in `audit.detector_rules.known_symbols`. The extension owns that list. The contract is "guaranteed to exist at runtime", which is stronger than "ships with WordPress".
+
+Some WordPress library code legitimately runs in two contexts:
+
+- Inside a loaded WordPress install, where the WP function is available.
+- Inside a pure-PHP smoke test or vendored consumer, where it is not.
+
+For these dual-context shapes the conventional WordPress idiom is a defensive guard with a pure-PHP fallback:
+
+```php
+private static function json_encode( $data ) {
+    if ( function_exists( 'wp_json_encode' ) ) {
+        return wp_json_encode( $data );
+    }
+
+    // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Pure-PHP smoke tests run without WordPress loaded.
+    return json_encode( $data );
+}
+```
+
+This is correct production code, not a dead branch. The extension therefore curates `known_symbols.header_versions` along a single principle:
+
+- **Include** WordPress symbols that have no natural pure-PHP equivalent and whose presence implies "WordPress is loaded": REST classes (`WP_REST_Server`, `WP_REST_Request`, `WP_REST_Response`), block infrastructure (`WP_Block`, `WP_Block_Type_Registry`, `register_block_type`, `parse_blocks`, `has_blocks`), HTML processing (`WP_HTML_Tag_Processor`), abilities (`WP_Ability`), REST routing (`register_rest_route`), post-type metadata (`get_post_type_object`), environment classification (`wp_get_environment_type`), and the `REST_REQUEST` constant.
+- **Exclude** WordPress utility wrappers that are interchangeable with a pure-PHP standard-library call: JSON encoding (`wp_json_encode` ↔ `json_encode`), UUID generation (`wp_generate_uuid4` ↔ `random_bytes` + `bin2hex`), URL parsing (`wp_parse_url` ↔ `parse_url`), date/timezone helpers (`wp_date`, `wp_timezone`, `wp_timezone_string` ↔ `DateTimeImmutable`/`DateTimeZone`).
+
+Excluded symbols simply never enter the dead-guard known-symbol table, so a guard around `wp_json_encode` is treated like any unknown symbol — left alone. WP-only symbols still produce real `dead_guard` findings when guarded outside lifecycle/test contexts. Both behaviors are exercised by `tests/audit-detector-config-smoke.sh` against fixtures under `tests/fixtures/audit-dead-guard-fallback/` and `tests/fixtures/audit-dead-guard-wp-only/`.
+
+This curation is generic: it expresses "what WordPress utility functions have natural pure-PHP fallbacks" without naming any consumer plugin's paths.
+
+## Other Generic Core Hooks Still Missing
 
 ### Comment-Based Dead-Guard Contexts
 
-Core `dead_guard` can exempt paths and known lifecycle callbacks, but not source comments near a guard. The extension needs a generic comment-context exemption, for example:
+Core `dead_guard` can exempt paths and known lifecycle callbacks, but not source comments near a guard. A more granular comment-context exemption would let the extension keep utility wrappers in `known_symbols` while letting individual call sites mark themselves as dual-context. Sketch:
 
 ```json
 {
@@ -32,29 +103,7 @@ Core `dead_guard` can exempt paths and known lifecycle callbacks, but not source
 }
 ```
 
-Expected core behavior: when a guard is on or near a matching comment block, treat it as contextual and do not emit `dead_guard` even if the guarded symbol is known in production runtime metadata.
-
-### Role-Aware Convention Families
-
-Core can mark suffixes as utility-like after a directory convention is inferred, but it cannot yet split convention inference by extension-owned file roles before method/signature comparison. The extension needs a generic role classifier, for example:
-
-```json
-{
-  "audit": {
-    "detector_rules": {
-      "file_roles": [
-        { "role": "procedural_helper", "path_globs": ["**/register-*.php", "**/*-functions.php"] },
-        { "role": "contract", "type_suffixes": ["Interface", "Contract", "Store"] },
-        { "role": "lock", "type_suffixes": ["Lock"] },
-        { "role": "value", "type_suffixes": ["Value", "Result", "Payload", "Package"] }
-      ],
-      "convention_group_key": ["directory", "role"]
-    }
-  }
-}
-```
-
-Expected core behavior: convention discovery, missing-method checks, naming checks, and signature consistency compare files only within compatible role families. That keeps procedural helpers out of class conventions, store contracts out of lock implementations, and package result/value objects out of one constructor-signature convention.
+Expected core behavior: when a guard is on or near a matching comment block, treat it as contextual and do not emit `dead_guard` even if the guarded symbol is known in production runtime metadata. Until that lands, the curation principle above is the WordPress-extension-only resolution.
 
 ### Requested Detector Context Filters
 

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,7 +10,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh tests/audit-detector-config-smoke.sh"
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh"
     ],
     "test": [
       "bash scripts/test/host-smoke-runner-smoke.sh",
@@ -23,7 +23,8 @@
       "bash scripts/lint/wordpress-lint-role-smoke.sh",
       "bash scripts/lint/vendor-prefixed-exclusion-smoke.sh",
       "bash scripts/lint/eslint-no-files-smoke.sh",
-      "bash tests/audit-detector-config-smoke.sh"
+      "bash tests/audit-detector-config-smoke.sh",
+      "bash tests/audit-dead-guard-fallback-smoke.sh"
     ]
   }
 }

--- a/wordpress/tests/audit-dead-guard-fallback-smoke.sh
+++ b/wordpress/tests/audit-dead-guard-fallback-smoke.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Verifies that core's dead_guard detector ignores WordPress-utility guards
+# whose else-branch is a natural pure-PHP fallback (the dual-context idiom),
+# while still reporting guards around symbols that only ship with WordPress.
+#
+# The contract under test lives entirely in wordpress.json's
+# audit.detector_rules.known_symbols.header_versions list. WordPress utility
+# wrappers with natural pure-PHP equivalents must not be declared there;
+# WordPress-only types/functions must remain declared.
+
+set -euo pipefail
+
+EXTENSION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST_PATH="${MANIFEST_PATH:-${EXTENSION_DIR}/wordpress.json}"
+FALLBACK_FIXTURE="${EXTENSION_DIR}/tests/fixtures/audit-dead-guard-fallback"
+WP_ONLY_FIXTURE="${EXTENSION_DIR}/tests/fixtures/audit-dead-guard-wp-only"
+
+# Step 1: manifest contract — utility wrappers excluded, WP-only kept.
+python3 - "$MANIFEST_PATH" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+header_versions = manifest["audit"]["detector_rules"]["known_symbols"]["header_versions"]
+declared = {entry["name"] for provider in header_versions for entry in provider.get("symbols", [])}
+
+excluded = [
+    "wp_json_encode",
+    "wp_generate_uuid4",
+    "wp_parse_url",
+    "wp_date",
+    "wp_timezone",
+    "wp_timezone_string",
+]
+violations = [name for name in excluded if name in declared]
+if violations:
+    raise SystemExit(
+        "WordPress utility wrappers with natural pure-PHP fallbacks must not be "
+        "declared in known_symbols.header_versions: "
+        + ", ".join(sorted(violations))
+    )
+
+required = [
+    "register_rest_route",
+    "register_block_type",
+    "WP_REST_Server",
+    "WP_REST_Request",
+    "WP_REST_Response",
+    "WP_Block_Type_Registry",
+    "WP_Block",
+    "REST_REQUEST",
+]
+missing = [name for name in required if name not in declared]
+if missing:
+    raise SystemExit(
+        "WordPress-only symbols must remain in known_symbols.header_versions: "
+        + ", ".join(sorted(missing))
+    )
+
+print("manifest contract ok")
+PY
+
+# Step 2: behavioral contract — only run if a homeboy CLI is available.
+# Prefer the Homebrew install over a stale `cargo install` build so behavior is
+# reproducible across hosts; respect HOMEBOY_BIN when callers know better.
+if [[ -z "${HOMEBOY_BIN:-}" ]]; then
+    if [[ -x "/opt/homebrew/bin/homeboy" ]]; then
+        HOMEBOY_BIN="/opt/homebrew/bin/homeboy"
+    elif [[ -x "/usr/local/bin/homeboy" ]]; then
+        HOMEBOY_BIN="/usr/local/bin/homeboy"
+    else
+        HOMEBOY_BIN="$(command -v homeboy || true)"
+    fi
+fi
+if [[ -z "${HOMEBOY_BIN}" ]]; then
+    echo "homeboy CLI unavailable; skipping behavioral audit checks" >&2
+    echo "wordpress audit dead-guard fallback smoke passed (manifest only)"
+    exit 0
+fi
+
+run_audit() {
+    local fixture_path="$1"
+    local out_path="$2"
+    "${HOMEBOY_BIN}" audit --path "${fixture_path}" --output "${out_path}" --force-hot >/dev/null
+}
+
+FALLBACK_REPORT="$(mktemp -t audit-fallback.XXXXXX.json)"
+WP_ONLY_REPORT="$(mktemp -t audit-wp-only.XXXXXX.json)"
+trap 'rm -f "${FALLBACK_REPORT}" "${WP_ONLY_REPORT}"' EXIT
+
+run_audit "${FALLBACK_FIXTURE}" "${FALLBACK_REPORT}"
+run_audit "${WP_ONLY_FIXTURE}" "${WP_ONLY_REPORT}"
+
+python3 - "$FALLBACK_REPORT" "$WP_ONLY_REPORT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+fallback = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+wp_only = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+
+def files_scanned(report):
+    return (report.get("data", {}).get("summary") or {}).get("files_scanned", 0)
+
+# Sanity-guard against an audit binary that fails to recurse src/ — without
+# this, a zero-finding wp-only run would look like a known-symbol regression
+# instead of a scanning regression.
+for label, report in (("fallback", fallback), ("wp_only", wp_only)):
+    if files_scanned(report) < 2:
+        raise SystemExit(
+            f"{label} fixture audit scanned {files_scanned(report)} files; "
+            "expected the runner to recurse into src/Runtime/. The homeboy "
+            "binary on PATH may be stale or built differently from the "
+            "shipping release."
+        )
+
+def dead_guards(report):
+    return [
+        finding
+        for finding in report.get("data", {}).get("findings", [])
+        if finding.get("kind") == "dead_guard"
+    ]
+
+fallback_guards = dead_guards(fallback)
+if fallback_guards:
+    raise SystemExit(
+        "fallback fixture must produce zero dead_guard findings, got: "
+        + json.dumps(fallback_guards, indent=2)
+    )
+
+wp_only_guards = dead_guards(wp_only)
+if not wp_only_guards:
+    raise SystemExit(
+        "wp-only fixture must still report dead_guard findings; "
+        "core's known-symbol pipeline appears broken or the fixture changed shape"
+    )
+
+descriptions = " | ".join(g["description"] for g in wp_only_guards)
+if "WP_REST_Server" not in descriptions:
+    raise SystemExit(
+        "wp-only fixture should still flag class_exists('WP_REST_Server'); got: "
+        + descriptions
+    )
+if "register_rest_route" not in descriptions:
+    raise SystemExit(
+        "wp-only fixture should still flag function_exists('register_rest_route'); got: "
+        + descriptions
+    )
+
+print(
+    "behavioral contract ok: fallback=%d findings, wp_only=%d findings"
+    % (len(fallback_guards), len(wp_only_guards))
+)
+PY
+
+echo "wordpress audit dead-guard fallback smoke passed"

--- a/wordpress/tests/audit-detector-config-smoke.sh
+++ b/wordpress/tests/audit-detector-config-smoke.sh
@@ -6,6 +6,7 @@ MANIFEST_PATH="${1:-${EXTENSION_DIR}/wordpress.json}"
 FIXTURE_DIR="${EXTENSION_DIR}/tests/fixtures/audit-detector-config"
 
 python3 - "$MANIFEST_PATH" "$FIXTURE_DIR" <<'PY'
+import fnmatch
 import json
 import re
 import sys
@@ -28,9 +29,102 @@ exception_globs = set(rules.get("convention_exception_globs", []))
 require("**/register-*.php" in exception_globs, "procedural register helpers must be convention-exempt")
 require("**/*-functions.php" in exception_globs, "procedural functions files must be convention-exempt")
 
+# v0.157.0 best-effort — off-role file suffixes must be exempt from sibling-method conventions.
+for pattern in [
+    "**/class-*-store.php",
+    "**/class-*-registry.php",
+    "**/class-*-adopter.php",
+    "**/class-*-resolver.php",
+    "**/class-*-result.php",
+    "**/class-*-diff.php",
+    "**/class-*-factory.php",
+    "**/class-*-adapter.php",
+    "**/class-*-lock.php",
+]:
+    require(pattern in exception_globs, f"missing PHP role exception glob: {pattern}")
+
 lifecycle_globs = set(rules.get("lifecycle_path_globs", []))
 for pattern in ["**/*-smoke.php", "**/*-fallback.php", "**/*-shim.php", "**/*-stub.php"]:
     require(pattern in lifecycle_globs, f"missing contextual dead-guard path glob: {pattern}")
+
+# Forward-compat (core main): convention_tag_globs splits unrelated PHP roles.
+tag_globs = rules.get("convention_tag_globs", [])
+require(tag_globs, "convention_tag_globs must be configured to split PHP roles in mixed directories")
+
+required_tags = {
+    "wordpress:php-role:procedural-helper",
+    "wordpress:php-role:contract",
+    "wordpress:php-role:registry",
+    "wordpress:php-role:result",
+    "wordpress:php-role:adapter",
+    "wordpress:php-role:factory",
+    "wordpress:php-role:lock",
+    "wordpress:php-role:null-impl",
+}
+have_tags = {entry["tag"] for entry in tag_globs}
+missing_tags = required_tags - have_tags
+require(not missing_tags, f"missing convention_tag_globs roles: {sorted(missing_tags)}")
+
+# Tags must be opaque, namespaced strings — core never interprets them.
+for entry in tag_globs:
+    require("tag" in entry and "globs" in entry, f"convention_tag_globs entry malformed: {entry}")
+    require(entry["tag"].startswith("wordpress:"), f"convention tag must be namespaced: {entry['tag']}")
+    require(entry["globs"], f"convention tag {entry['tag']} must declare path globs")
+
+# Each role's globs must match files in the canonical role.
+def globs_for(tag):
+    for entry in tag_globs:
+        if entry["tag"] == tag:
+            return entry["globs"]
+    return []
+
+def matches_any(path, patterns):
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns)
+
+# Identity fixture: store contract gets contract tag; value objects get no tag.
+identity_store = "src/Identity/class-demo-identity-store.php"
+identity_scope = "src/Identity/class-demo-identity-scope.php"
+identity_materialized = "src/Identity/class-demo-materialized-identity.php"
+require(matches_any(identity_store, globs_for("wordpress:php-role:contract")),
+        "identity store fixture must be tagged as contract role")
+require(not matches_any(identity_scope, globs_for("wordpress:php-role:contract")),
+        "identity scope value object must not be tagged as contract role")
+require(not matches_any(identity_materialized, globs_for("wordpress:php-role:contract")),
+        "materialized identity value object must not be tagged as contract role")
+
+# Packages fixture: split into value/contract/result/registry/procedural roles.
+packages_value_paths = [
+    "src/Packages/class-demo-package.php",
+    "src/Packages/class-demo-package-artifact.php",
+    "src/Packages/class-demo-package-artifact-type.php",
+]
+for path in packages_value_paths:
+    for tag in required_tags:
+        require(not matches_any(path, globs_for(tag)),
+                f"value-object fixture {path} must remain untagged (matched {tag})")
+
+require(matches_any("src/Packages/class-demo-package-adopter.php", globs_for("wordpress:php-role:contract")),
+        "adopter interface fixture must be tagged as contract role")
+require(matches_any("src/Packages/class-demo-package-adoption-result.php", globs_for("wordpress:php-role:result")),
+        "adoption result fixture must be tagged as result role")
+require(matches_any("src/Packages/class-demo-package-adoption-diff.php", globs_for("wordpress:php-role:result")),
+        "adoption diff fixture must be tagged as result role")
+require(matches_any("src/Packages/class-demo-package-artifacts-registry.php", globs_for("wordpress:php-role:registry")),
+        "artifacts registry fixture must be tagged as registry role")
+require(matches_any("src/Packages/register-demo-package-artifacts.php", globs_for("wordpress:php-role:procedural-helper")),
+        "procedural helper fixture must be tagged as procedural-helper role")
+
+# v0.157.0 best-effort fallback: every off-role file must also be in convention_exception_globs.
+for path in [
+    "src/Identity/class-demo-identity-store.php",
+    "src/Packages/class-demo-package-adopter.php",
+    "src/Packages/class-demo-package-adoption-result.php",
+    "src/Packages/class-demo-package-adoption-diff.php",
+    "src/Packages/class-demo-package-artifacts-registry.php",
+    "src/Packages/register-demo-package-artifacts.php",
+]:
+    require(matches_any(path, exception_globs),
+            f"off-role file {path} must also be exempt for v0.157.0 fallback")
 
 literal_rule = next(
     rule for rule in rules["requested_detectors"] if rule["id"] == "wordpress-constant-backed-slug-literal"
@@ -50,6 +144,17 @@ for relative in [
     "src/Contracts/class-demo-message-store.php",
     "src/Runtime/class-demo-message-result.php",
     "tests/runtime-smoke.php",
+    "src/Identity/class-demo-identity-scope.php",
+    "src/Identity/class-demo-identity-store.php",
+    "src/Identity/class-demo-materialized-identity.php",
+    "src/Packages/class-demo-package.php",
+    "src/Packages/class-demo-package-artifact.php",
+    "src/Packages/class-demo-package-artifact-type.php",
+    "src/Packages/class-demo-package-adopter.php",
+    "src/Packages/class-demo-package-adoption-result.php",
+    "src/Packages/class-demo-package-adoption-diff.php",
+    "src/Packages/class-demo-package-artifacts-registry.php",
+    "src/Packages/register-demo-package-artifacts.php",
 ]:
     require((fixture_dir / relative).exists(), f"missing audit detector fixture: {relative}")
 

--- a/wordpress/tests/fixtures/audit-dead-guard-fallback/dual-context-plugin.php
+++ b/wordpress/tests/fixtures/audit-dead-guard-fallback/dual-context-plugin.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Plugin Name: Dual Context Plugin
+ * Description: Fixture exercising WordPress + pure-PHP fallback guards.
+ * Requires at least: 6.0
+ * Requires PHP: 8.1
+ * Author: Extra Chill
+ * License: GPL-2.0-or-later
+ *
+ * The shape under test:
+ *
+ * - Production source under src/ defensively guards WordPress utility helpers
+ *   that have natural pure-PHP equivalents (wp_json_encode, wp_generate_uuid4).
+ * - The library is intended to load both inside WordPress and inside pure-PHP
+ *   smoke tests, so the guard's else branch is reached for real.
+ * - The WordPress extension's audit.detector_rules.known_symbols list must not
+ *   declare these utility helpers as guaranteed at runtime, otherwise core's
+ *   dead_guard detector will report the guards as dead.
+ */
+
+require_once __DIR__ . '/src/Runtime/class-dual-context-encoder.php';
+require_once __DIR__ . '/src/Runtime/class-dual-context-identifier.php';

--- a/wordpress/tests/fixtures/audit-dead-guard-fallback/src/Runtime/class-dual-context-encoder.php
+++ b/wordpress/tests/fixtures/audit-dead-guard-fallback/src/Runtime/class-dual-context-encoder.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Encoder helper that prefers WordPress JSON encoding when available and
+ * otherwise falls back to the PHP standard library. The fallback is reached
+ * during pure-PHP smoke tests run without WordPress loaded.
+ */
+
+final class Dual_Context_Encoder {
+	/**
+	 * Encode a value as JSON.
+	 *
+	 * @param mixed $value Value to encode.
+	 * @return string|false
+	 */
+	public static function encode( $value ) {
+		if ( function_exists( 'wp_json_encode' ) ) {
+			return wp_json_encode( $value );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Pure-PHP smoke tests run without WordPress loaded.
+		return json_encode( $value );
+	}
+}

--- a/wordpress/tests/fixtures/audit-dead-guard-fallback/src/Runtime/class-dual-context-identifier.php
+++ b/wordpress/tests/fixtures/audit-dead-guard-fallback/src/Runtime/class-dual-context-identifier.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Identifier helper that prefers wp_generate_uuid4 when WordPress is loaded
+ * and otherwise falls back to a pure-PHP UUID-shaped random string.
+ */
+
+final class Dual_Context_Identifier {
+	/**
+	 * Generate a request/chain identifier.
+	 *
+	 * @return string
+	 */
+	public static function generate(): string {
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			return wp_generate_uuid4();
+		}
+
+		return bin2hex( random_bytes( 16 ) );
+	}
+}

--- a/wordpress/tests/fixtures/audit-dead-guard-wp-only/src/Runtime/class-rest-bootstrap.php
+++ b/wordpress/tests/fixtures/audit-dead-guard-wp-only/src/Runtime/class-rest-bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * REST bootstrap that defensively guards genuinely-WordPress-only symbols.
+ * Both guards are dead at runtime: the plugin floor guarantees the symbols
+ * whenever WordPress is loaded, and neither symbol has a meaningful pure-PHP
+ * fallback shape, so dead_guard should still report them.
+ */
+
+final class REST_Bootstrap {
+	public static function boot(): void {
+		if ( ! class_exists( 'WP_REST_Server' ) ) {
+			return;
+		}
+
+		if ( function_exists( 'register_rest_route' ) ) {
+			register_rest_route( 'demo/v1', '/ping', array() );
+		}
+	}
+}

--- a/wordpress/tests/fixtures/audit-dead-guard-wp-only/src/Runtime/class-rest-helper.php
+++ b/wordpress/tests/fixtures/audit-dead-guard-wp-only/src/Runtime/class-rest-helper.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * REST helper used alongside REST_Bootstrap. Present so the wp-only fixture
+ * has the same overall PHP file count as the dual-context fallback fixture,
+ * which keeps the smoke test's behavioral contract symmetric.
+ */
+
+final class REST_Helper {
+	public static function namespace_for( string $version ): string {
+		return 'demo/' . $version;
+	}
+}

--- a/wordpress/tests/fixtures/audit-dead-guard-wp-only/wp-only-plugin.php
+++ b/wordpress/tests/fixtures/audit-dead-guard-wp-only/wp-only-plugin.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Plugin Name: WP Only Plugin
+ * Description: Fixture exercising guards around symbols that only ship with WordPress.
+ * Requires at least: 6.0
+ * Requires PHP: 8.1
+ * Author: Extra Chill
+ * License: GPL-2.0-or-later
+ *
+ * The shape under test:
+ *
+ * - Production source guards a WordPress-only class (WP_REST_Server) and a
+ *   WordPress-only function (register_rest_route) outside any lifecycle/test
+ *   path. Neither symbol has a sensible pure-PHP fallback.
+ * - The WordPress extension keeps these symbols in known_symbols, so core's
+ *   dead_guard detector should still flag the guards as redundant.
+ */
+
+require_once __DIR__ . '/src/Runtime/class-rest-bootstrap.php';

--- a/wordpress/tests/fixtures/audit-detector-config/src/Identity/class-demo-identity-scope.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Identity/class-demo-identity-scope.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Identity scope value object — declares a `key()` method shared by sibling
+ * value objects. The `class-*-store.php` interface in the same directory must
+ * not be forced into this method convention.
+ */
+
+final class Demo_Identity_Scope {
+	public function __construct( public readonly string $owner_id, public readonly string $tenant ) {}
+
+	public function key(): string {
+		return $this->owner_id . ':' . $this->tenant;
+	}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Identity/class-demo-identity-store.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Identity/class-demo-identity-store.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Identity store contract — persistence interface, NOT a value object. Must
+ * not be flagged as missing `key()` because it sits next to two value-object
+ * siblings that happen to share that method.
+ */
+
+interface Demo_Identity_Store {
+	public function resolve( Demo_Identity_Scope $scope ): ?Demo_Materialized_Identity;
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Identity/class-demo-materialized-identity.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Identity/class-demo-materialized-identity.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Materialized identity value object — sibling of the scope above.
+ */
+
+final class Demo_Materialized_Identity {
+	public function __construct(
+		public readonly int $identity_id,
+		public readonly string $owner_id,
+		public readonly string $tenant
+	) {}
+
+	public function key(): string {
+		return $this->owner_id . ':' . $this->tenant;
+	}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-adopter.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-adopter.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Adopter contract — interface, distinct PHP role from the value-object
+ * siblings.
+ */
+
+interface Demo_Package_Adopter {
+	public function diff( Demo_Package $package ): Demo_Package_Adoption_Diff;
+
+	public function adopt( Demo_Package $package ): Demo_Package_Adoption_Result;
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-adoption-diff.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-adoption-diff.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Adoption diff — sibling result-shaped object.
+ */
+
+final class Demo_Package_Adoption_Diff {
+	public function __construct(
+		public readonly string $status,
+		public readonly array $additions = array(),
+		public readonly array $removals = array()
+	) {}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-adoption-result.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-adoption-result.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Adoption result — distinct constructor shape (status-driven), separate role
+ * from the package value-object family.
+ */
+
+final class Demo_Package_Adoption_Result {
+	public function __construct(
+		public readonly string $status,
+		public readonly ?string $adopted_slug = null,
+		public readonly array $messages = array()
+	) {}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-artifact-type.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-artifact-type.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Artifact type marker — value-object family alongside the package and
+ * artifact siblings.
+ */
+
+final class Demo_Package_Artifact_Type {
+	public function __construct(
+		public readonly string $slug,
+		public readonly array $definition,
+		public readonly array $artifacts
+	) {}
+
+	public function to_array(): array {
+		return array(
+			'slug'       => $this->slug,
+			'definition' => $this->definition,
+			'artifacts'  => $this->artifacts,
+		);
+	}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-artifact.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-artifact.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Artifact value object inside a package. Same constructor shape family as the
+ * package manifest above.
+ */
+
+final class Demo_Package_Artifact {
+	public function __construct(
+		public readonly string $slug,
+		public readonly array $definition,
+		public readonly array $artifacts
+	) {}
+
+	public function to_array(): array {
+		return array(
+			'slug'       => $this->slug,
+			'definition' => $this->definition,
+			'artifacts'  => $this->artifacts,
+		);
+	}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-artifacts-registry.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-artifacts-registry.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Artifacts registry — singleton service role, distinct from value objects,
+ * results, and adopter contracts.
+ */
+
+final class Demo_Package_Artifacts_Registry {
+	private static ?self $instance = null;
+
+	/** @var array<string, Demo_Package_Artifact_Type> */
+	private array $types = array();
+
+	private function __construct() {}
+
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	public function register( Demo_Package_Artifact_Type $type ): void {
+		$this->types[ $type->slug ] = $type;
+	}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Package value object — declarative manifest. Sibling of the artifact value
+ * objects below; together they form a small constructor convention that the
+ * detector should NOT pollute with adopter/registry/result roles.
+ */
+
+final class Demo_Package {
+	public function __construct(
+		public readonly string $slug,
+		public readonly array $definition,
+		public readonly array $artifacts
+	) {}
+
+	public function to_array(): array {
+		return array(
+			'slug'       => $this->slug,
+			'definition' => $this->definition,
+			'artifacts'  => $this->artifacts,
+		);
+	}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Packages/register-demo-package-artifacts.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Packages/register-demo-package-artifacts.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Procedural helper — registers the demo artifact types. Already covered by
+ * `convention_exception_globs` `**\/register-*.php`.
+ */
+
+Demo_Package_Artifacts_Registry::instance()->register(
+	new Demo_Package_Artifact_Type( 'demo', array(), array() )
+);

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -248,7 +248,127 @@
         "**/*_bootstrap.php",
         "**/functions.php",
         "**/*-functions.php",
-        "**/*_functions.php"
+        "**/*_functions.php",
+        "**/class-*-store.php",
+        "**/class-*-stores.php",
+        "**/class-*-registry.php",
+        "**/class-*-registries.php",
+        "**/class-*-repository.php",
+        "**/class-*-repositories.php",
+        "**/class-*-adopter.php",
+        "**/class-*-adapter.php",
+        "**/class-*-bridge.php",
+        "**/class-*-resolver.php",
+        "**/class-*-handler.php",
+        "**/class-*-validator.php",
+        "**/class-*-persister.php",
+        "**/class-*-runner.php",
+        "**/class-*-executor.php",
+        "**/class-*-dispatcher.php",
+        "**/class-*-router.php",
+        "**/class-*-factory.php",
+        "**/class-*-builder.php",
+        "**/class-*-hydrator.php",
+        "**/class-*-result.php",
+        "**/class-*-results.php",
+        "**/class-*-diff.php",
+        "**/class-*-report.php",
+        "**/class-*-response.php",
+        "**/class-*-outcome.php",
+        "**/class-*-decision.php",
+        "**/class-*-policy.php",
+        "**/class-*-policy-filter.php",
+        "**/class-*-policy-provider.php",
+        "**/class-*-policy-resolver.php",
+        "**/class-*-lock.php",
+        "**/class-*-locks.php",
+        "**/class-null-*.php",
+        "**/class-*-null-*.php"
+      ],
+      "convention_tag_globs": [
+        {
+          "tag": "wordpress:php-role:procedural-helper",
+          "globs": [
+            "**/register-*.php",
+            "**/*-register.php",
+            "**/bootstrap.php",
+            "**/*-bootstrap.php",
+            "**/*_bootstrap.php",
+            "**/functions.php",
+            "**/*-functions.php",
+            "**/*_functions.php"
+          ]
+        },
+        {
+          "tag": "wordpress:php-role:contract",
+          "globs": [
+            "**/class-*-store.php",
+            "**/class-*-stores.php",
+            "**/class-*-repository.php",
+            "**/class-*-repositories.php",
+            "**/class-*-adopter.php",
+            "**/class-*-resolver.php",
+            "**/class-*-handler.php",
+            "**/class-*-validator.php",
+            "**/class-*-persister.php",
+            "**/class-*-runner.php",
+            "**/class-*-executor.php",
+            "**/class-*-dispatcher.php",
+            "**/class-*-router.php",
+            "**/class-*-policy.php",
+            "**/class-*-policy-filter.php",
+            "**/class-*-policy-provider.php",
+            "**/class-*-policy-resolver.php"
+          ]
+        },
+        {
+          "tag": "wordpress:php-role:registry",
+          "globs": [
+            "**/class-*-registry.php",
+            "**/class-*-registries.php"
+          ]
+        },
+        {
+          "tag": "wordpress:php-role:adapter",
+          "globs": [
+            "**/class-*-adapter.php",
+            "**/class-*-bridge.php"
+          ]
+        },
+        {
+          "tag": "wordpress:php-role:factory",
+          "globs": [
+            "**/class-*-factory.php",
+            "**/class-*-builder.php",
+            "**/class-*-hydrator.php"
+          ]
+        },
+        {
+          "tag": "wordpress:php-role:result",
+          "globs": [
+            "**/class-*-result.php",
+            "**/class-*-results.php",
+            "**/class-*-diff.php",
+            "**/class-*-report.php",
+            "**/class-*-response.php",
+            "**/class-*-outcome.php",
+            "**/class-*-decision.php"
+          ]
+        },
+        {
+          "tag": "wordpress:php-role:lock",
+          "globs": [
+            "**/class-*-lock.php",
+            "**/class-*-locks.php"
+          ]
+        },
+        {
+          "tag": "wordpress:php-role:null-impl",
+          "globs": [
+            "**/class-null-*.php",
+            "**/class-*-null-*.php"
+          ]
+        }
       ],
       "known_symbols": {
         "header_versions": [
@@ -257,15 +377,10 @@
             "version_header": "Requires at least:",
             "symbols": [
               { "name": "get_post_type_object", "kind": "function", "introduced": "3.0" },
-              { "name": "wp_json_encode", "kind": "function", "introduced": "4.4" },
-              { "name": "wp_generate_uuid4", "kind": "function", "introduced": "4.7" },
               { "name": "register_rest_route", "kind": "function", "introduced": "4.4" },
               { "name": "register_block_type", "kind": "function", "introduced": "5.0" },
               { "name": "has_blocks", "kind": "function", "introduced": "5.0" },
               { "name": "parse_blocks", "kind": "function", "introduced": "5.0" },
-              { "name": "wp_timezone_string", "kind": "function", "introduced": "5.1" },
-              { "name": "wp_timezone", "kind": "function", "introduced": "5.3" },
-              { "name": "wp_date", "kind": "function", "introduced": "5.3" },
               { "name": "wp_get_environment_type", "kind": "function", "introduced": "5.5" },
               { "name": "WP_REST_Server", "kind": "class", "introduced": "4.4" },
               { "name": "WP_REST_Request", "kind": "class", "introduced": "4.4" },


### PR DESCRIPTION
## Summary
- Curate `audit.detector_rules.known_symbols` so WordPress utility wrappers that have natural pure-PHP equivalents (`wp_json_encode` ↔ `json_encode`, `wp_generate_uuid4` ↔ `random_bytes`+`bin2hex`, `wp_parse_url` ↔ `parse_url`, `wp_date`/`wp_timezone`/`wp_timezone_string` ↔ `DateTimeImmutable`/`DateTimeZone`) no longer trigger `dead_guard` on dual-context library code that ships defensive guards. WP-only infrastructure symbols (REST classes, blocks, abilities, environment classification, `REST_REQUEST`) stay in the table so genuine dead guards still fire.
- Adopt core's new `convention_tag_globs` contract (Extra-Chill/homeboy@fd422975) with namespaced opaque tags `wordpress:php-role:{contract,registry,adapter,factory,result,lock,null-impl,procedural-helper}` so unrelated PHP roles inside the same directory land in different convention groups once consumers upgrade past the next homeboy release.
- For hosts still on `homeboy 0.157.0`, expand `convention_exception_globs` with PHP role-suffix file globs (`class-*-store.php`, `class-*-registry.php`, `class-*-result.php`, `class-*-lock.php`, …) so missing-method, missing-registration, and missing-interface false positives are suppressed today even before the new core release lands.
- Add fixtures and assertions: `tests/fixtures/audit-dead-guard-fallback/` (must produce zero `dead_guard`), `tests/fixtures/audit-dead-guard-wp-only/` (must still produce `dead_guard`), and `tests/fixtures/audit-detector-config/src/{Identity,Packages}/` exercising role-tag and exception-glob behavior on the same shapes that surfaced in `agents-api`.
- Wire two smoke tests into `homeboy.json` self-checks: `tests/audit-detector-config-smoke.sh` (manifest contracts + role coverage) and `tests/audit-dead-guard-fallback-smoke.sh` (manifest contract plus a behavioral pass that runs `homeboy audit` against both fixtures and asserts the right finding shapes; prefers `/opt/homebrew/bin/homeboy` and guards against scan-recursion regressions).
- Update `wordpress/docs/audit-core-contract-gaps.md` to record what's supported today, what core ships on `main` but not yet released, and what generic core hooks remain (comment-context dead guards, requested-detector context filters).

Fixes #410.
Refs #411 (fully resolved once the host installs a release containing Extra-Chill/homeboy@fd422975; on `homeboy 0.157.0` the constructor-signature drift inside the `Packages/` group remains, as documented in `audit-core-contract-gaps.md`).
Refs Extra-Chill/homeboy#2309.

## Verification

Against `/Users/chubes/Developer/agents-api` with `homeboy 0.157.0` and this branch linked as the WordPress extension:

| metric | v2.40.1 | this branch |
|---|---|---|
| `dead_guard` findings | 7 | **0** |
| Convention outliers | 6 | **3** |
| Alignment score | 0.6470 | **0.8235** |

Remaining 3 outliers are `Packages/` constructor-signature drift across mixed value/result/registry roles; these split cleanly under `convention_tag_globs` once the host upgrades past `fd422975`.

## Tests
- `jq empty wordpress.json homeboy.json`
- `bash wordpress/tests/audit-detector-config-smoke.sh`
- `bash wordpress/tests/audit-dead-guard-fallback-smoke.sh`
- `homeboy lint wordpress --path /Users/chubes/Developer/homeboy-extensions/wordpress` — passed, no findings
- `homeboy test wordpress --path /Users/chubes/Developer/homeboy-extensions/wordpress` — all smokes passed (host-smoke, file-routing, parse-test-failures, playground cleanup, trace runner, lint role, vendor-prefixed exclusion, eslint no-files, audit detector config, audit dead-guard fallback)
- `homeboy audit` against `/Users/chubes/Developer/agents-api` — see Verification table above

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the WordPress extension audit config (`known_symbols` curation, `convention_tag_globs` taxonomy, expanded `convention_exception_globs`), new fixtures, smoke-test assertions, and core-contract gap documentation; Chris remains responsible for review, the `homeboy audit` verification on `agents-api`, and merge.