### PR TITLE
Document Playground agent CI sandbox

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,6 +3,8 @@
 `datamachine-agent-ci.yml` wraps the common GitHub Actions shape for running a
 Data Machine agent bundle in WordPress Playground. Consumers provide bundle and
 flow identifiers, dependency refs, a prompt, and optional output projections.
+See [`wordpress/docs/AGENT_CI_PLAYGROUND.md`](../../wordpress/docs/AGENT_CI_PLAYGROUND.md)
+for the full Playground sandbox model, runtime contract, and evaluation notes.
 
 The reusable workflow exposes `engine_data_json` as one combined JSON object.
 Dynamic per-key `workflow_call` outputs are not possible in GitHub Actions, so

--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -139,6 +139,10 @@ Numeric metrics are aggregated across measured iterations with the same
 mean/p50/p95/p99/min/max suffixes used by PHP bench files. Artifacts and metadata
 are carried into the Homeboy BenchResults scenario envelope.
 
+The same workload contract powers Data Machine agent CI in Playground. See
+[`../../wordpress/docs/AGENT_CI_PLAYGROUND.md`](../../wordpress/docs/AGENT_CI_PLAYGROUND.md)
+for the dedicated agent sandbox guide.
+
 Example: drive a plugin's pipeline through an Abilities API entry point.
 
 ```json

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -457,5 +457,6 @@ at the root to grandfather pre-existing findings (see PHPStan above).
 ## Further reading
 
 - [`docs/TESTING.md`](docs/TESTING.md) — canonical test/lint/bench reference, debug markers, sanctioned suppressions, browser-target schema, known gaps
+- [`docs/AGENT_CI_PLAYGROUND.md`](docs/AGENT_CI_PLAYGROUND.md) — running Data Machine agents in WordPress Playground CI and why Playground is the agent sandbox
 - [`docs/PLAYGROUND_DROPIN.md`](docs/PLAYGROUND_DROPIN.md) — `db.php` coexistence with Playground SQLite
 - [`docs/CHANGELOG.md`](docs/CHANGELOG.md) — release history

--- a/wordpress/docs/AGENT_CI_PLAYGROUND.md
+++ b/wordpress/docs/AGENT_CI_PLAYGROUND.md
@@ -1,0 +1,126 @@
+# Data Machine Agent CI in WordPress Playground
+
+Homeboy can run a Data Machine agent bundle inside WordPress Playground from
+GitHub Actions. The reusable workflow gives agent repos one CI entry point for
+booting WordPress, loading dependencies, running the agent, collecting
+transcripts, and asserting the expected outcome.
+
+## Why Playground is the sandbox
+
+WordPress Playground gives agent CI a disposable WordPress runtime instead of a
+long-lived server, local database, or per-repo test harness. Each run starts from
+a declared environment and exits with structured Homeboy artifacts.
+
+```text
+GitHub Actions workflow
+        |
+        v
+Homeboy WordPress extension
+        |
+        v
+WordPress Playground
+  PHP-WASM + embedded SQLite + mounted plugins
+        |
+        v
+Data Machine agent runtime
+  abilities, WP-CLI, GitHub tools, transcripts, metrics
+```
+
+That shape is useful for agents because the model still interacts with real
+WordPress APIs while the host stays small and repeatable:
+
+- No host MySQL, local WordPress install, or component-owned PHPUnit bootstrap.
+- Runtime dependencies are mounted into the same Playground site as the bundle.
+- Blueprints and runner config declare the initial WordPress state.
+- Workload steps can call PHP files, WP-CLI commands, and registered abilities.
+- Homeboy captures metrics, metadata, artifacts, transcripts, and status checks.
+- The site is disposable, so destructive WordPress-side state changes disappear
+  with the CI job.
+
+## Reusable workflow
+
+Use `.github/workflows/datamachine-agent-ci.yml` from a consumer workflow:
+
+```yaml
+jobs:
+  run-static-site-agent:
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@main
+    with:
+      bundle_path: bundles/static-site-agent
+      agent_slug: static-site-agent
+      pipeline_slug: static-site-pipeline
+      flow_slug: static-site-manual-flow
+      target_repo: chubes4/wp-site-generator
+      prompt: ${{ inputs.prompt }}
+      validation_dependencies: Automattic/agents-api@main,Extra-Chill/data-machine@main,Extra-Chill/data-machine-code@main,WordPress/ai-provider-for-openai@main
+      success_requires_pr: true
+      engine_data_outputs: '{"static_site_pr_url":"metadata.engine_data.static_site_agent.pr_url"}'
+      comment_pr_summary: true
+      transcript_artifact_name: static-site-agent-transcript-${{ github.run_id }}
+    secrets: inherit
+```
+
+The workflow checks out `homeboy-extensions`, installs the WordPress extension
+toolchain, mounts validation dependencies under `.ci/<repo>`, builds a runner
+config, and calls `wordpress/scripts/agent/run-datamachine-agent.sh`.
+
+## Runtime contract
+
+The runner converts the agent config into a single Playground bench workload:
+
+- `component_path` points at the consumer checkout.
+- `bundle_path` points at the Data Machine agent bundle.
+- `validation_dependencies` are mounted as local plugins or support checkouts.
+- `playground_file_mounts` adds fixture files such as the CI driver plugin.
+- `bench_env` forwards credentials and the serialized runner config into
+  PHP-WASM.
+- `transcript_dir` controls where exported conversation artifacts are written.
+- `success_requires_pr` can require the agent to open or reuse a pull request.
+
+Inside Playground, `datamachine-agent-workload.php` installs the bundle, configures
+the provider, starts the Data Machine flow, drains queued work, records tool
+results, exports the transcript, and writes a Homeboy scenario result.
+
+## Outputs and assertions
+
+The reusable workflow exposes stable outputs:
+
+- `job_status` from the workload metadata.
+- `transcript_json` path when transcript export is enabled.
+- `transcript_summary` path when a summary artifact is available.
+- `engine_data_json`, a caller-declared projection of agent engine data.
+
+Use `success_requires_pr: true` when the task is only successful if the agent
+opens or reuses a pull request. Use `engine_data_outputs` for additional
+consumer-specific assertions such as a generated PR URL, published artifact path,
+or scenario result field.
+
+## Why this can support agent evaluation
+
+The same contract is close to an agent evaluation environment:
+
+- Initial state: Playground blueprint, mounted dependencies, bundle files, and
+  configured WordPress constants.
+- Actions: registered abilities, WP-CLI commands, GitHub tools, and Data Machine
+  pipeline steps.
+- Observations: tool results, WordPress state, logs, transcripts, metrics, and
+  artifacts.
+- Rewards: passing tests, expected WordPress state, PR creation, artifact shape,
+  benchmark movement, and policy checks.
+- Termination: max turns, step budget, time budget, or flow completion.
+
+For reinforcement-learning style use, prefer explicit reward functions over weak
+proxy goals. For example, reward a verified diff plus passing checks rather than
+only rewarding that a pull request URL exists. Mock or scope external services
+when reproducibility matters.
+
+## Related files
+
+- `.github/workflows/datamachine-agent-ci.yml` is the reusable workflow.
+- `.github/workflows/README.md` documents workflow inputs and examples.
+- `wordpress/scripts/agent/run-datamachine-agent.sh` builds the Playground
+  workload config.
+- `wordpress/scripts/agent/datamachine-agent-workload.php` runs the agent inside
+  WordPress.
+- `wordpress/tests/fixtures/datamachine-agent-ci-driver/` provides the stable
+  plugin path used for workloads and transcript artifacts.

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -68,6 +68,9 @@ dot-path assertions against the manifest or example runner config. `bundle_dir`
 and `example_runner_config` are resolved relative to the spec file's parent
 directory so specs can live at repo root or under `tests/`.
 
+For full CI agent runs inside WordPress Playground, see
+[`AGENT_CI_PLAYGROUND.md`](AGENT_CI_PLAYGROUND.md).
+
 ## Dependencies
 
 If your plugin depends on other local plugins at runtime, declare them:


### PR DESCRIPTION
## Summary
- Add a dedicated guide for running Data Machine agent CI inside WordPress Playground.
- Explain why Playground is the preferred sandbox for disposable WordPress agent runs.
- Document the runtime contract, outputs, assertions, and evaluation/RL environment shape.

## Testing
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the documentation update and PR description; Chris remains responsible for review and merge.