### PR TITLE
fix(wordpress): preserve Playground JSON template payloads

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -445,32 +445,25 @@ if [ ! -f "$TEMPLATE" ]; then
 fi
 
 WRAPPER_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/pg-bench-runner.XXXXXX")
-# Use ASCII SOH (\x01) as the sed delimiter for the JSON substitution so
-# embedded `|` / `/` / `,` in user-supplied wp_config_defines values don't
-# need escaping. The other placeholders use `|` (their values never contain
-# a pipe in practice — slugs, integers, and POSIX paths only).
+# Use ASCII SOH (\x01) as the sed delimiter for JSON-ish substitutions so
+# embedded `|` / `/` / `,` don't need escaping. JSON payloads are base64-encoded
+# before template insertion because PHP single-quoted strings collapse `\\`
+# sequences, corrupting nested JSON string values such as bench_env payloads.
 WP_CONFIG_DEFINES_DELIM=$(printf '\1')
 
-# Escape sed `s` replacement metacharacters in JSON values before
-# substituting them into the PHP runner template. GNU sed processes the
-# replacement string by treating `&` as a backreference to the matched
-# pattern and `\X` as an escape sequence — so an unescaped `&` in JSON
-# (e.g. an ampersand inside a string) gets replaced with the placeholder
-# itself, and `\"` collapses to `"`, silently corrupting the JSON. The
-# decode in playground-bench-runner.php then fails and ALL declared
-# bench_env / wp_config_defines entries drop on the floor.
-#
-# Only `\` and `&` need escaping here: the SOH delimiter cannot appear in
-# JSON content, and the only `\X` sequences sed treats specially are
-# `\&`, `\\`, the delimiter, and `\1`-`\9` — which all share the `\`
-# escape, so escaping `\` covers them.
+# Escape sed `s` replacement metacharacters for non-JSON payloads. JSON
+# payloads are base64-encoded above so they survive both sed replacement and
+# PHP string parsing without a second escaping scheme.
 sed_escape_replacement() {
     printf '%s' "$1" | sed -e 's/[\&]/\\&/g'
 }
-WP_CONFIG_DEFINES_JSON_ESC=$(sed_escape_replacement "$WP_CONFIG_DEFINES_JSON")
-BENCH_ENV_JSON_ESC=$(sed_escape_replacement "$BENCH_ENV_JSON")
-BENCH_WORKLOADS_JSON_ESC=$(sed_escape_replacement "$BENCH_WORKLOADS_JSON")
-PLAYGROUND_WORKLOADS_JSON_ESC=$(sed_escape_replacement "$PLAYGROUND_WORKLOADS_JSON")
+json_to_base64() {
+    printf '%s' "$1" | base64 | tr -d '\n'
+}
+WP_CONFIG_DEFINES_JSON_B64=$(json_to_base64 "$WP_CONFIG_DEFINES_JSON")
+BENCH_ENV_JSON_B64=$(json_to_base64 "$BENCH_ENV_JSON")
+BENCH_WORKLOADS_JSON_B64=$(json_to_base64 "$BENCH_WORKLOADS_JSON")
+PLAYGROUND_WORKLOADS_JSON_B64=$(json_to_base64 "$PLAYGROUND_WORKLOADS_JSON")
 EXTRA_WORKLOADS_LIST_ESC=$(sed_escape_replacement "$EXTRA_WORKLOADS_LIST")
 
 sed \
@@ -486,10 +479,10 @@ sed \
     -e "s|{{RESULT_SUFFIX}}|${RESULT_SUFFIX}|g" \
     -e "s|{{BENCH_HELPER_PHP}}|${BENCH_HELPER_PHP_GUEST}|g" \
     -e "s|{{BENCH_SITE_MODE}}|${BENCH_SITE_MODE}|g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_WORKLOADS_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_WORKLOADS_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{PLAYGROUND_WORKLOADS_JSON}}${WP_CONFIG_DEFINES_DELIM}${PLAYGROUND_WORKLOADS_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON_B64}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON_B64}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON_B64}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON_B64}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_WORKLOADS_JSON_B64}}${WP_CONFIG_DEFINES_DELIM}${BENCH_WORKLOADS_JSON_B64}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{PLAYGROUND_WORKLOADS_JSON_B64}}${WP_CONFIG_DEFINES_DELIM}${PLAYGROUND_WORKLOADS_JSON_B64}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{EXTRA_WORKLOADS_LIST}}${WP_CONFIG_DEFINES_DELIM}${EXTRA_WORKLOADS_LIST_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
     "$TEMPLATE" > "$WRAPPER_TMPFILE"
 

