### PR TITLE
fix: fail agent ci on noncompleted jobs

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -661,7 +661,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Assert success
-        if: ${{ inputs.run_agent && inputs.success_requires_pr && ! inputs.dry_run }}
+        if: ${{ inputs.run_agent && ! inputs.dry_run }}
         env:
           RESULTS_FILE: ${{ runner.temp }}/run-results.json
         run: |


### PR DESCRIPTION
## Summary
- Fail reusable Data Machine agent CI runs whenever the drained job status is not `completed`.
- Keep dry-run behavior unchanged.

## Testing
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\"); puts \"yaml ok\"'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed a green GitHub Actions run hiding a `failed - item-deferred` Data Machine job and drafted the workflow assertion change; Chris remains responsible for review and merge.