### PR TITLE
fix(wordpress): run deferred init after activation

### DIFF
--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -228,7 +228,6 @@ if ($installed_site_mode) {
     // end DB work runs before activation creates plugin tables). Activation is
     // the canonical seam for install-time side effects.
     pg_remove_new_wordpress_hook_callbacks('shutdown', $pre_component_shutdown_callbacks);
-    pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks, [], 'init');
 
     // Fire activation hooks now that wp-phpunit has created the wptests_*
     // tables. Activation order: deps first, then the component-under-test
@@ -242,6 +241,10 @@ if ($installed_site_mode) {
         $activation_files[] = $loaded_component_file;
     }
     pg_run_activation_stage(['plugin_files' => $activation_files]);
+
+    // Replay plugin-added init callbacks after activation. In a normal request,
+    // init-time runtime work observes schemas/options prepared by activation.
+    pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks, [], 'init');
 }
 
 /**

--- a/wordpress/scripts/test/playground-init-lifecycle-smoke.sh
+++ b/wordpress/scripts/test/playground-init-lifecycle-smoke.sh
@@ -97,7 +97,13 @@ if [ "$metric" != "1" ]; then
     cat "$RESULTS_TMPFILE" >&2
     exit 1
 fi
-echo "✓ bench runner replayed deferred init callbacks in init context"
+activation_metric=$(jq -r '.scenarios[] | select(.id == "assert-init-lifecycle") | .metrics.deferred_init_after_activation_ok_mean // "missing"' "$RESULTS_TMPFILE")
+if [ "$activation_metric" != "1" ]; then
+    echo "ERROR: bench workload did not verify deferred init ran after activation (got $activation_metric)" >&2
+    cat "$RESULTS_TMPFILE" >&2
+    exit 1
+fi
+echo "✓ bench runner replayed deferred init callbacks after activation in init context"
 
 echo ""
 echo "============================================"

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -146,7 +146,6 @@ pg_run_install_stage(['config_path' => $config_path, 'tests_dir' => $tests_dir])
 // only callbacks the component added during that install bootstrap; activation
 // below remains the post-table seam for install-time side effects.
 pg_remove_new_wordpress_hook_callbacks('shutdown', $pre_component_shutdown_callbacks);
-pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks, [], 'init');
 
 // Fire activation hooks now that wp-phpunit has created database tables.
 // Pre-#431 activation fired inline during muplugins_loaded — before the test
@@ -160,6 +159,10 @@ if ($loaded_component_file !== null) {
     $activation_files[] = $loaded_component_file;
 }
 pg_run_activation_stage(['plugin_files' => $activation_files]);
+
+// Replay plugin-added init callbacks after activation. In a normal request,
+// init-time runtime work observes schemas/options prepared by activation.
+pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks, [], 'init');
 
 // ---------------------------------------------------------------------------
 // Stage: load_fixtures (test case classes, mock mailer, harness filters)

--- a/wordpress/tests/fixtures/playground-init-lifecycle-host/playground-init-lifecycle-host.php
+++ b/wordpress/tests/fixtures/playground-init-lifecycle-host/playground-init-lifecycle-host.php
@@ -5,11 +5,21 @@
  */
 
 add_action( 'init', 'homeboy_playground_init_lifecycle_callback', 20 );
+register_activation_hook( __FILE__, 'homeboy_playground_init_lifecycle_activate' );
+
+function homeboy_playground_init_lifecycle_activate() {
+    update_option( 'homeboy_playground_init_lifecycle_activated', 'yes' );
+}
 
 function homeboy_playground_init_lifecycle_callback() {
     update_option(
         'homeboy_playground_init_lifecycle_context',
         doing_action( 'init' ) ? 'init' : 'not-init'
+    );
+
+    update_option(
+        'homeboy_playground_init_lifecycle_activation_seen',
+        get_option( 'homeboy_playground_init_lifecycle_activated' ) === 'yes' ? 'yes' : 'no'
     );
 
     if ( class_exists( 'WP_Connector_Registry' ) ) {

--- a/wordpress/tests/fixtures/playground-init-lifecycle-host/tests/bench/assert-init-lifecycle.php
+++ b/wordpress/tests/fixtures/playground-init-lifecycle-host/tests/bench/assert-init-lifecycle.php
@@ -6,9 +6,15 @@ return function (): array {
         throw new RuntimeException( 'Deferred init callback ran outside init context.' );
     }
 
+    $activation_seen = get_option( 'homeboy_playground_init_lifecycle_activation_seen' );
+    if ( $activation_seen !== 'yes' ) {
+        throw new RuntimeException( 'Deferred init callback ran before plugin activation.' );
+    }
+
     return [
         'metrics' => [
             'deferred_init_context_ok' => 1,
+            'deferred_init_after_activation_ok' => 1,
         ],
         'metadata' => [
             'fixture' => 'playground-init-lifecycle-host',


### PR DESCRIPTION
## Summary
- Replays plugin-added deferred `init` callbacks after activation in both Playground bench and test runners.
- Extends the init-lifecycle fixture smoke to assert deferred `init` runs in `init` context and observes activation-prepared state.

## Why
WooCommerce activation prepares tables/options that later `init` callbacks expect. Homeboy's Playground bootstrap was replaying deferred `init` before activation, which caused WooCommerce Admin Notes queries to run before their SQLite-backed tables existed.

## Validation
- `bash wordpress/scripts/test/playground-init-lifecycle-smoke.sh` passed.
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-playground-wc-sqlite-install --extension wordpress` passed; no root PHPUnit files discovered.
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-playground-wc-sqlite-install --extension wordpress` failed on existing unrelated repo-wide lint/PHPStan findings in files such as `wordpress/scripts/validation/validate-autoload.php` and `wordpress/tests/fixtures/audit-detector-config/**`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the downstream wc-site-generator validation failure, drafted the bootstrap ordering fix and fixture assertions, and ran local validation for Chris to review.