### PR TITLE
Harden WordPress and Rust extension command defaults

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",
@@ -106,6 +106,11 @@
       "target"
     ],
     "lockfile_paths": ["Cargo.lock"]
+  },
+  "autofix_verify": {
+    "command": "cargo",
+    "args": ["check", "--release"],
+    "timeout_secs": 300
   },
   "cli": {
     "tool": "cargo",

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "2.85.0",
+  "version": "2.85.1",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",
@@ -745,7 +745,7 @@
   "cli": {
     "tool": "wp",
     "display_name": "WP-CLI",
-    "command_template": "{{cliPath}} {{args}} --path={{sitePath}} --url={{domain}}",
+    "command_template": "{{cliPath}} --path={{sitePath}} --url={{domain}} {{args}}",
     "working_dir_template": "{{sitePath}}",
     "default_cli_path": "wp",
     "settings_flags": {


### PR DESCRIPTION
## Summary
- Moves WordPress WP-CLI globals before user command args so remote runners that require global arguments before subcommands accept `homeboy wp` commands.
- Adds Rust extension `autofix_verify` using `cargo check --release` to prevent compile-broken autofix commits.
- Bumps the affected extension manifest versions.

## Tests
- `jq empty wordpress/wordpress.json rust/rust.json`
- `wordpress/tests/wp-cli-auto-flags-smoke.sh wordpress/wordpress.json`
- Live smoke after local extension install: `homeboy wp intelligence-horse -- core version` returned `7.0-RC3` with executed command `wp --path=/htdocs/__wp__ --url=balanced-jovial-earth.wpcloudstation.dev core version`

Closes Extra-Chill/homeboy#2522.
Related: Extra-Chill/homeboy#1476.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updating extension manifests, validating JSON/smoke tests, and verifying the corrected `homeboy wp` command against the live project. Chris reviewed the architectural constraint that WordPress-specific behavior belongs in extensions, not Homeboy core.