### PR TITLE
Dispatch runtime WP-CLI compatibility commands

### DIFF
--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -135,12 +135,12 @@ The runner converts the agent config into a single WP Codebox sandbox run:
   that must execute like a real shell command. The default `run_wp_cli` tool runs
   through `WP_CLI::runcommand()` when WP-CLI is available in the active
   WordPress runtime. When the runtime has WordPress loaded but no `WP_CLI`
-  class, `wp eval ...` runs directly in that runtime and `wp plugin list` is
-  projected from WordPress plugin APIs. Other WP-CLI commands fall back to a
-  `wp_cli` terminal action as `wp ...` through `bash -lc` with the runtime root
-  as the command boundary and return exit code, stdout, and stderr. Use
-  `wp_cli_tool_name` only when a consumer needs a different agent-facing tool
-  name.
+  class, supported commands (`wp eval ...`, `wp plugin list`, `wp plugin
+  activate ...`, and `&&` chains of those commands) run against runtime
+  WordPress APIs. Other WP-CLI commands fall back to a `wp_cli` terminal action
+  as `wp ...` through `bash -lc` with the runtime root as the command boundary
+  and return exit code, stdout, and stderr. Use `wp_cli_tool_name` only when a
+  consumer needs a different agent-facing tool name.
 - `pipeline_step_patches` and `flow_step_patches` can adjust imported bundle
   step configuration before execution.
 - `fallback_pull_request` can open a PR when files were written but the agent did

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1980,9 +1980,33 @@ if ( ! class_exists( 'Homeboy_Datamachine_Agent_Terminal_Tool' ) ) {
             );
         }
 
