### PR TITLE
fix(rust): stop self-packaging extension releases

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -36,11 +36,6 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - name: Install cargo-dist
-        if: matrix.component == 'rust'
-        shell: bash
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh
-
       - uses: Extra-Chill/homeboy-action@v2
         with:
           component: ${{ matrix.component }}

--- a/rust/homeboy.json
+++ b/rust/homeboy.json
@@ -1,9 +1,6 @@
 {
   "id": "rust",
   "changelog_target": "docs/CHANGELOG.md",
-  "extensions": {
-    "rust": {}
-  },
   "version_targets": [
     {
       "file": "rust.json",


### PR DESCRIPTION
## Summary
- Removes the rust extension's self-reference from `rust/homeboy.json` so releasing the extension manifest does not invoke the rust crate packaging/publish actions against a non-crate directory.
- Removes the now-unneeded `cargo-dist` install from the homeboy-extensions release workflow.

## Why
The homeboy-extensions release run failed because the `rust` component was configured to load the `rust` extension, which made Homeboy run `release.package` via cargo-dist in `homeboy-extensions/rust`. That directory is an extension definition, not a Rust crate, so cargo-dist correctly failed with no `Cargo.toml` or `dist.toml`.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/homeboy.yml")'`
- `jq empty rust/homeboy.json`
- `git diff --check`

## Notes
- `homeboy lint --changed-since origin/main` and `homeboy test --changed-since origin/main` still fail for the repo-level aggregate component because `homeboy-extensions` has no extension provider configured. That is pre-existing and unrelated to this diff.
- The same failed release run also exposed a separate stale `swift-v2.6.0` remote tag issue: the tag exists, no GitHub Release exists for it, and `main` still has Swift at `2.5.1`. This PR does not delete or repair that tag.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the failed release run, drafted the minimal configuration fix, and ran local validation checks. Chris remains responsible for review and merge.