### PR TITLE
Enrich Data Machine agent artifact pull requests

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -748,8 +748,8 @@ jobs:
                 include_job_artifacts: false,
                 branch_template: "agent-artifacts/{agent_slug}-{run_id}-{provider}-{model}-{job_id}",
                 commit_message_template: "chore: persist {type} artifact",
-                pr_title_template: "Persist agent run artifacts",
-                pr_body_template: "## Summary\n- Persist bundle-file run artifacts from Data Machine agent job {job_id}.\n\n## Artifacts\n{paths}\n"
+                pr_title_template: "[{agent_slug}] {task_id} - {model_label} - {result_label}",
+                pr_body_template: "## Result\n{result_table}\n\n## Checks\n{checks_table}\n\n## Tools\n{tools_table}\n\n## Review Artifacts\n{links_table}\n"
               } * $artifactExportConfig),
               dry_run: $dryRun,
               transcript_dir: $transcriptGuestDir,

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -323,6 +323,182 @@ if ( ! function_exists( 'homeboy_datamachine_agent_slug_fragment' ) ) {
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_markdown_cell' ) ) {
+    function homeboy_datamachine_agent_markdown_cell( $value ): string {
+        if ( is_bool( $value ) ) {
+            $value = $value ? 'yes' : 'no';
+        } elseif ( is_array( $value ) || is_object( $value ) ) {
+            $value = wp_json_encode( $value, JSON_UNESCAPED_SLASHES );
+        }
+
+        $value = trim( str_replace( array( "\r", "\n", '|' ), array( '', '<br>', '\\|' ), (string) $value ) );
+        return '' !== $value ? $value : '-';
+    }
+
+    function homeboy_datamachine_agent_markdown_table( array $headers, array $rows ): string {
+        if ( empty( $rows ) ) {
+            return '_None recorded._';
+        }
+
+        $header = '| ' . implode( ' | ', array_map( 'homeboy_datamachine_agent_markdown_cell', $headers ) ) . ' |';
+        $rule   = '| ' . implode( ' | ', array_fill( 0, count( $headers ), '---' ) ) . ' |';
+        $lines  = array( $header, $rule );
+        foreach ( $rows as $row ) {
+            $cells = array();
+            foreach ( array_keys( $headers ) as $index ) {
+                $cells[] = homeboy_datamachine_agent_markdown_cell( is_array( $row ) ? ( $row[ $index ] ?? '' ) : '' );
+            }
+            $lines[] = '| ' . implode( ' | ', $cells ) . ' |';
+        }
+
+        return implode( "\n", $lines );
+    }
+
+    function homeboy_datamachine_agent_source_value( array $sources, string $path ) {
+        $parts = array_filter( explode( '.', $path ), static fn( $part ) => '' !== $part );
+        if ( empty( $parts ) ) {
+            return null;
+        }
+        $source = array_shift( $parts );
+        $value  = $sources[ $source ] ?? null;
+        foreach ( $parts as $part ) {
+            if ( ! is_array( $value ) || ! array_key_exists( $part, $value ) ) {
+                return null;
+            }
+            $value = $value[ $part ];
+        }
+        return $value;
+    }
+
+    function homeboy_datamachine_agent_workflow_run_url(): string {
+        $repository = trim( (string) getenv( 'GITHUB_REPOSITORY' ) );
+        $run_id     = trim( (string) getenv( 'GITHUB_RUN_ID' ) );
+        if ( '' === $repository || '' === $run_id ) {
+            return '';
+        }
+        $server = trim( (string) getenv( 'GITHUB_SERVER_URL' ) );
+        if ( '' === $server ) {
+            $server = 'https://github.com';
+        }
+        return rtrim( $server, '/' ) . '/' . $repository . '/actions/runs/' . rawurlencode( $run_id );
+    }
+
+    function homeboy_datamachine_agent_artifact_pr_context( int $job_id, array $config, array $engine_data, array $artifact_result, array $written, array $run_context ): array {
+        $workflow_url      = homeboy_datamachine_agent_workflow_run_url();
+        $task_id           = homeboy_datamachine_agent_scalar( $config, 'task_id', homeboy_datamachine_agent_scalar( $config, 'workload_id', homeboy_datamachine_agent_scalar( $config, 'flow_slug', 'task' ) ) );
+        $task_label        = homeboy_datamachine_agent_scalar( $config, 'task_label', homeboy_datamachine_agent_scalar( $config, 'workload_label', $task_id ) );
+        $provider          = homeboy_datamachine_agent_scalar( $config, 'provider', 'provider' );
+        $model             = homeboy_datamachine_agent_scalar( $config, 'model', 'model' );
+        $agent_slug        = homeboy_datamachine_agent_scalar( $config, 'agent_slug', 'agent' );
+        $error_message     = (string) ( $run_context['error_message'] ?? $engine_data['error_message'] ?? '' );
+        $success_status    = (string) ( $run_context['success_status'] ?? '' );
+        $result_label      = '' !== $success_status ? $success_status : ( '' !== $error_message ? 'failed' : 'artifact' );
+        $runner_workspace  = is_array( $run_context['runner_workspace_capture']['status'] ?? null ) ? $run_context['runner_workspace_capture']['status'] : array();
+        $transcript        = is_array( $run_context['transcript_artifacts'] ?? null ) ? $run_context['transcript_artifacts'] : array();
+        $grade             = is_array( $run_context['grade'] ?? null ) ? $run_context['grade'] : ( is_array( $engine_data['grade'] ?? null ) ? $engine_data['grade'] : array() );
+
+        $result_rows = array(
+            array( 'Task', $task_label ),
+            array( 'Task ID', $task_id ),
+            array( 'Agent', $agent_slug ),
+            array( 'Model', $provider . ' / ' . $model ),
+            array( 'Job', $job_id ),
+            array( 'Result', $result_label ),
+        );
+        if ( '' !== $error_message ) {
+            $result_rows[] = array( 'Error', $error_message );
+        }
+
+        $check_rows = array();
+        foreach ( (array) ( $grade['checks'] ?? array() ) as $check ) {
+            if ( is_array( $check ) ) {
+                $check_rows[] = array(
+                    (string) ( $check['id'] ?? '' ),
+                    ! empty( $check['passed'] ),
+                    (string) ( $check['score'] ?? '' ),
+                    (string) ( $check['max_score'] ?? '' ),
+                    (string) ( $check['message'] ?? '' ),
+                );
+            }
+        }
+
+        $tool_rows = array();
+        foreach ( (array) ( $engine_data['tool_execution_summary'] ?? array() ) as $tool ) {
+            if ( is_array( $tool ) ) {
+                $tool_rows[] = array(
+                    (string) ( $tool['turn_count'] ?? '' ),
+                    (string) ( $tool['tool_name'] ?? '' ),
+                    ! empty( $tool['success'] ),
+                );
+            }
+        }
+
+        $link_rows = array();
+        if ( '' !== $workflow_url ) {
+            $link_rows[] = array( 'Workflow run', $workflow_url );
+        }
+        foreach ( array( 'json' => 'Transcript JSON', 'summary' => 'Transcript summary' ) as $key => $label ) {
+            if ( ! empty( $transcript[ $key ] ) && is_string( $transcript[ $key ] ) ) {
+                $link_rows[] = array( $label, '`' . $transcript[ $key ] . '`' );
+            }
+        }
+        foreach ( $written as $path ) {
+            $link_rows[] = array( 'Artifact', '`' . $path . '`' );
+        }
+
+        $values = array(
+            'task_id'           => $task_id,
+            'task_label'        => $task_label,
+            'agent_slug'        => $agent_slug,
+            'provider'          => $provider,
+            'model'             => $model,
+            'model_label'       => $provider . '/' . $model,
+            'job_id'            => $job_id,
+            'result_label'      => $result_label,
+            'error_message'     => $error_message,
+            'workflow_run_url'  => $workflow_url,
+            'workspace_branch'  => (string) ( $runner_workspace['branch'] ?? '' ),
+            'workspace_handle'  => (string) ( $runner_workspace['name'] ?? '' ),
+            'workspace_changed' => ! empty( $run_context['runner_workspace_capture']['changed'] ) ? 'yes' : 'no',
+            'result_table'      => homeboy_datamachine_agent_markdown_table( array( 'Field', 'Value' ), $result_rows ),
+            'checks_table'      => homeboy_datamachine_agent_markdown_table( array( 'Check', 'Passed', 'Score', 'Max', 'Message' ), $check_rows ),
+            'tools_table'       => homeboy_datamachine_agent_markdown_table( array( 'Turn', 'Tool', 'Success' ), $tool_rows ),
+            'links_table'       => homeboy_datamachine_agent_markdown_table( array( 'Artifact', 'Location' ), $link_rows ),
+            'paths'             => '- `' . implode( "`\n- `", $written ) . '`',
+        );
+
+        $export_config = is_array( $config['artifact_export'] ?? null ) ? $config['artifact_export'] : array();
+        foreach ( (array) ( $export_config['pr_template_values'] ?? array() ) as $key => $value ) {
+            if ( is_string( $key ) && '' !== $key && is_scalar( $value ) ) {
+                $values[ $key ] = (string) $value;
+            }
+        }
+
+        $sources = array(
+            'config'          => $config,
+            'engine_data'     => $engine_data,
+            'artifact_result' => $artifact_result,
+            'run'             => $run_context,
+            'env'             => array(
+                'GITHUB_RUN_ID'      => (string) getenv( 'GITHUB_RUN_ID' ),
+                'GITHUB_RUN_ATTEMPT' => (string) getenv( 'GITHUB_RUN_ATTEMPT' ),
+                'GITHUB_REPOSITORY'  => (string) getenv( 'GITHUB_REPOSITORY' ),
+            ),
+        );
+        foreach ( (array) ( $export_config['pr_template_paths'] ?? array() ) as $key => $path ) {
+            if ( ! is_string( $key ) || '' === $key || ! is_string( $path ) || '' === $path ) {
+                continue;
+            }
+            $value = homeboy_datamachine_agent_source_value( $sources, $path );
+            if ( is_scalar( $value ) ) {
+                $values[ $key ] = (string) $value;
+            }
+        }
+
+        return $values;
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_exportable_artifacts' ) ) {
     function homeboy_datamachine_agent_job_artifact_relative_path( int $job_id, array $config ): string {
         $flow_slug = homeboy_datamachine_agent_slug_fragment( homeboy_datamachine_agent_scalar( $config, 'flow_slug', 'run' ) );
@@ -404,7 +580,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_pr_head_branch' ) ) {
 }
 
 if ( ! function_exists( 'homeboy_datamachine_agent_export_job_artifacts' ) ) {
-    function homeboy_datamachine_agent_export_job_artifacts( int $job_id, array $config, bool $pr_opened, array $engine_data = array() ): array {
+    function homeboy_datamachine_agent_export_job_artifacts( int $job_id, array $config, bool $pr_opened, array $engine_data = array(), array $run_context = array() ): array {
         $export_config = is_array( $config['artifact_export'] ?? null ) ? $config['artifact_export'] : array();
         if ( $job_id <= 0 || empty( $export_config['enabled'] ) || ! class_exists( JobArtifacts::class ) || ! function_exists( 'wp_get_ability' ) ) {
             return array();
@@ -538,16 +714,14 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_job_artifacts' ) ) {
             return array( 'error' => 'Artifact export requires artifact_export.pr_title_template and artifact_export.pr_body_template.' );
         }
 
-        $pr_values        = array_merge(
+        $pr_values = array_merge(
             $template_values,
-            array(
-                'paths' => '- `' . implode( "`\n- `", $written ) . '`',
-            )
+            homeboy_datamachine_agent_artifact_pr_context( $job_id, $config, $engine_data, $artifact_result, $written, $run_context )
         );
         $pr_result = $pr_ability->execute(
             array(
                 'repo'  => $target_repo,
-                'title' => homeboy_datamachine_agent_template( $pr_title_template, $template_values ),
+                'title' => homeboy_datamachine_agent_template( $pr_title_template, $pr_values ),
                 'head'  => $branch,
                 'body'  => homeboy_datamachine_agent_template( $pr_body_template, $pr_values ),
             )
@@ -1786,7 +1960,15 @@ if ( $file_written && ! $pr_opened && empty( $runner_workspace_capture['changed'
 }
 $completion_outcome_satisfied = homeboy_datamachine_agent_completion_outcome_satisfied( $engine_data, $config );
 $success_status = $pr_opened ? 'pr_opened' : ( $completion_outcome_satisfied ? 'completion_outcome_satisfied' : 'no_changes' );
-$job_artifact_exports = homeboy_datamachine_agent_export_job_artifacts( $job_id, $config, $pr_opened, $engine_data );
+$artifact_pr_context = array(
+    'success_status'           => $success_status,
+    'success_requires_pr'      => $success_requires_pr,
+    'transcript_artifacts'     => $transcript_artifacts,
+    'runner_workspace_capture' => $runner_workspace_capture,
+    'fallback_pull_request'    => $fallback_pull_request,
+    'error_message'            => (string) ( $engine_data['error_message'] ?? '' ),
+);
+$job_artifact_exports = homeboy_datamachine_agent_export_job_artifacts( $job_id, $config, $pr_opened, $engine_data, $artifact_pr_context );
 
 $metadata += array(
     'agent_id'             => $agent_id,

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -378,6 +378,8 @@ namespace {
     }
 
     $artifact_export_calls = array();
+    putenv( 'GITHUB_REPOSITORY=owner/repo' );
+    putenv( 'GITHUB_RUN_ID=123456' );
     $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
         'datamachine/create-or-update-github-file' => new Homeboy_Datamachine_Agent_Fake_Ability(
             function ( array $input ) use ( &$artifact_export_calls ): array {
@@ -399,19 +401,41 @@ namespace {
         42,
         array(
             'target_repo'     => 'owner/repo',
+            'task_id'         => 'example-task',
+            'task_label'      => 'Example task',
+            'provider'        => 'openai',
+            'model'           => 'gpt-smoke',
+            'agent_slug'      => 'review-agent',
             'flow_slug'       => 'review-flow',
             'artifact_export' => array(
                 'enabled'                 => true,
                 'repo'                    => 'owner/repo',
                 'path_prefix'             => 'bundles/task-runner',
+                'include_job_artifacts'    => true,
                 'branch_template'         => 'agent-artifacts/{agent_slug}-{run_id}-{job_id}',
                 'commit_message_template' => 'chore: persist {type} artifact',
-                'pr_title_template'       => 'Persist agent run artifacts',
-                'pr_body_template'        => "## Artifacts\n{paths}\n",
+                'pr_title_template'       => '[{agent_slug}] {task_id} - {model_label} - {result_label}',
+                'pr_body_template'        => "## Result\n{result_table}\n\nStatus: {engine_status}\nCustom: {custom_label}\n\n## Checks\n{checks_table}\n\n## Tools\n{tools_table}\n\n## Review Artifacts\n{links_table}\n",
+                'pr_template_values'      => array( 'custom_label' => 'custom value' ),
+                'pr_template_paths'       => array( 'engine_status' => 'engine_data.status' ),
             ),
         ),
         false,
-        array()
+        array(
+            'status'                 => 'processing',
+            'tool_execution_summary' => array(
+                array( 'turn_count' => 1, 'tool_name' => 'workspace_read', 'success' => true ),
+            ),
+        ),
+        array(
+            'success_status'       => 'no_changes',
+            'transcript_artifacts' => array( 'json' => 'artifacts/transcript.json' ),
+            'grade'                => array(
+                'checks' => array(
+                    array( 'id' => 'example_check', 'passed' => false, 'score' => 0, 'max_score' => 1, 'message' => 'Needs work.' ),
+                ),
+            ),
+        )
     );
 
     if ( empty( $job_artifact_export['pr_url'] ) ) {
@@ -421,6 +445,17 @@ namespace {
     if ( 'bundles/task-runner/run-artifacts/review-flow/job-42/job-artifacts.json' !== ( $artifact_export_calls[0]['input']['file_path'] ?? null ) ) {
         fwrite( STDERR, "Expected Data Machine job artifact payload to be written as reviewable JSON.\n" );
         exit( 1 );
+    }
+    $artifact_pr_input = $artifact_export_calls[1]['input'] ?? array();
+    if ( '[review-agent] example-task - openai/gpt-smoke - no_changes' !== ( $artifact_pr_input['title'] ?? '' ) ) {
+        fwrite( STDERR, "Expected artifact PR title to include agent, task, model, and result.\n" );
+        exit( 1 );
+    }
+    foreach ( array( 'Example task', 'Status: processing', 'Custom: custom value', 'example_check', 'workspace_read', 'https://github.com/owner/repo/actions/runs/123456', 'artifacts/transcript.json' ) as $expected_pr_body_fragment ) {
+        if ( ! str_contains( (string) ( $artifact_pr_input['body'] ?? '' ), $expected_pr_body_fragment ) ) {
+            fwrite( STDERR, "Expected artifact PR body to include {$expected_pr_body_fragment}.\n" );
+            exit( 1 );
+        }
     }
 
     $merged_daily_memory = homeboy_datamachine_agent_merge_daily_memory_artifact(


### PR DESCRIPTION
## Summary
- Replace the generic runner-owned artifact PR defaults with task/model/result-focused titles and reviewable tables.
- Add data-driven artifact PR placeholders from config, engine data, run context, artifact results, and GitHub Actions environment values.
- Preserve consumer overrides through existing title/body templates plus new `pr_template_values` and `pr_template_paths` hooks.

## Testing
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php && php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner-owned PR rendering helpers, updated defaults, and expanded smoke coverage from Chris's direction.