### PR TITLE
Default WordPress tests to WP Codebox

### DIFF
--- a/.github/workflows/wp-codebox-test-runtime-canary.yml
+++ b/.github/workflows/wp-codebox-test-runtime-canary.yml
@@ -50,6 +50,5 @@ jobs:
 
       - name: Run WP Codebox-backed test runner canary
         env:
-          HOMEBOY_WORDPRESS_TEST_RUNTIME: wp-codebox
           HOMEBOY_WP_CODEBOX_BIN: ${{ github.workspace }}/.ci/wp-codebox/packages/cli/dist/index.js
         run: bash wordpress/scripts/test/playground-db-activation-smoke.sh

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -62,11 +62,11 @@ verbs also accept a project id to fan out across all of its components.
 
 ## Test runner
 
-The default backend boots WordPress inside Playground, mounts the
-component under `/wordpress/wp-content/plugins/<slug>` (or themes path for
-themes), and runs PHPUnit in-process. No `bootstrap.php` or `phpunit.xml`
-in the component is required — and **shipping one is rejected** with a
-clear error. The extension owns bootstrap.
+The default backend boots WordPress through WP Codebox, mounts the component
+under `/wordpress/wp-content/plugins/<slug>` (or themes path for themes), and
+runs PHPUnit in-process. No `bootstrap.php` or `phpunit.xml` in the component is
+required — and **shipping one is rejected** with a clear error. The extension
+owns bootstrap.
 
 A component needs:
 
@@ -75,7 +75,7 @@ A component needs:
 - A plugin header (`Plugin Name:`) or theme `style.css` with `Theme Name:`
   — the runner detects which is which.
 
-The Playground runner emits a structured log at
+The test runner emits a structured log at
 `<component>/.pg-test-result.txt` with `STAGE_BEGIN` / `STAGE_OK` /
 `STAGE_FAIL` / `STAGE_FATAL` / `NOTICE` markers across stages
 `boot → install → load_fixtures → load_deps → load_component → discover_tests
@@ -105,7 +105,7 @@ Available factories from the WordPress test framework: `user`, `post`,
 
 ### Host-smoke backend
 
-Pure PHP smoke suites that don't need WordPress can opt out of Playground:
+Pure PHP smoke suites that don't need WordPress can opt out of WP Codebox:
 
 ```bash
 homeboy component set <component-id> test_backend host-smoke
@@ -332,12 +332,11 @@ Configure per-component in the component's homeboy/component config under
 
 | Setting | Type | Default | Purpose |
 |---|---|---|---|
-| `test_runtime` | string | `""` | Transitional runtime selector tracked by #697; `wp-codebox` exercises the WP Codebox parity path while the default test runner remains Playground-backed |
-| `test_backend` | string | `playground` | `playground` (default) or `host-smoke` / `host` for standalone smoke scripts |
+| `test_backend` | string | `wp-codebox` | `wp-codebox` (default) or `host-smoke` / `host` for standalone non-WordPress smoke scripts |
 | `validation_dependencies` | string | `""` | Comma / newline / JSON list of local components to mount during PHPStan, autoload validation, and PHPUnit |
 | `user` | string | `""` | WP-CLI user (email/login/ID); appended as `--user` when set |
-| `wp_config_defines` | object | `{}` | `CONSTANT_NAME => value` map appended to Playground `wp-tests-config.php`; PHP type preserved via `var_export` |
-| `bench_env` | object | `{}` | `NAME => value` env vars forwarded into Playground PHP-WASM (workloads/fixtures read via `getenv()`) |
+| `wp_config_defines` | object | `{}` | `CONSTANT_NAME => value` map appended to the runtime `wp-tests-config.php`; PHP type preserved via `var_export` |
+| `bench_env` | object | `{}` | `NAME => value` env vars forwarded into the runtime (workloads/fixtures read via `getenv()`) |
 | `playground_blueprint` | object | `{}` | Blueprint JSON passed to `wp-playground-cli --blueprint` for cold-boot scenarios |
 | `playground_workloads` | array | `[]` | Declared bench workloads run after bootstrap, blueprint, deps, and component load |
 | `playground_file_mounts` | array | `[]` | Files from the component or validation dependencies mounted into explicit Playground paths |

