### PR TITLE
Extract generic project script helpers

### DIFF
--- a/nodejs/scripts/build/build-runner.sh
+++ b/nodejs/scripts/build/build-runner.sh
@@ -58,18 +58,18 @@ elif [ -f "${PROJECT_PATH}/nx.json" ]; then
     # the project author choose the exact `nx ...` invocation), else
     # default to `nx run-many`.
     if homeboy_has_npm_script "build"; then
-        BUILD_CMD="$PKG_RUN build"
+        BUILD_CMD="$(homeboy_project_run_script_command build)"
     else
-        BUILD_CMD="$PKG_EXEC nx run-many --target=build --all"
+        BUILD_CMD="$(homeboy_project_exec_command nx run-many --target=build --all)"
     fi
 elif [ -f "${PROJECT_PATH}/turbo.json" ]; then
     if homeboy_has_npm_script "build"; then
-        BUILD_CMD="$PKG_RUN build"
+        BUILD_CMD="$(homeboy_project_run_script_command build)"
     else
-        BUILD_CMD="$PKG_EXEC turbo run build"
+        BUILD_CMD="$(homeboy_project_exec_command turbo run build)"
     fi
 elif homeboy_has_npm_script "build"; then
-    BUILD_CMD="$PKG_RUN build"
+    BUILD_CMD="$(homeboy_project_run_script_command build)"
 else
     FAILED_STEP="No build defined"
     FAILURE_OUTPUT="No scripts.build in package.json and no nx.json/turbo.json detected. Set HOMEBOY_NODE_BUILD_COMMAND or add a scripts.build entry."

--- a/nodejs/scripts/lib/node-helpers.sh
+++ b/nodejs/scripts/lib/node-helpers.sh
@@ -1,78 +1,41 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_SCRIPTS_HELPER="${HOMEBOY_RUNTIME_PROJECT_SCRIPTS:-${SCRIPT_DIR}/../../../scripts/lib/project-scripts.sh}"
+# shellcheck source=/dev/null
+source "$PROJECT_SCRIPTS_HELPER"
+
 # Verify the resolved component is actually a Node.js project.
 # Walks up to find package.json (so monorepo subpackages also pass).
 homeboy_require_package_json() {
-    local _dir="${1:-$PROJECT_PATH}"
-    while [ "$_dir" != "/" ] && [ "$_dir" != "." ]; do
-        if [ -f "$_dir/package.json" ]; then
-            return 0
-        fi
-        _dir="$(dirname "$_dir")"
-    done
-    echo "Error: No package.json found at or above ${PROJECT_PATH}" >&2
-    echo "Not a Node.js project — cannot run." >&2
-    return 1
+    homeboy_project_init --ecosystem node --path "${1:-$PROJECT_PATH}"
 }
 
 # Detect which package manager the project uses, in priority order:
 # pnpm-lock.yaml → pnpm; yarn.lock → yarn; package-lock.json → npm; default npm.
 # Sets PKG_MANAGER and PKG_RUN ("pnpm run", "yarn", "npm run", "npx").
 homeboy_detect_package_manager() {
-    local _dir="${1:-$PROJECT_PATH}"
-    if [ -f "$_dir/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
-        PKG_MANAGER="pnpm"
-        PKG_RUN="pnpm run"
-        PKG_EXEC="pnpm exec"
-    elif [ -f "$_dir/yarn.lock" ] && command -v yarn >/dev/null 2>&1; then
-        PKG_MANAGER="yarn"
-        PKG_RUN="yarn"
-        PKG_EXEC="yarn"
-    else
-        PKG_MANAGER="npm"
-        PKG_RUN="npm run"
-        PKG_EXEC="npx"
+    if [ -z "${HOMEBOY_PROJECT_ECOSYSTEM:-}" ]; then
+        homeboy_project_init --ecosystem node --path "${1:-$PROJECT_PATH}"
     fi
-
-    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
-        echo "DEBUG: Package manager: $PKG_MANAGER" >&2
-    fi
+    PKG_MANAGER="$HOMEBOY_PROJECT_PACKAGE_MANAGER"
+    PKG_RUN="$HOMEBOY_PROJECT_RUN_CMD"
+    PKG_EXEC="$HOMEBOY_PROJECT_EXEC_CMD"
 }
 
 # Prepare dependencies for clean runner snapshots. Lab offload intentionally
 # excludes node_modules, so package scripts need a deterministic install step.
 homeboy_ensure_node_dependencies() {
-    local _dir="${1:-$PROJECT_PATH}"
-    if [ -d "$_dir/node_modules" ]; then
-        return 0
-    fi
-
-    echo "Installing Node.js dependencies..."
-    case "$PKG_MANAGER" in
-        pnpm)
-            (cd "$_dir" && pnpm install --frozen-lockfile)
-            ;;
-        yarn)
-            (cd "$_dir" && yarn install --frozen-lockfile)
-            ;;
-        npm|*)
-            if [ -f "$_dir/package-lock.json" ]; then
-                (cd "$_dir" && npm ci)
-            else
-                (cd "$_dir" && npm install)
-            fi
-            ;;
-    esac
+    [ -n "${1:-}" ] && homeboy_project_init --ecosystem node --path "$1"
+    homeboy_project_ensure_dependencies
 }
 
 # Check whether a script name is defined in package.json.
 # Returns 0 if defined, 1 otherwise. Uses node so we don't depend on jq.
 homeboy_has_npm_script() {
     local _script="$1"
-    local _pkg="${2:-$PROJECT_PATH/package.json}"
-    [ -f "$_pkg" ] || return 1
-    node -e "
-        const pkg = require('$_pkg');
-        process.exit(pkg.scripts && pkg.scripts['$_script'] ? 0 : 1);
-    " 2>/dev/null
+    if [ -n "${2:-}" ]; then
+        HOMEBOY_PROJECT_SCRIPT_FILE="$2"
+    fi
+    homeboy_project_has_script "$_script"
 }

