### PR TITLE
Install WP Codebox from release artifacts

### DIFF
--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -10,8 +10,32 @@ FAKE_BIN="${TMPDIR}/bin"
 HOME_DIR="${TMPDIR}/home"
 EXTENSION_DIR="${TMPDIR}/extension"
 GITHUB_ENV_FILE="${TMPDIR}/github-env"
+SOURCE_GITHUB_ENV_FILE="${TMPDIR}/source-github-env"
+ARTIFACT_ROOT="${TMPDIR}/artifact-root"
+ARTIFACT_PATH="${TMPDIR}/wp-codebox-cli-linux-x64.tar.gz"
 
-mkdir -p "${FAKE_BIN}" "${HOME_DIR}" "${EXTENSION_DIR}"
+mkdir -p "${FAKE_BIN}" "${HOME_DIR}" "${EXTENSION_DIR}" "${ARTIFACT_ROOT}/wp-codebox-cli/bin"
+
+cat > "${ARTIFACT_ROOT}/wp-codebox-cli/bin/wp-codebox" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' 'wp-codebox release stub'
+SH
+chmod +x "${ARTIFACT_ROOT}/wp-codebox-cli/bin/wp-codebox"
+tar -czf "${ARTIFACT_PATH}" -C "${ARTIFACT_ROOT}" wp-codebox-cli
+
+cat > "${FAKE_BIN}/curl" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "\$#" -lt 4 ] || [ "\${3}" != "-o" ]; then
+    printf 'unexpected curl invocation: %s\n' "\$*" >&2
+    exit 1
+fi
+
+cp "${ARTIFACT_PATH}" "\${4}"
+SH
+chmod +x "${FAKE_BIN}/curl"
 
 cat > "${FAKE_BIN}/git" <<'SH'
 #!/usr/bin/env bash
@@ -46,14 +70,14 @@ while [ "$#" -gt 0 ]; do
             ;;
         install)
             if [[ " $* " != *" --omit=optional "* ]]; then
-                printf 'expected wp-codebox install to omit optional dependencies: %s\n' "$*" >&2
+                printf 'expected wp-codebox source install to omit optional dependencies: %s\n' "$*" >&2
                 exit 1
             fi
             exit 0
             ;;
         run)
             mkdir -p "${prefix}/packages/cli/dist"
-            printf '%s\n' 'console.log("wp-codebox stub")' > "${prefix}/packages/cli/dist/index.js"
+            printf '%s\n' 'console.log("wp-codebox source stub")' > "${prefix}/packages/cli/dist/index.js"
             exit 0
             ;;
         *)
@@ -69,8 +93,7 @@ chmod +x "${FAKE_BIN}/npm"
     HOME="${HOME_DIR}" \
     PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" \
     GITHUB_ENV="${GITHUB_ENV_FILE}" \
-    HOMEBOY_WP_CODEBOX_SOURCE="https://example.test/wp-codebox.git" \
-    HOMEBOY_WP_CODEBOX_REF="main" \
+    HOMEBOY_WP_CODEBOX_DOWNLOAD_URL="https://example.test/wp-codebox-cli-linux-x64.tar.gz" \
     bash "${ROOT_DIR}/scripts/build/setup.sh" > "${TMPDIR}/setup.out"
 )
 
@@ -86,8 +109,27 @@ if [ ! -x "${wp_codebox_bin}" ]; then
     exit 1
 fi
 
