### PR TITLE
Include default agent runtime dependencies

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,8 @@
 
 `datamachine-agent-ci.yml` wraps the common GitHub Actions shape for running a
 Data Machine agent bundle in WordPress Playground. Consumers provide bundle and
-flow identifiers, dependency refs, a prompt, and optional output projections.
+flow identifiers, a prompt, and optional output projections. By default the
+workflow brings the standard WordPress agent runtime dependencies.
 See [`wordpress/docs/AGENT_CI_PLAYGROUND.md`](../../wordpress/docs/AGENT_CI_PLAYGROUND.md)
 for the full Playground sandbox model, runtime contract, and evaluation notes.
 
@@ -24,7 +25,6 @@ jobs:
       flow_slug: static-site-manual-flow
       target_repo: chubes4/wp-site-generator
       prompt: ${{ inputs.prompt }}
-      validation_dependencies: Automattic/agents-api@main,Extra-Chill/data-machine@main,Extra-Chill/data-machine-code@main,WordPress/ai-provider-for-openai@main
       success_requires_pr: true
       engine_data_outputs: '{"static_site_pr_url":"metadata.engine_data.static_site_agent.pr_url"}'
       comment_pr_summary: true
@@ -51,7 +51,7 @@ jobs:
       flow_slug: world-creator-day-cycle-flow
       target_repo: chubes4/world-of-wordpress
       prompt: ${{ inputs.prompt }}
-      validation_dependencies: chubes4/world-of-wordpress@main,chubes4/markdown-database-integration@main,Automattic/agents-api@main,Extra-Chill/data-machine@main,Extra-Chill/data-machine-code@main,WordPress/ai-provider-for-openai@main
+      validation_dependencies: chubes4/world-of-wordpress@main,chubes4/markdown-database-integration@main
       playground_wordpress: beta
       max_turns: 16
       step_budget: 20
@@ -84,7 +84,9 @@ jobs:
 
 ## Inputs worth calling out
 
-- `validation_dependencies` accepts `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`.
+- `include_agent_runtime_dependencies` defaults to `true` and checks out the standard WordPress agent runtime stack: `Automattic/agents-api`, `Extra-Chill/data-machine`, `Extra-Chill/data-machine-code`, and the provider plugin.
+- `agents_api_ref`, `data_machine_ref`, `data_machine_code_ref`, and `openai_provider_ref` control runtime dependency refs. `openai_provider_ref` defaults to `trunk`.
+- `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.
 - `bundle_path` is resolved relative to the consumer checkout.
 - `bundle_repo`, `bundle_ref`, and `bundle_path_in_repo` let a consumer run against a bundle stored in another repository. The runner clones that repository before mounting the bundle into Playground.
 - `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`.

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -49,9 +49,29 @@ name: Data Machine Agent CI (reusable)
         type: string
         default: gpt-5.5
       validation_dependencies:
-        description: Comma-separated OWNER/REPO or OWNER/REPO@REF entries checked out under .ci/<repo>. Entries without @REF use the repository default branch.
+        description: Comma-separated additional OWNER/REPO or OWNER/REPO@REF entries checked out under .ci/<repo>. Entries without @REF use the repository default branch.
         type: string
         default: ""
+      include_agent_runtime_dependencies:
+        description: "Include the standard WordPress agent runtime stack: Agents API, Data Machine, Data Machine Code, and the selected provider plugin."
+        type: boolean
+        default: true
+      agents_api_ref:
+        description: Ref for Automattic/agents-api when include_agent_runtime_dependencies is true.
+        type: string
+        default: main
+      data_machine_ref:
+        description: Ref for Extra-Chill/data-machine when include_agent_runtime_dependencies is true.
+        type: string
+        default: main
+      data_machine_code_ref:
+        description: Ref for Extra-Chill/data-machine-code when include_agent_runtime_dependencies is true.
+        type: string
+        default: main
+      openai_provider_ref:
+        description: Ref for WordPress/ai-provider-for-openai when provider is openai and include_agent_runtime_dependencies is true.
+        type: string
+        default: trunk
       playground_wordpress:
         type: string
         default: "7.0"
@@ -297,11 +317,30 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           VALIDATION_DEPENDENCIES: ${{ inputs.validation_dependencies }}
+          INCLUDE_AGENT_RUNTIME_DEPENDENCIES: ${{ inputs.include_agent_runtime_dependencies }}
+          AGENTS_API_REF: ${{ inputs.agents_api_ref }}
+          DATA_MACHINE_REF: ${{ inputs.data_machine_ref }}
+          DATA_MACHINE_CODE_REF: ${{ inputs.data_machine_code_ref }}
+          OPENAI_PROVIDER_REF: ${{ inputs.openai_provider_ref }}
+          PROVIDER: ${{ inputs.provider }}
         run: |
           set -euo pipefail
-          [ -n "$VALIDATION_DEPENDENCIES" ] || exit 0
-          IFS=',' read -ra entries <<< "$VALIDATION_DEPENDENCIES"
-          for raw_entry in "${entries[@]}"; do
+          dependency_entries=()
+          if [ "$INCLUDE_AGENT_RUNTIME_DEPENDENCIES" = "true" ]; then
+            dependency_entries+=("Automattic/agents-api@${AGENTS_API_REF}")
+            dependency_entries+=("Extra-Chill/data-machine@${DATA_MACHINE_REF}")
+            dependency_entries+=("Extra-Chill/data-machine-code@${DATA_MACHINE_CODE_REF}")
+            if [ "$PROVIDER" = "openai" ]; then
+              dependency_entries+=("WordPress/ai-provider-for-openai@${OPENAI_PROVIDER_REF}")
+            fi
+          fi
+          if [ -n "$VALIDATION_DEPENDENCIES" ]; then
+            IFS=',' read -ra extra_entries <<< "$VALIDATION_DEPENDENCIES"
+            dependency_entries+=("${extra_entries[@]}")
+          fi
+          [ "${#dependency_entries[@]}" -gt 0 ] || exit 0
+          declare -A seen_dependencies=()
+          for raw_entry in "${dependency_entries[@]}"; do
             entry="$(printf '%s' "$raw_entry" | xargs)"
             [ -n "$entry" ] || continue
             repo_ref="$entry"
@@ -322,6 +361,11 @@ jobs:
               ref="$(gh repo view "$repo_ref" --json defaultBranchRef --jq '.defaultBranchRef.name')"
               [ -n "$ref" ] || { echo "Could not resolve default branch for validation dependency: $repo_ref" >&2; exit 1; }
             fi
+            dedupe_key="${repo_ref}@${ref}"
+            if [ -n "${seen_dependencies[$dedupe_key]:-}" ]; then
+              continue
+            fi
+            seen_dependencies[$dedupe_key]=1
             repo_name="${repo_ref#*/}"
             target=".ci/$repo_name"
             rm -rf "$target"

--- a/wordpress/docs/AGENT_CI_PLAYGROUND.md
+++ b/wordpress/docs/AGENT_CI_PLAYGROUND.md
@@ -31,6 +31,9 @@ WordPress APIs while the host stays small and repeatable:
 
 - No host MySQL, local WordPress install, or component-owned PHPUnit bootstrap.
 - Runtime dependencies are mounted into the same Playground site as the bundle.
+- The reusable workflow can bring the standard WordPress agent runtime stack by
+  default, so consumers do not repeat Agents API, Data Machine, Data Machine
+  Code, or provider plugin refs in every workflow.
 - Blueprints and runner config declare the initial WordPress state.
 - Workload steps can call PHP files, WP-CLI commands, and registered abilities.
 - Homeboy captures metrics, metadata, artifacts, transcripts, and status checks.
@@ -52,7 +55,6 @@ jobs:
       flow_slug: static-site-manual-flow
       target_repo: chubes4/wp-site-generator
       prompt: ${{ inputs.prompt }}
-      validation_dependencies: Automattic/agents-api@main,Extra-Chill/data-machine@main,Extra-Chill/data-machine-code@main,WordPress/ai-provider-for-openai@main
       success_requires_pr: true
       engine_data_outputs: '{"static_site_pr_url":"metadata.engine_data.static_site_agent.pr_url"}'
       comment_pr_summary: true
@@ -61,8 +63,9 @@ jobs:
 ```
 
 The workflow checks out `homeboy-extensions`, installs the WordPress extension
