### PR TITLE
Expose agent CI post-run hooks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -93,7 +93,8 @@ jobs:
 - `dry_run` is intended for workflow smoke tests only; production consumers should leave it `false`.
 - `transcript_artifact_name` controls artifact upload. An empty value skips upload.
 - `extra_wp_config_defines` must be a JSON object and is merged into the runner config `wp_config_defines`.
-- `extra_playground_file_mounts`, `workload_run_before`, and `extra_required_abilities` must be JSON arrays.
+- `extra_playground_file_mounts`, `workload_run_before`, `workload_run_after`, and `extra_required_abilities` must be JSON arrays.
+- `workload_run_after` runs post-agent Playground verifier hooks in the same scenario, so consumers can assert the agent left WordPress in a valid state.
 - `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.
 - `tool_recorders` configures tool-result projection, forced parameters, and engine-data capture. It must be a JSON array.
 - `pipeline_step_patches` and `flow_step_patches` modify imported bundle step config before the flow runs. They must be JSON arrays.

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -131,6 +131,14 @@ name: Data Machine Agent CI (reusable)
           pre-run hook.
         type: string
         default: "[]"
+      workload_run_after:
+        description: |
+          JSON array of post-run hooks executed after the agent workload inside
+          the same Playground scenario. Use this for verifier probes that assert
+          the agent left WordPress in a valid state. Default '[]' means no
+          post-run hook.
+        type: string
+        default: "[]"
       daily_memory_enabled:
         description: |
           When true, sets daily_memory_enabled in the runner config so the
@@ -353,6 +361,7 @@ jobs:
           EXTRA_WP_CONFIG_DEFINES: ${{ inputs.extra_wp_config_defines }}
           EXTRA_PLAYGROUND_FILE_MOUNTS: ${{ inputs.extra_playground_file_mounts }}
           WORKLOAD_RUN_BEFORE: ${{ inputs.workload_run_before }}
+          WORKLOAD_RUN_AFTER: ${{ inputs.workload_run_after }}
           DAILY_MEMORY_ENABLED: ${{ inputs.daily_memory_enabled }}
           EXTRA_REQUIRED_ABILITIES: ${{ inputs.extra_required_abilities }}
           ALLOWED_REPOS: ${{ inputs.allowed_repos }}
@@ -391,6 +400,7 @@ jobs:
           extra_wp_config_defines_json="$(validate_json_input extra_wp_config_defines object "$EXTRA_WP_CONFIG_DEFINES")"
           extra_playground_file_mounts_json="$(validate_json_input extra_playground_file_mounts array "$EXTRA_PLAYGROUND_FILE_MOUNTS")"
           workload_run_before_json="$(validate_json_input workload_run_before array "$WORKLOAD_RUN_BEFORE")"
+          workload_run_after_json="$(validate_json_input workload_run_after array "$WORKLOAD_RUN_AFTER")"
           extra_required_abilities_json="$(validate_json_input extra_required_abilities array "$EXTRA_REQUIRED_ABILITIES")"
           success_completion_outcomes_json="$(validate_json_input success_completion_outcomes array "$SUCCESS_COMPLETION_OUTCOMES")"
           allowed_repos_json="$(validate_json_input allowed_repos array "$ALLOWED_REPOS")"
@@ -431,6 +441,7 @@ jobs:
             --argjson extraWpConfigDefines "$extra_wp_config_defines_json" \
             --argjson extraPlaygroundFileMounts "$extra_playground_file_mounts_json" \
             --argjson workloadRunBefore "$workload_run_before_json" \
+            --argjson workloadRunAfter "$workload_run_after_json" \
             --argjson dailyMemoryEnabled "$DAILY_MEMORY_ENABLED" \
             --argjson extraRequiredAbilities "$extra_required_abilities_json" \
             --argjson allowedRepos "$allowed_repos_json" \
@@ -455,6 +466,7 @@ jobs:
               ] + $extraPlaygroundFileMounts),
               wp_config_defines: $extraWpConfigDefines,
               workload_run_before: $workloadRunBefore,
+              workload_run_after: $workloadRunAfter,
               required_abilities: (["datamachine/import-agent", "datamachine/run-flow", "datamachine/drain-job"] + $extraRequiredAbilities | reduce .[] as $ability ([]; if index($ability) then . else . + [$ability] end)),
               bundle_path: $bundlePath,
               bundle_repo: $bundleRepo,

--- a/wordpress/docs/AGENT_CI_PLAYGROUND.md
+++ b/wordpress/docs/AGENT_CI_PLAYGROUND.md
@@ -83,7 +83,7 @@ Consumers can customize:
 - Runtime tools through `ability_tools` and `tool_recorders`.
 - GitHub scope through `target_repo`, `allowed_repos`, and `app_token_repos`.
 - WordPress state through `extra_wp_config_defines`, file mounts, and pre-run
-  hooks.
+  and post-run hooks.
 - Success criteria through `success_requires_pr`, completion outcomes,
   engine-data projections, artifacts, and verifier jobs.
 
@@ -97,6 +97,8 @@ The runner converts the agent config into a single Playground bench workload:
 - `playground_file_mounts` adds fixture files such as the CI driver plugin.
 - `bench_env` forwards credentials and the serialized runner config into
   PHP-WASM.
+- `workload_run_before` and `workload_run_after` attach setup and verifier hooks
+  around the agent run inside the same Playground scenario.
 - `transcript_dir` controls where exported conversation artifacts are written.
 - `success_requires_pr` can require the agent to open or reuse a pull request.
 - `tool_recorders` can force tool parameters and project tool results into
@@ -122,7 +124,7 @@ knobs to `run-datamachine-agent.sh`:
 
 - Bundle location: `bundle_path`, `bundle_repo`, `bundle_ref`, `bundle_path_in_repo`.
 - Agent selection: `agent_slug`, `pipeline_slug`, `flow_slug`, `prompt`, `provider`, `model`.
-- WordPress runtime: `playground_wordpress`, `extra_wp_config_defines`, `extra_playground_file_mounts`, `workload_run_before`.
+- WordPress runtime: `playground_wordpress`, `extra_wp_config_defines`, `extra_playground_file_mounts`, `workload_run_before`, `workload_run_after`.
 - GitHub access: `target_repo`, `app_token_repos`, `allowed_repos`, `engine_key`, `tool_results_key`.
 - Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
 - Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`.


### PR DESCRIPTION
## Summary
- Add a `workload_run_after` input to the reusable Data Machine agent CI workflow.
- Pass post-run hooks through to the runner config so consumers can run verifier probes after the agent in the same Playground scenario.
- Document setup/verifier hooks as part of the custom agent runner contract.

## Why
- Consumers such as `world-of-wordpress` already have verifier workloads that assert the generated WordPress world still boots correctly. This makes that pattern first-class instead of requiring consumer-specific CI glue.

## Validation
- `git diff --check`
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\"); puts \"yaml ok\"'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified and implemented the reusable post-run verifier hook contract.