### PR TITLE
Read nested transcript artifacts in runner evidence

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -906,8 +906,8 @@ jobs:
             --results "$RESULTS_FILE" \
             --scenario "${{ inputs.flow_slug }}" \
             --field job_status=metadata.job_status \
-            --field transcript_json='(.metadata.transcript_artifacts | if type == "array" then (.[0].json? // "") elif type == "object" then (.json? // "") else "" end)' \
-            --field transcript_summary='(.metadata.transcript_artifacts | if type == "array" then (.[0].summary? // "") elif type == "object" then (.summary? // "") else "" end)' \
+            --field transcript_json='(.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].json? // "") elif type == "object" then (.json? // "") else "" end)' \
+            --field transcript_summary='(.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].summary? // "") elif type == "object" then (.summary? // "") else "" end)' \
             --required-status "" \
             --to-github-output
 
@@ -1015,9 +1015,9 @@ jobs:
           fi
           if [ -z "$transcript_path" ] && [ -f "$RESULTS_FILE" ]; then
             transcript_content_path="${RUNNER_TEMP}/datamachine-agent-transcripts/$(basename "${TRANSCRIPT_JSON:-job-transcript.json}")"
-            if jq -e --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | (.metadata.transcript_artifacts | if type == "array" then (.[0].content? // empty) elif type == "object" then (.content? // empty) else empty end)' "$RESULTS_FILE" >/dev/null; then
+            if jq -e --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | (.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].content? // empty) elif type == "object" then (.content? // empty) else empty end)' "$RESULTS_FILE" >/dev/null; then
               mkdir -p "$(dirname "$transcript_content_path")"
-              jq -r --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | (.metadata.transcript_artifacts | if type == "array" then (.[0].content? // "") elif type == "object" then (.content? // "") else "" end)' "$RESULTS_FILE" > "$transcript_content_path"
+              jq -r --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | (.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].content? // "") elif type == "object" then (.content? // "") else "" end)' "$RESULTS_FILE" > "$transcript_content_path"
               transcript_path="$transcript_content_path"
             fi
           fi

--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -140,6 +140,7 @@ const output = {
     model: 'example-model',
     agent_slug: 'wp-codebox-smoke-agent',
     flow_slug: 'wp-codebox-smoke-flow',
+    transcript_artifacts: [[{ json: '/tmp/wp-codebox-smoke-transcript.json', summary: 'Nested transcript fixture' }]],
     engine_data: {
       ok: true,
     },
@@ -239,8 +240,9 @@ runtime_trace_available=$(jq -r "$scenario | .metadata.evidence_references.refer
 replay_bundle_available=$(jq -r "$scenario | .metadata.evidence_references.references.replay_bundle_artifact.available // false" "$RESULTS_TMPFILE")
 verifier_available=$(jq -r "$scenario | .metadata.evidence_references.references.artifact_verifier_result.available // false" "$RESULTS_TMPFILE")
 policy_available=$(jq -r "$scenario | .metadata.evidence_references.references.workspace_policy_result.available // false" "$RESULTS_TMPFILE")
+transcript_path=$(jq -r "$scenario | .metadata.evidence_references.references.transcript_artifact.path // \"\"" "$RESULTS_TMPFILE")
 trace_gap=$(jq -r "$scenario | any(.metadata.evidence_references.compatibility_gaps[]?; .field == \"runtime_episode_trace\")" "$RESULTS_TMPFILE")
-if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_available" != "true" ] || [ "$policy_available" != "true" ] || [ "$trace_gap" != "false" ]; then
+if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_available" != "true" ] || [ "$policy_available" != "true" ] || [ "$transcript_path" != "/tmp/wp-codebox-smoke-transcript.json" ] || [ "$trace_gap" != "false" ]; then
     echo "ERROR: stable evidence references missing or incomplete" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1

--- a/wordpress/scripts/agent/extract-engine-data-smoke.sh
+++ b/wordpress/scripts/agent/extract-engine-data-smoke.sh
@@ -31,7 +31,12 @@ jq -n '{
                 engine_data: {
                     foo: { bar: "baz" },
                     deep: { nested: 42 }
-                }
+                },
+                transcript_artifacts: [[{
+                    json: "/tmp/transcript.json",
+                    summary: "nested transcript",
+                    content: "nested transcript content"
+                }]]
             }
         },
         {
@@ -62,6 +67,8 @@ stdout=$(GITHUB_OUTPUT="$GITHUB_OUTPUT_TMPFILE" bash "$EXTRACTOR" \
     --scenario fixture-agent \
     --field foo_bar=metadata.engine_data.foo.bar \
     --field expression='(.metadata.engine_data.foo | if type == "object" then (.bar // "") else "" end)' \
+    --field transcript_json='(.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].json? // "") elif type == "object" then (.json? // "") else "" end)' \
+    --field transcript_summary='(.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].summary? // "") elif type == "object" then (.summary? // "") else "" end)' \
     --field nested=metadata.engine_data.deep.nested \
     --field missing=metadata.engine_data.missing \
     --required-field foo_bar \
@@ -70,6 +77,8 @@ stdout=$(GITHUB_OUTPUT="$GITHUB_OUTPUT_TMPFILE" bash "$EXTRACTOR" \
 
 if grep -F "foo_bar:" <<<"$stdout" | grep -F "baz" >/dev/null \
     && grep -F "expression:" <<<"$stdout" | grep -F "baz" >/dev/null \
+    && grep -F "transcript_json:" <<<"$stdout" | grep -F "/tmp/transcript.json" >/dev/null \
+    && grep -F "transcript_summary:" <<<"$stdout" | grep -F "nested transcript" >/dev/null \
     && grep -F "nested:" <<<"$stdout" | grep -F "42" >/dev/null; then
     pass "stdout includes projected key/value pairs"
 else
@@ -79,6 +88,8 @@ fi
 
 if grep -Fx "foo_bar=baz" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
     && grep -Fx "expression=baz" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
+    && grep -Fx "transcript_json=/tmp/transcript.json" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
+    && grep -Fx "transcript_summary=nested transcript" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
     && grep -Fx "nested=42" "$GITHUB_OUTPUT_TMPFILE" >/dev/null \
     && grep -Fx "missing=" "$GITHUB_OUTPUT_TMPFILE" >/dev/null; then
     pass "GITHUB_OUTPUT includes projected key=value lines"

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -486,14 +486,13 @@ homeboy_datamachine_agent_attach_evidence_references() {
             ($scenario.metadata // {}) as $metadata
             | ($scenario.artifacts // {}) as $artifacts
             | ($metadata.wp_codebox.canonical_artifacts // {}) as $wpPaths
-            | ($metadata.transcript_artifacts // {}) as $transcript
             | ($metadata.fingerprints // {}) as $fingerprints
             | ($metadata.runtime_versions // {}) as $runtimeVersions
             | first_field($metadata; "artifact_verifier_result") as $artifactVerifier
             | (first_field($metadata; "workspace_policy_result") // $metadata.datamachine_code_policy_attestation // null) as $policyResult
             | ($artifacts.episode_jsonl.path // $metadata.runtime_episode_trace.path // $metadata.runtime_episode_trace // "") as $episodeTrace
             | ($artifacts.replay_bundle.path // $metadata.replay_bundle_path // "") as $replayBundle
-            | ($transcript.json // "") as $transcriptJson
+            | (first_field($metadata.transcript_artifacts; "json") // "") as $transcriptJson
             | {
                 schema: "homeboy/datamachine-agent-evidence-references/v1",
                 scope: "generic-runner-evidence",


### PR DESCRIPTION
## Summary
- read transcript artifact paths from nested transcript artifact arrays when attaching evidence references
- cover the nested transcript artifact shape in the WP Codebox runner smoke

## Testing
- `npm run test:datamachine-agent-wp-codebox-runner`
- `bash scripts/agent/extract-engine-data-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the remaining World Creator runner evidence failure and drafted the jq normalization/test coverage; Chris remains responsible for review and merge.
