### PR TITLE
fix(wordpress): consume Lab mappings and list Codebox bench workloads

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
@@ -8,9 +8,10 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 
 SOURCE_ROOT="${TMP_ROOT}/wp-site-generator"
 EXTRA_WORKLOAD="${TMP_ROOT}/rig-workload.php"
-mkdir -p "${SOURCE_ROOT}/static-sites/demo" "${SOURCE_ROOT}/.github/homeboy"
+mkdir -p "${SOURCE_ROOT}/static-sites/demo" "${SOURCE_ROOT}/.github/homeboy" "${SOURCE_ROOT}/tests/bench"
 printf '<!doctype html><title>Demo</title>\n' > "${SOURCE_ROOT}/static-sites/demo/index.html"
 printf '<?php return array();\n' > "${SOURCE_ROOT}/.github/homeboy/ssi-import-diagnostics.php"
+printf '<?php return function (): array { return array(); };\n' > "${SOURCE_ROOT}/tests/bench/website-generation.php"
 printf '<?php return function (): array { return array(); };\n' > "$EXTRA_WORKLOAD"
 
 RESOLVE_HELPER="${TMP_ROOT}/resolve-context.sh"
@@ -123,7 +124,9 @@ bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
 jq -e '
     .component_id == "wp-site-generator"
     and .iterations == 0
+    and (.scenarios[] | select(.id == "website-generation" and .file == "tests/bench/website-generation.php" and .source == "component"))
     and (.scenarios[] | select(.id == "rig-workload" and .file == "tests/bench/rig-workload.php" and .source == "rig"))
+    and (.scenarios[] | select(.id == "ssi-import" and .source == "configured"))
 ' "$LIST_RESULTS_FILE" >/dev/null
 
 PLUGIN_ROOT="${TMP_ROOT}/plugin-component"

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -172,6 +172,45 @@ homeboy_wp_codebox_extra_workload_scenarios_json() {
     printf '%s\n' "$scenarios"
 }
 
