### PR TITLE
Add generic settings accessors

### DIFF
--- a/nodejs/scripts/lib/settings.sh
+++ b/nodejs/scripts/lib/settings.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# Safe accessors for Homeboy's merged extension settings payload.
+#
+# Runners pass jq expressions so this helper stays generic and does not encode
+# extension-specific setting names or aliases.
+
+homeboy_settings_json() {
+    local settings_json="${HOMEBOY_SETTINGS_JSON:-}"
+    if [ -z "$settings_json" ]; then
+        printf '{}'
+        return 0
+    fi
+
+    if printf '%s' "$settings_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        printf '%s' "$settings_json"
+    else
+        printf '{}'
+    fi
+}
+
+homeboy_setting_json() {
+    local setting_name="${1:?setting name is required}"
+    local default_json="${2:-null}"
+    local expression="${3:-.$setting_name}"
+    local settings_json
+    settings_json="$(homeboy_settings_json)"
+
+    printf '%s' "$settings_json" | jq -c "$expression" 2>/dev/null || printf '%s' "$default_json"
+}
+
+homeboy_setting() {
+    local setting_name="${1:?setting name is required}"
+    local expression="${2:-.$setting_name}"
+    local default_value="${3:-}"
+    local settings_json value
+    settings_json="$(homeboy_settings_json)"
+
+    value=$(printf '%s' "$settings_json" | jq -r "$expression" 2>/dev/null || true)
+    case "$value" in
+        ""|null)
+            printf '%s' "$default_value"
+            ;;
+        *)
+            printf '%s' "$value"
+            ;;
+    esac
+}
+
+homeboy_setting_bool() {
+    local setting_name="${1:?setting name is required}"
+    local default_value="${2:-false}"
+    local expression="${3:-.$setting_name}"
+    local settings_json value
+    settings_json="$(homeboy_settings_json)"
+
+    value=$(printf '%s' "$settings_json" | jq -r "$expression" 2>/dev/null || true)
+    case "$value" in
+        true|TRUE|1|yes|YES|on|ON)
+            printf 'true'
+            ;;
+        false|FALSE|0|no|NO|off|OFF)
+            printf 'false'
+            ;;
+        null|"")
+            case "$default_value" in
+                true|TRUE|1|yes|YES|on|ON) printf 'true' ;;
+                *) printf 'false' ;;
+            esac
+            ;;
+        *)
+            case "$default_value" in
+                true|TRUE|1|yes|YES|on|ON) printf 'true' ;;
+                *) printf 'false' ;;
+            esac
+            ;;
+    esac
+}
+
+homeboy_setting_array() {
+    local setting_name="${1:?setting name is required}"
+    local expression="${2:-.$setting_name}"
+    local default_json="${3:-[]}"
+    local settings_json value
+    settings_json="$(homeboy_settings_json)"
+
+    value=$(printf '%s' "$settings_json" | jq -c "$expression" 2>/dev/null || true)
+    if printf '%s' "$value" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        printf '%s' "$value"
+    else
+        printf '%s' "$default_json"
+    fi
+}

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -35,9 +35,12 @@ homeboy_require_bash_version 4
 
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
 SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
+SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SCRIPT_DIR}/../lib/settings.sh}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
+# shellcheck source=/dev/null
+source "$SETTINGS_HELPER"
 # shellcheck source=/dev/null
 if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
     source "$SIDECAR_WRITER_HELPER"
@@ -55,17 +58,6 @@ if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
         RUNNER_ARGS+=("$selected_test_file")
     done <<< "$HOMEBOY_CHANGED_TEST_FILES"
 fi
