### PR TITLE
Preserve eval rule metadata

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -122,6 +122,22 @@ name: Data Machine Agent CI (reusable)
         description: JSON config for exporting bundle-file artifacts back to the target repo. Set include_job_artifacts true to also commit full job artifact JSON.
         type: string
         default: "{}"
+      rules:
+        description: JSON object describing eval rule policy for the task. Preserved in metadata.eval_artifact.rules.
+        type: string
+        default: "{}"
+      general_rules:
+        description: JSON array of reusable eval rule IDs that apply to the task.
+        type: string
+        default: "[]"
+      task_rules:
+        description: JSON array of task-specific eval rule IDs that apply to the task.
+        type: string
+        default: "[]"
+      probes:
+        description: JSON object of zero-weight behavioral probes to preserve in eval metadata.
+        type: string
+        default: "{}"
       comment_pr_summary:
         type: boolean
         default: false
@@ -535,6 +551,10 @@ jobs:
           STEP_BUDGET: ${{ inputs.step_budget }}
           TIME_BUDGET_MS: ${{ inputs.time_budget_ms }}
           ARTIFACT_EXPORT_CONFIG: ${{ inputs.artifact_export_config }}
+          RULES: ${{ inputs.rules }}
+          GENERAL_RULES: ${{ inputs.general_rules }}
+          TASK_RULES: ${{ inputs.task_rules }}
+          PROBES: ${{ inputs.probes }}
           DRY_RUN: ${{ inputs.dry_run }}
           EXTRA_WP_CONFIG_DEFINES: ${{ inputs.extra_wp_config_defines }}
           EXTRA_PLAYGROUND_FILE_MOUNTS: ${{ inputs.extra_playground_file_mounts }}
@@ -631,6 +651,10 @@ jobs:
           flow_step_patches_json="$(validate_json_input flow_step_patches array "$FLOW_STEP_PATCHES")"
           runner_workspace_json="$(validate_json_input runner_workspace object "$RUNNER_WORKSPACE_CONFIG")"
           fallback_pull_request_json="$(validate_json_input fallback_pull_request object "$FALLBACK_PULL_REQUEST")"
+          rules_json="$(validate_json_input rules object "$RULES")"
+          general_rules_json="$(validate_json_input general_rules array "$GENERAL_RULES")"
+          task_rules_json="$(validate_json_input task_rules array "$TASK_RULES")"
+          probes_json="$(validate_json_input probes object "$PROBES")"
           provider_register_function="$(jq -r '.register_function // ""' <<< "$provider_plugin_json")"
           provider_credentials_json="$(jq -c '.credentials // {}' <<< "$provider_plugin_json")"
           provider_bench_env_json="{}"
@@ -691,6 +715,10 @@ jobs:
             --argjson flowStepPatches "$flow_step_patches_json" \
             --argjson runnerWorkspace "$runner_workspace_json" \
             --argjson fallbackPullRequest "$fallback_pull_request_json" \
+            --argjson rules "$rules_json" \
+            --argjson generalRules "$general_rules_json" \
+            --argjson taskRules "$task_rules_json" \
+            --argjson probes "$probes_json" \
             '{
               component_id: "datamachine-agent-ci-driver",
               component_path: $componentPath,
@@ -737,6 +765,10 @@ jobs:
               flow_step_patches: $flowStepPatches,
               runner_workspace: $runnerWorkspace,
               fallback_pull_request: $fallbackPullRequest,
+              rules: $rules,
+              general_rules: $generalRules,
+              task_rules: $taskRules,
+              probes: $probes,
               execute_workflow_path: $executeWorkflowPath,
               success_requires_pr: $successRequiresPr,
               success_completion_outcomes: $successCompletionOutcomes,

--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -397,6 +397,9 @@ Supported fields:
   loop. The supported step types are still `php`, `ability`, and `wp-cli`.
 - `grader` or `grader_file`: PHP file appended after `run`, so grading happens
   after the action loop.
