### PR TITLE
Keep runner prelude self-contained

### DIFF
--- a/nodejs/scripts/build/build-runner.sh
+++ b/nodejs/scripts/build/build-runner.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 #   HOMEBOY_DEBUG                — verbose
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../../../scripts/lib/runner-prelude.sh}"
+RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../lib/runner-prelude.sh}"
 COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${SCRIPT_DIR}/../lib/command-capture.sh}"
 # shellcheck source=/dev/null
 source "$RUNNER_PRELUDE"

--- a/nodejs/scripts/lib/runner-prelude.sh
+++ b/nodejs/scripts/lib/runner-prelude.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# Direct-invocation fallback for Homeboy core's shared runner prelude.
+# Keep this file aligned with homeboy/src/core/extension/runtime/runner-prelude.sh.
+
+homeboy_runtime_dir() {
+    cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+}
+
+homeboy_require_bash_version() {
+    local required_major="$1"
+
+    if [ -z "${BASH_VERSION:-}" ] || ((BASH_VERSINFO[0] < required_major)); then
+        echo "ERROR: bash ${required_major}.0+ required (found ${BASH_VERSION:-non-bash shell})" >&2
+        case "$(uname -s)" in
+            Darwin)
+                echo "macOS ships with bash 3.2. Install newer bash: brew install bash" >&2
+                echo "Then restart your terminal so Homebrew bash takes priority on PATH." >&2
+                ;;
+            Linux)
+                echo "Update bash via your package manager (apt, dnf, pacman, etc.)" >&2
+                ;;
+            MINGW*|MSYS*|CYGWIN*)
+                echo "Update Git Bash or use WSL with a modern bash version" >&2
+                ;;
+            *)
+                echo "Install bash ${required_major}.0 or later for your platform" >&2
+                ;;
+        esac
+        exit 1
+    fi
+}
+
+homeboy_source_runtime_helper() {
+    local env_var="$1"
+    local fallback="$2"
+    local required="${3:-required}"
+    local helper="${!env_var:-}"
+
+    if [ -z "$helper" ]; then
+        helper="$fallback"
+    fi
+
+    if [ -n "$helper" ] && [ -f "$helper" ]; then
+        # shellcheck source=/dev/null
+        source "$helper"
+        return 0
+    fi
+
+    if [ "$required" = "optional" ]; then
+        return 0
+    fi
+
+    echo "homeboy_runner_init: missing runtime helper for ${env_var}: ${helper}" >&2
+    return 2
+}
+
+homeboy_runner_init() {
+    local required_bash=""
+    local project_alias="PROJECT_PATH"
+    local component_alias=""
+    local load_steps=0
+    local load_failure_trap=0
+    local load_sidecar_writer=0
+    local runtime_dir
+    runtime_dir="$(homeboy_runtime_dir)"
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --bash)
+                required_bash="${2:-}"
+                shift 2
+                ;;
+            --project-alias)
+                project_alias="${2:-}"
+                shift 2
+                ;;
+            --component-alias)
+                component_alias="${2:-}"
+                shift 2
+                ;;
+            --steps)
+                load_steps=1
+                shift
+                ;;
+            --failure-trap)
+                load_failure_trap=1
+                shift
+                ;;
+            --sidecar-writer)
+                load_sidecar_writer=1
+                shift
+                ;;
+            *)
+                echo "homeboy_runner_init: unknown argument: $1" >&2
+                return 2
+                ;;
+        esac
+    done
+
+    if [ -n "$required_bash" ]; then
+        homeboy_require_bash_version "$required_bash"
+    fi
+
+    homeboy_source_runtime_helper HOMEBOY_RUNTIME_RESOLVE_CONTEXT "${runtime_dir}/resolve-context.sh"
+    homeboy_resolve_context --project-alias "$project_alias" --component-alias "$component_alias"
+
+    if [ "$load_steps" -eq 1 ]; then
+        homeboy_source_runtime_helper HOMEBOY_RUNTIME_RUNNER_STEPS "${runtime_dir}/runner-steps.sh"
+    fi
+
+    if [ "$load_sidecar_writer" -eq 1 ]; then
+        homeboy_source_runtime_helper HOMEBOY_RUNTIME_SIDECAR_WRITER "${runtime_dir}/sidecar-writer.sh" optional
+    fi
+
+    if [ "$load_failure_trap" -eq 1 ]; then
+        if homeboy_source_runtime_helper HOMEBOY_RUNTIME_FAILURE_TRAP "${runtime_dir}/failure-trap.sh" optional; then
+            if type homeboy_init_failure_trap >/dev/null 2>&1; then
+                homeboy_init_failure_trap
+            else
+                FAILED_STEP=""
+                FAILURE_OUTPUT=""
+                FAILURE_REPLAY_MODE="full"
+            fi
+        fi
+    fi
+}

