### PR TITLE
Install Node deps for clean runner snapshots

### DIFF
--- a/nodejs/scripts/build/build-runner.sh
+++ b/nodejs/scripts/build/build-runner.sh
@@ -36,6 +36,7 @@ homeboy_resolve_context
 source "${SCRIPT_DIR}/../lib/node-helpers.sh"
 homeboy_require_package_json
 homeboy_detect_package_manager
+homeboy_ensure_node_dependencies
 
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 # shellcheck source=/dev/null

--- a/nodejs/scripts/lib/node-helpers.sh
+++ b/nodejs/scripts/lib/node-helpers.sh
@@ -39,6 +39,32 @@ homeboy_detect_package_manager() {
     fi
 }
 
+# Prepare dependencies for clean runner snapshots. Lab offload intentionally
+# excludes node_modules, so package scripts need a deterministic install step.
+homeboy_ensure_node_dependencies() {
+    local _dir="${1:-$PROJECT_PATH}"
+    if [ -d "$_dir/node_modules" ]; then
+        return 0
+    fi
+
+    echo "Installing Node.js dependencies..."
+    case "$PKG_MANAGER" in
+        pnpm)
+            (cd "$_dir" && pnpm install --frozen-lockfile)
+            ;;
+        yarn)
+            (cd "$_dir" && yarn install --frozen-lockfile)
+            ;;
+        npm|*)
+            if [ -f "$_dir/package-lock.json" ]; then
+                (cd "$_dir" && npm ci)
+            else
+                (cd "$_dir" && npm install)
+            fi
+            ;;
+    esac
+}
+
 # Check whether a script name is defined in package.json.
 # Returns 0 if defined, 1 otherwise. Uses node so we don't depend on jq.
 homeboy_has_npm_script() {

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -41,6 +41,7 @@ homeboy_resolve_context
 source "${SCRIPT_DIR}/../lib/node-helpers.sh"
 homeboy_require_package_json
 homeboy_detect_package_manager
+homeboy_ensure_node_dependencies
 
 RUNNER_ARGS=("$@")
 if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then


### PR DESCRIPTION
## Summary
- Add a shared Node.js dependency preparation helper for clean snapshots.
- Run it before Node.js build and test commands when `node_modules` is absent.
- Use lockfile-aware installs: pnpm/yarn frozen lockfiles, `npm ci` for package-lock, and `npm install` as the npm fallback.

Fixes #765.

## Verification
- `homeboy test --path /Users/chubes/Developer/isolated-block-editor@fix-clean-react18-deps --extension nodejs --runner lab` with this extension copied to the Lab. Result: passed, 8 passed / 9 skipped.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the clean Lab snapshot dependency failure, drafting the Node.js runner helper, and verifying against the IBE Lab run. Chris remains responsible for review and merge.
