### PR TITLE
fix(wordpress): preserve bench env JSON replacements

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -193,6 +193,7 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
         BENCH_ENV_JSON="$extracted"
     fi
 fi
+BENCH_ENV_JSON_B64=$(printf '%s' "$BENCH_ENV_JSON" | base64 | tr -d '\n')
 
 # Extract `bench_workloads` from the merged settings JSON. Components can
 # restrict a bench run to specific workload IDs under
@@ -465,10 +466,9 @@ WP_CONFIG_DEFINES_DELIM=$(printf '\1')
 # `\&`, `\\`, the delimiter, and `\1`-`\9` — which all share the `\`
 # escape, so escaping `\` covers them.
 sed_escape_replacement() {
-    printf '%s' "$1" | sed -e 's/[\&]/\\&/g'
+    printf '%s' "$1" | sed -e 's/[\\&]/\\&/g'
 }
 WP_CONFIG_DEFINES_JSON_ESC=$(sed_escape_replacement "$WP_CONFIG_DEFINES_JSON")
-BENCH_ENV_JSON_ESC=$(sed_escape_replacement "$BENCH_ENV_JSON")
 BENCH_WORKLOADS_JSON_ESC=$(sed_escape_replacement "$BENCH_WORKLOADS_JSON")
 PLAYGROUND_WORKLOADS_JSON_ESC=$(sed_escape_replacement "$PLAYGROUND_WORKLOADS_JSON")
 EXTRA_WORKLOADS_LIST_ESC=$(sed_escape_replacement "$EXTRA_WORKLOADS_LIST")
@@ -487,7 +487,7 @@ sed \
     -e "s|{{BENCH_HELPER_PHP}}|${BENCH_HELPER_PHP_GUEST}|g" \
     -e "s|{{BENCH_SITE_MODE}}|${BENCH_SITE_MODE}|g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
-    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON_B64}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON_B64}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_WORKLOADS_JSON}}${WP_CONFIG_DEFINES_DELIM}${BENCH_WORKLOADS_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{PLAYGROUND_WORKLOADS_JSON}}${WP_CONFIG_DEFINES_DELIM}${PLAYGROUND_WORKLOADS_JSON_ESC}${WP_CONFIG_DEFINES_DELIM}g" \
     -e "s${WP_CONFIG_DEFINES_DELIM}{{EXTRA_WORKLOADS_LIST}}${WP_CONFIG_DEFINES_DELIM}${EXTRA_WORKLOADS_LIST_ESC}${WP_CONFIG_DEFINES_DELIM}g" \

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -128,7 +128,10 @@ $config_path = pg_run_boot_stage([
 //
 // Empty object is the no-op case — components that don't declare
 // bench_env see no behavioural change.
-$bench_env_raw = '{{BENCH_ENV_JSON}}';
+$bench_env_raw = base64_decode('{{BENCH_ENV_JSON_B64}}', true);
+if (!is_string($bench_env_raw)) {
+    $bench_env_raw = '{}';
+}
 $bench_env = json_decode($bench_env_raw, true);
 if (is_array($bench_env)) {
     foreach ($bench_env as $name => $value) {


### PR DESCRIPTION
## Summary
- Encode `bench_env` JSON before substituting it into the Playground bench PHP template so nested JSON survives shell/sed/PHP parsing.
- Correct the sed replacement escaping helper for remaining JSON placeholders.

## Verification
- `bash wordpress/scripts/bench/playground-bench-env-smoke.sh`
- Local `wc-site-generator` iterator smoke reproduction with fake credentials now reaches Playground PHP with token/key/source metadata/finding groups present.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the CI bench_env transport regression and drafted the focused runner/template fix; Chris remains responsible for review and merge.