### PR TITLE
feat(wordpress): add release.package and release.publish actions

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,7 +10,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/release/package.sh scripts/release/publish.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
       "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js scripts/agent/terminal-action-server.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js",
       "php -l scripts/agent/datamachine-agent-workload.php tests/datamachine-terminal-tool-smoke.php"
     ],
@@ -31,6 +31,7 @@
       "bash tests/audit-detector-config-smoke.sh",
       "bash tests/audit-dead-guard-fallback-smoke.sh",
       "bash tests/eslint-eqeqeq-null-smoke.sh",
+      "bash tests/release-scripts-smoke.sh",
       "node tests/request-profiler-smoke.js",
       "node tests/playground-readiness-smoke.js",
       "node tests/agent-terminal-actions-smoke.js",

--- a/wordpress/scripts/release/package.sh
+++ b/wordpress/scripts/release/package.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a vendor-bundled WordPress plugin or theme ZIP and emit machine-readable
+# artifact JSON for the release pipeline. Human-readable logs go to stderr;
+# only the final JSON payload is written to stdout.
+#
+# Reuses scripts/build/build.sh (the same script the build command runs) so
+# release artifacts are produced exactly the same way as developer builds.
+# That keeps a single source of truth for build behaviour and avoids
+# release-only surprises like missing vendor directories or stripped files.
+#
+# Output JSON shape (matches the homeboy release pipeline contract):
+#   [{"path": "build/<component>.zip", "type": "wordpress-zip", "platform": null}]
+#
+# Env vars expected by the upstream pipeline:
+#   HOMEBOY_COMPONENT_ID   - component id (used by build.sh to name the ZIP)
+#   HOMEBOY_RUNTIME_*      - resolve-context helpers (set automatically)
+#
+# Optional:
+#   HOMEBOY_SETTINGS_JSON  - JSON payload from homeboy with release.version,
+#                            release.tag, and release.component_id. Not parsed
+#                            here because build.sh derives names from
+#                            HOMEBOY_COMPONENT_ID and plugin/theme headers
+#                            directly. The publish step consumes the tag.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BUILD_SCRIPT="${EXTENSION_PATH}/scripts/build/build.sh"
+
+if [[ ! -x "${BUILD_SCRIPT}" ]] && [[ ! -r "${BUILD_SCRIPT}" ]]; then
+  echo "Error: build script not found at ${BUILD_SCRIPT}" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required to emit release artifact JSON" >&2
+  exit 1
+fi
+
+# Resolve the component slug the way build.sh does (so the ZIP path matches).
+COMPONENT_SLUG="${HOMEBOY_COMPONENT_ID:-}"
+if [[ -z "${COMPONENT_SLUG}" ]]; then
+  # Fall back to a plugin/theme header probe so this script also works when
+  # invoked outside the homeboy release pipeline (developer dry-runs).
+  for candidate in *.php; do
+    [[ -f "${candidate}" ]] || continue
+    if grep -q "^[[:space:]]*\*\?[[:space:]]*Plugin Name:" "${candidate}"; then
+      COMPONENT_SLUG="${candidate%.php}"
+      break
+    fi
+  done
+  if [[ -z "${COMPONENT_SLUG}" ]] && [[ -f "style.css" ]]; then
+    if grep -q "^[[:space:]]*\*\?[[:space:]]*Theme Name:" "style.css"; then
+      COMPONENT_SLUG="$(basename "$(pwd)")"
+    fi
+  fi
+fi
+
+if [[ -z "${COMPONENT_SLUG}" ]]; then
+  echo "Error: could not determine WordPress component slug (set HOMEBOY_COMPONENT_ID)" >&2
+  exit 1
+fi
+
+echo "Building release ZIP for ${COMPONENT_SLUG}..." >&2
+
+# Run the standard build pipeline. build.sh produces build/${COMPONENT_SLUG}.zip
+# and prints its own progress to stdout/stderr; redirect stdout to stderr so we
+# can keep the artifact JSON line clean.
+bash "${BUILD_SCRIPT}" >&2
+
+ARTIFACT_PATH="build/${COMPONENT_SLUG}.zip"
+
+if [[ ! -f "${ARTIFACT_PATH}" ]]; then
+  echo "Error: expected ZIP at ${ARTIFACT_PATH} but none was produced" >&2
+  exit 1
+fi
+
+echo "Built ${ARTIFACT_PATH}" >&2
+
+jq -cn --arg path "${ARTIFACT_PATH}" \
+  '[{path: $path, type: "wordpress-zip", platform: null}]'

