### PR TITLE
Build WordPress PHPUnit recipes via WP Codebox

### DIFF
--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -74,6 +74,45 @@ printf 'ARGS=%s\n' "$*"
 if [ -n "${WP_CODEBOX_ARGS_FILE:-}" ]; then
     printf '%s\n' "$@" > "${WP_CODEBOX_ARGS_FILE}"
 fi
+if [ "${1:-}" = "recipe" ] && [ "${2:-}" = "build" ] && [ "${3:-}" = "phpunit" ]; then
+    options_path=""
+    output_path=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --options)
+                shift
+                options_path="${1:-}"
+                ;;
+            --output)
+                shift
+                output_path="${1:-}"
+                ;;
+        esac
+        shift || true
+    done
+    node - "$options_path" "$output_path" <<'NODE'
+const fs = require('node:fs')
+const options = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))
+const recipe = {
+  schema: 'wp-codebox/workspace-recipe/v1',
+  runtime: { wp: options.wordpressVersion, blueprint: { steps: [] } },
+  inputs: { mounts: options.mounts || [] },
+  workflow: { steps: [{ command: 'wordpress.phpunit', args: [
+    `plugin-slug=${options.pluginSlug}`,
+    `test-file=${options.selectedTestFile || ''}`,
+    `changed-tests-json=${JSON.stringify(options.changedTestFiles || [])}`,
+    `env-json=${JSON.stringify(options.env || {})}`,
+    `wp-config-defines-json=${JSON.stringify(options.wpConfigDefines || {})}`,
+    `autoload-file=${options.autoloadFile}`,
+    `tests-dir=${options.testsDir}`,
+    `dependency-mounts=${(options.dependencyMounts || []).filter(Boolean).join(',')}`,
+    `multisite=${options.multisite ? '1' : '0'}`,
+  ] }] },
+}
+fs.writeFileSync(process.argv[3], `${JSON.stringify(recipe, null, 2)}\n`)
+NODE
+    exit 0
+fi
 component_path=""
 recipe_path=""
 while [ "$#" -gt 0 ]; do
@@ -106,6 +145,7 @@ fi
 printf '{"success":true,"executions":[{"stdout":"OK (1 test, 1 assertion)\n","stderr":""}]}\n'
 SH
 chmod +x "${TMPDIR}/stubs/wp-codebox.sh"
+
 
 cat > "${TMPDIR}/stubs/composer" <<'SH'
 #!/usr/bin/env bash

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -396,6 +396,7 @@ fi
 WP_CODEBOX_TMPFILE=$(mktemp)
 PHPUNIT_STDOUT_TMPFILE=$(mktemp)
 RECIPE_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-test-recipe.XXXXXX")
+RECIPE_OPTIONS_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-test-recipe-options.XXXXXX")
 wp_codebox_command=("$WP_CODEBOX_BIN")
 case "$WP_CODEBOX_BIN" in
     *.js)
@@ -408,27 +409,26 @@ jq -n \
     --argjson mounts "$MOUNTS_JSON" \
     --arg pluginSlug "$PLUGIN_SLUG" \
     --arg selectedTestFile "$SELECTED_TEST_FILE_REL" \
-    --arg changedTestsJson "$CHANGED_TEST_FILES_JSON" \
-    --arg envJson "$BENCH_ENV_JSON" \
-    --arg definesJson "$WP_CONFIG_DEFINES_JSON" \
+    --argjson changedTests "$CHANGED_TEST_FILES_JSON" \
+    --argjson env "$BENCH_ENV_JSON" \
+    --argjson defines "$WP_CONFIG_DEFINES_JSON" \
     --arg dependencyMounts "$WP_CODEBOX_DEP_MOUNTS" \
     --arg multisite "$WP_CODEBOX_MULTISITE" \
     '{
