### PR TITLE
Escape sed replacement metacharacters in Playground bench/test runners

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -450,6 +450,29 @@ WRAPPER_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/pg-bench-runner.XXXXXX")
 # need escaping. The other placeholders use `|` (their values never contain
 # a pipe in practice — slugs, integers, and POSIX paths only).
 WP_CONFIG_DEFINES_DELIM=$(printf '\1')
+
+# Escape sed `s` replacement metacharacters in JSON values before
+# substituting them into the PHP runner template. GNU sed processes the
+# replacement string by treating `&` as a backreference to the matched
+# pattern and `\X` as an escape sequence — so an unescaped `&` in JSON
+# (e.g. an ampersand inside a string) gets replaced with the placeholder
+# itself, and `\"` collapses to `"`, silently corrupting the JSON. The
+# decode in playground-bench-runner.php then fails and ALL declared
+# bench_env / wp_config_defines entries drop on the floor.
+#
+# Only `\` and `&` need escaping here: the SOH delimiter cannot appear in
+# JSON content, and the only `\X` sequences sed treats specially are
+# `\&`, `\\`, the delimiter, and `\1`-`\9` — which all share the `\`
+# escape, so escaping `\` covers them.
+sed_escape_replacement() {
+    printf '%s' "$1" | sed -e 's/[\&]/\\&/g'
+}
+WP_CONFIG_DEFINES_JSON_ESC=$(sed_escape_replacement "$WP_CONFIG_DEFINES_JSON")
+BENCH_ENV_JSON_ESC=$(sed_escape_replacement "$BENCH_ENV_JSON")
+BENCH_WORKLOADS_JSON_ESC=$(sed_escape_replacement "$BENCH_WORKLOADS_JSON")
+PLAYGROUND_WORKLOADS_JSON_ESC=$(sed_escape_replacement "$PLAYGROUND_WORKLOADS_JSON")
+EXTRA_WORKLOADS_LIST_ESC=$(sed_escape_replacement "$EXTRA_WORKLOADS_LIST")
+
 sed \
     -e "s|{{PLUGIN_SLUG}}|${PLUGIN_SLUG}|g" \
     -e "s|{{COMPONENT_ID}}|${COMPONENT_ID}|g" \
@@ -463,11 +486,11 @@ sed \
     -e "s|{{RESULT_SUFFIX}}|${RESULT_SUFFIX}|g" \
     -e "s|{{BENCH_HELPER_PHP}}|${BENCH_HELPER_PHP_GUEST}|g" \
     -e "s|{{BENCH_SITE_MODE}}|${BENCH_SITE_MODE}|g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_WORKLOADS_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_WORKLOADS_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{PLAYGROUND_WORKLOADS_JSON}}${WP_CONFIG_DEFINES_DELIM}${PLAYGROUND_WORKLOADS_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{EXTRA_WORKLOADS_LIST}}${WP_CONFIG_DEFINES_DELIM}${EXTRA_WORKLOADS_LIST}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_WORKLOADS_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_WORKLOADS_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{PLAYGROUND_WORKLOADS_JSON}}${WP_CONFIG_DEFINES_DELIM}${PLAYGROUND_WORKLOADS_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{EXTRA_WORKLOADS_LIST}}${WP_CONFIG_DEFINES_DELIM}${EXTRA_WORKLOADS_LIST_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
     "$TEMPLATE" > "$WRAPPER_TMPFILE"
 
 echo "Running performance benchmarks via WordPress Playground..."

