### PR TITLE
Mark empty PHPUnit discovery as skipped

### DIFF
--- a/wordpress/scripts/test/playground-no-test-files-smoke.sh
+++ b/wordpress/scripts/test/playground-no-test-files-smoke.sh
@@ -96,11 +96,13 @@ if [ "$skip_status" -ne 0 ]; then
     exit 1
 fi
 assert_contains "$skip_output" "NO PHPUNIT TEST FILES DISCOVERED"
-assert_contains "$skip_output" "Skipping PHPUnit tests: no files matched the WordPress runner discovery contract."
+assert_contains "$skip_output" "Skipping PHPUnit tests: plugin activation/install passed, but no files matched the WordPress runner discovery contract."
 assert_contains "$skip_output" "ending in Test.php or starting with test-."
+assert_contains "$skip_output" "PHPUnit discovery found zero tests; no PHPUnit assertions ran."
 assert_not_contains "$skip_output" "UNCLASSIFIED PLAYGROUND FAILURE"
 assert_contains "$(cat "$RESULTS_FILE")" '"total": 0'
 assert_contains "$(cat "$RESULTS_FILE")" '"failed": 0'
+assert_contains "$(cat "$RESULTS_FILE")" '"status": "skipped"'
 assert_contains "$(cat "$RESULTS_FILE")" '"partial": "no-phpunit-tests"'
 
 cat > "${PLUGIN_PATH}/composer.json" <<'JSON'
@@ -146,6 +148,22 @@ assert_not_contains "$failure_output" "UNCLASSIFIED PLAYGROUND FAILURE"
 assert_not_contains "$failure_output" "Skipping PHPUnit tests: no files matched"
 assert_contains "$(cat "$RESULTS_FILE")" '"total": 1'
 assert_contains "$(cat "$RESULTS_FILE")" '"failed": 1'
+assert_contains "$(cat "$RESULTS_FILE")" '"status": "failed"'
+assert_contains "$(cat "$RESULTS_FILE")" '"partial": "no-phpunit-tests-configured"'
+rm -f "${PLUGIN_PATH}/phpunit.xml.dist" "$RESULTS_FILE"
+
+set +e
+configured_failure_output=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" HOMEBOY_COMPONENT_ID="example" HOMEBOY_SETTINGS_JSON='{"phpunit_no_tests":"failed"}' HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WRITE_RESULTS_HELPER" HOMEBOY_TEST_RESULTS_FILE="$RESULTS_FILE" bash "$RUNNER" 2>&1)
+configured_failure_status=$?
+set -e
+
+if [ "$configured_failure_status" -eq 0 ]; then
+    echo "Expected phpunit_no_tests=failed to fail zero-discovery runs" >&2
+    echo "$configured_failure_output" >&2
+    exit 1
+fi
+assert_contains "$configured_failure_output" "PHPUnit no-test discovery is configured as failure"
+assert_contains "$(cat "$RESULTS_FILE")" '"status": "failed"'
 assert_contains "$(cat "$RESULTS_FILE")" '"partial": "no-phpunit-tests-configured"'
 
 assert_contains "$RUNNER_SRC" "pg_run_install_stage(['config_path' => \$config_path, 'tests_dir' => \$tests_dir]);"
@@ -176,4 +194,4 @@ assert_contains "$RUNNER_SRC" "pg_reopen_wordpress_action('wp_abilities_api_cate
 assert_contains "$RUNNER_SRC" "pg_fire_reopened_wordpress_action('wp_abilities_api_init'"
 assert_contains "$BOOTSTRAP_SRC" "\$cfg['activate'] ?? true"
 
