### PR TITLE
Omit optional deps when installing WP Codebox in setup

### DIFF
--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -5,6 +5,7 @@ TMPDIR="$(mktemp -d)"
 trap 'rm -rf "${TMPDIR}"' EXIT
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NODE_BIN_DIR="$(dirname "$(command -v node)")"
 FAKE_BIN="${TMPDIR}/bin"
 HOME_DIR="${TMPDIR}/home"
 EXTENSION_DIR="${TMPDIR}/extension"
@@ -44,6 +45,10 @@ while [ "$#" -gt 0 ]; do
             shift 2
             ;;
         install)
+            if [[ " $* " != *" --omit=optional "* ]]; then
+                printf 'expected wp-codebox install to omit optional dependencies: %s\n' "$*" >&2
+                exit 1
+            fi
             exit 0
             ;;
         run)
@@ -62,7 +67,7 @@ chmod +x "${FAKE_BIN}/npm"
 (
     cd "${EXTENSION_DIR}"
     HOME="${HOME_DIR}" \
-    PATH="${FAKE_BIN}:${PATH}" \
+    PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" \
     GITHUB_ENV="${GITHUB_ENV_FILE}" \
     HOMEBOY_WP_CODEBOX_SOURCE="https://example.test/wp-codebox.git" \
     HOMEBOY_WP_CODEBOX_REF="main" \

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -47,7 +47,7 @@ install_wp_codebox() {
     git -C "${repo_dir}" fetch --quiet origin "${ref}"
     git -C "${repo_dir}" checkout --quiet FETCH_HEAD
 
-    npm --prefix "${repo_dir}" install --quiet --no-fund --no-audit
+    npm --prefix "${repo_dir}" install --quiet --no-fund --no-audit --omit=optional
     npm --prefix "${repo_dir}" run build --silent
 
     cat > "${bin_path}" <<EOF


### PR DESCRIPTION
## Summary
- Install WP Codebox with `--omit=optional` during WordPress extension setup so Linux CI does not try to install platform-only optional packages like `fsevents`.
- Tighten the WP Codebox setup smoke test to verify optional dependencies stay omitted and to isolate the fake PATH from any preinstalled `wp-codebox` binary.

## Testing
- `bash -n wordpress/scripts/build/setup.sh`
- `bash -n wordpress/scripts/build/setup-wp-codebox-smoke.sh`
- `bash wordpress/scripts/build/setup-wp-codebox-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the CI setup failure and drafted the setup-script/test changes; Chris remains responsible for review and validation.