### PR TITLE
Fix WordPress JS-only changed-since test routing

### DIFF
--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -27,7 +27,7 @@ assert_not_contains() {
 }
 
 component="${TMPDIR}/component"
-mkdir -p "${component}/tests/Unit" "${TMPDIR}/stubs"
+mkdir -p "${component}/tests/Unit" "${component}/wordpress/tests" "${TMPDIR}/stubs"
 
 cat > "${component}/tests/import-agent-ability-smoke.php" <<'PHP'
 <?php
@@ -38,6 +38,14 @@ cat > "${component}/tests/queue-routing-smoke.php" <<'PHP'
 <?php
 fwrite( STDOUT, "queue routing smoke ran\n" );
 PHP
+
+cat > "${component}/tests/codebox-agent-task-matrix-smoke.js" <<'JS'
+console.log('codebox agent task matrix smoke ran');
+JS
+
+cat > "${component}/wordpress/tests/codebox-agent-task-matrix-smoke.js" <<'JS'
+console.log('prefixed codebox agent task matrix smoke ran');
+JS
 
 cat > "${component}/tests/Unit/ImportAgentAbilityTest.php" <<'PHP'
 <?php
@@ -127,6 +135,44 @@ assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_BEGIN:tests/impo
 assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_BEGIN:tests/queue-routing-smoke.php"
 assert_contains "${TMPDIR}/changed-smoke-files.out" "HOST_SMOKE_SUMMARY:passed=2 failed=0"
 assert_not_contains "${TMPDIR}/changed-smoke-files.out" "WP_CODEBOX_STUB"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${TMPDIR}/stubs/wp-codebox.sh" \
+HOMEBOY_CHANGED_TEST_FILES='tests/codebox-agent-task-matrix-smoke.js' \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/changed-js-smoke-files.out"
+
+assert_contains "${TMPDIR}/changed-js-smoke-files.out" "JS_SMOKE_BEGIN:tests/codebox-agent-task-matrix-smoke.js"
+assert_contains "${TMPDIR}/changed-js-smoke-files.out" "codebox agent task matrix smoke ran"
+assert_contains "${TMPDIR}/changed-js-smoke-files.out" "JS_SMOKE_SUMMARY:passed=1 failed=0"
+assert_not_contains "${TMPDIR}/changed-js-smoke-files.out" "WP_CODEBOX_STUB"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${TMPDIR}/stubs/wp-codebox.sh" \
+HOMEBOY_CHANGED_TEST_FILES='wordpress/tests/codebox-agent-task-matrix-smoke.js' \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/changed-prefixed-js-smoke-files.out"
+
+assert_contains "${TMPDIR}/changed-prefixed-js-smoke-files.out" "JS_SMOKE_BEGIN:wordpress/tests/codebox-agent-task-matrix-smoke.js"
+assert_contains "${TMPDIR}/changed-prefixed-js-smoke-files.out" "prefixed codebox agent task matrix smoke ran"
+assert_contains "${TMPDIR}/changed-prefixed-js-smoke-files.out" "JS_SMOKE_SUMMARY:passed=1 failed=0"
+assert_not_contains "${TMPDIR}/changed-prefixed-js-smoke-files.out" "WP_CODEBOX_STUB"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${TMPDIR}/stubs/wp-codebox.sh" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/codebox-agent-task-matrix-smoke.js > "${TMPDIR}/js-smoke-file.out"
+
+assert_contains "${TMPDIR}/js-smoke-file.out" "JS_SMOKE_BEGIN:tests/codebox-agent-task-matrix-smoke.js"
+assert_contains "${TMPDIR}/js-smoke-file.out" "codebox agent task matrix smoke ran"
+assert_contains "${TMPDIR}/js-smoke-file.out" "JS_SMOKE_SUMMARY:passed=1 failed=0"
+assert_not_contains "${TMPDIR}/js-smoke-file.out" "WP_CODEBOX_STUB"
 
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -105,9 +105,94 @@ homeboy_wordpress_rel_test_file() {
     esac
 }
 
