### PR TITLE
Pass app token to runner workspace clones

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -2123,12 +2123,18 @@ if ( ! function_exists( 'homeboy_datamachine_agent_provision_workspace' ) ) {
                 return array( 'enabled' => true, 'success' => false, 'error' => 'workspace primary missing and runner_workspace.clone_url is empty' );
             }
 
+            $clone_input = array(
+                'url'  => $clone_url,
+                'name' => $repo,
+            );
+            $github_token_env = homeboy_datamachine_agent_scalar( $config, 'github_token_env', 'GITHUB_TOKEN' );
+            if ( '' !== $github_token_env && '' !== trim( (string) getenv( $github_token_env ) ) && preg_match( '#^https://github\.com/#', $clone_url ) ) {
+                $clone_input['auth_token_env'] = $github_token_env;
+            }
+
             $clone = wp_get_ability( 'datamachine/workspace-clone' )->execute(
                 array_filter(
-                    array(
-                        'url'  => $clone_url,
-                        'name' => $repo,
-                    ),
+                    $clone_input,
                     static fn( $value ) => '' !== $value
                 )
             );


### PR DESCRIPTION
## Summary
- Passes the runner's configured GitHub token environment through to `workspace-clone` for GitHub HTTPS runner workspaces.
- Lets Data Machine Agent CI clone private target repositories without storing tokens in remotes.

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the docs-agent private repository clone failure and drafting the runner workspace token plumbing; Chris remains responsible for review and testing.