### PR TITLE
Fix agent WP-CLI runtime execution

### DIFF
--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -133,10 +133,11 @@ The runner converts the agent config into a single WP Codebox sandbox run:
 - `enable_terminal_actions` exposes host-side terminal actions through the
   WordPress extension's `agent-terminal-actions` helper for runner-owned tools
   that must execute like a real shell command. The default `run_wp_cli` tool runs
-  a `wp_cli` action as `wp ...` through `bash -lc` with the runtime root as the
-  command boundary and returns exit code, stdout, and stderr. Use
-  `wp_cli_tool_name` only when a consumer needs a different agent-facing tool
-  name.
+  through `WP_CLI::runcommand()` when WP-CLI is available in the active
+  WordPress runtime. It falls back to a `wp_cli` terminal action as `wp ...`
+  through `bash -lc` with the runtime root as the command boundary and returns
+  exit code, stdout, and stderr. Use `wp_cli_tool_name` only when a consumer
+  needs a different agent-facing tool name.
 - `pipeline_step_patches` and `flow_step_patches` can adjust imported bundle
   step configuration before execution.
 - `fallback_pull_request` can open a PR when files were written but the agent did

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1888,7 +1888,71 @@ if ( ! class_exists( 'Homeboy_Datamachine_Agent_Tool_Recorder' ) ) {
 
 if ( ! class_exists( 'Homeboy_Datamachine_Agent_Terminal_Tool' ) ) {
     class Homeboy_Datamachine_Agent_Terminal_Tool {
+        private function normalize_wp_cli_command( string $command ): string {
+            $command = trim( $command );
+            return str_starts_with( $command, 'wp ' ) ? $command : 'wp ' . $command;
+        }
+
+        private function run_runtime_wp_cli_command( string $command ): array {
+            $normalized_command = $this->normalize_wp_cli_command( $command );
+            $wp_cli_command     = trim( preg_replace( '/^wp\s+/', '', $normalized_command ) );
+
+            ob_start();
+            $started = microtime( true );
+            $result  = WP_CLI::runcommand(
+                $wp_cli_command,
+                array(
+                    'return'     => true,
+                    'parse'      => 'shell',
+                    'launch'     => false,
+                    'exit_error' => false,
+                )
+            );
+            $stdout  = (string) ob_get_clean();
+            $success = false !== $result && ! is_wp_error( $result );
+            $stderr  = '';
+
+            if ( is_wp_error( $result ) ) {
+                $stderr = $result->get_error_message();
+            } elseif ( is_string( $result ) && '' !== $result ) {
+                $stdout .= $result;
+                if ( ! str_ends_with( $stdout, "\n" ) ) {
+                    $stdout .= "\n";
+                }
+            }
+
+            return array(
+                'type'       => 'wp_cli',
+                'command'    => $normalized_command,
+                'exitCode'   => $success ? 0 : 1,
+                'stdout'     => $stdout,
+                'stderr'     => $stderr,
+                'success'    => $success,
+                'timedOut'   => false,
+                'durationMs' => (int) round( ( microtime( true ) - $started ) * 1000 ),
+                'error'      => $success ? '' : ( '' !== $stderr ? $stderr : 'WP-CLI command failed' ),
+            );
+        }
+
         public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+            $type = (string) ( $tool_def['terminal_action_type'] ?? 'wp_cli' );
+
+            $command = trim( (string) ( $parameters['command'] ?? '' ) );
+            if ( '' === $command ) {
+                return array(
+                    'success'   => false,
+                    'tool_name' => (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' ),
+                    'error'     => 'command is required.',
+                );
+            }
+
+            if ( 'wp_cli' === $type && class_exists( 'WP_CLI' ) && method_exists( 'WP_CLI', 'runcommand' ) ) {
+                $result              = $this->run_runtime_wp_cli_command( $command );
+                $result['tool_name'] = (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' );
+                $result['status']    = 200;
+                return $result;
+            }
+
             $url   = rtrim( (string) ( $tool_def['terminal_action_url'] ?? getenv( 'HOMEBOY_TERMINAL_ACTION_URL' ) ), '/' );
             $token = (string) ( $tool_def['terminal_action_token'] ?? getenv( 'HOMEBOY_TERMINAL_ACTION_TOKEN' ) );
 
@@ -1900,18 +1964,9 @@ if ( ! class_exists( 'Homeboy_Datamachine_Agent_Terminal_Tool' ) ) {
                 );
             }
 
-            $command = trim( (string) ( $parameters['command'] ?? '' ) );
-            if ( '' === $command ) {
-                return array(
-                    'success'   => false,
-                    'tool_name' => (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' ),
-                    'error'     => 'command is required.',
-                );
-            }
-
             $action = array_filter(
                 array(
-                    'type'       => (string) ( $tool_def['terminal_action_type'] ?? 'wp_cli' ),
+                    'type'       => $type,
                     'command'    => $command,
                     'timeout_ms' => isset( $parameters['timeout_ms'] ) ? (int) $parameters['timeout_ms'] : null,
                     'cwd'        => isset( $parameters['cwd'] ) ? (string) $parameters['cwd'] : null,

--- a/wordpress/tests/datamachine-terminal-tool-smoke.php
+++ b/wordpress/tests/datamachine-terminal-tool-smoke.php
@@ -141,6 +141,33 @@ try {
 		exit(1);
 	}
 
+	class WP_CLI {
+		public static array $commands = array();
+
+		public static function runcommand($command, $options = array()) {
+			self::$commands[] = array($command, $options);
+			return 'runtime-wp:' . $command;
+		}
+	}
+
+	$runtime_result = $tool->handle_tool_call(
+		array('command' => 'wp plugin list --format=table'),
+		array(
+			'tool_name'            => 'run_wp_cli',
+			'terminal_action_type' => 'wp_cli',
+		)
+	);
+
+	if (empty($runtime_result['success']) || 'wp plugin list --format=table' !== ($runtime_result['command'] ?? '') || ! str_contains((string) ($runtime_result['stdout'] ?? ''), 'runtime-wp:plugin list --format=table')) {
+		fwrite(STDERR, "Unexpected runtime WP-CLI result:\n" . json_encode($runtime_result, JSON_PRETTY_PRINT) . "\n");
+		exit(1);
+	}
+
+	if ('plugin list --format=table' !== (WP_CLI::$commands[0][0] ?? '') || true !== (WP_CLI::$commands[0][1]['return'] ?? null) || false !== (WP_CLI::$commands[0][1]['launch'] ?? null)) {
+		fwrite(STDERR, "Unexpected WP_CLI::runcommand call:\n" . json_encode(WP_CLI::$commands, JSON_PRETTY_PRINT) . "\n");
+		exit(1);
+	}
+
 	fwrite(STDOUT, "Data Machine terminal tool smoke passed.\n");
 } finally {
 	if ($pid > 0) {


### PR DESCRIPTION
## Summary
- Run the `run_wp_cli` Data Machine agent tool through in-process `WP_CLI::runcommand()` when WP-CLI is available in the active WordPress runtime.
- Keep the existing host terminal action server as a fallback for non-runtime terminal dispatches.
- Extend the terminal tool smoke to cover the runtime WP-CLI path and update the WP Codebox agent CI docs.

Fixes #860.

## Testing
- `node tests/agent-terminal-actions-smoke.js`
- `node tests/terminal-action-server-smoke.js`
- `php tests/datamachine-terminal-tool-smoke.php`
- `npm run test:datamachine-agent-wp-codebox-runner`
- `php -l scripts/agent/datamachine-agent-workload.php && php -l tests/datamachine-terminal-tool-smoke.php`
- `git diff --check`

## Notes
- `npm run lint:js -- --quiet lib/agent-terminal-actions.js scripts/agent/terminal-action-server.js tests/agent-terminal-actions-smoke.js tests/terminal-action-server-smoke.js` could not run in this worktree because `eslint` is not installed (`sh: eslint: command not found`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the runner/runtime boundary, drafting the runtime WP-CLI fix, and running targeted validation. Chris remains responsible for review and merge.