### PR TITLE
Keep agent wp eval inside runtime

### DIFF
--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -134,10 +134,12 @@ The runner converts the agent config into a single WP Codebox sandbox run:
   WordPress extension's `agent-terminal-actions` helper for runner-owned tools
   that must execute like a real shell command. The default `run_wp_cli` tool runs
   through `WP_CLI::runcommand()` when WP-CLI is available in the active
-  WordPress runtime. It falls back to a `wp_cli` terminal action as `wp ...`
-  through `bash -lc` with the runtime root as the command boundary and returns
-  exit code, stdout, and stderr. Use `wp_cli_tool_name` only when a consumer
-  needs a different agent-facing tool name.
+  WordPress runtime. When the runtime has WordPress loaded but no `WP_CLI`
+  class, `wp eval ...` runs directly in that runtime. Other WP-CLI commands fall
+  back to a `wp_cli` terminal action as `wp ...` through `bash -lc` with the
+  runtime root as the command boundary and return exit code, stdout, and stderr.
+  Use `wp_cli_tool_name` only when a consumer needs a different agent-facing tool
+  name.
 - `pipeline_step_patches` and `flow_step_patches` can adjust imported bundle
   step configuration before execution.
 - `fallback_pull_request` can open a PR when files were written but the agent did

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1934,6 +1934,52 @@ if ( ! class_exists( 'Homeboy_Datamachine_Agent_Terminal_Tool' ) ) {
             );
         }
 
+        private function runtime_wp_cli_eval_code( string $command ): ?string {
+            $wp_cli_command = trim( preg_replace( '/^wp\s+/', '', $this->normalize_wp_cli_command( $command ) ) );
+            if ( ! str_starts_with( $wp_cli_command, 'eval ' ) ) {
+                return null;
+            }
+
+            $code = trim( substr( $wp_cli_command, 5 ) );
+            if ( strlen( $code ) >= 2 ) {
+                $quote = $code[0];
+                if ( ( "'" === $quote || '"' === $quote ) && str_ends_with( $code, $quote ) ) {
+                    $code = substr( $code, 1, -1 );
+                }
+            }
+
+            return $code;
+        }
+
+        private function run_runtime_wp_cli_eval_command( string $command ): array {
+            $normalized_command = $this->normalize_wp_cli_command( $command );
+            $code               = $this->runtime_wp_cli_eval_code( $command );
+            $started            = microtime( true );
+            $success            = true;
+            $stderr             = '';
+
+            ob_start();
+            try {
+                eval( (string) $code );
+            } catch ( Throwable $throwable ) {
+                $success = false;
+                $stderr  = $throwable->getMessage();
+            }
+            $stdout = (string) ob_get_clean();
+
+            return array(
+                'type'       => 'wp_cli',
+                'command'    => $normalized_command,
+                'exitCode'   => $success ? 0 : 1,
+                'stdout'     => $stdout,
+                'stderr'     => $stderr,
+                'success'    => $success,
+                'timedOut'   => false,
+                'durationMs' => (int) round( ( microtime( true ) - $started ) * 1000 ),
+                'error'      => $success ? '' : ( '' !== $stderr ? $stderr : 'WP-CLI eval command failed' ),
+            );
+        }
+
         public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
             $type = (string) ( $tool_def['terminal_action_type'] ?? 'wp_cli' );
 
@@ -1948,6 +1994,13 @@ if ( ! class_exists( 'Homeboy_Datamachine_Agent_Terminal_Tool' ) ) {
 
             if ( 'wp_cli' === $type && class_exists( 'WP_CLI' ) && method_exists( 'WP_CLI', 'runcommand' ) ) {
                 $result              = $this->run_runtime_wp_cli_command( $command );
+                $result['tool_name'] = (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' );
+                $result['status']    = 200;
+                return $result;
+            }
+
+            if ( 'wp_cli' === $type && null !== $this->runtime_wp_cli_eval_code( $command ) ) {
+                $result              = $this->run_runtime_wp_cli_eval_command( $command );
                 $result['tool_name'] = (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' );
                 $result['status']    = 200;
                 return $result;

--- a/wordpress/tests/datamachine-terminal-tool-smoke.php
+++ b/wordpress/tests/datamachine-terminal-tool-smoke.php
@@ -141,6 +141,19 @@ try {
 		exit(1);
 	}
 
+	$eval_result = $tool->handle_tool_call(
+		array('command' => 'eval \' $GLOBALS["homeboy_eval_smoke"] = "ok"; \''),
+		array(
+			'tool_name'            => 'run_wp_cli',
+			'terminal_action_type' => 'wp_cli',
+		)
+	);
+
+	if (empty($eval_result['success']) || 'ok' !== ($GLOBALS['homeboy_eval_smoke'] ?? null)) {
+		fwrite(STDERR, "Unexpected runtime WP-CLI eval result:\n" . json_encode($eval_result, JSON_PRETTY_PRINT) . "\n");
+		exit(1);
+	}
+
 	class WP_CLI {
 		public static array $commands = array();
 


### PR DESCRIPTION
## Summary
- Add a `wp eval ...` runtime fallback for the Data Machine agent `run_wp_cli` tool when WordPress is loaded but the `WP_CLI` class is unavailable.
- Preserve the `WP_CLI::runcommand()` path added in #861 and keep host terminal execution as the fallback for non-eval commands.
- Cover the runtime eval path in the terminal tool smoke and document the execution order.

Fixes #860.

## Follow-up Evidence
- `wp-gym` proof after #861 still showed `bash: line 1: wp: command not found` for an agent-generated `wp eval ...` command in https://github.com/Automattic/wp-gym/actions/runs/26649975525.
- The failed path had WordPress loaded in the agent runtime but no `WP_CLI` class, so it fell through to the host terminal server.

## Testing
- `php tests/datamachine-terminal-tool-smoke.php`
- `php -l scripts/agent/datamachine-agent-workload.php && php -l tests/datamachine-terminal-tool-smoke.php`
- `npm run test:datamachine-agent-wp-codebox-runner`
- `node tests/agent-terminal-actions-smoke.js && node tests/terminal-action-server-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the failed proof artifact, drafting the runtime `wp eval` fallback, and running targeted validation. Chris remains responsible for review and merge.