-
-homeboy_node_json_value() {
-    local expression="$1"
-    node -e "
-        const raw = process.env.HOMEBOY_SETTINGS_JSON || '{}';
-        let settings = {};
-        try { settings = JSON.parse(raw); } catch {}
-        const value = (${expression});
-        if (typeof value === 'string' && value) console.log(value);
-    " 2>/dev/null || true
-}
 
 homeboy_node_package_value() {
     local expression="$1"
@@ -85,7 +77,7 @@ homeboy_node_script_command() {
 homeboy_node_targeted_test_script() {
     local configured_script="${HOMEBOY_NODE_TARGETED_TEST_SCRIPT:-}"
     if [ -z "$configured_script" ]; then
-        configured_script="$(homeboy_node_json_value "settings.node_targeted_test_script || settings.targeted_test_script || settings.test_script || settings.testing?.targeted_test_script || ''")"
+        configured_script="$(homeboy_setting node_targeted_test_script '.node_targeted_test_script // .targeted_test_script // .test_script // .testing.targeted_test_script // empty')"
     fi
 
     if [ -n "$configured_script" ]; then

--- a/rust/scripts/bench/bench-runner.sh
+++ b/rust/scripts/bench/bench-runner.sh
@@ -57,9 +57,12 @@ homeboy_require_bash_version 4
 
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
+SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SCRIPT_DIR}/../lib/settings.sh}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
+# shellcheck source=/dev/null
+source "$SETTINGS_HELPER"
 # shellcheck source=/dev/null
 if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
     source "$FAILURE_TRAP_HELPER"
@@ -105,10 +108,8 @@ rust_cargo_timings_enabled() {
             ;;
     esac
 
-    if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && command -v jq >/dev/null 2>&1; then
-        if printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -e '.rust_bench_cargo_timings == true or .rust.bench.cargo_timings == true' >/dev/null 2>&1; then
-            return 0
-        fi
+    if [ "$(homeboy_setting_bool rust_bench_cargo_timings false '.rust_bench_cargo_timings // .rust.bench.cargo_timings // false')" = "true" ]; then
+        return 0
     fi
 
     return 1

--- a/rust/scripts/lib/settings.sh
+++ b/rust/scripts/lib/settings.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# Safe accessors for Homeboy's merged extension settings payload.
+#
+# Runners pass jq expressions so this helper stays generic and does not encode
+# extension-specific setting names or aliases.
+
+homeboy_settings_json() {
+    local settings_json="${HOMEBOY_SETTINGS_JSON:-}"
+    if [ -z "$settings_json" ]; then
+        printf '{}'
+        return 0
+    fi
+
+    if printf '%s' "$settings_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        printf '%s' "$settings_json"
+    else
+        printf '{}'
+    fi
+}
+
+homeboy_setting_json() {
+    local setting_name="${1:?setting name is required}"
+    local default_json="${2:-null}"
+    local expression="${3:-.$setting_name}"
+    local settings_json
+    settings_json="$(homeboy_settings_json)"
+
+    printf '%s' "$settings_json" | jq -c "$expression" 2>/dev/null || printf '%s' "$default_json"
+}
+
+homeboy_setting() {
+    local setting_name="${1:?setting name is required}"
+    local expression="${2:-.$setting_name}"
+    local default_value="${3:-}"
+    local settings_json value
+    settings_json="$(homeboy_settings_json)"
+
+    value=$(printf '%s' "$settings_json" | jq -r "$expression" 2>/dev/null || true)
+    case "$value" in
+        ""|null)
+            printf '%s' "$default_value"
+            ;;
+        *)
+            printf '%s' "$value"
+            ;;
+    esac
+}
+
+homeboy_setting_bool() {
+    local setting_name="${1:?setting name is required}"
+    local default_value="${2:-false}"
+    local expression="${3:-.$setting_name}"
+    local settings_json value
+    settings_json="$(homeboy_settings_json)"
+
+    value=$(printf '%s' "$settings_json" | jq -r "$expression" 2>/dev/null || true)
+    case "$value" in
+        true|TRUE|1|yes|YES|on|ON)
+            printf 'true'
+            ;;
+        false|FALSE|0|no|NO|off|OFF)
+            printf 'false'
+            ;;
+        null|"")
+            case "$default_value" in
+                true|TRUE|1|yes|YES|on|ON) printf 'true' ;;
+                *) printf 'false' ;;
+            esac
+            ;;
+        *)
+            case "$default_value" in
+                true|TRUE|1|yes|YES|on|ON) printf 'true' ;;
+                *) printf 'false' ;;
+            esac
+            ;;
+    esac
+}
+
+homeboy_setting_array() {
+    local setting_name="${1:?setting name is required}"
+    local expression="${2:-.$setting_name}"
+    local default_json="${3:-[]}"
+    local settings_json value
+    settings_json="$(homeboy_settings_json)"
+
+    value=$(printf '%s' "$settings_json" | jq -c "$expression" 2>/dev/null || true)
+    if printf '%s' "$value" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        printf '%s' "$value"
+    else
+        printf '%s' "$default_json"
+    fi
+}

