### PR TITLE
feat(rust/audit): declare trivial/plumbing call lists for duplication detector

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -85,6 +85,10 @@
         "heading": "## Manifests",
         "template": "### `{name}`\n\n{description}\n\n{fields}"
       }
+    },
+    "duplication_detector": {
+      "trivial_calls": ["var", "cfg", "not", "matches"],
+      "plumbing_calls": ["internal_io", "internal_unexpected", "internal_invariant"]
     }
   },
   "build": {


### PR DESCRIPTION
## Summary

Declares Rust-specific trivial/plumbing call-name lists for the homeboy parallel-implementation detector via the new `DuplicationDetectorConfig` contract.

- **trivial**: `var`, `cfg`, `not`, `matches`
- **plumbing**: `internal_io`, `internal_unexpected`, `internal_invariant`

## Why

These four-to-seven Rust idioms appeared in shape-matching false positives in the homeboy parallel-implementation detector when env-derived path helpers (`cache_fallback_root` ↔ `homeboy_data` / `homeboy`) and IO-error-producing functions shared a call signature without sharing a workflow.

## Consumed by

- Extra-Chill/homeboy#2345 — adds the `DuplicationDetectorConfig` field on `AuditConfig`. This rust manifest entry only takes effect once that core PR ships and is consumed by an extension install of `rust` at the new revision.

## Validation

Once both PRs are merged, running `homeboy audit homeboy` on a homeboy checkout consuming the new rust extension revision should drop the env-path parallel-implementation findings.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** identified the Rust-specific call names from the homeboy FP shared-call sets in audit run 25443673444. Chris reviewed/approved.