### PR TITLE
Pass through Codebox runtime overlays

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -56,6 +56,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     model: request.executor.model || config.model || options.model || '',
     provider_plugin_paths: config.provider_plugin_paths || options.providerPluginPaths || [],
     runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
+    runtime_overlays: config.runtime_overlays || options.runtimeOverlays || [],
     secret_env: config.secret_env || options.secretEnv || [],
     agents_api: config.agents_api || options.agentsApi || '',
     data_machine: config.data_machine || options.dataMachine || '',

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -31,7 +31,7 @@ function hasFlag(name) {
 }
 
 function usage() {
-  console.error('Usage: homeboy-wp-codebox-task-runner.cjs --agents-api <path> --data-machine <path> --data-machine-code <path> [--homeboy <path>] [--homeboy-extensions <path>] [--wp-codebox-bin <bin>] [--provider <id>] [--model <id>] [--max-turns <n>] [--task-timeout-seconds <n>] [--provider-plugin-path <path>] [--secret-env <ENV>] [--mount <host:vfs[:mode]>] [--runtime-stack-mount <host:vfs[:mode]>] [--artifacts <dir>]');
+  console.error('Usage: homeboy-wp-codebox-task-runner.cjs --agents-api <path> --data-machine <path> --data-machine-code <path> [--homeboy <path>] [--homeboy-extensions <path>] [--wp-codebox-bin <bin>] [--provider <id>] [--model <id>] [--max-turns <n>] [--task-timeout-seconds <n>] [--provider-plugin-path <path>] [--secret-env <ENV>] [--mount <host:vfs[:mode]>] [--runtime-stack-mount <host:vfs[:mode]>] [--runtime-overlay-json <json>] [--artifacts <dir>]');
   process.exit(1);
 }
 
@@ -136,6 +136,13 @@ function runtimeStackMountEntries(request) {
   ];
 }
 
+function runtimeOverlayEntries(request) {
+  return [
+    ...(request.runtime_overlays || []),
+    ...argValues('--runtime-overlay-json').map((value) => JSON.parse(value)),
+  ];
+}
+
 function realPathForContainment(filePath) {
   const resolved = path.resolve(filePath);
   if (fs.existsSync(resolved)) {
@@ -232,12 +239,16 @@ function recipeForRequest(request, options) {
   }
 
   const runtimeStackMounts = runtimeStackMountEntries(request);
+  const runtimeOverlays = runtimeOverlayEntries(request);
   const runtime = {
     wp: argValue('--wp') || 'latest',
     blueprint: { steps: [] },
   };
   if (runtimeStackMounts.length > 0) {
     runtime.stack = { mounts: runtimeStackMounts };
+  }
+  if (runtimeOverlays.length > 0) {
+    runtime.overlays = runtimeOverlays;
   }
 
   return {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -59,6 +59,13 @@ const request = {
         mode: 'readonly',
         metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
       }],
+      runtime_overlays: [{
+        type: 'bundled-library',
+        library: 'php-ai-client',
+        source: '/components/php-ai-client',
+        target: '/wordpress/wp-includes/php-ai-client',
+        metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
+      }],
       secret_env: ['OPENAI_API_KEY'],
       max_turns: 8,
     },
@@ -94,6 +101,13 @@ assert.deepEqual(codeboxRequest.runtime_stack_mounts, [{
   source: '/components/php-ai-client',
   target: '/wordpress/wp-includes/php-ai-client',
   mode: 'readonly',
+  metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
+}]);
+assert.deepEqual(codeboxRequest.runtime_overlays, [{
+  type: 'bundled-library',
+  library: 'php-ai-client',
+  source: '/components/php-ai-client',
+  target: '/wordpress/wp-includes/php-ai-client',
   metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
 }]);
 assert.deepEqual(codeboxRequest.secret_env, ['OPENAI_API_KEY']);
@@ -228,6 +242,7 @@ try {
   const captured = JSON.parse(fs.readFileSync(capture, 'utf8'));
   assert.equal(captured.request.schema, 'homeboy/wp-codebox-task-request/v1');
   assert.equal(captured.request.orchestrator.agent_task_id, 'task-123');
+  assert.equal(captured.request.runtime_overlays[0].type, 'bundled-library');
 
   const codexResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -68,6 +68,13 @@ try {
       mode: 'readonly',
       metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
     }],
+    runtime_overlays: [{
+      type: 'bundled-library',
+      library: 'php-ai-client',
+      source: '/components/php-ai-client',
+      target: '/wordpress/wp-includes/php-ai-client',
+      metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
+    }],
     secret_env: ['OPENCODE_API_KEY'],
     orchestrator: {
       id: 'homeboy-extensions/audit-wp-codebox-fanout',
@@ -109,6 +116,12 @@ try {
     '/repo/plugin:/wordpress/wp-content/plugins/plugin:readwrite',
     '--runtime-stack-mount',
     '/components/wordpress-develop:/wordpress:readonly',
+    '--runtime-overlay-json',
+    JSON.stringify({
+      type: 'wordpress-scoped-bundle',
+      source: '/components/wordpress-scoped-bundle',
+      scope: 'runtime',
+    }),
     '--max-turns',
     '80',
     '--task-timeout-seconds',
@@ -166,6 +179,11 @@ try {
   assert.equal(recipe.runtime.stack.mounts[1].source, '/components/wordpress-develop');
   assert.equal(recipe.runtime.stack.mounts[1].target, '/wordpress');
   assert.equal(recipe.runtime.stack.mounts[1].metadata.kind, 'homeboy-runtime-stack');
+  assert.equal(recipe.runtime.overlays[0].type, 'bundled-library');
+  assert.equal(recipe.runtime.overlays[0].library, 'php-ai-client');
+  assert.equal(recipe.runtime.overlays[0].source, '/components/php-ai-client');
+  assert.equal(recipe.runtime.overlays[1].type, 'wordpress-scoped-bundle');
+  assert.equal(recipe.runtime.overlays[1].source, '/components/wordpress-scoped-bundle');
   assert.equal(recipe.inputs.extraPlugins[0].slug, 'agents-api');
   assert.equal(recipe.inputs.extraPlugins[1].slug, 'data-machine');
   assert.equal(recipe.inputs.extraPlugins[2].slug, 'data-machine-code');


### PR DESCRIPTION
## Summary
- Pass `runtime_overlays` from Homeboy agent task executor config into `homeboy/wp-codebox-task-request/v1`.
- Emit request overlays as `recipe.runtime.overlays` in the WP Codebox task runner while preserving existing `runtime_stack_mounts` behavior.
- Add smoke coverage for executor request translation and runner recipe generation, including request overlays and CLI `--runtime-overlay-json` input.

## Tests
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `git diff --check`
- `homeboy audit --path /Users/chubes/Developer/homeboy-extensions@fix-992-codebox-runtime-overlays --extension nodejs` reported existing repo-wide warnings unrelated to this change.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/992

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation and tests for issue #992.