### PR TITLE
Preflight WordPress dependency plugin packages

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -99,6 +99,17 @@ If your plugin depends on other local plugins at runtime, declare them:
 Dependencies are mounted alongside the plugin under test and their entry
 files are loaded during the `load_deps` bootstrap stage.
 
+Bench and trace scenarios preflight dependency plugin packages before WP
+Codebox dispatch. The dependency path must be the runnable WordPress plugin
+package root with a root `Plugin Name:` main file. Monorepo source checkouts,
+such as a WooCommerce repository root where the plugin lives under
+`plugins/woocommerce/woocommerce.php`, may need a packaged plugin build before
+they can be used as WordPress runtime evidence. Preflight failures write
+structured diagnostics to
+`wordpress-dependency-plugin-preflight-diagnostics.json` in the run artifact
+directory and distinguish missing paths, missing plugin main files, and plugin
+load fatals caused by missing generated build artifacts.
+
 ## Drop-ins (`db.php`)
 
 Plugins that ship a `db.php` drop-in are supported automatically. The

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -42,6 +42,7 @@
     "test:wp-codebox-task-runner": "node tests/wp-codebox-task-runner-smoke.js",
     "test:wp-codebox-bench-recipe-builder": "node tests/wp-codebox-bench-recipe-builder-smoke.js",
     "test:wp-codebox-prepared-dependency-cache": "bash tests/prepared-bench-dependency-cache-smoke.sh",
+    "test:dependency-plugin-preflight": "bash tests/dependency-plugin-preflight-smoke.sh",
     "test:wp-codebox-bench-bootstrap-steps": "node tests/wp-codebox-bench-bootstrap-steps-smoke.js",
     "test:wp-codebox-phpunit-recipe-builder": "node tests/wp-codebox-phpunit-recipe-builder-smoke.js",
     "test:build-package-artifacts": "bash scripts/build/build-package-artifacts-smoke.sh",

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -505,6 +505,13 @@ if [ -z "$ARTIFACTS_DIR" ]; then
     ARTIFACTS_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-bench-artifacts.XXXXXX")
 fi
 
+if type homeboy_preflight_declared_validation_dependency_paths &>/dev/null; then
+    if ! homeboy_preflight_declared_validation_dependency_paths "$ARTIFACTS_DIR" "bench"; then
+        FAILED_STEP="WordPress dependency plugin preflight"
+        exit 1
+    fi
+fi
+
 wp_codebox_command=("$WP_CODEBOX_BIN")
 case "$WP_CODEBOX_BIN" in
     *.js)
@@ -522,6 +529,12 @@ fi
 DEPENDENCY_PATHS="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
 if [ -n "$DEPENDENCY_PATHS" ] && type homeboy_prepare_validation_dependency_paths_for_wp_codebox_bench &>/dev/null; then
     DEPENDENCY_PATHS=$(homeboy_prepare_validation_dependency_paths_for_wp_codebox_bench "$DEPENDENCY_PATHS" "$ARTIFACTS_DIR")
+fi
+if [ -n "$DEPENDENCY_PATHS" ] && type homeboy_preflight_wordpress_dependency_plugins &>/dev/null; then
+    if ! homeboy_preflight_wordpress_dependency_plugins "$DEPENDENCY_PATHS" "$ARTIFACTS_DIR" "bench"; then
+        FAILED_STEP="WordPress dependency plugin preflight"
+        exit 1
+    fi
 fi
 
 WP_CONFIG_DEFINES_JSON="{}"

--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -114,6 +114,297 @@ homeboy_get_validation_dependency_slug() {
     printf '%s\n' "$dir_slug"
 }
 