--- a/scripts/lib/settings.sh
+++ b/scripts/lib/settings.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# Safe accessors for Homeboy's merged extension settings payload.
+#
+# Runners pass jq expressions so this helper stays generic and does not encode
+# extension-specific setting names or aliases.
+
+homeboy_settings_json() {
+    local settings_json="${HOMEBOY_SETTINGS_JSON:-}"
+    if [ -z "$settings_json" ]; then
+        printf '{}'
+        return 0
+    fi
+
+    if printf '%s' "$settings_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        printf '%s' "$settings_json"
+    else
+        printf '{}'
+    fi
+}
+
+homeboy_setting_json() {
+    local setting_name="${1:?setting name is required}"
+    local default_json="${2:-null}"
+    local expression="${3:-.$setting_name}"
+    local settings_json
+    settings_json="$(homeboy_settings_json)"
+
+    printf '%s' "$settings_json" | jq -c "$expression" 2>/dev/null || printf '%s' "$default_json"
+}
+
+homeboy_setting() {
+    local setting_name="${1:?setting name is required}"
+    local expression="${2:-.$setting_name}"
+    local default_value="${3:-}"
+    local settings_json value
+    settings_json="$(homeboy_settings_json)"
+
+    value=$(printf '%s' "$settings_json" | jq -r "$expression" 2>/dev/null || true)
+    case "$value" in
+        ""|null)
+            printf '%s' "$default_value"
+            ;;
+        *)
+            printf '%s' "$value"
+            ;;
+    esac
+}
+
+homeboy_setting_bool() {
+    local setting_name="${1:?setting name is required}"
+    local default_value="${2:-false}"
+    local expression="${3:-.$setting_name}"
+    local settings_json value
+    settings_json="$(homeboy_settings_json)"
+
+    value=$(printf '%s' "$settings_json" | jq -r "$expression" 2>/dev/null || true)
+    case "$value" in
+        true|TRUE|1|yes|YES|on|ON)
+            printf 'true'
+            ;;
+        false|FALSE|0|no|NO|off|OFF)
+            printf 'false'
+            ;;
+        null|"")
+            case "$default_value" in
+                true|TRUE|1|yes|YES|on|ON) printf 'true' ;;
+                *) printf 'false' ;;
+            esac
+            ;;
+        *)
+            case "$default_value" in
+                true|TRUE|1|yes|YES|on|ON) printf 'true' ;;
+                *) printf 'false' ;;
+            esac
+            ;;
+    esac
+}
+
+homeboy_setting_array() {
+    local setting_name="${1:?setting name is required}"
+    local expression="${2:-.$setting_name}"
+    local default_json="${3:-[]}"
+    local settings_json value
+    settings_json="$(homeboy_settings_json)"
+
+    value=$(printf '%s' "$settings_json" | jq -c "$expression" 2>/dev/null || true)
+    if printf '%s' "$value" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        printf '%s' "$value"
+    else
+        printf '%s' "$default_json"
+    fi
+}

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -11,6 +11,12 @@ BASH_PREFLIGHT_HELPERS=(
     "${ROOT_DIR}/rust/scripts/lib/bash-preflight.sh"
     "${ROOT_DIR}/wordpress/scripts/lib/bash-preflight.sh"
 )
