### PR TITLE
Use core sidecar helpers in non-WP runners

### DIFF
--- a/go/scripts/lint-runner.sh
+++ b/go/scripts/lint-runner.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 PROJECT_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
+# shellcheck source=/dev/null
+if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
+    source "$SIDECAR_WRITER_HELPER"
+fi
 
 write_lint_findings() {
     local gofmt_file="$1"
@@ -11,7 +16,15 @@ write_lint_findings() {
         return 0
     fi
 
-    python3 - "$PROJECT_PATH" "$gofmt_file" "$govet_file" "$HOMEBOY_LINT_FINDINGS_FILE" <<'PY'
+    if ! type homeboy_merge_lint_findings >/dev/null 2>&1; then
+        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write lint findings" >&2
+        return 1
+    fi
+
+    local findings_file
+    findings_file="$(mktemp)"
+
+    python3 - "$PROJECT_PATH" "$gofmt_file" "$govet_file" "$findings_file" <<'PY'
 import hashlib
 import json
 import os
@@ -90,6 +103,8 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(findings, handle, indent=2)
     handle.write("\n")
 PY
+    homeboy_merge_lint_findings "$findings_file"
+    rm -f "$findings_file"
 }
 
 GOFMT_FILE="$(mktemp)"

--- a/go/scripts/test-runner.sh
+++ b/go/scripts/test-runner.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 PROJECT_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
+# shellcheck source=/dev/null
+if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
+    source "$SIDECAR_WRITER_HELPER"
+fi
 OUTPUT_FILE="$(mktemp)"
 trap 'rm -f "$OUTPUT_FILE"' EXIT
 
@@ -11,7 +16,12 @@ TEST_EXIT=${PIPESTATUS[0]}
 set -e
 
 if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ]; then
-    python3 - "$PROJECT_PATH" "$OUTPUT_FILE" "$HOMEBOY_TEST_FAILURES_FILE" <<'PY'
+    if ! type homeboy_merge_test_failures >/dev/null 2>&1; then
+        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write test failures" >&2
+        exit 1
+    fi
+    TEST_FAILURES_TMP="$(mktemp)"
+    python3 - "$PROJECT_PATH" "$OUTPUT_FILE" "$TEST_FAILURES_TMP" <<'PY'
 import hashlib
 import json
 import os
@@ -81,6 +91,8 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(failures, handle, indent=2)
     handle.write("\n")
 PY
+    homeboy_merge_test_failures "$TEST_FAILURES_TMP"
+    rm -f "$TEST_FAILURES_TMP"
 fi
 
 exit "$TEST_EXIT"

--- a/nodejs/scripts/lint/lint-runner.sh
+++ b/nodejs/scripts/lint/lint-runner.sh
@@ -28,9 +28,14 @@ source "$BASH_PREFLIGHT_HELPER"
 homeboy_require_bash_version 4
 
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
+# shellcheck source=/dev/null
+if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
+    source "$SIDECAR_WRITER_HELPER"
+fi
 # shellcheck source=../lib/node-helpers.sh
 source "${SCRIPT_DIR}/../lib/node-helpers.sh"
 homeboy_require_package_json
@@ -48,6 +53,11 @@ fi
 
 FIX_MODE="${HOMEBOY_FIX_ONLY:-0}"
 FINDINGS_FILE="${HOMEBOY_LINT_FINDINGS_FILE:-${PROJECT_PATH}/.node-lint-findings.json}"
+export HOMEBOY_LINT_FINDINGS_FILE="$FINDINGS_FILE"
+if ! type homeboy_merge_lint_findings >/dev/null 2>&1; then
+    echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write lint findings" >&2
+    exit 1
+fi
 
 # Detect if eslint is available locally (vendored in node_modules) — that's
 # our preferred runner because we can ask for JSON output.
@@ -75,7 +85,7 @@ if [ -n "${HOMEBOY_NODE_LINT_COMMAND:-}" ]; then
         else
             FAILED_STEP="No typecheck script defined"
             FAILURE_OUTPUT="CI job requested typecheck, but package.json does not define scripts.typecheck. Set HOMEBOY_NODE_LINT_COMMAND to a project-specific command or add scripts.typecheck."
-            echo "[]" > "$FINDINGS_FILE"
+            homeboy_write_lint_findings
             exit 1
         fi
     else
