### PR TITLE
Prefer runtime bridge env for agent terminal tools

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1900,8 +1900,10 @@ if ( ! class_exists( 'Homeboy_Datamachine_Agent_Terminal_Tool' ) ) {
                 );
             }
 
-            $url   = rtrim( (string) ( $tool_def['terminal_action_url'] ?? getenv( 'HOMEBOY_TERMINAL_ACTION_URL' ) ), '/' );
-            $token = (string) ( $tool_def['terminal_action_token'] ?? getenv( 'HOMEBOY_TERMINAL_ACTION_TOKEN' ) );
+            $env_url   = getenv( 'HOMEBOY_TERMINAL_ACTION_URL' );
+            $env_token = getenv( 'HOMEBOY_TERMINAL_ACTION_TOKEN' );
+            $url       = rtrim( (string) ( false !== $env_url && '' !== $env_url ? $env_url : ( $tool_def['terminal_action_url'] ?? '' ) ), '/' );
+            $token     = (string) ( false !== $env_token && '' !== $env_token ? $env_token : ( $tool_def['terminal_action_token'] ?? '' ) );
 
             if ( '' === $url || '' === $token ) {
                 return array(

--- a/wordpress/tests/datamachine-terminal-tool-smoke.php
+++ b/wordpress/tests/datamachine-terminal-tool-smoke.php
@@ -141,6 +141,25 @@ try {
 		exit(1);
 	}
 
+	putenv('HOMEBOY_TERMINAL_ACTION_URL=' . $ready['url']);
+	putenv('HOMEBOY_TERMINAL_ACTION_TOKEN=' . $token);
+	$env_result = $tool->handle_tool_call(
+		array('command' => 'option get siteurl'),
+		array(
+			'tool_name'             => 'run_wp_cli',
+			'terminal_action_url'   => 'http://127.0.0.1:1',
+			'terminal_action_token' => 'wrong-token',
+			'terminal_action_type'  => 'wp_cli',
+		)
+	);
+
+	if (empty($env_result['success']) || 'wp option get siteurl' !== ($env_result['command'] ?? '') || ! str_contains((string) ($env_result['stdout'] ?? ''), 'php-tool-wp:option get siteurl')) {
+		fwrite(STDERR, "Unexpected env bridge precedence result:\n" . json_encode($env_result, JSON_PRETTY_PRINT) . "\n");
+		exit(1);
+	}
+	putenv('HOMEBOY_TERMINAL_ACTION_URL');
+	putenv('HOMEBOY_TERMINAL_ACTION_TOKEN');
+
 	$missing_bridge_result = $tool->handle_tool_call(
 		array('command' => 'wp plugin list --format=table'),
 		array(


### PR DESCRIPTION
## Summary
- Prefer `HOMEBOY_TERMINAL_ACTION_URL` and `HOMEBOY_TERMINAL_ACTION_TOKEN` over tool-definition terminal credentials when present.
- Add smoke coverage proving the runtime bridge env wins over stale host terminal config.

Follow-up for #860 after proof run 26653754762 showed `run_wp_cli` still reached the host terminal server.

## Testing
- `php -l scripts/agent/datamachine-agent-workload.php && php -l tests/datamachine-terminal-tool-smoke.php && php tests/datamachine-terminal-tool-smoke.php`
- `npm run test:agent-terminal-actions`
- `npm run test:datamachine-agent-wp-codebox-runner`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining bridge precedence bug from wp-gym artifacts, implemented the follow-up fix, and ran focused validation; Chris remains responsible for review and merge.