### PR TITLE
Route audit fanout through refactor source

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -332,6 +332,39 @@ convention-exception globs, and convention tag globs (e.g. tagging
 `wordpress:php-role:procedural-helper`). The extension's own smoke
 scripts under `tests/audit-*-smoke.sh` cover regressions in the rule set.
 
+### WP Codebox audit fan-out
+
+The canonical Homeboy mutation path is `homeboy refactor --from audit --write`;
+`audit` remains read-only. WordPress-owned WP Codebox fan-out helpers live under
+`scripts/agent/` so extension orchestration can turn a structured audit report
+into sandbox task requests without teaching Homeboy core about WordPress or WP
+Codebox.
+
+When Homeboy's generic extension refactor-source seam is enabled, the WordPress
+extension handles the audit source with:
+
+```bash
+homeboy refactor <component> \
+  --from audit \
+  --setting refactor.audit.extension=wordpress \
+  --setting wp_codebox_provider=opencode \
+  --setting wp_codebox_model=opencode-go/kimi-k2.6 \
+  --setting wp_codebox_provider_plugin_paths=/Users/chubes/Developer/ai-provider-for-opencode \
+  --setting wp_codebox_secret_env=OPENCODE_API_KEY
+```
+
+`scripts/agent/homeboy-audit-wp-codebox-fanout.cjs` turns a structured audit
+report into one `homeboy/wp-codebox-task-request/v1` request per fix batch. With
+`--execute`, it streams each request to a WP Codebox task runner command such as
+`scripts/agent/homeboy-wp-codebox-task-runner.cjs`, which builds a
+provider-configured `wp-codebox/workspace-recipe/v1` recipe.
+
+Approved artifact-map entries become `apply_back` records for the reviewed
+apply adapter. Rejected entries with `approved: false` become `issue_reports`
+records instead, preserving the finding IDs, artifact evidence, disposition,
+reason, and issue title/body metadata needed to file a follow-up false-positive
+or rejected-artifact tracker.
+
 ## Component settings
 
 Configure per-component in the component's homeboy/component config under

--- a/wordpress/homeboy.json
+++ b/wordpress/homeboy.json
@@ -11,7 +11,7 @@
     "lint": [
       "jq empty wordpress.json",
       "bash -n scripts/test/test-runner.sh scripts/test/test-runner-wp-codebox.sh scripts/test/test-runner-core-dev.sh scripts/test/test-runner-core-dev-wp-codebox.sh scripts/test/test-runner-host-smoke.sh scripts/test/core-dev-shape-smoke.sh scripts/bench/bench-runner.sh scripts/bench/bench-runner-wp-codebox.sh scripts/bench/bench-results-artifacts.sh scripts/bench/bench-results-artifacts-smoke.sh scripts/lib/wp-codebox-paths.sh scripts/test/host-smoke-runner-smoke.sh scripts/test/test-runner-file-routing-smoke.sh scripts/test/parse-test-failures-sidecar-smoke.sh scripts/test/parse-wp-codebox-artifacts-smoke.sh scripts/test/wp-codebox-mount-translation-smoke.sh scripts/test/wp-codebox-bootstrap-failure-smoke.sh scripts/agent/validate-bundle-smoke.sh scripts/release/package.sh scripts/release/publish.sh scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh scripts/lint/wordpress-lint-role-smoke.sh scripts/lint/vendor-prefixed-exclusion-smoke.sh scripts/lint/eslint-no-files-smoke.sh scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh tests/audit-detector-config-smoke.sh tests/audit-doc-placeholder-refs-smoke.sh tests/audit-dead-guard-fallback-smoke.sh tests/eslint-eqeqeq-null-smoke.sh",
-      "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js lib/wp-codebox-apply-adapter.js lib/audit-wp-codebox-fanout.js scripts/agent/terminal-action-server.js scripts/agent/wp-codebox-apply-adapter.cjs scripts/agent/homeboy-audit-wp-codebox-fanout.cjs scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js tests/wp-codebox-apply-adapter-smoke.js tests/audit-wp-codebox-fanout-smoke.js tests/wp-codebox-task-runner-smoke.js",
+      "node --check index.js lib/request-profiler.js lib/playground-readiness.js lib/timing-correlator.js lib/agent-terminal-actions.js lib/wp-codebox-apply-adapter.js lib/audit-wp-codebox-fanout.js scripts/agent/terminal-action-server.js scripts/agent/wp-codebox-apply-adapter.cjs scripts/agent/homeboy-audit-wp-codebox-fanout.cjs scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/request-profiler-smoke.js tests/playground-readiness-smoke.js tests/timing-correlator-smoke.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js tests/wp-codebox-apply-adapter-smoke.js tests/audit-wp-codebox-fanout-smoke.js tests/wp-codebox-task-runner-smoke.js tests/refactor-source-wp-codebox-smoke.js",
       "php -l scripts/agent/datamachine-agent-workload.php tests/datamachine-terminal-tool-smoke.php"
     ],
     "test": [
@@ -42,7 +42,8 @@
       "node tests/timing-correlator-smoke.js",
       "node tests/wp-codebox-apply-adapter-smoke.js",
       "node tests/audit-wp-codebox-fanout-smoke.js",
-      "node tests/wp-codebox-task-runner-smoke.js"
+      "node tests/wp-codebox-task-runner-smoke.js",
+      "node tests/refactor-source-wp-codebox-smoke.js"
     ]
   }
 }

