### PR TITLE
fix: reuse existing fallback agent pull requests

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -491,6 +491,66 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_job_artifacts' ) ) {
 }
 
 if ( ! function_exists( 'homeboy_datamachine_agent_open_fallback_pr' ) ) {
+    function homeboy_datamachine_agent_record_pr_tool_result( array $engine_data, array $config, array $tool_result ): array {
+        $tool_results_key = homeboy_datamachine_agent_scalar( $config, 'tool_results_key', 'github_tool_results' );
+        $engine_key       = homeboy_datamachine_agent_scalar( $config, 'engine_key' );
+        if ( '' !== $engine_key ) {
+            if ( ! isset( $engine_data[ $engine_key ] ) || ! is_array( $engine_data[ $engine_key ] ) ) {
+                $engine_data[ $engine_key ] = array();
+            }
+            if ( ! isset( $engine_data[ $engine_key ][ $tool_results_key ] ) || ! is_array( $engine_data[ $engine_key ][ $tool_results_key ] ) ) {
+                $engine_data[ $engine_key ][ $tool_results_key ] = array();
+            }
+            $engine_data[ $engine_key ][ $tool_results_key ][] = $tool_result;
+            return $engine_data;
+        }
+
+        if ( ! isset( $engine_data[ $tool_results_key ] ) || ! is_array( $engine_data[ $tool_results_key ] ) ) {
+            $engine_data[ $tool_results_key ] = array();
+        }
+        $engine_data[ $tool_results_key ][] = $tool_result;
+
+        return $engine_data;
+    }
+
+    function homeboy_datamachine_agent_existing_fallback_pr( string $repo, string $head, string $base ): array {
+        $ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/list-github-pulls' ) : null;
+        if ( ! $ability ) {
+            return array();
+        }
+
+        $result = $ability->execute(
+            array(
+                'repo'     => $repo,
+                'state'    => 'open',
+                'per_page' => 100,
+            )
+        );
+        if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
+            return array();
+        }
+        if ( ! is_array( $result ) || empty( $result['success'] ) || ! is_array( $result['pulls'] ?? null ) ) {
+            return array();
+        }
+
+        foreach ( $result['pulls'] as $pull ) {
+            if ( ! is_array( $pull ) ) {
+                continue;
+            }
+            if ( $head !== (string) ( $pull['head'] ?? $pull['head_ref'] ?? '' ) ) {
+                continue;
+            }
+            if ( '' !== $base && $base !== (string) ( $pull['base'] ?? $pull['base_ref'] ?? '' ) ) {
+                continue;
+            }
+            if ( '' !== homeboy_datamachine_agent_first_url( $pull ) ) {
+                return $pull;
+            }
+        }
+
+        return array();
+    }
+
     function homeboy_datamachine_agent_open_fallback_pr( array $engine_data, array $config ): array {
         $fallback = is_array( $config['fallback_pull_request'] ?? null ) ? $config['fallback_pull_request'] : array();
         if ( empty( $fallback ) ) {
@@ -504,6 +564,34 @@ if ( ! function_exists( 'homeboy_datamachine_agent_open_fallback_pr' ) ) {
             return array( 'opened' => false, 'error' => 'fallback_pull_request requires repo, title, and head.' );
         }
 
+        $base        = homeboy_datamachine_agent_scalar( $fallback, 'base' );
+        $existing_pr = homeboy_datamachine_agent_existing_fallback_pr( $repo, $head, $base );
+        if ( ! empty( $existing_pr ) ) {
+            $tool_result = array(
+                'tool_name' => 'create_github_pull_request',
+                'success'   => true,
+                'repo'      => $repo,
+                'head'      => $head,
+                'base'      => $base,
+                'url'       => homeboy_datamachine_agent_first_url( $existing_pr ),
+                'result'    => array(
+                    'success'      => true,
+                    'pull_request' => $existing_pr,
+                    'pull_number'  => (int) ( $existing_pr['number'] ?? 0 ),
+                    'html_url'     => homeboy_datamachine_agent_first_url( $existing_pr ),
+                    'message'      => sprintf( 'Reused existing pull request #%d in %s.', (int) ( $existing_pr['number'] ?? 0 ), $repo ),
+                ),
+            );
+
+            return array(
+                'opened'      => true,
+                'reused'      => true,
+                'result'      => $tool_result['result'],
+                'input'       => array( 'repo' => $repo, 'title' => $title, 'head' => $head, 'base' => $base ),
+                'engine_data' => homeboy_datamachine_agent_record_pr_tool_result( $engine_data, $config, $tool_result ),
+            );
+        }
+
         $ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/create-github-pull-request' ) : null;
         if ( ! $ability ) {
             return array( 'opened' => false, 'error' => 'datamachine/create-github-pull-request ability is not available.' );
@@ -513,7 +601,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_open_fallback_pr' ) ) {
             'repo'                  => $repo,
             'title'                 => $title,
             'head'                  => $head,
-            'base'                  => homeboy_datamachine_agent_scalar( $fallback, 'base' ),
+            'base'                  => $base,
             'body'                  => (string) ( $fallback['body'] ?? '' ),
             'draft'                 => ! empty( $fallback['draft'] ),
             'maintainer_can_modify' => array_key_exists( 'maintainer_can_modify', $fallback ) ? (bool) $fallback['maintainer_can_modify'] : true,
@@ -537,22 +625,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_open_fallback_pr' ) ) {
             'result'    => $result,
         );
 
-        $tool_results_key = homeboy_datamachine_agent_scalar( $config, 'tool_results_key', 'github_tool_results' );
-        $engine_key       = homeboy_datamachine_agent_scalar( $config, 'engine_key' );
-        if ( '' !== $engine_key ) {
-            if ( ! isset( $engine_data[ $engine_key ] ) || ! is_array( $engine_data[ $engine_key ] ) ) {
-                $engine_data[ $engine_key ] = array();
-            }
-            if ( ! isset( $engine_data[ $engine_key ][ $tool_results_key ] ) || ! is_array( $engine_data[ $engine_key ][ $tool_results_key ] ) ) {
-                $engine_data[ $engine_key ][ $tool_results_key ] = array();
-            }
-            $engine_data[ $engine_key ][ $tool_results_key ][] = $tool_result;
-        } else {
-            if ( ! isset( $engine_data[ $tool_results_key ] ) || ! is_array( $engine_data[ $tool_results_key ] ) ) {
-                $engine_data[ $tool_results_key ] = array();
-            }
-            $engine_data[ $tool_results_key ][] = $tool_result;
-        }
+        $engine_data = homeboy_datamachine_agent_record_pr_tool_result( $engine_data, $config, $tool_result );
 
         return array( 'opened' => true, 'result' => $result, 'input' => $input, 'engine_data' => $engine_data );
     }

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -40,6 +40,30 @@ namespace {
         }
     }
 
