### PR TITLE
Use core sidecar helpers in WordPress runners

### DIFF
--- a/wordpress/scripts/lint/autofixable-exit-smoke.sh
+++ b/wordpress/scripts/lint/autofixable-exit-smoke.sh
@@ -2,9 +2,17 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
 RUNNER="${SCRIPT_DIR}/lint-runner.sh"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
+
+if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
+    echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
+    exit 1
+fi
 
 EXTENSION_DIR="${TMPDIR}/extension"
 COMPONENT_DIR="${TMPDIR}/component"
@@ -65,6 +73,7 @@ run_lint() {
         "HOMEBOY_COMPONENT_PATH=$COMPONENT_DIR"
         "HOMEBOY_COMPONENT_ID=autofixable-fixture"
         "HOMEBOY_LINT_FINDINGS_FILE=$FINDINGS_FILE"
+        "HOMEBOY_RUNTIME_SIDECAR_WRITER=$SIDECAR_WRITER_HELPER"
         "HOMEBOY_STEP=phpcs"
         "HOMEBOY_SUMMARY_MODE=$mode"
     )

--- a/wordpress/scripts/lint/eslint-glob-filter-smoke.sh
+++ b/wordpress/scripts/lint/eslint-glob-filter-smoke.sh
@@ -3,8 +3,16 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
+
+if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
+    echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
+    exit 1
+fi
 
 assert_contains() {
     local file="$1"
@@ -27,6 +35,7 @@ assert_not_contains() {
 }
 
 component_dir="${TMPDIR}/component"
+findings_file="${TMPDIR}/eslint-findings.json"
 mkdir -p "${component_dir}/inc" "${component_dir}/assets" "${EXTENSION_PATH}/node_modules/.bin"
 touch "${EXTENSION_PATH}/.eslintrc.json"
 printf '%s\n' '<?php' > "${component_dir}/inc/Thing.php"
@@ -60,11 +69,20 @@ HOMEBOY_COMPONENT_PATH="$component_dir" \
 HOMEBOY_COMPONENT_TEXT_DOMAIN="component" \
 HOMEBOY_SUMMARY_MODE=1 \
 HOMEBOY_LINT_GLOB="{${component_dir}/inc/Thing.php,${component_dir}/assets/app.js}" \
+HOMEBOY_LINT_FINDINGS_FILE="$findings_file" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
 ESLINT_LOG="$eslint_log" \
     bash "${EXTENSION_PATH}/scripts/lint/eslint-runner.sh" > "${TMPDIR}/mixed.out"
 
 assert_contains "${TMPDIR}/mixed.out" "Linting 1 JS/TS files matching"
 assert_contains "$eslint_log" "${component_dir}/assets/app.js"
 assert_not_contains "$eslint_log" "${component_dir}/inc/Thing.php"
+
+python3 - "$findings_file" <<'PY'
+import json
+import sys
+
+assert json.load(open(sys.argv[1], encoding="utf-8")) == []
+PY
 
 echo "ESLint glob filter smoke passed"

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -22,9 +22,30 @@ fi
 # Resolve execution context (shared helper)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
 # shellcheck source=../lib/resolve-context.sh
 source "${RESOLVE_CONTEXT_HELPER}"
 homeboy_resolve_context --component-alias PLUGIN_PATH
+# shellcheck source=/dev/null
+if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
+    source "$SIDECAR_WRITER_HELPER"
+fi
+
+write_eslint_findings_sidecar() {
+    local target="$1"
+    local source="$2"
+
+    [ -z "$target" ] && return 0
+    [ ! -s "$source" ] && return 0
+
+    if ! type homeboy_sidecar_merge_json_array >/dev/null 2>&1; then
+        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write ESLint lint findings" >&2
+        return 1
+    fi
+
+    rm -f "$target"
+    homeboy_sidecar_merge_json_array "$target" "$source"
+}
 
 # Check if component has JavaScript files
 js_file_count=$(find "$PLUGIN_PATH" -type f \( -name "*.js" -o -name "*.jsx" -o -name "*.ts" -o -name "*.tsx" \) \
@@ -178,6 +199,7 @@ set -e
 # and PHPStan findings. Direct ESLint runs may write HOMEBOY_LINT_FINDINGS_FILE.
 ESLINT_FINDINGS_FILE="${_HOMEBOY_ESLINT_FINDINGS_FILE:-${HOMEBOY_LINT_FINDINGS_FILE:-}}"
 if [ -n "$ESLINT_FINDINGS_FILE" ] && [ -n "$json_output" ] && command -v node &> /dev/null; then
+    ESLINT_FINDINGS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-eslint-findings.XXXXXX")
     node -e '
         const fs = require("fs");
         const path = require("path");
@@ -227,7 +249,9 @@ if [ -n "$ESLINT_FINDINGS_FILE" ] && [ -n "$json_output" ] && command -v node &>
             }
         }
         fs.writeFileSync(outputFile, JSON.stringify(findings) + "\n");
