### PR TITLE
docs(wordpress): clarify WP Codebox substrate transition

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,11 +44,13 @@ mark with `if: always()` after the validation job starts producing reviewer
 evidence.
 
 `datamachine-agent-ci.yml` wraps the common GitHub Actions shape for running a
-Data Machine agent bundle in WordPress Playground. Consumers provide bundle and
-flow identifiers, a prompt, and optional output projections. By default the
-workflow brings the standard WordPress agent runtime dependencies.
-See [`wordpress/docs/AGENT_CI_PLAYGROUND.md`](../../wordpress/docs/AGENT_CI_PLAYGROUND.md)
-for the full Playground sandbox model, runtime contract, and evaluation notes.
+Data Machine agent bundle in a disposable WordPress execution substrate.
+Consumers provide bundle and flow identifiers, a prompt, and optional output
+projections. New and maintained agent runs should use the WP Codebox substrate;
+the legacy direct Playground runner remains only as a transition path until
+issue #696 removes `agent_runtime`.
+See [`wordpress/docs/AGENT_CI_WP_CODEBOX.md`](../../wordpress/docs/AGENT_CI_WP_CODEBOX.md)
+for the WP Codebox contract, runtime surface, and evaluation notes.
 
 The reusable workflow exposes `engine_data_json` as one combined JSON object.
 Dynamic per-key `workflow_call` outputs are not possible in GitHub Actions, so
@@ -75,9 +77,9 @@ jobs:
     secrets: inherit
 ```
 
-## World Creator migration example
+## World Creator agent example
 
-Workflows that need additional WordPress Playground configuration can pass
+Workflows that need additional WordPress sandbox configuration can pass
 JSON-string inputs through to the runner config without changing the reusable
 workflow. This shape covers the `world-of-wordpress` migration that needs MDI
 primary mode, a `db.php` drop-in mount, pre-run bootstrap work, daily memory,
@@ -128,13 +130,13 @@ jobs:
 ## Inputs worth calling out
 
 - `include_agent_runtime_dependencies` defaults to `true` and checks out the standard WordPress agent runtime stack: `Automattic/agents-api`, `Extra-Chill/data-machine`, `Extra-Chill/data-machine-code`, and the provider plugin.
-- `agent_runtime` selects the sandbox runner. `homeboy` preserves the legacy Playground runner; `wp-codebox` checks out, builds, and runs `chubes4/wp-codebox` as the WordPress sandbox/runtime boundary.
-- `wp_codebox_ref` controls the `chubes4/wp-codebox` ref used when `agent_runtime: wp-codebox`.
+- `agent_runtime` is a transitional compatibility switch tracked by #696. Use `wp-codebox` for the WP Codebox substrate; `homeboy` keeps the legacy direct runner available until that issue deletes the switch.
+- `wp_codebox_ref` controls the `chubes4/wp-codebox` ref used by the WP Codebox substrate.
 - `agents_api_ref`, `data_machine_ref`, `data_machine_code_ref`, and `openai_provider_ref` control runtime dependency refs. `openai_provider_ref` defaults to `trunk` for the built-in OpenAI preset.
 - `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `credentials` keys. When `provider: openai`, an empty object preserves the existing OpenAI provider defaults.
 - `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.
 - `bundle_path` is resolved relative to the consumer checkout.
-- `bundle_repo`, `bundle_ref`, and `bundle_path_in_repo` let a consumer run against a bundle stored in another repository. The runner clones that repository before mounting the bundle into Playground.
+- `bundle_repo`, `bundle_ref`, and `bundle_path_in_repo` let a consumer run against a bundle stored in another repository. The runner clones that repository before mounting the bundle into the WordPress substrate.
 - `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`.
 - `allowed_repos` is a JSON array of `OWNER/REPO` entries exposed to the injected GitHub profile. It defaults to `[target_repo]`.
 - `engine_key` and `tool_results_key` control where built-in GitHub tool captures and fallback PR data are written in `metadata.engine_data`.
@@ -142,11 +144,11 @@ jobs:
 - `transcript_artifact_name` controls artifact upload. An empty value skips upload.
 - `extra_wp_config_defines` must be a JSON object and is merged into the runner config `wp_config_defines`.
 - `extra_playground_file_mounts`, `workload_run_before`, `workload_run_after`, and `extra_required_abilities` must be JSON arrays.
-- `workload_run_after` runs post-agent Playground verifier hooks in the same scenario, so consumers can assert the agent left WordPress in a valid state.
+- `workload_run_after` runs post-agent verifier hooks in the same WordPress scenario, so consumers can assert the agent left WordPress in a valid state.
 - `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.
 - `tool_recorders` configures tool-result projection, forced parameters, and engine-data capture. It must be a JSON array.
 - `pipeline_step_patches` and `flow_step_patches` modify imported bundle step config before the flow runs. They must be JSON arrays.
