### PR TITLE
Group WP Codebox audit remediation tasks

### DIFF
--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -104,10 +104,19 @@ function normalizeFinding(finding, index) {
 }
 
 function groupFindings(findings) {
-  return findings.map((finding, index) => ({
-    key: finding.id,
+  const groupsByKey = new Map();
+  for (const finding of findings) {
+    const key = finding.fix_batch_key || finding.kind;
+    if (!groupsByKey.has(key)) {
+      groupsByKey.set(key, []);
+    }
+    groupsByKey.get(key).push(finding);
+  }
+
+  return Array.from(groupsByKey.entries()).map(([key, groupedFindings], index) => ({
+    key,
     index,
-    findings: [finding],
+    findings: groupedFindings,
   }));
 }
 
@@ -121,23 +130,25 @@ function sandboxSessionId(orchestrator, group) {
 }
 
 function taskPrompt(group) {
-  const finding = group.findings[0] || {};
-  const location = `${finding.file || ''}${finding.line ? `:${finding.line}` : ''}`;
+  const findings = group.findings || [];
+  const findingList = findings
+    .map((finding) => {
+      const location = `${finding.file || ''}${finding.line ? `:${finding.line}` : ''}`;
+      return `- ${finding.id}: ${finding.kind}${location ? ` in ${location}` : ''}${finding.message ? ` — ${finding.message}` : ''}`;
+    })
+    .join('\n');
 
   return [
-    `Fix Homeboy audit finding ${finding.id || group.key}.`,
+    `Fix the Homeboy audit remediation group ${group.key}.`,
     '',
     'Expected outcome:',
-    '- Open a pull request that fixes this audit finding, or',
-    '- If the finding is a false positive, fix the audit detector/config/test path that produced it and open a pull request for that correction.',
+    '- Open a pull request that fixes every finding in this remediation group, or',
+    '- If the group is a false positive, fix the audit detector/config/test path that produced it and open a pull request for that correction.',
     '',
-    'Return machine-readable outcome metadata when possible, including the PR URL, false-positive PR URL, or explicit failure reason.',
+    'Return machine-readable outcome metadata when possible, including the PR URL, false-positive PR URL, or explicit failure reason. The parent run reconciles this outcome back to each finding ID.',
     '',
     'Finding evidence:',
-    `- id: ${finding.id || group.key}`,
-    `- kind: ${finding.kind || 'unknown'}`,
-    location ? `- location: ${location}` : '',
-    finding.message ? `- message: ${finding.message}` : '',
+    findingList,
   ].join('\n\n');
 }
 
@@ -147,7 +158,6 @@ function createTaskRequest(group, orchestrator) {
     schema: TASK_SCHEMA,
     sandbox_session_id,
     group_key: group.key,
-    finding_id: group.findings[0]?.id || group.key,
     orchestrator: {
       id: orchestrator.id,
       run_id: orchestrator.run_id,
@@ -166,7 +176,7 @@ function createTaskRequest(group, orchestrator) {
       severity: finding.severity,
     })),
     task: {
-      title: `Fix Homeboy audit finding ${group.findings[0]?.id || group.key}`,
+      title: `Fix Homeboy audit remediation group ${group.key}`,
       prompt: taskPrompt(group),
     },
   };

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -116,7 +116,7 @@ process.stdin.on('end', () => {
     setInterval(() => {}, 1000);
     return;
   }
-  if (request.group_key === 'finding-doc-001') {
+  if (request.group_key === 'docs-reference') {
     if (process.env.FIXTURE_EXPECT_INCREMENTAL_RUN) {
       const run = JSON.parse(fs.readFileSync(process.env.FIXTURE_EXPECT_INCREMENTAL_RUN, 'utf8'));
       if (run.status !== 'incomplete' || run.records.length !== 1 || !run.current_group || run.current_group.group_key !== request.group_key) {
@@ -155,7 +155,7 @@ process.stdin.on('end', () => {
       preview: { url: 'https://preview.example.test/' + request.sandbox_session_id },
     },
     outcome: {
-      pr_url: 'https://github.com/Extra-Chill/homeboy-extensions/pull/' + (request.finding_id === 'finding-phpcs-002' ? '778' : '777')
+      pr_url: 'https://github.com/Extra-Chill/homeboy-extensions/pull/' + (request.group_key === 'docs-reference' ? '778' : '777')
     },
   }));
 });
@@ -179,9 +179,9 @@ try {
   });
   assert.equal(initialPlan.schema, 'homeboy/audit-wp-codebox-fanout/v1');
   assert.equal(initialPlan.audit.finding_count, 3);
-  assert.equal(initialPlan.audit.group_count, 3);
-  assert.equal(initialPlan.audit.task_count, 3);
-  assert.equal(initialPlan.task_requests.length, 3);
+  assert.equal(initialPlan.audit.group_count, 2);
+  assert.equal(initialPlan.audit.task_count, 2);
+  assert.equal(initialPlan.task_requests.length, 2);
 
   assert.equal(safeBranchSlug('PHPCS Formatting/Auto Fix!'), 'phpcs-formatting-auto-fix');
   assert.equal(safeBranchSlug('foo..bar'), 'foo-bar');
@@ -189,18 +189,19 @@ try {
   assert.equal(safeBranchSlug('foo/bar.lock'), 'foo-bar-lock');
   assert.equal(safeBranchSlug('../.@{'), 'audit-batch');
 
-  const phpcsRequest = initialPlan.task_requests.find((request) => request.group_key === 'finding-phpcs-001');
-  const docsRequest = initialPlan.task_requests.find((request) => request.group_key === 'finding-doc-001');
-  assert.equal(phpcsRequest.audit_findings.length, 1);
+  const phpcsRequest = initialPlan.task_requests.find((request) => request.group_key === 'PHPCS Formatting/Auto Fix!');
+  const docsRequest = initialPlan.task_requests.find((request) => request.group_key === 'docs-reference');
+  assert.equal(phpcsRequest.audit_findings.length, 2);
   assert.equal(docsRequest.audit_findings.length, 1);
-  assert.equal(phpcsRequest.finding_id, 'finding-phpcs-001');
   assert.match(phpcsRequest.sandbox_session_id, /^homeboy-audit-[a-f0-9]{16}$/);
   assert.equal(phpcsRequest.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/769');
   assert.equal(phpcsRequest.provider, 'codex');
   assert.equal(phpcsRequest.model, 'gpt-5.5');
   assert.deepEqual(phpcsRequest.provider_plugin_paths, ['/opt/ai-provider-for-openai']);
   assert.deepEqual(phpcsRequest.secret_env, ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN']);
+  assert.match(phpcsRequest.task.prompt, /remediation group PHPCS Formatting\/Auto Fix!/);
   assert.match(phpcsRequest.task.prompt, /finding-phpcs-001/);
+  assert.match(phpcsRequest.task.prompt, /finding-phpcs-002/);
   assert.match(phpcsRequest.task.prompt, /false positive/);
   const falsePositiveOutcome = taskOutcome(phpcsRequest, {
     outcome: {
@@ -224,21 +225,14 @@ try {
     'docs/setup.md'
   );
   const artifactMap = {
-    'finding-phpcs-001': {
+    'PHPCS Formatting/Auto Fix!': {
       bundle_path: phpcsBundle.bundle,
       approved_files: [phpcsBundle.changedPath],
       reviewed_at: '2026-05-25T00:00:00.000Z',
       reviewer: 'homeboy-review-fixture',
       base: 'main',
     },
-    'finding-phpcs-002': {
-      bundle_path: phpcsBundle.bundle,
-      approved_files: [phpcsBundle.changedPath],
-      reviewed_at: '2026-05-25T00:00:00.000Z',
-      reviewer: 'homeboy-review-fixture',
-      base: 'main',
-    },
-    'finding-doc-001': {
+    'docs-reference': {
       bundle_path: docsBundle.bundle,
       approved_files: [docsBundle.changedPath],
       reviewed_at: '2026-05-25T00:00:00.000Z',
@@ -252,23 +246,23 @@ try {
     artifact_map: artifactMap,
     issue_url: 'https://github.com/Extra-Chill/homeboy-extensions/issues/769',
   });
-  assert.equal(plan.apply_back.length, 3);
-  const phpcsApplyBack = plan.apply_back.find((entry) => entry.group_key === 'finding-phpcs-001');
+  assert.equal(plan.apply_back.length, 2);
+  const phpcsApplyBack = plan.apply_back.find((entry) => entry.group_key === 'PHPCS Formatting/Auto Fix!');
   assert.equal(phpcsApplyBack.adapter_id, 'homeboy/wp-codebox-apply-adapter/v1');
   assert.equal(phpcsApplyBack.sandbox_session_id, phpcsRequest.sandbox_session_id);
-  assert.deepEqual(phpcsApplyBack.finding_ids, ['finding-phpcs-001']);
+  assert.deepEqual(phpcsApplyBack.finding_ids, ['finding-phpcs-001', 'finding-phpcs-002']);
   assert.equal(phpcsApplyBack.artifact.id, phpcsBundle.artifactId);
   assert.equal(phpcsApplyBack.artifact.content_digest, phpcsBundle.contentDigest);
   assert.equal(phpcsApplyBack.artifact.patch_sha256, phpcsBundle.patchSha256);
   assert.deepEqual(phpcsApplyBack.review.approved_files, [phpcsBundle.changedPath]);
   assert.equal(phpcsApplyBack.adapter_payload.bundlePath, fs.realpathSync(phpcsBundle.bundle));
-  assert.equal(phpcsApplyBack.adapter_payload.branch, 'fix/homeboy-audit/finding-phpcs-001');
+  assert.equal(phpcsApplyBack.adapter_payload.branch, 'fix/homeboy-audit/phpcs-formatting-auto-fix');
   assert.equal(phpcsApplyBack.pull_request.base, 'main');
-  assert.equal(phpcsApplyBack.pull_request.head, 'fix/homeboy-audit/finding-phpcs-001');
+  assert.equal(phpcsApplyBack.pull_request.head, 'fix/homeboy-audit/phpcs-formatting-auto-fix');
   assert.match(phpcsApplyBack.pull_request.body, /Extra-Chill\/homeboy-extensions\/issues\/769/);
 
   const missingApprovalMap = {
-    'finding-phpcs-001': {
+    'PHPCS Formatting/Auto Fix!': {
       bundle_path: phpcsBundle.bundle,
     },
   };
@@ -283,9 +277,9 @@ try {
   const rejectedPlan = createAuditWpCodeboxFanoutPlan({
     report,
     issue_url: 'https://github.com/Extra-Chill/homeboy-extensions/issues/769',
-    artifact_map: {
-      ...artifactMap,
-      'finding-doc-001': {
+      artifact_map: {
+        ...artifactMap,
+      'docs-reference': {
         bundle_path: docsBundle.bundle,
         approved_files: [docsBundle.changedPath],
         approved: false,
@@ -294,11 +288,11 @@ try {
       },
     },
   });
-  assert.equal(rejectedPlan.apply_back.length, 2);
-  assert.equal(rejectedPlan.apply_back[0].group_key, 'finding-phpcs-001');
+  assert.equal(rejectedPlan.apply_back.length, 1);
+  assert.equal(rejectedPlan.apply_back[0].group_key, 'PHPCS Formatting/Auto Fix!');
   assert.equal(rejectedPlan.issue_reports.length, 1);
   assert.equal(rejectedPlan.issue_reports[0].schema, 'homeboy/audit-wp-codebox-issue-report/v1');
-  assert.equal(rejectedPlan.issue_reports[0].group_key, 'finding-doc-001');
+  assert.equal(rejectedPlan.issue_reports[0].group_key, 'docs-reference');
   assert.equal(rejectedPlan.issue_reports[0].disposition, 'false_positive');
   assert.deepEqual(rejectedPlan.issue_reports[0].finding_ids, ['finding-doc-001']);
   assert.equal(rejectedPlan.issue_reports[0].artifact.id, docsBundle.artifactId);
@@ -319,8 +313,8 @@ try {
     providerPluginPaths: ['/opt/ai-provider-for-openai'],
     secretEnv: ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN'],
   });
-  assert.equal(filePlan.apply_back.length, 3);
-  assert.equal(readJson(outputPath).apply_back.length, 3);
+  assert.equal(filePlan.apply_back.length, 2);
+  assert.equal(readJson(outputPath).apply_back.length, 2);
 
   const cliOutput = run(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-audit-wp-codebox-fanout.cjs'),
@@ -340,8 +334,8 @@ try {
     'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
   ]);
   const cliPlan = JSON.parse(cliOutput);
-  assert.equal(cliPlan.task_requests.length, 3);
-  assert.equal(cliPlan.apply_back.length, 3);
+  assert.equal(cliPlan.task_requests.length, 2);
+  assert.equal(cliPlan.apply_back.length, 2);
   assert.equal(cliPlan.task_requests[0].provider, 'codex');
 
   const fixtureCommand = createWpCodeboxFixtureCommand(root);
@@ -354,19 +348,20 @@ try {
     wp_codebox_args: [fixtureCommand],
   });
   assert.equal(execution.schema, 'homeboy/audit-wp-codebox-execution/v1');
-  assert.equal(execution.records.length, 3);
+  assert.equal(execution.records.length, 2);
   assert.equal(execution.status, 'failed');
-  const completedRecord = execution.records.find((record) => record.group_key === 'finding-phpcs-001');
-  const failedRecord = execution.records.find((record) => record.group_key === 'finding-doc-001');
+  const completedRecord = execution.records.find((record) => record.group_key === 'PHPCS Formatting/Auto Fix!');
+  const failedRecord = execution.records.find((record) => record.group_key === 'docs-reference');
   assert.equal(completedRecord.status, 'completed');
   assert.equal(completedRecord.finding_id, 'finding-phpcs-001');
+  assert.deepEqual(completedRecord.finding_ids, ['finding-phpcs-001', 'finding-phpcs-002']);
   assert.equal(completedRecord.command.bin, process.execPath);
   assert.equal(completedRecord.result.session.id, completedRecord.sandbox_session_id);
   assert.equal(completedRecord.result.session.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/773');
   assert.match(completedRecord.artifact.id, /^artifact-homeboy-audit-/);
   assert.equal(completedRecord.outcome.kind, 'fix_pr');
   assert.equal(completedRecord.outcome.pr_url, 'https://github.com/Extra-Chill/homeboy-extensions/pull/777');
-  assert.equal(execution.outcomes.length, 3);
+  assert.equal(execution.outcomes.length, 2);
   assert.equal(failedRecord.status, 'failed');
   assert.equal(failedRecord.command.exit_code, 3);
   assert.equal(failedRecord.outcome.kind, 'explicit_failure');
@@ -378,7 +373,7 @@ try {
     wp_codebox_args: [fixtureCommand],
     env: { FIXTURE_NESTED_WP_ERROR: '1' },
   });
-  const nestedFailedRecord = nestedErrorExecution.records.find((record) => record.group_key === 'finding-doc-001');
+  const nestedFailedRecord = nestedErrorExecution.records.find((record) => record.group_key === 'docs-reference');
   assert.equal(nestedErrorExecution.status, 'failed');
   assert.equal(nestedFailedRecord.status, 'failed');
   assert.equal(nestedFailedRecord.command.exit_code, 0);
@@ -392,11 +387,11 @@ try {
     concurrency: 1,
     task_timeout_seconds: 1,
     runsOutputPath: timeoutRunsOutputPath,
-    env: { FIXTURE_HANG_GROUP: 'finding-phpcs-001' },
+    env: { FIXTURE_HANG_GROUP: 'PHPCS Formatting/Auto Fix!' },
   });
   assert.equal(timeoutExecution.status, 'failed');
-  assert.equal(timeoutExecution.records.length, 3);
-  const timeoutRecord = timeoutExecution.records.find((record) => record.group_key === 'finding-phpcs-001');
+  assert.equal(timeoutExecution.records.length, 2);
+  const timeoutRecord = timeoutExecution.records.find((record) => record.group_key === 'PHPCS Formatting/Auto Fix!');
   assert.equal(timeoutRecord.status, 'failed');
   assert.equal(timeoutRecord.command.timed_out, true);
   assert.equal(timeoutRecord.command.timeout_seconds, 1);
@@ -405,13 +400,13 @@ try {
   assert.equal(timeoutRecord.outcome.kind, 'timeout');
   assert.match(timeoutRecord.stdout, /fixture partial stdout before timeout/);
   assert.match(timeoutRecord.stderr, /fixture partial stderr before timeout/);
-  const timeoutFollowupRecord = timeoutExecution.records.find((record) => record.group_key === 'finding-doc-001');
+  const timeoutFollowupRecord = timeoutExecution.records.find((record) => record.group_key === 'docs-reference');
   assert.equal(timeoutFollowupRecord.status, 'failed');
   assert.equal(timeoutFollowupRecord.command.exit_code, 3);
   const timeoutFinalRun = readJson(timeoutRunsOutputPath);
   assert.equal(timeoutFinalRun.status, 'failed');
-  assert.equal(timeoutFinalRun.records.length, 3);
-  assert.equal(timeoutFinalRun.outcomes.length, 3);
+  assert.equal(timeoutFinalRun.records.length, 2);
+  assert.equal(timeoutFinalRun.outcomes.length, 2);
   assert.equal(Object.hasOwn(timeoutFinalRun, 'current_group'), false);
 
   const runsOutputPath = path.join(root, 'fanout-run.json');
@@ -426,9 +421,9 @@ try {
       FIXTURE_EXPECT_INCREMENTAL_RUN: runsOutputPath,
     },
   });
-  assert.equal(fileExecution.records.length, 3);
+  assert.equal(fileExecution.records.length, 2);
   const finalRun = readJson(runsOutputPath);
-  assert.equal(finalRun.records.length, 3);
+  assert.equal(finalRun.records.length, 2);
   assert.equal(Object.hasOwn(finalRun, 'current_group'), false);
 
   const cliExecutionResult = spawnSync(process.execPath, [
@@ -449,11 +444,11 @@ try {
   ], { encoding: 'utf8' });
   assert.equal(cliExecutionResult.status, 0, cliExecutionResult.stderr || cliExecutionResult.stdout);
   const cliExecution = JSON.parse(cliExecutionResult.stdout);
-  assert.equal(cliExecution.records.length, 3);
+  assert.equal(cliExecution.records.length, 2);
   assert.equal(cliExecution.records[0].schema, 'homeboy/audit-wp-codebox-run/v1');
-  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/3 group=finding-phpcs-001 session=homeboy-audit-/);
-  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] completed 1\/3 group=finding-phpcs-001 session=homeboy-audit-.*artifact=\/tmp\/homeboy-audit-/);
-  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] failed 3\/3 group=finding-doc-001 session=homeboy-audit-/);
+  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-/);
+  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] completed 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-.*artifact=\/tmp\/homeboy-audit-/);
+  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] failed 2\/2 group=docs-reference session=homeboy-audit-/);
   assert.doesNotMatch(cliExecutionResult.stderr, /FIXTURE_SECRET_TOKEN/);
 
   console.log('Homeboy audit WP Codebox fanout smoke passed');

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -46,14 +46,14 @@ try {
   assert.equal(response.handled, true);
   assert.equal(response.detected_findings, 3);
   assert.equal(response.changed_files.length, 0);
-  assert.equal(response.fix_results.length, 3);
+  assert.equal(response.fix_results.length, 2);
   assert.equal(response.fix_results[0].rule, 'wp_codebox.audit_fanout');
   assert.equal(response.fix_results[0].primitive, 'extension_refactor_source');
   assert.match(response.warnings[0], /fanout-plan\.json/);
 
   const plan = JSON.parse(fs.readFileSync(path.join(outputDir, 'fanout-plan.json'), 'utf8'));
   assert.equal(plan.schema, 'homeboy/audit-wp-codebox-fanout/v1');
-  assert.equal(plan.task_requests.length, 3);
+  assert.equal(plan.task_requests.length, 2);
   assert.equal(plan.task_requests[0].provider, 'opencode');
   assert.equal(plan.task_requests[0].model, 'opencode-go/kimi-k2.6');
   assert.deepEqual(plan.task_requests[0].provider_plugin_paths, ['/plugins/ai-provider-for-opencode']);
@@ -73,7 +73,7 @@ const stepArgs = recipe.workflow.steps[0].args;
 const task = JSON.parse(stepArgs.find((arg) => arg.startsWith('task=')).slice('task='.length));
 const sessionId = task.sandbox_session_id;
 const artifactDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'fixture-wp-codebox-artifact-'));
-if (task.group_key === 'finding-phpcs-001') {
+if (task.group_key === 'PHPCS Formatting/Auto Fix!') {
   const filesDirectory = path.join(artifactDirectory, 'files');
   fs.mkdirSync(filesDirectory, { recursive: true });
   fs.writeFileSync(path.join(filesDirectory, 'changed-files.json'), JSON.stringify({
@@ -104,7 +104,7 @@ process.stdout.write(JSON.stringify({
     directory: artifactDirectory
   },
   outcome: {
-    pr_url: 'https://github.com/Extra-Chill/homeboy-extensions/pull/' + (task.group_key === 'finding-phpcs-001' ? '777' : '778')
+    pr_url: 'https://github.com/Extra-Chill/homeboy-extensions/pull/' + (task.group_key === 'PHPCS Formatting/Auto Fix!' ? '777' : '778')
   }
 }));
 `);
@@ -145,8 +145,8 @@ process.stdout.write(JSON.stringify({
   assert.equal(writeResponse.handled, true);
   assert.deepEqual(writeResponse.changed_files, ['src/example.php']);
   assert.equal(fs.readFileSync(path.join(writeCommand.settings.wp_codebox_agents_api_path, 'src', 'example.php'), 'utf8'), 'after\n');
-  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/3 group=finding-phpcs-001 session=homeboy-audit-/);
-  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] completed 3\/3 group=finding-doc-001 session=homeboy-audit-.*artifact=.*fixture-wp-codebox-artifact-/);
+  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-/);
+  assert.match(writeResult.stderr, /\[homeboy wp-codebox fanout\] completed 2\/2 group=docs-reference session=homeboy-audit-.*artifact=.*fixture-wp-codebox-artifact-/);
   assert.doesNotMatch(writeResult.stderr, /OPENCODE_API_KEY/);
   assert.match(writeResponse.warnings[1], /fanout-run\.json/);
   const run = JSON.parse(fs.readFileSync(path.join(writeOutputDir, 'fanout-run.json'), 'utf8'));
@@ -175,7 +175,7 @@ process.stdout.write(JSON.stringify({
     },
   });
   assert.notEqual(missingSecretResult.status, 0);
-  assert.match(missingSecretResult.stderr, /WP Codebox audit fan-out failed: 3 of 3 task\(s\) failed/);
+  assert.match(missingSecretResult.stderr, /WP Codebox audit fan-out failed: 2 of 2 task\(s\) failed/);
   assert.match(missingSecretResult.stderr, /Required WP Codebox secret environment variable missing: OPENCODE_API_KEY/);
 
   const riskyRoot = path.join(root, 'risky-source');


### PR DESCRIPTION
## Summary
- Restore WP Codebox audit fanout units to remediation groups using fix_batch_key or finding kind.
- Keep all individual audit findings inside each grouped task for evidence and reconciliation.
- Update prompts and smoke expectations to describe remediation groups rather than one task per finding.

## Related
- Follow-up to #821 and Extra-Chill/homeboy#2978.

## Tests
- node wordpress/tests/audit-wp-codebox-fanout-smoke.js
- node wordpress/tests/refactor-source-wp-codebox-smoke.js
- python3 -m py_compile wordpress/scripts/refactor.py
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Corrected the fanout unit semantics and updated focused smoke coverage for Chris to review.