@@ -99,7 +109,7 @@ elif [ $HAS_ESLINT_CONFIG -eq 1 ]; then
         # clear message rather than silently npx-installing it.
         FAILED_STEP="eslint config found but eslint not installed"
         FAILURE_OUTPUT="Run: npm i -D eslint (or your package manager equivalent) in ${PROJECT_PATH}"
-        echo "[]" > "$FINDINGS_FILE"
+        homeboy_write_lint_findings
         exit 1
     fi
 else
@@ -108,7 +118,7 @@ else
     echo "⚠ No lint surface detected (no scripts.lint, no eslint config)."
     echo "  Skipping lint — emitting empty findings."
     echo ""
-    echo "[]" > "$FINDINGS_FILE"
+    homeboy_write_lint_findings
     exit 0
 fi
 
@@ -148,7 +158,8 @@ if [ $USE_ESLINT_JSON -eq 1 ] && [ -s "$OUTPUT_FILE" ]; then
     # only if HOMEBOY_LINT_INCLUDE_WARNINGS=1 (matches Rust extension's
     # ratchet-friendly default).
     INCLUDE_WARNINGS="${HOMEBOY_LINT_INCLUDE_WARNINGS:-0}"
-    node - "$OUTPUT_FILE" "$FINDINGS_FILE" "$INCLUDE_WARNINGS" "$PROJECT_PATH" <<'NODEJS'
+    FINDINGS_TMP="$(mktemp)"
+    node - "$OUTPUT_FILE" "$FINDINGS_TMP" "$INCLUDE_WARNINGS" "$PROJECT_PATH" <<'NODEJS'
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -229,9 +240,11 @@ for (const file of report) {
 
 fs.writeFileSync(outputFile, JSON.stringify(findings, null, 2));
 NODEJS
+    homeboy_merge_lint_findings "$FINDINGS_TMP"
+    rm -f "$FINDINGS_TMP"
 else
     # Unknown runner output — emit empty findings, rely on exit code.
-    echo "[]" > "$FINDINGS_FILE"
+    homeboy_write_lint_findings
 fi
 
 rm -f "$OUTPUT_FILE"

--- a/nodejs/scripts/lint/nodejs-lint-findings-sidecar-smoke.sh
+++ b/nodejs/scripts/lint/nodejs-lint-findings-sidecar-smoke.sh
@@ -3,9 +3,16 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_DIR}/../.." && pwd)/homeboy}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
 RUNNER="$SCRIPT_DIR/lint-runner.sh"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
+
+if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
+    echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
+    exit 1
+fi
 
 PROJECT_PATH="$TMPDIR/project"
 FINDINGS_FILE="$TMPDIR/lint-findings.json"
@@ -27,6 +34,7 @@ set +e
 HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
 HOMEBOY_COMPONENT_PATH="$PROJECT_PATH" \
 HOMEBOY_COMPONENT_ID="node-lint-sidecar-smoke" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
 HOMEBOY_LINT_FINDINGS_FILE="$FINDINGS_FILE" \
     bash "$RUNNER" >"$OUTPUT_FILE" 2>&1
 status=$?

--- a/nodejs/scripts/lint/typecheck-ci-command-smoke.sh
+++ b/nodejs/scripts/lint/typecheck-ci-command-smoke.sh
@@ -3,8 +3,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
+
+if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
+    echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
+    exit 1
+fi
 
 PROJECT="${TMPDIR}/project"
 mkdir -p "$PROJECT"
@@ -20,6 +27,7 @@ JSON
 
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_PATH="$PROJECT" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
 HOMEBOY_NODE_LINT_COMMAND="__homeboy_typecheck" \
     bash "${EXTENSION_PATH}/scripts/lint/lint-runner.sh" > "${TMPDIR}/typecheck.out"
 

--- a/nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh
+++ b/nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh
@@ -3,9 +3,16 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_DIR}/../.." && pwd)/homeboy}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
 
 TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-nx-vitest.XXXXXX")"
 trap 'rm -rf "$TMPDIR"' EXIT
+
+if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
+    echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
+    exit 1
+fi
 
 PROJECT_DIR="${TMPDIR}/project"
 mkdir -p "$PROJECT_DIR"
