### PR TITLE
Fix WP Codebox audit fanout task runner routing

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -111,7 +111,6 @@ function recipeForRequest(request, options) {
     `provider=${provider}`,
     `model=${model}`,
     `provider-plugin-slugs=${providerSlugs}`,
-    `session-id=${request.sandbox_session_id}`,
   ];
 
   return {

--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -672,6 +672,33 @@ def split_setting(value):
     return parts
 
 
+def default_sibling_path(component_root, sibling_name):
+    if not component_root:
+        return ''
+    return os.path.join(os.path.dirname(os.path.abspath(component_root)), sibling_name)
+
+
+def wp_codebox_task_runner_args(data, settings, script_dir):
+    component_root = data.get('root') or data.get('component_path') or os.getcwd()
+    agents_api_path = settings.get('wp_codebox_agents_api_path') or os.environ.get('HOMEBOY_WP_CODEBOX_AGENTS_API_PATH') or component_root
+    data_machine_path = settings.get('wp_codebox_data_machine_path') or os.environ.get('HOMEBOY_WP_CODEBOX_DATA_MACHINE_PATH') or default_sibling_path(component_root, 'data-machine')
+    data_machine_code_path = settings.get('wp_codebox_data_machine_code_path') or os.environ.get('HOMEBOY_WP_CODEBOX_DATA_MACHINE_CODE_PATH') or default_sibling_path(component_root, 'data-machine-code')
+
+    args = [
+        os.path.join(script_dir, 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+        '--agents-api', agents_api_path,
+        '--data-machine', data_machine_path,
+        '--data-machine-code', data_machine_code_path,
+    ]
+    if settings.get('wp_codebox_bin'):
+        args.extend(['--wp-codebox-bin', settings['wp_codebox_bin']])
+    if settings.get('wp_codebox_artifacts'):
+        args.extend(['--artifacts', settings['wp_codebox_artifacts']])
+    for mount in split_setting(settings.get('wp_codebox_mounts')):
+        args.extend(['--mount', mount])
+    return args
+
+
 def refactor_source(data):
     """Handle Homeboy's generic extension refactor source command."""
     if data.get('source') != 'audit':
@@ -720,7 +747,11 @@ def refactor_source(data):
         args.extend(['--runs-output', runs_path])
         if settings.get('wp_codebox_command'):
             args.extend(['--wp-codebox-command', settings['wp_codebox_command']])
-        for arg in shlex.split(settings.get('wp_codebox_args') or ''):
+            task_runner_args = shlex.split(settings.get('wp_codebox_args') or '')
+        else:
+            args.extend(['--wp-codebox-command', settings.get('node_bin') or 'node'])
+            task_runner_args = wp_codebox_task_runner_args(data, settings, script_dir)
+        for arg in task_runner_args:
             args.extend(['--wp-codebox-arg', arg])
 
     result = subprocess.run(args, text=True, capture_output=True, check=False)

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -54,6 +54,64 @@ try {
   assert.deepEqual(plan.task_requests[0].provider_plugin_paths, ['/plugins/ai-provider-for-opencode']);
   assert.deepEqual(plan.task_requests[0].secret_env, ['OPENCODE_API_KEY']);
 
+  const fixtureWpCodebox = path.join(root, 'fixture-wp-codebox.cjs');
+  fs.writeFileSync(fixtureWpCodebox, `#!/usr/bin/env node
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const recipeIndex = process.argv.indexOf('--recipe');
+if (process.argv[2] !== 'recipe-run' || recipeIndex < 0) {
+  process.exit(2);
+}
+const recipe = JSON.parse(fs.readFileSync(process.argv[recipeIndex + 1], 'utf8'));
+const stepArgs = recipe.workflow.steps[0].args;
+const task = JSON.parse(stepArgs.find((arg) => arg.startsWith('task=')).slice('task='.length));
+const sessionId = task.sandbox_session_id;
+const artifactDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'fixture-wp-codebox-artifact-'));
+process.stdout.write(JSON.stringify({
+  session: { id: sessionId },
+  artifacts: {
+    id: 'artifact-' + sessionId,
+    directory: artifactDirectory
+  }
+}));
+`);
+  fs.chmodSync(fixtureWpCodebox, 0o755);
+
+  const writeOutputDir = path.join(root, 'fanout-write');
+  const writeCommand = {
+    ...command,
+    root: path.join(root, 'agents-api'),
+    write: true,
+    settings: {
+      ...command.settings,
+      wp_codebox_output_dir: writeOutputDir,
+      wp_codebox_bin: fixtureWpCodebox,
+      wp_codebox_agents_api_path: path.join(root, 'agents-api'),
+      wp_codebox_data_machine_path: path.join(root, 'data-machine'),
+      wp_codebox_data_machine_code_path: path.join(root, 'data-machine-code'),
+    },
+  };
+  fs.mkdirSync(writeCommand.settings.wp_codebox_agents_api_path, { recursive: true });
+  fs.mkdirSync(writeCommand.settings.wp_codebox_data_machine_path, { recursive: true });
+  fs.mkdirSync(writeCommand.settings.wp_codebox_data_machine_code_path, { recursive: true });
+
+  const writeResult = spawnSync('python3', [path.join(__dirname, '..', 'scripts', 'refactor.py')], {
+    encoding: 'utf8',
+    input: JSON.stringify(writeCommand),
+  });
+
+  assert.equal(writeResult.status, 0, writeResult.stderr || writeResult.stdout);
+  const writeResponse = JSON.parse(writeResult.stdout);
+  assert.equal(writeResponse.handled, true);
+  assert.match(writeResponse.warnings[1], /fanout-run\.json/);
+  const run = JSON.parse(fs.readFileSync(path.join(writeOutputDir, 'fanout-run.json'), 'utf8'));
+  assert.equal(run.status, 'completed');
+  assert.equal(run.records[0].command.bin, 'node');
+  assert.match(run.records[0].command.args[0], /homeboy-wp-codebox-task-runner\.cjs$/);
+  assert.equal(run.records[0].command.args.includes('--wp-codebox-bin'), true);
+  assert.equal(run.records[0].artifact.id.startsWith('artifact-homeboy-audit-'), true);
+
   console.log('WordPress refactor source WP Codebox smoke passed');
 } finally {
   fs.rmSync(root, { recursive: true, force: true });

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -119,12 +119,13 @@ try {
   assert.equal(step.args.includes('provider=opencode'), true);
   assert.equal(step.args.includes('model=opencode-go/kimi-k2.6'), true);
   assert.equal(step.args.includes('provider-plugin-slugs=ai-provider-for-opencode'), true);
-  assert.equal(step.args.includes('session-id=homeboy-audit-fixture-session'), true);
+  assert.equal(step.args.some((arg) => arg.startsWith('session-id=')), false);
 
   const taskArg = step.args.find((arg) => arg.startsWith('task='));
   assert.ok(taskArg);
   const task = JSON.parse(taskArg.slice('task='.length));
   assert.equal(task.schema, 'homeboy/wp-codebox-audit-task/v1');
+  assert.equal(task.sandbox_session_id, 'homeboy-audit-fixture-session');
   assert.equal(task.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/775');
   assert.equal(task.audit_findings[0].id, 'finding-1');
 


### PR DESCRIPTION
## Summary
- Route write-mode WP Codebox audit fanout through the bundled task runner by default instead of invoking bare `wp-codebox` with no args.
- Keep the external `sandbox_session_id` in the task payload instead of passing it as an `agents/chat` conversation session id.
- Extend smoke coverage for the default write path and task-runner session mapping.

## Testing
- `python3 -m py_compile wordpress/scripts/refactor.py`
- `npm run test:refactor-source-wp-codebox`
- `npm run test:wp-codebox-task-runner`
- `npm run test:audit-wp-codebox-fanout`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the WP Codebox audit fanout canary failure, drafting the routing/session mapping fix, and running targeted verification. Chris remains responsible for review and merge.