### PR TITLE
nodejs: add typed workload setting helpers

### DIFF
--- a/nodejs/docs/workload-utils.md
+++ b/nodejs/docs/workload-utils.md
@@ -10,7 +10,13 @@ const { metric, runCommand, writeJson } = await import(process.env.HOMEBOY_NODEJ
 The module keeps common workload plumbing in one place without encoding product
 concepts:
 
-- `setting(key, fallback)` resolves `HOMEBOY_SETTINGS_JSON` first, then `HOMEBOY_SETTINGS_<KEY>`.
+- `setting(key, fallback)` resolves `HOMEBOY_SETTINGS_JSON` first, then `HOMEBOY_SETTINGS_<KEY>`, and returns the resolved value as a string.
+- `settingInt(key, fallback, options)` resolves the same sources and returns an integer, or `fallback` when the value is missing, not an integer, below `options.min`, or above `options.max`.
+- `settingBool(key, fallback, options)` accepts JSON booleans, `1`/`0`, and string booleans such as `true`/`false`, `yes`/`no`, and `on`/`off`; invalid values return `fallback`.
+- `settingList(key, fallback, options)` accepts JSON arrays or splits string values on `options.separator` (`,` by default), trims entries by default, and drops empty entries unless `options.keepEmpty` is true.
+- `settingJson(key, fallback, options)` returns JSON object/array values from `HOMEBOY_SETTINGS_JSON` as-is, parses string/env values as JSON, and returns `fallback` when parsing fails.
+- `expandHome(value, options)` expands `~` and `~/...` using `options.homeDir` or the current OS home directory.
+- `resolvePath(value, options)` expands `~`, preserves absolute paths, and resolves relative paths from `options.baseDir`, `HOMEBOY_COMPONENT_PATH`, or the current working directory.
 - `metric(value, fallback)` coerces finite numeric values.
 - `runCommand(command, args, options)` runs a subprocess with redacted output by default.
 - `writeJson(file, data)` and `writeText(file, data)` create parent directories and redact common secrets.
@@ -20,3 +26,9 @@ concepts:
 - `percentile(values, pct)` uses R-7 linear interpolation.
 
 Use `{ redact: false }` with `runCommand()`, `writeJson()`, or `writeText()` only when a workload needs raw output for parsing before writing a redacted artifact.
+
+Typed setting helpers use the same precedence as `setting()`: values in
+`HOMEBOY_SETTINGS_JSON` win when the key exists and is not `null`; otherwise the
+helper reads `HOMEBOY_SETTINGS_<KEY>`, or a custom `options.prefix` when one is
+provided. Invalid typed values return the helper fallback instead of throwing so
+workloads can keep a single defaulting path.

--- a/nodejs/scripts/bench/lib/workload-utils.mjs
+++ b/nodejs/scripts/bench/lib/workload-utils.mjs
@@ -33,6 +33,67 @@ export function setting(key, fallback = '', options = {}) {
     return env[envKey] !== undefined ? env[envKey] : fallback;
 }
 
+export function settingInt(key, fallback = 0, options = {}) {
+    const value = settingValue(key, undefined, options);
+    const parsed = typeof value === 'number'
+        ? value
+        : (/^[+-]?\d+$/.test(String(value ?? '').trim()) ? Number(String(value).trim()) : Number.NaN);
+    if (!Number.isInteger(parsed)) return fallback;
+    if (options.min !== undefined && parsed < options.min) return fallback;
+    if (options.max !== undefined && parsed > options.max) return fallback;
+    return parsed;
+}
+
+export function settingBool(key, fallback = false, options = {}) {
+    const value = settingValue(key, undefined, options);
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'number') {
+        if (value === 1) return true;
+        if (value === 0) return false;
+        return fallback;
+    }
+
+    const normalized = String(value ?? '').trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+    return fallback;
+}
+
+export function settingList(key, fallback = [], options = {}) {
+    const value = settingValue(key, undefined, options);
+    if (Array.isArray(value)) return value.map((item) => String(item));
+    if (value === undefined || value === null || value === '') return fallback;
+
+    const separator = options.separator || ',';
+    const parts = String(value).split(separator).map((item) => (options.trim === false ? item : item.trim()));
+    return options.keepEmpty === true ? parts : parts.filter((item) => item !== '');
+}
+
+export function settingJson(key, fallback = undefined, options = {}) {
+    const value = settingValue(key, undefined, options);
+    if (value === undefined || value === null || value === '') return fallback;
+    if (typeof value === 'object') return value;
+
+    try {
+        return JSON.parse(String(value));
+    } catch {
+        return fallback;
+    }
+}
+
+export function expandHome(value, options = {}) {
+    const input = String(value ?? '');
+    if (input === '~') return options.homeDir || os.homedir();
+    if (input.startsWith('~/')) return path.join(options.homeDir || os.homedir(), input.slice(2));
+    return input;
+}
+
+export function resolvePath(value, options = {}) {
+    const expanded = expandHome(value, options);
+    if (path.isAbsolute(expanded)) return expanded;
+    return path.resolve(options.baseDir || process.env.HOMEBOY_COMPONENT_PATH || process.cwd(), expanded);
+}
+
 export function metric(value, fallback = 0) {
     const number = Number(value ?? fallback);
     return Number.isFinite(number) ? number : fallback;
@@ -158,4 +219,15 @@ function sanitizeSegment(value) {
         .replace(/[^A-Za-z0-9._-]+/g, '-')
         .replace(/^-+|-+$/g, '');
     return segment || 'workload';
+}
+
+function settingValue(key, fallback = undefined, options = {}) {
+    const env = options.env || process.env;
+    const resolved = settings(env);
+    if (Object.hasOwn(resolved, key) && resolved[key] !== undefined && resolved[key] !== null) {
+        return resolved[key];
+    }
+
+    const envKey = `${options.prefix || DEFAULT_SETTINGS_PREFIX}${String(key).toUpperCase()}`;
+    return env[envKey] !== undefined ? env[envKey] : fallback;
 }

--- a/nodejs/scripts/bench/nodejs-workload-utils-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-workload-utils-smoke.sh
@@ -7,8 +7,12 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 mkdir -p "$TMP_DIR/component-under-test"
 
 HOMEBOY_COMPONENT_PATH="$TMP_DIR/component-under-test" \
-HOMEBOY_SETTINGS_JSON='{"alpha":"json-value","number":42,"namespace":"json namespace","ignored_null":null}' \
+HOMEBOY_SETTINGS_JSON='{"alpha":"json-value","number":42,"namespace":"json namespace","ignored_null":null,"enabled":true,"list":["json","items"],"object":{"source":"json"},"json_text":"{\"source\":\"json-string\"}","relative_path":"reports/out.json"}' \
 HOMEBOY_SETTINGS_BETA='env-value' \
+HOMEBOY_SETTINGS_ENV_INT='17' \
+HOMEBOY_SETTINGS_ENV_BOOL='off' \
+HOMEBOY_SETTINGS_ENV_LIST='one, two,,three' \
+HOMEBOY_SETTINGS_ENV_JSON='{"source":"env"}' \
 WORKLOAD_UTILS_UNDER_TEST="$SCRIPT_DIR/lib/workload-utils.mjs" \
 node --input-type=module - <<'EOF'
 import { readFile } from 'node:fs/promises';
@@ -21,6 +25,28 @@ if (utils.setting('number') !== '42') throw new Error('numeric JSON setting was 
 if (utils.setting('beta') !== 'env-value') throw new Error('env setting fallback was not resolved');
 if (utils.setting('ignored_null', 'fallback') !== 'fallback') throw new Error('null JSON setting should use fallback');
 if (utils.setting('missing', 'fallback') !== 'fallback') throw new Error('missing setting fallback failed');
+
+if (utils.settingInt('number') !== 42) throw new Error('JSON integer setting was not parsed');
+if (utils.settingInt('env_int') !== 17) throw new Error('env integer setting was not parsed');
+if (utils.settingInt('env_int', 0, { max: 10 }) !== 0) throw new Error('integer max bound was not enforced');
+if (utils.settingInt('alpha', 9) !== 9) throw new Error('invalid integer did not use fallback');
+
+if (utils.settingBool('enabled') !== true) throw new Error('JSON boolean setting was not parsed');
+if (utils.settingBool('env_bool', true) !== false) throw new Error('env boolean setting was not parsed');
+if (utils.settingBool('alpha', true) !== true) throw new Error('invalid boolean did not use fallback');
+
+if (utils.settingList('list').join('|') !== 'json|items') throw new Error('JSON list setting was not parsed');
+if (utils.settingList('env_list').join('|') !== 'one|two|three') throw new Error('env list setting was not split/trimmed');
+if (utils.settingList('missing_list', ['fallback']).join('|') !== 'fallback') throw new Error('missing list did not use fallback');
+
+if (utils.settingJson('object').source !== 'json') throw new Error('JSON object setting was not preserved');
+if (utils.settingJson('json_text').source !== 'json-string') throw new Error('JSON string setting was not parsed');
+if (utils.settingJson('env_json').source !== 'env') throw new Error('env JSON setting was not parsed');
+if (utils.settingJson('alpha', { fallback: true }).fallback !== true) throw new Error('invalid JSON did not use fallback');
+
+if (utils.expandHome('~/project', { homeDir: '/home/test' }) !== '/home/test/project') throw new Error('home path was not expanded');
+if (utils.resolvePath('relative_path', { baseDir: '/tmp/base' }) !== '/tmp/base/relative_path') throw new Error('relative path was not resolved from baseDir');
+if (utils.resolvePath(utils.setting('relative_path'), { baseDir: process.env.HOMEBOY_COMPONENT_PATH }) !== join(process.env.HOMEBOY_COMPONENT_PATH, 'reports/out.json')) throw new Error('setting path was not resolved from component path');
 
 if (utils.metric('12.5') !== 12.5) throw new Error('metric did not coerce numeric string');
 if (utils.metric('nan', 3) !== 3) throw new Error('metric did not use fallback for NaN');


### PR DESCRIPTION
## Summary
- Add product-neutral typed workload setting helpers for ints, booleans, lists, and JSON values while preserving existing `setting()` string behavior.
- Add generic path helpers for `~` expansion and component-relative path resolution.
- Document helper precedence and invalid-value fallback behavior, and extend the focused smoke coverage.

Closes #937

## Verification
- `bash nodejs/scripts/bench/nodejs-workload-utils-smoke.sh` — passed
- `node --check nodejs/scripts/bench/lib/workload-utils.mjs && bash nodejs/scripts/bench/nodejs-workload-utils-smoke.sh` — passed
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@issue-937-node-typed-settings --extension nodejs` — failed before running tests because Homeboy reported no `package.json` at or above the repo root: `No package.json found at or above /home/chubes/Developer/_lab_workspaces/homeboy-extensions-issue-937-node-typed-settings-9c84b38576e1`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the helper additions, smoke coverage, docs, and verification notes for Chris to review.