### PR TITLE
Use repo-backed agent bundle path

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -478,7 +478,7 @@ jobs:
             --required-status completed
 
       - name: Upload transcript artifact
-        if: ${{ always() && inputs.transcript_artifact_name != '' }}
+        if: ${{ always() && inputs.transcript_artifact_name != '' && (steps.extract.outputs.transcript_json != '' || steps.extract_dry_run.outputs.transcript_json != '') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.transcript_artifact_name }}

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -321,6 +321,8 @@ jobs:
             --arg componentPath "$GITHUB_WORKSPACE" \
             --arg bundlePath "$bundle_abs" \
             --arg bundlePathInRepo "$BUNDLE_PATH" \
+            --arg bundleRepo "https://github.com/${TARGET_REPO}.git" \
+            --arg bundleRef "$GITHUB_SHA" \
             --arg agentSlug "$AGENT_SLUG" \
             --arg pipelineSlug "$PIPELINE_SLUG" \
             --arg flowSlug "$FLOW_SLUG" \
@@ -362,6 +364,8 @@ jobs:
               workload_run_before: $workloadRunBefore,
               required_abilities: (["datamachine/import-agent", "datamachine/run-flow", "datamachine/drain-job"] + $extraRequiredAbilities | reduce .[] as $ability ([]; if index($ability) then . else . + [$ability] end)),
               bundle_path: $bundlePath,
+              bundle_repo: $bundleRepo,
+              bundle_ref: $bundleRef,
               bundle_path_in_repo: $bundlePathInRepo,
               agent_slug: $agentSlug,
               pipeline_slug: $pipelineSlug,


### PR DESCRIPTION
## Summary
- Pass `bundle_repo`, `bundle_ref`, and repo-relative `bundle_path_in_repo` from the reusable Data Machine agent workflow.
- Lets the existing `run-datamachine-agent.sh` repo-backed bundle path map the bundle into the Playground-visible guest path instead of handing the workload a host-only checkout path.

## Context
World Creator now reaches the Data Machine workload but fails with `Agent bundle directory missing or incomplete` because the host absolute bundle path is not visible inside Playground.

## Testing
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\")'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the host-vs-Playground bundle path mismatch and drafted the reusable workflow fix; Chris remains responsible for review and merge.