### PR TITLE
Delegate Codebox agent tasks to upstream runner

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -153,6 +153,29 @@ function artifactFromCodeboxArtifact(artifact, index) {
 }
 
 function normalizeArtifacts(result) {
+  if (result?.schema === 'wp-codebox/agent-task-run/v1') {
+    const artifacts = [];
+    if (typeof result.artifacts === 'string' && result.artifacts) {
+      artifacts.push({
+        id: result.session?.artifacts?.bundle_id || 'wp-codebox-artifacts',
+        kind: 'codebox-artifact-directory',
+        path: result.artifacts,
+        metadata: {
+          session_id: result.session?.id,
+          preview_url: result.session?.artifacts?.preview_url,
+        },
+      });
+    }
+    if (result.session?.artifacts && typeof result.session.artifacts === 'object') {
+      artifacts.push({
+        id: result.session.artifacts.bundle_id || `wp-codebox-session-artifacts-${artifacts.length + 1}`,
+        kind: 'codebox-session-artifacts',
+        url: result.session.artifacts.preview_url,
+        metadata: result.session.artifacts,
+      });
+    }
+    return artifacts.map(artifactFromCodeboxArtifact);
+  }
   const artifacts = Array.isArray(result?.artifacts)
     ? result.artifacts
     : Object.values(result?.artifacts || {}).filter((value) => value && typeof value === 'object');
@@ -160,6 +183,20 @@ function normalizeArtifacts(result) {
 }
 
 function normalizeEvidenceRefs(result) {
+  if (result?.schema === 'wp-codebox/agent-task-run/v1') {
+    return [
+      result.session?.artifacts?.preview_url ? {
+        kind: 'codebox-preview',
+        uri: result.session.artifacts.preview_url,
+        label: 'WP Codebox preview',
+      } : null,
+      typeof result.artifacts === 'string' && result.artifacts ? {
+        kind: 'codebox-artifact-directory',
+        uri: result.artifacts,
+        label: 'WP Codebox artifacts',
+      } : null,
+    ].filter(Boolean);
+  }
   const evidenceRefs = result?.evidence_refs || result?.evidence || [];
   return evidenceRefs.map((ref) => ({
     kind: ref.kind || ref.type || 'codebox_evidence',

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -30,11 +30,6 @@ function hasFlag(name) {
   return process.argv.includes(name);
 }
 
-function usage() {
-  console.error('Usage: homeboy-wp-codebox-task-runner.cjs --agents-api <path> --data-machine <path> --data-machine-code <path> [--homeboy <path>] [--homeboy-extensions <path>] [--wp-codebox-bin <bin>] [--provider <id>] [--model <id>] [--max-turns <n>] [--task-timeout-seconds <n>] [--provider-plugin-path <path>] [--secret-env <ENV>] [--mount <host:vfs[:mode]>] [--runtime-stack-mount <host:vfs[:mode]>] [--runtime-overlay-json <json>] [--artifacts <dir>]');
-  process.exit(1);
-}
-
 function readStdin() {
   try {
     return fs.readFileSync(0, 'utf8');
@@ -53,52 +48,6 @@ function readTaskRequest() {
     throw new Error('Task request must use schema homeboy/wp-codebox-task-request/v1.');
   }
   return request;
-}
-
-function requireValue(name, value) {
-  if (!value) {
-    throw new Error(`Required WP Codebox task runner option missing: ${name}`);
-  }
-  return value;
-}
-
-function pluginEntry(source, slug, activate = false) {
-  const pluginSlug = (slug || path.basename(source)).split('@')[0].replace(/[^a-zA-Z0-9_-]/g, '-');
-  const entry = { source, slug: pluginSlug, activate };
-  const pluginFile = detectPluginMainFile(source, pluginSlug);
-  if (pluginFile) {
-    entry.pluginFile = pluginFile;
-  }
-  return entry;
-}
-
-function detectPluginMainFile(source, pluginSlug) {
-  if (!fs.existsSync(source) || !fs.statSync(source).isDirectory()) {
-    return '';
-  }
-
-  const phpFiles = fs.readdirSync(source)
-    .filter((fileName) => fileName.endsWith('.php'))
-    .sort((left, right) => {
-      const preferred = [`${pluginSlug}.php`, 'plugin.php'];
-      const leftIndex = preferred.includes(left) ? preferred.indexOf(left) : preferred.length;
-      const rightIndex = preferred.includes(right) ? preferred.indexOf(right) : preferred.length;
-      return leftIndex - rightIndex || left.localeCompare(right);
-    });
-
-  for (const fileName of phpFiles) {
-    const header = fs.readFileSync(path.join(source, fileName), 'utf8').slice(0, 8192);
-    if (/Plugin Name\s*:/i.test(header)) {
-      return `${pluginSlug}/${fileName}`;
-    }
-  }
-
-  return '';
-}
-
-function providerPluginEntries(request) {
-  const paths = [...(request.provider_plugin_paths || []), ...argValues('--provider-plugin-path')];
-  return paths.map((source) => pluginEntry(source, path.basename(source), false));
 }
 
 function secretEnvNames(request) {
@@ -125,8 +74,11 @@ function mountEntryFromValue(value, metadata) {
   };
 }
 
-function mountEntries() {
-  return argValues('--mount').map((value) => mountEntryFromValue(value, { kind: 'homeboy-audit-fanout' }));
+function mountEntries(request) {
+  return [
+    ...(request.mounts || []),
+    ...argValues('--mount').map((value) => mountEntryFromValue(value, { kind: 'homeboy-audit-fanout' })),
+  ];
 }
 
 function runtimeStackMountEntries(request) {
@@ -162,127 +114,6 @@ function pathInside(parent, candidate) {
   }
 }
 
-function workspaceSlug(source) {
-  return path.basename(source).split('@')[0].replace(/[^a-zA-Z0-9_-]/g, '-');
-}
-
-function workspaceEntry(source) {
-  const slug = workspaceSlug(source);
-  return {
-    seed: {
-      type: 'directory',
-      source,
-      slug,
-      excludePaths: [
-        '.git',
-        '.homeboy',
-        '.homeboy-bin',
-        '.homeboy-build',
-        '.datamachine',
-        '.DS_Store',
-        '._*',
-        '.env*',
-        'node_modules',
-        'target',
-        'vendor',
-      ],
-    },
-    target: `/workspace/${slug}`,
-    mode: 'readwrite',
-    sourceMode: 'repo-backed',
-  };
-}
-
-function recipeWorkspaces(options) {
-  return [
-    options.agentsApi,
-    options.homeboy,
-    options.homeboyExtensions,
-  ].filter(Boolean).map(workspaceEntry);
-}
-
-function recipeForRequest(request, options) {
-  const provider = argValue('--provider') || request.provider || '';
-  const model = argValue('--model') || request.model || '';
-  const workspaceSlugs = recipeWorkspaces(options).map((workspace) => workspace.seed.slug);
-  const task = JSON.stringify({
-    schema: 'homeboy/wp-codebox-audit-task/v1',
-    sandbox_session_id: request.sandbox_session_id,
-    group_key: request.group_key,
-    orchestrator: request.orchestrator,
-    audit_findings: request.audit_findings,
-    task: {
-      ...(request.task || {}),
-      prompt: [
-        request.task?.prompt || '',
-        `Use Data Machine Code workspace repos ${workspaceSlugs.map((slug) => `\`${slug}\``).join(', ')} for workspace_* tool calls.`,
-      ].filter(Boolean).join('\n\n'),
-    },
-  });
-
-  const providerSlugs = providerPluginEntries(request).map((plugin) => plugin.slug).join(',');
-  const maxTurns = argValue('--max-turns') || request.max_turns || request.maxTurns || '';
-  const taskTimeoutSeconds = argValue('--task-timeout-seconds') || request.task_timeout_seconds || request.taskTimeoutSeconds || '';
-  const stepArgs = [
-    `task=${task}`,
-    'agent=sandbox-agent',
-    'mode=sandbox',
-    `provider=${provider}`,
-    `model=${model}`,
-    `provider-plugin-slugs=${providerSlugs}`,
-  ];
-  if (maxTurns) {
-    stepArgs.push(`max-turns=${maxTurns}`);
-  }
-  if (taskTimeoutSeconds) {
-    stepArgs.push(`timeout-seconds=${taskTimeoutSeconds}`);
-  }
-
-  const runtimeStackMounts = runtimeStackMountEntries(request);
-  const runtimeOverlays = runtimeOverlayEntries(request);
-  const runtime = {
-    wp: argValue('--wp') || 'latest',
-    blueprint: { steps: [] },
-  };
-  if (runtimeStackMounts.length > 0) {
-    runtime.stack = { mounts: runtimeStackMounts };
-  }
-  if (runtimeOverlays.length > 0) {
-    runtime.overlays = runtimeOverlays;
-  }
-
-  return {
-    schema: 'wp-codebox/workspace-recipe/v1',
-    runtime,
-    inputs: {
-      workspaces: recipeWorkspaces(options),
-      mounts: mountEntries(),
-      extraPlugins: [
-        pluginEntry(options.agentsApi, 'agents-api', false),
-        pluginEntry(options.dataMachine, 'data-machine', false),
-        pluginEntry(options.dataMachineCode, 'data-machine-code', false),
-        ...providerPluginEntries(request),
-      ],
-      secretEnv: secretEnvNames(request),
-    },
-    workflow: {
-      steps: [
-        {
-          command: 'wp-codebox.agent-sandbox-run',
-          args: stepArgs,
-        },
-      ],
-    },
-  };
-}
-
-function writeRecipe(recipe) {
-  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-recipe-'));
-  const recipePath = path.join(directory, 'recipe.json');
-  fs.writeFileSync(recipePath, `${JSON.stringify(recipe, null, 2)}\n`);
-  return recipePath;
-}
-
 function requestTimeoutMs(request) {
   const seconds = Number.parseInt(request.task_timeout_seconds || request.taskTimeoutSeconds || argValue('--task-timeout-seconds'), 10);
   return Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : undefined;
@@ -298,10 +129,17 @@ function executable(filePath) {
 }
 
 function resolveCommand(command, args) {
-  if (path.extname(command) === '.js' && !executable(command)) {
+  if ((path.extname(command) === '.js' || path.extname(command) === '.cjs' || path.extname(command) === '.mjs') && !executable(command)) {
     return { command: process.execPath, args: [command, ...args] };
   }
   return { command, args };
+}
+
+function writeJsonFile(prefix, value) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const filePath = path.join(directory, 'input.json');
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+  return filePath;
 }
 
 function writePreflightEvidence(artifacts, evidence) {
@@ -315,17 +153,39 @@ function writePreflightEvidence(artifacts, evidence) {
   }
 }
 
-function timeoutPayload(timeoutMs, artifacts, evidencePath, recipePath, command, args) {
+function runnerInput(request, artifacts) {
+  return Object.fromEntries(Object.entries({
+    parent_request: request,
+    provider: argValue('--provider') || request.provider || '',
+    model: argValue('--model') || request.model || '',
+    provider_plugin_paths: [...(request.provider_plugin_paths || []), ...argValues('--provider-plugin-path')],
+    secret_env: secretEnvNames(request),
+    mounts: mountEntries(request),
+    runtime_stack_mounts: runtimeStackMountEntries(request),
+    runtime_overlays: runtimeOverlayEntries(request),
+    max_turns: Number.parseInt(argValue('--max-turns') || request.max_turns || request.maxTurns || 0, 10) || undefined,
+    task_timeout_seconds: Number.parseInt(argValue('--task-timeout-seconds') || request.task_timeout_seconds || request.taskTimeoutSeconds || 0, 10) || undefined,
+    sandbox_session_id: request.sandbox_session_id || '',
+    orchestrator: request.orchestrator || {},
+    artifacts_path: artifacts,
+    wp_codebox_bin: argValue('--wp-codebox-bin') || request.wp_codebox_bin || '',
+    agents_api_path: argValue('--agents-api') || request.agents_api || '',
+    data_machine_path: argValue('--data-machine') || request.data_machine || '',
+    data_machine_code_path: argValue('--data-machine-code') || request.data_machine_code || '',
+  }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
+}
+
+function timeoutPayload(timeoutMs, artifacts, evidencePath, inputPath, command, args) {
   const artifact = evidencePath ? [{
     id: 'homeboy-codebox-task-runner-preflight',
     kind: 'codebox-task-runner-preflight',
     path: evidencePath,
-    metadata: { recipePath, artifacts, command, args },
+    metadata: { inputPath, artifacts, command, args },
   }] : [];
   return {
     success: false,
     timeout: true,
-    summary: `WP Codebox recipe-run timed out after ${timeoutMs}ms.`,
+    summary: `WP Codebox run-agent-task timed out after ${timeoutMs}ms.`,
     artifacts: artifact,
     evidence_refs: evidencePath ? [{
       kind: 'codebox-task-runner-preflight',
@@ -333,42 +193,42 @@ function timeoutPayload(timeoutMs, artifacts, evidencePath, recipePath, command,
       label: 'WP Codebox task runner preflight evidence',
     }] : [],
     diagnostics: [{
-      class: 'codebox.recipe_run.timeout',
-      message: 'wp-codebox recipe-run exceeded the configured task timeout.',
-      data: { timeout_ms: timeoutMs, recipePath, artifacts },
+      class: 'codebox.run_agent_task.timeout',
+      message: 'wp codebox run-agent-task exceeded the configured task timeout.',
+      data: { timeout_ms: timeoutMs, inputPath, artifacts },
     }],
-    metadata: { timeout_ms: timeoutMs, recipePath, artifacts, command, args },
+    metadata: { timeout_ms: timeoutMs, inputPath, artifacts, command, args },
   };
 }
 
-function runWpCodebox(recipePath, request) {
-  const wpCodeboxBin = argValue('--wp-codebox-bin') || request.wp_codebox_bin || 'wp-codebox';
-  const args = ['recipe-run', '--recipe', recipePath, '--json'];
+function runWpCodeboxParentTask(request) {
   const explicitArtifacts = argValue('--artifacts') || request.artifacts || '';
   const artifacts = explicitArtifacts || fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-artifacts-'));
-  args.push('--artifacts', artifacts);
   if (explicitArtifacts) {
-    const riskyMount = mountEntries().find((mount) => pathInside(mount.source, explicitArtifacts));
+    const riskyMount = mountEntries(request).find((mount) => pathInside(mount.source, explicitArtifacts));
     if (riskyMount) {
       console.error(`Warning: WP Codebox artifact directory is inside mounted source ${riskyMount.source} and may be captured recursively: ${explicitArtifacts}`);
     }
   }
-  if (argValue('--preview-hold')) {
-    args.push('--preview-hold', argValue('--preview-hold'));
+
+  const input = runnerInput(request, artifacts);
+  const inputPath = writeJsonFile('homeboy-wp-codebox-parent-task-', input);
+  const wpCliBin = argValue('--wp-cli-bin') || request.wp_cli_bin || 'wp';
+  const args = ['codebox', 'run-agent-task', '--input-file', inputPath, '--format=json'];
+  const previewHold = argValue('--preview-hold');
+  if (previewHold) {
+    args.push('--preview-hold-seconds', previewHold);
   }
-  if (argValue('--preview-public-url')) {
-    args.push('--preview-public-url', argValue('--preview-public-url'));
+  const previewPublicUrl = argValue('--preview-public-url');
+  if (previewPublicUrl) {
+    args.push('--preview-public-url', previewPublicUrl);
   }
 
-  if (hasFlag('--print-command')) {
-    console.error(JSON.stringify({ command: wpCodeboxBin, args }, null, 2));
-  }
-
-  const resolved = resolveCommand(wpCodeboxBin, args);
+  const resolved = resolveCommand(wpCliBin, args);
   const timeoutMs = requestTimeoutMs(request);
   const evidencePath = writePreflightEvidence(artifacts, {
     schema: 'homeboy/wp-codebox-task-runner-preflight/v1',
-    recipePath,
+    inputPath,
     artifacts,
     command: resolved.command,
     args: resolved.args,
@@ -376,6 +236,11 @@ function runWpCodebox(recipePath, request) {
     task_id: request.orchestrator?.agent_task_id,
     sandbox_session_id: request.sandbox_session_id,
   });
+
+  if (hasFlag('--print-command')) {
+    console.error(JSON.stringify({ command: resolved.command, args: resolved.args, input }, null, 2));
+  }
+
   const result = spawnSync(resolved.command, resolved.args, {
     encoding: 'utf8',
     env: process.env,
@@ -384,7 +249,7 @@ function runWpCodebox(recipePath, request) {
   });
 
   if (result.error && result.error.code === 'ETIMEDOUT') {
-    process.stdout.write(`${JSON.stringify(timeoutPayload(timeoutMs, artifacts, evidencePath, recipePath, resolved.command, resolved.args), null, 2)}\n`);
+    process.stdout.write(`${JSON.stringify(timeoutPayload(timeoutMs, artifacts, evidencePath, inputPath, resolved.command, resolved.args), null, 2)}\n`);
     return 1;
   }
 
@@ -403,21 +268,7 @@ function runWpCodebox(recipePath, request) {
 try {
   const request = readTaskRequest();
   assertRequiredSecretEnvAvailable(request);
-  const options = {
-    agentsApi: requireValue('--agents-api', argValue('--agents-api') || request.agents_api),
-    dataMachine: requireValue('--data-machine', argValue('--data-machine') || request.data_machine),
-    dataMachineCode: requireValue('--data-machine-code', argValue('--data-machine-code') || request.data_machine_code),
-    homeboy: argValue('--homeboy') || request.homeboy,
-    homeboyExtensions: argValue('--homeboy-extensions') || request.homeboy_extensions,
-  };
-  const recipe = recipeForRequest(request, options);
-  const recipePath = writeRecipe(recipe);
-
-  if (hasFlag('--print-recipe')) {
-    console.error(JSON.stringify({ recipePath, recipe }, null, 2));
-  }
-
-  process.exitCode = runWpCodebox(recipePath, request);
+  process.exitCode = runWpCodeboxParentTask(request);
 } catch (error) {
   console.error(error && error.message ? error.message : String(error));
   process.exitCode = 1;

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -191,6 +191,25 @@ assert.equal(outcome.failure_classification, 'provider');
 assert.equal(outcome.artifacts[0].id, 'bundle-1');
 assert.equal(outcome.artifacts[0].path, '/tmp/artifacts');
 
+const upstreamRunnerOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  session: {
+    id: 'sandbox-session-1',
+    artifacts: {
+      bundle_id: 'artifact-bundle-1',
+      preview_url: 'https://preview.example.test/sandbox-session-1',
+    },
+  },
+  artifacts: '/tmp/wp-codebox-artifacts',
+});
+assert.equal(upstreamRunnerOutcome.status, 'succeeded');
+assert.equal(upstreamRunnerOutcome.artifacts[0].kind, 'codebox-artifact-directory');
+assert.equal(upstreamRunnerOutcome.artifacts[0].path, '/tmp/wp-codebox-artifacts');
+assert.equal(upstreamRunnerOutcome.artifacts[1].kind, 'codebox-session-artifacts');
+assert.equal(upstreamRunnerOutcome.evidence_refs[0].uri, 'https://preview.example.test/sandbox-session-1');
+assert.equal(upstreamRunnerOutcome.evidence_refs[1].uri, '/tmp/wp-codebox-artifacts');
+
 const codexOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: true,
   summary: 'Codex task completed.',

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -6,11 +6,6 @@ const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
-function writeJson(filePath, value) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
-}
-
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
@@ -20,23 +15,44 @@ function pathInside(parent, candidate) {
   return relative === '' || (Boolean(relative) && !relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
-function createFixtureWpCodebox(root, mode = 0o755) {
-  const binPath = path.join(root, 'fixture-wp-codebox.js');
+function createFixtureWpCli(root, mode = 0o755) {
+  const binPath = path.join(root, 'fixture-wp-cli.js');
   fs.writeFileSync(binPath, `#!/usr/bin/env node
 'use strict';
 const fs = require('node:fs');
 const path = require('node:path');
-const out = process.env.FIXTURE_WP_CODEBOX_CAPTURE;
-const recipeIndex = process.argv.indexOf('--recipe');
-const recipePath = recipeIndex >= 0 ? process.argv[recipeIndex + 1] : '';
-const recipe = recipePath ? JSON.parse(fs.readFileSync(recipePath, 'utf8')) : null;
-fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), recipe }, null, 2));
+const out = process.env.FIXTURE_WP_CLI_CAPTURE;
+const inputIndex = process.argv.indexOf('--input-file');
+const inputPath = inputIndex >= 0 ? process.argv[inputIndex + 1] : '';
+const input = inputPath ? JSON.parse(fs.readFileSync(inputPath, 'utf8')) : null;
+fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), input }, null, 2));
 process.stdout.write(JSON.stringify({
   success: true,
-  artifacts: {
-    id: 'artifact-bundle-sha256-fixture',
-    directory: path.dirname(out),
+  schema: 'wp-codebox/agent-task-run/v1',
+  session: {
+    schema: 'wp-codebox/sandbox-session/v1',
+    id: input.sandbox_session_id,
+    status: 'completed',
+    artifacts: {
+      bundle_id: 'artifact-bundle-sha256-fixture',
+      preview_url: 'https://preview.example.test/' + input.sandbox_session_id,
+    },
+    orchestrator: input.orchestrator,
   },
+  task: input.parent_request.task.prompt,
+  task_input: {
+    schema: 'wp-codebox/task-input/v1',
+    version: 1,
+    goal: input.parent_request.task.prompt,
+    target: {},
+    allowed_tools: [],
+    expected_artifacts: input.parent_request.task.expected_artifacts || [],
+    policy: input.parent_request.task.policy || {},
+    context: input.parent_request.task.context || {},
+  },
+  artifacts: input.artifacts_path,
+  exit_code: 0,
+  run: { agentResult: { status: 'completed' } },
 }));
 `);
   fs.chmodSync(binPath, mode);
@@ -47,13 +63,9 @@ const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-task-runn
 
 try {
   const capturePath = path.join(root, 'capture.json');
-  const fixtureWpCodebox = createFixtureWpCodebox(root);
+  const fixtureWpCli = createFixtureWpCli(root);
   const providerPluginPath = path.join(root, 'example-provider@feature-branch');
   fs.mkdirSync(providerPluginPath, { recursive: true });
-  fs.writeFileSync(path.join(providerPluginPath, 'provider-main.php'), '<?php\n/**\n * Plugin Name: Example Provider\n */');
-  const codexProviderPluginPath = path.join(root, 'ai-provider-for-openai');
-  fs.mkdirSync(codexProviderPluginPath, { recursive: true });
-  fs.writeFileSync(path.join(codexProviderPluginPath, 'ai-provider-for-openai.php'), '<?php\n/**\n * Plugin Name: AI Provider for OpenAI\n */');
   const request = {
     schema: 'homeboy/wp-codebox-task-request/v1',
     sandbox_session_id: 'homeboy-audit-fixture-session',
@@ -81,6 +93,7 @@ try {
       run_id: 'run-123',
       report_id: 'report-123',
       issue_url: 'https://github.com/Extra-Chill/homeboy-extensions/issues/775',
+      agent_task_id: 'agent-task-123',
     },
     audit_findings: [
       {
@@ -95,13 +108,18 @@ try {
     task: {
       title: 'Fix Homeboy audit batch PHPCS Formatting/Auto Fix!',
       prompt: 'Fix the finding.',
+      expected_artifacts: ['patch'],
+      policy: { kind: 'audit-remediation' },
+      context: { source: 'homeboy-smoke' },
     },
   };
 
   const result = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-cli-bin',
+    fixtureWpCli,
     '--wp-codebox-bin',
-    fixtureWpCodebox,
+    '/bin/wp-codebox',
     '--agents-api',
     '/components/agents-api',
     '--data-machine',
@@ -133,80 +151,43 @@ try {
     input: JSON.stringify(request),
     env: {
       ...process.env,
-      FIXTURE_WP_CODEBOX_CAPTURE: capturePath,
+      FIXTURE_WP_CLI_CAPTURE: capturePath,
       OPENCODE_API_KEY: 'redacted-test-key',
     },
   });
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const output = JSON.parse(result.stdout);
+  assert.equal(output.schema, 'wp-codebox/agent-task-run/v1');
   assert.equal(output.success, true);
 
   const captured = readJson(capturePath);
-  assert.deepEqual(captured.argv.slice(0, 4), ['recipe-run', '--recipe', captured.argv[2], '--json']);
-  assert.equal(captured.argv.includes('--artifacts'), true);
+  assert.deepEqual(captured.argv.slice(0, 4), ['codebox', 'run-agent-task', '--input-file', captured.argv[3]]);
+  assert.equal(captured.argv.includes('--format=json'), true);
 
-  const recipe = captured.recipe;
-  assert.equal(recipe.schema, 'wp-codebox/workspace-recipe/v1');
-  assert.deepEqual(recipe.inputs.workspaces.map((workspace) => workspace.seed.slug), [
-    'agents-api',
-    'homeboy',
-    'homeboy-extensions',
-  ]);
-  assert.deepEqual(recipe.inputs.workspaces[0].seed.excludePaths, [
-    '.git',
-    '.homeboy',
-    '.homeboy-bin',
-    '.homeboy-build',
-    '.datamachine',
-    '.DS_Store',
-    '._*',
-    '.env*',
-    'node_modules',
-    'target',
-    'vendor',
-  ]);
-  assert.deepEqual(recipe.inputs.workspaces.map((workspace) => workspace.mode), [
-    'readwrite',
-    'readwrite',
-    'readwrite',
-  ]);
-  assert.deepEqual(recipe.inputs.secretEnv, ['OPENCODE_API_KEY']);
-  assert.equal(recipe.inputs.mounts[0].source, '/repo/plugin');
-  assert.equal(recipe.runtime.stack.mounts[0].source, '/components/php-ai-client');
-  assert.equal(recipe.runtime.stack.mounts[0].target, '/wordpress/wp-includes/php-ai-client');
-  assert.equal(recipe.runtime.stack.mounts[0].metadata.component, 'php-ai-client');
-  assert.equal(recipe.runtime.stack.mounts[1].source, '/components/wordpress-develop');
-  assert.equal(recipe.runtime.stack.mounts[1].target, '/wordpress');
-  assert.equal(recipe.runtime.stack.mounts[1].metadata.kind, 'homeboy-runtime-stack');
-  assert.equal(recipe.runtime.overlays[0].type, 'bundled-library');
-  assert.equal(recipe.runtime.overlays[0].library, 'php-ai-client');
-  assert.equal(recipe.runtime.overlays[0].source, '/components/php-ai-client');
-  assert.equal(recipe.runtime.overlays[1].type, 'wordpress-scoped-bundle');
-  assert.equal(recipe.runtime.overlays[1].source, '/components/wordpress-scoped-bundle');
-  assert.equal(recipe.inputs.extraPlugins[0].slug, 'agents-api');
-  assert.equal(recipe.inputs.extraPlugins[1].slug, 'data-machine');
-  assert.equal(recipe.inputs.extraPlugins[2].slug, 'data-machine-code');
-  assert.equal(recipe.inputs.extraPlugins[3].slug, 'example-provider');
-  assert.equal(recipe.inputs.extraPlugins[3].pluginFile, 'example-provider/provider-main.php');
-
-  const step = recipe.workflow.steps[0];
-  assert.equal(step.command, 'wp-codebox.agent-sandbox-run');
-  assert.equal(step.args.includes('provider=opencode'), true);
-  assert.equal(step.args.includes('model=opencode-go/kimi-k2.6'), true);
-  assert.equal(step.args.includes('max-turns=80'), true);
-  assert.equal(step.args.includes('timeout-seconds=7200'), true);
-  assert.equal(step.args.includes('provider-plugin-slugs=example-provider'), true);
-  assert.equal(step.args.some((arg) => arg.startsWith('session-id=')), false);
-
-  const taskArg = step.args.find((arg) => arg.startsWith('task='));
-  assert.ok(taskArg);
-  const task = JSON.parse(taskArg.slice('task='.length));
-  assert.equal(task.schema, 'homeboy/wp-codebox-audit-task/v1');
-  assert.equal(task.sandbox_session_id, 'homeboy-audit-fixture-session');
-  assert.equal(task.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/775');
-  assert.equal(task.audit_findings[0].id, 'finding-1');
-  assert.match(task.task.prompt, /`agents-api`, `homeboy`, `homeboy-extensions`/);
+  const input = captured.input;
+  assert.equal(input.parent_request.schema, 'homeboy/wp-codebox-task-request/v1');
+  assert.equal(input.parent_request.orchestrator.issue_url, 'https://github.com/Extra-Chill/homeboy-extensions/issues/775');
+  assert.equal(input.parent_request.audit_findings[0].id, 'finding-1');
+  assert.equal(input.provider, 'opencode');
+  assert.equal(input.model, 'opencode-go/kimi-k2.6');
+  assert.equal(input.max_turns, 80);
+  assert.equal(input.task_timeout_seconds, 7200);
+  assert.equal(input.sandbox_session_id, 'homeboy-audit-fixture-session');
+  assert.equal(input.artifacts_path, path.join(root, 'artifacts'));
+  assert.equal(input.wp_codebox_bin, '/bin/wp-codebox');
+  assert.equal(input.agents_api_path, '/components/agents-api');
+  assert.equal(input.data_machine_path, '/components/data-machine');
+  assert.equal(input.data_machine_code_path, '/components/data-machine-code');
+  assert.deepEqual(input.secret_env, ['OPENCODE_API_KEY']);
+  assert.equal(input.mounts[0].source, '/repo/plugin');
+  assert.equal(input.runtime_stack_mounts[0].source, '/components/php-ai-client');
+  assert.equal(input.runtime_stack_mounts[1].source, '/components/wordpress-develop');
+  assert.equal(input.runtime_stack_mounts[1].metadata.kind, 'homeboy-runtime-stack');
+  assert.equal(input.runtime_overlays[0].type, 'bundled-library');
+  assert.equal(input.runtime_overlays[1].type, 'wordpress-scoped-bundle');
+  assert.equal(input.provider_plugin_paths[0], providerPluginPath);
+  assert(!JSON.stringify(input).includes('redacted-test-key'));
 
   const codexCapturePath = path.join(root, 'capture-codex.json');
   const codexSecretEnv = [
@@ -218,8 +199,8 @@ try {
   ];
   const codexResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
-    '--wp-codebox-bin',
-    fixtureWpCodebox,
+    '--wp-cli-bin',
+    fixtureWpCli,
     '--agents-api',
     '/components/agents-api',
     '--data-machine',
@@ -232,12 +213,12 @@ try {
       ...request,
       provider: 'codex',
       model: 'gpt-5.5',
-      provider_plugin_paths: [codexProviderPluginPath],
+      provider_plugin_paths: ['/components/ai-provider-for-openai'],
       secret_env: codexSecretEnv,
     }),
     env: {
       ...process.env,
-      FIXTURE_WP_CODEBOX_CAPTURE: codexCapturePath,
+      FIXTURE_WP_CLI_CAPTURE: codexCapturePath,
       AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'access-token-value',
       AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'refresh-token-value',
       AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '4102444800',
@@ -246,23 +227,21 @@ try {
     },
   });
   assert.equal(codexResult.status, 0, codexResult.stderr || codexResult.stdout);
-  const codexRecipe = readJson(codexCapturePath).recipe;
-  assert.deepEqual(codexRecipe.inputs.secretEnv, codexSecretEnv);
-  assert.equal(codexRecipe.inputs.extraPlugins[3].slug, 'ai-provider-for-openai');
-  assert.equal(codexRecipe.inputs.extraPlugins[3].pluginFile, 'ai-provider-for-openai/ai-provider-for-openai.php');
-  assert.equal(codexRecipe.workflow.steps[0].args.includes('provider=codex'), true);
-  assert.equal(codexRecipe.workflow.steps[0].args.includes('model=gpt-5.5'), true);
-  assert.equal(codexRecipe.workflow.steps[0].args.includes('provider-plugin-slugs=ai-provider-for-openai'), true);
-  const serializedCodexRecipe = JSON.stringify(codexRecipe);
-  assert(!serializedCodexRecipe.includes('access-token-value'));
-  assert(!serializedCodexRecipe.includes('refresh-token-value'));
-  assert(!serializedCodexRecipe.includes('wp-ai-gateway'));
+  const codexInput = readJson(codexCapturePath).input;
+  assert.deepEqual(codexInput.secret_env, codexSecretEnv);
+  assert.equal(codexInput.provider, 'codex');
+  assert.equal(codexInput.model, 'gpt-5.5');
+  assert.equal(codexInput.provider_plugin_paths[0], '/components/ai-provider-for-openai');
+  const serializedCodexInput = JSON.stringify(codexInput);
+  assert(!serializedCodexInput.includes('access-token-value'));
+  assert(!serializedCodexInput.includes('refresh-token-value'));
+  assert(!serializedCodexInput.includes('wp-ai-gateway'));
 
   const nonExecutableCapturePath = path.join(root, 'capture-non-executable.json');
-  const nonExecutableFixture = createFixtureWpCodebox(root, 0o644);
+  const nonExecutableFixture = createFixtureWpCli(root, 0o644);
   const nonExecutableResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
-    '--wp-codebox-bin',
+    '--wp-cli-bin',
     nonExecutableFixture,
     '--agents-api',
     '/components/agents-api',
@@ -275,16 +254,14 @@ try {
     input: JSON.stringify(request),
     env: {
       ...process.env,
-      FIXTURE_WP_CODEBOX_CAPTURE: nonExecutableCapturePath,
+      FIXTURE_WP_CLI_CAPTURE: nonExecutableCapturePath,
       OPENCODE_API_KEY: 'redacted-test-key',
     },
   });
   assert.equal(nonExecutableResult.status, 0, nonExecutableResult.stderr || nonExecutableResult.stdout);
   const nonExecutableCapture = readJson(nonExecutableCapturePath);
-  assert.equal(nonExecutableCapture.argv[0], 'recipe-run');
-  const defaultArtifactsIndex = nonExecutableCapture.argv.indexOf('--artifacts');
-  assert.notEqual(defaultArtifactsIndex, -1);
-  assert.equal(pathInside(root, nonExecutableCapture.argv[defaultArtifactsIndex + 1]), false);
+  assert.equal(nonExecutableCapture.argv[0], 'codebox');
+  assert.equal(pathInside(root, nonExecutableCapture.input.artifacts_path), false);
 
   const sourceRoot = path.join(root, 'source-plugin');
   fs.mkdirSync(sourceRoot, { recursive: true });
@@ -292,8 +269,8 @@ try {
   const riskyCapturePath = path.join(root, 'capture-risky-artifacts.json');
   const riskyResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
-    '--wp-codebox-bin',
-    fixtureWpCodebox,
+    '--wp-cli-bin',
+    fixtureWpCli,
     '--agents-api',
     '/components/agents-api',
     '--data-machine',
@@ -309,7 +286,7 @@ try {
     input: JSON.stringify(request),
     env: {
       ...process.env,
-      FIXTURE_WP_CODEBOX_CAPTURE: riskyCapturePath,
+      FIXTURE_WP_CLI_CAPTURE: riskyCapturePath,
       OPENCODE_API_KEY: 'redacted-test-key',
     },
   });
@@ -318,8 +295,8 @@ try {
 
   const missingSecretResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
-    '--wp-codebox-bin',
-    fixtureWpCodebox,
+    '--wp-cli-bin',
+    fixtureWpCli,
     '--agents-api',
     '/components/agents-api',
     '--data-machine',
@@ -331,7 +308,7 @@ try {
     input: JSON.stringify(request),
     env: {
       ...process.env,
-      FIXTURE_WP_CODEBOX_CAPTURE: path.join(root, 'capture-missing-secret.json'),
+      FIXTURE_WP_CLI_CAPTURE: path.join(root, 'capture-missing-secret.json'),
       OPENCODE_API_KEY: '',
     },
   });


### PR DESCRIPTION
## Summary
- Replaces Homeboy-owned WP Codebox recipe synthesis with a thin adapter to the upstream `wp codebox run-agent-task` parent runner contract.
- Passes the Homeboy task request through as `parent_request` while preserving provider/model, mounts, runtime stack mounts/overlays, timeout, artifacts, orchestrator metadata, and secret env names without serializing secret values.
- Normalizes upstream `wp-codebox/agent-task-run/v1` results back into `homeboy/agent-task-outcome/v1` artifact and evidence refs.

## Verification
- `npm run test:wp-codebox-task-runner`
- `npm run test:codebox-agent-task-executor`
- `npm run test:codebox-agent-task-matrix`
- `npx eslint lib/codebox-agent-task-executor.js scripts/agent/homeboy-wp-codebox-task-runner.cjs`

Closes #1007 for the agent task runner cleanup lane.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the Homeboy runner adapter to the WP Codebox parent task contract, updated result normalization and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.