### PR TITLE
Materialize agent CI transcript content for upload

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -496,6 +496,8 @@ jobs:
         id: transcript-artifact
         if: ${{ always() && inputs.transcript_artifact_name != '' && (steps.extract.outputs.transcript_json != '' || steps.extract_dry_run.outputs.transcript_json != '') }}
         env:
+          RESULTS_FILE: ${{ runner.temp }}/run-results.json
+          FLOW_SLUG: ${{ inputs.flow_slug }}
           TRANSCRIPT_JSON: ${{ steps.extract.outputs.transcript_json || steps.extract_dry_run.outputs.transcript_json }}
           TRANSCRIPT_HOST_DIR: ${{ steps.config.outputs.transcript_host_dir }}
         run: |
@@ -507,6 +509,14 @@ jobs:
             candidate="${TRANSCRIPT_HOST_DIR}/$(basename "$TRANSCRIPT_JSON")"
             if [ -f "$candidate" ]; then
               transcript_path="$candidate"
+            fi
+          fi
+          if [ -z "$transcript_path" ] && [ -f "$RESULTS_FILE" ]; then
+            transcript_content_path="${RUNNER_TEMP}/datamachine-agent-transcripts/$(basename "${TRANSCRIPT_JSON:-job-transcript.json}")"
+            if jq -e --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | .metadata.transcript_artifacts.content? // empty' "$RESULTS_FILE" >/dev/null; then
+              mkdir -p "$(dirname "$transcript_content_path")"
+              jq -r --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | .metadata.transcript_artifacts.content' "$RESULTS_FILE" > "$transcript_content_path"
+              transcript_path="$transcript_content_path"
             fi
           fi
           if [ -z "$transcript_path" ]; then

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -857,25 +857,25 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_transcript' ) ) {
             return array( 'session_id' => $session_id, 'error' => 'Transcript directory could not be created' );
         }
 
-        $path = rtrim( $transcript_dir, '/' ) . '/job-' . $job_id . '-transcript.json';
-        file_put_contents(
-            $path,
-            wp_json_encode(
-                array(
-                    'job_id'     => $job_id,
-                    'session_id' => $session_id,
-                    'provider'   => $session['provider'] ?? null,
-                    'model'      => $session['model'] ?? null,
-                    'metadata'   => is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array(),
-                    'messages'   => is_array( $session['messages'] ?? null ) ? $session['messages'] : array(),
-                ),
-                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
-            )
+        $path    = rtrim( $transcript_dir, '/' ) . '/job-' . $job_id . '-transcript.json';
+        $content = wp_json_encode(
+            array(
+                'job_id'     => $job_id,
+                'session_id' => $session_id,
+                'provider'   => $session['provider'] ?? null,
+                'model'      => $session['model'] ?? null,
+                'metadata'   => is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array(),
+                'messages'   => is_array( $session['messages'] ?? null ) ? $session['messages'] : array(),
+            ),
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
         );
+
+        file_put_contents( $path, $content );
 
         return array(
             'session_id' => $session_id,
             'json'       => $path,
+            'content'    => $content,
         );
     }
 }


### PR DESCRIPTION
## Summary
- Includes transcript JSON content in the agent workload metadata so host-side CI can materialize it when Playground-created files are not synced back through mounts.
- Adds a workflow fallback that writes the transcript content from the results JSON before uploading the artifact.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\"); puts \"yaml ok\"'`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed why Playground-created transcript files were not visible to the host runner and drafted the generic metadata materialization fallback; Chris reviewed and triggered PR creation.