### PR TITLE
Force Data Machine agent tool parameters

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Smoke test for forced Data Machine agent tool parameters.
+ *
+ * Run with: php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
+ */
+
+namespace DataMachine\Core\Database\Agents {
+    class Agents {}
+}
+
+namespace DataMachine\Core\Database\Chat {
+    class ConversationStoreFactory {}
+}
+
+namespace DataMachine\Core\Database\Flows {
+    class Flows {}
+}
+
+namespace DataMachine\Core\Database\Jobs {
+    class Jobs {}
+}
+
+namespace DataMachine\Core\Database\Pipelines {
+    class Pipelines {}
+}
+
+namespace DataMachine\Core {
+    class PluginSettings {}
+}
+
+namespace {
+    if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/' );
+    }
+
+    if ( ! function_exists( 'wp_set_current_user' ) ) {
+        function wp_set_current_user( int $user_id ): void {}
+    }
+
+    if ( ! function_exists( 'wp_get_ability' ) ) {
+        function wp_get_ability( string $ability_name ): object {
+            return new class {
+                public function execute( array $args ): array {
+                    $GLOBALS['homeboy_forced_parameters_args'] = $args;
+                    return array(
+                        'success' => true,
+                        'args'    => $args,
+                    );
+                }
+            };
+        }
+    }
+
+    if ( ! function_exists( 'is_wp_error' ) ) {
+        function is_wp_error( $value ): bool {
+            return false;
+        }
+    }
+
+    if ( ! function_exists( 'wp_json_encode' ) ) {
+        function wp_json_encode( $value, int $flags = 0 ): string {
+            return (string) json_encode( $value, $flags );
+        }
+    }
+
+    putenv(
+        'HOMEBOY_DATAMACHINE_AGENT_CONFIG=' . wp_json_encode(
+            array(
+                'dry_run'    => true,
+                'agent_slug' => 'forced-parameters-smoke-agent',
+                'flow_slug'  => 'forced-parameters-smoke-flow',
+            )
+        )
+    );
+
+    require __DIR__ . '/datamachine-agent-workload.php';
+
+    $recorder = new Homeboy_Datamachine_Agent_Tool_Recorder();
+    $result   = $recorder->handle_tool_call(
+        array(
+            'repo'               => 'owner/repo',
+            'file_path'          => 'docs/generated.md',
+            'content'            => '# Generated',
+            'commit_message'     => 'docs: generated',
+            'allowed_file_paths' => array( 'src/**' ),
+        ),
+        array(
+            'ability'                    => 'datamachine/create-or-update-github-file',
+            'tool_name'                  => 'create_or_update_github_file',
+            'homeboy_forced_parameters' => array(
+                'allowed_file_paths' => array( 'README.md', 'docs/**' ),
+            ),
+        )
+    );
+
+    $args = $GLOBALS['homeboy_forced_parameters_args'] ?? array();
+    if ( empty( $result['success'] ) ) {
+        fwrite( STDERR, "Expected forced-parameter tool call to succeed.\n" );
+        exit( 1 );
+    }
+
+    if ( array( 'README.md', 'docs/**' ) !== ( $args['allowed_file_paths'] ?? null ) ) {
+        fwrite( STDERR, "Expected forced allowed_file_paths to override model parameters.\n" );
+        exit( 1 );
+    }
+
+    fwrite( STDOUT, "Data Machine agent forced parameters smoke passed.\n" );
+}

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -128,12 +128,23 @@ if ( ! class_exists( 'Homeboy_Datamachine_Agent_Tool_Recorder' ) ) {
         private static array $tool_results = array();
 
         public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+            $parameters = $this->apply_forced_parameters( $parameters, $tool_def );
+
             $response = isset( $tool_def['homeboy_original_tool'] ) && is_array( $tool_def['homeboy_original_tool'] )
                 ? $this->call_original_tool( $parameters, $tool_def['homeboy_original_tool'] )
                 : $this->call_ability_tool( $parameters, $tool_def );
 
             $this->record( $parameters, $tool_def, $response );
             return $response;
+        }
+
+        private function apply_forced_parameters( array $parameters, array $tool_def ): array {
+            $forced_parameters = is_array( $tool_def['homeboy_forced_parameters'] ?? null ) ? $tool_def['homeboy_forced_parameters'] : array();
+            if ( empty( $forced_parameters ) ) {
+                return $parameters;
+            }
+
+            return array_replace_recursive( $parameters, $forced_parameters );
         }
 
         private function call_original_tool( array $parameters, array $original_tool ): array {
@@ -297,13 +308,14 @@ if ( ! function_exists( 'homeboy_datamachine_agent_register_tool_recorders' ) ) 
                         continue;
                     }
                     $tools[ $tool_name ] = array(
-                        'class'          => 'Homeboy_Datamachine_Agent_Tool_Recorder',
-                        'method'         => 'handle_tool_call',
-                        'ability'        => $ability_name,
-                        'tool_name'      => $tool_name,
-                        'description'    => (string) ( $tool_config['description'] ?? 'Execute ' . $ability_name . '.' ),
-                        'parameters'     => homeboy_datamachine_agent_ability_schema( $ability_name ),
-                        'homeboy_record' => is_array( $tool_config['record'] ?? null ) ? $tool_config['record'] : array(),
+                        'class'                      => 'Homeboy_Datamachine_Agent_Tool_Recorder',
+                        'method'                     => 'handle_tool_call',
+                        'ability'                    => $ability_name,
+                        'tool_name'                  => $tool_name,
+                        'description'                => (string) ( $tool_config['description'] ?? 'Execute ' . $ability_name . '.' ),
+                        'parameters'                 => homeboy_datamachine_agent_ability_schema( $ability_name ),
+                        'homeboy_record'             => is_array( $tool_config['record'] ?? null ) ? $tool_config['record'] : array(),
+                        'homeboy_forced_parameters' => is_array( $tool_config['forced_parameters'] ?? null ) ? $tool_config['forced_parameters'] : array(),
                     );
                 }
 
