### PR TITLE
Install WP Codebox during WordPress extension setup

### DIFF
--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FAKE_BIN="${TMPDIR}/bin"
+HOME_DIR="${TMPDIR}/home"
+EXTENSION_DIR="${TMPDIR}/extension"
+GITHUB_ENV_FILE="${TMPDIR}/github-env"
+
+mkdir -p "${FAKE_BIN}" "${HOME_DIR}" "${EXTENSION_DIR}"
+
+cat > "${FAKE_BIN}/git" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$1" in
+    clone)
+        dest="${@: -1}"
+        mkdir -p "${dest}/.git"
+        ;;
+    -C)
+        exit 0
+        ;;
+    *)
+        printf 'unexpected git invocation: %s\n' "$*" >&2
+        exit 1
+        ;;
+esac
+SH
+chmod +x "${FAKE_BIN}/git"
+
+cat > "${FAKE_BIN}/npm" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+prefix=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --prefix)
+            prefix="$2"
+            shift 2
+            ;;
+        install)
+            exit 0
+            ;;
+        run)
+            mkdir -p "${prefix}/packages/cli/dist"
+            printf '%s\n' 'console.log("wp-codebox stub")' > "${prefix}/packages/cli/dist/index.js"
+            exit 0
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+SH
+chmod +x "${FAKE_BIN}/npm"
+
+(
+    cd "${EXTENSION_DIR}"
+    HOME="${HOME_DIR}" \
+    PATH="${FAKE_BIN}:${PATH}" \
+    GITHUB_ENV="${GITHUB_ENV_FILE}" \
+    HOMEBOY_WP_CODEBOX_SOURCE="https://example.test/wp-codebox.git" \
+    HOMEBOY_WP_CODEBOX_REF="main" \
+    bash "${ROOT_DIR}/scripts/build/setup.sh" > "${TMPDIR}/setup.out"
+)
+
+if ! grep -q '^HOMEBOY_WP_CODEBOX_BIN=' "${GITHUB_ENV_FILE}"; then
+    echo "Expected setup to export HOMEBOY_WP_CODEBOX_BIN" >&2
+    exit 1
+fi
+
+wp_codebox_bin="$(grep '^HOMEBOY_WP_CODEBOX_BIN=' "${GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
+
+if [ ! -x "${wp_codebox_bin}" ]; then
+    echo "Expected wp-codebox wrapper to be executable" >&2
+    exit 1
+fi
+
+if [ "$("${wp_codebox_bin}")" != "wp-codebox stub" ]; then
+    echo "Expected wp-codebox wrapper to execute built CLI" >&2
+    exit 1
+fi
+
+echo "WP Codebox setup smoke passed"

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -3,14 +3,66 @@ set -euo pipefail
 
 # Setup script for WordPress Homeboy extension.
 #
-# Installs npm dependencies (including @wp-playground/cli for the default
-# Playground test backend) and PHP dev dependencies (PHPCS, PHPStan for linting).
+# Installs npm dependencies, PHP dev dependencies (PHPCS, PHPStan for linting),
+# and the WP Codebox CLI used by the default WordPress test backend.
 #
-# The legacy wp-phpunit dependency was removed in Phase 3 (#214) — WordPress
-# PHPUnit execution now runs inside Playground. The host-smoke backend is only
-# for standalone PHP smoke scripts.
+# The legacy wp-phpunit dependency was removed in Phase 3 (#214). WordPress
+# PHPUnit execution now runs through WP Codebox by default. The host-smoke
+# backend is only for standalone PHP smoke scripts.
 
 EXTENSION_PATH="$(pwd)"
+
+install_wp_codebox() {
+    if [ -n "${HOMEBOY_WP_CODEBOX_BIN:-}" ] && [ -x "${HOMEBOY_WP_CODEBOX_BIN}" ]; then
+        echo "WP Codebox already configured: ${HOMEBOY_WP_CODEBOX_BIN}"
+        return 0
+    fi
+
+    if command -v wp-codebox >/dev/null 2>&1; then
+        local detected_bin
+        detected_bin="$(command -v wp-codebox)"
+        echo "WP Codebox already available: ${detected_bin}"
+        if [ -n "${GITHUB_ENV:-}" ]; then
+            echo "HOMEBOY_WP_CODEBOX_BIN=${detected_bin}" >> "${GITHUB_ENV}"
+        fi
+        return 0
+    fi
+
+    local source ref install_root repo_dir bin_dir bin_path
+    source="${HOMEBOY_WP_CODEBOX_SOURCE:-https://github.com/chubes4/wp-codebox.git}"
+    ref="${HOMEBOY_WP_CODEBOX_REF:-main}"
+    install_root="${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-${HOME}/.cache/homeboy/wp-codebox}"
+    repo_dir="${install_root}/source"
+    bin_dir="${HOME}/.local/bin"
+    bin_path="${bin_dir}/wp-codebox"
+
+    echo "Installing WP Codebox CLI (${source}@${ref})..."
+    mkdir -p "${install_root}" "${bin_dir}"
+
+    if [ ! -d "${repo_dir}/.git" ]; then
+        rm -rf "${repo_dir}"
+        git clone --quiet "${source}" "${repo_dir}"
+    fi
+
+    git -C "${repo_dir}" fetch --quiet origin "${ref}"
+    git -C "${repo_dir}" checkout --quiet FETCH_HEAD
+
+    npm --prefix "${repo_dir}" install --quiet --no-fund --no-audit
+    npm --prefix "${repo_dir}" run build --silent
+
+    cat > "${bin_path}" <<EOF
+#!/usr/bin/env bash
+exec node "${repo_dir}/packages/cli/dist/index.js" "\$@"
+EOF
+    chmod +x "${bin_path}"
+
+    if [ -n "${GITHUB_ENV:-}" ]; then
+        echo "HOMEBOY_WP_CODEBOX_BIN=${bin_path}" >> "${GITHUB_ENV}"
+        echo "PATH=${bin_dir}:${PATH}" >> "${GITHUB_ENV}"
+    fi
+
+    echo "WP Codebox installed: ${bin_path}"
+}
 
 echo "Setting up WordPress extension..."
 
@@ -42,12 +94,14 @@ fi
 
 # Install npm dependencies (Playground CLI, ESLint).
 if [ -f "package.json" ]; then
-    echo "Installing npm dependencies (including @wp-playground/cli)..."
+    echo "Installing npm dependencies..."
     npm install --quiet --no-fund --no-audit 2>&1 || {
-        echo "Warning: npm install failed — Playground test backend will not be available"
+        echo "Warning: npm install failed — extension Node tooling may not be available"
     }
 fi
 
+install_wp_codebox
+
 echo "WordPress extension setup complete."
-echo "Default test backend: Playground (PHP-WASM + embedded SQLite)"
+echo "Default test backend: WP Codebox (WordPress Playground runtime)"
 echo "Host smoke backend: set test_backend=host-smoke for standalone tests/**/*-smoke.php"


### PR DESCRIPTION
## Summary
- Install the `wp-codebox` CLI during WordPress extension setup when it is not already provided by `HOMEBOY_WP_CODEBOX_BIN` or available on `PATH`.
- Export `HOMEBOY_WP_CODEBOX_BIN` through `GITHUB_ENV` so later Homeboy Action steps can run the mandatory WP Codebox test backend.
- Add a setup smoke test proving setup creates an executable wrapper and exports the binary path.

## Why
Data Machine PR #2125 exposed the gap after Homeboy Extensions made WP Codebox the default WordPress test backend: `homeboy extension setup wordpress` reported success, but the following `homeboy test` step failed with `wp-codebox not found`.

## Verification
- `bash -n wordpress/scripts/build/setup.sh wordpress/scripts/build/setup-wp-codebox-smoke.sh`
- `bash wordpress/scripts/build/setup-wp-codebox-smoke.sh`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-wp-codebox-setup-installs-bin --extension nodejs --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-wp-codebox-setup-installs-bin --extension nodejs --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the failing downstream Data Machine check, implementing the WordPress extension setup fix, and running targeted verification. Chris remains responsible for review and merge.