--- a/wordpress/scripts/release/publish.sh
+++ b/wordpress/scripts/release/publish.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Upload a WordPress plugin/theme release ZIP to the GitHub Release for the
+# current tag. Idempotent: re-running for an existing asset uses --clobber so
+# partial-success release runs can be safely retried.
+#
+# This action runs as part of the homeboy release pipeline after the package
+# step has produced build/<slug>.zip and the github.release step has created
+# the Release entry on GitHub.
+#
+# Reads the release payload from HOMEBOY_SETTINGS_JSON which homeboy passes
+# when invoking extension actions. The payload shape is:
+#   { "release": { "tag": "vX.Y.Z", "component_id": "data-machine", ... },
+#     "config":  { ... } }
+#
+# Requires:
+#   - gh CLI on PATH (used for both auth check and upload)
+#   - GH_TOKEN or gh auth login session
+#   - GITHUB_REPOSITORY env (set by GitHub Actions) or git remote origin
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: gh CLI is required to upload release assets" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required to parse the release payload" >&2
+  exit 1
+fi
+
+PAYLOAD="${HOMEBOY_SETTINGS_JSON:-}"
+if [[ -z "${PAYLOAD}" ]]; then
+  echo "Error: HOMEBOY_SETTINGS_JSON is empty (homeboy release pipeline must invoke this action)" >&2
+  exit 1
+fi
+
+TAG="$(echo "${PAYLOAD}" | jq -r '.release.tag // empty')"
+COMPONENT_SLUG="$(echo "${PAYLOAD}" | jq -r '.release.component_id // empty')"
+
+if [[ -z "${TAG}" ]]; then
+  echo "Error: release payload did not contain release.tag" >&2
+  exit 1
+fi
+
+if [[ -z "${COMPONENT_SLUG}" ]]; then
+  COMPONENT_SLUG="${HOMEBOY_COMPONENT_ID:-}"
+fi
+
+if [[ -z "${COMPONENT_SLUG}" ]]; then
+  echo "Error: could not determine component slug for ZIP lookup" >&2
+  exit 1
+fi
+
+ARTIFACT_PATH="build/${COMPONENT_SLUG}.zip"
+
+if [[ ! -f "${ARTIFACT_PATH}" ]]; then
+  echo "Error: expected release artifact at ${ARTIFACT_PATH}, run release.package first" >&2
+  exit 1
+fi
+
+# Resolve the GitHub repository slug. Prefer the env var set by GitHub Actions;
+# fall back to parsing the origin remote so local dry-runs also work.
+REPO_SLUG="${GITHUB_REPOSITORY:-}"
+if [[ -z "${REPO_SLUG}" ]]; then
+  REMOTE_URL="$(git config --get remote.origin.url 2>/dev/null || true)"
+  if [[ -n "${REMOTE_URL}" ]]; then
+    # Normalize both git@github.com:owner/repo.git and https://github.com/owner/repo(.git)
+    REPO_SLUG="$(echo "${REMOTE_URL}" \
+      | sed -E 's#^git@github\.com:#https://github.com/#' \
+      | sed -E 's#\.git$##' \
+      | sed -E 's#^https://github\.com/##')"
+  fi
+fi
+
+if [[ -z "${REPO_SLUG}" ]]; then
+  echo "Error: could not determine GitHub repository (set GITHUB_REPOSITORY or configure git remote origin)" >&2
+  exit 1
+fi
+
+echo "Uploading ${ARTIFACT_PATH} to ${REPO_SLUG} release ${TAG}..." >&2
+
+gh release upload "${TAG}" "${ARTIFACT_PATH}" \
+  --clobber \
+  --repo "${REPO_SLUG}" >&2
+
+echo "Uploaded ${ARTIFACT_PATH} to ${REPO_SLUG} release ${TAG}" >&2
+
+# Emit a small JSON receipt so the homeboy pipeline can record this as a
+# successful publish step. Match the shape other publish targets use.
+jq -cn \
+  --arg tag "${TAG}" \
+  --arg repo "${REPO_SLUG}" \
+  --arg path "${ARTIFACT_PATH}" \
+  '{
+    target: "github-release-asset",
+    tag: $tag,
+    repository: $repo,
+    artifact_path: $path,
+    success: true
+  }'

