### PR TITLE
fix: configure WordPress bench PHP memory

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -402,6 +402,17 @@ if [ "$settings_json" != "{}" ]; then
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_WORDPRESS_VERSION="$extracted"
 fi
 
+WP_CODEBOX_PHP_MEMORY_LIMIT="${HOMEBOY_WP_CODEBOX_PHP_MEMORY_LIMIT:-}"
+if [ -z "$WP_CODEBOX_PHP_MEMORY_LIMIT" ] && [ "$settings_json" != "{}" ]; then
+    extracted=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_php_memory_limit // .wp_codebox_memory_limit // empty' 2>/dev/null || true)
+    [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_PHP_MEMORY_LIMIT="$extracted"
+fi
+if [ -n "$WP_CODEBOX_PHP_MEMORY_LIMIT" ] && ! printf '%s' "$WP_CODEBOX_PHP_MEMORY_LIMIT" | grep -Eq '^[0-9]+[KMG]?$'; then
+    echo "Error: wp_codebox_php_memory_limit must be a PHP shorthand size such as 512M." >&2
+    FAILED_STEP="WP Codebox PHP memory budget setup"
+    exit 1
+fi
+
 ITERATIONS="${HOMEBOY_BENCH_ITERATIONS:-3}"
 WARMUP_ITERATIONS="${HOMEBOY_BENCH_WARMUP_ITERATIONS:-}"
 if [ -z "$WARMUP_ITERATIONS" ] && [ "$settings_json" != "{}" ]; then
@@ -571,6 +582,78 @@ RUNTIME_BLUEPRINT_JSON=$(jq -nc \
     ($base + $scenario) as $merged |
     $merged + {steps: ($merged.steps // [])}
 ')
+WP_CODEBOX_PLUGIN_RUNTIME_JSON="{}"
+if [ -n "$WP_CODEBOX_PHP_MEMORY_LIMIT" ]; then
+    WP_CODEBOX_PLUGIN_RUNTIME_JSON=$(jq -nc --arg memoryLimit "$WP_CODEBOX_PHP_MEMORY_LIMIT" '{php: {memoryLimit: $memoryLimit}}')
+fi
+
+homeboy_wp_codebox_emit_memory_fatal_diagnostic() {
+    local output_file="$1"
+    local exit_code="$2"
+    local fatal_line="$3"
+    local diagnostics_file="${ARTIFACTS_DIR}/wp-codebox-bench-diagnostics.json"
+    local output_artifact="${ARTIFACTS_DIR}/wp-codebox-output.txt"
+    local exit_artifact="${ARTIFACTS_DIR}/wp-codebox-exit-code.txt"
+    local allowed_bytes=""
+    local attempted_bytes=""
+    local failing_file=""
+    local failing_line=""
+
+    mkdir -p "$ARTIFACTS_DIR"
+    cp "$output_file" "$output_artifact"
+    printf '%s\n' "$exit_code" > "$exit_artifact"
+
+    allowed_bytes=$(printf '%s\n' "$fatal_line" | sed -E 's/.*Allowed memory size of ([0-9]+) bytes exhausted.*/\1/' || true)
+    attempted_bytes=$(printf '%s\n' "$fatal_line" | sed -E 's/.*tried to allocate ([0-9]+) bytes.*/\1/' || true)
+    failing_file=$(printf '%s\n' "$fatal_line" | sed -E 's/.* in ([^ ]+) on line [0-9]+.*/\1/' || true)
+    failing_line=$(printf '%s\n' "$fatal_line" | sed -E 's/.* on line ([0-9]+).*/\1/' || true)
+    [ "$allowed_bytes" != "$fatal_line" ] || allowed_bytes=""
+    [ "$attempted_bytes" != "$fatal_line" ] || attempted_bytes=""
+    [ "$failing_file" != "$fatal_line" ] || failing_file=""
+    [ "$failing_line" != "$fatal_line" ] || failing_line=""
+
+    jq -n \
+        --arg schema "homeboy/wordpress-bench-diagnostic/v1" \
+        --arg code "wp-codebox-php-memory-exhausted" \
+        --arg message "WP Codebox wordpress.bench exhausted PHP memory before producing structured bench output." \
+        --argjson exitCode "$exit_code" \
+        --arg configuredMemoryLimit "$WP_CODEBOX_PHP_MEMORY_LIMIT" \
+        --arg allowedBytes "$allowed_bytes" \
+        --arg attemptedBytes "$attempted_bytes" \
+        --arg failingFile "$failing_file" \
+        --arg failingLine "$failing_line" \
+        --arg artifactsDir "$ARTIFACTS_DIR" \
+        --arg outputArtifact "$output_artifact" \
+        --arg exitArtifact "$exit_artifact" \
+        '{
+            schema: $schema,
+            diagnostics: [{
+                code: $code,
+                severity: "error",
+                message: $message,
+                exit_code: $exitCode,
+                php_memory_limit: (if $configuredMemoryLimit == "" then null else $configuredMemoryLimit end),
+                allowed_bytes: (if $allowedBytes == "" then null else ($allowedBytes | tonumber) end),
+                attempted_allocation_bytes: (if $attemptedBytes == "" then null else ($attemptedBytes | tonumber) end),
+                failing_file: (if $failingFile == "" then null else $failingFile end),
+                failing_line: (if $failingLine == "" then null else ($failingLine | tonumber) end),
+                artifacts: {
+                    directory: $artifactsDir,
+                    output: $outputArtifact,
+                    exit_code: $exitArtifact
+                }
+            }]
+        }' > "$diagnostics_file"
+
+    echo "WP Codebox wordpress.bench exhausted PHP memory before producing structured output." >&2
+    [ -z "$WP_CODEBOX_PHP_MEMORY_LIMIT" ] || echo "  Configured PHP memory limit: $WP_CODEBOX_PHP_MEMORY_LIMIT" >&2
+    [ -z "$allowed_bytes" ] || echo "  Allowed bytes: $allowed_bytes" >&2
+    [ -z "$failing_file" ] || echo "  Failing file: $failing_file" >&2
+    [ -z "$failing_line" ] || echo "  Failing line: $failing_line" >&2
+    echo "  Exit code: $exit_code" >&2
+    echo "  Diagnostics: $diagnostics_file" >&2
+    echo "  Raw output: $output_artifact" >&2
+}
 
 RECIPE_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-bench-recipe.XXXXXX")
 jq -n \
@@ -588,6 +671,7 @@ jq -n \
     --argjson dependencySlugs "$(printf '%s\n' "$DEPENDENCY_SLUGS_CSV" | jq -R 'split(",") | map(select(. != ""))')" \
     --argjson bootstrapFiles "$WP_CODEBOX_BOOTSTRAP_FILES_JSON" \
     --argjson workloads "$WP_CODEBOX_WORKLOADS_JSON" \
+    --argjson pluginRuntime "$WP_CODEBOX_PLUGIN_RUNTIME_JSON" \
     '{
         wpCodeboxBin: $wpCodeboxBin,
         options: {
@@ -602,6 +686,7 @@ jq -n \
             dependencySlugs: $dependencySlugs,
             env: $env,
             wpConfigDefines: $wpConfigDefines,
+            pluginRuntime: $pluginRuntime,
             bootstrapFiles: $bootstrapFiles,
             workloads: $workloads
         }
@@ -619,6 +704,9 @@ set -e
 
 if [ $wp_codebox_exit -ne 0 ]; then
     cat "$WP_CODEBOX_TMPFILE" >&2
+    if fatal_line=$(grep -E '^(PHP Fatal error: |Fatal error: )?Allowed memory size of [0-9]+ bytes exhausted|^(PHP Fatal error: |Fatal error: ).*Allowed memory size of [0-9]+ bytes exhausted' "$WP_CODEBOX_TMPFILE" | head -1); then
+        homeboy_wp_codebox_emit_memory_fatal_diagnostic "$WP_CODEBOX_TMPFILE" "$wp_codebox_exit" "$fatal_line"
+    fi
     FAILED_STEP="WP Codebox bench run"
     exit $wp_codebox_exit
 fi

--- a/wordpress/scripts/bench/build-wp-codebox-bench-recipe.mjs
+++ b/wordpress/scripts/bench/build-wp-codebox-bench-recipe.mjs
@@ -11,7 +11,13 @@ if (typeof buildWordPressBenchRecipe !== 'function') {
 	throw new Error('WP Codebox core does not export buildWordPressBenchRecipe(). Update wp-codebox after chubes4/wp-codebox#487.');
 }
 
-process.stdout.write(`${JSON.stringify(buildWordPressBenchRecipe(input.options), null, 2)}\n`);
+const recipe = buildWordPressBenchRecipe(input.options);
+if (input.options?.pluginRuntime && typeof input.options.pluginRuntime === 'object' && !Array.isArray(input.options.pluginRuntime)) {
+	recipe.inputs = recipe.inputs ?? {};
+	recipe.inputs.pluginRuntime = input.options.pluginRuntime;
+}
+
+process.stdout.write(`${JSON.stringify(recipe, null, 2)}\n`);
 
 async function loadWpCodeboxCore(wpCodeboxBin) {
 	const candidates = [];

--- a/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PLUGIN_PATH="${TMPDIR}/component"
+FAKE_WP_CODEBOX="${TMPDIR}/wp-codebox.js"
+FAKE_CORE_MODULE="${TMPDIR}/wp-codebox-core.mjs"
+FAKE_PREFLIGHT="${TMPDIR}/bash-preflight.sh"
+FAKE_BENCH_HELPER="${TMPDIR}/bench-helper.sh"
+CAPTURED_RECIPE="${TMPDIR}/captured-recipe.json"
+RESULTS_FILE="${TMPDIR}/bench-results.json"
+ARTIFACTS_DIR="${TMPDIR}/artifacts"
+
+mkdir -p "${PLUGIN_PATH}/tests/bench"
+printf '<?php\nreturn array( "metrics" => array( "noop" => 1 ) );\n' > "${PLUGIN_PATH}/tests/bench/noop.php"
+cat > "$FAKE_PREFLIGHT" <<'SH'
+homeboy_require_bash_version() { :; }
+SH
+cat > "$FAKE_BENCH_HELPER" <<'SH'
+homeboy_write_empty_bench_results() { :; }
+SH
+
+cat > "$FAKE_CORE_MODULE" <<'NODE'
+export function buildWordPressBenchRecipe(options) {
+  return {
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: { wp: options.wordpressVersion, blueprint: options.blueprint },
+    inputs: { mounts: options.mounts ?? [] },
+    workflow: { steps: [{ command: "wordpress.bench", args: [`plugin-slug=${options.pluginSlug}`] }] },
+  }
+}
+NODE
+
+cat > "$FAKE_WP_CODEBOX" <<'NODE'
+#!/usr/bin/env node
+import { copyFileSync, writeFileSync } from "node:fs"
+
+const recipeIndex = process.argv.indexOf("--recipe")
+if (recipeIndex !== -1 && process.argv[recipeIndex + 1]) {
+  copyFileSync(process.argv[recipeIndex + 1], process.env.CAPTURED_RECIPE)
+}
+writeFileSync(1, 'PHP.run() failed with exit code 255.\n\nFatal error: Allowed memory size of 268435456 bytes exhausted (tried to allocate 126976 bytes) in /internal/shared/sqlite-database-integration/wp-includes/database/sqlite/class-wp-pdo-proxy-statement.php on line 358\n')
+process.exit(255)
+NODE
+chmod +x "$FAKE_WP_CODEBOX"
+
+set +e
+output=$(CAPTURED_RECIPE="$CAPTURED_RECIPE" \
+    HOMEBOY_WP_CODEBOX_BIN="$FAKE_WP_CODEBOX" \
+    HOMEBOY_WP_CODEBOX_CORE_MODULE="$FAKE_CORE_MODULE" \
+    HOMEBOY_RUNTIME_BASH_PREFLIGHT="$FAKE_PREFLIGHT" \
+    HOMEBOY_RUNTIME_BENCH_HELPER_SH="$FAKE_BENCH_HELPER" \
+    HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_FILE" \
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+    HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
+    HOMEBOY_COMPONENT_ID="bench-memory-budget" \
+    HOMEBOY_SETTINGS_JSON="{\"wp_codebox_php_memory_limit\":\"768M\",\"wp_codebox_artifacts_dir\":\"${ARTIFACTS_DIR}\"}" \
+    bash "${SCRIPT_DIR}/bench-runner.sh" 2>&1)
+status=$?
+set -e
+
+if [ "$status" -ne 255 ]; then
+    echo "Expected fake WP Codebox exit 255, got $status" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+if ! jq -e '.inputs.pluginRuntime.php.memoryLimit == "768M"' "$CAPTURED_RECIPE" >/dev/null; then
+    echo "Expected generated recipe to include pluginRuntime.php.memoryLimit=768M" >&2
+    cat "$CAPTURED_RECIPE" >&2
+    exit 1
+fi
+
+DIAGNOSTICS_FILE="${ARTIFACTS_DIR}/wp-codebox-bench-diagnostics.json"
+if ! jq -e '
+    .schema == "homeboy/wordpress-bench-diagnostic/v1"
+    and .diagnostics[0].code == "wp-codebox-php-memory-exhausted"
+    and .diagnostics[0].php_memory_limit == "768M"
+    and .diagnostics[0].exit_code == 255
+    and .diagnostics[0].allowed_bytes == 268435456
+    and .diagnostics[0].attempted_allocation_bytes == 126976
+    and .diagnostics[0].failing_file == "/internal/shared/sqlite-database-integration/wp-includes/database/sqlite/class-wp-pdo-proxy-statement.php"
+    and .diagnostics[0].failing_line == 358
+' "$DIAGNOSTICS_FILE" >/dev/null; then
+    echo "Expected structured memory fatal diagnostics" >&2
+    echo "$output" >&2
+    [ -f "$DIAGNOSTICS_FILE" ] && cat "$DIAGNOSTICS_FILE" >&2
+    exit 1
+fi
+
+if [[ "$output" != *"WP Codebox wordpress.bench exhausted PHP memory"* ]]; then
+    echo "Expected memory fatal summary in output" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+echo "WP Codebox bench memory budget smoke passed"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1021,6 +1021,13 @@
       "type": "string",
       "default": "",
       "description": "Optional WordPress core version passed to WP Codebox test and bench runners. Leave empty for the runner default. Use this when a component needs classes or behavior from a newer WordPress core build."
+    },
+    {
+      "id": "wp_codebox_php_memory_limit",
+      "label": "WP Codebox PHP memory limit",
+      "type": "string",
+      "default": "",
+      "description": "Optional PHP memory_limit for WP Codebox-backed wordpress.bench runs, expressed as a PHP shorthand size such as 512M or 1G. High-cardinality bench rigs can raise this per scenario or matrix cell."
     }
   ],
   "actions": [


### PR DESCRIPTION
## Summary
- Add `wp_codebox_php_memory_limit` for WP Codebox-backed `wordpress.bench` runs and map it to WP Codebox `inputs.pluginRuntime.php.memoryLimit`.
- Classify PHP memory-exhaustion crashes before structured bench output and write diagnostics preserving memory limit, exit code, failing file/line, and artifact paths.
- Add a focused smoke test with a fake WP Codebox runtime to verify recipe memory budget propagation and diagnostic output.

Closes #1026.

## Tests
- `bash wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh`
- `bash -n wordpress/scripts/bench/bench-runner-wp-codebox.sh wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh`
- `jq empty wordpress/wordpress.json`
- `node --check wordpress/scripts/bench/build-wp-codebox-bench-recipe.mjs`
- `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-bench-memory-budget --extension wordpress --changed-only`

## Notes
- Full `homeboy lint --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-bench-memory-budget --extension wordpress` still fails on pre-existing repository-wide findings outside this branch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the WordPress bench memory-budget plumbing, diagnostics, smoke coverage, and verification commands for Chris to review.