### PR TITLE
fix: avoid activating php ai client in wp-codebox

### DIFF
--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -107,7 +107,7 @@ PHP
         --arg code "$data_machine_code_path" \
         '[
             {source: $agents, slug: "agents-api", activate: false},
-            (if $wpAiClient != "" then {source: $wpAiClient, slug: "php-ai-client", pluginFile: "php-ai-client/plugin.php"} else empty end),
+            (if $wpAiClient != "" then {source: $wpAiClient, slug: "php-ai-client", activate: false} else empty end),
             {source: $datamachine, slug: "data-machine", activate: false},
             {source: $code, slug: "data-machine-code", activate: false}
         ]')


### PR DESCRIPTION
## Summary
- Mount PHP AI Client into WP Codebox recipes as a non-activating runtime component.
- Prevents Playground from trying to activate `php-ai-client/plugin.php`, which does not exist because PHP AI Client is a library dependency rather than a WordPress plugin entrypoint.

## Testing
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the World Creator workflow failure, drafting the minimal runtime recipe fix, and running local smoke verification. Chris remains responsible for review and merge.