### PR TITLE
feat(wordpress): expose terminal action workflow input

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -228,6 +228,14 @@ name: Data Machine Agent CI (reusable)
         description: JSON array of existing tool recorder configs for field projection, forced parameters, and tool result capture.
         type: string
         default: "[]"
+      enable_terminal_actions:
+        description: Expose runner-owned terminal tools such as run_wp_cli to the agent.
+        type: boolean
+        default: false
+      wp_cli_tool_name:
+        description: Tool name used when enable_terminal_actions registers the WP-CLI terminal tool.
+        type: string
+        default: run_wp_cli
       pipeline_step_patches:
         description: JSON array of patches applied to imported pipeline step configs before the flow runs.
         type: string
@@ -592,6 +600,8 @@ jobs:
           TOOL_RESULTS_KEY: ${{ inputs.tool_results_key }}
           ABILITY_TOOLS: ${{ inputs.ability_tools }}
           TOOL_RECORDERS: ${{ inputs.tool_recorders }}
+          ENABLE_TERMINAL_ACTIONS: ${{ inputs.enable_terminal_actions }}
+          WP_CLI_TOOL_NAME: ${{ inputs.wp_cli_tool_name }}
           PIPELINE_STEP_PATCHES: ${{ inputs.pipeline_step_patches }}
           FLOW_STEP_PATCHES: ${{ inputs.flow_step_patches }}
           RUNNER_WORKSPACE_CONFIG: ${{ inputs.runner_workspace }}
@@ -724,6 +734,7 @@ jobs:
             --arg githubRunAttempt "$GITHUB_RUN_ATTEMPT_VALUE" \
             --arg executeWorkflowPath "$execute_workflow_guest_path" \
             --arg providerRegisterFunction "$provider_register_function" \
+            --arg wpCliToolName "$WP_CLI_TOOL_NAME" \
             --argjson validationDependencies "$validation_json" \
             --argjson providerCredentials "$provider_credentials_json" \
             --argjson providerBenchEnv "$provider_bench_env_json" \
@@ -745,6 +756,7 @@ jobs:
             --argjson allowedRepos "$allowed_repos_json" \
             --argjson abilityTools "$ability_tools_json" \
             --argjson toolRecorders "$tool_recorders_json" \
+            --argjson enableTerminalActions "$ENABLE_TERMINAL_ACTIONS" \
             --argjson pipelineStepPatches "$pipeline_step_patches_json" \
             --argjson flowStepPatches "$flow_step_patches_json" \
             --argjson runnerWorkspace "$runner_workspace_json" \
@@ -796,6 +808,8 @@ jobs:
               allowed_repos: (if ($allowedRepos | length) > 0 then $allowedRepos else [$targetRepo] end),
               engine_key: $engineKey,
               tool_results_key: $toolResultsKey,
+              enable_terminal_actions: $enableTerminalActions,
+              wp_cli_tool_name: $wpCliToolName,
               max_turns: $maxTurns,
               prompt: $prompt,
               step_budget: $stepBudget,

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -130,10 +130,13 @@ The runner converts the agent config into a single WP Codebox sandbox run:
   status/diff, commits, pushes, and opens or reuses a fallback PR after the run.
 - `ability_tools` can expose additional WordPress abilities as tools during the
   agent run.
-- Host-side terminal actions are available through the WordPress extension's
-  `agent-terminal-actions` helper for runner-owned tools that must execute like a
-  real shell command. A `wp_cli` action runs `wp ...` through `bash -lc` with the
-  runtime root as the command boundary and returns exit code, stdout, and stderr.
+- `enable_terminal_actions` exposes host-side terminal actions through the
+  WordPress extension's `agent-terminal-actions` helper for runner-owned tools
+  that must execute like a real shell command. The default `run_wp_cli` tool runs
+  a `wp_cli` action as `wp ...` through `bash -lc` with the runtime root as the
+  command boundary and returns exit code, stdout, and stderr. Use
+  `wp_cli_tool_name` only when a consumer needs a different agent-facing tool
+  name.
 - `pipeline_step_patches` and `flow_step_patches` can adjust imported bundle
   step configuration before execution.
 - `fallback_pull_request` can open a PR when files were written but the agent did
@@ -159,7 +162,7 @@ knobs to `run-datamachine-agent.sh`:
 - GitHub access: `target_repo`, `app_token_repos`, `allowed_repos`, `engine_key`, `tool_results_key`.
 - Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
 - Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`, `replay_bundle_artifact_name`.
-- Extension points: `extra_required_abilities`, `ability_tools`, `tool_recorders`, `pipeline_step_patches`, `flow_step_patches`, `runner_workspace`, `fallback_pull_request`.
+- Extension points: `extra_required_abilities`, `ability_tools`, `tool_recorders`, `enable_terminal_actions`, `wp_cli_tool_name`, `pipeline_step_patches`, `flow_step_patches`, `runner_workspace`, `fallback_pull_request`.
 
 `bundle_repo` is for cross-repo consumers. The shell runner clones the bundle
 repository, points `bundle_path` at the cloned bundle inside WP Codebox, and adds


### PR DESCRIPTION
## Summary
- Add reusable workflow inputs for enabling runner-owned terminal actions.
- Forward `enable_terminal_actions` and `wp_cli_tool_name` into the Data Machine agent runner config.
- Document the default `run_wp_cli` tool behavior for WP Codebox agent runs.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); puts "workflow yaml ok"'`
- `npm run lint:js` in `wordpress/`
- `npm run test:agent-terminal-actions && npm run test:terminal-action-server` in `wordpress/`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and implemented the workflow/config/doc change; Chris remains responsible for review and merge.