### PR TITLE
fix(wordpress): surface wp-codebox agent artifacts

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -51,6 +51,46 @@ has_arg --secret-env "$@"
 has_arg HOMEBOY_DATAMACHINE_AGENT_CONFIG "$@"
 
 node - <<'NODE'
+const fs = require('node:fs')
+const path = require('node:path')
+
+const artifactRoot = path.join(path.dirname(process.env.FAKE_WP_CODEBOX_ARGS_FILE), 'wp-codebox-artifacts', 'runtime-smoke')
+const filesRoot = path.join(artifactRoot, 'files')
+fs.mkdirSync(filesRoot, { recursive: true })
+
+const changedFiles = {
+  schema: 'wp-codebox/changed-files/v1',
+  files: [
+    {
+      path: '/wordpress/wp-content/plugins/example/generated.txt',
+      status: 'added',
+      mountTarget: '/wordpress/wp-content/plugins/example',
+      relativePath: 'generated.txt',
+    },
+  ],
+}
+const review = {
+  schema: 'wp-codebox/artifact-review/v1',
+  artifactId: 'runtime-smoke',
+  summary: 'Sandbox produced changes in 1 file.',
+  stats: { added: 1, modified: 0, deleted: 0, total: 1 },
+  changedFiles: changedFiles.files,
+  progress: [{ type: 'complete', label: 'Ready for your review.' }],
+  actions: [{ kind: 'approve', label: 'Apply changes', requiresApprovedFiles: true }],
+  evidence: {
+    patch: 'files/patch.diff',
+    patchSha256: 'sha256:example',
+    changedFiles: 'files/changed-files.json',
+  },
+  riskFlags: [],
+}
+
+fs.writeFileSync(path.join(artifactRoot, 'manifest.json'), JSON.stringify({ files: [] }, null, 2) + '\n')
+fs.writeFileSync(path.join(artifactRoot, 'metadata.json'), JSON.stringify({ artifacts: { review: 'files/review.json', changedFiles: 'files/changed-files.json', patch: 'files/patch.diff' } }, null, 2) + '\n')
+fs.writeFileSync(path.join(filesRoot, 'changed-files.json'), JSON.stringify(changedFiles, null, 2) + '\n')
+fs.writeFileSync(path.join(filesRoot, 'review.json'), JSON.stringify(review, null, 2) + '\n')
+fs.writeFileSync(path.join(filesRoot, 'patch.diff'), 'diff --git a/generated.txt b/generated.txt\n')
+
 const output = {
   metrics: {
     config_present: 1,
@@ -77,10 +117,14 @@ process.stdout.write(JSON.stringify({
     stdout: JSON.stringify({ output: JSON.stringify(output) }),
   },
   artifacts: {
-    directory: '/tmp/wp-codebox-artifacts/runtime-smoke',
-    manifestPath: '/tmp/wp-codebox-artifacts/runtime-smoke/manifest.json',
-    blueprintAfterPath: '/tmp/wp-codebox-artifacts/runtime-smoke/blueprint.after.json',
-    capturedMountsPath: '/tmp/wp-codebox-artifacts/runtime-smoke/files/mounted-files.json',
+    directory: artifactRoot,
+    manifestPath: path.join(artifactRoot, 'manifest.json'),
+    metadataPath: path.join(artifactRoot, 'metadata.json'),
+    blueprintAfterPath: path.join(artifactRoot, 'blueprint.after.json'),
+    capturedMountsPath: path.join(filesRoot, 'mounted-files.json'),
+    changedFilesPath: path.join(filesRoot, 'changed-files.json'),
+    patchPath: path.join(filesRoot, 'patch.diff'),
+    reviewPath: path.join(filesRoot, 'review.json'),
   },
 }) + '\n')
 NODE
@@ -135,7 +179,11 @@ done
 
 wp_codebox_success=$(jq -r "$scenario | .metadata.wp_codebox.success // false" "$RESULTS_TMPFILE")
 artifact_dir=$(jq -r "$scenario | .metadata.wp_codebox.artifacts.directory // \"\"" "$RESULTS_TMPFILE")
-if [ "$wp_codebox_success" != "true" ] || [ -z "$artifact_dir" ]; then
+review_schema=$(jq -r "$scenario | .metadata.wp_codebox.review_payload.schema // \"missing\"" "$RESULTS_TMPFILE")
+changed_files_schema=$(jq -r "$scenario | .metadata.wp_codebox.changed_files.schema // \"missing\"" "$RESULTS_TMPFILE")
+review_artifact=$(jq -r "$scenario | .artifacts.wp_codebox_review.kind // \"missing\"" "$RESULTS_TMPFILE")
+patch_artifact=$(jq -r "$scenario | .artifacts.wp_codebox_patch.kind // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$wp_codebox_success" != "true" ] || [ -z "$artifact_dir" ] || [ "$review_schema" != "wp-codebox/artifact-review/v1" ] || [ "$changed_files_schema" != "wp-codebox/changed-files/v1" ] || [ "$review_artifact" != "review" ] || [ "$patch_artifact" != "patch" ]; then
     echo "ERROR: wp_codebox metadata missing (success=$wp_codebox_success artifact_dir=$artifact_dir)" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -131,16 +131,71 @@ PHP
         "$wp_codebox_bin" "${wp_codebox_args[@]}" \
         >"$wp_codebox_output"
 
+    local wp_codebox_review_input="$RUNTIME_DIR/wp-codebox-review.json"
+    local wp_codebox_changed_files_input="$RUNTIME_DIR/wp-codebox-changed-files.json"
+    local wp_codebox_artifacts_json="$RUNTIME_DIR/wp-codebox-artifacts.json"
+    printf 'null\n' >"$wp_codebox_review_input"
+    printf 'null\n' >"$wp_codebox_changed_files_input"
+
+    local wp_codebox_review_path
+    local wp_codebox_changed_files_path
+    wp_codebox_review_path=$(jq -r '.artifacts.reviewPath // empty' "$wp_codebox_output")
+    wp_codebox_changed_files_path=$(jq -r '.artifacts.changedFilesPath // empty' "$wp_codebox_output")
+    if [ -n "$wp_codebox_review_path" ] && [ -f "$wp_codebox_review_path" ]; then
+        cp "$wp_codebox_review_path" "$wp_codebox_review_input"
+    fi
+    if [ -n "$wp_codebox_changed_files_path" ] && [ -f "$wp_codebox_changed_files_path" ]; then
+        cp "$wp_codebox_changed_files_path" "$wp_codebox_changed_files_input"
+    fi
+
+    jq -n \
+        --slurpfile run "$wp_codebox_output" \
+        --slurpfile review "$wp_codebox_review_input" \
+        --slurpfile changedFiles "$wp_codebox_changed_files_input" \
+        '
+        ($run[0].artifacts // {}) as $artifacts
+        | {
+            schema: "homeboy/wp-codebox-artifacts/v1",
+            success: ($run[0].success // false),
+            runtime: ($run[0].runtime // null),
+            paths: {
+                directory: ($artifacts.directory // ""),
+                manifest: ($artifacts.manifestPath // ""),
+                metadata: ($artifacts.metadataPath // ""),
+                blueprint_after: ($artifacts.blueprintAfterPath // ""),
+                blueprint_after_notes: ($artifacts.blueprintAfterNotesPath // ""),
+                events: ($artifacts.eventsPath // ""),
+                commands: ($artifacts.commandsPath // ""),
+                observations: ($artifacts.observationsPath // ""),
+                runtime_log: ($artifacts.runtimeLogPath // ""),
+                commands_log: ($artifacts.commandsLogPath // ""),
+                mounts: ($artifacts.mountsPath // ""),
+                captured_mounts: ($artifacts.capturedMountsPath // ""),
+                diffs: ($artifacts.diffsPath // ""),
+                changed_files: ($artifacts.changedFilesPath // ""),
+                patch: ($artifacts.patchPath // ""),
+                review: ($artifacts.reviewPath // "")
+            } | with_entries(select(.value != "")),
+            review_payload: ($review[0] // null),
+            changed_files: ($changedFiles[0] // null)
+        }
+        ' >"$wp_codebox_artifacts_json"
+
     jq -n \
         --arg component "$COMPONENT_ID" \
         --arg workloadId "$WORKLOAD_ID" \
         --arg workloadLabel "$WORKLOAD_LABEL" \
         --slurpfile run "$wp_codebox_output" \
+        --slurpfile wpCodeboxArtifacts "$wp_codebox_artifacts_json" \
         '
         def parsed_workload:
             ($run[0].execution.stdout? // "{}" | fromjson? // {}) as $outer
             | ($outer.output? // "{}" | fromjson? // {});
+        def artifact_entry($path; $kind; $label):
+            { path: $path, kind: $kind, label: $label };
         parsed_workload as $workload
+        | ($wpCodeboxArtifacts[0] // {}) as $wpArtifacts
+        | ($wpArtifacts.paths // {}) as $wpPaths
         | {
             component_id: $component,
             iterations: 1,
@@ -149,11 +204,21 @@ PHP
                     id: $workloadId,
                     label: $workloadLabel,
                     metrics: (($workload.metrics // {}) | with_entries(.key |= . + "_mean")),
+                    artifacts: ({
+                        wp_codebox_manifest: artifact_entry(($wpPaths.manifest // ""); "manifest"; "WP Codebox manifest"),
+                        wp_codebox_metadata: artifact_entry(($wpPaths.metadata // ""); "metadata"; "WP Codebox metadata"),
+                        wp_codebox_review: artifact_entry(($wpPaths.review // ""); "review"; "WP Codebox review payload"),
+                        wp_codebox_changed_files: artifact_entry(($wpPaths.changed_files // ""); "changed-files"; "WP Codebox changed files"),
+                        wp_codebox_patch: artifact_entry(($wpPaths.patch // ""); "patch"; "WP Codebox patch")
+                    } | with_entries(select(.value.path != ""))),
                     metadata: (($workload.metadata // {}) + {
                         wp_codebox: {
                             success: ($run[0].success // false),
                             runtime: ($run[0].runtime // null),
                             artifacts: ($run[0].artifacts // null),
+                            canonical_artifacts: ($wpPaths // {}),
+                            review_payload: ($wpArtifacts.review_payload // null),
+                            changed_files: ($wpArtifacts.changed_files // null),
                             error: ($run[0].error // null)
                         }
                     })


### PR DESCRIPTION
## Summary
- Normalize wp-codebox canonical artifact paths into the Data Machine agent runner scenario `artifacts` envelope.
- Parse and expose wp-codebox `files/review.json` and `files/changed-files.json` under `metadata.wp_codebox` for review/replay consumers.
- Extend the wp-codebox runner smoke fixture to produce and assert the canonical artifact/review payload contract.

Fixes chubes4/wp-codebox#33.

## Tests
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `npm run test:datamachine-agent-wp-codebox-runner` from `wordpress/`
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected the wp-codebox artifact contract and Homeboy Extensions runner, drafted the focused runner adapter changes, updated the smoke test fixture, and ran the listed checks. Chris remains responsible for review and merge.