### PR TITLE
Add hidden Data Machine agent workspace capture

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -101,6 +101,8 @@ jobs:
 - `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.
 - `tool_recorders` configures tool-result projection, forced parameters, and engine-data capture. It must be a JSON array.
 - `pipeline_step_patches` and `flow_step_patches` modify imported bundle step config before the flow runs. They must be JSON arrays.
+- `runner_workspace` provisions a Data Machine Code worktree before the agent runs. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for opt-in runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner inspects, commits, pushes, and opens/reuses a fallback PR for captured workspace changes after completion.
+- `runner_workspace.capture_changes` defaults to `true` only when `expose_to_agent: false`; set it explicitly to disable hidden-mode publication or to enable runner-owned capture while still exposing the workspace handle.
 - `fallback_pull_request` opens or reuses a PR when files were written but the agent did not call the PR tool. It must be a JSON object.
 
 ## External bundle and tool recording example

--- a/wordpress/docs/AGENT_CI_PLAYGROUND.md
+++ b/wordpress/docs/AGENT_CI_PLAYGROUND.md
@@ -111,6 +111,13 @@ The runner converts the agent config into a single Playground bench workload:
   `metadata.engine_data`.
 - `engine_key` and `tool_results_key` control where built-in tool capture and
   fallback pull request data are recorded.
+- `runner_workspace` can provision a Data Machine Code worktree. The default
+  mode prepends the workspace handle to the agent prompt so current consumers
+  can explicitly ask the agent to work in that checkout and open a PR.
+- `runner_workspace.expose_to_agent: false` is an opt-in runner-owned capture
+  mode. It preserves the natural task prompt, keeps workspace tool calls scoped
+  to the provisioned handle when those tools are used, then captures final git
+  status/diff, commits, pushes, and opens or reuses a fallback PR after the run.
 - `ability_tools` can expose additional WordPress abilities as tools during the
   agent run.
 - `pipeline_step_patches` and `flow_step_patches` can adjust imported bundle
@@ -135,7 +142,7 @@ knobs to `run-datamachine-agent.sh`:
 - GitHub access: `target_repo`, `app_token_repos`, `allowed_repos`, `engine_key`, `tool_results_key`.
 - Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
 - Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`, `replay_bundle_artifact_name`.
-- Extension points: `extra_required_abilities`, `ability_tools`, `tool_recorders`, `pipeline_step_patches`, `flow_step_patches`, `fallback_pull_request`.
+- Extension points: `extra_required_abilities`, `ability_tools`, `tool_recorders`, `pipeline_step_patches`, `flow_step_patches`, `runner_workspace`, `fallback_pull_request`.
 
 `bundle_repo` is for cross-repo consumers. The shell runner clones the bundle
 repository, points `bundle_path` at the cloned bundle inside Playground, and adds
@@ -147,6 +154,12 @@ maintaining a bespoke runner script.
 wrap GitHub tools. A recorder can attach forced parameters, capture selected input
 or output fields, and write them under a stable `metadata.engine_data` key for
 later `engine_data_outputs` projection.
+
+`runner_workspace.expose_to_agent` defaults to `true` for backwards
+compatibility. Set it to `false` for task-sandbox runs where the agent should see
+only the natural task request. Hidden mode enables runner-owned change capture by
+default; set `runner_workspace.capture_changes: false` only when a consumer wants
+hidden prompt behavior without post-run workspace publication.
 
 `provider_plugin` lets callers replace the OpenAI provider preset without
 changing the workload. The reusable workflow checks out the configured plugin,

--- a/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
@@ -138,6 +138,39 @@ namespace {
         exit( 1 );
     }
 
