### PR TITLE
Report Codebox browser memory comparisons

### DIFF
--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -5,6 +5,7 @@ module.exports = {
 	...require('./lib/request-profiler'),
 	...require('./lib/page-profiler'),
 	...require('./lib/timing-correlator'),
+	...require('./lib/codebox-memory-report'),
 	...require('./lib/agent-terminal-actions'),
 	...require('./lib/wp-codebox-apply-adapter'),
 };

--- a/wordpress/lib/codebox-memory-report.js
+++ b/wordpress/lib/codebox-memory-report.js
@@ -1,0 +1,369 @@
+'use strict';
+
+/**
+ * Codebox-specific browser memory comparison helpers for Homeboy bench output.
+ */
+
+/**
+ * External dependencies
+ */
+const fs = require('fs');
+
+const DEFAULT_THRESHOLDS = Object.freeze({
+	failPeakHeapPercent: null,
+	failPostIdleRetainedHeapBytes: null,
+	warnLongTaskTotalPercent: null,
+	warnResourceCount: null,
+	warnTransferSizeBytes: null,
+});
+
+const METRIC_ALIASES = Object.freeze({
+	peakHeapBytes: [
+		'browser_memory_peak_heap_bytes',
+		'peak_heap_bytes',
+		'peakHeapBytes',
+		'peak_js_heap_bytes',
+		'js_heap_peak_bytes',
+	],
+	postIdleRetainedHeapBytes: [
+		'browser_memory_post_idle_retained_heap_bytes',
+		'post_idle_retained_heap_bytes',
+		'post_idle_heap_bytes',
+		'postIdleRetainedHeapBytes',
+		'postIdleHeapBytes',
+	],
+	longTaskTotalMs: [
+		'browser_memory_long_task_total_ms',
+		'long_task_total_ms',
+		'longTaskTotalMs',
+	],
+	resourceCount: [
+		'browser_memory_resource_count',
+		'resource_count',
+		'resourceCount',
+	],
+	transferSizeBytes: [
+		'browser_memory_transfer_size_bytes',
+		'resource_transfer_size_bytes',
+		'transfer_size_bytes',
+		'transferSizeBytes',
+	],
+});
+
+const CHECKPOINT_ALIASES = [
+	'browser_memory_checkpoints',
+	'memory_checkpoints',
+	'checkpoints',
+];
+
+function isPlainObject(value) {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function finiteNumber(value) {
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return value;
+	}
+	if (typeof value === 'string' && value.trim() !== '') {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? parsed : null;
+	}
+	return null;
+}
+
+function firstNumber(source, keys) {
+	if (!isPlainObject(source)) {
+		return null;
+	}
+	for (const key of keys) {
+		const value = finiteNumber(source[key]);
+		if (value !== null) {
+			return value;
+		}
+	}
+	return null;
+}
+
+function normalizeThresholds(input = {}) {
+	const thresholds = { ...DEFAULT_THRESHOLDS };
+	if (!isPlainObject(input)) {
+		return thresholds;
+	}
+	const aliases = {
+		failPeakHeapPercent: ['failPeakHeapPercent', 'fail_peak_heap_percent', 'peak_heap_percent'],
+		failPostIdleRetainedHeapBytes: ['failPostIdleRetainedHeapBytes', 'fail_post_idle_retained_heap_bytes', 'post_idle_retained_heap_bytes'],
+		warnLongTaskTotalPercent: ['warnLongTaskTotalPercent', 'warn_long_task_total_percent', 'long_task_total_percent'],
+		warnResourceCount: ['warnResourceCount', 'warn_resource_count', 'resource_count'],
+		warnTransferSizeBytes: ['warnTransferSizeBytes', 'warn_transfer_size_bytes', 'transfer_size_bytes'],
+	};
+	for (const [target, keys] of Object.entries(aliases)) {
+		const value = firstNumber(input, keys);
+		if (value !== null) {
+			thresholds[target] = value;
+		}
+	}
+	return thresholds;
+}
+
+function scenarioIsCodeboxBrowserMemory(scenario) {
+	const metadata = scenario?.metadata || {};
+	const metrics = scenario?.metrics || {};
+	const kind = String(metadata.kind || metadata.artifact_kind || metadata.profile_kind || '').toLowerCase();
+	return (
+		kind.includes('browser-memory') ||
+		kind.includes('browser_memory') ||
+		String(metadata.backend || '').toLowerCase().includes('codebox') ||
+		Object.values(METRIC_ALIASES).some((aliases) => aliases.some((key) => Object.prototype.hasOwnProperty.call(metrics, key))) ||
+		CHECKPOINT_ALIASES.some((key) => Object.prototype.hasOwnProperty.call(metrics, key))
+	);
+}
+
+function checkpointLabel(row) {
+	return String(row?.checkpoint || row?.name || row?.label || row?.id || '').trim();
+}
+
+function normalizeCheckpoints(metrics = {}) {
+	let rows = [];
+	for (const key of CHECKPOINT_ALIASES) {
+		if (Array.isArray(metrics[key])) {
+			rows = metrics[key];
+			break;
+		}
+	}
+	return rows.map((row) => {
+		const label = checkpointLabel(row);
+		return {
+			checkpoint: label,
+			heapBytes: firstNumber(row, ['heap_bytes', 'heapBytes', 'used_heap_bytes', 'usedHeapBytes', 'js_heap_bytes', 'value']),
+		};
+	}).filter((row) => row.checkpoint && row.heapBytes !== null);
+}
+
+function normalizeMemoryScenario(scenario) {
+	const metrics = scenario?.metrics || {};
+	const normalized = {
+		id: String(scenario?.id || scenario?.scenario_id || 'unknown'),
+		label: String(scenario?.label || scenario?.id || scenario?.scenario_id || 'unknown'),
+		metrics: {
+			peakHeapBytes: firstNumber(metrics, METRIC_ALIASES.peakHeapBytes),
+			postIdleRetainedHeapBytes: firstNumber(metrics, METRIC_ALIASES.postIdleRetainedHeapBytes),
+			longTaskTotalMs: firstNumber(metrics, METRIC_ALIASES.longTaskTotalMs),
+			resourceCount: firstNumber(metrics, METRIC_ALIASES.resourceCount),
+			transferSizeBytes: firstNumber(metrics, METRIC_ALIASES.transferSizeBytes),
+		},
+		checkpoints: normalizeCheckpoints(metrics),
+	};
+	return normalized;
+}
+
+function extractCodeboxMemoryScenarios(results) {
+	return (Array.isArray(results?.scenarios) ? results.scenarios : [])
+		.filter(scenarioIsCodeboxBrowserMemory)
+		.map(normalizeMemoryScenario)
+		.filter((scenario) => Object.values(scenario.metrics).some((value) => value !== null) || scenario.checkpoints.length > 0);
+}
+
+function delta(baseline, candidate) {
+	return baseline === null || candidate === null ? null : candidate - baseline;
+}
+
+function percentDelta(baseline, candidate) {
+	if (baseline === null || candidate === null || baseline === 0) {
+		return null;
+	}
+	return ((candidate - baseline) / baseline) * 100;
+}
+
+function evaluateThresholds(metrics, thresholds) {
+	const findings = [];
+	const peakPercent = percentDelta(metrics.peakHeapBytes.baseline, metrics.peakHeapBytes.candidate);
+	if (thresholds.failPeakHeapPercent !== null && peakPercent !== null && peakPercent > thresholds.failPeakHeapPercent) {
+		findings.push({ status: 'fail', metric: 'Peak heap', delta: peakPercent, threshold: thresholds.failPeakHeapPercent, unit: '%' });
+	}
+	const postIdleDelta = metrics.postIdleRetainedHeapBytes.delta;
+	if (thresholds.failPostIdleRetainedHeapBytes !== null && postIdleDelta !== null && postIdleDelta > thresholds.failPostIdleRetainedHeapBytes) {
+		findings.push({ status: 'fail', metric: 'Post-idle retained heap', delta: postIdleDelta, threshold: thresholds.failPostIdleRetainedHeapBytes, unit: 'bytes' });
+	}
+	const longTaskPercent = percentDelta(metrics.longTaskTotalMs.baseline, metrics.longTaskTotalMs.candidate);
+	if (thresholds.warnLongTaskTotalPercent !== null && longTaskPercent !== null && longTaskPercent > thresholds.warnLongTaskTotalPercent) {
+		findings.push({ status: 'warn', metric: 'Long task total', delta: longTaskPercent, threshold: thresholds.warnLongTaskTotalPercent, unit: '%' });
+	}
+	if (thresholds.warnResourceCount !== null && metrics.resourceCount.delta !== null && metrics.resourceCount.delta > thresholds.warnResourceCount) {
+		findings.push({ status: 'warn', metric: 'Resource count', delta: metrics.resourceCount.delta, threshold: thresholds.warnResourceCount, unit: 'resources' });
+	}
+	if (thresholds.warnTransferSizeBytes !== null && metrics.transferSizeBytes.delta !== null && metrics.transferSizeBytes.delta > thresholds.warnTransferSizeBytes) {
+		findings.push({ status: 'warn', metric: 'Transfer size', delta: metrics.transferSizeBytes.delta, threshold: thresholds.warnTransferSizeBytes, unit: 'bytes' });
+	}
+	return findings;
+}
+
+function compareMetric(baseline, candidate, key) {
+	return {
+		baseline: baseline.metrics[key],
+		candidate: candidate.metrics[key],
+		delta: delta(baseline.metrics[key], candidate.metrics[key]),
+		percentDelta: percentDelta(baseline.metrics[key], candidate.metrics[key]),
+	};
+}
+
+function compareCheckpoints(baseline, candidate) {
+	const candidateByCheckpoint = new Map(candidate.checkpoints.map((row) => [row.checkpoint, row]));
+	return baseline.checkpoints.map((baselineRow) => {
+		const candidateRow = candidateByCheckpoint.get(baselineRow.checkpoint);
+		return {
+			checkpoint: baselineRow.checkpoint,
+			baselineHeapBytes: baselineRow.heapBytes,
+			candidateHeapBytes: candidateRow?.heapBytes ?? null,
+			deltaHeapBytes: delta(baselineRow.heapBytes, candidateRow?.heapBytes ?? null),
+		};
+	}).filter((row) => row.candidateHeapBytes !== null);
+}
+
+function compareCodeboxMemoryResults({ baseline, candidate, thresholds = {} }) {
+	const normalizedThresholds = normalizeThresholds(thresholds);
+	const baselineScenarios = extractCodeboxMemoryScenarios(baseline);
+	const candidateScenarios = extractCodeboxMemoryScenarios(candidate);
+	const candidateById = new Map(candidateScenarios.map((scenario) => [scenario.id, scenario]));
+	const scenarios = baselineScenarios.map((baselineScenario) => {
+		const candidateScenario = candidateById.get(baselineScenario.id);
+		if (!candidateScenario) {
+			return null;
+		}
+		const metrics = {
+			peakHeapBytes: compareMetric(baselineScenario, candidateScenario, 'peakHeapBytes'),
+			postIdleRetainedHeapBytes: compareMetric(baselineScenario, candidateScenario, 'postIdleRetainedHeapBytes'),
+			longTaskTotalMs: compareMetric(baselineScenario, candidateScenario, 'longTaskTotalMs'),
+			resourceCount: compareMetric(baselineScenario, candidateScenario, 'resourceCount'),
+			transferSizeBytes: compareMetric(baselineScenario, candidateScenario, 'transferSizeBytes'),
+		};
+		return {
+			id: baselineScenario.id,
+			label: baselineScenario.label,
+			metrics,
+			checkpoints: compareCheckpoints(baselineScenario, candidateScenario),
+			findings: evaluateThresholds(metrics, normalizedThresholds),
+		};
+	}).filter(Boolean);
+	const findings = scenarios.flatMap((scenario) => scenario.findings.map((finding) => ({ ...finding, scenario: scenario.id })));
+	let status = 'reported';
+	if (findings.some((finding) => finding.status === 'fail')) {
+		status = 'failed';
+	} else if (findings.some((finding) => finding.status === 'warn')) {
+		status = 'warning';
+	}
+	return {
+		thresholds: normalizedThresholds,
+		status,
+		scenarios,
+		findings,
+	};
+}
+
+function formatBytes(value) {
+	if (value === null || value === undefined) {
+		return 'n/a';
+	}
+	const abs = Math.abs(value);
+	const mb = value / 1024 / 1024;
+	if (abs >= 1024 * 1024) {
+		return `${Math.round(mb)} MB`;
+	}
+	if (abs >= 1024) {
+		return `${Math.round(value / 1024)} KB`;
+	}
+	return `${Math.round(value)} B`;
+}
+
+function formatNumber(value, suffix = '') {
+	if (value === null || value === undefined) {
+		return 'n/a';
+	}
+	return `${Math.round(value * 100) / 100}${suffix}`;
+}
+
+function formatDelta(value, formatter) {
+	if (value === null || value === undefined) {
+		return 'n/a';
+	}
+	return `${value > 0 ? '+' : ''}${formatter(value)}`;
+}
+
+function metricLine(label, metric, formatter) {
+	return `| ${label} | ${formatter(metric.baseline)} | ${formatter(metric.candidate)} | ${formatDelta(metric.delta, formatter)} |`;
+}
+
+function formatCodeboxMemoryComparisonMarkdown(comparison) {
+	const lines = ['# Codebox Browser Memory Comparison', ''];
+	if (!comparison.scenarios.length) {
+		return `${lines.join('\n')}No matching Codebox browser memory scenarios found.\n`;
+	}
+	lines.push(`Status: **${comparison.status}**`, '');
+	if (comparison.findings.length > 0) {
+		lines.push('| Scenario | Status | Metric | Delta | Threshold |', '|---|---|---|---:|---:|');
+		for (const finding of comparison.findings) {
+			const formatter = finding.unit === 'bytes' ? formatBytes : (value) => formatNumber(value, finding.unit === '%' ? '%' : '');
+			lines.push(`| ${finding.scenario} | ${finding.status} | ${finding.metric} | ${formatDelta(finding.delta, formatter)} | ${formatter(finding.threshold)} |`);
+		}
+		lines.push('');
+	} else {
+		lines.push('Thresholds are report-only unless configured. No configured warning or failure thresholds were exceeded.', '');
+	}
+	for (const scenario of comparison.scenarios) {
+		lines.push(`## ${scenario.label}`, '', '| Metric | Baseline | Candidate | Delta |', '|---|---:|---:|---:|');
+		lines.push(metricLine('Peak heap', scenario.metrics.peakHeapBytes, formatBytes));
+		lines.push(metricLine('Post-idle retained heap', scenario.metrics.postIdleRetainedHeapBytes, formatBytes));
+		lines.push(metricLine('Long task total', scenario.metrics.longTaskTotalMs, (value) => formatNumber(value, ' ms')));
+		lines.push(metricLine('Resource count', scenario.metrics.resourceCount, formatNumber));
+		lines.push(metricLine('Transfer size', scenario.metrics.transferSizeBytes, formatBytes));
+		lines.push('');
+		if (scenario.checkpoints.length > 0) {
+			lines.push('| Checkpoint | Baseline Heap | Candidate Heap | Delta |', '|---|---:|---:|---:|');
+			for (const checkpoint of scenario.checkpoints) {
+				lines.push(`| ${checkpoint.checkpoint} | ${formatBytes(checkpoint.baselineHeapBytes)} | ${formatBytes(checkpoint.candidateHeapBytes)} | ${formatDelta(checkpoint.deltaHeapBytes, formatBytes)} |`);
+			}
+			lines.push('');
+		}
+	}
+	return `${lines.join('\n')}\n`;
+}
+
+function readJsonFile(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function runCli(argv = process.argv.slice(2)) {
+	const args = new Map();
+	for (let index = 0; index < argv.length; index += 2) {
+		args.set(argv[index], argv[index + 1]);
+	}
+	const baselinePath = args.get('--baseline');
+	const candidatePath = args.get('--candidate');
+	if (!baselinePath || !candidatePath) {
+		throw new Error('Usage: node codebox-memory-report.js --baseline <file> --candidate <file> [--thresholds-json <json>]');
+	}
+	const thresholdsJson = args.get('--thresholds-json') || '{}';
+	const comparison = compareCodeboxMemoryResults({
+		baseline: readJsonFile(baselinePath),
+		candidate: readJsonFile(candidatePath),
+		thresholds: JSON.parse(thresholdsJson),
+	});
+	process.stdout.write(formatCodeboxMemoryComparisonMarkdown(comparison));
+	return comparison.status === 'failed' ? 1 : 0;
+}
+
+if (require.main === module) {
+	try {
+		process.exitCode = runCli();
+	} catch (error) {
+		process.stderr.write(`${error.message}\n`);
+		process.exitCode = 2;
+	}
+}
+
+module.exports = {
+	DEFAULT_THRESHOLDS,
+	compareCodeboxMemoryResults,
+	extractCodeboxMemoryScenarios,
+	formatCodeboxMemoryComparisonMarkdown,
+	normalizeThresholds,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -10,6 +10,7 @@
     "./request-profiler": "./lib/request-profiler.js",
     "./agent-terminal-actions": "./lib/agent-terminal-actions.js",
     "./timing-correlator": "./lib/timing-correlator.js",
+    "./codebox-memory-report": "./lib/codebox-memory-report.js",
     "./wp-codebox-apply-adapter": "./lib/wp-codebox-apply-adapter.js",
     "./audit-wp-codebox-fanout": "./lib/audit-wp-codebox-fanout.js"
   },
@@ -24,6 +25,7 @@
     "test:playground-readiness": "node tests/playground-readiness-smoke.js",
     "test:request-profiler": "node tests/request-profiler-smoke.js",
     "test:timing-correlator": "node tests/timing-correlator-smoke.js",
+    "test:codebox-memory-report": "node tests/codebox-memory-report-smoke.js",
     "test:wp-codebox-apply-adapter": "node tests/wp-codebox-apply-adapter-smoke.js",
     "test:audit-wp-codebox-fanout": "node tests/audit-wp-codebox-fanout-smoke.js",
     "test:audit-wp-codebox-execute": "node tests/audit-wp-codebox-fanout-smoke.js",

--- a/wordpress/scripts/bench/bench-results-artifacts.sh
+++ b/wordpress/scripts/bench/bench-results-artifacts.sh
@@ -94,10 +94,13 @@ homeboy_wordpress_bench_leaderboard_filter() {
 }
 
 homeboy_wordpress_emit_bench_results_artifacts() {
-    local bench_results_file="$1"
-    local artifact_dir
-    local jsonl_file
-    local leaderboard_file
+	local bench_results_file="$1"
+	local artifact_dir
+	local jsonl_file
+	local leaderboard_file
+	local baseline_results_file
+	local codebox_memory_report_file
+	local codebox_thresholds_json
 
     if [ -z "$bench_results_file" ] || [ ! -s "$bench_results_file" ]; then
         return 0
@@ -106,21 +109,36 @@ homeboy_wordpress_emit_bench_results_artifacts() {
     artifact_dir="$(homeboy_wordpress_bench_artifact_dir "$bench_results_file")"
     mkdir -p "$artifact_dir"
 
-    jsonl_file="${artifact_dir}/results.jsonl"
-    leaderboard_file="${artifact_dir}/leaderboard.md"
+	jsonl_file="${artifact_dir}/results.jsonl"
+	leaderboard_file="${artifact_dir}/leaderboard.md"
+	codebox_memory_report_file="${artifact_dir}/codebox-browser-memory-comparison.md"
 
     if ! homeboy_wordpress_bench_jsonl_filter < "$bench_results_file" > "$jsonl_file"; then
         echo "ERROR: failed to emit bench results JSONL artifact at $jsonl_file" >&2
         return 1
     fi
 
-    if ! homeboy_wordpress_bench_leaderboard_filter < "$jsonl_file" > "$leaderboard_file"; then
-        echo "ERROR: failed to emit bench leaderboard artifact at $leaderboard_file" >&2
-        return 1
-    fi
+	if ! homeboy_wordpress_bench_leaderboard_filter < "$jsonl_file" > "$leaderboard_file"; then
+		echo "ERROR: failed to emit bench leaderboard artifact at $leaderboard_file" >&2
+		return 1
+	fi
 
-    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
-        echo "DEBUG: [bench] Results JSONL: $jsonl_file"
-        echo "DEBUG: [bench] Leaderboard: $leaderboard_file"
-    fi
+	baseline_results_file="${HOMEBOY_BENCH_BASELINE_RESULTS_FILE:-${HOMEBOY_CODEBOX_MEMORY_BASELINE_RESULTS_FILE:-}}"
+	if [ -n "$baseline_results_file" ] && [ -s "$baseline_results_file" ]; then
+		codebox_thresholds_json="${HOMEBOY_CODEBOX_MEMORY_THRESHOLDS_JSON:-${HOMEBOY_BENCH_CODEBOX_MEMORY_THRESHOLDS_JSON:-{}}}"
+		if ! node "${SCRIPT_DIR}/../../lib/codebox-memory-report.js" \
+			--baseline "$baseline_results_file" \
+			--candidate "$bench_results_file" \
+			--thresholds-json "$codebox_thresholds_json" \
+			> "$codebox_memory_report_file"; then
+			echo "ERROR: failed to emit Codebox browser memory comparison at $codebox_memory_report_file" >&2
+			return 1
+		fi
+	fi
+
+	if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+		echo "DEBUG: [bench] Results JSONL: $jsonl_file"
+		echo "DEBUG: [bench] Leaderboard: $leaderboard_file"
+		[ -s "$codebox_memory_report_file" ] && echo "DEBUG: [bench] Codebox browser memory comparison: $codebox_memory_report_file"
+	fi
 }

--- a/wordpress/tests/codebox-memory-report-smoke.js
+++ b/wordpress/tests/codebox-memory-report-smoke.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const assert = require('assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const {
+	compareCodeboxMemoryResults,
+	extractCodeboxMemoryScenarios,
+	formatCodeboxMemoryComparisonMarkdown,
+	normalizeThresholds,
+} = require('../lib/codebox-memory-report');
+
+const baseline = {
+	component_id: 'wp-codebox-fixture',
+	scenarios: [
+		{
+			id: 'browser-memory/site-editor',
+			label: 'Site editor',
+			metadata: { backend: 'wp-codebox' },
+			metrics: {
+				browser_memory_peak_heap_bytes: 100 * 1024 * 1024,
+				browser_memory_post_idle_retained_heap_bytes: 78 * 1024 * 1024,
+				browser_memory_long_task_total_ms: 200,
+				browser_memory_resource_count: 50,
+				browser_memory_transfer_size_bytes: 1024 * 1024,
+				browser_memory_checkpoints: [
+					{ checkpoint: 'shell ready', heap_bytes: 42 * 1024 * 1024 },
+					{ checkpoint: 'preview ready', heap_bytes: 91 * 1024 * 1024 },
+					{ checkpoint: 'post idle', heap_bytes: 78 * 1024 * 1024 },
+				],
+			},
+		},
+	],
+};
+
+const candidate = {
+	component_id: 'wp-codebox-fixture',
+	scenarios: [
+		{
+			id: 'browser-memory/site-editor',
+			label: 'Site editor',
+			metadata: { backend: 'wp-codebox' },
+			metrics: {
+				browser_memory_peak_heap_bytes: 112 * 1024 * 1024,
+				browser_memory_post_idle_retained_heap_bytes: 86 * 1024 * 1024,
+				browser_memory_long_task_total_ms: 260,
+				browser_memory_resource_count: 54,
+				browser_memory_transfer_size_bytes: 1536 * 1024,
+				browser_memory_checkpoints: [
+					{ checkpoint: 'shell ready', heap_bytes: 40 * 1024 * 1024 },
+					{ checkpoint: 'preview ready', heap_bytes: 104 * 1024 * 1024 },
+					{ checkpoint: 'post idle', heap_bytes: 86 * 1024 * 1024 },
+				],
+			},
+		},
+	],
+};
+
+const scenarios = extractCodeboxMemoryScenarios(baseline);
+assert.equal(scenarios.length, 1);
+assert.equal(scenarios[0].metrics.peakHeapBytes, 100 * 1024 * 1024);
+assert.equal(scenarios[0].checkpoints.length, 3);
+
+assert.deepEqual(normalizeThresholds({ fail_peak_heap_percent: 10, warn_resource_count: 3 }), {
+	failPeakHeapPercent: 10,
+	failPostIdleRetainedHeapBytes: null,
+	warnLongTaskTotalPercent: null,
+	warnResourceCount: 3,
+	warnTransferSizeBytes: null,
+});
+
+const reportOnlyComparison = compareCodeboxMemoryResults({ baseline, candidate });
+assert.equal(reportOnlyComparison.status, 'reported');
+assert.equal(reportOnlyComparison.findings.length, 0);
+assert.equal(reportOnlyComparison.scenarios[0].metrics.peakHeapBytes.delta, 12 * 1024 * 1024);
+assert.equal(reportOnlyComparison.scenarios[0].checkpoints[1].deltaHeapBytes, 13 * 1024 * 1024);
+
+const gatedComparison = compareCodeboxMemoryResults({
+	baseline,
+	candidate,
+	thresholds: {
+		fail_peak_heap_percent: 10,
+		fail_post_idle_retained_heap_bytes: 7 * 1024 * 1024,
+		warn_long_task_total_percent: 20,
+		warn_resource_count: 3,
+		warn_transfer_size_bytes: 256 * 1024,
+	},
+});
+assert.equal(gatedComparison.status, 'failed');
+assert.equal(gatedComparison.findings.filter((finding) => finding.status === 'fail').length, 2);
+assert.equal(gatedComparison.findings.filter((finding) => finding.status === 'warn').length, 3);
+
+const markdown = formatCodeboxMemoryComparisonMarkdown(gatedComparison);
+assert.match(markdown, /Codebox Browser Memory Comparison/);
+assert.match(markdown, /\| Checkpoint \| Baseline Heap \| Candidate Heap \| Delta \|/);
+assert.match(markdown, /\| shell ready \| 42 MB \| 40 MB \| -2 MB \|/);
+assert.match(markdown, /\| preview ready \| 91 MB \| 104 MB \| \+13 MB \|/);
+assert.match(markdown, /\| Peak heap \| 100 MB \| 112 MB \| \+12 MB \|/);
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-memory-report-'));
+try {
+	const baselinePath = path.join(tmpDir, 'baseline.json');
+	const candidatePath = path.join(tmpDir, 'candidate.json');
+	fs.writeFileSync(baselinePath, JSON.stringify(baseline), 'utf8');
+	fs.writeFileSync(candidatePath, JSON.stringify(candidate), 'utf8');
+	const cli = spawnSync(process.execPath, [
+		path.join(__dirname, '..', 'lib', 'codebox-memory-report.js'),
+		'--baseline',
+		baselinePath,
+		'--candidate',
+		candidatePath,
+		'--thresholds-json',
+		'{"warn_resource_count":3}',
+	], { encoding: 'utf8' });
+	assert.equal(cli.status, 0, cli.stderr);
+	assert.match(cli.stdout, /Status: \*\*warning\*\*/);
+	assert.match(cli.stdout, /Resource count/);
+} finally {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+console.log('Codebox memory report smoke passed');


### PR DESCRIPTION
## Summary
- Adds extension-owned Codebox browser memory baseline/candidate comparison helpers for bench results.
- Emits a PR-friendly `codebox-browser-memory-comparison.md` artifact when a baseline results file is supplied.
- Keeps thresholds report-only by default, with configurable fail/warn gates for heap, long tasks, resource count, and transfer size.

## Tests
- `npm run test:codebox-memory-report`
- `bash scripts/bench/bench-results-artifacts-smoke.sh`
- `npx eslint lib/codebox-memory-report.js`
- `npm run lint:js -- lib/codebox-memory-report.js`

Closes #874.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Codebox-specific comparison/reporting implementation, targeted smoke coverage, and PR description; Chris remains responsible for review and validation.