### PR TITLE
Allow agent completion outcomes to satisfy CI

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -42,6 +42,13 @@ name: Data Machine Agent CI (reusable)
       success_requires_pr:
         type: boolean
         default: true
+      success_completion_outcomes:
+        description: |
+          JSON array of Data Machine completion outcome names that may satisfy
+          success_requires_pr when no PR is opened. File writes without PRs
+          still fail. Default '[]' preserves PR-required behavior.
+        type: string
+        default: "[]"
       max_turns:
         type: number
         default: 12
@@ -277,6 +284,7 @@ jobs:
           MODEL: ${{ inputs.model }}
           PLAYGROUND_WORDPRESS: ${{ inputs.playground_wordpress }}
           SUCCESS_REQUIRES_PR: ${{ inputs.success_requires_pr }}
+          SUCCESS_COMPLETION_OUTCOMES: ${{ inputs.success_completion_outcomes }}
           MAX_TURNS: ${{ inputs.max_turns }}
           STEP_BUDGET: ${{ inputs.step_budget }}
           TIME_BUDGET_MS: ${{ inputs.time_budget_ms }}
@@ -308,6 +316,7 @@ jobs:
           extra_playground_file_mounts_json="$(validate_json_input extra_playground_file_mounts array "$EXTRA_PLAYGROUND_FILE_MOUNTS")"
           workload_run_before_json="$(validate_json_input workload_run_before array "$WORKLOAD_RUN_BEFORE")"
           extra_required_abilities_json="$(validate_json_input extra_required_abilities array "$EXTRA_REQUIRED_ABILITIES")"
+          success_completion_outcomes_json="$(validate_json_input success_completion_outcomes array "$SUCCESS_COMPLETION_OUTCOMES")"
           jq -n \
             --arg componentPath "$GITHUB_WORKSPACE" \
             --arg bundlePath "$bundle_abs" \
@@ -325,6 +334,7 @@ jobs:
             --argjson validationDependencies "$validation_json" \
             --argjson artifactExportConfig "$ARTIFACT_EXPORT_CONFIG" \
             --argjson successRequiresPr "$SUCCESS_REQUIRES_PR" \
+            --argjson successCompletionOutcomes "$success_completion_outcomes_json" \
             --argjson maxTurns "$MAX_TURNS" \
             --argjson stepBudget "$STEP_BUDGET" \
             --argjson timeBudgetMs "$TIME_BUDGET_MS" \
@@ -369,6 +379,7 @@ jobs:
               step_budget: $stepBudget,
               time_budget_ms: $timeBudgetMs,
               success_requires_pr: $successRequiresPr,