-- `runner_workspace` provisions a Data Machine Code worktree before the agent runs. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for opt-in runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner inspects, commits, pushes, and opens/reuses a fallback PR for captured workspace changes after completion.
+- `runner_workspace` provisions a Data Machine Code worktree before the agent runs. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner inspects, commits, pushes, and opens/reuses a fallback PR for captured workspace changes after completion.
 - `runner_workspace.capture_changes` defaults to `true` only when `expose_to_agent: false`; set it explicitly to disable hidden-mode publication or to enable runner-owned capture while still exposing the workspace handle.
 - `fallback_pull_request` opens or reuses a PR when files were written but the agent did not call the PR tool. It must be a JSON object.
 
@@ -154,7 +156,7 @@ jobs:
 
 Consumers such as `docs-agent` can keep the agent bundle in one repository while
 running it against another repository. The reusable workflow handles the bundle
-checkout and passes tool recorder config to the Playground runner.
+checkout and passes tool recorder config to the WordPress runner.
 
 ```yaml
 jobs:

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -69,11 +69,11 @@ name: Data Machine Agent CI (reusable)
         type: boolean
         default: true
       agent_runtime:
-        description: Agent sandbox runtime. Use `homeboy` for the legacy Playground runner or `wp-codebox` for the WP Codebox runtime adapter.
+        description: Transitional agent sandbox selector. Use `wp-codebox` for the WP Codebox substrate; `homeboy` remains only for legacy runner compatibility until issue #696 removes the switch.
         type: string
         default: homeboy
       wp_codebox_ref:
-        description: Ref for chubes4/wp-codebox when agent_runtime is wp-codebox.
+        description: Ref for chubes4/wp-codebox when the agent runtime uses the WP Codebox substrate.
         type: string
         default: main
       agents_api_ref:
@@ -183,14 +183,14 @@ name: Data Machine Agent CI (reusable)
         description: |
           JSON array appended to the runner config playground_file_mounts after
           the default ci-driver fixture mount. Use for plugin drop-ins,
-          must-use plugin mounts, or any consumer-specific Playground file
+          must-use plugin mounts, or any consumer-specific WordPress sandbox file
           placement. Default '[]' means no extra mounts.
         type: string
         default: "[]"
       workload_run_before:
         description: |
           JSON array of pre-run hooks executed before the main bench workload
-          inside Playground. Each entry is { type, file } the same way
+          inside the WordPress sandbox. Each entry is { type, file } the same way
           playground_workloads[*].run entries are. Default '[]' means no
           pre-run hook.
         type: string
@@ -198,7 +198,7 @@ name: Data Machine Agent CI (reusable)
       workload_run_after:
         description: |
           JSON array of post-run hooks executed after the agent workload inside
-          the same Playground scenario. Use this for verifier probes that assert
+          the same WordPress scenario. Use this for verifier probes that assert
           the agent left WordPress in a valid state. Default '[]' means no
           post-run hook.
         type: string

--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -338,8 +338,9 @@ Set `HOMEBOY_PLAYGROUND_RESULTS_ARTIFACT_DIR` to write these derived artifacts
 to a specific directory. Otherwise they are written beside
 `HOMEBOY_BENCH_RESULTS_FILE`.
 
-The same workload contract powers Data Machine agent CI in Playground. See
-[`../../wordpress/docs/AGENT_CI_PLAYGROUND.md`](../../wordpress/docs/AGENT_CI_PLAYGROUND.md)
+The same workload contract powers Data Machine agent CI on the WP Codebox
+WordPress substrate. See
+[`../../wordpress/docs/AGENT_CI_WP_CODEBOX.md`](../../wordpress/docs/AGENT_CI_WP_CODEBOX.md)
 for the dedicated agent sandbox guide.
 
 ## Playground Scenario Manifests

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -142,7 +142,7 @@ Playground's built-in SQLite mu-plugin detects it and steps aside. See
 coexistence mechanism.
 
 For everything else about testing — debug markers, level overrides,
-phpunit.xml consumption, known gaps — see
+phpunit.xml consumption, current WP Codebox parity status, known gaps — see
 [`docs/TESTING.md`](docs/TESTING.md).
 
 ## Lint runner
@@ -332,6 +332,7 @@ Configure per-component in the component's homeboy/component config under
 
 | Setting | Type | Default | Purpose |
 |---|---|---|---|
+| `test_runtime` | string | `""` | Transitional runtime selector tracked by #697; `wp-codebox` exercises the WP Codebox parity path while the default test runner remains Playground-backed |
 | `test_backend` | string | `playground` | `playground` (default) or `host-smoke` / `host` for standalone smoke scripts |
 | `validation_dependencies` | string | `""` | Comma / newline / JSON list of local components to mount during PHPStan, autoload validation, and PHPUnit |
 | `user` | string | `""` | WP-CLI user (email/login/ID); appended as `--user` when set |
@@ -457,6 +458,6 @@ at the root to grandfather pre-existing findings (see PHPStan above).
 ## Further reading
 
 - [`docs/TESTING.md`](docs/TESTING.md) — canonical test/lint/bench reference, debug markers, sanctioned suppressions, browser-target schema, known gaps
-- [`docs/AGENT_CI_PLAYGROUND.md`](docs/AGENT_CI_PLAYGROUND.md) — running Data Machine agents in WordPress Playground CI and why Playground is the agent sandbox
+- [`docs/AGENT_CI_WP_CODEBOX.md`](docs/AGENT_CI_WP_CODEBOX.md) — running Data Machine agents on the WP Codebox WordPress execution substrate
 - [`docs/PLAYGROUND_DROPIN.md`](docs/PLAYGROUND_DROPIN.md) — `db.php` coexistence with Playground SQLite
 - [`docs/CHANGELOG.md`](docs/CHANGELOG.md) — release history

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -1,15 +1,15 @@
-# Data Machine Agent CI in WordPress Playground
+# Data Machine Agent CI on WP Codebox
 
-Homeboy can run a Data Machine agent bundle inside WordPress Playground from
-GitHub Actions. The reusable workflow gives agent repos one CI entry point for
-booting WordPress, loading dependencies, running the agent, collecting
-transcripts, and asserting the expected outcome.
+Homeboy can run a Data Machine agent bundle inside the WP Codebox WordPress
+execution substrate from GitHub Actions. The reusable workflow gives agent repos
+one CI entry point for booting WordPress, loading dependencies, running the
+agent, collecting transcripts, and asserting the expected outcome.
 
-## Why Playground is the sandbox
+## Why WP Codebox is the substrate
 
-WordPress Playground gives agent CI a disposable WordPress runtime instead of a
-long-lived server, local database, or per-repo test harness. Each run starts from
-a declared environment and exits with structured Homeboy artifacts.
+WP Codebox gives agent CI a disposable WordPress runtime instead of a long-lived
+server, local database, or per-repo test harness. Each run starts from a declared
+environment and exits with structured Homeboy artifacts.
 
 ```text
 GitHub Actions workflow
