### PR TITLE
fix(wordpress): prefer repository token for agent CI

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -2586,16 +2586,6 @@ if ( ! function_exists( 'homeboy_datamachine_agent_configure_settings' ) ) {
             $allowed_repos = is_array( $config['allowed_repos'] ?? null ) ? $config['allowed_repos'] : array( $target_repo );
             $profile_id    = homeboy_datamachine_agent_scalar( $config, 'github_profile_id', 'homeboy-agent-ci' );
             $profiles      = array();
-            if ( '' !== $github_token ) {
-                $profiles[] = array(
-                    'id'            => $profile_id,
-                    'label'         => 'Homeboy agent CI token',
-                    'mode'          => 'pat',
-                    'pat'           => $github_token,
-                    'default_repo'  => $target_repo,
-                    'allowed_repos' => array_values( array_unique( array_filter( array_map( 'strval', $allowed_repos ) ) ) ),
-                );
-            }
             if ( '' !== $github_repository_token ) {
                 $profiles[] = array(
                     'id'            => $profile_id . '-repository',
@@ -2606,8 +2596,18 @@ if ( ! function_exists( 'homeboy_datamachine_agent_configure_settings' ) ) {
                     'allowed_repos' => array( $target_repo ),
                 );
             }
+            if ( '' !== $github_token ) {
+                $profiles[] = array(
+                    'id'            => $profile_id,
+                    'label'         => 'Homeboy agent CI token',
+                    'mode'          => 'pat',
+                    'pat'           => $github_token,
+                    'default_repo'  => $target_repo,
+                    'allowed_repos' => array_values( array_unique( array_filter( array_map( 'strval', $allowed_repos ) ) ) ),
+                );
+            }
             $settings['github_credential_profiles'] = $profiles;
-            $settings['github_default_profile_id']  = '' !== $github_token ? $profile_id : $profile_id . '-repository';
+            $settings['github_default_profile_id']  = '' !== $github_repository_token ? $profile_id . '-repository' : $profile_id;
             $settings['github_default_repo']       = $target_repo;
         }
 

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -640,12 +640,16 @@ namespace {
     );
     $datamachine_settings = $GLOBALS['homeboy_datamachine_agent_fake_options']['datamachine_settings'] ?? array();
     $github_profiles = $datamachine_settings['github_credential_profiles'] ?? array();
-    if ( 'app-token' !== ( $github_profiles[0]['pat'] ?? '' ) || array( 'owner/repo', 'owner/other' ) !== ( $github_profiles[0]['allowed_repos'] ?? array() ) ) {
-        fwrite( STDERR, "Expected app token profile to be first and preserve cross-repo allowed repositories.\n" );
+    if ( 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) || array( 'owner/repo' ) !== ( $github_profiles[0]['allowed_repos'] ?? array() ) ) {
+        fwrite( STDERR, "Expected repository token profile to be first for same-repo GitHub operations.\n" );
         exit( 1 );
     }
-    if ( 'repository-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'owner/repo' ) !== ( $github_profiles[1]['allowed_repos'] ?? array() ) ) {
-        fwrite( STDERR, "Expected repository token profile to remain available as a target-repo fallback.\n" );
+    if ( 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'owner/repo', 'owner/other' ) !== ( $github_profiles[1]['allowed_repos'] ?? array() ) ) {
+        fwrite( STDERR, "Expected app token profile to remain available for cross-repo allowed repositories.\n" );
+        exit( 1 );
+    }
+    if ( 'smoke-ci-repository' !== ( $datamachine_settings['github_default_profile_id'] ?? '' ) ) {
+        fwrite( STDERR, "Expected repository token profile to be the default credential when available.\n" );
         exit( 1 );
     }
 


### PR DESCRIPTION
## Summary
- Prefer the workflow repository token for same-repo Data Machine agent CI GitHub operations.
- Keep the Homeboy App token available for extra allowed repositories/cross-repo operations.
- Cover profile ordering and default profile selection in the write-without-PR smoke.

## Verification
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the issue-comment credential selection failure, drafted the token precedence fix, and ran smoke tests. Chris remains responsible for review and merge.