--- a/wordpress/scripts/bench/playground-bench-env-sed-escape-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-env-sed-escape-smoke.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Sed-replacement-escape regression smoke test.
+#
+# Asserts that the `sed_escape_replacement` helper used by
+# bench-runner-playground.sh and test-runner-playground.sh correctly
+# escapes `\` and `&` so JSON values round-trip through the sed `s`
+# command without corruption.
+#
+# Why this matters
+# ----------------
+# GNU sed (CI) treats `&` in the replacement string as a backreference
+# to the matched pattern and `\X` as an escape sequence. JSON values
+# routinely contain `\"` (escaped quote) and may contain literal `&`
+# (e.g. inside an arbitrary string payload). Substituting an unescaped
+# JSON value into a runner template with `s${DELIM}{{PLACEHOLDER}}${DELIM}${VALUE}${DELIM}`
+# silently mangles the JSON — `\"` becomes `"` (drops the backslash) and
+# `&` gets replaced with the matched placeholder. The PHP-side
+# json_decode then returns null and ALL declared bench_env /
+# wp_config_defines entries drop, including unrelated values like
+# GITHUB_TOKEN.
+#
+# This smoke replays the corruption without standing up Playground:
+#   1. Renders a tiny inline template with the historic (broken)
+#      substitution and asserts the corruption pattern.
+#   2. Renders the same template using the escaped helper and asserts
+#      bit-for-bit JSON round-trip.
+#
+# Run via: bash wordpress/scripts/bench/playground-bench-env-sed-escape-smoke.sh
+# Exit:    0 = round-trips, non-zero = regression
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Pathological JSON value covering both metacharacters:
+#   - PAYLOAD contains `\"` (escaped JSON quotes within a string).
+#   - The text `a & b` contains a literal `&`.
+#   - GITHUB_TOKEN is the bystander we care about — it must survive
+#     unmangled when one of its sibling keys carries `\` or `&`.
+PATHOLOGICAL_JSON='{"GITHUB_TOKEN":"ghs_x","PAYLOAD":"{\"text\":\"a & b\"}"}'
+
+# Mirror the SOH delimiter and template shape used by the real runners.
+DELIM=$(printf '\1')
+TEMPLATE_BODY="\$bench_env_raw = '{{BENCH_ENV_JSON}}';"
+
+echo "============================================"
+echo "sed_escape_replacement smoke test"
+echo "============================================"
+echo "Input JSON:"
+echo "  $PATHOLOGICAL_JSON"
+echo ""
+
+# --- Stage 1: confirm the bug is reproducible without the helper ---------
+RAW_OUT=$(printf '%s' "$TEMPLATE_BODY" \
+    | sed -e "s${DELIM}{{BENCH_ENV_JSON}}${DELIM}${PATHOLOGICAL_JSON}${DELIM}g")
+
+echo "Unescaped sed output (regression baseline):"
+echo "  $RAW_OUT"
+echo ""
+
+# Both corruption shapes must show up — `\"` collapses to `"`, and `&`
+# gets replaced with the placeholder text. If either invariant changes
+# (e.g. sed semantics shift, or the test template stops triggering the
+# bug), the after-fix check below would also pass vacuously, so we gate
+# on it explicitly here.
+if ! printf '%s' "$RAW_OUT" | grep -q '{{BENCH_ENV_JSON}}'; then
+    echo "ERROR: expected unescaped sed output to substitute '&' with the matched"
+    echo "       placeholder ({{BENCH_ENV_JSON}}). Got:" >&2
+    echo "       $RAW_OUT" >&2
+    exit 1
+fi
+if printf '%s' "$RAW_OUT" | grep -q '\\"text\\"'; then
+    echo "ERROR: expected unescaped sed output to drop backslashes from \\\"" >&2
+    echo "       Got: $RAW_OUT" >&2
+    exit 1
+fi
+
+# --- Stage 2: confirm the helper produces a clean round-trip --------------
+sed_escape_replacement() {
+    printf '%s' "$1" | sed -e 's/[\&]/\\&/g'
+}
+
+ESC=$(sed_escape_replacement "$PATHOLOGICAL_JSON")
+FIXED_OUT=$(printf '%s' "$TEMPLATE_BODY" \
+    | sed -e "s${DELIM}{{BENCH_ENV_JSON}}${DELIM}${ESC}${DELIM}g")
+
+EXPECTED="\$bench_env_raw = '${PATHOLOGICAL_JSON}';"
+
+echo "Escaped sed output:"
+echo "  $FIXED_OUT"
+echo ""
+
+if [ "$FIXED_OUT" != "$EXPECTED" ]; then
+    echo "ERROR: escaped substitution did not round-trip JSON value." >&2
+    echo "  expected: $EXPECTED" >&2
+    echo "  actual:   $FIXED_OUT" >&2
+    exit 1
+fi
+
+# --- Stage 3: confirm both real runners still ship the helper -------------
+# Guards against a future refactor that drops the helper while leaving
+# the placeholder substitution in place — which would silently
+# reintroduce the bug.
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+for runner in \
+    "$EXTENSION_PATH/scripts/bench/bench-runner-playground.sh" \
+    "$EXTENSION_PATH/scripts/test/test-runner-playground.sh"
+do
+    if [ ! -f "$runner" ]; then
+        echo "ERROR: runner not found at $runner" >&2
+        exit 1
+    fi
+    if ! grep -q 'sed_escape_replacement' "$runner"; then
+        echo "ERROR: $runner no longer calls sed_escape_replacement." >&2
+        echo "       JSON values substituted into the PHP template will be" >&2
+        echo "       silently corrupted whenever they contain '\\' or '&'." >&2
+        exit 1
+    fi
+done
+
+echo "============================================"
+echo "✓ sed_escape_replacement smoke test PASSED"
+echo "  - Unescaped substitution corrupts JSON (regression baseline holds)."
+echo "  - Escaped substitution round-trips '\\' and '&' losslessly."
+echo "  - bench-runner-playground.sh and test-runner-playground.sh still"
+echo "    invoke the helper."
+echo "============================================"

