### PR TITLE
fix(wordpress): configure playground core version

### DIFF
--- a/wordpress/docs/PLAYGROUND_DROPIN.md
+++ b/wordpress/docs/PLAYGROUND_DROPIN.md
@@ -152,7 +152,9 @@ during build).
   means it must delegate to Playground's bundled SQLite for the initial
   schema.
 
-- **WP version pinning.** The `--wp=6.9` flag in the Playground runner must
+- **WP version pinning.** The Playground runner defaults to `--wp=6.9`, and the
+  `playground_wordpress_version` setting can pass a different `--wp=<version>`.
+  The selected WordPress version must
   match the `wp-phpunit` package version. Don't forget to update both when
   bumping WordPress. A mismatch often manifests as missing `WP_UnitTestCase`
   factory methods, not as a database error — the drop-in will load fine but

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -382,7 +382,8 @@ or publish it with benchmark results without redacting the fields listed in
 
 ## Known gaps
 
-- **WP version is pinned.** Currently `--wp=6.9`. Mismatched pins produce
+- **WP version defaults to 6.9.** Override `playground_wordpress_version` to pass
+  a different `--wp=<version>` to Playground. Mismatched versions produce
   missing-class errors.
 - **Partial phpunit.xml consumption.** The runner reads `<testsuite>` and
   `<exclude>` entries from `phpunit.xml.dist` only; other elements are

--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -271,6 +271,14 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     fi
 fi
 
+PLAYGROUND_WORDPRESS_VERSION="6.9"
+if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.playground_wordpress_version // empty' 2>/dev/null || true)
+    if [ -n "$extracted" ] && [ "$extracted" != "null" ]; then
+        PLAYGROUND_WORDPRESS_VERSION="$extracted"
+    fi
+fi
+
 ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-10}"
 
 # ---------------------------------------------------------------------------
@@ -484,6 +492,7 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "  Wrapper: $WRAPPER_TMPFILE"
     echo "  Mount-before-install args: ${MOUNT_BEFORE_INSTALL_ARGS[*]}"
     echo "  Mount args: ${MOUNT_ARGS[*]}"
+    echo "  WordPress version: ${PLAYGROUND_WORDPRESS_VERSION}"
     echo "  WordPress install mode: ${PLAYGROUND_WORDPRESS_INSTALL_MODE}"
 fi
 
@@ -496,7 +505,7 @@ set +e
     "--mount" "${WRAPPER_TMPFILE}:/runner.php" \
     "${BLUEPRINT_ARGS[@]}" \
     "--wordpress-install-mode=${PLAYGROUND_WORDPRESS_INSTALL_MODE}" \
-    --wp=6.9 \
+    "--wp=${PLAYGROUND_WORDPRESS_VERSION}" \
     --verbosity=normal \
     -- /runner.php \
     2>&1 | tee "$BENCH_TMPFILE"

