### PR TITLE
Guard transcript artifact upload path

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -478,7 +478,7 @@ jobs:
             --required-status completed
 
       - name: Upload transcript artifact
-        if: ${{ always() && inputs.transcript_artifact_name != '' }}
+        if: ${{ always() && inputs.transcript_artifact_name != '' && (steps.extract.outputs.transcript_json != '' || steps.extract_dry_run.outputs.transcript_json != '') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.transcript_artifact_name }}


### PR DESCRIPTION
## Summary
- Skip transcript artifact upload when an early reusable-workflow failure prevents transcript path outputs from being produced.

## Context
World Creator dependency checkout failures currently produce a second noisy `actions/upload-artifact` failure because `path` is empty. This keeps the real failure visible without a misleading follow-on error.

## Testing
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\")'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the follow-on upload-artifact failure and drafted the guard; Chris remains responsible for review and merge.