### PR TITLE
fix(wordpress): refresh stale frontend dependencies

### DIFF
--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -287,6 +287,15 @@ install_frontend_dependencies() {
     if [ ! -d "node_modules" ]; then
         print_status "${scope_label}Installing npm dependencies..."
         need_install=1
+    elif [ -f "package-lock.json" ] && [ ! -f "node_modules/.package-lock.json" ]; then
+        print_warning "${scope_label}node_modules exists but npm install state cannot be verified. Reinstalling dependencies..."
+        need_install=1
+    elif [ -f "package-lock.json" ] && [ "package-lock.json" -nt "node_modules/.package-lock.json" ]; then
+        print_warning "${scope_label}package-lock.json is newer than node_modules. Reinstalling dependencies..."
+        need_install=1
+    elif [ -f "package-lock.json" ] && ! npm ls --depth=0 --silent >/dev/null 2>&1; then
+        print_warning "${scope_label}node_modules contains missing or invalid packages. Reinstalling dependencies..."
+        need_install=1
     elif [ -n "$expected_bin" ] && [ ! -x "node_modules/.bin/$expected_bin" ]; then
         print_warning "${scope_label}node_modules exists but '$expected_bin' is missing. Reinstalling dependencies..."
         need_install=1


### PR DESCRIPTION
## Summary
- Reinstall lockfile-backed frontend dependencies when npm install metadata is missing or older than `package-lock.json`.
- Reinstall when `npm ls --depth=0` reports missing or invalid top-level packages, catching stale `node_modules` before WordPress frontend builds.

## Testing
- `bash -n wordpress/scripts/build/build.sh`
- Smoke fixture invoking `wordpress/scripts/build/build.sh` with stale `node_modules`; verified it ran `npm ci` and produced `build/fixture.zip`.
- In `/Users/chubes/Developer/data-machine`: `npm ci --include=dev`, `npm ls @extrachill/chat @wordpress/scripts --depth=0`, `npm run build`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the stale Data Machine dependency/build warning, drafted the WordPress extension fix, and ran targeted verification. Chris remains responsible for review and merge.