### PR TITLE
Share test result parser adapters

### DIFF
--- a/rust/scripts/parse-test-results.sh
+++ b/rust/scripts/parse-test-results.sh
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
-# Parse cargo test output and ask Homeboy's runtime helper to write test results.
-#
-# Cargo output pattern (one per test binary):
-#   test result: ok. 551 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out;
-#   test result: FAILED. 540 passed; 11 failed; 2 ignored; 0 measured; 0 filtered out;
-#
-# Multiple test result lines are aggregated (unit + integration + doc-tests).
+# Parse cargo test output through the shared Homeboy test-result adapter.
 #
 # Usage: parse-test-results.sh <cargo-output-file>
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 OUTPUT_FILE="${1:-}"
 if [ -z "$OUTPUT_FILE" ] || [ ! -f "$OUTPUT_FILE" ]; then
@@ -22,19 +18,7 @@ if [ -n "$WRITE_TEST_RESULTS_HELPER" ] && [ -f "$WRITE_TEST_RESULTS_HELPER" ]; t
     source "$WRITE_TEST_RESULTS_HELPER"
 fi
 
-# Aggregate all "test result:" lines
-TOTAL_PASSED=$(awk '{ for (i = 1; i < NF; i++) if ($i ~ /^[0-9]+$/ && $(i + 1) ~ /^passed;?$/) s += $i } END { print s + 0 }' "$OUTPUT_FILE")
-TOTAL_FAILED=$(awk '{ for (i = 1; i < NF; i++) if ($i ~ /^[0-9]+$/ && $(i + 1) ~ /^failed;?$/) s += $i } END { print s + 0 }' "$OUTPUT_FILE")
-TOTAL_IGNORED=$(awk '{ for (i = 1; i < NF; i++) if ($i ~ /^[0-9]+$/ && $(i + 1) ~ /^ignored;?$/) s += $i } END { print s + 0 }' "$OUTPUT_FILE")
-
-TOTAL=$((TOTAL_PASSED + TOTAL_FAILED + TOTAL_IGNORED))
-
-# If no test result lines found, exit silently
-if [ "$TOTAL" -eq 0 ]; then
-    exit 0
-fi
-
-# Write JSON to file if requested by core.
-if type homeboy_write_test_results >/dev/null 2>&1; then
-    homeboy_write_test_results "$TOTAL" "$TOTAL_PASSED" "$TOTAL_FAILED" "$TOTAL_IGNORED"
-fi
+ADAPTERS_HELPER="${HOMEBOY_RUNTIME_TEST_RESULT_ADAPTERS:-${HOMEBOY_EXTENSION_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}/scripts/lib/test-result-adapters.sh}"
+# shellcheck source=../../scripts/lib/test-result-adapters.sh
+source "$ADAPTERS_HELPER"
+homeboy_parse_test_results_with_adapters "$OUTPUT_FILE" cargo-test