-if [ "$("${wp_codebox_bin}")" != "wp-codebox stub" ]; then
-    echo "Expected wp-codebox wrapper to execute built CLI" >&2
+if [ "$("${wp_codebox_bin}")" != "wp-codebox release stub" ]; then
+    echo "Expected wp-codebox wrapper to execute release artifact CLI" >&2
+    exit 1
+fi
+
+(
+    cd "${EXTENSION_DIR}"
+    HOME="${HOME_DIR}" \
+    PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" \
+    GITHUB_ENV="${SOURCE_GITHUB_ENV_FILE}" \
+    HOMEBOY_WP_CODEBOX_INSTALL_MODE="source" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${TMPDIR}/source-install" \
+    HOMEBOY_WP_CODEBOX_SOURCE="https://example.test/wp-codebox.git" \
+    HOMEBOY_WP_CODEBOX_REF="main" \
+    bash "${ROOT_DIR}/scripts/build/setup.sh" > "${TMPDIR}/source-setup.out"
+)
+
+source_wp_codebox_bin="$(grep '^HOMEBOY_WP_CODEBOX_BIN=' "${SOURCE_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
+
+if [ "$("${source_wp_codebox_bin}")" != "wp-codebox source stub" ]; then
+    echo "Expected source fallback wrapper to execute built CLI" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -28,13 +28,63 @@ install_wp_codebox() {
         return 0
     fi
 
-    local source ref install_root repo_dir bin_dir bin_path
-    source="${HOMEBOY_WP_CODEBOX_SOURCE:-https://github.com/chubes4/wp-codebox.git}"
-    ref="${HOMEBOY_WP_CODEBOX_REF:-main}"
+    local install_mode install_root bin_dir bin_path platform arch artifact_name download_url artifact_path extract_dir
+    install_mode="${HOMEBOY_WP_CODEBOX_INSTALL_MODE:-release}"
     install_root="${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-${HOME}/.cache/homeboy/wp-codebox}"
-    repo_dir="${install_root}/source"
     bin_dir="${HOME}/.local/bin"
     bin_path="${bin_dir}/wp-codebox"
+
+    if [ "${install_mode}" != "source" ]; then
+        platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+        arch="$(uname -m)"
+        case "${platform}" in
+            darwin) platform="macos" ;;
+        esac
+        case "${arch}" in
+            x86_64|amd64) arch="x64" ;;
+            aarch64) arch="arm64" ;;
+        esac
+
+        artifact_name="wp-codebox-cli-${platform}-${arch}.tar.gz"
+        download_url="${HOMEBOY_WP_CODEBOX_DOWNLOAD_URL:-https://github.com/chubes4/wp-codebox/releases/latest/download/${artifact_name}}"
+        artifact_path="${install_root}/${artifact_name}"
+        extract_dir="${install_root}/release"
+
+        echo "Installing WP Codebox CLI from release artifact (${download_url})..."
+        mkdir -p "${install_root}" "${bin_dir}"
+
+        if command -v curl >/dev/null 2>&1 && curl -fsSL "${download_url}" -o "${artifact_path}"; then
+            rm -rf "${extract_dir}"
+            mkdir -p "${extract_dir}"
+            tar -xzf "${artifact_path}" -C "${extract_dir}"
+
+            if [ ! -x "${extract_dir}/wp-codebox-cli/bin/wp-codebox" ]; then
+                echo "Downloaded WP Codebox artifact did not contain an executable bin/wp-codebox" >&2
+                exit 1
+            fi
+
+            cat > "${bin_path}" <<EOF
+#!/usr/bin/env bash
+exec "${extract_dir}/wp-codebox-cli/bin/wp-codebox" "\$@"
+EOF
+            chmod +x "${bin_path}"
+
+            if [ -n "${GITHUB_ENV:-}" ]; then
+                echo "HOMEBOY_WP_CODEBOX_BIN=${bin_path}" >> "${GITHUB_ENV}"
+                echo "PATH=${bin_dir}:${PATH}" >> "${GITHUB_ENV}"
+            fi
+
+            echo "WP Codebox installed: ${bin_path}"
+            return 0
+        fi
+
+        echo "WP Codebox release artifact unavailable; falling back to source install" >&2
+    fi
+
+    local source ref repo_dir
+    source="${HOMEBOY_WP_CODEBOX_SOURCE:-https://github.com/chubes4/wp-codebox.git}"
+    ref="${HOMEBOY_WP_CODEBOX_REF:-main}"
+    repo_dir="${install_root}/source"
 
     echo "Installing WP Codebox CLI (${source}@${ref})..."
     mkdir -p "${install_root}" "${bin_dir}"


### PR DESCRIPTION
## Summary
- Prefer downloading the prebuilt WP Codebox CLI release artifact during WordPress extension setup.
- Keep the source clone/build path as an explicit fallback with optional dependencies omitted for Linux compatibility.
- Expand the setup smoke test to cover both release-artifact install and source fallback.

## Testing
- `bash -n wordpress/scripts/build/setup.sh wordpress/scripts/build/setup-wp-codebox-smoke.sh`
- `bash wordpress/scripts/build/setup-wp-codebox-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the setup script changes and smoke coverage; Chris directed the workflow and remains responsible for review/testing.