--- a/wordpress/docs/PLAYGROUND_DROPIN.md
+++ b/wordpress/docs/PLAYGROUND_DROPIN.md
@@ -152,8 +152,8 @@ during build).
   means it must delegate to Playground's bundled SQLite for the initial
   schema.
 
-- **WP version pinning.** The Playground runner defaults to `--wp=6.9`, and the
-  `playground_wordpress_version` setting can pass a different `--wp=<version>`.
+- **WP version pinning.** The WordPress test runner defaults to `--wp=6.9`, and
+  the `playground_wordpress_version` setting can pass a different `--wp=<version>`.
   The selected WordPress version must
   match the `wp-phpunit` package version. Don't forget to update both when
   bumping WordPress. A mismatch often manifests as missing `WP_UnitTestCase`
@@ -163,8 +163,8 @@ during build).
 - **MDI-specific note.** Markdown Database Integration's production drop-in
   assumes its own plugin directory is at
   `wp-content/plugins/markdown-database-integration/` (to load its classes).
-  When testing MDI through the Playground backend, the MDI plugin itself is
-  mounted to that location by `test-runner-playground.sh`. You don't have
+  When testing MDI through the WordPress test backend, the MDI plugin itself is
+  mounted to that location by the runner. You don't have
   to configure anything special for this common case.
 
 ## Related

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -1,11 +1,12 @@
 # Testing
 
-The WordPress extension runs PHPUnit inside [WordPress Playground][playground]
-(PHP-WASM + embedded SQLite) by default. There is no host PHP, MySQL, or
-WordPress installation to configure. Components only need a `tests/` directory
-with PHPUnit test files.
+The WordPress extension runs PHPUnit through [WP Codebox][wp-codebox] by
+default. WP Codebox owns the disposable WordPress runtime, mounts, command
+execution, logs, and test artifacts. There is no host PHP, MySQL, or WordPress
+installation to configure. Components only need a `tests/` directory with
+PHPUnit test files.
 
-[playground]: https://www.npmjs.com/package/@wp-playground/cli
+[wp-codebox]: https://github.com/chubes4/wp-codebox
 
 ## Running tests
 
@@ -20,9 +21,8 @@ homeboy test <project-id>
 HOMEBOY_DEBUG=1 homeboy test <component-id>
 ```
 
-Tests run through `scripts/test/test-runner.sh`, which dispatches to the
-configured backend. The default Playground runner (`test-runner-playground.sh`
-and `playground-runner.php`) mounts the component under
+Tests run through `scripts/test/test-runner.sh`, which dispatches to the WP
+Codebox runner for WordPress PHPUnit. The runner mounts the component under
 `/wordpress/wp-content/plugins/<slug>`, boots WordPress in-process, discovers
 test files, and runs PHPUnit.
 
@@ -41,8 +41,8 @@ rejected with a clear error.
 
 ## Host smoke backend
 
-Pure PHP smoke suites can opt out of Playground and run directly under host
-PHP:
+Pure PHP smoke suites can run directly under host PHP when they are genuinely
+standalone and do not require a WordPress bootstrap:
 
 ```bash
 homeboy component set <component-id> test_backend host-smoke
@@ -50,8 +50,9 @@ homeboy component set <component-id> test_backend host-smoke
 
 The host-smoke backend discovers `tests/**/*-smoke.php`, runs each script in a
 separate `php` process, emits `HOST_SMOKE_*` markers, and fails fast with the
-failing script name. It does not bootstrap WordPress, connect to MySQL, or start
-Playground.
+failing script name. It remains separate because these scripts are non-WordPress
+PHP checks by contract: they do not bootstrap WordPress, connect to MySQL, or
+start a sandbox runtime.
 
 ## Data Machine agent bundle validator
 
