### PR TITLE
fix: classify WordPress changed-since registration drift

### DIFF
--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -76,6 +76,11 @@ if [ -n "$recipe_path" ] && [ -f "$recipe_path" ]; then
     component_path="$(jq -r '.inputs.mounts[]? | select(.target == "/wordpress/wp-content/plugins/component") | .source' "$recipe_path" | head -n 1)"
 fi
 if [ -n "$component_path" ]; then
+    if [ "${WP_CODEBOX_STUB_REGISTRATION_DRIFT:-}" = "1" ]; then
+        printf 'SOME TESTS FAILED\nTESTS: 4 FAILURES: 3 ERRORS: 1\n' > "${component_path}/.pg-test-result.txt"
+        printf '%s\n' '{"success":false,"executions":[{"stdout":"Abilities not registered during plugin boot: datamachine/get-flows, datamachine/create-flow\\nAbility category '\''datamachine-content'\'' should be registered during plugin boot\\nUnexpected incorrect usage notice for WP_Abilities_Registry::get_registered.\\nAbility \\\"datamachine/execute-workflow\\\" not found.\\nFailed asserting that an array has the key '\''image_generation'\''.\\nFailed asserting that an array has the key '\''web_fetch'\''.\\n","stderr":""}]}'
+        exit 1
+    fi
     printf 'ALL TESTS PASSED\nTESTS: 1 FAILURES: 0 ERRORS: 0\n' > "${component_path}/.pg-test-result.txt"
 fi
 printf '{"success":true,"executions":[{"stdout":"OK (1 test, 1 assertion)\n","stderr":""}]}\n'
@@ -154,6 +159,27 @@ WP_CODEBOX_ARGS_FILE="${TMPDIR}/wp-codebox-settings-args.txt" \
 
 assert_contains "${TMPDIR}/wp-codebox-settings.out" "WP_CODEBOX_STUB"
 assert_contains "${TMPDIR}/wp-codebox-settings-args.txt" "latest"
+
+set +e
+WP_CODEBOX_STUB_REGISTRATION_DRIFT=1 \
+HOMEBOY_CHANGED_SINCE="origin/main" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/stubs/wp-codebox.sh" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/registration-drift.out" 2>&1
+status=$?
+set -e
+
+if [ "$status" -ne 1 ]; then
+    echo "Expected registration drift preflight to exit 1, got $status" >&2
+    sed 's/^/  /' "${TMPDIR}/registration-drift.out" >&2
+    exit 1
+fi
+assert_contains "${TMPDIR}/registration-drift.out" "HARNESS PREFLIGHT FAILURE: WordPress bootstrap registration drift"
+assert_contains "${TMPDIR}/registration-drift.out" "Changed-since PHPUnit hit broad missing registration drift"
+assert_contains "${TMPDIR}/registration-drift.out" "changed-since: origin/main"
 
 set +e
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -488,6 +488,43 @@ dump_diagnostics() {
     fi
 }
 
+is_changed_since_registration_drift() {
+    if [ -z "${HOMEBOY_CHANGED_SINCE:-}" ]; then
+        return 1
+    fi
+
+    local registration_output
+    registration_output="${PHPUNIT_STDOUT}
+${WP_CODEBOX_OUTPUT}"
+
+    if echo "$registration_output" | grep -qE "Abilities not registered during plugin boot|Ability category '.+' should be registered during plugin boot|WP_Abilities_Registry::get_registered|Ability .* not found"; then
+        return 0
+    fi
+
+    local drift_count
+    drift_count=$(echo "$registration_output" | grep -Ec "Failed asserting that an array has the key '([^']+)'." || true)
+    if [ "${drift_count:-0}" -ge 3 ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+dump_registration_drift_preflight() {
+    local registration_output
+    registration_output="${PHPUNIT_STDOUT}
+${WP_CODEBOX_OUTPUT}"
+
+    dump_diagnostics "HARNESS PREFLIGHT FAILURE: WordPress bootstrap registration drift"
+    echo ""
+    echo "Changed-since PHPUnit hit broad missing registration drift in the WordPress test runtime."
+    echo "This is reported as one harness/preflight failure so unrelated ability, task, and tool tests do not mask the branch signal."
+    echo "  changed-since: ${HOMEBOY_CHANGED_SINCE}"
+    echo ""
+    echo "--- Registration drift evidence ---"
+    echo "$registration_output" | grep -E "Abilities not registered during plugin boot|Ability category '.+' should be registered during plugin boot|WP_Abilities_Registry::get_registered|Ability .* not found|Failed asserting that an array has the key '([^']+)'." | head -20 || true
+}
+
 if echo "$PHPUNIT_OUTPUT" | grep -qE '^STAGE_(FAIL|FATAL):'; then
     FAILED_STAGE_LINE=$(echo "$PHPUNIT_OUTPUT" | grep -E '^STAGE_(FAIL|FATAL):' | head -1)
     FAILED_STAGE_DETAIL=$(echo "$FAILED_STAGE_LINE" | sed -E 's/^STAGE_(FAIL|FATAL)://')
@@ -496,6 +533,15 @@ if echo "$PHPUNIT_OUTPUT" | grep -qE '^STAGE_(FAIL|FATAL):'; then
     dump_diagnostics "BOOTSTRAP FAILURE: $FAILED_STAGE_DETAIL"
     rm -f "$RESULT_FILE"
     exit ${wp_codebox_exit:-1}
+fi
+
+if [ $wp_codebox_exit -ne 0 ] && is_changed_since_registration_drift; then
+    FAILED_STEP="WordPress PHPUnit harness preflight (registration drift)"
+    FAILURE_OUTPUT="Changed-since WordPress PHPUnit detected broad missing registration drift."
+    dump_registration_drift_preflight
+    write_phpunit_discovery_result failed "wordpress-registration-drift" "Changed-since WordPress PHPUnit detected broad missing registration drift in the test runtime."
+    rm -f "$RESULT_FILE"
+    exit 1
 fi
 
 if echo "$PHPUNIT_OUTPUT" | grep -q "SOME TESTS FAILED"; then


### PR DESCRIPTION
## Summary
- Detect changed-since WordPress PHPUnit runs that fail with broad missing registration drift and report them as one harness/preflight failure.
- Keep normal PHPUnit failures unchanged outside changed-since runs.
- Extend the WordPress test-runner routing smoke to cover the registration-drift diagnostic path.

Closes #372.

## Verification
- `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `bash wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `bash wordpress/scripts/test/wp-codebox-bootstrap-failure-smoke.sh`
- `bash wordpress/scripts/test/parse-test-failures-sidecar-smoke.sh`
- `bash wordpress/scripts/test/parse-wp-codebox-artifacts-smoke.sh`
- `bash wordpress/scripts/test/host-smoke-runner-smoke.sh`
- `bash wordpress/scripts/test/core-dev-shape-smoke.sh`
- `bash wordpress/tests/wp-cli-runtime-dispatch-fingerprint-smoke.sh`
- `bash wordpress/tests/wp-cli-auto-flags-smoke.sh`
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `homeboy lint homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-changed-since-preflight --extension nodejs --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Issue investigation, harness fix implementation, smoke coverage update, and local verification. Chris remains responsible for review and merge.