### PR TITLE
fix(wordpress): initialize playground plugin slug before composer fallback

### DIFF
--- a/wordpress/scripts/test/playground-no-test-files-smoke.sh
+++ b/wordpress/scripts/test/playground-no-test-files-smoke.sh
@@ -113,6 +113,7 @@ cat > "${PLUGIN_PATH}/composer.json" <<'JSON'
 }
 JSON
 COMPOSER_CALLS_FILE="${TMPDIR}/composer-calls.log"
+rm -rf "${PLUGIN_PATH}/tests"
 set +e
 composer_output=$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" HOMEBOY_COMPONENT_ID="example" HOMEBOY_COMPOSER_CALLS_FILE="$COMPOSER_CALLS_FILE" bash "$RUNNER" 2>&1)
 composer_status=$?
@@ -123,12 +124,14 @@ if [ "$composer_status" -ne 0 ]; then
     echo "$composer_output" >&2
     exit 1
 fi
-assert_contains "$composer_output" "NO PHPUNIT TEST FILES DISCOVERED"
 assert_contains "$composer_output" "Running Composer test script..."
+assert_contains "$composer_output" "Plugin: example (${PLUGIN_PATH})"
 assert_contains "$composer_output" "Backend: composer-script"
 assert_contains "$composer_output" "Composer smoke script ran"
+assert_not_contains "$composer_output" "PLUGIN_SLUG: unbound variable"
 assert_contains "$(cat "$COMPOSER_CALLS_FILE")" "composer:${PLUGIN_PATH}:test"
 rm -f "${PLUGIN_PATH}/composer.json"
+mkdir -p "${PLUGIN_PATH}/tests"
 
 touch "${PLUGIN_PATH}/phpunit.xml.dist"
 rm -f "$RESULTS_FILE"

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -179,6 +179,18 @@ if [ ! -f "$PLAYGROUND_CLI" ]; then
     exit 1
 fi
 
+# PLUGIN_SLUG is the wp-content/plugins/ path segment Playground uses to
+# mount the component-under-test. When homeboy core tells us the canonical
+# component id (HOMEBOY_COMPONENT_ID), use it — basename($PLUGIN_PATH)
+# breaks for git-worktree checkouts (`<repo>@<branch-slug>`) and any
+# workspace where the on-disk directory name diverges from the canonical
+# slug. See bench-runner-playground.sh for the full rationale.
+if [ -n "${COMPONENT_ID:-}" ]; then
+    PLUGIN_SLUG="$COMPONENT_ID"
+else
+    PLUGIN_SLUG="$(basename "$PLUGIN_PATH")"
+fi
+
 component_has_composer_test_script() {
     [ -f "${PLUGIN_PATH}/composer.json" ] || return 1
 
@@ -322,17 +334,6 @@ if [ -n "$SELECTED_TEST_FILE" ]; then
 fi
 SELECTED_TEST_FILE_B64=$(printf '%s' "$SELECTED_TEST_FILE_REL" | base64 | tr -d '\n')
 
-# PLUGIN_SLUG is the wp-content/plugins/ path segment Playground uses to
-# mount the component-under-test. When homeboy core tells us the canonical
-# component id (HOMEBOY_COMPONENT_ID), use it — basename($PLUGIN_PATH)
-# breaks for git-worktree checkouts (`<repo>@<branch-slug>`) and any
-# workspace where the on-disk directory name diverges from the canonical
-# slug. See bench-runner-playground.sh for the full rationale.
-if [ -n "${COMPONENT_ID:-}" ]; then
-    PLUGIN_SLUG="$COMPONENT_ID"
-else
-    PLUGIN_SLUG="$(basename "$PLUGIN_PATH")"
-fi
 MOUNT_ARGS=()
 
 MOUNT_ARGS+=("--mount" "${PLUGIN_PATH}:/wordpress/wp-content/plugins/${PLUGIN_SLUG}")


### PR DESCRIPTION
## Summary
- Initialize the Playground plugin slug before the early composer fallback path can run.
- Extend the no-test-files smoke to cover composer `scripts.test` with no `tests/` directory.

Fixes #619.

## Testing
- `bash wordpress/scripts/test/playground-no-test-files-smoke.sh`
- `bash tests/runtime-helpers-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused shell runner fix, updated smoke coverage, and ran verification; Chris reviewed and approved opening the PR.