### PR TITLE
Fix WordPress deploy verification for non-root ZIP entries

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -172,12 +172,12 @@
     "verifications": [
       {
         "path_pattern": "/wp-content/plugins/",
-        "verify_command": "test -f {{stagingArtifact}} && plugin_slug=$(basename {{targetDir}}) && zip_root=$(unzip -qql {{stagingArtifact}} | head -1 | awk '{print $4}' | cut -d/ -f1) && test -n \"$zip_root\" && candidate=\"$zip_root/$plugin_slug.php\" && if ! unzip -Z1 {{stagingArtifact}} | grep -Fxq \"$candidate\"; then candidate=$(unzip -Z1 {{stagingArtifact}} | awk -v root=\"$zip_root/\" '$0 ~ \"^\" root \".+\\\\.php$\" { print; exit }'); fi && test -n \"$candidate\" && rel=${candidate#\"$zip_root/\"} && test -f \"{{targetDir}}/$rel\" && unzip -p {{stagingArtifact}} \"$candidate\" | cmp -s - \"{{targetDir}}/$rel\" && find {{targetDir}} -maxdepth 2 -name '*.php' -exec grep -l 'Plugin Name:' {} + 2>/dev/null | head -1",
+        "verify_command": "test -f {{stagingArtifact}} && plugin_slug=$(basename {{targetDir}}) && candidate=$(unzip -Z1 {{stagingArtifact}} | awk -v slug=\"$plugin_slug\" '$0 == slug \"/\" slug \".php\" { print; exit }') && if [ -z \"$candidate\" ]; then candidate=$(unzip -Z1 {{stagingArtifact}} | awk '$0 ~ \"(^|/)[^/]+[.]php$\" { print; exit }'); fi && test -n \"$candidate\" && rel=\"$candidate\" && case \"$candidate\" in */*) rel=\"${candidate#*/}\" ;; esac && test -f \"{{targetDir}}/$rel\" && unzip -p {{stagingArtifact}} \"$candidate\" | cmp -s - \"{{targetDir}}/$rel\" && find {{targetDir}} -maxdepth 2 -name '*.php' -exec grep -l 'Plugin Name:' {} + 2>/dev/null | head -1",
         "verify_error_message": "WordPress plugin deploy verification failed for {{targetDir}}: installed files do not match {{stagingArtifact}} or no plugin header was found"
       },
       {
         "path_pattern": "/wp-content/themes/",
-        "verify_command": "test -f {{stagingArtifact}} && zip_root=$(unzip -qql {{stagingArtifact}} | head -1 | awk '{print $4}' | cut -d/ -f1) && test -n \"$zip_root\" && test -f {{targetDir}}/style.css && unzip -p {{stagingArtifact}} \"$zip_root/style.css\" | cmp -s - {{targetDir}}/style.css && grep -l 'Theme Name:' {{targetDir}}/style.css 2>/dev/null",
+        "verify_command": "test -f {{stagingArtifact}} && style_entry=$(unzip -Z1 {{stagingArtifact}} | awk '$0 == \"style.css\" { print; exit } $0 ~ \"(^|/)style[.]css$\" { print; exit }') && test -n \"$style_entry\" && rel=\"$style_entry\" && case \"$style_entry\" in */*) rel=\"${style_entry#*/}\" ;; esac && test -f \"{{targetDir}}/$rel\" && unzip -p {{stagingArtifact}} \"$style_entry\" | cmp -s - \"{{targetDir}}/$rel\" && grep -l 'Theme Name:' \"{{targetDir}}/$rel\" 2>/dev/null",
         "verify_error_message": "WordPress theme deploy verification failed for {{targetDir}}: installed style.css does not match {{stagingArtifact}} or no theme header was found"
       }
     ],


### PR DESCRIPTION
## Summary
- Make WordPress plugin and theme deploy verification find the relevant PHP/style entry instead of trusting the first ZIP entry as the archive root.
- Keeps verification aligned with deployed file paths when plugin/theme archives include leading files like README entries.

Refs Extra-Chill/homeboy#2646.

## Testing
- `jq empty wordpress/wordpress.json`
- Local plugin verifier smoke against ZIP with `README.md` as the first entry
- Local theme verifier smoke against ZIP with `README.md` as the first entry

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the deploy verification failure path, drafting the manifest command changes, and running local smoke verification. Chris remains responsible for review and merge.