--- a/wordpress/tests/release-scripts-smoke.sh
+++ b/wordpress/tests/release-scripts-smoke.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Smoke test for the wordpress extension release pipeline scripts.
+#
+# Validates:
+#   - scripts/release/package.sh emits a single-line JSON array with the
+#     expected artifact shape when build/<slug>.zip exists.
+#   - scripts/release/publish.sh refuses to run when HOMEBOY_SETTINGS_JSON is
+#     missing.
+#   - scripts/release/publish.sh refuses to run when the artifact ZIP is
+#     missing.
+#   - scripts/release/publish.sh refuses to run when release.tag is missing
+#     from the payload.
+#
+# These checks exercise the failure paths without requiring gh, network, or
+# a real GitHub repository — the happy path is exercised by the live release
+# pipeline.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PACKAGE_SH="${EXTENSION_PATH}/scripts/release/package.sh"
+PUBLISH_SH="${EXTENSION_PATH}/scripts/release/publish.sh"
+
+if [[ ! -x "${PACKAGE_SH}" ]]; then
+  echo "FAIL: package.sh is not executable" >&2
+  exit 1
+fi
+
+if [[ ! -x "${PUBLISH_SH}" ]]; then
+  echo "FAIL: publish.sh is not executable" >&2
+  exit 1
+fi
+
+# Use a throwaway working directory so we don't disturb the extension repo.
+WORK_DIR="$(mktemp -d -t homeboy-wp-release-smoke.XXXXXX)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+cd "${WORK_DIR}"
+
+failures=0
+
+# ---------------------------------------------------------------------------
+# package.sh: emits artifact JSON when build/<slug>.zip exists.
+# ---------------------------------------------------------------------------
+mkdir -p build
+echo "fake-zip-bytes" > build/test-plugin.zip
+
+# Replace the real build script with a no-op so we don't actually run the
+# WordPress build harness (which needs composer, node, plugin headers, …).
+PACKAGE_SCRIPT_DIR="$(mktemp -d -t homeboy-wp-release-pkg.XXXXXX)"
+trap 'rm -rf "${WORK_DIR}" "${PACKAGE_SCRIPT_DIR}"' EXIT
+mkdir -p "${PACKAGE_SCRIPT_DIR}/scripts/build" "${PACKAGE_SCRIPT_DIR}/scripts/release"
+cat > "${PACKAGE_SCRIPT_DIR}/scripts/build/build.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "stub build" >&2
+STUB
+chmod +x "${PACKAGE_SCRIPT_DIR}/scripts/build/build.sh"
+cp "${PACKAGE_SH}" "${PACKAGE_SCRIPT_DIR}/scripts/release/package.sh"
+chmod +x "${PACKAGE_SCRIPT_DIR}/scripts/release/package.sh"
+
+stub_output="$(HOMEBOY_COMPONENT_ID=test-plugin "${PACKAGE_SCRIPT_DIR}/scripts/release/package.sh" 2>/dev/null)" || stub_output=""
+
+if [[ -z "${stub_output}" ]]; then
+  echo "FAIL: package.sh produced no stdout" >&2
+  failures=$((failures + 1))
+elif ! echo "${stub_output}" | jq -e '.[0].path == "build/test-plugin.zip"' >/dev/null 2>&1; then
+  echo "FAIL: package.sh JSON does not have expected path; got: ${stub_output}" >&2
+  failures=$((failures + 1))
+elif ! echo "${stub_output}" | jq -e '.[0].type == "wordpress-zip"' >/dev/null 2>&1; then
+  echo "FAIL: package.sh JSON does not have type=wordpress-zip; got: ${stub_output}" >&2
+  failures=$((failures + 1))
+else
+  echo "OK: package.sh emits expected artifact JSON"
+fi
+
+# ---------------------------------------------------------------------------
+# publish.sh: missing HOMEBOY_SETTINGS_JSON should fail loudly.
+# ---------------------------------------------------------------------------
+set +e
+unset HOMEBOY_SETTINGS_JSON
+publish_err="$("${PUBLISH_SH}" 2>&1 >/dev/null)"
+publish_status=$?
+set -e
+
+if [[ ${publish_status} -eq 0 ]]; then
+  echo "FAIL: publish.sh exited 0 without HOMEBOY_SETTINGS_JSON" >&2
+  failures=$((failures + 1))
+elif ! echo "${publish_err}" | grep -q "HOMEBOY_SETTINGS_JSON is empty"; then
+  echo "FAIL: publish.sh did not surface the missing-payload error; got: ${publish_err}" >&2
+  failures=$((failures + 1))
+else
+  echo "OK: publish.sh rejects empty HOMEBOY_SETTINGS_JSON"
+fi
+
+# ---------------------------------------------------------------------------
+# publish.sh: missing release.tag should fail loudly.
+# ---------------------------------------------------------------------------
+set +e
+publish_err="$(HOMEBOY_SETTINGS_JSON='{"release":{}}' "${PUBLISH_SH}" 2>&1 >/dev/null)"
+publish_status=$?
+set -e
+
+if [[ ${publish_status} -eq 0 ]]; then
+  echo "FAIL: publish.sh exited 0 with missing release.tag" >&2
+  failures=$((failures + 1))
+elif ! echo "${publish_err}" | grep -q "release.tag"; then
+  echo "FAIL: publish.sh did not surface the missing-tag error; got: ${publish_err}" >&2
+  failures=$((failures + 1))
+else
+  echo "OK: publish.sh rejects missing release.tag"
+fi
+
+# ---------------------------------------------------------------------------
+# publish.sh: missing artifact ZIP should fail loudly.
+# ---------------------------------------------------------------------------
+set +e
+publish_err="$(HOMEBOY_SETTINGS_JSON='{"release":{"tag":"v0.0.0","component_id":"missing-plugin"}}' "${PUBLISH_SH}" 2>&1 >/dev/null)"
+publish_status=$?
+set -e
+
+if [[ ${publish_status} -eq 0 ]]; then
+  echo "FAIL: publish.sh exited 0 with missing artifact ZIP" >&2
+  failures=$((failures + 1))
+elif ! echo "${publish_err}" | grep -q "missing-plugin.zip"; then
+  echo "FAIL: publish.sh did not surface the missing-artifact error; got: ${publish_err}" >&2
+  failures=$((failures + 1))
+else
+  echo "OK: publish.sh rejects missing artifact ZIP"
+fi
+
+if [[ ${failures} -gt 0 ]]; then
+  echo "FAIL: release-scripts-smoke had ${failures} failure(s)" >&2
+  exit 1
+fi
+
+echo "PASS: release-scripts-smoke"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -916,5 +916,27 @@
       "default": "",
       "description": "Optional pass-through for wp-playground-cli --wordpress-install-mode. Leave empty unless a bench needs a non-default Playground install policy; bench_site_mode chooses the normal default for fresh versus installed runs."
     }
