### PR TITLE
feat(wordpress): define Playground grader reward schema

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -139,6 +139,38 @@ Numeric metrics are aggregated across measured iterations with the same
 mean/p50/p95/p99/min/max suffixes used by PHP bench files. Artifacts and metadata
 are carried into the Homeboy BenchResults scenario envelope.
 
+Playground grader workloads may also return a normalized reward payload:
+
+```json
+{
+  "success": false,
+  "reward": 0.75,
+  "done": true,
+  "grade": {
+    "max_score": 1,
+    "score": 0.75,
+    "checks": [
+      { "id": "valid_block_markup", "passed": true, "score": 0.4, "max_score": 0.4 },
+      { "id": "matches_expected_structure", "passed": false, "score": 0, "max_score": 0.3 }
+    ]
+  }
+}
+```
+
+`reward` is a finite number from `0` to `1`. `grade.score` and each check
+`score` are finite numbers from `0` to their matching `max_score`. The runner
+mirrors stable numeric keys into metrics (`success`, `reward`, `done`,
+`grade_score`, and `grade_max_score`) so the normal BenchResults aggregation
+emits fields such as `reward_mean` and `grade_score_mean`. The structured
+payload is stored under `metadata.grade` with per-check `id`, `passed`, `score`,
+`max_score`, and optional `message` fields.
+
+Use `success` for binary task completion and `reward`/`grade.checks` when a
+scenario can earn partial credit. Configured workload steps marked
+`"role": "grader"` or `"grader": true` convert thrown exceptions into a
+structured zero-reward grade with `metadata.grade.failure`, allowing result
+aggregation to consume failures without scenario-specific parsing.
+
 The same workload contract powers Data Machine agent CI in Playground. See
 [`../../wordpress/docs/AGENT_CI_PLAYGROUND.md`](../../wordpress/docs/AGENT_CI_PLAYGROUND.md)
 for the dedicated agent sandbox guide.

--- a/wordpress/docs/AGENT_CI_PLAYGROUND.md
+++ b/wordpress/docs/AGENT_CI_PLAYGROUND.md
@@ -178,6 +178,30 @@ proxy goals. For example, reward a verified diff plus passing checks rather than
 only rewarding that a pull request URL exists. Mock or scope external services
 when reproducibility matters.
 
+Playground grader workloads should return the shared reward payload used by the
+bench runner:
+
+```json
+{
+  "success": false,
+  "reward": 0.75,
+  "done": true,
+  "grade": {
+    "max_score": 1,
+    "score": 0.75,
+    "checks": [
+      { "id": "valid_block_markup", "passed": true, "score": 0.4, "max_score": 0.4 }
+    ]
+  }
+}
+```
+
+Use `success` for binary pass/fail completion. Use `reward` and
+`grade.checks` for partial credit, with `reward` bounded from `0` to `1` and
+per-check scores bounded by their `max_score`. The runner exposes aggregate
+metrics such as `reward_mean`, while the structured details remain in
+`metadata.grade` for JSONL consumers.
+
 ## Related files
 
 - `.github/workflows/datamachine-agent-ci.yml` is the reusable workflow.

