### PR TITLE
Skip PHP AI Client as WP Codebox plugin

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -18,13 +18,14 @@ BUNDLE_DIR="$RUNTIME_DIR/bundle"
 AGENTS_API_DIR="$RUNTIME_DIR/agents-api"
 DATA_MACHINE_DIR="$RUNTIME_DIR/data-machine"
 DATA_MACHINE_CODE_DIR="$RUNTIME_DIR/data-machine-code"
+PHP_AI_CLIENT_DIR="$RUNTIME_DIR/php-ai-client"
 
 cleanup() {
     rm -rf "$RUNTIME_DIR"
 }
 trap cleanup EXIT
 
-mkdir -p "$BUNDLE_DIR" "$AGENTS_API_DIR" "$DATA_MACHINE_DIR" "$DATA_MACHINE_CODE_DIR"
+mkdir -p "$BUNDLE_DIR" "$AGENTS_API_DIR" "$DATA_MACHINE_DIR" "$DATA_MACHINE_CODE_DIR" "$PHP_AI_CLIENT_DIR"
 printf '{"agent":{"slug":"wp-codebox-smoke-agent"}}\n' > "$BUNDLE_DIR/manifest.json"
 
 cat > "$FAKE_WP_CODEBOX" <<'NODE'
@@ -60,6 +61,9 @@ for (const expected of ['wp-codebox.agent-sandbox-run', 'HOMEBOY_DATAMACHINE_AGE
   if (!recipeText.includes(expected)) {
     throw new Error(`missing expected wp-codebox recipe value: ${expected}`)
   }
+}
+if (recipe.inputs?.extraPlugins?.some((plugin) => plugin.slug === 'php-ai-client')) {
+  throw new Error('php-ai-client is a Composer library and must not be mounted as a WP Codebox extra plugin')
 }
 if (!recipe.inputs?.mounts?.some((mount) => mount.source.endsWith('/bundle') && mount.target === '/wordpress/wp-content/plugins/bundle' && mount.mode === 'readonly')) {
   throw new Error('missing bundle readonly mount in recipe')
@@ -147,6 +151,7 @@ jq -n \
     --arg agentsApi "$AGENTS_API_DIR" \
     --arg dataMachine "$DATA_MACHINE_DIR" \
     --arg dataMachineCode "$DATA_MACHINE_CODE_DIR" \
+    --arg phpAiClient "$PHP_AI_CLIENT_DIR" \
     '{
         component_id: "wp-codebox-smoke-component",
         component_path: env.PWD,
@@ -161,6 +166,7 @@ jq -n \
         prompt: "Smoke the WP Codebox runner adapter.",
         wp_codebox_components: {
             agents_api: $agentsApi,
+            wp_ai_client: $phpAiClient,
             data_machine: $dataMachine,
             data_machine_code: $dataMachineCode
         }

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -76,7 +76,6 @@ echo wp_json_encode( is_array( $homeboy_workload_result ) ? $homeboy_workload_re
 PHP
 
     local agents_api_path="${HOMEBOY_AGENTS_API_PATH:-${AGENTS_API_PATH:-}}"
-    local wp_ai_client_path="${HOMEBOY_WP_AI_CLIENT_PATH:-${WP_AI_CLIENT_PATH:-}}"
     local data_machine_path="${HOMEBOY_DATA_MACHINE_PATH:-${DATA_MACHINE_PATH:-}}"
     local data_machine_code_path="${HOMEBOY_DATA_MACHINE_CODE_PATH:-${DATA_MACHINE_CODE_PATH:-}}"
     if [ -z "$agents_api_path" ]; then
@@ -84,9 +83,6 @@ PHP
     fi
     if [ -z "$data_machine_path" ]; then
         data_machine_path=$(jq -r '.wp_codebox_components.data_machine // .wp_codebox_data_machine_path // empty' "$CONFIG_PATH")
-    fi
-    if [ -z "$wp_ai_client_path" ]; then
-        wp_ai_client_path=$(jq -r '.wp_codebox_components.wp_ai_client // .wp_codebox_wp_ai_client_path // empty' "$CONFIG_PATH")
     fi
     if [ -z "$data_machine_code_path" ]; then
         data_machine_code_path=$(jq -r '.wp_codebox_components.data_machine_code // .wp_codebox_data_machine_code_path // empty' "$CONFIG_PATH")
@@ -102,12 +98,10 @@ PHP
     local extra_plugins_json mounts_json secret_env_json provider_slugs_csv
     extra_plugins_json=$(jq -nc \
         --arg agents "$agents_api_path" \
-        --arg wpAiClient "$wp_ai_client_path" \
         --arg datamachine "$data_machine_path" \
         --arg code "$data_machine_code_path" \
         '[
             {source: $agents, slug: "agents-api", activate: false},
-            (if $wpAiClient != "" then {source: $wpAiClient, slug: "php-ai-client", activate: false} else empty end),
             {source: $datamachine, slug: "data-machine", activate: false},
             {source: $code, slug: "data-machine-code", activate: false}
         ]')


### PR DESCRIPTION
## Summary
- Stop adding WordPress/php-ai-client to generated WP Codebox recipe extraPlugins.
- Keep php-ai-client treated as a Composer library instead of a WordPress plugin.
- Extend the WP Codebox runner smoke test so a configured wp_ai_client component does not produce a php-ai-client extra plugin.

Fixes the WoW day-cycle failure in chubes4/world-of-wordpress/actions/runs/26528859953 where WP Codebox validation looked for .ci/php-ai-client/php-ai-client.php.

## Verification
- npm run test:datamachine-agent-wp-codebox-runner

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the failed WoW day-cycle run, implemented the Homeboy Extensions runner fix, added smoke coverage, and verified the targeted runner path for Chris to review/test.