### PR TITLE
Fix wp-gym fields in sealed eval artifacts

### DIFF
--- a/wordpress/scripts/agent/build-replay-bundle-smoke.sh
+++ b/wordpress/scripts/agent/build-replay-bundle-smoke.sh
@@ -113,13 +113,14 @@ if [ "$final_state_available" != "false" ]; then
 fi
 
 sealed_status=$(jq -r '.sealed_eval_artifact.status' "$BUNDLE_PATH")
+generic_has_wp_gym=$(jq -r '.sealed_eval_artifact | has("wp_gym")' "$BUNDLE_PATH")
 tool_audit_count=$(jq -r '.sealed_eval_artifact.replay.tool_audit_event_count' "$BUNDLE_PATH")
 episode_row_count=$(jq -r '.sealed_eval_artifact.replay.episode_row_count' "$BUNDLE_PATH")
 transcript_hash=$(jq -r '.sealed_eval_artifact.hashes.artifact_hashes.transcript_json.sha256 // "missing"' "$BUNDLE_PATH")
 episode_hash=$(jq -r '.sealed_eval_artifact.hashes.artifact_hashes.episode_jsonl.sha256 // "missing"' "$BUNDLE_PATH")
 envelope_hash=$(jq -r '.sealed_eval_artifact.hashes.envelope // "missing"' "$BUNDLE_PATH")
 missing_seams=$(jq -r '.sealed_eval_artifact.integration_seams | join(",")' "$BUNDLE_PATH")
-if [ "$sealed_status" != "ready_for_replay" ] || [ "$tool_audit_count" != "1" ] || [ "$episode_row_count" != "2" ] || [ "$transcript_hash" = "missing" ] || [ "$episode_hash" = "missing" ] || [ "$envelope_hash" = "missing" ]; then
+if [ "$sealed_status" != "ready_for_replay" ] || [ "$generic_has_wp_gym" != "false" ] || [ "$tool_audit_count" != "1" ] || [ "$episode_row_count" != "2" ] || [ "$transcript_hash" = "missing" ] || [ "$episode_hash" = "missing" ] || [ "$envelope_hash" = "missing" ]; then
 	echo "ERROR: sealed eval artifact envelope incomplete" >&2
 	cat "$BUNDLE_PATH" >&2
 	exit 1
@@ -135,6 +136,98 @@ fi
 if [[ "$missing_seams" != *"datamachine_provenance"* ]] || [[ "$missing_seams" != *"datamachine_code_policy_attestation"* ]]; then
 	echo "ERROR: expected missing provenance/policy seams to remain explicit" >&2
 	cat "$BUNDLE_PATH" >&2
