### PR TITLE
Declare WordPress content deploy path root

### DIFF
--- a/tests/wordpress-remote-path-inference-smoke.sh
+++ b/tests/wordpress-remote-path-inference-smoke.sh
@@ -23,5 +23,10 @@ assert_contains "$MANIFEST" '"remote_path": "wp-content/plugins/{{dir_name}}"'
 assert_contains "$MANIFEST" '"file": "style.css"'
 assert_contains "$MANIFEST" '"text": "Theme Name:"'
 assert_contains "$MANIFEST" '"remote_path": "wp-content/themes/{{dir_name}}"'
+assert_contains "$MANIFEST" '"path_roots"'
+assert_contains "$MANIFEST" '"path_prefix": "wp-content/"'
+assert_contains "$MANIFEST" '"root": "wp_content"'
+assert_contains "$MANIFEST" '"strip_prefix": true'
+assert_contains "$MANIFEST" '"detect_command": "wp eval '\''echo WP_CONTENT_DIR;'\''"'
 
 echo "wordpress remote path inference smoke passed"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -141,6 +141,14 @@
       "/wp-content/themes",
       "/wp-content/mu-plugins"
     ],
+    "path_roots": [
+      {
+        "path_prefix": "wp-content/",
+        "root": "wp_content",
+        "strip_prefix": true,
+        "detect_command": "wp eval 'echo WP_CONTENT_DIR;'"
+      }
+    ],
     "owner_hints": [
       {
         "path_contains": "wp-content/",


### PR DESCRIPTION
## Summary
- Declares a WordPress deploy path root for `wp-content/` paths.
- Maps portable plugin/theme/mu-plugin paths to `wp_content` and strips the prefix before deploy resolution.
- Adds a detection command using `WP_CONTENT_DIR` so split root/content installs can be resolved dynamically by Homeboy.

Related to https://github.com/Extra-Chill/homeboy/issues/2507

## Testing
- `bash tests/wordpress-remote-path-inference-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the WordPress extension manifest update; Chris retains responsibility for review and merge.