+  ],
+  "actions": [
+    {
+      "id": "release.package",
+      "label": "Build WordPress plugin/theme ZIP",
+      "type": "command",
+      "command": "bash \"{{extension_path}}/scripts/release/package.sh\"",
+      "payload": {
+        "release": "{{payload.release}}",
+        "config": "{{payload.config}}"
+      }
+    },
+    {
+      "id": "release.publish",
+      "label": "Upload release ZIP to GitHub Release assets",
+      "type": "command",
+      "command": "bash \"{{extension_path}}/scripts/release/publish.sh\"",
+      "payload": {
+        "release": "{{payload.release}}",
+        "config": "{{payload.config}}"
+      }
+    }
   ]
 }


### PR DESCRIPTION
## Summary

The wordpress extension didn't participate in homeboy's release artifact pipeline. The other extensions (`nodejs`, `rust`) already provide `release.package` and `release.publish` actions, which let `homeboy release` build artifacts and publish them as part of the standard pipeline. This PR closes that gap for WordPress.

```diff
+ wordpress/scripts/release/package.sh
+ wordpress/scripts/release/publish.sh
+ wordpress/tests/release-scripts-smoke.sh
~ wordpress/wordpress.json   # add two actions to the manifest
~ wordpress/homeboy.json     # cover the new scripts in self_checks
```

