### PR TITLE
Provision runner-owned agent worktrees

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -169,6 +169,10 @@ name: Data Machine Agent CI (reusable)
         description: JSON array of patches applied to imported flow step configs before the flow runs.
         type: string
         default: "[]"
+      runner_workspace:
+        description: JSON object for runner-owned Data Machine Code workspace/worktree provisioning before the agent runs.
+        type: string
+        default: "{}"
       fallback_pull_request:
         description: JSON object describing a fallback PR to open or reuse when files were written but the agent did not open a PR.
         type: string
@@ -371,6 +375,7 @@ jobs:
           TOOL_RECORDERS: ${{ inputs.tool_recorders }}
           PIPELINE_STEP_PATCHES: ${{ inputs.pipeline_step_patches }}
           FLOW_STEP_PATCHES: ${{ inputs.flow_step_patches }}
+          RUNNER_WORKSPACE: ${{ inputs.runner_workspace }}
           FALLBACK_PULL_REQUEST: ${{ inputs.fallback_pull_request }}
           GITHUB_TOKEN_VALUE: ${{ steps.app-token.outputs.token || github.token }}
           GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
@@ -408,6 +413,7 @@ jobs:
           tool_recorders_json="$(validate_json_input tool_recorders array "$TOOL_RECORDERS")"
           pipeline_step_patches_json="$(validate_json_input pipeline_step_patches array "$PIPELINE_STEP_PATCHES")"
           flow_step_patches_json="$(validate_json_input flow_step_patches array "$FLOW_STEP_PATCHES")"
+          runner_workspace_json="$(validate_json_input runner_workspace object "$RUNNER_WORKSPACE")"
           fallback_pull_request_json="$(validate_json_input fallback_pull_request object "$FALLBACK_PULL_REQUEST")"
           jq -n \
             --arg componentPath "$GITHUB_WORKSPACE" \
@@ -449,6 +455,7 @@ jobs:
             --argjson toolRecorders "$tool_recorders_json" \
             --argjson pipelineStepPatches "$pipeline_step_patches_json" \
             --argjson flowStepPatches "$flow_step_patches_json" \
+            --argjson runnerWorkspace "$runner_workspace_json" \
             --argjson fallbackPullRequest "$fallback_pull_request_json" \
             '{
               component_id: "datamachine-agent-ci-driver",
@@ -493,6 +500,7 @@ jobs:
               tool_recorders: $toolRecorders,
               pipeline_step_patches: $pipelineStepPatches,
               flow_step_patches: $flowStepPatches,
+              runner_workspace: $runnerWorkspace,
               fallback_pull_request: $fallbackPullRequest,
               success_requires_pr: $successRequiresPr,
               success_completion_outcomes: $successCompletionOutcomes,

--- a/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
@@ -105,5 +105,33 @@ namespace {
         exit( 1 );
     }
 
