### PR TITLE
Preserve WP Codebox fanout outcome kinds

### DIFF
--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -24,6 +24,13 @@ const TASK_SCHEMA = 'homeboy/wp-codebox-task-request/v1';
 const RUN_SCHEMA = 'homeboy/audit-wp-codebox-run/v1';
 const DEFAULT_CONCURRENCY = 3;
 const DEFAULT_TASK_TIMEOUT_SECONDS = 45 * 60;
+const WP_CODEBOX_STRUCTURED_OUTCOME_KINDS = new Set([
+  'fix_pr',
+  'false_positive_pr',
+  'provider_error',
+  'agent_no_pr_outcome',
+  'max_turns_exceeded',
+]);
 
 function sha256(value) {
   return crypto.createHash('sha256').update(value).digest('hex');
@@ -69,6 +76,9 @@ function progressEvent(status, taskRequest, plan, record = null) {
     finished_at: finishedAt,
     elapsed_ms: elapsedMs,
     artifact_directory: record?.artifact?.directory || '',
+    outcome_kind: record?.outcome?.kind || '',
+    retryable: record?.outcome?.retryable ?? null,
+    failure: record?.outcome?.failure || '',
   };
 }
 
@@ -561,8 +571,12 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
 }
 
 function taskOutcome(taskRequest, parsed, artifact, success, errorMessage = '', timedOut = false) {
+  const explicit = explicitWpCodeboxOutcome(parsed);
+  if (isStructuredWpCodeboxOutcome(explicit)) {
+    return structuredTaskOutcome(taskRequest, explicit, artifact, errorMessage);
+  }
+
   const urls = pullRequestUrls(parsed);
-  const explicit = parsed && typeof parsed === 'object' ? parsed.outcome || parsed.result || parsed : {};
   const falsePositive = Boolean(
     explicit.kind === 'false_positive_pr' ||
     explicit.false_positive ||
@@ -601,6 +615,62 @@ function taskOutcome(taskRequest, parsed, artifact, success, errorMessage = '', 
     artifact_id: artifact?.id || '',
     failure,
   };
+}
+
+function explicitWpCodeboxOutcome(parsed) {
+  if (!parsed || typeof parsed !== 'object') {
+    return {};
+  }
+  if (parsed.outcome && typeof parsed.outcome === 'object') {
+    return parsed.outcome;
+  }
+  if (parsed.result?.outcome && typeof parsed.result.outcome === 'object') {
+    return parsed.result.outcome;
+  }
+  if (parsed.result && typeof parsed.result === 'object') {
+    return parsed.result;
+  }
+  return parsed;
+}
+
+function isStructuredWpCodeboxOutcome(explicit) {
+  return Boolean(explicit && typeof explicit === 'object' && WP_CODEBOX_STRUCTURED_OUTCOME_KINDS.has(explicit.kind));
+}
+
+function structuredTaskOutcome(taskRequest, explicit, artifact, errorMessage = '') {
+  const urls = pullRequestUrls(explicit);
+  const kind = explicit.kind;
+  const falsePositive = kind === 'false_positive_pr' || Boolean(explicit.false_positive || explicit.falsePositive);
+  const prUrl = explicit.pr_url || explicit.pull_request_url || explicit.pullRequestUrl || urls[0] || '';
+  const falsePositivePrUrl = explicit.false_positive_pr_url || explicit.falsePositivePullRequestUrl || (falsePositive ? prUrl : '');
+  const failure = explicit.failure || wpCodeboxOutcomeErrorMessage(explicit) || errorMessage || '';
+  const retryable = explicit.retryable ?? explicit.provider_error?.retryable ?? explicit.error?.retryable;
+
+  return {
+    ...explicit,
+    schema: 'homeboy/audit-wp-codebox-finding-outcome/v1',
+    kind,
+    finding_id: taskRequest.finding_id || taskRequest.audit_findings?.[0]?.id || '',
+    finding_ids: taskRequest.audit_findings.map((finding) => finding.id),
+    sandbox_session_id: taskRequest.sandbox_session_id,
+    pr_url: prUrl,
+    false_positive_pr_url: falsePositivePrUrl,
+    false_positive: falsePositive,
+    artifact_id: explicit.artifact_id || artifact?.id || '',
+    failure,
+    ...(retryable === undefined ? {} : { retryable: Boolean(retryable) }),
+  };
+}
+
+function wpCodeboxOutcomeErrorMessage(explicit) {
+  const candidates = [
+    explicit.message,
+    explicit.provider_message,
+    explicit.provider_error?.message,
+    explicit.error?.message,
+    typeof explicit.error === 'string' ? explicit.error : '',
+  ];
+  return candidates.find((candidate) => typeof candidate === 'string' && candidate.trim()) || '';
 }
 
 function taskOutcomeSucceeded(outcome) {

--- a/wordpress/scripts/agent/homeboy-audit-wp-codebox-fanout.cjs
+++ b/wordpress/scripts/agent/homeboy-audit-wp-codebox-fanout.cjs
@@ -38,13 +38,16 @@ function usage() {
 function writeProgress(event) {
   const elapsed = event.elapsed_ms === null ? '' : ` elapsed=${event.elapsed_ms}ms`;
   const artifact = event.artifact_directory ? ` artifact=${event.artifact_directory}` : '';
+  const outcome = event.outcome_kind ? ` outcome=${event.outcome_kind}` : '';
+  const retryable = event.retryable === null ? '' : ` retryable=${event.retryable ? 'yes' : 'no'}`;
+  const failure = event.failure ? ` failure=${event.failure}` : '';
   process.stderr.write([
     '[homeboy wp-codebox fanout]',
     event.status,
     `${event.group_index}/${event.group_count}`,
     `group=${event.group_key}`,
     `session=${event.sandbox_session_id}`,
-    `${elapsed}${artifact}`.trim(),
+    `${elapsed}${artifact}${outcome}${retryable}${failure}`.trim(),
   ].filter(Boolean).join(' ') + '\n');
 }
 

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -116,6 +116,28 @@ process.stdin.on('end', () => {
     setInterval(() => {}, 1000);
     return;
   }
+  if (process.env.FIXTURE_PROVIDER_ERROR_GROUP === request.group_key) {
+    process.stdout.write(JSON.stringify({
+      success: false,
+      outcome: {
+        kind: 'provider_error',
+        retryable: true,
+        provider: 'openai',
+        provider_error: {
+          code: 'rate_limit_exceeded',
+          message: 'Fixture provider returned 429',
+          retryable: true,
+        },
+        metadata: {
+          datamachine: {
+            completed: false,
+            max_turns_reached: false,
+          },
+        },
+      },
+    }));
+    process.exit(2);
+  }
   if (request.group_key === 'docs-reference') {
     if (process.env.FIXTURE_EXPECT_INCREMENTAL_RUN) {
       const run = JSON.parse(fs.readFileSync(process.env.FIXTURE_EXPECT_INCREMENTAL_RUN, 'utf8'));
@@ -211,6 +233,62 @@ try {
   }, null, true);
   assert.equal(falsePositiveOutcome.kind, 'false_positive_pr');
   assert.equal(falsePositiveOutcome.false_positive_pr_url, 'https://github.com/Extra-Chill/homeboy-extensions/pull/779');
+  assert.deepEqual(falsePositiveOutcome.finding_ids, ['finding-phpcs-001', 'finding-phpcs-002']);
+
+  const structuredFixOutcome = taskOutcome(phpcsRequest, {
+    outcome: {
+      kind: 'fix_pr',
+      pr_url: 'https://github.com/Extra-Chill/homeboy-extensions/pull/780',
+      remediation_summary: 'Fixture fix PR opened.',
+    },
+  }, { id: 'artifact-fixture-fix' }, true);
+  assert.equal(structuredFixOutcome.kind, 'fix_pr');
+  assert.equal(structuredFixOutcome.pr_url, 'https://github.com/Extra-Chill/homeboy-extensions/pull/780');
+  assert.equal(structuredFixOutcome.artifact_id, 'artifact-fixture-fix');
+  assert.equal(structuredFixOutcome.remediation_summary, 'Fixture fix PR opened.');
+  assert.deepEqual(structuredFixOutcome.finding_ids, ['finding-phpcs-001', 'finding-phpcs-002']);
+
+  const providerErrorOutcome = taskOutcome(phpcsRequest, {
+    outcome: {
+      kind: 'provider_error',
+      retryable: true,
+      provider: 'openai',
+      provider_error: {
+        code: 'rate_limit_exceeded',
+        message: 'Fixture provider returned 429',
+        retryable: true,
+      },
+      metadata: {
+        datamachine: {
+          completed: false,
+          max_turns_reached: false,
+        },
+      },
+    },
+  }, null, false, 'WP Codebox task reported success=false');
+  assert.equal(providerErrorOutcome.kind, 'provider_error');
+  assert.equal(providerErrorOutcome.retryable, true);
+  assert.equal(providerErrorOutcome.provider_error.code, 'rate_limit_exceeded');
+  assert.equal(providerErrorOutcome.failure, 'Fixture provider returned 429');
+  assert.deepEqual(providerErrorOutcome.finding_ids, ['finding-phpcs-001', 'finding-phpcs-002']);
+  assert.equal(providerErrorOutcome.metadata.datamachine.completed, false);
+
+  const noPrOutcome = taskOutcome(docsRequest, {
+    outcome: {
+      kind: 'agent_no_pr_outcome',
+      message: 'Agent completed without opening a required PR.',
+      metadata: {
+        datamachine: {
+          completed: true,
+          max_turns_reached: false,
+        },
+      },
+    },
+  }, null, true);
+  assert.equal(noPrOutcome.kind, 'agent_no_pr_outcome');
+  assert.equal(noPrOutcome.failure, 'Agent completed without opening a required PR.');
+  assert.deepEqual(noPrOutcome.finding_ids, ['finding-doc-001']);
+  assert.equal(noPrOutcome.metadata.datamachine.completed, true);
 
   const phpcsBundle = createBundle(
     root,
@@ -379,6 +457,24 @@ try {
   assert.equal(nestedFailedRecord.command.exit_code, 0);
   assert.match(nestedFailedRecord.command.error, /Fixture nested WP error/);
 
+  const providerRunsOutputPath = path.join(root, 'fanout-provider-error-run.json');
+  const providerErrorExecution = await executeAuditWpCodeboxFanout({
+    report,
+    wp_codebox_command: process.execPath,
+    wp_codebox_args: [fixtureCommand],
+    runsOutputPath: providerRunsOutputPath,
+    env: { FIXTURE_PROVIDER_ERROR_GROUP: 'PHPCS Formatting/Auto Fix!' },
+  });
+  const providerFailedRecord = providerErrorExecution.records.find((record) => record.group_key === 'PHPCS Formatting/Auto Fix!');
+  assert.equal(providerErrorExecution.status, 'failed');
+  assert.equal(providerFailedRecord.status, 'failed');
+  assert.equal(providerFailedRecord.outcome.kind, 'provider_error');
+  assert.equal(providerFailedRecord.outcome.retryable, true);
+  assert.equal(providerFailedRecord.outcome.provider_error.message, 'Fixture provider returned 429');
+  assert.deepEqual(providerFailedRecord.outcome.finding_ids, ['finding-phpcs-001', 'finding-phpcs-002']);
+  const providerFinalRun = readJson(providerRunsOutputPath);
+  assert.equal(providerFinalRun.outcomes.find((outcome) => outcome.kind === 'provider_error').retryable, true);
+
   const timeoutRunsOutputPath = path.join(root, 'fanout-timeout-run.json');
   const timeoutExecution = await executeAuditWpCodeboxFanout({
     report,
@@ -450,6 +546,25 @@ try {
   assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] completed 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-.*artifact=\/tmp\/homeboy-audit-/);
   assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] failed 2\/2 group=docs-reference session=homeboy-audit-/);
   assert.doesNotMatch(cliExecutionResult.stderr, /FIXTURE_SECRET_TOKEN/);
+
+  const cliProviderExecutionResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-audit-wp-codebox-fanout.cjs'),
+    '--audit-report',
+    auditReportPath,
+    '--execute',
+    '--wp-codebox-command',
+    process.execPath,
+    '--wp-codebox-arg',
+    fixtureCommand,
+  ], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      FIXTURE_PROVIDER_ERROR_GROUP: 'PHPCS Formatting/Auto Fix!',
+    },
+  });
+  assert.equal(cliProviderExecutionResult.status, 0, cliProviderExecutionResult.stderr || cliProviderExecutionResult.stdout);
+  assert.match(cliProviderExecutionResult.stderr, /failed 1\/2 group=PHPCS Formatting\/Auto Fix! .* outcome=provider_error retryable=yes failure=Fixture provider returned 429/);
 
   console.log('Homeboy audit WP Codebox fanout smoke passed');
 } finally {


### PR DESCRIPTION
## Summary
- preserve structured WP Codebox `outcome.kind` values in fanout run records and aggregate outcomes
- carry structured fields like `retryable`, `provider_error`, metadata, PR URLs, and reconciled finding IDs into normalized outcomes
- include outcome kind, retryability, and failure text in fanout progress output
- add fixture coverage for provider error, no-PR, fix PR, and false-positive PR outcomes

## Dependency
- Depends on chubes4/wp-codebox#202 exposing the structured `agent-sandbox-run` remediation outcome contract.
- This PR prepares the Homeboy Extensions consumer side using fixtures for the expected contract and keeps legacy fallback behavior for older/unstructured WP Codebox output.

## Verification
- `npm run test:audit-wp-codebox-fanout`
- `npm run lint:js -- lib/audit-wp-codebox-fanout.js scripts/agent/homeboy-audit-wp-codebox-fanout.cjs`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-wp-codebox-structured-outcomes --extension wordpress` (PHPUnit phase discovered zero PHPUnit test files and was skipped; activation/install passed)
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-wp-codebox-structured-outcomes --extension wordpress` (fails on existing broad PHP/fixture lint backlog outside this change)

Refs #828

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the fanout outcome preservation logic, fixture tests, verification, and PR preparation for Chris to review.