### PR TITLE
fix(rust/audit): nest duplication detector config under detector_rules

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -86,9 +86,11 @@
         "template": "### `{name}`\n\n{description}\n\n{fields}"
       }
     },
-    "duplication_detector": {
-      "trivial_calls": ["var", "cfg", "not", "matches"],
-      "plumbing_calls": ["internal_io", "internal_unexpected", "internal_invariant"]
+    "detector_rules": {
+      "duplication_detector": {
+        "trivial_calls": ["var", "cfg", "not", "matches"],
+        "plumbing_calls": ["internal_io", "internal_unexpected", "internal_invariant"]
+      }
     }
   },
   "build": {


### PR DESCRIPTION
## Summary

Fixes the Rust extension manifest shape from #430 by moving the duplication detector call lists under `audit.detector_rules`.

## What changed

- Moves `audit.duplication_detector` to `audit.detector_rules.duplication_detector` in `rust/rust.json`.
- Keeps the Rust-specific call-name lists unchanged:
  - **trivial**: `var`, `cfg`, `not`, `matches`
  - **plumbing**: `internal_io`, `internal_unexpected`, `internal_invariant`

## Why

The extension manifest `audit` block deserializes as `AuditCapability`, not directly as `AuditConfig`. Detector-specific audit config is exposed through `AuditCapability::detector_rules`, then core merges it via `manifest.audit_detector_rules()`.

The payload merged in #430 placed `duplication_detector` directly under `audit`, where serde ignores it. This PR restores the intended path consumed by Extra-Chill/homeboy#2345.

## Validation

- `python3 -m json.tool rust/rust.json > /dev/null`
- Verified the core consumption path: `manifest.audit_detector_rules()` returns `&self.audit.detector_rules`.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** diagnosed the manifest schema mismatch after #430 merged, corrected the JSON nesting, and validated the fix. Chris reviewed/approved.