### PR TITLE
fix: fail wp-codebox tests on bootstrap errors

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -10,7 +10,7 @@
   "self_checks": {
     "lint": [
       "jq empty wordpress.json",
-      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/test-runner-host-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/bench/bench-results-artifacts.sh scripts/bench/bench-results-artifacts-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/parse-wp-codebox-artifacts-smoke.sh scripts/test/wp-codebox-mount-translation-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/release/package.sh scripts/release/publish.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
+      "bash -n scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/test-runner-host-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/bench/bench-results-artifacts.sh scripts/bench/bench-results-artifacts-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/parse-wp-codebox-artifacts-smoke.sh scripts/test/wp-codebox-mount-translation-smoke.sh scripts/test/wp-codebox-bootstrap-failure-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/release/package.sh scripts/release/publish.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
       "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js lib/wp-codebox-apply-adapter.js scripts/agent/terminal-action-server.js scripts/agent/wp-codebox-apply-adapter.cjs tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js tests/wp-codebox-apply-adapter-smoke.js",
       "php -l scripts/agent/datamachine-agent-workload.php tests/datamachine-terminal-tool-smoke.php"
     ],
@@ -20,6 +20,7 @@
       "bash scripts/test/parse-test-failures-sidecar-smoke.sh",
       "bash scripts/test/parse-wp-codebox-artifacts-smoke.sh",
       "bash scripts/test/wp-codebox-mount-translation-smoke.sh",
+      "bash scripts/test/wp-codebox-bootstrap-failure-smoke.sh",
       "bash scripts/bench/bench-results-artifacts-smoke.sh",
       "bash scripts/agent/validate-bundle-smoke.sh",
       "bash scripts/trace/trace-runner-smoke.sh",

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -478,6 +478,15 @@ if echo "$PHPUNIT_OUTPUT" | grep -q "SOME TESTS FAILED"; then
     exit ${wp_codebox_exit:-1}
 fi
 
+if echo "$PHPUNIT_STDOUT" | grep -q 'Error in bootstrap script:'; then
+    FAILED_STEP="PHPUnit bootstrap failure (wp-codebox)"
+    FAILURE_OUTPUT=$(echo "$PHPUNIT_STDOUT" | grep 'Error in bootstrap script:' | head -1)
+    dump_diagnostics "PHPUNIT BOOTSTRAP FAILURE"
+    write_phpunit_discovery_result failed "phpunit-bootstrap-failure" "PHPUnit bootstrap failed before executing tests."
+    rm -f "$RESULT_FILE"
+    exit 1
+fi
+
 if [ $wp_codebox_exit -ne 0 ] && echo "$PHPUNIT_STDOUT" | grep -qE '^(FAILURES|ERRORS)!'; then
     FAILED_STEP="PHPUnit tests (wp-codebox backend)"
     FAILURE_REPLAY_MODE="none"

--- a/wordpress/scripts/test/wp-codebox-bootstrap-failure-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-bootstrap-failure-smoke.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/test-runner.sh"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PLUGIN_PATH="${TMPDIR}/component"
+FAKE_WP_CODEBOX="${TMPDIR}/wp-codebox.js"
+mkdir -p "${PLUGIN_PATH}/tests"
+
+printf '<?php
+class BootstrapFailureTest extends WP_UnitTestCase {}
+' > "${PLUGIN_PATH}/tests/BootstrapFailureTest.php"
+
+cat > "$FAKE_WP_CODEBOX" <<'NODE'
+#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  success: true,
+  executions: [
+    {
+      stdout: 'PHPUnit 9.6.34 by Sebastian Bergmann and contributors.\n\nError in bootstrap script: Error:\nInterface "AgentsAPI\\Core\\Database\\Chat\\WP_Agent_Conversation_Store" not found\n#0 /wordpress/wp-content/plugins/data-machine/data-machine.php(440)\n',
+      stderr: '',
+    },
+  ],
+}) + '\n')
+NODE
+chmod +x "$FAKE_WP_CODEBOX"
+
+set +e
+output=$(HOMEBOY_WP_CODEBOX_BIN="$FAKE_WP_CODEBOX" \
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
+    HOMEBOY_COMPONENT_ID="example" \
+    bash "$RUNNER" 2>&1)
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+    echo "Expected WP Codebox runner to fail on PHPUnit bootstrap error" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+if [[ "$output" != *"PHPUNIT BOOTSTRAP FAILURE"* ]]; then
+    echo "Expected PHPUnit bootstrap failure diagnostics" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+if [[ "$output" != *"Error in bootstrap script:"* ]]; then
+    echo "Expected original PHPUnit bootstrap error in output" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+echo "WP Codebox bootstrap failure smoke passed"

--- a/wordpress/tests/audit-detector-config-smoke.sh
+++ b/wordpress/tests/audit-detector-config-smoke.sh
@@ -315,11 +315,19 @@ literal_rule = next(
 )
 literal_pattern = literal_rule["literal_pattern"].replace("{value}", re.escape("tool_call"))
 literal_regex = re.compile(literal_pattern, re.MULTILINE)
+exclude_patterns = [
+    pattern.replace("{value}", re.escape("tool_call"))
+    for pattern in literal_rule.get("exclude_match_context_patterns", [])
+]
+exclude_regexes = [re.compile(pattern, re.MULTILINE) for pattern in exclude_patterns]
 fixture = (fixture_dir / "src/Runtime/class-demo-event.php").read_text(encoding="utf-8")
 matches = [match.group(0) for match in literal_regex.finditer(fixture)]
 
-require(any("===" in match for match in matches), "constant-backed slug detector should still flag comparisons")
-require(not any(match.strip() == "'tool_call'" for match in matches), "detector must not match a bare literal everywhere")
+require(matches, "constant-backed slug detector literal pattern must match slug literals")
+require(literal_regex.search("self::TOOL_CALL === 'tool_call'"), "constant-backed slug detector should still flag comparisons")
+require(not any(regex.search("self::TOOL_CALL === 'tool_call'") for regex in exclude_regexes), "comparison duplicate must not be excluded")
+require(any(regex.search("'tool_call' =>") for regex in exclude_regexes), "array/protocol key literal must be excluded by context")
+require(any(regex.search("do_action( 'tool_call'") for regex in exclude_regexes), "event-name literal must be excluded by context")
 require("'tool_call' =>" in fixture, "fixture should include array/protocol key literal")
 require("do_action( 'tool_call'" in fixture, "fixture should include event-name literal")
 


### PR DESCRIPTION
## Summary
- Fail the WP Codebox PHPUnit runner when PHPUnit reports `Error in bootstrap script:` before any tests execute.
- Add a regression smoke that reproduces the previous green-on-bootstrap-fatal shape.
- Update the constant-backed slug detector smoke to assert the current `literal_pattern` plus exclude-context contract.

Fixes #729.
Fixes #627.

## Testing
- `homeboy lint --path wordpress --extension wordpress`
- `bash wordpress/scripts/test/wp-codebox-bootstrap-failure-smoke.sh`
- `bash wordpress/tests/audit-detector-config-smoke.sh`

## Known follow-up
- `homeboy test --path wordpress --extension wordpress` still fails in `wordpress/tests/audit-dead-guard-fallback-smoke.sh` with `wp-only fixture must still report dead_guard findings; core's known-symbol pipeline appears broken or the fixture changed shape`. That appears unrelated to this runner fix and should be handled as the next audit pipeline bug.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing the WP Codebox PHPUnit bootstrap-failure classifier, adding the regression smoke, and updating the stale detector smoke assertion.