-        private function can_run_runtime_plugin_list( string $command ): bool {
-            $wp_cli_command = trim( preg_replace( '/^wp\s+/', '', $this->normalize_wp_cli_command( $command ) ) );
-            return 1 === preg_match( '/^plugin\s+list(?:\s|$)/', $wp_cli_command );
+        private function runtime_wp_cli_command_parts( string $command ): array {
+            return array_values(
+                array_filter(
+                    array_map(
+                        static fn( string $part ): string => trim( preg_replace( '/^wp\s+/', '', trim( $part ) ) ),
+                        explode( '&&', $command )
+                    ),
+                    static fn( string $part ): bool => '' !== $part
+                )
+            );
+        }
+
+        private function can_run_runtime_wp_cli_compat_command( string $command ): bool {
+            $parts = $this->runtime_wp_cli_command_parts( $this->normalize_wp_cli_command( $command ) );
+            if ( empty( $parts ) ) {
+                return false;
+            }
+
+            foreach ( $parts as $part ) {
+                if ( str_starts_with( $part, 'eval ' ) || 1 === preg_match( '/^plugin\s+list(?:\s|$)/', $part ) || 1 === preg_match( '/^plugin\s+activate\s+\S+/', $part ) ) {
+                    continue;
+                }
+
+                return false;
+            }
+
+            return true;
         }
 
         private function run_runtime_plugin_list_command( string $command ): array {
@@ -2025,6 +2049,76 @@ if ( ! class_exists( 'Homeboy_Datamachine_Agent_Terminal_Tool' ) ) {
             );
         }
 
+        private function run_runtime_plugin_activate_part( string $part ): array {
+            if ( ! function_exists( 'activate_plugin' ) && defined( 'ABSPATH' ) ) {
+                require_once ABSPATH . 'wp-admin/includes/plugin.php';
+            }
+
+            if ( ! function_exists( 'activate_plugin' ) ) {
+                return array( false, '', 'WordPress plugin activation APIs are not available.' );
+            }
+
+            preg_match( '/^plugin\s+activate\s+(\S+)/', $part, $matches );
+            $plugin = (string) ( $matches[1] ?? '' );
+            if ( '' === $plugin ) {
+                return array( false, '', 'Plugin slug is required.' );
+            }
+
+            if ( ! str_ends_with( $plugin, '.php' ) ) {
+                $plugin = $plugin . '/' . $plugin . '.php';
+            }
+
+            $result = activate_plugin( $plugin, '', false, true );
+            if ( is_wp_error( $result ) ) {
+                return array( false, '', $result->get_error_message() );
+            }
+
+            return array( true, "Plugin '{$plugin}' activated.\n", '' );
+        }
+
+        private function run_runtime_wp_cli_compat_command( string $command ): array {
+            $normalized_command = $this->normalize_wp_cli_command( $command );
+            $started            = microtime( true );
+            $stdout             = '';
+            $stderr             = '';
+            $success            = true;
+
+            foreach ( $this->runtime_wp_cli_command_parts( $normalized_command ) as $part ) {
+                if ( str_starts_with( $part, 'eval ' ) ) {
+                    $result  = $this->run_runtime_wp_cli_eval_command( $part );
+                    $stdout .= (string) ( $result['stdout'] ?? '' );
+                    $stderr .= (string) ( $result['stderr'] ?? '' );
+                    $success = $success && ! empty( $result['success'] );
+                } elseif ( 1 === preg_match( '/^plugin\s+list(?:\s|$)/', $part ) ) {
+                    $result  = $this->run_runtime_plugin_list_command( $part );
+                    $stdout .= (string) ( $result['stdout'] ?? '' );
+                    $stderr .= (string) ( $result['stderr'] ?? '' );
+                    $success = $success && ! empty( $result['success'] );
+                } elseif ( 1 === preg_match( '/^plugin\s+activate\s+\S+/', $part ) ) {
+                    list( $part_success, $part_stdout, $part_stderr ) = $this->run_runtime_plugin_activate_part( $part );
+                    $stdout .= $part_stdout;
+                    $stderr .= $part_stderr;
+                    $success = $success && $part_success;
+                }
+
+                if ( ! $success ) {
+                    break;
+                }
+            }
+
+            return array(
+                'type'       => 'wp_cli',
+                'command'    => $normalized_command,
+                'exitCode'   => $success ? 0 : 1,
+                'stdout'     => $stdout,
+                'stderr'     => $stderr,
+                'success'    => $success,
+                'timedOut'   => false,
+                'durationMs' => (int) round( ( microtime( true ) - $started ) * 1000 ),
+                'error'      => $success ? '' : ( '' !== $stderr ? $stderr : 'WP-CLI compatibility command failed' ),
+            );
+        }
+
         public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
             $type = (string) ( $tool_def['terminal_action_type'] ?? 'wp_cli' );
 
@@ -2044,15 +2138,8 @@ if ( ! class_exists( 'Homeboy_Datamachine_Agent_Terminal_Tool' ) ) {
                 return $result;
             }
 
-            if ( 'wp_cli' === $type && null !== $this->runtime_wp_cli_eval_code( $command ) ) {
-                $result              = $this->run_runtime_wp_cli_eval_command( $command );
-                $result['tool_name'] = (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' );
-                $result['status']    = 200;
-                return $result;
-            }
-
-            if ( 'wp_cli' === $type && $this->can_run_runtime_plugin_list( $command ) ) {
-                $result              = $this->run_runtime_plugin_list_command( $command );
+            if ( 'wp_cli' === $type && $this->can_run_runtime_wp_cli_compat_command( $command ) ) {
+                $result              = $this->run_runtime_wp_cli_compat_command( $command );
                 $result['tool_name'] = (string) ( $tool_def['tool_name'] ?? 'run_wp_cli' );
                 $result['status']    = 200;
                 return $result;

--- a/wordpress/tests/datamachine-terminal-tool-smoke.php
+++ b/wordpress/tests/datamachine-terminal-tool-smoke.php
@@ -164,6 +164,11 @@ try {
 		return 'fixture-plugin/fixture-plugin.php' === $plugin;
 	}
 
+	function activate_plugin(string $plugin, string $redirect = '', bool $network_wide = false, bool $silent = false) {
+		$GLOBALS['homeboy_activated_plugin'] = array($plugin, $redirect, $network_wide, $silent);
+		return null;
+	}
+
 	$plugin_list_result = $tool->handle_tool_call(
 		array('command' => 'plugin list'),
 		array(
@@ -174,6 +179,19 @@ try {
 
 	if (empty($plugin_list_result['success']) || ! str_contains((string) ($plugin_list_result['stdout'] ?? ''), "fixture-plugin\tactive\tnone\t1.2.3")) {
 		fwrite(STDERR, "Unexpected runtime plugin list result:\n" . json_encode($plugin_list_result, JSON_PRETTY_PRINT) . "\n");
+		exit(1);
+	}
+
+	$chain_result = $tool->handle_tool_call(
+		array('command' => 'wp plugin activate fixture-plugin && wp eval \' $GLOBALS["homeboy_chain_eval"] = "ok"; \''),
+		array(
+			'tool_name'            => 'run_wp_cli',
+			'terminal_action_type' => 'wp_cli',
+		)
+	);
+
+	if (empty($chain_result['success']) || 'ok' !== ($GLOBALS['homeboy_chain_eval'] ?? null) || 'fixture-plugin/fixture-plugin.php' !== ($GLOBALS['homeboy_activated_plugin'][0] ?? null)) {
+		fwrite(STDERR, "Unexpected runtime WP-CLI chain result:\n" . json_encode($chain_result, JSON_PRETTY_PRINT) . "\n");
 		exit(1);
 	}
 


### PR DESCRIPTION
## Summary
- Replace one-off no-`WP_CLI` fallbacks with a small runtime compatibility dispatcher for supported WP-CLI commands.
- Run `wp eval ...`, `wp plugin list`, `wp plugin activate ...`, and `&&` chains of those commands against the loaded WordPress runtime before falling back to host terminal execution.
- Extend the smoke test to cover a chained `wp plugin activate ... && wp eval ...` command.

Fixes #860.

## Follow-up Evidence
- After #863, `wp eval` and `plugin list` no longer needed host `wp` in the live proof.
- The remaining `wp: command not found` failures in https://github.com/Automattic/wp-gym/actions/runs/26651118328 were `plugin activate` and `wp plugin activate ... && wp eval ...` shapes.

## Testing
- `php tests/datamachine-terminal-tool-smoke.php`
- `php -l scripts/agent/datamachine-agent-workload.php && php -l tests/datamachine-terminal-tool-smoke.php`
- `npm run test:datamachine-agent-wp-codebox-runner`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting follow-up proof artifacts, drafting the runtime WP-CLI compatibility dispatcher, and running targeted validation. Chris remains responsible for review and merge.