### PR TITLE
Declare structured sidecar capabilities

### DIFF
--- a/docs/structured-sidecars.md
+++ b/docs/structured-sidecars.md
@@ -1,0 +1,18 @@
+# Structured Sidecars
+
+Extension manifests declare structured sidecar support in `structured_sidecars`.
+
+Each key names a stable sidecar contract and each value is a boolean indicating whether the extension can emit that sidecar today.
+
+Supported keys:
+
+- `lint.findings` — writes normalized lint findings to `HOMEBOY_LINT_FINDINGS_FILE`.
+- `test.results` — writes normalized test result counts to `HOMEBOY_TEST_RESULTS_FILE`.
+- `test.failures` — writes parsed test failure details to `HOMEBOY_TEST_FAILURES_FILE`.
+- `test.coverage` — writes normalized coverage data.
+- `bench.results` — writes benchmark result envelopes to `HOMEBOY_BENCH_RESULTS_FILE`.
+- `trace.results` — writes trace result envelopes to `HOMEBOY_TRACE_RESULTS_FILE`.
+- `trace.artifacts` — writes trace artifacts to `HOMEBOY_TRACE_ARTIFACT_DIR`.
+- `annotations` — writes inline-review annotation JSON files to `HOMEBOY_ANNOTATIONS_DIR`.
+
+Use `false` for unsupported contracts. Absence means the manifest has not been audited and should not be treated as support.

--- a/go/go.json
+++ b/go/go.json
@@ -9,6 +9,13 @@
     "file_extensions": ["go", "mod", "sum"],
     "capabilities": ["fingerprint", "format", "validate"]
   },
+  "structured_sidecars": {
+    "lint.findings": false,
+    "test.results": false,
+    "test.failures": false,
+    "test.coverage": false,
+    "annotations": false
+  },
   "scripts": {
     "fingerprint": "scripts/fingerprint.sh",
     "validate": "scripts/validate.sh",

--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -8,6 +8,16 @@
     "file_extensions": ["js", "jsx", "ts", "tsx", "mjs", "cjs", "json"],
     "capabilities": ["format", "validate"]
   },
+  "structured_sidecars": {
+    "lint.findings": true,
+    "test.results": true,
+    "test.failures": true,
+    "test.coverage": false,
+    "bench.results": true,
+    "trace.results": true,
+    "trace.artifacts": true,
+    "annotations": false
+  },
   "scripts": {
     "validate": "scripts/validate.sh",
     "format": "scripts/format.sh"

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -8,6 +8,14 @@
     "file_extensions": ["rs"],
     "capabilities": ["fingerprint", "refactor", "format", "validate"]
   },
+  "structured_sidecars": {
+    "lint.findings": false,
+    "test.results": true,
+    "test.failures": false,
+    "test.coverage": false,
+    "bench.results": true,
+    "annotations": true
+  },
   "scripts": {
     "fingerprint": "scripts/fingerprint.sh",
     "refactor": "scripts/refactor.sh",

--- a/swift/swift.json
+++ b/swift/swift.json
@@ -8,6 +8,13 @@
     "file_extensions": ["swift", "xcodeproj", "xcworkspace", "yml"],
     "capabilities": ["fingerprint", "validate"]
   },
