### PR TITLE
Persist runner workspace aliases for agent tools

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
@@ -39,6 +39,7 @@ namespace {
     }
 
     $GLOBALS['homeboy_forced_parameters_filters'] = array();
+    $GLOBALS['homeboy_forced_parameters_options'] = array();
 
     if ( ! function_exists( 'add_filter' ) ) {
         function add_filter( string $tag, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
@@ -72,6 +73,19 @@ namespace {
                     );
                 }
             };
+        }
+    }
+
+    if ( ! function_exists( 'get_option' ) ) {
+        function get_option( string $option, $default = false ) {
+            return array_key_exists( $option, $GLOBALS['homeboy_forced_parameters_options'] ) ? $GLOBALS['homeboy_forced_parameters_options'][ $option ] : $default;
+        }
+    }
+
+    if ( ! function_exists( 'update_option' ) ) {
+        function update_option( string $option, $value, $autoload = null ): bool {
+            $GLOBALS['homeboy_forced_parameters_options'][ $option ] = $value;
+            return true;
         }
     }
 
@@ -332,6 +346,17 @@ namespace {
 
     if ( '.agent-workspace/current-project' !== ( $aliases['current-project']['root'] ?? null ) ) {
         fwrite( STDERR, "Expected alias runner workspace mode to register the scoped alias root.\n" );
+        exit( 1 );
+    }
+
+    $persisted_aliases = get_option( 'datamachine_code_workspace_aliases', array() );
+    if ( 'demo@agent-run-openai-gpt-5-5' !== ( $persisted_aliases['current-project']['target'] ?? null ) ) {
+        fwrite( STDERR, "Expected alias runner workspace mode to persist the opaque alias mapping for tool requests.\n" );
+        exit( 1 );
+    }
+
+    if ( '.agent-workspace/current-project' !== ( $persisted_aliases['current-project']['root'] ?? null ) ) {
+        fwrite( STDERR, "Expected alias runner workspace mode to persist the scoped alias root for tool requests.\n" );
         exit( 1 );
     }
 

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1586,6 +1586,25 @@ if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_capture_enab
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_persist_runner_workspace_alias' ) ) {
+    function homeboy_datamachine_agent_persist_runner_workspace_alias( string $alias, string $handle, string $root ): void {
+        if ( '' === $alias || '' === $handle || ! function_exists( 'get_option' ) || ! function_exists( 'update_option' ) ) {
+            return;
+        }
+
+        $aliases = get_option( 'datamachine_code_workspace_aliases', array() );
+        if ( ! is_array( $aliases ) ) {
+            $aliases = array();
+        }
+
+        $aliases[ $alias ] = array(
+            'target' => $handle,
+            'root'   => $root,
+        );
+        update_option( 'datamachine_code_workspace_aliases', $aliases, false );
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_execute_workspace_ability' ) ) {
     function homeboy_datamachine_agent_execute_workspace_ability( string $ability_name, array $input ): array {
         $ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
@@ -2285,6 +2304,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_apply_runner_workspace' ) ) {
         $agent_root   = homeboy_datamachine_agent_runner_workspace_root( $config );
         $agent_handle = '' !== $agent_alias ? $agent_alias : $handle;
         if ( '' !== $agent_alias ) {
+            homeboy_datamachine_agent_persist_runner_workspace_alias( $agent_alias, $handle, $agent_root );
             add_filter(
                 'datamachine_code_workspace_aliases',
                 static function ( array $aliases ) use ( $agent_alias, $handle, $agent_root ): array {


### PR DESCRIPTION
## Summary
- Persist runner workspace aliases into Data Machine Code's `datamachine_code_workspace_aliases` option.
- Keep the existing in-request alias filter for same-process resolution.
- Add smoke coverage proving the `current-project` alias mapping is persisted for later tool requests.

This fixes the remaining wp-gym proof failure where agent tool calls saw `current-project` in a separate request and hit `Remote workspace repository \"current-project\" is not registered. Call workspace_clone first.`

## Testing
- `php -l scripts/agent/datamachine-agent-workload.php && php -l scripts/agent/datamachine-agent-forced-parameters-smoke.php && php scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `npm run test:datamachine-agent-wp-codebox-runner`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the request-scoped workspace alias failure, implemented persistent alias registration, and ran focused validation; Chris remains responsible for review and merge.