### PR TITLE
Preserve Codebox task workspace refs

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -195,12 +195,14 @@ function workspaceMounts(request) {
   if (!root) {
     return [];
   }
-  const slug = workspace.slug || slugFromPath(root, 'workspace');
+  const workspaceRef = workspace.ref || workspace.handle || path.basename(String(root).replace(/\/$/, ''));
+  const repo = workspace.repo || String(workspaceRef).split('@')[0] || slugFromPath(root, 'workspace');
+  const slug = workspace.slug || repo.replace(/[^A-Za-z0-9_-]/g, '-');
   return [{
     source: root,
     target: `/workspace/${slug}`,
     mode: workspace.mode === 'readonly' ? 'readonly' : 'readwrite',
-    metadata: { kind: 'homeboy-agent-task-workspace', slug },
+    metadata: { kind: 'homeboy-agent-task-workspace', slug, workspaceRef, repo },
   }];
 }
 

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -49,7 +49,7 @@ try {
   const capturePath = path.join(root, 'capture.json');
   const fixtureWpCodebox = createFixtureWpCodebox(root);
   const providerPluginPath = path.join(root, 'example-provider@feature-branch');
-  const workspaceRoot = path.join(root, 'homeboy@fix-test');
+  const workspaceRoot = path.join(root, 'wp-coding-agents@proof-homeboy-fanout-a');
   fs.mkdirSync(providerPluginPath, { recursive: true });
   fs.mkdirSync(workspaceRoot, { recursive: true });
 
@@ -160,7 +160,13 @@ try {
   assert.deepEqual(recipe.inputs.secretEnv, ['OPENCODE_API_KEY']);
   assert.equal(recipe.inputs.mounts[0].source, '/repo/plugin');
   assert.equal(recipe.inputs.mounts[1].source, workspaceRoot);
-  assert.equal(recipe.inputs.mounts[1].target, '/workspace/homeboy');
+  assert.equal(recipe.inputs.mounts[1].target, '/workspace/wp-coding-agents');
+  assert.deepEqual(recipe.inputs.mounts[1].metadata, {
+    kind: 'homeboy-agent-task-workspace',
+    slug: 'wp-coding-agents',
+    workspaceRef: 'wp-coding-agents@proof-homeboy-fanout-a',
+    repo: 'wp-coding-agents',
+  });
   assert.equal(recipe.runtime.stack.mounts[0].source, '/components/php-ai-client');
   assert.equal(recipe.runtime.stack.mounts[1].source, '/components/wordpress-develop');
   assert.equal(recipe.runtime.overlays[0].kind, 'bundled-library');


### PR DESCRIPTION
## Summary
- Preserve DMC worktree identity in WP Codebox task recipe mount metadata while keeping the agent-facing mount target stable at `/workspace/<repo>`.
- Add smoke coverage for a task workspace rooted at `wp-coding-agents@proof-homeboy-fanout-a` so recipe metadata keeps the full handle.

## Trackers
- Parent: https://github.com/Extra-Chill/homeboy/issues/3378
- Homeboy Extensions: https://github.com/Extra-Chill/homeboy-extensions/issues/1038
- WP Codebox: https://github.com/Automattic/wp-codebox/issues/518

## Verification
- `node tests/wp-codebox-task-runner-smoke.js` passed
- `node --check scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/wp-codebox-task-runner-smoke.js` passed
- `homeboy test --path . --extension wordpress` failed in existing WP Codebox/PHPUnit fixtures unrelated to this change
- `homeboy lint --path . --extension wordpress` failed on existing PHP lint findings unrelated to this JS-only change

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the mount metadata preservation change, added focused smoke coverage, and ran verification commands for Chris to review.