### PR TITLE
Stop strict comparison fixer rewrites

### DIFF
--- a/wordpress/scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh
+++ b/wordpress/scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh
@@ -22,6 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WP_FILESYSTEM_FIXER="${SCRIPT_DIR}/wp-filesystem-fixer.php"
 SHORT_TERNARY_FIXER="${SCRIPT_DIR}/short-ternary-fixer.php"
 LONELY_IF_FIXER="${SCRIPT_DIR}/lonely-if-fixer.php"
+STRICT_COMPARISON_FIXER="${SCRIPT_DIR}/strict-comparison-fixer.php"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
@@ -194,5 +195,32 @@ assert_grep 'if \( config\.type === '\''checkbox'\'' \)' "${TMPDIR}/assets/Handl
 	"JavaScript nested if must not become PHP elseif"
 assert_not_grep 'elseif' "${TMPDIR}/assets/HandlerModel.js" \
 	"JavaScript file must not contain PHP elseif after lonely-if fixer"
+
+# === Bug 4: strict-comparison fixer must not rewrite loose comparisons ===
+
+rm -rf "${TMPDIR}"/*
+mkdir -p "${TMPDIR}"
+
+cat > "${TMPDIR}/loose-comparisons.php" <<'PHP'
+<?php
+$matches_zero_string = $id == '0';
+$not_false = $enabled != false;
+PHP
+
+php "$STRICT_COMPARISON_FIXER" "${TMPDIR}/loose-comparisons.php" > "${TMPDIR}/strict-comparison-output.txt"
+
+assert_grep '\$id == '\''0'\''' "${TMPDIR}/loose-comparisons.php" \
+    "strict-comparison fixer must leave == unchanged for manual review"
+assert_grep '\$enabled != false' "${TMPDIR}/loose-comparisons.php" \
+    "strict-comparison fixer must leave != unchanged for manual review"
+assert_not_grep '===' "${TMPDIR}/loose-comparisons.php" \
+    "strict-comparison fixer must not introduce === automatically"
+assert_not_grep '!==' "${TMPDIR}/loose-comparisons.php" \
+    "strict-comparison fixer must not introduce !== automatically"
+assert_grep 'Reported 2 loose comparison' "${TMPDIR}/strict-comparison-output.txt" \
+    "strict-comparison fixer must report loose comparisons for audit"
+assert_grep "loose-comparisons.php:[0-9]+: loose comparison '==' requires manual review" \
+    "${TMPDIR}/strict-comparison-output.txt" \
+    "strict-comparison fixer must include file and line context"
 
 echo "OK: fixer test harness skip + short-ternary call guard regression smoke passed"

--- a/wordpress/scripts/lint/php-fixers/strict-comparison-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/strict-comparison-fixer.php
@@ -3,13 +3,13 @@
 /**
  * Strict Comparison Fixer
  *
- * Converts loose comparisons to strict:
- *   == → ===
- *   != → !==
+ * Reports loose comparisons that need manual review:
+ *   ==
+ *   !=
  *
  * WPCS marks Universal.Operators.StrictComparisons as phpcs-only (phpcbf won't fix it)
- * because loose-to-strict can change behavior. This fixer handles it since the codebase
- * has opted into strict comparisons via the WordPress coding standard.
+ * because loose-to-strict can change behavior. This fixer intentionally stays
+ * report-only so fix-only runs surface the issue without changing semantics.
  *
  * Usage: php strict-comparison-fixer.php <path>
  */
@@ -31,9 +31,9 @@ if (!file_exists($path)) {
 $result = fixer_process_path($path, 'process_file');
 
 if ($result['total_fixes'] > 0) {
-    echo "Strict comparison fixer: Fixed {$result['total_fixes']} comparison(s) in {$result['files_fixed']} file(s)\n";
+    echo "Strict comparison fixer: Reported {$result['total_fixes']} loose comparison(s) in {$result['files_fixed']} file(s); no automatic rewrites applied\n";
 } else {
-    echo "Strict comparison fixer: No fixable comparisons found\n";
+    echo "Strict comparison fixer: No loose comparisons found\n";
 }
 
 exit(0);
@@ -53,35 +53,24 @@ function process_file($filepath) {
     }
 
     $fixes = 0;
-    $new_content = '';
     $count = count($tokens);
 
     for ($i = 0; $i < $count; $i++) {
         $token = $tokens[$i];
 
         if (is_array($token)) {
-            // == → ===
             if ($token[0] === T_IS_EQUAL) {
-                $new_content .= '===';
+                echo "$filepath:{$token[2]}: loose comparison '==' requires manual review\n";
                 $fixes++;
                 continue;
             }
 
-            // != → !==
             if ($token[0] === T_IS_NOT_EQUAL) {
-                $new_content .= '!==';
+                echo "$filepath:{$token[2]}: loose comparison '!=' requires manual review\n";
                 $fixes++;
                 continue;
             }
-
-            $new_content .= $token[1];
-        } else {
-            $new_content .= $token;
         }
-    }
-
-    if ($fixes > 0) {
-        file_put_contents($filepath, $new_content);
     }
 
     return $fixes;


### PR DESCRIPTION
## Summary
- Changes `strict-comparison-fixer.php` from an automatic loose-to-strict rewriter into a report-only scanner.
- Reports `==` and `!=` with file/line/operator context so fix-only runs remain auditable without changing PHP semantics.
- Adds smoke coverage proving unsafe loose comparisons are not rewritten to `===`/`!==`.

## Verification
- `bash scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh` passed
- `php -l scripts/lint/php-fixers/strict-comparison-fixer.php` passed
- `bash -n scripts/lint/php-fixers/fixer-test-harness-skip-smoke.sh` passed

## Caveat
- `homeboy lint --path wordpress --extension wordpress` still fails on existing repository lint findings outside this change, including `scripts/agent/validate-bundle.php` formatting/security findings. Targeted regression and syntax checks pass.

Refs #878.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the report-only strict-comparison fixer change and focused smoke coverage; Chris remains responsible for review and merge.