### PR TITLE
Diagnose WordPress page profile bottlenecks

### DIFF
--- a/wordpress/lib/page-profiler.js
+++ b/wordpress/lib/page-profiler.js
@@ -13,6 +13,16 @@ const DEFAULT_RESOURCE_INCLUDE = [
 	'/wp-includes/',
 ];
 
+const DEFAULT_DIAGNOSIS_THRESHOLDS = {
+	readyMs: 1000,
+	networkIdleGapMs: 2000,
+	requestCount: 100,
+	lateRequestCount: 5,
+	restAfterReadyCount: 1,
+	assetBytes: 500000,
+	failedRequestCount: 1,
+};
+
 function round(value) {
 	return typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : 0;
 }
@@ -115,6 +125,28 @@ function classifyResourceUrl(url) {
 	return 'other';
 }
 
+function resourceFamily(url) {
+	const normalized = normalizeUrl(url, { lowercasePath: false }).split('?', 1)[0];
+	const parts = normalized.split('/').filter(Boolean);
+	const wpIncludes = parts.indexOf('wp-includes');
+	if (wpIncludes >= 0 && parts[wpIncludes + 1] === 'js' && parts[wpIncludes + 2] === 'dist' && parts[wpIncludes + 3]) {
+		return `/wp-includes/js/dist/${parts[wpIncludes + 3].replace(/\.min\.js$/, '.js')}`;
+	}
+	const wpContent = parts.indexOf('wp-content');
+	if (wpContent >= 0 && parts[wpContent + 1] && parts[wpContent + 2]) {
+		return `/wp-content/${parts[wpContent + 1]}/${parts[wpContent + 2]}`;
+	}
+	const wpAdmin = parts.indexOf('wp-admin');
+	if (wpAdmin >= 0 && parts[wpAdmin + 1]) {
+		return `/wp-admin/${parts[wpAdmin + 1]}`;
+	}
+	return normalized || 'unknown';
+}
+
+function browserMetricName(name) {
+	return String(name).trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '') || 'mark';
+}
+
 async function collectBrowserResourceTimings(page, options = {}) {
 	if (!page || typeof page.evaluate !== 'function') {
 		throw new TypeError('page must provide evaluate()');
@@ -196,6 +228,7 @@ function summarizeResourceTimings(entries) {
 		kind: entry.kind || classifyResourceUrl(entry.name || entry.url),
 		initiatorType: entry.initiatorType,
 		startMs: round(entry.startTime),
+		responseEndMs: round(entry.responseEnd),
 		durationMs: round(entry.duration),
 		ttfbMs: round(entry.ttfbMs),
 		transferSize: entry.transferSize || 0,
@@ -214,6 +247,144 @@ function summarizeResourceTimings(entries) {
 		restCount: countsByKind.rest || 0,
 		slowest: [...resources].sort((a, b) => b.durationMs - a.durationMs).slice(0, 20),
 		resources,
+	};
+}
+
+function addFinding(findings, severity, code, message, data = {}) {
+	findings.push({ severity, code, message, ...data });
+}
+
+function aggregateResourcesByKind(resources) {
+	const groups = {};
+	for (const resource of resources) {
+		const kind = resource.kind || 'other';
+		groups[kind] ||= { kind, count: 0, transferSize: 0, encodedBodySize: 0, decodedBodySize: 0 };
+		groups[kind].count += 1;
+		groups[kind].transferSize += resource.transferSize || 0;
+		groups[kind].encodedBodySize += resource.encodedBodySize || 0;
+		groups[kind].decodedBodySize += resource.decodedBodySize || 0;
+	}
+	return Object.values(groups).sort((a, b) => b.transferSize - a.transferSize);
+}
+
+function aggregateResourcesByFamily(resources) {
+	const groups = new Map();
+	for (const resource of resources) {
+		const family = resourceFamily(resource.url);
+		if (!groups.has(family)) {
+			groups.set(family, { family, kind: resource.kind || 'other', count: 0, transferSize: 0, encodedBodySize: 0, decodedBodySize: 0 });
+		}
+		const group = groups.get(family);
+		group.count += 1;
+		group.transferSize += resource.transferSize || 0;
+		group.encodedBodySize += resource.encodedBodySize || 0;
+		group.decodedBodySize += resource.decodedBodySize || 0;
+	}
+	return [...groups.values()].sort((a, b) => b.transferSize - a.transferSize);
+}
+
+function normalizeNetworkRequest(request) {
+	return {
+		url: normalizeUrl(request?.url || ''),
+		method: request?.method,
+		resourceType: request?.resource_type || request?.resourceType,
+		status: request?.status || 0,
+		failed: Boolean(request?.failed),
+		failure: request?.failure,
+		durationMs: round(request?.duration_ms ?? request?.durationMs),
+	};
+}
+
+function diagnoseWordPressPageProfile(profile, options = {}) {
+	if (!profile || typeof profile !== 'object') {
+		throw new TypeError('diagnoseWordPressPageProfile requires a page profile object');
+	}
+	const thresholds = { ...DEFAULT_DIAGNOSIS_THRESHOLDS, ...(options.thresholds || {}) };
+	const resources = Array.isArray(profile.resources?.resources) ? profile.resources.resources : [];
+	const browserMetrics = options.browserMetrics || {};
+	const networkRequests = Array.isArray(options.networkRequests) ? options.networkRequests.map(normalizeNetworkRequest) : [];
+	const readyMetric = browserMetrics[`${browserMetricName(profile.id)}_ready_ms`];
+	const readyAbsoluteMs = typeof readyMetric === 'number' ? readyMetric : undefined;
+	const networkIdleMs = typeof browserMetrics.browser_network_idle_ms === 'number' ? browserMetrics.browser_network_idle_ms : undefined;
+	const networkIdleAfterReadyMs = readyAbsoluteMs !== undefined && networkIdleMs !== undefined
+		? Math.max(0, round(networkIdleMs - readyAbsoluteMs))
+		: undefined;
+	const findings = [];
+	const lateResources = resources
+		.filter((resource) => typeof resource.startMs === 'number' && resource.startMs > profile.readyMs)
+		.sort((a, b) => b.startMs - a.startMs);
+	const restAfterReady = lateResources.filter((resource) => resource.kind === 'rest');
+	const failedRequests = networkRequests.filter((request) => request.failed || request.status >= 400);
+	const failedRequestCount = networkRequests.length > 0
+		? failedRequests.length
+		: round(browserMetrics.browser_failed_request_count);
+	const totalRequestCount = networkRequests.length || round(browserMetrics.browser_request_count || resources.length);
+	const byKind = aggregateResourcesByKind(resources);
+	const byFamily = aggregateResourcesByFamily(resources);
+	const heavyFamilies = byFamily.filter((group) => group.transferSize >= thresholds.assetBytes).slice(0, 10);
+
+	if (profile.readyMs >= thresholds.readyMs) {
+		addFinding(findings, 'info', 'slow-ready', `Page reached readiness in ${round(profile.readyMs)}ms`, {
+			readyMs: round(profile.readyMs),
+		});
+	}
+	if (networkIdleAfterReadyMs !== undefined && networkIdleAfterReadyMs >= thresholds.networkIdleGapMs) {
+		addFinding(findings, 'warn', 'network-active-after-ready', `Network stayed active ${networkIdleAfterReadyMs}ms after page readiness`, {
+			networkIdleAfterReadyMs,
+			readyMetricMs: round(readyAbsoluteMs),
+			networkIdleMs: round(networkIdleMs),
+		});
+	}
+	if (totalRequestCount >= thresholds.requestCount) {
+		addFinding(findings, 'info', 'high-request-count', `Page loaded ${totalRequestCount} tracked browser requests/resources`, {
+			requestCount: totalRequestCount,
+		});
+	}
+	if (failedRequestCount >= thresholds.failedRequestCount) {
+		addFinding(findings, 'warn', 'failed-requests', `Page had ${failedRequestCount} failed/error browser requests`, {
+			failedRequestCount,
+			failedRequests: failedRequests.slice(0, 10),
+		});
+	}
+	if (lateResources.length >= thresholds.lateRequestCount) {
+		addFinding(findings, 'info', 'late-resources', `${lateResources.length} resources started after page readiness`, {
+			lateRequestCount: lateResources.length,
+			latestResources: lateResources.slice(0, 10),
+		});
+	}
+	if (restAfterReady.length >= thresholds.restAfterReadyCount) {
+		addFinding(findings, 'warn', 'rest-after-ready', `${restAfterReady.length} REST requests started after page readiness`, {
+			restAfterReadyCount: restAfterReady.length,
+			restAfterReady: restAfterReady.slice(0, 10),
+		});
+	}
+	if (heavyFamilies.length > 0) {
+		addFinding(findings, 'info', 'heavy-asset-families', `${heavyFamilies.length} asset families exceeded ${thresholds.assetBytes} transfer bytes`, {
+			heavyFamilies,
+		});
+	}
+
+	return {
+		thresholds,
+		summary: {
+			readyMs: round(profile.readyMs),
+			networkIdleAfterReadyMs,
+			requestCount: totalRequestCount,
+			failedRequestCount,
+			lateRequestCount: lateResources.length,
+			restAfterReadyCount: restAfterReady.length,
+			resourceCount: resources.length,
+			restCount: profile.resources?.restCount || 0,
+		},
+		assets: {
+			byKind,
+			byFamily: byFamily.slice(0, 20),
+			heavyFamilies,
+		},
+		lateResources: lateResources.slice(0, 20),
+		restAfterReady: restAfterReady.slice(0, 20),
+		failedRequests: failedRequests.slice(0, 20),
+		findings,
 	};
 }
 
@@ -250,8 +421,7 @@ async function profileWordPressPage(input) {
 		browserTimings: resources,
 		wordpressProfilerRows,
 	});
-
-	return {
+	const profile = {
 		id: spec.id,
 		label: spec.label,
 		url,
@@ -261,6 +431,8 @@ async function profileWordPressPage(input) {
 		resources: resourceSummary,
 		correlation,
 	};
+
+	return { ...profile, diagnosis: diagnoseWordPressPageProfile(profile) };
 }
 
 async function profileWordPressPages(input) {
@@ -291,8 +463,10 @@ module.exports = {
 	DEFAULT_RESOURCE_INCLUDE,
 	classifyResourceUrl,
 	collectBrowserResourceTimings,
+	diagnoseWordPressPageProfile,
 	normalizePageManifest,
 	normalizePageSpec,
+	resourceFamily,
 	profileWordPressPage,
 	profileWordPressPages,
 	resolveWordPressUrl,

--- a/wordpress/tests/page-profiler-smoke.js
+++ b/wordpress/tests/page-profiler-smoke.js
@@ -12,9 +12,11 @@ const assert = require('node:assert/strict');
  */
 const {
 	classifyResourceUrl,
+	diagnoseWordPressPageProfile,
 	normalizePageManifest,
 	profileWordPressPage,
 	profileWordPressPages,
+	resourceFamily,
 	resolveWordPressUrl,
 	summarizeResourceTimings,
 } = require('../lib/page-profiler');
@@ -67,6 +69,8 @@ assert.equal(resolveWordPressUrl('https://example.test/site', '/wp-admin/index.p
 assert.equal(classifyResourceUrl('https://example.test/wp-json/wp/v2/posts?context=edit'), 'rest');
 assert.equal(classifyResourceUrl('https://example.test/wp-admin/load-styles.php'), 'admin');
 assert.equal(classifyResourceUrl('https://example.test/wp-content/themes/theme/style.css'), 'content-asset');
+assert.equal(resourceFamily('https://example.test/wp-includes/js/dist/block-editor.min.js?ver=1'), '/wp-includes/js/dist/block-editor.js');
+assert.equal(resourceFamily('https://example.test/wp-content/plugins/data-machine/assets/admin.js?ver=1'), '/wp-content/plugins/data-machine');
 
 const manifest = normalizePageManifest({
 	pages: [
@@ -91,7 +95,9 @@ const resources = [
 		requestStart: 30,
 		responseStart: 140,
 		responseEnd: 200,
-		transferSize: 1000,
+		transferSize: 600000,
+		encodedBodySize: 580000,
+		decodedBodySize: 580000,
 	},
 	{
 		name: 'https://example.test/wp-content/themes/twentytwentyfive/style.css',
@@ -101,6 +107,7 @@ const resources = [
 		requestStart: 6,
 		responseStart: 10,
 		responseEnd: 25,
+		transferSize: 2000,
 	},
 	{
 		name: 'https://example.test/favicon.ico',
@@ -108,11 +115,48 @@ const resources = [
 		startTime: 8,
 		duration: 5,
 	},
+	{
+		name: 'https://example.test/wp-json/wp/v2/settings',
+		initiatorType: 'fetch',
+		startTime: 1300,
+		duration: 90,
+		requestStart: 1310,
+		responseStart: 1360,
+		responseEnd: 1390,
+		transferSize: 3000,
+	},
 ];
 
 const summary = summarizeResourceTimings(resources.map((entry) => ({ ...entry, kind: classifyResourceUrl(entry.name) })));
-assert.equal(summary.count, 3);
-assert.equal(summary.countsByKind.rest, 1);
+	assert.equal(summary.count, 4);
+	assert.equal(summary.countsByKind.rest, 2);
+	assert.equal(summary.resources[0].responseEndMs, 200);
+
+	const diagnosis = diagnoseWordPressPageProfile(
+		{
+			id: 'admin-dashboard',
+			readyMs: 1200,
+			resources: summary,
+		},
+		{
+			browserMetrics: {
+				admin_dashboard_ready_ms: 1500,
+				browser_network_idle_ms: 4700,
+				browser_request_count: 120,
+				browser_failed_request_count: 1,
+			},
+			networkRequests: [
+				{ url: 'https://example.test/wp-json/wp/v2/fail', method: 'GET', status: 500, failed: true, duration_ms: 120 },
+			],
+		}
+	);
+	assert.equal(diagnosis.summary.networkIdleAfterReadyMs, 3200);
+	assert.equal(diagnosis.summary.lateRequestCount, 1);
+	assert.equal(diagnosis.summary.restAfterReadyCount, 1);
+	assert.equal(diagnosis.summary.failedRequestCount, 1);
+	assert.equal(diagnosis.assets.heavyFamilies[0].family, '/wp-json/wp/v2/posts');
+	assert.equal(diagnosis.findings.some((finding) => finding.code === 'network-active-after-ready'), true);
+	assert.equal(diagnosis.findings.some((finding) => finding.code === 'rest-after-ready'), true);
 
 async function main() {
 	const page = new FakePage(resources);
@@ -128,14 +172,14 @@ async function main() {
 
 	assert.equal(result.id, 'site-editor');
 	assert.equal(result.status, 200);
-	assert.equal(result.resources.restCount, 1);
+	assert.equal(result.resources.restCount, 2);
 	assert.equal(result.correlation.correlated.length, 1);
 	assert.equal(page.calls.some((call) => call[0] === 'frame.waitForSelector' && call[1] === '[data-block]'), true);
 
 	const multiPage = new FakePage(resources);
 	const multi = await profileWordPressPages({ page: multiPage, baseUrl: 'https://example.test', manifest });
 	assert.equal(multi.pages.length, 2);
-	assert.equal(multi.topRestWaterfalls[0].restCount, 1);
+	assert.equal(multi.topRestWaterfalls[0].restCount, 2);
 
 	assert.throws(() => normalizePageManifest({ pages: [{ id: 'bad' }] }), /requires url or path/);
 


### PR DESCRIPTION
## Summary
- Add generic page-profile diagnosis for slow readiness, network-active gaps, high request counts, failed requests, late resources, REST-after-ready bursts, and heavy asset families.
- Group assets by generic WordPress resource families such as `wp-includes/js/dist/*`, plugin/theme roots, and admin loaders.
- Cover the diagnosis behavior in the WordPress page profiler smoke test.

## Verification
- `node wordpress/tests/page-profiler-smoke.js`
- `node --check wordpress/lib/page-profiler.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic diagnosis helper and smoke coverage; Chris remains responsible for review and merge.