@@ -73,13 +74,11 @@ For full CI agent runs on the WP Codebox WordPress execution substrate, see
 
 ## WP Codebox test runtime status
 
-Issue #697 tracks the cutover from the direct Playground PHPUnit runner to WP
-Codebox-backed WordPress tests. Until that migration lands,
-`test_runtime: wp-codebox` is a parity path for the same component mounts,
-dependency mounts, drop-ins, file routing, WordPress version selection, and
-artifact parsing contract. The default WordPress test backend remains the direct
-Playground runner, while `host-smoke` remains available for standalone PHP smoke
-scripts that do not bootstrap WordPress.
+WordPress PHPUnit runs through WP Codebox by default. The WP Codebox path owns
+the same component mounts, dependency mounts, drop-ins, file routing, WordPress
+version selection, and artifact parsing contract that the direct Playground
+runner previously handled. `host-smoke` remains available for standalone PHP
+smoke scripts that do not bootstrap WordPress.
 
 ## Dependencies
 

--- a/wordpress/scripts/test/playground-changed-scope-smoke.sh
+++ b/wordpress/scripts/test/playground-changed-scope-smoke.sh
@@ -18,12 +18,12 @@ assert_contains() {
     fi
 }
 
-assert_contains "$TEMPLATE" "{{CHANGED_TEST_FILES_JSON}}"
+assert_contains "$TEMPLATE" "{{CHANGED_TEST_FILES_JSON_B64}}"
 assert_contains "$TEMPLATE" "pg_filter_changed_test_files"
 assert_contains "$BOOTSTRAP" "function pg_filter_changed_test_files"
 assert_contains "$BOOTSTRAP" "SCOPED_TEST_FILES requested="
 assert_contains "$RUNNER" "CHANGED_TEST_FILES_JSON"
-assert_contains "$RUNNER" "{{CHANGED_TEST_FILES_JSON}}"
+assert_contains "$RUNNER" "{{CHANGED_TEST_FILES_JSON_B64}}"
 
 EXTENSION_PATH="${TMPDIR}/extension"
 PLUGIN_PATH="${TMPDIR}/component"
@@ -60,11 +60,11 @@ if [ -z "$wrapper" ] || [ ! -f "$wrapper" ]; then
     exit 1
 fi
 
-if ! grep -Fq '["tests/OnlyTest.php"]' "$wrapper"; then
-    echo "changed-test JSON was not substituted into wrapper" >&2
+if ! grep -Fq 'WyJ0ZXN0cy9Pbmx5VGVzdC5waHAiXQ==' "$wrapper"; then
+    echo "changed-test JSON was not base64-substituted into wrapper" >&2
     exit 1
 fi
-if grep -Fq '{{CHANGED_TEST_FILES_JSON}}' "$wrapper"; then
+if grep -Fq '{{CHANGED_TEST_FILES_JSON_B64}}' "$wrapper"; then
     echo "changed-test placeholder leaked into wrapper" >&2
     exit 1
 fi

--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -41,7 +41,7 @@ PHP
 
 cat > "${component}/tests/Unit/ImportAgentAbilityTest.php" <<'PHP'
 <?php
-// PHPUnit-shaped file; the playground backend owns execution.
+// PHPUnit-shaped file; the WP Codebox backend owns execution.
 PHP
 
 cat > "${component}/tests/helper.php" <<'PHP'
