### PR TITLE
Select plugin archive headers by target basename

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -176,7 +176,7 @@
         "staging_path": "/tmp/homeboy-staging",
         "root_must_match_target_basename": true,
         "required_header": {
-          "file_glob": "*.php",
+          "file": "{{targetBasename}}.php",
           "contains": "Plugin Name:"
         }
       },


### PR DESCRIPTION
## Summary
- Updates the WordPress archive install config to verify plugin archives against `{{targetBasename}}.php`.
- Keeps WordPress-specific plugin header file selection in the WordPress extension instead of Homeboy core.
- Companion to Extra-Chill/homeboy#3222.

## Testing
- `jq empty wordpress/wordpress.json`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated the WordPress extension deploy archive config and ran targeted validation. Chris remains responsible for review and merge.