### PR TITLE
fix(wordpress): skip resolved dependency slugs

### DIFF
--- a/wordpress/scripts/bench/playground-bench-dependency-worktree-dedupe-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-dependency-worktree-dedupe-smoke.sh
@@ -13,6 +13,7 @@ WORKTREE_DEP_DIR="${TMPROOT}/data-machine@fix-run-flow-paused-manual"
 RUNTIME_DIR="${TMPROOT}/runtime"
 BIN_DIR="${TMPROOT}/bin"
 RESULTS_TMPFILE="${TMPROOT}/bench-results.json"
+RESOLVED_SLUG_MARKER="${TMPROOT}/resolved-header-slug"
 
 mkdir -p \
     "${EXTENSION_PATH}/node_modules/.bin" \
@@ -61,6 +62,7 @@ cat > "${BIN_DIR}/homeboy" <<SH
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "component" ] && [ "\${2:-}" = "show" ] && [ "\${3:-}" = "data-machine" ]; then
+    touch "$RESOLVED_SLUG_MARKER"
     printf '{"data":{"entity":{"local_path":"%s"}}}\n' "$CANONICAL_DEP_DIR"
     exit 0
 fi
@@ -153,6 +155,11 @@ HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
 
 if [ ! -s "$RESULTS_TMPFILE" ]; then
     echo "expected bench results file to be written" >&2
+    exit 1
+fi
+
+if [ -e "$RESOLVED_SLUG_MARKER" ]; then
+    echo "header slug was resolved even though settings already supplied the dependency path" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -298,6 +298,10 @@ homeboy_resolve_validation_dependency_paths() {
         fi
         seen_dependencies["$dependency"]=1
 
+        if [[ "$dependency" != */* ]] && [ -n "${seen_slugs[$dependency]+x}" ]; then
+            continue
+        fi
+
         local resolved
         resolved=$(homeboy_resolve_validation_dependency_path "$dependency" || true)
 


### PR DESCRIPTION
## Summary
- Avoid resolving/cloning a header dependency slug when a prepared validation dependency path already satisfied the same plugin slug.
- Tighten the Playground bench dependency dedupe smoke so it fails if the fallback resolver is invoked after a prepared path wins.

## Testing
- `bash wordpress/scripts/bench/playground-bench-dependency-worktree-dedupe-smoke.sh`
- `git diff --check`
- `bash -n wordpress/scripts/lib/validation-dependencies.sh wordpress/scripts/bench/playground-bench-dependency-worktree-dedupe-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the CI dependency-resolution failure, drafted the minimal resolver guard and smoke-test assertion, and ran local validation. Chris remains responsible for review and merge.