### PR TITLE
fix: normalize sidecar contracts across extensions

### DIFF
--- a/docs/structured-sidecars.md
+++ b/docs/structured-sidecars.md
@@ -16,3 +16,34 @@ Supported keys:
 - `annotations` — writes inline-review annotation JSON files to `HOMEBOY_ANNOTATIONS_DIR`.
 
 Use `false` for unsupported contracts. Absence means the manifest has not been audited and should not be treated as support.
+
+## `lint.findings` v1
+
+`HOMEBOY_LINT_FINDINGS_FILE` contains a JSON array of lint finding objects. Emit fields when known; use `null` for optional unknown values when a stable field is useful to consumers.
+
+- `id` — stable finding identity derived from tool, file, location, rule, and message.
+- `file` — repository-relative path when available.
+- `line` — 1-based line number when available.
+- `column` — 1-based column number when available.
+- `severity` — `error` or `warning`.
+- `source` — producing tool, for example `eslint`, `phpcs`, `phpstan`, `rustfmt`, `clippy`, `swiftlint`, `gofmt`, or `go vet`.
+- `code` — tool rule or diagnostic code.
+- `category` — coarse grouping such as `style`, `format`, or `correctness`.
+- `message` — human-readable diagnostic message.
+- `fixable` — boolean indicating whether the tool can apply a fix automatically.
+- `fingerprint` — stable hash for unchanged findings.
+- `excerpt` — bounded source line excerpt when available.
+
+## `test.failures` v1
+
+`HOMEBOY_TEST_FAILURES_FILE` contains a JSON array of test failure objects.
+
+- `test_id` — stable test identifier, usually package/module plus test name.
+- `suite` — suite, package, class, or runner grouping when available.
+- `file` — repository-relative test file when available.
+- `line` — 1-based failure line when available.
+- `message` — human-readable failure summary.
+- `failure_type` — `test_failure` for assertion/test failures or `infrastructure` for runner/package/setup failures.
+- `fingerprint` — stable hash for unchanged failures.
+- `stdout_excerpt` — bounded output excerpt relevant to the failure.
+- `stderr_excerpt` — bounded stderr excerpt relevant to the failure.

--- a/go/go.json
+++ b/go/go.json
@@ -10,9 +10,9 @@
     "capabilities": ["fingerprint", "format", "validate"]
   },
   "structured_sidecars": {
-    "lint.findings": false,
+    "lint.findings": true,
     "test.results": false,
-    "test.failures": false,
+    "test.failures": true,
     "test.coverage": false,
     "annotations": false
   },

