### PR TITLE
Route WordPress bench settings through WP Codebox

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -241,21 +241,21 @@ errors and PSR-4 violations block the build; lint findings do not.
 
 ## Bench runner
 
-Basic `tests/bench/*.php` workloads run through WP Codebox by default. WP
-Codebox owns the disposable WordPress runtime, component mount, command
-execution, and artifacts, and emits the same `BenchResults` envelope Homeboy
-core parses.
+Bench workloads run through WP Codebox. WP Codebox owns the disposable WordPress
+runtime, component mount, command execution, and artifacts, and emits the same
+`BenchResults` envelope Homeboy core parses.
 
-Advanced bench features still dispatch to the legacy direct Playground runner
-while #698 ports them one at a time: configured `playground_workloads`, scenario
-manifests, extra file mounts, custom `wp_config_defines`, `bench_env`, installed
-site mode, blueprints, and browser handoff descriptors.
+Each file under `tests/bench/*.php` returns a callable. The callable may return
+numeric metrics directly or `{metrics, metadata, artifacts}`. Components may
+also declare configured workloads via `playground_workloads`; the WordPress
+runner maps those declarations onto `wp-codebox bench-run` inputs alongside
+`validation_dependencies`, `playground_file_mounts`, `wp_config_defines`,
+`bench_env`, shared-state mounts, and browser handoff descriptors.
 
-For the WP Codebox path, each file under `tests/bench/*.php` returns a callable.
-The callable may return numeric metrics directly or `{metrics, metadata}`.
-Configured workloads are still declared per component via the
-`playground_workloads` setting (see below) and remain on the legacy runner until
-their WP Codebox command mapping lands.
+Bootstrap-only Playground features no longer fall back to the legacy runner. A
+component that still relies on `playground_blueprint`, scenario manifests, or
+`bench_site_mode=installed` fails fast so the missing WP Codebox contract can be
+ported explicitly instead of hiding behind a second runtime.
 
 The browser bench target is a two-extension handoff: the WordPress
 extension prepares/describes the WordPress target by writing
@@ -343,12 +343,12 @@ Configure per-component in the component's homeboy/component config under
 | `user` | string | `""` | WP-CLI user (email/login/ID); appended as `--user` when set |
 | `wp_config_defines` | object | `{}` | `CONSTANT_NAME => value` map appended to the runtime `wp-tests-config.php`; PHP type preserved via `var_export` |
 | `bench_env` | object | `{}` | `NAME => value` env vars forwarded into the runtime (workloads/fixtures read via `getenv()`) |
-| `playground_blueprint` | object | `{}` | Blueprint JSON passed to `wp-playground-cli --blueprint` for cold-boot scenarios |
-| `playground_workloads` | array | `[]` | Declared bench workloads run after bootstrap, blueprint, deps, and component load |
-| `playground_file_mounts` | array | `[]` | Files from the component or validation dependencies mounted into explicit Playground paths |
-| `bench_site_mode` | string | `fresh` | `fresh` runs `wp-phpunit` install; `installed` mounts a persisted site under `HOMEBOY_BENCH_SHARED_STATE` |
+| `playground_blueprint` | object | `{}` | Reserved for cold-boot scenarios; current WP Codebox bench runner fails fast when set |
+| `playground_workloads` | array | `[]` | Declared bench workloads passed to `wp-codebox bench-run` after deps and component load |
+| `playground_file_mounts` | array | `[]` | Files from the component or validation dependencies mounted into explicit WordPress runtime paths |
+| `bench_site_mode` | string | `fresh` | `fresh` uses a disposable WP Codebox site; `installed` currently fails fast until a WP Codebox persisted-site contract lands |
 | `bench_browser_target` | object | `{}` | Browser bench target descriptor (see Bench runner above) |
