### PR TITLE
Require Homeboy app token for agent runs

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -153,6 +153,10 @@ name: Data Machine Agent CI (reusable)
         description: Comma-separated OWNER/REPO entries for the Homeboy app token. Defaults to target_repo.
         type: string
         default: ""
+      require_homeboy_app_token:
+        description: Fail before running the agent when Homeboy app credentials are unavailable.
+        type: boolean
+        default: false
       allowed_repos:
         description: JSON array of OWNER/REPO strings the injected GitHub profile may access. Defaults to [target_repo].
         type: string
@@ -332,6 +336,18 @@ jobs:
           else
             printf 'available=false\n' >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Require Homeboy app credentials
+        if: ${{ inputs.run_agent && ! inputs.dry_run && inputs.require_homeboy_app_token && steps.homeboy-app-creds.outputs.available != 'true' }}
+        run: |
+          set -euo pipefail
+          cat >&2 <<'EOF'
+          HOMEBOY_APP_ID and HOMEBOY_APP_PRIVATE_KEY are required for this Data Machine agent run.
+          The workflow was configured with require_homeboy_app_token=true so repository-scoped
+          GITHUB_TOKEN fallback is not allowed. Add the Homeboy app secrets to the caller repo
+          or organization and rerun the workflow.
+          EOF
+          exit 1
 
       - name: Resolve Homeboy app token scope
         id: token-scope


### PR DESCRIPTION
## Summary
- Adds a reusable `require_homeboy_app_token` input to the Data Machine agent CI workflow.
- Fails before running the agent when the caller requires Homeboy app credentials but the app secrets are unavailable.

## Why
Some target repositories keep the default `GITHUB_TOKEN` unable to create pull requests. Agent runs that must open PRs should fail clearly instead of writing/pushing branches and then hitting GitHub API 403s.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); puts "ok"'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the docs-agent PR creation failure and drafted the reusable workflow guard.