### PR TITLE
feat: add engine_data extraction helper for Data Machine agent runner consumers

### DIFF
--- a/wordpress/scripts/agent/extract-engine-data-smoke.sh
+++ b/wordpress/scripts/agent/extract-engine-data-smoke.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTRACTOR="$SCRIPT_DIR/extract-engine-data.sh"
+
+if [ ! -f "$EXTRACTOR" ]; then
+    echo "ERROR: extractor not found at $EXTRACTOR" >&2
+    exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required" >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/extract-engine-data-results.XXXXXX.json")
+GITHUB_OUTPUT_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/extract-engine-data-output.XXXXXX")
+cleanup() {
+    rm -f "$RESULTS_TMPFILE" "$GITHUB_OUTPUT_TMPFILE"
+}
+trap cleanup EXIT
+
+jq -n '{
+    component_id: "fixture",
+    iterations: 1,
+    scenarios: [
+        {
+            id: "fixture-agent",
+            metadata: {
+                job_status: "completed",
+                engine_data: {
+                    foo: { bar: "baz" },
+                    deep: { nested: 42 }
+                }
+            }
+        },
+        {
+            id: "other-agent",
+            metadata: {
+                job_status: "failed",
+                engine_data: {}
+            }
+        }
+    ]
+}' > "$RESULTS_TMPFILE"
+
+pass_count=0
+fail_count=0
+
+pass() {
+    pass_count=$((pass_count + 1))
+    echo "PASS: $*"
+}
+
+fail() {
+    fail_count=$((fail_count + 1))
+    echo "FAIL: $*" >&2
+}
+
+stdout=$(GITHUB_OUTPUT="$GITHUB_OUTPUT_TMPFILE" bash "$EXTRACTOR" \
+    --results "$RESULTS_TMPFILE" \
+    --scenario fixture-agent \
+    --field foo_bar=metadata.engine_data.foo.bar \
+    --field nested=metadata.engine_data.deep.nested \
+    --field missing=metadata.engine_data.missing \
+    --required-field foo_bar \
+    --required-field nested)
+
+if grep -F "foo_bar:" <<<"$stdout" | grep -F "baz" >/dev/null \
+    && grep -F "nested:" <<<"$stdout" | grep -F "42" >/dev/null; then
+    pass "stdout includes projected key/value pairs"
+else
+    fail "stdout missing projected key/value pairs"
+    printf '%s\n' "$stdout" >&2
+fi
+
+if grep -Fx "foo_bar=baz" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
+    && grep -Fx "nested=42" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
+    && grep -Fx "missing=" "$GITHUB_OUTPUT_TMPFILE" >/dev/null; then
+    pass "GITHUB_OUTPUT includes projected key=value lines"
+else
+    fail "GITHUB_OUTPUT missing projected key=value lines"
+    cat "$GITHUB_OUTPUT_TMPFILE" >&2
+fi
+
+if ! bash "$EXTRACTOR" \
+    --results "$RESULTS_TMPFILE" \
+    --scenario missing-agent \
+    --field foo_bar=metadata.engine_data.foo.bar \
+    --quiet >/dev/null 2>&1; then
+    pass "missing scenario fails closed"
+else
+    fail "missing scenario unexpectedly succeeded"
+fi
+
+if ! bash "$EXTRACTOR" \
+    --results "$RESULTS_TMPFILE" \
+    --scenario fixture-agent \
+    --field missing=metadata.engine_data.missing \
+    --required-field missing \
+    --quiet >/dev/null 2>&1; then
+    pass "missing required field fails closed"
+else
+    fail "missing required field unexpectedly succeeded"
+fi
+
+if ! bash "$EXTRACTOR" \
+    --results "$RESULTS_TMPFILE" \
+    --scenario fixture-agent \
+    --field foo_bar=metadata.engine_data.foo.bar \
+    --required-status failed \
+    --quiet >/dev/null 2>&1; then
+    pass "required status mismatch fails closed"
+else
+    fail "required status mismatch unexpectedly succeeded"
+fi
+
+if [ "$fail_count" -gt 0 ]; then
+    echo "✗ engine_data extractor smoke test FAILED (${fail_count} failed, ${pass_count} passed)" >&2
+    exit 1
+fi
+
+echo "✓ engine_data extractor smoke test PASSED (${pass_count} checks)"

