### PR TITLE
Allow bundled prompts in agent CI

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -25,7 +25,7 @@ name: Data Machine Agent CI (reusable)
         required: true
       prompt:
         type: string
-        required: true
+        default: ""
       provider:
         type: string
         default: openai

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -999,9 +999,6 @@ foreach ( array( 'bundle_path' => $bundle_path, 'agent_slug' => $agent_slug, 'fl
         return homeboy_datamachine_agent_result( array( $label . '_present' => 0 ), $metadata, $label . ' is required' );
     }
 }
-if ( '' === $prompt ) {
-    return homeboy_datamachine_agent_result( array( 'prompt_present' => 0 ), $metadata, 'prompt or prompt_env is required' );
-}
 if ( ! $metadata['bundle_exists'] || ! is_file( $bundle_path . '/manifest.json' ) ) {
     return homeboy_datamachine_agent_result( array( 'bundle_exists' => 0 ), $metadata, 'Agent bundle directory missing or incomplete' );
 }

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -52,6 +52,34 @@ namespace {
 
     require __DIR__ . '/datamachine-agent-workload.php';
 
+    $flow_prompt_queue = homeboy_datamachine_agent_run_prompt_queue(
+        array(
+            'prompt_queue' => array(
+                array( 'prompt' => 'Use the bundled flow prompt.' ),
+            ),
+        ),
+        ''
+    );
+
+    if ( 'Use the bundled flow prompt.' !== ( $flow_prompt_queue[0]['prompt'] ?? '' ) ) {
+        fwrite( STDERR, "Expected an empty run prompt to preserve the bundled flow prompt.\n" );
+        exit( 1 );
+    }
+
+    $combined_prompt_queue = homeboy_datamachine_agent_run_prompt_queue(
+        array(
+            'prompt_queue' => array(
+                array( 'prompt' => 'Use the bundled flow prompt.' ),
+            ),
+        ),
+        'Apply this run context.'
+    );
+
+    if ( "Use the bundled flow prompt.\n\nRun context:\nApply this run context." !== ( $combined_prompt_queue[0]['prompt'] ?? '' ) ) {
+        fwrite( STDERR, "Expected a run prompt to be appended to the bundled flow prompt.\n" );
+        exit( 1 );
+    }
+
     $config = array( 'tool_results_key' => 'github_tool_results' );
 
     $write_without_pr = array(


### PR DESCRIPTION
## Summary
- Makes the reusable Data Machine agent CI prompt input optional so callers can rely on bundled flow prompts.
- Removes the workload guard that rejected empty run prompts before imported flow prompt queues could be used.
- Adds smoke coverage for preserving bundled prompts and appending optional run context.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the reusable workflow prompt startup failure, drafted the minimal HE prompt fallback fix, and ran focused smoke validation.