### PR TITLE
Allow Data Machine agent CI without directives

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -201,6 +201,13 @@ name: Data Machine Agent CI (reusable)
           imported agent runs with daily memory storage on. Default false.
         type: boolean
         default: false
+      disable_datamachine_directives:
+        description: |
+          When true, disables Data Machine's directive stack before agent
+          requests are assembled. Use for eval/training runs where benchmark
+          prompts must not inherit runner system context.
+        type: boolean
+        default: false
       extra_required_abilities:
         description: |
           JSON array of additional ability slugs the runner must assert are
@@ -561,6 +568,7 @@ jobs:
           WORKLOAD_RUN_BEFORE: ${{ inputs.workload_run_before }}
           WORKLOAD_RUN_AFTER: ${{ inputs.workload_run_after }}
           DAILY_MEMORY_ENABLED: ${{ inputs.daily_memory_enabled }}
+          DISABLE_DATAMACHINE_DIRECTIVES: ${{ inputs.disable_datamachine_directives }}
           EXTRA_REQUIRED_ABILITIES: ${{ inputs.extra_required_abilities }}
           ALLOWED_REPOS: ${{ inputs.allowed_repos }}
           ENGINE_KEY: ${{ inputs.engine_key }}
@@ -707,6 +715,7 @@ jobs:
             --argjson workloadRunBefore "$workload_run_before_json" \
             --argjson workloadRunAfter "$workload_run_after_json" \
             --argjson dailyMemoryEnabled "$DAILY_MEMORY_ENABLED" \
+            --argjson disableDatamachineDirectives "$DISABLE_DATAMACHINE_DIRECTIVES" \
             --argjson extraRequiredAbilities "$extra_required_abilities_json" \
             --argjson allowedRepos "$allowed_repos_json" \
             --argjson abilityTools "$ability_tools_json" \
@@ -791,7 +800,7 @@ jobs:
                 GITHUB_RUN_ID: $githubRunId,
                 GITHUB_RUN_ATTEMPT: $githubRunAttempt
               } + $providerBenchEnv)
-            } + (if $dailyMemoryEnabled then {daily_memory_enabled: true} else {} end)' > "$config_path"
+            } + (if $dailyMemoryEnabled then {daily_memory_enabled: true} else {} end) + (if $disableDatamachineDirectives then {disable_datamachine_directives: true} else {} end)' > "$config_path"
           printf 'config_path=%s\n' "$config_path" >> "$GITHUB_OUTPUT"
           printf 'transcript_host_dir=%s\n' "$transcript_host_dir" >> "$GITHUB_OUTPUT"
 

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1953,6 +1953,16 @@ if ( ! function_exists( 'homeboy_datamachine_agent_register_terminal_tools' ) ) 
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_register_directive_controls' ) ) {
+    function homeboy_datamachine_agent_register_directive_controls( array $config ): void {
+        if ( empty( $config['disable_datamachine_directives'] ) ) {
+            return;
+        }
+
+        add_filter( 'datamachine_directives_enabled', '__return_false', 100, 3 );
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_array_merge_recursive_distinct' ) ) {
     function homeboy_datamachine_agent_array_merge_recursive_distinct( array $base, array $patch ): array {
         foreach ( $patch as $key => $value ) {
@@ -2510,6 +2520,7 @@ foreach ( array( Agents::class, Pipelines::class, Flows::class, Jobs::class ) as
 }
 
 $settings = homeboy_datamachine_agent_configure_settings( $config );
+homeboy_datamachine_agent_register_directive_controls( $config );
 homeboy_datamachine_agent_register_terminal_tools( $config );
 homeboy_datamachine_agent_register_tool_recorders( $config );
 


### PR DESCRIPTION
## Summary
- Adds a `disable_datamachine_directives` input to the reusable Data Machine agent CI workflow.
- Propagates the flag into the runner config as `disable_datamachine_directives`.
- Registers `datamachine_directives_enabled => false` in the Playground workload when that flag is set, so eval/training runs can use Data Machine orchestration without standard Data Machine prompt directives.

## Dependency
- Depends on Extra-Chill/data-machine#2030 for the `datamachine_directives_enabled` hook. Older Data Machine versions ignore this filter registration harmlessly because no code applies the hook.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@disable-datamachine-directives/wordpress --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Wiring the reusable workflow input, runner config, workload hook registration, and running focused verification. Chris remains responsible for review and merge.