### PR TITLE
Route WordPress fixtures through WP Codebox

### DIFF
--- a/wordpress/lib/fixture-setup.js
+++ b/wordpress/lib/fixture-setup.js
@@ -61,6 +61,19 @@ function fixtureCommand(step) {
 	return normalizeCliCommand(step.command);
 }
 
+function fixtureRecipeStep(step) {
+	if (step.type === 'wp-eval-file') {
+		return {
+			command: 'wordpress.run-php',
+			args: [`code-file=${step.path}`],
+		};
+	}
+	return {
+		command: 'wordpress.wp-cli',
+		args: [`command=${normalizeCliCommand(step.command)}`],
+	};
+}
+
 function defaultRunCli(command, options = {}) {
 	const cliPath = options.cliPath || 'wp';
 	const args = [normalizeCliCommand(command)];
@@ -107,14 +120,63 @@ function normalizeCliResult(result) {
 		return { exitCode: 0, stdout: result, stderr: '' };
 	}
 	if (isPlainObject(result)) {
+		let exitCode = 0;
+		if (Number.isInteger(result.exitCode)) {
+			exitCode = result.exitCode;
+		} else if (Number.isInteger(result.code)) {
+			exitCode = result.code;
+		}
 		return {
 			...result,
-			exitCode: Number.isInteger(result.exitCode) ? result.exitCode : (Number.isInteger(result.code) ? result.code : 0),
+			exitCode,
 			stdout: result.stdout === undefined ? '' : String(result.stdout),
 			stderr: result.stderr === undefined ? '' : String(result.stderr),
 		};
 	}
 	return { exitCode: 0, stdout: String(result), stderr: '' };
+}
+
+function normalizeExecutionRoute(options) {
+	const route = options.fixtureExecutionRoute || options.executionRoute || options.route;
+	if (route === 'wp-codebox' || route === 'codebox') {
+		return 'wp-codebox';
+	}
+	if (route === 'host' || route === 'live-site' || route === 'live') {
+		return 'host';
+	}
+	if (options.runRecipeStep || options.runWpCodeboxStep) {
+		return 'wp-codebox';
+	}
+	if (options.runCli) {
+		return 'host';
+	}
+	return '';
+}
+
+function createFixtureRunner(options, context) {
+	const route = normalizeExecutionRoute(options);
+	if (route === 'wp-codebox') {
+		const runRecipeStep = options.runRecipeStep || options.runWpCodeboxStep;
+		if (typeof runRecipeStep !== 'function') {
+			throw new Error('WP Codebox fixture setup requires runRecipeStep or runWpCodeboxStep.');
+		}
+		return async (step, stepContext) => {
+			const recipeStep = fixtureRecipeStep(step);
+			const result = normalizeCliResult(await runRecipeStep(recipeStep, { ...context, ...stepContext, recipeStep }));
+			return {
+				...result,
+				recipeStep,
+			};
+		};
+	}
+	if (route === 'host') {
+		const runCli = options.runCli || ((command, runContext) => defaultRunCli(command, {
+			...options,
+			...runContext,
+		}));
+		return async (step, stepContext) => runCli(fixtureCommand(step), { ...context, ...stepContext });
+	}
+	throw new Error('WordPress fixture setup requires an explicit execution route: fixtureExecutionRoute="wp-codebox" with runRecipeStep, or fixtureExecutionRoute="host" for live-site host wp execution.');
 }
 
 function excerpt(value) {
@@ -151,11 +213,11 @@ function normalizeSkipCheck(skipIf) {
 	throw new TypeError('fixture skipIf must be a string or object');
 }
 
-async function runStep(runCli, step, context, role = 'fixture') {
+async function runStep(runFixtureStep, step, context, role = 'fixture') {
 	const command = fixtureCommand(step);
 	const startedAt = new Date().toISOString();
 	const started = Date.now();
-	const result = normalizeCliResult(await runCli(command, { ...context, step, role }));
+	const result = normalizeCliResult(await runFixtureStep(step, { step, role }));
 	const summary = {
 		label: step.label,
 		type: step.type,
@@ -171,6 +233,9 @@ async function runStep(runCli, step, context, role = 'fixture') {
 	if (result.signal) {
 		summary.signal = result.signal;
 	}
+	if (result.recipeStep) {
+		summary.recipeStep = result.recipeStep;
+	}
 	if (result.exitCode !== 0) {
 		throw Object.assign(failedStepError(step, command, result), { fixtureStep: summary });
 	}
@@ -183,24 +248,26 @@ async function runWordPressFixtureSetup(options = {}) {
 	}
 	const startedAt = new Date().toISOString();
 	const steps = [];
-	const runCli = options.runCli || ((command, context) => defaultRunCli(command, {
-		...options,
-		...context,
-	}));
 	const context = {
 		sitePath: options.sitePath,
 		artifactDir: options.artifactDir,
 		cwd: options.cwd,
 		env: options.env,
 	};
+	const runFixtureStep = createFixtureRunner(options, context);
+	const runCli = async (command, runContext = {}) => runFixtureStep(
+		normalizeFixtureStep({ type: 'wp-cli', command, label: runContext.label || 'wp-cli' }, 0),
+		runContext
+	);
 
 	if (typeof options.setupWordPressFixture === 'function') {
 		try {
 			const calls = [];
 			const capturingRunCli = async (command, callOptions = {}) => {
-				const result = normalizeCliResult(await runCli(command, { ...context, ...callOptions, role: 'hook' }));
+				const result = normalizeCliResult(await runCli(command, { ...callOptions, role: 'hook' }));
 				calls.push({
 					command: normalizeCliCommand(command),
+					...(result.recipeStep ? { recipeStep: result.recipeStep } : {}),
 					exitCode: result.exitCode,
 					stdout: result.stdout,
 					stderr: result.stderr,
@@ -225,7 +292,7 @@ async function runWordPressFixtureSetup(options = {}) {
 		for (const step of normalizeFixtureList(options.fixtures)) {
 			const skipCheck = normalizeSkipCheck(step.skipIf || step.idempotencyCheck);
 			if (skipCheck) {
-				const check = await runStep(runCli, skipCheck, context, 'idempotency-check').catch((error) => error.fixtureStep || {
+				const check = await runStep(runFixtureStep, skipCheck, context, 'idempotency-check').catch((error) => error.fixtureStep || {
 					label: skipCheck.label,
 					type: skipCheck.type,
 					role: 'idempotency-check',
@@ -238,7 +305,7 @@ async function runWordPressFixtureSetup(options = {}) {
 				}
 				steps.push({ ...check, fixture: step.label, status: 'check-failed' });
 			}
-			steps.push(await runStep(runCli, step, context));
+			steps.push(await runStep(runFixtureStep, step, context));
 		}
 	} catch (error) {
 		if (error.fixtureStep) {
@@ -269,6 +336,7 @@ function writeFixtureSummary(summary, options, error) {
 }
 
 module.exports = {
+	fixtureRecipeStep,
 	defaultRunCli,
 	normalizeFixtureList,
 	runWordPressFixtureSetup,

--- a/wordpress/lib/fixture-setup.js
+++ b/wordpress/lib/fixture-setup.js
@@ -147,9 +147,6 @@ function normalizeExecutionRoute(options) {
 	if (options.runRecipeStep || options.runWpCodeboxStep) {
 		return 'wp-codebox';
 	}
-	if (options.runCli) {
-		return 'host';
-	}
 	return '';
 }
 

--- a/wordpress/tests/fixture-setup-smoke.js
+++ b/wordpress/tests/fixture-setup-smoke.js
@@ -8,6 +8,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const {
+	fixtureRecipeStep,
 	normalizeFixtureList,
 	runWordPressFixtureSetup,
 } = require('../lib/fixture-setup');
@@ -25,6 +26,7 @@ async function main() {
 		const result = await runWordPressFixtureSetup({
 			artifactDir: fixtureDir,
 			sitePath: '/tmp/example-site',
+			fixtureExecutionRoute: 'host',
 			runCli: async (command, context) => {
 				calls.push({ command, role: context.role });
 				return { exitCode: 0, stdout: `ok:${command}`, stderr: '' };
@@ -52,9 +54,52 @@ async function main() {
 		assert.equal(calls.some((call) => call.command === 'post create --post_title=Skipped'), false);
 		assert.ok(fs.existsSync(result.artifacts.fixtureSetup));
 		assert.match(fs.readFileSync(result.artifacts.fixtureSetup, 'utf8'), /seed-posts/);
+		assert.deepEqual(
+			fixtureRecipeStep({ type: 'wp-cli', command: 'wp option get blogname' }),
+			{ command: 'wordpress.wp-cli', args: ['command=option get blogname'] }
+		);
+		assert.deepEqual(
+			fixtureRecipeStep({ type: 'wp-eval-file', path: 'fixtures/seed.php' }),
+			{ command: 'wordpress.run-php', args: ['code-file=fixtures/seed.php'] }
+		);
+
+		const recipeSteps = [];
+		const wpCodeboxResult = await runWordPressFixtureSetup({
+			fixtureExecutionRoute: 'wp-codebox',
+			runRecipeStep: async (recipeStep, context) => {
+				recipeSteps.push({ recipeStep, role: context.role });
+				if (recipeStep.args[0] === 'command=option get homeboy_fixture_ready') {
+					return { exitCode: 1, stdout: '', stderr: 'not ready' };
+				}
+				return { exitCode: 0, stdout: `ok:${recipeStep.command}`, stderr: '' };
+			},
+			fixtures: [
+				{
+					id: 'seed-codebox-posts',
+					type: 'wp-eval-file',
+					path: 'fixtures/seed-codebox-posts.php',
+					skipIf: 'option get homeboy_fixture_ready',
+				},
+			],
+		});
+		assert.equal(wpCodeboxResult.status, 'passed');
+		assert.equal(wpCodeboxResult.steps[0].status, 'check-failed');
+		assert.deepEqual(wpCodeboxResult.steps[1].recipeStep, {
+			command: 'wordpress.run-php',
+			args: ['code-file=fixtures/seed-codebox-posts.php'],
+		});
+		assert.deepEqual(recipeSteps.map((call) => call.recipeStep.command), ['wordpress.wp-cli', 'wordpress.run-php']);
 
 		await assert.rejects(
 			() => runWordPressFixtureSetup({
+				fixtures: [{ id: 'implicit-host', type: 'wp-cli', command: 'option get blogname' }],
+			}),
+			/explicit execution route/
+		);
+
+		await assert.rejects(
+			() => runWordPressFixtureSetup({
+				fixtureExecutionRoute: 'host',
 				runCli: async () => ({ exitCode: 2, stdout: 'fixture stdout', stderr: 'fixture stderr' }),
 				fixtures: [{ id: 'broken', type: 'wp-cli', command: 'option update broken 1' }],
 			}),

--- a/wordpress/tests/fixture-setup-smoke.js
+++ b/wordpress/tests/fixture-setup-smoke.js
@@ -92,6 +92,7 @@ async function main() {
 
 		await assert.rejects(
 			() => runWordPressFixtureSetup({
+				runCli: async () => ({ exitCode: 0, stdout: 'implicit host', stderr: '' }),
 				fixtures: [{ id: 'implicit-host', type: 'wp-cli', command: 'option get blogname' }],
 			}),
 			/explicit execution route/

--- a/wordpress/tests/page-profiler-smoke.js
+++ b/wordpress/tests/page-profiler-smoke.js
@@ -627,6 +627,7 @@ async function main() {
 		baseUrl: 'https://example.test',
 		manifest,
 		fixtures: [{ id: 'profile-ready', type: 'wp-cli', command: 'option update profile_ready 1' }],
+		fixtureExecutionRoute: 'host',
 		runCli: async (command) => ({ exitCode: 0, stdout: command, stderr: '' }),
 	});
 	assert.equal(multi.pages.length, 2);


### PR DESCRIPTION
## Summary
- Route disposable WordPress fixture setup through generic WP Codebox recipe commands via an explicit `wp-codebox` execution route.
- Keep Homeboy-owned fixture normalization, idempotency checks, summaries, and failure diagnostics intact.
- Require an explicit host/live route for host `wp` execution instead of silently defaulting disposable fixture setup to host WP-CLI.

## Tests
- `node wordpress/tests/fixture-setup-smoke.js`
- `node wordpress/tests/page-profiler-smoke.js`
- `npm run lint:js -- lib/fixture-setup.js`

Closes #930.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the fixture execution route migration, updated smoke coverage, and ran focused verification. Chris remains responsible for review and merge.