### PR TITLE
fix(wordpress): omit empty agent CI app profiles

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -2601,14 +2601,16 @@ if ( ! function_exists( 'homeboy_datamachine_agent_configure_settings' ) ) {
                 if ( '' !== $github_repository_token ) {
                     $app_allowed_repos = array_values( array_filter( $app_allowed_repos, static fn ( string $repo ): bool => strtolower( $repo ) !== strtolower( $target_repo ) ) );
                 }
-                $profiles[] = array(
-                    'id'            => $profile_id,
-                    'label'         => 'Homeboy agent CI token',
-                    'mode'          => 'pat',
-                    'pat'           => $github_token,
-                    'default_repo'  => '' !== $github_repository_token ? '' : $target_repo,
-                    'allowed_repos' => $app_allowed_repos,
-                );
+                if ( ! empty( $app_allowed_repos ) || '' === $github_repository_token ) {
+                    $profiles[] = array(
+                        'id'            => $profile_id,
+                        'label'         => 'Homeboy agent CI token',
+                        'mode'          => 'pat',
+                        'pat'           => $github_token,
+                        'default_repo'  => '' !== $github_repository_token ? '' : $target_repo,
+                        'allowed_repos' => $app_allowed_repos,
+                    );
+                }
             }
             $settings['github_credential_profiles'] = $profiles;
             $settings['github_default_profile_id']  = '' !== $github_repository_token ? $profile_id . '-repository' : $profile_id;

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -653,5 +653,23 @@ namespace {
         exit( 1 );
     }
 
+    homeboy_datamachine_agent_configure_settings(
+        array(
+            'provider'                    => 'openai',
+            'model'                       => 'gpt-5.5',
+            'github_token_env'            => 'HOMEBOY_GITHUB_APP_TOKEN',
+            'github_repository_token_env' => 'GITHUB_TOKEN',
+            'github_profile_id'           => 'smoke-ci-target-only',
+            'target_repo'                 => 'owner/repo',
+            'allowed_repos'               => array( 'owner/repo' ),
+        )
+    );
+    $datamachine_settings = $GLOBALS['homeboy_datamachine_agent_fake_options']['datamachine_settings'] ?? array();
+    $github_profiles      = $datamachine_settings['github_credential_profiles'] ?? array();
+    if ( 1 !== count( $github_profiles ) || 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) ) {
+        fwrite( STDERR, "Expected target-only runs to omit the empty app token profile.\n" );
+        exit( 1 );
+    }
+
     fwrite( STDOUT, "Data Machine agent write-without-PR smoke passed.\n" );
 }


### PR DESCRIPTION
## Summary
- Skip registering the Homeboy App-token profile when the repository token already covers the target repo and no extra repos remain.
- Add smoke coverage for target-only runs so same-repo operations cannot accidentally select an empty App-token profile.

## Tests
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the agent CI token-selection failure, drafted the patch and smoke coverage, and ran focused verification.