### PR TITLE
Delegate WP Codebox apply preflight

### DIFF
--- a/wordpress/lib/wp-codebox-apply-adapter.js
+++ b/wordpress/lib/wp-codebox-apply-adapter.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-const crypto = require('node:crypto');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -11,17 +10,8 @@ const { spawnSync } = require('node:child_process');
 
 const ADAPTER_ID = 'homeboy/wp-codebox-apply-adapter/v1';
 const APPLY_RESULT_SCHEMA = 'homeboy/apply-result/v1';
-const CONTENT_DIGEST_PREFIX = 'wp-codebox/artifact-content/v1\nfiles/changed-files.json\n';
-const CONTENT_DIGEST_SEPARATOR = '\nfiles/patch.diff\n';
+const WP_CODEBOX_PREFLIGHT_SCHEMA = 'wp-codebox/artifact-apply-preflight/v1';
 const PROTECTED_BRANCHES = new Set(['main', 'master', 'trunk', 'develop']);
-
-function sha256(value) {
-  return crypto.createHash('sha256').update(value).digest('hex');
-}
-
-function artifactContentDigest(changedFilesJson, patch) {
-  return sha256(`${CONTENT_DIGEST_PREFIX}${changedFilesJson}${CONTENT_DIGEST_SEPARATOR}${patch}`);
-}
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -54,6 +44,11 @@ function realDirectory(directory, label) {
   return real;
 }
 
