### PR TITLE
fix(wordpress): consume generic audit detector contracts

### DIFF
--- a/wordpress/docs/audit-core-contract-gaps.md
+++ b/wordpress/docs/audit-core-contract-gaps.md
@@ -75,18 +75,20 @@ private static function json_encode( $data ) {
 }
 ```
 
-This is correct production code, not a dead branch. The extension therefore curates `known_symbols.header_versions` along a single principle:
+This is correct production code, not a dead branch. The extension uses `dead_guard_context_comment_patterns` for those call-site comments and curates `known_symbols.header_versions` along a single principle:
 
 - **Include** WordPress symbols that have no natural pure-PHP equivalent and whose presence implies "WordPress is loaded": REST classes (`WP_REST_Server`, `WP_REST_Request`, `WP_REST_Response`), block infrastructure (`WP_Block`, `WP_Block_Type_Registry`, `register_block_type`, `parse_blocks`, `has_blocks`), HTML processing (`WP_HTML_Tag_Processor`), abilities (`WP_Ability`), REST routing (`register_rest_route`), post-type metadata (`get_post_type_object`), environment classification (`wp_get_environment_type`), and the `REST_REQUEST` constant.
-- **Exclude** WordPress utility wrappers that are interchangeable with a pure-PHP standard-library call: JSON encoding (`wp_json_encode` ↔ `json_encode`), UUID generation (`wp_generate_uuid4` ↔ `random_bytes` + `bin2hex`), URL parsing (`wp_parse_url` ↔ `parse_url`), date/timezone helpers (`wp_date`, `wp_timezone`, `wp_timezone_string` ↔ `DateTimeImmutable`/`DateTimeZone`).
+- **Include** WordPress utility wrappers that are interchangeable with a pure-PHP standard-library call, but only exempt dual-context guard sites whose nearby comments identify the pure-PHP fallback path: JSON encoding (`wp_json_encode` ↔ `json_encode`), UUID generation (`wp_generate_uuid4` ↔ `random_bytes` + `bin2hex`), URL parsing (`wp_parse_url` ↔ `parse_url`), date/timezone helpers (`wp_date`, `wp_timezone`, `wp_timezone_string` ↔ `DateTimeImmutable`/`DateTimeZone`).
 
-Excluded symbols simply never enter the dead-guard known-symbol table, so a guard around `wp_json_encode` is treated like any unknown symbol — left alone. WP-only symbols still produce real `dead_guard` findings when guarded outside lifecycle/test contexts. Both behaviors are exercised by `tests/audit-detector-config-smoke.sh` against fixtures under `tests/fixtures/audit-dead-guard-fallback/` and `tests/fixtures/audit-dead-guard-wp-only/`.
+Comment-marked fallback guards are treated as contextual, while the same utility wrappers still produce real `dead_guard` findings when guarded in unambiguously WordPress-only code. WP-only symbols also continue to produce findings when guarded outside lifecycle/test contexts. These behaviors are exercised by `tests/audit-detector-config-smoke.sh` against fixtures under `tests/fixtures/audit-dead-guard-fallback/` and `tests/fixtures/audit-dead-guard-wp-only/`.
 
 This curation is generic: it expresses "what WordPress utility functions have natural pure-PHP fallbacks" without naming any consumer plugin's paths.
 
 ## Other Generic Core Hooks Still Missing
 
 ### Comment-Based Dead-Guard Contexts
+
+Status: implemented in the WordPress extension config via `dead_guard_context_comment_patterns`.
 
 Core `dead_guard` can exempt paths and known lifecycle callbacks, but not source comments near a guard. A more granular comment-context exemption would let the extension keep utility wrappers in `known_symbols` while letting individual call sites mark themselves as dual-context. Sketch:
 
@@ -103,11 +105,13 @@ Core `dead_guard` can exempt paths and known lifecycle callbacks, but not source
 }
 ```
 
-Expected core behavior: when a guard is on or near a matching comment block, treat it as contextual and do not emit `dead_guard` even if the guarded symbol is known in production runtime metadata. Until that lands, the curation principle above is the WordPress-extension-only resolution.
+Expected core behavior: when a guard is on or near a matching comment block, treat it as contextual and do not emit `dead_guard` even if the guarded symbol is known in production runtime metadata.
 
 ### Requested Detector Context Filters
 
