### PR TITLE
fix(rust): fail scoped zero-test runs

### DIFF
--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -216,7 +216,7 @@ if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
         module_path="${module_path#tests/}"      # strip leading tests/
         module_path="${module_path%.rs}"          # strip .rs extension
         module_path="${module_path%/mod}"         # strip /mod suffix
-        module_path="${module_path//\//::\:}"     # replace / with ::
+        module_path="${module_path//\//::}"       # replace / with ::
         if [ -n "$module_path" ]; then
             SCOPE_FILTER_ARGS+=("$module_path")
         fi
@@ -289,5 +289,10 @@ if [ "$TOTAL_PASSED" -eq 0 ]; then
         echo ""
         echo "Found ${TEST_FILE_COUNT} test files but no tests were executed."
         echo "This may indicate a configuration issue."
+        if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
+            FAILED_STEP="cargo test"
+            FAILURE_REPLAY_MODE="none"
+            exit 1
+        fi
     fi
 fi


### PR DESCRIPTION
## Summary
- Fix Rust changed-file scope conversion so nested source paths map to valid `cargo test` module filters.
- Fail scoped Rust test runs when no tests execute, preventing false-green `--changed-since` verification.

## Verification
- `bash -n rust/scripts/test-runner.sh`
- Direct runner smoke with `HOMEBOY_CHANGED_TEST_FILES=src/core/extension/test/drift.rs` against Homeboy core ran 10 matching tests.
- Direct runner smoke with a bogus scoped file reached the zero-test guard.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Rust runner scoped-test false green and drafted the shell fix; Chris remains responsible for review and merge.