### PR TITLE
fix(wordpress): allow disabling bench warmup

### DIFF
--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -281,6 +281,25 @@ fi
 
 ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-10}"
 
+# Warmup iterations are useful for pure performance workloads because they
+# discard autoload / OPcache cold-start cost. Configured Playground workloads
+# can also drive side-effectful integration flows, so let callers opt out.
+BENCH_WARMUP_ITERATIONS="${HOMEBOY_BENCH_WARMUP_ITERATIONS:-}"
+if [ -z "$BENCH_WARMUP_ITERATIONS" ] && [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.bench_warmup_iterations // empty' 2>/dev/null || true)
+    if [ -n "$extracted" ] && [ "$extracted" != "null" ]; then
+        BENCH_WARMUP_ITERATIONS="$extracted"
+    fi
+fi
+if [ -z "$BENCH_WARMUP_ITERATIONS" ]; then
+    BENCH_WARMUP_ITERATIONS="1"
+fi
+if ! [[ "$BENCH_WARMUP_ITERATIONS" =~ ^[0-9]+$ ]]; then
+    echo "Error: bench_warmup_iterations must be a non-negative integer (got '$BENCH_WARMUP_ITERATIONS')" >&2
+    FAILED_STEP="Bench warmup setup"
+    exit 1
+fi
+
 # ---------------------------------------------------------------------------
 # Build VFS mount args (mirrors test-runner-playground.sh shape)
 # ---------------------------------------------------------------------------
@@ -470,6 +489,7 @@ sed \
     -e "s|{{PLUGIN_SLUG}}|${PLUGIN_SLUG}|g" \
     -e "s|{{COMPONENT_ID}}|${COMPONENT_ID}|g" \
     -e "s|{{ITERATIONS}}|${ITERATIONS}|g" \
+    -e "s|{{WARMUP_ITERATIONS}}|${BENCH_WARMUP_ITERATIONS}|g" \
     -e "s|{{PLAYGROUND_DEP_MOUNTS}}|${PLAYGROUND_DEP_MOUNTS}|g" \
     -e "s|{{PLAYGROUND_BLUEPRINT_PLUGIN_SLUGS}}|${PLAYGROUND_BLUEPRINT_PLUGIN_SLUGS}|g" \
     -e "s|{{SHARED_STATE_PATH}}|${SHARED_STATE_GUEST}|g" \
@@ -489,6 +509,7 @@ sed \
 echo "Running performance benchmarks via WordPress Playground..."
 echo "  Plugin: ${PLUGIN_SLUG} (${PLUGIN_PATH})"
 echo "  Iterations: ${ITERATIONS}"
+echo "  Warmup iterations: ${BENCH_WARMUP_ITERATIONS}"
 echo "  Backend: playground (PHP-WASM + SQLite)"
 echo "  Site mode: ${BENCH_SITE_MODE}"
 if [ "$LIST_ONLY" = "1" ]; then

--- a/wordpress/scripts/bench/playground-bench-configured-workloads-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-configured-workloads-smoke.sh
@@ -39,7 +39,7 @@ fi
 RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-configured-workloads-smoke.XXXXXX")
 
 cleanup() {
-    rm -f "$RESULTS_TMPFILE" "${FIXTURE_DIR}/workloads/report.json"
+    rm -f "$RESULTS_TMPFILE" "${FIXTURE_DIR}/workloads/report.json" "${FIXTURE_DIR}/workloads/count.txt"
 }
 trap cleanup EXIT
 
@@ -66,7 +66,8 @@ SETTINGS_JSON=$(cat <<'JSON'
         "source": "settings"
       }
     }
-  ]
+  ],
+  "bench_warmup_iterations": 0
 }
 JSON
 )
@@ -76,6 +77,7 @@ echo "Playground bench configured workloads smoke test"
 echo "============================================"
 echo "Fixture:    $FIXTURE_DIR"
 echo "Iterations: 2 (per configured workload)"
+echo "Warmup:    0"
 echo ""
 
 HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
@@ -136,6 +138,13 @@ if [ "$artifact_path" != "workloads/report.json" ] || [ "$artifact_label" != "Ge
     exit 1
 fi
 echo "✓ configured workload artifacts emitted"
+
+run_count=$(jq -r '.run_count // "missing"' "${FIXTURE_DIR}/workloads/report.json")
+if [ "$run_count" != "2" ]; then
+    echo "ERROR: expected configured workload to run exactly 2 times with zero warmup, got $run_count" >&2
+    exit 1
+fi
+echo "✓ configured workload warmup can be disabled"
 
 echo ""
 echo "============================================"

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -927,10 +927,13 @@ function pg_bench_record_workload_result($result, array &$custom_metric_samples,
 pg_stage_begin('run_workloads');
 $scenarios = [];
 $iterations_per_workload = (int) '{{ITERATIONS}}';
-$warmup_iterations = 1; // Discard first iteration (autoload + OPcache warmup).
+$warmup_iterations = (int) '{{WARMUP_ITERATIONS}}';
 
 if ($iterations_per_workload < 1) {
     $iterations_per_workload = 1;
+}
+if ($warmup_iterations < 0) {
+    $warmup_iterations = 0;
 }
 
 if (HOMEBOY_BENCH_LIST_ONLY) {

--- a/wordpress/tests/fixtures/playground-workloads/workloads/configured.php
+++ b/wordpress/tests/fixtures/playground-workloads/workloads/configured.php
@@ -1,9 +1,15 @@
 <?php
 
 $report_path = __DIR__ . '/report.json';
+$count_path = __DIR__ . '/count.txt';
+$run_count = is_file($count_path) ? (int) file_get_contents($count_path) : 0;
+$run_count++;
+file_put_contents($count_path, (string) $run_count);
+
 file_put_contents($report_path, json_encode([
     'ok' => true,
     'source' => 'configured-playground-workload',
+    'run_count' => $run_count,
 ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
 return [


### PR DESCRIPTION
## Summary
- Add `bench_warmup_iterations` / `HOMEBOY_BENCH_WARMUP_ITERATIONS` for Playground bench runs.
- Preserve the historical default of one warmup iteration.
- Cover `bench_warmup_iterations: 0` for configured Playground workloads.

## Why
The wc-static-site-agent proof now gets through bootstrap, agent import, OpenAI generation, PR creation, and transcript export, but the workflow still fails because the side-effectful configured workload is run once as warmup and once as the measured iteration. The measured iteration attempts to publish the same static branch/PR again and receives GitHub 422.

This is an upstream runner contract gap: configured Playground workloads can be integration flows with side effects, not only pure benchmark functions.

Failed proof run: https://github.com/chubes4/wc-site-generator/actions/runs/25566244082

## Testing
- `bash -n wordpress/scripts/bench/bench-runner-playground.sh wordpress/scripts/bench/playground-bench-configured-workloads-smoke.sh wordpress/scripts/bench/playground-bench-shared-state-smoke.sh`
- `php -l wordpress/scripts/bench/playground-bench-runner.php`
- `php -l wordpress/tests/fixtures/playground-workloads/workloads/configured.php`
- `bash wordpress/scripts/bench/playground-bench-configured-workloads-smoke.sh`
- `bash wordpress/scripts/bench/playground-bench-shared-state-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the warmup/side-effect interaction, drafted the configurable warmup support and smoke coverage, and ran focused validation.