### PR TITLE
Evaluate general rule results

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -403,6 +403,14 @@ Supported fields:
 - `tags`, `metadata`, and `limits`: copied into the BenchResults scenario
   envelope for reports, filtering, and downstream eval tooling.
 
+Data Machine agent workloads also evaluate known general rules against available
+runner evidence and expose the results under
+`metadata.eval_artifact.general_rule_results`. Initial executable general rules
+cover editable block failures, raw HTML/shortcode failures, speculative plugin
+packaging metadata, unsupported plugin author metadata, docs-standards failures
+when evidence is attached, and production-build parity when buildable asset paths
+changed.
+
 Relative manifest entries resolve from the component/corpus root. Relative
 references inside a manifest resolve from the manifest file's directory. Inline
 manifest objects resolve relative paths from the component root.

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -104,6 +104,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_eval_artifact' ) ) {
             'grade'           => $grade,
             'metrics'         => $metrics,
             'failure_reasons' => $failure_reasons,
+            'general_rule_results' => is_array( $metadata['general_rule_results'] ?? null ) ? $metadata['general_rule_results'] : array(),
             'rules'           => array_filter(
                 array(
                     'general'       => is_array( $metadata['general_rules'] ?? null ) ? $metadata['general_rules'] : array(),
@@ -119,6 +120,141 @@ if ( ! function_exists( 'homeboy_datamachine_agent_eval_artifact' ) ) {
                 )
             ),
         );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_normalized_list' ) ) {
