### PR TITLE
fix(wordpress): mount rig bench workloads in Codebox

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
@@ -7,9 +7,11 @@ TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-static-source-smoke.XX
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 SOURCE_ROOT="${TMP_ROOT}/wp-site-generator"
+EXTRA_WORKLOAD="${TMP_ROOT}/rig-workload.php"
 mkdir -p "${SOURCE_ROOT}/static-sites/demo" "${SOURCE_ROOT}/.github/homeboy"
 printf '<!doctype html><title>Demo</title>\n' > "${SOURCE_ROOT}/static-sites/demo/index.html"
 printf '<?php return array();\n' > "${SOURCE_ROOT}/.github/homeboy/ssi-import-diagnostics.php"
+printf '<?php return function (): array { return array(); };\n' > "$EXTRA_WORKLOAD"
 
 RESOLVE_HELPER="${TMP_ROOT}/resolve-context.sh"
 cat > "$RESOLVE_HELPER" <<'STUB'
@@ -89,6 +91,7 @@ HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
 HOMEBOY_SMOKE_SOURCE_ROOT="$SOURCE_ROOT" \
 HOMEBOY_SMOKE_CAPTURE_FILE="$CAPTURE_FILE" \
 HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+HOMEBOY_BENCH_EXTRA_WORKLOADS="$EXTRA_WORKLOAD" \
 HOMEBOY_WP_CODEBOX_BIN="$WP_CODEBOX_BIN" \
 HOMEBOY_BENCH_RESULTS_FILE="${TMP_ROOT}/bench-results.json" \
 HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="${TMP_ROOT}/artifacts" \
@@ -100,9 +103,28 @@ bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
 jq -e --arg sourceRoot "$SOURCE_ROOT" '
     .recipe.inputs.extraPlugins == []
     and (.recipe.inputs.mounts[] | select(.source == $sourceRoot and .target == "/wordpress/wp-content/plugins/wp-site-generator" and .mode == "readonly"))
+    and (.recipe.inputs.mounts[] | select(.source == ($sourceRoot | sub("/wp-site-generator$"; ""))) | .target == "/wordpress/wp-content/plugins/wp-site-generator/tests/bench")
     and (.recipe.runtime.blueprint.steps[] | select(.step == "installPlugin" and .options.targetFolderName == "static-site-importer"))
     and (.recipe.workflow.steps[0].args[] | select(startswith("workloads-json=") and contains("static-site-importer import-theme")))
 ' "$CAPTURE_FILE" >/dev/null
+
+LIST_RESULTS_FILE="${TMP_ROOT}/bench-list-results.json"
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \
+HOMEBOY_RUNTIME_BENCH_HELPER_SH="$BENCH_HELPER" \
+HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+HOMEBOY_SMOKE_SOURCE_ROOT="$SOURCE_ROOT" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+HOMEBOY_BENCH_EXTRA_WORKLOADS="$EXTRA_WORKLOAD" \
+HOMEBOY_BENCH_RESULTS_FILE="$LIST_RESULTS_FILE" \
+HOMEBOY_RUNTIME_FAILURE_TRAP="" \
+HOMEBOY_BENCH_LIST_ONLY=1 \
+bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
+
+jq -e '
+    .component_id == "wp-site-generator"
+    and .iterations == 0
+    and (.scenarios[] | select(.id == "rig-workload" and .file == "tests/bench/rig-workload.php" and .source == "rig"))
+' "$LIST_RESULTS_FILE" >/dev/null
 
 PLUGIN_ROOT="${TMP_ROOT}/plugin-component"
 mkdir -p "$PLUGIN_ROOT"

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -84,6 +84,50 @@ homeboy_wp_codebox_component_relative_path() {
     fi
 }
 