--- a/wordpress/scripts/test/playground-wordpress-version-smoke.sh
+++ b/wordpress/scripts/test/playground-wordpress-version-smoke.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_RUNNER="${SCRIPT_DIR}/test-runner-playground.sh"
+BENCH_RUNNER="${SCRIPT_DIR}/../bench/bench-runner-playground.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+EXTENSION_PATH="${TMP_ROOT}/extension"
+PLUGIN_PATH="${TMP_ROOT}/component"
+BENCH_HELPER_SH="${TMP_ROOT}/bench-helper.sh"
+BENCH_HELPER_PHP="${TMP_ROOT}/bench-helper.php"
+
+mkdir -p "${EXTENSION_PATH}/node_modules/.bin" "${PLUGIN_PATH}/tests/bench" "${PLUGIN_PATH}/tests"
+
+cat > "${PLUGIN_PATH}/tests/OnlyTest.php" <<'PHP'
+<?php
+class OnlyTest extends WP_UnitTestCase {}
+PHP
+
+cat > "${PLUGIN_PATH}/tests/bench/noop.php" <<'PHP'
+<?php
+function bench_main(): void {}
+PHP
+
+cat > "$BENCH_HELPER_SH" <<'SH'
+#!/usr/bin/env bash
+homeboy_write_empty_bench_results() {
+    printf '{"component_id":"%s","iterations":%s,"scenarios":[]}' "$1" "$2" > "$3"
+}
+SH
+chmod +x "$BENCH_HELPER_SH"
+
+cat > "$BENCH_HELPER_PHP" <<'PHP'
+<?php
+PHP
+
+cat > "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+actual=""
+for arg in "$@"; do
+    case "$arg" in
+        --wp=*)
+            actual="${arg#--wp=}"
+            ;;
+    esac
+done
+
+if [ -z "$actual" ]; then
+    echo "missing --wp argument" >&2
+    exit 1
+fi
+
+if [ "$actual" != "${EXPECT_PLAYGROUND_WP}" ]; then
+    echo "expected --wp=${EXPECT_PLAYGROUND_WP}, got --wp=${actual}" >&2
+    exit 1
+fi
+
+echo "WP_VERSION_OK:${actual}"
+
+if [ -n "${HOMEBOY_PLUGIN_PATH:-}" ]; then
+    cat > "${HOMEBOY_PLUGIN_PATH}/.pg-test-result.txt" <<'LOG'
+STAGE_BEGIN:run_tests
+ALL TESTS PASSED
+TESTS: 1 FAILURES: 0 ERRORS: 0
+STAGE_OK:run_tests
+LOG
+    cat > "${HOMEBOY_PLUGIN_PATH}/.pg-bench-result.txt" <<'LOG'
+STAGE_BEGIN:run_bench
+STAGE_OK:run_bench
+LOG
+    cat > "${HOMEBOY_PLUGIN_PATH}/.pg-bench-results.json" <<'JSON'
+{"component_id":"example","iterations":1,"scenarios":[]}
+JSON
+fi
+SH
+chmod +x "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli"
+
+SETTINGS_JSON='{"playground_wordpress_version":"6.10"}'
+
+bash -n "$TEST_RUNNER"
+bash -n "$BENCH_RUNNER"
+
+test_output=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
+    HOMEBOY_COMPONENT_ID="example" \
+    HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    EXPECT_PLAYGROUND_WP="6.10" \
+    bash "$TEST_RUNNER" 2>&1)
+
+if [[ "$test_output" != *"WP_VERSION_OK:6.10"* ]]; then
+    echo "Expected configured WordPress version to reach Playground test runner" >&2
+    echo "$test_output" >&2
+    exit 1
+fi
+
+bench_results="${TMP_ROOT}/bench-results.json"
+bench_output=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
+    HOMEBOY_COMPONENT_ID="example" \
+    HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    HOMEBOY_BENCH_ITERATIONS=1 \
+    HOMEBOY_BENCH_RESULTS_FILE="$bench_results" \
+    HOMEBOY_RUNTIME_BENCH_HELPER_SH="$BENCH_HELPER_SH" \
+    HOMEBOY_RUNTIME_BENCH_HELPER_PHP="$BENCH_HELPER_PHP" \
+    EXPECT_PLAYGROUND_WP="6.10" \
+    bash "$BENCH_RUNNER" 2>&1)
+
+if [[ "$bench_output" != *"WP_VERSION_OK:6.10"* ]]; then
+    echo "Expected configured WordPress version to reach Playground bench runner" >&2
+    echo "$bench_output" >&2
+    exit 1
+fi
+
+default_output=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
+    HOMEBOY_COMPONENT_ID="example" \
+    EXPECT_PLAYGROUND_WP="6.9" \
+    bash "$TEST_RUNNER" 2>&1)
+
+if [[ "$default_output" != *"WP_VERSION_OK:6.9"* ]]; then
+    echo "Expected omitted WordPress version setting to preserve --wp=6.9" >&2
+    echo "$default_output" >&2
+    exit 1
+fi
+
+echo "Playground WordPress version smoke passed"

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -31,7 +31,8 @@ set -euo pipefail
 # 3. Runs the filled template via `wp-playground-cli php`
 #
 # KNOWN GAPS (Phase 1):