--- a/scripts/lib/test-result-adapters.sh
+++ b/scripts/lib/test-result-adapters.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Shared test-result parser adapters for extension runner wrappers.
+
+homeboy_parse_test_results_with_adapters() {
+    local output_file="$1"
+    shift || true
+
+    if [ -z "${output_file:-}" ] || [ ! -f "$output_file" ]; then
+        return 0
+    fi
+
+    if ! type homeboy_write_test_results >/dev/null 2>&1; then
+        return 0
+    fi
+
+    local parsed
+    parsed=$(python3 - "$output_file" "$@" <<'PY'
+import json
+import re
+import sys
+
+output_file = sys.argv[1]
+adapters = sys.argv[2:]
+
+try:
+    with open(output_file, encoding="utf-8") as handle:
+        text = handle.read()
+except OSError:
+    sys.exit(0)
+
+
+def emit(total, passed, failed, skipped, partial=""):
+    print("\t".join(str(value) for value in (total, passed, failed, skipped, partial)))
+    sys.exit(0)
+
+
+def count_after(label, line):
+    match = re.search(rf"{re.escape(label)}\s*(\d+)", line)
+    return int(match.group(1)) if match else 0
+
+
+def count_before(label, line):
+    match = re.search(rf"(\d+)\s+{re.escape(label)}", line)
+    return int(match.group(1)) if match else 0
+
+
+def parse_wp_codebox_json():
+    if '"schema"' not in text or '"wp-codebox/test-results/v1"' not in text:
+        return False
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(data, dict) or data.get("schema") != "wp-codebox/test-results/v1":
+        return False
+
+    summary = data.get("summary") if isinstance(data.get("summary"), dict) else {}
+    total = int(summary.get("total") or 0)
+    passed = int(summary.get("passed") or 0)
+    failed = int(summary.get("failed") or 0)
+    skipped = int(summary.get("skipped") or 0)
+    unknown = int(summary.get("unknown") or 0)
+
+    if total == 0 and isinstance(data.get("suites"), list):
+        for suite in data["suites"]:
+            if not isinstance(suite, dict):
+                continue
+            total += int(suite.get("tests") or suite.get("total") or 0)
+            passed += int(suite.get("passed") or 0)
+            failed += int(suite.get("failed") or 0)
+            skipped += int(suite.get("skipped") or 0)
+            unknown += int(suite.get("unknown") or 0)
+
+    partial = "wp-codebox-unknown" if data.get("status") == "unknown" or unknown > 0 else ""
+    emit(total, passed, failed, skipped, partial)
+    return True
+
+
+def parse_phpunit():
+    ok_match = re.search(r"OK \((\d+) tests?", text)
+    if ok_match:
+        total = int(ok_match.group(1))
+        emit(total, total, 0, 0)
+        return True
+
+    summary_lines = [line for line in text.splitlines() if re.match(r"^Tests: \d+", line)]
+    if not summary_lines:
+        return False
+    summary = summary_lines[-1]
+    total = count_after("Tests:", summary)
+    failed = count_after("Errors:", summary) + count_after("Failures:", summary)
+    skipped = (
+        count_after("Skipped:", summary)
+        + count_after("Incomplete:", summary)
+        + count_after("Risky:", summary)
+        + count_after("Warnings:", summary)
+    )
+    passed = max(total - failed - skipped, 0)
+    emit(total, passed, failed, skipped)
+    return True
+
+
+def parse_phpunit_testdox():
+    passed = len(re.findall(r"^ ✔", text, flags=re.MULTILINE))
+    failed = len(re.findall(r"^ ✘", text, flags=re.MULTILINE))
+    if passed == 0 and failed == 0:
+        return False
+    emit(passed + failed, passed, failed, 0, "testdox-fallback")
+    return True
+
+
+def parse_cargo_test():
+    passed = failed = skipped = 0
+    matched = False
+    for line in text.splitlines():
+        if not line.startswith("test result:"):
+            continue
+        matched = True
+        passed += count_before("passed", line)
+        failed += count_before("failed", line)
+        skipped += count_before("ignored", line)
+    if not matched:
+        return False
+    emit(passed + failed + skipped, passed, failed, skipped)
+    return True
+
+
+adapter_functions = {
+    "wp-codebox-json": parse_wp_codebox_json,
+    "phpunit": parse_phpunit,
+    "phpunit-testdox": parse_phpunit_testdox,
+    "cargo-test": parse_cargo_test,
+}
+
+for adapter in adapters:
+    parser = adapter_functions.get(adapter)
+    if parser and parser():
+        break
+PY
+    )
+
+    [ -n "$parsed" ] || return 0
+
+    local total passed failed skipped partial
+    IFS=$'\t' read -r total passed failed skipped partial <<EOF
+$parsed
+EOF
+
+    homeboy_write_test_results "${total:-0}" "${passed:-0}" "${failed:-0}" "${skipped:-0}" "${partial:-}"
+}

--- a/wordpress/scripts/test/parse-test-results.sh
+++ b/wordpress/scripts/test/parse-test-results.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Parse PHPUnit output and ask Homeboy's runtime helper to write test results.
+# Parse PHPUnit/WP Codebox output through shared Homeboy test-result adapters.
 #
 # PHPUnit output patterns:
 #   OK (481 tests, 1234 assertions)
