### PR TITLE
fix(wordpress): declare WP-CLI command output recognizers

### DIFF
--- a/wordpress/tests/audit-detector-config-smoke.sh
+++ b/wordpress/tests/audit-detector-config-smoke.sh
@@ -55,6 +55,35 @@ lifecycle_globs = set(rules.get("lifecycle_path_globs", []))
 for pattern in ["**/*-smoke.php", "**/*-fallback.php", "**/*-shim.php", "**/*-stub.php"]:
     require(pattern in lifecycle_globs, f"missing contextual dead-guard path glob: {pattern}")
 
+# WP-CLI command-output policy recognizers live in the WordPress extension, not
+# homeboy core. Core consumes these as opaque substring rules.
+framework_command_recognizers = rules.get("framework_command_recognizers", [])
+recognizers_by_id = {entry["id"]: entry for entry in framework_command_recognizers}
+for recognizer_id in [
+    "wp-cli-direct-registration",
+    "wp-cli-direct-subclass",
+    "wp-cli-indirect-subclass",
+]:
+    require(recognizer_id in recognizers_by_id,
+            f"missing WP-CLI command recognizer: {recognizer_id}")
+
+direct_registration = recognizers_by_id["wp-cli-direct-registration"]
+require("WP_CLI::add_command" in direct_registration.get("requires_all", []),
+        "direct registration recognizer must require WP_CLI::add_command")
+
+direct_subclass = recognizers_by_id["wp-cli-direct-subclass"]
+require("extends \\WP_CLI_Command" in direct_subclass.get("requires_any", []),
+        "direct subclass recognizer must accept fully-qualified WP_CLI_Command")
+
+indirect_subclass = recognizers_by_id["wp-cli-indirect-subclass"]
+any_groups = indirect_subclass.get("requires_any_groups", [])
+require(len(any_groups) == 2,
+        "indirect subclass recognizer must require both an import group and an output-method group")
+require(any("use WP_CLI;" in group for group in any_groups),
+        "indirect subclass recognizer must require a WP_CLI import marker")
+require(any("WP_CLI::success" in group and "WP_CLI::error" in group for group in any_groups),
+        "indirect subclass recognizer must require a WP_CLI output-method marker")
+
 # Forward-compat (core main): convention_tag_globs splits unrelated PHP roles.
 tag_globs = rules.get("convention_tag_globs", [])
 require(tag_globs, "convention_tag_globs must be configured to split PHP roles in mixed directories")

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -537,6 +537,35 @@
           "description": "Option scope drift at line {line}: docs mention network/site-option storage but implementation calls `{call}`",
           "suggestion": "Use the matching site-option call or update the storage contract so multisite behaviour is explicit."
         }
+      ],
+      "framework_command_recognizers": [
+        {
+          "id": "wp-cli-direct-registration",
+          "requires_all": ["WP_CLI::add_command"]
+        },
+        {
+          "id": "wp-cli-direct-subclass",
+          "requires_any": ["extends WP_CLI_Command", "extends \\WP_CLI_Command"]
+        },
+        {
+          "id": "wp-cli-indirect-subclass",
+          "requires_any_groups": [
+            [
+              "use WP_CLI;",
+              "use \\WP_CLI;",
+              "use WP_CLI ",
+              "use \\WP_CLI "
+            ],
+            [
+              "WP_CLI::success",
+              "WP_CLI::error",
+              "WP_CLI::log",
+              "WP_CLI::warning",
+              "WP_CLI::print_value",
+              "WP_CLI\\Utils\\format_items"
+            ]
+          ]
+        }
       ]
     },
     "ignore_claim_patterns": [


### PR DESCRIPTION
## Summary

Moves the WP-CLI-specific `command_output_policy` scope recognition out of homeboy core and into the WordPress extension manifest.

This is the companion PR for Extra-Chill/homeboy#2348.

## What changed

Adds `audit.detector_rules.framework_command_recognizers` entries to `wordpress/wordpress.json`:

- `wp-cli-direct-registration` — files containing `WP_CLI::add_command`.
- `wp-cli-direct-subclass` — files extending `WP_CLI_Command` directly.
- `wp-cli-indirect-subclass` — files with a `WP_CLI` import marker and a WP-CLI output-method marker (`success`, `error`, `log`, `warning`, `print_value`, or `WP_CLI\\Utils\\format_items`).

The indirect recognizer is the data-machine shape: command classes extend an in-tree `BaseCommand`, registration happens centrally, and the command files import `WP_CLI` while emitting through the framework contract.

## Validation

- `bash wordpress/tests/audit-detector-config-smoke.sh` passed.
- With Extra-Chill/homeboy#2348 built locally and this manifest copied into a temporary `HOME`, `/Users/chubes/Developer/data-machine` reports `command_output_policy` findings = **0**.
- The same homeboy build still reports `command_output_policy` findings = **5** on `/Users/chubes/Developer/homeboy`, preserving the legitimate #2249 findings.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added the WordPress extension recognizer config and smoke-test assertions, then validated it against the companion homeboy core branch. Chris directed that WP-CLI knowledge belongs in `homeboy-extensions`, not core.