### PR TITLE
Parse Codebox browser artifacts into bench metrics

### DIFF
--- a/wordpress/lib/wp-codebox-browser-metrics.js
+++ b/wordpress/lib/wp-codebox-browser-metrics.js
@@ -1,0 +1,304 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ARTIFACTS = {
+  summary: { file: 'summary.json', key: 'browser_summary', kind: 'json' },
+  memory: { file: 'memory.json', key: 'browser_memory', kind: 'json' },
+  performance: { file: 'performance.json', key: 'browser_performance', kind: 'json' },
+  checkpoints: { file: 'checkpoints.jsonl', key: 'browser_checkpoints', kind: 'jsonl' },
+};
+
+function readJsonIfPresent(filePath) {
+  if (!fs.existsSync(filePath) || fs.statSync(filePath).size === 0) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function readJsonlIfPresent(filePath) {
+  if (!fs.existsSync(filePath) || fs.statSync(filePath).size === 0) {
+    return [];
+  }
+  return fs.readFileSync(filePath, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function numberValue(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function valueAt(object, selector) {
+  if (!object || typeof object !== 'object') {
+    return undefined;
+  }
+  return selector.split('.').reduce((current, segment) => {
+    if (!current || typeof current !== 'object') {
+      return undefined;
+    }
+    return current[segment];
+  }, object);
+}
+
+function firstNumber(sources, selectors) {
+  for (const source of sources) {
+    for (const selector of selectors) {
+      const value = numberValue(valueAt(source, selector));
+      if (value !== null) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+function maxSampleNumber(samples, selectors) {
+  const values = samples.flatMap((sample) => selectors.map((selector) => numberValue(valueAt(sample, selector))))
+    .filter((value) => value !== null);
+  return values.length > 0 ? Math.max(...values) : null;
+}
+
+function lastSampleNumber(samples, selectors, labelPattern = null) {
+  const filtered = labelPattern
+    ? samples.filter((sample) => labelPattern.test(String(sample.label || sample.name || sample.checkpoint || sample.phase || '')))
+    : samples;
+  for (let index = filtered.length - 1; index >= 0; index -= 1) {
+    for (const selector of selectors) {
+      const value = numberValue(valueAt(filtered[index], selector));
+      if (value !== null) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+function sumArrayNumbers(items, selectors) {
+  const values = items.map((item) => firstNumber([item], selectors)).filter((value) => value !== null);
+  return values.length > 0 ? values.reduce((total, value) => total + value, 0) : null;
+}
+
+function listFrom(value, selectors) {
+  for (const selector of selectors) {
+    const candidate = selector ? valueAt(value, selector) : value;
+    if (Array.isArray(candidate)) {
+      return candidate;
+    }
+  }
+  return [];
+}
+
+function findBrowserDirectory(artifactsDirectory) {
+  if (!artifactsDirectory || !fs.existsSync(artifactsDirectory)) {
+    return null;
+  }
+
+  const directCandidates = [
+    path.join(artifactsDirectory, 'files', 'browser'),
+    path.join(artifactsDirectory, 'browser'),
+  ];
+  const direct = directCandidates.find((candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isDirectory());
+  if (direct) {
+    return direct;
+  }
+
+  const queue = [artifactsDirectory];
+  while (queue.length > 0) {
+    const directory = queue.shift();
+    const entries = fs.readdirSync(directory, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const child = path.join(directory, entry.name);
+      if (path.basename(child) === 'browser' && path.basename(path.dirname(child)) === 'files') {
+        return child;
+      }
+      queue.push(child);
+    }
+  }
+
+  return null;
+}
+
+function parseWpCodeboxBrowserArtifacts(artifactsDirectory) {
+  const browserDirectory = findBrowserDirectory(artifactsDirectory);
+  if (!browserDirectory) {
+    return { metrics: {}, artifacts: {} };
+  }
+
+  const paths = Object.fromEntries(
+    Object.entries(ARTIFACTS).map(([name, artifact]) => [name, path.join(browserDirectory, artifact.file)])
+  );
+  const summary = readJsonIfPresent(paths.summary) || {};
+  const memory = readJsonIfPresent(paths.memory) || {};
+  const performance = readJsonIfPresent(paths.performance) || {};
+  const checkpoints = readJsonlIfPresent(paths.checkpoints);
+  const memorySamples = [
+    ...listFrom(memory, ['samples', 'snapshots', 'measurements', 'checkpoints']),
+    ...checkpoints,
+  ];
+  const resources = listFrom(performance, ['resources', 'resourceTimings', 'entries.resources']);
+  const longTasks = listFrom(performance, ['longTasks', 'long_tasks', 'entries.longTasks']);
+  const sources = [summary, memory, performance, ...checkpoints];
+
+  const metrics = {};
+  const setMetric = (key, value) => {
+    if (value !== null && value !== undefined) {
+      metrics[key] = value;
+    }
+  };
+
+  setMetric('browser_peak_used_js_heap_bytes', firstNumber(sources, [
+    'browser_peak_used_js_heap_bytes',
+    'peak_used_js_heap_bytes',
+    'peakUsedJSHeapSize',
+    'peak.usedJSHeapSize',
+    'peak.used_js_heap_bytes',
+    'memory.peakUsedJSHeapSize',
+    'memory.peak.usedJSHeapSize',
+  ]) ?? maxSampleNumber(memorySamples, ['usedJSHeapSize', 'used_js_heap_bytes', 'memory.usedJSHeapSize']));
+  setMetric('browser_final_used_js_heap_bytes', firstNumber(sources, [
+    'browser_final_used_js_heap_bytes',
+    'final_used_js_heap_bytes',
+    'finalUsedJSHeapSize',
+    'final.usedJSHeapSize',
+    'final.used_js_heap_bytes',
+    'memory.finalUsedJSHeapSize',
+    'memory.final.usedJSHeapSize',
+  ]) ?? lastSampleNumber(memorySamples, ['usedJSHeapSize', 'used_js_heap_bytes', 'memory.usedJSHeapSize']));
+  setMetric('browser_post_idle_used_js_heap_bytes', firstNumber(sources, [
+    'browser_post_idle_used_js_heap_bytes',
+    'post_idle_used_js_heap_bytes',
+    'postIdleUsedJSHeapSize',
+    'postIdle.usedJSHeapSize',
+    'post_idle.used_js_heap_bytes',
+    'afterIdle.usedJSHeapSize',
+  ]) ?? lastSampleNumber(memorySamples, ['usedJSHeapSize', 'used_js_heap_bytes', 'memory.usedJSHeapSize'], /post[-_ ]?idle|after[-_ ]?idle/i));
+  setMetric('browser_generation_heap_delta_bytes', firstNumber(sources, [
+    'browser_generation_heap_delta_bytes',
+    'generation_heap_delta_bytes',
+    'generationHeapDeltaBytes',
+    'generation.heapDeltaBytes',
+    'generation.heap_delta_bytes',
+  ]));
+  if (!Object.hasOwn(metrics, 'browser_generation_heap_delta_bytes')) {
+    const before = firstNumber(sources, ['beforeGeneration.usedJSHeapSize', 'generation.before.usedJSHeapSize', 'initial.usedJSHeapSize']);
+    const after = firstNumber(sources, ['afterGeneration.usedJSHeapSize', 'generation.after.usedJSHeapSize', 'final.usedJSHeapSize']);
+    if (before !== null && after !== null) {
+      metrics.browser_generation_heap_delta_bytes = after - before;
+    }
+  }
+  setMetric('browser_dom_node_count', firstNumber(sources, [
+    'browser_dom_node_count',
+    'dom_node_count',
+    'domNodeCount',
+    'dom.nodeCount',
+    'counts.domNodes',
+    'memory.domNodeCount',
+  ]) ?? lastSampleNumber(memorySamples, ['domNodeCount', 'dom_node_count', 'dom.nodeCount']));
+  setMetric('browser_iframe_count', firstNumber(sources, [
+    'browser_iframe_count',
+    'iframe_count',
+    'iframeCount',
+    'dom.iframeCount',
+    'counts.iframes',
+  ]));
+  setMetric('browser_resource_count', firstNumber(sources, [
+    'browser_resource_count',
+    'resource_count',
+    'resourceCount',
+    'resources.count',
+    'network.resourceCount',
+  ]) ?? (resources.length > 0 ? resources.length : null));
+  setMetric('browser_transfer_size_bytes', firstNumber(sources, [
+    'browser_transfer_size_bytes',
+    'transfer_size_bytes',
+    'transferSizeBytes',
+    'resources.transferSizeBytes',
+    'network.transferSizeBytes',
+  ]) ?? sumArrayNumbers(resources, ['transferSize', 'transfer_size', 'transferSizeBytes']));
+  setMetric('browser_long_task_count', firstNumber(sources, [
+    'browser_long_task_count',
+    'long_task_count',
+    'longTaskCount',
+    'longTasks.count',
+  ]) ?? (longTasks.length > 0 ? longTasks.length : null));
+  setMetric('browser_long_task_total_ms', firstNumber(sources, [
+    'browser_long_task_total_ms',
+    'long_task_total_ms',
+    'longTaskTotalMs',
+    'longTasks.totalMs',
+  ]) ?? sumArrayNumbers(longTasks, ['duration', 'durationMs', 'duration_ms']));
+
+  const artifacts = {};
+  for (const [name, artifact] of Object.entries(ARTIFACTS)) {
+    if (!fs.existsSync(paths[name])) {
+      continue;
+    }
+    artifacts[artifact.key] = {
+      path: path.relative(artifactsDirectory, paths[name]),
+      kind: artifact.kind,
+    };
+  }
+
+  return { metrics, artifacts };
+}
+
+function scenarioReceivesBrowserMetrics(scenario) {
+  return scenario && scenario.id !== '__bootstrap';
+}
+
+function enrichBenchResultsWithBrowserMetrics(benchResults, artifactsDirectory) {
+  const parsed = parseWpCodeboxBrowserArtifacts(artifactsDirectory);
+  if (Object.keys(parsed.metrics).length === 0 && Object.keys(parsed.artifacts).length === 0) {
+    return benchResults;
+  }
+
+  const next = JSON.parse(JSON.stringify(benchResults));
+  next.metrics = { ...(next.metrics || {}), ...parsed.metrics };
+  next.artifacts = { ...(next.artifacts || {}), ...parsed.artifacts };
+  next.scenarios = (next.scenarios || []).map((scenario) => {
+    if (!scenarioReceivesBrowserMetrics(scenario)) {
+      return scenario;
+    }
+    return {
+      ...scenario,
+      metrics: { ...(scenario.metrics || {}), ...parsed.metrics },
+      artifacts: { ...(scenario.artifacts || {}), ...parsed.artifacts },
+    };
+  });
+  return next;
+}
+
+function cli(argv) {
+  const [benchResultsPath, artifactsDirectory] = argv;
+  if (!benchResultsPath || !artifactsDirectory) {
+    throw new Error('Usage: node wp-codebox-browser-metrics.js <bench-results.json> <artifacts-directory>');
+  }
+  const benchResults = JSON.parse(fs.readFileSync(benchResultsPath, 'utf8'));
+  process.stdout.write(`${JSON.stringify(enrichBenchResultsWithBrowserMetrics(benchResults, artifactsDirectory), null, 2)}\n`);
+}
+
+if (require.main === module) {
+  cli(process.argv.slice(2));
+}
+
+module.exports = {
+  enrichBenchResultsWithBrowserMetrics,
+  parseWpCodeboxBrowserArtifacts,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -11,6 +11,7 @@
     "./agent-terminal-actions": "./lib/agent-terminal-actions.js",
     "./timing-correlator": "./lib/timing-correlator.js",
     "./wp-codebox-apply-adapter": "./lib/wp-codebox-apply-adapter.js",
+    "./wp-codebox-browser-metrics": "./lib/wp-codebox-browser-metrics.js",
     "./audit-wp-codebox-fanout": "./lib/audit-wp-codebox-fanout.js"
   },
   "scripts": {
@@ -25,6 +26,7 @@
     "test:request-profiler": "node tests/request-profiler-smoke.js",
     "test:timing-correlator": "node tests/timing-correlator-smoke.js",
     "test:wp-codebox-apply-adapter": "node tests/wp-codebox-apply-adapter-smoke.js",
+    "test:wp-codebox-browser-metrics": "node tests/wp-codebox-browser-metrics-smoke.js",
     "test:audit-wp-codebox-fanout": "node tests/audit-wp-codebox-fanout-smoke.js",
     "test:audit-wp-codebox-execute": "node tests/audit-wp-codebox-fanout-smoke.js",
     "test:wp-codebox-task-runner": "node tests/wp-codebox-task-runner-smoke.js",

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -4,10 +4,12 @@ set -euo pipefail
 # WP Codebox-backed WordPress bench runner.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 BENCH_HELPER_SH="${HOMEBOY_RUNTIME_BENCH_HELPER_SH:-${HOME}/.homeboy/runtime/bench-helper.sh}"
 BENCH_RESULTS_ARTIFACTS_HELPER="${SCRIPT_DIR}/bench-results-artifacts.sh"
+BENCH_BROWSER_METRICS_HELPER="${EXTENSION_DIR}/lib/wp-codebox-browser-metrics.js"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
 BENCH_BROWSER_TARGET_HELPER="${SCRIPT_DIR}/browser-target.sh"
 
@@ -473,6 +475,16 @@ fi
 
 mkdir -p "$(dirname "$RESULTS_FILE")"
 jq '.benchResults | del(.warmup_iterations)' "$WP_CODEBOX_TMPFILE" > "$RESULTS_FILE"
+
+if [ -f "$BENCH_BROWSER_METRICS_HELPER" ]; then
+    ENRICHED_RESULTS_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-browser-metrics.XXXXXX")
+    if node "$BENCH_BROWSER_METRICS_HELPER" "$RESULTS_FILE" "$ARTIFACTS_DIR" > "$ENRICHED_RESULTS_FILE"; then
+        mv "$ENRICHED_RESULTS_FILE" "$RESULTS_FILE"
+    else
+        rm -f "$ENRICHED_RESULTS_FILE"
+        echo "Warning: failed to parse WP Codebox browser artifacts; continuing with raw bench results." >&2
+    fi
+fi
 
 homeboy_wordpress_emit_bench_results_artifacts "$RESULTS_FILE"
 

--- a/wordpress/tests/wp-codebox-browser-metrics-smoke.js
+++ b/wordpress/tests/wp-codebox-browser-metrics-smoke.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const {
+  enrichBenchResultsWithBrowserMetrics,
+  parseWpCodeboxBrowserArtifacts,
+} = require('../lib/wp-codebox-browser-metrics');
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeJsonl(filePath, rows) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`);
+}
+
+function withTempDirectory(callback) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wp-codebox-browser-metrics-'));
+  try {
+    callback(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+withTempDirectory((root) => {
+  const browser = path.join(root, 'artifact-123', 'files', 'browser');
+  writeJson(path.join(browser, 'summary.json'), {
+    peakUsedJSHeapSize: 9000,
+    finalUsedJSHeapSize: 7000,
+    postIdleUsedJSHeapSize: 6500,
+    generationHeapDeltaBytes: 4500,
+    domNodeCount: 42,
+    iframeCount: 3,
+  });
+  writeJson(path.join(browser, 'memory.json'), {
+    samples: [
+      { label: 'before_generation', usedJSHeapSize: 2500 },
+      { label: 'after_generation', usedJSHeapSize: 7000 },
+      { label: 'post_idle', usedJSHeapSize: 6500 },
+    ],
+  });
+  writeJson(path.join(browser, 'performance.json'), {
+    resources: [
+      { name: 'editor.js', transferSize: 1000 },
+      { name: 'style.css', transferSize: 250 },
+    ],
+    longTasks: [
+      { duration: 50.5 },
+      { duration: 12.25 },
+    ],
+  });
+  writeJsonl(path.join(browser, 'checkpoints.jsonl'), [
+    { label: 'load', usedJSHeapSize: 3000 },
+    { label: 'post_idle', usedJSHeapSize: 6500 },
+  ]);
+
+  const parsed = parseWpCodeboxBrowserArtifacts(root);
+  assert.deepEqual(parsed.metrics, {
+    browser_peak_used_js_heap_bytes: 9000,
+    browser_final_used_js_heap_bytes: 7000,
+    browser_post_idle_used_js_heap_bytes: 6500,
+    browser_generation_heap_delta_bytes: 4500,
+    browser_dom_node_count: 42,
+    browser_iframe_count: 3,
+    browser_resource_count: 2,
+    browser_transfer_size_bytes: 1250,
+    browser_long_task_count: 2,
+    browser_long_task_total_ms: 62.75,
+  });
+  assert.deepEqual(parsed.artifacts, {
+    browser_summary: { path: 'artifact-123/files/browser/summary.json', kind: 'json' },
+    browser_memory: { path: 'artifact-123/files/browser/memory.json', kind: 'json' },
+    browser_performance: { path: 'artifact-123/files/browser/performance.json', kind: 'json' },
+    browser_checkpoints: { path: 'artifact-123/files/browser/checkpoints.jsonl', kind: 'jsonl' },
+  });
+
+  const enriched = enrichBenchResultsWithBrowserMetrics({
+    component_id: 'fixture',
+    scenarios: [
+      { id: '__bootstrap', metrics: { boot_ms: 1 } },
+      { id: 'editor-generation', metrics: { mean_ms: 123 }, artifacts: { transcript: { path: 'transcript.json' } } },
+    ],
+  }, root);
+  assert.equal(enriched.metrics.browser_peak_used_js_heap_bytes, 9000);
+  assert.equal(enriched.scenarios[0].metrics.browser_peak_used_js_heap_bytes, undefined);
+  assert.equal(enriched.scenarios[1].metrics.browser_peak_used_js_heap_bytes, 9000);
+  assert.equal(enriched.scenarios[1].artifacts.browser_summary.path, 'artifact-123/files/browser/summary.json');
+  assert.equal(enriched.scenarios[1].artifacts.transcript.path, 'transcript.json');
+});
+
+withTempDirectory((root) => {
+  const result = parseWpCodeboxBrowserArtifacts(root);
+  assert.deepEqual(result, { metrics: {}, artifacts: {} });
+
+  const benchResults = { component_id: 'fixture', scenarios: [{ id: 'one', metrics: { mean_ms: 1 } }] };
+  assert.deepEqual(enrichBenchResultsWithBrowserMetrics(benchResults, root), benchResults);
+});
+
+withTempDirectory((root) => {
+  const browser = path.join(root, 'files', 'browser');
+  writeJson(path.join(browser, 'memory.json'), {
+    samples: [
+      { label: 'initial', usedJSHeapSize: 100 },
+      { label: 'after_generation', usedJSHeapSize: 250 },
+      { label: 'post_idle', usedJSHeapSize: 175, domNodeCount: 9 },
+    ],
+  });
+
+  const parsed = parseWpCodeboxBrowserArtifacts(root);
+  assert.equal(parsed.metrics.browser_peak_used_js_heap_bytes, 250);
+  assert.equal(parsed.metrics.browser_final_used_js_heap_bytes, 175);
+  assert.equal(parsed.metrics.browser_post_idle_used_js_heap_bytes, 175);
+  assert.equal(parsed.metrics.browser_dom_node_count, 9);
+  assert.deepEqual(Object.keys(parsed.artifacts), ['browser_memory']);
+});
+
+withTempDirectory((root) => {
+  const browser = path.join(root, 'files', 'browser');
+  writeJson(path.join(browser, 'summary.json'), { peakUsedJSHeapSize: 12 });
+  const benchResultsPath = path.join(root, 'bench-results.json');
+  writeJson(benchResultsPath, { scenarios: [{ id: 'scenario', metrics: {} }] });
+
+  const result = spawnSync(process.execPath, [path.join(__dirname, '..', 'lib', 'wp-codebox-browser-metrics.js'), benchResultsPath, root], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const enriched = JSON.parse(result.stdout);
+  assert.equal(enriched.scenarios[0].metrics.browser_peak_used_js_heap_bytes, 12);
+});
+
+console.log('✓ WP Codebox browser metrics smoke test PASSED');


### PR DESCRIPTION
## Summary
- Parse WP Codebox browser summary, memory, performance, and checkpoints artifacts into numeric benchmark metrics.
- Attach raw browser artifact paths to bench results so debugging links remain available.
- Degrade gracefully when optional browser artifacts are absent or unparsable.

Closes #875.

## Testing
- `npm run test:wp-codebox-browser-metrics`
- `bash scripts/bench/bench-results-artifacts-smoke.sh`
- `npx eslint lib/wp-codebox-browser-metrics.js`
- `bash -n scripts/bench/bench-runner-wp-codebox.sh scripts/bench/bench-results-artifacts.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Codebox browser artifact parser, bench runner integration, and targeted smoke tests; Chris remains responsible for review and validation.