### PR TITLE
Preserve Codebox agent task evidence

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -456,6 +456,18 @@ runner request, invokes the Codebox recipe runner, and emits a
 `homeboy/agent-task-outcome/v1` outcome with normalized status, artifacts,
 evidence refs, diagnostics, and failure classification.
 
+The outcome preserves the Homeboy decision evidence needed for Codebox worker
+canaries: why the Codebox executor was selected, which capabilities were used,
+the WP Codebox run/runtime IDs, cleanup status, heartbeat timestamp, changed-file
+count, patch digest/size, transcript/log artifact refs, and no-op reason when the
+sandbox completes without a promotable patch. Runtime gaps discovered during the
+worker-runtime canary are tracked upstream in:
+
+- https://github.com/Automattic/wp-codebox/issues/529
+- https://github.com/Automattic/wp-codebox/issues/530
+- https://github.com/Automattic/wp-codebox/issues/531
+- https://github.com/Automattic/wp-codebox/issues/532
+
 Removing the Homeboy-owned WP Codebox task runner is blocked on the upstream
 agent task runner API tracked in https://github.com/Automattic/wp-codebox/issues/480.
 Until that lands, this provider is a preparatory contract plus request/outcome

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -8,9 +8,22 @@ const WP_CODEBOX_TASK_REQUEST_SCHEMA = 'homeboy/wp-codebox-task-request/v1';
 const PROVIDER_CAPABILITIES = [
   'browser_runtime',
   'wordpress_sandbox',
+  'workspace_mounts',
+  'workspace_tools',
   'artifact_materialization',
+  'patch_artifacts',
+  'verification_artifacts',
+  'run_registry',
+  'cleanup_observability',
   'screenshots',
   'structured_outcome',
+];
+
+const WP_CODEBOX_RUNTIME_GAP_TRACKERS = [
+  'https://github.com/Automattic/wp-codebox/issues/529',
+  'https://github.com/Automattic/wp-codebox/issues/530',
+  'https://github.com/Automattic/wp-codebox/issues/531',
+  'https://github.com/Automattic/wp-codebox/issues/532',
 ];
 
 function assertAgentTaskRequest(request) {
@@ -37,6 +50,7 @@ function providerContract(options = {}) {
     capabilities: PROVIDER_CAPABILITIES,
     status: 'preparatory',
     upstream_dependency: 'https://github.com/Automattic/wp-codebox/issues/480',
+    runtime_gap_trackers: WP_CODEBOX_RUNTIME_GAP_TRACKERS,
   };
 }
 
