### PR TITLE
Enable multisite mode for WordPress WP Codebox tests

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -519,6 +519,10 @@ if (result.status === 'process_exited') {
 - **WP version defaults to 6.9.** Override `playground_wordpress_version` to pass
   a different `--wp=<version>` to Playground. Mismatched versions produce
   missing-class errors.
+- **Multisite is opt-in.** Set `HOMEBOY_PLAYGROUND_MULTISITE=1`,
+  `HOMEBOY_WORDPRESS_MULTISITE=1`, or `playground.multisite: true` in settings.
+  Plugin tests also auto-enable multisite when the plugin header declares
+  `Network: true`.
 - **Partial phpunit.xml consumption.** The runner reads `<testsuite>` and
   `<exclude>` entries from `phpunit.xml.dist` only; other elements are
   ignored.

--- a/wordpress/scripts/test/core-dev-shape-smoke.sh
+++ b/wordpress/scripts/test/core-dev-shape-smoke.sh
@@ -130,6 +130,7 @@ HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="wordpress-develop" \
 HOMEBOY_COMPONENT_PATH="$CORE_WP_CODEBOX_FIXTURE" \
 HOMEBOY_COMPONENT_SHAPE="core-dev" \
+HOMEBOY_WORDPRESS_MULTISITE=1 \
 HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/wp-codebox-core-stub.sh" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/phpunit/tests/basic.php > "${TMPDIR}/test-wp-codebox.out"
 assert_contains "${TMPDIR}/test-wp-codebox.out" "Running WordPress core PHPUnit tests via WP Codebox"
@@ -138,6 +139,7 @@ assert_contains "${TMPDIR}/core-wp-codebox-recipe.json" "wordpress.core-phpunit"
 assert_contains "${TMPDIR}/core-wp-codebox-recipe.json" '"target": "/wordpress"'
 assert_contains "${TMPDIR}/core-wp-codebox-recipe.json" '"target": "/wordpress/tests/phpunit"'
 assert_contains "${TMPDIR}/core-wp-codebox-recipe.json" 'test-file=tests/phpunit/tests/basic.php'
+assert_contains "${TMPDIR}/core-wp-codebox-recipe.json" 'multisite=1'
 
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="wordpress-develop" \

--- a/wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh
@@ -105,12 +105,21 @@ fi
 
 WP_CONFIG_DEFINES_JSON="{}"
 PLAYGROUND_WORDPRESS_VERSION="6.9"
+PLAYGROUND_MULTISITE="${HOMEBOY_WORDPRESS_MULTISITE:-}"
 if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.wp_config_defines // {}' 2>/dev/null || echo "{}")
     [ -n "$extracted" ] && WP_CONFIG_DEFINES_JSON="$extracted"
 
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.playground_wordpress_version // .wp_codebox_wordpress_version // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && PLAYGROUND_WORDPRESS_VERSION="$extracted"
+
+    if [ -z "$PLAYGROUND_MULTISITE" ]; then
+        extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.playground.multisite // .wp_codebox_multisite // .multisite // empty' 2>/dev/null || true)
+        [ -n "$extracted" ] && [ "$extracted" != "null" ] && PLAYGROUND_MULTISITE="$extracted"
+    fi
+fi
+if [ -n "${HOMEBOY_PLAYGROUND_MULTISITE+x}" ]; then
+    PLAYGROUND_MULTISITE="$HOMEBOY_PLAYGROUND_MULTISITE"
 fi
 
 MOUNTS_JSON=$(jq -nc \
@@ -151,6 +160,7 @@ jq -n \
     --arg selectedTestFile "$SELECTED_TEST_FILE" \
     --arg changedTestsJson "$CHANGED_TEST_FILES_JSON" \
     --arg definesJson "$WP_CONFIG_DEFINES_JSON" \
+    --arg multisite "$PLAYGROUND_MULTISITE" \
     '{
         schema: "wp-codebox/workspace-recipe/v1",
         runtime: {wp: $wp, blueprint: {steps: []}},
@@ -162,7 +172,8 @@ jq -n \
             "autoload-file=/wordpress/vendor/autoload.php",
             "test-file=" + $selectedTestFile,
             "changed-tests-json=" + $changedTestsJson,
-            "wp-config-defines-json=" + $definesJson
+            "wp-config-defines-json=" + $definesJson,
+            "multisite=" + (if (($multisite | ascii_downcase) as $v | $v == "1" or $v == "true" or $v == "yes" or $v == "on") then "1" else "0" end)
         ]}]}
     }' > "$RECIPE_FILE"
 

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -52,6 +52,17 @@ else
     PLUGIN_SLUG="$(basename "$PLUGIN_PATH")"
 fi
 
