### PR TITLE
fix: prepare cloned WordPress validation dependencies

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -223,6 +223,7 @@ _homeboy_clone_dependency() {
     fi
 
     if git clone --depth 1 --quiet "$repo_url" "$clone_path" 2>/dev/null; then
+        _homeboy_prepare_cloned_dependency "$slug" "$clone_path"
         printf '%s\n' "$clone_path"
         return 0
     fi
@@ -230,6 +231,28 @@ _homeboy_clone_dependency() {
     # Clone failed — clean up partial clone
     rm -rf "$clone_path" 2>/dev/null || true
     return 1
+}
+
+_homeboy_prepare_cloned_dependency() {
+    local slug="${1:-}"
+    local clone_path="${2:-}"
+
+    [ -n "$clone_path" ] && [ -d "$clone_path" ] || return 0
+    [ -f "${clone_path}/composer.json" ] || return 0
+    [ ! -f "${clone_path}/vendor/autoload.php" ] || return 0
+
+    if ! command -v composer >/dev/null 2>&1; then
+        echo "Warning: Cloned validation dependency '${slug}' has composer.json but composer is not available; dependency may fail to bootstrap." >&2
+        return 0
+    fi
+
+    if [ "${HOMEBOY_SUPPRESS_DEPENDENCY_RESOLUTION_LOG:-}" != "1" ]; then
+        echo "Preparing cloned validation dependency '${slug}' with composer install." >&2
+    fi
+
+    if ! ( cd "$clone_path" && composer install --no-interaction --prefer-dist >/dev/null ); then
+        echo "Warning: composer install failed for cloned validation dependency '${slug}' at ${clone_path}; dependency may fail to bootstrap." >&2
+    fi
 }
 
 _homeboy_known_dependency_github_org() {

--- a/wordpress/tests/validation-dependencies-smoke.sh
+++ b/wordpress/tests/validation-dependencies-smoke.sh
@@ -129,6 +129,9 @@ if [ "${1:-}" = "clone" ]; then
  * Plugin Name: Data Machine
  */
 PHP
+            cat > "${clone_path}/composer.json" <<'JSON'
+{"require": {}}
+JSON
             exit 0
             ;;
     esac
@@ -137,6 +140,20 @@ fi
 exit 1
 SH
 chmod +x "${CLONE_BIN_DIR}/git"
+
+cat > "${CLONE_BIN_DIR}/composer" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "install" ]; then
+    mkdir -p vendor
+    printf '%s\n' '<?php // fake autoload' > vendor/autoload.php
+    exit 0
+fi
+
+exit 1
+SH
+chmod +x "${CLONE_BIN_DIR}/composer"
 
 source "$HELPER"
 
@@ -177,6 +194,11 @@ fallback_data_machine="${FALLBACK_CACHE_DIR}/homeboy-deps/data-machine"
 if ! grep -F -- "$fallback_data_machine" <<< "$fallback_resolved" >/dev/null; then
     echo "FAIL: data-machine dependency should resolve from Extra-Chill/data-machine" >&2
     printf '%s\n' "$fallback_resolved" >&2
+    exit 1
+fi
+
+if [ ! -f "${fallback_data_machine}/vendor/autoload.php" ]; then
+    echo "FAIL: cloned composer dependency was not prepared before mounting" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- run Composer install for git-cloned WordPress validation dependencies before mounting them into WP Codebox
- cover the cloned data-machine dependency path in the validation dependency smoke test

## Verification
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-dependency-composer-install/wordpress --extension nodejs --changed-since origin/main --force-hot`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-dependency-composer-install/wordpress --extension nodejs --changed-since origin/main --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WP Codebox validation dependency bootstrap failure, drafted the shell fix and smoke coverage, and ran local verification.