@@ -92,6 +106,12 @@ function normalizeStatus(result, exitStatus = 0) {
   if (result?.status) {
     return result.status;
   }
+  const agentResult = result?.run?.agentResult || result?.agentResult || result?.metadata?.recipe_run?.agentResult || result?.metadata?.recipe_run?.run?.agentResult;
+  const changedFileCount = agentResult?.changedFiles?.count;
+  const patchBytes = agentResult?.patch?.bytes;
+  if (result?.success === true && agentResult?.noOpReason && changedFileCount === 0 && patchBytes === 0) {
+    return 'no_op';
+  }
   if (result?.outcome === 'no_op' || result?.no_op) {
     return 'no_op';
   }
@@ -105,6 +125,103 @@ function normalizeStatus(result, exitStatus = 0) {
     return 'provider_error';
   }
   return result?.success === true && exitStatus === 0 ? 'succeeded' : 'failed';
+}
+
+function appendUniqueArtifact(artifacts, artifact) {
+  if (!artifact || !artifact.kind) {
+    return;
+  }
+  const key = artifact.path || artifact.url || artifact.id;
+  if (key && artifacts.some((existing) => (existing.path || existing.url || existing.id) === key)) {
+    return;
+  }
+  artifacts.push(artifact);
+}
+
+function appendUniqueEvidenceRef(refs, ref) {
+  if (!ref || !ref.uri) {
+    return;
+  }
+  if (refs.some((existing) => existing.uri === ref.uri && existing.kind === ref.kind)) {
+    return;
+  }
+  refs.push(ref);
+}
+
+function artifactPath(root, relativePath) {
+  if (!root || !relativePath) {
+    return '';
+  }
+  return `${String(root).replace(/\/$/, '')}/${String(relativePath).replace(/^\//, '')}`;
+}
+
+function codeboxBundleArtifacts(result) {
+  const artifacts = [];
+  const artifactRefs = Array.isArray(result.run?.artifactRefs) ? result.run.artifactRefs : [];
+  for (const ref of artifactRefs) {
+    appendUniqueArtifact(artifacts, {
+      id: ref.id || ref.digest?.value,
+      kind: ref.kind || 'codebox-artifact-bundle',
+      path: ref.directory,
+      sha256: ref.digest?.value,
+      metadata: { digest: ref.digest },
+    });
+  }
+
+  const bundleDirectory = result.run?.agentResult?.artifacts?.directory || result.completionOutcome?.provenance?.artifactDirectory;
+  const artifactBundleId = result.completionOutcome?.provenance?.artifactBundleId || result.artifacts?.id;
+  appendUniqueArtifact(artifacts, {
+    id: artifactBundleId,
+    kind: 'codebox-artifact-bundle',
+    path: bundleDirectory,
+    metadata: {
+      runtime_id: result.run?.runtime?.id,
+      runtime_status: result.run?.runtime?.status,
+    },
+  });
+
+  const agentResult = result.run?.agentResult || result.agentResult || result.metadata?.recipe_run?.agentResult || {};
+  const changedFilesPath = artifactPath(bundleDirectory, agentResult.changedFiles?.artifact || '');
+  appendUniqueArtifact(artifacts, {
+    id: changedFilesPath ? 'codebox-changed-files' : '',
+    kind: 'codebox-changed-files',
+    path: changedFilesPath,
+    metadata: agentResult.changedFiles || {},
+  });
+
+  const patchPath = artifactPath(bundleDirectory, agentResult.patch?.artifact || '');
+  appendUniqueArtifact(artifacts, {
+    id: patchPath ? 'codebox-patch' : '',
+    kind: 'codebox-patch',
+    path: patchPath,
+    sha256: agentResult.patch?.sha256,
+    size_bytes: agentResult.patch?.bytes,
+    metadata: agentResult.patch || {},
+  });
+
+  const transcriptPath = artifactPath(bundleDirectory, agentResult.transcript?.artifact || '');
+  appendUniqueArtifact(artifacts, {
+    id: transcriptPath ? 'codebox-transcript' : '',
+    kind: 'codebox-transcript',
+    path: transcriptPath,
+    metadata: agentResult.transcript || {},
+  });
+
+  const runtimeLogPath = result.artifacts?.runtimeLogPath;
+  appendUniqueArtifact(artifacts, {
+    id: runtimeLogPath ? 'codebox-runtime-log' : '',
+    kind: 'codebox-runtime-log',
+    path: runtimeLogPath,
+  });
+
+  const commandsLogPath = result.artifacts?.commandsLogPath;
+  appendUniqueArtifact(artifacts, {
+    id: commandsLogPath ? 'codebox-command-log' : '',
+    kind: 'codebox-command-log',
+    path: commandsLogPath,
+  });
+
+  return artifacts;
 }
 
 function failureClassificationForStatus(status) {
@@ -177,6 +294,9 @@ function normalizeArtifacts(result) {
         metadata: result.session.artifacts,
       });
     }
+    for (const artifact of codeboxBundleArtifacts(result)) {
+      appendUniqueArtifact(artifacts, artifact);
+    }
     return artifacts.map(artifactFromCodeboxArtifact);
   }
   const artifacts = Array.isArray(result?.artifacts)
