### PR TITLE
feat: add extra Playground config inputs to the reusable Data Machine agent CI workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -30,6 +30,56 @@ jobs:
     secrets: inherit
 ```
 
+## World Creator migration example
+
+Workflows that need additional WordPress Playground configuration can pass
+JSON-string inputs through to the runner config without changing the reusable
+workflow. This shape covers the `world-of-wordpress` migration that needs MDI
+primary mode, a `db.php` drop-in mount, pre-run bootstrap work, daily memory,
+and extra ability assertions.
+
+```yaml
+jobs:
+  run-world-creator:
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@v3
+    with:
+      bundle_path: bundles/world-creator
+      agent_slug: world-creator
+      pipeline_slug: world-creator-pipeline
+      flow_slug: world-creator-day-cycle-flow
+      target_repo: chubes4/world-of-wordpress
+      prompt: ${{ inputs.prompt }}
+      validation_dependencies: chubes4/world-of-wordpress@main,chubes4/markdown-database-integration@main,Automattic/agents-api@main,Extra-Chill/data-machine@main,Extra-Chill/data-machine-code@main,WordPress/ai-provider-for-openai@main
+      playground_wordpress: beta
+      max_turns: 16
+      step_budget: 20
+      time_budget_ms: 900000
+      extra_wp_config_defines: |
+        {
+          "MARKDOWN_DB_MODE": "primary",
+          "MARKDOWN_DB_CONTENT_DIR": "/wordpress/wp-content/plugins/world-of-wordpress/content"
+        }
+      extra_playground_file_mounts: |
+        [
+          {
+            "from_dependency": "markdown-database-integration",
+            "from": "db.php",
+            "to": "/wordpress/wp-content/db.php"
+          }
+        ]
+      workload_run_before: |
+        [
+          { "type": "php", "file": "world-creator-bootstrap.php" }
+        ]
+      daily_memory_enabled: true
+      extra_required_abilities: |
+        ["datamachine/create-or-update-github-file", "datamachine/daily-memory-write"]
+      success_requires_pr: true
+      engine_data_outputs: '{"world_creator_pr_url":"metadata.engine_data.world_creator.pr_url"}'
+      transcript_artifact_name: world-creator-transcript-${{ github.run_id }}
+    secrets: inherit
+```
+
 ## Inputs worth calling out
 
 - `validation_dependencies` accepts `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`.
@@ -37,3 +87,5 @@ jobs:
 - `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`.
 - `dry_run` is intended for workflow smoke tests only; production consumers should leave it `false`.
 - `transcript_artifact_name` controls artifact upload. An empty value skips upload.
+- `extra_wp_config_defines` must be a JSON object and is merged into the runner config `wp_config_defines`.
+- `extra_playground_file_mounts`, `workload_run_before`, and `extra_required_abilities` must be JSON arrays.

--- a/.github/workflows/datamachine-agent-ci-self-smoke.yml
+++ b/.github/workflows/datamachine-agent-ci-self-smoke.yml
@@ -20,6 +20,7 @@ jobs:
       prompt: Acknowledge this self-smoke run with a single line and stop. Do not call any GitHub tools.
       success_requires_pr: false
       dry_run: true
+      extra_wp_config_defines: '{"FIXTURE_DEFINE":"hello"}'
       engine_data_outputs: '{}'
     secrets:
       HOMEBOY_APP_ID: ${{ secrets.HOMEBOY_APP_ID }}

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -74,6 +74,42 @@ name: Data Machine Agent CI (reusable)
         description: Build runner config and exercise the runner dry-run path without a live agent call.
         type: boolean
         default: false
+      extra_wp_config_defines:
+        description: |
+          JSON object merged into the runner config wp_config_defines.
+          Default '{}' means no extra defines.
+        type: string
+        default: "{}"
+      extra_playground_file_mounts:
+        description: |
+          JSON array appended to the runner config playground_file_mounts after
+          the default ci-driver fixture mount. Use for plugin drop-ins,
+          must-use plugin mounts, or any consumer-specific Playground file
+          placement. Default '[]' means no extra mounts.
+        type: string
+        default: "[]"
+      workload_run_before:
+        description: |
+          JSON array of pre-run hooks executed before the main bench workload
+          inside Playground. Each entry is { type, file } the same way
+          playground_workloads[*].run entries are. Default '[]' means no
+          pre-run hook.
+        type: string
+        default: "[]"
+      daily_memory_enabled:
+        description: |
+          When true, sets daily_memory_enabled in the runner config so the
+          imported agent runs with daily memory storage on. Default false.
+        type: boolean
+        default: false
+      extra_required_abilities:
+        description: |
+          JSON array of additional ability slugs the runner must assert are
+          registered before invoking the agent. Default '[]' means rely on
+          the runner's built-in ability set (datamachine/import-agent,
+          datamachine/run-flow, datamachine/drain-job).
+        type: string
+        default: "[]"
     secrets:
       HOMEBOY_APP_ID:
         required: true
@@ -228,6 +264,11 @@ jobs:
           STEP_BUDGET: ${{ inputs.step_budget }}
           TIME_BUDGET_MS: ${{ inputs.time_budget_ms }}
           DRY_RUN: ${{ inputs.dry_run }}
+          EXTRA_WP_CONFIG_DEFINES: ${{ inputs.extra_wp_config_defines }}
+          EXTRA_PLAYGROUND_FILE_MOUNTS: ${{ inputs.extra_playground_file_mounts }}
+          WORKLOAD_RUN_BEFORE: ${{ inputs.workload_run_before }}
+          DAILY_MEMORY_ENABLED: ${{ inputs.daily_memory_enabled }}
+          EXTRA_REQUIRED_ABILITIES: ${{ inputs.extra_required_abilities }}
           GITHUB_TOKEN_VALUE: ${{ steps.app-token.outputs.token || github.token }}
           OPENAI_API_KEY_VALUE: ${{ secrets.OPENAI_API_KEY }}
         run: |
@@ -236,6 +277,19 @@ jobs:
           bundle_abs="${GITHUB_WORKSPACE}/${BUNDLE_PATH}"
           mapfile -t validation_paths < <(find "${GITHUB_WORKSPACE}/.ci" -mindepth 1 -maxdepth 1 -type d | sort)
           validation_json="$(printf '%s\n' "${validation_paths[@]}" | jq -Rsc 'split("\n") | map(select(. != ""))')"
+          validate_json_input() {
+            local name="$1"
+            local expected_type="$2"
+            local value="$3"
+            if ! jq -ce --arg expected_type "$expected_type" 'if type == $expected_type then . else error("expected " + $expected_type + ", got " + type) end' <<< "$value"; then
+              echo "Invalid $name: expected JSON $expected_type." >&2
+              return 1
+            fi
+          }
+          extra_wp_config_defines_json="$(validate_json_input extra_wp_config_defines object "$EXTRA_WP_CONFIG_DEFINES")"
+          extra_playground_file_mounts_json="$(validate_json_input extra_playground_file_mounts array "$EXTRA_PLAYGROUND_FILE_MOUNTS")"
+          workload_run_before_json="$(validate_json_input workload_run_before array "$WORKLOAD_RUN_BEFORE")"
+          extra_required_abilities_json="$(validate_json_input extra_required_abilities array "$EXTRA_REQUIRED_ABILITIES")"
           jq -n \
             --arg componentPath "$GITHUB_WORKSPACE" \
             --arg bundlePath "$bundle_abs" \
@@ -255,6 +309,11 @@ jobs:
             --argjson stepBudget "$STEP_BUDGET" \
             --argjson timeBudgetMs "$TIME_BUDGET_MS" \
             --argjson dryRun "$DRY_RUN" \
+            --argjson extraWpConfigDefines "$extra_wp_config_defines_json" \
+            --argjson extraPlaygroundFileMounts "$extra_playground_file_mounts_json" \
+            --argjson workloadRunBefore "$workload_run_before_json" \
+            --argjson dailyMemoryEnabled "$DAILY_MEMORY_ENABLED" \
+            --argjson extraRequiredAbilities "$extra_required_abilities_json" \
             '{
               component_id: "datamachine-agent-ci-driver",
               component_path: $componentPath,
@@ -268,7 +327,10 @@ jobs:
                   from: "wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php",
                   to: "/wordpress/wp-content/plugins/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php"
                 }
-              ],
+              ] + $extraPlaygroundFileMounts,
+              wp_config_defines: $extraWpConfigDefines,
+              workload_run_before: $workloadRunBefore,
+              required_abilities: (["datamachine/import-agent", "datamachine/run-flow", "datamachine/drain-job"] + $extraRequiredAbilities | reduce .[] as $ability ([]; if index($ability) then . else . + [$ability] end)),
               bundle_path: $bundlePath,
               agent_slug: $agentSlug,
               pipeline_slug: $pipelineSlug,
@@ -292,7 +354,7 @@ jobs:
                 GITHUB_TOKEN: $githubToken,
                 OPENAI_API_KEY: $openaiKey
               }
-            }' > "$config_path"
+            } + (if $dailyMemoryEnabled then {daily_memory_enabled: true} else {} end)' > "$config_path"
           printf 'config_path=%s\n' "$config_path" >> "$GITHUB_OUTPUT"
 
       - name: Run Data Machine agent

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -321,13 +321,13 @@ jobs:
               workload_label: ("Run " + $agentSlug + " Data Machine agent"),
               validation_dependencies: $validationDependencies,
               playground_wordpress_version: $playgroundWordPress,
-              playground_file_mounts: [
+              playground_file_mounts: ([
                 {
                   from_dependency: "homeboy-extensions",
                   from: "wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php",
                   to: "/wordpress/wp-content/plugins/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php"
                 }
-              ] + $extraPlaygroundFileMounts,
+              ] + $extraPlaygroundFileMounts),
               wp_config_defines: $extraWpConfigDefines,
               workload_run_before: $workloadRunBefore,
               required_abilities: (["datamachine/import-agent", "datamachine/run-flow", "datamachine/drain-job"] + $extraRequiredAbilities | reduce .[] as $ability ([]; if index($ability) then . else . + [$ability] end)),


### PR DESCRIPTION
## Summary
- Adds `extra_wp_config_defines` as a JSON-object input merged into runner config `wp_config_defines`.
- Adds `extra_playground_file_mounts` as a JSON-array input appended after the default CI driver mount.
- Adds `workload_run_before` as a JSON-array input passed through for pre-run Playground hooks.
- Adds `daily_memory_enabled` as a boolean input that writes `daily_memory_enabled: true` only when enabled.
- Adds `extra_required_abilities` as a JSON-array input merged with the built-in required abilities using order-preserving dedupe.

Closes #503

## Motivation
- Unblocks migrating the World Creator workflow from its hand-rolled runner shape to this reusable workflow: https://github.com/chubes4/world-of-wordpress/blob/main/.github/workflows/world-creator.yml
- Existing consumers are unaffected because every new input defaults to a zero-effect value and no existing input changed semantics.

## Composes
- `wordpress/scripts/agent/run-datamachine-agent.sh`
- `wordpress/scripts/agent/extract-engine-data.sh`
- `wordpress/scripts/agent/validate-bundle.php`
- `wordpress/tests/fixtures/datamachine-agent-ci-driver/`
- Reusable workflow foundation from #500: https://github.com/Extra-Chill/homeboy-extensions/pull/500

## Backward compatibility
- No existing workflow inputs were renamed or changed.
- `extra_wp_config_defines` defaults to `{}`.
- `extra_playground_file_mounts`, `workload_run_before`, and `extra_required_abilities` default to `[]`.
- `daily_memory_enabled` defaults to `false` and is omitted from runner config unless enabled.

## Out of scope
- No consumer workflow migrations.
- No runtime behavior changes in `run-datamachine-agent.sh`.
- No changes to `datamachine-agent-workload.php`.
- No schema enforcement on JSON-string inputs beyond JSON parse and top-level object/array type checks.

## Validation
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/datamachine-agent-ci.yml"))'` passed.
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/datamachine-agent-ci-self-smoke.yml"))'` passed.
- `actionlint` was not available locally.
- `homeboy lint --path wordpress --extension wordpress` passed.
- `homeboy test --path wordpress --extension wordpress` failed in the pre-existing Playground test-runner template self-check noted in #500; expected `tests_add_filter('plugins_loaded'` while the current template contains `tests_add_filter('muplugins_loaded'`.
- Workflow dispatch self-smoke passed on `reusable-extra-inputs`: https://github.com/Extra-Chill/homeboy-extensions/actions/runs/25634460164

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the five new pass-through inputs, plumbed them through to the runner config JSON, and extended the README with a worked WoW migration example. Chris reviewed the input names, defaults, and merge semantics.