+function artifactIdFromBundlePath(bundlePath) {
+  const manifestPath = path.join(realDirectory(bundlePath, 'bundlePath'), 'manifest.json');
+  return readJson(manifestPath).id;
+}
+
 function loadWpCodeboxArtifactBundle(bundlePath) {
   const directory = realDirectory(bundlePath, 'bundlePath');
   const manifestPath = path.join(directory, 'manifest.json');
@@ -61,19 +56,19 @@ function loadWpCodeboxArtifactBundle(bundlePath) {
   const changedFilesPath = path.join(directory, 'files', 'changed-files.json');
   const patchPath = path.join(directory, 'files', 'patch.diff');
   const reviewPath = path.join(directory, 'files', 'review.json');
-
-  const changedFilesJson = fs.readFileSync(changedFilesPath, 'utf8');
-  const patch = fs.readFileSync(patchPath, 'utf8');
+  const manifest = readJson(manifestPath);
+  const review = fs.existsSync(reviewPath) ? readJson(reviewPath) : {};
 
   return {
-    id: readJson(manifestPath).id,
+    id: manifest.id,
     directory,
-    manifest: readJson(manifestPath),
+    manifest,
     metadata: fs.existsSync(metadataPath) ? readJson(metadataPath) : {},
     changed_files: readJson(changedFilesPath),
-    review: fs.existsSync(reviewPath) ? readJson(reviewPath) : {},
-    changedFilesJson,
-    patch,
+    review,
+    patch: fs.readFileSync(patchPath, 'utf8'),
+    content_digest: manifest.contentDigest?.value || review.evidence?.artifactContentDigest || '',
+    patch_sha256: review.evidence?.patchSha256 || '',
     paths: {
       manifest: manifestPath,
       metadata: metadataPath,
@@ -84,10 +79,21 @@ function loadWpCodeboxArtifactBundle(bundlePath) {
   };
 }
 
-function wpCodeboxChangeArtifactFromBundle(bundle, options = {}) {
-  const contentDigest = artifactContentDigest(bundle.changedFilesJson, bundle.patch);
-  const patchSha256 = sha256(bundle.patch);
-  const artifactId = bundle.id || `artifact-bundle-sha256-${contentDigest}`;
+function preflightPayloadFromBundle(bundle, approvedFiles) {
+  return {
+    artifact_id: bundle.id,
+    artifact: bundle,
+    approved_files: approvedFiles,
+    patch: bundle.patch,
+    patch_sha256: bundle.patch_sha256,
+    artifact_content_digest: bundle.content_digest,
+    artifact_verification: { valid: true },
+  };
+}
+
+function wpCodeboxChangeArtifactFromPreflight(payload, options = {}) {
+  const artifact = payload.artifact || {};
+  const artifactId = payload.artifact_id || artifact.id;
 
   return {
     id: artifactId,
@@ -97,40 +103,48 @@ function wpCodeboxChangeArtifactFromBundle(bundle, options = {}) {
       ...(options.runId ? { run_id: options.runId } : {}),
       ...(options.stepId ? { step_id: options.stepId } : {}),
       ...(options.command ? { command: options.command } : {}),
-      ...(bundle.manifest?.createdAt ? { captured_at: bundle.manifest.createdAt } : {}),
+      ...(artifact.manifest?.createdAt ? { captured_at: artifact.manifest.createdAt } : {}),
     },
     title: options.title || `WP Codebox artifact ${artifactId}`,
     summary: options.summary || 'Approved WP Codebox patch artifact.',
-    path: bundle.directory,
-    files: changedFilePaths(bundle.changed_files),
+    path: artifact.directory || artifact.path || '',
+    files: payload.changed_files || changedFilePaths(artifact.changed_files || {}),
     approval_scope: {
       scope: 'artifact',
       artifact_id: artifactId,
     },
     metadata: {
       wp_codebox: {
-        bundle_path: bundle.directory,
-        content_digest: contentDigest,
-        patch_sha256: patchSha256,
-        review: bundle.review,
-        changed_files: bundle.changed_files,
+        bundle_path: artifact.directory || artifact.path || '',
+        content_digest: payload.artifact_content_digest || payload.content_digest,
+        patch_sha256: payload.patch_sha256,
+        review: artifact.review || {},
+        changed_files: artifact.changed_files || {},
       },
     },
   };
 }
 
+function wpCodeboxChangeArtifactFromBundle(bundle, options = {}) {
+  return wpCodeboxChangeArtifactFromPreflight(preflightPayloadFromBundle(bundle, changedFilePaths(bundle.changed_files)), options);
+}
+
 function wpCodeboxApplyRequestFromBundle(options) {
-  const bundle = options.bundle || loadWpCodeboxArtifactBundle(options.bundlePath);
-  const artifact = wpCodeboxChangeArtifactFromBundle(bundle, options);
-  const wpCodeboxMetadata = artifact.metadata.wp_codebox;
-  const approvedFiles = options.approvedFiles || options.approved_files || [];
+  const preflight = normalizeWpCodeboxPreflight(options);
+  const payload = preflight.payload;
+  const artifact = wpCodeboxChangeArtifactFromPreflight(payload, options);
+  const approvedFiles = options.approvedFiles || options.approved_files || payload.approved_files || [];
 
   return {
     id: options.id || `apply-request-${artifact.id}`,
     artifact,
     approval_scope: artifact.approval_scope,
     inputs: {
-      bundlePath: bundle.directory,
+      ...(options.bundlePath ? { bundlePath: realDirectory(options.bundlePath, 'bundlePath') } : {}),
+      ...(options.bundle?.directory ? { bundlePath: realDirectory(options.bundle.directory, 'bundlePath') } : {}),
+      ...(options.artifactsPath ? { artifactsPath: realDirectory(options.artifactsPath, 'artifactsPath') } : {}),
+      ...(payload.artifact_id ? { artifactId: payload.artifact_id } : {}),
+      preflight,
       ...(options.worktreePath ? { worktreePath: options.worktreePath } : {}),
       ...(options.branch ? { branch: options.branch } : {}),
       ...(options.commitMessage ? { commitMessage: options.commitMessage } : {}),
@@ -138,8 +152,8 @@ function wpCodeboxApplyRequestFromBundle(options) {
     },
     policy: {
       approved_files: approvedFiles,
-      content_digest: wpCodeboxMetadata.content_digest,
-      patch_sha256: wpCodeboxMetadata.patch_sha256,
+      content_digest: payload.artifact_content_digest || payload.content_digest,
+      patch_sha256: payload.patch_sha256,
       publish: {
         push: Boolean(options.push),
         open_pull_request: Boolean(options.openPullRequest),
@@ -147,6 +161,82 @@ function wpCodeboxApplyRequestFromBundle(options) {
         ...(options.remote ? { remote: options.remote } : {}),
       },
     },
+  };
+}
+
+function runWpCodeboxApplyPreflight(options) {
+  const bundlePath = options.bundlePath ? realDirectory(options.bundlePath, 'bundlePath') : '';
+  let artifactsPath = '';
+  if (options.artifactsPath) {
+    artifactsPath = realDirectory(options.artifactsPath, 'artifactsPath');
+  } else if (bundlePath) {
+    artifactsPath = path.dirname(bundlePath);
+  }
+  const artifactId = options.artifactId || options.artifact_id || (bundlePath ? artifactIdFromBundlePath(bundlePath) : '');
+  const approvedFiles = options.approvedFiles || options.approved_files || [];
+
+  if (!artifactId || !artifactsPath) {
+    throw new Error('artifactId and artifactsPath are required for WP Codebox apply preflight');
+  }
+  if (!Array.isArray(approvedFiles) || approvedFiles.length === 0) {
+    throw new Error('approvedFiles is required for WP Codebox apply preflight');
+  }
+
+  const wpCommand = options.wpCommand || options.wpCli || process.env.HOMEBOY_WP_CLI || 'wp';
+  const args = [
+    'codebox',
+    'artifacts',
+    'preflight-apply',
+    artifactId,
+    `--artifacts-path=${artifactsPath}`,
+    `--approved-files=${JSON.stringify(approvedFiles)}`,
+    '--format=json',
+  ];
+
+  const output = run(wpCommand, args, { cwd: options.cwd, env: options.env });
+  return JSON.parse(output);
+}
+
+function normalizeWpCodeboxPreflight(input) {
+  if (input.bundle && typeof input.bundle === 'object') {
+    const payload = preflightPayloadFromBundle(input.bundle, input.approvedFiles || input.approved_files || []);
+    verifyWpCodeboxPayload(payload);
+    return {
+      schema: WP_CODEBOX_PREFLIGHT_SCHEMA,
+      payload,
+    };
+  }
+
+  if (input.preflightPath) {
+    return normalizeWpCodeboxPreflight(readJson(input.preflightPath));
+  }
+
+  const preflight = input.preflight || input.applyPreflight || (
+    input.schema === WP_CODEBOX_PREFLIGHT_SCHEMA ? input : null
+  );
+
+  if (preflight) {
+    if (preflight.schema && preflight.schema !== WP_CODEBOX_PREFLIGHT_SCHEMA) {
+      throw new Error(`unsupported WP Codebox preflight schema: ${preflight.schema}`);
+    }
+    const payload = preflight.payload || preflight;
+    verifyWpCodeboxPayload(payload);
+    return {
+      ...preflight,
+      payload,
+    };
+  }
+
+  if (input.payload && typeof input.payload === 'object') {
+    verifyWpCodeboxPayload(input.payload);
+    return {
+      schema: WP_CODEBOX_PREFLIGHT_SCHEMA,
+      payload: input.payload,
+    };
+  }
+
+  return {
+    ...runWpCodeboxApplyPreflight(input),
   };
 }
 
@@ -168,50 +258,27 @@ function normalizePayload(input) {
       inputs: applyRequest.inputs || {},
       policy: applyRequest.policy || {},
     };
-    const wpCodeboxMetadata = artifact.metadata?.wp_codebox || {};
-    const bundlePath = controls.inputs.bundlePath || controls.inputs.bundle_path || wpCodeboxMetadata.bundle_path || artifact.path;
-    const bundle = bundlePath ? loadWpCodeboxArtifactBundle(bundlePath) : null;
-    const changedFilesJson = bundle?.changedFilesJson || JSON.stringify(wpCodeboxMetadata.changed_files || {}, null, 2) + '\n';
-    const patch = artifact.diff || bundle?.patch;
+    const preflight = normalizeWpCodeboxPreflight({
+      ...controls.inputs,
+      artifactId: controls.inputs.artifactId || controls.inputs.artifact_id || artifact.id,
+      approvedFiles: controls.policy.approved_files || controls.inputs.approvedFiles || controls.inputs.approved_files || [],
+    });
+    const payload = preflight.payload;
 
     return {
-      artifact_id: artifact.id,
-      artifact: bundle || {
-        id: artifact.id,
-        changed_files: wpCodeboxMetadata.changed_files || {},
-        changedFilesJson,
-        review: wpCodeboxMetadata.review || {},
-      },
-      approved_files: controls.policy.approved_files || controls.inputs.approvedFiles || controls.inputs.approved_files || [],
-      patch,
-      patch_sha256: controls.policy.patch_sha256 || wpCodeboxMetadata.patch_sha256,
-      artifact_content_digest: controls.policy.content_digest || wpCodeboxMetadata.content_digest,
+      ...payload,
       applyRequest,
       applyInputs: controls.inputs,
       applyPolicy: controls.policy,
     };
   }
 
-  if (input.bundlePath) {
-    const bundle = loadWpCodeboxArtifactBundle(input.bundlePath);
-    return {
-      artifact_id: bundle.id,
-      artifact: bundle,
-      approved_files: input.approvedFiles || input.approved_files || [],
-      patch: bundle.patch,
-      patch_sha256: sha256(bundle.patch),
-      artifact_content_digest: artifactContentDigest(bundle.changedFilesJson, bundle.patch),
-      applyRequest: wpCodeboxApplyRequestFromBundle(input),
-      applyInputs: input,
-      applyPolicy: {},
-    };
-  }
-
-  if (!input.payload || typeof input.payload !== 'object') {
-    throw new Error('payload or bundlePath is required');
-  }
-
-  return input.payload;
+  const preflight = normalizeWpCodeboxPreflight(input);
+  return {
+    ...preflight.payload,
+    applyInputs: input,
+    applyPolicy: {},
+  };
 }
 
 function changedFilePaths(changedFiles) {
@@ -223,38 +290,29 @@ function changedFilePaths(changedFiles) {
 function verifyWpCodeboxPayload(payload) {
   const artifact = payload.artifact || {};
   const changedFiles = artifact.changed_files || {};
-  const changedFilesJson = artifact.changedFilesJson || (
-    artifact.paths?.changed_files && fs.existsSync(artifact.paths.changed_files)
-      ? fs.readFileSync(artifact.paths.changed_files, 'utf8')
-      : JSON.stringify(changedFiles, null, 2) + '\n'
-  );
   const patch = payload.patch || artifact.patch;
   if (typeof patch !== 'string' || patch.trim() === '') {
-    throw new Error('payload.patch must contain the approved canonical patch');
+    throw new Error('WP Codebox preflight payload.patch must contain the approved canonical patch');
   }
 
-  const contentDigest = artifactContentDigest(changedFilesJson, patch);
-  const patchSha256 = sha256(patch);
-  const declaredContentDigest = payload.artifact_content_digest || artifact.content_digest || artifact.manifest?.contentDigest?.value;
-  const declaredPatchSha256 = payload.patch_sha256 || artifact.review?.evidence?.patchSha256;
   const artifactId = payload.artifact_id || artifact.id;
-
-  if (declaredContentDigest && declaredContentDigest !== contentDigest) {
-    throw new Error('artifact content digest mismatch');
+  if (!artifactId) {
+    throw new Error('WP Codebox preflight payload.artifact_id is required');
   }
-  if (declaredPatchSha256 && declaredPatchSha256 !== patchSha256) {
-    throw new Error('patch digest mismatch');
+  const contentDigest = payload.artifact_content_digest || payload.content_digest || artifact.content_digest || artifact.manifest?.contentDigest?.value;
+  if (!contentDigest) {
+    throw new Error('WP Codebox preflight payload.artifact_content_digest is required');
   }
-  if (artifactId && artifactId !== `artifact-bundle-sha256-${contentDigest}`) {
-    throw new Error('artifact id does not match content digest');
+  const patchSha256 = payload.patch_sha256 || artifact.review?.evidence?.patchSha256;
+  if (!patchSha256) {
+    throw new Error('WP Codebox preflight payload.patch_sha256 is required');
   }
 
   const approvedFiles = Array.isArray(payload.approved_files) ? payload.approved_files : [];
-  const changedPaths = changedFilePaths(changedFiles);
-  const missingApproval = changedPaths.filter((filePath) => !approvedFiles.includes(filePath));
-  if (missingApproval.length > 0) {
-    throw new Error(`adapter requires approval for every changed file: ${missingApproval.join(', ')}`);
+  if (approvedFiles.length === 0) {
+    throw new Error('WP Codebox preflight payload.approved_files must contain at least one file');
   }
+  const changedPaths = changedFilePaths(changedFiles);
 
   return {
     artifactId,
@@ -340,7 +398,7 @@ function applyApprovedWpCodeboxArtifact(input) {
     prUrl = run('gh', args, { cwd: worktreePath });
   }
 
-  const resultArtifact = payload.applyRequest?.artifact || wpCodeboxChangeArtifactFromBundle(payload.artifact, {
+  const resultArtifact = payload.applyRequest?.artifact || wpCodeboxChangeArtifactFromPreflight(payload, {
     title: `Applied WP Codebox artifact ${verified.artifactId}`,
   });
 
@@ -399,10 +457,12 @@ function applyApprovedWpCodeboxArtifact(input) {
 module.exports = {
   ADAPTER_ID,
   APPLY_RESULT_SCHEMA,
-  artifactContentDigest,
   applyApprovedWpCodeboxArtifact,
   loadWpCodeboxArtifactBundle,
+  normalizeWpCodeboxPreflight,
+  runWpCodeboxApplyPreflight,
   verifyWpCodeboxPayload,
   wpCodeboxApplyRequestFromBundle,
   wpCodeboxChangeArtifactFromBundle,
+  wpCodeboxChangeArtifactFromPreflight,
 };

--- a/wordpress/scripts/agent/wp-codebox-apply-adapter.cjs
+++ b/wordpress/scripts/agent/wp-codebox-apply-adapter.cjs
@@ -21,16 +21,18 @@ function hasArg(name) {
 }
 
 function usage() {
-  console.error('Usage: wp-codebox-apply-adapter.cjs (--bundle <artifact-dir> --approved-file <sandbox-path> | --request <apply-request.json>) --worktree <path> [--branch <branch>] [--patch-strip <n>] [--push] [--open-pr]');
+  console.error('Usage: wp-codebox-apply-adapter.cjs (--preflight <preflight.json> | --bundle <artifact-dir> --approved-file <sandbox-path> | --request <apply-request.json>) --worktree <path> [--wp-cli <wp>] [--branch <branch>] [--patch-strip <n>] [--push] [--open-pr]');
   process.exit(1);
 }
 
 const requestPath = argValue('--request');
+const preflightPath = argValue('--preflight');
 const bundlePath = argValue('--bundle');
 const worktreePath = argValue('--worktree');
 const branch = argValue('--branch');
 const commitMessage = argValue('--commit-message');
 const patchStripValue = argValue('--patch-strip');
+const wpCli = argValue('--wp-cli');
 const approvedFiles = [];
 
 for (let index = 0; index < process.argv.length; index += 1) {
@@ -39,19 +41,22 @@ for (let index = 0; index < process.argv.length; index += 1) {
   }
 }
 
-if (!worktreePath || (!requestPath && (!bundlePath || approvedFiles.length === 0))) {
+if (!worktreePath || (!requestPath && !preflightPath && (!bundlePath || approvedFiles.length === 0))) {
   usage();
 }
 
 try {
   const applyRequest = requestPath ? JSON.parse(fs.readFileSync(requestPath, 'utf8')) : undefined;
+  const preflight = preflightPath ? JSON.parse(fs.readFileSync(preflightPath, 'utf8')) : undefined;
   const result = applyApprovedWpCodeboxArtifact({
     applyRequest,
+    preflight,
     bundlePath,
     worktreePath,
     branch,
     commitMessage,
     approvedFiles,
+    wpCli,
     patchStrip: patchStripValue ? Number(patchStripValue) : undefined,
     push: hasArg('--push'),
     openPullRequest: hasArg('--open-pr'),

--- a/wordpress/tests/audit-wp-codebox-fanout-smoke.js
+++ b/wordpress/tests/audit-wp-codebox-fanout-smoke.js
@@ -15,8 +15,6 @@ const {
   taskOutcome,
   taskOutcomeSucceeded,
 } = require('../lib/audit-wp-codebox-fanout');
-const { artifactContentDigest } = require('../lib/wp-codebox-apply-adapter');
-
 function sha256(value) {
   return crypto.createHash('sha256').update(value).digest('hex');
 }
@@ -74,7 +72,6 @@ function createBundle(root, name, changedPath, relativePath) {
       },
     ],
   };
-  const changedFilesJson = `${JSON.stringify(changedFiles, null, 2)}\n`;
   const patch = [
     `diff --git a/wordpress/wp-content/plugins/fixture-plugin/${relativePath} b/wordpress/wp-content/plugins/fixture-plugin/${relativePath}`,
     `--- a/wordpress/wp-content/plugins/fixture-plugin/${relativePath}`,
@@ -84,7 +81,7 @@ function createBundle(root, name, changedPath, relativePath) {
     '+after',
     '',
   ].join('\n');
-  const contentDigest = artifactContentDigest(changedFilesJson, patch);
+  const contentDigest = sha256(`fixture-artifact:${name}:${changedPath}:${relativePath}`);
   const artifactId = `artifact-bundle-sha256-${contentDigest}`;
   const contentDigestMetadata = {
     algorithm: 'sha256',

--- a/wordpress/tests/wp-codebox-apply-adapter-smoke.js
+++ b/wordpress/tests/wp-codebox-apply-adapter-smoke.js
@@ -8,7 +8,6 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const {
   applyApprovedWpCodeboxArtifact,
-  artifactContentDigest,
   verifyWpCodeboxPayload,
   wpCodeboxApplyRequestFromBundle,
 } = require('../lib/wp-codebox-apply-adapter');
@@ -65,7 +64,7 @@ function createBundle(root) {
     '+after',
     '',
   ].join('\n');
-  const contentDigest = artifactContentDigest(changedFilesJson, patch);
+  const contentDigest = 'fixture-content-digest';
   const artifactId = `artifact-bundle-sha256-${contentDigest}`;
   const contentDigestMetadata = {
     algorithm: 'sha256',
@@ -104,20 +103,51 @@ function createBundle(root) {
   return { artifactId, bundle, contentDigest, patch };
 }
 
+function createPreflight(fixture, changedFiles) {
+  const patchSha256 = sha256(fixture.patch);
+  return {
+    success: true,
+    schema: 'wp-codebox/artifact-apply-preflight/v1',
+    artifact_id: fixture.artifactId,
+    approved_files: ['/wordpress/wp-content/plugins/fixture-plugin/readme.txt'],
+    changed_files: ['/wordpress/wp-content/plugins/fixture-plugin/readme.txt'],
+    patch_sha256: patchSha256,
+    content_digest: fixture.contentDigest,
+    payload: {
+      artifact_id: fixture.artifactId,
+      artifact: {
+        id: fixture.artifactId,
+        changed_files: changedFiles,
+        review: {
+          evidence: {
+            patchSha256,
+            artifactContentDigest: fixture.contentDigest,
+          },
+        },
+      },
+      approved_files: ['/wordpress/wp-content/plugins/fixture-plugin/readme.txt'],
+      patch: fixture.patch,
+      patch_sha256: patchSha256,
+      artifact_content_digest: fixture.contentDigest,
+      artifact_verification: { valid: true },
+    },
+  };
+}
+
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wp-codebox-apply-adapter-'));
 
 try {
   const fixture = createBundle(root);
   const changedFilesJson = fs.readFileSync(path.join(fixture.bundle, 'files', 'changed-files.json'), 'utf8');
   const changedFiles = JSON.parse(changedFilesJson);
+  const preflight = createPreflight(fixture, changedFiles);
   const repo = createRepo(root, 'feature/apply-smoke');
 
   const result = applyApprovedWpCodeboxArtifact({
-    bundlePath: fixture.bundle,
+    preflight,
     worktreePath: repo,
     branch: 'feature/wp-codebox-apply-smoke',
     commitMessage: 'Apply fixture wp-codebox artifact',
-    approvedFiles: ['/wordpress/wp-content/plugins/fixture-plugin/readme.txt'],
     patchStrip: 5,
   });
 
@@ -139,17 +169,7 @@ try {
   assert.equal(run('git', ['status', '--porcelain'], { cwd: repo }), '');
 
   assert.equal(
-    verifyWpCodeboxPayload({
-      artifact_id: fixture.artifactId,
-      artifact: {
-        changed_files: changedFiles,
-        paths: { changed_files: path.join(fixture.bundle, 'files', 'changed-files.json') },
-      },
-      approved_files: ['/wordpress/wp-content/plugins/fixture-plugin/readme.txt'],
-      patch: fixture.patch,
-      patch_sha256: sha256(fixture.patch),
-      artifact_content_digest: fixture.contentDigest,
-    }).contentDigest,
+    verifyWpCodeboxPayload(preflight.payload).contentDigest,
     fixture.contentDigest
   );
 
@@ -158,21 +178,22 @@ try {
       artifact_id: fixture.artifactId,
       artifact: {
         changed_files: changedFiles,
-        changedFilesJson,
       },
       approved_files: [],
       patch: fixture.patch,
       patch_sha256: sha256(fixture.patch),
-      artifact_content_digest: fixture.contentDigest,
     }),
-    /approval for every changed file/
+    /artifact_content_digest is required/
   );
+
+  const preflightPath = path.join(root, 'preflight.json');
+  writeJson(preflightPath, preflight);
 
   const cliRepo = createRepo(root, 'feature/apply-cli-smoke');
   const cliOutput = run(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'wp-codebox-apply-adapter.cjs'),
-    '--bundle',
-    fixture.bundle,
+    '--preflight',
+    preflightPath,
     '--worktree',
     cliRepo,
     '--branch',
@@ -193,11 +214,10 @@ try {
 
   const requestRepo = createRepo(root, 'feature/apply-request-smoke');
   const request = wpCodeboxApplyRequestFromBundle({
-    bundlePath: fixture.bundle,
+    preflight,
     worktreePath: requestRepo,
     branch: 'feature/wp-codebox-apply-request-smoke',
     commitMessage: 'Apply fixture wp-codebox artifact through ApplyRequest',
-    approvedFiles: ['/wordpress/wp-content/plugins/fixture-plugin/readme.txt'],
     patchStrip: 5,
   });
   const requestResult = applyApprovedWpCodeboxArtifact({ applyRequest: request });
@@ -208,10 +228,9 @@ try {
 
   const requestPath = path.join(root, 'apply-request.json');
   writeJson(requestPath, wpCodeboxApplyRequestFromBundle({
-    bundlePath: fixture.bundle,
+    preflight,
     branch: 'feature/wp-codebox-apply-request-cli-smoke',
     commitMessage: 'Apply fixture wp-codebox artifact through ApplyRequest CLI',
-    approvedFiles: ['/wordpress/wp-content/plugins/fixture-plugin/readme.txt'],
     patchStrip: 5,
   }));
   const requestCliRepo = createRepo(root, 'feature/apply-request-cli-smoke');
@@ -227,6 +246,31 @@ try {
   assert.equal(requestCliResult.request_id, `apply-request-${fixture.artifactId}`);
   assert.deepEqual(requestCliResult.files_changed, ['readme.txt']);
   assert.equal(fs.readFileSync(path.join(requestCliRepo, 'readme.txt'), 'utf8'), 'after\n');
+
+  const fakeWpCli = path.join(root, 'fake-wp-cli.cjs');
+  const fakeWpCliCapture = path.join(root, 'fake-wp-cli-capture.json');
+  fs.writeFileSync(fakeWpCli, [
+    '#!/usr/bin/env node',
+    "const fs = require('node:fs');",
+    `fs.writeFileSync(${JSON.stringify(fakeWpCliCapture)}, JSON.stringify(process.argv.slice(2), null, 2));`,
+    `process.stdout.write(${JSON.stringify(JSON.stringify(preflight))});`,
+    '',
+  ].join('\n'));
+  fs.chmodSync(fakeWpCli, 0o755);
+  const delegatedRepo = createRepo(root, 'feature/apply-delegated-preflight-smoke');
+  const delegatedResult = applyApprovedWpCodeboxArtifact({
+    bundlePath: fixture.bundle,
+    worktreePath: delegatedRepo,
+    branch: 'feature/wp-codebox-delegated-preflight-smoke',
+    commitMessage: 'Apply fixture wp-codebox artifact through delegated preflight',
+    approvedFiles: ['/wordpress/wp-content/plugins/fixture-plugin/readme.txt'],
+    wpCli: fakeWpCli,
+    patchStrip: 5,
+  });
+  assert.equal(delegatedResult.status, 'applied');
+  const delegatedArgs = JSON.parse(fs.readFileSync(fakeWpCliCapture, 'utf8'));
+  assert.deepEqual(delegatedArgs.slice(0, 4), ['codebox', 'artifacts', 'preflight-apply', fixture.artifactId]);
+  assert.equal(delegatedArgs.some((arg) => arg.startsWith('--approved-files=')), true);
 
   console.log('WP Codebox apply adapter smoke passed');
 } finally {


### PR DESCRIPTION
## Summary
- Delegates WP Codebox artifact verification and preflight to `wp codebox artifacts preflight-apply` / `wp-codebox/artifact-apply-preflight/v1` instead of recomputing bundle digests in Homeboy.
- Keeps Homeboy responsible for parent-side git/apply policy, branch safety, commits, publish controls, and the existing `homeboy/apply-result/v1` response shape.
- Updates the apply adapter CLI and smoke coverage to exercise preflight JSON and delegated WP-CLI preflight flows.

## Testing
- `npm run test:wp-codebox-apply-adapter`
- `npm run test:audit-wp-codebox-fanout`
- `npx eslint lib/wp-codebox-apply-adapter.js scripts/agent/wp-codebox-apply-adapter.cjs tests/wp-codebox-apply-adapter-smoke.js tests/audit-wp-codebox-fanout-smoke.js` (0 errors; existing console/ignored-test warnings only)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspecting the upstream WP Codebox preflight contract, drafting the Homeboy adapter changes and smoke coverage, and running targeted verification; Chris remains responsible for review and merge.