@@ -61,6 +68,7 @@ HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
 HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
 HOMEBOY_COMPONENT_ID="node-nx-vitest-smoke" \
 HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="${TMPDIR}/write-results.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
 HOMEBOY_TEST_RESULTS_FILE="${TMPDIR}/test-results.json" \
 HOMEBOY_TEST_FAILURES_FILE="${TMPDIR}/test-failures.json" \
 bash "${SCRIPT_DIR}/test-runner.sh" > "${TMPDIR}/runner.out" 2>&1
@@ -85,24 +93,22 @@ assert.equal(results.skipped, 0);
 assert.equal(results.partial, 'vitest-timeout');
 
 const failures = JSON.parse(fs.readFileSync(process.argv[3], 'utf8'));
-assert.equal(failures.total, 1);
-assert.equal(failures.passed, 0);
-assert.equal(failures.failures.length, 1);
+assert.equal(failures.length, 1);
 assert.equal(
-  failures.failures[0].test_name,
+  failures[0].test_name,
   'Test WP version detection > detects WP trunk at runtime'
 );
-assert.equal(failures.failures[0].test_file, 'src/test/version-detect.spec.ts');
-assert.equal(failures.failures[0].error_type, 'vitest_timeout');
-assert.equal(failures.failures[0].test_id, failures.failures[0].test_name);
-assert.equal(failures.failures[0].file, failures.failures[0].test_file);
-assert.equal(failures.failures[0].failure_type, failures.failures[0].error_type);
-assert.equal(failures.failures[0].line, 0);
-assert.equal(failures.failures[0].stderr_excerpt, '');
-assert.match(failures.failures[0].fingerprint, /^[a-f0-9]{64}$/);
-assert.match(failures.failures[0].stdout_excerpt, /FAIL src\/test\/version-detect\.spec\.ts/);
-assert.match(failures.failures[0].message, /Test timed out in 30000ms/);
-assert.match(failures.failures[0].message, /Nx task: playground-wordpress:test:vite/);
+assert.equal(failures[0].test_file, 'src/test/version-detect.spec.ts');
+assert.equal(failures[0].error_type, 'vitest_timeout');
+assert.equal(failures[0].test_id, failures[0].test_name);
+assert.equal(failures[0].file, failures[0].test_file);
+assert.equal(failures[0].failure_type, failures[0].error_type);
+assert.equal(failures[0].line, 0);
+assert.equal(failures[0].stderr_excerpt, '');
+assert.match(failures[0].fingerprint, /^[a-f0-9]{64}$/);
+assert.match(failures[0].stdout_excerpt, /FAIL src\/test\/version-detect\.spec\.ts/);
+assert.match(failures[0].message, /Test timed out in 30000ms/);
+assert.match(failures[0].message, /Nx task: playground-wordpress:test:vite/);
 JS
 
 if grep -q 'unknown-runner' "${TMPDIR}/test-results.json"; then

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -34,9 +34,14 @@ source "$BASH_PREFLIGHT_HELPER"
 homeboy_require_bash_version 4
 
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
+# shellcheck source=/dev/null
+if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
+    source "$SIDECAR_WRITER_HELPER"
+fi
 # shellcheck source=../lib/node-helpers.sh
 source "${SCRIPT_DIR}/../lib/node-helpers.sh"
 homeboy_require_package_json
