### PR TITLE
Support block theme builds

### DIFF
--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -533,8 +533,15 @@ validate_build() {
         fi
 
     elif [ "$PROJECT_TYPE" = "theme" ]; then
-        # Theme validation: Check for essential files
-        local required_files=("index.php" "style.css")
+        # Theme validation: classic themes need index.php; block themes use
+        # templates/index.html as the fallback template.
+        local required_files=("style.css")
+        if [ -f "$staging_dir/theme.json" ]; then
+            required_files+=("templates/index.html")
+        else
+            required_files+=("index.php")
+        fi
+
         local missing_files=()
 
         for file in "${required_files[@]}"; do


### PR DESCRIPTION
## Summary
- Update the WordPress build validator so block themes do not require `index.php`.
- Validate block themes with `style.css`, `theme.json`, and `templates/index.html`; keep `index.php` required for classic themes.

## Verification
- `bash -n wordpress/scripts/build/build.sh`
- Built `intelligence-horse-theme` from `origin/trunk` without `index.php` using the patched build script.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated the WordPress build validation rule and verified it against a real block theme package.