### PR TITLE
Add shared command capture helper

### DIFF
--- a/nodejs/scripts/build/build-runner-shell-smoke.sh
+++ b/nodejs/scripts/build/build-runner-shell-smoke.sh
@@ -30,7 +30,7 @@ assert(runner.startsWith('#!/usr/bin/env bash'), 'build runner declares bash she
 assert(runner.includes('exec bash "$0" "$@"'), 'build runner re-execs bash when invoked by sh');
 assert(runner.includes('set -euo pipefail'), 'build runner uses bash pipefail mode');
 assert(runner.includes('BASH_SOURCE[0]'), 'build runner uses bash BASH_SOURCE');
-assert(runner.includes('PIPESTATUS[0]'), 'build runner uses bash PIPESTATUS');
+assert(runner.includes('homeboy_run_step_capture'), 'build runner uses shared command capture');
 
 if (process.exitCode) {
   process.exit();

--- a/nodejs/scripts/build/build-runner.sh
+++ b/nodejs/scripts/build/build-runner.sh
@@ -29,9 +29,12 @@ source "$BASH_PREFLIGHT_HELPER"
 homeboy_require_bash_version 4
 
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${SCRIPT_DIR}/../lib/command-capture.sh}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
+# shellcheck source=/dev/null
+source "$COMMAND_CAPTURE_HELPER"
 # shellcheck source=../lib/node-helpers.sh
 source "${SCRIPT_DIR}/../lib/node-helpers.sh"
 homeboy_require_package_json
@@ -87,17 +90,11 @@ echo ""
 
 cd "$PROJECT_PATH"
 
-OUTPUT_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-node-build.XXXXXX")
-set +e
-# shellcheck disable=SC2086
-$BUILD_CMD "$@" 2>&1 | tee "$OUTPUT_FILE"
-BUILD_EXIT=${PIPESTATUS[0]}
-set -e
+homeboy_run_step_capture OUTPUT_FILE BUILD_EXIT "Build failed" -- bash -c "$BUILD_CMD \"\$@\"" _ "$@" || true
 
 if [ $BUILD_EXIT -ne 0 ]; then
     FAILED_STEP="Build failed (exit $BUILD_EXIT)"
-    FAILURE_OUTPUT="$(tail -20 "$OUTPUT_FILE")"
 fi
 
-rm -f "$OUTPUT_FILE"
+homeboy_cleanup_step_capture "$OUTPUT_FILE"
 exit $BUILD_EXIT

--- a/nodejs/scripts/lib/command-capture.sh
+++ b/nodejs/scripts/lib/command-capture.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Direct-invocation fallback for Homeboy core's shared command-capture helper.
+# Keep this file aligned across installed extension trees.
+
+homeboy_run_step_capture() {
+    local output_var="$1"
+    local exit_var="$2"
+    local step_name="$3"
+    shift 3
+
+    if [ "${1:-}" = "--" ]; then
+        shift
+    fi
+
+    if [ "$#" -eq 0 ]; then
+        printf -v "$output_var" '%s' ''
+        printf -v "$exit_var" '%s' '127'
+        FAILED_STEP="${step_name}"
+        FAILURE_OUTPUT="No command provided"
+        return 127
+    fi
+
+    local output_file
+    output_file="$(mktemp "${TMPDIR:-/tmp}/homeboy-command.XXXXXX")"
+
+    set +e
+    "$@" 2>&1 | tee "$output_file"
+    local command_exit=${PIPESTATUS[0]}
+    set -e
+
+    printf -v "$output_var" '%s' "$output_file"
+    printf -v "$exit_var" '%s' "$command_exit"
+
+    if [ "$command_exit" -ne 0 ]; then
+        FAILED_STEP="${step_name}"
+        local tail_lines="${HOMEBOY_FAILURE_TAIL_LINES:-20}"
+        if [ "$tail_lines" -gt 0 ] 2>/dev/null; then
+            FAILURE_OUTPUT="$(tail -"$tail_lines" "$output_file")"
+        else
+            FAILURE_OUTPUT=""
+        fi
+    fi
+
+    return "$command_exit"
+}
+
+homeboy_cleanup_step_capture() {
+    local output_file="$1"
+    [ -z "$output_file" ] || rm -f "$output_file"
+}
+
+homeboy_run_step() {
+    local output_file=""
+    local command_exit="0"
+
+    homeboy_run_step_capture output_file command_exit "$@" || command_exit=$?
+    homeboy_cleanup_step_capture "$output_file"
+    return "$command_exit"
+}

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -34,6 +34,7 @@ source "$BASH_PREFLIGHT_HELPER"
 homeboy_require_bash_version 4
 
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${SCRIPT_DIR}/../lib/command-capture.sh}"
 SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
 SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SCRIPT_DIR}/../lib/settings.sh}"
 # shellcheck source=/dev/null
