### PR TITLE
fix(wordpress): upload agent transcripts after failures

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -716,7 +716,7 @@ jobs:
 
       - name: Extract scenario outputs
         id: extract
-        if: ${{ inputs.run_agent && ! inputs.dry_run }}
+        if: ${{ always() && inputs.run_agent && ! inputs.dry_run }}
         env:
           RESULTS_FILE: ${{ runner.temp }}/run-results.json
         run: |
@@ -732,7 +732,7 @@ jobs:
 
       - name: Extract dry-run outputs
         id: extract_dry_run
-        if: ${{ inputs.run_agent && inputs.dry_run }}
+        if: ${{ always() && inputs.run_agent && inputs.dry_run }}
         env:
           RESULTS_FILE: ${{ runner.temp }}/run-results.json
         run: |


### PR DESCRIPTION
## Summary
- Keep extracting Data Machine agent result metadata after failed agent steps.
- Allows transcript artifact resolution/upload to run for failed jobs, preserving failure evidence.

## Testing
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the failed World Creator runner artifact path and drafted this workflow condition fix; Chris reviewed/approved the merge path.