+    list( $hidden_config, $hidden_prompt ) = homeboy_datamachine_agent_apply_runner_workspace(
+        array(
+            'runner_workspace' => array(
+                'enabled'         => true,
+                'expose_to_agent' => false,
+            ),
+        ),
+        'Run the agent naturally.',
+        array(
+            'success' => true,
+            'handle'  => 'demo@hidden-run',
+            'branch'  => 'agent/hidden-run',
+        )
+    );
+
+    if ( 'Run the agent naturally.' !== $hidden_prompt ) {
+        fwrite( STDERR, "Expected hidden runner workspace mode to preserve the natural prompt.\n" );
+        exit( 1 );
+    }
+
+    $hidden_workspace_recorder = null;
+    foreach ( $hidden_config['tool_recorders'] ?? array() as $runner_recorder ) {
+        if ( is_array( $runner_recorder ) && 'workspace_write' === ( $runner_recorder['tool'] ?? '' ) ) {
+            $hidden_workspace_recorder = $runner_recorder;
+            break;
+        }
+    }
+
+    if ( 'demo@hidden-run' !== ( $hidden_workspace_recorder['forced_parameters']['repo'] ?? null ) ) {
+        fwrite( STDERR, "Expected hidden runner workspace mode to keep workspace tool scoping.\n" );
+        exit( 1 );
+    }
+
     $implicit_fallback = homeboy_datamachine_agent_open_fallback_pr(
         array(),
         array(

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -693,6 +693,136 @@ if ( ! function_exists( 'homeboy_datamachine_agent_open_fallback_pr' ) ) {
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_config' ) ) {
+    function homeboy_datamachine_agent_runner_workspace_config( array $config ): array {
+        return is_array( $config['runner_workspace'] ?? null ) ? $config['runner_workspace'] : array();
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_exposed' ) ) {
+    function homeboy_datamachine_agent_runner_workspace_exposed( array $config ): bool {
+        return homeboy_datamachine_agent_bool_config( homeboy_datamachine_agent_runner_workspace_config( $config ), 'expose_to_agent', true );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_capture_enabled' ) ) {
+    function homeboy_datamachine_agent_runner_workspace_capture_enabled( array $config ): bool {
+        $workspace = homeboy_datamachine_agent_runner_workspace_config( $config );
+        if ( ! homeboy_datamachine_agent_bool_config( $workspace, 'enabled', false ) ) {
+            return false;
+        }
+        if ( array_key_exists( 'capture_changes', $workspace ) ) {
+            return homeboy_datamachine_agent_bool_config( $workspace, 'capture_changes', false );
+        }
+
+        return ! homeboy_datamachine_agent_runner_workspace_exposed( $config );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_execute_workspace_ability' ) ) {
+    function homeboy_datamachine_agent_execute_workspace_ability( string $ability_name, array $input ): array {
+        $ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
+        if ( ! $ability ) {
+            return array( 'success' => false, 'error' => $ability_name . ' is not registered.' );
+        }
+
+        $result = $ability->execute( $input );
+        if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
+            return array( 'success' => false, 'error' => $result->get_error_message(), 'input' => $input );
+        }
+        if ( ! is_array( $result ) ) {
+            return array( 'success' => false, 'error' => $ability_name . ' returned a non-array result.', 'input' => $input );
+        }
+
+        return $result + array( 'success' => ! empty( $result['success'] ) );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_fallback_config' ) ) {
+    function homeboy_datamachine_agent_runner_workspace_fallback_config( array $config, array $runner_workspace ): array {
+        $fallback = is_array( $config['fallback_pull_request'] ?? null ) ? $config['fallback_pull_request'] : array();
+        $repo     = homeboy_datamachine_agent_scalar( $fallback, 'repo', homeboy_datamachine_agent_scalar( $config, 'target_repo' ) );
+        $branch   = (string) ( $runner_workspace['branch'] ?? '' );
+
+        if ( '' === homeboy_datamachine_agent_scalar( $fallback, 'head' ) && '' !== $branch ) {
+            $fallback['head'] = $branch;
+        }
+        if ( '' === homeboy_datamachine_agent_scalar( $fallback, 'repo' ) && '' !== $repo ) {
+            $fallback['repo'] = $repo;
+        }
+        if ( '' === homeboy_datamachine_agent_scalar( $fallback, 'title' ) ) {
+            $fallback['title'] = 'Persist Data Machine agent workspace changes';
+        }
+
+        return $fallback;
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_capture_runner_workspace' ) ) {
+    function homeboy_datamachine_agent_capture_runner_workspace( array $engine_data, array $config ): array {
+        if ( ! homeboy_datamachine_agent_runner_workspace_capture_enabled( $config ) ) {
+            return array( 'enabled' => false, 'changed' => false, 'engine_data' => $engine_data );
+        }
+
+        $runner_workspace = is_array( $config['runner_workspace_result'] ?? null ) ? $config['runner_workspace_result'] : array();
+        $handle           = (string) ( $runner_workspace['handle'] ?? '' );
+        if ( empty( $runner_workspace['success'] ) || '' === $handle ) {
+            return array( 'enabled' => true, 'changed' => false, 'engine_data' => $engine_data, 'error' => 'Runner workspace capture requires a provisioned workspace handle.' );
+        }
+
+        $status = homeboy_datamachine_agent_execute_workspace_ability( 'datamachine/workspace-git-status', array( 'name' => $handle ) );
+        if ( empty( $status['success'] ) ) {
+            return array( 'enabled' => true, 'changed' => false, 'engine_data' => $engine_data, 'status' => $status, 'error' => (string) ( $status['error'] ?? 'Workspace status failed.' ) );
+        }
+
+        $files = is_array( $status['files'] ?? null ) ? array_values( array_filter( $status['files'], 'is_string' ) ) : array();
+        if ( (int) ( $status['dirty'] ?? 0 ) <= 0 && empty( $files ) ) {
+            return array( 'enabled' => true, 'changed' => false, 'engine_data' => $engine_data, 'status' => $status );
+        }
+
+        $diff = homeboy_datamachine_agent_execute_workspace_ability( 'datamachine/workspace-git-diff', array( 'name' => $handle ) );
+        $add  = homeboy_datamachine_agent_execute_workspace_ability( 'datamachine/workspace-git-add', array( 'name' => $handle, 'paths' => empty( $files ) ? array( '.' ) : $files ) );
+        if ( empty( $add['success'] ) ) {
+            return array( 'enabled' => true, 'changed' => true, 'engine_data' => $engine_data, 'status' => $status, 'diff' => $diff, 'add' => $add, 'error' => (string) ( $add['error'] ?? 'Workspace git add failed.' ) );
+        }
+
+        $workspace_config = homeboy_datamachine_agent_runner_workspace_config( $config );
+        $message          = isset( $workspace_config['commit_message'] ) && is_scalar( $workspace_config['commit_message'] ) ? trim( (string) $workspace_config['commit_message'] ) : '';
+        if ( '' === $message ) {
+            $message = 'chore: persist Data Machine agent workspace changes';
+        }
+
+        $commit = homeboy_datamachine_agent_execute_workspace_ability( 'datamachine/workspace-git-commit', array( 'name' => $handle, 'message' => $message ) );
+        if ( empty( $commit['success'] ) ) {
+            return array( 'enabled' => true, 'changed' => true, 'engine_data' => $engine_data, 'status' => $status, 'diff' => $diff, 'add' => $add, 'commit' => $commit, 'error' => (string) ( $commit['error'] ?? 'Workspace git commit failed.' ) );
+        }
+
+        $push = homeboy_datamachine_agent_execute_workspace_ability( 'datamachine/workspace-git-push', array( 'name' => $handle, 'branch' => (string) ( $runner_workspace['branch'] ?? '' ) ) );
+        if ( empty( $push['success'] ) ) {
+            return array( 'enabled' => true, 'changed' => true, 'engine_data' => $engine_data, 'status' => $status, 'diff' => $diff, 'add' => $add, 'commit' => $commit, 'push' => $push, 'error' => (string) ( $push['error'] ?? 'Workspace git push failed.' ) );
+        }
+
+        $capture_config                          = $config;
+        $capture_config['fallback_pull_request'] = homeboy_datamachine_agent_runner_workspace_fallback_config( $config, $runner_workspace );
+        $fallback_pull_request                   = homeboy_datamachine_agent_open_fallback_pr( $engine_data, $capture_config );
+        if ( ! empty( $fallback_pull_request['engine_data'] ) && is_array( $fallback_pull_request['engine_data'] ) ) {
+            $engine_data = $fallback_pull_request['engine_data'];
+        }
+
+        return array(
+            'enabled'               => true,
+            'changed'               => true,
+            'engine_data'           => $engine_data,
+            'status'                => $status,
+            'diff'                  => $diff,
+            'add'                   => $add,
+            'commit'                => $commit,
+            'push'                  => $push,
+            'fallback_pull_request' => $fallback_pull_request,
+        );
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_ability_schema' ) ) {
     function homeboy_datamachine_agent_ability_schema( string $ability_name ): array {
         $ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
@@ -1031,7 +1161,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_slug' ) ) {
 
 if ( ! function_exists( 'homeboy_datamachine_agent_provision_workspace' ) ) {
     function homeboy_datamachine_agent_provision_workspace( array $config ): array {
-        $workspace = is_array( $config['runner_workspace'] ?? null ) ? $config['runner_workspace'] : array();
+        $workspace = homeboy_datamachine_agent_runner_workspace_config( $config );
         if ( ! homeboy_datamachine_agent_bool_config( $workspace, 'enabled', false ) ) {
             return array( 'enabled' => false );
         }
@@ -1123,9 +1253,11 @@ if ( ! function_exists( 'homeboy_datamachine_agent_apply_runner_workspace' ) ) {
         }
 
         $handle = (string) $runner_workspace['handle'];
-        $branch = (string) ( $runner_workspace['branch'] ?? '' );
-        $prefix = "Runner-provided workspace:\n- Workspace handle: {$handle}\n- Branch: {$branch}\n\nUse this workspace handle for all repository file and git changes. Do not mutate the primary checkout and do not create another worktree for this run.";
-        $prompt = '' === trim( $prompt ) ? $prefix : $prefix . "\n\n" . $prompt;
+        if ( homeboy_datamachine_agent_runner_workspace_exposed( $config ) ) {
+            $branch = (string) ( $runner_workspace['branch'] ?? '' );
+            $prefix = "Runner-provided workspace:\n- Workspace handle: {$handle}\n- Branch: {$branch}\n\nUse this workspace handle for all repository file and git changes. Do not mutate the primary checkout and do not create another worktree for this run.";
+            $prompt = '' === trim( $prompt ) ? $prefix : $prefix . "\n\n" . $prompt;
+        }
 
         $recorders        = is_array( $config['tool_recorders'] ?? null ) ? $config['tool_recorders'] : array();
         $tool_results_key = homeboy_datamachine_agent_scalar( $config, 'tool_results_key', 'github_tool_results' );
@@ -1562,13 +1694,17 @@ $job_status = is_array( $job ) ? (string) ( $job['status'] ?? '' ) : '';
 $engine_data = function_exists( 'datamachine_get_engine_data' ) ? datamachine_get_engine_data( $job_id ) : array();
 $engine_data = homeboy_datamachine_agent_merge_recorded_tool_results( $engine_data, $config );
 $engine_data = homeboy_datamachine_agent_merge_child_engine_data( $engine_data, $child_drain_summary['children'], $config );
+$runner_workspace_capture = homeboy_datamachine_agent_capture_runner_workspace( $engine_data, $config );
+if ( is_array( $runner_workspace_capture['engine_data'] ?? null ) ) {
+    $engine_data = $runner_workspace_capture['engine_data'];
+}
 $transcript_dir = homeboy_datamachine_agent_scalar( $config, 'transcript_dir' );
 $transcript_artifacts = homeboy_datamachine_agent_export_transcript( $job_id, $engine_data, $transcript_dir );
 $pr_opened = homeboy_datamachine_agent_pr_opened( $engine_data, $config );
-$file_written = homeboy_datamachine_agent_file_written( $engine_data, $config );
-$fallback_pull_request = array( 'opened' => false );
+$file_written = homeboy_datamachine_agent_file_written( $engine_data, $config ) || ! empty( $runner_workspace_capture['changed'] );
+$fallback_pull_request = is_array( $runner_workspace_capture['fallback_pull_request'] ?? null ) ? $runner_workspace_capture['fallback_pull_request'] : array( 'opened' => false );
 $success_requires_pr = ! empty( $config['success_requires_pr'] );
-if ( $file_written && ! $pr_opened ) {
+if ( $file_written && ! $pr_opened && empty( $runner_workspace_capture['changed'] ) ) {
     $fallback_pull_request = homeboy_datamachine_agent_open_fallback_pr( $engine_data, $config );
     if ( ! empty( $fallback_pull_request['opened'] ) && is_array( $fallback_pull_request['engine_data'] ?? null ) ) {
         $engine_data = $fallback_pull_request['engine_data'];
@@ -1593,17 +1729,25 @@ $metadata += array(
     'success_status'        => $success_status,
     'success_requires_pr'   => $success_requires_pr,
     'fallback_pull_request' => $fallback_pull_request,
+    'runner_workspace_capture' => $runner_workspace_capture,
     'completion_outcome_satisfied' => $completion_outcome_satisfied,
     'file_written'          => $file_written,
     'job_artifact_exports'    => $job_artifact_exports,
 );
 
+if ( ! empty( $runner_workspace_capture['enabled'] ) && ! empty( $runner_workspace_capture['error'] ) && empty( $runner_workspace_capture['changed'] ) ) {
+    return homeboy_datamachine_agent_result( array( 'runner_workspace_captured' => 0 ), $metadata, (string) $runner_workspace_capture['error'] );
+}
+
 if ( $file_written && ! $pr_opened ) {
     $metadata['success_status'] = 'write_without_pr';
     $fallback_error = is_array( $fallback_pull_request ) ? (string) ( $fallback_pull_request['error'] ?? '' ) : '';
+    $capture_error  = is_array( $runner_workspace_capture ) ? (string) ( $runner_workspace_capture['error'] ?? '' ) : '';
     $error_message  = 'Agent wrote files without opening a pull request';
     if ( '' !== $fallback_error ) {
         $error_message .= ': ' . $fallback_error;
+    } elseif ( '' !== $capture_error ) {
+        $error_message .= ': ' . $capture_error;
     }
     return homeboy_datamachine_agent_result( array( 'file_written' => 1, 'pr_opened' => 0 ), $metadata, $error_message );
 }
@@ -1626,6 +1770,7 @@ return homeboy_datamachine_agent_result(
         'import_elapsed_ms'           => $import_elapsed_ms,
         'agent_resolved'              => 1,
         'runner_workspace_provisioned' => empty( $runner_workspace['enabled'] ) || ! empty( $runner_workspace['success'] ) ? 1 : 0,
+        'runner_workspace_captured'    => empty( $runner_workspace_capture['enabled'] ) || empty( $runner_workspace_capture['error'] ) ? 1 : 0,
         'pipeline_resolved'           => '' === $pipeline_slug || $pipeline_id > 0 ? 1 : 0,
         'flow_resolved'               => 1,
         'run_flow_succeeded'          => 1,

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -275,6 +275,80 @@ namespace {
         exit( 1 );
     }
 
+    $runner_capture_calls = array();
+    $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
+        'datamachine/workspace-git-status' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            function ( array $input ) use ( &$runner_capture_calls ): array {
+                $runner_capture_calls[] = array( 'ability' => 'status', 'input' => $input );
+                return array(
+                    'success' => true,
+                    'dirty'   => 1,
+                    'files'   => array( 'docs/generated.md' ),
+                );
+            }
+        ),
+        'datamachine/workspace-git-diff' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            fn( array $input ) => array(
+                'success' => true,
+                'name'    => $input['name'] ?? '',
+                'diff'    => "diff --git a/docs/generated.md b/docs/generated.md\n",
+            )
+        ),
+        'datamachine/workspace-git-add' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            function ( array $input ) use ( &$runner_capture_calls ): array {
+                $runner_capture_calls[] = array( 'ability' => 'add', 'input' => $input );
+                return array( 'success' => true, 'paths' => $input['paths'] ?? array() );
+            }
+        ),
+        'datamachine/workspace-git-commit' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            fn( array $input ) => array( 'success' => true, 'commit' => 'abc123', 'message' => $input['message'] ?? '' )
+        ),
+        'datamachine/workspace-git-push' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            fn( array $input ) => array( 'success' => true, 'branch' => $input['branch'] ?? '', 'html_url' => 'https://github.com/owner/repo/tree/agent/hidden-run' )
+        ),
+        'datamachine/list-github-pulls' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            fn() => array( 'success' => true, 'pulls' => array() )
+        ),
+        'datamachine/create-github-pull-request' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            function ( array $input ) use ( &$fallback_pr_input ): array {
+                $fallback_pr_input = $input;
+                return array(
+                    'success'  => true,
+                    'html_url' => 'https://github.com/owner/repo/pull/987',
+                );
+            }
+        ),
+    );
+    $runner_capture = homeboy_datamachine_agent_capture_runner_workspace(
+        array(),
+        array(
+            'target_repo'              => 'owner/repo',
+            'tool_results_key'         => 'github_tool_results',
+            'runner_workspace'         => array(
+                'enabled'         => true,
+                'expose_to_agent' => false,
+            ),
+            'runner_workspace_result'  => array(
+                'success' => true,
+                'handle'  => 'repo@hidden-run',
+                'branch'  => 'agent/hidden-run',
+            ),
+        )
+    );
+
+    if ( empty( $runner_capture['changed'] ) || empty( $runner_capture['fallback_pull_request']['opened'] ) ) {
+        fwrite( STDERR, "Expected hidden runner workspace capture to commit, push, and open a fallback PR.\n" );
+        exit( 1 );
+    }
+    if ( 'agent/hidden-run' !== ( $fallback_pr_input['head'] ?? null ) || 'owner/repo' !== ( $fallback_pr_input['repo'] ?? null ) ) {
+        fwrite( STDERR, "Expected runner workspace capture fallback PR to use the captured branch.\n" );
+        exit( 1 );
+    }
+    if ( 'repo@hidden-run' !== ( $runner_capture_calls[0]['input']['name'] ?? null ) || array( 'docs/generated.md' ) !== ( $runner_capture_calls[1]['input']['paths'] ?? null ) ) {
+        fwrite( STDERR, "Expected runner workspace capture to inspect and stage the provisioned handle.\n" );
+        exit( 1 );
+    }
+
     $merged_daily_memory = homeboy_datamachine_agent_merge_daily_memory_artifact(
         "# Daily Memory: 2026-05-10\n\n### Existing Entry\n- Keep this.\n### Concurrent Entry\n- Do not delete this.\n",
         "# Daily Memory: 2026-05-10\n\n### Existing Entry\n- Keep this.\n### New Entry\n- Add this.\n"


### PR DESCRIPTION
## Summary
- Add opt-in `runner_workspace.expose_to_agent: false` mode that preserves natural prompts while keeping workspace tool calls scoped to the runner-provisioned worktree.
- Capture final runner workspace status/diff, commit, push, and open/reuse fallback PRs after the agent run when hidden capture is enabled.
- Document current visible workspace behavior and add smoke coverage for hidden prompt behavior plus runner-owned fallback PR metadata.

Closes #581.

## Tests
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner capture implementation, docs updates, smoke coverage, and targeted verification; Chris remains responsible for review and merge.