@@ -41,6 +42,7 @@ source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
 # shellcheck source=/dev/null
 source "$SETTINGS_HELPER"
+source "$COMMAND_CAPTURE_HELPER"
 # shellcheck source=/dev/null
 if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
     source "$SIDECAR_WRITER_HELPER"
@@ -142,12 +144,7 @@ echo ""
 
 cd "$PROJECT_PATH"
 
-OUTPUT_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-node-test.XXXXXX")
-set +e
-# shellcheck disable=SC2086 # word-splitting is intentional here
-$TEST_CMD "${RUNNER_ARGS[@]}" 2>&1 | tee "$OUTPUT_FILE"
-TEST_EXIT=${PIPESTATUS[0]}
-set -e
+homeboy_run_step_capture OUTPUT_FILE TEST_EXIT "Tests failed" -- bash -c "$TEST_CMD \"\$@\"" _ "${RUNNER_ARGS[@]}" || true
 
 OUTPUT="$(cat "$OUTPUT_FILE")"
 
@@ -314,12 +311,10 @@ if type homeboy_write_test_results >/dev/null 2>&1; then
 fi
 
 write_node_failure_json
-rm -f "$OUTPUT_FILE"
 
 if [ $TEST_EXIT -ne 0 ]; then
     FAILED_STEP="Tests failed (exit $TEST_EXIT)"
-    # Show the last 20 lines as failure context — full output already streamed above.
-    FAILURE_OUTPUT="$(echo "$OUTPUT" | tail -20)"
 fi
 
+homeboy_cleanup_step_capture "$OUTPUT_FILE"
 exit $TEST_EXIT

--- a/rust/scripts/lib/command-capture.sh
+++ b/rust/scripts/lib/command-capture.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Direct-invocation fallback for Homeboy core's shared command-capture helper.
+# Keep this file aligned across installed extension trees.
+
+homeboy_run_step_capture() {
+    local output_var="$1"
+    local exit_var="$2"
+    local step_name="$3"
+    shift 3
+
+    if [ "${1:-}" = "--" ]; then
+        shift
+    fi
+
+    if [ "$#" -eq 0 ]; then
+        printf -v "$output_var" '%s' ''
+        printf -v "$exit_var" '%s' '127'
+        FAILED_STEP="${step_name}"
+        FAILURE_OUTPUT="No command provided"
+        return 127
+    fi
+
+    local output_file
+    output_file="$(mktemp "${TMPDIR:-/tmp}/homeboy-command.XXXXXX")"
+
+    set +e
+    "$@" 2>&1 | tee "$output_file"
+    local command_exit=${PIPESTATUS[0]}
+    set -e
+
+    printf -v "$output_var" '%s' "$output_file"
+    printf -v "$exit_var" '%s' "$command_exit"
+
+    if [ "$command_exit" -ne 0 ]; then
+        FAILED_STEP="${step_name}"
+        local tail_lines="${HOMEBOY_FAILURE_TAIL_LINES:-20}"
+        if [ "$tail_lines" -gt 0 ] 2>/dev/null; then
+            FAILURE_OUTPUT="$(tail -"$tail_lines" "$output_file")"
+        else
+            FAILURE_OUTPUT=""
+        fi
+    fi
+
+    return "$command_exit"
+}
+
+homeboy_cleanup_step_capture() {
+    local output_file="$1"
+    [ -z "$output_file" ] || rm -f "$output_file"
+}
+
+homeboy_run_step() {
+    local output_file=""
+    local command_exit="0"
+
+    homeboy_run_step_capture output_file command_exit "$@" || command_exit=$?
+    homeboy_cleanup_step_capture "$output_file"
+    return "$command_exit"
+}

