### PR TITLE
fix(wordpress): parenthesize agent bench env merge

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -691,11 +691,11 @@ jobs:
               } * $artifactExportConfig),
               dry_run: $dryRun,
               transcript_dir: $transcriptGuestDir,
-              bench_env: {
+              bench_env: ({
                 GITHUB_TOKEN: $githubToken,
                 GITHUB_RUN_ID: $githubRunId,
                 GITHUB_RUN_ATTEMPT: $githubRunAttempt
-              } + $providerBenchEnv
+              } + $providerBenchEnv)
             } + (if $dailyMemoryEnabled then {daily_memory_enabled: true} else {} end)' > "$config_path"
           printf 'config_path=%s\n' "$config_path" >> "$GITHUB_OUTPUT"
           printf 'transcript_host_dir=%s\n' "$transcript_host_dir" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fix the Data Machine agent CI config generator so `bench_env` merges provider credentials with valid jq syntax.
- Prevents reusable workflow runs from failing in `Build runner config` before the agent starts.

## Validation
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\"); puts \"yaml ok\"'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the workflow jq parse failure from a downstream iterator run and drafted this small syntax fix; Chris reviewed the PR path.