### PR TITLE
Prove Codebox Codex task requests

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -110,6 +110,22 @@ function failureClassificationForStatus(status) {
   return undefined;
 }
 
+function sanitizePublicMetadata(value) {
+  if (Array.isArray(value)) {
+    return value.map(sanitizePublicMetadata);
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.fromEntries(Object.entries(value).map(([key, entry]) => {
+    if (/^(secret_env_values|secretEnvValues|secrets)$/i.test(key)) {
+      return [key, '[redacted]'];
+    }
+    return [key, sanitizePublicMetadata(entry)];
+  }));
+}
+
 function artifactFromCodeboxArtifact(artifact, index) {
   const id = artifact.id || artifact.sha256 || artifact.path || artifact.url || `codebox-artifact-${index + 1}`;
   return {
@@ -122,7 +138,7 @@ function artifactFromCodeboxArtifact(artifact, index) {
     mime: artifact.mime,
     size_bytes: artifact.size_bytes,
     sha256: artifact.sha256,
-    metadata: artifact.metadata || {},
+    metadata: sanitizePublicMetadata(artifact.metadata || {}),
   };
 }
 
@@ -160,7 +176,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     })),
     metadata: {
       provider: 'wordpress.codebox-agent-task-executor',
-      codebox: result.metadata || result,
+      codebox: sanitizePublicMetadata(result.metadata || result),
       upstream_dependency: 'https://github.com/chubes4/wp-codebox/issues/392',
     },
   };

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -172,7 +172,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     diagnostics: (result.diagnostics || []).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
       message: diagnostic.message || String(diagnostic),
-      data: diagnostic.data || {},
+      data: sanitizePublicMetadata(diagnostic.data || {}),
     })),
     metadata: {
       provider: 'wordpress.codebox-agent-task-executor',

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -145,12 +145,22 @@ const codexOutcome = agentTaskOutcomeFromCodeboxResult(request, {
       AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'codex-refresh-token-value',
     },
   },
+  diagnostics: [{
+    class: 'codex',
+    message: 'Codex token diagnostics.',
+    data: {
+      secretEnvValues: {
+        AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'diagnostic-access-token-value',
+      },
+    },
+  }],
 });
 const serializedCodexOutcome = JSON.stringify(codexOutcome);
 assert(serializedCodexOutcome.includes('AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN'));
 assert(!serializedCodexOutcome.includes('codex-access-token-value'));
 assert(!serializedCodexOutcome.includes('codex-refresh-token-value'));
 assert(!serializedCodexOutcome.includes('artifact-access-token-value'));
