### PR TITLE
fix(wordpress): tag app token for issue writes

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -2606,7 +2606,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_configure_settings' ) ) {
                     'pat'           => $github_token,
                     'default_repo'  => '' !== $github_repository_token ? '' : $target_repo,
                     'allowed_repos' => $app_allowed_repos,
-                    'capabilities'  => array( 'pull_request_create' ),
+                    'capabilities'  => array( 'issues_write', 'pull_request_create' ),
                 );
             }
             $settings['github_credential_profiles'] = $profiles;

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -644,7 +644,7 @@ namespace {
         fwrite( STDERR, "Expected repository token profile to be first for same-repo GitHub operations.\n" );
         exit( 1 );
     }
-    if ( 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'owner/repo', 'owner/other' ) !== ( $github_profiles[1]['allowed_repos'] ?? array() ) || array( 'pull_request_create' ) !== ( $github_profiles[1]['capabilities'] ?? array() ) || '' !== ( $github_profiles[1]['default_repo'] ?? '' ) ) {
+    if ( 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'owner/repo', 'owner/other' ) !== ( $github_profiles[1]['allowed_repos'] ?? array() ) || array( 'issues_write', 'pull_request_create' ) !== ( $github_profiles[1]['capabilities'] ?? array() ) || '' !== ( $github_profiles[1]['default_repo'] ?? '' ) ) {
         fwrite( STDERR, "Expected app token profile to remain available for PR creation across allowed repositories.\n" );
         exit( 1 );
     }
@@ -666,7 +666,7 @@ namespace {
     );
     $datamachine_settings = $GLOBALS['homeboy_datamachine_agent_fake_options']['datamachine_settings'] ?? array();
     $github_profiles      = $datamachine_settings['github_credential_profiles'] ?? array();
-    if ( 2 !== count( $github_profiles ) || 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) || 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'pull_request_create' ) !== ( $github_profiles[1]['capabilities'] ?? array() ) ) {
+    if ( 2 !== count( $github_profiles ) || 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) || 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'issues_write', 'pull_request_create' ) !== ( $github_profiles[1]['capabilities'] ?? array() ) ) {
         fwrite( STDERR, "Expected target-only runs to keep app token profile for pull request creation.\n" );
         exit( 1 );
     }


### PR DESCRIPTION
## Summary
- Mark the Homeboy App-token profile as capable of `issues_write` as well as `pull_request_create`.
- Update smoke expectations for operation-aware issue mutation routing.

## Tests
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the remaining design-agent issue mutation failure, drafted the profile capability update, and ran focused smoke tests.