### PR TITLE
fix(wordpress): tighten option-scope-drift detector for single-site plugins

### DIFF
--- a/wordpress/tests/audit-detector-config-smoke.sh
+++ b/wordpress/tests/audit-detector-config-smoke.sh
@@ -180,6 +180,96 @@ for path in [
     require(matches_any(path, exception_globs),
             f"off-role file {path} must also be exempt for v0.157.0 fallback")
 
+# Option scope drift detector — must require explicit drift vocabulary in a
+# comment block (claims of network/site-option storage), recognize file-level
+# opt-out markers, and ignore incidental mentions of "multisite"/"network".
+# Regression coverage for Extra-Chill/homeboy-extensions#424.
+option_scope_rule = next(
+    rule for rule in rules["requested_detectors"] if rule["id"] == "wordpress-option-scope-drift"
+)
+include_regex = re.compile(option_scope_rule["comment_pattern"])
+exclude_regex = re.compile(option_scope_rule["comment_exclude_pattern"])
+call_regex = re.compile(option_scope_rule["pattern"])
+
+drift_fixture = (fixture_dir / "src/Options/class-demo-network-drift.php").read_text(encoding="utf-8")
+single_site_fixture = (fixture_dir / "src/Options/class-demo-single-site-noise.php").read_text(encoding="utf-8")
+opt_out_fixture = (fixture_dir / "src/Options/class-demo-opt-out-marker.php").read_text(encoding="utf-8")
+
+# True-positive fixture: drift docblock vocabulary triggers include, no
+# opt-out, and three option call sites are flagged.
+require(include_regex.search(drift_fixture),
+        "drift fixture must trigger option-scope include pattern")
+require(not exclude_regex.search(drift_fixture),
+        "drift fixture must not trigger option-scope exclude pattern")
+drift_calls = call_regex.findall(drift_fixture)
+require(len(drift_calls) == 3,
+        f"drift fixture should expose 3 option call sites, got {len(drift_calls)}")
+
+# False-positive fixture: incidental "multisite"/"network" mentions must NOT
+# trigger the include pattern — this is the over-fire that issue #424 fixed.
+require(not include_regex.search(single_site_fixture),
+        "single-site noise fixture must not trigger option-scope include pattern (regression for #424)")
+# Sanity: the file does mention the loose vocabulary, just not the tight one.
+require(re.search(r"(?i)\bmultisite\b", single_site_fixture),
+        "single-site fixture must contain bare 'multisite' to exercise the previous over-fire shape")
+require(re.search(r"(?i)\bnetwork\s+request\b", single_site_fixture),
+        "single-site fixture must contain a non-storage 'network' mention")
+
+# Opt-out fixture: even when drift vocabulary appears, the file-level
+# `@option-scope single-site` marker suppresses the detector for the whole
+# file.
+require(include_regex.search(opt_out_fixture),
+        "opt-out fixture should contain drift vocabulary to exercise the suppress path")
+require(exclude_regex.search(opt_out_fixture),
+        "opt-out fixture must trigger the file-level @option-scope single-site exclude marker")
+
+# Exclude pattern must recognize each documented opt-out phrase.
+for phrase in [
+    "@option-scope single-site",
+    "@option-scope: single-site",
+    "single-site option",
+    "single-site only",
+    "single-site plugin",
+    "not a network option",
+    "does not support multisite",
+    "do not support multisite",
+    "no multisite support",
+    "multisite: false",
+]:
+    require(exclude_regex.search(phrase),
+            f"option-scope exclude pattern must recognize opt-out phrase: {phrase!r}")
+
+# Include pattern must NOT match incidental vocabulary that issue #424
+# called out as the false-positive shape.
+for phrase in [
+    "network request",
+    "multisite-aware logger",
+    "multisite",
+    "network",
+    "network option",  # bare phrase no longer enough on its own
+    "site option",     # bare phrase no longer enough on its own
+]:
+    require(not include_regex.search(phrase),
+            f"option-scope include pattern must not fire on incidental phrase: {phrase!r}")
+
+# Include pattern MUST match explicit drift vocabulary.
+for phrase in [
+    "stored as a network option",
+    "stored as a site option",
+    "should use update_site_option",
+    "should use site option API",
+    "must use get_site_option",
+    "network-wide setting",
+    "network wide storage",
+    "network-scoped option",
+    "shared across subsites",
+    "shared across the network",
+    "multisite-aware option",
+    "multisite option storage",
+]:
+    require(include_regex.search(phrase),
+            f"option-scope include pattern must recognize drift phrase: {phrase!r}")
+
 literal_rule = next(
     rule for rule in rules["requested_detectors"] if rule["id"] == "wordpress-constant-backed-slug-literal"
 )
@@ -214,6 +304,9 @@ for relative in [
     "src/Auth/class-demo-token-authenticator.php",
     "src/Context/class-demo-context-conflict-resolver.php",
     "src/Context/class-demo-context-injection-policy.php",
+    "src/Options/class-demo-network-drift.php",
+    "src/Options/class-demo-single-site-noise.php",
+    "src/Options/class-demo-opt-out-marker.php",
 ]:
     require((fixture_dir / relative).exists(), f"missing audit detector fixture: {relative}")
 

--- a/wordpress/tests/fixtures/audit-detector-config/src/Options/class-demo-network-drift.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Options/class-demo-network-drift.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * True-positive fixture for the wordpress-option-scope-drift detector.
+ *
+ * The docblock explicitly claims this value is stored as a network option and
+ * should use update_site_option / get_site_option, but the implementation
+ * calls the single-site `update_option` family. The detector MUST flag every
+ * `(get|update|delete)_option` call site in this file.
+ */
+
+class Demo_Network_Drift {
+
+	/**
+	 * Read the network-wide setting.
+	 *
+	 * This setting is shared across the network and stored as a network
+	 * option, so callers should use get_site_option here.
+	 */
+	public function read() {
+		return get_option( 'demo_network_setting' );
+	}
+
+	/**
+	 * Persist the network-wide option.
+	 *
+	 * Network-scoped storage: must use update_site_option.
+	 */
+	public function write( $value ) {
+		return update_option( 'demo_network_setting', $value );
+	}
+
+	/**
+	 * Delete the network-wide option.
+	 *
+	 * Stored as a site option — should use delete_site_option.
+	 */
+	public function clear() {
+		return delete_option( 'demo_network_setting' );
+	}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Options/class-demo-opt-out-marker.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Options/class-demo-opt-out-marker.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * File-level opt-out fixture for the wordpress-option-scope-drift detector.
+ *
+ * @option-scope single-site
+ *
+ * This file may legitimately discuss network-scoped storage in a comment for
+ * documentation purposes — for example, explaining that the plugin's storage
+ * is stored as a site option in a hypothetical multisite future. The
+ * `@option-scope single-site` marker above tells the detector that this file
+ * has already declared its intended option scope, so the comment-pattern
+ * trigger should be suppressed even though "stored as a site option" appears
+ * below.
+ */
+
+class Demo_Opt_Out_Marker {
+
+	/**
+	 * Hypothetically this would be stored as a site option in a multisite
+	 * deployment, but this plugin is intentionally single-site only and the
+	 * `@option-scope single-site` marker above documents that decision.
+	 */
+	public function read() {
+		return get_option( 'demo_opt_out_setting' );
+	}
+
+	public function write( $value ) {
+		return update_option( 'demo_opt_out_setting', $value );
+	}
+
+	public function clear() {
+		return delete_option( 'demo_opt_out_setting' );
+	}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Options/class-demo-single-site-noise.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Options/class-demo-single-site-noise.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * False-positive fixture for the wordpress-option-scope-drift detector.
+ *
+ * This file mentions "multisite" and "network" only in passing — discussing
+ * an incidental network request, a multisite-aware logger that lives in
+ * another package, and the fact that this plugin is intentionally
+ * single-site. None of the comments here make a claim about how any
+ * option below is supposed to be stored.
+ *
+ * The detector MUST NOT fire on this file. Under the previous rule, every
+ * `(get|update|delete)_option` call below would have been flagged because
+ * the words "multisite" and "network" appear above. The tightened
+ * `comment_pattern` ignores these incidental mentions.
+ */
+
+class Demo_Single_Site_Noise {
+
+	/**
+	 * Read the plugin's normal single-site option.
+	 *
+	 * The retry logic below makes a network request to refresh the cache
+	 * before reading. The multisite-aware logger lives in another package
+	 * and is not used here.
+	 */
+	public function read() {
+		return get_option( 'demo_single_site_setting' );
+	}
+
+	public function write( $value ) {
+		return update_option( 'demo_single_site_setting', $value );
+	}
+
+	public function clear() {
+		return delete_option( 'demo_single_site_setting' );
+	}
+}

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -531,8 +531,8 @@
           "language": "php",
           "file_extensions": ["php"],
           "exclude_path_contains": ["/vendor/", "vendor/", "/node_modules/", "node_modules/"],
-          "comment_pattern": "(?i)\\b(network option|site option|multisite|shared across subsites|shared across sites)\\b",
-          "comment_exclude_pattern": "(?i)\\b(not a network option|single-site option)\\b",
+          "comment_pattern": "(?i)\\b(?:should\\s+use\\s+(?:get_site_option|update_site_option|delete_site_option|site\\s+option)|must\\s+use\\s+(?:get_site_option|update_site_option|delete_site_option|site\\s+option)|stored\\s+as\\s+a\\s+(?:network|site)\\s+option|network[\\s-]?wide\\s+(?:option|setting|storage)|network[\\s-]?scoped\\s+(?:option|setting|storage|value)|shared\\s+across\\s+(?:subsites|sites|the\\s+network)|multisite[\\s-]?aware\\s+(?:option|storage)|multisite\\s+option\\s+storage)\\b",
+          "comment_exclude_pattern": "(?i)(?:\\bnot\\s+a\\s+network\\s+option\\b|\\bsingle-site\\s+(?:option|only|plugin|storage)\\b|\\bdo(?:es)?\\s+not\\s+support\\s+multisite\\b|\\bno\\s+multisite\\s+support\\b|\\bmultisite\\s*:\\s*false\\b|@option-scope[\\s:]+single-site\\b)",
           "pattern": "\\b(?P<call>get_option|update_option|delete_option)\\s*\\(",
           "description": "Option scope drift at line {line}: docs mention network/site-option storage but implementation calls `{call}`",
           "suggestion": "Use the matching site-option call or update the storage contract so multisite behaviour is explicit."


### PR DESCRIPTION
## Summary

Resolves the `wordpress-option-scope-drift` over-fire reported in #424 by tightening the detector's `comment_pattern` to require explicit drift vocabulary, broadening `comment_exclude_pattern` to recognize file-level opt-out markers, and adding fixture + smoke coverage for the new behavior.

The detector now only fires when a comment block in the file actually **claims** that an option is network-scoped storage — not when "multisite" or "network" appear incidentally (e.g. "network request", "multisite-aware logger").

## Rule changes

`wordpress/wordpress.json`, `wordpress-option-scope-drift` rule:

**`comment_pattern`** — drift vocabulary required:
- `should\|must use (get_site_option\|update_site_option\|delete_site_option\|site option)`
- `stored as a (network\|site) option`
- `network[-\s]?wide (option\|setting\|storage)`
- `network[-\s]?scoped (option\|setting\|storage\|value)`
- `shared across (subsites\|sites\|the network)`
- `multisite[-\s]?aware (option\|storage)`
- `multisite option storage`

Removed bare `multisite`, `network option`, `site option` triggers.

**`comment_exclude_pattern`** — file-level opt-out markers:
- `@option-scope single-site` / `@option-scope: single-site`
- `single-site (option\|only\|plugin\|storage)`
- `do(es) not support multisite`
- `no multisite support`
- `multisite: false`
- existing `not a network option` preserved

## Validation

End-to-end via `homeboy extension relink` against `/Users/chubes/Developer/data-machine` (`main`):

| | `option_scope_drift` findings | files scanned |
|---|---|---|
| **Before** | **54** | 847 |
| **After** | **0** | 847 |

Regex-level contract via `wordpress/tests/audit-detector-config-smoke.sh`:
- Three new fixtures under `wordpress/tests/fixtures/audit-detector-config/src/Options/`:
  - `class-demo-network-drift.php` — true-positive: docblock claims "stored as a network option / shared across the network / must use update_site_option" with single-site option calls below.
  - `class-demo-single-site-noise.php` — false-positive: incidental "multisite"/"network request"/"multisite-aware logger" mentions only.
  - `class-demo-opt-out-marker.php` — drift vocabulary present but suppressed by `@option-scope single-site` marker.
- Smoke test compiles the manifest patterns and asserts:
  - All documented drift phrases match the include pattern.
  - Every incidental phrase listed in #424 is rejected by the include pattern.
  - Every documented opt-out phrase matches the exclude pattern.
  - Drift fixture exposes 3 option call sites; opt-out fixture matches both include and exclude (so the file is suppressed in production runs).

All other `wordpress/tests/*-smoke.sh` continue to pass; the `audit-dead-guard-fallback-smoke.sh` failure is pre-existing in worktree contexts (workspace-level `.claude/CLAUDE.local.md` injection changes the file count seen by core's audit walker) and is unaffected by this change.

## Out of scope

Issue #424 also proposes (item 2) scoping the comment match to the call site (preceding docblock or same-statement comment) instead of file-wide. That requires changes to the `comment_regex` rule kind in homeboy core's `requested_detectors` module and is not implemented here. Per the "fix upstream first" rule, the file-level opt-out marker is a clean way to declare intent once at the file level without requiring core changes; if call-site scoping becomes necessary later it should be filed as a separate homeboy core issue.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** drafted detector rule changes and validation against data-machine audit output

Refs: #424