--- a/nodejs/scripts/lint/lint-runner.sh
+++ b/nodejs/scripts/lint/lint-runner.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 # empty unless we recognize the format."
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../../../scripts/lib/runner-prelude.sh}"
+RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../lib/runner-prelude.sh}"
 FIX_RESULTS_HELPER="${HOMEBOY_RUNTIME_FIX_RESULTS:-${SCRIPT_DIR}/../lib/fix-results.sh}"
 # shellcheck source=/dev/null
 source "$RUNNER_PRELUDE"

--- a/nodejs/scripts/test/test-runner.sh
+++ b/nodejs/scripts/test/test-runner.sh
@@ -28,7 +28,7 @@ set -euo pipefail
 #   HOMEBOY_DEBUG                — verbose
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../../../scripts/lib/runner-prelude.sh}"
+RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../lib/runner-prelude.sh}"
 COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${SCRIPT_DIR}/../lib/command-capture.sh}"
 SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SCRIPT_DIR}/../lib/settings.sh}"
 # shellcheck source=/dev/null

--- a/rust/scripts/lib/runner-prelude.sh
+++ b/rust/scripts/lib/runner-prelude.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# Direct-invocation fallback for Homeboy core's shared runner prelude.
+# Keep this file aligned with homeboy/src/core/extension/runtime/runner-prelude.sh.
+
+homeboy_runtime_dir() {
+    cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+}
+
+homeboy_require_bash_version() {
+    local required_major="$1"
+
+    if [ -z "${BASH_VERSION:-}" ] || ((BASH_VERSINFO[0] < required_major)); then
+        echo "ERROR: bash ${required_major}.0+ required (found ${BASH_VERSION:-non-bash shell})" >&2
+        case "$(uname -s)" in
+            Darwin)
+                echo "macOS ships with bash 3.2. Install newer bash: brew install bash" >&2
+                echo "Then restart your terminal so Homebrew bash takes priority on PATH." >&2
+                ;;
+            Linux)
+                echo "Update bash via your package manager (apt, dnf, pacman, etc.)" >&2
+                ;;
+            MINGW*|MSYS*|CYGWIN*)
+                echo "Update Git Bash or use WSL with a modern bash version" >&2
+                ;;
+            *)
+                echo "Install bash ${required_major}.0 or later for your platform" >&2
+                ;;
+        esac
+        exit 1
+    fi
+}
+
+homeboy_source_runtime_helper() {
+    local env_var="$1"
+    local fallback="$2"
+    local required="${3:-required}"
+    local helper="${!env_var:-}"
+
+    if [ -z "$helper" ]; then
+        helper="$fallback"
+    fi
+
+    if [ -n "$helper" ] && [ -f "$helper" ]; then
+        # shellcheck source=/dev/null
+        source "$helper"
+        return 0
+    fi
+
+    if [ "$required" = "optional" ]; then
+        return 0
+    fi
+
+    echo "homeboy_runner_init: missing runtime helper for ${env_var}: ${helper}" >&2
+    return 2
+}
+
+homeboy_runner_init() {
+    local required_bash=""
+    local project_alias="PROJECT_PATH"
+    local component_alias=""
+    local load_steps=0
+    local load_failure_trap=0
+    local load_sidecar_writer=0
+    local runtime_dir
+    runtime_dir="$(homeboy_runtime_dir)"
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --bash)
+                required_bash="${2:-}"
+                shift 2
+                ;;
+            --project-alias)
+                project_alias="${2:-}"
+                shift 2
+                ;;
+            --component-alias)
+                component_alias="${2:-}"
+                shift 2
+                ;;
+            --steps)
+                load_steps=1
+                shift
+                ;;
+            --failure-trap)
+                load_failure_trap=1
+                shift
+                ;;
+            --sidecar-writer)
+                load_sidecar_writer=1
+                shift
+                ;;
+            *)
+                echo "homeboy_runner_init: unknown argument: $1" >&2
+                return 2
+                ;;
+        esac
+    done
+
+    if [ -n "$required_bash" ]; then
+        homeboy_require_bash_version "$required_bash"
+    fi
+
+    homeboy_source_runtime_helper HOMEBOY_RUNTIME_RESOLVE_CONTEXT "${runtime_dir}/resolve-context.sh"
+    homeboy_resolve_context --project-alias "$project_alias" --component-alias "$component_alias"
+
+    if [ "$load_steps" -eq 1 ]; then
+        homeboy_source_runtime_helper HOMEBOY_RUNTIME_RUNNER_STEPS "${runtime_dir}/runner-steps.sh"
+    fi
+
+    if [ "$load_sidecar_writer" -eq 1 ]; then
+        homeboy_source_runtime_helper HOMEBOY_RUNTIME_SIDECAR_WRITER "${runtime_dir}/sidecar-writer.sh" optional
+    fi
+
+    if [ "$load_failure_trap" -eq 1 ]; then
+        if homeboy_source_runtime_helper HOMEBOY_RUNTIME_FAILURE_TRAP "${runtime_dir}/failure-trap.sh" optional; then
+            if type homeboy_init_failure_trap >/dev/null 2>&1; then
+                homeboy_init_failure_trap
+            else
+                FAILED_STEP=""
+                FAILURE_OUTPUT=""
+                FAILURE_REPLAY_MODE="full"
+            fi
+        fi
+    fi
+}

