### PR TITLE
Normalize runner JSON inputs

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -419,7 +419,7 @@ jobs:
             local name="$1"
             local expected_type="$2"
             local value="$3"
-            if ! jq -ce --arg expected_type "$expected_type" 'if type == $expected_type then . else error("expected " + $expected_type + ", got " + type) end' <<< "$value"; then
+            if ! printf '%s' "$value" | jq -Rse --arg expected_type "$expected_type" 'gsub("^\\s+|\\s+$"; "") | fromjson | if type == $expected_type then . else error("expected " + $expected_type + ", got " + type) end'; then
               echo "Invalid $name: expected JSON $expected_type." >&2
               return 1
             fi


### PR DESCRIPTION
## Summary
- Normalize reusable workflow JSON inputs through raw-string parsing before type validation.
- Make multi-line JSON inputs from caller workflows safe for runner config assembly.
- Fixes the World Creator runner failure where `runner_workspace` failed validation before the agent started.

## Testing
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "YAML OK"' .github/workflows/datamachine-agent-ci.yml`
- `git diff --check`
- Local jq validation of a multi-line `runner_workspace` payload

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runner input parsing failure and drafted the normalization fix.