### PR TITLE
Fix Data Machine bundle mounts in Codebox tasks

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -124,6 +124,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const config = request.executor.config || {};
   const inputs = request.inputs || {};
   const datamachineBundle = datamachineBundleConfigFromAgentTaskRequest(request, config, inputs);
+  const mounts = datamachineBundleMounts(datamachineBundle, config.mounts || options.mounts || []);
   const timeoutSeconds = request.limits?.task_timeout_seconds || request.limits?.taskTimeoutSeconds;
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
   const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
@@ -156,7 +157,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
     runtime_overlays: config.runtime_overlays || options.runtimeOverlays || [],
     secret_env: config.secret_env || options.secretEnv || [],
-    mounts: config.mounts || options.mounts || [],
+    mounts,
     workspaces: config.workspaces || options.workspaces || [],
     agents_api_path: config.agents_api || config.agents_api_path || options.agentsApi || '',
     data_machine_path: config.data_machine || config.data_machine_path || options.dataMachine || '',
@@ -177,6 +178,27 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     datamachine_bundle: datamachineBundle,
     parent_request: request,
   };
+}
+
+function datamachineBundleMounts(bundleConfig, explicitMounts = []) {
+  const mounts = Array.isArray(explicitMounts) ? [...explicitMounts] : [];
+  const source = bundleConfig?.bundle_host_path;
+  const target = bundleConfig?.bundle_path;
+  if (!source || !target) {
+    return mounts;
+  }
+  if (mounts.some((mount) => mount?.source === source || mount?.target === target)) {
+    return mounts;
+  }
+  return [
+    ...mounts,
+    {
+      source,
+      target,
+      mode: 'readonly',
+      metadata: { kind: 'datamachine-bundle' },
+    },
+  ];
 }
 
 function datamachineBundleConfigFromAgentTaskRequest(request, config, inputs) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -301,6 +301,7 @@ const datamachineBundleRequest = codeboxTaskRequestFromAgentTaskRequest({
       data_machine_code: '/components/data-machine-code',
       homeboy_extensions: '/components/homeboy-extensions/wordpress',
       bundle_path: '/bundles/static-site-agent',
+      bundle_host_path: '/home/runner/work/wp-site-generator/wp-site-generator/bundles/static-site-agent',
       agent_slug: 'static-site-agent',
       pipeline_slug: 'static-site-pipeline',
       flow_slug: 'static-site-manual-flow',
@@ -324,6 +325,32 @@ assert.deepEqual(datamachineBundleRequest.datamachine_bundle.flow_step_patches, 
 assert.deepEqual(datamachineBundleRequest.datamachine_bundle.tool_recorders, [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }]);
 assert.deepEqual(datamachineBundleRequest.datamachine_bundle.engine_data_outputs, { static_site_pr_url: 'metadata.engine_data.static_site_agent.pr_url' });
 assert.equal(datamachineBundleRequest.homeboy_extensions_path, '/components/homeboy-extensions/wordpress');
+assert.deepEqual(datamachineBundleRequest.mounts, [{
+  source: '/home/runner/work/wp-site-generator/wp-site-generator/bundles/static-site-agent',
+  target: '/bundles/static-site-agent',
+  mode: 'readonly',
+  metadata: { kind: 'datamachine-bundle' },
+}]);
+
+const datamachineBundleRequestWithExplicitMount = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  executor: {
+    backend: 'codebox',
+    config: {
+      execution_kind: 'datamachine_bundle',
+      mounts: [{
+        source: '/custom/static-site-agent',
+        target: '/bundles/static-site-agent',
+        mode: 'readonly',
+        metadata: { kind: 'custom' },
+      }],
+      bundle_path: '/bundles/static-site-agent',
+      bundle_host_path: '/home/runner/work/wp-site-generator/wp-site-generator/bundles/static-site-agent',
+    },
+  },
+});
+assert.equal(datamachineBundleRequestWithExplicitMount.mounts.length, 1);
+assert.equal(datamachineBundleRequestWithExplicitMount.mounts[0].source, '/custom/static-site-agent');
 
 const outcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: false,


### PR DESCRIPTION
## Summary
- Mount Data Machine bundle host paths into the WP Codebox sandbox at the requested bundle path.
- Preserve explicit caller mounts and avoid adding duplicate bundle mounts.
- Add smoke coverage for generated bundle mounts in Codebox agent task requests.

## Testing
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the failing `wp-site-generator` Homeboy run artifacts, drafted the minimal runner request fix and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.