### PR TITLE
Use archive install deploy policy for WordPress

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -169,30 +169,24 @@
         "remote_path": "wp-content/themes/{{dir_name}}"
       }
     ],
-    "verifications": [
-      {
-        "path_pattern": "/wp-content/plugins/",
-        "verify_command": "test -f {{stagingArtifact}} && plugin_slug=$(basename {{targetDir}}) && candidate=$(unzip -Z1 {{stagingArtifact}} | awk -v slug=\"$plugin_slug\" '$0 == slug \"/\" slug \".php\" { print; exit }') && if [ -z \"$candidate\" ]; then candidate=$(unzip -Z1 {{stagingArtifact}} | awk '$0 ~ \"(^|/)[^/]+[.]php$\" { print; exit }'); fi && test -n \"$candidate\" && rel=\"$candidate\" && case \"$candidate\" in */*) rel=\"${candidate#*/}\" ;; esac && test -f \"{{targetDir}}/$rel\" && unzip -p {{stagingArtifact}} \"$candidate\" | cmp -s - \"{{targetDir}}/$rel\" && find {{targetDir}} -maxdepth 2 -name '*.php' -exec grep -l 'Plugin Name:' {} + 2>/dev/null | head -1",
-        "verify_error_message": "WordPress plugin deploy verification failed for {{targetDir}}: installed files do not match {{stagingArtifact}} or no plugin header was found"
-      },
-      {
-        "path_pattern": "/wp-content/themes/",
-        "verify_command": "test -f {{stagingArtifact}} && style_entry=$(unzip -Z1 {{stagingArtifact}} | awk '$0 == \"style.css\" { print; exit } $0 ~ \"(^|/)style[.]css$\" { print; exit }') && test -n \"$style_entry\" && rel=\"$style_entry\" && case \"$style_entry\" in */*) rel=\"${style_entry#*/}\" ;; esac && test -f \"{{targetDir}}/$rel\" && unzip -p {{stagingArtifact}} \"$style_entry\" | cmp -s - \"{{targetDir}}/$rel\" && grep -l 'Theme Name:' \"{{targetDir}}/$rel\" 2>/dev/null",
-        "verify_error_message": "WordPress theme deploy verification failed for {{targetDir}}: installed style.css does not match {{stagingArtifact}} or no theme header was found"
-      }
-    ],
-    "overrides": [
+    "archive_install": [
       {
         "path_pattern": "/wp-content/plugins/",
         "staging_path": "/tmp/homeboy-staging",
-        "install_command": "cd {{siteRoot}} && plugin_slug=$(basename {{targetDir}}) && zip_root=$(unzip -Z1 {{stagingArtifact}} | awk -F/ 'NF && $1 != \"\" { print $1; exit }') && if [ -z \"$zip_root\" ]; then echo 'ERROR: Could not determine zip root directory' && exit 1; fi && if [ \"$zip_root\" != \"$plugin_slug\" ]; then echo \"ERROR: ZIP root $zip_root does not match plugin slug $plugin_slug\" && exit 1; fi && rm -rf {{targetDir}} && mkdir -p {{targetParentDir}} && unzip -oq {{stagingArtifact}} -d {{targetParentDir}} && test -d {{targetDir}} || (echo 'ERROR: Plugin install failed' && exit 1)",
-        "cleanup_command": "rm -f {{stagingArtifact}}"
+        "root_must_match_target_basename": true,
+        "required_header": {
+          "file_glob": "*.php",
+          "contains": "Plugin Name:"
+        }
       },
       {
         "path_pattern": "/wp-content/themes/",
         "staging_path": "/tmp/homeboy-staging",
-        "install_command": "cd {{siteRoot}} && theme_slug=$(basename {{targetDir}}) && zip_root=$(unzip -Z1 {{stagingArtifact}} | awk -F/ 'NF && $1 != \"\" { print $1; exit }') && if [ -z \"$zip_root\" ]; then echo 'ERROR: Could not determine zip root directory' && exit 1; fi && if [ \"$zip_root\" != \"$theme_slug\" ]; then echo \"ERROR: ZIP root $zip_root does not match theme slug $theme_slug\" && exit 1; fi && rm -rf {{targetDir}} && mkdir -p {{targetParentDir}} && unzip -oq {{stagingArtifact}} -d {{targetParentDir}} && test -d {{targetDir}} || (echo 'ERROR: Theme install failed' && exit 1)",
-        "cleanup_command": "rm -f {{stagingArtifact}}"
+        "root_must_match_target_basename": true,
+        "required_header": {
+          "file": "style.css",
+          "contains": "Theme Name:"
+        }
       }
     ],
     "version_patterns": [


### PR DESCRIPTION
## Summary
- Replaces the WordPress deploy `verifications` and `overrides` shell snippets with declarative `deploy.archive_install` policies.
- Keeps WordPress-specific behavior as path patterns and header probes for plugin and theme archives.
- Depends on the generic core support in Extra-Chill/homeboy#3103.

## Verification
- `jq . wordpress/wordpress.json >/dev/null`
- Core behavior covered by Extra-Chill/homeboy#3103: `cargo test core::deploy::version_overrides`

Closes #898.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the manifest policy migration and coordinated the paired core PR; Chris remains responsible for review and validation.