### PR TITLE
Sync Rust lockfile before release commits

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -108,6 +108,16 @@
   },
   "actions": [
     {
+      "id": "release.prepare",
+      "label": "Prepare release files",
+      "type": "command",
+      "command": "bash \"{{extension_path}}/scripts/prepare-release.sh\"",
+      "payload": {
+        "release": "{{payload.release}}",
+        "config": "{{payload.config}}"
+      }
+    },
+    {
       "id": "release.package",
       "label": "Package release artifacts",
       "type": "command",

--- a/rust/scripts/prepare-release.sh
+++ b/rust/scripts/prepare-release.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f Cargo.lock ]]; then
+  echo "No Cargo.lock found; skipping Rust release preparation."
+  exit 0
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required for parsing cargo metadata but is not installed." >&2
+  exit 1
+fi
+
+PACKAGE_NAME=$(cargo metadata --format-version 1 --no-deps 2>/dev/null | jq -r '.packages[0].name // empty')
+CURRENT_VERSION=$(cargo metadata --format-version 1 --no-deps 2>/dev/null | jq -r '.packages[0].version // empty')
+
+if [[ -z "$PACKAGE_NAME" || -z "$CURRENT_VERSION" ]]; then
+  echo "Failed to read package info from Cargo.toml" >&2
+  exit 1
+fi
+
+echo "Preparing $PACKAGE_NAME v$CURRENT_VERSION for release..." >&2
+cargo update -p "$PACKAGE_NAME" --precise "$CURRENT_VERSION"

--- a/tests/rust-release-prepare-smoke.sh
+++ b/tests/rust-release-prepare-smoke.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PROJECT_DIR="$TMP_DIR/project"
+mkdir -p "$PROJECT_DIR/src"
+
+cat > "$PROJECT_DIR/Cargo.toml" <<'EOF'
+[package]
+name = "homeboy-release-prepare-fixture"
+version = "0.1.0"
+edition = "2021"
+EOF
+
+cat > "$PROJECT_DIR/src/lib.rs" <<'EOF'
+pub fn answer() -> u8 {
+    42
+}
+EOF
+
+(cd "$PROJECT_DIR" && cargo generate-lockfile --quiet)
+perl -0pi -e 's/version = "0\.1\.0"/version = "0.1.1"/' "$PROJECT_DIR/Cargo.toml"
+
+(cd "$PROJECT_DIR" && bash "$ROOT_DIR/rust/scripts/prepare-release.sh" >/dev/null)
+
+if ! grep -A2 'name = "homeboy-release-prepare-fixture"' "$PROJECT_DIR/Cargo.lock" | grep -q 'version = "0.1.1"'; then
+  echo "Cargo.lock was not updated to the package release version" >&2
+  exit 1
+fi
+
+echo "rust release prepare smoke passed"


### PR DESCRIPTION
## Summary
- Add a Rust `release.prepare` action that runs before Homeboy creates the release commit.
- Update `Cargo.lock` to match the bumped `Cargo.toml` package version before `cargo publish --locked` runs.
- Add a smoke test that proves a bumped fixture lockfile is refreshed.

Depends on Extra-Chill/homeboy#2370 for the core `release.prepare` step.

## Testing
- `jq empty rust/rust.json`
- `bash tests/rust-release-prepare-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Rust extension action, lockfile preparation script, and smoke test; Chris reviewed via this PR workflow.