--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/lib/resolve-context.sh}"
 RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/../../scripts/lib/runner-steps.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${SCRIPT_DIR}/lib/command-capture.sh}"
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
 # shellcheck source=/dev/null
@@ -31,6 +32,8 @@ source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
 # shellcheck source=./lib/runner-steps.sh
 source "${RUNNER_STEPS_HELPER}"
+# shellcheck source=./lib/command-capture.sh
+source "${COMMAND_CAPTURE_HELPER}"
 # shellcheck source=/dev/null
 if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
     source "$FAILURE_TRAP_HELPER"
@@ -396,20 +399,16 @@ if should_run_step "clippy"; then
         echo "DEBUG: cargo ${CLIPPY_ARGS[*]}"
     fi
 
-    CLIPPY_TMPFILE=$(mktemp)
     CLIPPY_BEFORE=""
     if [ "${HOMEBOY_FIX_ONLY:-}" = "1" ]; then
         CLIPPY_BEFORE="$(mktemp)"
         capture_rust_file_hashes > "$CLIPPY_BEFORE"
     fi
 
-    set +e
-    cargo "${CLIPPY_ARGS[@]}" 2>&1 | tee "$CLIPPY_TMPFILE"
-    CLIPPY_EXIT=${PIPESTATUS[0]}
-    set -e
+    homeboy_run_step_capture CLIPPY_TMPFILE CLIPPY_EXIT "cargo clippy" -- cargo "${CLIPPY_ARGS[@]}" || true
 
     CLIPPY_OUTPUT=$(cat "$CLIPPY_TMPFILE")
-    rm -f "$CLIPPY_TMPFILE"
+    homeboy_cleanup_step_capture "$CLIPPY_TMPFILE"
 
     # Write annotations sidecar JSON for CI inline comments
     # Parse clippy's "warning: message\n  --> file:line:col" format

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/lib/resolve-context.sh}"
 RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/../../scripts/lib/runner-steps.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${SCRIPT_DIR}/lib/command-capture.sh}"
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
 # shellcheck source=/dev/null
@@ -26,6 +27,8 @@ source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
 # shellcheck source=./lib/runner-steps.sh
 source "${RUNNER_STEPS_HELPER}"
+# shellcheck source=./lib/command-capture.sh
+source "${COMMAND_CAPTURE_HELPER}"
 # shellcheck source=/dev/null
 if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
     source "$FAILURE_TRAP_HELPER"
@@ -97,12 +100,7 @@ if [ "${HOMEBOY_COVERAGE:-}" = "1" ]; then
             echo "DEBUG: cargo ${TARPAULIN_ARGS[*]} $*"
         fi
 
-        TEST_TMPFILE=$(mktemp)
-
-        set +e
-        cargo "${TARPAULIN_ARGS[@]}" "$@" 2>&1 | tee "$TEST_TMPFILE"
-        TEST_EXIT=${PIPESTATUS[0]}
-        set -e
+        homeboy_run_step_capture TEST_TMPFILE TEST_EXIT "cargo tarpaulin" -- cargo "${TARPAULIN_ARGS[@]}" "$@" || true
 
         # Parse test results for homeboy core (best-effort, non-blocking)
         PARSE_RESULTS="${EXTENSION_PATH}/scripts/parse-test-results.sh"
@@ -111,7 +109,7 @@ if [ "${HOMEBOY_COVERAGE:-}" = "1" ]; then
         fi
 
         TEST_OUTPUT=$(cat "$TEST_TMPFILE")
-        rm -f "$TEST_TMPFILE"
+        homeboy_cleanup_step_capture "$TEST_TMPFILE"
 
 
         if [ $TEST_EXIT -ne 0 ]; then
