### PR TITLE
fix: support engine data jq expressions

### DIFF
--- a/wordpress/scripts/agent/extract-engine-data-smoke.sh
+++ b/wordpress/scripts/agent/extract-engine-data-smoke.sh
@@ -61,12 +61,15 @@ stdout=$(GITHUB_OUTPUT="$GITHUB_OUTPUT_TMPFILE" bash "$EXTRACTOR" \
     --results "$RESULTS_TMPFILE" \
     --scenario fixture-agent \
     --field foo_bar=metadata.engine_data.foo.bar \
+    --field expression='(.metadata.engine_data.foo | if type == "object" then (.bar // "") else "" end)' \
     --field nested=metadata.engine_data.deep.nested \
     --field missing=metadata.engine_data.missing \
     --required-field foo_bar \
+    --required-field expression \
     --required-field nested)
 
 if grep -F "foo_bar:" <<<"$stdout" | grep -F "baz" >/dev/null \
+    && grep -F "expression:" <<<"$stdout" | grep -F "baz" >/dev/null \
     && grep -F "nested:" <<<"$stdout" | grep -F "42" >/dev/null; then
     pass "stdout includes projected key/value pairs"
 else
@@ -75,6 +78,7 @@ else
 fi
 
 if grep -Fx "foo_bar=baz" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
+    && grep -Fx "expression=baz" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
     && grep -Fx "nested=42" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
     && grep -Fx "missing=" "$GITHUB_OUTPUT_TMPFILE" >/dev/null; then
     pass "GITHUB_OUTPUT includes projected key=value lines"

--- a/wordpress/scripts/agent/extract-engine-data.sh
+++ b/wordpress/scripts/agent/extract-engine-data.sh
@@ -73,7 +73,9 @@ for field in "${FIELDS[@]}"; do
     path="${field#*=}"
     [ -n "$key" ] && [ -n "$path" ] || error "--field requires non-empty key and jq_path, got: $field"
     jq_path="$path"
-    [[ "$jq_path" == .* ]] || jq_path=".$jq_path"
+    if [[ "$jq_path" != .* && "$jq_path" != \(* ]]; then
+        jq_path=".$jq_path"
+    fi
     if ! value=$(jq -r "($jq_path) // empty" <<<"$scenario_json"); then
         error "failed to resolve jq path for $key: $path"
     fi


### PR DESCRIPTION
## Summary
- Allow `extract-engine-data.sh` fields to use full jq expressions starting with `(`, not only dotted paths.
- Add smoke coverage for expression-based field projection.

## Testing
- `bash wordpress/scripts/agent/extract-engine-data-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the workflow extraction failure and drafting the jq expression support.