### PR TITLE
wordpress: emit Playground bench artifacts

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -171,6 +171,33 @@ scenario can earn partial credit. Configured workload steps marked
 structured zero-reward grade with `metadata.grade.failure`, allowing result
 aggregation to consume failures without scenario-specific parsing.
 
+Playground bench runs also emit `wp-rl`-friendly artifacts next to the
+BenchResults JSON file:
+
+- `results.jsonl` — one JSON object per workload scenario row, excluding the
+  synthetic `__bootstrap` BenchResults scenario. Rows include `scenario_id`,
+  `provider`, `model`, `seed`, `run_id`, `success`, `reward`, `duration_ms`,
+  `turns`, `tokens`, `artifacts`, and `error` when those values are present in
+  scenario metadata, metrics, artifacts, or runner environment.
+- `leaderboard.md` — a basic human summary grouped by provider/model with run
+  count, success rate, error count, average reward, and average duration.
+
+Rows tolerate partial and failed scenario envelopes. If a workload reports
+`metadata.provider`, `metadata.model`, `metadata.seed`, `metadata.tokens`,
+`metrics.reward_mean`, `metrics.success_mean`, `metrics.turns_mean`, or an
+`error`/`failure` object, those fields are projected directly into
+`results.jsonl` for downstream analysis without custom post-processing.
+
+Example `results.jsonl` row:
+
+```json
+{"component_id":"example-plugin","scenario_id":"block-markup/navigation-001","provider":"openai","model":"gpt-5.5","seed":1,"run_id":"1","success":true,"reward":1,"duration_ms":1234,"turns":7,"tokens":{"input":1000,"output":500},"artifacts":{"transcript":{"path":"artifacts/transcript.json","kind":"json"}},"error":null}
+```
+
+Set `HOMEBOY_PLAYGROUND_RESULTS_ARTIFACT_DIR` to write these derived artifacts
+to a specific directory. Otherwise they are written beside
+`HOMEBOY_BENCH_RESULTS_FILE`.
+
 The same workload contract powers Data Machine agent CI in Playground. See
 [`../../wordpress/docs/AGENT_CI_PLAYGROUND.md`](../../wordpress/docs/AGENT_CI_PLAYGROUND.md)
 for the dedicated agent sandbox guide.

--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -39,6 +39,7 @@ BENCH_HELPER_SH="${HOMEBOY_RUNTIME_BENCH_HELPER_SH:-${HOME}/.homeboy/runtime/ben
 BENCH_HELPER_PHP_HOST="${HOMEBOY_RUNTIME_BENCH_HELPER_PHP:-${HOME}/.homeboy/runtime/bench-helper.php}"
 BENCH_HELPER_PHP_GUEST="/homeboy-runtime/bench-helper.php"
 BENCH_BROWSER_TARGET_HELPER="${SCRIPT_DIR}/browser-target.sh"
+PLAYGROUND_RESULTS_ARTIFACTS_HELPER="${SCRIPT_DIR}/playground-results-artifacts.sh"
 PHP_PREFLIGHT_HELPER="${SCRIPT_DIR}/../lib/php-preflight.sh"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
 PLAYGROUND_PATHS_HELPER="${SCRIPT_DIR}/../lib/playground-paths.sh"
@@ -76,6 +77,8 @@ if [ ! -f "$BENCH_HELPER_PHP_HOST" ]; then
 fi
 # shellcheck source=browser-target.sh
 source "$BENCH_BROWSER_TARGET_HELPER"
+# shellcheck source=playground-results-artifacts.sh
+source "$PLAYGROUND_RESULTS_ARTIFACTS_HELPER"
 
 # PLUGIN_SLUG is the wp-content/plugins/ path segment Playground uses to
 # mount the component-under-test. The historical default was
