### PR TITLE
Keep WP Codebox fanout artifacts external

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -92,6 +92,25 @@ function mountEntries() {
   });
 }
 
+function realPathForContainment(filePath) {
+  const resolved = path.resolve(filePath);
+  if (fs.existsSync(resolved)) {
+    return fs.realpathSync(resolved);
+  }
+  return path.join(fs.realpathSync(path.dirname(resolved)), path.basename(resolved));
+}
+
+function pathInside(parent, candidate) {
+  try {
+    const parentReal = realPathForContainment(parent);
+    const candidateReal = realPathForContainment(candidate);
+    const relative = path.relative(parentReal, candidateReal);
+    return relative === '' || (Boolean(relative) && !relative.startsWith('..') && !path.isAbsolute(relative));
+  } catch {
+    return false;
+  }
+}
+
 function recipeForRequest(request, options) {
   const provider = argValue('--provider') || request.provider || '';
   const model = argValue('--model') || request.model || '';
@@ -186,9 +205,14 @@ function resolveCommand(command, args) {
 function runWpCodebox(recipePath) {
   const wpCodeboxBin = argValue('--wp-codebox-bin') || 'wp-codebox';
   const args = ['recipe-run', '--recipe', recipePath, '--json'];
-  const artifacts = argValue('--artifacts');
-  if (artifacts) {
-    args.push('--artifacts', artifacts);
+  const explicitArtifacts = argValue('--artifacts');
+  const artifacts = explicitArtifacts || fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-artifacts-'));
+  args.push('--artifacts', artifacts);
+  if (explicitArtifacts) {
+    const riskyMount = mountEntries().find((mount) => pathInside(mount.source, explicitArtifacts));
+    if (riskyMount) {
+      console.error(`Warning: WP Codebox artifact directory is inside mounted source ${riskyMount.source} and may be captured recursively: ${explicitArtifacts}`);
+    }
   }
   if (argValue('--preview-hold')) {
     args.push('--preview-hold', argValue('--preview-hold'));

--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -678,6 +678,28 @@ def default_sibling_path(component_root, sibling_name):
     return os.path.join(os.path.dirname(os.path.abspath(component_root)), sibling_name)
 
 
+def path_inside(parent, candidate):
+    try:
+        parent_real = os.path.realpath(parent)
+        candidate_real = os.path.realpath(candidate)
+        return os.path.commonpath([parent_real, candidate_real]) == parent_real
+    except (OSError, ValueError):
+        return False
+
+
+def wp_codebox_path_warnings(component_root, output_dir, artifacts_dir, settings):
+    warnings = []
+    if component_root and settings.get('wp_codebox_output_dir') and path_inside(component_root, output_dir):
+        warnings.append(
+            f"WP Codebox audit fan-out output directory is inside the source tree and may be captured recursively: {output_dir}"
+        )
+    if component_root and settings.get('wp_codebox_artifacts') and path_inside(component_root, artifacts_dir):
+        warnings.append(
+            f"WP Codebox artifact directory is inside the source tree and may be captured recursively: {artifacts_dir}"
+        )
+    return warnings
+
+
 def wp_codebox_task_runner_args(data, settings, script_dir):
     component_root = data.get('root') or data.get('component_path') or os.getcwd()
     agents_api_path = settings.get('wp_codebox_agents_api_path') or os.environ.get('HOMEBOY_WP_CODEBOX_AGENTS_API_PATH') or component_root
@@ -692,8 +714,7 @@ def wp_codebox_task_runner_args(data, settings, script_dir):
     ]
     if settings.get('wp_codebox_bin'):
         args.extend(['--wp-codebox-bin', settings['wp_codebox_bin']])
-    if settings.get('wp_codebox_artifacts'):
-        args.extend(['--artifacts', settings['wp_codebox_artifacts']])
+    args.extend(['--artifacts', settings['wp_codebox_artifacts']])
     for mount in split_setting(settings.get('wp_codebox_mounts')):
         args.extend(['--mount', mount])
     return args
@@ -708,7 +729,15 @@ def refactor_source(data):
 
     settings = data.get('settings') or {}
     output_dir = settings.get('wp_codebox_output_dir') or tempfile.mkdtemp(prefix='homeboy-wp-codebox-audit-')
+    settings['wp_codebox_artifacts'] = settings.get('wp_codebox_artifacts') or tempfile.mkdtemp(prefix='homeboy-wp-codebox-artifacts-')
     os.makedirs(output_dir, exist_ok=True)
+    os.makedirs(settings['wp_codebox_artifacts'], exist_ok=True)
+    path_warnings = wp_codebox_path_warnings(
+        data.get('root') or data.get('component_path') or os.getcwd(),
+        output_dir,
+        settings['wp_codebox_artifacts'],
+        settings,
+    )
 
     audit_report_path = os.path.join(output_dir, 'audit-report.json')
     plan_path = os.path.join(output_dir, 'fanout-plan.json')
@@ -784,6 +813,7 @@ def refactor_source(data):
 
     warnings = [
         f"WP Codebox audit fan-out plan: {plan_path}",
+        *path_warnings,
     ]
     if data.get('write'):
         warnings.append(f"WP Codebox audit fan-out run: {runs_path}")

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -8,6 +8,11 @@ const { spawnSync } = require('node:child_process');
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wordpress-refactor-source-wp-codebox-'));
 
+function pathInside(parent, candidate) {
+  const relative = path.relative(fs.realpathSync(parent), path.resolve(candidate));
+  return relative === '' || (Boolean(relative) && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
 try {
   const auditResult = JSON.parse(fs.readFileSync(
     path.join(__dirname, 'fixtures', 'homeboy-audit-wp-codebox-fanout', 'audit-report.json'),
@@ -110,7 +115,30 @@ process.stdout.write(JSON.stringify({
   assert.equal(run.records[0].command.bin, 'node');
   assert.match(run.records[0].command.args[0], /homeboy-wp-codebox-task-runner\.cjs$/);
   assert.equal(run.records[0].command.args.includes('--wp-codebox-bin'), true);
+  const artifactsIndex = run.records[0].command.args.indexOf('--artifacts');
+  assert.notEqual(artifactsIndex, -1);
+  assert.equal(pathInside(writeCommand.root, run.records[0].command.args[artifactsIndex + 1]), false);
   assert.equal(run.records[0].artifact.id.startsWith('artifact-homeboy-audit-'), true);
+
+  const riskyRoot = path.join(root, 'risky-source');
+  const riskyCommand = {
+    ...command,
+    root: riskyRoot,
+    settings: {
+      ...command.settings,
+      wp_codebox_output_dir: path.join(riskyRoot, 'fanout'),
+      wp_codebox_artifacts: path.join(riskyRoot, 'artifacts'),
+    },
+  };
+  fs.mkdirSync(riskyRoot, { recursive: true });
+  const riskyResult = spawnSync('python3', [path.join(__dirname, '..', 'scripts', 'refactor.py')], {
+    encoding: 'utf8',
+    input: JSON.stringify(riskyCommand),
+  });
+  assert.equal(riskyResult.status, 0, riskyResult.stderr || riskyResult.stdout);
+  const riskyResponse = JSON.parse(riskyResult.stdout);
+  assert.match(riskyResponse.warnings.join('\n'), /output directory is inside the source tree/);
+  assert.match(riskyResponse.warnings.join('\n'), /artifact directory is inside the source tree/);
 
   console.log('WordPress refactor source WP Codebox smoke passed');
 } finally {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -15,6 +15,11 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
+function pathInside(parent, candidate) {
+  const relative = path.relative(fs.realpathSync(parent), path.resolve(candidate));
+  return relative === '' || (Boolean(relative) && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
 function createFixtureWpCodebox(root, mode = 0o755) {
   const binPath = path.join(root, 'fixture-wp-codebox.js');
   fs.writeFileSync(binPath, `#!/usr/bin/env node
@@ -151,7 +156,41 @@ try {
     },
   });
   assert.equal(nonExecutableResult.status, 0, nonExecutableResult.stderr || nonExecutableResult.stdout);
-  assert.equal(readJson(nonExecutableCapturePath).argv[0], 'recipe-run');
+  const nonExecutableCapture = readJson(nonExecutableCapturePath);
+  assert.equal(nonExecutableCapture.argv[0], 'recipe-run');
+  const defaultArtifactsIndex = nonExecutableCapture.argv.indexOf('--artifacts');
+  assert.notEqual(defaultArtifactsIndex, -1);
+  assert.equal(pathInside(root, nonExecutableCapture.argv[defaultArtifactsIndex + 1]), false);
+
+  const sourceRoot = path.join(root, 'source-plugin');
+  fs.mkdirSync(sourceRoot, { recursive: true });
+  const riskyArtifacts = path.join(sourceRoot, 'artifacts');
+  const riskyCapturePath = path.join(root, 'capture-risky-artifacts.json');
+  const riskyResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin',
+    fixtureWpCodebox,
+    '--agents-api',
+    '/components/agents-api',
+    '--data-machine',
+    '/components/data-machine',
+    '--data-machine-code',
+    '/components/data-machine-code',
+    '--mount',
+    `${sourceRoot}:/wordpress/wp-content/plugins/plugin:readwrite`,
+    '--artifacts',
+    riskyArtifacts,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(request),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: riskyCapturePath,
+      OPENCODE_API_KEY: 'redacted-test-key',
+    },
+  });
+  assert.equal(riskyResult.status, 0, riskyResult.stderr || riskyResult.stdout);
+  assert.match(riskyResult.stderr, /may be captured recursively/);
 
   console.log('Homeboy WP Codebox task runner smoke passed');
 } finally {


### PR DESCRIPTION
## Summary
- Default WP Codebox fan-out task runs now pass an external temp artifact root instead of letting artifacts land in the captured workspace.
- Explicit artifact/output paths inside the source tree now produce clear recursive-capture warnings.
- Adds smoke coverage for default external artifact selection and risky source-tree artifact path warnings.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/785

## Tests
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/refactor-source-wp-codebox-smoke.js`
- `node wordpress/tests/audit-wp-codebox-fanout-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris remains responsible for review and testing.