### PR TITLE
fix(wordpress): reserve issue writes for app token

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -2594,7 +2594,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_configure_settings' ) ) {
                     'pat'           => $github_repository_token,
                     'default_repo'  => $target_repo,
                     'allowed_repos' => array( $target_repo ),
-                    'capabilities'  => array( 'contents_write', 'issues_write' ),
+                    'capabilities'  => array( 'contents_write' ),
                 );
             }
             if ( '' !== $github_token ) {

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -640,7 +640,7 @@ namespace {
     );
     $datamachine_settings = $GLOBALS['homeboy_datamachine_agent_fake_options']['datamachine_settings'] ?? array();
     $github_profiles = $datamachine_settings['github_credential_profiles'] ?? array();
-    if ( 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) || array( 'owner/repo' ) !== ( $github_profiles[0]['allowed_repos'] ?? array() ) || array( 'contents_write', 'issues_write' ) !== ( $github_profiles[0]['capabilities'] ?? array() ) ) {
+    if ( 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) || array( 'owner/repo' ) !== ( $github_profiles[0]['allowed_repos'] ?? array() ) || array( 'contents_write' ) !== ( $github_profiles[0]['capabilities'] ?? array() ) ) {
         fwrite( STDERR, "Expected repository token profile to be first for same-repo GitHub operations.\n" );
         exit( 1 );
     }


### PR DESCRIPTION
## Summary
- Keep repository-token profiles scoped to contents writes only.
- Reserve `issues_write` and `pull_request_create` for the Homeboy App-token profile so issue comments/labels avoid the repository token integration limit.

## Tests
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the remaining issue-write selection problem, adjusted profile capabilities, and ran focused smoke tests.