### PR TITLE
Persist Playground plugin activation state

### DIFF
--- a/wordpress/scripts/bench/playground-bench-dep-plugins-loaded-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-dep-plugins-loaded-smoke.sh
@@ -9,8 +9,8 @@
 #   2. Mounting a host fixture (bench-plugins-loaded-host) whose tests/bench/
 #      workload throws if the global is unset.
 #   3. Confirming the bench dispatcher exits 0 (workload didn't throw) AND
-#      the BenchResults envelope reports `dep_plugins_loaded_fired_mean=1`
-#      and `dep_ability_registered_mean=1`.
+#      the BenchResults envelope reports `dep_plugins_loaded_fired_mean=1`,
+#      `dep_ability_registered_mean=1`, and `dep_plugin_active_mean=1`.
 #
 # Pre-#426 the workload threw because the dep's plugins_loaded callback
 # never ran — its file was required AFTER plugins_loaded had already fired.
@@ -125,6 +125,22 @@ if [ "$registered" != "1" ]; then
     exit 1
 fi
 echo "✓ dep ability registered with the Abilities API"
+
+# --- Assertion: dep is visible through WordPress active plugin state ---
+active=$(jq -r "$scenario | .metrics.dep_plugin_active_mean // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$active" != "1" ]; then
+    echo "ERROR: dep_plugin_active_mean expected 1, got $active" >&2
+    echo "       The dep loaded, but WordPress still reports it inactive." >&2
+    exit 1
+fi
+echo "✓ dep appears in WordPress active plugin state"
+
+active_plugin_match=$(jq -r "$scenario | .metadata.active_plugins | index(\"bench-plugins-loaded-dep/bench-plugins-loaded-dep.php\") // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$active_plugin_match" = "missing" ] || [ "$active_plugin_match" = "null" ]; then
+    echo "ERROR: bench-plugins-loaded-dep missing from active_plugins metadata" >&2
+    exit 1
+fi
+echo "✓ active_plugins metadata contains validation dependency"
 
 # --- Assertion: bootstrap stage timings still emitted ---
 first_id=$(jq -r '.scenarios[0].id' "$RESULTS_TMPFILE")

--- a/wordpress/scripts/lib/playground-bootstrap.php
+++ b/wordpress/scripts/lib/playground-bootstrap.php
@@ -808,9 +808,32 @@ function pg_activate_plugin_file(string $plugin_file): void {
     pg_log("PLUGIN_ACTIVATE_BEGIN $plugin_basename " . pg_diagnostic_context());
 
     do_action("activate_$plugin_basename", false);
+    pg_mark_plugin_active($plugin_basename);
     do_action('activated_plugin', $plugin_basename, false);
 
     pg_log("PLUGIN_ACTIVATE_OK $plugin_basename " . pg_diagnostic_context());
+}
+
+/**
+ * Persist activation state for directly loaded Playground plugins.
+ *
+ * The Playground runners require plugin files directly, then fire activation
+ * hooks manually. Without updating `active_plugins`, runtime inspectors and
+ * SITE.md-style context see those loaded plugins as inactive even though their
+ * code and hooks are running.
+ */
+function pg_mark_plugin_active(string $plugin_basename): void {
+    if (!function_exists('get_option') || !function_exists('update_option')) {
+        pg_log("NOTICE:cannot mark plugin active before option API is available: $plugin_basename");
+        return;
+    }
+
+    $active_plugins = (array) get_option('active_plugins', []);
+    if (!in_array($plugin_basename, $active_plugins, true)) {
+        $active_plugins[] = $plugin_basename;
+        sort($active_plugins);
+        update_option('active_plugins', array_values($active_plugins));
+    }
 }
 
 /**

--- a/wordpress/tests/fixtures/bench-plugins-loaded-host/tests/bench/assert-dep-plugins-loaded.php
+++ b/wordpress/tests/fixtures/bench-plugins-loaded-host/tests/bench/assert-dep-plugins-loaded.php
@@ -35,6 +35,13 @@ return function (): array {
         }
     }
 
+    if (!function_exists('is_plugin_active')) {
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+    }
+
+    $plugin_file = 'bench-plugins-loaded-dep/bench-plugins-loaded-dep.php';
+    $plugin_active = is_plugin_active($plugin_file);
+
     $ability_registered = function_exists('wp_get_ability')
         && wp_get_ability('bench-plugins-loaded-dep/ping') !== null;
 
@@ -42,10 +49,12 @@ return function (): array {
         'metrics' => [
             'dep_plugins_loaded_fired' => 1,
             'dep_ability_registered' => $ability_registered ? 1 : 0,
+            'dep_plugin_active' => $plugin_active ? 1 : 0,
         ],
         'metadata' => [
             'fixture' => 'bench-plugins-loaded-host',
             'asserts_issue' => 'homeboy-extensions#426',
+            'active_plugins' => array_values((array) get_option('active_plugins', [])),
         ],
     ];
 };


### PR DESCRIPTION
## Summary
- Persists directly loaded Playground plugin basenames into `active_plugins` after manual activation hooks run.
- Extends the validation-dependency smoke test to assert `is_plugin_active()` and `active_plugins` metadata both reflect loaded dependencies.

## Why
Data Machine agent runs were seeing required plugins as "inactive" in runtime inventory even though the runner had loaded their files and fired activation hooks. This made CI transcripts and SITE.md-style context misleading for Playground-backed agent runs.

## Verification
- `bash wordpress/scripts/bench/playground-bench-dep-plugins-loaded-smoke.sh`
- `php -l wordpress/scripts/lib/playground-bootstrap.php`
- `php -l wordpress/tests/fixtures/bench-plugins-loaded-host/tests/bench/assert-dep-plugins-loaded.php`
- `bash -n wordpress/scripts/bench/playground-bench-dep-plugins-loaded-smoke.sh`
- `git diff --check`

## Notes
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-playground-active-plugins --extension wordpress` still reports broad existing repository findings outside this patch; the targeted regression smoke passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the World of WordPress CI transcript/runtime mismatch, drafting the focused runner fix and smoke coverage, and running targeted validation. Chris remains responsible for review and merge.