### PR TITLE
Add Data Machine agent replay bundles

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -102,6 +102,10 @@ name: Data Machine Agent CI (reusable)
         description: Empty string disables transcript artifact upload.
         type: string
         default: ""
+      replay_bundle_artifact_name:
+        description: Empty string disables replay bundle generation and artifact upload.
+        type: string
+        default: ""
       artifact_export_config:
         description: JSON config for exporting job artifacts back to the target repo. Empty object uses the reusable workflow defaults.
         type: string
@@ -598,6 +602,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           HOMEBOY_DATAMACHINE_AGENT_RESULTS_FILE: ${{ runner.temp }}/run-results.json
+          HOMEBOY_DATAMACHINE_AGENT_REPLAY_BUNDLE_DIR: ${{ inputs.replay_bundle_artifact_name != '' && format('{0}/datamachine-agent-replay-bundles', runner.temp) || '' }}
         run: bash .ci/homeboy-extensions/wordpress/scripts/agent/run-datamachine-agent.sh "${{ steps.config.outputs.config_path }}"
 
       - name: Extract scenario outputs
@@ -711,6 +716,14 @@ jobs:
         with:
           name: ${{ inputs.transcript_artifact_name }}
           path: ${{ steps.transcript-artifact.outputs.path }}
+          if-no-files-found: error
+
+      - name: Upload replay bundle artifact
+        if: ${{ always() && inputs.run_agent && inputs.replay_bundle_artifact_name != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.replay_bundle_artifact_name }}
+          path: ${{ runner.temp }}/datamachine-agent-replay-bundles
           if-no-files-found: error
 
       - name: Comment PR summary

--- a/wordpress/docs/AGENT_CI_PLAYGROUND.md
+++ b/wordpress/docs/AGENT_CI_PLAYGROUND.md
@@ -131,7 +131,7 @@ knobs to `run-datamachine-agent.sh`:
 - WordPress runtime: `include_agent_runtime_dependencies`, runtime dependency refs, `playground_wordpress`, `extra_wp_config_defines`, `extra_playground_file_mounts`, `workload_run_before`, `workload_run_after`.
 - GitHub access: `target_repo`, `app_token_repos`, `allowed_repos`, `engine_key`, `tool_results_key`.
 - Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
-- Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`.
+- Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`, `replay_bundle_artifact_name`.
 - Extension points: `extra_required_abilities`, `ability_tools`, `tool_recorders`, `pipeline_step_patches`, `flow_step_patches`, `fallback_pull_request`.
 
 `bundle_repo` is for cross-repo consumers. The shell runner clones the bundle
@@ -158,6 +158,21 @@ Use `success_requires_pr: true` when the task is only successful if the agent
 opens or reuses a pull request. Use `engine_data_outputs` for additional
 consumer-specific assertions such as a generated PR URL, published artifact path,
 or scenario result field.
+
+Set `replay_bundle_artifact_name` to publish a redacted replay bundle alongside
+the run. The bundle snapshots the scenario envelope, initial Playground
+blueprint, prompt, runner config, provider/model/seed metadata, transcript/action
+log references, and grader metadata. The runner also attaches
+`artifacts.replay_bundle.path` and `metadata.playground_review` to the scenario
+result JSON so downstream JSONL publishers can link failure rows back to the
+bundle.
+
+Final-state Playground review URLs are only emitted when the caller supplies a
+hosted review URL in runner config or scenario metadata. The current Playground
+PHP bench runner exits after scenario execution and does not export a restorable
+site state, so the default bundle records `playground_review.available=false`
+and `final_state.available=false` rather than pretending an encoded initial
+blueprint is a final-state replay.
 
 ## Why this can support agent evaluation
 

