### PR TITLE
Fix data-machine dependency resolution for scoped PHPStan

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -193,6 +193,16 @@ _homeboy_clone_dependency() {
     return 1
 }
 
+_homeboy_known_dependency_github_org() {
+    local slug="${1:-}"
+
+    case "$slug" in
+        data-machine)
+            printf '%s\n' 'Extra-Chill'
+            ;;
+    esac
+}
+
 homeboy_resolve_validation_dependency_path() {
     local dependency="${1:-}"
 
@@ -229,6 +239,18 @@ homeboy_resolve_validation_dependency_path() {
             cloned_path=$(_homeboy_clone_dependency "$dependency" "$github_org" || true)
             if [ -n "$cloned_path" ] && [ -d "$cloned_path" ]; then
                 echo "Resolved dependency '$dependency' via git clone from ${github_org}/${dependency}" >&2
+                printf '%s\n' "$cloned_path"
+                return 0
+            fi
+        fi
+
+        local known_github_org
+        known_github_org=$(_homeboy_known_dependency_github_org "$dependency" || true)
+        if [ -n "$known_github_org" ] && [ "$known_github_org" != "$github_org" ]; then
+            local cloned_path
+            cloned_path=$(_homeboy_clone_dependency "$dependency" "$known_github_org" || true)
+            if [ -n "$cloned_path" ] && [ -d "$cloned_path" ]; then
+                echo "Resolved dependency '$dependency' via git clone from ${known_github_org}/${dependency}" >&2
                 printf '%s\n' "$cloned_path"
                 return 0
             fi

--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -234,23 +234,23 @@ homeboy_resolve_validation_dependency_path() {
             github_org=$(_homeboy_infer_github_org "${_HOMEBOY_DEP_PLUGIN_PATH:-.}" || true)
         fi
 
-        if [ -n "$github_org" ]; then
+        local known_github_org
+        known_github_org=$(_homeboy_known_dependency_github_org "$dependency" || true)
+        if [ -n "$known_github_org" ]; then
             local cloned_path
-            cloned_path=$(_homeboy_clone_dependency "$dependency" "$github_org" || true)
+            cloned_path=$(_homeboy_clone_dependency "$dependency" "$known_github_org" || true)
             if [ -n "$cloned_path" ] && [ -d "$cloned_path" ]; then
-                echo "Resolved dependency '$dependency' via git clone from ${github_org}/${dependency}" >&2
+                echo "Resolved dependency '$dependency' via git clone from ${known_github_org}/${dependency}" >&2
                 printf '%s\n' "$cloned_path"
                 return 0
             fi
         fi
 
-        local known_github_org
-        known_github_org=$(_homeboy_known_dependency_github_org "$dependency" || true)
-        if [ -n "$known_github_org" ] && [ "$known_github_org" != "$github_org" ]; then
+        if [ -n "$github_org" ] && [ "$github_org" != "$known_github_org" ]; then
             local cloned_path
-            cloned_path=$(_homeboy_clone_dependency "$dependency" "$known_github_org" || true)
+            cloned_path=$(_homeboy_clone_dependency "$dependency" "$github_org" || true)
             if [ -n "$cloned_path" ] && [ -d "$cloned_path" ]; then
-                echo "Resolved dependency '$dependency' via git clone from ${known_github_org}/${dependency}" >&2
+                echo "Resolved dependency '$dependency' via git clone from ${github_org}/${dependency}" >&2
                 printf '%s\n' "$cloned_path"
                 return 0
             fi

--- a/wordpress/tests/validation-dependencies-smoke.sh
+++ b/wordpress/tests/validation-dependencies-smoke.sh
@@ -12,8 +12,10 @@ CLONED_DATA_MACHINE_DIR="${TMPDIR}/cache/data-machine"
 AGENTS_API_DIR="${TMPDIR}/agents-api"
 OPENAI_PROVIDER_DIR="${TMPDIR}/ai-provider-for-openai"
 BIN_DIR="${TMPDIR}/bin"
+CLONE_BIN_DIR="${TMPDIR}/clone-bin"
+FALLBACK_CACHE_DIR="${TMPDIR}/fallback-cache"
 
-mkdir -p "$COMPONENT_DIR" "$DATA_MACHINE_DIR" "$CLONED_DATA_MACHINE_DIR" "$AGENTS_API_DIR" "$OPENAI_PROVIDER_DIR" "$BIN_DIR"
+mkdir -p "$COMPONENT_DIR" "$DATA_MACHINE_DIR" "$CLONED_DATA_MACHINE_DIR" "$AGENTS_API_DIR" "$OPENAI_PROVIDER_DIR" "$BIN_DIR" "$CLONE_BIN_DIR" "$FALLBACK_CACHE_DIR"
 
 cat > "${COMPONENT_DIR}/intelligence.php" <<'PHP'
 <?php
@@ -71,6 +73,52 @@ fi
 SH
 chmod +x "${BIN_DIR}/homeboy"
 
+cat > "${CLONE_BIN_DIR}/homeboy" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "component" ] && [ "${2:-}" = "show" ]; then
+    printf '%s\n' '{"data":{"entity":{}}}'
+fi
+SH
+chmod +x "${CLONE_BIN_DIR}/homeboy"
+
+cat > "${CLONE_BIN_DIR}/git" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "-C" ]; then
+    shift 2
+fi
+
+if [ "${1:-}" = "remote" ] && [ "${2:-}" = "get-url" ] && [ "${3:-}" = "origin" ]; then
+    printf '%s\n' 'https://github.com/Automattic/intelligence.git'
+    exit 0
+fi
+
+if [ "${1:-}" = "clone" ]; then
+    repo_url="${@: -2:1}"
+    clone_path="${@: -1}"
+    case "$repo_url" in
+        *github.com/Automattic/data-machine.git)
+            exit 1
+            ;;
+        *github.com/Extra-Chill/data-machine.git)
+            mkdir -p "$clone_path"
+            cat > "${clone_path}/data-machine.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Data Machine
+ */
+PHP
+            exit 0
+            ;;
+    esac
+fi
+
+exit 1
+SH
+chmod +x "${CLONE_BIN_DIR}/git"
+
 source "$HELPER"
 
 resolved=$(PATH="${BIN_DIR}:$PATH" homeboy_resolve_validation_dependency_paths "$COMPONENT_DIR")