@@ -268,12 +266,7 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: cargo ${TEST_ARGS[*]} $*"
 fi
 
-TEST_TMPFILE=$(mktemp)
-
-set +e
-cargo "${TEST_ARGS[@]}" "$@" 2>&1 | tee "$TEST_TMPFILE"
-TEST_EXIT=${PIPESTATUS[0]}
-set -e
+homeboy_run_step_capture TEST_TMPFILE TEST_EXIT "cargo test" -- cargo "${TEST_ARGS[@]}" "$@" || true
 
 # Parse test results for homeboy core (best-effort, non-blocking)
 PARSE_RESULTS="${EXTENSION_PATH}/scripts/parse-test-results.sh"

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -18,6 +18,11 @@ SETTINGS_HELPERS=(
     "${ROOT_DIR}/rust/scripts/lib/settings.sh"
     "${ROOT_DIR}/wordpress/scripts/lib/settings.sh"
 )
+COMMAND_CAPTURE_HELPERS=(
+    "${ROOT_DIR}/nodejs/scripts/lib/command-capture.sh"
+    "${ROOT_DIR}/rust/scripts/lib/command-capture.sh"
+    "${ROOT_DIR}/wordpress/scripts/lib/command-capture.sh"
+)
 
 assert_file() {
     local path="$1"
@@ -63,6 +68,10 @@ for settings_helper in "${SETTINGS_HELPERS[@]}"; do
     assert_file "$settings_helper"
     bash -c 'source "$1"; type homeboy_setting >/dev/null; type homeboy_setting_bool >/dev/null; type homeboy_setting_array >/dev/null' _ "$settings_helper"
 done
+for command_capture_helper in "${COMMAND_CAPTURE_HELPERS[@]}"; do
+    assert_file "$command_capture_helper"
+    bash -c 'source "$1"; type homeboy_run_step >/dev/null; type homeboy_run_step_capture >/dev/null; type homeboy_cleanup_step_capture >/dev/null' _ "$command_capture_helper"
+done
 
 if ! cmp -s "${BASH_PREFLIGHT_HELPERS[0]}" "${BASH_PREFLIGHT_HELPERS[1]}" \
     || ! cmp -s "${BASH_PREFLIGHT_HELPERS[0]}" "${BASH_PREFLIGHT_HELPERS[2]}"; then
@@ -77,6 +86,12 @@ if ! cmp -s "${SETTINGS_HELPERS[0]}" "${SETTINGS_HELPERS[1]}" \
     exit 1
 fi
 
+if ! cmp -s "${COMMAND_CAPTURE_HELPERS[0]}" "${COMMAND_CAPTURE_HELPERS[1]}" \
+    || ! cmp -s "${COMMAND_CAPTURE_HELPERS[0]}" "${COMMAND_CAPTURE_HELPERS[2]}"; then
+    echo "Command capture helpers should stay identical across installed extension trees" >&2
+    exit 1
+fi
+
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -86,6 +101,55 @@ printf '[{"file":"b.php","line":2}]\n' > "$ANNOTATIONS_SOURCE"
 HOMEBOY_ANNOTATIONS_DIR="$ANNOTATIONS_DIR" bash -c 'source "$1"; homeboy_write_annotations phpcs "{\"file\":\"a.php\",\"line\":1}"; homeboy_merge_annotations phpstan "$2"' _ "$SIDECAR_WRITER_HELPER" "$ANNOTATIONS_SOURCE"
 assert_contains "$ANNOTATIONS_DIR/phpcs.json" '"file":"a.php"'
 assert_contains "$ANNOTATIONS_DIR/phpstan.json" '"file":"b.php"'
+
+# shellcheck source=/dev/null
+source "${COMMAND_CAPTURE_HELPERS[0]}"
+FAILED_STEP=""
+FAILURE_OUTPUT=""
+SUCCESS_OUTPUT_FILE=""
+SUCCESS_EXIT=""
+homeboy_run_step_capture SUCCESS_OUTPUT_FILE SUCCESS_EXIT "successful command" -- bash -c 'printf "ok\n"' || true
+if [ "$SUCCESS_EXIT" -ne 0 ]; then
+    echo "Expected successful command capture to preserve exit 0" >&2
+    exit 1
+fi
+assert_contains "$SUCCESS_OUTPUT_FILE" "ok"
+homeboy_cleanup_step_capture "$SUCCESS_OUTPUT_FILE"
+if [ -e "$SUCCESS_OUTPUT_FILE" ]; then
+    echo "Expected command capture cleanup to remove output file" >&2
+    exit 1
+fi
+
+FAILED_OUTPUT_FILE=""
+FAILED_EXIT=""
+homeboy_run_step_capture FAILED_OUTPUT_FILE FAILED_EXIT "failing command" -- bash -c 'printf "first\n"; printf "last\n"; exit 42' || true
+if [ "$FAILED_EXIT" -ne 42 ]; then
+    echo "Expected failing command capture to preserve exit 42, got ${FAILED_EXIT}" >&2
+    exit 1
+fi
+if [ "$FAILED_STEP" != "failing command" ]; then
+    echo "Expected failing command capture to set FAILED_STEP" >&2
+    exit 1
+fi
+case "$FAILURE_OUTPUT" in
+    *last*) ;;
+    *)
+        echo "Expected failing command capture to set FAILURE_OUTPUT tail" >&2
+        exit 1
+        ;;
+esac
+homeboy_cleanup_step_capture "$FAILED_OUTPUT_FILE"
+
+FAILED_STEP=""
+FAILURE_OUTPUT=""
+if homeboy_run_step "wrapped command" -- bash -c 'printf "wrapped\n"; exit 7'; then
+    echo "Expected wrapped command capture to preserve failure" >&2
+    exit 1
+fi
+if [ "$FAILED_STEP" != "wrapped command" ]; then
+    echo "Expected wrapped command capture to set FAILED_STEP" >&2
+    exit 1
+fi
 
 WORDPRESS_OUTPUT="$TMP_DIR/phpunit.txt"
 WORDPRESS_RESULTS="$TMP_DIR/wordpress-results.json"

