### PR TITLE
feat(wordpress): add canonical agent eval artifact

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
@@ -117,6 +117,17 @@ namespace {
         exit( 1 );
     }
 
+    $eval_artifact = is_array( $dry_run_result ) ? ( $dry_run_result['metadata']['eval_artifact'] ?? array() ) : array();
+    if ( 'homeboy.agent_eval_result' !== ( $eval_artifact['schema_name'] ?? '' ) ) {
+        fwrite( STDERR, "Expected dry-run result to include canonical eval artifact schema.\n" );
+        exit( 1 );
+    }
+
+    if ( 'forced-parameters-smoke-agent' !== ( $eval_artifact['agent']['slug'] ?? '' ) ) {
+        fwrite( STDERR, "Expected eval artifact to identify the agent slug.\n" );
+        exit( 1 );
+    }
+
     $recorder = new Homeboy_Datamachine_Agent_Tool_Recorder();
     $result   = $recorder->handle_tool_call(
         array(

--- a/wordpress/scripts/agent/datamachine-agent-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-runner-smoke.sh
@@ -85,6 +85,9 @@ bundle_path=$(jq -r "$scenario | .metadata.bundle_path // \"missing\"" "$RESULTS
 prompt_sha=$(jq -r "$scenario | .metadata.fingerprints.prompt.sha256 // \"missing\"" "$RESULTS_TMPFILE")
 bundle_sha=$(jq -r "$scenario | .metadata.fingerprints.bundle.sha256 // \"missing\"" "$RESULTS_TMPFILE")
 tool_policy_sha=$(jq -r "$scenario | .metadata.fingerprints.tool_policy.sha256 // \"missing\"" "$RESULTS_TMPFILE")
+eval_schema=$(jq -r "$scenario | .metadata.eval_artifact.schema_name // \"missing\"" "$RESULTS_TMPFILE")
+eval_agent=$(jq -r "$scenario | .metadata.eval_artifact.agent.slug // \"missing\"" "$RESULTS_TMPFILE")
+eval_prompt_sha=$(jq -r "$scenario | .metadata.eval_artifact.prompt.sha256 // \"missing\"" "$RESULTS_TMPFILE")
 if [ "$provider" != "example-provider" ] || [ "$model" != "example-model" ]; then
     echo "ERROR: provider/model metadata missing (provider=$provider model=$model)" >&2
     cat "$RESULTS_TMPFILE" >&2
@@ -92,6 +95,11 @@ if [ "$provider" != "example-provider" ] || [ "$model" != "example-model" ]; the
 fi
 if [ "$prompt_sha" = "missing" ] || [ -z "$prompt_sha" ] || [ "$bundle_sha" = "missing" ] || [ -z "$bundle_sha" ] || [ "$tool_policy_sha" = "missing" ] || [ -z "$tool_policy_sha" ]; then
     echo "ERROR: fingerprint metadata missing (prompt=$prompt_sha bundle=$bundle_sha tool_policy=$tool_policy_sha)" >&2
+    cat "$RESULTS_TMPFILE" >&2
+    exit 1
+fi
+if [ "$eval_schema" != "homeboy.agent_eval_result" ] || [ "$eval_agent" != "example-agent" ] || [ "$eval_prompt_sha" = "missing" ] || [ -z "$eval_prompt_sha" ]; then
+    echo "ERROR: canonical eval artifact missing (schema=$eval_schema agent=$eval_agent prompt_sha=$eval_prompt_sha)" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1
 fi

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -13,10 +13,115 @@ use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\JobArtifacts;
 use DataMachine\Core\PluginSettings;
 
+if ( ! function_exists( 'homeboy_datamachine_agent_eval_artifact' ) ) {
+    function homeboy_datamachine_agent_eval_artifact( array $metrics, array $metadata, ?string $error = null ): array {
+        $engine_data = is_array( $metadata['engine_data'] ?? null ) ? $metadata['engine_data'] : array();
+        $grade       = is_array( $metadata['grade'] ?? null ) ? $metadata['grade'] : ( is_array( $engine_data['grade'] ?? null ) ? $engine_data['grade'] : array() );
+        $workspace   = is_array( $metadata['runner_workspace'] ?? null ) ? $metadata['runner_workspace'] : array();
+        $capture     = is_array( $metadata['runner_workspace_capture'] ?? null ) ? $metadata['runner_workspace_capture'] : array();
+        $transcript  = is_array( $metadata['transcript_artifacts'] ?? null ) ? $metadata['transcript_artifacts'] : array();
+        $exports     = is_array( $metadata['job_artifact_exports'] ?? null ) ? $metadata['job_artifact_exports'] : array();
+
+        $failure_reasons = array();
+        if ( is_array( $metadata['failure_reasons'] ?? null ) ) {
+            $failure_reasons = array_values( array_filter( array_map( 'strval', $metadata['failure_reasons'] ) ) );
+        }
+        if ( null !== $error && empty( $failure_reasons ) ) {
+            $failure_reasons[] = 'runner_error';
+        }
+
+        $prompt = (string) ( $metadata['prompt'] ?? '' );
+
+        return array(
+            'schema_version'  => 1,
+            'schema_name'     => 'homeboy.agent_eval_result',
+            'run'             => array_filter(
+                array(
+                    'job_id'         => (int) ( $metadata['job_id'] ?? 0 ),
+                    'job_status'     => (string) ( $metadata['job_status'] ?? '' ),
+                    'success_status' => (string) ( $metadata['success_status'] ?? '' ),
+                    'error'          => null !== $error ? $error : (string) ( $metadata['error_message'] ?? '' ),
+                ),
+                static fn( $value ) => '' !== $value && 0 !== $value && null !== $value
+            ),
+            'subject'         => array_filter(
+                array(
+                    'target_repo' => (string) ( $metadata['target_repo'] ?? '' ),
+                    'bundle_path' => (string) ( $metadata['bundle_path'] ?? '' ),
+                    'flow_slug'   => (string) ( $metadata['flow_slug'] ?? '' ),
+                ),
+                static fn( $value ) => '' !== $value
+            ),
+            'agent'           => array_filter(
+                array(
+                    'slug' => (string) ( $metadata['agent_slug'] ?? '' ),
+                    'id'   => (int) ( $metadata['agent_id'] ?? 0 ),
+                ),
+                static fn( $value ) => '' !== $value && 0 !== $value
+            ),
+            'model'           => array_filter(
+                array(
+                    'provider' => (string) ( $metadata['provider'] ?? '' ),
+                    'model'    => (string) ( $metadata['model'] ?? '' ),
+                ),
+                static fn( $value ) => '' !== $value
+            ),
+            'prompt'          => array_filter(
+                array(
+                    'sha256' => '' !== $prompt ? hash( 'sha256', $prompt ) : '',
+                    'bytes'  => strlen( $prompt ),
+                ),
+                static fn( $value ) => '' !== $value && 0 !== $value
+            ),
+            'runtime'         => array_filter(
+                array(
+                    'job_id'                   => (int) ( $metadata['job_id'] ?? 0 ),
+                    'pipeline_id'              => (int) ( $metadata['pipeline_id'] ?? 0 ),
+                    'flow_id'                  => (int) ( $metadata['flow_id'] ?? 0 ),
+                    'transcript_session_id'    => (string) ( $metadata['transcript_session_id'] ?? '' ),
+                    'completion_outcome_satisfied' => (bool) ( $metadata['completion_outcome_satisfied'] ?? false ),
+                ),
+                static fn( $value ) => '' !== $value && 0 !== $value && false !== $value
+            ),
+            'workspace'       => array_filter(
+                array(
+                    'provisioned' => ! empty( $workspace ),
+                    'captured'    => ! empty( $capture ),
+                    'changed'     => ! empty( $capture['changed'] ),
+                    'handle'      => (string) ( $workspace['handle'] ?? $capture['status']['handle'] ?? '' ),
+                    'branch'      => (string) ( $workspace['branch'] ?? $capture['status']['branch'] ?? '' ),
+                ),
+                static fn( $value ) => '' !== $value && false !== $value
+            ),
+            'transcript'      => array_filter(
+                array(
+                    'session_id' => (string) ( $transcript['session_id'] ?? $metadata['transcript_session_id'] ?? '' ),
+                    'json'       => (string) ( $transcript['json'] ?? '' ),
+                    'summary'    => (string) ( $transcript['summary'] ?? '' ),
+                ),
+                static fn( $value ) => '' !== $value
+            ),
+            'grade'           => $grade,
+            'metrics'         => $metrics,
+            'failure_reasons' => $failure_reasons,
+            'artifacts'       => array_filter(
+                array(
+                    'job_artifact_exports' => $exports,
+                    'fallback_pull_request' => is_array( $metadata['fallback_pull_request'] ?? null ) ? $metadata['fallback_pull_request'] : array(),
+                )
+            ),
+        );
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_result' ) ) {
     function homeboy_datamachine_agent_result( array $metrics, array $metadata, ?string $error = null ): array {
         if ( null !== $error ) {
             $metadata['error'] = $error;
+        }
+
+        if ( ! isset( $metadata['eval_artifact'] ) ) {
+            $metadata['eval_artifact'] = homeboy_datamachine_agent_eval_artifact( $metrics, $metadata, $error );
         }
 
         return array(
@@ -1961,6 +2066,7 @@ if ( ! empty( $config['dry_run'] ) ) {
             'flow_slug'           => homeboy_datamachine_agent_scalar( $config, 'flow_slug' ),
             'provider'            => homeboy_datamachine_agent_scalar( $config, 'provider', 'openai' ),
             'model'               => homeboy_datamachine_agent_scalar( $config, 'model', 'gpt-5.5' ),
+            'prompt'              => homeboy_datamachine_agent_scalar( $config, 'prompt' ),
             'fingerprints'        => homeboy_datamachine_agent_fingerprints( $config, homeboy_datamachine_agent_scalar( $config, 'prompt' ), homeboy_datamachine_agent_scalar( $config, 'bundle_path' ) ),
         )
     );
@@ -1982,6 +2088,7 @@ $metadata = array(
     'target_repo'   => homeboy_datamachine_agent_scalar( $config, 'target_repo' ),
     'provider'      => homeboy_datamachine_agent_scalar( $config, 'provider', 'openai' ),
     'model'         => homeboy_datamachine_agent_scalar( $config, 'model', 'gpt-5.5' ),
+    'prompt'        => $prompt,
     'fingerprints'  => homeboy_datamachine_agent_fingerprints( $config, $prompt, $bundle_path ),
     'bundle_exists' => '' !== $bundle_path && is_dir( $bundle_path ),
 );


### PR DESCRIPTION
## Summary
- Add a versioned `metadata.eval_artifact` envelope to Data Machine agent workload results.
- Include normalized run, subject, agent, model, prompt, runtime, workspace, transcript, grade, metrics, failure reason, and artifact sections.
- Cover the schema in PHP-only smoke coverage and the Playground runner smoke assertions.

Fixes #625

## Tests
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`

## Notes
- `bash wordpress/scripts/agent/datamachine-agent-runner-smoke.sh` currently fails before the workload runs with a Playground bootstrap path error writing `/wordpress/wp-content/plugins/playground-workloads/.pg-bench-result.txt`; the new assertion is still present for environments where that smoke reaches the workload.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the schema envelope, wired result metadata, and added smoke assertions under Chris's direction.