### PR TITLE
feat(wordpress): add WordPress request profiler helper

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -187,3 +187,56 @@ fields where each tool reports them:
 - `fingerprint` — stable SHA-1 hash of the finding `id`.
 - `excerpt` — source line text when the file is readable locally; otherwise
   `null`.
+
+## Request Profiler Helper
+
+The WordPress extension exports a Node helper for bench and trace workloads that
+need server-side WordPress request timing. It installs a temporary MU-plugin into
+a target WordPress site, preserves JSONL profile entries on disk, parses those
+entries after the workload runs, and removes the profiler when requested.
+
+```js
+const {
+  installWordPressRequestProfiler,
+  collectWordPressRequestProfiles,
+  uninstallWordPressRequestProfiler,
+} = require('homeboy-extension-wordpress/request-profiler');
+
+const sitePath = '/path/to/wordpress';
+
+installWordPressRequestProfiler(sitePath);
+
+// Run one or more browser, curl, WP-CLI, bench, or trace requests here.
+
+const entries = collectWordPressRequestProfiles(sitePath);
+uninstallWordPressRequestProfiler(sitePath);
+
+console.log(entries.filter((entry) => entry.event === 'http.request.start'));
+```
+
+By default the helper writes `wp-content/homeboy-profile.jsonl` and installs
+`wp-content/mu-plugins/homeboy-request-profiler.php`. The JSONL file is left in
+place during cleanup so benchmark and trace runners can preserve it as an
+artifact. Pass `{ removeArtifact: true }` to `uninstallWordPressRequestProfiler`
+when the raw profile should also be deleted.
+
+Captured entries include:
+
+- request start timing and request metadata
+- WordPress lifecycle hook marks such as `muplugins_loaded`, `plugins_loaded`,
+  `init`, `admin_init`, `current_screen`, `admin_enqueue_scripts`, and `shutdown`
+- priority-band start/end marks around `admin_init`, `current_screen`, and
+  `admin_enqueue_scripts`
+- outbound HTTP request starts from `pre_http_request`, including hashed IDs,
+  URLs, and methods
+
+The default hooks can be overridden when a workload needs a smaller or more
+specific profile:
+
+```js
+installWordPressRequestProfiler(sitePath, {
+  artifactRelativePath: 'wp-content/uploads/homeboy/admin-profile.jsonl',
+  hooks: ['init', 'admin_init', 'shutdown'],
+  priorityBandHooks: ['admin_init'],
+});
+```

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,7 +10,8 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh"
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh",
+      "node --check index.js lib/request-profiler.js tests/request-profiler-smoke.js"
     ],
     "test": [
       "bash scripts/test/host-smoke-runner-smoke.sh",
@@ -24,7 +25,8 @@
       "bash scripts/lint/vendor-prefixed-exclusion-smoke.sh",
       "bash scripts/lint/eslint-no-files-smoke.sh",
       "bash tests/audit-detector-config-smoke.sh",
-      "bash tests/audit-dead-guard-fallback-smoke.sh"
+      "bash tests/audit-dead-guard-fallback-smoke.sh",
+      "node tests/request-profiler-smoke.js"
     ]
   }
 }

--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./lib/request-profiler');

