### PR TITLE
fix(wordpress): update Codebox agent task dependency

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -435,10 +435,10 @@ runner request, invokes the Codebox recipe runner, and emits a
 `homeboy/agent-task-outcome/v1` outcome with normalized status, artifacts,
 evidence refs, diagnostics, and failure classification.
 
-The richer sandbox-agent host-tool registration surface is blocked on
-https://github.com/chubes4/wp-codebox/issues/392. Until that lands, this provider
-is a preparatory contract plus request/outcome adapter around the current
-`wp-codebox.agent-sandbox-run` command boundary.
+Removing the Homeboy-owned WP Codebox task runner is blocked on the upstream
+agent task runner API tracked in https://github.com/chubes4/wp-codebox/issues/480.
+Until that lands, this provider is a preparatory contract plus request/outcome
+adapter around the current `wp-codebox.agent-sandbox-run` command boundary.
 
 Approved artifact-map entries become `apply_back` records for the reviewed
 apply adapter. Rejected entries with `approved: false` become `issue_reports`

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -176,10 +176,10 @@ the extension-owned WP Codebox request shape, then translating Codebox output ba
 to `AgentTaskOutcome` with Homeboy-native artifacts, evidence refs, diagnostics,
 and failure classifications.
 
-The provider is intentionally marked preparatory while Codebox's generic host-tool
-registry is still tracked in https://github.com/chubes4/wp-codebox/issues/392.
-Once that surface lands, the same provider contract can attach richer sandbox
-tools without moving Codebox-specific logic into Homeboy core.
+The provider is intentionally marked preparatory while Codebox's upstream agent
+task runner API is still tracked in https://github.com/chubes4/wp-codebox/issues/480.
+Once that surface lands, the same provider contract can remove Homeboy-owned
+recipe synthesis without moving Codebox-specific logic into Homeboy core.
 
 ## Runner config surface
 

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -36,7 +36,7 @@ function providerContract(options = {}) {
     outcome_schema: AGENT_TASK_OUTCOME_SCHEMA,
     capabilities: PROVIDER_CAPABILITIES,
     status: 'preparatory',
-    upstream_dependency: 'https://github.com/chubes4/wp-codebox/issues/392',
+    upstream_dependency: 'https://github.com/chubes4/wp-codebox/issues/480',
   };
 }
 
@@ -187,7 +187,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     metadata: {
       provider: 'wordpress.codebox-agent-task-executor',
       codebox: sanitizePublicMetadata(result.metadata || result),
-      upstream_dependency: 'https://github.com/chubes4/wp-codebox/issues/392',
+      upstream_dependency: 'https://github.com/chubes4/wp-codebox/issues/480',
     },
   };
   if (failureClassification) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -87,7 +87,7 @@ const provider = providerContract();
 assert.equal(provider.backend, 'codebox');
 assert.equal(provider.request_schema, 'homeboy/agent-task-request/v1');
 assert.equal(provider.outcome_schema, 'homeboy/agent-task-outcome/v1');
-assert.equal(provider.upstream_dependency, 'https://github.com/chubes4/wp-codebox/issues/392');
+assert.equal(provider.upstream_dependency, 'https://github.com/chubes4/wp-codebox/issues/480');
 assert.equal(provider.capabilities.includes('browser_runtime'), true);
 
 const codeboxRequest = codeboxTaskRequestFromAgentTaskRequest(request);

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -35,7 +35,7 @@
         "structured_outcome"
       ],
       "status": "preparatory",
-      "upstream_dependency": "https://github.com/chubes4/wp-codebox/issues/392"
+      "upstream_dependency": "https://github.com/chubes4/wp-codebox/issues/480"
     }
   ],
   "scripts": {


### PR DESCRIPTION
## Summary
- Replaces stale closed `wp-codebox#392` metadata/docs references with the current `wp-codebox#480` agent task runner API dependency.
- Keeps the Homeboy-owned WP Codebox task runner in place because the upstream replacement contract has not landed yet.

## Verification
- `npm run test:codebox-agent-task-executor`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspected the upstream issue dependency shape, updated stale dependency metadata/docs, and ran targeted verification; Chris remains responsible for review and merge.