### PR TITLE
Support scoped runner workspace roots

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
@@ -199,6 +199,7 @@ namespace {
             'runner_workspace' => array(
                 'enabled'     => true,
                 'agent_alias' => 'current-project',
+                'agent_root'  => '.agent-workspace/current-project',
             ),
         ),
         'Make the requested code changes.',
@@ -233,8 +234,13 @@ namespace {
     }
 
     $aliases = apply_filters( 'datamachine_code_workspace_aliases', array() );
-    if ( 'demo@agent-run-openai-gpt-5-5' !== ( $aliases['current-project'] ?? null ) ) {
+    if ( 'demo@agent-run-openai-gpt-5-5' !== ( $aliases['current-project']['target'] ?? null ) ) {
         fwrite( STDERR, "Expected alias runner workspace mode to register the opaque alias mapping.\n" );
+        exit( 1 );
+    }
+
+    if ( '.agent-workspace/current-project' !== ( $aliases['current-project']['root'] ?? null ) ) {
+        fwrite( STDERR, "Expected alias runner workspace mode to register the scoped alias root.\n" );
         exit( 1 );
     }
 

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -912,6 +912,23 @@ if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_alias' ) ) {
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_root' ) ) {
+    function homeboy_datamachine_agent_runner_workspace_root( array $config ): string {
+        $workspace = homeboy_datamachine_agent_runner_workspace_config( $config );
+        $root      = isset( $workspace['agent_root'] ) && is_scalar( $workspace['agent_root'] ) ? trim( (string) $workspace['agent_root'] ) : '';
+        $root      = trim( str_replace( '\\', '/', $root ), '/' );
+        $parts     = array();
+        foreach ( explode( '/', $root ) as $part ) {
+            if ( '' === $part || '.' === $part || '..' === $part ) {
+                continue;
+            }
+            $parts[] = $part;
+        }
+
+        return implode( '/', $parts );
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_capture_enabled' ) ) {
     function homeboy_datamachine_agent_runner_workspace_capture_enabled( array $config ): bool {
         $workspace = homeboy_datamachine_agent_runner_workspace_config( $config );
@@ -1461,12 +1478,18 @@ if ( ! function_exists( 'homeboy_datamachine_agent_apply_runner_workspace' ) ) {
 
         $handle       = (string) $runner_workspace['handle'];
         $agent_alias  = homeboy_datamachine_agent_runner_workspace_alias( $config );
+        $agent_root   = homeboy_datamachine_agent_runner_workspace_root( $config );
         $agent_handle = '' !== $agent_alias ? $agent_alias : $handle;
         if ( '' !== $agent_alias ) {
             add_filter(
                 'datamachine_code_workspace_aliases',
-                static function ( array $aliases ) use ( $agent_alias, $handle ): array {
-                    $aliases[ $agent_alias ] = $handle;
+                static function ( array $aliases ) use ( $agent_alias, $handle, $agent_root ): array {
+                    $aliases[ $agent_alias ] = '' !== $agent_root
+                        ? array(
+                            'target' => $handle,
+                            'root'   => $agent_root,
+                        )
+                        : $handle;
                     return $aliases;
                 }
             );


### PR DESCRIPTION
## Summary
- Add `runner_workspace.agent_root` so runner-provisioned workspaces can expose an alias rooted at a neutral project subdirectory.
- Register DMC alias specs as `{ target, root }` when an agent alias and root are configured.
- Update forced-parameter smoke coverage for scoped alias registration.

## Depends on
- Extra-Chill/data-machine-code#398 for scoped workspace alias enforcement.

## Tests
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted runner workspace root wiring and smoke coverage; Chris remains responsible for review and validation.