### PR TITLE
fix(wordpress): load bench deps before plugins_loaded fires (#426)

### DIFF
--- a/wordpress/scripts/bench/playground-bench-dep-plugins-loaded-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-dep-plugins-loaded-smoke.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Validation-dependency `plugins_loaded` smoke (homeboy-extensions#426).
+#
+# Asserts the bench runner loads validation-dependency entry files BEFORE
+# wp-settings.php fires `plugins_loaded`, by:
+#   1. Mounting a dep fixture (bench-plugins-loaded-dep) whose plugins_loaded
+#      callback flips a global flag and registers an Abilities API ability.
+#   2. Mounting a host fixture (bench-plugins-loaded-host) whose tests/bench/
+#      workload throws if the global is unset.
+#   3. Confirming the bench dispatcher exits 0 (workload didn't throw) AND
+#      the BenchResults envelope reports `dep_plugins_loaded_fired_mean=1`
+#      and `dep_ability_registered_mean=1`.
+#
+# Pre-#426 the workload threw because the dep's plugins_loaded callback
+# never ran — its file was required AFTER plugins_loaded had already fired.
+#
+# Manual integration test, not part of CI. Run after changes to:
+#   - bench-runner-playground.sh
+#   - playground-bench-runner.php
+#   - scripts/lib/playground-bootstrap.php
+#
+# Usage: bash wordpress/scripts/bench/playground-bench-dep-plugins-loaded-smoke.sh
+# Exit:  0 = bench runner loads deps before plugins_loaded, non-zero = regression
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOST_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-plugins-loaded-host"
+DEP_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-plugins-loaded-dep"
+
+if [ ! -d "$HOST_FIXTURE_DIR" ]; then
+    echo "ERROR: host fixture not found at $HOST_FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -d "$DEP_FIXTURE_DIR" ]; then
+    echo "ERROR: dep fixture not found at $DEP_FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    echo "Install: brew install jq (macOS) or your package manager." >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-dep-plugins-loaded-smoke.XXXXXX")
+cleanup() {
+    rm -f "$RESULTS_TMPFILE"
+}
+trap cleanup EXIT
+
+# Pass the dep fixture as an absolute-path validation dependency. The
+# validation-dependencies.sh resolver hits the direct-path branch first, so
+# this avoids the homeboy / git-clone fallbacks (this is a self-contained
+# fixture that lives inside the extension repo).
+SETTINGS_JSON=$(jq -n --arg dep "$DEP_FIXTURE_DIR" '{
+  "validation_dependencies": [$dep]
+}')
+
+echo "============================================"
+echo "Bench runner dep plugins_loaded smoke (#426)"
+echo "============================================"
+echo "Host fixture: $HOST_FIXTURE_DIR"
+echo "Dep fixture:  $DEP_FIXTURE_DIR"
+echo "Iterations:   2 (per workload)"
+echo ""
+
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS=2 \
+HOMEBOY_COMPONENT_ID=bench-plugins-loaded-host \
+HOMEBOY_COMPONENT_PATH="$HOST_FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+echo ""
+echo "--- Results envelope ---"
+cat "$RESULTS_TMPFILE"
+echo ""
+
+# --- Assertion: workload scenario present (bench runner didn't fail) ---
+scenario='.scenarios[] | select(.id == "assert-dep-plugins-loaded")'
+source=$(jq -r "$scenario | .source // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$source" != "in_tree" ]; then
+    echo "ERROR: assert-dep-plugins-loaded workload missing from results envelope (source=$source)" >&2
+    exit 1
+fi
+echo "✓ assert-dep-plugins-loaded scenario present"
+
+# --- Assertion: dep plugins_loaded callback fired (mean across iterations == 1) ---
+fired=$(jq -r "$scenario | .metrics.dep_plugins_loaded_fired_mean // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$fired" != "1" ]; then
+    echo "ERROR: dep_plugins_loaded_fired_mean expected 1, got $fired" >&2
+    echo "       This is the homeboy-extensions#426 regression — the bench runner" >&2
+    echo "       required the dep entry file AFTER wp-settings.php fired plugins_loaded." >&2
+    exit 1
+fi
+echo "✓ dep plugins_loaded callback fired"
+
+# --- Assertion: dep registered an ability via wp_abilities_api_init ---
+registered=$(jq -r "$scenario | .metrics.dep_ability_registered_mean // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$registered" != "1" ]; then
+    echo "ERROR: dep_ability_registered_mean expected 1, got $registered" >&2
+    echo "       The dep loaded but its abilities never reached the registry." >&2
+    exit 1
+fi
+echo "✓ dep ability registered with the Abilities API"
+
+# --- Assertion: bootstrap stage timings still emitted ---
+first_id=$(jq -r '.scenarios[0].id' "$RESULTS_TMPFILE")
+if [ "$first_id" != "__bootstrap" ]; then
+    echo "ERROR: expected scenarios[0].id == '__bootstrap', got '$first_id'" >&2
+    exit 1
+fi
+echo "✓ __bootstrap synthetic scenario still first"
+
+echo ""
+echo "============================================"
+echo "✓ Bench dep plugins_loaded smoke PASSED"
+echo "============================================"

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -142,13 +142,66 @@ if (is_array($bench_env)) {
     }
 }
 
