### PR TITLE
fix(rust): handle nested changed tests

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -1,6 +1,6 @@
 {
   "name": "Rust",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "icon": "gearshape.2.fill",
   "description": "Cargo CLI integration for Rust components",
   "author": "Extra Chill",

--- a/rust/scripts/rust-changed-scope-smoke.sh
+++ b/rust/scripts/rust-changed-scope-smoke.sh
@@ -146,3 +146,23 @@ if [[ "$OUTPUT" != *"2 passed"* ]]; then
     printf 'Expected full fallback to run both inline tests. Output:\n%s\n' "$OUTPUT" >&2
     exit 1
 fi
+
+OUTPUT=$(
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_CHANGED_TEST_FILES='tests/core/unknown_nested_test.rs' \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    bash "$SCRIPT_DIR/test-runner.sh"
+)
+
+if [[ "$OUTPUT" != *"Changed files include nested tests without a direct Cargo target; running full cargo test."* ]]; then
+    printf 'Expected nested test fallback to full cargo test. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+if [[ "$OUTPUT" != *"2 passed"* || "$OUTPUT" != *"1 passed"* ]]; then
+    printf 'Expected full fallback to run top-level and inline tests. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -206,6 +206,7 @@ TEST_ARGS=(
 # We extract module paths from file paths (e.g., src/commands/audit.rs → commands::audit).
 SCOPE_FILTER_ARGS=()
 SCOPE_INTEGRATION_ARGS=()
+SCOPE_FALLBACK_FULL=false
 if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
     while IFS= read -r test_file; do
         [ -z "$test_file" ] && continue
@@ -230,6 +231,9 @@ if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
         source_module="${module_path%_test}"
         if [[ "$test_file" == tests/*_test.rs ]] && { [ -f "${PROJECT_PATH}/src/${source_module}.rs" ] || [ -f "${PROJECT_PATH}/src/${source_module}/mod.rs" ]; }; then
             module_path="${source_module}::${test_module}"
+        elif [[ "$test_file" == tests/*/*.rs ]]; then
+            SCOPE_FALLBACK_FULL=true
+            continue
         fi
         module_path="${module_path//\//::}"       # replace / with ::
         if [ -n "$module_path" ]; then
@@ -237,7 +241,9 @@ if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
         fi
     done <<< "${HOMEBOY_CHANGED_TEST_FILES}"
 
-    if [ ${#SCOPE_INTEGRATION_ARGS[@]} -gt 0 ] && [ ${#SCOPE_FILTER_ARGS[@]} -gt 0 ]; then
+    if [ "$SCOPE_FALLBACK_FULL" = true ]; then
+        echo "Changed files include nested tests without a direct Cargo target; running full cargo test."
+    elif [ ${#SCOPE_INTEGRATION_ARGS[@]} -gt 0 ] && [ ${#SCOPE_FILTER_ARGS[@]} -gt 0 ]; then
         echo "Changed files include integration and inline tests; running full cargo test."
     elif [ ${#SCOPE_INTEGRATION_ARGS[@]} -gt 0 ]; then
         for test_target in "${SCOPE_INTEGRATION_ARGS[@]}"; do


### PR DESCRIPTION
## Summary
- Fall back to the full Rust test suite when changed test scope contains nested `tests/**/*.rs` files that are not direct Cargo integration targets or source-linked inline modules.
- Cover the nested-test fallback in the Rust changed-scope smoke test.
- Bump the Rust extension manifest version for the bug fix.

## Testing
- `bash rust/scripts/rust-changed-scope-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the changed-test dispatch failure, drafted the extension fix and smoke coverage, and ran local verification for Chris to review.