### PR TITLE
Stabilize WordPress build PHP syntax checks

### DIFF
--- a/tests/wordpress-build-staging-syntax-smoke.sh
+++ b/tests/wordpress-build-staging-syntax-smoke.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_SCRIPT="$ROOT_DIR/wordpress/scripts/build/build.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PROJECT_DIR="$TMP_DIR/staging-smoke-plugin"
+OUTPUT_FILE="$TMP_DIR/build.out"
+mkdir -p "$PROJECT_DIR/inc"
+
+cat > "$PROJECT_DIR/staging-smoke-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Staging Smoke Plugin
+ * Version: 1.2.3
+ */
+PHP
+
+cat > "$PROJECT_DIR/inc/good.php" <<'PHP'
+<?php
+function staging_smoke_plugin_good() {
+	return true;
+}
+PHP
+
+cat > "$PROJECT_DIR/.buildignore" <<'EOF'
+README.md
+EOF
+
+(
+    cd "$PROJECT_DIR"
+    bash "$BUILD_SCRIPT" >"$OUTPUT_FILE"
+)
+
+ZIP_FILE="$PROJECT_DIR/build/staging-smoke-plugin.zip"
+if [ ! -f "$ZIP_FILE" ]; then
+    echo "Expected build artifact missing: $ZIP_FILE" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+if unzip -Z1 "$ZIP_FILE" | grep -q '^staging-smoke-plugin/.homeboy-build/'; then
+    echo "Build artifact unexpectedly contains Homeboy staging files" >&2
+    unzip -Z1 "$ZIP_FILE" >&2
+    exit 1
+fi
+
+if ! grep -q 'PHP syntax check passed' "$OUTPUT_FILE"; then
+    echo "Build did not run PHP syntax validation" >&2
+    cat "$OUTPUT_FILE" >&2
+    exit 1
+fi
+
+BAD_PROJECT_DIR="$TMP_DIR/staging-bad-plugin"
+BAD_OUTPUT_FILE="$TMP_DIR/bad-build.out"
+mkdir -p "$BAD_PROJECT_DIR/inc"
+
+cat > "$BAD_PROJECT_DIR/staging-bad-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Staging Bad Plugin
+ * Version: 1.2.3
+ */
+PHP
+
+cat > "$BAD_PROJECT_DIR/inc/bad.php" <<'PHP'
+<?php
+function staging_bad_plugin_broken( {
+	return true;
+}
+PHP
+
+cat > "$BAD_PROJECT_DIR/.buildignore" <<'EOF'
+README.md
+EOF
+
+if (
+    cd "$BAD_PROJECT_DIR"
+    bash "$BUILD_SCRIPT" >"$BAD_OUTPUT_FILE" 2>&1
+); then
+    echo "Build unexpectedly passed with invalid staged PHP" >&2
+    cat "$BAD_OUTPUT_FILE" >&2
+    exit 1
+fi
+
+if ! grep -q 'PHP syntax errors found' "$BAD_OUTPUT_FILE"; then
+    echo "Build did not report PHP syntax validation failure" >&2
+    cat "$BAD_OUTPUT_FILE" >&2
+    exit 1
+fi
+
+echo "wordpress build staging syntax smoke passed"

--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -549,6 +549,12 @@ package-lock.json
 webpack.config.js
 EOF
     fi
+
+    # Homeboy-managed staging must never be copied into itself. Keep this
+    # mandatory even when a project supplies a custom .buildignore.
+    cat >> "$exclude_file" << 'EOF'
+/.homeboy-build/
+EOF
 }
 
 resolve_package_artifacts() {
@@ -772,14 +778,42 @@ validate_php_syntax() {
     print_status "Running PHP syntax check on build..."
 
     local staging_dir="${STAGING_ROOT}/$PROJECT_NAME"
+    local staging_abs=""
+    local php_file_list="/tmp/.wordpress-php-syntax-files-$$.list"
     local php_errors=0
 
-    while IFS= read -r -d '' file; do
-        if ! php -l "$file" > /dev/null 2>&1; then
-            php -l "$file" 2>&1
+    if [ ! -d "$staging_dir" ]; then
+        print_error "Staging directory not found for PHP syntax validation: $staging_dir"
+        return 1
+    fi
+
+    staging_abs="$(cd "$staging_dir" && pwd)"
+
+    if ! find "$staging_abs" -type f -name "*.php" -print > "$php_file_list"; then
+        rm -f "$php_file_list"
+        print_error "Could not enumerate staged PHP files under: $staging_dir"
+        return 1
+    fi
+
+    LC_ALL=C sort -o "$php_file_list" "$php_file_list"
+
+    while IFS= read -r file; do
+        [ -n "$file" ] || continue
+
+        if [ ! -f "$file" ]; then
+            print_error "Staged PHP file disappeared during syntax validation: ${file#$staging_abs/}"
+            php_errors=1
+            continue
+        fi
+
+        local lint_output=""
+        if ! lint_output="$(php -l "$file" 2>&1)"; then
+            printf '%s\n' "$lint_output"
             php_errors=1
         fi
-    done < <(find "$staging_dir" -name "*.php" -print0)
+    done < "$php_file_list"
+
+    rm -f "$php_file_list"
 
     if [ $php_errors -eq 1 ]; then
         print_error "PHP syntax errors found. Build aborted."

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "2.114.3",
+  "version": "2.114.4",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",


### PR DESCRIPTION
## Summary
- Always exclude Homeboy's `.homeboy-build/` staging directory from WordPress build rsync inputs, including projects that provide a custom `.buildignore`.
- Resolve and sort the staged PHP file list before linting so syntax validation is deterministic and reports staging disappearance as a staging failure instead of repeated missing input files.
- Add a smoke test covering custom `.buildignore` staging behavior and invalid staged PHP detection.

Fixes Extra-Chill/homeboy#3381.

## Verification
- `bash -n wordpress/scripts/build/build.sh tests/wordpress-build-staging-syntax-smoke.sh`
- `bash tests/wordpress-build-staging-syntax-smoke.sh`
- `php -r 'json_decode(file_get_contents($argv[1]), true, 512, JSON_THROW_ON_ERROR);' wordpress/wordpress.json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause tracing, patch drafting, smoke coverage, and targeted verification. Chris remains responsible for review and acceptance.