### PR TITLE
feat(nodejs): add package script bench helper

### DIFF
--- a/nodejs/docs/workload-utils.md
+++ b/nodejs/docs/workload-utils.md
@@ -19,6 +19,7 @@ concepts:
 - `resolvePath(value, options)` expands `~`, preserves absolute paths, and resolves relative paths from `options.baseDir`, `HOMEBOY_COMPONENT_PATH`, or the current working directory.
 - `metric(value, fallback)` coerces finite numeric values.
 - `runCommand(command, args, options)` runs a subprocess with redacted output by default.
+- `runPackageScriptBench(options)` runs a `package.json` script with optional spec args and returns the standard bench workload shape: `{ metrics, artifacts, metadata }`.
 - `writeJson(file, data)` and `writeText(file, data)` create parent directories and redact common secrets.
 - `runId(name)` creates a sanitized run identifier.
 - `artifactDir(name)` returns a directory under `HOMEBOY_BENCH_SHARED_STATE` or the OS temp directory.
@@ -32,3 +33,26 @@ Typed setting helpers use the same precedence as `setting()`: values in
 helper reads `HOMEBOY_SETTINGS_<KEY>`, or a custom `options.prefix` when one is
 provided. Invalid typed values return the helper fallback instead of throwing so
 workloads can keep a single defaulting path.
+
+## Package Script Bench Helper
+
+Use `runPackageScriptBench()` when a workload only needs to benchmark an existing
+package script or a subset of specs accepted by that script.
+
+```js
+const { runPackageScriptBench } = await import(process.env.HOMEBOY_NODEJS_WORKLOAD_UTILS);
+
+export default async function () {
+  return runPackageScriptBench({
+    script: 'test:e2e',
+    specs: ['specs/editor.spec.ts'],
+    timeoutMs: 120_000,
+  });
+}
+```
+
+The helper detects `pnpm`, `yarn`, or `npm` from the component root, validates
+that the script exists, forwards `args` followed by `specs`, writes a redacted
+JSON artifact with command output, and returns neutral metrics such as
+`package_script_elapsed_ms`, `package_script_exit_code`, and
+`package_script_spec_count`.

--- a/nodejs/scripts/bench/lib/workload-utils.mjs
+++ b/nodejs/scripts/bench/lib/workload-utils.mjs
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
@@ -179,6 +179,100 @@ export function runNode(args, options = {}) {
     return runCommand(options.nodeBinary || process.env.HOMEBOY_NODE_BINARY || 'node', args, options);
 }
 
