### PR TITLE
Add host-side terminal actions for WordPress agents

### DIFF
--- a/wordpress/docs/AGENT_CI_PLAYGROUND.md
+++ b/wordpress/docs/AGENT_CI_PLAYGROUND.md
@@ -120,6 +120,10 @@ The runner converts the agent config into a single Playground bench workload:
   status/diff, commits, pushes, and opens or reuses a fallback PR after the run.
 - `ability_tools` can expose additional WordPress abilities as tools during the
   agent run.
+- Host-side terminal actions are available through the WordPress extension's
+  `agent-terminal-actions` helper for runner-owned tools that must execute like a
+  real shell command. A `wp_cli` action runs `wp ...` through `bash -lc` with the
+  runtime root as the command boundary and returns exit code, stdout, and stderr.
 - `pipeline_step_patches` and `flow_step_patches` can adjust imported bundle
   step configuration before execution.
 - `fallback_pull_request` can open a PR when files were written but the agent did

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -11,7 +11,7 @@
     "lint": [
       "jq empty wordpress.json",
       "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
-      "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js"
+      "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js"
     ],
     "test": [
       "bash scripts/test/host-smoke-runner-smoke.sh",
@@ -32,6 +32,7 @@
       "bash tests/eslint-eqeqeq-null-smoke.sh",
       "node tests/request-profiler-smoke.js",
       "node tests/playground-readiness-smoke.js",
+      "node tests/agent-terminal-actions-smoke.js",
       "node tests/timing-correlator-smoke.js"
     ]
   }

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -11,7 +11,8 @@
     "lint": [
       "jq empty wordpress.json",
       "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
-      "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js"
+      "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js scripts/agent/terminal-action-server.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js",
+      "php -l scripts/agent/datamachine-agent-workload.php tests/datamachine-terminal-tool-smoke.php"
     ],
     "test": [
       "bash scripts/test/host-smoke-runner-smoke.sh",
@@ -33,6 +34,8 @@
       "node tests/request-profiler-smoke.js",
       "node tests/playground-readiness-smoke.js",
       "node tests/agent-terminal-actions-smoke.js",
+      "node tests/terminal-action-server-smoke.js",
+      "php tests/datamachine-terminal-tool-smoke.php",
       "node tests/timing-correlator-smoke.js"
     ]
   }

--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -5,4 +5,5 @@ module.exports = {
 	...require('./lib/request-profiler'),
 	...require('./lib/page-profiler'),
 	...require('./lib/timing-correlator'),
+	...require('./lib/agent-terminal-actions'),
 };

