### PR TITLE
Surface host smoke failures in test summaries

### DIFF
--- a/scripts/lib/test-result-adapters.sh
+++ b/scripts/lib/test-result-adapters.sh
@@ -109,6 +109,23 @@ def parse_phpunit_testdox():
     return True
 
 
+def parse_host_smoke():
+    summary_match = re.search(r"^HOST_SMOKE_SUMMARY:passed=(\d+) failed=(\d+)\b", text, flags=re.MULTILINE)
+    if summary_match:
+        passed = int(summary_match.group(1))
+        failed = int(summary_match.group(2))
+        emit(passed + failed, passed, failed, 0)
+        return True
+
+    failed = len(re.findall(r"^HOST_SMOKE_FAIL:.+:exit=\d+", text, flags=re.MULTILINE))
+    if failed == 0:
+        return False
+
+    passed = len(re.findall(r"^HOST_SMOKE_OK:", text, flags=re.MULTILINE))
+    emit(passed + failed, passed, failed, 0, "host-smoke-failure")
+    return True
+
+
 def parse_cargo_test():
     passed = failed = skipped = 0
     matched = False
@@ -127,6 +144,7 @@ def parse_cargo_test():
 
 adapter_functions = {
     "wp-codebox-json": parse_wp_codebox_json,
+    "host-smoke": parse_host_smoke,
     "phpunit": parse_phpunit,
     "phpunit-testdox": parse_phpunit_testdox,
     "cargo-test": parse_cargo_test,

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -198,6 +198,24 @@ assert_contains "$WORDPRESS_PARTIAL_RESULTS" '"passed": 2'
 assert_contains "$WORDPRESS_PARTIAL_RESULTS" '"failed": 1'
 assert_contains "$WORDPRESS_PARTIAL_RESULTS" '"partial": "testdox-fallback"'
 
+WORDPRESS_HOST_SMOKE_OUTPUT="$TMP_DIR/host-smoke.txt"
+WORDPRESS_HOST_SMOKE_RESULTS="$TMP_DIR/host-smoke-results.json"
+cat > "$WORDPRESS_HOST_SMOKE_OUTPUT" <<'EOF'
+HOST_SMOKE_BEGIN:tests/wiki/installed-brain-discovery-smoke.php
+[FAIL] packaged meetups brain surfaces in brains registry
+HOST_SMOKE_FAIL:tests/wiki/installed-brain-discovery-smoke.php:exit=1
+
+Host smoke test failed: tests/wiki/installed-brain-discovery-smoke.php
+EOF
+
+HOMEBOY_RUNTIME_WRITE_TEST_RESULTS="$WRITE_TEST_RESULTS_HELPER" \
+HOMEBOY_TEST_RESULTS_FILE="$WORDPRESS_HOST_SMOKE_RESULTS" \
+    bash "$ROOT_DIR/wordpress/scripts/test/parse-test-results.sh" "$WORDPRESS_HOST_SMOKE_OUTPUT" >/dev/null
+assert_contains "$WORDPRESS_HOST_SMOKE_RESULTS" '"total": 1'
+assert_contains "$WORDPRESS_HOST_SMOKE_RESULTS" '"passed": 0'
+assert_contains "$WORDPRESS_HOST_SMOKE_RESULTS" '"failed": 1'
+assert_contains "$WORDPRESS_HOST_SMOKE_RESULTS" '"partial": "host-smoke-failure"'
+
 RUST_OUTPUT="$TMP_DIR/cargo-test.txt"
 RUST_RESULTS="$TMP_DIR/rust-results.json"
 cat > "$RUST_OUTPUT" <<'EOF'

--- a/wordpress/scripts/test/parse-test-failures-sidecar-smoke.sh
+++ b/wordpress/scripts/test/parse-test-failures-sidecar-smoke.sh
@@ -59,3 +59,50 @@ assert failure.get("stderr_excerpt") == ""
 
 print("wordpress parse-test-failures sidecar smoke passed")
 PY
+
+HOST_SMOKE_OUTPUT="$TMP_DIR/host-smoke-output.txt"
+HOST_SMOKE_FAILURES_FILE="$TMP_DIR/host-smoke-failures.json"
+
+cat > "$HOST_SMOKE_OUTPUT" <<'EOF'
+Running host PHP smoke tests...
+  Component: intelligence (/tmp/plugin)
+  Backend: host-smoke
+  Files: 1
+
+HOST_SMOKE_BEGIN:tests/wiki/installed-brain-discovery-smoke.php
+Preparing registry
+[FAIL] packaged meetups brain surfaces in brains registry
+HOST_SMOKE_FAIL:tests/wiki/installed-brain-discovery-smoke.php:exit=1
+
+Host smoke test failed: tests/wiki/installed-brain-discovery-smoke.php
+EOF
+
+HOMEBOY_TEST_FAILURES_FILE="$HOST_SMOKE_FAILURES_FILE" \
+    bash "$SCRIPT_DIR/parse-test-failures.sh" "$HOST_SMOKE_OUTPUT" "/tmp/plugin"
+
+python3 - "$HOST_SMOKE_FAILURES_FILE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+assert payload["total"] == 1, payload
+assert payload["passed"] == 0, payload
+failures = payload["failures"]
+assert len(failures) == 1, failures
+failure = failures[0]
+
+expected_file = "tests/wiki/installed-brain-discovery-smoke.php"
+assert failure["suite"] == "host-smoke", failure
+assert failure["file"] == expected_file, failure
+assert failure["test_file"] == expected_file, failure
+assert failure["source_file"] == expected_file, failure
+assert failure["message"] == "[FAIL] packaged meetups brain surfaces in brains registry", failure
+assert "HOST_SMOKE_FAIL:tests/wiki/installed-brain-discovery-smoke.php:exit=1" in failure["stdout_excerpt"], failure
+assert "[FAIL] packaged meetups brain surfaces in brains registry" in failure["stdout_excerpt"], failure
+assert failure["exit_code"] == 1, failure
+assert len(failure.get("fingerprint", "")) == 64
+
+print("wordpress host-smoke failure sidecar smoke passed")
+PY

--- a/wordpress/scripts/test/parse-test-failures.php
+++ b/wordpress/scripts/test/parse-test-failures.php
@@ -55,6 +55,14 @@ if ( is_array( $wp_codebox_payload ) && ( $wp_codebox_payload['schema'] ?? '' ) 
 	exit( 0 );
 }
 
+if ( preg_match( '/^HOST_SMOKE_FAIL:/m', $raw ) ) {
+	echo json_encode(
+		parse_host_smoke_test_results( $raw ),
+		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+	) . "\n";
+	exit( 0 );
+}
+
 // ============================================================================
 // Phase 1: Extract test counts from summary line
 // ============================================================================
@@ -217,6 +225,95 @@ function make_output_excerpt( array $lines ): string {
 	}
 
 	return $excerpt;
+}
+
+/**
+ * Normalize host-smoke runner markers into Homeboy's failure sidecar shape.
+ */
+function parse_host_smoke_test_results( string $raw ): array {
+	$lines    = explode( "\n", $raw );
+	$passed   = preg_match_all( '/^HOST_SMOKE_OK:/m', $raw );
+	$failures = [];
+
+	foreach ( $lines as $index => $line ) {
+		if ( ! preg_match( '/^HOST_SMOKE_FAIL:(.+):exit=(\d+)$/', $line, $match ) ) {
+			continue;
+		}
+
+		$file       = $match[1];
+		$exit_code  = (int) $match[2];
+		$context    = host_smoke_failure_context_lines( $lines, $index );
+		$message    = host_smoke_failure_message( $context, $file, $exit_code );
+		$test_name  = 'Host smoke failed: ' . $file;
+		$error_type = 'HostSmokeFailure';
+
+		$failures[] = [
+			'test_name'      => $test_name,
+			'test_file'      => $file,
+			'error_type'     => $error_type,
+			'message'        => $message,
+			'source_file'    => $file,
+			'source_line'    => 0,
+			'test_id'        => $test_name,
+			'suite'          => 'host-smoke',
+			'file'           => $file,
+			'line'           => 0,
+			'failure_type'   => $error_type,
+			'fingerprint'    => make_failure_fingerprint( $test_name, $file, 0, $error_type, $message ),
+			'stdout_excerpt' => make_output_excerpt( $context ),
+			'stderr_excerpt' => '',
+			'exit_code'      => $exit_code,
+		];
+	}
+
+	return [
+		'failures' => $failures,
+		'total'    => $passed + count( $failures ),
+		'passed'   => $passed,
+	];
+}
+
+/**
+ * Keep the failed script output and runner marker together for PR comments.
+ *
+ * @param array<int,string> $lines Raw runner output lines.
+ * @return array<int,string>
+ */
+function host_smoke_failure_context_lines( array $lines, int $marker_index ): array {
+	$start = max( 0, $marker_index - 12 );
+	for ( $i = $marker_index - 1; $i >= 0; $i-- ) {
+		if ( strpos( $lines[ $i ], 'HOST_SMOKE_BEGIN:' ) === 0 ) {
+			$start = $i;
+			break;
+		}
+	}
+
+	$end = min( count( $lines ) - 1, $marker_index + 4 );
+
+	return array_slice( $lines, $start, $end - $start + 1 );
+}
+
+/**
+ * Prefer assertion text from the smoke script over the runner marker.
+ *
+ * @param array<int,string> $context Failure-context lines from one smoke file.
+ */
+function host_smoke_failure_message( array $context, string $file, int $exit_code ): string {
+	foreach ( $context as $line ) {
+		$trimmed = trim( $line );
+		if ( preg_match( '/^\[(FAIL|ERROR)\]\s+(.+)$/', $trimmed ) ) {
+			return $trimmed;
+		}
+	}
+
+	foreach ( $context as $line ) {
+		$trimmed = trim( $line );
+		if ( $trimmed !== '' && strpos( $trimmed, 'HOST_SMOKE_' ) !== 0 && strpos( $trimmed, 'Host smoke test failed:' ) !== 0 ) {
+			return $trimmed;
+		}
+	}
+
+	return sprintf( 'Host smoke test failed: %s (exit %d)', $file, $exit_code );
 }
 
 // ============================================================================

