### PR TITLE
fix(wordpress): make phpcs-ignore-fixer string-literal-aware (closes #981)

### DIFF
--- a/wordpress/scripts/lint/php-fixers/phpcs-ignore-fixer.php
+++ b/wordpress/scripts/lint/php-fixers/phpcs-ignore-fixer.php
@@ -340,9 +340,26 @@ function apply_ignores_to_file( string $filepath, array $messages, array $sniff_
 		} else {
 			// Multi-line block OR inside a string: wrap with phpcs:disable/enable.
 			// Find the statement boundaries (the $wpdb-> call and its closing ;).
-			$stmt_start = find_statement_start( $lines, $start_idx );
-			$end_idx    = $block['end'] - 1;
-			$stmt_end   = find_statement_end( $lines, $end_idx );
+			//
+			// Token-aware boundary detection: when the violation line sits inside a
+			// multi-line string literal (e.g. a SQL string in $wpdb->prepare()), the
+			// real statement terminator is the closing `);` of the whole call — NOT
+			// the first interior line that happens to end in `;`/`);`. We tokenize
+			// the file and walk paren depth back to zero, skipping the contents of
+			// string-literal tokens entirely, so the phpcs:enable marker can never
+			// land inside a string literal (issue #981).
+			$boundaries = find_statement_boundaries_tokenized( $lines, $start_idx, $block['end'] - 1 );
+
+			if ( null !== $boundaries ) {
+				$stmt_start = $boundaries['start'];
+				$stmt_end   = $boundaries['end'];
+			} else {
+				// Fallback to legacy line-based heuristics for cases the tokenizer
+				// could not resolve (preserves prior behavior for non-string cases).
+				$stmt_start = find_statement_start( $lines, $start_idx );
+				$end_idx    = $block['end'] - 1;
+				$stmt_end   = find_statement_end( $lines, $end_idx );
+			}
 
 			preg_match( '/^(\s*)/', $lines[ $stmt_start ], $m );
 			$indent = $m[1] ?? '';
@@ -409,6 +426,174 @@ function is_inside_multiline_string( array $lines, int $idx ): bool {
 	}
 
 	return false;
+}
+
+/**
+ * Find the real statement boundaries containing a violation, using the PHP
+ * token stream so string-literal contents are never mistaken for code.
+ *
+ * This is the string-literal-aware replacement for the legacy line-based
+ * find_statement_start()/find_statement_end() heuristics. It exists to fix
+ * issue #981: a multi-line SQL string in $wpdb->prepare()/$wpdb->query() has
+ * no real statement terminator until the closing `);` of the whole call, but
+ * the regex heuristics matched an interior line ending in `;`/`);` and spliced
+ * the `// phpcs:enable` marker INSIDE the string literal — producing invalid
+ * runtime SQL (MariaDB 1064).
+ *
+ * Approach:
+ *   1. token_get_all() the whole file.
+ *   2. Find the statement that contains the violation line. The statement
+ *      "anchor" is the last `;`, `{`, `}` (or file start) token at depth 0
+ *      before the first non-whitespace token on/after the violation line.
+ *   3. From the statement anchor, the statement START line is the first line
+ *      bearing real code (skipping leading phpcs comments handled by caller).
+ *   4. The statement END is the line of the `;` token that terminates the
+ *      statement at paren/brace depth 0. String tokens
+ *      (T_CONSTANT_ENCAPSED_STRING, heredoc, and double-quote-delimited
+ *      interpolated strings) are atomic — their internal newlines never count
+ *      as statement boundaries and their `;`/`)` characters are never code.
+ *
+ * Returns array{ start:int, end:int } as 0-based line indices, or null if the
+ * statement could not be resolved (caller falls back to legacy heuristics).
+ *
+ * @param array $lines        File lines (each retaining its trailing newline).
+ * @param int   $start_idx    0-based index of the first violation line in block.
+ * @param int   $end_idx      0-based index of the last violation line in block.
+ * @return array{start:int,end:int}|null
+ */
+function find_statement_boundaries_tokenized( array $lines, int $start_idx, int $end_idx ): ?array {
+	$source = implode( '', $lines );
+
+	// token_get_all needs a leading <?php to tokenize as PHP. The fixer always
+	// runs on real PHP files that already begin with an open tag, so tokenize
+	// directly and bail to the legacy path if anything looks off.
+	$tokens = @token_get_all( $source );
+	if ( empty( $tokens ) ) {
+		return null;
+	}
+
+	// Violation lines are 1-based in token line numbers.
+	$violation_line_start = $start_idx + 1;
+	$violation_line_end   = $end_idx + 1;
+
+	// Normalize tokens into a uniform shape with line numbers. Single-character
+	// tokens (e.g. ';', '(', ')', '{', '}') are strings without a line number,
+	// so we track line numbers by accumulating from typed tokens. token_get_all
+	// already gives typed tokens their starting line; single-char tokens inherit
+	// the line of the preceding content, which we recompute precisely below.
+	$norm = array();
+	$line = 1;
+	foreach ( $tokens as $tok ) {
+		if ( is_array( $tok ) ) {
+			$norm[] = array(
+				'id'   => $tok[0],
+				'text' => $tok[1],
+				'line' => $tok[2],
+			);
+			// Advance the running line by the newlines this token spans.
+			$line = $tok[2] + substr_count( $tok[1], "\n" );
+		} else {
+			$norm[] = array(
+				'id'   => null,
+				'text' => $tok,
+				'line' => $line,
+			);
+			$line += substr_count( $tok, "\n" );
+		}
+	}
+
+	$count = count( $norm );
+
+	// Find the index of the first token whose line is >= the violation start.
+	// That token is somewhere inside (or just before) the statement of interest.
+	$anchor_idx = null;
+	for ( $i = 0; $i < $count; $i++ ) {
+		if ( $norm[ $i ]['line'] >= $violation_line_start ) {
+			$anchor_idx = $i;
+			break;
+		}
+	}
+	if ( null === $anchor_idx ) {
+		return null;
+	}
+
+	// Walk BACKWARD from the anchor to the statement start. A statement begins
+	// after the previous `;`, `{`, `}`, or `(` at depth 0 — i.e. the previous
+	// statement/block boundary. We only count structural single-char tokens;
+	// string tokens are atomic so their text is never inspected.
+	$depth     = 0;
+	$start_tok = 0;
+	for ( $i = $anchor_idx; $i >= 0; $i-- ) {
+		$t = $norm[ $i ];
+		if ( null === $t['id'] ) {
+			if ( ')' === $t['text'] || ']' === $t['text'] ) {
+				$depth++;
+			} elseif ( '(' === $t['text'] || '[' === $t['text'] ) {
+				if ( $depth > 0 ) {
+					$depth--;
+				}
+			} elseif ( 0 === $depth && ( ';' === $t['text'] || '{' === $t['text'] || '}' === $t['text'] ) ) {
+				$start_tok = $i + 1;
+				break;
+			}
+		}
+	}
+
+	// Skip leading whitespace tokens to the first real token of the statement.
+	while ( $start_tok < $count
+		&& T_WHITESPACE === $norm[ $start_tok ]['id'] ) {
+		$start_tok++;
+	}
+	if ( $start_tok >= $count ) {
+		return null;
+	}
+
+	// Walk FORWARD from the statement start to the terminating `;` at depth 0.
+	// Paren/bracket depth is tracked on structural single-char tokens only;
+	// string tokens are atomic and skipped, so a `;` or `)` that is part of SQL
+	// text inside a string literal can never be mistaken for a terminator.
+	$depth   = 0;
+	$end_tok = null;
+	for ( $i = $start_tok; $i < $count; $i++ ) {
+		$t = $norm[ $i ];
+		if ( null !== $t['id'] ) {
+			continue; // Typed tokens (incl. all string literals) are atomic.
+		}
+		if ( '(' === $t['text'] || '[' === $t['text'] ) {
+			$depth++;
+		} elseif ( ')' === $t['text'] || ']' === $t['text'] ) {
+			if ( $depth > 0 ) {
+				$depth--;
+			}
+		} elseif ( ';' === $t['text'] && 0 === $depth ) {
+			$end_tok = $i;
+			break;
+		}
+	}
+
+	if ( null === $end_tok ) {
+		return null;
+	}
+
+	$stmt_start_line = $norm[ $start_tok ]['line'];
+	$stmt_end_line   = $norm[ $end_tok ]['line'];
+
+	// Sanity: the statement must actually span the violation lines.
+	if ( $stmt_start_line > $violation_line_start || $stmt_end_line < $violation_line_end ) {
+		return null;
+	}
+
+	$start_index = $stmt_start_line - 1;
+	$end_index   = $stmt_end_line - 1;
+
+	if ( ! isset( $lines[ $start_index ] ) || ! isset( $lines[ $end_index ] ) ) {
+		return null;
+	}
+
+	return array(
+		'start' => $start_index,
+		'end'   => $end_index,
+	);
 }
 
 /**

--- a/wordpress/tests/phpcs-ignore-fixer-multiline-sql-smoke.sh
+++ b/wordpress/tests/phpcs-ignore-fixer-multiline-sql-smoke.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# Smoke test: confirm the phpcs-ignore-fixer never injects a `phpcs:enable`
+# (or `phpcs:disable`) comment INSIDE a multi-line SQL string literal.
+#
+# Why this test exists (issue #981):
+#
+# The fixer wraps known false-positive `WordPress.DB.PreparedSQL` violations
+# (table names from `$wpdb->prefix`) in `// phpcs:disable` / `// phpcs:enable`
+# blocks. The old statement-boundary finders were line-based regex heuristics
+# that were NOT string-content-aware: `find_statement_end()` walked forward and
+# returned the first line ending in `;`/`);`. Inside a multi-line SQL string
+# there is no real terminator until the closing `);` of the whole
+# `$wpdb->prepare()` call — so the `// phpcs:enable` marker was spliced INSIDE
+# the SQL string literal. PHP does not treat `//` as a comment inside a string,
+# so the literal text became part of the SQL, producing invalid runtime SQL
+# that MariaDB/MySQL rejected with ERROR 1064. This silently broke
+# extrachill-community draft-storage (downstream: extrachill-community#113,
+# fixed there via PR #118). The fixer is now token-aware
+# (`find_statement_boundaries_tokenized()`): it tokenizes the file and walks
+# paren depth back to zero, skipping the contents of string-literal tokens, so
+# the markers always land on their own PHP comment lines outside any string.
+#
+# This is the same class of bug as #878 and #458 (php-fixers operating on
+# regex/line heuristics instead of the PHP token stream).
+#
+# The test:
+#   1. Builds a temp PHP fixture with a multi-line `$wpdb->prepare("INSERT INTO
+#      {$table} ... ON DUPLICATE KEY UPDATE ...;", ...)` (the exact shape that
+#      broke draft-storage — note the interior `;` inside the string that the
+#      old line-based finder mistook for the statement end).
+#   2. Runs the fixer against it (real phpcs + WordPress standard from vendor).
+#   3. Asserts:
+#        a. The fixed file still passes `php -l`.
+#        b. NO `phpcs:` text appears inside ANY string-literal token (the core
+#           regression guard — verified via token_get_all, not a fragile grep).
+#        c. The `WordPress.DB.PreparedSQL` violation is actually suppressed
+#           (the disable/enable block did its job).
+
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${TESTS_DIR}/.." && pwd)"
+FIXER="${EXTENSION_DIR}/scripts/lint/php-fixers/phpcs-ignore-fixer.php"
+PHPCS_BIN="${EXTENSION_DIR}/vendor/bin/phpcs"
+
+if ! command -v php >/dev/null 2>&1; then
+	echo "Skipping: php not found on PATH" >&2
+	exit 0
+fi
+
+if [ ! -f "$FIXER" ]; then
+	echo "Missing fixer: $FIXER" >&2
+	exit 1
+fi
+
+if [ ! -x "$PHPCS_BIN" ]; then
+	echo "Skipping: $PHPCS_BIN not found (run \`composer install\` in $EXTENSION_DIR)" >&2
+	exit 0
+fi
+
+# Resolve the WordPress coding standard the same way lint-runner.sh does, so
+# this test is self-contained regardless of the global phpcs config.
+PHPCS_STANDARD_PATHS=()
+for phpcs_standard_path in \
+	"${EXTENSION_DIR}/vendor/wp-coding-standards/wpcs" \
+	"${EXTENSION_DIR}/vendor/phpcsstandards/phpcsextra" \
+	"${EXTENSION_DIR}/vendor/phpcsstandards/phpcsutils" \
+	"${EXTENSION_DIR}/HomeboyWordPress"; do
+	if [ -d "$phpcs_standard_path" ]; then
+		PHPCS_STANDARD_PATHS+=("$phpcs_standard_path")
+	fi
+done
+
+if [ ! -d "${EXTENSION_DIR}/vendor/wp-coding-standards/wpcs" ]; then
+	echo "Skipping: WordPress coding standard not installed in vendor" >&2
+	exit 0
+fi
+
+if [ "${#PHPCS_STANDARD_PATHS[@]}" -gt 0 ]; then
+	PHPCS_INSTALLED_PATHS=$(IFS=','; printf '%s' "${PHPCS_STANDARD_PATHS[*]}")
+	"$PHPCS_BIN" --config-set installed_paths "$PHPCS_INSTALLED_PATHS" --quiet >/dev/null 2>&1 || true
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+SAMPLE="$TMP_DIR/draft-storage-fixture.php"
+cat > "$SAMPLE" <<'PHP'
+<?php
+function save_draft( $wpdb, $table, $row ) {
+	$sql = $wpdb->prepare(
+		"INSERT INTO {$table}
+			(user_id, blog_id, type, title, content, updated_at)
+		VALUES (%d, %d, %s, %s, %s, %d)
+		ON DUPLICATE KEY UPDATE
+			title = VALUES(title),
+			content = VALUES(content),
+			updated_at = VALUES(updated_at);",
+		$row['user_id'],
+		$row['blog_id'],
+		$row['type'],
+		$row['title'],
+		$row['content'],
+		$row['updated_at']
+	);
+	return $wpdb->query( $sql );
+}
+PHP
+
+# Sanity: the fixture must parse before we run the fixer.
+if ! php -l "$SAMPLE" >/dev/null 2>&1; then
+	echo "FAIL: fixture does not parse before fixing (test bug)." >&2
+	exit 1
+fi
+
+# Run the fixer.
+php "$FIXER" "$SAMPLE" --phpcs-binary="$PHPCS_BIN" --phpcs-standard=WordPress >/dev/null 2>&1 || {
+	echo "FAIL: fixer exited non-zero." >&2
+	exit 1
+}
+
+# Assertion (a): the fixed file still parses.
+if ! php -l "$SAMPLE" >/dev/null 2>&1; then
+	echo "FAIL: fixed file no longer passes php -l." >&2
+	php -l "$SAMPLE" >&2 || true
+	cat "$SAMPLE" >&2
+	exit 1
+fi
+
+# Assertion (b): NO phpcs: marker lives inside any string-literal token. This is
+# the core regression guard for #981. We use token_get_all so the check is not
+# fooled by `//` appearing inside SQL text.
+INSIDE_STRING=$(php -r '
+$src = file_get_contents( $argv[1] );
+$tokens = token_get_all( $src );
+$found = 0;
+foreach ( $tokens as $t ) {
+	if ( is_array( $t ) && in_array( $t[0], array( T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE, T_INLINE_HTML ), true ) ) {
+		if ( strpos( $t[1], "phpcs:" ) !== false ) {
+			$found++;
+		}
+	}
+}
+echo $found;
+' "$SAMPLE")
+
+if [ "$INSIDE_STRING" -ne 0 ]; then
+	echo "FAIL: found $INSIDE_STRING phpcs: marker(s) inside a string literal (issue #981 regression)." >&2
+	cat "$SAMPLE" >&2
+	exit 1
+fi
+
+# Assertion (c): the disable/enable block actually suppressed the violation.
+REMAINING=$("$PHPCS_BIN" --report=json --sniffs=WordPress.DB.PreparedSQL --standard=WordPress "$SAMPLE" 2>/dev/null | php -r '
+$d = json_decode( file_get_contents( "php://stdin" ), true );
+$n = 0;
+if ( ! empty( $d["files"] ) ) {
+	foreach ( $d["files"] as $f ) {
+		$n += count( $f["messages"] ?? array() );
+	}
+}
+echo $n;
+')
+
+if [ "$REMAINING" -ne 0 ]; then
+	echo "FAIL: expected 0 WordPress.DB.PreparedSQL violations after fix, got $REMAINING." >&2
+	cat "$SAMPLE" >&2
+	exit 1
+fi
+
+echo "phpcs-ignore-fixer multiline-sql boundary smoke passed (no marker inside string, php -l clean, violation suppressed)"


### PR DESCRIPTION
## Summary

Fixes #981 — the `wordpress/scripts/lint/php-fixers/phpcs-ignore-fixer.php` auto-fixer was injecting a `// phpcs:enable WordPress.DB.PreparedSQL` comment **inside** the double-quoted SQL string literal of a multi-line `$wpdb->prepare()` call.

## Root cause

The fixer wraps known false-positive `WordPress.DB.PreparedSQL` violations (table names from `$wpdb->prefix`) in `// phpcs:disable` / `// phpcs:enable` blocks. It **correctly detected** the "inside a multi-line string" case via `is_inside_multiline_string()` and routed to the disable/enable "wrap whole statement" branch — but the statement-boundary finders `find_statement_start()` / `find_statement_end()` were **line-based regex heuristics that were not string-content-aware**:

- `find_statement_end()` walked forward and returned the **first** line ending in `;` / `);`.
- Inside a multi-line SQL string there is no real terminator until the closing `);` of the whole `$wpdb->prepare()` call — but the heuristic matched an interior line (e.g. the `ON DUPLICATE KEY UPDATE ... = VALUES(...);` line inside the string).
- The `// phpcs:enable` marker was then `array_splice`'d at `$stmt_end + 1`, landing **inside the string body**.

Because PHP does not treat `//` as a comment inside a string, the literal text `// phpcs:enable WordPress.DB.PreparedSQL` became part of the SQL, producing:

```
INSERT INTO wp_ec_bbpress_drafts // phpcs:enable WordPress.DB.PreparedSQL (user_id, ...)
```

→ **MariaDB ERROR 1064**. `php -l` still passes (it's valid PHP — the broken text is inside a string), so the corruption is **silent** until runtime, where the query returns `false`/`null`.

## The fix (token-aware)

Added `find_statement_boundaries_tokenized()` which uses `token_get_all()` to locate the real statement that contains the violation:

- Walks **paren/bracket depth back to zero** to find the statement start and the terminating `;` at depth 0.
- Treats string-literal tokens (`T_CONSTANT_ENCAPSED_STRING`, heredoc, interpolated double-quoted strings) as **atomic** — their internal `;`/`)` characters and newlines are never inspected as code.
- The `// phpcs:disable` marker goes on its own line **before** the statement start; `// phpcs:enable` on its own line **after** the line containing the statement-terminating `);` — never inside a string literal.

The legacy line-based finders remain as a **fallback** for cases the tokenizer cannot resolve, so prior behavior for single-line, non-DB, and non-string cases is preserved (verified: the `phpcs:ignore`-on-line-above path for `mt_srand`/`base64_encode` is unchanged; single-line DB queries still wrap correctly). Existing dedup logic (skipping lines already covered by `phpcs:disable`/`ignore`) is untouched.

### Result shape (mirrors the human fix in extrachill-community)

```php
// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
$sql = $wpdb->prepare(
    "INSERT INTO {$table}
        ...
        VALUES (%d, %s)",
    $a, $b
);
// phpcs:enable WordPress.DB.PreparedSQL
```

## Downstream damage (already happened)

- **Extra-Chill/extrachill-community#113** — the fixer corrupted `inc/content/editor/draft-storage.php` (both the INSERT and SELECT `$wpdb->prepare()` calls), silently breaking compose-draft (new topic / new reply autosave) network-wide since 2026-05-30. Repaired downstream via **extrachill-community PR #118**. This PR fixes the **tool** that caused it.

## Prior art (same bug class)

This is another instance of the php-fixers suite operating on **regex/line heuristics instead of the PHP token stream**:

- #878 — `strict-comparison-fixer applies == → === blindly with no type analysis`
- #458 — `file_get_contents/file_put_contents auto-fix produces broken code in test files`

## Verification

- ✅ `php -l wordpress/scripts/lint/php-fixers/phpcs-ignore-fixer.php` passes.
- ✅ **New regression test** `wordpress/tests/phpcs-ignore-fixer-multiline-sql-smoke.sh`:
  - Builds the exact draft-storage-shaped multi-line `$wpdb->prepare("INSERT INTO {$table} ... ON DUPLICATE KEY UPDATE ...;", ...)` fixture (interior `;` inside the string — the trap that broke the old finder).
  - Runs the fixer with real `phpcs` + WordPress standard from vendor.
  - Asserts: fixed file passes `php -l`; **no `phpcs:` marker inside any string-literal token** (checked via `token_get_all`, not a fragile grep); the `WordPress.DB.PreparedSQL` violation is suppressed.
  - Confirmed it **FAILS** against the old buggy fixer and **PASSES** against the fix — a genuine regression guard.
- ✅ Existing `wordpress/scripts/lint/scoped-fix-only-smoke.sh` still passes.
- ✅ Manually verified preserved behavior for single-line non-DB (`phpcs:ignore` above) and single-line DB (`disable`/`enable` wrap) cases.

No `CHANGELOG.md` edits, no hand-bumped version strings (homeboy owns both).

closes #981