### PR TITLE
Project agent plugin list inside runtime

### DIFF
--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -135,10 +135,11 @@ The runner converts the agent config into a single WP Codebox sandbox run:
   that must execute like a real shell command. The default `run_wp_cli` tool runs
   through `WP_CLI::runcommand()` when WP-CLI is available in the active
   WordPress runtime. When the runtime has WordPress loaded but no `WP_CLI`
-  class, `wp eval ...` runs directly in that runtime. Other WP-CLI commands fall
-  back to a `wp_cli` terminal action as `wp ...` through `bash -lc` with the
-  runtime root as the command boundary and return exit code, stdout, and stderr.
-  Use `wp_cli_tool_name` only when a consumer needs a different agent-facing tool
+  class, `wp eval ...` runs directly in that runtime and `wp plugin list` is
+  projected from WordPress plugin APIs. Other WP-CLI commands fall back to a
+  `wp_cli` terminal action as `wp ...` through `bash -lc` with the runtime root
+  as the command boundary and return exit code, stdout, and stderr. Use
+  `wp_cli_tool_name` only when a consumer needs a different agent-facing tool
   name.
 - `pipeline_step_patches` and `flow_step_patches` can adjust imported bundle
   step configuration before execution.

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1980,6 +1980,51 @@ if ( ! class_exists( 'Homeboy_Datamachine_Agent_Terminal_Tool' ) ) {
             );
         }
 
+        private function can_run_runtime_plugin_list( string $command ): bool {
+            $wp_cli_command = trim( preg_replace( '/^wp\s+/', '', $this->normalize_wp_cli_command( $command ) ) );
+            return 1 === preg_match( '/^plugin\s+list(?:\s|$)/', $wp_cli_command );
+        }
+
+        private function run_runtime_plugin_list_command( string $command ): array {
+            $normalized_command = $this->normalize_wp_cli_command( $command );
+            $started            = microtime( true );
+            $stderr             = '';
+            $stdout             = '';
+            $success            = true;
+
+            if ( ! function_exists( 'get_plugins' ) && defined( 'ABSPATH' ) ) {
+                require_once ABSPATH . 'wp-admin/includes/plugin.php';
+            }
+
+            if ( function_exists( 'get_plugins' ) ) {
+                $stdout = "name\tstatus\tupdate\tversion\n";
+                foreach ( get_plugins() as $plugin_file => $plugin_data ) {
+                    $status = function_exists( 'is_plugin_active' ) && is_plugin_active( $plugin_file ) ? 'active' : 'inactive';
+                    $stdout .= sprintf(
+                        "%s\t%s\tnone\t%s\n",
+                        dirname( $plugin_file ) === '.' ? basename( $plugin_file, '.php' ) : dirname( $plugin_file ),
+                        $status,
+                        (string) ( $plugin_data['Version'] ?? '' )
+                    );
+                }
+            } else {
+                $success = false;
+                $stderr  = 'WordPress plugin APIs are not available.';
+            }
+
+            return array(
+                'type'       => 'wp_cli',
+                'command'    => $normalized_command,
+                'exitCode'   => $success ? 0 : 1,
+                'stdout'     => $stdout,
+                'stderr'     => $stderr,
+                'success'    => $success,
+                'timedOut'   => false,
+                'durationMs' => (int) round( ( microtime( true ) - $started ) * 1000 ),
+                'error'      => $success ? '' : $stderr,
+            );
+        }
+
         public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
             $type = (string) ( $tool_def['terminal_action_type'] ?? 'wp_cli' );
 
@@ -2001,6 +2046,13 @@ if ( ! class_exists( 'Homeboy_Datamachine_Agent_Terminal_Tool' ) ) {
 
             if ( 'wp_cli' === $type && null !== $this->runtime_wp_cli_eval_code( $command ) ) {
                 $result              = $this->run_runtime_wp_cli_eval_command( $command );
+                $result['tool_name'] = (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' );
+                $result['status']    = 200;
+                return $result;
+            }
+
+            if ( 'wp_cli' === $type && $this->can_run_runtime_plugin_list( $command ) ) {
+                $result              = $this->run_runtime_plugin_list_command( $command );
                 $result['tool_name'] = (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' );
                 $result['status']    = 200;
                 return $result;

--- a/wordpress/tests/datamachine-terminal-tool-smoke.php
+++ b/wordpress/tests/datamachine-terminal-tool-smoke.php
@@ -154,6 +154,29 @@ try {
 		exit(1);
 	}
 
+	function get_plugins(): array {
+		return array(
+			'fixture-plugin/fixture-plugin.php' => array('Version' => '1.2.3'),
+		);
+	}
+
+	function is_plugin_active(string $plugin): bool {
+		return 'fixture-plugin/fixture-plugin.php' === $plugin;
+	}
+
+	$plugin_list_result = $tool->handle_tool_call(
+		array('command' => 'plugin list'),
+		array(
+			'tool_name'            => 'run_wp_cli',
+			'terminal_action_type' => 'wp_cli',
+		)
+	);
+
+	if (empty($plugin_list_result['success']) || ! str_contains((string) ($plugin_list_result['stdout'] ?? ''), "fixture-plugin\tactive\tnone\t1.2.3")) {
+		fwrite(STDERR, "Unexpected runtime plugin list result:\n" . json_encode($plugin_list_result, JSON_PRETTY_PRINT) . "\n");
+		exit(1);
+	}
+
 	class WP_CLI {
 		public static array $commands = array();
 


### PR DESCRIPTION
## Summary
- Add an in-runtime `wp plugin list` compatibility path for the Data Machine agent `run_wp_cli` tool when `WP_CLI` is unavailable.
- Preserve the existing priority order: real `WP_CLI::runcommand()`, runtime `wp eval`, runtime `wp plugin list`, then host terminal fallback for anything else.
- Extend terminal tool smoke coverage and docs for the plugin-list projection.

Fixes #860.

## Follow-up Evidence
- After #862, `wp eval ...` calls succeeded in https://github.com/Automattic/wp-gym/actions/runs/26650539520.
- The remaining `wp: command not found` failures were `plugin list` calls from the modern WordPress site-summary task.

## Testing
- `php tests/datamachine-terminal-tool-smoke.php`
- `php -l scripts/agent/datamachine-agent-workload.php && php -l tests/datamachine-terminal-tool-smoke.php`
- `npm run test:datamachine-agent-wp-codebox-runner`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the follow-up proof artifacts, drafting the runtime plugin-list projection, and running targeted validation. Chris remains responsible for review and merge.