### PR TITLE
Correlate WordPress timings by browser phase

### DIFF
--- a/wordpress/lib/timing-correlator.js
+++ b/wordpress/lib/timing-correlator.js
@@ -125,6 +125,19 @@ function pickFirstString(source, keys) {
 	return undefined;
 }
 
+function pickFirstBoolean(source, keys) {
+	if (!source || typeof source !== 'object') {
+		return undefined;
+	}
+	for (const key of keys) {
+		const value = source[key];
+		if (typeof value === 'boolean') {
+			return value;
+		}
+	}
+	return undefined;
+}
+
 /**
  * Convert a single browser resource timing entry into a normalized record.
  * Accepts native `PerformanceResourceTiming`-shaped objects as well as
@@ -144,9 +157,9 @@ function normalizeBrowserTiming(entry, options = {}) {
 		return null;
 	}
 
-	const startTime = pickFirstNumber(entry, ['startTime', 'fetchStart', 'requestStart', 'start_ms', 'startMs']);
+	const startTime = pickFirstNumber(entry, ['startTime', 'fetchStart', 'requestStart', 'start_time_ms', 'start_ms', 'startMs']);
 	const responseStart = pickFirstNumber(entry, ['responseStart', 'ttfb_ms', 'ttfbMs', 'response_start']);
-	const responseEnd = pickFirstNumber(entry, ['responseEnd', 'response_end', 'endMs', 'end_ms']);
+	const responseEnd = pickFirstNumber(entry, ['responseEnd', 'response_end', 'endMs', 'end_ms', 'response_end_ms']);
 	const duration = pickFirstNumber(entry, ['duration', 'duration_ms', 'durationMs']);
 
 	let computedDuration = duration;
@@ -164,11 +177,15 @@ function normalizeBrowserTiming(entry, options = {}) {
 	const initiator = pickFirstString(entry, ['initiatorType', 'initiator_type', 'initiator', 'resourceType']);
 	const phase = pickFirstString(entry, ['phase', 'phase_label', 'phaseLabel']);
 	const method = pickFirstString(entry, ['method', 'request_method', 'requestMethod']);
+	const status = pickFirstNumber(entry, ['status', 'statusCode', 'status_code', 'http_status']);
+	const failed = pickFirstBoolean(entry, ['failed', 'error']);
 
 	return {
 		url: rawUrl,
 		normalizedUrl: normalizeUrl(rawUrl, options),
 		method: method ? method.toUpperCase() : undefined,
+		status: typeof status === 'number' ? status : undefined,
+		failed,
 		startTime: typeof startTime === 'number' ? startTime : undefined,
 		ttfbMs: typeof computedTtfb === 'number' ? computedTtfb : undefined,
 		durationMs: typeof computedDuration === 'number' ? computedDuration : undefined,
@@ -176,6 +193,112 @@ function normalizeBrowserTiming(entry, options = {}) {
 		phase,
 		raw: entry,
 	};
+}
+
+function normalizeBrowserProfileTimings(profile, options = {}) {
+	if (!profile || typeof profile !== 'object') {
+		return [];
+	}
+
+	const phases = normalizeProfilePhases(profile);
+	const resources = Array.isArray(profile.resources) ? profile.resources : [];
+	const network = Array.isArray(profile.network) ? profile.network : [];
+	const resourcesByUrl = new Map();
+
+	for (const resource of resources) {
+		const rawUrl = pickFirstString(resource, ['name', 'url']);
+		const normalizedUrl = normalizeUrl(rawUrl, options);
+		if (!normalizedUrl) {
+			continue;
+		}
+		if (!resourcesByUrl.has(normalizedUrl)) {
+			resourcesByUrl.set(normalizedUrl, []);
+		}
+		resourcesByUrl.get(normalizedUrl).push(resource);
+	}
+
+	const rows = [];
+	for (const entry of network) {
+		const rawUrl = pickFirstString(entry, ['url', 'name']);
+		const normalizedUrl = normalizeUrl(rawUrl, options);
+		const resource = normalizedUrl ? (resourcesByUrl.get(normalizedUrl) || []).shift() : undefined;
+		const startTime = pickFirstNumber(entry, ['start_time_ms', 'startTime', 'start_ms', 'startMs'])
+			?? pickFirstNumber(resource, ['startTime', 'fetchStart', 'requestStart']);
+		const phase = pickFirstString(entry, ['phase', 'phase_label', 'phaseLabel'])
+			|| pickFirstString(resource, ['phase', 'phase_label', 'phaseLabel'])
+			|| phaseForStartTime(phases, startTime);
+
+		rows.push({
+			...resource,
+			...entry,
+			name: rawUrl,
+			url: rawUrl,
+			startTime,
+			responseStart: pickFirstNumber(resource, ['responseStart']) ?? pickFirstNumber(entry, ['responseStart', 'ttfb_ms', 'ttfbMs']),
+			responseEnd: pickFirstNumber(resource, ['responseEnd']) ?? pickFirstNumber(entry, ['response_end_ms', 'responseEnd']),
+			durationMs: pickFirstNumber(entry, ['duration_ms', 'durationMs']) ?? pickFirstNumber(resource, ['duration', 'duration_ms', 'durationMs']),
+			phase,
+		});
+	}
+
+	for (const entries of resourcesByUrl.values()) {
+		for (const resource of entries) {
+			const startTime = pickFirstNumber(resource, ['startTime', 'fetchStart', 'requestStart']);
+			rows.push({
+				...resource,
+				phase: pickFirstString(resource, ['phase', 'phase_label', 'phaseLabel']) || phaseForStartTime(phases, startTime),
+			});
+		}
+	}
+
+	return rows;
+}
+
+function normalizeProfilePhases(profile) {
+	const phases = [];
+	if (profile.phases && typeof profile.phases === 'object' && !Array.isArray(profile.phases)) {
+		for (const [name, phase] of Object.entries(profile.phases)) {
+			if (!phase || typeof phase !== 'object') {
+				continue;
+			}
+			const startMs = pickFirstNumber(phase, ['start_time_ms', 'startTime', 'start_ms', 'startMs']);
+			const endMs = pickFirstNumber(phase, ['end_time_ms', 'endTime', 'end_ms', 'endMs']);
+			if (startMs !== undefined) {
+				phases.push({ name, startMs, endMs });
+			}
+		}
+	} else if (Array.isArray(profile.phase_marks)) {
+		const marks = profile.phase_marks
+			.map((mark) => ({
+				name: pickFirstString(mark, ['name', 'phase', 'label']),
+				startMs: pickFirstNumber(mark, ['start_time_ms', 'startTime', 'start_ms', 'startMs']),
+			}))
+			.filter((mark) => mark.name && mark.startMs !== undefined)
+			.sort((a, b) => a.startMs - b.startMs);
+		for (let i = 0; i < marks.length; i++) {
+			phases.push({
+				name: marks[i].name,
+				startMs: marks[i].startMs,
+				endMs: marks[i + 1]?.startMs,
+			});
+		}
+	}
+
+	return phases.sort((a, b) => a.startMs - b.startMs);
+}
+
+function phaseForStartTime(phases, startTime) {
+	if (!Array.isArray(phases) || typeof startTime !== 'number') {
+		return undefined;
+	}
+	let matched;
+	for (const phase of phases) {
+		const endMs = typeof phase.endMs === 'number' ? phase.endMs : Infinity;
+		if (startTime >= phase.startMs && startTime < endMs) {
+			matched = phase.name;
+		}
+	}
+	return matched;
 }
 
 /**
@@ -298,16 +421,23 @@ function correlateBrowserAndWordPressTimings(input, options = {}) {
 	if (!input || typeof input !== 'object') {
 		throw new TypeError('correlateBrowserAndWordPressTimings requires an input object');
 	}
-	const { browserTimings, wordpressProfilerRows } = input;
+	const { browserTimings, browserProfile, wordpressProfilerRows } = input;
 
-	if (!Array.isArray(browserTimings)) {
+	const rawBrowserTimings = Array.isArray(browserTimings)
+		? browserTimings
+		: normalizeBrowserProfileTimings(browserProfile, options);
+
+	if (!Array.isArray(rawBrowserTimings)) {
+		throw new TypeError('input.browserTimings must be an array');
+	}
+	if (!Array.isArray(browserTimings) && !browserProfile) {
 		throw new TypeError('input.browserTimings must be an array');
 	}
 	if (!Array.isArray(wordpressProfilerRows)) {
 		throw new TypeError('input.wordpressProfilerRows must be an array');
 	}
 
-	const normalizedBrowser = browserTimings
+	const normalizedBrowser = rawBrowserTimings
 		.map((entry) => normalizeBrowserTiming(entry, options))
 		.filter((entry) => entry !== null && entry.normalizedUrl !== '');
 
@@ -347,6 +477,7 @@ function correlateBrowserAndWordPressTimings(input, options = {}) {
 
 		if (bucket && bucket.length > 0) {
 			const summary = bucket.shift();
+			const browserMethod = browser.method || method;
 			const browserDurationMs = browser.durationMs;
 			const browserTtfbMs = browser.ttfbMs;
 			const wordpressDurationMs = summary.durationMs;
@@ -361,6 +492,9 @@ function correlateBrowserAndWordPressTimings(input, options = {}) {
 				url: browser.url,
 				normalizedUrl: browser.normalizedUrl,
 				method,
+				browserUrl: browser.url,
+				browserMethod,
+				browserStatus: browser.status,
 				phase: browser.phase,
 				initiatorType: browser.initiatorType,
 				browserDurationMs,
@@ -368,6 +502,8 @@ function correlateBrowserAndWordPressTimings(input, options = {}) {
 				wordpressDurationMs,
 				wordpressRequestId: summary.requestId,
 				wordpressUri: summary.uri,
+				wordpressNormalizedUri: summary.normalizedUri,
+				wordpressMethod: summary.method,
 				transportDeltaMs,
 				totalDeltaMs,
 			});
@@ -384,12 +520,17 @@ function correlateBrowserAndWordPressTimings(input, options = {}) {
 	}
 
 	const phaseGroups = groupByPhase(correlated);
+	const topDeltasByPhase = buildTopDeltasByPhase(correlated, options.topDeltaLimit || 5);
+	const metrics = buildCorrelationMetrics(phaseGroups);
 
 	return {
 		correlated,
+		matchedRows: correlated,
 		unmatchedBrowser,
 		unmatchedWordPress,
 		phaseGroups,
+		topDeltasByPhase,
+		metrics,
 	};
 }
 
@@ -405,6 +546,8 @@ function groupByPhase(correlated) {
 				totalBrowserTtfbMs: 0,
 				totalWordPressDurationMs: 0,
 				totalTransportDeltaMs: 0,
+				transportDeltaCount: 0,
+				maxTransportDeltaMs: undefined,
 			});
 		}
 		const group = groups.get(key);
@@ -420,6 +563,10 @@ function groupByPhase(correlated) {
 		}
 		if (typeof row.transportDeltaMs === 'number') {
 			group.totalTransportDeltaMs += row.transportDeltaMs;
+			group.transportDeltaCount += 1;
+			if (group.maxTransportDeltaMs === undefined || row.transportDeltaMs > group.maxTransportDeltaMs) {
+				group.maxTransportDeltaMs = row.transportDeltaMs;
+			}
 		}
 	}
 
@@ -432,15 +579,117 @@ function groupByPhase(correlated) {
 			avgBrowserDurationMs: group.totalBrowserDurationMs / count,
 			avgBrowserTtfbMs: group.totalBrowserTtfbMs / count,
 			avgWordPressDurationMs: group.totalWordPressDurationMs / count,
-			avgTransportDeltaMs: group.totalTransportDeltaMs / count,
+			avgTransportDeltaMs: group.transportDeltaCount > 0 ? group.totalTransportDeltaMs / group.transportDeltaCount : undefined,
+			maxTransportDeltaMs: group.maxTransportDeltaMs,
 		});
 	}
 	return result;
 }
 
+function buildTopDeltasByPhase(correlated, limit) {
+	const groups = new Map();
+	for (const row of correlated) {
+		if (typeof row.transportDeltaMs !== 'number') {
+			continue;
+		}
+		const key = row.phase || '__unphased__';
+		if (!groups.has(key)) {
+			groups.set(key, { phase: row.phase, rows: [] });
+		}
+		groups.get(key).rows.push(row);
+	}
+
+	return [...groups.values()].map((group) => ({
+		phase: group.phase,
+		rows: group.rows
+			.sort((a, b) => Math.abs(b.transportDeltaMs) - Math.abs(a.transportDeltaMs))
+			.slice(0, limit),
+	}));
+}
+
+function buildCorrelationMetrics(phaseGroups) {
+	const phases = {};
+	for (const group of phaseGroups) {
+		const key = group.phase || 'unphased';
+		phases[key] = {
+			count: group.count,
+			avg_transport_delta_ms: group.avgTransportDeltaMs,
+			max_transport_delta_ms: group.maxTransportDeltaMs,
+			avg_browser_ttfb_ms: group.avgBrowserTtfbMs,
+			avg_browser_duration_ms: group.avgBrowserDurationMs,
+			avg_wordpress_duration_ms: group.avgWordPressDurationMs,
+		};
+	}
+	return { phases };
+}
+
+function formatNumber(value) {
+	return typeof value === 'number' && Number.isFinite(value) ? String(Math.round(value)) : '';
+}
+
+function escapeMarkdownCell(value) {
+	return String(value ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function formatEndpoint(method, url) {
+	const endpoint = `${method || ''} ${url || ''}`.trim();
+	return endpoint ? `\`${escapeMarkdownCell(endpoint)}\`` : '';
+}
+
+function formatTimingCorrelationMarkdownReport(correlation, options = {}) {
+	const limit = options.limit || 10;
+	const lines = [
+		'## WordPress timing correlation',
+		'',
+		'| Phase | Count | Avg transport delta | Max transport delta | Avg browser TTFB | Avg WP app |',
+		'|---|---:|---:|---:|---:|---:|',
+	];
+
+	for (const group of correlation.phaseGroups || []) {
+		lines.push(`| ${escapeMarkdownCell(group.phase || 'unphased')} | ${group.count} | ${formatNumber(group.avgTransportDeltaMs)} | ${formatNumber(group.maxTransportDeltaMs)} | ${formatNumber(group.avgBrowserTtfbMs)} | ${formatNumber(group.avgWordPressDurationMs)} |`);
+	}
+
+	const topDeltas = correlation.topDeltasByPhase || buildTopDeltasByPhase(correlation.correlated || [], limit);
+	for (const group of topDeltas) {
+		if (!Array.isArray(group.rows) || group.rows.length === 0) {
+			continue;
+		}
+		lines.push(
+			'',
+			`## Largest transport deltas: ${escapeMarkdownCell(group.phase || 'unphased')}`,
+			'',
+			'| Browser request | Status | WordPress request | Browser TTFB | Browser duration | WP app | Transport delta |',
+			'|---|---:|---|---:|---:|---:|---:|'
+		);
+		for (const row of group.rows.slice(0, limit)) {
+			lines.push(`| ${formatEndpoint(row.browserMethod || row.method, row.browserUrl || row.url)} | ${formatNumber(row.browserStatus)} | ${formatEndpoint(row.wordpressMethod, row.wordpressNormalizedUri || row.normalizedUrl)} | ${formatNumber(row.browserTtfbMs)} | ${formatNumber(row.browserDurationMs)} | ${formatNumber(row.wordpressDurationMs)} | ${formatNumber(row.transportDeltaMs)} |`);
+		}
+	}
+
+	const unmatchedBrowser = correlation.unmatchedBrowser || [];
+	if (unmatchedBrowser.length > 0) {
+		lines.push('', '## Unmatched browser rows', '', '| Browser request | Status | Phase | Duration |', '|---|---:|---|---:|');
+		for (const row of unmatchedBrowser.slice(0, limit)) {
+			lines.push(`| ${formatEndpoint(row.method, row.url)} | ${formatNumber(row.status)} | ${escapeMarkdownCell(row.phase || 'unphased')} | ${formatNumber(row.durationMs)} |`);
+		}
+	}
+
+	const unmatchedWordPress = correlation.unmatchedWordPress || [];
+	if (unmatchedWordPress.length > 0) {
+		lines.push('', '## Unmatched WordPress rows', '', '| WordPress request | App duration | Request ID |', '|---|---:|---|');
+		for (const row of unmatchedWordPress.slice(0, limit)) {
+			lines.push(`| ${formatEndpoint(row.method, row.normalizedUri || row.uri)} | ${formatNumber(row.durationMs)} | ${escapeMarkdownCell(row.requestId || '')} |`);
+		}
+	}
+
+	return lines.join('\n');
+}
+
 module.exports = {
 	correlateBrowserAndWordPressTimings,
+	formatTimingCorrelationMarkdownReport,
 	normalizeBrowserTiming,
+	normalizeBrowserProfileTimings,
 	normalizeUrl,
 	summarizeWordPressProfilerRows,
 };

--- a/wordpress/tests/timing-correlator-smoke.js
+++ b/wordpress/tests/timing-correlator-smoke.js
@@ -4,7 +4,9 @@ const assert = require('node:assert/strict');
 
 const {
 	correlateBrowserAndWordPressTimings,
+	formatTimingCorrelationMarkdownReport,
 	normalizeBrowserTiming,
+	normalizeBrowserProfileTimings,
 	normalizeUrl,
 	summarizeWordPressProfilerRows,
 } = require('../lib/timing-correlator');
@@ -67,10 +69,12 @@ const browserEntry = normalizeBrowserTiming({
 	duration: 380,
 	initiatorType: 'fetch',
 	method: 'get',
+	status: 200,
 });
 
 assert.equal(browserEntry.normalizedUrl, '/wp-json/wp/v2/posts');
 assert.equal(browserEntry.method, 'GET');
+assert.equal(browserEntry.status, 200);
 assert.equal(browserEntry.ttfbMs, 320, 'ttfb derived from responseStart - startTime');
 assert.equal(browserEntry.durationMs, 380);
 assert.equal(browserEntry.initiatorType, 'fetch');
@@ -84,6 +88,74 @@ assert.equal(browserNoDuration.durationMs, 90, 'duration derived from responseEn
 
 assert.equal(normalizeBrowserTiming(null), null);
 assert.equal(normalizeBrowserTiming({}), null);
+
+const browserProfile = {
+	resources: [
+		{
+			name: 'https://example.test/wp-json/wp/v2/posts?context=edit&_=11',
+			startTime: 100,
+			requestStart: 105,
+			responseStart: 420,
+			responseEnd: 480,
+			duration: 380,
+			initiatorType: 'fetch',
+		},
+		{
+			name: 'https://example.test/wp-json/WP/v2/posts/?context=edit&_=22',
+			startTime: 600,
+			requestStart: 600,
+			responseStart: 1030,
+			responseEnd: 1100,
+			duration: 500,
+			initiatorType: 'fetch',
+		},
+		{
+			name: 'https://example.test/wp-json/wp/v2/types',
+			startTime: 700,
+			requestStart: 700,
+			responseStart: 760,
+			responseEnd: 790,
+			duration: 90,
+			initiatorType: 'fetch',
+		},
+	],
+	network: [
+		{
+			url: 'https://example.test/wp-json/wp/v2/posts?context=edit&_=11',
+			method: 'GET',
+			status: 200,
+			resource_type: 'fetch',
+			start_time_ms: 100,
+			duration_ms: 380,
+		},
+		{
+			url: 'https://example.test/wp-json/WP/v2/posts/?context=edit&_=22',
+			method: 'GET',
+			status: 200,
+			resource_type: 'fetch',
+			start_time_ms: 600,
+			duration_ms: 500,
+		},
+		{
+			url: 'https://example.test/wp-json/wp/v2/types',
+			method: 'GET',
+			status: 204,
+			resource_type: 'fetch',
+			start_time_ms: 700,
+			duration_ms: 90,
+		},
+	],
+	phases: {
+		'site-editor.boot': { start_time_ms: 0, end_time_ms: 650, duration_ms: 650 },
+		'site-editor.idle': { start_time_ms: 650, end_time_ms: null, duration_ms: 0 },
+	},
+};
+
+const profileTimings = normalizeBrowserProfileTimings(browserProfile);
+assert.equal(profileTimings.length, 3, 'profile network rows normalize into browser timings');
+assert.equal(profileTimings[0].status, 200, 'browser profile status is retained');
+assert.equal(profileTimings[0].phase, 'site-editor.boot', 'browser profile phases are assigned by start time');
+assert.equal(profileTimings[2].phase, 'site-editor.idle');
 
 // --- summarizeWordPressProfilerRows ----------------------------------------
 
@@ -192,14 +264,20 @@ assert.equal(firstPosts.browserTtfbMs, 320);
 assert.equal(firstPosts.wordpressDurationMs, 66);
 assert.equal(firstPosts.transportDeltaMs, 254, 'TTFB - WP duration is the transport overhead');
 assert.equal(firstPosts.totalDeltaMs, 314, 'total browser duration - WP duration');
+assert.equal(firstPosts.wordpressNormalizedUri, '/wp-json/wp/v2/posts?context=edit');
+assert.equal(firstPosts.wordpressMethod, 'GET');
 
 // Phase grouping should aggregate the two boot rows together and the idle row separately.
 const bootGroup = result.phaseGroups.find((g) => g.phase === 'site-editor.boot');
 const idleGroup = result.phaseGroups.find((g) => g.phase === 'site-editor.idle');
 assert.ok(bootGroup, 'boot phase group present');
 assert.equal(bootGroup.count, 2);
+assert.equal(bootGroup.maxTransportDeltaMs, 340, 'max transport delta is emitted per phase');
+assert.equal(bootGroup.avgTransportDeltaMs, 297, 'avg transport delta is emitted per phase');
 assert.ok(idleGroup, 'idle phase group present');
 assert.equal(idleGroup.count, 1);
+assert.equal(result.metrics.phases['site-editor.boot'].max_transport_delta_ms, 340);
+assert.equal(result.topDeltasByPhase.find((group) => group.phase === 'site-editor.boot').rows[0].wordpressRequestId, 'r2');
 
 // Unmatched buckets must surface entries that did not pair up.
 assert.equal(result.unmatchedBrowser.length, 1);
@@ -213,6 +291,22 @@ const surplusResult = correlateBrowserAndWordPressTimings({
 });
 assert.equal(surplusResult.correlated.length, 1);
 assert.equal(surplusResult.unmatchedWordPress.length, 2, 'unpaired WordPress requests are reported');
+
+const profileResult = correlateBrowserAndWordPressTimings({
+	browserProfile,
+	wordpressProfilerRows: profilerRows,
+});
+assert.equal(profileResult.correlated.length, 3, 'browser profile input correlates without browserTimings');
+assert.equal(profileResult.correlated[0].browserStatus, 200, 'matched rows include browser status');
+assert.equal(profileResult.correlated[2].browserStatus, 204);
+assert.equal(profileResult.correlated[0].phase, 'site-editor.boot');
+assert.equal(profileResult.correlated[2].phase, 'site-editor.idle');
+
+const markdown = formatTimingCorrelationMarkdownReport(profileResult, { limit: 5 });
+assert.match(markdown, /WordPress timing correlation/);
+assert.match(markdown, /Avg transport delta/);
+assert.match(markdown, /Largest transport deltas: site-editor\.boot/);
+assert.match(markdown, /`GET \/wp-json\/wp\/v2\/posts\?context=edit`/);
 
 // Input validation.
 assert.throws(


### PR DESCRIPTION
## Summary
- Extends the WordPress timing correlator to consume generic browser performance profiles with network/resources/phases while preserving the existing flat browser timing API.
- Adds browser status/method, normalized WordPress URI/method, phase labels, matched/unmatched rows, top deltas by phase, and max/avg transport delta metrics.
- Adds compact markdown report output for phase metrics, largest transport deltas, and unmatched browser/WordPress rows.

## Verification
- node wordpress/tests/timing-correlator-smoke.js
- node --check wordpress/lib/timing-correlator.js && node --check wordpress/tests/timing-correlator-smoke.js
- git diff --check origin/main...HEAD

Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/538

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the correlator implementation, smoke coverage, verification, commit, and PR setup for Chris to review.