### PR TITLE
Materialize agent CI transcript content for upload

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -496,6 +496,8 @@ jobs:
         id: transcript-artifact
         if: ${{ always() && inputs.transcript_artifact_name != '' && (steps.extract.outputs.transcript_json != '' || steps.extract_dry_run.outputs.transcript_json != '') }}
         env:
+          RESULTS_FILE: ${{ runner.temp }}/run-results.json
+          FLOW_SLUG: ${{ inputs.flow_slug }}
           TRANSCRIPT_JSON: ${{ steps.extract.outputs.transcript_json || steps.extract_dry_run.outputs.transcript_json }}
           TRANSCRIPT_HOST_DIR: ${{ steps.config.outputs.transcript_host_dir }}
         run: |
@@ -507,6 +509,14 @@ jobs:
             candidate="${TRANSCRIPT_HOST_DIR}/$(basename "$TRANSCRIPT_JSON")"
             if [ -f "$candidate" ]; then
               transcript_path="$candidate"
+            fi
+          fi
+          if [ -z "$transcript_path" ] && [ -f "$RESULTS_FILE" ]; then
+            transcript_content_path="${RUNNER_TEMP}/datamachine-agent-transcripts/$(basename "${TRANSCRIPT_JSON:-job-transcript.json}")"
+            if jq -e --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | .metadata.transcript_artifacts.content? // empty' "$RESULTS_FILE" >/dev/null; then
+              mkdir -p "$(dirname "$transcript_content_path")"
+              jq -r --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | .metadata.transcript_artifacts.content' "$RESULTS_FILE" > "$transcript_content_path"
+              transcript_path="$transcript_content_path"
             fi
           fi
           if [ -z "$transcript_path" ]; then

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -301,6 +301,9 @@ jobs:
           set -euo pipefail
           config_path="${RUNNER_TEMP}/datamachine-agent-config.json"
           bundle_abs="${GITHUB_WORKSPACE}/${BUNDLE_PATH}"
+          component_slug="$(basename "$GITHUB_WORKSPACE")"
+          transcript_host_dir="${GITHUB_WORKSPACE}/datamachine-agent-artifacts/${AGENT_SLUG}"
+          transcript_guest_dir="/wordpress/wp-content/plugins/${component_slug}/datamachine-agent-artifacts/${AGENT_SLUG}"
           mapfile -t validation_paths < <(find "${GITHUB_WORKSPACE}/.ci" -mindepth 1 -maxdepth 1 -type d | sort)
           validation_json="$(printf '%s\n' "${validation_paths[@]}" | jq -Rsc 'split("\n") | map(select(. != ""))')"
           validate_json_input() {
@@ -331,6 +334,7 @@ jobs:
             --arg provider "$PROVIDER" \
             --arg model "$MODEL" \
             --arg playgroundWordPress "$PLAYGROUND_WORDPRESS" \
+            --arg transcriptGuestDir "$transcript_guest_dir" \
             --arg githubToken "$GITHUB_TOKEN_VALUE" \
             --arg openaiKey "$OPENAI_API_KEY_VALUE" \
             --argjson validationDependencies "$validation_json" \
@@ -395,13 +399,14 @@ jobs:
                 pr_body_template: "## Summary\n- Persist bundle-file run artifacts from Data Machine agent job {job_id}.\n\n## Artifacts\n{paths}\n"
               } * $artifactExportConfig),
               dry_run: $dryRun,
-              transcript_dir: ("/wordpress/wp-content/plugins/datamachine-agent-ci-driver/artifacts/" + $agentSlug),
+              transcript_dir: $transcriptGuestDir,
               bench_env: {
                 GITHUB_TOKEN: $githubToken,
                 OPENAI_API_KEY: $openaiKey
               }
             } + (if $dailyMemoryEnabled then {daily_memory_enabled: true} else {} end)' > "$config_path"
           printf 'config_path=%s\n' "$config_path" >> "$GITHUB_OUTPUT"
+          printf 'transcript_host_dir=%s\n' "$transcript_host_dir" >> "$GITHUB_OUTPUT"
 
       - name: Run Data Machine agent
         env:
@@ -481,13 +486,36 @@ jobs:
             --field job_status=metadata.job_status \
             --required-status completed
 
-      - name: Upload transcript artifact
+      - name: Resolve transcript artifact path
+        id: transcript-artifact
         if: ${{ always() && inputs.transcript_artifact_name != '' && (steps.extract.outputs.transcript_json != '' || steps.extract_dry_run.outputs.transcript_json != '') }}
