### PR TITLE
Omit incomplete wp-gym replay projections

### DIFF
--- a/wordpress/scripts/agent/build-replay-bundle-smoke.sh
+++ b/wordpress/scripts/agent/build-replay-bundle-smoke.sh
@@ -231,4 +231,46 @@ if [ "$wp_gym_projection" != "navigation-menu-001 navigation wp-admin-tasks cand
 	exit 1
 fi
 
+jq -n '{
+	scenarios: [
+		{
+			id: "agent-wp-gym-partial",
+			name: "Partial wp-gym projection",
+			metadata: {
+				eval_artifact: {
+					run: { job_status: "completed", success_status: "no_changes" },
+					grade: {}
+				},
+				fingerprints: { prompt: { sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } }
+			}
+		}
+	]
+}' > "$RESULTS_TMPFILE"
+
+jq -n '{
+	component_id: "example-plugin",
+	workload_id: "agent-wp-gym-partial",
+	provider: "openai",
+	model: "gpt-example",
+	wp_gym_eval: {
+		status: { outcome: "completed" },
+		grader: { grade: {}, checks: [] }
+	}
+}' > "$CONFIG_TMPFILE"
+
+node "$SCRIPT_DIR/build-replay-bundle.js" \
+	--results "$RESULTS_TMPFILE" \
+	--scenario agent-wp-gym-partial \
+	--config "$CONFIG_TMPFILE" \
+	--output-dir "$BUNDLE_DIR" >/dev/null
+
+PARTIAL_WPGYM_BUNDLE_PATH="$BUNDLE_DIR/agent-wp-gym-partial-replay-bundle.json"
+partial_status_has_outcome=$(jq -r '(.sealed_eval_artifact.wp_gym.status // {}) | has("outcome")' "$PARTIAL_WPGYM_BUNDLE_PATH")
+partial_grade_has_score=$(jq -r '(.sealed_eval_artifact.wp_gym.grader.grade // {}) | has("score")' "$PARTIAL_WPGYM_BUNDLE_PATH")
+if [ "$partial_status_has_outcome" != "false" ] || [ "$partial_grade_has_score" != "false" ]; then
+	echo "ERROR: partial wp-gym status or grade should not be projected" >&2
+	cat "$PARTIAL_WPGYM_BUNDLE_PATH" >&2
+	exit 1
+fi
+
 echo "✓ replay bundle smoke test PASSED"

--- a/wordpress/scripts/agent/build-replay-bundle.js
+++ b/wordpress/scripts/agent/build-replay-bundle.js
@@ -273,6 +273,40 @@ function firstDefined(...values) {
 	return values.find((value) => value !== undefined && value !== null && value !== '');
 }
 
+function canonicalGrade(value) {
+	if (!value || typeof value !== 'object' || Array.isArray(value) || typeof value.score !== 'number') {
+		return undefined;
+	}
+	return value;
+}
+
+function canonicalStatus(statusConfig, metadata, success) {
+	const allowedOutcomes = new Set(['passed', 'failed', 'errored']);
+	const allowedFailureClasses = new Set(['none', 'runtime_failure', 'agent_failure', 'grader_failure', 'task_failure']);
+	const configuredOutcome = firstDefined(statusConfig.outcome, metadata.status?.outcome);
+	const configuredFailureClass = firstDefined(statusConfig.failure_class, metadata.failure_class, metadata.status?.failure_class);
+	let outcome;
+	let failureClass;
+
+	if (allowedOutcomes.has(configuredOutcome)) {
+		outcome = configuredOutcome;
+	} else if (success === true) {
+		outcome = 'passed';
+	} else if (success === false) {
+		outcome = 'failed';
+	}
+
+	if (allowedFailureClasses.has(configuredFailureClass)) {
+		failureClass = configuredFailureClass;
+	} else if (success === true) {
+		failureClass = 'none';
+	} else if (success === false) {
+		failureClass = 'task_failure';
+	}
+
+	return outcome && failureClass ? { outcome, failure_class: failureClass } : undefined;
+}
+
 function buildWpGymProjection(scenario, config, metadata, evalArtifact) {
 	const configEval = objectValue(config.wp_gym_eval);
 	const metadataEval = objectValue(metadata.wp_gym_eval);
@@ -287,11 +321,11 @@ function buildWpGymProjection(scenario, config, metadata, evalArtifact) {
 	const statusConfig = firstObject(metadataEval.status, configEval.status, manifest.wp_gym?.status);
 	const fingerprints = objectValue(metadata.fingerprints);
 	const evalHashes = objectValue(evalArtifact.hashes);
-	const grade = firstObject(graderConfig.grade, evalArtifact.grade, metadata.grade);
-	const reward = firstDefined(graderConfig.reward, metadata.reward, metadata.score, grade.reward, grade.score);
+	const grade = canonicalGrade(firstObject(graderConfig.grade, evalArtifact.grade, metadata.grade));
+	const reward = firstDefined(graderConfig.reward, metadata.reward, metadata.score, grade?.reward, grade?.score);
 	const failureReasons = firstDefined(graderConfig.failure_reasons, evalArtifact.failure_reasons, metadata.failure_reasons, []);
-	const success = firstDefined(graderConfig.success, metadata.success, metadata.success_status === 'success' ? true : undefined, grade.score !== undefined && grade.max_score !== undefined ? grade.score >= grade.max_score : undefined);
-	const outcome = firstDefined(statusConfig.outcome, success === true ? 'passed' : undefined, success === false ? 'failed' : undefined, metadata.completion_outcome, metadata.job_status, evalArtifact.run?.job_status);
+	const success = firstDefined(graderConfig.success, metadata.success, metadata.success_status === 'success' ? true : undefined, grade?.score !== undefined && grade?.max_score !== undefined ? grade.score >= grade.max_score : undefined);
+	const status = canonicalStatus(statusConfig, metadata, success);
 	const taskFamily = firstDefined(scenarioConfig.task_family, metadataEval.task_family, configEval.task_family, metadata.task_family, config.task_family, manifest.task_family);
 
 	return compactObject({
@@ -320,10 +354,7 @@ function buildWpGymProjection(scenario, config, metadata, evalArtifact) {
 			failure_reasons: Array.isArray(failureReasons) ? failureReasons : [],
 			checks: firstDefined(graderConfig.checks, metadata.grader_checks, metadata.checks, []),
 		}),
-		status: compactObject({
-			outcome,
-			failure_class: firstDefined(statusConfig.failure_class, metadata.failure_class, success === false ? 'grader' : undefined, success === true ? 'none' : undefined),
-		}),
+		status,
 	});
 }
 


### PR DESCRIPTION
## Summary
- Emit wp-gym replay status only when it has a canonical outcome and failure class.
- Emit wp-gym grade only when it includes a numeric score, allowing downstream wp-gym projection to derive fallback values from termination metadata.
- Add replay-bundle smoke coverage for partial `completed`/empty-grade projection data.

Fixes Extra-Chill/homeboy-extensions#857.

## Verification
- `bash wordpress/scripts/agent/build-replay-bundle-smoke.sh`
- `npm run test:validate-wpgym-eval-row`
- `npm run test:project-wpgym-eval-row`
- `npm run lint:js -- --quiet scripts/agent/build-replay-bundle.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause analysis, patch drafting, local validation, and PR description drafting; Chris remains responsible for review and merge.