### PR TITLE
fix: map host bundle paths for wp-codebox agents

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -84,6 +84,10 @@ name: Data Machine Agent CI (reusable)
         description: Ref for Extra-Chill/data-machine-code when include_agent_runtime_dependencies is true.
         type: string
         default: main
+      php_ai_client_ref:
+        description: Ref for WordPress/php-ai-client when mounting the default OpenAI provider runtime.
+        type: string
+        default: trunk
       openai_provider_ref:
         description: Legacy ref for explicit provider_plugin overrides that still checkout WordPress/ai-provider-for-openai.
         type: string
@@ -412,6 +416,7 @@ jobs:
           AGENTS_API_REF: ${{ inputs.agents_api_ref }}
           DATA_MACHINE_REF: ${{ inputs.data_machine_ref }}
           DATA_MACHINE_CODE_REF: ${{ inputs.data_machine_code_ref }}
+          PHP_AI_CLIENT_REF: ${{ inputs.php_ai_client_ref }}
           OPENAI_PROVIDER_REF: ${{ inputs.openai_provider_ref }}
           PROVIDER: ${{ inputs.provider }}
           PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
@@ -436,6 +441,10 @@ jobs:
             dependency_entries+=("Automattic/agents-api@${AGENTS_API_REF}")
             dependency_entries+=("Extra-Chill/data-machine@${DATA_MACHINE_REF}")
             dependency_entries+=("Extra-Chill/data-machine-code@${DATA_MACHINE_CODE_REF}")
+            if [ "$PROVIDER" = "openai" ] && [ -z "$provider_plugin_repo" ]; then
+              dependency_entries+=("WordPress/php-ai-client@${PHP_AI_CLIENT_REF}")
+              dependency_entries+=("WordPress/ai-provider-for-openai@${OPENAI_PROVIDER_REF}")
+            fi
             if [ -n "$provider_plugin_repo" ]; then
               if [ -n "$provider_plugin_ref" ]; then
                 dependency_entries+=("${provider_plugin_repo}@${provider_plugin_ref}")
@@ -667,6 +676,13 @@ jobs:
           provider_plugin_repo="$(jq -r '.repo // ""' <<< "$provider_plugin_json")"
           provider_plugin_path="$(jq -r '.path // "."' <<< "$provider_plugin_json")"
           provider_plugin_host_path=""
+          wp_ai_client_host_path=""
+          if [ -d "${GITHUB_WORKSPACE}/.ci/php-ai-client" ]; then
+            wp_ai_client_host_path="${GITHUB_WORKSPACE}/.ci/php-ai-client"
+          fi
+          if [ -z "$provider_plugin_repo" ] && [ "$PROVIDER" = "openai" ] && [ -d "${GITHUB_WORKSPACE}/.ci/ai-provider-for-openai" ]; then
+            provider_plugin_host_path="${GITHUB_WORKSPACE}/.ci/ai-provider-for-openai"
+          fi
           if [ -n "$provider_plugin_repo" ]; then
             provider_plugin_repo_name="${provider_plugin_repo#*/}"
             provider_plugin_root="${GITHUB_WORKSPACE}/.ci/${provider_plugin_repo_name}"
@@ -740,6 +756,7 @@ jobs:
             --arg model "$MODEL" \
             --arg wpCodeboxBin "$wp_codebox_bin" \
             --arg providerPluginHostPath "$provider_plugin_host_path" \
+            --arg wpAiClientHostPath "$wp_ai_client_host_path" \
             --arg engineKey "$ENGINE_KEY" \
             --arg toolResultsKey "$TOOL_RESULTS_KEY" \
             --arg playgroundWordPress "$PLAYGROUND_WORDPRESS" \
@@ -815,7 +832,7 @@ jobs:
                 agents_api: ($componentPath + "/.ci/agents-api"),
                 data_machine: ($componentPath + "/.ci/data-machine"),
                 data_machine_code: ($componentPath + "/.ci/data-machine-code")
-              },
+              } + (if $wpAiClientHostPath != "" then {wp_ai_client: $wpAiClientHostPath} else {} end),
               provider_plugin_paths: (if $providerPluginHostPath != "" then [$providerPluginHostPath] else [] end),
               github_token_env: "HOMEBOY_GITHUB_APP_TOKEN",
               github_repository_token_env: "GITHUB_TOKEN",

--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -150,7 +150,7 @@ jq -n \
     '{
         component_id: "wp-codebox-smoke-component",
         component_path: env.PWD,
