### PR TITLE
fix(rust): scope changed integration tests

### DIFF
--- a/rust/scripts/rust-changed-scope-smoke.sh
+++ b/rust/scripts/rust-changed-scope-smoke.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PROJECT_DIR="$WORKDIR/project"
+HELPER_DIR="$WORKDIR/helpers"
+mkdir -p "$PROJECT_DIR/src" "$PROJECT_DIR/tests" "$HELPER_DIR"
+
+cat > "$PROJECT_DIR/Cargo.toml" <<'EOF'
+[package]
+name = "rust-changed-scope-smoke"
+version = "0.1.0"
+edition = "2021"
+EOF
+
+cat > "$PROJECT_DIR/src/lib.rs" <<'EOF'
+pub fn value() -> u8 {
+    1
+}
+EOF
+
+cat > "$PROJECT_DIR/tests/integration_scope.rs" <<'EOF'
+#[test]
+fn integration_scope_runs() {
+    assert_eq!(rust_changed_scope_smoke::value(), 1);
+}
+EOF
+
+cat > "$HELPER_DIR/resolve-context.sh" <<'EOF'
+homeboy_resolve_context() {
+    PROJECT_PATH="${HOMEBOY_COMPONENT_PATH}"
+    EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH}"
+}
+EOF
+
+cat > "$HELPER_DIR/runner-steps.sh" <<'EOF'
+should_run_step() {
+    return 0
+}
+EOF
+
+OUTPUT=$(
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_CHANGED_TEST_FILES='tests/integration_scope.rs' \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    bash "$SCRIPT_DIR/test-runner.sh"
+)
+
+if [[ "$OUTPUT" != *"Scoped to changed integration tests: integration_scope"* ]]; then
+    printf 'Expected integration test target scope. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+if [[ "$OUTPUT" != *"1 passed"* ]]; then
+    printf 'Expected scoped integration test to run. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -205,9 +205,19 @@ TEST_ARGS=(
 # Cargo test accepts positional test name patterns after --.
 # We extract module paths from file paths (e.g., src/commands/audit.rs → commands::audit).
 SCOPE_FILTER_ARGS=()
+SCOPE_INTEGRATION_ARGS=()
 if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
     while IFS= read -r test_file; do
         [ -z "$test_file" ] && continue
+        if [[ "$test_file" == tests/*.rs && "$test_file" != tests/*/* ]]; then
+            test_target="${test_file#tests/}"
+            test_target="${test_target%.rs}"
+            if [ -n "$test_target" ]; then
+                SCOPE_INTEGRATION_ARGS+=("$test_target")
+            fi
+            continue
+        fi
+
         # Convert file path to Rust module path for cargo test filtering
         # e.g., src/commands/audit.rs → commands::audit
         #        src/utils/baseline.rs → utils::baseline
@@ -222,7 +232,14 @@ if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
         fi
     done <<< "${HOMEBOY_CHANGED_TEST_FILES}"
 
-    if [ ${#SCOPE_FILTER_ARGS[@]} -gt 0 ]; then
+    if [ ${#SCOPE_INTEGRATION_ARGS[@]} -gt 0 ] && [ ${#SCOPE_FILTER_ARGS[@]} -gt 0 ]; then
+        echo "Changed files include integration and inline tests; running full cargo test."
+    elif [ ${#SCOPE_INTEGRATION_ARGS[@]} -gt 0 ]; then
+        for test_target in "${SCOPE_INTEGRATION_ARGS[@]}"; do
+            TEST_ARGS+=(--test "$test_target")
+        done
+        echo "Scoped to changed integration tests: ${SCOPE_INTEGRATION_ARGS[*]}"
+    elif [ ${#SCOPE_FILTER_ARGS[@]} -gt 0 ]; then
         # Join module paths with | for regex-style OR matching
         FILTER=$(IFS='|'; echo "${SCOPE_FILTER_ARGS[*]}")
         TEST_ARGS+=(-- "$FILTER")


### PR DESCRIPTION
## Summary
- Run changed Rust integration test files with Cargo's `--test <target>` selection instead of a positional name filter.
- Fall back to full `cargo test` when changed scope mixes integration tests and inline/module tests.
- Add a smoke script covering `HOMEBOY_CHANGED_TEST_FILES=tests/*.rs`.

## Verification
- `bash rust/scripts/rust-changed-scope-smoke.sh`
- `bash -n rust/scripts/test-runner.sh && bash -n rust/scripts/rust-changed-scope-smoke.sh`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-rust-integration-test-scope --extension nodejs --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-rust-integration-test-scope --extension nodejs --changed-since origin/main`
- `HOME=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-rust-extension-smoke RUSTUP_HOME=/Users/chubes/.rustup CARGO_HOME=/Users/chubes/.cargo homeboy test --path /Users/chubes/Developer/homeboy@core-agnostic-baseline-report --extension rust --changed-since origin/main --skip-lint`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the script fix and smoke coverage; Chris remains responsible for review and merge.