### PR TITLE
Add a generic Data Machine agent runner

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-runner-smoke.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/playground-workloads"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required" >&2
+    exit 1
+fi
+
+CONFIG_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/datamachine-agent-config.XXXXXX.json")
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/datamachine-agent-results.XXXXXX.json")
+cleanup() {
+    rm -f "$CONFIG_TMPFILE" "$RESULTS_TMPFILE"
+}
+trap cleanup EXIT
+
+jq -n \
+    --arg componentPath "$FIXTURE_DIR" \
+    '{
+        component_id: "playground-workloads",
+        component_path: $componentPath,
+        workload_id: "datamachine-agent-dry-run",
+        workload_label: "Data Machine agent dry run",
+        dry_run: true,
+        agent_slug: "example-agent",
+        flow_slug: "example-flow",
+        provider: "example-provider",
+        model: "example-model",
+        prompt: "Dry-run the generic Data Machine agent workload."
+    }' > "$CONFIG_TMPFILE"
+
+HOMEBOY_DATAMACHINE_AGENT_RESULTS_FILE="$RESULTS_TMPFILE" \
+    bash "$SCRIPT_DIR/run-datamachine-agent.sh" "$CONFIG_TMPFILE"
+
+scenario='.scenarios[] | select(.id == "datamachine-agent-dry-run")'
+if ! jq -e "$scenario" "$RESULTS_TMPFILE" >/dev/null; then
+    echo "ERROR: datamachine-agent-dry-run scenario missing" >&2
+    cat "$RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+for metric in config_present_mean dry_run_mean; do
+    value=$(jq -r "$scenario | .metrics.${metric} // \"missing\"" "$RESULTS_TMPFILE")
+    if [ "$value" != "1" ]; then
+        echo "ERROR: ${metric} expected 1, got ${value}" >&2
+        cat "$RESULTS_TMPFILE" >&2
+        exit 1
+    fi
+done
+
+provider=$(jq -r "$scenario | .metadata.provider // \"missing\"" "$RESULTS_TMPFILE")
+model=$(jq -r "$scenario | .metadata.model // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$provider" != "example-provider" ] || [ "$model" != "example-model" ]; then
+    echo "ERROR: provider/model metadata missing (provider=$provider model=$model)" >&2
+    cat "$RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+echo "✓ Data Machine agent runner smoke test PASSED"

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1,0 +1,374 @@
+<?php
+/**
+ * Generic Data Machine agent workload for WordPress Playground runs.
+ *
+ * Configuration is read from HOMEBOY_DATAMACHINE_AGENT_CONFIG as JSON.
+ */
+
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Database\Chat\ConversationStoreFactory;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\PluginSettings;
+
+if ( ! function_exists( 'homeboy_datamachine_agent_result' ) ) {
+    function homeboy_datamachine_agent_result( array $metrics, array $metadata, ?string $error = null ): array {
+        if ( null !== $error ) {
+            $metadata['error'] = $error;
+        }
+
+        return array(
+            'metrics'  => $metrics,
+            'metadata' => $metadata,
+        );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_config' ) ) {
+    function homeboy_datamachine_agent_config(): array {
+        $raw = trim( (string) getenv( 'HOMEBOY_DATAMACHINE_AGENT_CONFIG' ) );
+        if ( '' === $raw ) {
+            return array();
+        }
+
+        $config = json_decode( $raw, true );
+        return is_array( $config ) ? $config : array();
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_scalar' ) ) {
+    function homeboy_datamachine_agent_scalar( array $config, string $key, string $default = '' ): string {
+        $value = $config[ $key ] ?? $default;
+        return is_scalar( $value ) ? trim( (string) $value ) : $default;
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_bootstrap_provider' ) ) {
+    function homeboy_datamachine_agent_bootstrap_provider( array $config ): void {
+        $function = homeboy_datamachine_agent_scalar( $config, 'provider_register_function' );
+        if ( '' !== $function && function_exists( $function ) ) {
+            call_user_func( $function );
+        }
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_bootstrap_abilities' ) ) {
+    function homeboy_datamachine_agent_bootstrap_abilities(): ?array {
+        if ( ! function_exists( 'did_action' ) || ! function_exists( 'do_action' ) ) {
+            return homeboy_datamachine_agent_result( array( 'has_actions_api' => 0 ), array(), 'WordPress action API not available' );
+        }
+
+        if ( ! did_action( 'wp_abilities_api_categories_init' ) ) {
+            do_action( 'wp_abilities_api_categories_init' );
+        }
+        if ( ! did_action( 'wp_abilities_api_init' ) ) {
+            do_action( 'wp_abilities_api_init' );
+        }
+
+        if ( ! function_exists( 'wp_get_ability' ) ) {
+            return homeboy_datamachine_agent_result( array( 'has_abilities_api' => 0 ), array(), 'Abilities API not loaded' );
+        }
+
+        return null;
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_configure_settings' ) ) {
+    function homeboy_datamachine_agent_configure_settings( array $config ): array {
+        $provider = homeboy_datamachine_agent_scalar( $config, 'provider', 'openai' );
+        $model    = homeboy_datamachine_agent_scalar( $config, 'model', 'gpt-5.5' );
+        $settings = function_exists( 'get_option' ) ? (array) get_option( 'datamachine_settings', array() ) : array();
+
+        $github_token_env = homeboy_datamachine_agent_scalar( $config, 'github_token_env', 'GITHUB_TOKEN' );
+        $github_token     = trim( (string) getenv( $github_token_env ) );
+        $target_repo      = homeboy_datamachine_agent_scalar( $config, 'target_repo' );
+        if ( '' !== $github_token && '' !== $target_repo ) {
+            $allowed_repos = is_array( $config['allowed_repos'] ?? null ) ? $config['allowed_repos'] : array( $target_repo );
+            $profile_id    = homeboy_datamachine_agent_scalar( $config, 'github_profile_id', 'homeboy-agent-ci' );
+            $settings['github_credential_profiles'] = array(
+                array(
+                    'id'            => $profile_id,
+                    'label'         => 'Homeboy agent CI token',
+                    'mode'          => 'pat',
+                    'pat'           => $github_token,
+                    'default_repo'  => $target_repo,
+                    'allowed_repos' => array_values( array_unique( array_filter( array_map( 'strval', $allowed_repos ) ) ) ),
+                ),
+            );
+            $settings['github_default_profile_id'] = $profile_id;
+            $settings['github_default_repo']       = $target_repo;
+        }
+
+        $settings['default_provider'] = $provider;
+        $settings['default_model']    = $model;
+        $settings['mode_models']      = array(
+            'pipeline' => array( 'provider' => $provider, 'model' => $model ),
+            'chat'     => array( 'provider' => $provider, 'model' => $model ),
+            'system'   => array( 'provider' => $provider, 'model' => $model ),
+        );
+        $settings['max_turns']        = isset( $config['max_turns'] ) ? max( 1, (int) $config['max_turns'] ) : 12;
+
+        if ( isset( $config['daily_memory_enabled'] ) ) {
+            $settings['daily_memory_enabled'] = (bool) $config['daily_memory_enabled'];
+        }
+
+        update_option( 'datamachine_settings', $settings, false );
+
+        $credential_options = is_array( $config['provider_credentials'] ?? null ) ? $config['provider_credentials'] : array();
+        foreach ( $credential_options as $option_name => $env_name ) {
+            if ( ! is_string( $option_name ) || '' === $option_name || ! is_scalar( $env_name ) ) {
+                continue;
+            }
+            $credential = trim( (string) getenv( (string) $env_name ) );
+            if ( '' !== $credential ) {
+                update_option( $option_name, $credential, false );
+            }
+        }
+
+        if ( class_exists( PluginSettings::class ) ) {
+            PluginSettings::clearCache();
+        }
+
+        return $settings;
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_export_transcript' ) ) {
+    function homeboy_datamachine_agent_export_transcript( int $job_id, array $engine_data, string $transcript_dir ): array {
+        $session_id = (string) ( $engine_data['transcript_session_id'] ?? '' );
+        if ( '' === $session_id || '' === $transcript_dir || ! class_exists( ConversationStoreFactory::class ) ) {
+            return array();
+        }
+
+        $store   = ConversationStoreFactory::get();
+        $session = $store->get_session( $session_id );
+        if ( ! $session ) {
+            return array( 'session_id' => $session_id, 'error' => 'Transcript session missing' );
+        }
+
+        if ( ! is_dir( $transcript_dir ) && function_exists( 'wp_mkdir_p' ) && ! wp_mkdir_p( $transcript_dir ) ) {
+            return array( 'session_id' => $session_id, 'error' => 'Transcript directory could not be created' );
+        }
+
+        $path = rtrim( $transcript_dir, '/' ) . '/job-' . $job_id . '-transcript.json';
+        file_put_contents(
+            $path,
+            wp_json_encode(
+                array(
+                    'job_id'     => $job_id,
+                    'session_id' => $session_id,
+                    'provider'   => $session['provider'] ?? null,
+                    'model'      => $session['model'] ?? null,
+                    'metadata'   => is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array(),
+                    'messages'   => is_array( $session['messages'] ?? null ) ? $session['messages'] : array(),
+                ),
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+            )
+        );
+
+        return array(
+            'session_id' => $session_id,
+            'json'       => $path,
+        );
+    }
+}
+
+if ( function_exists( 'wp_set_current_user' ) ) {
+    wp_set_current_user( 1 );
+}
+
+$config = homeboy_datamachine_agent_config();
+if ( empty( $config ) ) {
+    return homeboy_datamachine_agent_result( array( 'config_present' => 0 ), array(), 'HOMEBOY_DATAMACHINE_AGENT_CONFIG is required' );
+}
+
+if ( ! empty( $config['dry_run'] ) ) {
+    return homeboy_datamachine_agent_result(
+        array( 'config_present' => 1, 'dry_run' => 1 ),
+        array(
+            'agent_slug' => homeboy_datamachine_agent_scalar( $config, 'agent_slug' ),
+            'flow_slug'  => homeboy_datamachine_agent_scalar( $config, 'flow_slug' ),
+            'provider'   => homeboy_datamachine_agent_scalar( $config, 'provider', 'openai' ),
+            'model'      => homeboy_datamachine_agent_scalar( $config, 'model', 'gpt-5.5' ),
+        )
+    );
+}
+
+$bundle_path = homeboy_datamachine_agent_scalar( $config, 'bundle_path' );
+$agent_slug  = homeboy_datamachine_agent_scalar( $config, 'agent_slug' );
+$flow_slug   = homeboy_datamachine_agent_scalar( $config, 'flow_slug' );
+$prompt      = homeboy_datamachine_agent_scalar( $config, 'prompt' );
+$prompt_env  = homeboy_datamachine_agent_scalar( $config, 'prompt_env' );
+if ( '' === $prompt && '' !== $prompt_env ) {
+    $prompt = trim( (string) getenv( $prompt_env ) );
+}
+
+$metadata = array(
+    'bundle_path'   => $bundle_path,
+    'agent_slug'    => $agent_slug,
+    'flow_slug'     => $flow_slug,
+    'target_repo'   => homeboy_datamachine_agent_scalar( $config, 'target_repo' ),
+    'provider'      => homeboy_datamachine_agent_scalar( $config, 'provider', 'openai' ),
+    'model'         => homeboy_datamachine_agent_scalar( $config, 'model', 'gpt-5.5' ),
+    'bundle_exists' => '' !== $bundle_path && is_dir( $bundle_path ),
+);
+
+foreach ( array( 'bundle_path' => $bundle_path, 'agent_slug' => $agent_slug, 'flow_slug' => $flow_slug ) as $label => $value ) {
+    if ( '' === $value ) {
+        return homeboy_datamachine_agent_result( array( $label . '_present' => 0 ), $metadata, $label . ' is required' );
+    }
+}
+if ( '' === $prompt ) {
+    return homeboy_datamachine_agent_result( array( 'prompt_present' => 0 ), $metadata, 'prompt or prompt_env is required' );
+}
+if ( ! $metadata['bundle_exists'] || ! is_file( $bundle_path . '/manifest.json' ) ) {
+    return homeboy_datamachine_agent_result( array( 'bundle_exists' => 0 ), $metadata, 'Agent bundle directory missing or incomplete' );
+}
+
+homeboy_datamachine_agent_bootstrap_provider( $config );
+$bootstrap_error = homeboy_datamachine_agent_bootstrap_abilities();
+if ( null !== $bootstrap_error ) {
+    return $bootstrap_error;
+}
+
+$required_abilities = is_array( $config['required_abilities'] ?? null ) ? $config['required_abilities'] : array( 'datamachine/import-agent', 'datamachine/run-flow', 'datamachine/drain-job' );
+foreach ( $required_abilities as $ability_name ) {
+    if ( ! is_string( $ability_name ) || ! wp_get_ability( $ability_name ) ) {
+        return homeboy_datamachine_agent_result( array( 'required_abilities_resolved' => 0 ), $metadata, (string) $ability_name . ' not registered' );
+    }
+}
+
+foreach ( array( Agents::class, Pipelines::class, Flows::class, Jobs::class ) as $class_name ) {
+    if ( ! class_exists( $class_name ) ) {
+        return homeboy_datamachine_agent_result( array( 'required_classes_available' => 0 ), $metadata, $class_name . ' is not available' );
+    }
+}
+
+$settings = homeboy_datamachine_agent_configure_settings( $config );
+
+$import_start = hrtime( true );
+$import_result = wp_get_ability( 'datamachine/import-agent' )->execute(
+    array(
+        'source'      => $bundle_path,
+        'on_conflict' => homeboy_datamachine_agent_scalar( $config, 'on_conflict', 'skip' ),
+    )
+);
+$import_elapsed_ms = ( hrtime( true ) - $import_start ) / 1000000;
+$metadata['import_result'] = $import_result;
+if ( ! is_array( $import_result ) || empty( $import_result['success'] ) ) {
+    return homeboy_datamachine_agent_result( array( 'import_succeeded' => 0, 'import_elapsed_ms' => $import_elapsed_ms ), $metadata, 'datamachine/import-agent did not succeed' );
+}
+
+$agents    = new Agents();
+$pipelines = new Pipelines();
+$flows     = new Flows();
+$jobs      = new Jobs();
+
+$agent = $agents->get_by_slug( $agent_slug );
+if ( ! $agent ) {
+    return homeboy_datamachine_agent_result( array( 'agent_resolved' => 0 ), $metadata, 'Imported agent was not found' );
+}
+
+$agent_id = (int) $agent['agent_id'];
+$agent_config = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
+$agent_config['default_provider'] = $settings['default_provider'];
+$agent_config['default_model']    = $settings['default_model'];
+$agent_config['mode_models']      = $settings['mode_models'];
+$agents->update_agent( $agent_id, array( 'agent_config' => $agent_config ) );
+PluginSettings::clearCache();
+
+$pipeline_id = 0;
+$pipeline_slug = homeboy_datamachine_agent_scalar( $config, 'pipeline_slug' );
+if ( '' !== $pipeline_slug ) {
+    $pipeline = $pipelines->get_by_portable_slug( $agent_id, $pipeline_slug );
+    if ( ! $pipeline ) {
+        return homeboy_datamachine_agent_result( array( 'pipeline_resolved' => 0 ), $metadata + array( 'agent_id' => $agent_id ), 'Imported pipeline was not found' );
+    }
+    $pipeline_id = (int) $pipeline['pipeline_id'];
+}
+
+$flow = $flows->get_by_portable_slug( $pipeline_id, $flow_slug );
+if ( ! $flow && 0 !== $pipeline_id ) {
+    $flow = $flows->get_by_portable_slug( 0, $flow_slug );
+}
+if ( ! $flow ) {
+    return homeboy_datamachine_agent_result( array( 'flow_resolved' => 0 ), $metadata + array( 'agent_id' => $agent_id, 'pipeline_id' => $pipeline_id ), 'Imported flow was not found' );
+}
+
+$flow_id = (int) $flow['flow_id'];
+$flow_config = is_array( $flow['flow_config'] ?? null ) ? $flow['flow_config'] : array();
+foreach ( $flow_config as &$step_config ) {
+    if ( 'ai' === (string) ( $step_config['step_type'] ?? '' ) ) {
+        $step_config['prompt_queue'] = array(
+            array(
+                'prompt'   => $prompt,
+                'added_at' => gmdate( 'c' ),
+            ),
+        );
+        $step_config['queue_mode'] = 'static';
+    }
+}
+unset( $step_config );
+$flows->update_flow( $flow_id, array( 'flow_config' => $flow_config, 'agent_id' => $agent_id ) );
+
+$run_start = hrtime( true );
+$run_result = wp_get_ability( 'datamachine/run-flow' )->execute( array( 'flow_id' => $flow_id ) );
+$run_elapsed_ms = ( hrtime( true ) - $run_start ) / 1000000;
+$metadata['run_result'] = $run_result;
+$job_id = is_array( $run_result ) ? (int) ( $run_result['job_id'] ?? 0 ) : 0;
+if ( ! is_array( $run_result ) || empty( $run_result['success'] ) || $job_id <= 0 ) {
+    return homeboy_datamachine_agent_result( array( 'run_flow_succeeded' => 0, 'run_elapsed_ms' => $run_elapsed_ms ), $metadata, 'datamachine/run-flow failed or returned no job_id' );
+}
+
+$drain_start = hrtime( true );
+$drain_result = wp_get_ability( 'datamachine/drain-job' )->execute(
+    array(
+        'job_id'         => $job_id,
+        'step_budget'    => isset( $config['step_budget'] ) ? max( 1, (int) $config['step_budget'] ) : 20,
+        'time_budget_ms' => isset( $config['time_budget_ms'] ) ? max( 1000, (int) $config['time_budget_ms'] ) : 300000,
+    )
+);
+$drain_elapsed_ms = ( hrtime( true ) - $drain_start ) / 1000000;
+$metadata['drain_result'] = $drain_result;
+
+$job = $jobs->get_job( $job_id );
+$job_status = is_array( $job ) ? (string) ( $job['status'] ?? '' ) : '';
+$engine_data = function_exists( 'datamachine_get_engine_data' ) ? datamachine_get_engine_data( $job_id ) : array();
+$transcript_dir = homeboy_datamachine_agent_scalar( $config, 'transcript_dir' );
+$transcript_artifacts = homeboy_datamachine_agent_export_transcript( $job_id, $engine_data, $transcript_dir );
+
+$metadata += array(
+    'agent_id'             => $agent_id,
+    'pipeline_id'          => $pipeline_id,
+    'flow_id'              => $flow_id,
+    'job_id'               => $job_id,
+    'job_status'           => $job_status,
+    'engine_data'          => $engine_data,
+    'transcript_session_id' => (string) ( $engine_data['transcript_session_id'] ?? '' ),
+    'transcript_artifacts'  => $transcript_artifacts,
+    'token_usage'           => is_array( $engine_data['token_usage'] ?? null ) ? $engine_data['token_usage'] : array(),
+    'error_message'         => (string) ( $engine_data['error_message'] ?? '' ),
+);
+
+return homeboy_datamachine_agent_result(
+    array(
+        'config_present'              => 1,
+        'required_abilities_resolved' => 1,
+        'required_classes_available'  => 1,
+        'bundle_exists'               => 1,
+        'import_succeeded'            => 1,
+        'import_elapsed_ms'           => $import_elapsed_ms,
+        'agent_resolved'              => 1,
+        'pipeline_resolved'           => '' === $pipeline_slug || $pipeline_id > 0 ? 1 : 0,
+        'flow_resolved'               => 1,
+        'run_flow_succeeded'          => 1,
+        'run_elapsed_ms'              => $run_elapsed_ms,
+        'drain_succeeded'             => is_array( $drain_result ) && ! empty( $drain_result['success'] ) ? 1 : 0,
+        'drain_elapsed_ms'            => $drain_elapsed_ms,
+        'job_completed'               => 'completed' === $job_status ? 1 : 0,
+        'transcript_exported'         => ! empty( $transcript_artifacts['json'] ) ? 1 : 0,
+        'total_tokens'                => (int) ( $metadata['token_usage']['total_tokens'] ?? 0 ),
+    ),
+    $metadata
+);

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKLOAD_PATH="$SCRIPT_DIR/datamachine-agent-workload.php"
+WORKLOAD_PLAYGROUND_PATH="/homeboy-extension/scripts/agent/datamachine-agent-workload.php"
+
+CONFIG_PATH="${HOMEBOY_DATAMACHINE_AGENT_CONFIG_PATH:-}"
+if [ -z "$CONFIG_PATH" ] && [ "${1:-}" != "" ]; then
+    CONFIG_PATH="$1"
+fi
+if [ -z "$CONFIG_PATH" ] || [ ! -s "$CONFIG_PATH" ]; then
+    echo "ERROR: pass a Data Machine agent config JSON path as argv[1] or HOMEBOY_DATAMACHINE_AGENT_CONFIG_PATH" >&2
+    exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required" >&2
+    exit 1
+fi
+if [ ! -f "$WORKLOAD_PATH" ]; then
+    echo "ERROR: Data Machine agent workload missing at $WORKLOAD_PATH" >&2
+    exit 1
+fi
+
+RESULTS_FILE="${HOMEBOY_DATAMACHINE_AGENT_RESULTS_FILE:-${HOMEBOY_BENCH_RESULTS_FILE:-}}"
+if [ -z "$RESULTS_FILE" ]; then
+    RESULTS_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-datamachine-agent.XXXXXX")
+    PRINT_RESULTS=1
+else
+    PRINT_RESULTS=0
+fi
+
+CONFIG_JSON=$(jq -c . "$CONFIG_PATH")
+COMPONENT_PATH=$(jq -r '.component_path // env.HOMEBOY_COMPONENT_PATH // empty' "$CONFIG_PATH")
+COMPONENT_ID=$(jq -r '.component_id // env.HOMEBOY_COMPONENT_ID // empty' "$CONFIG_PATH")
+if [ -z "$COMPONENT_PATH" ]; then
+    COMPONENT_PATH="$(pwd)"
+fi
+if [ -z "$COMPONENT_ID" ]; then
+    COMPONENT_ID="$(basename "$COMPONENT_PATH")"
+fi
+
+WORKLOAD_ID=$(jq -r '.workload_id // "datamachine-agent"' "$CONFIG_PATH")
+WORKLOAD_LABEL=$(jq -r '.workload_label // "Run Data Machine agent"' "$CONFIG_PATH")
+PLAYGROUND_WORDPRESS_VERSION=$(jq -r '.playground_wordpress_version // "7.0"' "$CONFIG_PATH")
+BENCH_WARMUP_ITERATIONS=$(jq -r '.bench_warmup_iterations // 0' "$CONFIG_PATH")
+
+SETTINGS_JSON=$(jq -nc \
+    --arg workloadPath "$WORKLOAD_PLAYGROUND_PATH" \
+    --arg workloadId "$WORKLOAD_ID" \
+    --arg workloadLabel "$WORKLOAD_LABEL" \
+    --arg wordpressVersion "$PLAYGROUND_WORDPRESS_VERSION" \
+    --argjson config "$CONFIG_JSON" \
+    --argjson warmup "$BENCH_WARMUP_ITERATIONS" \
+    '{
+        validation_dependencies: ($config.validation_dependencies // $config.dependencies // []),
+        playground_wordpress_version: $wordpressVersion,
+        wp_config_defines: ($config.wp_config_defines // {}),
+        playground_file_mounts: ($config.playground_file_mounts // []),
+        playground_blueprint: ($config.playground_blueprint // {}),
+        bench_site_mode: ($config.bench_site_mode // "fresh"),
+        bench_warmup_iterations: $warmup,
+        bench_env: (($config.bench_env // {}) + { HOMEBOY_DATAMACHINE_AGENT_CONFIG: ($config | tojson) }),
+        playground_workloads: [
+            {
+                id: $workloadId,
+                label: $workloadLabel,
+                run: [
+                    { type: "php", file: $workloadPath }
+                ]
+            }
+        ]
+    }')
+
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_FILE" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_BENCH_WARMUP_ITERATIONS="$BENCH_WARMUP_ITERATIONS" \
+HOMEBOY_COMPONENT_ID="$COMPONENT_ID" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_PATH" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+    bash "$EXTENSION_PATH/scripts/bench/bench-runner.sh"
+
+if [ "$PRINT_RESULTS" = "1" ]; then
+    cat "$RESULTS_FILE"
+fi
+
+scenario='.scenarios[] | select(.id == "'"$WORKLOAD_ID"'")'
+if ! jq -e "$scenario | .metrics.config_present_mean == 1" "$RESULTS_FILE" >/dev/null; then
+    echo "ERROR: Data Machine agent workload did not run" >&2
+    exit 1
+fi
+
+if jq -e "$scenario | .metadata.error?" "$RESULTS_FILE" >/dev/null; then
+    echo "ERROR: Data Machine agent workload reported an error" >&2
+    jq -r "$scenario | .metadata.error" "$RESULTS_FILE" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds a reusable WordPress Playground workload for importing, running, draining, and reporting on a Data Machine agent bundle.
- Adds a shell wrapper that turns a repo-local JSON config into Homeboy's existing `playground_workloads`, `bench_env`, dependency, and mount settings.
- Adds a dry-run smoke test proving the wrapper can execute the generic workload through the Playground bench harness without repo-specific PHP glue.

## Why
World of WordPress and wc-site-generator are already duplicating the same agent-runner shape: mount dependencies, configure provider/model/GitHub settings, import a Data Machine bundle, run a flow, drain the job, and inspect the result. This PR starts extracting that into Homeboy Extensions without changing the core Playground bootstrap path.

## Validation
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh && bash -n wordpress/scripts/agent/datamachine-agent-runner-smoke.sh`
- `bash scripts/agent/datamachine-agent-runner-smoke.sh`
- `homeboy lint --changed-since origin/main --path /Users/chubes/Developer/homeboy-extensions@generic-datamachine-agent-runner --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Extracted the duplicated agent-runner pattern into a reusable Homeboy Extensions workload/wrapper and added smoke coverage; Chris directed the abstraction and reviewed the product boundary.