### PR TITLE
Preserve WP Codebox fanout failure evidence

### DIFF
--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -132,6 +132,100 @@ function fanoutRecordMetrics(startedAt, finishedAt, parsed, artifact) {
   };
 }
 
+function artifactsRootFromArgs(args = []) {
+  const index = args.indexOf('--artifacts');
+  if (index >= 0 && args[index + 1]) {
+    return args[index + 1];
+  }
+  return '';
+}
+
+function discoverTaskArtifacts(args, taskRequest, startedAt, finishedAt) {
+  const root = artifactsRootFromArgs(args);
+  if (!root || !fs.existsSync(root)) {
+    return [];
+  }
+
+  const startedMs = Date.parse(startedAt);
+  const finishedMs = Date.parse(finishedAt);
+  const earliestMs = Number.isFinite(startedMs) ? startedMs - 1000 : 0;
+  const latestMs = Number.isFinite(finishedMs) ? finishedMs + 1000 : Date.now() + 1000;
+
+  const artifacts = fs.readdirSync(root)
+    .map((entry) => artifactEvidence(path.join(root, entry), earliestMs, latestMs))
+    .filter(Boolean)
+    .sort((left, right) => left.directory.localeCompare(right.directory));
+  const sessionArtifacts = artifacts.filter((artifact) => artifact.directory.includes(taskRequest.sandbox_session_id));
+  return sessionArtifacts.length > 0 ? sessionArtifacts : artifacts;
+}
+
+function artifactEvidence(directory, earliestMs, latestMs) {
+  try {
+    const stat = fs.statSync(directory);
+    if (!stat.isDirectory() || stat.mtimeMs < earliestMs || stat.mtimeMs > latestMs) {
+      return null;
+    }
+    const changedFilesPath = path.join(directory, 'files', 'changed-files.json');
+    const manifestPath = path.join(directory, 'manifest.json');
+    const runtimeManifestPath = path.join(directory, 'files', 'runtime-reference-manifest.json');
+    return {
+      directory,
+      bytes: directorySizeBytes(directory),
+      mtime: stat.mtime.toISOString(),
+      has_manifest: fs.existsSync(manifestPath),
+      has_changed_files: fs.existsSync(changedFilesPath),
+      changed_files_path: fs.existsSync(changedFilesPath) ? changedFilesPath : '',
+      runtime_reference_manifest: runtimeManifestPath && fs.existsSync(runtimeManifestPath)
+        ? wpCodeboxRuntimeReferenceManifest({ artifacts: { runtimeReferenceManifestPath: runtimeManifestPath } }, {})
+        : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function failureMessageFromCommand(command) {
+  if (command.error) {
+    return command.error;
+  }
+  if (command.timed_out) {
+    return `WP Codebox task timed out after ${command.timeout_seconds} seconds`;
+  }
+  if (command.signal) {
+    return `WP Codebox task exited from signal ${command.signal}`;
+  }
+  if (command.exit_code !== 0 && command.exit_code !== null && command.exit_code !== undefined) {
+    return `WP Codebox task exited with code ${command.exit_code}`;
+  }
+  return 'WP Codebox task failed without a structured outcome';
+}
+
+function enrichFailureOutcome(outcome, taskRequest, command, startedAt, finishedAt, partialArtifacts = []) {
+  if (taskOutcomeSucceeded(outcome)) {
+    return outcome;
+  }
+  const elapsedMs = Math.max(0, Date.parse(finishedAt) - Date.parse(startedAt));
+  const failureMetadata = {
+    group_key: taskRequest.group_key,
+    sandbox_session_id: taskRequest.sandbox_session_id,
+    finding_ids: taskRequest.audit_findings.map((finding) => finding.id),
+    exit_code: command.exit_code ?? null,
+    signal: command.signal || null,
+    elapsed_ms: Number.isFinite(elapsedMs) ? elapsedMs : null,
+    timed_out: Boolean(command.timed_out),
+    timeout_seconds: command.timeout_seconds ?? null,
+    killed_process_group: Boolean(command.killed_process_group),
+    force_killed_process_group: Boolean(command.force_killed_process_group),
+    partial_artifact_count: partialArtifacts.length,
+  };
+  return {
+    ...outcome,
+    failure: outcome.failure || failureMessageFromCommand(command),
+    failure_metadata: failureMetadata,
+    partial_artifacts: partialArtifacts,
+  };
+}
+
 function numberOrNull(value) {
   return Number.isFinite(Number(value)) ? Number(value) : null;
 }
@@ -524,7 +618,22 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
   const metrics = fanoutRecordMetrics(startedAt, finishedAt, parsed, artifact);
   const taskFailure = parsed ? wpCodeboxTaskFailure(parsed) : null;
   const commandSuccess = result.status === 0 && result.error === undefined && null === taskFailure;
-  const outcome = taskOutcome(taskRequest, parsed, artifact, commandSuccess, taskFailure || (result.error ? result.error.message : ''));
+  const commandInfo = {
+    bin: command,
+    args,
+    exit_code: result.status,
+    signal: result.signal || null,
+    error: result.error ? result.error.message : (taskFailure || ''),
+  };
+  const partialArtifacts = commandSuccess ? [] : discoverTaskArtifacts(args, taskRequest, startedAt, finishedAt);
+  const outcome = enrichFailureOutcome(
+    taskOutcome(taskRequest, parsed, artifact, commandSuccess, taskFailure || (result.error ? result.error.message : '')),
+    taskRequest,
+    commandInfo,
+    startedAt,
+    finishedAt,
+    partialArtifacts
+  );
   const success = taskOutcomeSucceeded(outcome);
 
   return {
@@ -533,13 +642,7 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
     group_key: taskRequest.group_key,
     finding_id: taskRequest.finding_id || taskRequest.audit_findings[0]?.id || '',
     finding_ids: taskRequest.audit_findings.map((finding) => finding.id),
-    command: {
-      bin: command,
-      args,
-      exit_code: result.status,
-      signal: result.signal || null,
-      error: result.error ? result.error.message : (taskFailure || ''),
-    },
+    command: commandInfo,
     status: success ? 'completed' : 'failed',
     started_at: startedAt,
     finished_at: finishedAt,
@@ -553,6 +656,7 @@ function executeWpCodeboxTaskRequest(taskRequest, options = {}) {
       preview_url: artifact.preview?.url || artifact.preview_url || '',
       runtime_reference_manifest: wpCodeboxRuntimeReferenceManifest(parsed, artifact),
     } : null,
+    partial_artifacts: partialArtifacts,
     metrics,
   };
 }
@@ -631,7 +735,26 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
       const timeoutError = timedOut ? `WP Codebox task timed out after ${taskTimeoutSeconds} seconds` : '';
       const errorMessage = timeoutError || (spawnError ? spawnError.message : (taskFailure || ''));
       const commandSuccess = code === 0 && !spawnError && null === taskFailure && !timedOut;
-      const outcome = taskOutcome(taskRequest, parsed, artifact, commandSuccess, errorMessage, timedOut);
+      const commandInfo = {
+        bin: command,
+        args,
+        exit_code: code,
+        signal: signal || null,
+        error: errorMessage,
+        timed_out: timedOut,
+        timeout_seconds: taskTimeoutSeconds,
+        killed_process_group: killedProcessGroup,
+        force_killed_process_group: forceKilledProcessGroup,
+      };
+      const partialArtifacts = commandSuccess ? [] : discoverTaskArtifacts(args, taskRequest, startedAt, finishedAt);
+      const outcome = enrichFailureOutcome(
+        taskOutcome(taskRequest, parsed, artifact, commandSuccess, errorMessage, timedOut),
+        taskRequest,
+        commandInfo,
+        startedAt,
+        finishedAt,
+        partialArtifacts
+      );
       const success = taskOutcomeSucceeded(outcome);
 
       resolve({
@@ -640,17 +763,7 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
         group_key: taskRequest.group_key,
         finding_id: taskRequest.finding_id || taskRequest.audit_findings[0]?.id || '',
         finding_ids: taskRequest.audit_findings.map((finding) => finding.id),
-        command: {
-          bin: command,
-          args,
-          exit_code: code,
-          signal: signal || null,
-          error: errorMessage,
-          timed_out: timedOut,
-          timeout_seconds: taskTimeoutSeconds,
-          killed_process_group: killedProcessGroup,
-          force_killed_process_group: forceKilledProcessGroup,
-        },
+        command: commandInfo,
         status: success ? 'completed' : 'failed',
         started_at: startedAt,
         finished_at: finishedAt,
@@ -664,6 +777,7 @@ function executeWpCodeboxTaskRequestAsync(taskRequest, options = {}) {
           preview_url: artifact.preview?.url || artifact.preview_url || '',
           runtime_reference_manifest: wpCodeboxRuntimeReferenceManifest(parsed, artifact),
         } : null,
+        partial_artifacts: partialArtifacts,
         metrics,
       });
     });

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -135,7 +135,27 @@ process.stdin.setEncoding('utf8');
 process.stdin.on('data', (chunk) => { input += chunk; });
 process.stdin.on('end', () => {
   const request = JSON.parse(input);
+  const artifactsIndex = process.argv.indexOf('--artifacts');
+  const artifactsRoot = artifactsIndex >= 0 ? process.argv[artifactsIndex + 1] : '';
+  function writePartialArtifact() {
+    if (!artifactsRoot) {
+      return '';
+    }
+    const artifactDirectory = path.join(artifactsRoot, 'partial-' + request.sandbox_session_id);
+    const filesDirectory = path.join(artifactDirectory, 'files');
+    fs.mkdirSync(filesDirectory, { recursive: true });
+    fs.writeFileSync(path.join(filesDirectory, 'changed-files.json'), JSON.stringify({
+      schema: 'wp-codebox/changed-files/v1',
+      files: [{ path: '/workspace/homeboy-extensions/partial.php', relativePath: 'partial.php', status: 'modified' }],
+    }, null, 2) + '\\n');
+    fs.writeFileSync(path.join(filesDirectory, 'runtime-reference-manifest.json'), JSON.stringify({
+      schema: 'wp-codebox/runtime-reference-manifest-fixture/v1',
+      cookie: 'partial-cookie-secret',
+    }, null, 2) + '\\n');
+    return artifactDirectory;
+  }
   if (process.env.FIXTURE_HANG_GROUP === request.group_key) {
+    writePartialArtifact();
     process.stdout.write('fixture partial stdout before timeout\\n');
     process.stderr.write('fixture partial stderr before timeout\\n');
     setInterval(() => {}, 1000);
@@ -631,10 +651,11 @@ try {
   assert.equal(noopRecord.metrics.artifact_bytes, null);
 
   const timeoutRunsOutputPath = path.join(root, 'fanout-timeout-run.json');
+  const timeoutArtifactsRoot = path.join(root, 'timeout-artifacts');
   const timeoutExecution = await executeAuditWpCodeboxFanout({
     report,
     wp_codebox_command: process.execPath,
-    wp_codebox_args: [fixtureCommand],
+    wp_codebox_args: [fixtureCommand, '--artifacts', timeoutArtifactsRoot],
     concurrency: 1,
     task_timeout_seconds: 1,
     runsOutputPath: timeoutRunsOutputPath,
@@ -649,6 +670,16 @@ try {
   assert.equal(timeoutRecord.command.killed_process_group, true);
   assert.match(timeoutRecord.command.error, /timed out after 1 seconds/);
   assert.equal(timeoutRecord.outcome.kind, 'timeout');
+  assert.equal(timeoutRecord.outcome.failure_metadata.group_key, 'PHPCS Formatting/Auto Fix!');
+  assert.equal(timeoutRecord.outcome.failure_metadata.sandbox_session_id, timeoutRecord.sandbox_session_id);
+  assert.equal(timeoutRecord.outcome.failure_metadata.timed_out, true);
+  assert.equal(timeoutRecord.outcome.failure_metadata.timeout_seconds, 1);
+  assert.equal(timeoutRecord.outcome.failure_metadata.partial_artifact_count, 1);
+  assert.equal(timeoutRecord.partial_artifacts.length, 1);
+  assert.equal(timeoutRecord.partial_artifacts[0].has_changed_files, true);
+  assert.equal(timeoutRecord.partial_artifacts[0].runtime_reference_manifest.available, true);
+  assert.equal(timeoutRecord.partial_artifacts[0].runtime_reference_manifest.payload.cookie, '[redacted]');
+  assert.equal(timeoutRecord.outcome.partial_artifacts[0].directory, timeoutRecord.partial_artifacts[0].directory);
   assert.match(timeoutRecord.stdout, /fixture partial stdout before timeout/);
   assert.match(timeoutRecord.stderr, /fixture partial stderr before timeout/);
   assertMetrics(timeoutRecord);
@@ -657,6 +688,9 @@ try {
   const timeoutFollowupRecord = timeoutExecution.records.find((record) => record.group_key === 'docs-reference');
   assert.equal(timeoutFollowupRecord.status, 'failed');
   assert.equal(timeoutFollowupRecord.command.exit_code, 3);
+  assert.equal(timeoutFollowupRecord.outcome.failure, 'WP Codebox task exited with code 3');
+  assert.equal(timeoutFollowupRecord.outcome.failure_metadata.exit_code, 3);
+  assert.equal(timeoutFollowupRecord.outcome.failure_metadata.group_key, 'docs-reference');
   const timeoutFinalRun = readJson(timeoutRunsOutputPath);
   assert.equal(timeoutFinalRun.status, 'failed');
   assert.equal(timeoutFinalRun.records.length, 2);

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -68,11 +68,29 @@ const recipeIndex = process.argv.indexOf('--recipe');
 if (process.argv[2] !== 'recipe-run' || recipeIndex < 0) {
   process.exit(2);
 }
+const artifactsIndex = process.argv.indexOf('--artifacts');
+const artifactsRoot = artifactsIndex >= 0 ? process.argv[artifactsIndex + 1] : '';
 const recipe = JSON.parse(fs.readFileSync(process.argv[recipeIndex + 1], 'utf8'));
 const stepArgs = recipe.workflow.steps[0].args;
 const task = JSON.parse(stepArgs.find((arg) => arg.startsWith('task=')).slice('task='.length));
 const sessionId = task.sandbox_session_id;
 if (process.env.FIXTURE_HANG_GROUP === task.group_key) {
+  if (artifactsRoot) {
+    const partialDirectory = path.join(artifactsRoot, 'partial-' + sessionId);
+    const filesDirectory = path.join(partialDirectory, 'files');
+    fs.mkdirSync(filesDirectory, { recursive: true });
+    fs.writeFileSync(path.join(filesDirectory, 'changed-files.json'), JSON.stringify({
+      schema: 'wp-codebox/changed-files/v1',
+      files: [
+        {
+          path: '/workspace/homeboy-extensions/wordpress/docs/partial.md',
+          status: 'modified',
+          mountTarget: '/workspace/homeboy-extensions',
+          relativePath: 'wordpress/docs/partial.md'
+        }
+      ]
+    }, null, 2) + '\\n');
+  }
   process.stderr.write('fixture task hung before producing an artifact\\n');
   setInterval(() => {}, 1000);
   return;
@@ -258,6 +276,11 @@ process.stdout.write(JSON.stringify({
   assert.match(partialFailureResponse.warnings.join('\n'), /WP Codebox task timed out after 1 seconds/);
   const partialRun = JSON.parse(fs.readFileSync(path.join(root, 'fanout-partial-failure', 'fanout-run.json'), 'utf8'));
   assert.equal(partialRun.status, 'failed');
+  const partialFailedRecord = partialRun.records.find((record) => record.group_key === 'docs-reference');
+  assert.equal(partialFailedRecord.outcome.failure_metadata.group_key, 'docs-reference');
+  assert.equal(partialFailedRecord.outcome.failure_metadata.timed_out, true);
+  assert.equal(partialFailedRecord.partial_artifacts.length, 1);
+  assert.equal(partialFailedRecord.partial_artifacts[0].has_changed_files, true);
 
   const missingSecretResult = spawnSync('python3', [path.join(__dirname, '..', 'scripts', 'refactor.py')], {
     encoding: 'utf8',


### PR DESCRIPTION
## Summary
- Preserve signal/timeout/exit metadata for failed WP Codebox fanout tasks.
- Attach partial artifact evidence when available so interrupted tasks remain diagnosable.
- Keep valid completed artifacts visible when sibling fanout tasks fail.

## Tests
- `npm run test:audit-wp-codebox-fanout`
- `npm run test:refactor-source-wp-codebox`
- `npm run test:wp-codebox-task-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the fanout evidence handling and targeted smoke coverage; Chris directed the remediation target and validation flow.