### PR TITLE
Read nested PR evidence metadata

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -141,6 +141,7 @@ const output = {
     agent_slug: 'wp-codebox-smoke-agent',
     flow_slug: 'wp-codebox-smoke-flow',
     transcript_artifacts: [[{ json: '/tmp/wp-codebox-smoke-transcript.json', summary: 'Nested transcript fixture' }]],
+    job_artifact_exports: [{ pr_url: 'https://github.com/example/repo/pull/123', branch: 'agent-artifacts/example' }],
     engine_data: {
       ok: true,
     },
@@ -241,8 +242,10 @@ replay_bundle_available=$(jq -r "$scenario | .metadata.evidence_references.refer
 verifier_available=$(jq -r "$scenario | .metadata.evidence_references.references.artifact_verifier_result.available // false" "$RESULTS_TMPFILE")
 policy_available=$(jq -r "$scenario | .metadata.evidence_references.references.workspace_policy_result.available // false" "$RESULTS_TMPFILE")
 transcript_path=$(jq -r "$scenario | .metadata.evidence_references.references.transcript_artifact.path // \"\"" "$RESULTS_TMPFILE")
+pull_request_value=$(jq -r "$scenario | .metadata.evidence_references.references.pull_request.value // \"\"" "$RESULTS_TMPFILE")
+workspace_branch_value=$(jq -r "$scenario | .metadata.evidence_references.references.workspace_branch.value // \"\"" "$RESULTS_TMPFILE")
 trace_gap=$(jq -r "$scenario | any(.metadata.evidence_references.compatibility_gaps[]?; .field == \"runtime_episode_trace\")" "$RESULTS_TMPFILE")
-if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_available" != "true" ] || [ "$policy_available" != "true" ] || [ "$transcript_path" != "/tmp/wp-codebox-smoke-transcript.json" ] || [ "$trace_gap" != "false" ]; then
+if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_available" != "true" ] || [ "$policy_available" != "true" ] || [ "$transcript_path" != "/tmp/wp-codebox-smoke-transcript.json" ] || [ "$pull_request_value" != "https://github.com/example/repo/pull/123" ] || [ "$workspace_branch_value" != "agent-artifacts/example" ] || [ "$trace_gap" != "false" ]; then
     echo "ERROR: stable evidence references missing or incomplete" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -470,17 +470,16 @@ homeboy_datamachine_agent_attach_evidence_references() {
                 ($metadata.engine_data[]? | objects | .github_tool_results? // [] | .[]?)
             ] | map(select(.tool_name == "create_github_pull_request" and .success == true and (.url // "") != "") | .url) | first) // "";
         def pr_url($metadata):
-            $metadata.job_artifact_exports.pr_url
-            // $metadata.fallback_pull_request.result.html_url
-            // $metadata.fallback_pull_request.result.url
-            // $metadata.fallback_pull_request.result.pull_request.html_url
+            first_field($metadata.job_artifact_exports; "pr_url")
+            // first_field($metadata.fallback_pull_request; "html_url")
+            // first_field($metadata.fallback_pull_request; "url")
             // first_tool_pr_url($metadata)
             // "";
         def workspace_branch($metadata):
-            $metadata.runner_workspace_capture.status.branch
-            // $metadata.runner_workspace.branch
-            // $metadata.job_artifact_exports.branch
-            // $metadata.fallback_pull_request.input.head
+            first_field($metadata.runner_workspace_capture; "branch")
+            // first_field($metadata.runner_workspace; "branch")
+            // first_field($metadata.job_artifact_exports; "branch")
+            // first_field($metadata.fallback_pull_request; "head")
             // "";
         def evidence($scenario):
             ($scenario.metadata // {}) as $metadata


### PR DESCRIPTION
## Summary
- resolve PR URL and workspace branch evidence through recursive metadata lookup so array-shaped exports do not break runner evidence attachment
- cover array-shaped job artifact export metadata in the WP Codebox runner smoke

## Testing
- `npm run test:datamachine-agent-wp-codebox-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the World Creator evidence extraction failure and drafted the metadata-shape hardening/test coverage; Chris remains responsible for review and merge.
