### PR TITLE
Fix scoped WordPress lint and dependency resolution

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -9,10 +9,11 @@ set -euo pipefail
 #
 # Resolution chain for each dependency slug:
 #   1. Direct path (if the value is an existing directory)
-#   2. homeboy component show → local_path (if homeboy is available)
-#   3. Git clone from GitHub org (shallow, cached across steps)
+#   2. Consumer composer.lock vendor package, when present and plugin-shaped
+#   3. homeboy component show → local_path (if homeboy is available)
+#   4. Git clone from GitHub org (shallow, cached across steps)
 #      Org inferred from: HOMEBOY_DEPENDENCY_GITHUB_ORG → git remote origin
-#   4. Warn and skip
+#   5. Warn and skip
 #
 # Settings deps take priority — they can be absolute paths or slugs.
 # Header deps are resolved through the same chain by slug.
@@ -111,6 +112,44 @@ homeboy_get_validation_dependency_slug() {
     fi
 
     printf '%s\n' "$dir_slug"
+}
+
+_homeboy_is_plugin_shaped_path() {
+    local plugin_path="${1:-}"
+
+    [ -z "$plugin_path" ] || [ ! -d "$plugin_path" ] && return 1
+
+    local main_file
+    main_file=$(find "$plugin_path" -maxdepth 1 -name "*.php" -exec grep -l "Plugin Name:" {} \; 2>/dev/null | head -1)
+    [ -n "$main_file" ]
+}
+
+_homeboy_resolve_composer_locked_dependency_path() {
+    local dependency="${1:-}"
+    local plugin_path="${2:-}"
+
+    [ -z "$dependency" ] || [ -z "$plugin_path" ] && return 1
+    [[ "$dependency" == */* ]] && return 1
+    [ -f "${plugin_path}/composer.lock" ] || return 1
+    command -v jq >/dev/null 2>&1 || return 1
+
+    local package_name
+    package_name=$(jq -r --arg slug "$dependency" '
+        [.packages[]?, .["packages-dev"][]?]
+        | .[]?
+        | .name? // empty
+        | select(split("/")[-1] == $slug)
+    ' "${plugin_path}/composer.lock" 2>/dev/null | head -1)
+
+    [ -n "$package_name" ] || return 1
+
+    local package_path="${plugin_path}/vendor/${package_name}"
+    if _homeboy_is_plugin_shaped_path "$package_path"; then
+        printf '%s\n' "$package_path"
+        return 0
+    fi
+
+    return 1
 }
 
 # Infer GitHub org from a git repo's remote.
@@ -214,7 +253,19 @@ homeboy_resolve_validation_dependency_path() {
         return 0
     fi
 
-    # 2. Homeboy component registry lookup
+    # 2. Prefer the consumer's Composer-locked plugin package when available.
+    # This keeps validation aligned with the dependency ref the component actually
+    # installed, instead of silently mounting a stale local registry checkout.
+    if [ -n "${_HOMEBOY_DEP_PLUGIN_PATH:-}" ]; then
+        local composer_resolved
+        composer_resolved=$(_homeboy_resolve_composer_locked_dependency_path "$dependency" "${_HOMEBOY_DEP_PLUGIN_PATH}" || true)
+        if [ -n "$composer_resolved" ] && [ -d "$composer_resolved" ]; then
+            printf '%s\n' "$composer_resolved"
+            return 0
+        fi
+    fi
+
+    # 3. Homeboy component registry lookup
     if command -v homeboy >/dev/null 2>&1; then
         local resolved
         resolved=$(homeboy component show "$dependency" 2>/dev/null | jq -r '.data.entity.local_path // empty' 2>/dev/null || true)
@@ -224,7 +275,7 @@ homeboy_resolve_validation_dependency_path() {
         fi
     fi
 
-    # 3. Git clone from GitHub org (for CI environments)
+    # 4. Git clone from GitHub org (for CI environments)
     #    Only attempt for slug-like values (no slashes, no absolute paths)
     if [[ "$dependency" != */* ]] && command -v git >/dev/null 2>&1; then
         local github_org="${HOMEBOY_DEPENDENCY_GITHUB_ORG:-}"

--- a/wordpress/scripts/lint/autofixable-exit-smoke.sh
+++ b/wordpress/scripts/lint/autofixable-exit-smoke.sh
@@ -56,17 +56,24 @@ chmod +x "${EXTENSION_DIR}/vendor/bin/phpcs"
 
 run_lint() {
     local mode="$1"
+    local changed_since="${2:-}"
     : > "$OUTPUT_FILE"
     rm -f "$FINDINGS_FILE"
 
+    local -a env_args=(
+        "HOMEBOY_EXTENSION_PATH=$EXTENSION_DIR"
+        "HOMEBOY_COMPONENT_PATH=$COMPONENT_DIR"
+        "HOMEBOY_COMPONENT_ID=autofixable-fixture"
+        "HOMEBOY_LINT_FINDINGS_FILE=$FINDINGS_FILE"
+        "HOMEBOY_STEP=phpcs"
+        "HOMEBOY_SUMMARY_MODE=$mode"
+    )
+    if [ -n "$changed_since" ]; then
+        env_args+=("HOMEBOY_CHANGED_SINCE=$changed_since")
+    fi
+
     set +e
-    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
-    HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
-    HOMEBOY_COMPONENT_ID="autofixable-fixture" \
-    HOMEBOY_LINT_FINDINGS_FILE="$FINDINGS_FILE" \
-    HOMEBOY_STEP="phpcs" \
-    HOMEBOY_SUMMARY_MODE="$mode" \
-        "$RUNNER" >"$OUTPUT_FILE" 2>&1
+    env "${env_args[@]}" "$RUNNER" >"$OUTPUT_FILE" 2>&1
     local exit_code=$?
     set -e
 
@@ -82,7 +89,13 @@ run_lint() {
         exit 1
     fi
 
-    if ! grep -Fq "Run:  homeboy refactor --from lint --write autofixable-fixture" "$OUTPUT_FILE"; then
+    expected_command="Run:  homeboy refactor --from lint --write"
+    if [ -n "$changed_since" ]; then
+        expected_command="${expected_command} --changed-since ${changed_since}"
+    fi
+    expected_command="${expected_command} autofixable-fixture"
+
+    if ! grep -Fq "$expected_command" "$OUTPUT_FILE"; then
         echo "FAIL: refactor command missing (summary=${mode})" >&2
         sed 's/^/  /' "$OUTPUT_FILE" >&2
         exit 1
@@ -126,5 +139,6 @@ PY
 
 run_lint 1
 run_lint 0
+run_lint 1 origin/main
 
 echo "autofixable lint exit smoke passed"

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -506,11 +506,15 @@ print(json.dumps(results))
     done
 
     # Run reserved keyword parameter name fixer ($default -> $default_value, etc.)
-    # MUST run on full plugin path (not per-file) because its two-pass architecture
-    # builds a rename manifest in Pass 1 (declarations) and applies it to call sites
-    # in Pass 2 (named arguments). Per-file invocation loses the manifest between
-    # processes, leaving call sites with stale parameter names.
-    run_fixer "reserved-param" "$RESERVED_PARAM_FIXER" "$PLUGIN_PATH"
+    # MUST run on full plugin path because its two-pass architecture builds a
+    # rename manifest in Pass 1 and applies it to call sites in Pass 2. In scoped
+    # fix-only mode, skip it rather than dirtying unrelated files outside the
+    # review scope.
+    if [ -n "${HOMEBOY_LINT_FILE:-}" ] || [ -n "${HOMEBOY_LINT_GLOB:-}" ]; then
+        echo "Skipping reserved-param fixer for scoped lint fix; it requires a full-component scan."
+    else
+        run_fixer "reserved-param" "$RESERVED_PARAM_FIXER" "$PLUGIN_PATH"
+    fi
 
     # Run phpcbf for remaining auto-fixable issues
     if [ -f "$PHPCBF_BIN" ]; then
@@ -751,7 +755,11 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
         echo ""
         echo "============================================"
         echo "AUTO-FIXABLE: ${fixable_count} lint finding(s) can be fixed automatically."
-        echo "  Run:  homeboy refactor --from lint --write ${fix_target}"
+        fix_scope_args=""
+        if [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
+            fix_scope_args=" --changed-since ${HOMEBOY_CHANGED_SINCE}"
+        fi
+        echo "  Run:  homeboy refactor --from lint --write${fix_scope_args} ${fix_target}"
         echo "============================================"
     fi
 

--- a/wordpress/scripts/lint/scoped-fix-only-smoke.sh
+++ b/wordpress/scripts/lint/scoped-fix-only-smoke.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/lint-runner.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+EXTENSION_DIR="${TMPDIR}/extension"
+COMPONENT_DIR="${TMPDIR}/component"
+OUTPUT_FILE="${TMPDIR}/lint-output.txt"
+TARGET_FILE="${COMPONENT_DIR}/inc/Changed.php"
+UNRELATED_FILE="${COMPONENT_DIR}/inc/Unrelated.php"
+
+mkdir -p "${EXTENSION_DIR}/vendor/bin" "${EXTENSION_DIR}/scripts/lint/php-fixers" "${COMPONENT_DIR}/inc"
+touch "${EXTENSION_DIR}/phpcs.xml.dist"
+
+cat > "${COMPONENT_DIR}/component.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Scoped Fix Fixture
+ * Text Domain: scoped-fix-fixture
+ */
+PHP
+
+cat > "$TARGET_FILE" <<'PHP'
+<?php
+function changed_fixture( $default ) {
+    return $default;
+}
+PHP
+
+cat > "$UNRELATED_FILE" <<'PHP'
+<?php
+function unrelated_fixture( $default ) {
+    return $default;
+}
+PHP
+
+cat > "${EXTENSION_DIR}/vendor/bin/phpcs" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+for arg in "$@"; do
+    if [ "$arg" = "--config-set" ]; then
+        exit 0
+    fi
+done
+
+exit 0
+SH
+chmod +x "${EXTENSION_DIR}/vendor/bin/phpcs"
+
+cat > "${EXTENSION_DIR}/scripts/lint/php-fixers/reserved-param-fixer.php" <<'PHP'
+<?php
+$path = $argv[1] ?? '';
+if (is_dir($path)) {
+    foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path)) as $file) {
+        if ($file->isFile() && substr($file->getFilename(), -4) === '.php') {
+            file_put_contents($file->getPathname(), "// touched by reserved fixer\n", FILE_APPEND);
+        }
+    }
+} elseif (is_file($path)) {
+    file_put_contents($path, "// touched by reserved fixer\n", FILE_APPEND);
+}
+echo "Reserved param fixer: Fixed 1 parameter(s) in 1 file(s)\n";
+PHP
+
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$COMPONENT_DIR" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_TEXT_DOMAIN="scoped-fix-fixture" \
+HOMEBOY_FIX_ONLY=1 \
+HOMEBOY_STEP="phpcs" \
+HOMEBOY_LINT_FILE="inc/Changed.php" \
+    "$RUNNER" >"$OUTPUT_FILE" 2>&1
+runner_exit=$?
+set -e
+
+if [ "$runner_exit" -ne 0 ]; then
+    echo "FAIL: scoped fix-only runner exited ${runner_exit}" >&2
+    sed 's/^/  /' "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+if ! grep -Fq "Skipping reserved-param fixer for scoped lint fix" "$OUTPUT_FILE"; then
+    echo "FAIL: scoped fix-only mode should skip reserved-param fixer" >&2
+    sed 's/^/  /' "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+if grep -Fq "touched by reserved fixer" "$UNRELATED_FILE"; then
+    echo "FAIL: scoped fix-only mode dirtied an unrelated file" >&2
+    sed 's/^/  /' "$UNRELATED_FILE" >&2
+    exit 1
+fi
+
+echo "scoped fix-only smoke passed"

--- a/wordpress/tests/validation-dependencies-smoke.sh
+++ b/wordpress/tests/validation-dependencies-smoke.sh
@@ -10,12 +10,13 @@ COMPONENT_DIR="${TMPDIR}/intelligence"
 DATA_MACHINE_DIR="${TMPDIR}/data-machine"
 CLONED_DATA_MACHINE_DIR="${TMPDIR}/cache/data-machine"
 AGENTS_API_DIR="${TMPDIR}/agents-api"
+VENDORED_AGENTS_API_DIR="${COMPONENT_DIR}/vendor/automattic/agents-api"
 OPENAI_PROVIDER_DIR="${TMPDIR}/ai-provider-for-openai"
 BIN_DIR="${TMPDIR}/bin"
 CLONE_BIN_DIR="${TMPDIR}/clone-bin"
 FALLBACK_CACHE_DIR="${TMPDIR}/fallback-cache"
 
-mkdir -p "$COMPONENT_DIR" "$DATA_MACHINE_DIR" "$CLONED_DATA_MACHINE_DIR" "$AGENTS_API_DIR" "$OPENAI_PROVIDER_DIR" "$BIN_DIR" "$CLONE_BIN_DIR" "$FALLBACK_CACHE_DIR"
+mkdir -p "$COMPONENT_DIR" "$DATA_MACHINE_DIR" "$CLONED_DATA_MACHINE_DIR" "$AGENTS_API_DIR" "$VENDORED_AGENTS_API_DIR" "$OPENAI_PROVIDER_DIR" "$BIN_DIR" "$CLONE_BIN_DIR" "$FALLBACK_CACHE_DIR"
 
 cat > "${COMPONENT_DIR}/intelligence.php" <<'PHP'
 <?php
@@ -46,6 +47,23 @@ cat > "${AGENTS_API_DIR}/agents-api.php" <<'PHP'
  * Plugin Name: Agents API
  */
 PHP
+
+cat > "${VENDORED_AGENTS_API_DIR}/agents-api.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Agents API Locked Vendor Copy
+ */
+PHP
+
+cat > "${COMPONENT_DIR}/composer.lock" <<'JSON'
+{
+    "packages": [
+        {
+            "name": "automattic/agents-api"
+        }
+    ]
+}
+JSON
 
 cat > "${OPENAI_PROVIDER_DIR}/ai-provider-for-openai.php" <<'PHP'
 <?php
@@ -130,13 +148,19 @@ if ! grep -F -- "$DATA_MACHINE_DIR" <<< "$resolved" >/dev/null; then
     exit 1
 fi
 
-if ! grep -F -- "$AGENTS_API_DIR" <<< "$resolved" >/dev/null; then
-    echo "FAIL: transitive Requires Plugins dependency was not resolved" >&2
+if ! grep -F -- "$VENDORED_AGENTS_API_DIR" <<< "$resolved" >/dev/null; then
+    echo "FAIL: transitive Requires Plugins dependency should prefer composer-locked vendor copy" >&2
     printf '%s\n' "$resolved" >&2
     exit 1
 fi
 
-agents_api_line=$(grep -nF -- "$AGENTS_API_DIR" <<< "$resolved" | cut -d: -f1 | head -1)
+if grep -F -- "$AGENTS_API_DIR" <<< "$resolved" >/dev/null; then
+    echo "FAIL: stale local registry checkout should not override composer-locked vendor copy" >&2
+    printf '%s\n' "$resolved" >&2
+    exit 1
+fi
+
+agents_api_line=$(grep -nF -- "$VENDORED_AGENTS_API_DIR" <<< "$resolved" | cut -d: -f1 | head -1)
 data_machine_line=$(grep -nF -- "$DATA_MACHINE_DIR" <<< "$resolved" | cut -d: -f1 | head -1)
 if [ "$agents_api_line" -ge "$data_machine_line" ]; then
     echo "FAIL: transitive dependency should be emitted before dependent plugin" >&2
@@ -183,9 +207,9 @@ if grep -F -- "$CLONED_DATA_MACHINE_DIR" <<< "$merged_prepared" >/dev/null; then
     exit 1
 fi
 
-topological_resolved="${AGENTS_API_DIR}"$'\n'"${DATA_MACHINE_DIR}"
+topological_resolved="${VENDORED_AGENTS_API_DIR}"$'\n'"${DATA_MACHINE_DIR}"
 merged_topological=$(homeboy_merge_validation_dependency_paths "$prepared_paths" "$topological_resolved")
-agents_api_merged_line=$(grep -nF -- "$AGENTS_API_DIR" <<< "$merged_topological" | cut -d: -f1 | head -1)
+agents_api_merged_line=$(grep -nF -- "$VENDORED_AGENTS_API_DIR" <<< "$merged_topological" | cut -d: -f1 | head -1)
 data_machine_merged_line=$(grep -nF -- "$DATA_MACHINE_DIR" <<< "$merged_topological" | cut -d: -f1 | head -1)
 if [ "$agents_api_merged_line" -ge "$data_machine_merged_line" ]; then
     echo "FAIL: merge should preserve resolved transitive dependency order" >&2


### PR DESCRIPTION
## Summary
- Prefer Composer-locked, plugin-shaped vendor dependencies before local Homeboy component checkouts for WordPress validation dependencies.
- Keep scoped WordPress lint fix-only runs from invoking the full-component reserved-param fixer, avoiding unrelated file churn.
- Preserve `--changed-since` in the lint auto-fix command hint and add smoke coverage for both regressions.

Fixes #706.
Fixes #707.

## Testing
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `bash wordpress/scripts/lint/autofixable-exit-smoke.sh`
- `bash wordpress/scripts/lint/scoped-fix-only-smoke.sh`
- `HOMEBOY_SETTINGS_JSON='{"validation_dependencies":"agents-api"}' bash -c 'source /Users/chubes/Developer/homeboy-extensions@fix-validation-deps-lint-scope/wordpress/scripts/lib/validation-dependencies.sh; homeboy_resolve_validation_dependency_paths /Users/chubes/Developer/data-machine@cleanup-taxonomy-ability-scaffold'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the targeted shell fixes, smoke tests, and verification commands for Chris to review.