--- a/go/scripts/lint-runner.sh
+++ b/go/scripts/lint-runner.sh
@@ -1,5 +1,116 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-go fmt ./...
-go vet ./...
+PROJECT_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
+
+write_lint_findings() {
+    local gofmt_file="$1"
+    local govet_file="$2"
+
+    if [ -z "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
+        return 0
+    fi
+
+    python3 - "$PROJECT_PATH" "$gofmt_file" "$govet_file" "$HOMEBOY_LINT_FINDINGS_FILE" <<'PY'
+import hashlib
+import json
+import os
+import re
+import sys
+
+project, gofmt_file, govet_file, target = sys.argv[1:]
+
+def rel(path):
+    if os.path.isabs(path):
+        try:
+            return os.path.relpath(path, project)
+        except ValueError:
+            return path
+    return path
+
+def excerpt(file, line):
+    try:
+        with open(os.path.join(project, file), encoding="utf-8") as handle:
+            lines = handle.read().splitlines()
+        if 1 <= line <= len(lines):
+            return lines[line - 1][:240]
+    except OSError:
+        return None
+    return None
+
+findings = []
+with open(gofmt_file, encoding="utf-8") as handle:
+    for raw_file in handle.read().splitlines():
+        file = rel(raw_file.strip())
+        if not file:
+            continue
+        identity = f"go:gofmt:{file}:1"
+        findings.append({
+            "id": identity,
+            "file": file,
+            "line": 1,
+            "column": 1,
+            "severity": "warning",
+            "source": "gofmt",
+            "code": "formatting",
+            "category": "format",
+            "message": "File is not gofmt-formatted",
+            "fixable": True,
+            "fingerprint": hashlib.sha1(identity.encode()).hexdigest(),
+            "excerpt": excerpt(file, 1),
+        })
+
+vet_pattern = re.compile(r"^(?P<file>[^:\n]+\.go):(?P<line>\d+):(?:(?P<column>\d+):)?\s*(?P<message>.+)$")
+with open(govet_file, encoding="utf-8") as handle:
+    for line in handle.read().splitlines():
+        match = vet_pattern.match(line.strip())
+        if not match:
+            continue
+        file = rel(match.group("file"))
+        line_no = int(match.group("line"))
+        column = int(match.group("column") or 1)
+        message = match.group("message")
+        identity = f"go:govet:{file}:{line_no}:{column}:{message}"
+        findings.append({
+            "id": identity,
+            "file": file,
+            "line": line_no,
+            "column": column,
+            "severity": "error",
+            "source": "go vet",
+            "code": "vet",
+            "category": "correctness",
+            "message": message,
+            "fixable": False,
+            "fingerprint": hashlib.sha1(identity.encode()).hexdigest(),
+            "excerpt": excerpt(file, line_no),
+        })
+
+with open(target, "w", encoding="utf-8") as handle:
+    json.dump(findings, handle, indent=2)
+    handle.write("\n")
+PY
+}
+
+GOFMT_FILE="$(mktemp)"
+GOVET_FILE="$(mktemp)"
+trap 'rm -f "$GOFMT_FILE" "$GOVET_FILE"' EXIT
+
+find "$PROJECT_PATH" -name '*.go' -not -path '*/vendor/*' -not -path '*/.git/*' -print0 | while IFS= read -r -d '' file; do
+    gofmt -l "$file"
+done > "$GOFMT_FILE" || true
+
+set +e
+(cd "$PROJECT_PATH" && go vet ./...) 2>&1 | tee "$GOVET_FILE"
+GOVET_EXIT=${PIPESTATUS[0]}
+set -e
+
+write_lint_findings "$GOFMT_FILE" "$GOVET_FILE"
+
+if [ -s "$GOFMT_FILE" ]; then
+    echo "Go files need formatting:"
+    sed 's/^/  /' "$GOFMT_FILE"
+    exit 1
+fi
+
+exit "$GOVET_EXIT"

--- a/go/scripts/test-runner.sh
+++ b/go/scripts/test-runner.sh
@@ -1,4 +1,86 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-go test ./...
+PROJECT_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
+OUTPUT_FILE="$(mktemp)"
+trap 'rm -f "$OUTPUT_FILE"' EXIT
+
+set +e
+(cd "$PROJECT_PATH" && go test -json ./...) 2>&1 | tee "$OUTPUT_FILE"
+TEST_EXIT=${PIPESTATUS[0]}
+set -e
+
+if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ]; then
+    python3 - "$PROJECT_PATH" "$OUTPUT_FILE" "$HOMEBOY_TEST_FAILURES_FILE" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+project, output_file, target = sys.argv[1:]
+events = []
+with open(output_file, encoding="utf-8") as handle:
+    for raw in handle:
+        try:
+            events.append(json.loads(raw))
+        except json.JSONDecodeError:
+            continue
+
+output_by_test = {}
+failed_tests = []
+failed_packages = set()
+for event in events:
+    package = event.get("Package", "")
+    test = event.get("Test", "")
+    action = event.get("Action", "")
+    if event.get("Output") and test:
+        output_by_test.setdefault((package, test), []).append(event["Output"].rstrip())
+    if action == "fail" and test:
+        failed_tests.append((package, test))
+    elif action == "fail" and package:
+        failed_packages.add(package)
+
+failures = []
+seen = set()
+for package, test in failed_tests:
+    if (package, test) in seen:
+        continue
+    seen.add((package, test))
+    lines = output_by_test.get((package, test), [])
+    message = next((line.strip() for line in reversed(lines) if line.strip()), f"{test} failed")
+    test_id = f"{package}.{test}" if package else test
+    identity = f"go:test:{test_id}:{message}"
+    failures.append({
+        "test_id": test_id,
+        "suite": package or None,
+        "file": None,
+        "line": None,
+        "message": message,
+        "failure_type": "test_failure",
+        "fingerprint": hashlib.sha256(identity.encode()).hexdigest(),
+        "stdout_excerpt": "\n".join(lines)[-4000:] if lines else "",
+        "stderr_excerpt": "",
+    })
+
+if not failures:
+    for package in sorted(failed_packages):
+        identity = f"go:package:{package}:failed"
+        failures.append({
+            "test_id": package,
+            "suite": package,
+            "file": None,
+            "line": None,
+            "message": f"go test package failed: {package}",
+            "failure_type": "infrastructure",
+            "fingerprint": hashlib.sha256(identity.encode()).hexdigest(),
+            "stdout_excerpt": "",
+            "stderr_excerpt": "",
+        })
+
+with open(target, "w", encoding="utf-8") as handle:
+    json.dump(failures, handle, indent=2)
+    handle.write("\n")
+PY
+fi
+
+exit "$TEST_EXIT"

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -9,9 +9,9 @@
     "capabilities": ["fingerprint", "refactor", "format", "validate"]
   },
   "structured_sidecars": {
-    "lint.findings": false,
+    "lint.findings": true,
     "test.results": true,
-    "test.failures": false,
+    "test.failures": true,
     "test.coverage": false,
     "bench.results": true,
     "annotations": true

--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -104,6 +104,109 @@ write_fix_results_sidecar() {
     fi
 }
 
+write_lint_findings_from_output() {
+    local tool="$1"
+    local output_file="$2"
+
+    if [ -z "${HOMEBOY_LINT_FINDINGS_FILE:-}" ] || [ ! -f "$output_file" ]; then
+        return 0
+    fi
+
+    python3 - "$PROJECT_PATH" "$tool" "$output_file" "$HOMEBOY_LINT_FINDINGS_FILE" <<'PY'
+import hashlib
+import json
+import os
+import re
+import sys
+
+project, tool, output_file, target = sys.argv[1:]
+try:
+    with open(target, encoding="utf-8") as handle:
+        findings = json.load(handle)
+        if not isinstance(findings, list):
+            findings = []
+except (OSError, json.JSONDecodeError):
+    findings = []
+
+def excerpt(file, line):
+    try:
+        with open(os.path.join(project, file), encoding="utf-8") as handle:
+            lines = handle.read().splitlines()
+        if 1 <= line <= len(lines):
+            return lines[line - 1][:240]
+    except OSError:
+        return None
+    return None
+
+with open(output_file, encoding="utf-8") as handle:
+    lines = handle.read().splitlines()
+
+if tool == "rustfmt":
+    pattern = re.compile(r"^Diff in (?P<file>.+) at line (?P<line>\d+):")
+    for raw in lines:
+        match = pattern.match(raw)
+        if not match:
+            continue
+        file = match.group("file")
+        if os.path.isabs(file):
+            file = os.path.relpath(file, project)
+        line = int(match.group("line"))
+        identity = f"rust:rustfmt:{file}:{line}"
+        findings.append({
+            "id": identity,
+            "file": file,
+            "line": line,
+            "column": 1,
+            "severity": "warning",
+            "source": "rustfmt",
+            "code": "formatting",
+            "category": "format",
+            "message": "File needs formatting",
+            "fixable": True,
+            "fingerprint": hashlib.sha1(identity.encode()).hexdigest(),
+            "excerpt": excerpt(file, line),
+        })
+elif tool == "clippy":
+    pending = None
+    diagnostic = re.compile(r"^(?P<severity>warning|error)(\[(?P<code>[^\]]+)\])?: (?P<message>.+)$")
+    location = re.compile(r"^\s+--> (?P<file>[^:\n]+):(?P<line>\d+):(?P<column>\d+)")
+    for raw in lines:
+        match = diagnostic.match(raw)
+        if match:
+            pending = match.groupdict()
+            continue
+        match = location.match(raw)
+        if not match or not pending:
+            continue
+        file = match.group("file")
+        line = int(match.group("line"))
+        column = int(match.group("column"))
+        code = pending.get("code") or "clippy"
+        message = pending.get("message") or "clippy finding"
+        severity = pending.get("severity") or "warning"
+        identity = f"rust:clippy:{file}:{line}:{column}:{code}:{message}"
+        findings.append({
+            "id": identity,
+            "file": file,
+            "line": line,
+            "column": column,
+            "severity": severity,
+            "source": "clippy",
+            "code": code,
+            "category": "correctness",
+            "message": message,
+            "fixable": False,
+            "fingerprint": hashlib.sha1(identity.encode()).hexdigest(),
+            "excerpt": excerpt(file, line),
+        })
+        pending = None
+
+with open(target, "w", encoding="utf-8") as handle:
+    json.dump(findings, handle, indent=2)
+    handle.write("\n")
+PY
+}
+
 trap write_fix_results_sidecar EXIT
 
 # Verify this is a Rust project
@@ -179,6 +282,13 @@ if should_run_step "fmt"; then
         if [ $FMT_EXIT -eq 0 ]; then
             echo "cargo fmt: passed"
         else
+            if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
+                FMT_FINDINGS_TMP="$(mktemp)"
+                printf '%s\n' "$FMT_OUTPUT" > "$FMT_FINDINGS_TMP"
+                write_lint_findings_from_output "rustfmt" "$FMT_FINDINGS_TMP"
+                rm -f "$FMT_FINDINGS_TMP"
+            fi
+
             if [ "${HOMEBOY_SUMMARY_MODE:-}" = "1" ]; then
                 # Count files with formatting issues
                 FILE_COUNT=$(echo "$FMT_OUTPUT" | grep -c "^Diff in" || true)
@@ -320,6 +430,13 @@ if should_run_step "clippy"; then
         if [ -n "$CLIPPY_BEFORE" ]; then
             rm -f "$CLIPPY_BEFORE"
         fi
+        if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
+            CLIPPY_FINDINGS_TMP="$(mktemp)"
+            printf '%s\n' "$CLIPPY_OUTPUT" > "$CLIPPY_FINDINGS_TMP"
+            write_lint_findings_from_output "clippy" "$CLIPPY_FINDINGS_TMP"
+            rm -f "$CLIPPY_FINDINGS_TMP"
+        fi
+
         if [ "${HOMEBOY_SUMMARY_MODE:-}" = "1" ]; then
             WARNING_COUNT=$(echo "$CLIPPY_OUTPUT" | grep -c "^warning\[" || true)
             ERROR_COUNT=$(echo "$CLIPPY_OUTPUT" | grep -c "^error\[" || true)

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -277,7 +277,6 @@ if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$PARSE_RESULTS" ]; then
 fi
 
 TEST_OUTPUT=$(cat "$TEST_TMPFILE")
-rm -f "$TEST_TMPFILE"
 
 
 if [ $TEST_EXIT -eq 0 ]; then
@@ -289,6 +288,7 @@ if [ $TEST_EXIT -eq 0 ]; then
     fi
     echo ""
     echo "Rust tests passed"
+    rm -f "$TEST_TMPFILE"
 else
     # Extract failure details
     SUMMARY=$(echo "$TEST_OUTPUT" | grep -E "^test result:" | tail -1 || true)
@@ -299,8 +299,69 @@ else
         echo "$SUMMARY"
     fi
 
+    if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ]; then
+        python3 - "$PROJECT_PATH" "$TEST_TMPFILE" "$HOMEBOY_TEST_FAILURES_FILE" <<'PY'
+import hashlib
+import json
+import os
+import re
+import sys
+
+project, output_file, target = sys.argv[1:]
+with open(output_file, encoding="utf-8") as handle:
+    lines = handle.read().splitlines()
+
+failed = []
+for raw in lines:
+    match = re.match(r"^test (?P<name>.+) \.\.\. FAILED$", raw)
+    if match:
+        failed.append(match.group("name"))
+
+if not failed:
+    for raw in lines:
+        match = re.match(r"^---- (?P<name>.+) stdout ----$", raw)
+        if match:
+            failed.append(match.group("name"))
+
+failures = []
+for name in dict.fromkeys(failed):
+    message = f"Rust test failed: {name}"
+    identity = f"rust:test:{name}"
+    failures.append({
+        "test_id": name,
+        "suite": None,
+        "file": None,
+        "line": None,
+        "message": message,
+        "failure_type": "test_failure",
+        "fingerprint": hashlib.sha256(identity.encode()).hexdigest(),
+        "stdout_excerpt": "\n".join(lines)[-4000:],
+        "stderr_excerpt": "",
+    })
+
+if not failures:
+    identity = "rust:cargo-test:failed"
+    failures.append({
+        "test_id": "cargo test",
+        "suite": None,
+        "file": None,
+        "line": None,
+        "message": "cargo test failed before individual test failures could be parsed",
+        "failure_type": "infrastructure",
+        "fingerprint": hashlib.sha256(identity.encode()).hexdigest(),
+        "stdout_excerpt": "\n".join(lines)[-4000:],
+        "stderr_excerpt": "",
+    })
+
+with open(target, "w", encoding="utf-8") as handle:
+    json.dump(failures, handle, indent=2)
+    handle.write("\n")
+PY
+    fi
+
     FAILED_STEP="cargo test"
     FAILURE_REPLAY_MODE="none"