-| `playground_wordpress_install_mode` | string | `""` | Pass-through for `wp-playground-cli --wordpress-install-mode` |
+| `playground_wordpress_install_mode` | string | `""` | Legacy direct-Playground pass-through; ignored by the WP Codebox bench runner |
 
 ## Blueprint Validation
 

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -1,17 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# WP Codebox-backed minimal WordPress bench runner.
-#
-# This first #698 slice covers in-tree `tests/bench/*.php` workloads. The
-# top-level bench router keeps complex Playground-only features on the legacy
-# runner until their WP Codebox equivalents are ported explicitly.
+# WP Codebox-backed WordPress bench runner.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 BENCH_HELPER_SH="${HOMEBOY_RUNTIME_BENCH_HELPER_SH:-${HOME}/.homeboy/runtime/bench-helper.sh}"
 PLAYGROUND_RESULTS_ARTIFACTS_HELPER="${SCRIPT_DIR}/playground-results-artifacts.sh"
+DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
+BENCH_BROWSER_TARGET_HELPER="${SCRIPT_DIR}/browser-target.sh"
 
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
@@ -35,6 +33,12 @@ else
 fi
 # shellcheck source=playground-results-artifacts.sh
 source "$PLAYGROUND_RESULTS_ARTIFACTS_HELPER"
+# shellcheck source=../lib/validation-dependencies.sh
+if [ -f "$DEPENDENCY_HELPER" ]; then
+    source "$DEPENDENCY_HELPER"
+fi
+# shellcheck source=browser-target.sh
+source "$BENCH_BROWSER_TARGET_HELPER"
 
 if [ -n "${COMPONENT_ID:-}" ]; then
     PLUGIN_SLUG="$COMPONENT_ID"
@@ -54,25 +58,34 @@ if [ "$WP_CODEBOX_BIN" = "wp-codebox" ] && ! command -v wp-codebox >/dev/null 2>
     exit 1
 fi
 
-BENCH_DIR="${PLUGIN_PATH}/tests/bench"
-if [ ! -d "$BENCH_DIR" ]; then
-    echo "Warning: No bench workload directory found at ${BENCH_DIR}" >&2
-    exit 0
+settings_json="${HOMEBOY_SETTINGS_JSON:-}"
+[ -n "$settings_json" ] || settings_json="{}"
+
+if printf '%s' "$settings_json" | jq -e '((.playground_blueprint // {}) | length > 0) or ((.playground_scenario_manifests // .scenario_manifests // []) | length > 0) or ((.bench_site_mode // "fresh") == "installed")' >/dev/null 2>&1; then
+    echo "Error: this bench configuration uses Playground-only bootstrap features that no longer dispatch to the legacy runner." >&2
+    echo "       Port the setting to wp-codebox first: playground_blueprint, scenario manifests, or bench_site_mode=installed." >&2
+    FAILED_STEP="WP Codebox bench configuration"
+    exit 1
 fi
 
 PLAYGROUND_WORDPRESS_VERSION="7.0"
-if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
-    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_wordpress_version // .playground_wordpress_version // empty' 2>/dev/null || true)
+if [ "$settings_json" != "{}" ]; then
+    extracted=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_wordpress_version // .playground_wordpress_version // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && PLAYGROUND_WORDPRESS_VERSION="$extracted"
 fi
 
 ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-3}"
-WARMUP_ITERATIONS="${HOMEBOY_BENCH_WARMUP_ITERATIONS:-1}"
+WARMUP_ITERATIONS="${HOMEBOY_BENCH_WARMUP_ITERATIONS:-}"
+if [ -z "$WARMUP_ITERATIONS" ] && [ "$settings_json" != "{}" ]; then
+    extracted=$(printf '%s' "$settings_json" | jq -r '.bench_warmup_iterations // empty' 2>/dev/null || true)
+    [ -n "$extracted" ] && [ "$extracted" != "null" ] && WARMUP_ITERATIONS="$extracted"
+fi
+WARMUP_ITERATIONS="${WARMUP_ITERATIONS:-1}"
 RESULTS_FILE="${HOMEBOY_BENCH_RESULTS_FILE:-${PLUGIN_PATH}/.pg-bench-results.json}"
 
 ARTIFACTS_DIR="${HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR:-}"
