### PR TITLE
fix(wordpress): split auth and policy audit roles

### DIFF
--- a/wordpress/docs/audit-core-contract-gaps.md
+++ b/wordpress/docs/audit-core-contract-gaps.md
@@ -38,7 +38,7 @@ Homeboy core supports `audit.detector_rules.convention_tag_globs` on `main`. Thi
 }
 ```
 
-Core does not interpret the tag string. It uses tag membership as part of the convention group key, so files with different tags inside the same directory land in different convention groups. That keeps store contracts, registries, adopter interfaces, result/diff objects, factories, and value objects out of one shared method/signature convention.
+Core does not interpret the tag string. It uses tag membership as part of the convention group key, so files with different tags inside the same directory land in different convention groups. That keeps store contracts, registries, adopter interfaces, service/authenticator classes, credential/token objects, policy/configuration vocabularies, result/diff objects, factories, and value objects out of one shared method/signature convention.
 
 Extensions own the role taxonomy. Tags are namespaced (`wordpress:php-role:*`) so multiple extensions in the same component never collide.
 

--- a/wordpress/tests/audit-detector-config-smoke.sh
+++ b/wordpress/tests/audit-detector-config-smoke.sh
@@ -22,7 +22,7 @@ def require(condition, message):
         raise SystemExit(message)
 
 utility_suffixes = set(rules.get("utility_suffixes", []))
-for suffix in ["Contract", "Interface", "Store", "Lock", "Result", "Value", "Package"]:
+for suffix in ["Authenticator", "Contract", "Credential", "Interface", "Store", "Lock", "Policy", "Result", "Secret", "Service", "Token", "Value", "Package"]:
     require(suffix in utility_suffixes, f"missing PHP role utility suffix: {suffix}")
 
 exception_globs = set(rules.get("convention_exception_globs", []))
@@ -35,6 +35,12 @@ for pattern in [
     "**/class-*-registry.php",
     "**/class-*-adopter.php",
     "**/class-*-resolver.php",
+    "**/class-*-authenticator.php",
+    "**/class-*-service.php",
+    "**/class-*-policy.php",
+    "**/class-*-config.php",
+    "**/class-*-token.php",
+    "**/class-*-credential.php",
     "**/class-*-result.php",
     "**/class-*-diff.php",
     "**/class-*-factory.php",
@@ -60,7 +66,10 @@ required_tags = {
     "wordpress:php-role:result",
     "wordpress:php-role:artifact",
     "wordpress:php-role:adapter",
+    "wordpress:php-role:service",
     "wordpress:php-role:factory",
+    "wordpress:php-role:configuration",
+    "wordpress:php-role:credential",
     "wordpress:php-role:lock",
     "wordpress:php-role:null-impl",
 }
@@ -125,6 +134,35 @@ require(matches_any("src/Packages/class-demo-package-artifacts-registry.php", gl
 require(matches_any("src/Packages/register-demo-package-artifacts.php", globs_for("wordpress:php-role:procedural-helper")),
         "procedural helper fixture must be tagged as procedural-helper role")
 
+# Auth fixture: normal DTOs stay in the value-object convention; credential/token
+# objects and request-edge authenticators get separate role tags so neither
+# inherits full DTO serialization methods from the other.
+auth_value_paths = [
+    "src/Auth/class-demo-access-grant.php",
+]
+for path in auth_value_paths:
+    for tag in required_tags:
+        require(not matches_any(path, globs_for(tag)),
+                f"auth value-object fixture {path} must remain untagged (matched {tag})")
+
+require(matches_any("src/Auth/class-demo-token-authenticator.php", globs_for("wordpress:php-role:service")),
+        "authenticator fixture must be tagged as service role")
+require(not matches_any("src/Auth/class-demo-token-authenticator.php", globs_for("wordpress:php-role:contract")),
+        "authenticator fixture must not be tagged as contract role")
+require(matches_any("src/Auth/class-demo-token.php", globs_for("wordpress:php-role:credential")),
+        "token fixture must be tagged as credential role")
+require(not matches_any("src/Auth/class-demo-token.php", globs_for("wordpress:php-role:service")),
+        "token fixture must not be tagged as service role")
+
+# Context fixture: resolver interfaces remain contract role files; policy/config
+# vocabulary classes are configuration role files, not resolver contracts.
+require(matches_any("src/Context/class-demo-context-conflict-resolver.php", globs_for("wordpress:php-role:contract")),
+        "context resolver fixture must be tagged as contract role")
+require(matches_any("src/Context/class-demo-context-injection-policy.php", globs_for("wordpress:php-role:configuration")),
+        "context injection policy fixture must be tagged as configuration role")
+require(not matches_any("src/Context/class-demo-context-injection-policy.php", globs_for("wordpress:php-role:contract")),
+        "context injection policy fixture must not be tagged as contract role")
+
 # v0.157.0 best-effort fallback: every off-role file must also be in convention_exception_globs.
 for path in [
     "src/Identity/class-demo-identity-store.php",
@@ -134,6 +172,10 @@ for path in [
     "src/Packages/class-demo-package-adoption-diff.php",
     "src/Packages/class-demo-package-artifacts-registry.php",
     "src/Packages/register-demo-package-artifacts.php",
+    "src/Auth/class-demo-token.php",
+    "src/Auth/class-demo-token-authenticator.php",
+    "src/Context/class-demo-context-conflict-resolver.php",
+    "src/Context/class-demo-context-injection-policy.php",
 ]:
     require(matches_any(path, exception_globs),
             f"off-role file {path} must also be exempt for v0.157.0 fallback")
@@ -167,6 +209,11 @@ for relative in [
     "src/Packages/class-demo-package-adoption-diff.php",
     "src/Packages/class-demo-package-artifacts-registry.php",
     "src/Packages/register-demo-package-artifacts.php",
+    "src/Auth/class-demo-access-grant.php",
+    "src/Auth/class-demo-token.php",
+    "src/Auth/class-demo-token-authenticator.php",
+    "src/Context/class-demo-context-conflict-resolver.php",
+    "src/Context/class-demo-context-injection-policy.php",
 ]:
     require((fixture_dir / relative).exists(), f"missing audit detector fixture: {relative}")
 

--- a/wordpress/tests/fixtures/audit-detector-config/src/Auth/class-demo-access-grant.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Auth/class-demo-access-grant.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Auth value object with stable JSON export helpers.
+ */
+
+final class Demo_Access_Grant {
+ public function __construct(
+ 	public readonly string $agent_id,
+ 	public readonly int $user_id,
+ 	public readonly array $metadata = array()
+ ) {}
+
+ public static function from_array( array $grant ): self {
+ 	return new self(
+ 		isset( $grant['agent_id'] ) ? (string) $grant['agent_id'] : '',
+ 		isset( $grant['user_id'] ) ? (int) $grant['user_id'] : 0,
+ 		isset( $grant['metadata'] ) && is_array( $grant['metadata'] ) ? $grant['metadata'] : array()
+ 	);
+ }
+
+ public function to_array(): array {
+ 	return array(
+ 		'agent_id' => $this->agent_id,
+ 		'user_id'  => $this->user_id,
+ 		'metadata' => $this->metadata,
+ 	);
+ }
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Auth/class-demo-token-authenticator.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Auth/class-demo-token-authenticator.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Request-edge auth service; not an auth DTO/value object.
+ */
+
+final class Demo_Token_Authenticator {
+ public function __construct(
+ 	private readonly Demo_Token_Store $token_store
+ ) {}
+
+ public function authenticate_bearer_token( string $raw_token ): ?Demo_Token {
+ 	$raw_token = trim( $raw_token );
+ 	if ( '' === $raw_token ) {
+ 		return null;
+ 	}
+
+ 	return $this->token_store->resolve_token_hash( hash( 'sha256', $raw_token ) );
+ }
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Auth/class-demo-token.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Auth/class-demo-token.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Auth value object that intentionally exposes redacted metadata, not full storage rows.
+ */
+
+final class Demo_Token {
+ public function __construct(
+ 	public readonly int $token_id,
+ 	public readonly string $token_hash,
+ 	public readonly string $token_prefix,
+ 	public readonly array $metadata = array()
+ ) {}
+
+ public static function from_array( array $token ): self {
+ 	return new self(
+ 		isset( $token['token_id'] ) ? (int) $token['token_id'] : 0,
+ 		isset( $token['token_hash'] ) ? (string) $token['token_hash'] : '',
+ 		isset( $token['token_prefix'] ) ? (string) $token['token_prefix'] : '',
+ 		isset( $token['metadata'] ) && is_array( $token['metadata'] ) ? $token['metadata'] : array()
+ 	);
+ }
+
+ public function to_metadata_array(): array {
+ 	return array(
+ 		'token_id'     => $this->token_id,
+ 		'token_prefix' => $this->token_prefix,
+ 		'metadata'     => $this->metadata,
+ 	);
+ }
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Context/class-demo-context-conflict-resolver.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Context/class-demo-context-conflict-resolver.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Resolver contract for context conflict decisions.
+ */
+
+interface Demo_Context_Conflict_Resolver {
+ public function resolve( array $items, array $context = array() ): array;
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Context/class-demo-context-injection-policy.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Context/class-demo-context-injection-policy.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Context policy vocabulary/configuration values.
+ */
+
+final class Demo_Context_Injection_Policy {
+ public const ALWAYS    = 'always';
+ public const ON_INTENT = 'on_intent';
+ public const MANUAL    = 'manual';
+
+ public static function values(): array {
+ 	return array( self::ALWAYS, self::ON_INTENT, self::MANUAL );
+ }
+
+ public static function normalize( string $policy ): string {
+ 	return in_array( $policy, self::values(), true ) ? $policy : self::ALWAYS;
+ }
+}

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -208,10 +208,13 @@
       ],
       "utility_suffixes": [
         "Adapter",
+        "Authenticator",
         "Builder",
         "Collection",
         "Contract",
         "Contracts",
+        "Credential",
+        "Credentials",
         "DTO",
         "Data",
         "Error",
@@ -225,6 +228,7 @@
         "Lock",
         "Package",
         "Payload",
+        "Policy",
         "Provider",
         "Registry",
         "Repository",
@@ -233,10 +237,16 @@
         "Response",
         "Result",
         "Serializer",
+        "Service",
+        "Services",
         "Shim",
         "Store",
         "Stub",
+        "Secret",
+        "Secrets",
         "Transformer",
+        "Token",
+        "Tokens",
         "Value",
         "Validator"
       ],
@@ -266,6 +276,9 @@
         "**/class-*-executor.php",
         "**/class-*-dispatcher.php",
         "**/class-*-router.php",
+        "**/class-*-authenticator.php",
+        "**/class-*-service.php",
+        "**/class-*-services.php",
         "**/class-*-factory.php",
         "**/class-*-builder.php",
         "**/class-*-hydrator.php",
@@ -276,6 +289,15 @@
         "**/class-*-response.php",
         "**/class-*-outcome.php",
         "**/class-*-decision.php",
+        "**/class-*-credential.php",
+        "**/class-*-credentials.php",
+        "**/class-*-secret.php",
+        "**/class-*-secrets.php",
+        "**/class-*-token.php",
+        "**/class-*-tokens.php",
+        "**/class-*-config.php",
+        "**/class-*-configuration.php",
+        "**/class-*-options.php",
         "**/class-*-artifact.php",
         "**/class-*-artifacts.php",
         "**/class-*-policy.php",
@@ -316,11 +338,7 @@
             "**/class-*-runner.php",
             "**/class-*-executor.php",
             "**/class-*-dispatcher.php",
-            "**/class-*-router.php",
-            "**/class-*-policy.php",
-            "**/class-*-policy-filter.php",
-            "**/class-*-policy-provider.php",
-            "**/class-*-policy-resolver.php"
+            "**/class-*-router.php"
           ]
         },
         {
@@ -335,6 +353,14 @@
           "globs": [
             "**/class-*-adapter.php",
             "**/class-*-bridge.php"
+          ]
+        },
+        {
+          "tag": "wordpress:php-role:service",
+          "globs": [
+            "**/class-*-authenticator.php",
+            "**/class-*-service.php",
+            "**/class-*-services.php"
           ]
         },
         {
@@ -355,6 +381,29 @@
             "**/class-*-response.php",
             "**/class-*-outcome.php",
             "**/class-*-decision.php"
+          ]
+        },
+        {
+          "tag": "wordpress:php-role:configuration",
+          "globs": [
+            "**/class-*-config.php",
+            "**/class-*-configuration.php",
+            "**/class-*-options.php",
+            "**/class-*-policy.php",
+            "**/class-*-policy-filter.php",
+            "**/class-*-policy-provider.php",
+            "**/class-*-policy-resolver.php"
+          ]
+        },
+        {
+          "tag": "wordpress:php-role:credential",
+          "globs": [
+            "**/class-*-credential.php",
+            "**/class-*-credentials.php",
+            "**/class-*-secret.php",
+            "**/class-*-secrets.php",
+            "**/class-*-token.php",
+            "**/class-*-tokens.php"
           ]
         },
         {


### PR DESCRIPTION
## Summary
- Split WordPress/PHP audit convention grouping for service/authenticator, configuration/policy, and credential/token role families.
- Add audit detector fixtures covering auth DTO vs authenticator/credential grouping and context resolver contract vs injection policy grouping.
- Document the expanded extension-owned role taxonomy so Homeboy core remains language-agnostic.

Fixes #416.
Fixes #417.

## Testing
- `bash tests/audit-detector-config-smoke.sh`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions/wordpress --force-hot`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions/wordpress --force-hot`
- `php -l` on new PHP fixtures
- `/opt/homebrew/bin/homeboy audit --force-hot` in `/Users/chubes/Developer/agents-api` passed with `alignment_score: 1.0`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the WordPress extension role-taxonomy changes, fixtures, smoke-test updates, and verification commands; Chris remains responsible for review and merge.