### PR TITLE
feat(wordpress): add block theme quality probe

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -171,6 +171,86 @@ scenario can earn partial credit. Configured workload steps marked
 structured zero-reward grade with `metadata.grade.failure`, allowing result
 aggregation to consume failures without scenario-specific parsing.
 
+## Block Theme Quality Probe
+
+Playground scenario graders can call a generic PHP-first WordPress quality probe
+after the scenario action loop has modified the site. The helper is mounted with
+the WordPress extension inside Playground:
+
+```php
+require_once '/homeboy-extension/scripts/bench/lib/block-theme-quality-probe.php';
+
+return homeboy_wordpress_block_theme_quality_payload([
+    'target_post_ids' => [(int) get_option('page_on_front', 0)],
+]);
+```
+
+`homeboy_wordpress_collect_block_theme_quality()` returns the raw structured
+probe. `homeboy_wordpress_block_theme_quality_payload()` wraps it as a Playground
+workload payload: numeric and boolean values are emitted under `metrics`, and
+the full raw probe is stored under `metadata.wordpress_quality`.
+
+Collected signals include:
+
+- active theme signals: `used_block_theme`, `theme_json_present`
+- site/content counts: `front_page_id`, `pages_seen`, `templates_seen`,
+  `template_parts_seen`, `navigation_posts_seen`
+- block counts: `posts_with_blocks`, `total_blocks`, `core_html_blocks`,
+  `serialized_block_comments`, `template_part_blocks`, `navigation_blocks`
+- target/front-page counts: `target_pages_seen`, `target_posts_with_blocks`,
+  `target_total_blocks`, `target_core_html_blocks`,
+  `target_serialized_block_comments`
+- fallback-quality signals: `raw_html_unconverted`,
+  `target_raw_html_unconverted`, `navigation_created`
+
+Use `target_post_ids` or `target_post_titles` when a scenario creates a specific
+page that should be graded independently from the rest of the site. If no target
+is supplied, the helper automatically treats `page_on_front` as the target when
+that option is set.
+
+Example grader that gives partial credit:
+
+```php
+require_once '/homeboy-extension/scripts/bench/lib/block-theme-quality-probe.php';
+
+$quality = homeboy_wordpress_collect_block_theme_quality();
+$checks = [
+    [
+        'id' => 'uses_block_theme',
+        'passed' => $quality['used_block_theme'],
+        'score' => $quality['used_block_theme'] ? 0.25 : 0,
+        'max_score' => 0.25,
+    ],
+    [
+        'id' => 'front_page_has_blocks',
+        'passed' => $quality['target_total_blocks'] >= 5,
+        'score' => $quality['target_total_blocks'] >= 5 ? 0.5 : 0,
+        'max_score' => 0.5,
+    ],
+    [
+        'id' => 'avoids_raw_html',
+        'passed' => $quality['target_raw_html_unconverted'] === 0,
+        'score' => $quality['target_raw_html_unconverted'] === 0 ? 0.25 : 0,
+        'max_score' => 0.25,
+    ],
+];
+
+$score = array_sum(array_column($checks, 'score'));
+
+return [
+    'success' => $score >= 1,
+    'reward' => $score,
+    'grade' => [
+        'score' => $score,
+        'max_score' => 1,
+        'checks' => $checks,
+    ],
+    'metadata' => [
+        'wordpress_quality' => $quality,
+    ],
+];
+```
+
 Playground bench runs also emit `wp-rl`-friendly artifacts next to the
 BenchResults JSON file:
 

