### PR TITLE
Add Rust bench Criterion and profile adapters

### DIFF
--- a/rust/docs/bench.md
+++ b/rust/docs/bench.md
@@ -1,0 +1,77 @@
+# Rust Bench Extension
+
+The Rust extension owns Rust-specific benchmark adapters and emits the same
+Homeboy `BenchResults` envelope consumed by core. Homeboy core should only see
+normalized scenarios, numeric metrics, metadata, and artifact pointers.
+
+## Default `bench-*` Binaries
+
+The default contract is unchanged: Cargo binaries named `bench-*` are discovered
+from `src/bin/bench-*.rs` or explicit `[[bin]]` manifest entries and executed as
+release binaries.
+
+Use this path for small purpose-built workloads that can emit one JSON payload:
+
+```json
+{"timings_ns":[12345,12678],"peak_rss_bytes":41943040}
+```
+
+The runner normalizes those timings into `mean_ms`, `p50_ms`, `p95_ms`,
+`p99_ms`, `min_ms`, and `max_ms`.
+
+## Criterion Adapter
+
+Criterion support is additive and opt-in:
+
+```bash
+HOMEBOY_RUST_BENCH_CRITERION=1 homeboy bench my-rust-component
+```
+
+The adapter discovers Cargo bench targets, runs `cargo bench --bench <target>`,
+then normalizes `target/criterion/**/new/estimates.json` files into Homeboy
+scenarios. Criterion estimate files are preserved as scenario artifacts.
+
+Use Criterion when the project already has statistical microbenchmarks or needs
+Criterion reports. Use `bench-*` binaries when a lightweight Homeboy-only
+workload is enough.
+
+If Criterion is requested but no bench targets are declared, the runner reports a
+warning and emits a valid empty result instead of requiring Homeboy core to know
+anything about Criterion.
+
+## Rust Perf Profiles
+
+Rust developer-loop profiles are also opt-in:
+
+```bash
+HOMEBOY_RUST_BENCH_PROFILES=1 homeboy bench my-rust-component
+```
+
+The first slice emits these normalized scenarios:
+
+- `rust-clean-build` — runs `cargo clean`, then measures `cargo build --release`.
+- `rust-warm-build` — prebuilds once, then measures warm `cargo build --release`.
+- `rust-changed-file-check` — touches one source file, measures `cargo check`, then restores the file.
+- `rust-test` — prebuilds test binaries, then measures `cargo test --no-run`.
+
+Each profile scenario includes metadata identifying `cache_mode`, `change_mode`,
+the command, and the changed file when applicable. This keeps cache/change
+semantics in the Rust extension while Homeboy core compares ordinary scenario
+metrics.
+
+Set `HOMEBOY_RUST_BENCH_CHANGED_FILE=path/to/file.rs` to choose the changed-file
+profile target. When omitted, the runner uses `src/lib.rs` or `src/main.rs`.
+
+## Homeboy Lab Guidance
+
+Use these profiles for local Lab runs where hardware and cache state are stable.
+Run enough repetitions before ratcheting baselines, especially for clean builds
+that are sensitive to disk and dependency cache noise.
+
+Examples:
+
+```bash
+HOMEBOY_RUST_BENCH_PROFILES=1 homeboy bench my-rust-component --iterations 5
+HOMEBOY_RUST_BENCH_PROFILES=1 homeboy bench my-rust-component --scenario rust-warm-build --iterations 10
+HOMEBOY_RUST_BENCH_CRITERION=1 homeboy bench my-rust-component --scenario criterion-my-bench
+```

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -39,6 +39,29 @@
   "bench": {
     "extension_script": "scripts/bench/bench-runner.sh"
   },