-echo "Playground no-test-files smoke passed (43 assertions)"
+echo "Playground no-test-files smoke passed (50 assertions)"

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -87,6 +87,7 @@ fi
 write_phpunit_discovery_result() {
     local status="$1"
     local partial="$2"
+    local message="$3"
 
     if ! type homeboy_write_test_results >/dev/null 2>&1; then
         return 0
@@ -96,6 +97,23 @@ write_phpunit_discovery_result() {
         homeboy_write_test_results 1 0 1 0 "$partial"
     else
         homeboy_write_test_results 0 0 0 0 "$partial"
+    fi
+
+    if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$HOMEBOY_TEST_RESULTS_FILE" ]; then
+        php -r '
+            $path = $argv[1];
+            $status = $argv[2];
+            $message = $argv[3];
+            $data = json_decode(file_get_contents($path), true);
+            if (!is_array($data)) {
+                $data = [];
+            }
+            $data["status"] = $status;
+            if ($message !== "") {
+                $data["message"] = $message;
+            }
+            file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+        ' "$HOMEBOY_TEST_RESULTS_FILE" "$status" "$message"
     fi
 }
 
@@ -251,6 +269,14 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.bench_env // {}' 2>/dev/null || echo "{}")
     if [ -n "$extracted" ]; then
         BENCH_ENV_JSON="$extracted"
+    fi
+fi
+
+PHPUNIT_NO_TESTS="skipped"
+if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.phpunit_no_tests // empty' 2>/dev/null || true)
+    if [ -n "$extracted" ] && [ "$extracted" != "null" ]; then
+        PHPUNIT_NO_TESTS="$extracted"
     fi
 fi
 
@@ -614,21 +640,26 @@ if echo "$PHPUNIT_OUTPUT" | grep -q "^NO_TEST_FILES"; then
         exit $?
     fi
 
-    if [ -f "${PLUGIN_PATH}/phpunit.xml" ] || [ -f "${PLUGIN_PATH}/phpunit.xml.dist" ]; then
+    if [ "$PHPUNIT_NO_TESTS" = "failed" ] || [ "$PHPUNIT_NO_TESTS" = "fail" ] || [ -f "${PLUGIN_PATH}/phpunit.xml" ] || [ -f "${PLUGIN_PATH}/phpunit.xml.dist" ]; then
         echo ""
-        echo "PHPUnit config exists, but no files matched the WordPress runner discovery contract."
+        if [ "$PHPUNIT_NO_TESTS" = "failed" ] || [ "$PHPUNIT_NO_TESTS" = "fail" ]; then
+            echo "PHPUnit no-test discovery is configured as failure, and no files matched the WordPress runner discovery contract."
+        else
+            echo "PHPUnit config exists, but no files matched the WordPress runner discovery contract."
+        fi
         echo "  Check phpunit.xml(.dist), tests/ directory layout, and Test.php/test- naming."
         FAILED_STEP="PHPUnit tests (configured suite discovered no test files, playground)"
-        write_phpunit_discovery_result failed "no-phpunit-tests-configured"
+        write_phpunit_discovery_result failed "no-phpunit-tests-configured" "Plugin activation/install passed; PHPUnit discovery found zero tests; no PHPUnit assertions ran."
         rm -f "$RESULT_FILE"
         exit 1
     fi
 
     echo ""
-    echo "Skipping PHPUnit tests: no files matched the WordPress runner discovery contract."
+    echo "Skipping PHPUnit tests: plugin activation/install passed, but no files matched the WordPress runner discovery contract."
     echo "  Contract: files under ${TEST_DIR} ending in Test.php or starting with test-."
+    echo "  PHPUnit discovery found zero tests; no PHPUnit assertions ran."
     echo "  Add matching PHPUnit files or a component phpunit.xml(.dist) if this suite should run here."
-    write_phpunit_discovery_result skipped "no-phpunit-tests"
+    write_phpunit_discovery_result skipped "no-phpunit-tests" "Plugin activation/install passed; PHPUnit discovery found zero tests; no PHPUnit assertions ran."
     rm -f "$RESULT_FILE"
     exit 0
 fi

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -853,6 +853,13 @@
       "description": "Map of NAME => value forwarded into Playground PHP-WASM as environment variables. Workloads (bench) and test fixtures (test runner) read them via getenv() / $_ENV. Required because host shell env doesn't cross the wp-playground-cli sandbox boundary; without this seam, getenv('MY_KNOB') returns false regardless of what the parent shell set. Values are coerced to strings (via json_encode for non-scalars) per PHP env-var convention. Component declares static defaults; matrix drivers can synthesize HOMEBOY_SETTINGS_JSON inline to override per-cell."
     },
     {
+      "id": "phpunit_no_tests",
+      "label": "No PHPUnit tests discovered",
+      "type": "string",
+      "default": "skipped",
+      "description": "How the Playground PHPUnit backend treats successful WordPress install/activation when discovery finds zero PHPUnit files. Use 'skipped' for components that intentionally test through smoke scripts, or 'failed' when the component expects PHPUnit coverage. Components with phpunit.xml(.dist) still fail on zero discovery."
+    },
+    {
       "id": "playground_blueprint",
       "label": "Playground blueprint",
       "type": "object",


### PR DESCRIPTION
## Summary
- Add explicit `status: skipped` structured output when Playground PHPUnit install/activation succeeds but discovery finds zero test files.
- Keep configured suites failing on zero discovery and add `phpunit_no_tests: failed` for components that expect PHPUnit tests without a config file.
- Clarify the human summary so it says install/activation passed, discovery found zero tests, and no PHPUnit assertions ran.

Fixes #607.

## Tests
- `bash wordpress/scripts/test/playground-no-test-files-smoke.sh`
- `bash wordpress/tests/playground-test-discovery-smoke.sh`
- `bash tests/runtime-helpers-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the PHPUnit no-discovery status handling, smoke coverage, and focused verification; Chris remains responsible for review and merge.