### PR TITLE
Run fanout tasks through WP Codebox recipes

### DIFF
--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -11,7 +11,7 @@
     "lint": [
       "jq empty wordpress.json",
       "bash -n scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/test-runner-core-dev.sh scripts/test/test-runner-core-dev-wp-codebox.sh scripts/test/test-runner-host-smoke.sh scripts/test/core-dev-shape-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/bench/bench-results-artifacts.sh scripts/bench/bench-results-artifacts-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/parse-wp-codebox-artifacts-smoke.sh scripts/test/wp-codebox-mount-translation-smoke.sh scripts/test/wp-codebox-bootstrap-failure-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/release/package.sh scripts/release/publish.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-doc-placeholder-refs-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
-      "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js lib/wp-codebox-apply-adapter.js lib/audit-wp-codebox-fanout.js scripts/agent/terminal-action-server.js scripts/agent/wp-codebox-apply-adapter.cjs scripts/agent/homeboy-audit-wp-codebox-fanout.cjs tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js tests/wp-codebox-apply-adapter-smoke.js tests/audit-wp-codebox-fanout-smoke.js",
+      "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js lib/wp-codebox-apply-adapter.js lib/audit-wp-codebox-fanout.js scripts/agent/terminal-action-server.js scripts/agent/wp-codebox-apply-adapter.cjs scripts/agent/homeboy-audit-wp-codebox-fanout.cjs scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js tests/wp-codebox-apply-adapter-smoke.js tests/audit-wp-codebox-fanout-smoke.js tests/wp-codebox-task-runner-smoke.js",
       "php -l scripts/agent/datamachine-agent-workload.php tests/datamachine-terminal-tool-smoke.php"
     ],
     "test": [
@@ -41,7 +41,8 @@
       "php tests/datamachine-terminal-tool-smoke.php",
       "node tests/timing-correlator-smoke.js",
       "node tests/wp-codebox-apply-adapter-smoke.js",
-      "node tests/audit-wp-codebox-fanout-smoke.js"
+      "node tests/audit-wp-codebox-fanout-smoke.js",
+      "node tests/wp-codebox-task-runner-smoke.js"
     ]
   }
 }

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -24,7 +24,8 @@
     "test:timing-correlator": "node tests/timing-correlator-smoke.js",
     "test:wp-codebox-apply-adapter": "node tests/wp-codebox-apply-adapter-smoke.js",
     "test:audit-wp-codebox-fanout": "node tests/audit-wp-codebox-fanout-smoke.js",
