### PR TITLE
Forward Playground PHPUnit runner args

### DIFF
--- a/wordpress/scripts/test/playground-changed-scope-smoke.sh
+++ b/wordpress/scripts/test/playground-changed-scope-smoke.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNNER="${SCRIPT_DIR}/test-runner-playground.sh"
 TEMPLATE="${SCRIPT_DIR}/playground-runner.php"
+BOOTSTRAP="${SCRIPT_DIR}/../lib/playground-bootstrap.php"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
@@ -18,8 +19,9 @@ assert_contains() {
 }
 
 assert_contains "$TEMPLATE" "{{CHANGED_TEST_FILES_JSON}}"
-assert_contains "$TEMPLATE" "pg_filter_changed_tests"
-assert_contains "$TEMPLATE" "changed test scope skipped non-PHPUnit file"
+assert_contains "$TEMPLATE" "pg_filter_changed_test_files"
+assert_contains "$BOOTSTRAP" "function pg_filter_changed_test_files"
+assert_contains "$BOOTSTRAP" "SCOPED_TEST_FILES requested="
 assert_contains "$RUNNER" "CHANGED_TEST_FILES_JSON"
 assert_contains "$RUNNER" "{{CHANGED_TEST_FILES_JSON}}"
 

--- a/wordpress/scripts/test/playground-passthrough-args-smoke.sh
+++ b/wordpress/scripts/test/playground-passthrough-args-smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/test-runner-playground.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+EXTENSION_PATH="${TMPDIR}/extension"
+PLUGIN_PATH="${TMPDIR}/component"
+mkdir -p "${EXTENSION_PATH}/node_modules/.bin" "${PLUGIN_PATH}/tests"
+
+cat > "${PLUGIN_PATH}/tests/OnlyTest.php" <<'PHP'
+<?php
+class OnlyTest extends WP_UnitTestCase {}
+PHP
+
+cat > "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+wrapper=""
+runner_args=()
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--mount" ]; then
+        mount_arg="$2"
+        if [[ "$mount_arg" == *":/runner.php" ]]; then
+            wrapper="${mount_arg%:/runner.php}"
+        fi
+        shift 2
+        continue
+    fi
+    if [ "$1" = "--" ]; then
+        shift
+        runner_args=("$@")
+        break
+    fi
+    shift
+done
+
+if [ -z "$wrapper" ] || [ ! -f "$wrapper" ]; then
+    echo "runner wrapper mount not found" >&2
+    exit 1
+fi
+
+printf 'PASSTHROUGH:'
+printf ' [%s]' "${runner_args[@]}"
+printf '\n'
+
+if [ "${EXPECT_SELECTED_FILE:-}" = "1" ]; then
+    expected_b64="$(printf '%s' 'tests/OnlyTest.php' | base64 | tr -d '\n')"
+    if ! grep -Fq "$expected_b64" "$wrapper"; then
+        echo "selected PHPUnit file was not substituted into wrapper" >&2
+        exit 1
+    fi
+    echo "SELECTED_FILE_OK"
+fi
+
+cat > "${HOMEBOY_PLUGIN_PATH}/.pg-test-result.txt" <<'LOG'
+STAGE_BEGIN:run_tests
+ALL TESTS PASSED
+TESTS: 1 FAILURES: 0 ERRORS: 0
+STAGE_OK:run_tests
+LOG
+SH
+chmod +x "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli"
+
+bash -n "$RUNNER"
+
+filter_output=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
+    HOMEBOY_COMPONENT_ID="example" \
+    bash "$RUNNER" --filter OnlyTest --list-tests 2>&1)
+
+if [[ "$filter_output" != *"PASSTHROUGH: [/runner.php] [--filter] [OnlyTest] [--list-tests]"* ]]; then
+    echo "Expected PHPUnit passthrough args to reach Playground runner" >&2
+    echo "$filter_output" >&2
+    exit 1
+fi
+
+file_output=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
+    HOMEBOY_COMPONENT_ID="example" \
+    EXPECT_SELECTED_FILE=1 \
+    bash "$RUNNER" tests/OnlyTest.php 2>&1)
+
+if [[ "$file_output" != *"SELECTED_FILE_OK"* ]]; then
+    echo "Expected bare PHPUnit file arg to select that file in Playground wrapper" >&2
+    echo "$file_output" >&2
+    exit 1
+fi
+
+echo "Playground passthrough args smoke passed"

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -83,6 +83,15 @@ SELECTED_TEST_FILE="${HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE:-}"
 PASSTHROUGH_ARGS=()
 while [ "$#" -gt 0 ]; do
     case "$1" in
+        --filter)
+            PASSTHROUGH_ARGS+=("$1")
+            shift
+            if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
+                echo "ERROR: --filter requires a value" >&2
+                exit 2
+            fi
+            PASSTHROUGH_ARGS+=("$1")
+            ;;
         --file)
             shift
             if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