--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -239,6 +239,49 @@ function createApplyBackMetadata(taskRequest, artifactEntry, options) {
   };
 }
 
+function createIssueReport(taskRequest, artifactEntry, options) {
+  const bundle = artifactEntry.bundle_path ? loadWpCodeboxArtifactBundle(artifactEntry.bundle_path) : null;
+  const issueUrl = options.issue_url || taskRequest.orchestrator.issue_url || '';
+  const disposition = artifactEntry.disposition || (artifactEntry.false_positive ? 'false_positive' : 'rejected_artifact');
+  const reason = artifactEntry.reason || artifactEntry.false_positive_reason || artifactEntry.rejection_reason || '';
+  const title = artifactEntry.issue_title || (
+    disposition === 'false_positive'
+      ? `Review Homeboy audit false positive for ${taskRequest.group_key}`
+      : `Review rejected WP Codebox artifact for ${taskRequest.group_key}`
+  );
+  const body = artifactEntry.issue_body || [
+    issueUrl ? `Source tracker: ${issueUrl}` : '',
+    '',
+    `Disposition: ${disposition}`,
+    reason ? `Reason: ${reason}` : '',
+    '',
+    'Findings:',
+    ...taskRequest.audit_findings.map((finding) => `- ${finding.id}: ${finding.kind} in ${finding.file}${finding.line ? `:${finding.line}` : ''}`),
+    bundle ? '' : '',
+    bundle ? `WP Codebox artifact: ${bundle.id}` : '',
+  ].filter(Boolean).join('\n');
+
+  return {
+    schema: 'homeboy/audit-wp-codebox-issue-report/v1',
+    sandbox_session_id: taskRequest.sandbox_session_id,
+    group_key: taskRequest.group_key,
+    disposition,
+    reason,
+    finding_ids: taskRequest.audit_findings.map((finding) => finding.id),
+    artifact: bundle ? {
+      id: bundle.id,
+      bundle_path: bundle.directory,
+      review: bundle.review,
+      changed_files: bundle.changed_files,
+    } : null,
+    issue: {
+      title,
+      body,
+      labels: artifactEntry.labels || ['homeboy-audit', 'wp-codebox', disposition],
+    },
+  };
+}
+
 function createAuditWpCodeboxFanoutPlan(input) {
   const report = input.report || readJson(input.auditReportPath);
   const orchestrator = {
@@ -261,6 +304,12 @@ function createAuditWpCodeboxFanoutPlan(input) {
   };
 
   const task_requests = groups.map((group) => createTaskRequest(group, orchestrator));
+  const issue_reports = task_requests
+    .map((taskRequest) => {
+      const artifactEntry = artifactMap[taskRequest.sandbox_session_id] || artifactMap[taskRequest.group_key];
+      return artifactEntry?.approved === false ? createIssueReport(taskRequest, artifactEntry, options) : null;
+    })
+    .filter(Boolean);
   const apply_back = task_requests
     .map((taskRequest) => {
       const artifactEntry = artifactMap[taskRequest.sandbox_session_id] || artifactMap[taskRequest.group_key];
@@ -281,6 +330,7 @@ function createAuditWpCodeboxFanoutPlan(input) {
     },
     task_requests,
     apply_back,
+    issue_reports,
   };
 }
 
@@ -399,6 +449,7 @@ module.exports = {
   executeAuditWpCodeboxFanout,
   executeAuditWpCodeboxFanoutFromFiles,
   executeWpCodeboxTaskRequest,
+  createIssueReport,
   groupFindings,
   safeBranchSlug,
   sandboxSessionId,

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -25,7 +25,8 @@
     "test:wp-codebox-apply-adapter": "node tests/wp-codebox-apply-adapter-smoke.js",
     "test:audit-wp-codebox-fanout": "node tests/audit-wp-codebox-fanout-smoke.js",
     "test:audit-wp-codebox-execute": "node tests/audit-wp-codebox-fanout-smoke.js",
-    "test:wp-codebox-task-runner": "node tests/wp-codebox-task-runner-smoke.js"
+    "test:wp-codebox-task-runner": "node tests/wp-codebox-task-runner-smoke.js",
+    "test:refactor-source-wp-codebox": "node tests/refactor-source-wp-codebox-smoke.js"
   },
   "devDependencies": {
     "@wp-playground/cli": "^3.1.29",

--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -11,7 +11,10 @@ Commands:
 import json
 import os
 import re
+import shlex
+import subprocess
 import sys
+import tempfile
 
 
 # ============================================================================
@@ -658,6 +661,108 @@ def extract_shared(data):
 # Command Dispatch
 # ============================================================================
 
+def split_setting(value):
+    if not value:
+        return []
+    parts = []
+    for chunk in str(value).replace(os.pathsep, ',').split(','):
+        chunk = chunk.strip()
+        if chunk:
+            parts.append(chunk)
+    return parts
+
+
+def refactor_source(data):
+    """Handle Homeboy's generic extension refactor source command."""
+    if data.get('source') != 'audit':
+        return {'handled': False}
+
+    settings = data.get('settings') or {}
+    output_dir = settings.get('wp_codebox_output_dir') or tempfile.mkdtemp(prefix='homeboy-wp-codebox-audit-')
+    os.makedirs(output_dir, exist_ok=True)
+
+    audit_report_path = os.path.join(output_dir, 'audit-report.json')
+    plan_path = os.path.join(output_dir, 'fanout-plan.json')
+    runs_path = os.path.join(output_dir, 'fanout-run.json')
+    with open(audit_report_path, 'w') as f:
+        json.dump(data.get('audit_result') or {}, f, indent=2)
+        f.write('\n')
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    fanout_script = os.path.join(script_dir, 'agent', 'homeboy-audit-wp-codebox-fanout.cjs')
+    args = [
+        settings.get('node_bin') or 'node',
+        fanout_script,
+        '--audit-report', audit_report_path,
+        '--output', plan_path,
+    ]
+
+    option_map = {
+        'wp_codebox_issue_url': '--issue-url',
+        'wp_codebox_provider': '--provider',
+        'wp_codebox_model': '--model',
+        'wp_codebox_base': '--base',
+        'wp_codebox_branch_prefix': '--branch-prefix',
+    }
+    for setting_key, flag in option_map.items():
+        if settings.get(setting_key):
+            args.extend([flag, settings[setting_key]])
+
+    for plugin_path in split_setting(settings.get('wp_codebox_provider_plugin_paths')):
+        args.extend(['--provider-plugin-path', plugin_path])
+    for secret_env in split_setting(settings.get('wp_codebox_secret_env')):
+        args.extend(['--secret-env', secret_env])
+
+    if data.get('write'):
+        args.append('--execute')
+        args.extend(['--runs-output', runs_path])
+        if settings.get('wp_codebox_command'):
+            args.extend(['--wp-codebox-command', settings['wp_codebox_command']])
+        for arg in shlex.split(settings.get('wp_codebox_args') or ''):
+            args.extend(['--wp-codebox-arg', arg])
+
+    result = subprocess.run(args, text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        return {
+            'handled': True,
+            'detected_findings': len((data.get('audit_result') or {}).get('findings') or []),
+            'changed_files': [],
+            'fix_results': [],
+            'warnings': [
+                'WP Codebox audit fan-out failed',
+                result.stderr.strip() or result.stdout.strip(),
+            ],
+        }
+
+    with open(plan_path, 'r') as f:
+        plan = json.load(f)
+
+    fix_results = []
+    for request in plan.get('task_requests') or []:
+        findings = request.get('audit_findings') or []
+        first_finding = findings[0] if findings else {}
+        action = 'executed' if data.get('write') else 'planned'
+        fix_results.append({
+            'file': first_finding.get('file') or request.get('group_key') or 'audit',
+            'rule': 'wp_codebox.audit_fanout',
+            'action': f"{action}:{request.get('group_key')}",
+            'primitive': 'extension_refactor_source',
+        })
+
+    warnings = [
+        f"WP Codebox audit fan-out plan: {plan_path}",
+    ]
+    if data.get('write'):
+        warnings.append(f"WP Codebox audit fan-out run: {runs_path}")
+
+    return {
+        'handled': True,
+        'detected_findings': (plan.get('audit') or {}).get('finding_count'),
+        'changed_files': [],
+        'fix_results': fix_results,
+        'warnings': warnings,
+    }
+
 def main():
     data = json.load(sys.stdin)
     command = data.get('command', '')
@@ -671,6 +776,10 @@ def main():
 
     elif command == 'extract_shared':
         result = extract_shared(data)
+        print(json.dumps(result))
+
+    elif command == 'refactor_source':
+        result = refactor_source(data)
         print(json.dumps(result))
 
     else:

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -231,17 +231,29 @@ try {
 
   const rejectedPlan = createAuditWpCodeboxFanoutPlan({
     report,
+    issue_url: 'https://github.com/Extra-Chill/homeboy-extensions/issues/769',
     artifact_map: {
       ...artifactMap,
       'docs-reference': {
         bundle_path: docsBundle.bundle,
         approved_files: [docsBundle.changedPath],
         approved: false,
+        false_positive: true,
+        reason: 'Fixture docs-reference rule is intentionally noisy.',
       },
     },
   });
   assert.equal(rejectedPlan.apply_back.length, 1);
   assert.equal(rejectedPlan.apply_back[0].group_key, 'PHPCS Formatting/Auto Fix!');
+  assert.equal(rejectedPlan.issue_reports.length, 1);
+  assert.equal(rejectedPlan.issue_reports[0].schema, 'homeboy/audit-wp-codebox-issue-report/v1');
+  assert.equal(rejectedPlan.issue_reports[0].group_key, 'docs-reference');
+  assert.equal(rejectedPlan.issue_reports[0].disposition, 'false_positive');
+  assert.deepEqual(rejectedPlan.issue_reports[0].finding_ids, ['finding-doc-001']);
+  assert.equal(rejectedPlan.issue_reports[0].artifact.id, docsBundle.artifactId);
+  assert.match(rejectedPlan.issue_reports[0].issue.title, /false positive/);
+  assert.match(rejectedPlan.issue_reports[0].issue.body, /Fixture docs-reference rule is intentionally noisy/);
+  assert.match(rejectedPlan.issue_reports[0].issue.body, /Extra-Chill\/homeboy-extensions\/issues\/769/);
 
   const artifactMapPath = path.join(root, 'artifact-map.json');
   const outputPath = path.join(root, 'fanout-plan.json');

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wordpress-refactor-source-wp-codebox-'));
+
+try {
+  const auditResult = JSON.parse(fs.readFileSync(
+    path.join(__dirname, 'fixtures', 'homeboy-audit-wp-codebox-fanout', 'audit-report.json'),
+    'utf8'
+  ));
+  const outputDir = path.join(root, 'fanout');
+  const command = {
+    command: 'refactor_source',
+    source: 'audit',
+    component_id: 'fixture-plugin',
+    root: '/repo/fixture-plugin',
+    audit_result: auditResult,
+    write: false,
+    settings: {
+      wp_codebox_output_dir: outputDir,
+      wp_codebox_provider: 'opencode',
+      wp_codebox_model: 'opencode-go/kimi-k2.6',
+      wp_codebox_provider_plugin_paths: '/plugins/ai-provider-for-opencode',
+      wp_codebox_secret_env: 'OPENCODE_API_KEY',
+      wp_codebox_issue_url: 'https://github.com/Extra-Chill/homeboy-extensions/issues/769',
+    },
+  };
+
+  const result = spawnSync('python3', [path.join(__dirname, '..', 'scripts', 'refactor.py')], {
+    encoding: 'utf8',
+    input: JSON.stringify(command),
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const response = JSON.parse(result.stdout);
+  assert.equal(response.handled, true);
+  assert.equal(response.detected_findings, 3);
+  assert.equal(response.changed_files.length, 0);
+  assert.equal(response.fix_results.length, 2);
+  assert.equal(response.fix_results[0].rule, 'wp_codebox.audit_fanout');
+  assert.equal(response.fix_results[0].primitive, 'extension_refactor_source');
+  assert.match(response.warnings[0], /fanout-plan\.json/);
+
+  const plan = JSON.parse(fs.readFileSync(path.join(outputDir, 'fanout-plan.json'), 'utf8'));
+  assert.equal(plan.schema, 'homeboy/audit-wp-codebox-fanout/v1');
+  assert.equal(plan.task_requests.length, 2);
+  assert.equal(plan.task_requests[0].provider, 'opencode');
+  assert.equal(plan.task_requests[0].model, 'opencode-go/kimi-k2.6');
+  assert.deepEqual(plan.task_requests[0].provider_plugin_paths, ['/plugins/ai-provider-for-opencode']);
+  assert.deepEqual(plan.task_requests[0].secret_env, ['OPENCODE_API_KEY']);
+
+  console.log('WordPress refactor source WP Codebox smoke passed');
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- Implements the WordPress extension side of Homeboy's generic `command=refactor_source` seam for audit fan-out through WP Codebox.
- Keeps WP Codebox provider/model/plugin/secrets configurable via refactor settings rather than hardcoding OpenCode, Codex, or credentials.
- Preserves rejected WP Codebox artifacts as `issue_reports` so false positives and rejected fixes can become follow-up trackers instead of disappearing from apply-back.

## Dependency
- Depends on Extra-Chill/homeboy#2876 for the generic extension refactor-source seam.

## Tests
- `python3 -m py_compile scripts/refactor.py`
- `node --check tests/refactor-source-wp-codebox-smoke.js`
- `jq empty homeboy.json`
- `jq empty package.json`
- `npm run test:refactor-source-wp-codebox`
- `npm run test:audit-wp-codebox-fanout`
- `npm run test:wp-codebox-task-runner`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the WordPress extension refactor-source implementation, fan-out issue-report handling, documentation, and smoke coverage; Chris directed the canonical Homeboy contract and reviewed architecture constraints.