--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${SCRIPT_DIR}/lib/command-capture.sh}"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../../scripts/lib/runner-prelude.sh}"
+RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/lib/runner-prelude.sh}"
 FIX_RESULTS_HELPER="${HOMEBOY_RUNTIME_FIX_RESULTS:-${SCRIPT_DIR}/lib/fix-results.sh}"
 # shellcheck source=/dev/null
 source "$RUNNER_PRELUDE"

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${SCRIPT_DIR}/lib/command-capture.sh}"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../../scripts/lib/runner-prelude.sh}"
+RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/lib/runner-prelude.sh}"
 # shellcheck source=/dev/null
 source "$RUNNER_PRELUDE"
 homeboy_runner_init --steps --failure-trap --sidecar-writer

--- a/wordpress/scripts/lib/runner-prelude.sh
+++ b/wordpress/scripts/lib/runner-prelude.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# Direct-invocation fallback for Homeboy core's shared runner prelude.
+# Keep this file aligned with homeboy/src/core/extension/runtime/runner-prelude.sh.
+
+homeboy_runtime_dir() {
+    cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+}
+
+homeboy_require_bash_version() {
+    local required_major="$1"
+
+    if [ -z "${BASH_VERSION:-}" ] || ((BASH_VERSINFO[0] < required_major)); then
+        echo "ERROR: bash ${required_major}.0+ required (found ${BASH_VERSION:-non-bash shell})" >&2
+        case "$(uname -s)" in
+            Darwin)
+                echo "macOS ships with bash 3.2. Install newer bash: brew install bash" >&2
+                echo "Then restart your terminal so Homebrew bash takes priority on PATH." >&2
+                ;;
+            Linux)
+                echo "Update bash via your package manager (apt, dnf, pacman, etc.)" >&2
+                ;;
+            MINGW*|MSYS*|CYGWIN*)
+                echo "Update Git Bash or use WSL with a modern bash version" >&2
+                ;;
+            *)
+                echo "Install bash ${required_major}.0 or later for your platform" >&2
+                ;;
+        esac
+        exit 1
+    fi
+}
+
+homeboy_source_runtime_helper() {
+    local env_var="$1"
+    local fallback="$2"
+    local required="${3:-required}"
+    local helper="${!env_var:-}"
+
+    if [ -z "$helper" ]; then
+        helper="$fallback"
+    fi
+
+    if [ -n "$helper" ] && [ -f "$helper" ]; then
+        # shellcheck source=/dev/null
+        source "$helper"
+        return 0
+    fi
+
+    if [ "$required" = "optional" ]; then
+        return 0
+    fi
+
+    echo "homeboy_runner_init: missing runtime helper for ${env_var}: ${helper}" >&2
+    return 2
+}
+
+homeboy_runner_init() {
+    local required_bash=""
+    local project_alias="PROJECT_PATH"
+    local component_alias=""
+    local load_steps=0
+    local load_failure_trap=0
+    local load_sidecar_writer=0
+    local runtime_dir
+    runtime_dir="$(homeboy_runtime_dir)"
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --bash)
+                required_bash="${2:-}"
+                shift 2
+                ;;
+            --project-alias)
+                project_alias="${2:-}"
+                shift 2
+                ;;
+            --component-alias)
+                component_alias="${2:-}"
+                shift 2
+                ;;
+            --steps)
+                load_steps=1
+                shift
+                ;;
+            --failure-trap)
+                load_failure_trap=1
+                shift
+                ;;
+            --sidecar-writer)
+                load_sidecar_writer=1
+                shift
+                ;;
+            *)
+                echo "homeboy_runner_init: unknown argument: $1" >&2
+                return 2
+                ;;
+        esac
+    done
+
+    if [ -n "$required_bash" ]; then
+        homeboy_require_bash_version "$required_bash"
+    fi
+
+    homeboy_source_runtime_helper HOMEBOY_RUNTIME_RESOLVE_CONTEXT "${runtime_dir}/resolve-context.sh"
+    homeboy_resolve_context --project-alias "$project_alias" --component-alias "$component_alias"
+
+    if [ "$load_steps" -eq 1 ]; then
+        homeboy_source_runtime_helper HOMEBOY_RUNTIME_RUNNER_STEPS "${runtime_dir}/runner-steps.sh"
+    fi
+
+    if [ "$load_sidecar_writer" -eq 1 ]; then
+        homeboy_source_runtime_helper HOMEBOY_RUNTIME_SIDECAR_WRITER "${runtime_dir}/sidecar-writer.sh" optional
+    fi
+
+    if [ "$load_failure_trap" -eq 1 ]; then
+        if homeboy_source_runtime_helper HOMEBOY_RUNTIME_FAILURE_TRAP "${runtime_dir}/failure-trap.sh" optional; then
+            if type homeboy_init_failure_trap >/dev/null 2>&1; then
+                homeboy_init_failure_trap
+            else
+                FAILED_STEP=""
+                FAILURE_OUTPUT=""
+                FAILURE_REPLAY_MODE="full"
+            fi
+        fi
+    fi
+}

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # flows go through `homeboy refactor --from lint --write` (#1145).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../../../scripts/lib/runner-prelude.sh}"
+RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../lib/runner-prelude.sh}"
 # shellcheck source=/dev/null
 source "$RUNNER_PRELUDE"
 homeboy_runner_init --bash 4 --steps --sidecar-writer --component-alias PLUGIN_PATH

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # runner. Pure host-PHP smoke suites can explicitly use the host-smoke backend.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../../../scripts/lib/runner-prelude.sh}"
+RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../lib/runner-prelude.sh}"
 
 HOST_SMOKE_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_HOST_SMOKE:-${SCRIPT_DIR}/test-runner-host-smoke.sh}"
 WP_CODEBOX_RUNNER="${HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX:-${SCRIPT_DIR}/test-runner-wp-codebox.sh}"


### PR DESCRIPTION
## Summary
- Adds extension-local runner prelude fallbacks for NodeJS, Rust, and WordPress runners.
- Keeps `HOMEBOY_RUNTIME_RUNNER_PRELUDE` as the core-provided override when available.
- Prevents extension runners from depending on an unreleased Homeboy binary just to source the shared prelude.

## Verification
- `bash -n nodejs/scripts/lib/runner-prelude.sh rust/scripts/lib/runner-prelude.sh wordpress/scripts/lib/runner-prelude.sh nodejs/scripts/test/test-runner.sh nodejs/scripts/lint/lint-runner.sh nodejs/scripts/build/build-runner.sh rust/scripts/test-runner.sh rust/scripts/lint-runner.sh wordpress/scripts/test/test-runner.sh wordpress/scripts/lint/lint-runner.sh`
- `homeboy audit --path /Users/chubes/Developer/homeboy-extensions@fix-self-contained-runner-prelude --extension nodejs` reported existing repository-wide warnings unrelated to this shell prelude change.

Closes #920

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the self-contained runner prelude fallback and verification; Chris remains responsible for review and validation.