@@ -95,6 +104,20 @@ while [ "$#" -gt 0 ]; do
             SELECTED_TEST_FILE="${1#--file=}"
             ;;
         *)
+            if [ -z "$SELECTED_TEST_FILE" ]; then
+                if [ "${1#/}" != "$1" ]; then
+                    candidate_test_file="$1"
+                else
+                    candidate_test_file="${PLUGIN_PATH}/${1}"
+                fi
+
+                if [ -f "$candidate_test_file" ]; then
+                    SELECTED_TEST_FILE="$1"
+                    shift
+                    continue
+                fi
+            fi
+
             PASSTHROUGH_ARGS+=("$1")
             ;;
     esac
@@ -358,7 +381,7 @@ set +e
     "--mount" "${WRAPPER_TMPFILE}:/runner.php" \
     --wp=6.9 \
     --verbosity=normal \
-    -- /runner.php "$@" \
+    -- /runner.php "${PASSTHROUGH_ARGS[@]}" \
     2>&1 | homeboy_filter_playground_cleanup_noise | tee "$PHPUNIT_TMPFILE"
 playground_exit=${PIPESTATUS[0]}
 set -e

--- a/wordpress/tests/playground-test-discovery-smoke.sh
+++ b/wordpress/tests/playground-test-discovery-smoke.sh
@@ -30,7 +30,8 @@ assert_not_contains() {
     fi
 }
 
-assert_contains "$RUNNER_SH" '-- /runner.php "$@"' "Playground runner forwards PHPUnit passthrough args"
+assert_contains "$RUNNER_SH" 'PASSTHROUGH_ARGS=()' "Playground runner captures PHPUnit passthrough args"
+assert_contains "$RUNNER_SH" '-- /runner.php "${PASSTHROUGH_ARGS[@]}"' "Playground runner forwards parsed PHPUnit passthrough args"
 
 assert_contains "$RUNNER_PHP" 'function pg_is_component_phpunit_directory($raw_path)' "Component directory filter exists"
 assert_contains "$RUNNER_PHP" "return \$normalized === 'tests' || strpos(\$normalized, 'tests/') === 0;" "Only plugin tests/ entries are accepted"


### PR DESCRIPTION
## Summary
- Fixes the WordPress Playground test runner to pass parsed PHPUnit args into `/runner.php` instead of forwarding an already-shifted empty `$@`.
- Treats bare existing test-file arguments like `tests/Unit/FooTest.php` as the existing selected-file seam, matching normal PHPUnit file selection expectations.
- Adds a focused smoke test for `--filter` pass-through and bare test-file selection, and refreshes stale Playground discovery/changing-scope smoke assertions.

Fixes #432.

## Testing
- `bash -n wordpress/scripts/test/test-runner-playground.sh && bash -n wordpress/scripts/test/playground-passthrough-args-smoke.sh`
- `php -l wordpress/scripts/test/playground-runner.php`
- `bash wordpress/scripts/test/playground-passthrough-args-smoke.sh`
- `bash wordpress/tests/playground-test-discovery-smoke.sh`
- `bash wordpress/scripts/test/playground-changed-scope-smoke.sh && bash wordpress/scripts/test/playground-discovery-smoke.sh && bash wordpress/scripts/test/playground-no-test-files-smoke.sh && bash wordpress/scripts/test/playground-passthrough-args-smoke.sh && bash wordpress/tests/playground-test-discovery-smoke.sh`
- Direct regression check: `HOMEBOY_EXTENSION_PATH=/Users/chubes/.config/homeboy/extensions/wordpress HOMEBOY_COMPONENT_PATH=/Users/chubes/Developer/data-machine@feat-sync-flow-drain-ability HOMEBOY_COMPONENT_ID=data-machine bash wordpress/scripts/test/test-runner-playground.sh --filter DrainJobAbilityTest` ran exactly `1 test, 13 assertions`.
- Direct regression check: `HOMEBOY_EXTENSION_PATH=/Users/chubes/.config/homeboy/extensions/wordpress HOMEBOY_COMPONENT_PATH=/Users/chubes/Developer/data-machine@feat-sync-flow-drain-ability HOMEBOY_COMPONENT_ID=data-machine bash wordpress/scripts/test/test-runner-playground.sh tests/Unit/Abilities/Engine/DrainJobAbilityTest.php` ran exactly `1 test, 13 assertions`.

## Notes
- `homeboy test homeboy-extensions --changed-since origin/main` cannot run because `homeboy-extensions` has no extension provider configured for itself.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the Playground runner arg-forwarding fix, smoke coverage, and validation commands. Chris reviews, validates, and owns the final change.