### PR TITLE
Add agent runner evidence artifacts

### DIFF
--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -257,6 +257,22 @@ verifier, policy, workflow, PR, or artifact evidence is reported in
 or runner config `wp_gym_eval.benchmark_mode: true` to turn those gaps into
 projection errors for benchmark-mode jobs.
 
+Every WP Codebox-backed Data Machine agent result includes generic runner
+evidence at `metadata.runner_evidence` using schema
+`homeboy/datamachine-agent-runner-evidence/v1`. This report is benchmark-neutral
+and records the effective prompt/instruction surface, tool/ability summaries,
+workspace refs and dirty state, provider/model/runtime IDs, WP Codebox artifact
+paths, and redaction policy markers. Secret-like keys and inline token/password
+markers are redacted by default using `[redacted]`.
+
+When WP Codebox emits a runtime reference manifest path, the runner preserves it
+as `metadata.wp_codebox.runtime_reference_manifest`, exposes the path as
+`artifacts.wp_codebox_runtime_reference_manifest`, and links it from
+`metadata.evidence_references.references.wp_codebox_runtime_reference_manifest`.
+The preservation path accepts compatible manifest path names without requiring a
+final WP Codebox #222 schema, and redacts secret-like manifest fields before
+embedding payload data in reports.
+
 Final-state review URLs are only emitted when the caller supplies a hosted review
 URL in runner config or scenario metadata. The default bundle records
 `playground_review.available=false` and `final_state.available=false` rather than

--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -35,6 +35,7 @@ const WP_CODEBOX_STRUCTURED_OUTCOME_KINDS = new Set([
   'unable_to_remediate',
   'max_turns_exceeded',
 ]);
+const SECRET_KEY_PATTERN = /(secret|token|password|passwd|authorization|cookie|nonce|api[_-]?key|access[_-]?key|private[_-]?key|bearer)/i;
 
 function sha256(value) {
   return crypto.createHash('sha256').update(value).digest('hex');
@@ -59,6 +60,58 @@ function tryParseJson(value) {
   } catch {
     return null;
   }
+}
+
+function redact(value, key = '') {
+  if (SECRET_KEY_PATTERN.test(key)) {
+    return '[redacted]';
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redact(entry));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([entryKey, entryValue]) => [entryKey, redact(entryValue, entryKey)]));
+  }
+  if (typeof value === 'string') {
+    return value.replace(/(bearer|token|api[_-]?key|password|cookie|authorization|private[_-]?key)(\s*[:=]\s*)[^\s,;]+/gi, '$1$2[redacted]');
+  }
+  return value;
+}
+
+function wpCodeboxRuntimeReferenceManifestPath(parsed, artifact) {
+  const artifacts = parsed && typeof parsed === 'object' && parsed.artifacts && typeof parsed.artifacts === 'object'
+    ? parsed.artifacts
+    : {};
+  const candidates = [
+    artifacts.runtimeReferenceManifestPath,
+    artifacts.runtimeReferencesManifestPath,
+    artifacts.runtime_reference_manifest_path,
+    artifacts.referenceManifestPath,
+    artifacts.runtimeReferencePath,
+    artifacts.runtimeReferencesPath,
+    artifacts.runtime?.referenceManifestPath,
+    artifact?.runtimeReferenceManifestPath,
+    artifact?.runtime_reference_manifest_path,
+  ];
+  return candidates.find((candidate) => typeof candidate === 'string' && candidate.trim()) || '';
+}
+
+function wpCodeboxRuntimeReferenceManifest(parsed, artifact) {
+  const manifestPath = wpCodeboxRuntimeReferenceManifestPath(parsed, artifact);
+  if (!manifestPath) {
+    return null;
+  }
+
+  const manifest = { path: manifestPath, available: false };
+  if (fs.existsSync(manifestPath) && fs.statSync(manifestPath).isFile()) {
+    manifest.available = true;
+    try {
+      manifest.payload = redact(readJson(manifestPath));
+    } catch (error) {
+      manifest.error = error && error.message ? error.message : String(error);
+    }
+  }
+  return manifest;
 }
 
 function fanoutRecordMetrics(startedAt, finishedAt, parsed, artifact) {
@@ -498,6 +551,7 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
       id: artifact.id || '',
       directory: artifact.directory || artifact.path || '',
       preview_url: artifact.preview?.url || artifact.preview_url || '',
+      runtime_reference_manifest: wpCodeboxRuntimeReferenceManifest(parsed, artifact),
     } : null,
     metrics,
   };