+  "settings": [
+    {
+      "id": "bench_criterion",
+      "label": "Criterion bench adapter",
+      "type": "boolean",
+      "default": false,
+      "description": "Opt into the Rust extension's Criterion adapter. Set HOMEBOY_RUST_BENCH_CRITERION=1 to run Cargo bench targets and normalize target/criterion estimates into Homeboy BenchResults. bench-* binaries remain the default contract."
+    },
+    {
+      "id": "bench_profiles",
+      "label": "Rust perf profiles",
+      "type": "boolean",
+      "default": false,
+      "description": "Opt into Rust developer-loop perf scenarios. Set HOMEBOY_RUST_BENCH_PROFILES=1 to emit rust-clean-build, rust-warm-build, rust-changed-file-check, and rust-test scenarios with cache/change metadata."
+    },
+    {
+      "id": "bench_changed_file",
+      "label": "Rust bench changed file",
+      "type": "string",
+      "default": "",
+      "description": "Optional changed-file profile target relative to the Cargo project root. When omitted, the runner uses src/lib.rs or src/main.rs if present."
+    }
+  ],
   "audit": {
     "feature_patterns": [
       "#\\[derive\\(.*Subcommand.*\\)\\]\\s*(?:pub\\s+)?enum\\s+(\\w+)",

--- a/rust/scripts/bench/bench-runner.sh
+++ b/rust/scripts/bench/bench-runner.sh
@@ -43,6 +43,10 @@ set -euo pipefail
 #   HOMEBOY_BENCH_ITERATIONS     — iterations per workload (default 10)
 #   HOMEBOY_BENCH_RESULTS_FILE   — where core wants the envelope written
 #   HOMEBOY_BENCH_LIST_ONLY      — when 1, emit scenario inventory only
+#   HOMEBOY_BENCH_SCENARIOS      — comma-separated exact scenario ids selected by core
+#   HOMEBOY_RUST_BENCH_CRITERION — when 1/true, run Criterion benches and normalize reports
+#   HOMEBOY_RUST_BENCH_PROFILES  — when 1/true/all, add Rust clean/warm/changed profiles
+#   HOMEBOY_RUST_BENCH_CHANGED_FILE — changed-file profile target (default src/lib.rs or src/main.rs)
 #   HOMEBOY_DEBUG                — verbose output
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -68,6 +72,9 @@ fi
 ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-10}"
 RESULTS_FILE="${HOMEBOY_BENCH_RESULTS_FILE:-${PROJECT_PATH}/.rust-bench-results.json}"
 LIST_ONLY="${HOMEBOY_BENCH_LIST_ONLY:-0}"
+SELECTED_SCENARIOS="${HOMEBOY_BENCH_SCENARIOS:-}"
+CRITERION_REQUEST="${HOMEBOY_RUST_BENCH_CRITERION:-0}"
+PROFILE_REQUEST="${HOMEBOY_RUST_BENCH_PROFILES:-0}"
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: [bench:rust] extension=$EXTENSION_PATH" >&2
@@ -76,6 +83,9 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: [bench:rust] iterations=$ITERATIONS" >&2
     echo "DEBUG: [bench:rust] results=$RESULTS_FILE" >&2
     echo "DEBUG: [bench:rust] list_only=$LIST_ONLY" >&2
+    echo "DEBUG: [bench:rust] scenarios=${SELECTED_SCENARIOS:-<all>}" >&2
+    echo "DEBUG: [bench:rust] criterion=$CRITERION_REQUEST" >&2
+    echo "DEBUG: [bench:rust] profiles=$PROFILE_REQUEST" >&2
 fi
 
 if [ ! -f "${PROJECT_PATH}/Cargo.toml" ]; then
@@ -128,7 +138,9 @@ discover_bench_bins() {
             | jq -r '.packages[].targets[] | select(.kind[0] == "bin") | select(.name | startswith("bench-")) | .name')
     fi
 
-    printf '%s\n' "${_bins[@]:-}"
+    if [ "${#_bins[@]}" -gt 0 ]; then
+        printf '%s\n' "${_bins[@]}"
+    fi
 }
 
 bench_bin_file() {
@@ -141,7 +153,65 @@ bench_bin_file() {
     printf 'null\n'
 }
 
+scenario_selected() {
+    local _scenario="$1"
+    [ -z "$SELECTED_SCENARIOS" ] && return 0
+    case ",${SELECTED_SCENARIOS}," in
+        *",${_scenario},"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+truthy() {
+    case "${1:-}" in
+        1|true|TRUE|yes|YES|all|ALL) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+criterion_requested() {
+    truthy "$CRITERION_REQUEST" && return 0
+    case ",${SELECTED_SCENARIOS}," in
+        *,criterion-*) return 0 ;;
+    esac
+    return 1
+}
+
+profiles_requested() {
+    truthy "$PROFILE_REQUEST" && return 0
+    case ",${SELECTED_SCENARIOS}," in
+        *,rust-clean-build,*|*,rust-warm-build,*|*,rust-changed-file-check,*|*,rust-test,*) return 0 ;;
+    esac
+    return 1
+}
+
+discover_criterion_benches() {
+    command -v jq >/dev/null 2>&1 || return 0
+    cargo metadata --no-deps --format-version=1 --manifest-path="${PROJECT_PATH}/Cargo.toml" 2>/dev/null \
+        | jq -r '.packages[].targets[] | select(.kind[]? == "bench") | .name' \
+        | sort -u
+}
+
+profile_changed_file() {
+    if [ -n "${HOMEBOY_RUST_BENCH_CHANGED_FILE:-}" ]; then
+        printf '%s\n' "$HOMEBOY_RUST_BENCH_CHANGED_FILE"
+        return 0
+    fi
+    if [ -f "${PROJECT_PATH}/src/lib.rs" ]; then
+        printf 'src/lib.rs\n'
+        return 0
+    fi
+    if [ -f "${PROJECT_PATH}/src/main.rs" ]; then
+        printf 'src/main.rs\n'
+        return 0
+    fi
+    return 1
+}
+
+PROFILE_IDS=(rust-clean-build rust-warm-build rust-changed-file-check rust-test)
+
 mapfile -t BENCH_BINS < <(discover_bench_bins)