--- a/wordpress/lib/request-profiler.js
+++ b/wordpress/lib/request-profiler.js
@@ -1,0 +1,270 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_ARTIFACT_RELATIVE_PATH = 'wp-content/homeboy-profile.jsonl';
+const DEFAULT_PLUGIN_FILE_NAME = 'homeboy-request-profiler.php';
+const DEFAULT_HOOKS = [
+	'muplugins_loaded',
+	'plugins_loaded',
+	'setup_theme',
+	'after_setup_theme',
+	'init',
+	'wp_loaded',
+	'admin_menu',
+	'admin_init',
+	'current_screen',
+	'admin_enqueue_scripts',
+	'admin_head',
+	'admin_footer',
+	'shutdown',
+];
+const DEFAULT_PRIORITY_BAND_HOOKS = [
+	'admin_init',
+	'current_screen',
+	'admin_enqueue_scripts',
+];
+
+function normalizeSitePath(sitePath) {
+	if (!sitePath || typeof sitePath !== 'string') {
+		throw new TypeError('sitePath must be a non-empty string');
+	}
+
+	return path.resolve(sitePath);
+}
+
+function normalizeRelativePath(value, fallback) {
+	const relativePath = value || fallback;
+	if (typeof relativePath !== 'string' || relativePath.trim() === '') {
+		throw new TypeError('artifactRelativePath must be a non-empty string');
+	}
+	if (path.isAbsolute(relativePath)) {
+		throw new Error('artifactRelativePath must be relative to the WordPress site path');
+	}
+
+	const normalized = path.normalize(relativePath);
+	if (normalized === '..' || normalized.startsWith(`..${path.sep}`)) {
+		throw new Error('artifactRelativePath must stay inside the WordPress site path');
+	}
+
+	return normalized;
+}
+
+function normalizeList(value, fallback, label) {
+	const list = value === undefined ? fallback : value;
+	if (!Array.isArray(list)) {
+		throw new TypeError(`${label} must be an array`);
+	}
+
+	return list.map((item) => {
+		if (typeof item !== 'string' || item.trim() === '') {
+			throw new TypeError(`${label} entries must be non-empty strings`);
+		}
+		return item.trim();
+	});
+}
+
+function resolveProfilerPaths(sitePath, options = {}) {
+	const root = normalizeSitePath(sitePath);
+	const artifactRelativePath = normalizeRelativePath(
+		options.artifactRelativePath,
+		DEFAULT_ARTIFACT_RELATIVE_PATH
+	);
+	const pluginFileName = options.pluginFileName || DEFAULT_PLUGIN_FILE_NAME;
+	if (typeof pluginFileName !== 'string' || pluginFileName.trim() === '' || pluginFileName.includes('/') || pluginFileName.includes('\\')) {
+		throw new TypeError('pluginFileName must be a file name, not a path');
+	}
+
+	return {
+		sitePath: root,
+		muPluginsDir: path.join(root, 'wp-content', 'mu-plugins'),
+		pluginPath: path.join(root, 'wp-content', 'mu-plugins', pluginFileName),
+		artifactPath: path.join(root, artifactRelativePath),
+		artifactRelativePath,
+	};
+}
+
+function phpString(value) {
+	return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+function phpArray(values) {
+	return `array( ${values.map(phpString).join(', ')} )`;
+}
+
+function generateProfilerPlugin(options = {}) {
+	const artifactRelativePath = normalizeRelativePath(
+		options.artifactRelativePath,
+		DEFAULT_ARTIFACT_RELATIVE_PATH
+	).replace(/\\/g, '/');
+	const hooks = normalizeList(options.hooks, DEFAULT_HOOKS, 'hooks');
+	const priorityBandHooks = normalizeList(
+		options.priorityBandHooks,
+		DEFAULT_PRIORITY_BAND_HOOKS,
+		'priorityBandHooks'
+	);
+
+	return `<?php
+/**
+ * Plugin Name: Homeboy Request Profiler
+ * Description: Temporary Homeboy MU-plugin for WordPress request profiling.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
+if ( defined( 'HOMEBOY_REQUEST_PROFILER_LOADED' ) ) {
+	return;
+}
+
+define( 'HOMEBOY_REQUEST_PROFILER_LOADED', true );
+
+$homeboy_request_profiler_start = microtime( true );
+$homeboy_request_profiler_id    = substr( hash( 'sha256', ( $_SERVER['REQUEST_METHOD'] ?? 'CLI' ) . '|' . ( $_SERVER['REQUEST_URI'] ?? '' ) . '|' . $homeboy_request_profiler_start ), 0, 16 );
+$homeboy_request_profiler_file  = ABSPATH . ${phpString(artifactRelativePath)};
+
+if ( ! function_exists( 'homeboy_request_profiler_write' ) ) {
+	function homeboy_request_profiler_write( $event, $data = array() ) {
+		global $homeboy_request_profiler_start, $homeboy_request_profiler_id, $homeboy_request_profiler_file;
+
+		$entry = array(
+			'v'          => 1,
+			'event'      => $event,
+			'timestamp'  => gmdate( 'c' ),
+			't_ms'       => round( ( microtime( true ) - $homeboy_request_profiler_start ) * 1000, 3 ),
+			'request_id' => $homeboy_request_profiler_id,
+			'method'     => $_SERVER['REQUEST_METHOD'] ?? 'CLI',
+			'uri'        => $_SERVER['REQUEST_URI'] ?? '',
+			'data'       => $data,
+		);
+
+		$dir = dirname( $homeboy_request_profiler_file );
+		if ( ! is_dir( $dir ) ) {
+			wp_mkdir_p( $dir );
+		}
+
+		file_put_contents(
+			$homeboy_request_profiler_file,
+			wp_json_encode( $entry, JSON_UNESCAPED_SLASHES ) . PHP_EOL,
+			FILE_APPEND | LOCK_EX
+		);
+	}
+}
+
+homeboy_request_profiler_write( 'request.start', array( 'php_sapi' => PHP_SAPI ) );
+
+foreach ( ${phpArray(hooks)} as $homeboy_request_profiler_hook ) {
+	add_action(
+		$homeboy_request_profiler_hook,
+		static function () use ( $homeboy_request_profiler_hook ) {
+			homeboy_request_profiler_write( 'hook', array( 'hook' => $homeboy_request_profiler_hook ) );
+		},
+		10,
+		0
+	);
+}
+
+foreach ( ${phpArray(priorityBandHooks)} as $homeboy_request_profiler_hook ) {
+	add_action(
+		$homeboy_request_profiler_hook,
+		static function () use ( $homeboy_request_profiler_hook ) {
+			homeboy_request_profiler_write( 'hook.priority_band.start', array( 'hook' => $homeboy_request_profiler_hook, 'priority' => -1000000 ) );
+		},
+		-1000000,
+		0
+	);
+	add_action(
+		$homeboy_request_profiler_hook,
+		static function () use ( $homeboy_request_profiler_hook ) {
+			homeboy_request_profiler_write( 'hook.priority_band.end', array( 'hook' => $homeboy_request_profiler_hook, 'priority' => 1000000 ) );
+		},
+		1000000,
+		0
+	);
+}
+
+add_filter(
+	'pre_http_request',
+	static function ( $preempt, $parsed_args, $url ) {
+		homeboy_request_profiler_write(
+			'http.request.start',
+			array(
+				'id'     => substr( hash( 'sha256', $url ), 0, 16 ),
+				'url'    => $url,
+				'method' => $parsed_args['method'] ?? 'GET',
+			)
+		);
+
+		return $preempt;
+	},
+	10,
+	3
+);
+`;
+}
+
+function installWordPressRequestProfiler(sitePath, options = {}) {
+	const paths = resolveProfilerPaths(sitePath, options);
+	fs.mkdirSync(paths.muPluginsDir, { recursive: true });
+	fs.mkdirSync(path.dirname(paths.artifactPath), { recursive: true });
+
+	if (options.clearArtifact !== false && fs.existsSync(paths.artifactPath)) {
+		fs.unlinkSync(paths.artifactPath);
+	}
+
+	fs.writeFileSync(paths.pluginPath, generateProfilerPlugin(options), 'utf8');
+	return paths;
+}
+
+function uninstallWordPressRequestProfiler(sitePath, options = {}) {
+	const paths = resolveProfilerPaths(sitePath, options);
+	if (fs.existsSync(paths.pluginPath)) {
+		fs.unlinkSync(paths.pluginPath);
+	}
+	if (options.removeArtifact === true && fs.existsSync(paths.artifactPath)) {
+		fs.unlinkSync(paths.artifactPath);
+	}
+	return paths;
+}
+
+function parseWordPressRequestProfileJsonl(contents) {
+	if (typeof contents !== 'string') {
+		throw new TypeError('contents must be a string');
+	}
+
+	return contents
+		.split(/\r?\n/)
+		.map((line, index) => ({ line: line.trim(), lineNumber: index + 1 }))
+		.filter(({ line }) => line !== '')
+		.map(({ line, lineNumber }) => {
+			try {
+				return JSON.parse(line);
+			} catch (error) {
+				throw new Error(`Invalid WordPress request profile JSONL at line ${lineNumber}: ${error.message}`);
+			}
+		});
+}
+
+function collectWordPressRequestProfiles(sitePath, options = {}) {
+	const paths = resolveProfilerPaths(sitePath, options);
+	if (!fs.existsSync(paths.artifactPath)) {
+		return [];
+	}
+
+	return parseWordPressRequestProfileJsonl(fs.readFileSync(paths.artifactPath, 'utf8'));
+}
+
+module.exports = {
+	DEFAULT_ARTIFACT_RELATIVE_PATH,
+	DEFAULT_HOOKS,
+	DEFAULT_PLUGIN_FILE_NAME,
+	DEFAULT_PRIORITY_BAND_HOOKS,
+	collectWordPressRequestProfiles,
+	generateProfilerPlugin,
+	installWordPressRequestProfiler,
+	parseWordPressRequestProfileJsonl,
+	resolveProfilerPaths,
+	uninstallWordPressRequestProfiler,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -2,8 +2,14 @@
   "name": "homeboy-extension-wordpress",
   "version": "1.0.0",
   "private": true,
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./request-profiler": "./lib/request-profiler.js"
+  },
   "scripts": {
-    "lint:js": "eslint --ext .js,.jsx,.ts,.tsx"
+    "lint:js": "eslint --ext .js,.jsx,.ts,.tsx",
+    "test:request-profiler": "node tests/request-profiler-smoke.js"
   },
   "devDependencies": {
     "@wp-playground/cli": "^3.1.20",

--- a/wordpress/tests/request-profiler-smoke.js
+++ b/wordpress/tests/request-profiler-smoke.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+	DEFAULT_ARTIFACT_RELATIVE_PATH,
+	collectWordPressRequestProfiles,
+	generateProfilerPlugin,
+	installWordPressRequestProfiler,
+	parseWordPressRequestProfileJsonl,
+	resolveProfilerPaths,
+	uninstallWordPressRequestProfiler,
+} = require('../lib/request-profiler');
+
+const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-profiler-'));
+
+try {
+	fs.mkdirSync(path.join(fixture, 'wp-content'), { recursive: true });
+
+	const plugin = generateProfilerPlugin();
+	assert.match(plugin, /Plugin Name: Homeboy Request Profiler/);
+	assert.match(plugin, /admin_init/);
+	assert.match(plugin, /pre_http_request/);
+	assert.match(plugin, /homeboy-profile\.jsonl/);
+
+	const paths = installWordPressRequestProfiler(fixture);
+	assert.equal(paths.artifactRelativePath, DEFAULT_ARTIFACT_RELATIVE_PATH);
+	assert.equal(paths.pluginPath, path.join(fixture, 'wp-content', 'mu-plugins', 'homeboy-request-profiler.php'));
+	assert.equal(fs.existsSync(paths.pluginPath), true);
+	assert.equal(fs.existsSync(path.dirname(paths.artifactPath)), true);
+
+	fs.writeFileSync(
+		paths.artifactPath,
+		[
+			JSON.stringify({ event: 'request.start', request_id: 'abc', t_ms: 0 }),
+			JSON.stringify({ event: 'hook', request_id: 'abc', t_ms: 12.3, data: { hook: 'init' } }),
+			'',
+		].join('\n'),
+		'utf8'
+	);
+
+	const entries = collectWordPressRequestProfiles(fixture);
+	assert.equal(entries.length, 2);
+	assert.equal(entries[1].data.hook, 'init');
+
+	const parsed = parseWordPressRequestProfileJsonl('{"event":"one"}\n\n{"event":"two"}\n');
+	assert.deepEqual(parsed.map((entry) => entry.event), ['one', 'two']);
+
+	assert.throws(
+		() => parseWordPressRequestProfileJsonl('{"event":"ok"}\nnot-json'),
+		/Invalid WordPress request profile JSONL at line 2/
+	);
+
+	assert.throws(
+		() => resolveProfilerPaths(fixture, { artifactRelativePath: '../outside.jsonl' }),
+		/must stay inside/
+	);
+
+	uninstallWordPressRequestProfiler(fixture);
+	assert.equal(fs.existsSync(paths.pluginPath), false);
+	assert.equal(fs.existsSync(paths.artifactPath), true);
+
+	uninstallWordPressRequestProfiler(fixture, { removeArtifact: true });
+	assert.equal(fs.existsSync(paths.artifactPath), false);
+
+	console.log('WordPress request profiler smoke passed.');
+} finally {
+	fs.rmSync(fixture, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Adds a reusable Node helper to the WordPress extension that captures server-side WordPress request timing without forcing each rig to hand-roll a temporary MU-plugin.

- `wordpress/lib/request-profiler.js` — Node API: `installWordPressRequestProfiler`, `collectWordPressRequestProfiles`, `parseWordPressRequestProfileJsonl`, `uninstallWordPressRequestProfiler`, `generateProfilerPlugin`, `resolveProfilerPaths`.
- Generates a temporary MU-plugin at `wp-content/mu-plugins/homeboy-request-profiler.php` that emits JSONL entries to `wp-content/homeboy-profile.jsonl` (path/hooks/priority bands all configurable).
- Captures hook timings for `muplugins_loaded`, `plugins_loaded`, `setup_theme`, `after_setup_theme`, `init`, `wp_loaded`, `admin_menu`, `admin_init`, `current_screen`, `admin_enqueue_scripts`, `admin_head`, `admin_footer`, `shutdown`.
- Captures priority-band start/end marks around `admin_init`, `current_screen`, `admin_enqueue_scripts`.
- Captures outbound HTTP request starts via `pre_http_request` with hashed IDs, URL, and method.
- Cleanup leaves the JSONL artifact in place by default so bench/trace runners can preserve it; `removeArtifact: true` deletes it.
- Wires `node --check` and `node tests/request-profiler-smoke.js` into the WordPress extension's `homeboy.json` self-checks.
- Adds a Request Profiler Helper section to `docs/extensions/wordpress.md` with usage example, defaults, captured event taxonomy, and configuration knobs.

This is a WordPress domain adapter authored in Node — it lives in the `wordpress` extension, not `nodejs`, because the runtime target is WordPress (MU-plugin injection, `wp-content`, hooks, `pre_http_request`).

Closes #445

## Validation

- `node --check index.js lib/request-profiler.js tests/request-profiler-smoke.js` — clean
- `node tests/request-profiler-smoke.js` — passes end-to-end (install/uninstall, JSONL parsing, error paths, artifact preservation/removal)
- `php -l` against the rendered MU-plugin string — `No syntax errors detected`

## Caveats

`homeboy test --path wordpress` reports a failure in `scripts/test/playground-no-test-files-smoke.sh` (expected `pg_run_deferred_wordpress_hook_callbacks(...)` line not found in the runner template). Reproduces against the clean tree of `feat/wordpress-request-profiler` before any of these changes — it is an existing failure on this branch unrelated to the profiler scope and worth tracking separately.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the Node helper, MU-plugin generator, smoke test, manifest wiring, and docs from the issue spec. Chris reviewed the design (placement in `wordpress` over `nodejs`) and validated locally.