### PR TITLE
Align runner step fallback with core

### DIFF
--- a/tests/runner-steps-smoke.sh
+++ b/tests/runner-steps-smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$ROOT/wordpress/scripts/lib/runner-steps.sh"
+
+assert_runs() {
+    local label="$1"
+    local step="$2"
+
+    if ! should_run_step "$step"; then
+        echo "FAIL: expected $label to run" >&2
+        exit 1
+    fi
+}
+
+assert_skips() {
+    local label="$1"
+    local step="$2"
+
+    if should_run_step "$step"; then
+        echo "FAIL: expected $label to skip" >&2
+        exit 1
+    fi
+}
+
+unset HOMEBOY_STEP HOMEBOY_SKIP
+assert_runs "unfiltered step" "phpcs"
+assert_runs "empty step" ""
+assert_runs "whitespace-padded step name" " phpcs "
+
+HOMEBOY_STEP="phpcs,eslint"
+unset HOMEBOY_SKIP
+assert_runs "allowlisted step" "phpcs"
+assert_skips "non-allowlisted step" "phpstan"
+assert_runs "empty step with allowlist" ""
+
+HOMEBOY_SKIP="phpcs"
+assert_skips "skiplisted step also present in allowlist" "phpcs"
+assert_runs "allowlisted step not skiplisted" "eslint"
+assert_skips "non-allowlisted step with skiplist" "phpstan"
+
+unset HOMEBOY_STEP
+HOMEBOY_SKIP="eslint,phpstan"
+assert_runs "step not in skiplist" "phpcs"
+assert_skips "skiplisted step without allowlist" "phpstan"
+
+echo "runner-steps smoke ok"

--- a/wordpress/scripts/lib/runner-steps.sh
+++ b/wordpress/scripts/lib/runner-steps.sh
@@ -1,36 +1,34 @@
 #!/usr/bin/env bash
 
-# Shared step filtering for extension runners.
+# Direct-invocation fallback for Homeboy core's shared runner-step helper.
+# Keep this file aligned with homeboy/src/core/extension/runtime/runner-steps.sh.
 #
-# HOMEBOY_STEP is a comma-separated allowlist. When set, only listed steps run.
-# HOMEBOY_SKIP is a comma-separated denylist. Denylist wins when both are set.
-
-homeboy_step_list_contains() {
-    local list="$1"
-    local needle="$2"
-    local item
-
-    IFS=',' read -ra _homeboy_step_items <<< "$list"
-    for item in "${_homeboy_step_items[@]}"; do
-        item="${item//[[:space:]]/}"
-        if [ "$item" = "$needle" ]; then
-            return 0
-        fi
-    done
-
-    return 1
-}
+# Reads HOMEBOY_STEP / HOMEBOY_SKIP as comma-separated step names and exposes
+# should_run_step <name> with the same semantics as Homeboy core's
+# RunnerStepFilter:
+# - HOMEBOY_STEP present => only listed steps run
+# - HOMEBOY_SKIP present => listed steps are skipped
+# - empty step name => runs by default
 
 should_run_step() {
-    local step="$1"
+    local step_name="${1:-}"
+    step_name="$(printf '%s' "$step_name" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
 
-    if [ -n "${HOMEBOY_SKIP:-}" ] && homeboy_step_list_contains "${HOMEBOY_SKIP}" "$step"; then
-        return 1
+    if [ -z "$step_name" ]; then
+        return 0
     fi
 
     if [ -n "${HOMEBOY_STEP:-}" ]; then
-        homeboy_step_list_contains "${HOMEBOY_STEP}" "$step"
-        return $?
+        case ",${HOMEBOY_STEP}," in
+            *",${step_name},"*) ;;
+            *) return 1 ;;
+        esac
+    fi
+
+    if [ -n "${HOMEBOY_SKIP:-}" ]; then
+        case ",${HOMEBOY_SKIP}," in
+            *",${step_name},"*) return 1 ;;
+        esac
     fi
 
     return 0


### PR DESCRIPTION
## Summary
- Align the WordPress runner-step fallback with Homeboy core runner-step semantics.
- Keep the fallback explicitly documented as a direct-invocation copy of the core helper.
- Add a focused smoke test for HOMEBOY_STEP / HOMEBOY_SKIP precedence and empty-step behavior.

Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/790

## Testing
- `bash tests/runner-steps-smoke.sh`
- `bash tests/cross-extension-sidecar-normalization-smoke.sh`
- `bash -n wordpress/scripts/lib/runner-steps.sh tests/runner-steps-smoke.sh`
- `bash tests/runtime-helpers-smoke.sh`
- `bash tests/wordpress-lint-context-smoke.sh`
- `bash tests/bootstrap-standard-extensions-smoke.sh`
- `bash tests/wordpress-eslint-scope-smoke.sh`
- `bash tests/wordpress-remote-path-inference-smoke.sh`

## Notes
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-runtime-helper-drift --changed-only` could not run because this checkout has no extension provider configured for component `homeboy-extensions`; direct smoke/syntax coverage above exercised the changed helper path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the helper alignment and smoke test, ran targeted verification, and prepared this PR for Chris to review.