+mapfile -t CRITERION_BENCHES < <(discover_criterion_benches)
 
 if [ "$LIST_ONLY" = "1" ]; then
     if ! command -v python3 >/dev/null 2>&1; then
@@ -151,11 +221,27 @@ if [ "$LIST_ONLY" = "1" ]; then
     fi
 
     SCENARIO_ARGS=()
-    for _bin in "${BENCH_BINS[@]:-}"; do
+    for _bin in "${BENCH_BINS[@]}"; do
         _scenario_id="${_bin#bench-}"
+        scenario_selected "$_scenario_id" || continue
         _scenario_file="$(bench_bin_file "$_bin")"
-        SCENARIO_ARGS+=("${_scenario_id}=${_scenario_file}")
+        SCENARIO_ARGS+=("${_scenario_id}=${_scenario_file}=bench-binary")
     done
+
+    if profiles_requested; then
+        for _profile_id in "${PROFILE_IDS[@]}"; do
+            scenario_selected "$_profile_id" || continue
+            SCENARIO_ARGS+=("${_profile_id}=null=rust-profile")
+        done
+    fi
+
+    if criterion_requested; then
+        for _criterion_bench in "${CRITERION_BENCHES[@]}"; do
+            _scenario_id="criterion-${_criterion_bench}"
+            scenario_selected "$_scenario_id" || continue
+            SCENARIO_ARGS+=("${_scenario_id}=benches/${_criterion_bench}.rs=criterion")
+        done
+    fi
 
     python3 - <<PYTHON_LIST "$RESULTS_FILE" "$COMPONENT_ID" "$ITERATIONS" "${SCENARIO_ARGS[@]:-}"
 import json, os, sys
@@ -166,17 +252,17 @@ iterations = int(sys.argv[3])
 scenario_kvs = sys.argv[4:]
 scenarios = []
 for kv in scenario_kvs:
-    scenario_id, rel_file = kv.split('=', 1)
+    scenario_id, rel_file, source = kv.split('=', 2)
     scenario = {
         'id': scenario_id,
         'iterations': 0,
         'default_iterations': iterations,
         'tags': [],
         'metrics': {},
+        'source': source,
     }
     if rel_file != 'null':
         scenario['file'] = rel_file
-        scenario['source'] = 'in_tree'
     scenarios.append(scenario)
 
 os.makedirs(os.path.dirname(results_file) or '.', exist_ok=True)
@@ -184,11 +270,11 @@ with open(results_file, 'w', encoding='utf-8') as fh:
     json.dump({'component_id': component_id, 'iterations': 0, 'scenarios': scenarios}, fh, indent=2)
 PYTHON_LIST
 
-    echo "Discovered ${#BENCH_BINS[@]} Rust bench scenarios."
+    echo "Discovered ${#SCENARIO_ARGS[@]} Rust bench scenarios."
     exit 0
 fi
 
-if [ "${#BENCH_BINS[@]}" -eq 0 ]; then
+if [ "${#BENCH_BINS[@]}" -eq 0 ] && ! profiles_requested && ! criterion_requested; then
     echo "" >&2
     echo "⚠ No bench binaries found at ${PROJECT_PATH}" >&2
     echo "  Bench binaries must be named 'bench-*' and live at" >&2
