### PR TITLE
Refactor WordPress shared profiler defaults

### DIFF
--- a/wordpress/lib/admin-page-scenarios.js
+++ b/wordpress/lib/admin-page-scenarios.js
@@ -4,14 +4,10 @@
  * Internal dependencies
  */
 const { profileWordPressPages } = require('./page-profiler');
-
-const WORDPRESS_ADMIN_RESOURCE_INCLUDE = [
-	'/wp-json/',
-	'?rest_route=',
-	'/wp-admin/',
-	'/wp-content/',
-	'/wp-includes/',
-];
+const {
+	WORDPRESS_RESOURCE_INCLUDE,
+	assertPlainObject,
+} = require('./shared');
 
 const WORDPRESS_ADMIN_RESOURCE_EXCLUDE = [
 	'/wp-admin/admin-ajax.php?action=heartbeat',
@@ -29,7 +25,7 @@ const WORDPRESS_ADMIN_REST_GATE = {
 };
 
 const DEFAULT_SCENARIO_RESOURCES = {
-	includeResourceSubstrings: WORDPRESS_ADMIN_RESOURCE_INCLUDE,
+	includeResourceSubstrings: WORDPRESS_RESOURCE_INCLUDE,
 	excludeResourceSubstrings: WORDPRESS_ADMIN_RESOURCE_EXCLUDE,
 };
 
@@ -146,12 +142,6 @@ function clone(value) {
 	return JSON.parse(JSON.stringify(value));
 }
 
-function assertPlainObject(value, name) {
-	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-		throw new TypeError(`${name} must be an object`);
-	}
-}
-
 function replaceParams(value, params, missing) {
 	if (typeof value === 'string') {
 		return value.replace(/\{([A-Za-z0-9_:-]+)\}/g, (match, key) => {
@@ -253,7 +243,7 @@ module.exports = {
 	WORDPRESS_ADMIN_PAGE_SCENARIO_IDS,
 	WORDPRESS_ADMIN_PAGE_SCENARIOS,
 	WORDPRESS_ADMIN_RESOURCE_EXCLUDE,
-	WORDPRESS_ADMIN_RESOURCE_INCLUDE,
+	WORDPRESS_RESOURCE_INCLUDE,
 	WORDPRESS_ADMIN_REST_GATE,
 	createWordPressAdminPageScenarioManifest,
 	getWordPressAdminPageScenario,

--- a/wordpress/lib/fixture-setup.js
+++ b/wordpress/lib/fixture-setup.js
@@ -1,12 +1,16 @@
 'use strict';
 
+/**
+ * External dependencies
+ */
 const fs = require('node:fs');
 const path = require('node:path');
 const { spawn } = require('node:child_process');
 
-function isPlainObject(value) {
-	return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
+/**
+ * Internal dependencies
+ */
+const { isPlainObject } = require('./shared');
 
 function normalizeFixtureList(fixtures) {
 	if (fixtures === undefined || fixtures === null) {

--- a/wordpress/lib/page-profiler.js
+++ b/wordpress/lib/page-profiler.js
@@ -5,14 +5,11 @@
  */
 const { correlateBrowserAndWordPressTimings, normalizeUrl } = require('./timing-correlator');
 const { runWordPressFixtureSetup } = require('./fixture-setup');
-
-const DEFAULT_RESOURCE_INCLUDE = [
-	'/wp-json/',
-	'?rest_route=',
-	'/wp-admin/',
-	'/wp-content/',
-	'/wp-includes/',
-];
+const {
+	WORDPRESS_RESOURCE_INCLUDE,
+	isPlainObject,
+	sleep,
+} = require('./shared');
 
 const DEFAULT_DIAGNOSIS_THRESHOLDS = {
 	readyMs: 1000,
@@ -35,10 +32,6 @@ const DEFAULT_GATE_THRESHOLDS = {
 
 function round(value) {
 	return typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : 0;
-}
-
-function isPlainObject(value) {
-	return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function normalizeBaseUrl(baseUrl) {
@@ -103,7 +96,7 @@ function normalizePageManifest(manifest) {
 function shouldIncludeResource(url, options = {}) {
 	const include = Array.isArray(options.includeResourceSubstrings)
 		? options.includeResourceSubstrings
-		: DEFAULT_RESOURCE_INCLUDE;
+		: WORDPRESS_RESOURCE_INCLUDE;
 	const exclude = Array.isArray(options.excludeResourceSubstrings)
 		? options.excludeResourceSubstrings
 		: [];
@@ -155,10 +148,6 @@ function resourceFamily(url) {
 
 function browserMetricName(name) {
 	return String(name).trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '') || 'mark';
-}
-
-function sleep(ms) {
-	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function normalizeRestUrl(url) {
@@ -2485,8 +2474,8 @@ async function profileWordPressPages(input) {
 }
 
 module.exports = {
-	DEFAULT_RESOURCE_INCLUDE,
 	DEFAULT_REST_OBSERVATION_MS,
+	WORDPRESS_RESOURCE_INCLUDE,
 	classifyResourceUrl,
 	classifyWordPressRestPreloadOpportunities,
 	compareWordPressRestNetworkWaterfalls,

--- a/wordpress/lib/playground-readiness.js
+++ b/wordpress/lib/playground-readiness.js
@@ -1,8 +1,16 @@
 'use strict';
 
+/**
+ * External dependencies
+ */
 const http = require('node:http');
 const https = require('node:https');
 const net = require('node:net');
+
+/**
+ * Internal dependencies
+ */
+const { sleep } = require('./shared');
 
 const DEFAULT_READINESS_PATH = '/wp-json/';
 const DEFAULT_DIAGNOSTIC_PATHS = ['/', '/wp-login.php', '/wp-json/', '/wp-admin/'];
@@ -162,10 +170,6 @@ async function emit(onEvent, source, event, data) {
 	} catch (_) {
 		// trace bridge errors must not break readiness polling
 	}
-}
-
-function sleep(ms) {
-	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function processExited(child) {

--- a/wordpress/lib/shared.js
+++ b/wordpress/lib/shared.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const WORDPRESS_RESOURCE_INCLUDE = Object.freeze([
+	'/wp-json/',
+	'?rest_route=',
+	'/wp-admin/',
+	'/wp-content/',
+	'/wp-includes/',
+]);
+
+function isPlainObject(value) {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function assertPlainObject(value, name) {
+	if (!isPlainObject(value)) {
+		throw new TypeError(`${name} must be an object`);
+	}
+}
+
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+module.exports = {
+	WORDPRESS_RESOURCE_INCLUDE,
+	assertPlainObject,
+	isPlainObject,
+	sleep,
+};

--- a/wordpress/tests/admin-page-scenarios-smoke.js
+++ b/wordpress/tests/admin-page-scenarios-smoke.js
@@ -13,6 +13,7 @@ const assert = require('node:assert/strict');
 const {
 	WORDPRESS_ADMIN_PAGE_SCENARIO_IDS,
 	WORDPRESS_ADMIN_PAGE_SCENARIOS,
+	WORDPRESS_RESOURCE_INCLUDE,
 	createWordPressAdminPageScenarioManifest,
 	getWordPressAdminPageScenario,
 	listWordPressAdminPageScenarios,
@@ -20,6 +21,8 @@ const {
 	normalizePageManifest,
 	resolveWordPressAdminPageScenario,
 } = require('../index');
+
+assert.equal(Object.isFrozen(WORDPRESS_RESOURCE_INCLUDE), true);
 
 const expectedIds = [
 	'dashboard',


### PR DESCRIPTION
## Summary
- Add a small WordPress shared helper module for common profiler defaults and utility helpers.
- Replace duplicated resource include, plain-object, and sleep helpers with the shared source of truth.
- Export one immutable `WORDPRESS_RESOURCE_INCLUDE` constant instead of separate page/admin resource defaults.

## Testing
- `npm run test:page-profiler`
- `npm run test:playground-readiness`
- `npm run test:request-profiler`
- `npm run test:timing-correlator`
- `node tests/admin-page-scenarios-smoke.js`
- `git diff --check origin/main...HEAD`
- `npx eslint lib/shared.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the small WordPress refactor; Chris reviewed direction and requested iterative cleanup passes.