--- a/wordpress/scripts/lib/command-capture.sh
+++ b/wordpress/scripts/lib/command-capture.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Direct-invocation fallback for Homeboy core's shared command-capture helper.
+# Keep this file aligned across installed extension trees.
+
+homeboy_run_step_capture() {
+    local output_var="$1"
+    local exit_var="$2"
+    local step_name="$3"
+    shift 3
+
+    if [ "${1:-}" = "--" ]; then
+        shift
+    fi
+
+    if [ "$#" -eq 0 ]; then
+        printf -v "$output_var" '%s' ''
+        printf -v "$exit_var" '%s' '127'
+        FAILED_STEP="${step_name}"
+        FAILURE_OUTPUT="No command provided"
+        return 127
+    fi
+
+    local output_file
+    output_file="$(mktemp "${TMPDIR:-/tmp}/homeboy-command.XXXXXX")"
+
+    set +e
+    "$@" 2>&1 | tee "$output_file"
+    local command_exit=${PIPESTATUS[0]}
+    set -e
+
+    printf -v "$output_var" '%s' "$output_file"
+    printf -v "$exit_var" '%s' "$command_exit"
+
+    if [ "$command_exit" -ne 0 ]; then
+        FAILED_STEP="${step_name}"
+        local tail_lines="${HOMEBOY_FAILURE_TAIL_LINES:-20}"
+        if [ "$tail_lines" -gt 0 ] 2>/dev/null; then
+            FAILURE_OUTPUT="$(tail -"$tail_lines" "$output_file")"
+        else
+            FAILURE_OUTPUT=""
+        fi
+    fi
+
+    return "$command_exit"
+}
+
+homeboy_cleanup_step_capture() {
+    local output_file="$1"
+    [ -z "$output_file" ] || rm -f "$output_file"
+}
+
+homeboy_run_step() {
+    local output_file=""
+    local command_exit="0"
+
+    homeboy_run_step_capture output_file command_exit "$@" || command_exit=$?
+    homeboy_cleanup_step_capture "$output_file"
+    return "$command_exit"
+}