+SETTINGS_HELPERS=(
+    "${ROOT_DIR}/scripts/lib/settings.sh"
+    "${ROOT_DIR}/nodejs/scripts/lib/settings.sh"
+    "${ROOT_DIR}/rust/scripts/lib/settings.sh"
+    "${ROOT_DIR}/wordpress/scripts/lib/settings.sh"
+)
 
 assert_file() {
     local path="$1"
@@ -50,10 +56,21 @@ for bash_preflight_helper in "${BASH_PREFLIGHT_HELPERS[@]}"; do
     assert_file "$bash_preflight_helper"
     bash -c 'source "$1"; homeboy_require_bash_version 4' _ "$bash_preflight_helper"
 done
+for settings_helper in "${SETTINGS_HELPERS[@]}"; do
+    assert_file "$settings_helper"
+    bash -c 'source "$1"; type homeboy_setting >/dev/null; type homeboy_setting_bool >/dev/null; type homeboy_setting_array >/dev/null' _ "$settings_helper"
+done
 
 if ! cmp -s "${BASH_PREFLIGHT_HELPERS[0]}" "${BASH_PREFLIGHT_HELPERS[1]}" \
     || ! cmp -s "${BASH_PREFLIGHT_HELPERS[0]}" "${BASH_PREFLIGHT_HELPERS[2]}"; then
     echo "Bash preflight helpers should stay identical across installed extension trees" >&2
+    exit 1
+fi
+
+if ! cmp -s "${SETTINGS_HELPERS[0]}" "${SETTINGS_HELPERS[1]}" \
+    || ! cmp -s "${SETTINGS_HELPERS[0]}" "${SETTINGS_HELPERS[2]}" \
+    || ! cmp -s "${SETTINGS_HELPERS[0]}" "${SETTINGS_HELPERS[3]}"; then
+    echo "Settings helpers should stay identical across installed extension trees" >&2
     exit 1
 fi
 

--- a/tests/settings-helper-smoke.sh
+++ b/tests/settings-helper-smoke.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SETTINGS_HELPER="${ROOT_DIR}/scripts/lib/settings.sh"
+WORDPRESS_SETTINGS_HELPER="${ROOT_DIR}/wordpress/scripts/lib/settings.sh"
+RUST_SETTINGS_HELPER="${ROOT_DIR}/rust/scripts/lib/settings.sh"
+NODEJS_SETTINGS_HELPER="${ROOT_DIR}/nodejs/scripts/lib/settings.sh"
+
+# shellcheck source=../scripts/lib/settings.sh
+source "$SETTINGS_HELPER"
+
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+    local message="$3"
+
+    if [ "$actual" != "$expected" ]; then
+        echo "${message}: expected '${expected}', got '${actual}'" >&2
+        exit 1
+    fi
+}
+
+for helper in "$WORDPRESS_SETTINGS_HELPER" "$RUST_SETTINGS_HELPER" "$NODEJS_SETTINGS_HELPER"; do
+    if ! cmp -s "$SETTINGS_HELPER" "$helper"; then
+        echo "Settings helper should stay identical across installed extension trees: $helper" >&2
+        exit 1
+    fi
+done
+
+HOMEBOY_SETTINGS_JSON='{"test_backend":"host-smoke","testing":{"backend":"wp-codebox"}}'
+assert_equals "host-smoke" "$(homeboy_setting test_backend '.test_backend // .testing.backend // empty')" "scalar setting alias order"
+
+HOMEBOY_SETTINGS_JSON='{"testing":{"backend":"host"}}'
+assert_equals "host" "$(homeboy_setting test_backend '.test_backend // .testing.backend // empty')" "nested scalar setting fallback"
+
+HOMEBOY_SETTINGS_JSON='{}'
+assert_equals "wp-codebox" "$(homeboy_setting test_backend '.test_backend // .testing.backend // empty' 'wp-codebox')" "scalar setting default"
+
+HOMEBOY_SETTINGS_JSON='{"rust":{"bench":{"cargo_timings":true}}}'
+assert_equals "true" "$(homeboy_setting_bool rust_bench_cargo_timings false '.rust_bench_cargo_timings // .rust.bench.cargo_timings // false')" "bool setting nested true"
+
+HOMEBOY_SETTINGS_JSON='{"rust_bench_cargo_timings":"no"}'
+assert_equals "false" "$(homeboy_setting_bool rust_bench_cargo_timings true '.rust_bench_cargo_timings // .rust.bench.cargo_timings // false')" "bool setting explicit false beats default"
+
+HOMEBOY_SETTINGS_JSON='{"validation_dependencies":["agents-api","data-machine"]}'
+assert_equals '["agents-api","data-machine"]' "$(homeboy_setting_array validation_dependencies '.validation_dependencies // .depends_on // []')" "array setting"
+
+HOMEBOY_SETTINGS_JSON='not json'
+assert_equals "fallback" "$(homeboy_setting missing '.missing // empty' 'fallback')" "invalid JSON scalar default"
+assert_equals "false" "$(homeboy_setting_bool flag false '.flag // false')" "invalid JSON bool default"
+assert_equals "[]" "$(homeboy_setting_array dependencies '.dependencies // []')" "invalid JSON array default"
+
+HOMEBOY_SETTINGS_JSON='{"depends_on":"agents-api, data-machine"}'
+# shellcheck source=../wordpress/scripts/lib/validation-dependencies.sh
+source "${ROOT_DIR}/wordpress/scripts/lib/validation-dependencies.sh"
+assert_equals '"agents-api, data-machine"' "$(homeboy_get_validation_dependencies_raw)" "validation dependency raw JSON string"
+
+echo "settings helper smoke passed"

