### PR TITLE
Pass Codebox runtime stack mounts

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -55,6 +55,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     provider: config.provider || options.provider || '',
     model: request.executor.model || config.model || options.model || '',
     provider_plugin_paths: config.provider_plugin_paths || options.providerPluginPaths || [],
+    runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
     secret_env: config.secret_env || options.secretEnv || [],
     agents_api: config.agents_api || options.agentsApi || '',
     data_machine: config.data_machine || options.dataMachine || '',

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -31,7 +31,7 @@ function hasFlag(name) {
 }
 
 function usage() {
-  console.error('Usage: homeboy-wp-codebox-task-runner.cjs --agents-api <path> --data-machine <path> --data-machine-code <path> [--homeboy <path>] [--homeboy-extensions <path>] [--wp-codebox-bin <bin>] [--provider <id>] [--model <id>] [--max-turns <n>] [--task-timeout-seconds <n>] [--provider-plugin-path <path>] [--secret-env <ENV>] [--mount <host:vfs[:mode]>] [--artifacts <dir>]');
+  console.error('Usage: homeboy-wp-codebox-task-runner.cjs --agents-api <path> --data-machine <path> --data-machine-code <path> [--homeboy <path>] [--homeboy-extensions <path>] [--wp-codebox-bin <bin>] [--provider <id>] [--model <id>] [--max-turns <n>] [--task-timeout-seconds <n>] [--provider-plugin-path <path>] [--secret-env <ENV>] [--mount <host:vfs[:mode]>] [--runtime-stack-mount <host:vfs[:mode]>] [--artifacts <dir>]');
   process.exit(1);
 }
 
@@ -112,19 +112,28 @@ function assertRequiredSecretEnvAvailable(request) {
   }
 }
 
+function mountEntryFromValue(value, metadata) {
+  const [source, target, mode = 'readwrite'] = value.split(':');
+  if (!source || !target) {
+    throw new Error(`Invalid --mount value: ${value}`);
+  }
+  return {
+    source,
+    target,
+    mode,
+    metadata,
+  };
+}
+
 function mountEntries() {
-  return argValues('--mount').map((value) => {
-    const [source, target, mode = 'readwrite'] = value.split(':');
-    if (!source || !target) {
-      throw new Error(`Invalid --mount value: ${value}`);
-    }
-    return {
-      source,
-      target,
-      mode,
-      metadata: { kind: 'homeboy-audit-fanout' },
-    };
-  });
+  return argValues('--mount').map((value) => mountEntryFromValue(value, { kind: 'homeboy-audit-fanout' }));
+}
+
+function runtimeStackMountEntries(request) {
+  return [
+    ...(request.runtime_stack_mounts || []),
+    ...argValues('--runtime-stack-mount').map((value) => mountEntryFromValue(value, { kind: 'homeboy-runtime-stack' })),
+  ];
 }
 
 function realPathForContainment(filePath) {
@@ -222,12 +231,18 @@ function recipeForRequest(request, options) {
     stepArgs.push(`timeout-seconds=${taskTimeoutSeconds}`);
   }
 
+  const runtimeStackMounts = runtimeStackMountEntries(request);
+  const runtime = {
+    wp: argValue('--wp') || 'latest',
+    blueprint: { steps: [] },
+  };
+  if (runtimeStackMounts.length > 0) {
+    runtime.stack = { mounts: runtimeStackMounts };
+  }
+
   return {
     schema: 'wp-codebox/workspace-recipe/v1',
-    runtime: {
-      wp: argValue('--wp') || 'latest',
-      blueprint: { steps: [] },
-    },
+    runtime,
     inputs: {
       workspaces: recipeWorkspaces(options),
       mounts: mountEntries(),

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -52,6 +52,13 @@ const request = {
     config: {
       provider: 'openai',
       provider_plugin_paths: ['/providers/openai'],
+      runtime_stack_mounts: [{
+        type: 'directory',
+        source: '/components/php-ai-client',
+        target: '/wordpress/wp-includes/php-ai-client',
+        mode: 'readonly',
+        metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
+      }],
       secret_env: ['OPENAI_API_KEY'],
       max_turns: 8,
     },
@@ -82,6 +89,13 @@ assert.equal(codeboxRequest.sandbox_session_id, 'task-123');
 assert.equal(codeboxRequest.provider, 'openai');
 assert.equal(codeboxRequest.model, 'gpt-5.5');
 assert.deepEqual(codeboxRequest.provider_plugin_paths, ['/providers/openai']);
+assert.deepEqual(codeboxRequest.runtime_stack_mounts, [{
+  type: 'directory',
+  source: '/components/php-ai-client',
+  target: '/wordpress/wp-includes/php-ai-client',
+  mode: 'readonly',
+  metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
+}]);
 assert.deepEqual(codeboxRequest.secret_env, ['OPENAI_API_KEY']);
 assert.equal(codeboxRequest.max_turns, 8);
 assert.equal(codeboxRequest.task_timeout_seconds, 120);

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -61,6 +61,13 @@ try {
     provider: 'opencode',
     model: 'opencode-go/kimi-k2.6',
     provider_plugin_paths: [providerPluginPath],
+    runtime_stack_mounts: [{
+      type: 'directory',
+      source: '/components/php-ai-client',
+      target: '/wordpress/wp-includes/php-ai-client',
+      mode: 'readonly',
+      metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
+    }],
     secret_env: ['OPENCODE_API_KEY'],
     orchestrator: {
       id: 'homeboy-extensions/audit-wp-codebox-fanout',
@@ -100,6 +107,8 @@ try {
     '/components/homeboy-extensions',
     '--mount',
     '/repo/plugin:/wordpress/wp-content/plugins/plugin:readwrite',
+    '--runtime-stack-mount',
+    '/components/wordpress-develop:/wordpress:readonly',
     '--max-turns',
     '80',
     '--task-timeout-seconds',
@@ -151,6 +160,12 @@ try {
   ]);
   assert.deepEqual(recipe.inputs.secretEnv, ['OPENCODE_API_KEY']);
   assert.equal(recipe.inputs.mounts[0].source, '/repo/plugin');
+  assert.equal(recipe.runtime.stack.mounts[0].source, '/components/php-ai-client');
+  assert.equal(recipe.runtime.stack.mounts[0].target, '/wordpress/wp-includes/php-ai-client');
+  assert.equal(recipe.runtime.stack.mounts[0].metadata.component, 'php-ai-client');
+  assert.equal(recipe.runtime.stack.mounts[1].source, '/components/wordpress-develop');
+  assert.equal(recipe.runtime.stack.mounts[1].target, '/wordpress');
+  assert.equal(recipe.runtime.stack.mounts[1].metadata.kind, 'homeboy-runtime-stack');
   assert.equal(recipe.inputs.extraPlugins[0].slug, 'agents-api');
   assert.equal(recipe.inputs.extraPlugins[1].slug, 'data-machine');
   assert.equal(recipe.inputs.extraPlugins[2].slug, 'data-machine-code');


### PR DESCRIPTION
## Summary
- Pass `runtime_stack_mounts` from Codebox executor config into the Homeboy WP Codebox task request.
- Map request/CLI runtime stack mounts into `recipe.runtime.stack.mounts` for WP Codebox recipes.
- Cover both executor request translation and task-runner recipe generation with smoke assertions.

## Testing
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `git diff --check`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@feat-codebox-runtime-stack-mounts --extension wordpress` reached WP Codebox install/activation and reported no PHPUnit test files discovered for this extension; targeted JS smokes cover this path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Codebox runtime stack mount pass-through, smoke coverage, and PR description for Chris to review and test.