+homeboy_find_validation_dependency_plugin_main_file() {
+    local plugin_path="${1:-}"
+
+    [ -n "$plugin_path" ] && [ -d "$plugin_path" ] || return 1
+
+    local candidate
+    for candidate in "${plugin_path}/$(basename "$plugin_path").php" "${plugin_path}/plugin.php"; do
+        [ -f "$candidate" ] || continue
+        if grep -q 'Plugin Name:' "$candidate"; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    for candidate in "$plugin_path"/*.php; do
+        [ -f "$candidate" ] || continue
+        if grep -q 'Plugin Name:' "$candidate"; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+_homeboy_wordpress_dependency_preflight_diagnostics_file() {
+    local artifacts_dir="${1:-}"
+
+    [ -n "$artifacts_dir" ] || return 1
+    printf '%s\n' "${artifacts_dir%/}/wordpress-dependency-plugin-preflight-diagnostics.json"
+}
+
+_homeboy_wordpress_dependency_preflight_append_diagnostic() {
+    local artifacts_dir="${1:-}"
+    local code="${2:-wordpress-dependency-plugin-preflight-failed}"
+    local message="${3:-WordPress dependency plugin preflight failed.}"
+    local context="${4:-wordpress}"
+    local slug="${5:-}"
+    local dependency_path="${6:-}"
+    local expected_plugin_file="${7:-}"
+    local plugin_file="${8:-}"
+    local missing_include="${9:-}"
+    local exit_code="${10:-}"
+    local output="${11:-}"
+    local package_required="${12:-false}"
+    local source_checkout_plugin_file="${13:-}"
+
+    [ -n "$artifacts_dir" ] || return 0
+    command -v jq >/dev/null 2>&1 || return 0
+
+    local diagnostics_file existing_json tmp_file
+    diagnostics_file=$(_homeboy_wordpress_dependency_preflight_diagnostics_file "$artifacts_dir")
+    mkdir -p "$(dirname "$diagnostics_file")"
+    existing_json='{"schema":"homeboy/wordpress-dependency-plugin-preflight/v1","diagnostics":[]}'
+    if [ -f "$diagnostics_file" ]; then
+        existing_json=$(jq -c 'if type == "object" and (.diagnostics | type) == "array" then . else {schema:"homeboy/wordpress-dependency-plugin-preflight/v1", diagnostics:[]} end' "$diagnostics_file" 2>/dev/null || printf '%s\n' "$existing_json")
+    fi
+
+    tmp_file=$(mktemp "${diagnostics_file}.XXXXXX")
+    jq -n \
+        --argjson existing "$existing_json" \
+        --arg schema 'homeboy/wordpress-dependency-plugin-preflight/v1' \
+        --arg code "$code" \
+        --arg message "$message" \
+        --arg context "$context" \
+        --arg slug "$slug" \
+        --arg dependencyPath "$dependency_path" \
+        --arg expectedPluginFile "$expected_plugin_file" \
+        --arg pluginFile "$plugin_file" \
+        --arg missingInclude "$missing_include" \
+        --arg exitCode "$exit_code" \
+        --arg output "$output" \
+        --argjson packageRequired "$package_required" \
+        --arg sourceCheckoutPluginFile "$source_checkout_plugin_file" \
+        '$existing + {schema: $schema} | .diagnostics += [{
+            code: $code,
+            severity: "error",
+            phase: "dependency-preflight",
+            context: $context,
+            message: $message,
+            dependency_slug: (if $slug == "" then null else $slug end),
+            dependency_path: (if $dependencyPath == "" then null else $dependencyPath end),
+            expected_plugin_file: (if $expectedPluginFile == "" then null else $expectedPluginFile end),
+            plugin_file: (if $pluginFile == "" then null else $pluginFile end),
+            missing_include: (if $missingInclude == "" then null else $missingInclude end),
+            package_required: $packageRequired,
+            source_checkout_plugin_file: (if $sourceCheckoutPluginFile == "" then null else $sourceCheckoutPluginFile end),
+            exit_code: (if $exitCode == "" then null else ($exitCode | tonumber) end),
+            output: (if $output == "" then null else $output end)
+        }]' > "$tmp_file"
+    mv "$tmp_file" "$diagnostics_file"
+}
+
+_homeboy_wordpress_dependency_preflight_source_checkout_plugin_file() {
+    local dependency_path="${1:-}"
+    local dependency_slug="${2:-}"
+    local candidate
+
+    [ -n "$dependency_path" ] && [ -d "$dependency_path" ] || return 1
+
+    for candidate in \
+        "${dependency_path}/plugins/${dependency_slug}/${dependency_slug}.php" \
+        "${dependency_path}/plugins/${dependency_slug}/plugin.php"; do
+        [ -f "$candidate" ] || continue
+        if grep -q 'Plugin Name:' "$candidate"; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+_homeboy_wordpress_dependency_preflight_extract_missing_include() {
+    local output="${1:-}"
+    local missing=""
+
+    missing=$(printf '%s\n' "$output" | sed -n -E "s/.*Failed opening required '([^']+)'.*/\1/p; s/.*Failed opening '([^']+)'.*/\1/p" | head -1)
+    if [ -n "$missing" ]; then
+        printf '%s\n' "$missing"
+        return 0
+    fi
+
+    missing=$(printf '%s\n' "$output" | sed -n -E 's/.*(require_once|require|include_once|include)\(([^)]+)\): Failed to open stream.*/\2/p' | head -1)
+    [ -n "$missing" ] && printf '%s\n' "$missing"
+}
+
+_homeboy_wordpress_dependency_preflight_php_load() {
+    local plugin_file="${1:-}"
+    local tmp_file output exit_code
+
+    [ -n "$plugin_file" ] && [ -f "$plugin_file" ] || return 1
+
+    tmp_file=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-dependency-preflight.XXXXXX.php")
+    cat > "$tmp_file" <<'PHP'
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', '1');
+define('ABSPATH', sys_get_temp_dir() . '/homeboy-wordpress-preflight/');
+define('WPINC', 'wp-includes');
+foreach (array(
+    'add_action', 'add_filter', 'remove_action', 'remove_filter', 'do_action', 'do_action_ref_array',
+    'register_activation_hook', 'register_deactivation_hook', 'register_uninstall_hook',
+    'wp_register_script', 'wp_enqueue_script', 'wp_register_style', 'wp_enqueue_style',
+) as $function) {
+    if (!function_exists($function)) {
+        eval('function ' . $function . '(...$args) { return true; }');
+    }
+}
+if (!function_exists('apply_filters')) { function apply_filters($hook, $value = null, ...$args) { return $value; } }
+if (!function_exists('apply_filters_ref_array')) { function apply_filters_ref_array($hook, $args) { return $args[0] ?? null; } }
+if (!function_exists('plugin_dir_path')) { function plugin_dir_path($file) { return rtrim(dirname($file), '/\\') . '/'; } }
+if (!function_exists('plugin_dir_url')) { function plugin_dir_url($file) { return ''; } }
+if (!function_exists('plugin_basename')) { function plugin_basename($file) { return basename(dirname($file)) . '/' . basename($file); } }
+if (!function_exists('trailingslashit')) { function trailingslashit($string) { return rtrim($string, '/\\') . '/'; } }
+if (!function_exists('wp_normalize_path')) { function wp_normalize_path($path) { return str_replace('\\', '/', $path); } }
+if (!function_exists('wp_die')) { function wp_die($message = '', $title = '', $args = array()) { fwrite(STDERR, (string) $message); exit(1); } }
+if (!function_exists('__')) { function __($text, $domain = 'default') { return $text; } }
+if (!function_exists('_e')) { function _e($text, $domain = 'default') { echo $text; } }
+if (!function_exists('esc_html__')) { function esc_html__($text, $domain = 'default') { return $text; } }
+if (!function_exists('esc_attr__')) { function esc_attr__($text, $domain = 'default') { return $text; } }
+if (!function_exists('esc_html')) { function esc_html($text) { return $text; } }
+if (!function_exists('esc_attr')) { function esc_attr($text) { return $text; } }
+if (!function_exists('esc_url')) { function esc_url($url) { return $url; } }
+if (!function_exists('is_admin')) { function is_admin() { return false; } }
+if (!function_exists('is_multisite')) { function is_multisite() { return false; } }
+if (!function_exists('get_option')) { function get_option($option, $default = false) { return $default; } }
+if (!function_exists('get_site_option')) { function get_site_option($option, $default = false) { return $default; } }
+if (!function_exists('current_user_can')) { function current_user_can($capability, ...$args) { return false; } }
+require_once $argv[1];
+PHP
+
+    set +e
+    output=$(php "$tmp_file" "$plugin_file" 2>&1)
+    exit_code=$?
+    set -e
+    rm -f "$tmp_file"
+
+    if [ "$exit_code" -ne 0 ]; then
+        printf '%s\n' "$exit_code"
+        printf '%s\n' "$output"
+        return 1
+    fi
+
+    return 0
+}
+
+homeboy_preflight_declared_validation_dependency_paths() {
+    local artifacts_dir="${1:-}"
+    local context="${2:-wordpress}"
+    local raw configured dependency
+    local failed=0
+
+    raw="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
+    configured=$(homeboy_normalize_validation_dependencies "$(homeboy_get_validation_dependencies_raw || true)" || true)
+    if [ -n "$configured" ]; then
+        raw="${raw}"$'\n'"${configured}"
+    fi
+
+    while IFS= read -r dependency; do
+        [ -n "$dependency" ] || continue
+        case "$dependency" in
+            /*|./*|../*|*/*)
+                if [ ! -d "$dependency" ]; then
+                    _homeboy_wordpress_dependency_preflight_append_diagnostic \
+                        "$artifacts_dir" \
+                        'wordpress-dependency-path-missing' \
+                        "WordPress dependency plugin path does not exist: ${dependency}" \
+                        "$context" \
+                        "$(basename "$dependency")" \
+                        "$dependency" \
+                        "$dependency" \
+                        '' \
+                        '' \
+                        '' \
+                        '' \
+                        false \
+                        ''
+                    echo "Error: WordPress dependency plugin path does not exist: ${dependency}" >&2
+                    failed=1
+                fi
+                ;;
+        esac
+    done <<< "$raw"
+
+    [ "$failed" -eq 0 ]
+}
+
+homeboy_preflight_wordpress_dependency_plugins() {
+    local dependency_paths="${1:-}"
+    local artifacts_dir="${2:-}"
+    local context="${3:-wordpress}"
+    local dependency_path dependency_slug expected_plugin_file plugin_file nested_plugin_file load_result load_exit load_output missing_include
+    local failed=0
+
+    while IFS= read -r dependency_path; do
+        [ -n "$dependency_path" ] || continue
+
+        dependency_slug=$(homeboy_get_validation_dependency_slug "$dependency_path" || basename "$dependency_path")
+        expected_plugin_file="${dependency_path%/}/${dependency_slug}.php"
+
+        if [ ! -d "$dependency_path" ]; then
+            _homeboy_wordpress_dependency_preflight_append_diagnostic \
+                "$artifacts_dir" \
+                'wordpress-dependency-path-missing' \
+                "WordPress dependency plugin path does not exist: ${dependency_path}" \
+                "$context" "$dependency_slug" "$dependency_path" "$expected_plugin_file" '' '' '' '' false ''
+            echo "Error: WordPress dependency plugin '${dependency_slug}' path does not exist: ${dependency_path}" >&2
+            failed=1
+            continue
+        fi
+
+        plugin_file=$(homeboy_find_validation_dependency_plugin_main_file "$dependency_path" || true)
+        if [ -z "$plugin_file" ]; then
+            nested_plugin_file=$(_homeboy_wordpress_dependency_preflight_source_checkout_plugin_file "$dependency_path" "$dependency_slug" || true)
+            _homeboy_wordpress_dependency_preflight_append_diagnostic \
+                "$artifacts_dir" \
+                'wordpress-dependency-plugin-main-file-missing' \
+                "WordPress dependency plugin '${dependency_slug}' is not a runnable plugin package; no plugin main file was found at the dependency root." \
+                "$context" "$dependency_slug" "$dependency_path" "$expected_plugin_file" '' '' '' '' true "$nested_plugin_file"
+            echo "Error: WordPress dependency plugin '${dependency_slug}' is not a runnable plugin package: ${dependency_path}" >&2
+            echo "  Expected plugin main file: ${expected_plugin_file}" >&2
+            if [ -n "$nested_plugin_file" ]; then
+                echo "  Found source-checkout plugin file: ${nested_plugin_file}" >&2
+            fi
+            echo "  Use a packaged plugin build for WordPress runtime bench/trace evidence." >&2
+            failed=1
+            continue
+        fi
+
+        load_result=$(_homeboy_wordpress_dependency_preflight_php_load "$plugin_file" || true)
+        if [ -n "$load_result" ]; then
+            load_exit=$(printf '%s\n' "$load_result" | head -1)
+            load_output=$(printf '%s\n' "$load_result" | tail -n +2 | head -c 4000)
+            missing_include=$(_homeboy_wordpress_dependency_preflight_extract_missing_include "$load_output" || true)
+            _homeboy_wordpress_dependency_preflight_append_diagnostic \
+                "$artifacts_dir" \
+                'wordpress-dependency-plugin-load-fatal' \
+                "WordPress dependency plugin '${dependency_slug}' failed a lightweight PHP load preflight before WP Codebox dispatch." \
+                "$context" "$dependency_slug" "$dependency_path" "$expected_plugin_file" "$plugin_file" "$missing_include" "$load_exit" "$load_output" true ''
+            echo "Error: WordPress dependency plugin '${dependency_slug}' failed PHP load preflight before WP Codebox dispatch." >&2
+            echo "  Plugin file: ${plugin_file}" >&2
+            [ -z "$missing_include" ] || echo "  Missing include/build artifact: ${missing_include}" >&2
+            echo "  Use a packaged plugin build if this checkout needs generated runtime artifacts." >&2
+            failed=1
+        fi
+    done <<< "$dependency_paths"
+
+    [ "$failed" -eq 0 ]
+}
+
 _homeboy_is_plugin_shaped_path() {
     local plugin_path="${1:-}"
 

--- a/wordpress/scripts/trace/trace-runner.sh
+++ b/wordpress/scripts/trace/trace-runner.sh
@@ -18,6 +18,11 @@ homeboy_resolve_context --component-alias PLUGIN_PATH
 WP_CODEBOX_PATHS_HELPER="${SCRIPT_DIR}/../lib/wp-codebox-paths.sh"
 # shellcheck source=../lib/wp-codebox-paths.sh
 source "$WP_CODEBOX_PATHS_HELPER"
+DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
+# shellcheck source=../lib/validation-dependencies.sh
+if [ -f "$DEPENDENCY_HELPER" ]; then
+    source "$DEPENDENCY_HELPER"
+fi
 
 export HOMEBOY_COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-$COMPONENT_PATH}"
 export HOMEBOY_TRACE_COMPONENT_PATH="${HOMEBOY_TRACE_COMPONENT_PATH:-$HOMEBOY_COMPONENT_PATH}"
