### PR TITLE
Complete WP Codebox no-op outcomes

### DIFF
--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -25,6 +25,8 @@ const RUN_SCHEMA = 'homeboy/audit-wp-codebox-run/v1';
 const DEFAULT_CONCURRENCY = 3;
 const DEFAULT_TASK_TIMEOUT_SECONDS = 45 * 60;
 const WP_CODEBOX_STRUCTURED_OUTCOME_KINDS = new Set([
+  'fix_artifact',
+  'false_positive_artifact',
   'fix_pr',
   'false_positive_pr',
   'provider_error',
@@ -152,10 +154,10 @@ function taskPrompt(group) {
     `Fix the Homeboy audit remediation group ${group.key}.`,
     '',
     'Expected outcome:',
-    '- Open a pull request that fixes every finding in this remediation group, or',
-    '- If the group is a false positive, fix the audit detector/config/test path that produced it and open a pull request for that correction.',
+    '- Produce a reviewed WP Codebox artifact that fixes every finding in this remediation group, or',
+    '- If the group is a false positive, produce a reviewed artifact that fixes the audit detector/config/test path that produced it.',
     '',
-    'Return machine-readable outcome metadata when possible, including the PR URL, false-positive PR URL, or explicit failure reason. The parent run reconciles this outcome back to each finding ID.',
+    'The parent orchestrator applies accepted artifacts and opens pull requests outside the sandbox. Return machine-readable outcome metadata when possible, including an explicit artifact outcome or failure reason. The parent run reconciles this outcome back to each finding ID.',
     '',
     'Finding evidence:',
     findingList,
@@ -627,10 +629,46 @@ function explicitWpCodeboxOutcome(parsed) {
   if (parsed.result?.outcome && typeof parsed.result.outcome === 'object') {
     return parsed.result.outcome;
   }
+  if (parsed.agent_runtime?.result?.outcome && typeof parsed.agent_runtime.result.outcome === 'object') {
+    return parsed.agent_runtime.result.outcome;
+  }
+  if (parsed.output && typeof parsed.output === 'string') {
+    const output = tryParseJsonFragment(parsed.output);
+    const outcome = explicitWpCodeboxOutcome(output);
+    if (isStructuredWpCodeboxOutcome(outcome)) {
+      return outcome;
+    }
+  }
+  for (const execution of Array.isArray(parsed.executions) ? parsed.executions : []) {
+    for (const stream of ['stdout', 'stderr']) {
+      const decoded = tryParseJsonFragment(execution?.[stream] || '');
+      const outcome = explicitWpCodeboxOutcome(decoded);
+      if (isStructuredWpCodeboxOutcome(outcome)) {
+        return outcome;
+      }
+    }
+  }
   if (parsed.result && typeof parsed.result === 'object') {
     return parsed.result;
   }
   return parsed;
+}
+
+function tryParseJsonFragment(value) {
+  const text = String(value || '').trim();
+  if (!text) {
+    return null;
+  }
+  const direct = tryParseJson(text);
+  if (direct) {
+    return direct;
+  }
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start < 0 || end <= start) {
+    return null;
+  }
+  return tryParseJson(text.slice(start, end + 1));
 }
 
 function isStructuredWpCodeboxOutcome(explicit) {
@@ -640,7 +678,7 @@ function isStructuredWpCodeboxOutcome(explicit) {
 function structuredTaskOutcome(taskRequest, explicit, artifact, errorMessage = '') {
   const urls = pullRequestUrls(explicit);
   const kind = explicit.kind;
-  const falsePositive = kind === 'false_positive_pr' || Boolean(explicit.false_positive || explicit.falsePositive);
+  const falsePositive = ['false_positive_artifact', 'false_positive_pr'].includes(kind) || Boolean(explicit.false_positive || explicit.falsePositive);
   const prUrl = explicit.pr_url || explicit.pull_request_url || explicit.pullRequestUrl || urls[0] || '';
   const falsePositivePrUrl = explicit.false_positive_pr_url || explicit.falsePositivePullRequestUrl || (falsePositive ? prUrl : '');
   const failure = explicit.failure || wpCodeboxOutcomeErrorMessage(explicit) || errorMessage || '';
@@ -674,7 +712,7 @@ function wpCodeboxOutcomeErrorMessage(explicit) {
 }
 
 function taskOutcomeSucceeded(outcome) {
-  return ['fix_pr', 'false_positive_pr'].includes(outcome?.kind);
+  return ['fix_artifact', 'false_positive_artifact', 'fix_pr', 'false_positive_pr'].includes(outcome?.kind);
 }
 
 function pullRequestUrls(value, urls = []) {

--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -31,6 +31,8 @@ const WP_CODEBOX_STRUCTURED_OUTCOME_KINDS = new Set([
   'false_positive_pr',
   'provider_error',
   'agent_no_pr_outcome',
+  'noop_artifact',
+  'unable_to_remediate',
   'max_turns_exceeded',
 ]);
 
@@ -157,7 +159,7 @@ function taskPrompt(group) {
     '- Produce a reviewed WP Codebox artifact that fixes every finding in this remediation group, or',
     '- If the group is a false positive, produce a reviewed artifact that fixes the audit detector/config/test path that produced it.',
     '',
-    'The parent orchestrator applies accepted artifacts and opens pull requests outside the sandbox. Return machine-readable outcome metadata when possible, including an explicit artifact outcome or failure reason. The parent run reconciles this outcome back to each finding ID.',
+    'The parent orchestrator applies accepted artifacts and opens pull requests outside the sandbox. Return machine-readable outcome metadata for every terminal result: fix_artifact, false_positive_artifact, noop_artifact, unable_to_remediate, provider_error, max_turns_exceeded, or explicit_failure. The parent run reconciles this outcome back to each finding ID.',
     '',
     'Finding evidence:',
     findingList,
@@ -603,7 +605,7 @@ function taskOutcome(taskRequest, parsed, artifact, success, errorMessage = '', 
   );
   const prUrl = explicit.pr_url || explicit.pull_request_url || explicit.pullRequestUrl || urls[0] || '';
   const falsePositivePrUrl = explicit.false_positive_pr_url || explicit.falsePositivePullRequestUrl || (falsePositive ? prUrl : '');
-  let kind = 'explicit_failure';
+  let kind = success ? 'unable_to_remediate' : 'explicit_failure';
 
   if (timedOut) {
     kind = 'timeout';
@@ -616,7 +618,7 @@ function taskOutcome(taskRequest, parsed, artifact, success, errorMessage = '', 
   if (!success) {
     failure = errorMessage;
   } else if (kind === 'explicit_failure') {
-    failure = 'WP Codebox task completed without PR outcome';
+    failure = 'WP Codebox task failed without a structured outcome';
   }
 
   return {
@@ -748,7 +750,7 @@ function wpCodeboxOutcomeErrorMessage(explicit) {
 }
 
 function taskOutcomeSucceeded(outcome) {
-  return ['fix_artifact', 'false_positive_artifact', 'fix_pr', 'false_positive_pr'].includes(outcome?.kind);
+  return ['fix_artifact', 'false_positive_artifact', 'noop_artifact', 'unable_to_remediate', 'fix_pr', 'false_positive_pr'].includes(outcome?.kind);
 }
 
 function pullRequestUrls(value, urls = []) {

--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -578,6 +578,20 @@ function taskOutcome(taskRequest, parsed, artifact, success, errorMessage = '', 
     return structuredTaskOutcome(taskRequest, explicit, artifact, errorMessage);
   }
 
+  const changedFiles = artifactChangedFiles(artifact);
+  if (success && changedFiles.length > 0) {
+    const falsePositive = outputLooksFalsePositive(parsed);
+    return structuredTaskOutcome(taskRequest, {
+      kind: falsePositive ? 'false_positive_artifact' : 'fix_artifact',
+      artifact: {
+        id: artifact?.id || '',
+        directory: artifact?.directory || artifact?.path || '',
+        changed_files: changedFiles,
+      },
+      false_positive: falsePositive,
+    }, artifact, errorMessage);
+  }
+
   const urls = pullRequestUrls(parsed);
   const falsePositive = Boolean(
     explicit.kind === 'false_positive_pr' ||
@@ -617,6 +631,28 @@ function taskOutcome(taskRequest, parsed, artifact, success, errorMessage = '', 
     artifact_id: artifact?.id || '',
     failure,
   };
+}
+
+function artifactChangedFiles(artifact) {
+  const directory = artifact?.directory || artifact?.path || '';
+  if (!directory) {
+    return [];
+  }
+  const changedFilesPath = path.join(directory, 'files', 'changed-files.json');
+  if (!fs.existsSync(changedFilesPath)) {
+    return [];
+  }
+  const decoded = readJson(changedFilesPath);
+  return (Array.isArray(decoded.files) ? decoded.files : []).map((file) => ({
+    path: file.path || '',
+    relative_path: file.relativePath || file.relative_path || '',
+    status: file.status || '',
+  })).filter((file) => file.path || file.relative_path);
+}
+
+function outputLooksFalsePositive(parsed) {
+  const text = JSON.stringify(parsed || {}).toLowerCase();
+  return text.includes('false positive') || text.includes('false_positive');
 }
 
 function explicitWpCodeboxOutcome(parsed) {

--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -715,7 +715,7 @@ function isStructuredWpCodeboxOutcome(explicit) {
 
 function structuredTaskOutcome(taskRequest, explicit, artifact, errorMessage = '') {
   const urls = pullRequestUrls(explicit);
-  const kind = explicit.kind;
+  const kind = explicit.kind === 'agent_no_pr_outcome' ? 'unable_to_remediate' : explicit.kind;
   const falsePositive = ['false_positive_artifact', 'false_positive_pr'].includes(kind) || Boolean(explicit.false_positive || explicit.falsePositive);
   const prUrl = explicit.pr_url || explicit.pull_request_url || explicit.pullRequestUrl || urls[0] || '';
   const falsePositivePrUrl = explicit.false_positive_pr_url || explicit.falsePositivePullRequestUrl || (falsePositive ? prUrl : '');

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -338,7 +338,7 @@ try {
       },
     },
   }, null, true);
-  assert.equal(noPrOutcome.kind, 'agent_no_pr_outcome');
+  assert.equal(noPrOutcome.kind, 'unable_to_remediate');
   assert.equal(noPrOutcome.failure, 'Agent completed without opening a required PR.');
   assert.deepEqual(noPrOutcome.finding_ids, ['finding-doc-001']);
   assert.equal(noPrOutcome.metadata.datamachine.completed, true);

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -256,6 +256,27 @@ try {
   assert.equal(nestedArtifactOutcome.kind, 'fix_artifact');
   assert.equal(nestedArtifactOutcome.artifact.id, 'artifact-fixture-nested');
   assert.deepEqual(nestedArtifactOutcome.finding_ids, ['finding-phpcs-001', 'finding-phpcs-002']);
+
+  const artifactOnlyBundle = createBundle(
+    root,
+    'artifact-only-bundle',
+    '/wordpress/wp-content/plugins/fixture-plugin/src/ArtifactOnly.php',
+    'src/ArtifactOnly.php'
+  );
+  const artifactOnlyOutcome = taskOutcome(phpcsRequest, {
+    success: true,
+    artifacts: {
+      id: artifactOnlyBundle.artifactId,
+      directory: artifactOnlyBundle.bundle,
+    },
+    executions: [
+      {
+        stdout: JSON.stringify({ output: 'Agent completed with a reviewed artifact.' }),
+      },
+    ],
+  }, { id: artifactOnlyBundle.artifactId, directory: artifactOnlyBundle.bundle }, true);
+  assert.equal(artifactOnlyOutcome.kind, 'fix_artifact');
+  assert.equal(artifactOnlyOutcome.artifact.changed_files[0].relative_path, 'src/ArtifactOnly.php');
   const falsePositiveOutcome = taskOutcome(phpcsRequest, {
     outcome: {
       kind: 'false_positive_pr',

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -13,6 +13,7 @@ const {
   executeAuditWpCodeboxFanoutFromFiles,
   safeBranchSlug,
   taskOutcome,
+  taskOutcomeSucceeded,
 } = require('../lib/audit-wp-codebox-fanout');
 const { artifactContentDigest } = require('../lib/wp-codebox-apply-adapter');
 
@@ -341,6 +342,27 @@ try {
   assert.equal(noPrOutcome.failure, 'Agent completed without opening a required PR.');
   assert.deepEqual(noPrOutcome.finding_ids, ['finding-doc-001']);
   assert.equal(noPrOutcome.metadata.datamachine.completed, true);
+
+  const zeroChangeOutcome = taskOutcome(docsRequest, {
+    success: true,
+    artifacts: {
+      id: 'artifact-zero-change',
+      directory: path.join(root, 'zero-change-artifact'),
+    },
+  }, { id: 'artifact-zero-change', directory: path.join(root, 'zero-change-artifact') }, true);
+  assert.equal(zeroChangeOutcome.kind, 'unable_to_remediate');
+  assert.equal(taskOutcomeSucceeded(zeroChangeOutcome), true);
+  assert.deepEqual(zeroChangeOutcome.finding_ids, ['finding-doc-001']);
+
+  const noopOutcome = taskOutcome(docsRequest, {
+    outcome: {
+      kind: 'noop_artifact',
+      false_positive: true,
+    },
+  }, null, true);
+  assert.equal(noopOutcome.kind, 'noop_artifact');
+  assert.equal(noopOutcome.false_positive, true);
+  assert.equal(taskOutcomeSucceeded(noopOutcome), true);
 
   const phpcsBundle = createBundle(
     root,

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -224,7 +224,38 @@ try {
   assert.match(phpcsRequest.task.prompt, /remediation group PHPCS Formatting\/Auto Fix!/);
   assert.match(phpcsRequest.task.prompt, /finding-phpcs-001/);
   assert.match(phpcsRequest.task.prompt, /finding-phpcs-002/);
-  assert.match(phpcsRequest.task.prompt, /false positive/);
+  assert.match(phpcsRequest.task.prompt, /reviewed artifact/);
+  assert.match(phpcsRequest.task.prompt, /opens pull requests outside the sandbox/);
+
+  const nestedArtifactOutcome = taskOutcome(phpcsRequest, {
+    success: true,
+    executions: [
+      {
+        command: 'wordpress.run-php',
+        stdout: JSON.stringify({
+          command: 'agent-sandbox.run',
+          output: JSON.stringify({
+            agent_runtime: {
+              success: true,
+              result: {
+                outcome: {
+                  kind: 'fix_artifact',
+                  artifact: {
+                    id: 'artifact-fixture-nested',
+                    directory: '/tmp/artifact-fixture-nested',
+                    changed_files: [{ relative_path: 'src/Example.php' }],
+                  },
+                },
+              },
+            },
+          }),
+        }),
+      },
+    ],
+  }, { id: 'artifact-fixture-nested' }, true);
+  assert.equal(nestedArtifactOutcome.kind, 'fix_artifact');
+  assert.equal(nestedArtifactOutcome.artifact.id, 'artifact-fixture-nested');
+  assert.deepEqual(nestedArtifactOutcome.finding_ids, ['finding-phpcs-001', 'finding-phpcs-002']);
   const falsePositiveOutcome = taskOutcome(phpcsRequest, {
     outcome: {
       kind: 'false_positive_pr',


### PR DESCRIPTION
## Summary
- Accept `noop_artifact` and `unable_to_remediate` as completed WP Codebox fanout outcomes.
- Normalize legacy `agent_no_pr_outcome` to `unable_to_remediate` so zero-change sandbox runs can finish cleanly.
- Update fanout prompt and smoke coverage for terminal no-op outcomes.

## Tests
- npm run test:audit-wp-codebox-fanout
- Lab smoke: `npm run test:audit-wp-codebox-fanout` in `/home/chubes/Developer/homeboy-extensions/wordpress`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the no-op outcome normalization, prompt update, and smoke test coverage; Chris directed the contract and reviewed lab evidence.