### PR TITLE
Normalize WP Codebox bench results for Homeboy

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -442,7 +442,7 @@ if ! jq -e '.success == true and (.benchResults | type == "object")' "$WP_CODEBO
 fi
 
 mkdir -p "$(dirname "$RESULTS_FILE")"
-jq '.benchResults' "$WP_CODEBOX_TMPFILE" > "$RESULTS_FILE"
+jq '.benchResults | del(.warmup_iterations)' "$WP_CODEBOX_TMPFILE" > "$RESULTS_FILE"
 
 homeboy_wordpress_emit_bench_results_artifacts "$RESULTS_FILE"
 


### PR DESCRIPTION
## Summary
- Strip WP Codebox-only `warmup_iterations` before writing Homeboy BenchResults JSON.
- Keeps the recipe-backed bench runner output compatible with Homeboy core's persisted bench schema.

## Verification
- `bash -n wordpress/scripts/bench/bench-runner-wp-codebox.sh wordpress/scripts/bench/bench-runner.sh`
- `bash wordpress/scripts/bench/wp-codebox-bench-smoke.sh`
- `bash wordpress/scripts/bench/wp-codebox-bench-custom-metrics-smoke.sh`
- `homeboy bench --path /Users/chubes/Developer/wp-gym --extension wordpress --iterations 1`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@recipe-bench-runner/wordpress/tests/fixtures/playground-schema-scope --extension wordpress -- --file tests/SchemaScopeRunsTest.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the Homeboy BenchResults schema mismatch, applying the normalization fix, and running verification. Chris remains responsible for review and merge.