### PR TITLE
Pass Codebox provider paths from task config

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -56,6 +56,13 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     model: request.executor.model || config.model || options.model || '',
     provider_plugin_paths: config.provider_plugin_paths || options.providerPluginPaths || [],
     secret_env: config.secret_env || options.secretEnv || [],
+    agents_api: config.agents_api || options.agentsApi || '',
+    data_machine: config.data_machine || options.dataMachine || '',
+    data_machine_code: config.data_machine_code || options.dataMachineCode || '',
+    homeboy: config.homeboy || options.homeboy || '',
+    homeboy_extensions: config.homeboy_extensions || options.homeboyExtensions || '',
+    wp_codebox_bin: config.wp_codebox_bin || options.wpCodeboxBin || '',
+    artifacts: config.artifacts || options.artifacts || '',
     max_turns: config.max_turns || options.maxTurns,
     task_timeout_seconds: config.task_timeout_seconds || timeoutSeconds || timeoutFromMs || options.taskTimeoutSeconds,
     orchestrator: {

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -55,10 +55,9 @@ function readTaskRequest() {
   return request;
 }
 
-function requireArg(name) {
-  const value = argValue(name);
+function requireValue(name, value) {
   if (!value) {
-    usage();
+    throw new Error(`Required WP Codebox task runner option missing: ${name}`);
   }
   return value;
 }
@@ -317,9 +316,9 @@ function timeoutPayload(timeoutMs, artifacts, evidencePath, recipePath, command,
 }
 
 function runWpCodebox(recipePath, request) {
-  const wpCodeboxBin = argValue('--wp-codebox-bin') || 'wp-codebox';
+  const wpCodeboxBin = argValue('--wp-codebox-bin') || request.wp_codebox_bin || 'wp-codebox';
   const args = ['recipe-run', '--recipe', recipePath, '--json'];
-  const explicitArtifacts = argValue('--artifacts');
+  const explicitArtifacts = argValue('--artifacts') || request.artifacts || '';
   const artifacts = explicitArtifacts || fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-artifacts-'));
   args.push('--artifacts', artifacts);
   if (explicitArtifacts) {
@@ -379,11 +378,11 @@ try {
   const request = readTaskRequest();
   assertRequiredSecretEnvAvailable(request);
   const options = {
-    agentsApi: requireArg('--agents-api'),
-    dataMachine: requireArg('--data-machine'),
-    dataMachineCode: requireArg('--data-machine-code'),
-    homeboy: argValue('--homeboy'),
-    homeboyExtensions: argValue('--homeboy-extensions'),
+    agentsApi: requireValue('--agents-api', argValue('--agents-api') || request.agents_api),
+    dataMachine: requireValue('--data-machine', argValue('--data-machine') || request.data_machine),
+    dataMachineCode: requireValue('--data-machine-code', argValue('--data-machine-code') || request.data_machine_code),
+    homeboy: argValue('--homeboy') || request.homeboy,
+    homeboyExtensions: argValue('--homeboy-extensions') || request.homeboy_extensions,
   };
   const recipe = recipeForRequest(request, options);
   const recipePath = writeRecipe(recipe);

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -106,6 +106,12 @@ const codexAgentRequest = {
         'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
         'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
       ],
+      agents_api: '/components/agents-api',
+      data_machine: '/components/data-machine',
+      data_machine_code: '/components/data-machine-code',
+      homeboy: '/components/homeboy',
+      homeboy_extensions: '/components/homeboy-extensions',
+      wp_codebox_bin: '/bin/wp-codebox',
       max_turns: 8,
     },
   },
@@ -114,6 +120,12 @@ const codexRequest = codeboxTaskRequestFromAgentTaskRequest(codexAgentRequest);
 assert.equal(codexRequest.provider, 'codex');
 assert.equal(codexRequest.model, 'gpt-5.5');
 assert.deepEqual(codexRequest.provider_plugin_paths, ['/components/ai-provider-for-openai']);
+assert.equal(codexRequest.agents_api, '/components/agents-api');
+assert.equal(codexRequest.data_machine, '/components/data-machine');
+assert.equal(codexRequest.data_machine_code, '/components/data-machine-code');
+assert.equal(codexRequest.homeboy, '/components/homeboy');
+assert.equal(codexRequest.homeboy_extensions, '/components/homeboy-extensions');
+assert.equal(codexRequest.wp_codebox_bin, '/bin/wp-codebox');
 assert.deepEqual(codexRequest.secret_env, [
   'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
   'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
@@ -219,6 +231,11 @@ try {
   assert.equal(capturedCodex.request.provider, 'codex');
   assert.equal(capturedCodex.request.model, 'gpt-5.5');
   assert.deepEqual(capturedCodex.request.provider_plugin_paths, ['/components/ai-provider-for-openai']);
+  assert.equal(capturedCodex.request.agents_api, '/components/agents-api');
+  assert.equal(capturedCodex.request.data_machine, '/components/data-machine');
+  assert.equal(capturedCodex.request.data_machine_code, '/components/data-machine-code');
+  assert.equal(capturedCodex.request.homeboy, '/components/homeboy');
+  assert.equal(capturedCodex.request.homeboy_extensions, '/components/homeboy-extensions');
   assert.deepEqual(capturedCodex.request.secret_env, [
     'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
     'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',


### PR DESCRIPTION
## Summary
- Carry Codebox runner paths from `AgentTaskRequest.executor.config` into the WP Codebox task request.
- Let the task runner consume those request fields as an alternative to CLI-only arguments.
- Extend the Codebox agent-task smoke coverage for request-configured provider paths.

## Validation
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node --check wordpress/lib/codebox-agent-task-executor.js`
- `node --check wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs`
- `node --check wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs`

## Follow-up evidence
- Stacked with Extra-Chill/homeboy#3247, `agent-task run-plan` executed the two-cell Codebox proof for Extra-Chill/homeboy#3234 through scheduler -> extension provider -> WP Codebox recipe-run and returned two structured succeeded outcomes with artifact directories.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the provider-config plumbing, tests, and local validation; Chris remains responsible for review and merge.