### PR TITLE
fix: pass WP Codebox max turns setting

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -31,7 +31,7 @@ function hasFlag(name) {
 }
 
 function usage() {
-  console.error('Usage: homeboy-wp-codebox-task-runner.cjs --agents-api <path> --data-machine <path> --data-machine-code <path> [--wp-codebox-bin <bin>] [--provider <id>] [--model <id>] [--provider-plugin-path <path>] [--secret-env <ENV>] [--mount <host:vfs[:mode]>] [--artifacts <dir>]');
+  console.error('Usage: homeboy-wp-codebox-task-runner.cjs --agents-api <path> --data-machine <path> --data-machine-code <path> [--wp-codebox-bin <bin>] [--provider <id>] [--model <id>] [--max-turns <n>] [--provider-plugin-path <path>] [--secret-env <ENV>] [--mount <host:vfs[:mode]>] [--artifacts <dir>]');
   process.exit(1);
 }
 
@@ -167,6 +167,7 @@ function recipeForRequest(request, options) {
   });
 
   const providerSlugs = providerPluginEntries(request).map((plugin) => plugin.slug).join(',');
+  const maxTurns = argValue('--max-turns') || request.max_turns || request.maxTurns || '';
   const stepArgs = [
     `task=${task}`,
     'agent=sandbox-agent',
@@ -175,6 +176,9 @@ function recipeForRequest(request, options) {
     `model=${model}`,
     `provider-plugin-slugs=${providerSlugs}`,
   ];
+  if (maxTurns) {
+    stepArgs.push(`max-turns=${maxTurns}`);
+  }
 
   return {
     schema: 'wp-codebox/workspace-recipe/v1',

--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -849,6 +849,8 @@ def wp_codebox_task_runner_args(data, settings, script_dir):
     ]
     if settings.get('wp_codebox_bin'):
         args.extend(['--wp-codebox-bin', settings['wp_codebox_bin']])
+    if settings.get('wp_codebox_max_turns'):
+        args.extend(['--max-turns', str(settings['wp_codebox_max_turns'])])
     args.extend(['--artifacts', settings['wp_codebox_artifacts']])
     for mount in split_setting(settings.get('wp_codebox_mounts')):
         args.extend(['--mount', mount])

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -93,6 +93,8 @@ try {
     '/components/data-machine-code',
     '--mount',
     '/repo/plugin:/wordpress/wp-content/plugins/plugin:readwrite',
+    '--max-turns',
+    '80',
     '--artifacts',
     path.join(root, 'artifacts'),
   ], {
@@ -127,6 +129,7 @@ try {
   assert.equal(step.command, 'wp-codebox.agent-sandbox-run');
   assert.equal(step.args.includes('provider=opencode'), true);
   assert.equal(step.args.includes('model=opencode-go/kimi-k2.6'), true);
+  assert.equal(step.args.includes('max-turns=80'), true);
   assert.equal(step.args.includes('provider-plugin-slugs=example-provider'), true);
   assert.equal(step.args.some((arg) => arg.startsWith('session-id=')), false);
 


### PR DESCRIPTION
## Summary
- add wp_codebox_max_turns plumbing from Homeboy refactor settings into the WP Codebox task runner
- pass max-turns=<n> to wp-codebox.agent-sandbox-run
- cover the generated recipe argument in the task-runner smoke test

## Tests
- node tests/wp-codebox-task-runner-smoke.js
- python3 -m py_compile scripts/refactor.py
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the lab fanout turn-budget bottleneck, drafted the setting pass-through, and ran focused verification.