### PR TITLE
Generate WP Codebox recipes for WordPress bench

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -80,7 +80,8 @@ Each dependency entry may be either:
 WordPress bench runs can declare Playground workloads in extension settings when
 the workload should be configured by the repo instead of living under
 `tests/bench/*.php`. Configured workloads run after the existing Playground
-bootstrap, `playground_blueprint`, dependency mounts, and component load.
+bootstrap, `playground_blueprint`, dependency mounts, and component load through
+a generated WP Codebox recipe.
 
 ```json
 {
@@ -347,7 +348,7 @@ for the dedicated agent sandbox guide.
 
 Repos can declare first-class scenario manifests and let the WordPress runner
 compile them into `playground_workloads`. This keeps eval/RL-style scenarios on
-the existing Playground bench execution path instead of adding a second runner.
+the WP Codebox recipe execution path instead of adding a second runner.
 
 ```json
 {
@@ -392,8 +393,7 @@ Supported fields:
 - `prompt` or `prompt_file`: prompt text is copied into scenario metadata. File
   references resolve relative to the manifest file.
 - `blueprint` or `blueprint_file`: inline object or JSON file passed to
-  Playground as the run blueprint. Multiple manifests in one run must use the
-  same blueprint because the existing Playground process boots once.
+  WP Codebox as part of the generated recipe runtime blueprint.
 - `run`: existing `playground_workloads` steps for the model or agent action
   loop. The supported step types are still `php`, `ability`, and `wp-cli`.
 - `grader` or `grader_file`: PHP file appended after `run`, so grading happens

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -248,14 +248,15 @@ runtime, component mount, command execution, and artifacts, and emits the same
 Each file under `tests/bench/*.php` returns a callable. The callable may return
 numeric metrics directly or `{metrics, metadata, artifacts}`. Components may
 also declare configured workloads via `playground_workloads`; the WordPress
-runner maps those declarations onto `wp-codebox bench-run` inputs alongside
+runner maps those declarations into a temporary WP Codebox recipe alongside
 `validation_dependencies`, `playground_file_mounts`, `wp_config_defines`,
 `bench_env`, shared-state mounts, and browser handoff descriptors.
 
-Bootstrap-only Playground features no longer fall back to the legacy runner. A
-component that still relies on `playground_blueprint`, scenario manifests, or
-`bench_site_mode=installed` fails fast so the missing WP Codebox contract can be
-ported explicitly instead of hiding behind a second runtime.
+The generated recipe is the single WP Codebox entry point for benchmarks:
+`playground_blueprint` becomes `runtime.blueprint`, dependencies become recipe
+plugin inputs, and scenario manifests compile into configured workloads.
+`bench_site_mode=installed` still fails fast until WP Codebox has an explicit
+persisted-site recipe contract.
 
 The browser bench target is a two-extension handoff: the WordPress
 extension prepares/describes the WordPress target by writing
@@ -343,8 +344,8 @@ Configure per-component in the component's homeboy/component config under
 | `user` | string | `""` | WP-CLI user (email/login/ID); appended as `--user` when set |
 | `wp_config_defines` | object | `{}` | `CONSTANT_NAME => value` map appended to the runtime `wp-tests-config.php`; PHP type preserved via `var_export` |
 | `bench_env` | object | `{}` | `NAME => value` env vars forwarded into the runtime (workloads/fixtures read via `getenv()`) |
-| `playground_blueprint` | object | `{}` | Reserved for cold-boot scenarios; current WP Codebox bench runner fails fast when set |
-| `playground_workloads` | array | `[]` | Declared bench workloads passed to `wp-codebox bench-run` after deps and component load |
+| `playground_blueprint` | object | `{}` | Runtime blueprint merged into the generated WP Codebox bench recipe |
+| `playground_workloads` | array | `[]` | Declared bench workloads passed to `wordpress.bench` through the generated recipe after deps and component load |
 | `playground_file_mounts` | array | `[]` | Files from the component or validation dependencies mounted into explicit WordPress runtime paths |
 | `bench_site_mode` | string | `fresh` | `fresh` uses a disposable WP Codebox site; `installed` currently fails fast until a WP Codebox persisted-site contract lands |
 | `bench_browser_target` | object | `{}` | Browser bench target descriptor (see Bench runner above) |

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -61,12 +61,172 @@ fi
 settings_json="${HOMEBOY_SETTINGS_JSON:-}"
 [ -n "$settings_json" ] || settings_json="{}"
 
-if printf '%s' "$settings_json" | jq -e '((.playground_blueprint // {}) | length > 0) or ((.playground_scenario_manifests // .scenario_manifests // []) | length > 0) or ((.bench_site_mode // "fresh") == "installed")' >/dev/null 2>&1; then
-    echo "Error: this bench configuration uses Playground-only bootstrap features that no longer dispatch to the legacy runner." >&2
-    echo "       Port the setting to wp-codebox first: playground_blueprint, scenario manifests, or bench_site_mode=installed." >&2
+if printf '%s' "$settings_json" | jq -e '((.bench_site_mode // "fresh") == "installed")' >/dev/null 2>&1; then
+    echo "Error: bench_site_mode=installed requires a persisted-site WP Codebox recipe contract." >&2
     FAILED_STEP="WP Codebox bench configuration"
     exit 1
 fi
+
+homeboy_wp_codebox_resolve_host_path() {
+    local base_dir="$1"
+    local path_value="$2"
+    if [[ "$path_value" = /* ]]; then
+        printf '%s\n' "$path_value"
+    else
+        printf '%s\n' "${base_dir}/${path_value}"
+    fi
+}
+
+homeboy_wp_codebox_component_relative_path() {
+    local host_path="$1"
+    if [[ "$host_path" = "$PLUGIN_PATH"/* ]]; then
+        printf '%s\n' "${host_path#"$PLUGIN_PATH/"}"
+    else
+        echo "Error: scenario manifest file references must stay under component root: $host_path" >&2
+        FAILED_STEP="Scenario manifest setup"
+        exit 1
+    fi
+}
+
+homeboy_wp_codebox_compile_scenario_manifests() {
+    local entries_json
+    entries_json=$(printf '%s' "$settings_json" | jq -c '
+        .playground_scenario_manifests // .scenario_manifests // []
+        | if type == "array" then . elif type == "string" or type == "object" then [.] else [] end
+    ' 2>/dev/null || echo '[]')
+
+    SCENARIO_MANIFEST_WORKLOADS_JSON="[]"
+    SCENARIO_MANIFEST_BLUEPRINT_JSON="{}"
+    if ! printf '%s' "$entries_json" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+        return 0
+    fi
+
+    local index=0
+    while IFS= read -r manifest_entry; do
+        [ -n "$manifest_entry" ] || continue
+        local entry_type manifest_json manifest_host manifest_dir manifest_rel
+        entry_type=$(printf '%s' "$manifest_entry" | jq -r 'type')
+        manifest_dir="$PLUGIN_PATH"
+        manifest_rel=""
+        if [ "$entry_type" = "string" ]; then
+            local manifest_ref
+            manifest_ref=$(printf '%s' "$manifest_entry" | jq -r '.')
+            manifest_host=$(homeboy_wp_codebox_resolve_host_path "$PLUGIN_PATH" "$manifest_ref")
+            if [ ! -f "$manifest_host" ]; then
+                echo "Error: scenario manifest not found: $manifest_host" >&2
+                FAILED_STEP="Scenario manifest setup"
+                exit 1
+            fi
+            manifest_dir=$(dirname "$manifest_host")
+            manifest_rel=$(homeboy_wp_codebox_component_relative_path "$manifest_host")
+            manifest_json=$(jq -c '.' "$manifest_host")
+        elif [ "$entry_type" = "object" ]; then
+            manifest_json=$(printf '%s' "$manifest_entry" | jq -c '.')
+        else
+            echo "Error: playground_scenario_manifests[$index] must be a path string or object" >&2
+            FAILED_STEP="Scenario manifest setup"
+            exit 1
+        fi
+
+        local prompt prompt_file_ref prompt_file_host prompt_file_rel
+        prompt=$(printf '%s' "$manifest_json" | jq -r 'if (.prompt? | type) == "string" then .prompt else empty end')
+        prompt_file_ref=$(printf '%s' "$manifest_json" | jq -r 'if ((.prompt_file? // .prompt_path?) | type) == "string" then (.prompt_file // .prompt_path) else empty end')
+        prompt_file_rel=""
+        if [ -z "$prompt" ] && [ -n "$prompt_file_ref" ]; then
+            prompt_file_host=$(homeboy_wp_codebox_resolve_host_path "$manifest_dir" "$prompt_file_ref")
+            if [ ! -f "$prompt_file_host" ]; then
+                echo "Error: scenario prompt file not found: $prompt_file_host" >&2
+                FAILED_STEP="Scenario manifest setup"
+                exit 1
+            fi
+            prompt=$(<"$prompt_file_host")
+            prompt_file_rel=$(homeboy_wp_codebox_component_relative_path "$prompt_file_host")
+        fi
+
+        local blueprint_json blueprint_ref blueprint_host blueprint_rel
+        blueprint_json="{}"
+        blueprint_rel=""
+        if printf '%s' "$manifest_json" | jq -e '(.blueprint? | type) == "object"' >/dev/null 2>&1; then
+            blueprint_json=$(printf '%s' "$manifest_json" | jq -c '.blueprint')
+        else
+            blueprint_ref=$(printf '%s' "$manifest_json" | jq -r 'if ((.blueprint? // .blueprint_file?) | type) == "string" then (.blueprint // .blueprint_file) else empty end')
+            if [ -n "$blueprint_ref" ]; then
+                blueprint_host=$(homeboy_wp_codebox_resolve_host_path "$manifest_dir" "$blueprint_ref")
+                if [ ! -f "$blueprint_host" ]; then
+                    echo "Error: scenario blueprint file not found: $blueprint_host" >&2
+                    FAILED_STEP="Scenario manifest setup"
+                    exit 1
+                fi
+                blueprint_json=$(jq -c '.' "$blueprint_host")
+                blueprint_rel=$(homeboy_wp_codebox_component_relative_path "$blueprint_host")
+            fi
+        fi
+        if printf '%s' "$blueprint_json" | jq -e 'length > 0' >/dev/null 2>&1; then
+            SCENARIO_MANIFEST_BLUEPRINT_JSON=$(jq -nc --argjson base "$SCENARIO_MANIFEST_BLUEPRINT_JSON" --argjson next "$blueprint_json" '
+                ($base + $next) | .steps = (($base.steps // []) + ($next.steps // []))
+            ')
+        fi
+
+        local grader_ref grader_host grader_rel run_json
+        grader_ref=$(printf '%s' "$manifest_json" | jq -r 'if ((.grader? // .grader_file?) | type) == "string" then (.grader // .grader_file) else empty end')
+        grader_rel=""
+        if [ -n "$grader_ref" ]; then
+            grader_host=$(homeboy_wp_codebox_resolve_host_path "$manifest_dir" "$grader_ref")
+            if [ ! -f "$grader_host" ]; then
+                echo "Error: scenario grader file not found: $grader_host" >&2
+                FAILED_STEP="Scenario manifest setup"
+                exit 1
+            fi
+            grader_rel=$(homeboy_wp_codebox_component_relative_path "$grader_host")
+        fi
+
+        run_json=$(printf '%s' "$manifest_json" | jq -c 'if (.run? | type) == "array" then .run else [] end')
+        if [ -n "$grader_rel" ]; then
+            run_json=$(jq -nc --argjson run "$run_json" --arg grader "$grader_rel" '$run + [{type: "php", file: $grader}]')
+        fi
+        if ! printf '%s' "$run_json" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+            echo "Error: scenario manifest requires run steps or a grader PHP file" >&2
+            FAILED_STEP="Scenario manifest setup"
+            exit 1
+        fi
+
+        local workload_json
+        workload_json=$(jq -nc \
+            --argjson manifest "$manifest_json" \
+            --argjson run "$run_json" \
+            --arg prompt "$prompt" \
+            --arg manifestFile "$manifest_rel" \
+            --arg promptFile "$prompt_file_rel" \
+            --arg blueprintFile "$blueprint_rel" \
+            --arg graderFile "$grader_rel" \
+            '($manifest.metadata // {}) as $metadata |
+            {
+                id: ($manifest.id // $manifest.label),
+                label: $manifest.label,
+                run: $run,
+                tags: ($manifest.tags // []),
+                artifacts: ($manifest.artifacts // {}),
+                metadata: ($metadata + {
+                    scenario_manifest: $manifestFile,
+                    prompt: $prompt,
+                    prompt_file: $promptFile,
+                    blueprint_file: $blueprintFile,
+                    grader_file: $graderFile,
+                    limits: ($manifest.limits // {}),
+                    rules: ($manifest.rules // {}),
+                    general_rules: ($manifest.general_rules // $manifest.rules.general // []),
+                    task_rules: ($manifest.task_rules // $manifest.rules.task_specific // []),
+                    probes: ($manifest.probes // {})
+                })
+            }
+            | if .label == null then del(.label) else . end
+            | .metadata |= with_entries(select(.value != "" and .value != {}))')
+        SCENARIO_MANIFEST_WORKLOADS_JSON=$(jq -nc --argjson workloads "$SCENARIO_MANIFEST_WORKLOADS_JSON" --argjson workload "$workload_json" '$workloads + [$workload]')
+        index=$((index + 1))
+    done < <(printf '%s' "$entries_json" | jq -c '.[]')
+}
+
+homeboy_wp_codebox_compile_scenario_manifests
 
 PLAYGROUND_WORDPRESS_VERSION="7.0"
 if [ "$settings_json" != "{}" ]; then
@@ -111,20 +271,23 @@ if [ "$settings_json" != "{}" ]; then
     BENCH_ENV_JSON=$(printf '%s' "$settings_json" | jq -c '.bench_env // {}' 2>/dev/null || echo "{}")
     PLAYGROUND_WORKLOADS_JSON=$(printf '%s' "$settings_json" | jq -c '.playground_workloads // []' 2>/dev/null || echo "[]")
 fi
+PLAYGROUND_WORKLOADS_JSON=$(jq -nc --argjson declared "$PLAYGROUND_WORKLOADS_JSON" --argjson scenarios "$SCENARIO_MANIFEST_WORKLOADS_JSON" '$declared + $scenarios')
 
-MOUNT_ARGS=()
-DEPENDENCY_ARGS=()
+EXTRA_PLUGINS_JSON=$(jq -nc --arg source "$PLUGIN_PATH" --arg slug "$PLUGIN_SLUG" '[{source: $source, slug: $slug, activate: false}]')
+MOUNTS_JSON="[]"
+DEPENDENCY_SLUGS=()
 if [ -n "$DEPENDENCY_PATHS" ]; then
     while IFS= read -r dep_path; do
         [ -n "$dep_path" ] || continue
         dep_slug="$(homeboy_get_validation_dependency_slug "$dep_path" || basename "$dep_path")"
-        DEPENDENCY_ARGS+=("--dependency" "${dep_path}:${dep_slug}")
+        DEPENDENCY_SLUGS+=("$dep_slug")
+        EXTRA_PLUGINS_JSON=$(jq -nc --argjson plugins "$EXTRA_PLUGINS_JSON" --arg source "$dep_path" --arg slug "$dep_slug" '$plugins + [{source: $source, slug: $slug, activate: false}]')
     done <<< "$DEPENDENCY_PATHS"
 fi
 
 PLUGIN_DB_PHP="${PLUGIN_PATH}/db.php"
 if [ -f "$PLUGIN_DB_PHP" ]; then
-    MOUNT_ARGS+=("--mount" "${PLUGIN_DB_PHP}:/wordpress/wp-content/db.php")
+    MOUNTS_JSON=$(jq -nc --argjson mounts "$MOUNTS_JSON" --arg source "$PLUGIN_DB_PHP" '$mounts + [{source: $source, target: "/wordpress/wp-content/db.php", mode: "readonly"}]')
 fi
 
 PLAYGROUND_FILE_MOUNTS_JSON="[]"
@@ -167,14 +330,14 @@ if printf '%s' "$PLAYGROUND_FILE_MOUNTS_JSON" | jq -e 'type == "array" and lengt
             FAILED_STEP="WP Codebox file mount setup"
             exit 1
         fi
-        MOUNT_ARGS+=("--mount" "${mount_host}:${mount_to}")
+        MOUNTS_JSON=$(jq -nc --argjson mounts "$MOUNTS_JSON" --arg source "$mount_host" --arg target "$mount_to" '$mounts + [{source: $source, target: $target, mode: "readonly"}]')
     done < <(printf '%s' "$PLAYGROUND_FILE_MOUNTS_JSON" | jq -c '.[]')
 fi
 
 SHARED_STATE_HOST="${HOMEBOY_BENCH_SHARED_STATE:-}"
 if [ -n "$SHARED_STATE_HOST" ]; then
     mkdir -p "$SHARED_STATE_HOST"
-    MOUNT_ARGS+=("--mount" "${SHARED_STATE_HOST}:/bench-shared-state")
+    MOUNTS_JSON=$(jq -nc --argjson mounts "$MOUNTS_JSON" --arg source "$SHARED_STATE_HOST" '$mounts + [{source: $source, target: "/bench-shared-state", mode: "readwrite"}]')
     BENCH_ENV_JSON=$(jq -nc --argjson env "$BENCH_ENV_JSON" --arg shared "/bench-shared-state" --arg instance "${HOMEBOY_BENCH_INSTANCE_ID:-0}" --arg concurrency "${HOMEBOY_BENCH_CONCURRENCY:-1}" '$env + {HOMEBOY_BENCH_SHARED_STATE: $shared, HOMEBOY_BENCH_INSTANCE_ID: $instance, HOMEBOY_BENCH_CONCURRENCY: $concurrency}')
     WP_CONFIG_DEFINES_JSON=$(jq -nc --argjson defines "$WP_CONFIG_DEFINES_JSON" --arg shared "/bench-shared-state" --arg instance "${HOMEBOY_BENCH_INSTANCE_ID:-0}" --arg concurrency "${HOMEBOY_BENCH_CONCURRENCY:-1}" '$defines + {HOMEBOY_BENCH_SHARED_STATE: $shared, HOMEBOY_BENCH_INSTANCE_ID: $instance, HOMEBOY_BENCH_CONCURRENCY: $concurrency}')
 fi
@@ -198,20 +361,68 @@ echo "Running bench workloads via WP Codebox..."
 echo "  Plugin: ${PLUGIN_SLUG} (${PLUGIN_PATH})"
 echo "  Backend: wp-codebox (WordPress Playground runtime)"
 
+DEPENDENCY_SLUGS_CSV=""
+if [ ${#DEPENDENCY_SLUGS[@]} -gt 0 ]; then
+    DEPENDENCY_SLUGS_CSV=$(IFS=,; printf '%s' "${DEPENDENCY_SLUGS[*]}")
+fi
+
+PLAYGROUND_BLUEPRINT_JSON="{}"
+if [ "$settings_json" != "{}" ]; then
+    PLAYGROUND_BLUEPRINT_JSON=$(printf '%s' "$settings_json" | jq -c '.playground_blueprint // {}' 2>/dev/null || echo "{}")
+fi
+RUNTIME_BLUEPRINT_JSON=$(jq -nc \
+    --argjson base "$PLAYGROUND_BLUEPRINT_JSON" \
+    --argjson scenario "$SCENARIO_MANIFEST_BLUEPRINT_JSON" \
+    --argjson defines "$WP_CONFIG_DEFINES_JSON" '
+    ($base + $scenario) as $merged |
+    ($merged.steps // []) as $steps |
+    if ($defines | length) > 0 then
+        $merged + {steps: ($steps + [{step: "defineWpConfigConsts", consts: $defines}])}
+    else
+        $merged + {steps: $steps}
+    end
+')
+
+WORKFLOW_STEP_JSON=$(jq -nc \
+    --arg component "$COMPONENT_ID" \
+    --arg slug "$PLUGIN_SLUG" \
+    --arg iterations "$ITERATIONS" \
+    --arg warmup "$WARMUP_ITERATIONS" \
+    --arg dependencySlugs "$DEPENDENCY_SLUGS_CSV" \
+    --argjson env "$BENCH_ENV_JSON" \
+    --argjson workloads "$PLAYGROUND_WORKLOADS_JSON" '
+    {
+        command: "wordpress.bench",
+        args: [
+            "component-id=" + $component,
+            "plugin-slug=" + $slug,
+            "iterations=" + $iterations,
+            "warmup=" + $warmup,
+            "dependency-slugs=" + $dependencySlugs,
+            "env-json=" + ($env | tostring),
+            "workloads-json=" + ($workloads | tostring)
+        ]
+    }
+')
+
+RECIPE_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-bench-recipe.XXXXXX")
+jq -n \
+    --arg wp "$PLAYGROUND_WORDPRESS_VERSION" \
+    --argjson blueprint "$RUNTIME_BLUEPRINT_JSON" \
+    --argjson extraPlugins "$EXTRA_PLUGINS_JSON" \
+    --argjson mounts "$MOUNTS_JSON" \
+    --argjson step "$WORKFLOW_STEP_JSON" \
+    '{
+        schema: "wp-codebox/workspace-recipe/v1",
+        runtime: {wp: $wp, blueprint: $blueprint},
+        inputs: {extraPlugins: $extraPlugins, mounts: $mounts},
+        workflow: {steps: [$step]}
+    }' > "$RECIPE_FILE"
+
 WP_CODEBOX_TMPFILE=$(mktemp)
 set +e
-"${wp_codebox_command[@]}" bench-run \
-    --component "$PLUGIN_PATH" \
-    --component-id "$COMPONENT_ID" \
-    --plugin-slug "$PLUGIN_SLUG" \
-    "${DEPENDENCY_ARGS[@]}" \
-    "${MOUNT_ARGS[@]}" \
-    --env-json "$BENCH_ENV_JSON" \
-    --wp-config-defines-json "$WP_CONFIG_DEFINES_JSON" \
-    --workloads-json "$PLAYGROUND_WORKLOADS_JSON" \
-    --iterations "$ITERATIONS" \
-    --warmup "$WARMUP_ITERATIONS" \
-    --wp "$PLAYGROUND_WORDPRESS_VERSION" \
+"${wp_codebox_command[@]}" recipe-run \
+    --recipe "$RECIPE_FILE" \
     --artifacts "$ARTIFACTS_DIR" \
     --json \
     > "$WP_CODEBOX_TMPFILE" 2>&1
@@ -236,3 +447,4 @@ jq '.benchResults' "$WP_CODEBOX_TMPFILE" > "$RESULTS_FILE"
 homeboy_wordpress_emit_bench_results_artifacts "$RESULTS_FILE"
 
 rm -f "$WP_CODEBOX_TMPFILE"
+rm -f "$RECIPE_FILE"

--- a/wordpress/scripts/bench/wp-codebox-bench-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-smoke.sh
@@ -12,7 +12,7 @@
 #
 # Manual integration test, not part of CI. Run after changes to:
 #   - bench-runner-wp-codebox.sh
-#   - wp-codebox bench-run / wordpress.bench
+#   - wp-codebox recipe-run / wordpress.bench
 #
 # Usage: bash wordpress/scripts/bench/wp-codebox-bench-smoke.sh
 # Exit:  0 = harness round-trips end-to-end, non-zero = regression

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -866,21 +866,21 @@
       "label": "Playground blueprint",
       "type": "object",
       "default": {},
-      "description": "Reserved cold-boot scenario blueprint setting. The WP Codebox bench runner currently fails fast when this is set so cold-boot support can be ported explicitly. Empty object means stock WordPress."
+      "description": "Runtime blueprint merged into the generated WP Codebox bench recipe. Empty object means stock WordPress."
     },
     {
       "id": "playground_workloads",
       "label": "Bench workloads",
       "type": "array",
       "default": [],
-      "description": "Config-declared WordPress bench workloads passed to wp-codebox bench-run after dependency mounts and component load. Each workload declares an id, optional label, run steps ({type: 'php', code|file}, {type: 'ability', ability|name, input}, or {type: 'wp-cli', command}), and optional metrics/artifacts/metadata. Step returns use the same {metrics, artifacts, metadata} shape as Node.js bench workloads."
+      "description": "Config-declared WordPress bench workloads passed to wordpress.bench through the generated WP Codebox recipe after dependency mounts and component load. Each workload declares an id, optional label, run steps ({type: 'php', code|file}, {type: 'ability', ability|name, input}, or {type: 'wp-cli', command}), and optional metrics/artifacts/metadata. Step returns use the same {metrics, artifacts, metadata} shape as Node.js bench workloads."
     },
     {
       "id": "playground_scenario_manifests",
       "label": "Playground scenario manifests",
       "type": "array",
       "default": [],
-      "description": "Reserved scenario manifest setting. The WP Codebox bench runner currently fails fast when manifests are set so manifest compilation can be ported explicitly instead of falling back to a second runtime."
+      "description": "Scenario manifest files or inline objects compiled into wordpress.bench workloads in the generated WP Codebox recipe. Prompt, blueprint, grader, rules, tags, limits, and metadata are preserved in BenchResults metadata."
     },
     {
       "id": "bench_site_mode",


### PR DESCRIPTION
## Summary
- Generate temporary WP Codebox recipes for WordPress bench runs instead of calling the removed `bench-run` convenience command.
- Map `playground_blueprint`, validation dependencies, file mounts, shared state, env, wp-config defines, and configured workloads into the recipe.
- Compile `playground_scenario_manifests` into `wordpress.bench` workloads so wp-gym-style corpora run on the WP Codebox recipe path.

Depends on chubes4/wp-codebox#75.

## Verification
- `bash -n wordpress/scripts/bench/bench-runner-wp-codebox.sh wordpress/scripts/bench/bench-runner.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@recipe-entrypoint/packages/cli/dist/index.js bash wordpress/scripts/bench/wp-codebox-bench-smoke.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@recipe-entrypoint/packages/cli/dist/index.js bash wordpress/scripts/bench/wp-codebox-bench-custom-metrics-smoke.sh`
- Direct wp-gym verification with current `homeboy.json` settings, including `playground_blueprint` and `playground_scenario_manifests`, produced a BenchResults envelope through the recipe runner.
- `jq empty wordpress/wordpress.json wordpress/homeboy.json`
- `git diff --check`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@recipe-bench-runner/wordpress --extension wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Homeboy recipe adapter, restored scenario-manifest execution on WP Codebox, updated docs, and ran local verification; Chris directed the architecture and remains responsible for review.