@@ -341,6 +346,22 @@ export HOMEBOY_TRACE_RESULTS_FILE="${HOMEBOY_TRACE_RESULTS_FILE:-${HOMEBOY_RUN_D
 
 mkdir -p "$HOMEBOY_TRACE_ARTIFACT_DIR" "$(dirname "$HOMEBOY_TRACE_RESULTS_FILE")"
 homeboy_wordpress_export_context
+
+if type homeboy_preflight_declared_validation_dependency_paths &>/dev/null; then
+    if ! homeboy_preflight_declared_validation_dependency_paths "$HOMEBOY_TRACE_ARTIFACT_DIR" "trace"; then
+        homeboy_trace_write_failure "fail" "WordPress dependency plugin preflight failed before WP Codebox dispatch"
+        exit 1
+    fi
+fi
+if type homeboy_export_validation_dependency_paths &>/dev/null; then
+    homeboy_export_validation_dependency_paths "$HOMEBOY_COMPONENT_PATH"
+fi
+if [ -n "${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}" ] && type homeboy_preflight_wordpress_dependency_plugins &>/dev/null; then
+    if ! homeboy_preflight_wordpress_dependency_plugins "$HOMEBOY_WORDPRESS_DEPENDENCY_PATHS" "$HOMEBOY_TRACE_ARTIFACT_DIR" "trace"; then
+        homeboy_trace_write_failure "fail" "WordPress dependency plugin preflight failed before WP Codebox dispatch"
+        exit 1
+    fi
+fi
 
 stdout_file="${HOMEBOY_TRACE_ARTIFACT_DIR}/${HOMEBOY_TRACE_SCENARIO}.stdout.txt"
 stderr_file="${HOMEBOY_TRACE_ARTIFACT_DIR}/${HOMEBOY_TRACE_SCENARIO}.stderr.txt"

