### PR TITLE
fix: avoid pipefail-sensitive agent terminal tokens

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -186,6 +186,7 @@ jq -n \
         workload_id: "wp-codebox-runner-smoke",
         workload_label: "WP Codebox runner smoke",
         dry_run: true,
+        enable_terminal_actions: true,
         provider: "example-provider",
         model: "example-model",
         workspace_policy_check: {

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -706,7 +706,7 @@ if [ "$ENABLE_TERMINAL_ACTIONS" = "1" ]; then
         RUNTIME_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-datamachine-agent-runtime.XXXXXX")
     fi
     TERMINAL_READY_FILE="$RUNTIME_DIR/terminal-action-server.json"
-    TERMINAL_TOKEN="$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)"
+    TERMINAL_TOKEN="$(node -e "process.stdout.write(require('node:crypto').randomBytes(24).toString('base64url'))")"
     node "$SCRIPT_DIR/terminal-action-server.js" \
         --runtime-root "$COMPONENT_PATH" \
         --ready-file "$TERMINAL_READY_FILE" \


### PR DESCRIPTION
## Summary
- Generate the Data Machine agent terminal action token with Node crypto instead of a `tr | head` pipeline that can fail under `set -o pipefail`.
- Enable terminal actions in the WP Codebox agent runner smoke test so this path is covered.

## Evidence
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh` passed.
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh` passed.
- `git diff --check` passed.
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-validation-dependency-composer-install --extension wordpress` reached WP Codebox activation/install but returned non-zero because no PHPUnit files are discoverable for this component.

Fixes #847.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the wp-gym workflow blocker, identifying the shell pipefail failure, drafting the minimal runner fix, and running validation. Chris remains responsible for review and merge.
