### PR TITLE
Parse WP Codebox WordPress test artifacts

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,7 +10,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/release/package.sh scripts/release/publish.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-playground.sh scripts/test/test-runner-host-smoke.sh scripts/lib/playground-process-cleanup.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/parse-wp-codebox-artifacts-smoke.sh scripts/test/playground-process-cleanup-smoke.sh scripts/test/playground-composer-fallback-no-tests-dir-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/release/package.sh scripts/release/publish.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
       "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js lib/wp-codebox-apply-adapter.js scripts/agent/terminal-action-server.js scripts/agent/wp-codebox-apply-adapter.cjs tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js tests/wp-codebox-apply-adapter-smoke.js",
       "php -l scripts/agent/datamachine-agent-workload.php tests/datamachine-terminal-tool-smoke.php"
     ],
@@ -18,6 +18,7 @@
       "bash scripts/test/host-smoke-runner-smoke.sh",
       "bash scripts/test/test-runner-file-routing-smoke.sh",
       "bash scripts/test/parse-test-failures-sidecar-smoke.sh",
+      "bash scripts/test/parse-wp-codebox-artifacts-smoke.sh",
       "bash scripts/test/playground-process-cleanup-smoke.sh",
       "bash scripts/test/playground-cleanup-noise-smoke.sh",
       "bash scripts/test/playground-no-test-files-smoke.sh",

--- a/wordpress/scripts/test/parse-test-failures.php
+++ b/wordpress/scripts/test/parse-test-failures.php
@@ -19,7 +19,7 @@
  * - fingerprint: stable hash for grouping equivalent failures
  * - stdout_excerpt/stderr_excerpt: bounded captured output excerpts
  *
- * Usage: php parse-test-failures.php <phpunit_output_file> [component_path]
+ * Usage: php parse-test-failures.php <phpunit_output_file|wp-codebox-artifact-dir|wp-codebox-test-results.json> [component_path]
  */
 
 require_once __DIR__ . '/parsers/classify-error.php';
