### PR TITLE
Document remote runner extension bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id
 homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id nodejs
 ```
 
+Remote runners need the same extension IDs installed on the runner host before
+Homeboy can offload matching jobs to them. For the standard runner bootstrap
+path, see [`docs/remote-runner-bootstrap.md`](docs/remote-runner-bootstrap.md).
+
 ### Verify installation
 
 ```bash

--- a/docs/remote-runner-bootstrap.md
+++ b/docs/remote-runner-bootstrap.md
@@ -1,0 +1,135 @@
+# Remote Runner Extension Bootstrap
+
+Remote Homeboy runners need the same extension set as the machine that dispatches
+work to them. If a runner only has part of the standard set installed, Homeboy's
+offload preflight rejects matching jobs before execution, for example when a
+Rust component is sent to a runner that only has `nodejs` installed.
+
+Use this page as the canonical bootstrap path for machines such as Homeboy Lab.
+
+## Standard Extension Set
+
+Install these extension IDs on general-purpose runners:
+
+```text
+nodejs rust wordpress go swift
+```
+
+This set covers the official project-type extensions in this repository. A
+special-purpose runner may install fewer extensions, but the runner should only
+advertise or receive workloads for extension IDs that are present on that host.
+
+## Bootstrap A Remote Runner
+
+From a checkout of this repository, run:
+
+```bash
+scripts/bootstrap-standard-extensions.sh --target homeboy-lab
+```
+
+Use any SSH target accepted by `ssh`:
+
+```bash
+scripts/bootstrap-standard-extensions.sh --target chubes@homeboy-lab
+```
+
+The script runs this idempotent install-and-verify loop on the target:
+
+```bash
+homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id <extension-id>
+homeboy extension show <extension-id>
+```
+
+After all installs pass, it prints `homeboy extension list` from the target so
+the installed runner state is visible in the command output.
+
+## Bootstrap The Local Machine
+
+Omit `--target` to apply the same standard set locally:
+
+```bash
+scripts/bootstrap-standard-extensions.sh
+```
+
+Preview the exact target script without changing anything:
+
+```bash
+scripts/bootstrap-standard-extensions.sh --target homeboy-lab --dry-run
+```
+
+## Install A Subset
+
+Use `--extensions` for narrow runners or repair passes:
+
+```bash
+scripts/bootstrap-standard-extensions.sh --target homeboy-lab --extensions "nodejs rust wordpress"
+```
+
+## GitHub Installs Vs Local Path Installs
+
+Use the GitHub monorepo URL for normal runner bootstrap:
+
+```bash
+homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id rust
+```
+
+GitHub installs give the runner a managed extracted copy under Homeboy's
+extension directory and keep remote machines independent from a developer's
+local checkout or short-lived worktree.
+
+Use local path installs only while actively developing an extension on that
+machine:
+
+```bash
+homeboy extension install ./homeboy-extensions/rust
+```
+
+Local path installs are linked installs. The active extension code is whatever
+the symlink target points at, so they are easy to leave attached to stale or
+temporary worktrees. Before debugging remote-runner behavior, inspect the target:
+
+```bash
+ssh homeboy-lab 'homeboy extension list && homeboy extension show rust'
+ssh homeboy-lab 'readlink ~/.config/homeboy/extensions/rust || true'
+```
+
+If a linked install is stale, reinstall from the GitHub monorepo URL with the
+matching `--id`.
+
+## Custom Homeboy Binary Or Source
+
+If the target exposes Homeboy under a different command path, pass `--homeboy`:
+
+```bash
+scripts/bootstrap-standard-extensions.sh \
+    --target homeboy-lab \
+    --homeboy /home/chubes/.local/bin/homeboy
+```
+
+To test an extension branch on a runner, pass a repository path or URL with
+`--repo`. Prefer this only for deliberate extension development; general runners
+should use the canonical GitHub URL.
+
+```bash
+scripts/bootstrap-standard-extensions.sh \
+    --target homeboy-lab \
+    --repo /home/chubes/src/homeboy-extensions \
+    --extensions "rust"
+```
+
+## Verification Checklist
+
+After bootstrap, verify the runner from the dispatching machine:
+
+```bash
+ssh homeboy-lab 'homeboy extension list'
+ssh homeboy-lab 'homeboy extension show nodejs'
+ssh homeboy-lab 'homeboy extension show rust'
+ssh homeboy-lab 'homeboy extension show wordpress'
+ssh homeboy-lab 'homeboy extension show go'
+ssh homeboy-lab 'homeboy extension show swift'
+```
+
+For a real offload check, run a Homeboy command for a component that requires one
+of the installed extensions and confirm preflight no longer reports the runner as
+missing that extension.

