### PR TITLE
fix(wordpress): dedupe playground dependency mounts

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -283,7 +283,7 @@ MOUNT_ARGS+=("--mount" "${PLUGIN_PATH}:/wordpress/wp-content/plugins/${PLUGIN_SL
 if [ -n "$DEPENDENCY_PATHS" ]; then
     while IFS= read -r dep_path; do
         [ -z "$dep_path" ] && continue
-        dep_slug="$(basename "$dep_path")"
+        dep_slug="$(homeboy_get_validation_dependency_slug "$dep_path" || basename "$dep_path")"
         MOUNT_ARGS+=("--mount" "${dep_path}:/wordpress/wp-content/plugins/${dep_slug}")
     done <<< "$DEPENDENCY_PATHS"
 fi
@@ -389,7 +389,7 @@ PLAYGROUND_DEP_MOUNTS=""
 if [ -n "$DEPENDENCY_PATHS" ]; then
     while IFS= read -r dep_path; do
         [ -z "$dep_path" ] && continue
-        dep_slug="$(basename "$dep_path")"
+        dep_slug="$(homeboy_get_validation_dependency_slug "$dep_path" || basename "$dep_path")"
         if [ -n "$PLAYGROUND_DEP_MOUNTS" ]; then
             PLAYGROUND_DEP_MOUNTS+="\\n"
         fi

--- a/wordpress/scripts/bench/playground-bench-dependency-worktree-dedupe-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-dependency-worktree-dedupe-smoke.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/bench-runner-playground.sh"
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+EXTENSION_PATH="${TMPROOT}/extension"
+HOST_FIXTURE_DIR="${TMPROOT}/host-plugin"
+CANONICAL_DEP_DIR="${TMPROOT}/data-machine"
+WORKTREE_DEP_DIR="${TMPROOT}/data-machine@fix-run-flow-paused-manual"
+RUNTIME_DIR="${TMPROOT}/runtime"
+BIN_DIR="${TMPROOT}/bin"
+RESULTS_TMPFILE="${TMPROOT}/bench-results.json"
+
+mkdir -p \
+    "${EXTENSION_PATH}/node_modules/.bin" \
+    "${HOST_FIXTURE_DIR}/tests/bench" \
+    "$CANONICAL_DEP_DIR" \
+    "$WORKTREE_DEP_DIR" \
+    "$RUNTIME_DIR" \
+    "$BIN_DIR"
+
+cat > "${HOST_FIXTURE_DIR}/host-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Host Plugin
+ * Requires Plugins: data-machine
+ */
+PHP
+
+cat > "${HOST_FIXTURE_DIR}/tests/bench/noop.php" <<'PHP'
+<?php
+function bench_main() {
+    return true;
+}
+PHP
+
+cat > "${CANONICAL_DEP_DIR}/data-machine.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Data Machine
+ */
+PHP
+
+cp "${CANONICAL_DEP_DIR}/data-machine.php" "${WORKTREE_DEP_DIR}/data-machine.php"
+
+cat > "${RUNTIME_DIR}/bench-helper.sh" <<'SH'
+#!/usr/bin/env bash
+homeboy_write_empty_bench_results() {
+    printf '{"component":"%s","iterations":%s,"scenarios":[]}\n' "$1" "$2" > "$3"
+}
+SH
+
+cat > "${RUNTIME_DIR}/bench-helper.php" <<'PHP'
+<?php
+PHP
+
+cat > "${BIN_DIR}/homeboy" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "component" ] && [ "\${2:-}" = "show" ] && [ "\${3:-}" = "data-machine" ]; then
+    printf '{"data":{"entity":{"local_path":"%s"}}}\n' "$CANONICAL_DEP_DIR"
+    exit 0
+fi
+exit 1
+SH
+chmod +x "${BIN_DIR}/homeboy"
+
+cat > "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+wrapper=""
+canonical_mounts=0
+suffix_mounts=0
+worktree_canonical_mounts=0
+
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--mount" ]; then
+        mount_arg="$2"
+        case "$mount_arg" in
+            *:/runner.php)
+                wrapper="${mount_arg%:/runner.php}"
+                ;;
+            *:/wordpress/wp-content/plugins/data-machine)
+                canonical_mounts=$((canonical_mounts + 1))
+                case "$mount_arg" in
+                    *data-machine@fix-run-flow-paused-manual:/wordpress/wp-content/plugins/data-machine)
+                        worktree_canonical_mounts=$((worktree_canonical_mounts + 1))
+                        ;;
+                esac
+                ;;
+            *:/wordpress/wp-content/plugins/data-machine@fix-run-flow-paused-manual)
+                suffix_mounts=$((suffix_mounts + 1))
+                ;;
+        esac
+        shift 2
+        continue
+    fi
+    shift
+done
+
+if [ -z "$wrapper" ] || [ ! -f "$wrapper" ]; then
+    echo "runner wrapper mount not found" >&2
+    exit 1
+fi
+
+if [ "$canonical_mounts" -ne 1 ]; then
+    echo "expected exactly one canonical data-machine dependency mount, got $canonical_mounts" >&2
+    exit 1
+fi
+
+if [ "$worktree_canonical_mounts" -ne 1 ]; then
+    echo "expected the worktree dependency to mount at canonical slug data-machine" >&2
+    exit 1
+fi
+
+if [ "$suffix_mounts" -ne 0 ]; then
+    echo "worktree-suffixed dependency was mounted as a second plugin copy" >&2
+    exit 1
+fi
+
+if grep -Fq '/wordpress/wp-content/plugins/data-machine@fix-run-flow-paused-manual' "$wrapper"; then
+    echo "runner wrapper would load the worktree-suffixed dependency slug" >&2
+    exit 1
+fi
+
+if ! grep -Fq '/wordpress/wp-content/plugins/data-machine' "$wrapper"; then
+    echo "runner wrapper missing canonical dependency load path" >&2
+    exit 1
+fi
+
+cat > "${HOMEBOY_PLUGIN_PATH}/.pg-bench-results.json" <<'JSON'
+{"component":"host-plugin","iterations":1,"scenarios":[]}
+JSON
+SH
+chmod +x "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli"
+
+SETTINGS_JSON=$(jq -n --arg dep "$WORKTREE_DEP_DIR" '{"validation_dependencies": [$dep]}')
+
+PATH="${BIN_DIR}:${PATH}" \
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_COMPONENT_ID=host-plugin \
+HOMEBOY_COMPONENT_PATH="$HOST_FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_RUNTIME_BENCH_HELPER_SH="${RUNTIME_DIR}/bench-helper.sh" \
+HOMEBOY_RUNTIME_BENCH_HELPER_PHP="${RUNTIME_DIR}/bench-helper.php" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    bash "$RUNNER"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "expected bench results file to be written" >&2
+    exit 1
+fi
+
+echo "Playground bench dependency worktree dedupe smoke passed"

