### PR TITLE
fix(wordpress): use latest Playground CLI

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -16,7 +16,7 @@
     "test:timing-correlator": "node tests/timing-correlator-smoke.js"
   },
   "devDependencies": {
-    "@wp-playground/cli": "3.1.20",
+    "@wp-playground/cli": "^3.1.29",
     "@wordpress/eslint-plugin": "^24.2.0",
     "eslint": "^8.57.0"
   },


### PR DESCRIPTION
## Summary
- Move the WordPress extension's Playground CLI dependency from the temporary `3.1.20` pin to the latest 3.1 line via `^3.1.29`.
- Keeps Homeboy aligned with the current Playground package set instead of freezing on an older known-good version.

## Verification
- `npm install --quiet --no-fund --no-audit`
- `node tests/playground-readiness-smoke.js && node tests/request-profiler-smoke.js && node tests/timing-correlator-smoke.js`
- `bash scripts/bench/playground-bench-wp-cli-plugin-install-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Corrected the dependency strategy to use latest Playground CLI, verified install and smoke behavior, and drafted this PR; Chris remains responsible for review and merge.