### PR TITLE
Wait for Data Machine bundle jobs to finish

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Smoke test for Data Machine agent terminal-state handling and scenario output.
+ *
+ * Run with: php wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php
+ */
+
+namespace DataMachine\Core\Database\Jobs {
+    class Jobs {
+        public function get_job( int $job_id ): array {
+            $GLOBALS['homeboy_terminal_state_reads'] = ( $GLOBALS['homeboy_terminal_state_reads'] ?? 0 ) + 1;
+            return array(
+                'job_id' => $job_id,
+                'status' => ( $GLOBALS['homeboy_terminal_state_reads'] ?? 0 ) >= 3 ? 'completed' : 'pending',
+            );
+        }
+
+        public function get_children( int $parent_job_id ): array {
+            return array(
+                array(
+                    'job_id'        => 456,
+                    'parent_job_id' => $parent_job_id,
+                    'status'        => 'pending',
+                ),
+            );
+        }
+    }
+}
+
+namespace DataMachine\Core\Database\Agents {
+    class Agents {}
+}
+
+namespace DataMachine\Core\Database\Chat {
+    class ConversationStoreFactory {}
+}
+
+namespace DataMachine\Core\Database\Flows {
+    class Flows {}
+}
+
+namespace DataMachine\Core\Database\Pipelines {
+    class Pipelines {}
+}
+
+namespace DataMachine\Core {
+    class PluginSettings {}
+}
+
+namespace {
+    if ( ! defined( 'ABSPATH' ) ) {
+        define( 'ABSPATH', __DIR__ . '/' );
+    }
+
+    if ( ! function_exists( 'wp_set_current_user' ) ) {
+        function wp_set_current_user( int $user_id ): void {}
+    }
+
+    if ( ! function_exists( 'wp_get_ability' ) ) {
+        function wp_get_ability( string $ability_name ): object {
+            return new class {
+                public function execute( array $args ): array {
+                    $GLOBALS['homeboy_terminal_state_drain_calls'] = ( $GLOBALS['homeboy_terminal_state_drain_calls'] ?? 0 ) + 1;
+                    return array(
+                        'success' => true,
+                        'job_id'  => (int) ( $args['job_id'] ?? 0 ),
+                    );
+                }
+            };
+        }
+    }
+
+    if ( ! function_exists( 'datamachine_get_engine_data' ) ) {
+        function datamachine_get_engine_data( int $job_id ): array {
+            return array();
+        }
+    }
+
+    if ( ! function_exists( 'wp_json_encode' ) ) {
+        function wp_json_encode( $value, int $flags = 0 ): string {
+            return (string) json_encode( $value, $flags );
+        }
+    }
+
+    putenv(
+        'HOMEBOY_DATAMACHINE_AGENT_CONFIG=' . wp_json_encode(
+            array(
+                'dry_run'    => true,
+                'agent_slug' => 'terminal-state-smoke-agent',
+                'flow_slug'  => 'terminal-state-smoke-flow',
+            )
+        )
+    );
+
+    require __DIR__ . '/datamachine-agent-workload.php';
+
+    $summary = homeboy_datamachine_agent_drain_job(
+        123,
+        array(
+            'terminal_wait_budget_ms' => 250,
+            'terminal_poll_sleep_ms'  => 1,
+            'step_budget'             => 1,
+            'time_budget_ms'          => 1000,
+        ),
+        new \DataMachine\Core\Database\Jobs\Jobs()
+    );
+
+    if ( empty( $summary['job_terminal'] ) || 'completed' !== $summary['final_job_status'] ) {
+        fwrite( STDERR, "Expected drain to wait until the job reached completed status.\n" );
+        exit( 1 );
+    }
+
+    if ( ( $GLOBALS['homeboy_terminal_state_drain_calls'] ?? 0 ) < 2 ) {
+        fwrite( STDERR, "Expected drain to keep polling after an initial successful non-terminal drain pass.\n" );
+        exit( 1 );
+    }
+
+    $result = homeboy_datamachine_agent_result(
+        array( 'job_completed' => 1 ),
+        array(
+            'task_id'     => 'store-idea-agent',
+            'engine_data' => array(
+                'store_idea_agent' => array(
+                    'issue_number' => 123,
+                ),
+            ),
+        )
+    );
+
+    if ( 123 !== ( $result['scenarios'][0]['metadata']['engine_data']['store_idea_agent']['issue_number'] ?? 0 ) ) {
+        fwrite( STDERR, "Expected workload result scenarios to expose engine_data.\n" );
+        exit( 1 );
+    }
+
+    $child_error = homeboy_datamachine_agent_job_terminal_error( 456, 'pending', 'Data Machine child job' );
+    if ( ! str_contains( $child_error, 'did not reach a terminal state' ) ) {
+        fwrite( STDERR, "Expected non-terminal child job diagnostic to be precise.\n" );
+        exit( 1 );
+    }
+
+    fwrite( STDOUT, "Data Machine agent terminal state smoke passed.\n" );
+}

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -323,9 +323,21 @@ if ( ! function_exists( 'homeboy_datamachine_agent_result' ) ) {
             $metadata['eval_artifact'] = homeboy_datamachine_agent_eval_artifact( $metrics, $metadata, $error );
         }
 