+    rm -f "$TEST_TMPFILE"
     exit $TEST_EXIT
 fi
 
@@ -321,7 +382,10 @@ if [ "$TOTAL_PASSED" -eq 0 ]; then
         if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
             FAILED_STEP="cargo test"
             FAILURE_REPLAY_MODE="none"
+            rm -f "$TEST_TMPFILE"
             exit 1
         fi
     fi
 fi
+
+rm -f "$TEST_TMPFILE"

--- a/swift/scripts/lint-runner.sh
+++ b/swift/scripts/lint-runner.sh
@@ -9,8 +9,84 @@ homeboy_resolve_context
 
 echo "Running Swift lint for: $(basename "$COMPONENT_PATH")"
 
+write_swiftlint_findings() {
+    local input_file="$1"
+
+    if [ -z "${HOMEBOY_LINT_FINDINGS_FILE:-}" ] || [ ! -f "$input_file" ]; then
+        return 0
+    fi
+
+    python3 - "$COMPONENT_PATH" "$input_file" "$HOMEBOY_LINT_FINDINGS_FILE" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+component, input_file, target = sys.argv[1:]
+try:
+    with open(input_file, encoding="utf-8") as handle:
+        diagnostics = json.load(handle)
+except (OSError, json.JSONDecodeError):
+    diagnostics = []
+
+def rel(path):
+    if os.path.isabs(path):
+        try:
+            return os.path.relpath(path, component)
+        except ValueError:
+            return path
+    return path
+
+def excerpt(file, line):
+    try:
+        with open(os.path.join(component, file), encoding="utf-8") as handle:
+            lines = handle.read().splitlines()
+        if 1 <= line <= len(lines):
+            return lines[line - 1][:240]
+    except OSError:
+        return None
+    return None
+
+findings = []
+for diagnostic in diagnostics if isinstance(diagnostics, list) else []:
+    file = rel(str(diagnostic.get("file", "")))
+    line = int(diagnostic.get("line") or 1)
+    column = int(diagnostic.get("character") or 1)
+    rule = str(diagnostic.get("rule_id") or "swiftlint")
+    message = str(diagnostic.get("reason") or diagnostic.get("message") or "SwiftLint finding")
+    severity = str(diagnostic.get("severity") or "warning")
+    identity = f"swift:swiftlint:{file}:{line}:{column}:{rule}:{message}"
+    findings.append({
+        "id": identity,
+        "file": file,
+        "line": line,
+        "column": column,
+        "severity": "error" if severity == "error" else "warning",
+        "source": "swiftlint",
+        "code": rule,
+        "category": "style",
+        "message": message,
+        "fixable": bool(diagnostic.get("correction")),
+        "fingerprint": hashlib.sha1(identity.encode()).hexdigest(),
+        "excerpt": excerpt(file, line),
+    })
+
+with open(target, "w", encoding="utf-8") as handle:
+    json.dump(findings, handle, indent=2)
+    handle.write("\n")
+PY
+}
+
 if command -v swiftlint >/dev/null 2>&1; then
