### PR TITLE
fix: enrich node lint findings sidecar

### DIFF
--- a/nodejs/scripts/lint/lint-runner.sh
+++ b/nodejs/scripts/lint/lint-runner.sh
@@ -12,9 +12,9 @@ set -euo pipefail
 # In fix mode (HOMEBOY_FIX_ONLY=1), prefers `lint:fix` script if defined,
 # otherwise falls back to `eslint . --fix`.
 #
-# Output: writes a LintFinding[] JSON array to HOMEBOY_LINT_FINDINGS_FILE.
-# Each finding has `id`, `message`, `category` (matches LintFinding struct
-# in homeboy/src/core/extension/lint/baseline.rs).
+# Output: writes a normalized LintFinding[] JSON array to
+# HOMEBOY_LINT_FINDINGS_FILE. Core consumes `id`, `message`, and `category`;
+# richer fields remain available through the flattened metadata map.
 #
 # We try to consume ESLint's machine-readable JSON output (--format=json)
 # when ESLint is the runner. For arbitrary `npm run lint` scripts the user
@@ -137,10 +137,28 @@ if [ $USE_ESLINT_JSON -eq 1 ] && [ -s "$OUTPUT_FILE" ]; then
     # only if HOMEBOY_LINT_INCLUDE_WARNINGS=1 (matches Rust extension's
     # ratchet-friendly default).
     INCLUDE_WARNINGS="${HOMEBOY_LINT_INCLUDE_WARNINGS:-0}"
-    node - "$OUTPUT_FILE" "$FINDINGS_FILE" "$INCLUDE_WARNINGS" <<'NODEJS'
+    node - "$OUTPUT_FILE" "$FINDINGS_FILE" "$INCLUDE_WARNINGS" "$PROJECT_PATH" <<'NODEJS'
+const crypto = require('node:crypto');
 const fs = require('node:fs');
-const [, , inputFile, outputFile, includeWarningsFlag] = process.argv;
+const path = require('node:path');
+const [, , inputFile, outputFile, includeWarningsFlag, projectPath] = process.argv;
 const includeWarnings = includeWarningsFlag === '1';
