### PR TITLE
fix: expose WordPress quality helper paths

### DIFF
--- a/wordpress/lib/helper-manifest.js
+++ b/wordpress/lib/helper-manifest.js
@@ -11,6 +11,8 @@ const HELPER_PATHS = Object.freeze({
 	requestProfiler: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'request-profiler.js'),
 	timingCorrelator: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'timing-correlator.js'),
 	bootstrapTimeline: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'wordpress-bootstrap-timeline.js'),
+	blockQuality: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'block-quality.js'),
+	editorCanvasProbes: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'editor-canvas-probes.js'),
 });
 
 function getWordPressHelperManifest() {

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -11,6 +11,8 @@
     "./wordpress-bootstrap-timeline": "./lib/wordpress-bootstrap-timeline.js",
     "./request-profiler": "./lib/request-profiler.js",
     "./helper-manifest": "./lib/helper-manifest.js",
+    "./block-quality": "./lib/block-quality.js",
+    "./editor-canvas-probes": "./lib/editor-canvas-probes.js",
     "./agent-terminal-actions": "./lib/agent-terminal-actions.js",
     "./timing-correlator": "./lib/timing-correlator.js",
     "./codebox-memory-report": "./lib/codebox-memory-report.js",

--- a/wordpress/tests/helper-manifest-smoke.js
+++ b/wordpress/tests/helper-manifest-smoke.js
@@ -32,5 +32,13 @@ assert.equal(
 	manifest.helpers.bootstrapTimeline,
 	path.resolve(__dirname, '..', 'lib', 'wordpress-bootstrap-timeline.js')
 );
+assert.equal(
+	manifest.helpers.blockQuality,
+	path.resolve(__dirname, '..', 'lib', 'block-quality.js')
+);
+assert.equal(
+	manifest.helpers.editorCanvasProbes,
+	path.resolve(__dirname, '..', 'lib', 'editor-canvas-probes.js')
+);
 
 console.log('helper manifest smoke passed');


### PR DESCRIPTION
## Summary
- Add block quality and editor canvas probe helpers to the WordPress helper manifest.
- Add package subpath exports for the promoted helper modules so consumers can import them directly.
- Extend the helper manifest smoke test to lock the new paths.

## Verification
- `node tests/helper-manifest-smoke.js`
- `node tests/block-quality-smoke.js`
- `node tests/editor-canvas-probes-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Audited the helper discovery gap, drafted the export/manifest patch, and ran focused smoke tests; Chris remains responsible for review and merge.