### PR TITLE
Support custom Data Machine agent CI provider plugins

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -85,7 +85,8 @@ jobs:
 ## Inputs worth calling out
 
 - `include_agent_runtime_dependencies` defaults to `true` and checks out the standard WordPress agent runtime stack: `Automattic/agents-api`, `Extra-Chill/data-machine`, `Extra-Chill/data-machine-code`, and the provider plugin.
-- `agents_api_ref`, `data_machine_ref`, `data_machine_code_ref`, and `openai_provider_ref` control runtime dependency refs. `openai_provider_ref` defaults to `trunk`.
+- `agents_api_ref`, `data_machine_ref`, `data_machine_code_ref`, and `openai_provider_ref` control runtime dependency refs. `openai_provider_ref` defaults to `trunk` for the built-in OpenAI preset.
+- `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `credentials` keys. When `provider: openai`, an empty object preserves the existing OpenAI provider defaults.
 - `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.
 - `bundle_path` is resolved relative to the consumer checkout.
 - `bundle_repo`, `bundle_ref`, and `bundle_path_in_repo` let a consumer run against a bundle stored in another repository. The runner clones that repository before mounting the bundle into Playground.
@@ -148,3 +149,53 @@ jobs:
 Use tool recorders when a consumer currently has a custom bootstrap file whose
 only job is to force GitHub tool parameters or copy selected tool results into
 `metadata.engine_data`.
+
+## Provider plugin examples
+
+OpenAI remains the compatibility preset. Existing callers can keep omitting
+`provider_plugin` and pass `OPENAI_API_KEY` through inherited secrets:
+
+```yaml
+jobs:
+  run-agent:
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@v3
+    with:
+      bundle_path: bundles/example-agent
+      agent_slug: example-agent
+      pipeline_slug: example-pipeline
+      flow_slug: example-flow
+      target_repo: Extra-Chill/example
+      provider: openai
+      model: gpt-5.5
+    secrets: inherit
+```
+
+Non-OpenAI providers supply the plugin checkout and Data Machine credential
+mapping explicitly. Map each Data Machine option to one of the generic provider
+secret env names, then pass that secret in the reusable workflow call:
+
+```yaml
+jobs:
+  run-agent:
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@v3
+    with:
+      bundle_path: bundles/example-agent
+      agent_slug: example-agent
+      pipeline_slug: example-pipeline
+      flow_slug: example-flow
+      target_repo: Extra-Chill/example
+      provider: example-provider
+      model: example-model
+      provider_plugin: |
+        {
+          "repo": "Example/example-ai-provider",
+          "ref": "main",
+          "path": ".",
+          "register_function": "Example\\AiProvider\\register_provider",
+          "credentials": {
+            "connectors_ai_example_api_key": "PROVIDER_SECRET_1"
+          }
+        }
+    secrets:
+      PROVIDER_SECRET_1: ${{ secrets.EXAMPLE_PROVIDER_API_KEY }}
+```

--- a/.github/workflows/datamachine-agent-ci-self-smoke.yml
+++ b/.github/workflows/datamachine-agent-ci-self-smoke.yml
@@ -26,3 +26,32 @@ jobs:
       HOMEBOY_APP_ID: ${{ secrets.HOMEBOY_APP_ID }}
       HOMEBOY_APP_PRIVATE_KEY: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+  generic-provider-smoke:
+    uses: ./.github/workflows/datamachine-agent-ci.yml
+    with:
+      bundle_path: tests/fixtures/datamachine-agent-self-smoke/bundles/self-smoke-agent
+      agent_slug: self-smoke-agent
+      pipeline_slug: self-smoke-pipeline
+      flow_slug: self-smoke-generic-provider-flow
+      target_repo: Extra-Chill/homeboy-extensions
+      prompt: Exercise the generic provider plugin config path in dry-run mode.
+      provider: example-provider
+      model: example-model
+      success_requires_pr: false
+      dry_run: true
+      provider_plugin: |
+        {
+          "repo": "WordPress/ai-provider-for-openai",
+          "ref": "trunk",
+          "path": ".",
+          "register_function": "",
+          "credentials": {
+            "connectors_ai_example_api_key": "PROVIDER_SECRET_1"
+          }
+        }
+      engine_data_outputs: '{}'
+    secrets:
+      HOMEBOY_APP_ID: ${{ secrets.HOMEBOY_APP_ID }}
+      HOMEBOY_APP_PRIVATE_KEY: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
+      PROVIDER_SECRET_1: ${{ secrets.PROVIDER_SECRET_1 }}

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -45,6 +45,14 @@ name: Data Machine Agent CI (reusable)
       provider:
         type: string
         default: openai
