### PR TITLE
fix: handle large WordPress lint sidecars

### DIFF
--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -766,6 +766,7 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
     # Write annotations sidecar JSON for CI inline comments
     if [ -n "${HOMEBOY_ANNOTATIONS_DIR:-}" ] && [ -d "${HOMEBOY_ANNOTATIONS_DIR}" ]; then
         echo "$json_output" | php -r '
+            ini_set("memory_limit", "-1");
             $json = json_decode(file_get_contents("php://stdin"), true);
             if (!$json || empty($json["files"])) exit;
             $componentPath = $argv[1] ?? "";
@@ -800,6 +801,7 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
     # Category is derived from the top-level PHPCS source namespace.
     if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
         echo "$json_output" | php -r '
+            ini_set("memory_limit", "-1");
             $json = json_decode(file_get_contents("php://stdin"), true);
             if (!$json || empty($json["files"])) {
                 file_put_contents($argv[2], "[]");


### PR DESCRIPTION
## Summary
- Raises PHP memory for WordPress PHPCS annotations/findings sidecar writers so large lint reports still produce Homeboy findings.
- Restores the refactor/autofix flow for repositories with tens of thousands of PHPCS findings by preventing empty sidecars after memory exhaustion.

## Verification
- `bash -n wordpress/scripts/lint/lint-runner.sh`
- Verified `homeboy refactor --from lint --write data-machine-code` entered `HOMEBOY_FIX_ONLY=1` and ran PHPCBF after relinking this extension worktree locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the sidecar memory failure and drafted the small runner patch; Chris remains responsible for review and merge.