### PR TITLE
Read Data Machine bundle stdout results

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -374,13 +374,13 @@ function datamachineBundleConfig(input, bundleConfig = {}) {
 
 function agentTaskRunFromRecipeRun(input, result, artifacts) {
   const execution = Array.isArray(result.executions) ? result.executions.find((item) => item?.recipeCommand === 'wp-codebox.agent-sandbox-run') || result.executions[0] : null;
-  const agentResult = result.agentResult || result.run?.agentResult || result.artifacts?.agentResult || execution?.agentResult || {};
   const datamachineConfig = input.execution_kind === 'datamachine_bundle' || input.execution_kind === 'datamachine-bundle'
     ? datamachineBundleConfig(input, datamachineBundleMount(input).config)
     : null;
+  const agentResult = result.agentResult || result.run?.agentResult || result.artifacts?.agentResult || execution?.agentResult || (datamachineConfig ? datamachineWorkloadFromExecutionStdout(execution, datamachineConfig) : {}) || {};
   const previewUrl = result.runtime?.preview?.url || result.artifacts?.preview_url || result.artifacts?.previewUrl || '';
   const datamachineValidation = datamachineConfig ? validateDatamachineWorkload(agentResult, datamachineConfig) : null;
-  const success = Boolean(result.success) && !datamachineValidation;
+  const success = datamachineConfig ? !datamachineValidation : Boolean(result.success);
   return {
     success,
     schema: 'wp-codebox/agent-task-run/v1',
@@ -420,6 +420,39 @@ function agentTaskRunFromRecipeRun(input, result, artifacts) {
       ...(datamachineConfig ? { datamachine: { bundle: datamachineConfig, workload: agentResult } } : {}),
     },
   };
+}
+
+function parseJsonObject(value) {
+  if (!value || typeof value !== 'string') {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function datamachineWorkloadFromExecutionStdout(execution, config) {
+  const wrapper = parseJsonObject(execution?.stdout || '');
+  const workload = parseJsonObject(wrapper?.output || '') || parseJsonObject(execution?.stdout || '');
+  if (!workload) {
+    return {};
+  }
+  if (Array.isArray(workload.scenarios)) {
+    return workload;
+  }
+  if (workload.metadata || workload.metrics) {
+    return {
+      scenarios: [{
+        id: config.workload_id || config.agent_slug || config.flow_slug || 'datamachine-agent',
+        metrics: workload.metrics || {},
+        metadata: workload.metadata || {},
+      }],
+    };
+  }
+  return {};
 }
 
 function pathValue(source, dottedPath) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -68,21 +68,20 @@ if (codeFilePath) {
   fs.readFileSync(codeFilePath, 'utf8');
 }
 const datamachineConfig = JSON.parse(process.env.HOMEBOY_DATAMACHINE_AGENT_CONFIG || '{}');
+const datamachineWorkload = {
+  metrics: { config_present: 1 },
+  metadata: {
+    transcript_artifacts: { json: artifacts + '/transcript.json' },
+    replay_bundle_path: artifacts + '/replay-bundle',
+    engine_data: { static_site_agent: { pr_url: 'https://github.com/chubes4/wp-site-generator/pull/123' } }
+  }
+};
 fs.writeFileSync(${JSON.stringify(capture)}, JSON.stringify({ argv: process.argv.slice(2), recipe, datamachineConfig }, null, 2));
 process.stdout.write(JSON.stringify({
-  success: true,
+  success: false,
   executions: [{
     recipeCommand: 'wp-codebox.agent-sandbox-run',
-    agentResult: {
-      scenarios: [{
-        id: 'datamachine-agent',
-        metadata: {
-          transcript_artifacts: { json: artifacts + '/transcript.json' },
-          replay_bundle_path: artifacts + '/replay-bundle',
-          engine_data: { static_site_agent: { pr_url: 'https://github.com/chubes4/wp-site-generator/pull/123' } }
-        }
-      }]
-    }
+    stdout: JSON.stringify({ status: 'completed', output: JSON.stringify(datamachineWorkload) })
   }],
   artifacts: { id: 'fake-artifact-bundle', directory: artifacts }
 }));

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -35,17 +35,17 @@ if (codeFilePath) {
 }
 const isDatamachineBundle = Boolean(codeFilePath);
 const agentResult = isDatamachineBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_DATAMACHINE
-  ? { scenarios: [{ id: 'datamachine-agent', metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }] }
+  ? { metrics: { config_present: 1 }, metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }
   : { status: 'completed' };
 fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), recipe, datamachineConfig: JSON.parse(process.env.HOMEBOY_DATAMACHINE_AGENT_CONFIG || '{}') }, null, 2));
 process.stdout.write(JSON.stringify({
-  success: true,
+  success: !isDatamachineBundle,
   schema: 'wp-codebox/recipe-run/v1',
   recipePath,
   runtime: { preview: { url: 'https://preview.example.test/' + sessionId } },
-  executions: [{ recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed' }) }],
+  executions: [{ recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed', output: JSON.stringify(agentResult) }) }],
   artifacts: { id: 'artifact-bundle-sha256-fixture', directory: artifacts },
-  agentResult,
+  ...(isDatamachineBundle ? {} : { agentResult }),
 }));
 `);
   fs.chmodSync(binPath, mode);
@@ -286,6 +286,9 @@ try {
   assert.match(fs.readFileSync(expectedCodeFile, 'utf8'), /\/homeboy-extension\/scripts\/agent\/datamachine-agent-workload\.php/);
   assert(composerRecipe.inputs.secretEnv.includes('HOMEBOY_DATAMACHINE_AGENT_CONFIG'));
   assert.equal(readJson(composerCapturePath).datamachineConfig.engine_data_outputs.issue_number, 'metadata.engine_data.store_idea_agent.issue_number');
+  const composerOutput = JSON.parse(composerResult.stdout);
+  assert.equal(composerOutput.success, true);
+  assert.equal(composerOutput.run.agentResult.scenarios[0].metadata.engine_data.store_idea_agent.issue_number, 123);
   const preparedDataMachine = composerRecipe.inputs.extraPlugins.find((plugin) => plugin.slug === 'data-machine');
   assert.notEqual(preparedDataMachine.source, composerPluginPath);
   assert(pathInside(path.join(root, 'composer-artifacts', 'prepared-plugins'), fs.realpathSync(preparedDataMachine.source)));


### PR DESCRIPTION
## Summary
- Parse `wp-codebox.agent-sandbox-run` command stdout for Data Machine bundle `code-file` output.
- Normalize single Data Machine workload payloads (`metrics` + `metadata`) into the `scenarios[]` shape consumed by Homeboy output bindings.
- Treat Data Machine bundle success as required-output validation, not WP Codebox's generic nested-agent completion heuristic.

## Root cause
After #1054, `wp-site-generator` got past the host `code-file` path error and executed the Data Machine workload. WP Codebox returned the workload result in the command stdout wrapper:

`{ "command": "agent-sandbox.run", "output": "{...workload json...}" }`

Homeboy Extensions only looked for `agentResult` fields, so it reported `Data Machine bundle workload did not return any scenarios` even though the workload JSON was present. WP Codebox also marked the generic sandbox run failed with `agent-runtime-failed`, but the bundle workload contract should be judged by the workload payload and configured `engine_data_outputs`.

Evidence: https://github.com/chubes4/wp-site-generator/actions/runs/26956932641

## Tests
- `npm run test:wp-codebox-task-runner`
- `npm run test:codebox-agent-task-executor`
- `npm run lint:js -- scripts/agent/homeboy-wp-codebox-task-runner.cjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the latest downstream verification failure, identified the Data Machine stdout wrapper mismatch, drafted the parser/normalizer and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.