### PR TITLE
Fail Core lint when analyzers fail

### DIFF
--- a/wordpress/scripts/lint/lint-runner-core-dev.sh
+++ b/wordpress/scripts/lint/lint-runner-core-dev.sh
@@ -30,10 +30,14 @@ fi
 cd "$CORE_PATH"
 
 PHPCS_BIN="${CORE_PATH}/vendor/bin/phpcs"
-PHPCS_CONFIG="${CORE_PATH}/.phpcs.xml.dist"
+PHPCS_CONFIG="${CORE_PATH}/phpcs.xml.dist"
+if [ ! -f "$PHPCS_CONFIG" ]; then
+    PHPCS_CONFIG="${CORE_PATH}/.phpcs.xml.dist"
+fi
 PHPSTAN_BIN="${CORE_PATH}/vendor/bin/phpstan"
 PHPSTAN_CONFIG="${CORE_PATH}/phpstan.neon.dist"
 CHANGED_SINCE="${HOMEBOY_CHANGED_SINCE:-origin/trunk}"
+lint_status=0
 
 mapfile -t CHANGED_PHP_FILES < <(
     git diff --name-only "$CHANGED_SINCE" -- '*.php' 2>/dev/null \
@@ -49,9 +53,10 @@ if [ "${#CHANGED_PHP_FILES[@]}" -eq 0 ]; then
 else
     if [ -x "$PHPCS_BIN" ] && [ -f "$PHPCS_CONFIG" ]; then
         echo "Running WordPress core PHPCS on ${#CHANGED_PHP_FILES[@]} changed PHP file(s)..."
-        "$PHPCS_BIN" --standard="$PHPCS_CONFIG" "${CHANGED_PHP_FILES[@]}" || true
+        "$PHPCS_BIN" --standard="$PHPCS_CONFIG" "${CHANGED_PHP_FILES[@]}" || lint_status=1
     else
-        echo "Warning: WordPress core PHPCS config or binary missing; skipping PHPCS."
+        echo "Error: WordPress core PHPCS config or binary missing; run composer install before Homeboy lint." >&2
+        lint_status=1
     fi
 
     if [ -x "$PHPSTAN_BIN" ] && [ -f "$PHPSTAN_CONFIG" ]; then
@@ -61,15 +66,20 @@ else
         fi
         phpstan_args+=("${CHANGED_PHP_FILES[@]}")
         echo "Running WordPress core PHPStan on ${#CHANGED_PHP_FILES[@]} changed PHP file(s)..."
-        "$PHPSTAN_BIN" "${phpstan_args[@]}" || true
+        "$PHPSTAN_BIN" "${phpstan_args[@]}" || lint_status=1
     else
-        echo "Warning: WordPress core PHPStan config or binary missing; skipping PHPStan."
+        echo "Error: WordPress core PHPStan config or binary missing; run composer install before Homeboy lint." >&2
+        lint_status=1
     fi
 fi
 
 if [ "${#CHANGED_JS_FILES[@]}" -gt 0 ] && [ -f package.json ] && command -v npm >/dev/null 2>&1; then
     echo "Changed JS/TS files detected; running WordPress core JS lint script."
-    npm run lint:js -- "${CHANGED_JS_FILES[@]}" || true
+    npm run lint:js -- "${CHANGED_JS_FILES[@]}" || lint_status=1
+fi
+
+if [ "$lint_status" -ne 0 ]; then
+    fail "Core-dev lint run failed."
 fi
 
 echo "Core-dev lint run complete."

--- a/wordpress/scripts/test/core-dev-shape-smoke.sh
+++ b/wordpress/scripts/test/core-dev-shape-smoke.sh
@@ -28,6 +28,41 @@ assert_equals() {
     fi
 }
 
+prepare_core_lint_fixture() {
+    local target="$1"
+
+    cp -R "$FIXTURE" "$target"
+    mkdir -p "${target}/vendor/bin"
+    cat > "${target}/vendor/bin/phpcs" <<'EOF'
+#!/usr/bin/env bash
+exit "${HOMEBOY_FAKE_PHPCS_EXIT:-0}"
+EOF
+    cat > "${target}/vendor/bin/phpstan" <<'EOF'
+#!/usr/bin/env bash
+exit "${HOMEBOY_FAKE_PHPSTAN_EXIT:-0}"
+EOF
+    chmod +x "${target}/vendor/bin/phpcs" "${target}/vendor/bin/phpstan"
+
+    git -C "$target" init -q
+    git -C "$target" config user.email smoke@example.com
+    git -C "$target" config user.name 'Smoke Test'
+    git -C "$target" add .
+    git -C "$target" commit -q -m 'base'
+    printf '\n// changed\n' >> "${target}/src/wp-includes/version.php"
+}
+
+run_core_lint_fixture() {
+    local target="$1"
+    shift
+
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_ID="wordpress-develop" \
+    HOMEBOY_COMPONENT_PATH="$target" \
+    HOMEBOY_COMPONENT_SHAPE="core-dev" \
+    HOMEBOY_CHANGED_SINCE="HEAD" \
+        "$@" bash "${EXTENSION_PATH}/scripts/lint/lint-runner.sh"
+}
+
 source "${EXTENSION_PATH}/scripts/lib/detect-component.sh"
 homeboy_detect_component "$FIXTURE"
 assert_equals "$HOMEBOY_COMPONENT_TYPE" "core-dev" "component type"
@@ -56,6 +91,24 @@ HOMEBOY_COMPONENT_SHAPE="core-dev" \
 HOMEBOY_CORE_DEV_DRY_RUN=1 \
     bash "${EXTENSION_PATH}/scripts/lint/lint-runner.sh" > "${TMPDIR}/lint.out"
 assert_contains "${TMPDIR}/lint.out" "core-dev lint runner selected"
+
+LINT_FIXTURE="${TMPDIR}/core-lint-fixture"
+prepare_core_lint_fixture "$LINT_FIXTURE"
+run_core_lint_fixture "$LINT_FIXTURE" env > "${TMPDIR}/lint-success.out"
+assert_contains "${TMPDIR}/lint-success.out" "Core-dev lint run complete"
+
+HOMEBOY_FAKE_PHPSTAN_EXIT=1 run_core_lint_fixture "$LINT_FIXTURE" env > "${TMPDIR}/lint-phpstan-fail.out" 2>&1 && {
+    echo "Expected core-dev lint to fail when PHPStan fails" >&2
+    exit 1
+}
+assert_contains "${TMPDIR}/lint-phpstan-fail.out" "Core-dev lint run failed"
+
+rm -f "${LINT_FIXTURE}/vendor/bin/phpstan"
+run_core_lint_fixture "$LINT_FIXTURE" env > "${TMPDIR}/lint-missing-phpstan.out" 2>&1 && {
+    echo "Expected core-dev lint to fail when PHPStan is missing" >&2
+    exit 1
+}
+assert_contains "${TMPDIR}/lint-missing-phpstan.out" "PHPStan config or binary missing"
 
 (
     cd "$FIXTURE"


### PR DESCRIPTION
## Summary
- Fail the WordPress core-dev lint runner when PHPCS, PHPStan, or JS lint fails instead of swallowing analyzer exits.
- Treat missing Core PHPCS/PHPStan binaries as infrastructure failures with a `composer install` hint.
- Prefer Core's `phpcs.xml.dist` while retaining `.phpcs.xml.dist` fallback, and add smoke coverage for success, analyzer failure, and missing PHPStan.

## Motivation
This came out of reviewing why Homeboy did not flag a WordPress Core backport issue on https://github.com/WordPress/wordpress-develop/pull/11766.

Weston Ruter noted a strict PHPStan `foreach.nonIterable` issue in `src/wp-admin/site-editor.php`: https://github.com/WordPress/wordpress-develop/pull/11766#discussion_r3215147950

Strict PHPStan did catch the issue when run directly, but Homeboy still reported success because the core-dev lint runner swallowed analyzer exits with `|| true`. The runner also skipped PHPCS in Core because it looked for `.phpcs.xml.dist` while Core uses `phpcs.xml.dist`, and it treated missing Composer-installed analyzer binaries as warnings instead of actionable infrastructure failures.

## Testing
- `bash wordpress/scripts/test/core-dev-shape-smoke.sh`
- `bash -n wordpress/scripts/lint/lint-runner-core-dev.sh && bash -n wordpress/scripts/test/core-dev-shape-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the missed WordPress Core PHPStan coverage, drafted the shell runner fix and smoke coverage, and ran targeted validation. Chris remains responsible for review and merge.