--- a/scripts/bootstrap-standard-extensions.sh
+++ b/scripts/bootstrap-standard-extensions.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_REPO="https://github.com/Extra-Chill/homeboy-extensions"
+DEFAULT_EXTENSIONS="nodejs rust wordpress go swift"
+
+TARGET=""
+REPO="$DEFAULT_REPO"
+HOMEBOY_BIN="homeboy"
+EXTENSIONS="$DEFAULT_EXTENSIONS"
+DRY_RUN=0
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/bootstrap-standard-extensions.sh [options]
+
+Install the standard Homeboy extension set on the local machine or an SSH
+reachable remote runner.
+
+Options:
+  --target <ssh-host>         SSH target such as homeboy-lab or user@host.
+                             Omit for local bootstrap.
+  --extensions "<ids>"       Space-separated extension IDs to install.
+                             Default: nodejs rust wordpress go swift.
+  --repo <url-or-path>        Extension monorepo URL or path.
+                             Default: https://github.com/Extra-Chill/homeboy-extensions.
+  --homeboy <command>         Homeboy executable on the target.
+                             Default: homeboy.
+  --dry-run                  Print the target script without executing it.
+  -h, --help                 Show this help.
+
+Examples:
+  scripts/bootstrap-standard-extensions.sh --target homeboy-lab
+  scripts/bootstrap-standard-extensions.sh --target chubes@homeboy-lab --extensions "nodejs rust wordpress"
+  scripts/bootstrap-standard-extensions.sh --repo /path/to/homeboy-extensions --extensions "rust" --dry-run
+USAGE
+}
+
+shell_quote() {
+    printf "'%s'" "$(printf "%s" "$1" | sed "s/'/'\\\\''/g")"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --target)
+            TARGET="${2:-}"
+            shift 2
+            ;;
+        --extensions)
+            EXTENSIONS="${2:-}"
+            shift 2
+            ;;
+        --repo)
+            REPO="${2:-}"
+            shift 2
+            ;;
+        --homeboy)
+            HOMEBOY_BIN="${2:-}"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$EXTENSIONS" ]; then
+    echo "--extensions must not be empty" >&2
+    exit 2
+fi
+
+if [ -z "$REPO" ]; then
+    echo "--repo must not be empty" >&2
+    exit 2
+fi
+
+if [ -z "$HOMEBOY_BIN" ]; then
+    echo "--homeboy must not be empty" >&2
+    exit 2
+fi
+
+REMOTE_SCRIPT="set -euo pipefail
+HOMEBOY_BIN=$(shell_quote "$HOMEBOY_BIN")
+REPO=$(shell_quote "$REPO")
+EXTENSIONS=$(shell_quote "$EXTENSIONS")
+
+command -v \"\$HOMEBOY_BIN\" >/dev/null 2>&1 || {
+    echo \"Homeboy executable not found on target: \$HOMEBOY_BIN\" >&2
+    exit 127
+}
+
+for EXTENSION_ID in \$EXTENSIONS; do
+    echo \"Installing Homeboy extension: \$EXTENSION_ID\"
+    \"\$HOMEBOY_BIN\" extension install \"\$REPO\" --id \"\$EXTENSION_ID\"
+    \"\$HOMEBOY_BIN\" extension show \"\$EXTENSION_ID\" >/dev/null
+done
+
+echo \"Installed Homeboy extensions:\"
+\"\$HOMEBOY_BIN\" extension list
+"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    if [ -n "$TARGET" ]; then
+        echo "# Target: $TARGET"
+    else
+        echo "# Target: local"
+    fi
+    printf "%s" "$REMOTE_SCRIPT"
+    exit 0
+fi
+
+if [ -n "$TARGET" ]; then
+    printf "%s" "$REMOTE_SCRIPT" | ssh "$TARGET" 'bash -s'
+else
+    bash -s <<<"$REMOTE_SCRIPT"
+fi

