### PR TITLE
fix: surface Codebox preflight diagnostics

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -171,7 +171,7 @@ function normalizeEvidenceRefs(result) {
 function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   assertAgentTaskRequest(request);
   const status = normalizeStatus(result, options.exitStatus ?? 0);
-  const failureClassification = failureClassificationForStatus(status);
+  const failureClassification = result.failure_classification || failureClassificationForStatus(status);
   const outcome = {
     schema: AGENT_TASK_OUTCOME_SCHEMA,
     task_id: request.task_id,

--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -259,6 +259,57 @@ function timeoutPayload(timeoutMs) {
   };
 }
 
+function redactDiagnosticText(text) {
+  return String(text || '')
+    .replace(/((?:TOKEN|SECRET|PASSWORD|API[_-]?KEY|ACCESS[_-]?KEY|REFRESH[_-]?TOKEN)[A-Z0-9_-]*\s*=\s*)\S+/gi, '$1[redacted]')
+    .slice(0, 8000);
+}
+
+function missingSecretEnvNames(stderr) {
+  const match = String(stderr || '').match(/Required WP Codebox secret environment variable missing:\s*([^\n\r]+)/i);
+  if (!match) {
+    return [];
+  }
+  return match[1]
+    .split(',')
+    .map((name) => name.trim())
+    .filter((name) => /^[A-Z0-9_]+$/.test(name));
+}
+
+function stderrFailurePayload(result) {
+  const stderr = redactDiagnosticText(result.stderr || '');
+  const missingSecretEnv = missingSecretEnvNames(stderr);
+  const diagnosticClass = missingSecretEnv.length > 0
+    ? 'codebox.preflight.missing_secret_env'
+    : 'codebox.preflight.stderr';
+  const message = missingSecretEnv.length > 0
+    ? `WP Codebox task runner preflight is missing required secret environment variables: ${missingSecretEnv.join(', ')}.`
+    : 'WP Codebox task runner failed before returning a JSON outcome.';
+
+  return {
+    success: false,
+    status: 'failed',
+    failure_classification: 'provider',
+    summary: message,
+    diagnostics: [{
+      class: diagnosticClass,
+      message,
+      data: {
+        phase: 'codebox.preflight',
+        exit_status: result.status ?? 1,
+        missing_env: missingSecretEnv,
+        stderr,
+      },
+    }],
+    metadata: {
+      phase: 'codebox.preflight',
+      exit_status: result.status ?? 1,
+      missing_env: missingSecretEnv,
+      stderr,
+    },
+  };
+}
+
 function runTaskRunner(request) {
   const runner = argValue('--task-runner') || `${__dirname}/homeboy-wp-codebox-task-runner.cjs`;
   const config = request.executor?.config || {};
@@ -296,12 +347,29 @@ function runTaskRunner(request) {
     try {
       payload = JSON.parse(result.stdout);
     } catch {
-      payload = {
+      payload = missingSecretEnvNames(result.stderr).length > 0 ? stderrFailurePayload(result) : {
         success: result.status === 0,
         summary: result.stdout.trim(),
-        diagnostics: [{ class: 'codebox.stdout', message: 'WP Codebox returned non-JSON stdout.', data: {} }],
+        status: result.status === 0 ? 'succeeded' : 'failed',
+        failure_classification: result.status === 0 ? undefined : 'provider',
+        diagnostics: [{
+          class: 'codebox.stdout',
+          message: 'WP Codebox returned non-JSON stdout.',
+          data: {
+            phase: 'codebox.preflight',
+            exit_status: result.status ?? 1,
+            stderr: redactDiagnosticText(result.stderr || ''),
+          },
+        }],
+        metadata: {
+          phase: 'codebox.preflight',
+          exit_status: result.status ?? 1,
+          stderr: redactDiagnosticText(result.stderr || ''),
+        },
       };
     }
+  } else if ((result.status ?? 0) !== 0 || (result.stderr || '').trim()) {
+    payload = stderrFailurePayload(result);
   }
 
   return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: result.status ?? 1 });

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -42,6 +42,17 @@ setInterval(() => {}, 1000);
   return fixture;
 }
 
+function writeMissingSecretTaskRunner(root) {
+  const fixture = path.join(root, 'missing-secret-task-runner.cjs');
+  fs.writeFileSync(fixture, `#!/usr/bin/env node
+'use strict';
+console.error('Required WP Codebox secret environment variable missing: AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN, AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN');
+process.exit(1);
+`);
+  fs.chmodSync(fixture, 0o755);
+  return fixture;
+}
+
 const request = {
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'task-123',
@@ -332,6 +343,27 @@ try {
   assert.equal(timeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-command-log'), true);
   assert.equal(timeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-transcript'), true);
   assert.equal(timeoutOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-transcript'), true);
+
+  const missingSecretResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+    '--task-runner',
+    writeMissingSecretTaskRunner(root),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(codexAgentRequest),
+  });
+  assert.equal(missingSecretResult.status, 1, missingSecretResult.stderr || missingSecretResult.stdout);
+  const missingSecretOutcome = JSON.parse(missingSecretResult.stdout);
+  assert.equal(missingSecretOutcome.status, 'failed');
+  assert.equal(missingSecretOutcome.failure_classification, 'provider');
+  assert.equal(missingSecretOutcome.diagnostics[0].class, 'codebox.preflight.missing_secret_env');
+  assert.deepEqual(missingSecretOutcome.diagnostics[0].data.missing_env, [
+    'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+    'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+  ]);
+  assert.equal(missingSecretOutcome.diagnostics[0].data.phase, 'codebox.preflight');
+  assert.equal(missingSecretOutcome.metadata.codebox.missing_env[0], 'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN');
+  assert(!JSON.stringify(missingSecretOutcome).includes('codex-access-token-value'));
 } finally {
   fs.rmSync(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- Converts empty-stdout and non-JSON child runner preflight failures into structured AgentTask diagnostics.
- Classifies missing required secret env failures as provider failures with `codebox.preflight.missing_secret_env` and redacted metadata.
- Adds smoke coverage for missing `AI_PROVIDER_OPENAI_CODEX_*` preflight diagnostics.

Fixes #1014.

## Verification
- `npm run test:codebox-agent-task-executor` passed.
- `./node_modules/.bin/eslint --no-ignore scripts/agent/homeboy-codebox-agent-task-executor.cjs lib/codebox-agent-task-executor.js` passed.
- `homeboy test --path . --extension wordpress` passed. It reported no discovered PHPUnit files after plugin activation/install passed.
- `homeboy lint --path . --extension wordpress --file wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs` passed.
- `homeboy lint --path . --extension wordpress --file wordpress/lib/codebox-agent-task-executor.js` passed.

## Known verification caveat
- `homeboy lint --path . --extension wordpress --changed-only` reports one warning because `wordpress/tests/codebox-agent-task-executor-smoke.js` is intentionally ignored by ESLint, even though the ESLint producer reports pass and the targeted smoke test passes.
- Full `homeboy lint --path . --extension wordpress` still fails on existing repository-wide unrelated findings outside this PR scope.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the bridge diagnostic implementation, smoke coverage, and verification/PR text for Chris to review.