### PR TITLE
fix(wordpress): suppress empty PHPStan raw output

### DIFF
--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -852,7 +852,11 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
         if [ -n "$parsed_output" ]; then
             echo ""
             echo "$parsed_output"
-        elif [ -n "$json_output" ]; then
+        elif [ -n "$json_output" ] && echo "$json_output" | php -r '
+            $json = json_decode(file_get_contents("php://stdin"), true);
+            if (!$json) exit(0);
+            exit((int) ($json["totals"]["file_errors"] ?? 0) > 0 ? 0 : 1);
+        ' 2>/dev/null; then
             # Fallback: show raw JSON when PHP parsing fails
             echo ""
             echo "ERRORS (raw):"

--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -137,6 +137,7 @@ run_phpstan
 assert_contains "--level=7" "full-component PHPStan run defaults to level 7"
 assert_not_contains "--baseline" "full-component PHPStan run avoids removed --baseline flag"
 assert_file_contains "$CONFIG_CAPTURE" "${COMPONENT_DIR}/phpstan-baseline.neon" "full-component PHPStan config includes component baseline via neon"
+assert_file_not_contains "$OUTPUT_FILE" "ERRORS (raw)" "zero-error PHPStan JSON should not be printed as raw errors"
 
 HOMEBOY_LINT_GLOB='{main.php,assets/app.js,includes/extra.php}' run_phpstan
 assert_contains "${COMPONENT_DIR}/main.php" "glob scope includes matching PHP source file"


### PR DESCRIPTION
## Summary
- Suppress the PHPStan raw JSON fallback when the JSON envelope is valid and contains zero file errors.
- Add a smoke assertion so passing PHPStan output does not get labeled as `ERRORS (raw)`.

## Verification
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- Patched runner verified against the plain `agents-api` clone with `HOMEBOY_PHP_VERSION=8.1`.

## Context
- Follow-up from https://github.com/Extra-Chill/homeboy/issues/2642 while investigating noisy PHPStan output in plain path lint runs.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigation, patch drafting, smoke-test update, and verification command execution. Chris remains responsible for review and merge.