### PR TITLE
Fix WP Codebox audit fanout per finding

### DIFF
--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -23,6 +23,7 @@ const PLAN_SCHEMA = 'homeboy/audit-wp-codebox-fanout/v1';
 const TASK_SCHEMA = 'homeboy/wp-codebox-task-request/v1';
 const RUN_SCHEMA = 'homeboy/audit-wp-codebox-run/v1';
 const DEFAULT_CONCURRENCY = 3;
+const DEFAULT_TASK_TIMEOUT_SECONDS = 60 * 60 * 2;
 
 function sha256(value) {
   return crypto.createHash('sha256').update(value).digest('hex');
@@ -102,19 +103,10 @@ function normalizeFinding(finding, index) {
 }
 
 function groupFindings(findings) {
-  const groupsByKey = new Map();
-  for (const finding of findings) {
-    const key = finding.fix_batch_key || finding.kind;
-    if (!groupsByKey.has(key)) {
-      groupsByKey.set(key, []);
-    }
-    groupsByKey.get(key).push(finding);
-  }
-
-  return Array.from(groupsByKey.entries()).map(([key, groupedFindings], index) => ({
-    key,
+  return findings.map((finding, index) => ({
+    key: finding.id || finding.fingerprint || `${finding.kind}-${index + 1}`,
     index,
-    findings: groupedFindings,
+    findings: [finding],
   }));
 }
 
@@ -128,14 +120,16 @@ function sandboxSessionId(orchestrator, group) {
 }
 
 function taskPrompt(group) {
-  const findingList = group.findings
-    .map((finding) => `- ${finding.id}: ${finding.kind} in ${finding.file}${finding.line ? `:${finding.line}` : ''}`)
-    .join('\n');
+  const finding = group.findings[0] || {};
+  const location = `${finding.file || 'unknown file'}${finding.line ? `:${finding.line}` : ''}`;
 
   return [
-    `Fix the grouped Homeboy audit findings for batch ${group.key}.`,
-    'Return a WP Codebox artifact bundle with changed-files, patch, and review metadata.',
-    findingList,
+    `Fix Homeboy audit finding ${finding.id || group.key}.`,
+    `Finding: ${finding.kind || 'unknown'} in ${location}`,
+    finding.message ? `Message: ${finding.message}` : '',
+    'Expected outcome: open a PR that fixes this finding.',
+    'If the finding is a false positive, fix the audit detector/config/test path that produced it and open a PR for that correction instead.',
+    'Return the session id, PR URL, and whether the PR fixes the finding or fixes the false-positive source. If the runtime produces a WP Codebox artifact bundle, include changed-files, patch, and review metadata.',
   ].join('\n\n');
 }
 
@@ -152,6 +146,7 @@ function createTaskRequest(group, orchestrator) {
       source: 'homeboy audit',
       issue_url: orchestrator.issue_url || '',
       group_index: group.index,
+      finding_index: group.index,
     },
     audit_findings: group.findings.map((finding) => ({
       id: finding.id,
@@ -163,7 +158,7 @@ function createTaskRequest(group, orchestrator) {
       severity: finding.severity,
     })),
     task: {
-      title: `Fix Homeboy audit batch ${group.key}`,
+      title: `Fix Homeboy audit finding ${group.findings[0]?.id || group.key}`,
       prompt: taskPrompt(group),
     },
   };
@@ -215,7 +210,7 @@ function createApplyBackMetadata(taskRequest, artifactEntry, options) {
     artifact_content_digest: artifactEntry.artifact_content_digest,
   });
   const branch = artifactEntry.branch || `${options.branch_prefix || 'fix/homeboy-audit'}/${safeBranchSlug(taskRequest.group_key)}`;
-  const title = artifactEntry.pr_title || `Fix Homeboy audit batch ${taskRequest.group_key}`;
+  const title = artifactEntry.pr_title || `Fix Homeboy audit finding ${taskRequest.group_key}`;
   const issueUrl = options.issue_url || taskRequest.orchestrator.issue_url || '';
 
   return {
@@ -254,7 +249,7 @@ function createApplyBackMetadata(taskRequest, artifactEntry, options) {
       body: [
         issueUrl ? `Closes ${issueUrl}` : '',
         '',
-        `Applies WP Codebox artifact ${verified.artifactId} for Homeboy audit batch ${taskRequest.group_key}.`,
+        `Applies WP Codebox artifact ${verified.artifactId} for Homeboy audit finding ${taskRequest.group_key}.`,
       ].filter(Boolean).join('\n'),
       labels: artifactEntry.labels || ['homeboy-audit', 'wp-codebox'],
     },
@@ -302,6 +297,59 @@ function createIssueReport(taskRequest, artifactEntry, options) {
       labels: artifactEntry.labels || ['homeboy-audit', 'wp-codebox', disposition],
     },
   };
+}
+
+function normalizeTaskOutcome(parsed, taskRequest, artifact) {
+  const pullRequest = parsed?.pull_request || parsed?.pr || parsed?.result?.pull_request || null;
+  const falsePositive = parsed?.false_positive || parsed?.result?.false_positive || null;
+  const disposition = parsed?.disposition || parsed?.result?.disposition || inferredDisposition({
+    falsePositive,
+    pullRequest,
+    artifact,
+  });
+  const prUrl = stringValue(
+    parsed?.pull_request_url
+    || parsed?.pr_url
+    || parsed?.result?.pull_request_url
+    || parsed?.result?.pr_url
+    || pullRequest?.url
+    || pullRequest?.html_url
+  );
+  const falsePositivePrUrl = stringValue(
+    parsed?.false_positive_pr_url
+    || parsed?.result?.false_positive_pr_url
+    || falsePositive?.pull_request_url
+    || falsePositive?.pr_url
+    || falsePositive?.pull_request?.url
+    || falsePositive?.pull_request?.html_url
+  );
+
+  return {
+    finding_id: taskRequest.audit_findings[0]?.id || '',
+    disposition,
+    session_id: stringValue(parsed?.session?.id || parsed?.session_id || taskRequest.sandbox_session_id),
+    pr_url: prUrl,
+    false_positive_pr_url: falsePositivePrUrl,
+    artifact_id: artifact?.id || '',
+    report: stringValue(parsed?.report || parsed?.summary || parsed?.result?.report || parsed?.result?.summary),
+  };
+}
+
+function stringValue(value) {
+  return typeof value === 'string' ? value : '';
+}
+
+function inferredDisposition({ falsePositive, pullRequest, artifact }) {
+  if (falsePositive) {
+    return 'false_positive_fix_pr';
+  }
+  if (pullRequest) {
+    return 'fix_pr';
+  }
+  if (artifact) {
+    return 'artifact';
+  }
+  return 'unknown';
 }
 
 function createAuditWpCodeboxFanoutPlan(input) {
@@ -418,6 +466,7 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
       error: result.error ? result.error.message : (taskFailure || ''),
     },
     status: success ? 'completed' : 'failed',
+    outcome: normalizeTaskOutcome(parsed, taskRequest, artifact),
     started_at: startedAt,
     finished_at: finishedAt,
     stdout,
@@ -438,6 +487,8 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
   const startedAt = new Date().toISOString();
 
   return new Promise((resolve) => {
+    const timeoutMs = normalizeTaskTimeoutMs(options.task_timeout_seconds ?? options.taskTimeoutSeconds);
+    let timedOut = false;
     const child = spawn(command, args, {
       cwd: options.cwd || process.cwd(),
       env: {
@@ -453,6 +504,14 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
     let stderr = '';
     let spawnError = null;
     const maxBuffer = options.max_buffer || 1024 * 1024 * 10;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      setTimeout(() => {
+        child.kill('SIGKILL');
+      }, 5000).unref();
+    }, timeoutMs);
+    timeout.unref();
 
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
@@ -472,12 +531,16 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
       spawnError = error;
     });
     child.on('close', (code, signal) => {
+      clearTimeout(timeout);
       const finishedAt = new Date().toISOString();
       const parsed = tryParseJson(stdout);
       const artifact = parsed && typeof parsed === 'object' && parsed.artifacts ? parsed.artifacts : null;
       const taskFailure = parsed ? wpCodeboxTaskFailure(parsed) : null;
-      const errorMessage = spawnError ? spawnError.message : (taskFailure || '');
-      const success = code === 0 && !spawnError && null === taskFailure;
+      const timeoutMessage = timedOut ? `WP Codebox task timed out after ${Math.round(timeoutMs / 1000)}s` : '';
+      const errorMessage = timeoutMessage || (spawnError ? spawnError.message : (taskFailure || ''));
+      const success = code === 0 && !spawnError && null === taskFailure && !timedOut;
+
+      const status = timedOut ? 'timeout' : statusForSuccess(success);
 
       resolve({
         schema: RUN_SCHEMA,
@@ -491,7 +554,8 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
           signal: signal || null,
           error: errorMessage,
         },
-        status: success ? 'completed' : 'failed',
+        status,
+        outcome: normalizeTaskOutcome(parsed, taskRequest, artifact),
         started_at: startedAt,
         finished_at: finishedAt,
         stdout,
@@ -506,6 +570,10 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
     });
     child.stdin.end(requestJson);
   });
+}
+
+function statusForSuccess(success) {
+  return success ? 'completed' : 'failed';
 }
 
 function wpCodeboxTaskFailure(parsed) {
@@ -610,6 +678,15 @@ async function executeAuditWpCodeboxFanout(input) {
     ...baseRun,
     records,
     status: records.every((record) => record.status === 'completed') ? 'completed' : 'failed',
+    outcomes: records.map((record) => ({
+      finding_id: record.outcome?.finding_id || record.finding_ids?.[0] || '',
+      sandbox_session_id: record.sandbox_session_id,
+      status: record.status,
+      pr_url: record.outcome?.pr_url || '',
+      false_positive_pr_url: record.outcome?.false_positive_pr_url || '',
+      artifact_id: record.outcome?.artifact_id || '',
+      error: record.command?.error || '',
+    })),
   };
 
   writeRun(run);
@@ -626,6 +703,7 @@ function executeAuditWpCodeboxFanoutFromFiles(options) {
     cwd: options.cwd,
     env: options.env,
     concurrency: options.concurrency,
+    task_timeout_seconds: options.taskTimeoutSeconds,
     runsOutputPath: options.runsOutputPath,
     on_progress: options.onProgress,
   });
@@ -637,6 +715,14 @@ function normalizeConcurrency(value) {
     return DEFAULT_CONCURRENCY;
   }
   return Math.min(parsed, 16);
+}
+
+function normalizeTaskTimeoutMs(value) {
+  const parsed = Number.parseInt(value || DEFAULT_TASK_TIMEOUT_SECONDS, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_TASK_TIMEOUT_SECONDS * 1000;
+  }
+  return parsed * 1000;
 }
 
 function runningGroup(taskRequest) {
@@ -671,6 +757,7 @@ module.exports = {
   RUN_SCHEMA,
   TASK_SCHEMA,
   DEFAULT_CONCURRENCY,
+  DEFAULT_TASK_TIMEOUT_SECONDS,
   auditFindings,
   createAuditWpCodeboxFanoutPlan,
   createAuditWpCodeboxFanoutPlanFromFiles,

--- a/wordpress/scripts/agent/homeboy-audit-wp-codebox-fanout.cjs
+++ b/wordpress/scripts/agent/homeboy-audit-wp-codebox-fanout.cjs
@@ -31,7 +31,7 @@ function hasFlag(name) {
 }
 
 function usage() {
-  console.error('Usage: homeboy-audit-wp-codebox-fanout.cjs --audit-report <report.json> [--execute --concurrency <n> --wp-codebox-command <bin> --wp-codebox-arg <arg> --runs-output <run.json>] [--artifact-map <map.json>] [--output <plan.json>] [--issue-url <url>]');
+  console.error('Usage: homeboy-audit-wp-codebox-fanout.cjs --audit-report <report.json> [--execute --concurrency <n> --task-timeout-seconds <seconds> --wp-codebox-command <bin> --wp-codebox-arg <arg> --runs-output <run.json>] [--artifact-map <map.json>] [--output <plan.json>] [--issue-url <url>]');
   process.exit(1);
 }
 
@@ -77,6 +77,7 @@ async function main() {
     wpCodeboxArgs: argValues('--wp-codebox-arg'),
     runsOutputPath: argValue('--runs-output') || '',
     concurrency: argValue('--concurrency') || undefined,
+    taskTimeoutSeconds: argValue('--task-timeout-seconds') || undefined,
     onProgress: writeProgress,
   }) : createAuditWpCodeboxFanoutPlanFromFiles(options);
 

--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -907,6 +907,8 @@ def refactor_source(data):
         args.extend(['--secret-env', secret_env])
     if settings.get('wp_codebox_concurrency'):
         args.extend(['--concurrency', str(settings['wp_codebox_concurrency'])])
+    if settings.get('wp_codebox_task_timeout_seconds'):
+        args.extend(['--task-timeout-seconds', str(settings['wp_codebox_task_timeout_seconds'])])
 
     if data.get('write'):
         args.append('--execute')

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -109,10 +109,14 @@ process.stdin.setEncoding('utf8');
 process.stdin.on('data', (chunk) => { input += chunk; });
 process.stdin.on('end', () => {
   const request = JSON.parse(input);
-  if (request.group_key === 'docs-reference') {
+  if (request.group_key === 'finding-doc-001') {
+    if (process.env.FIXTURE_SLEEP) {
+      setTimeout(() => {}, 10000);
+      return;
+    }
     if (process.env.FIXTURE_EXPECT_INCREMENTAL_RUN) {
       const run = JSON.parse(fs.readFileSync(process.env.FIXTURE_EXPECT_INCREMENTAL_RUN, 'utf8'));
-      if (run.status !== 'incomplete' || run.records.length !== 1 || !run.current_group || run.current_group.group_key !== request.group_key) {
+      if (run.status !== 'incomplete' || run.records.length !== 2 || !run.current_group || run.current_group.group_key !== request.group_key) {
         process.stderr.write('fixture incremental fanout-run summary missing expected partial state\\n');
         process.exit(4);
       }
@@ -169,8 +173,8 @@ try {
   });
   assert.equal(initialPlan.schema, 'homeboy/audit-wp-codebox-fanout/v1');
   assert.equal(initialPlan.audit.finding_count, 3);
-  assert.equal(initialPlan.audit.group_count, 2);
-  assert.equal(initialPlan.task_requests.length, 2);
+  assert.equal(initialPlan.audit.group_count, 3);
+  assert.equal(initialPlan.task_requests.length, 3);
 
   assert.equal(safeBranchSlug('PHPCS Formatting/Auto Fix!'), 'phpcs-formatting-auto-fix');
   assert.equal(safeBranchSlug('foo..bar'), 'foo-bar');
@@ -178,9 +182,11 @@ try {
   assert.equal(safeBranchSlug('foo/bar.lock'), 'foo-bar-lock');
   assert.equal(safeBranchSlug('../.@{'), 'audit-batch');
 
-  const phpcsRequest = initialPlan.task_requests.find((request) => request.group_key === 'PHPCS Formatting/Auto Fix!');
-  const docsRequest = initialPlan.task_requests.find((request) => request.group_key === 'docs-reference');
-  assert.equal(phpcsRequest.audit_findings.length, 2);
+  const phpcsRequest = initialPlan.task_requests.find((request) => request.group_key === 'finding-phpcs-001');
+  const secondPhpcsRequest = initialPlan.task_requests.find((request) => request.group_key === 'finding-phpcs-002');
+  const docsRequest = initialPlan.task_requests.find((request) => request.group_key === 'finding-doc-001');
+  assert.equal(phpcsRequest.audit_findings.length, 1);
+  assert.equal(secondPhpcsRequest.audit_findings.length, 1);
   assert.equal(docsRequest.audit_findings.length, 1);
   assert.match(phpcsRequest.sandbox_session_id, /^homeboy-audit-[a-f0-9]{16}$/);
   assert.equal(phpcsRequest.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/769');
@@ -189,6 +195,7 @@ try {
   assert.deepEqual(phpcsRequest.provider_plugin_paths, ['/opt/ai-provider-for-openai']);
   assert.deepEqual(phpcsRequest.secret_env, ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN']);
   assert.match(phpcsRequest.task.prompt, /finding-phpcs-001/);
+  assert.match(phpcsRequest.task.prompt, /false positive/);
 
   const phpcsBundle = createBundle(
     root,
@@ -203,14 +210,21 @@ try {
     'docs/setup.md'
   );
   const artifactMap = {
-    'PHPCS Formatting/Auto Fix!': {
+    'finding-phpcs-001': {
       bundle_path: phpcsBundle.bundle,
       approved_files: [phpcsBundle.changedPath],
       reviewed_at: '2026-05-25T00:00:00.000Z',
       reviewer: 'homeboy-review-fixture',
       base: 'main',
     },
-    'docs-reference': {
+    'finding-phpcs-002': {
+      bundle_path: phpcsBundle.bundle,
+      approved_files: [phpcsBundle.changedPath],
+      reviewed_at: '2026-05-25T00:00:00.000Z',
+      reviewer: 'homeboy-review-fixture',
+      base: 'main',
+    },
+    'finding-doc-001': {
       bundle_path: docsBundle.bundle,
       approved_files: [docsBundle.changedPath],
       reviewed_at: '2026-05-25T00:00:00.000Z',
@@ -224,24 +238,24 @@ try {
     artifact_map: artifactMap,
     issue_url: 'https://github.com/Extra-Chill/homeboy-extensions/issues/769',
   });
-  assert.equal(plan.apply_back.length, 2);
+  assert.equal(plan.apply_back.length, 3);
 
-  const phpcsApplyBack = plan.apply_back.find((entry) => entry.group_key === 'PHPCS Formatting/Auto Fix!');
+  const phpcsApplyBack = plan.apply_back.find((entry) => entry.group_key === 'finding-phpcs-001');
   assert.equal(phpcsApplyBack.adapter_id, 'homeboy/wp-codebox-apply-adapter/v1');
   assert.equal(phpcsApplyBack.sandbox_session_id, phpcsRequest.sandbox_session_id);
-  assert.deepEqual(phpcsApplyBack.finding_ids, ['finding-phpcs-001', 'finding-phpcs-002']);
+  assert.deepEqual(phpcsApplyBack.finding_ids, ['finding-phpcs-001']);
   assert.equal(phpcsApplyBack.artifact.id, phpcsBundle.artifactId);
   assert.equal(phpcsApplyBack.artifact.content_digest, phpcsBundle.contentDigest);
   assert.equal(phpcsApplyBack.artifact.patch_sha256, phpcsBundle.patchSha256);
   assert.deepEqual(phpcsApplyBack.review.approved_files, [phpcsBundle.changedPath]);
   assert.equal(phpcsApplyBack.adapter_payload.bundlePath, fs.realpathSync(phpcsBundle.bundle));
-  assert.equal(phpcsApplyBack.adapter_payload.branch, 'fix/homeboy-audit/phpcs-formatting-auto-fix');
+  assert.equal(phpcsApplyBack.adapter_payload.branch, 'fix/homeboy-audit/finding-phpcs-001');
   assert.equal(phpcsApplyBack.pull_request.base, 'main');
-  assert.equal(phpcsApplyBack.pull_request.head, 'fix/homeboy-audit/phpcs-formatting-auto-fix');
+  assert.equal(phpcsApplyBack.pull_request.head, 'fix/homeboy-audit/finding-phpcs-001');
   assert.match(phpcsApplyBack.pull_request.body, /Extra-Chill\/homeboy-extensions\/issues\/769/);
 
   const missingApprovalMap = {
-    'PHPCS Formatting/Auto Fix!': {
+    'finding-phpcs-001': {
       bundle_path: phpcsBundle.bundle,
     },
   };
@@ -258,7 +272,7 @@ try {
     issue_url: 'https://github.com/Extra-Chill/homeboy-extensions/issues/769',
     artifact_map: {
       ...artifactMap,
-      'docs-reference': {
+      'finding-doc-001': {
         bundle_path: docsBundle.bundle,
         approved_files: [docsBundle.changedPath],
         approved: false,
@@ -267,11 +281,11 @@ try {
       },
     },
   });
-  assert.equal(rejectedPlan.apply_back.length, 1);
-  assert.equal(rejectedPlan.apply_back[0].group_key, 'PHPCS Formatting/Auto Fix!');
+  assert.equal(rejectedPlan.apply_back.length, 2);
+  assert.equal(rejectedPlan.apply_back[0].group_key, 'finding-phpcs-001');
   assert.equal(rejectedPlan.issue_reports.length, 1);
   assert.equal(rejectedPlan.issue_reports[0].schema, 'homeboy/audit-wp-codebox-issue-report/v1');
-  assert.equal(rejectedPlan.issue_reports[0].group_key, 'docs-reference');
+  assert.equal(rejectedPlan.issue_reports[0].group_key, 'finding-doc-001');
   assert.equal(rejectedPlan.issue_reports[0].disposition, 'false_positive');
   assert.deepEqual(rejectedPlan.issue_reports[0].finding_ids, ['finding-doc-001']);
   assert.equal(rejectedPlan.issue_reports[0].artifact.id, docsBundle.artifactId);
@@ -292,8 +306,8 @@ try {
     providerPluginPaths: ['/opt/ai-provider-for-openai'],
     secretEnv: ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN'],
   });
-  assert.equal(filePlan.apply_back.length, 2);
-  assert.equal(readJson(outputPath).apply_back.length, 2);
+  assert.equal(filePlan.apply_back.length, 3);
+  assert.equal(readJson(outputPath).apply_back.length, 3);
 
   const cliOutput = run(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-audit-wp-codebox-fanout.cjs'),
@@ -313,8 +327,8 @@ try {
     'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
   ]);
   const cliPlan = JSON.parse(cliOutput);
-  assert.equal(cliPlan.task_requests.length, 2);
-  assert.equal(cliPlan.apply_back.length, 2);
+  assert.equal(cliPlan.task_requests.length, 3);
+  assert.equal(cliPlan.apply_back.length, 3);
   assert.equal(cliPlan.task_requests[0].provider, 'codex');
 
   const fixtureCommand = createWpCodeboxFixtureCommand(root);
@@ -327,15 +341,17 @@ try {
     wp_codebox_args: [fixtureCommand],
   });
   assert.equal(execution.schema, 'homeboy/audit-wp-codebox-execution/v1');
-  assert.equal(execution.records.length, 2);
+  assert.equal(execution.records.length, 3);
   assert.equal(execution.status, 'failed');
-  const completedRecord = execution.records.find((record) => record.group_key === 'PHPCS Formatting/Auto Fix!');
-  const failedRecord = execution.records.find((record) => record.group_key === 'docs-reference');
+  const completedRecord = execution.records.find((record) => record.group_key === 'finding-phpcs-001');
+  const failedRecord = execution.records.find((record) => record.group_key === 'finding-doc-001');
   assert.equal(completedRecord.status, 'completed');
   assert.equal(completedRecord.command.bin, process.execPath);
   assert.equal(completedRecord.result.session.id, completedRecord.sandbox_session_id);
   assert.equal(completedRecord.result.session.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/773');
   assert.match(completedRecord.artifact.id, /^artifact-homeboy-audit-/);
+  assert.equal(completedRecord.outcome.finding_id, 'finding-phpcs-001');
+  assert.equal(execution.outcomes.length, 3);
   assert.equal(failedRecord.status, 'failed');
   assert.equal(failedRecord.command.exit_code, 3);
   assert.match(failedRecord.stderr, /fixture docs-reference failure/);
@@ -346,11 +362,23 @@ try {
     wp_codebox_args: [fixtureCommand],
     env: { FIXTURE_NESTED_WP_ERROR: '1' },
   });
-  const nestedFailedRecord = nestedErrorExecution.records.find((record) => record.group_key === 'docs-reference');
+  const nestedFailedRecord = nestedErrorExecution.records.find((record) => record.group_key === 'finding-doc-001');
   assert.equal(nestedErrorExecution.status, 'failed');
   assert.equal(nestedFailedRecord.status, 'failed');
   assert.equal(nestedFailedRecord.command.exit_code, 0);
   assert.match(nestedFailedRecord.command.error, /Fixture nested WP error/);
+
+  const timeoutExecution = await executeAuditWpCodeboxFanout({
+    report,
+    wp_codebox_command: process.execPath,
+    wp_codebox_args: [fixtureCommand],
+    task_timeout_seconds: 1,
+    env: { FIXTURE_SLEEP: '1' },
+  });
+  const timeoutRecord = timeoutExecution.records.find((record) => record.group_key === 'finding-doc-001');
+  assert.equal(timeoutExecution.status, 'failed');
+  assert.equal(timeoutRecord.status, 'timeout');
+  assert.match(timeoutRecord.command.error, /timed out after 1s/);
 
   const runsOutputPath = path.join(root, 'fanout-run.json');
   const fileExecution = await executeAuditWpCodeboxFanoutFromFiles({
@@ -364,9 +392,9 @@ try {
       FIXTURE_EXPECT_INCREMENTAL_RUN: runsOutputPath,
     },
   });
-  assert.equal(fileExecution.records.length, 2);
+  assert.equal(fileExecution.records.length, 3);
   const finalRun = readJson(runsOutputPath);
-  assert.equal(finalRun.records.length, 2);
+  assert.equal(finalRun.records.length, 3);
   assert.equal(Object.hasOwn(finalRun, 'current_group'), false);
 
   const cliExecutionResult = spawnSync(process.execPath, [
@@ -385,11 +413,11 @@ try {
   ], { encoding: 'utf8' });
   assert.equal(cliExecutionResult.status, 0, cliExecutionResult.stderr || cliExecutionResult.stdout);
   const cliExecution = JSON.parse(cliExecutionResult.stdout);
-  assert.equal(cliExecution.records.length, 2);
+  assert.equal(cliExecution.records.length, 3);
   assert.equal(cliExecution.records[0].schema, 'homeboy/audit-wp-codebox-run/v1');
-  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-/);
-  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] completed 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-.*artifact=\/tmp\/homeboy-audit-/);
-  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] failed 2\/2 group=docs-reference session=homeboy-audit-/);
+  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/3 group=finding-phpcs-001 session=homeboy-audit-/);
+  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] completed 1\/3 group=finding-phpcs-001 session=homeboy-audit-.*artifact=\/tmp\/homeboy-audit-/);
+  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] failed 3\/3 group=finding-doc-001 session=homeboy-audit-/);
   assert.doesNotMatch(cliExecutionResult.stderr, /FIXTURE_SECRET_TOKEN/);
 
   console.log('Homeboy audit WP Codebox fanout smoke passed');

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -46,14 +46,14 @@ try {
   assert.equal(response.handled, true);
   assert.equal(response.detected_findings, 3);
   assert.equal(response.changed_files.length, 0);
-  assert.equal(response.fix_results.length, 2);
+  assert.equal(response.fix_results.length, 3);
   assert.equal(response.fix_results[0].rule, 'wp_codebox.audit_fanout');
   assert.equal(response.fix_results[0].primitive, 'extension_refactor_source');
   assert.match(response.warnings[0], /fanout-plan\.json/);
 
   const plan = JSON.parse(fs.readFileSync(path.join(outputDir, 'fanout-plan.json'), 'utf8'));
   assert.equal(plan.schema, 'homeboy/audit-wp-codebox-fanout/v1');
-  assert.equal(plan.task_requests.length, 2);
+  assert.equal(plan.task_requests.length, 3);
   assert.equal(plan.task_requests[0].provider, 'opencode');
   assert.equal(plan.task_requests[0].model, 'opencode-go/kimi-k2.6');
   assert.deepEqual(plan.task_requests[0].provider_plugin_paths, ['/plugins/ai-provider-for-opencode']);
@@ -73,7 +73,7 @@ const stepArgs = recipe.workflow.steps[0].args;
 const task = JSON.parse(stepArgs.find((arg) => arg.startsWith('task=')).slice('task='.length));
 const sessionId = task.sandbox_session_id;
 const artifactDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'fixture-wp-codebox-artifact-'));
-if (task.group_key === 'PHPCS Formatting/Auto Fix!') {
+if (task.group_key === 'finding-phpcs-001') {
   const filesDirectory = path.join(artifactDirectory, 'files');
   fs.mkdirSync(filesDirectory, { recursive: true });
   fs.writeFileSync(path.join(filesDirectory, 'changed-files.json'), JSON.stringify({
@@ -141,8 +141,8 @@ process.stdout.write(JSON.stringify({
   assert.equal(writeResponse.handled, true);
   assert.deepEqual(writeResponse.changed_files, ['src/example.php']);
   assert.equal(fs.readFileSync(path.join(writeCommand.settings.wp_codebox_agents_api_path, 'src', 'example.php'), 'utf8'), 'after\n');
-  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-/);
-  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] completed 2\/2 group=docs-reference session=homeboy-audit-.*artifact=.*fixture-wp-codebox-artifact-/);
+  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/3 group=finding-phpcs-001 session=homeboy-audit-/);
+  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] completed 3\/3 group=finding-doc-001 session=homeboy-audit-.*artifact=.*fixture-wp-codebox-artifact-/);
   assert.doesNotMatch(writeResult.stderr, /OPENCODE_API_KEY/);
   assert.match(writeResponse.warnings[1], /fanout-run\.json/);
   const run = JSON.parse(fs.readFileSync(path.join(writeOutputDir, 'fanout-run.json'), 'utf8'));
@@ -170,7 +170,7 @@ process.stdout.write(JSON.stringify({
     },
   });
   assert.notEqual(missingSecretResult.status, 0);
-  assert.match(missingSecretResult.stderr, /WP Codebox audit fan-out failed: 2 of 2 task\(s\) failed/);
+  assert.match(missingSecretResult.stderr, /WP Codebox audit fan-out failed: 3 of 3 task\(s\) failed/);
   assert.match(missingSecretResult.stderr, /Required WP Codebox secret environment variable missing: OPENCODE_API_KEY/);
 
   const riskyRoot = path.join(root, 'risky-source');


### PR DESCRIPTION
## Summary
- Change audit WP Codebox fanout planning from grouped batches to one task per audit finding.
- Update WP Codebox task prompts to require either a fix PR or a false-positive detector/config/test PR.
- Add per-task outcome summaries with session, PR, false-positive PR, artifact, error, and status fields.
- Add a configurable task timeout with a realistic 2-hour default and wp_codebox_task_timeout_seconds / --task-timeout-seconds overrides.

## Related
- Unblocks Extra-Chill/homeboy#2978
- Related to Extra-Chill/homeboy-extensions#815

## Tests
- npm run test:audit-wp-codebox-fanout
- npm run test:refactor-source-wp-codebox
- npm run test:wp-codebox-task-runner
- npx eslint lib/audit-wp-codebox-fanout.js scripts/agent/homeboy-audit-wp-codebox-fanout.cjs
- homeboy audit --path /Users/chubes/Developer/homeboy-extensions@fix-codebox-audit-fanout/wordpress --extension nodejs failed with existing audit findings; this PR changes the fanout workflow rather than remediating the repository-wide audit backlog.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the WP Codebox audit fanout workflow change, updated focused smoke coverage, and ran verification. Chris remains responsible for review and merge.