+/**
+ * Run a package.json script as a benchmark workload and return the standard
+ * `{ metrics, artifacts, metadata }` shape consumed by bench-runner.mjs.
+ */
+export async function runPackageScriptBench(options = {}) {
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+        throw new Error('runPackageScriptBench requires an options object.');
+    }
+    if (!options.script || typeof options.script !== 'string') {
+        throw new Error('runPackageScriptBench requires a package script name.');
+    }
+
+    const cwd = resolvePath(options.cwd || process.env.HOMEBOY_COMPONENT_PATH || process.cwd());
+    const packageJson = await readPackageJson(cwd, options.packageJsonPath);
+    if (!packageJson.scripts || typeof packageJson.scripts[options.script] !== 'string') {
+        throw new Error(`package script "${options.script}" is not defined in ${packageJson.path}`);
+    }
+
+    const packageManager = options.packageManager || await detectPackageManager(cwd);
+    const scriptArgs = normalizeStringList(options.args);
+    const specs = normalizeStringList(options.specs || options.specFiles);
+    const forwardedArgs = [...scriptArgs, ...specs];
+    const command = packageScriptCommand(packageManager, options.script, forwardedArgs);
+    const result = await runCommand(command.command, command.args, {
+        cwd,
+        env: options.env,
+        timeoutMs: options.timeoutMs,
+        allowFailure: options.allowFailure,
+        redaction: options.redaction,
+        redact: options.redact,
+    });
+
+    const context = options.artifactContext || createArtifactContext({
+        id: options.id || options.script,
+        sharedState: options.sharedState,
+        runId: options.runId,
+        artifactsDir: options.artifactsDir,
+    });
+    const artifactName = options.artifactName || 'package-script-result';
+    const artifact = await context.writeJson(artifactName, {
+        package_manager: packageManager,
+        script: options.script,
+        command: command.command,
+        args: command.args,
+        cwd,
+        specs,
+        code: result.code,
+        signal: result.signal,
+        elapsed_ms: result.elapsedMs,
+        stdout: result.stdout,
+        stderr: result.stderr,
+    }, { label: options.artifactLabel || `Package script ${options.script} result` });
+
+    return {
+        metrics: {
+            package_script_elapsed_ms: metric(result.elapsedMs),
+            package_script_exit_code: metric(result.code),
+            package_script_stdout_bytes: Buffer.byteLength(result.stdout || ''),
+            package_script_stderr_bytes: Buffer.byteLength(result.stderr || ''),
+            package_script_spec_count: specs.length,
+        },
+        artifacts: {
+            [artifactName]: artifact,
+        },
+        metadata: {
+            package_manager: packageManager,
+            package_script: options.script,
+            package_script_arg_count: forwardedArgs.length,
+            package_script_spec_count: specs.length,
+        },
+    };
+}
+
+export async function detectPackageManager(cwd = process.env.HOMEBOY_COMPONENT_PATH || process.cwd()) {
+    const root = resolvePath(cwd);
+    if (await fileExists(path.join(root, 'pnpm-lock.yaml'))) return 'pnpm';
+    if (await fileExists(path.join(root, 'yarn.lock'))) return 'yarn';
+    return 'npm';
+}
+
+export function packageScriptCommand(packageManager, script, args = []) {
+    const forwardedArgs = normalizeStringList(args);
+    switch (packageManager) {
+        case 'pnpm':
+            return { command: 'pnpm', args: ['run', script, ...scriptSeparator(forwardedArgs), ...forwardedArgs] };
+        case 'yarn':
+            return { command: 'yarn', args: [script, ...forwardedArgs] };
+        case 'npm':
+            return { command: 'npm', args: ['run', script, ...scriptSeparator(forwardedArgs), ...forwardedArgs] };
+        default:
+            throw new Error(`Unsupported package manager "${packageManager}".`);
+    }
+}
+
 export async function writeJson(file, data, options = {}) {
     await mkdir(path.dirname(file), { recursive: true });
     const value = options.redact === false
@@ -219,6 +313,38 @@ function sanitizeSegment(value) {
         .replace(/[^A-Za-z0-9._-]+/g, '-')
         .replace(/^-+|-+$/g, '');
     return segment || 'workload';
+}
+
+async function readPackageJson(cwd, packageJsonPath) {
+    const file = packageJsonPath ? resolvePath(packageJsonPath, { baseDir: cwd }) : path.join(cwd, 'package.json');
+    try {
+        const parsed = JSON.parse(await readFile(file, 'utf8'));
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            throw new Error('package.json root must be an object');
+        }
+        return { ...parsed, path: file };
+    } catch (error) {
+        throw new Error(`Unable to read package.json at ${file}: ${error.message}`);
+    }
+}
+
+async function fileExists(file) {
+    try {
+        await access(file);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function normalizeStringList(value) {
+    if (value === undefined || value === null || value === '') return [];
+    const values = Array.isArray(value) ? value : [value];
+    return values.map((item) => String(item)).filter((item) => item !== '');
+}
+
+function scriptSeparator(args) {
+    return args.length > 0 ? ['--'] : [];
 }
 
 function settingValue(key, fallback = undefined, options = {}) {

--- a/nodejs/scripts/bench/nodejs-package-script-bench-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-package-script-bench-smoke.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-node-package-script-bench.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PROJECT_DIR="$TMP_DIR/project"
+mkdir -p "$PROJECT_DIR/specs"
+
+cat > "$PROJECT_DIR/package.json" <<'JSON'
+{
+  "name": "package-script-bench-smoke",
+  "scripts": {
+    "bench:e2e": "node fake-e2e-runner.mjs"
+  }
+}
+JSON
+
+cat > "$PROJECT_DIR/fake-e2e-runner.mjs" <<'JS'
+import { writeFileSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+writeFileSync('received-args.json', JSON.stringify(args));
+
+if (args.join('\n') !== '--project=chromium\nspecs/editor.spec.ts') {
+  console.error(`Unexpected args: ${JSON.stringify(args)}`);
+  process.exit(1);
+}
+
+console.log('fake e2e passed token=abc');
+console.error('Authorization: Bearer secret');
+JS
+
+touch "$PROJECT_DIR/specs/editor.spec.ts"
+
+HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+HOMEBOY_BENCH_ARTIFACTS_DIR="$TMP_DIR/artifacts" \
+WORKLOAD_UTILS_UNDER_TEST="$SCRIPT_DIR/lib/workload-utils.mjs" \
+node --input-type=module - <<'EOF'
+import { readFile } from 'node:fs/promises';
+import assert from 'node:assert/strict';
+
+const { runPackageScriptBench } = await import(process.env.WORKLOAD_UTILS_UNDER_TEST);
+
+const result = await runPackageScriptBench({
+  id: 'fake-e2e',
+  script: 'bench:e2e',
+  args: ['--project=chromium'],
+  specs: ['specs/editor.spec.ts'],
+  runId: 'package-script-smoke',
+});
+
+assert.equal(result.metrics.package_script_exit_code, 0);
+assert.equal(result.metrics.package_script_spec_count, 1);
+assert.equal(result.metadata.package_manager, 'npm');
+assert.equal(result.metadata.package_script, 'bench:e2e');
+assert.equal(result.metadata.package_script_arg_count, 2);
+assert.ok(result.metrics.package_script_elapsed_ms >= 0);
+assert.ok(result.metrics.package_script_stdout_bytes > 0);
+assert.ok(result.metrics.package_script_stderr_bytes > 0);
+
+const artifact = result.artifacts['package-script-result'];
+assert.equal(artifact.kind, 'json');
+assert.equal(artifact.label, 'Package script bench:e2e result');
+
+const payload = JSON.parse(await readFile(artifact.path, 'utf8'));
+assert.equal(payload.script, 'bench:e2e');
+assert.deepEqual(payload.args, ['run', 'bench:e2e', '--', '--project=chromium', 'specs/editor.spec.ts']);
+assert.deepEqual(payload.specs, ['specs/editor.spec.ts']);
+assert.equal(payload.code, 0);
+assert.match(payload.stdout, /fake e2e passed/);
+assert.doesNotMatch(payload.stdout, /abc/);
+assert.doesNotMatch(payload.stderr, /secret/);
+
+const receivedArgs = JSON.parse(await readFile(`${process.env.HOMEBOY_COMPONENT_PATH}/received-args.json`, 'utf8'));
+assert.deepEqual(receivedArgs, ['--project=chromium', 'specs/editor.spec.ts']);
+
+let missingScriptFailed = false;
+try {
+  await runPackageScriptBench({ script: 'missing' });
+} catch (error) {
+  missingScriptFailed = true;
+  assert.match(error.message, /package script "missing" is not defined/);
+}
+assert.equal(missingScriptFailed, true);
+EOF
+
+echo "Node.js package script bench smoke passed."


### PR DESCRIPTION
## Summary
- Adds `runPackageScriptBench()` to Node.js workload utilities for package-script/spec-subset benchmark workloads.
- Records redacted package-script command output as a bench artifact with neutral metrics and metadata.
- Documents the helper and adds a fake package-script smoke test covering args, specs, artifacts, and redaction.

## Tests
- `bash nodejs/scripts/bench/nodejs-package-script-bench-smoke.sh`
- `bash nodejs/scripts/bench/nodejs-workload-utils-smoke.sh`
- `for script in nodejs/scripts/bench/nodejs-bench-artifact-context-smoke.sh nodejs/scripts/bench/nodejs-bench-artifacts-smoke.sh nodejs/scripts/bench/nodejs-bench-custom-metrics-smoke.sh nodejs/scripts/bench/nodejs-bench-warmup-smoke.sh nodejs/scripts/bench/nodejs-package-script-bench-smoke.sh nodejs/scripts/bench/nodejs-workload-utils-smoke.sh; do bash "$script"; done`
- `node --check nodejs/scripts/bench/lib/workload-utils.mjs`
- `bash -n nodejs/scripts/bench/nodejs-package-script-bench-smoke.sh`
- `git diff --check`

## Notes
- `homeboy test --extension nodejs` and `homeboy lint --extension nodejs` did not run the extension smokes in this checkout shape; both failed during preflight because the Node.js runner required a `package.json` at or above the selected path.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/1008

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the helper implementation, documentation, smoke coverage, and verification commands for Chris to review.