### PR TITLE
fix(wordpress): respect component PHPStan config

### DIFF
--- a/wordpress/scripts/lint/lint-runner.sh
+++ b/wordpress/scripts/lint/lint-runner.sh
@@ -138,13 +138,13 @@ write_lint_producers_sidecar() {
         return 1
     fi
 
-    "$python_bin" - "$HOMEBOY_LINT_PRODUCERS_FILE" "${HOMEBOY_LINT_FINDINGS_FILE:-}" "$phpcs_passed" "$eslint_passed" "$phpstan_passed" <<'PYEOF'
+    "$python_bin" - "$HOMEBOY_LINT_PRODUCERS_FILE" "${HOMEBOY_LINT_FINDINGS_FILE:-}" "$phpcs_passed" "$eslint_passed" "$phpstan_passed" "${HOMEBOY_PHPSTAN_PRODUCER_METADATA_FILE:-}" <<'PYEOF'
 import json
 import os
 import sys
 import tempfile
 
-target, findings_path, phpcs_passed, eslint_passed, phpstan_passed = sys.argv[1:6]
+target, findings_path, phpcs_passed, eslint_passed, phpstan_passed, phpstan_metadata_path = sys.argv[1:7]
 counts = {"phpcs": 0, "eslint": 0, "phpstan": 0}
 if findings_path and os.path.exists(findings_path) and os.path.getsize(findings_path) > 0:
     with open(findings_path, "r", encoding="utf-8") as handle:
@@ -159,13 +159,19 @@ statuses = {
     "eslint": "passed" if eslint_passed == "1" else "failed",
     "phpstan": "passed" if phpstan_passed == "1" else "failed",
 }
+phpstan_metadata = {"source_sidecar": "lint-producers"}
+if phpstan_metadata_path and os.path.exists(phpstan_metadata_path) and os.path.getsize(phpstan_metadata_path) > 0:
+    with open(phpstan_metadata_path, "r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if isinstance(loaded, dict):
+        phpstan_metadata.update(loaded)
 producers = [
     {
         "tool": tool,
         "status": statuses[tool],
         "finding_count": counts[tool],
         "step": tool,
-        "metadata": {"source_sidecar": "lint-producers"},
+        "metadata": phpstan_metadata if tool == "phpstan" else {"source_sidecar": "lint-producers"},
     }
     for tool in ("phpcs", "eslint", "phpstan")
 ]
@@ -919,9 +925,13 @@ fi
 # writes its own parsed array, then the core sidecar helper owns final merging.
 _ESLINT_FINDINGS_TMPFILE=""
 _PHPSTAN_FINDINGS_TMPFILE=""
+HOMEBOY_PHPSTAN_PRODUCER_METADATA_FILE=""
 if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ]; then
     _ESLINT_FINDINGS_TMPFILE=$(homeboy_mktemp 'eslint-findings.XXXXXX')
     _PHPSTAN_FINDINGS_TMPFILE=$(homeboy_mktemp 'phpstan-findings.XXXXXX')
+fi
+if [ -n "${HOMEBOY_LINT_PRODUCERS_FILE:-}" ]; then
+    HOMEBOY_PHPSTAN_PRODUCER_METADATA_FILE=$(homeboy_mktemp 'phpstan-producer.XXXXXX.json')
 fi
 
 # Summary mode: show summary header + top violations, skip full report
@@ -1014,6 +1024,7 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
         echo ""
         set +e
         _HOMEBOY_PHPSTAN_FINDINGS_FILE="${_PHPSTAN_FINDINGS_TMPFILE:-}" \
+            HOMEBOY_PHPSTAN_PRODUCER_METADATA_FILE="${HOMEBOY_PHPSTAN_PRODUCER_METADATA_FILE:-}" \
             HOMEBOY_SUMMARY_MODE=1 bash "$phpstan_runner"
         local phpstan_exit=$?
         set -e
@@ -1040,6 +1051,7 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
         rm -f "$_PHPSTAN_FINDINGS_TMPFILE"
     fi
     write_lint_producers_sidecar "$PHPCS_PASSED" "$ESLINT_PASSED" "$PHPSTAN_PASSED"
+    [ -n "${HOMEBOY_PHPSTAN_PRODUCER_METADATA_FILE:-}" ] && rm -f "$HOMEBOY_PHPSTAN_PRODUCER_METADATA_FILE"
 
     if [ "$PHPCS_PASSED" -eq 1 ] && [ "$ESLINT_PASSED" -eq 1 ] && [ "$PHPSTAN_PASSED" -eq 1 ]; then
         echo "Linting passed"
@@ -1106,6 +1118,7 @@ run_phpstan() {
     echo ""
     set +e
     _HOMEBOY_PHPSTAN_FINDINGS_FILE="${_PHPSTAN_FINDINGS_TMPFILE:-}" \
+        HOMEBOY_PHPSTAN_PRODUCER_METADATA_FILE="${HOMEBOY_PHPSTAN_PRODUCER_METADATA_FILE:-}" \
         HOMEBOY_SUMMARY_MODE=1 bash "$phpstan_runner"
     local phpstan_exit=$?
     set -e
@@ -1133,6 +1146,7 @@ if [ -n "${HOMEBOY_LINT_FINDINGS_FILE:-}" ] && [ -n "$_PHPSTAN_FINDINGS_TMPFILE"
     rm -f "$_PHPSTAN_FINDINGS_TMPFILE"
 fi
 write_lint_producers_sidecar "$PHPCS_PASSED" "$ESLINT_PASSED" "$PHPSTAN_PASSED"
+[ -n "${HOMEBOY_PHPSTAN_PRODUCER_METADATA_FILE:-}" ] && rm -f "$HOMEBOY_PHPSTAN_PRODUCER_METADATA_FILE"
 
 if [ "$PHPCS_PASSED" -eq 1 ] && [ "$ESLINT_PASSED" -eq 1 ] && [ "$PHPSTAN_PASSED" -eq 1 ]; then
     echo ""

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -124,8 +124,11 @@ case "$WORDPRESS_LINT_ROLE" in
 esac
 
 PHPSTAN_BIN="${EXTENSION_PATH}/vendor/bin/phpstan"
-PHPSTAN_CONFIG="${EXTENSION_PATH}/phpstan.neon.dist"
-PHPSTAN_BASE_CONFIG="$PHPSTAN_CONFIG"
+PHPSTAN_DEFAULT_CONFIG="${EXTENSION_PATH}/phpstan.neon.dist"
+PHPSTAN_COMPONENT_CONFIG=""
+PHPSTAN_COMPONENT_CONFIG_SOURCE="extension-default"
+PHPSTAN_BASE_CONFIG="$PHPSTAN_DEFAULT_CONFIG"
+PHPSTAN_LEVEL_SOURCE="extension-default"
 COMPONENT_BASELINE="${PLUGIN_PATH}/phpstan-baseline.neon"
 COMPOSITE_AUTOLOAD=""
 DEPENDENCY_CONFIG=""
@@ -192,15 +195,38 @@ if [ ! -f "$PHPSTAN_BIN" ]; then
     exit 0
 fi
 
-if [ ! -f "$PHPSTAN_CONFIG" ]; then
-    echo "Warning: phpstan.neon.dist not found at $PHPSTAN_CONFIG, skipping static analysis"
+if [ ! -f "$PHPSTAN_DEFAULT_CONFIG" ]; then
+    echo "Warning: phpstan.neon.dist not found at $PHPSTAN_DEFAULT_CONFIG, skipping static analysis"
     exit 0
+fi
+
+resolve_component_phpstan_config() {
+    local candidate
+
+    for candidate in \
+        "${PLUGIN_PATH}/phpstan.neon" \
+        "${PLUGIN_PATH}/phpstan.neon.dist" \
+        "${PLUGIN_PATH}/phpstan.dist.neon"; do
+        if [ -f "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+PHPSTAN_COMPONENT_CONFIG=$(resolve_component_phpstan_config || true)
+if [ -n "$PHPSTAN_COMPONENT_CONFIG" ]; then
+    PHPSTAN_COMPONENT_CONFIG_SOURCE="component-local"
+    PHPSTAN_BASE_CONFIG="$PHPSTAN_COMPONENT_CONFIG"
 fi
 
 generate_dependency_config() {
     local tmpfile
     local has_dependencies=0
     local has_baseline=0
+    local has_component_config=0
     local has_component_context=0
     local context_path
     local scan_file_count=0
@@ -209,7 +235,12 @@ generate_dependency_config() {
 
     {
         printf '%s\n' 'includes:'
-        printf '    - %s\n' "$PHPSTAN_CONFIG"
+        if [ -n "$PHPSTAN_COMPONENT_CONFIG" ]; then
+            printf '    - %s\n' "$PHPSTAN_COMPONENT_CONFIG"
+            has_component_config=1
+        else
+            printf '    - %s\n' "$PHPSTAN_DEFAULT_CONFIG"
+        fi
         # Component baseline: PHPStan 2.x removed the `--baseline` CLI flag, so
         # the baseline file must be pulled in via `includes:` in the neon. We
         # do this here (rather than via --baseline) so every invocation path
@@ -248,7 +279,7 @@ generate_dependency_config() {
         fi
     } > "$tmpfile"
 
-    if [ "$has_dependencies" -eq 1 ] || [ "$has_baseline" -eq 1 ] || [ "$has_component_context" -eq 1 ]; then
+    if [ "$has_dependencies" -eq 1 ] || [ "$has_baseline" -eq 1 ] || [ "$has_component_context" -eq 1 ] || [ "${has_component_config:-0}" -eq 1 ]; then
         printf '%s\n' "$tmpfile"
     else
         rm -f "$tmpfile"
@@ -492,7 +523,41 @@ phpstan_args+=(--configuration="$PHPSTAN_BASE_CONFIG")
 # must now track what the neon declares (level 7, set in homeboy-extensions#225).
 # Keep them in sync when bumping further.
 PHPSTAN_LEVEL="${HOMEBOY_PHPSTAN_LEVEL:-7}"
-phpstan_args+=(--level="$PHPSTAN_LEVEL")
+if [ -n "${HOMEBOY_PHPSTAN_LEVEL:-}" ]; then
+    PHPSTAN_LEVEL_SOURCE="env"
+    phpstan_args+=(--level="$PHPSTAN_LEVEL")
+elif [ -z "$PHPSTAN_COMPONENT_CONFIG" ]; then
+    phpstan_args+=(--level="$PHPSTAN_LEVEL")
+else
+    PHPSTAN_LEVEL="config"
+    PHPSTAN_LEVEL_SOURCE="component-local"
+fi
+
+write_phpstan_producer_metadata() {
+    local target="${HOMEBOY_PHPSTAN_PRODUCER_METADATA_FILE:-}"
+    [ -z "$target" ] && return 0
+
+    php -r '
+        $target = $argv[1] ?? "";
+        if ($target === "") {
+            exit;
+        }
+        $metadata = [
+            "phpstan_config" => $argv[2] ?? "",
+            "phpstan_config_source" => $argv[3] ?? "",
+            "phpstan_component_config" => ($argv[4] ?? "") !== "" ? $argv[4] : null,
+            "phpstan_level" => $argv[5] ?? "",
+            "phpstan_level_source" => $argv[6] ?? "",
+        ];
+        $dir = dirname($target);
+        if ($dir !== "" && $dir !== ".") {
+            @mkdir($dir, 0777, true);
+        }
+        file_put_contents($target, json_encode($metadata, JSON_UNESCAPED_SLASHES) . "\n");
+    ' "$target" "$PHPSTAN_BASE_CONFIG" "$PHPSTAN_COMPONENT_CONFIG_SOURCE" "$PHPSTAN_COMPONENT_CONFIG" "$PHPSTAN_LEVEL" "$PHPSTAN_LEVEL_SOURCE" 2>/dev/null || true
+}
+
+write_phpstan_producer_metadata
 
 # Memory limit (default: 2G)
 phpstan_args+=(--memory-limit=2G)
@@ -559,6 +624,9 @@ if [ -f "$COMPOSITE_AUTOLOAD" ]; then
     if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
         echo "DEBUG: Using composite autoloader: $COMPOSITE_AUTOLOAD"
         echo "DEBUG: Using PHPStan config: $PHPSTAN_BASE_CONFIG"
+        echo "DEBUG: PHPStan config source: $PHPSTAN_COMPONENT_CONFIG_SOURCE"
+        [ -n "$PHPSTAN_COMPONENT_CONFIG" ] && echo "DEBUG: Component PHPStan config: $PHPSTAN_COMPONENT_CONFIG"
+        echo "DEBUG: PHPStan level source: $PHPSTAN_LEVEL_SOURCE"
     fi
     phpstan_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
 fi
@@ -633,7 +701,9 @@ if [ -n "$PHPSTAN_MAX_PROCESSES" ] || [ -n "$PHPSTAN_PHP_VERSION" ]; then
     # Replace the --configuration arg with our temp config
     phpstan_args=(analyse)
     phpstan_args+=(--configuration="$PHPSTAN_TMPCONFIG")
-    phpstan_args+=(--level="$PHPSTAN_LEVEL")
+    if [ -n "${HOMEBOY_PHPSTAN_LEVEL:-}" ] || [ -z "$PHPSTAN_COMPONENT_CONFIG" ]; then
+        phpstan_args+=(--level="$PHPSTAN_LEVEL")
+    fi
     phpstan_args+=(--memory-limit=2G)
     # Baseline is pulled in via neon includes (PHPSTAN_TMPCONFIG includes
     # PHPSTAN_BASE_CONFIG which includes COMPONENT_BASELINE when present),
@@ -724,7 +794,10 @@ if [[ "${HOMEBOY_SUMMARY_MODE:-}" == "1" ]]; then
     if [ "$json_exit" -ne 0 ] && is_parallel_worker_failure "$json_output"; then
         echo "Parallel worker failure detected, retrying single-process (--debug)..."
         prepare_phpstan_retry_config > /dev/null
-        retry_args=(analyse --configuration="$PHPSTAN_TMPCONFIG" --level="$PHPSTAN_LEVEL" --memory-limit=2G --no-progress --debug)
+        retry_args=(analyse --configuration="$PHPSTAN_TMPCONFIG" --memory-limit=2G --no-progress --debug)
+        if [ -n "${HOMEBOY_PHPSTAN_LEVEL:-}" ] || [ -z "$PHPSTAN_COMPONENT_CONFIG" ]; then
+            retry_args+=(--level="$PHPSTAN_LEVEL")
+        fi
         # Baseline is pulled in via PHPSTAN_TMPCONFIG → PHPSTAN_BASE_CONFIG
         # → COMPONENT_BASELINE include chain (no --baseline CLI flag in PHPStan 2.x).
         [ -f "$COMPOSITE_AUTOLOAD" ] && retry_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
@@ -1117,7 +1190,10 @@ if [ "$full_exit" -ne 0 ] && \
    { is_parallel_worker_failure_text "$stderr_output" || is_parallel_worker_failure_text "$stdout_output"; }; then
     echo "Parallel worker failure detected, retrying single-process (--debug)..."
     prepare_phpstan_retry_config > /dev/null
-    retry_args=(analyse --configuration="$PHPSTAN_TMPCONFIG" --level="$PHPSTAN_LEVEL" --memory-limit=2G --no-progress --debug)
+    retry_args=(analyse --configuration="$PHPSTAN_TMPCONFIG" --memory-limit=2G --no-progress --debug)
+    if [ -n "${HOMEBOY_PHPSTAN_LEVEL:-}" ] || [ -z "$PHPSTAN_COMPONENT_CONFIG" ]; then
+        retry_args+=(--level="$PHPSTAN_LEVEL")
+    fi
     # Baseline pulled in via PHPSTAN_TMPCONFIG include chain, same as summary-mode retry.
     [ -f "$COMPOSITE_AUTOLOAD" ] && retry_args+=(--autoload-file="$COMPOSITE_AUTOLOAD")
     add_phpstan_retry_targets

--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -23,6 +23,7 @@ CONFIG_CAPTURE="${TMPDIR}/phpstan-config-capture.neon"
 AUTOLOAD_CAPTURE="${TMPDIR}/phpstan-autoload-capture.php"
 OUTPUT_FILE="${TMPDIR}/phpstan-output.txt"
 FINDINGS_FILE="${TMPDIR}/phpstan-findings.json"
+PRODUCER_METADATA_FILE="${TMPDIR}/phpstan-producer-metadata.json"
 
 mkdir -p "${EXTENSION_DIR}/vendor/bin" "${COMPONENT_DIR}/tests" "${COMPONENT_DIR}/assets" "${COMPONENT_DIR}/includes" "${COMPONENT_DIR}/vendor_prefixed"
 touch "${EXTENSION_DIR}/phpstan.neon.dist"
@@ -144,8 +145,33 @@ assert_file_contains "$AUTOLOAD_CAPTURE" "${COMPONENT_DIR}/vendor_prefixed/autol
 run_phpstan
 assert_contains "--level=7" "full-component PHPStan run defaults to level 7"
 assert_not_contains "--baseline" "full-component PHPStan run avoids removed --baseline flag"
+assert_file_contains "$CONFIG_CAPTURE" "${EXTENSION_DIR}/phpstan.neon.dist" "full-component PHPStan config includes the extension default config"
 assert_file_contains "$CONFIG_CAPTURE" "${COMPONENT_DIR}/phpstan-baseline.neon" "full-component PHPStan config includes component baseline via neon"
 assert_file_not_contains "$OUTPUT_FILE" "ERRORS (raw)" "zero-error PHPStan JSON should not be printed as raw errors"
+
+printf '%s\n' 'parameters:' '    level: max' > "${COMPONENT_DIR}/phpstan.neon.dist"
+run_phpstan
+assert_not_contains "--level=7" "component PHPStan config controls level when env override is absent"
+assert_file_not_contains "$CONFIG_CAPTURE" "${EXTENSION_DIR}/phpstan.neon.dist" "component-config run does not duplicate the extension default config"
+assert_file_contains "$CONFIG_CAPTURE" "${COMPONENT_DIR}/phpstan.neon.dist" "component-config run includes the component config"
+
+HOMEBOY_PHPSTAN_LEVEL=5 run_phpstan
+assert_contains "--level=5" "HOMEBOY_PHPSTAN_LEVEL explicitly overrides component PHPStan config level"
+assert_file_contains "$CONFIG_CAPTURE" "${COMPONENT_DIR}/phpstan.neon.dist" "env override still uses component PHPStan config"
+
+HOMEBOY_PHPSTAN_PRODUCER_METADATA_FILE="$PRODUCER_METADATA_FILE" HOMEBOY_PHPSTAN_LEVEL=5 run_phpstan
+python3 - "$PRODUCER_METADATA_FILE" "$COMPONENT_DIR" <<'PY'
+import json
+import sys
+
+metadata = json.load(open(sys.argv[1], encoding="utf-8"))
+component_dir = sys.argv[2]
+assert metadata["phpstan_config_source"] == "component-local", metadata
+assert metadata["phpstan_component_config"] == f"{component_dir}/phpstan.neon.dist", metadata
+assert metadata["phpstan_level"] == "5", metadata
+assert metadata["phpstan_level_source"] == "env", metadata
+PY
+rm -f "${COMPONENT_DIR}/phpstan.neon.dist"
 
 HOMEBOY_LINT_GLOB='{main.php,assets/app.js,includes/extra.php}' run_phpstan
 assert_contains "${COMPONENT_DIR}/main.php" "glob scope includes matching PHP source file"


### PR DESCRIPTION
## Summary
- Keep the WordPress extension PHPStan config as the default when a component does not provide local PHPStan config.
- Detect component-local PHPStan config (`phpstan.neon`, `phpstan.neon.dist`, `phpstan.dist.neon`) and use it through the same Homeboy runner, finding sidecar, and producer summary path.
- Preserve `HOMEBOY_PHPSTAN_LEVEL` as the explicit override while allowing component config to own `level` when no env override is set.
- Add PHPStan producer metadata for effective config source, component config path, effective level, and level source.

## Behavior
- No component config: Homeboy uses the WordPress extension default `phpstan.neon.dist` and keeps the default `--level=7` behavior.
- Component config present: Homeboy uses the component config instead of duplicating the extension default config, while still layering generated Homeboy wiring for component baselines, dependency scan paths, scoped context, autoload, PHP version, and sidecar normalization.
- Env override present: `HOMEBOY_PHPSTAN_LEVEL` still adds the CLI `--level` and wins over config-defined levels.

## Test Evidence
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- `bash wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh`
- `bash -n wordpress/scripts/lint/phpstan-runner.sh wordpress/scripts/lint/lint-runner.sh wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `git diff --check`

## Real-World Proof
Using `Automattic/agents-api` PR 247 with this branch linked into a temp Homeboy extension install:

```bash
tmp_home=$(mktemp -d) && HOME="$tmp_home" homeboy extension install /Users/chubes/Developer/homeboy-extensions@fix-wordpress-phpstan-local-config/wordpress && HOME="$tmp_home" HOMEBOY_SKIP=phpcs,eslint HOMEBOY_SUMMARY_MODE=1 homeboy lint --path /Users/chubes/Developer/agents-api@proof-phpstan-local-config-pr247 --extension wordpress
```

Result: PHPStan ran through `homeboy lint`, detected `/Users/chubes/Developer/agents-api@proof-phpstan-local-config-pr247/phpstan.neon.dist` as `component-local`, preserved `phpstan_level_source=component-local`, and emitted normalized `phpstan.*` findings through `lint-findings.json` plus a `lint-producers.json` PHPStan producer summary. The command failed with 783 PHPStan findings from the PR branch, which is expected proof that the repo max-level config is now being respected rather than bypassed.

## Related
- Supports Automattic/agents-api#247 by keeping max-level PHPStan inside the Homeboy lint path instead of a parallel Composer CI gate.
- Related to Extra-Chill/homeboy#3253 because producer metadata now makes the effective PHPStan config and level source visible instead of opaque.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the PHPStan runner changes, smoke-test updates, and proof commands; Chris remains responsible for review and merge.