### PR TITLE
Include declared WordPress package artifacts

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -239,6 +239,27 @@ homeboy build <component>
 Pre-build validation runs `scripts/build/validate-build.sh`. PHP syntax
 errors and PSR-4 violations block the build; lint findings do not.
 
+Production builds exclude arbitrary nested `*.zip` files by default to avoid
+shipping stale release artifacts. Components that intentionally need ZIP package
+artifacts inside the deployed plugin or theme can declare explicit include globs:
+
+```json
+{
+	"extensions": {
+		"wordpress": {
+			"package_artifacts": [
+				"runtime/studio-web-sandbox/packages/*.zip"
+			]
+		}
+	}
+}
+```
+
+Each pattern is component-relative, must not contain `..`, and must match at
+least one file. Included package artifacts are copied into the staging directory
+after the default rsync excludes and reported with SHA-256 values in the build
+output.
+
 ## Bench runner
 
 Bench workloads run through WP Codebox. WP Codebox owns the disposable WordPress

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -42,6 +42,7 @@
     "test:wp-codebox-task-runner": "node tests/wp-codebox-task-runner-smoke.js",
     "test:wp-codebox-bench-recipe-builder": "node tests/wp-codebox-bench-recipe-builder-smoke.js",
     "test:wp-codebox-phpunit-recipe-builder": "node tests/wp-codebox-phpunit-recipe-builder-smoke.js",
+    "test:build-package-artifacts": "bash scripts/build/build-package-artifacts-smoke.sh",
     "test:codebox-agent-task-executor": "node tests/codebox-agent-task-executor-smoke.js",
     "test:codebox-agent-task-matrix": "node tests/codebox-agent-task-matrix-smoke.js",
     "test:refactor-source-wp-codebox": "node tests/refactor-source-wp-codebox-smoke.js"

--- a/wordpress/scripts/build/build-package-artifacts-smoke.sh
+++ b/wordpress/scripts/build/build-package-artifacts-smoke.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wordpress-package-artifacts.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+assert_zip_contains() {
+    local zip_file="$1"
+    local expected="$2"
+    if ! unzip -l "$zip_file" | grep -F -- "$expected" >/dev/null; then
+        echo "Expected $zip_file to contain $expected" >&2
+        unzip -l "$zip_file" >&2
+        exit 1
+    fi
+}
+
+assert_zip_not_contains() {
+    local zip_file="$1"
+    local unexpected="$2"
+    if unzip -l "$zip_file" | grep -F -- "$unexpected" >/dev/null; then
+        echo "Expected $zip_file not to contain $unexpected" >&2
+        unzip -l "$zip_file" >&2
+        exit 1
+    fi
+}
+
+component_dir="${TMP_DIR}/package-artifact-plugin"
+mkdir -p "${component_dir}/runtime/packages" "${component_dir}/includes"
+
+cat > "${component_dir}/package-artifact-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Package Artifact Plugin
+ * Version: 1.0.0
+ */
+PHP
+
+printf '%s\n' '<?php' > "${component_dir}/includes/bootstrap.php"
+printf '%s\n' 'accidental release zip' > "${component_dir}/accidental.zip"
+printf '%s\n' 'intentional package zip' > "${component_dir}/runtime/packages/static-site-importer.zip"
+
+(
+    cd "$component_dir"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_ID="package-artifact-plugin" \
+    HOMEBOY_SKIP_TESTS=1 \
+        bash "${EXTENSION_DIR}/scripts/build/build.sh" > "${TMP_DIR}/default-build.out"
+)
+
+default_zip="${component_dir}/build/package-artifact-plugin.zip"
+assert_zip_contains "$default_zip" "package-artifact-plugin/package-artifact-plugin.php"
+assert_zip_not_contains "$default_zip" "package-artifact-plugin/accidental.zip"
+assert_zip_not_contains "$default_zip" "package-artifact-plugin/runtime/packages/static-site-importer.zip"
+
+(
+    cd "$component_dir"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_ID="package-artifact-plugin" \
+    HOMEBOY_SKIP_TESTS=1 \
+    HOMEBOY_SETTINGS_JSON='{"package_artifacts":["runtime/packages/*.zip"]}' \
+        bash "${EXTENSION_DIR}/scripts/build/build.sh" > "${TMP_DIR}/included-build.out"
+)
+
+included_zip="${component_dir}/build/package-artifact-plugin.zip"
+assert_zip_contains "$included_zip" "package-artifact-plugin/runtime/packages/static-site-importer.zip"
+assert_zip_not_contains "$included_zip" "package-artifact-plugin/accidental.zip"
+
+if ! grep -Fq '"type":"wordpress.package_artifacts"' "${TMP_DIR}/included-build.out"; then
+    echo "Expected structured package artifact output" >&2
+    sed 's/^/  /' "${TMP_DIR}/included-build.out" >&2
+    exit 1
+fi
+
+if ! grep -Fq '"path":"runtime/packages/static-site-importer.zip"' "${TMP_DIR}/included-build.out"; then
+    echo "Expected included artifact path in structured output" >&2
+    sed 's/^/  /' "${TMP_DIR}/included-build.out" >&2
+    exit 1
+fi
+
+if ! grep -Eq '"sha256":"[0-9a-f]{64}"' "${TMP_DIR}/included-build.out"; then
+    echo "Expected included artifact SHA-256 in structured output" >&2
+    sed 's/^/  /' "${TMP_DIR}/included-build.out" >&2
+    exit 1
+fi
+
+if (
+    cd "$component_dir"
+    HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+    HOMEBOY_COMPONENT_ID="package-artifact-plugin" \
+    HOMEBOY_SKIP_TESTS=1 \
+    HOMEBOY_SETTINGS_JSON='{"package_artifacts":["runtime/missing/*.zip"]}' \
+        bash "${EXTENSION_DIR}/scripts/build/build.sh" > "${TMP_DIR}/missing-build.out" 2>&1
+); then
+    echo "Expected missing declared package artifact pattern to fail" >&2
+    sed 's/^/  /' "${TMP_DIR}/missing-build.out" >&2
+    exit 1
+fi
+
+if ! grep -Fq 'Declared WordPress package artifact pattern matched no files: runtime/missing/*.zip' "${TMP_DIR}/missing-build.out"; then
+    echo "Expected missing artifact error" >&2
+    sed 's/^/  /' "${TMP_DIR}/missing-build.out" >&2
+    exit 1
+fi
+
+echo "WordPress package artifacts build smoke passed."