@@ -204,24 +290,38 @@ echo "Running Rust benchmarks..."
 echo "  Component: ${COMPONENT_ID} (${PROJECT_PATH})"
 echo "  Iterations: ${ITERATIONS}"
 echo "  Discovered: ${#BENCH_BINS[@]} bench binaries"
+if profiles_requested; then
+    echo "  Rust profiles: enabled"
+fi
+if criterion_requested; then
+    echo "  Criterion: enabled (${#CRITERION_BENCHES[@]} bench target(s))"
+fi
 
 # ── Run each bench binary ──────────────────────────────────────────
 
 # Build all bench binaries up front so the per-binary loop only pays
 # cargo's metadata-resolution cost, not a fresh compile each time.
-echo ""
-echo "Building bench binaries (release)..."
-BUILD_ARGS=(build --release --manifest-path="${PROJECT_PATH}/Cargo.toml")
+SELECTED_BENCH_BINS=()
 for _bin in "${BENCH_BINS[@]}"; do
-    BUILD_ARGS+=(--bin "$_bin")
+    _scenario_id="${_bin#bench-}"
+    scenario_selected "$_scenario_id" && SELECTED_BENCH_BINS+=("$_bin")
 done
-if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
-    cargo "${BUILD_ARGS[@]}"
-else
-    cargo "${BUILD_ARGS[@]}" 2>&1 | tail -5 || {
-        FAILED_STEP="cargo build"
-        exit 1
-    }
+
+if [ "${#SELECTED_BENCH_BINS[@]}" -gt 0 ]; then
+    echo ""
+    echo "Building bench binaries (release)..."
+    BUILD_ARGS=(build --release --manifest-path="${PROJECT_PATH}/Cargo.toml")
+    for _bin in "${SELECTED_BENCH_BINS[@]}"; do
+        BUILD_ARGS+=(--bin "$_bin")
+    done
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        cargo "${BUILD_ARGS[@]}"
+    else
+        cargo "${BUILD_ARGS[@]}" 2>&1 | tail -5 || {
+            FAILED_STEP="cargo build"
+            exit 1
+        }
+    fi
 fi
 
 SCENARIOS_JSON_TMPDIR="$(mktemp -d)"
@@ -235,7 +335,7 @@ trap cleanup_scenarios EXIT
 
 OVERALL_OK=1
 SCENARIOS_PATHS=()
-for _bin in "${BENCH_BINS[@]}"; do
+for _bin in "${SELECTED_BENCH_BINS[@]}"; do
     # scenario id = bin name minus "bench-" prefix
     _scenario_id="${_bin#bench-}"
     _scenario_file="${SCENARIOS_JSON_TMPDIR}/${_scenario_id}.json"
@@ -281,6 +381,235 @@ for _bin in "${BENCH_BINS[@]}"; do
         echo "WORKLOAD_DONE:  ${_scenario_id}"
     fi
 done
