### PR TITLE
fix(wordpress): fail agent ci on reported errors

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -1027,13 +1027,22 @@ jobs:
           scenario_json="$(jq -ec --arg scenario "${{ inputs.flow_slug }}" '.scenarios[] | select(.id == $scenario)' "$RESULTS_FILE")"
           job_status="$(jq -r '.metadata.job_status // ""' <<< "$scenario_json")"
           success_status="$(jq -r '.metadata.success_status // ""' <<< "$scenario_json")"
+          error_message="$(jq -r '.metadata.error_message // ""' <<< "$scenario_json")"
           completion_outcome_satisfied="$(jq -r 'if .metadata.completion_outcome_satisfied == true then "true" else "false" end' <<< "$scenario_json")"
           no_changes_allowed="${{ inputs.success_requires_pr && 'false' || 'true' }}"
 
           printf 'job_status:                      %s\n' "$job_status"
           printf 'success_status:                  %s\n' "$success_status"
+          printf 'error_message:                   %s\n' "$error_message"
           printf 'completion_outcome_satisfied:    %s\n' "$completion_outcome_satisfied"
           printf 'no_changes_allowed:              %s\n' "$no_changes_allowed"
+
+          if [ -n "$error_message" ]; then
+            printf 'ERROR: scenario %s completed with error_message=%s\n' \
+              "${{ inputs.flow_slug }}" \
+              "$error_message" >&2
+            exit 1
+          fi
 
           if [ "$job_status" = "completed" ] || [ "$success_status" = "pr_opened" ] || [ "$completion_outcome_satisfied" = "true" ] || { [ "$success_status" = "no_changes" ] && [ "$no_changes_allowed" = "true" ]; }; then
             exit 0

--- a/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
@@ -138,6 +138,10 @@ namespace {
 		fwrite( STDERR, "Expected reusable workflow success assertion to accept opened PRs and satisfied completion outcomes.\n" );
 		exit( 1 );
 	}
+	if ( ! str_contains( $workflow_source, 'error_message="$(jq -r' ) || ! str_contains( $workflow_source, 'if [ -n "$error_message" ]; then' ) ) {
+		fwrite( STDERR, "Expected reusable workflow success assertion to fail when the agent reports an error message.\n" );
+		exit( 1 );
+	}
 
 	$jobs = new \DataMachine\Core\Database\Jobs\Jobs();
     $summary = homeboy_datamachine_agent_drain_child_jobs( 101, array(), $jobs );


### PR DESCRIPTION
## Summary
- Fail reusable Data Machine agent CI assertions when the workload reports a non-empty `metadata.error_message`.
- Cover the assertion path in the child-drain smoke so completion assertion failures cannot be hidden by allowed no-op runs.

## Verification
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the wp-site-generator e2e masking failure, drafted the reusable workflow assertion change, and ran the targeted smoke test. Chris remains responsible for review and merge.