### PR TITLE
Support reusable Data Machine agent bundles

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-runner-smoke.sh
@@ -31,11 +31,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
+REPO_ROOT="$(cd "$EXTENSION_PATH/.." && pwd)"
+BUNDLE_REF="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+
 jq -n \
     --arg componentPath "$FIXTURE_DIR" \
+    --arg bundleRepo "$REPO_ROOT" \
+    --arg bundleRef "$BUNDLE_REF" \
     '{
         component_id: "playground-workloads",
         component_path: $componentPath,
+        bundle_repo: $bundleRepo,
+        bundle_ref: $bundleRef,
+        bundle_path_in_repo: ".",
         workload_id: "datamachine-agent-dry-run",
         workload_label: "Data Machine agent dry run",
         dry_run: true,
@@ -71,6 +79,9 @@ done
 provider=$(jq -r "$scenario | .metadata.provider // \"missing\"" "$RESULTS_TMPFILE")
 model=$(jq -r "$scenario | .metadata.model // \"missing\"" "$RESULTS_TMPFILE")
 bootstrap_value=$(jq -r "$scenario | .metadata.bootstrap_value // \"missing\"" "$RESULTS_TMPFILE")
+bundle_repo=$(jq -r "$scenario | .metadata.bundle_repo // \"missing\"" "$RESULTS_TMPFILE")
+bundle_ref=$(jq -r "$scenario | .metadata.bundle_ref // \"missing\"" "$RESULTS_TMPFILE")
+bundle_path=$(jq -r "$scenario | .metadata.bundle_path // \"missing\"" "$RESULTS_TMPFILE")
 if [ "$provider" != "example-provider" ] || [ "$model" != "example-model" ]; then
     echo "ERROR: provider/model metadata missing (provider=$provider model=$model)" >&2
     cat "$RESULTS_TMPFILE" >&2
@@ -78,6 +89,11 @@ if [ "$provider" != "example-provider" ] || [ "$model" != "example-model" ]; the
 fi
 if [ "$bootstrap_value" != "ran" ]; then
     echo "ERROR: bootstrap metadata missing (bootstrap_value=$bootstrap_value)" >&2