@@ -18,8 +18,11 @@ GitHub Actions workflow
 Homeboy WordPress extension
         |
         v
-WordPress Playground
-  PHP-WASM + embedded SQLite + mounted plugins
+WP Codebox WordPress runtime
+  disposable site + mounted plugins
+        |
+        v
+WP Codebox command boundary
         |
         v
 Data Machine agent runtime
@@ -30,7 +33,8 @@ That shape is useful for agents because the model still interacts with real
 WordPress APIs while the host stays small and repeatable:
 
 - No host MySQL, local WordPress install, or component-owned PHPUnit bootstrap.
-- Runtime dependencies are mounted into the same Playground site as the bundle.
+- Runtime dependencies are mounted into the same WP Codebox WordPress workspace
+  as the bundle.
 - The reusable workflow can bring the standard WordPress agent runtime stack by
   default, so consumers do not repeat Agents API, Data Machine, Data Machine
   Code, or provider plugin refs in every workflow.
@@ -67,6 +71,11 @@ toolchain, mounts the standard agent runtime and any additional validation
 dependencies under `.ci/<repo>`, builds a runner config, and calls
 `wordpress/scripts/agent/run-datamachine-agent.sh`.
 
+The reusable workflow still exposes `agent_runtime` while #696 removes the
+legacy direct runner path. Use `agent_runtime: wp-codebox` for current agent CI
+work. Treat `agent_runtime: homeboy` as compatibility for older callers, not as a
+new integration target.
+
 ## Fully Custom Agents
 
 The reusable workflow does not hard-code a specific agent. A consumer supplies a