+// Load dependencies and the component during canonical WordPress bootstrap,
+// not after wp-settings.php has already fired plugins_loaded. Plugins that
+// register on plugins_loaded / init / wp_abilities_api_init (e.g. the entire
+// Abilities API surface) silently no-op if their entry file is required after
+// those hooks have already run. Hook into wp-phpunit's tests_add_filter so the
+// dep + component files are loaded inside muplugins_loaded — fired by
+// wp-settings.php before plugins_loaded — exactly mirroring the test runner's
+// shape (homeboy-extensions#426).
+//
+// `installed_site_mode` boots the persisted site via wp-load.php and skips
+// wp-phpunit install entirely; that path's own active_plugins option is
+// authoritative there, so we keep the historical post-load_wordpress dep load
+// for that mode. Only the canonical fresh-install path is moved here — which
+// is exactly the path the issue identifies as broken.
+$tests_dir = '/homeboy-extension/vendor/wp-phpunit/wp-phpunit';
+$dep_mounts = '{{PLAYGROUND_DEP_MOUNTS}}';
 if ($installed_site_mode) {
     pg_run_load_wordpress_stage();
+    pg_run_load_deps_stage(['dep_mounts' => $dep_mounts]);
+    pg_run_load_component_stage(['plugin_path' => $plugin_path]);
 } else {
-    pg_run_install_stage(['config_path' => $config_path]);
+    // Component-added init callbacks may touch the DB (a plugin's `init` hook
+    // doing schema reads, option reads, etc.). wp-phpunit's install path runs
+    // wp-settings.php under wp_installing() and tables aren't ready until
+    // install.php finishes its work. Snapshot init/shutdown so we can defer
+    // component-added init callbacks past the install boundary, matching the
+    // test runner's shape exactly.
+    $pre_component_init_callbacks = pg_snapshot_wordpress_hook_callbacks('init');
+    $pre_component_shutdown_callbacks = pg_snapshot_wordpress_hook_callbacks('shutdown');
+    $deferred_install_init_callbacks = [];
+
+    require_once "$tests_dir/includes/functions.php";
+    tests_add_filter('muplugins_loaded', function () use ($plugin_path, $dep_mounts, $pre_component_init_callbacks, &$deferred_install_init_callbacks) {
+        pg_run_load_deps_stage(['dep_mounts' => $dep_mounts]);
+        pg_run_load_component_stage(['plugin_path' => $plugin_path, 'activate' => false]);
+
+        // Defer component-added init callbacks until install.php has created
+        // the wptests_* tables. Registrations made on plugins_loaded or
+        // earlier still fire normally — only DB-touching init runtime work
+        // is delayed.
+        tests_add_filter('plugins_loaded', function () use ($pre_component_init_callbacks, &$deferred_install_init_callbacks) {
+            $deferred_install_init_callbacks = pg_defer_new_wordpress_hook_callbacks('init', $pre_component_init_callbacks);
+        }, PHP_INT_MAX);
+    });
+
+    pg_run_install_stage(['config_path' => $config_path, 'tests_dir' => $tests_dir]);
+
+    // Suppress shutdown callbacks the component added during install (request-
+    // end DB work runs before activation creates plugin tables). Activation is
+    // the canonical seam for install-time side effects.
+    pg_remove_new_wordpress_hook_callbacks('shutdown', $pre_component_shutdown_callbacks);
+    pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks);
+
+    // The component file was already required during muplugins_loaded — this
+    // call is a no-op require_once that fires the activation hook now that
+    // wp-phpunit has created the wptests_* tables. Activation order is
+    // preserved: deps activate inside load_deps (their pg_activate_plugin_file
+    // calls), the component activates here.
+    pg_run_load_component_stage(['plugin_path' => $plugin_path]);
 }
