### PR TITLE
fix: mount wordpress extension in wp-codebox tests

### DIFF
--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -335,6 +335,8 @@ fi
 
 EXTENSION_VENDOR_PATH="$(homeboy_wp_codebox_resolve_mount_path "${EXTENSION_PATH}/vendor")"
 homeboy_wp_codebox_add_recipe_mount "${EXTENSION_VENDOR_PATH}" "/wp-codebox-vendor" "readonly"
+EXTENSION_MOUNT_PATH="$(homeboy_wp_codebox_resolve_mount_path "${EXTENSION_PATH}")"
+homeboy_wp_codebox_add_recipe_mount "${EXTENSION_MOUNT_PATH}" "/homeboy-extension" "readonly"
 
 PLAYGROUND_DEP_MOUNTS=""
 if [ -n "$DEPENDENCY_PATHS" ]; then

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -144,7 +144,8 @@ REQUIRED_MOUNTS_JSON=$(jq -nc \
     --arg componentExtra "${PLUGIN_PATH}/config/component-extra.php:/wordpress/wp-content/component-extra.php" \
     --arg depExtra "${DEP_PATH}/fixtures/dep-extra.php:/wordpress/wp-content/dep-extra.php" \
     --arg vendor "${EXTENSION_PATH}/vendor:/wp-codebox-vendor:readonly" \
-    '[$component, $dep, $dropin, $componentExtra, $depExtra, $vendor]')
+    --arg extension "${EXTENSION_PATH}:/homeboy-extension:readonly" \
+    '[$component, $dep, $dropin, $componentExtra, $depExtra, $vendor, $extension]')
 export REQUIRED_MOUNTS_JSON
 
 bash -n "$SCRIPT_DIR/test-runner-wp-codebox.sh"


### PR DESCRIPTION
## Summary
- Mounts the WordPress Homeboy extension into WP Codebox test recipes at `/homeboy-extension`.
- Keeps the existing vendor mount at `/wp-codebox-vendor` for PHPUnit dependencies.
- Extends the mount translation smoke test to assert both mounts are present.

## Why
Data Machine PR https://github.com/Extra-Chill/data-machine/pull/2146 exposed a CI bootstrap crash before PHPUnit:

`require_once(/homeboy-extension/scripts/lib/playground-bootstrap.php): Failed to open stream: No such file or directory`

The WordPress PHPUnit command requires extension scripts from `/homeboy-extension`, but `test-runner-wp-codebox.sh` only mounted the extension vendor directory.

## Verification
- `bash wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `git diff --check`

## Known unrelated failure
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-wp-codebox-extension-mount/wordpress --extension nodejs --force-hot` reaches and passes the WP Codebox mount smoke, then fails later in an existing detector smoke with `constant-backed slug detector should still flag comparisons`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Data Machine CI bootstrap failure, drafted the WP Codebox mount fix, and ran targeted verification for Chris to review/test.