### PR TITLE
Expose a WP-CLI tool to Playground agents

### DIFF
--- a/wordpress/docs/AGENT_CI_PLAYGROUND.md
+++ b/wordpress/docs/AGENT_CI_PLAYGROUND.md
@@ -120,6 +120,9 @@ The runner converts the agent config into a single Playground bench workload:
   status/diff, commits, pushes, and opens or reuses a fallback PR after the run.
 - `ability_tools` can expose additional WordPress abilities as tools during the
   agent run.
+- `enable_wp_cli_tool: true` exposes a built-in `run_wp_cli` tool that executes
+  `WP_CLI::runcommand()` against the current disposable Playground WordPress
+  runtime and returns the real command, exit code, stdout, and stderr.
 - `pipeline_step_patches` and `flow_step_patches` can adjust imported bundle
   step configuration before execution.
 - `fallback_pull_request` can open a PR when files were written but the agent did
@@ -143,6 +146,7 @@ knobs to `run-datamachine-agent.sh`:
 - Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
 - Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`, `replay_bundle_artifact_name`.
 - Extension points: `extra_required_abilities`, `ability_tools`, `tool_recorders`, `pipeline_step_patches`, `flow_step_patches`, `runner_workspace`, `fallback_pull_request`.
+- Built-in WordPress actions: `enable_wp_cli_tool`, `wp_cli_tool_name`.
 
 `bundle_repo` is for cross-repo consumers. The shell runner clones the bundle
 repository, points `bundle_path` at the cloned bundle inside Playground, and adds
@@ -154,6 +158,11 @@ maintaining a bespoke runner script.
 wrap GitHub tools. A recorder can attach forced parameters, capture selected input
 or output fields, and write them under a stable `metadata.engine_data` key for
 later `engine_data_outputs` projection.
+
+Set `enable_wp_cli_tool: true` when the task should let the agent inspect or
+mutate the WordPress runtime through WP-CLI. The default tool name is
+`run_wp_cli`; override it with `wp_cli_tool_name` when a caller needs a different
+agent-facing name. Commands may include or omit the leading `wp`.
 
 `runner_workspace.expose_to_agent` defaults to `true` for backwards
 compatibility. Set it to `false` for task-sandbox runs where the agent should see

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -11,6 +11,7 @@
     "lint": [
       "jq empty wordpress.json",
       "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
+      "php -l scripts/agent/datamachine-agent-wp-cli-tool-smoke.php",
       "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js"
     ],
     "test": [
@@ -22,6 +23,7 @@
       "bash scripts/test/playground-no-test-files-smoke.sh",
       "bash scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh",
       "bash scripts/agent/validate-bundle-smoke.sh",
+      "php scripts/agent/datamachine-agent-wp-cli-tool-smoke.php",
       "bash scripts/trace/trace-runner-smoke.sh",
       "bash scripts/lint/wordpress-lint-role-smoke.sh",
       "bash scripts/lint/vendor-prefixed-exclusion-smoke.sh",

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -2080,6 +2080,195 @@ if ( ! function_exists( 'homeboy_datamachine_agent_bootstrap_abilities' ) ) {
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_prepare_wp_cli_runtime' ) ) {
+    function homeboy_datamachine_agent_prepare_wp_cli_runtime(): void {
+        if ( ! class_exists( 'WP_CLI' ) ) {
+            return;
+        }
+
+        $wp_cli_root = dirname( dirname( ( new ReflectionClass( 'WP_CLI' ) )->getFileName() ) );
+        if ( ! defined( 'WP_CLI_ROOT' ) ) {
+            define( 'WP_CLI_ROOT', $wp_cli_root );
+        }
+        if ( ! defined( 'WP_CLI_VERSION' ) && is_readable( WP_CLI_ROOT . '/VERSION' ) ) {
+            define( 'WP_CLI_VERSION', trim( file_get_contents( WP_CLI_ROOT . '/VERSION' ) ) );
+        }
+        if ( ! defined( 'WP_CLI_START_MICROTIME' ) ) {
+            define( 'WP_CLI_START_MICROTIME', microtime( true ) );
+        }
+        if ( ! defined( 'WP_CLI_VENDOR_DIR' ) ) {
+            if ( file_exists( WP_CLI_ROOT . '/vendor/autoload.php' ) ) {
+                define( 'WP_CLI_VENDOR_DIR', WP_CLI_ROOT . '/vendor' );
+            } elseif ( file_exists( dirname( dirname( WP_CLI_ROOT ) ) . '/autoload.php' ) ) {
+                define( 'WP_CLI_VENDOR_DIR', dirname( dirname( WP_CLI_ROOT ) ) );
+            } elseif ( file_exists( dirname( WP_CLI_ROOT ) . '/vendor/autoload.php' ) ) {
+                define( 'WP_CLI_VENDOR_DIR', dirname( WP_CLI_ROOT ) . '/vendor' );
+            } else {
+                define( 'WP_CLI_VENDOR_DIR', WP_CLI_ROOT . '/vendor' );
+            }
+        }
+        if ( ! function_exists( 'WP_CLI\\Utils\\parse_str_to_argv' ) && is_readable( WP_CLI_ROOT . '/php/utils.php' ) ) {
+            require_once WP_CLI_ROOT . '/php/utils.php';
+        }
+        if ( ! function_exists( 'WP_CLI\\Dispatcher\\get_path' ) && is_readable( WP_CLI_ROOT . '/php/dispatcher.php' ) ) {
+            require_once WP_CLI_ROOT . '/php/dispatcher.php';
+        }
+    }
+
+    function homeboy_datamachine_agent_run_wp_cli_command( string $command ): array {
+        $command = trim( $command );
+        if ( str_starts_with( $command, 'wp ' ) ) {
+            $command = trim( substr( $command, 3 ) );
+        }
+        if ( '' === $command ) {
+            return array(
+                'success'   => false,
+                'command'   => '',
+                'exit_code' => 1,
+                'stdout'    => '',
+                'stderr'    => 'WP-CLI command must not be empty.',
+                'error'     => 'WP-CLI command must not be empty.',
+            );
+        }
+
+        if ( ! class_exists( 'WP_CLI' ) || ! method_exists( 'WP_CLI', 'runcommand' ) ) {
+            return array(
+                'success'   => false,
+                'command'   => $command,
+                'exit_code' => 127,
+                'stdout'    => '',
+                'stderr'    => 'WP_CLI::runcommand() is unavailable in this runtime.',
+                'error'     => 'WP_CLI::runcommand() is unavailable in this runtime.',
+            );
+        }
+
+        homeboy_datamachine_agent_prepare_wp_cli_runtime();
+        $result = WP_CLI::runcommand(
+            $command,
+            array(
+                'launch'     => false,
+                'exit_error' => false,
+                'return'     => 'all',
+                'parse'      => false,
+            )
+        );
+
+        $stdout    = is_object( $result ) && isset( $result->stdout ) ? (string) $result->stdout : '';
+        $stderr    = is_object( $result ) && isset( $result->stderr ) ? (string) $result->stderr : '';
+        $exit_code = is_object( $result ) && isset( $result->return_code ) ? (int) $result->return_code : 0;
+
+        return array(
+            'success'   => 0 === $exit_code,
+            'command'   => $command,
+            'exit_code' => $exit_code,
+            'stdout'    => $stdout,
+            'stderr'    => $stderr,
+            'error'     => 0 === $exit_code ? '' : trim( '' !== $stderr ? $stderr : $stdout ),
+        );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_register_wp_cli_ability' ) ) {
+    function homeboy_datamachine_agent_register_wp_cli_ability( array &$config ): void {
+        if ( empty( $config['enable_wp_cli_tool'] ) ) {
+            return;
+        }
+
+        add_action(
+            'wp_abilities_api_categories_init',
+            static function (): void {
+                if ( ! function_exists( 'wp_register_ability_category' ) ) {
+                    return;
+                }
+                if ( function_exists( 'wp_get_ability_category' ) && wp_get_ability_category( 'homeboy-agent' ) ) {
+                    return;
+                }
+                wp_register_ability_category(
+                    'homeboy-agent',
+                    array(
+                        'label'       => 'Homeboy Agent',
+                        'description' => 'Runtime tools exposed to disposable WordPress agent runs.',
+                    )
+                );
+            }
+        );
+
+        add_action(
+            'wp_abilities_api_init',
+            static function (): void {
+                if ( ! function_exists( 'wp_register_ability' ) || ( function_exists( 'wp_get_ability' ) && wp_get_ability( 'homeboy-agent/run-wp-cli' ) ) ) {
+                    return;
+                }
+                wp_register_ability(
+                    'homeboy-agent/run-wp-cli',
+                    array(
+                        'label'               => 'Run WP-CLI command',
+                        'description'         => 'Run a WP-CLI command against the current disposable WordPress runtime and return stdout, stderr, and exit status.',
+                        'category'            => 'homeboy-agent',
+                        'permission_callback' => static fn(): bool => true,
+                        'input_schema'        => array(
+                            'type'                 => 'object',
+                            'required'             => array( 'command' ),
+                            'properties'           => array(
+                                'command'    => array(
+                                    'type'        => 'string',
+                                    'description' => 'WP-CLI command to run. The command may include or omit the leading `wp`.',
+                                ),
+                                'timeout_ms' => array(
+                                    'type'        => 'integer',
+                                    'description' => 'Reserved for callers that enforce an outer command timeout.',
+                                    'minimum'     => 1,
+                                ),
+                            ),
+                            'additionalProperties' => false,
+                        ),
+                        'output_schema'       => array(
+                            'type'       => 'object',
+                            'properties' => array(
+                                'success'   => array( 'type' => 'boolean' ),
+                                'command'   => array( 'type' => 'string' ),
+                                'exit_code' => array( 'type' => 'integer' ),
+                                'stdout'    => array( 'type' => 'string' ),
+                                'stderr'    => array( 'type' => 'string' ),
+                                'error'     => array( 'type' => 'string' ),
+                            ),
+                        ),
+                        'execute_callback'    => static function ( array $input = array() ): array {
+                            return homeboy_datamachine_agent_run_wp_cli_command( (string) ( $input['command'] ?? '' ) );
+                        },
+                    )
+                );
+            }
+        );
+
+        $ability_tools = is_array( $config['ability_tools'] ?? null ) ? $config['ability_tools'] : array();
+        $tool_name     = is_scalar( $config['wp_cli_tool_name'] ?? null ) && '' !== trim( (string) $config['wp_cli_tool_name'] )
+            ? trim( (string) $config['wp_cli_tool_name'] )
+            : 'run_wp_cli';
+        $already_registered = false;
+        foreach ( $ability_tools as $tool_config ) {
+            if ( is_array( $tool_config ) && $tool_name === (string) ( $tool_config['name'] ?? '' ) ) {
+                $already_registered = true;
+                break;
+            }
+        }
+        if ( ! $already_registered ) {
+            $ability_tools[] = array(
+                'name'        => $tool_name,
+                'ability'     => 'homeboy-agent/run-wp-cli',
+                'description' => 'Run a WP-CLI command against the current disposable WordPress runtime. Returns real WP-CLI stdout, stderr, and exit status.',
+                'record'      => array(
+                    'engine_key' => homeboy_datamachine_agent_scalar( $config, 'engine_key' ),
+                    'fields'     => array(
+                        'last_wp_cli_command' => 'parameters.command',
+                    ),
+                ),
+            );
+        }
+        $config['ability_tools'] = $ability_tools;
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_configure_settings' ) ) {
     function homeboy_datamachine_agent_configure_settings( array $config ): array {
         $provider = homeboy_datamachine_agent_scalar( $config, 'provider', 'openai' );
@@ -2364,6 +2553,7 @@ if ( ! $metadata['bundle_exists'] || ! is_file( $bundle_path . '/manifest.json' 
 }
 
 homeboy_datamachine_agent_bootstrap_provider( $config );
+homeboy_datamachine_agent_register_wp_cli_ability( $config );
 $bootstrap_error = homeboy_datamachine_agent_bootstrap_abilities();
 if ( null !== $bootstrap_error ) {
     return $bootstrap_error;

--- a/wordpress/scripts/agent/datamachine-agent-wp-cli-tool-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-wp-cli-tool-smoke.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Smoke test for the Data Machine agent WP-CLI tool surface.
+ *
+ * Run with: php wordpress/scripts/agent/datamachine-agent-wp-cli-tool-smoke.php
+ */
+
+namespace DataMachine\Core\Database\Agents {
+    class Agents {}
+}
+
+namespace DataMachine\Core\Database\Chat {
+    class ConversationStoreFactory {}
+}
+
+namespace DataMachine\Core\Database\Flows {
+    class Flows {}
+}
+
+namespace DataMachine\Core\Database\Jobs {
+    class Jobs {}
+}
+
+namespace DataMachine\Core\Database\Pipelines {
+    class Pipelines {}
+}
+
+namespace DataMachine\Core {
+    class PluginSettings {}
+}
+
+namespace {
+    if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/' );
+    }
+
+    class WP_CLI {
+        public static string $last_command = '';
+
+        public static function runcommand( string $command, array $options = array() ): object {
+            self::$last_command = $command;
+
+            return (object) array(
+                'stdout'      => "Example Site\n",
+                'stderr'      => '',
+                'return_code' => 0,
+                'options'     => $options,
+            );
+        }
+    }
+
+    $GLOBALS['homeboy_wp_cli_tool_actions']    = array();
+    $GLOBALS['homeboy_wp_cli_tool_filters']    = array();
+    $GLOBALS['homeboy_wp_cli_tool_abilities']  = array();
+    $GLOBALS['homeboy_wp_cli_tool_categories'] = array();
+    $GLOBALS['homeboy_wp_cli_tool_done']       = array();
+
+    if ( ! function_exists( 'wp_set_current_user' ) ) {
+        function wp_set_current_user( int $user_id ): void {}
+    }
+
+    if ( ! function_exists( 'add_action' ) ) {
+        function add_action( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+            $GLOBALS['homeboy_wp_cli_tool_actions'][ $tag ][ $priority ][] = $callback;
+        }
+    }
+
+    if ( ! function_exists( 'do_action' ) ) {
+        function do_action( string $tag ): void {
+            $GLOBALS['homeboy_wp_cli_tool_done'][ $tag ] = true;
+            if ( empty( $GLOBALS['homeboy_wp_cli_tool_actions'][ $tag ] ) ) {
+                return;
+            }
+            ksort( $GLOBALS['homeboy_wp_cli_tool_actions'][ $tag ] );
+            foreach ( $GLOBALS['homeboy_wp_cli_tool_actions'][ $tag ] as $callbacks ) {
+                foreach ( $callbacks as $callback ) {
+                    $callback();
+                }
+            }
+        }
+    }
+
+    if ( ! function_exists( 'did_action' ) ) {
+        function did_action( string $tag ): int {
+            return empty( $GLOBALS['homeboy_wp_cli_tool_done'][ $tag ] ) ? 0 : 1;
+        }
+    }
+
+    if ( ! function_exists( 'add_filter' ) ) {
+        function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+            $GLOBALS['homeboy_wp_cli_tool_filters'][ $tag ][ $priority ][] = $callback;
+        }
+    }
+
+    if ( ! function_exists( 'apply_filters' ) ) {
+        function apply_filters( string $tag, $value ) {
+            if ( empty( $GLOBALS['homeboy_wp_cli_tool_filters'][ $tag ] ) ) {
+                return $value;
+            }
+            ksort( $GLOBALS['homeboy_wp_cli_tool_filters'][ $tag ] );
+            foreach ( $GLOBALS['homeboy_wp_cli_tool_filters'][ $tag ] as $callbacks ) {
+                foreach ( $callbacks as $callback ) {
+                    $value = $callback( $value );
+                }
+            }
+            return $value;
+        }
+    }
+
+    if ( ! function_exists( 'wp_register_ability_category' ) ) {
+        function wp_register_ability_category( string $slug, array $args ): void {
+            $GLOBALS['homeboy_wp_cli_tool_categories'][ $slug ] = $args;
+        }
+    }
+
+    if ( ! function_exists( 'wp_get_ability_category' ) ) {
+        function wp_get_ability_category( string $slug ) {
+            return $GLOBALS['homeboy_wp_cli_tool_categories'][ $slug ] ?? null;
+        }
+    }
+
+    if ( ! function_exists( 'wp_register_ability' ) ) {
+        function wp_register_ability( string $name, array $args ): void {
+            $GLOBALS['homeboy_wp_cli_tool_abilities'][ $name ] = new class( $args ) {
+                private array $args;
+
+                public function __construct( array $args ) {
+                    $this->args = $args;
+                }
+
+                public function get_input_schema(): array {
+                    return $this->args['input_schema'] ?? array( 'type' => 'object', 'properties' => array() );
+                }
+
+                public function execute( array $input = array() ): array {
+                    return ( $this->args['execute_callback'] )( $input );
+                }
+            };
+        }
+    }
+
+    if ( ! function_exists( 'wp_get_ability' ) ) {
+        function wp_get_ability( string $name ) {
+            return $GLOBALS['homeboy_wp_cli_tool_abilities'][ $name ] ?? null;
+        }
+    }
+
+    if ( ! function_exists( 'is_wp_error' ) ) {
+        function is_wp_error( $value ): bool {
+            return false;
+        }
+    }
+
+    if ( ! function_exists( 'wp_json_encode' ) ) {
+        function wp_json_encode( $value, int $flags = 0 ): string {
+            return (string) json_encode( $value, $flags );
+        }
+    }
+
+    putenv(
+        'HOMEBOY_DATAMACHINE_AGENT_CONFIG=' . wp_json_encode(
+            array(
+                'dry_run'     => true,
+                'bundle_path' => __DIR__,
+                'agent_slug'  => 'wp-cli-tool-smoke-agent',
+                'flow_slug'   => 'wp-cli-tool-smoke-flow',
+                'prompt'      => 'Dry-run the WP-CLI tool smoke test.',
+            )
+        )
+    );
+
+    require __DIR__ . '/datamachine-agent-workload.php';
+
+    $config = array(
+        'enable_wp_cli_tool' => true,
+        'engine_key'         => 'wp_gym',
+    );
+    homeboy_datamachine_agent_register_wp_cli_ability( $config );
+    homeboy_datamachine_agent_bootstrap_abilities();
+    homeboy_datamachine_agent_register_tool_recorders( $config );
+
+    $tools = apply_filters( 'datamachine_resolved_tools', array() );
+    if ( empty( $tools['run_wp_cli'] ) || ! is_array( $tools['run_wp_cli'] ) ) {
+        fwrite( STDERR, "Expected run_wp_cli tool to be registered.\n" );
+        exit( 1 );
+    }
+
+    $tool   = new Homeboy_Datamachine_Agent_Tool_Recorder();
+    $result = $tool->handle_tool_call( array( 'command' => 'wp option get blogname' ), $tools['run_wp_cli'] );
+
+    if ( empty( $result['success'] ) ) {
+        fwrite( STDERR, "Expected run_wp_cli tool call to succeed.\n" );
+        exit( 1 );
+    }
+    if ( 'option get blogname' !== WP_CLI::$last_command ) {
+        fwrite( STDERR, "Expected WP_CLI::runcommand() to receive the normalized command.\n" );
+        exit( 1 );
+    }
+    if ( "Example Site\n" !== ( $result['stdout'] ?? '' ) || 0 !== ( $result['exit_code'] ?? null ) ) {
+        fwrite( STDERR, "Expected real WP-CLI stdout and exit status in tool response.\n" );
+        exit( 1 );
+    }
+
+    echo "Data Machine agent WP-CLI tool smoke passed.\n";
+}


### PR DESCRIPTION
## Summary
- Adds `enable_wp_cli_tool` to the Data Machine agent Playground runner config.
- Registers a built-in `homeboy-agent/run-wp-cli` ability and exposes it as the agent-facing `run_wp_cli` tool by default.
- Executes commands through `WP_CLI::runcommand(..., ['launch' => false])` in the current disposable Playground WordPress runtime and returns command, exit code, stdout, stderr, and error text.
- Documents the config and adds a PHP smoke test that proves the tool calls the real WP-CLI dispatch surface.

## Context
This gives consumers such as `wp-gym` and `world-of-wordpress` a real agent WP-CLI action surface instead of simulating WordPress state downstream.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-wp-cli-tool-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-wp-cli-tool-smoke.php`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@agent-wp-cli-actions/wordpress --extension wordpress`

## Known test status
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@agent-wp-cli-actions/wordpress --extension wordpress` reaches the existing audit smoke and fails with `constant-backed slug detector should still flag comparisons` / `WordPress utility wrappers with natural pure-PHP fallbacks must not be declared in known_symbols.header_versions...`. The new WP-CLI smoke passes before that failure.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the runner config/ability/tool wiring, adding smoke coverage, updating docs, and running verification commands. Chris remains responsible for review and merge.