### PR TITLE
Report fallback PR creation errors

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1527,7 +1527,12 @@ $metadata += array(
 
 if ( $file_written && ! $pr_opened ) {
     $metadata['success_status'] = 'write_without_pr';
-    return homeboy_datamachine_agent_result( array( 'file_written' => 1, 'pr_opened' => 0 ), $metadata, 'Agent wrote files without opening a pull request' );
+    $fallback_error = is_array( $fallback_pull_request ) ? (string) ( $fallback_pull_request['error'] ?? '' ) : '';
+    $error_message  = 'Agent wrote files without opening a pull request';
+    if ( '' !== $fallback_error ) {
+        $error_message .= ': ' . $fallback_error;
+    }
+    return homeboy_datamachine_agent_result( array( 'file_written' => 1, 'pr_opened' => 0 ), $metadata, $error_message );
 }
 
 if ( ! empty( $job_artifact_exports['error'] ) ) {


### PR DESCRIPTION
## Summary
- Include fallback pull request creation errors in the agent runner failure message when writes occur without a PR.
- Preserve the existing write-without-PR failure behavior while making the underlying fallback failure actionable.

## Tests
- php -l wordpress/scripts/agent/datamachine-agent-workload.php
- php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the standard World Creator run failure and drafting the runner error-reporting fix.