### PR TITLE
Expose phased WordPress page readiness

### DIFF
--- a/wordpress/lib/page-profiler.js
+++ b/wordpress/lib/page-profiler.js
@@ -1485,9 +1485,15 @@ async function collectBrowserResourceTimings(page, options = {}) {
 async function waitForPageReady(page, ready, options = {}) {
 	const spec = normalizeReadySpec(ready);
 	const timeout = spec.timeout || options.timeout || 120000;
+	const startedAt = typeof options.startedAt === 'number' ? options.startedAt : Date.now();
+	const readiness = {};
+	const record = (key) => {
+		readiness[key] = Date.now() - startedAt;
+	};
 
 	if (spec.state && typeof page.waitForLoadState === 'function') {
 		await page.waitForLoadState(spec.state, { timeout });
+		record('loadStateMs');
 	}
 
 	if (spec.selector) {
@@ -1495,6 +1501,7 @@ async function waitForPageReady(page, ready, options = {}) {
 			state: spec.selectorState || 'visible',
 			timeout,
 		});
+		record('selectorMs');
 	}
 
 	if (spec.frame || spec.frameSelector) {
@@ -1507,12 +1514,14 @@ async function waitForPageReady(page, ready, options = {}) {
 		}
 		if (spec.frameState && typeof frame.waitForLoadState === 'function') {
 			await frame.waitForLoadState(spec.frameState, { timeout });
+			record('frameLoadStateMs');
 		}
 		if (spec.frameSelector) {
 			await frame.waitForSelector(spec.frameSelector, {
 				state: spec.frameSelectorState || 'visible',
 				timeout,
 			});
+			record('frameSelectorMs');
 		}
 	}
 
@@ -1521,7 +1530,11 @@ async function waitForPageReady(page, ready, options = {}) {
 			throw new TypeError('ready.function requires page.waitForFunction()');
 		}
 		await page.waitForFunction(spec.function, spec.functionArg, { timeout });
+		record('functionMs');
 	}
+
+	readiness.readyMs = Date.now() - startedAt;
+	return readiness;
 }
 
 function summarizeResourceTimings(entries) {
@@ -2354,16 +2367,20 @@ async function profileWordPressPage(input) {
 		waitUntil: spec.gotoWaitUntil || 'commit',
 		timeout: spec.timeout || 120000,
 	});
+	const commitMs = Date.now() - started;
 	if (typeof mark === 'function') {
 		await mark(`${spec.id}_commit`);
 	}
 
-	await waitForPageReady(page, spec.ready, { timeout: spec.timeout || 120000 });
+	const readiness = {
+		commitMs,
+		...await waitForPageReady(page, spec.ready, { timeout: spec.timeout || 120000, startedAt: started }),
+	};
 	if (typeof mark === 'function') {
 		await mark(`${spec.id}_ready`);
 	}
 
-	const readyMs = Date.now() - started;
+	const readyMs = readiness.readyMs;
 	const initialResources = await collectBrowserResourceTimings(page, spec.resources || {}).catch(() => []);
 	let interactionActions = [];
 	if (Array.isArray(input.interactions)) {
@@ -2429,6 +2446,7 @@ async function profileWordPressPage(input) {
 		path: new URL(url).pathname + new URL(url).search,
 		status: response && typeof response.status === 'function' ? response.status() : 0,
 		readyMs,
+		readiness,
 		resources: resourceSummary,
 		initialResources: initialResourceSummary,
 		interactions,

--- a/wordpress/lib/page-profiler.js
+++ b/wordpress/lib/page-profiler.js
@@ -60,7 +60,7 @@ function normalizeReadySpec(ready) {
 	}
 
 	const normalized = { ...ready };
-	if (!normalized.state && !normalized.selector && !normalized.frame && !normalized.frameSelector && !normalized.function) {
+	if (!normalized.state && !normalized.selector && !normalized.frame && !normalized.frameSelector && !normalized.function && !normalized.frameFunction) {
 		normalized.state = 'domcontentloaded';
 	}
 	return normalized;
@@ -1522,6 +1522,13 @@ async function waitForPageReady(page, ready, options = {}) {
 				timeout,
 			});
 			record('frameSelectorMs');
+		}
+		if (spec.frameFunction) {
+			if (typeof frame.waitForFunction !== 'function') {
+				throw new TypeError('ready.frameFunction requires frame.waitForFunction()');
+			}
+			await frame.waitForFunction(spec.frameFunction, spec.frameFunctionArg, { timeout });
+			record('frameFunctionMs');
 		}
 	}
 