+    cat "$RESULTS_TMPFILE" >&2
+    exit 1
+fi
+if [ "$bundle_repo" != "$REPO_ROOT" ] || [ "$bundle_ref" != "$BUNDLE_REF" ] || [ -z "$bundle_path" ] || [ "$bundle_path" = "missing" ]; then
+    echo "ERROR: external bundle metadata missing (repo=$bundle_repo ref=$bundle_ref path=$bundle_path)" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1
 fi

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -86,6 +86,26 @@ if ( ! function_exists( 'homeboy_datamachine_agent_first_url' ) ) {
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_pr_opened' ) ) {
+    function homeboy_datamachine_agent_pr_opened( array $engine_data, array $config ): bool {
+        $tool_results_key = homeboy_datamachine_agent_scalar( $config, 'tool_results_key', 'github_tool_results' );
+        $tool_results     = is_array( $engine_data[ $tool_results_key ] ?? null ) ? $engine_data[ $tool_results_key ] : array();
+
+        foreach ( $tool_results as $tool_result ) {
+            if ( ! is_array( $tool_result ) || empty( $tool_result['success'] ) ) {
+                continue;
+            }
+
+            $url = (string) ( $tool_result['url'] ?? '' );
+            if ( str_contains( $url, '/pull/' ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_ability_schema' ) ) {
     function homeboy_datamachine_agent_ability_schema( string $ability_name ): array {
         $ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
@@ -577,10 +597,14 @@ if ( ! empty( $config['dry_run'] ) ) {
     return homeboy_datamachine_agent_result(
         array( 'config_present' => 1, 'dry_run' => 1 ),
         array(
-            'agent_slug' => homeboy_datamachine_agent_scalar( $config, 'agent_slug' ),
-            'flow_slug'  => homeboy_datamachine_agent_scalar( $config, 'flow_slug' ),
-            'provider'   => homeboy_datamachine_agent_scalar( $config, 'provider', 'openai' ),
-            'model'      => homeboy_datamachine_agent_scalar( $config, 'model', 'gpt-5.5' ),
+            'bundle_path'         => homeboy_datamachine_agent_scalar( $config, 'bundle_path' ),
+            'bundle_repo'         => homeboy_datamachine_agent_scalar( $config, 'bundle_repo' ),
+            'bundle_ref'          => homeboy_datamachine_agent_scalar( $config, 'bundle_ref' ),
+            'bundle_path_in_repo' => homeboy_datamachine_agent_scalar( $config, 'bundle_path_in_repo' ),
+            'agent_slug'          => homeboy_datamachine_agent_scalar( $config, 'agent_slug' ),
+            'flow_slug'           => homeboy_datamachine_agent_scalar( $config, 'flow_slug' ),
+            'provider'            => homeboy_datamachine_agent_scalar( $config, 'provider', 'openai' ),
+            'model'               => homeboy_datamachine_agent_scalar( $config, 'model', 'gpt-5.5' ),
         )
     );
 }
@@ -731,6 +755,9 @@ $job_status = is_array( $job ) ? (string) ( $job['status'] ?? '' ) : '';
 $engine_data = function_exists( 'datamachine_get_engine_data' ) ? datamachine_get_engine_data( $job_id ) : array();
 $transcript_dir = homeboy_datamachine_agent_scalar( $config, 'transcript_dir' );
 $transcript_artifacts = homeboy_datamachine_agent_export_transcript( $job_id, $engine_data, $transcript_dir );
+$pr_opened = homeboy_datamachine_agent_pr_opened( $engine_data, $config );
+$success_status = $pr_opened ? 'pr_opened' : 'no_changes';
+$success_requires_pr = ! empty( $config['success_requires_pr'] );
 
 $metadata += array(
     'agent_id'             => $agent_id,
@@ -743,7 +770,13 @@ $metadata += array(
     'transcript_artifacts'  => $transcript_artifacts,
     'token_usage'           => is_array( $engine_data['token_usage'] ?? null ) ? $engine_data['token_usage'] : array(),
     'error_message'         => (string) ( $engine_data['error_message'] ?? '' ),
+    'success_status'        => $success_status,
+    'success_requires_pr'   => $success_requires_pr,
 );
+
+if ( $success_requires_pr && ! $pr_opened ) {
+    return homeboy_datamachine_agent_result( array( 'pr_opened' => 0 ), $metadata, 'Agent completed without opening a pull request' );
+}
 
 return homeboy_datamachine_agent_result(
     array(
@@ -761,6 +794,8 @@ return homeboy_datamachine_agent_result(
         'drain_succeeded'             => is_array( $drain_result ) && ! empty( $drain_result['success'] ) ? 1 : 0,
         'drain_elapsed_ms'            => $drain_elapsed_ms,
         'job_completed'               => 'completed' === $job_status ? 1 : 0,
+        'pr_opened'                   => $pr_opened ? 1 : 0,
+        'no_changes'                  => ! $pr_opened ? 1 : 0,
         'transcript_exported'         => ! empty( $transcript_artifacts['json'] ) ? 1 : 0,
         'total_tokens'                => (int) ( $metadata['token_usage']['total_tokens'] ?? 0 ),
     ),

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -89,7 +89,6 @@ else
     PRINT_RESULTS=0
 fi
 
-CONFIG_JSON=$(jq -c . "$CONFIG_PATH")
 COMPONENT_PATH=$(jq -r '.component_path // env.HOMEBOY_COMPONENT_PATH // empty' "$CONFIG_PATH")
 COMPONENT_ID=$(jq -r '.component_id // env.HOMEBOY_COMPONENT_ID // empty' "$CONFIG_PATH")
 if [ -z "$COMPONENT_PATH" ]; then
@@ -97,6 +96,39 @@ if [ -z "$COMPONENT_PATH" ]; then
 fi
 if [ -z "$COMPONENT_ID" ]; then
     COMPONENT_ID="$(basename "$COMPONENT_PATH")"
+fi
+
+CONFIG_JSON=$(jq -c . "$CONFIG_PATH")
+BUNDLE_REPO=$(jq -r '.bundle_repo // empty' "$CONFIG_PATH")
+if [ -n "$BUNDLE_REPO" ]; then
+    BUNDLE_REF=$(jq -r '.bundle_ref // "main"' "$CONFIG_PATH")
+    BUNDLE_PATH_IN_REPO=$(jq -r '.bundle_path_in_repo // "."' "$CONFIG_PATH")
+    if ! command -v git >/dev/null 2>&1; then
+        echo "ERROR: git required for bundle_repo" >&2
+        exit 1
+    fi
+    if [ -z "$RUNTIME_DIR" ]; then
+        RUNTIME_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-datamachine-agent-runtime.XXXXXX")
+    fi
+    BUNDLE_CHECKOUT_DIR="$RUNTIME_DIR/bundle-repo"
+    git clone --quiet "$BUNDLE_REPO" "$BUNDLE_CHECKOUT_DIR"
+    git -C "$BUNDLE_CHECKOUT_DIR" checkout --quiet "$BUNDLE_REF"
+    BUNDLE_PATH="$BUNDLE_CHECKOUT_DIR/$BUNDLE_PATH_IN_REPO"
+    if [ ! -d "$BUNDLE_PATH" ]; then
+        echo "ERROR: bundle_path_in_repo does not exist in bundle_repo: $BUNDLE_PATH_IN_REPO" >&2
+        exit 1
+    fi
+    CONFIG_JSON=$(jq -c \
+        --arg bundlePath "$BUNDLE_PATH" \
+        --arg bundleRepo "$BUNDLE_REPO" \
+        --arg bundleRef "$BUNDLE_REF" \
+        --arg bundlePathInRepo "$BUNDLE_PATH_IN_REPO" \
+        '. + {
+            bundle_path: $bundlePath,
+            bundle_repo: $bundleRepo,
+            bundle_ref: $bundleRef,
+            bundle_path_in_repo: $bundlePathInRepo
+        }' <<<"$CONFIG_JSON")
 fi
 
 WORKLOAD_ID=$(jq -r '.workload_id // "datamachine-agent"' "$CONFIG_PATH")


### PR DESCRIPTION
## Summary
- Allow the generic Data Machine agent runner to clone an external bundle repo/ref and run a bundle from a path inside that checkout.
- Surface `pr_opened`/`no_changes` outcome metadata so reusable repo agents can succeed when no PR is needed, while still allowing callers to require a PR.
- Extend the runner smoke test to prove external bundle config is resolved and passed into the Playground workload.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh && bash -n wordpress/scripts/agent/datamachine-agent-runner-smoke.sh`
- `git diff --check`
- `homeboy lint --path wordpress --extension wordpress --changed-since origin/main`
- `bash wordpress/scripts/agent/datamachine-agent-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner/workload changes and smoke coverage; Chris remains responsible for review and merge.