### PR TITLE
feat(wordpress): add Playground HTTP readiness helper

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -335,6 +335,7 @@ wordpress/
 │   ├── TESTING.md            # Canonical test/lint/bench reference
 │   ├── PLAYGROUND_DROPIN.md  # db.php coexistence mechanism
 │   └── commands/
+├── lib/                      # Node helpers: request profiler, Playground HTTP readiness
 ├── scripts/
 │   ├── audit/                # Detector setup + WP test smells
 │   ├── bench/                # Playground bench runner + workload smokes

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -380,6 +380,107 @@ It can contain credentials or auto-login URLs; runners must not print it to logs
 or publish it with benchmark results without redacting the fields listed in
 `artifactPolicy.secretFields`.
 
+## Playground HTTP readiness
+
+`lib/playground-readiness.js` exports a Node helper for callers that boot a
+`wp-playground-cli` HTTP server (or any WordPress origin) and need to wait
+until it is actually serving traffic before driving Playwright, REST calls,
+or load tests.
+
+The helper is CommonJS, has no external dependencies, and lives alongside
+`lib/request-profiler.js` because the readiness paths and Playground quirks
+are WordPress-domain knowledge.
+
+### `waitForWordPressReady(baseUrl, options)`
+
+Polls a single readiness path until it returns a ready status, then resolves
+with `{ status: 'ready', url, http_status, status_history, redirect_history,
+elapsedMs }`. Resolves with `{ status: 'process_exited', ... }` if the
+optional `playgroundProcess` exits before ready. Throws on timeout with a
+populated `.diagnostics` property.
+
+Options:
+
+| Option | Default | Purpose |
+|---|---|---|
+| `path` | `/wp-json/` | Path to poll. Defaults to `/wp-json/` because `wp-playground-cli` returns `302 Location: /` on `/`, which hangs Node's `fetch()` in a self-redirect loop. The helper uses `http.request()` directly and never follows redirects. |
+| `readyStatus` | `200` | Single status or array of statuses considered ready. Strict by default; 3xx is not treated as ready. |
+| `intervalMs` | `1000` | Delay between poll attempts. |
+| `requestTimeoutMs` | `5000` | Per-request abort. |
+| `timeoutMs` | `120000` | Total budget before throwing. |
+| `playgroundProcess` | `null` | Optional `ChildProcess`-like with `.exitCode` / `.signalCode`. If it exits before ready, the helper resolves with `process_exited` instead of throwing. |
+| `playgroundOutput` | `null` | Optional `() => string` returning captured stdout/stderr. The last 4000 chars are attached to the timeout artifact for debugging. |
+| `onEvent` | `null` | Optional `(source, event, data) => void`. Emits `http.first_response`, `http.status`, `http.redirect`, `http.ready`, `http.timeout`, `process.exited`. |
+
+### `probeWordPressDiagnostics(baseUrl, options)`
+
+One-shot diagnostic probe over a fixed set of WordPress paths. Returns
+`{ origin, paths: [{ path, url, status, contentType, redirectLocation,
+bodyPreview, elapsedMs, error?, tcp? }, ...] }`. Used internally to
+populate the timeout artifact, but exposed for callers that want a
+standalone snapshot. Defaults to probing
+`['/', '/wp-login.php', '/wp-json/', '/wp-admin/']`. Manual redirect
+handling — never follows `Location`.
+
+### Why the default path is `/wp-json/`, not `/`
+
+The `wp-playground-cli` HTTP server responds to `/` with `302 Location:
+/`, a self-redirect. Node's built-in `fetch()` treats `Location` as
+follow-by-default, so a naive `fetch(baseUrl)` against a Playground
+server hangs until the abort signal fires. Polling `/wp-json/` instead
+returns a clean `200 application/json` once WordPress has finished
+booting, with no redirect involved. The helper also uses
+`http.request()` rather than `fetch()` so even the `/` poll path stays
+single-attempt.
+
+### Timeout artifact shape
+
+```json
+{
+  "url": "http://127.0.0.1:9400/wp-json/",
+  "timeoutMs": 120000,
+  "attempts": 17,
+  "lastError": null,
+  "recentAttempts": [
+    { "at_ms": 1010, "status": 503 },
+    { "at_ms": 2020, "status": 503 }
+  ],
+  "redirect_history": [],
+  "status_history": [{ "status": 503, "count": 17 }],
+  "routes": {
+    "origin": "http://127.0.0.1:9400",
+    "paths": [
+      { "path": "/", "url": "http://127.0.0.1:9400/", "status": 302, "redirectLocation": "/", "bodyPreview": "...", "elapsedMs": 12 }
+    ]
+  },
+  "tcp": { "open": true },
+  "playground": { "pid": 12345, "exitCode": null, "signalCode": null },
+  "playgroundOutputTail": "...last 4000 chars of captured stdout/stderr..."
+}
+```
+
+### Usage
+
+```js
+const { waitForWordPressReady } = require('homeboy-extension-wordpress/playground-readiness');
+
+const child = spawnPlaygroundCli({ port: 9400 });
+const captured = [];
+child.stdout.on('data', (chunk) => captured.push(chunk));
+child.stderr.on('data', (chunk) => captured.push(chunk));
+
+const result = await waitForWordPressReady('http://127.0.0.1:9400', {
+  playgroundProcess: child,
+  playgroundOutput: () => Buffer.concat(captured).toString('utf8'),
+  timeoutMs: 60000,
+});
+
+if (result.status === 'process_exited') {
+  throw new Error(`Playground exited before ready: code=${result.playground.exitCode}`);
+}
+// result.status === 'ready' — drive Playwright/REST against result.url
+```
+
 ## Known gaps
 
 - **WP version defaults to 6.9.** Override `playground_wordpress_version` to pass

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -11,7 +11,7 @@
     "lint": [
       "jq empty wordpress.json",
       "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh",
-      "node --check index.js lib/request-profiler.js tests/request-profiler-smoke.js"
+      "node --check index.js lib/request-profiler.js lib/playground-readiness.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js"
     ],
     "test": [
       "bash scripts/test/host-smoke-runner-smoke.sh",
@@ -26,7 +26,8 @@
       "bash scripts/lint/eslint-no-files-smoke.sh",
       "bash tests/audit-detector-config-smoke.sh",
       "bash tests/audit-dead-guard-fallback-smoke.sh",
-      "node tests/request-profiler-smoke.js"
+      "node tests/request-profiler-smoke.js",
+      "node tests/playground-readiness-smoke.js"
     ]
   }
 }