-    ' "$json_output" "$PLUGIN_PATH" "$ESLINT_FINDINGS_FILE" 2>/dev/null || true
+    ' "$json_output" "$PLUGIN_PATH" "$ESLINT_FINDINGS_TMPFILE" 2>/dev/null || true
+    write_eslint_findings_sidecar "$ESLINT_FINDINGS_FILE" "$ESLINT_FINDINGS_TMPFILE" || exit 1
+    rm -f "$ESLINT_FINDINGS_TMPFILE"
 fi
 
 # Parse JSON and print summary header (only if issues exist)

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -20,6 +20,12 @@ RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/../lib/runner
 # shellcheck source=../lib/runner-steps.sh
 source "${RUNNER_STEPS_HELPER}"
 
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
+# shellcheck source=/dev/null
+if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
+    source "$SIDECAR_WRITER_HELPER"
+fi
+
 
 # Debug environment variables (only shown when HOMEBOY_DEBUG=1)
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -115,21 +121,28 @@ merge_findings_into_sidecar() {
     [ -z "$target" ] && return 0
     [ ! -f "$extra_file" ] && return 0
 
-    # If the target doesn't exist yet, just copy the extra file
-    if [ ! -f "$target" ]; then
-        cp "$extra_file" "$target"
-        return 0
+    if ! type homeboy_merge_lint_findings >/dev/null 2>&1; then
+        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to merge lint findings" >&2
+        return 1
     fi
 
-    # Merge both JSON arrays into one
-    if command -v php &> /dev/null; then
-        php -r '
-            $existing = json_decode(file_get_contents($argv[1]), true) ?: [];
-            $extra = json_decode(file_get_contents($argv[2]), true) ?: [];
-            $merged = array_merge($existing, $extra);
-            file_put_contents($argv[1], json_encode($merged, JSON_UNESCAPED_SLASHES) . "\n");
-        ' "$target" "$extra_file" 2>/dev/null || true
+    homeboy_merge_lint_findings "$extra_file"
+}
+
+write_json_array_sidecar_file() {
+    local target="$1"
+    local source="$2"
+
+    [ -z "$target" ] && return 0
+    [ ! -f "$source" ] && return 0
+
+    if ! type homeboy_sidecar_merge_json_array >/dev/null 2>&1; then
+        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write JSON array sidecars" >&2
+        return 1
     fi
+
+    rm -f "$target"
+    homeboy_sidecar_merge_json_array "$target" "$source"
 }
 
 # Determine lint target (file, glob, or full component)
@@ -574,12 +587,18 @@ print(json.dumps(results))
 
     # Write fix plan sidecar for planning flows (same shape as fix results)
     if [ -n "${HOMEBOY_FIX_PLAN_FILE:-}" ]; then
