### PR TITLE
wordpress: promote reusable block quality probes

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -232,6 +232,93 @@ The helper returns a `fixtureSetup` summary and writes
 steps throw errors that include the fixture label, command, exit code, stdout,
 and stderr.
 
+## Reusable Block Quality Probes
+
+WordPress workloads can collect product-neutral block quality counts without
+copying PHP probe strings into each rig. Import the helpers from `wordpress` or
+from `wordpress/lib/block-quality.js`:
+
+```js
+const {
+	probeWordPressBlockQuality,
+	probeWordPressPostBlockQuality,
+} = require('./wordpress');
+
+const siteQuality = await probeWordPressBlockQuality('/path/to/site', {
+	postTypes: ['page', 'post', 'wp_template', 'wp_template_part'],
+	postStatuses: ['any'],
+});
+
+const pageQuality = await probeWordPressPostBlockQuality('/path/to/site', 123);
+```
+
+The site probe reports stable WordPress counters:
+
+```json
+{
+	"posts_seen": 4,
+	"posts_with_content": 4,
+	"posts_with_blocks": 3,
+	"pages_seen": 1,
+	"templates_seen": 1,
+	"template_parts_seen": 1,
+	"raw_html_unconverted": 1,
+	"total_blocks": 18,
+	"core_html_blocks": 2,
+	"serialized_block_comments": 18,
+	"fallback_count": 0,
+	"core_html_without_fallback": 2,
+	"post_type_counts": { "page": 1, "post": 1, "wp_template": 1, "wp_template_part": 1 }
+}
+```
+
+The post-scoped probe includes the same counts plus `post_id`, `post_type`,
+`post_title`, `stored_content_hash`, `stored_content_bytes`, and
+`stored_content_preview`. Pass `contentPreviewBytes` to adjust the preview size.
+
+Fallback counts are opt-in and product-neutral. If a workload owns a fallback
+counter option, pass `fallbackOptionNames: ['example_fallback_count']`; the probe
+sums those options into `fallback_count` and subtracts it from
+`core_html_without_fallback`.
+
+## Reusable Editor Canvas Probes
+
+The WordPress extension also exports generic editor canvas helpers from
+`wordpress/lib/editor-canvas-probes.js`:
+
+```js
+const {
+	waitForWordPressEditorCanvas,
+	captureWordPressEditorCanvasScreenshot,
+	summarizeVisibleSelectors,
+} = require('./wordpress');
+
+await waitForWordPressEditorCanvas(page, {
+	url: `${baseUrl}/wp-admin/site-editor.php`,
+});
+
+await captureWordPressEditorCanvasScreenshot(
+	page,
+	'artifacts/editor-canvas.png',
+	{ url: `${baseUrl}/wp-admin/site-editor.php` }
+);
+
+const selectors = await summarizeVisibleSelectors(page, [
+	{ name: 'hero', selectors: ['.hero', '.wp-block-cover'] },
+	{ name: 'footer', selector: 'footer' },
+]);
+```
+
+`waitForWordPressEditorCanvas()` waits for `iframe[name="editor-canvas"]`, then
+waits inside the frame until `.block-editor-block-list__layout` has dimensions,
+is not visibly loading, and contains at least one editor block. It applies a
+small stabilizing stylesheet by default so screenshots are less noisy.
+
+`summarizeVisibleSelectors()` is intentionally generic: it returns per-selector
+match counts, visible counts, nonzero bounding-box counts, first-match text, and
+group/totals summaries. Product-specific visual parity gates should stay in the
+rig or workload that owns those expectations.
+
 ## Block Theme Quality Probe
 
 Playground scenario graders can call a generic PHP-first WordPress quality probe

