### PR TITLE
Consume Codebox diagnostics artifacts

### DIFF
--- a/wordpress/scripts/test/parse-test-failures.php
+++ b/wordpress/scripts/test/parse-test-failures.php
@@ -259,11 +259,66 @@ function parse_wp_codebox_test_results( array $payload, string $test_results_pat
 		}
 	}
 
+	$failures = array_merge( $failures, wp_codebox_diagnostic_failures( $artifact_root, $component_path, $raw_excerpt ) );
+
 	return [
 		'failures' => $failures,
 		'total'    => $total,
 		'passed'   => $passed,
 	];
+}
+
+/**
+ * Convert generic WP Codebox artifact diagnostics into Homeboy failure entries.
+ */
+function wp_codebox_diagnostic_failures( string $artifact_root, string $component_path, string $raw_excerpt ): array {
+	$diagnostics_path = $artifact_root . '/files/diagnostics.json';
+	if ( ! is_file( $diagnostics_path ) ) {
+		return [];
+	}
+
+	$payload = json_decode( (string) file_get_contents( $diagnostics_path ), true );
+	if ( ! is_array( $payload ) || ( $payload['schema'] ?? '' ) !== 'wp-codebox/artifact-diagnostics/v1' ) {
+		return [];
+	}
+
+	$entries     = [];
+	$diagnostics = is_array( $payload['diagnostics'] ?? null ) ? $payload['diagnostics'] : [];
+	foreach ( $diagnostics as $diagnostic ) {
+		if ( ! is_array( $diagnostic ) ) {
+			continue;
+		}
+
+		$severity = strtolower( (string) ( $diagnostic['severity'] ?? 'warning' ) );
+		if ( ! in_array( $severity, [ 'error', 'warning' ], true ) ) {
+			continue;
+		}
+
+		$diagnostic_id = (string) ( $diagnostic['id'] ?? $diagnostic['type'] ?? 'wp-codebox diagnostic' );
+		$message       = (string) ( $diagnostic['message'] ?? $diagnostic['type'] ?? $diagnostic_id );
+		$file          = wp_codebox_normalize_component_path( (string) ( $diagnostic['path'] ?? '' ), $component_path );
+		$error_type    = 'WPCodebox' . ucfirst( $severity ) . 'Diagnostic';
+
+		$entries[] = [
+			'test_name'      => $diagnostic_id,
+			'test_file'      => '',
+			'error_type'     => $error_type,
+			'message'        => $message,
+			'source_file'    => $file,
+			'source_line'    => 0,
+			'test_id'        => $diagnostic_id,
+			'suite'          => 'wp-codebox-diagnostics',
+			'file'           => $file,
+			'line'           => 0,
+			'failure_type'   => $error_type,
+			'fingerprint'    => make_failure_fingerprint( $diagnostic_id, $file, 0, $error_type, $message ),
+			'stdout_excerpt' => make_output_excerpt( explode( "\n", $raw_excerpt ) ),
+			'stderr_excerpt' => '',
+			'diagnostic'     => $diagnostic,
+		];
+	}
+
+	return $entries;
 }
 
 /**

--- a/wordpress/scripts/test/parse-wp-codebox-artifacts-smoke.sh
+++ b/wordpress/scripts/test/parse-wp-codebox-artifacts-smoke.sh
@@ -45,6 +45,31 @@ cat > "$ARTIFACT_DIR/files/test-results.json" <<'JSON'
 }
 JSON
 
+cat > "$ARTIFACT_DIR/files/diagnostics.json" <<'JSON'
+{
+  "schema": "wp-codebox/artifact-diagnostics/v1",
+  "status": "reported",
+  "summary": { "total": 2, "error": 0, "warning": 1, "notice": 1, "info": 0 },
+  "diagnostics": [
+    {
+      "id": "layout-gap-1",
+      "type": "layout_fidelity_gap",
+      "severity": "warning",
+      "message": "Generated artifact lost source grid structure.",
+      "path": "/tmp/plugin/inc/Layout.php",
+      "selector": ".hero",
+      "details": { "source_report": { "html": { "element_count": 8 } } }
+    },
+    {
+      "id": "trace-note-1",
+      "type": "trace_note",
+      "severity": "notice",
+      "message": "Notice diagnostics stay out of failure sidecars."
+    }
+  ]
+}
+JSON
+
 cat > "$ARTIFACT_DIR/commands.jsonl" <<'JSONL'
 {"command":"phpunit","exitCode":1,"summary":"Tests: 3, Assertions: 4, Failures: 1, Skipped: 1."}
 JSONL
@@ -103,7 +128,7 @@ with open(sys.argv[2], encoding="utf-8") as handle:
 assert failures_payload["total"] == 3, failures_payload
 assert failures_payload["passed"] == 1, failures_payload
 failures = failures_payload["failures"]
-assert len(failures) == 1, failures
+assert len(failures) == 2, failures
 failure = failures[0]
 
 expected = {
@@ -127,6 +152,13 @@ assert len(failure.get("fingerprint", "")) == 64
 assert "commands.log" in failure.get("stdout_excerpt", "")
 assert "runtime completed" in failure.get("stdout_excerpt", "")
 assert failure.get("stderr_excerpt") == ""
+
+diagnostic_failure = failures[1]
+assert diagnostic_failure["test_id"] == "layout-gap-1", diagnostic_failure
+assert diagnostic_failure["suite"] == "wp-codebox-diagnostics", diagnostic_failure
+assert diagnostic_failure["file"] == "inc/Layout.php", diagnostic_failure
+assert diagnostic_failure["failure_type"] == "WPCodeboxWarningDiagnostic", diagnostic_failure
+assert diagnostic_failure["diagnostic"]["details"]["source_report"]["html"]["element_count"] == 8, diagnostic_failure
 
 print("wordpress parse wp-codebox artifacts smoke passed")
 PY

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -460,14 +460,20 @@ fi
 PARSE_RESULTS="${EXTENSION_PATH}/scripts/test/parse-test-results.sh"
 PARSE_FAILURES="${EXTENSION_PATH}/scripts/test/parse-test-failures.sh"
 if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ] && [ -f "$PARSE_RESULTS" ]; then
-    if [ -n "$PHPUNIT_STDOUT" ]; then
-        bash "$PARSE_RESULTS" "$PHPUNIT_STDOUT_TMPFILE" || true
-    elif [ -n "$PHPUNIT_OUTPUT" ]; then
-        bash "$PARSE_RESULTS" "$RESULT_FILE" || true
-    fi
+	if [ -f "${ARTIFACTS_DIR}/files/test-results.json" ]; then
+		bash "$PARSE_RESULTS" "$ARTIFACTS_DIR" || true
+	elif [ -n "$PHPUNIT_STDOUT" ]; then
+		bash "$PARSE_RESULTS" "$PHPUNIT_STDOUT_TMPFILE" || true
+	elif [ -n "$PHPUNIT_OUTPUT" ]; then
+		bash "$PARSE_RESULTS" "$RESULT_FILE" || true
+	fi
 fi
-if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] && [ -f "$PARSE_FAILURES" ] && [ -n "$PHPUNIT_STDOUT" ]; then
-    bash "$PARSE_FAILURES" "$PHPUNIT_STDOUT_TMPFILE" "${PLUGIN_PATH:-}" || true
+if [ -n "${HOMEBOY_TEST_FAILURES_FILE:-}" ] && [ -f "$PARSE_FAILURES" ]; then
+	if [ -f "${ARTIFACTS_DIR}/files/test-results.json" ]; then
+		bash "$PARSE_FAILURES" "$ARTIFACTS_DIR" "${PLUGIN_PATH:-}" || true
+	elif [ -n "$PHPUNIT_STDOUT" ]; then
+		bash "$PARSE_FAILURES" "$PHPUNIT_STDOUT_TMPFILE" "${PLUGIN_PATH:-}" || true
+	fi
 fi
 rm -f "$WP_CODEBOX_TMPFILE" "$PHPUNIT_STDOUT_TMPFILE"
 


### PR DESCRIPTION
## Summary
- Parse WP Codebox `files/diagnostics.json` artifacts from the WordPress test failure sidecar path.
- Surface warning/error diagnostics as `wp-codebox-diagnostics` failure entries while leaving notice/info diagnostics out of failure sidecars.
- Prefer the Codebox artifact directory for test result/failure parsing when artifact JSON is available.

## Testing
- `bash scripts/test/parse-wp-codebox-artifacts-smoke.sh`
- `bash -n scripts/test/test-runner-wp-codebox.sh scripts/test/parse-test-failures.sh`
- `php -l scripts/test/parse-test-failures.php`
- `homeboy test --path "/Users/chubes/Developer/homeboy-extensions@feat-consume-codebox-diagnostics/wordpress" --extension nodejs`

## Dependency
- Builds on the generic Codebox diagnostics contract in https://github.com/chubes4/wp-codebox/pull/391.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the Homeboy Extensions consumer for Codebox diagnostics artifacts and updated smoke coverage under Chris's direction on Codebox/Homeboy/SSI ownership boundaries.