### PR TITLE
fix(wordpress): replay deferred init callbacks in hook context

### DIFF
--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -225,7 +225,7 @@ if ($installed_site_mode) {
     // end DB work runs before activation creates plugin tables). Activation is
     // the canonical seam for install-time side effects.
     pg_remove_new_wordpress_hook_callbacks('shutdown', $pre_component_shutdown_callbacks);
-    pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks);
+    pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks, [], 'init');
 
     // Fire activation hooks now that wp-phpunit has created the wptests_*
     // tables. Activation order: deps first, then the component-under-test

--- a/wordpress/scripts/lib/playground-bootstrap.php
+++ b/wordpress/scripts/lib/playground-bootstrap.php
@@ -291,16 +291,38 @@ function pg_defer_new_wordpress_hook_callbacks(string $hook_name, array $before)
 
 /**
  * Run callbacks extracted by pg_defer_new_wordpress_hook_callbacks().
+ *
+ * When a hook name is supplied, the callbacks run with that hook on
+ * $wp_current_filter. This preserves WordPress lifecycle context for APIs that
+ * validate doing_action() while still letting the runner defer DB-touching work
+ * until after wp-phpunit has created tables.
  */
-function pg_run_deferred_wordpress_hook_callbacks(array $deferred, array $args = []): void {
-    foreach ($deferred as $entry) {
-        $callback = $entry['callback'] ?? null;
-        if (!is_array($callback) || !isset($callback['function'])) {
-            continue;
-        }
+function pg_run_deferred_wordpress_hook_callbacks(array $deferred, array $args = [], ?string $hook_name = null): void {
+    global $wp_current_filter;
 
-        $accepted_args = isset($callback['accepted_args']) ? (int) $callback['accepted_args'] : count($args);
-        call_user_func_array($callback['function'], array_slice($args, 0, $accepted_args));
+    $pushed_hook = false;
+    if (is_string($hook_name) && $hook_name !== '') {
+        if (!is_array($wp_current_filter)) {
+            $wp_current_filter = [];
+        }
+        $wp_current_filter[] = $hook_name;
+        $pushed_hook = true;
+    }
+
+    try {
+        foreach ($deferred as $entry) {
+            $callback = $entry['callback'] ?? null;
+            if (!is_array($callback) || !isset($callback['function'])) {
+                continue;
+            }
+
+            $accepted_args = isset($callback['accepted_args']) ? (int) $callback['accepted_args'] : count($args);
+            call_user_func_array($callback['function'], array_slice($args, 0, $accepted_args));
+        }
+    } finally {
+        if ($pushed_hook) {
+            array_pop($wp_current_filter);
+        }
     }
 }
 

--- a/wordpress/scripts/test/playground-init-lifecycle-smoke.sh
+++ b/wordpress/scripts/test/playground-init-lifecycle-smoke.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TEST_RUNNER="${SCRIPT_DIR}/test-runner-playground.sh"
+BENCH_RUNNER="${SCRIPT_DIR}/../bench/bench-runner-playground.sh"
+HOST_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/playground-init-lifecycle-host"
+RESULTS_TMPFILE="$(mktemp "${TMPDIR:-/tmp}/playground-init-lifecycle.XXXXXX.json")"
+
+cleanup() {
+    rm -f "$RESULTS_TMPFILE"
+}
+trap cleanup EXIT
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    exit 1
+fi
+
+SETTINGS_JSON='{"playground_wordpress_version":"7.0"}'
+
+assert_no_connector_notice() {
+    local output="$1"
+    local label="$2"
+
+    if grep -Fq 'WP_Connector_Registry::set_instance' <<< "$output"; then
+        echo "ERROR: ${label} emitted the WP 7.0 connector registry timing notice" >&2
+        echo "$output" >&2
+        exit 1
+    fi
+
+    if grep -Fqi 'connector registry instance must be set during' <<< "$output"; then
+        echo "ERROR: ${label} emitted the WP 7.0 connector registry timing notice" >&2
+        echo "$output" >&2
+        exit 1
+    fi
+}
+
+echo "============================================"
+echo "Playground init lifecycle smoke (#443)"
+echo "============================================"
+echo "Host fixture: $HOST_FIXTURE_DIR"
+echo "WordPress:    7.0"
+echo ""
+
+set +e
+test_output=$(HOMEBOY_COMPONENT_ID=playground-init-lifecycle-host \
+    HOMEBOY_COMPONENT_PATH="$HOST_FIXTURE_DIR" \
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    bash "$TEST_RUNNER" 2>&1)
+test_exit=$?
+set -e
+
+if [ $test_exit -ne 0 ]; then
+    echo "ERROR: Playground test runner failed" >&2
+    echo "$test_output" >&2
+    exit $test_exit
+fi
+assert_no_connector_notice "$test_output" "test runner"
+echo "✓ test runner replayed deferred init callbacks in init context"
+
+set +e
+bench_output=$(HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+    HOMEBOY_BENCH_ITERATIONS=1 \
+    HOMEBOY_COMPONENT_ID=playground-init-lifecycle-host \
+    HOMEBOY_COMPONENT_PATH="$HOST_FIXTURE_DIR" \
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    bash "$BENCH_RUNNER" 2>&1)
+bench_exit=$?
+set -e
+
+if [ $bench_exit -ne 0 ]; then
+    echo "ERROR: Playground bench runner failed" >&2
+    echo "$bench_output" >&2
+    exit $bench_exit
+fi
+assert_no_connector_notice "$bench_output" "bench runner"
+
+metric=$(jq -r '.scenarios[] | select(.id == "assert-init-lifecycle") | .metrics.deferred_init_context_ok_mean // "missing"' "$RESULTS_TMPFILE")
+if [ "$metric" != "1" ]; then
+    echo "ERROR: bench workload did not verify deferred init lifecycle context (got $metric)" >&2
+    cat "$RESULTS_TMPFILE" >&2
+    exit 1
+fi
+echo "✓ bench runner replayed deferred init callbacks in init context"
+
+echo ""
+echo "============================================"
+echo "✓ Playground init lifecycle smoke PASSED"
+echo "============================================"

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -146,7 +146,7 @@ pg_run_install_stage(['config_path' => $config_path, 'tests_dir' => $tests_dir])
 // only callbacks the component added during that install bootstrap; activation
 // below remains the post-table seam for install-time side effects.
 pg_remove_new_wordpress_hook_callbacks('shutdown', $pre_component_shutdown_callbacks);
-pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks);
+pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks, [], 'init');
 
 // Fire activation hooks now that wp-phpunit has created database tables.
 // Pre-#431 activation fired inline during muplugins_loaded — before the test

