### PR TITLE
Fix Playground ability init after deferred bootstrap

### DIFF
--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -250,6 +250,8 @@ if ($installed_site_mode) {
     // activated-plugin request, these callbacks observe schemas/options
     // prepared by activation.
     $pre_replayed_plugins_loaded_init_callbacks = pg_snapshot_wordpress_hook_callbacks('init');
+    $reopened_ability_categories_init = pg_reopen_wordpress_action('wp_abilities_api_categories_init');
+    $reopened_ability_init = pg_reopen_wordpress_action('wp_abilities_api_init');
     pg_run_deferred_wordpress_hook_callbacks($deferred_install_plugins_loaded_callbacks, [], 'plugins_loaded');
     $deferred_install_init_callbacks = array_merge(
         $deferred_install_init_callbacks,
@@ -259,6 +261,8 @@ if ($installed_site_mode) {
         return ($left['priority'] ?? 10) <=> ($right['priority'] ?? 10);
     });
     pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks, [], 'init');
+    pg_fire_reopened_wordpress_action('wp_abilities_api_categories_init', $reopened_ability_categories_init);
+    pg_fire_reopened_wordpress_action('wp_abilities_api_init', $reopened_ability_init);
 }
 
 /**

--- a/wordpress/scripts/lib/playground-bootstrap.php
+++ b/wordpress/scripts/lib/playground-bootstrap.php
@@ -326,6 +326,39 @@ function pg_run_deferred_wordpress_hook_callbacks(array $deferred, array $args =
     }
 }
 
+/**
+ * Reopen a one-shot WordPress action so callbacks replayed after install can
+ * still attach to lazy registries that may have initialized during install.
+ */
+function pg_reopen_wordpress_action(string $hook_name): bool {
+    global $wp_actions;
+
+    if (!function_exists('did_action') || did_action($hook_name) === 0) {
+        return false;
+    }
+
+    if (!is_array($wp_actions)) {
+        $wp_actions = [];
+    }
+
+    $wp_actions[$hook_name] = 0;
+    pg_log("NOTICE:reopened WordPress action after install: {$hook_name}");
+
+    return true;
+}
+
+/**
+ * Fire a reopened one-shot WordPress action after deferred plugin callbacks
+ * have been replayed.
+ */
+function pg_fire_reopened_wordpress_action(string $hook_name, bool $reopened): void {
+    if (!$reopened || !function_exists('do_action')) {
+        return;
+    }
+
+    do_action($hook_name);
+}
+
 // ---------------------------------------------------------------------------
 // Stage executors
 // ---------------------------------------------------------------------------

--- a/wordpress/scripts/test/playground-runner.php
+++ b/wordpress/scripts/test/playground-runner.php
@@ -172,6 +172,8 @@ pg_run_activation_stage(['plugin_files' => $activation_files]);
 // activated-plugin request, these callbacks observe schemas/options prepared by
 // activation.
 $pre_replayed_plugins_loaded_init_callbacks = pg_snapshot_wordpress_hook_callbacks('init');
+$reopened_ability_categories_init = pg_reopen_wordpress_action('wp_abilities_api_categories_init');
+$reopened_ability_init = pg_reopen_wordpress_action('wp_abilities_api_init');
 pg_run_deferred_wordpress_hook_callbacks($deferred_install_plugins_loaded_callbacks, [], 'plugins_loaded');
 $deferred_install_init_callbacks = array_merge(
     $deferred_install_init_callbacks,
@@ -181,6 +183,8 @@ usort($deferred_install_init_callbacks, static function (array $left, array $rig
     return ($left['priority'] ?? 10) <=> ($right['priority'] ?? 10);
 });
 pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks, [], 'init');
+pg_fire_reopened_wordpress_action('wp_abilities_api_categories_init', $reopened_ability_categories_init);
+pg_fire_reopened_wordpress_action('wp_abilities_api_init', $reopened_ability_init);
 
 // ---------------------------------------------------------------------------
 // Stage: load_fixtures (test case classes, mock mailer, harness filters)


### PR DESCRIPTION
## Summary
- Reopen and replay Abilities API init hooks when Playground defers plugin `plugins_loaded` callbacks past wp-phpunit install.
- Apply the replay path to both PHPUnit and benchmark Playground runners so ability registration survives install-time lazy registry initialization.

## Validation
- `php -l wordpress/scripts/lib/playground-bootstrap.php`
- `php -l wordpress/scripts/test/playground-runner.php`
- `php -l wordpress/scripts/bench/playground-bench-runner.php`
- `bash wordpress/scripts/test/playground-dep-plugins-loaded-smoke.sh`
- `homeboy test data-machine --path "/Users/chubes/Developer/data-machine@fix-agents-api-plugin-dependency" --changed-since 92da579dd35d20bc488da57379240543c17cd6e6 --setting playground_wordpress_version=7.0`

## Notes
- This fixes the remote-only Data Machine PR #1794 failure where `wp_get_ability(...)->execute()` errored because plugin ability callbacks were replayed after `wp_abilities_api_init` had already fired during install.
- `homeboy lint --path ... --extension wordpress` still reports existing repo-wide lint noise unrelated to this patch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-caused the Playground bootstrap regression, drafted the runner patch, and ran local validation; Chris reviewed and directed opening this PR.