### PR TITLE
Add browser page scenario bench helper

### DIFF
--- a/nodejs/docs/browser-bench-helpers.md
+++ b/nodejs/docs/browser-bench-helpers.md
@@ -1,0 +1,34 @@
+# Node.js Browser Bench Helpers
+
+Browser benchmark workloads can import the helper path exported by
+`HOMEBOY_NODEJS_BROWSER_BENCH_HELPER`.
+
+```js
+const { runBrowserPageScenario } = await import(process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER);
+
+export default async function () {
+  return runBrowserPageScenario({
+    id: 'homepage',
+    target: 'https://example.test/',
+    assertions: [
+      { type: 'status', expected: 200 },
+      { type: 'selector', selector: 'main' },
+      { type: 'artifact', key: 'trace', kind: 'playwright-trace' },
+    ],
+    action: async ({ page, mark }) => {
+      await page.getByRole('heading').first().waitFor();
+      await mark('heading_visible');
+    },
+  });
+}
+```
+
+`runBrowserPageScenario()` wraps the lower-level `runBrowserBench()` lifecycle
+without changing that API. It opens the target page, runs workload actions,
+checks page and artifact assertions, writes a stable raw result artifact, and
+returns `{ metrics, artifacts }` for the Homeboy bench runner.
+
+The helper is substrate-agnostic. Assertions describe generic browser/page
+facts such as status, selectors, text, title, and artifact presence. Workloads
+can provide `sanitizeArtifacts()` or `sanitizeRawResult()` hooks to redact or
+normalize generated artifacts before returning results.

--- a/nodejs/scripts/bench/browser-helper.mjs
+++ b/nodejs/scripts/bench/browser-helper.mjs
@@ -569,6 +569,59 @@ export async function runBrowserBench(options) {
     return { metrics, artifacts };
 }
 
