### PR TITLE
Make Data Machine agent artifact export configurable

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -80,9 +80,9 @@ name: Data Machine Agent CI (reusable)
         default: false
     secrets:
       HOMEBOY_APP_ID:
-        required: true
+        required: false
       HOMEBOY_APP_PRIVATE_KEY:
-        required: true
+        required: false
       OPENAI_API_KEY:
         required: true
     outputs:
@@ -112,9 +112,22 @@ jobs:
       - name: Checkout consumer repo
         uses: actions/checkout@v4
 
+      - name: Detect Homeboy app credentials
+        id: homeboy-app-creds
+        env:
+          HOMEBOY_APP_ID: ${{ secrets.HOMEBOY_APP_ID }}
+          HOMEBOY_APP_PRIVATE_KEY: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "$HOMEBOY_APP_ID" ] && [ -n "$HOMEBOY_APP_PRIVATE_KEY" ]; then
+            printf 'available=true\n' >> "$GITHUB_OUTPUT"
+          else
+            printf 'available=false\n' >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Resolve Homeboy app token scope
         id: token-scope
-        if: ${{ ! inputs.dry_run }}
+        if: ${{ ! inputs.dry_run && steps.homeboy-app-creds.outputs.available == 'true' }}
         env:
           APP_TOKEN_REPOS: ${{ inputs.app_token_repos }}
           TARGET_REPO: ${{ inputs.target_repo }}
@@ -149,7 +162,7 @@ jobs:
 
       - name: Generate Homeboy app token
         id: app-token
-        if: ${{ ! inputs.dry_run }}
+        if: ${{ ! inputs.dry_run && steps.homeboy-app-creds.outputs.available == 'true' }}
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -59,6 +59,10 @@ name: Data Machine Agent CI (reusable)
         description: Empty string disables transcript artifact upload.
         type: string
         default: ""
+      artifact_export_config:
+        description: JSON config for exporting job artifacts back to the target repo. Empty object uses the reusable workflow defaults.
+        type: string
+        default: "{}"
       comment_pr_summary:
         type: boolean
         default: false
@@ -227,6 +231,7 @@ jobs:
           MAX_TURNS: ${{ inputs.max_turns }}
           STEP_BUDGET: ${{ inputs.step_budget }}
           TIME_BUDGET_MS: ${{ inputs.time_budget_ms }}
+          ARTIFACT_EXPORT_CONFIG: ${{ inputs.artifact_export_config }}
           DRY_RUN: ${{ inputs.dry_run }}
           GITHUB_TOKEN_VALUE: ${{ steps.app-token.outputs.token || github.token }}
           OPENAI_API_KEY_VALUE: ${{ secrets.OPENAI_API_KEY }}
@@ -239,6 +244,7 @@ jobs:
           jq -n \
             --arg componentPath "$GITHUB_WORKSPACE" \
             --arg bundlePath "$bundle_abs" \
+            --arg bundlePathInRepo "$BUNDLE_PATH" \
             --arg agentSlug "$AGENT_SLUG" \
             --arg pipelineSlug "$PIPELINE_SLUG" \
             --arg flowSlug "$FLOW_SLUG" \
@@ -250,6 +256,7 @@ jobs:
             --arg githubToken "$GITHUB_TOKEN_VALUE" \
             --arg openaiKey "$OPENAI_API_KEY_VALUE" \
             --argjson validationDependencies "$validation_json" \
+            --argjson artifactExportConfig "$ARTIFACT_EXPORT_CONFIG" \
             --argjson successRequiresPr "$SUCCESS_REQUIRES_PR" \
             --argjson maxTurns "$MAX_TURNS" \
             --argjson stepBudget "$STEP_BUDGET" \
@@ -270,7 +277,7 @@ jobs:
                 }
               ],
               bundle_path: $bundlePath,
-              bundle_path_in_repo: $bundlePath,
+              bundle_path_in_repo: $bundlePathInRepo,
               agent_slug: $agentSlug,
               pipeline_slug: $pipelineSlug,
               flow_slug: $flowSlug,