--- a/nodejs/scripts/lint/lint-runner.sh
+++ b/nodejs/scripts/lint/lint-runner.sh
@@ -81,7 +81,7 @@ USE_ESLINT_JSON=0
 if [ -n "${HOMEBOY_NODE_LINT_COMMAND:-}" ]; then
     if [ "$HOMEBOY_NODE_LINT_COMMAND" = "__homeboy_typecheck" ]; then
         if homeboy_has_npm_script "typecheck"; then
-            LINT_CMD="$PKG_RUN typecheck"
+            LINT_CMD="$(homeboy_project_run_script_command typecheck)"
         else
             FAILED_STEP="No typecheck script defined"
             FAILURE_OUTPUT="CI job requested typecheck, but package.json does not define scripts.typecheck. Set HOMEBOY_NODE_LINT_COMMAND to a project-specific command or add scripts.typecheck."
@@ -92,9 +92,9 @@ if [ -n "${HOMEBOY_NODE_LINT_COMMAND:-}" ]; then
         LINT_CMD="$HOMEBOY_NODE_LINT_COMMAND"
     fi
 elif [ "$FIX_MODE" = "1" ] && homeboy_has_npm_script "lint:fix"; then
-    LINT_CMD="$PKG_RUN lint:fix"
+    LINT_CMD="$(homeboy_project_run_script_command lint:fix)"
 elif homeboy_has_npm_script "lint"; then
