### PR TITLE
Fix agent CI artifact token routing

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -249,6 +249,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
+      actions: read
       contents: write
       pull-requests: write
       issues: write
@@ -508,7 +509,8 @@ jobs:
           FLOW_STEP_PATCHES: ${{ inputs.flow_step_patches }}
           RUNNER_WORKSPACE_CONFIG: ${{ inputs.runner_workspace }}
           FALLBACK_PULL_REQUEST: ${{ inputs.fallback_pull_request }}
-          GITHUB_TOKEN_VALUE: ${{ steps.app-token.outputs.token || github.token }}
+          GITHUB_APP_TOKEN_VALUE: ${{ steps.app-token.outputs.token }}
+          GITHUB_REPOSITORY_TOKEN_VALUE: ${{ github.token }}
           GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT_VALUE: ${{ github.run_attempt }}
           PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
@@ -610,7 +612,8 @@ jobs:
             --arg toolResultsKey "$TOOL_RESULTS_KEY" \
             --arg playgroundWordPress "$PLAYGROUND_WORDPRESS" \
             --arg transcriptGuestDir "$transcript_guest_dir" \
-            --arg githubToken "$GITHUB_TOKEN_VALUE" \
+            --arg githubAppToken "$GITHUB_APP_TOKEN_VALUE" \
+            --arg githubRepositoryToken "$GITHUB_REPOSITORY_TOKEN_VALUE" \
             --arg githubRunId "$GITHUB_RUN_ID_VALUE" \
             --arg githubRunAttempt "$GITHUB_RUN_ATTEMPT_VALUE" \
             --arg providerRegisterFunction "$provider_register_function" \
@@ -666,7 +669,8 @@ jobs:
               model: $model,
               provider_register_function: $providerRegisterFunction,
               provider_credentials: $providerCredentials,
-              github_token_env: "GITHUB_TOKEN",
+              github_token_env: "HOMEBOY_GITHUB_APP_TOKEN",
+              github_repository_token_env: "GITHUB_TOKEN",
               github_profile_id: ($agentSlug + "-ci"),
               target_repo: $targetRepo,
               allowed_repos: (if ($allowedRepos | length) > 0 then $allowedRepos else [$targetRepo] end),