@@ -187,7 +307,7 @@ function normalizeArtifacts(result) {
 
 function normalizeEvidenceRefs(result) {
   if (result?.schema === 'wp-codebox/agent-task-run/v1') {
-    return [
+    const refs = [
       result.session?.artifacts?.preview_url ? {
         kind: 'codebox-preview',
         uri: result.session.artifacts.preview_url,
@@ -199,6 +319,14 @@ function normalizeEvidenceRefs(result) {
         label: 'WP Codebox artifacts',
       } : null,
     ].filter(Boolean);
+    for (const artifact of codeboxBundleArtifacts(result)) {
+      appendUniqueEvidenceRef(refs, {
+        kind: artifact.kind,
+        uri: artifact.path || artifact.url,
+        label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
+      });
+    }
+    return refs;
   }
   const evidenceRefs = result?.evidence_refs || result?.evidence || [];
   return evidenceRefs.map((ref) => ({
@@ -206,6 +334,32 @@ function normalizeEvidenceRefs(result) {
     uri: ref.uri || ref.url || ref.path,
     label: ref.label || ref.name,
   })).filter((ref) => ref.uri);
+}
+
+function codeboxDecisionEvidence(result) {
+  const agentResult = result.run?.agentResult || result.agentResult || result.metadata?.recipe_run?.agentResult || result.metadata?.recipe_run?.run?.agentResult || {};
+  const completionOutcome = result.completionOutcome || result.metadata?.recipe_run?.completionOutcome || {};
+  const runtime = result.run?.runtime || result.metadata?.recipe_run?.run?.runtime || {};
+  const run = result.run || result.metadata?.recipe_run?.run || {};
+  return Object.fromEntries(Object.entries({
+    selected_backend: 'codebox',
+    selected_executor: 'wordpress.codebox-agent-task-executor',
+    capabilities_used: PROVIDER_CAPABILITIES,
+    runtime_gap_trackers: WP_CODEBOX_RUNTIME_GAP_TRACKERS,
+    run_id: run.runId,
+    run_status: run.status,
+    runtime_id: runtime.id,
+    runtime_status: runtime.status,
+    heartbeat_at: run.heartbeatAt,
+    cleanup_observed: runtime.status === 'destroyed' ? 'runtime_destroyed' : '',
+    changed_files_count: agentResult.changedFiles?.count,
+    patch_bytes: agentResult.patch?.bytes,
+    patch_sha256: agentResult.patch?.sha256,
+    no_op_reason: agentResult.noOpReason,
+    completion_status: completionOutcome.status,
+    completion_next_action: completionOutcome.nextAction,
+    confidence: completionOutcome.confidence,
+  }).filter(([, value]) => value !== undefined && value !== ''));
 }
 
 function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
@@ -228,6 +382,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
       provider: 'wordpress.codebox-agent-task-executor',
       codebox: sanitizePublicMetadata(result.metadata || result),
       upstream_dependency: 'https://github.com/Automattic/wp-codebox/issues/480',
+      decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result)),
     },
   };
   if (failureClassification) {

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -263,7 +263,7 @@ function buildRecipe(input) {
 
 function agentTaskRunFromRecipeRun(input, result, artifacts) {
   const execution = Array.isArray(result.executions) ? result.executions.find((item) => item?.recipeCommand === 'wp-codebox.agent-sandbox-run') || result.executions[0] : null;
-  const agentResult = result.run?.agentResult || result.artifacts?.agentResult || execution?.agentResult || {};
+  const agentResult = result.agentResult || result.run?.agentResult || result.artifacts?.agentResult || execution?.agentResult || {};
   const previewUrl = result.runtime?.preview?.url || result.artifacts?.preview_url || result.artifacts?.previewUrl || '';
   return {
     success: Boolean(result.success),

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -100,6 +100,15 @@ assert.equal(provider.request_schema, 'homeboy/agent-task-request/v1');
 assert.equal(provider.outcome_schema, 'homeboy/agent-task-outcome/v1');
 assert.equal(provider.upstream_dependency, 'https://github.com/Automattic/wp-codebox/issues/480');
 assert.equal(provider.capabilities.includes('browser_runtime'), true);
+assert.equal(provider.capabilities.includes('workspace_tools'), true);
+assert.equal(provider.capabilities.includes('patch_artifacts'), true);
+assert.equal(provider.capabilities.includes('cleanup_observability'), true);
+assert.deepEqual(provider.runtime_gap_trackers, [
+  'https://github.com/Automattic/wp-codebox/issues/529',
+  'https://github.com/Automattic/wp-codebox/issues/530',
+  'https://github.com/Automattic/wp-codebox/issues/531',
+  'https://github.com/Automattic/wp-codebox/issues/532',
+]);
 
 const codeboxRequest = codeboxTaskRequestFromAgentTaskRequest(request);
 assert.equal(codeboxRequest.schema, 'homeboy/wp-codebox-task-request/v1');
@@ -227,6 +236,67 @@ assert.equal(upstreamRunnerOutcome.artifacts[0].path, '/tmp/wp-codebox-artifacts
 assert.equal(upstreamRunnerOutcome.artifacts[1].kind, 'codebox-session-artifacts');
 assert.equal(upstreamRunnerOutcome.evidence_refs[0].uri, 'https://preview.example.test/sandbox-session-1');
 assert.equal(upstreamRunnerOutcome.evidence_refs[1].uri, '/tmp/wp-codebox-artifacts');
+
+const canaryRunOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  session: {
+    id: 'homeboy-codebox-canary-1042',
+    artifacts: {
+      bundle_id: 'artifact-bundle-sha256-canary',
+      preview_url: '',
+    },
+  },
+  artifacts: {
+    id: 'artifact-bundle-sha256-canary',
+    runtimeLogPath: '/tmp/canary/runtime/logs/runtime.log',
+    commandsLogPath: '/tmp/canary/runtime/logs/commands.log',
+  },
+  run: {
+    runId: 'run-canary',
+    status: 'succeeded',
+    heartbeatAt: '2026-06-03T11:19:00.998Z',
+    runtime: { id: 'runtime-canary', status: 'destroyed' },
+    artifactRefs: [{
+      kind: 'artifact-bundle',
+      directory: '/tmp/canary/runtime',
+      id: 'artifact-bundle-sha256-canary',
+      digest: { algorithm: 'sha256', value: 'canary-digest' },
+    }],
+    agentResult: {
+      summary: 'Agent sandbox completed without actionable file changes.',
+      changedFiles: { count: 0, paths: [], artifact: 'files/changed-files.json' },
+      patch: { bytes: 0, sha256: 'empty-patch-sha', artifact: 'files/patch.diff' },
+      transcript: { artifact: 'files/transcript.json', executionCount: 1 },
+      artifacts: { directory: '/tmp/canary/runtime' },
+      noOpReason: 'no_file_changes',
+    },
+  },
+  completionOutcome: {
+    status: 'partial',
+    nextAction: 'review',
+    confidence: 'medium',
+    provenance: {
+      artifactBundleId: 'artifact-bundle-sha256-canary',
+      artifactDirectory: '/tmp/canary/runtime',
+    },
+  },
+});
+assert.equal(canaryRunOutcome.status, 'no_op');
+assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'artifact-bundle' && artifact.path === '/tmp/canary/runtime'), true);
+assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-changed-files' && artifact.path === '/tmp/canary/runtime/files/changed-files.json'), true);
+assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-patch' && artifact.path === '/tmp/canary/runtime/files/patch.diff'), true);
+assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-transcript' && artifact.path === '/tmp/canary/runtime/files/transcript.json'), true);
+assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-runtime-log'), true);
+assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-command-log'), true);
+assert.equal(canaryRunOutcome.evidence_refs.some((ref) => ref.uri === '/tmp/canary/runtime/files/patch.diff'), true);
+assert.equal(canaryRunOutcome.metadata.decision_evidence.selected_backend, 'codebox');
+assert.equal(canaryRunOutcome.metadata.decision_evidence.run_id, 'run-canary');
+assert.equal(canaryRunOutcome.metadata.decision_evidence.runtime_status, 'destroyed');
+assert.equal(canaryRunOutcome.metadata.decision_evidence.cleanup_observed, 'runtime_destroyed');
+assert.equal(canaryRunOutcome.metadata.decision_evidence.no_op_reason, 'no_file_changes');
+assert.equal(canaryRunOutcome.metadata.decision_evidence.patch_bytes, 0);
+assert.equal(canaryRunOutcome.metadata.decision_evidence.runtime_gap_trackers.includes('https://github.com/Automattic/wp-codebox/issues/529'), true);
 
 const codexOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: true,

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -36,7 +36,7 @@ process.stdout.write(JSON.stringify({
   runtime: { preview: { url: 'https://preview.example.test/' + sessionId } },
   executions: [{ recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed' }) }],
   artifacts: { id: 'artifact-bundle-sha256-fixture', directory: artifacts },
-  run: { agentResult: { status: 'completed' } },
+  agentResult: { status: 'completed' },
 }));
 `);
   fs.chmodSync(binPath, mode);
@@ -137,6 +137,7 @@ try {
   assert.equal(output.success, true);
   assert.equal(output.session.id, 'homeboy-audit-fixture-session');
   assert.equal(output.artifacts, path.join(root, 'artifacts'));
+  assert.equal(output.run.agentResult.status, 'completed');
 
   const captured = readJson(capturePath);
   assert.deepEqual(captured.argv.slice(0, 4), ['recipe-run', '--recipe', captured.argv[2], '--json']);

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -30,12 +30,24 @@
       "capabilities": [
         "browser_runtime",
         "wordpress_sandbox",
+        "workspace_mounts",
+        "workspace_tools",
         "artifact_materialization",
+        "patch_artifacts",
+        "verification_artifacts",
+        "run_registry",
+        "cleanup_observability",
         "screenshots",
         "structured_outcome"
       ],
       "status": "preparatory",
-      "upstream_dependency": "https://github.com/Automattic/wp-codebox/issues/480"
+      "upstream_dependency": "https://github.com/Automattic/wp-codebox/issues/480",
+      "runtime_gap_trackers": [
+        "https://github.com/Automattic/wp-codebox/issues/529",
+        "https://github.com/Automattic/wp-codebox/issues/530",
+        "https://github.com/Automattic/wp-codebox/issues/531",
+        "https://github.com/Automattic/wp-codebox/issues/532"
+      ]
     }
   ],
   "scripts": {


### PR DESCRIPTION
## Summary
- Preserve WP Codebox agent-task run evidence in Homeboy outcomes, including bundle/log/transcript/patch artifacts, run/runtime cleanup state, heartbeat, no-op reason, and decision metadata.
- Keep the static executor provider contract aligned with runtime discovery by advertising workspace, patch, verification, run-registry, cleanup-observability capabilities and linked WP Codebox gap trackers.
- Fix the task runner adapter to preserve top-level WP Codebox `agentResult` payloads from real recipe runs.

## Verification
- `npm run test:codebox-agent-task-executor`
- `npm run test:wp-codebox-task-runner`
- `npm run test:wp-codebox-apply-adapter`
- `npm run test:codebox-agent-task-matrix`
- `npm run lint:js -- --no-warn-ignored lib/codebox-agent-task-executor.js scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/codebox-agent-task-executor-smoke.js tests/wp-codebox-task-runner-smoke.js`
- `git diff --check`
- Live bounded canary through `wordpress.codebox-agent-task-executor` using WP Codebox + OpenAI provider: outcome normalized to `status: no_op`, included `codebox-patch`, run id, runtime id, `runtime_status: destroyed`, `cleanup_observed: runtime_destroyed`, `patch_bytes: 0`, and linked WP Codebox runtime-gap trackers.
- `wp-codebox doctor --json` after canary reported `status: ok` and `recipeRunCount: 0`.

## Notes
- This does not claim the parent runtime canary is fully complete: the live run was an inspect-only no-op canary, not a patch promotion run.
- Patch artifact generation, host-tool bridge, worker status/cleanup, and resource evidence remain tracked upstream in Automattic/wp-codebox#529, #530, #531, and #532.

Refs https://github.com/Extra-Chill/homeboy-extensions/issues/1042

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the Homeboy-side Codebox outcome normalization changes, tests, docs, live canary execution, and PR description for Chris to review.