### PR TITLE
fix(wordpress): pin eslint config resolution in worktrees

### DIFF
--- a/tests/wordpress-eslint-scope-smoke.sh
+++ b/tests/wordpress-eslint-scope-smoke.sh
@@ -33,6 +33,7 @@ COMPONENT_DIR="$TMP_DIR/example-plugin"
 FAKE_EXTENSION="$TMP_DIR/fake-wordpress-extension"
 ESLINT_ARGS_FILE="$TMP_DIR/eslint-args.txt"
 FINDINGS_FILE="$TMP_DIR/eslint-findings.json"
+SIDECAR_WRITER="$TMP_DIR/sidecar-writer.sh"
 
 mkdir -p "$COMPONENT_DIR/inc" "$COMPONENT_DIR/assets" "$COMPONENT_DIR/docs" "$FAKE_EXTENSION/node_modules/.bin"
 
@@ -66,6 +67,14 @@ MD
 cat > "$FAKE_EXTENSION/.eslintrc.json" <<'JSON'
 {}
 JSON
+
+cat > "$SIDECAR_WRITER" <<'SH'
+homeboy_sidecar_merge_json_array() {
+    local target="$1"
+    local source="$2"
+    cp "$source" "$target"
+}
+SH
 
 cat > "$FAKE_EXTENSION/node_modules/.bin/eslint" <<'SH'
 #!/usr/bin/env bash
@@ -142,6 +151,9 @@ HOMEBOY_LINT_FILE='assets/admin.js' \
 
 assert_contains "$TMP_DIR/js-success.out" "Linting single file: assets/admin.js"
 assert_contains "$TMP_DIR/js-success.out" "ESLint linting passed"
+assert_contains "$ESLINT_ARGS_FILE" "--no-eslintrc"
+assert_contains "$ESLINT_ARGS_FILE" "--resolve-plugins-relative-to"
+assert_contains "$ESLINT_ARGS_FILE" "$FAKE_EXTENSION"
 assert_contains "$ESLINT_ARGS_FILE" "assets/admin.js"
 
 cat > "$COMPONENT_DIR/assets/bad.js" <<'JS'
@@ -155,6 +167,7 @@ HOMEBOY_COMPONENT_ID="example-plugin" \
 ESLINT_ARGS_FILE="$ESLINT_ARGS_FILE" \
 ESLINT_COMPONENT_DIR="$COMPONENT_DIR" \
 HOMEBOY_LINT_FINDINGS_FILE="$FINDINGS_FILE" \
+HOMEBOY_RUNTIME_SIDECAR_WRITER="$SIDECAR_WRITER" \
 HOMEBOY_LINT_FILE='assets/bad.js' \
     bash "$RUNNER" > "$TMP_DIR/js-failure.out" 2>&1
 failure_status=$?

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -155,8 +155,9 @@ if [ -n "$TEXT_DOMAIN" ] && [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Detected text domain: $TEXT_DOMAIN"
 fi
 
-# Build base ESLint arguments
-eslint_base_args=(--config "$ESLINT_CONFIG" --ext .js,.jsx,.ts,.tsx)
+# Build base ESLint arguments. Keep config and plugin resolution anchored to
+# this extension so worktree targets do not also load a primary-checkout config.
+eslint_base_args=(--no-eslintrc --config "$ESLINT_CONFIG" --resolve-plugins-relative-to "$EXTENSION_PATH" --ext .js,.jsx,.ts,.tsx)
 
 if [ -n "$TEXT_DOMAIN" ]; then
     eslint_base_args+=(--rule "@wordpress/i18n-text-domain: [error, { allowedTextDomain: \"$TEXT_DOMAIN\" }]")


### PR DESCRIPTION
## Summary
- Anchor the WordPress ESLint runner to the extension `.eslintrc.json` with `--no-eslintrc` so worktree targets do not cascade into a second checkout config.
- Resolve ESLint plugins relative to the same extension root to avoid duplicate primary/worktree dependency trees.
- Extend the ESLint scope smoke to guard the single config/dependency root invocation.

## Verification
- `bash tests/wordpress-eslint-scope-smoke.sh`
- `homeboy lint wordpress --path . --extension wordpress --changed-since origin/main`
- `bash wordpress/tests/eslint-eqeqeq-null-smoke.sh`
- `git diff --check`

Closes #974.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the duplicate ESLint config/plugin resolution failure, implemented the runner guard and smoke assertion, and ran focused verification. Chris remains responsible for review and merge.