### PR TITLE
Project agent runs to wp-gym eval rows

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -146,6 +146,10 @@ name: Data Machine Agent CI (reusable)
         description: JSON object of zero-weight behavioral probes to preserve in eval metadata.
         type: string
         default: "{}"
+      wp_gym_benchmark_mode:
+        description: Fail the wp-gym eval row projection when required replay/evidence references are missing.
+        type: boolean
+        default: false
       comment_pr_summary:
         type: boolean
         default: false
@@ -612,6 +616,7 @@ jobs:
           GENERAL_RULES: ${{ inputs.general_rules }}
           TASK_RULES: ${{ inputs.task_rules }}
           PROBES: ${{ inputs.probes }}
+          WP_GYM_BENCHMARK_MODE: ${{ inputs.wp_gym_benchmark_mode }}
           DRY_RUN: ${{ inputs.dry_run }}
           EXTRA_WP_CONFIG_DEFINES: ${{ inputs.extra_wp_config_defines }}
           EXTRA_PLAYGROUND_FILE_MOUNTS: ${{ inputs.extra_playground_file_mounts }}
@@ -798,6 +803,7 @@ jobs:
             --argjson generalRules "$general_rules_json" \
             --argjson taskRules "$task_rules_json" \
             --argjson probes "$probes_json" \
+            --argjson wpGymBenchmarkMode "$WP_GYM_BENCHMARK_MODE" \
             '{
               component_id: "datamachine-agent-ci-driver",
               component_path: $componentPath,
@@ -857,6 +863,9 @@ jobs:
               general_rules: $generalRules,
               task_rules: $taskRules,
               probes: $probes,
