### PR TITLE
Share browser result shapes

### DIFF
--- a/docs/browser-result-shapes.md
+++ b/docs/browser-result-shapes.md
@@ -1,0 +1,51 @@
+# Browser Result Shapes
+
+Homeboy extensions share a small product-neutral vocabulary for browser,
+profile, and trace results in `scripts/lib/browser-result-shapes.cjs` and
+`scripts/lib/browser-result-shapes.mjs`.
+
+These helpers describe transportable shapes only. Product semantics stay in the
+extension that owns them. For example, WordPress REST route normalization,
+preload attribution, and route grouping remain in `wordpress`.
+
+## Shared Helpers
+
+- `normalizeBrowserPerformanceProfile(profile)` returns a stable profile
+  envelope with `schema_version`, `page_url`, `summary`, timing arrays,
+  `phase_marks`, and computed `phases`.
+- `normalizeBrowserProfileTimings(profile, { normalizeUrl })` adapts a profile's
+  `resources` plus `network` rows into timing rows suitable for correlation.
+- `normalizeBrowserTiming(entry, { normalizeUrl })` adapts loose resource or
+  network rows to `{ url, normalizedUrl, method, status, startTime, ttfbMs,
+  durationMs, initiatorType, phase, raw }`.
+- `normalizeBrowserArtifact(artifact)` returns stable artifact metadata with
+  `path`, optional `kind`, and optional `label`.
+- `normalizeBrowserBottleneck(row)` returns stable bottleneck rows with `kind`,
+  `phase`, `message`, and optional `data`.
+- `normalizeTraceEvent()`, `normalizeTraceAssertion()`, and
+  `normalizeTraceEnvelope()` describe generic trace timelines and assertions.
+
+## Shape Boundary
+
+Shared browser result shapes are intentionally narrow:
+
+- **Network request rows** capture URL, method, resource type, status, failure,
+  start time, and duration.
+- **Resource timing rows** preserve browser timing fields and become correlation
+  rows through `normalizeBrowserTiming()`.
+- **Timeline phases** are phase marks plus computed phase windows.
+- **Artifacts** describe where evidence lives and what broad kind it is.
+- **Bottlenecks** describe generic report rows without product-specific meaning.
+
+Callers pass their own `normalizeUrl` when URL semantics matter. WordPress uses
+that hook to preserve its existing REST/cache-busting behavior without moving
+route semantics into shared code.
+
+## Current Consumers
+
+- `nodejs/scripts/bench/browser-helper.mjs` emits browser profile, artifact, and
+  bottleneck shapes through the shared helpers.
+- `nodejs/scripts/trace/lib/timeline.mjs` emits trace events, assertions,
+  artifacts, and envelopes through the shared helpers.
+- `wordpress/lib/timing-correlator.js` adapts browser profiles through the shared
+  timing helpers while keeping WordPress-specific URL normalization local.

--- a/nodejs/docs/browser-bench-helpers.md
+++ b/nodejs/docs/browser-bench-helpers.md
@@ -28,6 +28,9 @@ without changing that API. It opens the target page, runs workload actions,
 checks page and artifact assertions, writes a stable raw result artifact, and
 returns `{ metrics, artifacts }` for the Homeboy bench runner.
 
+Browser profile, artifact, and bottleneck result rows use the shared
+product-neutral shapes documented in `../../docs/browser-result-shapes.md`.
+
 The helper is substrate-agnostic. Assertions describe generic browser/page
 facts such as status, selectors, text, title, and artifact presence. Workloads
 can provide `sanitizeArtifacts()` or `sanitizeRawResult()` hooks to redact or

--- a/nodejs/docs/trace-helpers.md
+++ b/nodejs/docs/trace-helpers.md
@@ -17,7 +17,8 @@ const { pollHttp } = await import(`${helperDir}/probes.mjs`);
   the final Homeboy trace JSON envelope. `TraceRecorder#recordCheck()` maps a
   boolean check to a pass/fail assertion, and `TraceRecorder#writeArtifact()`
   writes an artifact under `HOMEBOY_TRACE_ARTIFACT_DIR` while registering it in
-  the result envelope.
+  the result envelope. Timeline, assertion, artifact, and envelope rows use the
+  shared product-neutral shapes documented in `../../docs/browser-result-shapes.md`.
 - `process.mjs` launches black-box commands, captures a best-effort process
   tree artifact on macOS/Linux, waits for exits, and cleans up spawned process
   groups on process exit/signals.

--- a/nodejs/scripts/bench/browser-helper.mjs
+++ b/nodejs/scripts/bench/browser-helper.mjs
@@ -3,6 +3,12 @@ import { createRequire } from 'node:module';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { performance } from 'node:perf_hooks';
+import {
+    collectBrowserPhases,
+    normalizeBrowserArtifact,
+    normalizeBrowserBottleneck,
+    normalizeBrowserPerformanceProfile,
+} from '../../../scripts/lib/browser-result-shapes.mjs';
 
 const DEFAULT_NETWORK_IDLE_TIMEOUT_MS = 5000;
 const BROWSER_PERFORMANCE_STATE = new WeakMap();
@@ -192,7 +198,7 @@ export async function collectBrowserPerformanceProfile(page, options = {}) {
         ...state.phaseMarks.filter((mark) => !browserPhaseNames.has(mark.name)),
     ].sort(comparePhaseMarks);
 
