### PR TITLE
fix(wordpress): skip dependency drop-ins during playground load

### DIFF
--- a/wordpress/scripts/bench/playground-bench-dep-dropin-skip-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-dep-dropin-skip-smoke.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Validation-dependency db.php skip smoke.
+#
+# Asserts dependency plugin discovery ignores db.php even when that drop-in has
+# a Plugin Name header and sorts before the dependency's actual entry file.
+#
+# Usage: bash wordpress/scripts/bench/playground-bench-dep-dropin-skip-smoke.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOST_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-plugins-loaded-host"
+
+if [ ! -d "$HOST_FIXTURE_DIR" ]; then
+    echo "ERROR: host fixture not found at $HOST_FIXTURE_DIR" >&2
+    exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    exit 1
+fi
+
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-dep-dropin.XXXXXX")
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-dep-dropin-skip.XXXXXX")
+cleanup() {
+    rm -rf "$TMP_DIR"
+    rm -f "$RESULTS_TMPFILE"
+}
+trap cleanup EXIT
+
+cat > "$TMP_DIR/db.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Dependency Drop-in That Must Be Skipped
+ */
+
+throw new RuntimeException( 'Dependency db.php was loaded as a plugin entry.' );
+PHP
+
+cat > "$TMP_DIR/plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Dependency Actual Plugin Entry
+ */
+
+add_action( 'plugins_loaded', static function (): void {
+    $GLOBALS['homeboy_bench_426_dep_plugins_loaded_fired'] = true;
+} );
+PHP
+
+SETTINGS_JSON=$(jq -n --arg dep "$TMP_DIR" '{"validation_dependencies": [$dep]}')
+
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
+HOMEBOY_COMPONENT_ID=bench-plugins-loaded-host \
+HOMEBOY_COMPONENT_PATH="$HOST_FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+scenario='.scenarios[] | select(.id == "assert-dep-plugins-loaded")'
+fired=$(jq -r "$scenario | .metrics.dep_plugins_loaded_fired_mean // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$fired" != "1" ]; then
+    echo "ERROR: dep plugin entry was not loaded after skipping db.php (got $fired)" >&2
+    exit 1
+fi
+
+echo "✓ Dependency db.php skip smoke PASSED"

--- a/wordpress/scripts/lib/playground-bootstrap.php
+++ b/wordpress/scripts/lib/playground-bootstrap.php
@@ -643,6 +643,13 @@ function pg_run_load_deps_stage(array $cfg): array {
                 }
                 $dep_files = glob("$dep_mount/*.php") ?: [];
                 foreach ($dep_files as $df) {
+                    // db.php is a WordPress drop-in, not a plugin entry file.
+                    // Dependencies can ship one too, and re-loading it after
+                    // wp-settings.php has already loaded the active drop-in
+                    // re-runs database side effects.
+                    if (basename($df) === 'db.php') {
+                        continue;
+                    }
                     if (strpos(file_get_contents($df), 'Plugin Name:') !== false) {
                         require_once $df;
                         $loaded[] = $df;


### PR DESCRIPTION
## Summary
- Skip `db.php` while discovering validation dependency plugin entry files in the Playground bootstrap.
- Match the existing component-loading behavior so dependency drop-ins are not re-required after WordPress has already loaded the active drop-in.
- Add a manual Playground bench smoke that proves a dependency `db.php` with a `Plugin Name` header is ignored and the real plugin entry still loads.

## Testing
- `php -l wordpress/scripts/lib/playground-bootstrap.php`
- `git diff --check`
- `wordpress/scripts/bench/playground-bench-dep-dropin-skip-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the Playground dependency drop-in regression, drafting the focused fix and smoke coverage, and running local validation. Chris reviewed the direction and requested the upstream PR.