+        $scenario_id = (string) ( $metadata['task_id'] ?? $metadata['workload_id'] ?? $metadata['flow_slug'] ?? $metadata['agent_slug'] ?? 'datamachine-agent' );
+        if ( '' === $scenario_id ) {
+            $scenario_id = 'datamachine-agent';
+        }
+
         return array(
-            'metrics'  => $metrics,
-            'metadata' => $metadata,
+            'metrics'   => $metrics,
+            'metadata'  => $metadata,
+            'scenarios' => array(
+                array(
+                    'id'       => $scenario_id,
+                    'metrics'  => $metrics,
+                    'metadata' => $metadata,
+                ),
+            ),
         );
     }
 }
@@ -2688,16 +2700,39 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_transcript' ) ) {
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_job_status_terminal' ) ) {
+    function homeboy_datamachine_agent_job_status_terminal( string $job_status ): bool {
+        return in_array( $job_status, array( 'completed', 'failed', 'cancelled' ), true );
+    }
+
+    function homeboy_datamachine_agent_job_terminal_error( int $job_id, string $job_status, string $label = 'Data Machine job' ): string {
+        if ( 'completed' === $job_status ) {
+            return '';
+        }
+
+        if ( homeboy_datamachine_agent_job_status_terminal( $job_status ) ) {
+            return sprintf( '%s %d ended with status %s.', $label, $job_id, $job_status );
+        }
+
+        $status = '' !== $job_status ? $job_status : 'unknown';
+        return sprintf( '%s %d did not reach a terminal state after drain; current status is %s.', $label, $job_id, $status );
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_drain_job' ) ) {
     function homeboy_datamachine_agent_drain_job( int $job_id, array $config, Jobs $jobs ): array {
         $started_at              = hrtime( true );
         $retry_wait_budget_ms    = isset( $config['retry_wait_budget_ms'] ) ? max( 0, (int) $config['retry_wait_budget_ms'] ) : 180000;
         $retry_max_sleep_ms      = isset( $config['retry_max_sleep_ms'] ) ? max( 1000, (int) $config['retry_max_sleep_ms'] ) : 30000;
+        $terminal_wait_budget_ms = isset( $config['terminal_wait_budget_ms'] ) ? max( 0, (int) $config['terminal_wait_budget_ms'] ) : 300000;
+        $poll_sleep_ms           = isset( $config['terminal_poll_sleep_ms'] ) ? max( 100, (int) $config['terminal_poll_sleep_ms'] ) : 1000;
         $step_budget             = isset( $config['step_budget'] ) ? max( 1, (int) $config['step_budget'] ) : 20;
         $time_budget_ms          = isset( $config['time_budget_ms'] ) ? max( 1000, (int) $config['time_budget_ms'] ) : 300000;
         $history                 = array();
         $drain_result            = array( 'success' => false );
         $waited_ms               = 0;
+        $terminal_waited_ms      = 0;
+        $job_status              = '';
 
         do {
             $drain_result = wp_get_ability( 'datamachine/drain-job' )->execute(
@@ -2718,42 +2753,47 @@ if ( ! function_exists( 'homeboy_datamachine_agent_drain_job' ) ) {
                 'retry'        => is_array( $engine_data['retry'] ?? null ) ? $engine_data['retry'] : array(),
             );
 
-            if ( is_array( $drain_result ) && ! empty( $drain_result['success'] ) ) {
-                break;
-            }
-
-            if ( in_array( $job_status, array( 'completed', 'failed', 'cancelled' ), true ) ) {
+            if ( homeboy_datamachine_agent_job_status_terminal( $job_status ) ) {
                 break;
             }
 
             $retry = is_array( $engine_data['retry'] ?? null ) ? $engine_data['retry'] : array();
+            $sleep_ms = 0;
             if ( empty( $retry['last_retryable'] ) || empty( $retry['next_retry_at'] ) ) {
-                break;
-            }
+                $remaining_budget_ms = $terminal_wait_budget_ms - $terminal_waited_ms;
+                if ( $remaining_budget_ms <= 0 ) {
+                    break;
+                }
+                $sleep_ms = min( $poll_sleep_ms, $remaining_budget_ms );
+                $terminal_waited_ms += $sleep_ms;
+            } else {
+                $next_retry_ts = strtotime( (string) $retry['next_retry_at'] );
+                if ( false === $next_retry_ts ) {
+                    break;
+                }
 
-            $next_retry_ts = strtotime( (string) $retry['next_retry_at'] );
-            if ( false === $next_retry_ts ) {
-                break;
-            }
+                $remaining_budget_ms = $retry_wait_budget_ms - $waited_ms;
+                if ( $remaining_budget_ms <= 0 ) {
+                    break;
+                }
 
-            $remaining_budget_ms = $retry_wait_budget_ms - $waited_ms;
-            if ( $remaining_budget_ms <= 0 ) {
-                break;
-            }
-
-            $delay_ms = max( 0, ( $next_retry_ts - time() ) * 1000 ) + 1000;
-            $sleep_ms = min( $delay_ms, $retry_max_sleep_ms, $remaining_budget_ms );
-            if ( $sleep_ms > 0 ) {
-                usleep( $sleep_ms * 1000 );
+                $delay_ms = max( 0, ( $next_retry_ts - time() ) * 1000 ) + 1000;
+                $sleep_ms = min( $delay_ms, $retry_max_sleep_ms, $remaining_budget_ms );
                 $waited_ms += $sleep_ms;
             }
-        } while ( $waited_ms <= $retry_wait_budget_ms );
+            if ( $sleep_ms > 0 ) {
+                usleep( $sleep_ms * 1000 );
+            }
+        } while ( ( $waited_ms <= $retry_wait_budget_ms ) && ( $terminal_waited_ms <= $terminal_wait_budget_ms ) );
 
         return array(
             'drain_result'     => $drain_result,
             'drain_elapsed_ms' => ( hrtime( true ) - $started_at ) / 1000000,
             'drain_history'    => $history,
             'retry_waited_ms'  => $waited_ms,
+            'terminal_waited_ms' => $terminal_waited_ms,
+            'final_job_status' => $job_status,
+            'job_terminal'     => homeboy_datamachine_agent_job_status_terminal( $job_status ),
         );
     }
 
@@ -3035,6 +3075,8 @@ $drain_elapsed_ms = (float) $drain_summary['drain_elapsed_ms'];
 $metadata['drain_result'] = $drain_result;
 $metadata['drain_history'] = $drain_summary['drain_history'];
 $metadata['retry_waited_ms'] = $drain_summary['retry_waited_ms'];
+$metadata['terminal_waited_ms'] = $drain_summary['terminal_waited_ms'];
+$metadata['job_terminal'] = ! empty( $drain_summary['job_terminal'] );
 
 $child_drain_summary = homeboy_datamachine_agent_drain_child_jobs( $job_id, $config, $jobs );
 $metadata['child_jobs'] = array_map(
@@ -3049,6 +3091,42 @@ $metadata['child_drain_results'] = $child_drain_summary['drain_results'];
 
 $job = $jobs->get_job( $job_id );
 $job_status = is_array( $job ) ? (string) ( $job['status'] ?? '' ) : '';
+$terminal_error = homeboy_datamachine_agent_job_terminal_error( $job_id, $job_status );
+if ( '' !== $terminal_error ) {
+    $metadata['job_id'] = $job_id;
+    $metadata['job_status'] = $job_status;
+    return homeboy_datamachine_agent_result(
+        array(
+            'job_completed' => 0,
+            'job_terminal'  => homeboy_datamachine_agent_job_status_terminal( $job_status ) ? 1 : 0,
+        ),
+        $metadata,
+        $terminal_error
+    );
+}
+
+foreach ( $child_drain_summary['children'] as $child_job ) {
+    if ( ! is_array( $child_job ) ) {
+        continue;
+    }
+    $child_job_id = (int) ( $child_job['job_id'] ?? 0 );
+    $child_status = (string) ( $child_job['status'] ?? '' );
+    $child_error = homeboy_datamachine_agent_job_terminal_error( $child_job_id, $child_status, 'Data Machine child job' );
+    if ( '' !== $child_error ) {
+        $metadata['job_id'] = $job_id;
+        $metadata['job_status'] = $job_status;
+        return homeboy_datamachine_agent_result(
+            array(
+                'job_completed' => 1,
+                'child_job_completed' => 0,
+                'child_job_terminal' => homeboy_datamachine_agent_job_status_terminal( $child_status ) ? 1 : 0,
+            ),
+            $metadata,
+            $child_error
+        );
+    }
+}
+
 $engine_data = function_exists( 'datamachine_get_engine_data' ) ? datamachine_get_engine_data( $job_id ) : array();
 $engine_data = homeboy_datamachine_agent_merge_recorded_tool_results( $engine_data, $config );
 $engine_data = homeboy_datamachine_agent_merge_child_engine_data( $engine_data, $child_drain_summary['children'], $config );

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -436,6 +436,15 @@ function validateDatamachineWorkload(workload, config) {
     };
   }
 
+  const failedScenario = scenarios.find((scenario) => scenario?.metadata?.error || scenario?.metadata?.error_message);
+  if (failedScenario) {
+    return {
+      class: 'datamachine.workload.failed',
+      message: failedScenario.metadata.error || failedScenario.metadata.error_message,
+      data: { reason: 'scenario_error', scenario_id: failedScenario.id, metadata: failedScenario.metadata },
+    };
+  }
+
   const outputs = config.engine_data_outputs && typeof config.engine_data_outputs === 'object' ? config.engine_data_outputs : {};
   const missing = [];
   for (const [name, outputPath] of Object.entries(outputs)) {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -34,9 +34,11 @@ if (codeFilePath) {
   fs.readFileSync(codeFilePath, 'utf8');
 }
 const isDatamachineBundle = Boolean(codeFilePath);
-const agentResult = isDatamachineBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_DATAMACHINE
-  ? { scenarios: [{ id: 'datamachine-agent', metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }] }
-  : { status: 'completed' };
+const agentResult = isDatamachineBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_DATAMACHINE
+  ? { scenarios: [{ id: 'datamachine-agent', metadata: { error: 'Data Machine child job 456 did not reach a terminal state after drain; current status is pending.' } }] }
+  : (isDatamachineBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_DATAMACHINE
+      ? { scenarios: [{ id: 'datamachine-agent', metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }] }
+      : { status: 'completed' });
 fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), recipe, datamachineConfig: JSON.parse(process.env.HOMEBOY_DATAMACHINE_AGENT_CONFIG || '{}') }, null, 2));
 process.stdout.write(JSON.stringify({
   success: true,
@@ -324,6 +326,39 @@ try {
   assert.equal(incompleteDatamachineOutput.session.status, 'failed');
   assert.equal(incompleteDatamachineOutput.diagnostics[0].class, 'datamachine.workload.incomplete');
   assert.equal(incompleteDatamachineOutput.diagnostics[0].data.reason, 'missing_scenarios');
+
+  const failedDatamachineCapturePath = path.join(root, 'capture-failed-datamachine.json');
+  const failedDatamachineResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin',
+    fixtureWpCodebox,
+    '--artifacts',
+    path.join(root, 'failed-datamachine-artifacts'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      execution_kind: 'datamachine_bundle',
+      homeboy_extensions: path.join(__dirname, '..'),
+      datamachine_bundle: {
+        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
+        engine_data_outputs: { issue_number: 'metadata.engine_data.store_idea_agent.issue_number' },
+      },
+      provider_plugin_paths: [],
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: failedDatamachineCapturePath,
+      FIXTURE_WP_CODEBOX_FAILED_DATAMACHINE: '1',
+      OPENCODE_API_KEY: 'redacted-test-key',
+    },
+  });
+  assert.equal(failedDatamachineResult.status, 1, failedDatamachineResult.stderr || failedDatamachineResult.stdout);
+  const failedDatamachineOutput = JSON.parse(failedDatamachineResult.stdout);
+  assert.equal(failedDatamachineOutput.success, false);
+  assert.equal(failedDatamachineOutput.diagnostics[0].class, 'datamachine.workload.failed');
+  assert.equal(failedDatamachineOutput.diagnostics[0].data.reason, 'scenario_error');
+  assert.match(failedDatamachineOutput.summary, /did not reach a terminal state/);
 
   const nonExecutableCapturePath = path.join(root, 'capture-non-executable.json');
   const nonExecutableFixture = createFixtureWpCodebox(root, 0o644);


### PR DESCRIPTION
## Summary
- Wait for Data Machine bundle jobs to reach a terminal job status before treating drain as complete.
- Return workload `scenarios` with metadata/engine data so producer output bindings can resolve.
- Surface scenario-level workload errors before missing-output diagnostics, so non-terminal nested jobs fail clearly.

Fixes Extra-Chill/homeboy-extensions#1061.

## Testing
- `php wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-retry-drain-smoke.php`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating the Homeboy/Data Machine bundle drain path, drafting the terminal-state fix and targeted smoke coverage, and running verification commands. Chris remains responsible for review and merge.