### PR TITLE
fix(wordpress): define PLUGIN_SLUG early so composer-test fallback works without tests/ dir

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,7 +10,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
       "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js"
     ],
     "test": [
@@ -20,6 +20,7 @@
       "bash scripts/test/playground-process-cleanup-smoke.sh",
       "bash scripts/test/playground-cleanup-noise-smoke.sh",
       "bash scripts/test/playground-no-test-files-smoke.sh",
+      "bash scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh",
       "bash scripts/agent/validate-bundle-smoke.sh",
       "bash scripts/trace/trace-runner-smoke.sh",
       "bash scripts/lint/wordpress-lint-role-smoke.sh",

--- a/wordpress/scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh
+++ b/wordpress/scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Regression smoke: when a component has composer.json declaring scripts.test
+# but NO tests/ directory, the runner must fall through to composer-fallback
+# WITHOUT tripping `set -u` on PLUGIN_SLUG.
+#
+# Bug: homeboy-extensions#619. Before the fix, PLUGIN_SLUG was defined further
+# down the script (past the composer-fallback exit), so the fallback's
+# `echo "  Plugin: ${PLUGIN_SLUG} (...)"` died with `unbound variable`.
+#
+# This complements playground-no-test-files-smoke.sh, which always pre-creates
+# tests/ — it exercises the empty-tests-dir composer fallback path, not the
+# no-tests-dir-at-all path that triggered #619.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/test-runner-playground.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+EXTENSION_PATH="${TMPDIR}/extension"
+PLUGIN_PATH="${TMPDIR}/component"
+BIN_PATH="${TMPDIR}/bin"
+mkdir -p "${BIN_PATH}"
+export PATH="${BIN_PATH}:${PATH}"
+
+# Critical: do NOT create ${PLUGIN_PATH}/tests — that's what makes this smoke
+# different from playground-no-test-files-smoke.sh and what trips #619.
+mkdir -p "${EXTENSION_PATH}/node_modules/.bin" "${PLUGIN_PATH}"
+
+# Stub playground-cli — should never be reached in the composer-fallback path,
+# but provide it so the runner's discovery checks don't crash earlier.
+cat > "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli" <<'SH'
+#!/usr/bin/env bash
+echo "wp-playground-cli should not be invoked in composer-fallback path" >&2
+exit 99
+SH
+chmod +x "${EXTENSION_PATH}/node_modules/.bin/wp-playground-cli"
+
+# Stub composer so we can verify the fallback actually invokes `composer test`.
+cat > "${BIN_PATH}/composer" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "composer:$PWD:$*" >> "${HOMEBOY_COMPOSER_CALLS_FILE}"
+echo "stub-composer ran composer $*"
+SH
+chmod +x "${BIN_PATH}/composer"
+
+cat > "${PLUGIN_PATH}/composer.json" <<'JSON'
+{
+    "scripts": {
+        "test": "phpunit"
+    }
+}
+JSON
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        echo "Expected output to contain: $needle" >&2
+        echo "Actual output:" >&2
+        echo "$haystack" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1"
+    local needle="$2"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        echo "Expected output not to contain: $needle" >&2
+        echo "Actual output:" >&2
+        echo "$haystack" >&2
+        exit 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Branch 1: COMPONENT_ID set → PLUGIN_SLUG resolves from $COMPONENT_ID
+# ---------------------------------------------------------------------------
+
+COMPOSER_CALLS_FILE="${TMPDIR}/composer-calls-with-id.log"
+set +e
+output_with_id=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
+    HOMEBOY_COMPONENT_ID="example" \
+    HOMEBOY_COMPOSER_CALLS_FILE="$COMPOSER_CALLS_FILE" \
+    bash "$RUNNER" 2>&1)
+status_with_id=$?
+set -e
+
+# The whole point of the regression: the runner must NOT die with an unbound
+# variable error before reaching the composer call.
+assert_not_contains "$output_with_id" "PLUGIN_SLUG: unbound variable"
+assert_not_contains "$output_with_id" "unbound variable"
+
+# Composer fallback path must be reached and announce itself with the
+# canonical component slug, not basename.
+assert_contains "$output_with_id" "Running Composer test script..."
+assert_contains "$output_with_id" "Backend: composer-script"
+assert_contains "$output_with_id" "Plugin: example (${PLUGIN_PATH})"
+
+# And composer test must actually be invoked.
+assert_contains "$(cat "$COMPOSER_CALLS_FILE")" "composer:${PLUGIN_PATH}:test"
+
+if [ "$status_with_id" -ne 0 ]; then
+    echo "Expected composer-fallback with COMPONENT_ID to exit 0; got $status_with_id" >&2
+    echo "$output_with_id" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Branch 2: COMPONENT_ID unset → PLUGIN_SLUG falls back to basename
+# ---------------------------------------------------------------------------
+
+COMPOSER_CALLS_FILE_NO_ID="${TMPDIR}/composer-calls-no-id.log"
+set +e
+output_no_id=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
+    HOMEBOY_COMPOSER_CALLS_FILE="$COMPOSER_CALLS_FILE_NO_ID" \
+    bash "$RUNNER" 2>&1)
+status_no_id=$?
+set -e
+
+assert_not_contains "$output_no_id" "PLUGIN_SLUG: unbound variable"
+assert_not_contains "$output_no_id" "unbound variable"
+assert_contains "$output_no_id" "Running Composer test script..."
+
+# basename of /tmp/<random>/component → "component"
+assert_contains "$output_no_id" "Plugin: component (${PLUGIN_PATH})"
+assert_contains "$(cat "$COMPOSER_CALLS_FILE_NO_ID")" "composer:${PLUGIN_PATH}:test"
+
+if [ "$status_no_id" -ne 0 ]; then
+    echo "Expected composer-fallback without COMPONENT_ID to exit 0; got $status_no_id" >&2
+    echo "$output_no_id" >&2
+    exit 1
+fi
+
+echo "Playground composer-fallback no-tests-dir smoke passed (#619 regression guard)"

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -84,6 +84,22 @@ if [ -n "$WRITE_TEST_RESULTS_HELPER" ] && [ -f "$WRITE_TEST_RESULTS_HELPER" ]; t
     source "$WRITE_TEST_RESULTS_HELPER"
 fi
 
