### PR TITLE
fix(wordpress): reserve app token for extra repos

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -2597,13 +2597,17 @@ if ( ! function_exists( 'homeboy_datamachine_agent_configure_settings' ) ) {
                 );
             }
             if ( '' !== $github_token ) {
+                $app_allowed_repos = array_values( array_unique( array_filter( array_map( 'strval', $allowed_repos ) ) ) );
+                if ( '' !== $github_repository_token ) {
+                    $app_allowed_repos = array_values( array_filter( $app_allowed_repos, static fn ( string $repo ): bool => strtolower( $repo ) !== strtolower( $target_repo ) ) );
+                }
                 $profiles[] = array(
                     'id'            => $profile_id,
                     'label'         => 'Homeboy agent CI token',
                     'mode'          => 'pat',
                     'pat'           => $github_token,
-                    'default_repo'  => $target_repo,
-                    'allowed_repos' => array_values( array_unique( array_filter( array_map( 'strval', $allowed_repos ) ) ) ),
+                    'default_repo'  => '' !== $github_repository_token ? '' : $target_repo,
+                    'allowed_repos' => $app_allowed_repos,
                 );
             }
             $settings['github_credential_profiles'] = $profiles;

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -644,8 +644,8 @@ namespace {
         fwrite( STDERR, "Expected repository token profile to be first for same-repo GitHub operations.\n" );
         exit( 1 );
     }
-    if ( 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'owner/repo', 'owner/other' ) !== ( $github_profiles[1]['allowed_repos'] ?? array() ) ) {
-        fwrite( STDERR, "Expected app token profile to remain available for cross-repo allowed repositories.\n" );
+    if ( 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'owner/other' ) !== ( $github_profiles[1]['allowed_repos'] ?? array() ) || '' !== ( $github_profiles[1]['default_repo'] ?? '' ) ) {
+        fwrite( STDERR, "Expected app token profile to remain available only for non-target allowed repositories.\n" );
         exit( 1 );
     }
     if ( 'smoke-ci-repository' !== ( $datamachine_settings['github_default_profile_id'] ?? '' ) ) {


### PR DESCRIPTION
## Summary
- Keep same-repo GitHub operations pinned to the workflow repository token when it is available.
- Remove the target repo from the Homeboy App token profile so repo-selected operations cannot choose an under-scoped App token.
- Preserve the App token for extra allowed repositories/cross-repo operations.

## Verification
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed intermittent same-repo issue-comment 403s, drafted the credential scope fix, and ran smoke tests. Chris remains responsible for review and merge.