### PR TITLE
fix(wordpress): accept completion outcome agent runs

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -897,11 +897,22 @@ jobs:
           RESULTS_FILE: ${{ runner.temp }}/run-results.json
         run: |
           set -euo pipefail
-          bash .ci/homeboy-extensions/wordpress/scripts/agent/extract-engine-data.sh \
-            --results "$RESULTS_FILE" \
-            --scenario "${{ inputs.flow_slug }}" \
-            --field job_status=metadata.job_status \
-            --required-status completed
+          scenario_json="$(jq -ec --arg scenario "${{ inputs.flow_slug }}" '.scenarios[] | select(.id == $scenario)' "$RESULTS_FILE")"
+          job_status="$(jq -r '.metadata.job_status // ""' <<< "$scenario_json")"
+          completion_outcome_satisfied="$(jq -r 'if .metadata.completion_outcome_satisfied == true then "true" else "false" end' <<< "$scenario_json")"
+
+          printf 'job_status:                      %s\n' "$job_status"
+          printf 'completion_outcome_satisfied:    %s\n' "$completion_outcome_satisfied"
+
+          if [ "$job_status" = "completed" ] || [ "$completion_outcome_satisfied" = "true" ]; then
+            exit 0
+          fi
+
+          printf 'ERROR: scenario %s expected completed job or satisfied completion outcome, got job_status=%s completion_outcome_satisfied=%s\n' \
+            "${{ inputs.flow_slug }}" \
+            "$job_status" \
+            "$completion_outcome_satisfied" >&2
+          exit 1
 
       - name: Resolve transcript artifact path
         id: transcript-artifact

--- a/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
@@ -134,6 +134,10 @@ namespace {
 		fwrite( STDERR, "Expected reusable workflow config to require import-agent for execute-workflow runs.\n" );
 		exit( 1 );
 	}
+	if ( ! str_contains( $workflow_source, 'completion_outcome_satisfied="$(jq -r' ) || ! str_contains( $workflow_source, '[ "$job_status" = "completed" ] || [ "$completion_outcome_satisfied" = "true" ]' ) ) {
+		fwrite( STDERR, "Expected reusable workflow success assertion to accept satisfied completion outcomes.\n" );
+		exit( 1 );
+	}
 
 	$jobs = new \DataMachine\Core\Database\Jobs\Jobs();
     $summary = homeboy_datamachine_agent_drain_child_jobs( 101, array(), $jobs );


### PR DESCRIPTION
## Summary
- Let the reusable Data Machine agent CI workflow pass when a configured `success_completion_outcomes` value is satisfied, even if the underlying Data Machine job status is not `completed`.
- Preserve the existing strict completed-job success path.
- Add smoke coverage that the workflow assertion honors completion outcomes.

## Tests
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the reusable workflow success assertion mismatch from wp-site-generator runs, drafted the workflow/smoke update, and ran focused checks; Chris remains responsible for review and merge.