--- a/wordpress/scripts/bench/playground-bench-grader-schema-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-grader-schema-smoke.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# Playground grader schema smoke test (homeboy-extensions#563).
+#
+# Asserts configured Playground workloads can emit normalized grader output
+# with binary success, partial reward, per-check details, and structured
+# grader failure metadata when a grader step throws.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/playground-grader-schema"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-grader-schema-smoke.XXXXXX")
+cleanup() {
+    rm -f "$RESULTS_TMPFILE"
+}
+trap cleanup EXIT
+
+SETTINGS_JSON='{
+  "playground_workloads": [
+    {
+      "id": "grader-success",
+      "run": [
+        { "type": "php", "file": "workloads/grader-success.php", "role": "grader" }
+      ]
+    },
+    {
+      "id": "grader-partial",
+      "run": [
+        { "type": "php", "file": "workloads/grader-partial.php", "role": "grader" }
+      ]
+    },
+    {
+      "id": "grader-throws",
+      "run": [
+        { "type": "php", "file": "workloads/grader-throws.php", "role": "grader", "id": "grader_runtime" }
+      ]
+    }
+  ]
+}'
+
+echo "============================================"
+echo "Playground bench grader schema smoke test"
+echo "============================================"
+echo "Fixture:    $FIXTURE_DIR"
+echo "Iterations: 1 (per configured grader workload)"
+echo ""
+
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_COMPONENT_ID=playground-grader-schema \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+scenario_count=$(jq -r '.scenarios | length' "$RESULTS_TMPFILE")
+if [ "$scenario_count" -ne 4 ]; then
+    echo "ERROR: expected 4 scenarios (__bootstrap + 3 graders), got $scenario_count" >&2
+    exit 1
+fi
+echo "✓ scenarios length == 4 (__bootstrap + 3 grader workloads)"
+
+success='.scenarios[] | select(.id == "grader-success")'
+if [ "$(jq -r "$success | .metrics.success_mean" "$RESULTS_TMPFILE")" != "1" ]; then
+    echo "ERROR: grader-success success_mean was not 1" >&2
+    exit 1
+fi
+if [ "$(jq -r "$success | .metrics.reward_mean" "$RESULTS_TMPFILE")" != "1" ]; then
+    echo "ERROR: grader-success reward_mean was not 1" >&2
+    exit 1
+fi
+echo "✓ binary success and reward metrics emitted"
+
+partial='.scenarios[] | select(.id == "grader-partial")'
+if [ "$(jq -r "$partial | .metrics.reward_mean" "$RESULTS_TMPFILE")" != "0.5" ]; then
+    echo "ERROR: grader-partial reward_mean was not 0.5" >&2
+    exit 1
+fi
+if [ "$(jq -r "$partial | .metadata.grade.checks[1].passed" "$RESULTS_TMPFILE")" != "false" ]; then
+    echo "ERROR: grader-partial failed check was not structured" >&2
+    exit 1
+fi
+echo "✓ partial credit and failed check details emitted"
+
+throws='.scenarios[] | select(.id == "grader-throws")'
+if [ "$(jq -r "$throws | .metrics.reward_mean" "$RESULTS_TMPFILE")" != "0" ]; then
+    echo "ERROR: grader-throws reward_mean was not 0" >&2
+    exit 1
+fi
+if [ "$(jq -r "$throws | .metadata.grade.failure.type" "$RESULTS_TMPFILE")" != "RuntimeException" ]; then
+    echo "ERROR: grader-throws failure type was not structured" >&2
+    exit 1
+fi
+if [ "$(jq -r "$throws | .metadata.grade.checks[0].id" "$RESULTS_TMPFILE")" != "grader_runtime" ]; then
+    echo "ERROR: grader-throws failure check id was not preserved" >&2
+    exit 1
+fi
+echo "✓ thrown grader failure became structured grade metadata"
+
+echo ""
+echo "============================================"
+echo "✓ Grader schema smoke test PASSED"
+echo "============================================"

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -44,6 +44,9 @@
  * `['metrics' => ['rows' => 10], 'metadata' => ['phase' => 'warm']]`;
  * numeric custom metrics are aggregated with the same percentile machinery
  * and the latest metadata/artifacts payloads are attached to the scenario.
+ * Grader payloads may also return top-level `success`, `reward`, `done`,
+ * and `grade` fields. These are normalized into stable metrics and the
+ * structured `metadata.grade` object for JSONL/eval aggregation.
  *
  * OUTPUT CONTRACT
  *
@@ -383,6 +386,129 @@ function pg_bench_json_object($value, string $label): array {
     return $value;
 }
 