--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -81,6 +81,38 @@ homeboy_get_requires_plugins_from_header() {
     done
 }
 
+# Resolve the wp-content/plugins/<slug> path segment for a plugin checkout.
+# Normal checkouts keep using their directory basename. Worktree-style
+# directories may carry a branch suffix (for example data-machine@fix/foo), so
+# use the root plugin entry file when it matches the pre-suffix basename.
+homeboy_get_validation_dependency_slug() {
+    local plugin_path="${1:-}"
+
+    [ -z "$plugin_path" ] || [ ! -d "$plugin_path" ] && return 1
+
+    local dir_slug
+    dir_slug="$(basename "$plugin_path")"
+
+    local canonical_dir_slug="${dir_slug%%@*}"
+    if [ "$canonical_dir_slug" = "$dir_slug" ]; then
+        printf '%s\n' "$dir_slug"
+        return 0
+    fi
+
+    local main_file
+    main_file=$(find "$plugin_path" -maxdepth 1 -name "*.php" -exec grep -l "Plugin Name:" {} \; 2>/dev/null | head -1)
+    if [ -n "$main_file" ]; then
+        local main_slug
+        main_slug="$(basename "$main_file" .php)"
+        if [ "$main_slug" = "$canonical_dir_slug" ]; then
+            printf '%s\n' "$main_slug"
+            return 0
+        fi
+    fi
+
+    printf '%s\n' "$dir_slug"
+}
+
 # Infer GitHub org from a git repo's remote.
 # Parses "origin" remote URL to extract the org/owner.
 # Arg: optional directory to read from (defaults to cwd).