+
+run_profile_command() {
+    local _scenario_id="$1"
+    local _payload_file="$2"
+    local _metadata_json="$3"
+    shift 3
+
+    python3 - <<'PYTHON_PROFILE' "$_payload_file" "$ITERATIONS" "$_metadata_json" "$@"
+import json, os, subprocess, sys, time
+
+payload_file = sys.argv[1]
+iterations = int(sys.argv[2])
+metadata = json.loads(sys.argv[3])
+command = sys.argv[4:]
+
+timings = []
+last_stderr = ''
+for _ in range(iterations):
+    start = time.perf_counter_ns()
+    proc = subprocess.run(command, cwd=os.environ['PROJECT_PATH'], text=True, capture_output=True)
+    elapsed = time.perf_counter_ns() - start
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr or proc.stdout or f'command exited {proc.returncode}\n')
+        sys.exit(proc.returncode)
+    last_stderr = proc.stderr
+    timings.append(elapsed)
+
+with open(payload_file, 'w', encoding='utf-8') as fh:
+    json.dump({
+        'timings_ns': timings,
+        'metadata': metadata,
+        'source': 'rust-profile',
+    }, fh, indent=2)
+PYTHON_PROFILE
+}
+
+run_profile_scenario() {
+    local _scenario_id="$1"
+    local _scenario_file="${SCENARIOS_JSON_TMPDIR}/${_scenario_id}.json"
+    local _changed_rel=""
+    local _changed_abs=""
+    local _backup_file=""
+
+    scenario_selected "$_scenario_id" || return 0
+
+    echo ""
+    echo "WORKLOAD_BEGIN: ${_scenario_id} (Rust profile)"
+
+    case "$_scenario_id" in
+        rust-clean-build)
+            cargo clean --manifest-path="${PROJECT_PATH}/Cargo.toml" >/dev/null 2>&1 || true
+            set +e
+            PROJECT_PATH="$PROJECT_PATH" run_profile_command "$_scenario_id" "$_scenario_file" \
+                '{"cache_mode":"clean","change_mode":"none","command":"cargo build --release"}' \
+                cargo build --release --manifest-path="${PROJECT_PATH}/Cargo.toml" >"${_scenario_file}.out" 2>"${_scenario_file}.err"
+            _exit=$?
+            set -e
+            ;;
+        rust-warm-build)
+            cargo build --release --manifest-path="${PROJECT_PATH}/Cargo.toml" >/dev/null 2>&1 || true
+            set +e
+            PROJECT_PATH="$PROJECT_PATH" run_profile_command "$_scenario_id" "$_scenario_file" \
+                '{"cache_mode":"warm","change_mode":"none","command":"cargo build --release"}' \
+                cargo build --release --manifest-path="${PROJECT_PATH}/Cargo.toml" >"${_scenario_file}.out" 2>"${_scenario_file}.err"
+            _exit=$?
+            set -e
+            ;;
+        rust-changed-file-check)
+            if ! _changed_rel="$(profile_changed_file)"; then
+                echo "WORKLOAD_SKIP: ${_scenario_id} — no src/lib.rs or src/main.rs changed-file target" >&2
+                return 0
+            fi
+            _changed_abs="${PROJECT_PATH}/${_changed_rel}"
+            if [ ! -f "$_changed_abs" ]; then
+                echo "WORKLOAD_ERROR: ${_scenario_id} — changed file not found: ${_changed_rel}" >&2
+                OVERALL_OK=0
+                return 0
+            fi
+            _backup_file="${SCENARIOS_JSON_TMPDIR}/${_scenario_id}.backup"
+            cp "$_changed_abs" "$_backup_file"
+            printf '\n// homeboy bench changed-file profile touch\n' >> "$_changed_abs"
+            set +e
+            PROJECT_PATH="$PROJECT_PATH" run_profile_command "$_scenario_id" "$_scenario_file" \
+                "{\"cache_mode\":\"warm\",\"change_mode\":\"changed_file\",\"changed_file\":\"${_changed_rel}\",\"command\":\"cargo check\"}" \
+                cargo check --manifest-path="${PROJECT_PATH}/Cargo.toml" >"${_scenario_file}.out" 2>"${_scenario_file}.err"
+            _exit=$?
+            set -e
+            cp "$_backup_file" "$_changed_abs"
+            ;;
+        rust-test)
+            cargo test --no-run --manifest-path="${PROJECT_PATH}/Cargo.toml" >/dev/null 2>&1 || true
+            set +e
+            PROJECT_PATH="$PROJECT_PATH" run_profile_command "$_scenario_id" "$_scenario_file" \
+                '{"cache_mode":"warm","change_mode":"none","command":"cargo test --no-run"}' \
+                cargo test --no-run --manifest-path="${PROJECT_PATH}/Cargo.toml" >"${_scenario_file}.out" 2>"${_scenario_file}.err"
+            _exit=$?
+            set -e
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+
+    if [ "${_exit:-1}" -ne 0 ]; then
+        echo "WORKLOAD_ERROR: ${_scenario_id} — profile command exit ${_exit}" >&2
+        if [ -s "${_scenario_file}.err" ]; then
+            echo "  stderr:" >&2
+            sed 's/^/    /' "${_scenario_file}.err" >&2
+        fi
+        OVERALL_OK=0
+        return 0
+    fi
+
+    SCENARIOS_PATHS+=("${_scenario_id}=${_scenario_file}")
+    echo "WORKLOAD_DONE:  ${_scenario_id} (${ITERATIONS} iterations measured)"
+}
+
+if profiles_requested; then
+    for _profile_id in "${PROFILE_IDS[@]}"; do
+        run_profile_scenario "$_profile_id"
+    done
+fi
+
+normalize_criterion_reports() {
+    local _bench_name="$1"
+    local _artifact_root="${PROJECT_PATH}/target/criterion"
+    [ -d "$_artifact_root" ] || return 0
+
+    python3 - <<'PYTHON_CRITERION' "$SCENARIOS_JSON_TMPDIR" "$PROJECT_PATH" "$_bench_name" "$ITERATIONS"
+import json, os, pathlib, re, sys
+
+out_dir = pathlib.Path(sys.argv[1])
+project = pathlib.Path(sys.argv[2])
+bench_name = sys.argv[3]
+iterations = int(sys.argv[4])
+criterion_root = project / 'target' / 'criterion'
+
+def slug(value):
+    return re.sub(r'[^A-Za-z0-9_.-]+', '-', value).strip('-').lower() or 'criterion'
+
+estimate_files = sorted(criterion_root.glob('**/new/estimates.json'))
+for estimates in estimate_files:
+    rel = estimates.relative_to(project)
+    parts = list(estimates.relative_to(criterion_root).parts[:-2])
+    if not parts:
+        continue
+    sid = 'criterion-' + slug(bench_name if len(estimate_files) == 1 else f"{bench_name}-{'-'.join(parts)}")
+    scenario_file = out_dir / f'{sid}.json'
+    with estimates.open(encoding='utf-8') as fh:
+        data = json.load(fh)
+    mean = data.get('mean', {}).get('point_estimate')
+    median = data.get('median', {}).get('point_estimate')
+    if mean is None and median is None:
+        continue
+    lower = data.get('mean', {}).get('confidence_interval', {}).get('lower_bound', mean or median)
+    upper = data.get('mean', {}).get('confidence_interval', {}).get('upper_bound', mean or median)
+    point = mean if mean is not None else median
+    timings = [int(point)] * max(1, iterations)
+    payload = {
+        'timings_ns': timings,
+        'metadata': {
+            'adapter': 'criterion',
+            'criterion_bench': bench_name,
+            'criterion_id': '/'.join(parts),
+        },
+        'artifacts': {
+            'criterion_estimates': {
+                'path': str(rel),
+                'kind': 'json',
+                'label': 'Criterion estimates',
+            },
+        },
+        'metrics': {
+            'criterion_mean_ms': (mean or point) / 1_000_000.0,
+            'criterion_median_ms': (median or point) / 1_000_000.0,
+            'criterion_mean_ci_lower_ms': (lower or point) / 1_000_000.0,
+            'criterion_mean_ci_upper_ms': (upper or point) / 1_000_000.0,
+        },
+        'source': 'criterion',
+        'file': str(rel),
+    }
+    with scenario_file.open('w', encoding='utf-8') as fh:
+        json.dump(payload, fh, indent=2)
+    print(f'{sid}={scenario_file}')
+PYTHON_CRITERION
+}
+
+if criterion_requested; then
+    if [ "${#CRITERION_BENCHES[@]}" -eq 0 ]; then
+        echo "WORKLOAD_WARN: Criterion requested but no Cargo bench targets were discovered." >&2
+        echo "  Add [[bench]] entries with harness = false and Criterion dev-dependency, or disable HOMEBOY_RUST_BENCH_CRITERION." >&2
+    fi
+
+    for _criterion_bench in "${CRITERION_BENCHES[@]}"; do
+        _scenario_id="criterion-${_criterion_bench}"
+        if [ -n "$SELECTED_SCENARIOS" ]; then
+            case ",${SELECTED_SCENARIOS}," in
+                *,criterion-*) ;;
+                *) continue ;;
+            esac
+        fi
+
+        echo ""
+        echo "WORKLOAD_BEGIN: ${_scenario_id} (Criterion)"
+        set +e
+        cargo bench --manifest-path="${PROJECT_PATH}/Cargo.toml" --bench "$_criterion_bench" -- --quiet >"${SCENARIOS_JSON_TMPDIR}/${_scenario_id}.out" 2>"${SCENARIOS_JSON_TMPDIR}/${_scenario_id}.err"
+        _exit=$?
+        set -e
+
+        if [ "$_exit" -ne 0 ]; then
+            echo "WORKLOAD_ERROR: ${_scenario_id} — cargo bench exit $_exit" >&2
+            echo "  Criterion support is optional; verify the bench target uses Criterion with harness = false." >&2
+            if [ -s "${SCENARIOS_JSON_TMPDIR}/${_scenario_id}.err" ]; then
+                echo "  stderr:" >&2
+                sed 's/^/    /' "${SCENARIOS_JSON_TMPDIR}/${_scenario_id}.err" >&2
+            fi
+            OVERALL_OK=0
+            continue
+        fi
+
+        while IFS= read -r _kv; do
+            [ -n "$_kv" ] || continue
+            _sid="${_kv%%=*}"
+            scenario_selected "$_sid" || [ -z "$SELECTED_SCENARIOS" ] || continue
+            SCENARIOS_PATHS+=("$_kv")
+        done < <(normalize_criterion_reports "$_criterion_bench")
+        echo "WORKLOAD_DONE:  ${_scenario_id} (Criterion reports normalized)"
+    done
+fi
 
 # ── Build the BenchResults envelope ────────────────────────────────
 #