--- a/wordpress/scripts/lib/settings.sh
+++ b/wordpress/scripts/lib/settings.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# Safe accessors for Homeboy's merged extension settings payload.
+#
+# Runners pass jq expressions so this helper stays generic and does not encode
+# extension-specific setting names or aliases.
+
+homeboy_settings_json() {
+    local settings_json="${HOMEBOY_SETTINGS_JSON:-}"
+    if [ -z "$settings_json" ]; then
+        printf '{}'
+        return 0
+    fi
+
+    if printf '%s' "$settings_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        printf '%s' "$settings_json"
+    else
+        printf '{}'
+    fi
+}
+
+homeboy_setting_json() {
+    local setting_name="${1:?setting name is required}"
+    local default_json="${2:-null}"
+    local expression="${3:-.$setting_name}"
+    local settings_json
+    settings_json="$(homeboy_settings_json)"
+
+    printf '%s' "$settings_json" | jq -c "$expression" 2>/dev/null || printf '%s' "$default_json"
+}
+
+homeboy_setting() {
+    local setting_name="${1:?setting name is required}"
+    local expression="${2:-.$setting_name}"
+    local default_value="${3:-}"
+    local settings_json value
+    settings_json="$(homeboy_settings_json)"
+
+    value=$(printf '%s' "$settings_json" | jq -r "$expression" 2>/dev/null || true)
+    case "$value" in
+        ""|null)
+            printf '%s' "$default_value"
+            ;;
+        *)
+            printf '%s' "$value"
+            ;;
+    esac
+}
+
+homeboy_setting_bool() {
+    local setting_name="${1:?setting name is required}"
+    local default_value="${2:-false}"
+    local expression="${3:-.$setting_name}"
+    local settings_json value
+    settings_json="$(homeboy_settings_json)"
+
+    value=$(printf '%s' "$settings_json" | jq -r "$expression" 2>/dev/null || true)
+    case "$value" in
+        true|TRUE|1|yes|YES|on|ON)
+            printf 'true'
+            ;;
+        false|FALSE|0|no|NO|off|OFF)
+            printf 'false'
+            ;;
+        null|"")
+            case "$default_value" in
+                true|TRUE|1|yes|YES|on|ON) printf 'true' ;;
+                *) printf 'false' ;;
+            esac
+            ;;
+        *)
+            case "$default_value" in
+                true|TRUE|1|yes|YES|on|ON) printf 'true' ;;
+                *) printf 'false' ;;
+            esac
+            ;;
+    esac
+}
+
+homeboy_setting_array() {
+    local setting_name="${1:?setting name is required}"
+    local expression="${2:-.$setting_name}"
+    local default_json="${3:-[]}"
+    local settings_json value
+    settings_json="$(homeboy_settings_json)"
+
+    value=$(printf '%s' "$settings_json" | jq -c "$expression" 2>/dev/null || true)
+    if printf '%s' "$value" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        printf '%s' "$value"
+    else
+        printf '%s' "$default_json"
+    fi
+}

