### PR TITLE
Fix agent CI transcript artifact uploads

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -301,6 +301,9 @@ jobs:
           set -euo pipefail
           config_path="${RUNNER_TEMP}/datamachine-agent-config.json"
           bundle_abs="${GITHUB_WORKSPACE}/${BUNDLE_PATH}"
+          component_slug="$(basename "$GITHUB_WORKSPACE")"
+          transcript_host_dir="${GITHUB_WORKSPACE}/datamachine-agent-artifacts/${AGENT_SLUG}"
+          transcript_guest_dir="/wordpress/wp-content/plugins/${component_slug}/datamachine-agent-artifacts/${AGENT_SLUG}"
           mapfile -t validation_paths < <(find "${GITHUB_WORKSPACE}/.ci" -mindepth 1 -maxdepth 1 -type d | sort)
           validation_json="$(printf '%s\n' "${validation_paths[@]}" | jq -Rsc 'split("\n") | map(select(. != ""))')"
           validate_json_input() {
@@ -331,6 +334,7 @@ jobs:
             --arg provider "$PROVIDER" \
             --arg model "$MODEL" \
             --arg playgroundWordPress "$PLAYGROUND_WORDPRESS" \
+            --arg transcriptGuestDir "$transcript_guest_dir" \
             --arg githubToken "$GITHUB_TOKEN_VALUE" \
             --arg openaiKey "$OPENAI_API_KEY_VALUE" \
             --argjson validationDependencies "$validation_json" \
@@ -395,13 +399,14 @@ jobs:
                 pr_body_template: "## Summary\n- Persist bundle-file run artifacts from Data Machine agent job {job_id}.\n\n## Artifacts\n{paths}\n"
               } * $artifactExportConfig),
               dry_run: $dryRun,
-              transcript_dir: ("/wordpress/wp-content/plugins/datamachine-agent-ci-driver/artifacts/" + $agentSlug),
+              transcript_dir: $transcriptGuestDir,
               bench_env: {
                 GITHUB_TOKEN: $githubToken,
                 OPENAI_API_KEY: $openaiKey
               }
             } + (if $dailyMemoryEnabled then {daily_memory_enabled: true} else {} end)' > "$config_path"
           printf 'config_path=%s\n' "$config_path" >> "$GITHUB_OUTPUT"
+          printf 'transcript_host_dir=%s\n' "$transcript_host_dir" >> "$GITHUB_OUTPUT"
 
       - name: Run Data Machine agent
         env:
@@ -481,13 +486,36 @@ jobs:
             --field job_status=metadata.job_status \
             --required-status completed
 
-      - name: Upload transcript artifact
+      - name: Resolve transcript artifact path
+        id: transcript-artifact
         if: ${{ always() && inputs.transcript_artifact_name != '' && (steps.extract.outputs.transcript_json != '' || steps.extract_dry_run.outputs.transcript_json != '') }}
+        env:
+          TRANSCRIPT_JSON: ${{ steps.extract.outputs.transcript_json || steps.extract_dry_run.outputs.transcript_json }}
+          TRANSCRIPT_HOST_DIR: ${{ steps.config.outputs.transcript_host_dir }}
+        run: |
+          set -euo pipefail
+          transcript_path=""
+          if [ -n "$TRANSCRIPT_JSON" ] && [ -f "$TRANSCRIPT_JSON" ]; then
+            transcript_path="$TRANSCRIPT_JSON"
+          elif [ -n "$TRANSCRIPT_JSON" ] && [ -n "$TRANSCRIPT_HOST_DIR" ]; then
+            candidate="${TRANSCRIPT_HOST_DIR}/$(basename "$TRANSCRIPT_JSON")"
+            if [ -f "$candidate" ]; then
+              transcript_path="$candidate"
+            fi
+          fi
+          if [ -z "$transcript_path" ]; then
+            echo "Transcript artifact file not found for path: $TRANSCRIPT_JSON"
+            exit 0
+          fi
+          printf 'path=%s\n' "$transcript_path" >> "$GITHUB_OUTPUT"
+
+      - name: Upload transcript artifact
+        if: ${{ always() && inputs.transcript_artifact_name != '' && steps.transcript-artifact.outputs.path != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.transcript_artifact_name }}
-          path: ${{ steps.extract.outputs.transcript_json || steps.extract_dry_run.outputs.transcript_json }}
-          if-no-files-found: ignore
+          path: ${{ steps.transcript-artifact.outputs.path }}
+          if-no-files-found: error
 
       - name: Comment PR summary
         if: ${{ inputs.comment_pr_summary && github.event_name == 'pull_request' && ! inputs.dry_run }}


### PR DESCRIPTION
## Summary
- Writes agent transcript exports to a host-mounted repo directory so the GitHub runner can upload them.
- Resolves the host path before invoking `actions/upload-artifact` and fails upload only when a resolved file unexpectedly disappears.

## Testing
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\"); puts \"yaml ok\"'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the failed transcript artifact upload path and drafted the workflow fix; Chris reviewed and triggered PR creation.