### PR TITLE
feat(wordpress): add profiling fixture setup hooks

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -171,6 +171,66 @@ scenario can earn partial credit. Configured workload steps marked
 structured zero-reward grade with `metadata.grade.failure`, allowing result
 aggregation to consume failures without scenario-specific parsing.
 
+## Reusable Profiling Fixtures
+
+Browser/API profiling workloads can seed a WordPress site before profiling by
+calling the reusable fixture setup helper exported from
+`wordpress/lib/page-profiler.js` or `wordpress/lib/fixture-setup.js`.
+
+```js
+const { profileWordPressPages } = require('./wordpress/lib/page-profiler');
+
+await profileWordPressPages({
+  page,
+  baseUrl,
+  manifest,
+  sitePath,
+  artifactDir,
+  fixtures: [
+    { id: 'scale-content', type: 'wp-eval-file', path: 'fixtures/scale.php' },
+    { id: 'ready-flag', type: 'wp-cli', command: 'option update fixture_ready 1' }
+  ]
+});
+```
+
+For imperative setup, pass `setupWordPressFixture`:
+
+```js
+await profileWordPressPages({
+  page,
+  baseUrl,
+  manifest,
+  sitePath,
+  artifactDir,
+  async setupWordPressFixture({ runCli }) {
+    await runCli('wp eval-file fixtures/scale.php');
+  }
+});
+```
+
+Supported declarative fixture step types:
+
+- `wp-eval-file` with `path`: runs `wp eval-file <path>`.
+- `wp-cli` with `command`: runs the command through WP-CLI. The command may
+  include or omit the leading `wp` token.
+
+Fixtures may declare `skipIf` or `idempotencyCheck` as a WP-CLI command. A zero
+exit code skips that fixture step so already-seeded sites can be reused:
+
+```json
+{
+  "id": "scale-content",
+  "type": "wp-eval-file",
+  "path": "fixtures/scale.php",
+  "skipIf": "option get scale_fixture_ready"
+}
+```
+
+The helper returns a `fixtureSetup` summary and writes
+`wordpress-fixture-setup.json` when `artifactDir` is provided. Failed fixture
+steps throw errors that include the fixture label, command, exit code, stdout,
+and stderr.
+
 ## Block Theme Quality Probe
 
 Playground scenario graders can call a generic PHP-first WordPress quality probe

