### PR TITLE
feat: declare CI reproduction profiles

### DIFF
--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -61,6 +61,59 @@
       "description": "npm script to run when homeboy test receives passthrough test args, for example 'test:unit'"
     }
   ],
+  "ci": {
+    "profiles": {
+      "pr": {
+        "label": "Pull request checks",
+        "jobs": ["lint", "typecheck", "test", "build"]
+      },
+      "baseline": {
+        "label": "Baseline local reproduction",
+        "jobs": ["lint", "test", "build"]
+      }
+    },
+    "jobs": {
+      "lint": {
+        "check_names": ["Lint", "lint"],
+        "command": "lint",
+        "env": { "CI": "1" },
+        "provider": "github-actions",
+        "workflow": "ci.yml",
+        "fidelity": "local-equivalent",
+        "limitations": []
+      },
+      "typecheck": {
+        "check_names": ["Typecheck", "Lint and typecheck", "typecheck"],
+        "command": "lint",
+        "env": {
+          "CI": "1",
+          "HOMEBOY_NODE_LINT_COMMAND": "__homeboy_typecheck"
+        },
+        "provider": "github-actions",
+        "workflow": "ci.yml",
+        "fidelity": "local-partial",
+        "limitations": ["Requires a package.json scripts.typecheck command; alternate project-specific typecheck script names are not inferred."]
+      },
+      "test": {
+        "check_names": ["Test", "Tests", "test"],
+        "command": "test",
+        "env": { "CI": "1" },
+        "provider": "github-actions",
+        "workflow": "ci.yml",
+        "fidelity": "local-equivalent",
+        "limitations": []
+      },
+      "build": {
+        "check_names": ["Build", "build"],
+        "command": "build",
+        "env": { "CI": "1" },
+        "provider": "github-actions",
+        "workflow": "ci.yml",
+        "fidelity": "local-equivalent",
+        "limitations": []
+      }
+    }
+  },
   "audit": {
     "feature_patterns": [
       "app\\.get\\(['\"]([^'\"]+)['\"]",

--- a/nodejs/scripts/lint/lint-runner.sh
+++ b/nodejs/scripts/lint/lint-runner.sh
@@ -69,7 +69,18 @@ done
 # Resolve the lint command.
 USE_ESLINT_JSON=0
 if [ -n "${HOMEBOY_NODE_LINT_COMMAND:-}" ]; then
-    LINT_CMD="$HOMEBOY_NODE_LINT_COMMAND"
+    if [ "$HOMEBOY_NODE_LINT_COMMAND" = "__homeboy_typecheck" ]; then
+        if homeboy_has_npm_script "typecheck"; then
+            LINT_CMD="$PKG_RUN typecheck"
+        else
+            FAILED_STEP="No typecheck script defined"
+            FAILURE_OUTPUT="CI job requested typecheck, but package.json does not define scripts.typecheck. Set HOMEBOY_NODE_LINT_COMMAND to a project-specific command or add scripts.typecheck."
+            echo "[]" > "$FINDINGS_FILE"
+            exit 1
+        fi
+    else
+        LINT_CMD="$HOMEBOY_NODE_LINT_COMMAND"
+    fi
 elif [ "$FIX_MODE" = "1" ] && homeboy_has_npm_script "lint:fix"; then
     LINT_CMD="$PKG_RUN lint:fix"
 elif homeboy_has_npm_script "lint"; then

--- a/nodejs/scripts/lint/typecheck-ci-command-smoke.sh
+++ b/nodejs/scripts/lint/typecheck-ci-command-smoke.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PROJECT="${TMPDIR}/project"
+mkdir -p "$PROJECT"
+cat > "${PROJECT}/package.json" <<'JSON'
+{
+  "name": "typecheck-ci-smoke",
+  "private": true,
+  "scripts": {
+    "typecheck": "node -e \"console.log('typecheck ran')\""
+  }
+}
+JSON
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_PATH="$PROJECT" \
+HOMEBOY_NODE_LINT_COMMAND="__homeboy_typecheck" \
+    bash "${EXTENSION_PATH}/scripts/lint/lint-runner.sh" > "${TMPDIR}/typecheck.out"
+
+if ! grep -Fq "Command:   npm run typecheck" "${TMPDIR}/typecheck.out"; then
+    echo "Expected typecheck CI sentinel to resolve through package-manager runner" >&2
+    sed 's/^/  /' "${TMPDIR}/typecheck.out" >&2
+    exit 1
+fi
+
+if ! grep -Fq "typecheck ran" "${TMPDIR}/typecheck.out"; then
+    echo "Expected typecheck script to run" >&2
+    sed 's/^/  /' "${TMPDIR}/typecheck.out" >&2
+    exit 1
+fi
+
+echo "Node.js typecheck CI command smoke passed"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -818,6 +818,53 @@
     "backend": "wp-codebox",
     "description": "Plugin/theme PHPUnit runs through WP Codebox by default. Use the host-smoke backend only for standalone tests/**/*-smoke.php scripts that run under host PHP without WordPress bootstrap."
   },
+  "ci": {
+    "profiles": {
+      "pr": {
+        "label": "Pull request checks",
+        "jobs": ["lint", "wp-codebox-phpunit"]
+      },
+      "wp-codebox-runtime": {
+        "label": "WP Codebox runtime checks",
+        "jobs": ["wp-codebox-phpunit", "wp-codebox-bench"]
+      }
+    },
+    "jobs": {
+      "lint": {
+        "check_names": ["Lint", "PHP lint", "WordPress lint"],
+        "command": "lint",
+        "env": { "CI": "1" },
+        "provider": "github-actions",
+        "workflow": "homeboy.yml",
+        "fidelity": "local-equivalent",
+        "limitations": []
+      },
+      "wp-codebox-phpunit": {
+        "check_names": ["DB activation PHPUnit smoke", "WP Codebox PHPUnit", "WordPress PHPUnit"],
+        "command": "test",
+        "env": {
+          "CI": "1",
+          "HOMEBOY_WORDPRESS_TEST_BACKEND": "wp-codebox"
+        },
+        "provider": "github-actions",
+        "workflow": "wp-codebox-test-runtime-canary.yml",
+        "fidelity": "local-partial",
+        "limitations": ["Runs the local WP Codebox-backed WordPress test runner; CI checkout/setup details such as a freshly built external wp-codebox checkout are not reproduced by the profile itself."]
+      },
+      "wp-codebox-bench": {
+        "check_names": ["WP Codebox bench", "WordPress bench"],
+        "command": "bench",
+        "env": {
+          "CI": "1",
+          "HOMEBOY_BENCH_ITERATIONS": "3"
+        },
+        "provider": "github-actions",
+        "workflow": "homeboy.yml",
+        "fidelity": "local-partial",
+        "limitations": ["Runs local WP Codebox bench recipes for the current component; provider matrices, hosted runner hardware, and remote artifacts are not reproduced."]
+      }
+    }
+  },
   "settings": [
     {
       "id": "test_backend",


### PR DESCRIPTION
## Summary
- Add explicit Node.js CI profiles/jobs for lint, typecheck, test, and build reproduction.
- Add WordPress CI profiles/jobs for WP Codebox-backed test and bench reproduction with fidelity/limitations metadata.
- Add package-manager-aware Node.js `typecheck` CI handling through the existing lint runner contract.

Fixes #730.

## Verification
- `jq empty nodejs/nodejs.json wordpress/wordpress.json`
- `bash -n nodejs/scripts/lint/lint-runner.sh nodejs/scripts/lint/typecheck-ci-command-smoke.sh`
- `bash nodejs/scripts/lint/typecheck-ci-command-smoke.sh`
- Isolated Homeboy home: installed worktree Node.js/WordPress extensions and verified `homeboy ci list` surfaces the declared profiles/jobs.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the manifest CI contracts, added Node.js typecheck runner support, and ran local verification for Chris to review.