--- a/tests/bootstrap-standard-extensions-smoke.sh
+++ b/tests/bootstrap-standard-extensions-smoke.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/bootstrap-standard-extensions.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "Missing bootstrap script: $SCRIPT" >&2
+    exit 1
+fi
+
+OUTPUT="$($SCRIPT --target runner.example --extensions "nodejs rust" --repo "https://example.com/extensions.git" --homeboy /opt/homeboy/bin/homeboy --dry-run)"
+
+case "$OUTPUT" in
+    *"# Target: runner.example"*) ;;
+    *)
+        echo "Dry-run output did not include target" >&2
+        echo "$OUTPUT" >&2
+        exit 1
+        ;;
+esac
+
+case "$OUTPUT" in
+    *"HOMEBOY_BIN='/opt/homeboy/bin/homeboy'"*) ;;
+    *)
+        echo "Dry-run output did not include quoted Homeboy binary" >&2
+        echo "$OUTPUT" >&2
+        exit 1
+        ;;
+esac
+
+case "$OUTPUT" in
+    *"REPO='https://example.com/extensions.git'"*) ;;
+    *)
+        echo "Dry-run output did not include quoted repo" >&2
+        echo "$OUTPUT" >&2
+        exit 1
+        ;;
+esac
+
+case "$OUTPUT" in
+    *"EXTENSIONS='nodejs rust'"*) ;;
+    *)
+        echo "Dry-run output did not include selected extensions" >&2
+        echo "$OUTPUT" >&2
+        exit 1
+        ;;
+esac
+
+case "$OUTPUT" in
+    *'"$HOMEBOY_BIN" extension install "$REPO" --id "$EXTENSION_ID"'*) ;;
+    *)
+        echo "Dry-run output did not include install command" >&2
+        echo "$OUTPUT" >&2
+        exit 1
+        ;;
+esac
+
+case "$OUTPUT" in
+    *'"$HOMEBOY_BIN" extension show "$EXTENSION_ID" >/dev/null'*) ;;
+    *)
+        echo "Dry-run output did not include verify command" >&2
+        echo "$OUTPUT" >&2
+        exit 1
+        ;;
+esac
+
+HELP_OUTPUT="$($SCRIPT --help)"
+case "$HELP_OUTPUT" in
+    *"--target <ssh-host>"*"--dry-run"*) ;;
+    *)
+        echo "Help output is missing expected options" >&2
+        echo "$HELP_OUTPUT" >&2
+        exit 1
+        ;;
+esac
+
+FAKE_HOMEBOY="$TMP_DIR/homeboy"
+LOG_FILE="$TMP_DIR/homeboy.log"
+cat > "$FAKE_HOMEBOY" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$HOMEBOY_FAKE_LOG"
+case "$1 $2" in
+    "extension install") exit 0 ;;
+    "extension show") exit 0 ;;
+    "extension list") printf 'nodejs\nrust\n' ; exit 0 ;;
+    *) exit 2 ;;
+esac
+FAKE
+chmod +x "$FAKE_HOMEBOY"
+
+HOMEBOY_FAKE_LOG="$LOG_FILE" "$SCRIPT" --extensions "nodejs rust" --repo "https://example.com/extensions.git" --homeboy "$FAKE_HOMEBOY" >/dev/null
+
+EXPECTED_LOG="$TMP_DIR/expected.log"
+cat > "$EXPECTED_LOG" <<EOF
+extension install https://example.com/extensions.git --id nodejs
+extension show nodejs
+extension install https://example.com/extensions.git --id rust
+extension show rust
+extension list
+EOF
+
+if ! cmp -s "$EXPECTED_LOG" "$LOG_FILE"; then
+    echo "Local bootstrap did not call Homeboy as expected" >&2
+    echo "Expected:" >&2
+    sed 's/^/  /' "$EXPECTED_LOG" >&2
+    echo "Actual:" >&2
+    sed 's/^/  /' "$LOG_FILE" >&2
+    exit 1
+fi
+
+echo "bootstrap standard extensions smoke passed"


### PR DESCRIPTION
## Summary
- Adds canonical remote-runner bootstrap docs for the standard Homeboy extension set: `nodejs`, `rust`, `wordpress`, `go`, and `swift`.
- Adds `scripts/bootstrap-standard-extensions.sh` for local or SSH-targeted install-and-verify bootstraps.
- Adds a focused smoke test for dry-run generation and local install command sequencing.

Closes #771.

## Verification
- `git diff --check`
- `bash -n scripts/bootstrap-standard-extensions.sh && bash -n tests/bootstrap-standard-extensions-smoke.sh`
- `bash tests/bootstrap-standard-extensions-smoke.sh`

## Notes
- I kept the automation in this repo because it installs this repo's canonical extension set and does not require Homeboy core runner/server registry integration.
- `homeboy test --path . --extension nodejs` was not applicable at the monorepo root: the Node runner rejected the root before tests because there is no root `package.json`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the remote-runner bootstrap documentation, helper script, smoke test, and focused verification.