### PR TITLE
Support opaque runner workspace aliases

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -210,7 +210,7 @@ name: Data Machine Agent CI (reusable)
         type: string
         default: "[]"
       runner_workspace:
-        description: JSON object for runner-owned Data Machine Code workspace/worktree provisioning before the agent runs.
+        description: JSON object for runner-owned Data Machine Code workspace/worktree provisioning before the agent runs. Set agent_alias to expose an opaque project name instead of the real workspace handle.
         type: string
         default: "{}"
       fallback_pull_request:

--- a/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
@@ -38,6 +38,29 @@ namespace {
         function wp_set_current_user( int $user_id ): void {}
     }
 
+    $GLOBALS['homeboy_forced_parameters_filters'] = array();
+
+    if ( ! function_exists( 'add_filter' ) ) {
+        function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+            $GLOBALS['homeboy_forced_parameters_filters'][ $tag ][ $priority ][] = $callback;
+        }
+    }
+
+    if ( ! function_exists( 'apply_filters' ) ) {
+        function apply_filters( string $tag, $value ) {
+            if ( empty( $GLOBALS['homeboy_forced_parameters_filters'][ $tag ] ) ) {
+                return $value;
+            }
+            ksort( $GLOBALS['homeboy_forced_parameters_filters'][ $tag ] );
+            foreach ( $GLOBALS['homeboy_forced_parameters_filters'][ $tag ] as $callbacks ) {
+                foreach ( $callbacks as $callback ) {
+                    $value = $callback( $value );
+                }
+            }
+            return $value;
+        }
+    }
+
     if ( ! function_exists( 'wp_get_ability' ) ) {
         function wp_get_ability( string $ability_name ): object {
             return new class {
@@ -168,6 +191,50 @@ namespace {
 
     if ( 'demo@hidden-run' !== ( $hidden_workspace_recorder['forced_parameters']['repo'] ?? null ) ) {
         fwrite( STDERR, "Expected hidden runner workspace mode to keep workspace tool scoping.\n" );
+        exit( 1 );
+    }
+
+    list( $alias_config, $alias_prompt ) = homeboy_datamachine_agent_apply_runner_workspace(
+        array(
+            'runner_workspace' => array(
+                'enabled'     => true,
+                'agent_alias' => 'current-project',
+            ),
+        ),
+        'Make the requested code changes.',
+        array(
+            'success' => true,
+            'handle'  => 'demo@agent-run-openai-gpt-5-5',
+            'branch'  => 'agent/run-openai-gpt-5-5',
+        )
+    );
+
+    if ( str_contains( $alias_prompt, 'demo@agent-run-openai-gpt-5-5' ) || str_contains( $alias_prompt, 'agent/run-openai-gpt-5-5' ) ) {
+        fwrite( STDERR, "Expected alias runner prompt to hide the real workspace handle and branch.\n" );
+        exit( 1 );
+    }
+
+    if ( ! str_contains( $alias_prompt, 'current-project' ) ) {
+        fwrite( STDERR, "Expected alias runner prompt to mention the opaque project alias.\n" );
+        exit( 1 );
+    }
+
+    $alias_workspace_recorder = null;
+    foreach ( $alias_config['tool_recorders'] ?? array() as $runner_recorder ) {
+        if ( is_array( $runner_recorder ) && 'workspace_git_status' === ( $runner_recorder['tool'] ?? '' ) ) {
+            $alias_workspace_recorder = $runner_recorder;
+            break;
+        }
+    }
+
+    if ( 'current-project' !== ( $alias_workspace_recorder['forced_parameters']['name'] ?? null ) ) {
+        fwrite( STDERR, "Expected alias runner workspace mode to scope git tools to the opaque alias.\n" );
+        exit( 1 );
+    }
+
+    $aliases = apply_filters( 'datamachine_code_workspace_aliases', array() );
+    if ( 'demo@agent-run-openai-gpt-5-5' !== ( $aliases['current-project'] ?? null ) ) {
+        fwrite( STDERR, "Expected alias runner workspace mode to register the opaque alias mapping.\n" );
         exit( 1 );
     }
 

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -904,6 +904,14 @@ if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_exposed' ) )
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_alias' ) ) {
+    function homeboy_datamachine_agent_runner_workspace_alias( array $config ): string {
+        $workspace = homeboy_datamachine_agent_runner_workspace_config( $config );
+        $alias     = isset( $workspace['agent_alias'] ) && is_scalar( $workspace['agent_alias'] ) ? trim( (string) $workspace['agent_alias'] ) : '';
+        return '' !== $alias ? $alias : '';
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_capture_enabled' ) ) {
     function homeboy_datamachine_agent_runner_workspace_capture_enabled( array $config ): bool {
         $workspace = homeboy_datamachine_agent_runner_workspace_config( $config );
@@ -1451,10 +1459,23 @@ if ( ! function_exists( 'homeboy_datamachine_agent_apply_runner_workspace' ) ) {
             return array( $config, $prompt );
         }
 
-        $handle = (string) $runner_workspace['handle'];
+        $handle       = (string) $runner_workspace['handle'];
+        $agent_alias  = homeboy_datamachine_agent_runner_workspace_alias( $config );
+        $agent_handle = '' !== $agent_alias ? $agent_alias : $handle;
+        if ( '' !== $agent_alias ) {
+            add_filter(
+                'datamachine_code_workspace_aliases',
+                static function ( array $aliases ) use ( $agent_alias, $handle ): array {
+                    $aliases[ $agent_alias ] = $handle;
+                    return $aliases;
+                }
+            );
+        }
+
         if ( homeboy_datamachine_agent_runner_workspace_exposed( $config ) ) {
-            $branch = (string) ( $runner_workspace['branch'] ?? '' );
-            $prefix = "Runner-provided workspace:\n- Workspace handle: {$handle}\n- Branch: {$branch}\n\nUse this workspace handle for all repository file and git changes. Do not mutate the primary checkout and do not create another worktree for this run.";
+            $prefix = '' !== $agent_alias
+                ? "Project workspace:\nUse `{$agent_alias}` for repository file and git changes when a workspace tool asks for a project or repository name."
+                : "Runner-provided workspace:\n- Workspace handle: {$handle}\n- Branch: " . (string) ( $runner_workspace['branch'] ?? '' ) . "\n\nUse this workspace handle for all repository file and git changes. Do not mutate the primary checkout and do not create another worktree for this run.";
             $prompt = '' === trim( $prompt ) ? $prefix : $prefix . "\n\n" . $prompt;
         }
 
@@ -1464,14 +1485,14 @@ if ( ! function_exists( 'homeboy_datamachine_agent_apply_runner_workspace' ) ) {
         foreach ( array( 'workspace_ls', 'workspace_read', 'workspace_grep', 'workspace_write', 'workspace_edit', 'workspace_apply_patch', 'workspace_delete' ) as $tool_name ) {
             $recorders[] = array(
                 'tool'              => $tool_name,
-                'forced_parameters' => array( 'repo' => $handle ),
+                'forced_parameters' => array( 'repo' => $agent_handle ),
                 'record'            => $record_config,
             );
         }
         foreach ( array( 'workspace_git_status', 'workspace_git_log', 'workspace_git_diff', 'workspace_git_pull', 'workspace_git_add', 'workspace_git_commit', 'workspace_git_push' ) as $tool_name ) {
             $recorders[] = array(
                 'tool'              => $tool_name,
-                'forced_parameters' => array( 'name' => $handle ),
+                'forced_parameters' => array( 'name' => $agent_handle ),
                 'record'            => $record_config,
             );
         }


### PR DESCRIPTION
## Summary
- Add opt-in `runner_workspace.agent_alias` support so runner-provisioned workspaces can be exposed to agents as generic project names.
- Register the DMC workspace alias filter and force workspace tools through the alias while keeping the real handle for runner capture/fallback behavior.
- Cover prompt hiding, forced alias scoping, and alias registration in the forced-parameters smoke.

## Testing
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `git diff --check origin/main...HEAD`

## Dependency
- Depends on Data Machine Code alias resolution from https://github.com/Extra-Chill/data-machine-code/pull/394 for model-facing tool result sanitization.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic runner alias plumbing, smoke coverage, and local verification; Chris reviewed the direction and requested the PR.

Fixes #604.