### PR TITLE
fix: make coverage completeness audit advisory

### DIFF
--- a/go/go.json
+++ b/go/go.json
@@ -79,14 +79,6 @@
         "heading": "## Interfaces",
         "template": "- `{name}` — `{source_file}` (line {line})"
       }
-    },
-    "test_mapping": {
-      "source_dirs": ["."],
-      "test_dirs": ["."],
-      "test_file_pattern": "{dir}/{name}_test.{ext}",
-      "method_prefix": "Test",
-      "inline_tests": false,
-      "critical_patterns": ["cmd/", "pkg/", "internal/"]
     }
   },
   "docs": [

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -60,15 +60,6 @@
       "Config)\\b": { "doc_comment": true, "block_fields": true },
       "Manifest)\\b": { "doc_comment": true, "block_fields": true }
     },
-    "test_mapping": {
-      "source_dirs": ["src"],
-      "test_dirs": ["tests"],
-      "test_file_pattern": "tests/{dir}/{name}_test.{ext}",
-      "method_prefix": "test_",
-      "inline_tests": true,
-      "critical_patterns": ["core/"],
-      "skip_test_patterns": ["commands/"]
-    },
     "doc_targets": {
       "Subcommands": {
         "file": "cli-reference.md",

--- a/swift/swift.json
+++ b/swift/swift.json
@@ -40,14 +40,6 @@
       "enum\\s+": "Enums",
       "protocol\\s+": "Protocols",
       "func\\s+": "Functions"
-    },
-    "test_mapping": {
-      "source_dirs": [".", "Sources"],
-      "test_dirs": ["tests", "Tests"],
-      "test_file_pattern": "{dir}/{name}Tests.{ext}",
-      "method_prefix": "test",
-      "inline_tests": false,
-      "critical_patterns": ["Sources/", "App/", "Homeboy/"]
     }
   },
   "settings": [

--- a/swift/tests/swift-extension-smoke.sh
+++ b/swift/tests/swift-extension-smoke.sh
@@ -38,10 +38,11 @@ labels = audit.get("feature_labels", {})
 for label in ["Classes", "Structs", "Enums", "Protocols", "Functions"]:
     assert_true(label in labels.values(), f"missing feature label: {label}")
 
-mapping = audit.get("test_mapping", {})
+assert_true("test_mapping" not in audit, "audit test_mapping must stay disabled so historical coverage gaps are advisory")
+mapping = manifest.get("test", {}).get("drift", {})
 assert_true("tests" in mapping.get("test_dirs", []), "missing lowercase tests dir")
 assert_true("Tests" in mapping.get("test_dirs", []), "missing uppercase Tests dir")
-assert_true(mapping.get("test_file_pattern") == "{dir}/{name}Tests.{ext}", "unexpected test file pattern")
+assert_true(mapping.get("inline_tests") is False, "swift tests should not be inline")
 
 capabilities = provides.get("capabilities", [])
 assert_true("fingerprint" in capabilities, "missing fingerprint capability")

--- a/tests/structured-sidecars-smoke.mjs
+++ b/tests/structured-sidecars-smoke.mjs
@@ -102,6 +102,11 @@ for (const manifestPath of manifestPaths) {
 	const manifest = JSON.parse(await readFile(path.join(root, manifestPath), 'utf8'));
 	assert.equal(typeof manifest.structured_sidecars, 'object', `${manifestPath} declares structured_sidecars`);
 	assert.equal(Array.isArray(manifest.structured_sidecars), false, `${manifestPath} sidecars must be an object`);
+	assert.equal(manifest.audit?.test_mapping, undefined, `${manifestPath} keeps structural test coverage out of audit findings`);
+
+	if (manifestPath !== 'nodejs/nodejs.json') {
+		assert.equal(typeof manifest.test?.drift, 'object', `${manifestPath} keeps changed-test drift guidance configured`);
+	}
 
 	for (const key of requiredKeys) {
 		assert.equal(typeof manifest.structured_sidecars[key], 'boolean', `${manifestPath} declares ${key}`);

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -656,26 +656,6 @@
       "wp_register_ability": { "doc_comment": true, "block_fields": false },
       "registerTool": { "doc_comment": true, "block_fields": false }
     },
-    "test_mapping": {
-      "source_dirs": ["inc"],
-      "test_dirs": ["tests/Unit"],
-      "test_file_pattern": "tests/Unit/{dir}/{name}Test.{ext}",
-      "method_prefix": "test_",
-      "inline_tests": false,
-      "critical_patterns": ["Abilities/", "Core/"],
-      "skip_test_patterns": [
-        ".js",
-        ".jsx",
-        ".ts",
-        ".tsx",
-        ".css",
-        ".scss",
-        ".json",
-        "/assets/",
-        "/Admin/Pages/",
-        "/Admin/Settings/"
-      ]
-    },
     "doc_targets": {
       "Post Types": {
         "file": "features.md",


### PR DESCRIPTION
## Summary
- Removes extension `audit.test_mapping` declarations so `missing_test_file` and `missing_test_method` are no longer emitted as default audit blockers for historical coverage gaps.
- Keeps `test.drift` configured for changed-test/drift workflows so source/test guidance remains available without blocking unrelated release prep.
- Adds manifest smoke coverage that asserts structural coverage mapping stays out of audit findings while drift guidance remains configured.

Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/756

## Tests
- `node -e "for (const f of ['wordpress/wordpress.json','rust/rust.json','go/go.json','swift/swift.json','nodejs/nodejs.json']) JSON.parse(require('fs').readFileSync(f,'utf8')); console.log('json ok')"`
- `node tests/structured-sidecars-smoke.mjs`
- `bash swift/tests/swift-extension-smoke.sh`
- `bash wordpress/tests/audit-detector-config-smoke.sh`
- `homeboy audit --path /Users/chubes/Developer/homeboy-extensions@fix-756-audit-coverage-advisory --extension nodejs --changed-since origin/main`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-756-audit-coverage-advisory --extension nodejs`
- `homeboy audit --path /Users/chubes/Developer/homeboy-extensions@fix-756-audit-coverage-advisory --extension nodejs --only missing_test_file --only missing_test_method --ignore-baseline --force-hot`

## Notes
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-756-audit-coverage-advisory --extension nodejs --changed-since origin/main` does not run in this repo root because there is no root `package.json`; the selected smoke tests were run directly instead.
- I first tried `homeboy audit ... --report=pr-comment`, but this installed Homeboy version does not support `--report` on `audit`; the scoped audit was rerun with supported flags.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigating the audit/test mapping contract, editing manifests and smoke tests, running verification, and drafting this PR summary.