-if [ -z "$ARTIFACTS_DIR" ] && [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
-    ARTIFACTS_DIR=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_artifacts_dir // empty' 2>/dev/null || true)
+if [ -z "$ARTIFACTS_DIR" ] && [ "$settings_json" != "{}" ]; then
+    ARTIFACTS_DIR=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_artifacts_dir // empty' 2>/dev/null || true)
 fi
 if [ -z "$ARTIFACTS_DIR" ]; then
     ARTIFACTS_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-bench-artifacts.XXXXXX")
@@ -85,6 +98,102 @@ case "$WP_CODEBOX_BIN" in
         ;;
 esac
 
+if type homeboy_export_validation_dependency_paths &>/dev/null; then
+    homeboy_export_validation_dependency_paths "$PLUGIN_PATH"
+fi
+DEPENDENCY_PATHS="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
+
+WP_CONFIG_DEFINES_JSON="{}"
+BENCH_ENV_JSON="{}"
+PLAYGROUND_WORKLOADS_JSON="[]"
+if [ "$settings_json" != "{}" ]; then
+    WP_CONFIG_DEFINES_JSON=$(printf '%s' "$settings_json" | jq -c '.wp_config_defines // {}' 2>/dev/null || echo "{}")
+    BENCH_ENV_JSON=$(printf '%s' "$settings_json" | jq -c '.bench_env // {}' 2>/dev/null || echo "{}")
+    PLAYGROUND_WORKLOADS_JSON=$(printf '%s' "$settings_json" | jq -c '.playground_workloads // []' 2>/dev/null || echo "[]")
+fi
+
+MOUNT_ARGS=()
+DEPENDENCY_ARGS=()
+if [ -n "$DEPENDENCY_PATHS" ]; then
+    while IFS= read -r dep_path; do
+        [ -n "$dep_path" ] || continue
+        dep_slug="$(homeboy_get_validation_dependency_slug "$dep_path" || basename "$dep_path")"
+        DEPENDENCY_ARGS+=("--dependency" "${dep_path}:${dep_slug}")
+    done <<< "$DEPENDENCY_PATHS"
+fi
+
+PLUGIN_DB_PHP="${PLUGIN_PATH}/db.php"
+if [ -f "$PLUGIN_DB_PHP" ]; then
+    MOUNT_ARGS+=("--mount" "${PLUGIN_DB_PHP}:/wordpress/wp-content/db.php")
+fi
+
+PLAYGROUND_FILE_MOUNTS_JSON="[]"
+if [ "$settings_json" != "{}" ]; then
+    PLAYGROUND_FILE_MOUNTS_JSON=$(printf '%s' "$settings_json" | jq -c '.playground_file_mounts // []' 2>/dev/null || echo "[]")
+fi
+if printf '%s' "$PLAYGROUND_FILE_MOUNTS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+    while IFS= read -r mount_json; do
+        [ -n "$mount_json" ] || continue
+        mount_from=$(printf '%s' "$mount_json" | jq -r '.from // empty')
+        mount_to=$(printf '%s' "$mount_json" | jq -r '.to // empty')
+        mount_dependency=$(printf '%s' "$mount_json" | jq -r '.from_dependency // empty')
+        if [ -z "$mount_from" ] || [ -z "$mount_to" ] || [[ "$mount_from" = /* ]] || [[ "$mount_from" == *..* ]] || [[ "$mount_to" != /* ]]; then
+            echo "Error: playground_file_mounts entries require relative 'from' and absolute 'to' paths." >&2
+            FAILED_STEP="WP Codebox file mount setup"
+            exit 1
+        fi
+        mount_root="$PLUGIN_PATH"
+        if [ -n "$mount_dependency" ]; then
+            mount_root=""
+            if [ -n "$DEPENDENCY_PATHS" ]; then
+                while IFS= read -r dep_path; do
+                    [ -n "$dep_path" ] || continue
+                    dep_slug="$(homeboy_get_validation_dependency_slug "$dep_path" || basename "$dep_path")"
+                    if [ "$dep_slug" = "$mount_dependency" ] || [ "$(basename "$dep_path")" = "$mount_dependency" ]; then
+                        mount_root="$dep_path"
+                        break
+                    fi
+                done <<< "$DEPENDENCY_PATHS"
+            fi
+        fi
+        if [ -z "$mount_root" ]; then
+            echo "Error: playground_file_mounts dependency not found: $mount_dependency" >&2
+            FAILED_STEP="WP Codebox file mount setup"
+            exit 1
+        fi
+        mount_host="${mount_root}/${mount_from}"
+        if [ ! -f "$mount_host" ]; then
+            echo "Error: playground_file_mounts source file not found: $mount_host" >&2
+            FAILED_STEP="WP Codebox file mount setup"
+            exit 1
+        fi
+        MOUNT_ARGS+=("--mount" "${mount_host}:${mount_to}")
+    done < <(printf '%s' "$PLAYGROUND_FILE_MOUNTS_JSON" | jq -c '.[]')
+fi
+
+SHARED_STATE_HOST="${HOMEBOY_BENCH_SHARED_STATE:-}"
+if [ -n "$SHARED_STATE_HOST" ]; then
+    mkdir -p "$SHARED_STATE_HOST"
+    MOUNT_ARGS+=("--mount" "${SHARED_STATE_HOST}:/bench-shared-state")
+    BENCH_ENV_JSON=$(jq -nc --argjson env "$BENCH_ENV_JSON" --arg shared "/bench-shared-state" --arg instance "${HOMEBOY_BENCH_INSTANCE_ID:-0}" --arg concurrency "${HOMEBOY_BENCH_CONCURRENCY:-1}" '$env + {HOMEBOY_BENCH_SHARED_STATE: $shared, HOMEBOY_BENCH_INSTANCE_ID: $instance, HOMEBOY_BENCH_CONCURRENCY: $concurrency}')
+    WP_CONFIG_DEFINES_JSON=$(jq -nc --argjson defines "$WP_CONFIG_DEFINES_JSON" --arg shared "/bench-shared-state" --arg instance "${HOMEBOY_BENCH_INSTANCE_ID:-0}" --arg concurrency "${HOMEBOY_BENCH_CONCURRENCY:-1}" '$defines + {HOMEBOY_BENCH_SHARED_STATE: $shared, HOMEBOY_BENCH_INSTANCE_ID: $instance, HOMEBOY_BENCH_CONCURRENCY: $concurrency}')
+fi
+
+if ! homeboy_wordpress_emit_browser_target "$settings_json" "$SHARED_STATE_HOST" "$COMPONENT_ID" "$PLUGIN_SLUG" "fresh"; then
+    FAILED_STEP="Browser bench target setup"
+    exit 1
+fi
+
+BENCH_DIR="${PLUGIN_PATH}/tests/bench"
+if [ ! -d "$BENCH_DIR" ] && ! printf '%s' "$PLAYGROUND_WORKLOADS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+    echo "Warning: No bench workloads found for ${PLUGIN_PATH}" >&2
+    if [ -n "${HOMEBOY_BENCH_RESULTS_FILE:-}" ]; then
+        homeboy_write_empty_bench_results "$COMPONENT_ID" 0 "$RESULTS_FILE"
+        homeboy_wordpress_emit_playground_results_artifacts "$RESULTS_FILE"
+    fi
+    exit 0
+fi
+
 echo "Running bench workloads via WP Codebox..."
 echo "  Plugin: ${PLUGIN_SLUG} (${PLUGIN_PATH})"
 echo "  Backend: wp-codebox (WordPress Playground runtime)"
@@ -95,6 +204,11 @@ set +e
     --component "$PLUGIN_PATH" \
     --component-id "$COMPONENT_ID" \
     --plugin-slug "$PLUGIN_SLUG" \
+    "${DEPENDENCY_ARGS[@]}" \
+    "${MOUNT_ARGS[@]}" \
+    --env-json "$BENCH_ENV_JSON" \
+    --wp-config-defines-json "$WP_CONFIG_DEFINES_JSON" \
+    --workloads-json "$PLAYGROUND_WORKLOADS_JSON" \
     --iterations "$ITERATIONS" \
     --warmup "$WARMUP_ITERATIONS" \
     --wp "$PLAYGROUND_WORDPRESS_VERSION" \

--- a/wordpress/scripts/bench/bench-runner.sh
+++ b/wordpress/scripts/bench/bench-runner.sh
@@ -1,15 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Bench runner router for WordPress Homeboy extension.
+# Bench runner entrypoint for WordPress Homeboy extension.
 #
-# Basic in-tree bench workloads run through WP Codebox by default. More complex
-# bench features still dispatch to the legacy direct Playground runner until
-# their WP Codebox equivalents land under #698.
-#
-# This entry script resolves execution context and dispatches to the selected
-# bench runner. Bash 4.0+ required (matches test-runner.sh's gate so bench
-# inherits the same surface).
+# Bench workloads run through WP Codebox so WordPress runtime behavior uses the
+# same sandbox/artifact contract as tests and agent CI.
 
 if ((BASH_VERSINFO[0] < 4)); then
     echo "============================================" >&2
@@ -28,42 +23,4 @@ if ((BASH_VERSINFO[0] < 4)); then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# Resolve execution context. When invoked through homeboy core the env
-# vars are pre-set; when invoked directly (e.g. via composer or
-# `bash scripts/bench/bench-runner.sh`) we synthesize them from CWD so the
-# runner can mount the right paths.
-RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
-# shellcheck source=/dev/null
-source "$RESOLVE_CONTEXT_HELPER"
-homeboy_resolve_context --component-alias PLUGIN_PATH
-
-if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
-    echo "DEBUG: [bench] Extension path: $EXTENSION_PATH"
-    echo "DEBUG: [bench] Component: ${HOMEBOY_COMPONENT_ID:-none}"
-    echo "DEBUG: [bench] Component path: ${COMPONENT_PATH:-$(pwd)}"
-fi
-
-settings_json="${HOMEBOY_SETTINGS_JSON:-}"
-[ -n "$settings_json" ] || settings_json="{}"
-
-requires_legacy_playground=0
-if printf '%s' "$settings_json" | jq -e '
-    ((.playground_workloads // []) | length > 0)
-    or ((.playground_scenario_manifests // .scenario_manifests // []) | length > 0)
-    or ((.playground_file_mounts // []) | length > 0)
-    or ((.wp_config_defines // {}) | length > 0)
-    or ((.bench_env // {}) | length > 0)
-    or ((.playground_blueprint // {}) | length > 0)
-    or ((.bench_site_mode // "fresh") == "installed")
-    or ((.bench_browser_target // {}) | length > 0)
-' >/dev/null 2>&1; then
-    requires_legacy_playground=1
-fi
-
-if [ "$requires_legacy_playground" -eq 1 ]; then
-    echo "Notice: dispatching to legacy Playground bench runner for unsupported WP Codebox bench features." >&2
-    exec bash "${SCRIPT_DIR}/bench-runner-playground.sh" "$@"
-fi
-
 exec bash "${SCRIPT_DIR}/bench-runner-wp-codebox.sh" "$@"


### PR DESCRIPTION
## Summary
- Route WordPress bench settings through `wp-codebox bench-run` instead of falling back to the legacy direct Playground bench runner.
- Map validation dependencies, file mounts, `bench_env`, `wp_config_defines`, configured workloads, shared state, and browser handoff metadata onto WP Codebox inputs.
- Fail fast for remaining bootstrap-only Playground settings (`playground_blueprint`, scenario manifests, `bench_site_mode=installed`) so unsupported contracts are explicit rather than hidden behind a second runtime.

## Verification
- `npm run check` in `chubes4/wp-codebox` PR #74 worktree
- `bash -n wordpress/scripts/bench/bench-runner.sh && bash -n wordpress/scripts/bench/bench-runner-wp-codebox.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@followup-bench-runtime-command/packages/cli/dist/index.js bash wordpress/scripts/bench/wp-codebox-bench-smoke.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@followup-bench-runtime-command/packages/cli/dist/index.js bash wordpress/scripts/bench/wp-codebox-bench-custom-metrics-smoke.sh`
- Manual direct runner checks for configured `playground_workloads`, `bench_env` + shared-state constants, and `wp_config_defines` using the local WP Codebox PR #74 build.

## Related
- Advances #698.
- Follows chubes4/wp-codebox#74 for the extended `bench-run` input contract.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the bench runner wiring, upstream WP Codebox contract changes, smoke verification, and documentation updates; Chris remains responsible for review and testing.