--- a/wordpress/scripts/agent/build-replay-bundle-smoke.sh
+++ b/wordpress/scripts/agent/build-replay-bundle-smoke.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-replay-results.XXXXXX.json")
+CONFIG_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-replay-config.XXXXXX.json")
+BUNDLE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-replay-bundles.XXXXXX")
+cleanup() {
+    rm -f "$RESULTS_TMPFILE" "$CONFIG_TMPFILE"
+    rm -rf "$BUNDLE_DIR"
+}
+trap cleanup EXIT
+
+jq -n '{
+    component_id: "example-plugin",
+    iterations: 1,
+    scenarios: [
+        {
+            id: "agent-failure",
+            source: "config",
+            metrics: { config_present_mean: 1 },
+            artifacts: {
+                transcript_json: { path: "transcripts/session.json", kind: "json" }
+            },
+            metadata: {
+                provider: "openai",
+                model: "gpt-example",
+                job_status: "failed",
+                error: "grader failed",
+                github_token: "should-not-leak"
+            }
+        }
+    ]
+}' > "$RESULTS_TMPFILE"
+
+jq -n '{
+    component_id: "example-plugin",
+    workload_id: "agent-failure",
+    provider: "openai",
+    model: "gpt-example",
+    seed: 123,
+    prompt: "Reproduce the failure.",
+    openai_api_key: "should-not-leak",
+    playground_blueprint: {
+        steps: [
+            { step: "login", username: "admin", password: "should-not-leak" }
+        ]
+    }
+}' > "$CONFIG_TMPFILE"
+
+node "$SCRIPT_DIR/build-replay-bundle.js" \
+    --results "$RESULTS_TMPFILE" \
+    --scenario agent-failure \
+    --config "$CONFIG_TMPFILE" \
+    --output-dir "$BUNDLE_DIR" \
+    --update-results >/dev/null
+
+BUNDLE_PATH="$BUNDLE_DIR/agent-failure-replay-bundle.json"
+if [ ! -s "$BUNDLE_PATH" ]; then
+    echo "ERROR: replay bundle was not written" >&2
+    exit 1
+fi
+
+if grep -q 'should-not-leak' "$BUNDLE_PATH"; then
+    echo "ERROR: replay bundle leaked a secret value" >&2
+    cat "$BUNDLE_PATH" >&2
+    exit 1
+fi
+
+artifact_path=$(jq -r '.scenarios[] | select(.id == "agent-failure") | .artifacts.replay_bundle.path // "missing"' "$RESULTS_TMPFILE")
+if [ "$artifact_path" = "missing" ]; then
+    echo "ERROR: replay bundle artifact was not attached to results" >&2
+    cat "$RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+review_available=$(jq -r '.scenarios[] | select(.id == "agent-failure") | .metadata.playground_review.available' "$RESULTS_TMPFILE")
+if [ "$review_available" != "false" ]; then
+    echo "ERROR: expected unavailable Playground review fallback" >&2
+    cat "$RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+final_state_available=$(jq -r '.final_state.available' "$BUNDLE_PATH")
+if [ "$final_state_available" != "false" ]; then
+    echo "ERROR: expected final_state.available=false" >&2
+    cat "$BUNDLE_PATH" >&2
+    exit 1
+fi
+
+echo "✓ replay bundle smoke test PASSED"

