### PR TITLE
Template runner workspace fallback PRs

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -963,7 +963,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_execute_workspace_ability' ) 
 }
 
 if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_fallback_config' ) ) {
-    function homeboy_datamachine_agent_runner_workspace_fallback_config( array $config, array $runner_workspace, array $engine_data = array(), int $job_id = 0 ): array {
+    function homeboy_datamachine_agent_runner_workspace_fallback_config( array $config, array $runner_workspace, array $template_values = array() ): array {
         $fallback = is_array( $config['fallback_pull_request'] ?? null ) ? $config['fallback_pull_request'] : array();
         $repo     = homeboy_datamachine_agent_scalar( $fallback, 'repo', homeboy_datamachine_agent_scalar( $config, 'target_repo' ) );
         $branch   = (string) ( $runner_workspace['branch'] ?? '' );
@@ -975,37 +975,11 @@ if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_fallback_con
             $fallback['repo'] = $repo;
         }
         $export_config = is_array( $config['artifact_export'] ?? null ) ? $config['artifact_export'] : array();
-        if ( '' === homeboy_datamachine_agent_scalar( $fallback, 'title' ) && '' !== (string) ( $export_config['pr_title_template'] ?? '' ) ) {
-            $fallback['title'] = homeboy_datamachine_agent_template(
-                (string) $export_config['pr_title_template'],
-                homeboy_datamachine_agent_artifact_pr_context(
-                    $job_id,
-                    $config,
-                    $engine_data,
-                    array(),
-                    array(),
-                    array(
-                        'success_status'           => 'pr_opened',
-                        'runner_workspace_capture' => array( 'status' => $runner_workspace ),
-                    )
-                )
-            );
+        if ( ! empty( $template_values ) && '' === homeboy_datamachine_agent_scalar( $fallback, 'title' ) && '' !== (string) ( $export_config['pr_title_template'] ?? '' ) ) {
+            $fallback['title'] = homeboy_datamachine_agent_template( (string) $export_config['pr_title_template'], $template_values );
         }
-        if ( '' === homeboy_datamachine_agent_scalar( $fallback, 'body' ) && '' !== (string) ( $export_config['pr_body_template'] ?? '' ) ) {
-            $fallback['body'] = homeboy_datamachine_agent_template(
-                (string) $export_config['pr_body_template'],
-                homeboy_datamachine_agent_artifact_pr_context(
-                    $job_id,
-                    $config,
-                    $engine_data,
-                    array(),
-                    array(),
-                    array(
-                        'success_status'           => 'pr_opened',
-                        'runner_workspace_capture' => array( 'status' => $runner_workspace ),
-                    )
-                )
-            );
+        if ( ! empty( $template_values ) && '' === homeboy_datamachine_agent_scalar( $fallback, 'body' ) && '' !== (string) ( $export_config['pr_body_template'] ?? '' ) ) {
+            $fallback['body'] = homeboy_datamachine_agent_template( (string) $export_config['pr_body_template'], $template_values );
         }
         if ( '' === homeboy_datamachine_agent_scalar( $fallback, 'title' ) ) {
             $fallback['title'] = 'Persist Data Machine agent workspace changes';
@@ -1016,7 +990,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_fallback_con
 }
 
 if ( ! function_exists( 'homeboy_datamachine_agent_capture_runner_workspace' ) ) {
-    function homeboy_datamachine_agent_capture_runner_workspace( array $engine_data, array $config, int $job_id = 0 ): array {
+    function homeboy_datamachine_agent_capture_runner_workspace( array $engine_data, array $config ): array {
         if ( ! homeboy_datamachine_agent_runner_workspace_capture_enabled( $config ) ) {
             return array( 'enabled' => false, 'changed' => false, 'engine_data' => $engine_data );
         }
@@ -1031,6 +1005,8 @@ if ( ! function_exists( 'homeboy_datamachine_agent_capture_runner_workspace' ) )
         if ( empty( $status['success'] ) ) {
             return array( 'enabled' => true, 'changed' => false, 'engine_data' => $engine_data, 'status' => $status, 'error' => (string) ( $status['error'] ?? 'Workspace status failed.' ) );
         }
+        $status['branch'] = (string) ( $runner_workspace['branch'] ?? '' );
+        $status['handle'] = $handle;
 
         $files = is_array( $status['files'] ?? null ) ? array_values( array_filter( $status['files'], 'is_string' ) ) : array();
         if ( (int) ( $status['dirty'] ?? 0 ) <= 0 && empty( $files ) ) {
@@ -1059,13 +1035,6 @@ if ( ! function_exists( 'homeboy_datamachine_agent_capture_runner_workspace' ) )
             return array( 'enabled' => true, 'changed' => true, 'engine_data' => $engine_data, 'status' => $status, 'diff' => $diff, 'add' => $add, 'commit' => $commit, 'push' => $push, 'error' => (string) ( $push['error'] ?? 'Workspace git push failed.' ) );
         }
 
-        $capture_config                          = $config;
-        $capture_config['fallback_pull_request'] = homeboy_datamachine_agent_runner_workspace_fallback_config( $config, $runner_workspace, $engine_data, $job_id );
-        $fallback_pull_request                   = homeboy_datamachine_agent_open_fallback_pr( $engine_data, $capture_config );
-        if ( ! empty( $fallback_pull_request['engine_data'] ) && is_array( $fallback_pull_request['engine_data'] ) ) {
-            $engine_data = $fallback_pull_request['engine_data'];
-        }
-
         return array(
             'enabled'               => true,
             'changed'               => true,
@@ -1075,8 +1044,14 @@ if ( ! function_exists( 'homeboy_datamachine_agent_capture_runner_workspace' ) )
             'add'                   => $add,
             'commit'                => $commit,
             'push'                  => $push,
-            'fallback_pull_request' => $fallback_pull_request,
         );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_written_paths' ) ) {
+    function homeboy_datamachine_agent_runner_workspace_written_paths( array $runner_workspace_capture ): array {
+        $status = is_array( $runner_workspace_capture['status'] ?? null ) ? $runner_workspace_capture['status'] : array();
+        return is_array( $status['files'] ?? null ) ? array_values( array_filter( $status['files'], 'is_string' ) ) : array();
     }
 }
 
@@ -2045,7 +2020,7 @@ $job_status = is_array( $job ) ? (string) ( $job['status'] ?? '' ) : '';
 $engine_data = function_exists( 'datamachine_get_engine_data' ) ? datamachine_get_engine_data( $job_id ) : array();
 $engine_data = homeboy_datamachine_agent_merge_recorded_tool_results( $engine_data, $config );
 $engine_data = homeboy_datamachine_agent_merge_child_engine_data( $engine_data, $child_drain_summary['children'], $config );
-$runner_workspace_capture = homeboy_datamachine_agent_capture_runner_workspace( $engine_data, $config, $job_id );
+$runner_workspace_capture = homeboy_datamachine_agent_capture_runner_workspace( $engine_data, $config );
 if ( is_array( $runner_workspace_capture['engine_data'] ?? null ) ) {
     $engine_data = $runner_workspace_capture['engine_data'];
 }
@@ -2053,7 +2028,7 @@ $transcript_dir = homeboy_datamachine_agent_scalar( $config, 'transcript_dir' );
 $transcript_artifacts = homeboy_datamachine_agent_export_transcript( $job_id, $engine_data, $transcript_dir );
 $pr_opened = homeboy_datamachine_agent_pr_opened( $engine_data, $config );
 $file_written = homeboy_datamachine_agent_file_written( $engine_data, $config ) || ! empty( $runner_workspace_capture['changed'] );
-$fallback_pull_request = is_array( $runner_workspace_capture['fallback_pull_request'] ?? null ) ? $runner_workspace_capture['fallback_pull_request'] : array( 'opened' => false );
+$fallback_pull_request = array( 'opened' => false );
 $success_requires_pr = ! empty( $config['success_requires_pr'] );
 if ( $file_written && ! $pr_opened && empty( $runner_workspace_capture['changed'] ) ) {
     $fallback_pull_request = homeboy_datamachine_agent_open_fallback_pr( $engine_data, $config );
@@ -2072,6 +2047,25 @@ $artifact_pr_context = array(
     'fallback_pull_request'    => $fallback_pull_request,
     'error_message'            => (string) ( $engine_data['error_message'] ?? '' ),
 );
+if ( ! empty( $runner_workspace_capture['changed'] ) && ! $pr_opened ) {
+    $runner_workspace = is_array( $config['runner_workspace_result'] ?? null ) ? $config['runner_workspace_result'] : array();
+    $template_values  = homeboy_datamachine_agent_artifact_pr_context(
+        $job_id,
+        $config,
+        $engine_data,
+        array(),
+        homeboy_datamachine_agent_runner_workspace_written_paths( $runner_workspace_capture ),
+        $artifact_pr_context
+    );
+    $capture_config                          = $config;
+    $capture_config['fallback_pull_request'] = homeboy_datamachine_agent_runner_workspace_fallback_config( $config, $runner_workspace, $template_values );
+    $fallback_pull_request                   = homeboy_datamachine_agent_open_fallback_pr( $engine_data, $capture_config );
+    if ( ! empty( $fallback_pull_request['opened'] ) && is_array( $fallback_pull_request['engine_data'] ?? null ) ) {
+        $engine_data = $fallback_pull_request['engine_data'];
+        $pr_opened   = true;
+    }
+    $artifact_pr_context['fallback_pull_request'] = $fallback_pull_request;
+}
 $job_artifact_exports = homeboy_datamachine_agent_export_job_artifacts( $job_id, $config, $pr_opened, $engine_data, $artifact_pr_context );
 
 $metadata += array(

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -458,7 +458,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_markdown_cell' ) ) {
             'error_message'     => $error_message,
             'workflow_run_url'  => $workflow_url,
             'workspace_branch'  => (string) ( $runner_workspace['branch'] ?? '' ),
-            'workspace_handle'  => (string) ( $runner_workspace['name'] ?? '' ),
+            'workspace_handle'  => (string) ( $runner_workspace['handle'] ?? $runner_workspace['name'] ?? '' ),
             'workspace_changed' => ! empty( $run_context['runner_workspace_capture']['changed'] ) ? 'yes' : 'no',
             'result_table'      => homeboy_datamachine_agent_markdown_table( array( 'Field', 'Value' ), $result_rows ),
             'checks_table'      => homeboy_datamachine_agent_markdown_table( array( 'Check', 'Passed', 'Score', 'Max', 'Message' ), $check_rows ),
@@ -963,7 +963,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_execute_workspace_ability' ) 
 }
 
 if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_fallback_config' ) ) {
-    function homeboy_datamachine_agent_runner_workspace_fallback_config( array $config, array $runner_workspace ): array {
+    function homeboy_datamachine_agent_runner_workspace_fallback_config( array $config, array $runner_workspace, array $engine_data = array(), int $job_id = 0 ): array {
         $fallback = is_array( $config['fallback_pull_request'] ?? null ) ? $config['fallback_pull_request'] : array();
         $repo     = homeboy_datamachine_agent_scalar( $fallback, 'repo', homeboy_datamachine_agent_scalar( $config, 'target_repo' ) );
         $branch   = (string) ( $runner_workspace['branch'] ?? '' );
@@ -974,6 +974,39 @@ if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_fallback_con
         if ( '' === homeboy_datamachine_agent_scalar( $fallback, 'repo' ) && '' !== $repo ) {
             $fallback['repo'] = $repo;
         }
+        $export_config = is_array( $config['artifact_export'] ?? null ) ? $config['artifact_export'] : array();
+        if ( '' === homeboy_datamachine_agent_scalar( $fallback, 'title' ) && '' !== (string) ( $export_config['pr_title_template'] ?? '' ) ) {
+            $fallback['title'] = homeboy_datamachine_agent_template(
+                (string) $export_config['pr_title_template'],
+                homeboy_datamachine_agent_artifact_pr_context(
+                    $job_id,
+                    $config,
+                    $engine_data,
+                    array(),
+                    array(),
+                    array(
+                        'success_status'           => 'pr_opened',
+                        'runner_workspace_capture' => array( 'status' => $runner_workspace ),
+                    )
+                )
+            );
+        }
+        if ( '' === homeboy_datamachine_agent_scalar( $fallback, 'body' ) && '' !== (string) ( $export_config['pr_body_template'] ?? '' ) ) {
+            $fallback['body'] = homeboy_datamachine_agent_template(
+                (string) $export_config['pr_body_template'],
+                homeboy_datamachine_agent_artifact_pr_context(
+                    $job_id,
+                    $config,
+                    $engine_data,
+                    array(),
+                    array(),
+                    array(
+                        'success_status'           => 'pr_opened',
+                        'runner_workspace_capture' => array( 'status' => $runner_workspace ),
+                    )
+                )
+            );
+        }
         if ( '' === homeboy_datamachine_agent_scalar( $fallback, 'title' ) ) {
             $fallback['title'] = 'Persist Data Machine agent workspace changes';
         }
@@ -983,7 +1016,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_fallback_con
 }
 
 if ( ! function_exists( 'homeboy_datamachine_agent_capture_runner_workspace' ) ) {
-    function homeboy_datamachine_agent_capture_runner_workspace( array $engine_data, array $config ): array {
+    function homeboy_datamachine_agent_capture_runner_workspace( array $engine_data, array $config, int $job_id = 0 ): array {
         if ( ! homeboy_datamachine_agent_runner_workspace_capture_enabled( $config ) ) {
             return array( 'enabled' => false, 'changed' => false, 'engine_data' => $engine_data );
         }
@@ -1027,7 +1060,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_capture_runner_workspace' ) )
         }
 
         $capture_config                          = $config;
-        $capture_config['fallback_pull_request'] = homeboy_datamachine_agent_runner_workspace_fallback_config( $config, $runner_workspace );
+        $capture_config['fallback_pull_request'] = homeboy_datamachine_agent_runner_workspace_fallback_config( $config, $runner_workspace, $engine_data, $job_id );
         $fallback_pull_request                   = homeboy_datamachine_agent_open_fallback_pr( $engine_data, $capture_config );
         if ( ! empty( $fallback_pull_request['engine_data'] ) && is_array( $fallback_pull_request['engine_data'] ) ) {
             $engine_data = $fallback_pull_request['engine_data'];
@@ -2012,7 +2045,7 @@ $job_status = is_array( $job ) ? (string) ( $job['status'] ?? '' ) : '';
 $engine_data = function_exists( 'datamachine_get_engine_data' ) ? datamachine_get_engine_data( $job_id ) : array();
 $engine_data = homeboy_datamachine_agent_merge_recorded_tool_results( $engine_data, $config );
 $engine_data = homeboy_datamachine_agent_merge_child_engine_data( $engine_data, $child_drain_summary['children'], $config );
-$runner_workspace_capture = homeboy_datamachine_agent_capture_runner_workspace( $engine_data, $config );
+$runner_workspace_capture = homeboy_datamachine_agent_capture_runner_workspace( $engine_data, $config, $job_id );
 if ( is_array( $runner_workspace_capture['engine_data'] ?? null ) ) {
     $engine_data = $runner_workspace_capture['engine_data'];
 }

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -304,6 +304,7 @@ namespace {
     }
 
     $runner_capture_calls = array();
+    $fallback_pr_input    = array();
     $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
         'datamachine/workspace-git-status' => new Homeboy_Datamachine_Agent_Fake_Ability(
             function ( array $input ) use ( &$runner_capture_calls ): array {
@@ -347,48 +348,82 @@ namespace {
             }
         ),
     );
-    $runner_capture = homeboy_datamachine_agent_capture_runner_workspace(
-        array( 'status' => 'runner-workspace-status' ),
-        array(
-            'target_repo'              => 'owner/repo',
-            'task_id'                  => 'runner-task',
-            'task_label'               => 'Runner task',
-            'provider'                 => 'openai',
-            'model'                    => 'gpt-smoke',
-            'agent_slug'               => 'runner-agent',
-            'tool_results_key'         => 'github_tool_results',
-            'artifact_export'          => array(
-                'pr_title_template'  => '[{agent_slug}] {task_id} - {workspace_branch} - {result_label}',
-                'pr_body_template'   => "## Runner Workspace\nBranch: {workspace_branch}\nHandle: {workspace_handle}\nStatus: {engine_status}\nCustom: {custom_label}\n",
-                'pr_template_values' => array( 'custom_label' => 'custom fallback value' ),
-                'pr_template_paths'  => array( 'engine_status' => 'engine_data.status' ),
-            ),
-            'runner_workspace'         => array(
-                'enabled'         => true,
-                'expose_to_agent' => false,
-            ),
-            'runner_workspace_result'  => array(
-                'success' => true,
-                'handle'  => 'repo@hidden-run',
-                'branch'  => 'agent/hidden-run',
+    putenv( 'GITHUB_REPOSITORY=owner/repo' );
+    putenv( 'GITHUB_RUN_ID=123456' );
+    $runner_config = array(
+        'target_repo'              => 'owner/repo',
+        'task_id'                  => 'runner-task',
+        'task_label'               => 'Runner task',
+        'provider'                 => 'openai',
+        'model'                    => 'gpt-smoke',
+        'agent_slug'               => 'runner-agent',
+        'tool_results_key'         => 'github_tool_results',
+        'artifact_export'          => array(
+            'pr_title_template'  => '[{agent_slug}] {task_id} - {workspace_branch} - {result_label}',
+            'pr_body_template'   => "## Runner Workspace\nBranch: {workspace_branch}\nHandle: {workspace_handle}\nStatus: {engine_status}\nCustom: {custom_label}\n\n## Checks\n{checks_table}\n\n## Links\n{links_table}\n\n## Paths\n{paths}\n",
+            'pr_template_values' => array( 'custom_label' => 'custom fallback value' ),
+            'pr_template_paths'  => array( 'engine_status' => 'engine_data.status' ),
+        ),
+        'runner_workspace'         => array(
+            'enabled'         => true,
+            'expose_to_agent' => false,
+        ),
+        'runner_workspace_result'  => array(
+            'success' => true,
+            'handle'  => 'repo@hidden-run',
+            'branch'  => 'agent/hidden-run',
+        ),
+    );
+    $runner_engine_data = array(
+        'status' => 'runner-workspace-status',
+        'grade'  => array(
+            'checks' => array(
+                array( 'id' => 'runner_check', 'passed' => true, 'score' => 1, 'max_score' => 1, 'message' => 'Looks good.' ),
             ),
         ),
-        43
+    );
+    $runner_capture = homeboy_datamachine_agent_capture_runner_workspace(
+        $runner_engine_data,
+        $runner_config
     );
 
-    if ( empty( $runner_capture['changed'] ) || empty( $runner_capture['fallback_pull_request']['opened'] ) ) {
-        fwrite( STDERR, "Expected hidden runner workspace capture to commit, push, and open a fallback PR.\n" );
+    if ( ! empty( $fallback_pr_input ) ) {
+        fwrite( STDERR, "Did not expect runner workspace capture to open the fallback PR before artifact context is assembled.\n" );
+        exit( 1 );
+    }
+    $runner_template_values = homeboy_datamachine_agent_artifact_pr_context(
+        43,
+        $runner_config,
+        $runner_engine_data,
+        array(),
+        homeboy_datamachine_agent_runner_workspace_written_paths( $runner_capture ),
+        array(
+            'success_status'           => 'completion_outcome_satisfied',
+            'transcript_artifacts'     => array( 'json' => 'artifacts/runner-transcript.json' ),
+            'runner_workspace_capture' => $runner_capture,
+        )
+    );
+    $runner_capture_config = $runner_config;
+    $runner_capture_config['fallback_pull_request'] = homeboy_datamachine_agent_runner_workspace_fallback_config(
+        $runner_config,
+        $runner_config['runner_workspace_result'],
+        $runner_template_values
+    );
+    $runner_fallback = homeboy_datamachine_agent_open_fallback_pr( $runner_engine_data, $runner_capture_config );
+
+    if ( empty( $runner_capture['changed'] ) || empty( $runner_fallback['opened'] ) ) {
+        fwrite( STDERR, "Expected hidden runner workspace capture to commit, push, and open a fallback PR after context assembly.\n" );
         exit( 1 );
     }
     if ( 'agent/hidden-run' !== ( $fallback_pr_input['head'] ?? null ) || 'owner/repo' !== ( $fallback_pr_input['repo'] ?? null ) ) {
         fwrite( STDERR, "Expected runner workspace capture fallback PR to use the captured branch.\n" );
         exit( 1 );
     }
-    if ( '[runner-agent] runner-task - agent/hidden-run - pr_opened' !== ( $fallback_pr_input['title'] ?? '' ) ) {
-        fwrite( STDERR, "Expected runner workspace fallback PR to use the artifact PR title template.\n" );
+    if ( '[runner-agent] runner-task - agent/hidden-run - completion_outcome_satisfied' !== ( $fallback_pr_input['title'] ?? '' ) ) {
+        fwrite( STDERR, "Expected runner workspace fallback PR to use the final artifact PR title context.\n" );
         exit( 1 );
     }
-    foreach ( array( 'Branch: agent/hidden-run', 'Handle: repo@hidden-run', 'Status: runner-workspace-status', 'Custom: custom fallback value' ) as $expected_fallback_body_fragment ) {
+    foreach ( array( 'Branch: agent/hidden-run', 'Handle: repo@hidden-run', 'Status: runner-workspace-status', 'Custom: custom fallback value', 'runner_check', 'https://github.com/owner/repo/actions/runs/123456', 'artifacts/runner-transcript.json', 'docs/generated.md' ) as $expected_fallback_body_fragment ) {
         if ( ! str_contains( (string) ( $fallback_pr_input['body'] ?? '' ), $expected_fallback_body_fragment ) ) {
             fwrite( STDERR, "Expected runner workspace fallback PR body to include {$expected_fallback_body_fragment}.\n" );
             exit( 1 );
@@ -400,31 +435,50 @@ namespace {
     }
 
     $fallback_pr_input = array();
+    $explicit_runner_config = array(
+        'target_repo'              => 'owner/repo',
+        'tool_results_key'         => 'github_tool_results',
+        'fallback_pull_request'    => array(
+            'title' => 'Explicit fallback title',
+            'body'  => 'Explicit fallback body',
+        ),
+        'artifact_export'          => array(
+            'pr_title_template' => 'Templated {task_id}',
+            'pr_body_template'  => 'Templated {workspace_branch}',
+        ),
+        'runner_workspace'         => array(
+            'enabled'         => true,
+            'expose_to_agent' => false,
+        ),
+        'runner_workspace_result'  => array(
+            'success' => true,
+            'handle'  => 'repo@explicit-run',
+            'branch'  => 'agent/explicit-run',
+        ),
+    );
     $explicit_runner_capture = homeboy_datamachine_agent_capture_runner_workspace(
         array(),
+        $explicit_runner_config
+    );
+    $explicit_runner_template_values = homeboy_datamachine_agent_artifact_pr_context(
+        43,
+        $explicit_runner_config,
+        array(),
+        array(),
+        array(),
         array(
-            'target_repo'              => 'owner/repo',
-            'tool_results_key'         => 'github_tool_results',
-            'fallback_pull_request'    => array(
-                'title' => 'Explicit fallback title',
-                'body'  => 'Explicit fallback body',
-            ),
-            'artifact_export'          => array(
-                'pr_title_template' => 'Templated {task_id}',
-                'pr_body_template'  => 'Templated {workspace_branch}',
-            ),
-            'runner_workspace'         => array(
-                'enabled'         => true,
-                'expose_to_agent' => false,
-            ),
-            'runner_workspace_result'  => array(
-                'success' => true,
-                'handle'  => 'repo@explicit-run',
-                'branch'  => 'agent/explicit-run',
-            ),
+            'success_status'           => 'no_changes',
+            'runner_workspace_capture' => $explicit_runner_capture,
         )
     );
-    if ( empty( $explicit_runner_capture['fallback_pull_request']['opened'] ) ) {
+    $explicit_runner_capture_config = $explicit_runner_config;
+    $explicit_runner_capture_config['fallback_pull_request'] = homeboy_datamachine_agent_runner_workspace_fallback_config(
+        $explicit_runner_config,
+        $explicit_runner_config['runner_workspace_result'],
+        $explicit_runner_template_values
+    );
+    $explicit_runner_fallback = homeboy_datamachine_agent_open_fallback_pr( array(), $explicit_runner_capture_config );
+    if ( empty( $explicit_runner_fallback['opened'] ) ) {
         fwrite( STDERR, "Expected explicit runner workspace fallback PR to open.\n" );
         exit( 1 );
     }
@@ -434,8 +488,6 @@ namespace {
     }
 
     $artifact_export_calls = array();
-    putenv( 'GITHUB_REPOSITORY=owner/repo' );
-    putenv( 'GITHUB_RUN_ID=123456' );
     $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
         'datamachine/create-or-update-github-file' => new Homeboy_Datamachine_Agent_Fake_Ability(
             function ( array $input ) use ( &$artifact_export_calls ): array {

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -348,10 +348,21 @@ namespace {
         ),
     );
     $runner_capture = homeboy_datamachine_agent_capture_runner_workspace(
-        array(),
+        array( 'status' => 'runner-workspace-status' ),
         array(
             'target_repo'              => 'owner/repo',
+            'task_id'                  => 'runner-task',
+            'task_label'               => 'Runner task',
+            'provider'                 => 'openai',
+            'model'                    => 'gpt-smoke',
+            'agent_slug'               => 'runner-agent',
             'tool_results_key'         => 'github_tool_results',
+            'artifact_export'          => array(
+                'pr_title_template'  => '[{agent_slug}] {task_id} - {workspace_branch} - {result_label}',
+                'pr_body_template'   => "## Runner Workspace\nBranch: {workspace_branch}\nHandle: {workspace_handle}\nStatus: {engine_status}\nCustom: {custom_label}\n",
+                'pr_template_values' => array( 'custom_label' => 'custom fallback value' ),
+                'pr_template_paths'  => array( 'engine_status' => 'engine_data.status' ),
+            ),
             'runner_workspace'         => array(
                 'enabled'         => true,
                 'expose_to_agent' => false,
@@ -361,7 +372,8 @@ namespace {
                 'handle'  => 'repo@hidden-run',
                 'branch'  => 'agent/hidden-run',
             ),
-        )
+        ),
+        43
     );
 
     if ( empty( $runner_capture['changed'] ) || empty( $runner_capture['fallback_pull_request']['opened'] ) ) {
@@ -372,8 +384,52 @@ namespace {
         fwrite( STDERR, "Expected runner workspace capture fallback PR to use the captured branch.\n" );
         exit( 1 );
     }
+    if ( '[runner-agent] runner-task - agent/hidden-run - pr_opened' !== ( $fallback_pr_input['title'] ?? '' ) ) {
+        fwrite( STDERR, "Expected runner workspace fallback PR to use the artifact PR title template.\n" );
+        exit( 1 );
+    }
+    foreach ( array( 'Branch: agent/hidden-run', 'Handle: repo@hidden-run', 'Status: runner-workspace-status', 'Custom: custom fallback value' ) as $expected_fallback_body_fragment ) {
+        if ( ! str_contains( (string) ( $fallback_pr_input['body'] ?? '' ), $expected_fallback_body_fragment ) ) {
+            fwrite( STDERR, "Expected runner workspace fallback PR body to include {$expected_fallback_body_fragment}.\n" );
+            exit( 1 );
+        }
+    }
     if ( 'repo@hidden-run' !== ( $runner_capture_calls[0]['input']['name'] ?? null ) || array( 'docs/generated.md' ) !== ( $runner_capture_calls[1]['input']['paths'] ?? null ) ) {
         fwrite( STDERR, "Expected runner workspace capture to inspect and stage the provisioned handle.\n" );
+        exit( 1 );
+    }
+
+    $fallback_pr_input = array();
+    $explicit_runner_capture = homeboy_datamachine_agent_capture_runner_workspace(
+        array(),
+        array(
+            'target_repo'              => 'owner/repo',
+            'tool_results_key'         => 'github_tool_results',
+            'fallback_pull_request'    => array(
+                'title' => 'Explicit fallback title',
+                'body'  => 'Explicit fallback body',
+            ),
+            'artifact_export'          => array(
+                'pr_title_template' => 'Templated {task_id}',
+                'pr_body_template'  => 'Templated {workspace_branch}',
+            ),
+            'runner_workspace'         => array(
+                'enabled'         => true,
+                'expose_to_agent' => false,
+            ),
+            'runner_workspace_result'  => array(
+                'success' => true,
+                'handle'  => 'repo@explicit-run',
+                'branch'  => 'agent/explicit-run',
+            ),
+        )
+    );
+    if ( empty( $explicit_runner_capture['fallback_pull_request']['opened'] ) ) {
+        fwrite( STDERR, "Expected explicit runner workspace fallback PR to open.\n" );
+        exit( 1 );
+    }
+    if ( 'Explicit fallback title' !== ( $fallback_pr_input['title'] ?? '' ) || 'Explicit fallback body' !== ( $fallback_pr_input['body'] ?? '' ) ) {
+        fwrite( STDERR, "Expected explicit runner workspace fallback PR title/body to take precedence over artifact templates.\n" );
         exit( 1 );
     }
 


### PR DESCRIPTION
## Summary
- Apply `artifact_export.pr_title_template` and `pr_body_template` to runner workspace fallback PRs when explicit fallback title/body values are not configured.
- Preserve explicit `fallback_pull_request.title` and `fallback_pull_request.body` precedence over artifact templates.
- Extend the Data Machine agent write-without-PR smoke coverage for templated runner fallback PRs and explicit fallback precedence.

## Context
- Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/611
- Bug evidence: https://github.com/chubes4/wp-gym/actions/runs/25757124127
- Generic fallback PR examples: https://github.com/chubes4/wp-gym/pull/50 and https://github.com/chubes4/wp-gym/pull/51

## Verification
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php && php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris remains responsible for review and testing.