+export async function runBrowserPageScenario(options) {
+    const config = normalizePageScenarioOptions(options);
+    let response = null;
+
+    const result = await config.browserBench({
+        ...config.browserOptions,
+        id: config.id,
+        artifactsDir: config.artifactsDir,
+        action: async (context) => {
+            const { page, mark } = context;
+            if (config.target) {
+                response = await page.goto(config.target, config.gotoOptions);
+                await mark('page_loaded');
+            }
+            if (config.action) {
+                await config.action({ ...context, response, target: config.target });
+            }
+            await runPageScenarioAssertions({ assertions: config.pageAssertions, page, response, target: config.target });
+        },
+    });
+
+    const metrics = stableJson(result.metrics || {});
+    let artifacts = stableJson({ ...(result.artifacts || {}), ...config.artifacts });
+    await runPageScenarioAssertions({ assertions: config.artifactAssertions, artifacts, metrics, target: config.target });
+
+    const rawResult = stableJson({
+        artifacts,
+        id: config.id,
+        metadata: config.metadata,
+        metrics,
+        target: config.target,
+    });
+    const rawResultPath = join(config.artifactsDir, `${config.id}-raw-result.json`);
+    await writeJson(rawResultPath, config.sanitizeRawResult ? await config.sanitizeRawResult(rawResult) : rawResult);
+    artifacts = stableJson({
+        ...artifacts,
+        rawResult: {
+            path: rawResultPath,
+            kind: 'browser-page-scenario-result',
+            label: 'Browser page scenario raw result',
+        },
+    });
+
+    if (config.sanitizeArtifacts) {
+        const sanitized = await config.sanitizeArtifacts({ artifacts, metrics, id: config.id, target: config.target });
+        if (sanitized !== undefined) artifacts = stableJson(sanitized);
+    }
+
+    await runPageScenarioAssertions({ assertions: config.postSanitizeArtifactAssertions, artifacts, metrics, target: config.target });
+
+    return { metrics, artifacts };
+}
+
 function normalizeOptions(options) {
     if (!options || typeof options !== 'object' || Array.isArray(options)) {
         throw new Error('runBrowserBench requires an options object.');
@@ -600,6 +653,153 @@ function normalizeOptions(options) {
         launchOptions: options.launchOptions || {},
         contextOptions: options.contextOptions || {},
     };
+}
+
+function normalizePageScenarioOptions(options) {
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+        throw new Error('runBrowserPageScenario requires an options object.');
+    }
+
+    const id = sanitizeFilePart(options.id || 'browser-page-scenario');
+    const componentPath = process.env.HOMEBOY_COMPONENT_PATH || process.cwd();
+    const artifactsDir = resolve(
+        options.artifactsDir ||
+        options.artifactDir ||
+        process.env.HOMEBOY_BENCH_ARTIFACTS_DIR ||
+        join(componentPath, '.homeboy-bench-artifacts', id)
+    );
+    const assertions = Array.isArray(options.assertions) ? options.assertions : [];
+    const pageAssertions = assertions.filter((assertion) => !isArtifactAssertion(assertion));
+    const artifactAssertions = assertions.filter(isArtifactAssertion);
+    const postSanitizeArtifactAssertions = Array.isArray(options.postSanitizeAssertions) ? options.postSanitizeAssertions.filter(isArtifactAssertion) : [];
+    const browserBench = options.browserBench || runBrowserBench;
+
+    if (typeof browserBench !== 'function') {
+        throw new Error('runBrowserPageScenario requires browserBench to be a function when provided.');
+    }
+
+    return {
+        id,
+        artifactsDir,
+        target: typeof options.target === 'string' && options.target.trim() !== '' ? options.target : '',
+        gotoOptions: options.gotoOptions || {},
+        action: typeof options.action === 'function' ? options.action : null,
+        artifacts: normalizeStaticArtifacts(options.artifacts),
+        metadata: normalizeJsonObject(options.metadata, 'metadata'),
+        sanitizeArtifacts: normalizeOptionalFunction(options.sanitizeArtifacts, 'sanitizeArtifacts'),
+        sanitizeRawResult: normalizeOptionalFunction(options.sanitizeRawResult, 'sanitizeRawResult'),
+        browserBench,
+        pageAssertions,
+        artifactAssertions,
+        postSanitizeArtifactAssertions,
+        browserOptions: {
+            actions: Array.isArray(options.actions) ? options.actions : [],
+            actionOptions: options.actionOptions || {},
+            browserName: options.browserName,
+            contextOptions: options.contextOptions,
+            headless: options.headless,
+            launchOptions: options.launchOptions,
+            networkIdleTimeoutMs: options.networkIdleTimeoutMs,
+            screenshot: options.screenshot,
+            trace: options.trace,
+            waitForNetworkIdle: options.waitForNetworkIdle,
+        },
+    };
+}
+
+async function runPageScenarioAssertions(context) {
+    const assertions = Array.isArray(context.assertions) ? context.assertions : [];
+    for (let index = 0; index < assertions.length; index += 1) {
+        const assertion = assertions[index];
+        if (typeof assertion === 'function') {
+            await assertion({ ...context, assert: pageScenarioAssert });
+            continue;
+        }
+        await runPageScenarioAssertion(assertion, index, context);
+    }
+}
+
+async function runPageScenarioAssertion(assertion, index, context) {
+    if (!assertion || typeof assertion !== 'object' || Array.isArray(assertion)) {
+        throw new Error(`Browser page scenario assertion ${index} must be an object or function.`);
+    }
+
+    const type = assertion.type || inferPageScenarioAssertionType(assertion);
+    if (type === 'status') {
+        const status = typeof context.response?.status === 'function' ? context.response.status() : context.response?.status;
+        const expected = assertion.expected ?? assertion.expectedStatus ?? assertion.status ?? 200;
+        pageScenarioAssert(Number(status) === Number(expected), assertion.message || `Expected page status ${expected}, got ${status ?? 'none'}.`);
+        return;
+    }
+    if (type === 'selector') {
+        pageScenarioAssert(context.page && typeof context.page.waitForSelector === 'function', 'Selector assertion requires page.waitForSelector().');
+        await context.page.waitForSelector(assertion.selector, { state: assertion.state || 'visible', timeout: assertion.timeout || 30000 });
+        return;
+    }
+    if (type === 'text') {
+        pageScenarioAssert(context.page && typeof context.page.getByText === 'function', 'Text assertion requires page.getByText().');
+        await context.page.getByText(assertion.text, { exact: assertion.exact }).waitFor({ timeout: assertion.timeout || 30000 });
+        return;
+    }
+    if (type === 'title') {
+        pageScenarioAssert(context.page && typeof context.page.title === 'function', 'Title assertion requires page.title().');
+        const title = await context.page.title();
+        const expected = assertion.includes ?? assertion.title;
+        pageScenarioAssert(String(title).includes(String(expected)), assertion.message || `Expected page title to include "${expected}", got "${title}".`);
+        return;
+    }
+    if (type === 'artifact') {
+        const artifactKey = assertion.key || assertion.artifact;
+        const artifact = context.artifacts?.[artifactKey];
+        pageScenarioAssert(Boolean(artifact), assertion.message || `Expected artifact "${artifactKey}" to be present.`);
+        if (assertion.kind !== undefined) {
+            pageScenarioAssert(artifact.kind === assertion.kind, assertion.message || `Expected artifact "${artifactKey}" kind "${assertion.kind}", got "${artifact.kind}".`);
+        }
+        return;
+    }
+
+    throw new Error(`Unsupported browser page scenario assertion type: ${type}`);
+}
+
+function inferPageScenarioAssertionType(assertion) {
+    if (assertion.status !== undefined || assertion.expectedStatus !== undefined) return 'status';
+    if (assertion.selector !== undefined) return 'selector';
+    if (assertion.text !== undefined) return 'text';
+    if (assertion.title !== undefined || assertion.includes !== undefined) return 'title';
+    if (assertion.key !== undefined || assertion.artifact !== undefined) return 'artifact';
+    return assertion.type;
+}
+
+function isArtifactAssertion(assertion) {
+    if (typeof assertion === 'function') return false;
+    if (!assertion || typeof assertion !== 'object' || Array.isArray(assertion)) return false;
+    return inferPageScenarioAssertionType(assertion) === 'artifact';
+}
+
+function pageScenarioAssert(condition, message) {
+    if (!condition) throw new Error(`Browser page scenario assertion failed: ${message}`);
+}
+
+function normalizeStaticArtifacts(artifacts) {
+    if (artifacts === undefined) return {};
+    if (!artifacts || typeof artifacts !== 'object' || Array.isArray(artifacts)) {
+        throw new Error('runBrowserPageScenario artifacts must be an object when provided.');
+    }
+    return stableJson(artifacts);
+}
+
+function normalizeJsonObject(value, label) {
+    if (value === undefined) return {};
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error(`runBrowserPageScenario ${label} must be an object when provided.`);
+    }
+    return stableJson(JSON.parse(JSON.stringify(value)));
+}
+
+function normalizeOptionalFunction(value, label) {
+    if (value === undefined) return null;
+    if (typeof value !== 'function') throw new Error(`runBrowserPageScenario ${label} must be a function when provided.`);
+    return value;
 }
 
 function normalizeBrowserAction(action, index, options = {}) {

--- a/nodejs/scripts/bench/nodejs-browser-page-scenario-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-browser-page-scenario-smoke.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-browser-page-scenario.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+HELPER_UNDER_TEST="$SCRIPT_DIR/browser-helper.mjs" node --input-type=module - "$TMP_DIR" <<'EOF'
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const tmpDir = process.argv[2];
+const { runBrowserPageScenario } = await import(process.env.HELPER_UNDER_TEST);
+
+function makePage(status = 200) {
+  return {
+    gotoCalls: [],
+    selectorCalls: [],
+    textCalls: [],
+    async goto(target, options) {
+      this.gotoCalls.push({ target, options });
+      return { status: () => status };
+    },
+    async waitForSelector(selector, options) {
+      this.selectorCalls.push({ selector, options });
+    },
+    getByText(text, options) {
+      this.textCalls.push({ text, options });
+      return { waitFor: async () => {} };
+    },
+    async title() {
+      return 'Scenario smoke page';
+    },
+  };
+}
+
+async function fakeBrowserBench(options) {
+  const page = makePage(options.status ?? 200);
+  const marks = [];
+  await options.action({
+    page,
+    mark: async (name) => marks.push(name),
+  });
+  return {
+    metrics: { custom_ms: 12, mark_count: marks.length },
+    artifacts: {
+      report: { path: join(tmpDir, 'report.json'), kind: 'json', label: 'Report' },
+    },
+  };
+}
+
+const success = await runBrowserPageScenario({
+  id: 'page-scenario-success',
+  artifactDir: tmpDir,
+  target: 'https://example.test/page',
+  browserBench: fakeBrowserBench,
+  metadata: { suite: 'smoke' },
+  assertions: [
+    { type: 'status', expected: 200 },
+    { type: 'selector', selector: 'main' },
+    { type: 'text', text: 'Ready' },
+    { type: 'title', includes: 'smoke' },
+    { type: 'artifact', key: 'report', kind: 'json' },
+  ],
+  action: async ({ response, target }) => {
+    if (response.status() !== 200) throw new Error('action did not receive navigation response');
+    if (target !== 'https://example.test/page') throw new Error('action did not receive target');
+  },
+  sanitizeArtifacts: async ({ artifacts }) => ({
+    ...artifacts,
+    report: { ...artifacts.report, path: '<sanitized-report-path>' },
+  }),
+  postSanitizeAssertions: [{ type: 'artifact', key: 'rawResult', kind: 'browser-page-scenario-result' }],
+});
+
+if (success.metrics.custom_ms !== 12) throw new Error('success metrics were not preserved');
+if (success.artifacts.report.path !== '<sanitized-report-path>') throw new Error('sanitizeArtifacts did not rewrite artifact');
+if (!success.artifacts.rawResult) throw new Error('raw result artifact missing');
+if (!existsSync(success.artifacts.rawResult.path)) throw new Error('raw result file missing');
+const rawResult = JSON.parse(await readFile(success.artifacts.rawResult.path, 'utf8'));
+if (rawResult.id !== 'page-scenario-success') throw new Error('raw result id missing');
+if (rawResult.artifacts.report.kind !== 'json') throw new Error('raw result did not propagate bench artifact');
+
+let failed = false;
+try {
+  await runBrowserPageScenario({
+    id: 'page-scenario-failure',
+    artifactDir: tmpDir,
+    target: 'https://example.test/fail',
+    browserBench: async (options) => {
+      const page = makePage(500);
+      await options.action({ page, mark: async () => {} });
+      return { metrics: {}, artifacts: {} };
+    },
+    assertions: [{ type: 'status', expected: 200 }],
+  });
+} catch (err) {
+  failed = err.message.includes('Browser page scenario assertion failed') && err.message.includes('Expected page status 200');
+}
+if (!failed) throw new Error('assertion failure did not produce expected error');
+
+const propagated = await runBrowserPageScenario({
+  id: 'page-scenario-artifacts',
+  artifactDir: tmpDir,
+  browserBench: fakeBrowserBench,
+  assertions: [{ type: 'artifact', key: 'report', kind: 'json' }],
+});
+if (propagated.artifacts.report.kind !== 'json') throw new Error('bench artifact was not propagated');
+if (!propagated.artifacts.rawResult.path.endsWith('page-scenario-artifacts-raw-result.json')) throw new Error('raw result artifact path not stable');
+EOF
+
+echo "Node.js browser page scenario smoke passed."


### PR DESCRIPTION
## Summary
- Adds `runBrowserPageScenario()` on top of `runBrowserBench()` for generic page navigation, page assertions, artifact assertions, raw result artifacts, and optional sanitization hooks.
- Documents the substrate-agnostic browser page helper API for Node.js benchmark workloads.
- Adds a smoke test covering success, assertion failure, and artifact propagation.

Fixes #894.

## Tests
- `bash nodejs/scripts/bench/nodejs-browser-page-scenario-smoke.sh`
- `bash nodejs/scripts/bench/nodejs-bench-artifacts-smoke.sh`
- `node --check nodejs/scripts/bench/browser-helper.mjs`
- `bash nodejs/scripts/bench/nodejs-browser-helper-smoke.sh`

## Notes
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@issue-894-browser-page-scenario/nodejs --extension nodejs` was attempted but is not applicable because the extension directory is not a standalone Node package with `package.json`; the direct smoke scripts above exercise the helper path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the helper, smoke test, docs, and local verification; Chris remains responsible for review and merge.