### PR TITLE
fix: omit empty fallback pr base

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -630,11 +630,13 @@ if ( ! function_exists( 'homeboy_datamachine_agent_open_fallback_pr' ) ) {
             'repo'                  => $repo,
             'title'                 => $title,
             'head'                  => $head,
-            'base'                  => $base,
             'body'                  => (string) ( $fallback['body'] ?? '' ),
             'draft'                 => ! empty( $fallback['draft'] ),
             'maintainer_can_modify' => array_key_exists( 'maintainer_can_modify', $fallback ) ? (bool) $fallback['maintainer_can_modify'] : true,
         );
+        if ( '' !== $base ) {
+            $input['base'] = $base;
+        }
 
         $result = $ability->execute( $input );
         if ( is_wp_error( $result ) ) {

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -237,6 +237,44 @@ namespace {
         exit( 1 );
     }
 
+    $fallback_pr_input = array();
+    $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
+        'datamachine/list-github-pulls' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            fn() => array(
+                'success' => true,
+                'pulls'   => array(),
+            )
+        ),
+        'datamachine/create-github-pull-request' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            function ( array $input ) use ( &$fallback_pr_input ): array {
+                $fallback_pr_input = $input;
+                return array(
+                    'success'  => true,
+                    'html_url' => 'https://github.com/owner/repo/pull/654',
+                );
+            }
+        ),
+    );
+    $created_fallback = homeboy_datamachine_agent_open_fallback_pr(
+        array(),
+        array(
+            'tool_results_key'      => 'github_tool_results',
+            'fallback_pull_request' => array(
+                'repo'  => 'owner/repo',
+                'title' => 'Fallback PR',
+                'head'  => 'agent/new-pr-branch',
+            ),
+        )
+    );
+    if ( empty( $created_fallback['opened'] ) ) {
+        fwrite( STDERR, "Expected fallback PR handling to create a PR when no existing PR matches.\n" );
+        exit( 1 );
+    }
+    if ( array_key_exists( 'base', $fallback_pr_input ) ) {
+        fwrite( STDERR, "Expected fallback PR creation to omit an empty base parameter.\n" );
+        exit( 1 );
+    }
+
     $merged_daily_memory = homeboy_datamachine_agent_merge_daily_memory_artifact(
         "# Daily Memory: 2026-05-10\n\n### Existing Entry\n- Keep this.\n### Concurrent Entry\n- Do not delete this.\n",
         "# Daily Memory: 2026-05-10\n\n### Existing Entry\n- Keep this.\n### New Entry\n- Add this.\n"


### PR DESCRIPTION
## Summary
- Omit the optional `base` field from fallback PR creation when no base is configured, allowing the GitHub API to use the repository default branch instead of receiving an empty string.
- Add smoke coverage for creating a fallback PR without an explicit base.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the fallback PR failure, drafting the fix, and adding smoke coverage.