--- a/wordpress/scripts/agent/extract-engine-data.sh
+++ b/wordpress/scripts/agent/extract-engine-data.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   extract-engine-data.sh --results results.json --scenario scenario-id \
+#       --field key=metadata.engine_data.path --required-field key
+
+error() { echo "ERROR: $*" >&2; exit 1; }
+warn() { echo "WARNING: $*" >&2; }
+
+RESULTS_PATH=""
+SCENARIO_ID=""
+REQUIRED_STATUS="completed"
+PRINT_ALIGNED_WIDTH="32"
+TO_STDOUT=1
+TO_GITHUB_OUTPUT=0
+GITHUB_OUTPUT_REQUESTED=0
+QUIET=0
+FIELDS=()
+REQUIRED_FIELDS=()
+
+[ -z "${GITHUB_OUTPUT:-}" ] || TO_GITHUB_OUTPUT=1
+
+next_value() {
+    [ "$2" -gt 0 ] || error "$1 requires a value"
+    printf '%s' "${3:-}"
+}
+
+while [ "$#" -gt 0 ]; do
+    arg="$1"
+    shift
+    case "$arg" in
+        --results) RESULTS_PATH=$(next_value --results "$#" "${1:-}"); shift ;;
+        --results=*) RESULTS_PATH="${arg#--results=}" ;;
+        --scenario) SCENARIO_ID=$(next_value --scenario "$#" "${1:-}"); shift ;;
+        --scenario=*) SCENARIO_ID="${arg#--scenario=}" ;;
+        --field) FIELDS+=("$(next_value --field "$#" "${1:-}")"); shift ;;
+        --field=*) FIELDS+=("${arg#--field=}") ;;
+        --required-status) REQUIRED_STATUS=$(next_value --required-status "$#" "${1:-}"); shift ;;
+        --required-status=*) REQUIRED_STATUS="${arg#--required-status=}" ;;
+        --required-field) REQUIRED_FIELDS+=("$(next_value --required-field "$#" "${1:-}")"); shift ;;
+        --required-field=*) REQUIRED_FIELDS+=("${arg#--required-field=}") ;;
+        --to-github-output) TO_GITHUB_OUTPUT=1; GITHUB_OUTPUT_REQUESTED=1 ;;
+        --to-stdout) TO_STDOUT=1 ;;
+        --print-aligned-width) PRINT_ALIGNED_WIDTH=$(next_value --print-aligned-width "$#" "${1:-}"); shift ;;
+        --print-aligned-width=*) PRINT_ALIGNED_WIDTH="${arg#--print-aligned-width=}" ;;
+        --quiet) QUIET=1 ;;
+        *) error "unknown argument: $arg" ;;
+    esac
+done
+
+[ -n "$RESULTS_PATH" ] || error "--results is required"
+[ -s "$RESULTS_PATH" ] || error "results file missing or empty: $RESULTS_PATH"
+[ -n "$SCENARIO_ID" ] || error "--scenario is required"
+[ "${#FIELDS[@]}" -gt 0 ] || error "at least one --field is required"
+[[ "$PRINT_ALIGNED_WIDTH" =~ ^[0-9]+$ ]] || error "--print-aligned-width must be a number"
+command -v jq >/dev/null 2>&1 || error "jq required"
+
+if [ "$TO_GITHUB_OUTPUT" = "1" ] && [ -z "${GITHUB_OUTPUT:-}" ]; then
+    [ "$GITHUB_OUTPUT_REQUESTED" = "0" ] || warn "--to-github-output requested but GITHUB_OUTPUT is unset; skipping GitHub output"
+    TO_GITHUB_OUTPUT=0
+fi
+
+if ! scenario_json=$(jq -ec --arg scenario "$SCENARIO_ID" '.scenarios[] | select(.id == $scenario)' "$RESULTS_PATH"); then
+    error "scenario not found in results: $SCENARIO_ID"
+fi
+
+FIELD_KEYS=()
+FIELD_VALUES=()
+for field in "${FIELDS[@]}"; do
+    [[ "$field" == *=* ]] || error "--field must use key=jq_path, got: $field"
+    key="${field%%=*}"
+    path="${field#*=}"
+    [ -n "$key" ] && [ -n "$path" ] || error "--field requires non-empty key and jq_path, got: $field"
+    jq_path="$path"
+    [[ "$jq_path" == .* ]] || jq_path=".$jq_path"
+    if ! value=$(jq -r "($jq_path) // empty" <<<"$scenario_json"); then
+        error "failed to resolve jq path for $key: $path"
+    fi
+
+    FIELD_KEYS+=("$key")
+    FIELD_VALUES+=("$value")
+    [ "$TO_GITHUB_OUTPUT" = "0" ] || printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT"
+    if [ "$TO_STDOUT" = "1" ] && [ "$QUIET" != "1" ]; then
+        printf "%-${PRINT_ALIGNED_WIDTH}s %s\n" "${key}:" "$value"
+    fi
+done
+
+if [ -n "$REQUIRED_STATUS" ]; then
+    actual_status=$(jq -r '.metadata.job_status // empty' <<<"$scenario_json")
+    [ "$actual_status" = "$REQUIRED_STATUS" ] || error "scenario $SCENARIO_ID job_status expected $REQUIRED_STATUS, got ${actual_status:-empty}"
+fi
+
+for required_key in "${REQUIRED_FIELDS[@]}"; do
+    found=0
+    for i in "${!FIELD_KEYS[@]}"; do
+        [ "${FIELD_KEYS[$i]}" = "$required_key" ] || continue
+        found=1
+        [ -n "${FIELD_VALUES[$i]}" ] || error "required field $required_key is empty"
+    done
+    [ "$found" = "1" ] || error "required field was not projected: $required_key"
+done

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -189,3 +189,10 @@ if jq -e "$scenario | .metadata.error?" "$RESULTS_FILE" >/dev/null; then
     jq -r "$scenario | .metadata.error" "$RESULTS_FILE" >&2
     exit 1
 fi