-        bundle_host_path: $bundle,
+        bundle_path: $bundle,
         agent_slug: "wp-codebox-smoke-agent",
         flow_slug: "wp-codebox-smoke-flow",
         workload_id: "wp-codebox-runner-smoke",

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -76,6 +76,7 @@ echo wp_json_encode( is_array( $homeboy_workload_result ) ? $homeboy_workload_re
 PHP
 
     local agents_api_path="${HOMEBOY_AGENTS_API_PATH:-${AGENTS_API_PATH:-}}"
+    local wp_ai_client_path="${HOMEBOY_WP_AI_CLIENT_PATH:-${WP_AI_CLIENT_PATH:-}}"
     local data_machine_path="${HOMEBOY_DATA_MACHINE_PATH:-${DATA_MACHINE_PATH:-}}"
     local data_machine_code_path="${HOMEBOY_DATA_MACHINE_CODE_PATH:-${DATA_MACHINE_CODE_PATH:-}}"
     if [ -z "$agents_api_path" ]; then
@@ -83,6 +84,9 @@ PHP
     fi
     if [ -z "$data_machine_path" ]; then
         data_machine_path=$(jq -r '.wp_codebox_components.data_machine // .wp_codebox_data_machine_path // empty' "$CONFIG_PATH")
+    fi
+    if [ -z "$wp_ai_client_path" ]; then
+        wp_ai_client_path=$(jq -r '.wp_codebox_components.wp_ai_client // .wp_codebox_wp_ai_client_path // empty' "$CONFIG_PATH")
     fi
     if [ -z "$data_machine_code_path" ]; then
         data_machine_code_path=$(jq -r '.wp_codebox_components.data_machine_code // .wp_codebox_data_machine_code_path // empty' "$CONFIG_PATH")
@@ -98,10 +102,12 @@ PHP
     local extra_plugins_json mounts_json secret_env_json provider_slugs_csv
     extra_plugins_json=$(jq -nc \
         --arg agents "$agents_api_path" \
+        --arg wpAiClient "$wp_ai_client_path" \
         --arg datamachine "$data_machine_path" \
         --arg code "$data_machine_code_path" \
         '[
             {source: $agents, slug: "agents-api", activate: false},
+            (if $wpAiClient != "" then {source: $wpAiClient, slug: "php-ai-client", pluginFile: "php-ai-client/plugin.php"} else empty end),
             {source: $datamachine, slug: "data-machine", activate: false},
             {source: $code, slug: "data-machine-code", activate: false}
         ]')
@@ -128,7 +134,7 @@ PHP
         else
             provider_slugs_csv="$provider_slug"
         fi
-        extra_plugins_json=$(jq -nc --argjson plugins "$extra_plugins_json" --arg source "$provider_plugin_path" --arg slug "$provider_slug" '$plugins + [{source: $source, slug: $slug, activate: false}]')
+        extra_plugins_json=$(jq -nc --argjson plugins "$extra_plugins_json" --arg source "$provider_plugin_path" --arg slug "$provider_slug" '$plugins + [{source: $source, slug: $slug, pluginFile: ($slug + "/plugin.php")} ]')
     done < <(jq -r '.provider_plugin_paths? // [] | .[]? | select(type == "string" and . != "")' <<<"$CONFIG_JSON")
 
     secret_env_json="[]"

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -417,10 +417,18 @@ if [ -n "$BUNDLE_REPO" ]; then
         )' <<<"$CONFIG_JSON")
 else
     BUNDLE_HOST_PATH=$(jq -r '.bundle_host_path // empty' "$CONFIG_PATH")
+    BUNDLE_PATH_IS_HOST_PATH=0
+    if [ -z "$BUNDLE_HOST_PATH" ]; then
+        BUNDLE_CONFIG_PATH=$(jq -r '.bundle_path // empty' "$CONFIG_PATH")
+        if [ -n "$BUNDLE_CONFIG_PATH" ] && [ -d "$BUNDLE_CONFIG_PATH" ]; then
+            BUNDLE_HOST_PATH="$BUNDLE_CONFIG_PATH"
+            BUNDLE_PATH_IS_HOST_PATH=1
+        fi
+    fi
     if [ -n "$BUNDLE_HOST_PATH" ]; then
         BUNDLE_PATH="$BUNDLE_HOST_PATH"
         BUNDLE_GUEST_SLUG="$(basename "$(cd "$BUNDLE_PATH" && pwd)")"
-        BUNDLE_GUEST_PATH=$(jq -r --arg fallback "/wordpress/wp-content/plugins/${BUNDLE_GUEST_SLUG}" '.bundle_path // $fallback' "$CONFIG_PATH")
+        BUNDLE_GUEST_PATH=$(jq -r --arg fallback "/wordpress/wp-content/plugins/${BUNDLE_GUEST_SLUG}" --argjson bundlePathIsHostPath "$BUNDLE_PATH_IS_HOST_PATH" 'if $bundlePathIsHostPath then $fallback else (.bundle_path // $fallback) end' "$CONFIG_PATH")
         CONFIG_JSON=$(jq -c \
             --arg bundlePath "$BUNDLE_PATH" \
             --arg bundleGuestPath "$BUNDLE_GUEST_PATH" \


### PR DESCRIPTION
## Summary
- Treat an existing configured `bundle_path` as the host bundle directory when `bundle_host_path` is absent.
- Rewrite that host path to the sandbox guest plugin path before running the Data Machine workload through WP Codebox.
- Update the WP Codebox agent runner smoke test to cover the workflow-generated `bundle_path` shape.

## Evidence
- World Creator now reaches `Run Data Machine agent` after chubes4/world-of-wordpress#399, but exits before writing `run-results.json`: https://github.com/chubes4/world-of-wordpress/actions/runs/26227709608
- The caller workflow builds config with `bundle_path` set to the checked-out host bundle directory.
- Local smoke passes: `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WP Codebox agent runner bundle-path mapping failure and drafted the fix plus smoke coverage.