@@ -92,19 +101,21 @@ Consumers can customize:
 - Success criteria through `success_requires_pr`, completion outcomes,
   engine-data projections, artifacts, and verifier jobs.
 
-## Runtime contract
+## WP Codebox contract
 
-The runner converts the agent config into a single Playground bench workload:
+The runner converts the agent config into a single WordPress workload envelope:
 
 - `component_path` points at the consumer checkout.
 - `bundle_path` points at the Data Machine agent bundle.
 - `include_agent_runtime_dependencies` mounts the standard Data Machine agent
   runtime before consumer-supplied `validation_dependencies`.
-- `playground_file_mounts` adds fixture files such as the CI driver plugin.
-- `bench_env` forwards credentials and the serialized runner config into
-  PHP-WASM.
+- `playground_file_mounts` adds fixture files such as the CI driver plugin. The
+  setting name is inherited from the previous direct-runner contract and is kept
+  as part of the current workflow input surface.
+- `bench_env` forwards credentials and the serialized runner config into the
+  WordPress runtime.
 - `workload_run_before` and `workload_run_after` attach setup and verifier hooks
-  around the agent run inside the same Playground scenario.
+  around the agent run inside the same WordPress scenario.
 - `transcript_dir` controls where exported conversation artifacts are written.
 - `success_requires_pr` can require the agent to open or reuse a pull request.
 - `tool_recorders` can force tool parameters and project tool results into
@@ -114,7 +125,7 @@ The runner converts the agent config into a single Playground bench workload:
 - `runner_workspace` can provision a Data Machine Code worktree. The default
   mode prepends the workspace handle to the agent prompt so current consumers
   can explicitly ask the agent to work in that checkout and open a PR.
-- `runner_workspace.expose_to_agent: false` is an opt-in runner-owned capture
+- `runner_workspace.expose_to_agent: false` enables runner-owned capture
   mode. It preserves the natural task prompt, keeps workspace tool calls scoped
   to the provisioned handle when those tools are used, then captures final git
   status/diff, commits, pushes, and opens or reuses a fallback PR after the run.
@@ -129,9 +140,12 @@ The runner converts the agent config into a single Playground bench workload:
 - `fallback_pull_request` can open a PR when files were written but the agent did
   not explicitly call the PR tool.
 
-Inside Playground, `datamachine-agent-workload.php` installs the bundle, configures
-the provider, starts the Data Machine flow, drains queued work, records tool
-results, exports the transcript, and writes a Homeboy scenario result.
+Inside WordPress, `datamachine-agent-workload.php` installs the bundle,
+configures the provider, starts the Data Machine flow, drains queued work,
+records tool results, exports the transcript, and writes a Homeboy scenario
+result. In WP Codebox mode, the workflow checks out and builds `chubes4/wp-codebox`,
+passes the runner config to the WP Codebox CLI, mounts provider/runtime plugins,
+and reads back the generated artifacts from the run workspace.
 
 ## Runner config surface
 
@@ -149,10 +163,10 @@ knobs to `run-datamachine-agent.sh`:
 - Extension points: `extra_required_abilities`, `ability_tools`, `tool_recorders`, `pipeline_step_patches`, `flow_step_patches`, `runner_workspace`, `fallback_pull_request`.
 
 `bundle_repo` is for cross-repo consumers. The shell runner clones the bundle
-repository, points `bundle_path` at the cloned bundle inside Playground, and adds
-that checkout to the mounted validation dependencies. This lets a repository such
-as `agents-api` run a bundle owned by `docs-agent` without copying the bundle or
-maintaining a bespoke runner script.
+repository, points `bundle_path` at the cloned bundle inside the WordPress
+substrate, and adds that checkout to the mounted validation dependencies. This
+lets a repository such as `agents-api` run a bundle owned by `docs-agent` without
+copying the bundle or maintaining a bespoke runner script.
 
 `tool_recorders` are the main migration path for custom bootstrap files that only
 wrap GitHub tools. A recorder can attach forced parameters, capture selected input
