### PR TITLE
fix(wordpress): separate agent CI token env vars

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -937,7 +937,8 @@ jobs:
       - name: Run Data Machine agent
         if: ${{ inputs.run_agent }}
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          HOMEBOY_GITHUB_APP_TOKEN: ${{ steps.app-token.outputs.token }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           PROVIDER_SECRET_1: ${{ secrets.PROVIDER_SECRET_1 }}
           PROVIDER_SECRET_2: ${{ secrets.PROVIDER_SECRET_2 }}

--- a/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
@@ -146,6 +146,10 @@ namespace {
 		fwrite( STDERR, "Expected reusable workflow to request explicit Homeboy app token write permissions.\n" );
 		exit( 1 );
 	}
+	if ( ! str_contains( $workflow_source, 'GITHUB_TOKEN: ${{ github.token }}' ) || ! str_contains( $workflow_source, 'HOMEBOY_GITHUB_APP_TOKEN: ${{ steps.app-token.outputs.token }}' ) ) {
+		fwrite( STDERR, "Expected agent runtime to receive repository and Homeboy app tokens in separate environment variables.\n" );
+		exit( 1 );
+	}
 
 	$jobs = new \DataMachine\Core\Database\Jobs\Jobs();
     $summary = homeboy_datamachine_agent_drain_child_jobs( 101, array(), $jobs );


### PR DESCRIPTION
## Summary
- Pass the workflow repository token as `GITHUB_TOKEN` to the Data Machine agent runtime.
- Pass the Homeboy App installation token separately as `HOMEBOY_GITHUB_APP_TOKEN`.
- Cover the environment mapping in the reusable workflow smoke.

## Verification
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed why agent CI still selected an under-scoped App token at runtime, drafted the env mapping fix, and ran smoke tests. Chris remains responsible for review and merge.