### PR TITLE
fix(wordpress): import agent before execute workflows

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -190,7 +190,7 @@ name: Data Machine Agent CI (reusable)
           JSON array of additional ability slugs the runner must assert are
           registered before invoking the agent. Default '[]' means rely on
           the runner's built-in ability set (datamachine/import-agent,
-          datamachine/run-flow, datamachine/drain-job).
+          datamachine/run-flow or datamachine/execute-workflow, datamachine/drain-job).
         type: string
         default: "[]"
       ability_tools:
@@ -708,7 +708,7 @@ jobs:
               wp_config_defines: $extraWpConfigDefines,
               workload_run_before: $workloadRunBefore,
               workload_run_after: $workloadRunAfter,
-              required_abilities: (((if $executeWorkflowPath != "" then ["datamachine/execute-workflow", "datamachine/drain-job"] else ["datamachine/import-agent", "datamachine/run-flow", "datamachine/drain-job"] end) + $extraRequiredAbilities) | reduce .[] as $ability ([]; if index($ability) then . else . + [$ability] end)),
+              required_abilities: (((if $executeWorkflowPath != "" then ["datamachine/import-agent", "datamachine/execute-workflow", "datamachine/drain-job"] else ["datamachine/import-agent", "datamachine/run-flow", "datamachine/drain-job"] end) + $extraRequiredAbilities) | reduce .[] as $ability ([]; if index($ability) then . else . + [$ability] end)),
               bundle_path: $bundlePath,
               bundle_repo: $bundleRepo,
               bundle_ref: $bundleRef,

--- a/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
@@ -113,9 +113,26 @@ namespace {
         )
     );
 
-    require __DIR__ . '/datamachine-agent-workload.php';
+	require __DIR__ . '/datamachine-agent-workload.php';
 
