### PR TITLE
Move shared Rust target env into Rust extension

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -24,6 +24,9 @@
     "compiler_warnings": "scripts/compiler-warnings.py",
     "compiler_warning_fixes": "scripts/compiler-warning-fixes.py"
   },
+  "env_provider": {
+    "script": "scripts/env-provider.sh"
+  },
   "lint": {
     "extension_script": "scripts/lint-runner.sh"
   },

--- a/rust/scripts/env-provider.sh
+++ b/rust/scripts/env-provider.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_path="${HOMEBOY_COMPONENT_PATH:-${PWD}}"
+
+if [ -n "${CARGO_TARGET_DIR:-}" ] || [ ! -f "${project_path}/Cargo.toml" ]; then
+    printf '{}\n'
+    exit 0
+fi
+
+normalize_identity() {
+    local value="$1"
+    value="${value%/}"
+    value="${value%.git}"
+    case "$value" in
+        git@github.com:*) value="https://github.com/${value#git@github.com:}" ;;
+        git@github.a8c.com:*) value="https://github.a8c.com/${value#git@github.a8c.com:}" ;;
+    esac
+    printf '%s' "$value" | tr '[:upper:]' '[:lower:]'
+}
+
+hash_identity() {
+    if command -v shasum >/dev/null 2>&1; then
+        printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+    elif command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "$1" | sha256sum | awk '{print $1}'
+    else
+        printf '%s' "$1" | openssl dgst -sha256 | awk '{print $NF}'
+    fi
+}
+
+identity="component:${HOMEBOY_COMPONENT_ID:-component}"
+if origin="$(git -C "$project_path" config --get remote.origin.url 2>/dev/null)" && [ -n "$origin" ]; then
+    identity="$(normalize_identity "$origin")"
+fi
+
+label="$(printf '%s' "${HOMEBOY_COMPONENT_ID:-component}" | sed -E 's/[^A-Za-z0-9._-]+/_/g; s/^_+//; s/_+$//')"
+if [ -z "$label" ]; then
+    label="component"
+fi
+
+hash="$(hash_identity "$identity")"
+data_dir="${HOMEBOY_DATA_DIR:-${XDG_DATA_HOME:-${HOME}/.local/share}/homeboy}"
+target_dir="${data_dir}/cargo-targets/${label}-${hash:0:12}"
+
+python3 - "$target_dir" <<'PY'
+import json
+import sys
+
+target_dir = sys.argv[1]
+print(json.dumps({
+    "CARGO_TARGET_DIR": target_dir,
+    "HOMEBOY_CARGO_TARGET_DIR": target_dir,
+}))
+PY

--- a/rust/tests/env-provider-smoke.sh
+++ b/rust/tests/env-provider-smoke.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WORK_DIR="$(mktemp -d -t homeboy-rust-env-provider.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+make_project() {
+    local dir="$1"
+    mkdir -p "$dir/src"
+    cat > "$dir/Cargo.toml" <<'TOML'
+[package]
+name = "fixture"
+version = "0.1.0"
+edition = "2021"
+TOML
+    printf 'fn main() {}\n' > "$dir/src/main.rs"
+}
+
+target_dir_for() {
+    local project="$1"
+    HOMEBOY_COMPONENT_ID=fixture \
+        HOMEBOY_COMPONENT_PATH="$project" \
+        HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+        XDG_DATA_HOME="$WORK_DIR/data" \
+        "$EXTENSION_DIR/scripts/env-provider.sh" \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin).get("CARGO_TARGET_DIR", ""))'
+}
+
+primary="$WORK_DIR/primary"
+worktree="$WORK_DIR/worktree"
+explicit="$WORK_DIR/explicit-target"
+make_project "$primary"
+cp -R "$primary" "$worktree"
+git -C "$primary" init -q
+git -C "$primary" remote add origin https://github.com/Extra-Chill/homeboy.git
+git -C "$worktree" init -q
+git -C "$worktree" remote add origin git@github.com:Extra-Chill/homeboy.git
+
+primary_target="$(target_dir_for "$primary")"
+worktree_target="$(target_dir_for "$worktree")"
+
+if [ -z "$primary_target" ] || [ "$primary_target" != "$worktree_target" ]; then
+    printf 'Expected matching shared target dirs, got primary=%s worktree=%s\n' "$primary_target" "$worktree_target" >&2
+    exit 1
+fi
+
+case "$primary_target" in
+    "$WORK_DIR/data/homeboy/cargo-targets/fixture-"*) ;;
+    *)
+        printf 'Expected target under Homeboy data dir, got %s\n' "$primary_target" >&2
+        exit 1
+        ;;
+esac
+
+explicit_output="$(
+    CARGO_TARGET_DIR="$explicit" \
+    HOMEBOY_COMPONENT_ID=fixture \
+    HOMEBOY_COMPONENT_PATH="$primary" \
+    "$EXTENSION_DIR/scripts/env-provider.sh"
+)"
+if [ "$explicit_output" != '{}' ]; then
+    printf 'Expected explicit CARGO_TARGET_DIR to suppress provider output, got %s\n' "$explicit_output" >&2
+    exit 1
+fi
+
+printf 'Rust env provider smoke passed\n'


### PR DESCRIPTION
## Summary
- Adds a Rust extension `env_provider` script that supplies shared Cargo target env for Homeboy-managed Rust runs.
- Preserves explicit `CARGO_TARGET_DIR` by emitting no provider env when the user already set it.
- Adds a smoke test for primary/worktree remote normalization and explicit target-dir handling.

## Tests
- `rust/tests/env-provider-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the env-provider script, smoke test, and manifest wiring; Chris remains responsible for review and validation.