### PR TITLE
Bound WP Codebox fanout tasks

### DIFF
--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -23,6 +23,7 @@ const PLAN_SCHEMA = 'homeboy/audit-wp-codebox-fanout/v1';
 const TASK_SCHEMA = 'homeboy/wp-codebox-task-request/v1';
 const RUN_SCHEMA = 'homeboy/audit-wp-codebox-run/v1';
 const DEFAULT_CONCURRENCY = 3;
+const DEFAULT_TASK_TIMEOUT_SECONDS = 15 * 60;
 
 function sha256(value) {
   return crypto.createHash('sha256').update(value).digest('hex');
@@ -436,10 +437,12 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
   const args = options.wp_codebox_args || [];
   const requestJson = `${JSON.stringify(taskRequest, null, 2)}\n`;
   const startedAt = new Date().toISOString();
+  const taskTimeoutSeconds = normalizeTaskTimeoutSeconds(options.task_timeout_seconds);
 
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       cwd: options.cwd || process.cwd(),
+      detached: true,
       env: {
         ...process.env,
         ...(options.env || {}),
@@ -452,7 +455,24 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
     let stdout = '';
     let stderr = '';
     let spawnError = null;
+    let timedOut = false;
+    let timeout = null;
+    let forceKillTimeout = null;
+    let killedProcessGroup = false;
+    let forceKilledProcessGroup = false;
     const maxBuffer = options.max_buffer || 1024 * 1024 * 10;
+
+    if (taskTimeoutSeconds > 0) {
+      timeout = setTimeout(() => {
+        timedOut = true;
+        killedProcessGroup = killProcessTree(child, 'SIGTERM');
+        forceKillTimeout = setTimeout(() => {
+          forceKilledProcessGroup = killProcessTree(child, 'SIGKILL');
+        }, 5000);
+        forceKillTimeout.unref?.();
+      }, taskTimeoutSeconds * 1000);
+      timeout.unref?.();
+    }
 
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
@@ -472,12 +492,19 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
       spawnError = error;
     });
     child.on('close', (code, signal) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      if (forceKillTimeout) {
+        clearTimeout(forceKillTimeout);
+      }
       const finishedAt = new Date().toISOString();
       const parsed = tryParseJson(stdout);
       const artifact = parsed && typeof parsed === 'object' && parsed.artifacts ? parsed.artifacts : null;
       const taskFailure = parsed ? wpCodeboxTaskFailure(parsed) : null;
-      const errorMessage = spawnError ? spawnError.message : (taskFailure || '');
-      const success = code === 0 && !spawnError && null === taskFailure;
+      const timeoutError = timedOut ? `WP Codebox task timed out after ${taskTimeoutSeconds} seconds` : '';
+      const errorMessage = timeoutError || (spawnError ? spawnError.message : (taskFailure || ''));
+      const success = code === 0 && !spawnError && null === taskFailure && !timedOut;
 
       resolve({
         schema: RUN_SCHEMA,
@@ -490,6 +517,10 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
           exit_code: code,
           signal: signal || null,
           error: errorMessage,
+          timed_out: timedOut,
+          timeout_seconds: taskTimeoutSeconds,
+          killed_process_group: killedProcessGroup,
+          force_killed_process_group: forceKilledProcessGroup,
         },
         status: success ? 'completed' : 'failed',
         started_at: startedAt,
@@ -506,6 +537,19 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
     });
     child.stdin.end(requestJson);
   });
+}
+
+function killProcessTree(child, signal) {
+  if (!child.pid) {
+    return child.kill(signal);
+  }
+
+  try {
+    process.kill(-child.pid, signal);
+    return true;
+  } catch {
+    return child.kill(signal);
+  }
 }
 
 function wpCodeboxTaskFailure(parsed) {
@@ -626,6 +670,7 @@ function executeAuditWpCodeboxFanoutFromFiles(options) {
     cwd: options.cwd,
     env: options.env,
     concurrency: options.concurrency,
+    task_timeout_seconds: options.taskTimeoutSeconds,
     runsOutputPath: options.runsOutputPath,
     on_progress: options.onProgress,
   });
@@ -637,6 +682,14 @@ function normalizeConcurrency(value) {
     return DEFAULT_CONCURRENCY;
   }
   return Math.min(parsed, 16);