@@ -137,6 +140,7 @@ if [ ! -d "$BENCH_DIR" ] && [ -z "${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}" ] && [ "$B
     # doesn't see a missing file and treat the run as a crash.
     if [ -n "${HOMEBOY_BENCH_RESULTS_FILE:-}" ]; then
         homeboy_write_empty_bench_results "$COMPONENT_ID" 0 "${HOMEBOY_BENCH_RESULTS_FILE}"
+        homeboy_wordpress_emit_playground_results_artifacts "${HOMEBOY_BENCH_RESULTS_FILE}"
     fi
     exit 0
 fi
@@ -714,10 +718,12 @@ fi
 # print the path so a human can inspect it.
 if [ -n "${HOMEBOY_BENCH_RESULTS_FILE:-}" ]; then
     cp "$RESULT_JSON" "${HOMEBOY_BENCH_RESULTS_FILE}"
+    homeboy_wordpress_emit_playground_results_artifacts "${HOMEBOY_BENCH_RESULTS_FILE}"
     if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
         echo "DEBUG: [bench:playground] Results copied to ${HOMEBOY_BENCH_RESULTS_FILE}"
     fi
 else
+    homeboy_wordpress_emit_playground_results_artifacts "$RESULT_JSON"
     echo ""
     echo "Bench results: $RESULT_JSON"
 fi

--- a/wordpress/scripts/bench/playground-results-artifacts-smoke.sh
+++ b/wordpress/scripts/bench/playground-results-artifacts-smoke.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=playground-results-artifacts.sh
+source "${SCRIPT_DIR}/playground-results-artifacts.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    exit 1
+fi
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/playground-results-artifacts.XXXXXX")
+cleanup() {
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+RESULTS_FILE="${TMP_ROOT}/bench-results.json"
+
+cat > "$RESULTS_FILE" <<'JSON'
+{
+  "component_id": "wp-rl-fixture",
+  "iterations": 1,
+  "scenarios": [
+    {
+      "id": "__bootstrap",
+      "iterations": 1,
+      "metrics": { "boot_ms": 12 }
+    },
+    {
+      "id": "block-markup/navigation-001",
+      "iterations": 1,
+      "metrics": { "mean_ms": 1234, "reward_mean": 1, "success_mean": 1, "turns_mean": 7 },
+      "metadata": {
+        "provider": "openai",
+        "model": "gpt-5.5",
+        "seed": 1,
+        "tokens": { "input": 1000, "output": 500 }
+      },
+      "artifacts": {
+        "transcript": { "path": "artifacts/transcript.json", "kind": "json" },
+        "playground_url": { "path": "https://example.test", "kind": "url" }
+      }
+    },
+    {
+      "id": "block-markup/query-002",
+      "iterations": 1,
+      "metrics": { "mean_ms": 500, "reward_mean": 0 },
+      "metadata": { "provider": "openai", "model": "gpt-5.5", "seed": 2 },
+      "error": { "message": "scenario failed" }
+    }
+  ]
+}
+JSON
+
+homeboy_wordpress_emit_playground_results_artifacts "$RESULTS_FILE"
+
+JSONL_FILE="${TMP_ROOT}/results.jsonl"
+LEADERBOARD_FILE="${TMP_ROOT}/leaderboard.md"
+
+if [ ! -s "$JSONL_FILE" ]; then
+    echo "ERROR: missing results.jsonl artifact" >&2
+    exit 1
+fi
+if [ ! -s "$LEADERBOARD_FILE" ]; then
+    echo "ERROR: missing leaderboard.md artifact" >&2
+    exit 1
+fi
+
+row_count=$(wc -l < "$JSONL_FILE" | tr -d ' ')
+if [ "$row_count" -ne 2 ]; then
+    echo "ERROR: expected 2 JSONL rows, got $row_count" >&2
+    cat "$JSONL_FILE" >&2
+    exit 1
+fi
+
+scenario='. | select(.scenario_id == "block-markup/navigation-001")'
+provider=$(jq -r "$scenario | .provider" "$JSONL_FILE")
+model=$(jq -r "$scenario | .model" "$JSONL_FILE")
+success=$(jq -r "$scenario | .success" "$JSONL_FILE")
+reward=$(jq -r "$scenario | .reward" "$JSONL_FILE")
+duration=$(jq -r "$scenario | .duration_ms" "$JSONL_FILE")
+artifact=$(jq -r "$scenario | .artifacts.transcript.path" "$JSONL_FILE")
+
+if [ "$provider" != "openai" ] || [ "$model" != "gpt-5.5" ] || [ "$success" != "true" ] || [ "$reward" != "1" ] || [ "$duration" != "1234" ] || [ "$artifact" != "artifacts/transcript.json" ]; then
+    echo "ERROR: JSONL row missing expected scenario fields" >&2
+    cat "$JSONL_FILE" >&2
+    exit 1
+fi
+
+error_count=$(grep -c 'scenario failed' "$JSONL_FILE" || true)
+if [ "$error_count" -ne 1 ]; then
+    echo "ERROR: JSONL did not preserve error row" >&2
+    cat "$JSONL_FILE" >&2
+    exit 1
+fi
+
+if ! grep -q '| openai | gpt-5.5 | 2 | 50% | 1 | 0.5 | 867 |' "$LEADERBOARD_FILE"; then
+    echo "ERROR: leaderboard did not aggregate success/error rows as expected" >&2
+    cat "$LEADERBOARD_FILE" >&2
+    exit 1
+fi
+
+echo "✓ Playground results artifacts smoke test PASSED"

--- a/wordpress/scripts/bench/playground-results-artifacts.sh
+++ b/wordpress/scripts/bench/playground-results-artifacts.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+# Emit wp-rl-friendly artifacts from the WordPress Playground BenchResults
+# envelope without changing the core BenchResults contract.
+
+homeboy_wordpress_playground_artifact_dir() {
+    local results_file="$1"
+
+    if [ -n "${HOMEBOY_PLAYGROUND_RESULTS_ARTIFACT_DIR:-}" ]; then
+        printf '%s\n' "$HOMEBOY_PLAYGROUND_RESULTS_ARTIFACT_DIR"
+        return 0
+    fi
+
+    dirname "$results_file"
+}
+
+homeboy_wordpress_playground_jsonl_filter() {
+    jq -c \
+        --arg env_provider "${HOMEBOY_BENCH_PROVIDER:-${HOMEBOY_PROVIDER:-}}" \
+        --arg env_model "${HOMEBOY_BENCH_MODEL:-${HOMEBOY_MODEL:-}}" \
+        --arg env_seed "${HOMEBOY_BENCH_SEED:-${HOMEBOY_SEED:-}}" \
+        --arg env_run_id "${HOMEBOY_BENCH_RUN_ID:-${HOMEBOY_RUN_ID:-${HOMEBOY_BENCH_INSTANCE_ID:-}}}" \
+        '
+        . as $root
+        | ($root.scenarios // [])[]
+        | select((.id // null) != "__bootstrap")
+        | . as $scenario
+        | ($scenario.metadata // {}) as $metadata
+        | ($scenario.metrics // {}) as $metrics
+        | {
+            component_id: ($root.component_id // null),
+            scenario_id: ($scenario.id // null),
+            provider: ($metadata.provider // $scenario.provider // ($env_provider | select(. != "")) // null),
+            model: ($metadata.model // $scenario.model // ($env_model | select(. != "")) // null),
+            seed: ($metadata.seed // $scenario.seed // ($env_seed | select(. != "")) // null),
+            run_id: ($metadata.run_id // $scenario.run_id // ($env_run_id | select(. != "")) // null),
+            success: (
+                $scenario.success
+                // $metadata.success
+                // (if ($metrics.success_mean? | type) == "number" then $metrics.success_mean >= 1 else null end)
+                // (if ($metrics.pass_mean? | type) == "number" then $metrics.pass_mean >= 1 else null end)
+            ),
+            reward: ($scenario.reward // $metadata.reward // $metrics.reward_mean // null),
+            duration_ms: ($scenario.duration_ms // $metadata.duration_ms // $metrics.mean_ms // null),
+            turns: ($scenario.turns // $metadata.turns // $metrics.turns_mean // null),
+            tokens: ($scenario.tokens // $metadata.tokens // null),
+            artifacts: ($scenario.artifacts // null),
+            error: ($scenario.error // $scenario.failure // $metadata.error // null)
+        }
+        '
+}
+
+homeboy_wordpress_playground_leaderboard_filter() {
+    jq -r -s '
+        def num_or_null: if type == "number" then . else null end;
+        def fmt_num:
+            if . == null then ""
+            else ((. * 1000 | round) / 1000 | tostring)
+            end;
+        def fmt_rate($successes; $total):
+            if $total == 0 then ""
+            else (((($successes / $total) * 1000) | round) / 10 | tostring) + "%"
+            end;
+        def key_for($row):
+            (($row.provider // "unknown") | tostring) + "\u0000" + (($row.model // "unknown") | tostring);
+
+        . as $rows
+        | ($rows | group_by(key_for(.)) | map({
+            provider: (.[0].provider // "unknown"),
+            model: (.[0].model // "unknown"),
+            runs: length,
+            successes: (map(select(.success == true)) | length),
+            errors: (map(select(.error != null or .success == false)) | length),
+            avg_reward: (map(.reward | num_or_null) | map(select(. != null)) | if length == 0 then null else add / length end),
+            avg_duration_ms: (map(.duration_ms | num_or_null) | map(select(. != null)) | if length == 0 then null else add / length end)
+        }) | sort_by(-.avg_reward, .avg_duration_ms // 999999999, .provider, .model)) as $groups
+        | [
+            "# Playground Scenario Leaderboard",
+            "",
+            "| Provider | Model | Runs | Success | Errors | Avg reward | Avg duration ms |",
+            "|---|---|---:|---:|---:|---:|---:|"
+        ]
+        + ($groups | map(
+            "| " + (.provider | tostring) + " | "
+            + (.model | tostring) + " | "
+            + (.runs | tostring) + " | "
+            + fmt_rate(.successes; .runs) + " | "
+            + (.errors | tostring) + " | "
+            + (.avg_reward | fmt_num) + " | "
+            + (.avg_duration_ms | fmt_num) + " |"
+        ))
+        | .[]
+    '
+}
+
+homeboy_wordpress_emit_playground_results_artifacts() {
+    local bench_results_file="$1"
+    local artifact_dir
+    local jsonl_file
+    local leaderboard_file
+
+    if [ -z "$bench_results_file" ] || [ ! -s "$bench_results_file" ]; then
+        return 0
+    fi
+
+    artifact_dir="$(homeboy_wordpress_playground_artifact_dir "$bench_results_file")"
+    mkdir -p "$artifact_dir"
+
+    jsonl_file="${artifact_dir}/results.jsonl"
+    leaderboard_file="${artifact_dir}/leaderboard.md"
+
+    if ! homeboy_wordpress_playground_jsonl_filter < "$bench_results_file" > "$jsonl_file"; then
+        echo "ERROR: failed to emit Playground results JSONL artifact at $jsonl_file" >&2
+        return 1
+    fi
+
+    if ! homeboy_wordpress_playground_leaderboard_filter < "$jsonl_file" > "$leaderboard_file"; then
+        echo "ERROR: failed to emit Playground leaderboard artifact at $leaderboard_file" >&2
+        return 1
+    fi
+
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: [bench:playground] Results JSONL: $jsonl_file"
+        echo "DEBUG: [bench:playground] Leaderboard: $leaderboard_file"
+    fi
+}


### PR DESCRIPTION
## Summary
- Emit `results.jsonl` beside WordPress Playground BenchResults with one row per workload scenario for `wp-rl` consumption.
- Emit `leaderboard.md` grouped by provider/model with run count, success rate, errors, average reward, and duration.
- Document the derived artifact shape and add a smoke test covering success, reward, artifacts, and error-row aggregation.

Closes #565.

## Verification
- `bash -n wordpress/scripts/bench/bench-runner-playground.sh && bash -n wordpress/scripts/bench/playground-results-artifacts.sh && bash -n wordpress/scripts/bench/playground-results-artifacts-smoke.sh`
- `bash wordpress/scripts/bench/playground-results-artifacts-smoke.sh`
- `git diff --check`

## Not fully run
- `bash wordpress/scripts/bench/playground-bench-configured-workloads-smoke.sh` stopped before running because `@wp-playground/cli` is not installed in this worktree.
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@issue-565-wordpress-jsonl-leaderboard --extension wordpress` failed on existing repository findings outside this change, including `wordpress/scripts/validation/validate-autoload.php` and audit-detector fixtures.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shell artifact exporter, smoke coverage, documentation, and verification notes for Chris to review.