### PR TITLE
fix: enrich node test failure sidecar

### DIFF
--- a/nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh
+++ b/nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh
@@ -94,6 +94,13 @@ assert.equal(
 );
 assert.equal(failures.failures[0].test_file, 'src/test/version-detect.spec.ts');
 assert.equal(failures.failures[0].error_type, 'vitest_timeout');
+assert.equal(failures.failures[0].test_id, failures.failures[0].test_name);
+assert.equal(failures.failures[0].file, failures.failures[0].test_file);
+assert.equal(failures.failures[0].failure_type, failures.failures[0].error_type);
+assert.equal(failures.failures[0].line, 0);
+assert.equal(failures.failures[0].stderr_excerpt, '');
+assert.match(failures.failures[0].fingerprint, /^[a-f0-9]{64}$/);
+assert.match(failures.failures[0].stdout_excerpt, /FAIL src\/test\/version-detect\.spec\.ts/);
 assert.match(failures.failures[0].message, /Test timed out in 30000ms/);
 assert.match(failures.failures[0].message, /Nx task: playground-wordpress:test:vite/);
 JS

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -152,7 +152,6 @@ TEST_EXIT=${PIPESTATUS[0]}
 set -e
 
 OUTPUT="$(cat "$OUTPUT_FILE")"
-rm -f "$OUTPUT_FILE"
 
 # ── Parse result counts by runner detection ──
 # Runners we recognize, in priority order. Each match block sets
@@ -191,12 +190,17 @@ write_node_failure_json() {
     [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] || return 0
     [ -n "$FAILED_TEST_NAME" ] || return 0
 
-    node - "$HOMEBOY_TEST_FAILURES_FILE" "$FAILED_TEST_NAME" "$FAILED_TEST_FILE" "$FAILED_ERROR_TYPE" "$FAILED_MESSAGE" "$TOTAL" "$PASSED" <<'JS'
+    HOMEBOY_NODE_TEST_OUTPUT="$OUTPUT" node - "$HOMEBOY_TEST_FAILURES_FILE" "$FAILED_TEST_NAME" "$FAILED_TEST_FILE" "$FAILED_ERROR_TYPE" "$FAILED_MESSAGE" "$TOTAL" "$PASSED" <<'JS'
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 
 const [file, testName, testFile, errorType, message, total, passed] = process.argv.slice(2);
 const parsedTotal = Number.parseInt(total || '0', 10) || 0;
 const parsedPassed = Number.parseInt(passed || '0', 10) || 0;
+const stdout = process.env.HOMEBOY_NODE_TEST_OUTPUT || '';
+const fingerprintInput = [testName, testFile, errorType, message].join('\0');
+const fingerprint = crypto.createHash('sha256').update(fingerprintInput).digest('hex');
+const stdoutExcerpt = stdout.split(/\r?\n/).slice(-40).join('\n');
 
 fs.writeFileSync(file, JSON.stringify({
   total: parsedTotal,
@@ -206,7 +210,15 @@ fs.writeFileSync(file, JSON.stringify({
       test_name: testName,
       test_file: testFile,
       error_type: errorType,
+      test_id: testName,
+      suite: '',
+      file: testFile,
+      line: 0,
       message,
+      failure_type: errorType,
+      fingerprint,
+      stdout_excerpt: stdoutExcerpt,
+      stderr_excerpt: '',
       source_file: testFile,
       source_line: 0
     }
@@ -307,6 +319,7 @@ if type homeboy_write_test_results >/dev/null 2>&1; then
 fi
 
 write_node_failure_json
+rm -f "$OUTPUT_FILE"
 
 if [ $TEST_EXIT -ne 0 ]; then
     FAILED_STEP="Tests failed (exit $TEST_EXIT)"


### PR DESCRIPTION
## Summary
- Add normalized aliases to Node.js test failure sidecars: `test_id`, `file`, `line`, and `failure_type`.
- Add a stable SHA-256 `fingerprint` plus stdout/stderr excerpt fields for cross-runner clustering.
- Extend the Nx/Vitest timeout smoke to assert the enriched sidecar fields.

Refs #388.

## Testing
- `bash -n nodejs/scripts/test/test-runner.sh nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh`
- `bash nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Enriching Node.js test failure sidecar output and updating smoke coverage.