### PR TITLE
fix(wordpress): prefer app token for agent GitHub writes

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -2095,16 +2095,6 @@ if ( ! function_exists( 'homeboy_datamachine_agent_configure_settings' ) ) {
             $allowed_repos = is_array( $config['allowed_repos'] ?? null ) ? $config['allowed_repos'] : array( $target_repo );
             $profile_id    = homeboy_datamachine_agent_scalar( $config, 'github_profile_id', 'homeboy-agent-ci' );
             $profiles      = array();
-            if ( '' !== $github_repository_token ) {
-                $profiles[] = array(
-                    'id'            => $profile_id . '-repository',
-                    'label'         => 'Homeboy agent CI repository token',
-                    'mode'          => 'pat',
-                    'pat'           => $github_repository_token,
-                    'default_repo'  => $target_repo,
-                    'allowed_repos' => array( $target_repo ),
-                );
-            }
             if ( '' !== $github_token ) {
                 $profiles[] = array(
                     'id'            => $profile_id,
@@ -2113,6 +2103,16 @@ if ( ! function_exists( 'homeboy_datamachine_agent_configure_settings' ) ) {
                     'pat'           => $github_token,
                     'default_repo'  => $target_repo,
                     'allowed_repos' => array_values( array_unique( array_filter( array_map( 'strval', $allowed_repos ) ) ) ),
+                );
+            }
+            if ( '' !== $github_repository_token ) {
+                $profiles[] = array(
+                    'id'            => $profile_id . '-repository',
+                    'label'         => 'Homeboy agent CI repository token',
+                    'mode'          => 'pat',
+                    'pat'           => $github_repository_token,
+                    'default_repo'  => $target_repo,
+                    'allowed_repos' => array( $target_repo ),
                 );
             }
             $settings['github_credential_profiles'] = $profiles;

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -620,12 +620,12 @@ namespace {
     );
     $datamachine_settings = $GLOBALS['homeboy_datamachine_agent_fake_options']['datamachine_settings'] ?? array();
     $github_profiles = $datamachine_settings['github_credential_profiles'] ?? array();
-    if ( 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) || array( 'owner/repo' ) !== ( $github_profiles[0]['allowed_repos'] ?? array() ) ) {
-        fwrite( STDERR, "Expected repository token profile to be first and scoped to the target repo.\n" );
+    if ( 'app-token' !== ( $github_profiles[0]['pat'] ?? '' ) || array( 'owner/repo', 'owner/other' ) !== ( $github_profiles[0]['allowed_repos'] ?? array() ) ) {
+        fwrite( STDERR, "Expected app token profile to be first and preserve cross-repo allowed repositories.\n" );
         exit( 1 );
     }
-    if ( 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'owner/repo', 'owner/other' ) !== ( $github_profiles[1]['allowed_repos'] ?? array() ) ) {
-        fwrite( STDERR, "Expected app token profile to preserve cross-repo allowed repositories.\n" );
+    if ( 'repository-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'owner/repo' ) !== ( $github_profiles[1]['allowed_repos'] ?? array() ) ) {
+        fwrite( STDERR, "Expected repository token profile to remain available as a target-repo fallback.\n" );
         exit( 1 );
     }
 


### PR DESCRIPTION
## Summary
- Prefer the Homeboy app token profile before the repository `GITHUB_TOKEN` profile for Data Machine agent CI runs.
- Keep the repository token profile available as a target-repo fallback, but prevent it from winning source-repo writes/comments when an app token is available.
- Update the existing smoke test to assert app-token precedence.

## Verification
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `git diff --check`

## Notes
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-agent-ci-app-token-precedence --extension wordpress` currently fails on existing repo-wide PHPCS/PHPStan findings in unrelated files, including `wordpress/scripts/validation/validate-autoload.php` and fixture parse errors.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Root-cause analysis of iterator callback authorship and drafting the token precedence fix; Chris requested PR creation.