### PR TITLE
Avoid elevating reusable workflow permissions

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -249,7 +249,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
-      actions: read
       contents: write
       pull-requests: write
       issues: write


### PR DESCRIPTION
## Summary
- Remove the `actions: read` permission request from the reusable Data Machine agent CI job.
- Keep callers from hitting GitHub Actions startup failures when they grant only the content/pull-request permissions the runner needs.

## Testing
- `git diff --check`
- Verified `chubes4/wp-rl` can start the reusable workflow graph against this branch without caller-level `actions: read`: https://github.com/chubes4/wp-rl/actions/runs/25735921828

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the reusable workflow permission regression and drafted the one-line fix; Chris remains responsible for review and merge.