--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -5,6 +5,8 @@ module.exports = {
 	...require('./lib/wordpress-bootstrap-timeline'),
 	...require('./lib/request-profiler'),
 	...require('./lib/page-profiler'),
+	...require('./lib/block-quality'),
+	...require('./lib/editor-canvas-probes'),
 	...require('./lib/timing-correlator'),
 	...require('./lib/codebox-memory-report'),
 	...require('./lib/agent-terminal-actions'),

--- a/wordpress/lib/block-quality.js
+++ b/wordpress/lib/block-quality.js
@@ -1,0 +1,303 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const { spawn } = require('node:child_process');
+
+/**
+ * Internal dependencies
+ */
+const { isPlainObject } = require('./shared');
+
+const DEFAULT_POST_TYPES = ['page', 'post', 'wp_template', 'wp_template_part'];
+const DEFAULT_POST_STATUSES = ['any'];
+const DEFAULT_CONTENT_PREVIEW_BYTES = 2000;
+
+function wordpressBlockQualityProbeCode(options = {}) {
+ const config = encodeProbeConfig(normalizeBlockQualityOptions(options));
+ return phpProbe(`
+$homeboy_config = json_decode( base64_decode( '${config}' ), true );
+$post_types = isset( $homeboy_config['post_types'] ) && is_array( $homeboy_config['post_types'] ) ? $homeboy_config['post_types'] : array( 'page', 'post', 'wp_template', 'wp_template_part' );
+$post_statuses = isset( $homeboy_config['post_statuses'] ) && is_array( $homeboy_config['post_statuses'] ) ? $homeboy_config['post_statuses'] : array( 'any' );
+$fallback_option_names = isset( $homeboy_config['fallback_option_names'] ) && is_array( $homeboy_config['fallback_option_names'] ) ? $homeboy_config['fallback_option_names'] : array();
+
+$counts = homeboy_wordpress_empty_block_quality_counts();
+$counts['fallback_count'] = homeboy_wordpress_fallback_option_total( $fallback_option_names );
+
+$posts = get_posts( array(
+    'post_type'   => $post_types,
+    'post_status' => $post_statuses,
+    'numberposts' => -1,
+) );
+
+foreach ( $posts as $post ) {
+    homeboy_wordpress_add_post_block_quality( $counts, $post );
+}
+
+$counts['core_html_without_fallback'] = max( 0, $counts['core_html_blocks'] - $counts['fallback_count'] );
+
+echo wp_json_encode( $counts, JSON_PRETTY_PRINT ) . PHP_EOL;
+`);
+}
+
+function wordpressPostBlockQualityProbeCode(postId, options = {}) {
+ const config = encodeProbeConfig({
+  ...normalizeBlockQualityOptions(options),
+  post_id: requiredPositiveInteger(postId, 'postId'),
+  content_preview_bytes: normalizeContentPreviewBytes(options.contentPreviewBytes),
+ });
+ return phpProbe(`
+$homeboy_config = json_decode( base64_decode( '${config}' ), true );
+$post_id = absint( $homeboy_config['post_id'] );
+$fallback_option_names = isset( $homeboy_config['fallback_option_names'] ) && is_array( $homeboy_config['fallback_option_names'] ) ? $homeboy_config['fallback_option_names'] : array();
+$content_preview_bytes = isset( $homeboy_config['content_preview_bytes'] ) ? absint( $homeboy_config['content_preview_bytes'] ) : 2000;
+
+$post = get_post( $post_id );
+if ( ! $post ) {
+    fwrite( STDERR, 'WordPress post not found: ' . $post_id );
+    exit( 1 );
+}
+
+$counts = homeboy_wordpress_empty_block_quality_counts();
+$counts['fallback_count'] = homeboy_wordpress_fallback_option_total( $fallback_option_names );
+homeboy_wordpress_add_post_block_quality( $counts, $post );
+$content = (string) $post->post_content;
+$counts['post_id'] = $post_id;
+$counts['post_type'] = (string) $post->post_type;
+$counts['post_title'] = (string) $post->post_title;
+$counts['stored_content_hash'] = hash( 'sha256', $content );
+$counts['stored_content_bytes'] = strlen( $content );
+$counts['stored_content_preview'] = substr( $content, 0, $content_preview_bytes );
+$counts['core_html_without_fallback'] = max( 0, $counts['core_html_blocks'] - $counts['fallback_count'] );
+
+echo wp_json_encode( $counts, JSON_PRETTY_PRINT ) . PHP_EOL;
+`);
+}
+
+async function probeWordPressBlockQuality(sitePath, options = {}) {
+ const result = await runWordPressEval(wordpressBlockQualityProbeCode(options), sitePath, options);
+ return parseWordPressBlockQualityProbeOutput(result.stdout);
+}
+
+async function probeWordPressPostBlockQuality(sitePath, postId, options = {}) {
+ const result = await runWordPressEval(wordpressPostBlockQualityProbeCode(postId, options), sitePath, options);
+ return parseWordPressBlockQualityProbeOutput(result.stdout);
+}
+
+function parseWordPressBlockQualityProbeOutput(stdout) {
+ const text = String(stdout || '');
+ const jsonStart = text.indexOf('{');
+ if (jsonStart === -1) {
+  throw new Error(`WordPress block quality probe did not emit JSON: ${text.slice(0, 1000)}`);
+ }
+ return JSON.parse(text.slice(jsonStart));
+}
+
+async function runWordPressEval(code, sitePath, options = {}) {
+ const command = `eval ${quoteShell(code)}`;
+ const runCli = options.runCli || defaultRunCli;
+ const result = normalizeCliResult(await runCli(command, {
+  ...options,
+  role: options.role || 'wordpress-block-quality-probe',
+  sitePath,
+ }));
+ if (result.exitCode !== 0) {
+  throw new Error(`WordPress block quality probe failed with exit code ${result.exitCode}: ${result.stderr || result.stdout || 'no output'}`);
+ }
+ return result;
+}
+
+function defaultRunCli(command, options = {}) {
+ const cliPath = options.cliPath || 'wp';
+ const args = [normalizeCliCommand(command)];
+ if (options.sitePath) {
+  args.push(`--path=${quoteShell(options.sitePath)}`);
+ }
+ return runShellCommand(`${cliPath} ${args.filter(Boolean).join(' ')}`, {
+  cwd: options.cwd || options.sitePath || process.cwd(),
+  env: options.env,
+ });
+}
+
+function runShellCommand(command, options = {}) {
+ return new Promise((resolve) => {
+  const child = spawn(command, {
+   cwd: options.cwd,
+   env: { ...process.env, ...(options.env || {}) },
+   shell: true,
+   stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (chunk) => {
+   stdout += chunk.toString();
+  });
+  child.stderr.on('data', (chunk) => {
+   stderr += chunk.toString();
+  });
+  child.on('error', (error) => {
+   resolve({ exitCode: 1, stdout, stderr: stderr || error.message, error });
+  });
+  child.on('close', (code, signal) => {
+   resolve({ exitCode: code ?? 1, signal, stdout, stderr });
+  });
+ });
+}
+
+function normalizeCliResult(result) {
+	if (result === undefined || result === null) {
+		return { exitCode: 0, stdout: '', stderr: '' };
+	}
+	if (typeof result === 'string') {
+		return { exitCode: 0, stdout: result, stderr: '' };
+	}
+	let exitCode = 0;
+	if (Number.isInteger(result.exitCode)) {
+		exitCode = result.exitCode;
+	} else if (Number.isInteger(result.code)) {
+		exitCode = result.code;
+	}
+	return {
+		exitCode,
+		stdout: String(result.stdout || ''),
+		stderr: String(result.stderr || ''),
+		signal: result.signal,
+	};
+}
+
+function normalizeCliCommand(command) {
+ const trimmed = String(command || '').trim();
+ return trimmed.startsWith('wp ') ? trimmed.slice(3).trim() : trimmed;
+}
+
+function normalizeBlockQualityOptions(options = {}) {
+ if (!isPlainObject(options)) {
+  throw new TypeError('WordPress block quality probe options must be an object');
+ }
+ return {
+  post_types: normalizeStringList(options.postTypes, DEFAULT_POST_TYPES),
+  post_statuses: normalizeStringList(options.postStatuses, DEFAULT_POST_STATUSES),
+  fallback_option_names: normalizeStringList(options.fallbackOptionNames, []),
+ };
+}
+
+function normalizeStringList(value, defaultValue) {
+ if (value === undefined || value === null) {
+  return [...defaultValue];
+ }
+ const list = Array.isArray(value) ? value : [value];
+ return list.map((item) => String(item || '').trim()).filter(Boolean);
+}
+
+function normalizeContentPreviewBytes(value) {
+ if (value === undefined || value === null) {
+  return DEFAULT_CONTENT_PREVIEW_BYTES;
+ }
+ const number = Number(value);
+ if (!Number.isFinite(number) || number < 0) {
+  throw new TypeError('contentPreviewBytes must be a non-negative number');
+ }
+ return Math.floor(number);
+}
+
+function requiredPositiveInteger(value, label) {
+ const number = Number(value);
+ if (!Number.isInteger(number) || number <= 0) {
+  throw new TypeError(`${label} must be a positive integer`);
+ }
+ return number;
+}
+
+function encodeProbeConfig(config) {
+ return Buffer.from(JSON.stringify(config)).toString('base64');
+}
+
+function quoteShell(value) {
+ return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function phpProbe(body) {
+ return String.raw`
+function homeboy_wordpress_count_blocks( $blocks, &$counts ) {
+    foreach ( $blocks as $block ) {
+        $name = isset( $block['blockName'] ) ? (string) $block['blockName'] : '';
+        if ( '' !== $name ) {
+            $counts['total_blocks']++;
+            if ( 'core/html' === $name ) {
+                $counts['core_html_blocks']++;
+            }
+        }
+        if ( ! empty( $block['innerBlocks'] ) ) {
+            homeboy_wordpress_count_blocks( $block['innerBlocks'], $counts );
+        }
+    }
+}
+
+function homeboy_wordpress_empty_block_quality_counts() {
+    return array(
+        'posts_seen'                  => 0,
+        'posts_with_content'          => 0,
+        'posts_with_blocks'           => 0,
+        'pages_seen'                  => 0,
+        'templates_seen'              => 0,
+        'template_parts_seen'         => 0,
+        'raw_html_unconverted'        => 0,
+        'total_blocks'                => 0,
+        'core_html_blocks'            => 0,
+        'serialized_block_comments'   => 0,
+        'fallback_count'              => 0,
+        'core_html_without_fallback'  => 0,
+        'post_type_counts'            => new stdClass(),
+    );
+}
+
+function homeboy_wordpress_add_post_type_count( &$counts, $post_type ) {
+    $post_type = (string) $post_type;
+    if ( ! isset( $counts['post_type_counts']->$post_type ) ) {
+        $counts['post_type_counts']->$post_type = 0;
+    }
+    $counts['post_type_counts']->$post_type++;
+}
+
+function homeboy_wordpress_add_post_block_quality( &$counts, $post ) {
+    $content = (string) $post->post_content;
+    $counts['posts_seen']++;
+    homeboy_wordpress_add_post_type_count( $counts, $post->post_type );
+    if ( 'page' === $post->post_type ) {
+        $counts['pages_seen']++;
+    } elseif ( 'wp_template' === $post->post_type ) {
+        $counts['templates_seen']++;
+    } elseif ( 'wp_template_part' === $post->post_type ) {
+        $counts['template_parts_seen']++;
+    }
+    if ( '' === trim( $content ) ) {
+        return;
+    }
+    $counts['posts_with_content']++;
+    $counts['serialized_block_comments'] += substr_count( $content, '<!-- wp:' );
+    if ( false !== strpos( $content, '<!-- wp:' ) ) {
+        $counts['posts_with_blocks']++;
+    } elseif ( preg_match( '/<\/?[a-z][\s>]/i', $content ) ) {
+        $counts['raw_html_unconverted']++;
+    }
+    homeboy_wordpress_count_blocks( parse_blocks( $content ), $counts );
+}
+
+function homeboy_wordpress_fallback_option_total( $option_names ) {
+    $total = 0;
+    foreach ( $option_names as $option_name ) {
+        $total += (int) get_option( (string) $option_name, 0 );
+    }
+    return $total;
+}
+${body}`;
+}
+
+module.exports = {
+ parseWordPressBlockQualityProbeOutput,
+ probeWordPressBlockQuality,
+ probeWordPressPostBlockQuality,
+ wordpressBlockQualityProbeCode,
+ wordpressPostBlockQualityProbeCode,
+};

--- a/wordpress/lib/editor-canvas-probes.js
+++ b/wordpress/lib/editor-canvas-probes.js
@@ -1,0 +1,250 @@
+'use strict';
+
+const DEFAULT_EDITOR_CANVAS_IFRAME_SELECTOR = 'iframe[name="editor-canvas"]';
+const DEFAULT_EDITOR_CANVAS_LAYOUT_SELECTOR = '.block-editor-block-list__layout';
+const DEFAULT_EDITOR_CANVAS_BLOCK_SELECTOR = '.block-editor-block-list__block, [data-block]';
+const DEFAULT_EDITOR_CANVAS_TIMEOUT_MS = 30000;
+
+async function waitForWordPressEditorCanvas(page, options = {}) {
+ if (!page || typeof page !== 'object') {
+  throw new TypeError('waitForWordPressEditorCanvas requires a Playwright page');
+ }
+ const timeout = Number(options.timeoutMs || options.timeout || DEFAULT_EDITOR_CANVAS_TIMEOUT_MS);
+ const iframeSelector = options.iframeSelector || DEFAULT_EDITOR_CANVAS_IFRAME_SELECTOR;
+ const layoutSelector = options.layoutSelector || DEFAULT_EDITOR_CANVAS_LAYOUT_SELECTOR;
+ const blockSelector = options.blockSelector || DEFAULT_EDITOR_CANVAS_BLOCK_SELECTOR;
+ const startedAt = Date.now();
+
+ if (options.url && typeof page.goto === 'function') {
+  await page.goto(options.url, { waitUntil: options.waitUntil || 'domcontentloaded', timeout });
+ }
+ if (typeof page.waitForSelector === 'function') {
+  await page.waitForSelector(iframeSelector, { timeout });
+ }
+
+ const frame = await resolveEditorCanvasFrame(page, iframeSelector, options);
+ if (!frame) {
+  throw new Error('WordPress editor canvas iframe did not expose a content frame');
+ }
+
+ if (typeof frame.waitForFunction !== 'function') {
+  throw new TypeError('waitForWordPressEditorCanvas requires frame.waitForFunction()');
+ }
+	await frame.waitForFunction(
+		({ layoutSelector: innerLayoutSelector, blockSelector: innerBlockSelector }) => {
+			const layout = document.querySelector(innerLayoutSelector);
+			if (!layout) {
+				return false;
+			}
+			const rect = layout.getBoundingClientRect();
+			const loading = layout.matches('.is-loading, [aria-busy="true"]') || layout.querySelector('.is-loading, [aria-busy="true"], .components-spinner');
+			const blockCount = layout.querySelectorAll(innerBlockSelector).length;
+   return rect.width > 0 && rect.height > 0 && !loading && blockCount > 0;
+  },
+  { layoutSelector, blockSelector },
+  { timeout }
+ );
+
+ if (options.stabilize !== false) {
+  await stabilizeEditorCanvas(frame, options);
+ }
+
+ return {
+  frame,
+  iframeSelector,
+  layoutSelector,
+  blockSelector,
+  readyMs: Date.now() - startedAt,
+ };
+}
+
+async function captureWordPressEditorCanvasScreenshot(page, screenshotPath, options = {}) {
+ const ready = await waitForWordPressEditorCanvas(page, options);
+ if (!screenshotPath || typeof screenshotPath !== 'string') {
+  throw new TypeError('captureWordPressEditorCanvasScreenshot requires screenshotPath');
+ }
+ const layout = ready.frame.locator(ready.layoutSelector).first();
+ await layout.screenshot({ path: screenshotPath, timeout: Number(options.timeoutMs || options.timeout || DEFAULT_EDITOR_CANVAS_TIMEOUT_MS) });
+ return {
+  path: screenshotPath,
+  readyMs: ready.readyMs,
+  layoutSelector: ready.layoutSelector,
+ };
+}
+
+async function summarizeVisibleSelectors(page, groups) {
+ if (!page || typeof page.$$eval !== 'function') {
+  throw new TypeError('summarizeVisibleSelectors requires a Playwright page with $$eval()');
+ }
+ const normalizedGroups = normalizeSelectorGroups(groups);
+ const evaluatedGroups = [];
+
+ for (const group of normalizedGroups) {
+  const selectors = [];
+  for (const selector of group.selectors) {
+   try {
+    const matches = await page.$$eval(selector, (elements) => elements.map((element) => {
+     const rect = element.getBoundingClientRect();
+     const style = window.getComputedStyle(element);
+     const visible = rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden' && Number(style.opacity || '1') > 0;
+     return {
+      visible,
+      boundingBox: {
+       x: Math.round(rect.x),
+       y: Math.round(rect.y),
+       width: Math.round(rect.width),
+       height: Math.round(rect.height),
+      },
+      text: String(element.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 160),
+     };
+    }));
+    selectors.push(normalizeSelectorSummary(selector, matches));
+   } catch (error) {
+    selectors.push({
+     selector,
+     count: 0,
+     visible_count: 0,
+     nonzero_bounding_box_count: 0,
+     first_match: null,
+     error: error?.message || String(error),
+    });
+   }
+  }
+  evaluatedGroups.push(normalizeSelectorGroupSummary(group.name, selectors));
+ }
+
+ return {
+  groups: evaluatedGroups,
+  totals: visibleSelectorTotals(evaluatedGroups),
+ };
+}
+
+async function resolveEditorCanvasFrame(page, iframeSelector, options = {}) {
+	if (options.frame) {
+		return options.frame;
+	}
+	if (typeof page.frame === 'function') {
+		const frame = page.frame({ name: options.frameName || 'editor-canvas' });
+		if (frame) {
+			return frame;
+		}
+	}
+ if (typeof page.locator === 'function') {
+  const handle = await page.locator(iframeSelector).elementHandle();
+  if (handle && typeof handle.contentFrame === 'function') {
+   return handle.contentFrame();
+  }
+ }
+ return null;
+}
+
+async function stabilizeEditorCanvas(frame, options = {}) {
+ if (typeof frame.addStyleTag === 'function') {
+  await frame.addStyleTag({ content: editorCanvasStabilizingCss() });
+ }
+ const waitMs = Number(options.stabilizeMs ?? 300);
+ if (waitMs > 0 && typeof frame.waitForTimeout === 'function') {
+  await frame.waitForTimeout(waitMs);
+ }
+}
+
+function editorCanvasStabilizingCss() {
+ return `
+*, *::before, *::after {
+  animation-delay: 0s !important;
+  animation-duration: 0.001ms !important;
+  caret-color: transparent !important;
+  transition-delay: 0s !important;
+  transition-duration: 0.001ms !important;
+}
+.block-editor-block-list__block,
+.block-editor-block-list__block::before,
+.block-editor-block-list__block::after,
+.is-selected,
+.is-highlighted,
+.has-child-selected {
+  box-shadow: none !important;
+  outline: 0 !important;
+}
+.block-editor-block-contextual-toolbar,
+.block-editor-block-list__insertion-point,
+.block-editor-block-list__breadcrumb,
+.block-editor-inserter,
+.block-editor-inserter__quick-inserter,
+.block-editor-rich-text__editable::after,
+.components-popover,
+.components-toolbar,
+.components-toolbar-group,
+.is-root-container > .block-list-appender {
+  display: none !important;
+}`;
+}
+
+function normalizeSelectorGroups(groups) {
+ if (!Array.isArray(groups)) {
+  throw new TypeError('visible selector groups must be an array');
+ }
+ return groups.map((group, index) => {
+  if (!group || typeof group !== 'object') {
+   throw new TypeError(`visible selector group ${index + 1} must be an object`);
+  }
+  const selectors = Array.isArray(group.selectors) ? group.selectors : [group.selector].filter(Boolean);
+  return {
+   name: String(group.name || `group_${index + 1}`),
+   selectors: selectors.map((selector) => String(selector || '').trim()).filter(Boolean),
+  };
+ }).filter((group) => group.selectors.length > 0);
+}
+
+function normalizeSelectorSummary(selector, matches) {
+ return {
+  selector,
+  count: matches.length,
+  visible_count: matches.filter((match) => match.visible).length,
+  nonzero_bounding_box_count: matches.filter((match) => match.boundingBox.width > 0 && match.boundingBox.height > 0).length,
+  first_match: matches[0] || null,
+  error: '',
+ };
+}
+
+function normalizeSelectorGroupSummary(name, selectors) {
+ return {
+  name,
+  selectors,
+  selector_count: selectors.length,
+  missing_selector_count: selectors.filter((item) => item.count === 0).length,
+  errored_selector_count: selectors.filter((item) => item.error).length,
+  matched_selector_count: selectors.filter((item) => item.count > 0).length,
+  visible_selector_count: selectors.filter((item) => item.visible_count > 0).length,
+  nonzero_bounding_box_selector_count: selectors.filter((item) => item.nonzero_bounding_box_count > 0).length,
+ };
+}
+
+function visibleSelectorTotals(groups) {
+ return groups.reduce((totals, group) => {
+  totals.selector_count += group.selector_count;
+  totals.missing_selector_count += group.missing_selector_count;
+  totals.errored_selector_count += group.errored_selector_count;
+  totals.matched_selector_count += group.matched_selector_count;
+  totals.visible_selector_count += group.visible_selector_count;
+  totals.nonzero_bounding_box_selector_count += group.nonzero_bounding_box_selector_count;
+  return totals;
+ }, {
+  selector_count: 0,
+  missing_selector_count: 0,
+  errored_selector_count: 0,
+  matched_selector_count: 0,
+  visible_selector_count: 0,
+  nonzero_bounding_box_selector_count: 0,
+ });
+}
+
+module.exports = {
+ DEFAULT_EDITOR_CANVAS_BLOCK_SELECTOR,
+ DEFAULT_EDITOR_CANVAS_IFRAME_SELECTOR,
+ DEFAULT_EDITOR_CANVAS_LAYOUT_SELECTOR,
+ captureWordPressEditorCanvasScreenshot,
+ editorCanvasStabilizingCss,
+ summarizeVisibleSelectors,
+ waitForWordPressEditorCanvas,
+};

--- a/wordpress/tests/block-quality-smoke.js
+++ b/wordpress/tests/block-quality-smoke.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/* eslint-disable no-console */
+
+const assert = require('node:assert/strict');
+
+const {
+	parseWordPressBlockQualityProbeOutput,
+	probeWordPressBlockQuality,
+	probeWordPressPostBlockQuality,
+	wordpressBlockQualityProbeCode,
+	wordpressPostBlockQualityProbeCode,
+} = require('../lib/block-quality');
+
+async function main() {
+	const siteProbe = wordpressBlockQualityProbeCode({
+		postTypes: ['page'],
+		postStatuses: ['publish'],
+		fallbackOptionNames: ['example_fallback_count'],
+	});
+	assert.match(siteProbe, /homeboy_wordpress_count_blocks/);
+	assert.match(siteProbe, /fallback_option_names/);
+	assert.doesNotMatch(siteProbe, /studio_bfb_unsupported_fallback_count/);
+
+	const postProbe = wordpressPostBlockQualityProbeCode(123, { contentPreviewBytes: 80 });
+	assert.match(postProbe, /stored_content_hash/);
+	assert.match(postProbe, /stored_content_preview/);
+	assert.throws(() => wordpressPostBlockQualityProbeCode('nope'), /postId must be a positive integer/);
+
+	const parsed = parseWordPressBlockQualityProbeOutput(`notice\n${JSON.stringify({
+		posts_seen: 2,
+		posts_with_blocks: 1,
+		total_blocks: 4,
+		core_html_blocks: 1,
+		serialized_block_comments: 4,
+		fallback_count: 1,
+		core_html_without_fallback: 0,
+	})}`);
+	assert.equal(parsed.total_blocks, 4);
+	assert.equal(parsed.core_html_without_fallback, 0);
+	assert.throws(() => parseWordPressBlockQualityProbeOutput('no json'), /did not emit JSON/);
+
+	const calls = [];
+	const siteQuality = await probeWordPressBlockQuality('/tmp/wp-site', {
+		runCli: async (command, context) => {
+			calls.push({ command, context });
+			return {
+				exitCode: 0,
+				stdout: JSON.stringify({ posts_seen: 1, pages_seen: 1, total_blocks: 3 }),
+				stderr: '',
+			};
+		},
+	});
+	assert.equal(siteQuality.total_blocks, 3);
+	assert.equal(calls[0].context.sitePath, '/tmp/wp-site');
+	assert.equal(calls[0].context.role, 'wordpress-block-quality-probe');
+	assert.match(calls[0].command, /^eval '/);
+
+	const postQuality = await probeWordPressPostBlockQuality('/tmp/wp-site', 55, {
+		runCli: async () => ({
+			exitCode: 0,
+			stdout: JSON.stringify({ post_id: 55, stored_content_hash: 'abc', stored_content_bytes: 12 }),
+			stderr: '',
+		}),
+	});
+	assert.equal(postQuality.post_id, 55);
+
+	await assert.rejects(
+		() => probeWordPressBlockQuality('/tmp/wp-site', {
+			runCli: async () => ({ exitCode: 1, stdout: 'stdout', stderr: 'stderr' }),
+		}),
+		/probe failed with exit code 1/
+	);
+
+	console.log('WordPress block quality smoke passed.');
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/wordpress/tests/editor-canvas-probes-smoke.js
+++ b/wordpress/tests/editor-canvas-probes-smoke.js
@@ -1,0 +1,134 @@
+'use strict';
+
+/* eslint-disable no-console */
+
+const assert = require('node:assert/strict');
+
+const {
+	captureWordPressEditorCanvasScreenshot,
+	summarizeVisibleSelectors,
+	waitForWordPressEditorCanvas,
+} = require('../lib/editor-canvas-probes');
+
+class FakeLayoutLocator {
+	constructor(calls, selector) {
+		this.calls = calls;
+		this.selector = selector;
+	}
+
+	first() {
+		this.calls.push(['layout.first', this.selector]);
+		return this;
+	}
+
+	async screenshot(options) {
+		this.calls.push(['layout.screenshot', options.path, options.timeout]);
+	}
+}
+
+class FakeFrame {
+	constructor(calls) {
+		this.calls = calls;
+	}
+
+	async waitForFunction(callback, arg, options) {
+		this.calls.push(['frame.waitForFunction', arg.layoutSelector, arg.blockSelector, options.timeout]);
+	}
+
+	async addStyleTag(options) {
+		this.calls.push(['frame.addStyleTag', options.content.includes('.components-popover')]);
+	}
+
+	async waitForTimeout(ms) {
+		this.calls.push(['frame.waitForTimeout', ms]);
+	}
+
+	locator(selector) {
+		this.calls.push(['frame.locator', selector]);
+		return new FakeLayoutLocator(this.calls, selector);
+	}
+}
+
+class FakePage {
+	constructor() {
+		this.calls = [];
+		this.frameObject = new FakeFrame(this.calls);
+	}
+
+	async goto(url, options) {
+		this.calls.push(['goto', url, options.waitUntil, options.timeout]);
+	}
+
+	async waitForSelector(selector, options) {
+		this.calls.push(['waitForSelector', selector, options.timeout]);
+	}
+
+	frame(options) {
+		this.calls.push(['page.frame', options.name]);
+		return this.frameObject;
+	}
+}
+
+class FakeElement {
+	constructor({ rect, display = 'block', visibility = 'visible', opacity = '1', text = '' }) {
+		this.rect = rect;
+		this.style = { display, visibility, opacity };
+		this.textContent = text;
+	}
+
+	getBoundingClientRect() {
+		return this.rect;
+	}
+}
+
+class FakeSelectorPage {
+	constructor() {
+		this.calls = [];
+		this.elementsBySelector = {
+			'.hero': [new FakeElement({ rect: { x: 1, y: 2, width: 300, height: 120 }, text: 'Hero text' })],
+			'.hidden': [new FakeElement({ rect: { x: 0, y: 0, width: 10, height: 10 }, display: 'none', text: 'Hidden' })],
+			'.missing': [],
+		};
+	}
+
+	async $$eval(selector, callback) {
+		this.calls.push(['$$eval', selector]);
+		const previousWindow = global.window;
+		global.window = { getComputedStyle: (element) => element.style };
+		try {
+			return callback(this.elementsBySelector[selector] || []);
+		} finally {
+			global.window = previousWindow;
+		}
+	}
+}
+
+async function main() {
+	const page = new FakePage();
+	const ready = await waitForWordPressEditorCanvas(page, { url: 'https://example.test/wp-admin/site-editor.php', timeoutMs: 1000, stabilizeMs: 5 });
+	assert.equal(ready.iframeSelector, 'iframe[name="editor-canvas"]');
+	assert.equal(ready.layoutSelector, '.block-editor-block-list__layout');
+	assert.equal(typeof ready.readyMs, 'number');
+	assert.deepEqual(page.calls[0], ['goto', 'https://example.test/wp-admin/site-editor.php', 'domcontentloaded', 1000]);
+	assert.equal(page.calls.some((call) => call[0] === 'frame.addStyleTag' && call[1] === true), true);
+
+	const screenshot = await captureWordPressEditorCanvasScreenshot(page, '/tmp/editor-canvas.png', { stabilize: false });
+	assert.equal(screenshot.path, '/tmp/editor-canvas.png');
+	assert.equal(page.calls.some((call) => call[0] === 'layout.screenshot' && call[1] === '/tmp/editor-canvas.png'), true);
+
+	const selectorSummary = await summarizeVisibleSelectors(new FakeSelectorPage(), [
+		{ name: 'hero', selectors: ['.hero', '.missing'] },
+		{ name: 'chrome', selector: '.hidden' },
+	]);
+	assert.equal(selectorSummary.totals.selector_count, 3);
+	assert.equal(selectorSummary.totals.visible_selector_count, 1);
+	assert.equal(selectorSummary.groups[0].selectors[0].first_match.text, 'Hero text');
+	assert.equal(selectorSummary.groups[1].selectors[0].visible_count, 0);
+
+	console.log('WordPress editor canvas probes smoke passed.');
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add reusable WordPress block/post quality probes for site-wide and post-scoped block counters, stored content metadata, and opt-in fallback option totals.
- Add generic editor canvas readiness/screenshot helpers plus visible selector group summaries without Studio/SSI-specific success gates.
- Document the reusable probe APIs and add focused smoke coverage for the promoted helpers.

## Verification
- `node wordpress/tests/block-quality-smoke.js`
- `node wordpress/tests/editor-canvas-probes-smoke.js`
- `for f in wordpress/tests/*.js; do node "$f" || exit $?; done`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-issue-1009-wordpress-quality-probes --extension wordpress --file wordpress/lib/block-quality.js`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-issue-1009-wordpress-quality-probes --extension wordpress --file wordpress/lib/editor-canvas-probes.js`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-issue-1009-wordpress-quality-probes --extension wordpress`

## Notes
- Full `homeboy lint --extension wordpress` still reports the existing repo-wide lint baseline, including unrelated PHPCS/PHPStan fixture findings and unrelated JS lint findings. The new source helpers pass targeted lint.
- Single-file Homeboy lint on the new smoke test files reports the repo's ESLint ignore warning as a lint finding, so those tests are verified by direct `node` execution and the full WordPress JS smoke loop.
- Studio/Static Site Importer-specific gates and import-report interpretation intentionally remain in rigs.

Closes #1009

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the reusable WordPress probe helpers, smoke tests, docs, and verification workflow; Chris remains responsible for review and merge.