### PR TITLE
feat: add shared Data Machine agent bundle validator with spec-driven assertions

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -53,6 +53,21 @@ separate `php` process, emits `HOST_SMOKE_*` markers, and fails fast with the
 failing script name. It does not bootstrap WordPress, connect to MySQL, or start
 Playground.
 
+## Data Machine agent bundle validator
+
+Agent bundle repositories can run the shared bundle validator as a standalone
+CI smoke without booting WordPress:
+
+```bash
+php path/to/homeboy-extensions/wordpress/scripts/agent/validate-bundle.php path/to/spec.json
+```
+
+The spec declares the bundle directory, expected manifest slugs, bundled
+pipeline and flow files, required memory files, required AI tools, and optional
+dot-path assertions against the manifest or example runner config. `bundle_dir`
+and `example_runner_config` are resolved relative to the spec file's parent
+directory so specs can live at repo root or under `tests/`.
+
 ## Dependencies
 
 If your plugin depends on other local plugins at runtime, declare them:

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,7 +10,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
       "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js"
     ],
     "test": [
@@ -20,6 +20,7 @@
       "bash scripts/test/playground-process-cleanup-smoke.sh",
       "bash scripts/test/playground-cleanup-noise-smoke.sh",
       "bash scripts/test/playground-no-test-files-smoke.sh",
+      "bash scripts/agent/validate-bundle-smoke.sh",
       "bash scripts/trace/trace-runner-smoke.sh",
       "bash scripts/lint/wordpress-lint-role-smoke.sh",
       "bash scripts/lint/vendor-prefixed-exclusion-smoke.sh",

--- a/wordpress/scripts/agent/validate-bundle-smoke.sh
+++ b/wordpress/scripts/agent/validate-bundle-smoke.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATOR="${SCRIPT_DIR}/validate-bundle.php"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/validate-bundle-smoke.XXXXXX")"
+PASSES=0
+FAILURES=0
+
+cleanup() {
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+pass() {
+    echo "PASS $1"
+    PASSES=$((PASSES + 1))
+}
+
+fail() {
+    echo "FAIL $1" >&2
+    FAILURES=$((FAILURES + 1))
+}
+
+write_good_bundle() {
+    rm -rf "${TMP_ROOT:?}/bundle" "${TMP_ROOT}/examples" "${TMP_ROOT}/spec.json"
+    mkdir -p "${TMP_ROOT}/bundle/pipelines" "${TMP_ROOT}/bundle/flows" "${TMP_ROOT}/bundle/memory/agent" "${TMP_ROOT}/examples"
+
+    cat > "${TMP_ROOT}/bundle/manifest.json" <<'JSON'
+{
+  "bundle_slug": "test-bundle",
+  "agent": {
+    "slug": "test-agent",
+    "label": "Test Agent",
+    "agent_config": {
+      "daily_memory": {
+        "enabled": true
+      }
+    }
+  },
+  "included": {
+    "pipelines": ["test-pipeline"],
+    "flows": ["test-flow"]
+  },
+  "run_artifacts": {
+    "completion_assertions": {
+      "egress": ["pr-body"]
+    }
+  }
+}
+JSON
+
+    cat > "${TMP_ROOT}/bundle/pipelines/test-pipeline.json" <<'JSON'
+{
+  "slug": "test-pipeline",
+  "steps": [
+    {
+      "step_type": "ai",
+      "step_config": {
+        "system_prompt": "Read source code and write a precise patch."
+      }
+    }
+  ]
+}
+JSON
+
+    cat > "${TMP_ROOT}/bundle/flows/test-flow.json" <<'JSON'
+{
+  "slug": "test-flow",
+  "pipeline_slug": "test-pipeline",
+  "steps": [
+    {
+      "step_type": "ai",
+      "enabled_tools": ["required_tool", "agent_daily_memory"],
+      "completion_assertions": []
+    }
+  ]
+}
+JSON
+
+    cat > "${TMP_ROOT}/bundle/memory/agent/SOUL.md" <<'EOF_MEMORY'
+# Test Agent
+EOF_MEMORY
+
+    cat > "${TMP_ROOT}/examples/homeboy-runner-config.example.json" <<'JSON'
+{
+  "success_requires_pr": false,
+  "pipeline_slug": "test-pipeline"
+}
+JSON
+
+    cat > "${TMP_ROOT}/spec.json" <<'JSON'
+{
+  "bundle_dir": "bundle",
+  "bundle_slug": "test-bundle",
+  "agent_slug": "test-agent",
+  "agent_label": "Test Agent",
+  "expected_pipelines": ["test-pipeline"],
+  "expected_flows": ["test-flow"],
+  "memory_files": ["SOUL.md"],
+  "manifest_assertions": {
+    "run_artifacts.completion_assertions.egress": ["pr-body"],
+    "agent.agent_config.daily_memory.enabled": true
+  },
+  "flow_assertions": {
+    "test-flow": {
+      "pipeline_slug": "test-pipeline",
+      "ai_step_required_tools": ["required_tool", "agent_daily_memory"],
+      "completion_assertions_empty": true
+    }
+  },
+  "pipeline_assertions": {
+    "test-pipeline": {
+      "system_prompt_must_contain": "source code"
+    }
+  },
+  "example_runner_config": "examples/homeboy-runner-config.example.json",
+  "example_assertions": {
+    "success_requires_pr": false,
+    "pipeline_slug": "test-pipeline"
+  }
+}
+JSON
+}
+
+json_set() {
+    local file="$1"
+    local path="$2"
+    local value_json="$3"
+
+    php -r '
+        $file = $argv[1];
+        $path = explode(".", $argv[2]);
+        $value = json_decode($argv[3], true);
+        $data = json_decode((string) file_get_contents($file), true);
+        $cursor =& $data;
+        foreach ($path as $part) {
+            $cursor =& $cursor[$part];
+        }
+        $cursor = $value;
+        file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+    ' "$file" "$path" "$value_json"
+}
+
+expect_success() {
+    local label="$1"
+    local output
+
+    if output="$(php "$VALIDATOR" "${TMP_ROOT}/spec.json" 2>&1)"; then
+        if grep -Fq "All " <<<"$output"; then
+            pass "$label"
+        else
+            fail "$label (success output missing summary)"
+            printf '%s\n' "$output" >&2
+        fi
+    else
+        fail "$label (validator exited non-zero)"
+        printf '%s\n' "$output" >&2
+    fi
+}
+
+expect_failure() {
+    local label="$1"
+    local expected_label="$2"
+    local output
+
+    set +e
+    output="$(php "$VALIDATOR" "${TMP_ROOT}/spec.json" 2>&1)"
+    local status=$?
+    set -e
+
+    if [ "$status" -eq 0 ]; then
+        fail "$label (validator exited zero)"
+        printf '%s\n' "$output" >&2
+        return
+    fi
+
+    if grep -Fq "$expected_label" <<<"$output"; then
+        pass "$label"
+    else
+        fail "$label (missing failure label: $expected_label)"
+        printf '%s\n' "$output" >&2
+    fi
+}
+
+write_good_bundle
+expect_success "valid bundle passes"
+
+write_good_bundle
+json_set "${TMP_ROOT}/bundle/manifest.json" "bundle_slug" '"wrong-bundle"'
+expect_failure "wrong bundle_slug fails" "manifest bundle_slug matches spec"
+
+write_good_bundle
+rm "${TMP_ROOT}/bundle/flows/test-flow.json"
+expect_failure "missing flow fails" "flow file exists for test-flow"
+
+write_good_bundle
+json_set "${TMP_ROOT}/bundle/flows/test-flow.json" "pipeline_slug" '"wrong-pipeline"'
+expect_failure "wrong pipeline_slug fails" "flow test-flow pipeline_slug"
+
+write_good_bundle
+json_set "${TMP_ROOT}/bundle/flows/test-flow.json" "steps.0.enabled_tools" '["agent_daily_memory"]'
+expect_failure "missing required tool fails" "flow test-flow AI step 0 enables tool required_tool"
+
+write_good_bundle
+rm "${TMP_ROOT}/bundle/memory/agent/SOUL.md"
+expect_failure "missing memory file fails" "memory file exists: SOUL.md"
+
+write_good_bundle
+json_set "${TMP_ROOT}/bundle/manifest.json" "agent.agent_config.daily_memory.enabled" 'false'
+expect_failure "wrong manifest assertion value fails" "manifest assertion agent.agent_config.daily_memory.enabled"
+
+if [ "$FAILURES" -gt 0 ]; then
+    echo "validate-bundle smoke: ${FAILURES} failed, ${PASSES} passed" >&2
+    exit 1
+fi
+
+echo "validate-bundle smoke: all ${PASSES} checks PASSED"

--- a/wordpress/scripts/agent/validate-bundle.php
+++ b/wordpress/scripts/agent/validate-bundle.php
@@ -1,0 +1,382 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+/**
+ * Validate a Data Machine agent bundle from a thin JSON spec.
+ *
+ * Usage:
+ *   php wordpress/scripts/agent/validate-bundle.php path/to/spec.json
+ *
+ * Spec example:
+ *   {
+ *     "bundle_dir": "bundles/docs-agent",
+ *     "bundle_slug": "docs-agent",
+ *     "agent_slug": "docs-agent",
+ *     "agent_label": "Docs Agent",
+ *     "expected_pipelines": ["technical-docs-pipeline", "user-docs-pipeline"],
+ *     "expected_flows": ["technical-docs-flow", "user-docs-flow"],
+ *     "memory_files": ["SOUL.md", "MEMORY.md"],
+ *     "manifest_assertions": {
+ *       "run_artifacts.completion_assertions.egress": ["pr-body"],
+ *       "agent.agent_config.daily_memory.enabled": true
+ *     },
+ *     "flow_assertions": {
+ *       "technical-docs-flow": {
+ *         "pipeline_slug": "technical-docs-pipeline",
+ *         "ai_step_required_tools": [
+ *           "get_github_file",
+ *           "create_or_update_github_file",
+ *           "create_github_pull_request"
+ *         ],
+ *         "completion_assertions_empty": true
+ *       }
+ *     },
+ *     "pipeline_assertions": {
+ *       "technical-docs-pipeline": {
+ *         "system_prompt_must_contain": "source code"
+ *       }
+ *     },
+ *     "example_runner_config": "examples/homeboy-runner-config.example.json",
+ *     "example_assertions": {
+ *       "success_requires_pr": false,
+ *       "pipeline_slug": "technical-docs-pipeline"
+ *     }
+ *   }
+ *
+ * Paths:
+ *   bundle_dir and example_runner_config are resolved relative to the spec
+ *   file's parent directory. This lets consumers keep the spec at repo root
+ *   with "bundle_dir": "bundles/docs-agent", or under tests/ with
+ *   "bundle_dir": "../bundles/docs-agent".
+ *
+ * This script is intentionally standalone: no Composer dependencies, no
+ * WordPress runtime, and no PHPUnit bootstrap.
+ */
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "ERROR: validate-bundle.php must be run from the CLI.\n");
+    exit(1);
+}
+
+$spec_file = $argv[1] ?? '';
+if ($spec_file === '' || in_array($spec_file, ['-h', '--help'], true)) {
+    fwrite(STDERR, "Usage: php wordpress/scripts/agent/validate-bundle.php path/to/spec.json\n");
+    exit($spec_file === '' ? 1 : 0);
+}
+
+$failures = 0;
+$checks = 0;
+
+$display = static function (mixed $value): string {
+    if (is_string($value)) {
+        return $value;
+    }
+
+    $encoded = json_encode($value, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+    return $encoded === false ? var_export($value, true) : $encoded;
+};
+
+$fail = static function (string $label, mixed $expected, mixed $actual) use (&$failures, &$checks, $display): void {
+    ++$checks;
+    ++$failures;
+
+    echo "  FAIL {$label}\n";
+    echo '    expected: ' . $display($expected) . "\n";
+    echo '    actual:   ' . $display($actual) . "\n";
+};
+
+$pass = static function (string $label) use (&$checks): void {
+    ++$checks;
+    echo "  PASS {$label}\n";
+};
+
+$assert_same = static function (string $label, mixed $expected, mixed $actual) use ($fail, $pass): void {
+    if ($actual === $expected) {
+        $pass($label);
+        return;
+    }
+
+    $fail($label, $expected, $actual);
+};
+
+$assert_true = static function (string $label, bool $condition, mixed $expected, mixed $actual) use ($fail, $pass): void {
+    if ($condition) {
+        $pass($label);
+        return;
+    }
+
+    $fail($label, $expected, $actual);
+};
+
+$resolve_path = static function (string $base_dir, string $path): string {
+    if ($path !== '' && str_starts_with($path, '/')) {
+        return $path;
+    }
+
+    return $base_dir . DIRECTORY_SEPARATOR . $path;
+};
+
+$read_json = static function (string $path, string $label): array {
+    if (!is_file($path)) {
+        fwrite(STDERR, "ERROR: {$label} not found at {$path}\n");
+        exit(1);
+    }
+
+    $contents = file_get_contents($path);
+    if ($contents === false) {
+        fwrite(STDERR, "ERROR: unable to read {$label} at {$path}\n");
+        exit(1);
+    }
+
+    $decoded = json_decode($contents, true);
+    if (!is_array($decoded)) {
+        fwrite(STDERR, "ERROR: malformed JSON in {$label} at {$path}: " . json_last_error_msg() . "\n");
+        exit(1);
+    }
+
+    return $decoded;
+};
+
+$walk_path = static function (array $data, string $path): array {
+    $current = $data;
+    $walked = [];
+
+    foreach (explode('.', $path) as $part) {
+        $walked[] = $part;
+        if (!is_array($current) || !array_key_exists($part, $current)) {
+            return [false, implode('.', $walked), null];
+        }
+
+        $current = $current[$part];
+    }
+
+    return [true, $path, $current];
+};
+
+$find_first_ai_step = static function (array $data): ?array {
+    $steps = $data['steps'] ?? null;
+    if (!is_array($steps)) {
+        return null;
+    }
+
+    foreach ($steps as $index => $step) {
+        if (is_array($step) && ($step['step_type'] ?? null) === 'ai') {
+            return [$index, $step];
+        }
+    }
+
+    return null;
+};
+
+$spec_path = realpath($spec_file);
+if ($spec_path === false) {
+    fwrite(STDERR, "ERROR: spec not found at {$spec_file}\n");
+    exit(1);
+}
+
+$spec_dir = dirname($spec_path);
+$spec = $read_json($spec_path, 'spec');
+
+foreach (['bundle_dir', 'bundle_slug', 'agent_slug'] as $required_key) {
+    if (!array_key_exists($required_key, $spec) || !is_string($spec[$required_key]) || $spec[$required_key] === '') {
+        fwrite(STDERR, "ERROR: spec missing required string key: {$required_key}\n");
+        exit(1);
+    }
+}
+
+$bundle_slug = $spec['bundle_slug'];
+$bundle_dir = realpath($resolve_path($spec_dir, $spec['bundle_dir']));
+if ($bundle_dir === false || !is_dir($bundle_dir)) {
+    fwrite(STDERR, "ERROR: bundle_dir not found at " . $resolve_path($spec_dir, $spec['bundle_dir']) . "\n");
+    exit(1);
+}
+
+echo "bundle-validator: {$bundle_slug}\n";
+
+$manifest = $read_json($bundle_dir . DIRECTORY_SEPARATOR . 'manifest.json', 'manifest');
+
+$assert_same('manifest bundle_slug matches spec', $bundle_slug, $manifest['bundle_slug'] ?? null);
+$assert_same('manifest agent.slug matches spec', $spec['agent_slug'], $manifest['agent']['slug'] ?? null);
+if (array_key_exists('agent_label', $spec)) {
+    $assert_same('manifest agent.label matches spec', $spec['agent_label'], $manifest['agent']['label'] ?? null);
+}
+
+$included_pipelines = $manifest['included']['pipelines'] ?? [];
+$included_flows = $manifest['included']['flows'] ?? [];
+$loaded_pipelines = [];
+$loaded_flows = [];
+
+foreach (($spec['expected_pipelines'] ?? []) as $pipeline_slug) {
+    $assert_true(
+        "manifest includes pipeline {$pipeline_slug}",
+        is_array($included_pipelines) && in_array($pipeline_slug, $included_pipelines, true),
+        'included in manifest.included.pipelines',
+        $included_pipelines
+    );
+
+    $pipeline_file = $bundle_dir . DIRECTORY_SEPARATOR . 'pipelines' . DIRECTORY_SEPARATOR . $pipeline_slug . '.json';
+    $assert_true("pipeline file exists for {$pipeline_slug}", is_file($pipeline_file), $pipeline_file, is_file($pipeline_file) ? $pipeline_file : 'missing');
+    if (is_file($pipeline_file)) {
+        $loaded_pipelines[$pipeline_slug] = $read_json($pipeline_file, "pipeline {$pipeline_slug}");
+        $assert_same("pipeline {$pipeline_slug} slug matches filename", $pipeline_slug, $loaded_pipelines[$pipeline_slug]['slug'] ?? null);
+    }
+}
+
+foreach (($spec['expected_flows'] ?? []) as $flow_slug) {
+    $assert_true(
+        "manifest includes flow {$flow_slug}",
+        is_array($included_flows) && in_array($flow_slug, $included_flows, true),
+        'included in manifest.included.flows',
+        $included_flows
+    );
+
+    $flow_file = $bundle_dir . DIRECTORY_SEPARATOR . 'flows' . DIRECTORY_SEPARATOR . $flow_slug . '.json';
+    $assert_true("flow file exists for {$flow_slug}", is_file($flow_file), $flow_file, is_file($flow_file) ? $flow_file : 'missing');
+    if (is_file($flow_file)) {
+        $loaded_flows[$flow_slug] = $read_json($flow_file, "flow {$flow_slug}");
+        $assert_same("flow {$flow_slug} slug matches filename", $flow_slug, $loaded_flows[$flow_slug]['slug'] ?? null);
+        $pipeline_slug = $loaded_flows[$flow_slug]['pipeline_slug'] ?? null;
+        $pipeline_file = is_string($pipeline_slug)
+            ? $bundle_dir . DIRECTORY_SEPARATOR . 'pipelines' . DIRECTORY_SEPARATOR . $pipeline_slug . '.json'
+            : null;
+        $assert_true(
+            "flow {$flow_slug} pipeline_slug points to an existing pipeline",
+            $pipeline_file !== null && is_file($pipeline_file),
+            'pipeline_slug referencing an existing pipeline file',
+            $pipeline_slug
+        );
+    }
+}
+
+foreach (($spec['memory_files'] ?? []) as $memory_file) {
+    $memory_path = $bundle_dir . DIRECTORY_SEPARATOR . 'memory' . DIRECTORY_SEPARATOR . 'agent' . DIRECTORY_SEPARATOR . $memory_file;
+    $assert_true("memory file exists: {$memory_file}", is_file($memory_path), $memory_path, is_file($memory_path) ? $memory_path : 'missing');
+}
+
+foreach (($spec['manifest_assertions'] ?? []) as $path => $expected) {
+    [$found, $missing_path, $actual] = $walk_path($manifest, (string) $path);
+    if (!$found) {
+        $fail("manifest assertion {$path}", $expected, "missing path: {$missing_path}");
+        continue;
+    }
+
+    $assert_same("manifest assertion {$path}", $expected, $actual);
+}
+
+foreach (($spec['flow_assertions'] ?? []) as $flow_slug => $assertions) {
+    if (!is_array($assertions)) {
+        $fail("flow {$flow_slug} assertions are an object", 'object', gettype($assertions));
+        continue;
+    }
+
+    if (!isset($loaded_flows[$flow_slug])) {
+        $flow_file = $bundle_dir . DIRECTORY_SEPARATOR . 'flows' . DIRECTORY_SEPARATOR . $flow_slug . '.json';
+        if (is_file($flow_file)) {
+            $loaded_flows[$flow_slug] = $read_json($flow_file, "flow {$flow_slug}");
+        } else {
+            $fail("flow assertion target exists: {$flow_slug}", $flow_file, 'missing');
+            continue;
+        }
+    }
+
+    $flow = $loaded_flows[$flow_slug];
+    if (array_key_exists('pipeline_slug', $assertions)) {
+        $assert_same("flow {$flow_slug} pipeline_slug", $assertions['pipeline_slug'], $flow['pipeline_slug'] ?? null);
+    }
+
+    if (array_key_exists('ai_step_required_tools', $assertions)) {
+        $ai_step = $find_first_ai_step($flow);
+        if ($ai_step === null) {
+            $fail("flow {$flow_slug} has an AI step", 'first step with step_type=ai', 'missing');
+        } else {
+            [$step_index, $step] = $ai_step;
+            $enabled_tools = $step['enabled_tools'] ?? [];
+            foreach ($assertions['ai_step_required_tools'] as $tool) {
+                $assert_true(
+                    "flow {$flow_slug} AI step {$step_index} enables tool {$tool}",
+                    is_array($enabled_tools) && in_array($tool, $enabled_tools, true),
+                    'enabled in steps[' . $step_index . '].enabled_tools',
+                    $enabled_tools
+                );
+            }
+        }
+    }
+
+    if (($assertions['completion_assertions_empty'] ?? false) === true) {
+        $ai_step = $find_first_ai_step($flow);
+        if ($ai_step === null) {
+            $fail("flow {$flow_slug} has an AI step for completion assertions", 'first step with step_type=ai', 'missing');
+        } else {
+            [$step_index, $step] = $ai_step;
+            $completion_assertions = $step['completion_assertions'] ?? [];
+            $assert_true(
+                "flow {$flow_slug} AI step {$step_index} completion_assertions empty",
+                $completion_assertions === [] || $completion_assertions === null,
+                'empty or absent',
+                $completion_assertions
+            );
+        }
+    }
+}
+
+foreach (($spec['pipeline_assertions'] ?? []) as $pipeline_slug => $assertions) {
+    if (!is_array($assertions)) {
+        $fail("pipeline {$pipeline_slug} assertions are an object", 'object', gettype($assertions));
+        continue;
+    }
+
+    if (!isset($loaded_pipelines[$pipeline_slug])) {
+        $pipeline_file = $bundle_dir . DIRECTORY_SEPARATOR . 'pipelines' . DIRECTORY_SEPARATOR . $pipeline_slug . '.json';
+        if (is_file($pipeline_file)) {
+            $loaded_pipelines[$pipeline_slug] = $read_json($pipeline_file, "pipeline {$pipeline_slug}");
+        } else {
+            $fail("pipeline assertion target exists: {$pipeline_slug}", $pipeline_file, 'missing');
+            continue;
+        }
+    }
+
+    if (array_key_exists('system_prompt_must_contain', $assertions)) {
+        $ai_step = $find_first_ai_step($loaded_pipelines[$pipeline_slug]);
+        if ($ai_step === null) {
+            $fail("pipeline {$pipeline_slug} has an AI step", 'first step with step_type=ai', 'missing');
+        } else {
+            [$step_index, $step] = $ai_step;
+            $system_prompt = $step['step_config']['system_prompt'] ?? '';
+            $needle = (string) $assertions['system_prompt_must_contain'];
+            $assert_true(
+                "pipeline {$pipeline_slug} AI step {$step_index} system_prompt contains {$needle}",
+                is_string($system_prompt) && str_contains($system_prompt, $needle),
+                "substring: {$needle}",
+                $system_prompt
+            );
+        }
+    }
+}
+
+if (array_key_exists('example_runner_config', $spec)) {
+    if (!is_string($spec['example_runner_config']) || $spec['example_runner_config'] === '') {
+        fwrite(STDERR, "ERROR: example_runner_config must be a non-empty string when provided.\n");
+        exit(1);
+    }
+
+    $example_path = $resolve_path($spec_dir, $spec['example_runner_config']);
+    $example_config = $read_json($example_path, 'example runner config');
+    foreach (($spec['example_assertions'] ?? []) as $path => $expected) {
+        [$found, $missing_path, $actual] = $walk_path($example_config, (string) $path);
+        if (!$found) {
+            $fail("example assertion {$path}", $expected, "missing path: {$missing_path}");
+            continue;
+        }
+
+        $assert_same("example assertion {$path}", $expected, $actual);
+    }
+}
+
+if ($failures > 0) {
+    echo "\nFAILED: {$failures} validation checks failed.\n";
+    exit(1);
+}
+
+echo "\nAll {$checks} validation checks passed.\n";
+exit(0);


### PR DESCRIPTION
## Summary
- Adds `wordpress/scripts/agent/validate-bundle.php`, a standalone PHP validator for Data Machine agent bundle manifests, flows, pipelines, memory files, and spec-driven dot-path assertions.
- Defines a thin JSON spec format that resolves bundle and example config paths relative to the spec file.
- Adds `wordpress/scripts/agent/validate-bundle-smoke.sh` with known-good and known-bad synthetic bundle coverage.
- Registers the validator smoke in the WordPress extension self-checks and documents the standalone CI usage.

Closes #493

## Why
- `world-of-wordpress` currently carries a per-bundle validator for the World Creator bundle: https://github.com/chubes4/world-of-wordpress/blob/main/tests/validate-world-creator-bundle.php
- `wc-site-generator` now ships multiple Data Machine agent bundles that need the same assertion shape: https://github.com/chubes4/wc-site-generator/tree/main/bundles
- `Automattic/docs-agent` PR #1 carries a near-identical validator for its initial bundle work: https://github.com/Automattic/docs-agent/pull/1

## Spec format
```json
{
  "bundle_dir": "bundles/docs-agent",
  "bundle_slug": "docs-agent",
  "agent_slug": "docs-agent",
  "expected_pipelines": ["technical-docs-pipeline"],
  "expected_flows": ["technical-docs-flow"],
  "memory_files": ["SOUL.md", "MEMORY.md"],
  "flow_assertions": {
    "technical-docs-flow": {
      "pipeline_slug": "technical-docs-pipeline",
      "ai_step_required_tools": ["create_github_pull_request"],
      "completion_assertions_empty": true
    }
  }
}
```

## Out of scope
- No consumer migrations in this PR.
- No JSON Schema dialect for bundle specs.
- No Composer dependencies or WordPress runtime dependency.
- No runtime validation in the agent runner; this remains a CI smoke layer.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the validator script, the spec format, and the smoke test. Chris reviewed the requested assertion semantics, error reporting style, and exit code behavior through the issue prompt.