### PR TITLE
Fan out Homeboy audit findings through WP Codebox

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -11,7 +11,7 @@
     "lint": [
       "jq empty wordpress.json",
       "bash -n scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/test-runner-core-dev.sh scripts/test/test-runner-core-dev-wp-codebox.sh scripts/test/test-runner-host-smoke.sh scripts/test/core-dev-shape-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/bench/bench-results-artifacts.sh scripts/bench/bench-results-artifacts-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/parse-wp-codebox-artifacts-smoke.sh scripts/test/wp-codebox-mount-translation-smoke.sh scripts/test/wp-codebox-bootstrap-failure-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/release/package.sh scripts/release/publish.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-doc-placeholder-refs-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
-      "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js lib/wp-codebox-apply-adapter.js scripts/agent/terminal-action-server.js scripts/agent/wp-codebox-apply-adapter.cjs tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js tests/wp-codebox-apply-adapter-smoke.js",
+      "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js lib/wp-codebox-apply-adapter.js lib/audit-wp-codebox-fanout.js scripts/agent/terminal-action-server.js scripts/agent/wp-codebox-apply-adapter.cjs scripts/agent/homeboy-audit-wp-codebox-fanout.cjs tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js tests/wp-codebox-apply-adapter-smoke.js tests/audit-wp-codebox-fanout-smoke.js",
       "php -l scripts/agent/datamachine-agent-workload.php tests/datamachine-terminal-tool-smoke.php"
     ],
     "test": [
@@ -40,7 +40,8 @@
       "node tests/terminal-action-server-smoke.js",
       "php tests/datamachine-terminal-tool-smoke.php",
       "node tests/timing-correlator-smoke.js",
-      "node tests/wp-codebox-apply-adapter-smoke.js"
+      "node tests/wp-codebox-apply-adapter-smoke.js",
+      "node tests/audit-wp-codebox-fanout-smoke.js"
     ]
   }
 }

