### PR TITLE
Fix prepared validation dependency path merging

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -360,7 +360,7 @@ homeboy_merge_validation_dependency_paths() {
         seen_slugs["$candidate_slug"]=1
         seen_paths["$candidate"]=1
         printf '%s\n' "$candidate"
-    done <<< "${existing_paths}${existing_paths:+$'\n'}${resolved_paths}"
+    done < <(printf '%s\n%s\n' "$existing_paths" "$resolved_paths")
 }
 
 homeboy_export_validation_dependency_paths() {

--- a/wordpress/tests/validation-dependencies-smoke.sh
+++ b/wordpress/tests/validation-dependencies-smoke.sh
@@ -10,9 +10,10 @@ COMPONENT_DIR="${TMPDIR}/intelligence"
 DATA_MACHINE_DIR="${TMPDIR}/data-machine"
 CLONED_DATA_MACHINE_DIR="${TMPDIR}/cache/data-machine"
 AGENTS_API_DIR="${TMPDIR}/agents-api"
+OPENAI_PROVIDER_DIR="${TMPDIR}/ai-provider-for-openai"
 BIN_DIR="${TMPDIR}/bin"
 
-mkdir -p "$COMPONENT_DIR" "$DATA_MACHINE_DIR" "$CLONED_DATA_MACHINE_DIR" "$AGENTS_API_DIR" "$BIN_DIR"
+mkdir -p "$COMPONENT_DIR" "$DATA_MACHINE_DIR" "$CLONED_DATA_MACHINE_DIR" "$AGENTS_API_DIR" "$OPENAI_PROVIDER_DIR" "$BIN_DIR"
 
 cat > "${COMPONENT_DIR}/intelligence.php" <<'PHP'
 <?php
@@ -41,6 +42,13 @@ cat > "${AGENTS_API_DIR}/agents-api.php" <<'PHP'
 <?php
 /**
  * Plugin Name: Agents API
+ */
+PHP
+
+cat > "${OPENAI_PROVIDER_DIR}/ai-provider-for-openai.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: AI Provider for OpenAI
  */
 PHP
 
@@ -89,6 +97,20 @@ fi
 if grep -F -- "$CLONED_DATA_MACHINE_DIR" <<< "$merged" >/dev/null; then
     echo "FAIL: cloned dependency path was not deduplicated by plugin slug" >&2
     printf '%s\n' "$merged" >&2
+    exit 1
+fi
+
+prepared_paths="${DATA_MACHINE_DIR}"$'\n'"${OPENAI_PROVIDER_DIR}"
+merged_prepared=$(homeboy_merge_validation_dependency_paths "$prepared_paths" "$CLONED_DATA_MACHINE_DIR")
+if ! grep -F -- "$DATA_MACHINE_DIR" <<< "$merged_prepared" >/dev/null || ! grep -F -- "$OPENAI_PROVIDER_DIR" <<< "$merged_prepared" >/dev/null; then
+    echo "FAIL: multi-line prepared dependency paths were not preserved" >&2
+    printf '%s\n' "$merged_prepared" >&2
+    exit 1
+fi
+
+if grep -F -- "$CLONED_DATA_MACHINE_DIR" <<< "$merged_prepared" >/dev/null; then
+    echo "FAIL: multi-line prepared dependency paths did not deduplicate cloned dependency" >&2
+    printf '%s\n' "$merged_prepared" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Merge prepared and resolved WordPress validation dependency paths using a real newline-preserving stream.
- Cover multi-line prepared dependency paths so CI-provided checkouts are preserved before fallback clones.

## Validation
- `bash -n wordpress/scripts/lib/validation-dependencies.sh`
- `bash -n wordpress/tests/validation-dependencies-smoke.sh`
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the prepared-path merge bug from the downstream CI rerun, drafted the fix and regression coverage, and ran local validation. Chris reviewed and directed the workflow.