### PR TITLE
fix(wordpress): split artifact audit role

### DIFF
--- a/wordpress/tests/audit-detector-config-smoke.sh
+++ b/wordpress/tests/audit-detector-config-smoke.sh
@@ -40,6 +40,8 @@ for pattern in [
     "**/class-*-factory.php",
     "**/class-*-adapter.php",
     "**/class-*-lock.php",
+    "**/class-*-artifact.php",
+    "**/class-*-artifacts.php",
 ]:
     require(pattern in exception_globs, f"missing PHP role exception glob: {pattern}")
 
@@ -56,6 +58,7 @@ required_tags = {
     "wordpress:php-role:contract",
     "wordpress:php-role:registry",
     "wordpress:php-role:result",
+    "wordpress:php-role:artifact",
     "wordpress:php-role:adapter",
     "wordpress:php-role:factory",
     "wordpress:php-role:lock",
@@ -92,10 +95,13 @@ require(not matches_any(identity_scope, globs_for("wordpress:php-role:contract")
 require(not matches_any(identity_materialized, globs_for("wordpress:php-role:contract")),
         "materialized identity value object must not be tagged as contract role")
 
-# Packages fixture: split into value/contract/result/registry/procedural roles.
+# Packages fixture: split into value/contract/result/artifact/registry/procedural roles.
+# Manifest + artifact-type are sibling value objects (slug/type + args ctor shape) and
+# stay untagged so they discover a shared convention. Artifact declaration objects are
+# their own role — different ctor shape (single declaration array) — and must be tagged
+# so core does not pollute the manifest convention with artifact-declaration constructors.
 packages_value_paths = [
     "src/Packages/class-demo-package.php",
-    "src/Packages/class-demo-package-artifact.php",
     "src/Packages/class-demo-package-artifact-type.php",
 ]
 for path in packages_value_paths:
@@ -105,6 +111,11 @@ for path in packages_value_paths:
 
 require(matches_any("src/Packages/class-demo-package-adopter.php", globs_for("wordpress:php-role:contract")),
         "adopter interface fixture must be tagged as contract role")
+require(matches_any("src/Packages/class-demo-package-artifact.php", globs_for("wordpress:php-role:artifact")),
+        "artifact declaration fixture must be tagged as artifact role")
+# Boundary check: `*-artifact-type.php` must NOT match the artifact role glob.
+require(not matches_any("src/Packages/class-demo-package-artifact-type.php", globs_for("wordpress:php-role:artifact")),
+        "artifact-type registration fixture must not be tagged as artifact role")
 require(matches_any("src/Packages/class-demo-package-adoption-result.php", globs_for("wordpress:php-role:result")),
         "adoption result fixture must be tagged as result role")
 require(matches_any("src/Packages/class-demo-package-adoption-diff.php", globs_for("wordpress:php-role:result")),
@@ -118,6 +129,7 @@ require(matches_any("src/Packages/register-demo-package-artifacts.php", globs_fo
 for path in [
     "src/Identity/class-demo-identity-store.php",
     "src/Packages/class-demo-package-adopter.php",
+    "src/Packages/class-demo-package-artifact.php",
     "src/Packages/class-demo-package-adoption-result.php",
     "src/Packages/class-demo-package-adoption-diff.php",
     "src/Packages/class-demo-package-artifacts-registry.php",

--- a/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-artifact-type.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-artifact-type.php
@@ -1,21 +1,20 @@
 <?php
 /**
- * Artifact type marker — value-object family alongside the package and
- * artifact siblings.
+ * Artifact type marker — sibling of `class-demo-package.php` in the value-object
+ * family. Matches the manifest's (slug/type, args) constructor shape so the
+ * shared convention is detectable.
  */
 
 final class Demo_Package_Artifact_Type {
 	public function __construct(
-		public readonly string $slug,
-		public readonly array $definition,
-		public readonly array $artifacts
+		public readonly string $type,
+		public readonly array $args = array()
 	) {}
 
 	public function to_array(): array {
 		return array(
-			'slug'       => $this->slug,
-			'definition' => $this->definition,
-			'artifacts'  => $this->artifacts,
+			'type' => $this->type,
+			'args' => $this->args,
 		);
 	}
 }

--- a/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-artifact.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package-artifact.php
@@ -1,21 +1,17 @@
 <?php
 /**
- * Artifact value object inside a package. Same constructor shape family as the
- * package manifest above.
+ * Artifact declaration object — distinct constructor shape from the package
+ * manifest family. Adopters pass a single declaration array describing one
+ * artifact; lumping this constructor into the manifest convention would
+ * pollute it with an unrelated role.
  */
 
 final class Demo_Package_Artifact {
 	public function __construct(
-		public readonly string $slug,
-		public readonly array $definition,
-		public readonly array $artifacts
+		public readonly array $declaration
 	) {}
 
 	public function to_array(): array {
-		return array(
-			'slug'       => $this->slug,
-			'definition' => $this->definition,
-			'artifacts'  => $this->artifacts,
-		);
+		return $this->declaration;
 	}
 }

--- a/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Packages/class-demo-package.php
@@ -1,22 +1,21 @@
 <?php
 /**
- * Package value object — declarative manifest. Sibling of the artifact value
- * objects below; together they form a small constructor convention that the
- * detector should NOT pollute with adopter/registry/result roles.
+ * Package value object — declarative manifest. Sibling of
+ * `class-demo-package-artifact-type.php` (slug/type + args ctor shape); together
+ * they form a small value-object family the detector should not pollute with
+ * artifact declarations, adopter contracts, registries, or result/diff objects.
  */
 
 final class Demo_Package {
 	public function __construct(
 		public readonly string $slug,
-		public readonly array $definition,
-		public readonly array $artifacts
+		public readonly array $args = array()
 	) {}
 
 	public function to_array(): array {
 		return array(
-			'slug'       => $this->slug,
-			'definition' => $this->definition,
-			'artifacts'  => $this->artifacts,
+			'slug' => $this->slug,
+			'args' => $this->args,
 		);
 	}
 }

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -276,6 +276,8 @@
         "**/class-*-response.php",
         "**/class-*-outcome.php",
         "**/class-*-decision.php",
+        "**/class-*-artifact.php",
+        "**/class-*-artifacts.php",
         "**/class-*-policy.php",
         "**/class-*-policy-filter.php",
         "**/class-*-policy-provider.php",
@@ -353,6 +355,13 @@
             "**/class-*-response.php",
             "**/class-*-outcome.php",
             "**/class-*-decision.php"
+          ]
+        },
+        {
+          "tag": "wordpress:php-role:artifact",
+          "globs": [
+            "**/class-*-artifact.php",
+            "**/class-*-artifacts.php"
           ]
         },
         {


### PR DESCRIPTION
## Summary
- Add a WordPress/PHP `artifact` convention tag so artifact declaration constructors are not compared with package manifest constructors.
- Update audit detector fixtures to model package manifests, artifact types, artifact declarations, and result/diff roles separately.
- Cover the artifact role and `*-artifact-type.php` boundary in the audit detector config smoke test.

## Validation
- `jq empty wordpress.json` plus shell syntax checks passed.
- WordPress extension self-check smoke suite passed.
- Source Homeboy with `convention_tag_globs` support against `/Users/chubes/Developer/agents-api`: `signature_mismatch` findings: 0; `Packages` and `Packages [wordpress:php-role:result]` clean.

## Notes
- `/opt/homebrew/bin/homeboy` still reports `0.157.0`, which does not honor `convention_tag_globs`, so the installed Homebrew binary still shows the old false positives until the tap/binary reaches the core contract that this extension metadata uses.

Fixes #414.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the WordPress extension metadata and fixture updates, ran local validation, and drafted this PR description. Chris remains responsible for review and merge.