### PR TITLE
fix: add bench bootstrap setup seam

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -42,6 +42,7 @@
     "test:wp-codebox-task-runner": "node tests/wp-codebox-task-runner-smoke.js",
     "test:wp-codebox-bench-recipe-builder": "node tests/wp-codebox-bench-recipe-builder-smoke.js",
     "test:wp-codebox-prepared-dependency-cache": "bash tests/prepared-bench-dependency-cache-smoke.sh",
+    "test:wp-codebox-bench-bootstrap-steps": "node tests/wp-codebox-bench-bootstrap-steps-smoke.js",
     "test:wp-codebox-phpunit-recipe-builder": "node tests/wp-codebox-phpunit-recipe-builder-smoke.js",
     "test:build-package-artifacts": "bash scripts/build/build-package-artifacts-smoke.sh",
     "test:codebox-agent-task-executor": "node tests/codebox-agent-task-executor-smoke.js",

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -129,6 +129,80 @@ homeboy_wp_codebox_compile_bootstrap_files() {
     exit 1
 }
 
+homeboy_wp_codebox_compile_bootstrap_steps() {
+    local steps_json
+    steps_json=$(printf '%s' "$settings_json" | jq -c '
+        .wp_codebox_bootstrap_steps // .wp_codebox_setup_steps // .bench_bootstrap_steps // []
+        | if type == "array" then . else [] end
+    ' 2>/dev/null || echo '[]')
+
+    WP_CODEBOX_BOOTSTRAP_STEPS_JSON="[]"
+    if ! printf '%s' "$steps_json" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if ! printf '%s' "$steps_json" | jq -e '
+        all(.[];
+            type == "object"
+            and (.command | type == "string" and . != "")
+            and ((.args // []) | type == "array" and all(.[]; type == "string"))
+        )
+    ' >/dev/null 2>&1; then
+        echo "Error: wp_codebox_bootstrap_steps entries require command plus optional string args array." >&2
+        FAILED_STEP="WP Codebox bench bootstrap setup"
+        exit 1
+    fi
+
+    WP_CODEBOX_BOOTSTRAP_STEPS_JSON="$steps_json"
+}
+
+homeboy_wp_codebox_output_has_bootstrap_failure() {
+    local output_file="$1"
+
+    grep -Eq 'plugin-runtime\.setup|plugin runtime setup|Recipe plugin runtime setup\[[0-9]+\] failed|"phase"[[:space:]]*:[[:space:]]*"setup"' "$output_file"
+}
+
+homeboy_wp_codebox_emit_bootstrap_failure_diagnostic() {
+    local output_file="$1"
+    local exit_code="$2"
+    local diagnostics_file="${ARTIFACTS_DIR}/wp-codebox-bench-bootstrap-diagnostics.json"
+    local output_artifact="${ARTIFACTS_DIR}/wp-codebox-output.txt"
+    local exit_artifact="${ARTIFACTS_DIR}/wp-codebox-exit-code.txt"
+
+    mkdir -p "$ARTIFACTS_DIR"
+    cp "$output_file" "$output_artifact"
+    printf '%s\n' "$exit_code" > "$exit_artifact"
+
+    jq -n \
+        --arg schema "homeboy/wordpress-bench-diagnostic/v1" \
+        --arg code "wp-codebox-bench-bootstrap-failed" \
+        --arg message "WP Codebox bench bootstrap setup failed before measured workloads executed." \
+        --argjson exitCode "$exit_code" \
+        --arg artifactsDir "$ARTIFACTS_DIR" \
+        --arg outputArtifact "$output_artifact" \
+        --arg exitArtifact "$exit_artifact" \
+        '{
+            schema: $schema,
+            diagnostics: [{
+                code: $code,
+                severity: "error",
+                phase: "setup",
+                message: $message,
+                exit_code: $exitCode,
+                artifacts: {
+                    directory: $artifactsDir,
+                    output: $outputArtifact,
+                    exit_code: $exitArtifact
+                }
+            }]
+        }' > "$diagnostics_file"
+
+    echo "WP Codebox bench bootstrap setup failed before measured workloads executed." >&2
+    echo "  Exit code: $exit_code" >&2
+    echo "  Diagnostics: $diagnostics_file" >&2
+    echo "  Raw output: $output_artifact" >&2
+}
+
 homeboy_wp_codebox_mount_extra_bench_workloads() {
     local workloads_value="${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}"
     [ -n "$workloads_value" ] || return 0
@@ -395,6 +469,7 @@ homeboy_wp_codebox_compile_scenario_manifests() {
 
 homeboy_wp_codebox_compile_scenario_manifests
 homeboy_wp_codebox_compile_bootstrap_files
+homeboy_wp_codebox_compile_bootstrap_steps
 
 WP_CODEBOX_WORDPRESS_VERSION="7.0"
 if [ "$settings_json" != "{}" ]; then
@@ -589,6 +664,9 @@ WP_CODEBOX_PLUGIN_RUNTIME_JSON="{}"
 if [ -n "$WP_CODEBOX_PHP_MEMORY_LIMIT" ]; then
     WP_CODEBOX_PLUGIN_RUNTIME_JSON=$(jq -nc --arg memoryLimit "$WP_CODEBOX_PHP_MEMORY_LIMIT" '{php: {memoryLimit: $memoryLimit}}')
 fi
+if printf '%s' "$WP_CODEBOX_BOOTSTRAP_STEPS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+    WP_CODEBOX_PLUGIN_RUNTIME_JSON=$(jq -nc --argjson runtime "$WP_CODEBOX_PLUGIN_RUNTIME_JSON" --argjson setup "$WP_CODEBOX_BOOTSTRAP_STEPS_JSON" '$runtime + {setup: $setup}')
+fi
 
 homeboy_wp_codebox_emit_memory_fatal_diagnostic() {
     local output_file="$1"
@@ -707,6 +785,11 @@ set -e
 
 if [ $wp_codebox_exit -ne 0 ]; then
     cat "$WP_CODEBOX_TMPFILE" >&2
+    if homeboy_wp_codebox_output_has_bootstrap_failure "$WP_CODEBOX_TMPFILE"; then
+        homeboy_wp_codebox_emit_bootstrap_failure_diagnostic "$WP_CODEBOX_TMPFILE" "$wp_codebox_exit"
+        FAILED_STEP="WP Codebox bench bootstrap setup"
+        exit $wp_codebox_exit
+    fi
     if fatal_line=$(grep -E '^(PHP Fatal error: |Fatal error: )?Allowed memory size of [0-9]+ bytes exhausted|^(PHP Fatal error: |Fatal error: ).*Allowed memory size of [0-9]+ bytes exhausted' "$WP_CODEBOX_TMPFILE" | head -1); then
         homeboy_wp_codebox_emit_memory_fatal_diagnostic "$WP_CODEBOX_TMPFILE" "$wp_codebox_exit" "$fatal_line"
     fi

--- a/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-bootstrap-steps-'));
+
+try {
+  const extensionPath = path.join(__dirname, '..');
+  const componentPath = path.join(root, 'bootstrap-steps-fixture');
+  const dependencyPath = path.join(root, 'generic-dependency');
+  const benchDir = path.join(componentPath, 'tests', 'bench');
+  fs.mkdirSync(benchDir, { recursive: true });
+  fs.mkdirSync(dependencyPath, { recursive: true });
+  fs.writeFileSync(path.join(componentPath, 'bootstrap-steps-fixture.php'), "<?php\n/* Plugin Name: Bootstrap Steps Fixture */\n");
+  fs.writeFileSync(path.join(dependencyPath, 'generic-dependency.php'), "<?php\n/* Plugin Name: Generic Dependency */\n");
+  fs.writeFileSync(path.join(benchDir, 'assert-bootstrap.php'), "<?php\nreturn static fn() => ['metrics' => ['bootstrap_seen' => 1]];\n");
+
+  const successCaptureFile = path.join(root, 'captured-success-recipe.json');
+  const failureArtifactsDir = path.join(root, 'failure-artifacts');
+  const fakeWpCodebox = path.join(root, 'fixture-wp-codebox.js');
+  fs.writeFileSync(fakeWpCodebox, `#!/usr/bin/env node
+const fs = require('node:fs');
+const recipeIndex = process.argv.indexOf('--recipe');
+if (process.argv[2] !== 'recipe-run' || recipeIndex < 0) {
+  process.exit(2);
+}
+const recipe = JSON.parse(fs.readFileSync(process.argv[recipeIndex + 1], 'utf8'));
+if (process.env.HOMEBOY_FORCE_BOOTSTRAP_FAILURE === '1') {
+  process.stdout.write(JSON.stringify({
+    success: false,
+    diagnostics: [{ schema: 'wp-codebox/plugin-runtime-diagnostic/v1', phase: 'setup', message: 'fixture bootstrap failed' }]
+  }) + '\\n');
+  process.exit(9);
+}
+fs.writeFileSync(process.env.HOMEBOY_CAPTURE_RECIPE, JSON.stringify(recipe, null, 2) + '\\n');
+process.stdout.write(JSON.stringify({
+  success: true,
+  benchResults: {
+    component_id: 'bootstrap-steps-fixture',
+    iterations: 1,
+    warmup_iterations: 0,
+    scenarios: [{ id: 'assert-bootstrap', metrics: { bootstrap_seen: 1 } }]
+  }
+}) + '\\n');
+`);
+  fs.chmodSync(fakeWpCodebox, 0o755);
+
+  const benchHelper = path.join(root, 'bench-helper.sh');
+  fs.writeFileSync(benchHelper, `#!/usr/bin/env bash
+homeboy_write_empty_bench_results() {
+  local component="$1"
+  local iterations="$2"
+  local results_file="$3"
+  printf '{"component_id":"%s","iterations":%s,"scenarios":[]}\\n' "$component" "$iterations" > "$results_file"
+}
+`);
+  const preflightHelper = path.join(root, 'preflight-helper.sh');
+  fs.writeFileSync(preflightHelper, `#!/usr/bin/env bash
+homeboy_require_bash_version() { :; }
+`);
+
+  const settings = {
+    validation_dependencies: [dependencyPath],
+    wp_codebox_bootstrap_steps: [
+      { command: 'wordpress.wp-cli', args: ['command=option update generic_dependency_bootstrap yes'] },
+    ],
+  };
+  const baseEnv = {
+    ...process.env,
+    HOMEBOY_BENCH_ITERATIONS: '1',
+    HOMEBOY_BENCH_WARMUP_ITERATIONS: '0',
+    HOMEBOY_COMPONENT_ID: 'bootstrap-steps-fixture',
+    HOMEBOY_COMPONENT_PATH: componentPath,
+    HOMEBOY_EXTENSION_PATH: extensionPath,
+    HOMEBOY_RUNTIME_BASH_PREFLIGHT: preflightHelper,
+    HOMEBOY_RUNTIME_BENCH_HELPER_SH: benchHelper,
+    HOMEBOY_SETTINGS_JSON: JSON.stringify(settings),
+    HOMEBOY_WP_CODEBOX_BIN: fakeWpCodebox,
+  };
+
+  const successResult = spawnSync('bash', [path.join(extensionPath, 'scripts', 'bench', 'bench-runner.sh')], {
+    cwd: componentPath,
+    encoding: 'utf8',
+    env: {
+      ...baseEnv,
+      HOMEBOY_BENCH_RESULTS_FILE: path.join(root, 'success-results.json'),
+      HOMEBOY_CAPTURE_RECIPE: successCaptureFile,
+    },
+  });
+
+  assert.equal(successResult.status, 0, successResult.stderr || successResult.stdout);
+  const recipe = JSON.parse(fs.readFileSync(successCaptureFile, 'utf8'));
+  assert.equal(recipe.inputs.extraPlugins.some((plugin) => plugin.slug === 'generic-dependency'), true);
+  assert.deepEqual(recipe.inputs.pluginRuntime.setup, settings.wp_codebox_bootstrap_steps);
+  assert.equal(recipe.workflow.steps[0].command, 'wordpress.bench');
+
+  const failureResult = spawnSync('bash', [path.join(extensionPath, 'scripts', 'bench', 'bench-runner.sh')], {
+    cwd: componentPath,
+    encoding: 'utf8',
+    env: {
+      ...baseEnv,
+      HOMEBOY_BENCH_RESULTS_FILE: path.join(root, 'failure-results.json'),
+      HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: failureArtifactsDir,
+      HOMEBOY_FORCE_BOOTSTRAP_FAILURE: '1',
+    },
+  });
+
+  assert.equal(failureResult.status, 9);
+  assert.match(failureResult.stderr, /WP Codebox bench bootstrap setup failed before measured workloads executed/);
+  const diagnostics = JSON.parse(fs.readFileSync(path.join(failureArtifactsDir, 'wp-codebox-bench-bootstrap-diagnostics.json'), 'utf8'));
+  assert.equal(diagnostics.diagnostics[0].code, 'wp-codebox-bench-bootstrap-failed');
+  assert.equal(diagnostics.diagnostics[0].phase, 'setup');
+
+  console.log('WP Codebox bench bootstrap steps smoke passed');
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
@@ -15,7 +15,11 @@ const input = {
 		wpConfigDefines: { WP_DEBUG: true },
 		bootstrapFiles: ['/wordpress/wp-content/plugins/fixture-plugin/bootstrap.php'],
 		workloads: [{ id: 'fixture-workload', steps: [{ type: 'php', code: 'return [];' }] }],
-		pluginRuntime: { url: 'https://example.com/runtime.zip', sha256: 'abc123' },
+		pluginRuntime: {
+			url: 'https://example.com/runtime.zip',
+			sha256: 'abc123',
+			setup: [{ command: 'wordpress.wp-cli', args: ['command=option update fixture_bootstrap yes'] }],
+		},
 		mounts: [{ source: '/tmp/fixture-plugin', target: '/wordpress/wp-content/plugins/fixture-plugin' }],
 		extraPlugins: [{ source: '/tmp/extra-plugin.zip', slug: 'extra-plugin', activate: true }],
 	},

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1038,6 +1038,13 @@
       "description": "Component-relative bootstrap file fallbacks for WP Codebox bench workloads. The runner resolves the list against the mounted component and passes the first existing file to wordpress.bench so it loads before workloads execute."
     },
     {
+      "id": "wp_codebox_bootstrap_steps",
+      "label": "WP Codebox bench bootstrap steps",
+      "type": "array",
+      "default": [],
+      "description": "Generic WP Codebox recipe steps to run during pluginRuntime.setup after dependency activation and before measured bench workloads. Use this for dependency setup that must be prepared outside workload timing."
+    },
+    {
       "id": "wp_codebox_scenario_manifests",
       "label": "WP Codebox scenario manifests",
       "type": "array",


### PR DESCRIPTION
## Summary
- Add a generic `wp_codebox_bootstrap_steps` WordPress extension setting that maps to WP Codebox `inputs.pluginRuntime.setup` so setup runs after dependency activation and before measured `wordpress.bench` workloads.
- Classify WP Codebox plugin-runtime setup failures as bench bootstrap setup failures and write a small diagnostic artifact bundle instead of treating them as workload regressions.
- Add smoke coverage with a generic fixture dependency proving dependency mounting composes with bootstrap setup before the bench workflow.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/1056

## Dependency note
- This is based on current `main`; PR #1053 is already merged and included via `origin/main`.

## Testing
- `npm run test:wp-codebox-bench-recipe-builder`
- `npm run test:wp-codebox-bench-bootstrap-steps`
- `bash wordpress/tests/validation-dependencies-smoke.sh`
- `bash -n wordpress/scripts/bench/bench-runner-wp-codebox.sh`
- `HOMEBOY_RUNTIME_BASH_PREFLIGHT=<fixture> node wordpress/tests/wp-codebox-bench-bootstrap-files-smoke.js`
- `bash wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic WordPress bench bootstrap seam, setup-failure classification, smoke coverage, and verification notes for Chris to review.