### PR TITLE
Persist WP Codebox fanout runs incrementally

### DIFF
--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -410,19 +410,56 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
 
 function executeAuditWpCodeboxFanout(input) {
   const plan = input.plan || createAuditWpCodeboxFanoutPlan(input);
-  const records = plan.task_requests.map((taskRequest) => executeWpCodeboxTaskRequest(taskRequest, input));
-  const run = {
+
+  const records = [];
+  const baseRun = {
     schema: 'homeboy/audit-wp-codebox-execution/v1',
     plan_schema: plan.schema,
     orchestrator: plan.orchestrator,
     audit: plan.audit,
+  };
+  const writeRun = (run) => {
+    if (input.runsOutputPath) {
+      writeJson(input.runsOutputPath, run);
+    }
+  };
+
+  writeRun({
+    ...baseRun,
+    records,
+    status: 'incomplete',
+    current_group: null,
+  });
+
+  for (const taskRequest of plan.task_requests) {
+    writeRun({
+      ...baseRun,
+      records,
+      status: 'incomplete',
+      current_group: {
+        sandbox_session_id: taskRequest.sandbox_session_id,
+        group_key: taskRequest.group_key,
+        finding_ids: taskRequest.audit_findings.map((finding) => finding.id),
+      },
+    });
+
+    records.push(executeWpCodeboxTaskRequest(taskRequest, input));
+
+    writeRun({
+      ...baseRun,
+      records,
+      status: 'incomplete',
+      current_group: null,
+    });
+  }
+
+  const run = {
+    ...baseRun,
     records,
     status: records.every((record) => record.status === 'completed') ? 'completed' : 'failed',
   };
 
-  if (input.runsOutputPath) {
-    writeJson(input.runsOutputPath, run);
-  }
+  writeRun(run);
 
   return run;
 }

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -103,12 +103,20 @@ function createWpCodeboxFixtureCommand(root) {
   const scriptPath = path.join(root, 'fixture-wp-codebox.cjs');
   fs.writeFileSync(scriptPath, `#!/usr/bin/env node
 'use strict';
+const fs = require('node:fs');
 let input = '';
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', (chunk) => { input += chunk; });
 process.stdin.on('end', () => {
   const request = JSON.parse(input);
   if (request.group_key === 'docs-reference') {
+    if (process.env.FIXTURE_EXPECT_INCREMENTAL_RUN) {
+      const run = JSON.parse(fs.readFileSync(process.env.FIXTURE_EXPECT_INCREMENTAL_RUN, 'utf8'));
+      if (run.status !== 'incomplete' || run.records.length !== 1 || !run.current_group || run.current_group.group_key !== request.group_key) {
+        process.stderr.write('fixture incremental fanout-run summary missing expected partial state\\n');
+        process.exit(4);
+      }
+    }
     process.stderr.write('fixture docs-reference failure\\n');
     process.exit(3);
   }
@@ -323,9 +331,14 @@ try {
     wpCodeboxCommand: process.execPath,
     wpCodeboxArgs: [fixtureCommand],
     runsOutputPath,
+    env: {
+      FIXTURE_EXPECT_INCREMENTAL_RUN: runsOutputPath,
+    },
   });
   assert.equal(fileExecution.records.length, 2);
-  assert.equal(readJson(runsOutputPath).records.length, 2);
+  const finalRun = readJson(runsOutputPath);
+  assert.equal(finalRun.records.length, 2);
+  assert.equal(Object.hasOwn(finalRun, 'current_group'), false);
 
   const cliExecutionOutput = run(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-audit-wp-codebox-fanout.cjs'),


### PR DESCRIPTION
## Summary
- Creates `fanout-run.json` before WP Codebox fan-out execution and refreshes it before and after each group so interrupted runs retain completed records and the current group.
- Preserves the final completed/failed execution schema shape by omitting incremental-only `current_group` metadata from the final run summary.
- Adds smoke coverage proving the second group sees the partial summary from the first completed group.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/784

## Tests
- `npm run test:audit-wp-codebox-fanout`
- `npm run test:refactor-source-wp-codebox`
- `npx eslint lib/audit-wp-codebox-fanout.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the incremental fan-out summary implementation, targeted smoke coverage, and PR description; Chris remains responsible for review and merge.