-        schema: "wp-codebox/workspace-recipe/v1",
-        runtime: {wp: $wp, blueprint: {steps: []}},
-        inputs: {mounts: $mounts},
-        workflow: {steps: [{command: "wordpress.phpunit", args: [
-            "plugin-slug=" + $pluginSlug,
-            "test-file=" + $selectedTestFile,
-            "changed-tests-json=" + $changedTestsJson,
-            "env-json=" + $envJson,
-            "wp-config-defines-json=" + $definesJson,
-            "autoload-file=/wp-codebox-vendor/autoload.php",
-            "tests-dir=/wp-codebox-vendor/wp-phpunit/wp-phpunit",
-            "dependency-mounts=" + ($dependencyMounts | split("\n") | map(select(. != "")) | join(",")),
-            "multisite=" + (if (($multisite | ascii_downcase) as $v | $v == "1" or $v == "true" or $v == "yes" or $v == "on") then "1" else "0" end)
-        ]}]}
-    }' > "$RECIPE_FILE"
+        wordpressVersion: $wp,
+        mounts: $mounts,
+        pluginSlug: $pluginSlug,
+        selectedTestFile: $selectedTestFile,
+        changedTestFiles: $changedTests,
+        env: $env,
+        wpConfigDefines: $defines,
+        autoloadFile: "/wp-codebox-vendor/autoload.php",
+        testsDir: "/wp-codebox-vendor/wp-phpunit/wp-phpunit",
+        dependencyMounts: ($dependencyMounts | split("\n") | map(select(. != ""))),
+        multisite: (if (($multisite | ascii_downcase) as $v | $v == "1" or $v == "true" or $v == "yes" or $v == "on") then true else false end)
+    }' > "$RECIPE_OPTIONS_FILE"
+
+"${wp_codebox_command[@]}" recipe build phpunit --options "$RECIPE_OPTIONS_FILE" --output "$RECIPE_FILE"
 
 set +e
 "${wp_codebox_command[@]}" recipe-run \
@@ -439,7 +439,7 @@ set +e
 wp_codebox_exit=$?
 set -e
 
-rm -f "$RECIPE_FILE"
+rm -f "$RECIPE_FILE" "$RECIPE_OPTIONS_FILE"
 
 WP_CODEBOX_OUTPUT=$(cat "$WP_CODEBOX_TMPFILE")
 PHPUNIT_OUTPUT=""

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -35,6 +35,33 @@ const path = require('node:path')
 const args = process.argv.slice(2)
 fs.writeFileSync(process.env.FAKE_WP_CODEBOX_ARGS_FILE, `${args.join('\n')}\n`)
 
+if (args[0] === 'recipe' && args[1] === 'build' && args[2] === 'phpunit') {
+  const options = JSON.parse(fs.readFileSync(argValue('--options'), 'utf8'))
+  const recipe = {
+    schema: 'wp-codebox/workspace-recipe/v1',
+    runtime: { wp: options.wordpressVersion, blueprint: { steps: [] } },
+    inputs: { mounts: options.mounts || [] },
+    workflow: {
+      steps: [{
+        command: 'wordpress.phpunit',
+        args: [
+          `plugin-slug=${options.pluginSlug}`,
+          `test-file=${options.selectedTestFile || ''}`,
+          `changed-tests-json=${JSON.stringify(options.changedTestFiles || [])}`,
+          `env-json=${JSON.stringify(options.env || {})}`,
+          `wp-config-defines-json=${JSON.stringify(options.wpConfigDefines || {})}`,
+          `autoload-file=${options.autoloadFile}`,
+          `tests-dir=${options.testsDir}`,
+          `dependency-mounts=${(options.dependencyMounts || []).filter(Boolean).join(',')}`,
+          `multisite=${options.multisite ? '1' : '0'}`,
+        ],
+      }],
+    },
+  }
+  fs.writeFileSync(argValue('--output'), `${JSON.stringify(recipe, null, 2)}\n`)
+  process.exit(0)
+}
+
 function requirePair(name, value) {
   for (let index = 0; index < args.length - 1; index += 1) {
     if (args[index] === name && args[index + 1] === value) {
@@ -128,6 +155,7 @@ process.stdout.write(JSON.stringify({
 }) + '\n')
 NODE
 chmod +x "$FAKE_WP_CODEBOX"
+
 
 SETTINGS_JSON=$(jq -nc \
     --argjson wpConfig '{"WP_DEBUG":true,"CUSTOM_NUMBER":7}' \


### PR DESCRIPTION
## Summary
- Replaces Homeboy's hand-built `wordpress.phpunit` workspace recipe JSON with a `wp-codebox recipe build phpunit` call.
- Keeps Homeboy-owned mount discovery, file routing, no-test handling, artifacts, and sidecar parsing behavior unchanged.
- Updates the WP Codebox smokes to cover the new build-then-run CLI flow.

## Upstream dependency
- Depends on chubes4/wp-codebox#492 for the `wp-codebox recipe build phpunit` CLI wrapper around `buildWordPressPhpunitRecipe()`.

## Verification
- `bash wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- Targeted WP Codebox-backed PHPUnit fixture: `dropin-coexistence` `tests/DropInCoexistenceTest.php`, using the built CLI from chubes4/wp-codebox#492. Result: `OK (3 tests, 8 assertions)`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the runner changes, smoke updates, verification runs, and PR description. Chris remains responsible for review and merge.