### PR TITLE
Refactor shared Bash version preflight

### DIFF
--- a/nodejs/scripts/bench/bench-runner.sh
+++ b/nodejs/scripts/bench/bench-runner.sh
@@ -16,15 +16,12 @@ set -euo pipefail
 #   HOMEBOY_BENCH_LIST_ONLY      — when 1, emit scenario inventory only
 #   HOMEBOY_DEBUG                — verbose output
 
-if ((BASH_VERSINFO[0] < 4)); then
-    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
-    case "$(uname -s)" in
-        Darwin) echo "  brew install bash" >&2 ;;
-    esac
-    exit 1
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${SCRIPT_DIR}/../lib/bash-preflight.sh}"
+# shellcheck source=/dev/null
+source "$BASH_PREFLIGHT_HELPER"
+homeboy_require_bash_version 4
+
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"

--- a/nodejs/scripts/build/build-runner.sh
+++ b/nodejs/scripts/build/build-runner.sh
@@ -22,12 +22,12 @@ set -euo pipefail
 #   HOMEBOY_NODE_BUILD_COMMAND   — override
 #   HOMEBOY_DEBUG                — verbose
 
-if ((BASH_VERSINFO[0] < 4)); then
-    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
-    exit 1
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${SCRIPT_DIR}/../lib/bash-preflight.sh}"
+# shellcheck source=/dev/null
+source "$BASH_PREFLIGHT_HELPER"
+homeboy_require_bash_version 4
+
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"

--- a/nodejs/scripts/lib/bash-preflight.sh
+++ b/nodejs/scripts/lib/bash-preflight.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+homeboy_require_bash_version() {
+    local required_major="$1"
+
+    if [ -z "${BASH_VERSION:-}" ] || ((BASH_VERSINFO[0] < required_major)); then
+        echo "ERROR: bash ${required_major}.0+ required (found ${BASH_VERSION:-non-bash shell})" >&2
+        case "$(uname -s)" in
+            Darwin)
+                echo "macOS ships with bash 3.2. Install newer bash: brew install bash" >&2
+                echo "Then restart your terminal so Homebrew bash takes priority on PATH." >&2
+                ;;
+            Linux)
+                echo "Update bash via your package manager (apt, dnf, pacman, etc.)" >&2
+                ;;
+            MINGW*|MSYS*|CYGWIN*)
+                echo "Update Git Bash or use WSL with a modern bash version" >&2
+                ;;
+            *)
+                echo "Install bash ${required_major}.0 or later for your platform" >&2
+                ;;
+        esac
+        exit 1
+    fi
+}

--- a/nodejs/scripts/lint/lint-runner.sh
+++ b/nodejs/scripts/lint/lint-runner.sh
@@ -21,12 +21,12 @@ set -euo pipefail
 # wired up, we fall back to "exit code is the truth, findings array stays
 # empty unless we recognize the format."
 
-if ((BASH_VERSINFO[0] < 4)); then
-    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
-    exit 1
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${SCRIPT_DIR}/../lib/bash-preflight.sh}"
+# shellcheck source=/dev/null
+source "$BASH_PREFLIGHT_HELPER"
+homeboy_require_bash_version 4
+
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -27,12 +27,12 @@ set -euo pipefail
 #   HOMEBOY_CHANGED_TEST_FILES   — newline-separated test files selected by core
 #   HOMEBOY_DEBUG                — verbose
 
-if ((BASH_VERSINFO[0] < 4)); then
-    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
-    exit 1
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${SCRIPT_DIR}/../lib/bash-preflight.sh}"
+# shellcheck source=/dev/null
+source "$BASH_PREFLIGHT_HELPER"
+homeboy_require_bash_version 4
+
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"

--- a/nodejs/scripts/trace/trace-runner.sh
+++ b/nodejs/scripts/trace/trace-runner.sh
@@ -18,15 +18,12 @@ set -euo pipefail
 #   HOMEBOY_RUN_DIR               — run-scoped working directory
 #   HOMEBOY_DEBUG                 — verbose output
 
