### PR TITLE
fix(wordpress): route bench dump_diagnostics to stderr so CI failures surface

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -551,20 +551,31 @@ rm -f "$BENCH_TMPFILE"
 
 dump_diagnostics() {
     local label="$1"
-    echo ""
-    echo "============================================"
-    echo "$label"
-    echo "============================================"
-    if [ -n "$BENCH_LOG" ]; then
+    # Write to stderr so the diagnostics survive homeboy core's CI bench
+    # progress mode, which calls the runner with `passthrough(false)` and
+    # `stderr_passthrough(false)` and only persists stderr in the failure
+    # envelope's `stderr_tail`. Echoing to stdout buried every Playground
+    # boot/workload failure inside the suppressed stdout buffer, which made
+    # `bench.json` show `failure.stderr_tail: ""` for every CI failure mode
+    # downstream of the Playground CLI invocation. Stderr is captured AND
+    # streamed to the GitHub Actions log, which is exactly what consumers
+    # of the bench JSON envelope expect for failure triage.
+    {
         echo ""
-        echo "--- Structured log ($RESULT_LOG) ---"
-        echo "$BENCH_LOG"
-    fi
-    if [ -n "$BENCH_STDOUT" ]; then
-        echo ""
-        echo "--- Playground stdout/stderr ---"
-        echo "$BENCH_STDOUT"
-    fi
+        echo "============================================"
+        echo "$label"
+        echo "============================================"
+        if [ -n "$BENCH_LOG" ]; then
+            echo ""
+            echo "--- Structured log ($RESULT_LOG) ---"
+            echo "$BENCH_LOG"
+        fi
+        if [ -n "$BENCH_STDOUT" ]; then
+            echo ""
+            echo "--- Playground stdout/stderr ---"
+            echo "$BENCH_STDOUT"
+        fi
+    } >&2
 }
 
 # Case 1: bootstrap failure captured in the structured log.


### PR DESCRIPTION
## Summary

`bench-runner-playground.sh::dump_diagnostics()` echoed every classified failure (BOOTSTRAP FAILURE / PHP CRASH / UNCLASSIFIED PLAYGROUND FAILURE / BENCH RUN COMPLETED BUT WROTE NO RESULTS) to **stdout**. After homeboy@f93de869 (\"feat: stream bench progress without stdout noise\") landed, the WordPress extension runner runs with `passthrough(false)` and `stderr_passthrough(false)` whenever `CI` is set — that's the default in GitHub Actions, GitLab CI, and most managed CI runners. In that mode stdout is captured but never streamed; stderr is captured AND surfaced through the bench JSON envelope as `failure.stderr_tail`.

Net effect on every CI bench failure downstream of the Playground CLI invocation:

- Nothing reaches the GitHub Actions log between the `Running:` banner and the JSON envelope.
- `bench.json` shows `failure.stderr_tail: \"\"`, so consumers (PR comments, finding-packet builders, downstream agents) have **zero failure context**.
- Triage requires reproducing the failure locally to see the diagnostics that should have been in the artifact.

This was the actual root cause of [chubes4/wc-site-generator#113](https://github.com/chubes4/wc-site-generator/issues/113): every static-site validation PR reported `bench: fail` with empty `stderr_tail`, and there was no way to know whether Playground crashed in boot, the wp-cli workload errored, the SSI import threw, or the structured log captured a STAGE_FAIL.

## Fix

Wrap the `dump_diagnostics` body in `{ ... } >&2` so the structured log + Playground stdout/stderr land on stderr. Stderr is still:

1. Captured by homeboy core into `CommandOutput.stderr`, so `bench_failure_stderr_tail()` keeps the failure narrative the runner already produced.
2. Streamed to the parent terminal in CI bench progress mode, which restores the GitHub Actions log's failure visibility.
3. Teed to the terminal in local interactive mode, identical to today's behavior.

## Verification

- `bash -n wordpress/scripts/bench/bench-runner-playground.sh` — passes.
- Reproduced the original failure mode locally with `CI=true homeboy bench wc-site-generator …`. With the patch, `bench.json`'s `failure.stderr_tail` carries the actual error (`mktemp: mkstemp failed on /var/folders/.../pg-blueprint.XXXXXX.json: File exists` in my macOS repro), instead of being empty as before.
- No tests grep for the dump output text, so no test changes required. The classification ladder (Cases 1-4) and exit codes are unchanged.

## Out of scope

- The macOS BSD `mktemp` template at line 382 (`mktemp \"${TMPDIR:-/tmp}/pg-blueprint.XXXXXX.json\"`) is fragile — BSD mktemp's `XXXXXX` suffix handling differs from GNU mktemp and produced the local repro failure above. Worth a follow-up that uses `mktemp -t pg-blueprint` or removes the `.json` suffix, but it's a separate failure mode from the stderr-routing bug this PR addresses.
- The downstream wc-site-generator side already shipped a finding-packet builder that emits a `bench_failure` packet whether or not stderr_tail is populated ([chubes4/wc-site-generator#115](https://github.com/chubes4/wc-site-generator/pull/115)). That ensures iterators always have something to route; this PR makes the routed packet *useful* by giving it real failure context.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Located the suppression path through `passthrough(false)`/`stderr_passthrough(false)`, traced it to `dump_diagnostics` writing to stdout, drafted the patch + commit message + PR description, and reproduced the failure mode locally with `CI=true` before/after the patch. Chris reviewed.