### PR TITLE
Seed orchestrator workspaces for WP Codebox audit fanout

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -31,7 +31,7 @@ function hasFlag(name) {
 }
 
 function usage() {
-  console.error('Usage: homeboy-wp-codebox-task-runner.cjs --agents-api <path> --data-machine <path> --data-machine-code <path> [--wp-codebox-bin <bin>] [--provider <id>] [--model <id>] [--max-turns <n>] [--provider-plugin-path <path>] [--secret-env <ENV>] [--mount <host:vfs[:mode]>] [--artifacts <dir>]');
+  console.error('Usage: homeboy-wp-codebox-task-runner.cjs --agents-api <path> --data-machine <path> --data-machine-code <path> [--homeboy <path>] [--homeboy-extensions <path>] [--wp-codebox-bin <bin>] [--provider <id>] [--model <id>] [--max-turns <n>] [--provider-plugin-path <path>] [--secret-env <ENV>] [--mount <host:vfs[:mode]>] [--artifacts <dir>]');
   process.exit(1);
 }
 
@@ -147,10 +147,36 @@ function pathInside(parent, candidate) {
   }
 }
 
+function workspaceSlug(source) {
+  return path.basename(source).split('@')[0].replace(/[^a-zA-Z0-9_-]/g, '-');
+}
+
+function workspaceEntry(source) {
+  const slug = workspaceSlug(source);
+  return {
+    seed: {
+      type: 'directory',
+      source,
+      slug,
+    },
+    target: `/workspace/${slug}`,
+    mode: 'readwrite',
+    sourceMode: 'repo-backed',
+  };
+}
+
+function recipeWorkspaces(options) {
+  return [
+    options.agentsApi,
+    options.homeboy,
+    options.homeboyExtensions,
+  ].filter(Boolean).map(workspaceEntry);
+}
+
 function recipeForRequest(request, options) {
   const provider = argValue('--provider') || request.provider || '';
   const model = argValue('--model') || request.model || '';
-  const workspaceSlug = path.basename(options.agentsApi).split('@')[0].replace(/[^a-zA-Z0-9_-]/g, '-');
+  const workspaceSlugs = recipeWorkspaces(options).map((workspace) => workspace.seed.slug);
   const task = JSON.stringify({
     schema: 'homeboy/wp-codebox-audit-task/v1',
     sandbox_session_id: request.sandbox_session_id,
@@ -161,7 +187,7 @@ function recipeForRequest(request, options) {
       ...(request.task || {}),
       prompt: [
         request.task?.prompt || '',
-        `Use Data Machine Code workspace repo \`${workspaceSlug}\` for all workspace_* tool calls.`,
+        `Use Data Machine Code workspace repos ${workspaceSlugs.map((slug) => `\`${slug}\``).join(', ')} for workspace_* tool calls.`,
       ].filter(Boolean).join('\n\n'),
     },
   });
@@ -187,18 +213,7 @@ function recipeForRequest(request, options) {
       blueprint: { steps: [] },
     },
     inputs: {
-      workspaces: [
-        {
-          seed: {
-            type: 'directory',
-            source: options.agentsApi,
-            slug: workspaceSlug,
-          },
-          target: `/workspace/${workspaceSlug}`,
-          mode: 'readwrite',
-          sourceMode: 'repo-backed',
-        },
-      ],
+      workspaces: recipeWorkspaces(options),
       mounts: mountEntries(),
       extraPlugins: [
         pluginEntry(options.agentsApi, 'agents-api', false),
@@ -291,6 +306,8 @@ try {
     agentsApi: requireArg('--agents-api'),
     dataMachine: requireArg('--data-machine'),
     dataMachineCode: requireArg('--data-machine-code'),
+    homeboy: argValue('--homeboy'),
+    homeboyExtensions: argValue('--homeboy-extensions'),
   };
   const recipe = recipeForRequest(request, options);
   const recipePath = writeRecipe(recipe);

--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -881,6 +881,8 @@ def wp_codebox_task_runner_args(data, settings, script_dir):
     agents_api_path = settings.get('wp_codebox_agents_api_path') or os.environ.get('HOMEBOY_WP_CODEBOX_AGENTS_API_PATH') or component_root
     data_machine_path = settings.get('wp_codebox_data_machine_path') or os.environ.get('HOMEBOY_WP_CODEBOX_DATA_MACHINE_PATH') or default_sibling_path(component_root, 'data-machine')
     data_machine_code_path = settings.get('wp_codebox_data_machine_code_path') or os.environ.get('HOMEBOY_WP_CODEBOX_DATA_MACHINE_CODE_PATH') or default_sibling_path(component_root, 'data-machine-code')
+    homeboy_path = settings.get('wp_codebox_homeboy_path') or os.environ.get('HOMEBOY_WP_CODEBOX_HOMEBOY_PATH') or default_sibling_path(component_root, 'homeboy')
+    homeboy_extensions_path = settings.get('wp_codebox_homeboy_extensions_path') or os.environ.get('HOMEBOY_WP_CODEBOX_HOMEBOY_EXTENSIONS_PATH') or default_sibling_path(component_root, 'homeboy-extensions')
 
     args = [
         os.path.join(script_dir, 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
@@ -888,6 +890,10 @@ def wp_codebox_task_runner_args(data, settings, script_dir):
         '--data-machine', data_machine_path,
         '--data-machine-code', data_machine_code_path,
     ]
+    if os.path.isdir(homeboy_path):
+        args.extend(['--homeboy', homeboy_path])
+    if os.path.isdir(homeboy_extensions_path):
+        args.extend(['--homeboy-extensions', homeboy_extensions_path])
     if settings.get('wp_codebox_bin'):
         args.extend(['--wp-codebox-bin', settings['wp_codebox_bin']])
     if settings.get('wp_codebox_max_turns'):

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -133,12 +133,16 @@ process.stdout.write(JSON.stringify({
       wp_codebox_agents_api_path: path.join(root, 'agents-api'),
       wp_codebox_data_machine_path: path.join(root, 'data-machine'),
       wp_codebox_data_machine_code_path: path.join(root, 'data-machine-code'),
+      wp_codebox_homeboy_path: path.join(root, 'homeboy'),
+      wp_codebox_homeboy_extensions_path: path.join(root, 'homeboy-extensions'),
       wp_codebox_task_timeout_seconds: 2,
     },
   };
   fs.mkdirSync(writeCommand.settings.wp_codebox_agents_api_path, { recursive: true });
   fs.mkdirSync(writeCommand.settings.wp_codebox_data_machine_path, { recursive: true });
   fs.mkdirSync(writeCommand.settings.wp_codebox_data_machine_code_path, { recursive: true });
+  fs.mkdirSync(writeCommand.settings.wp_codebox_homeboy_path, { recursive: true });
+  fs.mkdirSync(writeCommand.settings.wp_codebox_homeboy_extensions_path, { recursive: true });
   fs.mkdirSync(path.join(writeCommand.settings.wp_codebox_agents_api_path, 'src'), { recursive: true });
   fs.writeFileSync(path.join(writeCommand.settings.wp_codebox_agents_api_path, 'src', 'example.php'), 'before\n');
 
@@ -166,6 +170,8 @@ process.stdout.write(JSON.stringify({
   assert.equal(run.records[0].command.timeout_seconds, 2);
   assert.match(run.records[0].command.args[0], /homeboy-wp-codebox-task-runner\.cjs$/);
   assert.equal(run.records[0].command.args.includes('--wp-codebox-bin'), true);
+  assert.equal(run.records[0].command.args.includes('--homeboy'), true);
+  assert.equal(run.records[0].command.args.includes('--homeboy-extensions'), true);
   const artifactsIndex = run.records[0].command.args.indexOf('--artifacts');
   assert.notEqual(artifactsIndex, -1);
   assert.equal(pathInside(writeCommand.root, run.records[0].command.args[artifactsIndex + 1]), false);

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -91,6 +91,10 @@ try {
     '/components/data-machine',
     '--data-machine-code',
     '/components/data-machine-code',
+    '--homeboy',
+    '/components/homeboy',
+    '--homeboy-extensions',
+    '/components/homeboy-extensions',
     '--mount',
     '/repo/plugin:/wordpress/wp-content/plugins/plugin:readwrite',
     '--max-turns',
@@ -117,6 +121,16 @@ try {
 
   const recipe = captured.recipe;
   assert.equal(recipe.schema, 'wp-codebox/workspace-recipe/v1');
+  assert.deepEqual(recipe.inputs.workspaces.map((workspace) => workspace.seed.slug), [
+    'agents-api',
+    'homeboy',
+    'homeboy-extensions',
+  ]);
+  assert.deepEqual(recipe.inputs.workspaces.map((workspace) => workspace.mode), [
+    'readwrite',
+    'readwrite',
+    'readwrite',
+  ]);
   assert.deepEqual(recipe.inputs.secretEnv, ['OPENCODE_API_KEY']);
   assert.equal(recipe.inputs.mounts[0].source, '/repo/plugin');
   assert.equal(recipe.inputs.extraPlugins[0].slug, 'agents-api');
@@ -140,6 +154,7 @@ try {
   assert.equal(task.sandbox_session_id, 'homeboy-audit-fixture-session');
   assert.equal(task.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/775');
   assert.equal(task.audit_findings[0].id, 'finding-1');
+  assert.match(task.task.prompt, /`agents-api`, `homeboy`, `homeboy-extensions`/);
 
   const nonExecutableCapturePath = path.join(root, 'capture-non-executable.json');
   const nonExecutableFixture = createFixtureWpCodebox(root, 0o644);


### PR DESCRIPTION
## Summary
- Seed Homeboy and Homeboy Extensions into WP Codebox audit fanout recipes alongside the target repo so false-positive remediation has the detector/config/test source available.
- Pass optional Homeboy/HE paths through the refactor adapter and include all seeded workspace slugs in the sandbox prompt.
- Cover recipe generation and refactor handoff with smoke assertions for the additional workspaces.

## Testing
- `npm run test:wp-codebox-task-runner`
- `npm run test:refactor-source-wp-codebox`
- `npm run test:audit-wp-codebox-fanout`
- `python3 -m py_compile wordpress/scripts/refactor.py`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the workspace/prompt mismatch, implemented the WP Codebox recipe seeding changes, and ran focused smoke verification. Chris remains responsible for review and merge.