### PR TITLE
Provide WP Codebox sandbox tool policy

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -182,15 +182,18 @@ function runnerInput(request, artifacts) {
 }
 
 function stableTaskInput(input) {
+  const allowedTools = input.parent_request?.allowed_tools || input.parent_request?.task?.allowed_tools || [];
   const secretEnv = isDatamachineBundle(input)
     ? Array.from(new Set([...(input.secret_env || []), 'HOMEBOY_DATAMACHINE_AGENT_CONFIG']))
     : input.secret_env || [];
   return Object.fromEntries(Object.entries({
     schema: 'wp-codebox/task-input/v1',
+    version: 1,
     goal: input.parent_request?.goal || input.parent_request?.task?.prompt || input.parent_request?.task?.goal || '',
     target: input.parent_request?.target || input.parent_request?.task?.target || {},
-    allowed_tools: input.parent_request?.allowed_tools || input.parent_request?.task?.allowed_tools || [],
+    allowed_tools: allowedTools,
     expected_artifacts: input.parent_request?.expected_artifacts || input.parent_request?.task?.expected_artifacts || [],
+    sandbox_tool_policy: sandboxToolPolicy(input, allowedTools),
     policy: input.parent_request?.policy || input.parent_request?.task?.policy || {},
     context: input.parent_request?.context || input.parent_request?.task?.context || {},
     provider: input.provider,
@@ -217,6 +220,47 @@ function stableTaskInput(input) {
     datamachine_bundle: isDatamachineBundle(input) ? datamachineBundleConfig(input, input.datamachine_bundle || {}) : {},
     parent_request: input.parent_request,
   }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
+}
+
+function plainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function sandboxToolPolicy(input, allowedTools) {
+  const explicit = input.parent_request?.sandbox_tool_policy
+    || input.parent_request?.sandboxToolPolicy
+    || input.parent_request?.task?.sandbox_tool_policy
+    || input.parent_request?.task?.sandboxToolPolicy;
+  if (plainObject(explicit) && Array.isArray(explicit.tools) && explicit.tools.length > 0) {
+    return explicit;
+  }
+
+  const tools = Array.isArray(allowedTools) ? allowedTools.filter((tool) => typeof tool === 'string' && tool.trim() !== '') : [];
+  return {
+    schema: 'wp-codebox/sandbox-tool-policy/v1',
+    version: 1,
+    tools: tools.length > 0
+      ? tools.map((tool) => {
+          const id = tool.trim();
+          return {
+            id,
+            runtime_tool_id: id.replace(/^datamachine\//, '').replace(/[^A-Za-z0-9_]+/g, '_'),
+            execution_location: 'sandbox',
+            transport_visibility: 'sandbox',
+            allowed: true,
+            metadata: { source: 'homeboy_allowed_tools' },
+          };
+        })
+      : [{
+          id: 'homeboy/no-runtime-tools',
+          runtime_tool_id: 'homeboy_no_runtime_tools',
+          execution_location: 'external',
+          transport_visibility: 'hidden',
+          allowed: false,
+          metadata: { source: 'homeboy_default_empty_policy' },
+        }],
+    metadata: { source: 'homeboy-wp-codebox-task-runner' },
+  };
 }
 
 function isDatamachineBundle(input) {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -108,7 +108,12 @@ try {
   assert.equal(captured.argv.includes('--json'), true);
   assert(!captured.argv.includes('recipe-run'));
   assert.equal(captured.input.schema, 'wp-codebox/task-input/v1');
+  assert.equal(captured.input.version, 1);
   assert.equal(captured.input.goal, 'Fix the finding.');
+  assert.equal(captured.input.sandbox_tool_policy.schema, 'wp-codebox/sandbox-tool-policy/v1');
+  assert.equal(captured.input.sandbox_tool_policy.version, 1);
+  assert.equal(captured.input.sandbox_tool_policy.tools[0].id, 'homeboy/no-runtime-tools');
+  assert.equal(captured.input.sandbox_tool_policy.tools[0].allowed, false);
   assert.equal(captured.input.provider, 'opencode');
   assert.equal(captured.input.model, 'opencode-go/kimi-k2.6');
   assert.deepEqual(captured.input.secret_env, ['OPENCODE_API_KEY']);
@@ -203,6 +208,10 @@ try {
   const datamachineCapture = readJson(datamachineCapturePath);
   assert.equal(datamachineCapture.argv[0], 'agent-task-run');
   assert(datamachineCapture.input.secret_env.includes('HOMEBOY_DATAMACHINE_AGENT_CONFIG'));
+  assert.equal(datamachineCapture.input.sandbox_tool_policy.schema, 'wp-codebox/sandbox-tool-policy/v1');
+  assert.equal(datamachineCapture.input.sandbox_tool_policy.tools.length, 1);
+  assert.equal(datamachineCapture.input.sandbox_tool_policy.tools[0].id, 'homeboy/no-runtime-tools');
+  assert.equal(datamachineCapture.input.sandbox_tool_policy.tools[0].allowed, false);
   assert.equal(datamachineCapture.input.datamachine_bundle.engine_data_outputs.issue_number, 'metadata.engine_data.store_idea_agent.issue_number');
   assert.equal(datamachineCapture.datamachineConfig.engine_data_outputs.issue_number, 'metadata.engine_data.store_idea_agent.issue_number');
   const datamachineOutput = JSON.parse(datamachineResult.stdout);


### PR DESCRIPTION
## Summary
- Add a `wp-codebox/sandbox-tool-policy/v1` snapshot to Homeboy-generated WP Codebox task inputs.
- Preserve explicit caller-provided sandbox tool policies when present.
- Emit a safe denied sentinel policy when no runtime tools are requested, which satisfies WP Codebox validation without granting extra tools.

Follow-up for Extra-Chill/homeboy-extensions#1061 after wp-site-generator run https://github.com/chubes4/wp-site-generator/actions/runs/26961693993 exposed the next blocker:

> Sandbox tool policy is invalid: sandbox_tool_policy.schema must be wp-codebox/sandbox-tool-policy/v1.; sandbox_tool_policy.version must be 1.; sandbox_tool_policy.tools must be a non-empty array.

## Testing
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating the failing wp-site-generator rerun, drafting the Homeboy/WP Codebox sandbox tool policy fix, and running targeted smoke tests. Chris remains responsible for review and merge.