+	exit 1
+fi
+
+jq -n --arg transcriptFile "$TRANSCRIPT_FILE" '{
+	component_id: "example-plugin",
+	iterations: 1,
+	scenarios: [
+		{
+			id: "agent-wp-gym",
+			label: "Agent wp-gym task",
+			source: "config",
+			metrics: { reward_mean: 1 },
+			artifacts: {
+				transcript_json: { path: $transcriptFile, kind: "jsonl" }
+			},
+			metadata: {
+				provider: "openai",
+				model: "gpt-example",
+				job_status: "completed",
+				grade: { score: 1, max_score: 1 },
+				reward: 1,
+				wp_gym_eval: {
+					scenario: {
+						id: "navigation-menu-001",
+						label: "Create a navigation menu",
+						task_family: "navigation"
+					},
+					status: { outcome: "passed", failure_class: "none" }
+				},
+				tool_audit_events: [
+					{
+						schema_version: 1,
+						type: "tool_call",
+						turn_count: 1,
+						tool_name: "client/update_site",
+						parameters_sha256: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+						success: true,
+						result_status: "success"
+					}
+				]
+			}
+		}
+	]
+}' > "$RESULTS_TMPFILE"
+
+jq -n '{
+	component_id: "example-plugin",
+	workload_id: "agent-wp-gym",
+	provider: "openai",
+	model: "gpt-example",
+	prompt: "Create a navigation menu.",
+	general_rules: ["Follow the task instructions."],
+	task_rules: ["Do not modify unrelated content."],
+	wp_gym_eval: {
+		benchmark_mode: true,
+		task_set: {
+			id: "wp-admin-tasks",
+			version: "2026-05-29",
+			benchmark_status: "candidate",
+			compatibility_group: "wp-6.8",
+			aggregate_score: false,
+			headline_score_eligible: false
+		},
+		grader: {
+			success: true,
+			checks: [{ name: "menu_exists", status: "passed" }]
+		}
+	}
+}' > "$CONFIG_TMPFILE"
+
+node "$SCRIPT_DIR/build-replay-bundle.js" \
+	--results "$RESULTS_TMPFILE" \
+	--scenario agent-wp-gym \
+	--config "$CONFIG_TMPFILE" \
+	--output-dir "$BUNDLE_DIR" >/dev/null
+
+WPGYM_BUNDLE_PATH="$BUNDLE_DIR/agent-wp-gym-replay-bundle.json"
+wp_gym_projection=$(jq -r '[
+	.sealed_eval_artifact.wp_gym.scenario.id,
+	.sealed_eval_artifact.wp_gym.scenario.task_family,
+	.sealed_eval_artifact.wp_gym.task_set.id,
+	.sealed_eval_artifact.wp_gym.task_set.benchmark_status,
+	(.sealed_eval_artifact.wp_gym.grader.success | tostring),
+	(.sealed_eval_artifact.wp_gym.grader.reward | tostring),
+	.sealed_eval_artifact.wp_gym.status.outcome,
+	.sealed_eval_artifact.wp_gym.status.failure_class
+] | join(" ")' "$WPGYM_BUNDLE_PATH")
+wp_gym_prompt_hash=$(jq -r '.sealed_eval_artifact.wp_gym.scenario.prompt_sha256 // "missing"' "$WPGYM_BUNDLE_PATH")
+wp_gym_check_name=$(jq -r '.sealed_eval_artifact.wp_gym.grader.checks[0].name // "missing"' "$WPGYM_BUNDLE_PATH")
+if [ "$wp_gym_projection" != "navigation-menu-001 navigation wp-admin-tasks candidate true 1 passed none" ] || [ "$wp_gym_prompt_hash" = "missing" ] || [ "$wp_gym_check_name" != "menu_exists" ]; then
+	echo "ERROR: wp-gym sealed eval projection incomplete" >&2
+	cat "$WPGYM_BUNDLE_PATH" >&2
 	exit 1
 fi
 

--- a/wordpress/scripts/agent/build-replay-bundle.js
+++ b/wordpress/scripts/agent/build-replay-bundle.js
@@ -261,6 +261,72 @@ function replayObservationChannels(metadata, config) {
 	return Array.isArray(channels) ? channels.filter((channel) => typeof channel === 'string' && channel.length > 0) : [];
 }
 
