### PR TITLE
Update WP Codebox repository references

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -142,7 +142,7 @@ jobs:
 
 ## Inputs worth calling out
 
-- Agent CI always runs through WP Codebox. The workflow checks out and builds `chubes4/wp-codebox` whenever `run_agent` is true; `wp_codebox_ref` controls the ref.
+- Agent CI always runs through WP Codebox. The workflow checks out and builds `Automattic/wp-codebox` whenever `run_agent` is true; `wp_codebox_ref` controls the ref.
 - `include_agent_runtime_dependencies` defaults to `true` and checks out the standard WordPress agent runtime stack: `Automattic/agents-api`, `Extra-Chill/data-machine`, `Extra-Chill/data-machine-code`, and the provider plugin.
 - `agents_api_ref`, `data_machine_ref`, `data_machine_code_ref`, and `openai_provider_ref` control runtime dependency refs. `openai_provider_ref` defaults to `trunk` for the built-in OpenAI preset.
 - `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `credentials` keys. When `provider: openai`, an empty object preserves the existing OpenAI provider defaults.

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -71,7 +71,7 @@ name: Data Machine Agent CI (reusable)
         type: boolean
         default: true
       wp_codebox_ref:
-        description: Ref for chubes4/wp-codebox. Agent CI always checks out and builds WP Codebox when run_agent is true.
+        description: Ref for Automattic/wp-codebox. Agent CI always checks out and builds WP Codebox when run_agent is true.
         type: string
         default: main
       agents_api_ref:
@@ -481,7 +481,7 @@ jobs:
           ')"
           provider_plugin_repo="$(jq -r '.repo // ""' <<< "$provider_plugin_json")"
           provider_plugin_ref="$(jq -r '.ref // ""' <<< "$provider_plugin_json")"
-          dependency_entries+=("chubes4/wp-codebox@${WP_CODEBOX_REF}")
+          dependency_entries+=("Automattic/wp-codebox@${WP_CODEBOX_REF}")
           if [ "$INCLUDE_AGENT_RUNTIME_DEPENDENCIES" = "true" ]; then
             dependency_entries+=("Automattic/agents-api@${AGENTS_API_REF}")
             dependency_entries+=("Extra-Chill/data-machine@${DATA_MACHINE_REF}")

--- a/.github/workflows/wp-codebox-test-runtime-canary.yml
+++ b/.github/workflows/wp-codebox-test-runtime-canary.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout WP Codebox
         uses: actions/checkout@v4
         with:
-          repository: chubes4/wp-codebox
+          repository: Automattic/wp-codebox
           ref: main
           path: .ci/wp-codebox
 

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -5,7 +5,7 @@ Homeboy extension that gives WordPress plugins and themes a complete
 configuration. PHPUnit and benchmark workloads run through [WP Codebox][wp-codebox]
 by default, so there is no host PHP, MySQL, or local WordPress install to manage.
 
-[wp-codebox]: https://github.com/chubes4/wp-codebox
+[wp-codebox]: https://github.com/Automattic/wp-codebox
 [playground]: https://playground.wordpress.net/
 
 ## What this extension provides
@@ -436,7 +436,7 @@ runner request, invokes the Codebox recipe runner, and emits a
 evidence refs, diagnostics, and failure classification.
 
 Removing the Homeboy-owned WP Codebox task runner is blocked on the upstream
-agent task runner API tracked in https://github.com/chubes4/wp-codebox/issues/480.
+agent task runner API tracked in https://github.com/Automattic/wp-codebox/issues/480.
 Until that lands, this provider is a preparatory contract plus request/outcome
 adapter around the current `wp-codebox.agent-sandbox-run` command boundary.
 

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -177,7 +177,7 @@ to `AgentTaskOutcome` with Homeboy-native artifacts, evidence refs, diagnostics,
 and failure classifications.
 
 The provider is intentionally marked preparatory while Codebox's upstream agent
-task runner API is still tracked in https://github.com/chubes4/wp-codebox/issues/480.
+task runner API is still tracked in https://github.com/Automattic/wp-codebox/issues/480.
 Once that surface lands, the same provider contract can remove Homeboy-owned
 recipe synthesis without moving Codebox-specific logic into Homeboy core.
 

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -6,7 +6,7 @@ execution, logs, and test artifacts. There is no host PHP, MySQL, or WordPress
 installation to configure. Components only need a `tests/` directory with
 PHPUnit test files.
 
-[wp-codebox]: https://github.com/chubes4/wp-codebox
+[wp-codebox]: https://github.com/Automattic/wp-codebox
 
 ## Running tests
 

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -36,7 +36,7 @@ function providerContract(options = {}) {
     outcome_schema: AGENT_TASK_OUTCOME_SCHEMA,
     capabilities: PROVIDER_CAPABILITIES,
     status: 'preparatory',
-    upstream_dependency: 'https://github.com/chubes4/wp-codebox/issues/480',
+    upstream_dependency: 'https://github.com/Automattic/wp-codebox/issues/480',
   };
 }
 
@@ -224,7 +224,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     metadata: {
       provider: 'wordpress.codebox-agent-task-executor',
       codebox: sanitizePublicMetadata(result.metadata || result),
-      upstream_dependency: 'https://github.com/chubes4/wp-codebox/issues/480',
+      upstream_dependency: 'https://github.com/Automattic/wp-codebox/issues/480',
     },
   };
   if (failureClassification) {

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -46,7 +46,7 @@ install_wp_codebox() {
         esac
 
         artifact_name="wp-codebox-cli-${platform}-${arch}.tar.gz"
-        download_url="${HOMEBOY_WP_CODEBOX_DOWNLOAD_URL:-https://github.com/chubes4/wp-codebox/releases/latest/download/${artifact_name}}"
+        download_url="${HOMEBOY_WP_CODEBOX_DOWNLOAD_URL:-https://github.com/Automattic/wp-codebox/releases/latest/download/${artifact_name}}"
         artifact_path="${install_root}/${artifact_name}"
         extract_dir="${install_root}/release"
 
@@ -82,7 +82,7 @@ EOF
     fi
 
     local source ref repo_dir
-    source="${HOMEBOY_WP_CODEBOX_SOURCE:-https://github.com/chubes4/wp-codebox.git}"
+    source="${HOMEBOY_WP_CODEBOX_SOURCE:-https://github.com/Automattic/wp-codebox.git}"
     ref="${HOMEBOY_WP_CODEBOX_REF:-main}"
     repo_dir="${install_root}/source"
 

--- a/wordpress/scripts/build/update-wp-codebox-cache.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEFAULT_SOURCE="https://github.com/chubes4/wp-codebox.git"
+DEFAULT_SOURCE="https://github.com/Automattic/wp-codebox.git"
 TARGET=""
 SOURCE="$DEFAULT_SOURCE"
 REF=""
@@ -19,7 +19,7 @@ Options:
   --target <ssh-host>       SSH target such as homeboy-lab. Omit to run locally.
   --runner <ssh-host>       Alias for --target.
   --source <git-url>        WP Codebox repository URL.
-                           Default: https://github.com/chubes4/wp-codebox.git
+                           Default: https://github.com/Automattic/wp-codebox.git
   --ref <git-ref>           Branch, tag, or SHA to fetch/reset to. When omitted,
                            the source repository default branch is used.
   --cache-dir <path>        Runner-side checkout directory.
@@ -31,7 +31,7 @@ Options:
 Examples:
   scripts/update-wp-codebox-cache.sh --target homeboy-lab
   scripts/update-wp-codebox-cache.sh --runner homeboy-lab --ref main
-  scripts/update-wp-codebox-cache.sh --source git@github.com:chubes4/wp-codebox.git --ref afe6890
+  scripts/update-wp-codebox-cache.sh --source git@github.com:Automattic/wp-codebox.git --ref afe6890
 USAGE
 }
 

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -98,7 +98,7 @@ const provider = providerContract();
 assert.equal(provider.backend, 'codebox');
 assert.equal(provider.request_schema, 'homeboy/agent-task-request/v1');
 assert.equal(provider.outcome_schema, 'homeboy/agent-task-outcome/v1');
-assert.equal(provider.upstream_dependency, 'https://github.com/chubes4/wp-codebox/issues/480');
+assert.equal(provider.upstream_dependency, 'https://github.com/Automattic/wp-codebox/issues/480');
 assert.equal(provider.capabilities.includes('browser_runtime'), true);
 
 const codeboxRequest = codeboxTaskRequestFromAgentTaskRequest(request);

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -35,7 +35,7 @@
         "structured_outcome"
       ],
       "status": "preparatory",
-      "upstream_dependency": "https://github.com/chubes4/wp-codebox/issues/480"
+      "upstream_dependency": "https://github.com/Automattic/wp-codebox/issues/480"
     }
   ],
   "scripts": {


### PR DESCRIPTION
## Summary
- Update WP Codebox checkout, release download, cache, docs, and upstream dependency URLs from `chubes4/wp-codebox` to `Automattic/wp-codebox`.
- Keep existing `wp_codebox_ref` behavior unchanged; only the canonical repository owner changes.

## Testing
- `npm run test:codebox-agent-task-executor` from `wordpress/`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the mechanical repository-reference migration and running focused verification. Chris remains responsible for review and merge.