### PR TITLE
fix: support transcript artifact arrays

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -611,8 +611,8 @@ jobs:
             --results "$RESULTS_FILE" \
             --scenario "${{ inputs.flow_slug }}" \
             --field job_status=metadata.job_status \
-            --field transcript_json=metadata.transcript_artifacts.json \
-            --field transcript_summary=metadata.transcript_artifacts.summary \
+            --field transcript_json='.metadata.transcript_artifacts.json? // .metadata.transcript_artifacts[0].json?' \
+            --field transcript_summary='.metadata.transcript_artifacts.summary? // .metadata.transcript_artifacts[0].summary?' \
             --required-status "" \
             --to-github-output
 
@@ -693,9 +693,9 @@ jobs:
           fi
           if [ -z "$transcript_path" ] && [ -f "$RESULTS_FILE" ]; then
             transcript_content_path="${RUNNER_TEMP}/datamachine-agent-transcripts/$(basename "${TRANSCRIPT_JSON:-job-transcript.json}")"
-            if jq -e --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | .metadata.transcript_artifacts.content? // empty' "$RESULTS_FILE" >/dev/null; then
+            if jq -e --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | (.metadata.transcript_artifacts.content? // .metadata.transcript_artifacts[0].content? // empty)' "$RESULTS_FILE" >/dev/null; then
               mkdir -p "$(dirname "$transcript_content_path")"
-              jq -r --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | .metadata.transcript_artifacts.content' "$RESULTS_FILE" > "$transcript_content_path"
+              jq -r --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | (.metadata.transcript_artifacts.content? // .metadata.transcript_artifacts[0].content?)' "$RESULTS_FILE" > "$transcript_content_path"
               transcript_path="$transcript_content_path"
             fi
           fi


### PR DESCRIPTION
## Summary
- Support both object and array-shaped transcript artifacts when projecting reusable Data Machine agent workflow outputs.
- Keep transcript upload fallback compatible with either result shape.

## Testing
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\"); puts \"yaml ok\"'`
- `GITHUB_OUTPUT=... bash wordpress/scripts/agent/extract-engine-data.sh ...` with array-shaped `metadata.transcript_artifacts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the failing reusable workflow output extraction and drafted the compatibility fix; Chris remains responsible for review and merge.