--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -551,6 +551,112 @@ EOF
     fi
 }
 
+resolve_package_artifacts() {
+    local manifest_file="$1"
+    local list_file="$2"
+
+    : > "$list_file"
+    printf '%s\n' '{"type":"wordpress.package_artifacts","artifacts":[]}' > "$manifest_file"
+
+    [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] || return 0
+    [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ] || return 0
+
+    HOMEBOY_WORDPRESS_PACKAGE_ARTIFACTS_MANIFEST="$manifest_file" \
+    HOMEBOY_WORDPRESS_PACKAGE_ARTIFACTS_LIST="$list_file" \
+    php <<'PHP'
+<?php
+$settings = json_decode( getenv( 'HOMEBOY_SETTINGS_JSON' ) ?: '{}', true );
+if ( ! is_array( $settings ) ) {
+	fwrite( STDERR, "Invalid HOMEBOY_SETTINGS_JSON; expected a JSON object.\n" );
+	exit( 1 );
+}
+
+$patterns = $settings['package_artifacts'] ?? [];
+if ( ! is_array( $patterns ) ) {
+	fwrite( STDERR, "extensions.wordpress.package_artifacts must be an array of component-relative glob patterns.\n" );
+	exit( 1 );
+}
+
+$artifacts = [];
+$seen      = [];
+$list      = '';
+
+foreach ( $patterns as $pattern ) {
+	if ( ! is_string( $pattern ) || '' === $pattern ) {
+		fwrite( STDERR, "extensions.wordpress.package_artifacts entries must be non-empty strings.\n" );
+		exit( 1 );
+	}
+
+	$normalized = str_replace( '\\', '/', $pattern );
+	if ( str_starts_with( $normalized, '/' ) || preg_match( '#(^|/)\.\.(/|$)#', $normalized ) ) {
+		fwrite( STDERR, "Package artifact patterns must be component-relative and cannot contain '..': {$pattern}\n" );
+		exit( 1 );
+	}
+
+	$matches = glob( $pattern, GLOB_BRACE ) ?: [];
+	$files   = [];
+	foreach ( $matches as $match ) {
+		if ( is_file( $match ) ) {
+			$relative = str_replace( '\\', '/', $match );
+			if ( str_starts_with( $relative, './' ) ) {
+				$relative = substr( $relative, 2 );
+			}
+			$files[]  = $relative;
+		}
+	}
+
+	if ( [] === $files ) {
+		fwrite( STDERR, "Declared WordPress package artifact pattern matched no files: {$pattern}\n" );
+		exit( 1 );
+	}
+
+	sort( $files );
+	foreach ( $files as $relative ) {
+		if ( isset( $seen[ $relative ] ) ) {
+			continue;
+		}
+		$seen[ $relative ] = true;
+		$sha256            = hash_file( 'sha256', $relative ) ?: '';
+		$artifacts[]       = [
+			'path'    => $relative,
+			'sha256'  => $sha256,
+			'pattern' => $pattern,
+		];
+		$list .= $relative . "\t" . $sha256 . "\n";
+	}
+}
+
+$manifest = [
+	'type'      => 'wordpress.package_artifacts',
+	'artifacts' => $artifacts,
+];
+
+file_put_contents( getenv( 'HOMEBOY_WORDPRESS_PACKAGE_ARTIFACTS_MANIFEST' ), json_encode( $manifest, JSON_UNESCAPED_SLASHES ) . "\n" );
+file_put_contents( getenv( 'HOMEBOY_WORDPRESS_PACKAGE_ARTIFACTS_LIST' ), $list );
+PHP
+}
+
+include_package_artifacts() {
+    local staging_dir="$1"
+    local manifest_file="/tmp/.wordpress-package-artifacts-$$.json"
+    local list_file="/tmp/.wordpress-package-artifacts-$$.tsv"
+
+    resolve_package_artifacts "$manifest_file" "$list_file"
+
+    if [ -s "$list_file" ]; then
+        while IFS=$'\t' read -r relative_path sha256; do
+            [ -n "$relative_path" ] || continue
+            mkdir -p "$staging_dir/$(dirname "$relative_path")"
+            cp "$relative_path" "$staging_dir/$relative_path"
+            print_status "Included package artifact: $relative_path (sha256: $sha256)"
+        done < "$list_file"
+
+        cat "$manifest_file"
+    fi
+
+    rm -f "$manifest_file" "$list_file"
+}
+
 # Copy files to staging directory
 copy_project_files() {
     print_status "Copying project files to staging directory..."
@@ -564,6 +670,8 @@ copy_project_files() {
 
     # Copy files using rsync with excludes
     rsync -av --exclude-from="$exclude_file" ./ "$staging_dir/" --quiet
+
+    include_package_artifacts "$staging_dir"
 
     # Clean up exclude file
     rm -f "$exclude_file"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1028,6 +1028,13 @@
       "type": "string",
       "default": "",
       "description": "Optional PHP memory_limit for WP Codebox-backed wordpress.bench runs, expressed as a PHP shorthand size such as 512M or 1G. High-cardinality bench rigs can raise this per scenario or matrix cell."
+    },
+    {
+      "id": "package_artifacts",
+      "label": "WordPress package artifacts",
+      "type": "array",
+      "default": [],
+      "description": "Component-relative glob patterns for intentional package ZIP artifacts that should be included in the production build even though arbitrary *.zip files are excluded by default. Each declared pattern must match at least one file."
     }
   ],
   "actions": [


### PR DESCRIPTION
## Summary
- Add explicit `extensions.wordpress.package_artifacts` globs for intentional ZIP package artifacts in WordPress builds.
- Keep arbitrary `*.zip` excluded by default, then copy declared package artifacts into staging with SHA-256 reporting.
- Document the setting and add a build smoke covering default exclusion plus declared inclusion.

## Validation
- `npm run test:build-package-artifacts`
- `bash scripts/build/build-helper-smoke.sh`
- `node -e \"JSON.parse(require('fs').readFileSync('wordpress.json','utf8'))\"`

## Related
- Closes Extra-Chill/homeboy-extensions#1034
- Pairs with Extra-Chill/homeboy#3358 for cross-component artifact inputs
- Supports Studio Web runtime package deployment for https://github.a8c.com/chubes4/studio-web/pull/345

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and implemented the package artifact include setting, smoke coverage, docs, and PR summary; Chris remains responsible for review and merge.