### PR TITLE
Stream WP Codebox audit fanout progress

### DIFF
--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -48,6 +48,27 @@ function tryParseJson(value) {
   }
 }
 
+function progressEvent(status, taskRequest, plan, record = null) {
+  const groupIndex = Number(taskRequest.orchestrator?.group_index || 0) + 1;
+  const groupCount = Number(plan.audit?.group_count || plan.task_requests.length || 0);
+  const startedAt = record?.started_at || new Date().toISOString();
+  const finishedAt = record?.finished_at || '';
+  const elapsedMs = finishedAt ? Math.max(0, Date.parse(finishedAt) - Date.parse(startedAt)) : null;
+
+  return {
+    schema: 'homeboy/audit-wp-codebox-progress/v1',
+    status,
+    group_key: taskRequest.group_key,
+    group_index: groupIndex,
+    group_count: groupCount,
+    sandbox_session_id: taskRequest.sandbox_session_id,
+    started_at: startedAt,
+    finished_at: finishedAt,
+    elapsed_ms: elapsedMs,
+    artifact_directory: record?.artifact?.directory || '',
+  };
+}
+
 function auditFindings(report) {
   const candidates = [
     report?.data?.findings,
@@ -410,7 +431,14 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
 
 function executeAuditWpCodeboxFanout(input) {
   const plan = input.plan || createAuditWpCodeboxFanoutPlan(input);
-  const records = plan.task_requests.map((taskRequest) => executeWpCodeboxTaskRequest(taskRequest, input));
+  const onProgress = typeof input.on_progress === 'function' ? input.on_progress : () => {};
+  const records = [];
+  for (const taskRequest of plan.task_requests) {
+    onProgress(progressEvent('started', taskRequest, plan));
+    const record = executeWpCodeboxTaskRequest(taskRequest, input);
+    records.push(record);
+    onProgress(progressEvent(record.status, taskRequest, plan, record));
+  }
   const run = {
     schema: 'homeboy/audit-wp-codebox-execution/v1',
     plan_schema: plan.schema,
@@ -436,6 +464,7 @@ function executeAuditWpCodeboxFanoutFromFiles(options) {
     cwd: options.cwd,
     env: options.env,
     runsOutputPath: options.runsOutputPath,
+    on_progress: options.onProgress,
   });
 }
 

--- a/wordpress/scripts/agent/homeboy-audit-wp-codebox-fanout.cjs
+++ b/wordpress/scripts/agent/homeboy-audit-wp-codebox-fanout.cjs
@@ -35,6 +35,19 @@ function usage() {
   process.exit(1);
 }
 
+function writeProgress(event) {
+  const elapsed = event.elapsed_ms === null ? '' : ` elapsed=${event.elapsed_ms}ms`;
+  const artifact = event.artifact_directory ? ` artifact=${event.artifact_directory}` : '';
+  process.stderr.write([
+    '[homeboy wp-codebox fanout]',
+    event.status,
+    `${event.group_index}/${event.group_count}`,
+    `group=${event.group_key}`,
+    `session=${event.sandbox_session_id}`,
+    `${elapsed}${artifact}`.trim(),
+  ].filter(Boolean).join(' ') + '\n');
+}
+
 const auditReportPath = argValue('--audit-report');
 if (!auditReportPath) {
   usage();
@@ -62,6 +75,7 @@ const result = hasFlag('--execute') ? executeAuditWpCodeboxFanoutFromFiles({
   wpCodeboxCommand: argValue('--wp-codebox-command') || 'wp-codebox',
   wpCodeboxArgs: argValues('--wp-codebox-arg'),
   runsOutputPath: argValue('--runs-output') || '',
+  onProgress: writeProgress,
 }) : createAuditWpCodeboxFanoutPlanFromFiles(options);
 
 console.log(JSON.stringify(result, null, 2));

--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -15,6 +15,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import threading
 
 
 # ============================================================================
@@ -678,6 +679,23 @@ def default_sibling_path(component_root, sibling_name):
     return os.path.join(os.path.dirname(os.path.abspath(component_root)), sibling_name)
 
 
+def run_with_streamed_stderr(args):
+    stderr_chunks = []
+    process = subprocess.Popen(args, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    def stream_stderr():
+        for chunk in process.stderr:
+            stderr_chunks.append(chunk)
+            sys.stderr.write(chunk)
+            sys.stderr.flush()
+
+    stderr_thread = threading.Thread(target=stream_stderr)
+    stderr_thread.start()
+    stdout, _ = process.communicate()
+    stderr_thread.join()
+    return subprocess.CompletedProcess(args, process.returncode, stdout, ''.join(stderr_chunks))
+
+
 def wp_codebox_task_runner_args(data, settings, script_dir):
     component_root = data.get('root') or data.get('component_path') or os.getcwd()
     agents_api_path = settings.get('wp_codebox_agents_api_path') or os.environ.get('HOMEBOY_WP_CODEBOX_AGENTS_API_PATH') or component_root
@@ -754,7 +772,7 @@ def refactor_source(data):
         for arg in task_runner_args:
             args.extend(['--wp-codebox-arg', arg])
 
-    result = subprocess.run(args, text=True, capture_output=True, check=False)
+    result = run_with_streamed_stderr(args)
     if result.returncode != 0:
         return {
             'handled': True,

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -327,7 +327,7 @@ try {
   assert.equal(fileExecution.records.length, 2);
   assert.equal(readJson(runsOutputPath).records.length, 2);
 
-  const cliExecutionOutput = run(process.execPath, [
+  const cliExecutionResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-audit-wp-codebox-fanout.cjs'),
     '--audit-report',
     auditReportPath,
@@ -338,10 +338,17 @@ try {
     process.execPath,
     '--wp-codebox-arg',
     fixtureCommand,
-  ]);
-  const cliExecution = JSON.parse(cliExecutionOutput);
+    '--secret-env',
+    'FIXTURE_SECRET_TOKEN',
+  ], { encoding: 'utf8' });
+  assert.equal(cliExecutionResult.status, 0, cliExecutionResult.stderr || cliExecutionResult.stdout);
+  const cliExecution = JSON.parse(cliExecutionResult.stdout);
   assert.equal(cliExecution.records.length, 2);
   assert.equal(cliExecution.records[0].schema, 'homeboy/audit-wp-codebox-run/v1');
+  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-/);
+  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] completed 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-.*artifact=\/tmp\/homeboy-audit-/);
+  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] failed 2\/2 group=docs-reference session=homeboy-audit-/);
+  assert.doesNotMatch(cliExecutionResult.stderr, /FIXTURE_SECRET_TOKEN/);
 
   console.log('Homeboy audit WP Codebox fanout smoke passed');
 } finally {

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -104,6 +104,9 @@ process.stdout.write(JSON.stringify({
   assert.equal(writeResult.status, 0, writeResult.stderr || writeResult.stdout);
   const writeResponse = JSON.parse(writeResult.stdout);
   assert.equal(writeResponse.handled, true);
+  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-/);
+  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] completed 2\/2 group=docs-reference session=homeboy-audit-.*artifact=.*fixture-wp-codebox-artifact-/);
+  assert.doesNotMatch(writeResult.stderr, /OPENCODE_API_KEY/);
   assert.match(writeResponse.warnings[1], /fanout-run\.json/);
   const run = JSON.parse(fs.readFileSync(path.join(writeOutputDir, 'fanout-run.json'), 'utf8'));
   assert.equal(run.status, 'completed');


### PR DESCRIPTION
## Summary
- Emits stderr-only per-group WP Codebox audit fan-out progress with group key, index/count, sandbox session id, elapsed time, and artifact directory when present.
- Streams the fan-out stderr through the WordPress refactor bridge while keeping stdout reserved for Homeboy JSON responses.
- Adds smoke coverage that progress output is visible and does not include configured secret env names.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/783

## Tests
- `node wordpress/tests/audit-wp-codebox-fanout-smoke.js`
- `node wordpress/tests/refactor-source-wp-codebox-smoke.js`
- `npm run test:audit-wp-codebox-fanout`
- `npm run test:refactor-source-wp-codebox`
- `npm run test:wp-codebox-task-runner`
- `npm run lint:js -- lib/audit-wp-codebox-fanout.js scripts/agent/homeboy-audit-wp-codebox-fanout.cjs tests/audit-wp-codebox-fanout-smoke.js tests/refactor-source-wp-codebox-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the progress streaming change, updated smoke coverage, and ran targeted verification; Chris remains responsible for review and merge.