### PR TITLE
Remove legacy Playground runtime aliases

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -96,7 +96,7 @@ jobs:
       target_repo: chubes4/world-of-wordpress
       prompt: ${{ inputs.prompt }}
       validation_dependencies: chubes4/world-of-wordpress@main,chubes4/markdown-database-integration@main
-      playground_wordpress: beta
+      wp_codebox_wordpress_version: beta
       max_turns: 16
       step_budget: 20
       time_budget_ms: 900000
@@ -105,13 +105,9 @@ jobs:
           "MARKDOWN_DB_MODE": "primary",
           "MARKDOWN_DB_CONTENT_DIR": "/wordpress/wp-content/plugins/world-of-wordpress/content"
         }
-      extra_playground_file_mounts: |
+      extra_wp_codebox_mounts: |
         [
-          {
-            "from_dependency": "markdown-database-integration",
-            "from": "db.php",
-            "to": "/wordpress/wp-content/db.php"
-          }
+          "${{ github.workspace }}/.ci/markdown-database-integration/db.php:/wordpress/wp-content/db.php:readonly"
         ]
       workload_run_before: |
         [
@@ -141,7 +137,7 @@ jobs:
 - `dry_run` is intended for workflow smoke tests only; production consumers should leave it `false`.
 - `transcript_artifact_name` controls artifact upload. An empty value skips upload.
 - `extra_wp_config_defines` must be a JSON object and is merged into the runner config `wp_config_defines`.
-- `extra_playground_file_mounts`, `workload_run_before`, `workload_run_after`, and `extra_required_abilities` must be JSON arrays.
+- `extra_wp_codebox_mounts`, `workload_run_before`, `workload_run_after`, and `extra_required_abilities` must be JSON arrays.
 - `workload_run_after` runs post-agent verifier hooks in the same WordPress scenario, so consumers can assert the agent left WordPress in a valid state.
 - `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.
 - `tool_recorders` configures tool-result projection, forced parameters, and engine-data capture. It must be a JSON array.

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -88,7 +88,7 @@ name: Data Machine Agent CI (reusable)
         description: Ref for WordPress/ai-provider-for-openai when mounting the default OpenAI provider plugin.
         type: string
         default: trunk
-      playground_wordpress:
+      wp_codebox_wordpress_version:
         type: string
         default: "7.0"
       success_requires_pr:
@@ -183,19 +183,18 @@ name: Data Machine Agent CI (reusable)
           Default '{}' means no extra defines.
         type: string
         default: "{}"
-      extra_playground_file_mounts:
+      extra_wp_codebox_mounts:
         description: |
-          JSON array appended to the runner config playground_file_mounts after
-          the default ci-driver fixture mount. Use for plugin drop-ins,
-          must-use plugin mounts, or any consumer-specific WordPress sandbox file
-          placement. Default '[]' means no extra mounts.
+          JSON string array appended to the runner config wp_codebox_mounts after
+          the default ci-driver fixture mount. Each entry is SOURCE:TARGET[:MODE]
+          for a WP Codebox sandbox mount. Default '[]' means no extra mounts.
         type: string
         default: "[]"
       workload_run_before:
         description: |
           JSON array of pre-run hooks executed before the main bench workload
           inside the WordPress sandbox. Each entry is { type, file } the same way
-          playground_workloads[*].run entries are. Default '[]' means no
+          wp_codebox_workloads[*].run entries are. Default '[]' means no
           pre-run hook.
         type: string
         default: "[]"
@@ -599,7 +598,7 @@ jobs:
           PROMPT: ${{ inputs.prompt }}
           PROVIDER: ${{ inputs.provider }}
           MODEL: ${{ inputs.model }}
-          PLAYGROUND_WORDPRESS: ${{ inputs.playground_wordpress }}
+          WP_CODEBOX_WORDPRESS_VERSION: ${{ inputs.wp_codebox_wordpress_version }}
           SUCCESS_REQUIRES_PR: ${{ inputs.success_requires_pr }}
           SUCCESS_COMPLETION_OUTCOMES: ${{ inputs.success_completion_outcomes }}
           MAX_TURNS: ${{ inputs.max_turns }}
@@ -613,7 +612,7 @@ jobs:
           WP_GYM_BENCHMARK_MODE: ${{ inputs.wp_gym_benchmark_mode }}
           DRY_RUN: ${{ inputs.dry_run }}
           EXTRA_WP_CONFIG_DEFINES: ${{ inputs.extra_wp_config_defines }}
-          EXTRA_PLAYGROUND_FILE_MOUNTS: ${{ inputs.extra_playground_file_mounts }}
+          EXTRA_WP_CODEBOX_MOUNTS: ${{ inputs.extra_wp_codebox_mounts }}
           WORKLOAD_RUN_BEFORE: ${{ inputs.workload_run_before }}
           WORKLOAD_RUN_AFTER: ${{ inputs.workload_run_after }}
           DAILY_MEMORY_ENABLED: ${{ inputs.daily_memory_enabled }}
@@ -657,7 +656,7 @@ jobs:
           execute_workflow_mounts_json="[]"
           if [ -n "$EXECUTE_WORKFLOW_PATH" ] && [[ "$EXECUTE_WORKFLOW_PATH" != /* ]]; then
             execute_workflow_guest_path="/wordpress/wp-content/plugins/${component_slug}/${EXECUTE_WORKFLOW_PATH}"
-            execute_workflow_mounts_json="$(jq -nc --arg from "$EXECUTE_WORKFLOW_PATH" --arg to "$execute_workflow_guest_path" '[{from: $from, to: $to}]')"
+            execute_workflow_mounts_json="$(jq -nc --arg source "${GITHUB_WORKSPACE}/${EXECUTE_WORKFLOW_PATH}" --arg target "$execute_workflow_guest_path" '[$source + ":" + $target + ":readonly"]')"
           fi
           mapfile -t validation_paths < <(find "${GITHUB_WORKSPACE}/.ci" -mindepth 1 -maxdepth 1 -type d | sort)
           provider_plugin_json="$(printf '%s' "$PROVIDER_PLUGIN" | jq -Rsc --arg provider "$PROVIDER" --arg openaiRef "$OPENAI_PROVIDER_REF" '
@@ -705,7 +704,7 @@ jobs:
             fi
           }
           extra_wp_config_defines_json="$(validate_json_input extra_wp_config_defines object "$EXTRA_WP_CONFIG_DEFINES")"
-          extra_playground_file_mounts_json="$(validate_json_input extra_playground_file_mounts array "$EXTRA_PLAYGROUND_FILE_MOUNTS")"
+          extra_wp_codebox_mounts_json="$(validate_json_input extra_wp_codebox_mounts array "$EXTRA_WP_CODEBOX_MOUNTS")"
           workload_run_before_json="$(validate_json_input workload_run_before array "$WORKLOAD_RUN_BEFORE")"
           workload_run_after_json="$(validate_json_input workload_run_after array "$WORKLOAD_RUN_AFTER")"
           extra_required_abilities_json="$(validate_json_input extra_required_abilities array "$EXTRA_REQUIRED_ABILITIES")"
@@ -753,7 +752,8 @@ jobs:
             --arg providerPluginHostPath "$provider_plugin_host_path" \
             --arg engineKey "$ENGINE_KEY" \
             --arg toolResultsKey "$TOOL_RESULTS_KEY" \
-            --arg playgroundWordPress "$PLAYGROUND_WORDPRESS" \
+            --arg wpCodeboxWordPressVersion "$WP_CODEBOX_WORDPRESS_VERSION" \
+            --arg homeboyExtensionsPath "${GITHUB_WORKSPACE}/.ci/homeboy-extensions" \
             --arg transcriptGuestDir "$transcript_guest_dir" \
             --arg githubAppToken "$GITHUB_APP_TOKEN_VALUE" \
             --arg githubRepositoryToken "$GITHUB_REPOSITORY_TOKEN_VALUE" \
@@ -773,7 +773,7 @@ jobs:
             --argjson timeBudgetMs "$TIME_BUDGET_MS" \
             --argjson dryRun "$DRY_RUN" \
             --argjson extraWpConfigDefines "$extra_wp_config_defines_json" \
-            --argjson extraPlaygroundFileMounts "$extra_playground_file_mounts_json" \
+            --argjson extraWpCodeboxMounts "$extra_wp_codebox_mounts_json" \
             --argjson executeWorkflowMounts "$execute_workflow_mounts_json" \
             --argjson workloadRunBefore "$workload_run_before_json" \
             --argjson workloadRunAfter "$workload_run_after_json" \
@@ -799,14 +799,10 @@ jobs:
               workload_id: $flowSlug,
               workload_label: ("Run " + $agentSlug + " Data Machine agent"),
               validation_dependencies: $validationDependencies,
-              playground_wordpress_version: $playgroundWordPress,
-              playground_file_mounts: ([
-                {
-                  from_dependency: "homeboy-extensions",
-                  from: "wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php",
-                  to: "/wordpress/wp-content/plugins/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php"
-                }
-              ] + $extraPlaygroundFileMounts + $executeWorkflowMounts),
+              wp_codebox_wordpress_version: $wpCodeboxWordPressVersion,
+              wp_codebox_mounts: ([
+                $homeboyExtensionsPath + "/wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php:/wordpress/wp-content/plugins/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php:readonly"
+              ] + $extraWpCodeboxMounts + $executeWorkflowMounts),
               wp_config_defines: $extraWpConfigDefines,
               workload_run_before: $workloadRunBefore,
               workload_run_after: $workloadRunAfter,

--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -75,12 +75,12 @@ Each dependency entry may be either:
 - a registered Homeboy component ID
 - an absolute path to another local plugin checkout
 
-## Configurable Playground Bench Workloads
+## Configurable WP Codebox Bench Workloads
 
-WordPress bench runs can declare Playground workloads in extension settings when
+WordPress bench runs can declare WP Codebox workloads in extension settings when
 the workload should be configured by the repo instead of living under
-`tests/bench/*.php`. Configured workloads run after the existing Playground
-bootstrap, `playground_blueprint`, dependency mounts, and component load through
+`tests/bench/*.php`. Configured workloads run after the existing WP Codebox
+bootstrap, `wp_codebox_blueprint`, dependency mounts, and component load through
 a generated WP Codebox recipe.
 
 ```json
@@ -88,7 +88,7 @@ a generated WP Codebox recipe.
   "extensions": {
     "wordpress": {
       "settings": {
-        "playground_workloads": [
+        "wp_codebox_workloads": [
           {
             "id": "generated-site-preview",
             "label": "Generated site preview",
@@ -344,10 +344,10 @@ WordPress substrate. See
 [`../../wordpress/docs/AGENT_CI_WP_CODEBOX.md`](../../wordpress/docs/AGENT_CI_WP_CODEBOX.md)
 for the dedicated agent sandbox guide.
 
-## Playground Scenario Manifests
+## WP Codebox Scenario Manifests
 
 Repos can declare first-class scenario manifests and let the WordPress runner
-compile them into `playground_workloads`. This keeps eval/RL-style scenarios on
+compile them into `wp_codebox_workloads`. This keeps eval/RL-style scenarios on
 the WP Codebox recipe execution path instead of adding a second runner.
 
 ```json
@@ -355,7 +355,7 @@ the WP Codebox recipe execution path instead of adding a second runner.
   "extensions": {
     "wordpress": {
       "settings": {
-        "playground_scenario_manifests": [
+        "wp_codebox_scenario_manifests": [
           "scenarios/navigation-001.json"
         ]
       }
@@ -394,7 +394,7 @@ Supported fields:
   references resolve relative to the manifest file.
 - `blueprint` or `blueprint_file`: inline object or JSON file passed to
   WP Codebox as part of the generated recipe runtime blueprint.
-- `run`: existing `playground_workloads` steps for the model or agent action
+- `run`: existing `wp_codebox_workloads` steps for the model or agent action
   loop. The supported step types are still `php`, `ability`, and `wp-cli`.
 - `grader` or `grader_file`: PHP file appended after `run`, so grading happens
   after the action loop.
@@ -423,12 +423,12 @@ Example: drive a plugin's pipeline through an Abilities API entry point.
   "extensions": {
     "wordpress": {
       "settings": {
-        "playground_blueprint": {
+        "wp_codebox_blueprint": {
           "steps": [
             { "step": "installPlugin", "pluginData": { "resource": "wordpress.org/plugins", "slug": "data-machine" } }
           ]
         },
-        "playground_workloads": [
+        "wp_codebox_workloads": [
           {
             "id": "smoke-pipeline",
             "run": [

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -247,16 +247,14 @@ runtime, component mount, command execution, and artifacts, and emits the same
 
 Each file under `tests/bench/*.php` returns a callable. The callable may return
 numeric metrics directly or `{metrics, metadata, artifacts}`. Components may
-also declare configured workloads via `playground_workloads`; the WordPress
+also declare configured workloads via `wp_codebox_workloads`; the WordPress
 runner maps those declarations into a temporary WP Codebox recipe alongside
-`validation_dependencies`, `playground_file_mounts`, `wp_config_defines`,
+`validation_dependencies`, `wp_codebox_file_mounts`, `wp_config_defines`,
 `bench_env`, shared-state mounts, and browser handoff descriptors.
 
 The generated recipe is the single WP Codebox entry point for benchmarks:
-`playground_blueprint` becomes `runtime.blueprint`, dependencies become recipe
+`wp_codebox_blueprint` becomes `runtime.blueprint`, dependencies become recipe
 plugin inputs, and scenario manifests compile into configured workloads.
-`bench_site_mode=installed` still fails fast until WP Codebox has an explicit
-persisted-site recipe contract.
 
 The browser bench target is a two-extension handoff: the WordPress
 extension prepares/describes the WordPress target by writing
@@ -402,17 +400,15 @@ Configure per-component in the component's homeboy/component config under
 
 | Setting | Type | Default | Purpose |
 |---|---|---|---|
-| `test_backend` | string | `wp-codebox` | `wp-codebox` (default) or `host-smoke` / `host` for standalone non-WordPress smoke scripts |
+| `test_backend` | string | `wp-codebox` | `wp-codebox` (default) or `host-smoke` for standalone non-WordPress smoke scripts |
 | `validation_dependencies` | string | `""` | Comma / newline / JSON list of local components to mount during PHPStan, autoload validation, and PHPUnit |
 | `user` | string | `""` | WP-CLI user (email/login/ID); appended as `--user` when set |
 | `wp_config_defines` | object | `{}` | `CONSTANT_NAME => value` map appended to the runtime `wp-tests-config.php`; PHP type preserved via `var_export` |
 | `bench_env` | object | `{}` | `NAME => value` env vars forwarded into the runtime (workloads/fixtures read via `getenv()`) |
-| `playground_blueprint` | object | `{}` | Runtime blueprint merged into the generated WP Codebox bench recipe |
-| `playground_workloads` | array | `[]` | Declared bench workloads passed to `wordpress.bench` through the generated recipe after deps and component load |
-| `playground_file_mounts` | array | `[]` | Files from the component or validation dependencies mounted into explicit WordPress runtime paths |
-| `bench_site_mode` | string | `fresh` | `fresh` uses a disposable WP Codebox site; `installed` currently fails fast until a WP Codebox persisted-site contract lands |
+| `wp_codebox_blueprint` | object | `{}` | Runtime blueprint merged into the generated WP Codebox bench recipe |
+| `wp_codebox_workloads` | array | `[]` | Declared bench workloads passed to `wordpress.bench` through the generated recipe after deps and component load |
+| `wp_codebox_file_mounts` | array | `[]` | Files from the component or validation dependencies mounted into explicit WordPress runtime paths |
 | `bench_browser_target` | object | `{}` | Browser bench target descriptor (see Bench runner above) |
-| `playground_wordpress_install_mode` | string | `""` | Legacy direct-Playground pass-through; ignored by the WP Codebox bench runner |
 
 ## Blueprint Validation
 

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -108,9 +108,7 @@ The runner converts the agent config into a single WP Codebox sandbox run:
 - The workflow checks out and builds WP Codebox whenever `run_agent` is true.
 - `include_agent_runtime_dependencies` mounts the standard Data Machine agent
   runtime before consumer-supplied `validation_dependencies`.
-- `playground_file_mounts` adds fixture files such as the CI driver plugin. The
-  setting name is inherited from the previous direct-runner contract and is kept
-  as part of the current workflow input surface.
+- `wp_codebox_mounts` adds fixture files such as the CI driver plugin.
 - `bench_env` forwards credentials and the serialized runner config into the
   sandbox.
 - `workload_run_before` and `workload_run_after` attach setup and verifier hooks
@@ -135,7 +133,7 @@ The runner converts the agent config into a single WP Codebox sandbox run:
   execute like a real command. In WP Codebox agent runs, the default
   `run_wp_cli` tool posts to the authenticated runtime WP-CLI bridge injected by
   `wp-codebox.agent-sandbox-run`; the bridge executes the command with WP
-  Codebox's `wordpress.wp-cli` primitive inside the active Playground runtime
+  Codebox's `wordpress.wp-cli` primitive inside the active WP Codebox runtime
   and returns exit code, stdout, and stderr. Use `wp_cli_tool_name` only when a
   consumer needs a different agent-facing tool name.
 - `pipeline_step_patches` and `flow_step_patches` can adjust imported bundle
@@ -159,7 +157,7 @@ knobs to `run-datamachine-agent.sh`:
 - Bundle location: `bundle_path`, `bundle_repo`, `bundle_ref`, `bundle_path_in_repo`.
 - Agent selection: `agent_slug`, `pipeline_slug`, `flow_slug`, `prompt`, `provider`, `model`.
 - Provider plugin: `provider_plugin`, with OpenAI defaults preserved when omitted for `provider: openai`.
-- WordPress runtime: `include_agent_runtime_dependencies`, runtime dependency refs, `playground_wordpress`, `wp_codebox_ref`, `extra_wp_config_defines`, `extra_playground_file_mounts`, `workload_run_before`, `workload_run_after`.
+- WordPress runtime: `include_agent_runtime_dependencies`, runtime dependency refs, `wp_codebox_wordpress_version`, `wp_codebox_ref`, `extra_wp_config_defines`, `extra_wp_codebox_mounts`, `workload_run_before`, `workload_run_after`.
 - GitHub access: `target_repo`, `app_token_repos`, `allowed_repos`, `engine_key`, `tool_results_key`.
 - Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
 - Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`, `replay_bundle_artifact_name`.

--- a/wordpress/docs/PLAYGROUND_DROPIN.md
+++ b/wordpress/docs/PLAYGROUND_DROPIN.md
@@ -154,8 +154,8 @@ during build).
   means it must delegate to Playground's bundled SQLite for the initial
   schema.
 
-- **WP version pinning.** The WordPress test runner defaults to `--wp=6.9`, and
-  the `playground_wordpress_version` setting can pass a different `--wp=<version>`.
+- **WP version pinning.** The WordPress test runner defaults to `6.9`, and
+  the `wp_codebox_wordpress_version` setting can pass a different WordPress version.
   The selected WordPress version must
   match the `wp-phpunit` package version. Don't forget to update both when
   bumping WordPress. A mismatch often manifests as missing `WP_UnitTestCase`

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -515,11 +515,11 @@ if (result.status === 'process_exited') {
 
 ## Known gaps
 
-- **WP version defaults to 6.9.** Override `playground_wordpress_version` to pass
-  a different `--wp=<version>` to Playground. Mismatched versions produce
+- **WP version defaults to 6.9.** Override `wp_codebox_wordpress_version` to pass
+  a different WordPress version to WP Codebox. Mismatched versions produce
   missing-class errors.
-- **Multisite is opt-in.** Set `HOMEBOY_PLAYGROUND_MULTISITE=1`,
-  `HOMEBOY_WORDPRESS_MULTISITE=1`, or `playground.multisite: true` in settings.
+- **Multisite is opt-in.** Set `HOMEBOY_WORDPRESS_MULTISITE=1` or
+  `wp_codebox_multisite: true` in settings.
   Plugin tests also auto-enable multisite when the plugin header declares
   `Network: true`.
 - **Partial phpunit.xml consumption.** The runner reads `<testsuite>` and

--- a/wordpress/scripts/agent/build-replay-bundle-smoke.sh
+++ b/wordpress/scripts/agent/build-replay-bundle-smoke.sh
@@ -59,7 +59,7 @@ jq -n '{
     seed: 123,
     prompt: "Reproduce the failure.",
     openai_api_key: "should-not-leak",
-    playground_blueprint: {
+    wp_codebox_blueprint: {
         steps: [
             { step: "login", username: "admin", password: "should-not-leak" }
         ]

--- a/wordpress/scripts/agent/build-replay-bundle.js
+++ b/wordpress/scripts/agent/build-replay-bundle.js
@@ -510,7 +510,7 @@ function buildBundle(results, scenario, config, bundlePath, resultsPath, episode
 			file: scenario.file,
 			manifest: metadata.scenario_manifest || metadata.manifest || metadata.scenario,
 		}),
-		initial_blueprint: config.playground_blueprint || {},
+		initial_blueprint: config.wp_codebox_blueprint || {},
 		prompt: config.prompt,
 		runner_config: config,
 		provider: config.provider || metadata.provider,

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -140,7 +140,7 @@ PHP
     done < <(homeboy_datamachine_agent_wp_codebox_secret_env_names)
 
     jq -n \
-        --arg wp "$PLAYGROUND_WORDPRESS_VERSION" \
+        --arg wp "$WP_CODEBOX_WORDPRESS_VERSION" \
         --argjson extraPlugins "$extra_plugins_json" \
         --argjson mounts "$mounts_json" \
         --argjson secretEnv "$secret_env_json" \
@@ -834,7 +834,7 @@ fi
 
 WORKLOAD_ID=$(jq -r '.workload_id // "datamachine-agent"' "$CONFIG_PATH")
 WORKLOAD_LABEL=$(jq -r '.workload_label // "Run Data Machine agent"' "$CONFIG_PATH")
-PLAYGROUND_WORDPRESS_VERSION=$(jq -r '.playground_wordpress_version // "7.0"' "$CONFIG_PATH")
+WP_CODEBOX_WORDPRESS_VERSION=$(jq -r '.wp_codebox_wordpress_version // "7.0"' "$CONFIG_PATH")
 ENABLE_TERMINAL_ACTIONS=$(jq -r 'if (.enable_terminal_actions // .enable_wp_cli_tool // false) then "1" else "0" end' <<<"$CONFIG_JSON")
 if [ "$ENABLE_TERMINAL_ACTIONS" = "1" ]; then
     if [ -z "$RUNTIME_DIR" ]; then

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -63,12 +63,6 @@ fi
 settings_json="${HOMEBOY_SETTINGS_JSON:-}"
 [ -n "$settings_json" ] || settings_json="{}"
 
-if printf '%s' "$settings_json" | jq -e '((.bench_site_mode // "fresh") == "installed")' >/dev/null 2>&1; then
-    echo "Error: bench_site_mode=installed requires a persisted-site WP Codebox recipe contract." >&2
-    FAILED_STEP="WP Codebox bench configuration"
-    exit 1
-fi
-
 homeboy_wp_codebox_resolve_host_path() {
     local base_dir="$1"
     local path_value="$2"
@@ -93,7 +87,7 @@ homeboy_wp_codebox_component_relative_path() {
 homeboy_wp_codebox_compile_scenario_manifests() {
     local entries_json
     entries_json=$(printf '%s' "$settings_json" | jq -c '
-        .playground_scenario_manifests // .scenario_manifests // []
+        .wp_codebox_scenario_manifests // .scenario_manifests // []
         | if type == "array" then . elif type == "string" or type == "object" then [.] else [] end
     ' 2>/dev/null || echo '[]')
 
@@ -125,7 +119,7 @@ homeboy_wp_codebox_compile_scenario_manifests() {
         elif [ "$entry_type" = "object" ]; then
             manifest_json=$(printf '%s' "$manifest_entry" | jq -c '.')
         else
-            echo "Error: playground_scenario_manifests[$index] must be a path string or object" >&2
+            echo "Error: wp_codebox_scenario_manifests[$index] must be a path string or object" >&2
             FAILED_STEP="Scenario manifest setup"
             exit 1
         fi
@@ -260,10 +254,10 @@ homeboy_wp_codebox_compile_scenario_manifests() {
 
 homeboy_wp_codebox_compile_scenario_manifests
 
-PLAYGROUND_WORDPRESS_VERSION="7.0"
+WP_CODEBOX_WORDPRESS_VERSION="7.0"
 if [ "$settings_json" != "{}" ]; then
-    extracted=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_wordpress_version // .playground_wordpress_version // empty' 2>/dev/null || true)
-    [ -n "$extracted" ] && [ "$extracted" != "null" ] && PLAYGROUND_WORDPRESS_VERSION="$extracted"
+    extracted=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_wordpress_version // empty' 2>/dev/null || true)
+    [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_WORDPRESS_VERSION="$extracted"
 fi
 
 ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-3}"
@@ -297,13 +291,13 @@ DEPENDENCY_PATHS="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
 
 WP_CONFIG_DEFINES_JSON="{}"
 BENCH_ENV_JSON="{}"
-PLAYGROUND_WORKLOADS_JSON="[]"
+WP_CODEBOX_WORKLOADS_JSON="[]"
 if [ "$settings_json" != "{}" ]; then
     WP_CONFIG_DEFINES_JSON=$(printf '%s' "$settings_json" | jq -c '.wp_config_defines // {}' 2>/dev/null || echo "{}")
     BENCH_ENV_JSON=$(printf '%s' "$settings_json" | jq -c '.bench_env // {}' 2>/dev/null || echo "{}")
-    PLAYGROUND_WORKLOADS_JSON=$(printf '%s' "$settings_json" | jq -c '.playground_workloads // []' 2>/dev/null || echo "[]")
+    WP_CODEBOX_WORKLOADS_JSON=$(printf '%s' "$settings_json" | jq -c '.wp_codebox_workloads // []' 2>/dev/null || echo "[]")
 fi
-PLAYGROUND_WORKLOADS_JSON=$(jq -nc --argjson declared "$PLAYGROUND_WORKLOADS_JSON" --argjson scenarios "$SCENARIO_MANIFEST_WORKLOADS_JSON" '$declared + $scenarios')
+WP_CODEBOX_WORKLOADS_JSON=$(jq -nc --argjson declared "$WP_CODEBOX_WORKLOADS_JSON" --argjson scenarios "$SCENARIO_MANIFEST_WORKLOADS_JSON" '$declared + $scenarios')
 
 EXTRA_PLUGINS_JSON=$(jq -nc --arg source "$PLUGIN_PATH" --arg slug "$PLUGIN_SLUG" '[{source: $source, slug: $slug, activate: false}]')
 MOUNTS_JSON="[]"
@@ -322,18 +316,18 @@ if [ -f "$PLUGIN_DB_PHP" ]; then
     MOUNTS_JSON=$(jq -nc --argjson mounts "$MOUNTS_JSON" --arg source "$PLUGIN_DB_PHP" '$mounts + [{source: $source, target: "/wordpress/wp-content/db.php", mode: "readonly"}]')
 fi
 
-PLAYGROUND_FILE_MOUNTS_JSON="[]"
+WP_CODEBOX_FILE_MOUNTS_JSON="[]"
 if [ "$settings_json" != "{}" ]; then
-    PLAYGROUND_FILE_MOUNTS_JSON=$(printf '%s' "$settings_json" | jq -c '.playground_file_mounts // []' 2>/dev/null || echo "[]")
+    WP_CODEBOX_FILE_MOUNTS_JSON=$(printf '%s' "$settings_json" | jq -c '.wp_codebox_file_mounts // []' 2>/dev/null || echo "[]")
 fi
-if printf '%s' "$PLAYGROUND_FILE_MOUNTS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+if printf '%s' "$WP_CODEBOX_FILE_MOUNTS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
     while IFS= read -r mount_json; do
         [ -n "$mount_json" ] || continue
         mount_from=$(printf '%s' "$mount_json" | jq -r '.from // empty')
         mount_to=$(printf '%s' "$mount_json" | jq -r '.to // empty')
         mount_dependency=$(printf '%s' "$mount_json" | jq -r '.from_dependency // empty')
         if [ -z "$mount_from" ] || [ -z "$mount_to" ] || [[ "$mount_from" = /* ]] || [[ "$mount_from" == *..* ]] || [[ "$mount_to" != /* ]]; then
-            echo "Error: playground_file_mounts entries require relative 'from' and absolute 'to' paths." >&2
+            echo "Error: wp_codebox_file_mounts entries require relative 'from' and absolute 'to' paths." >&2
             FAILED_STEP="WP Codebox file mount setup"
             exit 1
         fi
@@ -352,18 +346,18 @@ if printf '%s' "$PLAYGROUND_FILE_MOUNTS_JSON" | jq -e 'type == "array" and lengt
             fi
         fi
         if [ -z "$mount_root" ]; then
-            echo "Error: playground_file_mounts dependency not found: $mount_dependency" >&2
+            echo "Error: wp_codebox_file_mounts dependency not found: $mount_dependency" >&2
             FAILED_STEP="WP Codebox file mount setup"
             exit 1
         fi
         mount_host="${mount_root}/${mount_from}"
         if [ ! -f "$mount_host" ]; then
-            echo "Error: playground_file_mounts source file not found: $mount_host" >&2
+            echo "Error: wp_codebox_file_mounts source file not found: $mount_host" >&2
             FAILED_STEP="WP Codebox file mount setup"
             exit 1
         fi
         MOUNTS_JSON=$(jq -nc --argjson mounts "$MOUNTS_JSON" --arg source "$mount_host" --arg target "$mount_to" '$mounts + [{source: $source, target: $target, mode: "readonly"}]')
-    done < <(printf '%s' "$PLAYGROUND_FILE_MOUNTS_JSON" | jq -c '.[]')
+    done < <(printf '%s' "$WP_CODEBOX_FILE_MOUNTS_JSON" | jq -c '.[]')
 fi
 
 SHARED_STATE_HOST="${HOMEBOY_BENCH_SHARED_STATE:-}"
@@ -380,7 +374,7 @@ if ! homeboy_wordpress_emit_browser_target "$settings_json" "$SHARED_STATE_HOST"
 fi
 
 BENCH_DIR="${PLUGIN_PATH}/tests/bench"
-if [ ! -d "$BENCH_DIR" ] && ! printf '%s' "$PLAYGROUND_WORKLOADS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+if [ ! -d "$BENCH_DIR" ] && ! printf '%s' "$WP_CODEBOX_WORKLOADS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
     echo "Warning: No bench workloads found for ${PLUGIN_PATH}" >&2
     if [ -n "${HOMEBOY_BENCH_RESULTS_FILE:-}" ]; then
         homeboy_write_empty_bench_results "$COMPONENT_ID" 0 "$RESULTS_FILE"
@@ -391,19 +385,19 @@ fi
 
 echo "Running bench workloads via WP Codebox..."
 echo "  Plugin: ${PLUGIN_SLUG} (${PLUGIN_PATH})"
-echo "  Backend: wp-codebox (WordPress Playground runtime)"
+echo "  Backend: wp-codebox"
 
 DEPENDENCY_SLUGS_CSV=""
 if [ ${#DEPENDENCY_SLUGS[@]} -gt 0 ]; then
     DEPENDENCY_SLUGS_CSV=$(IFS=,; printf '%s' "${DEPENDENCY_SLUGS[*]}")
 fi
 
-PLAYGROUND_BLUEPRINT_JSON="{}"
+WP_CODEBOX_BLUEPRINT_JSON="{}"
 if [ "$settings_json" != "{}" ]; then
-    PLAYGROUND_BLUEPRINT_JSON=$(printf '%s' "$settings_json" | jq -c '.playground_blueprint // {}' 2>/dev/null || echo "{}")
+    WP_CODEBOX_BLUEPRINT_JSON=$(printf '%s' "$settings_json" | jq -c '.wp_codebox_blueprint // {}' 2>/dev/null || echo "{}")
 fi
 RUNTIME_BLUEPRINT_JSON=$(jq -nc \
-    --argjson base "$PLAYGROUND_BLUEPRINT_JSON" \
+    --argjson base "$WP_CODEBOX_BLUEPRINT_JSON" \
     --argjson scenario "$SCENARIO_MANIFEST_BLUEPRINT_JSON" \
     --argjson defines "$WP_CONFIG_DEFINES_JSON" '
     ($base + $scenario) as $merged |
@@ -422,7 +416,7 @@ WORKFLOW_STEP_JSON=$(jq -nc \
     --arg warmup "$WARMUP_ITERATIONS" \
     --arg dependencySlugs "$DEPENDENCY_SLUGS_CSV" \
     --argjson env "$BENCH_ENV_JSON" \
-    --argjson workloads "$PLAYGROUND_WORKLOADS_JSON" '
+    --argjson workloads "$WP_CODEBOX_WORKLOADS_JSON" '
     {
         command: "wordpress.bench",
         args: [
@@ -439,7 +433,7 @@ WORKFLOW_STEP_JSON=$(jq -nc \
 
 RECIPE_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-bench-recipe.XXXXXX")
 jq -n \
-    --arg wp "$PLAYGROUND_WORDPRESS_VERSION" \
+    --arg wp "$WP_CODEBOX_WORDPRESS_VERSION" \
     --argjson blueprint "$RUNTIME_BLUEPRINT_JSON" \
     --argjson extraPlugins "$EXTRA_PLUGINS_JSON" \
     --argjson mounts "$MOUNTS_JSON" \

--- a/wordpress/scripts/bench/browser-target.sh
+++ b/wordpress/scripts/bench/browser-target.sh
@@ -26,7 +26,7 @@ homeboy_wordpress_emit_browser_target() {
     local shared_state_host="$2"
     local component_id="$3"
     local plugin_slug="$4"
-    local bench_site_mode="$5"
+    local runtime_mode="$5"
 
     if ! homeboy_wordpress_browser_target_enabled "$settings_json"; then
         return 0
@@ -66,7 +66,7 @@ homeboy_wordpress_emit_browser_target() {
     printf '%s' "$settings_json" | jq \
         --arg component_id "$component_id" \
         --arg plugin_slug "$plugin_slug" \
-        --arg bench_site_mode "$bench_site_mode" \
+        --arg runtime_mode "$runtime_mode" \
         --arg password "$password" '
         def target_config:
             if .bench_browser_target == true then {} else (.bench_browser_target // {}) end;
@@ -98,7 +98,7 @@ homeboy_wordpress_emit_browser_target() {
                 wpVersion: "6.9",
                 componentId: $component_id,
                 pluginSlug: $plugin_slug,
-                benchSiteMode: $bench_site_mode
+                runtimeMode: $runtime_mode
             },
             artifactPolicy: {
                 publishRaw: false,

--- a/wordpress/scripts/test/host-smoke-runner-smoke.sh
+++ b/wordpress/scripts/test/host-smoke-runner-smoke.sh
@@ -106,12 +106,19 @@ HOMEBOY_SETTINGS_JSON='{"test_backend":"host-smoke"}' \
 assert_contains "${TMPDIR}/router-host-smoke.out" "Backend: host-smoke"
 assert_not_contains "${TMPDIR}/router-host-smoke.out" "Backend: playground"
 
+set +e
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component-pass" \
 HOMEBOY_COMPONENT_PATH="$component_pass" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_SETTINGS_JSON='{"test_backend":"host"}' \
-    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/router-host-alias.out"
-assert_contains "${TMPDIR}/router-host-alias.out" "Backend: host-smoke"
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/router-host-alias.out" 2>&1
+host_alias_exit=$?
+set -e
+if [ "$host_alias_exit" -eq 0 ]; then
+    echo "Expected legacy host backend alias to fail" >&2
+    exit 1
+fi
+assert_contains "${TMPDIR}/router-host-alias.out" "Unsupported WordPress test backend: host"
 
 echo "Host smoke runner smoke passed"

--- a/wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # WP Codebox-backed test runner for wordpress-develop / WordPress core source
 # checkouts. Unlike plugin/theme tests, core tests mount the checkout's src and
-# tests/phpunit directories into a core-shaped Playground runtime. If the core
+# tests/phpunit directories into a core-shaped WP Codebox runtime. If the core
 # vendor autoload is absent, WP Codebox reports that as a structured runtime
 # failure instead of this wrapper provisioning host dependencies.
 
@@ -105,22 +105,19 @@ if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
 fi
 
 WP_CONFIG_DEFINES_JSON="{}"
-PLAYGROUND_WORDPRESS_VERSION="6.9"
-PLAYGROUND_MULTISITE="${HOMEBOY_WORDPRESS_MULTISITE:-}"
+WP_CODEBOX_WORDPRESS_VERSION="6.9"
+WP_CODEBOX_MULTISITE="${HOMEBOY_WORDPRESS_MULTISITE:-}"
 if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.wp_config_defines // {}' 2>/dev/null || echo "{}")
     [ -n "$extracted" ] && WP_CONFIG_DEFINES_JSON="$extracted"
 
-    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.playground_wordpress_version // .wp_codebox_wordpress_version // empty' 2>/dev/null || true)
-    [ -n "$extracted" ] && [ "$extracted" != "null" ] && PLAYGROUND_WORDPRESS_VERSION="$extracted"
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_wordpress_version // empty' 2>/dev/null || true)
+    [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_WORDPRESS_VERSION="$extracted"
 
-    if [ -z "$PLAYGROUND_MULTISITE" ]; then
-        extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.playground.multisite // .wp_codebox_multisite // .multisite // empty' 2>/dev/null || true)
-        [ -n "$extracted" ] && [ "$extracted" != "null" ] && PLAYGROUND_MULTISITE="$extracted"
+    if [ -z "$WP_CODEBOX_MULTISITE" ]; then
+        extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_multisite // empty' 2>/dev/null || true)
+        [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_MULTISITE="$extracted"
     fi
-fi
-if [ -n "${HOMEBOY_PLAYGROUND_MULTISITE+x}" ]; then
-    PLAYGROUND_MULTISITE="$HOMEBOY_PLAYGROUND_MULTISITE"
 fi
 
 MOUNTS_JSON=$(jq -nc \
@@ -142,7 +139,7 @@ fi
 
 echo "Running WordPress core PHPUnit tests via WP Codebox..."
 echo "  Core: ${CORE_PATH}"
-echo "  Backend: wp-codebox (WordPress Playground runtime)"
+echo "  Backend: wp-codebox"
 
 WP_CODEBOX_TMPFILE=$(mktemp)
 PHPUNIT_STDOUT_TMPFILE=$(mktemp)
@@ -155,12 +152,12 @@ case "$WP_CODEBOX_BIN" in
 esac
 
 jq -n \
-    --arg wp "$PLAYGROUND_WORDPRESS_VERSION" \
+    --arg wp "$WP_CODEBOX_WORDPRESS_VERSION" \
     --argjson mounts "$MOUNTS_JSON" \
     --arg selectedTestFile "$SELECTED_TEST_FILE" \
     --arg changedTestsJson "$CHANGED_TEST_FILES_JSON" \
     --arg definesJson "$WP_CONFIG_DEFINES_JSON" \
-    --arg multisite "$PLAYGROUND_MULTISITE" \
+    --arg multisite "$WP_CODEBOX_MULTISITE" \
     '{
         schema: "wp-codebox/workspace-recipe/v1",
         runtime: {wp: $wp, blueprint: {steps: []}},

--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -156,7 +156,7 @@ HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
-HOMEBOY_SETTINGS_JSON='{"wp_codebox_bin":"'"${TMPDIR}/stubs/wp-codebox.sh"'","playground_wordpress_version":"latest"}' \
+HOMEBOY_SETTINGS_JSON='{"wp_codebox_bin":"'"${TMPDIR}/stubs/wp-codebox.sh"'","wp_codebox_wordpress_version":"latest"}' \
 WP_CODEBOX_ARGS_FILE="${TMPDIR}/wp-codebox-settings-args.txt" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/Unit/ImportAgentAbilityTest.php > "${TMPDIR}/wp-codebox-settings.out"
 

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -219,10 +219,10 @@ DEPENDENCY_PATHS="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
 
 WP_CONFIG_DEFINES_JSON="{}"
 BENCH_ENV_JSON="{}"
-PLAYGROUND_FILE_MOUNTS_JSON="[]"
+WP_CODEBOX_FILE_MOUNTS_JSON="[]"
 PHPUNIT_NO_TESTS="skipped"
-PLAYGROUND_WORDPRESS_VERSION="6.9"
-PLAYGROUND_MULTISITE=""
+WP_CODEBOX_WORDPRESS_VERSION="6.9"
+WP_CODEBOX_MULTISITE=""
 if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.wp_config_defines // {}' 2>/dev/null || echo "{}")
     [ -n "$extracted" ] && WP_CONFIG_DEFINES_JSON="$extracted"
@@ -230,26 +230,23 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.bench_env // {}' 2>/dev/null || echo "{}")
     [ -n "$extracted" ] && BENCH_ENV_JSON="$extracted"
 
-    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.playground_file_mounts // []' 2>/dev/null || echo "[]")
-    [ -n "$extracted" ] && [ "$extracted" != "null" ] && PLAYGROUND_FILE_MOUNTS_JSON="$extracted"
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.wp_codebox_file_mounts // []' 2>/dev/null || echo "[]")
+    [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_FILE_MOUNTS_JSON="$extracted"
 
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.phpunit_no_tests // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && PHPUNIT_NO_TESTS="$extracted"
 
-    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.playground_wordpress_version // .wp_codebox_wordpress_version // empty' 2>/dev/null || true)
-    [ -n "$extracted" ] && [ "$extracted" != "null" ] && PLAYGROUND_WORDPRESS_VERSION="$extracted"
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_wordpress_version // empty' 2>/dev/null || true)
+    [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_WORDPRESS_VERSION="$extracted"
 
-    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.playground.multisite // .wp_codebox_multisite // .multisite // empty' 2>/dev/null || true)
-    [ -n "$extracted" ] && [ "$extracted" != "null" ] && PLAYGROUND_MULTISITE="$extracted"
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_multisite // empty' 2>/dev/null || true)
+    [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_MULTISITE="$extracted"
 fi
 if [ -n "${HOMEBOY_WORDPRESS_MULTISITE+x}" ]; then
-    PLAYGROUND_MULTISITE="$HOMEBOY_WORDPRESS_MULTISITE"
+    WP_CODEBOX_MULTISITE="$HOMEBOY_WORDPRESS_MULTISITE"
 fi
-if [ -n "${HOMEBOY_PLAYGROUND_MULTISITE+x}" ]; then
-    PLAYGROUND_MULTISITE="$HOMEBOY_PLAYGROUND_MULTISITE"
-fi
-if [ -z "$PLAYGROUND_MULTISITE" ] && detect_network_plugin_header; then
-    PLAYGROUND_MULTISITE="1"
+if [ -z "$WP_CODEBOX_MULTISITE" ] && detect_network_plugin_header; then
+    WP_CODEBOX_MULTISITE="1"
 fi
 
 CHANGED_TEST_FILES_JSON="[]"
@@ -305,24 +302,24 @@ if [ -f "$PLUGIN_DB_PHP" ]; then
     homeboy_wp_codebox_add_recipe_mount "${PLUGIN_DB_PHP}" "/wordpress/wp-content/db.php"
 fi
 
-if printf '%s' "$PLAYGROUND_FILE_MOUNTS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+if printf '%s' "$WP_CODEBOX_FILE_MOUNTS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
     while IFS= read -r mount_json; do
         [ -n "$mount_json" ] || continue
         mount_from=$(printf '%s' "$mount_json" | jq -r '.from // empty')
         mount_to=$(printf '%s' "$mount_json" | jq -r '.to // empty')
         mount_dependency=$(printf '%s' "$mount_json" | jq -r '.from_dependency // empty')
         if [ -z "$mount_from" ] || [ -z "$mount_to" ]; then
-            echo "Error: playground_file_mounts entries require 'from' and 'to'" >&2
+            echo "Error: wp_codebox_file_mounts entries require 'from' and 'to'" >&2
             FAILED_STEP="WP Codebox file mount setup"
             exit 1
         fi
         if [[ "$mount_from" = /* ]] || [[ "$mount_from" == *..* ]]; then
-            echo "Error: playground_file_mounts 'from' must be a relative path without '..' (got '$mount_from')" >&2
+            echo "Error: wp_codebox_file_mounts 'from' must be a relative path without '..' (got '$mount_from')" >&2
             FAILED_STEP="WP Codebox file mount setup"
             exit 1
         fi
         if [[ "$mount_to" != /* ]]; then
-            echo "Error: playground_file_mounts 'to' must be an absolute Playground path (got '$mount_to')" >&2
+            echo "Error: wp_codebox_file_mounts 'to' must be an absolute WP Codebox sandbox path (got '$mount_to')" >&2
             FAILED_STEP="WP Codebox file mount setup"
             exit 1
         fi
@@ -341,7 +338,7 @@ if printf '%s' "$PLAYGROUND_FILE_MOUNTS_JSON" | jq -e 'type == "array" and lengt
                 done <<< "$DEPENDENCY_PATHS"
             fi
             if [ -z "$mount_root" ]; then
-                echo "Error: playground_file_mounts dependency not found: $mount_dependency" >&2
+                echo "Error: wp_codebox_file_mounts dependency not found: $mount_dependency" >&2
                 FAILED_STEP="WP Codebox file mount setup"
                 exit 1
             fi
@@ -349,12 +346,12 @@ if printf '%s' "$PLAYGROUND_FILE_MOUNTS_JSON" | jq -e 'type == "array" and lengt
 
         mount_host="${mount_root}/${mount_from}"
         if [ ! -f "$mount_host" ]; then
-            echo "Error: playground_file_mounts source file not found: $mount_host" >&2
+            echo "Error: wp_codebox_file_mounts source file not found: $mount_host" >&2
             FAILED_STEP="WP Codebox file mount setup"
             exit 1
         fi
         homeboy_wp_codebox_add_recipe_mount "${mount_host}" "${mount_to}"
-    done < <(printf '%s' "$PLAYGROUND_FILE_MOUNTS_JSON" | jq -c '.[]')
+    done < <(printf '%s' "$WP_CODEBOX_FILE_MOUNTS_JSON" | jq -c '.[]')
 fi
 
 EXTENSION_VENDOR_PATH="$(homeboy_wp_codebox_resolve_mount_path "${EXTENSION_PATH}/vendor")"
@@ -362,15 +359,15 @@ homeboy_wp_codebox_add_recipe_mount "${EXTENSION_VENDOR_PATH}" "/wp-codebox-vend
 EXTENSION_MOUNT_PATH="$(homeboy_wp_codebox_resolve_mount_path "${EXTENSION_PATH}")"
 homeboy_wp_codebox_add_recipe_mount "${EXTENSION_MOUNT_PATH}" "/homeboy-extension" "readonly"
 
-PLAYGROUND_DEP_MOUNTS=""
+WP_CODEBOX_DEP_MOUNTS=""
 if [ -n "$DEPENDENCY_PATHS" ]; then
     while IFS= read -r dep_path; do
         [ -z "$dep_path" ] && continue
         dep_slug="$(homeboy_get_validation_dependency_slug "$dep_path" || basename "$dep_path")"
-        if [ -n "$PLAYGROUND_DEP_MOUNTS" ]; then
-            PLAYGROUND_DEP_MOUNTS+="\\n"
+        if [ -n "$WP_CODEBOX_DEP_MOUNTS" ]; then
+            WP_CODEBOX_DEP_MOUNTS+="\\n"
         fi
-        PLAYGROUND_DEP_MOUNTS+="/wordpress/wp-content/plugins/${dep_slug}"
+        WP_CODEBOX_DEP_MOUNTS+="/wordpress/wp-content/plugins/${dep_slug}"
     done <<< "$DEPENDENCY_PATHS"
 fi
 
@@ -387,12 +384,12 @@ fi
 
 echo "Running PHPUnit tests via WP Codebox..."
 echo "  Plugin: ${PLUGIN_SLUG} (${PLUGIN_PATH})"
-echo "  Backend: wp-codebox (WordPress Playground runtime)"
+echo "  Backend: wp-codebox"
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "  Mounts: ${MOUNTS_JSON}"
-    echo "  WordPress version: ${PLAYGROUND_WORDPRESS_VERSION}"
-    echo "  Multisite: ${PLAYGROUND_MULTISITE:-0}"
+    echo "  WordPress version: ${WP_CODEBOX_WORDPRESS_VERSION}"
+    echo "  Multisite: ${WP_CODEBOX_MULTISITE:-0}"
     echo "  Artifacts: ${ARTIFACTS_DIR}"
 fi
 
@@ -407,15 +404,15 @@ case "$WP_CODEBOX_BIN" in
 esac
 
 jq -n \
-    --arg wp "$PLAYGROUND_WORDPRESS_VERSION" \
+    --arg wp "$WP_CODEBOX_WORDPRESS_VERSION" \
     --argjson mounts "$MOUNTS_JSON" \
     --arg pluginSlug "$PLUGIN_SLUG" \
     --arg selectedTestFile "$SELECTED_TEST_FILE_REL" \
     --arg changedTestsJson "$CHANGED_TEST_FILES_JSON" \
     --arg envJson "$BENCH_ENV_JSON" \
     --arg definesJson "$WP_CONFIG_DEFINES_JSON" \
-    --arg dependencyMounts "$PLAYGROUND_DEP_MOUNTS" \
-    --arg multisite "$PLAYGROUND_MULTISITE" \
+    --arg dependencyMounts "$WP_CODEBOX_DEP_MOUNTS" \
+    --arg multisite "$WP_CODEBOX_MULTISITE" \
     '{
         schema: "wp-codebox/workspace-recipe/v1",
         runtime: {wp: $wp, blueprint: {steps: []}},

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -159,7 +159,7 @@ if [ -n "$TARGET_FILE" ]; then
 fi
 
 case "$TEST_BACKEND" in
-    host|host-smoke)
+    host-smoke)
         exec bash "$HOST_SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
         ;;
     ""|wp-codebox)
@@ -167,7 +167,7 @@ case "$TEST_BACKEND" in
         ;;
     *)
         echo "ERROR: Unsupported WordPress test backend: ${TEST_BACKEND}" >&2
-        echo "Supported backends: wp-codebox, host, host-smoke" >&2
+        echo "Supported backends: wp-codebox, host-smoke" >&2
         exit 2
         ;;
 esac

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -130,10 +130,10 @@ SETTINGS_JSON=$(jq -nc \
     --argjson wpConfig '{"WP_DEBUG":true,"CUSTOM_NUMBER":7}' \
     --argjson benchEnv '{"HOMEBOY_FLAG":"yes"}' \
     '{
-        playground_wordpress_version: "6.10",
+        wp_codebox_wordpress_version: "6.10",
         wp_config_defines: $wpConfig,
         bench_env: $benchEnv,
-        playground_file_mounts: [
+        wp_codebox_file_mounts: [
             {from: "config/component-extra.php", to: "/wordpress/wp-content/component-extra.php"},
             {from_dependency: "dep-plugin", from: "fixtures/dep-extra.php", to: "/wordpress/wp-content/dep-extra.php"}
         ]

--- a/wordpress/scripts/trace/trace-runner.sh
+++ b/wordpress/scripts/trace/trace-runner.sh
@@ -83,7 +83,7 @@ homeboy_wordpress_trace_wp_version() {
     local extracted=""
 
     if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
-        extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.playground_wordpress_version // .wp_codebox_wordpress_version // empty' 2>/dev/null || true)
+        extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_wordpress_version // empty' 2>/dev/null || true)
         [ -n "$extracted" ] && [ "$extracted" != "null" ] && version="$extracted"
     fi
 

--- a/wordpress/tests/fixtures/datamachine-agent-ci-driver/README.md
+++ b/wordpress/tests/fixtures/datamachine-agent-ci-driver/README.md
@@ -1,15 +1,15 @@
 # Data Machine Agent CI Driver fixture
 
-Generic Playground plugin scaffold consumed by Data Machine agent CI runs.
+Generic WP Codebox plugin scaffold consumed by Data Machine agent CI runs.
 
 ## Why
 
-Data Machine agent CI workflows need a stable plugin path inside Playground
+Data Machine agent CI workflows need a stable plugin path inside WP Codebox
 to host workloads, bundle copies, and transcript artifacts. Without a fixture
 each consumer ships its own near-identical `<repo>-ci-driver.php`.
 
 This fixture removes that duplication. Consumers mount it via the agent
-runner's `playground_file_mounts` mechanism and reference its plugin path
+runner's `wp_codebox_mounts` mechanism and reference its plugin path
 in their workload `run` entries and `transcript_dir` config.
 
 ## How consumers use it
@@ -18,15 +18,11 @@ In the agent runner config JSON:
 
 ```json
 {
-  "playground_file_mounts": [
-    {
-      "from_dependency": "homeboy-extensions",
-      "from": "wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php",
-      "to": "/wordpress/wp-content/plugins/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php"
-    }
+  "wp_codebox_mounts": [
+    "/host/path/homeboy-extensions/wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php:/wordpress/wp-content/plugins/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php:readonly"
   ],
   "transcript_dir": "/wordpress/wp-content/plugins/datamachine-agent-ci-driver/artifacts/<agent-slug>",
-  "playground_workloads": [
+  "wp_codebox_workloads": [
     {
       "id": "<scenario-id>",
       "label": "<human label>",
@@ -38,9 +34,8 @@ In the agent runner config JSON:
 }
 ```
 
-The runner already supports `playground_file_mounts` and `from_dependency`
-resolution against the homeboy-extensions checkout, so no new runner
-behavior is required to use this fixture.
+The reusable workflow mounts this fixture by default, so no new runner behavior
+is required to use it.
 
 ## What it does NOT do
 

--- a/wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php
+++ b/wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php
@@ -17,7 +17,7 @@
  *   /wordpress/wp-content/plugins/datamachine-agent-ci-driver/
  *
  * The Homeboy Data Machine agent runner (run-datamachine-agent.sh) mounts
- * this file into the Playground via playground_file_mounts so consumers do
+ * this file into WP Codebox via wp_codebox_mounts so consumers do
  * not have to ship their own CI driver plugin.
  */
 

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -908,7 +908,7 @@
       "label": "Test backend",
       "type": "string",
       "default": "wp-codebox",
-      "description": "WordPress test backend. Use 'wp-codebox' for default PHPUnit execution, or 'host-smoke' / 'host' for standalone tests/**/*-smoke.php scripts that run under host PHP without WordPress bootstrap."
+      "description": "WordPress test backend. Use 'wp-codebox' for default PHPUnit execution, or 'host-smoke' for standalone tests/**/*-smoke.php scripts that run under host PHP without WordPress bootstrap."
     },
     {
       "id": "validation_dependencies",
@@ -946,32 +946,25 @@
       "description": "How the WP Codebox PHPUnit backend treats successful WordPress install/activation when discovery finds zero PHPUnit files. Use 'skipped' for components that intentionally test through smoke scripts, or 'failed' when the component expects PHPUnit coverage. Components with phpunit.xml(.dist) still fail on zero discovery."
     },
     {
-      "id": "playground_blueprint",
-      "label": "Playground blueprint",
+      "id": "wp_codebox_blueprint",
+      "label": "WP Codebox blueprint",
       "type": "object",
       "default": {},
       "description": "Runtime blueprint merged into the generated WP Codebox bench recipe. Empty object means stock WordPress."
     },
     {
-      "id": "playground_workloads",
+      "id": "wp_codebox_workloads",
       "label": "Bench workloads",
       "type": "array",
       "default": [],
       "description": "Config-declared WordPress bench workloads passed to wordpress.bench through the generated WP Codebox recipe after dependency mounts and component load. Each workload declares an id, optional label, run steps ({type: 'php', code|file}, {type: 'ability', ability|name, input}, or {type: 'wp-cli', command}), and optional metrics/artifacts/metadata. Step returns use the same {metrics, artifacts, metadata} shape as Node.js bench workloads."
     },
     {
-      "id": "playground_scenario_manifests",
-      "label": "Playground scenario manifests",
+      "id": "wp_codebox_scenario_manifests",
+      "label": "WP Codebox scenario manifests",
       "type": "array",
       "default": [],
       "description": "Scenario manifest files or inline objects compiled into wordpress.bench workloads in the generated WP Codebox recipe. Prompt, blueprint, grader, verifier hooks, rules, tags, limits, policy metadata, and metadata are preserved in BenchResults metadata."
-    },
-    {
-      "id": "bench_site_mode",
-      "label": "Bench site mode",
-      "type": "string",
-      "default": "fresh",
-      "description": "WordPress bench boot shape. 'fresh' uses the disposable WP Codebox runtime. 'installed' currently fails fast until a WP Codebox persisted-site contract lands."
     },
     {
       "id": "bench_browser_target",
@@ -981,18 +974,11 @@
       "description": "Optional browser bench target descriptor. Set {\"enabled\": true} to write HOMEBOY_BENCH_SHARED_STATE/browser-target.json. Include baseUrl/adminUrl for an already-running site; otherwise the file is metadata-only because the WP Codebox bench command exits after workloads complete. Login supports method plus username/password or password_env; raw target files are handoff artifacts and must not be published in reports."
     },
     {
-      "id": "playground_wordpress_version",
+      "id": "wp_codebox_wordpress_version",
       "label": "WordPress runtime version",
       "type": "string",
       "default": "",
       "description": "Optional WordPress core version passed to WP Codebox test and bench runners. Leave empty for the runner default. Use this when a component needs classes or behavior from a newer WordPress core build."
-    },
-    {
-      "id": "playground_wordpress_install_mode",
-      "label": "Playground WordPress install mode",
-      "type": "string",
-      "default": "",
-      "description": "Legacy direct-Playground pass-through retained only for config compatibility. The WP Codebox bench runner ignores this setting."
     }
   ],
   "actions": [


### PR DESCRIPTION
## Summary
- Removes legacy Playground-named WordPress runtime settings and environment aliases from the WP Codebox test, bench, trace, and agent runners.
- Keeps `host-smoke` as the explicit standalone non-WordPress PHP smoke backend while rejecting the old `host` alias.
- Updates docs, workflow inputs, fixture examples, and smokes to use `wp_codebox_*` settings and mounts.

Closes #936

## Testing
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh wordpress/scripts/bench/bench-runner-wp-codebox.sh wordpress/scripts/trace/trace-runner.sh wordpress/scripts/agent/run-datamachine-agent.sh wordpress/scripts/test/host-smoke-runner-smoke.sh wordpress/scripts/test/test-runner-file-routing-smoke.sh wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh wordpress/scripts/agent/build-replay-bundle-smoke.sh`
- `node --check wordpress/scripts/agent/build-replay-bundle.js`
- `jq empty wordpress/wordpress.json`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' .github/workflows/datamachine-agent-ci.yml`
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `bash wordpress/scripts/test/host-smoke-runner-smoke.sh`
- `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `bash wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `bash wordpress/scripts/agent/build-replay-bundle-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the cleanup patch, updated related smoke tests/docs, and ran focused verification; Chris remains responsible for review and merge.