### PR TITLE
Install Composer deps for cloned validation dependencies

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -223,6 +223,10 @@ _homeboy_clone_dependency() {
     fi
 
     if git clone --depth 1 --quiet "$repo_url" "$clone_path" 2>/dev/null; then
+        if ! _homeboy_prepare_cloned_dependency "$clone_path"; then
+            rm -rf "$clone_path" 2>/dev/null || true
+            return 1
+        fi
         printf '%s\n' "$clone_path"
         return 0
     fi
@@ -230,6 +234,24 @@ _homeboy_clone_dependency() {
     # Clone failed — clean up partial clone
     rm -rf "$clone_path" 2>/dev/null || true
     return 1
+}
+
+_homeboy_prepare_cloned_dependency() {
+    local clone_path="${1:-}"
+
+    [ -n "$clone_path" ] && [ -d "$clone_path" ] || return 1
+    [ -f "${clone_path}/composer.json" ] || return 0
+    [ ! -f "${clone_path}/vendor/autoload.php" ] || return 0
+
+    if ! command -v composer >/dev/null 2>&1; then
+        echo "Warning: Validation dependency '${clone_path}' has composer.json but composer is not available." >&2
+        return 0
+    fi
+
+    if ! ( cd "$clone_path" && composer install --no-dev --no-interaction --quiet ); then
+        echo "Warning: Could not install Composer dependencies for validation dependency '${clone_path}'." >&2
+        return 1
+    fi
 }
 
 _homeboy_known_dependency_github_org() {

--- a/wordpress/tests/validation-dependencies-smoke.sh
+++ b/wordpress/tests/validation-dependencies-smoke.sh
@@ -129,6 +129,9 @@ if [ "${1:-}" = "clone" ]; then
  * Plugin Name: Data Machine
  */
 PHP
+            cat > "${clone_path}/composer.json" <<'JSON'
+{"name":"extra-chill/data-machine"}
+JSON
             exit 0
             ;;
     esac
@@ -137,6 +140,18 @@ fi
 exit 1
 SH
 chmod +x "${CLONE_BIN_DIR}/git"
+
+cat > "${CLONE_BIN_DIR}/composer" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "install" ]; then
+    mkdir -p vendor
+    : > vendor/autoload.php
+    exit 0
+fi
+exit 1
+SH
+chmod +x "${CLONE_BIN_DIR}/composer"
 
 source "$HELPER"
 
@@ -177,6 +192,11 @@ fallback_data_machine="${FALLBACK_CACHE_DIR}/homeboy-deps/data-machine"
 if ! grep -F -- "$fallback_data_machine" <<< "$fallback_resolved" >/dev/null; then
     echo "FAIL: data-machine dependency should resolve from Extra-Chill/data-machine" >&2
     printf '%s\n' "$fallback_resolved" >&2
+    exit 1
+fi
+
+if [ ! -f "${fallback_data_machine}/vendor/autoload.php" ]; then
+    echo "FAIL: cloned dependency Composer dependencies were not installed" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Install production Composer dependencies after Homeboy auto-clones a WordPress validation dependency.
- Clean up the cloned dependency if Composer preparation fails so later resolver attempts do not reuse a broken checkout.
- Extend the validation dependency smoke test to cover cloned dependency Composer preparation.

## Why
Data Machine Code CI auto-resolves `Requires Plugins: data-machine` by cloning `Extra-Chill/data-machine`, then mounts that checkout into WP Codebox. Without `vendor/autoload.php`, WordPress bootstrap fails before the selected DMC smoke test can run.

## Testing
- `bash wordpress/tests/validation-dependencies-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the validation dependency bootstrap failure, drafted the Composer preparation fix, and ran the targeted smoke test. Chris remains responsible for review and merge.
