### PR TITLE
fix: run codebox agent tasks in sandbox mode

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -52,6 +52,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     schema: WP_CODEBOX_TASK_REQUEST_SCHEMA,
     sandbox_session_id: config.sandbox_session_id || request.task_id,
     group_key: request.group_key,
+    agent: config.agent || options.agent || 'wp-codebox-sandbox',
+    mode: config.mode || options.mode || 'sandbox',
     provider: config.provider || options.provider || '',
     model: request.executor.model || config.model || options.model || '',
     provider_plugin_paths: config.provider_plugin_paths || options.providerPluginPaths || [],

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -156,6 +156,8 @@ function writePreflightEvidence(artifacts, evidence) {
 function runnerInput(request, artifacts) {
   return Object.fromEntries(Object.entries({
     parent_request: request,
+    agent: argValue('--agent') || request.agent || 'wp-codebox-sandbox',
+    mode: argValue('--mode') || request.mode || 'sandbox',
     provider: argValue('--provider') || request.provider || '',
     model: argValue('--model') || request.model || '',
     provider_plugin_paths: [...(request.provider_plugin_paths || []), ...argValues('--provider-plugin-path')],
@@ -213,7 +215,7 @@ function buildRecipe(input) {
   const workflowArgs = [
     `task=${task.prompt || ''}`,
     `agent=${input.agent || 'wp-codebox-sandbox'}`,
-    `mode=${input.mode || 'default'}`,
+    `mode=${input.mode || 'sandbox'}`,
     `provider=${input.provider || ''}`,
     `model=${input.model || ''}`,
     `provider-plugin-slugs=${providerSlugs.join(',')}`,

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -157,6 +157,8 @@ const codexAgentRequest = {
   },
 };
 const codexRequest = codeboxTaskRequestFromAgentTaskRequest(codexAgentRequest);
+assert.equal(codexRequest.agent, 'wp-codebox-sandbox');
+assert.equal(codexRequest.mode, 'sandbox');
 assert.equal(codexRequest.provider, 'codex');
 assert.equal(codexRequest.model, 'gpt-5.5');
 assert.deepEqual(codexRequest.provider_plugin_paths, ['/components/ai-provider-for-openai']);
@@ -175,6 +177,20 @@ assert.deepEqual(codexRequest.secret_env, [
   'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
 ]);
 assert(!JSON.stringify(codexRequest).includes('wp-ai-gateway'));
+assert.equal(codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  executor: {
+    ...request.executor,
+    config: { ...request.executor.config, agent: 'custom-agent', mode: 'review' },
+  },
+}).agent, 'custom-agent');
+assert.equal(codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  executor: {
+    ...request.executor,
+    config: { ...request.executor.config, agent: 'custom-agent', mode: 'review' },
+  },
+}).mode, 'review');
 assert.equal(codeboxTaskRequestFromAgentTaskRequest({
   ...request,
   limits: { task_timeout_seconds: 7 },

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -147,6 +147,8 @@ try {
   const recipe = captured.recipe;
   assert.equal(recipe.schema, 'wp-codebox/workspace-recipe/v1');
   assert.equal(recipe.workflow.steps[0].command, 'wp-codebox.agent-sandbox-run');
+  assert(recipe.workflow.steps[0].args.includes('agent=wp-codebox-sandbox'));
+  assert(recipe.workflow.steps[0].args.includes('mode=sandbox'));
   assert(recipe.workflow.steps[0].args.includes('provider=opencode'));
   assert(recipe.workflow.steps[0].args.includes('model=opencode-go/kimi-k2.6'));
   assert(recipe.workflow.steps[0].args.includes('max-turns=80'));


### PR DESCRIPTION
## Summary
- Defaults Homeboy WP Codebox agent tasks to `mode=sandbox` so the sandbox tool surface is available for code-editing tasks.
- Carries optional `agent` and `mode` values from the Homeboy agent-task executor config into the WP Codebox task request and generated recipe.
- Updates smoke coverage to assert the generated recipe invokes `wp-codebox.agent-sandbox-run` with the sandbox agent and mode.

## Tests
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node --check wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs`
- `node --check wordpress/lib/codebox-agent-task-executor.js`

## Evidence
A Homeboy `agent-task run` against Extra-Chill/wp-coding-agents#179 booted WP Codebox successfully, mounted the target workspace, and reached Codex, but the model reported it had no filesystem/shell tools. The generated recipe used `mode=default`; this PR switches Homeboy Codebox agent-task execution to sandbox mode by default.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the Homeboy/WP Codebox sandbox mode mismatch, implemented the minimal provider fix, ran targeted smoke tests, and drafted this PR description; Chris remains responsible for review and acceptance.