### PR TITLE
Add Rust compiler warning contracts

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -20,7 +20,9 @@
     "fingerprint": "scripts/fingerprint.sh",
     "refactor": "scripts/refactor.sh",
     "validate": "scripts/validate.sh",
-    "format": "scripts/format.sh"
+    "format": "scripts/format.sh",
+    "compiler_warnings": "scripts/compiler-warnings.py",
+    "compiler_warning_fixes": "scripts/compiler-warning-fixes.py"
   },
   "lint": {
     "extension_script": "scripts/lint-runner.sh"

--- a/rust/scripts/compiler-warning-fixes.py
+++ b/rust/scripts/compiler-warning-fixes.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Emit Homeboy compiler warning fix suggestions from Cargo JSON output."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from compiler_warnings_lib import (
+    relative_path,
+    run_cargo_check,
+    span_replaced_text,
+    warning_code,
+    warning_messages,
+)
+
+
+def fix_kind(code: str, line_start: int, line_end: int, replacement: str) -> str | None:
+    if code in {"unused_imports", "dead_code"}:
+        return "line_removal"
+    if line_start == line_end:
+        return "line_replacement"
+    if replacement == "":
+        return "line_removal"
+    return None
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    root = Path(payload.get("root") or ".")
+    fixes = []
+
+    for message in warning_messages(run_cargo_check(root)):
+        code = warning_code(message)
+        text = str(message.get("message") or "")
+        for child in message.get("children") or []:
+            for span in child.get("spans") or []:
+                if "suggested_replacement" not in span:
+                    continue
+
+                file = relative_path(root, str(span.get("file_name") or ""))
+                if not file or file.startswith("/") or "/.cargo/" in file:
+                    continue
+
+                line_start = int(span.get("line_start") or 1)
+                line_end = int(span.get("line_end") or line_start)
+                replacement = str(span.get("suggested_replacement") or "")
+                kind = fix_kind(code, line_start, line_end, replacement)
+                if kind is None:
+                    continue
+
+                fixes.append(
+                    {
+                        "code": code,
+                        "kind": kind,
+                        "file": file,
+                        "line_start": line_start,
+                        "line_end": line_end,
+                        "original_text": span_replaced_text(span),
+                        "replacement": replacement,
+                        "message": text,
+                    }
+                )
+
+    fixes.sort(key=lambda fix: (fix["file"], fix["line_start"], fix["code"]))
+    deduped = []
+    seen = set()
+    for fix in fixes:
+        key = (fix["file"], fix["line_start"], fix["code"])
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(fix)
+
+    print(json.dumps({"fixes": deduped}, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rust/scripts/compiler-warnings.py
+++ b/rust/scripts/compiler-warnings.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Emit Homeboy compiler warning findings from Cargo JSON output."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from compiler_warnings_lib import (
+    primary_span,
+    relative_path,
+    run_cargo_check,
+    warning_code,
+    warning_messages,
+    warning_suggestion,
+)
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    root = Path(payload.get("root") or ".")
+    warnings = []
+
+    for message in warning_messages(run_cargo_check(root)):
+        code = warning_code(message)
+        text = str(message.get("message") or "")
+        span = primary_span(message)
+        if span is None:
+            continue
+
+        file = relative_path(root, str(span.get("file_name") or ""))
+        if not file or file.startswith("/") or "/.cargo/" in file:
+            continue
+        if code == "unknown" and "generated" in text:
+            continue
+
+        warnings.append(
+            {
+                "code": code,
+                "message": text,
+                "file": file,
+                "line": int(span.get("line_start") or 0),
+                "suggestion": warning_suggestion(code),
+            }
+        )
+
+    warnings.sort(key=lambda warning: (warning["file"], warning["line"], warning["code"]))
+    deduped = []
+    seen = set()
+    for warning in warnings:
+        key = (warning["file"], warning["line"], warning["code"])
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(warning)
+
+    print(json.dumps({"warnings": deduped}, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rust/scripts/compiler_warnings_lib.py
+++ b/rust/scripts/compiler_warnings_lib.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Shared Cargo JSON parsing for Homeboy compiler warning contracts."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def run_cargo_check(root: Path) -> str:
+    if not (root / "Cargo.toml").exists():
+        return ""
+
+    completed = subprocess.run(
+        ["cargo", "check", "--message-format=json"],
+        cwd=root,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return completed.stdout
+
+
+def relative_path(root: Path, file_name: str) -> str:
+    if not file_name:
+        return ""
+
+    try:
+        return str(Path(file_name).resolve().relative_to(root.resolve()))
+    except ValueError:
+        root_prefix = str(root)
+        if file_name.startswith(root_prefix):
+            return file_name[len(root_prefix) :].lstrip("/")
+        return file_name
+
+
+def warning_messages(stdout: str) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = []
+    for line in stdout.splitlines():
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if message.get("reason") != "compiler-message":
+            continue
+        compiler_message = message.get("message") or {}
+        if compiler_message.get("level") != "warning":
+            continue
+        messages.append(compiler_message)
+    return messages
+
+
+def warning_code(message: dict[str, Any]) -> str:
+    code = message.get("code") or {}
+    return str(code.get("code") or "unknown")
+
+
+def primary_span(message: dict[str, Any]) -> dict[str, Any] | None:
+    spans = message.get("spans") or []
+    for span in spans:
+        if span.get("is_primary") is True:
+            return span
+    return spans[0] if spans else None
+
+
+def warning_suggestion(code: str) -> str:
+    suggestions = {
+        "dead_code": "Remove the unused item or add `#[allow(dead_code)]` if intentionally reserved",
+        "unused_imports": "Remove the unused import",
+        "unused_variables": "Prefix with underscore `_` or remove the variable",
+        "unused_assignments": "Remove the unnecessary assignment",
+        "unused_mut": "Remove the `mut` qualifier",
+        "unreachable_code": "Remove or refactor the unreachable code path",
+        "unused_must_use": "Handle the return value or explicitly ignore with `let _ = ...`",
+    }
+    return suggestions.get(code, f"Address compiler warning: {code}")
+
+
+def span_original_text(span: dict[str, Any]) -> str:
+    text = span.get("text") or []
+    if not text:
+        return ""
+    return str((text[0] or {}).get("text") or "")
+
+
+def span_replaced_text(span: dict[str, Any]) -> str:
+    original_text = span_original_text(span)
+    if not original_text:
+        return ""
+
+    line_start = int(span.get("line_start") or 1)
+    line_end = int(span.get("line_end") or line_start)
+    if line_start != line_end:
+        return original_text
+
+    column_start = int(span.get("column_start") or 1)
+    column_end = int(span.get("column_end") or column_start)
+    start = max(column_start - 1, 0)
+    end = max(column_end - 1, start)
+    if start < len(original_text) and end <= len(original_text):
+        return original_text[start:end]
+    return original_text


### PR DESCRIPTION
## Summary
- Adds Rust extension scripts for Homeboy's generic compiler warning and compiler warning fix contracts.
- Moves Cargo JSON parsing into the Rust extension and emits generic `warnings` / `fixes` envelopes for core to consume.

## Testing
- `python3 -m py_compile rust/scripts/compiler_warnings_lib.py rust/scripts/compiler-warnings.py rust/scripts/compiler-warning-fixes.py`
- `printf '{\"root\":\"/Users/chubes/Developer/homeboy@fix-compiler-warning-contracts\"}' | rust/scripts/compiler-warnings.py`
- `printf '{\"root\":\"/Users/chubes/Developer/homeboy@fix-compiler-warning-contracts\",\"findings\":[]}' | rust/scripts/compiler-warning-fixes.py`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-rust-compiler-warning-contracts --extension rust --changed-since origin/main`

## Companion
- Core contract PR: Extra-Chill/homeboy#2615
- Homeboy issue: Extra-Chill/homeboy#2420

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the Rust extension contract scripts and local validation commands; Chris remains responsible for review and merge.