### PR TITLE
Avoid runner workspace env collision

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -441,7 +441,7 @@ jobs:
           TOOL_RECORDERS: ${{ inputs.tool_recorders }}
           PIPELINE_STEP_PATCHES: ${{ inputs.pipeline_step_patches }}
           FLOW_STEP_PATCHES: ${{ inputs.flow_step_patches }}
-          RUNNER_WORKSPACE: ${{ inputs.runner_workspace }}
+          RUNNER_WORKSPACE_CONFIG: ${{ inputs.runner_workspace }}
           FALLBACK_PULL_REQUEST: ${{ inputs.fallback_pull_request }}
           GITHUB_TOKEN_VALUE: ${{ steps.app-token.outputs.token || github.token }}
           GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
@@ -479,7 +479,7 @@ jobs:
           tool_recorders_json="$(validate_json_input tool_recorders array "$TOOL_RECORDERS")"
           pipeline_step_patches_json="$(validate_json_input pipeline_step_patches array "$PIPELINE_STEP_PATCHES")"
           flow_step_patches_json="$(validate_json_input flow_step_patches array "$FLOW_STEP_PATCHES")"
-          runner_workspace_json="$(validate_json_input runner_workspace object "$RUNNER_WORKSPACE")"
+          runner_workspace_json="$(validate_json_input runner_workspace object "$RUNNER_WORKSPACE_CONFIG")"
           fallback_pull_request_json="$(validate_json_input fallback_pull_request object "$FALLBACK_PULL_REQUEST")"
           jq -n \
             --arg componentPath "$GITHUB_WORKSPACE" \


### PR DESCRIPTION
## Summary
- Rename the internal `RUNNER_WORKSPACE` environment variable to `RUNNER_WORKSPACE_CONFIG`.
- Avoid colliding with GitHub Actions' own `RUNNER_WORKSPACE` path variable.
- Fix reusable runner config assembly for callers using the `runner_workspace` input.

## Testing
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "YAML OK"' .github/workflows/datamachine-agent-ci.yml`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the GitHub Actions environment variable collision and drafted the runner fix.