@@ -63,7 +63,28 @@ cat > "${TMPDIR}/stubs/wp-codebox.sh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 echo "WP_CODEBOX_STUB"
-printf '%s\n' "$@" > "${WP_CODEBOX_ARGS_FILE}"
+echo "SELECTED=${HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE:-}"
+printf 'CHANGED=%s\n' "${HOMEBOY_CHANGED_TEST_FILES:-}"
+printf 'ARGS=%s\n' "$*"
+if [ -n "${WP_CODEBOX_ARGS_FILE:-}" ]; then
+    printf '%s\n' "$@" > "${WP_CODEBOX_ARGS_FILE}"
+fi
+component_path=""
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--mount" ]; then
+        shift
+        case "${1:-}" in
+            *:/wordpress/wp-content/plugins/component)
+                component_path="${1%:/wordpress/wp-content/plugins/component}"
+                ;;
+        esac
+    fi
+    shift || true
+done
+if [ -n "$component_path" ]; then
+    printf 'ALL TESTS PASSED\nTESTS: 1 FAILURES: 0 ERRORS: 0\n' > "${component_path}/.pg-test-result.txt"
+fi
+printf '{"execution":{"stdout":"OK (1 test, 1 assertion)\n","stderr":""}}\n'
 SH
 chmod +x "${TMPDIR}/stubs/wp-codebox.sh"
 
@@ -94,10 +115,10 @@ HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
-HOMEBOY_RUNTIME_TEST_RUNNER_PLAYGROUND="${TMPDIR}/stubs/playground.sh" \
+HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${TMPDIR}/stubs/wp-codebox.sh" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/Unit/ImportAgentAbilityTest.php --filter ImportAgent > "${TMPDIR}/phpunit-file.out"
 
-assert_contains "${TMPDIR}/phpunit-file.out" "PLAYGROUND_STUB"
+assert_contains "${TMPDIR}/phpunit-file.out" "WP_CODEBOX_STUB"
 assert_contains "${TMPDIR}/phpunit-file.out" "SELECTED=tests/Unit/ImportAgentAbilityTest.php"
 assert_contains "${TMPDIR}/phpunit-file.out" "ARGS=--filter ImportAgent"
 
@@ -105,11 +126,11 @@ HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
-HOMEBOY_RUNTIME_TEST_RUNNER_PLAYGROUND="${TMPDIR}/stubs/playground.sh" \
+HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${TMPDIR}/stubs/wp-codebox.sh" \
 HOMEBOY_CHANGED_TEST_FILES=$'tests/import-agent-ability-smoke.php\ntests/Unit/ImportAgentAbilityTest.php' \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/changed-mixed-files.out"
 
-assert_contains "${TMPDIR}/changed-mixed-files.out" "PLAYGROUND_STUB"
+assert_contains "${TMPDIR}/changed-mixed-files.out" "WP_CODEBOX_STUB"
 assert_contains "${TMPDIR}/changed-mixed-files.out" "CHANGED=tests/import-agent-ability-smoke.php"
 assert_not_contains "${TMPDIR}/changed-mixed-files.out" "HOST_SMOKE_BEGIN:tests/import-agent-ability-smoke.php"
 
@@ -118,7 +139,6 @@ HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
-HOMEBOY_WORDPRESS_TEST_RUNTIME="wp-codebox" \
 HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/stubs/wp-codebox.sh" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/Unit/ImportAgentAbilityTest.php --filter ImportAgent > "${TMPDIR}/wp-codebox-file.out"
 
@@ -136,7 +156,7 @@ HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
-HOMEBOY_SETTINGS_JSON='{"test_runtime":"wp-codebox","wp_codebox_bin":"'"${TMPDIR}/stubs/wp-codebox.sh"'","playground_wordpress_version":"latest"}' \
+HOMEBOY_SETTINGS_JSON='{"wp_codebox_bin":"'"${TMPDIR}/stubs/wp-codebox.sh"'","playground_wordpress_version":"latest"}' \
 WP_CODEBOX_ARGS_FILE="${TMPDIR}/wp-codebox-settings-args.txt" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/Unit/ImportAgentAbilityTest.php > "${TMPDIR}/wp-codebox-settings.out"
 

--- a/wordpress/scripts/test/test-runner-playground.sh
+++ b/wordpress/scripts/test/test-runner-playground.sh
@@ -7,9 +7,8 @@ set -euo pipefail
 # mounts the component under test, runs PHPUnit inside it, and emits
 # the same JSON result shape as test-runner.sh.
 #
