### PR TITLE
Classify nested Data Machine agent tool results

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -87,9 +87,19 @@ if ( ! function_exists( 'homeboy_datamachine_agent_first_url' ) ) {
 }
 
 if ( ! function_exists( 'homeboy_datamachine_agent_pr_opened' ) ) {
-    function homeboy_datamachine_agent_pr_opened( array $engine_data, array $config ): bool {
+    function homeboy_datamachine_agent_tool_results( array $engine_data, array $config ): array {
         $tool_results_key = homeboy_datamachine_agent_scalar( $config, 'tool_results_key', 'github_tool_results' );
-        $tool_results     = is_array( $engine_data[ $tool_results_key ] ?? null ) ? $engine_data[ $tool_results_key ] : array();
+        $engine_key       = homeboy_datamachine_agent_scalar( $config, 'engine_key' );
+
+        if ( '' !== $engine_key && is_array( $engine_data[ $engine_key ][ $tool_results_key ] ?? null ) ) {
+            return $engine_data[ $engine_key ][ $tool_results_key ];
+        }
+
+        return is_array( $engine_data[ $tool_results_key ] ?? null ) ? $engine_data[ $tool_results_key ] : array();
+    }
+
+    function homeboy_datamachine_agent_pr_opened( array $engine_data, array $config ): bool {
+        $tool_results = homeboy_datamachine_agent_tool_results( $engine_data, $config );
 
         foreach ( $tool_results as $tool_result ) {
             if ( ! is_array( $tool_result ) || empty( $tool_result['success'] ) ) {
@@ -108,8 +118,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_pr_opened' ) ) {
 
 if ( ! function_exists( 'homeboy_datamachine_agent_file_written' ) ) {
     function homeboy_datamachine_agent_file_written( array $engine_data, array $config ): bool {
-        $tool_results_key = homeboy_datamachine_agent_scalar( $config, 'tool_results_key', 'github_tool_results' );
-        $tool_results     = is_array( $engine_data[ $tool_results_key ] ?? null ) ? $engine_data[ $tool_results_key ] : array();
+        $tool_results = homeboy_datamachine_agent_tool_results( $engine_data, $config );
 
         foreach ( $tool_results as $tool_result ) {
             if ( ! is_array( $tool_result ) || empty( $tool_result['success'] ) ) {

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -89,6 +89,33 @@ namespace {
         exit( 1 );
     }
 
+    $nested_config = array(
+        'engine_key'       => 'docs_agent',
+        'tool_results_key' => 'github_tool_results',
+    );
+
+    $nested_results = array(
+        'docs_agent' => array(
+            'github_tool_results' => array(
+                array(
+                    'tool_name' => 'create_or_update_github_file',
+                    'success'   => true,
+                    'url'       => 'https://github.com/owner/repo/commit/def456',
+                ),
+                array(
+                    'tool_name' => 'create_github_pull_request',
+                    'success'   => true,
+                    'url'       => 'https://github.com/owner/repo/pull/456',
+                ),
+            ),
+        ),
+    );
+
+    if ( ! homeboy_datamachine_agent_file_written( $nested_results, $nested_config ) || ! homeboy_datamachine_agent_pr_opened( $nested_results, $nested_config ) ) {
+        fwrite( STDERR, "Expected nested engine-key tool results to drive write and PR classification.\n" );
+        exit( 1 );
+    }
+
     $no_changes = array( 'github_tool_results' => array() );
     if ( homeboy_datamachine_agent_file_written( $no_changes, $config ) || homeboy_datamachine_agent_pr_opened( $no_changes, $config ) ) {
         fwrite( STDERR, "Expected empty tool results to remain no-changes eligible.\n" );


### PR DESCRIPTION
## Summary
- Read recorded agent tool results from the configured `engine_key` namespace before falling back to top-level results.
- Make PR/file-write classification match the recorder shape used by Docs Agent (`docs_agent.github_tool_results`).
- Extend write-without-PR smoke coverage for nested recorder results.

## Testing
- `php -l scripts/agent/datamachine-agent-workload.php`
- `php -l scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the guarded Docs Agent run still reporting `no_changes` despite opening a PR and drafted the nested recorder classification fix; Chris remains responsible for review and merge.