### PR TITLE
feat: add Data Machine runner bootstrap steps

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-runner-smoke.sh
@@ -43,7 +43,10 @@ jq -n \
         flow_slug: "example-flow",
         provider: "example-provider",
         model: "example-model",
-        prompt: "Dry-run the generic Data Machine agent workload."
+        prompt: "Dry-run the generic Data Machine agent workload.",
+        workload_run_before: [
+            { type: "php", file: "workloads/datamachine-agent-bootstrap.php" }
+        ]
     }' > "$CONFIG_TMPFILE"
 
 HOMEBOY_DATAMACHINE_AGENT_RESULTS_FILE="$RESULTS_TMPFILE" \
@@ -56,7 +59,7 @@ if ! jq -e "$scenario" "$RESULTS_TMPFILE" >/dev/null; then
     exit 1
 fi
 
-for metric in config_present_mean dry_run_mean; do
+for metric in bootstrap_ran_mean config_present_mean dry_run_mean; do
     value=$(jq -r "$scenario | .metrics.${metric} // \"missing\"" "$RESULTS_TMPFILE")
     if [ "$value" != "1" ]; then
         echo "ERROR: ${metric} expected 1, got ${value}" >&2
@@ -67,8 +70,14 @@ done
 
 provider=$(jq -r "$scenario | .metadata.provider // \"missing\"" "$RESULTS_TMPFILE")
 model=$(jq -r "$scenario | .metadata.model // \"missing\"" "$RESULTS_TMPFILE")
+bootstrap_value=$(jq -r "$scenario | .metadata.bootstrap_value // \"missing\"" "$RESULTS_TMPFILE")
 if [ "$provider" != "example-provider" ] || [ "$model" != "example-model" ]; then
     echo "ERROR: provider/model metadata missing (provider=$provider model=$model)" >&2
+    cat "$RESULTS_TMPFILE" >&2
+    exit 1
+fi
+if [ "$bootstrap_value" != "ran" ]; then
+    echo "ERROR: bootstrap metadata missing (bootstrap_value=$bootstrap_value)" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1
 fi

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -54,6 +54,8 @@ SETTINGS_JSON=$(jq -nc \
     --argjson config "$CONFIG_JSON" \
     --argjson warmup "$BENCH_WARMUP_ITERATIONS" \
     '{
+        workload_run_before: ($config.workload_run_before // $config.bootstrap_run // []),
+        workload_run_after: ($config.workload_run_after // []),
         validation_dependencies: ($config.validation_dependencies // $config.dependencies // []),
         playground_wordpress_version: $wordpressVersion,
         wp_config_defines: ($config.wp_config_defines // {}),
@@ -66,9 +68,9 @@ SETTINGS_JSON=$(jq -nc \
             {
                 id: $workloadId,
                 label: $workloadLabel,
-                run: [
+                run: (($config.workload_run_before // $config.bootstrap_run // []) + [
                     { type: "php", file: $workloadPath }
-                ]
+                ] + ($config.workload_run_after // []))
             }
         ]
     }')

--- a/wordpress/tests/fixtures/playground-workloads/workloads/datamachine-agent-bootstrap.php
+++ b/wordpress/tests/fixtures/playground-workloads/workloads/datamachine-agent-bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+
+update_option( 'homeboy_datamachine_agent_bootstrap_smoke', 'ran', false );
+
+return array(
+    'metrics'  => array(
+        'bootstrap_ran' => 1,
+    ),
+    'metadata' => array(
+        'bootstrap_value' => get_option( 'homeboy_datamachine_agent_bootstrap_smoke' ),
+    ),
+);


### PR DESCRIPTION
## Summary
- Add optional `workload_run_before` / `bootstrap_run` and `workload_run_after` hooks around the generic Data Machine agent workload.
- Extend the runner smoke test with a bootstrap fixture so repo-specific setup can be proven before the shared import/run/drain path executes.

## Testing
- `php -l wordpress/tests/fixtures/playground-workloads/workloads/datamachine-agent-bootstrap.php`
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh && bash -n wordpress/scripts/agent/datamachine-agent-runner-smoke.sh`
- `bash wordpress/scripts/agent/datamachine-agent-runner-smoke.sh`
- `homeboy lint --changed-since origin/main --path /Users/chubes/Developer/homeboy-extensions@datamachine-agent-bootstrap-callback --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner hook implementation and smoke fixture; Chris requested the PR and remains responsible for review.