@@ -16,6 +16,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 OUTPUT_FILE="${1:-}"
 if [ -z "$OUTPUT_FILE" ]; then
     exit 0
@@ -29,130 +31,13 @@ if [ ! -f "$OUTPUT_FILE" ]; then
     exit 0
 fi
 
-OUTPUT=$(cat "$OUTPUT_FILE")
-
 WRITE_TEST_RESULTS_HELPER="${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-}"
 if [ -n "$WRITE_TEST_RESULTS_HELPER" ] && [ -f "$WRITE_TEST_RESULTS_HELPER" ]; then
     # shellcheck source=/dev/null
     source "$WRITE_TEST_RESULTS_HELPER"
 fi
 
-TOTAL=0
-PASSED=0
-FAILED=0
-SKIPPED=0
-PARTIAL=""
-
-if printf '%s' "$OUTPUT" | grep -q '"schema"[[:space:]]*:[[:space:]]*"wp-codebox/test-results/v1"'; then
-    wp_codebox_counts=$(php -r '
-        $path = $argv[1];
-        $data = json_decode(file_get_contents($path), true);
-        if (!is_array($data) || ($data["schema"] ?? "") !== "wp-codebox/test-results/v1") {
-            exit(1);
-        }
-
-        $summary = is_array($data["summary"] ?? null) ? $data["summary"] : array();
-        $total = (int) ($summary["total"] ?? 0);
-        $passed = (int) ($summary["passed"] ?? 0);
-        $failed = (int) ($summary["failed"] ?? 0);
-        $skipped = (int) ($summary["skipped"] ?? 0);
-        $unknown = (int) ($summary["unknown"] ?? 0);
-
-        if ($total === 0 && !empty($data["suites"]) && is_array($data["suites"])) {
-            foreach ($data["suites"] as $suite) {
-                if (!is_array($suite)) {
-                    continue;
-                }
-                $total += (int) ($suite["tests"] ?? $suite["total"] ?? 0);
-                $passed += (int) ($suite["passed"] ?? 0);
-                $failed += (int) ($suite["failed"] ?? 0);
-                $skipped += (int) ($suite["skipped"] ?? 0);
-                $unknown += (int) ($suite["unknown"] ?? 0);
-            }
-        }
-
-        $partial = "";
-        if (($data["status"] ?? "") === "unknown" || $unknown > 0) {
-            $partial = "wp-codebox-unknown";
-        }
-
-        echo implode("\t", array($total, $passed, $failed, $skipped, $partial));
-    ' "$OUTPUT_FILE" 2>/dev/null || true)
-
-    if [ -z "$wp_codebox_counts" ]; then
-        exit 0
-    fi
-
-    IFS=$'\t' read -r TOTAL PASSED FAILED SKIPPED PARTIAL <<EOF
-$wp_codebox_counts
-EOF
-
-    if type homeboy_write_test_results >/dev/null 2>&1; then
-        homeboy_write_test_results "${TOTAL:-0}" "${PASSED:-0}" "${FAILED:-0}" "${SKIPPED:-0}" "${PARTIAL:-}"
-    fi
-    exit 0
-fi
-
-# Portable helper: extract the number after a label like "Tests: 42"
-# Usage: extract_count "label" "text"
-# Uses sed instead of grep -P (Perl regex) for macOS compatibility.
-extract_count() {
-    echo "$2" | sed -n "s/.*$1 *\([0-9][0-9]*\).*/\1/p" | head -1
-}
-
-# Pattern 1: "OK (N tests, N assertions)"
-if echo "$OUTPUT" | grep -qE 'OK \([0-9]+ test'; then
-    TOTAL=$(echo "$OUTPUT" | sed -n 's/.*OK (\([0-9][0-9]*\) test.*/\1/p' | head -1)
-    TOTAL="${TOTAL:-0}"
-    PASSED="$TOTAL"
-    FAILED=0
-    SKIPPED=0
-
-# Pattern 2: "Tests: N, Assertions: N, ..." (failure/mixed output)
-elif echo "$OUTPUT" | grep -qE '^Tests: [0-9]+'; then
-    SUMMARY_LINE=$(echo "$OUTPUT" | grep -E '^Tests: [0-9]+' | tail -1)
-
-    TOTAL=$(extract_count "Tests:" "$SUMMARY_LINE")
-    TOTAL="${TOTAL:-0}"
-
-    ERRORS=$(extract_count "Errors:" "$SUMMARY_LINE")
-    ERRORS="${ERRORS:-0}"
-    FAILURES=$(extract_count "Failures:" "$SUMMARY_LINE")
-    FAILURES="${FAILURES:-0}"
-    WARNINGS=$(extract_count "Warnings:" "$SUMMARY_LINE")
-    WARNINGS="${WARNINGS:-0}"
-    SKIP_COUNT=$(extract_count "Skipped:" "$SUMMARY_LINE")
-    SKIP_COUNT="${SKIP_COUNT:-0}"
-    INCOMPLETE=$(extract_count "Incomplete:" "$SUMMARY_LINE")
-    INCOMPLETE="${INCOMPLETE:-0}"
-    RISKY=$(extract_count "Risky:" "$SUMMARY_LINE")
-    RISKY="${RISKY:-0}"
-
-    FAILED=$((ERRORS + FAILURES))
-    SKIPPED=$((SKIP_COUNT + INCOMPLETE + RISKY + WARNINGS))
-    PASSED=$((TOTAL - FAILED - SKIPPED))
-
-    # Guard against negative passed count
-    if [ "$PASSED" -lt 0 ]; then
-        PASSED=0
-    fi
-
-# Pattern 3 (fallback): count testdox ✔/✘ marks when PHPUnit crashed mid-run.
-# PHPUnit prints " ✔ Test name" for passes, " ✘ Test name" for failures in
-# --testdox mode. If we see these but no summary line, PHPUnit died before
-# printing its summary (e.g., a test called exit()). Count what we have.
-elif echo "$OUTPUT" | grep -qE '^ [✔✘]'; then
-    PASSED=$(echo "$OUTPUT" | grep -cE '^ ✔' || echo "0")
-    FAILED=$(echo "$OUTPUT" | grep -cE '^ ✘' || echo "0")
-    TOTAL=$((PASSED + FAILED))
-    SKIPPED=0
-    PARTIAL="testdox-fallback"
-else
-    # No recognizable output — exit silently
-    exit 0
-fi
-
-# Write JSON to file if requested by core.
-if type homeboy_write_test_results >/dev/null 2>&1; then
-    homeboy_write_test_results "$TOTAL" "$PASSED" "$FAILED" "$SKIPPED" "$PARTIAL"
-fi
+ADAPTERS_HELPER="${HOMEBOY_RUNTIME_TEST_RESULT_ADAPTERS:-$(cd "${SCRIPT_DIR}/../../.." && pwd)/scripts/lib/test-result-adapters.sh}"
+# shellcheck source=../../../scripts/lib/test-result-adapters.sh
+source "$ADAPTERS_HELPER"
+homeboy_parse_test_results_with_adapters "$OUTPUT_FILE" wp-codebox-json phpunit phpunit-testdox


### PR DESCRIPTION
## Summary
- Adds a shared `test-result-adapters.sh` helper with declarative adapters for WP Codebox JSON, PHPUnit summary/testdox, and Cargo test output.
- Replaces duplicated Rust and WordPress test-result parsing logic with thin adapter wrapper calls.
- Keeps the existing sidecar writer contract intact while making common parser formats reusable across extensions.

Closes #889.

## Verification
- `bash tests/runtime-helpers-smoke.sh`
- `bash wordpress/scripts/test/parse-wp-codebox-artifacts-smoke.sh`
- `bash rust/scripts/parse-test-results-smoke.sh`
- `bash -n scripts/lib/test-result-adapters.sh rust/scripts/parse-test-results.sh wordpress/scripts/test/parse-test-results.sh && git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspected existing Homeboy parser support and extension parser duplication, drafted the shared adapter helper and wrapper changes, and ran the verification commands above. Chris remains responsible for review and merge.