### PR TITLE
fix(wordpress): anchor constant-backed slug detector to real class declarations (#425)

### DIFF
--- a/wordpress/tests/audit-detector-config-smoke.sh
+++ b/wordpress/tests/audit-detector-config-smoke.sh
@@ -193,6 +193,54 @@ require(not any(match.strip() == "'tool_call'" for match in matches), "detector 
 require("'tool_call' =>" in fixture, "fixture should include array/protocol key literal")
 require("do_action( 'tool_call'" in fixture, "fixture should include event-name literal")
 
+# Issue #425 — source_pattern must not match `class` in docblock prose.
+# Pre-fix, `(?s).*?` between `class <name>` and `const` would let
+# `class has no knowledge` from the docblock match as the class name and
+# walk forward to the next const, producing a bogus `has::GROUP` finding.
+# The fix anchors `class` to start of line (so docblock continuation
+# lines beginning with `*` cannot satisfy it) and requires an opening
+# brace before `const` so the match has to live inside a real class body.
+source_pattern = literal_rule["source_pattern"]
+source_regex = re.compile(source_pattern)
+recurring_fixture = (fixture_dir / "src/Runtime/class-demo-recurring-scheduler.php").read_text(encoding="utf-8")
+require(
+    "This class has no knowledge" in recurring_fixture,
+    "recurring-scheduler fixture must contain the docblock prose that triggered the parser glitch",
+)
+source_matches = list(source_regex.finditer(recurring_fixture))
+require(
+    len(source_matches) == 1,
+    f"source_pattern must produce exactly one match on the recurring-scheduler fixture, got {len(source_matches)}",
+)
+match = source_matches[0]
+require(
+    match.group("class") == "Demo_Recurring_Scheduler",
+    f"source_pattern must capture the real class name, got class={match.group('class')!r}",
+)
+require(
+    match.group("const") == "GROUP",
+    f"source_pattern must capture the real const name, got const={match.group('const')!r}",
+)
+require(
+    match.group("value") == "demo-recurring",
+    f"source_pattern must capture the real const value, got value={match.group('value')!r}",
+)
+
+# Negative case: a class declared only inside a comment body must not match.
+comment_only = "\n".join([
+    "<?php",
+    "/**",
+    " * Some module that explains: class FakeStub has a const FOO = 'foo-bar' baked in.",
+    " * But there's no real class definition here.",
+    " */",
+    "$x = 1;",
+    "",
+])
+require(
+    not list(source_regex.finditer(comment_only)),
+    "source_pattern must not match a class declared only inside a comment block",
+)
+
 for relative in [
     "src/Registry/register-agents.php",
     "src/Contracts/class-demo-message-store.php",

--- a/wordpress/tests/fixtures/audit-detector-config/src/Runtime/class-demo-recurring-scheduler.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Runtime/class-demo-recurring-scheduler.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Demo Recurring Scheduler — fixture for issue #425.
+ *
+ * Exercises the constant-backed slug literal detector source pattern. The
+ * docblock intentionally contains the phrase "This class has no knowledge"
+ * because the original (?s) source pattern would non-greedily capture
+ * `class has` from the prose and walk forward to the next `const`,
+ * reporting a bogus `has::GROUP` constant.
+ *
+ * After the fix, the source pattern is anchored to start of line (so a
+ * docblock-continuation line beginning with `*` cannot satisfy `class`),
+ * AND it requires an opening brace before `const` so the match must live
+ * inside an actual class body.
+ *
+ * This class has no knowledge of flows, jobs, tasks, or settings.
+ */
+
+final class Demo_Recurring_Scheduler {
+	public const GROUP = 'demo-recurring';
+
+	public function dispatch(): array {
+		return array(
+			'group' => 'demo-recurring',
+		);
+	}
+}

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -515,7 +515,7 @@
           "language": "php",
           "file_extensions": ["php"],
           "exclude_path_contains": ["/vendor/", "vendor/", "/node_modules/", "node_modules/"],
-          "source_pattern": "(?s)\\b(?:final\\s+|abstract\\s+)?class\\s+(?P<class>[A-Za-z_][A-Za-z0-9_]*)\\b.*?\\b(?:(?:public|protected|private)\\s+)?const\\s+(?P<const>[A-Z][A-Z0-9_]*)\\s*=\\s*['\\\"](?P<value>[a-z][a-z0-9]*(?:[-_/:][a-z0-9]+)+)['\\\"]",
+          "source_pattern": "(?ms)^[ \\t]*(?:final\\s+|abstract\\s+)?class\\s+(?P<class>[A-Za-z_][A-Za-z0-9_]*)\\b[^{}\\n]*\\{.*?\\b(?:(?:public|protected|private)\\s+)?const\\s+(?P<const>[A-Z][A-Z0-9_]*)\\s*=\\s*['\\\"](?P<value>[a-z][a-z0-9]*(?:[-_/:][a-z0-9]+)+)['\\\"]",
           "value_capture": "value",
           "label": "{class}::{const}",
           "literal_pattern": "(?m)(?:[=!]==?\\s*['\\\"]{value}['\\\"]|['\\\"]{value}['\\\"]\\s*[=!]==?)",


### PR DESCRIPTION
## Summary

Closes #425.

The `wordpress-constant-backed-slug-literal` detector's `source_pattern` was greedy across the docblock between `class <name>` and `const`, which let `class <word>` match prose comments. Concrete failure: `inc/Engine/Tasks/RecurringScheduler.php` has the docblock line _"This class has no knowledge of flows…"_, so the regex captured `class has`, walked through the rest of the file to the real `const GROUP = 'data-machine'`, and emitted a bogus `has::GROUP` finding at every literal use of `'data-machine'`.

## Fix

Two anchoring tweaks to `source_pattern`:

```diff
- "(?s)\\b(?:final\\s+|abstract\\s+)?class\\s+(?P<class>[A-Za-z_][A-Za-z0-9_]*)\\b.*?\\b(?:(?:public|protected|private)\\s+)?const\\s+(?P<const>[A-Z][A-Z0-9_]*)\\s*=\\s*['\"](?P<value>[a-z][a-z0-9]*(?:[-_/:][a-z0-9]+)+)['\"]"
+ "(?ms)^[ \\t]*(?:final\\s+|abstract\\s+)?class\\s+(?P<class>[A-Za-z_][A-Za-z0-9_]*)\\b[^{}\\n]*\\{.*?\\b(?:(?:public|protected|private)\\s+)?const\\s+(?P<const>[A-Z][A-Z0-9_]*)\\s*=\\s*['\"](?P<value>[a-z][a-z0-9]*(?:[-_/:][a-z0-9]+)+)['\"]"
```

1. **`(?m)^[ \\t]*`** — anchors `class` to start of a real source line. Docblock continuation lines look like ` * This class has…`; the leading whitespace + `*` cannot satisfy `^[ \\t]*class`, so prose can't masquerade as a declaration.
2. **`[^{}\\n]*\\{`** — requires the class declaration to reach an opening brace on the same line (or via a same-line continuation). Defense in depth: even a `class <word>` that happens to start at column 0 in a comment is rejected because no `{` follows on that line.

The `(?s)` (dot-all) is preserved as part of `(?ms)` so the body match can still cross newlines down to the const.

## Validation

### Audit on `data-machine` (847 files)

Before:

```
total findings: 25
has::GROUP parser noise: 3
- inc/migrations/site-md.php:369  has::GROUP   ❌
- inc/migrations/site-md.php:425  has::GROUP   ❌
- tests/pending-action-helper-approval-envelope-smoke.php:122  has::GROUP   ❌
```

After:

```
total findings: 25
has::GROUP parser noise: 0   ✅
- inc/migrations/site-md.php:369  RecurringScheduler::GROUP   ✅ (replaces has::GROUP)
- inc/migrations/site-md.php:425  RecurringScheduler::GROUP   ✅ (replaces has::GROUP)
- tests/pending-action-helper-approval-envelope-smoke.php:122  RecurringScheduler::GROUP   ✅
```

The 3 parser-noise findings are gone. The detector now correctly attributes the `'data-machine'` literals to the real `RecurringScheduler::GROUP` constant.

The total stayed at 25 because the same-site duplication (one literal reported once per matching constant when several share a value, e.g. `'prompt_queue'` × 9 from one real `QueueAbility::SLOT_PROMPT_QUEUE` plus 8 test stubs) is unrelated to this parser glitch. That dedupe needs core-side work and is filed as a follow-up: **Extra-Chill/homeboy#2336**.

### Fixture + smoke

- New fixture: `wordpress/tests/fixtures/audit-detector-config/src/Runtime/class-demo-recurring-scheduler.php` — a real class whose docblock contains the exact phrase _"This class has no knowledge"_ that triggered the parser glitch.
- Extended `audit-detector-config-smoke.sh` to:
  - Compile the new `source_pattern` and assert exactly **one** match on the new fixture.
  - Assert the captured `class`/`const`/`value` are `Demo_Recurring_Scheduler` / `GROUP` / `demo-recurring` (i.e. NOT `has::GROUP`).
  - Assert a class declared **only** inside a comment block produces zero matches.

### Local smoke run

```
$ bash wordpress/tests/audit-detector-config-smoke.sh
wordpress audit detector config smoke passed
```

All other `wordpress/tests/*-smoke.sh` continue to pass.

## Out of scope

- Same-site multi-constant deduplication (the `prompt_queue` × 9 case). Tracked in Extra-Chill/homeboy#2336 — requires a homeboy-core change to collapse derived_literal findings keyed on `(file, line, value)`, which the JSON manifest cannot express today. Per repo rules: don't bury workarounds — splitting cleanly.
- No core (Rust) changes; JSON-only fix.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Reproducing the parser glitch from issue #425, designing the regex anchoring fix, building the fixture + smoke assertions, validating against `data-machine` audit before/after, and drafting the follow-up homeboy core issue.