### PR TITLE
Clarify Data Machine agent auth mode

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -54,7 +54,25 @@ for the WP Codebox contract, runtime surface, and evaluation notes.
 The reusable workflow exposes `engine_data_json` as one combined JSON object.
 Dynamic per-key `workflow_call` outputs are not possible in GitHub Actions, so
 callers should parse this object in their own workflow when they need named
-values.
+values. It also exposes `auth_mode`, which is `homeboy_app_token` when the
+workflow generated and used a Homeboy GitHub App installation token, or
+`github_token_fallback` when it used the repository-scoped GitHub Actions token.
+
+## GitHub auth modes
+
+The workflow keeps two GitHub authentication modes:
+
+- Same-repo consumer workflows can rely on the built-in `github.token` fallback.
+  Branches, commits, PRs, and comments created this way appear as
+  `github-actions[bot]`, and `auth_mode` is `github_token_fallback`.
+- Central, cross-repo, or private-target workflows should provide
+  `HOMEBOY_APP_ID` and `HOMEBOY_APP_PRIVATE_KEY`, set `app_token_repos` to the
+  repositories the run must access, and set `require_homeboy_app_token: true` so
+  missing app credentials fail before expensive setup. In this mode, `auth_mode`
+  is `homeboy_app_token`.
+
+The run summary includes the selected auth mode, target repository, token scope,
+and whether the caller required a Homeboy App token. Tokens are never printed.
 
 ## Example
 
