### PR TITLE
Allow no-change agent runs without PR requirement

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -978,20 +978,23 @@ jobs:
           job_status="$(jq -r '.metadata.job_status // ""' <<< "$scenario_json")"
           success_status="$(jq -r '.metadata.success_status // ""' <<< "$scenario_json")"
           completion_outcome_satisfied="$(jq -r 'if .metadata.completion_outcome_satisfied == true then "true" else "false" end' <<< "$scenario_json")"
+          no_changes_allowed="${{ inputs.success_requires_pr && 'false' || 'true' }}"
 
           printf 'job_status:                      %s\n' "$job_status"
           printf 'success_status:                  %s\n' "$success_status"
           printf 'completion_outcome_satisfied:    %s\n' "$completion_outcome_satisfied"
+          printf 'no_changes_allowed:              %s\n' "$no_changes_allowed"
 
-          if [ "$job_status" = "completed" ] || [ "$success_status" = "pr_opened" ] || [ "$completion_outcome_satisfied" = "true" ]; then
+          if [ "$job_status" = "completed" ] || [ "$success_status" = "pr_opened" ] || [ "$completion_outcome_satisfied" = "true" ] || { [ "$success_status" = "no_changes" ] && [ "$no_changes_allowed" = "true" ]; }; then
             exit 0
           fi
 
-          printf 'ERROR: scenario %s expected completed job, opened PR, or satisfied completion outcome, got job_status=%s success_status=%s completion_outcome_satisfied=%s\n' \
+          printf 'ERROR: scenario %s expected completed job, opened PR, satisfied completion outcome, or allowed no-changes result, got job_status=%s success_status=%s completion_outcome_satisfied=%s no_changes_allowed=%s\n' \
             "${{ inputs.flow_slug }}" \
             "$job_status" \
             "$success_status" \
-            "$completion_outcome_satisfied" >&2
+            "$completion_outcome_satisfied" \
+            "$no_changes_allowed" >&2
           exit 1
 
       - name: Resolve transcript artifact path

--- a/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
@@ -134,7 +134,7 @@ namespace {
 		fwrite( STDERR, "Expected reusable workflow config to require import-agent for execute-workflow runs.\n" );
 		exit( 1 );
 	}
-	if ( ! str_contains( $workflow_source, 'success_status="$(jq -r' ) || ! str_contains( $workflow_source, '[ "$job_status" = "completed" ] || [ "$success_status" = "pr_opened" ] || [ "$completion_outcome_satisfied" = "true" ]' ) ) {
+	if ( ! str_contains( $workflow_source, 'success_status="$(jq -r' ) || ! str_contains( $workflow_source, '[ "$success_status" = "no_changes" ] && [ "$no_changes_allowed" = "true" ]' ) ) {
 		fwrite( STDERR, "Expected reusable workflow success assertion to accept opened PRs and satisfied completion outcomes.\n" );
 		exit( 1 );
 	}

--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -141,6 +141,7 @@ const output = {
     agent_slug: 'wp-codebox-smoke-agent',
     flow_slug: 'wp-codebox-smoke-flow',
     transcript_artifacts: [[{ json: '/tmp/wp-codebox-smoke-transcript.json', summary: 'Nested transcript fixture' }]],
+    job_artifact_exports: [{ pr_url: 'https://github.com/example/repo/pull/123', branch: 'agent-artifacts/example' }],
     engine_data: {
       ok: true,
     },
@@ -241,8 +242,10 @@ replay_bundle_available=$(jq -r "$scenario | .metadata.evidence_references.refer
 verifier_available=$(jq -r "$scenario | .metadata.evidence_references.references.artifact_verifier_result.available // false" "$RESULTS_TMPFILE")
 policy_available=$(jq -r "$scenario | .metadata.evidence_references.references.workspace_policy_result.available // false" "$RESULTS_TMPFILE")
 transcript_path=$(jq -r "$scenario | .metadata.evidence_references.references.transcript_artifact.path // \"\"" "$RESULTS_TMPFILE")
+pull_request_value=$(jq -r "$scenario | .metadata.evidence_references.references.pull_request.value // \"\"" "$RESULTS_TMPFILE")
+workspace_branch_value=$(jq -r "$scenario | .metadata.evidence_references.references.workspace_branch.value // \"\"" "$RESULTS_TMPFILE")
 trace_gap=$(jq -r "$scenario | any(.metadata.evidence_references.compatibility_gaps[]?; .field == \"runtime_episode_trace\")" "$RESULTS_TMPFILE")
-if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_available" != "true" ] || [ "$policy_available" != "true" ] || [ "$transcript_path" != "/tmp/wp-codebox-smoke-transcript.json" ] || [ "$trace_gap" != "false" ]; then
+if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_available" != "true" ] || [ "$policy_available" != "true" ] || [ "$transcript_path" != "/tmp/wp-codebox-smoke-transcript.json" ] || [ "$pull_request_value" != "https://github.com/example/repo/pull/123" ] || [ "$workspace_branch_value" != "agent-artifacts/example" ] || [ "$trace_gap" != "false" ]; then
     echo "ERROR: stable evidence references missing or incomplete" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -470,17 +470,16 @@ homeboy_datamachine_agent_attach_evidence_references() {
                 ($metadata.engine_data[]? | objects | .github_tool_results? // [] | .[]?)
             ] | map(select(.tool_name == "create_github_pull_request" and .success == true and (.url // "") != "") | .url) | first) // "";
         def pr_url($metadata):
-            $metadata.job_artifact_exports.pr_url
-            // $metadata.fallback_pull_request.result.html_url
-            // $metadata.fallback_pull_request.result.url
-            // $metadata.fallback_pull_request.result.pull_request.html_url
+            first_field($metadata.job_artifact_exports; "pr_url")
+            // first_field($metadata.fallback_pull_request; "html_url")
+            // first_field($metadata.fallback_pull_request; "url")
             // first_tool_pr_url($metadata)
             // "";
         def workspace_branch($metadata):
-            $metadata.runner_workspace_capture.status.branch
-            // $metadata.runner_workspace.branch
-            // $metadata.job_artifact_exports.branch
-            // $metadata.fallback_pull_request.input.head
+            first_field($metadata.runner_workspace_capture; "branch")
+            // first_field($metadata.runner_workspace; "branch")
+            // first_field($metadata.job_artifact_exports; "branch")
+            // first_field($metadata.fallback_pull_request; "head")
             // "";
         def evidence($scenario):
             ($scenario.metadata // {}) as $metadata


### PR DESCRIPTION
## Summary
- allow reusable agent CI to pass `success_status=no_changes` when `success_requires_pr` is false
- keep no-change runs failing when a PR is explicitly required
- update the workflow assertion smoke guard

## Testing
- `php scripts/agent/datamachine-agent-child-drain-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the World Creator no-change assertion failure and drafted the reusable workflow assertion update; Chris remains responsible for review and merge.
