### PR TITLE
Attach runner metrics to WP Codebox fanout records

### DIFF
--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -61,6 +61,44 @@ function tryParseJson(value) {
   }
 }
 
+function fanoutRecordMetrics(startedAt, finishedAt, parsed, artifact) {
+  const runnerMetrics = parsed && typeof parsed === 'object' && parsed.metrics && typeof parsed.metrics === 'object'
+    ? parsed.metrics
+    : {};
+  const artifactDirectory = artifact?.directory || artifact?.path || '';
+
+  return {
+    duration_ms: Math.max(0, Date.parse(finishedAt) - Date.parse(startedAt)),
+    peak_rss_bytes: numberOrNull(runnerMetrics.peak_rss_bytes),
+    sample_count: numberOrDefault(runnerMetrics.sample_count, 0),
+    child_process_count_peak: numberOrNull(runnerMetrics.child_process_count_peak),
+    artifact_bytes: artifactDirectory ? directorySizeBytes(artifactDirectory) : null,
+    ...(runnerMetrics.cpu_user_ms === undefined ? {} : { cpu_user_ms: numberOrNull(runnerMetrics.cpu_user_ms) }),
+    ...(runnerMetrics.cpu_system_ms === undefined ? {} : { cpu_system_ms: numberOrNull(runnerMetrics.cpu_system_ms) }),
+    ...(runnerMetrics.source ? { source: runnerMetrics.source } : {}),
+  };
+}
+
+function numberOrNull(value) {
+  return Number.isFinite(Number(value)) ? Number(value) : null;
+}
+
+function numberOrDefault(value, fallback) {
+  return Number.isFinite(Number(value)) ? Number(value) : fallback;
+}
+
+function directorySizeBytes(directory) {
+  try {
+    const stat = fs.lstatSync(directory);
+    if (!stat.isDirectory()) {
+      return stat.size;
+    }
+    return fs.readdirSync(directory).reduce((total, entry) => total + directorySizeBytes(path.join(directory, entry)), 0);
+  } catch {
+    return null;
+  }
+}
+
 function progressEvent(status, taskRequest, plan, record = null) {
   const groupIndex = Number(taskRequest.orchestrator?.group_index || 0) + 1;
   const groupCount = Number(plan.audit?.group_count || plan.task_requests.length || 0);
@@ -430,6 +468,7 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
   const stderr = result.stderr || '';
   const parsed = tryParseJson(stdout);
   const artifact = parsed && typeof parsed === 'object' && parsed.artifacts ? parsed.artifacts : null;
+  const metrics = fanoutRecordMetrics(startedAt, finishedAt, parsed, artifact);
   const taskFailure = parsed ? wpCodeboxTaskFailure(parsed) : null;
   const commandSuccess = result.status === 0 && result.error === undefined && null === taskFailure;
   const outcome = taskOutcome(taskRequest, parsed, artifact, commandSuccess, taskFailure || (result.error ? result.error.message : ''));
@@ -460,6 +499,7 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
       directory: artifact.directory || artifact.path || '',
       preview_url: artifact.preview?.url || artifact.preview_url || '',
     } : null,
+    metrics,
   };
 }
 
@@ -532,6 +572,7 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
       const finishedAt = new Date().toISOString();
       const parsed = tryParseJson(stdout);
       const artifact = parsed && typeof parsed === 'object' && parsed.artifacts ? parsed.artifacts : null;
+      const metrics = fanoutRecordMetrics(startedAt, finishedAt, parsed, artifact);
       const taskFailure = parsed ? wpCodeboxTaskFailure(parsed) : null;
       const timeoutError = timedOut ? `WP Codebox task timed out after ${taskTimeoutSeconds} seconds` : '';
       const errorMessage = timeoutError || (spawnError ? spawnError.message : (taskFailure || ''));
@@ -568,6 +609,7 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
           directory: artifact.directory || artifact.path || '',
           preview_url: artifact.preview?.url || artifact.preview_url || '',
         } : null,
+        metrics,
       });
     });
     child.stdin.end(requestJson);

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -36,6 +36,28 @@ function run(command, args, options = {}) {
   return (result.stdout || '').trim();
 }
 
