### PR TITLE
Use core helper for annotation sidecars

### DIFF
--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -333,6 +333,11 @@ if should_run_step "fmt"; then
             # Write annotations sidecar for fmt issues
             # Parse "Diff in /path/to/file.rs at line N:" format
             if [ -n "${HOMEBOY_ANNOTATIONS_DIR:-}" ] && [ -d "${HOMEBOY_ANNOTATIONS_DIR}" ]; then
+                if ! type homeboy_merge_annotations >/dev/null 2>&1; then
+                    echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write annotations" >&2
+                    exit 1
+                fi
+                FMT_ANNOTATIONS_TMP="$(mktemp)"
                 echo "$FMT_OUTPUT" | awk -v comp_path="${PROJECT_PATH}/" '
                     /^Diff in .+ at line [0-9]+:/ {
                         file = $3
@@ -349,8 +354,9 @@ if should_run_step "fmt"; then
                             print "[\n" annotations "\n]"
                         }
                     }
-                ' > "${HOMEBOY_ANNOTATIONS_DIR}/rustfmt.json" 2>/dev/null || true
-                [ -s "${HOMEBOY_ANNOTATIONS_DIR}/rustfmt.json" ] || rm -f "${HOMEBOY_ANNOTATIONS_DIR}/rustfmt.json"
+                ' > "$FMT_ANNOTATIONS_TMP" 2>/dev/null || true
+                homeboy_merge_annotations rustfmt "$FMT_ANNOTATIONS_TMP"
+                rm -f "$FMT_ANNOTATIONS_TMP"
             fi
 
             FAILED_STEP="cargo fmt --check"
@@ -408,6 +414,11 @@ if should_run_step "clippy"; then
     # Write annotations sidecar JSON for CI inline comments
     # Parse clippy's "warning: message\n  --> file:line:col" format
     if [ -n "${HOMEBOY_ANNOTATIONS_DIR:-}" ] && [ -d "${HOMEBOY_ANNOTATIONS_DIR}" ]; then
+        if ! type homeboy_merge_annotations >/dev/null 2>&1; then
+            echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write annotations" >&2
+            exit 1
+        fi
+        CLIPPY_ANNOTATIONS_TMP="$(mktemp)"
         # Use awk to pair "warning/error" lines with their "--> file:line:col" location
         echo "$CLIPPY_OUTPUT" | awk '
             /^(warning|error)(\[.+\])?: / {
@@ -442,9 +453,9 @@ if should_run_step "clippy"; then
                     print "[\n" annotations "\n]"
                 }
             }
-        ' > "${HOMEBOY_ANNOTATIONS_DIR}/clippy.json" 2>/dev/null || true
-        # Remove empty file if no annotations were written
-        [ -s "${HOMEBOY_ANNOTATIONS_DIR}/clippy.json" ] || rm -f "${HOMEBOY_ANNOTATIONS_DIR}/clippy.json"
+        ' > "$CLIPPY_ANNOTATIONS_TMP" 2>/dev/null || true
+        homeboy_merge_annotations clippy "$CLIPPY_ANNOTATIONS_TMP"
+        rm -f "$CLIPPY_ANNOTATIONS_TMP"
     fi
 
     if [ $CLIPPY_EXIT -eq 0 ]; then

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -47,7 +47,7 @@ assert_file "$FAILURE_TRAP_HELPER"
 assert_file "$WRITE_TEST_RESULTS_HELPER"
 assert_file "$SIDECAR_WRITER_HELPER"
 assert_file "$PROJECT_SCRIPTS_HELPER"
-bash -c 'source "$1"; type homeboy_merge_lint_findings >/dev/null; type homeboy_merge_test_failures >/dev/null; type homeboy_write_fix_results >/dev/null' _ "$SIDECAR_WRITER_HELPER"
+bash -c 'source "$1"; type homeboy_merge_lint_findings >/dev/null; type homeboy_merge_test_failures >/dev/null; type homeboy_write_fix_results >/dev/null; type homeboy_merge_annotations >/dev/null' _ "$SIDECAR_WRITER_HELPER"
 bash -c 'source "$1"; type homeboy_project_init >/dev/null; type homeboy_project_has_script >/dev/null; type homeboy_project_run_script_command >/dev/null' _ "$PROJECT_SCRIPTS_HELPER"
 for bash_preflight_helper in "${BASH_PREFLIGHT_HELPERS[@]}"; do
     assert_file "$bash_preflight_helper"
@@ -62,6 +62,13 @@ fi
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+
+ANNOTATIONS_DIR="$TMP_DIR/annotations"
+ANNOTATIONS_SOURCE="$TMP_DIR/extra-annotations.json"
+printf '[{"file":"b.php","line":2}]\n' > "$ANNOTATIONS_SOURCE"
+HOMEBOY_ANNOTATIONS_DIR="$ANNOTATIONS_DIR" bash -c 'source "$1"; homeboy_write_annotations phpcs "{\"file\":\"a.php\",\"line\":1}"; homeboy_merge_annotations phpstan "$2"' _ "$SIDECAR_WRITER_HELPER" "$ANNOTATIONS_SOURCE"
+assert_contains "$ANNOTATIONS_DIR/phpcs.json" '"file":"a.php"'
+assert_contains "$ANNOTATIONS_DIR/phpstan.json" '"file":"b.php"'
 
 WORDPRESS_OUTPUT="$TMP_DIR/phpunit.txt"
 WORDPRESS_RESULTS="$TMP_DIR/wordpress-results.json"

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -19,6 +19,11 @@ homeboy_require_bash_version 4
 RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${SCRIPT_DIR}/../lib/runner-steps.sh}"
 # shellcheck source=../lib/runner-steps.sh
 source "${RUNNER_STEPS_HELPER}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