--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -1,0 +1,268 @@
+'use strict';
+
+/* eslint-disable camelcase */
+
+/**
+ * External dependencies
+ */
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Internal dependencies
+ */
+const {
+  ADAPTER_ID,
+  loadWpCodeboxArtifactBundle,
+  verifyWpCodeboxPayload,
+} = require('./wp-codebox-apply-adapter');
+
+const PLAN_SCHEMA = 'homeboy/audit-wp-codebox-fanout/v1';
+const TASK_SCHEMA = 'homeboy/wp-codebox-task-request/v1';
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function auditFindings(report) {
+  const candidates = [
+    report?.data?.findings,
+    report?.findings,
+    report?.data?.top_findings,
+    report?.top_findings,
+  ];
+  const findings = candidates.find((value) => Array.isArray(value)) || [];
+  return findings.map((finding, index) => normalizeFinding(finding, index));
+}
+
+function normalizeFinding(finding, index) {
+  const kind = finding.kind || finding.code || finding.rule || 'unknown';
+  const file = finding.file || finding.path || finding.location?.file || '';
+  const line = Number(finding.line || finding.location?.line || 0);
+  const fingerprint = finding.fingerprint || sha256(`${kind}\n${file}\n${line}\n${finding.message || ''}`);
+
+  return {
+    id: finding.id || fingerprint,
+    fingerprint,
+    kind,
+    file,
+    line,
+    message: finding.message || finding.description || '',
+    severity: finding.severity || finding.level || 'warning',
+    fix_batch_key: finding.fix_batch_key || finding.fixBatchKey || kind,
+    raw: finding,
+    index,
+  };
+}
+
+function groupFindings(findings) {
+  const groupsByKey = new Map();
+  for (const finding of findings) {
+    const key = finding.fix_batch_key || finding.kind;
+    if (!groupsByKey.has(key)) {
+      groupsByKey.set(key, []);
+    }
+    groupsByKey.get(key).push(finding);
+  }
+
+  return Array.from(groupsByKey.entries()).map(([key, groupedFindings], index) => ({
+    key,
+    index,
+    findings: groupedFindings,
+  }));
+}
+
+function sandboxSessionId(orchestrator, group) {
+  return `homeboy-audit-${sha256(JSON.stringify({
+    run_id: orchestrator.run_id,
+    report_id: orchestrator.report_id,
+    group_key: group.key,
+    finding_ids: group.findings.map((finding) => finding.id),
+  })).slice(0, 16)}`;
+}
+
+function taskPrompt(group) {
+  const findingList = group.findings
+    .map((finding) => `- ${finding.id}: ${finding.kind} in ${finding.file}${finding.line ? `:${finding.line}` : ''}`)
+    .join('\n');
+
+  return [
+    `Fix the grouped Homeboy audit findings for batch ${group.key}.`,
+    'Return a WP Codebox artifact bundle with changed-files, patch, and review metadata.',
+    findingList,
+  ].join('\n\n');
+}
+
+function createTaskRequest(group, orchestrator) {
+  const sandbox_session_id = sandboxSessionId(orchestrator, group);
+  return {
+    schema: TASK_SCHEMA,
+    sandbox_session_id,
+    group_key: group.key,
+    orchestrator: {
+      id: orchestrator.id,
+      run_id: orchestrator.run_id,
+      report_id: orchestrator.report_id,
+      source: 'homeboy audit',
+      issue_url: orchestrator.issue_url || '',
+      group_index: group.index,
+    },
+    audit_findings: group.findings.map((finding) => ({
+      id: finding.id,
+      fingerprint: finding.fingerprint,
+      kind: finding.kind,
+      file: finding.file,
+      line: finding.line,
+      message: finding.message,
+      severity: finding.severity,
+    })),
+    task: {
+      title: `Fix Homeboy audit batch ${group.key}`,
+      prompt: taskPrompt(group),
+    },
+  };
+}
+
+function approvedFilesForBundle(bundle, explicitApprovedFiles = []) {
+  if (explicitApprovedFiles.length > 0) {
+    return explicitApprovedFiles;
+  }
+  return (bundle.changed_files.files || [])
+    .map((file) => file && file.path)
+    .filter((filePath) => typeof filePath === 'string' && filePath.length > 0);
+}
+
+function createApplyBackMetadata(taskRequest, artifactEntry, options) {
+  const bundle = loadWpCodeboxArtifactBundle(artifactEntry.bundle_path);
+  const approvedFiles = approvedFilesForBundle(bundle, artifactEntry.approved_files || []);
+  const verified = verifyWpCodeboxPayload({
+    artifact_id: bundle.id,
+    artifact: bundle,
+    approved_files: approvedFiles,
+    patch: bundle.patch,
+    patch_sha256: artifactEntry.patch_sha256,
+    artifact_content_digest: artifactEntry.artifact_content_digest,
+  });
+  const branch = artifactEntry.branch || `${options.branch_prefix || 'fix/homeboy-audit'}/${taskRequest.group_key}`;
+  const title = artifactEntry.pr_title || `Fix Homeboy audit batch ${taskRequest.group_key}`;
+  const issueUrl = options.issue_url || taskRequest.orchestrator.issue_url || '';
+
+  return {
+    schema: 'homeboy/wp-codebox-apply-back/v1',
+    adapter_id: ADAPTER_ID,
+    sandbox_session_id: taskRequest.sandbox_session_id,
+    group_key: taskRequest.group_key,
+    finding_ids: taskRequest.audit_findings.map((finding) => finding.id),
+    artifact: {
+      id: verified.artifactId,
+      bundle_path: bundle.directory,
+      content_digest: verified.contentDigest,
+      patch_sha256: verified.patchSha256,
+      review: bundle.review,
+      changed_files: bundle.changed_files,
+    },
+    review: {
+      approved: artifactEntry.approved !== false,
+      approved_files: approvedFiles,
+      reviewer: artifactEntry.reviewer || 'fixture-reviewer',
+      reviewed_at: artifactEntry.reviewed_at || options.reviewed_at || '',
+    },
+    adapter_payload: {
+      bundlePath: bundle.directory,
+      approvedFiles,
+      branch,
+      commitMessage: artifactEntry.commit_message || title,
+      patchStrip: artifactEntry.patch_strip,
+      push: false,
+      openPullRequest: false,
+    },
+    pull_request: {
+      title,
+      base: artifactEntry.base || options.base || 'main',
+      head: branch,
+      body: [
+        issueUrl ? `Closes ${issueUrl}` : '',
+        '',
+        `Applies WP Codebox artifact ${verified.artifactId} for Homeboy audit batch ${taskRequest.group_key}.`,
+      ].filter(Boolean).join('\n'),
+      labels: artifactEntry.labels || ['homeboy-audit', 'wp-codebox'],
+    },
+  };
+}
+
+function createAuditWpCodeboxFanoutPlan(input) {
+  const report = input.report || readJson(input.auditReportPath);
+  const orchestrator = {
+    id: input.orchestrator_id || 'homeboy-extensions/audit-wp-codebox-fanout',
+    run_id: input.run_id || report.run_id || report.id || 'fixture-run',
+    report_id: input.report_id || report.id || report.run_id || 'fixture-report',
+    issue_url: input.issue_url || '',
+  };
+  const groups = groupFindings(auditFindings(report));
+  const artifactMap = input.artifact_map || {};
+  const options = {
+    base: input.base || 'main',
+    branch_prefix: input.branch_prefix || 'fix/homeboy-audit',
+    issue_url: input.issue_url || '',
+    reviewed_at: input.reviewed_at || '',
+  };
+
+  const task_requests = groups.map((group) => createTaskRequest(group, orchestrator));
+  const apply_back = task_requests
+    .map((taskRequest) => {
+      const artifactEntry = artifactMap[taskRequest.sandbox_session_id] || artifactMap[taskRequest.group_key];
+      return artifactEntry ? createApplyBackMetadata(taskRequest, artifactEntry, options) : null;
+    })
+    .filter(Boolean);
+
+  return {
+    schema: PLAN_SCHEMA,
+    orchestrator,
+    audit: {
+      report_id: orchestrator.report_id,
+      finding_count: task_requests.reduce((count, request) => count + request.audit_findings.length, 0),
+      group_count: task_requests.length,
+    },
+    task_requests,
+    apply_back,
+  };
+}
+
+function createAuditWpCodeboxFanoutPlanFromFiles(options) {
+  const artifact_map = options.artifactMapPath ? readJson(options.artifactMapPath) : {};
+  const plan = createAuditWpCodeboxFanoutPlan({
+    auditReportPath: options.auditReportPath,
+    artifact_map,
+    orchestrator_id: options.orchestratorId,
+    run_id: options.runId,
+    report_id: options.reportId,
+    issue_url: options.issueUrl,
+    base: options.base,
+    branch_prefix: options.branchPrefix,
+    reviewed_at: options.reviewedAt,
+  });
+  if (options.outputPath) {
+    writeJson(options.outputPath, plan);
+  }
+  return plan;
+}
+
+module.exports = {
+  PLAN_SCHEMA,
+  TASK_SCHEMA,
+  auditFindings,
+  createAuditWpCodeboxFanoutPlan,
+  createAuditWpCodeboxFanoutPlanFromFiles,
+  groupFindings,
+  sandboxSessionId,
+};

