### PR TITLE
Add generic node trace bridge helpers

### DIFF
--- a/nodejs/docs/trace-helpers.md
+++ b/nodejs/docs/trace-helpers.md
@@ -14,7 +14,10 @@ const { pollHttp } = await import(`${helperDir}/probes.mjs`);
 ## Stable Helpers
 
 - `timeline.mjs` records timestamped events, assertions, artifacts, and writes
-  the final Homeboy trace JSON envelope.
+  the final Homeboy trace JSON envelope. `TraceRecorder#recordCheck()` maps a
+  boolean check to a pass/fail assertion, and `TraceRecorder#writeArtifact()`
+  writes an artifact under `HOMEBOY_TRACE_ARTIFACT_DIR` while registering it in
+  the result envelope.
 - `process.mjs` launches black-box commands, captures a best-effort process
   tree artifact on macOS/Linux, waits for exits, and cleans up spawned process
   groups on process exit/signals.
@@ -26,7 +29,10 @@ const { pollHttp } = await import(`${helperDir}/probes.mjs`);
   records first response, status transitions, compact repeated-status history,
   ready, and timeout evidence without emitting one event per poll. Use
   `createHttpStatusHistory()` when a workload has to drive its own HTTP-style
-  probing loop.
+  probing loop. `installConsoleBridge()` and `captureTraceEventText()` parse
+  prefixed JSON bridge events. Payloads shaped as `{ source, event, data }` are
+  dispatched as structured timeline events; other payloads fall back to the
+  configured bridge source/event.
 
 ## Platform-Specific Helpers
 