--- a/wordpress/tests/page-profiler-smoke.js
+++ b/wordpress/tests/page-profiler-smoke.js
@@ -510,6 +510,10 @@ async function main() {
 
 	assert.equal(result.id, 'site-editor');
 	assert.equal(result.status, 200);
+	assert.equal(typeof result.readiness.commitMs, 'number');
+	assert.equal(typeof result.readiness.selectorMs, 'number');
+	assert.equal(typeof result.readiness.frameSelectorMs, 'number');
+	assert.equal(result.readyMs, result.readiness.readyMs);
 	assert.equal(result.resources.restCount, 2);
 	assert.equal(result.initialResources.restCount, 2);
 	assert.equal(result.interactions.actions.length, 6);

--- a/wordpress/tests/page-profiler-smoke.js
+++ b/wordpress/tests/page-profiler-smoke.js
@@ -50,6 +50,10 @@ class FakeFrame {
 	async waitForSelector(selector) {
 		this.calls.push(['frame.waitForSelector', selector]);
 	}
+
+	async waitForFunction(fn) {
+		this.calls.push(['frame.waitForFunction', typeof fn]);
+	}
 }
 
 class FakePage {
@@ -174,7 +178,7 @@ const manifest = normalizePageManifest({
 		{
 			id: 'site-editor',
 			path: '/wp-admin/site-editor.php',
-			ready: { selector: 'iframe[name="editor-canvas"]', frameName: 'editor-canvas', frameSelector: '[data-block]' },
+			ready: { selector: 'iframe[name="editor-canvas"]', frameName: 'editor-canvas', frameSelector: '[data-block]', frameFunction: () => true },
 			interactions: [
 				{ name: 'open_admin', clickRole: { role: 'button', name: 'Admin' } },
 				{ waitForSelector: '.datamachine-jobs-admin-modal' },
@@ -513,6 +517,7 @@ async function main() {
 	assert.equal(typeof result.readiness.commitMs, 'number');
 	assert.equal(typeof result.readiness.selectorMs, 'number');
 	assert.equal(typeof result.readiness.frameSelectorMs, 'number');
+	assert.equal(typeof result.readiness.frameFunctionMs, 'number');
 	assert.equal(result.readyMs, result.readiness.readyMs);
 	assert.equal(result.resources.restCount, 2);
 	assert.equal(result.initialResources.restCount, 2);
@@ -521,6 +526,7 @@ async function main() {
 	assert.equal(result.interactionRestWaterfall.counts.total, 2);
 	assert.equal(result.correlation.correlated.length, 1);
 	assert.equal(page.calls.some((call) => call[0] === 'frame.waitForSelector' && call[1] === '[data-block]'), true);
+	assert.equal(page.calls.some((call) => call[0] === 'frame.waitForFunction'), true);
 	assert.equal(page.calls.some((call) => call[0] === 'getByRole' && call[1] === 'button' && call[2] === 'Admin'), true);
 	assert.equal(page.calls.some((call) => call[0] === 'locator.selectOption' && call[2]?.index === 1), true);
 


### PR DESCRIPTION
## Summary
- Return a `readiness` object from `profileWordPressPage()` with navigation commit and ready-phase timings.
- Record selector, frame load state, frame selector, load state, top-page ready function, and iframe ready function timings when those phases are present in the page spec.
- Preserve the existing top-level `readyMs` contract by deriving it from `readiness.readyMs`.

## Verification
- `node wordpress/tests/page-profiler-smoke.js`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@phased-editor-readiness --extension nodejs --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added phased readiness support and smoke coverage. Chris remains responsible for review and merge.