### PR TITLE
Verify Rust autofixes compile

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",
@@ -106,6 +106,11 @@
       "target"
     ],
     "lockfile_paths": ["Cargo.lock"]
+  },
+  "autofix_verify": {
+    "command": "cargo",
+    "args": ["check", "--release"],
+    "timeout_secs": 300
   },
   "cli": {
     "tool": "cargo",


### PR DESCRIPTION
## Summary
- Adds Rust extension `autofix_verify` using `cargo check --release`.
- Bumps the Rust extension manifest version so installed copies can detect the hardening update.
- Keeps the safety net extension-owned instead of adding Rust-specific behavior to Homeboy core.

## Tests
- `jq empty rust/rust.json`

Related: Extra-Chill/homeboy#1476.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Creating the clean Rust-only manifest hardening change, validating JSON, and preparing the PR.