### PR TITLE
Suggest WordPress REST preload declarations

### DIFF
--- a/wordpress/lib/page-profiler.js
+++ b/wordpress/lib/page-profiler.js
@@ -236,6 +236,45 @@ function restDiagnosticKeyWithQueryParam(row, param, value) {
 	return restDiagnosticKey(row?.method, restWaterfallUrlWithQueryParam(row?.url || row?.path || row?.normalizedUrl, param, value));
 }
 
+function quotePhpString(value) {
+	return `'${String(value || '').replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+function phpPreloadDeclaration(method, url) {
+	const normalizedMethod = normalizeRestMethod(method);
+	const normalizedUrl = normalizeRestUrl(url);
+	if (!normalizedUrl) {
+		return '';
+	}
+	if (normalizedMethod === 'GET') {
+		return quotePhpString(normalizedUrl);
+	}
+	return `array( ${quotePhpString(normalizedUrl)}, ${quotePhpString(normalizedMethod)} )`;
+}
+
+function compactRestRows(rows) {
+	return rows.map((row) => ({
+		url: row.url,
+		method: row.method,
+		status: row.status,
+		durationMs: row.durationMs,
+		hit: row.hit,
+		nextUrl: row.nextUrl || undefined,
+		payloadBytes: row.payloadBytes,
+	}));
+}
+
+function uniquePreloadSuggestions(suggestions) {
+	const seen = new Set();
+	return suggestions.filter((suggestion) => {
+		if (!suggestion?.declaration || seen.has(suggestion.declaration)) {
+			return false;
+		}
+		seen.add(suggestion.declaration);
+		return true;
+	});
+}
+
 function restRoutePath(url) {
 	return normalizeRestWaterfallUrl(url).split('?', 1)[0];
 }
@@ -914,6 +953,7 @@ function diagnoseWordPressRestPreloadMisses(input = {}) {
 	const preloadedRowsByExactKey = new Map();
 	const preloadedRowsByLocaleFreeKey = new Map();
 	const apiFetchByExactKey = new Map();
+	const apiFetchByLocaleFreeKey = new Map();
 	const preloadChecksByExactKey = new Map();
 	const preloadChecksByLocaleFreeKey = new Map();
 
@@ -945,6 +985,7 @@ function diagnoseWordPressRestPreloadMisses(input = {}) {
 
 	for (const attempt of apiFetchAttempts) {
 		addToMap(apiFetchByExactKey, restKey(attempt), attempt);
+		addToMap(apiFetchByLocaleFreeKey, restDiagnosticKeyWithoutQueryParam(attempt, '_locale'), attempt);
 	}
 
 	for (const check of preloadChecks) {
@@ -966,6 +1007,40 @@ function diagnoseWordPressRestPreloadMisses(input = {}) {
 		const fetchAllPreloads = preloadsByExactKey.get(fetchAllKey) || preloadsByFetchAllKey.get(exactKey) || preloadsByFetchAllKey.get(localeFreeKey) || [];
 		const exactPreloadChecks = preloadChecksByExactKey.get(exactKey) || [];
 		const localeFreePreloadChecks = preloadChecksByLocaleFreeKey.get(localeFreeKey) || [];
+		const exactApiFetchAttempts = apiFetchByExactKey.get(exactKey) || [];
+		const localeFreeApiFetchAttempts = apiFetchByLocaleFreeKey.get(localeFreeKey) || [];
+		const serverDeclarationSuggestions = uniquePreloadSuggestions([
+			...localeFreePreloadChecks.map((check) => ({
+				reason: 'api-fetch-pre-middleware-key',
+				url: check.url,
+				method: check.method,
+				declaration: phpPreloadDeclaration(check.method, check.url),
+			})),
+			...localeFreeApiFetchAttempts.filter((attempt) => attempt.source === 'apiFetch').map((attempt) => ({
+				reason: 'api-fetch-pre-middleware-key',
+				url: attempt.url,
+				method: attempt.method,
+				declaration: phpPreloadDeclaration(attempt.method, attempt.url),
+			})),
+			{
+				reason: 'visible-network-url',
+				url: row.url,
+				method: row.method,
+				declaration: phpPreloadDeclaration(row.method, row.url),
+			},
+		]);
+		const attribution = {
+			visibleNetwork: {
+				url: row.url,
+				method: row.method,
+				status: row.status,
+				durationMs: row.durationMs,
+			},
+			apiFetchPreMiddleware: compactRestRows(localeFreeApiFetchAttempts.filter((attempt) => attempt.source === 'apiFetch')),
+			preloadChecks: compactRestRows([...exactPreloadChecks, ...localeFreePreloadChecks]),
+			preloadPayloadEntries: compactRestRows([...exactPreloads, ...localeFreePreloads, ...fetchAllPreloads]),
+			serverDeclarationSuggestions,
+		};
 
 		if (exactPreloads.length > 0) {
 			reasons.push(exactPreloadChecks.some((check) => check.hit === false) ? 'exact-preload-check-missed' : 'exact-preload-still-networked');
@@ -1017,12 +1092,14 @@ function diagnoseWordPressRestPreloadMisses(input = {}) {
 			durationMs: row.durationMs,
 			reasons,
 			primaryReason: reasons[0],
-			apiFetchAttempts: (apiFetchByExactKey.get(exactKey) || []).map((attempt) => ({
+			apiFetchAttempts: exactApiFetchAttempts.map((attempt) => ({
 				url: attempt.url,
 				method: attempt.method,
 				status: attempt.status,
 				durationMs: attempt.durationMs,
 			})),
+			attribution,
+			serverDeclarationSuggestions,
 			evidence,
 		};
 	});

--- a/wordpress/tests/page-profiler-smoke.js
+++ b/wordpress/tests/page-profiler-smoke.js
@@ -339,6 +339,13 @@ const summary = summarizeResourceTimings(resources.map((entry) => ({ ...entry, k
 	});
 	assert.equal(exactMissDiagnostics.rows[0].primaryReason, 'exact-preload-check-missed');
 	assert.equal(exactMissDiagnostics.rows[0].evidence.exactPreloadChecks[0].hit, false);
+	assert.equal(exactMissDiagnostics.rows[0].serverDeclarationSuggestions[0].declaration, "'/wp/v2/taxonomies?_locale=user&context=view'");
+	const optionsDeclarationDiagnostics = diagnoseWordPressRestPreloadMisses({
+		networkRows: [{ url: 'https://example.test/wp-json/wp/v2/settings?_locale=user', method: 'OPTIONS' }],
+		apiFetchAttempts: [{ source: 'apiFetch', path: '/wp/v2/settings', method: 'OPTIONS' }],
+		preloadChecks: [{ path: '/wp/v2/settings', method: 'OPTIONS', hit: false, nextUrl: '/wp/v2/settings' }],
+	});
+	assert.equal(optionsDeclarationDiagnostics.rows[0].serverDeclarationSuggestions[0].declaration, "array( '/wp/v2/settings', 'OPTIONS' )");
 	const payloadBudgetResult = diagnoseWordPressPageProfile({
 		id: 'payload-budget',
 		readyMs: 500,


### PR DESCRIPTION
## Summary
- Add preload attribution details for remaining REST network rows, including visible network request, pre-middleware apiFetch keys, preload checks, and matching preload payload entries.
- Add method-aware `serverDeclarationSuggestions` so OPTIONS requests can point to tuple declarations like `array( '/wp/v2/settings', 'OPTIONS' )`.
- Cover declaration suggestions in the WordPress page profiler smoke test.

## Verification
- `node wordpress/tests/page-profiler-smoke.js`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@expose-preload-checks --extension nodejs --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the preload attribution and declaration-suggestion tooling plus smoke coverage and verification workflow for Chris to review and test.