-    "test:audit-wp-codebox-execute": "node tests/audit-wp-codebox-fanout-smoke.js"
+    "test:audit-wp-codebox-execute": "node tests/audit-wp-codebox-fanout-smoke.js",
+    "test:wp-codebox-task-runner": "node tests/wp-codebox-task-runner-smoke.js"
   },
   "devDependencies": {
     "@wp-playground/cli": "^3.1.29",

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+'use strict';
+
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : '';
+}
+
+function argValues(name) {
+  const values = [];
+  for (let index = 0; index < process.argv.length; index += 1) {
+    if (process.argv[index] === name && process.argv[index + 1]) {
+      values.push(process.argv[index + 1]);
+    }
+  }
+  return values;
+}
+
+function hasFlag(name) {
+  return process.argv.includes(name);
+}
+
+function usage() {
+  console.error('Usage: homeboy-wp-codebox-task-runner.cjs --agents-api <path> --data-machine <path> --data-machine-code <path> [--wp-codebox-bin <bin>] [--provider <id>] [--model <id>] [--provider-plugin-path <path>] [--secret-env <ENV>] [--mount <host:vfs[:mode]>] [--artifacts <dir>]');
+  process.exit(1);
+}
+
+function readStdin() {
+  try {
+    return fs.readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function readTaskRequest() {
+  const raw = process.env.HOMEBOY_WP_CODEBOX_TASK_REQUEST || readStdin();
+  if (!raw.trim()) {
+    throw new Error('Task request JSON is required on stdin or HOMEBOY_WP_CODEBOX_TASK_REQUEST.');
+  }
+  const request = JSON.parse(raw);
+  if (!request || request.schema !== 'homeboy/wp-codebox-task-request/v1') {
+    throw new Error('Task request must use schema homeboy/wp-codebox-task-request/v1.');
+  }
+  return request;
+}
+
+function requireArg(name) {
+  const value = argValue(name);
+  if (!value) {
+    usage();
+  }
+  return value;
+}
+
+function pluginEntry(source, slug, activate = false) {
+  return { source, slug: slug || path.basename(source), activate };
+}
+
+function providerPluginEntries(request) {
+  const paths = [...(request.provider_plugin_paths || []), ...argValues('--provider-plugin-path')];
+  return paths.map((source) => pluginEntry(source, path.basename(source), false));
+}
+
+function secretEnvNames(request) {
+  return Array.from(new Set([...(request.secret_env || []), ...argValues('--secret-env')].filter(Boolean)));
+}
+
+function mountEntries() {
+  return argValues('--mount').map((value) => {
+    const [source, target, mode = 'readwrite'] = value.split(':');
+    if (!source || !target) {
+      throw new Error(`Invalid --mount value: ${value}`);
+    }
+    return {
+      source,
+      target,
+      mode,
+      metadata: { kind: 'homeboy-audit-fanout' },
+    };
+  });
+}
+
+function recipeForRequest(request, options) {
+  const provider = argValue('--provider') || request.provider || '';
+  const model = argValue('--model') || request.model || '';
+  const task = JSON.stringify({
+    schema: 'homeboy/wp-codebox-audit-task/v1',
+    sandbox_session_id: request.sandbox_session_id,
+    group_key: request.group_key,
+    orchestrator: request.orchestrator,
+    audit_findings: request.audit_findings,
+    task: request.task,
+  });
+
+  const providerSlugs = providerPluginEntries(request).map((plugin) => plugin.slug).join(',');
+  const stepArgs = [
+    `task=${task}`,
+    'agent=sandbox-agent',
+    'mode=sandbox',
+    `provider=${provider}`,
+    `model=${model}`,
+    `provider-plugin-slugs=${providerSlugs}`,
+    `session-id=${request.sandbox_session_id}`,
+  ];
+
+  return {
+    schema: 'wp-codebox/workspace-recipe/v1',
+    runtime: {
+      wp: argValue('--wp') || 'latest',
+      blueprint: { steps: [] },
+    },
+    inputs: {
+      mounts: mountEntries(),
+      extraPlugins: [
+        pluginEntry(options.agentsApi, 'agents-api', false),
+        pluginEntry(options.dataMachine, 'data-machine', false),
+        pluginEntry(options.dataMachineCode, 'data-machine-code', false),
+        ...providerPluginEntries(request),
+      ],
+      secretEnv: secretEnvNames(request),
+    },
+    workflow: {
+      steps: [
+        {
+          command: 'wp-codebox.agent-sandbox-run',
+          args: stepArgs,
+        },
+      ],
+    },
+  };
+}
+
+function writeRecipe(recipe) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-recipe-'));
+  const recipePath = path.join(directory, 'recipe.json');
+  fs.writeFileSync(recipePath, `${JSON.stringify(recipe, null, 2)}\n`);
+  return recipePath;
+}
+
+function runWpCodebox(recipePath) {
+  const wpCodeboxBin = argValue('--wp-codebox-bin') || 'wp-codebox';
+  const args = ['recipe-run', '--recipe', recipePath, '--json'];
+  const artifacts = argValue('--artifacts');
+  if (artifacts) {
+    args.push('--artifacts', artifacts);
+  }
+  if (argValue('--preview-hold')) {
+    args.push('--preview-hold', argValue('--preview-hold'));
+  }
+  if (argValue('--preview-public-url')) {
+    args.push('--preview-public-url', argValue('--preview-public-url'));
+  }
+
+  if (hasFlag('--print-command')) {
+    console.error(JSON.stringify({ command: wpCodeboxBin, args }, null, 2));
+  }
+
+  const result = spawnSync(wpCodeboxBin, args, {
+    encoding: 'utf8',
+    env: process.env,
+    maxBuffer: 1024 * 1024 * 20,
+  });
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  return result.status ?? 1;
+}
+
+try {
+  const request = readTaskRequest();
+  const options = {
+    agentsApi: requireArg('--agents-api'),
+    dataMachine: requireArg('--data-machine'),
+    dataMachineCode: requireArg('--data-machine-code'),
+  };
+  const recipe = recipeForRequest(request, options);
+  const recipePath = writeRecipe(recipe);
+
+  if (hasFlag('--print-recipe')) {
+    console.error(JSON.stringify({ recipePath, recipe }, null, 2));
+  }
+
+  process.exitCode = runWpCodebox(recipePath);
+} catch (error) {
+  console.error(error && error.message ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function createFixtureWpCodebox(root) {
+  const binPath = path.join(root, 'fixture-wp-codebox.cjs');
+  fs.writeFileSync(binPath, `#!/usr/bin/env node
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const out = process.env.FIXTURE_WP_CODEBOX_CAPTURE;
+const recipeIndex = process.argv.indexOf('--recipe');
+const recipePath = recipeIndex >= 0 ? process.argv[recipeIndex + 1] : '';
+const recipe = recipePath ? JSON.parse(fs.readFileSync(recipePath, 'utf8')) : null;
+fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), recipe }, null, 2));
+process.stdout.write(JSON.stringify({
+  success: true,
+  artifacts: {
+    id: 'artifact-bundle-sha256-fixture',
+    directory: path.dirname(out),
+  },
+}));
+`);
+  fs.chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-task-runner-'));
+
+try {
+  const capturePath = path.join(root, 'capture.json');
+  const fixtureWpCodebox = createFixtureWpCodebox(root);
+  const request = {
+    schema: 'homeboy/wp-codebox-task-request/v1',
+    sandbox_session_id: 'homeboy-audit-fixture-session',
+    group_key: 'PHPCS Formatting/Auto Fix!',
+    provider: 'opencode',
+    model: 'opencode-go/kimi-k2.6',
+    provider_plugin_paths: ['/plugins/ai-provider-for-opencode'],
+    secret_env: ['OPENCODE_API_KEY'],
+    orchestrator: {
+      id: 'homeboy-extensions/audit-wp-codebox-fanout',
+      run_id: 'run-123',
+      report_id: 'report-123',
+      issue_url: 'https://github.com/Extra-Chill/homeboy-extensions/issues/775',
+    },
+    audit_findings: [
+      {
+        id: 'finding-1',
+        kind: 'wordpress.phpcs.fixable',
+        file: 'src/Example.php',
+        line: 10,
+        message: 'Fix spacing.',
+        severity: 'warning',
+      },
+    ],
+    task: {
+      title: 'Fix Homeboy audit batch PHPCS Formatting/Auto Fix!',
+      prompt: 'Fix the finding.',
+    },
+  };
+
+  const result = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin',
+    fixtureWpCodebox,
+    '--agents-api',
+    '/components/agents-api',
+    '--data-machine',
+    '/components/data-machine',
+    '--data-machine-code',
+    '/components/data-machine-code',
+    '--mount',
+    '/repo/plugin:/wordpress/wp-content/plugins/plugin:readwrite',
+    '--artifacts',
+    path.join(root, 'artifacts'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(request),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: capturePath,
+      OPENCODE_API_KEY: 'redacted-test-key',
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.success, true);
+
+  const captured = readJson(capturePath);
+  assert.deepEqual(captured.argv.slice(0, 4), ['recipe-run', '--recipe', captured.argv[2], '--json']);
+  assert.equal(captured.argv.includes('--artifacts'), true);
+
+  const recipe = captured.recipe;
+  assert.equal(recipe.schema, 'wp-codebox/workspace-recipe/v1');
+  assert.deepEqual(recipe.inputs.secretEnv, ['OPENCODE_API_KEY']);
+  assert.equal(recipe.inputs.mounts[0].source, '/repo/plugin');
+  assert.equal(recipe.inputs.extraPlugins[0].slug, 'agents-api');
+  assert.equal(recipe.inputs.extraPlugins[1].slug, 'data-machine');
+  assert.equal(recipe.inputs.extraPlugins[2].slug, 'data-machine-code');
+  assert.equal(recipe.inputs.extraPlugins[3].slug, 'ai-provider-for-opencode');
+
+  const step = recipe.workflow.steps[0];
+  assert.equal(step.command, 'wp-codebox.agent-sandbox-run');
+  assert.equal(step.args.includes('provider=opencode'), true);
+  assert.equal(step.args.includes('model=opencode-go/kimi-k2.6'), true);
+  assert.equal(step.args.includes('provider-plugin-slugs=ai-provider-for-opencode'), true);
+  assert.equal(step.args.includes('session-id=homeboy-audit-fixture-session'), true);
+
+  const taskArg = step.args.find((arg) => arg.startsWith('task='));
+  assert.ok(taskArg);
+  const task = JSON.parse(taskArg.slice('task='.length));
+  assert.equal(task.schema, 'homeboy/wp-codebox-audit-task/v1');
+  assert.equal(task.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/775');
+  assert.equal(task.audit_findings[0].id, 'finding-1');
+
+  console.log('Homeboy WP Codebox task runner smoke passed');
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- Add a provider-agnostic task runner that reads `homeboy/wp-codebox-task-request/v1` from stdin/env and generates a WP Codebox recipe.
- Pass Agents API, Data Machine, Data Machine Code, mounted workspaces, provider plugin paths, provider/model, and secret env names into the recipe without hardcoding OpenCode/Codex/OpenAI.
- Add smoke coverage using an OpenCode-shaped configuration to prove provider/model/plugin/secret propagation through the generated recipe.

Closes #775

## Verification
- `npm run test:audit-wp-codebox-fanout && npm run test:wp-codebox-task-runner`
- `node --check scripts/agent/homeboy-wp-codebox-task-runner.cjs && node --check tests/wp-codebox-task-runner-smoke.js && git diff --check`
- `npm run lint:js -- scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/wp-codebox-task-runner-smoke.js` (passes with existing warning that the test file is ignored by eslint)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the provider-agnostic WP Codebox recipe bridge, smoke coverage, and PR description; Chris remains responsible for review and merge.