### PR TITLE
fix(wordpress): rename wp-only fixture so role-tag splitting keeps it scanned

### DIFF
--- a/wordpress/tests/fixtures/audit-dead-guard-wp-only/src/Runtime/class-rest-controller.php
+++ b/wordpress/tests/fixtures/audit-dead-guard-wp-only/src/Runtime/class-rest-controller.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * REST bootstrap that defensively guards genuinely-WordPress-only symbols.
+ * REST controller that defensively guards genuinely-WordPress-only symbols.
  * Both guards are dead at runtime: the plugin floor guarantees the symbols
  * whenever WordPress is loaded, and neither symbol has a meaningful pure-PHP
  * fallback shape, so dead_guard should still report them.
  */
 
-final class REST_Bootstrap {
+final class REST_Controller {
 	public static function boot(): void {
 		if ( ! class_exists( 'WP_REST_Server' ) ) {
 			return;

--- a/wordpress/tests/fixtures/audit-dead-guard-wp-only/wp-only-plugin.php
+++ b/wordpress/tests/fixtures/audit-dead-guard-wp-only/wp-only-plugin.php
@@ -16,4 +16,5 @@
  *   dead_guard detector should still flag the guards as redundant.
  */
 
-require_once __DIR__ . '/src/Runtime/class-rest-bootstrap.php';
+require_once __DIR__ . '/src/Runtime/class-rest-controller.php';
+require_once __DIR__ . '/src/Runtime/class-rest-helper.php';


### PR DESCRIPTION
## Summary

Forward-compatibility follow-up to #412. The `audit-dead-guard-wp-only` fixture asserts that genuine WordPress-only dead guards still produce findings even after the `known_symbols` curation. On `homeboy 0.157.0` the assertion holds because `convention_tag_globs` is silently ignored and both `src/Runtime/` files share the default convention bucket.

On the next homeboy release (post-Extra-Chill/homeboy@`fd422975`, when `convention_tag_globs` is honored) the original fixture filename `class-rest-bootstrap.php` matches `**/*-bootstrap.php` and gets tagged `wordpress:php-role:procedural-helper`, splitting it into a singleton convention bucket. Singleton buckets are dropped by discovery, so the file never gets fingerprinted and `dead_guard` never runs on it — silently flipping the wp-only fixture to zero findings and hiding a real regression.

## Fix

Rename `class-rest-bootstrap.php` → `class-rest-controller.php` (`REST_Controller` class). The new name matches no `convention_tag_globs` entry, so it groups with `class-rest-helper.php` under the default `[]` tag set on both `0.157.0` and the next release. Update `wp-only-plugin.php`'s `require_once` chain to match.

## Verification

| homeboy build | smoke result | wp_only findings |
|---|---|---|
| `/opt/homebrew/bin/homeboy` (0.157.0) | passed | 2 |
| post-0.157.0 with `convention_tag_globs` | passed | 2 |

## Tests
- `bash wordpress/tests/audit-dead-guard-fallback-smoke.sh` — passed
- `bash wordpress/tests/audit-detector-config-smoke.sh` — passed
- `homeboy lint wordpress --path /Users/chubes/Developer/homeboy-extensions/wordpress` — passed, no findings
- `homeboy test wordpress --path /Users/chubes/Developer/homeboy-extensions/wordpress` — all smokes passed

Refs #410.
Refs #412.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Diagnosed silent regression where role-tag splitting in the next homeboy release would suppress the wp-only fixture's `dead_guard` findings; renamed the fixture to neutral file names that do not match any `convention_tag_globs` entry, restoring forward compatibility. Chris remains responsible for review and merge.