### PR TITLE
fix(rust): install cargo-dist for releases

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -36,6 +36,11 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
+      - name: Install cargo-dist
+        if: matrix.component == 'rust'
+        shell: bash
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh
+
       - uses: Extra-Chill/homeboy-action@v2
         with:
           component: ${{ matrix.component }}


### PR DESCRIPTION
## Summary
- Install `cargo-dist` before running the `rust` release matrix job.
- Keep the install scoped to `matrix.component == 'rust'` so other extension releases are unchanged.

## Why
The rust release job currently reaches the rust extension `release.package` step without `cargo-dist` available, so the release stops before publishing the updated rust extension.

Failed run: https://github.com/Extra-Chill/homeboy-extensions/actions/runs/26101599459

## Testing
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/homeboy.yml\")'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the release failure, updated the workflow, and ran local validation. Chris remains responsible for review and merge.