### PR TITLE
Wait for Data Machine agent retries in CI

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-retry-drain-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-retry-drain-smoke.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Smoke test for retry-aware Data Machine agent drain loop.
+ *
+ * Run with: php wordpress/scripts/agent/datamachine-agent-retry-drain-smoke.php
+ */
+
+namespace DataMachine\Core\Database\Jobs {
+    class Jobs {
+        public function get_job( int $job_id ): array {
+            $GLOBALS['homeboy_retry_drain_job_reads'] = ( $GLOBALS['homeboy_retry_drain_job_reads'] ?? 0 ) + 1;
+            return array(
+                'job_id' => $job_id,
+                'status' => ( $GLOBALS['homeboy_retry_drain_calls'] ?? 0 ) >= 2 ? 'completed' : 'pending',
+            );
+        }
+    }
+}
+
+namespace DataMachine\Core\Database\Agents {
+    class Agents {}
+}
+
+namespace DataMachine\Core\Database\Chat {
+    class ConversationStoreFactory {}
+}
+
+namespace DataMachine\Core\Database\Flows {
+    class Flows {}
+}
+
+namespace DataMachine\Core\Database\Pipelines {
+    class Pipelines {}
+}
+
+namespace DataMachine\Core {
+    class PluginSettings {}
+}
+
+namespace {
+    if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/' );
+    }
+
+    if ( ! function_exists( 'wp_set_current_user' ) ) {
+        function wp_set_current_user( int $user_id ): void {}
+    }
+
+    if ( ! function_exists( 'wp_get_ability' ) ) {
+        function wp_get_ability( string $ability_name ): object {
+            return new class {
+                public function execute( array $args ): array {
+                    $GLOBALS['homeboy_retry_drain_calls'] = ( $GLOBALS['homeboy_retry_drain_calls'] ?? 0 ) + 1;
+                    if ( 1 === $GLOBALS['homeboy_retry_drain_calls'] ) {
+                        return array(
+                            'success'           => false,
+                            'job_id'            => (int) ( $args['job_id'] ?? 0 ),
+                            'remaining_actions' => 0,
+                        );
+                    }
+
+                    return array(
+                        'success' => true,
+                        'job_id'  => (int) ( $args['job_id'] ?? 0 ),
+                    );
+                }
+            };
+        }
+    }
+
+    if ( ! function_exists( 'datamachine_get_engine_data' ) ) {
+        function datamachine_get_engine_data( int $job_id ): array {
+            return array(
+                'retry' => array(
+                    'last_retryable' => true,
+                    'next_retry_at'  => gmdate( 'c', time() - 1 ),
+                ),
+            );
+        }
+    }
+
+    if ( ! function_exists( 'wp_json_encode' ) ) {
+        function wp_json_encode( $value, int $flags = 0 ): string {
+            return (string) json_encode( $value, $flags );
+        }
+    }
+
+    putenv(
+        'HOMEBOY_DATAMACHINE_AGENT_CONFIG=' . wp_json_encode(
+            array(
+                'dry_run'    => true,
+                'agent_slug' => 'retry-smoke-agent',
+                'flow_slug'  => 'retry-smoke-flow',
+            )
+        )
+    );
+
+    require __DIR__ . '/datamachine-agent-workload.php';
+
+    $summary = homeboy_datamachine_agent_drain_job(
+        123,
+        array(
+            'retry_wait_budget_ms' => 1,
+            'retry_max_sleep_ms'   => 1,
+            'step_budget'          => 1,
+            'time_budget_ms'       => 1000,
+        ),
+        new \DataMachine\Core\Database\Jobs\Jobs()
+    );
+
+    if ( 2 !== ( $GLOBALS['homeboy_retry_drain_calls'] ?? 0 ) ) {
+        fwrite( STDERR, "Expected two drain attempts.\n" );
+        exit( 1 );
+    }
+
+    if ( empty( $summary['drain_result']['success'] ) ) {
+        fwrite( STDERR, "Expected retry drain to finish successfully.\n" );
+        exit( 1 );
+    }
+
+    if ( 2 !== count( $summary['drain_history'] ?? array() ) ) {
+        fwrite( STDERR, "Expected two drain history entries.\n" );
+        exit( 1 );
+    }
+
+    fwrite( STDOUT, "Retry-aware Data Machine agent drain smoke passed.\n" );
+}

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -494,6 +494,76 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_transcript' ) ) {
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_drain_job' ) ) {
+    function homeboy_datamachine_agent_drain_job( int $job_id, array $config, Jobs $jobs ): array {
+        $started_at              = hrtime( true );
+        $retry_wait_budget_ms    = isset( $config['retry_wait_budget_ms'] ) ? max( 0, (int) $config['retry_wait_budget_ms'] ) : 180000;
+        $retry_max_sleep_ms      = isset( $config['retry_max_sleep_ms'] ) ? max( 1000, (int) $config['retry_max_sleep_ms'] ) : 30000;
+        $step_budget             = isset( $config['step_budget'] ) ? max( 1, (int) $config['step_budget'] ) : 20;
+        $time_budget_ms          = isset( $config['time_budget_ms'] ) ? max( 1000, (int) $config['time_budget_ms'] ) : 300000;
+        $history                 = array();
+        $drain_result            = array( 'success' => false );
+        $waited_ms               = 0;
+
+        do {
+            $drain_result = wp_get_ability( 'datamachine/drain-job' )->execute(
+                array(
+                    'job_id'         => $job_id,
+                    'step_budget'    => $step_budget,
+                    'time_budget_ms' => $time_budget_ms,
+                )
+            );
+
+            $job         = $jobs->get_job( $job_id );
+            $job_status  = is_array( $job ) ? (string) ( $job['status'] ?? '' ) : '';
+            $engine_data = function_exists( 'datamachine_get_engine_data' ) ? datamachine_get_engine_data( $job_id ) : array();
+
+            $history[] = array(
+                'drain_result' => $drain_result,
+                'job_status'   => $job_status,
+                'retry'        => is_array( $engine_data['retry'] ?? null ) ? $engine_data['retry'] : array(),
+            );
+
+            if ( is_array( $drain_result ) && ! empty( $drain_result['success'] ) ) {
+                break;
+            }
+
+            if ( in_array( $job_status, array( 'completed', 'failed', 'cancelled' ), true ) ) {
+                break;
+            }
+
+            $retry = is_array( $engine_data['retry'] ?? null ) ? $engine_data['retry'] : array();
+            if ( empty( $retry['last_retryable'] ) || empty( $retry['next_retry_at'] ) ) {
+                break;
+            }
+
+            $next_retry_ts = strtotime( (string) $retry['next_retry_at'] );
+            if ( false === $next_retry_ts ) {
+                break;
+            }
+
+            $remaining_budget_ms = $retry_wait_budget_ms - $waited_ms;
+            if ( $remaining_budget_ms <= 0 ) {
+                break;
+            }
+
+            $delay_ms = max( 0, ( $next_retry_ts - time() ) * 1000 ) + 1000;
+            $sleep_ms = min( $delay_ms, $retry_max_sleep_ms, $remaining_budget_ms );
+            if ( $sleep_ms > 0 ) {
+                usleep( $sleep_ms * 1000 );
+                $waited_ms += $sleep_ms;
+            }
+        } while ( $waited_ms <= $retry_wait_budget_ms );
+
+        return array(
+            'drain_result'     => $drain_result,
+            'drain_elapsed_ms' => ( hrtime( true ) - $started_at ) / 1000000,
+            'drain_history'    => $history,
+            'retry_waited_ms'  => $waited_ms,
+        );
+    }
+}
+
 if ( function_exists( 'wp_set_current_user' ) ) {
     wp_set_current_user( 1 );
 }
