### PR TITLE
Delegate WP Codebox doctor checks upstream

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -488,11 +488,10 @@ wordpress/scripts/doctor/wp-codebox-doctor.sh doctor
 wordpress/scripts/doctor/wp-codebox-doctor.sh cleanup --stale-after-seconds 3600
 ```
 
-The doctor reports the configured `wp-codebox` binary/source SHA, Node/npm
-availability, stale `recipe-run` processes, and corrupt `.zip` files in known WP
-Codebox/WordPress Playground cache roots. `cleanup` sends `TERM` to stale
-recipe-run processes and removes corrupt archives so the next runner invocation
-rebuilds them.
+The script resolves `HOMEBOY_WP_CODEBOX_BIN` or `wp_codebox_bin` from Homeboy
+settings, then delegates to upstream `wp-codebox doctor` or `wp-codebox cleanup`.
+WP Codebox owns the health output, including JSON mode, binary/source checks,
+stale `recipe-run` process checks, and archive cache cleanup behavior.
 
 ## Environment variables
 

--- a/wordpress/scripts/doctor/wp-codebox-doctor.sh
+++ b/wordpress/scripts/doctor/wp-codebox-doctor.sh
@@ -1,122 +1,52 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-MODE="doctor"
-FIX=0
-STALE_AFTER_SECONDS="${HOMEBOY_WP_CODEBOX_STALE_AFTER_SECONDS:-3600}"
-ARCHIVE_ROOTS=()
-
 usage() {
     cat <<'USAGE'
-Usage: wp-codebox-doctor.sh [doctor|cleanup] [--fix] [--stale-after-seconds N] [--archive-root DIR]
+Usage: wp-codebox-doctor.sh [doctor|cleanup] [wp-codebox doctor options]
 
-Checks WP Codebox runner health for Homeboy's WordPress extension.
+Thin Homeboy wrapper for upstream WP Codebox health commands.
 
 Commands:
-  doctor   Report binary/source fingerprint, Node/npm availability, stale recipe-run processes, and corrupt archives.
-  cleanup  Run the same checks and remove safe stale/corrupt runtime state.
+  doctor   Report WP Codebox runner health. Default.
+  cleanup  Run doctor checks and remove safe stale/corrupt runtime state.
 
-Options:
+Common options passed through to WP Codebox:
   --fix                      Allow mutating cleanup when command is doctor.
-  --stale-after-seconds N    Age threshold for stale recipe-run processes. Default: 3600.
-  --archive-root DIR         Additional archive/cache root to scan for corrupt .zip files.
+  --stale-after-seconds N    Age threshold for stale recipe-run processes.
+  --archive-root DIR         Additional archive/cache root to scan. Repeatable.
+  --json                     Emit WP Codebox JSON health output.
 
 Environment:
-  HOMEBOY_WP_CODEBOX_BIN                 Specific wp-codebox binary.
-  HOMEBOY_SETTINGS_JSON                  May provide wp_codebox_bin.
-  HOMEBOY_WP_CODEBOX_ARCHIVE_ROOTS       Colon-separated archive/cache roots.
-  HOMEBOY_WP_CODEBOX_STALE_AFTER_SECONDS Stale recipe-run age threshold.
+  HOMEBOY_WP_CODEBOX_BIN    Specific wp-codebox binary.
+  HOMEBOY_SETTINGS_JSON     May provide wp_codebox_bin.
 USAGE
 }
 
-while [ "$#" -gt 0 ]; do
-    case "$1" in
-        doctor|cleanup)
-            MODE="$1"
-            ;;
-        --fix)
-            FIX=1
-            ;;
-        --stale-after-seconds)
-            shift
-            if [ "$#" -eq 0 ] || ! [[ "${1:-}" =~ ^[0-9]+$ ]]; then
-                echo "ERROR: --stale-after-seconds requires an integer value" >&2
-                exit 2
-            fi
-            STALE_AFTER_SECONDS="$1"
-            ;;
-        --archive-root)
-            shift
-            if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
-                echo "ERROR: --archive-root requires a directory" >&2
-                exit 2
-            fi
-            ARCHIVE_ROOTS+=("$1")
-            ;;
-        -h|--help)
-            usage
-            exit 0
-            ;;
-        *)
-            echo "ERROR: Unknown argument: $1" >&2
-            usage >&2
-            exit 2
-            ;;
-    esac
-    shift
-done
+settings_wp_codebox_bin() {
+    [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] || return 0
+    [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ] || return 0
 
-if [ "$MODE" = "cleanup" ]; then
-    FIX=1
-fi
-
-STATUS="ok"
-
-mark_problem() {
-    local level="$1"
-    if [ "$level" = "error" ]; then
-        STATUS="error"
-    elif [ "$STATUS" = "ok" ]; then
-        STATUS="warning"
+    if command -v jq >/dev/null 2>&1; then
+        printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_bin // empty' 2>/dev/null || true
+        return 0
     fi
-}
 
-print_check() {
-    local level="$1"
-    local key="$2"
-    local message="$3"
-    printf '[%s] %s: %s\n' "$level" "$key" "$message"
-    case "$level" in
-        error|warning)
-            mark_problem "$level"
-            ;;
-    esac
-}
-
-sha256_file() {
-    local file="$1"
-    if command -v shasum >/dev/null 2>&1; then
-        shasum -a 256 "$file" | awk '{print $1}'
-    elif command -v sha256sum >/dev/null 2>&1; then
-        sha256sum "$file" | awk '{print $1}'
-    else
-        return 1
-    fi
-}
-
-realpath_portable() {
-    local target="$1"
-    if command -v realpath >/dev/null 2>&1; then
-        realpath "$target"
-    else
-        php -r 'echo realpath($argv[1]) ?: $argv[1];' "$target"
+    if command -v node >/dev/null 2>&1; then
+        node -e '
+const input = process.env.HOMEBOY_SETTINGS_JSON || "{}";
+try {
+  const value = JSON.parse(input).wp_codebox_bin;
+  if (typeof value === "string") process.stdout.write(value);
+} catch {}
+' 2>/dev/null || true
     fi
 }
 
 resolve_wp_codebox_bin() {
     local bin="${HOMEBOY_WP_CODEBOX_BIN:-}"
-    if [ -z "$bin" ] && [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ] && command -v jq >/dev/null 2>&1; then
-        bin=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_bin // empty' 2>/dev/null || true)
+    if [ -z "$bin" ]; then
+        bin="$(settings_wp_codebox_bin)"
     fi
     bin="${bin:-wp-codebox}"
 
@@ -128,256 +58,19 @@ resolve_wp_codebox_bin() {
     command -v "$bin" 2>/dev/null || printf '%s\n' "$bin"
 }
 
-find_package_root() {
-    local start="$1"
-    local dir
-    dir="$(dirname "$start")"
-    while [ "$dir" != "/" ] && [ -n "$dir" ]; do
-        if [ -f "$dir/package.json" ]; then
-            printf '%s\n' "$dir"
-            return 0
-        fi
-        dir="$(dirname "$dir")"
-    done
-    return 1
-}
+MODE="doctor"
+if [ "$#" -gt 0 ]; then
+    case "$1" in
+        doctor|cleanup)
+            MODE="$1"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+    esac
+fi
 
-git_head_for_dir() {
-    local dir="$1"
-    if command -v git >/dev/null 2>&1 && git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        git -C "$dir" rev-parse HEAD 2>/dev/null || true
-    fi
-}
-
-check_runtime_tools() {
-    if command -v node >/dev/null 2>&1; then
-        print_check ok node "$(node --version) at $(command -v node)"
-    else
-        print_check error node "node is not available on PATH"
-    fi
-
-    if command -v npm >/dev/null 2>&1; then
-        print_check ok npm "$(npm --version) at $(command -v npm)"
-    else
-        print_check warning npm "npm is not available on PATH"
-    fi
-}
-
-check_wp_codebox_binary() {
-    local bin="$1"
-    if [ ! -e "$bin" ] && ! command -v "$bin" >/dev/null 2>&1; then
-        print_check error wp-codebox "wp-codebox not found; set HOMEBOY_WP_CODEBOX_BIN, settings wp_codebox_bin, or install wp-codebox"
-        return 0
-    fi
-
-    local resolved="$bin"
-    if [ -e "$bin" ]; then
-        resolved="$(realpath_portable "$bin")"
-    elif command -v "$bin" >/dev/null 2>&1; then
-        resolved="$(realpath_portable "$(command -v "$bin")")"
-    fi
-
-    if [ -f "$resolved" ]; then
-        local digest
-        digest="$(sha256_file "$resolved" 2>/dev/null || true)"
-        if [ -n "$digest" ]; then
-            print_check ok wp-codebox.binary "${resolved} sha256:${digest}"
-        else
-            print_check warning wp-codebox.binary "${resolved}; sha256 tool unavailable"
-        fi
-    else
-        print_check ok wp-codebox.binary "$resolved"
-    fi
-
-    local package_root
-    package_root="$(find_package_root "$resolved" 2>/dev/null || true)"
-    if [ -n "$package_root" ]; then
-        local source_digest git_head
-        source_digest="$(sha256_file "$package_root/package.json" 2>/dev/null || true)"
-        git_head="$(git_head_for_dir "$package_root")"
-        if [ -n "$git_head" ]; then
-            print_check ok wp-codebox.source "${package_root} git:${git_head}"
-        elif [ -n "$source_digest" ]; then
-            print_check ok wp-codebox.source "${package_root}/package.json sha256:${source_digest}"
-        else
-            print_check ok wp-codebox.source "$package_root"
-        fi
-    else
-        print_check warning wp-codebox.source "package root not found for ${resolved}"
-    fi
-}
-
-recipe_run_process_rows() {
-    if ! command -v ps >/dev/null 2>&1; then
-        return 0
-    fi
-    if ps -axo pid=,etimes=,command= >/dev/null 2>&1; then
-        ps -axo pid=,etimes=,command= 2>/dev/null | awk '
-            /wp-codebox/ && /recipe-run/ { print }
-            /homeboy-wp-codebox-task-runner/ { print }
-        ' || true
-        return 0
-    fi
-
-    ps -axo pid=,command= 2>/dev/null | awk '
-        /wp-codebox/ && /recipe-run/ { pid=$1; $1=""; sub(/^ +/, ""); print pid, 0, $0 }
-        /homeboy-wp-codebox-task-runner/ { pid=$1; $1=""; sub(/^ +/, ""); print pid, 0, $0 }
-    ' || true
-}
-
-check_stale_recipe_runs() {
-    local rows stale_count cleaned_count
-    rows="$(recipe_run_process_rows)"
-    stale_count=0
-    cleaned_count=0
-
-    if [ -z "$rows" ]; then
-        print_check ok wp-codebox.processes "no recipe-run processes found"
-        return 0
-    fi
-
-    while IFS= read -r row; do
-        [ -n "$row" ] || continue
-        local pid age command
-        pid="$(printf '%s\n' "$row" | awk '{print $1}')"
-        age="$(printf '%s\n' "$row" | awk '{print $2}')"
-        command="$(printf '%s\n' "$row" | awk '{$1=""; $2=""; sub(/^ +/, ""); print}')"
-        if [ -z "$pid" ] || [ "$pid" = "$$" ] || ! [[ "$age" =~ ^[0-9]+$ ]]; then
-            continue
-        fi
-        if [ "$age" -ge "$STALE_AFTER_SECONDS" ]; then
-            stale_count=$((stale_count + 1))
-            if [ "$FIX" -eq 1 ]; then
-                if kill "$pid" >/dev/null 2>&1; then
-                    cleaned_count=$((cleaned_count + 1))
-                    print_check ok wp-codebox.cleanup "sent TERM to stale recipe-run pid ${pid} age=${age}s"
-                else
-                    print_check warning wp-codebox.cleanup "failed to terminate stale recipe-run pid ${pid} age=${age}s"
-                fi
-            else
-                print_check warning wp-codebox.process "stale recipe-run pid ${pid} age=${age}s command=${command}"
-            fi
-        fi
-    done <<< "$rows"
-
-    if [ "$stale_count" -eq 0 ]; then
-        print_check ok wp-codebox.processes "recipe-run processes found, none older than ${STALE_AFTER_SECONDS}s"
-    elif [ "$FIX" -eq 1 ]; then
-        print_check ok wp-codebox.cleanup "terminated ${cleaned_count}/${stale_count} stale recipe-run process(es)"
-    fi
-}
-
-add_archive_roots_from_env() {
-    local value="${HOMEBOY_WP_CODEBOX_ARCHIVE_ROOTS:-}"
-    [ -n "$value" ] || return 0
-    local root
-    IFS=':' read -r -a roots <<< "$value"
-    for root in "${roots[@]}"; do
-        [ -n "$root" ] && ARCHIVE_ROOTS+=("$root")
-    done
-}
-
-add_default_archive_roots() {
-    local root
-    for root in \
-        "${HOME}/.cache/wp-codebox" \
-        "${HOME}/.wp-codebox" \
-        "${HOME}/.cache/wordpress-playground" \
-        "${HOME}/.wordpress-playground"; do
-        ARCHIVE_ROOTS+=("$root")
-    done
-}
-
-zip_is_valid() {
-    local file="$1"
-    if command -v unzip >/dev/null 2>&1; then
-        unzip -tq "$file" >/dev/null 2>&1
-        return $?
-    fi
-    if command -v python3 >/dev/null 2>&1; then
-        python3 - "$file" <<'PY' >/dev/null 2>&1
-import sys, zipfile
-with zipfile.ZipFile(sys.argv[1]) as archive:
-    bad = archive.testzip()
-    if bad:
-        raise SystemExit(1)
-PY
-        return $?
-    fi
-    return 2
-}
-
-check_archives() {
-    add_archive_roots_from_env
-    add_default_archive_roots
-
-    local existing_roots=()
-    local root
-    for root in "${ARCHIVE_ROOTS[@]}"; do
-        [ -d "$root" ] || continue
-        existing_roots+=("$root")
-    done
-
-    if [ "${#existing_roots[@]}" -eq 0 ]; then
-        print_check ok wp-codebox.archives "no known WP Codebox/Playground archive roots found"
-        return 0
-    fi
-
-    local checked=0 corrupt=0 removed=0 skipped=0 file rc
-    while IFS= read -r -d '' file; do
-        checked=$((checked + 1))
-        set +e
-        zip_is_valid "$file"
-        rc=$?
-        set -e
-        if [ "$rc" -eq 0 ]; then
-            continue
-        fi
-        if [ "$rc" -eq 2 ]; then
-            skipped=$((skipped + 1))
-            continue
-        fi
-        corrupt=$((corrupt + 1))
-        if [ "$FIX" -eq 1 ]; then
-            if rm -f "$file"; then
-                removed=$((removed + 1))
-                print_check ok wp-codebox.archive-cleanup "removed corrupt archive ${file}"
-            else
-                print_check warning wp-codebox.archive-cleanup "failed to remove corrupt archive ${file}"
-            fi
-        else
-            print_check warning wp-codebox.archive "corrupt archive ${file}"
-        fi
-    done < <(find "${existing_roots[@]}" -type f \( -name '*.zip' -o -name '*.zip.tmp' \) -print0 2>/dev/null || true)
-
-    if [ "$skipped" -gt 0 ]; then
-        print_check warning wp-codebox.archives "archive validation skipped; install unzip or python3"
-    elif [ "$corrupt" -eq 0 ]; then
-        print_check ok wp-codebox.archives "checked ${checked} archive(s); no corrupt archives found"
-    elif [ "$FIX" -eq 1 ]; then
-        print_check ok wp-codebox.archive-cleanup "removed ${removed}/${corrupt} corrupt archive(s)"
-    fi
-}
-
-echo "WP Codebox runner ${MODE}"
-echo "  stale_after_seconds: ${STALE_AFTER_SECONDS}"
-echo "  cleanup_enabled: ${FIX}"
-
-check_runtime_tools
 WP_CODEBOX_BIN="$(resolve_wp_codebox_bin)"
-check_wp_codebox_binary "$WP_CODEBOX_BIN"
-check_stale_recipe_runs
-check_archives
-
-case "$STATUS" in
-    ok)
-        echo "WP Codebox runner ${MODE} complete: ok"
-        ;;
-    warning)
-        echo "WP Codebox runner ${MODE} complete: warnings"
-        ;;
-    error)
-        echo "WP Codebox runner ${MODE} complete: errors"
-        exit 1
-        ;;
-esac
+exec "$WP_CODEBOX_BIN" "$MODE" "$@"

--- a/wordpress/scripts/test/wp-codebox-doctor-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-doctor-smoke.sh
@@ -6,93 +6,79 @@ DOCTOR="${SCRIPT_DIR}/../doctor/wp-codebox-doctor.sh"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
-FAKE_PACKAGE="${TMPDIR}/wp-codebox-package"
-FAKE_BIN="${FAKE_PACKAGE}/bin/wp-codebox.js"
-STALE_PROCESS_BIN="${TMPDIR}/wp-codebox-process"
+FAKE_BIN="${TMPDIR}/wp-codebox"
+CALLS="${TMPDIR}/calls.log"
 ARCHIVE_ROOT="${TMPDIR}/archives"
-mkdir -p "$(dirname "$FAKE_BIN")" "$ARCHIVE_ROOT"
+mkdir -p "$ARCHIVE_ROOT"
 
-cat > "${FAKE_PACKAGE}/package.json" <<'JSON'
-{"name":"@chubes4/wp-codebox","version":"0.0.0-smoke"}
-JSON
-
-cat > "$FAKE_BIN" <<'NODE'
-#!/usr/bin/env node
-process.stdout.write('fake wp-codebox\n')
-NODE
+cat > "$FAKE_BIN" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$WP_CODEBOX_CALLS"
+case "$1" in
+    doctor)
+        printf 'WP Codebox doctor: warning\n'
+        ;;
+    cleanup)
+        printf 'WP Codebox cleanup: ok\n'
+        ;;
+    *)
+        printf 'unexpected mode: %s\n' "$1" >&2
+        exit 64
+        ;;
+esac
+SH
 chmod +x "$FAKE_BIN"
 
-cat > "$STALE_PROCESS_BIN" <<'SH'
+output=$(WP_CODEBOX_CALLS="$CALLS" \
+    HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
+    bash "$DOCTOR" doctor --fix --stale-after-seconds 1 --archive-root "$ARCHIVE_ROOT" --json 2>&1)
+
+if [[ "$output" != *"WP Codebox doctor: warning"* ]]; then
+    echo "Expected delegated doctor output" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+cleanup_output=$(WP_CODEBOX_CALLS="$CALLS" \
+    HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
+    bash "$DOCTOR" cleanup --stale-after-seconds 0 --archive-root "$ARCHIVE_ROOT" 2>&1)
+
+if [[ "$cleanup_output" != *"WP Codebox cleanup: ok"* ]]; then
+    echo "Expected delegated cleanup output" >&2
+    echo "$cleanup_output" >&2
+    exit 1
+fi
+
+if ! grep -Fq "doctor --fix --stale-after-seconds 1 --archive-root $ARCHIVE_ROOT --json" "$CALLS"; then
+    echo "Expected doctor args to be passed through" >&2
+    cat "$CALLS" >&2
+    exit 1
+fi
+
+if ! grep -Fq "cleanup --stale-after-seconds 0 --archive-root $ARCHIVE_ROOT" "$CALLS"; then
+    echo "Expected cleanup args to be passed through" >&2
+    cat "$CALLS" >&2
+    exit 1
+fi
+
+SETTINGS_BIN="${TMPDIR}/settings-wp-codebox"
+cat > "$SETTINGS_BIN" <<'SH'
 #!/usr/bin/env bash
-sleep 30
+set -euo pipefail
+printf '%s\n' "$*" >> "$WP_CODEBOX_CALLS"
+printf 'settings wp-codebox %s\n' "$1"
 SH
-chmod +x "$STALE_PROCESS_BIN"
+chmod +x "$SETTINGS_BIN"
 
-printf 'not a zip\n' > "${ARCHIVE_ROOT}/corrupt-playground.zip"
+settings_output=$(WP_CODEBOX_CALLS="$CALLS" \
+    HOMEBOY_SETTINGS_JSON="{\"wp_codebox_bin\":\"$SETTINGS_BIN\"}" \
+    bash "$DOCTOR" --json 2>&1)
 
-"$STALE_PROCESS_BIN" recipe-run &
-STALE_PID=$!
-trap 'kill "$STALE_PID" >/dev/null 2>&1 || true; rm -rf "$TMPDIR"' EXIT
-
-output=$(HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
-    HOMEBOY_WP_CODEBOX_ARCHIVE_ROOTS="$ARCHIVE_ROOT" \
-    bash "$DOCTOR" doctor --stale-after-seconds 1 2>&1)
-
-if [[ "$output" != *"WP Codebox runner doctor"* ]]; then
-    echo "Expected doctor header" >&2
-    echo "$output" >&2
+if [[ "$settings_output" != *"settings wp-codebox doctor"* ]]; then
+    echo "Expected settings wp_codebox_bin to be used" >&2
+    echo "$settings_output" >&2
     exit 1
 fi
 
-if [[ "$output" != *"wp-codebox.binary"* ]] || [[ "$output" != *"sha256:"* ]]; then
-    echo "Expected binary sha diagnostics" >&2
-    echo "$output" >&2
-    exit 1
-fi
-
-if [[ "$output" != *"wp-codebox.source"* ]]; then
-    echo "Expected source diagnostics" >&2
-    echo "$output" >&2
-    exit 1
-fi
-
-if [[ "$output" != *"corrupt archive"* ]]; then
-    echo "Expected corrupt archive warning" >&2
-    echo "$output" >&2
-    exit 1
-fi
-
-cleanup_output=$(HOMEBOY_WP_CODEBOX_BIN="$FAKE_BIN" \
-    HOMEBOY_WP_CODEBOX_ARCHIVE_ROOTS="$ARCHIVE_ROOT" \
-    bash "$DOCTOR" cleanup --stale-after-seconds 0 2>&1)
-
-if [[ "$cleanup_output" != *"removed corrupt archive"* ]]; then
-    echo "Expected corrupt archive cleanup" >&2
-    echo "$cleanup_output" >&2
-    exit 1
-fi
-
-if [[ "$cleanup_output" != *"sent TERM to stale recipe-run pid"* ]]; then
-    echo "Expected stale recipe-run process cleanup" >&2
-    echo "$cleanup_output" >&2
-    exit 1
-fi
-
-if [ -e "${ARCHIVE_ROOT}/corrupt-playground.zip" ]; then
-    echo "Expected cleanup to remove corrupt archive" >&2
-    exit 1
-fi
-
-for _ in 1 2 3 4 5; do
-    if ! kill -0 "$STALE_PID" >/dev/null 2>&1; then
-        break
-    fi
-    sleep 0.1
-done
-
-if kill -0 "$STALE_PID" >/dev/null 2>&1; then
-    echo "Expected cleanup to terminate stale recipe-run process" >&2
-    exit 1
-fi
-
-echo "WP Codebox doctor smoke passed"
+echo "WP Codebox doctor wrapper smoke passed"


### PR DESCRIPTION
## Summary
- Replace Homeboy's local WP Codebox doctor implementation with a thin wrapper around upstream `wp-codebox doctor` / `wp-codebox cleanup`.
- Preserve Homeboy binary resolution through `HOMEBOY_WP_CODEBOX_BIN` and `HOMEBOY_SETTINGS_JSON.wp_codebox_bin`, while passing doctor/cleanup flags through to WP Codebox.
- Update the smoke test and README to reflect that WP Codebox now owns the health output contract.

Closes #1007.

## Verification
- `bash -n wordpress/scripts/doctor/wp-codebox-doctor.sh wordpress/scripts/test/wp-codebox-doctor-smoke.sh`
- `bash wordpress/scripts/test/wp-codebox-doctor-smoke.sh`
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-issue-1007-wp-codebox-doctor-wrapper/wordpress --extension wordpress --skip-lint` failed in unrelated WP Codebox/Playground PHPUnit fixture behavior and a lab installed-extension path issue (`parse-test-results.sh` missing `scripts/lib/test-result-adapters.sh` from the installed extension path). The targeted doctor wrapper smoke passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the wrapper adoption, smoke test update, README update, verification commands, and PR description; Chris remains responsible for review and merge.