-        echo "$FIX_RESULTS_JSON" > "${HOMEBOY_FIX_PLAN_FILE}"
+        FIX_RESULTS_TMPFILE=$(homeboy_mktemp 'wordpress-fix-results.XXXXXX')
+        printf '%s\n' "$FIX_RESULTS_JSON" > "$FIX_RESULTS_TMPFILE"
+        write_json_array_sidecar_file "${HOMEBOY_FIX_PLAN_FILE}" "$FIX_RESULTS_TMPFILE"
+        rm -f "$FIX_RESULTS_TMPFILE"
     fi
 
     # Write fix results sidecar for homeboy to consume
     if [ -n "${HOMEBOY_FIX_RESULTS_FILE:-}" ]; then
-        echo "$FIX_RESULTS_JSON" > "${HOMEBOY_FIX_RESULTS_FILE}"
+        FIX_RESULTS_TMPFILE=$(homeboy_mktemp 'wordpress-fix-results.XXXXXX')
+        printf '%s\n' "$FIX_RESULTS_JSON" > "$FIX_RESULTS_TMPFILE"
+        write_json_array_sidecar_file "${HOMEBOY_FIX_RESULTS_FILE}" "$FIX_RESULTS_TMPFILE"
+        rm -f "$FIX_RESULTS_TMPFILE"
     fi
 
     # Post-fix syntax validation — catch any fixer that produced broken PHP
@@ -785,7 +804,8 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
     #   [{id: "file::source::line", message: "...", category: "..."}]
     # Category is derived from the top-level PHPCS source namespace.
     if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
-        echo "$json_output" | php -r '
+        _PHPCS_FINDINGS_TMPFILE=$(homeboy_mktemp 'phpcs-findings.XXXXXX')
+        if echo "$json_output" | php -r '
             ini_set("memory_limit", "-1");
             $json = json_decode(file_get_contents("php://stdin"), true);
             if (!$json || empty($json["files"])) {
@@ -858,7 +878,10 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
                 }
             }
             file_put_contents($argv[2], json_encode($findings, JSON_UNESCAPED_SLASHES) . "\n");
-        ' "$PLUGIN_PATH" "${HOMEBOY_LINT_FINDINGS_FILE}" 2>/dev/null || true
+        ' "$PLUGIN_PATH" "${_PHPCS_FINDINGS_TMPFILE}" 2>/dev/null; then
+            write_json_array_sidecar_file "${HOMEBOY_LINT_FINDINGS_FILE}" "${_PHPCS_FINDINGS_TMPFILE}" || exit 1
+        fi
+        rm -f "${_PHPCS_FINDINGS_TMPFILE}"
     fi
 fi
 

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -89,9 +89,14 @@ fi
 
 # Resolve execution context (shared helper)
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
 # shellcheck source=../lib/resolve-context.sh
 source "${RESOLVE_CONTEXT_HELPER}"
 homeboy_resolve_context --component-alias PLUGIN_PATH
+# shellcheck source=/dev/null
+if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
+    source "$SIDECAR_WRITER_HELPER"
+fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Extension path: $EXTENSION_PATH"
@@ -158,6 +163,22 @@ homeboy_mktemp() {
     fi
 
     mktemp 2>/dev/null
+}
+
+write_phpstan_findings_sidecar() {
+    local target="$1"
+    local source="$2"
+
+    [ -z "$target" ] && return 0
+    [ ! -s "$source" ] && return 0
+
+    if ! type homeboy_sidecar_merge_json_array >/dev/null 2>&1; then
+        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write PHPStan lint findings" >&2
+        return 1
+    fi
+
+    rm -f "$target"
+    homeboy_sidecar_merge_json_array "$target" "$source"
 }
 
 # Validate PHPStan exists (soft failure - not all installations have it)
@@ -900,6 +921,7 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
     #   [{id: "file::identifier::line", message: "...", category: "phpstan"}]
     # The lint-runner merges these with PHPCS findings into the final baseline.
     if [ -n "${_HOMEBOY_PHPSTAN_FINDINGS_FILE:-}" ] && [ -n "$json_output" ]; then