-    swiftlint lint --path "$COMPONENT_PATH"
+    SWIFTLINT_JSON="$(mktemp)"
+    trap 'rm -f "$SWIFTLINT_JSON"' EXIT
+    set +e
+    swiftlint lint --path "$COMPONENT_PATH" --reporter json > "$SWIFTLINT_JSON"
+    SWIFTLINT_EXIT=$?
+    set -e
+    write_swiftlint_findings "$SWIFTLINT_JSON"
+    cat "$SWIFTLINT_JSON"
+    exit "$SWIFTLINT_EXIT"
 elif command -v swiftformat >/dev/null 2>&1; then
     swiftformat "$COMPONENT_PATH" --lint
 else

--- a/swift/scripts/test-runner.sh
+++ b/swift/scripts/test-runner.sh
@@ -48,18 +48,83 @@ if [ "$TEST_TYPE" = "xcodebuild" ]; then
     WORKSPACE=$(find "$COMPONENT_PATH" -maxdepth 1 -name "*.xcworkspace" | head -1)
     PROJECT=$(find "$COMPONENT_PATH" -maxdepth 1 -name "*.xcodeproj" | head -1)
 
+    XCODE_OUTPUT="$(mktemp)"
+    trap 'rm -f "$XCODE_OUTPUT"' EXIT
     if [ -n "$WORKSPACE" ]; then
