### PR TITLE
Validate live-run wp-gym eval rows

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -18,6 +18,7 @@
     "test:page-profiler": "node tests/page-profiler-smoke.js",
     "test:datamachine-agent-wp-codebox-runner": "bash scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh",
     "test:project-wpgym-eval-row": "bash scripts/agent/project-wpgym-eval-row-smoke.sh",
+    "test:validate-wpgym-eval-row": "bash scripts/agent/validate-wpgym-eval-row-smoke.sh",
     "test:agent-terminal-actions": "node tests/agent-terminal-actions-smoke.js",
     "test:terminal-action-server": "node tests/terminal-action-server-smoke.js",
     "test:playground-readiness": "node tests/playground-readiness-smoke.js",

--- a/wordpress/scripts/agent/build-replay-bundle.js
+++ b/wordpress/scripts/agent/build-replay-bundle.js
@@ -106,6 +106,7 @@ function resolveReviewUrl(config, scenario) {
 function transcriptReferences(config, scenario) {
 	const artifacts = scenario.artifacts && typeof scenario.artifacts === 'object' ? scenario.artifacts : {};
 	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
+	const transcriptArtifacts = metadata.transcript_artifacts && typeof metadata.transcript_artifacts === 'object' ? metadata.transcript_artifacts : {};
 	const references = [];
 
 	for (const [name, artifact] of Object.entries(artifacts)) {
@@ -121,6 +122,12 @@ function transcriptReferences(config, scenario) {
 		if (metadata[key]) {
 			references.push({ name: key, path: metadata[key] });
 		}
+	}
+	if (transcriptArtifacts.json) {
+		references.push({ name: 'transcript_json', path: transcriptArtifacts.json });
+	}
+	if (transcriptArtifacts.summary) {
+		references.push({ name: 'transcript_summary', path: transcriptArtifacts.summary });
 	}
 
 	if (config.transcript_dir) {
@@ -141,10 +148,13 @@ function artifactReferences(scenario, config, bundlePath, episodeJsonlPath = '')
 	}
 
 	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
+	const transcriptArtifacts = metadata.transcript_artifacts && typeof metadata.transcript_artifacts === 'object' ? metadata.transcript_artifacts : {};
 	for (const [name, referencePath] of Object.entries({
 		transcript_json: metadata.transcript_json,
 		transcript_summary: metadata.transcript_summary,
 		action_log: metadata.action_log,
+		transcript_artifact_json: transcriptArtifacts.json,
+		transcript_artifact_summary: transcriptArtifacts.summary,
 	})) {
 		if (referencePath) {
 			references.push({ name, path: referencePath, kind: 'metadata', required: /transcript|action/.test(name) });

--- a/wordpress/scripts/agent/project-wpgym-eval-row.js
+++ b/wordpress/scripts/agent/project-wpgym-eval-row.js
@@ -167,6 +167,7 @@ function projectionReferences(scenario) {
 		transcript: firstReference(scenario, 'transcript_artifact', 'transcript_json'),
 		verifier: firstReference(scenario, 'artifact_verifier_result'),
 		policy: firstReference(scenario, 'workspace_policy_result'),
+		grader_result: firstReference(scenario, 'grader_result'),
 		workflow: firstReference(scenario, 'workflow_run'),
 		pull_request: firstReference(scenario, 'pull_request'),
 		homeboy_result: firstReference(scenario, 'homeboy_result_json'),

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -6,6 +6,7 @@ EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WORKLOAD_PATH="$SCRIPT_DIR/datamachine-agent-workload.php"
 REPLAY_BUNDLE_BUILDER="$SCRIPT_DIR/build-replay-bundle.js"
 WPGYM_EVAL_ROW_PROJECTOR="$SCRIPT_DIR/project-wpgym-eval-row.js"
+WPGYM_EVAL_ROW_VALIDATOR="$SCRIPT_DIR/validate-wpgym-eval-row.js"
 
 homeboy_datamachine_agent_bundle_clone_url() {
     local repo_url="${1:-}"
@@ -788,6 +789,17 @@ if [ -f "$WPGYM_EVAL_ROW_PROJECTOR" ]; then
         wpgym_projector_args+=(--benchmark-mode)
     fi
     node "$WPGYM_EVAL_ROW_PROJECTOR" "${wpgym_projector_args[@]}" >/dev/null
+
+    if [ "$(jq -r 'if (.wp_gym_eval.benchmark_mode // false) then "1" else "0" end' "$CONFIG_PATH")" = "1" ]; then
+        if [ ! -f "$WPGYM_EVAL_ROW_VALIDATOR" ]; then
+            echo "ERROR: wp-gym eval row validator missing at $WPGYM_EVAL_ROW_VALIDATOR" >&2
+            exit 1
+        fi
+        node "$WPGYM_EVAL_ROW_VALIDATOR" \
+            --results "$RESULTS_FILE" \
+            --scenario "$WORKLOAD_ID" \
+            --config "$CONFIG_PATH" >/dev/null
+    fi
 fi
 
 if jq -e "$scenario | .metadata.error?" "$RESULTS_FILE" >/dev/null; then

--- a/wordpress/scripts/agent/validate-wpgym-eval-row-smoke.sh
+++ b/wordpress/scripts/agent/validate-wpgym-eval-row-smoke.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECTOR="${SCRIPT_DIR}/project-wpgym-eval-row.js"
+VALIDATOR="${SCRIPT_DIR}/validate-wpgym-eval-row.js"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wpgym-validator.XXXXXX")"
+RESULTS_FILE="${TMP_ROOT}/results.json"
+CONFIG_FILE="${TMP_ROOT}/config.json"
+TRANSCRIPT_FILE="${TMP_ROOT}/transcript.json"
+EPISODE_FILE="${TMP_ROOT}/episode.jsonl"
+REPLAY_FILE="${TMP_ROOT}/replay.json"
+
+cleanup() {
+	rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+sha256_digest() {
+	shasum -a 256 "$1" | cut -d ' ' -f 1
+}
+
+write_valid_fixture() {
+	printf '%s\n' '{"messages":[]}' > "$TRANSCRIPT_FILE"
+	printf '%s\n' '{"row_type":"grader","terminal":true,"result_status":"completed","reward":1,"grade":{"score":1,"max_score":1}}' > "$EPISODE_FILE"
+	local transcript_sha episode_sha
+	transcript_sha="sha256:$(sha256_digest "$TRANSCRIPT_FILE")"
+	episode_sha="sha256:$(sha256_digest "$EPISODE_FILE")"
+	jq -n \
+		--arg transcriptSha "$transcript_sha" \
+		--arg episodeSha "$episode_sha" \
+		'{
+			sealed_eval_artifact: {
+				replay: { format: "jsonl", episode_row_count: 1, tool_audit_event_count: 1 },
+				hashes: {
+					envelope: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					artifact_hashes: {
+						transcript_json: { sha256: $transcriptSha },
+						episode_jsonl: { sha256: $episodeSha }
+					}
+				}
+			}
+		}' > "$REPLAY_FILE"
+
+	jq -n \
+		--arg transcriptFile "$TRANSCRIPT_FILE" \
+		--arg episodeFile "$EPISODE_FILE" \
+		--arg replayFile "$REPLAY_FILE" \
+		--arg resultsFile "$RESULTS_FILE" \
+		'{
+			component_id: "datamachine-agent-ci-driver",
+			scenarios: [
+				{
+					id: "agent-flow",
+					label: "Agent flow",
+					metrics: { reward_mean: 1 },
+					artifacts: {
+						episode_jsonl: { path: $episodeFile, kind: "jsonl", label: "Episode JSONL" },
+						replay_bundle: { path: $replayFile, kind: "json", label: "Replay bundle" }
+					},
+					metadata: {
+						job_id: 123,
+						job_status: "completed",
+						success_status: "pr_opened",
+						target_repo: "Extra-Chill/example",
+						agent_slug: "example-agent",
+						provider: "openai",
+						model: "gpt-example",
+						reward: 1,
+						grade: { score: 1, max_score: 1 },
+						evidence_references: {
+							schema: "homeboy/datamachine-agent-evidence-references/v1",
+							references: {
+								homeboy_result_json: { kind: "json", path: $resultsFile, label: "Homeboy result JSON", source: "homeboy", available: true },
+								artifact_verifier_result: { kind: "json", value: { status: "passed" }, label: "Artifact verifier result", source: "runner", available: true },
+								workspace_policy_result: { kind: "json", value: { status: "passed" }, label: "Workspace policy result", source: "data-machine-code", available: true },
+								grader_result: { kind: "json", value: { score: 1, max_score: 1 }, label: "Grader result", source: "runner", available: true },
+								runtime_episode_trace: { kind: "jsonl", path: $episodeFile, label: "Runtime episode trace", source: "homeboy", available: true },
+								transcript_artifact: { kind: "json", path: $transcriptFile, label: "Transcript artifact", source: "data-machine", available: true },
+								replay_bundle_artifact: { kind: "json", path: $replayFile, label: "Replay bundle artifact", source: "homeboy", available: true },
+								pull_request: { kind: "url", value: "https://github.com/Extra-Chill/example/pull/1", label: "Pull request URL", source: "github", available: true },
+								workflow_run: { kind: "url", path: "https://github.com/Extra-Chill/example/actions/runs/1", label: "Workflow run", source: "github", available: true }
+							},
+							compatibility_gaps: []
+						}
+					}
+				}
+			]
+		}' > "$RESULTS_FILE"
+
+	jq -n '{
+		workload_id: "agent-flow",
+		workload_label: "Agent flow",
+		agent_slug: "example-agent",
+		target_repo: "Extra-Chill/example",
+		provider: "openai",
+		model: "gpt-example",
+		prompt: "Do the thing.",
+		success_requires_pr: true,
+		wp_gym_eval: { benchmark_mode: true }
+	}' > "$CONFIG_FILE"
+
+	node "$PROJECTOR" --results "$RESULTS_FILE" --scenario agent-flow --config "$CONFIG_FILE" --benchmark-mode --update-results >/dev/null
+}
+
+assert_invalid() {
+	local label="$1"
+	local expected="$2"
+	local mutate_filter="$3"
+	write_valid_fixture
+	jq "$mutate_filter" "$RESULTS_FILE" > "${RESULTS_FILE}.invalid"
+	mv "${RESULTS_FILE}.invalid" "$RESULTS_FILE"
+	set +e
+	node "$VALIDATOR" --results "$RESULTS_FILE" --scenario agent-flow --config "$CONFIG_FILE" >/dev/null 2>"${TMP_ROOT}/${label}.err"
+	local status=$?
+	set -e
+	if [ "$status" -eq 0 ]; then
+		echo "ERROR: validator accepted invalid fixture: $label" >&2
+		exit 1
+	fi
+	if ! grep -q "$expected" "${TMP_ROOT}/${label}.err"; then
+		echo "ERROR: validator failure for $label did not mention $expected" >&2
+		cat "${TMP_ROOT}/${label}.err" >&2
+		exit 1
+	fi
+}
+
+write_valid_fixture
+node "$VALIDATOR" --results "$RESULTS_FILE" --scenario agent-flow --config "$CONFIG_FILE" >/dev/null
+
+assert_invalid "missing-artifact" "local artifact does not exist" '.scenarios[0].metadata.evidence_references.references.transcript_artifact.path = "missing-transcript.json" | .scenarios[0].metadata.wp_gym_eval_row.orchestration.artifacts.all_references.transcript.path = "missing-transcript.json"'
+assert_invalid "remote-artifact" "must be a local artifact" '.scenarios[0].metadata.evidence_references.references.runtime_episode_trace.path = "https://example.com/episode.jsonl" | .scenarios[0].metadata.wp_gym_eval_row.orchestration.artifacts.all_references.episode_trace.path = "https://example.com/episode.jsonl"'
+write_valid_fixture
+jq 'del(.sealed_eval_artifact.hashes.artifact_hashes.transcript_json)' "$REPLAY_FILE" > "${REPLAY_FILE}.missing-hash"
+mv "${REPLAY_FILE}.missing-hash" "$REPLAY_FILE"
+set +e
+node "$VALIDATOR" --results "$RESULTS_FILE" --scenario agent-flow --config "$CONFIG_FILE" >/dev/null 2>"${TMP_ROOT}/missing-hash.err"
+missing_hash_status=$?
+set -e
+if [ "$missing_hash_status" -eq 0 ] || ! grep -q 'missing a matching sha256 hash' "${TMP_ROOT}/missing-hash.err"; then
+	echo "ERROR: validator accepted an artifact without a matching hash" >&2
+	cat "${TMP_ROOT}/missing-hash.err" >&2
+	exit 1
+fi
+
+write_valid_fixture
+printf '%s\n' '{not json}' > "$EPISODE_FILE"
+set +e
+node "$VALIDATOR" --results "$RESULTS_FILE" --scenario agent-flow --config "$CONFIG_FILE" >/dev/null 2>"${TMP_ROOT}/invalid-jsonl.err"
+invalid_jsonl_status=$?
+set -e
+if [ "$invalid_jsonl_status" -eq 0 ] || ! grep -q 'Invalid JSONL' "${TMP_ROOT}/invalid-jsonl.err"; then
+	echo "ERROR: validator accepted invalid episode JSONL" >&2
+	cat "${TMP_ROOT}/invalid-jsonl.err" >&2
+	exit 1
+fi
+
+assert_invalid "missing-verifier" "verifier" 'del(.scenarios[0].metadata.evidence_references.references.artifact_verifier_result) | del(.scenarios[0].metadata.wp_gym_eval_row.orchestration.artifacts.all_references.verifier)'
+assert_invalid "missing-policy" "policy" 'del(.scenarios[0].metadata.evidence_references.references.workspace_policy_result) | del(.scenarios[0].metadata.wp_gym_eval_row.orchestration.artifacts.all_references.policy)'
+assert_invalid "grade-mismatch" "Terminal episode grader row" '.scenarios[0].metadata.wp_gym_eval_row.evaluation.grade.score = 0'
+
+echo "✓ wp-gym eval row validator smoke test PASSED"

--- a/wordpress/scripts/agent/validate-wpgym-eval-row.js
+++ b/wordpress/scripts/agent/validate-wpgym-eval-row.js
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+'use strict';
+
+/**
+ * External dependencies
+ */
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const SCHEMA_NAME = 'wp-gym.eval_artifact_row';
+const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/;
+
+function usage() {
+	console.error('Usage: validate-wpgym-eval-row.js --results <path> --scenario <id> --config <path>');
+}
+
+function parseArgs(argv) {
+	const args = {};
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (!arg.startsWith('--')) {
+			throw new Error(`Unexpected argument: ${arg}`);
+		}
+		const key = arg.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+		const value = argv[index + 1];
+		if (!value || value.startsWith('--')) {
+			throw new Error(`${arg} requires a value`);
+		}
+		args[key] = value;
+		index += 1;
+	}
+	return args;
+}
+
+function readJson(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function sha256File(filePath) {
+	return `sha256:${crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')}`;
+}
+
+function isRemoteReference(value) {
+	return /^https?:\/\//i.test(String(value || ''));
+}
+
+function referencePath(reference) {
+	if (!reference || typeof reference !== 'object') {
+		return '';
+	}
+	return reference.path ?? reference.value ?? reference.url ?? reference.href ?? '';
+}
+
+function resolveReferencePath(referenceValue, resultsPath) {
+	if (!referenceValue || path.isAbsolute(referenceValue) || isRemoteReference(referenceValue)) {
+		return referenceValue || '';
+	}
+	return path.resolve(path.dirname(resultsPath), referenceValue);
+}
+
+function hasObject(value) {
+	return value && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length > 0;
+}
+
+function validateJsonl(filePath, issueField, issues) {
+	const text = fs.readFileSync(filePath, 'utf8');
+	const rows = [];
+	text.split(/\r?\n/).forEach((line, index) => {
+		if (line.trim() === '') {
+			return;
+		}
+		try {
+			rows.push(JSON.parse(line));
+		} catch (error) {
+			issues.push({ field: issueField, reason: `Invalid JSONL at line ${index + 1}: ${error.message}` });
+		}
+	});
+	if (rows.length === 0) {
+		issues.push({ field: issueField, reason: 'Episode JSONL must contain at least one row.' });
+	}
+	return rows;
+}
+
+function findHash(hashSources, names, actualSha256) {
+	for (const source of hashSources) {
+		if (!source || typeof source !== 'object') {
+			continue;
+		}
+		for (const name of names) {
+			const hashValue = source[name]?.sha256 || source[name]?.hash || source[name];
+			if (typeof hashValue === 'string' && hashValue === actualSha256) {
+				return hashValue;
+			}
+		}
+	}
+	return '';
+}
+
+function expectedArtifactNames(scenario, config) {
+	const metadata = hasObject(scenario.metadata) ? scenario.metadata : {};
+	const manifest = hasObject(metadata.scenario_manifest) ? metadata.scenario_manifest : {};
+	const evalConfig = hasObject(config.wp_gym_eval) ? config.wp_gym_eval : {};
+	const candidates = [
+		config.expected_artifacts,
+		evalConfig.expected_artifacts,
+		metadata.expected_artifacts,
+		manifest.expected_artifacts,
+	];
+	return candidates.find((entry) => Array.isArray(entry)) || [];
+}
+
+function valuesEqual(left, right) {
+	if (left === undefined || right === undefined) {
+		return true;
+	}
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function validateTerminalGrade(row, episodeRows, issues) {
+	const terminal = [...episodeRows].reverse().find((entry) => entry && typeof entry === 'object' && (entry.terminal === true || entry.row_type === 'grader'));
+	if (!terminal) {
+		issues.push({ field: 'episode_trace', reason: 'Episode JSONL must include a terminal grader row.' });
+		return;
+	}
+
+	const rowGrade = row.evaluation?.grade || {};
+	const rowReward = row.evaluation?.outcome?.reward;
+	if (!valuesEqual(terminal.grade?.score, rowGrade.score) || !valuesEqual(terminal.grade?.max_score, rowGrade.max_score) || !valuesEqual(terminal.reward, rowReward)) {
+		issues.push({ field: 'terminal_grade', reason: 'Terminal episode grader row does not match the projected eval row grade/reward.' });
+	}
+}
+
+function validateLocalArtifact(name, reference, resultsPath, hashSources, aliases, issues, options = {}) {
+	const rawPath = referencePath(reference);
+	if (!rawPath) {
+		issues.push({ field: name, reason: `${name} reference is missing.` });
+		return { localPath: '', rows: [] };
+	}
+	if (isRemoteReference(rawPath)) {
+		issues.push({ field: name, reason: `${name} must be a local artifact, not a remote URL.` });
+		return { localPath: '', rows: [] };
+	}
+
+	const localPath = resolveReferencePath(rawPath, resultsPath);
+	if (!fs.existsSync(localPath) || !fs.statSync(localPath).isFile()) {
+		issues.push({ field: name, reason: `${name} local artifact does not exist: ${rawPath}` });
+		return { localPath, rows: [] };
+	}
+
+	const actualSha256 = sha256File(localPath);
+	const referenceHash = reference.sha256 || reference.hash || '';
+	if (referenceHash && !SHA256_PATTERN.test(referenceHash)) {
+		issues.push({ field: name, reason: `${name} hash is not a sha256:<hex> digest.` });
+	} else if (referenceHash && referenceHash !== actualSha256) {
+		issues.push({ field: name, reason: `${name} hash does not match the local artifact.` });
+	} else if (options.requireHash !== false && !referenceHash && !findHash(hashSources, [name, ...aliases], actualSha256)) {
+		issues.push({ field: name, reason: `${name} local artifact is missing a matching sha256 hash.` });
+	}
+
+	return { localPath, rows: [] };
+}
+
+function validateEvalRow(resultsPath, scenario, config) {
+	const issues = [];
+	const row = scenario.metadata?.wp_gym_eval_row;
+	if (!hasObject(row)) {
+		return [{ field: 'wp_gym_eval_row', reason: 'Scenario is missing metadata.wp_gym_eval_row.' }];
+	}
+	if (row.schema_name !== SCHEMA_NAME) {
+		issues.push({ field: 'schema_name', reason: `Expected schema_name ${SCHEMA_NAME}.` });
+	}
+	if (row.status !== 'ready') {
+		issues.push({ field: 'status', reason: 'Projected eval row must be ready before it can be trusted as benchmark evidence.' });
+	}
+	if (Array.isArray(row.compatibility_gaps) && row.compatibility_gaps.length > 0) {
+		issues.push({ field: 'compatibility_gaps', reason: 'Projected eval row still has compatibility gaps.' });
+	}
+
+	const references = row.orchestration?.artifacts?.all_references || {};
+	const replayReference = references.replay_bundle;
+	const replayPath = referencePath(replayReference);
+	let replayBundle = {};
+	if (replayPath && !isRemoteReference(replayPath)) {
+		const localReplayPath = resolveReferencePath(replayPath, resultsPath);
+		if (fs.existsSync(localReplayPath) && fs.statSync(localReplayPath).isFile()) {
+			replayBundle = readJson(localReplayPath);
+		}
+	}
+
+	const sealed = replayBundle.sealed_eval_artifact || scenario.metadata?.replay_bundle?.sealed_eval_artifact || {};
+	const artifactHashes = sealed.hashes?.artifact_hashes || {};
+	const hashSources = [artifactHashes, sealed.hashes || {}, replayBundle.hashes || {}];
+	const requiredArtifacts = [
+		['homeboy_result', references.homeboy_result, ['homeboy_result_json'], { requireHash: false }],
+		['transcript', references.transcript, ['transcript_json', 'transcript_artifact', 'transcript_artifact_json'], {}],
+		['episode_trace', references.episode_trace, ['episode_jsonl', 'runtime_episode_trace'], {}],
+		['replay_bundle', replayReference, ['replay_bundle_artifact'], { requireHash: false }],
+	];
+
+	const localArtifacts = new Map();
+	for (const [name, reference, aliases, options] of requiredArtifacts) {
+		localArtifacts.set(name, validateLocalArtifact(name, reference, resultsPath, hashSources, aliases, issues, options));
+	}
+
+	if (!SHA256_PATTERN.test(sealed.hashes?.envelope || '')) {
+		issues.push({ field: 'replay_bundle', reason: 'Replay bundle must include sealed_eval_artifact.hashes.envelope.' });
+	}
+
+	let episodeRows = [];
+	const episode = localArtifacts.get('episode_trace');
+	if (episode?.localPath && fs.existsSync(episode.localPath)) {
+		episodeRows = validateJsonl(episode.localPath, 'episode_trace', issues);
+	}
+	validateTerminalGrade(row, episodeRows, issues);
+
+	for (const [field, reference] of [
+		['verifier', references.verifier],
+		['policy', references.policy],
+		['grader_result', references.grader_result],
+	]) {
+		if (!hasObject(reference) || reference.available !== true) {
+			issues.push({ field, reason: `${field} evidence reference is missing or unavailable.` });
+		}
+	}
+
+	for (const expected of expectedArtifactNames(scenario, config)) {
+		const name = typeof expected === 'string' ? expected : expected?.name;
+		if (!name) {
+			continue;
+		}
+		const artifact = scenario.artifacts?.[name] || references[name];
+		validateLocalArtifact(`expected_artifacts.${name}`, artifact, resultsPath, hashSources, [name], issues);
+	}
+
+	return issues;
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	for (const required of ['results', 'scenario', 'config']) {
+		if (!args[required]) {
+			usage();
+			throw new Error(`Missing --${required}`);
+		}
+	}
+
+	const results = readJson(args.results);
+	const config = readJson(args.config);
+	const scenario = (results.scenarios || []).find((entry) => entry.id === args.scenario);
+	if (!scenario) {
+		throw new Error(`Scenario not found in results: ${args.scenario}`);
+	}
+
+	const issues = validateEvalRow(args.results, scenario, config);
+	if (issues.length > 0) {
+		console.error(`ERROR: wp-gym live-run eval row validation failed with ${issues.length} issue(s).`);
+		console.error(JSON.stringify(issues, null, 2));
+		process.exit(1);
+	}
+
+	console.log(JSON.stringify({ valid: true, scenario: args.scenario, schema_name: SCHEMA_NAME }, null, 2));
+}
+
+try {
+	main();
+} catch (error) {
+	console.error(`ERROR: ${error.message}`);
+	process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a fail-closed wp-gym live-run eval row validator for Homeboy agent outputs
- validate local required artifacts, artifact hashes, episode JSONL, verifier/policy/grader evidence, and terminal grade agreement
- run the validator automatically for Data Machine agent runs when `wp_gym_eval.benchmark_mode` is enabled

Fixes #812.

## Checks
- `npm run test:validate-wpgym-eval-row`
- `npm run test:project-wpgym-eval-row`
- `npm run test:datamachine-agent-wp-codebox-runner`
- `npm run test:request-profiler`
- `bash scripts/agent/build-replay-bundle-smoke.sh`
- `npm run lint:js -- scripts/agent/build-replay-bundle.js scripts/agent/project-wpgym-eval-row.js scripts/agent/validate-wpgym-eval-row.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the validator, smoke coverage, runner wiring, and local verification; Chris remains responsible for review and merge.
