### PR TITLE
feat(extensions): declare lockfile_paths for autofix drift resolution

### DIFF
--- a/go/go.json
+++ b/go/go.json
@@ -23,7 +23,8 @@
     "cleanup_paths": [
       "bin",
       "dist"
-    ]
+    ],
+    "lockfile_paths": ["go.sum"]
   },
   "lint": {
     "extension_script": "scripts/lint-runner.sh"

--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -143,6 +143,11 @@
     "cleanup_paths": [
       "node_modules",
       "dist"
+    ],
+    "lockfile_paths": [
+      "package-lock.json",
+      "yarn.lock",
+      "pnpm-lock.yaml"
     ]
   },
   "lint": {

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -90,7 +90,8 @@
   "build": {
     "cleanup_paths": [
       "target"
-    ]
+    ],
+    "lockfile_paths": ["Cargo.lock"]
   },
   "cli": {
     "tool": "cargo",

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -703,6 +703,12 @@
       "node_extensions",
       "vendor",
       "build"
+    ],
+    "lockfile_paths": [
+      "composer.lock",
+      "package-lock.json",
+      "yarn.lock",
+      "pnpm-lock.yaml"
     ]
   },
   "lint": {


### PR DESCRIPTION
## Summary
- Each extension declares which lockfiles its build pipeline regenerates via the new `build.lockfile_paths` manifest field.
- Homeboy core composes these into a per-component drift list (homeboy#2326). Homeboy-action consumes that list to push lockfile churn directly to the base branch instead of opening review-worthless autofix PRs.

## Declarations

| Extension | Lockfile paths |
|-----------|----------------|
| `rust`      | `Cargo.lock` |
| `wordpress` | `composer.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` |
| `nodejs`    | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` |
| `go`        | `go.sum` |

WordPress lists all three Node lockfiles because WP plugins commonly ship a JS build alongside PHP. Existence is checked at the action layer — components without a `yarn.lock` simply skip it.

## Component-level escape hatches

Components needing additional drift paths (a generated SDK file, a checksum manifest, etc.) opt in via `extra_drift_files` in their `homeboy.json`. Component entries are additive only; they can't remove extension-declared drift, which keeps extension policy authoritative.

## Dependency

Requires homeboy#2326 to land first — that PR adds the `build.lockfile_paths` field to the manifest schema and surfaces the resolved list via `homeboy component show`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** manifest edits and verification, reviewed/tested by Chris before merge.