### PR TITLE
Prepare Composer-backed Codebox plugins

### DIFF
--- a/wordpress/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php
+++ b/wordpress/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php
@@ -3,5 +3,5 @@
  * Echoes the Data Machine workload return value for WP Codebox code-file runs.
  */
 
-$homeboy_workload_result = require __DIR__ . '/datamachine-agent-workload.php';
+$homeboy_workload_result = require '/homeboy-extension/scripts/agent/datamachine-agent-workload.php';
 echo wp_json_encode( is_array( $homeboy_workload_result ) ? $homeboy_workload_result : array() );

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -187,11 +187,50 @@ function slugFromPath(filePath, fallback) {
   return (base.split('@')[0] || fallback).replace(/[^A-Za-z0-9_-]/g, '-');
 }
 
-function extraPlugin(source, slug, activate = true) {
+function copyFilter(source) {
+  const base = path.basename(source);
+  return base !== '.git' && base !== 'node_modules' && base !== 'vendor';
+}
+
+function prepareComposerPluginSource(source, slug, artifactsRoot) {
+  if (!source || !fs.existsSync(source) || !fs.existsSync(path.join(source, 'composer.json')) || fs.existsSync(path.join(source, 'vendor', 'autoload.php'))) {
+    return source;
+  }
+  if (!artifactsRoot) {
+    throw new Error(`Plugin ${slug} requires Composer dependencies but no artifacts directory is available for staging.`);
+  }
+
+  const preparedRoot = path.join(artifactsRoot, 'prepared-plugins');
+  const preparedSource = path.join(preparedRoot, slug);
+  fs.rmSync(preparedSource, { recursive: true, force: true });
+  fs.mkdirSync(preparedRoot, { recursive: true });
+  fs.cpSync(source, preparedSource, { recursive: true, filter: copyFilter });
+
+  const result = spawnSync('composer', ['install', '--no-interaction', '--prefer-dist', '--no-progress'], {
+    cwd: preparedSource,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.status !== 0) {
+    throw new Error(`Composer install failed for plugin ${slug}: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  }
+  if (!fs.existsSync(path.join(preparedSource, 'vendor', 'autoload.php'))) {
+    throw new Error(`Composer install for plugin ${slug} did not create vendor/autoload.php.`);
+  }
+
+  return preparedSource;
+}
+
+function extraPlugin(source, slug, activate = true, options = {}) {
   if (!source) {
     return null;
   }
-  return { source, slug: slug || slugFromPath(source, 'plugin'), activate };
+  const pluginSlug = slug || slugFromPath(source, 'plugin');
+  return {
+    source: prepareComposerPluginSource(source, pluginSlug, options.artifactsRoot || ''),
+    slug: pluginSlug,
+    activate,
+  };
 }
 
 function workspaceMounts(request) {
@@ -249,7 +288,7 @@ function homeboyExtensionMount(input) {
 }
 
 function providerPluginSpecs(input) {
-  return (input.provider_plugin_paths || []).map((source) => extraPlugin(source, slugFromPath(source, 'provider'), false)).filter(Boolean);
+  return (input.provider_plugin_paths || []).map((source) => extraPlugin(source, slugFromPath(source, 'provider'), false, { artifactsRoot: input.artifacts_path })).filter(Boolean);
 }
 
 function buildRecipe(input) {
@@ -297,10 +336,10 @@ function buildRecipe(input) {
         ...(isDatamachineBundle ? bundleMount.mounts : []),
       ],
       extraPlugins: [
-        extraPlugin(input.agents_api_path, 'agents-api'),
-        extraPlugin(input.data_machine_path, 'data-machine'),
-        extraPlugin(input.data_machine_code_path, 'data-machine-code'),
-        extraPlugin(input.homeboy_path, 'homeboy'),
+        extraPlugin(input.agents_api_path, 'agents-api', true, { artifactsRoot: input.artifacts_path }),
+        extraPlugin(input.data_machine_path, 'data-machine', true, { artifactsRoot: input.artifacts_path }),
+        extraPlugin(input.data_machine_code_path, 'data-machine-code', true, { artifactsRoot: input.artifacts_path }),
+        extraPlugin(input.homeboy_path, 'homeboy', true, { artifactsRoot: input.artifacts_path }),
         ...providerPlugins,
       ].filter(Boolean),
       secretEnv: input.secret_env || [],

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -307,7 +307,7 @@ function buildRecipe(input) {
     `provider-plugin-slugs=${providerSlugs.join(',')}`,
   ];
   if (isDatamachineBundle) {
-    workflowArgs.push('code-file=/homeboy-extension/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php');
+    workflowArgs.push(`code-file=${path.join(input.homeboy_extensions_path, 'scripts', 'agent', 'homeboy-datamachine-agent-workload-wrapper.php')}`);
   }
   if (input.sandbox_session_id) {
     workflowArgs.push(`session-id=${input.sandbox_session_id}`);

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -270,6 +270,7 @@ try {
   const composerRecipe = readJson(composerCapturePath).recipe;
   const codeFileArg = composerRecipe.workflow.steps[0].args.find((arg) => arg.startsWith('code-file='));
   assert.equal(codeFileArg, `code-file=${path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-datamachine-agent-workload-wrapper.php')}`);
+  assert.match(fs.readFileSync(codeFileArg.slice('code-file='.length), 'utf8'), /\/homeboy-extension\/scripts\/agent\/datamachine-agent-workload\.php/);
   const preparedDataMachine = composerRecipe.inputs.extraPlugins.find((plugin) => plugin.slug === 'data-machine');
   assert.notEqual(preparedDataMachine.source, composerPluginPath);
   assert(pathInside(path.join(root, 'composer-artifacts', 'prepared-plugins'), fs.realpathSync(preparedDataMachine.source)));

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -43,6 +43,22 @@ process.stdout.write(JSON.stringify({
   return binPath;
 }
 
+function createFixtureComposer(root) {
+  const binDir = path.join(root, 'bin');
+  const binPath = path.join(binDir, 'composer');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(binPath, `#!/usr/bin/env node
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+fs.mkdirSync(path.join(process.cwd(), 'vendor'), { recursive: true });
+fs.writeFileSync(path.join(process.cwd(), 'vendor', 'autoload.php'), '<?php // fixture autoload');
+process.stdout.write('fixture composer install\\n');
+`);
+  fs.chmodSync(binPath, 0o755);
+  return binDir;
+}
+
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-task-runner-'));
 
 try {
@@ -220,6 +236,37 @@ try {
   assert(!serializedCodexRecipe.includes('access-token-value'));
   assert(!serializedCodexRecipe.includes('refresh-token-value'));
   assert(!serializedCodexRecipe.includes('wp-ai-gateway'));
+
+  const composerCapturePath = path.join(root, 'capture-composer.json');
+  const composerPluginPath = path.join(root, 'data-machine-with-composer');
+  fs.mkdirSync(composerPluginPath, { recursive: true });
+  fs.writeFileSync(path.join(composerPluginPath, 'composer.json'), JSON.stringify({ name: 'fixture/data-machine' }));
+  fs.writeFileSync(path.join(composerPluginPath, 'data-machine.php'), '<?php require __DIR__ . "/vendor/autoload.php";');
+  const composerResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin',
+    fixtureWpCodebox,
+    '--data-machine',
+    composerPluginPath,
+    '--artifacts',
+    path.join(root, 'composer-artifacts'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({ ...request, provider_plugin_paths: [] }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: composerCapturePath,
+      PATH: `${createFixtureComposer(root)}${path.delimiter}${process.env.PATH}`,
+      OPENCODE_API_KEY: 'redacted-test-key',
+    },
+  });
+  assert.equal(composerResult.status, 0, composerResult.stderr || composerResult.stdout);
+  const composerRecipe = readJson(composerCapturePath).recipe;
+  const preparedDataMachine = composerRecipe.inputs.extraPlugins.find((plugin) => plugin.slug === 'data-machine');
+  assert.notEqual(preparedDataMachine.source, composerPluginPath);
+  assert(pathInside(path.join(root, 'composer-artifacts', 'prepared-plugins'), fs.realpathSync(preparedDataMachine.source)));
+  assert(fs.existsSync(path.join(preparedDataMachine.source, 'vendor', 'autoload.php')));
+  assert(!fs.existsSync(path.join(composerPluginPath, 'vendor', 'autoload.php')));
 
   const nonExecutableCapturePath = path.join(root, 'capture-non-executable.json');
   const nonExecutableFixture = createFixtureWpCodebox(root, 0o644);

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -252,7 +252,13 @@ try {
     path.join(root, 'composer-artifacts'),
   ], {
     encoding: 'utf8',
-    input: JSON.stringify({ ...request, provider_plugin_paths: [] }),
+    input: JSON.stringify({
+      ...request,
+      execution_kind: 'datamachine_bundle',
+      homeboy_extensions: path.join(__dirname, '..'),
+      datamachine_bundle: { bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent' },
+      provider_plugin_paths: [],
+    }),
     env: {
       ...process.env,
       FIXTURE_WP_CODEBOX_CAPTURE: composerCapturePath,
@@ -262,6 +268,8 @@ try {
   });
   assert.equal(composerResult.status, 0, composerResult.stderr || composerResult.stdout);
   const composerRecipe = readJson(composerCapturePath).recipe;
+  const codeFileArg = composerRecipe.workflow.steps[0].args.find((arg) => arg.startsWith('code-file='));
+  assert.equal(codeFileArg, `code-file=${path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-datamachine-agent-workload-wrapper.php')}`);
   const preparedDataMachine = composerRecipe.inputs.extraPlugins.find((plugin) => plugin.slug === 'data-machine');
   assert.notEqual(preparedDataMachine.source, composerPluginPath);
   assert(pathInside(path.join(root, 'composer-artifacts', 'prepared-plugins'), fs.realpathSync(preparedDataMachine.source)));


### PR DESCRIPTION
## Summary
- Stage WP Codebox plugin sources that require Composer dependencies before recipe execution.
- Run `composer install` in the staged copy so Data Machine bundle tasks mount plugins with `vendor/autoload.php` without mutating source checkouts.
- Add smoke coverage for Composer-backed plugin preparation.

## Testing
- `npm run test:wp-codebox-task-runner`
- `npx eslint scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/wp-codebox-task-runner-smoke.js` (test file is ignored by config; runner file linted with no errors)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner change, smoke test, and validation commands for Chris to review.