@@ -336,12 +665,23 @@ for kv in scenario_kvs:
         "min_ms":  timings_ms[0],
         "max_ms":  timings_ms[-1],
     }
+    for key, value in payload.get("metrics", {}).items():
+        if isinstance(value, (int, float)):
+            metrics[key] = value
 
     scenario = {
         "id": sid,
         "iterations": n,
         "metrics": metrics,
     }
+    if "file" in payload:
+        scenario["file"] = payload["file"]
+    if "source" in payload:
+        scenario["source"] = payload["source"]
+    if "metadata" in payload:
+        scenario["metadata"] = payload["metadata"]
+    if "artifacts" in payload:
+        scenario["artifacts"] = payload["artifacts"]
     if "peak_rss_bytes" in payload:
         scenario["memory"] = {"peak_bytes": int(payload["peak_rss_bytes"])}
 

--- a/rust/scripts/bench/rust-bench-smoke.sh
+++ b/rust/scripts/bench/rust-bench-smoke.sh
@@ -23,6 +23,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
 FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-noop"
+CRITERION_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-criterion"
 
 if [ ! -d "$FIXTURE_DIR" ]; then
     echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
@@ -41,9 +42,11 @@ fi
 
 RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/rust-bench-smoke-results.XXXXXX")
 LIST_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/rust-bench-list-smoke-results.XXXXXX")