-# This is the default WordPress PHPUnit backend until issue #697 completes the
-# WP Codebox test-runtime cutover. The host backend is reserved for standalone
-# smoke scripts that do not bootstrap WordPress.
+# This is the legacy direct Playground runner retained for parity checks while
+# WordPress test execution moves to WP Codebox.
 #
 # HOW IT WORKS:
 #
@@ -191,7 +190,6 @@ if [ ! -f "$PLAYGROUND_CLI" ]; then
     echo "Error: @wp-playground/cli not found at $PLAYGROUND_CLI"
     echo ""
     echo "Install it with: cd ${EXTENSION_PATH} && npm install"
-    echo "Or switch backends: homeboy component set <id> test_backend host"
     FAILED_STEP="Playground CLI setup"
     exit 1
 fi

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -3,11 +3,8 @@ set -euo pipefail
 
 # WP Codebox-backed WordPress PHPUnit runner.
 #
-# Issue #697 tracks making this the default WordPress test substrate. Until that
-# lands, this runner translates the same component/dependency/drop-in/file-mount/
-# config/env/version contract into wp-codebox run arguments when
-# HOMEBOY_WORDPRESS_TEST_RUNTIME=wp-codebox or test_runtime=wp-codebox is
-# selected.
+# This translates the component/dependency/drop-in/file-mount/config/env/version
+# contract into wp-codebox run arguments for the default WordPress PHPUnit path.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -3,10 +3,9 @@ set -euo pipefail
 
 # Test runner router for WordPress Homeboy extension.
 #
-# Plugin/theme tests run inside WordPress Playground by default while #697 moves
-# the WordPress test substrate to WP Codebox. Core-dev checkouts
-# (wordpress-develop) dispatch to WordPress core's native PHPUnit runner. Pure
-# host-PHP smoke suites use the host-smoke backend.
+# Plugin/theme PHPUnit tests run through WP Codebox by default. Core-dev
+# checkouts (wordpress-develop) dispatch to WordPress core's native PHPUnit
+# runner. Pure host-PHP smoke suites can explicitly use the host-smoke backend.
 
 # Bash 4.0+ required — lint-runner.sh (called during test runs) uses
 # associative arrays which are bash 4+ only. Fail early with a clear
@@ -29,10 +28,9 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOST_SMOKE_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_HOST_SMOKE:-${SCRIPT_DIR}/test-runner-host-smoke.sh}"
-PLAYGROUND_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_PLAYGROUND:-${SCRIPT_DIR}/test-runner-playground.sh}"
 WP_CODEBOX_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX:-${SCRIPT_DIR}/test-runner-wp-codebox.sh}"
 
-# Resolve execution context and export env vars that the Playground runner expects.
+# Resolve execution context and export env vars that the WordPress test runners expect.
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
@@ -45,17 +43,10 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
 fi
 
 TEST_BACKEND=""
-TEST_RUNTIME=""
 if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
     TEST_BACKEND=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.test_backend // .testing.backend // empty' 2>/dev/null || true)
-    TEST_RUNTIME=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.test_runtime // .testing.runtime // empty' 2>/dev/null || true)
 fi
-TEST_BACKEND="${HOMEBOY_WORDPRESS_TEST_BACKEND:-${TEST_BACKEND:-playground}}"
-TEST_RUNTIME="${HOMEBOY_WORDPRESS_TEST_RUNTIME:-${TEST_RUNTIME:-homeboy}}"
-if [ "$TEST_BACKEND" = "wp-codebox" ]; then
-    TEST_RUNTIME="wp-codebox"
-    TEST_BACKEND="playground"
-fi
+TEST_BACKEND="${HOMEBOY_WORDPRESS_TEST_BACKEND:-${TEST_BACKEND:-wp-codebox}}"
 
 TARGET_FILE=""
 PASSTHROUGH_ARGS=()
