### PR TITLE
Fix WordPress lint finding sidecars

### DIFF
--- a/tests/wordpress-eslint-scope-smoke.sh
+++ b/tests/wordpress-eslint-scope-smoke.sh
@@ -191,18 +191,20 @@ findings = json.load(open(sys.argv[1], encoding="utf-8"))
 assert len(findings) == 1, findings
 finding = findings[0]
 expected = {
+    "tool": "eslint",
     "file": "assets/bad.js",
     "line": 1,
     "column": 7,
     "severity": "error",
-    "source": "eslint",
     "code": "eslint.no-undef",
+    "rule": "eslint.no-undef",
     "category": "eslint",
     "fixable": True,
     "excerpt": "const bad = true;",
 }
 for key, value in expected.items():
     assert finding.get(key) == value, (key, finding)
+assert "source" not in finding, finding
 assert finding.get("fingerprint"), finding
 PY
 

--- a/wordpress/scripts/lint/autofixable-exit-smoke.sh
+++ b/wordpress/scripts/lint/autofixable-exit-smoke.sh
@@ -134,17 +134,19 @@ findings = json.load(open(sys.argv[1], encoding="utf-8"))
 assert len(findings) == 1, findings
 finding = findings[0]
 expected = {
+    "tool": "phpcs",
     "file": "plugin.php",
     "line": 8,
     "column": 7,
     "severity": "warning",
-    "source": "phpcs",
     "code": "Generic.Formatting.MultipleStatementAlignment.NotSameWarning",
+    "rule": "Generic.Formatting.MultipleStatementAlignment.NotSameWarning",
     "category": "formatting",
     "fixable": True,
 }
 for key, value in expected.items():
     assert finding.get(key) == value, (key, finding)
+assert "source" not in finding, finding
 assert finding.get("fingerprint"), finding
 assert finding.get("excerpt") == "$beta = 2;", finding
 PY

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -240,7 +240,6 @@ if [ -n "$ESLINT_FINDINGS_FILE" ] && [ -n "$json_output" ] && command -v node &>
                     line,
                     column,
                     severity: msg.severity === 1 ? "warning" : "error",
-                    source: "eslint",
                     code,
                     rule: code,
                     category: "eslint",

--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -102,12 +102,23 @@ merge_findings_into_sidecar() {
     local extra_file="$1"
     [ ! -f "$extra_file" ] && return 0
 
-    if ! type homeboy_sidecar_merge >/dev/null 2>&1; then
-        echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write lint findings" >&2
-        return 1
+    if type homeboy_sidecar_merge >/dev/null 2>&1; then
+        homeboy_sidecar_merge lint.findings "$extra_file"
+        return $?
     fi
 
-    homeboy_sidecar_merge lint.findings "$extra_file"
+    if type homeboy_merge_lint_findings >/dev/null 2>&1; then
+        homeboy_merge_lint_findings "$extra_file"
+        return $?
+    fi
+
+    if type homeboy_sidecar_merge_json_array >/dev/null 2>&1; then
+        homeboy_sidecar_merge_json_array "${HOMEBOY_LINT_FINDINGS_FILE:-}" "$extra_file"
+        return $?
+    fi
+
+    echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write lint findings" >&2
+    return 1
 }
 
 write_lint_producers_sidecar() {
@@ -819,14 +830,10 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
     fi
 
     # Write lint findings sidecar for homeboy baseline and categorized issues.
-    # Transforms PHPCS JSON report into the LintFinding format homeboy expects:
-    #   [{id: "file::source::line", message: "...", category: "..."}]
+    # Transforms PHPCS JSON report into the current LintFinding shape; Homeboy
+    # owns structured source metadata outside this sidecar payload.
     # Category is derived from the top-level PHPCS source namespace.
     if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
-        if ! type homeboy_sidecar_merge >/dev/null 2>&1; then
-            echo "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write lint findings" >&2
-            exit 1
-        fi
         _PHPCS_FINDINGS_TMPFILE=$(homeboy_mktemp 'phpcs-findings.XXXXXX')
         echo "$json_output" | php -r '
             ini_set("memory_limit", "-1");
@@ -891,7 +898,6 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
                         "line" => $line,
                         "column" => $column,
                         "severity" => strtolower($msg["type"] ?? "error"),
-                        "source" => "phpcs",
                         "code" => $code,
                         "rule" => $code,
                         "category" => $category,
@@ -904,7 +910,7 @@ if [ -n "$json_output" ] && command -v php &> /dev/null; then
             }
             file_put_contents($argv[2], json_encode($findings, JSON_UNESCAPED_SLASHES) . "\n");
         ' "$PLUGIN_PATH" "$_PHPCS_FINDINGS_TMPFILE" 2>/dev/null || true
-        homeboy_sidecar_merge lint.findings "$_PHPCS_FINDINGS_TMPFILE"
+        merge_findings_into_sidecar "$_PHPCS_FINDINGS_TMPFILE" || exit 1
         rm -f "$_PHPCS_FINDINGS_TMPFILE"
     fi
 fi

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -929,8 +929,7 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
     fi
 
     # Write PHPStan lint findings sidecar for homeboy baseline ratchet.
-    # Transforms PHPStan JSON into the same LintFinding format PHPCS uses:
-    #   [{id: "file::identifier::line", message: "...", category: "phpstan"}]
+    # Transforms PHPStan JSON into the same current LintFinding shape PHPCS uses.
     # The lint-runner merges these with PHPCS findings into the final baseline.
     if [ -n "${_HOMEBOY_PHPSTAN_FINDINGS_FILE:-}" ] && [ -n "$json_output" ]; then
         _PHPSTAN_FINDINGS_OUTPUT_TMPFILE=$(homeboy_mktemp 'phpstan-findings.XXXXXX')
@@ -968,7 +967,6 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
                         "line" => $line,
                         "column" => null,
                         "severity" => "error",
-                        "source" => "phpstan",
                         "code" => $code,
                         "rule" => $code,
                         "category" => "phpstan",

--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -211,18 +211,20 @@ findings = json.load(open(sys.argv[1], encoding="utf-8"))
 assert len(findings) == 1, findings
 finding = findings[0]
 expected = {
+    "tool": "phpstan",
     "file": "main.php",
     "line": 1,
     "column": None,
     "severity": "error",
-    "source": "phpstan",
     "code": "phpstan.function.notFound",
+    "rule": "phpstan.function.notFound",
     "category": "phpstan",
     "fixable": False,
     "excerpt": "<?php missing_function();",
 }
 for key, value in expected.items():
     assert finding.get(key) == value, (key, finding)
+assert "source" not in finding, finding
 assert finding.get("fingerprint"), finding
 PY
 


### PR DESCRIPTION
## Summary
- Update WordPress PHPCS, PHPStan, and ESLint lint findings sidecars to emit the current `LintFinding` shape without stale string `source` fields.
- Keep `tool`, `rule`, fingerprint, excerpt, and categorization fields in the baseline sidecar payloads while leaving annotation payload source metadata unchanged.
- Route PHPCS merged findings through the lint findings helper so the runner works with both current and generic sidecar writer helper surfaces.

Fixes https://github.com/Extra-Chill/homeboy/issues/3253

## Test evidence
- `bash tests/wordpress-eslint-scope-smoke.sh` passed
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh` passed
- `bash wordpress/scripts/lint/autofixable-exit-smoke.sh` passed
- `git diff` reviewed before commit; only WordPress lint sidecar runner/smoke files changed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the sidecar compatibility fix and smoke test assertions; Chris remains responsible for review and validation.