--- a/wordpress/lib/playground-readiness.js
+++ b/wordpress/lib/playground-readiness.js
@@ -1,0 +1,356 @@
+'use strict';
+
+const http = require('node:http');
+const https = require('node:https');
+const net = require('node:net');
+
+const DEFAULT_READINESS_PATH = '/wp-json/';
+const DEFAULT_DIAGNOSTIC_PATHS = ['/', '/wp-login.php', '/wp-json/', '/wp-admin/'];
+const DEFAULT_INTERVAL_MS = 1000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 5000;
+const DEFAULT_TIMEOUT_MS = 120000;
+const DEFAULT_BODY_PREVIEW_BYTES = 4096;
+const BODY_PREVIEW_CHAR_LIMIT = 500;
+const RECENT_ATTEMPTS_LIMIT = 10;
+const PLAYGROUND_OUTPUT_TAIL_LIMIT = 4000;
+
+function normalizeBaseUrl(baseUrl) {
+	if (typeof baseUrl !== 'string' || baseUrl.trim() === '') {
+		throw new TypeError('baseUrl must be a non-empty string');
+	}
+	const trimmed = baseUrl.trim();
+	const parsed = new URL(trimmed);
+	const origin = `${parsed.protocol}//${parsed.host}`;
+	return { origin, host: parsed.hostname, port: Number(parsed.port) || (parsed.protocol === 'https:' ? 443 : 80) };
+}
+
+function buildUrl(origin, path) {
+	const cleanPath = path && path.startsWith('/') ? path : `/${path || ''}`;
+	return `${origin}${cleanPath}`;
+}
+
+function normalizeReadyStatus(value) {
+	if (Array.isArray(value)) {
+		return new Set(value.map(Number));
+	}
+	return new Set([Number(value)]);
+}
+
+function isReadyStatus(status, readySet) {
+	return readySet.has(Number(status));
+}
+
+function recordHttpStatus(history, status) {
+	const normalized = Number(status);
+	const last = history.at(-1);
+	if (last && last.status === normalized) {
+		last.count += 1;
+		return;
+	}
+	history.push({ status: normalized, count: 1 });
+}
+
+function serializeError(err) {
+	if (!err) return null;
+	const out = {
+		name: err.name || 'Error',
+		message: err.message || String(err),
+	};
+	if (err.code) out.code = err.code;
+	if (err.cause) {
+		out.cause = err.cause instanceof Error ? serializeError(err.cause) : String(err.cause);
+	}
+	return out;
+}
+
+function probeTcp(host, port, timeoutMs) {
+	return new Promise((resolve) => {
+		const socket = net.createConnection({ host, port });
+		let settled = false;
+		const finish = (result) => {
+			if (settled) return;
+			settled = true;
+			try {
+				socket.destroy();
+			} catch (_) {
+				// best-effort cleanup
+			}
+			resolve(result);
+		};
+		socket.setTimeout(timeoutMs);
+		socket.once('connect', () => finish({ open: true }));
+		socket.once('timeout', () => finish({ open: false, error: `tcp connect timed out after ${timeoutMs}ms` }));
+		socket.once('error', (err) => finish({ open: false, error: serializeError(err).message }));
+	});
+}
+
+function httpProbeOnce(url, requestTimeoutMs, options = {}) {
+	const captureBody = options.captureBody === true;
+	const maxBodyBytes = Number.isFinite(options.maxBodyBytes) ? options.maxBodyBytes : DEFAULT_BODY_PREVIEW_BYTES;
+	return new Promise((resolve) => {
+		let parsed;
+		try {
+			parsed = new URL(url);
+		} catch (err) {
+			resolve({ ok: false, error: serializeError(err) });
+			return;
+		}
+		const transport = parsed.protocol === 'https:' ? https : http;
+		const startedAt = Date.now();
+		let settled = false;
+		const finish = (value) => {
+			if (settled) return;
+			settled = true;
+			resolve(value);
+		};
+
+		const req = transport.request(parsed, { method: 'GET', timeout: requestTimeoutMs }, (res) => {
+			const status = res.statusCode || 0;
+			const headers = res.headers || {};
+			if (!captureBody) {
+				res.resume();
+				res.once('end', () => finish({ ok: true, status, headers, elapsedMs: Date.now() - startedAt }));
+				res.once('error', (err) => finish({ ok: false, error: serializeError(err), elapsedMs: Date.now() - startedAt }));
+				return;
+			}
+			const chunks = [];
+			let received = 0;
+			res.on('data', (chunk) => {
+				if (received >= maxBodyBytes) return;
+				const room = maxBodyBytes - received;
+				const slice = chunk.length <= room ? chunk : chunk.slice(0, room);
+				chunks.push(slice);
+				received += slice.length;
+			});
+			res.once('end', () => {
+				let body;
+				try {
+					body = Buffer.concat(chunks).toString('utf8');
+				} catch (_) {
+					body = '';
+				}
+				finish({ ok: true, status, headers, body, elapsedMs: Date.now() - startedAt });
+			});
+			res.once('error', (err) => finish({ ok: false, error: serializeError(err), elapsedMs: Date.now() - startedAt }));
+		});
+
+		req.on('timeout', () => {
+			req.destroy(new Error(`request timed out after ${requestTimeoutMs}ms`));
+		});
+		req.on('error', (err) => finish({ ok: false, error: serializeError(err), elapsedMs: Date.now() - startedAt }));
+		req.end();
+	});
+}
+
+async function emit(onEvent, source, event, data) {
+	if (typeof onEvent !== 'function') return;
+	try {
+		await onEvent(source, event, data || {});
+	} catch (_) {
+		// trace bridge errors must not break readiness polling
+	}
+}
+
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function processExited(child) {
+	if (!child) return false;
+	return child.exitCode !== null && child.exitCode !== undefined
+		|| child.signalCode !== null && child.signalCode !== undefined;
+}
+
+async function waitForWordPressReady(baseUrl, options = {}) {
+	const { origin, host, port } = normalizeBaseUrl(baseUrl);
+	const path = typeof options.path === 'string' && options.path !== '' ? options.path : DEFAULT_READINESS_PATH;
+	const url = buildUrl(origin, path);
+	const readySet = normalizeReadyStatus(options.readyStatus !== undefined ? options.readyStatus : 200);
+	const intervalMs = Number.isFinite(options.intervalMs) ? options.intervalMs : DEFAULT_INTERVAL_MS;
+	const requestTimeoutMs = Number.isFinite(options.requestTimeoutMs) ? options.requestTimeoutMs : DEFAULT_REQUEST_TIMEOUT_MS;
+	const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : DEFAULT_TIMEOUT_MS;
+	const onEvent = options.onEvent;
+	const child = options.playgroundProcess || null;
+	const playgroundOutput = typeof options.playgroundOutput === 'function' ? options.playgroundOutput : null;
+
+	const startedAt = Date.now();
+	const deadline = startedAt + timeoutMs;
+	const statusHistory = [];
+	const redirectHistory = [];
+	const recentAttempts = [];
+	let attempts = 0;
+	let lastStatus = null;
+	let lastError = null;
+	let firstResponseEmitted = false;
+
+	while (Date.now() <= deadline) {
+		if (processExited(child)) {
+			const elapsedMs = Date.now() - startedAt;
+			const playground = {
+				pid: child.pid ?? null,
+				exitCode: child.exitCode ?? null,
+				signalCode: child.signalCode ?? null,
+			};
+			await emit(onEvent, 'http', 'process.exited', { url, ...playground, elapsedMs });
+			return {
+				status: 'process_exited',
+				url,
+				http_status: null,
+				status_history: statusHistory,
+				redirect_history: redirectHistory,
+				elapsedMs,
+				playground,
+			};
+		}
+
+		attempts += 1;
+		const probe = await httpProbeOnce(url, requestTimeoutMs);
+		const attemptElapsed = Date.now() - startedAt;
+		const attemptRecord = { at_ms: attemptElapsed };
+
+		if (probe.ok) {
+			const status = probe.status;
+			recordHttpStatus(statusHistory, status);
+			attemptRecord.status = status;
+			if (!firstResponseEmitted) {
+				firstResponseEmitted = true;
+				await emit(onEvent, 'http', 'http.first_response', { url, status });
+			}
+			if (status !== lastStatus) {
+				await emit(onEvent, 'http', 'http.status', { url, status });
+			}
+			lastStatus = status;
+
+			const location = probe.headers && probe.headers.location;
+			if (status >= 300 && status < 400 && typeof location === 'string' && location !== '') {
+				redirectHistory.push({ from: url, status, location });
+				attemptRecord.redirect_location = location;
+				await emit(onEvent, 'http', 'http.redirect', { url, status, location });
+			}
+
+			if (isReadyStatus(status, readySet)) {
+				const elapsedMs = Date.now() - startedAt;
+				await emit(onEvent, 'http', 'http.ready', {
+					url,
+					status,
+					elapsedMs,
+					status_history: statusHistory,
+					redirect_history: redirectHistory,
+				});
+				return {
+					status: 'ready',
+					url,
+					http_status: status,
+					status_history: statusHistory,
+					redirect_history: redirectHistory,
+					elapsedMs,
+				};
+			}
+		} else {
+			lastError = probe.error;
+			attemptRecord.error = probe.error;
+		}
+
+		recentAttempts.push(attemptRecord);
+		if (recentAttempts.length > RECENT_ATTEMPTS_LIMIT) {
+			recentAttempts.splice(0, recentAttempts.length - RECENT_ATTEMPTS_LIMIT);
+		}
+
+		if (Date.now() + intervalMs > deadline) {
+			break;
+		}
+		await sleep(intervalMs);
+	}
+
+	if (processExited(child)) {
+		const elapsedMs = Date.now() - startedAt;
+		const playground = {
+			pid: child.pid ?? null,
+			exitCode: child.exitCode ?? null,
+			signalCode: child.signalCode ?? null,
+		};
+		await emit(onEvent, 'http', 'process.exited', { url, ...playground, elapsedMs });
+		return {
+			status: 'process_exited',
+			url,
+			http_status: null,
+			status_history: statusHistory,
+			redirect_history: redirectHistory,
+			elapsedMs,
+			playground,
+		};
+	}
+
+	const elapsedMs = Date.now() - startedAt;
+	const tcp = await probeTcp(host, port, 1000);
+	const routes = await probeWordPressDiagnostics(baseUrl, { requestTimeoutMs });
+	const playground = child
+		? { pid: child.pid ?? null, exitCode: child.exitCode ?? null, signalCode: child.signalCode ?? null }
+		: null;
+	const playgroundOutputTail = playgroundOutput
+		? String(playgroundOutput() || '').slice(-PLAYGROUND_OUTPUT_TAIL_LIMIT)
+		: null;
+
+	const diagnostics = {
+		url,
+		timeoutMs,
+		attempts,
+		lastError,
+		recentAttempts,
+		redirect_history: redirectHistory,
+		status_history: statusHistory,
+		routes,
+		tcp,
+		playground,
+		playgroundOutputTail,
+	};
+
+	await emit(onEvent, 'http', 'http.timeout', { url, elapsedMs, ...diagnostics });
+
+	const error = new Error(`Timed out waiting for ${url} after ${timeoutMs}ms`);
+	error.diagnostics = diagnostics;
+	throw error;
+}
+
+async function probeWordPressDiagnostics(baseUrl, options = {}) {
+	const { origin, host, port } = normalizeBaseUrl(baseUrl);
+	const paths = Array.isArray(options.paths) && options.paths.length > 0 ? options.paths : DEFAULT_DIAGNOSTIC_PATHS;
+	const requestTimeoutMs = Number.isFinite(options.requestTimeoutMs) ? options.requestTimeoutMs : DEFAULT_REQUEST_TIMEOUT_MS;
+
+	const entries = [];
+	for (const probePath of paths) {
+		const url = buildUrl(origin, probePath);
+		const result = await httpProbeOnce(url, requestTimeoutMs, { captureBody: true });
+		const entry = { path: probePath, url };
+		if (result.ok) {
+			const headers = result.headers || {};
+			entry.status = result.status;
+			entry.contentType = headers['content-type'] || null;
+			entry.redirectLocation = (result.status >= 300 && result.status < 400 && typeof headers.location === 'string')
+				? headers.location
+				: null;
+			entry.bodyPreview = typeof result.body === 'string'
+				? result.body.slice(0, BODY_PREVIEW_CHAR_LIMIT)
+				: '';
+			entry.elapsedMs = result.elapsedMs ?? null;
+		} else {
+			entry.status = null;
+			entry.contentType = null;
+			entry.redirectLocation = null;
+			entry.bodyPreview = '';
+			entry.elapsedMs = result.elapsedMs ?? null;
+			entry.error = result.error || null;
+			entry.tcp = await probeTcp(host, port, 1000);
+		}
+		entries.push(entry);
+	}
+
+	return { origin, paths: entries };
+}
+
+module.exports = {
+	DEFAULT_READINESS_PATH,
+	DEFAULT_DIAGNOSTIC_PATHS,
+	waitForWordPressReady,
+	probeWordPressDiagnostics,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -5,10 +5,12 @@
   "main": "index.js",
   "exports": {
     ".": "./index.js",
+    "./playground-readiness": "./lib/playground-readiness.js",
     "./request-profiler": "./lib/request-profiler.js"
   },
   "scripts": {
     "lint:js": "eslint --ext .js,.jsx,.ts,.tsx",
+    "test:playground-readiness": "node tests/playground-readiness-smoke.js",
     "test:request-profiler": "node tests/request-profiler-smoke.js"
   },
   "devDependencies": {

--- a/wordpress/tests/playground-readiness-smoke.js
+++ b/wordpress/tests/playground-readiness-smoke.js
@@ -1,0 +1,207 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { EventEmitter } = require('node:events');
+
+const {
+	DEFAULT_READINESS_PATH,
+	DEFAULT_DIAGNOSTIC_PATHS,
+	waitForWordPressReady,
+	probeWordPressDiagnostics,
+} = require('../lib/playground-readiness');
+
+function startServer(handler) {
+	return new Promise((resolve) => {
+		const server = http.createServer(handler);
+		server.listen(0, '127.0.0.1', () => {
+			const address = server.address();
+			resolve({ server, port: address.port, baseUrl: `http://127.0.0.1:${address.port}` });
+		});
+	});
+}
+
+function closeServer(server) {
+	return new Promise((resolve) => {
+		if (!server) return resolve();
+		server.close(() => resolve());
+		// Force any keep-alive sockets closed quickly.
+		if (typeof server.closeAllConnections === 'function') {
+			server.closeAllConnections();
+		}
+	});
+}
+
+async function scenarioSelfRedirectButWpJsonReady() {
+	const { server, baseUrl } = await startServer((req, res) => {
+		if (req.url === '/wp-json/') {
+			res.writeHead(200, { 'Content-Type': 'application/json' });
+			res.end('{"namespaces":[]}');
+			return;
+		}
+		// Self-redirect at root: would hang Node fetch. Helper must NOT follow.
+		res.writeHead(302, { Location: '/', 'Content-Type': 'text/plain' });
+		res.end('redirect');
+	});
+	try {
+		const result = await waitForWordPressReady(baseUrl, {
+			intervalMs: 50,
+			requestTimeoutMs: 1000,
+			timeoutMs: 5000,
+		});
+		assert.equal(result.status, 'ready', 'expected ready status');
+		assert.equal(result.http_status, 200);
+		assert.ok(result.url.endsWith(DEFAULT_READINESS_PATH), `url should end with ${DEFAULT_READINESS_PATH}, got ${result.url}`);
+		assert.ok(Array.isArray(result.status_history));
+		assert.ok(Array.isArray(result.redirect_history));
+		assert.ok(result.elapsedMs < 5000, 'should resolve well under timeout');
+	} finally {
+		await closeServer(server);
+	}
+}
+
+async function scenarioAlways503() {
+	const { server, baseUrl } = await startServer((req, res) => {
+		res.writeHead(503, { 'Content-Type': 'text/plain' });
+		res.end('service unavailable');
+	});
+	try {
+		let threw = false;
+		try {
+			await waitForWordPressReady(baseUrl, {
+				intervalMs: 50,
+				requestTimeoutMs: 500,
+				timeoutMs: 1500,
+				playgroundOutput: () => 'some captured stdout/stderr from playground process\n',
+			});
+		} catch (err) {
+			threw = true;
+			assert.ok(err instanceof Error);
+			assert.match(err.message, /Timed out waiting for/);
+			const diag = err.diagnostics;
+			assert.ok(diag, 'diagnostics must be attached');
+			assert.equal(diag.timeoutMs, 1500);
+			assert.ok(diag.attempts >= 1, 'should record at least one attempt');
+			assert.ok(diag.routes && Array.isArray(diag.routes.paths));
+			assert.equal(diag.routes.paths.length, DEFAULT_DIAGNOSTIC_PATHS.length);
+			assert.equal(diag.routes.paths.length, 4);
+			assert.ok(diag.tcp && diag.tcp.open === true, 'tcp probe should report open');
+			assert.equal(typeof diag.playgroundOutputTail, 'string');
+			assert.ok(diag.playgroundOutputTail.length > 0);
+			assert.equal(diag.playground, null);
+		}
+		assert.ok(threw, 'always-503 must throw');
+	} finally {
+		await closeServer(server);
+	}
+}
+
+async function scenarioProcessExitsMidPoll() {
+	// Server returns 503 forever so readiness never succeeds.
+	const { server, baseUrl } = await startServer((req, res) => {
+		res.writeHead(503, { 'Content-Type': 'text/plain' });
+		res.end('not ready');
+	});
+
+	const fakeChild = new EventEmitter();
+	fakeChild.pid = 99999;
+	fakeChild.exitCode = null;
+	fakeChild.signalCode = null;
+
+	const exitTimer = setTimeout(() => {
+		fakeChild.exitCode = 1;
+		fakeChild.signalCode = null;
+		fakeChild.emit('exit', 1, null);
+	}, 300);
+
+	try {
+		const result = await waitForWordPressReady(baseUrl, {
+			intervalMs: 100,
+			requestTimeoutMs: 500,
+			timeoutMs: 10000,
+			playgroundProcess: fakeChild,
+		});
+		assert.equal(result.status, 'process_exited');
+		assert.ok(result.playground);
+		assert.equal(result.playground.exitCode, 1);
+		assert.equal(result.playground.pid, 99999);
+		assert.equal(result.http_status, null);
+	} finally {
+		clearTimeout(exitTimer);
+		await closeServer(server);
+	}
+}
+
+async function scenarioDiagnosticsStandalone() {
+	const hits = Object.create(null);
+	const { server, baseUrl } = await startServer((req, res) => {
+		hits[req.url] = (hits[req.url] || 0) + 1;
+		if (req.url === '/') {
+			res.writeHead(302, { Location: '/', 'Content-Type': 'text/plain' });
+			res.end('redirect-loop');
+			return;
+		}
+		if (req.url === '/wp-login.php') {
+			res.writeHead(200, { 'Content-Type': 'text/html' });
+			res.end('<html><body>login form</body></html>');
+			return;
+		}
+		if (req.url === '/wp-json/') {
+			res.writeHead(200, { 'Content-Type': 'application/json' });
+			res.end('{"namespaces":[]}');
+			return;
+		}
+		if (req.url === '/wp-admin/') {
+			res.writeHead(302, { Location: '/wp-login.php', 'Content-Type': 'text/plain' });
+			res.end('redirect');
+			return;
+		}
+		res.writeHead(404);
+		res.end();
+	});
+
+	try {
+		const result = await probeWordPressDiagnostics(baseUrl, { requestTimeoutMs: 1000 });
+		assert.equal(result.paths.length, 4);
+
+		const byPath = Object.fromEntries(result.paths.map((entry) => [entry.path, entry]));
+
+		assert.equal(byPath['/'].status, 302);
+		assert.equal(byPath['/'].redirectLocation, '/');
+		assert.ok(byPath['/'].contentType && byPath['/'].contentType.includes('text/plain'));
+
+		assert.equal(byPath['/wp-login.php'].status, 200);
+		assert.equal(byPath['/wp-login.php'].redirectLocation, null);
+		assert.ok(byPath['/wp-login.php'].contentType && byPath['/wp-login.php'].contentType.includes('text/html'));
+
+		assert.equal(byPath['/wp-json/'].status, 200);
+		assert.equal(byPath['/wp-json/'].redirectLocation, null);
+
+		assert.equal(byPath['/wp-admin/'].status, 302);
+		assert.equal(byPath['/wp-admin/'].redirectLocation, '/wp-login.php');
+
+		for (const entry of result.paths) {
+			assert.ok(typeof entry.bodyPreview === 'string', 'bodyPreview must be a string');
+			assert.ok(entry.bodyPreview.length <= 500, 'bodyPreview must be <=500 chars');
+			assert.equal(entry.error, undefined, `unexpected error on ${entry.path}`);
+		}
+
+		// Each diagnostic path must have been hit exactly once: no redirect-following.
+		for (const probePath of DEFAULT_DIAGNOSTIC_PATHS) {
+			assert.equal(hits[probePath], 1, `path ${probePath} should be hit exactly once, got ${hits[probePath]}`);
+		}
+	} finally {
+		await closeServer(server);
+	}
+}
+
+(async () => {
+	await scenarioSelfRedirectButWpJsonReady();
+	await scenarioAlways503();
+	await scenarioProcessExitsMidPoll();
+	await scenarioDiagnosticsStandalone();
+	console.log('Playground readiness smoke passed.');
+})().catch((err) => {
+	console.error(err && err.stack ? err.stack : err);
+	process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- `wp-playground-cli` returns `302 Location: /` on `/`, which hangs Node's `fetch()` in a follow-redirect loop. Callers that wait for readiness against `/` lock up until the abort signal fires; callers that poll `/wp-json/` get a clean `200`.
- Adds `lib/playground-readiness.js` (CommonJS, no deps) exporting `waitForWordPressReady` and `probeWordPressDiagnostics`. Uses `node:http` / `node:https` directly with manual redirect handling, defaults to polling `/wp-json/`, attaches a structured diagnostics artifact on timeout, and short-circuits when a supplied Playground child process exits.
- Adds a pure-Node smoke (no Playground required), wires the export + self-checks, and documents the helper alongside the existing browser-target handoff in `docs/TESTING.md`.

## Boundary

This lives in `wordpress/` (alongside `lib/request-profiler.js`) because the WP-shaped readiness paths and Playground self-redirect quirk are WordPress-domain knowledge. The generic `nodejs/scripts/trace/lib/probes.mjs` `pollHttp` stays generic — the small subset of HTTP polling logic is duplicated rather than cross-imported, keeping the two extensions decoupled.

## Tests

- Self-redirect at `/` but `/wp-json/` 200 — helper resolves `ready` against `/wp-json/`, never gets stuck following the self-redirect, and finishes well under the timeout. Critical regression for the bug.
- Always-503 — helper rejects with a `Timed out waiting for ...` error whose `.diagnostics` populates `routes` (4 entries), `tcp.open === true`, `playgroundOutputTail`, and `attempts >= 1`.
- Process exits mid-poll — fake `EventEmitter` child sets `exitCode = 1` after ~300ms; helper resolves `process_exited` with `playground.exitCode === 1` and never throws.
- `probeWordPressDiagnostics` standalone — distinct shapes per path, `redirectLocation` populated where expected, `bodyPreview` truncated to <=500 chars, and a per-path counter confirms each path was hit exactly once (no redirect-following).

Verified locally:

```
node --check index.js lib/request-profiler.js lib/playground-readiness.js \
  tests/request-profiler-smoke.js tests/playground-readiness-smoke.js
node tests/request-profiler-smoke.js
node tests/playground-readiness-smoke.js   # ~1.8s
jq empty wordpress.json homeboy.json package.json
bash -n scripts/test/test-runner.sh
```

All pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode (Claude Sonnet 4.5)
- **Used for:** Drafted the helper, smoke test, and docs from a planned spec; Chris reviewed and tested.

Closes #449