### PR TITLE
Preserve Codebox timeout artifact refs

### DIFF
--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -7,6 +7,7 @@
  * External dependencies
  */
 const fs = require('node:fs');
+const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 /**
@@ -51,9 +52,146 @@ function requestTimeoutMs(request) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
+function readJsonIfAvailable(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function directorySizeBytes(directory) {
+  try {
+    return fs.readdirSync(directory, { withFileTypes: true }).reduce((total, entry) => {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        return total + directorySizeBytes(entryPath);
+      }
+      return total + fs.statSync(entryPath).size;
+    }, 0);
+  } catch {
+    return undefined;
+  }
+}
+
+function fileArtifactKind(filePath) {
+  const fileName = path.basename(filePath).toLowerCase();
+  if (fileName === 'manifest.json') {
+    return 'codebox-artifact-manifest';
+  }
+  if (fileName === 'runtime-reference-manifest.json') {
+    return 'codebox-runtime-reference-manifest';
+  }
+  const relative = filePath.replace(/\\/g, '/');
+  if (/transcript|conversation|messages/.test(relative)) {
+    return 'codebox-transcript';
+  }
+  if (/command|stdout|stderr|console|log/.test(relative)) {
+    return 'codebox-command-log';
+  }
+  if (/heartbeat|status/.test(relative)) {
+    return 'codebox-heartbeat';
+  }
+  if (/phase/.test(relative)) {
+    return 'codebox-phase';
+  }
+  return '';
+}
+
+function discoverTimeoutArtifactRefs(artifactsRoot) {
+  if (!artifactsRoot || !fs.existsSync(artifactsRoot)) {
+    return { artifacts: [], evidenceRefs: [], lastKnownPhase: '', lastHeartbeat: null };
+  }
+
+  const discovered = [];
+  const queue = [{ filePath: artifactsRoot, depth: 0 }];
+  let lastKnownPhase = '';
+  let lastHeartbeat = null;
+  let runtimeId = '';
+
+  while (queue.length > 0 && discovered.length < 200) {
+    const { filePath, depth } = queue.shift();
+    let stat;
+    try {
+      stat = fs.statSync(filePath);
+    } catch {
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      const manifestPath = path.join(filePath, 'manifest.json');
+      if (filePath !== artifactsRoot && fs.existsSync(manifestPath)) {
+        const manifest = readJsonIfAvailable(manifestPath);
+        if (!runtimeId && manifest && typeof manifest === 'object') {
+          runtimeId = manifest.runtime_id || manifest.runtimeId || manifest.runtime?.id || '';
+        }
+        discovered.push({
+          id: manifest?.id || manifest?.artifact_id || `codebox-artifact-bundle-${discovered.length + 1}`,
+          kind: 'codebox-artifact-bundle',
+          path: filePath,
+          size_bytes: directorySizeBytes(filePath),
+          metadata: manifest && typeof manifest === 'object' ? {
+            schema: manifest.schema,
+            phase: manifest.phase || manifest.last_phase || manifest.current_phase,
+            runtime_id: manifest.runtime_id || manifest.runtimeId || manifest.runtime?.id,
+          } : {},
+        });
+      }
+      if (depth < 4) {
+        for (const entry of fs.readdirSync(filePath).sort()) {
+          queue.push({ filePath: path.join(filePath, entry), depth: depth + 1 });
+        }
+      }
+      continue;
+    }
+
+    if (!stat.isFile()) {
+      continue;
+    }
+
+    const kind = fileArtifactKind(path.relative(artifactsRoot, filePath));
+    if (!kind) {
+      continue;
+    }
+    const payload = filePath.endsWith('.json') ? readJsonIfAvailable(filePath) : null;
+    if (!lastKnownPhase && payload && typeof payload === 'object') {
+      lastKnownPhase = payload.phase || payload.last_phase || payload.lastKnownPhase || payload.current_phase || '';
+    }
+    if (!runtimeId && payload && typeof payload === 'object') {
+      runtimeId = payload.runtime_id || payload.runtimeId || payload.runtime?.id || '';
+    }
+    if (!lastHeartbeat && payload && typeof payload === 'object' && /heartbeat|status/i.test(filePath)) {
+      lastHeartbeat = payload.heartbeat || payload.last_heartbeat || payload;
+    }
+    discovered.push({
+      id: `${kind}-${discovered.length + 1}`,
+      kind,
+      path: filePath,
+      size_bytes: stat.size,
+      metadata: payload && typeof payload === 'object' ? {
+        schema: payload.schema,
+        phase: payload.phase || payload.last_phase || payload.current_phase,
+      } : {},
+    });
+  }
+
+  return {
+    artifacts: discovered,
+    evidenceRefs: discovered.map((artifact) => ({
+      kind: artifact.kind,
+      uri: artifact.path,
+      label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
+    })),
+    runtimeId,
+    lastKnownPhase,
+    lastHeartbeat,
+  };
+}
+
 function timeoutPayload(timeoutMs) {
   const artifacts = argValue('--artifacts');
   const evidencePath = artifacts ? `${artifacts}/homeboy-codebox-task-runner.json` : '';
+  const discovered = discoverTimeoutArtifactRefs(artifacts);
   const knownArtifacts = [];
   if (artifacts) {
     knownArtifacts.push({
@@ -71,23 +209,53 @@ function timeoutPayload(timeoutMs) {
       metadata: { artifacts },
     });
   }
+  for (const artifact of discovered.artifacts) {
+    if (!knownArtifacts.some((knownArtifact) => knownArtifact.path === artifact.path)) {
+      knownArtifacts.push(artifact);
+    }
+  }
+
+  const evidenceRefs = evidencePath && fs.existsSync(evidencePath) ? [{
+    kind: 'codebox-task-runner-preflight',
+    uri: evidencePath,
+    label: 'WP Codebox task runner preflight evidence',
+  }] : [];
+  for (const ref of discovered.evidenceRefs) {
+    if (!evidenceRefs.some((knownRef) => knownRef.uri === ref.uri)) {
+      evidenceRefs.push(ref);
+    }
+  }
 
   return {
     success: false,
     timeout: true,
     summary: `WP Codebox agent task timed out after ${timeoutMs}ms.`,
     artifacts: knownArtifacts,
-    evidence_refs: evidencePath && fs.existsSync(evidencePath) ? [{
-      kind: 'codebox-task-runner-preflight',
-      uri: evidencePath,
-      label: 'WP Codebox task runner preflight evidence',
-    }] : [],
+    evidence_refs: evidenceRefs,
     diagnostics: [{
       class: 'codebox.timeout',
       message: 'Task runner exceeded the AgentTaskRequest timeout.',
-      data: { timeout_ms: timeoutMs, artifacts, evidence_path: evidencePath },
+      data: {
+        timeout_ms: timeoutMs,
+        classification: 'provider_timeout',
+        artifacts,
+        evidence_path: evidencePath,
+        artifact_ref_count: knownArtifacts.length,
+        runtime_id: discovered.runtimeId,
+        last_known_phase: discovered.lastKnownPhase,
+        last_heartbeat: discovered.lastHeartbeat,
+      },
     }],
-    metadata: { timeout_ms: timeoutMs, artifacts, evidence_path: evidencePath },
+    metadata: {
+      timeout_ms: timeoutMs,
+      timeout_classification: 'provider_timeout',
+      artifacts,
+      evidence_path: evidencePath,
+      artifact_ref_count: knownArtifacts.length,
+      runtime_id: discovered.runtimeId,
+      last_known_phase: discovered.lastKnownPhase,
+      last_heartbeat: discovered.lastHeartbeat,
+    },
   };
 }
 

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -282,6 +282,23 @@ try {
   assert.equal(JSON.parse(contractResult.stdout).id, 'wordpress.codebox-agent-task-executor');
 
   const artifactRoot = path.join(root, 'timeout-artifacts');
+  const bundleRoot = path.join(artifactRoot, 'artifact-task-timeout');
+  const filesRoot = path.join(bundleRoot, 'files');
+  fs.mkdirSync(filesRoot, { recursive: true });
+  fs.writeFileSync(path.join(bundleRoot, 'manifest.json'), JSON.stringify({
+    schema: 'wp-codebox/artifact-manifest/v1',
+    phase: 'agent.inspecting-runtime',
+  }));
+  fs.writeFileSync(path.join(filesRoot, 'runtime-reference-manifest.json'), JSON.stringify({
+    schema: 'wp-codebox/runtime-reference-manifest/v1',
+    runtime: { id: 'runtime-task-timeout' },
+  }));
+  fs.writeFileSync(path.join(filesRoot, 'command.log'), 'ran wp-codebox.agent-sandbox-run\n');
+  fs.writeFileSync(path.join(filesRoot, 'agent-transcript.jsonl'), '{"role":"assistant","content":"partial transcript"}\n');
+  fs.writeFileSync(path.join(filesRoot, 'heartbeat.json'), JSON.stringify({
+    phase: 'agent.inspecting-runtime',
+    heartbeat: { at: '2026-06-01T00:00:00.000Z', turn: 3 },
+  }));
   const hangingRequest = {
     ...request,
     task_id: 'task-timeout',
@@ -306,6 +323,15 @@ try {
   assert.equal(timeoutOutcome.diagnostics[0].data.timeout_ms, 1000);
   assert.equal(timeoutOutcome.artifacts[0].path, artifactRoot);
   assert.equal(timeoutOutcome.metadata.codebox.evidence_path, path.join(artifactRoot, 'homeboy-codebox-task-runner.json'));
+  assert.equal(timeoutOutcome.metadata.codebox.timeout_classification, 'provider_timeout');
+  assert.equal(timeoutOutcome.metadata.codebox.runtime_id, 'runtime-task-timeout');
+  assert.equal(timeoutOutcome.metadata.codebox.last_known_phase, 'agent.inspecting-runtime');
+  assert.equal(timeoutOutcome.metadata.codebox.last_heartbeat.turn, 3);
+  assert.equal(timeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-artifact-bundle' && artifact.path === bundleRoot), true);
+  assert.equal(timeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-runtime-reference-manifest'), true);
+  assert.equal(timeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-command-log'), true);
+  assert.equal(timeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-transcript'), true);
+  assert.equal(timeoutOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-transcript'), true);
 } finally {
   fs.rmSync(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- Preserves WP Codebox artifact-root refs when the Homeboy Extensions Codebox provider times out before a structured runner response is available.
- Adds generic timeout metadata for provider timeout classification, runtime ID, last known phase, heartbeat, artifact ref counts, and evidence refs.
- Covers timeout preservation with the existing Codebox agent-task executor smoke test.

Fixes #1002.

## Tests
- `npm run test:codebox-agent-task-executor`
- `npx eslint scripts/agent/homeboy-codebox-agent-task-executor.cjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the provider timeout artifact-ref preservation and drafting the targeted smoke coverage. Chris remains responsible for review and merge.