+    function homeboy_datamachine_agent_normalized_list( $value ): array {
+        if ( ! is_array( $value ) ) {
+            return array();
+        }
+
+        return array_values(
+            array_unique(
+                array_filter(
+                    array_map(
+                        static fn( $item ) => is_scalar( $item ) ? trim( (string) $item ) : '',
+                        $value
+                    ),
+                    static fn( string $item ) => '' !== $item
+                )
+            )
+        );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_rule_result' ) ) {
+    function homeboy_datamachine_agent_rule_result( string $id, string $status, string $message, array $failure_reasons = array(), array $evidence = array() ): array {
+        return array_filter(
+            array(
+                'id'              => $id,
+                'status'          => $status,
+                'passed'          => 'passed' === $status,
+                'message'         => $message,
+                'failure_reasons' => homeboy_datamachine_agent_normalized_list( $failure_reasons ),
+                'evidence'        => $evidence,
+            ),
+            static fn( $value ) => array() !== $value && '' !== $value
+        );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_rule_matches_failures' ) ) {
+    function homeboy_datamachine_agent_rule_matches_failures( array $failure_reasons, array $watched_reasons ): array {
+        return array_values( array_intersect( $failure_reasons, $watched_reasons ) );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_asset_paths' ) ) {
+    function homeboy_datamachine_agent_asset_paths( array $paths ): array {
+        return array_values(
+            array_filter(
+                $paths,
+                static function ( string $path ): bool {
+                    return (bool) preg_match( '/\.(css|scss|sass|less|js|jsx|ts|tsx|mjs|cjs)$/i', $path ) || 'theme.json' === basename( $path );
+                }
+            )
+        );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_evaluate_general_rules' ) ) {
+    function homeboy_datamachine_agent_evaluate_general_rules( array $metadata, array $config ): array {
+        $general_rules = homeboy_datamachine_agent_normalized_list( $metadata['general_rules'] ?? $config['general_rules'] ?? array() );
+        if ( empty( $general_rules ) ) {
+            return array();
+        }
+
+        $failure_reasons = homeboy_datamachine_agent_normalized_list( $metadata['failure_reasons'] ?? array() );
+        $capture         = is_array( $metadata['runner_workspace_capture'] ?? null ) ? $metadata['runner_workspace_capture'] : array();
+        $status          = is_array( $capture['status'] ?? null ) ? $capture['status'] : array();
+        $changed_paths   = homeboy_datamachine_agent_normalized_list( $status['files'] ?? array() );
+        $results         = array();
+
+        foreach ( $general_rules as $rule ) {
+            if ( 'wordpress_editable_blocks' === $rule ) {
+                $matched = homeboy_datamachine_agent_rule_matches_failures(
+                    $failure_reasons,
+                    array( 'missing_block_markup', 'missing_required_blocks', 'invalid_block', 'raw_html_or_fallback_block', 'shortcode_markup' )
+                );
+                $results[] = empty( $matched )
+                    ? homeboy_datamachine_agent_rule_result( $rule, 'passed', 'No editable-block structure failures were reported.' )
+                    : homeboy_datamachine_agent_rule_result( $rule, 'failed', 'Editable-block structure failures were reported.', $matched );
+                continue;
+            }
+
+            if ( 'no_raw_html_or_shortcodes' === $rule ) {
+                $matched = homeboy_datamachine_agent_rule_matches_failures( $failure_reasons, array( 'raw_html_or_fallback_block', 'shortcode_markup' ) );
+                $results[] = empty( $matched )
+                    ? homeboy_datamachine_agent_rule_result( $rule, 'passed', 'No raw HTML, fallback block, or shortcode failures were reported.' )
+                    : homeboy_datamachine_agent_rule_result( $rule, 'failed', 'Raw HTML, fallback block, or shortcode failures were reported.', $matched );
+                continue;
+            }
+
+            if ( 'no_speculative_plugin_packaging' === $rule ) {
+                $matched = homeboy_datamachine_agent_rule_matches_failures( $failure_reasons, array( 'speculative_plugin_packaging_metadata' ) );
+                $results[] = empty( $matched )
+                    ? homeboy_datamachine_agent_rule_result( $rule, 'passed', 'No speculative plugin packaging metadata failures were reported.' )
+                    : homeboy_datamachine_agent_rule_result( $rule, 'failed', 'Speculative plugin packaging metadata was reported.', $matched );
+                continue;
+            }
+
+            if ( 'supported_plugin_author_metadata' === $rule ) {
+                $matched = homeboy_datamachine_agent_rule_matches_failures( $failure_reasons, array( 'unsupported_plugin_author' ) );
+                $results[] = empty( $matched )
+                    ? homeboy_datamachine_agent_rule_result( $rule, 'passed', 'No unsupported plugin author metadata failures were reported.' )
+                    : homeboy_datamachine_agent_rule_result( $rule, 'failed', 'Unsupported plugin author metadata was reported.', $matched );
+                continue;
+            }
+
+            if ( 'wordpress_docs_standards' === $rule ) {
+                $matched = homeboy_datamachine_agent_rule_matches_failures( $failure_reasons, array( 'wordpress_docs_standards_violation', 'missing_phpdoc', 'invalid_phpdoc_format' ) );
+                $results[] = empty( $matched )
+                    ? homeboy_datamachine_agent_rule_result( $rule, 'not_evaluated', 'No WordPress docs-standards evidence was attached to this run.' )
+                    : homeboy_datamachine_agent_rule_result( $rule, 'failed', 'WordPress docs-standards failures were reported.', $matched );
+                continue;
+            }
+
+            if ( 'production_build_when_assets_change' === $rule ) {
+                $asset_paths = homeboy_datamachine_agent_asset_paths( $changed_paths );
+                if ( empty( $asset_paths ) ) {
+                    $results[] = homeboy_datamachine_agent_rule_result( $rule, 'passed', 'No buildable asset paths changed.', array(), array( 'changed_asset_paths' => array() ) );
+                } else {
+                    $results[] = homeboy_datamachine_agent_rule_result(
+                        $rule,
+                        'failed',
+                        'Buildable asset paths changed, but no production build evidence was attached to this run.',
+                        array( 'production_build_not_run' ),
+                        array( 'changed_asset_paths' => $asset_paths )
+                    );
+                }
+                continue;
+            }
+
+            $results[] = homeboy_datamachine_agent_rule_result( $rule, 'not_evaluated', 'No executable evaluator is registered for this general rule.' );
+        }
+
+        return $results;
     }
 }
 
@@ -2373,6 +2509,18 @@ $metadata += array(
     'file_written'          => $file_written,
     'job_artifact_exports'    => $job_artifact_exports,
 );
+
+$metadata['general_rule_results'] = homeboy_datamachine_agent_evaluate_general_rules( $metadata, $config );
+$general_rule_failures = array();
+foreach ( $metadata['general_rule_results'] as $rule_result ) {
+    if ( ! is_array( $rule_result ) || 'failed' !== (string) ( $rule_result['status'] ?? '' ) ) {
+        continue;
+    }
+    $general_rule_failures = array_merge( $general_rule_failures, homeboy_datamachine_agent_normalized_list( $rule_result['failure_reasons'] ?? array() ) );
+}
+if ( ! empty( $general_rule_failures ) ) {
+    $metadata['failure_reasons'] = array_values( array_unique( array_merge( homeboy_datamachine_agent_normalized_list( $metadata['failure_reasons'] ?? array() ), $general_rule_failures ) ) );
+}
 
 if ( ! empty( $runner_workspace_capture['enabled'] ) && ! empty( $runner_workspace_capture['error'] ) && empty( $runner_workspace_capture['changed'] ) ) {
     return homeboy_datamachine_agent_result( array( 'runner_workspace_captured' => 0 ), $metadata, (string) $runner_workspace_capture['error'] );

--- a/wordpress/scripts/agent/update-runner-workspace-pr.cjs
+++ b/wordpress/scripts/agent/update-runner-workspace-pr.cjs
@@ -86,6 +86,7 @@ const engineData = metadata.engine_data || {};
 const runnerCapture = metadata.runner_workspace_capture || {};
 const runnerStatus = runnerCapture.status || {};
 const grade = scenario.grade || metadata.grade || engineData.grade || {};
+const evalArtifact = metadata.eval_artifact || {};
 const staticTemplateValues = artifactExport.pr_template_values || {};
 const taskId = staticTemplateValues.task_id || config.task_id || config.workload_id || scenarioId;
 const taskLabel = staticTemplateValues.task_label || config.task_label || config.workload_label || taskId;
@@ -117,6 +118,14 @@ const checkRows = Array.isArray(grade.checks) ? grade.checks.map((check) => [
   scalar(check.max_score),
   check.message || '',
 ]) : [];
+
+const generalRuleRows = Array.isArray(evalArtifact.general_rule_results)
+  ? evalArtifact.general_rule_results.map((rule) => [
+    rule.id || '',
+    rule.status || '',
+    rule.message || '',
+  ])
+  : [];
 
 const toolRows = Array.isArray(engineData.tool_execution_summary) ? engineData.tool_execution_summary.map((tool) => [
   scalar(tool.turn_count),
@@ -154,6 +163,7 @@ const values = {
   changed_file_count: scalar(runnerStatus.dirty || (Array.isArray(runnerStatus.files) ? runnerStatus.files.length : '')),
   result_table: markdownTable(['Field', 'Value'], resultRows),
   checks_table: markdownTable(['Check', 'Passed', 'Score', 'Max', 'Message'], checkRows),
+  general_rules_table: markdownTable(['Rule', 'Status', 'Message'], generalRuleRows),
   tools_table: markdownTable(['Turn', 'Tool', 'Success'], toolRows),
   links_table: markdownTable(['Artifact', 'Location'], linkRows),
   paths: writtenPaths.length ? `- \`${writtenPaths.join('`\n- `')}\`` : '_None recorded._',

--- a/wordpress/scripts/bench/playground-bench-runner.php
+++ b/wordpress/scripts/bench/playground-bench-runner.php
@@ -578,6 +578,121 @@ function pg_bench_merge_workload_payload($payload, array &$metrics, array &$arti
     pg_bench_apply_grader_payload($payload, $metrics, $metadata);
 }
 
+function pg_bench_normalized_string_list($value): array {
+    if (!is_array($value) || !pg_bench_is_list($value)) {
+        return [];
+    }
+
+    $items = [];
+    foreach ($value as $item) {
+        if (is_scalar($item) && trim((string) $item) !== '') {
+            $items[] = trim((string) $item);
+        }
+    }
+
+    return array_values(array_unique($items));
+}
+
+function pg_bench_general_rule_result(string $id, string $status, string $message, array $failure_reasons = [], array $evidence = []): array {
+    return array_filter([
+        'id' => $id,
+        'status' => $status,
+        'passed' => $status === 'passed',
+        'message' => $message,
+        'failure_reasons' => pg_bench_normalized_string_list($failure_reasons),
+        'evidence' => $evidence,
+    ], static fn($value) => $value !== [] && $value !== '');
+}
+
+function pg_bench_matched_failure_reasons(array $failure_reasons, array $watched): array {
+    return array_values(array_intersect($failure_reasons, $watched));
+}
+
+function pg_bench_asset_paths(array $paths): array {
+    return array_values(array_filter($paths, static function (string $path): bool {
+        return (bool) preg_match('/\.(css|scss|sass|less|js|jsx|ts|tsx|mjs|cjs)$/i', $path) || basename($path) === 'theme.json';
+    }));
+}
+
+function pg_bench_evaluate_general_rules(array &$metadata): void {
+    $general_rules = pg_bench_normalized_string_list($metadata['general_rules'] ?? []);
+    if (empty($general_rules)) {
+        return;
+    }
+
+    $failure_reasons = pg_bench_normalized_string_list($metadata['failure_reasons'] ?? []);
+    $capture = is_array($metadata['runner_workspace_capture'] ?? null) ? $metadata['runner_workspace_capture'] : [];
+    $status = is_array($capture['status'] ?? null) ? $capture['status'] : [];
+    $changed_paths = pg_bench_normalized_string_list($status['files'] ?? []);
+    $results = [];
+
+    foreach ($general_rules as $rule) {
+        if ($rule === 'wordpress_editable_blocks') {
+            $matched = pg_bench_matched_failure_reasons($failure_reasons, ['missing_block_markup', 'missing_required_blocks', 'invalid_block', 'raw_html_or_fallback_block', 'shortcode_markup']);
+            $results[] = empty($matched)
+                ? pg_bench_general_rule_result($rule, 'passed', 'No editable-block structure failures were reported.')
+                : pg_bench_general_rule_result($rule, 'failed', 'Editable-block structure failures were reported.', $matched);
+            continue;
+        }
+
+        if ($rule === 'no_raw_html_or_shortcodes') {
+            $matched = pg_bench_matched_failure_reasons($failure_reasons, ['raw_html_or_fallback_block', 'shortcode_markup']);
+            $results[] = empty($matched)
+                ? pg_bench_general_rule_result($rule, 'passed', 'No raw HTML, fallback block, or shortcode failures were reported.')
+                : pg_bench_general_rule_result($rule, 'failed', 'Raw HTML, fallback block, or shortcode failures were reported.', $matched);
+            continue;
+        }
+
+        if ($rule === 'no_speculative_plugin_packaging') {
+            $matched = pg_bench_matched_failure_reasons($failure_reasons, ['speculative_plugin_packaging_metadata']);
+            $results[] = empty($matched)
+                ? pg_bench_general_rule_result($rule, 'passed', 'No speculative plugin packaging metadata failures were reported.')
+                : pg_bench_general_rule_result($rule, 'failed', 'Speculative plugin packaging metadata was reported.', $matched);
+            continue;
+        }
+
+        if ($rule === 'supported_plugin_author_metadata') {
+            $matched = pg_bench_matched_failure_reasons($failure_reasons, ['unsupported_plugin_author']);
+            $results[] = empty($matched)
+                ? pg_bench_general_rule_result($rule, 'passed', 'No unsupported plugin author metadata failures were reported.')
+                : pg_bench_general_rule_result($rule, 'failed', 'Unsupported plugin author metadata was reported.', $matched);
+            continue;
+        }
+
+        if ($rule === 'wordpress_docs_standards') {
+            $matched = pg_bench_matched_failure_reasons($failure_reasons, ['wordpress_docs_standards_violation', 'missing_phpdoc', 'invalid_phpdoc_format']);
+            $results[] = empty($matched)
+                ? pg_bench_general_rule_result($rule, 'not_evaluated', 'No WordPress docs-standards evidence was attached to this run.')
+                : pg_bench_general_rule_result($rule, 'failed', 'WordPress docs-standards failures were reported.', $matched);
+            continue;
+        }
+
+        if ($rule === 'production_build_when_assets_change') {
+            $asset_paths = pg_bench_asset_paths($changed_paths);
+            $results[] = empty($asset_paths)
+                ? pg_bench_general_rule_result($rule, 'passed', 'No buildable asset paths changed.', [], ['changed_asset_paths' => []])
+                : pg_bench_general_rule_result($rule, 'failed', 'Buildable asset paths changed, but no production build evidence was attached to this run.', ['production_build_not_run'], ['changed_asset_paths' => $asset_paths]);
+            continue;
+        }
+
+        $results[] = pg_bench_general_rule_result($rule, 'not_evaluated', 'No executable evaluator is registered for this general rule.');
+    }
+
+    $metadata['general_rule_results'] = $results;
+    foreach ($results as $result) {
+        if (($result['status'] ?? '') !== 'failed') {
+            continue;
+        }
+        $failure_reasons = array_merge($failure_reasons, pg_bench_normalized_string_list($result['failure_reasons'] ?? []));
+    }
+    $metadata['failure_reasons'] = array_values(array_unique($failure_reasons));
+
+    if (isset($metadata['eval_artifact']) && is_array($metadata['eval_artifact'])) {
+        $metadata['eval_artifact']['general_rule_results'] = $results;
+        $metadata['eval_artifact']['failure_reasons'] = $metadata['failure_reasons'];
+    }
+}
+
 function pg_bench_step_is_grader(array $step): bool {
     return (isset($step['grader']) && $step['grader'] === true)
         || (isset($step['role']) && is_scalar($step['role']) && (string) $step['role'] === 'grader');
@@ -950,6 +1065,8 @@ function pg_bench_run_configured_workload(array $workload, string $plugin_path):
         }
         pg_bench_merge_workload_payload($result, $metrics, $artifacts, $metadata);
     }
+
+    pg_bench_evaluate_general_rules($metadata);
 
     return [
         'metrics' => $metrics,


### PR DESCRIPTION
## Summary
- Evaluate known eval general rules into `metadata.eval_artifact.general_rule_results` using grader failure reasons and runner workspace evidence.
- Fold failed general-rule reasons back into top-level `failure_reasons`.
- Add `{general_rules_table}` to generated runner workspace PR templates.

## Testing
- `bash -n wordpress/scripts/bench/bench-runner-playground.sh`
- `php -l wordpress/scripts/bench/playground-bench-runner.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `node --check wordpress/scripts/agent/update-runner-workspace-pr.cjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the general-rule evaluator, PR template projection, docs updates, and local validation; Chris remains responsible for review and merge.