### What the actions do

| Action | Purpose | Mechanism |
|---|---|---|
| `release.package` | Build the vendor-bundled plugin/theme ZIP | Reuses `scripts/build/build.sh` (the same script the build command runs) so release artifacts are produced identically to developer builds. Emits the standard artifact JSON: `[{"path": "build/<slug>.zip", "type": "wordpress-zip", "platform": null}]` |
| `release.publish` | Upload the ZIP to the matching GitHub Release | `gh release upload <tag> build/<slug>.zip --clobber` against the repo derived from `GITHUB_REPOSITORY` (or the local `origin` remote for dry-runs). Idempotent — re-running for an existing asset uses `--clobber` so partial-success retries are safe |

The publish step reads the release tag and component slug from `HOMEBOY_SETTINGS_JSON.release` — the same payload contract every other extension action uses, set by `homeboy::core::extension::execution::build_action_env`.

### Pipeline integration

Homeboy's release planner (`core/release/plan_steps.rs::build_release_steps`) sees the new `release.publish` action and adds a `publish.wordpress` step automatically. Final pipeline:

```
changelog.finalize → version → git.commit → package → git.tag
                                              ↓
                                            git.push → github.release → publish.wordpress
```

`package` runs **before** `git.tag` so the artifact exists by the time `publish.wordpress` runs against the just-created GitHub Release.

### What downstream WordPress components gain

Any component whose `homeboy.json` declares `"extensions": { "wordpress": {} }` (today: `data-machine`, `data-machine-code`, and effectively every Extra-Chill WordPress plugin) now gets ZIP build + GitHub release asset upload as part of `homeboy release` with zero extra workflow files.

This means the custom `release-asset.yml` workflows that `data-machine` and `data-machine-code` each maintain become deletable in follow-up PRs. Those workflows currently:
- Trigger on `release.published`
- Re-checkout, re-install composer + npm deps, rsync into `dist/`, zip
- Upload the ZIP via `gh release upload`

All of which is exactly what `release.package + release.publish` do, but as part of the homeboy pipeline itself with proper artifact metadata in `state.artifacts` for any downstream consumers.

### Validation

Includes `tests/release-scripts-smoke.sh` which exercises the failure paths:

| Check | Expected behaviour |
|---|---|
| `package.sh` emits valid JSON when `build/<slug>.zip` exists | ✅ |
| `publish.sh` rejects empty `HOMEBOY_SETTINGS_JSON` | ✅ |
| `publish.sh` rejects payload missing `release.tag` | ✅ |
| `publish.sh` rejects missing artifact ZIP | ✅ |

The happy path (actual `gh release upload`) is exercised by the live release pipeline. Local run:

```
$ bash wordpress/tests/release-scripts-smoke.sh
OK: package.sh emits expected artifact JSON
OK: publish.sh rejects empty HOMEBOY_SETTINGS_JSON
OK: publish.sh rejects missing release.tag
OK: publish.sh rejects missing artifact ZIP
PASS: release-scripts-smoke
```

The new scripts are also added to `homeboy.json` `self_checks.lint` (`bash -n`) and `self_checks.test` (the smoke runner).

### CORS / Playground note

This PR makes WordPress plugin releases automatable through `homeboy release`. It does **not** fix the separate CORS issue where GitHub release asset downloads (`releases/latest/download/<plugin>.zip`) fail in browser-based WordPress Playground because S3 doesn't send `Access-Control-Allow-Origin` headers. That's a follow-up: extend `release.publish` to also push the vendor-bundled tree to a `release-latest` branch in the same repo so Playground blueprints can pull it via `git:directory` (which goes through Playground's CORS proxy). Scoped out of this PR to keep the change focused on the homeboy pipeline integration.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Identified the missing homeboy release-pipeline integration during a Discord debugging session about WordPress Playground asset failures, modeled the new actions after the existing nodejs/rust scripts, drafted the scripts and smoke tests. Chris confirmed the homeboy gap and chose the recommended scope (GitHub release assets only, defer release-latest branch push to a follow-up).