+# shellcheck source=/dev/null
+if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
+    source "$SIDECAR_WRITER_HELPER"
+fi
 
 
 # Debug environment variables (only shown when HOMEBOY_DEBUG=1)
@@ -750,6 +755,11 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
 
     # Write annotations sidecar JSON for CI inline comments
     if [ -n "${HOMEBOY_ANNOTATIONS_DIR:-}" ] && [ -d "${HOMEBOY_ANNOTATIONS_DIR}" ]; then
+        if ! type homeboy_merge_annotations >/dev/null 2>&1; then
+            echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write annotations" >&2
+            exit 1
+        fi
+        annotations_tmpfile="$(homeboy_mktemp 'phpcs-annotations.XXXXXX.json')"
         echo "$json_output" | php -r '
             ini_set("memory_limit", "-1");
             $json = json_decode(file_get_contents("php://stdin"), true);
@@ -773,11 +783,12 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
                     ];
                 }
             }
-            $outDir = $argv[2] ?? "";
-            if ($outDir && !empty($annotations)) {
-                file_put_contents($outDir . "/phpcs.json", json_encode($annotations, JSON_PRETTY_PRINT) . "\n");
+            if (!empty($annotations)) {
+                file_put_contents($argv[2], json_encode($annotations, JSON_PRETTY_PRINT) . "\n");
             }
-        ' "$PLUGIN_PATH" "${HOMEBOY_ANNOTATIONS_DIR}" 2>/dev/null || true
+        ' "$PLUGIN_PATH" "$annotations_tmpfile" 2>/dev/null || true
+        homeboy_merge_annotations phpcs "$annotations_tmpfile"
+        rm -f "$annotations_tmpfile"
     fi
 
     # Write lint findings sidecar for homeboy baseline and categorized issues.

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -5,6 +5,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
 # shellcheck source=../lib/validation-dependencies.sh
 source "${DEPENDENCY_HELPER}"
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
+# shellcheck source=/dev/null
+if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
+    source "$SIDECAR_WRITER_HELPER"
+fi
 
 # Standalone PHP static analysis script using PHPStan
 # Supports summary mode via HOMEBOY_SUMMARY_MODE=1
@@ -866,6 +871,11 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
 
     # Write annotations sidecar JSON for CI inline comments
     if [ -n "${HOMEBOY_ANNOTATIONS_DIR:-}" ] && [ -d "${HOMEBOY_ANNOTATIONS_DIR}" ] && [ -n "$json_output" ]; then
+        if ! type homeboy_merge_annotations >/dev/null 2>&1; then
+            echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write annotations" >&2
+            exit 1
+        fi
+        annotations_tmpfile="$(homeboy_mktemp 'phpstan-annotations.XXXXXX.json')"
         echo "$json_output" | php -r '
             $json = json_decode(file_get_contents("php://stdin"), true);
             if (!$json || empty($json["files"])) exit;
@@ -888,11 +898,12 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
                     ];
                 }
             }
-            $outDir = $argv[3] ?? "";
-            if ($outDir && !empty($annotations)) {
-                file_put_contents($outDir . "/phpstan.json", json_encode($annotations, JSON_PRETTY_PRINT) . "\n");
+            if (!empty($annotations)) {
+                file_put_contents($argv[3], json_encode($annotations, JSON_PRETTY_PRINT) . "\n");
             }
-        ' "$PLUGIN_PATH" "$PHPSTAN_LEVEL" "${HOMEBOY_ANNOTATIONS_DIR}" 2>/dev/null || true
+        ' "$PLUGIN_PATH" "$PHPSTAN_LEVEL" "$annotations_tmpfile" 2>/dev/null || true
+        homeboy_merge_annotations phpstan "$annotations_tmpfile"
+        rm -f "$annotations_tmpfile"
     fi
 
     # Write PHPStan lint findings sidecar for homeboy baseline ratchet.


### PR DESCRIPTION
## Summary
- Migrates Rust `rustfmt`/`clippy` annotation sidecars to the shared runtime sidecar writer.
- Migrates WordPress PHPCS/PHPStan annotation sidecars to the shared runtime sidecar writer.
- Extends the runtime helper smoke test to require and exercise generic annotation sidecar helpers.

## Dependency
- Depends on Extra-Chill/homeboy#3094 for `homeboy_merge_annotations` / `homeboy_write_annotations` in `HOMEBOY_RUNTIME_SIDECAR_WRITER`.

Fixes Extra-Chill/homeboy-extensions#901.

## Verification
- `HOMEBOY_CORE_DIR="/Users/chubes/Developer/homeboy@fix-issue-901-annotation-sidecar-helper" bash tests/runtime-helpers-smoke.sh`
- `bash -n rust/scripts/lint-runner.sh wordpress/scripts/lint/lint-runner.sh wordpress/scripts/lint/phpstan-runner.sh tests/runtime-helpers-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the shell runtime-helper migration and smoke coverage; Chris remains responsible for review and merge.