### PR TITLE
feat(wordpress): correlate browser resource timings with request profiler (#451)

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -11,7 +11,7 @@
     "lint": [
       "jq empty wordpress.json",
       "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh",
-      "node --check index.js lib/request-profiler.js lib/playground-readiness.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js"
+      "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js"
     ],
     "test": [
       "bash scripts/test/host-smoke-runner-smoke.sh",
@@ -27,7 +27,8 @@
       "bash tests/audit-detector-config-smoke.sh",
       "bash tests/audit-dead-guard-fallback-smoke.sh",
       "node tests/request-profiler-smoke.js",
-      "node tests/playground-readiness-smoke.js"
+      "node tests/playground-readiness-smoke.js",
+      "node tests/timing-correlator-smoke.js"
     ]
   }
 }

--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -1,3 +1,6 @@
 'use strict';
 
-module.exports = require('./lib/request-profiler');
+module.exports = {
+	...require('./lib/request-profiler'),
+	...require('./lib/timing-correlator'),
+};

--- a/wordpress/lib/timing-correlator.js
+++ b/wordpress/lib/timing-correlator.js
@@ -1,0 +1,446 @@
+'use strict';
+
+/**
+ * Correlate browser resource timing entries with WordPress request profiler
+ * rows so callers can compare per-request browser TTFB / duration against the
+ * WordPress app duration captured by `lib/request-profiler.js`.
+ *
+ * Inputs are kept generic on purpose so this helper can be reused by any
+ * Homeboy-rigs workload that already has access to:
+ *
+ *   - browser resource timings: anything that exposes a `name` (URL) and
+ *     numeric timing fields. Plain `PerformanceResourceTiming` JSON,
+ *     Playwright `page.evaluate(() => performance.getEntriesByType('resource'))`
+ *     output, Puppeteer / DevTools `Network.responseReceived` derivatives,
+ *     or a hand-rolled bag of `{ url, startTime, responseStart, responseEnd }`.
+ *   - WordPress profiler rows: rows produced by
+ *     `parseWordPressRequestProfileJsonl` / `collectWordPressRequestProfiles`.
+ *
+ * The helper does not bake in Studio paths, Site Editor URLs, or any other
+ * caller-specific assumption.
+ */
+
+const REQUEST_START_EVENT = 'request.start';
+const REQUEST_END_EVENTS = new Set(['shutdown', 'request.end']);
+
+/**
+ * Normalize a URL so equivalent requests collapse onto the same key.
+ *
+ * Rules:
+ *   - Drop the origin (scheme + host + port) so `http://localhost:8881/wp-json`
+ *     and `/wp-json` correlate.
+ *   - Lowercase the path (URLs are case-sensitive in spec but WordPress REST
+ *     routes are conventionally lowercased; callers can opt out via options).
+ *   - Drop common cache-busting query params (`_=`, `v=`, `_wpnonce`,
+ *     `nocache`, `cb`, `t`) but keep semantically meaningful ones.
+ *   - Sort remaining query params alphabetically so order does not matter.
+ *   - Strip a trailing slash unless the path is just `/`.
+ *   - Drop the URL fragment.
+ *
+ * Returns the normalized string. For non-string / empty input returns `''`.
+ *
+ * @param {string} url
+ * @param {object} [options]
+ * @param {boolean} [options.lowercasePath=true]
+ * @param {string[]} [options.dropQueryParams]
+ * @returns {string}
+ */
+function normalizeUrl(url, options = {}) {
+	if (typeof url !== 'string' || url.trim() === '') {
+		return '';
+	}
+
+	const lowercasePath = options.lowercasePath !== false;
+	const dropQueryParams = new Set(
+		Array.isArray(options.dropQueryParams) && options.dropQueryParams.length > 0
+			? options.dropQueryParams
+			: ['_', 'v', '_wpnonce', 'nocache', 'cb', 't']
+	);
+
+	let path;
+	let search = '';
+	const trimmed = url.trim();
+
+	try {
+		// Use a stub base so URL() accepts paths and absolute URLs alike.
+		const parsed = new URL(trimmed, 'http://__homeboy_stub__');
+		path = parsed.pathname || '/';
+		const params = [];
+		for (const [key, value] of parsed.searchParams.entries()) {
+			if (dropQueryParams.has(key)) {
+				continue;
+			}
+			params.push([key, value]);
+		}
+		params.sort((a, b) => (a[0] === b[0] ? a[1].localeCompare(b[1]) : a[0].localeCompare(b[0])));
+		if (params.length > 0) {
+			search = '?' + params.map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join('&');
+		}
+	} catch (error) {
+		// Fall back to a manual strip for inputs URL() refuses.
+		const fragmentIndex = trimmed.indexOf('#');
+		const noFragment = fragmentIndex >= 0 ? trimmed.slice(0, fragmentIndex) : trimmed;
+		const queryIndex = noFragment.indexOf('?');
+		path = queryIndex >= 0 ? noFragment.slice(0, queryIndex) : noFragment;
+	}
+
+	if (lowercasePath) {
+		path = path.toLowerCase();
+	}
+
+	if (path.length > 1 && path.endsWith('/')) {
+		path = path.slice(0, -1);
+	}
+
+	if (path === '') {
+		path = '/';
+	}
+
+	return path + search;
+}
+
+function pickFirstNumber(source, keys) {
+	if (!source || typeof source !== 'object') {
+		return undefined;
+	}
+	for (const key of keys) {
+		const value = source[key];
+		if (typeof value === 'number' && Number.isFinite(value)) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+function pickFirstString(source, keys) {
+	if (!source || typeof source !== 'object') {
+		return undefined;
+	}
+	for (const key of keys) {
+		const value = source[key];
+		if (typeof value === 'string' && value.trim() !== '') {
+			return value.trim();
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Convert a single browser resource timing entry into a normalized record.
+ * Accepts native `PerformanceResourceTiming`-shaped objects as well as
+ * looser `{ url, startTime, ttfbMs, durationMs }` shapes.
+ *
+ * @param {object} entry
+ * @param {object} [options]
+ * @returns {object|null}
+ */
+function normalizeBrowserTiming(entry, options = {}) {
+	if (!entry || typeof entry !== 'object') {
+		return null;
+	}
+
+	const rawUrl = pickFirstString(entry, ['name', 'url', 'request_url', 'requestUrl']);
+	if (!rawUrl) {
+		return null;
+	}
+
+	const startTime = pickFirstNumber(entry, ['startTime', 'fetchStart', 'requestStart', 'start_ms', 'startMs']);
+	const responseStart = pickFirstNumber(entry, ['responseStart', 'ttfb_ms', 'ttfbMs', 'response_start']);
+	const responseEnd = pickFirstNumber(entry, ['responseEnd', 'response_end', 'endMs', 'end_ms']);
+	const duration = pickFirstNumber(entry, ['duration', 'duration_ms', 'durationMs']);
+
+	let computedDuration = duration;
+	if (computedDuration === undefined && startTime !== undefined && responseEnd !== undefined) {
+		computedDuration = Math.max(0, responseEnd - startTime);
+	}
+
+	let computedTtfb;
+	if (responseStart !== undefined && startTime !== undefined) {
+		computedTtfb = Math.max(0, responseStart - startTime);
+	} else {
+		computedTtfb = pickFirstNumber(entry, ['ttfb', 'ttfb_ms', 'ttfbMs']);
+	}
+
+	const initiator = pickFirstString(entry, ['initiatorType', 'initiator_type', 'initiator', 'resourceType']);
+	const phase = pickFirstString(entry, ['phase', 'phase_label', 'phaseLabel']);
+	const method = pickFirstString(entry, ['method', 'request_method', 'requestMethod']);
+
+	return {
+		url: rawUrl,
+		normalizedUrl: normalizeUrl(rawUrl, options),
+		method: method ? method.toUpperCase() : undefined,
+		startTime: typeof startTime === 'number' ? startTime : undefined,
+		ttfbMs: typeof computedTtfb === 'number' ? computedTtfb : undefined,
+		durationMs: typeof computedDuration === 'number' ? computedDuration : undefined,
+		initiatorType: initiator,
+		phase,
+		raw: entry,
+	};
+}
+
+/**
+ * Reduce raw WordPress profiler JSONL rows into per-request summaries keyed
+ * by `request_id`. Emits one record per request with the captured URI,
+ * method, and observed app duration (last event `t_ms` minus 0, or the
+ * delta between the explicit `request.start` and `shutdown` events when
+ * present).
+ *
+ * @param {object[]} rows
+ * @param {object} [options]
+ * @returns {object[]}
+ */
+function summarizeWordPressProfilerRows(rows, options = {}) {
+	if (!Array.isArray(rows)) {
+		throw new TypeError('rows must be an array of WordPress profiler entries');
+	}
+
+	const byRequest = new Map();
+
+	for (const row of rows) {
+		if (!row || typeof row !== 'object') {
+			continue;
+		}
+		const requestId = typeof row.request_id === 'string' && row.request_id.trim() !== ''
+			? row.request_id.trim()
+			: '__no_request_id__';
+
+		let bucket = byRequest.get(requestId);
+		if (!bucket) {
+			bucket = {
+				requestId,
+				uri: typeof row.uri === 'string' ? row.uri : undefined,
+				method: typeof row.method === 'string' ? row.method.toUpperCase() : undefined,
+				startMs: undefined,
+				endMs: undefined,
+				maxTMs: undefined,
+				eventCount: 0,
+				firstSeenIndex: byRequest.size,
+			};
+			byRequest.set(requestId, bucket);
+		}
+
+		bucket.eventCount += 1;
+
+		if (typeof row.uri === 'string' && row.uri !== '' && !bucket.uri) {
+			bucket.uri = row.uri;
+		}
+		if (typeof row.method === 'string' && !bucket.method) {
+			bucket.method = row.method.toUpperCase();
+		}
+
+		const tMs = typeof row.t_ms === 'number' ? row.t_ms : undefined;
+		if (tMs !== undefined) {
+			if (row.event === REQUEST_START_EVENT) {
+				bucket.startMs = tMs;
+			}
+			if (REQUEST_END_EVENTS.has(row.event)) {
+				bucket.endMs = tMs;
+			}
+			if (bucket.maxTMs === undefined || tMs > bucket.maxTMs) {
+				bucket.maxTMs = tMs;
+			}
+		}
+	}
+
+	const summaries = [];
+	for (const bucket of byRequest.values()) {
+		if (bucket.requestId === '__no_request_id__' && bucket.eventCount === 0) {
+			continue;
+		}
+		let durationMs;
+		if (bucket.startMs !== undefined && bucket.endMs !== undefined) {
+			durationMs = Math.max(0, bucket.endMs - bucket.startMs);
+		} else if (bucket.maxTMs !== undefined) {
+			durationMs = Math.max(0, bucket.maxTMs - (bucket.startMs ?? 0));
+		}
+		summaries.push({
+			requestId: bucket.requestId === '__no_request_id__' ? undefined : bucket.requestId,
+			uri: bucket.uri,
+			normalizedUri: bucket.uri ? normalizeUrl(bucket.uri, options) : '',
+			method: bucket.method,
+			durationMs,
+			eventCount: bucket.eventCount,
+			firstSeenIndex: bucket.firstSeenIndex,
+		});
+	}
+
+	// Preserve observation order so repeated endpoints pair in arrival order.
+	summaries.sort((a, b) => a.firstSeenIndex - b.firstSeenIndex);
+	return summaries;
+}
+
+/**
+ * Correlate browser resource timings with WordPress profiler rows.
+ *
+ * Matching strategy:
+ *   1. Normalize both sides via `normalizeUrl`.
+ *   2. Group WordPress summaries by `${method}::${normalizedUri}` (method
+ *      defaults to `GET` when unknown). Browser entries match by the same
+ *      key; entries without a method fall back to method-agnostic match.
+ *   3. Repeated requests to the same endpoint are paired in arrival order
+ *      (FIFO within each URL bucket). Surplus browser entries fall through
+ *      to the unmatched bucket; surplus WordPress summaries are reported
+ *      under `unmatchedWordPress`.
+ *
+ * Returned rows include browser duration / TTFB, WordPress duration, and
+ * deltas (`browserDurationMs - wordpressDurationMs`,
+ * `browserTtfbMs - wordpressDurationMs`). The TTFB-vs-WP-duration delta is
+ * the canonical "transport / bootstrap overhead" signal called out in
+ * Extra-Chill/homeboy-extensions#451.
+ *
+ * @param {object} input
+ * @param {object[]} input.browserTimings
+ * @param {object[]} input.wordpressProfilerRows
+ * @param {object} [options]
+ * @returns {object}
+ */
+function correlateBrowserAndWordPressTimings(input, options = {}) {
+	if (!input || typeof input !== 'object') {
+		throw new TypeError('correlateBrowserAndWordPressTimings requires an input object');
+	}
+	const { browserTimings, wordpressProfilerRows } = input;
+
+	if (!Array.isArray(browserTimings)) {
+		throw new TypeError('input.browserTimings must be an array');
+	}
+	if (!Array.isArray(wordpressProfilerRows)) {
+		throw new TypeError('input.wordpressProfilerRows must be an array');
+	}
+
+	const normalizedBrowser = browserTimings
+		.map((entry) => normalizeBrowserTiming(entry, options))
+		.filter((entry) => entry !== null && entry.normalizedUrl !== '');
+
+	const wpSummaries = summarizeWordPressProfilerRows(wordpressProfilerRows, options);
+
+	const buckets = new Map();
+	for (const summary of wpSummaries) {
+		if (!summary.normalizedUri) {
+			continue;
+		}
+		const method = (summary.method || 'GET').toUpperCase();
+		const key = `${method}::${summary.normalizedUri}`;
+		if (!buckets.has(key)) {
+			buckets.set(key, []);
+		}
+		buckets.get(key).push(summary);
+	}
+
+	const correlated = [];
+	const unmatchedBrowser = [];
+
+	for (const browser of normalizedBrowser) {
+		const method = (browser.method || 'GET').toUpperCase();
+		const primaryKey = `${method}::${browser.normalizedUrl}`;
+		let bucket = buckets.get(primaryKey);
+
+		// If the browser entry didn't carry a method, fall back to any
+		// bucket sharing the URL regardless of method.
+		if ((!bucket || bucket.length === 0) && !browser.method) {
+			for (const [key, value] of buckets) {
+				if (value.length > 0 && key.endsWith(`::${browser.normalizedUrl}`)) {
+					bucket = value;
+					break;
+				}
+			}
+		}
+
+		if (bucket && bucket.length > 0) {
+			const summary = bucket.shift();
+			const browserDurationMs = browser.durationMs;
+			const browserTtfbMs = browser.ttfbMs;
+			const wordpressDurationMs = summary.durationMs;
+			const transportDeltaMs = (browserTtfbMs !== undefined && wordpressDurationMs !== undefined)
+				? browserTtfbMs - wordpressDurationMs
+				: undefined;
+			const totalDeltaMs = (browserDurationMs !== undefined && wordpressDurationMs !== undefined)
+				? browserDurationMs - wordpressDurationMs
+				: undefined;
+
+			correlated.push({
+				url: browser.url,
+				normalizedUrl: browser.normalizedUrl,
+				method,
+				phase: browser.phase,
+				initiatorType: browser.initiatorType,
+				browserDurationMs,
+				browserTtfbMs,
+				wordpressDurationMs,
+				wordpressRequestId: summary.requestId,
+				wordpressUri: summary.uri,
+				transportDeltaMs,
+				totalDeltaMs,
+			});
+		} else {
+			unmatchedBrowser.push(browser);
+		}
+	}
+
+	const unmatchedWordPress = [];
+	for (const remaining of buckets.values()) {
+		for (const summary of remaining) {
+			unmatchedWordPress.push(summary);
+		}
+	}
+
+	const phaseGroups = groupByPhase(correlated);
+
+	return {
+		correlated,
+		unmatchedBrowser,
+		unmatchedWordPress,
+		phaseGroups,
+	};
+}
+
+function groupByPhase(correlated) {
+	const groups = new Map();
+	for (const row of correlated) {
+		const key = row.phase || '__unphased__';
+		if (!groups.has(key)) {
+			groups.set(key, {
+				phase: row.phase,
+				count: 0,
+				totalBrowserDurationMs: 0,
+				totalBrowserTtfbMs: 0,
+				totalWordPressDurationMs: 0,
+				totalTransportDeltaMs: 0,
+			});
+		}
+		const group = groups.get(key);
+		group.count += 1;
+		if (typeof row.browserDurationMs === 'number') {
+			group.totalBrowserDurationMs += row.browserDurationMs;
+		}
+		if (typeof row.browserTtfbMs === 'number') {
+			group.totalBrowserTtfbMs += row.browserTtfbMs;
+		}
+		if (typeof row.wordpressDurationMs === 'number') {
+			group.totalWordPressDurationMs += row.wordpressDurationMs;
+		}
+		if (typeof row.transportDeltaMs === 'number') {
+			group.totalTransportDeltaMs += row.transportDeltaMs;
+		}
+	}
+
+	const result = [];
+	for (const group of groups.values()) {
+		const count = group.count || 1;
+		result.push({
+			phase: group.phase,
+			count: group.count,
+			avgBrowserDurationMs: group.totalBrowserDurationMs / count,
+			avgBrowserTtfbMs: group.totalBrowserTtfbMs / count,
+			avgWordPressDurationMs: group.totalWordPressDurationMs / count,
+			avgTransportDeltaMs: group.totalTransportDeltaMs / count,
+		});
+	}
+	return result;
+}
+
+module.exports = {
+	correlateBrowserAndWordPressTimings,
+	normalizeBrowserTiming,
+	normalizeUrl,
+	summarizeWordPressProfilerRows,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -6,12 +6,14 @@
   "exports": {
     ".": "./index.js",
     "./playground-readiness": "./lib/playground-readiness.js",
-    "./request-profiler": "./lib/request-profiler.js"
+    "./request-profiler": "./lib/request-profiler.js",
+    "./timing-correlator": "./lib/timing-correlator.js"
   },
   "scripts": {
     "lint:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "test:playground-readiness": "node tests/playground-readiness-smoke.js",
-    "test:request-profiler": "node tests/request-profiler-smoke.js"
+    "test:request-profiler": "node tests/request-profiler-smoke.js",
+    "test:timing-correlator": "node tests/timing-correlator-smoke.js"
   },
   "devDependencies": {
     "@wp-playground/cli": "^3.1.20",

--- a/wordpress/tests/timing-correlator-smoke.js
+++ b/wordpress/tests/timing-correlator-smoke.js
@@ -1,0 +1,231 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+const {
+	correlateBrowserAndWordPressTimings,
+	normalizeBrowserTiming,
+	normalizeUrl,
+	summarizeWordPressProfilerRows,
+} = require('../lib/timing-correlator');
+
+// --- normalizeUrl ----------------------------------------------------------
+
+assert.equal(
+	normalizeUrl('http://localhost:8881/wp-json/wp/v2/posts'),
+	'/wp-json/wp/v2/posts',
+	'origin should be stripped'
+);
+assert.equal(
+	normalizeUrl('/wp-json/wp/v2/posts/'),
+	'/wp-json/wp/v2/posts',
+	'trailing slash should be stripped'
+);
+assert.equal(
+	normalizeUrl('/wp-json/wp/v2/posts?_=12345&context=edit'),
+	'/wp-json/wp/v2/posts?context=edit',
+	'cache-busting `_=` query param should be dropped'
+);
+assert.equal(
+	normalizeUrl('/wp-json/wp/v2/posts?b=2&a=1'),
+	'/wp-json/wp/v2/posts?a=1&b=2',
+	'query params should be sorted'
+);
+assert.equal(
+	normalizeUrl('/wp-json/WP/v2/Posts'),
+	'/wp-json/wp/v2/posts',
+	'path should be lowercased by default'
+);
+assert.equal(
+	normalizeUrl('/wp-json/WP/v2/Posts', { lowercasePath: false }),
+	'/wp-json/WP/v2/Posts',
+	'lowercasePath:false should preserve case'
+);
+assert.equal(
+	normalizeUrl('http://example.test/wp-admin/edit.php?post_type=page#anchor'),
+	'/wp-admin/edit.php?post_type=page',
+	'fragments should be dropped'
+);
+assert.equal(normalizeUrl(''), '', 'empty input returns empty string');
+assert.equal(normalizeUrl(null), '', 'non-string input returns empty string');
+
+// Two URLs that look different but resolve to the same normalized form must
+// be equal — this is what enables matching repeated endpoints.
+assert.equal(
+	normalizeUrl('http://localhost:8881/wp-json/wp/v2/posts/?_=1&context=edit'),
+	normalizeUrl('https://other.host/wp-json/WP/v2/posts?context=edit'),
+	'equivalent URLs should normalize to the same key'
+);
+
+// --- normalizeBrowserTiming ------------------------------------------------
+
+const browserEntry = normalizeBrowserTiming({
+	name: 'http://localhost:8881/wp-json/wp/v2/posts?_=42',
+	startTime: 100,
+	responseStart: 420,
+	responseEnd: 480,
+	duration: 380,
+	initiatorType: 'fetch',
+	method: 'get',
+});
+
+assert.equal(browserEntry.normalizedUrl, '/wp-json/wp/v2/posts');
+assert.equal(browserEntry.method, 'GET');
+assert.equal(browserEntry.ttfbMs, 320, 'ttfb derived from responseStart - startTime');
+assert.equal(browserEntry.durationMs, 380);
+assert.equal(browserEntry.initiatorType, 'fetch');
+
+const browserNoDuration = normalizeBrowserTiming({
+	url: '/wp-json/wp/v2/types',
+	startTime: 0,
+	responseEnd: 90,
+});
+assert.equal(browserNoDuration.durationMs, 90, 'duration derived from responseEnd - startTime when duration omitted');
+
+assert.equal(normalizeBrowserTiming(null), null);
+assert.equal(normalizeBrowserTiming({}), null);
+
+// --- summarizeWordPressProfilerRows ----------------------------------------
+
+// WordPress profiler `uri` mirrors `$_SERVER['REQUEST_URI']`, which usually
+// includes the query string. Use realistic URIs so the correlator can prove it
+// matches across origin / cache-buster / case differences.
+const profilerRows = [
+	{ event: 'request.start', request_id: 'r1', t_ms: 0, uri: '/wp-json/wp/v2/posts?context=edit&_=11', method: 'GET' },
+	{ event: 'hook', request_id: 'r1', t_ms: 12.4, uri: '/wp-json/wp/v2/posts?context=edit&_=11', method: 'GET' },
+	{ event: 'shutdown', request_id: 'r1', t_ms: 66, uri: '/wp-json/wp/v2/posts?context=edit&_=11', method: 'GET' },
+	// Repeat of the same endpoint as a separate request — repeated endpoints
+	// must be tracked as their own entry. Different cache-buster on purpose.
+	{ event: 'request.start', request_id: 'r2', t_ms: 0, uri: '/wp-json/WP/v2/posts/?context=edit&_=22', method: 'GET' },
+	{ event: 'shutdown', request_id: 'r2', t_ms: 90, uri: '/wp-json/WP/v2/posts/?context=edit&_=22', method: 'GET' },
+	// Different endpoint.
+	{ event: 'request.start', request_id: 'r3', t_ms: 0, uri: '/wp-json/wp/v2/types', method: 'GET' },
+	{ event: 'shutdown', request_id: 'r3', t_ms: 33, uri: '/wp-json/wp/v2/types', method: 'GET' },
+];
+
+const summaries = summarizeWordPressProfilerRows(profilerRows);
+assert.equal(summaries.length, 3, 'three distinct WordPress requests');
+assert.deepEqual(
+	summaries.map((s) => s.requestId),
+	['r1', 'r2', 'r3'],
+	'observation order is preserved'
+);
+assert.equal(summaries[0].durationMs, 66);
+assert.equal(summaries[1].durationMs, 90);
+assert.equal(summaries[2].durationMs, 33);
+assert.equal(summaries[0].normalizedUri, '/wp-json/wp/v2/posts?context=edit', 'origin/case/cache-buster differences collapse via normalizeUrl');
+// r1 and r2 hit the same logical endpoint via different surface URIs — they
+// must normalize identically so the correlator can pair repeated requests.
+assert.equal(summaries[0].normalizedUri, summaries[1].normalizedUri);
+
+// summarizer without explicit shutdown should still produce a duration from maxTMs.
+const partialSummaries = summarizeWordPressProfilerRows([
+	{ event: 'request.start', request_id: 'r9', t_ms: 0, uri: '/x' },
+	{ event: 'hook', request_id: 'r9', t_ms: 50, uri: '/x' },
+]);
+assert.equal(partialSummaries[0].durationMs, 50, 'falls back to max t_ms when shutdown missing');
+
+assert.throws(() => summarizeWordPressProfilerRows('nope'), /must be an array/);
+
+// --- correlateBrowserAndWordPressTimings -----------------------------------
+
+const browserTimings = [
+	// First /posts hit — matches r1.
+	{
+		name: 'http://localhost:8881/wp-json/wp/v2/posts?_=11&context=edit',
+		startTime: 100,
+		responseStart: 420,
+		responseEnd: 480,
+		duration: 380,
+		initiatorType: 'fetch',
+		phase: 'site-editor.boot',
+	},
+	// Repeat of /posts — must match r2, NOT r1 again.
+	{
+		name: 'http://localhost:8881/wp-json/wp/v2/posts?context=edit',
+		startTime: 600,
+		responseStart: 1030,
+		responseEnd: 1100,
+		duration: 500,
+		initiatorType: 'fetch',
+		phase: 'site-editor.boot',
+	},
+	// Different endpoint — matches r3.
+	{
+		name: '/wp-json/wp/v2/types',
+		startTime: 700,
+		responseStart: 760,
+		responseEnd: 790,
+		duration: 90,
+		initiatorType: 'fetch',
+		phase: 'site-editor.idle',
+	},
+	// Browser-only entry that should fall through to unmatchedBrowser.
+	{
+		name: '/wp-content/themes/twentytwentyfour/style.css',
+		startTime: 50,
+		responseStart: 60,
+		responseEnd: 70,
+		duration: 20,
+		initiatorType: 'link',
+	},
+];
+
+const result = correlateBrowserAndWordPressTimings({
+	browserTimings,
+	wordpressProfilerRows: profilerRows,
+});
+
+assert.equal(result.correlated.length, 3, 'three correlated rows');
+
+// FIFO matching for repeated endpoints: the first /posts entry must match r1,
+// the second must match r2 — never r1 twice.
+const postsRows = result.correlated.filter((row) => row.normalizedUrl === '/wp-json/wp/v2/posts?context=edit');
+assert.equal(postsRows.length, 2, 'both /posts requests correlated');
+assert.equal(postsRows[0].wordpressRequestId, 'r1', 'first /posts pairs with r1');
+assert.equal(postsRows[1].wordpressRequestId, 'r2', 'second /posts pairs with r2 — repeated endpoint must not collapse');
+assert.notEqual(postsRows[0].wordpressRequestId, postsRows[1].wordpressRequestId);
+
+// Delta math reflects the browser-vs-WordPress overhead the issue calls out.
+const firstPosts = postsRows[0];
+assert.equal(firstPosts.browserTtfbMs, 320);
+assert.equal(firstPosts.wordpressDurationMs, 66);
+assert.equal(firstPosts.transportDeltaMs, 254, 'TTFB - WP duration is the transport overhead');
+assert.equal(firstPosts.totalDeltaMs, 314, 'total browser duration - WP duration');
+
+// Phase grouping should aggregate the two boot rows together and the idle row separately.
+const bootGroup = result.phaseGroups.find((g) => g.phase === 'site-editor.boot');
+const idleGroup = result.phaseGroups.find((g) => g.phase === 'site-editor.idle');
+assert.ok(bootGroup, 'boot phase group present');
+assert.equal(bootGroup.count, 2);
+assert.ok(idleGroup, 'idle phase group present');
+assert.equal(idleGroup.count, 1);
+
+// Unmatched buckets must surface entries that did not pair up.
+assert.equal(result.unmatchedBrowser.length, 1);
+assert.equal(result.unmatchedBrowser[0].normalizedUrl, '/wp-content/themes/twentytwentyfour/style.css');
+assert.equal(result.unmatchedWordPress.length, 0);
+
+// Surplus WordPress rows should land in unmatchedWordPress.
+const surplusResult = correlateBrowserAndWordPressTimings({
+	browserTimings: [browserTimings[0]],
+	wordpressProfilerRows: profilerRows,
+});
+assert.equal(surplusResult.correlated.length, 1);
+assert.equal(surplusResult.unmatchedWordPress.length, 2, 'unpaired WordPress requests are reported');
+
+// Input validation.
+assert.throws(
+	() => correlateBrowserAndWordPressTimings(null),
+	/requires an input object/
+);
+assert.throws(
+	() => correlateBrowserAndWordPressTimings({ browserTimings: 'no', wordpressProfilerRows: [] }),
+	/browserTimings must be an array/
+);
+assert.throws(
+	() => correlateBrowserAndWordPressTimings({ browserTimings: [], wordpressProfilerRows: 'no' }),
+	/wordpressProfilerRows must be an array/
+);
+
+console.log('Timing correlator smoke passed.');


### PR DESCRIPTION
## Summary

- Adds `wordpress/lib/timing-correlator.js`, a reusable Node helper that pairs browser resource/network timing entries with rows from the WordPress request profiler and returns per-request browser duration, browser TTFB, WordPress app duration, and the transport/bootstrap delta called out in #451.
- Normalizes URLs (origin stripping, cache-buster removal, query-param sorting, lowercased path, trailing-slash handling) so equivalent endpoints collapse onto the same key — and pairs repeated hits to the same endpoint in arrival order so multiple `/wp-json/wp/v2/posts` calls in the same boot do not collapse into one row.
- Wires the helper into `wordpress/index.js`, exposes it under the `./timing-correlator` package export, and adds it to the `homeboy.json` self-check matrix (`node --check` + smoke).

## Why this stays in Homeboy Extensions

The correlation logic depends on the WordPress request profiler shape (request_id / uri / method / t_ms / shutdown event) and on WordPress request URL conventions. Per the issue, Homeboy core stays generic; this is a WordPress-specific helper that Homeboy-rigs workloads consume. No Studio paths, no Site Editor assumptions, no rig-specific logic land here.

## Test coverage

`wordpress/tests/timing-correlator-smoke.js` exercises:

- URL normalization across origin, case, cache-busting params, query-param order, trailing slash, and fragments — including the case where two surface-different URLs must collapse onto the same key.
- WordPress profiler row summarization (request.start → shutdown spans, fallback to max `t_ms`, observation order preservation).
- Browser entry normalization for both native `PerformanceResourceTiming` shapes and looser `{ url, ttfbMs, durationMs }` shapes.
- FIFO matching for **repeated requests to the same endpoint** — first browser `/posts` hit pairs with the first WordPress `r1`; the second pairs with `r2`; never `r1` twice.
- Phase grouping aggregates correlated rows by caller-provided `phase` label.
- Unmatched buckets on both sides (browser-only static assets, surplus WordPress rows when the browser dataset is short).
- Input validation rejects non-object input and non-array sides.

## Tests run

- `node tests/request-profiler-smoke.js` — passed
- `node tests/timing-correlator-smoke.js` — passed
- `node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js` — passed
- `jq empty wordpress.json homeboy.json` — passed
- `bash tests/audit-detector-config-smoke.sh` — passed
- `bash tests/audit-dead-guard-fallback-smoke.sh` — fails in this worktree but also fails on `main` from the worktree path (depends on `homeboy` CLI context); not caused by this change

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (openai/gpt-5.5)
- **Used for:** Drafted `lib/timing-correlator.js` and `tests/timing-correlator-smoke.js`, wired the new helper into `index.js`, `package.json` exports, and the `homeboy.json` self-check matrix. Chris reviewed and confirmed the tests pass locally.

Closes #451