### PR TITLE
fix(wordpress): request app token write permissions

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -403,6 +403,9 @@ jobs:
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
           owner: ${{ steps.token-scope.outputs.owner }}
           repositories: ${{ steps.token-scope.outputs.repositories }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Report GitHub auth mode
         id: auth-mode

--- a/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
@@ -142,6 +142,10 @@ namespace {
 		fwrite( STDERR, "Expected reusable workflow success assertion to fail when the agent reports an error message.\n" );
 		exit( 1 );
 	}
+	if ( ! str_contains( $workflow_source, 'permission-issues: write' ) || ! str_contains( $workflow_source, 'permission-pull-requests: write' ) || ! str_contains( $workflow_source, 'permission-contents: write' ) ) {
+		fwrite( STDERR, "Expected reusable workflow to request explicit Homeboy app token write permissions.\n" );
+		exit( 1 );
+	}
 
 	$jobs = new \DataMachine\Core\Database\Jobs\Jobs();
     $summary = homeboy_datamachine_agent_drain_child_jobs( 101, array(), $jobs );


### PR DESCRIPTION
## Summary
- Request explicit `contents`, `issues`, and `pull-requests` write permissions for Homeboy App tokens in reusable Data Machine agent CI.
- Cover the workflow contract in the agent CI smoke so issue-comment runs do not silently use under-scoped app tokens.

## Verification
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the design-agent issue-comment 403 path, drafted the Homeboy App token permission fix, and ran the smoke test. Chris remains responsible for review and merge.