### PR TITLE
Fix WP Codebox fanout stderr capture race

### DIFF
--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -713,7 +713,10 @@ def run_with_streamed_stderr(args):
 
     stderr_thread = threading.Thread(target=stream_stderr)
     stderr_thread.start()
-    stdout, _ = process.communicate()
+    # Do not use communicate() here: it also reads stderr, racing the streaming
+    # thread and dropping progress lines from the captured stderr buffer.
+    stdout = process.stdout.read()
+    process.wait()
     stderr_thread.join()
     return subprocess.CompletedProcess(args, process.returncode, stdout, ''.join(stderr_chunks))
 


### PR DESCRIPTION
## Summary
- Fix streamed stderr capture in the WordPress refactor source runner so the streaming thread is the only stderr reader.
- Prevent missing WP Codebox fanout progress lines in captured stderr during audit fanout execution.

## Verification
- Local: `python3 -m py_compile scripts/refactor.py`
- Local: `node tests/refactor-source-wp-codebox-smoke.js`
- Local: `node tests/audit-wp-codebox-fanout-smoke.js`
- Local: `node tests/wp-codebox-task-runner-smoke.js`
- Homeboy Lab: synced the fix worktree and ran `node tests/refactor-source-wp-codebox-smoke.js`
- Homeboy Lab: synced the fix worktree and ran `node tests/audit-wp-codebox-fanout-smoke.js`
- Homeboy Lab: synced the fix worktree and ran `node tests/wp-codebox-task-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Homeboy Lab audit fanout failure, identified the stderr reader race, drafted the fix, and ran local plus lab verification.