--- a/wordpress/tests/dependency-plugin-preflight-smoke.sh
+++ b/wordpress/tests/dependency-plugin-preflight-smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEPENDENCY_HELPER="${EXTENSION_DIR}/scripts/lib/validation-dependencies.sh"
+
+# shellcheck source=../scripts/lib/validation-dependencies.sh
+source "$DEPENDENCY_HELPER"
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-dependency-preflight-smoke.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+assert_diagnostic() {
+    local diagnostics_file="$1"
+    local jq_filter="$2"
+    local message="$3"
+
+    if ! jq -e "$jq_filter" "$diagnostics_file" >/dev/null; then
+        echo "ERROR: ${message}" >&2
+        jq '.' "$diagnostics_file" >&2 || true
+        exit 1
+    fi
+}
+
+MISSING_PATH="${TMP_ROOT}/missing-plugin"
+MISSING_PATH_ARTIFACTS="${TMP_ROOT}/missing-path-artifacts"
+if homeboy_preflight_wordpress_dependency_plugins "$MISSING_PATH" "$MISSING_PATH_ARTIFACTS" "bench"; then
+    echo "ERROR: expected missing dependency path preflight to fail." >&2
+    exit 1
+fi
+assert_diagnostic \
+    "${MISSING_PATH_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" \
+    '(.diagnostics | length) == 1 and .diagnostics[0].code == "wordpress-dependency-path-missing" and .diagnostics[0].dependency_slug == "missing-plugin"' \
+    'missing path diagnostic did not identify the missing dependency path.'
+
+WOOCOMMERCE_SOURCE="${TMP_ROOT}/woocommerce"
+mkdir -p "${WOOCOMMERCE_SOURCE}/plugins/woocommerce"
+cat > "${WOOCOMMERCE_SOURCE}/plugins/woocommerce/woocommerce.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: WooCommerce
+ */
+PHP
+
+MISSING_MAIN_ARTIFACTS="${TMP_ROOT}/missing-main-artifacts"
+if homeboy_preflight_wordpress_dependency_plugins "$WOOCOMMERCE_SOURCE" "$MISSING_MAIN_ARTIFACTS" "bench"; then
+    echo "ERROR: expected source checkout without root plugin main file to fail." >&2
+    exit 1
+fi
+assert_diagnostic \
+    "${MISSING_MAIN_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" \
+    '(.diagnostics | length) == 1 and .diagnostics[0].code == "wordpress-dependency-plugin-main-file-missing" and .diagnostics[0].package_required == true and (.diagnostics[0].source_checkout_plugin_file | endswith("/plugins/woocommerce/woocommerce.php"))' \
+    'missing main file diagnostic did not identify source-checkout package requirement.'
+
+FATAL_DEP="${TMP_ROOT}/woocommerce-packaged"
+mkdir -p "$FATAL_DEP"
+cat > "${FATAL_DEP}/woocommerce-packaged.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: WooCommerce Packaged Fixture
+ */
+require_once __DIR__ . '/includes/react-admin/feature-config.php';
+PHP
+
+LOAD_FATAL_ARTIFACTS="${TMP_ROOT}/load-fatal-artifacts"
+if homeboy_preflight_wordpress_dependency_plugins "$FATAL_DEP" "$LOAD_FATAL_ARTIFACTS" "bench"; then
+    echo "ERROR: expected plugin load fatal preflight to fail." >&2
+    exit 1
+fi
+assert_diagnostic \
+    "${LOAD_FATAL_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" \
+    '(.diagnostics | length) == 1 and .diagnostics[0].code == "wordpress-dependency-plugin-load-fatal" and .diagnostics[0].package_required == true and (.diagnostics[0].missing_include | endswith("/includes/react-admin/feature-config.php"))' \
+    'load fatal diagnostic did not identify the missing build artifact.'
+
+READY_DEP="${TMP_ROOT}/ready-plugin"
+mkdir -p "$READY_DEP"
+cat > "${READY_DEP}/ready-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Ready Plugin
+ */
+add_action('plugins_loaded', static function () {});
+PHP
+
+READY_ARTIFACTS="${TMP_ROOT}/ready-artifacts"
+homeboy_preflight_wordpress_dependency_plugins "$READY_DEP" "$READY_ARTIFACTS" "bench"
+if [ -f "${READY_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" ]; then
+    echo "ERROR: ready plugin dependency should not emit preflight diagnostics." >&2
+    exit 1
+fi
+
+echo "dependency plugin preflight smoke passed"