--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -137,11 +137,9 @@ function safeBranchSlug(value) {
   const slug = String(value || '')
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9._/-]+/g, '-')
+    .replace(/[^a-z0-9]+/g, '-')
     .replace(/-{2,}/g, '-')
-    .replace(/\/{2,}/g, '/')
-    .replace(/[-/.]+$/g, '')
-    .replace(/^[-/.]+/g, '');
+    .replace(/^-+|-+$/g, '');
 
   return slug || 'audit-batch';
 }

--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -133,18 +133,30 @@ function createTaskRequest(group, orchestrator) {
   };
 }
 
-function approvedFilesForBundle(bundle, explicitApprovedFiles = []) {
-  if (explicitApprovedFiles.length > 0) {
-    return explicitApprovedFiles;
+function safeBranchSlug(value) {
+  const slug = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._/-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/\/{2,}/g, '/')
+    .replace(/[-/.]+$/g, '')
+    .replace(/^[-/.]+/g, '');
+
+  return slug || 'audit-batch';
+}
+
+function explicitApprovedFiles(artifactEntry) {
+  if (!Array.isArray(artifactEntry.approved_files) || artifactEntry.approved_files.length === 0) {
+    throw new Error('apply-back artifact entries require non-empty explicit approved_files');
   }
-  return (bundle.changed_files.files || [])
-    .map((file) => file && file.path)
-    .filter((filePath) => typeof filePath === 'string' && filePath.length > 0);
+
+  return artifactEntry.approved_files;
 }
 
 function createApplyBackMetadata(taskRequest, artifactEntry, options) {
   const bundle = loadWpCodeboxArtifactBundle(artifactEntry.bundle_path);
-  const approvedFiles = approvedFilesForBundle(bundle, artifactEntry.approved_files || []);
+  const approvedFiles = explicitApprovedFiles(artifactEntry);
   const verified = verifyWpCodeboxPayload({
     artifact_id: bundle.id,
     artifact: bundle,
@@ -153,7 +165,7 @@ function createApplyBackMetadata(taskRequest, artifactEntry, options) {
     patch_sha256: artifactEntry.patch_sha256,
     artifact_content_digest: artifactEntry.artifact_content_digest,
   });
-  const branch = artifactEntry.branch || `${options.branch_prefix || 'fix/homeboy-audit'}/${taskRequest.group_key}`;
+  const branch = artifactEntry.branch || `${options.branch_prefix || 'fix/homeboy-audit'}/${safeBranchSlug(taskRequest.group_key)}`;
   const title = artifactEntry.pr_title || `Fix Homeboy audit batch ${taskRequest.group_key}`;
   const issueUrl = options.issue_url || taskRequest.orchestrator.issue_url || '';
 
@@ -221,6 +233,9 @@ function createAuditWpCodeboxFanoutPlan(input) {
   const apply_back = task_requests
     .map((taskRequest) => {
       const artifactEntry = artifactMap[taskRequest.sandbox_session_id] || artifactMap[taskRequest.group_key];
+      if (artifactEntry?.approved === false) {
+        return null;
+      }
       return artifactEntry ? createApplyBackMetadata(taskRequest, artifactEntry, options) : null;
     })
     .filter(Boolean);
@@ -264,5 +279,6 @@ module.exports = {
   createAuditWpCodeboxFanoutPlan,
   createAuditWpCodeboxFanoutPlanFromFiles,
   groupFindings,
+  safeBranchSlug,
   sandboxSessionId,
 };

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -10,7 +10,8 @@
     "./request-profiler": "./lib/request-profiler.js",
     "./agent-terminal-actions": "./lib/agent-terminal-actions.js",
     "./timing-correlator": "./lib/timing-correlator.js",
-    "./wp-codebox-apply-adapter": "./lib/wp-codebox-apply-adapter.js"
+    "./wp-codebox-apply-adapter": "./lib/wp-codebox-apply-adapter.js",
+    "./audit-wp-codebox-fanout": "./lib/audit-wp-codebox-fanout.js"
   },
   "scripts": {
     "lint:js": "eslint --ext .js,.jsx,.ts,.tsx",
@@ -21,7 +22,8 @@
     "test:playground-readiness": "node tests/playground-readiness-smoke.js",
     "test:request-profiler": "node tests/request-profiler-smoke.js",
     "test:timing-correlator": "node tests/timing-correlator-smoke.js",
-    "test:wp-codebox-apply-adapter": "node tests/wp-codebox-apply-adapter-smoke.js"
+    "test:wp-codebox-apply-adapter": "node tests/wp-codebox-apply-adapter-smoke.js",
+    "test:audit-wp-codebox-fanout": "node tests/audit-wp-codebox-fanout-smoke.js"
   },
   "devDependencies": {
     "@wp-playground/cli": "^3.1.29",

--- a/wordpress/scripts/agent/homeboy-audit-wp-codebox-fanout.cjs
+++ b/wordpress/scripts/agent/homeboy-audit-wp-codebox-fanout.cjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+'use strict';
+
+/* eslint-disable no-console */
+
+/**
+ * Internal dependencies
+ */
+const { createAuditWpCodeboxFanoutPlanFromFiles } = require('../../lib/audit-wp-codebox-fanout');
+
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : '';
+}
+
+function usage() {
+  console.error('Usage: homeboy-audit-wp-codebox-fanout.cjs --audit-report <report.json> [--artifact-map <map.json>] [--output <plan.json>] [--issue-url <url>]');
+  process.exit(1);
+}
+
+const auditReportPath = argValue('--audit-report');
+if (!auditReportPath) {
+  usage();
+}
+
+const plan = createAuditWpCodeboxFanoutPlanFromFiles({
+  auditReportPath,
+  artifactMapPath: argValue('--artifact-map') || '',
+  outputPath: argValue('--output') || '',
+  orchestratorId: argValue('--orchestrator-id') || undefined,
+  runId: argValue('--run-id') || undefined,
+  reportId: argValue('--report-id') || undefined,
+  issueUrl: argValue('--issue-url') || undefined,
+  base: argValue('--base') || undefined,
+  branchPrefix: argValue('--branch-prefix') || undefined,
+  reviewedAt: argValue('--reviewed-at') || undefined,
+});
+
+console.log(JSON.stringify(plan, null, 2));

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -111,7 +111,11 @@ try {
   assert.equal(initialPlan.audit.group_count, 2);
   assert.equal(initialPlan.task_requests.length, 2);
 
-  assert.equal(safeBranchSlug('PHPCS Formatting/Auto Fix!'), 'phpcs-formatting/auto-fix');
+  assert.equal(safeBranchSlug('PHPCS Formatting/Auto Fix!'), 'phpcs-formatting-auto-fix');
+  assert.equal(safeBranchSlug('foo..bar'), 'foo-bar');
+  assert.equal(safeBranchSlug('foo/.bar'), 'foo-bar');
+  assert.equal(safeBranchSlug('foo/bar.lock'), 'foo-bar-lock');
+  assert.equal(safeBranchSlug('../.@{'), 'audit-batch');
 
   const phpcsRequest = initialPlan.task_requests.find((request) => request.group_key === 'PHPCS Formatting/Auto Fix!');
   const docsRequest = initialPlan.task_requests.find((request) => request.group_key === 'docs-reference');
@@ -166,9 +170,9 @@ try {
   assert.equal(phpcsApplyBack.artifact.patch_sha256, phpcsBundle.patchSha256);
   assert.deepEqual(phpcsApplyBack.review.approved_files, [phpcsBundle.changedPath]);
   assert.equal(phpcsApplyBack.adapter_payload.bundlePath, fs.realpathSync(phpcsBundle.bundle));
-  assert.equal(phpcsApplyBack.adapter_payload.branch, 'fix/homeboy-audit/phpcs-formatting/auto-fix');
+  assert.equal(phpcsApplyBack.adapter_payload.branch, 'fix/homeboy-audit/phpcs-formatting-auto-fix');
   assert.equal(phpcsApplyBack.pull_request.base, 'main');
-  assert.equal(phpcsApplyBack.pull_request.head, 'fix/homeboy-audit/phpcs-formatting/auto-fix');
+  assert.equal(phpcsApplyBack.pull_request.head, 'fix/homeboy-audit/phpcs-formatting-auto-fix');
   assert.match(phpcsApplyBack.pull_request.body, /Extra-Chill\/homeboy-extensions\/issues\/769/);
 
   const missingApprovalMap = {

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -9,6 +9,7 @@ const { spawnSync } = require('node:child_process');
 const {
   createAuditWpCodeboxFanoutPlan,
   createAuditWpCodeboxFanoutPlanFromFiles,
+  safeBranchSlug,
 } = require('../lib/audit-wp-codebox-fanout');
 const { artifactContentDigest } = require('../lib/wp-codebox-apply-adapter');
 
@@ -110,7 +111,9 @@ try {
   assert.equal(initialPlan.audit.group_count, 2);
   assert.equal(initialPlan.task_requests.length, 2);
 
-  const phpcsRequest = initialPlan.task_requests.find((request) => request.group_key === 'phpcs-formatting');
+  assert.equal(safeBranchSlug('PHPCS Formatting/Auto Fix!'), 'phpcs-formatting/auto-fix');
+
+  const phpcsRequest = initialPlan.task_requests.find((request) => request.group_key === 'PHPCS Formatting/Auto Fix!');
   const docsRequest = initialPlan.task_requests.find((request) => request.group_key === 'docs-reference');
   assert.equal(phpcsRequest.audit_findings.length, 2);
   assert.equal(docsRequest.audit_findings.length, 1);
@@ -131,18 +134,18 @@ try {
     'docs/setup.md'
   );
   const artifactMap = {
-    'phpcs-formatting': {
+    'PHPCS Formatting/Auto Fix!': {
       bundle_path: phpcsBundle.bundle,
+      approved_files: [phpcsBundle.changedPath],
       reviewed_at: '2026-05-25T00:00:00.000Z',
       reviewer: 'homeboy-review-fixture',
-      branch: 'fix/homeboy-audit/phpcs-formatting',
       base: 'main',
     },
     'docs-reference': {
       bundle_path: docsBundle.bundle,
+      approved_files: [docsBundle.changedPath],
       reviewed_at: '2026-05-25T00:00:00.000Z',
       reviewer: 'homeboy-review-fixture',
-      branch: 'fix/homeboy-audit/docs-reference',
       base: 'main',
     },
   };
@@ -154,7 +157,7 @@ try {
   });
   assert.equal(plan.apply_back.length, 2);
 
-  const phpcsApplyBack = plan.apply_back.find((entry) => entry.group_key === 'phpcs-formatting');
+  const phpcsApplyBack = plan.apply_back.find((entry) => entry.group_key === 'PHPCS Formatting/Auto Fix!');
   assert.equal(phpcsApplyBack.adapter_id, 'homeboy/wp-codebox-apply-adapter/v1');
   assert.equal(phpcsApplyBack.sandbox_session_id, phpcsRequest.sandbox_session_id);
   assert.deepEqual(phpcsApplyBack.finding_ids, ['finding-phpcs-001', 'finding-phpcs-002']);
@@ -163,10 +166,37 @@ try {
   assert.equal(phpcsApplyBack.artifact.patch_sha256, phpcsBundle.patchSha256);
   assert.deepEqual(phpcsApplyBack.review.approved_files, [phpcsBundle.changedPath]);
   assert.equal(phpcsApplyBack.adapter_payload.bundlePath, fs.realpathSync(phpcsBundle.bundle));
-  assert.equal(phpcsApplyBack.adapter_payload.branch, 'fix/homeboy-audit/phpcs-formatting');
+  assert.equal(phpcsApplyBack.adapter_payload.branch, 'fix/homeboy-audit/phpcs-formatting/auto-fix');
   assert.equal(phpcsApplyBack.pull_request.base, 'main');
-  assert.equal(phpcsApplyBack.pull_request.head, 'fix/homeboy-audit/phpcs-formatting');
+  assert.equal(phpcsApplyBack.pull_request.head, 'fix/homeboy-audit/phpcs-formatting/auto-fix');
   assert.match(phpcsApplyBack.pull_request.body, /Extra-Chill\/homeboy-extensions\/issues\/769/);
+
+  const missingApprovalMap = {
+    'PHPCS Formatting/Auto Fix!': {
+      bundle_path: phpcsBundle.bundle,
+    },
+  };
+  assert.throws(
+    () => createAuditWpCodeboxFanoutPlan({
+      report,
+      artifact_map: missingApprovalMap,
+    }),
+    /non-empty explicit approved_files/
+  );
+
+  const rejectedPlan = createAuditWpCodeboxFanoutPlan({
+    report,
+    artifact_map: {
+      ...artifactMap,
+      'docs-reference': {
+        bundle_path: docsBundle.bundle,
+        approved_files: [docsBundle.changedPath],
+        approved: false,
+      },
+    },
+  });
+  assert.equal(rejectedPlan.apply_back.length, 1);
+  assert.equal(rejectedPlan.apply_back[0].group_key, 'PHPCS Formatting/Auto Fix!');
 
   const artifactMapPath = path.join(root, 'artifact-map.json');
   const outputPath = path.join(root, 'fanout-plan.json');

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -1,0 +1,199 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const {
+  createAuditWpCodeboxFanoutPlan,
+  createAuditWpCodeboxFanoutPlanFromFiles,
+} = require('../lib/audit-wp-codebox-fanout');
+const { artifactContentDigest } = require('../lib/wp-codebox-apply-adapter');
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { cwd: options.cwd, encoding: 'utf8' });
+  assert.equal(result.status, 0, `${command} ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
+  return (result.stdout || '').trim();
+}
+
+function createBundle(root, name, changedPath, relativePath) {
+  const bundle = path.join(root, name);
+  const files = path.join(bundle, 'files');
+  fs.mkdirSync(files, { recursive: true });
+
+  const changedFiles = {
+    schema: 'wp-codebox/changed-files/v1',
+    files: [
+      {
+        path: changedPath,
+        status: 'modified',
+        mountTarget: '/wordpress/wp-content/plugins/fixture-plugin',
+        relativePath,
+      },
+    ],
+  };
+  const changedFilesJson = `${JSON.stringify(changedFiles, null, 2)}\n`;
+  const patch = [
+    `diff --git a/wordpress/wp-content/plugins/fixture-plugin/${relativePath} b/wordpress/wp-content/plugins/fixture-plugin/${relativePath}`,
+    `--- a/wordpress/wp-content/plugins/fixture-plugin/${relativePath}`,
+    `+++ b/wordpress/wp-content/plugins/fixture-plugin/${relativePath}`,
+    '@@ -1,1 +1,1 @@',
+    '-before',
+    '+after',
+    '',
+  ].join('\n');
+  const contentDigest = artifactContentDigest(changedFilesJson, patch);
+  const artifactId = `artifact-bundle-sha256-${contentDigest}`;
+  const contentDigestMetadata = {
+    algorithm: 'sha256',
+    inputs: ['files/changed-files.json', 'files/patch.diff'],
+    value: contentDigest,
+  };
+
+  writeJson(path.join(bundle, 'manifest.json'), {
+    id: artifactId,
+    contentDigest: contentDigestMetadata,
+    files: [
+      { path: 'files/changed-files.json', kind: 'changed-files' },
+      { path: 'files/patch.diff', kind: 'patch' },
+      { path: 'files/review.json', kind: 'review' },
+    ],
+  });
+  writeJson(path.join(bundle, 'metadata.json'), {
+    id: artifactId,
+    contentDigest: contentDigestMetadata,
+    artifacts: { changedFiles: 'files/changed-files.json', patch: 'files/patch.diff' },
+  });
+  writeJson(path.join(files, 'changed-files.json'), changedFiles);
+  fs.writeFileSync(path.join(files, 'patch.diff'), patch);
+  writeJson(path.join(files, 'review.json'), {
+    schema: 'wp-codebox/artifact-review/v1',
+    artifactId,
+    summary: `Fixture review for ${name}`,
+    evidence: {
+      patch: 'files/patch.diff',
+      patchSha256: sha256(patch),
+      artifactContentDigest: contentDigest,
+      changedFiles: 'files/changed-files.json',
+    },
+  });
+
+  return { artifactId, bundle, changedPath, contentDigest, patchSha256: sha256(patch) };
+}
+
+const auditReportPath = path.join(__dirname, 'fixtures', 'homeboy-audit-wp-codebox-fanout', 'audit-report.json');
+const report = readJson(auditReportPath);
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-audit-wp-codebox-fanout-'));
+
+try {
+  const initialPlan = createAuditWpCodeboxFanoutPlan({
+    report,
+    issue_url: 'https://github.com/Extra-Chill/homeboy-extensions/issues/769',
+  });
+  assert.equal(initialPlan.schema, 'homeboy/audit-wp-codebox-fanout/v1');
+  assert.equal(initialPlan.audit.finding_count, 3);
+  assert.equal(initialPlan.audit.group_count, 2);
+  assert.equal(initialPlan.task_requests.length, 2);
+
+  const phpcsRequest = initialPlan.task_requests.find((request) => request.group_key === 'phpcs-formatting');
+  const docsRequest = initialPlan.task_requests.find((request) => request.group_key === 'docs-reference');
+  assert.equal(phpcsRequest.audit_findings.length, 2);
+  assert.equal(docsRequest.audit_findings.length, 1);
+  assert.match(phpcsRequest.sandbox_session_id, /^homeboy-audit-[a-f0-9]{16}$/);
+  assert.equal(phpcsRequest.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/769');
+  assert.match(phpcsRequest.task.prompt, /finding-phpcs-001/);
+
+  const phpcsBundle = createBundle(
+    root,
+    'phpcs-bundle',
+    '/wordpress/wp-content/plugins/fixture-plugin/src/Example/class-alpha.php',
+    'src/Example/class-alpha.php'
+  );
+  const docsBundle = createBundle(
+    root,
+    'docs-bundle',
+    '/wordpress/wp-content/plugins/fixture-plugin/docs/setup.md',
+    'docs/setup.md'
+  );
+  const artifactMap = {
+    'phpcs-formatting': {
+      bundle_path: phpcsBundle.bundle,
+      reviewed_at: '2026-05-25T00:00:00.000Z',
+      reviewer: 'homeboy-review-fixture',
+      branch: 'fix/homeboy-audit/phpcs-formatting',
+      base: 'main',
+    },
+    'docs-reference': {
+      bundle_path: docsBundle.bundle,
+      reviewed_at: '2026-05-25T00:00:00.000Z',
+      reviewer: 'homeboy-review-fixture',
+      branch: 'fix/homeboy-audit/docs-reference',
+      base: 'main',
+    },
+  };
+
+  const plan = createAuditWpCodeboxFanoutPlan({
+    report,
+    artifact_map: artifactMap,
+    issue_url: 'https://github.com/Extra-Chill/homeboy-extensions/issues/769',
+  });
+  assert.equal(plan.apply_back.length, 2);
+
+  const phpcsApplyBack = plan.apply_back.find((entry) => entry.group_key === 'phpcs-formatting');
+  assert.equal(phpcsApplyBack.adapter_id, 'homeboy/wp-codebox-apply-adapter/v1');
+  assert.equal(phpcsApplyBack.sandbox_session_id, phpcsRequest.sandbox_session_id);
+  assert.deepEqual(phpcsApplyBack.finding_ids, ['finding-phpcs-001', 'finding-phpcs-002']);
+  assert.equal(phpcsApplyBack.artifact.id, phpcsBundle.artifactId);
+  assert.equal(phpcsApplyBack.artifact.content_digest, phpcsBundle.contentDigest);
+  assert.equal(phpcsApplyBack.artifact.patch_sha256, phpcsBundle.patchSha256);
+  assert.deepEqual(phpcsApplyBack.review.approved_files, [phpcsBundle.changedPath]);
+  assert.equal(phpcsApplyBack.adapter_payload.bundlePath, fs.realpathSync(phpcsBundle.bundle));
+  assert.equal(phpcsApplyBack.adapter_payload.branch, 'fix/homeboy-audit/phpcs-formatting');
+  assert.equal(phpcsApplyBack.pull_request.base, 'main');
+  assert.equal(phpcsApplyBack.pull_request.head, 'fix/homeboy-audit/phpcs-formatting');
+  assert.match(phpcsApplyBack.pull_request.body, /Extra-Chill\/homeboy-extensions\/issues\/769/);
+
+  const artifactMapPath = path.join(root, 'artifact-map.json');
+  const outputPath = path.join(root, 'fanout-plan.json');
+  writeJson(artifactMapPath, artifactMap);
+  const filePlan = createAuditWpCodeboxFanoutPlanFromFiles({
+    auditReportPath,
+    artifactMapPath,
+    outputPath,
+    issueUrl: 'https://github.com/Extra-Chill/homeboy-extensions/issues/769',
+  });
+  assert.equal(filePlan.apply_back.length, 2);
+  assert.equal(readJson(outputPath).apply_back.length, 2);
+
+  const cliOutput = run(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-audit-wp-codebox-fanout.cjs'),
+    '--audit-report',
+    auditReportPath,
+    '--artifact-map',
+    artifactMapPath,
+    '--issue-url',
+    'https://github.com/Extra-Chill/homeboy-extensions/issues/769',
+  ]);
+  const cliPlan = JSON.parse(cliOutput);
+  assert.equal(cliPlan.task_requests.length, 2);
+  assert.equal(cliPlan.apply_back.length, 2);
+
+  console.log('Homeboy audit WP Codebox fanout smoke passed');
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/wordpress/tests/fixtures/homeboy-audit-wp-codebox-fanout/audit-report.json
+++ b/wordpress/tests/fixtures/homeboy-audit-wp-codebox-fanout/audit-report.json
@@ -1,0 +1,38 @@
+{
+  "id": "fixture-homeboy-audit-001",
+  "run_id": "homeboy-audit-fixture-run",
+  "data": {
+    "findings": [
+      {
+        "id": "finding-phpcs-001",
+        "kind": "wordpress.phpcs.fixable",
+        "fix_batch_key": "phpcs-formatting",
+        "file": "src/Example/class-alpha.php",
+        "line": 12,
+        "message": "Spacing around assignment can be fixed automatically.",
+        "severity": "warning",
+        "fingerprint": "fixture-phpcs-001"
+      },
+      {
+        "id": "finding-phpcs-002",
+        "kind": "wordpress.phpcs.fixable",
+        "fix_batch_key": "phpcs-formatting",
+        "file": "src/Example/class-beta.php",
+        "line": 24,
+        "message": "Array alignment can be fixed automatically.",
+        "severity": "warning",
+        "fingerprint": "fixture-phpcs-002"
+      },
+      {
+        "id": "finding-doc-001",
+        "kind": "wordpress.docs.broken_reference",
+        "fix_batch_key": "docs-reference",
+        "file": "docs/setup.md",
+        "line": 7,
+        "message": "Document references a removed setup script.",
+        "severity": "error",
+        "fingerprint": "fixture-doc-001"
+      }
+    ]
+  }
+}

--- a/wordpress/tests/fixtures/homeboy-audit-wp-codebox-fanout/audit-report.json
+++ b/wordpress/tests/fixtures/homeboy-audit-wp-codebox-fanout/audit-report.json
@@ -6,7 +6,7 @@
       {
         "id": "finding-phpcs-001",
         "kind": "wordpress.phpcs.fixable",
-        "fix_batch_key": "phpcs-formatting",
+        "fix_batch_key": "PHPCS Formatting/Auto Fix!",
         "file": "src/Example/class-alpha.php",
         "line": 12,
         "message": "Spacing around assignment can be fixed automatically.",
@@ -16,7 +16,7 @@
       {
         "id": "finding-phpcs-002",
         "kind": "wordpress.phpcs.fixable",
-        "fix_batch_key": "phpcs-formatting",
+        "fix_batch_key": "PHPCS Formatting/Auto Fix!",
         "file": "src/Example/class-beta.php",
         "line": 24,
         "message": "Array alignment can be fixed automatically.",


### PR DESCRIPTION
## Summary
- Add a Homeboy-owned audit fanout planner/CLI that consumes a fixture `homeboy audit` report and groups findings into WP Codebox task requests.
- Carry `sandbox_session_id` plus orchestrator metadata through each request for correlation.
- Record returned WP Codebox artifact/review metadata and PR-shaped apply-back metadata using the existing apply adapter contract.

Closes #769

## Verification
- `npm run test:audit-wp-codebox-fanout`
- `npm run test:wp-codebox-apply-adapter`
- `npm run lint:js -- lib/audit-wp-codebox-fanout.js scripts/agent/homeboy-audit-wp-codebox-fanout.cjs`
- `node --check lib/audit-wp-codebox-fanout.js && node --check scripts/agent/homeboy-audit-wp-codebox-fanout.cjs && node --check tests/audit-wp-codebox-fanout-smoke.js`
- `jq empty homeboy.json package.json tests/fixtures/homeboy-audit-wp-codebox-fanout/audit-report.json`
- `git diff --check`

## Notes
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@feat-wp-codebox-audit-fanout/wordpress --extension wordpress --changed-since origin/main` did not reach the local checks because Homeboy auto-offloaded to lab runner `lab`; the lab workspace failed loading `scripts/lib/resolve-context.sh` from `_lab_workspaces`.
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@feat-wp-codebox-audit-fanout/wordpress --extension wordpress --changed-since origin/main` also auto-offloaded to `lab` and failed before linting because the runner has no `php` binary.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the first-slice implementation, fixture smoke coverage, and PR description; Chris remains responsible for review and merge.