### PR TITLE
Add wp-codebox apply adapter

### DIFF
--- a/wordpress/docs/WP_CODEBOX_APPLY_ADAPTER.md
+++ b/wordpress/docs/WP_CODEBOX_APPLY_ADAPTER.md
@@ -1,0 +1,36 @@
+# WP Codebox Apply Adapter
+
+The WordPress extension provides `homeboy/wp-codebox-apply-adapter/v1`, a parent-side adapter core for approved WP Codebox artifacts.
+
+The adapter consumes the same approved payload shape passed by WP Codebox's `wp_codebox_apply_approved_artifact` filter, or a fixture artifact bundle directory with:
+
+- `manifest.json`
+- `metadata.json`
+- `files/changed-files.json`
+- `files/patch.diff`
+- `files/review.json`
+
+It re-computes the content digest from the exact bytes of `files/changed-files.json` and `files/patch.diff`, verifies the patch SHA-256, requires approval for every changed file in the current slice, applies that canonical patch to a clean git worktree, commits, and returns structured metadata.
+
+```bash
+node scripts/agent/wp-codebox-apply-adapter.cjs \
+  --bundle /path/to/artifact-bundle \
+  --worktree /path/to/safe/worktree \
+  --branch feature/apply-approved-artifact \
+  --approved-file /wordpress/wp-content/plugins/example/changed-file.php \
+  --patch-strip 5 \
+  --commit-message "Apply approved WP Codebox artifact"
+```
+
+The command prints JSON containing `adapter_id`, `artifact_id`, `patch_sha256`, `content_digest`, `approved_files`, `applied_files`, `worktree`, `branch`, `commit`, and `pr_url` when a PR is created.
+
+## PR Seam
+
+The core supports `--push` and `--open-pr`, but callers can also use the returned metadata and run the final PR step explicitly:
+
+```bash
+git push -u origin <branch>
+gh pr create --fill
+```
+
+Production callers should wire bot identity, DMC worktree creation/reuse, branch naming, PR title/body policy, and AI assistance disclosure before enabling automatic PR creation.

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -11,7 +11,7 @@
     "lint": [
       "jq empty wordpress.json",
       "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/release/package.sh scripts/release/publish.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
-      "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js scripts/agent/terminal-action-server.js tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js",
+      "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js lib/wp-codebox-apply-adapter.js scripts/agent/terminal-action-server.js scripts/agent/wp-codebox-apply-adapter.cjs tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js tests/wp-codebox-apply-adapter-smoke.js",
       "php -l scripts/agent/datamachine-agent-workload.php tests/datamachine-terminal-tool-smoke.php"
     ],
     "test": [
@@ -37,7 +37,8 @@
       "node tests/agent-terminal-actions-smoke.js",
       "node tests/terminal-action-server-smoke.js",
       "php tests/datamachine-terminal-tool-smoke.php",
-      "node tests/timing-correlator-smoke.js"
+      "node tests/timing-correlator-smoke.js",
+      "node tests/wp-codebox-apply-adapter-smoke.js"
     ]
   }
 }

--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -6,4 +6,5 @@ module.exports = {
 	...require('./lib/page-profiler'),
 	...require('./lib/timing-correlator'),
 	...require('./lib/agent-terminal-actions'),
+	...require('./lib/wp-codebox-apply-adapter'),
 };