@@ -215,25 +247,27 @@ homeboy_resolve_validation_dependency_paths() {
     # Collect all dependency identifiers from both sources
     local all_deps=""
 
-    # Source 1: Requires Plugins header (auto-discovered)
-    local header_deps
-    header_deps=$(homeboy_get_requires_plugins_from_header "$plugin_path" || true)
-    if [ -n "$header_deps" ]; then
-        all_deps="$header_deps"
-    fi
-
-    # Source 2: Settings JSON (manual overrides)
+    # Source 1: Settings JSON (manual overrides). Explicit configured paths
+    # take priority over auto-discovered header slugs so alternate checkouts can
+    # replace the canonical local component path.
     local settings_raw
     settings_raw=$(homeboy_get_validation_dependencies_raw)
     if [ -n "$settings_raw" ]; then
         local settings_deps
         settings_deps=$(homeboy_normalize_validation_dependencies "$settings_raw")
         if [ -n "$settings_deps" ]; then
-            if [ -n "$all_deps" ]; then
-                all_deps="${all_deps}"$'\n'"${settings_deps}"
-            else
-                all_deps="$settings_deps"
-            fi
+            all_deps="$settings_deps"
+        fi
+    fi
+
+    # Source 2: Requires Plugins header (auto-discovered)
+    local header_deps
+    header_deps=$(homeboy_get_requires_plugins_from_header "$plugin_path" || true)
+    if [ -n "$header_deps" ]; then
+        if [ -n "$all_deps" ]; then
+            all_deps="${all_deps}"$'\n'"${header_deps}"
+        else
+            all_deps="$header_deps"
         fi
     fi
 
@@ -245,6 +279,7 @@ homeboy_resolve_validation_dependency_paths() {
     # dependency's implementation classes.
     local -A seen_paths=()
     local -A seen_dependencies=()
+    local -A seen_slugs=()
     local -a dependency_queue=()
     local dependency_index=0
 
@@ -274,6 +309,18 @@ homeboy_resolve_validation_dependency_paths() {
         if [ -n "$plugin_path" ] && [ "$resolved" = "$plugin_path" ]; then
             continue
         fi
+
+        local resolved_slug
+        resolved_slug=$(homeboy_get_validation_dependency_slug "$resolved" || basename "$resolved")
+
+        # Deduplicate equivalent dependency checkouts by the WordPress plugin
+        # slug Playground will mount/load, not just by host path. This prevents
+        # a worktree path like data-machine@fix/foo and a canonical data-machine
+        # checkout from loading as two copies of the same plugin.
+        if [ -n "${seen_slugs[$resolved_slug]+x}" ]; then
+            continue
+        fi
+        seen_slugs["$resolved_slug"]=1
 
         # Deduplicate by resolved path
         if [ -n "${seen_paths[$resolved]+x}" ]; then

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -285,7 +285,7 @@ MOUNT_ARGS+=("--mount" "${PLUGIN_PATH}:/wordpress/wp-content/plugins/${PLUGIN_SL
 if [ -n "$DEPENDENCY_PATHS" ]; then
     while IFS= read -r dep_path; do
         [ -z "$dep_path" ] && continue
-        dep_slug="$(basename "$dep_path")"
+        dep_slug="$(homeboy_get_validation_dependency_slug "$dep_path" || basename "$dep_path")"
         MOUNT_ARGS+=("--mount" "${dep_path}:/wordpress/wp-content/plugins/${dep_slug}")
     done <<< "$DEPENDENCY_PATHS"
 fi
@@ -328,7 +328,7 @@ PLAYGROUND_DEP_MOUNTS=""
 if [ -n "$DEPENDENCY_PATHS" ]; then
     while IFS= read -r dep_path; do
         [ -z "$dep_path" ] && continue
-        dep_slug="$(basename "$dep_path")"
+        dep_slug="$(homeboy_get_validation_dependency_slug "$dep_path" || basename "$dep_path")"
         if [ -n "$PLAYGROUND_DEP_MOUNTS" ]; then
             PLAYGROUND_DEP_MOUNTS+="\\n"
         fi


### PR DESCRIPTION
## Summary
- Resolve worktree-style dependency directories to their canonical WordPress plugin slug before Playground mount/load args are built.
- Prefer explicitly configured validation dependency paths before header-discovered slugs so alternate checkouts can replace canonical registry paths.
- Add a regression smoke covering a `data-machine@...` dependency that must mount/load only as `data-machine`.

Fixes #438.

## Tests
- `bash -n wordpress/scripts/lib/validation-dependencies.sh wordpress/scripts/bench/bench-runner-playground.sh wordpress/scripts/test/test-runner-playground.sh wordpress/scripts/bench/playground-bench-dependency-worktree-dedupe-smoke.sh`
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `bash wordpress/scripts/bench/playground-bench-dependency-worktree-dedupe-smoke.sh`
- `bash wordpress/scripts/test/playground-passthrough-args-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and regression smoke; Chris requested and owns review/testing.