--- a/wordpress/scripts/agent/build-replay-bundle.js
+++ b/wordpress/scripts/agent/build-replay-bundle.js
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+'use strict';
+
+/**
+ * External dependencies
+ */
+const fs = require('fs');
+const path = require('path');
+
+const SECRET_KEY_PATTERN = /(secret|token|password|passwd|authorization|cookie|nonce|api[_-]?key|access[_-]?key|private[_-]?key|github[_-]?token|openai[_-]?api[_-]?key)/i;
+
+function usage() {
+	console.error('Usage: build-replay-bundle.js --results <path> --scenario <id> --config <path> --output-dir <dir> [--update-results]');
+}
+
+function parseArgs(argv) {
+	const args = {};
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === '--update-results') {
+			args.updateResults = true;
+			continue;
+		}
+		if (!arg.startsWith('--')) {
+			throw new Error(`Unexpected argument: ${arg}`);
+		}
+		const key = arg.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+		const value = argv[index + 1];
+		if (!value || value.startsWith('--')) {
+			throw new Error(`${arg} requires a value`);
+		}
+		args[key] = value;
+		index += 1;
+	}
+	return args;
+}
+
+function readJson(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function safeId(value) {
+	return String(value || 'scenario')
+		.toLowerCase()
+		.replace(/[^a-z0-9._-]+/g, '-')
+		.replace(/^-+|-+$/g, '') || 'scenario';
+}
+
+function redact(value, key = '') {
+	if (SECRET_KEY_PATTERN.test(key)) {
+		return '[redacted]';
+	}
+	if (Array.isArray(value)) {
+		return value.map((entry) => redact(entry));
+	}
+	if (value && typeof value === 'object') {
+		return Object.fromEntries(Object.entries(value).map(([entryKey, entryValue]) => [entryKey, redact(entryValue, entryKey)]));
+	}
+	return value;
+}
+
+function compactObject(entries) {
+	return Object.fromEntries(Object.entries(entries).filter(([, value]) => value !== undefined && value !== null && value !== ''));
+}
+
+function resolveReviewUrl(config, scenario) {
+	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
+	return metadata.playground_review_url || metadata.review_url || config.playground_review_url || config.review_url || null;
+}
+
+function transcriptReferences(config, scenario) {
+	const artifacts = scenario.artifacts && typeof scenario.artifacts === 'object' ? scenario.artifacts : {};
+	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
+	const references = [];
+
+	for (const [name, artifact] of Object.entries(artifacts)) {
+		if (!/transcript|action.?log/i.test(name)) {
+			continue;
+		}
+		if (artifact && typeof artifact === 'object' && artifact.path) {
+			references.push({ name, path: artifact.path, label: artifact.label || name });
+		}
+	}
+
+	for (const key of ['transcript_json', 'transcript_summary', 'action_log']) {
+		if (metadata[key]) {
+			references.push({ name: key, path: metadata[key] });
+		}
+	}
+
+	if (config.transcript_dir) {
+		references.push({ name: 'transcript_dir', path: config.transcript_dir });
+	}
+
+	return references;
+}
+
+function buildBundle(results, scenario, config, bundlePath) {
+	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
+	const reviewUrl = resolveReviewUrl(config, scenario);
+
+	return redact({
+		schema_version: 1,
+		generated_at: new Date().toISOString(),
+		scenario_id: scenario.id,
+		component_id: results.component_id || results.component,
+		replay_bundle_path: bundlePath,
+		scenario_manifest_snapshot: compactObject({
+			id: scenario.id,
+			label: metadata.label || scenario.label,
+			source: scenario.source,
+			file: scenario.file,
+			manifest: metadata.scenario_manifest || metadata.manifest || metadata.scenario,
+		}),
+		initial_blueprint: config.playground_blueprint || {},
+		prompt: config.prompt,
+		runner_config: config,
+		provider: config.provider || metadata.provider,
+		model: config.model || metadata.model,
+		seed: config.seed || metadata.seed,
+		transcripts: transcriptReferences(config, scenario),
+		grader: compactObject({
+			job_status: metadata.job_status,
+			completion_outcome: metadata.completion_outcome,
+			metrics: scenario.metrics,
+			result_metadata: metadata,
+		}),
+		logs: compactObject({
+			stage_log: metadata.stage_log,
+			error: metadata.error,
+		}),
+		final_state: {
+			available: false,
+			reason: 'The current Playground PHP bench runner exits after scenario execution and does not export a restorable final site state.',
+		},
+		playground_review: reviewUrl ? {
+			available: true,
+			url: reviewUrl,
+		} : {
+			available: false,
+			reason: 'No hosted final-state artifact or caller-supplied Playground review URL was available for this scenario.',
+		},
+		redaction: {
+			applied: true,
+			key_pattern: SECRET_KEY_PATTERN.source,
+		},
+	});
+}
+
+function attachBundle(results, scenarioId, relativeBundlePath, reviewUrl) {
+	return {
+		...results,
+		scenarios: (results.scenarios || []).map((scenario) => {
+			if (scenario.id !== scenarioId) {
+				return scenario;
+			}
+			return {
+				...scenario,
+				artifacts: {
+					...(scenario.artifacts || {}),
+					replay_bundle: {
+						path: relativeBundlePath,
+						kind: 'json',
+						label: 'Replay bundle',
+					},
+				},
+				metadata: {
+					...(scenario.metadata || {}),
+					replay_bundle_path: relativeBundlePath,
+					playground_review: reviewUrl ? {
+						available: true,
+						url: reviewUrl,
+					} : {
+						available: false,
+						reason: 'Final-state Playground URLs need a hosted state export or caller-supplied review URL.',
+					},
+				},
+			};
+		}),
+	};
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	for (const required of ['results', 'scenario', 'config', 'outputDir']) {
+		if (!args[required]) {
+			usage();
+			throw new Error(`Missing --${required.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`);
+		}
+	}
+
+	const results = readJson(args.results);
+	const config = readJson(args.config);
+	const scenario = (results.scenarios || []).find((entry) => entry.id === args.scenario);
+	if (!scenario) {
+		throw new Error(`Scenario not found in results: ${args.scenario}`);
+	}
+
+	fs.mkdirSync(args.outputDir, { recursive: true });
+	const filename = `${safeId(args.scenario)}-replay-bundle.json`;
+	const bundlePath = path.join(args.outputDir, filename);
+	const relativeBundlePath = path.relative(path.dirname(args.results), bundlePath) || filename;
+	const bundle = buildBundle(results, scenario, config, relativeBundlePath);
+	fs.writeFileSync(bundlePath, `${JSON.stringify(bundle, null, 2)}\n`);
+
+	if (args.updateResults) {
+		const updated = attachBundle(results, args.scenario, relativeBundlePath, resolveReviewUrl(config, scenario));
+		fs.writeFileSync(args.results, `${JSON.stringify(updated, null, 2)}\n`);
+	}
+
+	console.log(bundlePath);
+}
+
+try {
+	main();
+} catch (error) {
+	console.error(`ERROR: ${error.message}`);
+	process.exit(1);
+}

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WORKLOAD_PATH="$SCRIPT_DIR/datamachine-agent-workload.php"
 WORKLOAD_PLAYGROUND_PATH="/homeboy-extension/scripts/agent/datamachine-agent-workload.php"
+REPLAY_BUNDLE_BUILDER="$SCRIPT_DIR/build-replay-bundle.js"
 
 CONFIG_PATH="${HOMEBOY_DATAMACHINE_AGENT_CONFIG_PATH:-}"
 if [ -z "$CONFIG_PATH" ] && [ "${1:-}" != "" ]; then
@@ -189,6 +190,23 @@ scenario='.scenarios[] | select(.id == "'"$WORKLOAD_ID"'")'
 if ! jq -e "$scenario" "$RESULTS_FILE" >/dev/null; then
     echo "ERROR: Data Machine agent workload did not run" >&2
     exit 1
+fi
+
+REPLAY_BUNDLE_DIR="${HOMEBOY_DATAMACHINE_AGENT_REPLAY_BUNDLE_DIR:-}"
+if [ -z "$REPLAY_BUNDLE_DIR" ]; then
+    REPLAY_BUNDLE_DIR=$(jq -r '.replay_bundle_dir // empty' "$CONFIG_PATH")
+fi
+if [ -n "$REPLAY_BUNDLE_DIR" ]; then
+    if [ ! -f "$REPLAY_BUNDLE_BUILDER" ]; then
+        echo "ERROR: replay bundle builder missing at $REPLAY_BUNDLE_BUILDER" >&2
+        exit 1
+    fi
+    node "$REPLAY_BUNDLE_BUILDER" \
+        --results "$RESULTS_FILE" \
+        --scenario "$WORKLOAD_ID" \
+        --config "$CONFIG_PATH" \
+        --output-dir "$REPLAY_BUNDLE_DIR" \
+        --update-results >/dev/null
 fi
 
 if jq -e "$scenario | .metadata.error?" "$RESULTS_FILE" >/dev/null; then


### PR DESCRIPTION
## Summary
- Add an optional replay bundle builder for Data Machine agent scenarios that snapshots redacted runner config, scenario metadata, transcript/action-log references, grader metadata, and Playground review availability.
- Attach `artifacts.replay_bundle.path` and `metadata.playground_review` back onto the scenario results when replay bundles are enabled.
- Expose `replay_bundle_artifact_name` in the reusable agent CI workflow and document the current final-state Playground URL limitation.

## Testing
- `bash wordpress/scripts/agent/build-replay-bundle-smoke.sh`
- `npm run lint:js -- scripts/agent/build-replay-bundle.js`
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh`
- `bash -n wordpress/scripts/agent/build-replay-bundle-smoke.sh`
- `node --check wordpress/scripts/agent/build-replay-bundle.js`
- `git diff --check`

## Notes
- Final-state Playground URLs are not generated by default because the current PHP bench runner exits after scenario execution and does not export a restorable site state. The bundle records that limitation and accepts caller-provided review URLs when available.

Fixes #566

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the existing Playground/Data Machine agent CI surfaces, drafted the replay bundle helper, workflow integration, docs, and smoke test. Chris remains responsible for review and merge.