### PR TITLE
fix(wordpress): skip wp_filesystem rewrite in test files and fix Elvis-operator expansion (#458)

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,7 +10,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh",
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh",
       "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js"
     ],
     "test": [
@@ -24,6 +24,7 @@
       "bash scripts/lint/wordpress-lint-role-smoke.sh",
       "bash scripts/lint/vendor-prefixed-exclusion-smoke.sh",
       "bash scripts/lint/eslint-no-files-smoke.sh",
+      "bash scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh",
       "bash tests/audit-detector-config-smoke.sh",
       "bash tests/audit-dead-guard-fallback-smoke.sh",
       "node tests/request-profiler-smoke.js",

--- a/wordpress/scripts/lint/php-fixers/fixer-helpers.php
+++ b/wordpress/scripts/lint/php-fixers/fixer-helpers.php
@@ -66,3 +66,43 @@ function fixer_path_is_excluded($path) {
 
     return false;
 }
+
+/**
+ * Detect pure-PHP test harness files that don't bootstrap WordPress.
+ *
+ * Smoke tests (`tests/*-smoke.php`, `tests/smoke-*.php`) and PHPUnit test classes
+ * (`tests/*Test.php`, `tests/*TestCase.php`) frequently do filesystem I/O without
+ * a WP runtime. Auto-fixers that rewrite to WordPress runtime APIs (e.g.
+ * $wp_filesystem) MUST skip these files — the rewritten code would throw at
+ * runtime because $wp_filesystem is undefined.
+ *
+ * Mirrors the role detection in scripts/lint/lint-runner.sh
+ * (wordpress_lint_role_for_path: smoke_harness, phpunit_test).
+ *
+ * @param string $path Absolute or relative path to a PHP file.
+ * @return bool True if the file is a pure-PHP test harness.
+ */
+function fixer_path_is_test_harness($path) {
+    $path = str_replace('\\', '/', $path);
+    $basename = basename($path);
+
+    // PHPUnit test classes: tests/*Test.php, tests/*TestCase.php (any depth).
+    if (preg_match('#(^|/)tests/.*(Test|TestCase)\.php$#', $path)) {
+        return true;
+    }
+
+    // Smoke harnesses: tests/*-smoke.php, tests/smoke-*.php (any depth).
+    if (preg_match('#(^|/)tests/#', $path)) {
+        if (preg_match('/(^|-)smoke\.php$/', $basename) || preg_match('/^smoke-/', $basename)) {
+            return true;
+        }
+    }
+
+    // *-smoke.php anywhere — matches the lint role pattern */smoke-*.php and
+    // */*-smoke.php from wordpress_lint_role_for_path.
+    if (preg_match('/-smoke\.php$/', $basename) || preg_match('/^smoke-/', $basename)) {
+        return true;
+    }
+
+    return false;
+}

--- a/wordpress/scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh
+++ b/wordpress/scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# Regression smoke test for homeboy-extensions#458.
+#
+# Verifies that:
+#   1. wp-filesystem-fixer.php SKIPS pure-PHP test harness files
+#      (tests/*-smoke.php, tests/smoke-*.php, tests/*Test.php, tests/*TestCase.php).
+#      Rewriting file_get_contents() to $wp_filesystem->get_contents() in a file
+#      that doesn't bootstrap WordPress crashes at runtime.
+#
+#   2. short-ternary-fixer.php SKIPS expansion when the left expression contains
+#      a function or method call. Naively duplicating `f($x) ?: 'd'` into
+#      `f($x) ? f($x) : 'd'` double-invokes the call (extra I/O / side effects).
+#
+#   3. wp-filesystem-fixer.php still rewrites production runtime code.
+#
+#   4. short-ternary-fixer.php still expands variables, property chains, and
+#      array access (which are safe to duplicate).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WP_FILESYSTEM_FIXER="${SCRIPT_DIR}/wp-filesystem-fixer.php"
+SHORT_TERNARY_FIXER="${SCRIPT_DIR}/short-ternary-fixer.php"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_grep() {
+    local pattern="$1"
+    local file="$2"
+    local desc="$3"
+    if ! grep -qE "$pattern" "$file"; then
+        echo "--- file contents: $file ---" >&2
+        cat "$file" >&2
+        echo "---" >&2
+        fail "$desc — expected pattern '$pattern' in $file"
+    fi
+}
+
+assert_not_grep() {
+    local pattern="$1"
+    local file="$2"
+    local desc="$3"
+    if grep -qE "$pattern" "$file"; then
+        echo "--- file contents: $file ---" >&2
+        cat "$file" >&2
+        echo "---" >&2
+        fail "$desc — unexpected pattern '$pattern' in $file"
+    fi
+}
+
+# === Bug 1: wp-filesystem-fixer must skip test harness files ===
+
+mkdir -p "${TMPDIR}/tests" "${TMPDIR}/inc"
+
+cat > "${TMPDIR}/tests/agent-bundle-smoke.php" <<'PHP'
+<?php
+$docs = file_get_contents( __DIR__ . '/fixture.md' );
+PHP
+
+cat > "${TMPDIR}/tests/SomethingTest.php" <<'PHP'
+<?php
+class SomethingTest {
+    function setUp() {
+        $x = file_get_contents( __DIR__ . '/fixture.txt' );
+    }
+}
+PHP
+
+cat > "${TMPDIR}/tests/SomethingTestCase.php" <<'PHP'
+<?php
+class SomethingTestCase {
+    function it_reads() {
+        $x = file_get_contents( __DIR__ . '/fixture.txt' );
+    }
+}
+PHP
+
+cat > "${TMPDIR}/inc/runtime.php" <<'PHP'
+<?php
+class Runtime {
+    function read( $path ) {
+        return file_get_contents( $path );
+    }
+}
+PHP
+
+php "$WP_FILESYSTEM_FIXER" "$TMPDIR" > /dev/null
+
+assert_grep 'file_get_contents\( __DIR__' "${TMPDIR}/tests/agent-bundle-smoke.php" \
+    "smoke harness must not be rewritten"
+assert_not_grep 'wp_filesystem' "${TMPDIR}/tests/agent-bundle-smoke.php" \
+    "smoke harness must not introduce wp_filesystem"
+
+assert_grep 'file_get_contents\( __DIR__' "${TMPDIR}/tests/SomethingTest.php" \
+    "PHPUnit *Test.php must not be rewritten"
+assert_not_grep 'wp_filesystem' "${TMPDIR}/tests/SomethingTest.php" \
+    "PHPUnit *Test.php must not introduce wp_filesystem"
+
+assert_grep 'file_get_contents\( __DIR__' "${TMPDIR}/tests/SomethingTestCase.php" \
+    "PHPUnit *TestCase.php must not be rewritten"
+
+assert_grep 'wp_filesystem->get_contents' "${TMPDIR}/inc/runtime.php" \
+    "production runtime code must still be rewritten"
+assert_not_grep '\bfile_get_contents\b' "${TMPDIR}/inc/runtime.php" \
+    "production runtime code must replace file_get_contents"
+
+# === Bug 2: short-ternary-fixer must skip when left side contains a call ===
+
+rm -rf "${TMPDIR}"/*
+mkdir -p "${TMPDIR}"
+
+cat > "${TMPDIR}/calls.php" <<'PHP'
+<?php
+$a = file_get_contents( $path ) ?: '';
+$b = $obj->method( $x ) ?: 'fallback';
+$c = some_func() ?: [];
+PHP
+
+cat > "${TMPDIR}/safe.php" <<'PHP'
+<?php
+$a = $b ?: 'default';
+$c = $d->prop ?: 0;
+$e = $f[$g] ?: [];
+PHP
+
+php "$SHORT_TERNARY_FIXER" "${TMPDIR}/calls.php" > /dev/null
+php "$SHORT_TERNARY_FIXER" "${TMPDIR}/safe.php" > /dev/null
+
+# Calls must remain as ?: (skipped by the fixer to avoid double-invocation).
+assert_grep 'file_get_contents\( \$path \) \?: ' "${TMPDIR}/calls.php" \
+    "function call ?: must not be expanded (double-invoke regression)"
+assert_grep 'method\( \$x \) \?: ' "${TMPDIR}/calls.php" \
+    "method call ?: must not be expanded (double-invoke regression)"
+assert_grep 'some_func\(\) \?: ' "${TMPDIR}/calls.php" \
+    "bare function call ?: must not be expanded"
+
+# Variables, properties, and array access are safe to duplicate.
+assert_grep '\$b \? \$b :' "${TMPDIR}/safe.php" \
+    "variable ?: must still be expanded"
+assert_grep '\$d->prop \? \$d->prop :' "${TMPDIR}/safe.php" \
+    "property access ?: must still be expanded"
+assert_grep '\$f\[\$g\] \? \$f\[\$g\] :' "${TMPDIR}/safe.php" \
+    "array access ?: must still be expanded"
+
+# === End-to-end: chained smoke test (matches the data-machine repro) ===
+
+mkdir -p "${TMPDIR}/repro/tests"
+cat > "${TMPDIR}/repro/tests/agent-bundle-installed-artifact-smoke.php" <<'PHP'
+<?php
+$docs = file_get_contents( dirname( __DIR__ ) . '/docs/agent-bundles.md' ) ?: '';
+echo strlen( $docs );
+PHP
+
+# Run both fixers in the same order as lint-runner.sh (short-ternary then wp-filesystem).
+php "$SHORT_TERNARY_FIXER" "${TMPDIR}/repro/tests/agent-bundle-installed-artifact-smoke.php" > /dev/null
+php "$WP_FILESYSTEM_FIXER" "${TMPDIR}/repro/tests/agent-bundle-installed-artifact-smoke.php" > /dev/null
+
+# After both fixers, the original file must be untouched (test harness skip).
+assert_grep "file_get_contents\( dirname\( __DIR__ \) \. '/docs/agent-bundles.md' \) \?: ''" \
+    "${TMPDIR}/repro/tests/agent-bundle-installed-artifact-smoke.php" \
+    "data-machine repro: smoke file must be untouched after both fixers"
+
+# Sanity check: the file is still valid PHP.
+php -l "${TMPDIR}/repro/tests/agent-bundle-installed-artifact-smoke.php" > /dev/null
+
+echo "OK: fixer test harness skip + short-ternary call guard regression smoke passed"

--- a/wordpress/scripts/lint/php-fixers/short-ternary-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/short-ternary-fixer.php
@@ -134,6 +134,15 @@ function expand_short_ternary($emitted, $tokens, $colon_idx, $count) {
         $ws_before_qmark = ' ';
     }
 
+    // Skip expansion when the left expression contains a function or method call.
+    // Naively duplicating `f($x) ?: 'd'` into `f($x) ? f($x) : 'd'` double-invokes
+    // the call, which is a behavior regression (extra I/O, side effects, cost).
+    // Variables, property chains, and array access (`$a`, `$a->b`, `$a[$k]`) are
+    // safe to duplicate — they have no `(`. Calls do. See homeboy-extensions#458.
+    if (false !== strpos($left_expr, '(')) {
+        return null;
+    }
+
     // Build expanded ternary: prefix + left_expr + ? left_expr : + rest
     $expanded = $prefix . $left_expr . $ws_before_qmark . '? ' . $left_expr . ' :' . $ws_after_colon;
 

--- a/wordpress/scripts/lint/php-fixers/wp-filesystem-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/wp-filesystem-fixer.php
@@ -64,6 +64,14 @@ function process_file( $filepath ) {
 		return 0;
 	}
 
+	// Skip pure-PHP test harness files (smoke tests, PHPUnit test classes).
+	// These don't bootstrap WordPress, so $wp_filesystem is undefined and the
+	// rewritten code would throw "Call to a member function get_contents() on
+	// null" at runtime. See homeboy-extensions#458.
+	if ( fixer_path_is_test_harness( $filepath ) ) {
+		return 0;
+	}
+
 	$lines      = explode( "\n", $source );
 	$fixes      = 0;
 	$changed    = false;


### PR DESCRIPTION
Closes #458.

The `wordpress` extension's `homeboy lint --fix` produced broken code in
pure-PHP test harness files (smoke tests, PHPUnit test classes) that don't
bootstrap WordPress. Two cooperating fixer bugs caused it; this PR fixes
both and adds a regression smoke.

## Bug 1 — `wp-filesystem-fixer.php` rewrites in files with no WP runtime

`file_get_contents()` got rewritten to `$wp_filesystem->get_contents()` in
`tests/*-smoke.php` and `tests/*Test.php` files, but `$wp_filesystem` is
undefined there. Result at runtime:

```
PHP Fatal error: Call to a member function get_contents() on null in
tests/agent-bundle-installed-artifact-smoke.php:180
```

**Fix:** skip files matching the smoke-harness / PHPUnit path roles already
defined in `wordpress_lint_role_for_path` (`lint-runner.sh`). The detection
lives in a shared helper (`fixer_path_is_test_harness`) so other fixers can
opt in to the same rule when needed.

## Bug 2 — `short-ternary-fixer.php` double-invokes calls

`f($x) ?: 'd'` got expanded into `f($x) ? f($x) : 'd'`, calling `f()` twice.
That's an unwanted side-effect / extra I/O regression even when the code
runs in a normal WP runtime — the data-machine repro hit it on a
`file_get_contents()` call.

**Fix:** skip expansion when the captured left expression contains a `(`.
Variables, property chains, and array access (`$a`, `$a->b`, `$a[$k]`) are
still expanded — they're safe to duplicate. Function and method calls are
left as `?:` so phpcbf can either leave them alone or a future fixer can
introduce a temp-var binding without losing semantics.

## Regression test

`wordpress/scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh` covers:

- wp-filesystem-fixer skips `tests/*-smoke.php`, `tests/*Test.php`,
  `tests/*TestCase.php`
- wp-filesystem-fixer still rewrites production runtime code
- short-ternary-fixer skips `f() ?:`, `$o->m() ?:`, `func() ?:`
- short-ternary-fixer still expands `$v ?:`, `$o->p ?:`, `$a[$k] ?:`
- end-to-end: the exact data-machine repro line is unchanged after
  running both fixers in `lint-runner.sh` order

Wired into `homeboy.json` `self_checks.lint` (bash -n) and
`self_checks.test` (full run).

## Verification

End-to-end against `data-machine` `tests/agent-bundle-installed-artifact-smoke.php`
(the issue repro): both fixers now leave the file untouched and `php -l`
passes. Swept all 245 test/smoke files in `data-machine/tests/` — no
regression introduced; the only changes are 3 simple `$variable ?:`
expansions, which is the expected, semantically-equivalent style fix.

The "shifted assignment" symptom briefly mentioned in the issue body
(`handler-tool-policy-smoke.php`) is implicitly covered by the path-based
skip — the wp-filesystem-fixer no longer touches any test file. Tracking
the underlying multi-line tracking question separately if it ever surfaces
in non-test code.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** drafted the path-detection helper, the `(` guard in
  short-ternary-fixer, the regression smoke harness, and this PR body.
  Chris reviewed the patch, confirmed the data-machine repro, and ran
  the sweep across all 245 test files.