+homeboy_wp_codebox_component_workload_scenarios_json() {
+    local bench_dir="${PLUGIN_PATH}/tests/bench"
+    local scenarios="[]"
+    [ -d "$bench_dir" ] || {
+        printf '%s\n' "$scenarios"
+        return 0
+    }
+
+    local workload_path workload_name scenario_id
+    for workload_path in "$bench_dir"/*.php; do
+        [ -f "$workload_path" ] || continue
+        workload_name="$(basename "$workload_path")"
+        scenario_id="${workload_name%.*}"
+        scenarios=$(jq -nc \
+            --argjson scenarios "$scenarios" \
+            --arg id "$scenario_id" \
+            --arg file "tests/bench/${workload_name}" \
+            '$scenarios + [{id: $id, file: $file, source: "component", iterations: 0, metrics: {}}]')
+    done
+    printf '%s\n' "$scenarios"
+}
+
+homeboy_wp_codebox_configured_workload_scenarios_json() {
+    local workloads_json="$1"
+    printf '%s' "$workloads_json" | jq -c '
+        if type == "array" then . else [] end
+        | map(select((.id? | type) == "string" and .id != ""))
+        | map(
+            {
+                id: .id,
+                source: (if ((.metadata? // {}) | has("scenario_manifest")) then "scenario-manifest" else "configured" end),
+                iterations: 0,
+                metrics: {}
+            }
+            + (if (.label? | type) == "string" and .label != "" then {label: .label} else {} end)
+        )
+    '
+}
+
 homeboy_wp_codebox_find_plugin_file() {
     local plugin_dir="$1"
     local candidate
@@ -491,8 +530,11 @@ if [ "${HOMEBOY_BENCH_LIST_ONLY:-}" = "1" ]; then
     mkdir -p "$(dirname "$RESULTS_FILE")"
     jq -n \
         --arg component "$COMPONENT_ID" \
-        --argjson scenarios "$(homeboy_wp_codebox_extra_workload_scenarios_json)" \
-        '{component_id: $component, iterations: 0, scenarios: $scenarios}' > "$RESULTS_FILE"
+        --argjson componentScenarios "$(homeboy_wp_codebox_component_workload_scenarios_json)" \
+        --argjson extraScenarios "$(homeboy_wp_codebox_extra_workload_scenarios_json)" \
+        --argjson configuredScenarios "$(homeboy_wp_codebox_configured_workload_scenarios_json "$WP_CODEBOX_WORKLOADS_JSON")" \
+        '$componentScenarios + $extraScenarios + $configuredScenarios as $scenarios |
+        {component_id: $component, iterations: 0, scenarios: $scenarios}' > "$RESULTS_FILE"
     exit 0
 fi
 

--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -124,6 +124,133 @@ _homeboy_is_plugin_shaped_path() {
     [ -n "$main_file" ]
 }
 
+_homeboy_lab_workspace_mappings_json() {
+    local raw="${HOMEBOY_LAB_WORKSPACE_MAPPINGS_JSON:-${HOMEBOY_LAB_WORKSPACE_MAP_JSON:-}}"
+
+    if [ -z "$raw" ] && [ -n "${HOMEBOY_LAB_OFFLOAD_JSON:-}" ]; then
+        raw="$HOMEBOY_LAB_OFFLOAD_JSON"
+    fi
+
+    [ -n "$raw" ] || return 1
+
+    printf '%s\n' "$raw"
+}
+
+_homeboy_emit_lab_workspace_mappings() {
+    command -v jq >/dev/null 2>&1 || return 0
+
+    local raw
+    raw=$(_homeboy_lab_workspace_mappings_json || true)
+    [ -n "$raw" ] || return 0
+
+    printf '%s' "$raw" | jq -r '
+        def mapping_stream:
+            if type == "array" then
+                .[]
+                | {
+                    local: (.local_path // .local // .source // .from // empty),
+                    remote: (.remote_path // .remote // .target // .to // empty)
+                }
+            elif type == "object" then
+                to_entries[]
+                | {
+                    local: .key,
+                    remote: (
+                        if (.value | type) == "object" then
+                            (.value.remote_path // .value.remote // .value.target // .value.to // empty)
+                        else
+                            .value
+                        end
+                    )
+                }
+            else
+                empty
+            end;
+
+        if type == "object" then
+            (.workspace_mappings // .workspace_mapping // .workspace_map // .workspaces // .dependency_workspaces // .dependencies // .)
+        else
+            .
+        end
+        | mapping_stream
+        | select(.local != "" and .remote != "")
+        | [.local, .remote]
+        | @tsv
+    ' 2>/dev/null || true
+}
+
+homeboy_translate_lab_workspace_path() {
+    local path_value="${1:-}"
+    [ -n "$path_value" ] || return 1
+
+    local best_local=""
+    local best_remote=""
+    local local_path remote_path local_len
+    while IFS=$'\t' read -r local_path remote_path; do
+        [ -n "$local_path" ] && [ -n "$remote_path" ] || continue
+        case "$path_value" in
+            "$local_path"|"$local_path"/*)
+                local_len=${#local_path}
+                if [ "$local_len" -gt "${#best_local}" ]; then
+                    best_local="$local_path"
+                    best_remote="$remote_path"
+                fi
+                ;;
+        esac
+    done < <(_homeboy_emit_lab_workspace_mappings)
+
+    if [ -n "$best_local" ]; then
+        printf '%s%s\n' "${best_remote%/}" "${path_value#"$best_local"}"
+        return 0
+    fi
+
+    printf '%s\n' "$path_value"
+}
+
+homeboy_translate_validation_dependency_paths() {
+    local dependency_paths="${1:-}"
+    local dependency_path translated_path
+
+    while IFS= read -r dependency_path; do
+        [ -n "$dependency_path" ] || continue
+        translated_path=$(homeboy_translate_lab_workspace_path "$dependency_path" || true)
+        [ -n "$translated_path" ] && printf '%s\n' "$translated_path"
+    done <<< "$dependency_paths"
+}
+
+_homeboy_resolve_lab_mapped_dependency_path() {
+    local dependency="${1:-}"
+    [ -n "$dependency" ] || return 1
+
+    local translated
+    translated=$(homeboy_translate_lab_workspace_path "$dependency" || true)
+    if [ -n "$translated" ] && [ "$translated" != "$dependency" ] && [ -d "$translated" ]; then
+        _homeboy_report_resolved_dependency "$dependency" "Lab workspace mapping" "$translated"
+        printf '%s\n' "$translated"
+        return 0
+    fi
+
+    [[ "$dependency" == */* ]] && return 1
+
+    local local_path remote_path remote_slug local_slug remote_basename local_basename
+    while IFS=$'\t' read -r local_path remote_path; do
+        [ -n "$remote_path" ] && [ -d "$remote_path" ] || continue
+
+        remote_slug=$(homeboy_get_validation_dependency_slug "$remote_path" || true)
+        remote_basename="$(basename "$remote_path")"
+        local_basename="$(basename "$local_path")"
+        local_slug="${local_basename%%@*}"
+
+        if [ "$dependency" = "$remote_slug" ] || [ "$dependency" = "$remote_basename" ] || [ "$dependency" = "$local_slug" ] || [ "$dependency" = "$local_basename" ]; then
+            _homeboy_report_resolved_dependency "$dependency" "Lab workspace mapping" "$remote_path"
+            printf '%s\n' "$remote_path"
+            return 0
+        fi
+    done < <(_homeboy_emit_lab_workspace_mappings)
+
+    return 1
+}
+
 _homeboy_resolve_composer_locked_dependency_path() {
     local dependency="${1:-}"
     local plugin_path="${2:-}"
@@ -344,6 +471,13 @@ homeboy_resolve_validation_dependency_path() {
     local dependency="${1:-}"
 
     [ -z "$dependency" ] && return 1
+
+    local lab_mapped
+    lab_mapped=$(_homeboy_resolve_lab_mapped_dependency_path "$dependency" || true)
+    if [ -n "$lab_mapped" ] && [ -d "$lab_mapped" ]; then
+        printf '%s\n' "$lab_mapped"
+        return 0
+    fi
 
     # 1. Direct path (absolute or relative directory)
     if [ -d "$dependency" ]; then
@@ -586,9 +720,11 @@ homeboy_merge_validation_dependency_paths() {
 
 homeboy_export_validation_dependency_paths() {
     local plugin_path="${1:-}"
-    local existing_paths="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
+    local existing_paths
+    existing_paths=$(homeboy_translate_validation_dependency_paths "${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}")
     local resolved_paths
     resolved_paths=$(HOMEBOY_SUPPRESS_DEPENDENCY_RESOLUTION_LOG=1 homeboy_resolve_validation_dependency_paths "$plugin_path" || true)
+    resolved_paths=$(homeboy_translate_validation_dependency_paths "$resolved_paths")
 
     local merged_paths
     merged_paths="$(homeboy_merge_validation_dependency_paths "$existing_paths" "$resolved_paths")"

--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -43,6 +43,13 @@ cat > "${component}/tests/codebox-agent-task-matrix-smoke.js" <<'JS'
 console.log('codebox agent task matrix smoke ran');
 JS
 
+cat > "${component}/tests/shell-contract-smoke.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "shell contract smoke ran"
+SH
+chmod +x "${component}/tests/shell-contract-smoke.sh"
+
 cat > "${component}/wordpress/tests/codebox-agent-task-matrix-smoke.js" <<'JS'
 console.log('prefixed codebox agent task matrix smoke ran');
 JS
@@ -167,12 +174,37 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${TMPDIR}/stubs/wp-codebox.sh" \
+HOMEBOY_CHANGED_TEST_FILES='wordpress/tests/shell-contract-smoke.sh' \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/changed-prefixed-shell-smoke-files.out"
+
+assert_contains "${TMPDIR}/changed-prefixed-shell-smoke-files.out" "SHELL_SMOKE_BEGIN:tests/shell-contract-smoke.sh"
+assert_contains "${TMPDIR}/changed-prefixed-shell-smoke-files.out" "shell contract smoke ran"
+assert_contains "${TMPDIR}/changed-prefixed-shell-smoke-files.out" "SHELL_SMOKE_SUMMARY:passed=1 failed=0"
+assert_not_contains "${TMPDIR}/changed-prefixed-shell-smoke-files.out" "WP_CODEBOX_STUB"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${TMPDIR}/stubs/wp-codebox.sh" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/codebox-agent-task-matrix-smoke.js > "${TMPDIR}/js-smoke-file.out"
 
 assert_contains "${TMPDIR}/js-smoke-file.out" "JS_SMOKE_BEGIN:tests/codebox-agent-task-matrix-smoke.js"
 assert_contains "${TMPDIR}/js-smoke-file.out" "codebox agent task matrix smoke ran"
 assert_contains "${TMPDIR}/js-smoke-file.out" "JS_SMOKE_SUMMARY:passed=1 failed=0"
 assert_not_contains "${TMPDIR}/js-smoke-file.out" "WP_CODEBOX_STUB"
+
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${TMPDIR}/stubs/wp-codebox.sh" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file wordpress/tests/shell-contract-smoke.sh > "${TMPDIR}/shell-smoke-file.out"
+
+assert_contains "${TMPDIR}/shell-smoke-file.out" "SHELL_SMOKE_BEGIN:tests/shell-contract-smoke.sh"
+assert_contains "${TMPDIR}/shell-smoke-file.out" "shell contract smoke ran"
+assert_contains "${TMPDIR}/shell-smoke-file.out" "SHELL_SMOKE_SUMMARY:passed=1 failed=0"
+assert_not_contains "${TMPDIR}/shell-smoke-file.out" "WP_CODEBOX_STUB"
 
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -91,6 +91,10 @@ homeboy_wordpress_rel_test_file() {
         abs_path="${PLUGIN_PATH}/${raw_path}"
     fi
 
+    if [ ! -f "$abs_path" ] && [[ "$raw_path" == wordpress/* ]]; then
+        abs_path="${PLUGIN_PATH}/${raw_path#wordpress/}"
+    fi
+
     if [ ! -f "$abs_path" ]; then
         return 1
     fi
@@ -165,6 +169,63 @@ homeboy_wordpress_is_js_smoke_file() {
     esac
 }
 
+homeboy_wordpress_run_shell_smoke_files() {
+    local smoke_files_raw="$1"
+    local smoke_files=()
+    local smoke_file smoke_abs rel_path
+    local passed=0
+
+    while IFS= read -r smoke_file; do
+        [ -n "$smoke_file" ] || continue
+        if ! smoke_abs="$(homeboy_wordpress_rel_test_file "$smoke_file")"; then
+            echo "ERROR: requested shell smoke file not found or outside the component: ${smoke_file}" >&2
+            exit 2
+        fi
+        smoke_files+=("${PLUGIN_PATH}/${smoke_abs}")
+    done <<< "$smoke_files_raw"
+
+    if [ "${#smoke_files[@]}" -eq 0 ]; then
+        echo "ERROR: no shell smoke files were selected" >&2
+        exit 2
+    fi
+
+    echo "Running host shell smoke tests..."
+    echo "  Component: ${HOMEBOY_COMPONENT_ID:-$(basename "$PLUGIN_PATH")} (${PLUGIN_PATH})"
+    echo "  Backend: host-shell-smoke"
+    echo "  Files: ${#smoke_files[@]}"
+    echo ""
+
+    for smoke_file in "${smoke_files[@]}"; do
+        rel_path="${smoke_file#"${PLUGIN_PATH}/"}"
+        echo "SHELL_SMOKE_BEGIN:${rel_path}"
+        if bash "$smoke_file"; then
+            echo "SHELL_SMOKE_OK:${rel_path}"
+            passed=$((passed + 1))
+        else
+            exit_code=$?
+            echo "SHELL_SMOKE_FAIL:${rel_path}:exit=${exit_code}"
+            echo ""
+            echo "Shell smoke test failed: ${rel_path}"
+            exit "$exit_code"
+        fi
+    done
+
+    echo ""
+    echo "SHELL_SMOKE_SUMMARY:passed=${passed} failed=0"
+    echo "Host shell smoke test run complete."
+}
+
+homeboy_wordpress_is_shell_smoke_file() {
+    case "$1" in
+        tests/*-smoke.sh|tests/*/*-smoke.sh|tests/*/*/*-smoke.sh|tests/*/*/*/*-smoke.sh|wordpress/tests/*-smoke.sh|wordpress/tests/*/*-smoke.sh|wordpress/tests/*/*/*-smoke.sh|wordpress/tests/*/*/*/*-smoke.sh)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 if [ -z "$TARGET_FILE" ] && [ "${HOMEBOY_TEST_SCOPE_KIND:-}" = "exclusive_env" ]; then
     if [ "${HOMEBOY_TEST_SCOPE_ENV_NAME:-}" = "HOMEBOY_WORDPRESS_HOST_SMOKE_FILES" ] && [ -n "${HOMEBOY_TEST_SCOPE_ENV_VALUE:-}" ]; then
         HOMEBOY_WORDPRESS_HOST_SMOKE_FILES="$HOMEBOY_TEST_SCOPE_ENV_VALUE" exec bash "$HOST_SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
@@ -173,11 +234,12 @@ fi
 
 if [ -z "$TARGET_FILE" ] && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
     changed_js_smoke_files=""
-    changed_non_js_smoke_files=0
+    changed_shell_smoke_files=""
+    changed_non_host_smoke_files=0
     while IFS= read -r changed_test_file; do
         [ -n "$changed_test_file" ] || continue
         if ! changed_test_rel="$(homeboy_wordpress_rel_test_file "$changed_test_file")"; then
-            changed_non_js_smoke_files=1
+            changed_non_host_smoke_files=1
             continue
         fi
         if homeboy_wordpress_is_js_smoke_file "$changed_test_rel"; then
@@ -185,42 +247,41 @@ if [ -z "$TARGET_FILE" ] && [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
                 changed_js_smoke_files+=$'\n'
             fi
             changed_js_smoke_files+="$changed_test_rel"
+        elif homeboy_wordpress_is_shell_smoke_file "$changed_test_rel"; then
+            if [ -n "$changed_shell_smoke_files" ]; then
+                changed_shell_smoke_files+=$'\n'
+            fi
+            changed_shell_smoke_files+="$changed_test_rel"
         else
-            changed_non_js_smoke_files=1
+            changed_non_host_smoke_files=1
         fi
     done <<< "$HOMEBOY_CHANGED_TEST_FILES"
 
-    if [ -n "$changed_js_smoke_files" ] && [ "$changed_non_js_smoke_files" -eq 0 ]; then
+    if [ -n "$changed_js_smoke_files" ] && [ -z "$changed_shell_smoke_files" ] && [ "$changed_non_host_smoke_files" -eq 0 ]; then
         homeboy_wordpress_run_js_smoke_files "$changed_js_smoke_files"
+        exit 0
+    fi
+
+    if [ -z "$changed_js_smoke_files" ] && [ -n "$changed_shell_smoke_files" ] && [ "$changed_non_host_smoke_files" -eq 0 ]; then
+        homeboy_wordpress_run_shell_smoke_files "$changed_shell_smoke_files"
         exit 0
     fi
 fi
 
 if [ -n "$TARGET_FILE" ]; then
-    if [ "${TARGET_FILE#/}" != "$TARGET_FILE" ]; then
-        target_abs="$TARGET_FILE"
-    else
-        target_abs="${PLUGIN_PATH}/${TARGET_FILE}"
-    fi
-
-    if [ ! -f "$target_abs" ]; then
+    if ! target_rel="$(homeboy_wordpress_rel_test_file "$TARGET_FILE")"; then
         echo "ERROR: requested test file not found: ${TARGET_FILE}" >&2
         exit 2
     fi
 
-    case "$target_abs" in
-        "${PLUGIN_PATH}"/*)
-            target_rel="${target_abs#"${PLUGIN_PATH}/"}"
-            ;;
-        *)
-            echo "ERROR: requested test file is outside the component: ${TARGET_FILE}" >&2
-            exit 2
-            ;;
-    esac
-
     target_base="$(basename "$target_rel")"
     if homeboy_wordpress_is_js_smoke_file "$target_rel"; then
         homeboy_wordpress_run_js_smoke_files "$target_rel"
+        exit 0
+    fi
+
+    if homeboy_wordpress_is_shell_smoke_file "$target_rel"; then
+        homeboy_wordpress_run_shell_smoke_files "$target_rel"
         exit 0
     fi
 

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -9,10 +9,11 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 PLUGIN_PATH="${TMPDIR}/component"
 DEP_PATH="${TMPDIR}/dep-plugin@branch"
+REMOTE_DEP_PATH="${TMPDIR}/remote/dep-plugin"
 FAKE_WP_CODEBOX="${TMPDIR}/wp-codebox.js"
 ARGS_FILE="${TMPDIR}/wp-codebox-args.txt"
 ARTIFACTS_DIR="${TMPDIR}/artifacts"
-mkdir -p "${PLUGIN_PATH}/tests" "${PLUGIN_PATH}/config" "${DEP_PATH}/fixtures" "$ARTIFACTS_DIR"
+mkdir -p "${PLUGIN_PATH}/tests" "${PLUGIN_PATH}/config" "${DEP_PATH}/fixtures" "${REMOTE_DEP_PATH}/fixtures" "$ARTIFACTS_DIR"
 
 cat > "${PLUGIN_PATH}/tests/OnlyTest.php" <<'PHP'
 <?php
@@ -23,6 +24,8 @@ printf '<?php /*\nPlugin Name: Example\nNetwork: true\n*/\n' > "${PLUGIN_PATH}/e
 printf 'component-extra\n' > "${PLUGIN_PATH}/config/component-extra.php"
 printf '<?php /*\nPlugin Name: Dep Plugin\n*/\n' > "${DEP_PATH}/dep-plugin.php"
 printf 'dependency-extra\n' > "${DEP_PATH}/fixtures/dep-extra.php"
+printf '<?php /*\nPlugin Name: Dep Plugin Remote Lab Copy\n*/\n' > "${REMOTE_DEP_PATH}/dep-plugin.php"
+printf 'remote dependency-extra\n' > "${REMOTE_DEP_PATH}/fixtures/dep-extra.php"
 
 cat > "$FAKE_WP_CODEBOX" <<'NODE'
 #!/usr/bin/env node
@@ -141,14 +144,19 @@ SETTINGS_JSON=$(jq -nc \
 
 REQUIRED_MOUNTS_JSON=$(jq -nc \
     --arg component "${PLUGIN_PATH}:/wordpress/wp-content/plugins/example" \
-    --arg dep "${DEP_PATH}:/wordpress/wp-content/plugins/dep-plugin" \
+    --arg dep "${REMOTE_DEP_PATH}:/wordpress/wp-content/plugins/dep-plugin" \
     --arg dropin "${PLUGIN_PATH}/db.php:/wordpress/wp-content/db.php" \
     --arg componentExtra "${PLUGIN_PATH}/config/component-extra.php:/wordpress/wp-content/component-extra.php" \
-    --arg depExtra "${DEP_PATH}/fixtures/dep-extra.php:/wordpress/wp-content/dep-extra.php" \
+    --arg depExtra "${REMOTE_DEP_PATH}/fixtures/dep-extra.php:/wordpress/wp-content/dep-extra.php" \
     --arg vendor "${EXTENSION_PATH}/vendor:/wp-codebox-vendor:readonly" \
     --arg extension "${EXTENSION_PATH}:/homeboy-extension:readonly" \
     '[$component, $dep, $dropin, $componentExtra, $depExtra, $vendor, $extension]')
 export REQUIRED_MOUNTS_JSON
+
+LAB_OFFLOAD_JSON=$(jq -nc \
+    --arg depLocal "$DEP_PATH" \
+    --arg depRemote "$REMOTE_DEP_PATH" \
+    '{workspace_mappings: [{local_path: $depLocal, remote_path: $depRemote}]}')
 
 bash -n "$SCRIPT_DIR/test-runner-wp-codebox.sh"
 
@@ -158,6 +166,7 @@ output=$(FAKE_WP_CODEBOX_ARGS_FILE="$ARGS_FILE" \
     HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
     HOMEBOY_COMPONENT_ID="example" \
     HOMEBOY_WORDPRESS_DEPENDENCY_PATHS="$DEP_PATH" \
+    HOMEBOY_LAB_OFFLOAD_JSON="$LAB_OFFLOAD_JSON" \
     HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
     HOMEBOY_CHANGED_TEST_FILES="tests/OnlyTest.php" \
     HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="$ARTIFACTS_DIR" \

--- a/wordpress/tests/validation-dependencies-smoke.sh
+++ b/wordpress/tests/validation-dependencies-smoke.sh
@@ -10,13 +10,14 @@ COMPONENT_DIR="${TMPDIR}/intelligence"
 DATA_MACHINE_DIR="${TMPDIR}/data-machine"
 CLONED_DATA_MACHINE_DIR="${TMPDIR}/cache/data-machine"
 AGENTS_API_DIR="${TMPDIR}/agents-api"
+REMOTE_AGENTS_API_DIR="${TMPDIR}/remote/agents-api"
 VENDORED_AGENTS_API_DIR="${COMPONENT_DIR}/vendor/automattic/agents-api"
 OPENAI_PROVIDER_DIR="${TMPDIR}/ai-provider-for-openai"
 BIN_DIR="${TMPDIR}/bin"
 CLONE_BIN_DIR="${TMPDIR}/clone-bin"
 FALLBACK_CACHE_DIR="${TMPDIR}/fallback-cache"
 
-mkdir -p "$COMPONENT_DIR" "$DATA_MACHINE_DIR" "$CLONED_DATA_MACHINE_DIR" "$AGENTS_API_DIR" "$VENDORED_AGENTS_API_DIR" "$OPENAI_PROVIDER_DIR" "$BIN_DIR" "$CLONE_BIN_DIR" "$FALLBACK_CACHE_DIR"
+mkdir -p "$COMPONENT_DIR" "$DATA_MACHINE_DIR" "$CLONED_DATA_MACHINE_DIR" "$AGENTS_API_DIR" "$REMOTE_AGENTS_API_DIR" "$VENDORED_AGENTS_API_DIR" "$OPENAI_PROVIDER_DIR" "$BIN_DIR" "$CLONE_BIN_DIR" "$FALLBACK_CACHE_DIR"
 
 cat > "${COMPONENT_DIR}/intelligence.php" <<'PHP'
 <?php
@@ -45,6 +46,13 @@ cat > "${AGENTS_API_DIR}/agents-api.php" <<'PHP'
 <?php
 /**
  * Plugin Name: Agents API
+ */
+PHP
+
+cat > "${REMOTE_AGENTS_API_DIR}/agents-api.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Agents API Remote Lab Copy
  */
 PHP
 
@@ -155,6 +163,25 @@ chmod +x "${CLONE_BIN_DIR}/composer"
 
 source "$HELPER"
 
+LAB_OFFLOAD_JSON=$(jq -nc \
+    --arg agentsLocal "$AGENTS_API_DIR" \
+    --arg agentsRemote "$REMOTE_AGENTS_API_DIR" \
+    '{workspace_mappings: [{local_path: $agentsLocal, remote_path: $agentsRemote}]}')
+
+translated=$(HOMEBOY_LAB_OFFLOAD_JSON="$LAB_OFFLOAD_JSON" homeboy_translate_lab_workspace_path "${AGENTS_API_DIR}/fixtures/example.php")
+if [ "$translated" != "${REMOTE_AGENTS_API_DIR}/fixtures/example.php" ]; then
+    echo "FAIL: Lab workspace mapping should translate nested local paths" >&2
+    printf 'translated: %s\n' "$translated" >&2
+    exit 1
+fi
+
+mapped_resolved=$(HOMEBOY_LAB_OFFLOAD_JSON="$LAB_OFFLOAD_JSON" PATH="${BIN_DIR}:$PATH" homeboy_resolve_validation_dependency_path agents-api)
+if [ "$mapped_resolved" != "$REMOTE_AGENTS_API_DIR" ]; then
+    echo "FAIL: Lab workspace mapping should resolve dependency slugs before local registry fallback" >&2
+    printf '%s\n' "$mapped_resolved" >&2
+    exit 1
+fi
+
 resolved=$(PATH="${BIN_DIR}:$PATH" homeboy_resolve_validation_dependency_paths "$COMPONENT_DIR")
 
 if ! grep -F -- "$DATA_MACHINE_DIR" <<< "$resolved" >/dev/null; then
@@ -258,6 +285,29 @@ fi
 if grep -F -- "Homeboy component registry" <<< "$export_output" >/dev/null; then
     echo "FAIL: exported dependency diagnostics should not report discarded resolver candidates" >&2
     printf '%s\n' "$export_output" >&2
+    exit 1
+fi
+
+mapped_export_log=$(mktemp)
+HOMEBOY_WORDPRESS_DEPENDENCY_PATHS="$AGENTS_API_DIR"
+HOMEBOY_LAB_OFFLOAD_JSON="$LAB_OFFLOAD_JSON"
+PATH="${BIN_DIR}:$PATH" homeboy_export_validation_dependency_paths "$COMPONENT_DIR" 2>"$mapped_export_log"
+mapped_export_output=$(cat "$mapped_export_log")
+if ! grep -F -- "$REMOTE_AGENTS_API_DIR" <<< "$HOMEBOY_WORDPRESS_DEPENDENCY_PATHS" >/dev/null; then
+    echo "FAIL: exported dependency paths should include Lab-shipped remote checkouts" >&2
+    printf '%s\n' "$HOMEBOY_WORDPRESS_DEPENDENCY_PATHS" >&2
+    exit 1
+fi
+
+if grep -F -- "$AGENTS_API_DIR" <<< "$HOMEBOY_WORDPRESS_DEPENDENCY_PATHS" >/dev/null; then
+    echo "FAIL: exported dependency paths should not retain mapped local checkouts" >&2
+    printf '%s\n' "$HOMEBOY_WORDPRESS_DEPENDENCY_PATHS" >&2
+    exit 1
+fi
+
+if ! grep -F -- "Resolved dependency 'agents-api' via final validation dependency path: ${REMOTE_AGENTS_API_DIR}" <<< "$mapped_export_output" >/dev/null; then
+    echo "FAIL: mapped export diagnostics should report the remote dependency path" >&2
+    printf '%s\n' "$mapped_export_output" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Consume Lab-provided local-to-remote workspace mappings when resolving WordPress validation dependencies.
- Translate exported `HOMEBOY_WORDPRESS_DEPENDENCY_PATHS` before WP Codebox recipes are built, so shipped remote dependency checkouts are mounted instead of local controller paths.
- Route changed-scope shell smoke tests through the host shell runner, including `wordpress/tests/...` paths selected from the monorepo root.
- Extend resolver, WP Codebox, and test-router shell smoke coverage for mapped dependency paths.

## Related
- Closes https://github.com/Extra-Chill/homeboy-extensions/issues/1004
- Supports https://github.com/Extra-Chill/homeboy/issues/3292
- Supports https://github.com/Extra-Chill/homeboy/issues/3293

## Tests
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `bash wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/test-runner-file-routing-smoke.sh wordpress/scripts/lib/validation-dependencies.sh wordpress/tests/validation-dependencies-smoke.sh wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- Temporarily linked the installed `wordpress` extension to this worktree, then ran `homeboy lint --force-hot --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-lab-shipped-dependencies/wordpress --extension wordpress --changed-since origin/main --summary`
- With that temporary link, ran `homeboy test --force-hot --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-lab-shipped-dependencies/wordpress --extension wordpress --changed-since origin/main --skip-lint`

## Notes
- The installed `wordpress` extension link was restored afterward to `/Users/chubes/Developer/homeboy-extensions/wordpress`.
- Earlier unscoped full-component checks hit the globally installed extension / full fixture suite rather than this PR's changed-scope path; the PR now includes the router fix needed for the changed shell smoke selected by Homeboy.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing WordPress Lab dependency consumption.