### PR TITLE
Fix WP Codebox fanout task failure detection

### DIFF
--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -401,7 +401,8 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
   const stderr = result.stderr || '';
   const parsed = tryParseJson(stdout);
   const artifact = parsed && typeof parsed === 'object' && parsed.artifacts ? parsed.artifacts : null;
-  const success = result.status === 0 && result.error === undefined;
+  const taskFailure = parsed ? wpCodeboxTaskFailure(parsed) : null;
+  const success = result.status === 0 && result.error === undefined && null === taskFailure;
 
   return {
     schema: RUN_SCHEMA,
@@ -413,7 +414,7 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
       args,
       exit_code: result.status,
       signal: result.signal || null,
-      error: result.error ? result.error.message : '',
+      error: result.error ? result.error.message : (taskFailure || ''),
     },
     status: success ? 'completed' : 'failed',
     started_at: startedAt,
@@ -427,6 +428,37 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
       preview_url: artifact.preview?.url || artifact.preview_url || '',
     } : null,
   };
+}
+
+function wpCodeboxTaskFailure(parsed) {
+  if (!parsed || typeof parsed !== 'object') {
+    return null;
+  }
+
+  if (parsed.success === false) {
+    return wpCodeboxErrorMessage(parsed) || 'WP Codebox task reported success=false';
+  }
+
+  const executions = Array.isArray(parsed.executions) ? parsed.executions : [];
+  for (const execution of executions) {
+    const nested = tryParseJson(execution?.stdout || '');
+    if (nested && typeof nested === 'object' && nested.success === false) {
+      return wpCodeboxErrorMessage(nested) || 'WP Codebox nested execution reported success=false';
+    }
+  }
+
+  return null;
+}
+
+function wpCodeboxErrorMessage(parsed) {
+  const error = parsed && typeof parsed === 'object' ? parsed.error : null;
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error && typeof error === 'object' && typeof error.message === 'string') {
+    return error.message;
+  }
+  return '';
 }
 
 function executeAuditWpCodeboxFanout(input) {

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -106,6 +106,13 @@ function secretEnvNames(request) {
   return Array.from(new Set([...(request.secret_env || []), ...argValues('--secret-env')].filter(Boolean)));
 }
 
+function assertRequiredSecretEnvAvailable(request) {
+  const missing = secretEnvNames(request).filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(`Required WP Codebox secret environment variable missing: ${missing.join(', ')}`);
+  }
+}
+
 function mountEntries() {
   return argValues('--mount').map((value) => {
     const [source, target, mode = 'readwrite'] = value.split(':');
@@ -275,6 +282,7 @@ function runWpCodebox(recipePath) {
 
 try {
   const request = readTaskRequest();
+  assertRequiredSecretEnvAvailable(request);
   const options = {
     agentsApi: requireArg('--agents-api'),
     dataMachine: requireArg('--data-machine'),

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -117,6 +117,21 @@ process.stdin.on('end', () => {
         process.exit(4);
       }
     }
+    if (process.env.FIXTURE_NESTED_WP_ERROR) {
+      process.stdout.write(JSON.stringify({
+        success: true,
+        executions: [
+          {
+            command: 'wordpress.run-php',
+            stdout: JSON.stringify({
+              success: false,
+              error: { code: 'fixture_wp_error', message: 'Fixture nested WP error' },
+            }),
+          },
+        ],
+      }));
+      process.exit(0);
+    }
     process.stderr.write('fixture docs-reference failure\\n');
     process.exit(3);
   }
@@ -323,6 +338,18 @@ try {
   assert.equal(failedRecord.status, 'failed');
   assert.equal(failedRecord.command.exit_code, 3);
   assert.match(failedRecord.stderr, /fixture docs-reference failure/);
+
+  const nestedErrorExecution = executeAuditWpCodeboxFanout({
+    report,
+    wp_codebox_command: process.execPath,
+    wp_codebox_args: [fixtureCommand],
+    env: { FIXTURE_NESTED_WP_ERROR: '1' },
+  });
+  const nestedFailedRecord = nestedErrorExecution.records.find((record) => record.group_key === 'docs-reference');
+  assert.equal(nestedErrorExecution.status, 'failed');
+  assert.equal(nestedFailedRecord.status, 'failed');
+  assert.equal(nestedFailedRecord.command.exit_code, 0);
+  assert.match(nestedFailedRecord.command.error, /Fixture nested WP error/);
 
   const runsOutputPath = path.join(root, 'fanout-run.json');
   const fileExecution = executeAuditWpCodeboxFanoutFromFiles({

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -104,6 +104,10 @@ process.stdout.write(JSON.stringify({
   const writeResult = spawnSync('python3', [path.join(__dirname, '..', 'scripts', 'refactor.py')], {
     encoding: 'utf8',
     input: JSON.stringify(writeCommand),
+    env: {
+      ...process.env,
+      OPENCODE_API_KEY: 'redacted-test-key',
+    },
   });
 
   assert.equal(writeResult.status, 0, writeResult.stderr || writeResult.stdout);

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -196,6 +196,28 @@ try {
   assert.equal(riskyResult.status, 0, riskyResult.stderr || riskyResult.stdout);
   assert.match(riskyResult.stderr, /may be captured recursively/);
 
+  const missingSecretResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin',
+    fixtureWpCodebox,
+    '--agents-api',
+    '/components/agents-api',
+    '--data-machine',
+    '/components/data-machine',
+    '--data-machine-code',
+    '/components/data-machine-code',
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(request),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: path.join(root, 'capture-missing-secret.json'),
+      OPENCODE_API_KEY: '',
+    },
+  });
+  assert.notEqual(missingSecretResult.status, 0);
+  assert.match(missingSecretResult.stderr, /Required WP Codebox secret environment variable missing: OPENCODE_API_KEY/);
+
   console.log('Homeboy WP Codebox task runner smoke passed');
 } finally {
   fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Fail WP Codebox task runner before recipe execution when requested secret env vars are unavailable.
- Mark audit fanout records failed when WP Codebox output or nested WordPress execution output reports success=false.
- Add smoke coverage for missing secrets and nested WP error payloads.

## Tests
- node tests/wp-codebox-task-runner-smoke.js
- node tests/audit-wp-codebox-fanout-smoke.js
- node tests/refactor-source-wp-codebox-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the lab fanout false positive, drafted the guardrail changes and smoke coverage, and ran verification locally.