@@ -219,25 +233,24 @@ consumer-specific assertions such as a generated PR URL, published artifact path
 or scenario result field.
 
 Set `replay_bundle_artifact_name` to publish a redacted replay bundle alongside
-the run. The bundle snapshots the scenario envelope, initial Playground
-blueprint, prompt, runner config, provider/model/seed metadata, transcript/action
-log references, and grader metadata. The runner also attaches
+the run. The bundle snapshots the scenario envelope, initial WordPress state,
+prompt, runner config, provider/model/seed metadata, transcript/action log
+references, and grader metadata. The runner also attaches
 `artifacts.replay_bundle.path` and `metadata.playground_review` to the scenario
 result JSON so downstream JSONL publishers can link failure rows back to the
-bundle.
+bundle. The metadata key keeps the historical name until the artifact schema is
+renamed.
 
-Final-state Playground review URLs are only emitted when the caller supplies a
-hosted review URL in runner config or scenario metadata. The current Playground
-PHP bench runner exits after scenario execution and does not export a restorable
-site state, so the default bundle records `playground_review.available=false`
-and `final_state.available=false` rather than pretending an encoded initial
-blueprint is a final-state replay.
+Final-state review URLs are only emitted when the caller supplies a hosted review
+URL in runner config or scenario metadata. The default bundle records
+`playground_review.available=false` and `final_state.available=false` rather than
+pretending an encoded initial blueprint is a final-state replay.
 
 ## Why this can support agent evaluation
 
 The same contract is close to an agent evaluation environment:
 
-- Initial state: Playground blueprint, mounted dependencies, bundle files, and
+- Initial state: WordPress blueprint, mounted dependencies, bundle files, and
   configured WordPress constants.
 - Actions: registered abilities, WP-CLI commands, GitHub tools, and Data Machine
   pipeline steps.
@@ -252,7 +265,7 @@ proxy goals. For example, reward a verified diff plus passing checks rather than
 only rewarding that a pull request URL exists. Mock or scope external services
 when reproducibility matters.
 
