### PR TITLE
ci: opt into release-skip-publish and release-skip-github-release

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -40,4 +40,12 @@ jobs:
         with:
           component: ${{ matrix.component }}
           commands: release
+          # homeboy-extensions monorepo components release version bumps
+          # and tags only; they do not produce binary artifacts and the
+          # extension manifests themselves are consumed via
+          # `extension install-for-component`, not via GitHub Release
+          # assets. Opt out of the homeboy-native publish + github.release
+          # pipeline so per-component tag pushes stay tag-only.
+          release-skip-publish: 'true'
+          release-skip-github-release: 'true'
           app-token: ${{ steps.app-token.outputs.token || '' }}


### PR DESCRIPTION
## Summary

Companion PR to [homeboy-action#231](https://github.com/Extra-Chill/homeboy-action/pull/231). Explicitly opts the homeboy-extensions monorepo matrix release into the previous tag-only behavior using the new `release-skip-publish` / `release-skip-github-release` inputs.

```diff
       - uses: Extra-Chill/homeboy-action@v2
         with:
           component: ${{ matrix.component }}
           commands: release
+          release-skip-publish: 'true'
+          release-skip-github-release: 'true'
           app-token: ${{ steps.app-token.outputs.token || '' }}
```

## Why

homeboy-extensions monorepo components (wordpress, nodejs, rust, go, swift) release version bumps and tags only. Each extension is consumed by downstream repos via `homeboy extension install-for-component` reading from the main branch HEAD or a pinned ref, never via GitHub Release assets. The release planner adding `package` and `github.release` steps for these components would create empty GitHub Releases with no useful content.

Today this works because `homeboy-action@v2`'s `run-release.sh` hardcodes `--skip-publish --no-github-release`. The companion PR removes those hardcodes and exposes them as opt-in inputs (default `false`). Without this PR, every monorepo component release would start creating an empty GitHub Release.

## Safe to land before homeboy-action#231

GitHub Actions silently ignores unknown action inputs, so these two new settings are no-ops on the currently-pinned `v2.5.4` of homeboy-action. They take effect once the v2 tag rolls forward to v2.5.5+.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Companion edit identified while preparing the action change in homeboy-action#231.