### PR TITLE
Wire WP Codebox as selectable agent runtime

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -128,6 +128,8 @@ jobs:
 ## Inputs worth calling out
 
 - `include_agent_runtime_dependencies` defaults to `true` and checks out the standard WordPress agent runtime stack: `Automattic/agents-api`, `Extra-Chill/data-machine`, `Extra-Chill/data-machine-code`, and the provider plugin.
+- `agent_runtime` selects the sandbox runner. `homeboy` preserves the legacy Playground runner; `wp-codebox` checks out, builds, and runs `chubes4/wp-codebox` as the WordPress sandbox/runtime boundary.
+- `wp_codebox_ref` controls the `chubes4/wp-codebox` ref used when `agent_runtime: wp-codebox`.
 - `agents_api_ref`, `data_machine_ref`, `data_machine_code_ref`, and `openai_provider_ref` control runtime dependency refs. `openai_provider_ref` defaults to `trunk` for the built-in OpenAI preset.
 - `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `credentials` keys. When `provider: openai`, an empty object preserves the existing OpenAI provider defaults.
 - `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -68,6 +68,14 @@ name: Data Machine Agent CI (reusable)
         description: "Include the standard WordPress agent runtime stack: Agents API, Data Machine, Data Machine Code, and the selected provider plugin."
         type: boolean
         default: true
+      agent_runtime:
+        description: Agent sandbox runtime. Use `homeboy` for the legacy Playground runner or `wp-codebox` for the WP Codebox runtime adapter.
+        type: string
+        default: homeboy
+      wp_codebox_ref:
+        description: Ref for chubes4/wp-codebox when agent_runtime is wp-codebox.
+        type: string
+        default: main
       agents_api_ref:
         description: Ref for Automattic/agents-api when include_agent_runtime_dependencies is true.
         type: string
@@ -380,6 +388,8 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           VALIDATION_DEPENDENCIES: ${{ inputs.validation_dependencies }}
           INCLUDE_AGENT_RUNTIME_DEPENDENCIES: ${{ inputs.include_agent_runtime_dependencies }}
+          AGENT_RUNTIME: ${{ inputs.agent_runtime }}
+          WP_CODEBOX_REF: ${{ inputs.wp_codebox_ref }}
           AGENTS_API_REF: ${{ inputs.agents_api_ref }}
           DATA_MACHINE_REF: ${{ inputs.data_machine_ref }}
           DATA_MACHINE_CODE_REF: ${{ inputs.data_machine_code_ref }}
@@ -402,6 +412,10 @@ jobs:
           ')"
           provider_plugin_repo="$(jq -r '.repo // ""' <<< "$provider_plugin_json")"
           provider_plugin_ref="$(jq -r '.ref // ""' <<< "$provider_plugin_json")"
+          case "$AGENT_RUNTIME" in
+            homeboy|wp-codebox) ;;
+            *) echo "agent_runtime must be homeboy or wp-codebox, got: $AGENT_RUNTIME" >&2; exit 1 ;;
+          esac
           if [ "$INCLUDE_AGENT_RUNTIME_DEPENDENCIES" = "true" ]; then
             dependency_entries+=("Automattic/agents-api@${AGENTS_API_REF}")
             dependency_entries+=("Extra-Chill/data-machine@${DATA_MACHINE_REF}")
@@ -413,6 +427,9 @@ jobs:
                 dependency_entries+=("${provider_plugin_repo}")
               fi
             fi
+          fi
+          if [ "$AGENT_RUNTIME" = "wp-codebox" ]; then
+            dependency_entries+=("chubes4/wp-codebox@${WP_CODEBOX_REF}")
           fi
           if [ -n "$VALIDATION_DEPENDENCIES" ]; then
             IFS=',' read -ra extra_entries <<< "$VALIDATION_DEPENDENCIES"
@@ -500,6 +517,14 @@ jobs:
           composer install --no-interaction --no-progress --prefer-dist
           npm install
 
+      - name: Build WP Codebox runtime dependency
+        if: ${{ inputs.run_agent && inputs.agent_runtime == 'wp-codebox' }}
+        working-directory: .ci/wp-codebox
+        run: |
+          set -euo pipefail
+          npm install
+          npm run build
+
       - name: Install checked-out PHP dependencies
         if: ${{ inputs.run_agent }}
         env:
@@ -551,6 +576,7 @@ jobs:
           PROMPT: ${{ inputs.prompt }}
           PROVIDER: ${{ inputs.provider }}
           MODEL: ${{ inputs.model }}
+          AGENT_RUNTIME: ${{ inputs.agent_runtime }}
           PLAYGROUND_WORDPRESS: ${{ inputs.playground_wordpress }}
           SUCCESS_REQUIRES_PR: ${{ inputs.success_requires_pr }}
           SUCCESS_COMPLETION_OUTCOMES: ${{ inputs.success_completion_outcomes }}
@@ -623,6 +649,7 @@ jobs:
           ')"
           provider_plugin_repo="$(jq -r '.repo // ""' <<< "$provider_plugin_json")"
           provider_plugin_path="$(jq -r '.path // "."' <<< "$provider_plugin_json")"
+          provider_plugin_host_path=""
           if [ -n "$provider_plugin_repo" ] && [ "$provider_plugin_path" != "." ]; then
             provider_plugin_repo_name="${provider_plugin_repo#*/}"
             provider_plugin_root="${GITHUB_WORKSPACE}/.ci/${provider_plugin_repo_name}"
@@ -666,6 +693,11 @@ jobs:
           provider_register_function="$(jq -r '.register_function // ""' <<< "$provider_plugin_json")"
           provider_credentials_json="$(jq -c '.credentials // {}' <<< "$provider_plugin_json")"
           provider_bench_env_json="{}"
+          wp_codebox_bin=""
+          if [ "$AGENT_RUNTIME" = "wp-codebox" ]; then
+            wp_codebox_bin="${GITHUB_WORKSPACE}/.ci/wp-codebox/packages/cli/dist/index.js"
+            [ -f "$wp_codebox_bin" ] || { echo "WP Codebox CLI build missing at $wp_codebox_bin" >&2; exit 1; }
+          fi
           while IFS= read -r provider_env_name; do
             [ -n "$provider_env_name" ] || continue
             case "$provider_env_name" in
@@ -689,6 +721,9 @@ jobs:
             --arg prompt "$PROMPT" \
             --arg provider "$PROVIDER" \
             --arg model "$MODEL" \
+            --arg agentRuntime "$AGENT_RUNTIME" \
+            --arg wpCodeboxBin "$wp_codebox_bin" \
+            --arg providerPluginHostPath "$provider_plugin_host_path" \
             --arg engineKey "$ENGINE_KEY" \
             --arg toolResultsKey "$TOOL_RESULTS_KEY" \
             --arg playgroundWordPress "$PLAYGROUND_WORDPRESS" \
@@ -757,6 +792,14 @@ jobs:
               model: $model,
               provider_register_function: $providerRegisterFunction,
               provider_credentials: $providerCredentials,
+              agent_runtime: $agentRuntime,
+              wp_codebox_bin: $wpCodeboxBin,
+              wp_codebox_components: {
+                agents_api: ($componentPath + "/.ci/agents-api"),
+                data_machine: ($componentPath + "/.ci/data-machine"),
+                data_machine_code: ($componentPath + "/.ci/data-machine-code")
+              },
+              provider_plugin_paths: (if $providerPluginHostPath != "" then [$providerPluginHostPath] else [] end),
               github_token_env: "HOMEBOY_GITHUB_APP_TOKEN",
               github_repository_token_env: "GITHUB_TOKEN",
               github_profile_id: ($agentSlug + "-ci"),

--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -12,7 +12,7 @@ fi
 RUNTIME_DIR=$(mktemp -d "${TMPDIR:-/tmp}/datamachine-agent-wp-codebox.XXXXXX")
 CONFIG_TMPFILE="$RUNTIME_DIR/config.json"
 RESULTS_TMPFILE="$RUNTIME_DIR/results.json"
-FAKE_WP_CODEBOX="$RUNTIME_DIR/wp-codebox"
+FAKE_WP_CODEBOX="$RUNTIME_DIR/wp-codebox.js"
 FAKE_ARGS_FILE="$RUNTIME_DIR/wp-codebox-args.txt"
 BUNDLE_DIR="$RUNTIME_DIR/bundle"
 AGENTS_API_DIR="$RUNTIME_DIR/agents-api"