+
+# After this script returns, consumers can extract engine_data fields with:
+#
+#   "$EXTENSION_PATH/scripts/agent/extract-engine-data.sh" \
+#       --results "$RESULTS_FILE" \
+#       --scenario <scenario-id> \
+#       --field key=metadata.engine_data.path.to.value


### PR DESCRIPTION
## Summary
- Adds `wordpress/scripts/agent/extract-engine-data.sh` for projecting scenario `metadata.engine_data.*` values into stdout and `$GITHUB_OUTPUT`.
- Supports repeatable `--field key=jq_path`, required job status validation, and required projected fields.
- Adds a self-contained smoke test covering successful projection plus missing scenario, missing required field, and status mismatch failures.
- Documents the helper from `run-datamachine-agent.sh` without changing runner behavior.

Closes #491

## Why
- `chubes4/world-of-wordpress` already needs to project Data Machine agent engine data after world creator runs: https://github.com/chubes4/world-of-wordpress
- `chubes4/wc-site-generator` PR #173 needs the same post-run extraction path: https://github.com/chubes4/wc-site-generator/pull/173
- `Automattic/docs-agent` PR #1 also needs a generic helper instead of bespoke extraction code: https://github.com/Automattic/docs-agent/pull/1

## Out of scope
- No consumer migrations in this PR; those stay as per-consumer follow-ups.
- No probe-style PHP wrapper.
- No required-field schema in the runner layer.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the `extract-engine-data.sh` helper and its smoke test, and added a comment in `run-datamachine-agent.sh` pointing consumers at it. Chris reviewed all flag parsing, error handling, and the smoke test coverage.