-Playground grader workloads should return the shared reward payload used by the
+WordPress grader workloads should return the shared reward payload used by the
 bench runner:
 
 ```json
@@ -280,8 +293,8 @@ metrics such as `reward_mean`, while the structured details remain in
 
 - `.github/workflows/datamachine-agent-ci.yml` is the reusable workflow.
 - `.github/workflows/README.md` documents workflow inputs and examples.
-- `wordpress/scripts/agent/run-datamachine-agent.sh` builds the Playground
-  workload config.
+- `wordpress/scripts/agent/run-datamachine-agent.sh` builds the WordPress
+  workload config and dispatches the selected runtime.
 - `wordpress/scripts/agent/datamachine-agent-workload.php` runs the agent inside
   WordPress.
 - `wordpress/tests/fixtures/datamachine-agent-ci-driver/` provides the stable

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -68,8 +68,18 @@ dot-path assertions against the manifest or example runner config. `bundle_dir`
 and `example_runner_config` are resolved relative to the spec file's parent
 directory so specs can live at repo root or under `tests/`.
 
-For full CI agent runs inside WordPress Playground, see
-[`AGENT_CI_PLAYGROUND.md`](AGENT_CI_PLAYGROUND.md).
+For full CI agent runs on the WP Codebox WordPress execution substrate, see
+[`AGENT_CI_WP_CODEBOX.md`](AGENT_CI_WP_CODEBOX.md).
+
+## WP Codebox test runtime status
+
+Issue #697 tracks the cutover from the direct Playground PHPUnit runner to WP
+Codebox-backed WordPress tests. Until that migration lands,
+`test_runtime: wp-codebox` is a parity path for the same component mounts,
+dependency mounts, drop-ins, file routing, WordPress version selection, and
+artifact parsing contract. The default WordPress test backend remains the direct
+Playground runner, while `host-smoke` remains available for standalone PHP smoke
+scripts that do not bootstrap WordPress.
 
 ## Dependencies
 

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -7,8 +7,9 @@ set -euo pipefail
 # mounts the component under test, runs PHPUnit inside it, and emits
 # the same JSON result shape as test-runner.sh.
 #
-# This is the "playground" backend — opt-in, not the default.
-# The host backend (test-runner.sh) remains the default.
+# This is the default WordPress PHPUnit backend until issue #697 completes the
+# WP Codebox test-runtime cutover. The host backend is reserved for standalone
+# smoke scripts that do not bootstrap WordPress.
 #
 # HOW IT WORKS:
 #

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Opt-in WP Codebox-backed WordPress PHPUnit runner.
+# WP Codebox-backed WordPress PHPUnit runner.
 #
-# This keeps the legacy Playground runner as the default, but translates the
-# same component/dependency/drop-in/file-mount/config/env/version contract into
-# wp-codebox run arguments when HOMEBOY_WORDPRESS_TEST_RUNTIME=wp-codebox or
-# test_runtime=wp-codebox is selected.
+# Issue #697 tracks making this the default WordPress test substrate. Until that
+# lands, this runner translates the same component/dependency/drop-in/file-mount/
+# config/env/version contract into wp-codebox run arguments when
+# HOMEBOY_WORDPRESS_TEST_RUNTIME=wp-codebox or test_runtime=wp-codebox is
+# selected.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -3,9 +3,10 @@ set -euo pipefail
 
 # Test runner router for WordPress Homeboy extension.
 #
-# Plugin/theme tests run inside WordPress Playground by default. Core-dev
-# checkouts (wordpress-develop) dispatch to WordPress core's native PHPUnit
-# runner. Pure host-PHP smoke suites can opt into the host-smoke backend.
+# Plugin/theme tests run inside WordPress Playground by default while #697 moves
+# the WordPress test substrate to WP Codebox. Core-dev checkouts
+# (wordpress-develop) dispatch to WordPress core's native PHPUnit runner. Pure
+# host-PHP smoke suites use the host-smoke backend.
 
 # Bash 4.0+ required — lint-runner.sh (called during test runs) uses
 # associative arrays which are bash 4+ only. Fail early with a clear

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -822,7 +822,7 @@
   },
   "testing": {
     "backend": "playground",
-    "description": "Plugin/theme PHPUnit runs inside WordPress Playground by default. Pure PHP smoke suites can opt into the host-smoke backend. The WP Codebox runtime is opt-in through test_runtime."
+    "description": "Plugin/theme PHPUnit currently runs inside WordPress Playground by default while issue #697 moves WordPress tests onto the WP Codebox substrate. Pure PHP smoke suites can use the host-smoke backend."
   },
   "settings": [
     {
@@ -830,14 +830,14 @@
       "label": "Test runtime",
       "type": "string",
       "default": "",
-      "description": "Optional WordPress test runtime selector. Leave empty for the current runner. Use 'wp-codebox' to run the same PHPUnit mount/config translation through WP Codebox without changing the default backend."
+      "description": "Transitional WordPress test runtime selector tracked by issue #697. Leave empty for the current default runner, or set 'wp-codebox' to exercise the WP Codebox parity path for the same PHPUnit mount/config translation."
     },
     {
       "id": "test_backend",
       "label": "Test backend",
       "type": "string",
       "default": "playground",
-      "description": "WordPress test backend. Use 'playground' for PHPUnit inside WordPress Playground, 'wp-codebox' for the opt-in WP Codebox runtime, or 'host-smoke' / 'host' for standalone tests/**/*-smoke.php scripts run under host PHP without WordPress bootstrap."
+      "description": "WordPress test backend. Use 'playground' for the current default PHPUnit backend, 'wp-codebox' for the transitional WP Codebox runtime path, or 'host-smoke' / 'host' for standalone tests/**/*-smoke.php scripts run under host PHP without WordPress bootstrap."
     },
     {
       "id": "validation_dependencies",


### PR DESCRIPTION
## Summary
- Reframes Data Machine agent CI docs around the WP Codebox WordPress substrate and renames the agent guide away from Playground-specific wording.
- Updates workflow comments, README references, and WordPress settings descriptions so remaining `agent_runtime` / `test_runtime` switches are documented as transitional work tracked by #696 and #697.
- Leaves test and bench docs truthful to the current code state: direct Playground remains the default test/bench path until #697/#698 land.

## Links
- Closes #699
- Part of #695
- Coordinates with #696, #697, and #698

## Checks
- `git diff --check`
- `jq empty wordpress/wordpress.json`
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/test-runner-playground.sh wordpress/scripts/test/test-runner-wp-codebox.sh`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-699-wp-codebox-docs --extension wordpress` fails on existing unrelated PHPCS/PHPStan findings in untouched files such as `wordpress/scripts/validation/validate-autoload.php` and audit fixture PHP files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the documentation/settings cleanup and ran local validation; Chris remains responsible for review and merge.