-    LINT_CMD="$PKG_RUN lint"
+    LINT_CMD="$(homeboy_project_run_script_command lint)"
     [ "$FIX_MODE" = "1" ] && LINT_CMD="$LINT_CMD -- --fix"
 elif [ $HAS_ESLINT_CONFIG -eq 1 ]; then
     if [ -n "$ESLINT_BIN" ]; then

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -79,7 +79,7 @@ homeboy_node_package_value() {
 
 homeboy_node_script_command() {
     local script_name="$1"
-    printf '%s' "${PKG_RUN} ${script_name} --"
+    printf '%s --' "$(homeboy_project_run_script_command "$script_name")"
 }
 
 homeboy_node_targeted_test_script() {
@@ -129,7 +129,7 @@ if [ -n "${HOMEBOY_NODE_TEST_COMMAND:-}" ]; then
 elif [ ${#RUNNER_ARGS[@]} -gt 0 ] && TARGETED_TEST_SCRIPT="$(homeboy_node_targeted_test_script)"; then
     TEST_CMD="$(homeboy_node_script_command "$TARGETED_TEST_SCRIPT")"
 elif homeboy_has_npm_script "test"; then
-    TEST_CMD="$PKG_RUN test"
+    TEST_CMD="$(homeboy_project_run_script_command test)"
 else
     # Node 18+ ships a built-in test runner. This is the right default
     # for tiny projects without an explicit script.

--- a/scripts/lib/project-scripts.sh
+++ b/scripts/lib/project-scripts.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+
+# Generic project script helpers for extension runners.
+#
+# Extensions select an ecosystem adapter with homeboy_project_init, then use the
+# project helpers instead of hand-rolling package-manager or script checks.
+
+homeboy_project_find_file_upward() {
+    local _dir="$1"
+    local _file="$2"
+    while [ "$_dir" != "/" ] && [ "$_dir" != "." ]; do
+        if [ -f "$_dir/$_file" ]; then
+            printf '%s\n' "$_dir"
+            return 0
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+    return 1
+}
+
+homeboy_project_init() {
+    local _ecosystem=""
+    local _dir="${PROJECT_PATH:-.}"
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --ecosystem)
+                _ecosystem="${2:-}"
+                shift 2
+                ;;
+            --path)
+                _dir="${2:-}"
+                shift 2
+                ;;
+            *)
+                echo "Error: Unknown homeboy_project_init argument: $1" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    case "$_ecosystem" in
+        node|nodejs)
+            homeboy_project_init_node "$_dir"
+            ;;
+        "")
+            echo "Error: homeboy_project_init requires --ecosystem" >&2
+            return 1
+            ;;
+        *)
+            echo "Error: Unsupported Homeboy project ecosystem: $_ecosystem" >&2
+            return 1
+            ;;
+    esac
+}
+
+homeboy_project_init_node() {
+    local _dir="$1"
+    local _root
+
+    if ! _root="$(homeboy_project_find_file_upward "$_dir" "package.json")"; then
+        echo "Error: No package.json found at or above ${_dir}" >&2
+        echo "Not a Node.js project -- cannot run." >&2
+        return 1
+    fi
+
+    HOMEBOY_PROJECT_ECOSYSTEM="node"
+    HOMEBOY_PROJECT_ROOT="$_root"
+    HOMEBOY_PROJECT_SCRIPT_FILE="${_root}/package.json"
+
+    if [ -f "$_root/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
+        HOMEBOY_PROJECT_PACKAGE_MANAGER="pnpm"
+        HOMEBOY_PROJECT_RUN_CMD="pnpm run"
+        HOMEBOY_PROJECT_EXEC_CMD="pnpm exec"
+    elif [ -f "$_root/yarn.lock" ] && command -v yarn >/dev/null 2>&1; then
+        HOMEBOY_PROJECT_PACKAGE_MANAGER="yarn"
+        HOMEBOY_PROJECT_RUN_CMD="yarn"
+        HOMEBOY_PROJECT_EXEC_CMD="yarn"
+    else
+        HOMEBOY_PROJECT_PACKAGE_MANAGER="npm"
+        HOMEBOY_PROJECT_RUN_CMD="npm run"
+        HOMEBOY_PROJECT_EXEC_CMD="npx"
+    fi
+
+    if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
+        echo "DEBUG: Project ecosystem: $HOMEBOY_PROJECT_ECOSYSTEM" >&2
+        echo "DEBUG: Project root: $HOMEBOY_PROJECT_ROOT" >&2
+        echo "DEBUG: Package manager: $HOMEBOY_PROJECT_PACKAGE_MANAGER" >&2
+    fi
+}
+
+homeboy_project_require_script_file() {
+    if [ -z "${HOMEBOY_PROJECT_SCRIPT_FILE:-}" ] || [ ! -f "$HOMEBOY_PROJECT_SCRIPT_FILE" ]; then
+        echo "Error: homeboy_project_init must be called before project script helpers" >&2
+        return 1
+    fi
+}
+
+homeboy_project_has_script() {
+    local _script="$1"
+    homeboy_project_require_script_file || return 1
+
+    case "${HOMEBOY_PROJECT_ECOSYSTEM:-}" in
+        node)
+            HOMEBOY_PROJECT_SCRIPT_NAME="$_script" \
+            HOMEBOY_PROJECT_PACKAGE_JSON="$HOMEBOY_PROJECT_SCRIPT_FILE" \
+                node -e '
+                    const pkg = require(process.env.HOMEBOY_PROJECT_PACKAGE_JSON);
+                    const script = process.env.HOMEBOY_PROJECT_SCRIPT_NAME;
+                    process.exit(pkg.scripts && pkg.scripts[script] ? 0 : 1);
+                ' 2>/dev/null
+            ;;
+        *)
+            echo "Error: Unsupported Homeboy project ecosystem: ${HOMEBOY_PROJECT_ECOSYSTEM:-}" >&2
+            return 1
+            ;;
+    esac
+}
+
+homeboy_project_run_script_command() {
+    local _script="$1"
+    if [ -z "${HOMEBOY_PROJECT_RUN_CMD:-}" ]; then
+        echo "Error: homeboy_project_init must be called before project script helpers" >&2
+        return 1
+    fi
+    printf '%s %s' "$HOMEBOY_PROJECT_RUN_CMD" "$_script"
+}
+
+homeboy_project_exec_command() {
+    local _binary="$1"
+    shift || true
+    if [ -z "${HOMEBOY_PROJECT_EXEC_CMD:-}" ]; then
+        echo "Error: homeboy_project_init must be called before project script helpers" >&2
+        return 1
+    fi
+    printf '%s %s' "$HOMEBOY_PROJECT_EXEC_CMD" "$_binary"
+    if [ $# -gt 0 ]; then
+        printf ' %s' "$@"
+    fi
+}
+
+homeboy_project_run_script() {
+    local _script="$1"
+    shift || true
+    homeboy_project_require_script_file || return 1
+    (cd "$HOMEBOY_PROJECT_ROOT" && $(homeboy_project_run_script_command "$_script") "$@")
+}
+
+homeboy_project_exec() {
+    local _binary="$1"
+    shift || true
+    if [ -z "${HOMEBOY_PROJECT_ROOT:-}" ]; then
+        echo "Error: homeboy_project_init must be called before project script helpers" >&2
+        return 1
+    fi
+    (cd "$HOMEBOY_PROJECT_ROOT" && $HOMEBOY_PROJECT_EXEC_CMD "$_binary" "$@")
+}
+
+homeboy_project_ensure_dependencies() {
+    if [ "${HOMEBOY_PROJECT_ECOSYSTEM:-}" != "node" ]; then
+        echo "Error: Dependency installation is not implemented for ecosystem: ${HOMEBOY_PROJECT_ECOSYSTEM:-}" >&2
+        return 1
+    fi
+
+    local _dir="${HOMEBOY_PROJECT_ROOT:-}"
+    if [ -z "$_dir" ]; then
+        echo "Error: homeboy_project_init must be called before dependency helpers" >&2
+        return 1
+    fi
+
+    if [ -d "$_dir/node_modules" ]; then
+        return 0
+    fi
+
+    echo "Installing Node.js dependencies..."
+    case "${HOMEBOY_PROJECT_PACKAGE_MANAGER:-npm}" in
+        pnpm)
+            (cd "$_dir" && pnpm install --frozen-lockfile)
+            ;;
+        yarn)
+            (cd "$_dir" && yarn install --frozen-lockfile)
+            ;;
+        npm|*)
+            if [ -f "$_dir/package-lock.json" ]; then
+                (cd "$_dir" && npm ci)
+            else
+                (cd "$_dir" && npm install)
+            fi
+            ;;
+    esac
+}

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -6,6 +6,7 @@ HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/failure-trap.sh}"
 WRITE_TEST_RESULTS_HELPER="${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/write-test-results.sh}"
 SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
