### PR TITLE
feat(wordpress): mirror release ZIP to a CORS-friendly branch

### DIFF
--- a/wordpress/scripts/release/publish.sh
+++ b/wordpress/scripts/release/publish.sh
@@ -2,8 +2,15 @@
 set -euo pipefail
 
 # Upload a WordPress plugin/theme release ZIP to the GitHub Release for the
-# current tag. Idempotent: re-running for an existing asset uses --clobber so
-# partial-success release runs can be safely retried.
+# current tag, and optionally mirror the unzipped vendor-bundled tree to a
+# CORS-friendly branch (e.g. "release-latest") so WordPress Playground
+# blueprints can install it via `git:directory` without hitting CORS errors
+# on the GitHub release-asset CDN.
+#
+# Idempotent: re-running for an existing asset uses --clobber so partial-
+# success release runs can be safely retried. The release-latest branch is
+# always force-pushed to the new tree because it intentionally has no
+# linear history — each release replaces the entire branch.
 #
 # This action runs as part of the homeboy release pipeline after the package
 # step has produced build/<slug>.zip and the github.release step has created
@@ -14,10 +21,26 @@ set -euo pipefail
 #   { "release": { "tag": "vX.Y.Z", "component_id": "data-machine", ... },
 #     "config":  { ... } }
 #
+# Reads the release-latest branch name from the component's homeboy.json at
+# .extensions.wordpress.release_latest_branch. When empty or unset the mirror
+# push is skipped — the GitHub release-asset upload always runs. Components
+# that want the branch mirror set it to e.g. "release-latest" in their
+# homeboy.json:
+#
+#   {
+#     "extensions": {
+#       "wordpress": {
+#         "release_latest_branch": "release-latest"
+#       }
+#     }
+#   }
+#
 # Requires:
 #   - gh CLI on PATH (used for both auth check and upload)
 #   - GH_TOKEN or gh auth login session
 #   - GITHUB_REPOSITORY env (set by GitHub Actions) or git remote origin
+#   - git on PATH
+#   - unzip on PATH (when release_latest_branch is configured)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -89,16 +112,100 @@ gh release upload "${TAG}" "${ARTIFACT_PATH}" \
 
 echo "Uploaded ${ARTIFACT_PATH} to ${REPO_SLUG} release ${TAG}" >&2
 