--- a/wordpress/scripts/bench/playground-bench-env-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-env-smoke.sh
@@ -55,11 +55,20 @@ ITERATIONS=2
 # Synthesize the merged settings JSON the dispatcher would receive from
 # homeboy core. Real components declare this under
 # extensions.wordpress.settings.bench_env in their homeboy.json.
+#
+# BENCH_ENV_FIXTURE_METAS is the regression value for the sed-replacement
+# escape bug: it contains `\` (via the JSON-escaped `\"` sequences) and a
+# literal `&`, both of which GNU sed mangles in `s` replacement strings
+# unless the runner escapes them before substituting BENCH_ENV_JSON into
+# the PHP template. Without the fix, json_decode() of BENCH_ENV_JSON
+# returns null and ALL bench_env keys silently drop — including unrelated
+# bystanders like BENCH_ENV_FIXTURE_STR.
 SETTINGS_JSON=$(cat <<'JSON'
 {
   "bench_env": {
     "BENCH_ENV_FIXTURE_STR": "hello",
-    "BENCH_ENV_FIXTURE_NUM": "42"
+    "BENCH_ENV_FIXTURE_NUM": "42",
+    "BENCH_ENV_FIXTURE_METAS": "{\"text\":\"a & b\",\"path\":\"C:\\\\tmp\"}"
   }
 }
 JSON
@@ -118,7 +127,32 @@ if ! grep -q "\"BENCH_ENV_FIXTURE_STR_env_value\":\"hello\"" "$READ_BACK_LOG"; t
     exit 1
 fi
 
+# BENCH_ENV_FIXTURE_METAS carries the sed-replacement-escape regression
+# payload (see settings JSON above). The workload var_export()s the
+# getenv() result, so we expect:
+#   "BENCH_ENV_FIXTURE_METAS_getenv":"'{\"text\":\"a & b\",\"path\":\"C:\\\\tmp\"}'"
+# which after JSON-encoding (json_encode in the workload) and grep-quoting
+# becomes a long literal — keep the assertion small and split into the
+# two corruption signatures: the literal `&` survives and a `\"` survives.
+if ! grep -q '"BENCH_ENV_FIXTURE_METAS_getenv":"' "$READ_BACK_LOG"; then
+    echo "ERROR: BENCH_ENV_FIXTURE_METAS_getenv missing from read-back log" >&2
+    exit 1
+fi
+if ! grep -q 'a & b' "$READ_BACK_LOG"; then
+    echo "ERROR: literal '&' did not round-trip in BENCH_ENV_FIXTURE_METAS." >&2
+    echo "       Likely cause: BENCH_ENV_JSON sed substitution treated '&' as a" >&2
+    echo "       backreference and corrupted the JSON before json_decode()." >&2
+    exit 1
+fi
+if ! grep -q '\\"text\\"' "$READ_BACK_LOG"; then
+    echo "ERROR: '\\\"' did not round-trip in BENCH_ENV_FIXTURE_METAS." >&2
+    echo "       Likely cause: BENCH_ENV_JSON sed substitution dropped backslashes" >&2
+    echo "       in the replacement string, corrupting the JSON before json_decode()." >&2
+    exit 1
+fi
+
 echo "============================================"
 echo "✓ bench_env smoke test PASSED"
-echo "  All declared env vars round-trip through getenv() and \$_ENV."
+echo "  All declared env vars round-trip through getenv() and \$_ENV,"
+echo "  including values containing '\\\\' and '&'."
 echo "============================================"

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -359,13 +359,34 @@ WRAPPER_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/pg-runner.XXXXXX")
 # ASCII SOH delimiter for the JSON substitution — values may contain `|`
 # safely without shell escaping.
 WP_CONFIG_DEFINES_DELIM=$(printf '\1')
+
+# Escape sed `s` replacement metacharacters in JSON values before
+# substituting them into the PHP runner template. GNU sed processes the
+# replacement string by treating `&` as a backreference to the matched
+# pattern and `\X` as an escape sequence — so an unescaped `&` in JSON
+# (e.g. an ampersand inside a string) gets replaced with the placeholder
+# itself, and `\"` collapses to `"`, silently corrupting the JSON. The
+# decode in playground-runner.php then fails and ALL declared bench_env /
+# wp_config_defines entries drop on the floor.
+#
+# Only `\` and `&` need escaping here: the SOH delimiter cannot appear in
+# JSON content, and the only `\X` sequences sed treats specially are
+# `\&`, `\\`, the delimiter, and `\1`-`\9` — which all share the `\`
+# escape, so escaping `\` covers them.
+sed_escape_replacement() {
+    printf '%s' "$1" | sed -e 's/[\&]/\\&/g'
+}
+WP_CONFIG_DEFINES_JSON_ESC=$(sed_escape_replacement "$WP_CONFIG_DEFINES_JSON")
+BENCH_ENV_JSON_ESC=$(sed_escape_replacement "$BENCH_ENV_JSON")
+CHANGED_TEST_FILES_JSON_ESC=$(sed_escape_replacement "$CHANGED_TEST_FILES_JSON")
+
 sed \
     -e "s|{{PLUGIN_SLUG}}|${PLUGIN_SLUG}|g" \
     -e "s|{{PLAYGROUND_DEP_MOUNTS}}|${PLAYGROUND_DEP_MOUNTS}|g" \
     -e "s|{{PHPUNIT_TEST_FILE_B64}}|${SELECTED_TEST_FILE_B64}|g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{CHANGED_TEST_FILES_JSON}}${WP_CONFIG_DEFINES_DELIM}${CHANGED_TEST_FILES_JSON}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{CHANGED_TEST_FILES_JSON}}${WP_CONFIG_DEFINES_DELIM}${CHANGED_TEST_FILES_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
     "$TEMPLATE" > "$WRAPPER_TMPFILE"
 
 echo "Running PHPUnit tests via WordPress Playground..."

--- a/wordpress/tests/fixtures/bench-env/tests/bench/read-back-env.php
+++ b/wordpress/tests/fixtures/bench-env/tests/bench/read-back-env.php
@@ -20,11 +20,17 @@
 return function (): array {
     $shared = defined('HOMEBOY_BENCH_SHARED_STATE') ? HOMEBOY_BENCH_SHARED_STATE : '';
 
+    // BENCH_ENV_FIXTURE_METAS optionally carries a JSON value with `\` and
+    // `&` embedded — chars that GNU sed mangles in `s` replacement strings
+    // unless the dispatcher escapes them before substituting BENCH_ENV_JSON
+    // into the runner template (homeboy-extensions sed-escape fix). The
+    // smoke script grep-asserts these survive the Playground boundary.
     $values = [
         'BENCH_ENV_FIXTURE_STR_getenv' => var_export(getenv('BENCH_ENV_FIXTURE_STR'), true),
         'BENCH_ENV_FIXTURE_NUM_getenv' => var_export(getenv('BENCH_ENV_FIXTURE_NUM'), true),
         'BENCH_ENV_FIXTURE_STR_in_env' => array_key_exists('BENCH_ENV_FIXTURE_STR', $_ENV) ? 'yes' : 'no',
         'BENCH_ENV_FIXTURE_STR_env_value' => $_ENV['BENCH_ENV_FIXTURE_STR'] ?? '<missing>',
+        'BENCH_ENV_FIXTURE_METAS_getenv' => var_export(getenv('BENCH_ENV_FIXTURE_METAS'), true),
     ];
 
     if ($shared !== '') {


### PR DESCRIPTION
## Summary

The Playground bench and test runners substitute JSON values (`bench_env`, `wp_config_defines`, workload lists, changed-test-file lists) into the PHP runner template via `sed`. Any value carrying a `\` or `&` was silently mangled because GNU sed treats `&` as a backreference to the matched pattern and collapses `\X` escape sequences in the replacement string.

The PHP-side `json_decode` then returned `null` and **all** declared entries in that JSON dropped — including unrelated bystanders. In production this manifested as `GITHUB_TOKEN` and `OPENAI_API_KEY` silently going missing inside Playground in `chubes4/wc-site-generator` PR #111 because a sibling `bench_env` key contained JSON-escaped quotes.

Fix: add a small `sed_escape_replacement` helper to both `bench-runner-playground.sh` and `test-runner-playground.sh` and apply it to every JSON value before the outer `sed` call. Only `\` and `&` need escaping; the SOH (`\x01`) delimiter cannot appear in JSON content.

## Reproduction (GNU sed 4.9 / `ubuntu:24.04`)

```bash
docker run --rm -i ubuntu:24.04 bash -c '
sed_escape_replacement() {
    printf "%s" "$1" | sed -e "s/[\\\\&]/\\\\&/g"
}
DELIM=$(printf "\1")
BENCH_ENV_JSON="{\"GITHUB_TOKEN\":\"ghs_x\",\"PAYLOAD\":\"{\\\"text\\\":\\\"a & b\\\"}\"}"
TEMPLATE="\$bench_env_raw = '"'"'{{BENCH_ENV_JSON}}'"'"';"

echo "=== sed version ==="
sed --version | head -1

echo ""
echo "=== BEFORE FIX ==="
printf "%s" "$TEMPLATE" | sed -e "s${DELIM}{{BENCH_ENV_JSON}}${DELIM}${BENCH_ENV_JSON}${DELIM}g"

echo ""
echo "=== AFTER FIX ==="
ESC=$(sed_escape_replacement "$BENCH_ENV_JSON")
printf "%s" "$TEMPLATE" | sed -e "s${DELIM}{{BENCH_ENV_JSON}}${DELIM}${ESC}${DELIM}g"
'
```

Output:

```
=== sed version ===
sed (GNU sed) 4.9

=== BEFORE FIX ===
$bench_env_raw = '{"GITHUB_TOKEN":"ghs_x","PAYLOAD":"{"text":"a {{BENCH_ENV_JSON}} b"}"}';

=== AFTER FIX ===
$bench_env_raw = '{"GITHUB_TOKEN":"ghs_x","PAYLOAD":"{\"text\":\"a & b\"}"}';
```

Both corruption shapes show up in the unfixed output: `\"` collapsed to `"` and `& b` was rewritten to `{{BENCH_ENV_JSON}} b`. The fix recovers a bit-for-bit round-trip.

## Real-world impact

- `chubes4/wc-site-generator` PR #111 originally tried to pass an iterator finding-groups payload through `bench_env` as JSON and blew up the entire `bench_env` block — `GITHUB_TOKEN` and `OPENAI_API_KEY` silently went missing inside Playground despite being declared correctly. Failing run: <https://github.com/chubes4/wc-site-generator/actions/runs/25510087730>.
- `chubes4/wc-site-generator` PR #112 base64-encodes the payload as a downstream workaround. Once this PR lands the workaround can be reverted to plain JSON.

## Files changed

- `wordpress/scripts/bench/bench-runner-playground.sh` — escape `WP_CONFIG_DEFINES_JSON`, `BENCH_ENV_JSON`, `BENCH_WORKLOADS_JSON`, `PLAYGROUND_WORKLOADS_JSON`, `EXTRA_WORKLOADS_LIST` before substitution.
- `wordpress/scripts/test/test-runner-playground.sh` — escape `WP_CONFIG_DEFINES_JSON`, `BENCH_ENV_JSON`, `CHANGED_TEST_FILES_JSON` before substitution.
- `wordpress/scripts/bench/playground-bench-env-sed-escape-smoke.sh` — new unit-level smoke test. Confirms (1) the unfixed substitution corrupts JSON, (2) the helper round-trips losslessly, and (3) both real runners still invoke the helper. Runs in milliseconds, no Playground required.
- `wordpress/scripts/bench/playground-bench-env-smoke.sh` + `wordpress/tests/fixtures/bench-env/tests/bench/read-back-env.php` — extend the existing end-to-end Playground smoke to declare a `BENCH_ENV_FIXTURE_METAS` value containing `&` and `\` (`{"text":"a & b","path":"C:\\tmp"}`) and assert it survives the Playground boundary intact.

## Verification

Both verifications were run on this branch.

**Unit smoke** (`bash wordpress/scripts/bench/playground-bench-env-sed-escape-smoke.sh`):

```
============================================
sed_escape_replacement smoke test
============================================
Input JSON:
  {"GITHUB_TOKEN":"ghs_x","PAYLOAD":"{\"text\":\"a & b\"}"}

Unescaped sed output (regression baseline):
  $bench_env_raw = '{"GITHUB_TOKEN":"ghs_x","PAYLOAD":"{"text":"a {{BENCH_ENV_JSON}} b"}"}';

Escaped sed output:
  $bench_env_raw = '{"GITHUB_TOKEN":"ghs_x","PAYLOAD":"{\"text\":\"a & b\"}"}';

============================================
✓ sed_escape_replacement smoke test PASSED
============================================
```

Reverting the runner fixes (keeping the smoke + fixture changes) makes the unit smoke fail at the runner-presence guard with `exit=1`.

**Playground smoke** (`bash wordpress/scripts/bench/playground-bench-env-smoke.sh`):

After fix — read-back log:

```
{"BENCH_ENV_FIXTURE_STR_getenv":"'hello'","BENCH_ENV_FIXTURE_NUM_getenv":"'42'","BENCH_ENV_FIXTURE_STR_in_env":"yes","BENCH_ENV_FIXTURE_STR_env_value":"hello","BENCH_ENV_FIXTURE_METAS_getenv":"'{\"text\":\"a & b\",\"path\":\"C:\\\\tmp\"}'"}
```

`✓ bench_env smoke test PASSED — All declared env vars round-trip through getenv() and $_ENV, including values containing '\\' and '&'.`

Reverting the runner fixes (with the same smoke + fixture additions in place) reproduces the wc-site-generator failure shape exactly — read-back log shows **all** bench_env values silently dropped, including the bystanders that contain no special characters at all:

```
{"BENCH_ENV_FIXTURE_STR_getenv":"false","BENCH_ENV_FIXTURE_NUM_getenv":"false","BENCH_ENV_FIXTURE_STR_in_env":"no","BENCH_ENV_FIXTURE_STR_env_value":"<missing>","BENCH_ENV_FIXTURE_METAS_getenv":"false"}
```

`ERROR: BENCH_ENV_FIXTURE_STR did not round-trip via getenv()` (exit 1).

`bash -n` clean on every shell file touched.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** AI drafted the `sed_escape_replacement` helper, the new unit-level smoke script, the extension of the existing Playground smoke fixture/workload, and the docker reproducer. Chris reviewed the patch, ran both smoke tests against `wp-playground-cli` locally on macOS, and confirmed the regression shape under GNU sed 4.9 in `ubuntu:24.04` — including the before/after revert dance proving the new Playground assertion fails without the runner fix.