### PR TITLE
Fail Data Machine agent writes without PRs

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -106,6 +106,30 @@ if ( ! function_exists( 'homeboy_datamachine_agent_pr_opened' ) ) {
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_file_written' ) ) {
+    function homeboy_datamachine_agent_file_written( array $engine_data, array $config ): bool {
+        $tool_results_key = homeboy_datamachine_agent_scalar( $config, 'tool_results_key', 'github_tool_results' );
+        $tool_results     = is_array( $engine_data[ $tool_results_key ] ?? null ) ? $engine_data[ $tool_results_key ] : array();
+
+        foreach ( $tool_results as $tool_result ) {
+            if ( ! is_array( $tool_result ) || empty( $tool_result['success'] ) ) {
+                continue;
+            }
+
+            if ( 'create_or_update_github_file' === (string) ( $tool_result['tool_name'] ?? '' ) ) {
+                return true;
+            }
+
+            $url = (string) ( $tool_result['url'] ?? '' );
+            if ( str_contains( $url, '/commit/' ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_ability_schema' ) ) {
     function homeboy_datamachine_agent_ability_schema( string $ability_name ): array {
         $ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
@@ -769,6 +793,7 @@ $engine_data = function_exists( 'datamachine_get_engine_data' ) ? datamachine_ge
 $transcript_dir = homeboy_datamachine_agent_scalar( $config, 'transcript_dir' );
 $transcript_artifacts = homeboy_datamachine_agent_export_transcript( $job_id, $engine_data, $transcript_dir );
 $pr_opened = homeboy_datamachine_agent_pr_opened( $engine_data, $config );
+$file_written = homeboy_datamachine_agent_file_written( $engine_data, $config );
 $success_status = $pr_opened ? 'pr_opened' : 'no_changes';
 $success_requires_pr = ! empty( $config['success_requires_pr'] );
 
@@ -785,7 +810,13 @@ $metadata += array(
     'error_message'         => (string) ( $engine_data['error_message'] ?? '' ),
     'success_status'        => $success_status,
     'success_requires_pr'   => $success_requires_pr,
+    'file_written'          => $file_written,
 );
+
+if ( $file_written && ! $pr_opened ) {
+    $metadata['success_status'] = 'write_without_pr';
+    return homeboy_datamachine_agent_result( array( 'file_written' => 1, 'pr_opened' => 0 ), $metadata, 'Agent wrote files without opening a pull request' );
+}
 
 if ( $success_requires_pr && ! $pr_opened ) {
     return homeboy_datamachine_agent_result( array( 'pr_opened' => 0 ), $metadata, 'Agent completed without opening a pull request' );
@@ -807,8 +838,9 @@ return homeboy_datamachine_agent_result(
         'drain_succeeded'             => is_array( $drain_result ) && ! empty( $drain_result['success'] ) ? 1 : 0,
         'drain_elapsed_ms'            => $drain_elapsed_ms,
         'job_completed'               => 'completed' === $job_status ? 1 : 0,
+        'file_written'                => $file_written ? 1 : 0,
         'pr_opened'                   => $pr_opened ? 1 : 0,
-        'no_changes'                  => ! $pr_opened ? 1 : 0,
+        'no_changes'                  => ! $file_written && ! $pr_opened ? 1 : 0,
         'transcript_exported'         => ! empty( $transcript_artifacts['json'] ) ? 1 : 0,
         'total_tokens'                => (int) ( $metadata['token_usage']['total_tokens'] ?? 0 ),
     ),

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Smoke test for Data Machine agent write-without-PR classification.
+ *
+ * Run with: php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+ */
+
+namespace DataMachine\Core\Database\Agents {
+    class Agents {}
+}
+
+namespace DataMachine\Core\Database\Chat {
+    class ConversationStoreFactory {}
+}
+
+namespace DataMachine\Core\Database\Flows {
+    class Flows {}
+}
+
+namespace DataMachine\Core\Database\Jobs {
+    class Jobs {}
+}
+
+namespace DataMachine\Core\Database\Pipelines {
+    class Pipelines {}
+}
+
+namespace DataMachine\Core {
+    class PluginSettings {}
+}
+
+namespace {
+    if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/' );
+    }
+
+    if ( ! function_exists( 'wp_json_encode' ) ) {
+        function wp_json_encode( $value, int $flags = 0 ): string {
+            return (string) json_encode( $value, $flags );
+        }
+    }
+
+    putenv(
+        'HOMEBOY_DATAMACHINE_AGENT_CONFIG=' . wp_json_encode(
+            array(
+                'dry_run'    => true,
+                'agent_slug' => 'write-without-pr-smoke-agent',
+                'flow_slug'  => 'write-without-pr-smoke-flow',
+            )
+        )
+    );
+
+    require __DIR__ . '/datamachine-agent-workload.php';
+
+    $config = array( 'tool_results_key' => 'github_tool_results' );
+
+    $write_without_pr = array(
+        'github_tool_results' => array(
+            array(
+                'tool_name' => 'create_or_update_github_file',
+                'success'   => true,
+                'url'       => 'https://github.com/owner/repo/commit/abc123',
+            ),
+        ),
+    );
+
+    if ( ! homeboy_datamachine_agent_file_written( $write_without_pr, $config ) ) {
+        fwrite( STDERR, "Expected successful file-write tool result to count as file_written.\n" );
+        exit( 1 );
+    }
+
+    if ( homeboy_datamachine_agent_pr_opened( $write_without_pr, $config ) ) {
+        fwrite( STDERR, "Did not expect commit-only result to count as pr_opened.\n" );
+        exit( 1 );
+    }
+
+    $pr_opened = array(
+        'github_tool_results' => array(
+            array(
+                'tool_name' => 'create_github_pull_request',
+                'success'   => true,
+                'url'       => 'https://github.com/owner/repo/pull/123',
+            ),
+        ),
+    );
+
+    if ( ! homeboy_datamachine_agent_pr_opened( $pr_opened, $config ) ) {
+        fwrite( STDERR, "Expected pull-request URL to count as pr_opened.\n" );
+        exit( 1 );
+    }
+
+    $no_changes = array( 'github_tool_results' => array() );
+    if ( homeboy_datamachine_agent_file_written( $no_changes, $config ) || homeboy_datamachine_agent_pr_opened( $no_changes, $config ) ) {
+        fwrite( STDERR, "Expected empty tool results to remain no-changes eligible.\n" );
+        exit( 1 );
+    }
+
+    fwrite( STDOUT, "Data Machine agent write-without-PR smoke passed.\n" );
+}


### PR DESCRIPTION
## Summary
- Detect successful `create_or_update_github_file` writes in the generic Data Machine agent runner.
- Fail the workload when a file write happens without a corresponding pull request instead of reporting `no_changes`.
- Add a pure PHP smoke test for the write-without-PR classification invariant.

## Testing
- `php -l scripts/agent/datamachine-agent-workload.php`
- `php -l scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `php scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Docs Agent run that wrote a commit without opening a PR and drafted the runner classification fix; Chris remains responsible for review and merge.