### PR TITLE
Drain Data Machine child jobs in agent CI

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Smoke test for Data Machine agent child-job draining and result aggregation.
+ *
+ * Run with: php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
+ */
+
+namespace DataMachine\Core\Database\Jobs {
+    class Jobs {
+        public function get_job( int $job_id ): array {
+            return array(
+                'job_id' => $job_id,
+                'status' => 'completed',
+            );
+        }
+
+        public function get_children( int $parent_job_id ): array {
+            return array(
+                array(
+                    'job_id'        => 201,
+                    'parent_job_id' => $parent_job_id,
+                    'status'        => 'completed',
+                    'engine_data'   => array(
+                        'github_tool_results' => array(
+                            array(
+                                'success' => true,
+                                'url'     => 'https://github.com/example/repo/pull/12',
+                            ),
+                        ),
+                    ),
+                ),
+                array(
+                    'job_id'        => 202,
+                    'parent_job_id' => $parent_job_id,
+                    'status'        => 'completed',
+                    'engine_data'   => array(
+                        'github_tool_results' => array(
+                            array(
+                                'success'   => true,
+                                'tool_name' => 'comment_github_pull_request',
+                                'url'       => 'https://github.com/example/site/pull/99#issuecomment-1',
+                            ),
+                        ),
+                    ),
+                ),
+            );
+        }
+    }
+}
+
+namespace DataMachine\Core\Database\Agents {
+    class Agents {}
+}
+
+namespace DataMachine\Core\Database\Chat {
+    class ConversationStoreFactory {}
+}
+
+namespace DataMachine\Core\Database\Flows {
+    class Flows {}
+}
+
+namespace DataMachine\Core\Database\Pipelines {
+    class Pipelines {}
+}
+
+namespace DataMachine\Core {
+    class PluginSettings {}
+}
+
+namespace {
+    if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/' );
+    }
+
+    if ( ! function_exists( 'wp_set_current_user' ) ) {
+        function wp_set_current_user( int $user_id ): void {}
+    }
+
+    if ( ! function_exists( 'wp_get_ability' ) ) {
+        function wp_get_ability( string $ability_name ): object {
+            return new class {
+                public function execute( array $args ): array {
+                    $GLOBALS['homeboy_child_drain_calls'][] = (int) ( $args['job_id'] ?? 0 );
+                    return array(
+                        'success' => true,
+                        'job_id'  => (int) ( $args['job_id'] ?? 0 ),
+                    );
+                }
+            };
+        }
+    }
+
+    if ( ! function_exists( 'datamachine_get_engine_data' ) ) {
+        function datamachine_get_engine_data( int $job_id ): array {
+            return array();
+        }
+    }
+
+    if ( ! function_exists( 'wp_json_encode' ) ) {
+        function wp_json_encode( $value, int $flags = 0 ): string {
+            return (string) json_encode( $value, $flags );
+        }
+    }
+
+    putenv(
+        'HOMEBOY_DATAMACHINE_AGENT_CONFIG=' . wp_json_encode(
+            array(
+                'dry_run'    => true,
+                'agent_slug' => 'child-drain-smoke-agent',
+                'flow_slug'  => 'child-drain-smoke-flow',
+            )
+        )
+    );
+
+    require __DIR__ . '/datamachine-agent-workload.php';
+
+    $jobs = new \DataMachine\Core\Database\Jobs\Jobs();
+    $summary = homeboy_datamachine_agent_drain_child_jobs( 101, array(), $jobs );
+    $calls = $GLOBALS['homeboy_child_drain_calls'] ?? array();
+
+    if ( array( 201, 202 ) !== $calls ) {
+        fwrite( STDERR, "Expected child jobs 201 and 202 to be drained.\n" );
+        exit( 1 );
+    }
+
+    if ( 2 !== count( $summary['children'] ?? array() ) ) {
+        fwrite( STDERR, "Expected two child jobs in the summary.\n" );
+        exit( 1 );
+    }
+
+    $engine_data = homeboy_datamachine_agent_merge_child_engine_data( array(), $summary['children'], array() );
+    if ( ! homeboy_datamachine_agent_pr_opened( $engine_data, array() ) ) {
+        fwrite( STDERR, "Expected child pull request result to satisfy PR detection.\n" );
+        exit( 1 );
+    }
+
+    fwrite( STDOUT, "Data Machine agent child drain smoke passed.\n" );
+}

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -152,6 +152,53 @@ if ( ! function_exists( 'homeboy_datamachine_agent_pr_opened' ) ) {
         return is_array( $engine_data[ $tool_results_key ] ?? null ) ? $engine_data[ $tool_results_key ] : array();
     }
 
