### PR TITLE
fix(wordpress): pin Playground CLI dependency

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -16,7 +16,7 @@
     "test:timing-correlator": "node tests/timing-correlator-smoke.js"
   },
   "devDependencies": {
-    "@wp-playground/cli": "^3.1.20",
+    "@wp-playground/cli": "3.1.20",
     "@wordpress/eslint-plugin": "^24.2.0",
     "eslint": "^8.57.0"
   },


### PR DESCRIPTION
## Summary
- Pin the WordPress extension's `@wp-playground/cli` dependency to `3.1.20` so fresh extension setup does not select the currently broken `3.1.29` package graph.
- Keeps Homeboy bench/test Playground runners able to install `wp-playground-cli` in CI.

## Verification
- `npm install --quiet --no-fund --no-audit`
- `node tests/playground-readiness-smoke.js && node tests/request-profiler-smoke.js && node tests/timing-correlator-smoke.js`
- `bash scripts/bench/playground-bench-wp-cli-plugin-install-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the CI package resolution failure, drafted the dependency pin, and ran local smoke verification; Chris remains responsible for review and merge.