### PR TITLE
Map WP Codebox completed status for Homeboy

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -207,8 +207,11 @@ function datamachineBundleConfigFromAgentTaskRequest(request, config, inputs) {
 }
 
 function normalizeStatus(result, exitStatus = 0) {
-  if (result?.status) {
+  if (AGENT_TASK_OUTCOME_STATUSES.includes(result?.status)) {
     return result.status;
+  }
+  if (result?.status === 'completed') {
+    return result?.success === true && exitStatus === 0 ? 'succeeded' : 'failed';
   }
   const agentResult = result?.run?.agentResult || result?.agentResult || result?.agent_result || result?.metadata?.recipe_run?.agentResult || result?.metadata?.recipe_run?.run?.agentResult;
   const changedFileCount = agentResult?.changedFiles?.count;

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -341,6 +341,7 @@ assert.equal(outcome.artifacts[0].path, '/tmp/artifacts');
 const upstreamRunnerOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
   session: {
     id: 'sandbox-session-1',
     artifacts: {
@@ -353,6 +354,15 @@ const upstreamRunnerOutcome = agentTaskOutcomeFromCodeboxResult(request, {
 assert.equal(upstreamRunnerOutcome.status, 'succeeded');
 assert.equal(upstreamRunnerOutcome.artifacts[0].kind, 'codebox-artifact-directory');
 assert.equal(upstreamRunnerOutcome.artifacts[0].path, '/tmp/wp-codebox-artifacts');
+
+const completedFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: false,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  summary: 'Data Machine bundle workload did not return any scenarios.',
+});
+assert.equal(completedFailureOutcome.status, 'failed');
+assert.equal(completedFailureOutcome.failure_classification, 'execution_failed');
 
 const datamachineOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,


### PR DESCRIPTION
## Summary
- Map WP Codebox `status: completed` into Homeboy provider outcome statuses instead of passing it through.
- Preserve existing Homeboy statuses when already valid.
- Add regression coverage for successful and failed `completed` Codebox results.

Follow-up for Extra-Chill/homeboy-extensions#1061 after wp-site-generator run https://github.com/chubes4/wp-site-generator/actions/runs/26962425295 exposed the next blocker:

> provider 'wordpress.codebox-agent-task-executor' returned malformed JSON: unknown variant `completed`, expected one of `succeeded`, `no_op`, `unable_to_remediate`, `provider_error`, `timeout`, `failed`, `follow_up_issue`, `cancelled`

## Testing
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating the wp-site-generator rerun failure, drafting the Codebox/Homeboy status mapping fix, and running targeted smoke tests. Chris remains responsible for review and merge.