### PR TITLE
Bound Codebox agent task execution

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -44,8 +44,9 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   assertAgentTaskRequest(request);
   const config = request.executor.config || {};
   const inputs = request.inputs || {};
+  const timeoutSeconds = request.limits?.task_timeout_seconds || request.limits?.taskTimeoutSeconds;
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
-  const timeoutSeconds = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
+  const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
 
   return {
     schema: WP_CODEBOX_TASK_REQUEST_SCHEMA,
@@ -56,7 +57,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     provider_plugin_paths: config.provider_plugin_paths || options.providerPluginPaths || [],
     secret_env: config.secret_env || options.secretEnv || [],
     max_turns: config.max_turns || options.maxTurns,
-    task_timeout_seconds: config.task_timeout_seconds || timeoutSeconds || options.taskTimeoutSeconds,
+    task_timeout_seconds: config.task_timeout_seconds || timeoutSeconds || timeoutFromMs || options.taskTimeoutSeconds,
     orchestrator: {
       ...(inputs.orchestrator || {}),
       agent_task_id: request.task_id,

--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -43,19 +43,34 @@ function readRequest() {
   return JSON.parse(raw);
 }
 
+function requestTimeoutMs(request) {
+  const timeout = request?.limits?.timeout_ms || request?.limits?.max_runtime_ms;
+  const parsed = Number.parseInt(timeout, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 function runTaskRunner(request) {
   const runner = argValue('--task-runner') || `${__dirname}/homeboy-wp-codebox-task-runner.cjs`;
+  const config = request.executor?.config || {};
+  const configArgs = [
+    ['--agents-api', config.agents_api_path || config.agentsApiPath],
+    ['--data-machine', config.data_machine_path || config.dataMachinePath],
+    ['--data-machine-code', config.data_machine_code_path || config.dataMachineCodePath],
+    ['--homeboy', config.homeboy_path || config.homeboyPath],
+    ['--homeboy-extensions', config.homeboy_extensions_path || config.homeboyExtensionsPath],
+  ].flatMap(([name, value]) => (value ? [name, value] : []));
   const args = process.argv.slice(2).filter((arg, index, all) => {
     if (arg === '--task-runner' || all[index - 1] === '--task-runner' || arg === '--print-contract') {
       return false;
     }
     return true;
   });
-  const result = spawnSync(process.execPath, [runner, ...args], {
+  const result = spawnSync(process.execPath, [runner, ...args, ...configArgs], {
     encoding: 'utf8',
     input: JSON.stringify(codeboxTaskRequestFromAgentTaskRequest(request)),
     env: process.env,
     maxBuffer: 1024 * 1024 * 20,
+    timeout: requestTimeoutMs(request),
   });
 
   if (result.stderr) {
@@ -63,6 +78,19 @@ function runTaskRunner(request) {
   }
 
   let payload = {};
+  if (result.error && result.error.code === 'ETIMEDOUT') {
+    payload = {
+      success: false,
+      timeout: true,
+      summary: `WP Codebox agent task timed out after ${requestTimeoutMs(request)}ms.`,
+      diagnostics: [{
+        class: 'codebox.timeout',
+        message: 'Task runner exceeded the AgentTaskRequest timeout.',
+        data: { timeout_ms: requestTimeoutMs(request) },
+      }],
+    };
+    return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: 1 });
+  }
   if (result.stdout.trim()) {
     try {
       payload = JSON.parse(result.stdout);

--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -51,7 +51,7 @@ function requestTimeoutMs(request) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
-function timeoutPayload(request, timeoutMs) {
+function timeoutPayload(timeoutMs) {
   const artifacts = argValue('--artifacts');
   const evidencePath = artifacts ? `${artifacts}/homeboy-codebox-task-runner.json` : '';
   const knownArtifacts = [];
@@ -121,7 +121,7 @@ function runTaskRunner(request) {
 
   let payload = {};
   if (result.error && result.error.code === 'ETIMEDOUT') {
-    payload = timeoutPayload(request, requestTimeoutMs(request));
+    payload = timeoutPayload(requestTimeoutMs(request));
     return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: 1 });
   }
   if (result.stdout.trim()) {

--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -44,9 +44,51 @@ function readRequest() {
 }
 
 function requestTimeoutMs(request) {
-  const timeout = request?.limits?.timeout_ms || request?.limits?.max_runtime_ms;
+  const timeoutMs = request?.limits?.timeout_ms || request?.limits?.max_runtime_ms;
+  const timeoutSeconds = request?.limits?.task_timeout_seconds || request?.limits?.taskTimeoutSeconds;
+  const timeout = timeoutMs || (timeoutSeconds ? Number.parseInt(timeoutSeconds, 10) * 1000 : undefined);
   const parsed = Number.parseInt(timeout, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function timeoutPayload(request, timeoutMs) {
+  const artifacts = argValue('--artifacts');
+  const evidencePath = artifacts ? `${artifacts}/homeboy-codebox-task-runner.json` : '';
+  const knownArtifacts = [];
+  if (artifacts) {
+    knownArtifacts.push({
+      id: 'homeboy-codebox-artifacts',
+      kind: 'codebox-artifact-directory',
+      path: artifacts,
+      metadata: { evidencePath },
+    });
+  }
+  if (evidencePath && fs.existsSync(evidencePath)) {
+    knownArtifacts.push({
+      id: 'homeboy-codebox-task-runner-preflight',
+      kind: 'codebox-task-runner-preflight',
+      path: evidencePath,
+      metadata: { artifacts },
+    });
+  }
+
+  return {
+    success: false,
+    timeout: true,
+    summary: `WP Codebox agent task timed out after ${timeoutMs}ms.`,
+    artifacts: knownArtifacts,
+    evidence_refs: evidencePath && fs.existsSync(evidencePath) ? [{
+      kind: 'codebox-task-runner-preflight',
+      uri: evidencePath,
+      label: 'WP Codebox task runner preflight evidence',
+    }] : [],
+    diagnostics: [{
+      class: 'codebox.timeout',
+      message: 'Task runner exceeded the AgentTaskRequest timeout.',
+      data: { timeout_ms: timeoutMs, artifacts, evidence_path: evidencePath },
+    }],
+    metadata: { timeout_ms: timeoutMs, artifacts, evidence_path: evidencePath },
+  };
 }
 
 function runTaskRunner(request) {
@@ -79,16 +121,7 @@ function runTaskRunner(request) {
 
   let payload = {};
   if (result.error && result.error.code === 'ETIMEDOUT') {
-    payload = {
-      success: false,
-      timeout: true,
-      summary: `WP Codebox agent task timed out after ${requestTimeoutMs(request)}ms.`,
-      diagnostics: [{
-        class: 'codebox.timeout',
-        message: 'Task runner exceeded the AgentTaskRequest timeout.',
-        data: { timeout_ms: requestTimeoutMs(request) },
-      }],
-    };
+    payload = timeoutPayload(request, requestTimeoutMs(request));
     return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: 1 });
   }
   if (result.stdout.trim()) {

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -258,6 +258,11 @@ function writeRecipe(recipe) {
   return recipePath;
 }
 
+function requestTimeoutMs(request) {
+  const seconds = Number.parseInt(request.task_timeout_seconds || request.taskTimeoutSeconds || argValue('--task-timeout-seconds'), 10);
+  return Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : undefined;
+}
+
 function executable(filePath) {
   try {
     fs.accessSync(filePath, fs.constants.X_OK);
@@ -274,7 +279,44 @@ function resolveCommand(command, args) {
   return { command, args };
 }
 
-function runWpCodebox(recipePath) {
+function writePreflightEvidence(artifacts, evidence) {
+  try {
+    fs.mkdirSync(artifacts, { recursive: true });
+    const evidencePath = path.join(artifacts, 'homeboy-codebox-task-runner.json');
+    fs.writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`);
+    return evidencePath;
+  } catch {
+    return '';
+  }
+}
+
+function timeoutPayload(timeoutMs, artifacts, evidencePath, recipePath, command, args) {
+  const artifact = evidencePath ? [{
+    id: 'homeboy-codebox-task-runner-preflight',
+    kind: 'codebox-task-runner-preflight',
+    path: evidencePath,
+    metadata: { recipePath, artifacts, command, args },
+  }] : [];
+  return {
+    success: false,
+    timeout: true,
+    summary: `WP Codebox recipe-run timed out after ${timeoutMs}ms.`,
+    artifacts: artifact,
+    evidence_refs: evidencePath ? [{
+      kind: 'codebox-task-runner-preflight',
+      uri: evidencePath,
+      label: 'WP Codebox task runner preflight evidence',
+    }] : [],
+    diagnostics: [{
+      class: 'codebox.recipe_run.timeout',
+      message: 'wp-codebox recipe-run exceeded the configured task timeout.',
+      data: { timeout_ms: timeoutMs, recipePath, artifacts },
+    }],
+    metadata: { timeout_ms: timeoutMs, recipePath, artifacts, command, args },
+  };
+}
+
+function runWpCodebox(recipePath, request) {
   const wpCodeboxBin = argValue('--wp-codebox-bin') || 'wp-codebox';
   const args = ['recipe-run', '--recipe', recipePath, '--json'];
   const explicitArtifacts = argValue('--artifacts');
@@ -298,11 +340,28 @@ function runWpCodebox(recipePath) {
   }
 
   const resolved = resolveCommand(wpCodeboxBin, args);
+  const timeoutMs = requestTimeoutMs(request);
+  const evidencePath = writePreflightEvidence(artifacts, {
+    schema: 'homeboy/wp-codebox-task-runner-preflight/v1',
+    recipePath,
+    artifacts,
+    command: resolved.command,
+    args: resolved.args,
+    timeout_ms: timeoutMs,
+    task_id: request.orchestrator?.agent_task_id,
+    sandbox_session_id: request.sandbox_session_id,
+  });
   const result = spawnSync(resolved.command, resolved.args, {
     encoding: 'utf8',
     env: process.env,
     maxBuffer: 1024 * 1024 * 20,
+    timeout: timeoutMs,
   });
+
+  if (result.error && result.error.code === 'ETIMEDOUT') {
+    process.stdout.write(`${JSON.stringify(timeoutPayload(timeoutMs, artifacts, evidencePath, recipePath, resolved.command, resolved.args), null, 2)}\n`);
+    return 1;
+  }
 
   if (result.stdout) {
     process.stdout.write(result.stdout);
@@ -333,7 +392,7 @@ try {
     console.error(JSON.stringify({ recipePath, recipe }, null, 2));
   }
 
-  process.exitCode = runWpCodebox(recipePath);
+  process.exitCode = runWpCodebox(recipePath, request);
 } catch (error) {
   console.error(error && error.message ? error.message : String(error));
   process.exitCode = 1;

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -90,6 +90,11 @@ assert.equal(codeboxRequest.task.expected_artifacts[0], 'screenshot');
 assert.equal(codeboxRequest.orchestrator.agent_task_id, 'task-123');
 assert.equal(codeboxRequest.audit_findings[0].id, 'finding-1');
 
+assert.equal(codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  limits: { task_timeout_seconds: 7 },
+}).task_timeout_seconds, 7);
+
 const outcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: false,
   provider_error: true,
@@ -137,25 +142,31 @@ try {
   assert.equal(contractResult.status, 0, contractResult.stderr || contractResult.stdout);
   assert.equal(JSON.parse(contractResult.stdout).id, 'wordpress.codebox-agent-task-executor');
 
+  const artifactRoot = path.join(root, 'timeout-artifacts');
   const hangingRequest = {
     ...request,
     task_id: 'task-timeout',
-    limits: { timeout_ms: 50 },
+    limits: { task_timeout_seconds: 1 },
   };
   const timeoutResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
     '--task-runner',
     writeHangingTaskRunner(root),
+    '--artifacts',
+    artifactRoot,
   ], {
     encoding: 'utf8',
     input: JSON.stringify(hangingRequest),
-    timeout: 2000,
+    timeout: 3000,
   });
   assert.equal(timeoutResult.status, 1, timeoutResult.stderr || timeoutResult.stdout);
   const timeoutOutcome = JSON.parse(timeoutResult.stdout);
   assert.equal(timeoutOutcome.status, 'timeout');
   assert.equal(timeoutOutcome.failure_classification, 'timeout');
   assert.equal(timeoutOutcome.diagnostics[0].class, 'codebox.timeout');
+  assert.equal(timeoutOutcome.diagnostics[0].data.timeout_ms, 1000);
+  assert.equal(timeoutOutcome.artifacts[0].path, artifactRoot);
+  assert.equal(timeoutOutcome.metadata.codebox.evidence_path, path.join(artifactRoot, 'homeboy-codebox-task-runner.json'));
 } finally {
   fs.rmSync(root, { recursive: true, force: true });
 }

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -32,6 +32,16 @@ process.stdout.write(JSON.stringify({
   return { fixture, capture };
 }
 
+function writeHangingTaskRunner(root) {
+  const fixture = path.join(root, 'hanging-task-runner.cjs');
+  fs.writeFileSync(fixture, `#!/usr/bin/env node
+'use strict';
+setInterval(() => {}, 1000);
+`);
+  fs.chmodSync(fixture, 0o755);
+  return fixture;
+}
+
 const request = {
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'task-123',
@@ -126,6 +136,26 @@ try {
   ], { encoding: 'utf8' });
   assert.equal(contractResult.status, 0, contractResult.stderr || contractResult.stdout);
   assert.equal(JSON.parse(contractResult.stdout).id, 'wordpress.codebox-agent-task-executor');
+
+  const hangingRequest = {
+    ...request,
+    task_id: 'task-timeout',
+    limits: { timeout_ms: 50 },
+  };
+  const timeoutResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+    '--task-runner',
+    writeHangingTaskRunner(root),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(hangingRequest),
+    timeout: 2000,
+  });
+  assert.equal(timeoutResult.status, 1, timeoutResult.stderr || timeoutResult.stdout);
+  const timeoutOutcome = JSON.parse(timeoutResult.stdout);
+  assert.equal(timeoutOutcome.status, 'timeout');
+  assert.equal(timeoutOutcome.failure_classification, 'timeout');
+  assert.equal(timeoutOutcome.diagnostics[0].class, 'codebox.timeout');
 } finally {
   fs.rmSync(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- Allow Codebox agent-task requests to provide dependency paths through `executor.config`, so Homeboy core can dispatch provider commands via stdin without knowing WordPress-specific CLI args.
- Enforce timeout bounds around both the top-level task runner and `wp-codebox recipe-run`, including `limits.task_timeout_seconds`.
- Write preflight evidence before launching WP Codebox and return structured timeout outcomes with artifacts/evidence refs, including known artifact/preflight paths when the outer runner times out.

Fixes #980
Refs Extra-Chill/homeboy#3234

## Verification
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node --check wordpress/lib/codebox-agent-task-executor.js`
- `node --check wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs`
- `node --check wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs`
- `homeboy audit --path . --extension wordpress --changed-since origin/main --json-summary`
- Live validation with `homeboy agent-task run-plan` returned two structured `timeout` outcomes with `codebox-task-runner-preflight` artifacts instead of hanging.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented timeout/evidence handling, request-config path forwarding, tests, and live validation commands; Chris remains responsible for review and merge.