+}
+
+function normalizeTaskTimeoutSeconds(value) {
+  const parsed = Number.parseInt(value || DEFAULT_TASK_TIMEOUT_SECONDS, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_TASK_TIMEOUT_SECONDS;
+  }
+  return parsed;
 }
 
 function runningGroup(taskRequest) {
@@ -671,6 +724,7 @@ module.exports = {
   RUN_SCHEMA,
   TASK_SCHEMA,
   DEFAULT_CONCURRENCY,
+  DEFAULT_TASK_TIMEOUT_SECONDS,
   auditFindings,
   createAuditWpCodeboxFanoutPlan,
   createAuditWpCodeboxFanoutPlanFromFiles,

--- a/wordpress/scripts/agent/homeboy-audit-wp-codebox-fanout.cjs
+++ b/wordpress/scripts/agent/homeboy-audit-wp-codebox-fanout.cjs
@@ -31,7 +31,7 @@ function hasFlag(name) {
 }
 
 function usage() {
-  console.error('Usage: homeboy-audit-wp-codebox-fanout.cjs --audit-report <report.json> [--execute --concurrency <n> --wp-codebox-command <bin> --wp-codebox-arg <arg> --runs-output <run.json>] [--artifact-map <map.json>] [--output <plan.json>] [--issue-url <url>]');
+  console.error('Usage: homeboy-audit-wp-codebox-fanout.cjs --audit-report <report.json> [--execute --concurrency <n> --task-timeout-seconds <n> --wp-codebox-command <bin> --wp-codebox-arg <arg> --runs-output <run.json>] [--artifact-map <map.json>] [--output <plan.json>] [--issue-url <url>]');
   process.exit(1);
 }
 
@@ -77,6 +77,7 @@ async function main() {
     wpCodeboxArgs: argValues('--wp-codebox-arg'),
     runsOutputPath: argValue('--runs-output') || '',
     concurrency: argValue('--concurrency') || undefined,
+    taskTimeoutSeconds: argValue('--task-timeout-seconds') || undefined,
     onProgress: writeProgress,
   }) : createAuditWpCodeboxFanoutPlanFromFiles(options);
 

--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -907,6 +907,8 @@ def refactor_source(data):
         args.extend(['--secret-env', secret_env])
     if settings.get('wp_codebox_concurrency'):
         args.extend(['--concurrency', str(settings['wp_codebox_concurrency'])])
+    if settings.get('wp_codebox_task_timeout_seconds'):
+        args.extend(['--task-timeout-seconds', str(settings['wp_codebox_task_timeout_seconds'])])
 
     if data.get('write'):
         args.append('--execute')

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -109,6 +109,12 @@ process.stdin.setEncoding('utf8');
 process.stdin.on('data', (chunk) => { input += chunk; });
 process.stdin.on('end', () => {
   const request = JSON.parse(input);
+  if (process.env.FIXTURE_HANG_GROUP === request.group_key) {
+    process.stdout.write('fixture partial stdout before timeout\\n');
+    process.stderr.write('fixture partial stderr before timeout\\n');
+    setInterval(() => {}, 1000);
+    return;
+  }
   if (request.group_key === 'docs-reference') {
     if (process.env.FIXTURE_EXPECT_INCREMENTAL_RUN) {
       const run = JSON.parse(fs.readFileSync(process.env.FIXTURE_EXPECT_INCREMENTAL_RUN, 'utf8'));
@@ -352,6 +358,34 @@ try {
   assert.equal(nestedFailedRecord.command.exit_code, 0);
   assert.match(nestedFailedRecord.command.error, /Fixture nested WP error/);
 
+  const timeoutRunsOutputPath = path.join(root, 'fanout-timeout-run.json');
+  const timeoutExecution = await executeAuditWpCodeboxFanout({
+    report,
+    wp_codebox_command: process.execPath,
+    wp_codebox_args: [fixtureCommand],
+    concurrency: 1,
+    task_timeout_seconds: 1,
+    runsOutputPath: timeoutRunsOutputPath,
+    env: { FIXTURE_HANG_GROUP: 'PHPCS Formatting/Auto Fix!' },
+  });
+  assert.equal(timeoutExecution.status, 'failed');
+  assert.equal(timeoutExecution.records.length, 2);
+  const timeoutRecord = timeoutExecution.records.find((record) => record.group_key === 'PHPCS Formatting/Auto Fix!');
+  assert.equal(timeoutRecord.status, 'failed');
+  assert.equal(timeoutRecord.command.timed_out, true);
+  assert.equal(timeoutRecord.command.timeout_seconds, 1);
+  assert.equal(timeoutRecord.command.killed_process_group, true);
+  assert.match(timeoutRecord.command.error, /timed out after 1 seconds/);
+  assert.match(timeoutRecord.stdout, /fixture partial stdout before timeout/);
+  assert.match(timeoutRecord.stderr, /fixture partial stderr before timeout/);
+  const timeoutFollowupRecord = timeoutExecution.records.find((record) => record.group_key === 'docs-reference');
+  assert.equal(timeoutFollowupRecord.status, 'failed');
+  assert.equal(timeoutFollowupRecord.command.exit_code, 3);
+  const timeoutFinalRun = readJson(timeoutRunsOutputPath);
+  assert.equal(timeoutFinalRun.status, 'failed');
+  assert.equal(timeoutFinalRun.records.length, 2);
+  assert.equal(Object.hasOwn(timeoutFinalRun, 'current_group'), false);
+
   const runsOutputPath = path.join(root, 'fanout-run.json');
   const fileExecution = await executeAuditWpCodeboxFanoutFromFiles({
     auditReportPath,
@@ -380,6 +414,8 @@ try {
     process.execPath,
     '--wp-codebox-arg',
     fixtureCommand,
+    '--task-timeout-seconds',
+    '2',
     '--secret-env',
     'FIXTURE_SECRET_TOKEN',
   ], { encoding: 'utf8' });

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -119,6 +119,7 @@ process.stdout.write(JSON.stringify({
       wp_codebox_agents_api_path: path.join(root, 'agents-api'),
       wp_codebox_data_machine_path: path.join(root, 'data-machine'),
       wp_codebox_data_machine_code_path: path.join(root, 'data-machine-code'),
+      wp_codebox_task_timeout_seconds: 2,
     },
   };
   fs.mkdirSync(writeCommand.settings.wp_codebox_agents_api_path, { recursive: true });
@@ -148,6 +149,7 @@ process.stdout.write(JSON.stringify({
   const run = JSON.parse(fs.readFileSync(path.join(writeOutputDir, 'fanout-run.json'), 'utf8'));
   assert.equal(run.status, 'completed');
   assert.equal(run.records[0].command.bin, 'node');
+  assert.equal(run.records[0].command.timeout_seconds, 2);
   assert.match(run.records[0].command.args[0], /homeboy-wp-codebox-task-runner\.cjs$/);
   assert.equal(run.records[0].command.args.includes('--wp-codebox-bin'), true);
   const artifactsIndex = run.records[0].command.args.indexOf('--artifacts');


### PR DESCRIPTION
## Summary
- Add a conservative 15-minute default per-task timeout for WP Codebox audit fanout task execution.
- Wire CLI support via `--task-timeout-seconds` and refactor settings via `wp_codebox_task_timeout_seconds`.
- Kill timed-out child process groups with SIGTERM and a SIGKILL fallback, record explicit timeout metadata, preserve captured stdout/stderr, and continue fanout records.
- Add smoke coverage for a hanging task that is killed and recorded as a timeout.

Fixes #814.

## Tests
- `node wordpress/tests/audit-wp-codebox-fanout-smoke.js`
- `node wordpress/tests/refactor-source-wp-codebox-smoke.js`
- `python3 -m py_compile wordpress/scripts/refactor.py`
- `git diff --check`
- `./node_modules/.bin/eslint lib/audit-wp-codebox-fanout.js scripts/agent/homeboy-audit-wp-codebox-fanout.cjs` from `wordpress/`

## Lint note
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-wp-codebox-task-timeout --extension wordpress --force-hot` was run. The full repo lint remains red on existing PHP/fixture findings outside this change.
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-wp-codebox-task-timeout --extension wordpress --force-hot --changed-only` currently hits an ESLint plugin resolution conflict between the primary checkout and this worktree's `wordpress/node_modules`; Homeboy reports no lint findings, but ESLint prints the duplicate `@typescript-eslint` plugin error before exiting.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the timeout implementation, CLI/settings wiring, smoke coverage, and local validation commands for Chris to review.