### PR TITLE
Fix Data Machine bundle config in Codebox runner

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -297,6 +297,7 @@ function buildRecipe(input) {
   const isDatamachineBundle = input.execution_kind === 'datamachine_bundle' || input.execution_kind === 'datamachine-bundle';
   const bundleMount = datamachineBundleMount(input);
   const datamachineConfig = datamachineBundleConfig(input, bundleMount.config);
+  const secretEnv = input.secret_env || [];
   const task = input.parent_request?.task || {};
   const workflowArgs = [
     `task=${isDatamachineBundle ? (datamachineConfig.workload_label || task.title || 'Run Data Machine agent bundle') : (task.prompt || '')}`,
@@ -307,7 +308,7 @@ function buildRecipe(input) {
     `provider-plugin-slugs=${providerSlugs.join(',')}`,
   ];
   if (isDatamachineBundle) {
-    workflowArgs.push(`code-file=${path.join(input.homeboy_extensions_path, 'scripts', 'agent', 'homeboy-datamachine-agent-workload-wrapper.php')}`);
+    workflowArgs.push('code-file=/homeboy-extension/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php');
   }
   if (input.sandbox_session_id) {
     workflowArgs.push(`session-id=${input.sandbox_session_id}`);
@@ -342,7 +343,7 @@ function buildRecipe(input) {
         extraPlugin(input.homeboy_path, 'homeboy', true, { artifactsRoot: input.artifacts_path }),
         ...providerPlugins,
       ].filter(Boolean),
-      secretEnv: input.secret_env || [],
+      secretEnv: isDatamachineBundle ? Array.from(new Set([...secretEnv, 'HOMEBOY_DATAMACHINE_AGENT_CONFIG'])) : secretEnv,
     }).filter(([, value]) => !(Array.isArray(value) && value.length === 0))),
     workflow: {
       steps: [{ command: 'wp-codebox.agent-sandbox-run', args: workflowArgs }],
@@ -378,14 +379,16 @@ function agentTaskRunFromRecipeRun(input, result, artifacts) {
     ? datamachineBundleConfig(input, datamachineBundleMount(input).config)
     : null;
   const previewUrl = result.runtime?.preview?.url || result.artifacts?.preview_url || result.artifacts?.previewUrl || '';
+  const datamachineValidation = datamachineConfig ? validateDatamachineWorkload(agentResult, datamachineConfig) : null;
+  const success = Boolean(result.success) && !datamachineValidation;
   return {
-    success: Boolean(result.success),
+    success,
     schema: 'wp-codebox/agent-task-run/v1',
-    summary: result.success ? 'WP Codebox agent task succeeded.' : (result.error?.message || 'WP Codebox agent task failed.'),
+    summary: success ? 'WP Codebox agent task succeeded.' : (datamachineValidation?.message || result.error?.message || 'WP Codebox agent task failed.'),
     session: {
       schema: 'wp-codebox/sandbox-session/v1',
       id: input.sandbox_session_id || input.orchestrator?.agent_task_id || '',
-      status: result.success ? 'completed' : 'failed',
+      status: success ? 'completed' : 'failed',
       artifacts: {
         bundle_id: result.artifacts?.id || result.artifacts?.bundle_id || result.artifacts?.bundleId || '',
         preview_url: previewUrl,
@@ -404,14 +407,56 @@ function agentTaskRunFromRecipeRun(input, result, artifacts) {
       context: input.parent_request?.task?.context || {},
     },
     artifacts,
-    exit_code: result.success ? 0 : 1,
+    exit_code: success ? 0 : 1,
     run: { ...result.run, agentResult },
-    diagnostics: result.diagnostics || datamachineDiagnostics(agentResult) || (result.error ? [{ class: result.error.code || 'wp-codebox.recipe-run', message: result.error.message || String(result.error), data: result.error }] : []),
+    diagnostics: [
+      ...(result.diagnostics || []),
+      ...(datamachineValidation ? [datamachineValidation] : []),
+      ...(datamachineDiagnostics(agentResult) || []),
+      ...(result.error ? [{ class: result.error.code || 'wp-codebox.recipe-run', message: result.error.message || String(result.error), data: result.error }] : []),
+    ],
     metadata: {
       recipe_run: result,
       ...(datamachineConfig ? { datamachine: { bundle: datamachineConfig, workload: agentResult } } : {}),
     },
   };
+}
+
+function pathValue(source, dottedPath) {
+  return String(dottedPath || '').split('.').filter(Boolean).reduce((value, key) => (value && typeof value === 'object' ? value[key] : undefined), source);
+}
+
+function validateDatamachineWorkload(workload, config) {
+  const scenarios = Array.isArray(workload?.scenarios) ? workload.scenarios : [];
+  if (scenarios.length === 0) {
+    return {
+      class: 'datamachine.workload.incomplete',
+      message: 'Data Machine bundle workload did not return any scenarios.',
+      data: { reason: 'missing_scenarios' },
+    };
+  }
+
+  const outputs = config.engine_data_outputs && typeof config.engine_data_outputs === 'object' ? config.engine_data_outputs : {};
+  const missing = [];
+  for (const [name, outputPath] of Object.entries(outputs)) {
+    const present = scenarios.some((scenario) => {
+      const value = pathValue(scenario, outputPath);
+      return value !== undefined && value !== null && value !== '';
+    });
+    if (!present) {
+      missing.push({ name, path: outputPath });
+    }
+  }
+
+  if (missing.length > 0) {
+    return {
+      class: 'datamachine.workload.incomplete',
+      message: 'Data Machine bundle workload did not produce required engine data outputs.',
+      data: { reason: 'missing_engine_data_outputs', missing },
+    };
+  }
+
+  return null;
 }
 
 function datamachineDiagnostics(workload) {
@@ -511,7 +556,9 @@ function runWpCodeboxParentTask(request) {
 
   if (result.stdout) {
     try {
-      process.stdout.write(`${JSON.stringify(agentTaskRunFromRecipeRun(input, JSON.parse(result.stdout), artifacts), null, 2)}\n`);
+      const payload = agentTaskRunFromRecipeRun(input, JSON.parse(result.stdout), artifacts);
+      process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+      return payload.success ? (result.status ?? 0) : 1;
     } catch {
       process.stdout.write(result.stdout);
     }

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -572,6 +572,7 @@ try {
   assert.equal(capturedDatamachineRun.recipe.workflow.steps[0].args.includes('code-file=/homeboy-extension/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php'), true);
   assert.equal(capturedDatamachineRun.recipe.inputs.mounts.some((mount) => mount.target === '/homeboy-extension'), true);
   assert.equal(capturedDatamachineRun.recipe.inputs.mounts.some((mount) => mount.target === '/wordpress/wp-content/plugins/static-site-agent'), true);
+  assert.equal(capturedDatamachineRun.recipe.inputs.secretEnv.includes('HOMEBOY_DATAMACHINE_AGENT_CONFIG'), true);
   assert.equal(capturedDatamachineRun.datamachineConfig.bundle_path, '/wordpress/wp-content/plugins/static-site-agent');
   assert.equal(capturedDatamachineRun.datamachineConfig.agent_slug, 'static-site-agent');
   assert.equal(capturedDatamachineRun.datamachineConfig.pipeline_slug, 'static-site-pipeline');

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -28,7 +28,11 @@ const artifacts = artifactsIndex >= 0 ? process.argv[artifactsIndex + 1] : '';
 const recipe = recipePath ? JSON.parse(fs.readFileSync(recipePath, 'utf8')) : null;
 const sessionArg = recipe.workflow.steps[0].args.find((arg) => arg.startsWith('session-id=')) || 'session-id=fixture-session';
 const sessionId = sessionArg.slice('session-id='.length);
-fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), recipe }, null, 2));
+const isDatamachineBundle = recipe.workflow.steps[0].args.some((arg) => arg.startsWith('code-file='));
+const agentResult = isDatamachineBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_DATAMACHINE
+  ? { scenarios: [{ id: 'datamachine-agent', metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }] }
+  : { status: 'completed' };
+fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), recipe, datamachineConfig: JSON.parse(process.env.HOMEBOY_DATAMACHINE_AGENT_CONFIG || '{}') }, null, 2));
 process.stdout.write(JSON.stringify({
   success: true,
   schema: 'wp-codebox/recipe-run/v1',
@@ -36,7 +40,7 @@ process.stdout.write(JSON.stringify({
   runtime: { preview: { url: 'https://preview.example.test/' + sessionId } },
   executions: [{ recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed' }) }],
   artifacts: { id: 'artifact-bundle-sha256-fixture', directory: artifacts },
-  agentResult: { status: 'completed' },
+  agentResult,
 }));
 `);
   fs.chmodSync(binPath, mode);
@@ -256,7 +260,10 @@ try {
       ...request,
       execution_kind: 'datamachine_bundle',
       homeboy_extensions: path.join(__dirname, '..'),
-      datamachine_bundle: { bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent' },
+      datamachine_bundle: {
+        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
+        engine_data_outputs: { issue_number: 'metadata.engine_data.store_idea_agent.issue_number' },
+      },
       provider_plugin_paths: [],
     }),
     env: {
@@ -269,13 +276,48 @@ try {
   assert.equal(composerResult.status, 0, composerResult.stderr || composerResult.stdout);
   const composerRecipe = readJson(composerCapturePath).recipe;
   const codeFileArg = composerRecipe.workflow.steps[0].args.find((arg) => arg.startsWith('code-file='));
-  assert.equal(codeFileArg, `code-file=${path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-datamachine-agent-workload-wrapper.php')}`);
-  assert.match(fs.readFileSync(codeFileArg.slice('code-file='.length), 'utf8'), /\/homeboy-extension\/scripts\/agent\/datamachine-agent-workload\.php/);
+  assert.equal(codeFileArg, 'code-file=/homeboy-extension/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php');
+  assert.match(fs.readFileSync(path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-datamachine-agent-workload-wrapper.php'), 'utf8'), /\/homeboy-extension\/scripts\/agent\/datamachine-agent-workload\.php/);
+  assert(composerRecipe.inputs.secretEnv.includes('HOMEBOY_DATAMACHINE_AGENT_CONFIG'));
+  assert.equal(readJson(composerCapturePath).datamachineConfig.engine_data_outputs.issue_number, 'metadata.engine_data.store_idea_agent.issue_number');
   const preparedDataMachine = composerRecipe.inputs.extraPlugins.find((plugin) => plugin.slug === 'data-machine');
   assert.notEqual(preparedDataMachine.source, composerPluginPath);
   assert(pathInside(path.join(root, 'composer-artifacts', 'prepared-plugins'), fs.realpathSync(preparedDataMachine.source)));
   assert(fs.existsSync(path.join(preparedDataMachine.source, 'vendor', 'autoload.php')));
   assert(!fs.existsSync(path.join(composerPluginPath, 'vendor', 'autoload.php')));
+
+  const incompleteDatamachineCapturePath = path.join(root, 'capture-incomplete-datamachine.json');
+  const incompleteDatamachineResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin',
+    fixtureWpCodebox,
+    '--artifacts',
+    path.join(root, 'incomplete-datamachine-artifacts'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      execution_kind: 'datamachine_bundle',
+      homeboy_extensions: path.join(__dirname, '..'),
+      datamachine_bundle: {
+        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
+        engine_data_outputs: { issue_number: 'metadata.engine_data.store_idea_agent.issue_number' },
+      },
+      provider_plugin_paths: [],
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: incompleteDatamachineCapturePath,
+      FIXTURE_WP_CODEBOX_INCOMPLETE_DATAMACHINE: '1',
+      OPENCODE_API_KEY: 'redacted-test-key',
+    },
+  });
+  assert.equal(incompleteDatamachineResult.status, 1, incompleteDatamachineResult.stderr || incompleteDatamachineResult.stdout);
+  const incompleteDatamachineOutput = JSON.parse(incompleteDatamachineResult.stdout);
+  assert.equal(incompleteDatamachineOutput.success, false);
+  assert.equal(incompleteDatamachineOutput.session.status, 'failed');
+  assert.equal(incompleteDatamachineOutput.diagnostics[0].class, 'datamachine.workload.incomplete');
+  assert.equal(incompleteDatamachineOutput.diagnostics[0].data.reason, 'missing_scenarios');
 
   const nonExecutableCapturePath = path.join(root, 'capture-non-executable.json');
   const nonExecutableFixture = createFixtureWpCodebox(root, 0o644);


### PR DESCRIPTION
## Summary
- Pass `HOMEBOY_DATAMACHINE_AGENT_CONFIG` through the generated WP Codebox recipe `secretEnv` list so Data Machine bundle code-file runs can read their workload config inside Playground.
- Use the mounted `/homeboy-extension/...` workload wrapper path in the recipe instead of a host-only path.
- Fail Data Machine bundle task runs when the workload returns no scenarios or omits configured `engine_data_outputs`, preventing green no-op runs with missing downstream bindings.

## Tests
- `npm run test:wp-codebox-task-runner`
- `npm run test:codebox-agent-task-executor`
- `npm run lint:js -- scripts/agent/homeboy-wp-codebox-task-runner.cjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the Homeboy/Data Machine bundle runner failure, drafted the runner fix and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.