### PR TITLE
feat(wordpress): configurable Playground bench workloads

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -75,6 +75,59 @@ Each dependency entry may be either:
 - a registered Homeboy component ID
 - an absolute path to another local plugin checkout
 
+## Configurable Playground Bench Workloads
+
+WordPress bench runs can declare Playground workloads in extension settings when
+the workload should be configured by the repo instead of living under
+`tests/bench/*.php`. Configured workloads run after the existing Playground
+bootstrap, `playground_blueprint`, dependency mounts, and component load.
+
+```json
+{
+  "extensions": {
+    "wordpress": {
+      "settings": {
+        "playground_workloads": [
+          {
+            "id": "generated-site-preview",
+            "label": "Generated site preview",
+            "run": [
+              {
+                "type": "php",
+                "file": "workloads/generated-site-preview.php"
+              }
+            ],
+            "artifacts": {
+              "import_report": {
+                "path": "wp-content/themes/example/import-report.json",
+                "kind": "json",
+                "label": "Import report"
+              }
+            },
+            "metadata": {
+              "preview_url": "https://example.test/preview"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+Supported step types:
+
+- `php` with `file` or `code`: runs inside the Playground PHP process. Files are
+  resolved relative to the mounted component path unless absolute.
+- `wp-cli` with `command`: runs through `WP_CLI::runcommand()` when WP-CLI is
+  available in the Playground PHP process. The command may include or omit the
+  leading `wp` token.
+
+Workloads and steps may return `{ "metrics", "artifacts", "metadata" }`.
+Numeric metrics are aggregated across measured iterations with the same
+mean/p50/p95/p99/min/max suffixes used by PHP bench files. Artifacts and metadata
+are carried into the Homeboy BenchResults scenario envelope.
+
 ## Lint findings sidecar
 
 When `HOMEBOY_LINT_FINDINGS_FILE` is set, the WordPress lint runner writes a

--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -119,6 +119,13 @@ Supported step types:
 
 - `php` with `file` or `code`: runs inside the Playground PHP process. Files are
   resolved relative to the mounted component path unless absolute.
+- `ability` with `ability` (and optional `input`, `user`): resolves the named
+  ability via `wp_get_ability()` (WordPress core 6.9+) and executes it inside
+  the Playground PHP process. The runner fires `wp_abilities_api_categories_init`
+  and `wp_abilities_api_init` before the first ability call so plugin-declared
+  categories and abilities land in the registry. Use this for plugins that
+  expose their entry points as abilities so workloads don't need a WP-CLI
+  command surface.
 - `wp-cli` with `command`: runs through `WP_CLI::runcommand()` when WP-CLI is
   available in the Playground PHP process. The command may include or omit the
   leading `wp` token.
@@ -127,6 +134,36 @@ Workloads and steps may return `{ "metrics", "artifacts", "metadata" }`.
 Numeric metrics are aggregated across measured iterations with the same
 mean/p50/p95/p99/min/max suffixes used by PHP bench files. Artifacts and metadata
 are carried into the Homeboy BenchResults scenario envelope.
+
+Example: drive a plugin's pipeline through an Abilities API entry point.
+
+```json
+{
+  "extensions": {
+    "wordpress": {
+      "settings": {
+        "playground_blueprint": {
+          "steps": [
+            { "step": "installPlugin", "pluginData": { "resource": "wordpress.org/plugins", "slug": "data-machine" } }
+          ]
+        },
+        "playground_workloads": [
+          {
+            "id": "smoke-pipeline",
+            "run": [
+              {
+                "type": "ability",
+                "ability": "datamachine/run-pipeline",
+                "input": { "pipeline_id": 42 }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+```
 
 ## Lint findings sidecar
 

--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -120,8 +120,15 @@ elif [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}"
     fi
 fi
 
+PLAYGROUND_WORKLOADS_PROVIDED=0
+if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    if printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -e 'has("playground_workloads") and (.playground_workloads != null) and (.playground_workloads != [])' >/dev/null 2>&1; then
+        PLAYGROUND_WORKLOADS_PROVIDED=1
+    fi
+fi
+
 BENCH_DIR="${PLUGIN_PATH}/tests/bench"
-if [ ! -d "$BENCH_DIR" ] && [ -z "${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}" ] && [ "$BENCH_WORKLOADS_FILTER_PROVIDED" != "1" ]; then
+if [ ! -d "$BENCH_DIR" ] && [ -z "${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}" ] && [ "$BENCH_WORKLOADS_FILTER_PROVIDED" != "1" ] && [ "$PLAYGROUND_WORKLOADS_PROVIDED" != "1" ]; then
     echo ""
     echo "⚠ No tests/bench directory found at ${BENCH_DIR}"
     echo "  Skipping bench run — nothing to measure."
@@ -202,6 +209,18 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c 'if has("bench_workloads") then .bench_workloads else null end' 2>/dev/null || echo "null")
     if [ -n "$extracted" ] && [ "$extracted" != "null" ]; then
         BENCH_WORKLOADS_JSON="$extracted"
+    fi
+fi
+
+# Extract `playground_workloads` from the merged settings JSON. These are
+# config-declared workloads that run after the shared Playground bootstrap,
+# blueprint application, dependency mounts, and component load. They emit the
+# same BenchResults scenario shape as PHP files under tests/bench/.
+PLAYGROUND_WORKLOADS_JSON="[]"
+if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.playground_workloads // []' 2>/dev/null || echo "[]")
+    if [ -n "$extracted" ] && [ "$extracted" != "null" ]; then
+        PLAYGROUND_WORKLOADS_JSON="$extracted"
     fi
 fi
 if [ "$BENCH_WORKLOADS_JSON" = "null" ] && [ -n "${HOMEBOY_BENCH_WORKLOADS:-}" ]; then
@@ -427,6 +446,7 @@ sed \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_WORKLOADS_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_WORKLOADS_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{PLAYGROUND_WORKLOADS_JSON}}${WP_CONFIG_DEFINES_DELIM}${PLAYGROUND_WORKLOADS_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{EXTRA_WORKLOADS_LIST}}${WP_CONFIG_DEFINES_DELIM}${EXTRA_WORKLOADS_LIST}${WP_CONFIG_DEFINES_DELIM}g" \
     "$TEMPLATE" > "$WRAPPER_TMPFILE"
 
@@ -443,6 +463,9 @@ if [ -n "$SHARED_STATE_GUEST" ]; then
 fi
 if [ -n "$BLUEPRINT_TMPFILE" ]; then
     echo "  Playground blueprint: enabled"
+fi
+if [ "$PLAYGROUND_WORKLOADS_PROVIDED" = "1" ]; then
+    echo "  Configured Playground workloads: enabled"
 fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then

--- a/wordpress/scripts/bench/playground-bench-ability-step-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-ability-step-smoke.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Configured Playground workload `ability` step smoke (homeboy-extensions#420).
+#
+# Boots WordPress Playground, loads a fixture plugin that registers an
+# Abilities-API-shaped ability, and asserts a configured workload can invoke
+# the ability via the new step type and surface metrics/artifacts/metadata in
+# the BenchResults envelope.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/playground-workloads-ability"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    echo "Install: brew install jq (macOS) or your package manager." >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-ability-step-smoke.XXXXXX")
+cleanup() {
+    rm -f "$RESULTS_TMPFILE"
+}
+trap cleanup EXIT
+
+SETTINGS_JSON=$(cat <<'JSON'
+{
+  "playground_workloads": [
+    {
+      "id": "ability-pipeline",
+      "label": "Ability-driven pipeline",
+      "run": [
+        {
+          "type": "ability",
+          "ability": "playground-workloads-fixture/run-pipeline",
+          "input": { "pipeline_id": 42, "items": 7 }
+        }
+      ]
+    }
+  ]
+}
+JSON
+)
+
+echo "============================================"
+echo "Playground bench ability step smoke test"
+echo "============================================"
+echo "Fixture:    $FIXTURE_DIR"
+echo "Iterations: 2 (per configured workload)"
+echo ""
+
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS=2 \
+HOMEBOY_COMPONENT_ID=playground-workloads-ability \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+echo ""
+echo "--- Results envelope ---"
+cat "$RESULTS_TMPFILE"
+echo ""
+
+scenario_count=$(jq -r '.scenarios | length' "$RESULTS_TMPFILE")
+if [ "$scenario_count" -ne 2 ]; then
+    echo "ERROR: expected 2 scenarios (__bootstrap + ability workload), got $scenario_count" >&2
+    exit 1
+fi
+echo "✓ scenarios length == 2 (__bootstrap + ability workload)"
+
+scenario='.scenarios[] | select(.id == "ability-pipeline")'
+
+source=$(jq -r "$scenario | .source" "$RESULTS_TMPFILE")
+if [ "$source" != "config" ]; then
+    echo "ERROR: expected source=config, got $source" >&2
+    exit 1
+fi
+echo "✓ ability workload source emitted"
+
+for metric in items_processed_mean items_processed_p50 items_processed_p95 items_processed_p99 items_processed_min items_processed_max; do
+    value=$(jq -r "$scenario | .metrics.${metric} // \"missing\"" "$RESULTS_TMPFILE")
+    if [ "$value" != "7" ]; then
+        echo "ERROR: ${metric} expected 7, got ${value}" >&2
+        exit 1
+    fi
+done
+echo "✓ ability metrics aggregated"
+
+phase=$(jq -r "$scenario | .metadata.phase // \"missing\"" "$RESULTS_TMPFILE")
+pipeline_id=$(jq -r "$scenario | .metadata.pipeline_id // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$phase" != "ability-executed" ] || [ "$pipeline_id" != "42" ]; then
+    echo "ERROR: ability metadata missing expected phase/pipeline_id (phase=$phase pipeline_id=$pipeline_id)" >&2
+    exit 1
+fi
+echo "✓ ability metadata emitted"
+
+artifact_path=$(jq -r "$scenario | .artifacts.ability_report.path // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$artifact_path" != "wp-content/playground-workloads-fixture/ability-report.json" ]; then
+    echo "ERROR: ability_report artifact missing expected path (got $artifact_path)" >&2
+    exit 1
+fi
+echo "✓ ability artifact emitted"
+
+echo ""
+echo "============================================"
+echo "✓ Ability step smoke test PASSED"
+echo "============================================"

--- a/wordpress/scripts/bench/playground-bench-configured-workloads-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-configured-workloads-smoke.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Config-declared Playground workloads smoke test (homeboy-extensions#420).
+#
+# Runs a fixture with no tests/bench directory and supplies a
+# playground_workloads setting. The configured PHP step returns the same
+# { metrics, artifacts, metadata } shape as Node.js workloads and the smoke
+# asserts those values reach the BenchResults scenario envelope.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/playground-workloads"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    echo "Install: brew install jq (macOS) or your package manager." >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-configured-workloads-smoke.XXXXXX")
+
+cleanup() {
+    rm -f "$RESULTS_TMPFILE" "${FIXTURE_DIR}/workloads/report.json"
+}
+trap cleanup EXIT
+
+SETTINGS_JSON=$(cat <<'JSON'
+{
+  "playground_workloads": [
+    {
+      "id": "generated-site-preview",
+      "label": "Generated site preview",
+      "run": [
+        {
+          "type": "php",
+          "file": "workloads/configured.php"
+        }
+      ],
+      "artifacts": {
+        "configured_report": {
+          "path": "workloads/report.json",
+          "kind": "json",
+          "label": "Configured workload report"
+        }
+      },
+      "metadata": {
+        "source": "settings"
+      }
+    }
+  ]
+}
+JSON
+)
+
+echo "============================================"
+echo "Playground bench configured workloads smoke test"
+echo "============================================"
+echo "Fixture:    $FIXTURE_DIR"
+echo "Iterations: 2 (per configured workload)"
+echo ""
+
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS=2 \
+HOMEBOY_COMPONENT_ID=playground-workloads \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+echo ""
+echo "--- Results envelope ---"
+cat "$RESULTS_TMPFILE"
+echo ""
+
+scenario_count=$(jq -r '.scenarios | length' "$RESULTS_TMPFILE")
+if [ "$scenario_count" -ne 2 ]; then
+    echo "ERROR: expected 2 scenarios (__bootstrap + configured workload), got $scenario_count" >&2
+    exit 1
+fi
+echo "✓ scenarios length == 2 (__bootstrap + configured workload)"
+
+scenario='.scenarios[] | select(.id == "generated-site-preview")'
+
+source=$(jq -r "$scenario | .source" "$RESULTS_TMPFILE")
+if [ "$source" != "config" ]; then
+    echo "ERROR: expected source=config, got $source" >&2
+    exit 1
+fi
+echo "✓ configured workload source emitted"
+
+for metric in generated_pages_mean generated_pages_p50 generated_pages_p95 generated_pages_p99 generated_pages_min generated_pages_max; do
+    value=$(jq -r "$scenario | .metrics.${metric} // \"missing\"" "$RESULTS_TMPFILE")
+    if [ "$value" != "2" ]; then
+        echo "ERROR: ${metric} expected 2, got ${value}" >&2
+        exit 1
+    fi
+done
+echo "✓ configured workload metrics aggregated"
+
+phase=$(jq -r "$scenario | .metadata.phase // \"missing\"" "$RESULTS_TMPFILE")
+preview_url=$(jq -r "$scenario | .metadata.preview_url // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$phase" != "configured" ] || [ "$preview_url" != "https://example.test/playground-preview" ]; then
+    echo "ERROR: metadata missing expected phase/preview_url" >&2
+    exit 1
+fi
+echo "✓ configured workload metadata emitted"
+
+artifact_path=$(jq -r "$scenario | .artifacts.generated_report.path // \"missing\"" "$RESULTS_TMPFILE")
+artifact_label=$(jq -r "$scenario | .artifacts.generated_report.label // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$artifact_path" != "workloads/report.json" ] || [ "$artifact_label" != "Generated workload report" ]; then
+    echo "ERROR: generated_report artifact missing expected path/label" >&2
+    exit 1
+fi
+echo "✓ configured workload artifacts emitted"
+
+echo ""
+echo "============================================"
+echo "✓ Configured workloads smoke test PASSED"
+echo "============================================"

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -32,12 +32,18 @@
  * try to redeclare. Returning a callable scopes each workload's body
  * lexically, so two workloads coexist cleanly in one process.
  *
+ * Config-declared workloads from the `playground_workloads` extension setting
+ * run through the same loop after the same Playground bootstrap. Each entry is
+ * one scenario with `run` steps. PHP steps execute inside this PHP-WASM process;
+ * WP-CLI steps use `WP_CLI::runcommand(..., ['launch' => false])` when WP-CLI
+ * is available in-process.
+ *
  * The runner times wall-clock around the callable, captures peak memory
  * after, and aggregates per-iteration measurements into p50/p95/p99/mean/
  * min/max for the BenchResults envelope. Workloads may also return
  * `['metrics' => ['rows' => 10], 'metadata' => ['phase' => 'warm']]`;
  * numeric custom metrics are aggregated with the same percentile machinery
- * and the latest metadata payload is attached to the scenario.
+ * and the latest metadata/artifacts payloads are attached to the scenario.
  *
  * OUTPUT CONTRACT
  *
@@ -180,6 +186,209 @@ function pg_bench_normalize_workload_filter(string $raw): array {
     return $normalized;
 }
 
+/** Decode config-declared Playground workloads. */
+function pg_bench_configured_workloads(string $raw): array {
+    if ($raw === '' || $raw === 'null') {
+        return [];
+    }
+
+    $decoded = json_decode($raw, true);
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        throw new RuntimeException('playground_workloads must be a JSON array');
+    }
+    if ($decoded === null) {
+        return [];
+    }
+    if (!is_array($decoded) || !pg_bench_is_list($decoded)) {
+        throw new RuntimeException('playground_workloads must be a JSON array');
+    }
+
+    $workloads = [];
+    foreach ($decoded as $index => $workload) {
+        if (!is_array($workload)) {
+            throw new RuntimeException("playground_workloads[$index] must be an object");
+        }
+
+        $raw_id = $workload['id'] ?? $workload['label'] ?? ('configured-' . ($index + 1));
+        if (!is_scalar($raw_id)) {
+            throw new RuntimeException("playground_workloads[$index].id must be a string");
+        }
+        $id = homeboy_bench_scenario_id((string) $raw_id);
+        if ($id === '') {
+            throw new RuntimeException("playground_workloads[$index].id normalized to an empty scenario id");
+        }
+
+        $steps = $workload['run'] ?? null;
+        if (!is_array($steps) || empty($steps) || !pg_bench_is_list($steps)) {
+            throw new RuntimeException("playground_workloads[$index].run must be a non-empty array");
+        }
+
+        foreach ($steps as $step_index => $step) {
+            if (!is_array($step)) {
+                throw new RuntimeException("playground_workloads[$index].run[$step_index] must be an object");
+            }
+            $type = $step['type'] ?? '';
+            if (!in_array($type, ['php', 'wp-cli'], true)) {
+                throw new RuntimeException("playground_workloads[$index].run[$step_index].type must be 'php' or 'wp-cli'");
+            }
+            if ($type === 'php' && !isset($step['code']) && !isset($step['file'])) {
+                throw new RuntimeException("playground_workloads[$index].run[$step_index] php step requires code or file");
+            }
+            if ($type === 'wp-cli' && !isset($step['command'])) {
+                throw new RuntimeException("playground_workloads[$index].run[$step_index] wp-cli step requires command");
+            }
+        }
+
+        $workload['id'] = $id;
+        $workload['run'] = $steps;
+        $workloads[] = $workload;
+    }
+
+    return $workloads;
+}
+
+function pg_bench_is_list(array $value): bool {
+    return $value === [] || array_keys($value) === range(0, count($value) - 1);
+}
+
+function pg_bench_json_object($value, string $label): array {
+    if ($value === null) {
+        return [];
+    }
+    if ($value === []) {
+        return [];
+    }
+    if (!is_array($value) || pg_bench_is_list($value)) {
+        throw new RuntimeException("$label must be an object");
+    }
+
+    return $value;
+}
+
+function pg_bench_merge_workload_payload($payload, array &$metrics, array &$artifacts, array &$metadata): void {
+    if (!is_array($payload)) {
+        return;
+    }
+
+    foreach (pg_bench_json_object($payload['metrics'] ?? [], 'metrics') as $metric => $value) {
+        if (is_string($metric) && $metric !== '' && is_numeric($value) && is_finite((float) $value)) {
+            $metrics[$metric] = (float) $value;
+        }
+    }
+
+    foreach (pg_bench_json_object($payload['artifacts'] ?? [], 'artifacts') as $name => $artifact) {
+        if (!is_string($name) || $name === '') {
+            continue;
+        }
+        if (is_string($artifact) && $artifact !== '') {
+            $artifacts[$name] = ['path' => $artifact];
+            continue;
+        }
+        if (!is_array($artifact)) {
+            continue;
+        }
+        $path = $artifact['path'] ?? null;
+        if (!is_string($path) || $path === '') {
+            continue;
+        }
+        $normalized = ['path' => $path];
+        foreach (['kind', 'label', 'type', 'url'] as $field) {
+            if (isset($artifact[$field]) && is_string($artifact[$field])) {
+                $normalized[$field] = $artifact[$field];
+            }
+        }
+        $artifacts[$name] = $normalized;
+    }
+
+    $metadata = array_replace($metadata, pg_bench_json_object($payload['metadata'] ?? [], 'metadata'));
+}
+
+function pg_bench_run_php_step(array $step, string $plugin_path) {
+    if (isset($step['file'])) {
+        if (!is_scalar($step['file'])) {
+            throw new RuntimeException('php step file must be a string');
+        }
+        $file = (string) $step['file'];
+        if ($file === '') {
+            throw new RuntimeException('php step file must not be empty');
+        }
+        if ($file[0] !== '/') {
+            $file = $plugin_path . '/' . ltrim($file, '/');
+        }
+        if (!is_file($file)) {
+            throw new RuntimeException("php step file not found: $file");
+        }
+        $result = require $file;
+        return is_callable($result) ? $result() : $result;
+    }
+
+    if (!is_scalar($step['code'] ?? null)) {
+        throw new RuntimeException('php step code must be a string');
+    }
+
+    return eval((string) $step['code']);
+}
+
+function pg_bench_run_wp_cli_step(array $step) {
+    if (!class_exists('WP_CLI') || !method_exists('WP_CLI', 'runcommand')) {
+        throw new RuntimeException('wp-cli workload steps require WP_CLI::runcommand() to be available inside the Playground PHP process');
+    }
+
+    if (!is_scalar($step['command'])) {
+        throw new RuntimeException('wp-cli step command must be a string');
+    }
+    $command = trim((string) $step['command']);
+    if (strpos($command, 'wp ') === 0) {
+        $command = substr($command, 3);
+    }
+    if ($command === '') {
+        throw new RuntimeException('wp-cli step command must not be empty');
+    }
+
+    $parse = isset($step['parse']) && is_scalar($step['parse']) ? (string) $step['parse'] : false;
+    $result = WP_CLI::runcommand($command, [
+        'launch' => false,
+        'exit_error' => false,
+        'return' => 'all',
+        'parse' => false,
+    ]);
+    if (is_object($result) && isset($result->return_code) && (int) $result->return_code !== 0) {
+        throw new RuntimeException("wp-cli step failed with exit code {$result->return_code}: {$result->stderr}");
+    }
+    $stdout = is_object($result) && isset($result->stdout) ? (string) $result->stdout : '';
+    if ($parse === 'json' && $stdout !== '') {
+        $decoded = json_decode($stdout, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new RuntimeException('wp-cli step stdout was not valid JSON: ' . json_last_error_msg());
+        }
+        return is_array($decoded) ? $decoded : ['metadata' => ['stdout' => $decoded]];
+    }
+
+    return ['metadata' => ['stdout' => $stdout]];
+}
+
+function pg_bench_run_configured_workload(array $workload, string $plugin_path): array {
+    $metrics = [];
+    $artifacts = [];
+    $metadata = [];
+
+    pg_bench_merge_workload_payload($workload, $metrics, $artifacts, $metadata);
+
+    foreach ($workload['run'] as $step) {
+        $type = $step['type'];
+        $result = $type === 'php'
+            ? pg_bench_run_php_step($step, $plugin_path)
+            : pg_bench_run_wp_cli_step($step);
+        pg_bench_merge_workload_payload($result, $metrics, $artifacts, $metadata);
+    }
+
+    return [
+        'metrics' => $metrics,
+        'artifacts' => $artifacts,
+        'metadata' => $metadata,
+    ];
+}
+
 // ---------------------------------------------------------------------------
 // Stage: discover_workloads — find every tests/bench/*.php file.
 //
@@ -190,8 +399,7 @@ function pg_bench_normalize_workload_filter(string $raw): array {
 // you have a benchmark."
 // ---------------------------------------------------------------------------
 pg_stage_begin('discover_workloads');
-$workload_files = [];
-$workload_sources = [];
+$workloads = [];
 try {
     $bench_dir = "$plugin_path/tests/bench";
     if (is_dir($bench_dir)) {
@@ -202,8 +410,12 @@ try {
         foreach ($iterator as $file) {
             if ($file->isFile() && $file->getExtension() === 'php') {
                 $path = $file->getPathname();
-                $workload_files[] = $path;
-                $workload_sources[$path] = 'in_tree';
+                $workloads[] = [
+                    'kind' => 'file',
+                    'id' => homeboy_bench_scenario_id(basename($path)),
+                    'file' => $path,
+                    'source' => 'in_tree',
+                ];
             }
         }
     }
@@ -218,27 +430,45 @@ try {
             pg_log("NOTICE: skipping invalid rig bench workload: " . var_export($path, true));
             continue;
         }
-        $workload_files[] = $path;
-        $workload_sources[$path] = 'rig';
+        $workloads[] = [
+            'kind' => 'file',
+            'id' => homeboy_bench_scenario_id(basename($path)),
+            'file' => $path,
+            'source' => 'rig',
+        ];
     }
 
-    sort($workload_files);
+    foreach (pg_bench_configured_workloads('{{PLAYGROUND_WORKLOADS_JSON}}') as $configured_workload) {
+        $workloads[] = [
+            'kind' => 'configured',
+            'id' => $configured_workload['id'],
+            'label' => isset($configured_workload['label']) && is_scalar($configured_workload['label']) ? (string) $configured_workload['label'] : null,
+            'workload' => $configured_workload,
+            'source' => 'config',
+        ];
+    }
+
+    usort($workloads, static function (array $left, array $right): int {
+        $left_key = $left['kind'] === 'file' ? $left['file'] : ('~' . $left['id']);
+        $right_key = $right['kind'] === 'file' ? $right['file'] : ('~' . $right['id']);
+        return strcmp($left_key, $right_key);
+    });
 
     $requested_workloads = pg_bench_normalize_workload_filter('{{BENCH_WORKLOADS_JSON}}');
     if (!empty($requested_workloads)) {
         $requested_lookup = array_fill_keys($requested_workloads, true);
         $available_workloads = [];
-        $filtered_workload_files = [];
+        $filtered_workloads = [];
 
-        foreach ($workload_files as $workload_file) {
-            $scenario_id = homeboy_bench_scenario_id(basename($workload_file));
+        foreach ($workloads as $workload) {
+            $scenario_id = $workload['id'];
             $available_workloads[] = $scenario_id;
             if (isset($requested_lookup[$scenario_id])) {
-                $filtered_workload_files[] = $workload_file;
+                $filtered_workloads[] = $workload;
             }
         }
 
-        if (empty($filtered_workload_files)) {
+        if (empty($filtered_workloads)) {
             throw new RuntimeException(sprintf(
                 'bench_workloads matched no workloads. Requested: %s. Available: %s',
                 implode(', ', $requested_workloads),
@@ -246,14 +476,14 @@ try {
             ));
         }
 
-        $workload_files = $filtered_workload_files;
-        pg_log('WORKLOAD_FILTER: requested=' . implode(',', $requested_workloads) . ' matched=' . count($workload_files));
+        $workloads = $filtered_workloads;
+        pg_log('WORKLOAD_FILTER: requested=' . implode(',', $requested_workloads) . ' matched=' . count($workloads));
     }
 
-    if (empty($workload_files)) {
+    if (empty($workloads)) {
         pg_log("NO_WORKLOAD_FILES");
     }
-    pg_log("DISCOVERY: dir=$bench_dir in_tree=" . count(array_filter($workload_sources, fn($source) => $source === 'in_tree')) . " rig=" . count(array_filter($workload_sources, fn($source) => $source === 'rig')));
+    pg_log("DISCOVERY: dir=$bench_dir in_tree=" . count(array_filter($workloads, fn($workload) => $workload['source'] === 'in_tree')) . " rig=" . count(array_filter($workloads, fn($workload) => $workload['source'] === 'rig')) . " config=" . count(array_filter($workloads, fn($workload) => $workload['source'] === 'config')));
     pg_stage_ok('discover_workloads');
 } catch (Throwable $e) {
     pg_stage_fail('discover_workloads', $e);
@@ -288,13 +518,17 @@ function pg_bench_aggregate_metric(array $samples, string $prefix, string $suffi
 }
 
 /** Record custom metrics/metadata from a workload return payload. */
-function pg_bench_record_workload_result($result, array &$custom_metric_samples, &$latest_metadata): void {
+function pg_bench_record_workload_result($result, array &$custom_metric_samples, &$latest_metadata, &$latest_artifacts): void {
     if (!is_array($result)) {
         return;
     }
 
     if (array_key_exists('metadata', $result)) {
         $latest_metadata = $result['metadata'];
+    }
+
+    if (array_key_exists('artifacts', $result)) {
+        $latest_artifacts = $result['artifacts'];
     }
 
     if (!isset($result['metrics']) || !is_array($result['metrics'])) {
@@ -325,23 +559,27 @@ if ($iterations_per_workload < 1) {
 }
 
 if (HOMEBOY_BENCH_LIST_ONLY) {
-    foreach ($workload_files as $workload_file) {
-        $basename = basename($workload_file);
-        $scenario_id = homeboy_bench_scenario_id($basename);
-        $source = $workload_sources[$workload_file] ?? 'in_tree';
-        $relative_file = $source === 'in_tree'
-            ? substr($workload_file, strlen($plugin_path) + 1)
-            : $workload_file;
+    foreach ($workloads as $workload) {
+        $source = $workload['source'];
+        $relative_file = $workload['kind'] === 'file'
+            ? ($source === 'in_tree' ? substr($workload['file'], strlen($plugin_path) + 1) : $workload['file'])
+            : null;
 
-        $scenarios[] = [
-            'id' => $scenario_id,
-            'file' => $relative_file,
+        $scenario = [
+            'id' => $workload['id'],
             'source' => $source,
             'iterations' => 0,
             'default_iterations' => $iterations_per_workload,
             'tags' => [],
             'metrics' => new stdClass(),
         ];
+        if ($relative_file !== null) {
+            $scenario['file'] = $relative_file;
+        }
+        if (isset($workload['label']) && $workload['label'] !== null) {
+            $scenario['metadata'] = ['label' => $workload['label']];
+        }
+        $scenarios[] = $scenario;
     }
 
     homeboy_write_bench_results("$plugin_path/.pg-bench-results{{RESULT_SUFFIX}}.json", '{{COMPONENT_ID}}', 0, $scenarios);
@@ -350,33 +588,36 @@ if (HOMEBOY_BENCH_LIST_ONLY) {
 }
 
 try {
-    foreach ($workload_files as $workload_file) {
-        $basename = basename($workload_file);
-        $scenario_id = homeboy_bench_scenario_id($basename);
+    foreach ($workloads as $workload) {
+        $scenario_id = $workload['id'];
         // Path relative to the plugin root for the BenchResults envelope.
-        $source = $workload_sources[$workload_file] ?? 'in_tree';
-        $relative_file = $source === 'in_tree'
-            ? substr($workload_file, strlen($plugin_path) + 1)
-            : $workload_file;
+        $source = $workload['source'];
+        $relative_file = $workload['kind'] === 'file'
+            ? ($source === 'in_tree' ? substr($workload['file'], strlen($plugin_path) + 1) : $workload['file'])
+            : null;
 
-        pg_log("WORKLOAD_BEGIN: $scenario_id ($basename)");
+        pg_log("WORKLOAD_BEGIN: $scenario_id (" . ($relative_file ?? 'configured') . ")");
 
-        // Each workload returns a callable. `require` (not `require_once`)
-        // here so re-runs in the same process re-evaluate the file — that
-        // keeps the workload author's expectations simple: "every iteration
-        // starts where the file's top-level body left off." For Phase 1
-        // we pay the parse cost per workload (not per iteration); good
-        // enough until measurements show otherwise.
-        $callable = require $workload_file;
-        if (!is_callable($callable)) {
-            pg_log("WORKLOAD_SKIP: $scenario_id (file did not return a callable)");
-            continue;
+        if ($workload['kind'] === 'file') {
+            // Each workload returns a callable. `require` (not `require_once`)
+            // here so re-runs in the same process re-evaluate the file.
+            $callable = require $workload['file'];
+            if (!is_callable($callable)) {
+                pg_log("WORKLOAD_SKIP: $scenario_id (file did not return a callable)");
+                continue;
+            }
+        } else {
+            $callable = static function () use ($workload, $plugin_path): array {
+                return pg_bench_run_configured_workload($workload['workload'], $plugin_path);
+            };
         }
 
         $timings_ms = [];
         $custom_metric_samples = [];
         $latest_metadata = null;
+        $latest_artifacts = null;
         $has_metadata = false;
+        $has_artifacts = false;
         $peak_memory = 0;
 
         // Reset PHP's peak-memory counter so the workload's footprint is
@@ -399,7 +640,10 @@ try {
                 if (is_array($workload_result) && array_key_exists('metadata', $workload_result)) {
                     $has_metadata = true;
                 }
-                pg_bench_record_workload_result($workload_result, $custom_metric_samples, $latest_metadata);
+                if (is_array($workload_result) && array_key_exists('artifacts', $workload_result)) {
+                    $has_artifacts = true;
+                }
+                pg_bench_record_workload_result($workload_result, $custom_metric_samples, $latest_metadata, $latest_artifacts);
             }
         }
 
@@ -414,15 +658,20 @@ try {
 
         $scenario = [
             'id' => $scenario_id,
-            'file' => $relative_file,
             'source' => $source,
             'iterations' => $iterations_per_workload,
             'metrics' => $metrics,
             'memory' => ['peak_bytes' => $peak_memory],
         ];
+        if ($relative_file !== null) {
+            $scenario['file'] = $relative_file;
+        }
 
-        if ($has_metadata) {
+        if ($has_metadata && is_array($latest_metadata) && !empty($latest_metadata)) {
             $scenario['metadata'] = $latest_metadata;
+        }
+        if ($has_artifacts && is_array($latest_artifacts) && !empty($latest_artifacts)) {
+            $scenario['artifacts'] = $latest_artifacts;
         }
 
         $scenarios[] = $scenario;

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -228,14 +228,17 @@ function pg_bench_configured_workloads(string $raw): array {
                 throw new RuntimeException("playground_workloads[$index].run[$step_index] must be an object");
             }
             $type = $step['type'] ?? '';
-            if (!in_array($type, ['php', 'wp-cli'], true)) {
-                throw new RuntimeException("playground_workloads[$index].run[$step_index].type must be 'php' or 'wp-cli'");
+            if (!in_array($type, ['php', 'wp-cli', 'ability'], true)) {
+                throw new RuntimeException("playground_workloads[$index].run[$step_index].type must be 'php', 'wp-cli', or 'ability'");
             }
             if ($type === 'php' && !isset($step['code']) && !isset($step['file'])) {
                 throw new RuntimeException("playground_workloads[$index].run[$step_index] php step requires code or file");
             }
             if ($type === 'wp-cli' && !isset($step['command'])) {
                 throw new RuntimeException("playground_workloads[$index].run[$step_index] wp-cli step requires command");
+            }
+            if ($type === 'ability' && !isset($step['ability'])) {
+                throw new RuntimeException("playground_workloads[$index].run[$step_index] ability step requires `ability`");
             }
         }
 
@@ -367,6 +370,81 @@ function pg_bench_run_wp_cli_step(array $step) {
     return ['metadata' => ['stdout' => $stdout]];
 }
 
+function pg_bench_run_ability_step(array $step) {
+    if (!function_exists('wp_get_ability')) {
+        throw new RuntimeException('ability workload steps require the WordPress Abilities API (wp_get_ability) to be loaded inside the Playground PHP process');
+    }
+
+    if (!isset($step['ability']) || !is_scalar($step['ability'])) {
+        throw new RuntimeException('ability step requires a string `ability` name');
+    }
+    $name = trim((string) $step['ability']);
+    if ($name === '') {
+        throw new RuntimeException('ability step `ability` must not be empty');
+    }
+
+    // The Abilities API requires registrations to happen on the canonical
+    // init actions. wp-phpunit's install path boots wp-settings.php under
+    // WP_INSTALLING, which short-circuits the lazy registry init. Fire both
+    // actions once, idempotently, before resolving so plugin-declared
+    // categories and abilities land in the registry. Categories must register
+    // before abilities (core enforces the dependency).
+    if (function_exists('did_action') && function_exists('do_action')) {
+        if (!did_action('wp_abilities_api_categories_init')) {
+            do_action('wp_abilities_api_categories_init');
+        }
+        if (!did_action('wp_abilities_api_init')) {
+            do_action('wp_abilities_api_init');
+        }
+    }
+
+    $ability = wp_get_ability($name);
+    if (!$ability) {
+        throw new RuntimeException("ability not registered: $name");
+    }
+
+    $input = $step['input'] ?? [];
+    if ($input !== null && !is_array($input)) {
+        throw new RuntimeException('ability step `input` must be an object');
+    }
+
+    if (isset($step['user'])) {
+        if (!function_exists('get_user_by') || !function_exists('wp_set_current_user')) {
+            throw new RuntimeException('ability step `user` requires WordPress user functions to be loaded');
+        }
+        $candidate = $step['user'];
+        $user = false;
+        if (is_numeric($candidate)) {
+            $user = get_user_by('id', (int) $candidate);
+        } elseif (is_string($candidate) && $candidate !== '') {
+            $user = get_user_by('login', $candidate) ?: get_user_by('email', $candidate) ?: get_user_by('slug', $candidate);
+        }
+        if (!$user) {
+            throw new RuntimeException('ability step user not found: ' . var_export($candidate, true));
+        }
+        wp_set_current_user($user->ID);
+    }
+
+    if (method_exists($ability, 'execute')) {
+        $result = $ability->execute($input ?? []);
+    } elseif (is_callable($ability)) {
+        $result = $ability($input ?? []);
+    } else {
+        throw new RuntimeException("ability $name is not executable");
+    }
+
+    if (function_exists('is_wp_error') && is_wp_error($result)) {
+        $message = method_exists($result, 'get_error_message') ? $result->get_error_message() : 'wp_error';
+        throw new RuntimeException("ability $name returned WP_Error: $message");
+    }
+
+    if (is_array($result) && (isset($result['metrics']) || isset($result['artifacts']) || isset($result['metadata']))) {
+        return $result;
+    }
+
+    return ['metadata' => ['return' => $result]];
+}
+
 function pg_bench_run_configured_workload(array $workload, string $plugin_path): array {
     $metrics = [];
     $artifacts = [];
@@ -376,9 +454,19 @@ function pg_bench_run_configured_workload(array $workload, string $plugin_path):
 
     foreach ($workload['run'] as $step) {
         $type = $step['type'];
-        $result = $type === 'php'
-            ? pg_bench_run_php_step($step, $plugin_path)
-            : pg_bench_run_wp_cli_step($step);
+        switch ($type) {
+            case 'php':
+                $result = pg_bench_run_php_step($step, $plugin_path);
+                break;
+            case 'wp-cli':
+                $result = pg_bench_run_wp_cli_step($step);
+                break;
+            case 'ability':
+                $result = pg_bench_run_ability_step($step);
+                break;
+            default:
+                throw new RuntimeException("unsupported step type: $type");
+        }
         pg_bench_merge_workload_payload($result, $metrics, $artifacts, $metadata);
     }
 

--- a/wordpress/tests/fixtures/playground-workloads-ability/playground-workloads-ability.php
+++ b/wordpress/tests/fixtures/playground-workloads-ability/playground-workloads-ability.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Plugin Name: Playground Workloads Ability Fixture
+ *
+ * Registers a tiny ability through the canonical WordPress Abilities API
+ * (`wp_register_ability`, in core as of WP 6.9). The configured-workload
+ * `ability` step calls into it via `wp_get_ability( $name )->execute( $input )`
+ * to prove the runner can drive Abilities-API consumers without WP-CLI.
+ *
+ * Registration goes through the canonical `wp_abilities_api_init` action, the
+ * same way real plugins register. Fixture has no compatibility shim: if the
+ * Abilities API isn't loaded, the runner surfaces a typed RuntimeException.
+ */
+
+if (!function_exists('wp_register_ability')) {
+    return;
+}
+
+add_action('wp_abilities_api_categories_init', static function (): void {
+    if (!function_exists('wp_register_ability_category')) {
+        return;
+    }
+    if (function_exists('wp_get_ability_category') && wp_get_ability_category('fixtures')) {
+        return;
+    }
+    wp_register_ability_category('fixtures', [
+        'label' => 'Fixtures',
+        'description' => 'Abilities used by Playground bench fixtures.',
+    ]);
+});
+
+add_action('wp_abilities_api_init', static function (): void {
+    if (wp_get_ability('playground-workloads-fixture/run-pipeline')) {
+        return;
+    }
+    wp_register_ability('playground-workloads-fixture/run-pipeline', [
+        'label' => 'Playground Workloads Fixture: run pipeline',
+        'description' => 'Test ability that emits metrics, artifacts, and metadata.',
+        'category' => 'fixtures',
+        'permission_callback' => static fn (): bool => true,
+        'input_schema' => [
+            'type' => 'object',
+            'properties' => [
+                'pipeline_id' => ['type' => 'integer'],
+                'items' => ['type' => 'integer'],
+            ],
+        ],
+        'output_schema' => [
+            'type' => 'object',
+            'properties' => [
+                'metrics' => ['type' => 'object'],
+                'artifacts' => ['type' => 'object'],
+                'metadata' => ['type' => 'object'],
+            ],
+        ],
+        'execute_callback' => static function (array $input = []) {
+            $report_dir = WP_CONTENT_DIR . '/playground-workloads-fixture';
+            if (!is_dir($report_dir)) {
+                wp_mkdir_p($report_dir);
+            }
+            $report_path = $report_dir . '/ability-report.json';
+            $items = isset($input['items']) ? max(0, (int) $input['items']) : 0;
+            file_put_contents($report_path, wp_json_encode([
+                'ok' => true,
+                'items' => $items,
+                'pipeline_id' => $input['pipeline_id'] ?? null,
+            ]));
+
+            return [
+                'metrics' => [
+                    'items_processed' => $items,
+                ],
+                'artifacts' => [
+                    'ability_report' => [
+                        'path' => 'wp-content/playground-workloads-fixture/ability-report.json',
+                        'kind' => 'json',
+                        'label' => 'Ability run report',
+                    ],
+                ],
+                'metadata' => [
+                    'pipeline_id' => $input['pipeline_id'] ?? null,
+                    'phase' => 'ability-executed',
+                ],
+            ];
+        },
+    ]);
+});

--- a/wordpress/tests/fixtures/playground-workloads/playground-workloads.php
+++ b/wordpress/tests/fixtures/playground-workloads/playground-workloads.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * Plugin Name: Playground Workloads Fixture
+ */

--- a/wordpress/tests/fixtures/playground-workloads/workloads/configured.php
+++ b/wordpress/tests/fixtures/playground-workloads/workloads/configured.php
@@ -1,0 +1,24 @@
+<?php
+
+$report_path = __DIR__ . '/report.json';
+file_put_contents($report_path, json_encode([
+    'ok' => true,
+    'source' => 'configured-playground-workload',
+], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+return [
+    'metrics' => [
+        'generated_pages' => 2,
+    ],
+    'artifacts' => [
+        'generated_report' => [
+            'path' => 'workloads/report.json',
+            'kind' => 'json',
+            'label' => 'Generated workload report',
+        ],
+    ],
+    'metadata' => [
+        'phase' => 'configured',
+        'preview_url' => 'https://example.test/playground-preview',
+    ],
+];

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -781,6 +781,13 @@
       "description": "Blueprint JSON passed to wp-playground-cli --blueprint before bench workloads run. Use this for cold-boot scenarios that need plugins, themes, site options, or seeded content installed during Playground bootstrap. Empty object means stock WordPress."
     },
     {
+      "id": "playground_workloads",
+      "label": "Playground workloads",
+      "type": "array",
+      "default": [],
+      "description": "Config-declared WordPress Playground bench workloads run after the shared bootstrap, playground_blueprint, dependency mounts, and component load. Each workload declares an id, optional label, run steps ({type: 'php', code|file} or {type: 'wp-cli', command}), and optional metrics/artifacts/metadata. Step returns use the same {metrics, artifacts, metadata} shape as Node.js bench workloads."
+    },
+    {
       "id": "bench_site_mode",
       "label": "Bench site mode",
       "type": "string",


### PR DESCRIPTION
## Summary
- Closes #420 by adding a generic `playground_workloads` extension setting so repos can declare WordPress Playground bench workloads in their `homeboy.json` without shipping PHP files under `tests/bench/` or hardcoding consumer-specific behavior into the WordPress extension.
- Configured workloads run through the existing Playground bench runner — same boot path, same `playground_blueprint`, same dependency mounts, same component load, same BenchResults envelope. No new runner, no Homeboy core changes.
- Three step types: `php` (file or inline code), `ability` (`wp_get_ability()->execute()` against the WordPress core 6.9 Abilities API), and `wp-cli` (`WP_CLI::runcommand()` when WP-CLI is loaded). Step returns use the Node.js extension's `{ metrics, artifacts, metadata }` shape and are folded into the scenario in BenchResults exactly like in-tree custom-metric workloads.

## Why `ability` matters
The Abilities API landed in WordPress core 6.9, which Playground boots by default. That makes abilities the natural workload entry point for plugins like Data Machine and Intelligence: declare a blueprint that installs the plugin, declare a workload that calls its ability, collect structured results — no WP-CLI, no live MySQL, no staging install. CI runs the actual pipeline against a freshly-booted WP inside PHP-WASM + SQLite.

The runner fires `wp_abilities_api_categories_init` and `wp_abilities_api_init` once, idempotently, before the first ability call (wp-phpunit's `WP_INSTALLING` boot path short-circuits the lazy registry init). No polyfill or compatibility shim — if `wp_get_ability` isn't loaded, the runner raises a typed `RuntimeException`.

## Behavior
- New WordPress extension setting `playground_workloads` (`type: array`, default `[]`).
- Schema per workload: `id`, optional `label`, `run` array of steps, optional `metrics` / `artifacts` / `metadata` baselines.
- Step shapes:
  - `{ "type": "php", "file": "workloads/example.php" }` (file path, resolved relative to the mounted component when not absolute)
  - `{ "type": "php", "code": "return ['metrics' => ['rows' => 1]];" }`
  - `{ "type": "ability", "ability": "datamachine/run-pipeline", "input": { "pipeline_id": 42 }, "user": "admin" }`
  - `{ "type": "wp-cli", "command": "wp option get blogname --format=json", "parse": "json" }`
- Existing `bench_workloads` filter applies to configured workloads by id.
- Configured workloads sort after file-based workloads so PHP `tests/bench/*.php` ordering is unchanged.

## Validation
- `bash wordpress/scripts/bench/playground-bench-configured-workloads-smoke.sh` — new smoke; PHP-step workload returns metrics + artifacts + metadata.
- `bash wordpress/scripts/bench/playground-bench-ability-step-smoke.sh` — new smoke; registers a fixture ability through the canonical Abilities API (`wp_abilities_api_categories_init` + `wp_abilities_api_init`), executes it via the `ability` step, asserts the BenchResults envelope.
- `bash wordpress/scripts/bench/playground-bench-workloads-smoke.sh` — existing filter smoke still passes.
- `bash wordpress/scripts/bench/playground-bench-custom-metrics-smoke.sh` — existing custom-metrics smoke still passes.
- `php -l` clean for `wordpress/scripts/bench/playground-bench-runner.php` and the new fixtures; `bash -n` clean for both new smoke scripts.

## Notes
- Homeboy core's existing `BenchScenario` already accepts per-scenario `artifacts` and `metadata`; no core changes were needed to carry the new payload shapes.
- WP-CLI steps require `WP_CLI::runcommand()` to be loaded inside the Playground PHP process. The runner declares the contract clearly and surfaces a typed error when the seam is missing instead of silently no-opping; wiring up an in-process WP-CLI bootstrap is a separate, larger gap and intentionally not in scope here. For Abilities-API-backed plugins, prefer the `ability` step type — that's the canonical seam and doesn't need WP-CLI.
- Static Site Importer is mentioned only as a docs example; the extension itself has no SSI awareness.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the WordPress extension changes (`playground_workloads` setting, runner step types, idempotent Abilities API priming), the fixtures, the smoke tests, and the docs / PR copy. Chris reviewed and ran the smoke suite locally against WP 6.9 Playground.