### PR TITLE
Route WordPress traces through WP Codebox

### DIFF
--- a/wordpress/scripts/trace/trace-runner-smoke.sh
+++ b/wordpress/scripts/trace/trace-runner-smoke.sh
@@ -57,6 +57,47 @@ trap 'rm -rf "$fixture"' EXIT
 
 mkdir -p "$fixture/traces" "$fixture/tests/traces" "$fixture/scripts/trace"
 
+fake_wp_codebox="$fixture/wp-codebox.cjs"
+fake_wp_codebox_capture="$fixture/wp-codebox-capture.json"
+cat >"$fake_wp_codebox" <<'NODE'
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const recipePath = process.argv[process.argv.indexOf('--recipe') + 1];
+const recipe = JSON.parse(fs.readFileSync(recipePath, 'utf8'));
+const step = recipe.workflow.steps[0];
+if (process.argv[2] !== 'recipe-run' || step.command !== 'wordpress.run-php') {
+  process.exit(2);
+}
+
+const codeFile = step.args.find((arg) => arg.startsWith('code-file=')).slice('code-file='.length);
+const wrapper = fs.readFileSync(codeFile, 'utf8');
+const runMount = recipe.inputs.mounts.find((mount) => mount.target === '/homeboy-trace-run');
+const componentMount = recipe.inputs.mounts.find((mount) => mount.target.startsWith('/wordpress/wp-content/plugins/'));
+const resultPath = wrapper.match(/HOMEBOY_TRACE_RESULTS_FILE=([^']+)/)[1].replace('/homeboy-trace-run', runMount.source);
+const artifactDir = wrapper.match(/HOMEBOY_TRACE_ARTIFACT_DIR=([^']+)/)[1].replace('/homeboy-trace-run', runMount.source);
+
+fs.mkdirSync(artifactDir, { recursive: true });
+fs.writeFileSync(path.join(artifactDir, 'php-artifact.txt'), 'php artifact\n');
+fs.writeFileSync(resultPath, JSON.stringify({
+  component_id: 'trace-fixture',
+  scenario_id: 'php-scenario',
+  status: 'pass',
+  summary: 'PHP trace scenario passed via WP Codebox',
+  timeline: [{ t_ms: 0, source: 'php', event: 'scenario.start', data: { runtime: 'wp-codebox' } }],
+  assertions: [{ id: 'runtime', status: 'pass', message: 'ran through wordpress.run-php' }],
+  artifacts: [{ label: 'php artifact', path: path.join(artifactDir, 'php-artifact.txt') }]
+}, null, 2) + '\n');
+fs.writeFileSync(process.env.FAKE_WP_CODEBOX_CAPTURE, JSON.stringify({ argv: process.argv.slice(2), recipe, componentMount, runMount }, null, 2));
+process.stdout.write(JSON.stringify({
+  success: true,
+  schema: 'wp-codebox/recipe-run/v1',
+  executions: [{ command: 'wordpress.run-php', exitCode: 0, stdout: 'php stdout from wp-codebox\n', stderr: '' }]
+}, null, 2));
+NODE
+chmod +x "$fake_wp_codebox"
+
 cat >"$fixture/traces/php-scenario.trace.php" <<'PHP'
 <?php
 $artifact_dir = getenv( 'HOMEBOY_TRACE_ARTIFACT_DIR' );
@@ -153,6 +194,8 @@ HOMEBOY_TRACE_SCENARIO="php-scenario" \
 HOMEBOY_TRACE_RESULTS_FILE="$php_results" \
 HOMEBOY_TRACE_ARTIFACT_DIR="$run_dir/artifacts/php" \
 HOMEBOY_RUN_DIR="$run_dir" \
+HOMEBOY_WP_CODEBOX_BIN="$fake_wp_codebox" \
+FAKE_WP_CODEBOX_CAPTURE="$fake_wp_codebox_capture" \
 bash "$RUNNER"
 
 assert_file "$php_results" "PHP scenario results"
@@ -163,6 +206,9 @@ assert_file "$run_dir/artifacts/php/php-scenario.exit-code.txt" "PHP exit artifa
 assert_json_field "$php_results" "status-pass" "PHP scenario status"
 assert_json_field "$php_results" "has-artifacts" "PHP scenario artifacts"
 assert_json_field "$php_results" "has-timeline" "PHP scenario timeline"
+assert_file "$fake_wp_codebox_capture" "WP Codebox recipe capture"
+assert_contains "$(php -r '$json = json_decode(file_get_contents($argv[1]), true); echo $json["recipe"]["workflow"]["steps"][0]["command"] ?? "";' "$fake_wp_codebox_capture")" "wordpress.run-php" "WP Codebox PHP trace command"
+assert_contains "$(php -r '$json = json_decode(file_get_contents($argv[1]), true); echo $json["runMount"]["target"] ?? "";' "$fake_wp_codebox_capture")" "/homeboy-trace-run" "WP Codebox run mount"
 
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_PATH="$fixture" \

--- a/wordpress/scripts/trace/trace-runner.sh
+++ b/wordpress/scripts/trace/trace-runner.sh
@@ -15,6 +15,10 @@ RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context --component-alias PLUGIN_PATH
 
+WP_CODEBOX_PATHS_HELPER="${SCRIPT_DIR}/../lib/wp-codebox-paths.sh"
+# shellcheck source=../lib/wp-codebox-paths.sh
+source "$WP_CODEBOX_PATHS_HELPER"
+
 export HOMEBOY_COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-$COMPONENT_PATH}"
 export HOMEBOY_TRACE_COMPONENT_PATH="${HOMEBOY_TRACE_COMPONENT_PATH:-$HOMEBOY_COMPONENT_PATH}"
 export HOMEBOY_COMPONENT_ID="${HOMEBOY_COMPONENT_ID:-$COMPONENT_ID}"
@@ -56,6 +60,146 @@ homeboy_wordpress_export_context() {
             export HOMEBOY_WP_CLI="wp"
         fi
     fi
+}
+
+homeboy_wordpress_resolve_wp_codebox_bin() {
+    local bin="${HOMEBOY_WP_CODEBOX_BIN:-}"
+
+    if [ -z "$bin" ] && [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+        bin=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_bin // empty' 2>/dev/null || true)
+    fi
+
+    bin="${bin:-wp-codebox}"
+    if [ "$bin" = "wp-codebox" ] && ! command -v wp-codebox >/dev/null 2>&1; then
+        echo "Error: wp-codebox not found; set HOMEBOY_WP_CODEBOX_BIN, settings wp_codebox_bin, or install wp-codebox." >&2
+        return 1
+    fi
+
+    printf '%s\n' "$bin"
+}
+
+homeboy_wordpress_trace_wp_version() {
+    local version="6.9"
+    local extracted=""
+
+    if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
+        extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.playground_wordpress_version // .wp_codebox_wordpress_version // empty' 2>/dev/null || true)
+        [ -n "$extracted" ] && [ "$extracted" != "null" ] && version="$extracted"
+    fi
+
+    printf '%s\n' "$version"
+}
+
+homeboy_wordpress_trace_php_wrapper() {
+    local runtime_scenario="$1"
+    local runtime_results="$2"
+    local runtime_artifacts="$3"
+    local runtime_run_dir="$4"
+
+    php -r '
+        $env = array(
+            "HOMEBOY_COMPONENT_PATH" => "/wordpress/wp-content/plugins/" . getenv("PLUGIN_SLUG"),
+            "HOMEBOY_TRACE_COMPONENT_PATH" => "/wordpress/wp-content/plugins/" . getenv("PLUGIN_SLUG"),
+            "HOMEBOY_PLUGIN_PATH" => "/wordpress/wp-content/plugins/" . getenv("PLUGIN_SLUG"),
+            "HOMEBOY_COMPONENT_ID" => getenv("HOMEBOY_COMPONENT_ID") ?: basename(getenv("HOMEBOY_COMPONENT_PATH") ?: getcwd()),
+            "HOMEBOY_PROJECT_PATH" => getenv("HOMEBOY_PROJECT_PATH") ?: getenv("HOMEBOY_COMPONENT_PATH"),
+            "HOMEBOY_TRACE_SCENARIO" => getenv("HOMEBOY_TRACE_SCENARIO"),
+            "HOMEBOY_TRACE_RESULTS_FILE" => $argv[2],
+            "HOMEBOY_TRACE_ARTIFACT_DIR" => $argv[3],
+            "HOMEBOY_RUN_DIR" => $argv[4],
+            "HOMEBOY_WP_CLI" => "wp",
+        );
+
+        foreach ($env as $name => $value) {
+            echo "putenv(" . var_export($name . "=" . $value, true) . ");\n";
+        }
+
+        echo "require " . var_export($argv[1], true) . ";\n";
+    ' "$runtime_scenario" "$runtime_results" "$runtime_artifacts" "$runtime_run_dir"
+}
+
+homeboy_trace_run_php_scenario_wp_codebox() {
+    local scenario_rel="$1"
+    local stdout_file="$2"
+    local stderr_file="$3"
+    local codebox_bin wp_version plugin_slug run_mount_host runtime_run_dir runtime_results runtime_artifacts runtime_scenario wrapper_file recipe_file output_file codebox_artifacts_dir status
+
+    codebox_bin="$(homeboy_wordpress_resolve_wp_codebox_bin)" || return 1
+    wp_version="$(homeboy_wordpress_trace_wp_version)"
+    plugin_slug="$(basename "$HOMEBOY_COMPONENT_PATH")"
+    run_mount_host="$(homeboy_wp_codebox_resolve_mount_path "$HOMEBOY_RUN_DIR")"
+    runtime_run_dir="/homeboy-trace-run"
+    case "$HOMEBOY_TRACE_RESULTS_FILE" in
+        "${HOMEBOY_RUN_DIR}"/*)
+            runtime_results="${runtime_run_dir}/${HOMEBOY_TRACE_RESULTS_FILE#"${HOMEBOY_RUN_DIR}/"}"
+            ;;
+        *)
+            echo "Error: HOMEBOY_TRACE_RESULTS_FILE must live under HOMEBOY_RUN_DIR for WP Codebox trace execution: ${HOMEBOY_TRACE_RESULTS_FILE}" >&2
+            return 1
+            ;;
+    esac
+    case "$HOMEBOY_TRACE_ARTIFACT_DIR" in
+        "${HOMEBOY_RUN_DIR}"/*)
+            runtime_artifacts="${runtime_run_dir}/${HOMEBOY_TRACE_ARTIFACT_DIR#"${HOMEBOY_RUN_DIR}/"}"
+            ;;
+        *)
+            echo "Error: HOMEBOY_TRACE_ARTIFACT_DIR must live under HOMEBOY_RUN_DIR for WP Codebox trace execution: ${HOMEBOY_TRACE_ARTIFACT_DIR}" >&2
+            return 1
+            ;;
+    esac
+    runtime_scenario="/wordpress/wp-content/plugins/${plugin_slug}/${scenario_rel}"
+
+    wrapper_file="$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-trace-wrapper.XXXXXX")"
+    recipe_file="$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-trace-recipe.XXXXXX")"
+    output_file="$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-trace-output.XXXXXX")"
+    codebox_artifacts_dir="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-trace-artifacts.XXXXXX")"
+    PLUGIN_SLUG="$plugin_slug" homeboy_wordpress_trace_php_wrapper "$runtime_scenario" "$runtime_results" "$runtime_artifacts" "$runtime_run_dir" > "$wrapper_file"
+
+    jq -n \
+        --arg wp "$wp_version" \
+        --arg componentSource "$(homeboy_wp_codebox_resolve_mount_path "$HOMEBOY_COMPONENT_PATH")" \
+        --arg componentTarget "/wordpress/wp-content/plugins/${plugin_slug}" \
+        --arg runSource "$run_mount_host" \
+        --arg runTarget "$runtime_run_dir" \
+        --arg codeFile "$wrapper_file" \
+        '{
+            schema: "wp-codebox/workspace-recipe/v1",
+            runtime: {wp: $wp, blueprint: {steps: []}},
+            inputs: {mounts: [
+                {source: $componentSource, target: $componentTarget, mode: "readwrite"},
+                {source: $runSource, target: $runTarget, mode: "readwrite"}
+            ]},
+            workflow: {steps: [{command: "wordpress.run-php", args: ["code-file=" + $codeFile]}]}
+        }' > "$recipe_file"
+
+    wp_codebox_command=("$codebox_bin")
+    case "$codebox_bin" in
+        *.js|*.cjs)
+            wp_codebox_command=(node "$codebox_bin")
+            ;;
+    esac
+
+    set +e
+    "${wp_codebox_command[@]}" recipe-run --recipe "$recipe_file" --artifacts "$codebox_artifacts_dir" --json > "$output_file" 2>"$stderr_file"
+    status=$?
+    set -e
+
+    jq -r '(.executions // [])[-1].stdout // empty' "$output_file" > "$stdout_file" 2>/dev/null || true
+    if [ ! -s "$stderr_file" ]; then
+        jq -r '(.executions // [])[-1].stderr // empty' "$output_file" > "$stderr_file" 2>/dev/null || true
+    fi
+
+    if [ "$status" -eq 0 ] && ! jq -e '.success == true' "$output_file" >/dev/null 2>&1; then
+        status=1
+    fi
+
+    if [ "$status" -ne 0 ]; then
+        cat "$output_file" >> "$stderr_file"
+    fi
+
+    rm -f "$wrapper_file" "$recipe_file" "$output_file"
+    rm -rf "$codebox_artifacts_dir"
+    return "$status"
 }
 
 homeboy_trace_emit_scenario() {
@@ -206,7 +350,7 @@ scenario_abs="${HOMEBOY_COMPONENT_PATH}/${scenario_rel}"
 set +e
 case "$scenario_rel" in
     *.php)
-        php "$scenario_abs" >"$stdout_file" 2>"$stderr_file"
+        homeboy_trace_run_php_scenario_wp_codebox "$scenario_rel" "$stdout_file" "$stderr_file"
         status=$?
         ;;
     *.sh)


### PR DESCRIPTION
## Summary
- Routes PHP WordPress trace scenarios through generated WP Codebox `wordpress.run-php` recipes while keeping Homeboy-owned discovery, result files, stdout/stderr/exit artifacts, and failure envelope handling.
- Keeps shell trace scenarios host-local, matching the existing shell-only trace behavior.
- Adds smoke coverage that verifies PHP trace recipe generation and result artifact mapping through a fake WP Codebox command.

## Tests
- `bash -n scripts/trace/trace-runner.sh scripts/trace/trace-runner-smoke.sh`
- `bash scripts/trace/trace-runner-smoke.sh`
- `git diff --check`
- `homeboy lint --path wordpress --extension wordpress` (fails on pre-existing PHPCS findings in `scripts/agent/validate-bundle.php`)
- `homeboy test --path wordpress --extension wordpress` (fails on existing WP Codebox PHPUnit fixture failures unrelated to trace runner)
- Real local `wp-codebox` trace smoke with a temporary PHP trace scenario (timed out at 120s before producing output)

## Upstream Codebox gap
- None found for this migration. WP Codebox already provides the needed generic `wordpress.run-php` recipe primitive.

Closes #929.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the trace runner migration, smoke coverage, and validation runs for Chris to review.