### PR TITLE
Add reusable actions run-once gate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,5 +1,48 @@
 # Data Machine Agent CI reusable workflow
 
+## Actions Run Once
+
+`actions-run-once.yml` is a reusable idempotency gate for workflows that must
+process one evidence packet exactly once. Call it in `check` mode before the
+expensive job, then call it in `mark` mode after validation and fan-out reach
+the point that must not repeat.
+
+Use a stable evidence key built from the caller domain, such as
+`source_repo/source_pr/source_head_sha/site_slug/fanout_kind`. The workflow
+normalizes the key to a GitHub Actions cache marker and returns `should_run`.
+Pair the caller workflow with a concurrency group derived from the same key so
+parallel events cannot both pass the check before the marker is saved.
+
+```yaml
+jobs:
+  preflight:
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/actions-run-once.yml@main
+    with:
+      mode: check
+      idempotency_key: static-validation/${{ github.repository }}/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/${{ matrix.site }}
+
+  validate:
+    needs: preflight
+    if: needs.preflight.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./validate-and-dispatch-fanout
+
+  mark:
+    needs: validate
+    if: always() && needs.preflight.outputs.should_run == 'true'
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/actions-run-once.yml@main
+    with:
+      mode: mark
+      idempotency_key: static-validation/${{ github.repository }}/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/${{ matrix.site }}
+```
+
+`mark` should run only after the evidence has been consumed or fan-out has been
+scheduled. If the caller wants failed validations to be retryable, mark only on
+success. If the caller wants one validation attempt per immutable evidence key,
+mark with `if: always()` after the validation job starts producing reviewer
+evidence.
+
 `datamachine-agent-ci.yml` wraps the common GitHub Actions shape for running a
 Data Machine agent bundle in WordPress Playground. Consumers provide bundle and
 flow identifiers, a prompt, and optional output projections. By default the

--- a/.github/workflows/actions-run-once.yml
+++ b/.github/workflows/actions-run-once.yml
@@ -1,0 +1,125 @@
+# Reusable idempotency gate for GitHub Actions workflows.
+#
+# Consumers call this workflow in `check` mode before expensive validation or
+# agent fan-out, then call it again in `mark` mode after the work reaches the
+# point that must not repeat. Pair the caller workflow with a concurrency group
+# using the same logical key so parallel runs for the same evidence cannot both
+# pass the preflight before the marker is saved.
+name: Actions Run Once (reusable)
+
+'on':
+  workflow_call:
+    inputs:
+      idempotency_key:
+        description: Logical evidence key, for example repo/pr/head-sha/site/fanout-kind.
+        type: string
+        required: true
+      mode:
+        description: "check returns should_run; mark saves the marker for this key."
+        type: string
+        default: check
+      marker_prefix:
+        description: Stable prefix for the cache marker namespace.
+        type: string
+        default: homeboy-run-once
+      marker_path:
+        description: Path used for the cache marker payload.
+        type: string
+        default: .homeboy-run-once-marker
+    outputs:
+      should_run:
+        description: true when no marker exists for the key.
+        value: ${{ jobs.run-once.outputs.should_run }}
+      marker_exists:
+        description: true when a marker already exists for the key.
+        value: ${{ jobs.run-once.outputs.marker_exists }}
+      marker_key:
+        description: Normalized cache marker key.
+        value: ${{ jobs.run-once.outputs.marker_key }}
+
+jobs:
+  run-once:
+    name: Run-once ${{ inputs.mode }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    outputs:
+      should_run: ${{ steps.result.outputs.should_run }}
+      marker_exists: ${{ steps.result.outputs.marker_exists }}
+      marker_key: ${{ steps.normalize.outputs.marker_key }}
+    steps:
+      - name: Validate mode
+        shell: bash
+        env:
+          MODE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+          case "$MODE" in
+            check|mark) ;;
+            *)
+              echo "mode must be 'check' or 'mark' (got '$MODE')." >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Normalize marker key
+        id: normalize
+        shell: bash
+        env:
+          IDEMPOTENCY_KEY: ${{ inputs.idempotency_key }}
+          MARKER_PREFIX: ${{ inputs.marker_prefix }}
+          MARKER_PATH: ${{ inputs.marker_path }}
+          MODE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+          digest=$(printf '%s' "$IDEMPOTENCY_KEY" | sha256sum | awk '{ print $1 }')
+          marker_key="${MARKER_PREFIX}-${digest}"
+          mkdir -p "$(dirname "$MARKER_PATH")"
+          jq -nc \
+            --arg key "$IDEMPOTENCY_KEY" \
+            --arg marker_key "$marker_key" \
+            --arg mode "$MODE" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
+            '{idempotency_key:$key, marker_key:$marker_key, mode:$mode, run_id:$run_id, run_attempt:$run_attempt}' \
+            > "$MARKER_PATH"
+          echo "marker_key=$marker_key" >> "$GITHUB_OUTPUT"
+
+      - name: Check marker
+        id: restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ inputs.marker_path }}
+          key: ${{ steps.normalize.outputs.marker_key }}
+          lookup-only: true
+
+      - name: Save marker
+        if: inputs.mode == 'mark' && steps.restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ inputs.marker_path }}
+          key: ${{ steps.normalize.outputs.marker_key }}
+
+      - name: Set outputs
+        id: result
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.restore.outputs.cache-hit }}
+          MODE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+          marker_exists=false
+          should_run=true
+
+          if [ "$CACHE_HIT" = "true" ]; then
+            marker_exists=true
+            should_run=false
+          fi
+
+          if [ "$MODE" = "mark" ]; then
+            should_run=false
+          fi
+
+          echo "marker_exists=$marker_exists" >> "$GITHUB_OUTPUT"
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Add a reusable `actions-run-once.yml` workflow for idempotent GitHub Actions preflight and marker writes.
- Support a two-phase `check`/`mark` contract keyed by caller-provided evidence such as source repo, PR, head SHA, site slug, and fan-out kind.
- Document the caller pattern, including pairing the evidence key with workflow concurrency to prevent parallel duplicate fan-out.

## Testing
- Parsed `.github/workflows/actions-run-once.yml` with Ruby YAML.
- Ran `git diff --check`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the reusable workflow and documentation for the run-once evidence gate. Chris remains responsible for review and merge decisions.