@@ -697,7 +701,8 @@ jobs:
               dry_run: $dryRun,
               transcript_dir: $transcriptGuestDir,
               bench_env: ({
-                GITHUB_TOKEN: $githubToken,
+                GITHUB_TOKEN: $githubRepositoryToken,
+                HOMEBOY_GITHUB_APP_TOKEN: $githubAppToken,
                 GITHUB_RUN_ID: $githubRunId,
                 GITHUB_RUN_ATTEMPT: $githubRunAttempt
               } + $providerBenchEnv)

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1320,21 +1320,35 @@ if ( ! function_exists( 'homeboy_datamachine_agent_configure_settings' ) ) {
 
         $github_token_env = homeboy_datamachine_agent_scalar( $config, 'github_token_env', 'GITHUB_TOKEN' );
         $github_token     = trim( (string) getenv( $github_token_env ) );
+        $github_repository_token_env = homeboy_datamachine_agent_scalar( $config, 'github_repository_token_env', '' );
+        $github_repository_token     = '' !== $github_repository_token_env ? trim( (string) getenv( $github_repository_token_env ) ) : '';
         $target_repo      = homeboy_datamachine_agent_scalar( $config, 'target_repo' );
-        if ( '' !== $github_token && '' !== $target_repo ) {
+        if ( '' !== $target_repo && ( '' !== $github_token || '' !== $github_repository_token ) ) {
             $allowed_repos = is_array( $config['allowed_repos'] ?? null ) ? $config['allowed_repos'] : array( $target_repo );
             $profile_id    = homeboy_datamachine_agent_scalar( $config, 'github_profile_id', 'homeboy-agent-ci' );
-            $settings['github_credential_profiles'] = array(
-                array(
+            $profiles      = array();
+            if ( '' !== $github_repository_token ) {
+                $profiles[] = array(
+                    'id'            => $profile_id . '-repository',
+                    'label'         => 'Homeboy agent CI repository token',
+                    'mode'          => 'pat',
+                    'pat'           => $github_repository_token,
+                    'default_repo'  => $target_repo,
+                    'allowed_repos' => array( $target_repo ),
+                );
+            }
+            if ( '' !== $github_token ) {
+                $profiles[] = array(
                     'id'            => $profile_id,
                     'label'         => 'Homeboy agent CI token',
                     'mode'          => 'pat',
                     'pat'           => $github_token,
                     'default_repo'  => $target_repo,
                     'allowed_repos' => array_values( array_unique( array_filter( array_map( 'strval', $allowed_repos ) ) ) ),
-                ),
-            );
-            $settings['github_default_profile_id'] = $profile_id;
+                );
+            }
+            $settings['github_credential_profiles'] = $profiles;
+            $settings['github_default_profile_id']  = '' !== $github_token ? $profile_id : $profile_id . '-repository';
             $settings['github_default_repo']       = $target_repo;
         }
 

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -26,7 +26,9 @@ namespace DataMachine\Core\Database\Pipelines {
 }
 
 namespace DataMachine\Core {
-    class PluginSettings {}
+    class PluginSettings {
+        public static function clearCache(): void {}
+    }
 }
 
 namespace {
@@ -43,6 +45,19 @@ namespace {
     if ( ! function_exists( 'is_wp_error' ) ) {
         function is_wp_error( $value ): bool {
             return false;
+        }
+    }
+
+    if ( ! function_exists( 'get_option' ) ) {
+        function get_option( string $name, $default = false ) {
+            return $GLOBALS['homeboy_datamachine_agent_fake_options'][ $name ] ?? $default;
+        }
+    }
+
+    if ( ! function_exists( 'update_option' ) ) {
+        function update_option( string $name, $value, bool $autoload = true ): bool {
+            $GLOBALS['homeboy_datamachine_agent_fake_options'][ $name ] = $value;
+            return true;
         }
     }
 
@@ -385,6 +400,30 @@ namespace {
     $nested_mailbox_reply = array( 'world_creator' => $mailbox_reply );
     if ( ! homeboy_datamachine_agent_completion_outcome_satisfied( $nested_mailbox_reply, array( 'engine_key' => 'world_creator', 'success_completion_outcomes' => array( 'mailbox_reply' ) ) ) ) {
         fwrite( STDERR, "Expected nested completion outcome to satisfy success.\n" );
+        exit( 1 );
+    }
+
+    putenv( 'GITHUB_TOKEN=repository-token' );
+    putenv( 'HOMEBOY_GITHUB_APP_TOKEN=app-token' );
+    homeboy_datamachine_agent_configure_settings(
+        array(
+            'provider'                    => 'openai',
+            'model'                       => 'gpt-5.5',
+            'github_token_env'            => 'HOMEBOY_GITHUB_APP_TOKEN',
+            'github_repository_token_env' => 'GITHUB_TOKEN',
+            'github_profile_id'           => 'smoke-ci',
+            'target_repo'                 => 'owner/repo',
+            'allowed_repos'               => array( 'owner/repo', 'owner/other' ),
+        )
+    );
+    $datamachine_settings = $GLOBALS['homeboy_datamachine_agent_fake_options']['datamachine_settings'] ?? array();
+    $github_profiles = $datamachine_settings['github_credential_profiles'] ?? array();
+    if ( 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) || array( 'owner/repo' ) !== ( $github_profiles[0]['allowed_repos'] ?? array() ) ) {
+        fwrite( STDERR, "Expected repository token profile to be first and scoped to the target repo.\n" );
+        exit( 1 );
+    }
+    if ( 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'owner/repo', 'owner/other' ) !== ( $github_profiles[1]['allowed_repos'] ?? array() ) ) {
+        fwrite( STDERR, "Expected app token profile to preserve cross-repo allowed repositories.\n" );
         exit( 1 );
     }
 


### PR DESCRIPTION
## Summary
- Preserve the workflow repository token alongside the Homeboy app token in Data Machine agent CI.
- Scope the repository token to the target repo so Actions artifact reads can use `actions:read`, while keeping the app token available for cross-repo repair writes.
- Cover the two-profile ordering with the existing agent runner smoke test.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the iterator artifact fetch failure, drafted the token-routing fix, and ran focused smoke checks for Chris to review.