### PR TITLE
Add WordPress page profiler helpers

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -260,6 +260,52 @@ credentials — runners must not publish it without redacting fields
 listed in `artifactPolicy.secretFields`. Full schema in
 [`docs/TESTING.md`](docs/TESTING.md#browser-bench-target-handoff).
 
+### Page profiler primitives
+
+The extension exports reusable Node helpers for browser-backed WordPress page
+profiling. Rigs keep ownership of site lifecycle and Playwright launch, then
+call `profileWordPressPage()` or `profileWordPressPages()` with a manifest of
+URLs and readiness gates. The helpers collect resource timings, classify REST /
+admin / asset waterfalls, and correlate browser timings with rows from the
+temporary request profiler.
+
+```js
+const {
+	installWordPressRequestProfiler,
+	collectWordPressRequestProfiles,
+	profileWordPressPages,
+} = require('homeboy-extension-wordpress');
+
+installWordPressRequestProfiler(sitePath, { clearArtifact: true });
+
+const result = await profileWordPressPages({
+	page,
+	baseUrl: status.siteUrl,
+	manifest: {
+		pages: [
+			{ id: 'home', path: '/', ready: { state: 'networkidle' } },
+			{ id: 'dashboard', path: '/wp-admin/index.php', ready: '#dashboard-widgets' },
+			{
+				id: 'site-editor',
+				path: '/wp-admin/site-editor.php',
+				ready: {
+					selector: 'iframe[name="editor-canvas"]',
+					frameName: 'editor-canvas',
+					frameSelector: '[data-block]',
+				},
+			},
+		],
+	},
+	wordpressProfilerRows: collectWordPressRequestProfiles(sitePath),
+});
+```
+
+This is intentionally extension-level infrastructure, not Homeboy core. Core
+keeps orchestration, run persistence, baselines, and reports; WordPress owns
+WP-specific browser readiness, REST route classification, request profiling,
+and URL manifests. If the same page-profiling primitive appears in another
+extension later, then the shared seam can be promoted into core.
+
 ## Trace runner
 
 Project-owned scenarios live under one of:

--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -2,5 +2,6 @@
 
 module.exports = {
 	...require('./lib/request-profiler'),
+	...require('./lib/page-profiler'),
 	...require('./lib/timing-correlator'),
 };

--- a/wordpress/lib/page-profiler.js
+++ b/wordpress/lib/page-profiler.js
@@ -1,0 +1,301 @@
+'use strict';
+
+/**
+ * Internal dependencies
+ */
+const { correlateBrowserAndWordPressTimings, normalizeUrl } = require('./timing-correlator');
+
+const DEFAULT_RESOURCE_INCLUDE = [
+	'/wp-json/',
+	'?rest_route=',
+	'/wp-admin/',
+	'/wp-content/',
+	'/wp-includes/',
+];
+
+function round(value) {
+	return typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : 0;
+}
+
+function isPlainObject(value) {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeBaseUrl(baseUrl) {
+	if (typeof baseUrl !== 'string' || baseUrl.trim() === '') {
+		throw new TypeError('baseUrl must be a non-empty string');
+	}
+	return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+}
+
+function resolveWordPressUrl(baseUrl, value) {
+	if (typeof value !== 'string' || value.trim() === '') {
+		throw new TypeError('page url/path must be a non-empty string');
+	}
+	return new URL(value, normalizeBaseUrl(baseUrl)).toString();
+}
+
+function normalizeReadySpec(ready) {
+	if (ready === undefined || ready === null) {
+		return { state: 'domcontentloaded' };
+	}
+	if (typeof ready === 'string') {
+		return { selector: ready };
+	}
+	if (!isPlainObject(ready)) {
+		throw new TypeError('ready must be a string selector or object');
+	}
+
+	const normalized = { ...ready };
+	if (!normalized.state && !normalized.selector && !normalized.frame && !normalized.frameSelector && !normalized.function) {
+		normalized.state = 'domcontentloaded';
+	}
+	return normalized;
+}
+
+function normalizePageSpec(spec) {
+	if (!isPlainObject(spec)) {
+		throw new TypeError('page spec must be an object');
+	}
+	const url = spec.url || spec.path;
+	if (typeof url !== 'string' || url.trim() === '') {
+		throw new TypeError('page spec requires url or path');
+	}
+	const id = spec.id || url.replace(/^\/+/, '').replace(/[^A-Za-z0-9_.:-]+/g, '-').replace(/^-|-$/g, '') || 'home';
+
+	return {
+		...spec,
+		id,
+		url,
+		label: spec.label || id,
+		ready: normalizeReadySpec(spec.ready),
+	};
+}
+
+function normalizePageManifest(manifest) {
+	const pages = Array.isArray(manifest) ? manifest : manifest?.pages;
+	if (!Array.isArray(pages)) {
+		throw new TypeError('page manifest must be an array or object with pages array');
+	}
+	return pages.map(normalizePageSpec);
+}
+
+function shouldIncludeResource(url, options = {}) {
+	const include = Array.isArray(options.includeResourceSubstrings)
+		? options.includeResourceSubstrings
+		: DEFAULT_RESOURCE_INCLUDE;
+	const exclude = Array.isArray(options.excludeResourceSubstrings)
+		? options.excludeResourceSubstrings
+		: [];
+	const value = String(url || '');
+
+	if (exclude.some((needle) => value.includes(needle))) {
+		return false;
+	}
+	if (include.length === 0) {
+		return true;
+	}
+	return include.some((needle) => value.includes(needle));
+}
+
+function classifyResourceUrl(url) {
+	const normalized = normalizeUrl(url, { lowercasePath: false });
+	if (normalized.includes('/wp-json/') || normalized.includes('rest_route=')) {
+		return 'rest';
+	}
+	if (normalized.includes('/wp-admin/')) {
+		return 'admin';
+	}
+	if (normalized.includes('/wp-content/')) {
+		return 'content-asset';
+	}
+	if (normalized.includes('/wp-includes/')) {
+		return 'core-asset';
+	}
+	return 'other';
+}
+
+async function collectBrowserResourceTimings(page, options = {}) {
+	if (!page || typeof page.evaluate !== 'function') {
+		throw new TypeError('page must provide evaluate()');
+	}
+	const raw = await page.evaluate(() =>
+		performance.getEntriesByType('resource').map((entry) => ({
+			name: entry.name,
+			initiatorType: entry.initiatorType,
+			startTime: entry.startTime,
+			duration: entry.duration,
+			fetchStart: entry.fetchStart,
+			requestStart: entry.requestStart,
+			responseStart: entry.responseStart,
+			responseEnd: entry.responseEnd,
+			transferSize: entry.transferSize,
+			encodedBodySize: entry.encodedBodySize,
+			decodedBodySize: entry.decodedBodySize,
+		}))
+	);
+
+	return raw
+		.filter((entry) => shouldIncludeResource(entry.name, options))
+		.map((entry) => ({
+			...entry,
+			url: entry.name,
+			normalizedUrl: normalizeUrl(entry.name),
+			kind: classifyResourceUrl(entry.name),
+			ttfbMs: typeof entry.responseStart === 'number' && typeof entry.requestStart === 'number'
+				? entry.responseStart - entry.requestStart
+				: undefined,
+		}));
+}
+
+async function waitForPageReady(page, ready, options = {}) {
+	const spec = normalizeReadySpec(ready);
+	const timeout = spec.timeout || options.timeout || 120000;
+
+	if (spec.state && typeof page.waitForLoadState === 'function') {
+		await page.waitForLoadState(spec.state, { timeout });
+	}
+
+	if (spec.selector) {
+		await page.waitForSelector(spec.selector, {
+			state: spec.selectorState || 'visible',
+			timeout,
+		});
+	}
+
+	if (spec.frame || spec.frameSelector) {
+		const frameName = spec.frame?.name || spec.frameName;
+		const frame = typeof page.frame === 'function'
+			? page.frame(frameName ? { name: frameName } : spec.frame)
+			: null;
+		if (!frame) {
+			throw new Error(`Ready frame not found for ${frameName || JSON.stringify(spec.frame)}`);
+		}
+		if (spec.frameState && typeof frame.waitForLoadState === 'function') {
+			await frame.waitForLoadState(spec.frameState, { timeout });
+		}
+		if (spec.frameSelector) {
+			await frame.waitForSelector(spec.frameSelector, {
+				state: spec.frameSelectorState || 'visible',
+				timeout,
+			});
+		}
+	}
+
+	if (spec.function) {
+		if (typeof page.waitForFunction !== 'function') {
+			throw new TypeError('ready.function requires page.waitForFunction()');
+		}
+		await page.waitForFunction(spec.function, spec.functionArg, { timeout });
+	}
+}
+
+function summarizeResourceTimings(entries) {
+	const resources = entries.map((entry) => ({
+		url: entry.normalizedUrl || normalizeUrl(entry.name || entry.url),
+		kind: entry.kind || classifyResourceUrl(entry.name || entry.url),
+		initiatorType: entry.initiatorType,
+		startMs: round(entry.startTime),
+		durationMs: round(entry.duration),
+		ttfbMs: round(entry.ttfbMs),
+		transferSize: entry.transferSize || 0,
+		encodedBodySize: entry.encodedBodySize || 0,
+		decodedBodySize: entry.decodedBodySize || 0,
+	}));
+
+	const countsByKind = {};
+	for (const resource of resources) {
+		countsByKind[resource.kind] = (countsByKind[resource.kind] || 0) + 1;
+	}
+
+	return {
+		count: resources.length,
+		countsByKind,
+		restCount: countsByKind.rest || 0,
+		slowest: [...resources].sort((a, b) => b.durationMs - a.durationMs).slice(0, 20),
+		resources,
+	};
+}
+
+async function profileWordPressPage(input) {
+	if (!input || typeof input !== 'object') {
+		throw new TypeError('profileWordPressPage requires an input object');
+	}
+	const { page, baseUrl, wordpressProfilerRows = [], mark } = input;
+	const spec = normalizePageSpec(input.spec || input.pageSpec || input.page || {});
+	const url = resolveWordPressUrl(baseUrl, spec.url);
+	const started = Date.now();
+
+	if (!page || typeof page.goto !== 'function') {
+		throw new TypeError('page must provide goto()');
+	}
+
+	const response = await page.goto(url, {
+		waitUntil: spec.gotoWaitUntil || 'commit',
+		timeout: spec.timeout || 120000,
+	});
+	if (typeof mark === 'function') {
+		await mark(`${spec.id}_commit`);
+	}
+
+	await waitForPageReady(page, spec.ready, { timeout: spec.timeout || 120000 });
+	if (typeof mark === 'function') {
+		await mark(`${spec.id}_ready`);
+	}
+
+	const readyMs = Date.now() - started;
+	const resources = await collectBrowserResourceTimings(page, spec.resources || {});
+	const resourceSummary = summarizeResourceTimings(resources);
+	const correlation = correlateBrowserAndWordPressTimings({
+		browserTimings: resources,
+		wordpressProfilerRows,
+	});
+
+	return {
+		id: spec.id,
+		label: spec.label,
+		url,
+		path: new URL(url).pathname + new URL(url).search,
+		status: response && typeof response.status === 'function' ? response.status() : 0,
+		readyMs,
+		resources: resourceSummary,
+		correlation,
+	};
+}
+
+async function profileWordPressPages(input) {
+	if (!input || typeof input !== 'object') {
+		throw new TypeError('profileWordPressPages requires an input object');
+	}
+	const specs = normalizePageManifest(input.manifest || input.pages || []);
+	const results = [];
+	for (const spec of specs) {
+		results.push(await profileWordPressPage({ ...input, spec }));
+	}
+	return {
+		pages: results,
+		topRestWaterfalls: [...results]
+			.sort((a, b) => (b.resources.restCount - a.resources.restCount) || (b.readyMs - a.readyMs))
+			.slice(0, input.topLimit || 10)
+			.map((result) => ({
+				id: result.id,
+				path: result.path,
+				readyMs: result.readyMs,
+				restCount: result.resources.restCount,
+				slowest: result.resources.slowest.filter((resource) => resource.kind === 'rest').slice(0, 5),
+			})),
+	};
+}
+
+module.exports = {
+	DEFAULT_RESOURCE_INCLUDE,
+	classifyResourceUrl,
+	collectBrowserResourceTimings,
+	normalizePageManifest,
+	normalizePageSpec,
+	profileWordPressPage,
+	profileWordPressPages,
+	resolveWordPressUrl,
+	summarizeResourceTimings,
+	waitForPageReady,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -5,12 +5,14 @@
   "main": "index.js",
   "exports": {
     ".": "./index.js",
+    "./page-profiler": "./lib/page-profiler.js",
     "./playground-readiness": "./lib/playground-readiness.js",
     "./request-profiler": "./lib/request-profiler.js",
     "./timing-correlator": "./lib/timing-correlator.js"
   },
   "scripts": {
     "lint:js": "eslint --ext .js,.jsx,.ts,.tsx",
+    "test:page-profiler": "node tests/page-profiler-smoke.js",
     "test:playground-readiness": "node tests/playground-readiness-smoke.js",
     "test:request-profiler": "node tests/request-profiler-smoke.js",
     "test:timing-correlator": "node tests/timing-correlator-smoke.js"

--- a/wordpress/tests/page-profiler-smoke.js
+++ b/wordpress/tests/page-profiler-smoke.js
@@ -1,0 +1,148 @@
+'use strict';
+
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
+const assert = require('node:assert/strict');
+
+/**
+ * Internal dependencies
+ */
+const {
+	classifyResourceUrl,
+	normalizePageManifest,
+	profileWordPressPage,
+	profileWordPressPages,
+	resolveWordPressUrl,
+	summarizeResourceTimings,
+} = require('../lib/page-profiler');
+
+class FakeFrame {
+	constructor(calls) {
+		this.calls = calls;
+	}
+
+	async waitForLoadState(state) {
+		this.calls.push(['frame.waitForLoadState', state]);
+	}
+
+	async waitForSelector(selector) {
+		this.calls.push(['frame.waitForSelector', selector]);
+	}
+}
+
+class FakePage {
+	constructor(resources) {
+		this.resources = resources;
+		this.calls = [];
+		this.fakeFrame = new FakeFrame(this.calls);
+	}
+
+	async goto(url, options) {
+		this.calls.push(['goto', url, options.waitUntil]);
+		return { status: () => 200 };
+	}
+
+	async waitForLoadState(state) {
+		this.calls.push(['waitForLoadState', state]);
+	}
+
+	async waitForSelector(selector) {
+		this.calls.push(['waitForSelector', selector]);
+	}
+
+	frame(query) {
+		this.calls.push(['frame', query?.name || query]);
+		return this.fakeFrame;
+	}
+
+	async evaluate() {
+		return this.resources;
+	}
+}
+
+assert.equal(resolveWordPressUrl('https://example.test/site', '/wp-admin/index.php'), 'https://example.test/wp-admin/index.php');
+assert.equal(classifyResourceUrl('https://example.test/wp-json/wp/v2/posts?context=edit'), 'rest');
+assert.equal(classifyResourceUrl('https://example.test/wp-admin/load-styles.php'), 'admin');
+assert.equal(classifyResourceUrl('https://example.test/wp-content/themes/theme/style.css'), 'content-asset');
+
+const manifest = normalizePageManifest({
+	pages: [
+		{ id: 'dashboard', path: '/wp-admin/index.php', ready: '#dashboard-widgets' },
+		{
+			id: 'site-editor',
+			path: '/wp-admin/site-editor.php',
+			ready: { selector: 'iframe[name="editor-canvas"]', frameName: 'editor-canvas', frameSelector: '[data-block]' },
+		},
+	],
+});
+assert.equal(manifest.length, 2);
+assert.equal(manifest[0].ready.selector, '#dashboard-widgets');
+assert.equal(manifest[1].ready.frameSelector, '[data-block]');
+
+const resources = [
+	{
+		name: 'https://example.test/wp-json/wp/v2/posts?context=edit',
+		initiatorType: 'fetch',
+		startTime: 20,
+		duration: 180,
+		requestStart: 30,
+		responseStart: 140,
+		responseEnd: 200,
+		transferSize: 1000,
+	},
+	{
+		name: 'https://example.test/wp-content/themes/twentytwentyfive/style.css',
+		initiatorType: 'link',
+		startTime: 5,
+		duration: 20,
+		requestStart: 6,
+		responseStart: 10,
+		responseEnd: 25,
+	},
+	{
+		name: 'https://example.test/favicon.ico',
+		initiatorType: 'img',
+		startTime: 8,
+		duration: 5,
+	},
+];
+
+const summary = summarizeResourceTimings(resources.map((entry) => ({ ...entry, kind: classifyResourceUrl(entry.name) })));
+assert.equal(summary.count, 3);
+assert.equal(summary.countsByKind.rest, 1);
+
+async function main() {
+	const page = new FakePage(resources);
+	const result = await profileWordPressPage({
+		page,
+		baseUrl: 'https://example.test',
+		spec: manifest[1],
+		wordpressProfilerRows: [
+			{ event: 'request.start', request_id: 'r1', method: 'GET', uri: '/wp-json/wp/v2/posts?context=edit', t_ms: 0 },
+			{ event: 'shutdown', request_id: 'r1', method: 'GET', uri: '/wp-json/wp/v2/posts?context=edit', t_ms: 95 },
+		],
+	});
+
+	assert.equal(result.id, 'site-editor');
+	assert.equal(result.status, 200);
+	assert.equal(result.resources.restCount, 1);
+	assert.equal(result.correlation.correlated.length, 1);
+	assert.equal(page.calls.some((call) => call[0] === 'frame.waitForSelector' && call[1] === '[data-block]'), true);
+
+	const multiPage = new FakePage(resources);
+	const multi = await profileWordPressPages({ page: multiPage, baseUrl: 'https://example.test', manifest });
+	assert.equal(multi.pages.length, 2);
+	assert.equal(multi.topRestWaterfalls[0].restCount, 1);
+
+	assert.throws(() => normalizePageManifest({ pages: [{ id: 'bad' }] }), /requires url or path/);
+
+	console.log('WordPress page profiler smoke passed.');
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add reusable WordPress page profiling helpers for browser-backed rigs and workloads.
- Support manifest-driven URL/readiness specs, resource timing collection, REST/admin/asset classification, and request-profiler correlation.
- Export the helpers from the WordPress extension package and document the extension-owned primitive boundary.

## Context
This generalizes primitives surfaced by the Site Editor preload rig work in https://github.com/chubes4/homeboy-rigs/pull/106 and https://github.com/chubes4/homeboy-rigs/pull/108.

The goal is not to move WordPress-specific profiling into Homeboy core. The WordPress extension should own WordPress URL manifests, browser readiness gates, REST route classification, and request profiler correlation. Core can continue to own orchestration, runs, baselines, and reports. A primitive should only graduate to Homeboy core after the same pattern exists in two or more extensions and the cross-domain seam is proven.

## Testing
- `node tests/playground-readiness-smoke.js && node tests/request-profiler-smoke.js && node tests/timing-correlator-smoke.js && node tests/page-profiler-smoke.js`
- `npm run lint:js -- lib/page-profiler.js`
- `./node_modules/.bin/eslint --no-ignore tests/page-profiler-smoke.js`

## Notes
- `npm install` reported 4 moderate audit findings in the existing dependency tree. This PR does not change dependency versions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the WordPress page profiler helper, smoke coverage, documentation, and targeted validation. Chris remains responsible for review and merge.