+      provider_plugin:
+        description: |
+          JSON object describing the AI provider plugin to mount and configure.
+          Defaults to the OpenAI provider preset when provider is openai.
+          Supported keys: repo, ref, path, register_function, credentials.
+          credentials maps Data Machine option names to bench env names.
+        type: string
+        default: "{}"
       model:
         type: string
         default: gpt-5.5
@@ -207,7 +215,17 @@ name: Data Machine Agent CI (reusable)
       HOMEBOY_APP_PRIVATE_KEY:
         required: false
       OPENAI_API_KEY:
-        required: true
+        required: false
+      PROVIDER_SECRET_1:
+        required: false
+      PROVIDER_SECRET_2:
+        required: false
+      PROVIDER_SECRET_3:
+        required: false
+      PROVIDER_SECRET_4:
+        required: false
+      PROVIDER_SECRET_5:
+        required: false
     outputs:
       job_status:
         value: ${{ jobs.run-agent.outputs.job_status }}
@@ -323,15 +341,33 @@ jobs:
           DATA_MACHINE_CODE_REF: ${{ inputs.data_machine_code_ref }}
           OPENAI_PROVIDER_REF: ${{ inputs.openai_provider_ref }}
           PROVIDER: ${{ inputs.provider }}
+          PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
         run: |
           set -euo pipefail
           dependency_entries=()