+        env:
+          TRANSCRIPT_JSON: ${{ steps.extract.outputs.transcript_json || steps.extract_dry_run.outputs.transcript_json }}
+          TRANSCRIPT_HOST_DIR: ${{ steps.config.outputs.transcript_host_dir }}
+        run: |
+          set -euo pipefail
+          transcript_path=""
+          if [ -n "$TRANSCRIPT_JSON" ] && [ -f "$TRANSCRIPT_JSON" ]; then
+            transcript_path="$TRANSCRIPT_JSON"
+          elif [ -n "$TRANSCRIPT_JSON" ] && [ -n "$TRANSCRIPT_HOST_DIR" ]; then
+            candidate="${TRANSCRIPT_HOST_DIR}/$(basename "$TRANSCRIPT_JSON")"
+            if [ -f "$candidate" ]; then
+              transcript_path="$candidate"
+            fi
+          fi
+          if [ -z "$transcript_path" ]; then
+            echo "Transcript artifact file not found for path: $TRANSCRIPT_JSON"
+            exit 0
+          fi
+          printf 'path=%s\n' "$transcript_path" >> "$GITHUB_OUTPUT"
+
+      - name: Upload transcript artifact
+        if: ${{ always() && inputs.transcript_artifact_name != '' && steps.transcript-artifact.outputs.path != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.transcript_artifact_name }}
-          path: ${{ steps.extract.outputs.transcript_json || steps.extract_dry_run.outputs.transcript_json }}
-          if-no-files-found: ignore
+          path: ${{ steps.transcript-artifact.outputs.path }}
+          if-no-files-found: error
 
       - name: Comment PR summary
         if: ${{ inputs.comment_pr_summary && github.event_name == 'pull_request' && ! inputs.dry_run }}

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -296,6 +296,8 @@ jobs:
           DAILY_MEMORY_ENABLED: ${{ inputs.daily_memory_enabled }}
           EXTRA_REQUIRED_ABILITIES: ${{ inputs.extra_required_abilities }}
           GITHUB_TOKEN_VALUE: ${{ steps.app-token.outputs.token || github.token }}
+          GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT_VALUE: ${{ github.run_attempt }}
           OPENAI_API_KEY_VALUE: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
@@ -336,6 +338,8 @@ jobs:
             --arg playgroundWordPress "$PLAYGROUND_WORDPRESS" \
             --arg transcriptGuestDir "$transcript_guest_dir" \
             --arg githubToken "$GITHUB_TOKEN_VALUE" \
+            --arg githubRunId "$GITHUB_RUN_ID_VALUE" \
+            --arg githubRunAttempt "$GITHUB_RUN_ATTEMPT_VALUE" \
             --arg openaiKey "$OPENAI_API_KEY_VALUE" \
             --argjson validationDependencies "$validation_json" \
             --argjson artifactExportConfig "$ARTIFACT_EXPORT_CONFIG" \
@@ -402,6 +406,8 @@ jobs:
               transcript_dir: $transcriptGuestDir,
               bench_env: {
                 GITHUB_TOKEN: $githubToken,
+                GITHUB_RUN_ID: $githubRunId,
+                GITHUB_RUN_ATTEMPT: $githubRunAttempt,
                 OPENAI_API_KEY: $openaiKey
               }
             } + (if $dailyMemoryEnabled then {daily_memory_enabled: true} else {} end)' > "$config_path"

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -857,25 +857,25 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_transcript' ) ) {
             return array( 'session_id' => $session_id, 'error' => 'Transcript directory could not be created' );
         }
 
-        $path = rtrim( $transcript_dir, '/' ) . '/job-' . $job_id . '-transcript.json';
-        file_put_contents(
-            $path,
-            wp_json_encode(
-                array(
-                    'job_id'     => $job_id,
-                    'session_id' => $session_id,
-                    'provider'   => $session['provider'] ?? null,
-                    'model'      => $session['model'] ?? null,
-                    'metadata'   => is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array(),
-                    'messages'   => is_array( $session['messages'] ?? null ) ? $session['messages'] : array(),
-                ),
-                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
-            )
+        $path    = rtrim( $transcript_dir, '/' ) . '/job-' . $job_id . '-transcript.json';
+        $content = wp_json_encode(
+            array(
+                'job_id'     => $job_id,
+                'session_id' => $session_id,
+                'provider'   => $session['provider'] ?? null,
+                'model'      => $session['model'] ?? null,
+                'metadata'   => is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array(),
+                'messages'   => is_array( $session['messages'] ?? null ) ? $session['messages'] : array(),
+            ),
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
         );
+
+        file_put_contents( $path, $content );
 
         return array(
             'session_id' => $session_id,
             'json'       => $path,
+            'content'    => $content,
         );
     }
 }


### PR DESCRIPTION
## Summary
- Includes transcript JSON content in the agent workload metadata so host-side CI can materialize it when Playground-created files are not synced back through mounts.
- Adds a workflow fallback that writes the transcript content from the results JSON before uploading the artifact.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\"); puts \"yaml ok\"'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed why Playground-created transcript files were not visible to the host runner and drafted the generic metadata materialization fallback; Chris reviewed and triggered PR creation.