### PR TITLE
Expose agent CI engine data keys

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -89,6 +89,7 @@ jobs:
 - `bundle_repo`, `bundle_ref`, and `bundle_path_in_repo` let a consumer run against a bundle stored in another repository. The runner clones that repository before mounting the bundle into Playground.
 - `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`.
 - `allowed_repos` is a JSON array of `OWNER/REPO` entries exposed to the injected GitHub profile. It defaults to `[target_repo]`.
+- `engine_key` and `tool_results_key` control where built-in GitHub tool captures and fallback PR data are written in `metadata.engine_data`.
 - `dry_run` is intended for workflow smoke tests only; production consumers should leave it `false`.
 - `transcript_artifact_name` controls artifact upload. An empty value skips upload.
 - `extra_wp_config_defines` must be a JSON object and is merged into the runner config `wp_config_defines`.
@@ -119,6 +120,8 @@ jobs:
       target_repo: Automattic/agents-api
       app_token_repos: Automattic/agents-api,Automattic/docs-agent
       allowed_repos: '["Automattic/agents-api", "Automattic/docs-agent"]'
+      engine_key: docs_agent
+      tool_results_key: github_tool_results
       tool_recorders: |
         [
           {

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -97,6 +97,14 @@ name: Data Machine Agent CI (reusable)
         description: JSON array of OWNER/REPO strings the injected GitHub profile may access. Defaults to [target_repo].
         type: string
         default: "[]"
+      engine_key:
+        description: Optional engine data key used by built-in tool result capture and fallback pull request recording.
+        type: string
+        default: ""
+      tool_results_key:
+        description: Engine data field used for captured tool results.
+        type: string
+        default: github_tool_results
       dry_run:
         description: Build runner config and exercise the runner dry-run path without a live agent call.
         type: boolean
@@ -348,6 +356,8 @@ jobs:
           DAILY_MEMORY_ENABLED: ${{ inputs.daily_memory_enabled }}
           EXTRA_REQUIRED_ABILITIES: ${{ inputs.extra_required_abilities }}
           ALLOWED_REPOS: ${{ inputs.allowed_repos }}
+          ENGINE_KEY: ${{ inputs.engine_key }}
+          TOOL_RESULTS_KEY: ${{ inputs.tool_results_key }}
           ABILITY_TOOLS: ${{ inputs.ability_tools }}
           TOOL_RECORDERS: ${{ inputs.tool_recorders }}
           PIPELINE_STEP_PATCHES: ${{ inputs.pipeline_step_patches }}
@@ -402,6 +412,8 @@ jobs:
             --arg prompt "$PROMPT" \
             --arg provider "$PROVIDER" \
             --arg model "$MODEL" \
+            --arg engineKey "$ENGINE_KEY" \
+            --arg toolResultsKey "$TOOL_RESULTS_KEY" \
             --arg playgroundWordPress "$PLAYGROUND_WORDPRESS" \
             --arg transcriptGuestDir "$transcript_guest_dir" \
             --arg githubToken "$GITHUB_TOKEN_VALUE" \
@@ -459,6 +471,8 @@ jobs:
               github_profile_id: ($agentSlug + "-ci"),
               target_repo: $targetRepo,
               allowed_repos: (if ($allowedRepos | length) > 0 then $allowedRepos else [$targetRepo] end),
+              engine_key: $engineKey,
+              tool_results_key: $toolResultsKey,
               max_turns: $maxTurns,
               prompt: $prompt,
               step_budget: $stepBudget,

--- a/wordpress/docs/AGENT_CI_PLAYGROUND.md
+++ b/wordpress/docs/AGENT_CI_PLAYGROUND.md
@@ -78,6 +78,8 @@ The runner converts the agent config into a single Playground bench workload:
 - `success_requires_pr` can require the agent to open or reuse a pull request.
 - `tool_recorders` can force tool parameters and project tool results into
   `metadata.engine_data`.
+- `engine_key` and `tool_results_key` control where built-in tool capture and
+  fallback pull request data are recorded.
 - `ability_tools` can expose additional WordPress abilities as tools during the
   agent run.
 - `pipeline_step_patches` and `flow_step_patches` can adjust imported bundle
@@ -98,7 +100,7 @@ knobs to `run-datamachine-agent.sh`:
 - Bundle location: `bundle_path`, `bundle_repo`, `bundle_ref`, `bundle_path_in_repo`.
 - Agent selection: `agent_slug`, `pipeline_slug`, `flow_slug`, `prompt`, `provider`, `model`.
 - WordPress runtime: `playground_wordpress`, `extra_wp_config_defines`, `extra_playground_file_mounts`, `workload_run_before`.
-- GitHub access: `target_repo`, `app_token_repos`, `allowed_repos`.
+- GitHub access: `target_repo`, `app_token_repos`, `allowed_repos`, `engine_key`, `tool_results_key`.
 - Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
 - Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`.
 - Extension points: `extra_required_abilities`, `ability_tools`, `tool_recorders`, `pipeline_step_patches`, `flow_step_patches`, `fallback_pull_request`.


### PR DESCRIPTION
## Summary
- Add `engine_key` and `tool_results_key` inputs to the reusable Data Machine agent CI workflow.
- Pass those values through to the runner config so built-in GitHub tool capture and fallback PR recording can write to consumer-specific engine data namespaces.
- Update the workflow docs and Playground agent CI docs to include the new fields.

## Why
- `agents-api` now consumes the reusable workflow from `homeboy-extensions@main` and needs these inputs to preserve its previous `docs_agent.github_tool_results` result shape.

## Validation
- `git diff --check`
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\"); puts \"yaml ok\"'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified the missing post-merge reusable workflow inputs and drafted the passthrough/documentation fix.