### PR TITLE
fix: pass configured wp cli to codebox agent tasks

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -63,6 +63,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     data_machine_code: config.data_machine_code || options.dataMachineCode || '',
     homeboy: config.homeboy || options.homeboy || '',
     homeboy_extensions: config.homeboy_extensions || options.homeboyExtensions || '',
+    wp_cli_bin: config.wp_cli_bin || options.wpCliBin || '',
     wp_codebox_bin: config.wp_codebox_bin || options.wpCodeboxBin || '',
     artifacts: config.artifacts || options.artifacts || '',
     max_turns: config.max_turns || options.maxTurns,

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -150,6 +150,7 @@ const codexAgentRequest = {
       data_machine_code: '/components/data-machine-code',
       homeboy: '/components/homeboy',
       homeboy_extensions: '/components/homeboy-extensions',
+      wp_cli_bin: '/bin/wp',
       wp_codebox_bin: '/bin/wp-codebox',
       max_turns: 8,
     },
@@ -164,6 +165,7 @@ assert.equal(codexRequest.data_machine, '/components/data-machine');
 assert.equal(codexRequest.data_machine_code, '/components/data-machine-code');
 assert.equal(codexRequest.homeboy, '/components/homeboy');
 assert.equal(codexRequest.homeboy_extensions, '/components/homeboy-extensions');
+assert.equal(codexRequest.wp_cli_bin, '/bin/wp');
 assert.equal(codexRequest.wp_codebox_bin, '/bin/wp-codebox');
 assert.deepEqual(codexRequest.secret_env, [
   'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -263,6 +263,27 @@ try {
   assert.equal(nonExecutableCapture.argv[0], 'codebox');
   assert.equal(pathInside(root, nonExecutableCapture.input.artifacts_path), false);
 
+  const requestConfiguredCapturePath = path.join(root, 'capture-request-configured.json');
+  const requestConfiguredFixture = createFixtureWpCli(root);
+  const requestConfiguredResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      wp_cli_bin: requestConfiguredFixture,
+      secret_env: [],
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CLI_CAPTURE: requestConfiguredCapturePath,
+    },
+  });
+  assert.equal(requestConfiguredResult.status, 0, requestConfiguredResult.stderr || requestConfiguredResult.stdout);
+  const requestConfiguredCapture = readJson(requestConfiguredCapturePath);
+  assert.equal(requestConfiguredCapture.argv[0], 'codebox');
+  assert.equal(requestConfiguredCapture.input.parent_request.wp_cli_bin, requestConfiguredFixture);
+
   const sourceRoot = path.join(root, 'source-plugin');
   fs.mkdirSync(sourceRoot, { recursive: true });
   const riskyArtifacts = path.join(sourceRoot, 'artifacts');


### PR DESCRIPTION
## Summary
- Carries `executor.config.wp_cli_bin` through the generic Codebox agent-task request mapper.
- Adds smoke coverage for mapped WP-CLI binary configuration and request-supplied task-runner binary selection.

## Tests
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`

## Verification note
- `homeboy test --path /Users/chubes/Developer/homeboy-extensions@fix-issue-1031-agent-task-wp-cli-bin --extension nodejs` is currently blocked by Extra-Chill/homeboy-extensions#1032 because Lab offload's nodejs extension install is missing `scripts/lib/project-scripts.sh` before project tests run.

Closes #1031.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the failed Homeboy agent-task provider preflight, implemented the mapper/test fix, and drafted the PR description; Chris remains responsible for review and acceptance.