@@ -183,10 +174,7 @@ if [ -n "$TARGET_FILE" ]; then
                     HOMEBOY_WORDPRESS_HOST_SMOKE_FILE="$target_rel" exec bash "$HOST_SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
                     ;;
                 *Test.php|test-*.php)
-                    if [ "$TEST_RUNTIME" = "wp-codebox" ]; then
-                        HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE="$target_rel" exec bash "$WP_CODEBOX_RUNNER" "${PASSTHROUGH_ARGS[@]}"
-                    fi
-                    HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE="$target_rel" exec bash "$PLAYGROUND_RUNNER" "${PASSTHROUGH_ARGS[@]}"
+                    HOMEBOY_WORDPRESS_PHPUNIT_TEST_FILE="$target_rel" exec bash "$WP_CODEBOX_RUNNER" "${PASSTHROUGH_ARGS[@]}"
                     ;;
                 *)
                     echo "ERROR: cannot classify requested WordPress test file: ${target_rel}" >&2
@@ -208,29 +196,16 @@ case "$COMPONENT_SHAPE" in
         exec bash "${SCRIPT_DIR}/test-runner-core-dev.sh" "${PASSTHROUGH_ARGS[@]}"
         ;;
     *)
-        case "$TEST_RUNTIME" in
-            homeboy|"")
-                ;;
-            wp-codebox)
-                exec bash "$WP_CODEBOX_RUNNER" "${PASSTHROUGH_ARGS[@]}"
-                ;;
-            *)
-                echo "ERROR: Unsupported WordPress test runtime: ${TEST_RUNTIME}" >&2
-                echo "Supported runtimes: homeboy, wp-codebox" >&2
-                exit 2
-                ;;
-        esac
-
         case "$TEST_BACKEND" in
             host|host-smoke)
                 exec bash "$HOST_SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
                 ;;
-            ""|playground)
-                exec bash "$PLAYGROUND_RUNNER" "${PASSTHROUGH_ARGS[@]}"
+            ""|wp-codebox)
+                exec bash "$WP_CODEBOX_RUNNER" "${PASSTHROUGH_ARGS[@]}"
                 ;;
             *)
                 echo "ERROR: Unsupported WordPress test backend: ${TEST_BACKEND}" >&2
