### PR TITLE
Resolve validation dependency default branches

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -33,7 +33,7 @@ name: Data Machine Agent CI (reusable)
         type: string
         default: gpt-5.5
       validation_dependencies:
-        description: Comma-separated OWNER/REPO@REF entries checked out under .ci/<repo>.
+        description: Comma-separated OWNER/REPO or OWNER/REPO@REF entries checked out under .ci/<repo>. Entries without @REF use the repository default branch.
         type: string
         default: ""
       playground_wordpress:
@@ -230,15 +230,28 @@ jobs:
           for raw_entry in "${entries[@]}"; do
             entry="$(printf '%s' "$raw_entry" | xargs)"
             [ -n "$entry" ] || continue
-            repo_ref="${entry%@*}"
-            ref="${entry##*@}"
-            if [ "$repo_ref" = "$entry" ] || [ -z "$repo_ref" ] || [ -z "$ref" ]; then
-              echo "validation_dependencies entries must be OWNER/REPO@REF: $entry" >&2
+            repo_ref="$entry"
+            ref=""
+            if [[ "$entry" == *@* ]]; then
+              repo_ref="${entry%@*}"
+              ref="${entry##*@}"
+            fi
+            if [ -z "$repo_ref" ] || [[ "$repo_ref" != */* ]]; then
+              echo "validation_dependencies entries must be OWNER/REPO or OWNER/REPO@REF: $entry" >&2
               exit 1
+            fi
+            if [[ "$entry" == *@* && -z "$ref" ]]; then
+              echo "validation_dependencies entries must include a non-empty ref after @: $entry" >&2
+              exit 1
+            fi
+            if [ -z "$ref" ]; then
+              ref="$(gh repo view "$repo_ref" --json defaultBranchRef --jq '.defaultBranchRef.name')"
+              [ -n "$ref" ] || { echo "Could not resolve default branch for validation dependency: $repo_ref" >&2; exit 1; }
             fi
             repo_name="${repo_ref#*/}"
             target=".ci/$repo_name"
             rm -rf "$target"
+            echo "Checking out validation dependency $repo_ref@$ref into $target"
             gh repo clone "$repo_ref" "$target" -- --depth=1
             git -C "$target" fetch --depth=1 origin "$ref"
             git -C "$target" checkout --quiet FETCH_HEAD


### PR DESCRIPTION
## Summary
- Allows reusable agent CI callers to specify validation dependencies as `OWNER/REPO` without an explicit ref.
- Resolves unpinned dependencies to the repository default branch with `gh repo view`.
- Keeps existing `OWNER/REPO@REF` pinning behavior for callers that need exact refs.

## Context
`wp-site-generator` currently failed while checking out `WordPress/ai-provider-for-openai@main`, because that repository's default branch is `trunk`. The reusable HE workflow should own default-branch resolution so consumers do not need to hardcode every dependency's branch name.

Failing run: https://github.com/chubes4/wp-site-generator/actions/runs/25645281816

## Testing
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); puts "yaml ok"'`
- `bash -n <checkout validation dependencies run block>`
- `gh repo view WordPress/ai-provider-for-openai --json defaultBranchRef --jq '.defaultBranchRef.name'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the downstream validation dependency ref failure, drafted the reusable workflow default-branch resolution, and ran focused validation.