### PR TITLE
Make committed job artifacts opt-in

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -119,7 +119,7 @@ name: Data Machine Agent CI (reusable)
         type: string
         default: ""
       artifact_export_config:
-        description: JSON config for exporting job artifacts back to the target repo. Empty object uses the reusable workflow defaults.
+        description: JSON config for exporting bundle-file artifacts back to the target repo. Set include_job_artifacts true to also commit full job artifact JSON.
         type: string
         default: "{}"
       comment_pr_summary:
@@ -738,6 +738,7 @@ jobs:
                 only_when_no_pr: true,
                 repo: $targetRepo,
                 path_prefix: $bundlePathInRepo,
+                include_job_artifacts: false,
                 branch_template: "agent-artifacts/{agent_slug}-{run_id}-{provider}-{model}-{job_id}",
                 commit_message_template: "chore: persist {type} artifact",
                 pr_title_template: "Persist agent run artifacts",

--- a/wordpress/docs/AGENT_CI_PLAYGROUND.md
+++ b/wordpress/docs/AGENT_CI_PLAYGROUND.md
@@ -161,6 +161,11 @@ only the natural task request. Hidden mode enables runner-owned change capture b
 default; set `runner_workspace.capture_changes: false` only when a consumer wants
 hidden prompt behavior without post-run workspace publication.
 
+`artifact_export_config` writes bundle-file artifacts such as agent daily memory
+back to the target repository. Full job artifact JSON is noisier and is disabled
+by default; set `artifact_export_config: '{"include_job_artifacts":true}'` for
+deep sandbox runs that need committed job metadata beside the bundle.
+
 `provider_plugin` lets callers replace the OpenAI provider preset without
 changing the workload. The reusable workflow checks out the configured plugin,
 passes the configured register function to `datamachine-agent-workload.php`, and

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -329,6 +329,11 @@ if ( ! function_exists( 'homeboy_datamachine_agent_exportable_artifacts' ) ) {
         return sprintf( 'run-artifacts/%s/job-%d/job-artifacts.json', $flow_slug, $job_id );
     }
 
+    function homeboy_datamachine_agent_export_includes_job_artifacts( array $config ): bool {
+        $export_config = is_array( $config['artifact_export'] ?? null ) ? $config['artifact_export'] : array();
+        return filter_var( $export_config['include_job_artifacts'] ?? false, FILTER_VALIDATE_BOOLEAN );
+    }
+
     function homeboy_datamachine_agent_exportable_artifacts( array $artifacts ): array {
         $exportable_artifacts = array();
 
@@ -413,7 +418,11 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_job_artifacts' ) ) {
 
         $artifact_result = ( new JobArtifacts() )->get( $job_id );
         $artifacts       = is_array( $artifact_result['artifacts'] ?? null ) ? $artifact_result['artifacts'] : array();
-        if ( ! empty( $artifact_result['success'] ) && ! empty( $artifacts ) ) {
+        if (
+            ! empty( $artifact_result['success'] )
+            && ! empty( $artifacts )
+            && homeboy_datamachine_agent_export_includes_job_artifacts( $config )
+        ) {
             $artifacts['job_artifacts'] = array(
                 array(
                     'type'                 => 'job_artifacts',


### PR DESCRIPTION
## Summary
- Keep bundle-file artifact export enabled while making committed full job artifact JSON opt-in.
- Add `artifact_export_config.include_job_artifacts` for deeper sandbox runs that need committed job metadata.
- Document the opt-in behavior for reusable Data Machine agent CI consumers.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the artifact export path, drafted the opt-in guard, docs, and workflow default; Chris reviewed the direction and requested the PR/merge.