@@ -190,42 +195,39 @@ extract_vitest_failure_line() {
 write_node_failure_json() {
     [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] || return 0
     [ -n "$FAILED_TEST_NAME" ] || return 0
+    if ! type homeboy_append_test_failure >/dev/null 2>&1; then
+        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write test failures" >&2
+        return 1
+    fi
 
-    HOMEBOY_NODE_TEST_OUTPUT="$OUTPUT" node - "$HOMEBOY_TEST_FAILURES_FILE" "$FAILED_TEST_NAME" "$FAILED_TEST_FILE" "$FAILED_ERROR_TYPE" "$FAILED_MESSAGE" "$TOTAL" "$PASSED" <<'JS'
+    FAILURE_JSON="$(HOMEBOY_NODE_TEST_OUTPUT="$OUTPUT" node - "$FAILED_TEST_NAME" "$FAILED_TEST_FILE" "$FAILED_ERROR_TYPE" "$FAILED_MESSAGE" <<'JS'
 const crypto = require('node:crypto');
-const fs = require('node:fs');
 
-const [file, testName, testFile, errorType, message, total, passed] = process.argv.slice(2);
-const parsedTotal = Number.parseInt(total || '0', 10) || 0;
-const parsedPassed = Number.parseInt(passed || '0', 10) || 0;
+const [testName, testFile, errorType, message] = process.argv.slice(2);
 const stdout = process.env.HOMEBOY_NODE_TEST_OUTPUT || '';
 const fingerprintInput = [testName, testFile, errorType, message].join('\0');
 const fingerprint = crypto.createHash('sha256').update(fingerprintInput).digest('hex');
 const stdoutExcerpt = stdout.split(/\r?\n/).slice(-40).join('\n');
 
-fs.writeFileSync(file, JSON.stringify({
-  total: parsedTotal,
-  passed: parsedPassed,
-  failures: [
-    {
-      test_name: testName,
-      test_file: testFile,
-      error_type: errorType,
-      test_id: testName,
-      suite: '',
-      file: testFile,
-      line: 0,
-      message,
-      failure_type: errorType,
-      fingerprint,
-      stdout_excerpt: stdoutExcerpt,
-      stderr_excerpt: '',
-      source_file: testFile,
-      source_line: 0
-    }
-  ]
-}, null, 2));
+console.log(JSON.stringify({
+  test_name: testName,
+  test_file: testFile,
+  error_type: errorType,
+  test_id: testName,
+  suite: '',
+  file: testFile,
+  line: 0,
+  message,
+  failure_type: errorType,
+  fingerprint,
+  stdout_excerpt: stdoutExcerpt,
+  stderr_excerpt: '',
+  source_file: testFile,
+  source_line: 0
+}));
 JS
+)"
+    homeboy_append_test_failure "$FAILURE_JSON"
 }
 
 # Vitest summary lines look like:

--- a/rust/scripts/lint-fix-results-smoke.sh
+++ b/rust/scripts/lint-fix-results-smoke.sh
@@ -5,8 +5,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
+
+if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
+    echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
+    exit 1
+fi
 
 PROJECT_DIR="${TMP_DIR}/project"
 FAKE_BIN="${TMP_DIR}/bin"
@@ -58,6 +65,7 @@ PATH="${FAKE_BIN}:${PATH}" \
 HOMEBOY_COMPONENT_PATH="${PROJECT_DIR}" \
 HOMEBOY_EXTENSION_PATH="${ROOT_DIR}/rust" \
 HOMEBOY_RUNTIME_RUNNER_STEPS="${ROOT_DIR}/wordpress/scripts/lib/runner-steps.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
 HOMEBOY_FIX_ONLY=1 \
 HOMEBOY_FIX_RESULTS_FILE="${RESULTS_FILE}" \
     bash "${SCRIPT_DIR}/lint-runner.sh" >/dev/null

--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -25,6 +25,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/lib/resolve-context.sh}"
 RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/lib/runner-steps.sh}"
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
@@ -37,6 +38,10 @@ if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
 else
     FAILED_STEP=""
     FAILURE_OUTPUT=""
+fi
+# shellcheck source=/dev/null
+if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
+    source "$SIDECAR_WRITER_HELPER"
 fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -100,7 +105,19 @@ print(json.dumps(results))
 
 write_fix_results_sidecar() {
     if [ "${HOMEBOY_FIX_ONLY:-}" = "1" ] && [ -n "${HOMEBOY_FIX_RESULTS_FILE:-}" ]; then
-        printf '%s\n' "$FIX_RESULTS_JSON" > "${HOMEBOY_FIX_RESULTS_FILE}"
+        if ! type homeboy_write_fix_results >/dev/null 2>&1; then
+            echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write fix results" >&2
+            return 1
+        fi
+        HOMEBOY_FIX_RESULTS_JSON="$FIX_RESULTS_JSON" python3 - <<'PY' | while IFS= read -r result; do
+import json
+import os
+
+for item in json.loads(os.environ.get("HOMEBOY_FIX_RESULTS_JSON", "[]")):
+    print(json.dumps(item, separators=(",", ":")))
+PY
+            homeboy_append_fix_result "$result"
+        done
     fi
 }
 
