### PR TITLE
Normalize WP Codebox runner plugin slugs

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -64,7 +64,8 @@ function requireArg(name) {
 }
 
 function pluginEntry(source, slug, activate = false) {
-  return { source, slug: slug || path.basename(source), activate };
+  const pluginSlug = (slug || path.basename(source)).split('@')[0].replace(/[^a-zA-Z0-9_-]/g, '-');
+  return { source, slug: pluginSlug, activate };
 }
 
 function providerPluginEntries(request) {
@@ -166,6 +167,22 @@ function writeRecipe(recipe) {
   return recipePath;
 }
 
+function executable(filePath) {
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveCommand(command, args) {
+  if (path.extname(command) === '.js' && !executable(command)) {
+    return { command: process.execPath, args: [command, ...args] };
+  }
+  return { command, args };
+}
+
 function runWpCodebox(recipePath) {
   const wpCodeboxBin = argValue('--wp-codebox-bin') || 'wp-codebox';
   const args = ['recipe-run', '--recipe', recipePath, '--json'];
@@ -184,7 +201,8 @@ function runWpCodebox(recipePath) {
     console.error(JSON.stringify({ command: wpCodeboxBin, args }, null, 2));
   }
 
-  const result = spawnSync(wpCodeboxBin, args, {
+  const resolved = resolveCommand(wpCodeboxBin, args);
+  const result = spawnSync(resolved.command, resolved.args, {
     encoding: 'utf8',
     env: process.env,
     maxBuffer: 1024 * 1024 * 20,
@@ -195,6 +213,9 @@ function runWpCodebox(recipePath) {
   }
   if (result.stderr) {
     process.stderr.write(result.stderr);
+  }
+  if (result.error) {
+    process.stderr.write(`${result.error.message}\n`);
   }
   return result.status ?? 1;
 }

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -15,8 +15,8 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
-function createFixtureWpCodebox(root) {
-  const binPath = path.join(root, 'fixture-wp-codebox.cjs');
+function createFixtureWpCodebox(root, mode = 0o755) {
+  const binPath = path.join(root, 'fixture-wp-codebox.js');
   fs.writeFileSync(binPath, `#!/usr/bin/env node
 'use strict';
 const fs = require('node:fs');
@@ -34,7 +34,7 @@ process.stdout.write(JSON.stringify({
   },
 }));
 `);
-  fs.chmodSync(binPath, 0o755);
+  fs.chmodSync(binPath, mode);
   return binPath;
 }
 
@@ -49,7 +49,7 @@ try {
     group_key: 'PHPCS Formatting/Auto Fix!',
     provider: 'opencode',
     model: 'opencode-go/kimi-k2.6',
-    provider_plugin_paths: ['/plugins/ai-provider-for-opencode'],
+    provider_plugin_paths: ['/plugins/ai-provider-for-opencode@fix-opencode-tool-choice'],
     secret_env: ['OPENCODE_API_KEY'],
     orchestrator: {
       id: 'homeboy-extensions/audit-wp-codebox-fanout',
@@ -128,6 +128,30 @@ try {
   assert.equal(task.sandbox_session_id, 'homeboy-audit-fixture-session');
   assert.equal(task.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/775');
   assert.equal(task.audit_findings[0].id, 'finding-1');
+
+  const nonExecutableCapturePath = path.join(root, 'capture-non-executable.json');
+  const nonExecutableFixture = createFixtureWpCodebox(root, 0o644);
+  const nonExecutableResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin',
+    nonExecutableFixture,
+    '--agents-api',
+    '/components/agents-api',
+    '--data-machine',
+    '/components/data-machine',
+    '--data-machine-code',
+    '/components/data-machine-code',
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(request),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: nonExecutableCapturePath,
+      OPENCODE_API_KEY: 'redacted-test-key',
+    },
+  });
+  assert.equal(nonExecutableResult.status, 0, nonExecutableResult.stderr || nonExecutableResult.stdout);
+  assert.equal(readJson(nonExecutableCapturePath).argv[0], 'recipe-run');
 
   console.log('Homeboy WP Codebox task runner smoke passed');
 } finally {


### PR DESCRIPTION
## Summary
- Run non-executable JavaScript `--wp-codebox-bin` targets through Node so local JS shims work reliably.
- Normalize provider plugin worktree paths like `ai-provider-for-opencode@branch` to the WordPress plugin slug `ai-provider-for-opencode` before writing WP Codebox recipes.
- Extend the runner smoke to cover both paths.

## Testing
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/audit-wp-codebox-fanout-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed WP Codebox runner failures from the Homeboy canary, drafted the runner normalization fix, and ran smoke tests for Chris to review.