--- a/wordpress/tests/fixtures/playground-init-lifecycle-host/playground-init-lifecycle-host.php
+++ b/wordpress/tests/fixtures/playground-init-lifecycle-host/playground-init-lifecycle-host.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Plugin Name: Playground Init Lifecycle Host
+ * Description: Fixture proving deferred init callbacks still run as init callbacks.
+ */
+
+add_action( 'init', 'homeboy_playground_init_lifecycle_callback', 20 );
+
+function homeboy_playground_init_lifecycle_callback() {
+    update_option(
+        'homeboy_playground_init_lifecycle_context',
+        doing_action( 'init' ) ? 'init' : 'not-init'
+    );
+
+    if ( class_exists( 'WP_Connector_Registry' ) ) {
+        WP_Connector_Registry::set_instance( new WP_Connector_Registry() );
+    }
+}

--- a/wordpress/tests/fixtures/playground-init-lifecycle-host/tests/InitLifecycleTest.php
+++ b/wordpress/tests/fixtures/playground-init-lifecycle-host/tests/InitLifecycleTest.php
@@ -1,0 +1,11 @@
+<?php
+
+class InitLifecycleTest extends WP_UnitTestCase {
+    public function test_deferred_init_callback_runs_in_init_context() {
+        $this->assertSame(
+            'init',
+            get_option( 'homeboy_playground_init_lifecycle_context' ),
+            'Deferred init callbacks must run with doing_action("init") true.'
+        );
+    }
+}

--- a/wordpress/tests/fixtures/playground-init-lifecycle-host/tests/bench/assert-init-lifecycle.php
+++ b/wordpress/tests/fixtures/playground-init-lifecycle-host/tests/bench/assert-init-lifecycle.php
@@ -1,0 +1,17 @@
+<?php
+
+return function (): array {
+    $context = get_option( 'homeboy_playground_init_lifecycle_context' );
+    if ( $context !== 'init' ) {
+        throw new RuntimeException( 'Deferred init callback ran outside init context.' );
+    }
+
+    return [
+        'metrics' => [
+            'deferred_init_context_ok' => 1,
+        ],
+        'metadata' => [
+            'fixture' => 'playground-init-lifecycle-host',
+        ],
+    ];
+};


### PR DESCRIPTION
## Summary
- Replay deferred Playground `init` callbacks with `init` on the current WordPress filter stack so WP 7.0 lifecycle validators see normal hook context.
- Keep plugin activation delayed until after wp-phpunit tables exist, preserving the DB-touching activation guarantees from #431.
- Add a WP 7.0 Playground smoke that covers both test and bench runners and fails if the connector registry timing notice appears.

Fixes #443.

## Tests
- `bash -n wordpress/scripts/test/playground-init-lifecycle-smoke.sh wordpress/scripts/test/test-runner-playground.sh wordpress/scripts/bench/bench-runner-playground.sh`
- `php -l wordpress/scripts/lib/playground-bootstrap.php wordpress/scripts/test/playground-runner.php wordpress/scripts/bench/playground-bench-runner.php wordpress/tests/fixtures/playground-init-lifecycle-host/playground-init-lifecycle-host.php wordpress/tests/fixtures/playground-init-lifecycle-host/tests/InitLifecycleTest.php wordpress/tests/fixtures/playground-init-lifecycle-host/tests/bench/assert-init-lifecycle.php`
- `git diff --check`
- `bash wordpress/scripts/test/playground-init-lifecycle-smoke.sh`
- `bash wordpress/scripts/test/playground-wordpress-version-smoke.sh`
- `bash wordpress/scripts/bench/playground-bench-dependency-worktree-dedupe-smoke.sh`
- `bash wordpress/scripts/test/playground-db-activation-smoke.sh`
- `bash wordpress/scripts/bench/playground-bench-db-activation-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the lifecycle fix, regression smoke fixture, and local verification commands for Chris to review.