@@ -608,6 +662,7 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
           id: artifact.id || '',
           directory: artifact.directory || artifact.path || '',
           preview_url: artifact.preview?.url || artifact.preview_url || '',
+          runtime_reference_manifest: wpCodeboxRuntimeReferenceManifest(parsed, artifact),
         } : null,
         metrics,
       });

--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -126,6 +126,12 @@ const review = {
 
 fs.writeFileSync(path.join(artifactRoot, 'manifest.json'), JSON.stringify({ files: [] }, null, 2) + '\n')
 fs.writeFileSync(path.join(artifactRoot, 'metadata.json'), JSON.stringify({ artifacts: { review: 'files/review.json', changedFiles: 'files/changed-files.json', patch: 'files/patch.diff' } }, null, 2) + '\n')
+fs.writeFileSync(path.join(filesRoot, 'runtime-reference-manifest.json'), JSON.stringify({
+  schema: 'wp-codebox/runtime-reference-manifest-fixture/v1',
+  runtime: { id: 'runtime-fixture', provider: 'wordpress-playground' },
+  references: [{ kind: 'snapshot', digest: 'sha256:runtime-fixture' }],
+  apiToken: 'fixture-secret-token',
+}, null, 2) + '\n')
 fs.writeFileSync(path.join(filesRoot, 'changed-files.json'), JSON.stringify(changedFiles, null, 2) + '\n')
 fs.writeFileSync(path.join(filesRoot, 'review.json'), JSON.stringify(review, null, 2) + '\n')
 fs.writeFileSync(path.join(filesRoot, 'patch.diff'), 'diff --git a/generated.txt b/generated.txt\n')
@@ -164,6 +170,7 @@ process.stdout.write(JSON.stringify({
     metadataPath: path.join(artifactRoot, 'metadata.json'),
     blueprintAfterPath: path.join(artifactRoot, 'blueprint.after.json'),
     capturedMountsPath: path.join(filesRoot, 'mounted-files.json'),
+    runtimeReferenceManifestPath: path.join(filesRoot, 'runtime-reference-manifest.json'),
     changedFilesPath: path.join(filesRoot, 'changed-files.json'),
     patchPath: path.join(filesRoot, 'patch.diff'),
     reviewPath: path.join(filesRoot, 'review.json'),
@@ -193,6 +200,7 @@ jq -n \
             args: ["--scope", "smoke"]
         },
         prompt: "Smoke the WP Codebox runner adapter.",
+        ability_tools: [{name: "fixture_tool", apiToken: "fixture-tool-secret"}],
         wp_codebox_components: {
             agents_api: $agentsApi,
             data_machine: $dataMachine,
@@ -228,8 +236,21 @@ review_schema=$(jq -r "$scenario | .metadata.wp_codebox.review_payload.schema //
 changed_files_schema=$(jq -r "$scenario | .metadata.wp_codebox.changed_files.schema // \"missing\"" "$RESULTS_TMPFILE")
 review_artifact=$(jq -r "$scenario | .artifacts.wp_codebox_review.kind // \"missing\"" "$RESULTS_TMPFILE")
 patch_artifact=$(jq -r "$scenario | .artifacts.wp_codebox_patch.kind // \"missing\"" "$RESULTS_TMPFILE")
-if [ "$wp_codebox_success" != "true" ] || [ -z "$artifact_dir" ] || [ "$review_schema" != "wp-codebox/artifact-review/v1" ] || [ "$changed_files_schema" != "wp-codebox/changed-files/v1" ] || [ "$review_artifact" != "review" ] || [ "$patch_artifact" != "patch" ]; then
+runtime_manifest_artifact=$(jq -r "$scenario | .artifacts.wp_codebox_runtime_reference_manifest.kind // \"missing\"" "$RESULTS_TMPFILE")
+runtime_manifest_schema=$(jq -r "$scenario | .metadata.wp_codebox.runtime_reference_manifest.schema // \"missing\"" "$RESULTS_TMPFILE")
+runtime_manifest_secret=$(jq -r "$scenario | .metadata.wp_codebox.runtime_reference_manifest.apiToken // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$wp_codebox_success" != "true" ] || [ -z "$artifact_dir" ] || [ "$review_schema" != "wp-codebox/artifact-review/v1" ] || [ "$changed_files_schema" != "wp-codebox/changed-files/v1" ] || [ "$review_artifact" != "review" ] || [ "$patch_artifact" != "patch" ] || [ "$runtime_manifest_artifact" != "runtime-reference-manifest" ] || [ "$runtime_manifest_schema" != "wp-codebox/runtime-reference-manifest-fixture/v1" ] || [ "$runtime_manifest_secret" != "[redacted]" ]; then
     echo "ERROR: wp_codebox metadata missing (success=$wp_codebox_success artifact_dir=$artifact_dir)" >&2
+    cat "$RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+runner_evidence_schema=$(jq -r "$scenario | .metadata.runner_evidence.schema // \"missing\"" "$RESULTS_TMPFILE")
+runner_evidence_marker=$(jq -r "$scenario | .metadata.runner_evidence.redaction.marker // \"missing\"" "$RESULTS_TMPFILE")
+runner_evidence_tool_secret=$(jq -r "$scenario | .metadata.runner_evidence.tool_surface.ability_tools[0].apiToken // \"missing\"" "$RESULTS_TMPFILE")
+runner_evidence_runtime_manifest=$(jq -r "$scenario | .metadata.runner_evidence.runtime_surface.runtime_reference_manifest_available // false" "$RESULTS_TMPFILE")
+if [ "$runner_evidence_schema" != "homeboy/datamachine-agent-runner-evidence/v1" ] || [ "$runner_evidence_marker" != "[redacted]" ] || [ "$runner_evidence_tool_secret" != "[redacted]" ] || [ "$runner_evidence_runtime_manifest" != "true" ]; then
+    echo "ERROR: generic runner evidence missing or unredacted" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1
 fi
@@ -241,11 +262,12 @@ runtime_trace_available=$(jq -r "$scenario | .metadata.evidence_references.refer
 replay_bundle_available=$(jq -r "$scenario | .metadata.evidence_references.references.replay_bundle_artifact.available // false" "$RESULTS_TMPFILE")
 verifier_available=$(jq -r "$scenario | .metadata.evidence_references.references.artifact_verifier_result.available // false" "$RESULTS_TMPFILE")
 policy_available=$(jq -r "$scenario | .metadata.evidence_references.references.workspace_policy_result.available // false" "$RESULTS_TMPFILE")
+runtime_manifest_available=$(jq -r "$scenario | .metadata.evidence_references.references.wp_codebox_runtime_reference_manifest.available // false" "$RESULTS_TMPFILE")
 transcript_path=$(jq -r "$scenario | .metadata.evidence_references.references.transcript_artifact.path // \"\"" "$RESULTS_TMPFILE")
 pull_request_value=$(jq -r "$scenario | .metadata.evidence_references.references.pull_request.value // \"\"" "$RESULTS_TMPFILE")
 workspace_branch_value=$(jq -r "$scenario | .metadata.evidence_references.references.workspace_branch.value // \"\"" "$RESULTS_TMPFILE")
 trace_gap=$(jq -r "$scenario | any(.metadata.evidence_references.compatibility_gaps[]?; .field == \"runtime_episode_trace\")" "$RESULTS_TMPFILE")
-if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_available" != "true" ] || [ "$policy_available" != "true" ] || [ "$transcript_path" != "/tmp/wp-codebox-smoke-transcript.json" ] || [ "$pull_request_value" != "https://github.com/example/repo/pull/123" ] || [ "$workspace_branch_value" != "agent-artifacts/example" ] || [ "$trace_gap" != "false" ]; then
+if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_available" != "true" ] || [ "$policy_available" != "true" ] || [ "$runtime_manifest_available" != "true" ] || [ "$transcript_path" != "/tmp/wp-codebox-smoke-transcript.json" ] || [ "$pull_request_value" != "https://github.com/example/repo/pull/123" ] || [ "$workspace_branch_value" != "agent-artifacts/example" ] || [ "$trace_gap" != "false" ]; then
     echo "ERROR: stable evidence references missing or incomplete" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -199,28 +199,52 @@ PHP
 
     local wp_codebox_review_input="$RUNTIME_DIR/wp-codebox-review.json"
     local wp_codebox_changed_files_input="$RUNTIME_DIR/wp-codebox-changed-files.json"
+    local wp_codebox_runtime_reference_manifest_input="$RUNTIME_DIR/wp-codebox-runtime-reference-manifest.json"
     local wp_codebox_artifacts_json="$RUNTIME_DIR/wp-codebox-artifacts.json"
     printf 'null\n' >"$wp_codebox_review_input"
     printf 'null\n' >"$wp_codebox_changed_files_input"
+    printf 'null\n' >"$wp_codebox_runtime_reference_manifest_input"
 
     local wp_codebox_review_path
     local wp_codebox_changed_files_path
+    local wp_codebox_runtime_reference_manifest_path
     wp_codebox_review_path=$(jq -r '.artifacts.reviewPath // empty' "$wp_codebox_output")
     wp_codebox_changed_files_path=$(jq -r '.artifacts.changedFilesPath // empty' "$wp_codebox_output")
+    wp_codebox_runtime_reference_manifest_path=$(jq -r '
+        [
+            .artifacts.runtimeReferenceManifestPath?,
+            .artifacts.runtimeReferencesManifestPath?,
+            .artifacts.runtime_reference_manifest_path?,
+            .artifacts.referenceManifestPath?,
+            .artifacts.runtimeReferencePath?,
+            .artifacts.runtimeReferencesPath?,
+            .artifacts.runtime.referenceManifestPath?
+        ] | map(select(type == "string" and . != "")) | first // empty
+    ' "$wp_codebox_output")
     if [ -n "$wp_codebox_review_path" ] && [ -f "$wp_codebox_review_path" ]; then
         cp "$wp_codebox_review_path" "$wp_codebox_review_input"
     fi
     if [ -n "$wp_codebox_changed_files_path" ] && [ -f "$wp_codebox_changed_files_path" ]; then
         cp "$wp_codebox_changed_files_path" "$wp_codebox_changed_files_input"
     fi
+    if [ -n "$wp_codebox_runtime_reference_manifest_path" ] && [ -f "$wp_codebox_runtime_reference_manifest_path" ]; then
+        cp "$wp_codebox_runtime_reference_manifest_path" "$wp_codebox_runtime_reference_manifest_input"
+    fi
 
     jq -n \
         --slurpfile run "$wp_codebox_output" \
         --slurpfile review "$wp_codebox_review_input" \
         --slurpfile changedFiles "$wp_codebox_changed_files_input" \
+        --slurpfile runtimeReferenceManifest "$wp_codebox_runtime_reference_manifest_input" \
         --slurpfile verifier "$artifact_verifier_result" \
         --slurpfile policy "$workspace_policy_result" \
         '
+        def secret_key($key): ($key | test("secret|token|password|passwd|authorization|cookie|nonce|api[_-]?key|access[_-]?key|private[_-]?key|bearer"; "i"));
+        def redact:
+            if type == "object" then with_entries(.value = if secret_key(.key) then "[redacted]" else (.value | redact) end)
+            elif type == "array" then map(redact)
+            elif type == "string" then gsub("(?i)(bearer|token|api[_-]?key|password|cookie|authorization|private[_-]?key)(\\s*[:=]\\s*)[^\\s,;]+"; "\\1\\2[redacted]")
+            else . end;
         ($run[0].artifacts // {}) as $artifacts
         | {
             schema: "homeboy/wp-codebox-artifacts/v1",
@@ -242,10 +266,12 @@ PHP
                 diffs: ($artifacts.diffsPath // ""),
                 changed_files: ($artifacts.changedFilesPath // ""),
                 patch: ($artifacts.patchPath // ""),
-                review: ($artifacts.reviewPath // "")
+                review: ($artifacts.reviewPath // ""),
+                runtime_reference_manifest: ($artifacts.runtimeReferenceManifestPath // $artifacts.runtimeReferencesManifestPath // $artifacts.runtime_reference_manifest_path // $artifacts.referenceManifestPath // $artifacts.runtimeReferencePath // $artifacts.runtimeReferencesPath // $artifacts.runtime.referenceManifestPath // "")
             } | with_entries(select(.value != "")),
             review_payload: ($review[0] // null),
             changed_files: ($changedFiles[0] // null),
+            runtime_reference_manifest: (($runtimeReferenceManifest[0] // null) | redact),
             artifact_verifier_result: ($verifier[0] // null),
             workspace_policy_result: ($policy[0] // null)
         }
@@ -279,7 +305,8 @@ PHP
                         wp_codebox_metadata: artifact_entry(($wpPaths.metadata // ""); "metadata"; "WP Codebox metadata"),
                         wp_codebox_review: artifact_entry(($wpPaths.review // ""); "review"; "WP Codebox review payload"),
                         wp_codebox_changed_files: artifact_entry(($wpPaths.changed_files // ""); "changed-files"; "WP Codebox changed files"),
-                        wp_codebox_patch: artifact_entry(($wpPaths.patch // ""); "patch"; "WP Codebox patch")
+                        wp_codebox_patch: artifact_entry(($wpPaths.patch // ""); "patch"; "WP Codebox patch"),
+                        wp_codebox_runtime_reference_manifest: artifact_entry(($wpPaths.runtime_reference_manifest // ""); "runtime-reference-manifest"; "WP Codebox runtime reference manifest")
                     } | with_entries(select(.value.path != ""))),
                     metadata: (($workload.metadata // {}) + {
                         wp_codebox: {
@@ -291,6 +318,7 @@ PHP
                             workspace_policy_result: ($wpArtifacts.workspace_policy_result // null),
                             review_payload: ($wpArtifacts.review_payload // null),
                             changed_files: ($wpArtifacts.changed_files // null),
+                            runtime_reference_manifest: ($wpArtifacts.runtime_reference_manifest // null),
                             error: ($run[0].error // null)
                         }
                     })
@@ -454,6 +482,7 @@ homeboy_datamachine_agent_attach_evidence_references() {
         --arg scenarioId "$WORKLOAD_ID" \
         --arg resultsPath "$RESULTS_FILE" \
         --arg workflowRunUrl "$workflow_run_url" \
+        --argjson config "$CONFIG_JSON" \
         '
         def present($value): $value != null and $value != "" and $value != [] and $value != {};
         def ref($kind; $path; $label; $source):
@@ -462,6 +491,91 @@ homeboy_datamachine_agent_attach_evidence_references() {
             {kind: $kind, value: $value, label: $label, source: $source, available: present($value)};
         def gap($field; $reason):
             {field: $field, reason: $reason, compatibility_gap: true};
+        def secret_key($key): ($key | test("secret|token|password|passwd|authorization|cookie|nonce|api[_-]?key|access[_-]?key|private[_-]?key|bearer"; "i"));
+        def redact:
+            if type == "object" then with_entries(.value = if secret_key(.key) then "[redacted]" else (.value | redact) end)
+            elif type == "array" then map(redact)
+            elif type == "string" then gsub("(?i)(bearer|token|api[_-]?key|password|cookie|authorization|private[_-]?key)(\\s*[:=]\\s*)[^\\s,;]+"; "\\1\\2[redacted]")
+            else . end;
+        def tool_summary($metadata):
+            ([
+                ($metadata.tool_audit_events // [])[]?,
+                ($metadata.engine_data.tool_execution_summary // [])[]?,
+                ($metadata.engine_data.tool_results // [])[]?,
+                ($metadata.engine_data.github_tool_results // [])[]?
+            ] | map(select(type == "object")) | map({
+                tool_name: (.tool_name // .action_name // .name // ""),
+                tool_source: (.tool_source // .source // ""),
+                success: (.success // false),
+                result_status: (.result_status // (if (.success // false) then "success" else "unknown" end)),
+                parameters_redacted: (.parameters_redacted // true),
+                parameters_sha256: (.parameters_sha256 // .args_sha256 // ""),
+                result_sha256: (.result_sha256 // ""),
+                error_type: (.error_type // "")
+            } | with_entries(select(.value != "")))) as $events
+            | {
+                count: ($events | length),
+                names: ($events | map(.tool_name) | map(select(. != "")) | unique),
+                events: $events
+            };
+        def runner_evidence($scenario):
+            ($scenario.metadata // {}) as $metadata
+            | ($metadata.wp_codebox.canonical_artifacts // {}) as $wpPaths
+            | ($metadata.runner_workspace_capture // {}) as $workspaceCapture
+            | ($workspaceCapture.status // {}) as $workspaceStatus
+            | {
+                schema: "homeboy/datamachine-agent-runner-evidence/v1",
+                redaction: {
+                    applied: true,
+                    marker: "[redacted]",
+                    policy: "key-name and inline secret marker redaction for prompt/tool/workspace/runtime evidence"
+                },
+                prompt_surface: {
+                    sha256: ($metadata.fingerprints.prompt.sha256 // ""),
+                    bytes: ($metadata.fingerprints.prompt.bytes // (($metadata.prompt // "") | length)),
+                    prompt: (($metadata.prompt // "") | redact),
+                    prompt_env: (($config.prompt_env // "") | redact),
+                    instruction_sources: ([
+                        {kind: "bundle", path: ($metadata.bundle_path // $config.bundle_path // "")},
+                        {kind: "flow", slug: ($metadata.flow_slug // $config.flow_slug // "")},
+                        {kind: "agent", slug: ($metadata.agent_slug // $config.agent_slug // "")}
+                    ] | map(select(.path != "" or .slug != "")))
+                },
+                tool_surface: {
+                    required_abilities: (($config.required_abilities // []) | redact),
+                    ability_tools: (($config.ability_tools // []) | redact),
+                    tool_recorders: (($config.tool_recorders // []) | redact),
+                    audit_summary: tool_summary($metadata)
+                },
+                workspace_surface: {
+                    configured: (($config.runner_workspace // {}) | redact),
+                    provisioned: (($metadata.runner_workspace // {}) | redact),
+                    captured: {
+                        enabled: ($workspaceCapture.enabled // false),
+                        changed: ($workspaceCapture.changed // false),
+                        handle: ($workspaceStatus.handle // $workspaceStatus.name // ""),
+                        branch: ($workspaceStatus.branch // ""),
+                        dirty: ($workspaceStatus.dirty // null),
+                        files: (($workspaceStatus.files // []) | redact),
+                        diff_redacted: (if present($workspaceCapture.diff) then true else false end)
+                    } | with_entries(select(.value != null and .value != "" and .value != []))
+                },
+                runtime_surface: {
+                    provider: ($metadata.provider // $config.provider // ""),
+                    model: ($metadata.model // $config.model // ""),
+                    runtime_versions: (($metadata.runtime_versions // {}) | redact),
+                    wp_codebox_runtime: (($metadata.wp_codebox.runtime // null) | redact),
+                    wp_codebox_paths: ($wpPaths | redact),
+                    runtime_reference_manifest_available: present($metadata.wp_codebox.runtime_reference_manifest)
+                } | with_entries(select(.value != null and .value != "" and .value != {})),
+                config_surface: ({
+                    component_id: ($config.component_id // ""),
+                    workload_id: ($config.workload_id // ""),
+                    workload_label: ($config.workload_label // ""),
+                    dry_run: ($config.dry_run // false),
+                    secret_env_names: (($config.secret_env // $config.secretEnv // []) | if type == "array" then . else [] end)
+                } | redact | with_entries(select(.value != "" and .value != [])))
+            };
         def first_field($source; $name):
             ([$source | .. | objects | .[$name]? | select(present(.))] | first) // null;
         def first_tool_pr_url($metadata):
@@ -499,6 +613,7 @@ homeboy_datamachine_agent_attach_evidence_references() {
                     homeboy_result_json: ref("json"; $resultsPath; "Homeboy result JSON"; "homeboy"),
                     wp_codebox_artifact_bundle: ref("directory"; ($wpPaths.directory // ""); "WP Codebox artifact bundle"; "wp-codebox"),
                     wp_codebox_manifest: ref("json"; ($wpPaths.manifest // ""); "WP Codebox manifest"; "wp-codebox"),
+                    wp_codebox_runtime_reference_manifest: ref("json"; ($wpPaths.runtime_reference_manifest // ""); "WP Codebox runtime reference manifest"; "wp-codebox"),
                     artifact_verifier_result: inline_ref("json"; $artifactVerifier; "Artifact verifier result"; "runner"),
                     workspace_policy_result: inline_ref("json"; $policyResult; "Workspace policy result"; "data-machine-code"),
                     runtime_episode_trace: ref("jsonl"; $episodeTrace; "Runtime episode trace"; "homeboy"),
@@ -528,7 +643,7 @@ homeboy_datamachine_agent_attach_evidence_references() {
                     if present($replayBundle) then empty else gap("replay_bundle_artifact"; "No replay bundle artifact was generated for this run.") end
                 ])
             };
-        .scenarios |= map(if .id == $scenarioId then .metadata.evidence_references = evidence(.) else . end)
+        .scenarios |= map(if .id == $scenarioId then .metadata.runner_evidence = runner_evidence(.) | .metadata.evidence_references = evidence(.) else . end)
         ' "$RESULTS_FILE" >"$updated_results"
     mv "$updated_results" "$RESULTS_FILE"
 }

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -209,8 +209,16 @@ process.stdin.on('end', () => {
     process.exit(3);
   }
   const artifactDirectory = path.join(root, 'artifact-' + request.sandbox_session_id);
+  const filesDirectory = path.join(artifactDirectory, 'files');
   fs.mkdirSync(artifactDirectory, { recursive: true });
+  fs.mkdirSync(filesDirectory, { recursive: true });
   fs.writeFileSync(path.join(artifactDirectory, 'artifact.txt'), 'fixture artifact bytes\\n');
+  fs.writeFileSync(path.join(filesDirectory, 'runtime-reference-manifest.json'), JSON.stringify({
+    schema: 'wp-codebox/runtime-reference-manifest-fixture/v1',
+    runtime: { id: request.sandbox_session_id, provider: 'wordpress-playground' },
+    references: [{ kind: 'workspace', digest: 'sha256:fixture-reference' }],
+    cookie: 'fixture-cookie-secret',
+  }, null, 2) + '\\n');
   process.stdout.write(JSON.stringify({
     success: true,
     session: {
@@ -222,6 +230,7 @@ process.stdin.on('end', () => {
       id: 'artifact-' + request.sandbox_session_id,
       directory: artifactDirectory,
       preview: { url: 'https://preview.example.test/' + request.sandbox_session_id },
+      runtimeReferenceManifestPath: path.join(filesDirectory, 'runtime-reference-manifest.json'),
     },
     metrics: {
       duration_ms: 99,
@@ -566,6 +575,9 @@ try {
   assert.equal(completedRecord.result.session.id, completedRecord.sandbox_session_id);
   assert.equal(completedRecord.result.session.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/773');
   assert.match(completedRecord.artifact.id, /^artifact-homeboy-audit-/);
+  assert.equal(completedRecord.artifact.runtime_reference_manifest.available, true);
+  assert.equal(completedRecord.artifact.runtime_reference_manifest.payload.schema, 'wp-codebox/runtime-reference-manifest-fixture/v1');
+  assert.equal(completedRecord.artifact.runtime_reference_manifest.payload.cookie, '[redacted]');
   assert.equal(completedRecord.outcome.kind, 'fix_pr');
   assert.equal(completedRecord.outcome.pr_url, 'https://github.com/Extra-Chill/homeboy-extensions/pull/777');
   assertMetrics(completedRecord, { runnerMetrics: true, artifactBytes: true });


### PR DESCRIPTION
## Summary
- Add generic `metadata.runner_evidence` for WP Codebox-backed Data Machine agent runs, covering redacted prompt/instruction, tool, workspace, model, and runtime surfaces.
- Preserve WP Codebox runtime reference manifests when compatible manifest paths are present, with redacted embedded payloads and stable evidence references.
- Extend smoke coverage for redaction and tolerant reference-manifest fixtures.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/842
Closes https://github.com/Extra-Chill/homeboy-extensions/issues/843

## Tests
- `npm run test:datamachine-agent-wp-codebox-runner`
- `npm run test:audit-wp-codebox-fanout`
- `npm run test:wp-codebox-task-runner`
- `npm run lint:js -- lib/audit-wp-codebox-fanout.js`
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh && bash -n wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `git diff --check`

## Notes
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-agent-runner-evidence-artifacts --extension wordpress --ci-job wp-codebox-runtime --skip-lint` was not applicable because `wp-codebox-runtime` is not a declared CI job for this extension.
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-agent-runner-evidence-artifacts --extension wordpress --skip-lint --changed-since origin/main` routed to PHPUnit, selected a JS smoke file, and reported no PHPUnit tests to run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner evidence/report plumbing, redaction tests, docs update, and verification commands for Chris to review.