### PR TITLE
fix(wordpress): allow Playground login self-redirect readiness

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -394,8 +394,8 @@ are WordPress-domain knowledge.
 ### `waitForWordPressReady(baseUrl, options)`
 
 Polls a single readiness path until it returns a ready status, then resolves
-with `{ status: 'ready', url, http_status, status_history, redirect_history,
-elapsedMs }`. Resolves with `{ status: 'process_exited', ... }` if the
+with `{ status: 'ready', url, http_status, ready_reason, status_history,
+redirect_history, elapsedMs }`. Resolves with `{ status: 'process_exited', ... }` if the
 optional `playgroundProcess` exits before ready. Throws on timeout with a
 populated `.diagnostics` property.
 
@@ -405,6 +405,7 @@ Options:
 |---|---|---|
 | `path` | `/wp-json/` | Path to poll. Defaults to `/wp-json/` because `wp-playground-cli` returns `302 Location: /` on `/`, which hangs Node's `fetch()` in a self-redirect loop. The helper uses `http.request()` directly and never follows redirects. |
 | `readyStatus` | `200` | Single status or array of statuses considered ready. Strict by default; 3xx is not treated as ready. |
+| `readyOnSelfRedirect` | `false` | Treat a same-origin, same-path redirect as ready. Use this only for browser-driving flows such as `wp-playground-cli server --login`, where the CLI wrapper may return `302 Location: <same-path>` for every raw HTTP probe while Playwright browser navigation can still load the site. Keep this off for REST/load-test callers that require a real `200`. |
 | `intervalMs` | `1000` | Delay between poll attempts. |
 | `requestTimeoutMs` | `5000` | Per-request abort. |
 | `timeoutMs` | `120000` | Total budget before throwing. |
@@ -432,6 +433,13 @@ returns a clean `200 application/json` once WordPress has finished
 booting, with no redirect involved. The helper also uses
 `http.request()` rather than `fetch()` so even the `/` poll path stays
 single-attempt.
+
+When `wp-playground-cli server --login` is used, the CLI login wrapper may
+also return a same-path redirect for `/wp-json/` and other raw HTTP probes.
+Browser-based flows can pass `readyOnSelfRedirect: true` to treat that shape
+as server readiness before driving Playwright. The option is explicit so REST
+and load-test flows do not mistake a login wrapper redirect for a usable API
+response.
 
 ### Timeout artifact shape
 

--- a/wordpress/lib/playground-readiness.js
+++ b/wordpress/lib/playground-readiness.js
@@ -40,6 +40,19 @@ function isReadyStatus(status, readySet) {
 	return readySet.has(Number(status));
 }
 
