### PR TITLE
Seal Data Machine eval replay artifacts

### DIFF
--- a/wordpress/scripts/agent/build-replay-bundle-smoke.sh
+++ b/wordpress/scripts/agent/build-replay-bundle-smoke.sh
@@ -6,32 +6,49 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-replay-results.XXXXXX.json")
 CONFIG_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-replay-config.XXXXXX.json")
 BUNDLE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-replay-bundles.XXXXXX")
+TRANSCRIPT_FILE="$BUNDLE_DIR/session-transcript.jsonl"
 cleanup() {
-    rm -f "$RESULTS_TMPFILE" "$CONFIG_TMPFILE"
-    rm -rf "$BUNDLE_DIR"
+	rm -f "$RESULTS_TMPFILE" "$CONFIG_TMPFILE"
+	rm -rf "$BUNDLE_DIR"
 }
 trap cleanup EXIT
 
-jq -n '{
-    component_id: "example-plugin",
-    iterations: 1,
-    scenarios: [
-        {
-            id: "agent-failure",
-            source: "config",
-            metrics: { config_present_mean: 1 },
-            artifacts: {
-                transcript_json: { path: "transcripts/session.json", kind: "json" }
-            },
-            metadata: {
-                provider: "openai",
-                model: "gpt-example",
-                job_status: "failed",
-                error: "grader failed",
-                github_token: "should-not-leak"
-            }
-        }
-    ]
+printf '%s\n' '{"role":"user","content":"Run the task."}' > "$TRANSCRIPT_FILE"
+
+jq -n --arg transcriptFile "$TRANSCRIPT_FILE" '{
+	component_id: "example-plugin",
+	iterations: 1,
+	scenarios: [
+		{
+			id: "agent-failure",
+			source: "config",
+			metrics: { config_present_mean: 1 },
+			artifacts: {
+				transcript_json: { path: $transcriptFile, kind: "jsonl" }
+			},
+			metadata: {
+				provider: "openai",
+				model: "gpt-example",
+				job_status: "failed",
+				error: "grader failed",
+				tool_audit_events: [
+					{
+						schema_version: 1,
+						type: "tool_call",
+						turn_count: 1,
+						tool_name: "client/search_docs",
+						tool_source: "client",
+						parameters_sha256: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+						parameters_redacted: true,
+						success: true,
+						result_status: "success",
+						result_sha256: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+					}
+				],
+				github_token: "should-not-leak"
+			}
+		}
+	]
 }' > "$RESULTS_TMPFILE"
 
 jq -n '{
@@ -84,9 +101,25 @@ fi
 
 final_state_available=$(jq -r '.final_state.available' "$BUNDLE_PATH")
 if [ "$final_state_available" != "false" ]; then
-    echo "ERROR: expected final_state.available=false" >&2
-    cat "$BUNDLE_PATH" >&2
-    exit 1
+	echo "ERROR: expected final_state.available=false" >&2
+	cat "$BUNDLE_PATH" >&2
+	exit 1
+fi
+
+sealed_status=$(jq -r '.sealed_eval_artifact.status' "$BUNDLE_PATH")
+tool_audit_count=$(jq -r '.sealed_eval_artifact.replay.tool_audit_event_count' "$BUNDLE_PATH")
+transcript_hash=$(jq -r '.sealed_eval_artifact.hashes.artifact_hashes.transcript_json.sha256 // "missing"' "$BUNDLE_PATH")
+envelope_hash=$(jq -r '.sealed_eval_artifact.hashes.envelope // "missing"' "$BUNDLE_PATH")
+missing_seams=$(jq -r '.sealed_eval_artifact.integration_seams | join(",")' "$BUNDLE_PATH")
+if [ "$sealed_status" != "ready_for_replay" ] || [ "$tool_audit_count" != "1" ] || [ "$transcript_hash" = "missing" ] || [ "$envelope_hash" = "missing" ]; then
+	echo "ERROR: sealed eval artifact envelope incomplete" >&2
+	cat "$BUNDLE_PATH" >&2
+	exit 1
+fi
+if [[ "$missing_seams" != *"datamachine_provenance"* ]] || [[ "$missing_seams" != *"datamachine_code_policy_attestation"* ]]; then
+	echo "ERROR: expected missing provenance/policy seams to remain explicit" >&2
+	cat "$BUNDLE_PATH" >&2
+	exit 1
 fi
 
 echo "✓ replay bundle smoke test PASSED"

--- a/wordpress/scripts/agent/build-replay-bundle.js
+++ b/wordpress/scripts/agent/build-replay-bundle.js
@@ -7,6 +7,7 @@
  */
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 
 const SECRET_KEY_PATTERN = /(secret|token|password|passwd|authorization|cookie|nonce|api[_-]?key|access[_-]?key|private[_-]?key|github[_-]?token|openai[_-]?api[_-]?key)/i;
 
@@ -64,6 +65,39 @@ function compactObject(entries) {
 	return Object.fromEntries(Object.entries(entries).filter(([, value]) => value !== undefined && value !== null && value !== ''));
 }
 
