### PR TITLE
fix(wordpress): tag agent CI GitHub credentials

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -2594,23 +2594,20 @@ if ( ! function_exists( 'homeboy_datamachine_agent_configure_settings' ) ) {
                     'pat'           => $github_repository_token,
                     'default_repo'  => $target_repo,
                     'allowed_repos' => array( $target_repo ),
+                    'capabilities'  => array( 'contents_write', 'issues_write' ),
                 );
             }
             if ( '' !== $github_token ) {
                 $app_allowed_repos = array_values( array_unique( array_filter( array_map( 'strval', $allowed_repos ) ) ) );
-                if ( '' !== $github_repository_token ) {
-                    $app_allowed_repos = array_values( array_filter( $app_allowed_repos, static fn ( string $repo ): bool => strtolower( $repo ) !== strtolower( $target_repo ) ) );
-                }
-                if ( ! empty( $app_allowed_repos ) || '' === $github_repository_token ) {
-                    $profiles[] = array(
-                        'id'            => $profile_id,
-                        'label'         => 'Homeboy agent CI token',
-                        'mode'          => 'pat',
-                        'pat'           => $github_token,
-                        'default_repo'  => '' !== $github_repository_token ? '' : $target_repo,
-                        'allowed_repos' => $app_allowed_repos,
-                    );
-                }
+                $profiles[] = array(
+                    'id'            => $profile_id,
+                    'label'         => 'Homeboy agent CI token',
+                    'mode'          => 'pat',
+                    'pat'           => $github_token,
+                    'default_repo'  => '' !== $github_repository_token ? '' : $target_repo,
+                    'allowed_repos' => $app_allowed_repos,
+                    'capabilities'  => array( 'pull_request_create' ),
+                );
             }
             $settings['github_credential_profiles'] = $profiles;
             $settings['github_default_profile_id']  = '' !== $github_repository_token ? $profile_id . '-repository' : $profile_id;

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -640,12 +640,12 @@ namespace {
     );
     $datamachine_settings = $GLOBALS['homeboy_datamachine_agent_fake_options']['datamachine_settings'] ?? array();
     $github_profiles = $datamachine_settings['github_credential_profiles'] ?? array();
-    if ( 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) || array( 'owner/repo' ) !== ( $github_profiles[0]['allowed_repos'] ?? array() ) ) {
+    if ( 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) || array( 'owner/repo' ) !== ( $github_profiles[0]['allowed_repos'] ?? array() ) || array( 'contents_write', 'issues_write' ) !== ( $github_profiles[0]['capabilities'] ?? array() ) ) {
         fwrite( STDERR, "Expected repository token profile to be first for same-repo GitHub operations.\n" );
         exit( 1 );
     }
-    if ( 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'owner/other' ) !== ( $github_profiles[1]['allowed_repos'] ?? array() ) || '' !== ( $github_profiles[1]['default_repo'] ?? '' ) ) {
-        fwrite( STDERR, "Expected app token profile to remain available only for non-target allowed repositories.\n" );
+    if ( 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'owner/repo', 'owner/other' ) !== ( $github_profiles[1]['allowed_repos'] ?? array() ) || array( 'pull_request_create' ) !== ( $github_profiles[1]['capabilities'] ?? array() ) || '' !== ( $github_profiles[1]['default_repo'] ?? '' ) ) {
+        fwrite( STDERR, "Expected app token profile to remain available for PR creation across allowed repositories.\n" );
         exit( 1 );
     }
     if ( 'smoke-ci-repository' !== ( $datamachine_settings['github_default_profile_id'] ?? '' ) ) {
@@ -666,8 +666,8 @@ namespace {
     );
     $datamachine_settings = $GLOBALS['homeboy_datamachine_agent_fake_options']['datamachine_settings'] ?? array();
     $github_profiles      = $datamachine_settings['github_credential_profiles'] ?? array();
-    if ( 1 !== count( $github_profiles ) || 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) ) {
-        fwrite( STDERR, "Expected target-only runs to omit the empty app token profile.\n" );
+    if ( 2 !== count( $github_profiles ) || 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) || 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'pull_request_create' ) !== ( $github_profiles[1]['capabilities'] ?? array() ) ) {
+        fwrite( STDERR, "Expected target-only runs to keep app token profile for pull request creation.\n" );
         exit( 1 );
     }
 


### PR DESCRIPTION
## Summary
- Tag repository-token profiles for contents/issues operations.
- Keep the Homeboy App-token profile available for target repos and tag it for `pull_request_create`.
- Update smoke coverage for operation-aware credential routing.

## Tests
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the agent CI credential profile gap, drafted the profile capability wiring, and ran focused smoke tests.