+function assertMetrics(record, options = {}) {
+  assert.ok(record.metrics, `missing metrics for ${record.group_key}`);
+  assert.equal(typeof record.metrics.duration_ms, 'number');
+  assert.ok(record.metrics.duration_ms >= 0);
+  assert.ok(Object.hasOwn(record.metrics, 'peak_rss_bytes'));
+  assert.equal(typeof record.metrics.sample_count, 'number');
+  assert.ok(Object.hasOwn(record.metrics, 'child_process_count_peak'));
+  assert.ok(Object.hasOwn(record.metrics, 'artifact_bytes'));
+  if (options.runnerMetrics) {
+    assert.equal(record.metrics.peak_rss_bytes, 123456);
+    assert.equal(record.metrics.sample_count, 3);
+    assert.equal(record.metrics.child_process_count_peak, 2);
+    assert.equal(record.metrics.cpu_user_ms, 12);
+    assert.equal(record.metrics.cpu_system_ms, 4);
+    assert.equal(record.metrics.source, 'linux_procfs_process_tree');
+  }
+  if (options.artifactBytes) {
+    assert.equal(typeof record.metrics.artifact_bytes, 'number');
+    assert.ok(record.metrics.artifact_bytes > 0);
+  }
+}
+
 function createBundle(root, name, changedPath, relativePath) {
   const bundle = path.join(root, name);
   const files = path.join(bundle, 'files');
@@ -106,6 +128,8 @@ function createWpCodeboxFixtureCommand(root) {
   fs.writeFileSync(scriptPath, `#!/usr/bin/env node
 'use strict';
 const fs = require('node:fs');
+const path = require('node:path');
+const root = ${JSON.stringify(root)};
 let input = '';
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', (chunk) => { input += chunk; });
@@ -139,6 +163,25 @@ process.stdin.on('end', () => {
     }));
     process.exit(2);
   }
+  if (process.env.FIXTURE_NOOP_GROUP === request.group_key) {
+    process.stdout.write(JSON.stringify({
+      success: true,
+      outcome: {
+        kind: 'noop_artifact',
+        false_positive: true,
+      },
+      metrics: {
+        duration_ms: 99,
+        peak_rss_bytes: 123456,
+        sample_count: 3,
+        child_process_count_peak: 2,
+        cpu_user_ms: 12,
+        cpu_system_ms: 4,
+        source: 'linux_procfs_process_tree',
+      },
+    }));
+    process.exit(0);
+  }
   if (request.group_key === 'docs-reference') {
     if (process.env.FIXTURE_EXPECT_INCREMENTAL_RUN) {
       const run = JSON.parse(fs.readFileSync(process.env.FIXTURE_EXPECT_INCREMENTAL_RUN, 'utf8'));
@@ -165,6 +208,9 @@ process.stdin.on('end', () => {
     process.stderr.write('fixture docs-reference failure\\n');
     process.exit(3);
   }
+  const artifactDirectory = path.join(root, 'artifact-' + request.sandbox_session_id);
+  fs.mkdirSync(artifactDirectory, { recursive: true });
+  fs.writeFileSync(path.join(artifactDirectory, 'artifact.txt'), 'fixture artifact bytes\\n');
   process.stdout.write(JSON.stringify({
     success: true,
     session: {
@@ -174,8 +220,17 @@ process.stdin.on('end', () => {
     },
     artifacts: {
       id: 'artifact-' + request.sandbox_session_id,
-      directory: '/tmp/' + request.sandbox_session_id,
+      directory: artifactDirectory,
       preview: { url: 'https://preview.example.test/' + request.sandbox_session_id },
+    },
+    metrics: {
+      duration_ms: 99,
+      peak_rss_bytes: 123456,
+      sample_count: 3,
+      child_process_count_peak: 2,
+      cpu_user_ms: 12,
+      cpu_system_ms: 4,
+      source: 'linux_procfs_process_tree',
     },
     outcome: {
       pr_url: 'https://github.com/Extra-Chill/homeboy-extensions/pull/' + (request.group_key === 'docs-reference' ? '778' : '777')
@@ -513,6 +568,7 @@ try {
   assert.match(completedRecord.artifact.id, /^artifact-homeboy-audit-/);
   assert.equal(completedRecord.outcome.kind, 'fix_pr');
   assert.equal(completedRecord.outcome.pr_url, 'https://github.com/Extra-Chill/homeboy-extensions/pull/777');
+  assertMetrics(completedRecord, { runnerMetrics: true, artifactBytes: true });
   assert.equal(execution.outcomes.length, 2);
   assert.equal(failedRecord.status, 'failed');
   assert.equal(failedRecord.command.exit_code, 3);
@@ -549,6 +605,19 @@ try {
   const providerFinalRun = readJson(providerRunsOutputPath);
   assert.equal(providerFinalRun.outcomes.find((outcome) => outcome.kind === 'provider_error').retryable, true);
 
+  const noopExecution = await executeAuditWpCodeboxFanout({
+    report,
+    wp_codebox_command: process.execPath,
+    wp_codebox_args: [fixtureCommand],
+    concurrency: 1,
+    env: { FIXTURE_NOOP_GROUP: 'PHPCS Formatting/Auto Fix!' },
+  });
+  const noopRecord = noopExecution.records.find((record) => record.group_key === 'PHPCS Formatting/Auto Fix!');
+  assert.equal(noopRecord.status, 'completed');
+  assert.equal(noopRecord.outcome.kind, 'noop_artifact');
+  assertMetrics(noopRecord, { runnerMetrics: true });
+  assert.equal(noopRecord.metrics.artifact_bytes, null);
+
   const timeoutRunsOutputPath = path.join(root, 'fanout-timeout-run.json');
   const timeoutExecution = await executeAuditWpCodeboxFanout({
     report,
@@ -570,6 +639,9 @@ try {
   assert.equal(timeoutRecord.outcome.kind, 'timeout');
   assert.match(timeoutRecord.stdout, /fixture partial stdout before timeout/);
   assert.match(timeoutRecord.stderr, /fixture partial stderr before timeout/);
+  assertMetrics(timeoutRecord);
+  assert.equal(timeoutRecord.metrics.sample_count, 0);
+  assert.equal(timeoutRecord.metrics.artifact_bytes, null);
   const timeoutFollowupRecord = timeoutExecution.records.find((record) => record.group_key === 'docs-reference');
   assert.equal(timeoutFollowupRecord.status, 'failed');
   assert.equal(timeoutFollowupRecord.command.exit_code, 3);
@@ -617,7 +689,7 @@ try {
   assert.equal(cliExecution.records.length, 2);
   assert.equal(cliExecution.records[0].schema, 'homeboy/audit-wp-codebox-run/v1');
   assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] started 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-/);
-  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] completed 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-.*artifact=\/tmp\/homeboy-audit-/);
+  assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] completed 1\/2 group=PHPCS Formatting\/Auto Fix! session=homeboy-audit-.*artifact=.*artifact-homeboy-audit-/);
   assert.match(cliExecutionResult.stderr, /\[homeboy wp-codebox fanout\] failed 2\/2 group=docs-reference session=homeboy-audit-/);
   assert.doesNotMatch(cliExecutionResult.stderr, /FIXTURE_SECRET_TOKEN/);
 


### PR DESCRIPTION
## Summary
- Add a `metrics` block to each WP Codebox fanout record with wall-clock duration, runner resource metrics when provided, and artifact byte counts.
- Preserve timeout records with the metrics available at record finalization time.
- Extend the fanout smoke test for success, no-op, and timeout metric shapes.

Depends on upstream runner metrics: https://github.com/Extra-Chill/homeboy/pull/2997
Closes https://github.com/Extra-Chill/homeboy-extensions/issues/833

## Tests
- `cd wordpress && npm run test:audit-wp-codebox-fanout`

## Limitations
- CPU, peak RSS, and child-process counts come from the generic Homeboy runner `metrics` payload when WP Codebox is executed through that runner surface.
- Direct/local WP Codebox command execution still records fanout wall-clock duration and artifact bytes, with resource fields set to `null` and `sample_count: 0`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Wired the fanout consumer to attach generic runner metrics, added artifact byte accounting, and updated smoke tests.