### PR TITLE
fix(rust): scope inline test modules

### DIFF
--- a/rust/scripts/rust-changed-scope-smoke.sh
+++ b/rust/scripts/rust-changed-scope-smoke.sh
@@ -7,7 +7,7 @@ trap 'rm -rf "$WORKDIR"' EXIT
 
 PROJECT_DIR="$WORKDIR/project"
 HELPER_DIR="$WORKDIR/helpers"
-mkdir -p "$PROJECT_DIR/src" "$PROJECT_DIR/tests" "$HELPER_DIR"
+mkdir -p "$PROJECT_DIR/src/core" "$PROJECT_DIR/tests/core" "$HELPER_DIR"
 
 cat > "$PROJECT_DIR/Cargo.toml" <<'EOF'
 [package]
@@ -17,15 +17,40 @@ edition = "2021"
 EOF
 
 cat > "$PROJECT_DIR/src/lib.rs" <<'EOF'
+pub mod core;
+
 pub fn value() -> u8 {
     1
 }
+EOF
+
+cat > "$PROJECT_DIR/src/core/mod.rs" <<'EOF'
+pub mod daemon;
+EOF
+
+cat > "$PROJECT_DIR/src/core/daemon.rs" <<'EOF'
+pub fn daemon_value() -> u8 {
+    2
+}
+
+#[cfg(test)]
+#[path = "../../tests/core/daemon_test.rs"]
+mod daemon_test;
 EOF
 
 cat > "$PROJECT_DIR/tests/integration_scope.rs" <<'EOF'
 #[test]
 fn integration_scope_runs() {
     assert_eq!(rust_changed_scope_smoke::value(), 1);
+}
+EOF
+
+cat > "$PROJECT_DIR/tests/core/daemon_test.rs" <<'EOF'
+use super::*;
+
+#[test]
+fn inline_scope_runs() {
+    assert_eq!(daemon_value(), 2);
 }
 EOF
 
@@ -59,5 +84,25 @@ fi
 
 if [[ "$OUTPUT" != *"1 passed"* ]]; then
     printf 'Expected scoped integration test to run. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+OUTPUT=$(
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_CHANGED_TEST_FILES='tests/core/daemon_test.rs' \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    bash "$SCRIPT_DIR/test-runner.sh"
+)
+
+if [[ "$OUTPUT" != *"Scoped to changed files: core::daemon::daemon_test"* ]]; then
+    printf 'Expected inline test module scope. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+if [[ "$OUTPUT" != *"1 passed"* ]]; then
+    printf 'Expected scoped inline test to run. Output:\n%s\n' "$OUTPUT" >&2
     exit 1
 fi

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -221,11 +221,16 @@ if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
         # Convert file path to Rust module path for cargo test filtering
         # e.g., src/commands/audit.rs → commands::audit
         #        src/utils/baseline.rs → utils::baseline
-        #        tests/integration.rs  → integration
+        #        tests/core/foo_test.rs with src/core/foo.rs → core::foo::foo_test
         module_path="${test_file#src/}"          # strip leading src/
         module_path="${module_path#tests/}"      # strip leading tests/
         module_path="${module_path%.rs}"          # strip .rs extension
         module_path="${module_path%/mod}"         # strip /mod suffix
+        test_module="${module_path##*/}"
+        source_module="${module_path%_test}"
+        if [[ "$test_file" == tests/*_test.rs ]] && { [ -f "${PROJECT_PATH}/src/${source_module}.rs" ] || [ -f "${PROJECT_PATH}/src/${source_module}/mod.rs" ]; }; then
+            module_path="${source_module}::${test_module}"
+        fi
         module_path="${module_path//\//::}"       # replace / with ::
         if [ -n "$module_path" ]; then
             SCOPE_FILTER_ARGS+=("$module_path")


### PR DESCRIPTION
## Summary
- Fix Rust changed-scope filtering for inline test files under `tests/.../*_test.rs` that are wired into `src/...` modules with `#[path]`.
- Extend the changed-scope smoke test to cover `tests/core/daemon_test.rs` mapping to `core::daemon::daemon_test`.

## Verification
- `bash rust/scripts/rust-changed-scope-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the scoped zero-test failure and drafted the runner/smoke-test fix; Chris remains responsible for review and merge.