### PR TITLE
Use WP Codebox PHPUnit recipe command

### DIFF
--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -414,7 +414,7 @@ jq -n \
         schema: "wp-codebox/workspace-recipe/v1",
         runtime: {wp: $wp, blueprint: {steps: []}},
         inputs: {mounts: $mounts},
-        workflow: {steps: [{command: "wordpress.run-php", args: ["code-file=" + $codeFile, "bootstrap=none"]}]}
+        workflow: {steps: [{command: "wordpress.phpunit", args: ["code-file=" + $codeFile]}]}
     }' > "$RECIPE_FILE"
 
 set +e


### PR DESCRIPTION
## Summary
- Update the WordPress PHPUnit recipe generated by Homeboy to use `wordpress.phpunit` instead of low-level `wordpress.run-php`.
- Preserve the existing mounted runner artifact and output parsing contract.
- Keeps Homeboy aligned with the first-class WP Codebox command seam for test execution.

## Verification
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@recipe-entrypoint/packages/cli/dist/index.js homeboy test --path /Users/chubes/Developer/homeboy-extensions@recipe-bench-runner/wordpress/tests/fixtures/playground-schema-scope --extension wordpress -- --file tests/SchemaScopeRunsTest.php`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@recipe-entrypoint/packages/cli/dist/index.js bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@recipe-entrypoint/packages/cli/dist/index.js bash wordpress/scripts/bench/wp-codebox-bench-smoke.sh`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@recipe-entrypoint/packages/cli/dist/index.js homeboy bench --path /Users/chubes/Developer/wp-gym --extension wordpress --iterations 1`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@recipe-bench-runner/wordpress --extension wordpress`
- `git diff --check`

## Dependency
- Requires https://github.com/chubes4/wp-codebox/pull/76 for `wordpress.phpunit`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updating the Homeboy recipe step to the new WP Codebox command and running verification. Chris remains responsible for review and merge.