-if ((BASH_VERSINFO[0] < 4)); then
-    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
-    case "$(uname -s)" in
-        Darwin) echo "  brew install bash" >&2 ;;
-    esac
-    exit 1
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${SCRIPT_DIR}/../lib/bash-preflight.sh}"
+# shellcheck source=/dev/null
+source "$BASH_PREFLIGHT_HELPER"
+homeboy_require_bash_version 4
+
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"

--- a/rust/scripts/bench/bench-runner.sh
+++ b/rust/scripts/bench/bench-runner.sh
@@ -45,15 +45,12 @@ set -euo pipefail
 #   HOMEBOY_BENCH_LIST_ONLY      — when 1, emit scenario inventory only
 #   HOMEBOY_DEBUG                — verbose output
 
-if ((BASH_VERSINFO[0] < 4)); then
-    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
-    case "$(uname -s)" in
-        Darwin) echo "  brew install bash" >&2 ;;
-    esac
-    exit 1
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${SCRIPT_DIR}/../lib/bash-preflight.sh}"
+# shellcheck source=/dev/null
+source "$BASH_PREFLIGHT_HELPER"
+homeboy_require_bash_version 4
+
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 # shellcheck source=/dev/null

--- a/rust/scripts/lib/bash-preflight.sh
+++ b/rust/scripts/lib/bash-preflight.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+homeboy_require_bash_version() {
+    local required_major="$1"
+
+    if [ -z "${BASH_VERSION:-}" ] || ((BASH_VERSINFO[0] < required_major)); then
+        echo "ERROR: bash ${required_major}.0+ required (found ${BASH_VERSION:-non-bash shell})" >&2
+        case "$(uname -s)" in
+            Darwin)
+                echo "macOS ships with bash 3.2. Install newer bash: brew install bash" >&2
+                echo "Then restart your terminal so Homebrew bash takes priority on PATH." >&2
+                ;;
+            Linux)
+                echo "Update bash via your package manager (apt, dnf, pacman, etc.)" >&2
+                ;;
+            MINGW*|MSYS*|CYGWIN*)
+                echo "Update Git Bash or use WSL with a modern bash version" >&2
+                ;;
+            *)
+                echo "Install bash ${required_major}.0 or later for your platform" >&2
+                ;;
+        esac
+        exit 1
+    fi
+}

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -5,6 +5,11 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/failure-trap.sh}"
 WRITE_TEST_RESULTS_HELPER="${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/write-test-results.sh}"
