### PR TITLE
Upload agent results after failed runs

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -1038,6 +1038,14 @@ jobs:
           path: ${{ steps.transcript-artifact.outputs.path }}
           if-no-files-found: error
 
+      - name: Upload agent results artifact
+        if: ${{ always() && inputs.run_agent && inputs.transcript_artifact_name != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.transcript_artifact_name }}-results
+          path: ${{ runner.temp }}/run-results.json
+          if-no-files-found: warn
+
       - name: Upload replay bundle artifact
         if: ${{ always() && inputs.run_agent && inputs.replay_bundle_artifact_name != '' }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- always upload the Data Machine agent run-results JSON when a transcript artifact name is configured
- preserve diagnostics for failed agent runs that exit before transcript artifact resolution

## Testing
- npm run test:datamachine-agent-wp-codebox-runner
- bash scripts/agent/extract-engine-data-smoke.sh

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the reusable workflow artifact change and ran the targeted runner smoke checks; Chris remains responsible for review and merge.