--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -19,13 +19,13 @@ set -euo pipefail
 # Header deps are resolved through the same chain by slug.
 
 homeboy_get_validation_dependencies_raw() {
-    local settings_json="${HOMEBOY_SETTINGS_JSON:-}"
-
-    if [ -z "$settings_json" ] || [ "$settings_json" = "{}" ]; then
-        return 0
+    if ! type homeboy_setting_json >/dev/null 2>&1; then
+        local settings_helper="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-$(dirname "${BASH_SOURCE[0]}")/settings.sh}"
+        # shellcheck source=/dev/null
+        source "$settings_helper"
     fi
 
-    printf '%s' "$settings_json" | jq -r '.validation_dependencies // .depends_on // empty' 2>/dev/null || true
+    homeboy_setting_json validation_dependencies 'null' '.validation_dependencies // .depends_on // null'
 }
 
 homeboy_normalize_validation_dependencies() {

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -19,9 +19,12 @@ CORE_WP_CODEBOX_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_CORE_WP_CODEBOX:-${SCRIPT_
 
 # Resolve execution context and export env vars that the WordPress test runners expect.
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SCRIPT_DIR}/../lib/settings.sh}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context --component-alias PLUGIN_PATH
+# shellcheck source=/dev/null
+source "$SETTINGS_HELPER"
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Extension path: $EXTENSION_PATH"
@@ -29,10 +32,7 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Component path: ${COMPONENT_PATH:-$(pwd)}"
 fi
 
-TEST_BACKEND=""
-if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
-    TEST_BACKEND=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.test_backend // .testing.backend // empty' 2>/dev/null || true)
-fi
+TEST_BACKEND="$(homeboy_setting test_backend '.test_backend // .testing.backend // empty')"
 TEST_BACKEND="${HOMEBOY_WORDPRESS_TEST_BACKEND:-${TEST_BACKEND:-wp-codebox}}"
 
 TARGET_FILE=""


### PR DESCRIPTION
## Summary
- Adds generic `HOMEBOY_SETTINGS_JSON` shell accessors for scalar, boolean, JSON, and array settings with invalid/empty JSON defaults.
- Migrates representative WordPress, Rust, and NodeJS runner settings reads to the shared helper.
- Adds focused smoke coverage for typed defaults, aliases, invalid JSON handling, and helper parity across extension trees.

Closes #897

## Verification
- `bash tests/settings-helper-smoke.sh`
- `bash tests/runtime-helpers-smoke.sh`
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `bash nodejs/scripts/test/nodejs-targeted-script-smoke.sh`
- `bash -n scripts/lib/settings.sh nodejs/scripts/lib/settings.sh rust/scripts/lib/settings.sh wordpress/scripts/lib/settings.sh nodejs/scripts/test/test-runner.sh rust/scripts/bench/bench-runner.sh wordpress/scripts/test/test-runner.sh wordpress/scripts/lib/validation-dependencies.sh tests/settings-helper-smoke.sh tests/runtime-helpers-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and tested the settings helper, representative runner migrations, and PR description; Chris remains responsible for review and merge.