-    return stableJson({
+    return normalizeBrowserPerformanceProfile({
         schema_version: 1,
         page_url: browserEntries.url || '',
         summary: summarizeBrowserProfile({ navigation, resources, network: state.network, browserEntries, state }),
@@ -206,7 +212,7 @@ export async function collectBrowserPerformanceProfile(page, options = {}) {
         layout_shifts: browserEntries.layout_shifts.map(normalizeLayoutShiftEntry).sort(compareByNameThenStart),
         long_tasks: browserEntries.long_tasks.map(normalizeLongTaskEntry).sort(compareByNameThenStart),
         phase_marks: phaseMarks,
-        phases: collectPhases(phaseMarks),
+        phases: collectBrowserPhases(phaseMarks),
     });
 }
 
@@ -466,11 +472,11 @@ export async function runBrowserBench(options) {
             const interactionEvidence = await runBrowserActions(page, config.actions, { ...actionFailureOptions, ...config.actionOptions });
             metrics.browser_interaction_count = interactionEvidence.actions.length;
             metrics.browser_interaction_duration_ms = interactionEvidence.duration_ms;
-            artifacts.interactions = {
+            artifacts.interactions = normalizeBrowserArtifact({
                 path: join(config.artifactsDir, `${config.id}-interactions.json`),
                 kind: 'browser-interactions',
                 label: 'Browser interaction evidence',
-            };
+            });
             await writeJson(artifacts.interactions.path, interactionEvidence);
         }
 
@@ -484,63 +490,63 @@ export async function runBrowserBench(options) {
         const performanceProfile = await performanceController.collect();
         const profilePath = join(config.artifactsDir, `${config.id}-browser-profile.json`);
         await writeJson(profilePath, performanceProfile);
-        artifacts.browserProfile = {
+        artifacts.browserProfile = normalizeBrowserArtifact({
             path: profilePath,
             kind: 'browser-performance-profile',
             label: 'Browser performance profile',
-        };
+        });
 
         const traceSummary = summarizeBrowserPerformanceProfile(performanceProfile);
         Object.assign(metrics, collectBrowserSummaryMetrics(traceSummary));
         const traceSummaryPath = join(config.artifactsDir, `${config.id}-trace-summary.json`);
         await writeJson(traceSummaryPath, traceSummary);
-        artifacts.traceSummary = {
+        artifacts.traceSummary = normalizeBrowserArtifact({
             path: traceSummaryPath,
             kind: 'browser-trace-summary',
             label: 'Browser trace bottleneck summary',
-        };
+        });
 
         const traceSummaryMarkdownPath = join(config.artifactsDir, `${config.id}-trace-summary.md`);
         await writeFile(traceSummaryMarkdownPath, formatBrowserPerformanceSummaryMarkdown(traceSummary, { title: `${config.id} browser trace bottlenecks` }));
-        artifacts.traceSummaryMarkdown = {
+        artifacts.traceSummaryMarkdown = normalizeBrowserArtifact({
             path: traceSummaryMarkdownPath,
             kind: 'browser-trace-summary-markdown',
             label: 'Browser trace bottleneck summary markdown',
-        };
+        });
 
         if (config.screenshot) {
             const screenshotPath = join(config.artifactsDir, `${config.id}-screenshot.png`);
             await page.screenshot({ path: screenshotPath, fullPage: true });
-            artifacts.screenshot = {
+            artifacts.screenshot = normalizeBrowserArtifact({
                 path: screenshotPath,
                 kind: 'screenshot',
                 label: 'Final screenshot',
-            };
+            });
         }
 
         const networkPath = join(config.artifactsDir, `${config.id}-network.json`);
         await writeJson(networkPath, network);
-        artifacts.network = {
+        artifacts.network = normalizeBrowserArtifact({
             path: networkPath,
             kind: 'network-log',
             label: 'Network log',
-        };
+        });
 
         const consolePath = join(config.artifactsDir, `${config.id}-console.json`);
         await writeJson(consolePath, consoleMessages);
-        artifacts.console = {
+        artifacts.console = normalizeBrowserArtifact({
             path: consolePath,
             kind: 'console-log',
             label: 'Console log',
-        };
+        });
 
         if (config.trace) {
             await context.tracing.stop({ path: tracePath });
-            artifacts.trace = {
+            artifacts.trace = normalizeBrowserArtifact({
                 path: tracePath,
                 kind: 'playwright-trace',
                 label: 'Playwright trace',
-            };
+            });
         }
     } catch (error) {
         if (page && typeof page.screenshot === 'function') {
@@ -605,11 +611,11 @@ export async function runBrowserPageScenario(options) {
     await writeJson(rawResultPath, config.sanitizeRawResult ? await config.sanitizeRawResult(rawResult) : rawResult);
     artifacts = stableJson({
         ...artifacts,
-        rawResult: {
+        rawResult: normalizeBrowserArtifact({
             path: rawResultPath,
             kind: 'browser-page-scenario-result',
             label: 'Browser page scenario raw result',
-        },
+        }),
     });
 
     if (config.sanitizeArtifacts) {
@@ -1139,7 +1145,7 @@ function normalizeTraceSummaryOptions(options) {
 }
 
 function bottleneck(kind, phase, message, data) {
-    return stableJson({ kind, phase: phase || 'all', message, data });
+    return normalizeBrowserBottleneck({ kind, phase: phase || 'all', message, data });
 }
 
 function summarizeTransferFamilies(resources, maxItems) {
@@ -1491,20 +1497,6 @@ function summarizeBrowserProfile({ navigation, resources, network, browserEntrie
         console_message_count: state.consoleMessages.length,
         page_error_count: state.pageErrors.length,
     });
-}
-
-function collectPhases(phaseMarks) {
-    const phases = {};
-    for (let i = 0; i < phaseMarks.length; i++) {
-        const current = phaseMarks[i];
-        const next = phaseMarks[i + 1];
-        phases[current.name] = {
-            start_time_ms: current.start_time_ms,
-            end_time_ms: next ? next.start_time_ms : null,
-            duration_ms: next ? Math.max(0, roundNumber(next.start_time_ms - current.start_time_ms)) : 0,
-        };
-    }
-    return stableJson(phases);
 }
 
 function profileComparisonMetrics(profile) {

--- a/nodejs/scripts/trace/lib/timeline.mjs
+++ b/nodejs/scripts/trace/lib/timeline.mjs
@@ -2,9 +2,12 @@ import { mkdir, appendFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { artifactPath, artifactRelativePath, writeArtifact as writeArtifactFile } from './artifacts.mjs';
-
-const VALID_ASSERTION_STATUSES = new Set(['pass', 'fail', 'skip', 'unknown']);
-const VALID_ENVELOPE_STATUSES = new Set(['pass', 'fail', 'error', 'skip', 'unknown']);
+import {
+    normalizeBrowserArtifact,
+    normalizeTraceAssertion,
+    normalizeTraceEnvelope,
+    normalizeTraceEvent,
+} from '../../../../scripts/lib/browser-result-shapes.mjs';
 
 export class TraceRecorder {
     constructor(options = {}) {
@@ -23,12 +26,7 @@ export class TraceRecorder {
     }
 
     async recordEvent(source, event, data = {}) {
-        const entry = {
-            t_ms: this.timestampMs(),
-            source: source || 'scenario',
-            event,
-            data: data && typeof data === 'object' && !Array.isArray(data) ? data : { value: data },
-        };
+        const entry = normalizeTraceEvent(source || 'scenario', event, data, this.timestampMs());
 
         this.timeline.push(entry);
         await mkdir(dirname(this.timelinePath), { recursive: true });
@@ -38,9 +36,7 @@ export class TraceRecorder {
     }
 
     recordAssertion(id, status, message, data = undefined) {
-        const normalizedStatus = VALID_ASSERTION_STATUSES.has(status) ? status : 'unknown';
-        const assertion = { id, status: normalizedStatus, message };
-        if (data !== undefined) assertion.data = data;
+        const assertion = normalizeTraceAssertion(id, status, message, data);
         this.assertions.push(assertion);
         return assertion;
     }
@@ -50,8 +46,7 @@ export class TraceRecorder {
     }
 
     addArtifact(label, path, kind = undefined) {
-        const artifact = { label, path: artifactRelativePath(path) };
-        if (kind) artifact.kind = kind;
+        const artifact = normalizeBrowserArtifact({ label, path: artifactRelativePath(path), kind });
 
         if (!this.artifacts.some((existing) => existing.label === artifact.label && existing.path === artifact.path)) {
             this.artifacts.push(artifact);
@@ -70,8 +65,8 @@ export class TraceRecorder {
             throw new Error('HOMEBOY_TRACE_RESULTS_FILE is required to write trace results');
         }
 
-        const status = VALID_ENVELOPE_STATUSES.has(options.status) ? options.status : deriveStatus(this.assertions);
-        const envelope = {
+        const status = options.status || deriveStatus(this.assertions);
+        const envelope = normalizeTraceEnvelope({
             component_id: this.componentId,
             scenario_id: this.scenarioId,
             status,
@@ -79,9 +74,8 @@ export class TraceRecorder {
             timeline: this.timeline,
             assertions: this.assertions,
             artifacts: this.artifacts,
-        };
-
-        if (options.failure) envelope.failure = options.failure;
+            failure: options.failure,
+        });
 
         await mkdir(dirname(this.resultsFile), { recursive: true });
         await writeFile(this.resultsFile, JSON.stringify(envelope, null, 2));

--- a/nodejs/scripts/trace/trace-runner.sh
+++ b/nodejs/scripts/trace/trace-runner.sh
@@ -18,18 +18,18 @@ set -euo pipefail
 #   HOMEBOY_RUN_DIR               — run-scoped working directory
 #   HOMEBOY_DEBUG                 — verbose output
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${SCRIPT_DIR}/../lib/bash-preflight.sh}"
+TRACE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${TRACE_SCRIPT_DIR}/../lib/bash-preflight.sh}"
 # shellcheck source=/dev/null
 source "$BASH_PREFLIGHT_HELPER"
 homeboy_require_bash_version 4
 
-RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${TRACE_SCRIPT_DIR}/../lib/resolve-context.sh}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
 # shellcheck source=../lib/node-helpers.sh
-source "${SCRIPT_DIR}/../lib/node-helpers.sh"
+source "${TRACE_SCRIPT_DIR}/../lib/node-helpers.sh"
 homeboy_require_package_json
 homeboy_detect_package_manager
 
@@ -44,8 +44,8 @@ export HOMEBOY_TRACE_ARTIFACT_DIR="$ARTIFACT_DIR"
 export HOMEBOY_RUN_DIR="$RUN_DIR"
 export HOMEBOY_COMPONENT_ID="$COMPONENT_ID"
 export HOMEBOY_COMPONENT_PATH="$PROJECT_PATH"
-export HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER="${HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER:-${SCRIPT_DIR}/../runtime/invocation-runtime.mjs}"
-export HOMEBOY_TRACE_HELPER_DIR="${SCRIPT_DIR}/lib"
+export HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER="${HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER:-${TRACE_SCRIPT_DIR}/../runtime/invocation-runtime.mjs}"
+export HOMEBOY_TRACE_HELPER_DIR="${TRACE_SCRIPT_DIR}/lib"
 
 mkdir -p "$(dirname "$RESULTS_FILE")" "$RUN_DIR" "$ARTIFACT_DIR"
 

--- a/scripts/browser-result-shapes-smoke.sh
+++ b/scripts/browser-result-shapes-smoke.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+node - <<'EOF' "$SCRIPT_DIR/lib/browser-result-shapes.cjs"
+const assert = require('node:assert/strict');
+const shapes = require(process.argv[2]);
+
+const profile = shapes.normalizeBrowserPerformanceProfile({
+  page_url: 'https://example.test/app',
+  network: [{ url: 'https://example.test/app.js', method: 'get', status: 200, start_time_ms: 1.2345, duration_ms: 5.6789 }],
+  phase_marks: [{ name: 'load', start_time_ms: 0 }, { name: 'ready', start_time_ms: 20 }],
+  summary: { network_request_count: 1 },
+});
+assert.equal(profile.schema_version, 1);
+assert.equal(profile.network[0].url, 'https://example.test/app.js');
+assert.equal(profile.phases.load.duration_ms, 20);
+
+const timing = shapes.normalizeBrowserTiming({
+  name: 'https://example.test/wp-json/demo?_wpnonce=secret',
+  method: 'post',
+  startTime: 10,
+  responseStart: 30,
+  responseEnd: 50,
+}, {
+  normalizeUrl: (url) => new URL(url).pathname,
+});
+assert.equal(timing.normalizedUrl, '/wp-json/demo');
+assert.equal(timing.method, 'POST');
+assert.equal(timing.ttfbMs, 20);
+assert.equal(timing.durationMs, 40);
+
+const rows = shapes.normalizeBrowserProfileTimings({
+  resources: [{ name: 'https://example.test/app.js', startTime: 5, responseStart: 8, responseEnd: 12 }],
+  network: [{ url: 'https://example.test/app.js', method: 'GET', duration_ms: 9 }],
+  phases: { load: { start_time_ms: 0, end_time_ms: 10 } },
+}, {
+  normalizeUrl: (url) => new URL(url).pathname,
+});
+assert.equal(rows.length, 1);
+assert.equal(rows[0].phase, 'load');
+
+const assertion = shapes.normalizeTraceAssertion('ready', 'pass', 'ready observed', { port: 8881 });
+assert.deepEqual(assertion, { data: { port: 8881 }, id: 'ready', message: 'ready observed', status: 'pass' });
+
+const envelope = shapes.normalizeTraceEnvelope({
+  component_id: 'nodejs',
+  scenario_id: 'browser',
+  status: 'pass',
+  summary: 'ok',
+  artifacts: [{ label: 'profile', path: 'profile.json', kind: 'browser-performance-profile' }],
+});
+assert.equal(envelope.artifacts[0].kind, 'browser-performance-profile');
+
+console.log('Shared browser result shapes CommonJS smoke passed.');
+EOF
+
+node --input-type=module - <<'EOF' "$SCRIPT_DIR/lib/browser-result-shapes.mjs"
+import assert from 'node:assert/strict';
+
+const shapes = await import(process.argv[2]);
+const artifact = shapes.normalizeBrowserArtifact({ path: 'trace.zip', kind: 'playwright-trace', label: 'Trace' });
+assert.deepEqual(artifact, { kind: 'playwright-trace', label: 'Trace', path: 'trace.zip' });
+
+const bottleneck = shapes.normalizeBrowserBottleneck({ kind: 'network', phase: 'load', message: 'slow request', data: { duration_ms: 25 } });
+assert.equal(bottleneck.kind, 'network');
+assert.equal(bottleneck.data.duration_ms, 25);
+
+console.log('Shared browser result shapes ESM smoke passed.');
+EOF

--- a/scripts/lib/browser-result-shapes.cjs
+++ b/scripts/lib/browser-result-shapes.cjs
@@ -1,0 +1,372 @@
+'use strict';
+
+const BROWSER_RESULT_SCHEMA_VERSION = 1;
+
+const VALID_TRACE_ASSERTION_STATUSES = new Set(['pass', 'fail', 'skip', 'unknown']);
+const VALID_TRACE_ENVELOPE_STATUSES = new Set(['pass', 'fail', 'error', 'skip', 'unknown']);
+
+function normalizeBrowserArtifact(artifact, defaults = {}) {
+	const source = artifact && typeof artifact === 'object' && !Array.isArray(artifact) ? artifact : {};
+	const normalized = {
+		path: stringValue(source.path ?? source.relativePath ?? defaults.path),
+	};
+	const kind = stringValue(source.kind ?? defaults.kind);
+	const label = stringValue(source.label ?? defaults.label);
+	if (kind) normalized.kind = kind;
+	if (label) normalized.label = label;
+	return stableJson(normalized);
+}
+
+function normalizeBrowserNetworkRequest(entry) {
+	const source = entry && typeof entry === 'object' && !Array.isArray(entry) ? entry : {};
+	return stableJson({
+		url: stringValue(source.url ?? source.name),
+		method: stringValue(source.method ?? source.request_method ?? source.requestMethod).toUpperCase(),
+		resource_type: stringValue(source.resource_type ?? source.resourceType ?? source.initiator_type ?? source.initiatorType),
+		status: finiteOrNull(source.status ?? source.statusCode ?? source.status_code ?? source.http_status),
+		failed: Boolean(source.failed),
+		start_time_ms: finiteOrNull(source.start_time_ms ?? source.startTime ?? source.start_ms ?? source.startMs),
+		duration_ms: finiteOrNull(source.duration_ms ?? source.durationMs ?? source.duration),
+		failure_text: stringValue(source.failure_text ?? source.failureText) || undefined,
+	});
+}
+
+function normalizeBrowserPhaseMark(mark) {
+	const source = mark && typeof mark === 'object' && !Array.isArray(mark) ? mark : {};
+	return stableJson({
+		name: sanitizePhaseName(source.name ?? source.phase ?? source.label),
+		start_time_ms: finiteNumber(source.start_time_ms ?? source.startTime ?? source.start_ms ?? source.startMs),
+	});
+}
+
+function collectBrowserPhases(phaseMarks) {
+	const marks = Array.isArray(phaseMarks)
+		? phaseMarks.map(normalizeBrowserPhaseMark).filter((mark) => mark.name).sort(comparePhaseMarks)
+		: [];
+	const phases = {};
+	for (let index = 0; index < marks.length; index += 1) {
+		const current = marks[index];
+		const next = marks[index + 1];
+		phases[current.name] = {
+			start_time_ms: current.start_time_ms,
+			end_time_ms: next ? next.start_time_ms : null,
+			duration_ms: next ? Math.max(0, roundNumber(next.start_time_ms - current.start_time_ms)) : 0,
+		};
+	}
+	return stableJson(phases);
+}
+
+function normalizeBrowserBottleneck(row) {
+	const source = row && typeof row === 'object' && !Array.isArray(row) ? row : {};
+	const normalized = {
+		kind: stringValue(source.kind) || 'unknown',
+		phase: stringValue(source.phase) || 'all',
+		message: stringValue(source.message),
+	};
+	if (source.data !== undefined) normalized.data = source.data;
+	return stableJson(normalized);
+}
+
+function normalizeBrowserPerformanceProfile(profile) {
+	const source = profile && typeof profile === 'object' && !Array.isArray(profile) ? profile : {};
+	const phaseMarks = Array.isArray(source.phase_marks) ? source.phase_marks.map(normalizeBrowserPhaseMark).filter((mark) => mark.name).sort(comparePhaseMarks) : [];
+	const phases = normalizePhaseMap(source.phases, phaseMarks);
+	return stableJson({
+		schema_version: finiteNumber(source.schema_version) || BROWSER_RESULT_SCHEMA_VERSION,
+		page_url: stringValue(source.page_url ?? source.url),
+		summary: source.summary && typeof source.summary === 'object' && !Array.isArray(source.summary) ? stableJson(source.summary) : {},
+		navigation: Array.isArray(source.navigation) ? source.navigation.map(stableJson) : [],
+		resources: Array.isArray(source.resources) ? source.resources.map(stableJson) : [],
+		network: Array.isArray(source.network) ? source.network.map(stableJson) : [],
+		console_messages: Array.isArray(source.console_messages) ? source.console_messages.map(stableJson) : [],
+		page_errors: Array.isArray(source.page_errors) ? source.page_errors.map(stableJson) : [],
+		paints: Array.isArray(source.paints) ? source.paints.map(stableJson) : [],
+		largest_contentful_paint: Array.isArray(source.largest_contentful_paint) ? source.largest_contentful_paint.map(stableJson) : [],
+		layout_shifts: Array.isArray(source.layout_shifts) ? source.layout_shifts.map(stableJson) : [],
+		long_tasks: Array.isArray(source.long_tasks) ? source.long_tasks.map(stableJson) : [],
+		phase_marks: phaseMarks,
+		phases,
+	});
+}
+
+function normalizeBrowserTiming(entry, options = {}) {
+	if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+		return null;
+	}
+
+	const rawUrl = pickFirstString(entry, ['name', 'url', 'request_url', 'requestUrl']);
+	if (!rawUrl) {
+		return null;
+	}
+
+	const normalizeUrl = typeof options.normalizeUrl === 'function' ? options.normalizeUrl : defaultNormalizeUrl;
+	const startTime = pickFirstNumber(entry, ['startTime', 'fetchStart', 'requestStart', 'start_time_ms', 'start_ms', 'startMs']);
+	const responseStart = pickFirstNumber(entry, ['responseStart', 'ttfb_ms', 'ttfbMs', 'response_start']);
+	const responseEnd = pickFirstNumber(entry, ['responseEnd', 'response_end', 'endMs', 'end_ms', 'response_end_ms']);
+	const duration = pickFirstNumber(entry, ['duration', 'duration_ms', 'durationMs']);
+
+	let computedDuration = duration;
+	if (computedDuration === undefined && startTime !== undefined && responseEnd !== undefined) {
+		computedDuration = Math.max(0, responseEnd - startTime);
+	}
+
+	let computedTtfb;
+	if (responseStart !== undefined && startTime !== undefined) {
+		computedTtfb = Math.max(0, responseStart - startTime);
+	} else {
+		computedTtfb = pickFirstNumber(entry, ['ttfb', 'ttfb_ms', 'ttfbMs']);
+	}
+
+	const initiator = pickFirstString(entry, ['initiatorType', 'initiator_type', 'initiator', 'resourceType']);
+	const phase = pickFirstString(entry, ['phase', 'phase_label', 'phaseLabel']);
+	const method = pickFirstString(entry, ['method', 'request_method', 'requestMethod']);
+	const status = pickFirstNumber(entry, ['status', 'statusCode', 'status_code', 'http_status']);
+	const failed = pickFirstBoolean(entry, ['failed', 'error']);
+
+	return {
+		url: rawUrl,
+		normalizedUrl: normalizeUrl(rawUrl, options),
+		method: method ? method.toUpperCase() : undefined,
+		status: typeof status === 'number' ? status : undefined,
+		failed,
+		startTime: typeof startTime === 'number' ? startTime : undefined,
+		ttfbMs: typeof computedTtfb === 'number' ? computedTtfb : undefined,
+		durationMs: typeof computedDuration === 'number' ? computedDuration : undefined,
+		initiatorType: initiator,
+		phase,
+		raw: entry,
+	};
+}
+
+function normalizeBrowserProfileTimings(profile, options = {}) {
+	if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+		return [];
+	}
+
+	const normalizeUrl = typeof options.normalizeUrl === 'function' ? options.normalizeUrl : defaultNormalizeUrl;
+	const phases = normalizeProfilePhases(profile);
+	const resources = Array.isArray(profile.resources) ? profile.resources : [];
+	const network = Array.isArray(profile.network) ? profile.network : [];
+	const resourcesByUrl = new Map();
+
+	for (const resource of resources) {
+		const rawUrl = pickFirstString(resource, ['name', 'url']);
+		const normalizedUrl = normalizeUrl(rawUrl, options);
+		if (!normalizedUrl) continue;
+		if (!resourcesByUrl.has(normalizedUrl)) resourcesByUrl.set(normalizedUrl, []);
+		resourcesByUrl.get(normalizedUrl).push(resource);
+	}
+
+	const rows = [];
+	for (const entry of network) {
+		const rawUrl = pickFirstString(entry, ['url', 'name']);
+		const normalizedUrl = normalizeUrl(rawUrl, options);
+		const resource = normalizedUrl ? (resourcesByUrl.get(normalizedUrl) || []).shift() : undefined;
+		const startTime = pickFirstNumber(entry, ['start_time_ms', 'startTime', 'start_ms', 'startMs'])
+			?? pickFirstNumber(resource, ['startTime', 'fetchStart', 'requestStart']);
+		const phase = pickFirstString(entry, ['phase', 'phase_label', 'phaseLabel'])
+			|| pickFirstString(resource, ['phase', 'phase_label', 'phaseLabel'])
+			|| phaseForStartTime(phases, startTime);
+
+		rows.push({
+			...resource,
+			...entry,
+			name: rawUrl,
+			url: rawUrl,
+			startTime,
+			responseStart: pickFirstNumber(resource, ['responseStart']) ?? pickFirstNumber(entry, ['responseStart', 'ttfb_ms', 'ttfbMs']),
+			responseEnd: pickFirstNumber(resource, ['responseEnd']) ?? pickFirstNumber(entry, ['response_end_ms', 'responseEnd']),
+			durationMs: pickFirstNumber(entry, ['duration_ms', 'durationMs']) ?? pickFirstNumber(resource, ['duration', 'duration_ms', 'durationMs']),
+			phase,
+		});
+	}
+
+	for (const entries of resourcesByUrl.values()) {
+		for (const resource of entries) {
+			const startTime = pickFirstNumber(resource, ['startTime', 'fetchStart', 'requestStart']);
+			rows.push({
+				...resource,
+				phase: pickFirstString(resource, ['phase', 'phase_label', 'phaseLabel']) || phaseForStartTime(phases, startTime),
+			});
+		}
+	}
+
+	return rows;
+}
+
+function normalizeTraceEvent(source, event, data = {}, timestampMs = undefined) {
+	const entry = {
+		t_ms: finiteNumber(timestampMs),
+		source: stringValue(source) || 'scenario',
+		event: stringValue(event),
+		data: data && typeof data === 'object' && !Array.isArray(data) ? stableJson(data) : { value: data },
+	};
+	return stableJson(entry);
+}
+
+function normalizeTraceAssertion(id, status, message, data = undefined) {
+	const assertion = {
+		id: stringValue(id),
+		status: VALID_TRACE_ASSERTION_STATUSES.has(status) ? status : 'unknown',
+		message: stringValue(message),
+	};
+	if (data !== undefined) assertion.data = data;
+	return stableJson(assertion);
+}
+
+function normalizeTraceEnvelope(envelope) {
+	const source = envelope && typeof envelope === 'object' && !Array.isArray(envelope) ? envelope : {};
+	const normalized = {
+		component_id: stringValue(source.component_id ?? source.componentId) || 'unknown',
+		scenario_id: stringValue(source.scenario_id ?? source.scenarioId) || 'unknown',
+		status: VALID_TRACE_ENVELOPE_STATUSES.has(source.status) ? source.status : 'unknown',
+		summary: stringValue(source.summary),
+		timeline: Array.isArray(source.timeline) ? source.timeline.map((entry) => stableJson(entry)) : [],
+		assertions: Array.isArray(source.assertions) ? source.assertions.map((assertion) => stableJson(assertion)) : [],
+		artifacts: Array.isArray(source.artifacts) ? source.artifacts.map(normalizeBrowserArtifact) : [],
+	};
+	if (source.failure !== undefined) normalized.failure = source.failure;
+	return stableJson(normalized);
+}
+
+function normalizePhaseMap(phases, phaseMarks) {
+	if (!phases || typeof phases !== 'object' || Array.isArray(phases)) {
+		return collectBrowserPhases(phaseMarks);
+	}
+	const normalized = {};
+	for (const [name, phase] of Object.entries(phases).sort(([a], [b]) => a.localeCompare(b))) {
+		if (!phase || typeof phase !== 'object' || Array.isArray(phase)) continue;
+		normalized[sanitizePhaseName(name)] = {
+			start_time_ms: finiteNumber(phase.start_time_ms ?? phase.startTime ?? phase.start_ms ?? phase.startMs),
+			end_time_ms: finiteOrNull(phase.end_time_ms ?? phase.endTime ?? phase.end_ms ?? phase.endMs),
+			duration_ms: finiteNumber(phase.duration_ms ?? phase.durationMs ?? phase.duration),
+		};
+	}
+	return stableJson(normalized);
+}
+
+function normalizeProfilePhases(profile) {
+	const phases = [];
+	if (profile.phases && typeof profile.phases === 'object' && !Array.isArray(profile.phases)) {
+		for (const [name, phase] of Object.entries(profile.phases)) {
+			if (!phase || typeof phase !== 'object') continue;
+			const startMs = pickFirstNumber(phase, ['start_time_ms', 'startTime', 'start_ms', 'startMs']);
+			const endMs = pickFirstNumber(phase, ['end_time_ms', 'endTime', 'end_ms', 'endMs']);
+			if (startMs !== undefined) phases.push({ name, startMs, endMs });
+		}
+	} else if (Array.isArray(profile.phase_marks)) {
+		const marks = profile.phase_marks
+			.map((mark) => ({
+				name: pickFirstString(mark, ['name', 'phase', 'label']),
+				startMs: pickFirstNumber(mark, ['start_time_ms', 'startTime', 'start_ms', 'startMs']),
+			}))
+			.filter((mark) => mark.name && mark.startMs !== undefined)
+			.sort((a, b) => a.startMs - b.startMs);
+		for (let index = 0; index < marks.length; index += 1) {
+			phases.push({
+				name: marks[index].name,
+				startMs: marks[index].startMs,
+				endMs: marks[index + 1]?.startMs,
+			});
+		}
+	}
+	return phases.sort((a, b) => a.startMs - b.startMs);
+}
+
+function phaseForStartTime(phases, startTime) {
+	if (!Array.isArray(phases) || typeof startTime !== 'number') return undefined;
+	let matched;
+	for (const phase of phases) {
+		const endMs = typeof phase.endMs === 'number' ? phase.endMs : Infinity;
+		if (startTime >= phase.startMs && startTime < endMs) matched = phase.name;
+	}
+	return matched;
+}
+
+function defaultNormalizeUrl(url) {
+	if (typeof url !== 'string' || url.trim() === '') return '';
+	try {
+		const parsed = new URL(url.trim(), 'http://__homeboy_stub__');
+		return parsed.pathname + parsed.search;
+	} catch {
+		return url.trim();
+	}
+}
+
+function pickFirstNumber(source, keys) {
+	if (!source || typeof source !== 'object') return undefined;
+	for (const key of keys) {
+		const value = source[key];
+		if (typeof value === 'number' && Number.isFinite(value)) return value;
+	}
+	return undefined;
+}
+
+function pickFirstString(source, keys) {
+	if (!source || typeof source !== 'object') return undefined;
+	for (const key of keys) {
+		const value = source[key];
+		if (typeof value === 'string' && value.trim() !== '') return value.trim();
+	}
+	return undefined;
+}
+
+function pickFirstBoolean(source, keys) {
+	if (!source || typeof source !== 'object') return undefined;
+	for (const key of keys) {
+		const value = source[key];
+		if (typeof value === 'boolean') return value;
+	}
+	return undefined;
+}
+
+function finiteNumber(value) {
+	return typeof value === 'number' && Number.isFinite(value) ? roundNumber(value) : 0;
+}
+
+function finiteOrNull(value) {
+	return typeof value === 'number' && Number.isFinite(value) ? roundNumber(value) : null;
+}
+
+function roundNumber(value) {
+	return typeof value === 'number' && Number.isFinite(value) ? Math.round(value * 1000) / 1000 : value;
+}
+
+function stringValue(value) {
+	return typeof value === 'string' ? value.trim() : '';
+}
+
+function sanitizePhaseName(name) {
+	return String(name || '').trim().toLowerCase().replace(/[^a-z0-9_.:-]+/g, '_').replace(/^_+|_+$/g, '') || 'phase';
+}
+
+function comparePhaseMarks(a, b) {
+	return finiteNumber(a.start_time_ms) - finiteNumber(b.start_time_ms) || String(a.name).localeCompare(String(b.name));
+}
+
+function stableJson(value) {
+	if (Array.isArray(value)) return value.map(stableJson);
+	if (!value || typeof value !== 'object') return value;
+	return Object.fromEntries(
+		Object.entries(value)
+			.filter(([, item]) => item !== undefined)
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([key, item]) => [key, stableJson(item)])
+	);
+}
+
+module.exports = {
+	BROWSER_RESULT_SCHEMA_VERSION,
+	collectBrowserPhases,
+	normalizeBrowserArtifact,
+	normalizeBrowserBottleneck,
+	normalizeBrowserNetworkRequest,
+	normalizeBrowserPerformanceProfile,
+	normalizeBrowserPhaseMark,
+	normalizeBrowserProfileTimings,
+	normalizeBrowserTiming,
+	normalizeTraceAssertion,
+	normalizeTraceEnvelope,
+	normalizeTraceEvent,
+	stableJson,
+};

--- a/scripts/lib/browser-result-shapes.mjs
+++ b/scripts/lib/browser-result-shapes.mjs
@@ -1,0 +1,22 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const shapes = require('./browser-result-shapes.cjs');
+
+export const {
+    BROWSER_RESULT_SCHEMA_VERSION,
+    collectBrowserPhases,
+    normalizeBrowserArtifact,
+    normalizeBrowserBottleneck,
+    normalizeBrowserNetworkRequest,
+    normalizeBrowserPerformanceProfile,
+    normalizeBrowserPhaseMark,
+    normalizeBrowserProfileTimings,
+    normalizeBrowserTiming,
+    normalizeTraceAssertion,
+    normalizeTraceEnvelope,
+    normalizeTraceEvent,
+    stableJson,
+} = shapes;
+
+export default shapes;

--- a/wordpress/lib/timing-correlator.js
+++ b/wordpress/lib/timing-correlator.js
@@ -1,6 +1,14 @@
 'use strict';
 
 /**
+ * Internal dependencies
+ */
+const {
+	normalizeBrowserProfileTimings: normalizeSharedBrowserProfileTimings,
+	normalizeBrowserTiming: normalizeSharedBrowserTiming,
+} = require('../../scripts/lib/browser-result-shapes.cjs');
+
+/**
  * Correlate browser resource timing entries with WordPress request profiler
  * rows so callers can compare per-request browser TTFB / duration against the
  * WordPress app duration captured by `lib/request-profiler.js`.
@@ -39,11 +47,11 @@ const REQUEST_END_EVENTS = new Set(['shutdown', 'request.end']);
  *
  * Returns the normalized string. For non-string / empty input returns `''`.
  *
- * @param {string} url
- * @param {object} [options]
- * @param {boolean} [options.lowercasePath=true]
+ * @param {string}   url
+ * @param {Object}   [options]
+ * @param {boolean}  [options.lowercasePath=true]
  * @param {string[]} [options.dropQueryParams]
- * @returns {string}
+ * @return {string} Normalized URL key.
  */
 function normalizeUrl(url, options = {}) {
 	if (typeof url !== 'string' || url.trim() === '') {
@@ -99,206 +107,21 @@ function normalizeUrl(url, options = {}) {
 	return path + search;
 }
 
-function pickFirstNumber(source, keys) {
-	if (!source || typeof source !== 'object') {
-		return undefined;
-	}
-	for (const key of keys) {
-		const value = source[key];
-		if (typeof value === 'number' && Number.isFinite(value)) {
-			return value;
-		}
-	}
-	return undefined;
-}
-
-function pickFirstString(source, keys) {
-	if (!source || typeof source !== 'object') {
-		return undefined;
-	}
-	for (const key of keys) {
-		const value = source[key];
-		if (typeof value === 'string' && value.trim() !== '') {
-			return value.trim();
-		}
-	}
-	return undefined;
-}
-
-function pickFirstBoolean(source, keys) {
-	if (!source || typeof source !== 'object') {
-		return undefined;
-	}
-	for (const key of keys) {
-		const value = source[key];
-		if (typeof value === 'boolean') {
-			return value;
-		}
-	}
-	return undefined;
-}
-
 /**
  * Convert a single browser resource timing entry into a normalized record.
  * Accepts native `PerformanceResourceTiming`-shaped objects as well as
  * looser `{ url, startTime, ttfbMs, durationMs }` shapes.
  *
- * @param {object} entry
- * @param {object} [options]
- * @returns {object|null}
+ * @param {Object} entry
+ * @param {Object} [options]
+ * @return {Object|null} Normalized browser timing row, or null for invalid input.
  */
 function normalizeBrowserTiming(entry, options = {}) {
-	if (!entry || typeof entry !== 'object') {
-		return null;
-	}
-
-	const rawUrl = pickFirstString(entry, ['name', 'url', 'request_url', 'requestUrl']);
-	if (!rawUrl) {
-		return null;
-	}
-
-	const startTime = pickFirstNumber(entry, ['startTime', 'fetchStart', 'requestStart', 'start_time_ms', 'start_ms', 'startMs']);
-	const responseStart = pickFirstNumber(entry, ['responseStart', 'ttfb_ms', 'ttfbMs', 'response_start']);
-	const responseEnd = pickFirstNumber(entry, ['responseEnd', 'response_end', 'endMs', 'end_ms', 'response_end_ms']);
-	const duration = pickFirstNumber(entry, ['duration', 'duration_ms', 'durationMs']);
-
-	let computedDuration = duration;
-	if (computedDuration === undefined && startTime !== undefined && responseEnd !== undefined) {
-		computedDuration = Math.max(0, responseEnd - startTime);
-	}
-
-	let computedTtfb;
-	if (responseStart !== undefined && startTime !== undefined) {
-		computedTtfb = Math.max(0, responseStart - startTime);
-	} else {
-		computedTtfb = pickFirstNumber(entry, ['ttfb', 'ttfb_ms', 'ttfbMs']);
-	}
-
-	const initiator = pickFirstString(entry, ['initiatorType', 'initiator_type', 'initiator', 'resourceType']);
-	const phase = pickFirstString(entry, ['phase', 'phase_label', 'phaseLabel']);
-	const method = pickFirstString(entry, ['method', 'request_method', 'requestMethod']);
-	const status = pickFirstNumber(entry, ['status', 'statusCode', 'status_code', 'http_status']);
-	const failed = pickFirstBoolean(entry, ['failed', 'error']);
-
-	return {
-		url: rawUrl,
-		normalizedUrl: normalizeUrl(rawUrl, options),
-		method: method ? method.toUpperCase() : undefined,
-		status: typeof status === 'number' ? status : undefined,
-		failed,
-		startTime: typeof startTime === 'number' ? startTime : undefined,
-		ttfbMs: typeof computedTtfb === 'number' ? computedTtfb : undefined,
-		durationMs: typeof computedDuration === 'number' ? computedDuration : undefined,
-		initiatorType: initiator,
-		phase,
-		raw: entry,
-	};
+	return normalizeSharedBrowserTiming(entry, { ...options, normalizeUrl });
 }
 
 function normalizeBrowserProfileTimings(profile, options = {}) {
-	if (!profile || typeof profile !== 'object') {
-		return [];
-	}
-
-	const phases = normalizeProfilePhases(profile);
-	const resources = Array.isArray(profile.resources) ? profile.resources : [];
-	const network = Array.isArray(profile.network) ? profile.network : [];
-	const resourcesByUrl = new Map();
-
-	for (const resource of resources) {
-		const rawUrl = pickFirstString(resource, ['name', 'url']);
-		const normalizedUrl = normalizeUrl(rawUrl, options);
-		if (!normalizedUrl) {
-			continue;
-		}
-		if (!resourcesByUrl.has(normalizedUrl)) {
-			resourcesByUrl.set(normalizedUrl, []);
-		}
-		resourcesByUrl.get(normalizedUrl).push(resource);
-	}
-
-	const rows = [];
-	for (const entry of network) {
-		const rawUrl = pickFirstString(entry, ['url', 'name']);
-		const normalizedUrl = normalizeUrl(rawUrl, options);
-		const resource = normalizedUrl ? (resourcesByUrl.get(normalizedUrl) || []).shift() : undefined;
-		const startTime = pickFirstNumber(entry, ['start_time_ms', 'startTime', 'start_ms', 'startMs'])
-			?? pickFirstNumber(resource, ['startTime', 'fetchStart', 'requestStart']);
-		const phase = pickFirstString(entry, ['phase', 'phase_label', 'phaseLabel'])
-			|| pickFirstString(resource, ['phase', 'phase_label', 'phaseLabel'])
-			|| phaseForStartTime(phases, startTime);
-
-		rows.push({
-			...resource,
-			...entry,
-			name: rawUrl,
-			url: rawUrl,
-			startTime,
-			responseStart: pickFirstNumber(resource, ['responseStart']) ?? pickFirstNumber(entry, ['responseStart', 'ttfb_ms', 'ttfbMs']),
-			responseEnd: pickFirstNumber(resource, ['responseEnd']) ?? pickFirstNumber(entry, ['response_end_ms', 'responseEnd']),
-			durationMs: pickFirstNumber(entry, ['duration_ms', 'durationMs']) ?? pickFirstNumber(resource, ['duration', 'duration_ms', 'durationMs']),
-			phase,
-		});
-	}
-
-	for (const entries of resourcesByUrl.values()) {
-		for (const resource of entries) {
-			const startTime = pickFirstNumber(resource, ['startTime', 'fetchStart', 'requestStart']);
-			rows.push({
-				...resource,
-				phase: pickFirstString(resource, ['phase', 'phase_label', 'phaseLabel']) || phaseForStartTime(phases, startTime),
-			});
-		}
-	}
-
-	return rows;
-}
-
-function normalizeProfilePhases(profile) {
-	const phases = [];
-	if (profile.phases && typeof profile.phases === 'object' && !Array.isArray(profile.phases)) {
-		for (const [name, phase] of Object.entries(profile.phases)) {
-			if (!phase || typeof phase !== 'object') {
-				continue;
-			}
-			const startMs = pickFirstNumber(phase, ['start_time_ms', 'startTime', 'start_ms', 'startMs']);
-			const endMs = pickFirstNumber(phase, ['end_time_ms', 'endTime', 'end_ms', 'endMs']);
-			if (startMs !== undefined) {
-				phases.push({ name, startMs, endMs });
-			}
-		}
-	} else if (Array.isArray(profile.phase_marks)) {
-		const marks = profile.phase_marks
-			.map((mark) => ({
-				name: pickFirstString(mark, ['name', 'phase', 'label']),
-				startMs: pickFirstNumber(mark, ['start_time_ms', 'startTime', 'start_ms', 'startMs']),
-			}))
-			.filter((mark) => mark.name && mark.startMs !== undefined)
-			.sort((a, b) => a.startMs - b.startMs);
-		for (let i = 0; i < marks.length; i++) {
-			phases.push({
-				name: marks[i].name,
-				startMs: marks[i].startMs,
-				endMs: marks[i + 1]?.startMs,
-			});
-		}
-	}
-
-	return phases.sort((a, b) => a.startMs - b.startMs);
-}
-
-function phaseForStartTime(phases, startTime) {
-	if (!Array.isArray(phases) || typeof startTime !== 'number') {
-		return undefined;
-	}
-	let matched;
-	for (const phase of phases) {
-		const endMs = typeof phase.endMs === 'number' ? phase.endMs : Infinity;
-		if (startTime >= phase.startMs && startTime < endMs) {
-			matched = phase.name;
-		}
-	}
-	return matched;
+	return normalizeSharedBrowserProfileTimings(profile, { ...options, normalizeUrl });
 }
 
 /**
@@ -308,9 +131,9 @@ function phaseForStartTime(phases, startTime) {
  * delta between the explicit `request.start` and `shutdown` events when
  * present).
  *
- * @param {object[]} rows
- * @param {object} [options]
- * @returns {object[]}
+ * @param {Object[]} rows
+ * @param {Object}   [options]
+ * @return {Object[]} Per-request WordPress profiler summaries.
  */
 function summarizeWordPressProfilerRows(rows, options = {}) {
 	if (!Array.isArray(rows)) {
@@ -411,11 +234,11 @@ function summarizeWordPressProfilerRows(rows, options = {}) {
  * the canonical "transport / bootstrap overhead" signal called out in
  * Extra-Chill/homeboy-extensions#451.
  *
- * @param {object} input
- * @param {object[]} input.browserTimings
- * @param {object[]} input.wordpressProfilerRows
- * @param {object} [options]
- * @returns {object}
+ * @param {Object}   input
+ * @param {Object[]} input.browserTimings
+ * @param {Object[]} input.wordpressProfilerRows
+ * @param {Object}   [options]
+ * @return {Object} Browser and WordPress timing correlation result.
  */
 function correlateBrowserAndWordPressTimings(input, options = {}) {
 	if (!input || typeof input !== 'object') {


### PR DESCRIPTION
## Summary
- Adds shared product-neutral browser/profile/trace result shape helpers with CJS and ESM entrypoints.
- Reuses the shared helpers from Node browser bench, Node trace timelines, and WordPress timing correlation while keeping WordPress URL/REST semantics local.
- Documents the shared shape boundary and adds a focused smoke test.

Fixes #939.

## Verification
- `bash scripts/browser-result-shapes-smoke.sh` — passed
- `bash nodejs/scripts/bench/nodejs-browser-performance-profiler-smoke.sh` — passed
- `bash nodejs/scripts/bench/nodejs-browser-helper-smoke.sh` — passed
- `bash nodejs/scripts/trace/nodejs-trace-runner-smoke.sh` — passed
- `npm --prefix wordpress run test:timing-correlator` — passed
- `npm --prefix wordpress run test:page-profiler` — passed
- `node --check scripts/lib/browser-result-shapes.cjs && node --check nodejs/scripts/bench/browser-helper.mjs && node --check nodejs/scripts/trace/lib/timeline.mjs && node --check wordpress/lib/timing-correlator.js` — passed
- `npm --prefix wordpress run lint:js -- lib/timing-correlator.js` — passed
- `git diff --cached --check` — passed before commit

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the shared shape helpers, wiring the focused consumers, writing the docs/smoke coverage, and running verification. Chris remains responsible for review and merge.