--- a/wordpress/scripts/bench/lib/block-theme-quality-probe.php
+++ b/wordpress/scripts/bench/lib/block-theme-quality-probe.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Generic WordPress block theme quality probe for Playground workloads.
+ *
+ * Scenario graders can require this file from the mounted extension path:
+ * /homeboy-extension/scripts/bench/lib/block-theme-quality-probe.php
+ */
+
+if (!function_exists('homeboy_wordpress_count_blocks_for_quality_probe')) {
+    /**
+     * Count parsed blocks recursively into the quality probe accumulator.
+     *
+     * @param array<int,array<string,mixed>> $blocks Parsed block tree.
+     * @param array<string,int>             $counts Probe counters.
+     */
+    function homeboy_wordpress_count_blocks_for_quality_probe(array $blocks, array &$counts): void {
+        foreach ($blocks as $block) {
+            $name = isset($block['blockName']) ? (string) $block['blockName'] : '';
+            if ($name !== '') {
+                $counts['total_blocks']++;
+                if ($name === 'core/html') {
+                    $counts['core_html_blocks']++;
+                }
+                if ($name === 'core/navigation') {
+                    $counts['navigation_blocks']++;
+                }
+                if ($name === 'core/template-part') {
+                    $counts['template_part_blocks']++;
+                }
+            }
+
+            if (!empty($block['innerBlocks']) && is_array($block['innerBlocks'])) {
+                homeboy_wordpress_count_blocks_for_quality_probe($block['innerBlocks'], $counts);
+            }
+        }
+    }
+}
+
+if (!function_exists('homeboy_wordpress_quality_probe_scalar_list')) {
+    /**
+     * Normalize a scalar/list option into unique strings.
+     *
+     * @param mixed $value Input value.
+     * @return array<int,string>
+     */
+    function homeboy_wordpress_quality_probe_scalar_list($value): array {
+        if ($value === null || $value === '') {
+            return [];
+        }
+        $items = is_array($value) ? $value : [$value];
+        $normalized = [];
+        foreach ($items as $item) {
+            if (!is_scalar($item)) {
+                continue;
+            }
+            $item = trim((string) $item);
+            if ($item !== '' && !in_array($item, $normalized, true)) {
+                $normalized[] = $item;
+            }
+        }
+
+        return $normalized;
+    }
+}
+
+if (!function_exists('homeboy_wordpress_collect_block_theme_quality')) {
+    /**
+     * Collect generic WordPress site/block/theme quality metrics.
+     *
+     * Supported options:
+     * - target_post_ids: IDs to treat as scenario target pages/posts.
+     * - target_post_titles: titles to treat as scenario target pages/posts.
+     * - post_types: post types to scan. Defaults to pages, templates, template parts,
+     *   and navigation posts.
+     *
+     * @param array<string,mixed> $options Probe options.
+     * @return array<string,mixed> Structured quality metrics.
+     */
+    function homeboy_wordpress_collect_block_theme_quality(array $options = []): array {
+        $front_page_id = (int) get_option('page_on_front', 0);
+        $target_post_ids = array_map('intval', homeboy_wordpress_quality_probe_scalar_list($options['target_post_ids'] ?? []));
+        if ($front_page_id > 0 && !in_array($front_page_id, $target_post_ids, true)) {
+            $target_post_ids[] = $front_page_id;
+        }
+        $target_post_titles = homeboy_wordpress_quality_probe_scalar_list($options['target_post_titles'] ?? []);
+        $post_types = homeboy_wordpress_quality_probe_scalar_list($options['post_types'] ?? ['page', 'wp_template', 'wp_template_part', 'wp_navigation']);
+
+        $theme_json_present = false;
+        foreach (array_unique([get_stylesheet_directory(), get_template_directory()]) as $theme_dir) {
+            if (is_string($theme_dir) && $theme_dir !== '' && is_readable($theme_dir . '/theme.json')) {
+                $theme_json_present = true;
+                break;
+            }
+        }
+
+        $counts = [
+            'front_page_id' => $front_page_id,
+            'posts_seen' => 0,
+            'pages_seen' => 0,
+            'templates_seen' => 0,
+            'template_parts_seen' => 0,
+            'navigation_posts_seen' => 0,
+            'posts_with_blocks' => 0,
+            'total_blocks' => 0,
+            'core_html_blocks' => 0,
+            'serialized_block_comments' => 0,
+            'template_part_blocks' => 0,
+            'navigation_blocks' => 0,
+            'raw_html_unconverted' => 0,
+            'target_posts_seen' => 0,
+            'target_pages_seen' => 0,
+            'target_posts_with_blocks' => 0,
+            'target_total_blocks' => 0,
+            'target_core_html_blocks' => 0,
+            'target_serialized_block_comments' => 0,
+            'target_raw_html_unconverted' => 0,
+        ];
+
+        $posts = get_posts([
+            'post_type' => $post_types,
+            'post_status' => 'any',
+            'numberposts' => -1,
+        ]);
+
+        foreach ($posts as $post) {
+            $content = (string) $post->post_content;
+            $has_content = trim($content) !== '';
+            $has_blocks = strpos($content, '<!-- wp:') !== false;
+            $has_raw_html_without_blocks = !$has_blocks && $has_content && preg_match('/<\/?[a-z][a-z0-9:-]*(?:\s|>)/i', $content) === 1;
+
+            if ($has_content) {
+                $counts['posts_seen']++;
+            }
+            if ($post->post_type === 'page') {
+                $counts['pages_seen']++;
+            } elseif ($post->post_type === 'wp_template') {
+                $counts['templates_seen']++;
+            } elseif ($post->post_type === 'wp_template_part') {
+                $counts['template_parts_seen']++;
+            } elseif ($post->post_type === 'wp_navigation') {
+                $counts['navigation_posts_seen']++;
+            }
+
+            $serialized_block_comments = substr_count($content, '<!-- wp:');
+            $counts['serialized_block_comments'] += $serialized_block_comments;
+            if ($has_blocks) {
+                $counts['posts_with_blocks']++;
+            }
+            if ($has_raw_html_without_blocks) {
+                $counts['raw_html_unconverted']++;
+            }
+
+            $before_total = $counts['total_blocks'];
+            $before_core_html = $counts['core_html_blocks'];
+            if ($has_content && function_exists('parse_blocks')) {
+                homeboy_wordpress_count_blocks_for_quality_probe(parse_blocks($content), $counts);
+            }
+
+            $is_target = in_array((int) $post->ID, $target_post_ids, true)
+                || in_array((string) $post->post_title, $target_post_titles, true);
+            if (!$is_target) {
+                continue;
+            }
+
+            $counts['target_posts_seen']++;
+            if ($post->post_type === 'page') {
+                $counts['target_pages_seen']++;
+            }
+            if ($has_blocks) {
+                $counts['target_posts_with_blocks']++;
+            }
+            if ($has_raw_html_without_blocks) {
+                $counts['target_raw_html_unconverted']++;
+            }
+            $counts['target_serialized_block_comments'] += $serialized_block_comments;
+            $counts['target_total_blocks'] += $counts['total_blocks'] - $before_total;
+            $counts['target_core_html_blocks'] += $counts['core_html_blocks'] - $before_core_html;
+        }
+
+        $nav_menu_count = 0;
+        if (function_exists('wp_get_nav_menus')) {
+            $nav_menus = wp_get_nav_menus();
+            $nav_menu_count = is_array($nav_menus) ? count($nav_menus) : 0;
+        }
+
+        return array_merge([
+            'used_block_theme' => function_exists('wp_is_block_theme') ? (bool) wp_is_block_theme() : false,
+            'theme_json_present' => $theme_json_present,
+        ], $counts, [
+            'nav_menus_seen' => $nav_menu_count,
+            'navigation_created' => $counts['navigation_blocks'] > 0 || $counts['navigation_posts_seen'] > 0 || $nav_menu_count > 0,
+        ]);
+    }
+}
+
+if (!function_exists('homeboy_wordpress_block_theme_quality_payload')) {
+    /**
+     * Return a Playground workload payload with numeric metrics and metadata.
+     *
+     * @param array<string,mixed> $options Probe options.
+     * @return array<string,array<string,mixed>> Workload payload.
+     */
+    function homeboy_wordpress_block_theme_quality_payload(array $options = []): array {
+        $quality = homeboy_wordpress_collect_block_theme_quality($options);
+        $metrics = [];
+        foreach ($quality as $key => $value) {
+            if (is_bool($value)) {
+                $metrics[$key] = $value ? 1 : 0;
+            } elseif (is_int($value) || is_float($value)) {
+                $metrics[$key] = $value;
+            }
+        }
+
+        return [
+            'metrics' => $metrics,
+            'metadata' => [
+                'wordpress_quality' => $quality,
+            ],
+        ];
+    }
+}

