### PR TITLE
Consume canonical Data Machine bundle results

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -288,9 +288,12 @@ function normalizeAgentTaskRun(input, result) {
     return result;
   }
 
-  const execution = Array.isArray(result.executions) ? result.executions.find((item) => item?.recipeCommand === 'wp-codebox.agent-sandbox-run') || result.executions[0] : null;
+  const executions = Array.isArray(result.run?.executions) ? result.run.executions : result.executions;
+  const execution = Array.isArray(executions) ? executions.find((item) => item?.recipeCommand === 'wp-codebox.agent-sandbox-run') || executions[0] : null;
   const datamachineConfig = datamachineBundleConfig(input, input.datamachine_bundle || {});
-  const agentResult = result.run?.agentResult || result.agentResult || result.agent_result || result.metadata?.datamachine?.workload || execution?.agentResult || datamachineWorkloadFromExecutionStdout(execution, datamachineConfig) || {};
+  const stdoutWorkload = datamachineWorkloadFromExecutionStdout(execution, datamachineConfig);
+  const fallbackAgentResult = result.metadata?.datamachine?.workload || result.agent_result || result.run?.agentResult || result.agentResult || execution?.agentResult || {};
+  const agentResult = hasScenarios(stdoutWorkload) ? stdoutWorkload : fallbackAgentResult;
   const datamachineValidation = validateDatamachineWorkload(agentResult, datamachineConfig);
   const success = !datamachineValidation;
   const diagnostics = [
@@ -341,6 +344,10 @@ function datamachineWorkloadFromExecutionStdout(execution, config) {
   if (!workload) {
     return {};
   }
+  const bundleRun = workload.agent_runtime?.result || workload.result || workload;
+  if (bundleRun?.schema === 'datamachine/agent-bundle-run/v1') {
+    return datamachineWorkloadFromBundleRun(bundleRun, config);
+  }
   if (Array.isArray(workload.scenarios)) {
     return workload;
   }
@@ -354,6 +361,34 @@ function datamachineWorkloadFromExecutionStdout(execution, config) {
     };
   }
   return {};
+}
+
+function datamachineWorkloadFromBundleRun(bundleRun, config) {
+  const bundle = bundleRun.bundle && typeof bundleRun.bundle === 'object' ? bundleRun.bundle : {};
+  const workflowSteps = Array.isArray(bundleRun.workflow?.steps) ? bundleRun.workflow.steps : [];
+  return {
+    scenarios: [{
+      id: config.workload_id || bundle.flow_slug || bundle.bundle_slug || config.agent_slug || config.flow_slug || 'datamachine-agent',
+      metrics: {
+        workflow_step_count: workflowSteps.length,
+      },
+      metadata: {
+        schema: bundleRun.schema,
+        success: bundleRun.success !== false,
+        dry_run: Boolean(bundleRun.dry_run),
+        bundle,
+        job_id: bundleRun.job_id,
+        job_status: bundleRun.job_status,
+        wait_result: bundleRun.wait_result,
+        engine_data: bundleRun.engine_data,
+        error: bundleRun.success === false ? bundleRun.error : undefined,
+      },
+    }],
+  };
+}
+
+function hasScenarios(value) {
+  return Array.isArray(value?.scenarios) && value.scenarios.length > 0;
 }
 
 function pathValue(source, dottedPath) {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -20,11 +20,24 @@ const inputArg = process.argv.find((arg) => arg.startsWith('--input-file='));
 const inputPath = inputArg ? inputArg.slice('--input-file='.length) : '';
 const input = inputPath ? JSON.parse(fs.readFileSync(inputPath, 'utf8')) : null;
 const isDatamachineBundle = Boolean(input.datamachine_bundle && Object.keys(input.datamachine_bundle).length);
+const bundleRun = isDatamachineBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
+  ? {
+      schema: 'datamachine/agent-bundle-run/v1',
+      success: true,
+      dry_run: false,
+      job_id: 1,
+      job_status: 'completed',
+      bundle: { flow_slug: 'store-idea-home-and-craft-flow' },
+      wait_result: { success: true, terminal_state: 'completed' },
+      engine_data: { store_idea_agent: { issue_number: 123, issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123' } }
+    }
+  : null;
 const agentResult = isDatamachineBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_DATAMACHINE
   ? { scenarios: [{ id: 'datamachine-agent', metadata: { error: 'Data Machine child job 456 did not reach a terminal state after drain; current status is pending.' } }] }
   : (isDatamachineBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_DATAMACHINE
       ? { metrics: { config_present: 1 }, metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }
       : { status: 'completed' });
+const execution = { recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify(bundleRun ? { agent_runtime: { success: true, result: bundleRun } } : { status: 'completed', output: JSON.stringify(agentResult) }) };
 fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), input, datamachineConfig: JSON.parse(process.env.HOMEBOY_DATAMACHINE_AGENT_CONFIG || '{}') }, null, 2));
 process.stdout.write(JSON.stringify({
   success: !isDatamachineBundle,
@@ -38,8 +51,8 @@ process.stdout.write(JSON.stringify({
   },
   task_input: input,
   artifacts: input.artifacts_path,
-  run: isDatamachineBundle ? {} : { agentResult },
-  executions: [{ recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed', output: JSON.stringify(agentResult) }) }],
+  run: isDatamachineBundle ? (bundleRun ? { agentResult: { status: 'completed' }, executions: [execution] } : {}) : { agentResult },
+  executions: bundleRun ? [] : [execution],
 }));
 `);
   fs.chmodSync(binPath, mode);
@@ -218,6 +231,38 @@ try {
   assert.equal(datamachineOutput.success, true);
   assert.equal(datamachineOutput.session.status, 'completed');
   assert.equal(datamachineOutput.run.agentResult.scenarios[0].metadata.engine_data.store_idea_agent.issue_number, 123);
+
+  const canonicalBundleRunCapturePath = path.join(root, 'capture-canonical-datamachine-bundle-run.json');
+  const canonicalBundleRunResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin',
+    fixtureWpCodebox,
+    '--artifacts',
+    path.join(root, 'canonical-datamachine-bundle-run-artifacts'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      datamachine_bundle: {
+        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
+        engine_data_outputs: { issue_number: 'metadata.engine_data.store_idea_agent.issue_number' },
+      },
+      provider_plugin_paths: [],
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: canonicalBundleRunCapturePath,
+      FIXTURE_WP_CODEBOX_BUNDLE_RUN: '1',
+      OPENCODE_API_KEY: 'redacted-test-key',
+    },
+  });
+  assert.equal(canonicalBundleRunResult.status, 0, canonicalBundleRunResult.stderr || canonicalBundleRunResult.stdout);
+  const canonicalBundleRunOutput = JSON.parse(canonicalBundleRunResult.stdout);
+  assert.equal(canonicalBundleRunOutput.success, true);
+  assert.equal(canonicalBundleRunOutput.session.status, 'completed');
+  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.schema, 'datamachine/agent-bundle-run/v1');
+  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.job_status, 'completed');
+  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.engine_data.store_idea_agent.issue_number, 123);
 
   const incompleteDatamachineCapturePath = path.join(root, 'capture-incomplete-datamachine.json');
   const incompleteDatamachineResult = spawnSync(process.execPath, [


### PR DESCRIPTION
## Summary
- Parse canonical `datamachine/agent-bundle-run/v1` output from WP Codebox sandbox results.
- Project final `engine_data` into the existing Homeboy `scenarios[]` envelope expected by Site Generation Loop bindings.
- Add smoke coverage for canonical bundle-run output so future Data Machine/WP Codebox contract changes are caught.

## Dependencies
- Depends on Extra-Chill/data-machine#2514 for the Data Machine final-result contract.
- Depends on Automattic/wp-codebox#604 for requesting that final-result mode from WP Codebox.

## Testing
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the Site Generation Loop output binding failure, updated Homeboy Extensions to consume canonical Data Machine bundle results through WP Codebox, and ran targeted smoke verification. Chris remains responsible for review and merge.