+assert(!serializedCodexOutcome.includes('diagnostic-access-token-value'));
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-agent-task-executor-'));
 try {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -80,6 +80,39 @@ assert.equal(codeboxRequest.task.expected_artifacts[0], 'screenshot');
 assert.equal(codeboxRequest.orchestrator.agent_task_id, 'task-123');
 assert.equal(codeboxRequest.audit_findings[0].id, 'finding-1');
 
+const codexAgentRequest = {
+  ...request,
+  task_id: 'codex-task-123',
+  executor: {
+    backend: 'codebox',
+    model: 'gpt-5.5',
+    config: {
+      provider: 'codex',
+      provider_plugin_paths: ['/components/ai-provider-for-openai'],
+      secret_env: [
+        'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+        'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+        'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+        'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+        'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+      ],
+      max_turns: 8,
+    },
+  },
+};
+const codexRequest = codeboxTaskRequestFromAgentTaskRequest(codexAgentRequest);
+assert.equal(codexRequest.provider, 'codex');
+assert.equal(codexRequest.model, 'gpt-5.5');
+assert.deepEqual(codexRequest.provider_plugin_paths, ['/components/ai-provider-for-openai']);
+assert.deepEqual(codexRequest.secret_env, [
+  'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+  'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+  'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+]);
+assert(!JSON.stringify(codexRequest).includes('wp-ai-gateway'));
+
 const outcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: false,
   provider_error: true,
@@ -92,6 +125,32 @@ assert.equal(outcome.status, 'provider_error');
 assert.equal(outcome.failure_classification, 'provider');
 assert.equal(outcome.artifacts[0].id, 'bundle-1');
 assert.equal(outcome.artifacts[0].path, '/tmp/artifacts');
+
+const codexOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  summary: 'Codex task completed.',
+  artifacts: [{
+    id: 'codex-artifact-1',
+    metadata: {
+      secretEnvValues: {
+        AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'artifact-access-token-value',
+      },
+    },
+  }],
+  metadata: {
+    provider: 'codex',
+    secret_env: ['AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN'],
+    secret_env_values: {
+      AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'codex-access-token-value',
+      AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'codex-refresh-token-value',
+    },
+  },
+});
+const serializedCodexOutcome = JSON.stringify(codexOutcome);
+assert(serializedCodexOutcome.includes('AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN'));
+assert(!serializedCodexOutcome.includes('codex-access-token-value'));
+assert(!serializedCodexOutcome.includes('codex-refresh-token-value'));
+assert(!serializedCodexOutcome.includes('artifact-access-token-value'));
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-agent-task-executor-'));
 try {
@@ -119,6 +178,31 @@ try {
   const captured = JSON.parse(fs.readFileSync(capture, 'utf8'));
   assert.equal(captured.request.schema, 'homeboy/wp-codebox-task-request/v1');
   assert.equal(captured.request.orchestrator.agent_task_id, 'task-123');
+
+  const codexResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+    '--task-runner',
+    fixture,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...codexAgentRequest,
+      task_id: 'codex-cli-task-123',
+    }),
+  });
+  assert.equal(codexResult.status, 0, codexResult.stderr || codexResult.stdout);
+  const capturedCodex = JSON.parse(fs.readFileSync(capture, 'utf8'));
+  assert.equal(capturedCodex.request.provider, 'codex');
+  assert.equal(capturedCodex.request.model, 'gpt-5.5');
+  assert.deepEqual(capturedCodex.request.provider_plugin_paths, ['/components/ai-provider-for-openai']);
+  assert.deepEqual(capturedCodex.request.secret_env, [
+    'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+    'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+    'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+    'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+    'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+  ]);
+  assert(!JSON.stringify(capturedCodex).includes('wp-ai-gateway'));
 
   const contractResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -51,6 +51,9 @@ try {
   const providerPluginPath = path.join(root, 'example-provider@feature-branch');
   fs.mkdirSync(providerPluginPath, { recursive: true });
   fs.writeFileSync(path.join(providerPluginPath, 'provider-main.php'), '<?php\n/**\n * Plugin Name: Example Provider\n */');
+  const codexProviderPluginPath = path.join(root, 'ai-provider-for-openai');
+  fs.mkdirSync(codexProviderPluginPath, { recursive: true });
+  fs.writeFileSync(path.join(codexProviderPluginPath, 'ai-provider-for-openai.php'), '<?php\n/**\n * Plugin Name: AI Provider for OpenAI\n */');
   const request = {
     schema: 'homeboy/wp-codebox-task-request/v1',
     sandbox_session_id: 'homeboy-audit-fixture-session',
@@ -171,6 +174,56 @@ try {
   assert.equal(task.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/775');
   assert.equal(task.audit_findings[0].id, 'finding-1');
   assert.match(task.task.prompt, /`agents-api`, `homeboy`, `homeboy-extensions`/);
+
+  const codexCapturePath = path.join(root, 'capture-codex.json');
+  const codexSecretEnv = [
+    'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+    'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+    'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+    'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+    'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+  ];
+  const codexResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin',
+    fixtureWpCodebox,
+    '--agents-api',
+    '/components/agents-api',
+    '--data-machine',
+    '/components/data-machine',
+    '--data-machine-code',
+    '/components/data-machine-code',
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      provider: 'codex',
+      model: 'gpt-5.5',
+      provider_plugin_paths: [codexProviderPluginPath],
+      secret_env: codexSecretEnv,
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: codexCapturePath,
+      AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'access-token-value',
+      AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'refresh-token-value',
+      AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '4102444800',
+      AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'account-id-value',
+      AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
+    },
+  });
+  assert.equal(codexResult.status, 0, codexResult.stderr || codexResult.stdout);
+  const codexRecipe = readJson(codexCapturePath).recipe;
+  assert.deepEqual(codexRecipe.inputs.secretEnv, codexSecretEnv);
+  assert.equal(codexRecipe.inputs.extraPlugins[3].slug, 'ai-provider-for-openai');
+  assert.equal(codexRecipe.inputs.extraPlugins[3].pluginFile, 'ai-provider-for-openai/ai-provider-for-openai.php');
+  assert.equal(codexRecipe.workflow.steps[0].args.includes('provider=codex'), true);
+  assert.equal(codexRecipe.workflow.steps[0].args.includes('model=gpt-5.5'), true);
+  assert.equal(codexRecipe.workflow.steps[0].args.includes('provider-plugin-slugs=ai-provider-for-openai'), true);
+  const serializedCodexRecipe = JSON.stringify(codexRecipe);
+  assert(!serializedCodexRecipe.includes('access-token-value'));
+  assert(!serializedCodexRecipe.includes('refresh-token-value'));
+  assert(!serializedCodexRecipe.includes('wp-ai-gateway'));
 
   const nonExecutableCapturePath = path.join(root, 'capture-non-executable.json');
   const nonExecutableFixture = createFixtureWpCodebox(root, 0o644);


### PR DESCRIPTION
## Summary
- Adds Codex-shaped coverage for the WP Codebox agent-task executor request conversion: `provider=codex`, `model=gpt-5.5`, `ai-provider-for-openai` provider plugin paths, and `AI_PROVIDER_OPENAI_CODEX_*` secret env names.
- Extends the WP Codebox task-runner smoke to prove the generated recipe carries Codex provider plugin inheritance and secret env names without introducing `wp-ai-gateway`.
- Redacts secret value containers from public Codebox outcome/artifact/diagnostic metadata while keeping secret env names visible for diagnostics.

Fixes #979.

## Evidence
- `node wordpress/tests/codebox-agent-task-executor-smoke.js` passed.
- `node wordpress/tests/wp-codebox-task-runner-smoke.js` passed.
- `node --check wordpress/lib/codebox-agent-task-executor.js && node --check wordpress/tests/codebox-agent-task-executor-smoke.js && node --check wordpress/tests/wp-codebox-task-runner-smoke.js` passed.
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-codex-codebox-proof-979 --extension wordpress --changed-since origin/main` passed with the changed JS smoke files selected, but the current WordPress runner reported zero PHPUnit tests instead of re-running the JS smokes; the Node smoke commands above are the authoritative verification for this proof.
- Earlier broad `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-codex-codebox-proof-979/wordpress --extension wordpress` failed in existing Playground/PHPUnit fixture coverage unrelated to this change: 9 failures in drop-in coexistence, init lifecycle, schema scope, and dep activation/plugin-loaded fixtures.

## Codebox inheritance status
- Homeboy now proves the Codebox request and recipe include the provider plugin path and `AI_PROVIDER_OPENAI_CODEX_*` secret env names needed for connector inheritance.
- Live sandbox inheritance still depends on WP Codebox honoring those inherited connector provider plugin paths; chubes4/wp-codebox#395 remains open and clean: https://github.com/chubes4/wp-codebox/pull/395

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused smoke coverage, metadata redaction, local verification commands, and PR description; Chris remains responsible for review and merge.