+    function homeboy_datamachine_agent_set_tool_results( array $engine_data, array $config, array $tool_results ): array {
+        $tool_results_key = homeboy_datamachine_agent_scalar( $config, 'tool_results_key', 'github_tool_results' );
+        $engine_key       = homeboy_datamachine_agent_scalar( $config, 'engine_key' );
+
+        if ( '' !== $engine_key ) {
+            if ( ! isset( $engine_data[ $engine_key ] ) || ! is_array( $engine_data[ $engine_key ] ) ) {
+                $engine_data[ $engine_key ] = array();
+            }
+            $engine_data[ $engine_key ][ $tool_results_key ] = $tool_results;
+            return $engine_data;
+        }
+
+        $engine_data[ $tool_results_key ] = $tool_results;
+        return $engine_data;
+    }
+
+    function homeboy_datamachine_agent_merge_child_engine_data( array $engine_data, array $child_jobs, array $config ): array {
+        if ( empty( $child_jobs ) ) {
+            return $engine_data;
+        }
+
+        $tool_results = homeboy_datamachine_agent_tool_results( $engine_data, $config );
+        $child_summaries = array();
+
+        foreach ( $child_jobs as $child_job ) {
+            if ( ! is_array( $child_job ) ) {
+                continue;
+            }
+
+            $child_engine_data = is_array( $child_job['engine_data'] ?? null ) ? $child_job['engine_data'] : array();
+            $child_tool_results = homeboy_datamachine_agent_tool_results( $child_engine_data, $config );
+            if ( ! empty( $child_tool_results ) ) {
+                $tool_results = array_merge( $tool_results, $child_tool_results );
+            }
+
+            $child_summaries[] = array(
+                'job_id'        => (int) ( $child_job['job_id'] ?? 0 ),
+                'status'        => (string) ( $child_job['status'] ?? '' ),
+                'parent_job_id' => (int) ( $child_job['parent_job_id'] ?? 0 ),
+            );
+        }
+
+        $engine_data = homeboy_datamachine_agent_set_tool_results( $engine_data, $config, $tool_results );
+        $engine_data['child_jobs'] = $child_summaries;
+        return $engine_data;
+    }
+
     function homeboy_datamachine_agent_pr_opened( array $engine_data, array $config ): bool {
         $tool_results = homeboy_datamachine_agent_tool_results( $engine_data, $config );
 
@@ -1301,6 +1348,34 @@ if ( ! function_exists( 'homeboy_datamachine_agent_drain_job' ) ) {
             'retry_waited_ms'  => $waited_ms,
         );
     }
+
+    function homeboy_datamachine_agent_drain_child_jobs( int $parent_job_id, array $config, Jobs $jobs ): array {
+        if ( ! method_exists( $jobs, 'get_children' ) ) {
+            return array(
+                'children'      => array(),
+                'drain_results' => array(),
+            );
+        }
+
+        $children = $jobs->get_children( $parent_job_id );
+        $drain_results = array();
+        foreach ( $children as $child_job ) {
+            $child_job_id = (int) ( $child_job['job_id'] ?? 0 );
+            if ( $child_job_id <= 0 ) {
+                continue;
+            }
+
+            $drain_results[] = array(
+                'job_id'  => $child_job_id,
+                'summary' => homeboy_datamachine_agent_drain_job( $child_job_id, $config, $jobs ),
+            );
+        }
+
+        return array(
+            'children'      => $jobs->get_children( $parent_job_id ),
+            'drain_results' => $drain_results,
+        );
+    }
 }
 
 if ( function_exists( 'wp_set_current_user' ) ) {
@@ -1471,10 +1546,22 @@ $metadata['drain_result'] = $drain_result;
 $metadata['drain_history'] = $drain_summary['drain_history'];
 $metadata['retry_waited_ms'] = $drain_summary['retry_waited_ms'];
 
+$child_drain_summary = homeboy_datamachine_agent_drain_child_jobs( $job_id, $config, $jobs );
+$metadata['child_jobs'] = array_map(
+    static fn( array $child_job ) => array(
+        'job_id'        => (int) ( $child_job['job_id'] ?? 0 ),
+        'status'        => (string) ( $child_job['status'] ?? '' ),
+        'parent_job_id' => (int) ( $child_job['parent_job_id'] ?? 0 ),
+    ),
+    $child_drain_summary['children']
+);
+$metadata['child_drain_results'] = $child_drain_summary['drain_results'];
+
 $job = $jobs->get_job( $job_id );
 $job_status = is_array( $job ) ? (string) ( $job['status'] ?? '' ) : '';
 $engine_data = function_exists( 'datamachine_get_engine_data' ) ? datamachine_get_engine_data( $job_id ) : array();
 $engine_data = homeboy_datamachine_agent_merge_recorded_tool_results( $engine_data, $config );
+$engine_data = homeboy_datamachine_agent_merge_child_engine_data( $engine_data, $child_drain_summary['children'], $config );
 $transcript_dir = homeboy_datamachine_agent_scalar( $config, 'transcript_dir' );
 $transcript_artifacts = homeboy_datamachine_agent_export_transcript( $job_id, $engine_data, $transcript_dir );
 $pr_opened = homeboy_datamachine_agent_pr_opened( $engine_data, $config );


### PR DESCRIPTION
## Summary
- Drain Data Machine child jobs after a parent fan-out run completes.
- Merge child job tool results back into the runner engine data so success/output detection can see PRs opened by child jobs.
- Add a smoke test for child drain and PR-result aggregation.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-retry-drain-smoke.php`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@drain-datamachine-child-jobs --extension wordpress`

Note: `homeboy test --path /Users/chubes/Developer/homeboy-extensions@drain-datamachine-child-jobs --extension nodejs` was attempted first and failed before tests because this repo has no `package.json`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the fan-out runner gap, drafted the child-job drain/result aggregation code, and added smoke coverage for Chris to review.