+BASH_PREFLIGHT_HELPERS=(
+    "${ROOT_DIR}/nodejs/scripts/lib/bash-preflight.sh"
+    "${ROOT_DIR}/rust/scripts/lib/bash-preflight.sh"
+    "${ROOT_DIR}/wordpress/scripts/lib/bash-preflight.sh"
+)
 
 assert_file() {
     local path="$1"
@@ -38,6 +43,16 @@ assert_not_contains() {
 
 assert_file "$FAILURE_TRAP_HELPER"
 assert_file "$WRITE_TEST_RESULTS_HELPER"
+for bash_preflight_helper in "${BASH_PREFLIGHT_HELPERS[@]}"; do
+    assert_file "$bash_preflight_helper"
+    bash -c 'source "$1"; homeboy_require_bash_version 4' _ "$bash_preflight_helper"
+done
+
+if ! cmp -s "${BASH_PREFLIGHT_HELPERS[0]}" "${BASH_PREFLIGHT_HELPERS[1]}" \
+    || ! cmp -s "${BASH_PREFLIGHT_HELPERS[0]}" "${BASH_PREFLIGHT_HELPERS[2]}"; then
+    echo "Bash preflight helpers should stay identical across installed extension trees" >&2
+    exit 1
+fi
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -134,6 +149,20 @@ if grep -R --exclude='*smoke.sh' "homeboy_write_test_results()" \
     "$ROOT_DIR/rust/scripts" \
     "$ROOT_DIR/wordpress/scripts/test" >/dev/null; then
     echo "Extension scripts should not define local homeboy_write_test_results functions" >&2
+    exit 1
+fi
+
+if grep "BASH_VERSINFO" \
+    "$ROOT_DIR/nodejs/scripts/bench/bench-runner.sh" \
+    "$ROOT_DIR/nodejs/scripts/build/build-runner.sh" \
+    "$ROOT_DIR/nodejs/scripts/lint/lint-runner.sh" \
+    "$ROOT_DIR/nodejs/scripts/test/test-runner.sh" \
+    "$ROOT_DIR/nodejs/scripts/trace/trace-runner.sh" \
+    "$ROOT_DIR/rust/scripts/bench/bench-runner.sh" \
+    "$ROOT_DIR/wordpress/scripts/bench/bench-runner.sh" \
+    "$ROOT_DIR/wordpress/scripts/lint/lint-runner.sh" \
+    "$ROOT_DIR/wordpress/scripts/test/test-runner.sh" >/dev/null; then
+    echo "Runner scripts should use scripts/lib/bash-preflight.sh instead of local BASH_VERSINFO checks" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/bench/bench-runner.sh
+++ b/wordpress/scripts/bench/bench-runner.sh
@@ -6,21 +6,10 @@ set -euo pipefail
 # Bench workloads run through WP Codebox so WordPress runtime behavior uses the
 # same sandbox/artifact contract as tests and agent CI.
 
-if ((BASH_VERSINFO[0] < 4)); then
-    echo "============================================" >&2
-    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
-    echo "============================================" >&2
-    case "$(uname -s)" in
-        Darwin)
-            echo "macOS ships bash 3.2. Fix: brew install bash" >&2
-            echo "Then restart your terminal (Homebrew bash takes priority on PATH)." >&2
-            ;;
-        *)
-            echo "Update bash via your package manager." >&2
-            ;;
-    esac
-    exit 1
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${SCRIPT_DIR}/../lib/bash-preflight.sh}"
+# shellcheck source=/dev/null
+source "$BASH_PREFLIGHT_HELPER"
+homeboy_require_bash_version 4
+
 exec bash "${SCRIPT_DIR}/bench-runner-wp-codebox.sh" "$@"

--- a/wordpress/scripts/lib/bash-preflight.sh
+++ b/wordpress/scripts/lib/bash-preflight.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+homeboy_require_bash_version() {
+    local required_major="$1"
+
+    if [ -z "${BASH_VERSION:-}" ] || ((BASH_VERSINFO[0] < required_major)); then
+        echo "ERROR: bash ${required_major}.0+ required (found ${BASH_VERSION:-non-bash shell})" >&2
+        case "$(uname -s)" in
+            Darwin)
+                echo "macOS ships with bash 3.2. Install newer bash: brew install bash" >&2
+                echo "Then restart your terminal so Homebrew bash takes priority on PATH." >&2
+                ;;
+            Linux)
+                echo "Update bash via your package manager (apt, dnf, pacman, etc.)" >&2
+                ;;
+            MINGW*|MSYS*|CYGWIN*)
+                echo "Update Git Bash or use WSL with a modern bash version" >&2
+                ;;
+            *)
+                echo "Install bash ${required_major}.0 or later for your platform" >&2
+                ;;
+        esac
+        exit 1
+    fi
+}

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -1,26 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Bash 4.0+ required for associative arrays
-if ((BASH_VERSINFO[0] < 4)); then
-    echo "Error: This script requires bash 4.0+ (found ${BASH_VERSION})" >&2
-    case "$(uname -s)" in
-        Darwin)
-            echo "macOS ships with bash 3.2. Install newer bash: brew install bash" >&2
-            ;;
-        Linux)
-            echo "Update bash via your package manager (apt, dnf, pacman, etc.)" >&2
-            ;;
-        MINGW*|MSYS*|CYGWIN*)
-            echo "Update Git Bash or use WSL with a modern bash version" >&2
-            ;;
-        *)
-            echo "Install bash 4.0 or later for your platform" >&2
-            ;;
-    esac
-    exit 1
-fi
-
 # Standalone PHP linting script using PHPCS/PHPCBF
 # Supports fix-only mode via HOMEBOY_FIX_ONLY=1 (sent by `homeboy refactor`)
 # Supports summary mode via HOMEBOY_SUMMARY_MODE=1
