### PR TITLE
fix(wordpress): defer plugin runtime callbacks during install

### DIFF
--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -180,14 +180,17 @@ if ($installed_site_mode) {
     }
     pg_run_activation_stage(['plugin_files' => $activation_files]);
 } else {
-    // Component-added init callbacks may touch the DB (a plugin's `init` hook
-    // doing schema reads, option reads, etc.). wp-phpunit's install path runs
-    // wp-settings.php under wp_installing() and tables aren't ready until
-    // install.php finishes its work. Snapshot init/shutdown so we can defer
-    // component-added init callbacks past the install boundary, matching the
+    // Component-added bootstrap callbacks may touch the DB (a plugin's
+    // `plugins_loaded`/`init` hook doing schema reads, option reads, cron
+    // scheduling, etc.). wp-phpunit's install path runs wp-settings.php under
+    // wp_installing() and tables aren't ready until install.php finishes its
+    // work. Snapshot plugins_loaded/init/shutdown so we can defer
+    // component-added runtime callbacks past the install boundary, matching the
     // test runner's shape exactly.
+    $pre_component_plugins_loaded_callbacks = pg_snapshot_wordpress_hook_callbacks('plugins_loaded');
     $pre_component_init_callbacks = pg_snapshot_wordpress_hook_callbacks('init');
     $pre_component_shutdown_callbacks = pg_snapshot_wordpress_hook_callbacks('shutdown');
+    $deferred_install_plugins_loaded_callbacks = [];
     $deferred_install_init_callbacks = [];
 
     // Capture plugin entry files from the muplugins_loaded callback so the
@@ -200,7 +203,7 @@ if ($installed_site_mode) {
     $loaded_component_file = null;
 
     require_once "$tests_dir/includes/functions.php";
-    tests_add_filter('muplugins_loaded', function () use ($plugin_path, $dep_mounts, $pre_component_init_callbacks, &$deferred_install_init_callbacks, &$loaded_dep_files, &$loaded_blueprint_plugin_files, &$loaded_component_file) {
+    tests_add_filter('muplugins_loaded', function () use ($plugin_path, $dep_mounts, $pre_component_plugins_loaded_callbacks, $pre_component_init_callbacks, &$deferred_install_plugins_loaded_callbacks, &$deferred_install_init_callbacks, &$loaded_dep_files, &$loaded_blueprint_plugin_files, &$loaded_component_file) {
         pg_bench_prepare_wp_cli_runtime();
         $loaded_dep_files = pg_run_load_deps_stage(['dep_mounts' => $dep_mounts]);
         $exclude_roots = [$plugin_path];
@@ -213,13 +216,11 @@ if ($installed_site_mode) {
         $loaded_blueprint_plugin_files = pg_bench_load_blueprint_plugins_stage($exclude_roots, '{{PLAYGROUND_BLUEPRINT_PLUGIN_SLUGS}}');
         $loaded_component_file = pg_run_load_component_stage(['plugin_path' => $plugin_path, 'activate' => false]);
 
-        // Defer component-added init callbacks until install.php has created
-        // the wptests_* tables. Registrations made on plugins_loaded or
-        // earlier still fire normally — only DB-touching init runtime work
-        // is delayed.
-        tests_add_filter('plugins_loaded', function () use ($pre_component_init_callbacks, &$deferred_install_init_callbacks) {
-            $deferred_install_init_callbacks = pg_defer_new_wordpress_hook_callbacks('init', $pre_component_init_callbacks);
-        }, PHP_INT_MAX);
+        // Defer component-added runtime callbacks immediately. Waiting until a
+        // PHP_INT_MAX plugins_loaded callback is too late because lower-priority
+        // callbacks have already run in the current WP_Hook dispatch.
+        $deferred_install_plugins_loaded_callbacks = pg_defer_new_wordpress_hook_callbacks('plugins_loaded', $pre_component_plugins_loaded_callbacks);
+        $deferred_install_init_callbacks = pg_defer_new_wordpress_hook_callbacks('init', $pre_component_init_callbacks);
     });
 
     pg_run_install_stage(['config_path' => $config_path, 'tests_dir' => $tests_dir]);
@@ -242,8 +243,18 @@ if ($installed_site_mode) {
     }
     pg_run_activation_stage(['plugin_files' => $activation_files]);
 
-    // Replay plugin-added init callbacks after activation. In a normal request,
-    // init-time runtime work observes schemas/options prepared by activation.
+    // Replay plugin-added runtime callbacks after activation. In a normal
+    // activated-plugin request, these callbacks observe schemas/options
+    // prepared by activation.
+    $pre_replayed_plugins_loaded_init_callbacks = pg_snapshot_wordpress_hook_callbacks('init');
+    pg_run_deferred_wordpress_hook_callbacks($deferred_install_plugins_loaded_callbacks, [], 'plugins_loaded');
+    $deferred_install_init_callbacks = array_merge(
+        $deferred_install_init_callbacks,
+        pg_defer_new_wordpress_hook_callbacks('init', $pre_replayed_plugins_loaded_init_callbacks)
+    );
+    usort($deferred_install_init_callbacks, static function (array $left, array $right): int {
+        return ($left['priority'] ?? 10) <=> ($right['priority'] ?? 10);
+    });
     pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks, [], 'init');
 }
 

--- a/wordpress/scripts/test/playground-init-lifecycle-smoke.sh
+++ b/wordpress/scripts/test/playground-init-lifecycle-smoke.sh
@@ -103,7 +103,19 @@ if [ "$activation_metric" != "1" ]; then
     cat "$RESULTS_TMPFILE" >&2
     exit 1
 fi
-echo "✓ bench runner replayed deferred init callbacks after activation in init context"
+plugins_loaded_context_metric=$(jq -r '.scenarios[] | select(.id == "assert-init-lifecycle") | .metrics.deferred_plugins_loaded_context_ok_mean // "missing"' "$RESULTS_TMPFILE")
+if [ "$plugins_loaded_context_metric" != "1" ]; then
+    echo "ERROR: bench workload did not verify deferred plugins_loaded lifecycle context (got $plugins_loaded_context_metric)" >&2
+    cat "$RESULTS_TMPFILE" >&2
+    exit 1
+fi
+plugins_loaded_activation_metric=$(jq -r '.scenarios[] | select(.id == "assert-init-lifecycle") | .metrics.deferred_plugins_loaded_after_activation_ok_mean // "missing"' "$RESULTS_TMPFILE")
+if [ "$plugins_loaded_activation_metric" != "1" ]; then
+    echo "ERROR: bench workload did not verify deferred plugins_loaded ran after activation (got $plugins_loaded_activation_metric)" >&2
+    cat "$RESULTS_TMPFILE" >&2
+    exit 1
+fi
+echo "✓ bench runner replayed deferred plugins_loaded/init callbacks after activation in hook context"
 
 echo ""
 echo "============================================"

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -113,8 +113,10 @@ if (is_array($bench_env)) {
 // Load the component during WordPress bootstrap, not after wp-settings.php has
 // finished. Plugins that register hooks for core bootstrap events (for example
 // wp_abilities_api_init) need to be present before those events fire.
+$pre_component_plugins_loaded_callbacks = pg_snapshot_wordpress_hook_callbacks('plugins_loaded');
 $pre_component_init_callbacks = pg_snapshot_wordpress_hook_callbacks('init');
 $pre_component_shutdown_callbacks = pg_snapshot_wordpress_hook_callbacks('shutdown');
+$deferred_install_plugins_loaded_callbacks = [];
 $deferred_install_init_callbacks = [];
 
 // Capture plugin entry files from the muplugins_loaded callback so the
@@ -124,17 +126,17 @@ $loaded_dep_files = [];
 $loaded_component_file = null;
 
 require_once "$tests_dir/includes/functions.php";
-tests_add_filter('muplugins_loaded', function () use ($plugin_path, $pre_component_init_callbacks, &$deferred_install_init_callbacks, &$loaded_dep_files, &$loaded_component_file) {
+tests_add_filter('muplugins_loaded', function () use ($plugin_path, $pre_component_plugins_loaded_callbacks, $pre_component_init_callbacks, &$deferred_install_plugins_loaded_callbacks, &$deferred_install_init_callbacks, &$loaded_dep_files, &$loaded_component_file) {
     $loaded_dep_files = pg_run_load_deps_stage(['dep_mounts' => '{{PLAYGROUND_DEP_MOUNTS}}']);
     $loaded_component_file = pg_run_load_component_stage(['plugin_path' => $plugin_path, 'activate' => false]);
 
     // Let plugins attach early-bootstrap callbacks before lazy core registries
-    // initialize, but defer component-added init callbacks until install.php has
-    // created the wptests_* tables. This preserves registration order without
-    // letting DB-touching runtime callbacks run against a half-installed site.
-    tests_add_filter('plugins_loaded', function () use ($pre_component_init_callbacks, &$deferred_install_init_callbacks) {
-        $deferred_install_init_callbacks = pg_defer_new_wordpress_hook_callbacks('init', $pre_component_init_callbacks);
-    }, PHP_INT_MAX);
+    // initialize, but defer component-added runtime callbacks until install.php
+    // has created the wptests_* tables and activation has prepared plugin-owned
+    // state. Defer immediately: waiting for PHP_INT_MAX on plugins_loaded is
+    // too late because lower-priority callbacks have already run.
+    $deferred_install_plugins_loaded_callbacks = pg_defer_new_wordpress_hook_callbacks('plugins_loaded', $pre_component_plugins_loaded_callbacks);
+    $deferred_install_init_callbacks = pg_defer_new_wordpress_hook_callbacks('init', $pre_component_init_callbacks);
 });
 
 // Stage: install — wp-phpunit install.php creates WP tables in-process.
@@ -160,8 +162,18 @@ if ($loaded_component_file !== null) {
 }
 pg_run_activation_stage(['plugin_files' => $activation_files]);
 
-// Replay plugin-added init callbacks after activation. In a normal request,
-// init-time runtime work observes schemas/options prepared by activation.
+// Replay plugin-added runtime callbacks after activation. In a normal
+// activated-plugin request, these callbacks observe schemas/options prepared by
+// activation.
+$pre_replayed_plugins_loaded_init_callbacks = pg_snapshot_wordpress_hook_callbacks('init');
+pg_run_deferred_wordpress_hook_callbacks($deferred_install_plugins_loaded_callbacks, [], 'plugins_loaded');
+$deferred_install_init_callbacks = array_merge(
+    $deferred_install_init_callbacks,
+    pg_defer_new_wordpress_hook_callbacks('init', $pre_replayed_plugins_loaded_init_callbacks)
+);
+usort($deferred_install_init_callbacks, static function (array $left, array $right): int {
+    return ($left['priority'] ?? 10) <=> ($right['priority'] ?? 10);
+});
 pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks, [], 'init');
 
 // ---------------------------------------------------------------------------

--- a/wordpress/tests/fixtures/playground-init-lifecycle-host/playground-init-lifecycle-host.php
+++ b/wordpress/tests/fixtures/playground-init-lifecycle-host/playground-init-lifecycle-host.php
@@ -5,10 +5,23 @@
  */
 
 add_action( 'init', 'homeboy_playground_init_lifecycle_callback', 20 );
+add_action( 'plugins_loaded', 'homeboy_playground_plugins_loaded_lifecycle_callback', 20 );
 register_activation_hook( __FILE__, 'homeboy_playground_init_lifecycle_activate' );
 
 function homeboy_playground_init_lifecycle_activate() {
     update_option( 'homeboy_playground_init_lifecycle_activated', 'yes' );
+}
+
+function homeboy_playground_plugins_loaded_lifecycle_callback() {
+    update_option(
+        'homeboy_playground_plugins_loaded_lifecycle_context',
+        doing_action( 'plugins_loaded' ) ? 'plugins_loaded' : 'not-plugins-loaded'
+    );
+
+    update_option(
+        'homeboy_playground_plugins_loaded_lifecycle_activation_seen',
+        get_option( 'homeboy_playground_init_lifecycle_activated' ) === 'yes' ? 'yes' : 'no'
+    );
 }
 
 function homeboy_playground_init_lifecycle_callback() {

--- a/wordpress/tests/fixtures/playground-init-lifecycle-host/tests/bench/assert-init-lifecycle.php
+++ b/wordpress/tests/fixtures/playground-init-lifecycle-host/tests/bench/assert-init-lifecycle.php
@@ -11,10 +11,22 @@ return function (): array {
         throw new RuntimeException( 'Deferred init callback ran before plugin activation.' );
     }
 
+    $plugins_loaded_context = get_option( 'homeboy_playground_plugins_loaded_lifecycle_context' );
+    if ( $plugins_loaded_context !== 'plugins_loaded' ) {
+        throw new RuntimeException( 'Deferred plugins_loaded callback ran outside plugins_loaded context.' );
+    }
+
+    $plugins_loaded_activation_seen = get_option( 'homeboy_playground_plugins_loaded_lifecycle_activation_seen' );
+    if ( $plugins_loaded_activation_seen !== 'yes' ) {
+        throw new RuntimeException( 'Deferred plugins_loaded callback ran before plugin activation.' );
+    }
+
     return [
         'metrics' => [
             'deferred_init_context_ok' => 1,
             'deferred_init_after_activation_ok' => 1,
+            'deferred_plugins_loaded_context_ok' => 1,
+            'deferred_plugins_loaded_after_activation_ok' => 1,
         ],
         'metadata' => [
             'fixture' => 'playground-init-lifecycle-host',


### PR DESCRIPTION
## Summary
- Defers plugin-added `plugins_loaded` callbacks immediately after loading plugins in Playground test and bench runners.
- Replays deferred `plugins_loaded` and `init` runtime callbacks after wp-phpunit install and plugin activation.
- Extends the init-lifecycle smoke fixture to prove both callback types run in hook context and observe activation-prepared state.

## Why
WooCommerce's bundled Jetpack connection registers `plugins_loaded` runtime callbacks during plugin load. Those callbacks schedule cron/options work, which fails against Playground's SQLite-backed wp-phpunit install before tables exist. The previous fix moved deferred `init` after activation, but still allowed plugin-added `plugins_loaded` callbacks to run during the half-installed bootstrap.

## Validation
- `bash wordpress/scripts/test/playground-init-lifecycle-smoke.sh` passed.
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-playground-plugins-loaded-after-install --extension wordpress` passed; no root PHPUnit files discovered.
- The test command emitted a warm-machine resource warning before running, then completed successfully.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the second wc-site-generator validation failure shape, drafted the callback deferral fix and fixture assertions, and ran local validation for Chris to review.