@@ -112,7 +129,15 @@ write_lint_findings_from_output() {
         return 0
     fi
 
-    python3 - "$PROJECT_PATH" "$tool" "$output_file" "$HOMEBOY_LINT_FINDINGS_FILE" <<'PY'
+    if ! type homeboy_merge_lint_findings >/dev/null 2>&1; then
+        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write lint findings" >&2
+        return 1
+    fi
+
+    local findings_file
+    findings_file="$(mktemp)"
+
+    python3 - "$PROJECT_PATH" "$tool" "$output_file" "$findings_file" <<'PY'
 import hashlib
 import json
 import os
@@ -205,6 +230,8 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(findings, handle, indent=2)
     handle.write("\n")
 PY
+    homeboy_merge_lint_findings "$findings_file"
+    rm -f "$findings_file"
 }
 
 trap write_fix_results_sidecar EXIT

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -20,6 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/lib/resolve-context.sh}"
 RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/lib/runner-steps.sh}"
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
@@ -33,6 +34,10 @@ else
     FAILED_STEP=""
     FAILURE_OUTPUT=""
     FAILURE_REPLAY_MODE="full"
+fi
+# shellcheck source=/dev/null
+if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
+    source "$SIDECAR_WRITER_HELPER"
 fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -300,7 +305,12 @@ else
     fi
 
     if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ]; then
-        python3 - "$PROJECT_PATH" "$TEST_TMPFILE" "$HOMEBOY_TEST_FAILURES_FILE" <<'PY'
+        if ! type homeboy_merge_test_failures >/dev/null 2>&1; then
+            echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write test failures" >&2
+            exit 1
+        fi
+        TEST_FAILURES_TMP="$(mktemp)"
+        python3 - "$PROJECT_PATH" "$TEST_TMPFILE" "$TEST_FAILURES_TMP" <<'PY'
 import hashlib
 import json
 import os
@@ -357,6 +367,8 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(failures, handle, indent=2)
     handle.write("\n")
 PY
+        homeboy_merge_test_failures "$TEST_FAILURES_TMP"
+        rm -f "$TEST_FAILURES_TMP"
     fi
 
     FAILED_STEP="cargo test"

--- a/swift/scripts/lint-runner.sh
+++ b/swift/scripts/lint-runner.sh
@@ -3,9 +3,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/lib/resolve-context.sh}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
+# shellcheck source=/dev/null
+if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
+    source "$SIDECAR_WRITER_HELPER"
+fi
 
 echo "Running Swift lint for: $(basename "$COMPONENT_PATH")"
 
@@ -16,7 +21,15 @@ write_swiftlint_findings() {
         return 0
     fi
 
-    python3 - "$COMPONENT_PATH" "$input_file" "$HOMEBOY_LINT_FINDINGS_FILE" <<'PY'
+    if ! type homeboy_merge_lint_findings >/dev/null 2>&1; then
+        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write lint findings" >&2
+        return 1
+    fi
+
+    local findings_file
+    findings_file="$(mktemp)"
+
+    python3 - "$COMPONENT_PATH" "$input_file" "$findings_file" <<'PY'
 import hashlib
 import json
 import os
@@ -75,6 +88,8 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(findings, handle, indent=2)
     handle.write("\n")
 PY
+    homeboy_merge_lint_findings "$findings_file"
+    rm -f "$findings_file"
 }
 
 if command -v swiftlint >/dev/null 2>&1; then

--- a/swift/scripts/test-runner.sh
+++ b/swift/scripts/test-runner.sh
@@ -3,9 +3,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/lib/resolve-context.sh}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
+# shellcheck source=/dev/null
+if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
+    source "$SIDECAR_WRITER_HELPER"
+fi
 
 # Debug environment variables (only shown when HOMEBOY_DEBUG=1)
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -66,7 +71,12 @@ if [ "$TEST_TYPE" = "xcodebuild" ]; then
     fi
 
     if [ "$XCODE_EXIT" -ne 0 ] && [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ]; then