-# Emit a small JSON receipt so the homeboy pipeline can record this as a
-# successful publish step. Match the shape other publish targets use.
+# Optional: mirror the unzipped vendor-bundled tree to a CORS-friendly branch
+# so WordPress Playground blueprints can install via git:directory without
+# the release-asset CDN's missing Access-Control-Allow-Origin header.
+RELEASE_LATEST_BRANCH=""
+if [[ -f "homeboy.json" ]]; then
+  RELEASE_LATEST_BRANCH="$(jq -r '.extensions.wordpress.release_latest_branch // ""' homeboy.json)"
+fi
+
+if [[ -z "${RELEASE_LATEST_BRANCH}" ]]; then
+  echo "release_latest_branch not configured; skipping branch mirror" >&2
+  PUSHED_BRANCH=""
+else
+  if ! command -v unzip >/dev/null 2>&1; then
+    echo "Error: unzip is required to mirror the release tree to ${RELEASE_LATEST_BRANCH}" >&2
+    exit 1
+  fi
+
+  if [[ -z "${GH_TOKEN:-}" ]]; then
+    # The release pipeline always exports GH_TOKEN, but make the failure
+    # mode obvious for anyone running this script outside the standard CI
+    # context.
+    echo "Error: GH_TOKEN is required to push to ${RELEASE_LATEST_BRANCH}" >&2
+    exit 1
+  fi
+
+  echo "Mirroring ${ARTIFACT_PATH} to ${REPO_SLUG} branch ${RELEASE_LATEST_BRANCH}..." >&2
+
+  MIRROR_WORKTREE="$(mktemp -d -t homeboy-wp-release-mirror.XXXXXX)"
+  trap 'rm -rf "${MIRROR_WORKTREE}"' EXIT
+
+  unzip -q "${ARTIFACT_PATH}" -d "${MIRROR_WORKTREE}/extracted"
+
+  # The build script wraps the plugin/theme in a directory named after the
+  # component slug. The mirror branch should expose the contents of that
+  # wrapper at its root so consumers using `git:directory` get a directly
+  # installable WordPress plugin/theme tree.
+  ZIP_ROOT="${MIRROR_WORKTREE}/extracted/${COMPONENT_SLUG}"
+  if [[ ! -d "${ZIP_ROOT}" ]]; then
+    # Fall back to the only top-level entry when the ZIP root name does not
+    # match the component slug (rare; happens for renames mid-flight).
+    candidates=("${MIRROR_WORKTREE}/extracted"/*)
+    if [[ ${#candidates[@]} -eq 1 ]] && [[ -d "${candidates[0]}" ]]; then
+      ZIP_ROOT="${candidates[0]}"
+    else
+      echo "Error: could not locate plugin/theme root inside ${ARTIFACT_PATH}" >&2
+      exit 1
+    fi
+  fi
+
+  # Initialise a single-commit orphan branch in a separate working directory
+  # so we never touch the source repo's index or HEAD. The branch
+  # intentionally has no shared history with main; each release replaces
+  # the entire branch contents.
+  MIRROR_REPO="${MIRROR_WORKTREE}/repo"
+  mkdir -p "${MIRROR_REPO}"
+  git -C "${MIRROR_REPO}" init -q -b "${RELEASE_LATEST_BRANCH}"
+  git -C "${MIRROR_REPO}" config user.email "homeboy-release@example.invalid"
+  git -C "${MIRROR_REPO}" config user.name "Homeboy Release"
+
+  # Copy the extracted tree into the temporary repo. cp -a preserves modes
+  # and symlinks; the trailing /. copies contents rather than the directory.
+  cp -a "${ZIP_ROOT}/." "${MIRROR_REPO}/"
+
+  git -C "${MIRROR_REPO}" add -A
+  git -C "${MIRROR_REPO}" commit -q -m "Release ${TAG}
+
+Mirror of release ZIP ${ARTIFACT_PATH} for ${COMPONENT_SLUG}.
+Generated by homeboy-extensions/wordpress release.publish.
+Branch is force-pushed on every release; do not commit here directly."
+
+  # Push using a token-authenticated HTTPS URL. We never reuse the source
+  # repo's remote so the source checkout's credentials are untouched.
+  REMOTE_AUTHENTICATED_URL="https://x-access-token:${GH_TOKEN}@github.com/${REPO_SLUG}.git"
+
+  git -C "${MIRROR_REPO}" push --force "${REMOTE_AUTHENTICATED_URL}" \
+    "${RELEASE_LATEST_BRANCH}:${RELEASE_LATEST_BRANCH}" >&2
+
+  echo "Mirrored ${ARTIFACT_PATH} to ${REPO_SLUG} branch ${RELEASE_LATEST_BRANCH}" >&2
+  PUSHED_BRANCH="${RELEASE_LATEST_BRANCH}"
+fi
+
+# Emit a JSON receipt for the homeboy pipeline. Include the mirror branch
+# when one was pushed so downstream tooling can verify the dual-publish
+# without re-reading homeboy.json.
 jq -cn \
   --arg tag "${TAG}" \
   --arg repo "${REPO_SLUG}" \
   --arg path "${ARTIFACT_PATH}" \
+  --arg branch "${PUSHED_BRANCH}" \
   '{
     target: "github-release-asset",
     tag: $tag,
     repository: $repo,
     artifact_path: $path,
+    release_latest_branch: (if $branch == "" then null else $branch end),
     success: true
   }'

--- a/wordpress/tests/release-scripts-smoke.sh
+++ b/wordpress/tests/release-scripts-smoke.sh
@@ -10,10 +10,15 @@
 #     missing.
 #   - scripts/release/publish.sh refuses to run when release.tag is missing
 #     from the payload.
+#   - scripts/release/publish.sh skips the release-latest branch mirror when
+#     homeboy.json does not configure it and emits a null branch in the
+#     receipt.
+#   - scripts/release/publish.sh executes the release-latest branch mirror
+#     when homeboy.json configures it and emits the branch name in the
+#     receipt.
 #
-# These checks exercise the failure paths without requiring gh, network, or
-# a real GitHub repository — the happy path is exercised by the live release
-# pipeline.
+# Stubs gh and git for the happy-path tests so we never touch the network
+# or a real GitHub repository.
 
 set -euo pipefail
 
@@ -34,10 +39,34 @@ fi
 
 # Use a throwaway working directory so we don't disturb the extension repo.
 WORK_DIR="$(mktemp -d -t homeboy-wp-release-smoke.XXXXXX)"
-trap 'rm -rf "${WORK_DIR}"' EXIT
+STUB_BIN_DIR="$(mktemp -d -t homeboy-wp-release-bin.XXXXXX)"
+trap 'rm -rf "${WORK_DIR}" "${STUB_BIN_DIR}"' EXIT
 cd "${WORK_DIR}"
 
 failures=0
+
+# Build a tiny stub for gh that always succeeds for "release upload" and a
+# pass-through stub for git. The real binaries stay on PATH for everything
+# else.
+cat > "${STUB_BIN_DIR}/gh" <<'STUB_GH'
+#!/usr/bin/env bash
+# gh stub for release-scripts-smoke. Accept any args; just succeed.
+case "$1" in
+  release)
+    shift
+    case "$1" in
+      upload)
+        # gh release upload <tag> <file> --clobber --repo <slug>
+        echo "stub: gh release upload $*" >&2
+        exit 0
+        ;;
+    esac
+    ;;
+esac
+echo "stub: gh $*" >&2
+exit 0
+STUB_GH
+chmod +x "${STUB_BIN_DIR}/gh"
 
 # ---------------------------------------------------------------------------
 # package.sh: emits artifact JSON when build/<slug>.zip exists.
@@ -126,6 +155,122 @@ elif ! echo "${publish_err}" | grep -q "missing-plugin.zip"; then
   failures=$((failures + 1))
 else
   echo "OK: publish.sh rejects missing artifact ZIP"
+fi
+
+# ---------------------------------------------------------------------------
+# publish.sh: skips release-latest branch when homeboy.json does not declare
+# extensions.wordpress.release_latest_branch. Receipt has release_latest_branch=null.
+# ---------------------------------------------------------------------------
+HAPPY_DIR="$(mktemp -d -t homeboy-wp-release-happy.XXXXXX)"
+trap 'rm -rf "${WORK_DIR}" "${STUB_BIN_DIR}" "${HAPPY_DIR}"' EXIT
+mkdir -p "${HAPPY_DIR}/build"
+
+# Produce a minimal valid ZIP that unzip can read in the configured-branch
+# test below. Python ships in CI and on every supported workstation.
+python3 -c "
+import zipfile
+with zipfile.ZipFile('${HAPPY_DIR}/build/happy-plugin.zip', 'w') as z:
+  z.writestr('happy-plugin/happy-plugin.php', '<?php // happy plugin')
+  z.writestr('happy-plugin/readme.txt', 'happy plugin readme')
+"
+
+# No homeboy.json — release_latest_branch should be empty and skipped.
+set +e
+publish_out="$(
+  cd "${HAPPY_DIR}" && \
+  PATH="${STUB_BIN_DIR}:${PATH}" \
+  GITHUB_REPOSITORY="example/happy-plugin" \
+  HOMEBOY_SETTINGS_JSON='{"release":{"tag":"v1.0.0","component_id":"happy-plugin"}}' \
+  "${PUBLISH_SH}" 2>&1
+)"
+publish_status=$?
+set -e
+
+if [[ ${publish_status} -ne 0 ]]; then
+  echo "FAIL: publish.sh (no branch) exited ${publish_status}; output: ${publish_out}" >&2
+  failures=$((failures + 1))
+else
+  receipt="$(echo "${publish_out}" | tail -1)"
+  if ! echo "${receipt}" | jq -e '.success == true and .release_latest_branch == null' >/dev/null 2>&1; then
+    echo "FAIL: publish.sh receipt (no branch) missing success/null branch; got: ${receipt}" >&2
+    failures=$((failures + 1))
+  else
+    echo "OK: publish.sh skips branch mirror when release_latest_branch is unset"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# publish.sh: pushes release-latest branch when homeboy.json declares it.
+# Stub git so we record the push without touching a real remote.
+# ---------------------------------------------------------------------------
+BRANCH_DIR="$(mktemp -d -t homeboy-wp-release-branch.XXXXXX)"
+trap 'rm -rf "${WORK_DIR}" "${STUB_BIN_DIR}" "${HAPPY_DIR}" "${BRANCH_DIR}"' EXIT
+mkdir -p "${BRANCH_DIR}/build"
+cat > "${BRANCH_DIR}/homeboy.json" <<'JSON'
+{
+  "id": "happy-plugin",
+  "extensions": {
+    "wordpress": {
+      "release_latest_branch": "release-latest"
+    }
+  }
+}
+JSON
+python3 -c "
+import zipfile
+with zipfile.ZipFile('${BRANCH_DIR}/build/happy-plugin.zip', 'w') as z:
+  z.writestr('happy-plugin/happy-plugin.php', '<?php // happy plugin')
+  z.writestr('happy-plugin/readme.txt', 'happy plugin readme')
+"
+
+# Wrap git so push --force is intercepted (no real remote available).
+PUSH_LOG="${BRANCH_DIR}/git-push.log"
+cat > "${STUB_BIN_DIR}/git" <<STUB_GIT
+#!/usr/bin/env bash
+# Stub git: forward most subcommands to the real git but intercept "push"
+# (anywhere in the argument list, since publish.sh uses 'git -C <path>
+# push ...'). Log the push invocation for assertion.
+for arg in "\$@"; do
+  if [[ "\$arg" == "push" ]]; then
+    printf '%s\n' "\$*" >> "${PUSH_LOG}"
+    exit 0
+  fi
+done
+exec /usr/bin/env PATH="\${HOMEBOY_REAL_PATH}" git "\$@"
+STUB_GIT
+chmod +x "${STUB_BIN_DIR}/git"
+
+set +e
+REAL_PATH="${PATH}"
+publish_out="$(
+  cd "${BRANCH_DIR}" && \
+  HOMEBOY_REAL_PATH="${REAL_PATH}" \
+  PATH="${STUB_BIN_DIR}:${REAL_PATH}" \
+  GITHUB_REPOSITORY="example/happy-plugin" \
+  GH_TOKEN="stub-token" \
+  HOMEBOY_SETTINGS_JSON='{"release":{"tag":"v1.0.0","component_id":"happy-plugin"}}' \
+  "${PUBLISH_SH}" 2>&1
+)"
+publish_status=$?
+set -e
+
+if [[ ${publish_status} -ne 0 ]]; then
+  echo "FAIL: publish.sh (with branch) exited ${publish_status}; output: ${publish_out}" >&2
+  failures=$((failures + 1))
+else
+  receipt="$(echo "${publish_out}" | tail -1)"
+  if ! echo "${receipt}" | jq -e '.release_latest_branch == "release-latest"' >/dev/null 2>&1; then
+    echo "FAIL: publish.sh receipt (with branch) missing release-latest; got: ${receipt}" >&2
+    failures=$((failures + 1))
+  elif [[ ! -s "${PUSH_LOG}" ]]; then
+    echo "FAIL: publish.sh did not invoke git push for the configured branch" >&2
+    failures=$((failures + 1))
+  elif ! grep -q "release-latest:release-latest" "${PUSH_LOG}"; then
+    echo "FAIL: publish.sh did not force-push release-latest:release-latest; got: $(cat "${PUSH_LOG}")" >&2
+    failures=$((failures + 1))
+  else
+    echo "OK: publish.sh force-pushes release-latest branch when configured"
+  fi
 fi
 
 if [[ ${failures} -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Extend the wordpress extension's `release.publish` action to optionally mirror the unzipped vendor-bundled tree to a CORS-friendly branch (e.g. `release-latest`) so WordPress Playground blueprints can install the plugin via `git:directory` instead of the GitHub release-asset URL.

### The problem

WordPress Playground installs plugins via blueprints that fetch from URLs. For Data Machine and similar plugins, the blueprint uses:

```json
{
  "resource": "url",
  "url": "https://github.com/Extra-Chill/data-machine/releases/latest/download/data-machine.zip"
}
```

GitHub release-asset downloads 302 to S3 buckets that do **not** send `Access-Control-Allow-Origin` headers. Browser-based Playground (the public `playground.wordpress.net` runtime) hits this from inside the iframe and the request fails CORS preflight. The plugin never installs. We saw this fail live: Data Machine's `/datamachine/v1/*` routes all 404 because the plugin file system entry doesn't exist.

### The fix

Playground's `git:directory` resource resolves through Playground's CORS proxy and reliably installs from any GitHub branch. So this PR teaches the wordpress extension's `release.publish` action to dual-publish: GitHub release asset (canonical) **and** an opinionated `release-latest`-style branch that contains exactly the bytes the asset ZIP holds, but at the branch tip so `git:directory` can fetch it.

```diff
 wordpress/scripts/release/publish.sh   # add optional branch mirror
 wordpress/tests/release-scripts-smoke.sh   # cover skip + force-push paths
```

### How components opt in

Add `release_latest_branch` to the component's homeboy.json:

```json
{
  "extensions": {
    "wordpress": {
      "release_latest_branch": "release-latest"
    }
  }
}
```

When empty or unset the mirror push is skipped — the GitHub release-asset upload still runs. There is no global default; each component declares its own branch name so consumers know exactly what to expect.

### What the branch contains

- A **single orphan commit** containing the contents of `build/<slug>.zip` extracted at the branch root.
- **Force-pushed on every release.** The branch has no shared history with `main`; each release replaces the entire branch contents. Consumers always resolve the tip.
- Owned by the release pipeline. The commit message warns against editing the branch directly.

Playground blueprints then use:

```json
{
  "step": "installPlugin",
  "pluginData": {
    "resource": "git:directory",
    "url": "https://github.com/Extra-Chill/data-machine",
    "ref": "release-latest",
    "refType": "branch"
  },
  "options": { "activate": true, "targetFolderName": "data-machine" }
}
```

The wordpress extension that ships with `release.package` builds the vendor-bundled ZIP. The branch mirror unpacks that exact ZIP, so Playground sees the same composer-installed `vendor/` and `npm run build`-compiled assets that release-asset consumers see.

### Safety properties

- The mirror push uses a **temporary git worktree** created via `mktemp -d`. The source checkout's `.git/config`, remotes, and HEAD are never touched.
- The push uses a **token-authenticated HTTPS URL** assembled in the script. The source checkout's credentials/helpers are not consulted.
- `GH_TOKEN` is required. The script fails loudly when it is missing rather than attempting an unauthenticated push.
- `unzip` is required. The script fails loudly when it is missing rather than attempting an empty mirror.
- The receipt JSON reports `release_latest_branch` (or `null` when skipped) so downstream tooling can verify the dual-publish without re-reading homeboy.json.

### Smoke test coverage

Gains two new cases:

| Check | Expected behaviour |
|---|---|
| Skip branch mirror when `release_latest_branch` is unset | Receipt has `release_latest_branch: null`, no `git push` |
| Force-push `release-latest:release-latest` when configured | Receipt has `release_latest_branch: "release-latest"`, `git push` invoked with `--force` |

Both stub `gh` and `git` so the test never touches a real GitHub repository or remote. Local run:

```
$ bash wordpress/tests/release-scripts-smoke.sh
OK: package.sh emits expected artifact JSON
OK: publish.sh rejects empty HOMEBOY_SETTINGS_JSON
OK: publish.sh rejects missing release.tag
OK: publish.sh rejects missing artifact ZIP
OK: publish.sh skips branch mirror when release_latest_branch is unset
OK: publish.sh force-pushes release-latest branch when configured
PASS: release-scripts-smoke
```

### Why a branch instead of a different host

A separate S3/Cloudflare bucket with CORS would also work, but adds:
- a new credential to provision and rotate
- a new origin to keep in sync with the repo
- a new failure mode (bucket outage, region misroute)

A branch in the same repo:
- inherits the repo's existing credentials and access policy
- is implicitly versioned (the tag and branch both update from the same pipeline)
- works for every Extra-Chill WordPress plugin with one toggle

### Follow-ups (not in this PR)

- Data Machine and Data Machine Code will opt in via separate PRs that add `release_latest_branch: "release-latest"` to their homeboy.json.
- World of WordPress blueprint will switch from `releases/latest/download/*.zip` to `git:directory` `ref: release-latest` once those components have released.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Identified the Playground CORS failure from a live browser console log, traced the CORS handling in Playground's `fetchWithCorsProxy`, designed the orphan-branch mirror pattern, and drafted the script + smoke test extensions. Chris confirmed the homeboy gap and chose the dual-publish strategy.