+function pg_bench_float_in_range($value, string $label, float $min, float $max): float {
+    if (!is_numeric($value)) {
+        throw new RuntimeException("$label must be numeric");
+    }
+
+    $number = (float) $value;
+    if (!is_finite($number) || $number < $min || $number > $max) {
+        throw new RuntimeException("$label must be between $min and $max");
+    }
+
+    return $number;
+}
+
+function pg_bench_bool_value($value, string $label): bool {
+    if (is_bool($value)) {
+        return $value;
+    }
+    if ($value === 0 || $value === 1) {
+        return (bool) $value;
+    }
+
+    throw new RuntimeException("$label must be a boolean");
+}
+
+function pg_bench_normalize_grade_check($check, int $index): array {
+    if (!is_array($check) || pg_bench_is_list($check)) {
+        throw new RuntimeException("grade.checks[$index] must be an object");
+    }
+
+    $id = $check['id'] ?? ('check_' . ($index + 1));
+    if (!is_scalar($id) || trim((string) $id) === '') {
+        throw new RuntimeException("grade.checks[$index].id must be a non-empty string");
+    }
+
+    $max_score = pg_bench_float_in_range($check['max_score'] ?? 1, "grade.checks[$index].max_score", 0, PHP_FLOAT_MAX);
+    $score = pg_bench_float_in_range($check['score'] ?? 0, "grade.checks[$index].score", 0, $max_score);
+    $passed = array_key_exists('passed', $check)
+        ? pg_bench_bool_value($check['passed'], "grade.checks[$index].passed")
+        : ($max_score === 0.0 || $score >= $max_score);
+
+    $normalized = [
+        'id' => (string) $id,
+        'passed' => $passed,
+        'score' => $score,
+        'max_score' => $max_score,
+    ];
+
+    foreach (['message', 'details', 'expected', 'actual'] as $field) {
+        if (isset($check[$field]) && is_scalar($check[$field])) {
+            $normalized[$field] = (string) $check[$field];
+        }
+    }
+
+    return $normalized;
+}
+
+function pg_bench_normalize_grader_payload(array $payload): ?array {
+    $has_grade_payload = array_key_exists('success', $payload)
+        || array_key_exists('reward', $payload)
+        || array_key_exists('done', $payload)
+        || array_key_exists('grade', $payload);
+    if (!$has_grade_payload) {
+        return null;
+    }
+
+    $grade = pg_bench_json_object($payload['grade'] ?? [], 'grade');
+    $max_score = pg_bench_float_in_range($grade['max_score'] ?? 1, 'grade.max_score', 0, PHP_FLOAT_MAX);
+
+    $checks = [];
+    if (array_key_exists('checks', $grade)) {
+        if (!is_array($grade['checks']) || !pg_bench_is_list($grade['checks'])) {
+            throw new RuntimeException('grade.checks must be an array');
+        }
+        foreach ($grade['checks'] as $index => $check) {
+            $checks[] = pg_bench_normalize_grade_check($check, $index);
+        }
+    }
+
+    $score_default = array_key_exists('reward', $payload) ? $payload['reward'] : 0;
+    $score = pg_bench_float_in_range($grade['score'] ?? $score_default, 'grade.score', 0, $max_score);
+    $reward = pg_bench_float_in_range($payload['reward'] ?? ($max_score > 0 ? $score / $max_score : 0), 'reward', 0, 1);
+    $success = array_key_exists('success', $payload)
+        ? pg_bench_bool_value($payload['success'], 'success')
+        : ($reward >= 1.0);
+    $done = array_key_exists('done', $payload)
+        ? pg_bench_bool_value($payload['done'], 'done')
+        : true;
+
+    $normalized_grade = [
+        'max_score' => $max_score,
+        'score' => $score,
+        'checks' => $checks,
+    ];
+    if (isset($grade['failure']) && is_array($grade['failure']) && !pg_bench_is_list($grade['failure'])) {
+        $normalized_grade['failure'] = array_intersect_key($grade['failure'], array_flip(['type', 'message']));
+    }
+
+    return [
+        'success' => $success,
+        'reward' => $reward,
+        'done' => $done,
+        'grade' => $normalized_grade,
+    ];
+}
+
+function pg_bench_apply_grader_payload(array $payload, array &$metrics, array &$metadata): void {
+    $normalized = pg_bench_normalize_grader_payload($payload);
+    if ($normalized === null) {
+        return;
+    }
+
+    $metrics['success'] = $normalized['success'] ? 1.0 : 0.0;
+    $metrics['reward'] = $normalized['reward'];
+    $metrics['done'] = $normalized['done'] ? 1.0 : 0.0;
+    $metrics['grade_score'] = $normalized['grade']['score'];
+    $metrics['grade_max_score'] = $normalized['grade']['max_score'];
+
+    $metadata['success'] = $normalized['success'];
+    $metadata['reward'] = $normalized['reward'];
+    $metadata['done'] = $normalized['done'];
+    $metadata['grade'] = $normalized['grade'];
+}
+
 function pg_bench_merge_workload_payload($payload, array &$metrics, array &$artifacts, array &$metadata): void {
     if (!is_array($payload)) {
         return;
@@ -419,6 +545,45 @@ function pg_bench_merge_workload_payload($payload, array &$metrics, array &$arti
     }
 
     $metadata = array_replace($metadata, pg_bench_json_object($payload['metadata'] ?? [], 'metadata'));
+    pg_bench_apply_grader_payload($payload, $metrics, $metadata);
+}
+
+function pg_bench_step_is_grader(array $step): bool {
+    return (isset($step['grader']) && $step['grader'] === true)
+        || (isset($step['role']) && is_scalar($step['role']) && (string) $step['role'] === 'grader');
+}
+
+function pg_bench_grader_failure_payload(Throwable $error, array $step): array {
+    $check_id = isset($step['id']) && is_scalar($step['id']) && trim((string) $step['id']) !== ''
+        ? (string) $step['id']
+        : 'grader_exception';
+
+    return [
+        'success' => false,
+        'reward' => 0,
+        'done' => true,
+        'grade' => [
+            'score' => 0,
+            'max_score' => 1,
+            'checks' => [[
+                'id' => $check_id,
+                'passed' => false,
+                'score' => 0,
+                'max_score' => 1,
+                'message' => $error->getMessage(),
+            ]],
+            'failure' => [
+                'type' => get_class($error),
+                'message' => $error->getMessage(),
+            ],
+        ],
+        'metadata' => [
+            'grader_failure' => [
+                'type' => get_class($error),
+                'message' => $error->getMessage(),
+            ],
+        ],
+    ];
 }
 
 function pg_bench_run_php_step(array $step, string $plugin_path) {
@@ -733,18 +898,25 @@ function pg_bench_run_configured_workload(array $workload, string $plugin_path):
 
     foreach ($workload['run'] as $step) {
         $type = $step['type'];
-        switch ($type) {
-            case 'php':
-                $result = pg_bench_run_php_step($step, $plugin_path);
-                break;
-            case 'wp-cli':
-                $result = pg_bench_run_wp_cli_step($step);
-                break;
-            case 'ability':
-                $result = pg_bench_run_ability_step($step);
-                break;
-            default:
-                throw new RuntimeException("unsupported step type: $type");
+        try {
+            switch ($type) {
+                case 'php':
+                    $result = pg_bench_run_php_step($step, $plugin_path);
+                    break;
+                case 'wp-cli':
+                    $result = pg_bench_run_wp_cli_step($step);
+                    break;
+                case 'ability':
+                    $result = pg_bench_run_ability_step($step);
+                    break;
+                default:
+                    throw new RuntimeException("unsupported step type: $type");
+            }
+        } catch (Throwable $e) {
+            if (!pg_bench_step_is_grader($step)) {
+                throw $e;
+            }
+            $result = pg_bench_grader_failure_payload($e, $step);
         }
         pg_bench_merge_workload_payload($result, $metrics, $artifacts, $metadata);
     }
@@ -898,19 +1070,20 @@ function pg_bench_record_workload_result($result, array &$custom_metric_samples,
         return;
     }
 
-    if (array_key_exists('metadata', $result)) {
-        $latest_metadata = $result['metadata'];
+    $metrics = [];
+    $artifacts = [];
+    $metadata = [];
+    pg_bench_merge_workload_payload($result, $metrics, $artifacts, $metadata);
+
+    if (array_key_exists('metadata', $result) || !empty($metadata)) {
+        $latest_metadata = $metadata;
     }
 
-    if (array_key_exists('artifacts', $result)) {
-        $latest_artifacts = $result['artifacts'];
+    if (array_key_exists('artifacts', $result) || !empty($artifacts)) {
+        $latest_artifacts = $artifacts;
     }
 
-    if (!isset($result['metrics']) || !is_array($result['metrics'])) {
-        return;
-    }
-
-    foreach ($result['metrics'] as $metric => $value) {
+    foreach ($metrics as $metric => $value) {
         if (!is_string($metric) || $metric === '' || !is_numeric($value)) {
             continue;
         }
@@ -1016,6 +1189,9 @@ try {
             if (!$is_warmup) {
                 $timings_ms[] = $elapsed_ns / 1_000_000;
                 if (is_array($workload_result) && array_key_exists('metadata', $workload_result)) {
+                    $has_metadata = true;
+                }
+                if (is_array($workload_result) && pg_bench_normalize_grader_payload($workload_result) !== null) {
                     $has_metadata = true;
                 }
                 if (is_array($workload_result) && array_key_exists('artifacts', $workload_result)) {

--- a/wordpress/tests/fixtures/playground-grader-schema/playground-grader-schema.php
+++ b/wordpress/tests/fixtures/playground-grader-schema/playground-grader-schema.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * Plugin Name: Playground grader schema fixture
+ */

--- a/wordpress/tests/fixtures/playground-grader-schema/workloads/grader-partial.php
+++ b/wordpress/tests/fixtures/playground-grader-schema/workloads/grader-partial.php
@@ -1,0 +1,25 @@
+<?php
+return [
+    'success' => false,
+    'reward' => 0.5,
+    'done' => true,
+    'grade' => [
+        'score' => 0.5,
+        'max_score' => 1,
+        'checks' => [
+            [
+                'id' => 'created_post',
+                'passed' => true,
+                'score' => 0.5,
+                'max_score' => 0.5,
+            ],
+            [
+                'id' => 'matches_expected_structure',
+                'passed' => false,
+                'score' => 0,
+                'max_score' => 0.5,
+                'message' => 'Navigation block was missing.',
+            ],
+        ],
+    ],
+];

--- a/wordpress/tests/fixtures/playground-grader-schema/workloads/grader-success.php
+++ b/wordpress/tests/fixtures/playground-grader-schema/workloads/grader-success.php
@@ -1,0 +1,18 @@
+<?php
+return [
+    'success' => true,
+    'reward' => 1,
+    'done' => true,
+    'grade' => [
+        'score' => 1,
+        'max_score' => 1,
+        'checks' => [
+            [
+                'id' => 'valid_block_markup',
+                'passed' => true,
+                'score' => 1,
+                'max_score' => 1,
+            ],
+        ],
+    ],
+];

--- a/wordpress/tests/fixtures/playground-grader-schema/workloads/grader-throws.php
+++ b/wordpress/tests/fixtures/playground-grader-schema/workloads/grader-throws.php
@@ -1,0 +1,2 @@
+<?php
+throw new RuntimeException('Expected menu item was not created.');


### PR DESCRIPTION
## Summary
- Defines a normalized Playground grader payload with `success`, `reward`, `done`, and structured `grade.checks` details.
- Mirrors stable grader scalars into BenchResults metrics while preserving structured details under `metadata.grade` for JSONL aggregation.
- Adds a targeted smoke fixture covering full success, partial credit, and thrown grader failures converted into structured zero-reward output.

Closes #563.

## Testing
- `php -l wordpress/scripts/bench/playground-bench-runner.php`
- `php -l wordpress/tests/fixtures/playground-grader-schema/workloads/grader-success.php && php -l wordpress/tests/fixtures/playground-grader-schema/workloads/grader-partial.php && php -l wordpress/tests/fixtures/playground-grader-schema/workloads/grader-throws.php`
- `bash wordpress/scripts/bench/playground-bench-grader-schema-smoke.sh`
- `bash wordpress/scripts/bench/playground-bench-custom-metrics-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the schema normalization implementation, smoke fixture, documentation updates, and ran local verification for Chris to review.