### PR TITLE
feat(wordpress): add scenario verifier hooks

### DIFF
--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -291,6 +291,24 @@ per-check scores bounded by their `max_score`. The runner exposes aggregate
 metrics such as `reward_mean`, while the structured details remain in
 `metadata.grade` for JSONL consumers.
 
+Scenario manifests can keep visible grading and hidden verification separate:
+
+```json
+{
+  "grader_file": "graders/visible-grade.php",
+  "verifier_files": ["verifiers/no-grader-mutation.php"],
+  "forbidden_mutations": ["graders/**", "scenarios/**"],
+  "required_active_plugins": ["data-machine/data-machine.php"]
+}
+```
+
+The bench runner appends verifier PHP files after the manifest `run` steps and
+grader file. Verifiers return the same reward payload shape as graders, so
+hidden policy failures appear in `metadata.grade` and downstream JSONL rows.
+Use graders for task-visible success criteria, verifiers for anti-tamper checks
+and environment policy checks, and the `forbidden_mutations` /
+`required_active_plugins` metadata fields to describe the policy being enforced.
+
 ## Related files
 
 - `.github/workflows/datamachine-agent-ci.yml` is the reusable workflow.

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -167,7 +167,7 @@ homeboy_wp_codebox_compile_scenario_manifests() {
             ')
         fi
 
-        local grader_ref grader_host grader_rel run_json
+        local grader_ref grader_host grader_rel run_json verifier_refs_json verifier_rels_json
         grader_ref=$(printf '%s' "$manifest_json" | jq -r 'if ((.grader? // .grader_file?) | type) == "string" then (.grader // .grader_file) else empty end')
         grader_rel=""
         if [ -n "$grader_ref" ]; then
@@ -180,12 +180,38 @@ homeboy_wp_codebox_compile_scenario_manifests() {
             grader_rel=$(homeboy_wp_codebox_component_relative_path "$grader_host")
         fi
 
+        verifier_refs_json=$(printf '%s' "$manifest_json" | jq -c '
+            [
+                if ((.verifier? // .verifier_file?) | type) == "string" then (.verifier // .verifier_file) else empty end,
+                if (.verifier_files? | type) == "array" then .verifier_files[] else empty end,
+                if (.verifiers? | type) == "array" then .verifiers[] else empty end
+            ] | map(select(type == "string" and . != ""))
+        ')
+        verifier_rels_json="[]"
+        if printf '%s' "$verifier_refs_json" | jq -e 'length > 0' >/dev/null 2>&1; then
+            local verifier_ref verifier_host verifier_rel
+            while IFS= read -r verifier_ref; do
+                [ -n "$verifier_ref" ] || continue
+                verifier_host=$(homeboy_wp_codebox_resolve_host_path "$manifest_dir" "$verifier_ref")
+                if [ ! -f "$verifier_host" ]; then
+                    echo "Error: scenario verifier file not found: $verifier_host" >&2
+                    FAILED_STEP="Scenario manifest setup"
+                    exit 1
+                fi
+                verifier_rel=$(homeboy_wp_codebox_component_relative_path "$verifier_host")
+                verifier_rels_json=$(jq -nc --argjson verifiers "$verifier_rels_json" --arg verifier "$verifier_rel" '$verifiers + [$verifier]')
+            done < <(printf '%s' "$verifier_refs_json" | jq -r '.[]')
+        fi
+
         run_json=$(printf '%s' "$manifest_json" | jq -c 'if (.run? | type) == "array" then .run else [] end')
         if [ -n "$grader_rel" ]; then
             run_json=$(jq -nc --argjson run "$run_json" --arg grader "$grader_rel" '$run + [{type: "php", file: $grader}]')
         fi
+        if printf '%s' "$verifier_rels_json" | jq -e 'length > 0' >/dev/null 2>&1; then
+            run_json=$(jq -nc --argjson run "$run_json" --argjson verifiers "$verifier_rels_json" '$run + ($verifiers | map({type: "php", file: .}))')
+        fi
         if ! printf '%s' "$run_json" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
-            echo "Error: scenario manifest requires run steps or a grader PHP file" >&2
+            echo "Error: scenario manifest requires run steps, a grader PHP file, or verifier PHP files" >&2
             FAILED_STEP="Scenario manifest setup"
             exit 1
         fi
@@ -199,6 +225,7 @@ homeboy_wp_codebox_compile_scenario_manifests() {
             --arg promptFile "$prompt_file_rel" \
             --arg blueprintFile "$blueprint_rel" \
             --arg graderFile "$grader_rel" \
+            --argjson verifierFiles "$verifier_rels_json" \
             '($manifest.metadata // {}) as $metadata |
             {
                 id: ($manifest.id // $manifest.label),
@@ -212,6 +239,9 @@ homeboy_wp_codebox_compile_scenario_manifests() {
                     prompt_file: $promptFile,
                     blueprint_file: $blueprintFile,
                     grader_file: $graderFile,
+                    verifier_files: $verifierFiles,
+                    forbidden_mutations: ($manifest.forbidden_mutations // []),
+                    required_active_plugins: ($manifest.required_active_plugins // []),
                     limits: ($manifest.limits // {}),
                     rules: ($manifest.rules // {}),
                     general_rules: ($manifest.general_rules // $manifest.rules.general // []),

--- a/wordpress/tests/fixtures/playground-scenario-manifest/scenarios/manifest-001.json
+++ b/wordpress/tests/fixtures/playground-scenario-manifest/scenarios/manifest-001.json
@@ -4,6 +4,9 @@
   "prompt_file": "prompt.md",
   "blueprint": "blueprint.json",
   "grader": "grader.php",
+  "verifier_files": ["verifier.php"],
+  "forbidden_mutations": ["scenarios/**"],
+  "required_active_plugins": ["playground-scenario-manifest/playground-scenario-manifest.php"],
   "tags": ["blocks", "markup", "medium"],
   "rules": {
     "general": ["wordpress_editable_blocks"],
@@ -24,8 +27,8 @@
   },
   "run": [
     {
-      "type": "wp-cli",
-      "command": "wp option update scenario_manifest_subject navigation --autoload=no"
+      "type": "php",
+      "file": "scenarios/setup.php"
     }
   ],
   "metadata": {

--- a/wordpress/tests/fixtures/playground-scenario-manifest/scenarios/setup.php
+++ b/wordpress/tests/fixtures/playground-scenario-manifest/scenarios/setup.php
@@ -1,0 +1,4 @@
+<?php
+return function (): void {
+    update_option('scenario_manifest_subject', 'navigation', false);
+};

--- a/wordpress/tests/fixtures/playground-scenario-manifest/scenarios/verifier.php
+++ b/wordpress/tests/fixtures/playground-scenario-manifest/scenarios/verifier.php
@@ -1,0 +1,14 @@
+<?php
+return function (): array {
+    $subject = get_option('scenario_manifest_subject');
+
+    if ($subject !== 'navigation') {
+        throw new RuntimeException('scenario manifest setup step did not run before verifier');
+    }
+
+    return [
+        'metadata' => [
+            'verifier' => 'passed',
+        ],
+    ];
+};

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -927,7 +927,7 @@
       "label": "Playground scenario manifests",
       "type": "array",
       "default": [],
-      "description": "Scenario manifest files or inline objects compiled into wordpress.bench workloads in the generated WP Codebox recipe. Prompt, blueprint, grader, rules, tags, limits, and metadata are preserved in BenchResults metadata."
+      "description": "Scenario manifest files or inline objects compiled into wordpress.bench workloads in the generated WP Codebox recipe. Prompt, blueprint, grader, verifier hooks, rules, tags, limits, policy metadata, and metadata are preserved in BenchResults metadata."
     },
     {
       "id": "bench_site_mode",


### PR DESCRIPTION
## Summary
- Adds explicit `verifier`, `verifier_file(s)`, and `verifiers` scenario manifest support for hidden PHP verifier hooks after graders.
- Preserves verifier and policy metadata in BenchResults so downstream JSONL/replay consumers can inspect anti-tamper checks.
- Updates the scenario manifest fixture to exercise setup, grader, and verifier execution on the WP Codebox bench path.

## Verification
- `bash -n wordpress/scripts/bench/bench-runner-wp-codebox.sh`
- `HOMEBOY_BENCH_RESULTS_FILE=$(mktemp "${TMPDIR:-/tmp}/scenario-verifier-results.XXXXXX") HOMEBOY_BENCH_ITERATIONS=1 HOMEBOY_BENCH_WARMUP_ITERATIONS=0 HOMEBOY_COMPONENT_ID=playground-scenario-manifest HOMEBOY_COMPONENT_PATH="/Users/chubes/Developer/homeboy-extensions@feat-playground-verifier-hooks/wordpress/tests/fixtures/playground-scenario-manifest" HOMEBOY_EXTENSION_PATH="/Users/chubes/Developer/homeboy-extensions@feat-playground-verifier-hooks/wordpress" HOMEBOY_SETTINGS_JSON='{"playground_scenario_manifests":["scenarios/manifest-001.json"],"bench_warmup_iterations":0}' bash "wordpress/scripts/bench/bench-runner.sh"`

## Notes
- The initial smoke run exposed the existing WP Codebox `wp-cli` workload-step limitation already tracked from the roadmap context; the fixture setup now uses PHP because this PR is scoped to verifier hooks.

Closes #567.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the focused verifier hook support, fixture updates, verification commands, and PR draft. Chris remains responsible for review and merge.