### PR TITLE
Fix Data Machine bundle code-file path

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -308,7 +308,7 @@ function buildRecipe(input) {
     `provider-plugin-slugs=${providerSlugs.join(',')}`,
   ];
   if (isDatamachineBundle) {
-    workflowArgs.push('code-file=/homeboy-extension/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php');
+    workflowArgs.push(`code-file=${path.join(input.homeboy_extensions_path, 'scripts', 'agent', 'homeboy-datamachine-agent-workload-wrapper.php')}`);
   }
   if (input.sandbox_session_id) {
     workflowArgs.push(`session-id=${input.sandbox_session_id}`);

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -62,6 +62,11 @@ const fs = require('node:fs');
 const recipePath = process.argv[process.argv.indexOf('--recipe') + 1];
 const artifacts = process.argv[process.argv.indexOf('--artifacts') + 1];
 const recipe = JSON.parse(fs.readFileSync(recipePath, 'utf8'));
+const codeFileArg = recipe.workflow.steps[0].args.find((arg) => arg.startsWith('code-file=')) || '';
+const codeFilePath = codeFileArg.slice('code-file='.length);
+if (codeFilePath) {
+  fs.readFileSync(codeFilePath, 'utf8');
+}
 const datamachineConfig = JSON.parse(process.env.HOMEBOY_DATAMACHINE_AGENT_CONFIG || '{}');
 fs.writeFileSync(${JSON.stringify(capture)}, JSON.stringify({ argv: process.argv.slice(2), recipe, datamachineConfig }, null, 2));
 process.stdout.write(JSON.stringify({
@@ -569,7 +574,7 @@ try {
   assert.equal(datamachineCliOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/123'), true);
   const capturedDatamachineRun = JSON.parse(fs.readFileSync(fakeWpCodeboxCapture, 'utf8'));
   assert.equal(capturedDatamachineRun.recipe.workflow.steps[0].command, 'wp-codebox.agent-sandbox-run');
-  assert.equal(capturedDatamachineRun.recipe.workflow.steps[0].args.includes('code-file=/homeboy-extension/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php'), true);
+  assert.equal(capturedDatamachineRun.recipe.workflow.steps[0].args.includes(`code-file=${path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-datamachine-agent-workload-wrapper.php')}`), true);
   assert.equal(capturedDatamachineRun.recipe.inputs.mounts.some((mount) => mount.target === '/homeboy-extension'), true);
   assert.equal(capturedDatamachineRun.recipe.inputs.mounts.some((mount) => mount.target === '/wordpress/wp-content/plugins/static-site-agent'), true);
   assert.equal(capturedDatamachineRun.recipe.inputs.secretEnv.includes('HOMEBOY_DATAMACHINE_AGENT_CONFIG'), true);

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -28,7 +28,12 @@ const artifacts = artifactsIndex >= 0 ? process.argv[artifactsIndex + 1] : '';
 const recipe = recipePath ? JSON.parse(fs.readFileSync(recipePath, 'utf8')) : null;
 const sessionArg = recipe.workflow.steps[0].args.find((arg) => arg.startsWith('session-id=')) || 'session-id=fixture-session';
 const sessionId = sessionArg.slice('session-id='.length);
-const isDatamachineBundle = recipe.workflow.steps[0].args.some((arg) => arg.startsWith('code-file='));
+const codeFileArg = recipe.workflow.steps[0].args.find((arg) => arg.startsWith('code-file=')) || '';
+const codeFilePath = codeFileArg.slice('code-file='.length);
+if (codeFilePath) {
+  fs.readFileSync(codeFilePath, 'utf8');
+}
+const isDatamachineBundle = Boolean(codeFilePath);
 const agentResult = isDatamachineBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_DATAMACHINE
   ? { scenarios: [{ id: 'datamachine-agent', metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }] }
   : { status: 'completed' };
@@ -276,8 +281,9 @@ try {
   assert.equal(composerResult.status, 0, composerResult.stderr || composerResult.stdout);
   const composerRecipe = readJson(composerCapturePath).recipe;
   const codeFileArg = composerRecipe.workflow.steps[0].args.find((arg) => arg.startsWith('code-file='));
-  assert.equal(codeFileArg, 'code-file=/homeboy-extension/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php');
-  assert.match(fs.readFileSync(path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-datamachine-agent-workload-wrapper.php'), 'utf8'), /\/homeboy-extension\/scripts\/agent\/datamachine-agent-workload\.php/);
+  const expectedCodeFile = path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-datamachine-agent-workload-wrapper.php');
+  assert.equal(codeFileArg, `code-file=${expectedCodeFile}`);
+  assert.match(fs.readFileSync(expectedCodeFile, 'utf8'), /\/homeboy-extension\/scripts\/agent\/datamachine-agent-workload\.php/);
   assert(composerRecipe.inputs.secretEnv.includes('HOMEBOY_DATAMACHINE_AGENT_CONFIG'));
   assert.equal(readJson(composerCapturePath).datamachineConfig.engine_data_outputs.issue_number, 'metadata.engine_data.store_idea_agent.issue_number');
   const preparedDataMachine = composerRecipe.inputs.extraPlugins.find((plugin) => plugin.slug === 'data-machine');


### PR DESCRIPTION
## Summary
- Restore the Data Machine bundle `code-file` argument to the host-readable Homeboy Extensions wrapper path.
- Keep the runtime wrapper body requiring `/homeboy-extension/...`, which is the path available inside Playground after the extension mount.
- Update fake WP Codebox smoke fixtures to read `code-file` from the host, matching the real failure from the downstream `wp-site-generator` run.

## Root cause
The follow-up verification run for `wp-site-generator` failed because WP Codebox opens the `code-file` path on the host before executing it in the Playground runtime. PR #1052 changed that argument to `/homeboy-extension/...`, which exists only inside the runtime mount, so WP Codebox failed with:

`ENOENT: no such file or directory, open '/homeboy-extension/scripts/agent/homeboy-datamachine-agent-workload-wrapper.php'`

Evidence: https://github.com/chubes4/wp-site-generator/actions/runs/26955952364

## Tests
- `npm run test:wp-codebox-task-runner`
- `npm run test:codebox-agent-task-executor`
- `npm run lint:js -- scripts/agent/homeboy-wp-codebox-task-runner.cjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the failed downstream verification run, identified the host/runtime path mismatch, drafted the focused follow-up fix and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.