--- a/wordpress/scripts/test/test-runner-core-dev.sh
+++ b/wordpress/scripts/test/test-runner-core-dev.sh
@@ -7,9 +7,21 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${SCRIPT_DIR}/../lib/command-capture.sh}"
+FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 # shellcheck source=../lib/resolve-context.sh
 source "${RESOLVE_CONTEXT_HELPER}"
 homeboy_resolve_context --component-alias PLUGIN_PATH
+# shellcheck source=../lib/command-capture.sh
+source "${COMMAND_CAPTURE_HELPER}"
+# shellcheck source=/dev/null
+if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
+    source "$FAILURE_TRAP_HELPER"
+    homeboy_init_failure_trap
+else
+    FAILED_STEP=""
+    FAILURE_OUTPUT=""
+fi
 
 CORE_PATH="$PLUGIN_PATH"
 
@@ -129,16 +141,7 @@ fi
 PHPUNIT_ARGS+=("$@")
 
 echo "Running WordPress core PHPUnit tests..."
-set +e
-PHPUNIT_OUTPUT=$("$PHPUNIT_BIN" "${PHPUNIT_ARGS[@]}" 2>&1)
-PHPUNIT_EXIT=$?
-set -e
-
-printf '%s\n' "$PHPUNIT_OUTPUT"
-
-PHPUNIT_OUTPUT_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wordpress-core-phpunit.XXXXXX")
-printf '%s\n' "$PHPUNIT_OUTPUT" > "$PHPUNIT_OUTPUT_FILE"
-trap 'rm -f "$PHPUNIT_OUTPUT_FILE"' EXIT
+homeboy_run_step_capture PHPUNIT_OUTPUT_FILE PHPUNIT_EXIT "WordPress core PHPUnit" -- "$PHPUNIT_BIN" "${PHPUNIT_ARGS[@]}" || true
 
 PARSE_RESULTS="${EXTENSION_PATH}/scripts/test/parse-test-results.sh"
 PARSE_FAILURES="${EXTENSION_PATH}/scripts/test/parse-test-failures.sh"
@@ -149,4 +152,5 @@ if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] && [ -f "$PARSE_FAILURES" ]; then
     bash "$PARSE_FAILURES" "$PHPUNIT_OUTPUT_FILE" "$CORE_PATH" || true
 fi
 
+homeboy_cleanup_step_capture "$PHPUNIT_OUTPUT_FILE"
 exit "$PHPUNIT_EXIT"


### PR DESCRIPTION
## Summary
- Adds a shared shell command-capture helper for extension runners, with streaming output, original exit-code preservation, failure trap fields, configurable summary tails, and cleanup helpers.
- Adopts the helper in representative NodeJS, Rust, and WordPress runner paths while preserving runner-specific parsing and sidecar behavior.
- Extends smoke coverage for helper parity, success/failure capture, cleanup, and wrapper behavior.

Closes #887.

## Verification
- `bash tests/runtime-helpers-smoke.sh`
- `bash nodejs/scripts/build/build-runner-shell-smoke.sh && bash nodejs/scripts/test/nodejs-targeted-script-smoke.sh && bash nodejs/scripts/test/nodejs-nx-vitest-timeout-smoke.sh && bash rust/scripts/parse-test-results-smoke.sh && bash tests/runner-steps-smoke.sh`
- `bash -n nodejs/scripts/lib/command-capture.sh nodejs/scripts/build/build-runner.sh nodejs/scripts/test/test-runner.sh rust/scripts/lib/command-capture.sh rust/scripts/test-runner.sh rust/scripts/lint-runner.sh wordpress/scripts/lib/command-capture.sh wordpress/scripts/test/test-runner-core-dev.sh tests/runtime-helpers-smoke.sh nodejs/scripts/build/build-runner-shell-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and tested the shared command-capture helper and representative runner migrations for Chris to review.