@@ -27,32 +27,23 @@ trap cleanup EXIT
 mkdir -p "$BUNDLE_DIR" "$AGENTS_API_DIR" "$DATA_MACHINE_DIR" "$DATA_MACHINE_CODE_DIR"
 printf '{"agent":{"slug":"wp-codebox-smoke-agent"}}\n' > "$BUNDLE_DIR/manifest.json"
 
-cat > "$FAKE_WP_CODEBOX" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-
-args_file="${FAKE_WP_CODEBOX_ARGS_FILE:?}"
-printf '%s\n' "$@" > "$args_file"
-
-has_arg() {
-    local expected="$1"
-    shift
-    for arg in "$@"; do
-        if [ "$arg" = "$expected" ]; then
-            return 0
-        fi
-    done
-    return 1
-}
-
-has_arg agent-sandbox-run "$@"
-has_arg --json "$@"
-has_arg --secret-env "$@"
-has_arg HOMEBOY_DATAMACHINE_AGENT_CONFIG "$@"
-
-node - <<'NODE'
+cat > "$FAKE_WP_CODEBOX" <<'NODE'
+#!/usr/bin/env node
 const fs = require('node:fs')
 const path = require('node:path')
+
+const args = process.argv.slice(2)
+const argsFile = process.env.FAKE_WP_CODEBOX_ARGS_FILE
+if (!argsFile) {
+  throw new Error('FAKE_WP_CODEBOX_ARGS_FILE is required')
+}
+fs.writeFileSync(argsFile, `${args.join('\n')}\n`)
+
+for (const expected of ['agent-sandbox-run', '--json', '--secret-env', 'HOMEBOY_DATAMACHINE_AGENT_CONFIG']) {
+  if (!args.includes(expected)) {
+    throw new Error(`missing expected wp-codebox arg: ${expected}`)
+  }
+}
 
 const artifactRoot = path.join(path.dirname(process.env.FAKE_WP_CODEBOX_ARGS_FILE), 'wp-codebox-artifacts', 'runtime-smoke')
 const filesRoot = path.join(artifactRoot, 'files')
@@ -128,7 +119,6 @@ process.stdout.write(JSON.stringify({
   },
 }) + '\n')
 NODE
-SH
 chmod +x "$FAKE_WP_CODEBOX"
 
 jq -n \

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -127,8 +127,15 @@ PHP
 
     local wp_codebox_output
     wp_codebox_output=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-output.XXXXXX")
+    local wp_codebox_command=("$wp_codebox_bin")
+    case "$wp_codebox_bin" in
+        *.js)
+            wp_codebox_command=(node "$wp_codebox_bin")
+            ;;
+    esac
+
     HOMEBOY_DATAMACHINE_AGENT_CONFIG="$CONFIG_JSON" \
-        "$wp_codebox_bin" "${wp_codebox_args[@]}" \
+        "${wp_codebox_command[@]}" "${wp_codebox_args[@]}" \
         >"$wp_codebox_output"
 
     local wp_codebox_review_input="$RUNTIME_DIR/wp-codebox-review.json"


### PR DESCRIPTION
## Summary
- Add `agent_runtime` and `wp_codebox_ref` inputs to the reusable Data Machine Agent CI workflow.
- When `agent_runtime: wp-codebox`, check out/build `chubes4/wp-codebox` and pass its built CLI plus component paths into the runner config.
- Teach the runner to execute built WP Codebox JS CLI files through `node`, and update the adapter smoke to cover that path.

## Testing
- `npm run test:datamachine-agent-wp-codebox-runner`
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); puts "workflow yaml ok"'`
- Local real wp-codebox dry-run via `wordpress/scripts/agent/run-datamachine-agent.sh` using `/Users/chubes/Developer/sandbox-runtime@datamachine-pending-apply/packages/cli/dist/index.js`

## Notes
- This keeps `agent_runtime` defaulting to `homeboy`; consumers can canary `wp-codebox` before we flip the default.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the workflow/runtime wiring, smoke update, docs, and local verification commands; Chris directed the migration goal.