+              success_completion_outcomes: $successCompletionOutcomes,
               artifact_export: ({
                 enabled: true,
                 only_when_no_pr: true,

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -140,6 +140,44 @@ if ( ! function_exists( 'homeboy_datamachine_agent_file_written' ) ) {
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_completion_outcome_satisfied' ) ) {
+    function homeboy_datamachine_agent_completion_outcome_satisfied( array $engine_data, array $config ): bool {
+        $allowed_outcomes = is_array( $config['success_completion_outcomes'] ?? null ) ? $config['success_completion_outcomes'] : array();
+        $allowed_outcomes = array_values(
+            array_filter(
+                array_map(
+                    static fn( $outcome ) => is_scalar( $outcome ) ? trim( (string) $outcome ) : '',
+                    $allowed_outcomes
+                ),
+                static fn( string $outcome ) => '' !== $outcome
+            )
+        );
+
+        if ( empty( $allowed_outcomes ) ) {
+            return false;
+        }
+
+        $sources = $engine_data;
+        $engine_key = homeboy_datamachine_agent_scalar( $config, 'engine_key' );
+        if ( '' !== $engine_key && is_array( $engine_data[ $engine_key ] ?? null ) ) {
+            $sources = $engine_data[ $engine_key ];
+        }
+
+        $completed_outcomes = homeboy_datamachine_agent_path_value( $sources, 'completion_assertions_satisfied.complete_when_any' );
+        if ( ! is_array( $completed_outcomes ) ) {
+            return false;
+        }
+
+        foreach ( $completed_outcomes as $outcome ) {
+            if ( is_scalar( $outcome ) && in_array( trim( (string) $outcome ), $allowed_outcomes, true ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_bundle_path_in_repo' ) ) {
     function homeboy_datamachine_agent_bundle_path_in_repo( array $config ): string {
         $configured = trim( (string) ( $config['bundle_path_in_repo'] ?? '' ), '/' );
@@ -993,7 +1031,8 @@ $transcript_dir = homeboy_datamachine_agent_scalar( $config, 'transcript_dir' );
 $transcript_artifacts = homeboy_datamachine_agent_export_transcript( $job_id, $engine_data, $transcript_dir );
 $pr_opened = homeboy_datamachine_agent_pr_opened( $engine_data, $config );
 $file_written = homeboy_datamachine_agent_file_written( $engine_data, $config );
-$success_status = $pr_opened ? 'pr_opened' : 'no_changes';
+$completion_outcome_satisfied = homeboy_datamachine_agent_completion_outcome_satisfied( $engine_data, $config );
+$success_status = $pr_opened ? 'pr_opened' : ( $completion_outcome_satisfied ? 'completion_outcome_satisfied' : 'no_changes' );
 $success_requires_pr = ! empty( $config['success_requires_pr'] );
 $job_artifact_exports = homeboy_datamachine_agent_export_job_artifacts( $job_id, $config, $pr_opened );
 
@@ -1010,6 +1049,7 @@ $metadata += array(
     'error_message'         => (string) ( $engine_data['error_message'] ?? '' ),
     'success_status'        => $success_status,
     'success_requires_pr'   => $success_requires_pr,
+    'completion_outcome_satisfied' => $completion_outcome_satisfied,
     'file_written'          => $file_written,
     'job_artifact_exports'    => $job_artifact_exports,
 );
@@ -1023,7 +1063,7 @@ if ( ! empty( $job_artifact_exports['error'] ) ) {
     return homeboy_datamachine_agent_result( array( 'job_artifact_exported' => 0 ), $metadata, (string) $job_artifact_exports['error'] );
 }
 
-if ( $success_requires_pr && ! $pr_opened ) {
+if ( $success_requires_pr && ! $pr_opened && ! $completion_outcome_satisfied ) {
     return homeboy_datamachine_agent_result( array( 'pr_opened' => 0 ), $metadata, 'Agent completed without opening a pull request' );
 }
 
@@ -1045,7 +1085,8 @@ return homeboy_datamachine_agent_result(
         'job_completed'               => 'completed' === $job_status ? 1 : 0,
         'file_written'                => $file_written ? 1 : 0,
         'pr_opened'                   => $pr_opened ? 1 : 0,
-        'no_changes'                  => ! $file_written && ! $pr_opened ? 1 : 0,
+        'completion_outcome_satisfied' => $completion_outcome_satisfied ? 1 : 0,
+        'no_changes'                  => ! $file_written && ! $pr_opened && ! $completion_outcome_satisfied ? 1 : 0,
         'job_artifact_exported'       => ! empty( $job_artifact_exports['pr_url'] ) ? 1 : 0,
         'transcript_exported'         => ! empty( $transcript_artifacts['json'] ) ? 1 : 0,
         'total_tokens'                => (int) ( $metadata['token_usage']['total_tokens'] ?? 0 ),

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -122,5 +122,27 @@ namespace {
         exit( 1 );
     }
 
+    $mailbox_reply = array(
+        'completion_assertions_satisfied' => array(
+            'complete_when_any' => array( 'mailbox_reply' ),
+        ),
+    );
+
+    if ( ! homeboy_datamachine_agent_completion_outcome_satisfied( $mailbox_reply, array( 'success_completion_outcomes' => array( 'mailbox_reply' ) ) ) ) {
+        fwrite( STDERR, "Expected allowed completion outcome to satisfy success.\n" );
+        exit( 1 );
+    }
+
+    if ( homeboy_datamachine_agent_completion_outcome_satisfied( $mailbox_reply, array( 'success_completion_outcomes' => array( 'pr_body' ) ) ) ) {
+        fwrite( STDERR, "Did not expect unlisted completion outcome to satisfy success.\n" );
+        exit( 1 );
+    }
+
+    $nested_mailbox_reply = array( 'world_creator' => $mailbox_reply );
+    if ( ! homeboy_datamachine_agent_completion_outcome_satisfied( $nested_mailbox_reply, array( 'engine_key' => 'world_creator', 'success_completion_outcomes' => array( 'mailbox_reply' ) ) ) ) {
+        fwrite( STDERR, "Expected nested completion outcome to satisfy success.\n" );
+        exit( 1 );
+    }
+
     fwrite( STDOUT, "Data Machine agent write-without-PR smoke passed.\n" );
 }


### PR DESCRIPTION
## Summary
- Add a reusable workflow input for allowed Data Machine completion outcomes.
- Let the generic agent runner satisfy PR-required CI when an allowed outcome such as `mailbox_reply` is recorded.
- Preserve the existing failure for file writes without a PR, and add smoke coverage for direct and nested outcomes.

## Testing
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the World Creator mailbox-only CI failure, drafting the reusable workflow/runner changes, and running focused smoke/syntax checks. Chris reviewed and requested the PR.