### PR TITLE
Fix WordPress WP-CLI global argument order

### DIFF
--- a/wordpress/tests/wp-cli-auto-flags-smoke.sh
+++ b/wordpress/tests/wp-cli-auto-flags-smoke.sh
@@ -12,6 +12,7 @@ with open(manifest_path, encoding="utf-8") as handle:
     manifest = json.load(handle)
 
 auto_flags = manifest.get("cli", {}).get("auto_flags", [])
+command_template = manifest.get("cli", {}).get("command_template", "")
 expected = {
     "when": {"server_user": "root"},
     "flag": "--allow-root",
@@ -19,6 +20,16 @@ expected = {
 
 if expected not in auto_flags:
     raise SystemExit("wordpress cli.auto_flags must declare root => --allow-root")
+
+args_index = command_template.find("{{args}}")
+for global_arg in ("--path={{sitePath}}", "--url={{domain}}"):
+    global_index = command_template.find(global_arg)
+    if global_index == -1:
+        raise SystemExit(f"wordpress cli.command_template must include {global_arg}")
+    if args_index == -1 or global_index > args_index:
+        raise SystemExit(
+            f"wordpress cli.command_template must place {global_arg} before {{args}}"
+        )
 
 print("wordpress cli auto_flags smoke passed")
 PY

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "2.85.0",
+  "version": "2.85.1",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",
@@ -745,7 +745,7 @@
   "cli": {
     "tool": "wp",
     "display_name": "WP-CLI",
-    "command_template": "{{cliPath}} {{args}} --path={{sitePath}} --url={{domain}}",
+    "command_template": "{{cliPath}} --path={{sitePath}} --url={{domain}} {{args}}",
     "working_dir_template": "{{sitePath}}",
     "default_cli_path": "wp",
     "settings_flags": {


### PR DESCRIPTION
## Summary
- Move the WordPress extension WP-CLI globals before user command args so WP Cloud receives `wp --path=... --url=... core version`.
- Keep the fix in the WordPress extension manifest instead of Homeboy core.
- Extend the existing WP-CLI smoke test to guard the global-before-command ordering.

Closes Extra-Chill/homeboy#2522.
Supersedes Extra-Chill/homeboy-extensions#648.

## Testing
- `jq empty wordpress/wordpress.json`
- `wordpress/tests/wp-cli-auto-flags-smoke.sh wordpress/wordpress.json`
- `homeboy extension install wordpress --replace`
- `homeboy wp intelligence-horse -- core version` returned `7.0-RC3` with executed command `wp --path=/htdocs/__wp__ --url=balanced-jovial-earth.wpcloudstation.dev core version`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Applying the extension-manifest fix, adding smoke coverage, and verifying the corrected command against the live WP Cloud target. Chris identified that WordPress-specific command behavior belongs in the extension, not Homeboy core.