### PR TITLE
Support WP Codebox bench bootstrap files

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -84,6 +84,50 @@ homeboy_wp_codebox_component_relative_path() {
     fi
 }
 
+homeboy_wp_codebox_compile_bootstrap_files() {
+    local entries_json
+    entries_json=$(printf '%s' "$settings_json" | jq -c '
+        .wp_codebox_bootstrap_files // []
+        | if type == "array" then . elif type == "string" then [.] else [] end
+    ' 2>/dev/null || echo '[]')
+
+    WP_CODEBOX_BOOTSTRAP_FILES_JSON="[]"
+    if ! printf '%s' "$entries_json" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+        return 0
+    fi
+
+    local index=0
+    while IFS= read -r bootstrap_ref; do
+        [ -n "$bootstrap_ref" ] || continue
+        if [[ "$bootstrap_ref" == *..* ]]; then
+            echo "Error: wp_codebox_bootstrap_files[$index] must stay under component root: $bootstrap_ref" >&2
+            FAILED_STEP="WP Codebox bootstrap file setup"
+            exit 1
+        fi
+
+        local bootstrap_host
+        bootstrap_host=$(homeboy_wp_codebox_resolve_host_path "$PLUGIN_PATH" "$bootstrap_ref")
+        if [[ "$bootstrap_host" = /* && "$bootstrap_host" != "$PLUGIN_PATH"/* ]]; then
+            echo "Error: wp_codebox_bootstrap_files[$index] must stay under component root: $bootstrap_ref" >&2
+            FAILED_STEP="WP Codebox bootstrap file setup"
+            exit 1
+        fi
+        if [ ! -f "$bootstrap_host" ]; then
+            index=$((index + 1))
+            continue
+        fi
+
+        local bootstrap_rel
+        bootstrap_rel=$(homeboy_wp_codebox_component_relative_path "$bootstrap_host")
+        WP_CODEBOX_BOOTSTRAP_FILES_JSON=$(jq -nc --arg file "$bootstrap_rel" '[$file]')
+        return 0
+    done < <(printf '%s' "$entries_json" | jq -r '.[] | select(type == "string" and . != "")')
+
+    echo "Error: no wp_codebox_bootstrap_files entries exist under component root." >&2
+    FAILED_STEP="WP Codebox bootstrap file setup"
+    exit 1
+}
+
 homeboy_wp_codebox_mount_extra_bench_workloads() {
     local workloads_value="${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}"
     [ -n "$workloads_value" ] || return 0
@@ -310,6 +354,7 @@ homeboy_wp_codebox_compile_scenario_manifests() {
 }
 
 homeboy_wp_codebox_compile_scenario_manifests
+homeboy_wp_codebox_compile_bootstrap_files
 
 WP_CODEBOX_WORDPRESS_VERSION="7.0"
 if [ "$settings_json" != "{}" ]; then
@@ -493,6 +538,7 @@ WORKFLOW_STEP_JSON=$(jq -nc \
     --arg warmup "$WARMUP_ITERATIONS" \
     --arg dependencySlugs "$DEPENDENCY_SLUGS_CSV" \
     --argjson env "$BENCH_ENV_JSON" \
+    --argjson bootstrapFiles "$WP_CODEBOX_BOOTSTRAP_FILES_JSON" \
     --argjson workloads "$WP_CODEBOX_WORKLOADS_JSON" '
     {
         command: "wordpress.bench",
@@ -503,6 +549,7 @@ WORKFLOW_STEP_JSON=$(jq -nc \
             "warmup=" + $warmup,
             "dependency-slugs=" + $dependencySlugs,
             "env-json=" + ($env | tostring),
+            "bootstrap-files-json=" + ($bootstrapFiles | tostring),
             "workloads-json=" + ($workloads | tostring)
         ]
     }

--- a/wordpress/tests/wp-codebox-bench-bootstrap-files-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-bootstrap-files-smoke.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-bootstrap-files-'));
+
+try {
+  const extensionPath = path.join(__dirname, '..');
+  const componentPath = path.join(root, 'bootstrap-fixture');
+  const compatDir = path.join(componentPath, 'lib', 'compat', 'wordpress-7.0');
+  const benchDir = path.join(componentPath, 'tests', 'bench');
+  fs.mkdirSync(compatDir, { recursive: true });
+  fs.mkdirSync(benchDir, { recursive: true });
+  fs.writeFileSync(path.join(componentPath, 'bootstrap-fixture.php'), "<?php\n/* Plugin Name: Bootstrap Fixture */\n");
+  fs.writeFileSync(path.join(compatDir, 'collaboration.php'), "<?php\n$GLOBALS['homeboy_bootstrap_fixture'] = true;\n");
+  fs.writeFileSync(path.join(benchDir, 'noop.php'), "<?php\nreturn static fn() => ['metrics' => ['noop' => 1]];\n");
+
+  const resultsFile = path.join(root, 'bench-results.json');
+  const captureFile = path.join(root, 'captured-recipe.json');
+  const fakeWpCodebox = path.join(root, 'fixture-wp-codebox.js');
+  fs.writeFileSync(fakeWpCodebox, `#!/usr/bin/env node
+const fs = require('node:fs');
+const recipeIndex = process.argv.indexOf('--recipe');
+if (process.argv[2] !== 'recipe-run' || recipeIndex < 0) {
+  process.exit(2);
+}
+const recipe = JSON.parse(fs.readFileSync(process.argv[recipeIndex + 1], 'utf8'));
+fs.writeFileSync(process.env.HOMEBOY_CAPTURE_RECIPE, JSON.stringify(recipe, null, 2) + '\\n');
+process.stdout.write(JSON.stringify({
+  success: true,
+  benchResults: {
+    component_id: 'bootstrap-fixture',
+    iterations: 1,
+    warmup_iterations: 0,
+    scenarios: []
+  }
+}) + '\\n');
+`);
+  fs.chmodSync(fakeWpCodebox, 0o755);
+
+  const benchHelper = path.join(root, 'bench-helper.sh');
+  fs.writeFileSync(benchHelper, `#!/usr/bin/env bash
+homeboy_write_empty_bench_results() {
+  local component="$1"
+  local iterations="$2"
+  local results_file="$3"
+  printf '{"component_id":"%s","iterations":%s,"scenarios":[]}\\n' "$component" "$iterations" > "$results_file"
+}
+`);
+
+  const settings = {
+    wp_codebox_bootstrap_files: [
+      'lib/compat/wordpress-7.1/collaboration.php',
+      'lib/compat/wordpress-7.0/collaboration.php',
+    ],
+  };
+  const result = spawnSync('bash', [path.join(extensionPath, 'scripts', 'bench', 'bench-runner.sh')], {
+    cwd: componentPath,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOMEBOY_BENCH_RESULTS_FILE: resultsFile,
+      HOMEBOY_BENCH_ITERATIONS: '1',
+      HOMEBOY_BENCH_WARMUP_ITERATIONS: '0',
+      HOMEBOY_CAPTURE_RECIPE: captureFile,
+      HOMEBOY_COMPONENT_ID: 'bootstrap-fixture',
+      HOMEBOY_COMPONENT_PATH: componentPath,
+      HOMEBOY_EXTENSION_PATH: extensionPath,
+      HOMEBOY_RUNTIME_BENCH_HELPER_SH: benchHelper,
+      HOMEBOY_SETTINGS_JSON: JSON.stringify(settings),
+      HOMEBOY_WP_CODEBOX_BIN: fakeWpCodebox,
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const recipe = JSON.parse(fs.readFileSync(captureFile, 'utf8'));
+  const args = recipe.workflow.steps[0].args;
+  const bootstrapArg = args.find((arg) => arg.startsWith('bootstrap-files-json='));
+  assert.ok(bootstrapArg, 'expected bootstrap-files-json argument');
+  assert.deepEqual(
+    JSON.parse(bootstrapArg.slice('bootstrap-files-json='.length)),
+    ['lib/compat/wordpress-7.0/collaboration.php']
+  );
+  assert.ok(!bootstrapArg.includes('wordpress-7.1'), 'missing fallback should not be passed');
+
+  console.log('WP Codebox bench bootstrap files smoke passed');
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -995,6 +995,13 @@
       "description": "Config-declared WordPress bench workloads passed to wordpress.bench through the generated WP Codebox recipe after dependency mounts and component load. Each workload declares an id, optional label, run steps ({type: 'php', code|file}, {type: 'ability', ability|name, input}, or {type: 'wp-cli', command}), and optional metrics/artifacts/metadata. Step returns use the same {metrics, artifacts, metadata} shape as Node.js bench workloads."
     },
     {
+      "id": "wp_codebox_bootstrap_files",
+      "label": "WP Codebox bench bootstrap files",
+      "type": "array",
+      "default": [],
+      "description": "Component-relative bootstrap file fallbacks for WP Codebox bench workloads. The runner resolves the list against the mounted component and passes the first existing file to wordpress.bench so it loads before workloads execute."
+    },
+    {
       "id": "wp_codebox_scenario_manifests",
       "label": "WP Codebox scenario manifests",
       "type": "array",


### PR DESCRIPTION
## Summary
- Add `wp_codebox_bootstrap_files` for WordPress/WP Codebox bench workloads.
- Resolve component-relative fallback files and pass the first existing file to `wordpress.bench` as `bootstrap-files-json`.
- Add a focused smoke that captures the generated WP Codebox recipe and verifies missing fallbacks are skipped.

Depends on https://github.com/chubes4/wp-codebox/pull/423 for the runtime `wordpress.bench` argument.

Closes #998.

## Tests
- `node wordpress/tests/wp-codebox-bench-bootstrap-files-smoke.js`
- `bash -n wordpress/scripts/bench/bench-runner-wp-codebox.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Homeboy bench runner setting, recipe argument wiring, and focused capture smoke; Chris remains responsible for review and merge.