### PR TITLE
Avoid metadata-preserving WordPress deploy installs

### DIFF
--- a/tests/wordpress-install-command-smoke.sh
+++ b/tests/wordpress-install-command-smoke.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="$ROOT_DIR/wordpress/wordpress.json"
+
+php -r 'json_decode(file_get_contents($argv[1]), true, 512, JSON_THROW_ON_ERROR);' "$MANIFEST"
+
+php -r '
+$manifest = json_decode(file_get_contents($argv[1]), true, 512, JSON_THROW_ON_ERROR);
+$overrides = $manifest["deploy"]["overrides"] ?? [];
+$expected = [
+    "/wp-content/plugins/" => "plugin",
+    "/wp-content/themes/" => "theme",
+];
+
+foreach ($expected as $pattern => $kind) {
+    $match = null;
+    foreach ($overrides as $override) {
+        if (($override["path_pattern"] ?? "") === $pattern) {
+            $match = $override;
+            break;
+        }
+    }
+
+    if (!$match) {
+        fwrite(STDERR, "Missing override for $pattern\n");
+        exit(1);
+    }
+
+    $command = $match["install_command"] ?? "";
+    $cleanup = $match["cleanup_command"] ?? "";
+    $slugVar = $kind . "_slug";
+
+    $required = [
+        "$slugVar=\$(basename {{targetDir}})",
+        "zip_root=\$(unzip -Z1 {{stagingArtifact}}",
+        "if [ \"\$zip_root\" != \"\$$slugVar\" ]",
+        "rm -rf {{targetDir}}",
+        "mkdir -p {{targetParentDir}}",
+        "unzip -oq {{stagingArtifact}} -d {{targetParentDir}}",
+        "test -d {{targetDir}}",
+    ];
+
+    foreach ($required as $needle) {
+        if (!str_contains($command, $needle)) {
+            fwrite(STDERR, "Expected $kind install command to contain: $needle\n");
+            exit(1);
+        }
+    }
+
+    $forbidden = [
+        "mv {{targetDir}} {{targetDir}}.bak",
+        "mv \"\$extracted\" {{targetDir}}",
+        "cp -R",
+        "cp -a",
+        "{{targetDir}}.bak",
+        "mktemp -d",
+    ];
+
+    foreach ($forbidden as $needle) {
+        if (str_contains($command, $needle) || str_contains($cleanup, $needle)) {
+            fwrite(STDERR, "Expected $kind commands not to contain: $needle\n");
+            exit(1);
+        }
+    }
+
+    if ($cleanup !== "rm -f {{stagingArtifact}}") {
+        fwrite(STDERR, "Unexpected $kind cleanup command: $cleanup\n");
+        exit(1);
+    }
+}
+' "$MANIFEST"
+
+echo "wordpress install command smoke passed"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -185,14 +185,14 @@
       {
         "path_pattern": "/wp-content/plugins/",
         "staging_path": "/tmp/homeboy-staging",
-        "install_command": "cd {{siteRoot}} && plugin_slug=$(basename {{targetDir}}) && zip_root=$(unzip -qql {{stagingArtifact}} | head -1 | awk '{print $4}' | cut -d/ -f1) && if [ -z \"$zip_root\" ]; then echo 'ERROR: Could not determine zip root directory' && exit 1; fi && tmp_dir=$(mktemp -d /tmp/homeboy-install.XXXXXX) && unzip -q {{stagingArtifact}} -d \"$tmp_dir\" && extracted=\"$tmp_dir/$zip_root\" && if [ ! -d \"$extracted\" ]; then echo \"ERROR: Expected directory $extracted not found in archive\" && rm -rf \"$tmp_dir\" && exit 1; fi && rm -rf {{targetDir}}.bak && ([ -d {{targetDir}} ] && echo 'Backing up existing plugin to {{targetDir}}.bak' && mv {{targetDir}} {{targetDir}}.bak || true) && mv \"$extracted\" {{targetDir}} && rm -rf \"$tmp_dir\" || (echo 'ERROR: Plugin install failed — restoring backup' && rm -rf \"$tmp_dir\" && rm -rf {{targetDir}} && ([ -d {{targetDir}}.bak ] && mv {{targetDir}}.bak {{targetDir}} || true) && exit 1)",
-        "cleanup_command": "rm -f {{stagingArtifact}} && rm -rf {{targetDir}}.bak"
+        "install_command": "cd {{siteRoot}} && plugin_slug=$(basename {{targetDir}}) && zip_root=$(unzip -Z1 {{stagingArtifact}} | awk -F/ 'NF && $1 != \"\" { print $1; exit }') && if [ -z \"$zip_root\" ]; then echo 'ERROR: Could not determine zip root directory' && exit 1; fi && if [ \"$zip_root\" != \"$plugin_slug\" ]; then echo \"ERROR: ZIP root $zip_root does not match plugin slug $plugin_slug\" && exit 1; fi && rm -rf {{targetDir}} && mkdir -p {{targetParentDir}} && unzip -oq {{stagingArtifact}} -d {{targetParentDir}} && test -d {{targetDir}} || (echo 'ERROR: Plugin install failed' && exit 1)",
+        "cleanup_command": "rm -f {{stagingArtifact}}"
       },
       {
         "path_pattern": "/wp-content/themes/",
         "staging_path": "/tmp/homeboy-staging",
-        "install_command": "cd {{siteRoot}} && theme_slug=$(basename {{targetDir}}) && zip_root=$(unzip -qql {{stagingArtifact}} | head -1 | awk '{print $4}' | cut -d/ -f1) && if [ -z \"$zip_root\" ]; then echo 'ERROR: Could not determine zip root directory' && exit 1; fi && tmp_dir=$(mktemp -d /tmp/homeboy-install.XXXXXX) && unzip -q {{stagingArtifact}} -d \"$tmp_dir\" && extracted=\"$tmp_dir/$zip_root\" && if [ ! -d \"$extracted\" ]; then echo \"ERROR: Expected directory $extracted not found in archive\" && rm -rf \"$tmp_dir\" && exit 1; fi && rm -rf {{targetDir}}.bak && ([ -d {{targetDir}} ] && echo 'Backing up existing theme to {{targetDir}}.bak' && mv {{targetDir}} {{targetDir}}.bak || true) && mv \"$extracted\" {{targetDir}} && rm -rf \"$tmp_dir\" || (echo 'ERROR: Theme install failed — restoring backup' && rm -rf \"$tmp_dir\" && rm -rf {{targetDir}} && ([ -d {{targetDir}}.bak ] && mv {{targetDir}}.bak {{targetDir}} || true) && exit 1)",
-        "cleanup_command": "rm -f {{stagingArtifact}} && rm -rf {{targetDir}}.bak"
+        "install_command": "cd {{siteRoot}} && theme_slug=$(basename {{targetDir}}) && zip_root=$(unzip -Z1 {{stagingArtifact}} | awk -F/ 'NF && $1 != \"\" { print $1; exit }') && if [ -z \"$zip_root\" ]; then echo 'ERROR: Could not determine zip root directory' && exit 1; fi && if [ \"$zip_root\" != \"$theme_slug\" ]; then echo \"ERROR: ZIP root $zip_root does not match theme slug $theme_slug\" && exit 1; fi && rm -rf {{targetDir}} && mkdir -p {{targetParentDir}} && unzip -oq {{stagingArtifact}} -d {{targetParentDir}} && test -d {{targetDir}} || (echo 'ERROR: Theme install failed' && exit 1)",
+        "cleanup_command": "rm -f {{stagingArtifact}}"
       }
     ],
     "version_patterns": [


### PR DESCRIPTION
## Summary
- Replace WordPress plugin/theme backup-and-move deploy overrides with slug-validated direct ZIP extraction into the target parent directory.
- Drop `.bak` cleanup/restore paths so WP Cloud deploys do not hit metadata-preserving directory moves/copies.
- Add a manifest smoke test covering the plugin/theme install command shape and guarding against `mv`/recursive `cp` regressions.

Fixes #868.

## Tests
- `tests/wordpress-install-command-smoke.sh`
- `tests/wordpress-remote-path-inference-smoke.sh`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-wp-cloud-plugin-copy-install --extension wordpress` reached WP Codebox plugin activation/install, then reported no PHPUnit test files for this manifest-only component.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the manifest command update, smoke test, and verification notes for Chris to review.