### PR TITLE
Add Data Machine bundle agent task mode

### DIFF
--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -179,7 +179,7 @@ Provider discovery uses `homeboy/agent-task-executor-provider/v1`:
   "outcome_statuses": ["succeeded", "failed", "no_op", "unable_to_remediate", "timeout", "provider_error"],
   "failure_classifications": ["provider", "timeout", "execution_failed"],
   "redacted_metadata_keys": ["secret_env_values", "secretEnvValues", "secrets"],
-  "capabilities": ["browser_runtime", "wordpress_sandbox", "workspace_mounts", "workspace_tools", "artifact_materialization", "patch_artifacts", "verification_artifacts", "run_registry", "cleanup_observability", "screenshots", "structured_outcome"],
+  "capabilities": ["browser_runtime", "wordpress_sandbox", "workspace_mounts", "workspace_tools", "artifact_materialization", "patch_artifacts", "verification_artifacts", "run_registry", "cleanup_observability", "screenshots", "structured_outcome", "datamachine_bundle_execution"],
   "status": "preparatory",
   "upstream_dependency": "https://github.com/Automattic/wp-codebox/issues/480"
 }
@@ -279,6 +279,13 @@ select this provider through discovery, but should keep planning, scheduling,
 retry, and dashboard logic tied to the `homeboy/agent-task-request/v1` and
 `homeboy/agent-task-outcome/v1` schemas rather than Codebox recipe fields.
 
+Set `executor.config.execution_kind` to `datamachine_bundle` when the task should
+run the Data Machine workload path instead of the generic sandbox prompt path.
+The provider still emits the same `homeboy/agent-task-outcome/v1` shape, but the
+WP Codebox recipe mounts the Homeboy WordPress extension, exports
+`HOMEBOY_DATAMACHINE_AGENT_CONFIG`, and runs
+`datamachine-agent-workload.php` through the workload wrapper.
+
 The provider is intentionally marked preparatory while Codebox's upstream agent
 task runner API is still tracked in https://github.com/Automattic/wp-codebox/issues/480.
 Once that surface lands, the same provider contract can remove Homeboy-owned