@@ -316,11 +328,12 @@ if ( ! function_exists( 'homeboy_datamachine_agent_register_tool_recorders' ) ) 
                         continue;
                     }
                     $original_tool = $tools[ $tool_name ];
-                    $tools[ $tool_name ]['class']                 = 'Homeboy_Datamachine_Agent_Tool_Recorder';
-                    $tools[ $tool_name ]['method']                = 'handle_tool_call';
-                    $tools[ $tool_name ]['tool_name']             = $tool_name;
-                    $tools[ $tool_name ]['homeboy_original_tool'] = $original_tool;
-                    $tools[ $tool_name ]['homeboy_record']        = is_array( $recorder['record'] ?? null ) ? $recorder['record'] : array();
+                    $tools[ $tool_name ]['class']                      = 'Homeboy_Datamachine_Agent_Tool_Recorder';
+                    $tools[ $tool_name ]['method']                     = 'handle_tool_call';
+                    $tools[ $tool_name ]['tool_name']                  = $tool_name;
+                    $tools[ $tool_name ]['homeboy_original_tool']      = $original_tool;
+                    $tools[ $tool_name ]['homeboy_record']             = is_array( $recorder['record'] ?? null ) ? $recorder['record'] : array();
+                    $tools[ $tool_name ]['homeboy_forced_parameters'] = is_array( $recorder['forced_parameters'] ?? null ) ? $recorder['forced_parameters'] : array();
                 }
 
                 return $tools;


### PR DESCRIPTION
## Summary
- Allow Data Machine agent runner tool recorders and ability-backed tools to define `forced_parameters`.
- Apply forced parameters before executing and recording a tool call so runner config can hard-enforce values such as `allowed_file_paths`.
- Add a smoke test proving forced `allowed_file_paths` override model-supplied parameters.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php && php -l wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php && git diff --check`
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `homeboy lint --path wordpress --extension wordpress --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the forced parameter runner support and smoke coverage; Chris remains responsible for review and merge.