### PR TITLE
Fix WP Codebox audit finding fanout

### DIFF
--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -23,7 +23,7 @@ const PLAN_SCHEMA = 'homeboy/audit-wp-codebox-fanout/v1';
 const TASK_SCHEMA = 'homeboy/wp-codebox-task-request/v1';
 const RUN_SCHEMA = 'homeboy/audit-wp-codebox-run/v1';
 const DEFAULT_CONCURRENCY = 3;
-const DEFAULT_TASK_TIMEOUT_SECONDS = 15 * 60;
+const DEFAULT_TASK_TIMEOUT_SECONDS = 45 * 60;
 
 function sha256(value) {
   return crypto.createHash('sha256').update(value).digest('hex');
@@ -61,6 +61,7 @@ function progressEvent(status, taskRequest, plan, record = null) {
     schema: 'homeboy/audit-wp-codebox-progress/v1',
     status,
     group_key: taskRequest.group_key,
+    finding_id: taskRequest.finding_id || taskRequest.audit_findings?.[0]?.id || '',
     group_index: groupIndex,
     group_count: groupCount,
     sandbox_session_id: taskRequest.sandbox_session_id,
@@ -103,19 +104,10 @@ function normalizeFinding(finding, index) {
 }
 
 function groupFindings(findings) {
-  const groupsByKey = new Map();
-  for (const finding of findings) {
-    const key = finding.fix_batch_key || finding.kind;
-    if (!groupsByKey.has(key)) {
-      groupsByKey.set(key, []);
-    }
-    groupsByKey.get(key).push(finding);
-  }
-
-  return Array.from(groupsByKey.entries()).map(([key, groupedFindings], index) => ({
-    key,
+  return findings.map((finding, index) => ({
+    key: finding.id,
     index,
-    findings: groupedFindings,
+    findings: [finding],
   }));
 }
 
@@ -123,20 +115,29 @@ function sandboxSessionId(orchestrator, group) {
   return `homeboy-audit-${sha256(JSON.stringify({
     run_id: orchestrator.run_id,
     report_id: orchestrator.report_id,
-    group_key: group.key,
+    finding_id: group.findings[0]?.id || group.key,
     finding_ids: group.findings.map((finding) => finding.id),
   })).slice(0, 16)}`;
 }
 
 function taskPrompt(group) {
-  const findingList = group.findings
-    .map((finding) => `- ${finding.id}: ${finding.kind} in ${finding.file}${finding.line ? `:${finding.line}` : ''}`)
-    .join('\n');
+  const finding = group.findings[0] || {};
+  const location = `${finding.file || ''}${finding.line ? `:${finding.line}` : ''}`;
 
   return [
-    `Fix the grouped Homeboy audit findings for batch ${group.key}.`,
-    'Return a WP Codebox artifact bundle with changed-files, patch, and review metadata.',
-    findingList,
+    `Fix Homeboy audit finding ${finding.id || group.key}.`,
+    '',
+    'Expected outcome:',
+    '- Open a pull request that fixes this audit finding, or',
+    '- If the finding is a false positive, fix the audit detector/config/test path that produced it and open a pull request for that correction.',
+    '',
+    'Return machine-readable outcome metadata when possible, including the PR URL, false-positive PR URL, or explicit failure reason.',
+    '',
+    'Finding evidence:',
+    `- id: ${finding.id || group.key}`,
+    `- kind: ${finding.kind || 'unknown'}`,
+    location ? `- location: ${location}` : '',
+    finding.message ? `- message: ${finding.message}` : '',
   ].join('\n\n');
 }
 
@@ -146,6 +147,7 @@ function createTaskRequest(group, orchestrator) {
     schema: TASK_SCHEMA,
     sandbox_session_id,
     group_key: group.key,
+    finding_id: group.findings[0]?.id || group.key,
     orchestrator: {
       id: orchestrator.id,
       run_id: orchestrator.run_id,
@@ -164,7 +166,7 @@ function createTaskRequest(group, orchestrator) {
       severity: finding.severity,
     })),
     task: {
-      title: `Fix Homeboy audit batch ${group.key}`,
+      title: `Fix Homeboy audit finding ${group.findings[0]?.id || group.key}`,
       prompt: taskPrompt(group),
     },
   };
@@ -216,7 +218,7 @@ function createApplyBackMetadata(taskRequest, artifactEntry, options) {
     artifact_content_digest: artifactEntry.artifact_content_digest,
   });
   const branch = artifactEntry.branch || `${options.branch_prefix || 'fix/homeboy-audit'}/${safeBranchSlug(taskRequest.group_key)}`;
-  const title = artifactEntry.pr_title || `Fix Homeboy audit batch ${taskRequest.group_key}`;
+  const title = artifactEntry.pr_title || `Fix Homeboy audit finding ${taskRequest.group_key}`;
   const issueUrl = options.issue_url || taskRequest.orchestrator.issue_url || '';
 
   return {
@@ -255,7 +257,7 @@ function createApplyBackMetadata(taskRequest, artifactEntry, options) {
       body: [
         issueUrl ? `Closes ${issueUrl}` : '',
         '',
-        `Applies WP Codebox artifact ${verified.artifactId} for Homeboy audit batch ${taskRequest.group_key}.`,
+        `Applies WP Codebox artifact ${verified.artifactId} for Homeboy audit finding ${taskRequest.group_key}.`,
       ].filter(Boolean).join('\n'),
       labels: artifactEntry.labels || ['homeboy-audit', 'wp-codebox'],
     },
@@ -350,6 +352,7 @@ function createAuditWpCodeboxFanoutPlan(input) {
       report_id: orchestrator.report_id,
       finding_count: task_requests.reduce((count, request) => count + request.audit_findings.length, 0),
       group_count: task_requests.length,
+      task_count: task_requests.length,
     },
     task_requests,
     apply_back,
@@ -404,12 +407,15 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
   const parsed = tryParseJson(stdout);
   const artifact = parsed && typeof parsed === 'object' && parsed.artifacts ? parsed.artifacts : null;
   const taskFailure = parsed ? wpCodeboxTaskFailure(parsed) : null;
-  const success = result.status === 0 && result.error === undefined && null === taskFailure;
+  const commandSuccess = result.status === 0 && result.error === undefined && null === taskFailure;
+  const outcome = taskOutcome(taskRequest, parsed, artifact, commandSuccess, taskFailure || (result.error ? result.error.message : ''));
+  const success = taskOutcomeSucceeded(outcome);
 
   return {
     schema: RUN_SCHEMA,
     sandbox_session_id: taskRequest.sandbox_session_id,
     group_key: taskRequest.group_key,
+    finding_id: taskRequest.finding_id || taskRequest.audit_findings[0]?.id || '',
     finding_ids: taskRequest.audit_findings.map((finding) => finding.id),
     command: {
       bin: command,
@@ -424,6 +430,7 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
     stdout,
     stderr,
     result: parsed,
+    outcome,
     artifact: artifact ? {
       id: artifact.id || '',
       directory: artifact.directory || artifact.path || '',
@@ -504,12 +511,15 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
       const taskFailure = parsed ? wpCodeboxTaskFailure(parsed) : null;
       const timeoutError = timedOut ? `WP Codebox task timed out after ${taskTimeoutSeconds} seconds` : '';
       const errorMessage = timeoutError || (spawnError ? spawnError.message : (taskFailure || ''));
-      const success = code === 0 && !spawnError && null === taskFailure && !timedOut;
+      const commandSuccess = code === 0 && !spawnError && null === taskFailure && !timedOut;
+      const outcome = taskOutcome(taskRequest, parsed, artifact, commandSuccess, errorMessage, timedOut);
+      const success = taskOutcomeSucceeded(outcome);
 
       resolve({
         schema: RUN_SCHEMA,
         sandbox_session_id: taskRequest.sandbox_session_id,
         group_key: taskRequest.group_key,
+        finding_id: taskRequest.finding_id || taskRequest.audit_findings[0]?.id || '',
         finding_ids: taskRequest.audit_findings.map((finding) => finding.id),
         command: {
           bin: command,
@@ -528,6 +538,7 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
         stdout,
         stderr,
         result: parsed,
+        outcome,
         artifact: artifact ? {
           id: artifact.id || '',
           directory: artifact.directory || artifact.path || '',
@@ -537,6 +548,73 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
     });
     child.stdin.end(requestJson);
   });
+}
+
+function taskOutcome(taskRequest, parsed, artifact, success, errorMessage = '', timedOut = false) {
+  const urls = pullRequestUrls(parsed);
+  const explicit = parsed && typeof parsed === 'object' ? parsed.outcome || parsed.result || parsed : {};
+  const falsePositive = Boolean(
+    explicit.kind === 'false_positive_pr' ||
+    explicit.false_positive ||
+    explicit.falsePositive ||
+    explicit.false_positive_pr_url ||
+    explicit.falsePositivePullRequestUrl ||
+    explicit.disposition === 'false_positive'
+  );
+  const prUrl = explicit.pr_url || explicit.pull_request_url || explicit.pullRequestUrl || urls[0] || '';
+  const falsePositivePrUrl = explicit.false_positive_pr_url || explicit.falsePositivePullRequestUrl || (falsePositive ? prUrl : '');
+  let kind = 'explicit_failure';
+
+  if (timedOut) {
+    kind = 'timeout';
+  } else if (falsePositive && falsePositivePrUrl) {
+    kind = 'false_positive_pr';
+  } else if (prUrl) {
+    kind = 'fix_pr';
+  }
+  let failure = '';
+  if (!success) {
+    failure = errorMessage;
+  } else if (kind === 'explicit_failure') {
+    failure = 'WP Codebox task completed without PR outcome';
+  }
+
+  return {
+    schema: 'homeboy/audit-wp-codebox-finding-outcome/v1',
+    kind,
+    finding_id: taskRequest.finding_id || taskRequest.audit_findings?.[0]?.id || '',
+    finding_ids: taskRequest.audit_findings.map((finding) => finding.id),
+    sandbox_session_id: taskRequest.sandbox_session_id,
+    pr_url: prUrl,
+    false_positive_pr_url: falsePositivePrUrl,
+    false_positive: falsePositive,
+    artifact_id: artifact?.id || '',
+    failure,
+  };
+}
+
+function taskOutcomeSucceeded(outcome) {
+  return ['fix_pr', 'false_positive_pr'].includes(outcome?.kind);
+}
+
+function pullRequestUrls(value, urls = []) {
+  if (!value || urls.length >= 10) {
+    return urls;
+  }
+  if (typeof value === 'string') {
+    if (/^https:\/\/github\.com\/[^\s/]+\/[^\s/]+\/pull\/\d+/.test(value)) {
+      urls.push(value);
+    }
+    return urls;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((entry) => pullRequestUrls(entry, urls));
+    return urls;
+  }
+  if (typeof value === 'object') {
+    Object.values(value).forEach((entry) => pullRequestUrls(entry, urls));
+  }
+  return Array.from(new Set(urls));
 }
 
 function killProcessTree(child, signal) {
@@ -653,6 +731,7 @@ async function executeAuditWpCodeboxFanout(input) {
   const run = {
     ...baseRun,
     records,
+    outcomes: records.flatMap((record) => record.outcome ? [record.outcome] : []),
     status: records.every((record) => record.status === 'completed') ? 'completed' : 'failed',
   };
 
@@ -696,6 +775,7 @@ function runningGroup(taskRequest) {
   return {
     sandbox_session_id: taskRequest.sandbox_session_id,
     group_key: taskRequest.group_key,
+    finding_id: taskRequest.finding_id || taskRequest.audit_findings[0]?.id || '',
     finding_ids: taskRequest.audit_findings.map((finding) => finding.id),
   };
 }
@@ -733,6 +813,9 @@ module.exports = {
   executeWpCodeboxTaskRequest,
   createIssueReport,
   groupFindings,
+  pullRequestUrls,
   safeBranchSlug,
   sandboxSessionId,
+  taskOutcome,
+  taskOutcomeSucceeded,
 };

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -12,6 +12,7 @@ const {
   executeAuditWpCodeboxFanout,
   executeAuditWpCodeboxFanoutFromFiles,
   safeBranchSlug,
+  taskOutcome,
 } = require('../lib/audit-wp-codebox-fanout');
 const { artifactContentDigest } = require('../lib/wp-codebox-apply-adapter');
 
@@ -115,7 +116,7 @@ process.stdin.on('end', () => {
     setInterval(() => {}, 1000);
     return;
   }
-  if (request.group_key === 'docs-reference') {
+  if (request.group_key === 'finding-doc-001') {
     if (process.env.FIXTURE_EXPECT_INCREMENTAL_RUN) {
       const run = JSON.parse(fs.readFileSync(process.env.FIXTURE_EXPECT_INCREMENTAL_RUN, 'utf8'));
       if (run.status !== 'incomplete' || run.records.length !== 1 || !run.current_group || run.current_group.group_key !== request.group_key) {
@@ -153,6 +154,9 @@ process.stdin.on('end', () => {
       directory: '/tmp/' + request.sandbox_session_id,
       preview: { url: 'https://preview.example.test/' + request.sandbox_session_id },
     },
+    outcome: {
+      pr_url: 'https://github.com/Extra-Chill/homeboy-extensions/pull/' + (request.finding_id === 'finding-phpcs-002' ? '778' : '777')
+    },
   }));
 });
 `);
@@ -175,8 +179,9 @@ try {
   });
   assert.equal(initialPlan.schema, 'homeboy/audit-wp-codebox-fanout/v1');
   assert.equal(initialPlan.audit.finding_count, 3);
-  assert.equal(initialPlan.audit.group_count, 2);
-  assert.equal(initialPlan.task_requests.length, 2);
+  assert.equal(initialPlan.audit.group_count, 3);
+  assert.equal(initialPlan.audit.task_count, 3);
+  assert.equal(initialPlan.task_requests.length, 3);
 
   assert.equal(safeBranchSlug('PHPCS Formatting/Auto Fix!'), 'phpcs-formatting-auto-fix');
   assert.equal(safeBranchSlug('foo..bar'), 'foo-bar');
@@ -184,10 +189,11 @@ try {
   assert.equal(safeBranchSlug('foo/bar.lock'), 'foo-bar-lock');
   assert.equal(safeBranchSlug('../.@{'), 'audit-batch');
 
-  const phpcsRequest = initialPlan.task_requests.find((request) => request.group_key === 'PHPCS Formatting/Auto Fix!');
-  const docsRequest = initialPlan.task_requests.find((request) => request.group_key === 'docs-reference');
-  assert.equal(phpcsRequest.audit_findings.length, 2);
+  const phpcsRequest = initialPlan.task_requests.find((request) => request.group_key === 'finding-phpcs-001');
+  const docsRequest = initialPlan.task_requests.find((request) => request.group_key === 'finding-doc-001');
+  assert.equal(phpcsRequest.audit_findings.length, 1);
   assert.equal(docsRequest.audit_findings.length, 1);
+  assert.equal(phpcsRequest.finding_id, 'finding-phpcs-001');
   assert.match(phpcsRequest.sandbox_session_id, /^homeboy-audit-[a-f0-9]{16}$/);
   assert.equal(phpcsRequest.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/769');
   assert.equal(phpcsRequest.provider, 'codex');
@@ -195,6 +201,15 @@ try {
   assert.deepEqual(phpcsRequest.provider_plugin_paths, ['/opt/ai-provider-for-openai']);
   assert.deepEqual(phpcsRequest.secret_env, ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN']);
   assert.match(phpcsRequest.task.prompt, /finding-phpcs-001/);
+  assert.match(phpcsRequest.task.prompt, /false positive/);
+  const falsePositiveOutcome = taskOutcome(phpcsRequest, {
+    outcome: {
+      kind: 'false_positive_pr',
+      false_positive_pr_url: 'https://github.com/Extra-Chill/homeboy-extensions/pull/779',
+    },
+  }, null, true);
+  assert.equal(falsePositiveOutcome.kind, 'false_positive_pr');
+  assert.equal(falsePositiveOutcome.false_positive_pr_url, 'https://github.com/Extra-Chill/homeboy-extensions/pull/779');
 
   const phpcsBundle = createBundle(
     root,
@@ -209,14 +224,21 @@ try {
     'docs/setup.md'
   );
   const artifactMap = {
-    'PHPCS Formatting/Auto Fix!': {
+    'finding-phpcs-001': {
       bundle_path: phpcsBundle.bundle,
       approved_files: [phpcsBundle.changedPath],
       reviewed_at: '2026-05-25T00:00:00.000Z',
       reviewer: 'homeboy-review-fixture',
       base: 'main',
     },
-    'docs-reference': {
+    'finding-phpcs-002': {
+      bundle_path: phpcsBundle.bundle,
+      approved_files: [phpcsBundle.changedPath],
+      reviewed_at: '2026-05-25T00:00:00.000Z',
+      reviewer: 'homeboy-review-fixture',
+      base: 'main',
+    },
+    'finding-doc-001': {
       bundle_path: docsBundle.bundle,
       approved_files: [docsBundle.changedPath],
       reviewed_at: '2026-05-25T00:00:00.000Z',
@@ -230,24 +252,23 @@ try {
     artifact_map: artifactMap,
     issue_url: 'https://github.com/Extra-Chill/homeboy-extensions/issues/769',
   });
-  assert.equal(plan.apply_back.length, 2);
-
-  const phpcsApplyBack = plan.apply_back.find((entry) => entry.group_key === 'PHPCS Formatting/Auto Fix!');
+  assert.equal(plan.apply_back.length, 3);
+  const phpcsApplyBack = plan.apply_back.find((entry) => entry.group_key === 'finding-phpcs-001');
   assert.equal(phpcsApplyBack.adapter_id, 'homeboy/wp-codebox-apply-adapter/v1');
   assert.equal(phpcsApplyBack.sandbox_session_id, phpcsRequest.sandbox_session_id);
-  assert.deepEqual(phpcsApplyBack.finding_ids, ['finding-phpcs-001', 'finding-phpcs-002']);
+  assert.deepEqual(phpcsApplyBack.finding_ids, ['finding-phpcs-001']);
   assert.equal(phpcsApplyBack.artifact.id, phpcsBundle.artifactId);
   assert.equal(phpcsApplyBack.artifact.content_digest, phpcsBundle.contentDigest);
   assert.equal(phpcsApplyBack.artifact.patch_sha256, phpcsBundle.patchSha256);
   assert.deepEqual(phpcsApplyBack.review.approved_files, [phpcsBundle.changedPath]);
   assert.equal(phpcsApplyBack.adapter_payload.bundlePath, fs.realpathSync(phpcsBundle.bundle));
-  assert.equal(phpcsApplyBack.adapter_payload.branch, 'fix/homeboy-audit/phpcs-formatting-auto-fix');
+  assert.equal(phpcsApplyBack.adapter_payload.branch, 'fix/homeboy-audit/finding-phpcs-001');
   assert.equal(phpcsApplyBack.pull_request.base, 'main');
-  assert.equal(phpcsApplyBack.pull_request.head, 'fix/homeboy-audit/phpcs-formatting-auto-fix');
+  assert.equal(phpcsApplyBack.pull_request.head, 'fix/homeboy-audit/finding-phpcs-001');
   assert.match(phpcsApplyBack.pull_request.body, /Extra-Chill\/homeboy-extensions\/issues\/769/);
 
   const missingApprovalMap = {
-    'PHPCS Formatting/Auto Fix!': {
+    'finding-phpcs-001': {
       bundle_path: phpcsBundle.bundle,
     },
   };
@@ -264,7 +285,7 @@ try {
     issue_url: 'https://github.com/Extra-Chill/homeboy-extensions/issues/769',
     artifact_map: {
       ...artifactMap,
-      'docs-reference': {
+      'finding-doc-001': {
         bundle_path: docsBundle.bundle,
         approved_files: [docsBundle.changedPath],
         approved: false,
@@ -273,11 +294,11 @@ try {
       },
     },
   });
-  assert.equal(rejectedPlan.apply_back.length, 1);
-  assert.equal(rejectedPlan.apply_back[0].group_key, 'PHPCS Formatting/Auto Fix!');
+  assert.equal(rejectedPlan.apply_back.length, 2);
+  assert.equal(rejectedPlan.apply_back[0].group_key, 'finding-phpcs-001');
   assert.equal(rejectedPlan.issue_reports.length, 1);
   assert.equal(rejectedPlan.issue_reports[0].schema, 'homeboy/audit-wp-codebox-issue-report/v1');
-  assert.equal(rejectedPlan.issue_reports[0].group_key, 'docs-reference');
+  assert.equal(rejectedPlan.issue_reports[0].group_key, 'finding-doc-001');
   assert.equal(rejectedPlan.issue_reports[0].disposition, 'false_positive');
   assert.deepEqual(rejectedPlan.issue_reports[0].finding_ids, ['finding-doc-001']);
   assert.equal(rejectedPlan.issue_reports[0].artifact.id, docsBundle.artifactId);
@@ -298,8 +319,8 @@ try {
     providerPluginPaths: ['/opt/ai-provider-for-openai'],
     secretEnv: ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN'],
   });
-  assert.equal(filePlan.apply_back.length, 2);
-  assert.equal(readJson(outputPath).apply_back.length, 2);
+  assert.equal(filePlan.apply_back.length, 3);
+  assert.equal(readJson(outputPath).apply_back.length, 3);
 
   const cliOutput = run(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-audit-wp-codebox-fanout.cjs'),
@@ -319,8 +340,8 @@ try {
     'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
   ]);
   const cliPlan = JSON.parse(cliOutput);
-  assert.equal(cliPlan.task_requests.length, 2);
-  assert.equal(cliPlan.apply_back.length, 2);
+  assert.equal(cliPlan.task_requests.length, 3);
+  assert.equal(cliPlan.apply_back.length, 3);
   assert.equal(cliPlan.task_requests[0].provider, 'codex');
 
   const fixtureCommand = createWpCodeboxFixtureCommand(root);
@@ -333,17 +354,22 @@ try {
     wp_codebox_args: [fixtureCommand],
   });
   assert.equal(execution.schema, 'homeboy/audit-wp-codebox-execution/v1');
-  assert.equal(execution.records.length, 2);
+  assert.equal(execution.records.length, 3);
   assert.equal(execution.status, 'failed');
-  const completedRecord = execution.records.find((record) => record.group_key === 'PHPCS Formatting/Auto Fix!');
-  const failedRecord = execution.records.find((record) => record.group_key === 'docs-reference');
+  const completedRecord = execution.records.find((record) => record.group_key === 'finding-phpcs-001');
+  const failedRecord = execution.records.find((record) => record.group_key === 'finding-doc-001');
   assert.equal(completedRecord.status, 'completed');
+  assert.equal(completedRecord.finding_id, 'finding-phpcs-001');
   assert.equal(completedRecord.command.bin, process.execPath);
   assert.equal(completedRecord.result.session.id, completedRecord.sandbox_session_id);
   assert.equal(completedRecord.result.session.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/773');
   assert.match(completedRecord.artifact.id, /^artifact-homeboy-audit-/);
+  assert.equal(completedRecord.outcome.kind, 'fix_pr');
+  assert.equal(completedRecord.outcome.pr_url, 'https://github.com/Extra-Chill/homeboy-extensions/pull/777');
+  assert.equal(execution.outcomes.length, 3);
   assert.equal(failedRecord.status, 'failed');
   assert.equal(failedRecord.command.exit_code, 3);
+  assert.equal(failedRecord.outcome.kind, 'explicit_failure');
   assert.match(failedRecord.stderr, /fixture docs-reference failure/);
 
   const nestedErrorExecution = await executeAuditWpCodeboxFanout({
@@ -352,7 +378,7 @@ try {
     wp_codebox_args: [fixtureCommand],
     env: { FIXTURE_NESTED_WP_ERROR: '1' },
   });
-  const nestedFailedRecord = nestedErrorExecution.records.find((record) => record.group_key === 'docs-reference');
+  const nestedFailedRecord = nestedErrorExecution.records.find((record) => record.group_key === 'finding-doc-001');
   assert.equal(nestedErrorExecution.status, 'failed');
   assert.equal(nestedFailedRecord.status, 'failed');
   assert.equal(nestedFailedRecord.command.exit_code, 0);
@@ -366,24 +392,26 @@ try {
     concurrency: 1,
     task_timeout_seconds: 1,
     runsOutputPath: timeoutRunsOutputPath,
-    env: { FIXTURE_HANG_GROUP: 'PHPCS Formatting/Auto Fix!' },
+    env: { FIXTURE_HANG_GROUP: 'finding-phpcs-001' },
   });
   assert.equal(timeoutExecution.status, 'failed');
-  assert.equal(timeoutExecution.records.length, 2);
-  const timeoutRecord = timeoutExecution.records.find((record) => record.group_key === 'PHPCS Formatting/Auto Fix!');
+  assert.equal(timeoutExecution.records.length, 3);
+  const timeoutRecord = timeoutExecution.records.find((record) => record.group_key === 'finding-phpcs-001');
   assert.equal(timeoutRecord.status, 'failed');
   assert.equal(timeoutRecord.command.timed_out, true);
   assert.equal(timeoutRecord.command.timeout_seconds, 1);
   assert.equal(timeoutRecord.command.killed_process_group, true);
   assert.match(timeoutRecord.command.error, /timed out after 1 seconds/);
+  assert.equal(timeoutRecord.outcome.kind, 'timeout');
   assert.match(timeoutRecord.stdout, /fixture partial stdout before timeout/);
   assert.match(timeoutRecord.stderr, /fixture partial stderr before timeout/);
-  const timeoutFollowupRecord = timeoutExecution.records.find((record) => record.group_key === 'docs-reference');
+  const timeoutFollowupRecord = timeoutExecution.records.find((record) => record.group_key === 'finding-doc-001');
   assert.equal(timeoutFollowupRecord.status, 'failed');
   assert.equal(timeoutFollowupRecord.command.exit_code, 3);
   const timeoutFinalRun = readJson(timeoutRunsOutputPath);
   assert.equal(timeoutFinalRun.status, 'failed');
-  assert.equal(timeoutFinalRun.records.length, 2);
+  assert.equal(timeoutFinalRun.records.length, 3);
+  assert.equal(timeoutFinalRun.outcomes.length, 3);
   assert.equal(Object.hasOwn(timeoutFinalRun, 'current_group'), false);
 
   const runsOutputPath = path.join(root, 'fanout-run.json');
@@ -398,9 +426,9 @@ try {
       FIXTURE_EXPECT_INCREMENTAL_RUN: runsOutputPath,
     },
   });
-  assert.equal(fileExecution.records.length, 2);
+  assert.equal(fileExecution.records.length, 3);
   const finalRun = readJson(runsOutputPath);
-  assert.equal(finalRun.records.length, 2);
+  assert.equal(finalRun.records.length, 3);
   assert.equal(Object.hasOwn(finalRun, 'current_group'), false);
 
   const cliExecutionResult = spawnSync(process.execPath, [
@@ -421,11 +449,11 @@ try {
   ], { encoding: 'utf8' });
   assert.equal(cliExecutionResult.status, 0, cliExecutionResult.stderr || cliExecutionResult.stdout);
   const cliExecution = JSON.parse(cliExecutionResult.stdout);
-  assert.equal(cliExecution.records.length, 2);
+  assert.equal(cliExecution.records.length, 3);
   assert.equal(cliExecution.records[0].schema, 'homeboy/audit-wp-codebox-run/v1');
-  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-/);
-  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] completed 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-.*artifact=\/tmp\/homeboy-audit-/);
-  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] failed 2\/2 group=docs-reference session=homeboy-audit-/);
+  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/3 group=finding-phpcs-001 session=homeboy-audit-/);
+  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] completed 1\/3 group=finding-phpcs-001 session=homeboy-audit-.*artifact=\/tmp\/homeboy-audit-/);
+  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] failed 3\/3 group=finding-doc-001 session=homeboy-audit-/);
   assert.doesNotMatch(cliExecutionResult.stderr, /FIXTURE_SECRET_TOKEN/);
 
   console.log('Homeboy audit WP Codebox fanout smoke passed');

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -46,14 +46,14 @@ try {
   assert.equal(response.handled, true);
   assert.equal(response.detected_findings, 3);
   assert.equal(response.changed_files.length, 0);
-  assert.equal(response.fix_results.length, 2);
+  assert.equal(response.fix_results.length, 3);
   assert.equal(response.fix_results[0].rule, 'wp_codebox.audit_fanout');
   assert.equal(response.fix_results[0].primitive, 'extension_refactor_source');
   assert.match(response.warnings[0], /fanout-plan\.json/);
 
   const plan = JSON.parse(fs.readFileSync(path.join(outputDir, 'fanout-plan.json'), 'utf8'));
   assert.equal(plan.schema, 'homeboy/audit-wp-codebox-fanout/v1');
-  assert.equal(plan.task_requests.length, 2);
+  assert.equal(plan.task_requests.length, 3);
   assert.equal(plan.task_requests[0].provider, 'opencode');
   assert.equal(plan.task_requests[0].model, 'opencode-go/kimi-k2.6');
   assert.deepEqual(plan.task_requests[0].provider_plugin_paths, ['/plugins/ai-provider-for-opencode']);
@@ -73,7 +73,7 @@ const stepArgs = recipe.workflow.steps[0].args;
 const task = JSON.parse(stepArgs.find((arg) => arg.startsWith('task=')).slice('task='.length));
 const sessionId = task.sandbox_session_id;
 const artifactDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'fixture-wp-codebox-artifact-'));
-if (task.group_key === 'PHPCS Formatting/Auto Fix!') {
+if (task.group_key === 'finding-phpcs-001') {
   const filesDirectory = path.join(artifactDirectory, 'files');
   fs.mkdirSync(filesDirectory, { recursive: true });
   fs.writeFileSync(path.join(filesDirectory, 'changed-files.json'), JSON.stringify({
@@ -102,6 +102,9 @@ process.stdout.write(JSON.stringify({
   artifacts: {
     id: 'artifact-' + sessionId,
     directory: artifactDirectory
+  },
+  outcome: {
+    pr_url: 'https://github.com/Extra-Chill/homeboy-extensions/pull/' + (task.group_key === 'finding-phpcs-001' ? '777' : '778')
   }
 }));
 `);
@@ -142,8 +145,8 @@ process.stdout.write(JSON.stringify({
   assert.equal(writeResponse.handled, true);
   assert.deepEqual(writeResponse.changed_files, ['src/example.php']);
   assert.equal(fs.readFileSync(path.join(writeCommand.settings.wp_codebox_agents_api_path, 'src', 'example.php'), 'utf8'), 'after\n');
-  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-/);
-  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] completed 2\/2 group=docs-reference session=homeboy-audit-.*artifact=.*fixture-wp-codebox-artifact-/);
+  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/3 group=finding-phpcs-001 session=homeboy-audit-/);
+  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] completed 3\/3 group=finding-doc-001 session=homeboy-audit-.*artifact=.*fixture-wp-codebox-artifact-/);
   assert.doesNotMatch(writeResult.stderr, /OPENCODE_API_KEY/);
   assert.match(writeResponse.warnings[1], /fanout-run\.json/);
   const run = JSON.parse(fs.readFileSync(path.join(writeOutputDir, 'fanout-run.json'), 'utf8'));
@@ -172,7 +175,7 @@ process.stdout.write(JSON.stringify({
     },
   });
   assert.notEqual(missingSecretResult.status, 0);
-  assert.match(missingSecretResult.stderr, /WP Codebox audit fan-out failed: 2 of 2 task\(s\) failed/);
+  assert.match(missingSecretResult.stderr, /WP Codebox audit fan-out failed: 3 of 3 task\(s\) failed/);
   assert.match(missingSecretResult.stderr, /Required WP Codebox secret environment variable missing: OPENCODE_API_KEY/);
 
   const riskyRoot = path.join(root, 'risky-source');


### PR DESCRIPTION
## Summary
- Fan out WP Codebox audit remediation as one task per audit finding instead of fix-batch groups.
- Strengthen each task prompt around the required outcomes: fix PR, false-positive remediation PR, explicit failure, or timeout.
- Reconcile each completed record into a finding outcome with session ID, PR URL, false-positive PR URL, failure, or timeout metadata, and include an outcomes list in the parent run JSON.
- Use the bounded per-task timeout substrate from #815 with a larger default budget for real remediation work.

## Notes
- Replaces closed stacked PR #817 and conflicted recreation #820 after #815 merged.
- Refs Extra-Chill/homeboy#2978.

## Tests
- node wordpress/tests/audit-wp-codebox-fanout-smoke.js
- node wordpress/tests/refactor-source-wp-codebox-smoke.js
- python3 -m py_compile wordpress/scripts/refactor.py
- git diff --check origin/main...HEAD

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the per-finding fanout implementation, outcome reconciliation, smoke coverage updates, and local validation commands for Chris to review.