@@ -649,16 +719,12 @@ if ( ! is_array( $run_result ) || empty( $run_result['success'] ) || $job_id <= 
     return homeboy_datamachine_agent_result( array( 'run_flow_succeeded' => 0, 'run_elapsed_ms' => $run_elapsed_ms ), $metadata, 'datamachine/run-flow failed or returned no job_id' );
 }
 
-$drain_start = hrtime( true );
-$drain_result = wp_get_ability( 'datamachine/drain-job' )->execute(
-    array(
-        'job_id'         => $job_id,
-        'step_budget'    => isset( $config['step_budget'] ) ? max( 1, (int) $config['step_budget'] ) : 20,
-        'time_budget_ms' => isset( $config['time_budget_ms'] ) ? max( 1000, (int) $config['time_budget_ms'] ) : 300000,
-    )
-);
-$drain_elapsed_ms = ( hrtime( true ) - $drain_start ) / 1000000;
+$drain_summary = homeboy_datamachine_agent_drain_job( $job_id, $config, $jobs );
+$drain_result = $drain_summary['drain_result'];
+$drain_elapsed_ms = (float) $drain_summary['drain_elapsed_ms'];
 $metadata['drain_result'] = $drain_result;
+$metadata['drain_history'] = $drain_summary['drain_history'];
+$metadata['retry_waited_ms'] = $drain_summary['retry_waited_ms'];
 
 $job = $jobs->get_job( $job_id );
 $job_status = is_array( $job ) ? (string) ( $job['status'] ?? '' ) : '';


### PR DESCRIPTION
## Summary
- Wrap the generic Data Machine agent workload drain step in a bounded retry-aware loop.
- When Data Machine schedules a retryable pending job with `retry.next_retry_at`, wait within the CI budget and drain again instead of failing immediately.
- Record drain history and retry wait time in workload metadata for easier diagnosis.
- Add a smoke test for retry-aware drain behavior.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-retry-drain-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-retry-drain-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the World Creator CI retry failure, implementing the bounded retry-aware drain loop, and adding/running smoke validation. Chris remains responsible for review and merge.