@@ -131,7 +149,8 @@ jobs:
 - `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.
 - `bundle_path` is resolved relative to the consumer checkout.
 - `bundle_repo`, `bundle_ref`, and `bundle_path_in_repo` let a consumer run against a bundle stored in another repository. The runner clones that repository before mounting the bundle into the WordPress substrate.
-- `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`.
+- `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`. Use it when the workflow needs app-token access to more than the target repository.
+- `require_homeboy_app_token` fails before agent setup when Homeboy App credentials are missing. Enable it for central, cross-repo, and private-target runs; leave it false for same-repo consumers that intentionally use `github.token` fallback.
 - `allowed_repos` is a JSON array of `OWNER/REPO` entries exposed to the injected GitHub profile. It defaults to `[target_repo]`.
 - `engine_key` and `tool_results_key` control where built-in GitHub tool captures and fallback PR data are written in `metadata.engine_data`.
 - `dry_run` is intended for workflow smoke tests only; production consumers should leave it `false`.
@@ -166,6 +185,7 @@ jobs:
       flow_slug: docs-agent-flow
       target_repo: Automattic/agents-api
       app_token_repos: Automattic/agents-api,Automattic/docs-agent
+      require_homeboy_app_token: true
       allowed_repos: '["Automattic/agents-api", "Automattic/docs-agent"]'
       engine_key: docs_agent
       tool_results_key: github_tool_results

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -3,6 +3,8 @@
 # Consumers receive one stable `engine_data_json` output. GitHub Actions cannot
 # create dynamic workflow_call outputs from `engine_data_outputs`, so callers
 # should parse that JSON map in their own workflow when they need named fields.
+# The `auth_mode` output reports whether the run used a Homeboy GitHub App token
+# or the repository-scoped GitHub Actions token fallback.
 name: Data Machine Agent CI (reusable)
 
 'on':
@@ -298,6 +300,8 @@ name: Data Machine Agent CI (reusable)
         value: ${{ jobs.run-agent.outputs.transcript_summary }}
       engine_data_json:
         value: ${{ jobs.run-agent.outputs.engine_data_json }}
+      auth_mode:
+        value: ${{ jobs.run-agent.outputs.auth_mode }}
 
 jobs:
   run-agent:
@@ -312,6 +316,7 @@ jobs:
       transcript_json: ${{ steps.extract.outputs.transcript_json || steps.extract_dry_run.outputs.transcript_json || steps.skipped.outputs.transcript_json }}
       transcript_summary: ${{ steps.extract.outputs.transcript_summary || steps.extract_dry_run.outputs.transcript_summary || steps.skipped.outputs.transcript_summary }}
       engine_data_json: ${{ steps.engine-data.outputs.engine_data_json || steps.skipped.outputs.engine_data_json }}
+      auth_mode: ${{ steps.auth-mode.outputs.auth_mode || steps.skipped.outputs.auth_mode }}
     steps:
       - name: Record skipped agent run
         id: skipped
@@ -322,6 +327,7 @@ jobs:
           printf 'transcript_json=\n' >> "$GITHUB_OUTPUT"
           printf 'transcript_summary=\n' >> "$GITHUB_OUTPUT"
           printf 'engine_data_json={}\n' >> "$GITHUB_OUTPUT"
+          printf 'auth_mode=skipped\n' >> "$GITHUB_OUTPUT"
 
       - name: Checkout consumer repo
         if: ${{ inputs.run_agent }}
@@ -397,6 +403,43 @@ jobs:
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
           owner: ${{ steps.token-scope.outputs.owner }}
           repositories: ${{ steps.token-scope.outputs.repositories }}
+
+      - name: Report GitHub auth mode
+        id: auth-mode
+        if: ${{ inputs.run_agent }}
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_TOKEN_OWNER: ${{ steps.token-scope.outputs.owner }}
+          APP_TOKEN_REPOSITORIES: ${{ steps.token-scope.outputs.repositories }}
+          APP_TOKEN_REPOS_INPUT: ${{ inputs.app_token_repos }}
+          TARGET_REPO: ${{ inputs.target_repo }}
+          REQUIRE_HOMEBOY_APP_TOKEN: ${{ inputs.require_homeboy_app_token }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ -n "$APP_TOKEN" ]; then
+            auth_mode="homeboy_app_token"
+            token_scope="${APP_TOKEN_OWNER}/${APP_TOKEN_REPOSITORIES}"
+            token_note="Generated Homeboy GitHub App installation token."
+          else
+            auth_mode="github_token_fallback"
+            token_scope="$TARGET_REPO"
+            token_note="Using repository-scoped github.token fallback."
+          fi
+          printf 'auth_mode=%s\n' "$auth_mode" >> "$GITHUB_OUTPUT"
+          printf 'Data Machine agent CI auth_mode: %s\n' "$auth_mode"
+          printf 'Token scope: %s\n' "$token_scope"
+          printf 'require_homeboy_app_token: %s\n' "$REQUIRE_HOMEBOY_APP_TOKEN"
+          printf 'dry_run: %s\n' "$DRY_RUN"
+          {
+            printf '## Data Machine Agent CI Auth\n\n'
+            printf -- '- Auth mode: `%s`\n' "$auth_mode"
+            printf -- '- Target repository: `%s`\n' "$TARGET_REPO"
+            printf -- '- Token scope: `%s`\n' "$token_scope"
+            printf -- '- Homeboy App token repos input: `%s`\n' "${APP_TOKEN_REPOS_INPUT:-default target_repo}"
+            printf -- '- Require Homeboy App token: `%s`\n' "$REQUIRE_HOMEBOY_APP_TOKEN"
+            printf -- '- Note: %s\n' "$token_note"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Checkout homeboy-extensions
         if: ${{ inputs.run_agent }}

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -141,6 +141,13 @@ The runner converts the agent config into a single WP Codebox sandbox run:
 - `fallback_pull_request` can open a PR when files were written but the agent did
   not explicitly call the PR tool.
 
+The reusable workflow reports the selected GitHub token path as `auth_mode` and
+in the run summary. Same-repo consumers can use the repository-scoped
+`github.token` fallback, which posts as `github-actions[bot]`. Central,
+cross-repo, and private-target runs should provide Homeboy GitHub App secrets,
+set `app_token_repos` to every repository the run must access, and enable
+`require_homeboy_app_token` so missing app credentials fail before agent setup.
+
 Inside WP Codebox, `datamachine-agent-workload.php` installs the bundle,
 configures the provider, starts the Data Machine flow, drains queued work,
 records tool results, exports the transcript, and writes a Homeboy scenario
@@ -158,7 +165,7 @@ knobs to `run-datamachine-agent.sh`:
 - Agent selection: `agent_slug`, `pipeline_slug`, `flow_slug`, `prompt`, `provider`, `model`.
 - Provider plugin: `provider_plugin`, with OpenAI defaults preserved when omitted for `provider: openai`.
 - WordPress runtime: `include_agent_runtime_dependencies`, runtime dependency refs, `wp_codebox_wordpress_version`, `wp_codebox_ref`, `extra_wp_config_defines`, `extra_wp_codebox_mounts`, `workload_run_before`, `workload_run_after`.
-- GitHub access: `target_repo`, `app_token_repos`, `allowed_repos`, `engine_key`, `tool_results_key`.
+- GitHub access: `target_repo`, `app_token_repos`, `require_homeboy_app_token`, `allowed_repos`, `engine_key`, `tool_results_key`.
 - Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
 - Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`, `replay_bundle_artifact_name`.
 - Eval projection: `wp_gym_benchmark_mode` turns missing wp-gym replay/evidence references into errors.


### PR DESCRIPTION
## Summary
- Add a stable `auth_mode` output to the Data Machine Agent CI reusable workflow.
- Report whether runs use a Homeboy App token or `github.token` fallback in logs and the GitHub step summary.
- Document same-repo `github-actions[bot]` fallback versus central/cross-repo/private Homeboy App token requirements.

Fixes #949.

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); puts "workflow YAML parsed"'`
- `homeboy lint --path . --extension wordpress --changed-only --summary`
- `homeboy lint --path . --extension wordpress --file .github/workflows/datamachine-agent-ci.yml --summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the workflow reporting/docs update and ran local verification; Chris remains responsible for review and merge.