-toolchain, mounts validation dependencies under `.ci/<repo>`, builds a runner
-config, and calls `wordpress/scripts/agent/run-datamachine-agent.sh`.
+toolchain, mounts the standard agent runtime and any additional validation
+dependencies under `.ci/<repo>`, builds a runner config, and calls
+`wordpress/scripts/agent/run-datamachine-agent.sh`.
 
 ## Fully Custom Agents
 
@@ -93,7 +96,8 @@ The runner converts the agent config into a single Playground bench workload:
 
 - `component_path` points at the consumer checkout.
 - `bundle_path` points at the Data Machine agent bundle.
-- `validation_dependencies` are mounted as local plugins or support checkouts.
+- `include_agent_runtime_dependencies` mounts the standard Data Machine agent
+  runtime before consumer-supplied `validation_dependencies`.
 - `playground_file_mounts` adds fixture files such as the CI driver plugin.
 - `bench_env` forwards credentials and the serialized runner config into
   PHP-WASM.
@@ -124,7 +128,7 @@ knobs to `run-datamachine-agent.sh`:
 
 - Bundle location: `bundle_path`, `bundle_repo`, `bundle_ref`, `bundle_path_in_repo`.
 - Agent selection: `agent_slug`, `pipeline_slug`, `flow_slug`, `prompt`, `provider`, `model`.
-- WordPress runtime: `playground_wordpress`, `extra_wp_config_defines`, `extra_playground_file_mounts`, `workload_run_before`, `workload_run_after`.
+- WordPress runtime: `include_agent_runtime_dependencies`, runtime dependency refs, `playground_wordpress`, `extra_wp_config_defines`, `extra_playground_file_mounts`, `workload_run_before`, `workload_run_after`.
 - GitHub access: `target_repo`, `app_token_repos`, `allowed_repos`, `engine_key`, `tool_results_key`.
 - Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
 - Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`.


### PR DESCRIPTION
## Summary
- Add `include_agent_runtime_dependencies` to the reusable Data Machine agent CI workflow, defaulting to the standard WordPress agent runtime stack.
- Add first-class refs for Agents API, Data Machine, Data Machine Code, and the OpenAI provider, with `openai_provider_ref` defaulting to `trunk`.
- Treat `validation_dependencies` as consumer-supplied additional dependencies and dedupe checkout entries.
- Update docs/examples so consumers stop repeating baseline runtime repos.

## Why
- Consumers should not need to know every baseline runtime dependency or default branch. This prevents failures like using `WordPress/ai-provider-for-openai@main` when the provider repo uses `trunk`.

## Validation
- `git diff --check`
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\"); puts \"yaml ok\"'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Analyzed repeated consumer dependency setup and drafted the reusable runtime dependency contract.