### PR TITLE
fix: skip API helper roles in registration audit

### DIFF
--- a/wordpress/docs/audit-core-contract-gaps.md
+++ b/wordpress/docs/audit-core-contract-gaps.md
@@ -8,7 +8,7 @@ The extension uses these generic knobs Homeboy already exposes:
 
 - `audit.detector_rules.lifecycle_path_globs` for non-production guard contexts such as tests, smokes, shims, stubs, and fallback files.
 - `audit.detector_rules.utility_suffixes` for PHP role suffixes that should not be forced into a sibling class convention when a dominant naming suffix exists.
-- `audit.detector_rules.convention_exception_globs` for procedural helper files such as `register-*.php` and `*-functions.php`, plus PHP role-suffix file globs (`class-*-store.php`, `class-*-registry.php`, `class-*-result.php`, etc.) that fully exempt those files from missing-method/registration/interface checks.
+- `audit.detector_rules.convention_exception_globs` for procedural helper files such as `register-*.php` and `*-functions.php`, plus PHP role-suffix file globs (`class-*-store.php`, `class-*-registry.php`, `class-*-result.php`, PSR-4 `*Resolver.php`, `*Result.php`, `*Verifier.php`, etc.) that fully exempt those files from missing-method/registration/interface checks.
 - A narrower `wordpress-constant-backed-slug-literal` pattern that only reports comparison contexts, not array keys or event/protocol names.
 
 ## Role-Aware Convention Grouping (`convention_tag_globs`)

--- a/wordpress/tests/audit-detector-config-smoke.sh
+++ b/wordpress/tests/audit-detector-config-smoke.sh
@@ -22,7 +22,7 @@ def require(condition, message):
         raise SystemExit(message)
 
 utility_suffixes = set(rules.get("utility_suffixes", []))
-for suffix in ["Authenticator", "Base", "Contract", "Credential", "Handlers", "Interface", "Projector", "Store", "Lock", "Policy", "Result", "Secret", "Service", "Token", "Value", "Package"]:
+for suffix in ["Authenticator", "Base", "Contract", "Credential", "Handlers", "Interface", "Projector", "Store", "Lock", "Policy", "Result", "Secret", "Service", "Token", "Value", "Package", "Verifier"]:
     require(suffix in utility_suffixes, f"missing PHP role utility suffix: {suffix}")
 
 exception_globs = set(rules.get("convention_exception_globs", []))
@@ -57,6 +57,9 @@ for pattern in [
     "**/class-*-lock.php",
     "**/class-*-artifact.php",
     "**/class-*-artifacts.php",
+    "**/*Resolver.php",
+    "**/*Result.php",
+    "**/*Verifier.php",
 ]:
     require(pattern in exception_globs, f"missing PHP role exception glob: {pattern}")
 
