### PR TITLE
fix(wordpress): pass phpunit wrapper host path

### DIFF
--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -352,6 +352,32 @@ fi
 RESULT_FILE="${PLUGIN_PATH}/.pg-test-result.txt"
 rm -f "$RESULT_FILE"
 
+TEMPLATE="${SCRIPT_DIR}/playground-runner.php"
+if [ ! -f "$TEMPLATE" ]; then
+    echo "Error: playground-runner.php template not found at $TEMPLATE" >&2
+    FAILED_STEP="WP Codebox setup"
+    exit 1
+fi
+
+WRAPPER_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/wp-codebox-runner.XXXXXX")
+WRAPPER_RUNTIME_PATH="/homeboy-wp-codebox-runner.php"
+WP_CONFIG_DEFINES_DELIM=$(printf '\1')
+json_to_base64() {
+    printf '%s' "$1" | base64 | tr -d '\n'
+}
+WP_CONFIG_DEFINES_JSON_B64=$(json_to_base64 "$WP_CONFIG_DEFINES_JSON")
+BENCH_ENV_JSON_B64=$(json_to_base64 "$BENCH_ENV_JSON")
+CHANGED_TEST_FILES_JSON_B64=$(json_to_base64 "$CHANGED_TEST_FILES_JSON")
+
+sed \
+    -e "s|{{PLUGIN_SLUG}}|${PLUGIN_SLUG}|g" \
+    -e "s|{{PLAYGROUND_DEP_MOUNTS}}|${PLAYGROUND_DEP_MOUNTS}|g" \
+    -e "s|{{PHPUNIT_TEST_FILE_B64}}|${SELECTED_TEST_FILE_B64}|g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{WP_CONFIG_DEFINES_JSON_B64}}${WP_CONFIG_DEFINES_DELIM}${WP_CONFIG_DEFINES_JSON_B64}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{BENCH_ENV_JSON_B64}}${WP_CONFIG_DEFINES_DELIM}${BENCH_ENV_JSON_B64}${WP_CONFIG_DEFINES_DELIM}g" \
+    -e "s${WP_CONFIG_DEFINES_DELIM}{{CHANGED_TEST_FILES_JSON_B64}}${WP_CONFIG_DEFINES_DELIM}${CHANGED_TEST_FILES_JSON_B64}${WP_CONFIG_DEFINES_DELIM}g" \
+    "$TEMPLATE" > "$WRAPPER_TMPFILE"
+
 ARTIFACTS_DIR="${HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR:-}"
 if [ -z "$ARTIFACTS_DIR" ] && [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
     ARTIFACTS_DIR=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_artifacts_dir // empty' 2>/dev/null || true)
@@ -365,6 +391,7 @@ echo "  Plugin: ${PLUGIN_SLUG} (${PLUGIN_PATH})"
 echo "  Backend: wp-codebox (WordPress Playground runtime)"
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+    echo "  Wrapper: $WRAPPER_TMPFILE"
     echo "  Mounts: ${MOUNTS_JSON}"
     echo "  WordPress version: ${PLAYGROUND_WORDPRESS_VERSION}"
     echo "  Artifacts: ${ARTIFACTS_DIR}"
@@ -383,6 +410,7 @@ esac
 jq -n \
     --arg wp "$PLAYGROUND_WORDPRESS_VERSION" \
     --argjson mounts "$MOUNTS_JSON" \
+    --arg codeFile "$WRAPPER_TMPFILE" \
     --arg pluginSlug "$PLUGIN_SLUG" \
     --arg selectedTestFile "$SELECTED_TEST_FILE_REL" \
     --arg changedTestsJson "$CHANGED_TEST_FILES_JSON" \
@@ -394,6 +422,7 @@ jq -n \
         runtime: {wp: $wp, blueprint: {steps: []}},
         inputs: {mounts: $mounts},
         workflow: {steps: [{command: "wordpress.phpunit", args: [
+            "code-file=" + $codeFile,
             "plugin-slug=" + $pluginSlug,
             "test-file=" + $selectedTestFile,
             "changed-tests-json=" + $changedTestsJson,
@@ -412,7 +441,7 @@ set +e
 wp_codebox_exit=$?
 set -e
 
-rm -f "$RECIPE_FILE"
+rm -f "$WRAPPER_TMPFILE" "$RECIPE_FILE"
 
 WP_CODEBOX_OUTPUT=$(cat "$WP_CODEBOX_TMPFILE")
 if [ -n "$WP_CODEBOX_OUTPUT" ]; then

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -70,16 +70,12 @@ if (!codeFileArg) {
   throw new Error('missing code-file arg')
 }
 const wrapper = codeFileArg.slice('code-file='.length)
-if (wrapper !== '/homeboy-wp-codebox-runner.php') {
-  throw new Error(`unexpected wrapper runtime path: ${wrapper}`)
+if (!fs.existsSync(wrapper)) {
+  throw new Error(`wrapper code file missing: ${wrapper}`)
 }
 
 const mounts = recipe.inputs?.mounts || []
-const wrapperMount = mounts.find((mount) => mount.target === wrapper)
-if (!wrapperMount) {
-  throw new Error('wrapper mount missing')
-}
-const wrapperSource = fs.readFileSync(wrapperMount.source, 'utf8')
+const wrapperSource = fs.readFileSync(wrapper, 'utf8')
 for (const expected of [
   Buffer.from('tests/OnlyTest.php').toString('base64'),
   Buffer.from(JSON.stringify({ WP_DEBUG: true, CUSTOM_NUMBER: 7 })).toString('base64'),


### PR DESCRIPTION
## Summary
- Restore the generated PHPUnit wrapper for the WP Codebox runner while preserving structured PHPUnit args.
- Pass the wrapper temp file as the host-side `code-file` value, matching WP Codebox's current contract.
- Update the mount translation smoke to verify the generated wrapper file directly.

## Verification
- `bash wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `git diff --check`
- `HOMEBOY_DEBUG=1 homeboy test --path /Users/chubes/Developer/data-machine@cleanup-oauth-site-account-calls --extension wordpress --force-hot -- tests/Unit/Core/OAuth/BaseOAuth2ProviderTest.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WP Codebox `code-file` contract mismatch, patched the runner/smoke test, and ran verification. Chris remains responsible for review and testing.