### PR TITLE
feat(wordpress): add wp-admin page scenarios

### DIFF
--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+	...require('./lib/admin-page-scenarios'),
 	...require('./lib/request-profiler'),
 	...require('./lib/page-profiler'),
 	...require('./lib/timing-correlator'),

--- a/wordpress/lib/admin-page-scenarios.js
+++ b/wordpress/lib/admin-page-scenarios.js
@@ -1,0 +1,248 @@
+'use strict';
+
+/**
+ * Internal dependencies
+ */
+const { profileWordPressPages } = require('./page-profiler');
+
+const WORDPRESS_ADMIN_RESOURCE_INCLUDE = [
+	'/wp-json/',
+	'?rest_route=',
+	'/wp-admin/',
+	'/wp-content/',
+	'/wp-includes/',
+];
+
+const WORDPRESS_ADMIN_RESOURCE_EXCLUDE = [
+	'/wp-admin/admin-ajax.php?action=heartbeat',
+];
+
+const WORDPRESS_ADMIN_BROWSER_GATE = {
+	readyMs: { warn: 2500, fail: 5000 },
+	requestCount: { warn: 120, fail: 180 },
+	failedRequestCount: { warn: 1, fail: 1 },
+};
+
+const WORDPRESS_ADMIN_REST_GATE = {
+	restAfterReadyCount: { warn: 1, fail: 5 },
+	restNetworkCount: { warn: 20, fail: 40 },
+};
+
+const DEFAULT_SCENARIO_RESOURCES = {
+	includeResourceSubstrings: WORDPRESS_ADMIN_RESOURCE_INCLUDE,
+	excludeResourceSubstrings: WORDPRESS_ADMIN_RESOURCE_EXCLUDE,
+};
+
+const EDITOR_READY = {
+	selector: '.edit-post-layout, .interface-interface-skeleton',
+};
+
+const SITE_EDITOR_READY = {
+	selector: '.edit-site, .interface-interface-skeleton, iframe[name="editor-canvas"]',
+	frameName: 'editor-canvas',
+	frameSelector: 'body',
+};
+
+const WORDPRESS_ADMIN_PAGE_SCENARIOS = [
+	{
+		id: 'dashboard',
+		label: 'Dashboard',
+		path: '/wp-admin/index.php',
+		ready: { selector: '#dashboard-widgets' },
+	},
+	{
+		id: 'posts-list',
+		label: 'Posts list',
+		path: '/wp-admin/edit.php',
+		ready: { selector: 'body.post-type-post .wp-list-table, body.edit-php .wp-list-table' },
+	},
+	{
+		id: 'pages-list',
+		label: 'Pages list',
+		path: '/wp-admin/edit.php?post_type=page',
+		ready: { selector: 'body.post-type-page .wp-list-table' },
+	},
+	{
+		id: 'post-editor',
+		label: 'Post editor',
+		path: '/wp-admin/post-new.php',
+		ready: EDITOR_READY,
+		setup: {
+			recommended: 'Run against a site where the block editor is enabled for posts.',
+		},
+	},
+	{
+		id: 'site-editor-root',
+		label: 'Site Editor root',
+		path: '/wp-admin/site-editor.php',
+		ready: SITE_EDITOR_READY,
+		setup: {
+			recommended: 'Run against a block theme.',
+		},
+	},
+	{
+		id: 'site-editor-template',
+		label: 'Site Editor template route',
+		path: '/wp-admin/site-editor.php?postType=wp_template&postId={themeSlug}%2F%2F{templateSlug}&canvas=edit',
+		ready: SITE_EDITOR_READY,
+		params: ['themeSlug', 'templateSlug'],
+		setup: {
+			recommended: 'Provide themeSlug and templateSlug, for example twentytwentyfive/home.',
+		},
+	},
+	{
+		id: 'site-editor-static-front-page',
+		label: 'Site Editor static front page route',
+		path: '/wp-admin/site-editor.php?postType=page&postId={frontPageId}&canvas=edit',
+		ready: SITE_EDITOR_READY,
+		params: ['frontPageId'],
+		setup: {
+			recommended: 'Create a static front page and pass its page ID as frontPageId.',
+		},
+	},
+	{
+		id: 'patterns',
+		label: 'Patterns',
+		path: '/wp-admin/site-editor.php?path=%2Fpatterns',
+		ready: { selector: '.edit-site, .interface-interface-skeleton' },
+		setup: {
+			recommended: 'Run against a block theme for Site Editor pattern management.',
+		},
+	},
+	{
+		id: 'navigation',
+		label: 'Navigation',
+		path: '/wp-admin/site-editor.php?path=%2Fnavigation',
+		ready: { selector: '.edit-site, .interface-interface-skeleton' },
+		setup: {
+			recommended: 'Run against a block theme with the Site Editor enabled.',
+		},
+	},
+	{
+		id: 'themes',
+		label: 'Themes',
+		path: '/wp-admin/themes.php',
+		ready: { selector: '.theme-browser, .themes' },
+	},
+	{
+		id: 'plugins',
+		label: 'Plugins',
+		path: '/wp-admin/plugins.php',
+		ready: { selector: '.wp-list-table.plugins' },
+	},
+].map((scenario) => ({
+	resources: DEFAULT_SCENARIO_RESOURCES,
+	gate: {
+		browser: WORDPRESS_ADMIN_BROWSER_GATE,
+		rest: WORDPRESS_ADMIN_REST_GATE,
+	},
+	interactions: [],
+	...scenario,
+}));
+
+const WORDPRESS_ADMIN_PAGE_SCENARIO_IDS = WORDPRESS_ADMIN_PAGE_SCENARIOS.map((scenario) => scenario.id);
+
+function clone(value) {
+	return JSON.parse(JSON.stringify(value));
+}
+
+function assertPlainObject(value, name) {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		throw new TypeError(`${name} must be an object`);
+	}
+}
+
+function replaceParams(value, params, missing) {
+	if (typeof value === 'string') {
+		return value.replace(/\{([A-Za-z0-9_:-]+)\}/g, (match, key) => {
+			if (params[key] === undefined || params[key] === null || params[key] === '') {
+				missing.add(key);
+				return match;
+			}
+			return encodeURIComponent(String(params[key]));
+		});
+	}
+	if (Array.isArray(value)) {
+		return value.map((entry) => replaceParams(entry, params, missing));
+	}
+	if (value && typeof value === 'object') {
+		return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, replaceParams(entry, params, missing)]));
+	}
+	return value;
+}
+
+function resolveWordPressAdminPageScenario(scenario, options = {}) {
+	assertPlainObject(scenario, 'scenario');
+	assertPlainObject(options, 'options');
+	const params = options.params || {};
+	assertPlainObject(params, 'options.params');
+
+	const missing = new Set();
+	const resolved = replaceParams(clone(scenario), params, missing);
+	resolved.missingParams = [...missing];
+	if (resolved.missingParams.length > 0 && options.allowUnresolved === false) {
+		throw new Error(`Scenario ${scenario.id || scenario.label || 'unknown'} is missing params: ${resolved.missingParams.join(', ')}`);
+	}
+	return resolved;
+}
+
+function getWordPressAdminPageScenario(id, options = {}) {
+	if (typeof id !== 'string' || id.trim() === '') {
+		throw new TypeError('scenario id must be a non-empty string');
+	}
+	const scenario = WORDPRESS_ADMIN_PAGE_SCENARIOS.find((entry) => entry.id === id);
+	if (!scenario) {
+		throw new Error(`Unknown WordPress admin page scenario: ${id}`);
+	}
+	return resolveWordPressAdminPageScenario(scenario, options);
+}
+
+function listWordPressAdminPageScenarios(options = {}) {
+	assertPlainObject(options, 'options');
+	const ids = options.ids === undefined ? WORDPRESS_ADMIN_PAGE_SCENARIO_IDS : options.ids;
+	if (!Array.isArray(ids)) {
+		throw new TypeError('options.ids must be an array when provided');
+	}
+	const excludeIds = new Set(options.excludeIds || []);
+	return ids
+		.filter((id) => !excludeIds.has(id))
+		.map((id) => getWordPressAdminPageScenario(id, options));
+}
+
+function createWordPressAdminPageScenarioManifest(options = {}) {
+	const pages = listWordPressAdminPageScenarios(options);
+	const overrides = options.overrides || {};
+	assertPlainObject(overrides, 'options.overrides');
+
+	return {
+		pages: pages.map((page) => ({
+			...page,
+			...(overrides[page.id] || {}),
+		})),
+	};
+}
+
+async function profileWordPressAdminPageScenarios(input = {}) {
+	assertPlainObject(input, 'input');
+	const manifest = input.manifest || (Array.isArray(input.scenarios)
+		? { pages: input.scenarios }
+		: createWordPressAdminPageScenarioManifest(input.scenarios || input));
+	return profileWordPressPages({
+		...input,
+		manifest,
+	});
+}
+
+module.exports = {
+	WORDPRESS_ADMIN_BROWSER_GATE,
+	WORDPRESS_ADMIN_PAGE_SCENARIO_IDS,
+	WORDPRESS_ADMIN_PAGE_SCENARIOS,
+	WORDPRESS_ADMIN_RESOURCE_EXCLUDE,
+	WORDPRESS_ADMIN_RESOURCE_INCLUDE,
+	WORDPRESS_ADMIN_REST_GATE,
+	createWordPressAdminPageScenarioManifest,
+	getWordPressAdminPageScenario,
+	listWordPressAdminPageScenarios,
+	profileWordPressAdminPageScenarios,
+	resolveWordPressAdminPageScenario,
+};

