### PR TITLE
fix(wordpress): format only scoped files

### DIFF
--- a/wordpress/scripts/format.sh
+++ b/wordpress/scripts/format.sh
@@ -8,15 +8,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "${SCRIPT_DIR}/.." && pwd)"
 COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-$PWD}"
 
+if [ "$#" -eq 0 ]; then
+    echo "No formatter target files provided — skipping format"
+    exit 0
+fi
+
 if [ -x "${COMPONENT_PATH}/vendor/bin/phpcbf" ]; then
     cd "$COMPONENT_PATH"
-    "${COMPONENT_PATH}/vendor/bin/phpcbf" "$COMPONENT_PATH" 2>&1
+    "${COMPONENT_PATH}/vendor/bin/phpcbf" "$@" 2>&1
     exit $?
 fi
 
 if [ -x "${EXTENSION_PATH}/vendor/bin/phpcbf" ]; then
     cd "$COMPONENT_PATH"
-    "${EXTENSION_PATH}/vendor/bin/phpcbf" "$COMPONENT_PATH" 2>&1
+    "${EXTENSION_PATH}/vendor/bin/phpcbf" "$@" 2>&1
     exit $?
 fi
 

--- a/wordpress/tests/test-format-scope.sh
+++ b/wordpress/tests/test-format-scope.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORDPRESS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+COMPONENT_PATH="${TMPDIR}/component"
+mkdir -p "${COMPONENT_PATH}/vendor/bin"
+
+git -C "${TMPDIR}" init --quiet component
+
+git -C "${COMPONENT_PATH}" config user.email test@example.com
+git -C "${COMPONENT_PATH}" config user.name Test
+
+printf '<?php\n$a = 1;\n' > "${COMPONENT_PATH}/changed.php"
+printf '<?php\n$b = 1;\n' > "${COMPONENT_PATH}/clean.php"
+git -C "${COMPONENT_PATH}" add changed.php clean.php
+git -C "${COMPONENT_PATH}" commit --quiet -m init
+
+printf '<?php\n$a = 2;\n' > "${COMPONENT_PATH}/changed.php"
+
+cat > "${COMPONENT_PATH}/vendor/bin/phpcbf" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$PHPCBF_ARGS_FILE"
+SH
+chmod +x "${COMPONENT_PATH}/vendor/bin/phpcbf"
+
+PHPCBF_ARGS_FILE="${TMPDIR}/phpcbf-args" \
+HOMEBOY_COMPONENT_PATH="${COMPONENT_PATH}" \
+  "${WORDPRESS_DIR}/scripts/format.sh" changed.php >/tmp/homeboy-wordpress-format-test.log
+
+if ! grep -Fxq "changed.php" "${TMPDIR}/phpcbf-args"; then
+  printf 'FAIL: scoped file argument was not passed to phpcbf\n'
+  exit 1
+fi
+
+if grep -Fxq "clean.php" "${TMPDIR}/phpcbf-args"; then
+  printf 'FAIL: unscoped file was passed to phpcbf\n'
+  exit 1
+fi
+
+printf 'PASS: format script uses core-provided target files\n'


### PR DESCRIPTION
## Summary
- Update the WordPress formatter script to consume formatter targets provided by Homeboy core instead of formatting the entire component.
- Skip formatting when core provides no targets.
- Add a shell regression test proving only provided formatter targets are passed to PHPCBF.

Depends on Extra-Chill/homeboy#2910.

## Testing
- `bash wordpress/tests/test-format-scope.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the WordPress formatter drift, updated the formatter script to consume core-provided targets, and added targeted shell coverage. Chris remains responsible for review and merge.