### PR TITLE
feat: add generic ci-driver plugin fixture for Data Machine agent runs

### DIFF
--- a/wordpress/tests/fixtures/datamachine-agent-ci-driver/README.md
+++ b/wordpress/tests/fixtures/datamachine-agent-ci-driver/README.md
@@ -1,0 +1,51 @@
+# Data Machine Agent CI Driver fixture
+
+Generic Playground plugin scaffold consumed by Data Machine agent CI runs.
+
+## Why
+
+Data Machine agent CI workflows need a stable plugin path inside Playground
+to host workloads, bundle copies, and transcript artifacts. Without a fixture
+each consumer ships its own near-identical `<repo>-ci-driver.php`.
+
+This fixture removes that duplication. Consumers mount it via the agent
+runner's `playground_file_mounts` mechanism and reference its plugin path
+in their workload `run` entries and `transcript_dir` config.
+
+## How consumers use it
+
+In the agent runner config JSON:
+
+```json
+{
+  "playground_file_mounts": [
+    {
+      "from_dependency": "homeboy-extensions",
+      "from": "wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php",
+      "to": "/wordpress/wp-content/plugins/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php"
+    }
+  ],
+  "transcript_dir": "/wordpress/wp-content/plugins/datamachine-agent-ci-driver/artifacts/<agent-slug>",
+  "playground_workloads": [
+    {
+      "id": "<scenario-id>",
+      "label": "<human label>",
+      "run": [
+        { "type": "php", "file": "/wordpress/wp-content/plugins/datamachine-agent-ci-driver/<workload>.php" }
+      ]
+    }
+  ]
+}
+```
+
+The runner already supports `playground_file_mounts` and `from_dependency`
+resolution against the homeboy-extensions checkout, so no new runner
+behavior is required to use this fixture.
+
+## What it does NOT do
+
+- No abilities, hooks, or runtime registrations.
+- No data persistence.
+- No CLI commands.
+
+It is intentionally a no-op plugin header, used purely as a path anchor.

--- a/wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver-smoke.sh
+++ b/wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver-smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_FILE="${SCRIPT_DIR}/datamachine-agent-ci-driver.php"
+
+if [ ! -f "$PLUGIN_FILE" ]; then
+    echo "ERROR: plugin fixture not found at $PLUGIN_FILE" >&2
+    exit 1
+fi
+
+php -l "$PLUGIN_FILE" >/dev/null
+
+for header in "Plugin Name:" "Plugin URI:"; do
+    if ! grep -q "$header" "$PLUGIN_FILE"; then
+        echo "ERROR: missing plugin header: $header" >&2
+        exit 1
+    fi
+done
+
+for runtime_pattern in \
+    "add_action" \
+    "add_filter" \
+    "register_activation_hook" \
+    "register_deactivation_hook" \
+    "^[[:space:]]*class[[:space:]]"; do
+    if grep -qE "$runtime_pattern" "$PLUGIN_FILE"; then
+        echo "ERROR: unexpected runtime behavior matched: $runtime_pattern" >&2
+        exit 1
+    fi
+done
+
+echo "✓ Data Machine agent CI driver fixture smoke test PASSED"

--- a/wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php
+++ b/wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name:       Data Machine Agent CI Driver
+ * Plugin URI:        https://github.com/Extra-Chill/homeboy-extensions
+ * Description:       Path anchor plugin for Data Machine agent CI runs in WordPress Playground. Hosts no runtime behavior; mounted by the agent runner so workloads, bundles, and transcripts share a stable path.
+ * Version:           1.0.0
+ * Requires at least: 6.4
+ * Requires PHP:      8.1
+ * Author:            Extra Chill
+ * Author URI:        https://github.com/Extra-Chill
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       datamachine-agent-ci-driver
+ *
+ * This plugin intentionally has no runtime behavior. Its purpose is to give
+ * Data Machine agent CI runs a stable plugin path:
+ *   /wordpress/wp-content/plugins/datamachine-agent-ci-driver/
+ *
+ * The Homeboy Data Machine agent runner (run-datamachine-agent.sh) mounts
+ * this file into the Playground via playground_file_mounts so consumers do
+ * not have to ship their own CI driver plugin.
+ */
+
+defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
## Summary
- Adds a generic no-op Data Machine Agent CI Driver plugin fixture for WordPress Playground runs.
- Documents how consumers mount the fixture with existing `playground_file_mounts` support.
- Adds a standalone smoke test that verifies the fixture parses, has required plugin headers, and stays runtime-free.

Closes #492

## Why
- [world-of-wordpress](https://github.com/chubes4/world-of-wordpress) currently carries its own CI driver plugin path anchor.
- [wc-site-generator PR #173](https://github.com/chubes4/wc-site-generator/pull/173) needs the same generic path-anchor shape.
- [Automattic/docs-agent PR #1](https://github.com/Automattic/docs-agent/pull/1) also carries the same fixture need.

## How consumers use it
```json
{
  "playground_file_mounts": [
    {
      "from_dependency": "homeboy-extensions",
      "from": "wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php",
      "to": "/wordpress/wp-content/plugins/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php"
    }
  ]
}
```

## Out of scope
- No consumer migrations in this PR.
- No runner changes.
- No runtime behavior in the plugin file itself.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the no-op CI driver plugin fixture, README, and smoke test. Chris provided the fixture shape and no-runtime-behavior contract.