@@ -31,6 +11,11 @@ fi
 # flows go through `homeboy refactor --from lint --write` (#1145).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${SCRIPT_DIR}/../lib/bash-preflight.sh}"
+# shellcheck source=/dev/null
+source "$BASH_PREFLIGHT_HELPER"
+homeboy_require_bash_version 4
+
 RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/../lib/runner-steps.sh}"
 # shellcheck source=../lib/runner-steps.sh
 source "${RUNNER_STEPS_HELPER}"

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -7,26 +7,12 @@ set -euo pipefail
 # checkouts (wordpress-develop) dispatch to WordPress core's native PHPUnit
 # runner. Pure host-PHP smoke suites can explicitly use the host-smoke backend.
 
-# Bash 4.0+ required — lint-runner.sh (called during test runs) uses
-# associative arrays which are bash 4+ only. Fail early with a clear
-# message rather than producing misleading cascading errors.
-if ((BASH_VERSINFO[0] < 4)); then
-    echo "============================================" >&2
-    echo "ERROR: bash 4.0+ required (found ${BASH_VERSION})" >&2
-    echo "============================================" >&2
-    case "$(uname -s)" in
-        Darwin)
-            echo "macOS ships bash 3.2. Fix: brew install bash" >&2
-            echo "Then restart your terminal (Homebrew bash takes priority on PATH)." >&2
-            ;;
-        *)
-            echo "Update bash via your package manager." >&2
-            ;;
-    esac
-    exit 1
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${SCRIPT_DIR}/../lib/bash-preflight.sh}"
+# shellcheck source=/dev/null
+source "$BASH_PREFLIGHT_HELPER"
+homeboy_require_bash_version 4
+
 HOST_SMOKE_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_HOST_SMOKE:-${SCRIPT_DIR}/test-runner-host-smoke.sh}"
 WP_CODEBOX_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX:-${SCRIPT_DIR}/test-runner-wp-codebox.sh}"
 CORE_WP_CODEBOX_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_CORE_WP_CODEBOX:-${SCRIPT_DIR}/test-runner-core-dev-wp-codebox.sh}"


### PR DESCRIPTION
## Summary
- Add Bash 4+ preflight helpers under the Node.js, Rust, and WordPress extension runtime trees so extracted extension installs can source them locally.
- Replace repeated runner-level BASH_VERSINFO checks in the issue-listed runners with homeboy_require_bash_version 4.
- Extend runtime helper smoke coverage to verify the helpers are present, callable, identical across affected extension trees, and runner scripts no longer carry local BASH_VERSINFO checks.

Fixes #792.

## Verification
- `bash -n nodejs/scripts/lib/bash-preflight.sh rust/scripts/lib/bash-preflight.sh wordpress/scripts/lib/bash-preflight.sh tests/runtime-helpers-smoke.sh nodejs/scripts/bench/bench-runner.sh nodejs/scripts/build/build-runner.sh nodejs/scripts/lint/lint-runner.sh nodejs/scripts/test/test-runner.sh nodejs/scripts/trace/trace-runner.sh rust/scripts/bench/bench-runner.sh wordpress/scripts/bench/bench-runner.sh wordpress/scripts/lint/lint-runner.sh wordpress/scripts/test/test-runner.sh && bash tests/runtime-helpers-smoke.sh`
- `bash tests/bootstrap-standard-extensions-smoke.sh && bash tests/cross-extension-sidecar-normalization-smoke.sh && bash tests/nodejs-bench-metadata-smoke.sh && bash tests/runtime-helpers-smoke.sh && bash tests/rust-release-prepare-smoke.sh && node tests/structured-sidecars-smoke.mjs && bash tests/wordpress-eslint-scope-smoke.sh && bash tests/wordpress-lint-context-smoke.sh && bash tests/wordpress-remote-path-inference-smoke.sh`
- `git diff --check`

## Notes
- `homeboy lint --path .` was attempted but is not applicable in this checkout because the repo has no extension provider configured for component `homeboy-extensions`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused shell refactor, smoke test update, and PR text; Chris remains responsible for review and merge.