+function isSelfRedirect(url, location) {
+	if (typeof location !== 'string' || location === '') {
+		return false;
+	}
+	try {
+		const current = new URL(url);
+		const target = new URL(location, current);
+		return target.origin === current.origin && target.pathname === current.pathname && target.search === current.search;
+	} catch (_) {
+		return false;
+	}
+}
+
 function recordHttpStatus(history, status) {
 	const normalized = Number(status);
 	const last = history.at(-1);
@@ -169,6 +182,7 @@ async function waitForWordPressReady(baseUrl, options = {}) {
 	const intervalMs = Number.isFinite(options.intervalMs) ? options.intervalMs : DEFAULT_INTERVAL_MS;
 	const requestTimeoutMs = Number.isFinite(options.requestTimeoutMs) ? options.requestTimeoutMs : DEFAULT_REQUEST_TIMEOUT_MS;
 	const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : DEFAULT_TIMEOUT_MS;
+	const readyOnSelfRedirect = options.readyOnSelfRedirect === true;
 	const onEvent = options.onEvent;
 	const child = options.playgroundProcess || null;
 	const playgroundOutput = typeof options.playgroundOutput === 'function' ? options.playgroundOutput : null;
@@ -222,17 +236,21 @@ async function waitForWordPressReady(baseUrl, options = {}) {
 			lastStatus = status;
 
 			const location = probe.headers && probe.headers.location;
+			const selfRedirect = isSelfRedirect(url, location);
 			if (status >= 300 && status < 400 && typeof location === 'string' && location !== '') {
-				redirectHistory.push({ from: url, status, location });
+				redirectHistory.push({ from: url, status, location, self: selfRedirect });
 				attemptRecord.redirect_location = location;
-				await emit(onEvent, 'http', 'http.redirect', { url, status, location });
+				attemptRecord.redirect_self = selfRedirect;
+				await emit(onEvent, 'http', 'http.redirect', { url, status, location, self: selfRedirect });
 			}
 
-			if (isReadyStatus(status, readySet)) {
+			if (isReadyStatus(status, readySet) || (readyOnSelfRedirect && selfRedirect)) {
 				const elapsedMs = Date.now() - startedAt;
+				const readyReason = isReadyStatus(status, readySet) ? 'status' : 'self_redirect';
 				await emit(onEvent, 'http', 'http.ready', {
 					url,
 					status,
+					ready_reason: readyReason,
 					elapsedMs,
 					status_history: statusHistory,
 					redirect_history: redirectHistory,
@@ -241,6 +259,7 @@ async function waitForWordPressReady(baseUrl, options = {}) {
 					status: 'ready',
 					url,
 					http_status: status,
+					ready_reason: readyReason,
 					status_history: statusHistory,
 					redirect_history: redirectHistory,
 					elapsedMs,

--- a/wordpress/tests/playground-readiness-smoke.js
+++ b/wordpress/tests/playground-readiness-smoke.js
@@ -96,6 +96,59 @@ async function scenarioAlways503() {
 	}
 }
 
+async function scenarioSelfRedirectReadyOptIn() {
+	const { server, baseUrl } = await startServer((req, res) => {
+		res.writeHead(302, { Location: req.url, 'Content-Type': 'text/plain' });
+		res.end('playground login redirect');
+	});
+	try {
+		const strictTimeout = await waitForWordPressReady(baseUrl, {
+			intervalMs: 50,
+			requestTimeoutMs: 500,
+			timeoutMs: 250,
+		}).then(
+			() => false,
+			(err) => /Timed out waiting for/.test(err.message)
+		);
+		assert.equal(strictTimeout, true, 'same-path redirects must not be ready unless the caller opts in');
+
+		const result = await waitForWordPressReady(baseUrl, {
+			intervalMs: 50,
+			requestTimeoutMs: 500,
+			timeoutMs: 1000,
+			readyOnSelfRedirect: true,
+		});
+		assert.equal(result.status, 'ready');
+		assert.equal(result.http_status, 302);
+		assert.equal(result.ready_reason, 'self_redirect');
+		assert.equal(result.redirect_history.length, 1);
+		assert.equal(result.redirect_history[0].self, true);
+	} finally {
+		await closeServer(server);
+	}
+}
+
+async function scenarioDifferentRedirectStillNotReady() {
+	const { server, baseUrl } = await startServer((req, res) => {
+		res.writeHead(302, { Location: '/wp-login.php', 'Content-Type': 'text/plain' });
+		res.end('not same path');
+	});
+	try {
+		const timedOut = await waitForWordPressReady(baseUrl, {
+			intervalMs: 50,
+			requestTimeoutMs: 500,
+			timeoutMs: 250,
+			readyOnSelfRedirect: true,
+		}).then(
+			() => false,
+			(err) => /Timed out waiting for/.test(err.message)
+		);
+		assert.equal(timedOut, true, 'redirects to a different path are not readiness');
+	} finally {
+		await closeServer(server);
+	}
+}
+
 async function scenarioProcessExitsMidPoll() {
 	// Server returns 503 forever so readiness never succeeds.
 	const { server, baseUrl } = await startServer((req, res) => {
@@ -198,6 +251,8 @@ async function scenarioDiagnosticsStandalone() {
 (async () => {
 	await scenarioSelfRedirectButWpJsonReady();
 	await scenarioAlways503();
+	await scenarioSelfRedirectReadyOptIn();
+	await scenarioDifferentRedirectStillNotReady();
 	await scenarioProcessExitsMidPoll();
 	await scenarioDiagnosticsStandalone();
 	console.log('Playground readiness smoke passed.');


### PR DESCRIPTION
## Summary

- Adds an explicit `readyOnSelfRedirect` option to the WordPress Playground readiness helper for browser-driving flows that use `wp-playground-cli server --login`.
- Keeps the default strict: redirects are not readiness unless the caller opts in, so REST/load-test consumers still require a real ready status.
- Records whether redirects are same-path/self redirects and returns `ready_reason: \"self_redirect\"` when the opt-in path is used.

## Why

`chubes4/wc-site-generator` visual parity adopted the helper from #450 and immediately exposed another Playground CLI shape: with `--login`, raw HTTP probes can return `302 Location: <same-path>` for `/`, `/wp-json/`, `/wp-login.php`, and `/wp-admin/`, while Playwright browser navigation still loads the frontend. The visual-parity caller needs to treat that as server readiness before taking screenshots, but that should remain explicit so API callers do not mistake a login wrapper redirect for a usable REST response.

## Verification

```bash
node --check lib/playground-readiness.js tests/playground-readiness-smoke.js
node tests/playground-readiness-smoke.js
```

Also verified locally from `wc-site-generator` against `marbling-bench` using the patched helper: visual parity completed and generated `source.png`, `imported.png`, `comparison.html`, and `summary.json`.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the helper option, smoke coverage, docs update, and downstream validation summary. Chris reviewed the direction and requested the upstream PR.