### PR TITLE
Expose agent CI runner extensions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -86,8 +86,59 @@ jobs:
 
 - `validation_dependencies` accepts `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`.
 - `bundle_path` is resolved relative to the consumer checkout.
+- `bundle_repo`, `bundle_ref`, and `bundle_path_in_repo` let a consumer run against a bundle stored in another repository. The runner clones that repository before mounting the bundle into Playground.
 - `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`.
+- `allowed_repos` is a JSON array of `OWNER/REPO` entries exposed to the injected GitHub profile. It defaults to `[target_repo]`.
 - `dry_run` is intended for workflow smoke tests only; production consumers should leave it `false`.
 - `transcript_artifact_name` controls artifact upload. An empty value skips upload.
 - `extra_wp_config_defines` must be a JSON object and is merged into the runner config `wp_config_defines`.
 - `extra_playground_file_mounts`, `workload_run_before`, and `extra_required_abilities` must be JSON arrays.
+- `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.
+- `tool_recorders` configures tool-result projection, forced parameters, and engine-data capture. It must be a JSON array.
+- `pipeline_step_patches` and `flow_step_patches` modify imported bundle step config before the flow runs. They must be JSON arrays.
+- `fallback_pull_request` opens or reuses a PR when files were written but the agent did not call the PR tool. It must be a JSON object.
+
+## External bundle and tool recording example
+
+Consumers such as `docs-agent` can keep the agent bundle in one repository while
+running it against another repository. The reusable workflow handles the bundle
+checkout and passes tool recorder config to the Playground runner.
+
+```yaml
+jobs:
+  run-docs-agent:
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@v3
+    with:
+      bundle_path: bundles/docs-agent
+      bundle_repo: https://github.com/Automattic/docs-agent.git
+      bundle_ref: main
+      bundle_path_in_repo: bundles/docs-agent
+      agent_slug: docs-agent
+      pipeline_slug: docs-agent-pipeline
+      flow_slug: docs-agent-flow
+      target_repo: Automattic/agents-api
+      app_token_repos: Automattic/agents-api,Automattic/docs-agent
+      allowed_repos: '["Automattic/agents-api", "Automattic/docs-agent"]'
+      tool_recorders: |
+        [
+          {
+            "tool": "create_or_update_github_file",
+            "engine_data_key": "github_tool_results",
+            "forced_parameters": {
+              "repo": "Automattic/agents-api",
+              "branch": "${{ github.ref_name }}"
+            },
+            "fields": {
+              "path": "parameters.path",
+              "commit_sha": "result.commit.sha"
+            }
+          }
+        ]
+      success_requires_pr: false
+      transcript_artifact_name: docs-agent-transcript-${{ github.run_id }}
+    secrets: inherit
+```
+
+Use tool recorders when a consumer currently has a custom bootstrap file whose
+only job is to force GitHub tool parameters or copy selected tool results into
+`metadata.engine_data`.

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -11,6 +11,18 @@ name: Data Machine Agent CI (reusable)
       bundle_path:
         type: string
         required: true
+      bundle_repo:
+        description: Optional git URL for an external bundle repository. When set, the runner clones this repo and uses bundle_path_in_repo inside it.
+        type: string
+        default: ""
+      bundle_ref:
+        description: Ref to check out from bundle_repo. Defaults to the current workflow SHA when bundle_repo is empty.
+        type: string
+        default: ""
+      bundle_path_in_repo:
+        description: Path to the bundle inside bundle_repo. Defaults to bundle_path.
+        type: string
+        default: ""
       agent_slug:
         type: string
         required: true
@@ -81,6 +93,10 @@ name: Data Machine Agent CI (reusable)
         description: Comma-separated OWNER/REPO entries for the Homeboy app token. Defaults to target_repo.
         type: string
         default: ""
+      allowed_repos:
+        description: JSON array of OWNER/REPO strings the injected GitHub profile may access. Defaults to [target_repo].
+        type: string
+        default: "[]"
       dry_run:
         description: Build runner config and exercise the runner dry-run path without a live agent call.
         type: boolean
@@ -121,6 +137,26 @@ name: Data Machine Agent CI (reusable)
           datamachine/run-flow, datamachine/drain-job).
         type: string
         default: "[]"
+      ability_tools:
+        description: JSON array of additional tool definitions backed by WordPress abilities.
+        type: string
+        default: "[]"
+      tool_recorders:
+        description: JSON array of existing tool recorder configs for field projection, forced parameters, and tool result capture.
+        type: string
+        default: "[]"
+      pipeline_step_patches:
+        description: JSON array of patches applied to imported pipeline step configs before the flow runs.
+        type: string
+        default: "[]"
+      flow_step_patches:
+        description: JSON array of patches applied to imported flow step configs before the flow runs.
+        type: string
+        default: "[]"
+      fallback_pull_request:
+        description: JSON object describing a fallback PR to open or reuse when files were written but the agent did not open a PR.
+        type: string
+        default: "{}"
     secrets:
       HOMEBOY_APP_ID:
         required: false
@@ -291,6 +327,9 @@ jobs:
           PIPELINE_SLUG: ${{ inputs.pipeline_slug }}
           FLOW_SLUG: ${{ inputs.flow_slug }}
           BUNDLE_PATH: ${{ inputs.bundle_path }}
+          BUNDLE_REPO: ${{ inputs.bundle_repo }}
+          BUNDLE_REF: ${{ inputs.bundle_ref }}
+          BUNDLE_PATH_IN_REPO: ${{ inputs.bundle_path_in_repo }}
           TARGET_REPO: ${{ inputs.target_repo }}
           PROMPT: ${{ inputs.prompt }}
           PROVIDER: ${{ inputs.provider }}
@@ -308,6 +347,12 @@ jobs:
           WORKLOAD_RUN_BEFORE: ${{ inputs.workload_run_before }}
           DAILY_MEMORY_ENABLED: ${{ inputs.daily_memory_enabled }}
           EXTRA_REQUIRED_ABILITIES: ${{ inputs.extra_required_abilities }}
+          ALLOWED_REPOS: ${{ inputs.allowed_repos }}
+          ABILITY_TOOLS: ${{ inputs.ability_tools }}
+          TOOL_RECORDERS: ${{ inputs.tool_recorders }}
+          PIPELINE_STEP_PATCHES: ${{ inputs.pipeline_step_patches }}
+          FLOW_STEP_PATCHES: ${{ inputs.flow_step_patches }}
+          FALLBACK_PULL_REQUEST: ${{ inputs.fallback_pull_request }}
           GITHUB_TOKEN_VALUE: ${{ steps.app-token.outputs.token || github.token }}
           GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT_VALUE: ${{ github.run_attempt }}
@@ -316,6 +361,9 @@ jobs:
           set -euo pipefail
           config_path="${RUNNER_TEMP}/datamachine-agent-config.json"
           bundle_abs="${GITHUB_WORKSPACE}/${BUNDLE_PATH}"
+          bundle_repo_value="${BUNDLE_REPO:-https://github.com/${TARGET_REPO}.git}"
+          bundle_ref_value="${BUNDLE_REF:-$GITHUB_SHA}"
+          bundle_path_in_repo_value="${BUNDLE_PATH_IN_REPO:-$BUNDLE_PATH}"
           component_slug="$(basename "$GITHUB_WORKSPACE")"
           transcript_host_dir="${GITHUB_WORKSPACE}/datamachine-agent-artifacts/${AGENT_SLUG}"
           transcript_guest_dir="/wordpress/wp-content/plugins/${component_slug}/datamachine-agent-artifacts/${AGENT_SLUG}"
@@ -335,12 +383,18 @@ jobs:
           workload_run_before_json="$(validate_json_input workload_run_before array "$WORKLOAD_RUN_BEFORE")"
           extra_required_abilities_json="$(validate_json_input extra_required_abilities array "$EXTRA_REQUIRED_ABILITIES")"
           success_completion_outcomes_json="$(validate_json_input success_completion_outcomes array "$SUCCESS_COMPLETION_OUTCOMES")"
+          allowed_repos_json="$(validate_json_input allowed_repos array "$ALLOWED_REPOS")"
+          ability_tools_json="$(validate_json_input ability_tools array "$ABILITY_TOOLS")"
+          tool_recorders_json="$(validate_json_input tool_recorders array "$TOOL_RECORDERS")"
+          pipeline_step_patches_json="$(validate_json_input pipeline_step_patches array "$PIPELINE_STEP_PATCHES")"
+          flow_step_patches_json="$(validate_json_input flow_step_patches array "$FLOW_STEP_PATCHES")"
+          fallback_pull_request_json="$(validate_json_input fallback_pull_request object "$FALLBACK_PULL_REQUEST")"
           jq -n \
             --arg componentPath "$GITHUB_WORKSPACE" \
             --arg bundlePath "$bundle_abs" \
-            --arg bundlePathInRepo "$BUNDLE_PATH" \
-            --arg bundleRepo "https://github.com/${TARGET_REPO}.git" \
-            --arg bundleRef "$GITHUB_SHA" \
+            --arg bundlePathInRepo "$bundle_path_in_repo_value" \
+            --arg bundleRepo "$bundle_repo_value" \
+            --arg bundleRef "$bundle_ref_value" \
             --arg agentSlug "$AGENT_SLUG" \
             --arg pipelineSlug "$PIPELINE_SLUG" \
             --arg flowSlug "$FLOW_SLUG" \
@@ -367,6 +421,12 @@ jobs:
             --argjson workloadRunBefore "$workload_run_before_json" \
             --argjson dailyMemoryEnabled "$DAILY_MEMORY_ENABLED" \
             --argjson extraRequiredAbilities "$extra_required_abilities_json" \
+            --argjson allowedRepos "$allowed_repos_json" \
+            --argjson abilityTools "$ability_tools_json" \
+            --argjson toolRecorders "$tool_recorders_json" \
+            --argjson pipelineStepPatches "$pipeline_step_patches_json" \
+            --argjson flowStepPatches "$flow_step_patches_json" \
+            --argjson fallbackPullRequest "$fallback_pull_request_json" \
             '{
               component_id: "datamachine-agent-ci-driver",
               component_path: $componentPath,
@@ -398,11 +458,16 @@ jobs:
               github_token_env: "GITHUB_TOKEN",
               github_profile_id: ($agentSlug + "-ci"),
               target_repo: $targetRepo,
-              allowed_repos: [$targetRepo],
+              allowed_repos: (if ($allowedRepos | length) > 0 then $allowedRepos else [$targetRepo] end),
               max_turns: $maxTurns,
               prompt: $prompt,
               step_budget: $stepBudget,
               time_budget_ms: $timeBudgetMs,
+              ability_tools: $abilityTools,
+              tool_recorders: $toolRecorders,
+              pipeline_step_patches: $pipelineStepPatches,
+              flow_step_patches: $flowStepPatches,
+              fallback_pull_request: $fallbackPullRequest,
               success_requires_pr: $successRequiresPr,
               success_completion_outcomes: $successCompletionOutcomes,
               artifact_export: ({

--- a/wordpress/docs/AGENT_CI_PLAYGROUND.md
+++ b/wordpress/docs/AGENT_CI_PLAYGROUND.md
@@ -76,10 +76,43 @@ The runner converts the agent config into a single Playground bench workload:
   PHP-WASM.
 - `transcript_dir` controls where exported conversation artifacts are written.
 - `success_requires_pr` can require the agent to open or reuse a pull request.
+- `tool_recorders` can force tool parameters and project tool results into
+  `metadata.engine_data`.
+- `ability_tools` can expose additional WordPress abilities as tools during the
+  agent run.
+- `pipeline_step_patches` and `flow_step_patches` can adjust imported bundle
+  step configuration before execution.
+- `fallback_pull_request` can open a PR when files were written but the agent did
+  not explicitly call the PR tool.
 
 Inside Playground, `datamachine-agent-workload.php` installs the bundle, configures
 the provider, starts the Data Machine flow, drains queued work, records tool
 results, exports the transcript, and writes a Homeboy scenario result.
+
+## Runner config surface
+
+Most consumers should use `.github/workflows/datamachine-agent-ci.yml` rather than
+building runner config directly. The reusable workflow forwards these generic
+knobs to `run-datamachine-agent.sh`:
+
+- Bundle location: `bundle_path`, `bundle_repo`, `bundle_ref`, `bundle_path_in_repo`.
+- Agent selection: `agent_slug`, `pipeline_slug`, `flow_slug`, `prompt`, `provider`, `model`.
+- WordPress runtime: `playground_wordpress`, `extra_wp_config_defines`, `extra_playground_file_mounts`, `workload_run_before`.
+- GitHub access: `target_repo`, `app_token_repos`, `allowed_repos`.
+- Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
+- Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`.
+- Extension points: `extra_required_abilities`, `ability_tools`, `tool_recorders`, `pipeline_step_patches`, `flow_step_patches`, `fallback_pull_request`.
+
+`bundle_repo` is for cross-repo consumers. The shell runner clones the bundle
+repository, points `bundle_path` at the cloned bundle inside Playground, and adds
+that checkout to the mounted validation dependencies. This lets a repository such
+as `agents-api` run a bundle owned by `docs-agent` without copying the bundle or
+maintaining a bespoke runner script.
+
+`tool_recorders` are the main migration path for custom bootstrap files that only
+wrap GitHub tools. A recorder can attach forced parameters, capture selected input
+or output fields, and write them under a stable `metadata.engine_data` key for
+later `engine_data_outputs` projection.
 
 ## Outputs and assertions
 


### PR DESCRIPTION
## Summary
- Add reusable workflow inputs for external bundle repositories, allowed GitHub repos, ability tools, tool recorders, step patches, and fallback PR behavior.
- Pass the new JSON inputs through the runner config so consumers can use existing Playground runner primitives without bespoke wrapper scripts.
- Document the advanced runner surface with a docs-agent/agents-api style cross-repo example.

## Validation
- `git diff --check origin/main..HEAD`
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\"); puts \"yaml ok\"'`
- `actionlint` unavailable locally

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the reusable workflow input changes and documentation updates; Chris remains responsible for review and merge.