### PR TITLE
fix(wordpress): preserve resolved dependency order

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -352,6 +352,8 @@ homeboy_merge_validation_dependency_paths() {
 
     local -A seen_paths=()
     local -A seen_slugs=()
+    local -A existing_by_slug=()
+    local -a existing_order=()
     local candidate
     local candidate_slug
 
@@ -360,14 +362,45 @@ homeboy_merge_validation_dependency_paths() {
         [ -d "$candidate" ] || continue
 
         candidate_slug=$(homeboy_get_validation_dependency_slug "$candidate" || basename "$candidate")
-        if [ -n "${seen_slugs[$candidate_slug]+x}" ] || [ -n "${seen_paths[$candidate]+x}" ]; then
+        if [ -n "${existing_by_slug[$candidate_slug]+x}" ]; then
             continue
+        fi
+
+        existing_by_slug["$candidate_slug"]="$candidate"
+        existing_order+=("$candidate_slug")
+    done <<< "$existing_paths"
+
+    homeboy_emit_merged_validation_dependency_path() {
+        local candidate="${1:-}"
+        [ -n "$candidate" ] || return 0
+        [ -d "$candidate" ] || return 0
+
+        local candidate_slug
+        candidate_slug=$(homeboy_get_validation_dependency_slug "$candidate" || basename "$candidate")
+        if [ -n "${seen_slugs[$candidate_slug]+x}" ] || [ -n "${seen_paths[$candidate]+x}" ]; then
+            return 0
         fi
 
         seen_slugs["$candidate_slug"]=1
         seen_paths["$candidate"]=1
         printf '%s\n' "$candidate"
-    done < <(printf '%s\n%s\n' "$existing_paths" "$resolved_paths")
+    }
+
+    while IFS= read -r candidate; do
+        [ -n "$candidate" ] || continue
+        [ -d "$candidate" ] || continue
+
+        candidate_slug=$(homeboy_get_validation_dependency_slug "$candidate" || basename "$candidate")
+        if [ -n "${existing_by_slug[$candidate_slug]+x}" ]; then
+            homeboy_emit_merged_validation_dependency_path "${existing_by_slug[$candidate_slug]}"
+        else
+            homeboy_emit_merged_validation_dependency_path "$candidate"
+        fi
+    done <<< "$resolved_paths"
+
+    for candidate_slug in "${existing_order[@]}"; do
+        homeboy_emit_merged_validation_dependency_path "${existing_by_slug[$candidate_slug]}"
+    done
 }
 
 homeboy_export_validation_dependency_paths() {

--- a/wordpress/tests/validation-dependencies-smoke.sh
+++ b/wordpress/tests/validation-dependencies-smoke.sh
@@ -122,4 +122,20 @@ if grep -F -- "$CLONED_DATA_MACHINE_DIR" <<< "$merged_prepared" >/dev/null; then
     exit 1
 fi
 
+topological_resolved="${AGENTS_API_DIR}"$'\n'"${DATA_MACHINE_DIR}"
+merged_topological=$(homeboy_merge_validation_dependency_paths "$prepared_paths" "$topological_resolved")
+agents_api_merged_line=$(grep -nF -- "$AGENTS_API_DIR" <<< "$merged_topological" | cut -d: -f1 | head -1)
+data_machine_merged_line=$(grep -nF -- "$DATA_MACHINE_DIR" <<< "$merged_topological" | cut -d: -f1 | head -1)
+if [ "$agents_api_merged_line" -ge "$data_machine_merged_line" ]; then
+    echo "FAIL: merge should preserve resolved transitive dependency order" >&2
+    printf '%s\n' "$merged_topological" >&2
+    exit 1
+fi
+
+if ! grep -F -- "$OPENAI_PROVIDER_DIR" <<< "$merged_topological" >/dev/null; then
+    echo "FAIL: merge should append unrelated prepared dependency paths" >&2
+    printf '%s\n' "$merged_topological" >&2
+    exit 1
+fi
+
 echo "Validation dependency smoke passed"


### PR DESCRIPTION
## Summary
- Preserve resolver topological order when merging prepared dependency paths with auto-resolved dependencies.
- Keep prepared paths as the preferred physical checkout for each plugin slug.
- Append unrelated prepared paths after resolver-known dependencies so existing explicit mounts still survive.

## Why
PR #476 made transitive dependencies resolve before dependents, but CI still failed because `HOMEBOY_WORDPRESS_DEPENDENCY_PATHS` was merged ahead of the resolver output. That let `data-machine` load before its transitive `agents-api` dependency, causing `Class \"WP_Agent_Memory_Layer\" not found`.

Failed proof run: https://github.com/chubes4/wc-site-generator/actions/runs/25561608086

## Testing
- `bash -n wordpress/scripts/lib/validation-dependencies.sh wordpress/tests/validation-dependencies-smoke.sh wordpress/scripts/bench/playground-bench-dependency-worktree-dedupe-smoke.sh`
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `bash wordpress/scripts/bench/playground-bench-dependency-worktree-dedupe-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the prepared-path merge ordering regression after the CI run, drafted the resolver merge/test change, and ran focused validation. Chris approved opening the PR.