### PR TITLE
Mount external Data Machine agent bundles

### DIFF
--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -118,17 +118,24 @@ if [ -n "$BUNDLE_REPO" ]; then
         echo "ERROR: bundle_path_in_repo does not exist in bundle_repo: $BUNDLE_PATH_IN_REPO" >&2
         exit 1
     fi
+    BUNDLE_GUEST_SLUG="$(basename "$(cd "$BUNDLE_PATH" && pwd)")"
+    BUNDLE_GUEST_PATH="/wordpress/wp-content/plugins/${BUNDLE_GUEST_SLUG}"
     CONFIG_JSON=$(jq -c \
         --arg bundlePath "$BUNDLE_PATH" \
+        --arg bundleGuestPath "$BUNDLE_GUEST_PATH" \
         --arg bundleRepo "$BUNDLE_REPO" \
         --arg bundleRef "$BUNDLE_REF" \
         --arg bundlePathInRepo "$BUNDLE_PATH_IN_REPO" \
         '. + {
-            bundle_path: $bundlePath,
+            bundle_path: $bundleGuestPath,
+            bundle_host_path: $bundlePath,
             bundle_repo: $bundleRepo,
             bundle_ref: $bundleRef,
             bundle_path_in_repo: $bundlePathInRepo
-        }' <<<"$CONFIG_JSON")
+        } | .validation_dependencies = (
+            (if (.validation_dependencies // .dependencies // []) | type == "array" then (.validation_dependencies // .dependencies // []) elif (.validation_dependencies // .dependencies // null) | type == "string" then [(.validation_dependencies // .dependencies)] else [] end)
+            + [$bundlePath]
+        )' <<<"$CONFIG_JSON")
 fi
 
 WORKLOAD_ID=$(jq -r '.workload_id // "datamachine-agent"' "$CONFIG_PATH")


### PR DESCRIPTION
## Summary
- Mount `bundle_repo` checkouts into Playground before running the generic Data Machine agent workload.
- Rewrite imported `bundle_path` to the Playground guest path while preserving the host path for diagnostics.
- Include the mounted bundle path in validation dependencies so external bundles are available during local and CI proofs.

## Testing
- `bash -n scripts/agent/run-datamachine-agent.sh`
- `php scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- Local Agents API Docs Agent proof passed with `success_status=no_changes` after this fix.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the missing Playground bundle mount during the Docs Agent proof and drafted the runner fix; Chris remains responsible for review and merge.