+- `rules`, `general_rules`, `task_rules`, and `probes`: copied into scenario
+  metadata so eval corpora can declare reusable policy and zero-weight
+  behavioral probes separately from grader reward math.
 - `tags`, `metadata`, and `limits`: copied into the BenchResults scenario
   envelope for reports, filtering, and downstream eval tooling.
 

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -104,6 +104,14 @@ if ( ! function_exists( 'homeboy_datamachine_agent_eval_artifact' ) ) {
             'grade'           => $grade,
             'metrics'         => $metrics,
             'failure_reasons' => $failure_reasons,
+            'rules'           => array_filter(
+                array(
+                    'general'       => is_array( $metadata['general_rules'] ?? null ) ? $metadata['general_rules'] : array(),
+                    'task_specific' => is_array( $metadata['task_rules'] ?? null ) ? $metadata['task_rules'] : array(),
+                    'all'           => is_array( $metadata['rules'] ?? null ) ? $metadata['rules'] : array(),
+                )
+            ),
+            'probes'          => is_array( $metadata['probes'] ?? null ) ? $metadata['probes'] : array(),
             'artifacts'       => array_filter(
                 array(
                     'job_artifact_exports' => $exports,
@@ -2091,6 +2099,10 @@ $metadata = array(
     'prompt'        => $prompt,
     'fingerprints'  => homeboy_datamachine_agent_fingerprints( $config, $prompt, $bundle_path ),
     'bundle_exists' => '' !== $bundle_path && is_dir( $bundle_path ),
+    'rules'         => is_array( $config['rules'] ?? null ) ? $config['rules'] : array(),
+    'general_rules' => is_array( $config['general_rules'] ?? null ) ? $config['general_rules'] : array(),
+    'task_rules'    => is_array( $config['task_rules'] ?? null ) ? $config['task_rules'] : array(),
+    'probes'        => is_array( $config['probes'] ?? null ) ? $config['probes'] : array(),
 );
 $execute_workflow_path = homeboy_datamachine_agent_scalar( $config, 'execute_workflow_path' );
 

--- a/wordpress/scripts/bench/bench-runner-playground.sh
+++ b/wordpress/scripts/bench/bench-runner-playground.sh
@@ -270,7 +270,11 @@ homeboy_playground_compile_scenario_manifests() {
                     prompt_file: $promptFile,
                     blueprint_file: $blueprintFile,
                     grader_file: $graderFile,
-                    limits: ($manifest.limits // {})
+                    limits: ($manifest.limits // {}),
+                    rules: ($manifest.rules // {}),
+                    general_rules: ($manifest.general_rules // $manifest.rules.general // []),
+                    task_rules: ($manifest.task_rules // $manifest.rules.task_specific // []),
+                    probes: ($manifest.probes // {})
                 })
             }
             | if .label == null then del(.label) else . end

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -433,7 +433,7 @@ function pg_bench_normalize_grade_check($check, int $index): array {
         'max_score' => $max_score,
     ];
 
-    foreach (['message', 'details', 'expected', 'actual'] as $field) {
+    foreach (['message', 'details', 'expected', 'actual', 'failure_reason'] as $field) {
         if (isset($check[$field]) && is_scalar($check[$field])) {
             $normalized[$field] = (string) $check[$field];
         }
@@ -483,11 +483,21 @@ function pg_bench_normalize_grader_payload(array $payload): ?array {
         $normalized_grade['failure'] = array_intersect_key($grade['failure'], array_flip(['type', 'message']));
     }
 
+    $failure_reasons = [];
+    if (isset($payload['failure_reasons']) && is_array($payload['failure_reasons']) && pg_bench_is_list($payload['failure_reasons'])) {
+        foreach ($payload['failure_reasons'] as $reason) {
+            if (is_scalar($reason) && trim((string) $reason) !== '') {
+                $failure_reasons[] = trim((string) $reason);
+            }
+        }
+    }
+
     return [
         'success' => $success,
         'reward' => $reward,
         'done' => $done,
         'grade' => $normalized_grade,
+        'failure_reasons' => array_values(array_unique($failure_reasons)),
     ];
 }
 
@@ -507,6 +517,7 @@ function pg_bench_apply_grader_payload(array $payload, array &$metrics, array &$
     $metadata['reward'] = $normalized['reward'];
     $metadata['done'] = $normalized['done'];
     $metadata['grade'] = $normalized['grade'];
+    $metadata['failure_reasons'] = $normalized['failure_reasons'];
 }
 
 function pg_bench_workload_tags($value): array {

--- a/wordpress/scripts/bench/playground-bench-scenario-manifest-smoke.sh
+++ b/wordpress/scripts/bench/playground-bench-scenario-manifest-smoke.sh
@@ -99,6 +99,15 @@ if [ "$prompt" != "Create a page containing valid navigation block markup." ] ||
 fi
 echo "✓ prompt file, grader file, and limits metadata emitted"
 
+general_rule=$(jq -r "$scenario | .metadata.general_rules[0] // \"missing\"" "$RESULTS_TMPFILE")
+task_rule=$(jq -r "$scenario | .metadata.task_rules[0] // \"missing\"" "$RESULTS_TMPFILE")
+probe=$(jq -r "$scenario | .metadata.probes.behavioral_fingerprints[0].id // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$general_rule" != "wordpress_editable_blocks" ] || [ "$task_rule" != "navigation_block_markup" ] || [ "$probe" != "block_shape_fingerprint" ]; then
+    echo "ERROR: manifest rule/probe metadata did not round-trip" >&2
+    exit 1
+fi
+echo "✓ rule and probe metadata emitted"
+
 tag=$(jq -r "$scenario | .tags[0] // \"missing\"" "$RESULTS_TMPFILE")
 if [ "$tag" != "blocks" ]; then
     echo "ERROR: expected first tag to be blocks, got $tag" >&2

--- a/wordpress/tests/fixtures/playground-scenario-manifest/scenarios/manifest-001.json
+++ b/wordpress/tests/fixtures/playground-scenario-manifest/scenarios/manifest-001.json
@@ -5,6 +5,18 @@
   "blueprint": "blueprint.json",
   "grader": "grader.php",
   "tags": ["blocks", "markup", "medium"],
+  "rules": {
+    "general": ["wordpress_editable_blocks"],
+    "task_specific": ["navigation_block_markup"]
+  },
+  "probes": {
+    "behavioral_fingerprints": [
+      {
+        "id": "block_shape_fingerprint",
+        "reward_weight": 0
+      }
+    ]
+  },
   "limits": {
     "max_turns": 8,
     "step_budget": 12,


### PR DESCRIPTION
## Summary
- Preserve scenario `rules`, `general_rules`, `task_rules`, and `probes` in Playground scenario metadata.
- Carry grader `failure_reason` and top-level `failure_reasons` through normalized BenchResults metadata.
- Expose rule/probe policy in the canonical Data Machine eval artifact and reusable agent CI inputs.

## Testing
- `bash -n wordpress/scripts/bench/bench-runner-playground.sh`
- `php -l wordpress/scripts/bench/playground-bench-runner.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `git diff --check`

## Notes
- `bash wordpress/scripts/bench/playground-bench-scenario-manifest-smoke.sh` could not run in this fresh worktree because `wordpress/node_modules/.bin/wp-playground-cli` is not installed. The smoke fixture/assertions were updated to cover the new rule/probe metadata once dependencies are present.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the eval metadata plumbing, smoke fixture assertions, docs updates, and local syntax validation; Chris remains responsible for review and merge.