+
+function relativeFile(filePath) {
+    if (!filePath) return undefined;
+    const absolute = path.resolve(filePath);
+    const relative = path.relative(projectPath, absolute).replaceAll(path.sep, '/');
+    return relative && !relative.startsWith('..') ? relative : absolute;
+}
+
+function readExcerpt(filePath, line) {
+    if (!filePath || !Number.isFinite(line) || line <= 0) return undefined;
+    try {
+        return fs.readFileSync(filePath, 'utf8').split(/\r?\n/)[line - 1]?.trim() || undefined;
+    } catch {
+        return undefined;
+    }
+}
 
 let raw;
 try {
@@ -172,13 +190,28 @@ for (const file of report) {
     for (const msg of file.messages || []) {
         if (!includeWarnings && msg.severity !== 2) continue;
         const rule = msg.ruleId || 'parse-error';
-        const loc = `${file.filePath}:${msg.line || 0}:${msg.column || 0}`;
+        const relative = relativeFile(file.filePath);
+        const line = Number(msg.line || 0);
+        const column = Number(msg.column || 0);
+        const loc = `${relative || file.filePath}:${line}:${column}`;
+        const id = `eslint:${rule}:${loc}`;
+        const severity = msg.severity === 2 ? 'error' : 'warning';
+        const excerpt = readExcerpt(file.filePath, line);
         findings.push({
             // Stable fingerprint id: rule + path + 1-based line. Matches
             // baseline expectations — same finding twice deduplicates.
-            id: `eslint:${rule}:${loc}`,
+            id,
+            file: relative,
+            line,
+            column,
+            severity,
+            source: 'eslint',
+            code: rule,
             message: msg.message || '(no message)',
-            category: msg.severity === 2 ? 'error' : 'warning',
+            category: severity,
+            fixable: Boolean(msg.fix),
+            fingerprint: crypto.createHash('sha1').update(id).digest('hex'),
+            ...(excerpt ? { excerpt } : {}),
         });
     }
 }

--- a/nodejs/scripts/lint/nodejs-lint-findings-sidecar-smoke.sh
+++ b/nodejs/scripts/lint/nodejs-lint-findings-sidecar-smoke.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RUNNER="$SCRIPT_DIR/lint-runner.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PROJECT_PATH="$TMPDIR/project"
+FINDINGS_FILE="$TMPDIR/lint-findings.json"
+OUTPUT_FILE="$TMPDIR/lint.out"
+mkdir -p "$PROJECT_PATH/node_modules/.bin" "$PROJECT_PATH/src"
+printf '{"name":"node-lint-sidecar-smoke","scripts":{}}\n' > "$PROJECT_PATH/package.json"
+printf 'export const value = 1\n' > "$PROJECT_PATH/src/bad.js"
+printf 'export default []\n' > "$PROJECT_PATH/eslint.config.js"
+
+cat > "$PROJECT_PATH/node_modules/.bin/eslint" <<'SH'
+#!/usr/bin/env bash
+project_path="$(pwd)"
+printf '[{"filePath":"%s/src/bad.js","messages":[{"ruleId":"semi","message":"Missing semicolon.","line":1,"column":23,"severity":2,"fix":{"range":[22,22],"text":";"}}]}]\n' "$project_path"
+exit 1
+SH
+chmod +x "$PROJECT_PATH/node_modules/.bin/eslint"
+
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+HOMEBOY_COMPONENT_PATH="$PROJECT_PATH" \
+HOMEBOY_COMPONENT_ID="node-lint-sidecar-smoke" \
+HOMEBOY_LINT_FINDINGS_FILE="$FINDINGS_FILE" \
+    bash "$RUNNER" >"$OUTPUT_FILE" 2>&1
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+    echo "Expected lint runner to fail on fake ESLint finding" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+node - "$FINDINGS_FILE" <<'NODE'
+const fs = require('node:fs')
+const findings = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))
+if (findings.length !== 1) throw new Error(`expected one finding, got ${findings.length}`)
+const finding = findings[0]
+for (const key of ['id', 'file', 'line', 'column', 'severity', 'source', 'code', 'message', 'category', 'fixable', 'fingerprint', 'excerpt']) {
+  if (!(key in finding)) throw new Error(`missing ${key}: ${JSON.stringify(finding)}`)
+}
+if (finding.file !== 'src/bad.js') throw new Error(`unexpected file: ${finding.file}`)
+if (finding.line !== 1 || finding.column !== 23) throw new Error(`unexpected location: ${finding.line}:${finding.column}`)
+if (finding.severity !== 'error' || finding.category !== 'error') throw new Error(`unexpected severity: ${finding.severity}/${finding.category}`)
+if (finding.source !== 'eslint' || finding.code !== 'semi') throw new Error(`unexpected source/code: ${finding.source}/${finding.code}`)
+if (finding.fixable !== true) throw new Error('expected fixable=true')
+if (!/^[a-f0-9]{40}$/.test(finding.fingerprint)) throw new Error(`bad fingerprint: ${finding.fingerprint}`)
+if (finding.excerpt !== 'export const value = 1') throw new Error(`unexpected excerpt: ${finding.excerpt}`)
+NODE
+
+echo "nodejs lint findings sidecar smoke passed"


### PR DESCRIPTION
## Summary
- Enrich Node.js ESLint findings with normalized sidecar fields: `file`, `line`, `column`, `severity`, `source`, `code`, `fixable`, `fingerprint`, and `excerpt`.
- Keep the existing stable `id`, `message`, and `category` fields for Homeboy core baseline compatibility.
- Add a self-contained smoke with a fake local ESLint binary to verify the sidecar shape without installing packages.

Refs #387.

## Testing
- `bash -n nodejs/scripts/lint/lint-runner.sh nodejs/scripts/lint/nodejs-lint-findings-sidecar-smoke.sh`
- `bash nodejs/scripts/lint/nodejs-lint-findings-sidecar-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing Node.js lint finding sidecar enrichment and adding a focused smoke test.