--- a/wordpress/lib/fixture-setup.js
+++ b/wordpress/lib/fixture-setup.js
@@ -1,0 +1,271 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+function isPlainObject(value) {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeFixtureList(fixtures) {
+	if (fixtures === undefined || fixtures === null) {
+		return [];
+	}
+	if (!Array.isArray(fixtures)) {
+		throw new TypeError('fixtures must be an array');
+	}
+	return fixtures.map((fixture, index) => normalizeFixtureStep(fixture, index));
+}
+
+function normalizeFixtureStep(fixture, index) {
+	if (!isPlainObject(fixture)) {
+		throw new TypeError(`fixture step ${index + 1} must be an object`);
+	}
+	const type = fixture.type || (fixture.path ? 'wp-eval-file' : 'wp-cli');
+	if (type !== 'wp-eval-file' && type !== 'wp-cli') {
+		throw new Error(`Unsupported WordPress fixture step type: ${type}`);
+	}
+
+	if (type === 'wp-eval-file' && (typeof fixture.path !== 'string' || fixture.path.trim() === '')) {
+		throw new TypeError(`fixture step ${index + 1} requires a non-empty path`);
+	}
+	if (type === 'wp-cli' && (typeof fixture.command !== 'string' || fixture.command.trim() === '')) {
+		throw new TypeError(`fixture step ${index + 1} requires a non-empty command`);
+	}
+
+	return {
+		...fixture,
+		type,
+		label: fixture.label || fixture.id || `${type}:${index + 1}`,
+	};
+}
+
+function quoteShell(value) {
+	return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function normalizeCliCommand(command) {
+	const trimmed = String(command || '').trim();
+	return trimmed.startsWith('wp ') ? trimmed.slice(3).trim() : trimmed;
+}
+
+function fixtureCommand(step) {
+	if (step.type === 'wp-eval-file') {
+		return `eval-file ${quoteShell(step.path)}`;
+	}
+	return normalizeCliCommand(step.command);
+}
+
+function defaultRunCli(command, options = {}) {
+	const cliPath = options.cliPath || 'wp';
+	const args = [normalizeCliCommand(command)];
+	if (options.sitePath) {
+		args.push(`--path=${quoteShell(options.sitePath)}`);
+	}
+
+	return runShellCommand(`${cliPath} ${args.filter(Boolean).join(' ')}`, {
+		cwd: options.cwd || options.sitePath || process.cwd(),
+		env: options.env,
+	});
+}
+
+function runShellCommand(command, options = {}) {
+	return new Promise((resolve) => {
+		const child = spawn(command, {
+			cwd: options.cwd,
+			env: { ...process.env, ...(options.env || {}) },
+			shell: true,
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+		let stdout = '';
+		let stderr = '';
+		child.stdout.on('data', (chunk) => {
+			stdout += chunk.toString();
+		});
+		child.stderr.on('data', (chunk) => {
+			stderr += chunk.toString();
+		});
+		child.on('error', (error) => {
+			resolve({ exitCode: 1, stdout, stderr: stderr || error.message, error });
+		});
+		child.on('close', (code, signal) => {
+			resolve({ exitCode: code ?? 1, signal, stdout, stderr });
+		});
+	});
+}
+
+function normalizeCliResult(result) {
+	if (result === undefined || result === null) {
+		return { exitCode: 0, stdout: '', stderr: '' };
+	}
+	if (typeof result === 'string') {
+		return { exitCode: 0, stdout: result, stderr: '' };
+	}
+	if (isPlainObject(result)) {
+		return {
+			...result,
+			exitCode: Number.isInteger(result.exitCode) ? result.exitCode : (Number.isInteger(result.code) ? result.code : 0),
+			stdout: result.stdout === undefined ? '' : String(result.stdout),
+			stderr: result.stderr === undefined ? '' : String(result.stderr),
+		};
+	}
+	return { exitCode: 0, stdout: String(result), stderr: '' };
+}
+
+function excerpt(value) {
+	const text = String(value || '').trim();
+	if (!text) {
+		return '';
+	}
+	return text.length > 4000 ? `${text.slice(0, 4000)}\n...` : text;
+}
+
+function failedStepError(step, command, result) {
+	const parts = [
+		`WordPress fixture step "${step.label}" failed (${step.type}: ${command}) with exit code ${result.exitCode}.`,
+	];
+	if (result.stdout) {
+		parts.push(`STDOUT:\n${excerpt(result.stdout)}`);
+	}
+	if (result.stderr) {
+		parts.push(`STDERR:\n${excerpt(result.stderr)}`);
+	}
+	return new Error(parts.join('\n'));
+}
+
+function normalizeSkipCheck(skipIf) {
+	if (skipIf === undefined || skipIf === null || skipIf === false) {
+		return null;
+	}
+	if (typeof skipIf === 'string') {
+		return normalizeFixtureStep({ type: 'wp-cli', command: skipIf, label: 'idempotency check' }, 0);
+	}
+	if (isPlainObject(skipIf)) {
+		return normalizeFixtureStep({ type: 'wp-cli', ...skipIf, label: skipIf.label || 'idempotency check' }, 0);
+	}
+	throw new TypeError('fixture skipIf must be a string or object');
+}
+
+async function runStep(runCli, step, context, role = 'fixture') {
+	const command = fixtureCommand(step);
+	const startedAt = new Date().toISOString();
+	const started = Date.now();
+	const result = normalizeCliResult(await runCli(command, { ...context, step, role }));
+	const summary = {
+		label: step.label,
+		type: step.type,
+		command,
+		role,
+		status: result.exitCode === 0 ? 'passed' : 'failed',
+		exitCode: result.exitCode,
+		stdout: result.stdout,
+		stderr: result.stderr,
+		startedAt,
+		durationMs: Date.now() - started,
+	};
+	if (result.signal) {
+		summary.signal = result.signal;
+	}
+	if (result.exitCode !== 0) {
+		throw Object.assign(failedStepError(step, command, result), { fixtureStep: summary });
+	}
+	return summary;
+}
+
+async function runWordPressFixtureSetup(options = {}) {
+	if (!isPlainObject(options)) {
+		throw new TypeError('runWordPressFixtureSetup options must be an object');
+	}
+	const startedAt = new Date().toISOString();
+	const steps = [];
+	const runCli = options.runCli || ((command, context) => defaultRunCli(command, {
+		...options,
+		...context,
+	}));
+	const context = {
+		sitePath: options.sitePath,
+		artifactDir: options.artifactDir,
+		cwd: options.cwd,
+		env: options.env,
+	};
+
+	if (typeof options.setupWordPressFixture === 'function') {
+		try {
+			const calls = [];
+			const capturingRunCli = async (command, callOptions = {}) => {
+				const result = normalizeCliResult(await runCli(command, { ...context, ...callOptions, role: 'hook' }));
+				calls.push({
+					command: normalizeCliCommand(command),
+					exitCode: result.exitCode,
+					stdout: result.stdout,
+					stderr: result.stderr,
+				});
+				if (result.exitCode !== 0) {
+					throw failedStepError({ label: 'setupWordPressFixture', type: 'hook' }, normalizeCliCommand(command), result);
+				}
+				return result;
+			};
+			const value = await options.setupWordPressFixture({
+				...context,
+				runCli: capturingRunCli,
+			});
+			steps.push({ label: 'setupWordPressFixture', type: 'hook', status: 'passed', calls, value });
+		} catch (error) {
+			steps.push({ label: 'setupWordPressFixture', type: 'hook', status: 'failed', error: error.message });
+			return writeFixtureSummary({ status: 'failed', steps, startedAt }, options, error);
+		}
+	}
+
+	try {
+		for (const step of normalizeFixtureList(options.fixtures)) {
+			const skipCheck = normalizeSkipCheck(step.skipIf || step.idempotencyCheck);
+			if (skipCheck) {
+				const check = await runStep(runCli, skipCheck, context, 'idempotency-check').catch((error) => error.fixtureStep || {
+					label: skipCheck.label,
+					type: skipCheck.type,
+					role: 'idempotency-check',
+					status: 'failed',
+					error: error.message,
+				});
+				if (check.status === 'passed') {
+					steps.push({ ...check, fixture: step.label, status: 'skipped', reason: 'idempotency check passed' });
+					continue;
+				}
+				steps.push({ ...check, fixture: step.label, status: 'check-failed' });
+			}
+			steps.push(await runStep(runCli, step, context));
+		}
+	} catch (error) {
+		if (error.fixtureStep) {
+			steps.push(error.fixtureStep);
+		}
+		return writeFixtureSummary({ status: 'failed', steps, startedAt }, options, error);
+	}
+
+	return writeFixtureSummary({ status: 'passed', steps, startedAt }, options);
+}
+
+function writeFixtureSummary(summary, options, error) {
+	const output = {
+		...summary,
+		finishedAt: new Date().toISOString(),
+	};
+	if (options.artifactDir) {
+		fs.mkdirSync(options.artifactDir, { recursive: true });
+		const jsonPath = path.join(options.artifactDir, options.artifactFileName || 'wordpress-fixture-setup.json');
+		fs.writeFileSync(jsonPath, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
+		output.artifacts = { fixtureSetup: jsonPath };
+	}
+	if (error) {
+		error.fixtureSummary = output;
+		throw error;
+	}
+	return output;
+}
+
+module.exports = {
+	defaultRunCli,
+	normalizeFixtureList,
+	runWordPressFixtureSetup,
+};

--- a/wordpress/lib/page-profiler.js
+++ b/wordpress/lib/page-profiler.js
@@ -4,6 +4,7 @@
  * Internal dependencies
  */
 const { correlateBrowserAndWordPressTimings, normalizeUrl } = require('./timing-correlator');
+const { runWordPressFixtureSetup } = require('./fixture-setup');
 
 const DEFAULT_RESOURCE_INCLUDE = [
 	'/wp-json/',
@@ -1556,12 +1557,16 @@ async function profileWordPressPages(input) {
 		throw new TypeError('profileWordPressPages requires an input object');
 	}
 	const specs = normalizePageManifest(input.manifest || input.pages || []);
+	const fixtureSetup = input.fixtures || input.setupWordPressFixture
+		? await runWordPressFixtureSetup(input)
+		: undefined;
 	const results = [];
 	for (const spec of specs) {
 		results.push(await profileWordPressPage({ ...input, spec }));
 	}
 	return {
 		pages: results,
+		...(fixtureSetup ? { fixtureSetup } : {}),
 		topRestWaterfalls: [...results]
 			.sort((a, b) => (b.resources.restCount - a.resources.restCount) || (b.readyMs - a.readyMs))
 			.slice(0, input.topLimit || 10)
@@ -1590,6 +1595,7 @@ module.exports = {
 	formatWordPressRestNetworkDiffMarkdownReport,
 	formatWordPressRestWaterfallMarkdownReport,
 	installWordPressRestInstrumentation,
+	runWordPressFixtureSetup,
 	normalizePageManifest,
 	normalizePageSpec,
 	resourceFamily,

--- a/wordpress/tests/fixture-setup-smoke.js
+++ b/wordpress/tests/fixture-setup-smoke.js
@@ -1,0 +1,80 @@
+'use strict';
+
+/* eslint-disable no-console */
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+	normalizeFixtureList,
+	runWordPressFixtureSetup,
+} = require('../lib/fixture-setup');
+
+const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-fixtures-'));
+
+async function main() {
+	try {
+		assert.deepEqual(
+			normalizeFixtureList([{ path: 'fixtures/seed.php' }]).map((step) => ({ type: step.type, label: step.label })),
+			[{ type: 'wp-eval-file', label: 'wp-eval-file:1' }]
+		);
+
+		const calls = [];
+		const result = await runWordPressFixtureSetup({
+			artifactDir: fixtureDir,
+			sitePath: '/tmp/example-site',
+			runCli: async (command, context) => {
+				calls.push({ command, role: context.role });
+				return { exitCode: 0, stdout: `ok:${command}`, stderr: '' };
+			},
+			setupWordPressFixture: async ({ runCli }) => {
+				await runCli('wp option get hook_ready');
+				return { hook: true };
+			},
+			fixtures: [
+				{ id: 'seed-posts', type: 'wp-eval-file', path: 'fixtures/seed-posts.php' },
+				{ id: 'ready-flag', type: 'wp-cli', command: 'option update homeboy_fixture_ready 1' },
+				{
+					id: 'already-ready',
+					type: 'wp-cli',
+					command: 'post create --post_title=Skipped',
+					skipIf: 'option get homeboy_fixture_ready',
+				},
+			],
+		});
+
+		assert.equal(result.status, 'passed');
+		assert.equal(result.steps.length, 4);
+		assert.equal(result.steps[1].command, "eval-file 'fixtures/seed-posts.php'");
+		assert.equal(result.steps[3].status, 'skipped');
+		assert.equal(calls.some((call) => call.command === 'post create --post_title=Skipped'), false);
+		assert.ok(fs.existsSync(result.artifacts.fixtureSetup));
+		assert.match(fs.readFileSync(result.artifacts.fixtureSetup, 'utf8'), /seed-posts/);
+
+		await assert.rejects(
+			() => runWordPressFixtureSetup({
+				runCli: async () => ({ exitCode: 2, stdout: 'fixture stdout', stderr: 'fixture stderr' }),
+				fixtures: [{ id: 'broken', type: 'wp-cli', command: 'option update broken 1' }],
+			}),
+			(error) => {
+				assert.match(error.message, /WordPress fixture step "broken" failed/);
+				assert.match(error.message, /option update broken 1/);
+				assert.match(error.message, /fixture stdout/);
+				assert.match(error.message, /fixture stderr/);
+				assert.equal(error.fixtureSummary.status, 'failed');
+				return true;
+			}
+		);
+
+		console.log('WordPress fixture setup smoke passed.');
+	} finally {
+		fs.rmSync(fixtureDir, { recursive: true, force: true });
+	}
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/wordpress/tests/page-profiler-smoke.js
+++ b/wordpress/tests/page-profiler-smoke.js
@@ -354,8 +354,15 @@ async function main() {
 	assert.equal(page.calls.some((call) => call[0] === 'frame.waitForSelector' && call[1] === '[data-block]'), true);
 
 	const multiPage = new FakePage(resources);
-	const multi = await profileWordPressPages({ page: multiPage, baseUrl: 'https://example.test', manifest });
+	const multi = await profileWordPressPages({
+		page: multiPage,
+		baseUrl: 'https://example.test',
+		manifest,
+		fixtures: [{ id: 'profile-ready', type: 'wp-cli', command: 'option update profile_ready 1' }],
+		runCli: async (command) => ({ exitCode: 0, stdout: command, stderr: '' }),
+	});
 	assert.equal(multi.pages.length, 2);
+	assert.equal(multi.fixtureSetup.steps[0].label, 'profile-ready');
 	assert.equal(multi.topRestWaterfalls[0].restCount, 2);
 
 	assert.throws(() => normalizePageManifest({ pages: [{ id: 'bad' }] }), /requires url or path/);


### PR DESCRIPTION
## Summary
- Add a reusable WordPress fixture setup helper for profiling workloads with `wp-eval-file`, `wp-cli`, and imperative setup hooks.
- Capture fixture stdout/stderr in a returned summary and JSON artifact, with clear failed-step errors.
- Wire fixture setup into `profileWordPressPages()` so workloads can seed once before browser/API profiling.

Fixes #597.

## Testing
- `node wordpress/tests/fixture-setup-smoke.js`
- `node wordpress/tests/page-profiler-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the fixture setup helper, integration, smoke tests, and documentation; Chris remains responsible for review and validation.