--- a/wordpress/lib/agent-terminal-actions.js
+++ b/wordpress/lib/agent-terminal-actions.js
@@ -1,0 +1,149 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+
+/**
+ * Internal dependencies
+ */
+const { isPlainObject } = require('./shared');
+
+const DEFAULT_TIMEOUT_MS = 30000;
+const MAX_TIMEOUT_MS = 600000;
+
+function normalizeTimeoutMs(value, fallback = DEFAULT_TIMEOUT_MS) {
+	const number = Number(value ?? fallback);
+
+	if (!Number.isFinite(number) || number < 1) {
+		return fallback;
+	}
+
+	return Math.min(Math.floor(number), MAX_TIMEOUT_MS);
+}
+
+function resolveContainedCwd(cwd, root = process.cwd()) {
+	const base = path.resolve(root);
+	const resolved = path.resolve(base, cwd || '.');
+	const relative = path.relative(base, resolved);
+
+	if (relative.startsWith('..') || path.isAbsolute(relative)) {
+		throw new Error(`Terminal action cwd must stay inside the runtime root: ${cwd}`);
+	}
+
+	return resolved;
+}
+
+function normalizeTerminalAction(action, options = {}) {
+	if (!isPlainObject(action)) {
+		throw new TypeError('Terminal action must be an object');
+	}
+
+	const type = typeof action.type === 'string' ? action.type.trim() : '';
+	const command = typeof action.command === 'string' ? action.command.trim() : '';
+
+	if (type !== 'terminal' && type !== 'wp_cli') {
+		throw new Error(`Unsupported terminal action type: ${type || '(missing)'}`);
+	}
+	if (command === '') {
+		throw new Error('Terminal action command must be a non-empty string');
+	}
+
+	const runtimeRoot = options.runtimeRoot || process.cwd();
+	const cwd = resolveContainedCwd(action.cwd || options.cwd || '.', runtimeRoot);
+	const timeoutMs = normalizeTimeoutMs(action.timeout_ms ?? action.timeoutMs, options.timeoutMs);
+	const shell = action.shell || options.shell || 'bash';
+	const shellArgs = Array.isArray(action.shell_args || action.shellArgs)
+		? action.shell_args || action.shellArgs
+		: ['-lc'];
+	const env = {
+		...process.env,
+		...(options.env || {}),
+		...(isPlainObject(action.env) ? action.env : {}),
+	};
+
+	if (type === 'wp_cli') {
+		const trimmed = command.startsWith('wp ') ? command : `wp ${command}`;
+
+		return {
+			type,
+			command: trimmed,
+			cwd,
+			timeoutMs,
+			shell,
+			shellArgs,
+			env,
+		};
+	}
+
+	return { type, command, cwd, timeoutMs, shell, shellArgs, env };
+}
+
+function executeTerminalAction(action, options = {}) {
+	const normalized = normalizeTerminalAction(action, options);
+	const startedAt = new Date().toISOString();
+	const started = Date.now();
+
+	return new Promise((resolve) => {
+		const child = spawn(normalized.shell, [...normalized.shellArgs, normalized.command], {
+			cwd: normalized.cwd,
+			env: normalized.env,
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+		let stdout = '';
+		let stderr = '';
+		let timedOut = false;
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			child.kill('SIGTERM');
+		}, normalized.timeoutMs);
+
+		child.stdout.on('data', (chunk) => {
+			stdout += chunk.toString();
+		});
+		child.stderr.on('data', (chunk) => {
+			stderr += chunk.toString();
+		});
+		child.on('error', (error) => {
+			clearTimeout(timeout);
+			resolve({
+				type: normalized.type,
+				command: normalized.command,
+				cwd: normalized.cwd,
+				startedAt,
+				durationMs: Date.now() - started,
+				exitCode: 1,
+				stdout,
+				stderr: stderr || error.message,
+				success: false,
+				timedOut,
+				error: error.message,
+			});
+		});
+		child.on('close', (code, signal) => {
+			clearTimeout(timeout);
+			const exitCode = timedOut ? 124 : (code ?? 1);
+			resolve({
+				type: normalized.type,
+				command: normalized.command,
+				cwd: normalized.cwd,
+				startedAt,
+				durationMs: Date.now() - started,
+				exitCode,
+				signal: signal || null,
+				stdout,
+				stderr,
+				success: exitCode === 0,
+				timedOut,
+				error: exitCode === 0 ? '' : (stderr.trim() || stdout.trim() || (timedOut ? 'Command timed out' : 'Command failed')),
+			});
+		});
+	});
+}
+
+module.exports = {
+	executeTerminalAction,
+	normalizeTerminalAction,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -8,11 +8,13 @@
     "./page-profiler": "./lib/page-profiler.js",
     "./playground-readiness": "./lib/playground-readiness.js",
     "./request-profiler": "./lib/request-profiler.js",
+	"./agent-terminal-actions": "./lib/agent-terminal-actions.js",
     "./timing-correlator": "./lib/timing-correlator.js"
   },
   "scripts": {
     "lint:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "test:page-profiler": "node tests/page-profiler-smoke.js",
+	"test:agent-terminal-actions": "node tests/agent-terminal-actions-smoke.js",
     "test:playground-readiness": "node tests/playground-readiness-smoke.js",
     "test:request-profiler": "node tests/request-profiler-smoke.js",
     "test:timing-correlator": "node tests/timing-correlator-smoke.js"

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -8,13 +8,14 @@
     "./page-profiler": "./lib/page-profiler.js",
     "./playground-readiness": "./lib/playground-readiness.js",
     "./request-profiler": "./lib/request-profiler.js",
-	"./agent-terminal-actions": "./lib/agent-terminal-actions.js",
+    "./agent-terminal-actions": "./lib/agent-terminal-actions.js",
     "./timing-correlator": "./lib/timing-correlator.js"
   },
   "scripts": {
     "lint:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "test:page-profiler": "node tests/page-profiler-smoke.js",
-	"test:agent-terminal-actions": "node tests/agent-terminal-actions-smoke.js",
+    "test:agent-terminal-actions": "node tests/agent-terminal-actions-smoke.js",
+    "test:terminal-action-server": "node tests/terminal-action-server-smoke.js",
     "test:playground-readiness": "node tests/playground-readiness-smoke.js",
     "test:request-profiler": "node tests/request-profiler-smoke.js",
     "test:timing-correlator": "node tests/timing-correlator-smoke.js"

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1760,6 +1760,79 @@ if ( ! class_exists( 'Homeboy_Datamachine_Agent_Tool_Recorder' ) ) {
     }
 }
 