+PROFILES_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/rust-bench-profiles-smoke-results.XXXXXX")
+CRITERION_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/rust-bench-criterion-smoke-results.XXXXXX")
 
 # shellcheck disable=SC2064
-trap "rm -f '$RESULTS_TMPFILE' '$LIST_TMPFILE'" EXIT
+trap "rm -f '$RESULTS_TMPFILE' '$LIST_TMPFILE' '$PROFILES_TMPFILE' '$CRITERION_TMPFILE'" EXIT
 
 echo "============================================"
 echo "Rust bench harness smoke test"
@@ -154,6 +157,55 @@ if [ -n "$NOOP_P95" ] && [ -n "$BUSY_P95" ]; then
         echo "  ✗ unexpected ordering: busy ($BUSY_P95 ms) <= noop ($NOOP_P95 ms)" >&2
         exit 1
     fi
+fi
+
+echo
+echo "── Validating Rust perf profiles ──"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_COMPONENT_ID="bench-noop-fixture" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_RUST_BENCH_PROFILES=1 \
+HOMEBOY_BENCH_SCENARIOS="rust-clean-build,rust-warm-build,rust-changed-file-check" \
+HOMEBOY_BENCH_RESULTS_FILE="$PROFILES_TMPFILE" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+for _profile in rust-clean-build rust-warm-build rust-changed-file-check; do
+    PRESENT="$(jq -r --arg id "$_profile" '.scenarios[] | select(.id == $id) | .id' "$PROFILES_TMPFILE")"
+    assert "profile $_profile present" "$PRESENT" "$_profile"
+done
+
+assert "clean cache mode" "$(jq -r '.scenarios[] | select(.id == "rust-clean-build") | .metadata.cache_mode' "$PROFILES_TMPFILE")" "clean"
+assert "warm cache mode" "$(jq -r '.scenarios[] | select(.id == "rust-warm-build") | .metadata.cache_mode' "$PROFILES_TMPFILE")" "warm"
+assert "changed-file mode" "$(jq -r '.scenarios[] | select(.id == "rust-changed-file-check") | .metadata.change_mode' "$PROFILES_TMPFILE")" "changed_file"
+
+echo
+echo "── Validating Criterion adapter ──"
+
+if [ -d "$CRITERION_FIXTURE_DIR" ]; then
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$CRITERION_FIXTURE_DIR" \
+    HOMEBOY_COMPONENT_ID="bench-criterion-fixture" \
+    HOMEBOY_BENCH_ITERATIONS=1 \
+    HOMEBOY_RUST_BENCH_CRITERION=1 \
+    HOMEBOY_BENCH_RESULTS_FILE="$CRITERION_TMPFILE" \
+        bash "${SCRIPT_DIR}/bench-runner.sh"
+
+    CRITERION_COUNT="$(jq -r '[.scenarios[] | select(.source == "criterion")] | length' "$CRITERION_TMPFILE")"
+    if [ "$CRITERION_COUNT" -lt 1 ]; then
+        echo "  ✗ expected at least one Criterion scenario" >&2
+        cat "$CRITERION_TMPFILE" >&2
+        exit 1
+    fi
+    echo "  ✓ Criterion scenarios: $CRITERION_COUNT"
+
+    MISSING_ARTIFACT="$(jq -r '.scenarios[] | select(.source == "criterion") | select(.artifacts.criterion_estimates.path == null) | .id' "$CRITERION_TMPFILE")"
+    if [ -n "$MISSING_ARTIFACT" ]; then
+        echo "  ✗ Criterion scenario missing estimates artifact: $MISSING_ARTIFACT" >&2
+        exit 1
+    fi
+    echo "  ✓ Criterion estimates artifacts preserved"
 fi
 
 echo