-Core requested detectors currently support language, extension, and path filters. If the slug-literal detector needs to recover broader matching later, it needs generic match-context filters, for example:
+Status: implemented in the WordPress extension config via `exclude_match_context_patterns`.
+
+The slug-literal detector keeps its literal regex broad and uses generic match-context filters for contexts where WordPress conventions make a repeated literal acceptable:
 
 ```json
 {

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -444,6 +444,12 @@
           "rest_ensure_response"
         ]
       },
+      "dead_guard_context_comment_patterns": [
+        "(?i)pure-php smoke tests run without wordpress loaded",
+        "(?i)fallback when wordpress is not loaded",
+        "(?i)wordpress is not loaded",
+        "(?i)without wordpress loaded"
+      ],
       "known_symbols": {
         "header_versions": [
           {
@@ -451,10 +457,16 @@
             "version_header": "Requires at least:",
             "symbols": [
               { "name": "get_post_type_object", "kind": "function", "introduced": "3.0" },
+              { "name": "wp_json_encode", "kind": "function", "introduced": "4.1" },
               { "name": "register_rest_route", "kind": "function", "introduced": "4.4" },
+              { "name": "wp_parse_url", "kind": "function", "introduced": "4.4" },
+              { "name": "wp_generate_uuid4", "kind": "function", "introduced": "4.7" },
               { "name": "register_block_type", "kind": "function", "introduced": "5.0" },
               { "name": "has_blocks", "kind": "function", "introduced": "5.0" },
               { "name": "parse_blocks", "kind": "function", "introduced": "5.0" },
+              { "name": "wp_date", "kind": "function", "introduced": "5.3" },
+              { "name": "wp_timezone", "kind": "function", "introduced": "5.3" },
+              { "name": "wp_timezone_string", "kind": "function", "introduced": "5.3" },
               { "name": "wp_get_environment_type", "kind": "function", "introduced": "5.5" },
               { "name": "WP_REST_Server", "kind": "class", "introduced": "4.4" },
               { "name": "WP_REST_Request", "kind": "class", "introduced": "4.4" },
@@ -534,7 +546,14 @@
           "source_pattern": "(?ms)^[ \\t]*(?:final\\s+|abstract\\s+)?class\\s+(?P<class>[A-Za-z_][A-Za-z0-9_]*)\\b[^{}\\n]*\\{.*?\\b(?:(?:public|protected|private)\\s+)?const\\s+(?P<const>[A-Z][A-Z0-9_]*)\\s*=\\s*['\\\"](?P<value>[a-z][a-z0-9]*(?:[-_/:][a-z0-9]+)+)['\\\"]",
           "value_capture": "value",
           "label": "{class}::{const}",
-          "literal_pattern": "(?m)(?:[=!]==?\\s*['\\\"]{value}['\\\"]|['\\\"]{value}['\\\"]\\s*[=!]==?)",
+          "literal_pattern": "['\\\"]{value}['\\\"]",
+          "exclude_match_context_patterns": [
+            "['\\\"]{value}['\\\"]\\s*=>",
+            "\\bdo_action\\s*\\(\\s*['\\\"]{value}['\\\"]",
+            "\\bapply_filters\\s*\\(\\s*['\\\"]{value}['\\\"]",
+            "\\bdo_action_ref_array\\s*\\(\\s*['\\\"]{value}['\\\"]",
+            "\\bapply_filters_ref_array\\s*\\(\\s*['\\\"]{value}['\\\"]"
+          ],
           "description": "Raw slug literal `{value}` at line {line} duplicates constant {label}",
           "suggestion": "Use {label} instead of repeating the literal slug so the constant remains the source of truth."
         },


### PR DESCRIPTION
## Summary
- Move WordPress slug literal context exclusions into `exclude_match_context_patterns` while keeping the literal regex broad.
- Add WordPress-owned `dead_guard_context_comment_patterns` for dual-context pure-PHP fallback guards.
- Restore WordPress utility wrappers to known-symbol metadata so unmarked dead guards can be reported while comment-marked fallback guards stay contextual.

Depends on Extra-Chill/homeboy#2430 and Extra-Chill/homeboy#2431.

## Testing
- `jq empty wordpress/wordpress.json`
- `git diff --check`
- `homeboy audit --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-audit-contract-config --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the WordPress extension config update for the new generic Homeboy audit contracts and refreshed the contract-gap docs; Chris remains responsible for review and validation.