-    $jobs = new \DataMachine\Core\Database\Jobs\Jobs();
+	$workload_source = file_get_contents( __DIR__ . '/datamachine-agent-workload.php' ) ?: '';
+	$import_position = strpos( $workload_source, "wp_get_ability( 'datamachine/import-agent' )" );
+	$execute_position = strpos( $workload_source, "wp_get_ability( 'datamachine/execute-workflow' )" );
+	if ( false === $import_position || false === $execute_position || $import_position > $execute_position ) {
+		fwrite( STDERR, "Expected execute-workflow mode to import the agent bundle before running the raw workflow.\n" );
+		exit( 1 );
+	}
+	if ( ! str_contains( $workload_source, "array( 'datamachine/import-agent', 'datamachine/execute-workflow', 'datamachine/drain-job' )" ) ) {
+		fwrite( STDERR, "Expected execute-workflow mode to require import-agent, execute-workflow, and drain-job.\n" );
+		exit( 1 );
+	}
+	$workflow_source = file_get_contents( dirname( __DIR__, 3 ) . '/.github/workflows/datamachine-agent-ci.yml' ) ?: '';
+	if ( ! str_contains( $workflow_source, '["datamachine/import-agent", "datamachine/execute-workflow", "datamachine/drain-job"]' ) ) {
+		fwrite( STDERR, "Expected reusable workflow config to require import-agent for execute-workflow runs.\n" );
+		exit( 1 );
+	}
+
+	$jobs = new \DataMachine\Core\Database\Jobs\Jobs();
     $summary = homeboy_datamachine_agent_drain_child_jobs( 101, array(), $jobs );
     $calls = $GLOBALS['homeboy_child_drain_calls'] ?? array();
 

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1621,7 +1621,7 @@ if ( ! empty( $runner_workspace['enabled'] ) ) {
 
 $required_abilities = is_array( $config['required_abilities'] ?? null )
     ? $config['required_abilities']
-    : ( '' !== $execute_workflow_path ? array( 'datamachine/execute-workflow', 'datamachine/drain-job' ) : array( 'datamachine/import-agent', 'datamachine/run-flow', 'datamachine/drain-job' ) );
+    : ( '' !== $execute_workflow_path ? array( 'datamachine/import-agent', 'datamachine/execute-workflow', 'datamachine/drain-job' ) : array( 'datamachine/import-agent', 'datamachine/run-flow', 'datamachine/drain-job' ) );
 foreach ( $required_abilities as $ability_name ) {
     if ( ! is_string( $ability_name ) || ! wp_get_ability( $ability_name ) ) {
         return homeboy_datamachine_agent_result( array( 'required_abilities_resolved' => 0 ), $metadata, (string) $ability_name . ' not registered' );
@@ -1648,6 +1648,32 @@ $pipeline_slug = homeboy_datamachine_agent_scalar( $config, 'pipeline_slug' );
 $import_elapsed_ms = 0;
 
 if ( '' !== $execute_workflow_path ) {
+	$import_start = hrtime( true );
+	$import_result = wp_get_ability( 'datamachine/import-agent' )->execute(
+		array(
+			'source'      => $bundle_path,
+			'on_conflict' => homeboy_datamachine_agent_scalar( $config, 'on_conflict', 'skip' ),
+		)
+	);
+	$import_elapsed_ms = ( hrtime( true ) - $import_start ) / 1000000;
+	$metadata['import_result'] = $import_result;
+	if ( ! is_array( $import_result ) || empty( $import_result['success'] ) ) {
+		return homeboy_datamachine_agent_result( array( 'import_succeeded' => 0, 'import_elapsed_ms' => $import_elapsed_ms ), $metadata, 'datamachine/import-agent did not succeed' );
+	}
+
+	$agent = $agents->get_by_slug( $agent_slug );
+	if ( ! $agent ) {
+		return homeboy_datamachine_agent_result( array( 'agent_resolved' => 0 ), $metadata, 'Imported agent was not found' );
+	}
+
+	$agent_id = (int) $agent['agent_id'];
+	$agent_config = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
+	$agent_config['default_provider'] = $settings['default_provider'];
+	$agent_config['default_model']    = $settings['default_model'];
+	$agent_config['mode_models']      = $settings['mode_models'];
+	$agents->update_agent( $agent_id, array( 'agent_config' => $agent_config ) );
+	PluginSettings::clearCache();
+
     $workflow_payload_path = str_starts_with( $execute_workflow_path, '/' ) ? $execute_workflow_path : rtrim( homeboy_datamachine_agent_scalar( $config, 'component_path' ), '/' ) . '/' . ltrim( $execute_workflow_path, '/' );
     if ( ! is_file( $workflow_payload_path ) ) {
         return homeboy_datamachine_agent_result( array( 'execute_workflow_payload_exists' => 0 ), $metadata, 'execute_workflow_path does not exist: ' . $execute_workflow_path );
@@ -1662,6 +1688,7 @@ if ( '' !== $execute_workflow_path ) {
         $execute_input['initial_data'] = array();
     }
     $execute_input['initial_data']['agent_slug'] = $execute_input['initial_data']['agent_slug'] ?? $agent_slug;
+    $execute_input['initial_data']['agent_id'] = $execute_input['initial_data']['agent_id'] ?? $agent_id;
     $execute_input['initial_data']['job_source'] = $execute_input['initial_data']['job_source'] ?? 'system';
     $execute_input['initial_data']['job_label'] = $execute_input['initial_data']['job_label'] ?? 'Data Machine agent workflow';
 
@@ -1834,31 +1861,31 @@ if ( $success_requires_pr && ! $pr_opened && ! $completion_outcome_satisfied ) {
 }
 
 return homeboy_datamachine_agent_result(
-    array(
-        'config_present'              => 1,
-        'required_abilities_resolved' => 1,
-        'required_classes_available'  => 1,
-        'bundle_exists'               => 1,
-        'import_succeeded'            => '' !== $execute_workflow_path ? 0 : 1,
-        'execute_workflow_succeeded'  => '' !== $execute_workflow_path ? 1 : 0,
-        'import_elapsed_ms'           => $import_elapsed_ms,
-        'agent_resolved'              => '' !== $execute_workflow_path ? 0 : 1,
-        'runner_workspace_provisioned' => empty( $runner_workspace['enabled'] ) || ! empty( $runner_workspace['success'] ) ? 1 : 0,
-        'runner_workspace_captured'    => empty( $runner_workspace_capture['enabled'] ) || empty( $runner_workspace_capture['error'] ) ? 1 : 0,
-        'pipeline_resolved'           => '' !== $execute_workflow_path || '' === $pipeline_slug || $pipeline_id > 0 ? 1 : 0,
-        'flow_resolved'               => 1,
-        'run_flow_succeeded'          => 1,
-        'run_elapsed_ms'              => $run_elapsed_ms,
-        'drain_succeeded'             => is_array( $drain_result ) && ! empty( $drain_result['success'] ) ? 1 : 0,
-        'drain_elapsed_ms'            => $drain_elapsed_ms,
-        'job_completed'               => 'completed' === $job_status ? 1 : 0,
-        'file_written'                => $file_written ? 1 : 0,
-        'pr_opened'                   => $pr_opened ? 1 : 0,
-        'completion_outcome_satisfied' => $completion_outcome_satisfied ? 1 : 0,
-        'no_changes'                  => ! $file_written && ! $pr_opened && ! $completion_outcome_satisfied ? 1 : 0,
-        'job_artifact_exported'       => ! empty( $job_artifact_exports['pr_url'] ) ? 1 : 0,
-        'transcript_exported'         => ! empty( $transcript_artifacts['json'] ) ? 1 : 0,
-        'total_tokens'                => (int) ( $metadata['token_usage']['total_tokens'] ?? 0 ),
-    ),
-    $metadata
+	array(
+		'config_present'              => 1,
+		'required_abilities_resolved' => 1,
+		'required_classes_available'  => 1,
+		'bundle_exists'               => 1,
+		'import_succeeded'            => 1,
+		'execute_workflow_succeeded'  => '' !== $execute_workflow_path ? 1 : 0,
+		'import_elapsed_ms'           => $import_elapsed_ms,
+		'agent_resolved'              => 1,
+		'runner_workspace_provisioned' => empty( $runner_workspace['enabled'] ) || ! empty( $runner_workspace['success'] ) ? 1 : 0,
+		'runner_workspace_captured'    => empty( $runner_workspace_capture['enabled'] ) || empty( $runner_workspace_capture['error'] ) ? 1 : 0,
+		'pipeline_resolved'           => '' !== $execute_workflow_path || '' === $pipeline_slug || $pipeline_id > 0 ? 1 : 0,
+		'flow_resolved'               => 1,
+		'run_flow_succeeded'          => 1,
+		'run_elapsed_ms'              => $run_elapsed_ms,
+		'drain_succeeded'             => is_array( $drain_result ) && ! empty( $drain_result['success'] ) ? 1 : 0,
+		'drain_elapsed_ms'            => $drain_elapsed_ms,
+		'job_completed'               => 'completed' === $job_status ? 1 : 0,
+		'file_written'                => $file_written ? 1 : 0,
+		'pr_opened'                   => $pr_opened ? 1 : 0,
+		'completion_outcome_satisfied' => $completion_outcome_satisfied ? 1 : 0,
+		'no_changes'                  => ! $file_written && ! $pr_opened && ! $completion_outcome_satisfied ? 1 : 0,
+		'job_artifact_exported'       => ! empty( $job_artifact_exports['pr_url'] ) ? 1 : 0,
+		'transcript_exported'         => ! empty( $transcript_artifacts['json'] ) ? 1 : 0,
+		'total_tokens'                => (int) ( $metadata['token_usage']['total_tokens'] ?? 0 ),
+	),
+	$metadata
 );


### PR DESCRIPTION
## Summary
- Import and configure the agent bundle before running raw execute-workflow payloads.
- Include agent context in execute-workflow initial data so child jobs have the imported agent available.
- Cover the execute-workflow import contract in the child-drain smoke test.

## Testing
- php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
- php -l wordpress/scripts/agent/datamachine-agent-workload.php
- php -l wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
- homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-execute-workflow-child-results --extension wordpress

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner patch and smoke coverage; Chris remains responsible for review and merge.