--- a/rust/tests/fixtures/bench-criterion/Cargo.toml
+++ b/rust/tests/fixtures/bench-criterion/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bench-criterion-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "criterion_noop"
+harness = false
+
+[profile.release]
+opt-level = 3
+lto = false

--- a/rust/tests/fixtures/bench-criterion/benches/criterion_noop.rs
+++ b/rust/tests/fixtures/bench-criterion/benches/criterion_noop.rs
@@ -1,0 +1,18 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::time::Duration;
+
+fn criterion_noop(c: &mut Criterion) {
+    c.bench_function("tiny_workload", |b| {
+        b.iter(|| bench_criterion_fixture::tiny_workload().wrapping_add(black_box(1)))
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .measurement_time(Duration::from_millis(20))
+        .warm_up_time(Duration::from_millis(5));
+    targets = criterion_noop
+}
+criterion_main!(benches);

--- a/rust/tests/fixtures/bench-criterion/src/lib.rs
+++ b/rust/tests/fixtures/bench-criterion/src/lib.rs
@@ -1,0 +1,5 @@
+use std::hint::black_box;
+
+pub fn tiny_workload() -> u64 {
+    black_box(41u64).wrapping_add(black_box(1u64))
+}

--- a/rust/tests/fixtures/bench-noop/src/lib.rs
+++ b/rust/tests/fixtures/bench-noop/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn fixture_value() -> u64 {
+    42
+}


### PR DESCRIPTION
## Summary
- Adds opt-in Rust Criterion bench normalization while preserving the existing `bench-*` binary discovery/execution path as the default contract.
- Adds opt-in Rust developer-loop perf scenarios for clean build, warm build, changed-file check, and test binary build, with cache/change metadata on normalized Homeboy bench scenarios.
- Adds Rust bench docs plus fixtures/smoke coverage for default binaries, profiles, and Criterion estimates artifacts.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/837
Closes https://github.com/Extra-Chill/homeboy-extensions/issues/839

## Verification
- `bash rust/scripts/bench/rust-bench-smoke.sh`
- `bash -n rust/scripts/bench/bench-runner.sh rust/scripts/bench/rust-bench-smoke.sh`
- `jq empty rust/rust.json`
- `HOMEBOY_EXTENSION_PATH="$PWD/rust" HOMEBOY_COMPONENT_PATH="$PWD/rust/tests/fixtures/bench-criterion" HOMEBOY_COMPONENT_ID="bench-criterion-fixture" HOMEBOY_BENCH_ITERATIONS=1 HOMEBOY_RUST_BENCH_CRITERION=1 HOMEBOY_BENCH_LIST_ONLY=1 HOMEBOY_BENCH_RESULTS_FILE="/tmp/homeboy-rust-criterion-list.json" bash rust/scripts/bench/bench-runner.sh && jq -r '.scenarios[].id' /tmp/homeboy-rust-criterion-list.json`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the Rust extension adapter implementation, fixtures, docs, and smoke coverage; Chris remains responsible for review and merge.