### PR TITLE
Activate agent CI runtime plugins

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -92,6 +92,11 @@ for (const expected of ['wp-codebox.agent-sandbox-run', 'HOMEBOY_DATAMACHINE_AGE
 if (recipe.inputs?.extraPlugins?.some((plugin) => plugin.slug === 'php-ai-client')) {
   throw new Error('WP AI Client is provided by WordPress core and must not be mounted as a WP Codebox extra plugin')
 }
+for (const slug of ['agents-api', 'data-machine', 'data-machine-code']) {
+  if (!recipe.inputs?.extraPlugins?.some((plugin) => plugin.slug === slug && plugin.activate === true)) {
+    throw new Error(`expected ${slug} to be activated before the agent workload runs`)
+  }
+}
 if (!recipe.inputs?.mounts?.some((mount) => mount.source.endsWith('/bundle') && mount.target === '/wordpress/wp-content/plugins/bundle' && mount.mode === 'readonly')) {
   throw new Error('missing bundle readonly mount in recipe')
 }

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -162,9 +162,9 @@ PHP
         --arg datamachine "$data_machine_path" \
         --arg code "$data_machine_code_path" \
         '[
-            {source: $agents, slug: "agents-api", activate: false},
-            {source: $datamachine, slug: "data-machine", activate: false},
-            {source: $code, slug: "data-machine-code", activate: false}
+            {source: $agents, slug: "agents-api", activate: true},
+            {source: $datamachine, slug: "data-machine", activate: true},
+            {source: $code, slug: "data-machine-code", activate: true}
         ]')
     mounts_json=$(jq -nc --arg source "$EXTENSION_PATH" '[{type: "directory", source: $source, target: "/homeboy-extension", mode: "readonly"}]')
     provider_slugs_csv=""


### PR DESCRIPTION
## Summary
- Activate the Agents API, Data Machine, and Data Machine Code plugins in the WP Codebox agent CI recipe before running the workload.
- Extend the WP Codebox runner smoke test to assert the core agent runtime plugins are activated.

## Testing
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh && bash -n wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `bash scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the missing Data Machine Code plugin hook in the WP Codebox agent CI runtime, drafted the recipe/test update, and ran focused verification. Chris remains responsible for review and merge.