-        xcodebuild test -workspace "$WORKSPACE" -scheme "$(basename "$WORKSPACE" .xcworkspace)" -destination 'platform=macOS' "$@"
+        set +e
+        xcodebuild test -workspace "$WORKSPACE" -scheme "$(basename "$WORKSPACE" .xcworkspace)" -destination 'platform=macOS' "$@" 2>&1 | tee "$XCODE_OUTPUT"
+        XCODE_EXIT=${PIPESTATUS[0]}
+        set -e
     elif [ -n "$PROJECT" ]; then
-        xcodebuild test -project "$PROJECT" -scheme "$(basename "$PROJECT" .xcodeproj)" -destination 'platform=macOS' "$@"
+        set +e
+        xcodebuild test -project "$PROJECT" -scheme "$(basename "$PROJECT" .xcodeproj)" -destination 'platform=macOS' "$@" 2>&1 | tee "$XCODE_OUTPUT"
+        XCODE_EXIT=${PIPESTATUS[0]}
+        set -e
     else
         echo "Error: No Xcode project or workspace found"
         exit 1
     fi
+
+    if [ "$XCODE_EXIT" -ne 0 ] && [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ]; then
+        python3 - "$COMPONENT_PATH" "$XCODE_OUTPUT" "$HOMEBOY_TEST_FAILURES_FILE" <<'PY'
+import hashlib
+import json
+import re
+import sys
+
+component, output_file, target = sys.argv[1:]
+with open(output_file, encoding="utf-8") as handle:
+    lines = handle.read().splitlines()
+
+failures = []
+pattern = re.compile(r"Test Case '-\[(?P<suite>[^ ]+) (?P<test>[^\]]+)\]' failed(?: \((?P<seconds>[^)]+)\))?\.")
+for raw in lines:
+    match = pattern.search(raw)
+    if not match:
+        continue
+    suite = match.group("suite")
+    test = match.group("test")
+    test_id = f"{suite}.{test}"
+    identity = f"swift:xctest:{test_id}"
+    failures.append({
+        "test_id": test_id,
+        "suite": suite,
+        "file": None,
+        "line": None,
+        "message": raw.strip(),
+        "failure_type": "test_failure",
+        "fingerprint": hashlib.sha256(identity.encode()).hexdigest(),
+        "stdout_excerpt": "\n".join(lines)[-4000:],
+        "stderr_excerpt": "",
+    })
+
+if not failures:
+    identity = "swift:xcodebuild:failed"
+    failures.append({
+        "test_id": "xcodebuild test",
+        "suite": None,
+        "file": None,
+        "line": None,
+        "message": "xcodebuild test failed before XCTest failures could be parsed",
+        "failure_type": "infrastructure",
+        "fingerprint": hashlib.sha256(identity.encode()).hexdigest(),
+        "stdout_excerpt": "\n".join(lines)[-4000:],
+        "stderr_excerpt": "",
+    })
+
+with open(target, "w", encoding="utf-8") as handle:
+    json.dump(failures, handle, indent=2)
+    handle.write("\n")
+PY
+    fi
+    exit "$XCODE_EXIT"
 else
     # Script mode - run .swift files directly
     TESTS_RUN=0
     TESTS_FAILED=0