+          provider_plugin_json="$(printf '%s' "$PROVIDER_PLUGIN" | jq -Rsc --arg provider "$PROVIDER" --arg openaiRef "$OPENAI_PROVIDER_REF" '
+            if (gsub("^\\s+|\\s+$"; "") | length) == 0 then {} else fromjson end
+            | if type == "object" then . else error("provider_plugin must be a JSON object") end
+            | {
+                repo: (.repo // (if $provider == "openai" then "WordPress/ai-provider-for-openai" else "" end)),
+                ref: (.ref // (if $provider == "openai" then $openaiRef else "" end)),
+                path: (.path // "."),
+                register_function: (.register_function // (if $provider == "openai" then "WordPress\\OpenAiAiProvider\\register_provider" else "" end)),
+                credentials: (.credentials // (if $provider == "openai" then {connectors_ai_openai_api_key: "OPENAI_API_KEY"} else {} end))
+              }
+          ')"
+          provider_plugin_repo="$(jq -r '.repo // ""' <<< "$provider_plugin_json")"
+          provider_plugin_ref="$(jq -r '.ref // ""' <<< "$provider_plugin_json")"
           if [ "$INCLUDE_AGENT_RUNTIME_DEPENDENCIES" = "true" ]; then
             dependency_entries+=("Automattic/agents-api@${AGENTS_API_REF}")
             dependency_entries+=("Extra-Chill/data-machine@${DATA_MACHINE_REF}")
             dependency_entries+=("Extra-Chill/data-machine-code@${DATA_MACHINE_CODE_REF}")
-            if [ "$PROVIDER" = "openai" ]; then
-              dependency_entries+=("WordPress/ai-provider-for-openai@${OPENAI_PROVIDER_REF}")
+            if [ -n "$provider_plugin_repo" ]; then
+              if [ -n "$provider_plugin_ref" ]; then
+                dependency_entries+=("${provider_plugin_repo}@${provider_plugin_ref}")
+              else
+                dependency_entries+=("${provider_plugin_repo}")
+              fi
             fi
           fi
           if [ -n "$VALIDATION_DEPENDENCIES" ]; then
@@ -391,6 +427,10 @@ jobs:
 
       - name: Install checked-out PHP dependencies
         if: ${{ inputs.run_agent }}
+        env:
+          PROVIDER: ${{ inputs.provider }}
+          PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
+          OPENAI_PROVIDER_REF: ${{ inputs.openai_provider_ref }}
         run: |
           set -euo pipefail
           for composer_file in .ci/*/composer.json; do
@@ -400,6 +440,22 @@ jobs:
             [ "$component_dir" != ".ci/homeboy-extensions/wordpress" ] || continue
             composer install --working-dir="$component_dir" --no-interaction --no-progress --prefer-dist
           done
+          provider_plugin_json="$(printf '%s' "$PROVIDER_PLUGIN" | jq -Rsc --arg provider "$PROVIDER" --arg openaiRef "$OPENAI_PROVIDER_REF" '
+            if (gsub("^\\s+|\\s+$"; "") | length) == 0 then {} else fromjson end
+            | if type == "object" then . else error("provider_plugin must be a JSON object") end
+            | {
+                repo: (.repo // (if $provider == "openai" then "WordPress/ai-provider-for-openai" else "" end)),
+                path: (.path // ".")
+              }
+          ')"
+          provider_plugin_repo="$(jq -r '.repo // ""' <<< "$provider_plugin_json")"
+          provider_plugin_path="$(jq -r '.path // "."' <<< "$provider_plugin_json")"
+          if [ -n "$provider_plugin_repo" ] && [ "$provider_plugin_path" != "." ]; then
+            provider_plugin_dir=".ci/${provider_plugin_repo#*/}/${provider_plugin_path}"
+            if [ -f "${provider_plugin_dir}/composer.json" ]; then
+              composer install --working-dir="$provider_plugin_dir" --no-interaction --no-progress --prefer-dist
+            fi
+          fi
 
       - name: Pre-flight bundle validation
         if: ${{ inputs.run_agent && inputs.bundle_validator_spec != '' }}
@@ -446,7 +502,14 @@ jobs:
           GITHUB_TOKEN_VALUE: ${{ steps.app-token.outputs.token || github.token }}
           GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT_VALUE: ${{ github.run_attempt }}
-          OPENAI_API_KEY_VALUE: ${{ secrets.OPENAI_API_KEY }}
+          PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
+          OPENAI_PROVIDER_REF: ${{ inputs.openai_provider_ref }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PROVIDER_SECRET_1: ${{ secrets.PROVIDER_SECRET_1 }}
+          PROVIDER_SECRET_2: ${{ secrets.PROVIDER_SECRET_2 }}
+          PROVIDER_SECRET_3: ${{ secrets.PROVIDER_SECRET_3 }}
+          PROVIDER_SECRET_4: ${{ secrets.PROVIDER_SECRET_4 }}
+          PROVIDER_SECRET_5: ${{ secrets.PROVIDER_SECRET_5 }}
         run: |
           set -euo pipefail
           config_path="${RUNNER_TEMP}/datamachine-agent-config.json"
@@ -458,6 +521,33 @@ jobs:
           transcript_host_dir="${GITHUB_WORKSPACE}/datamachine-agent-artifacts/${AGENT_SLUG}"
           transcript_guest_dir="/wordpress/wp-content/plugins/${component_slug}/datamachine-agent-artifacts/${AGENT_SLUG}"
           mapfile -t validation_paths < <(find "${GITHUB_WORKSPACE}/.ci" -mindepth 1 -maxdepth 1 -type d | sort)
+          provider_plugin_json="$(printf '%s' "$PROVIDER_PLUGIN" | jq -Rsc --arg provider "$PROVIDER" --arg openaiRef "$OPENAI_PROVIDER_REF" '
+            if (gsub("^\\s+|\\s+$"; "") | length) == 0 then {} else fromjson end
+            | if type == "object" then . else error("provider_plugin must be a JSON object") end
+            | {
+                repo: (.repo // (if $provider == "openai" then "WordPress/ai-provider-for-openai" else "" end)),
+                ref: (.ref // (if $provider == "openai" then $openaiRef else "" end)),
+                path: (.path // "."),
+                register_function: (.register_function // (if $provider == "openai" then "WordPress\\OpenAiAiProvider\\register_provider" else "" end)),
+                credentials: (.credentials // (if $provider == "openai" then {connectors_ai_openai_api_key: "OPENAI_API_KEY"} else {} end))
+              }
+              | if (.credentials | type) == "object" then . else error("provider_plugin.credentials must be a JSON object") end
+          ')"
+          provider_plugin_repo="$(jq -r '.repo // ""' <<< "$provider_plugin_json")"
+          provider_plugin_path="$(jq -r '.path // "."' <<< "$provider_plugin_json")"
+          if [ -n "$provider_plugin_repo" ] && [ "$provider_plugin_path" != "." ]; then
+            provider_plugin_repo_name="${provider_plugin_repo#*/}"
+            provider_plugin_root="${GITHUB_WORKSPACE}/.ci/${provider_plugin_repo_name}"
+            provider_plugin_host_path="${provider_plugin_root}/${provider_plugin_path}"
+            if [ -d "$provider_plugin_host_path" ]; then
+              filtered_validation_paths=()
+              for validation_path in "${validation_paths[@]}"; do
+                [ "$validation_path" != "$provider_plugin_root" ] || continue
+                filtered_validation_paths+=("$validation_path")
+              done
+              validation_paths=("${filtered_validation_paths[@]}" "$provider_plugin_host_path")
+            fi
+          fi
           validation_json="$(printf '%s\n' "${validation_paths[@]}" | jq -Rsc 'split("\n") | map(select(. != ""))')"
           validate_json_input() {
             local name="$1"
@@ -481,6 +571,19 @@ jobs:
           flow_step_patches_json="$(validate_json_input flow_step_patches array "$FLOW_STEP_PATCHES")"
           runner_workspace_json="$(validate_json_input runner_workspace object "$RUNNER_WORKSPACE_CONFIG")"
           fallback_pull_request_json="$(validate_json_input fallback_pull_request object "$FALLBACK_PULL_REQUEST")"
+          provider_register_function="$(jq -r '.register_function // ""' <<< "$provider_plugin_json")"
+          provider_credentials_json="$(jq -c '.credentials // {}' <<< "$provider_plugin_json")"
+          provider_bench_env_json="{}"
+          while IFS= read -r provider_env_name; do
+            [ -n "$provider_env_name" ] || continue
+            case "$provider_env_name" in
+              (*[!A-Za-z0-9_]*|[0-9]*|'') echo "Invalid provider credential env name: $provider_env_name" >&2; exit 1 ;;
+            esac
+            provider_env_value="${!provider_env_name:-}"
+            if [ -n "$provider_env_value" ]; then
+              provider_bench_env_json="$(jq -c --arg name "$provider_env_name" --arg value "$provider_env_value" '. + {($name): $value}' <<< "$provider_bench_env_json")"
+            fi
+          done < <(jq -r 'to_entries[] | .value | select(type == "string" and length > 0)' <<< "$provider_credentials_json")
           jq -n \
             --arg componentPath "$GITHUB_WORKSPACE" \
             --arg bundlePath "$bundle_abs" \
@@ -501,8 +604,10 @@ jobs:
             --arg githubToken "$GITHUB_TOKEN_VALUE" \
             --arg githubRunId "$GITHUB_RUN_ID_VALUE" \
             --arg githubRunAttempt "$GITHUB_RUN_ATTEMPT_VALUE" \
-            --arg openaiKey "$OPENAI_API_KEY_VALUE" \
+            --arg providerRegisterFunction "$provider_register_function" \
             --argjson validationDependencies "$validation_json" \
+            --argjson providerCredentials "$provider_credentials_json" \
+            --argjson providerBenchEnv "$provider_bench_env_json" \
             --argjson artifactExportConfig "$ARTIFACT_EXPORT_CONFIG" \
             --argjson successRequiresPr "$SUCCESS_REQUIRES_PR" \
             --argjson successCompletionOutcomes "$success_completion_outcomes_json" \
@@ -550,8 +655,8 @@ jobs:
               flow_slug: $flowSlug,
               provider: $provider,
               model: $model,
-              provider_register_function: (if $provider == "openai" then "WordPress\\OpenAiAiProvider\\register_provider" else "" end),
-              provider_credentials: (if $provider == "openai" then {connectors_ai_openai_api_key: "OPENAI_API_KEY"} else {} end),
+              provider_register_function: $providerRegisterFunction,
+              provider_credentials: $providerCredentials,
               github_token_env: "GITHUB_TOKEN",
               github_profile_id: ($agentSlug + "-ci"),
               target_repo: $targetRepo,
@@ -585,9 +690,8 @@ jobs:
               bench_env: {
                 GITHUB_TOKEN: $githubToken,
                 GITHUB_RUN_ID: $githubRunId,
-                GITHUB_RUN_ATTEMPT: $githubRunAttempt,
-                OPENAI_API_KEY: $openaiKey
-              }
+                GITHUB_RUN_ATTEMPT: $githubRunAttempt
+              } + $providerBenchEnv
             } + (if $dailyMemoryEnabled then {daily_memory_enabled: true} else {} end)' > "$config_path"
           printf 'config_path=%s\n' "$config_path" >> "$GITHUB_OUTPUT"
           printf 'transcript_host_dir=%s\n' "$transcript_host_dir" >> "$GITHUB_OUTPUT"
@@ -597,6 +701,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PROVIDER_SECRET_1: ${{ secrets.PROVIDER_SECRET_1 }}
+          PROVIDER_SECRET_2: ${{ secrets.PROVIDER_SECRET_2 }}
+          PROVIDER_SECRET_3: ${{ secrets.PROVIDER_SECRET_3 }}
+          PROVIDER_SECRET_4: ${{ secrets.PROVIDER_SECRET_4 }}
+          PROVIDER_SECRET_5: ${{ secrets.PROVIDER_SECRET_5 }}
           HOMEBOY_DATAMACHINE_AGENT_RESULTS_FILE: ${{ runner.temp }}/run-results.json
         run: bash .ci/homeboy-extensions/wordpress/scripts/agent/run-datamachine-agent.sh "${{ steps.config.outputs.config_path }}"
 

--- a/wordpress/docs/AGENT_CI_PLAYGROUND.md
+++ b/wordpress/docs/AGENT_CI_PLAYGROUND.md
@@ -83,6 +83,8 @@ requests against `Automattic/agents-api`.
 Consumers can customize:
 
 - Agent behavior through the bundle manifest, prompts, flows, and pipelines.
+- AI provider plugins through `provider_plugin`, including the plugin repo, ref,
+  subdirectory path, register function, and Data Machine credential mapping.
 - Runtime tools through `ability_tools` and `tool_recorders`.
 - GitHub scope through `target_repo`, `allowed_repos`, and `app_token_repos`.
 - WordPress state through `extra_wp_config_defines`, file mounts, and pre-run
@@ -128,6 +130,7 @@ knobs to `run-datamachine-agent.sh`:
 
 - Bundle location: `bundle_path`, `bundle_repo`, `bundle_ref`, `bundle_path_in_repo`.
 - Agent selection: `agent_slug`, `pipeline_slug`, `flow_slug`, `prompt`, `provider`, `model`.
+- Provider plugin: `provider_plugin`, with OpenAI defaults preserved when omitted for `provider: openai`.
 - WordPress runtime: `include_agent_runtime_dependencies`, runtime dependency refs, `playground_wordpress`, `extra_wp_config_defines`, `extra_playground_file_mounts`, `workload_run_before`, `workload_run_after`.
 - GitHub access: `target_repo`, `app_token_repos`, `allowed_repos`, `engine_key`, `tool_results_key`.
 - Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
@@ -144,6 +147,40 @@ maintaining a bespoke runner script.
 wrap GitHub tools. A recorder can attach forced parameters, capture selected input
 or output fields, and write them under a stable `metadata.engine_data` key for
 later `engine_data_outputs` projection.
+
+`provider_plugin` lets callers replace the OpenAI provider preset without
+changing the workload. The reusable workflow checks out the configured plugin,
+passes the configured register function to `datamachine-agent-workload.php`, and
+copies credential env values into `bench_env` for the workload to store as Data
+Machine options. OpenAI callers can keep using the default preset:
+
+```yaml
+with:
+  provider: openai
+  model: gpt-5.5
+secrets: inherit
+```
+
+Generic providers should provide a full plugin object and map Data Machine option
+names to generic provider secret env names:
+
+```yaml
+with:
+  provider: example-provider
+  model: example-model
+  provider_plugin: |
+    {
+      "repo": "Example/example-ai-provider",
+      "ref": "main",
+      "path": ".",
+      "register_function": "Example\\AiProvider\\register_provider",
+      "credentials": {
+        "connectors_ai_example_api_key": "PROVIDER_SECRET_1"
+      }
+    }
+secrets:
+  PROVIDER_SECRET_1: ${{ secrets.EXAMPLE_PROVIDER_API_KEY }}
+```
 
 ## Outputs and assertions
 


### PR DESCRIPTION
## Summary
- Add a `provider_plugin` JSON input to the reusable Data Machine agent CI workflow with OpenAI defaults preserved as the compatibility preset.
- Allow provider plugin repo/ref/path/register function/credential mappings, optional generic provider secret slots, and provider subdirectory Composer installs.
- Document OpenAI and generic provider usage, and add a dry-run self-smoke job for the generic provider config path.

Closes #561.

## Testing
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@datamachine-agent-ci-provider-plugins --extension wordpress --changed-only --summary`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "YAML OK #{path}" }' .github/workflows/datamachine-agent-ci.yml .github/workflows/datamachine-agent-ci-self-smoke.yml`
- `git diff --check`
- Local jq exercises for default OpenAI provider config resolution and generic provider credential forwarding.

## Notes
- `actionlint` was not installed locally, and `npx --yes actionlint` could not determine an executable.
- `bash wordpress/scripts/agent/datamachine-agent-runner-smoke.sh` failed before reaching the agent workload because the Playground fixture path `/wordpress/wp-content/plugins/playground-workloads/.pg-bench-result.txt` was unavailable in the local run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the workflow, documentation, and smoke workflow changes; Chris remains responsible for review and merge.