### PR TITLE
Run WP Codebox verifier and policy checks

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -39,7 +39,31 @@ const argsFile = process.env.FAKE_WP_CODEBOX_ARGS_FILE
 if (!argsFile) {
   throw new Error('FAKE_WP_CODEBOX_ARGS_FILE is required')
 }
-fs.writeFileSync(argsFile, `${args.join('\n')}\n`)
+fs.appendFileSync(argsFile, `${args.join('\n')}\n---\n`)
+
+if (args[0] === 'artifacts' && args[1] === 'verify') {
+  if (!args.includes('--artifacts') || !args.includes('--json')) {
+    throw new Error('artifact verifier missing --artifacts or --json')
+  }
+  process.stdout.write(JSON.stringify({
+    success: true,
+    schema: 'wp-codebox/artifact-verification/v1',
+    checks: [{ id: 'manifest', status: 'passed' }],
+  }) + '\n')
+  process.exit(0)
+}
+
+if (args[0] === 'workspace-policy' && args[1] === 'check') {
+  if (!args.includes('--input') || !args.includes('--json')) {
+    throw new Error('workspace policy check missing --input or --json')
+  }
+  process.stdout.write(JSON.stringify({
+    success: true,
+    schema: 'wp-codebox/workspace-policy-check/v1',
+    checks: [{ id: 'allowed-files', status: 'passed' }],
+  }) + '\n')
+  process.exit(0)
+}
 
 for (const expected of ['recipe-run', '--recipe', '--json']) {
   if (!args.includes(expected)) {
@@ -164,6 +188,10 @@ jq -n \
         dry_run: true,
         provider: "example-provider",
         model: "example-model",
+        workspace_policy_check: {
+            enabled: true,
+            args: ["--scope", "smoke"]
+        },
         prompt: "Smoke the WP Codebox runner adapter.",
         wp_codebox_components: {
             agents_api: $agentsApi,
@@ -212,16 +240,16 @@ homeboy_result_path=$(jq -r "$scenario | .metadata.evidence_references.reference
 wp_codebox_bundle_available=$(jq -r "$scenario | .metadata.evidence_references.references.wp_codebox_artifact_bundle.available // false" "$RESULTS_TMPFILE")
 runtime_trace_available=$(jq -r "$scenario | .metadata.evidence_references.references.runtime_episode_trace.available // false" "$RESULTS_TMPFILE")
 replay_bundle_available=$(jq -r "$scenario | .metadata.evidence_references.references.replay_bundle_artifact.available // false" "$RESULTS_TMPFILE")
-verifier_gap=$(jq -r "$scenario | any(.metadata.evidence_references.compatibility_gaps[]?; .field == \"artifact_verifier_result\")" "$RESULTS_TMPFILE")
-policy_gap=$(jq -r "$scenario | any(.metadata.evidence_references.compatibility_gaps[]?; .field == \"workspace_policy_result\")" "$RESULTS_TMPFILE")
+verifier_available=$(jq -r "$scenario | .metadata.evidence_references.references.artifact_verifier_result.available // false" "$RESULTS_TMPFILE")
+policy_available=$(jq -r "$scenario | .metadata.evidence_references.references.workspace_policy_result.available // false" "$RESULTS_TMPFILE")
 trace_gap=$(jq -r "$scenario | any(.metadata.evidence_references.compatibility_gaps[]?; .field == \"runtime_episode_trace\")" "$RESULTS_TMPFILE")
-if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_gap" != "true" ] || [ "$policy_gap" != "true" ] || [ "$trace_gap" != "false" ]; then
+if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_available" != "true" ] || [ "$policy_available" != "true" ] || [ "$trace_gap" != "false" ]; then
     echo "ERROR: stable evidence references missing or incomplete" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1
 fi
 
-if ! grep -qx 'recipe-run' "$FAKE_ARGS_FILE" || ! grep -qx -- '--recipe' "$FAKE_ARGS_FILE"; then
+if ! grep -qx 'recipe-run' "$FAKE_ARGS_FILE" || ! grep -qx -- '--recipe' "$FAKE_ARGS_FILE" || ! grep -qx 'artifacts' "$FAKE_ARGS_FILE" || ! grep -qx 'workspace-policy' "$FAKE_ARGS_FILE"; then
     echo "ERROR: expected wp-codebox recipe-run invocation" >&2
     cat "$FAKE_ARGS_FILE" >&2
     exit 1

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -181,6 +181,20 @@ PHP
         exit $wp_codebox_exit
     fi
 
+    local wp_codebox_artifact_bundle
+    wp_codebox_artifact_bundle=$(jq -r '.artifacts.directory // empty' "$wp_codebox_output")
+
+    local artifact_verifier_result="$RUNTIME_DIR/wp-codebox-artifact-verifier.json"
+    local workspace_policy_result="$RUNTIME_DIR/wp-codebox-workspace-policy.json"
+    homeboy_datamachine_agent_run_artifact_verifier \
+        "$wp_codebox_bin" \
+        "$wp_codebox_artifact_bundle" \
+        "$artifact_verifier_result"
+    homeboy_datamachine_agent_run_workspace_policy_check \
+        "$wp_codebox_bin" \
+        "$wp_codebox_artifact_bundle" \
+        "$workspace_policy_result"
+
     local wp_codebox_review_input="$RUNTIME_DIR/wp-codebox-review.json"
     local wp_codebox_changed_files_input="$RUNTIME_DIR/wp-codebox-changed-files.json"
     local wp_codebox_artifacts_json="$RUNTIME_DIR/wp-codebox-artifacts.json"
@@ -202,6 +216,8 @@ PHP
         --slurpfile run "$wp_codebox_output" \
         --slurpfile review "$wp_codebox_review_input" \
         --slurpfile changedFiles "$wp_codebox_changed_files_input" \
+        --slurpfile verifier "$artifact_verifier_result" \
+        --slurpfile policy "$workspace_policy_result" \
         '
         ($run[0].artifacts // {}) as $artifacts
         | {
@@ -227,7 +243,9 @@ PHP
                 review: ($artifacts.reviewPath // "")
             } | with_entries(select(.value != "")),
             review_payload: ($review[0] // null),
-            changed_files: ($changedFiles[0] // null)
+            changed_files: ($changedFiles[0] // null),
+            artifact_verifier_result: ($verifier[0] // null),
+            workspace_policy_result: ($policy[0] // null)
         }
         ' >"$wp_codebox_artifacts_json"
 
@@ -267,6 +285,8 @@ PHP
                             runtime: ($run[0].runtime // null),
                             artifacts: ($run[0].artifacts // null),
                             canonical_artifacts: ($wpPaths // {}),
+                            artifact_verifier_result: ($wpArtifacts.artifact_verifier_result // null),
+                            workspace_policy_result: ($wpArtifacts.workspace_policy_result // null),
                             review_payload: ($wpArtifacts.review_payload // null),
                             changed_files: ($wpArtifacts.changed_files // null),
                             error: ($run[0].error // null)
@@ -276,6 +296,148 @@ PHP
             ]
         }
         ' >"$RESULTS_FILE"
+}
+
+homeboy_datamachine_agent_wp_codebox_command() {
+    local wp_codebox_bin="$1"
+    shift
+
+    local wp_codebox_command=("$wp_codebox_bin")
+    case "$wp_codebox_bin" in
+        *.js)
+            wp_codebox_command=(node "$wp_codebox_bin")
+            ;;
+    esac
+
+    "${wp_codebox_command[@]}" "$@"
+}
+
+homeboy_datamachine_agent_write_check_result() {
+    local output_path="$1"
+    local check_name="$2"
+    local required="$3"
+    local skipped_reason="$4"
+    local exit_code="$5"
+    local stdout_path="$6"
+
+    jq -n \
+        --arg check "$check_name" \
+        --argjson required "$required" \
+        --arg skippedReason "$skipped_reason" \
+        --argjson exitCode "$exit_code" \
+        --rawfile stdout "$stdout_path" \
+        '
+        ($stdout | fromjson? // null) as $jsonOutput
+        | {
+            schema: "homeboy/wp-codebox-post-run-check/v1",
+            check: $check,
+            required: $required,
+            skipped: ($skippedReason != ""),
+            skipped_reason: $skippedReason,
+            exit_code: $exitCode,
+            success: (($skippedReason == "") and ($exitCode == 0) and (($jsonOutput.success // $jsonOutput.valid // true) == true)),
+            output: $jsonOutput,
+            stdout: (if $jsonOutput == null then $stdout else null end)
+        }
+        | with_entries(select(.value != null and .value != ""))
+        ' >"$output_path"
+}
+
+homeboy_datamachine_agent_run_artifact_verifier() {
+    local wp_codebox_bin="$1"
+    local artifact_bundle="$2"
+    local result_path="$3"
+    local stdout_path="$RUNTIME_DIR/wp-codebox-artifact-verifier.stdout"
+    local required
+
+    required=$(jq -r 'if (.require_artifact_verifier // .wp_codebox_require_artifact_verifier // true) then "true" else "false" end' <<<"$CONFIG_JSON")
+    printf '' >"$stdout_path"
+
+    if [ -z "$artifact_bundle" ]; then
+        homeboy_datamachine_agent_write_check_result "$result_path" "artifact_verifier" "$required" "artifact_bundle_missing" 1 "$stdout_path"
+    else
+        set +e
+        homeboy_datamachine_agent_wp_codebox_command "$wp_codebox_bin" artifacts verify --artifacts "$artifact_bundle" --json >"$stdout_path" 2>&1
+        local verifier_exit=$?
+        set -e
+        homeboy_datamachine_agent_write_check_result "$result_path" "artifact_verifier" "$required" "" "$verifier_exit" "$stdout_path"
+    fi
+
+    if [ "$required" = "true" ] && ! jq -e '.success == true' "$result_path" >/dev/null; then
+        echo "ERROR: required WP Codebox artifact verification failed or was unavailable" >&2
+        cat "$result_path" >&2
+        exit 1
+    fi
+}
+
+homeboy_datamachine_agent_workspace_policy_args_json() {
+    jq -c '
+        def string_array($value):
+            if ($value | type) == "array" then [$value[] | select(type == "string" and . != "")]
+            elif ($value | type) == "string" and $value != "" then [$value]
+            else [] end;
+        (.workspace_policy_check // {}) as $check
+        | string_array($check.args // .workspace_policy_args // [])
+    ' <<<"$CONFIG_JSON"
+}
+
+homeboy_datamachine_agent_workspace_policy_available() {
+    jq -e '
+        (.workspace_policy_check // {}) as $check
+        | (($check.enabled // false) == true)
+            or (($check.args // .workspace_policy_args // []) | if type == "array" then length > 0 elif type == "string" then . != "" else false end)
+            or ((.workspace_policy_input // .workspace_policy_path // .workspace_policy // null) != null)
+    ' <<<"$CONFIG_JSON" >/dev/null
+}
+
+homeboy_datamachine_agent_run_workspace_policy_check() {
+    local wp_codebox_bin="$1"
+    local artifact_bundle="$2"
+    local result_path="$3"
+    local stdout_path="$RUNTIME_DIR/wp-codebox-workspace-policy.stdout"
+    local input_path="$RUNTIME_DIR/wp-codebox-workspace-policy-input.json"
+    local required
+
+    required=$(jq -r 'if (.require_workspace_policy // .wp_codebox_require_workspace_policy // false) then "true" else "false" end' <<<"$CONFIG_JSON")
+    printf '' >"$stdout_path"
+
+    if ! homeboy_datamachine_agent_workspace_policy_available; then
+        homeboy_datamachine_agent_write_check_result "$result_path" "workspace_policy" "$required" "policy_inputs_missing" 1 "$stdout_path"
+    else
+        jq '
+            {
+                workspace_policy_input: (.workspace_policy_input // null),
+                workspace_policy_path: (.workspace_policy_path // null),
+                workspace_policy: (.workspace_policy // null),
+                runner_workspace: (.runner_workspace // null),
+                runner_workspace_result: (.runner_workspace_result // null),
+                artifact_bundle: $artifactBundle
+            }
+        ' --arg artifactBundle "$artifact_bundle" <<<"$CONFIG_JSON" >"$input_path"
+
+        local policy_args_json
+        policy_args_json=$(homeboy_datamachine_agent_workspace_policy_args_json)
+        local policy_args=(workspace-policy check --json --input "$input_path")
+        if [ -n "$artifact_bundle" ]; then
+            policy_args+=(--artifacts "$artifact_bundle")
+        fi
+        while IFS= read -r policy_arg; do
+            [ -n "$policy_arg" ] || continue
+            policy_args+=("$policy_arg")
+        done < <(jq -r '.[]' <<<"$policy_args_json")
+
+        set +e
+        homeboy_datamachine_agent_wp_codebox_command "$wp_codebox_bin" "${policy_args[@]}" >"$stdout_path" 2>&1
+        local policy_exit=$?
+        set -e
+        homeboy_datamachine_agent_write_check_result "$result_path" "workspace_policy" "$required" "" "$policy_exit" "$stdout_path"
+    fi
+
+    if [ "$required" = "true" ] && ! jq -e '.success == true' "$result_path" >/dev/null; then
+        echo "ERROR: required WP Codebox workspace policy check failed or was unavailable" >&2
+        cat "$result_path" >&2
+        exit 1
+    fi
 }
 
 homeboy_datamachine_agent_attach_evidence_references() {


### PR DESCRIPTION
## Summary
- Run `wp-codebox artifacts verify` after live WP Codebox artifact bundle creation and attach the structured result to scenario metadata/evidence references.
- Run `wp-codebox workspace-policy check` when workspace policy inputs are configured, attach the structured result, and preserve skipped/failing states as JSON.
- Fail closed when required verifier or workspace-policy evidence is missing or failing.
- Update the WP Codebox Data Machine agent runner smoke to prove both evidence references are available.

Fixes #806

## Verification
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh`
- `bash -n wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `npm run test:datamachine-agent-wp-codebox-runner`
- `git diff --check -- wordpress/scripts/agent/run-datamachine-agent.sh wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner changes, updated the smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.