+    if ( ! function_exists( 'is_wp_error' ) ) {
+        function is_wp_error( $value ): bool {
+            return false;
+        }
+    }
+
+    class Homeboy_Datamachine_Agent_Fake_Ability {
+        private $callback;
+
+        public function __construct( callable $callback ) {
+            $this->callback = $callback;
+        }
+
+        public function execute( array $input ): array {
+            return ( $this->callback )( $input );
+        }
+    }
+
+    if ( ! function_exists( 'wp_get_ability' ) ) {
+        function wp_get_ability( string $name ) {
+            return $GLOBALS['homeboy_datamachine_agent_fake_abilities'][ $name ] ?? null;
+        }
+    }
+
     putenv(
         'HOMEBOY_DATAMACHINE_AGENT_CONFIG=' . wp_json_encode(
             array(
@@ -168,6 +192,48 @@ namespace {
 
     if ( 'agent/recorded-branch' !== homeboy_datamachine_agent_pr_head_branch( $merged_recorded_results, $config ) ) {
         fwrite( STDERR, "Expected current-run recorded tool results to preserve the PR head branch.\n" );
+        exit( 1 );
+    }
+
+    $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
+        'datamachine/list-github-pulls' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            fn() => array(
+                'success' => true,
+                'pulls'   => array(
+                    array(
+                        'number'   => 321,
+                        'html_url' => 'https://github.com/owner/repo/pull/321',
+                        'head'     => 'agent/existing-pr-branch',
+                        'base'     => 'main',
+                    ),
+                ),
+            )
+        ),
+        'datamachine/create-github-pull-request' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            function (): array {
+                fwrite( STDERR, "Did not expect fallback PR creation when an existing PR matches the head branch.\n" );
+                exit( 1 );
+            }
+        ),
+    );
+    $existing_fallback = homeboy_datamachine_agent_open_fallback_pr(
+        array(),
+        array(
+            'tool_results_key'      => 'github_tool_results',
+            'fallback_pull_request' => array(
+                'repo'  => 'owner/repo',
+                'title' => 'Fallback PR',
+                'head'  => 'agent/existing-pr-branch',
+                'base'  => 'main',
+            ),
+        )
+    );
+    if ( empty( $existing_fallback['opened'] ) || empty( $existing_fallback['reused'] ) ) {
+        fwrite( STDERR, "Expected fallback PR handling to reuse an existing open PR.\n" );
+        exit( 1 );
+    }
+    if ( ! homeboy_datamachine_agent_pr_opened( $existing_fallback['engine_data'] ?? array(), $config ) ) {
+        fwrite( STDERR, "Expected reused fallback PR to be recorded as pr_opened.\n" );
         exit( 1 );
     }
 


### PR DESCRIPTION
## Summary
- Reuse an already-open pull request when fallback PR handling runs against a generated branch that already has a PR.
- Record the reused PR as a successful `create_github_pull_request` tool result so `success_requires_pr` and PR artifact attachment classify the run correctly.
- Add smoke coverage for fallback PR reuse without calling PR creation again.

## Testing
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`

## Notes
- `composer lint` in `wordpress/` exits with `ERROR: You must supply at least one file or directory to process` because the package script is bare `phpcs`.
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fallback-existing-pr --extension wordpress` reports existing broad repository findings unrelated to this patch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the repeated Docs Agent fallback PR failure, drafted the idempotent fallback handling and smoke coverage, and ran focused validation. Chris remains responsible for review and merge.