@@ -92,6 +140,18 @@ data_machine_line=$(grep -nF -- "$DATA_MACHINE_DIR" <<< "$resolved" | cut -d: -f
 if [ "$agents_api_line" -ge "$data_machine_line" ]; then
     echo "FAIL: transitive dependency should be emitted before dependent plugin" >&2
     printf '%s\n' "$resolved" >&2
+    exit 1
+fi
+
+fallback_resolved=$(
+    PATH="${CLONE_BIN_DIR}:$PATH" \
+    HOMEBOY_CACHE_DIR="$FALLBACK_CACHE_DIR" \
+    homeboy_resolve_validation_dependency_paths "$COMPONENT_DIR"
+)
+fallback_data_machine="${FALLBACK_CACHE_DIR}/homeboy-deps/data-machine"
+if ! grep -F -- "$fallback_data_machine" <<< "$fallback_resolved" >/dev/null; then
+    echo "FAIL: data-machine dependency should fall back from inferred Automattic org to Extra-Chill" >&2
+    printf '%s\n' "$fallback_resolved" >&2
     exit 1
 fi
 

--- a/wordpress/tests/validation-dependencies-smoke.sh
+++ b/wordpress/tests/validation-dependencies-smoke.sh
@@ -100,6 +100,7 @@ if [ "${1:-}" = "clone" ]; then
     clone_path="${@: -1}"
     case "$repo_url" in
         *github.com/Automattic/data-machine.git)
+            echo "FAIL: data-machine should resolve through its canonical Extra-Chill owner" >&2
             exit 1
             ;;
         *github.com/Extra-Chill/data-machine.git)
@@ -150,7 +151,7 @@ fallback_resolved=$(
 )
 fallback_data_machine="${FALLBACK_CACHE_DIR}/homeboy-deps/data-machine"
 if ! grep -F -- "$fallback_data_machine" <<< "$fallback_resolved" >/dev/null; then
-    echo "FAIL: data-machine dependency should fall back from inferred Automattic org to Extra-Chill" >&2
+    echo "FAIL: data-machine dependency should resolve from Extra-Chill/data-machine" >&2
     printf '%s\n' "$fallback_resolved" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary
- Resolve the known `data-machine` WordPress dependency from its canonical `Extra-Chill/data-machine` owner when CI cannot use a local registry checkout.
- Add smoke coverage for an Automattic component that requires `data-machine`, verifying the dependency resolves from `Extra-Chill/data-machine` rather than an inferred component owner.

Fixes Extra-Chill/homeboy#2086.

## Tests
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-data-machine-dependency-org --extension nodejs --changed-since origin/capture-rest-response-samples`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Homeboy issue, corrected the dependency owner resolution for Data Machine, updated smoke coverage, and ran verification.