--- a/wordpress/lib/admin-page-scenarios.js
+++ b/wordpress/lib/admin-page-scenarios.js
@@ -197,16 +197,33 @@ function getWordPressAdminPageScenario(id, options = {}) {
 	return resolveWordPressAdminPageScenario(scenario, options);
 }
 
+function normalizeWordPressAdminPageScenarioInput(scenario, options = {}) {
+	if (typeof scenario === 'string') {
+		return getWordPressAdminPageScenario(scenario, options);
+	}
+	return resolveWordPressAdminPageScenario({
+		resources: DEFAULT_SCENARIO_RESOURCES,
+		gate: {
+			browser: WORDPRESS_ADMIN_BROWSER_GATE,
+			rest: WORDPRESS_ADMIN_REST_GATE,
+		},
+		interactions: [],
+		...scenario,
+	}, options);
+}
+
 function listWordPressAdminPageScenarios(options = {}) {
 	assertPlainObject(options, 'options');
-	const ids = options.ids === undefined ? WORDPRESS_ADMIN_PAGE_SCENARIO_IDS : options.ids;
-	if (!Array.isArray(ids)) {
-		throw new TypeError('options.ids must be an array when provided');
+	const scenarios = options.scenarios === undefined
+		? (options.ids === undefined ? WORDPRESS_ADMIN_PAGE_SCENARIO_IDS : options.ids)
+		: options.scenarios;
+	if (!Array.isArray(scenarios)) {
+		throw new TypeError('options.scenarios or options.ids must be an array when provided');
 	}
 	const excludeIds = new Set(options.excludeIds || []);
-	return ids
-		.filter((id) => !excludeIds.has(id))
-		.map((id) => getWordPressAdminPageScenario(id, options));
+	return scenarios
+		.map((scenario) => normalizeWordPressAdminPageScenarioInput(scenario, options))
+		.filter((scenario) => !excludeIds.has(scenario.id));
 }
 
 function createWordPressAdminPageScenarioManifest(options = {}) {
@@ -224,9 +241,7 @@ function createWordPressAdminPageScenarioManifest(options = {}) {
 
 async function profileWordPressAdminPageScenarios(input = {}) {
 	assertPlainObject(input, 'input');
-	const manifest = input.manifest || (Array.isArray(input.scenarios)
-		? { pages: input.scenarios }
-		: createWordPressAdminPageScenarioManifest(input.scenarios || input));
+	const manifest = input.manifest || createWordPressAdminPageScenarioManifest(input);
 	return profileWordPressPages({
 		...input,
 		manifest,
@@ -243,6 +258,7 @@ module.exports = {
 	createWordPressAdminPageScenarioManifest,
 	getWordPressAdminPageScenario,
 	listWordPressAdminPageScenarios,
+	normalizeWordPressAdminPageScenarioInput,
 	profileWordPressAdminPageScenarios,
 	resolveWordPressAdminPageScenario,
 };

--- a/wordpress/tests/admin-page-scenarios-smoke.js
+++ b/wordpress/tests/admin-page-scenarios-smoke.js
@@ -16,6 +16,7 @@ const {
 	createWordPressAdminPageScenarioManifest,
 	getWordPressAdminPageScenario,
 	listWordPressAdminPageScenarios,
+	normalizeWordPressAdminPageScenarioInput,
 	normalizePageManifest,
 	resolveWordPressAdminPageScenario,
 } = require('../index');
@@ -59,6 +60,28 @@ const subset = listWordPressAdminPageScenarios({
 });
 assert.deepEqual(subset.map((scenario) => scenario.id), ['dashboard', 'themes']);
 
+const customScenario = normalizeWordPressAdminPageScenarioInput({
+	id: 'woocommerce-orders',
+	label: 'WooCommerce orders',
+	path: '/wp-admin/admin.php?page=wc-orders',
+	ready: { selector: '.woocommerce-layout, .wp-list-table' },
+});
+assert.equal(customScenario.path, '/wp-admin/admin.php?page=wc-orders');
+assert.equal(customScenario.resources.includeResourceSubstrings.includes('/wp-json/'), true);
+
+const mixed = listWordPressAdminPageScenarios({
+	scenarios: [
+		'dashboard',
+		{
+			id: 'custom-settings',
+			label: 'Custom settings',
+			path: '/wp-admin/options-general.php?page=custom',
+			ready: { selector: '#wpbody-content' },
+		},
+	],
+});
+assert.deepEqual(mixed.map((scenario) => scenario.id), ['dashboard', 'custom-settings']);
+
 const template = getWordPressAdminPageScenario('site-editor-template', {
 	params: {
 		themeSlug: 'twentytwentyfive',
@@ -76,18 +99,18 @@ assert.throws(
 );
 
 const manifest = createWordPressAdminPageScenarioManifest({
-	ids: ['dashboard', 'site-editor-template', 'plugins'],
+	scenarios: ['dashboard', 'site-editor-template', customScenario],
 	params: {
 		themeSlug: 'twentytwentyfive',
 		templateSlug: 'home',
 	},
 	overrides: {
-		plugins: {
+		'woocommerce-orders': {
 			restObservationMs: 0,
 		},
 	},
 });
-assert.deepEqual(manifest.pages.map((scenario) => scenario.id), ['dashboard', 'site-editor-template', 'plugins']);
+assert.deepEqual(manifest.pages.map((scenario) => scenario.id), ['dashboard', 'site-editor-template', 'woocommerce-orders']);
 assert.equal(manifest.pages[2].restObservationMs, 0);
 assert.equal(normalizePageManifest(manifest).length, 3);
 

--- a/wordpress/tests/admin-page-scenarios-smoke.js
+++ b/wordpress/tests/admin-page-scenarios-smoke.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
+const assert = require('node:assert/strict');
+
+/**
+ * Internal dependencies
+ */
+const {
+	WORDPRESS_ADMIN_PAGE_SCENARIO_IDS,
+	WORDPRESS_ADMIN_PAGE_SCENARIOS,
+	createWordPressAdminPageScenarioManifest,
+	getWordPressAdminPageScenario,
+	listWordPressAdminPageScenarios,
+	normalizePageManifest,
+	resolveWordPressAdminPageScenario,
+} = require('../index');
+
+const expectedIds = [
+	'dashboard',
+	'posts-list',
+	'pages-list',
+	'post-editor',
+	'site-editor-root',
+	'site-editor-template',
+	'site-editor-static-front-page',
+	'patterns',
+	'navigation',
+	'themes',
+	'plugins',
+];
+
+assert.deepEqual(WORDPRESS_ADMIN_PAGE_SCENARIO_IDS, expectedIds);
+assert.equal(WORDPRESS_ADMIN_PAGE_SCENARIOS.length, expectedIds.length);
+
+for (const scenario of WORDPRESS_ADMIN_PAGE_SCENARIOS) {
+	assert.equal(typeof scenario.id, 'string');
+	assert.equal(typeof scenario.label, 'string');
+	assert.equal(typeof (scenario.path || scenario.url), 'string');
+	assert.equal(typeof scenario.ready, 'object');
+	assert.equal(Array.isArray(scenario.resources.includeResourceSubstrings), true);
+	assert.equal(Array.isArray(scenario.resources.excludeResourceSubstrings), true);
+	assert.equal(typeof scenario.gate.browser.readyMs.warn, 'number');
+	assert.equal(typeof scenario.gate.rest.restAfterReadyCount.warn, 'number');
+}
+
+const dashboard = getWordPressAdminPageScenario('dashboard');
+assert.equal(dashboard.path, '/wp-admin/index.php');
+dashboard.path = '/changed';
+assert.equal(getWordPressAdminPageScenario('dashboard').path, '/wp-admin/index.php');
+
+const subset = listWordPressAdminPageScenarios({
+	ids: ['dashboard', 'plugins', 'themes'],
+	excludeIds: ['plugins'],
+});
+assert.deepEqual(subset.map((scenario) => scenario.id), ['dashboard', 'themes']);
+
+const template = getWordPressAdminPageScenario('site-editor-template', {
+	params: {
+		themeSlug: 'twentytwentyfive',
+		templateSlug: 'home',
+	},
+});
+assert.equal(template.path, '/wp-admin/site-editor.php?postType=wp_template&postId=twentytwentyfive%2F%2Fhome&canvas=edit');
+assert.deepEqual(template.missingParams, []);
+
+const staticFrontPage = getWordPressAdminPageScenario('site-editor-static-front-page');
+assert.deepEqual(staticFrontPage.missingParams, ['frontPageId']);
+assert.throws(
+	() => resolveWordPressAdminPageScenario(WORDPRESS_ADMIN_PAGE_SCENARIOS.find((scenario) => scenario.id === 'site-editor-static-front-page'), { allowUnresolved: false }),
+	/missing params: frontPageId/
+);
+
+const manifest = createWordPressAdminPageScenarioManifest({
+	ids: ['dashboard', 'site-editor-template', 'plugins'],
+	params: {
+		themeSlug: 'twentytwentyfive',
+		templateSlug: 'home',
+	},
+	overrides: {
+		plugins: {
+			restObservationMs: 0,
+		},
+	},
+});
+assert.deepEqual(manifest.pages.map((scenario) => scenario.id), ['dashboard', 'site-editor-template', 'plugins']);
+assert.equal(manifest.pages[2].restObservationMs, 0);
+assert.equal(normalizePageManifest(manifest).length, 3);
+
+assert.throws(() => getWordPressAdminPageScenario('missing'), /Unknown WordPress admin page scenario/);
+
+console.log('WordPress admin page scenarios smoke passed.');


### PR DESCRIPTION
## Summary
- Adds reusable wp-admin scenario specs for dashboard, list tables, editors, Site Editor routes, patterns, navigation, themes, and plugins.
- Exposes helpers for selecting scenarios, resolving route params, creating manifests, and profiling selected scenarios through the existing WordPress page profiler.
- Adds a smoke test covering the initial scenario set, manifest overrides, and parameterized routes.

## Verification
- `node wordpress/tests/admin-page-scenarios-smoke.js`
- `node wordpress/tests/page-profiler-smoke.js`
- `node --check wordpress/lib/admin-page-scenarios.js`
- `node --check wordpress/tests/admin-page-scenarios-smoke.js`
- `node --check wordpress/index.js`
- `git diff --check`

## Related issue
- Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/537

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the scenario module, smoke test, and verification loop for Chris to review.