-        python3 - "$COMPONENT_PATH" "$XCODE_OUTPUT" "$HOMEBOY_TEST_FAILURES_FILE" <<'PY'
+        if ! type homeboy_merge_test_failures >/dev/null 2>&1; then
+            echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write test failures" >&2
+            exit 1
+        fi
+        TEST_FAILURES_TMP="$(mktemp)"
+        python3 - "$COMPONENT_PATH" "$XCODE_OUTPUT" "$TEST_FAILURES_TMP" <<'PY'
 import hashlib
 import json
 import re
@@ -116,6 +126,8 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(failures, handle, indent=2)
     handle.write("\n")
 PY
+        homeboy_merge_test_failures "$TEST_FAILURES_TMP"
+        rm -f "$TEST_FAILURES_TMP"
     fi
     exit "$XCODE_EXIT"
 else
@@ -156,7 +168,12 @@ else
 
     if [ $TESTS_FAILED -gt 0 ]; then
         if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ]; then
-            python3 - "$FAILURES_FILE" "$HOMEBOY_TEST_FAILURES_FILE" <<'PY'
+            if ! type homeboy_merge_test_failures >/dev/null 2>&1; then
+                echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write test failures" >&2
+                exit 1
+            fi
+            TEST_FAILURES_TMP="$(mktemp)"
+            python3 - "$FAILURES_FILE" "$TEST_FAILURES_TMP" <<'PY'
 import hashlib
 import json
 import sys
@@ -190,6 +207,8 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump(failures, handle, indent=2)
     handle.write("\n")
 PY
+            homeboy_merge_test_failures "$TEST_FAILURES_TMP"
+            rm -f "$TEST_FAILURES_TMP"
         fi
         while IFS=$'\t' read -r _ output_path; do
             [ -n "$output_path" ] && rm -f "$output_path"