+if ( ! class_exists( 'Homeboy_Datamachine_Agent_Terminal_Tool' ) ) {
+    class Homeboy_Datamachine_Agent_Terminal_Tool {
+        public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+            $url   = rtrim( (string) ( $tool_def['terminal_action_url'] ?? getenv( 'HOMEBOY_TERMINAL_ACTION_URL' ) ), '/' );
+            $token = (string) ( $tool_def['terminal_action_token'] ?? getenv( 'HOMEBOY_TERMINAL_ACTION_TOKEN' ) );
+
+            if ( '' === $url || '' === $token ) {
+                return array(
+                    'success'   => false,
+                    'tool_name' => (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' ),
+                    'error'     => 'Terminal action server is not configured.',
+                );
+            }
+
+            $command = trim( (string) ( $parameters['command'] ?? '' ) );
+            if ( '' === $command ) {
+                return array(
+                    'success'   => false,
+                    'tool_name' => (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' ),
+                    'error'     => 'command is required.',
+                );
+            }
+
+            $action = array_filter(
+                array(
+                    'type'       => (string) ( $tool_def['terminal_action_type'] ?? 'wp_cli' ),
+                    'command'    => $command,
+                    'timeout_ms' => isset( $parameters['timeout_ms'] ) ? (int) $parameters['timeout_ms'] : null,
+                    'cwd'        => isset( $parameters['cwd'] ) ? (string) $parameters['cwd'] : null,
+                ),
+                static fn( $value ) => null !== $value && '' !== $value
+            );
+
+            $response = wp_remote_post(
+                $url . '/execute',
+                array(
+                    'timeout' => max( 1, (int) ceil( ( (int) ( $action['timeout_ms'] ?? 30000 ) + 5000 ) / 1000 ) ),
+                    'headers' => array(
+                        'Authorization' => 'Bearer ' . $token,
+                        'Content-Type'  => 'application/json',
+                    ),
+                    'body'    => wp_json_encode( $action ),
+                )
+            );
+
+            if ( is_wp_error( $response ) ) {
+                return array(
+                    'success'   => false,
+                    'tool_name' => (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' ),
+                    'error'     => $response->get_error_message(),
+                );
+            }
+
+            $status = (int) wp_remote_retrieve_response_code( $response );
+            $body   = (string) wp_remote_retrieve_body( $response );
+            $result = json_decode( $body, true );
+            if ( ! is_array( $result ) ) {
+                return array(
+                    'success'   => false,
+                    'tool_name' => (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' ),
+                    'error'     => 'Terminal action server returned invalid JSON.',
+                    'status'    => $status,
+                    'body'      => $body,
+                );
+            }
+
+            $result['tool_name'] = (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' );
+            $result['status']    = $status;
+            return $result;
+        }
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_register_tool_recorders' ) ) {
     function homeboy_datamachine_agent_register_tool_recorders( array $config ): void {
         $ability_tools = is_array( $config['ability_tools'] ?? null ) ? $config['ability_tools'] : array();
@@ -1829,6 +1902,48 @@ if ( ! function_exists( 'homeboy_datamachine_agent_register_tool_recorders' ) ) 
                     $tools[ $tool_name ]['homeboy_record']             = is_array( $recorder['record'] ?? null ) ? $recorder['record'] : array();
                     $tools[ $tool_name ]['homeboy_forced_parameters'] = is_array( $recorder['forced_parameters'] ?? null ) ? $recorder['forced_parameters'] : array();
                 }
+
+                return $tools;
+            },
+            100,
+            1
+        );
+    }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_register_terminal_tools' ) ) {
+    function homeboy_datamachine_agent_register_terminal_tools( array $config ): void {
+        if ( empty( $config['enable_terminal_actions'] ) && empty( $config['enable_wp_cli_tool'] ) ) {
+            return;
+        }
+
+        $terminal_url   = homeboy_datamachine_agent_scalar( $config, 'terminal_action_url' );
+        $terminal_token = homeboy_datamachine_agent_scalar( $config, 'terminal_action_token' );
+        $tool_name      = homeboy_datamachine_agent_scalar( $config, 'wp_cli_tool_name', 'run_wp_cli' );
+
+        add_filter(
+            'datamachine_resolved_tools',
+            static function ( array $tools ) use ( $terminal_url, $terminal_token, $tool_name ): array {
+                $tools[ $tool_name ] = array(
+                    'class'                 => 'Homeboy_Datamachine_Agent_Terminal_Tool',
+                    'method'                => 'handle_tool_call',
+                    'tool_name'             => $tool_name,
+                    'description'           => 'Run a real WP-CLI command through the host terminal against the disposable WordPress runtime. Returns exit code, stdout, and stderr.',
+                    'terminal_action_type'  => 'wp_cli',
+                    'terminal_action_url'   => $terminal_url,
+                    'terminal_action_token' => $terminal_token,
+                    'parameters'            => array(
+                        'command'    => array(
+                            'type'        => 'string',
+                            'required'    => true,
+                            'description' => 'WP-CLI command to run. You may include or omit the leading `wp`.',
+                        ),
+                        'timeout_ms' => array(
+                            'type'        => 'integer',
+                            'description' => 'Maximum command runtime in milliseconds.',
+                        ),
+                    ),
+                );
 
                 return $tools;
             },
@@ -2395,6 +2510,7 @@ foreach ( array( Agents::class, Pipelines::class, Flows::class, Jobs::class ) as
 }
 
 $settings = homeboy_datamachine_agent_configure_settings( $config );
+homeboy_datamachine_agent_register_terminal_tools( $config );
 homeboy_datamachine_agent_register_tool_recorders( $config );
 
 $agents = new Agents();

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -49,7 +49,11 @@ if [ ! -f "$WORKLOAD_PATH" ]; then
 fi
 
 RUNTIME_DIR=""
+TERMINAL_SERVER_PID=""
 cleanup() {
+    if [ -n "$TERMINAL_SERVER_PID" ]; then
+        kill "$TERMINAL_SERVER_PID" >/dev/null 2>&1 || true
+    fi
     if [ -n "$RUNTIME_DIR" ]; then
         rm -rf "$RUNTIME_DIR"
     fi
@@ -168,6 +172,45 @@ WORKLOAD_ID=$(jq -r '.workload_id // "datamachine-agent"' "$CONFIG_PATH")
 WORKLOAD_LABEL=$(jq -r '.workload_label // "Run Data Machine agent"' "$CONFIG_PATH")
 PLAYGROUND_WORDPRESS_VERSION=$(jq -r '.playground_wordpress_version // "7.0"' "$CONFIG_PATH")
 BENCH_WARMUP_ITERATIONS=$(jq -r '.bench_warmup_iterations // 0' "$CONFIG_PATH")
+ENABLE_TERMINAL_ACTIONS=$(jq -r 'if (.enable_terminal_actions // .enable_wp_cli_tool // false) then "1" else "0" end' <<<"$CONFIG_JSON")
+if [ "$ENABLE_TERMINAL_ACTIONS" = "1" ]; then
+    if [ -z "$RUNTIME_DIR" ]; then
+        RUNTIME_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-datamachine-agent-runtime.XXXXXX")
+    fi
+    TERMINAL_READY_FILE="$RUNTIME_DIR/terminal-action-server.json"
+    TERMINAL_TOKEN="$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)"
+    node "$SCRIPT_DIR/terminal-action-server.js" \
+        --runtime-root "$COMPONENT_PATH" \
+        --ready-file "$TERMINAL_READY_FILE" \
+        --token "$TERMINAL_TOKEN" \
+        >"$RUNTIME_DIR/terminal-action-server.log" 2>&1 &
+    TERMINAL_SERVER_PID=$!
+    for _ in $(seq 1 100); do
+        if [ -s "$TERMINAL_READY_FILE" ]; then
+            break
+        fi
+        if ! kill -0 "$TERMINAL_SERVER_PID" >/dev/null 2>&1; then
+            echo "ERROR: terminal action server exited before becoming ready" >&2
+            cat "$RUNTIME_DIR/terminal-action-server.log" >&2 || true
+            exit 1
+        fi
+        sleep 0.1
+    done
+    if [ ! -s "$TERMINAL_READY_FILE" ]; then
+        echo "ERROR: terminal action server did not become ready" >&2
+        cat "$RUNTIME_DIR/terminal-action-server.log" >&2 || true
+        exit 1
+    fi
+    TERMINAL_URL=$(jq -r '.url' "$TERMINAL_READY_FILE")
+    CONFIG_JSON=$(jq -c \
+        --arg terminalUrl "$TERMINAL_URL" \
+        --arg terminalToken "$TERMINAL_TOKEN" \
+        '. + {
+            enable_terminal_actions: true,
+            terminal_action_url: $terminalUrl,
+            terminal_action_token: $terminalToken
+        }' <<<"$CONFIG_JSON")
+fi
 
 SETTINGS_JSON=$(jq -nc \
     --arg workloadPath "$WORKLOAD_PLAYGROUND_PATH" \
@@ -206,6 +249,11 @@ HOMEBOY_COMPONENT_PATH="$COMPONENT_PATH" \
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
     bash "$EXTENSION_PATH/scripts/bench/bench-runner.sh"
+
+if [ -n "$TERMINAL_SERVER_PID" ]; then
+    kill "$TERMINAL_SERVER_PID" >/dev/null 2>&1 || true
+    TERMINAL_SERVER_PID=""
+fi
 
 if [ "$PRINT_RESULTS" = "1" ]; then
     cat "$RESULTS_FILE"

--- a/wordpress/scripts/agent/terminal-action-server.js
+++ b/wordpress/scripts/agent/terminal-action-server.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+'use strict';
+
+/* eslint-disable no-console */
+
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const { executeTerminalAction } = require('../../lib/agent-terminal-actions');
+
+function parseArgs(argv) {
+	const args = {};
+	for (let index = 0; index < argv.length; index += 1) {
+		const entry = argv[index];
+		if (!entry.startsWith('--')) {
+			throw new Error(`Unexpected argument: ${entry}`);
+		}
+		const key = entry.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+		const value = argv[index + 1];
+		if (!value || value.startsWith('--')) {
+			throw new Error(`${entry} requires a value`);
+		}
+		args[key] = value;
+		index += 1;
+	}
+	return args;
+}
+
+function readJsonRequest(request) {
+	return new Promise((resolve, reject) => {
+		let body = '';
+		request.on('data', (chunk) => {
+			body += chunk.toString();
+			if (body.length > 1024 * 1024) {
+				reject(new Error('Request body too large'));
+				request.destroy();
+			}
+		});
+		request.on('end', () => {
+			try {
+				resolve(body ? JSON.parse(body) : {});
+			} catch (error) {
+				reject(error);
+			}
+		});
+		request.on('error', reject);
+	});
+}
+
+function writeJson(response, statusCode, payload) {
+	response.writeHead(statusCode, { 'content-type': 'application/json' });
+	response.end(`${JSON.stringify(payload)}\n`);
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const runtimeRoot = path.resolve(args.runtimeRoot || process.cwd());
+	const token = args.token || '';
+	const readyFile = args.readyFile || '';
+	const host = args.host || '127.0.0.1';
+	const port = Number(args.port || 0);
+
+	if (!token) {
+		throw new Error('--token is required');
+	}
+
+	const server = http.createServer(async (request, response) => {
+		try {
+			if (request.method === 'GET' && request.url === '/health') {
+				writeJson(response, 200, { ok: true });
+				return;
+			}
+
+			if (request.method !== 'POST' || request.url !== '/execute') {
+				writeJson(response, 404, { success: false, error: 'not_found' });
+				return;
+			}
+
+			if (request.headers.authorization !== `Bearer ${token}`) {
+				writeJson(response, 403, { success: false, error: 'forbidden' });
+				return;
+			}
+
+			const action = await readJsonRequest(request);
+			const result = await executeTerminalAction(action, {
+				runtimeRoot,
+				env: process.env,
+			});
+			writeJson(response, 200, result);
+		} catch (error) {
+			writeJson(response, 500, { success: false, error: error.message });
+		}
+	});
+
+	server.listen(port, host, () => {
+		const address = server.address();
+		const url = `http://${address.address}:${address.port}`;
+		if (readyFile) {
+			fs.writeFileSync(readyFile, `${JSON.stringify({ url, runtimeRoot })}\n`);
+		}
+		console.error(`homeboy terminal action server listening on ${url}`);
+	});
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/wordpress/tests/agent-terminal-actions-smoke.js
+++ b/wordpress/tests/agent-terminal-actions-smoke.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/* eslint-disable no-console */
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+	executeTerminalAction,
+	normalizeTerminalAction,
+} = require('../lib/agent-terminal-actions');
+
+const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-agent-terminal-'));
+const binDir = path.join(fixtureDir, 'bin');
+fs.mkdirSync(binDir, { recursive: true });
+fs.writeFileSync(
+	path.join(binDir, 'wp'),
+	'#!/usr/bin/env bash\nprintf "wp:%s\\n" "$*"\n',
+	{ mode: 0o755 }
+);
+
+async function main() {
+	try {
+		const normalized = normalizeTerminalAction(
+			{ type: 'wp_cli', command: 'option get blogname' },
+			{ runtimeRoot: fixtureDir, env: { PATH: `${binDir}:${process.env.PATH || ''}` } }
+		);
+
+		assert.equal(normalized.command, 'wp option get blogname');
+		assert.equal(normalized.cwd, fixtureDir);
+
+		const result = await executeTerminalAction(
+			{ type: 'wp_cli', command: 'option get blogname', timeout_ms: 5000 },
+			{ runtimeRoot: fixtureDir, env: { PATH: `${binDir}:${process.env.PATH || ''}` } }
+		);
+
+		assert.equal(result.success, true);
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.command, 'wp option get blogname');
+		assert.match(result.stdout, /wp:option get blogname/);
+		assert.equal(result.stderr, '');
+
+		assert.throws(
+			() => normalizeTerminalAction({ type: 'wp_cli', command: 'option get siteurl', cwd: '../outside' }, { runtimeRoot: fixtureDir }),
+			/cwd must stay inside the runtime root/
+		);
+
+		console.log('Agent terminal actions smoke passed.');
+	} finally {
+		fs.rmSync(fixtureDir, { recursive: true, force: true });
+	}
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/wordpress/tests/datamachine-terminal-tool-smoke.php
+++ b/wordpress/tests/datamachine-terminal-tool-smoke.php
@@ -1,0 +1,150 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$workload = $root . '/scripts/agent/datamachine-agent-workload.php';
+$source = file_get_contents($workload);
+if (false === $source) {
+	fwrite(STDERR, "Unable to read workload.\n");
+	exit(1);
+}
+
+$needle = 'class Homeboy_Datamachine_Agent_Terminal_Tool';
+$start = strpos($source, $needle);
+if (false === $start) {
+	fwrite(STDERR, "Terminal tool class not found.\n");
+	exit(1);
+}
+
+$brace = strpos($source, '{', $start);
+$depth = 0;
+$end = null;
+for ($index = $brace; $index < strlen($source); $index++) {
+	$char = $source[$index];
+	if ('{' === $char) {
+		$depth++;
+	} elseif ('}' === $char) {
+		$depth--;
+		if (0 === $depth) {
+			$end = $index + 1;
+			break;
+		}
+	}
+}
+if (null === $end) {
+	fwrite(STDERR, "Terminal tool class end not found.\n");
+	exit(1);
+}
+
+function wp_json_encode($value): string {
+	return (string) json_encode($value);
+}
+
+function wp_remote_post(string $url, array $args) {
+	$headers = '';
+	foreach (($args['headers'] ?? array()) as $name => $value) {
+		$headers .= $name . ': ' . $value . "\r\n";
+	}
+	$context = stream_context_create(
+		array(
+			'http' => array(
+				'method'        => 'POST',
+				'header'        => $headers,
+				'content'       => (string) ($args['body'] ?? ''),
+				'timeout'       => (int) ($args['timeout'] ?? 30),
+				'ignore_errors' => true,
+			),
+		)
+	);
+	$body = file_get_contents($url, false, $context);
+	if (false === $body) {
+		return array('error' => 'HTTP request failed');
+	}
+
+	$status = 0;
+	foreach (($http_response_header ?? array()) as $header) {
+		if (preg_match('/^HTTP\/\S+\s+(\d+)/', $header, $matches)) {
+			$status = (int) $matches[1];
+			break;
+		}
+	}
+
+	return array(
+		'response' => array('code' => $status),
+		'body'     => $body,
+	);
+}
+
+function is_wp_error($value): bool {
+	return is_array($value) && isset($value['error']);
+}
+
+function wp_remote_retrieve_response_code(array $response): int {
+	return (int) ($response['response']['code'] ?? 0);
+}
+
+function wp_remote_retrieve_body(array $response): string {
+	return (string) ($response['body'] ?? '');
+}
+
+eval(substr($source, $start, $end - $start));
+
+$runtime_dir = sys_get_temp_dir() . '/homeboy-php-terminal-tool-' . bin2hex(random_bytes(4));
+$bin_dir = $runtime_dir . '/bin';
+mkdir($bin_dir, 0777, true);
+file_put_contents($bin_dir . '/wp', "#!/usr/bin/env bash\nprintf 'php-tool-wp:%s\\n' \"$*\"\n");
+chmod($bin_dir . '/wp', 0755);
+
+$ready_file = $runtime_dir . '/ready.json';
+$token = 'php-smoke-token';
+$node = trim((string) shell_exec('command -v node'));
+if ('' === $node) {
+	fwrite(STDERR, "node is required for terminal action server smoke.\n");
+	exit(1);
+}
+$command = sprintf(
+	'PATH=%s:$PATH %s %s --runtime-root %s --ready-file %s --token %s >%s 2>&1 & echo $!',
+	escapeshellarg($bin_dir),
+	escapeshellarg($node),
+	escapeshellarg($root . '/scripts/agent/terminal-action-server.js'),
+	escapeshellarg($runtime_dir),
+	escapeshellarg($ready_file),
+	escapeshellarg($token),
+	escapeshellarg($runtime_dir . '/server.log')
+);
+$pid = (int) shell_exec($command);
+
+try {
+	$deadline = microtime(true) + 10;
+	while (! is_file($ready_file) && microtime(true) < $deadline) {
+		usleep(50000);
+	}
+	if (! is_file($ready_file)) {
+		fwrite(STDERR, "Terminal action server did not become ready.\n" . (string) @file_get_contents($runtime_dir . '/server.log'));
+		exit(1);
+	}
+
+	$ready = json_decode((string) file_get_contents($ready_file), true);
+	$tool = new Homeboy_Datamachine_Agent_Terminal_Tool();
+	$result = $tool->handle_tool_call(
+		array('command' => 'option get blogname'),
+		array(
+			'tool_name'             => 'run_wp_cli',
+			'terminal_action_url'   => $ready['url'],
+			'terminal_action_token' => $token,
+			'terminal_action_type'  => 'wp_cli',
+		)
+	);
+
+	if (empty($result['success']) || 'wp option get blogname' !== ($result['command'] ?? '') || ! str_contains((string) ($result['stdout'] ?? ''), 'php-tool-wp:option get blogname')) {
+		fwrite(STDERR, "Unexpected terminal tool result:\n" . json_encode($result, JSON_PRETTY_PRINT) . "\n");
+		exit(1);
+	}
+
+	fwrite(STDOUT, "Data Machine terminal tool smoke passed.\n");
+} finally {
+	if ($pid > 0) {
+		exec('kill ' . (int) $pid . ' >/dev/null 2>&1 || true');
+	}
+	exec('rm -rf ' . escapeshellarg($runtime_dir));
+}

--- a/wordpress/tests/terminal-action-server-smoke.js
+++ b/wordpress/tests/terminal-action-server-smoke.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/* eslint-disable no-console */
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-terminal-server-'));
+const readyFile = path.join(fixtureDir, 'ready.json');
+const binDir = path.join(fixtureDir, 'bin');
+const token = 'smoke-token';
+
+fs.mkdirSync(binDir, { recursive: true });
+fs.writeFileSync(path.join(binDir, 'wp'), '#!/usr/bin/env bash\nprintf "wp:%s\\n" "$*"\n', { mode: 0o755 });
+
+function waitForReady() {
+	return new Promise((resolve, reject) => {
+		const deadline = Date.now() + 10000;
+		const poll = () => {
+			if (fs.existsSync(readyFile)) {
+				resolve(JSON.parse(fs.readFileSync(readyFile, 'utf8')));
+				return;
+			}
+			if (Date.now() > deadline) {
+				reject(new Error('terminal action server did not become ready'));
+				return;
+			}
+			setTimeout(poll, 50);
+		};
+		poll();
+	});
+}
+
+function postJson(url, payload, bearer = token) {
+	return new Promise((resolve, reject) => {
+		const body = JSON.stringify(payload);
+		const request = http.request(`${url}/execute`, {
+			method: 'POST',
+			headers: {
+				authorization: `Bearer ${bearer}`,
+				'content-type': 'application/json',
+				'content-length': Buffer.byteLength(body),
+			},
+		}, (response) => {
+			let text = '';
+			response.on('data', (chunk) => {
+				text += chunk.toString();
+			});
+			response.on('end', () => {
+				resolve({ statusCode: response.statusCode, body: JSON.parse(text) });
+			});
+		});
+		request.on('error', reject);
+		request.end(body);
+	});
+}
+
+async function main() {
+	const child = spawn(process.execPath, [
+		path.join(__dirname, '../scripts/agent/terminal-action-server.js'),
+		'--runtime-root', fixtureDir,
+		'--ready-file', readyFile,
+		'--token', token,
+	], {
+		env: { ...process.env, PATH: `${binDir}:${process.env.PATH || ''}` },
+		stdio: ['ignore', 'ignore', 'pipe'],
+	});
+
+	try {
+		const ready = await waitForReady();
+		const response = await postJson(ready.url, { type: 'wp_cli', command: 'option get blogname' });
+		assert.equal(response.statusCode, 200);
+		assert.equal(response.body.success, true);
+		assert.equal(response.body.command, 'wp option get blogname');
+		assert.match(response.body.stdout, /wp:option get blogname/);
+
+		const forbidden = await postJson(ready.url, { type: 'wp_cli', command: 'option get blogname' }, 'wrong-token');
+		assert.equal(forbidden.statusCode, 403);
+
+		console.log('Terminal action server smoke passed.');
+	} finally {
+		child.kill('SIGTERM');
+		fs.rmSync(fixtureDir, { recursive: true, force: true });
+	}
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds a reusable `agent-terminal-actions` helper for runner-owned terminal actions.
- Supports `wp_cli` actions by executing the literal `wp ...` command through `bash -lc`, scoped to a runtime root, and returning exit code, stdout, stderr, duration, and timeout state.
- Adds a local HTTP sidecar that the Data Machine Playground workload can call with a bearer token, so model tool execution remains inside Data Machine while terminal execution happens on the host runner.
- Registers a `run_wp_cli` Data Machine tool when `enable_terminal_actions` or `enable_wp_cli_tool` is set, with smoke coverage proving the PHP tool reaches the host sidecar and fake `wp` binary.

## Context
This is the host-side primitive needed by consumers such as `wp-gym` and `world-of-wordpress` when an agent should experience WP-CLI like a normal terminal command, not through a WordPress Ability or in-process `WP_CLI::runcommand()` callback.

The earlier ability-backed experiment remains draft-only in #652 and is not the intended merge path.

## Testing
- `node wordpress/tests/agent-terminal-actions-smoke.js`
- `node wordpress/tests/terminal-action-server-smoke.js`
- `php wordpress/tests/datamachine-terminal-tool-smoke.php`
- `node --check wordpress/lib/agent-terminal-actions.js wordpress/scripts/agent/terminal-action-server.js wordpress/tests/agent-terminal-actions-smoke.js wordpress/tests/terminal-action-server-smoke.js`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php wordpress/tests/datamachine-terminal-tool-smoke.php`
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh`
- `homeboy lint --path wordpress --extension wordpress`

## Known test status
- `homeboy test --path wordpress --extension wordpress` still fails on existing audit smoke gates unrelated to this change:
  - `tests/audit-detector-config-smoke.sh`: `constant-backed slug detector should still flag comparisons`
  - `tests/audit-dead-guard-fallback-smoke.sh`: WordPress utility wrappers listed in `known_symbols.header_versions`
- The new terminal-action, sidecar, and PHP bridge smokes pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the host-side terminal action helper, sidecar bridge, Data Machine tool registration, smoke coverage, docs/exports, and running verification commands. Chris remains responsible for review and merge.