+PROJECT_SCRIPTS_HELPER="${ROOT_DIR}/scripts/lib/project-scripts.sh"
 BASH_PREFLIGHT_HELPERS=(
     "${ROOT_DIR}/nodejs/scripts/lib/bash-preflight.sh"
     "${ROOT_DIR}/rust/scripts/lib/bash-preflight.sh"
@@ -45,7 +46,9 @@ assert_not_contains() {
 assert_file "$FAILURE_TRAP_HELPER"
 assert_file "$WRITE_TEST_RESULTS_HELPER"
 assert_file "$SIDECAR_WRITER_HELPER"
+assert_file "$PROJECT_SCRIPTS_HELPER"
 bash -c 'source "$1"; type homeboy_merge_lint_findings >/dev/null; type homeboy_merge_test_failures >/dev/null; type homeboy_write_fix_results >/dev/null' _ "$SIDECAR_WRITER_HELPER"
+bash -c 'source "$1"; type homeboy_project_init >/dev/null; type homeboy_project_has_script >/dev/null; type homeboy_project_run_script_command >/dev/null' _ "$PROJECT_SCRIPTS_HELPER"
 for bash_preflight_helper in "${BASH_PREFLIGHT_HELPERS[@]}"; do
     assert_file "$bash_preflight_helper"
     bash -c 'source "$1"; homeboy_require_bash_version 4' _ "$bash_preflight_helper"
@@ -122,6 +125,22 @@ mkdir -p "$NODE_PROJECT"
 cat > "$NODE_PROJECT/package.json" <<'EOF'
 {"name":"runtime-helper-smoke","scripts":{}}
 EOF
+
+PROJECT_HELPER_NODE_PROJECT="$TMP_DIR/project-helper-node"
+mkdir -p "$PROJECT_HELPER_NODE_PROJECT/subdir"
+cat > "$PROJECT_HELPER_NODE_PROJECT/package.json" <<'EOF'
+{"name":"project-helper-node","scripts":{"test":"node --test","lint:fix":"eslint . --fix"}}
+EOF
+bash -c '
+    source "$1"
+    PROJECT_PATH="$2/subdir"
+    homeboy_project_init --ecosystem node --path "$PROJECT_PATH"
+    [ "$HOMEBOY_PROJECT_ROOT" = "$2" ]
+    [ "$(homeboy_project_run_script_command test)" = "npm run test" ]
+    homeboy_project_has_script test
+    homeboy_project_has_script lint:fix
+    ! homeboy_project_has_script build
+' _ "$PROJECT_SCRIPTS_HELPER" "$PROJECT_HELPER_NODE_PROJECT"
 
 set +e
 HOMEBOY_RUNTIME_FAILURE_TRAP="$FAILURE_TRAP_HELPER" \


### PR DESCRIPTION
## Summary
- Adds a shared `scripts/lib/project-scripts.sh` helper with `homeboy_project_init`, `homeboy_project_has_script`, command builders, and dependency preparation behind an ecosystem dispatch API.
- Converts NodeJS helper functions into thin wrappers around the generic project-script API, then updates Node build/lint/test command resolution to use the generic command helpers.
- Covers the new helper surface in the runtime helper smoke test, including upward package root detection and script presence checks.

Closes #890.

## Verification
- `bash tests/runtime-helpers-smoke.sh`
- `bash nodejs/scripts/build/build-runner-shell-smoke.sh`
- `bash nodejs/scripts/test/nodejs-targeted-script-smoke.sh`
- `bash nodejs/scripts/lint/typecheck-ci-command-smoke.sh`
- `bash -n scripts/lib/project-scripts.sh nodejs/scripts/lib/node-helpers.sh nodejs/scripts/build/build-runner.sh nodejs/scripts/lint/lint-runner.sh nodejs/scripts/test/test-runner.sh tests/runtime-helpers-smoke.sh`

## Notes
- `shellcheck` was not available in the local environment (`command not found`), so syntax validation used `bash -n`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the helper extraction, updated NodeJS usage, added smoke coverage, and ran focused verification for Chris to review.