+function stableValue(value) {
+	if (Array.isArray(value)) {
+		return value.map((entry) => stableValue(entry));
+	}
+	if (value && typeof value === 'object') {
+		return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableValue(value[key])]));
+	}
+	return value;
+}
+
+function sha256Buffer(buffer) {
+	return `sha256:${crypto.createHash('sha256').update(buffer).digest('hex')}`;
+}
+
+function sha256Json(value) {
+	return sha256Buffer(Buffer.from(JSON.stringify(stableValue(value)), 'utf8'));
+}
+
+function fileSha256(filePath) {
+	return sha256Buffer(fs.readFileSync(filePath));
+}
+
+function isRemoteReference(referencePath) {
+	return /^https?:\/\//i.test(String(referencePath || ''));
+}
+
+function resolveLocalArtifactPath(referencePath, resultsPath) {
+	if (!referencePath || path.isAbsolute(referencePath) || isRemoteReference(referencePath)) {
+		return referencePath || '';
+	}
+	return path.resolve(path.dirname(resultsPath), referencePath);
+}
+
 function resolveReviewUrl(config, scenario) {
 	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
 	return metadata.playground_review_url || metadata.review_url || config.playground_review_url || config.review_url || null;
@@ -96,13 +130,175 @@ function transcriptReferences(config, scenario) {
 	return references;
 }
 
-function buildBundle(results, scenario, config, bundlePath) {
+function artifactReferences(scenario, config, bundlePath) {
+	const artifacts = scenario.artifacts && typeof scenario.artifacts === 'object' ? scenario.artifacts : {};
+	const references = [];
+
+	for (const [name, artifact] of Object.entries(artifacts)) {
+		if (artifact && typeof artifact === 'object' && artifact.path) {
+			references.push({ name, path: artifact.path, kind: artifact.kind || 'artifact', required: /transcript|episode|replay|grade/i.test(name) });
+		}
+	}
+
+	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
+	for (const [name, referencePath] of Object.entries({
+		transcript_json: metadata.transcript_json,
+		transcript_summary: metadata.transcript_summary,
+		action_log: metadata.action_log,
+	})) {
+		if (referencePath) {
+			references.push({ name, path: referencePath, kind: 'metadata', required: /transcript|action/.test(name) });
+		}
+	}
+
+	if (config.transcript_dir) {
+		references.push({ name: 'transcript_dir', path: config.transcript_dir, kind: 'directory', required: false });
+	}
+	if (bundlePath) {
+		references.push({ name: 'replay_bundle', path: bundlePath, kind: 'json', required: false });
+	}
+
+	return references;
+}
+
+function hashArtifactReferences(references, resultsPath) {
+	const hashes = {};
+	const issues = [];
+	for (const reference of references) {
+		if (!reference.path) {
+			continue;
+		}
+		const normalizedPath = String(reference.path);
+		if (isRemoteReference(normalizedPath)) {
+			if (reference.required) {
+				issues.push({ type: 'remote_required_artifact', name: reference.name, path: normalizedPath });
+			}
+			continue;
+		}
+
+		const localPath = resolveLocalArtifactPath(normalizedPath, resultsPath);
+		if (!fs.existsSync(localPath) || !fs.statSync(localPath).isFile()) {
+			if (reference.required) {
+				issues.push({ type: 'missing_required_artifact', name: reference.name, path: normalizedPath });
+			}
+			continue;
+		}
+
+		hashes[reference.name] = {
+			path: normalizedPath,
+			sha256: fileSha256(localPath),
+			bytes: fs.statSync(localPath).size,
+		};
+	}
+
+	return { hashes, issues };
+}
+
+function normalizeToolAuditEvents(metadata) {
+	const evalArtifact = metadata.eval_artifact && typeof metadata.eval_artifact === 'object' ? metadata.eval_artifact : {};
+	const replay = evalArtifact.replay && typeof evalArtifact.replay === 'object' ? evalArtifact.replay : {};
+	const candidates = [metadata.tool_audit_events, replay.tool_audit_events];
+	const events = candidates.find((entry) => Array.isArray(entry)) || [];
+
+	return events.filter((event) => event && typeof event === 'object').map((event, index) => compactObject({
+		schema_version: event.schema_version || 1,
+		type: event.type || 'tool_call',
+		step_index: index,
+		actor: event.actor || 'agent',
+		turn_count: event.turn_count,
+		tool_name: event.tool_name,
+		tool_source: event.tool_source,
+		parameters_sha256: event.parameters_sha256,
+		parameters_redacted: event.parameters_redacted !== false,
+		success: event.success === true,
+		result_status: event.result_status || (event.success === true ? 'success' : 'error'),
+		result_sha256: event.result_sha256,
+		error_type: event.error_type,
+	}));
+}
+
+function buildSealedEnvelope(results, scenario, config, bundlePath, artifactIntegrity) {
+	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
+	const evalArtifact = metadata.eval_artifact && typeof metadata.eval_artifact === 'object' ? metadata.eval_artifact : {};
+	const fingerprints = metadata.fingerprints && typeof metadata.fingerprints === 'object' ? metadata.fingerprints : {};
+	const toolAuditEvents = normalizeToolAuditEvents(metadata);
+	const missingSeams = [];
+	const attestation = evalArtifact.attestation && typeof evalArtifact.attestation === 'object' ? evalArtifact.attestation : {};
+	const existingSeams = Array.isArray(attestation.integration_seams) ? attestation.integration_seams : [];
+	missingSeams.push(...existingSeams);
+	if (!attestation.datamachine_provenance || Object.keys(attestation.datamachine_provenance).length === 0) {
+		missingSeams.push('datamachine_provenance');
+	}
+	if (!attestation.datamachine_code_policy_attestation || Object.keys(attestation.datamachine_code_policy_attestation).length === 0) {
+		missingSeams.push('datamachine_code_policy_attestation');
+	}
+	if (toolAuditEvents.length === 0) {
+		missingSeams.push('agents_api_tool_audit_events');
+	}
+	const workflowRunUrl = metadata.workflow_run_url || (evalArtifact.run && evalArtifact.run.workflow_run_url) || (
+		process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
+			? `${process.env.GITHUB_SERVER_URL || 'https://github.com'}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+			: ''
+	);
+
+	return redact({
+		schema_name: 'homeboy.sealed_eval_artifact',
+		schema_version: 1,
+		generated_at: new Date().toISOString(),
+		status: artifactIntegrity.issues.length === 0 && toolAuditEvents.length > 0 ? 'ready_for_replay' : 'incomplete',
+		runner: compactObject({
+			ref: process.env.GITHUB_SHA || config.runner_ref || metadata.runner_ref,
+			workflow_run_url: workflowRunUrl,
+			job_id: process.env.GITHUB_JOB || config.github_job,
+		}),
+		run: compactObject({
+			job_id: metadata.job_id || (evalArtifact.run && evalArtifact.run.job_id),
+			job_status: metadata.job_status || (evalArtifact.run && evalArtifact.run.job_status),
+			success_status: metadata.success_status || (evalArtifact.run && evalArtifact.run.success_status),
+		}),
+		task: compactObject({
+			id: metadata.task_id || config.task_id || config.workload_id || scenario.id,
+			label: metadata.task_label || config.task_label || config.workload_label || scenario.label,
+		}),
+		model: compactObject({
+			provider: config.provider || metadata.provider,
+			model: config.model || metadata.model,
+		}),
+		hashes: compactObject({
+			prompt: fingerprints.prompt || (evalArtifact.hashes && evalArtifact.hashes.prompt) || (config.prompt ? { sha256: `sha256:${crypto.createHash('sha256').update(config.prompt).digest('hex')}`, bytes: Buffer.byteLength(config.prompt) } : undefined),
+			bundle: fingerprints.bundle || (evalArtifact.hashes && evalArtifact.hashes.bundle),
+			tool_policy: fingerprints.tool_policy || (evalArtifact.hashes && evalArtifact.hashes.tool_policy),
+			reset: config.reset_hash || metadata.reset_hash || undefined,
+			artifact_hashes: artifactIntegrity.hashes,
+		}),
+		grade: evalArtifact.grade || metadata.grade || {},
+		failure_reasons: evalArtifact.failure_reasons || metadata.failure_reasons || [],
+		termination: evalArtifact.termination || compactObject({ state: metadata.job_status, truncated: metadata.truncated === true }),
+		replay: {
+			format: 'jsonl',
+			tool_audit_events_source: 'Agents API result.tool_audit_events',
+			tool_audit_event_count: toolAuditEvents.length,
+			tool_audit_events: toolAuditEvents,
+		},
+		artifacts: {
+			references: artifactReferences(scenario, config, bundlePath),
+			hashes: artifactIntegrity.hashes,
+			issues: artifactIntegrity.issues,
+		},
+		integration_seams: Array.from(new Set(missingSeams.filter(Boolean))),
+	});
+}
+
+function buildBundle(results, scenario, config, bundlePath, resultsPath) {
 	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
 	const reviewUrl = resolveReviewUrl(config, scenario);
+	const references = artifactReferences(scenario, config, bundlePath);
+	const artifactIntegrity = hashArtifactReferences(references, resultsPath);
 
 	return redact({
 		schema_version: 1,
 		generated_at: new Date().toISOString(),
+		sealed_eval_artifact: buildSealedEnvelope(results, scenario, config, bundlePath, artifactIntegrity),
 		scenario_id: scenario.id,
 		component_id: results.component_id || results.component,
 		replay_bundle_path: bundlePath,
@@ -201,7 +397,10 @@ function main() {
 	const filename = `${safeId(args.scenario)}-replay-bundle.json`;
 	const bundlePath = path.join(args.outputDir, filename);
 	const relativeBundlePath = path.relative(path.dirname(args.results), bundlePath) || filename;
-	const bundle = buildBundle(results, scenario, config, relativeBundlePath);
+	const bundle = buildBundle(results, scenario, config, relativeBundlePath, args.results);
+	if (bundle.sealed_eval_artifact && bundle.sealed_eval_artifact.hashes) {
+		bundle.sealed_eval_artifact.hashes.envelope = sha256Json(bundle.sealed_eval_artifact);
+	}
 	fs.writeFileSync(bundlePath, `${JSON.stringify(bundle, null, 2)}\n`);
 
 	if (args.updateResults) {

--- a/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
@@ -95,6 +95,20 @@ namespace {
                 'agent_slug'  => 'forced-parameters-smoke-agent',
                 'flow_slug'   => 'forced-parameters-smoke-flow',
                 'prompt'      => 'Dry-run the fingerprint smoke test.',
+                'tool_audit_events' => array(
+                    array(
+                        'schema_version'      => 1,
+                        'type'                => 'tool_call',
+                        'turn_count'          => 1,
+                        'tool_name'           => 'client/search_docs',
+                        'tool_source'         => 'client',
+                        'parameters_sha256'   => 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                        'parameters_redacted' => true,
+                        'success'             => true,
+                        'result_status'       => 'success',
+                        'result_sha256'       => 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                    ),
+                ),
             )
         )
     );
@@ -125,6 +139,17 @@ namespace {
 
     if ( 'forced-parameters-smoke-agent' !== ( $eval_artifact['agent']['slug'] ?? '' ) ) {
         fwrite( STDERR, "Expected eval artifact to identify the agent slug.\n" );
+        exit( 1 );
+    }
+
+    if ( 1 !== ( $eval_artifact['replay']['tool_audit_event_count'] ?? 0 ) ) {
+        fwrite( STDERR, "Expected eval artifact to include Agents API tool audit events.\n" );
+        exit( 1 );
+    }
+
+    $integration_seams = $eval_artifact['attestation']['integration_seams'] ?? array();
+    if ( ! in_array( 'datamachine_provenance', $integration_seams, true ) || ! in_array( 'datamachine_code_policy_attestation', $integration_seams, true ) ) {
+        fwrite( STDERR, "Expected eval artifact to expose missing provenance and policy attestation seams.\n" );
         exit( 1 );
     }
 

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -14,41 +14,58 @@ use DataMachine\Core\JobArtifacts;
 use DataMachine\Core\PluginSettings;
 
 if ( ! function_exists( 'homeboy_datamachine_agent_eval_artifact' ) ) {
-    function homeboy_datamachine_agent_eval_artifact( array $metrics, array $metadata, ?string $error = null ): array {
-        $engine_data = is_array( $metadata['engine_data'] ?? null ) ? $metadata['engine_data'] : array();
-        $grade       = is_array( $metadata['grade'] ?? null ) ? $metadata['grade'] : ( is_array( $engine_data['grade'] ?? null ) ? $engine_data['grade'] : array() );
-        $workspace   = is_array( $metadata['runner_workspace'] ?? null ) ? $metadata['runner_workspace'] : array();
-        $capture     = is_array( $metadata['runner_workspace_capture'] ?? null ) ? $metadata['runner_workspace_capture'] : array();
-        $transcript  = is_array( $metadata['transcript_artifacts'] ?? null ) ? $metadata['transcript_artifacts'] : array();
-        $exports     = is_array( $metadata['job_artifact_exports'] ?? null ) ? $metadata['job_artifact_exports'] : array();
+	function homeboy_datamachine_agent_eval_artifact( array $metrics, array $metadata, ?string $error = null ): array {
+		$engine_data = is_array( $metadata['engine_data'] ?? null ) ? $metadata['engine_data'] : array();
+		$grade       = is_array( $metadata['grade'] ?? null ) ? $metadata['grade'] : ( is_array( $engine_data['grade'] ?? null ) ? $engine_data['grade'] : array() );
+		$workspace   = is_array( $metadata['runner_workspace'] ?? null ) ? $metadata['runner_workspace'] : array();
+		$capture     = is_array( $metadata['runner_workspace_capture'] ?? null ) ? $metadata['runner_workspace_capture'] : array();
+		$transcript  = is_array( $metadata['transcript_artifacts'] ?? null ) ? $metadata['transcript_artifacts'] : array();
+		$exports     = is_array( $metadata['job_artifact_exports'] ?? null ) ? $metadata['job_artifact_exports'] : array();
+		$fingerprints = is_array( $metadata['fingerprints'] ?? null ) ? $metadata['fingerprints'] : array();
+		$tool_audit_events = is_array( $metadata['tool_audit_events'] ?? null ) ? $metadata['tool_audit_events'] : array();
+		$policy_attestation = is_array( $metadata['datamachine_code_policy_attestation'] ?? null ) ? $metadata['datamachine_code_policy_attestation'] : array();
+		$provenance = is_array( $metadata['datamachine_provenance'] ?? null ) ? $metadata['datamachine_provenance'] : array();
 
-        $failure_reasons = array();
-        if ( is_array( $metadata['failure_reasons'] ?? null ) ) {
-            $failure_reasons = array_values( array_filter( array_map( 'strval', $metadata['failure_reasons'] ) ) );
-        }
+		$failure_reasons = array();
+		if ( is_array( $metadata['failure_reasons'] ?? null ) ) {
+			$failure_reasons = array_values( array_filter( array_map( 'strval', $metadata['failure_reasons'] ) ) );
+		}
         if ( null !== $error && empty( $failure_reasons ) ) {
             $failure_reasons[] = 'runner_error';
         }
 
         $prompt = (string) ( $metadata['prompt'] ?? '' );
 
-        return array(
-            'schema_version'  => 1,
-            'schema_name'     => 'homeboy.agent_eval_result',
-            'run'             => array_filter(
-                array(
-                    'job_id'         => (int) ( $metadata['job_id'] ?? 0 ),
-                    'job_status'     => (string) ( $metadata['job_status'] ?? '' ),
-                    'success_status' => (string) ( $metadata['success_status'] ?? '' ),
-                    'error'          => null !== $error ? $error : (string) ( $metadata['error_message'] ?? '' ),
-                ),
-                static fn( $value ) => '' !== $value && 0 !== $value && null !== $value
-            ),
-            'subject'         => array_filter(
-                array(
-                    'target_repo' => (string) ( $metadata['target_repo'] ?? '' ),
-                    'bundle_path' => (string) ( $metadata['bundle_path'] ?? '' ),
-                    'flow_slug'   => (string) ( $metadata['flow_slug'] ?? '' ),
+		return array(
+			'schema_version'  => 1,
+			'schema_name'     => 'homeboy.agent_eval_result',
+			'envelope'        => array(
+				'schema_name'    => 'homeboy.sealed_eval_artifact',
+				'schema_version' => 1,
+				'status'         => empty( $tool_audit_events ) ? 'incomplete' : 'ready_for_replay',
+			),
+			'run'             => array_filter(
+				array(
+					'job_id'         => (int) ( $metadata['job_id'] ?? 0 ),
+					'job_status'     => (string) ( $metadata['job_status'] ?? '' ),
+					'success_status' => (string) ( $metadata['success_status'] ?? '' ),
+					'error'          => null !== $error ? $error : (string) ( $metadata['error_message'] ?? '' ),
+					'workflow_run_url' => homeboy_datamachine_agent_workflow_run_url(),
+				),
+				static fn( $value ) => '' !== $value && 0 !== $value && null !== $value
+			),
+			'task'            => array_filter(
+				array(
+					'id'    => (string) ( $metadata['task_id'] ?? $metadata['workload_id'] ?? $metadata['flow_slug'] ?? '' ),
+					'label' => (string) ( $metadata['task_label'] ?? $metadata['workload_label'] ?? '' ),
+				),
+				static fn( $value ) => '' !== $value
+			),
+			'subject'         => array_filter(
+				array(
+					'target_repo' => (string) ( $metadata['target_repo'] ?? '' ),
+					'bundle_path' => (string) ( $metadata['bundle_path'] ?? '' ),
+					'flow_slug'   => (string) ( $metadata['flow_slug'] ?? '' ),
                 ),
                 static fn( $value ) => '' !== $value
             ),
@@ -66,18 +83,41 @@ if ( ! function_exists( 'homeboy_datamachine_agent_eval_artifact' ) ) {
                 ),
                 static fn( $value ) => '' !== $value
             ),
-            'prompt'          => array_filter(
-                array(
-                    'sha256' => '' !== $prompt ? hash( 'sha256', $prompt ) : '',
-                    'bytes'  => strlen( $prompt ),
-                ),
-                static fn( $value ) => '' !== $value && 0 !== $value
-            ),
-            'runtime'         => array_filter(
-                array(
-                    'job_id'                   => (int) ( $metadata['job_id'] ?? 0 ),
-                    'pipeline_id'              => (int) ( $metadata['pipeline_id'] ?? 0 ),
-                    'flow_id'                  => (int) ( $metadata['flow_id'] ?? 0 ),
+			'prompt'          => array_filter(
+				array(
+					'sha256' => '' !== $prompt ? hash( 'sha256', $prompt ) : '',
+					'bytes'  => strlen( $prompt ),
+				),
+				static fn( $value ) => '' !== $value && 0 !== $value
+			),
+			'hashes'          => array_filter(
+				array(
+					'prompt'      => is_array( $fingerprints['prompt'] ?? null ) ? $fingerprints['prompt'] : array(),
+					'bundle'      => is_array( $fingerprints['bundle'] ?? null ) ? $fingerprints['bundle'] : array(),
+					'tool_policy' => is_array( $fingerprints['tool_policy'] ?? null ) ? $fingerprints['tool_policy'] : array(),
+				),
+				static fn( $value ) => array() !== $value
+			),
+			'attestation'     => array_filter(
+				array(
+					'datamachine_provenance'             => $provenance,
+					'datamachine_code_policy_attestation' => $policy_attestation,
+					'integration_seams'                  => array_values(
+						array_filter(
+							array(
+								empty( $provenance ) ? 'datamachine_provenance' : '',
+								empty( $policy_attestation ) ? 'datamachine_code_policy_attestation' : '',
+							)
+						)
+					),
+				),
+				static fn( $value ) => array() !== $value
+			),
+			'runtime'         => array_filter(
+				array(
+					'job_id'                   => (int) ( $metadata['job_id'] ?? 0 ),
+					'pipeline_id'              => (int) ( $metadata['pipeline_id'] ?? 0 ),
+					'flow_id'                  => (int) ( $metadata['flow_id'] ?? 0 ),
                     'transcript_session_id'    => (string) ( $metadata['transcript_session_id'] ?? '' ),
                     'completion_outcome_satisfied' => (bool) ( $metadata['completion_outcome_satisfied'] ?? false ),
                 ),
@@ -93,17 +133,32 @@ if ( ! function_exists( 'homeboy_datamachine_agent_eval_artifact' ) ) {
                 ),
                 static fn( $value ) => '' !== $value && false !== $value
             ),
-            'transcript'      => array_filter(
-                array(
-                    'session_id' => (string) ( $transcript['session_id'] ?? $metadata['transcript_session_id'] ?? '' ),
-                    'json'       => (string) ( $transcript['json'] ?? '' ),
-                    'summary'    => (string) ( $transcript['summary'] ?? '' ),
-                ),
-                static fn( $value ) => '' !== $value
-            ),
-            'grade'           => $grade,
-            'metrics'         => $metrics,
-            'failure_reasons' => $failure_reasons,
+			'transcript'      => array_filter(
+				array(
+					'session_id' => (string) ( $transcript['session_id'] ?? $metadata['transcript_session_id'] ?? '' ),
+					'json'       => (string) ( $transcript['json'] ?? '' ),
+					'summary'    => (string) ( $transcript['summary'] ?? '' ),
+				),
+				static fn( $value ) => '' !== $value
+			),
+			'replay'          => array(
+				'tool_audit_events_available' => ! empty( $tool_audit_events ),
+				'tool_audit_event_count'      => count( $tool_audit_events ),
+				'tool_audit_events'           => $tool_audit_events,
+				'source'                      => 'agents_api_tool_audit_events',
+			),
+			'termination'     => array_filter(
+				array(
+					'state'      => (string) ( $metadata['job_status'] ?? '' ),
+					'success'    => 'completed' === (string) ( $metadata['job_status'] ?? '' ),
+					'truncated'  => ! empty( $metadata['truncated'] ),
+					'budget'     => (string) ( $engine_data['budget'] ?? '' ),
+				),
+				static fn( $value ) => '' !== $value && false !== $value
+			),
+			'grade'           => $grade,
+			'metrics'         => $metrics,
+			'failure_reasons' => $failure_reasons,
             'general_rule_results' => is_array( $metadata['general_rule_results'] ?? null ) ? $metadata['general_rule_results'] : array(),
             'rules'           => array_filter(
                 array(
@@ -521,9 +576,9 @@ if ( ! function_exists( 'homeboy_datamachine_agent_pr_opened' ) ) {
         return is_array( $engine_data[ $tool_results_key ] ?? null ) ? $engine_data[ $tool_results_key ] : array();
     }
 
-    function homeboy_datamachine_agent_set_tool_results( array $engine_data, array $config, array $tool_results ): array {
-        $tool_results_key = homeboy_datamachine_agent_scalar( $config, 'tool_results_key', 'github_tool_results' );
-        $engine_key       = homeboy_datamachine_agent_scalar( $config, 'engine_key' );
+	function homeboy_datamachine_agent_set_tool_results( array $engine_data, array $config, array $tool_results ): array {
+		$tool_results_key = homeboy_datamachine_agent_scalar( $config, 'tool_results_key', 'github_tool_results' );
+		$engine_key       = homeboy_datamachine_agent_scalar( $config, 'engine_key' );
 
         if ( '' !== $engine_key ) {
             if ( ! isset( $engine_data[ $engine_key ] ) || ! is_array( $engine_data[ $engine_key ] ) ) {
@@ -533,12 +588,54 @@ if ( ! function_exists( 'homeboy_datamachine_agent_pr_opened' ) ) {
             return $engine_data;
         }
 
-        $engine_data[ $tool_results_key ] = $tool_results;
-        return $engine_data;
-    }
+		$engine_data[ $tool_results_key ] = $tool_results;
+		return $engine_data;
+	}
 
-    function homeboy_datamachine_agent_completion_outcomes( array $engine_data, array $config ): array {
-        $sources = $engine_data;
+	function homeboy_datamachine_agent_tool_audit_events( array $engine_data, array $config ): array {
+		$engine_key = homeboy_datamachine_agent_scalar( $config, 'engine_key' );
+		$sources    = array( $engine_data );
+		if ( '' !== $engine_key && is_array( $engine_data[ $engine_key ] ?? null ) ) {
+			$sources[] = $engine_data[ $engine_key ];
+		}
+
+		$events = array();
+		foreach ( $sources as $source ) {
+			if ( ! is_array( $source['tool_audit_events'] ?? null ) ) {
+				continue;
+			}
+			foreach ( $source['tool_audit_events'] as $event ) {
+				if ( ! is_array( $event ) ) {
+					continue;
+				}
+				$events[] = $event;
+			}
+		}
+
+		return $events;
+	}
+
+	function homeboy_datamachine_agent_set_tool_audit_events( array $engine_data, array $config, array $tool_audit_events ): array {
+		$tool_audit_events = array_values( array_filter( $tool_audit_events, 'is_array' ) );
+		if ( empty( $tool_audit_events ) ) {
+			return $engine_data;
+		}
+
+		$engine_key = homeboy_datamachine_agent_scalar( $config, 'engine_key' );
+		if ( '' !== $engine_key ) {
+			if ( ! isset( $engine_data[ $engine_key ] ) || ! is_array( $engine_data[ $engine_key ] ) ) {
+				$engine_data[ $engine_key ] = array();
+			}
+			$engine_data[ $engine_key ]['tool_audit_events'] = $tool_audit_events;
+			return $engine_data;
+		}
+
+		$engine_data['tool_audit_events'] = $tool_audit_events;
+		return $engine_data;
+	}
+
+	function homeboy_datamachine_agent_completion_outcomes( array $engine_data, array $config ): array {
+		$sources = $engine_data;
         $engine_key = homeboy_datamachine_agent_scalar( $config, 'engine_key' );
         if ( '' !== $engine_key && is_array( $engine_data[ $engine_key ] ?? null ) ) {
             $sources = $engine_data[ $engine_key ];
@@ -590,9 +687,10 @@ if ( ! function_exists( 'homeboy_datamachine_agent_pr_opened' ) ) {
             return $engine_data;
         }
 
-        $tool_results = homeboy_datamachine_agent_tool_results( $engine_data, $config );
-        $completed_outcomes = homeboy_datamachine_agent_completion_outcomes( $engine_data, $config );
-        $child_summaries = array();
+		$tool_results = homeboy_datamachine_agent_tool_results( $engine_data, $config );
+		$tool_audit_events = homeboy_datamachine_agent_tool_audit_events( $engine_data, $config );
+		$completed_outcomes = homeboy_datamachine_agent_completion_outcomes( $engine_data, $config );
+		$child_summaries = array();
 
         foreach ( $child_jobs as $child_job ) {
             if ( ! is_array( $child_job ) ) {
@@ -600,13 +698,17 @@ if ( ! function_exists( 'homeboy_datamachine_agent_pr_opened' ) ) {
             }
 
             $child_engine_data = is_array( $child_job['engine_data'] ?? null ) ? $child_job['engine_data'] : array();
-            $child_tool_results = homeboy_datamachine_agent_tool_results( $child_engine_data, $config );
-            if ( ! empty( $child_tool_results ) ) {
-                $tool_results = array_merge( $tool_results, $child_tool_results );
-            }
-            $child_completion_outcomes = homeboy_datamachine_agent_completion_outcomes( $child_engine_data, $config );
-            if ( ! empty( $child_completion_outcomes ) ) {
-                $completed_outcomes = array_merge( $completed_outcomes, $child_completion_outcomes );
+			$child_tool_results = homeboy_datamachine_agent_tool_results( $child_engine_data, $config );
+			if ( ! empty( $child_tool_results ) ) {
+				$tool_results = array_merge( $tool_results, $child_tool_results );
+			}
+			$child_tool_audit_events = homeboy_datamachine_agent_tool_audit_events( $child_engine_data, $config );
+			if ( ! empty( $child_tool_audit_events ) ) {
+				$tool_audit_events = array_merge( $tool_audit_events, $child_tool_audit_events );
+			}
+			$child_completion_outcomes = homeboy_datamachine_agent_completion_outcomes( $child_engine_data, $config );
+			if ( ! empty( $child_completion_outcomes ) ) {
+				$completed_outcomes = array_merge( $completed_outcomes, $child_completion_outcomes );
             }
 
             $child_summaries[] = array(
@@ -616,8 +718,9 @@ if ( ! function_exists( 'homeboy_datamachine_agent_pr_opened' ) ) {
             );
         }
 
-        $engine_data = homeboy_datamachine_agent_set_tool_results( $engine_data, $config, $tool_results );
-        $engine_data = homeboy_datamachine_agent_set_completion_outcomes( $engine_data, $config, $completed_outcomes );
+		$engine_data = homeboy_datamachine_agent_set_tool_results( $engine_data, $config, $tool_results );
+		$engine_data = homeboy_datamachine_agent_set_tool_audit_events( $engine_data, $config, $tool_audit_events );
+		$engine_data = homeboy_datamachine_agent_set_completion_outcomes( $engine_data, $config, $completed_outcomes );
         $engine_data['child_jobs'] = $child_summaries;
         return $engine_data;
     }
@@ -2201,19 +2304,24 @@ if ( empty( $config ) ) {
 if ( ! empty( $config['dry_run'] ) ) {
     return homeboy_datamachine_agent_result(
         array( 'config_present' => 1, 'dry_run' => 1 ),
-        array(
-            'bundle_path'         => homeboy_datamachine_agent_scalar( $config, 'bundle_path' ),
-            'bundle_repo'         => homeboy_datamachine_agent_scalar( $config, 'bundle_repo' ),
-            'bundle_ref'          => homeboy_datamachine_agent_scalar( $config, 'bundle_ref' ),
-            'bundle_path_in_repo' => homeboy_datamachine_agent_scalar( $config, 'bundle_path_in_repo' ),
-            'agent_slug'          => homeboy_datamachine_agent_scalar( $config, 'agent_slug' ),
-            'flow_slug'           => homeboy_datamachine_agent_scalar( $config, 'flow_slug' ),
-            'provider'            => homeboy_datamachine_agent_scalar( $config, 'provider', 'openai' ),
-            'model'               => homeboy_datamachine_agent_scalar( $config, 'model', 'gpt-5.5' ),
-            'prompt'              => homeboy_datamachine_agent_scalar( $config, 'prompt' ),
-            'fingerprints'        => homeboy_datamachine_agent_fingerprints( $config, homeboy_datamachine_agent_scalar( $config, 'prompt' ), homeboy_datamachine_agent_scalar( $config, 'bundle_path' ) ),
-        )
-    );
+		array(
+			'bundle_path'         => homeboy_datamachine_agent_scalar( $config, 'bundle_path' ),
+			'bundle_repo'         => homeboy_datamachine_agent_scalar( $config, 'bundle_repo' ),
+			'bundle_ref'          => homeboy_datamachine_agent_scalar( $config, 'bundle_ref' ),
+			'bundle_path_in_repo' => homeboy_datamachine_agent_scalar( $config, 'bundle_path_in_repo' ),
+			'task_id'             => homeboy_datamachine_agent_scalar( $config, 'task_id', homeboy_datamachine_agent_scalar( $config, 'workload_id' ) ),
+			'task_label'          => homeboy_datamachine_agent_scalar( $config, 'task_label', homeboy_datamachine_agent_scalar( $config, 'workload_label' ) ),
+			'agent_slug'          => homeboy_datamachine_agent_scalar( $config, 'agent_slug' ),
+			'flow_slug'           => homeboy_datamachine_agent_scalar( $config, 'flow_slug' ),
+			'provider'            => homeboy_datamachine_agent_scalar( $config, 'provider', 'openai' ),
+			'model'               => homeboy_datamachine_agent_scalar( $config, 'model', 'gpt-5.5' ),
+			'prompt'              => homeboy_datamachine_agent_scalar( $config, 'prompt' ),
+			'tool_audit_events'   => is_array( $config['tool_audit_events'] ?? null ) ? $config['tool_audit_events'] : array(),
+			'datamachine_provenance' => is_array( $config['datamachine_provenance'] ?? null ) ? $config['datamachine_provenance'] : array(),
+			'datamachine_code_policy_attestation' => is_array( $config['datamachine_code_policy_attestation'] ?? null ) ? $config['datamachine_code_policy_attestation'] : array(),
+			'fingerprints'        => homeboy_datamachine_agent_fingerprints( $config, homeboy_datamachine_agent_scalar( $config, 'prompt' ), homeboy_datamachine_agent_scalar( $config, 'bundle_path' ) ),
+		)
+	);
 }
 
 $bundle_path = homeboy_datamachine_agent_scalar( $config, 'bundle_path' );
@@ -2231,14 +2339,18 @@ $metadata = array(
     'flow_slug'     => $flow_slug,
     'target_repo'   => homeboy_datamachine_agent_scalar( $config, 'target_repo' ),
     'provider'      => homeboy_datamachine_agent_scalar( $config, 'provider', 'openai' ),
-    'model'         => homeboy_datamachine_agent_scalar( $config, 'model', 'gpt-5.5' ),
-    'prompt'        => $prompt,
-    'fingerprints'  => homeboy_datamachine_agent_fingerprints( $config, $prompt, $bundle_path ),
-    'bundle_exists' => '' !== $bundle_path && is_dir( $bundle_path ),
-    'rules'         => is_array( $config['rules'] ?? null ) ? $config['rules'] : array(),
-    'general_rules' => is_array( $config['general_rules'] ?? null ) ? $config['general_rules'] : array(),
-    'task_rules'    => is_array( $config['task_rules'] ?? null ) ? $config['task_rules'] : array(),
-    'probes'        => is_array( $config['probes'] ?? null ) ? $config['probes'] : array(),
+	'model'         => homeboy_datamachine_agent_scalar( $config, 'model', 'gpt-5.5' ),
+	'task_id'      => homeboy_datamachine_agent_scalar( $config, 'task_id', homeboy_datamachine_agent_scalar( $config, 'workload_id' ) ),
+	'task_label'   => homeboy_datamachine_agent_scalar( $config, 'task_label', homeboy_datamachine_agent_scalar( $config, 'workload_label' ) ),
+	'prompt'        => $prompt,
+	'fingerprints'  => homeboy_datamachine_agent_fingerprints( $config, $prompt, $bundle_path ),
+	'bundle_exists' => '' !== $bundle_path && is_dir( $bundle_path ),
+	'rules'         => is_array( $config['rules'] ?? null ) ? $config['rules'] : array(),
+	'general_rules' => is_array( $config['general_rules'] ?? null ) ? $config['general_rules'] : array(),
+	'task_rules'    => is_array( $config['task_rules'] ?? null ) ? $config['task_rules'] : array(),
+	'probes'        => is_array( $config['probes'] ?? null ) ? $config['probes'] : array(),
+	'datamachine_provenance' => is_array( $config['datamachine_provenance'] ?? null ) ? $config['datamachine_provenance'] : array(),
+	'datamachine_code_policy_attestation' => is_array( $config['datamachine_code_policy_attestation'] ?? null ) ? $config['datamachine_code_policy_attestation'] : array(),
 );
 $execute_workflow_path = homeboy_datamachine_agent_scalar( $config, 'execute_workflow_path' );
 
@@ -2442,9 +2554,10 @@ $job_status = is_array( $job ) ? (string) ( $job['status'] ?? '' ) : '';
 $engine_data = function_exists( 'datamachine_get_engine_data' ) ? datamachine_get_engine_data( $job_id ) : array();
 $engine_data = homeboy_datamachine_agent_merge_recorded_tool_results( $engine_data, $config );
 $engine_data = homeboy_datamachine_agent_merge_child_engine_data( $engine_data, $child_drain_summary['children'], $config );
+$tool_audit_events = homeboy_datamachine_agent_tool_audit_events( $engine_data, $config );
 $runner_workspace_capture = homeboy_datamachine_agent_capture_runner_workspace( $engine_data, $config );
 if ( is_array( $runner_workspace_capture['engine_data'] ?? null ) ) {
-    $engine_data = $runner_workspace_capture['engine_data'];
+	$engine_data = $runner_workspace_capture['engine_data'];
 }
 $transcript_dir = homeboy_datamachine_agent_scalar( $config, 'transcript_dir' );
 $transcript_artifacts = homeboy_datamachine_agent_export_transcript( $job_id, $engine_data, $transcript_dir );
@@ -2496,8 +2609,9 @@ $metadata += array(
     'flow_id'              => $flow_id,
     'job_id'               => $job_id,
     'job_status'           => $job_status,
-    'engine_data'          => $engine_data,
-    'transcript_session_id' => (string) ( $engine_data['transcript_session_id'] ?? '' ),
+	'engine_data'          => $engine_data,
+	'tool_audit_events'   => $tool_audit_events,
+	'transcript_session_id' => (string) ( $engine_data['transcript_session_id'] ?? '' ),
     'transcript_artifacts'  => $transcript_artifacts,
     'token_usage'           => is_array( $engine_data['token_usage'] ?? null ) ? $engine_data['token_usage'] : array(),
     'error_message'         => (string) ( $engine_data['error_message'] ?? '' ),


### PR DESCRIPTION
## Summary
- Capture Agents API `tool_audit_events` from Data Machine agent engine data, including child job engine data, and expose them in the runner eval artifact replay section.
- Add a sealed eval artifact envelope to replay bundles with runner/task/model metadata, prompt/bundle/tool-policy hashes, local artifact hashes, replay audit events, termination state, and explicit integration seams.
- Extend smoke coverage for replay bundle hashing/redaction and PHP eval artifact replay/seam metadata.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/642
Refs https://github.com/Extra-Chill/homeboy-extensions/issues/643
Refs https://github.com/Automattic/wp-gym/pull/76
Depends on merged Agents API PR https://github.com/Automattic/agents-api/pull/171 for live `tool_audit_events` production.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `bash wordpress/scripts/agent/build-replay-bundle-smoke.sh`
- `node --check wordpress/scripts/agent/build-replay-bundle.js`
- `cd wordpress && npx eslint scripts/agent/build-replay-bundle.js`

## Known caveat
- `bash wordpress/scripts/agent/datamachine-agent-runner-smoke.sh` currently fails before the agent runner path with Playground bootstrap unable to write `/wordpress/wp-content/plugins/playground-workloads/.pg-bench-result.txt`. This appears unrelated to the replay changes and is captured as a runner-smoke environment/bootstrap blocker.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the reusable runner artifact/replay implementation, tests, and PR description; Chris remains responsible for review and merge decisions.