--- a/wordpress/scripts/bench/playground-bench-env-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-env-smoke.sh
@@ -11,7 +11,7 @@
 #
 # Manual integration test, not part of CI. Run after changes to:
 #   - playground-bench-runner.php (the putenv() loop)
-#   - bench-runner-playground.sh (the BENCH_ENV_JSON extraction + sed)
+#   - bench-runner-playground.sh (the BENCH_ENV_JSON extraction + template transport)
 #   - playground-runner.php (test-runner mirror)
 #   - test-runner-playground.sh (test-runner mirror)
 #
@@ -56,13 +56,11 @@ ITERATIONS=2
 # homeboy core. Real components declare this under
 # extensions.wordpress.settings.bench_env in their homeboy.json.
 #
-# BENCH_ENV_FIXTURE_METAS is the regression value for the sed-replacement
-# escape bug: it contains `\` (via the JSON-escaped `\"` sequences) and a
-# literal `&`, both of which GNU sed mangles in `s` replacement strings
-# unless the runner escapes them before substituting BENCH_ENV_JSON into
-# the PHP template. Without the fix, json_decode() of BENCH_ENV_JSON
-# returns null and ALL bench_env keys silently drop — including unrelated
-# bystanders like BENCH_ENV_FIXTURE_STR.
+# BENCH_ENV_FIXTURE_METAS is the regression value for JSON template transport:
+# it contains nested JSON with `\`, `\"`, and `&`. The runner must preserve it
+# exactly while substituting the payload into the PHP template; otherwise
+# json_decode() returns null and ALL bench_env keys silently drop — including
+# unrelated bystanders like BENCH_ENV_FIXTURE_STR.
 SETTINGS_JSON=$(cat <<'JSON'
 {
   "bench_env": {
@@ -140,14 +138,14 @@ if ! grep -q '"BENCH_ENV_FIXTURE_METAS_getenv":"' "$READ_BACK_LOG"; then
 fi
 if ! grep -q 'a & b' "$READ_BACK_LOG"; then
     echo "ERROR: literal '&' did not round-trip in BENCH_ENV_FIXTURE_METAS." >&2
-    echo "       Likely cause: BENCH_ENV_JSON sed substitution treated '&' as a" >&2
-    echo "       backreference and corrupted the JSON before json_decode()." >&2
+    echo "       Likely cause: BENCH_ENV_JSON template transport corrupted" >&2
+    echo "       the JSON before json_decode()." >&2
     exit 1
 fi
 if ! grep -q '\\"text\\"' "$READ_BACK_LOG"; then
     echo "ERROR: '\\\"' did not round-trip in BENCH_ENV_FIXTURE_METAS." >&2
-    echo "       Likely cause: BENCH_ENV_JSON sed substitution dropped backslashes" >&2
-    echo "       in the replacement string, corrupting the JSON before json_decode()." >&2
+    echo "       Likely cause: BENCH_ENV_JSON template transport dropped" >&2
+    echo "       backslashes before json_decode()." >&2
     exit 1
 fi
 

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -106,7 +106,10 @@ pg_install_diagnostics_handlers();
 // dispatcher reads the `wp_config_defines` setting from the merged
 // settings JSON and passes it through; an empty object ("{}") is the
 // no-op case. Decode here and hand to pg_run_boot_stage().
-$wp_config_defines_raw = '{{WP_CONFIG_DEFINES_JSON}}';
+$wp_config_defines_raw = base64_decode('{{WP_CONFIG_DEFINES_JSON_B64}}', true);
+if (!is_string($wp_config_defines_raw)) {
+    $wp_config_defines_raw = '{}';
+}
 $wp_config_defines = json_decode($wp_config_defines_raw, true);
 if (!is_array($wp_config_defines)) {
     $wp_config_defines = [];
@@ -128,7 +131,10 @@ $config_path = pg_run_boot_stage([
 //
 // Empty object is the no-op case — components that don't declare
 // bench_env see no behavioural change.
-$bench_env_raw = '{{BENCH_ENV_JSON}}';
+$bench_env_raw = base64_decode('{{BENCH_ENV_JSON_B64}}', true);
+if (!is_string($bench_env_raw)) {
+    $bench_env_raw = '{}';
+}
 $bench_env = json_decode($bench_env_raw, true);
 if (is_array($bench_env)) {
     foreach ($bench_env as $name => $value) {
@@ -781,7 +787,11 @@ try {
         ];
     }
 
-    foreach (pg_bench_configured_workloads('{{PLAYGROUND_WORKLOADS_JSON}}') as $configured_workload) {
+    $playground_workloads_raw = base64_decode('{{PLAYGROUND_WORKLOADS_JSON_B64}}', true);
+    if (!is_string($playground_workloads_raw)) {
+        $playground_workloads_raw = '[]';
+    }
+    foreach (pg_bench_configured_workloads($playground_workloads_raw) as $configured_workload) {
         $workloads[] = [
             'kind' => 'configured',
             'id' => $configured_workload['id'],
@@ -797,7 +807,11 @@ try {
         return strcmp($left_key, $right_key);
     });
 
-    $requested_workloads = pg_bench_normalize_workload_filter('{{BENCH_WORKLOADS_JSON}}');
+    $bench_workloads_raw = base64_decode('{{BENCH_WORKLOADS_JSON_B64}}', true);
+    if (!is_string($bench_workloads_raw)) {
+        $bench_workloads_raw = 'null';
+    }
+    $requested_workloads = pg_bench_normalize_workload_filter($bench_workloads_raw);
     if (!empty($requested_workloads)) {
         $requested_lookup = array_fill_keys($requested_workloads, true);
         $available_workloads = [];

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -83,7 +83,10 @@ if (!is_string($selected_test_file)) {
 // Component-declared wp-config defines flow through the
 // {{WP_CONFIG_DEFINES_JSON}} placeholder. Empty object is the no-op
 // default for components that don't need the seam.
-$wp_config_defines_raw = '{{WP_CONFIG_DEFINES_JSON}}';
+$wp_config_defines_raw = base64_decode('{{WP_CONFIG_DEFINES_JSON_B64}}', true);
+if (!is_string($wp_config_defines_raw)) {
+    $wp_config_defines_raw = '{}';
+}
 $wp_config_defines = json_decode($wp_config_defines_raw, true);
 if (!is_array($wp_config_defines)) {
     $wp_config_defines = [];
@@ -96,7 +99,10 @@ $config_path = pg_run_boot_stage(['extra_defines' => $wp_config_defines]);
 // dispatcher extracts `bench_env` from HOMEBOY_SETTINGS_JSON and we
 // putenv() each entry here before test fixtures load. Empty object is
 // the no-op case.
-$bench_env_raw = '{{BENCH_ENV_JSON}}';
+$bench_env_raw = base64_decode('{{BENCH_ENV_JSON_B64}}', true);
+if (!is_string($bench_env_raw)) {
+    $bench_env_raw = '{}';
+}
 $bench_env = json_decode($bench_env_raw, true);
 if (is_array($bench_env)) {
     foreach ($bench_env as $name => $value) {
@@ -243,7 +249,11 @@ try {
     );
 
     $test_files = pg_discover_tests($directories, $suffixes, $prefixes, $excludes);
-    $test_files = pg_filter_changed_test_files($test_files, '{{CHANGED_TEST_FILES_JSON}}', $plugin_path);
+    $changed_test_files_raw = base64_decode('{{CHANGED_TEST_FILES_JSON_B64}}', true);
+    if (!is_string($changed_test_files_raw)) {
+        $changed_test_files_raw = '[]';
+    }
+    $test_files = pg_filter_changed_test_files($test_files, $changed_test_files_raw, $plugin_path);
 
     if ($selected_test_file !== '') {
         $selected_abs = $plugin_path . '/' . ltrim($selected_test_file, '/');

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -356,37 +356,32 @@ if [ ! -f "$TEMPLATE" ]; then
 fi
 
 WRAPPER_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/pg-runner.XXXXXX")
-# ASCII SOH delimiter for the JSON substitution — values may contain `|`
-# safely without shell escaping.
+# Use ASCII SOH (\x01) as the sed delimiter for JSON-ish substitutions so
+# embedded `|` / `/` / `,` don't need escaping. JSON payloads are base64-encoded
+# before template insertion because PHP single-quoted strings collapse `\\`
+# sequences, corrupting nested JSON string values such as bench_env payloads.
 WP_CONFIG_DEFINES_DELIM=$(printf '\1')
 
-# Escape sed `s` replacement metacharacters in JSON values before
-# substituting them into the PHP runner template. GNU sed processes the
-# replacement string by treating `&` as a backreference to the matched
-# pattern and `\X` as an escape sequence — so an unescaped `&` in JSON
-# (e.g. an ampersand inside a string) gets replaced with the placeholder
-# itself, and `\"` collapses to `"`, silently corrupting the JSON. The
-# decode in playground-runner.php then fails and ALL declared bench_env /
-# wp_config_defines entries drop on the floor.
-#
-# Only `\` and `&` need escaping here: the SOH delimiter cannot appear in
-# JSON content, and the only `\X` sequences sed treats specially are
-# `\&`, `\\`, the delimiter, and `\1`-`\9` — which all share the `\`
-# escape, so escaping `\` covers them.
+# Escape sed `s` replacement metacharacters for non-JSON payloads. JSON
+# payloads are base64-encoded above so they survive both sed replacement and
+# PHP string parsing without a second escaping scheme.
 sed_escape_replacement() {
     printf '%s' "$1" | sed -e 's/[\&]/\\&/g'
 }
-WP_CONFIG_DEFINES_JSON_ESC=$(sed_escape_replacement "$WP_CONFIG_DEFINES_JSON")
-BENCH_ENV_JSON_ESC=$(sed_escape_replacement "$BENCH_ENV_JSON")
-CHANGED_TEST_FILES_JSON_ESC=$(sed_escape_replacement "$CHANGED_TEST_FILES_JSON")
+json_to_base64() {
+    printf '%s' "$1" | base64 | tr -d '\n'
+}
+WP_CONFIG_DEFINES_JSON_B64=$(json_to_base64 "$WP_CONFIG_DEFINES_JSON")
+BENCH_ENV_JSON_B64=$(json_to_base64 "$BENCH_ENV_JSON")
+CHANGED_TEST_FILES_JSON_B64=$(json_to_base64 "$CHANGED_TEST_FILES_JSON")
 
 sed \
     -e "s|{{PLUGIN_SLUG}}|${PLUGIN_SLUG}|g" \
     -e "s|{{PLAYGROUND_DEP_MOUNTS}}|${PLAYGROUND_DEP_MOUNTS}|g" \
     -e "s|{{PHPUNIT_TEST_FILE_B64}}|${SELECTED_TEST_FILE_B64}|g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{CHANGED_TEST_FILES_JSON}}${WP_CONFIG_DEFINES_DELIM}${CHANGED_TEST_FILES_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON_B64}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON_B64}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON_B64}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON_B64}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{CHANGED_TEST_FILES_JSON_B64}}${WP_CONFIG_DEFINES_DELIM}${CHANGED_TEST_FILES_JSON_B64}${WP_CONFIG_DEFINES_DELIM}g" \
     "$TEMPLATE" > "$WRAPPER_TMPFILE"
 
 echo "Running PHPUnit tests via WordPress Playground..."


### PR DESCRIPTION
## Summary
- Base64-encode JSON template payloads before inserting them into Playground runner wrappers.
- Decode those payloads in the PHP bench/test runners so nested JSON strings keep their backslashes intact.
- Update the bench_env smoke guidance to cover the broader template transport regression.

## Testing
- `bash -n wordpress/scripts/bench/bench-runner-playground.sh wordpress/scripts/test/test-runner-playground.sh wordpress/scripts/bench/playground-bench-env-smoke.sh`
- `php -l wordpress/scripts/bench/playground-bench-runner.php`
- `php -l wordpress/scripts/test/playground-runner.php`
- `bash wordpress/scripts/bench/playground-bench-env-smoke.sh`
- Verified wc-site-generator iterator smoke locally with this branch: Playground received `GITHUB_TOKEN`, `OPENAI_API_KEY`, and grouped finding JSON via `bench_env`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Debugged the Playground template transport regression, drafted the runner changes, and ran targeted local validation; Chris remains responsible for review and merge.