+homeboy_wordpress_run_js_smoke_files() {
+    local smoke_files_raw="$1"
+    local node_bin="${HOMEBOY_NODE_BIN:-node}"
+    local smoke_files=()
+    local smoke_file
+    local smoke_abs
+    local rel_path
+    local passed=0
+
+    while IFS= read -r smoke_file; do
+        [ -n "$smoke_file" ] || continue
+        if ! smoke_abs="$(homeboy_wordpress_rel_test_file "$smoke_file")"; then
+            echo "ERROR: requested JS smoke file not found or outside the component: ${smoke_file}" >&2
+            exit 2
+        fi
+        smoke_files+=("${PLUGIN_PATH}/${smoke_abs}")
+    done <<< "$smoke_files_raw"
+
+    if [ "${#smoke_files[@]}" -eq 0 ]; then
+        echo "ERROR: no JS smoke files were selected" >&2
+        exit 2
+    fi
+
+    echo "Running host JS smoke tests..."
+    echo "  Component: ${HOMEBOY_COMPONENT_ID:-$(basename "$PLUGIN_PATH")} (${PLUGIN_PATH})"
+    echo "  Backend: host-js-smoke"
+    echo "  Files: ${#smoke_files[@]}"
+    echo ""
+
+    for smoke_file in "${smoke_files[@]}"; do
+        rel_path="${smoke_file#"${PLUGIN_PATH}/"}"
+        echo "JS_SMOKE_BEGIN:${rel_path}"
+        if "$node_bin" "$smoke_file"; then
+            echo "JS_SMOKE_OK:${rel_path}"
+            passed=$((passed + 1))
+        else
+            exit_code=$?
+            echo "JS_SMOKE_FAIL:${rel_path}:exit=${exit_code}"
+            echo ""
+            echo "JS smoke test failed: ${rel_path}"
+            exit "$exit_code"
+        fi
+    done
+
+    echo ""
+    echo "JS_SMOKE_SUMMARY:passed=${passed} failed=0"
+    echo "Host JS smoke test run complete."
+}
+
+homeboy_wordpress_is_js_smoke_file() {
+    case "$1" in
+        tests/*-smoke.js|tests/*/*-smoke.js|tests/*/*/*-smoke.js|tests/*/*/*/*-smoke.js|wordpress/tests/*-smoke.js|wordpress/tests/*/*-smoke.js|wordpress/tests/*/*/*-smoke.js|wordpress/tests/*/*/*/*-smoke.js)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 if [ -z "$TARGET_FILE" ] && [ "${HOMEBOY_TEST_SCOPE_KIND:-}" = "exclusive_env" ]; then
     if [ "${HOMEBOY_TEST_SCOPE_ENV_NAME:-}" = "HOMEBOY_WORDPRESS_HOST_SMOKE_FILES" ] && [ -n "${HOMEBOY_TEST_SCOPE_ENV_VALUE:-}" ]; then
         HOMEBOY_WORDPRESS_HOST_SMOKE_FILES="$HOMEBOY_TEST_SCOPE_ENV_VALUE" exec bash "$HOST_SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
+    fi
+fi
+
+if [ -z "$TARGET_FILE" ] && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
+    changed_js_smoke_files=""
+    changed_non_js_smoke_files=0
+    while IFS= read -r changed_test_file; do
+        [ -n "$changed_test_file" ] || continue
+        if ! changed_test_rel="$(homeboy_wordpress_rel_test_file "$changed_test_file")"; then
+            changed_non_js_smoke_files=1
+            continue
+        fi
+        if homeboy_wordpress_is_js_smoke_file "$changed_test_rel"; then
+            if [ -n "$changed_js_smoke_files" ]; then
+                changed_js_smoke_files+=$'\n'
+            fi
+            changed_js_smoke_files+="$changed_test_rel"
+        else
+            changed_non_js_smoke_files=1
+        fi
+    done <<< "$HOMEBOY_CHANGED_TEST_FILES"
+
+    if [ -n "$changed_js_smoke_files" ] && [ "$changed_non_js_smoke_files" -eq 0 ]; then
+        homeboy_wordpress_run_js_smoke_files "$changed_js_smoke_files"
+        exit 0
     fi
 fi
 
@@ -134,6 +219,11 @@ if [ -n "$TARGET_FILE" ]; then
     esac
 
     target_base="$(basename "$target_rel")"
+    if homeboy_wordpress_is_js_smoke_file "$target_rel"; then
+        homeboy_wordpress_run_js_smoke_files "$target_rel"
+        exit 0
+    fi
+
     case "$target_rel" in
         tests/*.php|tests/*/*.php|tests/*/*/*.php|tests/*/*/*/*.php)
             case "$target_base" in


### PR DESCRIPTION
## Summary
- Route JS-only WordPress changed-since test selections matching `tests/**/*-smoke.js` or `wordpress/tests/**/*-smoke.js` through a host Node smoke path instead of the WP Codebox/PHPUnit backend.
- Keep mixed selections on the existing PHPUnit path so PHP tests still use the WP Codebox runner.
- Add router smoke coverage for both component-root and repo-root JS smoke paths.

Fixes #973.

## Verification
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `HOMEBOY_CHANGED_TEST_FILES='tests/codebox-agent-task-matrix-smoke.js' HOMEBOY_COMPONENT_ID=wordpress HOMEBOY_COMPONENT_PATH=/Users/chubes/Developer/homeboy-extensions@fix-issue-973-js-changed-since-routing/wordpress HOMEBOY_COMPONENT_SHAPE=plugin HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX=/bin/false bash wordpress/scripts/test/test-runner.sh`
- `node wordpress/tests/codebox-agent-task-matrix-smoke.js`
- `homeboy test wordpress --path . --extension wordpress --changed-since origin/main`
- Temporarily relinked local `wordpress` extension to this worktree, then restored it, and ran: `HOMEBOY_DEBUG=1 homeboy test wordpress --path . --extension wordpress --changed-since 4dd65e35^`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the JS-only changed-since routing fix, added focused smoke coverage, and ran local validation; Chris remains responsible for review and merge.