### PR TITLE
fix(nodejs): route targeted test args

### DIFF
--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -52,6 +52,13 @@
       "type": "string",
       "default": "https://registry.npmjs.org",
       "description": "npm registry URL for publishing"
+    },
+    {
+      "id": "targeted_test_script",
+      "label": "Targeted Test Script",
+      "type": "string",
+      "default": "",
+      "description": "npm script to run when homeboy test receives passthrough test args, for example 'test:unit'"
     }
   ],
   "audit": {

--- a/nodejs/scripts/test/nodejs-targeted-script-smoke.sh
+++ b/nodejs/scripts/test/nodejs-targeted-script-smoke.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-targeted.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+run_gutenberg_fallback_smoke() {
+    local project_dir="${TMPDIR}/gutenberg"
+    mkdir -p "$project_dir/packages/core-data/src/test"
+
+    cat > "${project_dir}/package.json" <<'JSON'
+{
+  "name": "gutenberg",
+  "scripts": {
+    "test": "node aggregate-test-should-not-run.mjs",
+    "test:unit": "node unit-test-recorder.mjs"
+  }
+}
+JSON
+
+    cat > "${project_dir}/aggregate-test-should-not-run.mjs" <<'JS'
+console.error('aggregate test script should not run for targeted Gutenberg args');
+process.exit(1);
+JS
+
+    cat > "${project_dir}/unit-test-recorder.mjs" <<'JS'
+import { writeFileSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+writeFileSync('received-args.json', JSON.stringify(args));
+
+if (args.join('\n') !== 'packages/core-data/src/test/resolvers.js\n--runInBand') {
+  console.error(`Unexpected test args: ${JSON.stringify(args)}`);
+  process.exit(1);
+}
+
+console.log('PASS packages/core-data/src/test/resolvers.js');
+console.log('Tests:       36 passed, 36 total');
+JS
+
+    touch "${project_dir}/packages/core-data/src/test/resolvers.js"
+
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_PATH="$project_dir" \
+    HOMEBOY_COMPONENT_ID="gutenberg-targeted-smoke" \
+    bash "${SCRIPT_DIR}/test-runner.sh" packages/core-data/src/test/resolvers.js --runInBand > "${TMPDIR}/gutenberg.out"
+
+    if ! grep -q 'Command:   npm run test:unit --' "${TMPDIR}/gutenberg.out"; then
+        echo "Expected Gutenberg targeted args to use test:unit" >&2
+        cat "${TMPDIR}/gutenberg.out" >&2
+        exit 1
+    fi
+
+    if [ "$(cat "${project_dir}/received-args.json")" != '["packages/core-data/src/test/resolvers.js","--runInBand"]' ]; then
+        echo "Runner did not forward targeted Gutenberg args to test:unit" >&2
+        cat "${project_dir}/received-args.json" >&2
+        exit 1
+    fi
+}
+
+run_configured_script_smoke() {
+    local project_dir="${TMPDIR}/configured"
+    mkdir -p "$project_dir/tests"
+
+    cat > "${project_dir}/package.json" <<'JSON'
+{
+  "name": "configured-targeted-script",
+  "scripts": {
+    "test": "node aggregate-test-should-not-run.mjs",
+    "test:unit": "node unit-test-recorder.mjs"
+  }
+}
+JSON
+
+    cat > "${project_dir}/aggregate-test-should-not-run.mjs" <<'JS'
+console.error('aggregate test script should not run when targeted test_script is configured');
+process.exit(1);
+JS
+
+    cat > "${project_dir}/unit-test-recorder.mjs" <<'JS'
+import { writeFileSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+writeFileSync('received-args.json', JSON.stringify(args));
+
+if (args.join('\n') !== 'tests/example.test.js') {
+  console.error(`Unexpected test args: ${JSON.stringify(args)}`);
+  process.exit(1);
+}
+
+console.log('# tests 1');
+console.log('# pass 1');
+console.log('# fail 0');
+JS
+
+    touch "${project_dir}/tests/example.test.js"
+
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_PATH="$project_dir" \
+    HOMEBOY_COMPONENT_ID="configured-targeted-smoke" \
+    HOMEBOY_SETTINGS_JSON='{"test_script":"test:unit"}' \
+    bash "${SCRIPT_DIR}/test-runner.sh" tests/example.test.js > "${TMPDIR}/configured.out"
+
+    if ! grep -q 'Command:   npm run test:unit --' "${TMPDIR}/configured.out"; then
+        echo "Expected configured targeted args to use test:unit" >&2
+        cat "${TMPDIR}/configured.out" >&2
+        exit 1
+    fi
+
+    if [ "$(cat "${project_dir}/received-args.json")" != '["tests/example.test.js"]' ]; then
+        echo "Runner did not forward configured targeted args to test:unit" >&2
+        cat "${project_dir}/received-args.json" >&2
+        exit 1
+    fi
+}
+
+run_gutenberg_fallback_smoke
+run_configured_script_smoke
+
+echo "nodejs targeted-script smoke passed"

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -23,6 +23,7 @@ set -euo pipefail
 #   HOMEBOY_TEST_RESULTS_FILE    — where to write TestResults envelope
 #   HOMEBOY_TEST_FAILURES_FILE   — where to write parsed failure details
 #   HOMEBOY_NODE_TEST_COMMAND    — override the test command entirely
+#   HOMEBOY_NODE_TARGETED_TEST_SCRIPT — npm script to use when args are present
 #   HOMEBOY_CHANGED_TEST_FILES   — newline-separated test files selected by core
 #   HOMEBOY_DEBUG                — verbose
 
@@ -40,6 +41,65 @@ homeboy_resolve_context
 source "${SCRIPT_DIR}/../lib/node-helpers.sh"
 homeboy_require_package_json
 homeboy_detect_package_manager
+
+RUNNER_ARGS=("$@")
+if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
+    while IFS= read -r selected_test_file; do
+        [ -n "$selected_test_file" ] || continue
+        RUNNER_ARGS+=("$selected_test_file")
+    done <<< "$HOMEBOY_CHANGED_TEST_FILES"
+fi
+
+homeboy_node_json_value() {
+    local expression="$1"
+    node -e "
+        const raw = process.env.HOMEBOY_SETTINGS_JSON || '{}';
+        let settings = {};
+        try { settings = JSON.parse(raw); } catch {}
+        const value = (${expression});
+        if (typeof value === 'string' && value) console.log(value);
+    " 2>/dev/null || true
+}
+
+homeboy_node_package_value() {
+    local expression="$1"
+    PACKAGE_JSON_PATH="${PROJECT_PATH}/package.json" \
+    node -e "
+        const pkg = require(process.env.PACKAGE_JSON_PATH);
+        const value = (${expression});
+        if (typeof value === 'string' && value) console.log(value);
+    " 2>/dev/null || true
+}
+
+homeboy_node_script_command() {
+    local script_name="$1"
+    printf '%s' "${PKG_RUN} ${script_name} --"
+}
+
+homeboy_node_targeted_test_script() {
+    local configured_script="${HOMEBOY_NODE_TARGETED_TEST_SCRIPT:-}"
+    if [ -z "$configured_script" ]; then
+        configured_script="$(homeboy_node_json_value "settings.node_targeted_test_script || settings.targeted_test_script || settings.test_script || settings.testing?.targeted_test_script || ''")"
+    fi
+
+    if [ -n "$configured_script" ]; then
+        if ! homeboy_has_npm_script "$configured_script"; then
+            echo "Error: targeted Node.js test script '${configured_script}' is not defined in package.json" >&2
+            exit 1
+        fi
+        printf '%s' "$configured_script"
+        return 0
+    fi
+
+    local package_name
+    package_name="$(homeboy_node_package_value "pkg.name || ''")"
+    if [ "$package_name" = "gutenberg" ] && homeboy_has_npm_script "test:unit"; then
+        printf '%s' "test:unit"
+        return 0
+    fi
+
+    return 1
+}
 
 WRITE_TEST_RESULTS_HELPER="${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-}"
 if [ -n "$WRITE_TEST_RESULTS_HELPER" ] && [ -f "$WRITE_TEST_RESULTS_HELPER" ]; then
@@ -60,6 +120,8 @@ fi
 # Resolve the test command.
 if [ -n "${HOMEBOY_NODE_TEST_COMMAND:-}" ]; then
     TEST_CMD="$HOMEBOY_NODE_TEST_COMMAND"
+elif [ ${#RUNNER_ARGS[@]} -gt 0 ] && TARGETED_TEST_SCRIPT="$(homeboy_node_targeted_test_script)"; then
+    TEST_CMD="$(homeboy_node_script_command "$TARGETED_TEST_SCRIPT")"
 elif homeboy_has_npm_script "test"; then
     TEST_CMD="$PKG_RUN test"
 else
@@ -70,14 +132,6 @@ fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: test command: $TEST_CMD" >&2
-fi
-
-RUNNER_ARGS=("$@")
-if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
-    while IFS= read -r selected_test_file; do
-        [ -n "$selected_test_file" ] || continue
-        RUNNER_ARGS+=("$selected_test_file")
-    done <<< "$HOMEBOY_CHANGED_TEST_FILES"
 fi
 
 echo "Running Node.js tests..."


### PR DESCRIPTION
## Summary
- Route Node.js `homeboy test` passthrough args through a targeted npm script when configured.
- Auto-route Gutenberg targeted args to `test:unit` when the package exposes that script.
- Add a smoke test covering Gutenberg-style args and explicit `targeted_test_script` settings.

Closes #674.

## Testing
- `bash -n nodejs/scripts/test/test-runner.sh nodejs/scripts/test/nodejs-targeted-script-smoke.sh`
- `bash nodejs/scripts/test/nodejs-targeted-script-smoke.sh`
- `bash nodejs/scripts/test/nodejs-changed-scope-smoke.sh`
- `bash nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh`
- `HOMEBOY_EXTENSION_PATH=/Users/chubes/Developer/homeboy-extensions@issue-674-nodejs-targeted-test-args/nodejs HOMEBOY_COMPONENT_PATH=/Users/chubes/Developer/gutenberg@fix-persist-crdt-doc-minimal-save-pr77050 HOMEBOY_COMPONENT_ID=gutenberg bash nodejs/scripts/test/test-runner.sh packages/core-data/src/test/resolvers.js --runInBand`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Node.js runner change, added smoke coverage, and ran focused verification. Chris remains responsible for review and merge decisions.