### PR TITLE
Pass WP Codebox task timeout into recipes

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -31,7 +31,7 @@ function hasFlag(name) {
 }
 
 function usage() {
-  console.error('Usage: homeboy-wp-codebox-task-runner.cjs --agents-api <path> --data-machine <path> --data-machine-code <path> [--homeboy <path>] [--homeboy-extensions <path>] [--wp-codebox-bin <bin>] [--provider <id>] [--model <id>] [--max-turns <n>] [--provider-plugin-path <path>] [--secret-env <ENV>] [--mount <host:vfs[:mode]>] [--artifacts <dir>]');
+  console.error('Usage: homeboy-wp-codebox-task-runner.cjs --agents-api <path> --data-machine <path> --data-machine-code <path> [--homeboy <path>] [--homeboy-extensions <path>] [--wp-codebox-bin <bin>] [--provider <id>] [--model <id>] [--max-turns <n>] [--task-timeout-seconds <n>] [--provider-plugin-path <path>] [--secret-env <ENV>] [--mount <host:vfs[:mode]>] [--artifacts <dir>]');
   process.exit(1);
 }
 
@@ -207,6 +207,7 @@ function recipeForRequest(request, options) {
 
   const providerSlugs = providerPluginEntries(request).map((plugin) => plugin.slug).join(',');
   const maxTurns = argValue('--max-turns') || request.max_turns || request.maxTurns || '';
+  const taskTimeoutSeconds = argValue('--task-timeout-seconds') || request.task_timeout_seconds || request.taskTimeoutSeconds || '';
   const stepArgs = [
     `task=${task}`,
     'agent=sandbox-agent',
@@ -217,6 +218,9 @@ function recipeForRequest(request, options) {
   ];
   if (maxTurns) {
     stepArgs.push(`max-turns=${maxTurns}`);
+  }
+  if (taskTimeoutSeconds) {
+    stepArgs.push(`timeout-seconds=${taskTimeoutSeconds}`);
   }
 
   return {

--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -1026,6 +1026,8 @@ def wp_codebox_task_runner_args(data, settings, script_dir):
         args.extend(['--wp-codebox-bin', settings['wp_codebox_bin']])
     if settings.get('wp_codebox_max_turns'):
         args.extend(['--max-turns', str(settings['wp_codebox_max_turns'])])
+    if settings.get('wp_codebox_task_timeout_seconds'):
+        args.extend(['--task-timeout-seconds', str(settings['wp_codebox_task_timeout_seconds'])])
     args.extend(['--artifacts', settings['wp_codebox_artifacts']])
     for mount in split_setting(settings.get('wp_codebox_mounts')):
         args.extend(['--mount', mount])

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -219,6 +219,7 @@ process.stdout.write(JSON.stringify({
   assert.equal(run.records[0].command.timeout_seconds, 2);
   assert.match(run.records[0].command.args[0], /homeboy-wp-codebox-task-runner\.cjs$/);
   assert.equal(run.records[0].command.args.includes('--wp-codebox-bin'), true);
+  assert.equal(run.records[0].command.args.includes('--task-timeout-seconds'), true);
   assert.equal(run.records[0].command.args.includes('--homeboy'), true);
   assert.equal(run.records[0].command.args.includes('--homeboy-extensions'), true);
   const artifactsIndex = run.records[0].command.args.indexOf('--artifacts');

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -99,6 +99,8 @@ try {
     '/repo/plugin:/wordpress/wp-content/plugins/plugin:readwrite',
     '--max-turns',
     '80',
+    '--task-timeout-seconds',
+    '7200',
     '--artifacts',
     path.join(root, 'artifacts'),
   ], {
@@ -157,6 +159,7 @@ try {
   assert.equal(step.args.includes('provider=opencode'), true);
   assert.equal(step.args.includes('model=opencode-go/kimi-k2.6'), true);
   assert.equal(step.args.includes('max-turns=80'), true);
+  assert.equal(step.args.includes('timeout-seconds=7200'), true);
   assert.equal(step.args.includes('provider-plugin-slugs=example-provider'), true);
   assert.equal(step.args.some((arg) => arg.startsWith('session-id=')), false);
 


### PR DESCRIPTION
## Summary
- Forwards `wp_codebox_task_timeout_seconds` into the Homeboy WP Codebox task runner invocation.
- Emits `timeout-seconds` on generated `wp-codebox.agent-sandbox-run` recipe steps so WP Codebox can bound the inner sandbox execution.
- Extends focused task-runner/refactor smoke tests to assert timeout propagation.

## Verification
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/refactor-source-wp-codebox-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the timeout propagation changes and ran focused local verification; Chris remains responsible for review and acceptance.