### PR TITLE
fix: render effective agent repo scope

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -764,7 +764,7 @@ jobs:
           success_completion_outcomes_json="$(validate_json_input success_completion_outcomes array "$SUCCESS_COMPLETION_OUTCOMES")"
           allowed_repos_json="$(validate_json_input allowed_repos array "$ALLOWED_REPOS")"
           app_token_repos_json="$(jq -Rsc 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != ""))' <<< "${APP_TOKEN_REPOS:-$TARGET_REPO}")"
-          effective_allowed_repos_json="$(jq -c --arg target "$TARGET_REPO" --argjson allowed "$allowed_repos_json" --argjson appTokenRepos "$app_token_repos_json" 'if ($allowed | length) > 0 then $allowed elif ($appTokenRepos | length) > 0 then $appTokenRepos else [$target] end')"
+          effective_allowed_repos_json="$(jq -nc --arg target "$TARGET_REPO" --argjson allowed "$allowed_repos_json" --argjson appTokenRepos "$app_token_repos_json" 'if ($allowed | length) > 0 then $allowed elif ($appTokenRepos | length) > 0 then $appTokenRepos else [$target] end')"
           ability_tools_json="$(validate_json_input ability_tools array "$ABILITY_TOOLS")"
           tool_recorders_json="$(validate_json_input tool_recorders array "$TOOL_RECORDERS")"
           pipeline_step_patches_json="$(validate_json_input pipeline_step_patches array "$PIPELINE_STEP_PATCHES")"


### PR DESCRIPTION
## Summary
- Use `jq -n` when deriving the effective Data Machine Agent CI allowed repo scope from `app_token_repos`.
- Fixes the config-render failure introduced while aligning injected GitHub profiles with the App token scope.

## Testing
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/datamachine-agent-ci.yml\"); puts \"workflow yaml parsed\"'`
- Local jq reproduction for `APP_TOKEN_REPOS` to `effective_allowed_repos_json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the failed workflow config rendering and drafted the minimal jq fix; Chris remains responsible for review and merge.