### PR TITLE
Rely on core WP AI Client in agent CI

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -84,12 +84,8 @@ name: Data Machine Agent CI (reusable)
         description: Ref for Extra-Chill/data-machine-code when include_agent_runtime_dependencies is true.
         type: string
         default: main
-      php_ai_client_ref:
-        description: Ref for WordPress/php-ai-client when mounting the default OpenAI provider runtime.
-        type: string
-        default: trunk
       openai_provider_ref:
-        description: Legacy ref for explicit provider_plugin overrides that still checkout WordPress/ai-provider-for-openai.
+        description: Ref for WordPress/ai-provider-for-openai when mounting the default OpenAI provider plugin.
         type: string
         default: trunk
       playground_wordpress:
@@ -416,7 +412,6 @@ jobs:
           AGENTS_API_REF: ${{ inputs.agents_api_ref }}
           DATA_MACHINE_REF: ${{ inputs.data_machine_ref }}
           DATA_MACHINE_CODE_REF: ${{ inputs.data_machine_code_ref }}
-          PHP_AI_CLIENT_REF: ${{ inputs.php_ai_client_ref }}
           OPENAI_PROVIDER_REF: ${{ inputs.openai_provider_ref }}
           PROVIDER: ${{ inputs.provider }}
           PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
@@ -442,7 +437,6 @@ jobs:
             dependency_entries+=("Extra-Chill/data-machine@${DATA_MACHINE_REF}")
             dependency_entries+=("Extra-Chill/data-machine-code@${DATA_MACHINE_CODE_REF}")
             if [ "$PROVIDER" = "openai" ] && [ -z "$provider_plugin_repo" ]; then
-              dependency_entries+=("WordPress/php-ai-client@${PHP_AI_CLIENT_REF}")
               dependency_entries+=("WordPress/ai-provider-for-openai@${OPENAI_PROVIDER_REF}")
             fi
             if [ -n "$provider_plugin_repo" ]; then
@@ -676,10 +670,6 @@ jobs:
           provider_plugin_repo="$(jq -r '.repo // ""' <<< "$provider_plugin_json")"
           provider_plugin_path="$(jq -r '.path // "."' <<< "$provider_plugin_json")"
           provider_plugin_host_path=""
-          wp_ai_client_host_path=""
-          if [ -d "${GITHUB_WORKSPACE}/.ci/php-ai-client" ]; then
-            wp_ai_client_host_path="${GITHUB_WORKSPACE}/.ci/php-ai-client"
-          fi
           if [ -z "$provider_plugin_repo" ] && [ "$PROVIDER" = "openai" ] && [ -d "${GITHUB_WORKSPACE}/.ci/ai-provider-for-openai" ]; then
             provider_plugin_host_path="${GITHUB_WORKSPACE}/.ci/ai-provider-for-openai"
           fi
@@ -756,7 +746,6 @@ jobs:
             --arg model "$MODEL" \
             --arg wpCodeboxBin "$wp_codebox_bin" \
             --arg providerPluginHostPath "$provider_plugin_host_path" \
-            --arg wpAiClientHostPath "$wp_ai_client_host_path" \
             --arg engineKey "$ENGINE_KEY" \
             --arg toolResultsKey "$TOOL_RESULTS_KEY" \
             --arg playgroundWordPress "$PLAYGROUND_WORDPRESS" \
@@ -832,7 +821,7 @@ jobs:
                 agents_api: ($componentPath + "/.ci/agents-api"),
                 data_machine: ($componentPath + "/.ci/data-machine"),
                 data_machine_code: ($componentPath + "/.ci/data-machine-code")
-              } + (if $wpAiClientHostPath != "" then {wp_ai_client: $wpAiClientHostPath} else {} end)),
+              }),
               provider_plugin_paths: (if $providerPluginHostPath != "" then [$providerPluginHostPath] else [] end),
               github_token_env: "HOMEBOY_GITHUB_APP_TOKEN",
               github_repository_token_env: "GITHUB_TOKEN",

--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -18,14 +18,13 @@ BUNDLE_DIR="$RUNTIME_DIR/bundle"
 AGENTS_API_DIR="$RUNTIME_DIR/agents-api"
 DATA_MACHINE_DIR="$RUNTIME_DIR/data-machine"
 DATA_MACHINE_CODE_DIR="$RUNTIME_DIR/data-machine-code"
-PHP_AI_CLIENT_DIR="$RUNTIME_DIR/php-ai-client"
 
 cleanup() {
     rm -rf "$RUNTIME_DIR"
 }
 trap cleanup EXIT
 
-mkdir -p "$BUNDLE_DIR" "$AGENTS_API_DIR" "$DATA_MACHINE_DIR" "$DATA_MACHINE_CODE_DIR" "$PHP_AI_CLIENT_DIR"
+mkdir -p "$BUNDLE_DIR" "$AGENTS_API_DIR" "$DATA_MACHINE_DIR" "$DATA_MACHINE_CODE_DIR"
 printf '{"agent":{"slug":"wp-codebox-smoke-agent"}}\n' > "$BUNDLE_DIR/manifest.json"
 
 cat > "$FAKE_WP_CODEBOX" <<'NODE'
@@ -63,7 +62,7 @@ for (const expected of ['wp-codebox.agent-sandbox-run', 'HOMEBOY_DATAMACHINE_AGE
   }
 }
 if (recipe.inputs?.extraPlugins?.some((plugin) => plugin.slug === 'php-ai-client')) {
-  throw new Error('php-ai-client is a Composer library and must not be mounted as a WP Codebox extra plugin')
+  throw new Error('WP AI Client is provided by WordPress core and must not be mounted as a WP Codebox extra plugin')
 }
 if (!recipe.inputs?.mounts?.some((mount) => mount.source.endsWith('/bundle') && mount.target === '/wordpress/wp-content/plugins/bundle' && mount.mode === 'readonly')) {
   throw new Error('missing bundle readonly mount in recipe')
@@ -151,7 +150,6 @@ jq -n \
     --arg agentsApi "$AGENTS_API_DIR" \
     --arg dataMachine "$DATA_MACHINE_DIR" \
     --arg dataMachineCode "$DATA_MACHINE_CODE_DIR" \
-    --arg phpAiClient "$PHP_AI_CLIENT_DIR" \
     '{
         component_id: "wp-codebox-smoke-component",
         component_path: env.PWD,
@@ -166,7 +164,6 @@ jq -n \
         prompt: "Smoke the WP Codebox runner adapter.",
         wp_codebox_components: {
             agents_api: $agentsApi,
-            wp_ai_client: $phpAiClient,
             data_machine: $dataMachine,
             data_machine_code: $dataMachineCode
         }


### PR DESCRIPTION
## Summary
- Stop checking out WordPress/php-ai-client in the reusable Data Machine Agent CI workflow.
- Keep the default OpenAI path provider-only by checking out/mounting WordPress/ai-provider-for-openai.
- Remove wp_ai_client from generated WP Codebox runtime component config because WP AI Client is provided by WordPress core in the 7.0 runtime.
- Update the WP Codebox runner smoke to guard against mounting php-ai-client as an extra plugin.

## Verification
- npm run test:datamachine-agent-wp-codebox-runner

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Corrected the reusable agent CI runtime model so WP AI Client is treated as WordPress core and only the provider plugin is supplied for Chris to review/test.