+        _PHPSTAN_FINDINGS_OUTPUT_TMPFILE=$(homeboy_mktemp 'phpstan-findings.XXXXXX')
         echo "$json_output" | php -r '
             $json = json_decode(file_get_contents("php://stdin"), true);
             if (!$json || empty($json["files"])) {
@@ -944,7 +966,9 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
                 }
             }
             file_put_contents($argv[2], json_encode($findings, JSON_UNESCAPED_SLASHES) . "\n");
-        ' "$PLUGIN_PATH" "${_HOMEBOY_PHPSTAN_FINDINGS_FILE}" 2>/dev/null || true
+        ' "$PLUGIN_PATH" "${_PHPSTAN_FINDINGS_OUTPUT_TMPFILE}" 2>/dev/null || true
+        write_phpstan_findings_sidecar "${_HOMEBOY_PHPSTAN_FINDINGS_FILE}" "${_PHPSTAN_FINDINGS_OUTPUT_TMPFILE}" || exit 1
+        rm -f "${_PHPSTAN_FINDINGS_OUTPUT_TMPFILE}"
     fi
 
     # Fallback: show stderr if PHPStan failed without producing JSON

--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -2,9 +2,17 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${ROOT_DIR}/.." && pwd)/homeboy}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/sidecar-writer.sh}"
 RUNNER="${SCRIPT_DIR}/phpstan-runner.sh"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
+
+if [ ! -f "$SIDECAR_WRITER_HELPER" ]; then
+    echo "Missing sidecar writer helper: $SIDECAR_WRITER_HELPER" >&2
+    exit 1
+fi
 
 EXTENSION_DIR="${TMPDIR}/extension"
 COMPONENT_DIR="${TMPDIR}/component"
@@ -183,6 +191,7 @@ PHPSTAN_CONFIG_CAPTURE="$CONFIG_CAPTURE" \
 PHPSTAN_AUTOLOAD_CAPTURE="$AUTOLOAD_CAPTURE" \
 PHPSTAN_EMIT_ERROR=1 \
 _HOMEBOY_PHPSTAN_FINDINGS_FILE="$FINDINGS_FILE" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER_HELPER" \
 HOMEBOY_SUMMARY_MODE=1 \
 "$RUNNER" >"$OUTPUT_FILE"
 phpstan_error_status=$?


### PR DESCRIPTION
## Summary
- Routes WordPress PHPCS, ESLint, PHPStan, and fix-result JSON array sidecar writes through the core runtime sidecar writer helper.
- Keeps WordPress-specific parsing and current lint finding/fingerprint/fix-result shapes extension-local.
- Updates focused WordPress smokes so PHPCS, ESLint, and PHPStan sidecar paths exercise `HOMEBOY_RUNTIME_SIDECAR_WRITER`.

Closes #791.

## Verification
- `bash -n wordpress/scripts/lint/lint-runner.sh wordpress/scripts/lint/eslint-runner.sh wordpress/scripts/lint/phpstan-runner.sh wordpress/scripts/lint/autofixable-exit-smoke.sh wordpress/scripts/lint/eslint-glob-filter-smoke.sh wordpress/scripts/lint/phpstan-scoped-smoke.sh wordpress/scripts/test/parse-test-failures.sh wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh`
- `bash wordpress/scripts/lint/autofixable-exit-smoke.sh`
- `bash wordpress/scripts/lint/eslint-glob-filter-smoke.sh`
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `bash wordpress/scripts/test/parse-test-failures-sidecar-smoke.sh && bash wordpress/scripts/test/parse-wp-codebox-artifacts-smoke.sh`
- `bash tests/runtime-helpers-smoke.sh && node tests/structured-sidecars-smoke.mjs`
- Earlier pre-rebase focused checks also covered `bash wordpress/scripts/lint/eslint-no-files-smoke.sh` and `bash tests/cross-extension-sidecar-normalization-smoke.sh`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the WordPress sidecar helper migration, updated focused smoke coverage, and ran local verification. Chris remains responsible for review and merge.