--- a/wordpress/scripts/test/parse-test-results.sh
+++ b/wordpress/scripts/test/parse-test-results.sh
@@ -40,4 +40,4 @@ fi
 ADAPTERS_HELPER="${HOMEBOY_RUNTIME_TEST_RESULT_ADAPTERS:-$(cd "${SCRIPT_DIR}/../../.." && pwd)/scripts/lib/test-result-adapters.sh}"
 # shellcheck source=../../../scripts/lib/test-result-adapters.sh
 source "$ADAPTERS_HELPER"
-homeboy_parse_test_results_with_adapters "$OUTPUT_FILE" wp-codebox-json phpunit phpunit-testdox
+homeboy_parse_test_results_with_adapters "$OUTPUT_FILE" wp-codebox-json host-smoke phpunit phpunit-testdox


### PR DESCRIPTION
## Summary
- Add a host-smoke adapter so `HOST_SMOKE_FAIL:<file>:exit=<code>` logs produce structured failed test counts instead of falling through to runner-level summaries.
- Normalize host-smoke failure logs into the WordPress failure sidecar with the failed smoke file, exit code, first nearby `[FAIL]`/`[ERROR]` assertion line, and a bounded excerpt around the marker.
- Cover both the result sidecar and failure sidecar paths with smoke-test fixtures matching issue #1064.

Closes #1064.

## Verification
- `bash -n scripts/lib/test-result-adapters.sh wordpress/scripts/test/parse-test-results.sh wordpress/scripts/test/parse-test-failures-sidecar-smoke.sh tests/runtime-helpers-smoke.sh`
- `php -l wordpress/scripts/test/parse-test-failures.php`
- `bash wordpress/scripts/test/parse-test-failures-sidecar-smoke.sh`
- `HOMEBOY_CORE_DIR=/Users/chubes/Developer/homeboy@fix-3461-bench-phase-events bash tests/runtime-helpers-smoke.sh`
- `bash wordpress/scripts/test/host-smoke-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the host-smoke parser/adapter changes and drafted targeted smoke-test coverage; Chris remains responsible for review and merge.