### PR TITLE
Fix Data Machine bundle run normalization

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -288,9 +288,10 @@ function normalizeAgentTaskRun(input, result) {
     return result;
   }
 
-  const execution = Array.isArray(result.executions) ? result.executions.find((item) => item?.recipeCommand === 'wp-codebox.agent-sandbox-run') || result.executions[0] : null;
+  const executions = Array.isArray(result.executions) && result.executions.length > 0 ? result.executions : (Array.isArray(result.run?.executions) ? result.run.executions : []);
+  const execution = executions.find((item) => item?.recipeCommand === 'wp-codebox.agent-sandbox-run') || executions[0] || null;
   const datamachineConfig = datamachineBundleConfig(input, input.datamachine_bundle || {});
-  const agentResult = result.run?.agentResult || result.agentResult || result.agent_result || result.metadata?.datamachine?.workload || execution?.agentResult || datamachineWorkloadFromExecutionStdout(execution, datamachineConfig) || {};
+  const agentResult = datamachineWorkloadFromExecutionStdout(execution, datamachineConfig) || result.metadata?.datamachine?.workload || execution?.agentResult || result.run?.agentResult || result.agentResult || result.agent_result || {};
   const datamachineValidation = validateDatamachineWorkload(agentResult, datamachineConfig);
   const success = !datamachineValidation;
   const diagnostics = [
@@ -339,7 +340,11 @@ function datamachineWorkloadFromExecutionStdout(execution, config) {
   const wrapper = parseJsonObject(execution?.stdout || '');
   const workload = parseJsonObject(wrapper?.output || '') || parseJsonObject(execution?.stdout || '');
   if (!workload) {
-    return {};
+    return null;
+  }
+  const bundleRun = workload.agent_runtime?.result || workload.result || workload;
+  if (bundleRun?.schema === 'datamachine/agent-bundle-run/v1') {
+    return datamachineWorkloadFromBundleRun(bundleRun, config);
   }
   if (Array.isArray(workload.scenarios)) {
     return workload;
@@ -353,7 +358,27 @@ function datamachineWorkloadFromExecutionStdout(execution, config) {
       }],
     };
   }
-  return {};
+  return null;
+}
+
+function datamachineWorkloadFromBundleRun(bundleRun, config) {
+  const bundle = bundleRun.bundle && typeof bundleRun.bundle === 'object' ? bundleRun.bundle : {};
+  const workflowSteps = Array.isArray(bundleRun.workflow?.steps) ? bundleRun.workflow.steps : [];
+  return {
+    scenarios: [{
+      id: config.workload_id || bundle.flow_slug || bundle.bundle_slug || config.agent_slug || config.flow_slug || 'datamachine-agent',
+      metrics: {
+        workflow_step_count: workflowSteps.length,
+      },
+      metadata: {
+        schema: bundleRun.schema,
+        success: bundleRun.success !== false,
+        dry_run: Boolean(bundleRun.dry_run),
+        bundle,
+        error: bundleRun.success === false ? bundleRun.error : undefined,
+      },
+    }],
+  };
 }
 
 function pathValue(source, dottedPath) {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -22,10 +22,28 @@ const input = inputPath ? JSON.parse(fs.readFileSync(inputPath, 'utf8')) : null;
 const isDatamachineBundle = Boolean(input.datamachine_bundle && Object.keys(input.datamachine_bundle).length);
 const agentResult = isDatamachineBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_DATAMACHINE
   ? { scenarios: [{ id: 'datamachine-agent', metadata: { error: 'Data Machine child job 456 did not reach a terminal state after drain; current status is pending.' } }] }
+  : (isDatamachineBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
+      ? {
+          agent_runtime: {
+            success: true,
+            result: {
+              schema: 'datamachine/agent-bundle-run/v1',
+              success: true,
+              dry_run: true,
+              bundle: {
+                bundle_slug: 'store-idea-agent',
+                flow_slug: 'static-site-manual-flow',
+                pipeline_slug: 'static-site-pipeline',
+              },
+              workflow: { steps: [{ step_type: 'ai' }] },
+            },
+          },
+        }
   : (isDatamachineBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_DATAMACHINE
       ? { metrics: { config_present: 1 }, metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }
-      : { status: 'completed' });
+      : { status: 'completed' }));
 fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), input, datamachineConfig: JSON.parse(process.env.HOMEBOY_DATAMACHINE_AGENT_CONFIG || '{}') }, null, 2));
+const executions = [{ recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed', output: JSON.stringify(agentResult) }) }];
 process.stdout.write(JSON.stringify({
   success: !isDatamachineBundle,
   schema: 'wp-codebox/agent-task-run/v1',
@@ -38,8 +56,8 @@ process.stdout.write(JSON.stringify({
   },
   task_input: input,
   artifacts: input.artifacts_path,
-  run: isDatamachineBundle ? {} : { agentResult },
-  executions: [{ recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed', output: JSON.stringify(agentResult) }) }],
+  run: isDatamachineBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN ? { executions } : (isDatamachineBundle ? {} : { agentResult }),
+  executions: isDatamachineBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN ? [] : executions,
 }));
 `);
   fs.chmodSync(binPath, mode);
@@ -218,6 +236,38 @@ try {
   assert.equal(datamachineOutput.success, true);
   assert.equal(datamachineOutput.session.status, 'completed');
   assert.equal(datamachineOutput.run.agentResult.scenarios[0].metadata.engine_data.store_idea_agent.issue_number, 123);
+
+  const canonicalBundleRunCapturePath = path.join(root, 'capture-canonical-datamachine-bundle-run.json');
+  const canonicalBundleRunResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin',
+    fixtureWpCodebox,
+    '--artifacts',
+    path.join(root, 'canonical-datamachine-bundle-run-artifacts'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      datamachine_bundle: {
+        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
+        dry_run: true,
+      },
+      provider_plugin_paths: [],
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: canonicalBundleRunCapturePath,
+      FIXTURE_WP_CODEBOX_BUNDLE_RUN: '1',
+      OPENCODE_API_KEY: 'redacted-test-key',
+    },
+  });
+  assert.equal(canonicalBundleRunResult.status, 0, canonicalBundleRunResult.stderr || canonicalBundleRunResult.stdout);
+  const canonicalBundleRunOutput = JSON.parse(canonicalBundleRunResult.stdout);
+  assert.equal(canonicalBundleRunOutput.success, true);
+  assert.equal(canonicalBundleRunOutput.session.status, 'completed');
+  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.schema, 'datamachine/agent-bundle-run/v1');
+  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.dry_run, true);
+  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metrics.workflow_step_count, 1);
 
   const incompleteDatamachineCapturePath = path.join(root, 'capture-incomplete-datamachine.json');
   const incompleteDatamachineResult = spawnSync(process.execPath, [


### PR DESCRIPTION
## Summary
- Normalize canonical `datamachine/agent-bundle-run/v1` results from WP Codebox sandbox output into Homeboy workload scenarios.
- Prefer the sandbox execution payload for Data Machine bundle runs, including `run.executions`, while preserving existing scenario and engine-output validation.

## Verification
- `node tests/wp-codebox-task-runner-smoke.js`
- `node tests/codebox-agent-task-executor-smoke.js`
- `git diff --check`
- Real Homeboy -> WP Codebox -> Data Machine dry-run E2E passed with `success: true`, `session.status: completed`, and a normalized `datamachine/agent-bundle-run/v1` scenario.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the E2E normalization failure, drafted the fix and smoke coverage, and ran verification. Chris remains responsible for review and merge.