### PR TITLE
Fail non-actionable Codebox fanout success

### DIFF
--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -792,7 +792,8 @@ function taskOutcome(taskRequest, parsed, artifact, success, errorMessage = '', 
   }
 
   const changedFiles = artifactChangedFiles(artifact);
-  if (success && changedFiles.length > 0) {
+  const hasPatch = artifactHasPatch(artifact);
+  if (success && changedFiles.length > 0 && hasPatch) {
     const falsePositive = outputLooksFalsePositive(parsed);
     return structuredTaskOutcome(taskRequest, {
       kind: falsePositive ? 'false_positive_artifact' : 'fix_artifact',
@@ -816,7 +817,7 @@ function taskOutcome(taskRequest, parsed, artifact, success, errorMessage = '', 
   );
   const prUrl = explicit.pr_url || explicit.pull_request_url || explicit.pullRequestUrl || urls[0] || '';
   const falsePositivePrUrl = explicit.false_positive_pr_url || explicit.falsePositivePullRequestUrl || (falsePositive ? prUrl : '');
-  let kind = success ? 'unable_to_remediate' : 'explicit_failure';
+  let kind = 'explicit_failure';
 
   if (timedOut) {
     kind = 'timeout';
@@ -829,7 +830,7 @@ function taskOutcome(taskRequest, parsed, artifact, success, errorMessage = '', 
   if (!success) {
     failure = errorMessage;
   } else if (kind === 'explicit_failure') {
-    failure = 'WP Codebox task failed without a structured outcome';
+    failure = 'WP Codebox task succeeded without an actionable patch, changed files, PR URL, or justified no-op outcome';
   }
 
   return {
@@ -843,6 +844,15 @@ function taskOutcome(taskRequest, parsed, artifact, success, errorMessage = '', 
     false_positive: falsePositive,
     artifact_id: artifact?.id || '',
     failure,
+    non_actionable: success && kind === 'explicit_failure',
+    evidence: success && kind === 'explicit_failure' ? {
+      artifact_id: artifact?.id || '',
+      artifact_directory: artifact?.directory || artifact?.path || '',
+      changed_file_count: changedFiles.length,
+      has_patch: hasPatch,
+      pr_url: prUrl,
+      false_positive_pr_url: falsePositivePrUrl,
+    } : undefined,
   };
 }
 
@@ -861,6 +871,11 @@ function artifactChangedFiles(artifact) {
     relative_path: file.relativePath || file.relative_path || '',
     status: file.status || '',
   })).filter((file) => file.path || file.relative_path);
+}
+
+function artifactHasPatch(artifact) {
+  const directory = artifact?.directory || artifact?.path || '';
+  return Boolean(directory && fs.existsSync(path.join(directory, 'files', 'patch.diff')));
 }
 
 function outputLooksFalsePositive(parsed) {
@@ -961,7 +976,20 @@ function wpCodeboxOutcomeErrorMessage(explicit) {
 }
 
 function taskOutcomeSucceeded(outcome) {
-  return ['fix_artifact', 'false_positive_artifact', 'noop_artifact', 'unable_to_remediate', 'fix_pr', 'false_positive_pr'].includes(outcome?.kind);
+  if (['fix_artifact', 'false_positive_artifact', 'noop_artifact', 'fix_pr', 'false_positive_pr'].includes(outcome?.kind)) {
+    return true;
+  }
+  return outcome?.kind === 'unable_to_remediate' && hasJustifiedNoopOutcome(outcome);
+}
+
+function hasJustifiedNoopOutcome(outcome) {
+  return [
+    outcome?.justification,
+    outcome?.noop_reason,
+    outcome?.reason,
+    outcome?.remediation_summary,
+    outcome?.failure,
+  ].some((value) => typeof value === 'string' && value.trim());
 }
 
 function pullRequestUrls(value, urls = []) {

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -202,6 +202,28 @@ process.stdin.on('end', () => {
     }));
     process.exit(0);
   }
+  if (process.env.FIXTURE_NO_ACTIONABLE_GROUP === request.group_key) {
+    const artifactDirectory = path.join(root, 'no-actionable-' + request.sandbox_session_id);
+    fs.mkdirSync(artifactDirectory, { recursive: true });
+    fs.writeFileSync(path.join(artifactDirectory, 'artifact.txt'), 'fixture non-actionable artifact bytes\\n');
+    process.stdout.write(JSON.stringify({
+      success: true,
+      artifacts: {
+        id: 'artifact-no-actionable-' + request.sandbox_session_id,
+        directory: artifactDirectory,
+      },
+      metrics: {
+        duration_ms: 99,
+        peak_rss_bytes: 123456,
+        sample_count: 3,
+        child_process_count_peak: 2,
+        cpu_user_ms: 12,
+        cpu_system_ms: 4,
+        source: 'linux_procfs_process_tree',
+      },
+    }));
+    process.exit(0);
+  }
   if (request.group_key === 'docs-reference') {
     if (process.env.FIXTURE_EXPECT_INCREMENTAL_RUN) {
       const run = JSON.parse(fs.readFileSync(process.env.FIXTURE_EXPECT_INCREMENTAL_RUN, 'utf8'));
@@ -434,8 +456,9 @@ try {
       directory: path.join(root, 'zero-change-artifact'),
     },
   }, { id: 'artifact-zero-change', directory: path.join(root, 'zero-change-artifact') }, true);
-  assert.equal(zeroChangeOutcome.kind, 'unable_to_remediate');
-  assert.equal(taskOutcomeSucceeded(zeroChangeOutcome), true);
+  assert.equal(zeroChangeOutcome.kind, 'explicit_failure');
+  assert.equal(zeroChangeOutcome.non_actionable, true);
+  assert.equal(taskOutcomeSucceeded(zeroChangeOutcome), false);
   assert.deepEqual(zeroChangeOutcome.finding_ids, ['finding-doc-001']);
 
   const noopOutcome = taskOutcome(docsRequest, {
@@ -649,6 +672,25 @@ try {
   assert.equal(noopRecord.outcome.kind, 'noop_artifact');
   assertMetrics(noopRecord, { runnerMetrics: true });
   assert.equal(noopRecord.metrics.artifact_bytes, null);
+
+  const noActionableExecution = await executeAuditWpCodeboxFanout({
+    report,
+    wp_codebox_command: process.execPath,
+    wp_codebox_args: [fixtureCommand],
+    concurrency: 1,
+    env: { FIXTURE_NO_ACTIONABLE_GROUP: 'PHPCS Formatting/Auto Fix!' },
+  });
+  const noActionableRecord = noActionableExecution.records.find((record) => record.group_key === 'PHPCS Formatting/Auto Fix!');
+  assert.equal(noActionableExecution.status, 'failed');
+  assert.equal(noActionableRecord.status, 'failed');
+  assert.equal(noActionableRecord.command.exit_code, 0);
+  assert.equal(noActionableRecord.outcome.kind, 'explicit_failure');
+  assert.equal(noActionableRecord.outcome.non_actionable, true);
+  assert.equal(noActionableRecord.outcome.evidence.changed_file_count, 0);
+  assert.match(noActionableRecord.outcome.failure, /without an actionable patch/);
+  assert.equal(noActionableRecord.outcome.failure_metadata.exit_code, 0);
+  assert.equal(noActionableRecord.outcome.failure_metadata.group_key, 'PHPCS Formatting/Auto Fix!');
+  assertMetrics(noActionableRecord, { runnerMetrics: true, artifactBytes: true });
 
   const timeoutRunsOutputPath = path.join(root, 'fanout-timeout-run.json');
   const timeoutArtifactsRoot = path.join(root, 'timeout-artifacts');


### PR DESCRIPTION
## Summary
- Require implicit WP Codebox artifact success to include both changed files and a patch.
- Fail runtime-success/no-actionable-patch fanout records as non-actionable with normalized failure evidence instead of completing as `unable_to_remediate`.
- Preserve explicit justified no-op completion through `noop_artifact` and justified `unable_to_remediate` outcomes.

Closes #801.

## Verification
- `node wordpress/tests/audit-wp-codebox-fanout-smoke.js`
- `npm --prefix wordpress run test:audit-wp-codebox-fanout`
- `npm --prefix wordpress run lint:js -- lib/audit-wp-codebox-fanout.js`
- `node --check wordpress/tests/audit-wp-codebox-fanout-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the fanout outcome contract change, added smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.