+# PLUGIN_SLUG is the wp-content/plugins/ path segment Playground uses to
+# mount the component-under-test. When homeboy core tells us the canonical
+# component id (HOMEBOY_COMPONENT_ID), use it — basename($PLUGIN_PATH)
+# breaks for git-worktree checkouts (`<repo>@<branch-slug>`) and any
+# workspace where the on-disk directory name diverges from the canonical
+# slug. See bench-runner-playground.sh for the full rationale.
+#
+# Defined here (before the TEST_DIR check) so the composer-test fallback
+# path — which fires when a component has composer.json scripts.test but
+# no tests/ dir — can reference PLUGIN_SLUG without tripping `set -u`.
+if [ -n "${COMPONENT_ID:-}" ]; then
+    PLUGIN_SLUG="$COMPONENT_ID"
+else
+    PLUGIN_SLUG="$(basename "$PLUGIN_PATH")"
+fi
+
 write_phpunit_discovery_result() {
     local status="$1"
     local partial="$2"
@@ -322,17 +338,6 @@ if [ -n "$SELECTED_TEST_FILE" ]; then
 fi
 SELECTED_TEST_FILE_B64=$(printf '%s' "$SELECTED_TEST_FILE_REL" | base64 | tr -d '\n')
 
-# PLUGIN_SLUG is the wp-content/plugins/ path segment Playground uses to
-# mount the component-under-test. When homeboy core tells us the canonical
-# component id (HOMEBOY_COMPONENT_ID), use it — basename($PLUGIN_PATH)
-# breaks for git-worktree checkouts (`<repo>@<branch-slug>`) and any
-# workspace where the on-disk directory name diverges from the canonical
-# slug. See bench-runner-playground.sh for the full rationale.
-if [ -n "${COMPONENT_ID:-}" ]; then
-    PLUGIN_SLUG="$COMPONENT_ID"
-else
-    PLUGIN_SLUG="$(basename "$PLUGIN_PATH")"
-fi
 MOUNT_ARGS=()
 
 MOUNT_ARGS+=("--mount" "${PLUGIN_PATH}:/wordpress/wp-content/plugins/${PLUGIN_SLUG}")


### PR DESCRIPTION
Fixes #619

## Summary

When a WordPress component has `composer.json` declaring `scripts.test` but **no `tests/` directory**, the playground test runner falls through to `run_composer_test_script()`. That function references `${PLUGIN_SLUG}`, but `PLUGIN_SLUG` was defined further down the script — past the composer-fallback `exit $?`. With `set -u` in effect, the runner died with:

```
test-runner-playground.sh: line 194: PLUGIN_SLUG: unbound variable
```

No tests ran, no useful diagnostic. Discovered while verifying the test gate downstream of `extrachill-multisite#21` — `homeboy test` against `extrachill-multisite` on unmodified `main` triggers this every time, because the plugin has `composer.json` with `scripts.test` but no `tests/` dir.

## Fix

Move the `PLUGIN_SLUG` definition (previously lines 326-335) above the `TEST_DIR` check at line 210, right after the helper-source block (~line 86). `PLUGIN_SLUG` only depends on `COMPONENT_ID` and `PLUGIN_PATH`, both of which are set by `homeboy_resolve_context` at line 54 — so the earlier definition has all the inputs it needs.

`bench-runner-playground.sh` already defines `PLUGIN_SLUG` early (lines 96-98) and is unaffected. **Note:** the original issue body incorrectly flagged this script as having the same bug — I retract that on inspection. Only `test-runner-playground.sh` had the problem.

## Smoke test

Adds `scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh` as a regression guard. The existing `playground-no-test-files-smoke.sh` pre-creates `${PLUGIN_PATH}/tests`, so it exercises the **empty-tests-dir composer fallback** path — not the **no-tests-dir-at-all** path that triggered #619.

The new smoke:
- Creates `composer.json` with `scripts.test`, deliberately omits `tests/`
- Asserts the runner does NOT emit `PLUGIN_SLUG: unbound variable`
- Asserts both lookup branches resolve correctly:
  - `COMPONENT_ID=example` → `Plugin: example (...)`
  - no `COMPONENT_ID` → `Plugin: component (...)` (basename of tmpdir)
- Asserts `composer test` is actually invoked via stub

**Verified to fail against the pre-fix state**, pass against the fix. Wired into `wordpress/homeboy.json`:
- `self_checks.lint` (the `bash -n` syntax-check list)
- `self_checks.test` (the actual self-check run list)

## Quality gates (`homeboy review --changed-since origin/main` from `wordpress/`)

| Stage | Result |
|---|---|
| Audit | passed (0 findings) |
| Lint | passed (0 findings) |
| Test | **my new smoke passed** (`Playground composer-fallback no-tests-dir smoke passed (#619 regression guard)`) — see below for an unrelated pre-existing failure |

### Pre-existing unrelated failure

`wordpress/tests/audit-detector-config-smoke.sh` exits 1 with `constant-backed slug detector should still flag comparisons`. Verified to **also fail on a fresh `git clone` of `main` with zero changes** — this is a pre-existing issue, not introduced by this PR. Worth filing separately.

## Downstream impact

Unblocks `homeboy test` for any WordPress plugin that:
- Has `composer.json` declaring `scripts.test`
- Doesn't (yet) have a populated `tests/` directory

That includes `extrachill-multisite` (which is what triggered this discovery). Also unblocks anyone trying to bootstrap a fresh WordPress component before they've populated the test suite.

## Files changed

- `wordpress/scripts/test/test-runner-playground.sh` — move `PLUGIN_SLUG` definition above `TEST_DIR` check
- `wordpress/scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh` — new regression smoke
- `wordpress/homeboy.json` — wire smoke into `self_checks.lint` and `self_checks.test`