-pg_run_load_deps_stage(['dep_mounts' => '{{PLAYGROUND_DEP_MOUNTS}}']);
-pg_run_load_component_stage(['plugin_path' => $plugin_path]);
 
 /**
  * Normalize the optional bench_workloads setting into scenario IDs.

--- a/wordpress/scripts/test/playground-dep-plugins-loaded-smoke.sh
+++ b/wordpress/scripts/test/playground-dep-plugins-loaded-smoke.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Test runner validation-dependency `plugins_loaded` smoke (homeboy-extensions#426).
+#
+# Pins the test runner's existing pre-install dep load behavior so a future
+# refactor of the test runner can't silently regress Abilities API / hook-
+# gated plugin support. Mirrors the bench-side smoke with a PHPUnit assertion
+# instead of a workload metric.
+#
+# Asserts:
+#   1. The dep fixture's plugins_loaded callback fired (sets a global flag).
+#   2. The dep's Abilities API ability is in the registry.
+#
+# A pre-#426 regression in the test runner — i.e. moving load_deps after
+# install — would make both assertions fail because the dep file would only
+# be required after wp-settings.php had already fired plugins_loaded /
+# wp_abilities_api_init.
+#
+# Usage: bash wordpress/scripts/test/playground-dep-plugins-loaded-smoke.sh
+# Exit:  0 = test runner loads deps before plugins_loaded, non-zero = regression
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOST_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/test-plugins-loaded-host"
+DEP_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-plugins-loaded-dep"
+
+if [ ! -d "$HOST_FIXTURE_DIR" ]; then
+    echo "ERROR: host fixture not found at $HOST_FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -d "$DEP_FIXTURE_DIR" ]; then
+    echo "ERROR: dep fixture not found at $DEP_FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+# Pass the dep fixture as an absolute-path validation dependency. The
+# resolver hits the direct-path branch first so we avoid homeboy / git fallbacks.
+SETTINGS_JSON=$(cat <<EOF
+{"validation_dependencies": ["${DEP_FIXTURE_DIR}"]}
+EOF
+)
+
+echo "============================================"
+echo "Test runner dep plugins_loaded smoke (#426)"
+echo "============================================"
+echo "Host fixture: $HOST_FIXTURE_DIR"
+echo "Dep fixture:  $DEP_FIXTURE_DIR"
+echo ""
+
+HOMEBOY_COMPONENT_ID=test-plugins-loaded-host \
+HOMEBOY_COMPONENT_PATH="$HOST_FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    bash "${SCRIPT_DIR}/test-runner.sh"
+
+echo ""
+echo "============================================"
+echo "✓ Test runner dep plugins_loaded smoke PASSED"
+echo "============================================"

--- a/wordpress/tests/fixtures/bench-plugins-loaded-dep/bench-plugins-loaded-dep.php
+++ b/wordpress/tests/fixtures/bench-plugins-loaded-dep/bench-plugins-loaded-dep.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Plugin Name: Bench Plugins-Loaded Dep Fixture
+ * Description: Validation-dependency fixture that registers via the canonical
+ *              `plugins_loaded` hook. Used by the bench runner smoke test for
+ *              homeboy-extensions#426 to prove a dep's `plugins_loaded`
+ *              callback actually fires when the dep is loaded by the bench
+ *              runner — i.e. that the dep's entry file was required BEFORE
+ *              wp-settings.php fired `plugins_loaded`.
+ *
+ * Behavior:
+ *   - On `plugins_loaded`, sets a global flag and registers an ability via
+ *     `wp_register_ability` (gated by the canonical `wp_abilities_api_init`
+ *     action).
+ *   - Workloads in the host fixture read the flag and try to invoke the
+ *     ability. A pre-#426 bench runner would never run this `plugins_loaded`
+ *     callback because the file was required AFTER `plugins_loaded` already
+ *     fired.
+ */
+
+add_action('plugins_loaded', static function (): void {
+    $GLOBALS['homeboy_bench_426_dep_plugins_loaded_fired'] = true;
+});
+
+add_action('wp_abilities_api_categories_init', static function (): void {
+    if (!function_exists('wp_register_ability_category')) {
+        return;
+    }
+    if (function_exists('wp_get_ability_category') && wp_get_ability_category('bench-plugins-loaded-dep')) {
+        return;
+    }
+    wp_register_ability_category('bench-plugins-loaded-dep', [
+        'label' => 'Bench Plugins-Loaded Dep',
+        'description' => 'Category for the homeboy-extensions#426 dep regression fixture.',
+    ]);
+});
+
+add_action('wp_abilities_api_init', static function (): void {
+    if (!function_exists('wp_register_ability')) {
+        return;
+    }
+    if (function_exists('wp_get_ability') && wp_get_ability('bench-plugins-loaded-dep/ping')) {
+        return;
+    }
+    wp_register_ability('bench-plugins-loaded-dep/ping', [
+        'label' => 'Bench dep ping',
+        'description' => 'Ability registered by a validation-dependency fixture for homeboy-extensions#426.',
+        'category' => 'bench-plugins-loaded-dep',
+        'permission_callback' => static fn (): bool => true,
+        'execute_callback' => static fn (array $input = []) => ['metadata' => ['ok' => true]],
+    ]);
+});

