### PR TITLE
Surface npm install failures in WordPress builds

### DIFF
--- a/wordpress/scripts/build/build-helper-smoke.sh
+++ b/wordpress/scripts/build/build-helper-smoke.sh
@@ -76,6 +76,6 @@ JSON
         bash "${EXTENSION_DIR}/scripts/build/build.sh" >/dev/null
 )
 
-assert_contains "$npm_log" "install --silent --no-audit --no-fund --legacy-peer-deps"
+assert_contains "$npm_log" "install --no-audit --no-fund --legacy-peer-deps"
 
 echo "WordPress build helper smoke passed."

--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -358,7 +358,7 @@ install_frontend_dependencies() {
     elif [ -f "package-lock.json" ] && [ "package-lock.json" -nt "node_modules/.package-lock.json" ]; then
         print_warning "${scope_label}package-lock.json is newer than node_modules. Reinstalling dependencies..."
         need_install=1
-    elif [ -f "package-lock.json" ] && ! npm ls --depth=0 --silent >/dev/null 2>&1; then
+    elif [ -f "package-lock.json" ] && ! npm ls --depth=0 $(npm_install_flags) >/dev/null 2>&1; then
         print_warning "${scope_label}node_modules contains missing or invalid packages. Reinstalling dependencies..."
         need_install=1
     elif [ -n "$expected_bin" ] && [ ! -x "node_modules/.bin/$expected_bin" ]; then
@@ -368,9 +368,9 @@ install_frontend_dependencies() {
 
     if [ "$need_install" -eq 1 ]; then
         if [ -f "package-lock.json" ]; then
-            run_npm_install ci --silent 2>&1
+            run_npm_install ci 2>&1
         else
-            run_npm_install install --silent 2>&1
+            run_npm_install install 2>&1
         fi
         print_success "${scope_label}npm dependencies ready"
     fi


### PR DESCRIPTION
## Summary
- Stop passing `--silent` to build-time `npm ci`/`npm install` so install failures are visible in logs.
- Reuse the build helper's npm install flags for `npm ls`, including `--legacy-peer-deps` when modern WordPress/React dependency splits require it.
- Update the build helper smoke expectation for the non-silent install command.

Closes #964.

## Verification
- `bash scripts/build/build-helper-smoke.sh`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions/wordpress --extension wordpress --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions/wordpress --extension wordpress --skip-lint --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Used Codebox/Codex fan-out artifacts to identify the target change, then manually reduced the generated full-file patch to the smallest safe build-script/test update and ran verification. Chris requested continuing the proof path.