-#   - WP version is pinned to match wp-phpunit package (6.9.x).
+#   - WP version defaults to match the wp-phpunit package (6.9.x), and can be
+#     overridden with the playground_wordpress_version setting.
 #   - db.php drop-in support needs per-case testing (Playground's built-in
 #     SQLite integration may conflict with custom drop-ins like MDI).
 #
@@ -233,6 +234,14 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     fi
 fi
 
+PLAYGROUND_WORDPRESS_VERSION="6.9"
+if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.playground_wordpress_version // empty' 2>/dev/null || true)
+    if [ -n "$extracted" ] && [ "$extracted" != "null" ]; then
+        PLAYGROUND_WORDPRESS_VERSION="$extracted"
+    fi
+fi
+
 # Homeboy core sends changed test paths as newline-delimited component-relative
 # paths. Playground PHP cannot reliably read host env directly, so substitute a
 # JSON array into the runner template and let it filter VFS-discovered tests.
@@ -366,6 +375,7 @@ echo "  Backend: playground (PHP-WASM + SQLite)"
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "  Wrapper: $WRAPPER_TMPFILE"
     echo "  Mount args: ${MOUNT_ARGS[*]}"
+    echo "  WordPress version: ${PLAYGROUND_WORDPRESS_VERSION}"
 fi
 
 PHPUNIT_TMPFILE=$(mktemp)
@@ -379,7 +389,7 @@ set +e
 "$PLAYGROUND_CLI" php \
     "${MOUNT_ARGS[@]}" \
     "--mount" "${WRAPPER_TMPFILE}:/runner.php" \
-    --wp=6.9 \
+    "--wp=${PLAYGROUND_WORDPRESS_VERSION}" \
     --verbosity=normal \
     -- /runner.php "${PASSTHROUGH_ARGS[@]}" \
     2>&1 | homeboy_filter_playground_cleanup_noise | tee "$PHPUNIT_TMPFILE"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -837,6 +837,13 @@
       "description": "Optional browser bench target descriptor. Set {\"enabled\": true} to write HOMEBOY_BENCH_SHARED_STATE/browser-target.json. Include baseUrl/adminUrl for an already-running site; otherwise the file is metadata-only because the Playground PHP bench runner exits after workloads complete. Login supports method plus username/password or password_env; raw target files are handoff artifacts and must not be published in reports."
     },
     {
+      "id": "playground_wordpress_version",
+      "label": "Playground WordPress version",
+      "type": "string",
+      "default": "",
+      "description": "Optional WordPress core version passed to wp-playground-cli as --wp=<version> for Playground test and bench runners. Leave empty for the runner default, currently 6.9. Use this when a component needs classes or behavior from a newer WordPress core build."
+    },
+    {
       "id": "playground_wordpress_install_mode",
       "label": "Playground WordPress install mode",
       "type": "string",


### PR DESCRIPTION
## Summary
- Add `playground_wordpress_version` so WordPress Playground test and bench runners can pass a configured `--wp=<version>`.
- Preserve the current `--wp=6.9` default when the setting is omitted.
- Add a focused smoke covering configured test/bench runner invocations and the default fallback.

Fixes #440.

## Testing
- `bash wordpress/scripts/test/playground-wordpress-version-smoke.sh`
- `jq empty wordpress/wordpress.json`
- `bash -n wordpress/scripts/bench/bench-runner-playground.sh`
- `bash -n wordpress/scripts/test/test-runner-playground.sh`
- `bash -n wordpress/scripts/test/playground-wordpress-version-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner/schema/smoke updates and ran focused validation; Chris remains responsible for review and merge.