@@ -287,6 +294,16 @@ jobs:
               step_budget: $stepBudget,
               time_budget_ms: $timeBudgetMs,
               success_requires_pr: $successRequiresPr,
+              artifact_export: ({
+                enabled: true,
+                only_when_no_pr: true,
+                repo: $targetRepo,
+                path_prefix: $bundlePathInRepo,
+                branch_template: "agent-artifacts/{agent_slug}-{run_id}-{job_id}",
+                commit_message_template: "chore: persist {type} artifact",
+                pr_title_template: "Persist agent run artifacts",
+                pr_body_template: "## Summary\n- Persist bundle-file run artifacts from Data Machine agent job {job_id}.\n\n## Artifacts\n{paths}\n"
+              } * $artifactExportConfig),
               dry_run: $dryRun,
               transcript_dir: ("/wordpress/wp-content/plugins/datamachine-agent-ci-driver/artifacts/" + $agentSlug),
               bench_env: {

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -270,6 +270,7 @@ jobs:
                 }
               ],
               bundle_path: $bundlePath,
+              bundle_path_in_repo: $bundlePath,
               agent_slug: $agentSlug,
               pipeline_slug: $pipelineSlug,
               flow_slug: $flowSlug,

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -157,6 +157,17 @@ if ( ! function_exists( 'homeboy_datamachine_agent_bundle_path_in_repo' ) ) {
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_template' ) ) {
+    function homeboy_datamachine_agent_template( string $template, array $values ): string {
+        $replacements = array();
+        foreach ( $values as $key => $value ) {
+            $replacements[ '{' . $key . '}' ] = (string) $value;
+        }
+
+        return strtr( $template, $replacements );
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_slug_fragment' ) ) {
     function homeboy_datamachine_agent_slug_fragment( string $value ): string {
         $fragment = strtolower( preg_replace( '/[^a-zA-Z0-9._-]+/', '-', $value ) ?? '' );
@@ -165,9 +176,9 @@ if ( ! function_exists( 'homeboy_datamachine_agent_slug_fragment' ) ) {
     }
 }
 
-if ( ! function_exists( 'homeboy_datamachine_agent_bundle_artifacts' ) ) {
-    function homeboy_datamachine_agent_bundle_artifacts( array $artifacts ): array {
-        $bundle_artifacts = array();
+if ( ! function_exists( 'homeboy_datamachine_agent_exportable_artifacts' ) ) {
+    function homeboy_datamachine_agent_exportable_artifacts( array $artifacts ): array {
+        $exportable_artifacts = array();
 
         foreach ( $artifacts as $artifact_group ) {
             if ( ! is_array( $artifact_group ) ) {
@@ -185,7 +196,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_bundle_artifacts' ) ) {
                     continue;
                 }
 
-                $bundle_artifacts[] = array(
+                $exportable_artifacts[] = array(
                     'type'          => (string) ( $artifact['type'] ?? 'artifact' ),
                     'relative_path' => $relative_path,
                     'content'       => $content,
@@ -193,26 +204,31 @@ if ( ! function_exists( 'homeboy_datamachine_agent_bundle_artifacts' ) ) {
             }
         }
 
-        return $bundle_artifacts;
+        return $exportable_artifacts;
     }
 }
 
-if ( ! function_exists( 'homeboy_datamachine_agent_export_bundle_artifacts' ) ) {
-    function homeboy_datamachine_agent_export_bundle_artifacts( int $job_id, array $config, bool $pr_opened ): array {
-        if ( $job_id <= 0 || $pr_opened || ! class_exists( JobArtifacts::class ) || ! function_exists( 'wp_get_ability' ) ) {
+if ( ! function_exists( 'homeboy_datamachine_agent_export_job_artifacts' ) ) {
+    function homeboy_datamachine_agent_export_job_artifacts( int $job_id, array $config, bool $pr_opened ): array {
+        $export_config = is_array( $config['artifact_export'] ?? null ) ? $config['artifact_export'] : array();
+        if ( $job_id <= 0 || empty( $export_config['enabled'] ) || ! class_exists( JobArtifacts::class ) || ! function_exists( 'wp_get_ability' ) ) {
             return array();
         }
 
-        $target_repo = homeboy_datamachine_agent_scalar( $config, 'target_repo' );
-        $bundle_path = homeboy_datamachine_agent_bundle_path_in_repo( $config );
-        if ( '' === $target_repo || '' === $bundle_path ) {
+        if ( $pr_opened && ! empty( $export_config['only_when_no_pr'] ) ) {
             return array();
+        }
+
+        $target_repo = trim( (string) ( $export_config['repo'] ?? '' ) );
+        $path_prefix = trim( (string) ( $export_config['path_prefix'] ?? '' ), '/' );
+        if ( '' === $target_repo || '' === $path_prefix || str_contains( $path_prefix, '..' ) ) {
+            return array( 'error' => 'Artifact export requires artifact_export.repo and artifact_export.path_prefix.' );
         }
 
         $artifact_result = ( new JobArtifacts() )->get( $job_id );
         $artifacts       = is_array( $artifact_result['artifacts'] ?? null ) ? $artifact_result['artifacts'] : array();
-        $bundle_artifacts = homeboy_datamachine_agent_bundle_artifacts( $artifacts );
-        if ( empty( $bundle_artifacts ) ) {
+        $exportable_artifacts = homeboy_datamachine_agent_exportable_artifacts( $artifacts );
+        if ( empty( $exportable_artifacts ) ) {
             return array();
         }
 
@@ -222,19 +238,41 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_bundle_artifacts' ) ) 
             return array( 'error' => 'GitHub file or pull request ability unavailable.' );
         }
 
-        $agent_slug = homeboy_datamachine_agent_slug_fragment( homeboy_datamachine_agent_scalar( $config, 'agent_slug', 'agent' ) );
-        $run_id     = homeboy_datamachine_agent_slug_fragment( (string) getenv( 'GITHUB_RUN_ID' ) );
-        $branch     = 'agent-artifacts/' . $agent_slug . '-' . $run_id . '-' . $job_id;
-        $written    = array();
+        $agent_slug      = homeboy_datamachine_agent_slug_fragment( homeboy_datamachine_agent_scalar( $config, 'agent_slug', 'agent' ) );
+        $run_id          = homeboy_datamachine_agent_slug_fragment( (string) getenv( 'GITHUB_RUN_ID' ) );
+        $template_values = array(
+            'agent_slug' => $agent_slug,
+            'run_id'     => $run_id,
+            'job_id'     => $job_id,
+        );
+        $branch_template = (string) ( $export_config['branch_template'] ?? '' );
+        $branch          = homeboy_datamachine_agent_template( $branch_template, $template_values );
+        if ( '' === $branch ) {
+            return array( 'error' => 'Artifact export requires artifact_export.branch_template.' );
+        }
 
-        foreach ( $bundle_artifacts as $artifact ) {
-            $repo_path = $bundle_path . '/' . $artifact['relative_path'];
-            $result    = $file_ability->execute(
+        $written = array();
+
+        foreach ( $exportable_artifacts as $artifact ) {
+            $repo_path        = $path_prefix . '/' . $artifact['relative_path'];
+            $artifact_values  = array_merge(
+                $template_values,
+                array(
+                    'type' => $artifact['type'],
+                    'path' => $repo_path,
+                )
+            );
+            $commit_message   = homeboy_datamachine_agent_template( (string) ( $export_config['commit_message_template'] ?? '' ), $artifact_values );
+            if ( '' === $commit_message ) {
+                return array( 'error' => 'Artifact export requires artifact_export.commit_message_template.' );
+            }
+
+            $result = $file_ability->execute(
                 array(
                     'repo'           => $target_repo,
                     'file_path'      => $repo_path,
                     'content'        => $artifact['content'],
-                    'commit_message' => 'chore: persist ' . $artifact['type'] . ' artifact',
+                    'commit_message' => $commit_message,
                     'branch'         => $branch,
                 )
             );
@@ -252,12 +290,24 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_bundle_artifacts' ) ) 
             return array();
         }
 
+        $pr_title_template = (string) ( $export_config['pr_title_template'] ?? '' );
+        $pr_body_template  = (string) ( $export_config['pr_body_template'] ?? '' );
+        if ( '' === $pr_title_template || '' === $pr_body_template ) {
+            return array( 'error' => 'Artifact export requires artifact_export.pr_title_template and artifact_export.pr_body_template.' );
+        }
+
+        $pr_values        = array_merge(
+            $template_values,
+            array(
+                'paths' => '- `' . implode( "`\n- `", $written ) . '`',
+            )
+        );
         $pr_result = $pr_ability->execute(
             array(
                 'repo'  => $target_repo,
-                'title' => 'Persist agent run artifacts',
+                'title' => homeboy_datamachine_agent_template( $pr_title_template, $template_values ),
                 'head'  => $branch,
-                'body'  => "## Summary\n- Persist bundle-file run artifacts from Data Machine agent job {$job_id}.\n\n## Artifacts\n- `" . implode( "`\n- `", $written ) . "`\n",
+                'body'  => homeboy_datamachine_agent_template( $pr_body_template, $pr_values ),
             )
         );
         if ( function_exists( 'is_wp_error' ) && is_wp_error( $pr_result ) ) {
@@ -945,7 +995,7 @@ $pr_opened = homeboy_datamachine_agent_pr_opened( $engine_data, $config );
 $file_written = homeboy_datamachine_agent_file_written( $engine_data, $config );
 $success_status = $pr_opened ? 'pr_opened' : 'no_changes';
 $success_requires_pr = ! empty( $config['success_requires_pr'] );
-$bundle_artifact_exports = homeboy_datamachine_agent_export_bundle_artifacts( $job_id, $config, $pr_opened );
+$job_artifact_exports = homeboy_datamachine_agent_export_job_artifacts( $job_id, $config, $pr_opened );
 
 $metadata += array(
     'agent_id'             => $agent_id,
@@ -961,7 +1011,7 @@ $metadata += array(
     'success_status'        => $success_status,
     'success_requires_pr'   => $success_requires_pr,
     'file_written'          => $file_written,
-    'bundle_artifact_exports' => $bundle_artifact_exports,
+    'job_artifact_exports'    => $job_artifact_exports,
 );
 
 if ( $file_written && ! $pr_opened ) {
@@ -969,8 +1019,8 @@ if ( $file_written && ! $pr_opened ) {
     return homeboy_datamachine_agent_result( array( 'file_written' => 1, 'pr_opened' => 0 ), $metadata, 'Agent wrote files without opening a pull request' );
 }
 
-if ( ! empty( $bundle_artifact_exports['error'] ) ) {
-    return homeboy_datamachine_agent_result( array( 'bundle_artifact_exported' => 0 ), $metadata, (string) $bundle_artifact_exports['error'] );
+if ( ! empty( $job_artifact_exports['error'] ) ) {
+    return homeboy_datamachine_agent_result( array( 'job_artifact_exported' => 0 ), $metadata, (string) $job_artifact_exports['error'] );
 }
 
 if ( $success_requires_pr && ! $pr_opened ) {
@@ -996,7 +1046,7 @@ return homeboy_datamachine_agent_result(
         'file_written'                => $file_written ? 1 : 0,
         'pr_opened'                   => $pr_opened ? 1 : 0,
         'no_changes'                  => ! $file_written && ! $pr_opened ? 1 : 0,
-        'bundle_artifact_exported'    => ! empty( $bundle_artifact_exports['pr_url'] ) ? 1 : 0,
+        'job_artifact_exported'       => ! empty( $job_artifact_exports['pr_url'] ) ? 1 : 0,
         'transcript_exported'         => ! empty( $transcript_artifacts['json'] ) ? 1 : 0,
         'total_tokens'                => (int) ( $metadata['token_usage']['total_tokens'] ?? 0 ),
     ),

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -10,6 +10,7 @@ use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\JobArtifacts;
 use DataMachine\Core\PluginSettings;
 
 if ( ! function_exists( 'homeboy_datamachine_agent_result' ) ) {
@@ -136,6 +137,123 @@ if ( ! function_exists( 'homeboy_datamachine_agent_file_written' ) ) {
         }
 
         return false;
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_bundle_path_in_repo' ) ) {
+    function homeboy_datamachine_agent_bundle_path_in_repo( array $config ): string {
+        $configured = trim( (string) ( $config['bundle_path_in_repo'] ?? '' ), '/' );
+        if ( '' !== $configured ) {
+            return $configured;
+        }
+
+        $component_path = rtrim( homeboy_datamachine_agent_scalar( $config, 'component_path' ), '/' ) . '/';
+        $bundle_path    = homeboy_datamachine_agent_scalar( $config, 'bundle_path' );
+        if ( '' !== $component_path && '' !== $bundle_path && str_starts_with( $bundle_path, $component_path ) ) {
+            return trim( substr( $bundle_path, strlen( $component_path ) ), '/' );
+        }
+
+        return '';
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_slug_fragment' ) ) {
+    function homeboy_datamachine_agent_slug_fragment( string $value ): string {
+        $fragment = strtolower( preg_replace( '/[^a-zA-Z0-9._-]+/', '-', $value ) ?? '' );
+        $fragment = trim( $fragment, '.-' );
+        return '' !== $fragment ? $fragment : 'artifact';
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_export_bundle_artifacts' ) ) {
+    function homeboy_datamachine_agent_export_bundle_artifacts( int $job_id, array $config, bool $pr_opened ): array {
+        if ( $job_id <= 0 || $pr_opened || ! class_exists( JobArtifacts::class ) || ! function_exists( 'wp_get_ability' ) ) {
+            return array();
+        }
+
+        $target_repo = homeboy_datamachine_agent_scalar( $config, 'target_repo' );
+        $bundle_path = homeboy_datamachine_agent_bundle_path_in_repo( $config );
+        if ( '' === $target_repo || '' === $bundle_path ) {
+            return array();
+        }
+
+        $artifact_result = ( new JobArtifacts() )->get( $job_id );
+        $artifacts       = is_array( $artifact_result['artifacts'] ?? null ) ? $artifact_result['artifacts'] : array();
+        $daily_memory    = is_array( $artifacts['daily_memory_artifacts'] ?? null ) ? $artifacts['daily_memory_artifacts'] : array();
+        if ( empty( $daily_memory ) ) {
+            return array();
+        }
+
+        $file_ability = wp_get_ability( 'datamachine/create-or-update-github-file' );
+        $pr_ability   = wp_get_ability( 'datamachine/create-github-pull-request' );
+        if ( ! $file_ability || ! $pr_ability ) {
+            return array( 'error' => 'GitHub file or pull request ability unavailable.' );
+        }
+
+        $agent_slug = homeboy_datamachine_agent_slug_fragment( homeboy_datamachine_agent_scalar( $config, 'agent_slug', 'agent' ) );
+        $run_id     = homeboy_datamachine_agent_slug_fragment( (string) getenv( 'GITHUB_RUN_ID' ) );
+        $branch     = 'agent-artifacts/' . $agent_slug . '-' . $run_id . '-' . $job_id;
+        $written    = array();
+
+        foreach ( $daily_memory as $artifact ) {
+            if ( ! is_array( $artifact ) || 'agent_daily_memory' !== (string) ( $artifact['type'] ?? '' ) ) {
+                continue;
+            }
+
+            $relative_path = trim( (string) ( $artifact['bundle_relative_path'] ?? '' ), '/' );
+            $content       = (string) ( $artifact['content'] ?? '' );
+            if ( '' === $relative_path || '' === $content || str_contains( $relative_path, '..' ) ) {
+                continue;
+            }
+
+            $repo_path = $bundle_path . '/' . $relative_path;
+            $result    = $file_ability->execute(
+                array(
+                    'repo'           => $target_repo,
+                    'file_path'      => $repo_path,
+                    'content'        => $content,
+                    'commit_message' => 'chore: persist agent run artifact',
+                    'branch'         => $branch,
+                )
+            );
+            if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
+                return array( 'error' => $result->get_error_message(), 'written' => $written );
+            }
+            if ( ! is_array( $result ) || empty( $result['success'] ) ) {
+                return array( 'error' => (string) ( $result['error'] ?? 'Artifact file export failed.' ), 'written' => $written );
+            }
+
+            $written[] = $repo_path;
+        }
+
+        if ( empty( $written ) ) {
+            return array();
+        }
+
+        $pr_result = $pr_ability->execute(
+            array(
+                'repo'  => $target_repo,
+                'title' => 'Persist agent run artifacts',
+                'head'  => $branch,
+                'body'  => "## Summary\n- Persist bundle-file run artifacts from Data Machine agent job {$job_id}.\n\n## Artifacts\n- `" . implode( "`\n- `", $written ) . "`\n",
+            )
+        );
+        if ( function_exists( 'is_wp_error' ) && is_wp_error( $pr_result ) ) {
+            return array( 'error' => $pr_result->get_error_message(), 'written' => $written, 'branch' => $branch );
+        }
+
+        $pr_url = '';
+        if ( is_array( $pr_result ) ) {
+            $pr_url = homeboy_datamachine_agent_first_url( $pr_result );
+        }
+
+        return array_filter(
+            array(
+                'branch' => $branch,
+                'paths'  => $written,
+                'pr_url' => $pr_url,
+            )
+        );
     }
 }
 
@@ -805,6 +923,7 @@ $pr_opened = homeboy_datamachine_agent_pr_opened( $engine_data, $config );
 $file_written = homeboy_datamachine_agent_file_written( $engine_data, $config );
 $success_status = $pr_opened ? 'pr_opened' : 'no_changes';
 $success_requires_pr = ! empty( $config['success_requires_pr'] );
+$bundle_artifact_exports = homeboy_datamachine_agent_export_bundle_artifacts( $job_id, $config, $pr_opened );
 
 $metadata += array(
     'agent_id'             => $agent_id,
@@ -820,11 +939,16 @@ $metadata += array(
     'success_status'        => $success_status,
     'success_requires_pr'   => $success_requires_pr,
     'file_written'          => $file_written,
+    'bundle_artifact_exports' => $bundle_artifact_exports,
 );
 
 if ( $file_written && ! $pr_opened ) {
     $metadata['success_status'] = 'write_without_pr';
     return homeboy_datamachine_agent_result( array( 'file_written' => 1, 'pr_opened' => 0 ), $metadata, 'Agent wrote files without opening a pull request' );
+}
+
+if ( ! empty( $bundle_artifact_exports['error'] ) ) {
+    return homeboy_datamachine_agent_result( array( 'bundle_artifact_exported' => 0 ), $metadata, (string) $bundle_artifact_exports['error'] );
 }
 
 if ( $success_requires_pr && ! $pr_opened ) {
@@ -850,6 +974,7 @@ return homeboy_datamachine_agent_result(
         'file_written'                => $file_written ? 1 : 0,
         'pr_opened'                   => $pr_opened ? 1 : 0,
         'no_changes'                  => ! $file_written && ! $pr_opened ? 1 : 0,
+        'bundle_artifact_exported'    => ! empty( $bundle_artifact_exports['pr_url'] ) ? 1 : 0,
         'transcript_exported'         => ! empty( $transcript_artifacts['json'] ) ? 1 : 0,
         'total_tokens'                => (int) ( $metadata['token_usage']['total_tokens'] ?? 0 ),
     ),

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -165,6 +165,38 @@ if ( ! function_exists( 'homeboy_datamachine_agent_slug_fragment' ) ) {
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_bundle_artifacts' ) ) {
+    function homeboy_datamachine_agent_bundle_artifacts( array $artifacts ): array {
+        $bundle_artifacts = array();
+
+        foreach ( $artifacts as $artifact_group ) {
+            if ( ! is_array( $artifact_group ) ) {
+                continue;
+            }
+
+            foreach ( $artifact_group as $artifact ) {
+                if ( ! is_array( $artifact ) ) {
+                    continue;
+                }
+
+                $relative_path = trim( (string) ( $artifact['bundle_relative_path'] ?? '' ), '/' );
+                $content       = (string) ( $artifact['content'] ?? '' );
+                if ( '' === $relative_path || '' === $content || str_contains( $relative_path, '..' ) ) {
+                    continue;
+                }
+
+                $bundle_artifacts[] = array(
+                    'type'          => (string) ( $artifact['type'] ?? 'artifact' ),
+                    'relative_path' => $relative_path,
+                    'content'       => $content,
+                );
+            }
+        }
+
+        return $bundle_artifacts;
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_export_bundle_artifacts' ) ) {
     function homeboy_datamachine_agent_export_bundle_artifacts( int $job_id, array $config, bool $pr_opened ): array {
         if ( $job_id <= 0 || $pr_opened || ! class_exists( JobArtifacts::class ) || ! function_exists( 'wp_get_ability' ) ) {
@@ -179,8 +211,8 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_bundle_artifacts' ) ) 
 
         $artifact_result = ( new JobArtifacts() )->get( $job_id );
         $artifacts       = is_array( $artifact_result['artifacts'] ?? null ) ? $artifact_result['artifacts'] : array();
-        $daily_memory    = is_array( $artifacts['daily_memory_artifacts'] ?? null ) ? $artifacts['daily_memory_artifacts'] : array();
-        if ( empty( $daily_memory ) ) {
+        $bundle_artifacts = homeboy_datamachine_agent_bundle_artifacts( $artifacts );
+        if ( empty( $bundle_artifacts ) ) {
             return array();
         }
 
@@ -195,24 +227,14 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_bundle_artifacts' ) ) 
         $branch     = 'agent-artifacts/' . $agent_slug . '-' . $run_id . '-' . $job_id;
         $written    = array();
 
-        foreach ( $daily_memory as $artifact ) {
-            if ( ! is_array( $artifact ) || 'agent_daily_memory' !== (string) ( $artifact['type'] ?? '' ) ) {
-                continue;
-            }
-
-            $relative_path = trim( (string) ( $artifact['bundle_relative_path'] ?? '' ), '/' );
-            $content       = (string) ( $artifact['content'] ?? '' );
-            if ( '' === $relative_path || '' === $content || str_contains( $relative_path, '..' ) ) {
-                continue;
-            }
-
-            $repo_path = $bundle_path . '/' . $relative_path;
+        foreach ( $bundle_artifacts as $artifact ) {
+            $repo_path = $bundle_path . '/' . $artifact['relative_path'];
             $result    = $file_ability->execute(
                 array(
                     'repo'           => $target_repo,
                     'file_path'      => $repo_path,
-                    'content'        => $content,
-                    'commit_message' => 'chore: persist agent run artifact',
+                    'content'        => $artifact['content'],
+                    'commit_message' => 'chore: persist ' . $artifact['type'] . ' artifact',
                     'branch'         => $branch,
                 )
             );


### PR DESCRIPTION
## Summary
- Make Data Machine agent artifact export opt-in via `artifact_export` config instead of hardcoding memory-specific behavior in Homeboy.
- Export any job artifact that exposes `bundle_relative_path` and `content`, with repo/path/branch/commit/PR text controlled by config templates.
- Add a reusable workflow `artifact_export_config` override while keeping the default wrapper behavior centralized in workflow config.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\")'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the configurable artifact export follow-up after review feedback; Chris remains responsible for review and merge.