### PR TITLE
fix: ignore i18n text domains in slug audit

### DIFF
--- a/wordpress/tests/audit-detector-config-smoke.sh
+++ b/wordpress/tests/audit-detector-config-smoke.sh
@@ -331,6 +331,28 @@ require(any(regex.search("do_action( 'tool_call'") for regex in exclude_regexes)
 require("'tool_call' =>" in fixture, "fixture should include array/protocol key literal")
 require("do_action( 'tool_call'" in fixture, "fixture should include event-name literal")
 
+i18n_literal_pattern = literal_rule["literal_pattern"].replace("{value}", re.escape("data-machine"))
+i18n_literal_regex = re.compile(i18n_literal_pattern, re.MULTILINE)
+i18n_exclude_patterns = [
+    pattern.replace("{value}", re.escape("data-machine"))
+    for pattern in literal_rule.get("exclude_match_context_patterns", [])
+]
+i18n_exclude_regexes = [re.compile(pattern, re.MULTILINE) for pattern in i18n_exclude_patterns]
+i18n_fixture = (fixture_dir / "src/Runtime/class-demo-i18n-text-domain.php").read_text(encoding="utf-8")
+
+require(i18n_literal_regex.search("__( 'Flow', 'data-machine' )"),
+        "constant-backed slug detector literal pattern must match i18n text-domain literals before context exclusion")
+require(any(regex.search("__( 'Flow', 'data-machine' )") for regex in i18n_exclude_regexes),
+        "i18n text-domain literal must be excluded by context")
+require(i18n_literal_regex.search("self::TEXT_DOMAIN === 'data-machine'"),
+        "constant-backed slug detector should still flag non-i18n duplicate slug literals")
+require(not any(regex.search("self::TEXT_DOMAIN === 'data-machine'") for regex in i18n_exclude_regexes),
+        "non-i18n duplicate slug literal must not be excluded")
+require("__( 'Flow', 'data-machine' )" in i18n_fixture,
+        "i18n fixture should include a WordPress translation text-domain literal")
+require("self::TEXT_DOMAIN === 'data-machine'" in i18n_fixture,
+        "i18n fixture should include a real duplicate slug literal")
+
 # Issue #425 — source_pattern must not match `class` in docblock prose.
 # Pre-fix, `(?s).*?` between `class <name>` and `const` would let
 # `class has no knowledge` from the docblock match as the class name and
@@ -340,6 +362,15 @@ require("do_action( 'tool_call'" in fixture, "fixture should include event-name 
 # brace before `const` so the match has to live inside a real class body.
 source_pattern = literal_rule["source_pattern"]
 source_regex = re.compile(source_pattern)
+i18n_source_matches = list(source_regex.finditer(i18n_fixture))
+require(
+    len(i18n_source_matches) == 1,
+    f"source_pattern must find the i18n fixture text-domain constant, got {len(i18n_source_matches)}",
+)
+require(
+    i18n_source_matches[0].group("value") == "data-machine",
+    f"source_pattern must capture the i18n fixture constant value, got {i18n_source_matches[0].group('value')!r}",
+)
 recurring_fixture = (fixture_dir / "src/Runtime/class-demo-recurring-scheduler.php").read_text(encoding="utf-8")
 require(
     "This class has no knowledge" in recurring_fixture,

--- a/wordpress/tests/fixtures/audit-detector-config/src/Runtime/class-demo-i18n-text-domain.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Runtime/class-demo-i18n-text-domain.php
@@ -1,0 +1,13 @@
+<?php
+
+final class Demo_I18n_Text_Domain {
+	public const TEXT_DOMAIN = 'data-machine';
+
+	public function label(): string {
+		return __( 'Flow', 'data-machine' );
+	}
+
+	public function is_text_domain( string $value ): bool {
+		return self::TEXT_DOMAIN === 'data-machine' && $value === self::TEXT_DOMAIN;
+	}
+}

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -563,7 +563,8 @@
             "\\bdo_action\\s*\\(\\s*['\\\"]{value}['\\\"]",
             "\\bapply_filters\\s*\\(\\s*['\\\"]{value}['\\\"]",
             "\\bdo_action_ref_array\\s*\\(\\s*['\\\"]{value}['\\\"]",
-            "\\bapply_filters_ref_array\\s*\\(\\s*['\\\"]{value}['\\\"]"
+            "\\bapply_filters_ref_array\\s*\\(\\s*['\\\"]{value}['\\\"]",
+            "\\b(?:__|_e|_x|_ex|_n|_nx|_n_noop|_nx_noop|esc_html__|esc_html_e|esc_html_x|esc_attr__|esc_attr_e|esc_attr_x|translate|translate_with_gettext_context)\\s*\\([^;]*,\\s*['\\\"]{value}['\\\"]\\s*\\)"
           ],
           "description": "Raw slug literal `{value}` at line {line} duplicates constant {label}",
           "suggestion": "Use {label} instead of repeating the literal slug so the constant remains the source of truth."


### PR DESCRIPTION
## Summary
- Ignore WordPress translation helper text-domain arguments in the `constant_backed_slug_literal` detector.
- Add a fixture and smoke coverage proving `__( 'Flow', 'data-machine' )` is excluded while a normal duplicate slug comparison still remains reportable.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/751

## Tests
- `wordpress/tests/audit-detector-config-smoke.sh` passed.
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-ignore-i18n-text-domain-slugs --extension wordpress` passed with PHPUnit discovery skipped because this component has no matching PHPUnit tests.
- `homeboy audit --path /Users/chubes/Developer/homeboy-extensions@fix-ignore-i18n-text-domain-slugs --extension wordpress` ran and failed on existing repo-wide audit findings unrelated to this patch.
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-ignore-i18n-text-domain-slugs --extension wordpress` ran and failed on existing repo-wide PHPCS/PHPStan findings unrelated to this patch.
- `homeboy audit --path /Users/chubes/Developer/homeboy-extensions@fix-ignore-i18n-text-domain-slugs/wordpress/tests/fixtures/audit-detector-config --extension wordpress` ran and failed on existing fixture convention drift unrelated to this patch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the audit rule config change, added the regression fixture/smoke assertions, and ran verification commands; Chris remains responsible for review and merge.