### PR TITLE
Fix eval run metadata evidence references

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -146,6 +146,9 @@ const output = {
     model: 'example-model',
     agent_slug: 'wp-codebox-smoke-agent',
     flow_slug: 'wp-codebox-smoke-flow',
+    eval_artifact: {
+      run: [{ workflow_run_url: 'https://github.com/example/repo/actions/runs/456' }],
+    },
     transcript_artifacts: [[{ json: '/tmp/wp-codebox-smoke-transcript.json', summary: 'Nested transcript fixture' }]],
     job_artifact_exports: [{ pr_url: 'https://github.com/example/repo/pull/123', branch: 'agent-artifacts/example' }],
     engine_data: {
@@ -267,8 +270,9 @@ runtime_manifest_available=$(jq -r "$scenario | .metadata.evidence_references.re
 transcript_path=$(jq -r "$scenario | .metadata.evidence_references.references.transcript_artifact.path // \"\"" "$RESULTS_TMPFILE")
 pull_request_value=$(jq -r "$scenario | .metadata.evidence_references.references.pull_request.value // \"\"" "$RESULTS_TMPFILE")
 workspace_branch_value=$(jq -r "$scenario | .metadata.evidence_references.references.workspace_branch.value // \"\"" "$RESULTS_TMPFILE")
+workflow_run_path=$(jq -r "$scenario | .metadata.evidence_references.references.workflow_run.path // \"\"" "$RESULTS_TMPFILE")
 trace_gap=$(jq -r "$scenario | any(.metadata.evidence_references.compatibility_gaps[]?; .field == \"runtime_episode_trace\")" "$RESULTS_TMPFILE")
-if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_available" != "true" ] || [ "$policy_available" != "true" ] || [ "$runtime_manifest_available" != "true" ] || [ "$transcript_path" != "/tmp/wp-codebox-smoke-transcript.json" ] || [ "$pull_request_value" != "https://github.com/example/repo/pull/123" ] || [ "$workspace_branch_value" != "agent-artifacts/example" ] || [ "$trace_gap" != "false" ]; then
+if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_available" != "true" ] || [ "$policy_available" != "true" ] || [ "$runtime_manifest_available" != "true" ] || [ "$transcript_path" != "/tmp/wp-codebox-smoke-transcript.json" ] || [ "$pull_request_value" != "https://github.com/example/repo/pull/123" ] || [ "$workspace_branch_value" != "agent-artifacts/example" ] || [ "$workflow_run_path" != "https://github.com/example/repo/actions/runs/456" ] || [ "$trace_gap" != "false" ]; then
     echo "ERROR: stable evidence references missing or incomplete" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -595,6 +595,14 @@ homeboy_datamachine_agent_attach_evidence_references() {
             // first_field($metadata.job_artifact_exports; "branch")
             // first_field($metadata.fallback_pull_request; "head")
             // "";
+        def eval_workflow_run_url($metadata):
+            if ($metadata.eval_artifact.run? | type) == "object" then
+                ($metadata.eval_artifact.run.workflow_run_url // "")
+            elif ($metadata.eval_artifact.run? | type) == "array" then
+                ([$metadata.eval_artifact.run[]? | objects | .workflow_run_url? | select(present(.))] | first) // ""
+            else
+                ""
+            end;
         def evidence($scenario):
             ($scenario.metadata // {}) as $metadata
             | ($scenario.artifacts // {}) as $artifacts
@@ -624,7 +632,7 @@ homeboy_datamachine_agent_attach_evidence_references() {
                     grader_result: inline_ref("json"; ($metadata.eval_artifact.grade // $metadata.grade // null); "Grader result"; "runner"),
                     pull_request: inline_ref("url"; pr_url($metadata); "Pull request URL"; "github"),
                     workspace_branch: inline_ref("git-ref"; workspace_branch($metadata); "Workspace branch"; "runner"),
-                    workflow_run: ref("url"; ($metadata.workflow_run_url // $metadata.eval_artifact.run.workflow_run_url // $workflowRunUrl); "Workflow run"; "github")
+                    workflow_run: ref("url"; ($metadata.workflow_run_url // eval_workflow_run_url($metadata) // $workflowRunUrl); "Workflow run"; "github")
                 },
                 fingerprints: {
                     prompt_sha256: ($fingerprints.prompt.sha256 // ""),


### PR DESCRIPTION
## Summary
- Make Data Machine agent evidence reference generation tolerate `metadata.eval_artifact.run` when it is an array instead of an object.
- Extend the WP Codebox runner smoke test to cover workflow URLs coming from array-shaped eval run metadata.

## Verification
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `git diff --check`
- wp-gym dry-run passed with this fix pinned: https://github.com/Automattic/wp-gym/actions/runs/26638085201

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the GitHub Actions jq failure, drafted the runner fix and smoke coverage, and ran verification; Chris remains responsible for review and merge.