### PR TITLE
fix: filter WordPress ability CLI boilerplate

### DIFF
--- a/wordpress/tests/audit-dead-guard-fallback-smoke.sh
+++ b/wordpress/tests/audit-dead-guard-fallback-smoke.sh
@@ -83,15 +83,38 @@ fi
 run_audit() {
     local fixture_path="$1"
     local out_path="$2"
-    "${HOMEBOY_BIN}" audit --path "${fixture_path}" --output "${out_path}" --force-hot >/dev/null
+    "${HOMEBOY_BIN}" audit --path "${fixture_path}" --extension wordpress --output "${out_path}" --force-hot >/dev/null
 }
 
 FALLBACK_REPORT="$(mktemp -t audit-fallback.XXXXXX.json)"
 WP_ONLY_REPORT="$(mktemp -t audit-wp-only.XXXXXX.json)"
-trap 'rm -f "${FALLBACK_REPORT}" "${WP_ONLY_REPORT}"' EXIT
+TMP_FIXTURE_ROOT="$(mktemp -d -t audit-dead-guard-fixtures.XXXXXX)"
+trap 'rm -f "${FALLBACK_REPORT}" "${WP_ONLY_REPORT}"; rm -rf "${TMP_FIXTURE_ROOT}"' EXIT
 
-run_audit "${FALLBACK_FIXTURE}" "${FALLBACK_REPORT}"
-run_audit "${WP_ONLY_FIXTURE}" "${WP_ONLY_REPORT}"
+copy_fixture_with_component_config() {
+    local source_fixture="$1"
+    local target_fixture="$2"
+    local component_id="$3"
+
+    mkdir -p "${target_fixture}"
+    cp -R "${source_fixture}/." "${target_fixture}/"
+    cat > "${target_fixture}/homeboy.json" <<JSON
+{
+  "id": "${component_id}",
+  "extensions": {
+    "wordpress": {}
+  }
+}
+JSON
+}
+
+FALLBACK_AUDIT_FIXTURE="${TMP_FIXTURE_ROOT}/fallback"
+WP_ONLY_AUDIT_FIXTURE="${TMP_FIXTURE_ROOT}/wp-only"
+copy_fixture_with_component_config "${FALLBACK_FIXTURE}" "${FALLBACK_AUDIT_FIXTURE}" "audit-dead-guard-fallback"
+copy_fixture_with_component_config "${WP_ONLY_FIXTURE}" "${WP_ONLY_AUDIT_FIXTURE}" "audit-dead-guard-wp-only"
+
+run_audit "${FALLBACK_AUDIT_FIXTURE}" "${FALLBACK_REPORT}"
+run_audit "${WP_ONLY_AUDIT_FIXTURE}" "${WP_ONLY_REPORT}"
 
 python3 - "$FALLBACK_REPORT" "$WP_ONLY_REPORT" <<'PY'
 import json

--- a/wordpress/tests/audit-detector-config-smoke.sh
+++ b/wordpress/tests/audit-detector-config-smoke.sh
@@ -37,6 +37,9 @@ for call in ["array", "empty", "get_param"]:
 for call in ["WP_REST_Response", "rest_ensure_response"]:
     require(call in set(duplication_detector.get("plumbing_calls", [])),
             f"WordPress REST response wrapper must be plumbing in parallel-implementation signal: {call}")
+for call in ["wp_get_ability", "is_wp_error", "get_error_message"]:
+    require(call in set(duplication_detector.get("plumbing_calls", [])),
+            f"WordPress ability CLI boilerplate must be plumbing in parallel-implementation signal: {call}")
 
 # v0.157.0 best-effort — off-role file suffixes must be exempt from sibling-method conventions.
 for pattern in [

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -457,6 +457,9 @@
           "get_param"
         ],
         "plumbing_calls": [
+          "get_error_message",
+          "is_wp_error",
+          "wp_get_ability",
           "WP_REST_Response",
           "rest_ensure_response"
         ]


### PR DESCRIPTION
## Summary
- Treat `wp_get_ability`, `is_wp_error`, and `get_error_message` as WordPress plumbing calls for the parallel-implementation detector.
- Pin the detector config in the WordPress audit smoke test so intentional ability CLI boilerplate stays advisory/noisy-filtered without hiding domain-specific shared workflows.
- Make the dead-guard behavioral fixture audit load the WordPress extension from temporary portable component configs, matching the contract under test.

Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/757

## Verification
- `bash tests/audit-detector-config-smoke.sh`
- `bash tests/audit-dead-guard-fallback-smoke.sh`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@issue-757-wp-schema-audit/wordpress --extension wordpress`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@issue-757-wp-schema-audit/wordpress --extension wordpress`
- Local extension audit check against Data Machine: `parallel_implementation` findings dropped from 24 to 14, with no remaining `wp_get_ability` / `is_wp_error` / `get_error_message` shared-call findings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the WordPress extension audit config update, regression smoke coverage, verification commands, and PR description draft for Chris to review.