+    list( $runner_config, $runner_prompt ) = homeboy_datamachine_agent_apply_runner_workspace(
+        array(),
+        'Run the agent.',
+        array(
+            'success' => true,
+            'handle'  => 'demo@agent-run',
+            'branch'  => 'agent/run',
+        )
+    );
+
+    if ( ! str_contains( $runner_prompt, 'Workspace handle: demo@agent-run' ) ) {
+        fwrite( STDERR, "Expected runner workspace prompt prefix.\n" );
+        exit( 1 );
+    }
+
+    $workspace_recorder = null;
+    foreach ( $runner_config['tool_recorders'] ?? array() as $runner_recorder ) {
+        if ( is_array( $runner_recorder ) && 'workspace_edit' === ( $runner_recorder['tool'] ?? '' ) ) {
+            $workspace_recorder = $runner_recorder;
+            break;
+        }
+    }
+
+    if ( 'demo@agent-run' !== ( $workspace_recorder['forced_parameters']['repo'] ?? null ) ) {
+        fwrite( STDERR, "Expected runner workspace tools to force the worktree handle.\n" );
+        exit( 1 );
+    }
+
     fwrite( STDOUT, "Data Machine agent forced parameters smoke passed.\n" );
 }

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -950,6 +950,140 @@ if ( ! function_exists( 'homeboy_datamachine_agent_apply_step_patches' ) ) {
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_bool_config' ) ) {
+    function homeboy_datamachine_agent_bool_config( array $config, string $key, bool $default = false ): bool {
+        if ( ! array_key_exists( $key, $config ) ) {
+            return $default;
+        }
+
+        return filter_var( $config[ $key ], FILTER_VALIDATE_BOOLEAN );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_slug' ) ) {
+    function homeboy_datamachine_agent_slug( string $value ): string {
+        $slug = strtolower( preg_replace( '/[^a-zA-Z0-9]+/', '-', $value ) ?? '' );
+        return trim( $slug, '-' );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_provision_workspace' ) ) {
+    function homeboy_datamachine_agent_provision_workspace( array $config ): array {
+        $workspace = is_array( $config['runner_workspace'] ?? null ) ? $config['runner_workspace'] : array();
+        if ( ! homeboy_datamachine_agent_bool_config( $workspace, 'enabled', false ) ) {
+            return array( 'enabled' => false );
+        }
+
+        $repo = isset( $workspace['repo'] ) && is_scalar( $workspace['repo'] ) ? trim( (string) $workspace['repo'] ) : '';
+        if ( str_contains( $repo, '/' ) ) {
+            $repo = basename( $repo );
+        }
+        $repo = preg_replace( '/\.git$/', '', $repo ) ?? $repo;
+        if ( '' === $repo ) {
+            return array( 'enabled' => true, 'success' => false, 'error' => 'runner_workspace.repo is required' );
+        }
+
+        $required = array(
+            'datamachine/workspace-show',
+            'datamachine/workspace-clone',
+            'datamachine/workspace-worktree-add',
+        );
+        foreach ( $required as $ability_name ) {
+            if ( ! wp_get_ability( $ability_name ) ) {
+                return array( 'enabled' => true, 'success' => false, 'error' => $ability_name . ' is not registered' );
+            }
+        }
+
+        $show = wp_get_ability( 'datamachine/workspace-show' )->execute( array( 'name' => $repo ) );
+        if ( function_exists( 'is_wp_error' ) && is_wp_error( $show ) ) {
+            $clone_url = isset( $workspace['clone_url'] ) && is_scalar( $workspace['clone_url'] ) ? trim( (string) $workspace['clone_url'] ) : '';
+            if ( '' === $clone_url ) {
+                return array( 'enabled' => true, 'success' => false, 'error' => 'workspace primary missing and runner_workspace.clone_url is empty' );
+            }
+
+            $clone = wp_get_ability( 'datamachine/workspace-clone' )->execute(
+                array_filter(
+                    array(
+                        'url'  => $clone_url,
+                        'name' => $repo,
+                    ),
+                    static fn( $value ) => '' !== $value
+                )
+            );
+            if ( function_exists( 'is_wp_error' ) && is_wp_error( $clone ) ) {
+                return array( 'enabled' => true, 'success' => false, 'error' => $clone->get_error_message() );
+            }
+        }
+
+        $branch = isset( $workspace['branch'] ) && is_scalar( $workspace['branch'] ) ? trim( (string) $workspace['branch'] ) : '';
+        if ( '' === $branch ) {
+            $prefix = isset( $workspace['branch_prefix'] ) && is_scalar( $workspace['branch_prefix'] ) ? trim( (string) $workspace['branch_prefix'] ) : 'agent-run';
+            $seed   = homeboy_datamachine_agent_slug( homeboy_datamachine_agent_scalar( $config, 'workload_id', 'datamachine-agent' ) );
+            $branch = rtrim( $prefix, '/' ) . '/' . gmdate( 'Y-m-d-His' ) . ( '' !== $seed ? '-' . $seed : '' );
+        }
+
+        $input = array(
+            'repo'           => $repo,
+            'branch'         => $branch,
+            'from'           => isset( $workspace['from'] ) && is_scalar( $workspace['from'] ) ? trim( (string) $workspace['from'] ) : 'origin/HEAD',
+            'inject_context' => homeboy_datamachine_agent_bool_config( $workspace, 'inject_context', true ),
+            'bootstrap'      => homeboy_datamachine_agent_bool_config( $workspace, 'bootstrap', true ),
+            'allow_stale'    => homeboy_datamachine_agent_bool_config( $workspace, 'allow_stale', false ),
+            'rebase_base'    => homeboy_datamachine_agent_bool_config( $workspace, 'rebase_base', false ),
+            'force'          => homeboy_datamachine_agent_bool_config( $workspace, 'force', false ),
+        );
+
+        $worktree = wp_get_ability( 'datamachine/workspace-worktree-add' )->execute( $input );
+        if ( function_exists( 'is_wp_error' ) && is_wp_error( $worktree ) ) {
+            return array( 'enabled' => true, 'success' => false, 'error' => $worktree->get_error_message(), 'input' => $input );
+        }
+        if ( ! is_array( $worktree ) || empty( $worktree['success'] ) ) {
+            return array( 'enabled' => true, 'success' => false, 'error' => 'workspace-worktree-add did not succeed', 'input' => $input, 'result' => $worktree );
+        }
+
+        return array(
+            'enabled' => true,
+            'success' => true,
+            'repo'    => $repo,
+            'branch'  => (string) ( $worktree['branch'] ?? $branch ),
+            'handle'  => (string) ( $worktree['handle'] ?? '' ),
+            'path'    => (string) ( $worktree['path'] ?? '' ),
+            'input'   => $input,
+            'result'  => $worktree,
+        );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_apply_runner_workspace' ) ) {
+    function homeboy_datamachine_agent_apply_runner_workspace( array $config, string $prompt, array $runner_workspace ): array {
+        if ( empty( $runner_workspace['success'] ) || empty( $runner_workspace['handle'] ) ) {
+            return array( $config, $prompt );
+        }
+
+        $handle = (string) $runner_workspace['handle'];
+        $branch = (string) ( $runner_workspace['branch'] ?? '' );
+        $prefix = "Runner-provided workspace:\n- Workspace handle: {$handle}\n- Branch: {$branch}\n\nUse this workspace handle for all repository file and git changes. Do not mutate the primary checkout and do not create another worktree for this run.";
+        $prompt = '' === trim( $prompt ) ? $prefix : $prefix . "\n\n" . $prompt;
+
+        $recorders = is_array( $config['tool_recorders'] ?? null ) ? $config['tool_recorders'] : array();
+        foreach ( array( 'workspace_ls', 'workspace_read', 'workspace_grep', 'workspace_write', 'workspace_edit', 'workspace_apply_patch', 'workspace_delete' ) as $tool_name ) {
+            $recorders[] = array(
+                'tool'              => $tool_name,
+                'forced_parameters' => array( 'repo' => $handle ),
+            );
+        }
+        foreach ( array( 'workspace_git_status', 'workspace_git_log', 'workspace_git_diff', 'workspace_git_pull', 'workspace_git_add', 'workspace_git_commit', 'workspace_git_push' ) as $tool_name ) {
+            $recorders[] = array(
+                'tool'              => $tool_name,
+                'forced_parameters' => array( 'name' => $handle ),
+            );
+        }
+        $config['tool_recorders'] = $recorders;
+
+        return array( $config, $prompt );
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_bootstrap_provider' ) ) {
     function homeboy_datamachine_agent_bootstrap_provider( array $config ): void {
         $function = homeboy_datamachine_agent_scalar( $config, 'provider_register_function' );
@@ -1209,6 +1343,15 @@ if ( null !== $bootstrap_error ) {
     return $bootstrap_error;
 }
 
+$runner_workspace = homeboy_datamachine_agent_provision_workspace( $config );
+if ( ! empty( $runner_workspace['enabled'] ) ) {
+    $metadata['runner_workspace'] = $runner_workspace;
+    if ( empty( $runner_workspace['success'] ) ) {
+        return homeboy_datamachine_agent_result( array( 'runner_workspace_provisioned' => 0 ), $metadata, (string) ( $runner_workspace['error'] ?? 'Runner workspace provisioning failed' ) );
+    }
+    list( $config, $prompt ) = homeboy_datamachine_agent_apply_runner_workspace( $config, $prompt, $runner_workspace );
+}
+
 $required_abilities = is_array( $config['required_abilities'] ?? null ) ? $config['required_abilities'] : array( 'datamachine/import-agent', 'datamachine/run-flow', 'datamachine/drain-job' );
 foreach ( $required_abilities as $ability_name ) {
     if ( ! is_string( $ability_name ) || ! wp_get_ability( $ability_name ) ) {
@@ -1370,6 +1513,7 @@ return homeboy_datamachine_agent_result(
         'import_succeeded'            => 1,
         'import_elapsed_ms'           => $import_elapsed_ms,
         'agent_resolved'              => 1,
+        'runner_workspace_provisioned' => empty( $runner_workspace['enabled'] ) || ! empty( $runner_workspace['success'] ) ? 1 : 0,
         'pipeline_resolved'           => '' === $pipeline_slug || $pipeline_id > 0 ? 1 : 0,
         'flow_resolved'               => 1,
         'run_flow_succeeded'          => 1,


### PR DESCRIPTION
## Summary
- Add a reusable `runner_workspace` input to Data Machine Agent CI so the runner can provision a Data Machine Code worktree before the agent starts.
- Inject the runner-provided workspace handle into the prompt and force workspace tool calls onto that handle.
- Extend the forced-parameters smoke test to cover runner workspace tool parameter enforcement.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "YAML OK"' .github/workflows/datamachine-agent-ci.yml`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner workspace implementation, smoke coverage, and validation pass for Chris to review.