### PR TITLE
Canary WP Codebox agent runtime in self-smoke

### DIFF
--- a/.github/workflows/datamachine-agent-ci-self-smoke.yml
+++ b/.github/workflows/datamachine-agent-ci-self-smoke.yml
@@ -55,3 +55,21 @@ jobs:
       HOMEBOY_APP_ID: ${{ secrets.HOMEBOY_APP_ID }}
       HOMEBOY_APP_PRIVATE_KEY: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
       PROVIDER_SECRET_1: ${{ secrets.PROVIDER_SECRET_1 }}
+
+  wp-codebox-runtime-smoke:
+    uses: ./.github/workflows/datamachine-agent-ci.yml
+    with:
+      bundle_path: tests/fixtures/datamachine-agent-self-smoke/bundles/self-smoke-agent
+      agent_slug: self-smoke-agent
+      pipeline_slug: self-smoke-pipeline
+      flow_slug: self-smoke-wp-codebox-flow
+      target_repo: Extra-Chill/homeboy-extensions
+      prompt: Exercise the WP Codebox agent runtime path in dry-run mode.
+      agent_runtime: wp-codebox
+      success_requires_pr: false
+      dry_run: true
+      engine_data_outputs: '{}'
+    secrets:
+      HOMEBOY_APP_ID: ${{ secrets.HOMEBOY_APP_ID }}
+      HOMEBOY_APP_PRIVATE_KEY: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary
- Add a self-smoke job that runs the reusable Data Machine Agent CI workflow with `agent_runtime: wp-codebox`.
- Keep the canary in dry-run mode so it proves checkout/build/config/runtime wiring without live agent tool effects.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci-self-smoke.yml"); YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); puts "workflow yaml ok"'`
- `npm run test:datamachine-agent-wp-codebox-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added the canary workflow job and ran local syntax/adapter checks; Chris directed the migration sequence.