### PR TITLE
Handle nested transcript artifacts

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -906,8 +906,8 @@ jobs:
             --results "$RESULTS_FILE" \
             --scenario "${{ inputs.flow_slug }}" \
             --field job_status=metadata.job_status \
-            --field transcript_json='(.metadata.transcript_artifacts | if type == "array" then (.[0].json? // "") elif type == "object" then (.json? // "") else "" end)' \
-            --field transcript_summary='(.metadata.transcript_artifacts | if type == "array" then (.[0].summary? // "") elif type == "object" then (.summary? // "") else "" end)' \
+            --field transcript_json='(.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].json? // "") elif type == "object" then (.json? // "") else "" end)' \
+            --field transcript_summary='(.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].summary? // "") elif type == "object" then (.summary? // "") else "" end)' \
             --required-status "" \
             --to-github-output
 
@@ -1015,9 +1015,9 @@ jobs:
           fi
           if [ -z "$transcript_path" ] && [ -f "$RESULTS_FILE" ]; then
             transcript_content_path="${RUNNER_TEMP}/datamachine-agent-transcripts/$(basename "${TRANSCRIPT_JSON:-job-transcript.json}")"
-            if jq -e --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | (.metadata.transcript_artifacts | if type == "array" then (.[0].content? // empty) elif type == "object" then (.content? // empty) else empty end)' "$RESULTS_FILE" >/dev/null; then
+            if jq -e --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | (.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].content? // empty) elif type == "object" then (.content? // empty) else empty end)' "$RESULTS_FILE" >/dev/null; then
               mkdir -p "$(dirname "$transcript_content_path")"
-              jq -r --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | (.metadata.transcript_artifacts | if type == "array" then (.[0].content? // "") elif type == "object" then (.content? // "") else "" end)' "$RESULTS_FILE" > "$transcript_content_path"
+              jq -r --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | (.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].content? // "") elif type == "object" then (.content? // "") else "" end)' "$RESULTS_FILE" > "$transcript_content_path"
               transcript_path="$transcript_content_path"
             fi
           fi

--- a/wordpress/scripts/agent/extract-engine-data-smoke.sh
+++ b/wordpress/scripts/agent/extract-engine-data-smoke.sh
@@ -31,7 +31,12 @@ jq -n '{
                 engine_data: {
                     foo: { bar: "baz" },
                     deep: { nested: 42 }
-                }
+                },
+                transcript_artifacts: [[{
+                    json: "/tmp/transcript.json",
+                    summary: "nested transcript",
+                    content: "nested transcript content"
+                }]]
             }
         },
         {
@@ -62,6 +67,8 @@ stdout=$(GITHUB_OUTPUT="$GITHUB_OUTPUT_TMPFILE" bash "$EXTRACTOR" \
     --scenario fixture-agent \
     --field foo_bar=metadata.engine_data.foo.bar \
     --field expression='(.metadata.engine_data.foo | if type == "object" then (.bar // "") else "" end)' \
+    --field transcript_json='(.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].json? // "") elif type == "object" then (.json? // "") else "" end)' \
+    --field transcript_summary='(.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].summary? // "") elif type == "object" then (.summary? // "") else "" end)' \
     --field nested=metadata.engine_data.deep.nested \
     --field missing=metadata.engine_data.missing \
     --required-field foo_bar \
@@ -70,6 +77,8 @@ stdout=$(GITHUB_OUTPUT="$GITHUB_OUTPUT_TMPFILE" bash "$EXTRACTOR" \
 
 if grep -F "foo_bar:" <<<"$stdout" | grep -F "baz" >/dev/null \
     && grep -F "expression:" <<<"$stdout" | grep -F "baz" >/dev/null \
+    && grep -F "transcript_json:" <<<"$stdout" | grep -F "/tmp/transcript.json" >/dev/null \
+    && grep -F "transcript_summary:" <<<"$stdout" | grep -F "nested transcript" >/dev/null \
     && grep -F "nested:" <<<"$stdout" | grep -F "42" >/dev/null; then
     pass "stdout includes projected key/value pairs"
 else
@@ -79,6 +88,8 @@ fi
 
 if grep -Fx "foo_bar=baz" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
     && grep -Fx "expression=baz" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
+    && grep -Fx "transcript_json=/tmp/transcript.json" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
+    && grep -Fx "transcript_summary=nested transcript" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
     && grep -Fx "nested=42" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
     && grep -Fx "missing=" "$GITHUB_OUTPUT_TMPFILE" >/dev/null; then
     pass "GITHUB_OUTPUT includes projected key=value lines"


### PR DESCRIPTION
## Summary
- normalize nested transcript artifact arrays before extracting transcript JSON, summary, and content
- extend the engine-data extractor smoke fixture with the nested transcript artifact shape observed in the World Creator run

## Testing
- `bash scripts/agent/extract-engine-data-smoke.sh`
- `npm run test:datamachine-agent-wp-codebox-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the World Creator workflow extraction failure and drafted the jq normalization/test coverage; Chris remains responsible for review and merge.