+              wp_gym_eval: {
+                benchmark_mode: $wpGymBenchmarkMode
+              },
               execute_workflow_path: $executeWorkflowPath,
               success_requires_pr: $successRequiresPr,
               success_completion_outcomes: $successCompletionOutcomes,

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -162,6 +162,7 @@ knobs to `run-datamachine-agent.sh`:
 - GitHub access: `target_repo`, `app_token_repos`, `allowed_repos`, `engine_key`, `tool_results_key`.
 - Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
 - Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`, `replay_bundle_artifact_name`.
+- Eval projection: `wp_gym_benchmark_mode` turns missing wp-gym replay/evidence references into errors.
 - Extension points: `extra_required_abilities`, `ability_tools`, `tool_recorders`, `enable_terminal_actions`, `wp_cli_tool_name`, `pipeline_step_patches`, `flow_step_patches`, `runner_workspace`, `fallback_pull_request`.
 
 `bundle_repo` is for cross-repo consumers. The shell runner clones the bundle
@@ -242,6 +243,19 @@ references, and grader metadata. The runner also attaches
 result JSON so downstream JSONL publishers can link failure rows back to the
 bundle. The metadata key keeps the historical name until the artifact schema is
 renamed.
+
+The runner also projects each Data Machine agent scenario into
+`metadata.wp_gym_eval_row`. This is a compatibility scaffold for the canonical
+wp-gym row tracked in https://github.com/Automattic/wp-gym/issues/117. The row
+uses `schema_name: "wp-gym.eval_artifact_row"`, `schema_version: 0`, and
+`projection_version: "homeboy-extensions.compat.1"` until the upstream wp-gym
+validator lands. Evaluation semantics live under `evaluation`; Homeboy, Data
+Machine, Data Machine Code, GitHub workflow/PR, verifier, policy, and artifact
+references live under `orchestration`. Missing replay, transcript, runtime trace,
+verifier, policy, workflow, PR, or artifact evidence is reported in
+`compatibility_gaps`. Set reusable workflow input `wp_gym_benchmark_mode: true`
+or runner config `wp_gym_eval.benchmark_mode: true` to turn those gaps into
+projection errors for benchmark-mode jobs.
 
 Final-state review URLs are only emitted when the caller supplies a hosted review
 URL in runner config or scenario metadata. The default bundle records

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -17,6 +17,7 @@
     "lint:js": "eslint --ext .js,.jsx,.ts,.tsx",
     "test:page-profiler": "node tests/page-profiler-smoke.js",
     "test:datamachine-agent-wp-codebox-runner": "bash scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh",
+    "test:project-wpgym-eval-row": "bash scripts/agent/project-wpgym-eval-row-smoke.sh",
     "test:agent-terminal-actions": "node tests/agent-terminal-actions-smoke.js",
     "test:terminal-action-server": "node tests/terminal-action-server-smoke.js",
     "test:playground-readiness": "node tests/playground-readiness-smoke.js",

--- a/wordpress/scripts/agent/project-wpgym-eval-row-smoke.sh
+++ b/wordpress/scripts/agent/project-wpgym-eval-row-smoke.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECTOR="${SCRIPT_DIR}/project-wpgym-eval-row.js"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wpgym-row.XXXXXX")"
+RESULTS_FILE="${TMP_ROOT}/results.json"
+CONFIG_FILE="${TMP_ROOT}/config.json"
+TRANSCRIPT_FILE="${TMP_ROOT}/transcript.json"
+EPISODE_FILE="${TMP_ROOT}/episode.jsonl"
+REPLAY_FILE="${TMP_ROOT}/replay.json"
+
+cleanup() {
+	rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+printf '%s\n' '{"messages":[]}' > "$TRANSCRIPT_FILE"
+printf '%s\n' '{"row_type":"grader","result_status":"completed"}' > "$EPISODE_FILE"
+printf '%s\n' '{"sealed_eval_artifact":{"replay":{"format":"jsonl","episode_row_count":1,"tool_audit_event_count":1}}}' > "$REPLAY_FILE"
+
+jq -n \
+	--arg transcriptFile "$TRANSCRIPT_FILE" \
+	--arg episodeFile "$EPISODE_FILE" \
+	--arg replayFile "$REPLAY_FILE" \
+	--arg resultsFile "$RESULTS_FILE" \
+	'{
+		component_id: "datamachine-agent-ci-driver",
+		scenarios: [
+			{
+				id: "agent-flow",
+				label: "Agent flow",
+				metrics: { reward_mean: 1 },
+				artifacts: {
+					episode_jsonl: { path: $episodeFile, kind: "jsonl", label: "Episode JSONL" },
+					replay_bundle: { path: $replayFile, kind: "json", label: "Replay bundle" }
+				},
+				metadata: {
+					job_id: 123,
+					job_status: "completed",
+					success_status: "pr_opened",
+					target_repo: "Extra-Chill/example",
+					agent_slug: "example-agent",
+					provider: "openai",
+					model: "gpt-example",
+					grade: { score: 1, max_score: 1 },
+					transcript_artifacts: { json: $transcriptFile },
+					evidence_references: {
+						schema: "homeboy/datamachine-agent-evidence-references/v1",
+						references: {
+							homeboy_result_json: { kind: "json", path: $resultsFile, label: "Homeboy result JSON", source: "homeboy", available: true },
+							artifact_verifier_result: { kind: "json", value: { status: "passed" }, label: "Artifact verifier result", source: "runner", available: true },
+							workspace_policy_result: { kind: "json", value: { status: "passed" }, label: "Workspace policy result", source: "data-machine-code", available: true },
+							runtime_episode_trace: { kind: "jsonl", path: $episodeFile, label: "Runtime episode trace", source: "homeboy", available: true },
+							transcript_artifact: { kind: "json", path: $transcriptFile, label: "Transcript artifact", source: "data-machine", available: true },
+							replay_bundle_artifact: { kind: "json", path: $replayFile, label: "Replay bundle artifact", source: "homeboy", available: true },
+							pull_request: { kind: "url", value: "https://github.com/Extra-Chill/example/pull/1", label: "Pull request URL", source: "github", available: true },
+							workflow_run: { kind: "url", path: "https://github.com/Extra-Chill/example/actions/runs/1", label: "Workflow run", source: "github", available: true }
+						},
+						compatibility_gaps: []
+					}
+				}
+			}
+		]
+	}' > "$RESULTS_FILE"
+
+jq -n '{
+	workload_id: "agent-flow",
+	workload_label: "Agent flow",
+	agent_slug: "example-agent",
+	target_repo: "Extra-Chill/example",
+	provider: "openai",
+	model: "gpt-example",
+	prompt: "Do the thing.",
+	success_requires_pr: true
+}' > "$CONFIG_FILE"
+
+node "$PROJECTOR" --results "$RESULTS_FILE" --scenario agent-flow --config "$CONFIG_FILE" --update-results >/dev/null
+
+status="$(jq -r '.scenarios[] | select(.id == "agent-flow") | .metadata.wp_gym_eval_row.status' "$RESULTS_FILE")"
+schema="$(jq -r '.scenarios[] | select(.id == "agent-flow") | .metadata.wp_gym_eval_row.schema_name' "$RESULTS_FILE")"
+orchestration_pr="$(jq -r '.scenarios[] | select(.id == "agent-flow") | .metadata.wp_gym_eval_row.orchestration.github.pull_request' "$RESULTS_FILE")"
+eval_has_orchestration="$(jq -r '.scenarios[] | select(.id == "agent-flow") | .metadata.wp_gym_eval_row.evaluation | has("github") or has("workflow") or has("pull_request")' "$RESULTS_FILE")"
+if [ "$status" != "ready" ] || [ "$schema" != "wp-gym.eval_artifact_row" ] || [ "$orchestration_pr" != "https://github.com/Extra-Chill/example/pull/1" ] || [ "$eval_has_orchestration" != "false" ]; then
+	echo "ERROR: wp-gym eval projection did not preserve expected row shape" >&2
+	cat "$RESULTS_FILE" >&2
+	exit 1
+fi
+
+jq 'del(.scenarios[0].metadata.evidence_references.references.transcript_artifact)' "$RESULTS_FILE" > "${RESULTS_FILE}.missing"
+mv "${RESULTS_FILE}.missing" "$RESULTS_FILE"
+
+set +e
+HOMEBOY_WPGYM_BENCHMARK_MODE=1 node "$PROJECTOR" --results "$RESULTS_FILE" --scenario agent-flow --config "$CONFIG_FILE" --update-results >/dev/null 2>"${TMP_ROOT}/benchmark.err"
+benchmark_status=$?
+set -e
+if [ "$benchmark_status" -eq 0 ]; then
+	echo "ERROR: benchmark mode accepted a missing transcript reference" >&2
+	cat "${TMP_ROOT}/benchmark.err" >&2
+	exit 1
+fi
+if ! grep -q 'transcript' "${TMP_ROOT}/benchmark.err"; then
+	echo "ERROR: benchmark-mode failure did not report the missing transcript gap" >&2
+	cat "${TMP_ROOT}/benchmark.err" >&2
+	exit 1
+fi
+
+echo "✓ wp-gym eval row projection smoke test PASSED"

--- a/wordpress/scripts/agent/project-wpgym-eval-row.js
+++ b/wordpress/scripts/agent/project-wpgym-eval-row.js
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+'use strict';
+
+/**
+ * External dependencies
+ */
+const fs = require('fs');
+const crypto = require('crypto');
+
+const CONTRACT_ISSUE = 'https://github.com/Automattic/wp-gym/issues/117';
+const PROJECTION_ISSUE = 'https://github.com/Extra-Chill/homeboy-extensions/issues/807';
+const SCHEMA_NAME = 'wp-gym.eval_artifact_row';
+const SCHEMA_VERSION = 0;
+const PROJECTION_VERSION = 'homeboy-extensions.compat.1';
+
+function usage() {
+	console.error('Usage: project-wpgym-eval-row.js --results <path> --scenario <id> --config <path> [--update-results] [--benchmark-mode]');
+}
+
+function parseArgs(argv) {
+	const args = {};
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === '--update-results') {
+			args.updateResults = true;
+			continue;
+		}
+		if (arg === '--benchmark-mode') {
+			args.benchmarkMode = true;
+			continue;
+		}
+		if (!arg.startsWith('--')) {
+			throw new Error(`Unexpected argument: ${arg}`);
+		}
+		const key = arg.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+		const value = argv[index + 1];
+		if (!value || value.startsWith('--')) {
+			throw new Error(`${arg} requires a value`);
+		}
+		args[key] = value;
+		index += 1;
+	}
+	return args;
+}
+
+function readJson(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function stableValue(value) {
+	if (Array.isArray(value)) {
+		return value.map((entry) => stableValue(entry));
+	}
+	if (value && typeof value === 'object') {
+		return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableValue(value[key])]));
+	}
+	return value;
+}
+
+function sha256Json(value) {
+	return `sha256:${crypto.createHash('sha256').update(JSON.stringify(stableValue(value))).digest('hex')}`;
+}
+
+function compactObject(value) {
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => {
+		if (entry === undefined || entry === null || entry === '') {
+			return false;
+		}
+		if (Array.isArray(entry) && entry.length === 0) {
+			return false;
+		}
+		if (entry && typeof entry === 'object' && !Array.isArray(entry) && Object.keys(entry).length === 0) {
+			return false;
+		}
+		return true;
+	}));
+}
+
+function present(value) {
+	if (value === undefined || value === null || value === '') {
+		return false;
+	}
+	if (Array.isArray(value)) {
+		return value.length > 0;
+	}
+	if (typeof value === 'object') {
+		if (Object.prototype.hasOwnProperty.call(value, 'available')) {
+			return value.available === true && present(value.path ?? value.value ?? value.url ?? value.href ?? value.sha256 ?? value.status);
+		}
+		return Object.keys(value).length > 0;
+	}
+	return true;
+}
+
+function referenceValue(reference) {
+	if (!reference || typeof reference !== 'object') {
+		return '';
+	}
+	return reference.path ?? reference.value ?? reference.url ?? reference.href ?? '';
+}
+
+function evidenceReference(scenario, name) {
+	const references = scenario.metadata?.evidence_references?.references;
+	if (!references || typeof references !== 'object') {
+		return null;
+	}
+	return references[name] || null;
+}
+
+function artifactReference(scenario, name) {
+	const artifact = scenario.artifacts?.[name];
+	if (!artifact || typeof artifact !== 'object') {
+		return null;
+	}
+	return {
+		kind: artifact.kind || 'artifact',
+		path: artifact.path || '',
+		label: artifact.label || name,
+		source: 'homeboy',
+		available: present(artifact.path),
+	};
+}
+
+function firstReference(scenario, ...names) {
+	for (const name of names) {
+		const reference = evidenceReference(scenario, name) || artifactReference(scenario, name);
+		if (present(reference)) {
+			return reference;
+		}
+		if (reference) {
+			return reference;
+		}
+	}
+	return null;
+}
+
+function requiredReferenceGaps(references, requirePullRequest) {
+	const required = [
+		['replay_bundle', references.replay_bundle, 'Replay bundle artifact is required for wp-gym replay rows.'],
+		['episode_trace', references.episode_trace, 'Runtime episode trace is required for action/replay projection.'],
+		['transcript', references.transcript, 'Transcript artifact is required for model-observation provenance.'],
+		['verifier', references.verifier, 'Verifier result is required for benchmark-mode grading.'],
+		['policy', references.policy, 'Policy attestation is required to separate allowed orchestration from eval semantics.'],
+		['workflow', references.workflow, 'Workflow run reference is required for artifact provenance.'],
+		['homeboy_result', references.homeboy_result, 'Homeboy result JSON is required as the source projection artifact.'],
+	];
+
+	if (requirePullRequest) {
+		required.push(['pull_request', references.pull_request, 'Pull request reference is required when success_requires_pr is enabled.']);
+	}
+
+	return required
+		.filter(([, reference]) => !present(reference))
+		.map(([field, reference, reason]) => ({
+			field,
+			reason,
+			compatibility_gap: true,
+			available: reference?.available === true,
+		}));
+}
+
+function projectionReferences(scenario) {
+	return {
+		replay_bundle: firstReference(scenario, 'replay_bundle_artifact', 'replay_bundle'),
+		episode_trace: firstReference(scenario, 'runtime_episode_trace', 'episode_jsonl'),
+		transcript: firstReference(scenario, 'transcript_artifact', 'transcript_json'),
+		verifier: firstReference(scenario, 'artifact_verifier_result'),
+		policy: firstReference(scenario, 'workspace_policy_result'),
+		workflow: firstReference(scenario, 'workflow_run'),
+		pull_request: firstReference(scenario, 'pull_request'),
+		homeboy_result: firstReference(scenario, 'homeboy_result_json'),
+		artifact_bundle: firstReference(scenario, 'wp_codebox_artifact_bundle'),
+	};
+}
+
+function projectionStatus(gaps, benchmarkMode) {
+	if (gaps.length === 0) {
+		return 'ready';
+	}
+	return benchmarkMode ? 'invalid' : 'compatibility_gaps';
+}
+
+function projectEvalRow(results, scenario, config, benchmarkMode) {
+	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
+	const evalArtifact = metadata.eval_artifact && typeof metadata.eval_artifact === 'object' ? metadata.eval_artifact : {};
+	const sealed = metadata.replay_bundle?.sealed_eval_artifact || evalArtifact.envelope || {};
+	const references = projectionReferences(scenario);
+	const requirePullRequest = config.success_requires_pr === true;
+	const gaps = [
+		...requiredReferenceGaps(references, requirePullRequest),
+		...(Array.isArray(metadata.evidence_references?.compatibility_gaps) ? metadata.evidence_references.compatibility_gaps : []),
+		...(Array.isArray(sealed.integration_seams) ? sealed.integration_seams.map((field) => ({ field, reason: 'Homeboy sealed artifact reports this integration seam as missing.', compatibility_gap: true })) : []),
+	];
+	const normalizedGaps = Array.from(new Map(gaps.map((gap) => [gap.field, gap])).values());
+	const outcome = compactObject({
+		status: metadata.job_status || evalArtifact.run?.job_status || '',
+		success_status: metadata.success_status || evalArtifact.run?.success_status || '',
+		completion_outcome: metadata.completion_outcome || '',
+		completion_outcome_satisfied: metadata.completion_outcome_satisfied === true,
+		reward: metadata.reward ?? metadata.score ?? evalArtifact.grade?.reward ?? evalArtifact.grade?.score,
+		failure_reasons: evalArtifact.failure_reasons || metadata.failure_reasons || [],
+		termination: evalArtifact.termination || {},
+	});
+	const evaluation = compactObject({
+		task: compactObject({
+			id: metadata.task_id || config.task_id || config.workload_id || scenario.id,
+			label: metadata.task_label || config.task_label || config.workload_label || scenario.label,
+		}),
+		subject: compactObject({
+			target_repo: metadata.target_repo || config.target_repo,
+			bundle_repo: metadata.bundle_repo || config.bundle_repo,
+			bundle_ref: metadata.bundle_ref || config.bundle_ref,
+			bundle_path: metadata.bundle_path || config.bundle_path,
+		}),
+		agent: compactObject({
+			slug: metadata.agent_slug || config.agent_slug,
+			id: metadata.agent_id,
+		}),
+		model: compactObject({
+			provider: metadata.provider || config.provider,
+			model: metadata.model || config.model,
+		}),
+		prompt: evalArtifact.prompt || evalArtifact.hashes?.prompt || metadata.fingerprints?.prompt || (config.prompt ? {
+			sha256: `sha256:${crypto.createHash('sha256').update(config.prompt).digest('hex')}`,
+			bytes: Buffer.byteLength(config.prompt),
+		} : {}),
+		outcome,
+		grade: evalArtifact.grade || metadata.grade || {},
+		rules: compactObject({
+			general: metadata.general_rules || config.general_rules || [],
+			task_specific: metadata.task_rules || config.task_rules || [],
+			results: metadata.general_rule_results || [],
+			policy: metadata.rules || config.rules || {},
+		}),
+		probes: metadata.probes || config.probes || {},
+		replay: compactObject({
+			format: sealed.replay?.format || 'jsonl',
+			episode_row_count: sealed.replay?.episode_row_count,
+			tool_audit_event_count: sealed.replay?.tool_audit_event_count ?? evalArtifact.replay?.tool_audit_event_count,
+			references: compactObject({
+				replay_bundle: referenceValue(references.replay_bundle),
+				episode_trace: referenceValue(references.episode_trace),
+				transcript: referenceValue(references.transcript),
+			}),
+		}),
+	});
+	const orchestration = compactObject({
+		homeboy: compactObject({
+			component_id: results.component_id || results.component,
+			scenario_id: scenario.id,
+			result_json: referenceValue(references.homeboy_result),
+			artifact_bundle: referenceValue(references.artifact_bundle),
+		}),
+		datamachine: compactObject({
+			job_id: metadata.job_id || evalArtifact.run?.job_id,
+			pipeline_id: metadata.pipeline_id,
+			flow_id: metadata.flow_id,
+			transcript_session_id: metadata.transcript_session_id,
+		}),
+		data_machine_code: compactObject({
+			workspace: metadata.runner_workspace || {},
+			workspace_capture: metadata.runner_workspace_capture || {},
+			policy_attestation: referenceValue(references.policy) || metadata.datamachine_code_policy_attestation,
+		}),
+		github: compactObject({
+			workflow_run: referenceValue(references.workflow),
+			pull_request: referenceValue(references.pull_request),
+		}),
+		artifacts: compactObject({
+			verifier: referenceValue(references.verifier),
+			policy: referenceValue(references.policy),
+			workflow: referenceValue(references.workflow),
+			all_references: references,
+		}),
+	});
+	const row = {
+		schema_name: SCHEMA_NAME,
+		schema_version: SCHEMA_VERSION,
+		projection_version: PROJECTION_VERSION,
+		contract_status: 'compatibility_scaffold',
+		contract_issue: CONTRACT_ISSUE,
+		projection_issue: PROJECTION_ISSUE,
+		projected_at: new Date().toISOString(),
+		status: projectionStatus(normalizedGaps, benchmarkMode),
+		benchmark_mode: benchmarkMode,
+		evaluation,
+		orchestration,
+		compatibility_gaps: normalizedGaps,
+	};
+	row.row_sha256 = sha256Json(row);
+	return row;
+}
+
+function attachProjection(results, scenarioId, row) {
+	return {
+		...results,
+		scenarios: (results.scenarios || []).map((scenario) => {
+			if (scenario.id !== scenarioId) {
+				return scenario;
+			}
+			return {
+				...scenario,
+				metadata: {
+					...(scenario.metadata || {}),
+					wp_gym_eval_row: row,
+				},
+			};
+		}),
+	};
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	for (const required of ['results', 'scenario', 'config']) {
+		if (!args[required]) {
+			usage();
+			throw new Error(`Missing --${required}`);
+		}
+	}
+
+	const results = readJson(args.results);
+	const config = readJson(args.config);
+	const benchmarkMode = args.benchmarkMode || process.env.HOMEBOY_WPGYM_BENCHMARK_MODE === '1' || config.wp_gym_eval?.benchmark_mode === true;
+	const scenario = (results.scenarios || []).find((entry) => entry.id === args.scenario);
+	if (!scenario) {
+		throw new Error(`Scenario not found in results: ${args.scenario}`);
+	}
+
+	const row = projectEvalRow(results, scenario, config, benchmarkMode);
+	if (benchmarkMode && row.compatibility_gaps.length > 0) {
+		console.error(`ERROR: wp-gym eval row projection has ${row.compatibility_gaps.length} benchmark-mode compatibility gap(s).`);
+		console.error(JSON.stringify(row.compatibility_gaps, null, 2));
+		process.exitCode = 1;
+	}
+
+	if (args.updateResults) {
+		const updated = attachProjection(results, args.scenario, row);
+		fs.writeFileSync(args.results, `${JSON.stringify(updated, null, 2)}\n`);
+	}
+
+	console.log(JSON.stringify(row, null, 2));
+}
+
+try {
+	main();
+} catch (error) {
+	console.error(`ERROR: ${error.message}`);
+	process.exit(1);
+}

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WORKLOAD_PATH="$SCRIPT_DIR/datamachine-agent-workload.php"
 REPLAY_BUNDLE_BUILDER="$SCRIPT_DIR/build-replay-bundle.js"
+WPGYM_EVAL_ROW_PROJECTOR="$SCRIPT_DIR/project-wpgym-eval-row.js"
 
 homeboy_datamachine_agent_bundle_clone_url() {
     local repo_url="${1:-}"
@@ -613,6 +614,19 @@ if [ -n "$REPLAY_BUNDLE_DIR" ]; then
 fi
 
 homeboy_datamachine_agent_attach_evidence_references
+
+if [ -f "$WPGYM_EVAL_ROW_PROJECTOR" ]; then
+    wpgym_projector_args=(
+        --results "$RESULTS_FILE"
+        --scenario "$WORKLOAD_ID"
+        --config "$CONFIG_PATH"
+        --update-results
+    )
+    if [ "$(jq -r 'if (.wp_gym_eval.benchmark_mode // false) then "1" else "0" end' "$CONFIG_PATH")" = "1" ]; then
+        wpgym_projector_args+=(--benchmark-mode)
+    fi
+    node "$WPGYM_EVAL_ROW_PROJECTOR" "${wpgym_projector_args[@]}" >/dev/null
+fi
 
 if jq -e "$scenario | .metadata.error?" "$RESULTS_FILE" >/dev/null; then
     echo "ERROR: Data Machine agent workload reported an error" >&2


### PR DESCRIPTION
## Summary
- project Data Machine agent scenario output into `metadata.wp_gym_eval_row` with a compatible `wp-gym.eval_artifact_row` scaffold
- keep eval semantics under `evaluation` and Homeboy/Data Machine/GitHub orchestration evidence under `orchestration`
- add benchmark-mode gap failures and a targeted smoke test for projection shape and missing evidence

Fixes #807.

## Checks
- `npm run test:project-wpgym-eval-row`
- `npx eslint scripts/agent/project-wpgym-eval-row.js`
- `bash wordpress/scripts/agent/build-replay-bundle-smoke.sh`
- `bash wordpress/scripts/agent/validate-bundle-smoke.sh`
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `bash wordpress/scripts/agent/datamachine-agent-runner-smoke.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); puts "workflow yaml ok"'`\n\n## Dependency note\n- `Automattic/wp-gym#117` is still open, so this PR ships a versioned compatibility scaffold (`schema_version: 0`, `projection_version: homeboy-extensions.compat.1`) and documents that the upstream live validator should replace the scaffold once landed.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** OpenCode (GPT-5.5)\n- **Used for:** Implementing the projection scaffold, smoke test, documentation, and local verification. Chris remains responsible for review and merge.