### PR TITLE
Accept generic refactor source results

### DIFF
--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -677,6 +677,8 @@ def refactor_source(data):
     if data.get('source') != 'audit':
         return {'handled': False}
 
+    source_result = data.get('source_result') or data.get('audit_result') or {}
+
     settings = data.get('settings') or {}
     output_dir = settings.get('wp_codebox_output_dir') or tempfile.mkdtemp(prefix='homeboy-wp-codebox-audit-')
     os.makedirs(output_dir, exist_ok=True)
@@ -685,7 +687,7 @@ def refactor_source(data):
     plan_path = os.path.join(output_dir, 'fanout-plan.json')
     runs_path = os.path.join(output_dir, 'fanout-run.json')
     with open(audit_report_path, 'w') as f:
-        json.dump(data.get('audit_result') or {}, f, indent=2)
+        json.dump(source_result, f, indent=2)
         f.write('\n')
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -725,7 +727,7 @@ def refactor_source(data):
     if result.returncode != 0:
         return {
             'handled': True,
-            'detected_findings': len((data.get('audit_result') or {}).get('findings') or []),
+            'detected_findings': len(source_result.get('findings') or []),
             'changed_files': [],
             'fix_results': [],
             'warnings': [

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -19,7 +19,7 @@ try {
     source: 'audit',
     component_id: 'fixture-plugin',
     root: '/repo/fixture-plugin',
-    audit_result: auditResult,
+    source_result: auditResult,
     write: false,
     settings: {
       wp_codebox_output_dir: outputDir,


### PR DESCRIPTION
## Summary
- Update WordPress `refactor_source` to prefer the generic `source_result` payload while retaining `audit_result` as a transition fallback.
- Keep existing WP Codebox audit fan-out behavior intact for `source=audit`.
- Update the refactor source smoke test to exercise the generic payload shape.

## Dependency
- Extension-side follow-up for Extra-Chill/homeboy-extensions#778.
- Pairs with Extra-Chill/homeboy#2877, which generalizes Homeboy core to send `source_result` through the extension refactor source seam. No upstream PR is currently open for #2877.

## Tests
- `npm run test:refactor-source-wp-codebox`
- `npm run test:audit-wp-codebox-fanout`
- `npm run test:wp-codebox-task-runner`
- `python3 -m py_compile wordpress/scripts/refactor.py`
- `jq empty wordpress/homeboy.json wordpress/package.json`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small compatibility change, updated smoke coverage, ran verification, and prepared this PR for Chris to review.