+function objectValue(value) {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function firstObject(...values) {
+	return values.find((value) => value && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length > 0) || {};
+}
+
+function firstDefined(...values) {
+	return values.find((value) => value !== undefined && value !== null && value !== '');
+}
+
+function buildWpGymProjection(scenario, config, metadata, evalArtifact) {
+	const configEval = objectValue(config.wp_gym_eval);
+	const metadataEval = objectValue(metadata.wp_gym_eval);
+	if (Object.keys(configEval).length === 0 && Object.keys(metadataEval).length === 0) {
+		return undefined;
+	}
+
+	const manifest = objectValue(metadata.scenario_manifest || metadata.manifest || metadata.scenario);
+	const scenarioConfig = firstObject(metadataEval.scenario, configEval.scenario, manifest.wp_gym?.scenario, manifest.scenario);
+	const taskSetConfig = firstObject(metadataEval.task_set, configEval.task_set, manifest.wp_gym?.task_set, manifest.task_set);
+	const graderConfig = firstObject(metadataEval.grader, configEval.grader, manifest.wp_gym?.grader);
+	const statusConfig = firstObject(metadataEval.status, configEval.status, manifest.wp_gym?.status);
+	const fingerprints = objectValue(metadata.fingerprints);
+	const evalHashes = objectValue(evalArtifact.hashes);
+	const grade = firstObject(graderConfig.grade, evalArtifact.grade, metadata.grade);
+	const reward = firstDefined(graderConfig.reward, metadata.reward, metadata.score, grade.reward, grade.score);
+	const failureReasons = firstDefined(graderConfig.failure_reasons, evalArtifact.failure_reasons, metadata.failure_reasons, []);
+	const success = firstDefined(graderConfig.success, metadata.success, metadata.success_status === 'success' ? true : undefined, grade.score !== undefined && grade.max_score !== undefined ? grade.score >= grade.max_score : undefined);
+	const outcome = firstDefined(statusConfig.outcome, success === true ? 'passed' : undefined, success === false ? 'failed' : undefined, metadata.completion_outcome, metadata.job_status, evalArtifact.run?.job_status);
+	const taskFamily = firstDefined(scenarioConfig.task_family, metadataEval.task_family, configEval.task_family, metadata.task_family, config.task_family, manifest.task_family);
+
+	return compactObject({
+		scenario: compactObject({
+			id: firstDefined(scenarioConfig.id, metadataEval.scenario_id, configEval.scenario_id, metadata.task_id, config.task_id, config.workload_id, scenario.id),
+			label: firstDefined(scenarioConfig.label, metadataEval.scenario_label, configEval.scenario_label, metadata.task_label, config.task_label, config.workload_label, scenario.label),
+			task_family: taskFamily,
+			prompt_sha256: firstDefined(scenarioConfig.prompt_sha256, fingerprints.prompt?.sha256, evalHashes.prompt?.sha256, config.prompt ? sha256Buffer(Buffer.from(config.prompt, 'utf8')) : undefined),
+			rules: compactObject({
+				general: firstDefined(scenarioConfig.rules?.general, metadata.general_rules, config.general_rules),
+				task_specific: firstDefined(scenarioConfig.rules?.task_specific, metadata.task_rules, config.task_rules),
+			}),
+		}),
+		task_set: compactObject({
+			id: firstDefined(taskSetConfig.id, metadataEval.task_set_id, configEval.task_set_id),
+			version: firstDefined(taskSetConfig.version, metadataEval.task_set_version, configEval.task_set_version),
+			benchmark_status: firstDefined(taskSetConfig.benchmark_status, metadataEval.benchmark_status, configEval.benchmark_status),
+			compatibility_group: firstDefined(taskSetConfig.compatibility_group, metadataEval.compatibility_group, configEval.compatibility_group),
+			aggregate_score: firstDefined(taskSetConfig.aggregate_score, metadataEval.aggregate_score, configEval.aggregate_score),
+			headline_score_eligible: firstDefined(taskSetConfig.headline_score_eligible, metadataEval.headline_score_eligible, configEval.headline_score_eligible),
+		}),
+		grader: compactObject({
+			success,
+			reward,
+			grade,
+			failure_reasons: Array.isArray(failureReasons) ? failureReasons : [],
+			checks: firstDefined(graderConfig.checks, metadata.grader_checks, metadata.checks, []),
+		}),
+		status: compactObject({
+			outcome,
+			failure_class: firstDefined(statusConfig.failure_class, metadata.failure_class, success === false ? 'grader' : undefined, success === true ? 'none' : undefined),
+		}),
+	});
+}
+
 function buildEpisodeRows(scenario, config) {
 	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
 	const evalArtifact = metadata.eval_artifact && typeof metadata.eval_artifact === 'object' ? metadata.eval_artifact : {};
@@ -340,6 +406,7 @@ function buildSealedEnvelope(results, scenario, config, bundlePath, artifactInte
 			? `${process.env.GITHUB_SERVER_URL || 'https://github.com'}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
 			: ''
 	);
+	const wpGym = buildWpGymProjection(scenario, config, metadata, evalArtifact);
 
 	return redact({
 		schema_name: 'homeboy.sealed_eval_artifact',
@@ -387,6 +454,7 @@ function buildSealedEnvelope(results, scenario, config, bundlePath, artifactInte
 			hashes: artifactIntegrity.hashes,
 			issues: artifactIntegrity.issues,
 		},
+		wp_gym: wpGym,
 		integration_seams: Array.from(new Set(missingSeams.filter(Boolean))),
 	});
 }


### PR DESCRIPTION
## Summary
- Adds an opt-in `wp_gym` projection to `homeboy.sealed_eval_artifact` when runner config or scenario metadata includes `wp_gym_eval` semantics.
- Projects explicit `wp_gym.scenario`, `wp_gym.task_set`, `wp_gym.grader`, and `wp_gym.status` fields from caller-provided metadata plus existing grade/prompt data.
- Extends replay-bundle smoke coverage to assert generic runs omit `wp_gym` and wp-gym-like runs include the sealed fields.

Fixes #853.

## Tests
- `bash scripts/agent/build-replay-bundle-smoke.sh`
- `npm run test:project-wpgym-eval-row`
- `npm run test:validate-wpgym-eval-row`
- `npx eslint scripts/agent/build-replay-bundle.js`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@issue-853-wp-gym-sealed-fields --extension wordpress` (activation/install passed; PHPUnit phase skipped because this component has no discoverable PHPUnit tests)

## Known existing baseline
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@issue-853-wp-gym-sealed-fields --extension wordpress` reports pre-existing broad PHP/fixture findings outside the touched files, including `wordpress/scripts/agent/validate-bundle.php` formatting findings and audit fixture parse errors.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the sealed artifact producer change, smoke coverage, and validation commands for Chris to review.