### PR TITLE
fix: prepare Composer bench dependencies

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -445,6 +445,9 @@ if type homeboy_export_validation_dependency_paths &>/dev/null; then
     homeboy_export_validation_dependency_paths "$PLUGIN_PATH"
 fi
 DEPENDENCY_PATHS="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
+if [ -n "$DEPENDENCY_PATHS" ] && type homeboy_prepare_validation_dependency_paths_for_wp_codebox_bench &>/dev/null; then
+    DEPENDENCY_PATHS=$(homeboy_prepare_validation_dependency_paths_for_wp_codebox_bench "$DEPENDENCY_PATHS" "$ARTIFACTS_DIR")
+fi
 
 WP_CONFIG_DEFINES_JSON="{}"
 BENCH_ENV_JSON="{}"

--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -718,6 +718,125 @@ homeboy_merge_validation_dependency_paths() {
     done
 }
 
+homeboy_dependency_needs_composer_prepare() {
+    local dependency_path="${1:-}"
+
+    [ -n "$dependency_path" ] && [ -d "$dependency_path" ] || return 1
+    [ -f "${dependency_path}/composer.json" ] || return 1
+    [ ! -f "${dependency_path}/vendor/autoload.php" ] || return 1
+    [ ! -f "${dependency_path}/vendor/autoload_packages.php" ] || return 1
+
+    return 0
+}
+
+_homeboy_dependency_repo_root() {
+    local dependency_path="${1:-}"
+
+    [ -n "$dependency_path" ] && [ -d "$dependency_path" ] || return 1
+    git -C "$dependency_path" rev-parse --show-toplevel 2>/dev/null || printf '%s\n' "$dependency_path"
+}
+
+_homeboy_copy_dependency_prepare_root() {
+    local source_root="${1:-}"
+    local target_root="${2:-}"
+
+    [ -n "$source_root" ] && [ -d "$source_root" ] || return 1
+    [ -n "$target_root" ] || return 1
+
+    rm -rf "$target_root"
+    mkdir -p "$target_root"
+
+    if command -v rsync >/dev/null 2>&1; then
+        rsync -a --delete --exclude '.git' "${source_root}/" "${target_root}/"
+    else
+        ( cd "$source_root" && tar --exclude './.git' -cf - . ) | ( cd "$target_root" && tar -xf - )
+    fi
+}
+
+homeboy_prepare_validation_dependency_for_wp_codebox_bench() {
+    local dependency_path="${1:-}"
+    local artifacts_dir="${2:-}"
+
+    [ -n "$dependency_path" ] && [ -d "$dependency_path" ] || return 1
+
+    if ! homeboy_dependency_needs_composer_prepare "$dependency_path"; then
+        printf '%s\n' "$dependency_path"
+        return 0
+    fi
+
+    if ! command -v composer >/dev/null 2>&1; then
+        echo "Error: WordPress bench dependency '${dependency_path}' has composer.json but no vendor autoload files, and composer is not available." >&2
+        return 1
+    fi
+
+    local dependency_slug
+    dependency_slug=$(homeboy_get_validation_dependency_slug "$dependency_path" || basename "$dependency_path")
+
+    local prepare_root
+    prepare_root="$(_homeboy_dependency_repo_root "$dependency_path")"
+    [ -n "$prepare_root" ] && [ -d "$prepare_root" ] || prepare_root="$dependency_path"
+
+    local dependency_realpath prepare_realpath relative_plugin_path
+    dependency_realpath=$(cd "$dependency_path" && pwd -P)
+    prepare_realpath=$(cd "$prepare_root" && pwd -P)
+    case "$dependency_realpath" in
+        "$prepare_realpath")
+            relative_plugin_path=""
+            ;;
+        "$prepare_realpath"/*)
+            relative_plugin_path="${dependency_realpath#"$prepare_realpath"/}"
+            ;;
+        *)
+            prepare_root="$dependency_path"
+            prepare_realpath="$dependency_realpath"
+            relative_plugin_path=""
+            ;;
+    esac
+
+    local prepared_root prepared_plugin_path
+    prepared_root="${artifacts_dir%/}/prepared-bench-dependencies/${dependency_slug}"
+    _homeboy_copy_dependency_prepare_root "$prepare_root" "$prepared_root"
+
+    prepared_plugin_path="$prepared_root"
+    if [ -n "$relative_plugin_path" ]; then
+        prepared_plugin_path="${prepared_root}/${relative_plugin_path}"
+    fi
+
+    if [ ! -f "${prepared_plugin_path}/composer.json" ]; then
+        echo "Error: Prepared WordPress bench dependency '${dependency_path}' lost composer.json at '${prepared_plugin_path}'." >&2
+        return 1
+    fi
+
+    echo "Preparing WordPress bench dependency '${dependency_slug}' with Composer at ${prepared_plugin_path}" >&2
+    if ! composer install --working-dir="$prepared_plugin_path" --no-dev --no-interaction --no-progress --prefer-dist; then
+        echo "Error: Could not prepare WordPress bench dependency '${dependency_slug}' with Composer at ${prepared_plugin_path}." >&2
+        return 1
+    fi
+
+    if [ ! -f "${prepared_plugin_path}/vendor/autoload.php" ] && [ ! -f "${prepared_plugin_path}/vendor/autoload_packages.php" ]; then
+        echo "Error: Composer preparation for WordPress bench dependency '${dependency_slug}' did not create vendor autoload files at ${prepared_plugin_path}." >&2
+        return 1
+    fi
+
+    printf '%s\n' "$prepared_plugin_path"
+}
+
+homeboy_prepare_validation_dependency_paths_for_wp_codebox_bench() {
+    local dependency_paths="${1:-}"
+    local artifacts_dir="${2:-}"
+
+    [ -n "$dependency_paths" ] || return 0
+    [ -n "$artifacts_dir" ] || return 1
+
+    local dependency_path prepared_path
+    while IFS= read -r dependency_path; do
+        [ -n "$dependency_path" ] || continue
+        [ -d "$dependency_path" ] || continue
+        prepared_path=$(homeboy_prepare_validation_dependency_for_wp_codebox_bench "$dependency_path" "$artifacts_dir")
+        [ -n "$prepared_path" ] && printf '%s\n' "$prepared_path"
+    done <<< "$dependency_paths"
+}
+
 homeboy_export_validation_dependency_paths() {
     local plugin_path="${1:-}"
     local existing_paths

--- a/wordpress/tests/validation-dependencies-smoke.sh
+++ b/wordpress/tests/validation-dependencies-smoke.sh
@@ -13,11 +13,13 @@ AGENTS_API_DIR="${TMPDIR}/agents-api"
 REMOTE_AGENTS_API_DIR="${TMPDIR}/remote/agents-api"
 VENDORED_AGENTS_API_DIR="${COMPONENT_DIR}/vendor/automattic/agents-api"
 OPENAI_PROVIDER_DIR="${TMPDIR}/ai-provider-for-openai"
+COMPOSER_PLUGIN_DIR="${TMPDIR}/composer-plugin"
+COMPOSER_ARTIFACTS_DIR="${TMPDIR}/composer-artifacts"
 BIN_DIR="${TMPDIR}/bin"
 CLONE_BIN_DIR="${TMPDIR}/clone-bin"
 FALLBACK_CACHE_DIR="${TMPDIR}/fallback-cache"
 
-mkdir -p "$COMPONENT_DIR" "$DATA_MACHINE_DIR" "$CLONED_DATA_MACHINE_DIR" "$AGENTS_API_DIR" "$REMOTE_AGENTS_API_DIR" "$VENDORED_AGENTS_API_DIR" "$OPENAI_PROVIDER_DIR" "$BIN_DIR" "$CLONE_BIN_DIR" "$FALLBACK_CACHE_DIR"
+mkdir -p "$COMPONENT_DIR" "$DATA_MACHINE_DIR" "$CLONED_DATA_MACHINE_DIR" "$AGENTS_API_DIR" "$REMOTE_AGENTS_API_DIR" "$VENDORED_AGENTS_API_DIR" "$OPENAI_PROVIDER_DIR" "$COMPOSER_PLUGIN_DIR" "$COMPOSER_ARTIFACTS_DIR" "$BIN_DIR" "$CLONE_BIN_DIR" "$FALLBACK_CACHE_DIR"
 
 cat > "${COMPONENT_DIR}/intelligence.php" <<'PHP'
 <?php
@@ -79,6 +81,17 @@ cat > "${OPENAI_PROVIDER_DIR}/ai-provider-for-openai.php" <<'PHP'
  * Plugin Name: AI Provider for OpenAI
  */
 PHP
