### PR TITLE
Preserve prepared WordPress validation dependency paths

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -339,10 +339,35 @@ homeboy_resolve_validation_dependency_paths() {
     done
 }
 
+homeboy_merge_validation_dependency_paths() {
+    local existing_paths="${1:-}"
+    local resolved_paths="${2:-}"
+
+    local -A seen_paths=()
+    local -A seen_slugs=()
+    local candidate
+    local candidate_slug
+
+    while IFS= read -r candidate; do
+        [ -n "$candidate" ] || continue
+        [ -d "$candidate" ] || continue
+
+        candidate_slug=$(homeboy_get_validation_dependency_slug "$candidate" || basename "$candidate")
+        if [ -n "${seen_slugs[$candidate_slug]+x}" ] || [ -n "${seen_paths[$candidate]+x}" ]; then
+            continue
+        fi
+
+        seen_slugs["$candidate_slug"]=1
+        seen_paths["$candidate"]=1
+        printf '%s\n' "$candidate"
+    done <<< "${existing_paths}${existing_paths:+$'\n'}${resolved_paths}"
+}
+
 homeboy_export_validation_dependency_paths() {
     local plugin_path="${1:-}"
+    local existing_paths="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
     local resolved_paths
     resolved_paths=$(homeboy_resolve_validation_dependency_paths "$plugin_path" || true)
 
-    export HOMEBOY_WORDPRESS_DEPENDENCY_PATHS="$resolved_paths"
+    export HOMEBOY_WORDPRESS_DEPENDENCY_PATHS="$(homeboy_merge_validation_dependency_paths "$existing_paths" "$resolved_paths")"
 }

--- a/wordpress/tests/validation-dependencies-smoke.sh
+++ b/wordpress/tests/validation-dependencies-smoke.sh
@@ -8,10 +8,11 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 COMPONENT_DIR="${TMPDIR}/intelligence"
 DATA_MACHINE_DIR="${TMPDIR}/data-machine"
+CLONED_DATA_MACHINE_DIR="${TMPDIR}/cache/data-machine"
 AGENTS_API_DIR="${TMPDIR}/agents-api"
 BIN_DIR="${TMPDIR}/bin"
 
-mkdir -p "$COMPONENT_DIR" "$DATA_MACHINE_DIR" "$AGENTS_API_DIR" "$BIN_DIR"
+mkdir -p "$COMPONENT_DIR" "$DATA_MACHINE_DIR" "$CLONED_DATA_MACHINE_DIR" "$AGENTS_API_DIR" "$BIN_DIR"
 
 cat > "${COMPONENT_DIR}/intelligence.php" <<'PHP'
 <?php
@@ -26,6 +27,13 @@ cat > "${DATA_MACHINE_DIR}/data-machine.php" <<'PHP'
 /**
  * Plugin Name: Data Machine
  * Requires Plugins: agents-api
+ */
+PHP
+
+cat > "${CLONED_DATA_MACHINE_DIR}/data-machine.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Data Machine
  */
 PHP
 
@@ -68,6 +76,19 @@ fi
 if ! grep -F -- "$AGENTS_API_DIR" <<< "$resolved" >/dev/null; then
     echo "FAIL: transitive Requires Plugins dependency was not resolved" >&2
     printf '%s\n' "$resolved" >&2
+    exit 1
+fi
+
+merged=$(homeboy_merge_validation_dependency_paths "$DATA_MACHINE_DIR" "$CLONED_DATA_MACHINE_DIR")
+if ! grep -F -- "$DATA_MACHINE_DIR" <<< "$merged" >/dev/null; then
+    echo "FAIL: existing prepared dependency path was not preserved" >&2
+    printf '%s\n' "$merged" >&2
+    exit 1
+fi
+
+if grep -F -- "$CLONED_DATA_MACHINE_DIR" <<< "$merged" >/dev/null; then
+    echo "FAIL: cloned dependency path was not deduplicated by plugin slug" >&2
+    printf '%s\n' "$merged" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Preserve pre-supplied `HOMEBOY_WORDPRESS_DEPENDENCY_PATHS` when exporting WordPress validation dependency paths.
- Emit prepared paths before resolver-discovered paths and dedupe by plugin slug/path so CI does not replace prepared checkouts with fallback clones.
- Extend the validation dependency smoke test to cover prepared path precedence over cloned duplicates.

## Validation
- `bash -n wordpress/scripts/lib/validation-dependencies.sh`
- `bash -n wordpress/tests/validation-dependencies-smoke.sh`
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the CI dependency-clobbering failure, drafted the helper/test changes, and ran local validation. Chris reviewed and directed the workflow.