### PR TITLE
fix(wordpress): support file mounts in agent ci recipes

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -186,8 +186,9 @@ name: Data Machine Agent CI (reusable)
       extra_wp_codebox_mounts:
         description: |
           JSON string array appended to the runner config wp_codebox_mounts after
-          the default ci-driver fixture mount. Each entry is SOURCE:TARGET[:MODE]
-          for a WP Codebox sandbox mount. Default '[]' means no extra mounts.
+          the default ci-driver fixture mount. Entries may be SOURCE:TARGET[:MODE]
+          strings or objects with source, target, mode, and optional type
+          (directory or file). Default '[]' means no extra mounts.
         type: string
         default: "[]"
       workload_run_before:
@@ -655,8 +656,13 @@ jobs:
           execute_workflow_guest_path="$EXECUTE_WORKFLOW_PATH"
           execute_workflow_mounts_json="[]"
           if [ -n "$EXECUTE_WORKFLOW_PATH" ] && [[ "$EXECUTE_WORKFLOW_PATH" != /* ]]; then
+            execute_workflow_host_path="${GITHUB_WORKSPACE}/${EXECUTE_WORKFLOW_PATH}"
+            execute_workflow_mount_type="directory"
+            if [ -f "$execute_workflow_host_path" ]; then
+              execute_workflow_mount_type="file"
+            fi
             execute_workflow_guest_path="/wordpress/wp-content/plugins/${component_slug}/${EXECUTE_WORKFLOW_PATH}"
-            execute_workflow_mounts_json="$(jq -nc --arg source "${GITHUB_WORKSPACE}/${EXECUTE_WORKFLOW_PATH}" --arg target "$execute_workflow_guest_path" '[$source + ":" + $target + ":readonly"]')"
+            execute_workflow_mounts_json="$(jq -nc --arg type "$execute_workflow_mount_type" --arg source "$execute_workflow_host_path" --arg target "$execute_workflow_guest_path" '[{type: $type, source: $source, target: $target, mode: "readonly"}]')"
           fi
           mapfile -t validation_paths < <(find "${GITHUB_WORKSPACE}/.ci" -mindepth 1 -maxdepth 1 -type d | sort)
           provider_plugin_json="$(printf '%s' "$PROVIDER_PLUGIN" | jq -Rsc --arg provider "$PROVIDER" --arg openaiRef "$OPENAI_PROVIDER_REF" '
@@ -801,7 +807,12 @@ jobs:
               validation_dependencies: $validationDependencies,
               wp_codebox_wordpress_version: $wpCodeboxWordPressVersion,
               wp_codebox_mounts: ([
-                $homeboyExtensionsPath + "/wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php:/wordpress/wp-content/plugins/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php:readonly"
+                {
+                  type: "file",
+                  source: ($homeboyExtensionsPath + "/wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php"),
+                  target: "/wordpress/wp-content/plugins/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php",
+                  mode: "readonly"
+                }
               ] + $extraWpCodeboxMounts + $executeWorkflowMounts),
               wp_config_defines: $extraWpConfigDefines,
               workload_run_before: $workloadRunBefore,

--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -19,14 +19,17 @@ BUNDLE_DIR="$RUNTIME_DIR/bundle"
 AGENTS_API_DIR="$RUNTIME_DIR/agents-api"
 DATA_MACHINE_DIR="$RUNTIME_DIR/data-machine"
 DATA_MACHINE_CODE_DIR="$RUNTIME_DIR/data-machine-code"
+FILE_MOUNT_PATH="$RUNTIME_DIR/fixture-config.json"
+DIR_MOUNT_PATH="$RUNTIME_DIR/fixture-directory-mount"
 
 cleanup() {
     rm -rf "$RUNTIME_DIR"
 }
 trap cleanup EXIT
 
-mkdir -p "$BUNDLE_DIR" "$AGENTS_API_DIR" "$DATA_MACHINE_DIR" "$DATA_MACHINE_CODE_DIR"
+mkdir -p "$BUNDLE_DIR" "$AGENTS_API_DIR" "$DATA_MACHINE_DIR" "$DATA_MACHINE_CODE_DIR" "$DIR_MOUNT_PATH"
 printf '{"agent":{"slug":"wp-codebox-smoke-agent"}}\n' > "$BUNDLE_DIR/manifest.json"
+printf '{"ok":true}\n' > "$FILE_MOUNT_PATH"
 
 cat > "$FAKE_WP_CODEBOX" <<'NODE'
 #!/usr/bin/env node
@@ -91,6 +94,12 @@ if (recipe.inputs?.extraPlugins?.some((plugin) => plugin.slug === 'php-ai-client
 }
 if (!recipe.inputs?.mounts?.some((mount) => mount.source.endsWith('/bundle') && mount.target === '/wordpress/wp-content/plugins/bundle' && mount.mode === 'readonly')) {
   throw new Error('missing bundle readonly mount in recipe')
+}
+if (!recipe.inputs?.mounts?.some((mount) => mount.type === 'file' && mount.source.endsWith('/fixture-config.json') && mount.target === '/wordpress/wp-content/plugins/example/fixture-config.json' && mount.mode === 'readonly')) {
+  throw new Error('missing typed file mount in recipe')
+}
+if (!recipe.inputs?.mounts?.some((mount) => mount.type === 'directory' && mount.source.endsWith('/fixture-directory-mount') && mount.target === '/wordpress/wp-content/plugins/example/fixtures' && mount.mode === 'readwrite')) {
+  throw new Error('missing typed directory mount in recipe')
 }
 
 const artifactRoot = path.join(valueAfter('--artifacts'), 'runtime-smoke')
@@ -187,6 +196,8 @@ jq -n \
     --arg agentsApi "$AGENTS_API_DIR" \
     --arg dataMachine "$DATA_MACHINE_DIR" \
     --arg dataMachineCode "$DATA_MACHINE_CODE_DIR" \
+    --arg fileMount "$FILE_MOUNT_PATH" \
+    --arg dirMount "$DIR_MOUNT_PATH" \
     '{
         component_id: "wp-codebox-smoke-component",
         component_path: env.PWD,
@@ -209,7 +220,11 @@ jq -n \
             agents_api: $agentsApi,
             data_machine: $dataMachine,
             data_machine_code: $dataMachineCode
-        }
+        },
+        wp_codebox_mounts: [
+            {type: "file", source: $fileMount, target: "/wordpress/wp-content/plugins/example/fixture-config.json", mode: "readonly"},
+            ($dirMount + ":/wordpress/wp-content/plugins/example/fixtures:readwrite")
+        ]
     }' > "$CONFIG_TMPFILE"
 
 FAKE_WP_CODEBOX_ARGS_FILE="$FAKE_ARGS_FILE" \

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -46,6 +46,65 @@ homeboy_datamachine_agent_wp_codebox_secret_env_names() {
     ' <<<"$CONFIG_JSON"
 }
 
+homeboy_datamachine_agent_wp_codebox_mount_type() {
+    local source="${1:-}"
+    local explicit_type="${2:-}"
+
+    case "$explicit_type" in
+        file|directory)
+            printf '%s\n' "$explicit_type"
+            return 0
+            ;;
+        "")
+            ;;
+        *)
+            echo "ERROR: wp_codebox_mounts type must be file or directory: $explicit_type" >&2
+            exit 1
+            ;;
+    esac
+
+    if [ -f "$source" ]; then
+        printf 'file\n'
+        return 0
+    fi
+    if [ -d "$source" ]; then
+        printf 'directory\n'
+        return 0
+    fi
+
+    echo "ERROR: wp_codebox_mounts source must be an existing file or directory: $source" >&2
+    exit 1
+}
+
+homeboy_datamachine_agent_add_wp_codebox_mount() {
+    local source="${1:-}"
+    local target="${2:-}"
+    local mode="${3:-readwrite}"
+    local type="${4:-}"
+
+    if [ -z "$source" ] || [ -z "$target" ]; then
+        return 0
+    fi
+
+    case "$mode" in
+        readonly|readwrite)
+            ;;
+        *)
+            echo "ERROR: wp_codebox_mounts mode must be readonly or readwrite: $mode" >&2
+            exit 1
+            ;;
+    esac
+
+    type="$(homeboy_datamachine_agent_wp_codebox_mount_type "$source" "$type")"
+    mounts_json=$(jq -nc \
+        --argjson mounts "$mounts_json" \
+        --arg type "$type" \
+        --arg source "$source" \
+        --arg target "$target" \
+        --arg mode "$mode" \
+        '$mounts + [{type: $type, source: $source, target: $target, mode: $mode}]')
+}
+
 homeboy_datamachine_agent_wp_codebox_run() {
     local wp_codebox_bin="${HOMEBOY_WP_CODEBOX_BIN:-}"
     if [ -z "$wp_codebox_bin" ]; then
@@ -107,20 +166,28 @@ PHP
             {source: $datamachine, slug: "data-machine", activate: false},
             {source: $code, slug: "data-machine-code", activate: false}
         ]')
-    mounts_json=$(jq -nc --arg source "$EXTENSION_PATH" '[{source: $source, target: "/homeboy-extension", mode: "readonly"}]')
+    mounts_json=$(jq -nc --arg source "$EXTENSION_PATH" '[{type: "directory", source: $source, target: "/homeboy-extension", mode: "readonly"}]')
     provider_slugs_csv=""
 
     if [ -n "$BUNDLE_PATH" ]; then
-        mounts_json=$(jq -nc --argjson mounts "$mounts_json" --arg source "$BUNDLE_PATH" --arg target "$BUNDLE_GUEST_PATH" '$mounts + [{source: $source, target: $target, mode: "readonly"}]')
+        homeboy_datamachine_agent_add_wp_codebox_mount "$BUNDLE_PATH" "$BUNDLE_GUEST_PATH" "readonly"
     fi
 
     local extra_mount
     while IFS= read -r extra_mount; do
-        IFS=: read -r mount_source mount_target mount_mode <<<"$extra_mount"
-        [ -n "$mount_source" ] && [ -n "$mount_target" ] || continue
-        mount_mode="${mount_mode:-readwrite}"
-        mounts_json=$(jq -nc --argjson mounts "$mounts_json" --arg source "$mount_source" --arg target "$mount_target" --arg mode "$mount_mode" '$mounts + [{source: $source, target: $target, mode: $mode}]')
-    done < <(jq -r '.wp_codebox_mounts? // [] | .[]? | select(type == "string" and . != "")' <<<"$CONFIG_JSON")
+        [ -n "$extra_mount" ] || continue
+        if jq -e 'type == "string"' >/dev/null 2>&1 <<<"$extra_mount"; then
+            IFS=: read -r mount_source mount_target mount_mode <<<"$(jq -r '.' <<<"$extra_mount")"
+            homeboy_datamachine_agent_add_wp_codebox_mount "$mount_source" "$mount_target" "${mount_mode:-readwrite}"
+            continue
+        fi
+
+        mount_source=$(jq -r '.source // .from // empty' <<<"$extra_mount")
+        mount_target=$(jq -r '.target // .to // empty' <<<"$extra_mount")
+        mount_mode=$(jq -r '.mode // "readwrite"' <<<"$extra_mount")
+        mount_type=$(jq -r '.type // empty' <<<"$extra_mount")
+        homeboy_datamachine_agent_add_wp_codebox_mount "$mount_source" "$mount_target" "$mount_mode" "$mount_type"
+    done < <(jq -c '.wp_codebox_mounts? // [] | .[]?' <<<"$CONFIG_JSON")
 
     local provider_plugin_path provider_slug
     while IFS= read -r provider_plugin_path; do


### PR DESCRIPTION
## Summary
- Emit typed WP Codebox mounts for Data Machine agent CI file sources so recipe consumers can distinguish files from directories.
- Preserve existing `SOURCE:TARGET[:MODE]` mount strings while allowing explicit object mounts with `type`, `source`, `target`, and `mode`.
- Cover both a typed file mount and legacy string directory mount in the WP Codebox agent runner smoke.

Fixes #945.

## Tests
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh && bash -n wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `npm run test:datamachine-agent-wp-codebox-runner`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** implementation and verification draft