### PR TITLE
Use WP Codebox browser metrics CLI in bench results

### DIFF
--- a/wordpress/lib/page-profiler.js
+++ b/wordpress/lib/page-profiler.js
@@ -11,7 +11,7 @@ const nodePath = require('node:path');
  */
 const { correlateBrowserAndWordPressTimings, normalizeUrl } = require('./timing-correlator');
 const { runWordPressFixtureSetup } = require('./fixture-setup');
-const { parseWpCodeboxBrowserArtifacts } = require('./wp-codebox-browser-metrics');
+const { runWpCodeboxBrowserMetrics } = require('./wp-codebox-browser-metrics');
 const {
 	WORDPRESS_RESOURCE_INCLUDE,
 	isPlainObject,
@@ -2105,7 +2105,7 @@ function resolveWpCodeboxArtifactDirectoryForSpec(input, spec) {
 	return input.wpCodeboxArtifactsDirectory || input.wpCodeboxArtifactDirectory || input.artifactsDirectory || input.artifactDirectory;
 }
 
-function readWpCodeboxBrowserProfileArtifacts(artifactsDirectory) {
+function readWpCodeboxBrowserProfileArtifacts(artifactsDirectory, wpCodeboxBin = process.env.HOMEBOY_WP_CODEBOX_BIN || 'wp-codebox') {
 	const browserDirectory = resolveWpCodeboxBrowserDirectory(artifactsDirectory);
 	if (!browserDirectory) {
 		throw new Error(`WP Codebox browser artifacts not found under ${artifactsDirectory}`);
@@ -2114,19 +2114,26 @@ function readWpCodeboxBrowserProfileArtifacts(artifactsDirectory) {
 	const actionSummary = readJsonFileIfPresent(nodePath.join(browserDirectory, 'action-summary.json')) || {};
 	const network = readJsonlFileIfPresent(nodePath.join(browserDirectory, 'network.jsonl'));
 	const actions = readJsonlFileIfPresent(nodePath.join(browserDirectory, 'actions.jsonl'));
+	let parsed = { metrics: {}, artifacts: {} };
+	try {
+		parsed = runWpCodeboxBrowserMetrics(artifactsDirectory, wpCodeboxBin);
+	} catch {
+		// Older local wp-codebox fixtures may not expose artifacts browser-metrics.
+	}
 	return {
 		browserDirectory,
 		summary,
 		actionSummary,
 		network,
 		actions,
-		parsed: parseWpCodeboxBrowserArtifacts(artifactsDirectory),
+		parsed,
 	};
 }
 
 function createWordPressPageProfileFromWpCodeboxArtifacts(input, spec) {
 	const artifactsDirectory = resolveWpCodeboxArtifactDirectoryForSpec(input, spec);
-	const artifactData = readWpCodeboxBrowserProfileArtifacts(artifactsDirectory);
+	const wpCodeboxBin = input.wpCodeboxBin || input.wp_codebox_bin || process.env.HOMEBOY_WP_CODEBOX_BIN || 'wp-codebox';
+	const artifactData = readWpCodeboxBrowserProfileArtifacts(artifactsDirectory, wpCodeboxBin);
 	const summary = artifactData.summary;
 	const actionSummary = artifactData.actionSummary;
 	const url = summary.finalUrl || summary.requestedUrl || actionSummary.finalUrl || actionSummary.requestedUrl || resolveWordPressUrl(input.baseUrl || summary.requestedUrl || 'http://example.test/', spec.url);

--- a/wordpress/lib/wp-codebox-browser-metrics.js
+++ b/wordpress/lib/wp-codebox-browser-metrics.js
@@ -4,291 +4,50 @@
  * External dependencies
  */
 const fs = require('node:fs');
-const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
-const ARTIFACTS = {
-  summary: { file: 'summary.json', key: 'browser_summary', kind: 'json' },
-  memory: { file: 'memory.json', key: 'browser_memory', kind: 'json' },
-  performance: { file: 'performance.json', key: 'browser_performance', kind: 'json' },
-  checkpoints: { file: 'checkpoints.jsonl', key: 'browser_checkpoints', kind: 'jsonl' },
+const ARTIFACT_KEYS = {
+  summary: 'browser_summary',
+  memory: 'browser_memory',
+  performance: 'browser_performance',
+  checkpoints: 'browser_checkpoints',
 };
 
-function readJsonIfPresent(filePath) {
-  if (!fs.existsSync(filePath) || fs.statSync(filePath).size === 0) {
-    return null;
+function runWpCodeboxBrowserMetrics(artifactsDirectory, wpCodeboxBin = 'wp-codebox') {
+  const wpCodeboxArgs = ['artifacts', 'browser-metrics', '--bundle', artifactsDirectory, '--json'];
+  const command = wpCodeboxBin.endsWith('.js') ? process.execPath : wpCodeboxBin;
+  const args = wpCodeboxBin.endsWith('.js') ? [wpCodeboxBin, ...wpCodeboxArgs] : wpCodeboxArgs;
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+  });
+  if (result.error) {
+    throw result.error;
   }
-  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-}
-
-function readJsonlIfPresent(filePath) {
-  if (!fs.existsSync(filePath) || fs.statSync(filePath).size === 0) {
-    return [];
-  }
-  return fs.readFileSync(filePath, 'utf8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => JSON.parse(line));
-}
-
-function numberValue(value) {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value;
-  }
-  if (typeof value === 'string' && value.trim() !== '') {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-  return null;
-}
-
-function valueAt(object, selector) {
-  if (!object || typeof object !== 'object') {
-    return undefined;
-  }
-  return selector.split('.').reduce((current, segment) => {
-    if (!current || typeof current !== 'object') {
-      return undefined;
-    }
-    return current[segment];
-  }, object);
-}
-
-function firstNumber(sources, selectors) {
-  for (const source of sources) {
-    for (const selector of selectors) {
-      const value = numberValue(valueAt(source, selector));
-      if (value !== null) {
-        return value;
-      }
-    }
-  }
-  return null;
-}
-
-function maxSampleNumber(samples, selectors) {
-  const values = samples.flatMap((sample) => selectors.map((selector) => numberValue(valueAt(sample, selector))))
-    .filter((value) => value !== null);
-  return values.length > 0 ? Math.max(...values) : null;
-}
-
-function lastSampleNumber(samples, selectors, labelPattern = null) {
-  const filtered = labelPattern
-    ? samples.filter((sample) => labelPattern.test(String(sample.label || sample.name || sample.checkpoint || sample.phase || '')))
-    : samples;
-  for (let index = filtered.length - 1; index >= 0; index -= 1) {
-    for (const selector of selectors) {
-      const value = numberValue(valueAt(filtered[index], selector));
-      if (value !== null) {
-        return value;
-      }
-    }
-  }
-  return null;
-}
-
-function sumArrayNumbers(items, selectors) {
-  const values = items.map((item) => firstNumber([item], selectors)).filter((value) => value !== null);
-  return values.length > 0 ? values.reduce((total, value) => total + value, 0) : null;
-}
-
-function listFrom(value, selectors) {
-  for (const selector of selectors) {
-    const candidate = selector ? valueAt(value, selector) : value;
-    if (Array.isArray(candidate)) {
-      return candidate;
-    }
-  }
-  return [];
-}
-
-function findBrowserDirectory(artifactsDirectory) {
-  if (!artifactsDirectory || !fs.existsSync(artifactsDirectory)) {
-    return null;
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || `wp-codebox artifacts browser-metrics exited with ${result.status}`);
   }
 
-  const directCandidates = [
-    path.join(artifactsDirectory, 'files', 'browser'),
-    path.join(artifactsDirectory, 'browser'),
-  ];
-  const direct = directCandidates.find((candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isDirectory());
-  if (direct) {
-    return direct;
-  }
-
-  const queue = [artifactsDirectory];
-  while (queue.length > 0) {
-    const directory = queue.shift();
-    const entries = fs.readdirSync(directory, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
-    for (const entry of entries) {
-      if (!entry.isDirectory()) {
-        continue;
-      }
-      const child = path.join(directory, entry.name);
-      if (path.basename(child) === 'browser' && path.basename(path.dirname(child)) === 'files') {
-        return child;
-      }
-      queue.push(child);
-    }
-  }
-
-  return null;
-}
-
-function parseWpCodeboxBrowserArtifacts(artifactsDirectory) {
-  const browserDirectory = findBrowserDirectory(artifactsDirectory);
-  if (!browserDirectory) {
-    return { metrics: {}, artifacts: {} };
-  }
-
-  const paths = Object.fromEntries(
-    Object.entries(ARTIFACTS).map(([name, artifact]) => [name, path.join(browserDirectory, artifact.file)])
-  );
-  const summary = readJsonIfPresent(paths.summary) || {};
-  const memory = readJsonIfPresent(paths.memory) || {};
-  const performance = readJsonIfPresent(paths.performance) || {};
-  const checkpoints = readJsonlIfPresent(paths.checkpoints);
-  const memorySamples = [
-    ...listFrom(memory, ['samples', 'snapshots', 'measurements', 'checkpoints']),
-    ...checkpoints,
-  ];
-  const resources = listFrom(performance, ['resources', 'resourceTimings', 'entries.resources']);
-  const longTasks = listFrom(performance, ['longTasks', 'long_tasks', 'entries.longTasks']);
-  const sources = [summary, memory, performance, ...checkpoints];
-
-  const metrics = {};
-  const setMetric = (key, value) => {
-    if (value !== null && value !== undefined) {
-      metrics[key] = value;
-    }
-  };
-
-  setMetric('browser_peak_used_js_heap_bytes', firstNumber(sources, [
-    'browser_peak_used_js_heap_bytes',
-    'peak_used_js_heap_bytes',
-    'peakUsedJSHeapSize',
-    'summary.memory.usedJSHeapSize.peak',
-    'peak.usedJSHeapSize.peak',
-    'peak.performanceMemory.usedJSHeapSize.peak',
-    'peak.usedJSHeapSize',
-    'peak.used_js_heap_bytes',
-    'memory.peakUsedJSHeapSize',
-    'memory.peak.usedJSHeapSize',
-  ]) ?? maxSampleNumber(memorySamples, ['usedJSHeapSize', 'used_js_heap_bytes', 'memory.usedJSHeapSize']));
-  setMetric('browser_final_used_js_heap_bytes', firstNumber(sources, [
-    'browser_final_used_js_heap_bytes',
-    'final_used_js_heap_bytes',
-    'finalUsedJSHeapSize',
-    'summary.memory.usedJSHeapSize.final',
-    'final.performanceMemory.usedJSHeapSize',
-    'final.cdpHeap.usedSize',
-    'peak.usedJSHeapSize.final',
-    'final.usedJSHeapSize',
-    'final.used_js_heap_bytes',
-    'memory.finalUsedJSHeapSize',
-    'memory.final.usedJSHeapSize',
-  ]) ?? lastSampleNumber(memorySamples, ['usedJSHeapSize', 'used_js_heap_bytes', 'memory.usedJSHeapSize']));
-  setMetric('browser_post_idle_used_js_heap_bytes', firstNumber(sources, [
-    'browser_post_idle_used_js_heap_bytes',
-    'post_idle_used_js_heap_bytes',
-    'postIdleUsedJSHeapSize',
-    'postIdle.usedJSHeapSize',
-    'post_idle.used_js_heap_bytes',
-    'afterIdle.usedJSHeapSize',
-  ]) ?? lastSampleNumber(memorySamples, ['usedJSHeapSize', 'used_js_heap_bytes', 'memory.usedJSHeapSize'], /post[-_ ]?idle|after[-_ ]?idle/i));
-  setMetric('browser_generation_heap_delta_bytes', firstNumber(sources, [
-    'browser_generation_heap_delta_bytes',
-    'generation_heap_delta_bytes',
-    'generationHeapDeltaBytes',
-    'generation.heapDeltaBytes',
-    'generation.heap_delta_bytes',
-  ]));
-  if (!Object.hasOwn(metrics, 'browser_generation_heap_delta_bytes')) {
-    const before = firstNumber(sources, ['beforeGeneration.usedJSHeapSize', 'generation.before.usedJSHeapSize', 'initial.usedJSHeapSize']);
-    const after = firstNumber(sources, ['afterGeneration.usedJSHeapSize', 'generation.after.usedJSHeapSize', 'final.usedJSHeapSize']);
-    if (before !== null && after !== null) {
-      metrics.browser_generation_heap_delta_bytes = after - before;
-    }
-  }
-  setMetric('browser_dom_node_count', firstNumber(sources, [
-    'browser_dom_node_count',
-    'dom_node_count',
-    'domNodeCount',
-    'summary.performance.domNodes.final',
-    'summary.memory.domNodes.final',
-    'final.dom.nodes',
-    'final.domCounters.nodes',
-    'dom.nodeCount',
-    'counts.domNodes',
-    'memory.domNodeCount',
-  ]) ?? lastSampleNumber(memorySamples, ['domNodeCount', 'dom_node_count', 'dom.nodeCount']));
-  setMetric('browser_iframe_count', firstNumber(sources, [
-    'browser_iframe_count',
-    'iframe_count',
-    'iframeCount',
-    'final.dom.iframes',
-    'dom.iframeCount',
-    'counts.iframes',
-  ]));
-  setMetric('browser_resource_count', firstNumber(sources, [
-    'browser_resource_count',
-    'resource_count',
-    'resourceCount',
-    'summary.performance.resources',
-    'final.resources.count',
-    'peak.resources',
-    'resources.count',
-    'network.resourceCount',
-  ]) ?? (resources.length > 0 ? resources.length : null));
-  setMetric('browser_transfer_size_bytes', firstNumber(sources, [
-    'browser_transfer_size_bytes',
-    'transfer_size_bytes',
-    'transferSizeBytes',
-    'summary.performance.transferSizeBytes',
-    'final.resources.transferSizeBytes',
-    'peak.transferSizeBytes',
-    'resources.transferSizeBytes',
-    'network.transferSizeBytes',
-  ]) ?? sumArrayNumbers(resources, ['transferSize', 'transfer_size', 'transferSizeBytes']));
-  setMetric('browser_long_task_count', firstNumber(sources, [
-    'browser_long_task_count',
-    'long_task_count',
-    'longTaskCount',
-    'summary.performance.longTasks',
-    'final.longTasks.count',
-    'peak.longTasks',
-    'longTasks.count',
-  ]) ?? (longTasks.length > 0 ? longTasks.length : null));
-  setMetric('browser_long_task_total_ms', firstNumber(sources, [
-    'browser_long_task_total_ms',
-    'long_task_total_ms',
-    'longTaskTotalMs',
-    'summary.performance.longTaskDurationMs',
-    'final.longTasks.totalDurationMs',
-    'peak.longTaskDurationMs',
-    'longTasks.totalMs',
-  ]) ?? sumArrayNumbers(longTasks, ['duration', 'durationMs', 'duration_ms']));
-
+  const parsed = JSON.parse(result.stdout);
   const artifacts = {};
-  for (const [name, artifact] of Object.entries(ARTIFACTS)) {
-    if (!fs.existsSync(paths[name])) {
-      continue;
+  for (const [name, artifact] of Object.entries(parsed.artifacts || {})) {
+    const key = ARTIFACT_KEYS[name];
+    if (key) {
+      artifacts[key] = artifact;
     }
-    artifacts[artifact.key] = {
-      path: path.relative(artifactsDirectory, paths[name]),
-      kind: artifact.kind,
-    };
   }
 
-  return { metrics, artifacts };
+  return {
+    metrics: parsed.metrics || {},
+    artifacts,
+  };
 }
 
 function scenarioReceivesBrowserMetrics(scenario) {
   return scenario && scenario.id !== '__bootstrap';
 }
 
-function enrichBenchResultsWithBrowserMetrics(benchResults, artifactsDirectory) {
-  const parsed = parseWpCodeboxBrowserArtifacts(artifactsDirectory);
+function enrichBenchResultsWithBrowserMetrics(benchResults, artifactsDirectory, wpCodeboxBin = 'wp-codebox') {
+  const parsed = runWpCodeboxBrowserMetrics(artifactsDirectory, wpCodeboxBin);
   if (Object.keys(parsed.metrics).length === 0 && Object.keys(parsed.artifacts).length === 0) {
     return benchResults;
   }
@@ -310,12 +69,12 @@ function enrichBenchResultsWithBrowserMetrics(benchResults, artifactsDirectory) 
 }
 
 function cli(argv) {
-  const [benchResultsPath, artifactsDirectory] = argv;
+  const [benchResultsPath, artifactsDirectory, wpCodeboxBin = 'wp-codebox'] = argv;
   if (!benchResultsPath || !artifactsDirectory) {
-    throw new Error('Usage: node wp-codebox-browser-metrics.js <bench-results.json> <artifacts-directory>');
+    throw new Error('Usage: node wp-codebox-browser-metrics.js <bench-results.json> <artifacts-directory> [wp-codebox-bin]');
   }
   const benchResults = JSON.parse(fs.readFileSync(benchResultsPath, 'utf8'));
-  process.stdout.write(`${JSON.stringify(enrichBenchResultsWithBrowserMetrics(benchResults, artifactsDirectory), null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(enrichBenchResultsWithBrowserMetrics(benchResults, artifactsDirectory, wpCodeboxBin), null, 2)}\n`);
 }
 
 if (require.main === module) {
@@ -324,5 +83,5 @@ if (require.main === module) {
 
 module.exports = {
   enrichBenchResultsWithBrowserMetrics,
-  parseWpCodeboxBrowserArtifacts,
+  runWpCodeboxBrowserMetrics,
 };

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -638,7 +638,7 @@ jq '.benchResults | del(.warmup_iterations)' "$WP_CODEBOX_TMPFILE" > "$RESULTS_F
 
 if [ -f "$BENCH_BROWSER_METRICS_HELPER" ]; then
     ENRICHED_RESULTS_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-browser-metrics.XXXXXX")
-    if node "$BENCH_BROWSER_METRICS_HELPER" "$RESULTS_FILE" "$ARTIFACTS_DIR" > "$ENRICHED_RESULTS_FILE"; then
+    if node "$BENCH_BROWSER_METRICS_HELPER" "$RESULTS_FILE" "$ARTIFACTS_DIR" "$WP_CODEBOX_BIN" > "$ENRICHED_RESULTS_FILE"; then
         mv "$ENRICHED_RESULTS_FILE" "$RESULTS_FILE"
     else
         rm -f "$ENRICHED_RESULTS_FILE"

--- a/wordpress/tests/page-profiler-smoke.js
+++ b/wordpress/tests/page-profiler-smoke.js
@@ -637,6 +637,18 @@ async function main() {
 	const artifactRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-browser-profile-'));
 	try {
 		const browserDirectory = path.join(artifactRoot, 'files', 'browser');
+		const fakeWpCodebox = path.join(artifactRoot, 'wp-codebox');
+		fs.writeFileSync(fakeWpCodebox, `#!/usr/bin/env node
+const output = {
+  schema: 'wp-codebox/browser-metrics/v1',
+  bundleDirectory: process.argv[process.argv.indexOf('--bundle') + 1],
+  hasBrowserMetrics: true,
+  metrics: { browser_resource_count: 3 },
+  artifacts: { performance: { path: 'files/browser/performance.json', kind: 'json' } },
+};
+process.stdout.write(JSON.stringify(output) + '\\n');
+`);
+		fs.chmodSync(fakeWpCodebox, 0o755);
 		writeJson(path.join(browserDirectory, 'summary.json'), {
 			schema: 'wp-codebox/browser-probe/v1',
 			requestedUrl: 'https://example.test/wp-admin/site-editor.php',
@@ -677,6 +689,7 @@ async function main() {
 			baseUrl: 'https://example.test',
 			spec: { id: 'site-editor-root', path: '/wp-admin/site-editor.php', ready: '.edit-site' },
 			wpCodeboxArtifactsDirectory: artifactRoot,
+			wpCodeboxBin: fakeWpCodebox,
 			wordpressProfilerRows: [
 				{ event: 'request.start', request_id: 'r2', method: 'GET', uri: '/wp-json/wp/v2/templates?context=edit', t_ms: 0 },
 				{ event: 'shutdown', request_id: 'r2', method: 'GET', uri: '/wp-json/wp/v2/templates?context=edit', t_ms: 45 },

--- a/wordpress/tests/wp-codebox-browser-metrics-smoke.js
+++ b/wordpress/tests/wp-codebox-browser-metrics-smoke.js
@@ -7,17 +7,12 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const {
   enrichBenchResultsWithBrowserMetrics,
-  parseWpCodeboxBrowserArtifacts,
+  runWpCodeboxBrowserMetrics,
 } = require('../lib/wp-codebox-browser-metrics');
 
 function writeJson(filePath, value) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
-}
-
-function writeJsonl(filePath, rows) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`);
 }
 
 function withTempDirectory(callback) {
@@ -29,106 +24,131 @@ function withTempDirectory(callback) {
   }
 }
 
+function writeFakeWpCodebox(filePath, output) {
+  fs.writeFileSync(filePath, `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.writeFileSync(process.env.FAKE_WP_CODEBOX_ARGS_PATH, JSON.stringify(args));
+if (args[0] !== 'artifacts' || args[1] !== 'browser-metrics' || !args.includes('--json')) {
+  console.error('unexpected wp-codebox args: ' + JSON.stringify(args));
+  process.exit(2);
+}
+process.stdout.write(${JSON.stringify(`${JSON.stringify(output, null, 2)}\n`)});
+`);
+  fs.chmodSync(filePath, 0o755);
+}
+
 withTempDirectory((root) => {
-  const browser = path.join(root, 'artifact-123', 'files', 'browser');
-  writeJson(path.join(browser, 'summary.json'), {
-    peakUsedJSHeapSize: 9000,
-    finalUsedJSHeapSize: 7000,
-    postIdleUsedJSHeapSize: 6500,
-    generationHeapDeltaBytes: 4500,
-    domNodeCount: 42,
-    iframeCount: 3,
-  });
-  writeJson(path.join(browser, 'memory.json'), {
-    samples: [
-      { label: 'before_generation', usedJSHeapSize: 2500 },
-      { label: 'after_generation', usedJSHeapSize: 7000 },
-      { label: 'post_idle', usedJSHeapSize: 6500 },
-    ],
-  });
-  writeJson(path.join(browser, 'performance.json'), {
-    resources: [
-      { name: 'editor.js', transferSize: 1000 },
-      { name: 'style.css', transferSize: 250 },
-    ],
-    longTasks: [
-      { duration: 50.5 },
-      { duration: 12.25 },
-    ],
-  });
-  writeJsonl(path.join(browser, 'checkpoints.jsonl'), [
-    { label: 'load', usedJSHeapSize: 3000 },
-    { label: 'post_idle', usedJSHeapSize: 6500 },
-  ]);
+  const artifactsDirectory = path.join(root, 'artifact-bundle');
+  const argsPath = path.join(root, 'wp-codebox-args.json');
+  const fakeWpCodebox = path.join(root, 'wp-codebox.js');
+  const cliOutput = {
+    schema: 'wp-codebox/browser-metrics/v1',
+    bundleDirectory: artifactsDirectory,
+    hasBrowserMetrics: true,
+    metrics: {
+      browser_peak_used_js_heap_bytes: 9000,
+      browser_final_used_js_heap_bytes: 7000,
+      browser_checkpoint_count: 4,
+      browser_dom_node_count: 42,
+      browser_iframe_count: 3,
+      browser_resource_count: 2,
+      browser_transfer_size_bytes: 1250,
+      browser_long_task_count: 2,
+      browser_long_task_total_ms: 62.75,
+    },
+    artifacts: {
+      summary: { path: 'files/browser/summary.json', kind: 'json' },
+      memory: { path: 'files/browser/memory.json', kind: 'json' },
+      performance: { path: 'files/browser/performance.json', kind: 'json' },
+      checkpoints: { path: 'files/browser/checkpoints.jsonl', kind: 'jsonl' },
+    },
+  };
+  writeFakeWpCodebox(fakeWpCodebox, cliOutput);
 
-  const parsed = parseWpCodeboxBrowserArtifacts(root);
-  assert.deepEqual(parsed.metrics, {
-    browser_peak_used_js_heap_bytes: 9000,
-    browser_final_used_js_heap_bytes: 7000,
-    browser_post_idle_used_js_heap_bytes: 6500,
-    browser_generation_heap_delta_bytes: 4500,
-    browser_dom_node_count: 42,
-    browser_iframe_count: 3,
-    browser_resource_count: 2,
-    browser_transfer_size_bytes: 1250,
-    browser_long_task_count: 2,
-    browser_long_task_total_ms: 62.75,
-  });
-  assert.deepEqual(parsed.artifacts, {
-    browser_summary: { path: 'artifact-123/files/browser/summary.json', kind: 'json' },
-    browser_memory: { path: 'artifact-123/files/browser/memory.json', kind: 'json' },
-    browser_performance: { path: 'artifact-123/files/browser/performance.json', kind: 'json' },
-    browser_checkpoints: { path: 'artifact-123/files/browser/checkpoints.jsonl', kind: 'jsonl' },
-  });
+  const previousArgsPath = process.env.FAKE_WP_CODEBOX_ARGS_PATH;
+  process.env.FAKE_WP_CODEBOX_ARGS_PATH = argsPath;
+  try {
+    const parsed = runWpCodeboxBrowserMetrics(artifactsDirectory, fakeWpCodebox);
+    assert.deepEqual(JSON.parse(fs.readFileSync(argsPath, 'utf8')), [
+      'artifacts',
+      'browser-metrics',
+      '--bundle',
+      artifactsDirectory,
+      '--json',
+    ]);
+    assert.deepEqual(parsed.metrics, cliOutput.metrics);
+    assert.deepEqual(parsed.artifacts, {
+      browser_summary: { path: 'files/browser/summary.json', kind: 'json' },
+      browser_memory: { path: 'files/browser/memory.json', kind: 'json' },
+      browser_performance: { path: 'files/browser/performance.json', kind: 'json' },
+      browser_checkpoints: { path: 'files/browser/checkpoints.jsonl', kind: 'jsonl' },
+    });
 
-  const enriched = enrichBenchResultsWithBrowserMetrics({
-    component_id: 'fixture',
-    scenarios: [
-      { id: '__bootstrap', metrics: { boot_ms: 1 } },
-      { id: 'editor-generation', metrics: { mean_ms: 123 }, artifacts: { transcript: { path: 'transcript.json' } } },
-    ],
-  }, root);
-  assert.equal(enriched.metrics.browser_peak_used_js_heap_bytes, 9000);
-  assert.equal(enriched.scenarios[0].metrics.browser_peak_used_js_heap_bytes, undefined);
-  assert.equal(enriched.scenarios[1].metrics.browser_peak_used_js_heap_bytes, 9000);
-  assert.equal(enriched.scenarios[1].artifacts.browser_summary.path, 'artifact-123/files/browser/summary.json');
-  assert.equal(enriched.scenarios[1].artifacts.transcript.path, 'transcript.json');
+    const enriched = enrichBenchResultsWithBrowserMetrics({
+      component_id: 'fixture',
+      scenarios: [
+        { id: '__bootstrap', metrics: { boot_ms: 1 } },
+        { id: 'editor-generation', metrics: { mean_ms: 123 }, artifacts: { transcript: { path: 'transcript.json' } } },
+      ],
+    }, artifactsDirectory, fakeWpCodebox);
+    assert.equal(enriched.metrics.browser_peak_used_js_heap_bytes, 9000);
+    assert.equal(enriched.scenarios[0].metrics.browser_peak_used_js_heap_bytes, undefined);
+    assert.equal(enriched.scenarios[1].metrics.browser_peak_used_js_heap_bytes, 9000);
+    assert.equal(enriched.scenarios[1].artifacts.browser_summary.path, 'files/browser/summary.json');
+    assert.equal(enriched.scenarios[1].artifacts.transcript.path, 'transcript.json');
+  } finally {
+    if (previousArgsPath === undefined) {
+      delete process.env.FAKE_WP_CODEBOX_ARGS_PATH;
+    } else {
+      process.env.FAKE_WP_CODEBOX_ARGS_PATH = previousArgsPath;
+    }
+  }
 });
 
 withTempDirectory((root) => {
-  const result = parseWpCodeboxBrowserArtifacts(root);
-  assert.deepEqual(result, { metrics: {}, artifacts: {} });
-
-  const benchResults = { component_id: 'fixture', scenarios: [{ id: 'one', metrics: { mean_ms: 1 } }] };
-  assert.deepEqual(enrichBenchResultsWithBrowserMetrics(benchResults, root), benchResults);
-});
-
-withTempDirectory((root) => {
-  const browser = path.join(root, 'files', 'browser');
-  writeJson(path.join(browser, 'memory.json'), {
-    samples: [
-      { label: 'initial', usedJSHeapSize: 100 },
-      { label: 'after_generation', usedJSHeapSize: 250 },
-      { label: 'post_idle', usedJSHeapSize: 175, domNodeCount: 9 },
-    ],
+  const artifactsDirectory = path.join(root, 'empty-artifact-bundle');
+  const fakeWpCodebox = path.join(root, 'wp-codebox');
+  const argsPath = path.join(root, 'wp-codebox-args.json');
+  writeFakeWpCodebox(fakeWpCodebox, {
+    schema: 'wp-codebox/browser-metrics/v1',
+    bundleDirectory: artifactsDirectory,
+    hasBrowserMetrics: false,
+    metrics: {},
+    artifacts: {},
   });
 
-  const parsed = parseWpCodeboxBrowserArtifacts(root);
-  assert.equal(parsed.metrics.browser_peak_used_js_heap_bytes, 250);
-  assert.equal(parsed.metrics.browser_final_used_js_heap_bytes, 175);
-  assert.equal(parsed.metrics.browser_post_idle_used_js_heap_bytes, 175);
-  assert.equal(parsed.metrics.browser_dom_node_count, 9);
-  assert.deepEqual(Object.keys(parsed.artifacts), ['browser_memory']);
+  const previousArgsPath = process.env.FAKE_WP_CODEBOX_ARGS_PATH;
+  process.env.FAKE_WP_CODEBOX_ARGS_PATH = argsPath;
+  try {
+    const benchResults = { component_id: 'fixture', scenarios: [{ id: 'one', metrics: { mean_ms: 1 } }] };
+    assert.deepEqual(enrichBenchResultsWithBrowserMetrics(benchResults, artifactsDirectory, fakeWpCodebox), benchResults);
+  } finally {
+    if (previousArgsPath === undefined) {
+      delete process.env.FAKE_WP_CODEBOX_ARGS_PATH;
+    } else {
+      process.env.FAKE_WP_CODEBOX_ARGS_PATH = previousArgsPath;
+    }
+  }
 });
 
 withTempDirectory((root) => {
-  const browser = path.join(root, 'files', 'browser');
-  writeJson(path.join(browser, 'summary.json'), { peakUsedJSHeapSize: 12 });
+  const artifactsDirectory = path.join(root, 'artifact-bundle');
+  const fakeWpCodebox = path.join(root, 'wp-codebox');
+  const argsPath = path.join(root, 'wp-codebox-args.json');
+  writeFakeWpCodebox(fakeWpCodebox, {
+    schema: 'wp-codebox/browser-metrics/v1',
+    bundleDirectory: artifactsDirectory,
+    hasBrowserMetrics: true,
+    metrics: { browser_peak_used_js_heap_bytes: 12 },
+    artifacts: {},
+  });
   const benchResultsPath = path.join(root, 'bench-results.json');
   writeJson(benchResultsPath, { scenarios: [{ id: 'scenario', metrics: {} }] });
 
-  const result = spawnSync(process.execPath, [path.join(__dirname, '..', 'lib', 'wp-codebox-browser-metrics.js'), benchResultsPath, root], {
+  const result = spawnSync(process.execPath, [path.join(__dirname, '..', 'lib', 'wp-codebox-browser-metrics.js'), benchResultsPath, artifactsDirectory, fakeWpCodebox], {
     encoding: 'utf8',
+    env: { ...process.env, FAKE_WP_CODEBOX_ARGS_PATH: argsPath },
   });
   assert.equal(result.status, 0, result.stderr);
   const enriched = JSON.parse(result.stdout);


### PR DESCRIPTION
## Summary
- Replace Homeboy's direct WP Codebox browser artifact parsing in the bench enrichment helper with `wp-codebox artifacts browser-metrics --bundle <dir> --json`.
- Preserve Homeboy's existing bench result shape by mapping upstream artifact keys back to `browser_summary`, `browser_memory`, `browser_performance`, and `browser_checkpoints`.
- Keep WP Codebox binary resolution consistent with the bench runner, including `.js` CLI entrypoints.

## Tests
- `npm run test:wp-codebox-browser-metrics`
- `npm run test:page-profiler`
- `bash scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- `npx eslint lib/wp-codebox-browser-metrics.js lib/page-profiler.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation and smoke test updates; Chris remains responsible for review and validation.

Fixes #1007