-                echo "Supported backends: playground, host, host-smoke" >&2
+                echo "Supported backends: wp-codebox, host, host-smoke" >&2
                 exit 2
                 ;;
         esac

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -122,7 +122,6 @@ SETTINGS_JSON=$(jq -nc \
     --argjson wpConfig '{"WP_DEBUG":true,"CUSTOM_NUMBER":7}' \
     --argjson benchEnv '{"HOMEBOY_FLAG":"yes"}' \
     '{
-        test_runtime: "wp-codebox",
         playground_wordpress_version: "6.10",
         wp_config_defines: $wpConfig,
         bench_env: $benchEnv,

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -821,23 +821,16 @@
     "extension_script": "scripts/trace/trace-runner.sh"
   },
   "testing": {
-    "backend": "playground",
-    "description": "Plugin/theme PHPUnit currently runs inside WordPress Playground by default while issue #697 moves WordPress tests onto the WP Codebox substrate. Pure PHP smoke suites can use the host-smoke backend."
+    "backend": "wp-codebox",
+    "description": "Plugin/theme PHPUnit runs through WP Codebox by default. Use the host-smoke backend only for standalone tests/**/*-smoke.php scripts that run under host PHP without WordPress bootstrap."
   },
   "settings": [
-    {
-      "id": "test_runtime",
-      "label": "Test runtime",
-      "type": "string",
-      "default": "",
-      "description": "Transitional WordPress test runtime selector tracked by issue #697. Leave empty for the current default runner, or set 'wp-codebox' to exercise the WP Codebox parity path for the same PHPUnit mount/config translation."
-    },
     {
       "id": "test_backend",
       "label": "Test backend",
       "type": "string",
-      "default": "playground",
-      "description": "WordPress test backend. Use 'playground' for the current default PHPUnit backend, 'wp-codebox' for the transitional WP Codebox runtime path, or 'host-smoke' / 'host' for standalone tests/**/*-smoke.php scripts run under host PHP without WordPress bootstrap."
+      "default": "wp-codebox",
+      "description": "WordPress test backend. Use 'wp-codebox' for default PHPUnit execution, or 'host-smoke' / 'host' for standalone tests/**/*-smoke.php scripts that run under host PHP without WordPress bootstrap."
     },
     {
       "id": "validation_dependencies",
@@ -858,21 +851,21 @@
       "label": "wp-config additions",
       "type": "object",
       "default": {},
-      "description": "Map of CONSTANT_NAME => value appended to the Playground wp-tests-config.php as additional define() statements. Lets a component declare wp-config-level constants (mode flags, debug toggles, custom paths) without shipping a custom drop-in. Values preserve PHP type via var_export() — booleans, integers, and nulls round-trip cleanly. Reserved canonical names (DB_NAME, ABSPATH, etc.) cannot be overridden."
+      "description": "Map of CONSTANT_NAME => value appended to the WP Codebox wp-tests-config.php as additional define() statements. Lets a component declare wp-config-level constants (mode flags, debug toggles, custom paths) without shipping a custom drop-in. Values preserve PHP type via var_export() — booleans, integers, and nulls round-trip cleanly. Reserved canonical names (DB_NAME, ABSPATH, etc.) cannot be overridden."
     },
     {
       "id": "bench_env",
       "label": "Bench env passthrough",
       "type": "object",
       "default": {},
-      "description": "Map of NAME => value forwarded into Playground PHP-WASM as environment variables. Workloads (bench) and test fixtures (test runner) read them via getenv() / $_ENV. Required because host shell env doesn't cross the wp-playground-cli sandbox boundary; without this seam, getenv('MY_KNOB') returns false regardless of what the parent shell set. Values are coerced to strings (via json_encode for non-scalars) per PHP env-var convention. Component declares static defaults; matrix drivers can synthesize HOMEBOY_SETTINGS_JSON inline to override per-cell."
+      "description": "Map of NAME => value forwarded into the WordPress runtime as environment variables. Workloads (bench) and test fixtures (test runner) read them via getenv() / $_ENV. Required because host shell env doesn't cross the sandbox boundary; without this seam, getenv('MY_KNOB') returns false regardless of what the parent shell set. Values are coerced to strings (via json_encode for non-scalars) per PHP env-var convention. Component declares static defaults; matrix drivers can synthesize HOMEBOY_SETTINGS_JSON inline to override per-cell."
     },
     {
       "id": "phpunit_no_tests",
       "label": "No PHPUnit tests discovered",
       "type": "string",
       "default": "skipped",
-      "description": "How the Playground PHPUnit backend treats successful WordPress install/activation when discovery finds zero PHPUnit files. Use 'skipped' for components that intentionally test through smoke scripts, or 'failed' when the component expects PHPUnit coverage. Components with phpunit.xml(.dist) still fail on zero discovery."
+      "description": "How the WP Codebox PHPUnit backend treats successful WordPress install/activation when discovery finds zero PHPUnit files. Use 'skipped' for components that intentionally test through smoke scripts, or 'failed' when the component expects PHPUnit coverage. Components with phpunit.xml(.dist) still fail on zero discovery."
     },
     {
       "id": "playground_blueprint",


### PR DESCRIPTION
## Summary
- Route WordPress plugin/theme PHPUnit execution to the WP Codebox runner by default.
- Remove the `test_runtime` settings surface and rewrite `test_backend` docs/settings so WP Codebox is the WordPress test backend, with `host-smoke` retained only for standalone non-WordPress PHP smoke scripts.
- Update the WP Codebox canary and runner smokes so they prove default routing, mount/config translation, artifact parsing, changed-file scope, and host-smoke separation.

## Parity checklist from #682
- [x] Plugin PHPUnit discovery and execution: default router now dispatches PHPUnit-shaped files and full plugin/theme runs to `test-runner-wp-codebox.sh`; DB activation fixture passes through WP Codebox.
- [x] No-test-files behavior and success/failure semantics: `phpunit_no_tests` still controls skipped/failed behavior; `playground-no-test-files-smoke.sh` passes on the default route.
- [x] Passthrough args after `--`: `playground-passthrough-args-smoke.sh` passes.
- [x] Changed-file routing and scoped test selection: router smoke covers mixed changed-file routing to WP Codebox; changed-scope smoke assertion updated for the base64 placeholder actually used by the template.
- [x] Dependency plugin mounting and activation: `playground-dep-plugins-loaded-smoke.sh` passes through WP Codebox.
- [x] DB/drop-in activation behavior: `playground-db-activation-smoke.sh` passes through WP Codebox; direct drop-in coexistence smoke still passes on the retained legacy Playground parity path.
- [x] WordPress version selection: `playground_wordpress_version` is still passed as `--wp`; `playground-wordpress-version-smoke.sh` passes.
- [x] Extra Playground file mounts and extension mounts: `wp-codebox-mount-translation-smoke.sh` covers component/dependency/drop-in/file/extension mounts; `playground-extension-mount-smoke.sh` still passes for the retained parity helper.
- [x] WP config defines: `wp-codebox-mount-translation-smoke.sh` validates base64 substitution of `wp_config_defines` into the wrapper.
- [x] Process cleanup and cleanup-noise filtering: owned by the retained direct Playground runner; not needed in the WP Codebox default path because WP Codebox owns the child runtime and artifacts.
- [x] Test result parsing and failure sidecar output: `parse-wp-codebox-artifacts-smoke.sh` passes for `wp-codebox/test-results/v1` artifacts; default runner still preserves stdout/result-file parsing.
- [x] Coverage parsing, if present in the current test lane: no default WordPress PHPUnit lane invokes coverage parsing today, so there is no cutover gap in this slice.
- [x] Core-dev checkout shape support: unchanged and intentionally remains native via `test-runner-core-dev.sh`, because wordpress-develop relies on core's own bootstrap/build/test config.

## Testing
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/scripts/test/test-runner-playground.sh wordpress/scripts/test/test-runner-core-dev.sh wordpress/scripts/test/parse-test-results.sh wordpress/scripts/test/parse-test-failures.sh`
- `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `bash wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `bash wordpress/scripts/test/parse-wp-codebox-artifacts-smoke.sh`
- `bash wordpress/scripts/test/host-smoke-runner-smoke.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@datamachine-pending-apply/packages/cli/dist/index.js bash wordpress/scripts/test/playground-db-activation-smoke.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@datamachine-pending-apply/packages/cli/dist/index.js bash wordpress/scripts/test/playground-dep-plugins-loaded-smoke.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@datamachine-pending-apply/packages/cli/dist/index.js bash wordpress/scripts/test/playground-no-test-files-smoke.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@datamachine-pending-apply/packages/cli/dist/index.js bash wordpress/scripts/test/playground-changed-scope-smoke.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@datamachine-pending-apply/packages/cli/dist/index.js bash wordpress/scripts/test/playground-passthrough-args-smoke.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@datamachine-pending-apply/packages/cli/dist/index.js bash wordpress/scripts/test/playground-wordpress-version-smoke.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@datamachine-pending-apply/packages/cli/dist/index.js bash wordpress/scripts/test/playground-extension-mount-smoke.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@datamachine-pending-apply/packages/cli/dist/index.js bash wordpress/scripts/test/playground-dropin-smoke.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/wp-codebox-test-runtime-canary.yml"); puts "workflow yaml ok"'`

## References
- Closes #697
- Closes #682
- Refs #695
- Builds on the #687 canary proof from #694

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the WP Codebox default routing slice, updated docs/settings/smokes, ran local validation, and drafted this PR body. Chris remains responsible for review and merge.