+  "structured_sidecars": {
+    "lint.findings": false,
+    "test.results": false,
+    "test.failures": false,
+    "test.coverage": false,
+    "annotations": false
+  },
   "scripts": {
     "fingerprint": "scripts/fingerprint.sh",
     "validate": "scripts/validate.sh"

--- a/tests/structured-sidecars-smoke.mjs
+++ b/tests/structured-sidecars-smoke.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(dirname, '..');
+const manifestPaths = [
+	'wordpress/wordpress.json',
+	'nodejs/nodejs.json',
+	'rust/rust.json',
+	'swift/swift.json',
+	'go/go.json',
+];
+
+const requiredKeys = [
+	'lint.findings',
+	'test.results',
+	'test.failures',
+	'test.coverage',
+	'annotations',
+];
+
+const expectedSupport = {
+	'wordpress/wordpress.json': {
+		'lint.findings': true,
+		'test.results': true,
+		'test.failures': true,
+		'test.coverage': false,
+		'bench.results': true,
+		'trace.results': true,
+		annotations: false,
+	},
+	'nodejs/nodejs.json': {
+		'lint.findings': true,
+		'test.results': true,
+		'test.failures': true,
+		'test.coverage': false,
+		'bench.results': true,
+		'trace.results': true,
+		'trace.artifacts': true,
+		annotations: false,
+	},
+	'rust/rust.json': {
+		'lint.findings': false,
+		'test.results': true,
+		'test.failures': false,
+		'test.coverage': false,
+		'bench.results': true,
+		annotations: true,
+	},
+	'swift/swift.json': {
+		'lint.findings': false,
+		'test.results': false,
+		'test.failures': false,
+		'test.coverage': false,
+		annotations: false,
+	},
+	'go/go.json': {
+		'lint.findings': false,
+		'test.results': false,
+		'test.failures': false,
+		'test.coverage': false,
+		annotations: false,
+	},
+};
+
+const supportEvidence = {
+	'wordpress/wordpress.json': {
+		'lint.findings': ['wordpress/scripts/lint/lint-runner.sh', 'HOMEBOY_LINT_FINDINGS_FILE'],
+		'test.results': ['wordpress/scripts/test/test-runner-playground.sh', 'HOMEBOY_TEST_RESULTS_FILE'],
+		'test.failures': ['wordpress/scripts/test/test-runner-playground.sh', 'HOMEBOY_TEST_FAILURES_FILE'],
+		'bench.results': ['wordpress/scripts/bench/bench-runner-playground.sh', 'HOMEBOY_BENCH_RESULTS_FILE'],
+		'trace.results': ['wordpress/scripts/trace/trace-runner.sh', 'HOMEBOY_TRACE_RESULTS_FILE'],
+	},
+	'nodejs/nodejs.json': {
+		'lint.findings': ['nodejs/scripts/lint/lint-runner.sh', 'HOMEBOY_LINT_FINDINGS_FILE'],
+		'test.results': ['nodejs/scripts/test/test-runner.sh', 'HOMEBOY_TEST_RESULTS_FILE'],
+		'test.failures': ['nodejs/scripts/test/test-runner.sh', 'HOMEBOY_TEST_FAILURES_FILE'],
+		'bench.results': ['nodejs/scripts/bench/bench-runner.sh', 'HOMEBOY_BENCH_RESULTS_FILE'],
+		'trace.results': ['nodejs/scripts/trace/trace-runner.sh', 'HOMEBOY_TRACE_RESULTS_FILE'],
+		'trace.artifacts': ['nodejs/scripts/trace/trace-runner.sh', 'HOMEBOY_TRACE_ARTIFACT_DIR'],
+	},
+	'rust/rust.json': {
+		'test.results': ['rust/scripts/test-runner.sh', 'HOMEBOY_TEST_RESULTS_FILE'],
+		'bench.results': ['rust/scripts/bench/bench-runner.sh', 'HOMEBOY_BENCH_RESULTS_FILE'],
+		annotations: ['rust/scripts/lint-runner.sh', 'HOMEBOY_ANNOTATIONS_DIR'],
+	},
+};
+
+for (const manifestPath of manifestPaths) {
+	const manifest = JSON.parse(await readFile(path.join(root, manifestPath), 'utf8'));
+	assert.equal(typeof manifest.structured_sidecars, 'object', `${manifestPath} declares structured_sidecars`);
+	assert.equal(Array.isArray(manifest.structured_sidecars), false, `${manifestPath} sidecars must be an object`);
+
+	for (const key of requiredKeys) {
+		assert.equal(typeof manifest.structured_sidecars[key], 'boolean', `${manifestPath} declares ${key}`);
+	}
+
+	assert.deepEqual(manifest.structured_sidecars, expectedSupport[manifestPath], `${manifestPath} sidecar support matches audited runner contracts`);
+
+	for (const [key, evidence] of Object.entries(supportEvidence[manifestPath] || {})) {
+		assert.equal(manifest.structured_sidecars[key], true, `${manifestPath} declares ${key} support`);
+		const [evidencePath, needle] = evidence;
+		const source = await readFile(path.join(root, evidencePath), 'utf8');
+		assert.match(source, new RegExp(needle), `${manifestPath} ${key} is backed by ${needle} in ${evidencePath}`);
+	}
+}

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -8,6 +8,15 @@
     "file_extensions": ["php", "css", "ts", "tsx", "js", "jsx", "json"],
     "capabilities": ["fingerprint", "refactor", "crossref", "validate"]
   },
+  "structured_sidecars": {
+    "lint.findings": true,
+    "test.results": true,
+    "test.failures": true,
+    "test.coverage": false,
+    "bench.results": true,
+    "trace.results": true,
+    "annotations": false
+  },
   "scripts": {
     "fingerprint": "scripts/fingerprint.sh",
     "refactor": "scripts/refactor.py",


### PR DESCRIPTION
## Summary
- Add explicit `structured_sidecars` declarations to WordPress, Node.js, Rust, Swift, and Go manifests.
- Document the supported sidecar capability keys and what each env-backed contract means.
- Add a smoke validator that locks audited declarations and checks true declarations against runner-script evidence.

## Testing
- `node tests/structured-sidecars-smoke.mjs`
- `bash wordpress/scripts/test/parse-test-failures-sidecar-smoke.sh`
- `bash nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh`
- `bash rust/scripts/parse-test-results-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the manifest declarations, docs, and smoke validator from runner-script evidence; Chris directed the next cleanup slice.