+    FAILURES_FILE="$(mktemp)"
+    : > "$FAILURES_FILE"
+    trap 'rm -f "$FAILURES_FILE"' EXIT
 
     for test_file in "$TEST_DIR"/*.swift; do
         if [ -f "$test_file" ]; then
@@ -67,11 +132,16 @@ else
             TEST_NAME=$(basename "$test_file")
             echo "Running: $TEST_NAME"
 
-            if swift "$test_file" "$TEST_DIR" 2>&1; then
+            TEST_OUTPUT="$(mktemp)"
+            if swift "$test_file" "$TEST_DIR" > "$TEST_OUTPUT" 2>&1; then
+                cat "$TEST_OUTPUT"
                 echo "  PASS"
+                rm -f "$TEST_OUTPUT"
             else
+                cat "$TEST_OUTPUT"
                 echo "  FAIL"
                 TESTS_FAILED=$((TESTS_FAILED + 1))
+                printf '%s\t%s\n' "$TEST_NAME" "$TEST_OUTPUT" >> "$FAILURES_FILE"
             fi
         fi
     done
@@ -85,6 +155,45 @@ else
     echo "Results: $((TESTS_RUN - TESTS_FAILED))/$TESTS_RUN tests passed"
 
     if [ $TESTS_FAILED -gt 0 ]; then
+        if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ]; then
+            python3 - "$FAILURES_FILE" "$HOMEBOY_TEST_FAILURES_FILE" <<'PY'
+import hashlib
+import json
+import sys
+
+failures_file, target = sys.argv[1:]
+failures = []
+with open(failures_file, encoding="utf-8") as handle:
+    for raw in handle:
+        name, _, output_path = raw.rstrip("\n").partition("\t")
+        if not name or not output_path:
+            continue
+        try:
+            with open(output_path, encoding="utf-8") as output_handle:
+                output = output_handle.read()
+        except OSError:
+            output = ""
+        identity = f"swift:script:{name}"
+        failures.append({
+            "test_id": name,
+            "suite": "script",
+            "file": f"tests/{name}",
+            "line": None,
+            "message": f"Swift script test failed: {name}",
+            "failure_type": "test_failure",
+            "fingerprint": hashlib.sha256(identity.encode()).hexdigest(),
+            "stdout_excerpt": output[-4000:],
+            "stderr_excerpt": "",
+        })
+
+with open(target, "w", encoding="utf-8") as handle:
+    json.dump(failures, handle, indent=2)
+    handle.write("\n")
+PY
+        fi
+        while IFS=$'\t' read -r _ output_path; do
+            [ -n "$output_path" ] && rm -f "$output_path"
+        done < "$FAILURES_FILE"
         exit 1
     fi
 fi

--- a/swift/swift.json
+++ b/swift/swift.json
@@ -9,9 +9,9 @@
     "capabilities": ["fingerprint", "validate"]
   },
   "structured_sidecars": {
-    "lint.findings": false,
+    "lint.findings": true,
     "test.results": false,
-    "test.failures": false,
+    "test.failures": true,
     "test.coverage": false,
     "annotations": false
   },

--- a/tests/cross-extension-sidecar-normalization-smoke.sh
+++ b/tests/cross-extension-sidecar-normalization-smoke.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+assert_json_fields() {
+    local file="$1"
+    shift
+    python3 - "$file" "$@" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+fields = sys.argv[2:]
+with open(path, encoding="utf-8") as handle:
+    data = json.load(handle)
+assert isinstance(data, list), data
+assert data, data
+for field in fields:
+    assert field in data[0], (field, data[0])
+print("ok", path)
+PY
+}
+
+# Go lint findings from gofmt.
+GO_PROJECT="$TMP_DIR/go-project"
+mkdir -p "$GO_PROJECT"
+cat > "$GO_PROJECT/go.mod" <<'EOF'
+module example.com/sidecar
+
+go 1.22
+EOF
+cat > "$GO_PROJECT/main.go" <<'EOF'
+package main
+func main(){println("hi")}
+EOF
+GO_LINT_FINDINGS="$TMP_DIR/go-lint-findings.json"
+set +e
+HOMEBOY_COMPONENT_PATH="$GO_PROJECT" \
+HOMEBOY_LINT_FINDINGS_FILE="$GO_LINT_FINDINGS" \
+bash "$ROOT/go/scripts/lint-runner.sh" >/dev/null 2>&1
+GO_LINT_EXIT=$?
+set -e
+[ "$GO_LINT_EXIT" -ne 0 ]
+assert_json_fields "$GO_LINT_FINDINGS" id file line column severity source code category message fixable fingerprint excerpt
+
+# Go test failures from go test -json.
+cat > "$GO_PROJECT/main_test.go" <<'EOF'
+package main
+import "testing"
+func TestSidecarFailure(t *testing.T) { t.Fatal("sidecar failure") }
+EOF
+GO_TEST_FAILURES="$TMP_DIR/go-test-failures.json"
+set +e
+HOMEBOY_COMPONENT_PATH="$GO_PROJECT" \
+HOMEBOY_TEST_FAILURES_FILE="$GO_TEST_FAILURES" \
+bash "$ROOT/go/scripts/test-runner.sh" >/dev/null 2>&1
+GO_TEST_EXIT=$?
+set -e
+[ "$GO_TEST_EXIT" -ne 0 ]
+assert_json_fields "$GO_TEST_FAILURES" test_id suite file line message failure_type fingerprint stdout_excerpt stderr_excerpt
+
+# Rust sidecars with a fake cargo binary so the smoke stays self-contained.
+RUST_PROJECT="$TMP_DIR/rust-project"
+RUST_BIN="$TMP_DIR/rust-bin"
+mkdir -p "$RUST_PROJECT/src" "$RUST_BIN"
+cat > "$RUST_PROJECT/Cargo.toml" <<'EOF'
+[package]
+name = "sidecar"
+version = "0.1.0"
+edition = "2021"
+EOF
+cat > "$RUST_PROJECT/src/lib.rs" <<'EOF'
+pub fn bad(){ }
+EOF
+cat > "$RUST_BIN/cargo" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "fmt" ]; then
+  printf 'Diff in %s/src/lib.rs at line 1:\n' "$HOMEBOY_COMPONENT_PATH"
+  exit 1
+fi
+if [ "$1" = "test" ]; then
+  printf 'running 1 test\n'
+  printf 'test tests::sidecar_failure ... FAILED\n'
+  printf '\nfailures:\n---- tests::sidecar_failure stdout ----\nthread panicked\n'
+  printf 'test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out;\n'
+  exit 101
+fi
+exit 0
+EOF
+chmod +x "$RUST_BIN/cargo"
+RUST_LINT_FINDINGS="$TMP_DIR/rust-lint-findings.json"
+set +e
+PATH="$RUST_BIN:$PATH" \
+HOMEBOY_EXTENSION_PATH="$ROOT/rust" \
+HOMEBOY_COMPONENT_PATH="$RUST_PROJECT" \
+HOMEBOY_RUNTIME_RUNNER_STEPS="$ROOT/wordpress/scripts/lib/runner-steps.sh" \
+HOMEBOY_LINT_FINDINGS_FILE="$RUST_LINT_FINDINGS" \
+bash "$ROOT/rust/scripts/lint-runner.sh" >/dev/null 2>&1
+RUST_LINT_EXIT=$?
+set -e
+[ "$RUST_LINT_EXIT" -ne 0 ]
+assert_json_fields "$RUST_LINT_FINDINGS" id file line column severity source code category message fixable fingerprint excerpt
+
+RUST_TEST_FAILURES="$TMP_DIR/rust-test-failures.json"
+set +e
+PATH="$RUST_BIN:$PATH" \
+HOMEBOY_EXTENSION_PATH="$ROOT/rust" \
+HOMEBOY_COMPONENT_PATH="$RUST_PROJECT" \
+HOMEBOY_RUNTIME_RUNNER_STEPS="$ROOT/wordpress/scripts/lib/runner-steps.sh" \
+HOMEBOY_SKIP_LINT=1 \
+HOMEBOY_TEST_FAILURES_FILE="$RUST_TEST_FAILURES" \
+bash "$ROOT/rust/scripts/test-runner.sh" >/dev/null 2>&1
+RUST_TEST_EXIT=$?
+set -e
+[ "$RUST_TEST_EXIT" -ne 0 ]
+assert_json_fields "$RUST_TEST_FAILURES" test_id suite file line message failure_type fingerprint stdout_excerpt stderr_excerpt
+
+# Swift lint and script test sidecars with fake tools.
+SWIFT_PROJECT="$TMP_DIR/swift-project"
+SWIFT_BIN="$TMP_DIR/swift-bin"
+mkdir -p "$SWIFT_PROJECT/tests" "$SWIFT_BIN"
+cat > "$SWIFT_PROJECT/tests/Fail.swift" <<'EOF'
+fatalError("sidecar")
+EOF
+cat > "$SWIFT_BIN/swiftlint" <<'EOF'
+#!/usr/bin/env bash
+printf '[{"file":"%s/tests/Fail.swift","line":1,"character":1,"severity":"Warning","rule_id":"force_unwrapping","reason":"Avoid force unwraps"}]\n' "$HOMEBOY_COMPONENT_PATH"
+exit 2
+EOF
+cat > "$SWIFT_BIN/swift" <<'EOF'
+#!/usr/bin/env bash
+printf 'Swift script failed\n'
+exit 1
+EOF
+chmod +x "$SWIFT_BIN/swiftlint" "$SWIFT_BIN/swift"
+SWIFT_LINT_FINDINGS="$TMP_DIR/swift-lint-findings.json"
+set +e
+PATH="$SWIFT_BIN:$PATH" \
+HOMEBOY_EXTENSION_PATH="$ROOT/swift" \
+HOMEBOY_COMPONENT_PATH="$SWIFT_PROJECT" \
+HOMEBOY_LINT_FINDINGS_FILE="$SWIFT_LINT_FINDINGS" \
+bash "$ROOT/swift/scripts/lint-runner.sh" >/dev/null 2>&1
+SWIFT_LINT_EXIT=$?
+set -e
+[ "$SWIFT_LINT_EXIT" -ne 0 ]
+assert_json_fields "$SWIFT_LINT_FINDINGS" id file line column severity source code category message fixable fingerprint excerpt
+
+SWIFT_TEST_FAILURES="$TMP_DIR/swift-test-failures.json"
+set +e
+PATH="$SWIFT_BIN:$PATH" \
+HOMEBOY_EXTENSION_PATH="$ROOT/swift" \
+HOMEBOY_COMPONENT_PATH="$SWIFT_PROJECT" \
+HOMEBOY_TEST_FAILURES_FILE="$SWIFT_TEST_FAILURES" \
+bash "$ROOT/swift/scripts/test-runner.sh" >/dev/null 2>&1
+SWIFT_TEST_EXIT=$?
+set -e
+[ "$SWIFT_TEST_EXIT" -ne 0 ]
+assert_json_fields "$SWIFT_TEST_FAILURES" test_id suite file line message failure_type fingerprint stdout_excerpt stderr_excerpt
+
+echo "cross-extension sidecar normalization smoke passed"

--- a/tests/structured-sidecars-smoke.mjs
+++ b/tests/structured-sidecars-smoke.mjs
@@ -42,24 +42,24 @@ const expectedSupport = {
 		annotations: false,
 	},
 	'rust/rust.json': {
-		'lint.findings': false,
+		'lint.findings': true,
 		'test.results': true,
-		'test.failures': false,
+		'test.failures': true,
 		'test.coverage': false,
 		'bench.results': true,
 		annotations: true,
 	},
 	'swift/swift.json': {
-		'lint.findings': false,
+		'lint.findings': true,
 		'test.results': false,
-		'test.failures': false,
+		'test.failures': true,
 		'test.coverage': false,
 		annotations: false,
 	},
 	'go/go.json': {
-		'lint.findings': false,
+		'lint.findings': true,
 		'test.results': false,
-		'test.failures': false,
+		'test.failures': true,
 		'test.coverage': false,
 		annotations: false,
 	},
@@ -82,9 +82,19 @@ const supportEvidence = {
 		'trace.artifacts': ['nodejs/scripts/trace/trace-runner.sh', 'HOMEBOY_TRACE_ARTIFACT_DIR'],
 	},
 	'rust/rust.json': {
+		'lint.findings': ['rust/scripts/lint-runner.sh', 'HOMEBOY_LINT_FINDINGS_FILE'],
 		'test.results': ['rust/scripts/test-runner.sh', 'HOMEBOY_TEST_RESULTS_FILE'],
+		'test.failures': ['rust/scripts/test-runner.sh', 'HOMEBOY_TEST_FAILURES_FILE'],
 		'bench.results': ['rust/scripts/bench/bench-runner.sh', 'HOMEBOY_BENCH_RESULTS_FILE'],
 		annotations: ['rust/scripts/lint-runner.sh', 'HOMEBOY_ANNOTATIONS_DIR'],
+	},
+	'swift/swift.json': {
+		'lint.findings': ['swift/scripts/lint-runner.sh', 'HOMEBOY_LINT_FINDINGS_FILE'],
+		'test.failures': ['swift/scripts/test-runner.sh', 'HOMEBOY_TEST_FAILURES_FILE'],
+	},
+	'go/go.json': {
+		'lint.findings': ['go/scripts/lint-runner.sh', 'HOMEBOY_LINT_FINDINGS_FILE'],
+		'test.failures': ['go/scripts/test-runner.sh', 'HOMEBOY_TEST_FAILURES_FILE'],
 	},
 };
 


### PR DESCRIPTION
## Summary
- Add normalized lint finding sidecars for Go, Rust, and Swift where runner output exposes diagnostics.
- Add normalized test failure sidecars for Go, Rust, and Swift, including infrastructure failure classification fallbacks.
- Document the v1 `lint.findings` and `test.failures` field contracts and extend structured sidecar smoke coverage.

Fixes #387.
Fixes #388.

## Testing
- `bash -n go/scripts/lint-runner.sh go/scripts/test-runner.sh rust/scripts/lint-runner.sh rust/scripts/test-runner.sh swift/scripts/lint-runner.sh swift/scripts/test-runner.sh tests/cross-extension-sidecar-normalization-smoke.sh`
- `node tests/structured-sidecars-smoke.mjs`
- `bash tests/cross-extension-sidecar-normalization-smoke.sh`
- `bash nodejs/scripts/lint/nodejs-lint-findings-sidecar-smoke.sh`
- `bash nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh`
- `bash wordpress/scripts/test/parse-test-failures-sidecar-smoke.sh`
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing the existing cross-extension sidecar contracts, implementing the remaining Go/Rust/Swift sidecar emitters, adding documentation, and adding smoke coverage. Chris remains responsible for review and merge.