@@ -334,6 +341,83 @@ with:
   model: gpt-5.5
 secrets: inherit
 ```
+
+## Agent-task plan example
+
+The same Data Machine bundle run can be expressed as a Homeboy agent-task plan,
+which lets `homeboy agent-task run-plan --plan ...` replace a bespoke workflow
+wrapper such as `wp-site-generator`'s site-generation loop:
+
+```json
+{
+  "schema": "homeboy/agent-task-plan/v1",
+  "plan_id": "site-generation-loop",
+  "tasks": [
+    {
+      "schema": "homeboy/agent-task-request/v1",
+      "task_id": "site-generation-loop/static-site-agent",
+      "group_key": "site-generation-loop",
+      "executor": {
+        "backend": "codebox",
+        "model": "gpt-5.5",
+        "config": {
+          "execution_kind": "datamachine_bundle",
+          "provider": "openai",
+          "provider_plugin_paths": ["/components/ai-provider-for-openai"],
+          "agents_api": "/components/agents-api",
+          "data_machine": "/components/data-machine",
+          "data_machine_code": "/components/data-machine-code",
+          "homeboy_extensions": "/components/homeboy-extensions/wordpress",
+          "wp_codebox_bin": "/components/wp-codebox/packages/wp-codebox/dist/cli.js",
+          "bundle_path": "bundles/static-site-agent",
+          "agent_slug": "static-site-agent",
+          "pipeline_slug": "static-site-pipeline",
+          "flow_slug": "static-site-manual-flow",
+          "target_repo": "chubes4/wp-site-generator",
+          "success_requires_pr": true,
+          "engine_data_outputs": {
+            "static_site_pr_url": "metadata.engine_data.static_site_agent.pr_url"
+          },
+          "tool_recorders": [
+            {
+              "tool": "github/create-pull-request",
+              "engine_data_path": "static_site_agent.pr_url"
+            }
+          ],
+          "pipeline_step_patches": [],
+          "flow_step_patches": [],
+          "transcript_artifact_name": "static-site-agent-transcript",
+          "replay_bundle_artifact_name": "static-site-agent-replay"
+        }
+      },
+      "instructions": "Generate the requested WordPress site and open or reuse a pull request with the materialized source.",
+      "inputs": {
+        "title": "Run static site agent"
+      },
+      "limits": {
+        "task_timeout_seconds": 1800
+      },
+      "expected_artifacts": [
+        "datamachine-transcript",
+        "datamachine-replay-bundle",
+        "datamachine-pull-request"
+      ]
+    }
+  ]
+}
+```
+
+Run it with:
+
+```bash
+homeboy agent-task run-plan --plan .homeboy/plans/site-generation-loop.json
+```
+
+For bundle repositories outside the target checkout, use `bundle_repo`,
+`bundle_ref`, and `bundle_path_in_repo` instead of a local `bundle_path`. Runtime
+stack mounts, overlays, provider plugins, tool recorders, engine-data outputs,
+artifact exports, transcript settings, and flow/pipeline step patches all remain
+provider config so Homeboy core does not need GitHub Actions-specific wiring.
 
 Generic providers should provide a full plugin object and map Data Machine option
 names to generic provider secret env names:

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -17,6 +17,51 @@ const PROVIDER_CAPABILITIES = [
   'cleanup_observability',
   'screenshots',
   'structured_outcome',
+  'datamachine_bundle_execution',
+];
+
+const DATAMACHINE_BUNDLE_CONFIG_FIELDS = [
+  'bundle_path',
+  'bundle_host_path',
+  'bundle_repo',
+  'bundle_ref',
+  'bundle_path_in_repo',
+  'agent_slug',
+  'pipeline_slug',
+  'flow_slug',
+  'target_repo',
+  'component_path',
+  'component_id',
+  'provider',
+  'model',
+  'prompt',
+  'success_requires_pr',
+  'success_completion_outcomes',
+  'pipeline_step_patches',
+  'flow_step_patches',
+  'tool_recorders',
+  'ability_tools',
+  'engine_data_outputs',
+  'engine_key',
+  'tool_results_key',
+  'artifact_export_config',
+  'transcript_artifact_name',
+  'replay_bundle_artifact_name',
+  'replay_bundle_dir',
+  'runner_workspace',
+  'fallback_pull_request',
+  'extra_required_abilities',
+  'enable_terminal_actions',
+  'enable_wp_cli_tool',
+  'wp_cli_tool_name',
+  'workload_run_before',
+  'workload_run_after',
+  'wp_codebox_mounts',
+  'extra_wp_config_defines',
+  'provider_plugin',
+  'provider_plugin_paths',
+  'step_budget',
+  'time_budget_ms',
 ];
 
 const WP_CODEBOX_RUNTIME_GAP_TRACKERS = [
@@ -83,6 +128,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   assertAgentTaskRequest(request);
   const config = request.executor.config || {};
   const inputs = request.inputs || {};
+  const executionKind = config.execution_kind || config.executionKind || config.kind || options.executionKind || 'sandbox';
+  const datamachineBundle = datamachineBundleConfigFromAgentTaskRequest(request, config, inputs);
   const timeoutSeconds = request.limits?.task_timeout_seconds || request.limits?.taskTimeoutSeconds;
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
   const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
@@ -91,6 +138,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     schema: WP_CODEBOX_TASK_REQUEST_SCHEMA,
     sandbox_session_id: config.sandbox_session_id || request.task_id,
     group_key: request.group_key,
+    execution_kind: executionKind,
     agent: config.agent || options.agent || 'wp-codebox-sandbox',
     mode: config.mode || options.mode || 'sandbox',
     provider: config.provider || options.provider || '',
@@ -106,9 +154,11 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     homeboy_extensions: config.homeboy_extensions || options.homeboyExtensions || '',
     wp_cli_bin: config.wp_cli_bin || options.wpCliBin || '',
     wp_codebox_bin: config.wp_codebox_bin || options.wpCodeboxBin || '',
+    wp_codebox_wordpress_version: config.wp_codebox_wordpress_version || config.wpCodeboxWordpressVersion || options.wpCodeboxWordpressVersion || '',
     artifacts: config.artifacts || options.artifacts || '',
     max_turns: config.max_turns || options.maxTurns,
     task_timeout_seconds: config.task_timeout_seconds || timeoutSeconds || timeoutFromMs || options.taskTimeoutSeconds,
+    datamachine_bundle: datamachineBundle,
     orchestrator: {
       ...(inputs.orchestrator || {}),
       agent_task_id: request.task_id,
@@ -125,6 +175,33 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
       inputs,
     },
   };
+}
+
+function datamachineBundleConfigFromAgentTaskRequest(request, config, inputs) {
+  const candidateSources = [
+    inputs.datamachine_bundle,
+    inputs.datamachineBundle,
+    inputs,
+    config.datamachine_bundle,
+    config.datamachineBundle,
+    config,
+  ].filter((value) => value && typeof value === 'object');
+  const bundleConfig = {};
+  for (const field of DATAMACHINE_BUNDLE_CONFIG_FIELDS) {
+    for (const source of candidateSources) {
+      if (source[field] !== undefined) {
+        bundleConfig[field] = source[field];
+        break;
+      }
+    }
+  }
+  bundleConfig.prompt = bundleConfig.prompt || request.instructions;
+  bundleConfig.provider = bundleConfig.provider || config.provider || '';
+  bundleConfig.model = bundleConfig.model || request.executor?.model || config.model || '';
+  if (!bundleConfig.provider_plugin_paths && config.provider_plugin_paths) {
+    bundleConfig.provider_plugin_paths = config.provider_plugin_paths;
+  }
+  return Object.fromEntries(Object.entries(bundleConfig).filter(([, value]) => value !== undefined && value !== ''));
 }
 
 function normalizeStatus(result, exitStatus = 0) {
@@ -322,6 +399,9 @@ function normalizeArtifacts(result) {
     for (const artifact of codeboxBundleArtifacts(result)) {
       appendUniqueArtifact(artifacts, artifact);
     }
+    for (const artifact of datamachineBundleArtifacts(result)) {
+      appendUniqueArtifact(artifacts, artifact);
+    }
     return artifacts.map(artifactFromCodeboxArtifact);
   }
   const artifacts = Array.isArray(result?.artifacts)
@@ -351,6 +431,13 @@ function normalizeEvidenceRefs(result) {
         label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
       });
     }
+    for (const artifact of datamachineBundleArtifacts(result)) {
+      appendUniqueEvidenceRef(refs, {
+        kind: artifact.kind,
+        uri: artifact.path || artifact.url,
+        label: artifact.kind.replace(/^datamachine-/, 'Data Machine ').replace(/-/g, ' '),
+      });
+    }
     return refs;
   }
   const evidenceRefs = result?.evidence_refs || result?.evidence || [];
@@ -359,6 +446,53 @@ function normalizeEvidenceRefs(result) {
     uri: ref.uri || ref.url || ref.path,
     label: ref.label || ref.name,
   })).filter((ref) => ref.uri);
+}
+
+function datamachineBundleArtifacts(result) {
+  const artifacts = [];
+  const workload = result.metadata?.datamachine?.workload || result.run?.agentResult || result.agentResult || {};
+  const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
+  for (const scenario of scenarios) {
+    const metadata = scenario?.metadata || {};
+    const transcript = metadata.transcript_artifacts || {};
+    appendUniqueArtifact(artifacts, {
+      id: transcript.json ? 'datamachine-transcript-json' : '',
+      kind: 'datamachine-transcript',
+      path: transcript.json,
+      metadata: { scenario_id: scenario.id, format: 'json' },
+    });
+    appendUniqueArtifact(artifacts, {
+      id: transcript.summary ? 'datamachine-transcript-summary' : '',
+      kind: 'datamachine-transcript-summary',
+      path: transcript.summary,
+      metadata: { scenario_id: scenario.id, format: 'markdown' },
+    });
+    const replayBundlePath = metadata.replay_bundle_path || metadata.replay_bundle?.path;
+    appendUniqueArtifact(artifacts, {
+      id: replayBundlePath ? 'datamachine-replay-bundle' : '',
+      kind: 'datamachine-replay-bundle',
+      path: replayBundlePath,
+      metadata: { scenario_id: scenario.id },
+    });
+    const exports = Array.isArray(metadata.job_artifact_exports) ? metadata.job_artifact_exports : [];
+    for (const [index, exported] of exports.entries()) {
+      appendUniqueArtifact(artifacts, {
+        id: exported.id || exported.path || `datamachine-job-artifact-${index + 1}`,
+        kind: exported.kind || 'datamachine-job-artifact',
+        path: exported.path,
+        url: exported.url,
+        metadata: { ...exported, scenario_id: scenario.id },
+      });
+    }
+    const pullRequestUrl = metadata.fallback_pull_request?.url || metadata.engine_data?.pull_request?.url || metadata.engine_data?.static_site_agent?.pr_url;
+    appendUniqueArtifact(artifacts, {
+      id: pullRequestUrl ? 'datamachine-pull-request' : '',
+      kind: 'datamachine-pull-request',
+      url: pullRequestUrl,
+      metadata: { scenario_id: scenario.id },
+    });
+  }
+  return artifacts;
 }
 
 function codeboxDecisionEvidence(result) {

--- a/wordpress/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php
+++ b/wordpress/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Echoes the Data Machine workload return value for WP Codebox code-file runs.
+ */
+
+$homeboy_workload_result = require __DIR__ . '/datamachine-agent-workload.php';
+echo wp_json_encode( is_array( $homeboy_workload_result ) ? $homeboy_workload_result : array() );

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -156,6 +156,7 @@ function writePreflightEvidence(artifacts, evidence) {
 function runnerInput(request, artifacts) {
   return Object.fromEntries(Object.entries({
     parent_request: request,
+    execution_kind: request.execution_kind || 'sandbox',
     agent: argValue('--agent') || request.agent || 'wp-codebox-sandbox',
     mode: argValue('--mode') || request.mode || 'sandbox',
     provider: argValue('--provider') || request.provider || '',
@@ -174,6 +175,10 @@ function runnerInput(request, artifacts) {
     agents_api_path: argValue('--agents-api') || request.agents_api || '',
     data_machine_path: argValue('--data-machine') || request.data_machine || '',
     data_machine_code_path: argValue('--data-machine-code') || request.data_machine_code || '',
+    homeboy_path: argValue('--homeboy') || request.homeboy || '',
+    homeboy_extensions_path: argValue('--homeboy-extensions') || request.homeboy_extensions || path.resolve(__dirname, '..', '..'),
+    wp_version: request.wp_codebox_wordpress_version || request.wp_version || request.wp || undefined,
+    datamachine_bundle: request.datamachine_bundle || {},
   }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
 }
 
@@ -206,6 +211,43 @@ function workspaceMounts(request) {
   }];
 }
 
+function datamachineBundleMount(input) {
+  const bundle = input.datamachine_bundle || {};
+  const source = bundle.bundle_host_path || bundle.bundle_path || '';
+  if (!source || !fs.existsSync(source)) {
+    return { mounts: [], config: bundle };
+  }
+  const slug = slugFromPath(source, 'datamachine-bundle');
+  const target = bundle.bundle_path && !fs.existsSync(bundle.bundle_path)
+    ? bundle.bundle_path
+    : `/wordpress/wp-content/plugins/${slug}`;
+  return {
+    mounts: [{
+      source,
+      target,
+      mode: 'readonly',
+      metadata: { kind: 'homeboy-datamachine-bundle', slug },
+    }],
+    config: {
+      ...bundle,
+      bundle_path: target,
+      bundle_host_path: source,
+    },
+  };
+}
+
+function homeboyExtensionMount(input) {
+  if (!input.homeboy_extensions_path) {
+    return [];
+  }
+  return [{
+    source: input.homeboy_extensions_path,
+    target: '/homeboy-extension',
+    mode: 'readonly',
+    metadata: { kind: 'homeboy-extension-runtime' },
+  }];
+}
+
 function providerPluginSpecs(input) {
   return (input.provider_plugin_paths || []).map((source) => extraPlugin(source, slugFromPath(source, 'provider'), false)).filter(Boolean);
 }
@@ -213,15 +255,21 @@ function providerPluginSpecs(input) {
 function buildRecipe(input) {
   const providerPlugins = providerPluginSpecs(input);
   const providerSlugs = providerPlugins.map((plugin) => plugin.slug);
+  const isDatamachineBundle = input.execution_kind === 'datamachine_bundle' || input.execution_kind === 'datamachine-bundle';
+  const bundleMount = datamachineBundleMount(input);
+  const datamachineConfig = datamachineBundleConfig(input, bundleMount.config);
   const task = input.parent_request?.task || {};
   const workflowArgs = [
-    `task=${task.prompt || ''}`,
+    `task=${isDatamachineBundle ? (datamachineConfig.workload_label || task.title || 'Run Data Machine agent bundle') : (task.prompt || '')}`,
     `agent=${input.agent || 'wp-codebox-sandbox'}`,
     `mode=${input.mode || 'sandbox'}`,
     `provider=${input.provider || ''}`,
     `model=${input.model || ''}`,
     `provider-plugin-slugs=${providerSlugs.join(',')}`,
   ];
+  if (isDatamachineBundle) {
+    workflowArgs.push('code-file=/homeboy-extension/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php');
+  }
   if (input.sandbox_session_id) {
     workflowArgs.push(`session-id=${input.sandbox_session_id}`);
   }
@@ -242,11 +290,17 @@ function buildRecipe(input) {
       overlays: input.runtime_overlays?.length ? input.runtime_overlays : undefined,
     }).filter(([, value]) => value !== undefined)),
     inputs: Object.fromEntries(Object.entries({
-      mounts: [...(input.mounts || []), ...workspaceMounts(input.parent_request || {})],
+      mounts: [
+        ...(input.mounts || []),
+        ...workspaceMounts(input.parent_request || {}),
+        ...(isDatamachineBundle ? homeboyExtensionMount(input) : []),
+        ...(isDatamachineBundle ? bundleMount.mounts : []),
+      ],
       extraPlugins: [
         extraPlugin(input.agents_api_path, 'agents-api'),
         extraPlugin(input.data_machine_path, 'data-machine'),
         extraPlugin(input.data_machine_code_path, 'data-machine-code'),
+        extraPlugin(input.homeboy_path, 'homeboy'),
         ...providerPlugins,
       ].filter(Boolean),
       secretEnv: input.secret_env || [],
@@ -258,12 +312,32 @@ function buildRecipe(input) {
       directory: input.artifacts_path,
       verify: { enabled: true },
     },
+    metadata: isDatamachineBundle ? { datamachine_bundle: datamachineConfig } : undefined,
   };
+}
+
+function datamachineBundleConfig(input, bundleConfig = {}) {
+  return Object.fromEntries(Object.entries({
+    ...bundleConfig,
+    prompt: bundleConfig.prompt || input.parent_request?.task?.prompt || '',
+    provider: bundleConfig.provider || input.provider || '',
+    model: bundleConfig.model || input.model || '',
+    provider_plugin_paths: bundleConfig.provider_plugin_paths || input.provider_plugin_paths || [],
+    wp_codebox_artifacts_dir: input.artifacts_path,
+    wp_codebox_components: {
+      agents_api: input.agents_api_path,
+      data_machine: input.data_machine_path,
+      data_machine_code: input.data_machine_code_path,
+    },
+  }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
 }
 
 function agentTaskRunFromRecipeRun(input, result, artifacts) {
   const execution = Array.isArray(result.executions) ? result.executions.find((item) => item?.recipeCommand === 'wp-codebox.agent-sandbox-run') || result.executions[0] : null;
   const agentResult = result.agentResult || result.run?.agentResult || result.artifacts?.agentResult || execution?.agentResult || {};
+  const datamachineConfig = input.execution_kind === 'datamachine_bundle' || input.execution_kind === 'datamachine-bundle'
+    ? datamachineBundleConfig(input, datamachineBundleMount(input).config)
+    : null;
   const previewUrl = result.runtime?.preview?.url || result.artifacts?.preview_url || result.artifacts?.previewUrl || '';
   return {
     success: Boolean(result.success),
@@ -293,9 +367,24 @@ function agentTaskRunFromRecipeRun(input, result, artifacts) {
     artifacts,
     exit_code: result.success ? 0 : 1,
     run: { ...result.run, agentResult },
-    diagnostics: result.diagnostics || (result.error ? [{ class: result.error.code || 'wp-codebox.recipe-run', message: result.error.message || String(result.error), data: result.error }] : []),
-    metadata: { recipe_run: result },
+    diagnostics: result.diagnostics || datamachineDiagnostics(agentResult) || (result.error ? [{ class: result.error.code || 'wp-codebox.recipe-run', message: result.error.message || String(result.error), data: result.error }] : []),
+    metadata: {
+      recipe_run: result,
+      ...(datamachineConfig ? { datamachine: { bundle: datamachineConfig, workload: agentResult } } : {}),
+    },
   };
+}
+
+function datamachineDiagnostics(workload) {
+  const scenarios = Array.isArray(workload?.scenarios) ? workload.scenarios : [];
+  const diagnostics = scenarios
+    .filter((scenario) => scenario?.metadata?.error || scenario?.metadata?.error_message)
+    .map((scenario) => ({
+      class: 'datamachine.workload',
+      message: scenario.metadata.error || scenario.metadata.error_message,
+      data: { scenario_id: scenario.id, metadata: scenario.metadata },
+    }));
+  return diagnostics.length > 0 ? diagnostics : null;
 }
 
 function timeoutPayload(timeoutMs, artifacts, evidencePath, inputPath, command, args) {
@@ -366,7 +455,12 @@ function runWpCodeboxParentTask(request) {
 
   const result = spawnSync(resolved.command, resolved.args, {
     encoding: 'utf8',
-    env: process.env,
+    env: {
+      ...process.env,
+      ...(input.execution_kind === 'datamachine_bundle' || input.execution_kind === 'datamachine-bundle'
+        ? { HOMEBOY_DATAMACHINE_AGENT_CONFIG: JSON.stringify(datamachineBundleConfig(input, datamachineBundleMount(input).config)) }
+        : {}),
+    },
     maxBuffer: 1024 * 1024 * 20,
     timeout: timeoutMs,
   });

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -53,6 +53,46 @@ process.exit(1);
   return fixture;
 }
 
+function writeFakeWpCodebox(root) {
+  const fixture = path.join(root, 'fake-wp-codebox.cjs');
+  const capture = path.join(root, 'fake-wp-codebox-capture.json');
+  fs.writeFileSync(fixture, `#!/usr/bin/env node
+'use strict';
+const fs = require('node:fs');
+const recipePath = process.argv[process.argv.indexOf('--recipe') + 1];
+const artifacts = process.argv[process.argv.indexOf('--artifacts') + 1];
+const recipe = JSON.parse(fs.readFileSync(recipePath, 'utf8'));
+const datamachineConfig = JSON.parse(process.env.HOMEBOY_DATAMACHINE_AGENT_CONFIG || '{}');
+fs.writeFileSync(${JSON.stringify(capture)}, JSON.stringify({ argv: process.argv.slice(2), recipe, datamachineConfig }, null, 2));
+process.stdout.write(JSON.stringify({
+  success: true,
+  executions: [{
+    recipeCommand: 'wp-codebox.agent-sandbox-run',
+    agentResult: {
+      scenarios: [{
+        id: 'datamachine-agent',
+        metadata: {
+          transcript_artifacts: { json: artifacts + '/transcript.json' },
+          replay_bundle_path: artifacts + '/replay-bundle',
+          engine_data: { static_site_agent: { pr_url: 'https://github.com/chubes4/wp-site-generator/pull/123' } }
+        }
+      }]
+    }
+  }],
+  artifacts: { id: 'fake-artifact-bundle', directory: artifacts }
+}));
+`);
+  fs.chmodSync(fixture, 0o755);
+  return { fixture, capture };
+}
+
+function writeBundleFixture(root) {
+  const bundle = path.join(root, 'static-site-agent');
+  fs.mkdirSync(bundle, { recursive: true });
+  fs.writeFileSync(path.join(bundle, 'manifest.json'), '{}\n');
+  return bundle;
+}
+
 function writeTimeoutArtifacts(artifactRoot, taskId) {
   const bundleRoot = path.join(artifactRoot, `artifact-${taskId}`);
   const filesRoot = path.join(bundleRoot, 'files');
@@ -128,6 +168,7 @@ assert.equal(provider.capabilities.includes('browser_runtime'), true);
 assert.equal(provider.capabilities.includes('workspace_tools'), true);
 assert.equal(provider.capabilities.includes('patch_artifacts'), true);
 assert.equal(provider.capabilities.includes('cleanup_observability'), true);
+assert.equal(provider.capabilities.includes('datamachine_bundle_execution'), true);
 assert.deepEqual(provider.runtime_gap_trackers, [
   'https://github.com/Automattic/wp-codebox/issues/529',
   'https://github.com/Automattic/wp-codebox/issues/530',
@@ -138,6 +179,7 @@ assert.deepEqual(provider.runtime_gap_trackers, [
 const codeboxRequest = codeboxTaskRequestFromAgentTaskRequest(request);
 assert.equal(codeboxRequest.schema, 'homeboy/wp-codebox-task-request/v1');
 assert.equal(codeboxRequest.sandbox_session_id, 'task-123');
+assert.equal(codeboxRequest.execution_kind, 'sandbox');
 assert.equal(codeboxRequest.provider, 'openai');
 assert.equal(codeboxRequest.model, 'gpt-5.5');
 assert.deepEqual(codeboxRequest.provider_plugin_paths, ['/providers/openai']);
@@ -230,6 +272,46 @@ assert.equal(codeboxTaskRequestFromAgentTaskRequest({
   limits: { task_timeout_seconds: 7 },
 }).task_timeout_seconds, 7);
 
+const datamachineBundleRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'datamachine-task-123',
+  executor: {
+    backend: 'codebox',
+    model: 'gpt-5.5',
+    config: {
+      execution_kind: 'datamachine_bundle',
+      provider: 'openai',
+      provider_plugin_paths: ['/components/ai-provider-for-openai'],
+      agents_api: '/components/agents-api',
+      data_machine: '/components/data-machine',
+      data_machine_code: '/components/data-machine-code',
+      homeboy_extensions: '/components/homeboy-extensions/wordpress',
+      bundle_path: '/bundles/static-site-agent',
+      agent_slug: 'static-site-agent',
+      pipeline_slug: 'static-site-pipeline',
+      flow_slug: 'static-site-manual-flow',
+      target_repo: 'chubes4/wp-site-generator',
+      pipeline_step_patches: [{ slug: 'generate', config: { max_turns: 4 } }],
+      flow_step_patches: [{ slug: 'run-pipeline', config: { step_budget: 12 } }],
+      tool_recorders: [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }],
+      engine_data_outputs: { static_site_pr_url: 'metadata.engine_data.static_site_agent.pr_url' },
+      transcript_artifact_name: 'static-site-agent-transcript',
+      replay_bundle_artifact_name: 'static-site-agent-replay',
+      runner_workspace: { handle: 'wp-site-generator@site-loop', expose_to_agent: false },
+    },
+  },
+});
+assert.equal(datamachineBundleRequest.execution_kind, 'datamachine_bundle');
+assert.equal(datamachineBundleRequest.datamachine_bundle.bundle_path, '/bundles/static-site-agent');
+assert.equal(datamachineBundleRequest.datamachine_bundle.agent_slug, 'static-site-agent');
+assert.equal(datamachineBundleRequest.datamachine_bundle.pipeline_slug, 'static-site-pipeline');
+assert.equal(datamachineBundleRequest.datamachine_bundle.flow_slug, 'static-site-manual-flow');
+assert.deepEqual(datamachineBundleRequest.datamachine_bundle.pipeline_step_patches, [{ slug: 'generate', config: { max_turns: 4 } }]);
+assert.deepEqual(datamachineBundleRequest.datamachine_bundle.flow_step_patches, [{ slug: 'run-pipeline', config: { step_budget: 12 } }]);
+assert.deepEqual(datamachineBundleRequest.datamachine_bundle.tool_recorders, [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }]);
+assert.deepEqual(datamachineBundleRequest.datamachine_bundle.engine_data_outputs, { static_site_pr_url: 'metadata.engine_data.static_site_agent.pr_url' });
+assert.equal(datamachineBundleRequest.homeboy_extensions, '/components/homeboy-extensions/wordpress');
+
 const outcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: false,
   provider_error: true,
@@ -258,6 +340,36 @@ const upstreamRunnerOutcome = agentTaskOutcomeFromCodeboxResult(request, {
 assert.equal(upstreamRunnerOutcome.status, 'succeeded');
 assert.equal(upstreamRunnerOutcome.artifacts[0].kind, 'codebox-artifact-directory');
 assert.equal(upstreamRunnerOutcome.artifacts[0].path, '/tmp/wp-codebox-artifacts');
+
+const datamachineOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  task_id: 'datamachine-task-123',
+  executor: { backend: 'codebox' },
+}, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  artifacts: '/tmp/wp-codebox-artifacts',
+  metadata: {
+    datamachine: {
+      bundle: datamachineBundleRequest.datamachine_bundle,
+      workload: {
+        scenarios: [{
+          id: 'datamachine-agent',
+          metadata: {
+            transcript_artifacts: { json: '/tmp/transcript.json', summary: '/tmp/transcript.md' },
+            replay_bundle_path: '/tmp/replay-bundle',
+            engine_data: { static_site_agent: { pr_url: 'https://github.com/chubes4/wp-site-generator/pull/123' } },
+          },
+        }],
+      },
+    },
+  },
+});
+assert.equal(datamachineOutcome.schema, 'homeboy/agent-task-outcome/v1');
+assert.equal(datamachineOutcome.status, 'succeeded');
+assert.equal(datamachineOutcome.artifacts.some((artifact) => artifact.kind === 'datamachine-transcript' && artifact.path === '/tmp/transcript.json'), true);
+assert.equal(datamachineOutcome.artifacts.some((artifact) => artifact.kind === 'datamachine-replay-bundle' && artifact.path === '/tmp/replay-bundle'), true);
+assert.equal(datamachineOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/123'), true);
 assert.equal(upstreamRunnerOutcome.artifacts[1].kind, 'codebox-session-artifacts');
 assert.equal(upstreamRunnerOutcome.evidence_refs[0].uri, 'https://preview.example.test/sandbox-session-1');
 assert.equal(upstreamRunnerOutcome.evidence_refs[1].uri, '/tmp/wp-codebox-artifacts');
@@ -416,6 +528,54 @@ try {
     'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
   ]);
   assert(!JSON.stringify(capturedCodex).includes('wp-ai-gateway'));
+
+  const datamachineRoot = fs.mkdtempSync(path.join(root, 'datamachine-bundle-'));
+  const bundle = writeBundleFixture(datamachineRoot);
+  const { fixture: fakeWpCodebox, capture: fakeWpCodeboxCapture } = writeFakeWpCodebox(datamachineRoot);
+  const datamachineCliRequest = {
+    ...request,
+    task_id: 'datamachine-cli-task-123',
+    executor: {
+      backend: 'codebox',
+      model: 'gpt-5.5',
+      config: {
+        execution_kind: 'datamachine_bundle',
+        provider: 'openai',
+        provider_plugin_paths: ['/components/ai-provider-for-openai'],
+        agents_api: '/components/agents-api',
+        data_machine: '/components/data-machine',
+        data_machine_code: '/components/data-machine-code',
+        homeboy_extensions: path.join(__dirname, '..'),
+        wp_codebox_bin: fakeWpCodebox,
+        bundle_path: bundle,
+        agent_slug: 'static-site-agent',
+        pipeline_slug: 'static-site-pipeline',
+        flow_slug: 'static-site-manual-flow',
+        tool_recorders: [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }],
+        engine_data_outputs: { static_site_pr_url: 'metadata.engine_data.static_site_agent.pr_url' },
+      },
+    },
+  };
+  const datamachineCliResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(datamachineCliRequest),
+  });
+  assert.equal(datamachineCliResult.status, 0, datamachineCliResult.stderr || datamachineCliResult.stdout);
+  const datamachineCliOutcome = JSON.parse(datamachineCliResult.stdout);
+  assert.equal(datamachineCliOutcome.status, 'succeeded');
+  assert.equal(datamachineCliOutcome.artifacts.some((artifact) => artifact.kind === 'datamachine-transcript'), true);
+  assert.equal(datamachineCliOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/123'), true);
+  const capturedDatamachineRun = JSON.parse(fs.readFileSync(fakeWpCodeboxCapture, 'utf8'));
+  assert.equal(capturedDatamachineRun.recipe.workflow.steps[0].command, 'wp-codebox.agent-sandbox-run');
+  assert.equal(capturedDatamachineRun.recipe.workflow.steps[0].args.includes('code-file=/homeboy-extension/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php'), true);
+  assert.equal(capturedDatamachineRun.recipe.inputs.mounts.some((mount) => mount.target === '/homeboy-extension'), true);
+  assert.equal(capturedDatamachineRun.recipe.inputs.mounts.some((mount) => mount.target === '/wordpress/wp-content/plugins/static-site-agent'), true);
+  assert.equal(capturedDatamachineRun.datamachineConfig.bundle_path, '/wordpress/wp-content/plugins/static-site-agent');
+  assert.equal(capturedDatamachineRun.datamachineConfig.agent_slug, 'static-site-agent');
+  assert.equal(capturedDatamachineRun.datamachineConfig.pipeline_slug, 'static-site-pipeline');
+  assert.deepEqual(capturedDatamachineRun.datamachineConfig.tool_recorders, [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }]);
 
   const contractResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),


### PR DESCRIPTION
## Summary
- Adds `datamachine_bundle` execution mode to the WordPress Codebox agent-task provider while preserving the existing generic sandbox path.
- Translates Data Machine bundle config into WP Codebox workload recipe mounts/env and normalizes transcript, replay bundle, PR, diagnostics, and artifact evidence into `homeboy/agent-task-outcome/v1`.
- Adds smoke coverage for request translation, fake Codebox recipe execution, artifact normalization, and documents a `homeboy agent-task run-plan --plan ...` replacement shape.

Fixes #1049.

## Verification
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/codebox-agent-task-matrix-smoke.js`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php`
- `node --check wordpress/lib/codebox-agent-task-executor.js && node --check wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs && node --check wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs`
- `npx eslint lib/codebox-agent-task-executor.js scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/codebox-agent-task-executor-smoke.js --no-warn-ignored` from `wordpress/`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the provider translation, recipe-mode wiring, smoke tests, and documentation. Chris remains responsible for review and merge.