### PR TITLE
Fix WP Codebox provider plugin main file detection

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -65,7 +65,14 @@ function requireArg(name) {
 
 function pluginEntry(source, slug, activate = false) {
   const pluginSlug = (slug || path.basename(source)).split('@')[0].replace(/[^a-zA-Z0-9_-]/g, '-');
-  return { source, slug: pluginSlug, activate };
+  const entry = { source, slug: pluginSlug, activate };
+  for (const fileName of [`${pluginSlug}.php`, 'plugin.php']) {
+    if (fs.existsSync(path.join(source, fileName))) {
+      entry.pluginFile = `${pluginSlug}/${fileName}`;
+      break;
+    }
+  }
+  return entry;
 }
 
 function providerPluginEntries(request) {

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -66,13 +66,35 @@ function requireArg(name) {
 function pluginEntry(source, slug, activate = false) {
   const pluginSlug = (slug || path.basename(source)).split('@')[0].replace(/[^a-zA-Z0-9_-]/g, '-');
   const entry = { source, slug: pluginSlug, activate };
-  for (const fileName of [`${pluginSlug}.php`, 'plugin.php']) {
-    if (fs.existsSync(path.join(source, fileName))) {
-      entry.pluginFile = `${pluginSlug}/${fileName}`;
-      break;
-    }
+  const pluginFile = detectPluginMainFile(source, pluginSlug);
+  if (pluginFile) {
+    entry.pluginFile = pluginFile;
   }
   return entry;
+}
+
+function detectPluginMainFile(source, pluginSlug) {
+  if (!fs.existsSync(source) || !fs.statSync(source).isDirectory()) {
+    return '';
+  }
+
+  const phpFiles = fs.readdirSync(source)
+    .filter((fileName) => fileName.endsWith('.php'))
+    .sort((left, right) => {
+      const preferred = [`${pluginSlug}.php`, 'plugin.php'];
+      const leftIndex = preferred.includes(left) ? preferred.indexOf(left) : preferred.length;
+      const rightIndex = preferred.includes(right) ? preferred.indexOf(right) : preferred.length;
+      return leftIndex - rightIndex || left.localeCompare(right);
+    });
+
+  for (const fileName of phpFiles) {
+    const header = fs.readFileSync(path.join(source, fileName), 'utf8').slice(0, 8192);
+    if (/Plugin Name\s*:/i.test(header)) {
+      return `${pluginSlug}/${fileName}`;
+    }
+  }
+
+  return '';
 }
 
 function providerPluginEntries(request) {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -48,9 +48,9 @@ const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-task-runn
 try {
   const capturePath = path.join(root, 'capture.json');
   const fixtureWpCodebox = createFixtureWpCodebox(root);
-  const providerPluginPath = path.join(root, 'ai-provider-for-opencode@fix-opencode-tool-choice');
+  const providerPluginPath = path.join(root, 'example-provider@feature-branch');
   fs.mkdirSync(providerPluginPath, { recursive: true });
-  fs.writeFileSync(path.join(providerPluginPath, 'plugin.php'), '<?php // fixture provider plugin.');
+  fs.writeFileSync(path.join(providerPluginPath, 'provider-main.php'), '<?php\n/**\n * Plugin Name: Example Provider\n */');
   const request = {
     schema: 'homeboy/wp-codebox-task-request/v1',
     sandbox_session_id: 'homeboy-audit-fixture-session',
@@ -120,14 +120,14 @@ try {
   assert.equal(recipe.inputs.extraPlugins[0].slug, 'agents-api');
   assert.equal(recipe.inputs.extraPlugins[1].slug, 'data-machine');
   assert.equal(recipe.inputs.extraPlugins[2].slug, 'data-machine-code');
-  assert.equal(recipe.inputs.extraPlugins[3].slug, 'ai-provider-for-opencode');
-  assert.equal(recipe.inputs.extraPlugins[3].pluginFile, 'ai-provider-for-opencode/plugin.php');
+  assert.equal(recipe.inputs.extraPlugins[3].slug, 'example-provider');
+  assert.equal(recipe.inputs.extraPlugins[3].pluginFile, 'example-provider/provider-main.php');
 
   const step = recipe.workflow.steps[0];
   assert.equal(step.command, 'wp-codebox.agent-sandbox-run');
   assert.equal(step.args.includes('provider=opencode'), true);
   assert.equal(step.args.includes('model=opencode-go/kimi-k2.6'), true);
-  assert.equal(step.args.includes('provider-plugin-slugs=ai-provider-for-opencode'), true);
+  assert.equal(step.args.includes('provider-plugin-slugs=example-provider'), true);
   assert.equal(step.args.some((arg) => arg.startsWith('session-id=')), false);
 
   const taskArg = step.args.find((arg) => arg.startsWith('task='));

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -48,13 +48,16 @@ const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-task-runn
 try {
   const capturePath = path.join(root, 'capture.json');
   const fixtureWpCodebox = createFixtureWpCodebox(root);
+  const providerPluginPath = path.join(root, 'ai-provider-for-opencode@fix-opencode-tool-choice');
+  fs.mkdirSync(providerPluginPath, { recursive: true });
+  fs.writeFileSync(path.join(providerPluginPath, 'plugin.php'), '<?php // fixture provider plugin.');
   const request = {
     schema: 'homeboy/wp-codebox-task-request/v1',
     sandbox_session_id: 'homeboy-audit-fixture-session',
     group_key: 'PHPCS Formatting/Auto Fix!',
     provider: 'opencode',
     model: 'opencode-go/kimi-k2.6',
-    provider_plugin_paths: ['/plugins/ai-provider-for-opencode@fix-opencode-tool-choice'],
+    provider_plugin_paths: [providerPluginPath],
     secret_env: ['OPENCODE_API_KEY'],
     orchestrator: {
       id: 'homeboy-extensions/audit-wp-codebox-fanout',
@@ -118,6 +121,7 @@ try {
   assert.equal(recipe.inputs.extraPlugins[1].slug, 'data-machine');
   assert.equal(recipe.inputs.extraPlugins[2].slug, 'data-machine-code');
   assert.equal(recipe.inputs.extraPlugins[3].slug, 'ai-provider-for-opencode');
+  assert.equal(recipe.inputs.extraPlugins[3].pluginFile, 'ai-provider-for-opencode/plugin.php');
 
   const step = recipe.workflow.steps[0];
   assert.equal(step.command, 'wp-codebox.agent-sandbox-run');


### PR DESCRIPTION
## Summary
- Detect WP AI Client-compatible provider plugin main files when building WP Codebox fanout recipes.
- Preserve the existing slug-based default while supporting provider plugins whose main file is any top-level PHP file with a WordPress `Plugin Name:` header.
- Cover the generic provider-main-file case with a fixture provider plugin in the WP Codebox task runner smoke test.

## Verification
- `node tests/wp-codebox-task-runner-smoke.js`
- `node tests/audit-wp-codebox-fanout-smoke.js`
- `node tests/refactor-source-wp-codebox-smoke.js`

## Context
A post-merge Homeboy Lab fanout run against `agents-api` failed recipe validation because the task runner emitted no explicit `pluginFile` for the provider plugin, causing WP Codebox to default to `<slug>/<slug>.php`. Provider plugins are generic WP AI Client-compatible WordPress plugins, so the runner should discover their actual plugin header file instead of assuming a filename convention.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Homeboy Lab fanout recipe validation failure, drafted the generic provider plugin main-file detection, and ran targeted smoke tests.