### PR TITLE
fix(rust): allow dirty crate publishes

### DIFF
--- a/rust/scripts/publish-crates-smoke.sh
+++ b/rust/scripts/publish-crates-smoke.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+SCRIPT="${ROOT_DIR}/rust/scripts/publish-crates.sh"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+BIN_DIR="${TMP_DIR}/bin"
+mkdir -p "${BIN_DIR}"
+
+cat >"${BIN_DIR}/cargo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$1" in
+  metadata)
+    printf '{"packages":[{"name":"homeboy-smoke","version":"1.2.3"}]}'
+    ;;
+  search)
+    printf 'homeboy-smoke = "1.2.2"\n'
+    ;;
+  publish)
+    printf '%s\n' "$@" >"${CARGO_PUBLISH_ARGS_LOG}"
+    ;;
+  *)
+    echo "unexpected cargo command: $*" >&2
+    exit 1
+    ;;
+esac
+SH
+chmod +x "${BIN_DIR}/cargo"
+
+export PATH="${BIN_DIR}:${PATH}"
+export CARGO_PUBLISH_ARGS_LOG="${TMP_DIR}/publish-args.log"
+
+bash "${SCRIPT}" >/dev/null
+
+if ! grep -qx -- '--allow-dirty' "${CARGO_PUBLISH_ARGS_LOG}"; then
+  echo "FAIL: cargo publish did not receive --allow-dirty" >&2
+  cat "${CARGO_PUBLISH_ARGS_LOG}" >&2
+  exit 1
+fi
+
+if ! grep -qx -- '--locked' "${CARGO_PUBLISH_ARGS_LOG}"; then
+  echo "FAIL: cargo publish did not preserve --locked" >&2
+  cat "${CARGO_PUBLISH_ARGS_LOG}" >&2
+  exit 1
+fi
+
+echo "OK: publish-crates.sh passes --allow-dirty to cargo publish"

--- a/rust/scripts/publish-crates.sh
+++ b/rust/scripts/publish-crates.sh
@@ -19,4 +19,4 @@ if [[ "$CURRENT_VERSION" == "$PUBLISHED_VERSION" ]]; then
 fi
 
 echo "Publishing $PACKAGE_NAME v$CURRENT_VERSION to crates.io..."
-cargo publish --locked
+cargo publish --locked --allow-dirty


### PR DESCRIPTION
## Summary
- Pass `--allow-dirty` to `cargo publish` in the rust extension publish step.
- Add a smoke test that stubs `cargo` and verifies `publish-crates.sh` preserves `--locked` while passing `--allow-dirty`.

## Why
Homeboy's `release --head --from-artifacts` flow downloads release artifacts into the worktree before invoking `publish.rust`. `cargo publish` then sees those artifact files as uncommitted changes and refuses to publish unless `--allow-dirty` is provided. The artifacts are release outputs, not crate source changes, so the rust extension should tolerate that publish context.

## Testing
- `bash -n rust/scripts/publish-crates.sh rust/scripts/publish-crates-smoke.sh`
- `bash rust/scripts/publish-crates-smoke.sh`
- `bash tests/rust-release-prepare-smoke.sh`
- `git diff --check`

## Context
Follow-up to Extra-Chill/homeboy#2581 and the failed Homeboy release run: https://github.com/Extra-Chill/homeboy/actions/runs/26098752635

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the rust publish failure from the Homeboy release logs, updated the rust extension publish script, added a smoke test, and ran local validation. Chris remains responsible for review and merge.