### PR TITLE
Allow Data Machine agent CI content writes

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
     outputs:


### PR DESCRIPTION
## Summary
- Grant `contents: write` to the reusable Data Machine agent CI job.

## Context
World Creator now reaches the Data Machine workload, but GitHub file/branch operations fail with `GitHub API error (403): Resource not accessible by integration` when the reusable workflow falls back to `github.token`. The agent and artifact paths need content write permission to create or update files and branches in the target repository.

## Testing
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\")'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the GitHub token permission failure and drafted the workflow permission fix; Chris remains responsible for review and merge.