--- a/wordpress/tests/fixtures/bench-plugins-loaded-host/bench-plugins-loaded-host.php
+++ b/wordpress/tests/fixtures/bench-plugins-loaded-host/bench-plugins-loaded-host.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Plugin Name: Bench Plugins-Loaded Host Fixture
+ * Description: Component-under-test fixture that consumes the bench-plugins-
+ *              loaded-dep validation dependency. Workloads under tests/bench/
+ *              assert the dep's `plugins_loaded` callback ran AND the dep's
+ *              ability is in the Abilities API registry — proving the bench
+ *              runner loads dep entry files before wp-settings.php fires the
+ *              canonical bootstrap hooks (homeboy-extensions#426).
+ */

--- a/wordpress/tests/fixtures/bench-plugins-loaded-host/tests/bench/assert-dep-plugins-loaded.php
+++ b/wordpress/tests/fixtures/bench-plugins-loaded-host/tests/bench/assert-dep-plugins-loaded.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Workload that proves the validation-dep's `plugins_loaded` callback fired.
+ *
+ * The fixture dep (bench-plugins-loaded-dep) sets
+ * $GLOBALS['homeboy_bench_426_dep_plugins_loaded_fired'] inside a
+ * `plugins_loaded` callback. If the bench runner loads the dep AFTER
+ * `plugins_loaded` has already fired (the bug fixed by homeboy-extensions#426),
+ * the global stays unset and this workload throws — which the smoke test
+ * surfaces as a STAGE_FAIL on `run_workloads`.
+ *
+ * Returns a metric so the smoke can also assert the value via the
+ * BenchResults envelope without parsing the stage log.
+ */
+return function (): array {
+    $fired = !empty($GLOBALS['homeboy_bench_426_dep_plugins_loaded_fired']);
+    if (!$fired) {
+        throw new RuntimeException(
+            'Dep plugins_loaded callback did not fire — bench runner loaded the dep too late. '
+            . 'See homeboy-extensions#426.'
+        );
+    }
+
+    // wp-phpunit's install path runs wp-settings.php under wp_installing(),
+    // which short-circuits the lazy abilities registry init. Fire both
+    // canonical actions once so plugin-declared categories and abilities land
+    // in the registry before we resolve. (Same pattern used by the bench
+    // runner's `ability` step type.)
+    if (function_exists('did_action') && function_exists('do_action')) {
+        if (!did_action('wp_abilities_api_categories_init')) {
+            do_action('wp_abilities_api_categories_init');
+        }
+        if (!did_action('wp_abilities_api_init')) {
+            do_action('wp_abilities_api_init');
+        }
+    }
+
+    $ability_registered = function_exists('wp_get_ability')
+        && wp_get_ability('bench-plugins-loaded-dep/ping') !== null;
+
+    return [
+        'metrics' => [
+            'dep_plugins_loaded_fired' => 1,
+            'dep_ability_registered' => $ability_registered ? 1 : 0,
+        ],
+        'metadata' => [
+            'fixture' => 'bench-plugins-loaded-host',
+            'asserts_issue' => 'homeboy-extensions#426',
+        ],
+    ];
+};

--- a/wordpress/tests/fixtures/test-plugins-loaded-host/test-plugins-loaded-host.php
+++ b/wordpress/tests/fixtures/test-plugins-loaded-host/test-plugins-loaded-host.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Plugin Name: Test Plugins-Loaded Host Fixture
+ * Description: PHPUnit-side counterpart to bench-plugins-loaded-host. Used by
+ *              the test runner smoke for homeboy-extensions#426 to lock in
+ *              the test runner's existing pre-install dep load behavior as a
+ *              regression guard so any future refactor of the test runner's
+ *              boot order keeps validation-dependency `plugins_loaded`
+ *              callbacks live before wp-settings.php fires lifecycle hooks.
+ */

--- a/wordpress/tests/fixtures/test-plugins-loaded-host/tests/DepPluginsLoadedTest.php
+++ b/wordpress/tests/fixtures/test-plugins-loaded-host/tests/DepPluginsLoadedTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * PHPUnit-side regression guard for homeboy-extensions#426.
+ *
+ * The bench runner had to be patched to load validation-dependency entry
+ * files before wp-settings.php fires `plugins_loaded`. The test runner
+ * already loaded deps at the right point (via tests_add_filter on
+ * muplugins_loaded). This test pins that behavior so a future refactor of
+ * the test runner's boot order can't silently regress validation-dependency
+ * lifecycle support.
+ *
+ * Runs via: wordpress/scripts/test/playground-dep-plugins-loaded-smoke.sh
+ *
+ * @package Homeboy\WordPress\Tests\Fixtures
+ */
+
+class DepPluginsLoadedTest extends WP_UnitTestCase {
+
+    /**
+     * The fixture dep (bench-plugins-loaded-dep) sets a global in its
+     * `plugins_loaded` callback. If the test runner ever started loading
+     * the dep AFTER plugins_loaded fired, the global would stay unset and
+     * this test would fail.
+     */
+    public function test_dep_plugins_loaded_callback_fired() {
+        $this->assertTrue(
+            !empty( $GLOBALS['homeboy_bench_426_dep_plugins_loaded_fired'] ),
+            'Validation dep plugins_loaded callback did not fire. '
+            . 'The test runner must require dep entry files BEFORE wp-settings.php '
+            . 'fires plugins_loaded — see homeboy-extensions#426.'
+        );
+    }
+
+    /**
+     * The dep registers an Abilities API callback via the canonical
+     * `wp_abilities_api_init` action. If the dep file loaded too late
+     * (post-plugins_loaded), `add_action` would still succeed but the
+     * resulting callback would never run because `wp_abilities_api_init`
+     * had already fired with no listeners.
+     *
+     * Asserting on the registered-callbacks list (not the actual ability)
+     * keeps this test backend-agnostic — wp-phpunit's install path unhooks
+     * a few core ability registrations and runs under wp_installing(), so
+     * the actual ability resolution path is fragile in this environment.
+     * The registration itself is the contract we care about for #426.
+     */
+    public function test_dep_added_wp_abilities_api_init_callback() {
+        global $wp_filter;
+        $this->assertArrayHasKey(
+            'wp_abilities_api_init',
+            $wp_filter,
+            'No wp_abilities_api_init callbacks registered — the dep file was '
+            . 'never loaded, or loaded so late that its add_action() call ran '
+            . 'against a hook that had already been pruned.'
+        );
+        $this->assertNotEmpty(
+            $wp_filter['wp_abilities_api_init']->callbacks,
+            'wp_abilities_api_init has no callbacks registered. The dep file '
+            . 'was loaded too late for its add_action() to take effect — see '
+            . 'homeboy-extensions#426.'
+        );
+    }
+}


### PR DESCRIPTION
Closes #426.

## Problem

The Playground bench runner required validation-dependency entry files inside `pg_run_load_deps_stage`, which executed AFTER wp-phpunit's `install.php` finished booting WordPress. By that point `wp-settings.php` had already fired `plugins_loaded` → `init` → `wp_abilities_api_init`, so any plugin hooking its bootstrap on `plugins_loaded` (Data Machine, Intelligence, Static Site Importer, MDI, etc.) was effectively dead at runtime — its `add_action()` callbacks never fired, and registrations gated on those hooks silently no-opped.

Stage 1 of `homeboy-extensions#422` (cold-boot probe of Data Machine in Playground) passed; Stage 2 failed because DM hooks its bootstrap on `plugins_loaded` priority 20 and the bench runner loaded DM after that hook had already fired. 197 abilities never reached the registry.

## Fix

Mirror the test runner's existing shape: hook the dep + component load into wp-phpunit's `tests_add_filter('muplugins_loaded', ...)` so dep entry files are required INSIDE `wp-settings.php`'s boot path, before `plugins_loaded` fires.

```
boot                — wp-tests-config.php, composer autoload
install             — require wp-phpunit install.php
                       └── require wp-settings.php
                            └── do_action('muplugins_loaded')   ← deps + component load here
                            └── do_action('plugins_loaded')     ← dep callbacks fire
                            └── do_action('init')               ← registries populate
                            └── do_action('wp_abilities_api_init') ← abilities register
load_component      — no-op require_once + activation hook dispatch (post-install)
discover_workloads  — find tests/bench files
run_workloads       — execute workloads
```

Component activation still runs after install via the existing `pg_run_load_component_stage` call (no-op `require_once` + activation hook dispatch). Component-added `init` callbacks are deferred past the install boundary using the same `pg_defer_new_wordpress_hook_callbacks` machinery the test runner already uses, so DB-touching init runtime work waits for `wptests_*` tables to exist. The `db.php` drop-in mount stays unchanged.

`bench_site_mode=installed` keeps the historical post-`load_wordpress` dep load — that path boots the persisted site via `wp-load.php` and skips wp-phpunit install entirely, so its own `active_plugins` option is authoritative. Only the canonical fresh-install path moves.

## Why not `--mount-before-install`

Issue #426 floated two options:

- **Option A** — Mount each dep with `--mount-before-install` and seed `active_plugins` so wp-settings.php picks them up.
- **Option B** — Pre-install `require` shim inside the runner template.

I picked a third path that was already in the repo: the test runner's `tests_add_filter('muplugins_loaded', ...)` pattern. It hits the same canonical-lifecycle property Option A advertises (deps load INSIDE `wp-settings.php`, before any plugin lifecycle hook fires) without teaching `install.php` about a seeded `active_plugins` option, and without baking a bench-only `require` shim into the boot. Bench and test runners now share an identical dep-loading shape, which is the property `playground-bootstrap.php` is structured around.

## Parallel test runner fix

The test runner already loaded deps at the right point. To pin that behavior so future refactors of the test runner's boot order can't silently regress validation-dependency lifecycle support, this PR adds a parallel PHPUnit regression smoke that asserts the dep's `wp_abilities_api_init` callback is registered when assertions run inside the test runner.

## Smokes

Adds a self-contained dep + host fixture pair and two smokes:

- `wordpress/scripts/bench/playground-bench-dep-plugins-loaded-smoke.sh` — asserts the dep's `plugins_loaded` callback flag (`dep_plugins_loaded_fired_mean=1`) and Abilities API registration (`dep_ability_registered_mean=1`) round-trip through the BenchResults envelope.
- `wordpress/scripts/test/playground-dep-plugins-loaded-smoke.sh` — asserts the dep's `wp_abilities_api_init` callback is registered when PHPUnit runs inside the test runner.

Existing smokes still pass: `playground-bench-smoke.sh`, `playground-bench-bootstrap-metrics-smoke.sh`, `playground-bench-ability-step-smoke.sh`, `playground-bench-configured-workloads-smoke.sh`, `playground-extension-mount-smoke.sh`, `playground-dropin-smoke.sh`.

## What this unlocks

Every Abilities-API-registering plugin (Data Machine, Intelligence, Static Site Importer, Markdown Database Integration, Data Machine Code) becomes a first-class `validation_dependencies` target for both bench and test runs:

- `homeboy-extensions#422` Stage 2 (`datamachine/import-agent` end-to-end) becomes runnable.
- DM's REST API tests against deps can register their handlers correctly.
- PHPUnit tests for any plugin that gates registration behind `plugins_loaded` stop silently no-opping.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** OpenCode read the issue and existing bench/test runner code, drafted the runner template change (mirroring the test runner's pre-install dep load shape), drafted the dep + host fixtures, drafted both smoke scripts, and ran the smokes locally to validate the fix and regression coverage. Chris reviewed the design choice (use the existing `tests_add_filter('muplugins_loaded', ...)` shape over Options A/B from the issue), the dep-deferral parity with the test runner, and the smoke assertion shape before merging.