--- a/wordpress/scripts/bench/playground-bench-block-theme-quality-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-block-theme-quality-smoke.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Playground block theme quality probe smoke test (homeboy-extensions#577).
+#
+# Exercises the generic PHP-first quality helper through the configured
+# Playground workload path that scenario graders use.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/playground-block-theme-quality"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ ! -f "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" ]; then
+    echo "ERROR: @wp-playground/cli not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && npm install" >&2
+    exit 1
+fi
+
+if [ ! -d "${EXTENSION_PATH}/vendor/wp-phpunit" ]; then
+    echo "ERROR: wp-phpunit not installed." >&2
+    echo "Run: cd ${EXTENSION_PATH} && composer install" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-block-theme-quality-smoke.XXXXXX")
+cleanup() {
+    rm -f "$RESULTS_TMPFILE"
+}
+trap cleanup EXIT
+
+SETTINGS_JSON=$(cat <<'JSON'
+{
+  "playground_workloads": [
+    {
+      "id": "block-theme-quality",
+      "label": "Block theme quality probe",
+      "run": [
+        {
+          "type": "php",
+          "file": "workloads/collect-quality.php",
+          "role": "grader"
+        }
+      ]
+    }
+  ],
+  "bench_warmup_iterations": 0
+}
+JSON
+)
+
+echo "============================================"
+echo "Playground block theme quality smoke test"
+echo "============================================"
+echo "Fixture:    $FIXTURE_DIR"
+echo "Iterations: 1"
+echo "Warmup:    0"
+echo ""
+
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_COMPONENT_ID=playground-block-theme-quality \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+scenario='.scenarios[] | select(.id == "block-theme-quality")'
+scenario_count=$(jq -r '.scenarios | length' "$RESULTS_TMPFILE")
+if [ "$scenario_count" -ne 2 ]; then
+    echo "ERROR: expected 2 scenarios (__bootstrap + quality probe), got $scenario_count" >&2
+    exit 1
+fi
+echo "✓ scenarios length == 2 (__bootstrap + quality probe)"
+
+for metric in \
+    used_block_theme_mean \
+    theme_json_present_mean \
+    front_page_id_mean \
+    pages_seen_mean \
+    templates_seen_mean \
+    template_parts_seen_mean \
+    posts_with_blocks_mean \
+    total_blocks_mean \
+    core_html_blocks_mean \
+    serialized_block_comments_mean \
+    target_pages_seen_mean \
+    target_total_blocks_mean \
+    target_core_html_blocks_mean \
+    raw_html_unconverted_mean \
+    navigation_created_mean; do
+    value=$(jq -r "$scenario | .metrics.${metric} // \"missing\"" "$RESULTS_TMPFILE")
+    if [ "$value" = "missing" ]; then
+        echo "ERROR: missing quality metric ${metric}" >&2
+        exit 1
+    fi
+done
+echo "✓ quality metrics emitted"
+
+if [ "$(jq -r "$scenario | .metrics.target_pages_seen_mean" "$RESULTS_TMPFILE")" != "1" ]; then
+    echo "ERROR: target front page was not counted" >&2
+    exit 1
+fi
+if [ "$(jq -r "$scenario | .metrics.target_total_blocks_mean" "$RESULTS_TMPFILE")" != "3" ]; then
+    echo "ERROR: target front page block count was not 3" >&2
+    exit 1
+fi
+if [ "$(jq -r "$scenario | .metrics.target_core_html_blocks_mean" "$RESULTS_TMPFILE")" != "1" ]; then
+    echo "ERROR: target core/html block count was not 1" >&2
+    exit 1
+fi
+if [ "$(jq -r "$scenario | .metrics.raw_html_unconverted_mean" "$RESULTS_TMPFILE")" != "1" ]; then
+    echo "ERROR: raw HTML without blocks was not detected" >&2
+    exit 1
+fi
+if [ "$(jq -r "$scenario | .metrics.navigation_created_mean" "$RESULTS_TMPFILE")" != "1" ]; then
+    echo "ERROR: navigation presence was not detected" >&2
+    exit 1
+fi
+echo "✓ target, raw HTML, and navigation signals are correct"
+
+if [ "$(jq -r "$scenario | .metadata.wordpress_quality.target_total_blocks" "$RESULTS_TMPFILE")" != "3" ]; then
+    echo "ERROR: structured wordpress_quality metadata missing target_total_blocks" >&2
+    exit 1
+fi
+echo "✓ structured metadata emitted"
+
+echo ""
+echo "============================================"
+echo "✓ Block theme quality smoke test PASSED"
+echo "============================================"

--- a/wordpress/scripts/bench/playground-results-artifacts.sh
+++ b/wordpress/scripts/bench/playground-results-artifacts.sh
@@ -73,7 +73,7 @@ homeboy_wordpress_playground_leaderboard_filter() {
             errors: (map(select(.error != null or .success == false)) | length),
             avg_reward: (map(.reward | num_or_null) | map(select(. != null)) | if length == 0 then null else add / length end),
             avg_duration_ms: (map(.duration_ms | num_or_null) | map(select(. != null)) | if length == 0 then null else add / length end)
-        }) | sort_by(-.avg_reward, .avg_duration_ms // 999999999, .provider, .model)) as $groups
+        }) | sort_by(-(.avg_reward // -1), .avg_duration_ms // 999999999, .provider, .model)) as $groups
         | [
             "# Playground Scenario Leaderboard",
             "",

--- a/wordpress/tests/fixtures/playground-block-theme-quality/playground-block-theme-quality.php
+++ b/wordpress/tests/fixtures/playground-block-theme-quality/playground-block-theme-quality.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * Plugin Name: Playground block theme quality fixture
+ */

--- a/wordpress/tests/fixtures/playground-block-theme-quality/workloads/collect-quality.php
+++ b/wordpress/tests/fixtures/playground-block-theme-quality/workloads/collect-quality.php
@@ -1,0 +1,67 @@
+<?php
+
+require_once '/homeboy-extension/scripts/bench/lib/block-theme-quality-probe.php';
+
+$front_page_id = wp_insert_post([
+    'post_type' => 'page',
+    'post_status' => 'publish',
+    'post_title' => 'Quality Probe Front Page',
+    'post_content' => '<!-- wp:navigation /--><!-- wp:paragraph --><p>Welcome to the bakery.</p><!-- /wp:paragraph --><!-- wp:html --><section>Hours</section><!-- /wp:html -->',
+], true);
+
+if (is_wp_error($front_page_id)) {
+    throw new RuntimeException($front_page_id->get_error_message());
+}
+
+$raw_page_id = wp_insert_post([
+    'post_type' => 'page',
+    'post_status' => 'publish',
+    'post_title' => 'Raw HTML Page',
+    'post_content' => '<main><h1>Plain HTML</h1></main>',
+], true);
+
+if (is_wp_error($raw_page_id)) {
+    throw new RuntimeException($raw_page_id->get_error_message());
+}
+
+// Bypass editor/content filters so the smoke has a stable raw-HTML fixture.
+global $wpdb;
+$wpdb->update($wpdb->posts, ['post_content' => '<main><h1>Plain HTML</h1></main>'], ['ID' => (int) $raw_page_id]);
+clean_post_cache((int) $raw_page_id);
+
+foreach ([
+    'wp_template' => '<!-- wp:template-part {"slug":"header"} /--><!-- wp:post-content /-->',
+    'wp_template_part' => '<!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph --><p>Header</p><!-- /wp:paragraph --></div><!-- /wp:group -->',
+] as $post_type => $content) {
+    $post_id = wp_insert_post([
+        'post_type' => $post_type,
+        'post_status' => 'publish',
+        'post_title' => 'Quality Probe ' . $post_type,
+        'post_name' => 'quality-probe-' . $post_type,
+        'post_content' => $content,
+    ], true);
+
+    if (is_wp_error($post_id)) {
+        throw new RuntimeException($post_id->get_error_message());
+    }
+}
+
+if (post_type_exists('wp_navigation')) {
+    $navigation_id = wp_insert_post([
+        'post_type' => 'wp_navigation',
+        'post_status' => 'publish',
+        'post_title' => 'Quality Probe Navigation',
+        'post_content' => '<!-- wp:navigation-link {"label":"Home","url":"/"} /-->',
+    ], true);
+
+    if (is_wp_error($navigation_id)) {
+        throw new RuntimeException($navigation_id->get_error_message());
+    }
+}
+
+update_option('show_on_front', 'page');
+update_option('page_on_front', (int) $front_page_id);
+
+return homeboy_wordpress_block_theme_quality_payload([
+    'target_post_ids' => [(int) $front_page_id],
+]);


### PR DESCRIPTION
## Summary
- Adds a generic PHP-first WordPress block/theme quality probe helper for Playground workload and grader scenarios.
- Emits numeric BenchResults metrics plus structured `metadata.wordpress_quality` for block theme, template, block, raw HTML, target page, and navigation signals.
- Adds smoke coverage and docs showing how scenario graders can call the helper.

## Verification
- `php -l wordpress/scripts/bench/lib/block-theme-quality-probe.php`
- `php -l wordpress/tests/fixtures/playground-block-theme-quality/workloads/collect-quality.php`
- `php -l wordpress/tests/fixtures/playground-block-theme-quality/playground-block-theme-quality.php`
- `bash wordpress/scripts/bench/playground-bench-block-theme-quality-smoke.sh`
- `bash wordpress/scripts/bench/playground-results-artifacts-smoke.sh`
- `bash wordpress/scripts/bench/playground-bench-configured-workloads-smoke.sh`

Closes #577

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the helper implementation, smoke fixture, documentation, and targeted verification steps for Chris to review.