### PR TITLE
Fix Codebox timeout artifact roots from executor config

### DIFF
--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -188,8 +188,8 @@ function discoverTimeoutArtifactRefs(artifactsRoot) {
   };
 }
 
-function timeoutPayload(timeoutMs) {
-  const artifacts = argValue('--artifacts');
+function timeoutPayload(timeoutMs, request = {}) {
+  const artifacts = argValue('--artifacts') || request.executor?.config?.artifacts || '';
   const evidencePath = artifacts ? `${artifacts}/homeboy-codebox-task-runner.json` : '';
   const discovered = discoverTimeoutArtifactRefs(artifacts);
   const knownArtifacts = [];
@@ -340,7 +340,7 @@ function runTaskRunner(request) {
 
   let payload = {};
   if (result.error && result.error.code === 'ETIMEDOUT') {
-    payload = timeoutPayload(requestTimeoutMs(request));
+    payload = timeoutPayload(requestTimeoutMs(request), request);
     return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: 1 });
   }
   if (result.stdout.trim()) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -53,6 +53,27 @@ process.exit(1);
   return fixture;
 }
 
+function writeTimeoutArtifacts(artifactRoot, taskId) {
+  const bundleRoot = path.join(artifactRoot, `artifact-${taskId}`);
+  const filesRoot = path.join(bundleRoot, 'files');
+  fs.mkdirSync(filesRoot, { recursive: true });
+  fs.writeFileSync(path.join(bundleRoot, 'manifest.json'), JSON.stringify({
+    schema: 'wp-codebox/artifact-manifest/v1',
+    phase: 'agent.inspecting-runtime',
+  }));
+  fs.writeFileSync(path.join(filesRoot, 'runtime-reference-manifest.json'), JSON.stringify({
+    schema: 'wp-codebox/runtime-reference-manifest/v1',
+    runtime: { id: `runtime-${taskId}` },
+  }));
+  fs.writeFileSync(path.join(filesRoot, 'command.log'), 'ran wp-codebox.agent-sandbox-run\n');
+  fs.writeFileSync(path.join(filesRoot, 'agent-transcript.jsonl'), '{"role":"assistant","content":"partial transcript"}\n');
+  fs.writeFileSync(path.join(filesRoot, 'heartbeat.json'), JSON.stringify({
+    phase: 'agent.inspecting-runtime',
+    heartbeat: { at: '2026-06-01T00:00:00.000Z', turn: 3 },
+  }));
+  return bundleRoot;
+}
+
 const request = {
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'task-123',
@@ -330,23 +351,7 @@ try {
   assert.equal(JSON.parse(contractResult.stdout).id, 'wordpress.codebox-agent-task-executor');
 
   const artifactRoot = path.join(root, 'timeout-artifacts');
-  const bundleRoot = path.join(artifactRoot, 'artifact-task-timeout');
-  const filesRoot = path.join(bundleRoot, 'files');
-  fs.mkdirSync(filesRoot, { recursive: true });
-  fs.writeFileSync(path.join(bundleRoot, 'manifest.json'), JSON.stringify({
-    schema: 'wp-codebox/artifact-manifest/v1',
-    phase: 'agent.inspecting-runtime',
-  }));
-  fs.writeFileSync(path.join(filesRoot, 'runtime-reference-manifest.json'), JSON.stringify({
-    schema: 'wp-codebox/runtime-reference-manifest/v1',
-    runtime: { id: 'runtime-task-timeout' },
-  }));
-  fs.writeFileSync(path.join(filesRoot, 'command.log'), 'ran wp-codebox.agent-sandbox-run\n');
-  fs.writeFileSync(path.join(filesRoot, 'agent-transcript.jsonl'), '{"role":"assistant","content":"partial transcript"}\n');
-  fs.writeFileSync(path.join(filesRoot, 'heartbeat.json'), JSON.stringify({
-    phase: 'agent.inspecting-runtime',
-    heartbeat: { at: '2026-06-01T00:00:00.000Z', turn: 3 },
-  }));
+  const bundleRoot = writeTimeoutArtifacts(artifactRoot, 'task-timeout');
   const hangingRequest = {
     ...request,
     task_id: 'task-timeout',
@@ -380,6 +385,40 @@ try {
   assert.equal(timeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-command-log'), true);
   assert.equal(timeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-transcript'), true);
   assert.equal(timeoutOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-transcript'), true);
+
+  const configArtifactRoot = path.join(root, 'timeout-config-artifacts');
+  const configBundleRoot = writeTimeoutArtifacts(configArtifactRoot, 'task-timeout-config-artifacts');
+  const configArtifactRequest = {
+    ...request,
+    task_id: 'task-timeout-config-artifacts',
+    limits: { task_timeout_seconds: 1 },
+    executor: {
+      ...request.executor,
+      config: {
+        ...request.executor.config,
+        artifacts: configArtifactRoot,
+      },
+    },
+  };
+  const configArtifactTimeoutResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+    '--task-runner',
+    writeHangingTaskRunner(root),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(configArtifactRequest),
+    timeout: 3000,
+  });
+  assert.equal(configArtifactTimeoutResult.status, 1, configArtifactTimeoutResult.stderr || configArtifactTimeoutResult.stdout);
+  const configArtifactTimeoutOutcome = JSON.parse(configArtifactTimeoutResult.stdout);
+  assert.equal(configArtifactTimeoutOutcome.status, 'timeout');
+  assert.equal(configArtifactTimeoutOutcome.artifacts[0].path, configArtifactRoot);
+  assert.equal(configArtifactTimeoutOutcome.metadata.codebox.artifacts, configArtifactRoot);
+  assert.equal(configArtifactTimeoutOutcome.metadata.codebox.evidence_path, path.join(configArtifactRoot, 'homeboy-codebox-task-runner.json'));
+  assert.equal(configArtifactTimeoutOutcome.metadata.codebox.artifact_ref_count > 0, true);
+  assert.equal(configArtifactTimeoutOutcome.metadata.codebox.runtime_id, 'runtime-task-timeout-config-artifacts');
+  assert.equal(configArtifactTimeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-artifact-bundle' && artifact.path === configBundleRoot), true);
+  assert.equal(configArtifactTimeoutOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-transcript'), true);
 
   const missingSecretResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),


### PR DESCRIPTION
## Summary
- Preserve WP Codebox timeout artifact/evidence metadata when the artifact root is supplied by `executor.config.artifacts` instead of only CLI `--artifacts`.
- Extend the Codebox agent task executor smoke test with a timeout case that omits CLI `--artifacts` and relies on request config artifacts.

## Links
- Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/1044
- Parent tracker: https://github.com/Extra-Chill/homeboy/issues/3378

## Verification
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `cd wordpress && npm run test:codebox-agent-task-executor`
- `cd wordpress && npm run lint:js -- scripts/agent/homeboy-codebox-agent-task-executor.cjs lib/codebox-agent-task-executor.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the timeout artifact-root fix and smoke coverage; Chris remains responsible for review and merge.