### PR TITLE
fix(wordpress): allow agent CI issue reads

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -2606,7 +2606,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_configure_settings' ) ) {
                     'pat'           => $github_token,
                     'default_repo'  => '' !== $github_repository_token ? '' : $target_repo,
                     'allowed_repos' => $app_allowed_repos,
-                    'capabilities'  => array( 'issues_write', 'pull_request_create' ),
+                    'capabilities'  => array( 'issues_read', 'issues_write', 'pull_request_create' ),
                 );
             }
             $settings['github_credential_profiles'] = $profiles;

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -644,7 +644,7 @@ namespace {
         fwrite( STDERR, "Expected repository token profile to be first for same-repo GitHub operations.\n" );
         exit( 1 );
     }
-    if ( 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'owner/repo', 'owner/other' ) !== ( $github_profiles[1]['allowed_repos'] ?? array() ) || array( 'issues_write', 'pull_request_create' ) !== ( $github_profiles[1]['capabilities'] ?? array() ) || '' !== ( $github_profiles[1]['default_repo'] ?? '' ) ) {
+    if ( 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'owner/repo', 'owner/other' ) !== ( $github_profiles[1]['allowed_repos'] ?? array() ) || array( 'issues_read', 'issues_write', 'pull_request_create' ) !== ( $github_profiles[1]['capabilities'] ?? array() ) || '' !== ( $github_profiles[1]['default_repo'] ?? '' ) ) {
         fwrite( STDERR, "Expected app token profile to remain available for PR creation across allowed repositories.\n" );
         exit( 1 );
     }
@@ -666,7 +666,7 @@ namespace {
     );
     $datamachine_settings = $GLOBALS['homeboy_datamachine_agent_fake_options']['datamachine_settings'] ?? array();
     $github_profiles      = $datamachine_settings['github_credential_profiles'] ?? array();
-    if ( 2 !== count( $github_profiles ) || 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) || 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'issues_write', 'pull_request_create' ) !== ( $github_profiles[1]['capabilities'] ?? array() ) ) {
+    if ( 2 !== count( $github_profiles ) || 'repository-token' !== ( $github_profiles[0]['pat'] ?? '' ) || 'app-token' !== ( $github_profiles[1]['pat'] ?? '' ) || array( 'issues_read', 'issues_write', 'pull_request_create' ) !== ( $github_profiles[1]['capabilities'] ?? array() ) ) {
         fwrite( STDERR, "Expected target-only runs to keep app token profile for pull request creation.\n" );
         exit( 1 );
     }


### PR DESCRIPTION
## Summary
- Adds `issues_read` to the Data Machine Agent CI app-token profile capabilities.
- Updates smoke coverage so CI credential profiles advertise read/write issue access plus PR creation.

## Verification
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php && php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed failed Data Machine Agent CI static-site runs, implemented the profile capability fix, and ran targeted smoke/lint checks; Chris remains responsible for review and merge.