--- a/nodejs/scripts/trace/fixtures/helper.trace.mjs
+++ b/nodejs/scripts/trace/fixtures/helper.trace.mjs
@@ -9,6 +9,7 @@ const { createTraceRecorder } = await import(pathToFileURL(`${helperDir}/timelin
 const { launchProcess, waitForExit, captureProcessTree } = await import(pathToFileURL(`${helperDir}/process.mjs`).href);
 const { observeVisibleWindows } = await import(pathToFileURL(`${helperDir}/desktop.mjs`).href);
 const {
+    captureTraceEventText,
     createHttpStatusHistory,
     installConsoleBridge,
     parseLogLines,
@@ -21,6 +22,7 @@ const {
 const recorder = createTraceRecorder();
 await recorder.recordEvent('scenario', 'helper.start', { helperDir: Boolean(helperDir) });
 const onEvent = recorder.recordEvent.bind(recorder);
+await recorder.writeArtifact('helper note', 'note.txt', 'artifact note', 'text/plain');
 
 const child = launchProcess('node', {
     args: ['-e', 'setTimeout(() => process.exit(0), 50)'],
@@ -32,6 +34,7 @@ await captureProcessTree(child.pid, 'process-tree.txt', { recorder });
 const exit = await waitForExit(child);
 await recorder.recordEvent('process', 'process.exit', exit);
 recorder.recordAssertion('dummy-process-exited', exit.code === 0 ? 'pass' : 'fail', `dummy process exited with ${exit.code}`);
+recorder.recordCheck('record-check-helper', exit.code === 0, 'recordCheck converts booleans to assertion status');
 
 const jsonPath = join(process.env.HOMEBOY_TRACE_ARTIFACT_DIR, 'state.json');
 const jsonPoll = pollJsonFile(jsonPath, {
@@ -107,6 +110,8 @@ recorder.recordAssertion('observation-window-resolved', observed === 'done' ? 'p
 const page = new EventEmitter();
 installConsoleBridge(page, { prefix: 'trace:', onEvent });
 page.emit('console', { text: () => 'trace:{"event":"bridge-ok"}' });
+page.emit('console', { text: () => 'trace:{"source":"renderer","event":"site_event_received","data":{"running":true}}' });
+await captureTraceEventText('[HOMEBOY_TRACE] {"source":"ipc","event":"createSite.resolve","data":{"result":{"port":9999}}}', onEvent);
 
 const windows = await observeVisibleWindows();
 recorder.recordAssertion(

--- a/nodejs/scripts/trace/lib/probes.mjs
+++ b/nodejs/scripts/trace/lib/probes.mjs
@@ -185,21 +185,53 @@ export async function parseLogLines(text, patterns, onEvent, options = {}) {
     return emitted;
 }
 
+export async function captureTraceEventText(text, onEvent, options = {}) {
+    const lines = String(text || '').split(/\r?\n/).filter(Boolean);
+    const emitted = [];
+
+    for (const line of lines) {
+        const parsed = parseTraceEventLine(line, options);
+        if (!parsed) continue;
+        emitted.push(await emitBridgePayload(parsed, onEvent, options));
+    }
+
+    return emitted;
+}
+
+export function parseTraceEventLine(line, options = {}) {
+    const prefix = options.prefix || '[HOMEBOY_TRACE] ';
+    const text = String(line || '');
+    if (!text.startsWith(prefix)) return null;
+    return parseBridgePayload(text.slice(prefix.length).trim());
+}
+
+export function parseBridgePayload(raw) {
+    try {
+        const parsed = JSON.parse(String(raw || '').trim());
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : { value: parsed };
+    } catch {
+        return { message: String(raw || '').trim() };
+    }
+}
+
+export async function emitBridgePayload(payload, onEvent, options = {}) {
+    const fallbackSource = options.source || 'browser';
+    const fallbackEvent = options.event || 'console.bridge';
+    const item = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : { value: payload };
+
+    if (typeof item.source === 'string' && typeof item.event === 'string') {
+        return await emit(onEvent, item.source, item.event, item.data || {});
+    }
+
+    return await emit(onEvent, fallbackSource, fallbackEvent, item);
+}
+
 export function installConsoleBridge(page, options = {}) {
     const prefix = options.prefix || 'trace:';
-    const source = options.source || 'browser';
     const handler = async (message) => {
         const text = typeof message.text === 'function' ? message.text() : String(message);
         if (!text.startsWith(prefix)) return;
-        const raw = text.slice(prefix.length).trim();
-        let data = { message: raw };
-        try {
-            const parsed = JSON.parse(raw);
-            data = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : { value: parsed };
-        } catch {
-            // Plain console messages are valid bridge payloads.
-        }
-        await emit(options.onEvent, source, options.event || 'console.bridge', data);
+        await emitBridgePayload(parseBridgePayload(text.slice(prefix.length).trim()), options.onEvent, options);
     };
 
     if (typeof page.on !== 'function') throw new Error('installConsoleBridge requires a page-like object with on(event, handler)');

--- a/nodejs/scripts/trace/lib/process.mjs
+++ b/nodejs/scripts/trace/lib/process.mjs
@@ -34,6 +34,10 @@ export function launchProcess(command, options = {}) {
 }
 
 export async function waitForExit(child) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+        return { code: child.exitCode, signal: child.signalCode };
+    }
+
     const [code, signal] = await once(child, 'exit');
     return { code, signal };
 }

--- a/nodejs/scripts/trace/lib/timeline.mjs
+++ b/nodejs/scripts/trace/lib/timeline.mjs
@@ -1,7 +1,7 @@
 import { mkdir, appendFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { performance } from 'node:perf_hooks';
-import { artifactPath, artifactRelativePath } from './artifacts.mjs';
+import { artifactPath, artifactRelativePath, writeArtifact as writeArtifactFile } from './artifacts.mjs';
 
 const VALID_ASSERTION_STATUSES = new Set(['pass', 'fail', 'skip', 'unknown']);
 const VALID_ENVELOPE_STATUSES = new Set(['pass', 'fail', 'error', 'skip', 'unknown']);
@@ -45,6 +45,10 @@ export class TraceRecorder {
         return assertion;
     }
 
+    recordCheck(id, ok, message, data = undefined) {
+        return this.recordAssertion(id, ok ? 'pass' : 'fail', message, data);
+    }
+
     addArtifact(label, path, kind = undefined) {
         const artifact = { label, path: artifactRelativePath(path) };
         if (kind) artifact.kind = kind;
@@ -54,6 +58,11 @@ export class TraceRecorder {
         }
 
         return artifact;
+    }
+
+    async writeArtifact(label, name, content, kind = undefined) {
+        const artifact = await writeArtifactFile(name, content);
+        return this.addArtifact(label, artifact.path, kind);
     }
 
     async writeTraceResults(options = {}) {

--- a/nodejs/scripts/trace/nodejs-trace-runner-smoke.sh
+++ b/nodejs/scripts/trace/nodejs-trace-runner-smoke.sh
@@ -130,6 +130,10 @@ if [ ! -f "$HELPER_ARTIFACTS/trace.jsonl" ]; then
     echo "expected timeline jsonl artifact to be written" >&2
     exit 1
 fi
+if [ ! -f "$HELPER_ARTIFACTS/note.txt" ]; then
+    echo "expected recorder artifact to be written" >&2
+    exit 1
+fi
 assert_json "$HELPER_RESULTS" '
 if (data.status !== "pass") throw new Error("helper scenario should pass");
 if (data.summary !== "helper scenario passed") throw new Error("helper summary missing");
@@ -151,7 +155,10 @@ if (!data.timeline.find((event) => event.event === "http.ready" && event.data.st
 if (!data.timeline.find((event) => event.event === "process.seen")) throw new Error("process seen event missing");
 if (!data.timeline.find((event) => event.event === "log.port_known" && event.data.port === 1234)) throw new Error("log parse event missing");
 if (!data.timeline.find((event) => event.event === "console.bridge" && event.data.event === "bridge-ok")) throw new Error("console bridge event missing");
+if (!data.timeline.find((event) => event.source === "renderer" && event.event === "site_event_received" && event.data.running === true)) throw new Error("structured console bridge event missing");
+if (!data.timeline.find((event) => event.source === "ipc" && event.event === "createSite.resolve" && event.data.result.port === 9999)) throw new Error("prefixed trace line event missing");
 if (!data.assertions.find((assertion) => assertion.id === "dummy-process-exited" && assertion.status === "pass")) throw new Error("process assertion missing");
+if (!data.assertions.find((assertion) => assertion.id === "record-check-helper" && assertion.status === "pass")) throw new Error("recordCheck assertion missing");
 if (!data.assertions.find((assertion) => assertion.id === "json-poll-port-known" && assertion.status === "pass")) throw new Error("json poll assertion missing");
 if (!data.assertions.find((assertion) => assertion.id === "http-poll-ready" && assertion.status === "pass")) throw new Error("http poll assertion missing");
 if (!data.assertions.find((assertion) => assertion.id === "http-status-history" && assertion.status === "pass")) throw new Error("http status history assertion missing");
@@ -160,6 +167,7 @@ if (!data.assertions.find((assertion) => assertion.id === "process-poll-seen" &&
 if (!data.assertions.find((assertion) => assertion.id === "observation-window-resolved" && assertion.status === "pass")) throw new Error("observation window assertion missing");
 if (!data.artifacts.find((artifact) => artifact.path === "process-tree.txt")) throw new Error("process tree artifact missing from envelope");
 if (!data.artifacts.find((artifact) => artifact.path === "trace.jsonl")) throw new Error("timeline artifact missing from envelope");
+if (!data.artifacts.find((artifact) => artifact.path === "note.txt" && artifact.kind === "text/plain")) throw new Error("recorder-written artifact missing from envelope");
 '
 
 SCRIPT_PROJECT="$(make_project scripts-scenario)"


### PR DESCRIPTION
## Summary
- Add product-agnostic trace bridge primitives for structured console/prefixed JSON events.
- Add recorder conveniences for boolean assertions and artifact writes so workloads can use the shared trace envelope plumbing.
- Extend the node trace smoke fixture to cover result writing, assertions, artifacts, HTTP probe evidence, console bridge fallback events, and structured bridge events.

Closes #893.

## Tests
- `bash nodejs/scripts/trace/nodejs-trace-runner-smoke.sh`

## Notes
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-issue-893-nodejs-trace-helper-primitives --extension nodejs` and the same command scoped to `/nodejs` failed before running tests because the lab runner expects a `package.json`; this extension is validated here through the trace runner smoke script.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic trace helper additions, extended smoke coverage, and ran verification; Chris remains responsible for review and merge.