+homeboy_wp_codebox_mount_extra_bench_workloads() {
+    local workloads_value="${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}"
+    [ -n "$workloads_value" ] || return 0
+
+    local workload_path
+    IFS=':' read -r -a workload_paths <<< "$workloads_value"
+    for workload_path in "${workload_paths[@]}"; do
+        [ -n "$workload_path" ] || continue
+        if [ ! -f "$workload_path" ]; then
+            echo "Error: extra bench workload not found: $workload_path" >&2
+            FAILED_STEP="WP Codebox bench workload setup"
+            exit 1
+        fi
+        MOUNTS_JSON=$(jq -nc \
+            --argjson mounts "$MOUNTS_JSON" \
+            --arg source "$(dirname "$workload_path")" \
+            --arg target "/wordpress/wp-content/plugins/${PLUGIN_SLUG}/tests/bench" \
+            '$mounts + [{source: $source, target: $target, mode: "readonly"}]')
+    done
+}
+
+homeboy_wp_codebox_extra_workload_scenarios_json() {
+    local workloads_value="${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}"
+    local scenarios="[]"
+    [ -n "$workloads_value" ] || {
+        printf '%s\n' "$scenarios"
+        return 0
+    }
+
+    local workload_path workload_name scenario_id
+    IFS=':' read -r -a workload_paths <<< "$workloads_value"
+    for workload_path in "${workload_paths[@]}"; do
+        [ -n "$workload_path" ] || continue
+        workload_name="$(basename "$workload_path")"
+        scenario_id="${workload_name%.*}"
+        scenarios=$(jq -nc \
+            --argjson scenarios "$scenarios" \
+            --arg id "$scenario_id" \
+            --arg file "tests/bench/${workload_name}" \
+            '$scenarios + [{id: $id, file: $file, source: "rig", iterations: 0, metrics: {}}]')
+    done
+    printf '%s\n' "$scenarios"
+}
+
 homeboy_wp_codebox_find_plugin_file() {
     local plugin_dir="$1"
     local candidate
@@ -379,6 +423,8 @@ if printf '%s' "$WP_CODEBOX_FILE_MOUNTS_JSON" | jq -e 'type == "array" and lengt
     done < <(printf '%s' "$WP_CODEBOX_FILE_MOUNTS_JSON" | jq -c '.[]')
 fi
 
+homeboy_wp_codebox_mount_extra_bench_workloads
+
 SHARED_STATE_HOST="${HOMEBOY_BENCH_SHARED_STATE:-}"
 if [ -n "$SHARED_STATE_HOST" ]; then
     mkdir -p "$SHARED_STATE_HOST"
@@ -393,7 +439,19 @@ if ! homeboy_wordpress_emit_browser_target "$settings_json" "$SHARED_STATE_HOST"
 fi
 
 BENCH_DIR="${PLUGIN_PATH}/tests/bench"
-if [ ! -d "$BENCH_DIR" ] && ! printf '%s' "$WP_CODEBOX_WORKLOADS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+HAS_EXTRA_BENCH_WORKLOADS=0
+[ -n "${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}" ] && HAS_EXTRA_BENCH_WORKLOADS=1
+
+if [ "${HOMEBOY_BENCH_LIST_ONLY:-}" = "1" ]; then
+    mkdir -p "$(dirname "$RESULTS_FILE")"
+    jq -n \
+        --arg component "$COMPONENT_ID" \
+        --argjson scenarios "$(homeboy_wp_codebox_extra_workload_scenarios_json)" \
+        '{component_id: $component, iterations: 0, scenarios: $scenarios}' > "$RESULTS_FILE"
+    exit 0
+fi
+
+if [ ! -d "$BENCH_DIR" ] && [ "$HAS_EXTRA_BENCH_WORKLOADS" -eq 0 ] && ! printf '%s' "$WP_CODEBOX_WORKLOADS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
     echo "Warning: No bench workloads found for ${PLUGIN_PATH}" >&2
     if [ -n "${HOMEBOY_BENCH_RESULTS_FILE:-}" ]; then
         homeboy_write_empty_bench_results "$COMPONENT_ID" 0 "$RESULTS_FILE"


### PR DESCRIPTION
## Summary
- Mount Homeboy rig-provided PHP bench workloads into the WP Codebox runtime plugin's `tests/bench` directory.
- Include rig-provided workloads in list-only discovery so `homeboy bench list --rig ... --extension wordpress` reports them before execution.
- Extend the WP Codebox bench smoke to cover recipe mounts and list-only output for rig workloads.

## Verification
- `bash -n wordpress/scripts/bench/bench-runner-wp-codebox.sh wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- `bash wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- With paired Homeboy/rig branches installed locally: `homeboy bench list --rig gutenberg-rtc --extension wordpress` reports `gutenberg-rtc-protocol-load` as `source: rig`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the missing WP Codebox rig-workload bridge, implemented the shell runner changes, and ran smoke verification; Chris remains responsible for review and merge.