--- a/wordpress/lib/wp-codebox-apply-adapter.js
+++ b/wordpress/lib/wp-codebox-apply-adapter.js
@@ -1,0 +1,245 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const ADAPTER_ID = 'homeboy/wp-codebox-apply-adapter/v1';
+const CONTENT_DIGEST_PREFIX = 'wp-codebox/artifact-content/v1\nfiles/changed-files.json\n';
+const CONTENT_DIGEST_SEPARATOR = '\nfiles/patch.diff\n';
+const PROTECTED_BRANCHES = new Set(['main', 'master', 'trunk', 'develop']);
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function artifactContentDigest(changedFilesJson, patch) {
+  return sha256(`${CONTENT_DIGEST_PREFIX}${changedFilesJson}${CONTENT_DIGEST_SEPARATOR}${patch}`);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: 'utf8',
+    env: options.env || process.env,
+    input: options.input,
+  });
+
+  if (result.status !== 0) {
+    const detail = [result.stderr, result.stdout].filter(Boolean).join('\n').trim();
+    throw new Error(`${command} ${args.join(' ')} failed${detail ? `: ${detail}` : ''}`);
+  }
+
+  return (result.stdout || '').trim();
+}
+
+function realDirectory(directory, label) {
+  if (!directory) {
+    throw new Error(`${label} is required`);
+  }
+  const real = fs.realpathSync(directory);
+  if (!fs.statSync(real).isDirectory()) {
+    throw new Error(`${label} must be a directory`);
+  }
+  return real;
+}
+
+function loadWpCodeboxArtifactBundle(bundlePath) {
+  const directory = realDirectory(bundlePath, 'bundlePath');
+  const manifestPath = path.join(directory, 'manifest.json');
+  const metadataPath = path.join(directory, 'metadata.json');
+  const changedFilesPath = path.join(directory, 'files', 'changed-files.json');
+  const patchPath = path.join(directory, 'files', 'patch.diff');
+  const reviewPath = path.join(directory, 'files', 'review.json');
+
+  const changedFilesJson = fs.readFileSync(changedFilesPath, 'utf8');
+  const patch = fs.readFileSync(patchPath, 'utf8');
+
+  return {
+    id: readJson(manifestPath).id,
+    directory,
+    manifest: readJson(manifestPath),
+    metadata: fs.existsSync(metadataPath) ? readJson(metadataPath) : {},
+    changed_files: readJson(changedFilesPath),
+    review: fs.existsSync(reviewPath) ? readJson(reviewPath) : {},
+    changedFilesJson,
+    patch,
+    paths: {
+      manifest: manifestPath,
+      metadata: metadataPath,
+      changed_files: changedFilesPath,
+      patch: patchPath,
+      review: reviewPath,
+    },
+  };
+}
+
+function normalizePayload(input) {
+  if (input.bundlePath) {
+    const bundle = loadWpCodeboxArtifactBundle(input.bundlePath);
+    return {
+      artifact_id: bundle.id,
+      artifact: bundle,
+      approved_files: input.approvedFiles || input.approved_files || [],
+      patch: bundle.patch,
+      patch_sha256: sha256(bundle.patch),
+      artifact_content_digest: artifactContentDigest(bundle.changedFilesJson, bundle.patch),
+    };
+  }
+
+  if (!input.payload || typeof input.payload !== 'object') {
+    throw new Error('payload or bundlePath is required');
+  }
+
+  return input.payload;
+}
+
+function changedFilePaths(changedFiles) {
+  return (changedFiles.files || [])
+    .map((file) => file && file.path)
+    .filter((filePath) => typeof filePath === 'string' && filePath.length > 0);
+}
+
+function verifyWpCodeboxPayload(payload) {
+  const artifact = payload.artifact || {};
+  const changedFiles = artifact.changed_files || {};
+  const changedFilesJson = artifact.changedFilesJson || (
+    artifact.paths?.changed_files && fs.existsSync(artifact.paths.changed_files)
+      ? fs.readFileSync(artifact.paths.changed_files, 'utf8')
+      : JSON.stringify(changedFiles, null, 2) + '\n'
+  );
+  const patch = payload.patch || artifact.patch;
+  if (typeof patch !== 'string' || patch.trim() === '') {
+    throw new Error('payload.patch must contain the approved canonical patch');
+  }
+
+  const contentDigest = artifactContentDigest(changedFilesJson, patch);
+  const patchSha256 = sha256(patch);
+  const declaredContentDigest = payload.artifact_content_digest || artifact.content_digest || artifact.manifest?.contentDigest?.value;
+  const declaredPatchSha256 = payload.patch_sha256 || artifact.review?.evidence?.patchSha256;
+  const artifactId = payload.artifact_id || artifact.id;
+
+  if (declaredContentDigest && declaredContentDigest !== contentDigest) {
+    throw new Error('artifact content digest mismatch');
+  }
+  if (declaredPatchSha256 && declaredPatchSha256 !== patchSha256) {
+    throw new Error('patch digest mismatch');
+  }
+  if (artifactId && artifactId !== `artifact-bundle-sha256-${contentDigest}`) {
+    throw new Error('artifact id does not match content digest');
+  }
+
+  const approvedFiles = Array.isArray(payload.approved_files) ? payload.approved_files : [];
+  const changedPaths = changedFilePaths(changedFiles);
+  const missingApproval = changedPaths.filter((filePath) => !approvedFiles.includes(filePath));
+  if (missingApproval.length > 0) {
+    throw new Error(`adapter requires approval for every changed file: ${missingApproval.join(', ')}`);
+  }
+
+  return {
+    artifactId,
+    approvedFiles,
+    changedPaths,
+    contentDigest,
+    patch,
+    patchSha256,
+  };
+}
+
+function currentBranch(worktreePath) {
+  return run('git', ['branch', '--show-current'], { cwd: worktreePath });
+}
+
+function ensureSafeWorktree(worktreePath, options = {}) {
+  const realWorktree = realDirectory(worktreePath, 'worktreePath');
+  const topLevel = fs.realpathSync(run('git', ['rev-parse', '--show-toplevel'], { cwd: realWorktree }));
+  if (topLevel !== realWorktree) {
+    throw new Error(`worktreePath must be the git worktree root: ${topLevel}`);
+  }
+
+  const branch = currentBranch(realWorktree);
+  if (!options.allowProtectedBranch && PROTECTED_BRANCHES.has(branch)) {
+    throw new Error(`refusing to apply artifact on protected branch ${branch}`);
+  }
+
+  const status = run('git', ['status', '--porcelain'], { cwd: realWorktree });
+  if (status !== '') {
+    throw new Error('worktree must be clean before applying an approved artifact');
+  }
+
+  return realWorktree;
+}
+
+function applyApprovedWpCodeboxArtifact(input) {
+  const payload = normalizePayload(input);
+  const verified = verifyWpCodeboxPayload(payload);
+  const worktreePath = ensureSafeWorktree(input.worktreePath, input);
+  const requestedBranch = input.branch || '';
+
+  if (requestedBranch) {
+    if (!input.allowProtectedBranch && PROTECTED_BRANCHES.has(requestedBranch)) {
+      throw new Error(`refusing to apply artifact on protected branch ${requestedBranch}`);
+    }
+    run('git', ['checkout', '-B', requestedBranch], { cwd: worktreePath });
+  }
+
+  const patchPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'wp-codebox-patch-')), 'patch.diff');
+  fs.writeFileSync(patchPath, verified.patch);
+
+  const stripComponents = Number.isInteger(input.patchStrip) ? input.patchStrip : 1;
+  run('git', ['apply', '--index', '--binary', `-p${stripComponents}`, patchPath], { cwd: worktreePath });
+
+  const appliedFiles = run('git', ['diff', '--cached', '--name-only'], { cwd: worktreePath })
+    .split('\n')
+    .filter(Boolean);
+  if (appliedFiles.length === 0) {
+    throw new Error('approved patch did not stage any files');
+  }
+
+  const commitMessage = input.commitMessage || `Apply wp-codebox artifact ${verified.artifactId}`;
+  run('git', ['commit', '-m', commitMessage], { cwd: worktreePath });
+  const commit = run('git', ['rev-parse', 'HEAD'], { cwd: worktreePath });
+  const branch = currentBranch(worktreePath);
+  let prUrl = input.prUrl || '';
+
+  if (input.push) {
+    run('git', ['push', '-u', input.remote || 'origin', branch], { cwd: worktreePath });
+  }
+
+  if (input.openPullRequest) {
+    const args = ['pr', 'create', '--fill'];
+    if (input.prBase) {
+      args.push('--base', input.prBase);
+    }
+    prUrl = run('gh', args, { cwd: worktreePath });
+  }
+
+  return {
+    success: true,
+    adapter_id: ADAPTER_ID,
+    artifact_id: verified.artifactId,
+    patch_sha256: verified.patchSha256,
+    content_digest: verified.contentDigest,
+    approved_files: verified.approvedFiles,
+    applied_files: appliedFiles,
+    worktree: worktreePath,
+    branch,
+    commit,
+    pr_url: prUrl,
+    pr_command: prUrl ? '' : 'gh pr create --fill',
+  };
+}
+
+module.exports = {
+  ADAPTER_ID,
+  artifactContentDigest,
+  applyApprovedWpCodeboxArtifact,
+  loadWpCodeboxArtifactBundle,
+  verifyWpCodeboxPayload,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -9,7 +9,8 @@
     "./playground-readiness": "./lib/playground-readiness.js",
     "./request-profiler": "./lib/request-profiler.js",
     "./agent-terminal-actions": "./lib/agent-terminal-actions.js",
-    "./timing-correlator": "./lib/timing-correlator.js"
+    "./timing-correlator": "./lib/timing-correlator.js",
+    "./wp-codebox-apply-adapter": "./lib/wp-codebox-apply-adapter.js"
   },
   "scripts": {
     "lint:js": "eslint --ext .js,.jsx,.ts,.tsx",
@@ -19,7 +20,8 @@
     "test:terminal-action-server": "node tests/terminal-action-server-smoke.js",
     "test:playground-readiness": "node tests/playground-readiness-smoke.js",
     "test:request-profiler": "node tests/request-profiler-smoke.js",
-    "test:timing-correlator": "node tests/timing-correlator-smoke.js"
+    "test:timing-correlator": "node tests/timing-correlator-smoke.js",
+    "test:wp-codebox-apply-adapter": "node tests/wp-codebox-apply-adapter-smoke.js"
   },
   "devDependencies": {
     "@wp-playground/cli": "^3.1.29",

--- a/wordpress/scripts/agent/wp-codebox-apply-adapter.cjs
+++ b/wordpress/scripts/agent/wp-codebox-apply-adapter.cjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+'use strict';
+
+const { applyApprovedWpCodeboxArtifact } = require('../../lib/wp-codebox-apply-adapter');
+
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : '';
+}
+
+function hasArg(name) {
+  return process.argv.includes(name);
+}
+
+function usage() {
+  console.error('Usage: wp-codebox-apply-adapter.cjs --bundle <artifact-dir> --worktree <path> --branch <branch> --approved-file <sandbox-path> [--patch-strip <n>] [--push] [--open-pr]');
+  process.exit(1);
+}
+
+const bundlePath = argValue('--bundle');
+const worktreePath = argValue('--worktree');
+const branch = argValue('--branch');
+const commitMessage = argValue('--commit-message');
+const patchStripValue = argValue('--patch-strip');
+const approvedFiles = [];
+
+for (let index = 0; index < process.argv.length; index += 1) {
+  if (process.argv[index] === '--approved-file' && process.argv[index + 1]) {
+    approvedFiles.push(process.argv[index + 1]);
+  }
+}
+
+if (!bundlePath || !worktreePath || approvedFiles.length === 0) {
+  usage();
+}
+
+try {
+  const result = applyApprovedWpCodeboxArtifact({
+    bundlePath,
+    worktreePath,
+    branch,
+    commitMessage,
+    approvedFiles,
+    patchStrip: patchStripValue ? Number(patchStripValue) : undefined,
+    push: hasArg('--push'),
+    openPullRequest: hasArg('--open-pr'),
+    prBase: argValue('--base') || undefined,
+  });
+  console.log(JSON.stringify(result, null, 2));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/wordpress/tests/wp-codebox-apply-adapter-smoke.js
+++ b/wordpress/tests/wp-codebox-apply-adapter-smoke.js
@@ -1,0 +1,187 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const {
+  applyApprovedWpCodeboxArtifact,
+  artifactContentDigest,
+  verifyWpCodeboxPayload,
+} = require('../lib/wp-codebox-apply-adapter');
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { cwd: options.cwd, encoding: 'utf8' });
+  assert.equal(result.status, 0, `${command} ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
+  return (result.stdout || '').trim();
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function createRepo(root, branch) {
+  const repo = path.join(root, `repo-${branch.replace(/[^a-z0-9]+/gi, '-')}`);
+  fs.mkdirSync(repo, { recursive: true });
+  fs.writeFileSync(path.join(repo, 'readme.txt'), 'before\n');
+  run('git', ['init', '-b', branch], { cwd: repo });
+  run('git', ['config', 'user.email', 'smoke@example.test'], { cwd: repo });
+  run('git', ['config', 'user.name', 'Smoke Test'], { cwd: repo });
+  run('git', ['add', 'readme.txt'], { cwd: repo });
+  run('git', ['commit', '-m', 'Initial fixture'], { cwd: repo });
+  return repo;
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function createBundle(root) {
+  const bundle = path.join(root, 'bundle');
+  const files = path.join(bundle, 'files');
+  fs.mkdirSync(files, { recursive: true });
+
+  const changedFiles = {
+    schema: 'wp-codebox/changed-files/v1',
+    files: [
+      {
+        path: '/wordpress/wp-content/plugins/fixture-plugin/readme.txt',
+        status: 'modified',
+        mountTarget: '/wordpress/wp-content/plugins/fixture-plugin',
+        relativePath: 'readme.txt',
+      },
+    ],
+  };
+  const changedFilesJson = `${JSON.stringify(changedFiles, null, 2)}\n`;
+  const patch = [
+    'diff --git a/wordpress/wp-content/plugins/fixture-plugin/readme.txt b/wordpress/wp-content/plugins/fixture-plugin/readme.txt',
+    '--- a/wordpress/wp-content/plugins/fixture-plugin/readme.txt',
+    '+++ b/wordpress/wp-content/plugins/fixture-plugin/readme.txt',
+    '@@ -1,1 +1,1 @@',
+    '-before',
+    '+after',
+    '',
+  ].join('\n');
+  const contentDigest = artifactContentDigest(changedFilesJson, patch);
+  const artifactId = `artifact-bundle-sha256-${contentDigest}`;
+  const contentDigestMetadata = {
+    algorithm: 'sha256',
+    inputs: ['files/changed-files.json', 'files/patch.diff'],
+    value: contentDigest,
+  };
+
+  writeJson(path.join(bundle, 'manifest.json'), {
+    id: artifactId,
+    contentDigest: contentDigestMetadata,
+    createdAt: '2026-05-19T00:00:00.000Z',
+    files: [
+      { path: 'files/changed-files.json', kind: 'changed-files' },
+      { path: 'files/patch.diff', kind: 'patch' },
+      { path: 'files/review.json', kind: 'review' },
+    ],
+  });
+  writeJson(path.join(bundle, 'metadata.json'), {
+    id: artifactId,
+    contentDigest: contentDigestMetadata,
+    artifacts: { changedFiles: 'files/changed-files.json', patch: 'files/patch.diff' },
+  });
+  writeJson(path.join(files, 'changed-files.json'), changedFiles);
+  fs.writeFileSync(path.join(files, 'patch.diff'), patch);
+  writeJson(path.join(files, 'review.json'), {
+    schema: 'wp-codebox/artifact-review/v1',
+    artifactId,
+    evidence: {
+      patch: 'files/patch.diff',
+      patchSha256: sha256(patch),
+      artifactContentDigest: contentDigest,
+      changedFiles: 'files/changed-files.json',
+    },
+  });
+
+  return { artifactId, bundle, contentDigest, patch };
+}
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wp-codebox-apply-adapter-'));
+
+try {
+  const fixture = createBundle(root);
+  const changedFilesJson = fs.readFileSync(path.join(fixture.bundle, 'files', 'changed-files.json'), 'utf8');
+  const changedFiles = JSON.parse(changedFilesJson);
+  const repo = createRepo(root, 'feature/apply-smoke');
+
+  const result = applyApprovedWpCodeboxArtifact({
+    bundlePath: fixture.bundle,
+    worktreePath: repo,
+    branch: 'feature/wp-codebox-apply-smoke',
+    commitMessage: 'Apply fixture wp-codebox artifact',
+    approvedFiles: ['/wordpress/wp-content/plugins/fixture-plugin/readme.txt'],
+    patchStrip: 5,
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.artifact_id, fixture.artifactId);
+  assert.equal(result.patch_sha256, sha256(fixture.patch));
+  assert.equal(result.content_digest, fixture.contentDigest);
+  assert.deepEqual(result.applied_files, ['readme.txt']);
+  assert.equal(fs.readFileSync(path.join(repo, 'readme.txt'), 'utf8'), 'after\n');
+  assert.equal(run('git', ['status', '--porcelain'], { cwd: repo }), '');
+
+  assert.equal(
+    verifyWpCodeboxPayload({
+      artifact_id: fixture.artifactId,
+      artifact: {
+        changed_files: changedFiles,
+        paths: { changed_files: path.join(fixture.bundle, 'files', 'changed-files.json') },
+      },
+      approved_files: ['/wordpress/wp-content/plugins/fixture-plugin/readme.txt'],
+      patch: fixture.patch,
+      patch_sha256: sha256(fixture.patch),
+      artifact_content_digest: fixture.contentDigest,
+    }).contentDigest,
+    fixture.contentDigest
+  );
+
+  assert.throws(
+    () => verifyWpCodeboxPayload({
+      artifact_id: fixture.artifactId,
+      artifact: {
+        changed_files: changedFiles,
+        changedFilesJson,
+      },
+      approved_files: [],
+      patch: fixture.patch,
+      patch_sha256: sha256(fixture.patch),
+      artifact_content_digest: fixture.contentDigest,
+    }),
+    /approval for every changed file/
+  );
+
+  const cliRepo = createRepo(root, 'feature/apply-cli-smoke');
+  const cliOutput = run(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'wp-codebox-apply-adapter.cjs'),
+    '--bundle',
+    fixture.bundle,
+    '--worktree',
+    cliRepo,
+    '--branch',
+    'feature/wp-codebox-apply-cli-smoke',
+    '--approved-file',
+    '/wordpress/wp-content/plugins/fixture-plugin/readme.txt',
+    '--patch-strip',
+    '5',
+    '--commit-message',
+    'Apply fixture wp-codebox artifact through CLI',
+  ]);
+  const cliResult = JSON.parse(cliOutput);
+  assert.equal(cliResult.success, true);
+  assert.equal(cliResult.artifact_id, fixture.artifactId);
+  assert.equal(cliResult.branch, 'feature/wp-codebox-apply-cli-smoke');
+  assert.deepEqual(cliResult.applied_files, ['readme.txt']);
+  assert.equal(fs.readFileSync(path.join(cliRepo, 'readme.txt'), 'utf8'), 'after\n');
+
+  console.log('WP Codebox apply adapter smoke passed');
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- Adds a Homeboy WordPress `homeboy/wp-codebox-apply-adapter/v1` core that loads approved WP Codebox artifact bundles or filter payloads, re-verifies content and patch digests, applies the canonical patch to a clean git worktree, and commits it.
- Exposes a CLI seam for bundle/worktree application plus documented PR handoff metadata for push/PR creation.
- Adds smoke coverage for fixture bundle loading, payload verification, library application, and CLI application.

## Verification
- `node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js lib/wp-codebox-apply-adapter.js scripts/agent/terminal-action-server.js scripts/agent/wp-codebox-apply-adapter.cjs tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js tests/wp-codebox-apply-adapter-smoke.js`
- `node tests/wp-codebox-apply-adapter-smoke.js`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@feature-wp-codebox-apply-adapter/wordpress --extension wordpress`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@feature-wp-codebox-apply-adapter/wordpress --extension wordpress` currently fails before the new smoke on existing `tests/audit-detector-config-smoke.sh` assertion: `constant-backed slug detector should still flag comparisons`. Reproduced the same failure on current main with `bash tests/audit-detector-config-smoke.sh`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the adapter implementation, fixture smoke coverage, documentation, verification commands, and PR description for Chris to review.