### PR TITLE
Accept opened agent PR as success

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -961,18 +961,21 @@ jobs:
           set -euo pipefail
           scenario_json="$(jq -ec --arg scenario "${{ inputs.flow_slug }}" '.scenarios[] | select(.id == $scenario)' "$RESULTS_FILE")"
           job_status="$(jq -r '.metadata.job_status // ""' <<< "$scenario_json")"
+          success_status="$(jq -r '.metadata.success_status // ""' <<< "$scenario_json")"
           completion_outcome_satisfied="$(jq -r 'if .metadata.completion_outcome_satisfied == true then "true" else "false" end' <<< "$scenario_json")"
 
           printf 'job_status:                      %s\n' "$job_status"
+          printf 'success_status:                  %s\n' "$success_status"
           printf 'completion_outcome_satisfied:    %s\n' "$completion_outcome_satisfied"
 
-          if [ "$job_status" = "completed" ] || [ "$completion_outcome_satisfied" = "true" ]; then
+          if [ "$job_status" = "completed" ] || [ "$success_status" = "pr_opened" ] || [ "$completion_outcome_satisfied" = "true" ]; then
             exit 0
           fi
 
-          printf 'ERROR: scenario %s expected completed job or satisfied completion outcome, got job_status=%s completion_outcome_satisfied=%s\n' \
+          printf 'ERROR: scenario %s expected completed job, opened PR, or satisfied completion outcome, got job_status=%s success_status=%s completion_outcome_satisfied=%s\n' \
             "${{ inputs.flow_slug }}" \
             "$job_status" \
+            "$success_status" \
             "$completion_outcome_satisfied" >&2
           exit 1
 

--- a/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
@@ -134,8 +134,8 @@ namespace {
 		fwrite( STDERR, "Expected reusable workflow config to require import-agent for execute-workflow runs.\n" );
 		exit( 1 );
 	}
-	if ( ! str_contains( $workflow_source, 'completion_outcome_satisfied="$(jq -r' ) || ! str_contains( $workflow_source, '[ "$job_status" = "completed" ] || [ "$completion_outcome_satisfied" = "true" ]' ) ) {
-		fwrite( STDERR, "Expected reusable workflow success assertion to accept satisfied completion outcomes.\n" );
+	if ( ! str_contains( $workflow_source, 'success_status="$(jq -r' ) || ! str_contains( $workflow_source, '[ "$job_status" = "completed" ] || [ "$success_status" = "pr_opened" ] || [ "$completion_outcome_satisfied" = "true" ]' ) ) {
+		fwrite( STDERR, "Expected reusable workflow success assertion to accept opened PRs and satisfied completion outcomes.\n" );
 		exit( 1 );
 	}
 


### PR DESCRIPTION
## Summary
- Updates the reusable Data Machine agent CI success assertion to treat `success_status=pr_opened` as a successful run.
- Keeps existing success paths for completed jobs and explicit completion outcomes.
- Extends the child-drain smoke test so the workflow assertion contract includes opened PRs.

## Why
A docs-agent bootstrap run opened the expected PR but the underlying Data Machine job later reported `failed - empty_data_packet_returned`. The runner metadata correctly classified the outcome as `success_status: pr_opened`, but the workflow still failed because it only accepted `job_status=completed` or `completion_outcome_satisfied=true`.

## Verification
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); puts "ok"'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the docs-agent run outcome mismatch and drafted the reusable workflow assertion fix.