@@ -34,6 +34,10 @@ if ( $argc < 2 ) {
 $output_file    = $argv[1];
 $component_path = $argc >= 3 ? rtrim( $argv[2], '/' ) . '/' : '';
 
+if ( is_dir( $output_file ) && file_exists( $output_file . '/files/test-results.json' ) ) {
+	$output_file = $output_file . '/files/test-results.json';
+}
+
 if ( ! file_exists( $output_file ) ) {
 	fwrite( STDERR, "File not found: $output_file\n" );
 	exit( 1 );
@@ -41,6 +45,15 @@ if ( ! file_exists( $output_file ) ) {
 
 $raw   = file_get_contents( $output_file );
 $lines = explode( "\n", $raw );
+
+$wp_codebox_payload = json_decode( $raw, true );
+if ( is_array( $wp_codebox_payload ) && ( $wp_codebox_payload['schema'] ?? '' ) === 'wp-codebox/test-results/v1' ) {
+	echo json_encode(
+		parse_wp_codebox_test_results( $wp_codebox_payload, $output_file, $component_path ),
+		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+	) . "\n";
+	exit( 0 );
+}
 
 // ============================================================================
 // Phase 1: Extract test counts from summary line
@@ -217,3 +230,181 @@ $output = [
 ];
 
 echo json_encode( $output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n";
+
+/**
+ * Normalize WP Codebox test artifacts into Homeboy's WordPress failure sidecar.
+ */
+function parse_wp_codebox_test_results( array $payload, string $test_results_path, string $component_path ): array {
+	$summary = is_array( $payload['summary'] ?? null ) ? $payload['summary'] : [];
+	$total   = (int) ( $summary['total'] ?? 0 );
+	$passed  = (int) ( $summary['passed'] ?? 0 );
+
+	$artifact_root = dirname( dirname( $test_results_path ) );
+	$raw_excerpt   = make_wp_codebox_raw_log_excerpt( $payload, $artifact_root );
+	$failures      = [];
+	$suites        = is_array( $payload['suites'] ?? null ) ? $payload['suites'] : [];
+
+	foreach ( $suites as $suite ) {
+		if ( ! is_array( $suite ) ) {
+			continue;
+		}
+
+		$suite_name = (string) ( $suite['name'] ?? 'wp-codebox' );
+		foreach ( wp_codebox_failure_entries( $suite ) as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$failures[] = normalize_wp_codebox_failure_entry( $entry, $suite_name, $component_path, $raw_excerpt );
+		}
+	}
+
+	return [
+		'failures' => $failures,
+		'total'    => $total,
+		'passed'   => $passed,
+	];
+}
+
+/**
+ * Extract failed test entries from the flexible WP Codebox suite shape.
+ */
+function wp_codebox_failure_entries( array $suite ): array {
+	$entries = [];
+
+	foreach ( [ 'failures', 'errors' ] as $key ) {
+		if ( is_array( $suite[ $key ] ?? null ) ) {
+			$entries = array_merge( $entries, $suite[ $key ] );
+		}
+	}
+
+	$test_entries = [];
+	foreach ( [ 'testCases', 'cases', 'tests' ] as $key ) {
+		if ( is_array( $suite[ $key ] ?? null ) ) {
+			$test_entries = $suite[ $key ];
+			break;
+		}
+	}
+
+	foreach ( $test_entries as $test ) {
+		if ( is_array( $test ) && in_array( $test['status'] ?? '', [ 'failed', 'error' ], true ) ) {
+			$entries[] = $test;
+		}
+	}
+
+	return $entries;
+}
+
+/**
+ * Convert one WP Codebox failure entry into the existing TestFailure shape.
+ */
+function normalize_wp_codebox_failure_entry( array $entry, string $suite_name, string $component_path, string $raw_excerpt ): array {
+	$test_name = (string) ( $entry['test_name'] ?? $entry['testName'] ?? $entry['test_id'] ?? $entry['id'] ?? $entry['name'] ?? 'wp-codebox failure' );
+	$message   = (string) ( $entry['message'] ?? $entry['failureMessage'] ?? $entry['error'] ?? '' );
+
+	if ( $message === '' && is_array( $entry['failure'] ?? null ) ) {
+		$message = (string) ( $entry['failure']['message'] ?? $entry['failure']['error'] ?? '' );
+	}
+
+	$error_type = (string) ( $entry['error_type'] ?? $entry['errorType'] ?? $entry['failure_type'] ?? '' );
+	if ( $error_type === '' && is_array( $entry['failure'] ?? null ) ) {
+		$error_type = (string) ( $entry['failure']['type'] ?? $entry['failure']['errorType'] ?? '' );
+	}
+	if ( $error_type === '' ) {
+		$error_type = classify_error_type( $message );
+	}
+
+	$test_file   = wp_codebox_normalize_component_path( (string) ( $entry['test_file'] ?? $entry['testFile'] ?? '' ), $component_path );
+	$source_file = wp_codebox_normalize_component_path( (string) ( $entry['source_file'] ?? $entry['sourceFile'] ?? $entry['file'] ?? '' ), $component_path );
+	$source_line = (int) ( $entry['source_line'] ?? $entry['sourceLine'] ?? $entry['line'] ?? 0 );
+
+	if ( $test_file === '' && $source_file !== '' && ( strpos( $source_file, '/tests/' ) !== false || strpos( $source_file, 'Test.php' ) !== false ) ) {
+		$test_file   = $source_file;
+		$source_file = '';
+		$source_line = 0;
+	}
+
+	if ( $test_file === '' ) {
+		$test_file = guess_test_file_from_name( $test_name );
+	}
+
+	$file           = $source_file ?: $test_file;
+	$line           = $source_line;
+	$stdout_excerpt = (string) ( $entry['stdout_excerpt'] ?? $entry['stdout'] ?? $entry['output'] ?? '' );
+	$stderr_excerpt = (string) ( $entry['stderr_excerpt'] ?? $entry['stderr'] ?? '' );
+
+	if ( $stdout_excerpt === '' ) {
+		$stdout_excerpt = $raw_excerpt;
+	}
+
+	$fingerprint = (string) ( $entry['fingerprint'] ?? '' );
+	if ( $fingerprint === '' ) {
+		$fingerprint = make_failure_fingerprint( $test_name, $file, $line, $error_type, $message );
+	}
+
+	return [
+		'test_name'      => $test_name,
+		'test_file'      => $test_file,
+		'error_type'     => $error_type,
+		'message'        => $message,
+		'source_file'    => $source_file,
+		'source_line'    => $source_line,
+		'test_id'        => $test_name,
+		'suite'          => $suite_name ?: 'wp-codebox',
+		'file'           => $file,
+		'line'           => $line,
+		'failure_type'   => $error_type,
+		'fingerprint'    => $fingerprint,
+		'stdout_excerpt' => make_output_excerpt( explode( "\n", $stdout_excerpt ) ),
+		'stderr_excerpt' => make_output_excerpt( explode( "\n", $stderr_excerpt ) ),
+	];
+}
+
+/**
+ * Make artifact paths relative to the tested component when possible.
+ */
+function wp_codebox_normalize_component_path( string $file, string $component_path ): string {
+	if ( $file === '' ) {
+		return '';
+	}
+
+	if ( $component_path && strpos( $file, $component_path ) === 0 ) {
+		return substr( $file, strlen( $component_path ) );
+	}
+
+	return $file;
+}
+
+/**
+ * Preserve nearby command/runtime logs for debugging artifact-only failures.
+ */
+function make_wp_codebox_raw_log_excerpt( array $payload, string $artifact_root ): string {
+	$references = is_array( $payload['rawLogReferences'] ?? null ) ? $payload['rawLogReferences'] : [];
+	$chunks     = [];
+
+	foreach ( $references as $reference ) {
+		if ( ! is_array( $reference ) || empty( $reference['path'] ) ) {
+			continue;
+		}
+
+		$path = (string) $reference['path'];
+		if ( substr( $path, 0, 1 ) === '/' ) {
+			$log_path = $path;
+		} else {
+			$log_path = $artifact_root . '/' . $path;
+		}
+
+		if ( ! is_file( $log_path ) ) {
+			continue;
+		}
+
+		$contents = trim( (string) file_get_contents( $log_path ) );
+		if ( $contents === '' ) {
+			continue;
+		}
+
+		$chunks[] = $path . "\n" . $contents;
+	}
+
+	return make_output_excerpt( explode( "\n", implode( "\n\n", $chunks ) ) );
+}

--- a/wordpress/scripts/test/parse-test-failures.sh
+++ b/wordpress/scripts/test/parse-test-failures.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Parse PHPUnit test failures from output and write JSON to HOMEBOY_TEST_FAILURES_FILE.
 #
-# Usage: parse-test-failures.sh <phpunit_output_file> [component_path]
+# Usage: parse-test-failures.sh <phpunit_output_file|wp-codebox-artifact-dir|wp-codebox-test-results.json> [component_path]
 # Env:   HOMEBOY_TEST_FAILURES_FILE — path to write JSON output
 
 set -euo pipefail
@@ -10,7 +10,15 @@ PHPUNIT_OUTPUT_FILE="${1:-}"
 COMPONENT_PATH="${2:-}"
 FAILURES_FILE="${HOMEBOY_TEST_FAILURES_FILE:-}"
 
-if [ -z "$PHPUNIT_OUTPUT_FILE" ] || [ ! -f "$PHPUNIT_OUTPUT_FILE" ]; then
+if [ -z "$PHPUNIT_OUTPUT_FILE" ]; then
+    exit 0
+fi
+
+if [ -d "$PHPUNIT_OUTPUT_FILE" ] && [ -f "$PHPUNIT_OUTPUT_FILE/files/test-results.json" ]; then
+    PHPUNIT_OUTPUT_FILE="$PHPUNIT_OUTPUT_FILE/files/test-results.json"
+fi
+
+if [ ! -f "$PHPUNIT_OUTPUT_FILE" ]; then
     exit 0
 fi
 

--- a/wordpress/scripts/test/parse-test-results.sh
+++ b/wordpress/scripts/test/parse-test-results.sh
@@ -10,14 +10,22 @@
 # Fallback: when PHPUnit crashes mid-run (e.g., a test calls exit()), the summary
 # line is never printed. In --testdox mode, we count ✔/✘ marks as a fallback.
 #
-# Usage: parse-test-results.sh <phpunit-output-file>
+# Usage: parse-test-results.sh <phpunit-output-file|wp-codebox-artifact-dir|wp-codebox-test-results.json>
 #
 # Writes JSON to HOMEBOY_TEST_RESULTS_FILE when the runtime helper is provided.
 
 set -euo pipefail
 
 OUTPUT_FILE="${1:-}"
-if [ -z "$OUTPUT_FILE" ] || [ ! -f "$OUTPUT_FILE" ]; then
+if [ -z "$OUTPUT_FILE" ]; then
+    exit 0
+fi
+
+if [ -d "$OUTPUT_FILE" ] && [ -f "$OUTPUT_FILE/files/test-results.json" ]; then
+    OUTPUT_FILE="$OUTPUT_FILE/files/test-results.json"
+fi
+
+if [ ! -f "$OUTPUT_FILE" ]; then
     exit 0
 fi
 
@@ -34,6 +42,56 @@ PASSED=0
 FAILED=0
 SKIPPED=0
 PARTIAL=""
+
+if printf '%s' "$OUTPUT" | grep -q '"schema"[[:space:]]*:[[:space:]]*"wp-codebox/test-results/v1"'; then
+    wp_codebox_counts=$(php -r '
+        $path = $argv[1];
+        $data = json_decode(file_get_contents($path), true);
+        if (!is_array($data) || ($data["schema"] ?? "") !== "wp-codebox/test-results/v1") {
+            exit(1);
+        }
+
+        $summary = is_array($data["summary"] ?? null) ? $data["summary"] : array();
+        $total = (int) ($summary["total"] ?? 0);
+        $passed = (int) ($summary["passed"] ?? 0);
+        $failed = (int) ($summary["failed"] ?? 0);
+        $skipped = (int) ($summary["skipped"] ?? 0);
+        $unknown = (int) ($summary["unknown"] ?? 0);
+
+        if ($total === 0 && !empty($data["suites"]) && is_array($data["suites"])) {
+            foreach ($data["suites"] as $suite) {
+                if (!is_array($suite)) {
+                    continue;
+                }
+                $total += (int) ($suite["tests"] ?? $suite["total"] ?? 0);
+                $passed += (int) ($suite["passed"] ?? 0);
+                $failed += (int) ($suite["failed"] ?? 0);
+                $skipped += (int) ($suite["skipped"] ?? 0);
+                $unknown += (int) ($suite["unknown"] ?? 0);
+            }
+        }
+
+        $partial = "";
+        if (($data["status"] ?? "") === "unknown" || $unknown > 0) {
+            $partial = "wp-codebox-unknown";
+        }
+
+        echo implode("\t", array($total, $passed, $failed, $skipped, $partial));
+    ' "$OUTPUT_FILE" 2>/dev/null || true)
+
+    if [ -z "$wp_codebox_counts" ]; then
+        exit 0
+    fi
+
+    IFS=$'\t' read -r TOTAL PASSED FAILED SKIPPED PARTIAL <<EOF
+$wp_codebox_counts
+EOF
+
+    if type homeboy_write_test_results >/dev/null 2>&1; then
+        homeboy_write_test_results "${TOTAL:-0}" "${PASSED:-0}" "${FAILED:-0}" "${SKIPPED:-0}" "${PARTIAL:-}"
+    fi
+    exit 0
+fi
 
 # Portable helper: extract the number after a label like "Tests: 42"
 # Usage: extract_count "label" "text"

--- a/wordpress/scripts/test/parse-wp-codebox-artifacts-smoke.sh
+++ b/wordpress/scripts/test/parse-wp-codebox-artifacts-smoke.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-artifacts.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+ARTIFACT_DIR="$TMP_DIR/artifact"
+RESULTS_FILE="$TMP_DIR/test-results-sidecar.json"
+FAILURES_FILE="$TMP_DIR/test-failures-sidecar.json"
+WRITE_RESULTS_HELPER="$TMP_DIR/write-test-results.sh"
+mkdir -p "$ARTIFACT_DIR/files" "$ARTIFACT_DIR/logs"
+
+cat > "$ARTIFACT_DIR/files/test-results.json" <<'JSON'
+{
+  "schema": "wp-codebox/test-results/v1",
+  "status": "failed",
+  "summary": { "total": 3, "passed": 1, "failed": 1, "skipped": 1, "unknown": 0 },
+  "suites": [
+    {
+      "name": "phpunit",
+      "status": "failed",
+      "tests": 3,
+      "passed": 1,
+      "failed": 1,
+      "skipped": 1,
+      "unknown": 0,
+      "testCases": [
+        {
+          "name": "DataMachine\\Tests\\Unit\\Abilities\\FileAbilitiesTest::test_list_files_rejects_both_scopes",
+          "status": "failed",
+          "message": "Failed asserting that 'Flow step 8-6 not found' contains \"Cannot provide both\".",
+          "file": "/tmp/plugin/inc/Abilities/FileAbilities.php",
+          "line": 94,
+          "testFile": "/tmp/plugin/tests/Unit/Abilities/FileAbilitiesTest.php"
+        }
+      ]
+    }
+  ],
+  "rawLogReferences": [
+    { "path": "commands.jsonl", "kind": "commands-jsonl" },
+    { "path": "logs/commands.log", "kind": "commands-log" },
+    { "path": "logs/runtime.log", "kind": "runtime-log" }
+  ]
+}
+JSON
+
+cat > "$ARTIFACT_DIR/commands.jsonl" <<'JSONL'
+{"command":"phpunit","exitCode":1,"summary":"Tests: 3, Assertions: 4, Failures: 1, Skipped: 1."}
+JSONL
+
+cat > "$ARTIFACT_DIR/logs/commands.log" <<'LOG'
+phpunit --configuration phpunit.xml.dist
+Tests: 3, Assertions: 4, Failures: 1, Skipped: 1.
+LOG
+
+cat > "$ARTIFACT_DIR/logs/runtime.log" <<'LOG'
+WP Codebox runtime completed with failed test status.
+LOG
+
+cat > "$WRITE_RESULTS_HELPER" <<'SH'
+function homeboy_write_test_results {
+    local total="$1"
+    local passed="$2"
+    local failed="$3"
+    local skipped="$4"
+    local partial="${5:-}"
+
+    php -r '
+        $payload = array(
+            "total" => (int) $argv[2],
+            "passed" => (int) $argv[3],
+            "failed" => (int) $argv[4],
+            "skipped" => (int) $argv[5],
+        );
+        if ($argv[6] !== "") {
+            $payload["partial"] = $argv[6];
+        }
+        file_put_contents($argv[1], json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+    ' "$HOMEBOY_TEST_RESULTS_FILE" "$total" "$passed" "$failed" "$skipped" "$partial"
+}
+SH
+
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WRITE_RESULTS_HELPER" \
+HOMEBOY_TEST_RESULTS_FILE="$RESULTS_FILE" \
+    bash "$SCRIPT_DIR/parse-test-results.sh" "$ARTIFACT_DIR"
+
+HOMEBOY_TEST_FAILURES_FILE="$FAILURES_FILE" \
+    bash "$SCRIPT_DIR/parse-test-failures.sh" "$ARTIFACT_DIR" "/tmp/plugin"
+
+python3 - "$RESULTS_FILE" "$FAILURES_FILE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    results = json.load(handle)
+
+assert results == {"total": 3, "passed": 1, "failed": 1, "skipped": 1}, results
+
+with open(sys.argv[2], encoding="utf-8") as handle:
+    failures_payload = json.load(handle)
+
+assert failures_payload["total"] == 3, failures_payload
+assert failures_payload["passed"] == 1, failures_payload
+failures = failures_payload["failures"]
+assert len(failures) == 1, failures
+failure = failures[0]
+
+expected = {
+    "test_id": "DataMachine\\Tests\\Unit\\Abilities\\FileAbilitiesTest::test_list_files_rejects_both_scopes",
+    "suite": "phpunit",
+    "file": "inc/Abilities/FileAbilities.php",
+    "line": 94,
+    "message": "Failed asserting that 'Flow step 8-6 not found' contains \"Cannot provide both\".",
+    "failure_type": "AssertionFailedError",
+    "test_file": "tests/Unit/Abilities/FileAbilitiesTest.php",
+}
+
+for key, value in expected.items():
+    assert failure.get(key) == value, f"{key}: {failure.get(key)!r} != {value!r}"
+
+assert failure["test_name"] == failure["test_id"]
+assert failure["error_type"] == failure["failure_type"]
+assert failure["source_file"] == failure["file"]
+assert failure["source_line"] == failure["line"]
+assert len(failure.get("fingerprint", "")) == 64
+assert "commands.log" in failure.get("stdout_excerpt", "")
+assert "runtime completed" in failure.get("stdout_excerpt", "")
+assert failure.get("stderr_excerpt") == ""
+
+print("wordpress parse wp-codebox artifacts smoke passed")
+PY


### PR DESCRIPTION
## Summary
- Teach the existing WordPress test result parser to consume explicit WP Codebox artifact directories or `files/test-results.json` without changing the default runner path.
- Normalize WP Codebox suite/test failures into the existing Homeboy WordPress failure sidecar keys, including fingerprints and raw command/runtime log excerpts.
- Add a smoke fixture that proves a WP Codebox-style artifact translates into the existing HBE result and failure shapes.

Fixes #685.
Coordinates with #683 and #684 by keeping this parser-only and runtime-default-neutral.

## Tests
- `bash -n wordpress/scripts/test/parse-test-results.sh wordpress/scripts/test/parse-test-failures.sh wordpress/scripts/test/parse-wp-codebox-artifacts-smoke.sh && php -l wordpress/scripts/test/parse-test-failures.php`
- `bash wordpress/scripts/test/parse-test-failures-sidecar-smoke.sh`
- `bash wordpress/scripts/test/parse-wp-codebox-artifacts-smoke.sh`
- `bash tests/runtime-helpers-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the WP Codebox artifact parser changes, smoke coverage, and targeted verification; Chris remains responsible for review and merge decisions.