+
+cat > "${COMPOSER_PLUGIN_DIR}/composer-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Composer Plugin
+ */
+PHP
+
+cat > "${COMPOSER_PLUGIN_DIR}/composer.json" <<'JSON'
+{"name":"example/composer-plugin"}
+JSON
 
 cat > "${BIN_DIR}/homeboy" <<SH
 #!/usr/bin/env bash
@@ -153,6 +166,15 @@ cat > "${CLONE_BIN_DIR}/composer" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 if [ "${1:-}" = "install" ]; then
+    working_dir="$PWD"
+    for arg in "$@"; do
+        case "$arg" in
+            --working-dir=*)
+                working_dir="${arg#--working-dir=}"
+                ;;
+        esac
+    done
+    cd "$working_dir"
     mkdir -p vendor
     : > vendor/autoload.php
     exit 0
@@ -308,6 +330,27 @@ fi
 if ! grep -F -- "Resolved dependency 'agents-api' via final validation dependency path: ${REMOTE_AGENTS_API_DIR}" <<< "$mapped_export_output" >/dev/null; then
     echo "FAIL: mapped export diagnostics should report the remote dependency path" >&2
     printf '%s\n' "$mapped_export_output" >&2
+    exit 1
+fi
+
+prepared_composer_plugin=$(
+    PATH="${CLONE_BIN_DIR}:$PATH" \
+    homeboy_prepare_validation_dependency_for_wp_codebox_bench "$COMPOSER_PLUGIN_DIR" "$COMPOSER_ARTIFACTS_DIR"
+)
+expected_prepared_composer_plugin="${COMPOSER_ARTIFACTS_DIR}/prepared-bench-dependencies/composer-plugin"
+if [ "$prepared_composer_plugin" != "$expected_prepared_composer_plugin" ]; then
+    echo "FAIL: Composer dependency should be prepared under bench artifacts" >&2
+    printf 'prepared: %s\nexpected: %s\n' "$prepared_composer_plugin" "$expected_prepared_composer_plugin" >&2
+    exit 1
+fi
+
+if [ ! -f "${prepared_composer_plugin}/vendor/autoload.php" ]; then
+    echo "FAIL: prepared Composer dependency should include Composer autoload files" >&2
+    exit 1
+fi
+
+if [ -f "${COMPOSER_PLUGIN_DIR}/vendor/autoload.php" ]; then
+    echo "FAIL: Composer dependency preparation should not mutate the source dependency" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Prepare Composer-backed WordPress bench dependencies in artifact space before mounting them into WP Codebox.
- Preserve monorepo-relative Composer path repositories by copying the dependency repo root, then returning the prepared plugin subpath.
- Add smoke coverage that verifies Composer preparation creates autoload files without mutating the source dependency.

## Testing
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `node wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js`
- `bash wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- `npm run test:wp-codebox-bench-recipe-builder`
- WooCommerce/Stripe rig progressed past the previous missing WooCommerce autoload blocker: WooCommerce was copied to bench artifacts and Composer generated `vendor/autoload.php` / `vendor/autoload_packages.php`. The remaining run failed later on `api.wordpress.org` connect timeout, and a retry exceeded the 15-minute command timeout after dependency preparation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic dependency preparation implementation, smoke coverage, and verification notes for Chris to review.