### PR TITLE
fix(wordpress): seed WP-CLI prompt config

### DIFF
--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -470,6 +470,7 @@ function pg_bench_prepare_wp_cli_runtime(): void {
             'debug' => false,
             'color' => false,
             'quiet' => false,
+            'prompt' => false,
             'require' => [],
             'ssh' => false,
             'http' => false,


### PR DESCRIPTION
## Summary
- Seed `prompt => false` in the in-process WP-CLI runner config used by configured Playground bench workloads.
- Prevents `WP_CLI::get_config('prompt')` from emitting `Warning: Unknown config option 'prompt'.` and failing `WP_CLI::runcommand()` before the workload command can run.

## Verification
- `npm install --quiet --no-fund --no-audit`
- `php -l scripts/bench/playground-bench-runner.php`
- `bash scripts/bench/playground-bench-wp-cli-plugin-install-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the static validation bench failures, identified the missing WP-CLI config key, drafted the runner fix, and ran smoke verification; Chris remains responsible for review and merge.