### PR TITLE
fix: wrap wp-codebox components jq merge

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -828,11 +828,11 @@ jobs:
               provider_register_function: $providerRegisterFunction,
               provider_credentials: $providerCredentials,
               wp_codebox_bin: $wpCodeboxBin,
-              wp_codebox_components: {
+              wp_codebox_components: ({
                 agents_api: ($componentPath + "/.ci/agents-api"),
                 data_machine: ($componentPath + "/.ci/data-machine"),
                 data_machine_code: ($componentPath + "/.ci/data-machine-code")
-              } + (if $wpAiClientHostPath != "" then {wp_ai_client: $wpAiClientHostPath} else {} end),
+              } + (if $wpAiClientHostPath != "" then {wp_ai_client: $wpAiClientHostPath} else {} end)),
               provider_plugin_paths: (if $providerPluginHostPath != "" then [$providerPluginHostPath] else [] end),
               github_token_env: "HOMEBOY_GITHUB_APP_TOKEN",
               github_repository_token_env: "GITHUB_TOKEN",


### PR DESCRIPTION
## Summary
- Wrap the `wp_codebox_components` jq merge so the reusable Data Machine agent CI workflow can build config JSON after adding the default PHP AI Client component.
- Keeps the existing WP Codebox runner smoke passing.

## Testing
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `jq -n --arg componentPath "/tmp/workspace" --arg wpAiClientHostPath "/tmp/php-ai-client" '{wp_codebox_components: ({agents_api: ($componentPath + "/.ci/agents-api"), data_machine: ($componentPath + "/.ci/data-machine"), data_machine_code: ($componentPath + "/.ci/data-machine-code")} + (if $wpAiClientHostPath != "" then {wp_ai_client: $wpAiClientHostPath} else {} end))}' >/dev/null`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the workflow jq syntax failure, drafting the minimal fix, and running local verification. Chris remains responsible for review and merge.