### PR TITLE
Use manifest changed-test routing

### DIFF
--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -224,7 +224,10 @@
     "extension_script": "scripts/lint/lint-runner.sh"
   },
   "test": {
-    "extension_script": "scripts/test/test-runner.sh"
+    "extension_script": "scripts/test/test-runner.sh",
+    "changed_file_routing": {
+      "strategy": "file_args"
+    }
   },
   "bench": {
     "extension_script": "scripts/bench/bench-runner.sh"

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -49,7 +49,12 @@ homeboy_detect_package_manager
 homeboy_ensure_node_dependencies
 
 RUNNER_ARGS=("$@")
-if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
+if [ -n "${HOMEBOY_TEST_RUNNER_ARGS:-}" ]; then
+    while IFS= read -r selected_test_arg; do
+        [ -n "$selected_test_arg" ] || continue
+        RUNNER_ARGS+=("$selected_test_arg")
+    done <<< "$HOMEBOY_TEST_RUNNER_ARGS"
+elif [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
     while IFS= read -r selected_test_file; do
         [ -n "$selected_test_file" ] || continue
         RUNNER_ARGS+=("$selected_test_file")

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -32,6 +32,9 @@
   },
   "test": {
     "extension_script": "scripts/test-runner.sh",
+    "changed_file_routing": {
+      "strategy": "rust_cargo"
+    },
     "drift": {
       "source_dirs": ["src"],
       "test_dirs": ["tests"],

--- a/rust/scripts/rust-changed-scope-smoke.sh
+++ b/rust/scripts/rust-changed-scope-smoke.sh
@@ -92,6 +92,8 @@ OUTPUT=$(
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
     HOMEBOY_SKIP_LINT=1 \
     HOMEBOY_CHANGED_TEST_FILES='tests/integration_scope.rs' \
+    HOMEBOY_TEST_SCOPE_MESSAGE='Scoped to changed integration tests: integration_scope' \
+    HOMEBOY_TEST_RUNNER_ARGS=$'--test\nintegration_scope' \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh"
@@ -112,6 +114,8 @@ OUTPUT=$(
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
     HOMEBOY_SKIP_LINT=1 \
     HOMEBOY_CHANGED_TEST_FILES='tests/core/daemon_test.rs' \
+    HOMEBOY_TEST_SCOPE_MESSAGE='Scoped to changed files: core::daemon::daemon_test' \
+    HOMEBOY_TEST_RUNNER_ARGS=$'--\ncore::daemon::daemon_test' \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh"
@@ -132,6 +136,7 @@ OUTPUT=$(
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
     HOMEBOY_SKIP_LINT=1 \
     HOMEBOY_CHANGED_TEST_FILES=$'tests/core/daemon_test.rs\ntests/core/service_test.rs' \
+    HOMEBOY_TEST_SCOPE_MESSAGE='Changed files include multiple inline test modules; running full cargo test.' \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh"
@@ -152,6 +157,7 @@ OUTPUT=$(
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
     HOMEBOY_SKIP_LINT=1 \
     HOMEBOY_CHANGED_TEST_FILES='tests/core/unknown_nested_test.rs' \
+    HOMEBOY_TEST_SCOPE_MESSAGE='Changed files include nested tests without a direct Cargo target; running full cargo test.' \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh"

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -205,63 +205,15 @@ TEST_ARGS=(
     --manifest-path "${PROJECT_PATH}/Cargo.toml"
 )
 
-# Scoped test selection: if HOMEBOY_CHANGED_TEST_FILES is set, derive
-# cargo test filter from the changed test file paths.
-# Cargo test accepts positional test name patterns after --.
-# We extract module paths from file paths (e.g., src/commands/audit.rs → commands::audit).
-SCOPE_FILTER_ARGS=()
-SCOPE_INTEGRATION_ARGS=()
-SCOPE_FALLBACK_FULL=false
-if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
-    while IFS= read -r test_file; do
-        [ -z "$test_file" ] && continue
-        if [[ "$test_file" == tests/*.rs && "$test_file" != tests/*/* ]]; then
-            test_target="${test_file#tests/}"
-            test_target="${test_target%.rs}"
-            if [ -n "$test_target" ]; then
-                SCOPE_INTEGRATION_ARGS+=("$test_target")
-            fi
-            continue
-        fi
+if [ -n "${HOMEBOY_TEST_SCOPE_MESSAGE:-}" ]; then
+    echo "$HOMEBOY_TEST_SCOPE_MESSAGE"
+fi
 
-        # Convert file path to Rust module path for cargo test filtering
-        # e.g., src/commands/audit.rs → commands::audit
-        #        src/utils/baseline.rs → utils::baseline
-        #        tests/core/foo_test.rs with src/core/foo.rs → core::foo::foo_test
-        module_path="${test_file#src/}"          # strip leading src/
-        module_path="${module_path#tests/}"      # strip leading tests/
-        module_path="${module_path%.rs}"          # strip .rs extension
-        module_path="${module_path%/mod}"         # strip /mod suffix
-        test_module="${module_path##*/}"
-        source_module="${module_path%_test}"
-        if [[ "$test_file" == tests/*_test.rs ]] && { [ -f "${PROJECT_PATH}/src/${source_module}.rs" ] || [ -f "${PROJECT_PATH}/src/${source_module}/mod.rs" ]; }; then
-            module_path="${source_module}::${test_module}"
-        elif [[ "$test_file" == tests/*/*.rs ]]; then
-            SCOPE_FALLBACK_FULL=true
-            continue
-        fi
-        module_path="${module_path//\//::}"       # replace / with ::
-        if [ -n "$module_path" ]; then
-            SCOPE_FILTER_ARGS+=("$module_path")
-        fi
-    done <<< "${HOMEBOY_CHANGED_TEST_FILES}"
-
-    if [ "$SCOPE_FALLBACK_FULL" = true ]; then
-        echo "Changed files include nested tests without a direct Cargo target; running full cargo test."
-    elif [ ${#SCOPE_INTEGRATION_ARGS[@]} -gt 0 ] && [ ${#SCOPE_FILTER_ARGS[@]} -gt 0 ]; then
-        echo "Changed files include integration and inline tests; running full cargo test."
-    elif [ ${#SCOPE_INTEGRATION_ARGS[@]} -gt 0 ]; then
-        for test_target in "${SCOPE_INTEGRATION_ARGS[@]}"; do
-            TEST_ARGS+=(--test "$test_target")
-        done
-        echo "Scoped to changed integration tests: ${SCOPE_INTEGRATION_ARGS[*]}"
-    elif [ ${#SCOPE_FILTER_ARGS[@]} -eq 1 ]; then
-        FILTER="${SCOPE_FILTER_ARGS[0]}"
-        TEST_ARGS+=(-- "$FILTER")
-        echo "Scoped to changed files: ${FILTER}"
-    elif [ ${#SCOPE_FILTER_ARGS[@]} -gt 1 ]; then
-        echo "Changed files include multiple inline test modules; running full cargo test."
-    fi
+if [ -n "${HOMEBOY_TEST_RUNNER_ARGS:-}" ]; then
+    while IFS= read -r scope_arg; do
+        [ -n "$scope_arg" ] || continue
+        TEST_ARGS+=("$scope_arg")
+    done <<< "$HOMEBOY_TEST_RUNNER_ARGS"
 fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then

--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -102,6 +102,9 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_CHANGED_TEST_FILES=$'tests/import-agent-ability-smoke.php\ntests/queue-routing-smoke.php' \
+HOMEBOY_TEST_SCOPE_KIND="exclusive_env" \
+HOMEBOY_TEST_SCOPE_ENV_NAME="HOMEBOY_WORDPRESS_HOST_SMOKE_FILES" \
+HOMEBOY_TEST_SCOPE_ENV_VALUE=$'tests/import-agent-ability-smoke.php\ntests/queue-routing-smoke.php' \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/changed-smoke-files.out"
 
 assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_BEGIN:tests/import-agent-ability-smoke.php"

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -114,39 +114,9 @@ homeboy_wordpress_rel_test_file() {
     esac
 }
 
-homeboy_wordpress_is_standalone_smoke() {
-    local rel_path="$1"
-    case "$rel_path" in
-        tests/*-smoke.php|tests/*/*-smoke.php|tests/*/*/*-smoke.php|tests/*/*/*/*-smoke.php)
-            return 0
-            ;;
-        *)
-            return 1
-            ;;
-    esac
-}
-
-if [ -z "$TARGET_FILE" ] && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
-    changed_smoke_files=()
-    changed_non_smoke_count=0
-
-    while IFS= read -r changed_file; do
-        [ -z "$changed_file" ] && continue
-
-        if ! changed_rel="$(homeboy_wordpress_rel_test_file "$changed_file")"; then
-            changed_non_smoke_count=$((changed_non_smoke_count + 1))
-            continue
-        fi
-
-        if homeboy_wordpress_is_standalone_smoke "$changed_rel"; then
-            changed_smoke_files+=("$changed_rel")
-        else
-            changed_non_smoke_count=$((changed_non_smoke_count + 1))
-        fi
-    done <<< "$HOMEBOY_CHANGED_TEST_FILES"
-
-    if [ "${#changed_smoke_files[@]}" -gt 0 ] && [ "$changed_non_smoke_count" -eq 0 ]; then
-        HOMEBOY_WORDPRESS_HOST_SMOKE_FILES="$(printf '%s\n' "${changed_smoke_files[@]}")" exec bash "$HOST_SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
+if [ -z "$TARGET_FILE" ] && [ "${HOMEBOY_TEST_SCOPE_KIND:-}" = "exclusive_env" ]; then
+    if [ "${HOMEBOY_TEST_SCOPE_ENV_NAME:-}" = "HOMEBOY_WORDPRESS_HOST_SMOKE_FILES" ] && [ -n "${HOMEBOY_TEST_SCOPE_ENV_VALUE:-}" ]; then
+        HOMEBOY_WORDPRESS_HOST_SMOKE_FILES="$HOMEBOY_TEST_SCOPE_ENV_VALUE" exec bash "$HOST_SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
     fi
 fi
 

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -835,6 +835,13 @@
     ]
   },
   "test": {
+    "changed_file_routing": {
+      "strategy": "exclusive_env",
+      "exclusive_env": {
+        "name": "HOMEBOY_WORDPRESS_HOST_SMOKE_FILES",
+        "globs": ["tests/**/*-smoke.php"]
+      }
+    },
     "drift": {
       "source_dirs": ["src", "inc", "lib"],
       "test_dirs": ["tests"],


### PR DESCRIPTION
## Summary
- Declare changed-test routing strategies in Node.js, Rust, and WordPress manifests.
- Update runners to consume core-provided routing env vars instead of duplicating changed-test routing logic.
- Keep direct smoke coverage aligned with the new core env contract.

## Related
- Closes #888
- Depends on Extra-Chill/homeboy#3099 for `test.changed_file_routing` support.

## Verification
- `bash -n nodejs/scripts/test/test-runner.sh rust/scripts/test-runner.sh wordpress/scripts/test/test-runner.sh wordpress/scripts/test/test-runner-file-routing-smoke.sh rust/scripts/rust-changed-scope-smoke.sh`
- `bash rust/scripts/rust-changed-scope-smoke.sh`
- `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the manifest declarations, runner simplifications, smoke-test updates, and verification commands; Chris remains responsible for review and merge decisions.