### PR DESCRIPTION
## Summary
- Adds a WordPress dependency plugin package preflight shared by bench and trace runners before WP Codebox dispatch.
- Emits structured diagnostics for missing dependency paths, missing root plugin main files, and lightweight PHP load fatals that point at missing generated build artifacts.
- Documents that monorepo source checkouts, including WooCommerce-style roots with `plugins/woocommerce/woocommerce.php`, may need a packaged plugin build for runtime evidence.

Fixes #1070.

## Tests
- `bash -n wordpress/scripts/lib/validation-dependencies.sh`
- `bash -n wordpress/scripts/bench/bench-runner-wp-codebox.sh`
- `bash -n wordpress/scripts/trace/trace-runner.sh`
- `bash -n wordpress/tests/dependency-plugin-preflight-smoke.sh`
- `git diff --check`
- `npm run test:dependency-plugin-preflight`
- `npm run test:wp-codebox-prepared-dependency-cache`
- `npm run test:wp-codebox-bench-bootstrap-steps`
- `bash wordpress/scripts/trace/trace-runner-smoke.sh`
- `npm run test:wp-codebox-bench-recipe-builder`

## Known existing lint debt
- `npm run lint:js` fails on unrelated pre-existing JS lint issues in `wordpress/lib/playground-readiness.js`, `wordpress/lib/request-profiler.js`, `wordpress/lib/timing-correlator.js`, and agent scripts. This PR does not modify those files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the dependency preflight implementation, smoke coverage, and PR description for Chris to review and test.