### PR TITLE
Fix Data Machine agent artifact PR export

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -693,7 +693,7 @@ jobs:
                 only_when_no_pr: true,
                 repo: $targetRepo,
                 path_prefix: $bundlePathInRepo,
-                branch_template: "agent-artifacts/{agent_slug}-{run_id}-{job_id}",
+                branch_template: "agent-artifacts/{agent_slug}-{run_id}-{provider}-{model}-{job_id}",
                 commit_message_template: "chore: persist {type} artifact",
                 pr_title_template: "Persist agent run artifacts",
                 pr_body_template: "## Summary\n- Persist bundle-file run artifacts from Data Machine agent job {job_id}.\n\n## Artifacts\n{paths}\n"

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -324,6 +324,11 @@ if ( ! function_exists( 'homeboy_datamachine_agent_slug_fragment' ) ) {
 }
 
 if ( ! function_exists( 'homeboy_datamachine_agent_exportable_artifacts' ) ) {
+    function homeboy_datamachine_agent_job_artifact_relative_path( int $job_id, array $config ): string {
+        $flow_slug = homeboy_datamachine_agent_slug_fragment( homeboy_datamachine_agent_scalar( $config, 'flow_slug', 'run' ) );
+        return sprintf( 'run-artifacts/%s/job-%d/job-artifacts.json', $flow_slug, $job_id );
+    }
+
     function homeboy_datamachine_agent_exportable_artifacts( array $artifacts ): array {
         $exportable_artifacts = array();
 
@@ -408,6 +413,15 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_job_artifacts' ) ) {
 
         $artifact_result = ( new JobArtifacts() )->get( $job_id );
         $artifacts       = is_array( $artifact_result['artifacts'] ?? null ) ? $artifact_result['artifacts'] : array();
+        if ( ! empty( $artifact_result['success'] ) && ! empty( $artifacts ) ) {
+            $artifacts['job_artifacts'] = array(
+                array(
+                    'type'                 => 'job_artifacts',
+                    'bundle_relative_path' => homeboy_datamachine_agent_job_artifact_relative_path( $job_id, $config ),
+                    'content'              => wp_json_encode( $artifacts, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n",
+                ),
+            );
+        }
         $exportable_artifacts = homeboy_datamachine_agent_exportable_artifacts( $artifacts );
         if ( empty( $exportable_artifacts ) ) {
             return array();

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -440,6 +440,8 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_job_artifacts' ) ) {
             'agent_slug' => $agent_slug,
             'run_id'     => $run_id,
             'job_id'     => $job_id,
+            'provider'   => homeboy_datamachine_agent_slug_fragment( homeboy_datamachine_agent_scalar( $config, 'provider', 'provider' ) ),
+            'model'      => homeboy_datamachine_agent_slug_fragment( homeboy_datamachine_agent_scalar( $config, 'model', 'model' ) ),
         );
         $branch_template = (string) ( $export_config['branch_template'] ?? '' );
         $attached_to_pr  = false;

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -26,6 +26,19 @@ namespace DataMachine\Core\Database\Pipelines {
 }
 
 namespace DataMachine\Core {
+    class JobArtifacts {
+        public function get( int $job_id, array $additional_tool_summaries = array() ): array {
+            return array(
+                'success'   => true,
+                'artifacts' => array(
+                    'transcript'             => array( 'session_id' => 'session-123' ),
+                    'agent_memory_artifacts' => array(),
+                    'daily_memory_artifacts' => array(),
+                ),
+            );
+        }
+    }
+
     class PluginSettings {
         public static function clearCache(): void {}
     }
@@ -361,6 +374,52 @@ namespace {
     }
     if ( 'repo@hidden-run' !== ( $runner_capture_calls[0]['input']['name'] ?? null ) || array( 'docs/generated.md' ) !== ( $runner_capture_calls[1]['input']['paths'] ?? null ) ) {
         fwrite( STDERR, "Expected runner workspace capture to inspect and stage the provisioned handle.\n" );
+        exit( 1 );
+    }
+
+    $artifact_export_calls = array();
+    $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
+        'datamachine/create-or-update-github-file' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            function ( array $input ) use ( &$artifact_export_calls ): array {
+                $artifact_export_calls[] = array( 'ability' => 'file', 'input' => $input );
+                return array( 'success' => true, 'html_url' => 'https://github.com/owner/repo/commit/artifact' );
+            }
+        ),
+        'datamachine/create-github-pull-request' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            function ( array $input ) use ( &$artifact_export_calls ): array {
+                $artifact_export_calls[] = array( 'ability' => 'pr', 'input' => $input );
+                return array( 'success' => true, 'html_url' => 'https://github.com/owner/repo/pull/988' );
+            }
+        ),
+        'datamachine/get-github-file' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            fn() => array( 'success' => false )
+        ),
+    );
+    $job_artifact_export = homeboy_datamachine_agent_export_job_artifacts(
+        42,
+        array(
+            'target_repo'     => 'owner/repo',
+            'flow_slug'       => 'review-flow',
+            'artifact_export' => array(
+                'enabled'                 => true,
+                'repo'                    => 'owner/repo',
+                'path_prefix'             => 'bundles/task-runner',
+                'branch_template'         => 'agent-artifacts/{agent_slug}-{run_id}-{job_id}',
+                'commit_message_template' => 'chore: persist {type} artifact',
+                'pr_title_template'       => 'Persist agent run artifacts',
+                'pr_body_template'        => "## Artifacts\n{paths}\n",
+            ),
+        ),
+        false,
+        array()
+    );
+
+    if ( empty( $job_artifact_export['pr_url'] ) ) {
+        fwrite( STDERR, "Expected job artifact export to open a runner-owned PR.\n" );
+        exit( 1 );
+    }
+    if ( 'bundles/task-runner/run-artifacts/review-flow/job-42/job-artifacts.json' !== ( $artifact_export_calls[0]['input']['file_path'] ?? null ) ) {
+        fwrite( STDERR, "Expected Data Machine job artifact payload to be written as reviewable JSON.\n" );
         exit( 1 );
     }
 


### PR DESCRIPTION
## Summary
- Always expose the Data Machine `JobArtifacts` payload itself as a bundle-file artifact for agent CI runs.
- This lets runner-owned artifact export open a review PR even when a task produced no memory/file artifacts.
- Cover the runner-owned artifact PR path in the existing write-without-PR smoke test.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php && php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner artifact export fix and smoke coverage; Chris remains responsible for review and merge.