@@ -203,6 +206,32 @@ require(matches_any("src/Context/class-demo-context-injection-policy.php", globs
 require(not matches_any("src/Context/class-demo-context-injection-policy.php", globs_for("wordpress:php-role:contract")),
         "context injection policy fixture must not be tagged as contract role")
 
+# PSR-4 API fixture: helper/value/resolver classes can live beside real REST
+# route/controller classes under broad Api namespaces. Only the helper roles are
+# exempt/tagged; route-like classes remain in the normal convention group so
+# missing register()/register_routes()/rest_api_init signals still report there.
+api_helper_roles = {
+    "src/Api/WebhookAuthResolver.php": "wordpress:php-role:contract",
+    "src/Api/WebhookVerificationResult.php": "wordpress:php-role:result",
+    "src/Api/WebhookVerifier.php": "wordpress:php-role:service",
+}
+for path, tag in api_helper_roles.items():
+    require(matches_any(path, exception_globs),
+            f"PSR-4 API helper {path} must be exempt from registrar/controller conventions")
+    require(matches_any(path, globs_for(tag)),
+            f"PSR-4 API helper {path} must be tagged as {tag}")
+
+for path in [
+    "src/Api/WebhookRoutes.php",
+    "src/Api/WebhookController.php",
+    "src/Api/WebhookStatusController.php",
+]:
+    require(not matches_any(path, exception_globs),
+            f"route/controller fixture {path} must not be exempt from registration audits")
+    for tag in required_tags:
+        require(not matches_any(path, globs_for(tag)),
+                f"route/controller fixture {path} must stay in normal convention group (matched {tag})")
+
 # v0.157.0 best-effort fallback: every off-role file must also be in convention_exception_globs.
 for path in [
     "src/Identity/class-demo-identity-store.php",
@@ -216,6 +245,9 @@ for path in [
     "src/Auth/class-demo-token-authenticator.php",
     "src/Context/class-demo-context-conflict-resolver.php",
     "src/Context/class-demo-context-injection-policy.php",
+    "src/Api/WebhookAuthResolver.php",
+    "src/Api/WebhookVerificationResult.php",
+    "src/Api/WebhookVerifier.php",
 ]:
     require(matches_any(path, exception_globs),
             f"off-role file {path} must also be exempt for v0.157.0 fallback")
@@ -403,6 +435,12 @@ for relative in [
     "src/Options/class-demo-network-drift.php",
     "src/Options/class-demo-single-site-noise.php",
     "src/Options/class-demo-opt-out-marker.php",
+    "src/Api/WebhookAuthResolver.php",
+    "src/Api/WebhookVerificationResult.php",
+    "src/Api/WebhookVerifier.php",
+    "src/Api/WebhookRoutes.php",
+    "src/Api/WebhookController.php",
+    "src/Api/WebhookStatusController.php",
 ]:
     require((fixture_dir / relative).exists(), f"missing audit detector fixture: {relative}")
 

--- a/wordpress/tests/fixtures/audit-detector-config/src/Api/WebhookAuthResolver.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Api/WebhookAuthResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Demo\Api;
+
+final class WebhookAuthResolver {
+	public static function resolve( array $config ): array {
+		return array_filter( $config );
+	}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Api/WebhookController.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Api/WebhookController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Demo\Api;
+
+final class WebhookController {
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		register_rest_route( 'demo/v1', '/webhook/status', array(
+			'methods'  => 'GET',
+			'callback' => array( $this, 'dispatch' ),
+		) );
+	}
+
+	public function dispatch( array $request ): array {
+		return $request;
+	}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Api/WebhookRoutes.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Api/WebhookRoutes.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Demo\Api;
+
+final class WebhookRoutes {
+	public function register(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	public function register_routes(): void {
+		register_rest_route( 'demo/v1', '/webhook', array(
+			'methods'  => 'POST',
+			'callback' => array( $this, 'handle' ),
+		) );
+	}
+
+	public function handle( array $request ): array {
+		return $request;
+	}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Api/WebhookStatusController.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Api/WebhookStatusController.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Demo\Api;
+
+final class WebhookStatusController {
+	public function dispatch( array $request ): array {
+		return $request;
+	}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Api/WebhookVerificationResult.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Api/WebhookVerificationResult.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Demo\Api;
+
+final class WebhookVerificationResult {
+	public function __construct(
+		public readonly bool $verified,
+		public readonly string $reason = ''
+	) {}
+}

--- a/wordpress/tests/fixtures/audit-detector-config/src/Api/WebhookVerifier.php
+++ b/wordpress/tests/fixtures/audit-detector-config/src/Api/WebhookVerifier.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Demo\Api;
+
+final class WebhookVerifier {
+	public function verify( string $payload, string $signature ): WebhookVerificationResult {
+		return new WebhookVerificationResult( '' !== $payload && '' !== $signature );
+	}
+}

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -268,7 +268,8 @@
         "Token",
         "Tokens",
         "Value",
-        "Validator"
+        "Validator",
+        "Verifier"
       ],
       "convention_exception_globs": [
         "**/register.php",
@@ -327,6 +328,18 @@
         "**/class-*-policy-resolver.php",
         "**/class-*-lock.php",
         "**/class-*-locks.php",
+        "**/*DTO.php",
+        "**/*Data.php",
+        "**/*Helper.php",
+        "**/*Helpers.php",
+        "**/*Interface.php",
+        "**/*Payload.php",
+        "**/*Request.php",
+        "**/*Resolver.php",
+        "**/*Response.php",
+        "**/*Result.php",
+        "**/*Value.php",
+        "**/*Verifier.php",
         "**/class-null-*.php",
         "**/class-*-null-*.php"
       ],
@@ -360,7 +373,9 @@
             "**/class-*-runner.php",
             "**/class-*-executor.php",
             "**/class-*-dispatcher.php",
-            "**/class-*-router.php"
+            "**/class-*-router.php",
+            "**/*Interface.php",
+            "**/*Resolver.php"
           ]
         },
         {
@@ -382,7 +397,8 @@
           "globs": [
             "**/class-*-authenticator.php",
             "**/class-*-service.php",
-            "**/class-*-services.php"
+            "**/class-*-services.php",
+            "**/*Verifier.php"
           ]
         },
         {
@@ -402,7 +418,9 @@
             "**/class-*-report.php",
             "**/class-*-response.php",
             "**/class-*-outcome.php",
-            "**/class-*-decision.php"
+            "**/class-*-decision.php",
+            "**/*Response.php",
+            "**/*Result.php"
           ]
         },
         {


### PR DESCRIPTION
## Summary
- Extend WordPress audit role config so PSR-4 helper/value/resolver-style API classes such as `WebhookAuthResolver`, `WebhookVerificationResult`, and `WebhookVerifier` are exempt from registrar/controller registration conventions.
- Add regression fixtures proving those helper roles are skipped while route/controller-shaped classes remain in the normal audit convention group.
- Document the PSR-4 helper/value suffix coverage in the audit core contract notes.

Fixes #753.

## Verification
- `bash wordpress/tests/audit-detector-config-smoke.sh`
- `python3 -m json.tool wordpress/wordpress.json >/dev/null`
- `homeboy audit --force-hot --changed-since origin/main --path /Users/chubes/Developer/homeboy-extensions@fix-issue-753-api-helper-audit --extension nodejs --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/hbe-self-audit-final.json`
- `homeboy lint --force-hot --changed-since origin/main --path /Users/chubes/Developer/homeboy-extensions@fix-issue-753-api-helper-audit --extension nodejs --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/hbe-self-lint-final.json`
- Temporarily relinked the installed `wordpress` extension to this worktree and ran `homeboy audit --force-hot --path /Users/chubes/Developer/data-machine --extension wordpress --only missing_registration --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/data-machine-missing-registration-narrowed.json`; the webhook helper false positives disappeared while `inc/Api/Flows/FlowScheduling.php` still reported. Restored the extension symlink afterward.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the audit config/test changes and ran local verification; Chris remains responsible for review and merge.