--- a/tests/cross-extension-sidecar-normalization-smoke.sh
+++ b/tests/cross-extension-sidecar-normalization-smoke.sh
@@ -2,8 +2,15 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT}/.." && pwd)/homeboy}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
+    echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
+    exit 1
+fi
 
 assert_json_fields() {
     local file="$1"
@@ -39,6 +46,7 @@ EOF
 GO_LINT_FINDINGS="$TMP_DIR/go-lint-findings.json"
 set +e
 HOMEBOY_COMPONENT_PATH="$GO_PROJECT" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
 HOMEBOY_LINT_FINDINGS_FILE="$GO_LINT_FINDINGS" \
 bash "$ROOT/go/scripts/lint-runner.sh" >/dev/null 2>&1
 GO_LINT_EXIT=$?
@@ -55,6 +63,7 @@ EOF
 GO_TEST_FAILURES="$TMP_DIR/go-test-failures.json"
 set +e
 HOMEBOY_COMPONENT_PATH="$GO_PROJECT" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
 HOMEBOY_TEST_FAILURES_FILE="$GO_TEST_FAILURES" \
 bash "$ROOT/go/scripts/test-runner.sh" >/dev/null 2>&1
 GO_TEST_EXIT=$?
@@ -97,6 +106,7 @@ PATH="$RUST_BIN:$PATH" \
 HOMEBOY_EXTENSION_PATH="$ROOT/rust" \
 HOMEBOY_COMPONENT_PATH="$RUST_PROJECT" \
 HOMEBOY_RUNTIME_RUNNER_STEPS="$ROOT/wordpress/scripts/lib/runner-steps.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
 HOMEBOY_LINT_FINDINGS_FILE="$RUST_LINT_FINDINGS" \
 bash "$ROOT/rust/scripts/lint-runner.sh" >/dev/null 2>&1
 RUST_LINT_EXIT=$?
@@ -110,6 +120,7 @@ PATH="$RUST_BIN:$PATH" \
 HOMEBOY_EXTENSION_PATH="$ROOT/rust" \
 HOMEBOY_COMPONENT_PATH="$RUST_PROJECT" \
 HOMEBOY_RUNTIME_RUNNER_STEPS="$ROOT/wordpress/scripts/lib/runner-steps.sh" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
 HOMEBOY_SKIP_LINT=1 \
 HOMEBOY_TEST_FAILURES_FILE="$RUST_TEST_FAILURES" \
 bash "$ROOT/rust/scripts/test-runner.sh" >/dev/null 2>&1
@@ -141,6 +152,7 @@ set +e
 PATH="$SWIFT_BIN:$PATH" \
 HOMEBOY_EXTENSION_PATH="$ROOT/swift" \
 HOMEBOY_COMPONENT_PATH="$SWIFT_PROJECT" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
 HOMEBOY_LINT_FINDINGS_FILE="$SWIFT_LINT_FINDINGS" \
 bash "$ROOT/swift/scripts/lint-runner.sh" >/dev/null 2>&1
 SWIFT_LINT_EXIT=$?
@@ -153,6 +165,7 @@ set +e
 PATH="$SWIFT_BIN:$PATH" \
 HOMEBOY_EXTENSION_PATH="$ROOT/swift" \
 HOMEBOY_COMPONENT_PATH="$SWIFT_PROJECT" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
 HOMEBOY_TEST_FAILURES_FILE="$SWIFT_TEST_FAILURES" \
 bash "$ROOT/swift/scripts/test-runner.sh" >/dev/null 2>&1
 SWIFT_TEST_EXIT=$?

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/failure-trap.sh}"
 WRITE_TEST_RESULTS_HELPER="${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/write-test-results.sh}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
 BASH_PREFLIGHT_HELPERS=(
     "${ROOT_DIR}/nodejs/scripts/lib/bash-preflight.sh"
     "${ROOT_DIR}/rust/scripts/lib/bash-preflight.sh"
@@ -43,6 +44,8 @@ assert_not_contains() {
 
 assert_file "$FAILURE_TRAP_HELPER"
 assert_file "$WRITE_TEST_RESULTS_HELPER"
+assert_file "$SIDECAR_WRITER_HELPER"
+bash -c 'source "$1"; type homeboy_merge_lint_findings >/dev/null; type homeboy_merge_test_failures >/dev/null; type homeboy_write_fix_results >/dev/null' _ "$SIDECAR_WRITER_HELPER"
 for bash_preflight_helper in "${BASH_PREFLIGHT_HELPERS[@]}"; do
     assert_file "$bash_preflight_helper"
     bash -c 'source "$1"; homeboy_require_bash_version 4' _ "$bash_preflight_helper"


### PR DESCRIPTION
## Summary
- Migrates Go, Rust, Swift, and Node sidecar writes to Homeboy core's `HOMEBOY_RUNTIME_SIDECAR_WRITER` helper contract.
- Keeps extension-local parsing for gofmt/go vet, cargo fmt/clippy/test, SwiftLint/XCTest/script tests, ESLint, and Node test timeout failures.
- Updates sidecar smokes to inject the core helper and preserve cross-extension normalized sidecar arrays.

Refs #791.

## Scope
- Covered: non-WordPress Go, Rust, Swift, and Node runners for lint findings, test failures, and Rust fix results.
- Deferred: WordPress runners, to avoid mixing with the recent WordPress-heavy PRs #880, #881, and #882.

## Verification
- `bash -n go/scripts/lint-runner.sh go/scripts/test-runner.sh rust/scripts/lint-runner.sh rust/scripts/test-runner.sh rust/scripts/lint-fix-results-smoke.sh swift/scripts/lint-runner.sh swift/scripts/test-runner.sh nodejs/scripts/lint/lint-runner.sh nodejs/scripts/lint/nodejs-lint-findings-sidecar-smoke.sh nodejs/scripts/lint/typecheck-ci-command-smoke.sh nodejs/scripts/test/test-runner.sh nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh tests/runtime-helpers-smoke.sh tests/cross-extension-sidecar-normalization-smoke.sh`
- `bash tests/runtime-helpers-smoke.sh && bash tests/cross-extension-sidecar-normalization-smoke.sh && node tests/structured-sidecars-smoke.mjs`
- `bash rust/scripts/lint-fix-results-smoke.sh && bash rust/scripts/parse-test-results-smoke.sh && bash swift/tests/lint-runner-smoke.sh && bash swift/tests/script-runner-smoke.sh`
- `bash nodejs/scripts/lint/nodejs-lint-findings-sidecar-smoke.sh && bash nodejs/scripts/lint/typecheck-ci-command-smoke.sh && bash nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh && bash nodejs/scripts/test/nodejs-targeted-script-smoke.sh && bash nodejs/scripts/test/nodejs-changed-scope-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Migrated non-WordPress sidecar writer calls to the Homeboy core runtime helper contract, updated focused smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.