+detect_network_plugin_header() {
+    local main_file
+    for main_file in "${PLUGIN_PATH}"/*.php; do
+        [ -f "$main_file" ] || continue
+        if grep -q '^[[:space:]]*Plugin Name:' "$main_file" && grep -qi '^[[:space:]]*Network:[[:space:]]*true[[:space:]]*$' "$main_file"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 component_has_composer_test_script() {
     [ -f "${PLUGIN_PATH}/composer.json" ] || return 1
 
@@ -211,6 +222,7 @@ BENCH_ENV_JSON="{}"
 PLAYGROUND_FILE_MOUNTS_JSON="[]"
 PHPUNIT_NO_TESTS="skipped"
 PLAYGROUND_WORDPRESS_VERSION="6.9"
+PLAYGROUND_MULTISITE=""
 if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.wp_config_defines // {}' 2>/dev/null || echo "{}")
     [ -n "$extracted" ] && WP_CONFIG_DEFINES_JSON="$extracted"
@@ -226,6 +238,18 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
 
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.playground_wordpress_version // .wp_codebox_wordpress_version // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && PLAYGROUND_WORDPRESS_VERSION="$extracted"
+
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.playground.multisite // .wp_codebox_multisite // .multisite // empty' 2>/dev/null || true)
+    [ -n "$extracted" ] && [ "$extracted" != "null" ] && PLAYGROUND_MULTISITE="$extracted"
+fi
+if [ -n "${HOMEBOY_WORDPRESS_MULTISITE+x}" ]; then
+    PLAYGROUND_MULTISITE="$HOMEBOY_WORDPRESS_MULTISITE"
+fi
+if [ -n "${HOMEBOY_PLAYGROUND_MULTISITE+x}" ]; then
+    PLAYGROUND_MULTISITE="$HOMEBOY_PLAYGROUND_MULTISITE"
+fi
+if [ -z "$PLAYGROUND_MULTISITE" ] && detect_network_plugin_header; then
+    PLAYGROUND_MULTISITE="1"
 fi
 
 CHANGED_TEST_FILES_JSON="[]"
@@ -368,6 +392,7 @@ echo "  Backend: wp-codebox (WordPress Playground runtime)"
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "  Mounts: ${MOUNTS_JSON}"
     echo "  WordPress version: ${PLAYGROUND_WORDPRESS_VERSION}"
+    echo "  Multisite: ${PLAYGROUND_MULTISITE:-0}"
     echo "  Artifacts: ${ARTIFACTS_DIR}"
 fi
 
@@ -390,6 +415,7 @@ jq -n \
     --arg envJson "$BENCH_ENV_JSON" \
     --arg definesJson "$WP_CONFIG_DEFINES_JSON" \
     --arg dependencyMounts "$PLAYGROUND_DEP_MOUNTS" \
+    --arg multisite "$PLAYGROUND_MULTISITE" \
     '{
         schema: "wp-codebox/workspace-recipe/v1",
         runtime: {wp: $wp, blueprint: {steps: []}},
@@ -402,7 +428,8 @@ jq -n \
             "wp-config-defines-json=" + $definesJson,
             "autoload-file=/wp-codebox-vendor/autoload.php",
             "tests-dir=/wp-codebox-vendor/wp-phpunit/wp-phpunit",
-            "dependency-mounts=" + ($dependencyMounts | split("\n") | map(select(. != "")) | join(","))
+            "dependency-mounts=" + ($dependencyMounts | split("\n") | map(select(. != "")) | join(",")),
+            "multisite=" + (if (($multisite | ascii_downcase) as $v | $v == "1" or $v == "true" or $v == "yes" or $v == "on") then "1" else "0" end)
         ]}]}
     }' > "$RECIPE_FILE"
 

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -19,6 +19,7 @@ cat > "${PLUGIN_PATH}/tests/OnlyTest.php" <<'PHP'
 class OnlyTest extends WP_UnitTestCase {}
 PHP
 printf '<?php // component drop-in\n' > "${PLUGIN_PATH}/db.php"
+printf '<?php /*\nPlugin Name: Example\nNetwork: true\n*/\n' > "${PLUGIN_PATH}/example.php"
 printf 'component-extra\n' > "${PLUGIN_PATH}/config/component-extra.php"
 printf '<?php /*\nPlugin Name: Dep Plugin\n*/\n' > "${DEP_PATH}/dep-plugin.php"
 printf 'dependency-extra\n' > "${DEP_PATH}/fixtures/dep-extra.php"
@@ -75,6 +76,7 @@ for (const expected of [
   'autoload-file=/wp-codebox-vendor/autoload.php',
   'tests-dir=/wp-codebox-vendor/wp-phpunit/wp-phpunit',
   'dependency-mounts=/wordpress/wp-content/plugins/dep-plugin',
+  'multisite=1',
 ]) {
   if (!(step.args || []).includes(expected)) {
     throw new Error(`step args missing expected value: ${expected}\nactual:\n${(step.args || []).join('\n')}`)


### PR DESCRIPTION
## Summary
- Pass `multisite=1` into WP Codebox PHPUnit recipes from the WordPress plugin and core-dev runners.
- Support `HOMEBOY_PLAYGROUND_MULTISITE=1`, existing `HOMEBOY_WORDPRESS_MULTISITE=1`, `playground.multisite: true`, and `Network: true` plugin-header auto-detection.
- Document the setting and extend runner smokes for plugin and core-dev multisite arguments.

Fixes #612.

## Upstream
- Requires WP Codebox multisite PHPUnit support from chubes4/wp-codebox#94, already merged.

## Testing
- `bash -n scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/test-runner-core-dev-wp-codebox.sh scripts/test/wp-codebox-mount-translation-smoke.sh scripts/test/core-dev-shape-smoke.sh scripts/test/test-runner-file-routing-smoke.sh`
- `bash scripts/test/wp-codebox-mount-translation-smoke.sh`
- `bash scripts/test/core-dev-shape-smoke.sh`
- `bash scripts/test/test-runner-file-routing-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the runner wiring, settings/env detection, documentation, and smoke coverage; Chris remains responsible for review and merge.