### PR TITLE
fix(wordpress): authenticate private bundle repo clones

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -11,6 +11,10 @@ name: Data Machine Agent CI (reusable)
       bundle_path:
         type: string
         required: true
+      homeboy_extensions_ref:
+        description: Ref of Extra-Chill/homeboy-extensions to check out for runner scripts.
+        type: string
+        default: main
       bundle_repo:
         description: Optional git URL for an external bundle repository. When set, the runner clones this repo and uses bundle_path_in_repo inside it.
         type: string
@@ -332,6 +336,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Extra-Chill/homeboy-extensions
+          ref: ${{ inputs.homeboy_extensions_ref }}
           path: .ci/homeboy-extensions
 
       - name: Checkout validation dependencies

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -7,6 +7,30 @@ WORKLOAD_PATH="$SCRIPT_DIR/datamachine-agent-workload.php"
 WORKLOAD_PLAYGROUND_PATH="/homeboy-extension/scripts/agent/datamachine-agent-workload.php"
 REPLAY_BUNDLE_BUILDER="$SCRIPT_DIR/build-replay-bundle.js"
 
+homeboy_datamachine_agent_bundle_clone_url() {
+    local repo_url="${1:-}"
+
+    if [ -z "${GITHUB_TOKEN:-}" ]; then
+        printf '%s\n' "$repo_url"
+        return 0
+    fi
+
+    case "$repo_url" in
+        https://github.com/*)
+            printf 'https://x-access-token:%s@github.com/%s\n' "$GITHUB_TOKEN" "${repo_url#https://github.com/}"
+            ;;
+        http://github.com/*)
+            printf 'https://x-access-token:%s@github.com/%s\n' "$GITHUB_TOKEN" "${repo_url#http://github.com/}"
+            ;;
+        git@github.com:*)
+            printf 'https://x-access-token:%s@github.com/%s\n' "$GITHUB_TOKEN" "${repo_url#git@github.com:}"
+            ;;
+        *)
+            printf '%s\n' "$repo_url"
+            ;;
+    esac
+}
+
 CONFIG_PATH="${HOMEBOY_DATAMACHINE_AGENT_CONFIG_PATH:-}"
 if [ -z "$CONFIG_PATH" ] && [ "${1:-}" != "" ]; then
     CONFIG_PATH="$1"
@@ -112,7 +136,8 @@ if [ -n "$BUNDLE_REPO" ]; then
         RUNTIME_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-datamachine-agent-runtime.XXXXXX")
     fi
     BUNDLE_CHECKOUT_DIR="$RUNTIME_DIR/bundle-repo"
-    git clone --quiet "$BUNDLE_REPO" "$BUNDLE_CHECKOUT_DIR"
+    BUNDLE_CLONE_URL=$(homeboy_datamachine_agent_bundle_clone_url "$BUNDLE_REPO")
+    git clone --quiet "$BUNDLE_CLONE_URL" "$BUNDLE_CHECKOUT_DIR"
     git -C "$BUNDLE_CHECKOUT_DIR" checkout --quiet "$BUNDLE_REF"
     BUNDLE_PATH="$BUNDLE_CHECKOUT_DIR/$BUNDLE_PATH_IN_REPO"
     if [ ! -d "$BUNDLE_PATH" ]; then


### PR DESCRIPTION
## Summary
- Authenticate GitHub bundle repo clones with `GITHUB_TOKEN` so private caller repositories can use the Data Machine agent runner.
- Add `homeboy_extensions_ref` so the reusable workflow can validate and pin the matching runner script checkout.

## Testing
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); puts "workflow yaml ok"'`
- Validated from `chubes4/wp-rl` smoke dry-run using this branch: https://github.com/chubes4/wp-rl/actions/runs/25705507705

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the private-repo clone failure, drafting the runner auth fix, and validating via GitHub Actions. Chris remains responsible for review and merge.