### PR TITLE
Add declarative browser interactions to page profiling

### DIFF
--- a/nodejs/scripts/bench/browser-helper.mjs
+++ b/nodejs/scripts/bench/browser-helper.mjs
@@ -9,6 +9,56 @@ const BROWSER_PERFORMANCE_STATE = new WeakMap();
 const SECRET_HEADER_PATTERN = /^(authorization|cookie|set-cookie|proxy-authorization|x-api-key|x-auth-token|x-csrf-token|x-xsrf-token)$/i;
 const SECRET_HEADER_PART_PATTERN = /(token|secret|session|cookie|credential|password|key)/i;
 
+export async function runBrowserActions(page, actions, options = {}) {
+    if (!Array.isArray(actions) || actions.length === 0) {
+        return { actions: [], duration_ms: 0, failed: false };
+    }
+    if (!page || typeof page !== 'object') {
+        throw new Error('runBrowserActions requires a Playwright page.');
+    }
+
+    const startedAt = performance.now();
+    const evidence = [];
+    for (let index = 0; index < actions.length; index += 1) {
+        const normalized = normalizeBrowserAction(actions[index], index, options);
+        const actionStartedAt = performance.now();
+        const row = {
+            index,
+            name: normalized.name,
+            type: normalized.type,
+            target: normalized.target,
+            timeout_ms: normalized.timeout,
+            started_at_ms: roundNumber(actionStartedAt - startedAt),
+        };
+        evidence.push(row);
+        try {
+            const result = await executeBrowserAction(page, normalized);
+            row.duration_ms = roundNumber(performance.now() - actionStartedAt);
+            row.status = 'passed';
+            if (result) row.result = result;
+            if (typeof options.mark === 'function') {
+                await options.mark(normalized.name || `interaction_${index + 1}`);
+            }
+        } catch (error) {
+            row.duration_ms = roundNumber(performance.now() - actionStartedAt);
+            row.status = 'failed';
+            row.error = error?.message || String(error);
+            await attachBrowserActionFailureEvidence(page, row, normalized, options).catch(() => {});
+            const wrapped = new Error(formatBrowserActionFailure(row, error));
+            wrapped.cause = error;
+            wrapped.action = row;
+            wrapped.actions = evidence;
+            throw wrapped;
+        }
+    }
+
+    return stableJson({
+        actions: evidence,
+        duration_ms: roundNumber(performance.now() - startedAt),
+        failed: false,
+    });
+}
+
 export async function installBrowserPerformanceObservers(page, options = {}) {
     if (!page || typeof page.on !== 'function' || typeof page.evaluate !== 'function') {
         throw new Error('installBrowserPerformanceObservers requires a Playwright page.');
@@ -304,6 +354,7 @@ export async function runBrowserBench(options) {
     let browser;
     let context;
     let page;
+    let tracePath;
 
     const mark = async (name) => {
         const key = `${sanitizeMetricName(name)}_ms`;
@@ -315,12 +366,29 @@ export async function runBrowserBench(options) {
         browser = await launchBrowser(browserType, config);
         context = await browser.newContext(config.contextOptions);
         if (config.trace) {
+            tracePath = join(config.artifactsDir, `${config.id}-trace.zip`);
             await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
         }
         page = await context.newPage();
         attachPageObservers(page, network, consoleMessages, requestStarts);
 
-        await config.action({ browser, context, page, mark });
+        const actionFailureOptions = {
+            mark,
+            failureScreenshotPath: join(config.artifactsDir, `${config.id}-interaction-failure.png`),
+            tracePath,
+        };
+        await config.action({ browser, context, page, mark, runActions: (actions, actionOptions = {}) => runBrowserActions(page, actions, { ...actionFailureOptions, ...actionOptions }) });
+        if (config.actions.length > 0) {
+            const interactionEvidence = await runBrowserActions(page, config.actions, { ...actionFailureOptions, ...config.actionOptions });
+            metrics.browser_interaction_count = interactionEvidence.actions.length;
+            metrics.browser_interaction_duration_ms = interactionEvidence.duration_ms;
+            artifacts.interactions = {
+                path: join(config.artifactsDir, `${config.id}-interactions.json`),
+                kind: 'browser-interactions',
+                label: 'Browser interaction evidence',
+            };
+            await writeJson(artifacts.interactions.path, interactionEvidence);
+        }
 
         if (config.waitForNetworkIdle) {
             await recordNetworkIdle(page, metrics, start, config.networkIdleTimeoutMs);
@@ -356,7 +424,6 @@ export async function runBrowserBench(options) {
         };
 
         if (config.trace) {
-            const tracePath = join(config.artifactsDir, `${config.id}-trace.zip`);
             await context.tracing.stop({ path: tracePath });
             artifacts.trace = {
                 path: tracePath,
@@ -364,6 +431,17 @@ export async function runBrowserBench(options) {
                 label: 'Playwright trace',
             };
         }
+    } catch (error) {
+        if (page && typeof page.screenshot === 'function') {
+            const screenshotPath = join(config.artifactsDir, `${config.id}-interaction-failure.png`);
+            await page.screenshot({ path: screenshotPath, fullPage: true }).catch(() => {});
+            error.screenshotPath = screenshotPath;
+        }
+        if (context && config.trace && tracePath) {
+            await context.tracing.stop({ path: tracePath }).catch(() => {});
+            error.tracePath = tracePath;
+        }
+        throw error;
     } finally {
         if (context && config.trace) {
             try {
@@ -384,8 +462,8 @@ function normalizeOptions(options) {
     if (!options || typeof options !== 'object' || Array.isArray(options)) {
         throw new Error('runBrowserBench requires an options object.');
     }
-    if (typeof options.action !== 'function') {
-        throw new Error('runBrowserBench requires an async action({ page, mark }) function.');
+    if (typeof options.action !== 'function' && !Array.isArray(options.actions)) {
+        throw new Error('runBrowserBench requires an async action({ page, mark }) function or an actions array.');
     }
 
     const id = sanitizeFilePart(options.id || 'browser-bench');
@@ -399,7 +477,9 @@ function normalizeOptions(options) {
     return {
         id,
         artifactsDir,
-        action: options.action,
+        action: typeof options.action === 'function' ? options.action : async () => {},
+        actions: Array.isArray(options.actions) ? options.actions : [],
+        actionOptions: options.actionOptions || {},
         browserName: options.browserName || 'chromium',
         headless: options.headless !== false,
         trace: options.trace !== false,
@@ -409,6 +489,177 @@ function normalizeOptions(options) {
         launchOptions: options.launchOptions || {},
         contextOptions: options.contextOptions || {},
     };
+}
+
+function normalizeBrowserAction(action, index, options = {}) {
+    if (!action || typeof action !== 'object' || Array.isArray(action)) {
+        throw new Error(`Browser action ${index} must be an object.`);
+    }
+
+    const timeout = finitePositiveNumber(action.timeout ?? options.timeout) || 30000;
+    const name = sanitizeMetricName(action.name || `interaction_${index + 1}`);
+    const candidates = [
+        ['click', action.click],
+        ['clickSelector', action.clickSelector],
+        ['clickRole', action.clickRole],
+        ['clickText', action.clickText],
+        ['fill', action.fill],
+        ['select', action.select],
+        ['waitForSelector', action.waitForSelector],
+        ['waitForResponse', action.waitForResponse],
+        ['sleep', action.sleep],
+    ].filter(([, value]) => value !== undefined);
+    if (candidates.length !== 1) {
+        throw new Error(`Browser action ${index} must define exactly one supported action.`);
+    }
+
+    const [type, rawSpec] = candidates[0];
+    const spec = typeof rawSpec === 'string' || typeof rawSpec === 'number' ? { value: rawSpec } : { ...(rawSpec || {}) };
+    return { index, name, type, timeout, spec, target: describeBrowserAction(type, spec) };
+}
+
+async function executeBrowserAction(page, action) {
+    const { type, spec, timeout } = action;
+    if (type === 'sleep') {
+        await new Promise((resolve) => setTimeout(resolve, Number(spec.ms ?? spec.value ?? 0)));
+        return null;
+    }
+    if (type === 'waitForResponse') {
+        if (typeof page.waitForResponse !== 'function') throw new Error('waitForResponse requires page.waitForResponse().');
+        const response = await page.waitForResponse((candidate) => responseMatches(candidate, spec), { timeout });
+        return normalizeActionResponse(response);
+    }
+    if (type === 'waitForSelector') {
+        const selector = requiredString(spec.selector ?? spec.value, 'waitForSelector.selector');
+        if (Number.isInteger(spec.index)) {
+            const locator = selectorLocator(page, selector, spec.index);
+            await locator.waitFor({ state: spec.state || 'visible', timeout });
+            return null;
+        }
+        if (typeof page.waitForSelector !== 'function') throw new Error('waitForSelector requires page.waitForSelector().');
+        await page.waitForSelector(selector, { state: spec.state || 'visible', timeout });
+        return null;
+    }
+    if (type === 'clickRole') {
+        const role = requiredString(spec.role, 'clickRole.role');
+        const locator = indexedLocator(page.getByRole(role, roleOptions(spec)), spec.index);
+        await locator.click({ timeout });
+        return null;
+    }
+    if (type === 'clickText') {
+        const text = requiredString(spec.text ?? spec.value, 'clickText.text');
+        const locator = indexedLocator(page.getByText(text, { exact: spec.exact }), spec.index);
+        await locator.click({ timeout });
+        return null;
+    }
+    if (type === 'click' || type === 'clickSelector') {
+        const selector = requiredString(spec.selector ?? spec.value, `${type}.selector`);
+        if (Number.isInteger(spec.index)) {
+            await selectorLocator(page, selector, spec.index).click({ timeout });
+            return null;
+        }
+        if (typeof page.click === 'function') {
+            await page.click(selector, { timeout });
+            return null;
+        }
+        await selectorLocator(page, selector, 0).click({ timeout });
+        return null;
+    }
+    if (type === 'fill') {
+        const selector = requiredString(spec.selector, 'fill.selector');
+        await selectorLocator(page, selector, spec.index).fill(String(spec.value ?? ''), { timeout });
+        return null;
+    }
+    if (type === 'select') {
+        const selector = requiredString(spec.selector, 'select.selector');
+        await selectorLocator(page, selector, spec.index).selectOption(selectOptionValue(spec), { timeout });
+        return null;
+    }
+    throw new Error(`Unsupported browser action type: ${type}`);
+}
+
+function selectorLocator(page, selector, index = 0) {
+    if (typeof page.locator !== 'function') throw new Error('selector actions require page.locator().');
+    return indexedLocator(page.locator(selector), index);
+}
+
+function indexedLocator(locator, index = 0) {
+    if (Number.isInteger(index) && index > 0) return locator.nth(index);
+    return locator;
+}
+
+function roleOptions(spec) {
+    const options = {};
+    if (spec.name !== undefined) options.name = spec.name;
+    if (spec.exact !== undefined) options.exact = spec.exact;
+    return options;
+}
+
+function selectOptionValue(spec) {
+    if (spec.optionIndex !== undefined) return { index: spec.optionIndex };
+    if (spec.label !== undefined) return { label: spec.label };
+    if (spec.value !== undefined) return spec.value;
+    throw new Error('select requires value, label, or optionIndex.');
+}
+
+function responseMatches(response, spec) {
+    const url = typeof response.url === 'function' ? response.url() : response.url;
+    const method = typeof response.request === 'function' ? response.request()?.method?.() : undefined;
+    const status = typeof response.status === 'function' ? response.status() : response.status;
+    if (spec.method && String(method || '').toUpperCase() !== String(spec.method).toUpperCase()) return false;
+    if (spec.status !== undefined && Number(status) !== Number(spec.status)) return false;
+    if (spec.substring && !String(url).includes(spec.substring)) return false;
+    if (spec.url && !String(url).includes(spec.url)) return false;
+    if (spec.pattern && !(new RegExp(spec.pattern).test(String(url)))) return false;
+    return Boolean(spec.substring || spec.url || spec.pattern || spec.method || spec.status !== undefined);
+}
+
+function normalizeActionResponse(response) {
+    if (!response) return null;
+    return {
+        url: typeof response.url === 'function' ? response.url() : response.url,
+        status: typeof response.status === 'function' ? response.status() : response.status,
+    };
+}
+
+async function attachBrowserActionFailureEvidence(page, row, action, options) {
+    if (typeof page.screenshot === 'function' && options.failureScreenshotPath) {
+        await page.screenshot({ path: options.failureScreenshotPath, fullPage: true });
+        row.screenshot = options.failureScreenshotPath;
+    }
+    if (options.tracePath) row.trace = options.tracePath;
+    row.action = { name: action.name, type: action.type, target: action.target };
+}
+
+function formatBrowserActionFailure(row, error) {
+    const parts = [
+        `Browser action ${row.index} (${row.name || row.type}) failed`,
+        `type=${row.type}`,
+        `target=${row.target || 'unknown'}`,
+        `timeout=${row.timeout_ms}ms`,
+    ];
+    if (row.screenshot) parts.push(`screenshot=${row.screenshot}`);
+    if (row.trace) parts.push(`trace=${row.trace}`);
+    parts.push(error?.message || String(error));
+    return parts.join('; ');
+}
+
+function describeBrowserAction(type, spec) {
+    if (type === 'clickRole') return `role:${spec.role}${spec.name !== undefined ? ` name:${spec.name}` : ''}`;
+    if (type === 'clickText') return `text:${spec.text ?? spec.value ?? ''}`;
+    if (type === 'waitForResponse') return `response:${spec.substring || spec.url || spec.pattern || spec.method || spec.status || ''}`;
+    if (type === 'sleep') return `${spec.ms ?? spec.value ?? 0}ms`;
+    return spec.selector ?? spec.value ?? '';
+}
+
+function requiredString(value, label) {
+    if (typeof value !== 'string' || value.trim() === '') throw new Error(`${label} must be a non-empty string.`);
+    return value;
+}
+
+function finitePositiveNumber(value) {
+    const number = Number(value);
+    return Number.isFinite(number) && number > 0 ? number : undefined;
 }
 
 async function loadPlaywright() {

--- a/nodejs/scripts/bench/nodejs-browser-performance-profiler-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-browser-performance-profiler-smoke.sh
@@ -11,6 +11,7 @@ const {
   collectBrowserPerformanceProfile,
   compareBrowserPerformanceProfiles,
   formatBrowserPerformanceReport,
+  runBrowserActions,
 } = await import(process.argv[2]);
 
 class FakePage {
@@ -56,8 +57,70 @@ class FakePage {
     return null;
   }
 
+  async click(selector) {
+    this.emit('action', ['click', selector]);
+  }
+
+  locator(selector) {
+    this.emit('action', ['locator', selector]);
+    return new FakeLocator(this, selector);
+  }
+
+  getByRole(role, options) {
+    this.emit('action', ['getByRole', role, options?.name]);
+    return new FakeLocator(this, `role:${role}`);
+  }
+
+  getByText(text, options) {
+    this.emit('action', ['getByText', text, options?.exact]);
+    return new FakeLocator(this, `text:${text}`);
+  }
+
+  async waitForSelector(selector) {
+    this.emit('action', ['waitForSelector', selector]);
+  }
+
+  async waitForResponse(predicate) {
+    this.emit('action', ['waitForResponse']);
+    const response = {
+      url: () => 'https://example.test/wp-json/datamachine/v1/jobs',
+      status: () => 200,
+      request: () => ({ method: () => 'GET' }),
+    };
+    if (!predicate(response)) throw new Error('response predicate did not match');
+    return response;
+  }
+
   emit(name, value) {
     for (const handler of this.handlers.get(name) || []) handler(value);
+  }
+}
+
+class FakeLocator {
+  constructor(page, selector) {
+    this.page = page;
+    this.selector = selector;
+  }
+
+  nth(index) {
+    this.page.emit('action', ['locator.nth', this.selector, index]);
+    return this;
+  }
+
+  async click() {
+    this.page.emit('action', ['locator.click', this.selector]);
+  }
+
+  async fill(value) {
+    this.page.emit('action', ['locator.fill', this.selector, value]);
+  }
+
+  async selectOption(value) {
+    this.page.emit('action', ['locator.selectOption', this.selector, value]);
+  }
+
+  async waitFor(options) {
+    this.page.emit('action', ['locator.waitFor', this.selector, options?.state]);
   }
 }
 
@@ -75,6 +138,22 @@ const response = {
 };
 
 const page = new FakePage();
+const actionCalls = [];
+page.on('action', (call) => actionCalls.push(call));
+const actionEvidence = await runBrowserActions(page, [
+  { click: '.button-primary' },
+  { clickRole: { role: 'button', name: 'Admin' } },
+  { fill: { selector: '.filter', value: 'queued' } },
+  { select: { selector: 'select', index: 1, optionIndex: 2 } },
+  { waitForSelector: '.modal' },
+  { waitForResponse: { substring: '/wp-json/datamachine/v1/jobs', status: 200 } },
+  { sleep: 1 },
+]);
+assert.equal(actionEvidence.actions.length, 7);
+assert.equal(actionEvidence.actions[0].status, 'passed');
+assert.equal(actionCalls.some((call) => call[0] === 'getByRole' && call[1] === 'button' && call[2] === 'Admin'), true);
+assert.equal(actionCalls.some((call) => call[0] === 'locator.selectOption' && call[2]?.index === 2), true);
+
 const controller = await installBrowserPerformanceObservers(page, { includeHeaders: true });
 page.emit('request', request);
 page.emit('response', response);

--- a/wordpress/lib/page-profiler.js
+++ b/wordpress/lib/page-profiler.js
@@ -1475,6 +1475,252 @@ function diagnoseWordPressPageProfile(profile, options = {}) {
 	};
 }
 
+async function runBrowserActions(page, actions, options = {}) {
+	if (!Array.isArray(actions) || actions.length === 0) {
+		return { actions: [], durationMs: 0, failed: false };
+	}
+	if (!page || typeof page !== 'object') {
+		throw new TypeError('runBrowserActions requires a Playwright page');
+	}
+
+	const startedAt = Date.now();
+	const evidence = [];
+	for (let index = 0; index < actions.length; index += 1) {
+		const action = normalizeBrowserAction(actions[index], index, options);
+		const actionStartedAt = Date.now();
+		const row = {
+			index,
+			name: action.name,
+			type: action.type,
+			target: action.target,
+			timeoutMs: action.timeout,
+			startedAtMs: actionStartedAt - startedAt,
+		};
+		evidence.push(row);
+		try {
+			const result = await executeBrowserAction(page, action);
+			row.durationMs = Date.now() - actionStartedAt;
+			row.status = 'passed';
+			if (result) {
+				row.result = result;
+			}
+			if (typeof options.mark === 'function') {
+				await options.mark(action.name || `interaction_${index + 1}`);
+			}
+		} catch (error) {
+			row.durationMs = Date.now() - actionStartedAt;
+			row.status = 'failed';
+			row.error = error?.message || String(error);
+			await attachBrowserActionFailureEvidence(page, row, options).catch(() => {});
+			const wrapped = new Error(formatBrowserActionFailure(row, error));
+			wrapped.cause = error;
+			wrapped.action = row;
+			wrapped.actions = evidence;
+			throw wrapped;
+		}
+	}
+
+	return {
+		actions: evidence,
+		durationMs: Date.now() - startedAt,
+		failed: false,
+	};
+}
+
+function normalizeBrowserAction(action, index, options = {}) {
+	if (!isPlainObject(action)) {
+		throw new TypeError(`browser action ${index} must be an object`);
+	}
+	const candidates = [
+		['click', action.click],
+		['clickSelector', action.clickSelector],
+		['clickRole', action.clickRole],
+		['clickText', action.clickText],
+		['fill', action.fill],
+		['select', action.select],
+		['waitForSelector', action.waitForSelector],
+		['waitForResponse', action.waitForResponse],
+		['sleep', action.sleep],
+	].filter(([, value]) => value !== undefined);
+	if (candidates.length !== 1) {
+		throw new TypeError(`browser action ${index} must define exactly one supported action`);
+	}
+	const [type, rawSpec] = candidates[0];
+	const spec = typeof rawSpec === 'string' || typeof rawSpec === 'number' ? { value: rawSpec } : { ...(rawSpec || {}) };
+	const timeout = Number(action.timeout ?? spec.timeout ?? options.timeout) || 30000;
+	const name = action.name || spec.name || `interaction_${index + 1}`;
+	return { index, name, type, spec, timeout, target: describeBrowserAction(type, spec) };
+}
+
+async function executeBrowserAction(page, action) {
+	const { type, spec, timeout } = action;
+	if (type === 'sleep') {
+		await sleep(Number(spec.ms ?? spec.value ?? 0));
+		return null;
+	}
+	if (type === 'waitForResponse') {
+		if (typeof page.waitForResponse !== 'function') {
+			throw new TypeError('waitForResponse requires page.waitForResponse()');
+		}
+		const response = await page.waitForResponse((candidate) => responseMatches(candidate, spec), { timeout });
+		return normalizeActionResponse(response);
+	}
+	if (type === 'waitForSelector') {
+		const selector = requiredString(spec.selector ?? spec.value, 'waitForSelector.selector');
+		if (Number.isInteger(spec.index)) {
+			await selectorLocator(page, selector, spec.index).waitFor({ state: spec.state || 'visible', timeout });
+			return null;
+		}
+		if (typeof page.waitForSelector !== 'function') {
+			throw new TypeError('waitForSelector requires page.waitForSelector()');
+		}
+		await page.waitForSelector(selector, { state: spec.state || 'visible', timeout });
+		return null;
+	}
+	if (type === 'clickRole') {
+		const role = requiredString(spec.role, 'clickRole.role');
+		await indexedLocator(page.getByRole(role, roleOptions(spec)), spec.index).click({ timeout });
+		return null;
+	}
+	if (type === 'clickText') {
+		const text = requiredString(spec.text ?? spec.value, 'clickText.text');
+		await indexedLocator(page.getByText(text, { exact: spec.exact }), spec.index).click({ timeout });
+		return null;
+	}
+	if (type === 'click' || type === 'clickSelector') {
+		const selector = requiredString(spec.selector ?? spec.value, `${type}.selector`);
+		if (Number.isInteger(spec.index)) {
+			await selectorLocator(page, selector, spec.index).click({ timeout });
+			return null;
+		}
+		if (typeof page.click === 'function') {
+			await page.click(selector, { timeout });
+			return null;
+		}
+		await selectorLocator(page, selector, 0).click({ timeout });
+		return null;
+	}
+	if (type === 'fill') {
+		await selectorLocator(page, requiredString(spec.selector, 'fill.selector'), spec.index).fill(String(spec.value ?? ''), { timeout });
+		return null;
+	}
+	if (type === 'select') {
+		await selectorLocator(page, requiredString(spec.selector, 'select.selector'), spec.index).selectOption(selectOptionValue(spec), { timeout });
+		return null;
+	}
+	throw new Error(`unsupported browser action type: ${type}`);
+}
+
+function selectorLocator(page, selector, index = 0) {
+	if (typeof page.locator !== 'function') {
+		throw new TypeError('selector actions require page.locator()');
+	}
+	return indexedLocator(page.locator(selector), index);
+}
+
+function indexedLocator(locator, index = 0) {
+	return Number.isInteger(index) && index > 0 ? locator.nth(index) : locator;
+}
+
+function roleOptions(spec) {
+	const options = {};
+	if (spec.name !== undefined) {
+		options.name = spec.name;
+	}
+	if (spec.exact !== undefined) {
+		options.exact = spec.exact;
+	}
+	return options;
+}
+
+function selectOptionValue(spec) {
+	if (spec.optionIndex !== undefined) {
+		return { index: spec.optionIndex };
+	}
+	if (spec.label !== undefined) {
+		return { label: spec.label };
+	}
+	if (spec.value !== undefined) {
+		return spec.value;
+	}
+	throw new TypeError('select requires value, label, or optionIndex');
+}
+
+function responseMatches(response, spec) {
+	const url = typeof response.url === 'function' ? response.url() : response.url;
+	const request = typeof response.request === 'function' ? response.request() : undefined;
+	const method = typeof request?.method === 'function' ? request.method() : request?.method;
+	const status = typeof response.status === 'function' ? response.status() : response.status;
+	if (spec.method && String(method || '').toUpperCase() !== String(spec.method).toUpperCase()) {
+		return false;
+	}
+	if (spec.status !== undefined && Number(status) !== Number(spec.status)) {
+		return false;
+	}
+	if (spec.substring && !String(url).includes(spec.substring)) {
+		return false;
+	}
+	if (spec.url && !String(url).includes(spec.url)) {
+		return false;
+	}
+	if (spec.pattern && !(new RegExp(spec.pattern).test(String(url)))) {
+		return false;
+	}
+	return Boolean(spec.substring || spec.url || spec.pattern || spec.method || spec.status !== undefined);
+}
+
+function normalizeActionResponse(response) {
+	return response ? {
+		url: typeof response.url === 'function' ? response.url() : response.url,
+		status: typeof response.status === 'function' ? response.status() : response.status,
+	} : null;
+}
+
+async function attachBrowserActionFailureEvidence(page, row, options) {
+	if (typeof page.screenshot === 'function' && options.failureScreenshotPath) {
+		await page.screenshot({ path: options.failureScreenshotPath, fullPage: true });
+		row.screenshot = options.failureScreenshotPath;
+	}
+	if (options.tracePath) {
+		row.trace = options.tracePath;
+	}
+}
+
+function formatBrowserActionFailure(row, error) {
+	return [
+		`Browser action ${row.index} (${row.name || row.type}) failed`,
+		`type=${row.type}`,
+		`target=${row.target || 'unknown'}`,
+		`timeout=${row.timeoutMs}ms`,
+		row.screenshot ? `screenshot=${row.screenshot}` : null,
+		row.trace ? `trace=${row.trace}` : null,
+		error?.message || String(error),
+	].filter(Boolean).join('; ');
+}
+
+function describeBrowserAction(type, spec) {
+	if (type === 'clickRole') {
+		return `role:${spec.role}${spec.name !== undefined ? ` name:${spec.name}` : ''}`;
+	}
+	if (type === 'clickText') {
+		return `text:${spec.text ?? spec.value ?? ''}`;
+	}
+	if (type === 'waitForResponse') {
+		return `response:${spec.substring || spec.url || spec.pattern || spec.method || spec.status || ''}`;
+	}
+	if (type === 'sleep') {
+		return `${spec.ms ?? spec.value ?? 0}ms`;
+	}
+	return spec.selector ?? spec.value ?? '';
+}
+
+function requiredString(value, label) {
+	if (typeof value !== 'string' || value.trim() === '') {
+		throw new TypeError(`${label} must be a non-empty string`);
+	}
+	return value;
+}
+
 async function profileWordPressPage(input) {
 	if (!input || typeof input !== 'object') {
 		throw new TypeError('profileWordPressPage requires an input object');
@@ -1505,15 +1751,30 @@ async function profileWordPressPage(input) {
 	}
 
 	const readyMs = Date.now() - started;
+	const initialResources = await collectBrowserResourceTimings(page, spec.resources || {}).catch(() => []);
+	const interactionActions = Array.isArray(input.interactions)
+		? input.interactions
+		: Array.isArray(spec.interactions) ? spec.interactions : Array.isArray(spec.actions) ? spec.actions : [];
+	const interactionStartedMs = Date.now() - started;
+	const interactions = await runBrowserActions(page, interactionActions, {
+		mark,
+		timeout: spec.interactionTimeout || input.interactionTimeout,
+		failureScreenshotPath: spec.failureScreenshotPath || input.failureScreenshotPath,
+		tracePath: spec.tracePath || input.tracePath,
+	});
 	const restObservationMs = Number(spec.restObservationMs ?? input.restObservationMs ?? DEFAULT_REST_OBSERVATION_MS);
 	if (restObservationMs > 0) {
 		await sleep(restObservationMs);
 	}
 	const resources = await collectBrowserResourceTimings(page, spec.resources || {});
+	const interactionResources = resources.filter((resource) => typeof resource.startTime === 'number' && resource.startTime >= interactionStartedMs);
 	const resourceSummary = summarizeResourceTimings(resources);
+	const initialResourceSummary = summarizeResourceTimings(initialResources);
+	const interactionResourceSummary = summarizeResourceTimings(interactionResources);
 	const apiFetchAttempts = typeof page.evaluate === 'function'
 		? await collectWordPressRestAttempts(page).catch(() => [])
 		: [];
+	const interactionApiFetchAttempts = apiFetchAttempts.filter((attempt) => typeof attempt.startedAtMs === 'number' && attempt.startedAtMs >= interactionStartedMs);
 	const restPreloads = [
 		...normalizeRestPreloadList(input.preloadedRestPaths),
 		...normalizeRestPreloadList(input.restPreloads),
@@ -1532,6 +1793,13 @@ async function profileWordPressPage(input) {
 		resourceTimings: resources,
 		networkRequests: input.networkRequests || [],
 	});
+	const interactionRestWaterfall = summarizeWordPressRestWaterfall({
+		readyMs: interactionStartedMs,
+		apiFetchAttempts: interactionApiFetchAttempts,
+		restPreloads,
+		resourceTimings: interactionResources,
+		networkRequests: (input.networkRequests || []).filter((request) => Number(request?.start_ms ?? request?.startMs ?? request?.startTime) >= interactionStartedMs),
+	});
 	const correlation = correlateBrowserAndWordPressTimings({
 		browserTimings: resources,
 		wordpressProfilerRows,
@@ -1544,7 +1812,11 @@ async function profileWordPressPage(input) {
 		status: response && typeof response.status === 'function' ? response.status() : 0,
 		readyMs,
 		resources: resourceSummary,
+		initialResources: initialResourceSummary,
+		interactions,
+		interactionResources: interactionResourceSummary,
 		restWaterfall,
+		interactionRestWaterfall,
 		correlation,
 	};
 
@@ -1590,6 +1862,7 @@ module.exports = {
 	formatWordPressRestNetworkDiffMarkdownReport,
 	formatWordPressRestWaterfallMarkdownReport,
 	installWordPressRestInstrumentation,
+	normalizeBrowserAction,
 	normalizePageManifest,
 	normalizePageSpec,
 	resourceFamily,
@@ -1597,6 +1870,7 @@ module.exports = {
 	profileWordPressPages,
 	recommendWordPressPerformanceGates,
 	resolveWordPressUrl,
+	runBrowserActions,
 	summarizeWordPressRestNetworkRows,
 	summarizeWordPressRestWaterfall,
 	summarizeResourceTimings,

--- a/wordpress/tests/page-profiler-smoke.js
+++ b/wordpress/tests/page-profiler-smoke.js
@@ -19,12 +19,14 @@ const {
 	formatWordPressPerformanceGateReport,
 	formatWordPressRestNetworkDiffMarkdownReport,
 	formatWordPressRestWaterfallMarkdownReport,
+	normalizeBrowserAction,
 	normalizePageManifest,
 	profileWordPressPage,
 	profileWordPressPages,
 	recommendWordPressPerformanceGates,
 	resourceFamily,
 	resolveWordPressUrl,
+	runBrowserActions,
 	summarizeWordPressRestNetworkRows,
 	summarizeWordPressRestWaterfall,
 	summarizeResourceTimings,
@@ -64,6 +66,38 @@ class FakePage {
 		this.calls.push(['waitForSelector', selector]);
 	}
 
+	async click(selector) {
+		this.calls.push(['click', selector]);
+	}
+
+	locator(selector) {
+		this.calls.push(['locator', selector]);
+		return new FakeLocator(this.calls, selector);
+	}
+
+	getByRole(role, options) {
+		this.calls.push(['getByRole', role, options?.name]);
+		return new FakeLocator(this.calls, `role:${role}`);
+	}
+
+	getByText(text, options) {
+		this.calls.push(['getByText', text, options?.exact]);
+		return new FakeLocator(this.calls, `text:${text}`);
+	}
+
+	async waitForResponse(predicate) {
+		this.calls.push(['waitForResponse']);
+		const response = {
+			url: () => 'https://example.test/wp-json/datamachine/v1/jobs',
+			status: () => 200,
+			request: () => ({ method: () => 'GET' }),
+		};
+		if (!predicate(response)) {
+			throw new Error('response predicate did not match');
+		}
+		return response;
+	}
+
 	frame(query) {
 		this.calls.push(['frame', query?.name || query]);
 		return this.fakeFrame;
@@ -71,6 +105,34 @@ class FakePage {
 
 	async evaluate() {
 		return this.resources;
+	}
+}
+
+class FakeLocator {
+	constructor(calls, selector) {
+		this.calls = calls;
+		this.selector = selector;
+	}
+
+	nth(index) {
+		this.calls.push(['locator.nth', this.selector, index]);
+		return this;
+	}
+
+	async click() {
+		this.calls.push(['locator.click', this.selector]);
+	}
+
+	async fill(value) {
+		this.calls.push(['locator.fill', this.selector, value]);
+	}
+
+	async selectOption(value) {
+		this.calls.push(['locator.selectOption', this.selector, value]);
+	}
+
+	async waitFor(options) {
+		this.calls.push(['locator.waitFor', this.selector, options?.state]);
 	}
 }
 
@@ -88,12 +150,21 @@ const manifest = normalizePageManifest({
 			id: 'site-editor',
 			path: '/wp-admin/site-editor.php',
 			ready: { selector: 'iframe[name="editor-canvas"]', frameName: 'editor-canvas', frameSelector: '[data-block]' },
+			interactions: [
+				{ name: 'open_admin', clickRole: { role: 'button', name: 'Admin' } },
+				{ waitForSelector: '.datamachine-jobs-admin-modal' },
+				{ select: { selector: '.datamachine-jobs-admin-modal select', index: 0, value: 'flow' } },
+				{ select: { selector: '.datamachine-jobs-admin-modal select', index: 1, optionIndex: 1 } },
+				{ fill: { selector: '.datamachine-filter', value: 'queued' } },
+				{ waitForResponse: { substring: '/wp-json/datamachine/v1/jobs', status: 200 } },
+			],
 		},
 	],
 });
 assert.equal(manifest.length, 2);
 assert.equal(manifest[0].ready.selector, '#dashboard-widgets');
 assert.equal(manifest[1].ready.frameSelector, '[data-block]');
+assert.equal(normalizeBrowserAction({ clickText: 'Save' }, 0).target, 'text:Save');
 
 const resources = [
 	{
@@ -336,6 +407,16 @@ const summary = summarizeResourceTimings(resources.map((entry) => ({ ...entry, k
 	assert.match(formatWordPressPerformanceGateReport(skippedGateRecommendations), /Skipped gates/);
 
 async function main() {
+	const actionPage = new FakePage(resources);
+	const actionEvidence = await runBrowserActions(actionPage, [
+		{ click: '.button-primary' },
+		{ clickText: { text: 'Open', exact: true } },
+		{ sleep: 1 },
+	]);
+	assert.equal(actionEvidence.actions.length, 3);
+	assert.equal(actionEvidence.actions[0].status, 'passed');
+	assert.equal(actionPage.calls.some((call) => call[0] === 'click' && call[1] === '.button-primary'), true);
+
 	const page = new FakePage(resources);
 	const result = await profileWordPressPage({
 		page,
@@ -350,8 +431,14 @@ async function main() {
 	assert.equal(result.id, 'site-editor');
 	assert.equal(result.status, 200);
 	assert.equal(result.resources.restCount, 2);
+	assert.equal(result.initialResources.restCount, 2);
+	assert.equal(result.interactions.actions.length, 6);
+	assert.equal(result.interactionResources.restCount, 2);
+	assert.equal(result.interactionRestWaterfall.counts.total, 2);
 	assert.equal(result.correlation.correlated.length, 1);
 	assert.equal(page.calls.some((call) => call[0] === 'frame.waitForSelector' && call[1] === '[data-block]'), true);
+	assert.equal(page.calls.some((call) => call[0] === 'getByRole' && call[1] === 'button' && call[2] === 'Admin'), true);
+	assert.equal(page.calls.some((call) => call[0] === 'locator.selectOption' && call[2]?.index === 1), true);
 
 	const multiPage = new FakePage(resources);
 	const multi = await profileWordPressPages({ page: multiPage, baseUrl: 'https://example.test', manifest });


### PR DESCRIPTION
## Summary
- Adds a declarative browser action runner for Playwright-backed browser profiles, including click selector/role/text, fill, select option, wait for selector, wait for response, and sleep actions.
- Wires WordPress page profiles to run `interactions` after initial readiness and report initial, interaction, and total resource/REST evidence separately.
- Extends smoke coverage for the generic Node.js browser profiler and WordPress page profiler interaction paths.

Fixes #596

## Testing
- `bash nodejs/scripts/bench/nodejs-browser-performance-profiler-smoke.sh`
- `npm run test:page-profiler` from `wordpress/`
- `git diff --check`

## Notes
- `npm run lint:js -- lib/page-profiler.js tests/page-profiler-smoke.js` could not run in this worktree because `eslint` is not installed in `wordpress/node_modules`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the declarative action runner, WordPress profiler integration, tests, and PR preparation for Chris to review.