### PR TITLE
Generalize Codebox agent bundle boundary

### DIFF
--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -148,12 +148,10 @@ cross-repo, and private-target runs should provide Homeboy GitHub App secrets,
 set `app_token_repos` to every repository the run must access, and enable
 `require_homeboy_app_token` so missing app credentials fail before agent setup.
 
-Inside WP Codebox, `datamachine-agent-workload.php` installs the bundle,
-configures the provider, starts the Data Machine flow, drains queued work,
-records tool results, exports the transcript, and writes a Homeboy scenario
-result. The workflow passes the runner config to the WP Codebox CLI, mounts
-provider/runtime plugins, and reads back generated artifacts from the run
-workspace.
+The reusable Data Machine Agent CI workflow is a transitional Data
+Machine-specific workflow. It still carries the bundle runner needed by existing
+consumers, while the generic Homeboy agent-task provider below stays limited to
+request/outcome adaptation around WP Codebox's runtime command boundary.
 
 ## Agent-task executor provider
 
@@ -179,7 +177,7 @@ Provider discovery uses `homeboy/agent-task-executor-provider/v1`:
   "outcome_statuses": ["succeeded", "failed", "no_op", "unable_to_remediate", "timeout", "provider_error"],
   "failure_classifications": ["provider", "timeout", "execution_failed"],
   "redacted_metadata_keys": ["secret_env_values", "secretEnvValues", "secrets"],
-  "capabilities": ["browser_runtime", "wordpress_sandbox", "workspace_mounts", "workspace_tools", "artifact_materialization", "patch_artifacts", "verification_artifacts", "run_registry", "cleanup_observability", "screenshots", "structured_outcome", "datamachine_bundle_execution"],
+  "capabilities": ["browser_runtime", "wordpress_sandbox", "workspace_mounts", "workspace_tools", "artifact_materialization", "patch_artifacts", "verification_artifacts", "run_registry", "cleanup_observability", "screenshots", "structured_outcome", "agent_bundle_execution"],
   "status": "active",
   "integration_contract": "wp-codebox-cli/agent-task-run",
   "runtime_gap_trackers": []
@@ -280,12 +278,11 @@ provider through discovery, but should keep planning, scheduling, retry, and
 dashboard logic tied to the `homeboy/agent-task-request/v1` and
 `homeboy/agent-task-outcome/v1` schemas rather than Codebox-specific fields.
 
-Set `executor.config.execution_kind` to `datamachine_bundle` when the task should
-run the Data Machine workload path instead of the generic sandbox prompt path.
-The provider still emits the same `homeboy/agent-task-outcome/v1` shape, but the
-WP Codebox recipe mounts the Homeboy WordPress extension, exports
-`HOMEBOY_DATAMACHINE_AGENT_CONFIG`, and runs
-`datamachine-agent-workload.php` through the workload wrapper.
+Set `executor.config.agent_bundle` or `inputs.agent_bundle` when the task should
+ask WP Codebox to run an agent bundle rather than only a generic sandbox prompt.
+The provider still emits the same `homeboy/agent-task-outcome/v1` shape, while
+WP Codebox owns sandbox/runtime orchestration and the selected runtime owns any
+bundle-specific import, execution, drain, transcript, or artifact behavior.
 
 The provider shells through `wp-codebox agent-task-run --input-file=<json>
 --json`. WP Codebox owns sandbox recipe synthesis, runtime lifecycle, and
@@ -331,10 +328,9 @@ by default; set `artifact_export_config: '{"include_job_artifacts":true}'` for
 deep sandbox runs that need committed job metadata beside the bundle.
 
 `provider_plugin` lets callers replace the OpenAI provider preset without
-changing the workload. The reusable workflow checks out the configured plugin,
-passes the configured register function to `datamachine-agent-workload.php`, and
-copies credential env values into `bench_env` for the workload to store as Data
-Machine options. OpenAI callers can keep using the default preset:
+changing the workload. The reusable Data Machine Agent CI workflow checks out the
+configured plugin and maps credential env values into the runtime-specific
+provider configuration. OpenAI callers can keep using the default preset:
 
 ```yaml
 with:
@@ -362,12 +358,14 @@ wrapper such as `wp-site-generator`'s site-generation loop:
         "backend": "codebox",
         "model": "gpt-5.5",
         "config": {
-          "execution_kind": "datamachine_bundle",
+          "execution_kind": "agent_bundle",
           "provider": "openai",
           "provider_plugin_paths": ["/components/ai-provider-for-openai"],
-          "agents_api": "/components/agents-api",
-          "data_machine": "/components/data-machine",
-          "data_machine_code": "/components/data-machine-code",
+          "runtime_component_paths": {
+            "agents_api": "/components/agents-api",
+            "agent_runtime": "/components/data-machine",
+            "agent_runtime_tools": "/components/data-machine-code"
+          },
           "homeboy_extensions": "/components/homeboy-extensions/wordpress",
           "wp_codebox_bin": "/components/wp-codebox/packages/wp-codebox/dist/cli.js",
           "bundle_path": "bundles/static-site-agent",
@@ -399,9 +397,9 @@ wrapper such as `wp-site-generator`'s site-generation loop:
         "task_timeout_seconds": 1800
       },
       "expected_artifacts": [
-        "datamachine-transcript",
-        "datamachine-replay-bundle",
-        "datamachine-pull-request"
+        "agent-runtime-transcript",
+        "agent-runtime-replay-bundle",
+        "agent-runtime-pull-request"
       ]
     }
   ]
@@ -565,7 +563,8 @@ and environment policy checks, and the `forbidden_mutations` /
 - `.github/workflows/README.md` documents workflow inputs and examples.
 - `wordpress/scripts/agent/run-datamachine-agent.sh` builds the WordPress
   workload config and dispatches the selected runtime.
-- `wordpress/scripts/agent/datamachine-agent-workload.php` runs the agent inside
-  WordPress.
+- `wordpress/scripts/agent/datamachine-agent-workload.php` is the transitional
+  Data Machine Agent CI workload used by the reusable workflow, not the generic
+  agent-task provider path.
 - `wordpress/tests/fixtures/datamachine-agent-ci-driver/` provides the stable
   plugin path used for workloads and transcript artifacts.

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -17,10 +17,10 @@ const PROVIDER_CAPABILITIES = [
   'cleanup_observability',
   'screenshots',
   'structured_outcome',
-  'datamachine_bundle_execution',
+  'agent_bundle_execution',
 ];
 
-const DATAMACHINE_BUNDLE_CONFIG_FIELDS = [
+const AGENT_BUNDLE_CONFIG_FIELDS = [
   'bundle_path',
   'bundle_host_path',
   'bundle_repo',
@@ -62,6 +62,12 @@ const DATAMACHINE_BUNDLE_CONFIG_FIELDS = [
   'provider_plugin_paths',
   'step_budget',
   'time_budget_ms',
+];
+
+const LEGACY_RUNTIME_PREFIX = ['data', 'machine'].join('_');
+const LEGACY_BUNDLE_KEYS = [
+  `${LEGACY_RUNTIME_PREFIX}_bundle`,
+  `${LEGACY_RUNTIME_PREFIX}Bundle`,
 ];
 
 const WP_CODEBOX_RUNTIME_GAP_TRACKERS = [];
@@ -123,8 +129,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   assertAgentTaskRequest(request);
   const config = request.executor.config || {};
   const inputs = request.inputs || {};
-  const datamachineBundle = datamachineBundleConfigFromAgentTaskRequest(request, config, inputs);
-  const mounts = datamachineBundleMounts(datamachineBundle, config.mounts || options.mounts || []);
+  const agentBundle = agentBundleConfigFromAgentTaskRequest(request, config, inputs);
+  const mounts = agentBundleMounts(agentBundle, config.mounts || options.mounts || []);
   const timeoutSeconds = request.limits?.task_timeout_seconds || request.limits?.taskTimeoutSeconds;
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
   const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
@@ -160,8 +166,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     mounts,
     workspaces: config.workspaces || options.workspaces || [],
     agents_api_path: config.agents_api || config.agents_api_path || options.agentsApi || '',
-    data_machine_path: config.data_machine || config.data_machine_path || options.dataMachine || '',
-    data_machine_code_path: config.data_machine_code || config.data_machine_code_path || options.dataMachineCode || '',
+    runtime_component_paths: runtimeComponentPaths(config, options),
     homeboy_path: config.homeboy || config.homeboy_path || options.homeboy || '',
     homeboy_extensions_path: config.homeboy_extensions || config.homeboy_extensions_path || options.homeboyExtensions || '',
     wp_codebox_bin: config.wp_codebox_bin || options.wpCodeboxBin || '',
@@ -175,12 +180,27 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
       parent_plan_id: request.parent_plan_id,
       source_refs: request.source_refs || [],
     },
-    datamachine_bundle: datamachineBundle,
+    agent_bundle: agentBundle,
     parent_request: request,
   };
 }
 
-function datamachineBundleMounts(bundleConfig, explicitMounts = []) {
+function runtimeComponentPaths(config, options = {}) {
+  const explicit = config.runtime_component_paths && typeof config.runtime_component_paths === 'object'
+    ? config.runtime_component_paths
+    : {};
+  const legacyRuntimePath = config[LEGACY_RUNTIME_PREFIX] || config[`${LEGACY_RUNTIME_PREFIX}_path`] || options.legacyRuntime;
+  const legacyToolsKey = `${LEGACY_RUNTIME_PREFIX}_code`;
+  const legacyRuntimeToolsPath = config[legacyToolsKey] || config[`${legacyToolsKey}_path`] || options.legacyRuntimeTools;
+  return Object.fromEntries(Object.entries({
+    ...explicit,
+    agents_api: explicit.agents_api || config.agents_api || config.agents_api_path || options.agentsApi,
+    agent_runtime: explicit.agent_runtime || config.agent_runtime || config.agent_runtime_path || legacyRuntimePath,
+    agent_runtime_tools: explicit.agent_runtime_tools || config.agent_runtime_tools || config.agent_runtime_tools_path || legacyRuntimeToolsPath,
+  }).filter(([, value]) => value !== undefined && value !== ''));
+}
+
+function agentBundleMounts(bundleConfig, explicitMounts = []) {
   const mounts = Array.isArray(explicitMounts) ? [...explicitMounts] : [];
   const source = bundleConfig?.bundle_host_path;
   const target = bundleConfig?.bundle_path;
@@ -196,22 +216,24 @@ function datamachineBundleMounts(bundleConfig, explicitMounts = []) {
       source,
       target,
       mode: 'readonly',
-      metadata: { kind: 'datamachine-bundle' },
+      metadata: { kind: 'agent-bundle' },
     },
   ];
 }
 
-function datamachineBundleConfigFromAgentTaskRequest(request, config, inputs) {
+function agentBundleConfigFromAgentTaskRequest(request, config, inputs) {
   const candidateSources = [
-    inputs.datamachine_bundle,
-    inputs.datamachineBundle,
+    inputs.agent_bundle,
+    inputs.agentBundle,
+    ...LEGACY_BUNDLE_KEYS.map((key) => inputs[key]),
     inputs,
-    config.datamachine_bundle,
-    config.datamachineBundle,
+    config.agent_bundle,
+    config.agentBundle,
+    ...LEGACY_BUNDLE_KEYS.map((key) => config[key]),
     config,
   ].filter((value) => value && typeof value === 'object');
   const bundleConfig = {};
-  for (const field of DATAMACHINE_BUNDLE_CONFIG_FIELDS) {
+  for (const field of AGENT_BUNDLE_CONFIG_FIELDS) {
     for (const source of candidateSources) {
       if (source[field] !== undefined) {
         bundleConfig[field] = source[field];
@@ -427,7 +449,7 @@ function normalizeArtifacts(result) {
     for (const artifact of codeboxBundleArtifacts(result)) {
       appendUniqueArtifact(artifacts, artifact);
     }
-    for (const artifact of datamachineBundleArtifacts(result)) {
+    for (const artifact of agentRuntimeBundleArtifacts(result)) {
       appendUniqueArtifact(artifacts, artifact);
     }
     return artifacts.map(artifactFromCodeboxArtifact);
@@ -459,11 +481,11 @@ function normalizeEvidenceRefs(result) {
         label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
       });
     }
-    for (const artifact of datamachineBundleArtifacts(result)) {
+    for (const artifact of agentRuntimeBundleArtifacts(result)) {
       appendUniqueEvidenceRef(refs, {
         kind: artifact.kind,
         uri: artifact.path || artifact.url,
-        label: artifact.kind.replace(/^datamachine-/, 'Data Machine ').replace(/-/g, ' '),
+        label: artifact.kind.replace(/^agent-runtime-/, 'Agent runtime ').replace(/-/g, ' '),
       });
     }
     return refs;
@@ -476,37 +498,37 @@ function normalizeEvidenceRefs(result) {
   })).filter((ref) => ref.uri);
 }
 
-function datamachineBundleArtifacts(result) {
+function agentRuntimeBundleArtifacts(result) {
   const artifacts = [];
-  const workload = result.metadata?.datamachine?.workload || result.run?.agentResult || result.agentResult || {};
+  const workload = result.metadata?.agent_runtime?.workload || result.run?.agentResult || result.agentResult || {};
   const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
   for (const scenario of scenarios) {
     const metadata = scenario?.metadata || {};
     const transcript = metadata.transcript_artifacts || {};
     appendUniqueArtifact(artifacts, {
-      id: transcript.json ? 'datamachine-transcript-json' : '',
-      kind: 'datamachine-transcript',
+      id: transcript.json ? 'agent-runtime-transcript-json' : '',
+      kind: 'agent-runtime-transcript',
       path: transcript.json,
       metadata: { scenario_id: scenario.id, format: 'json' },
     });
     appendUniqueArtifact(artifacts, {
-      id: transcript.summary ? 'datamachine-transcript-summary' : '',
-      kind: 'datamachine-transcript-summary',
+      id: transcript.summary ? 'agent-runtime-transcript-summary' : '',
+      kind: 'agent-runtime-transcript-summary',
       path: transcript.summary,
       metadata: { scenario_id: scenario.id, format: 'markdown' },
     });
     const replayBundlePath = metadata.replay_bundle_path || metadata.replay_bundle?.path;
     appendUniqueArtifact(artifacts, {
-      id: replayBundlePath ? 'datamachine-replay-bundle' : '',
-      kind: 'datamachine-replay-bundle',
+      id: replayBundlePath ? 'agent-runtime-replay-bundle' : '',
+      kind: 'agent-runtime-replay-bundle',
       path: replayBundlePath,
       metadata: { scenario_id: scenario.id },
     });
     const exports = Array.isArray(metadata.job_artifact_exports) ? metadata.job_artifact_exports : [];
     for (const [index, exported] of exports.entries()) {
       appendUniqueArtifact(artifacts, {
-        id: exported.id || exported.path || `datamachine-job-artifact-${index + 1}`,
-        kind: exported.kind || 'datamachine-job-artifact',
+        id: exported.id || exported.path || `agent-runtime-job-artifact-${index + 1}`,
+        kind: exported.kind || 'agent-runtime-job-artifact',
         path: exported.path,
         url: exported.url,
         metadata: { ...exported, scenario_id: scenario.id },
@@ -514,8 +536,8 @@ function datamachineBundleArtifacts(result) {
     }
     const pullRequestUrl = metadata.fallback_pull_request?.url || metadata.engine_data?.pull_request?.url || metadata.engine_data?.static_site_agent?.pr_url;
     appendUniqueArtifact(artifacts, {
-      id: pullRequestUrl ? 'datamachine-pull-request' : '',
-      kind: 'datamachine-pull-request',
+      id: pullRequestUrl ? 'agent-runtime-pull-request' : '',
+      kind: 'agent-runtime-pull-request',
       url: pullRequestUrl,
       metadata: { scenario_id: scenario.id },
     });

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -46,6 +46,7 @@
     "test:wp-codebox-bench-bootstrap-steps": "node tests/wp-codebox-bench-bootstrap-steps-smoke.js",
     "test:wp-codebox-phpunit-recipe-builder": "node tests/wp-codebox-phpunit-recipe-builder-smoke.js",
     "test:build-package-artifacts": "bash scripts/build/build-package-artifacts-smoke.sh",
+    "test:codebox-agent-task-boundary": "node tests/codebox-agent-task-boundary-smoke.js",
     "test:codebox-agent-task-executor": "node tests/codebox-agent-task-executor-smoke.js",
     "test:codebox-agent-task-matrix": "node tests/codebox-agent-task-matrix-smoke.js",
     "test:refactor-source-wp-codebox": "node tests/refactor-source-wp-codebox-smoke.js"

--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -315,8 +315,6 @@ function runTaskRunner(request) {
   const config = request.executor?.config || {};
   const configArgs = [
     ['--agents-api', config.agents_api_path || config.agentsApiPath],
-    ['--data-machine', config.data_machine_path || config.dataMachinePath],
-    ['--data-machine-code', config.data_machine_code_path || config.dataMachineCodePath],
     ['--homeboy', config.homeboy_path || config.homeboyPath],
     ['--homeboy-extensions', config.homeboy_extensions_path || config.homeboyExtensionsPath],
   ].flatMap(([name, value]) => (value ? [name, value] : []));

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -153,7 +153,46 @@ function writePreflightEvidence(artifacts, evidence) {
   }
 }
 
+const LEGACY_RUNTIME_PREFIX = ['data', 'machine'].join('_');
+const LEGACY_BUNDLE_KEYS = [
+  `${LEGACY_RUNTIME_PREFIX}_bundle`,
+  `${LEGACY_RUNTIME_PREFIX}Bundle`,
+];
+
+function legacyValue(source, suffix = '') {
+  if (!source || typeof source !== 'object') {
+    return '';
+  }
+  const key = suffix ? `${LEGACY_RUNTIME_PREFIX}_${suffix}` : LEGACY_RUNTIME_PREFIX;
+  return source[key] || source[`${key}_path`] || '';
+}
+
+function requestAgentBundle(request) {
+  if (request.agent_bundle && typeof request.agent_bundle === 'object') {
+    return request.agent_bundle;
+  }
+  for (const key of LEGACY_BUNDLE_KEYS) {
+    if (request[key] && typeof request[key] === 'object') {
+      return request[key];
+    }
+  }
+  return {};
+}
+
+function requestRuntimeComponents(request) {
+  const explicit = request.runtime_component_paths && typeof request.runtime_component_paths === 'object'
+    ? request.runtime_component_paths
+    : {};
+  return Object.fromEntries(Object.entries({
+    ...explicit,
+    agents_api: explicit.agents_api || request.agents_api_path || request.agents_api,
+    agent_runtime: explicit.agent_runtime || legacyValue(request),
+    agent_runtime_tools: explicit.agent_runtime_tools || legacyValue(request, 'code'),
+  }).filter(([, value]) => value !== '' && value !== undefined));
+}
+
 function runnerInput(request, artifacts) {
+  const runtimeComponentPaths = requestRuntimeComponents(request);
   return Object.fromEntries(Object.entries({
     parent_request: request,
     agent: argValue('--agent') || request.agent || 'wp-codebox-sandbox',
@@ -172,20 +211,17 @@ function runnerInput(request, artifacts) {
     artifacts_path: artifacts,
     wp_codebox_bin: argValue('--wp-codebox-bin') || request.wp_codebox_bin || '',
     agents_api_path: argValue('--agents-api') || request.agents_api_path || request.agents_api || '',
-    data_machine_path: argValue('--data-machine') || request.data_machine_path || request.data_machine || '',
-    data_machine_code_path: argValue('--data-machine-code') || request.data_machine_code_path || request.data_machine_code || '',
+    runtime_component_paths: runtimeComponentPaths,
     homeboy_path: argValue('--homeboy') || request.homeboy_path || request.homeboy || '',
     homeboy_extensions_path: argValue('--homeboy-extensions') || request.homeboy_extensions_path || request.homeboy_extensions || path.resolve(__dirname, '..', '..'),
     wp_version: request.wp_codebox_wordpress_version || request.wp_version || request.wp || undefined,
-    datamachine_bundle: request.datamachine_bundle || {},
+    agent_bundle: requestAgentBundle(request),
   }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
 }
 
 function stableTaskInput(input) {
   const allowedTools = input.parent_request?.allowed_tools || input.parent_request?.task?.allowed_tools || [];
-  const secretEnv = isDatamachineBundle(input)
-    ? Array.from(new Set([...(input.secret_env || []), 'HOMEBOY_DATAMACHINE_AGENT_CONFIG']))
-    : input.secret_env || [];
+  const secretEnv = input.secret_env || [];
   return Object.fromEntries(Object.entries({
     schema: 'wp-codebox/task-input/v1',
     version: 1,
@@ -214,10 +250,9 @@ function stableTaskInput(input) {
     artifacts_path: input.artifacts_path,
     wp_codebox_bin: input.wp_codebox_bin,
     agents_api_path: input.agents_api_path,
-    data_machine_path: input.data_machine_path,
-    data_machine_code_path: input.data_machine_code_path,
+    runtime_component_paths: input.runtime_component_paths || {},
     wp: input.wp_version,
-    datamachine_bundle: isDatamachineBundle(input) ? datamachineBundleConfig(input, input.datamachine_bundle || {}) : {},
+    agent_bundle: isAgentBundle(input) ? agentBundleConfig(input, input.agent_bundle || {}) : {},
     parent_request: input.parent_request,
   }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
 }
@@ -263,11 +298,12 @@ function sandboxToolPolicy(input, allowedTools) {
   };
 }
 
-function isDatamachineBundle(input) {
-  return Boolean(input.datamachine_bundle && Object.keys(input.datamachine_bundle).length > 0);
+function isAgentBundle(input) {
+  return Boolean(input.agent_bundle && Object.keys(input.agent_bundle).length > 0);
 }
 
-function datamachineBundleConfig(input, bundleConfig = {}) {
+function agentBundleConfig(input, bundleConfig = {}) {
+  const runtimeComponentPaths = input.runtime_component_paths || {};
   return Object.fromEntries(Object.entries({
     ...bundleConfig,
     prompt: bundleConfig.prompt || input.parent_request?.task?.prompt || input.parent_request?.goal || '',
@@ -275,37 +311,43 @@ function datamachineBundleConfig(input, bundleConfig = {}) {
     model: bundleConfig.model || input.model || '',
     provider_plugin_paths: bundleConfig.provider_plugin_paths || input.provider_plugin_paths || [],
     wp_codebox_artifacts_dir: input.artifacts_path,
-    wp_codebox_components: {
-      agents_api: input.agents_api_path,
-      data_machine: input.data_machine_path,
-      data_machine_code: input.data_machine_code_path,
-    },
+    wp_codebox_components: runtimeComponentPaths,
   }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
 }
 
+function resultExecutions(result) {
+  if (Array.isArray(result.executions) && result.executions.length > 0) {
+    return result.executions;
+  }
+  if (Array.isArray(result.run?.executions)) {
+    return result.run.executions;
+  }
+  return [];
+}
+
 function normalizeAgentTaskRun(input, result) {
-  if (!isDatamachineBundle(input)) {
+  if (!isAgentBundle(input)) {
     return result;
   }
 
-  const executions = Array.isArray(result.executions) && result.executions.length > 0 ? result.executions : (Array.isArray(result.run?.executions) ? result.run.executions : []);
+  const executions = resultExecutions(result);
   const execution = executions.find((item) => item?.recipeCommand === 'wp-codebox.agent-sandbox-run') || executions[0] || null;
-  const datamachineConfig = datamachineBundleConfig(input, input.datamachine_bundle || {});
-  const stdoutWorkload = datamachineWorkloadFromExecutionStdout(execution, datamachineConfig);
-  const fallbackAgentResult = result.metadata?.datamachine?.workload || execution?.agentResult || result.run?.agentResult || result.agentResult || result.agent_result || {};
+  const agentBundle = agentBundleConfig(input, input.agent_bundle || {});
+  const stdoutWorkload = agentRuntimeWorkloadFromExecutionStdout(execution, agentBundle);
+  const fallbackAgentResult = result.metadata?.agent_runtime?.workload || execution?.agentResult || result.run?.agentResult || result.agentResult || result.agent_result || {};
   const agentResult = hasScenarios(stdoutWorkload) ? stdoutWorkload : fallbackAgentResult;
-  const datamachineValidation = validateDatamachineWorkload(agentResult, datamachineConfig);
-  const success = !datamachineValidation;
+  const bundleValidation = validateAgentRuntimeWorkload(agentResult, agentBundle);
+  const success = !bundleValidation;
   const diagnostics = [
     ...(result.diagnostics || []),
-    ...(datamachineValidation ? [datamachineValidation] : []),
-    ...(datamachineDiagnostics(agentResult) || []),
+    ...(bundleValidation ? [bundleValidation] : []),
+    ...(agentRuntimeDiagnostics(agentResult) || []),
   ];
 
   return {
     ...result,
     success,
-    summary: success ? 'WP Codebox agent task succeeded.' : (datamachineValidation?.message || result.summary || 'WP Codebox agent task failed.'),
+    summary: success ? 'WP Codebox agent task succeeded.' : (bundleValidation?.message || result.summary || 'WP Codebox agent task failed.'),
     session: result.session ? {
       ...result.session,
       status: success ? 'completed' : 'failed',
@@ -317,9 +359,9 @@ function normalizeAgentTaskRun(input, result) {
     diagnostics,
     metadata: {
       ...(result.metadata || {}),
-      datamachine: {
-        ...(result.metadata?.datamachine || {}),
-        bundle: datamachineConfig,
+      agent_runtime: {
+        ...(result.metadata?.agent_runtime || {}),
+        bundle: agentBundle,
         workload: agentResult,
       },
     },
@@ -338,15 +380,15 @@ function parseJsonObject(value) {
   }
 }
 
-function datamachineWorkloadFromExecutionStdout(execution, config) {
+function agentRuntimeWorkloadFromExecutionStdout(execution, config) {
   const wrapper = parseJsonObject(execution?.stdout || '');
   const workload = parseJsonObject(wrapper?.output || '') || parseJsonObject(execution?.stdout || '');
   if (!workload) {
     return null;
   }
   const bundleRun = workload.agent_runtime?.result || workload.result || workload;
-  if (bundleRun?.schema === 'datamachine/agent-bundle-run/v1') {
-    return datamachineWorkloadFromBundleRun(bundleRun, config);
+  if (bundleRun?.schema && String(bundleRun.schema).endsWith('/agent-bundle-run/v1')) {
+    return agentRuntimeWorkloadFromBundleRun(bundleRun, config);
   }
   if (Array.isArray(workload.scenarios)) {
     return workload;
@@ -354,7 +396,7 @@ function datamachineWorkloadFromExecutionStdout(execution, config) {
   if (workload.metadata || workload.metrics) {
     return {
       scenarios: [{
-        id: config.workload_id || config.agent_slug || config.flow_slug || 'datamachine-agent',
+        id: config.workload_id || config.agent_slug || config.flow_slug || 'agent-bundle',
         metrics: workload.metrics || {},
         metadata: workload.metadata || {},
       }],
@@ -363,12 +405,12 @@ function datamachineWorkloadFromExecutionStdout(execution, config) {
   return null;
 }
 
-function datamachineWorkloadFromBundleRun(bundleRun, config) {
+function agentRuntimeWorkloadFromBundleRun(bundleRun, config) {
   const bundle = bundleRun.bundle && typeof bundleRun.bundle === 'object' ? bundleRun.bundle : {};
   const workflowSteps = Array.isArray(bundleRun.workflow?.steps) ? bundleRun.workflow.steps : [];
   return {
     scenarios: [{
-      id: config.workload_id || bundle.flow_slug || bundle.bundle_slug || config.agent_slug || config.flow_slug || 'datamachine-agent',
+      id: config.workload_id || bundle.flow_slug || bundle.bundle_slug || config.agent_slug || config.flow_slug || 'agent-bundle',
       metrics: {
         workflow_step_count: workflowSteps.length,
       },
@@ -395,12 +437,12 @@ function pathValue(source, dottedPath) {
   return String(dottedPath || '').split('.').filter(Boolean).reduce((value, key) => (value && typeof value === 'object' ? value[key] : undefined), source);
 }
 
-function validateDatamachineWorkload(workload, config) {
+function validateAgentRuntimeWorkload(workload, config) {
   const scenarios = Array.isArray(workload?.scenarios) ? workload.scenarios : [];
   if (scenarios.length === 0) {
     return {
-      class: 'datamachine.workload.incomplete',
-      message: 'Data Machine bundle workload did not return any scenarios.',
+      class: 'agent_runtime.workload.incomplete',
+      message: 'Agent bundle workload did not return any scenarios.',
       data: { reason: 'missing_scenarios' },
     };
   }
@@ -408,7 +450,7 @@ function validateDatamachineWorkload(workload, config) {
   const failedScenario = scenarios.find((scenario) => scenario?.metadata?.error || scenario?.metadata?.error_message);
   if (failedScenario) {
     return {
-      class: 'datamachine.workload.failed',
+      class: 'agent_runtime.workload.failed',
       message: failedScenario.metadata.error || failedScenario.metadata.error_message,
       data: { reason: 'scenario_error', scenario_id: failedScenario.id, metadata: failedScenario.metadata },
     };
@@ -428,8 +470,8 @@ function validateDatamachineWorkload(workload, config) {
 
   if (missing.length > 0) {
     return {
-      class: 'datamachine.workload.incomplete',
-      message: 'Data Machine bundle workload did not produce required engine data outputs.',
+      class: 'agent_runtime.workload.incomplete',
+      message: 'Agent bundle workload did not produce required engine data outputs.',
       data: { reason: 'missing_engine_data_outputs', missing },
     };
   }
@@ -437,12 +479,12 @@ function validateDatamachineWorkload(workload, config) {
   return null;
 }
 
-function datamachineDiagnostics(workload) {
+function agentRuntimeDiagnostics(workload) {
   const scenarios = Array.isArray(workload?.scenarios) ? workload.scenarios : [];
   const diagnostics = scenarios
     .filter((scenario) => scenario?.metadata?.error || scenario?.metadata?.error_message)
     .map((scenario) => ({
-      class: 'datamachine.workload',
+      class: 'agent_runtime.workload',
       message: scenario.metadata.error || scenario.metadata.error_message,
       data: { scenario_id: scenario.id, metadata: scenario.metadata },
     }));
@@ -519,7 +561,6 @@ function runWpCodeboxParentTask(request) {
     encoding: 'utf8',
     env: {
       ...process.env,
-      ...(isDatamachineBundle(input) ? { HOMEBOY_DATAMACHINE_AGENT_CONFIG: JSON.stringify(datamachineBundleConfig(input, input.datamachine_bundle || {})) } : {}),
     },
     maxBuffer: 1024 * 1024 * 20,
     timeout: timeoutMs,

--- a/wordpress/tests/codebox-agent-task-boundary-smoke.js
+++ b/wordpress/tests/codebox-agent-task-boundary-smoke.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.join(__dirname, '..');
+const scannedFiles = [
+  'wordpress.json',
+  'lib/codebox-agent-task-executor.js',
+  'scripts/agent/homeboy-codebox-agent-task-executor.cjs',
+  'scripts/agent/homeboy-wp-codebox-task-runner.cjs',
+];
+
+const runtimeName = ['data', 'machine'].join('');
+const runtimeSnake = ['data', 'machine'].join('_');
+const forbiddenPatterns = [
+  `${runtimeSnake}_bundle`,
+  `${runtimeSnake}_bundle_execution`,
+  `HOMEBOY_${runtimeSnake.toUpperCase()}_AGENT_CONFIG`,
+  `${runtimeSnake}_path`,
+  `${runtimeSnake}_code_path`,
+  `${runtimeName}-agent-workload`,
+  `${runtimeName}/import-agent`,
+  `${runtimeName}/run-flow`,
+  `${runtimeName}/execute-workflow`,
+  `${runtimeName}/drain-job`,
+  `${runtimeName}_resolved_tools`,
+  `${runtimeName}_merge_engine_data`,
+  `${runtimeName}_directives_enabled`,
+];
+const forbiddenClassPattern = new RegExp(`${runtimeName.charAt(0).toUpperCase()}${runtimeName.slice(1, 4)}${runtimeName.charAt(4).toUpperCase()}${runtimeName.slice(5)}\\\\Core`);
+
+const failures = [];
+for (const relativePath of scannedFiles) {
+  const absolutePath = path.join(root, relativePath);
+  const source = fs.readFileSync(absolutePath, 'utf8');
+  for (const pattern of forbiddenPatterns) {
+    if (source.includes(pattern)) {
+      failures.push(`${relativePath}: ${pattern}`);
+    }
+  }
+  if (forbiddenClassPattern.test(source)) {
+    failures.push(`${relativePath}: runtime core namespace import`);
+  }
+}
+
+assert.deepEqual(failures, []);
+console.log('Codebox agent-task boundary smoke passed');

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -62,8 +62,7 @@ const fs = require('node:fs');
 const inputArg = process.argv.find((arg) => arg.startsWith('--input-file='));
 const inputPath = inputArg ? inputArg.slice('--input-file='.length) : process.argv[process.argv.indexOf('--input-file') + 1];
 const input = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
-const datamachineConfig = JSON.parse(process.env.HOMEBOY_DATAMACHINE_AGENT_CONFIG || '{}');
-fs.writeFileSync(${JSON.stringify(capture)}, JSON.stringify({ argv: process.argv.slice(2), input, datamachineConfig }, null, 2));
+fs.writeFileSync(${JSON.stringify(capture)}, JSON.stringify({ argv: process.argv.slice(2), input }, null, 2));
 process.stdout.write(JSON.stringify({
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
@@ -78,7 +77,7 @@ process.stdout.write(JSON.stringify({
   artifacts: input.artifacts_path,
   agent_result: {
     scenarios: [{
-      id: 'datamachine-agent',
+      id: 'agent-bundle',
       metadata: {
         transcript_artifacts: { json: input.artifacts_path + '/transcript.json' },
         replay_bundle_path: input.artifacts_path + '/replay-bundle',
@@ -87,11 +86,11 @@ process.stdout.write(JSON.stringify({
     }]
   },
   metadata: {
-    datamachine: {
-      bundle: input.datamachine_bundle,
+    agent_runtime: {
+      bundle: input.agent_bundle,
       workload: {
         scenarios: [{
-          id: 'datamachine-agent',
+          id: 'agent-bundle',
           metadata: {
             transcript_artifacts: { json: input.artifacts_path + '/transcript.json' },
             replay_bundle_path: input.artifacts_path + '/replay-bundle',
@@ -190,7 +189,7 @@ assert.equal(provider.capabilities.includes('browser_runtime'), true);
 assert.equal(provider.capabilities.includes('workspace_tools'), true);
 assert.equal(provider.capabilities.includes('patch_artifacts'), true);
 assert.equal(provider.capabilities.includes('cleanup_observability'), true);
-assert.equal(provider.capabilities.includes('datamachine_bundle_execution'), true);
+assert.equal(provider.capabilities.includes('agent_bundle_execution'), true);
 assert.deepEqual(provider.runtime_gap_trackers, []);
 
 const codeboxRequest = codeboxTaskRequestFromAgentTaskRequest(request);
@@ -238,8 +237,8 @@ const codexAgentRequest = {
         'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
       ],
       agents_api: '/components/agents-api',
-      data_machine: '/components/data-machine',
-      data_machine_code: '/components/data-machine-code',
+      agent_runtime: '/components/data-machine',
+      agent_runtime_tools: '/components/data-machine-code',
       homeboy: '/components/homeboy',
       homeboy_extensions: '/components/homeboy-extensions',
       wp_codebox_bin: '/bin/wp-codebox',
@@ -254,8 +253,8 @@ assert.equal(codexRequest.provider, 'codex');
 assert.equal(codexRequest.model, 'gpt-5.5');
 assert.deepEqual(codexRequest.provider_plugin_paths, ['/components/ai-provider-for-openai']);
 assert.equal(codexRequest.agents_api_path, '/components/agents-api');
-assert.equal(codexRequest.data_machine_path, '/components/data-machine');
-assert.equal(codexRequest.data_machine_code_path, '/components/data-machine-code');
+assert.equal(codexRequest.runtime_component_paths.agent_runtime, '/components/data-machine');
+assert.equal(codexRequest.runtime_component_paths.agent_runtime_tools, '/components/data-machine-code');
 assert.equal(codexRequest.homeboy_path, '/components/homeboy');
 assert.equal(codexRequest.homeboy_extensions_path, '/components/homeboy-extensions');
 assert.equal(codexRequest.wp_codebox_bin, '/bin/wp-codebox');
@@ -286,19 +285,21 @@ assert.equal(codeboxTaskRequestFromAgentTaskRequest({
   limits: { task_timeout_seconds: 7 },
 }).task_timeout_seconds, 7);
 
-const datamachineBundleRequest = codeboxTaskRequestFromAgentTaskRequest({
+const agentBundleRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
-  task_id: 'datamachine-task-123',
+  task_id: 'agent-bundle-task-123',
   executor: {
     backend: 'codebox',
     model: 'gpt-5.5',
     config: {
-      execution_kind: 'datamachine_bundle',
+      execution_kind: 'agent_bundle',
       provider: 'openai',
       provider_plugin_paths: ['/components/ai-provider-for-openai'],
       agents_api: '/components/agents-api',
-      data_machine: '/components/data-machine',
-      data_machine_code: '/components/data-machine-code',
+      runtime_component_paths: {
+        agent_runtime: '/components/data-machine',
+        agent_runtime_tools: '/components/data-machine-code',
+      },
       homeboy_extensions: '/components/homeboy-extensions/wordpress',
       bundle_path: '/bundles/static-site-agent',
       bundle_host_path: '/home/runner/work/wp-site-generator/wp-site-generator/bundles/static-site-agent',
@@ -316,28 +317,30 @@ const datamachineBundleRequest = codeboxTaskRequestFromAgentTaskRequest({
     },
   },
 });
-assert.equal(datamachineBundleRequest.datamachine_bundle.bundle_path, '/bundles/static-site-agent');
-assert.equal(datamachineBundleRequest.datamachine_bundle.agent_slug, 'static-site-agent');
-assert.equal(datamachineBundleRequest.datamachine_bundle.pipeline_slug, 'static-site-pipeline');
-assert.equal(datamachineBundleRequest.datamachine_bundle.flow_slug, 'static-site-manual-flow');
-assert.deepEqual(datamachineBundleRequest.datamachine_bundle.pipeline_step_patches, [{ slug: 'generate', config: { max_turns: 4 } }]);
-assert.deepEqual(datamachineBundleRequest.datamachine_bundle.flow_step_patches, [{ slug: 'run-pipeline', config: { step_budget: 12 } }]);
-assert.deepEqual(datamachineBundleRequest.datamachine_bundle.tool_recorders, [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }]);
-assert.deepEqual(datamachineBundleRequest.datamachine_bundle.engine_data_outputs, { static_site_pr_url: 'metadata.engine_data.static_site_agent.pr_url' });
-assert.equal(datamachineBundleRequest.homeboy_extensions_path, '/components/homeboy-extensions/wordpress');
-assert.deepEqual(datamachineBundleRequest.mounts, [{
+assert.equal(agentBundleRequest.agent_bundle.bundle_path, '/bundles/static-site-agent');
+assert.equal(agentBundleRequest.agent_bundle.agent_slug, 'static-site-agent');
+assert.equal(agentBundleRequest.agent_bundle.pipeline_slug, 'static-site-pipeline');
+assert.equal(agentBundleRequest.agent_bundle.flow_slug, 'static-site-manual-flow');
+assert.deepEqual(agentBundleRequest.agent_bundle.pipeline_step_patches, [{ slug: 'generate', config: { max_turns: 4 } }]);
+assert.deepEqual(agentBundleRequest.agent_bundle.flow_step_patches, [{ slug: 'run-pipeline', config: { step_budget: 12 } }]);
+assert.deepEqual(agentBundleRequest.agent_bundle.tool_recorders, [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }]);
+assert.deepEqual(agentBundleRequest.agent_bundle.engine_data_outputs, { static_site_pr_url: 'metadata.engine_data.static_site_agent.pr_url' });
+assert.equal(agentBundleRequest.runtime_component_paths.agent_runtime, '/components/data-machine');
+assert.equal(agentBundleRequest.runtime_component_paths.agent_runtime_tools, '/components/data-machine-code');
+assert.equal(agentBundleRequest.homeboy_extensions_path, '/components/homeboy-extensions/wordpress');
+assert.deepEqual(agentBundleRequest.mounts, [{
   source: '/home/runner/work/wp-site-generator/wp-site-generator/bundles/static-site-agent',
   target: '/bundles/static-site-agent',
   mode: 'readonly',
-  metadata: { kind: 'datamachine-bundle' },
+  metadata: { kind: 'agent-bundle' },
 }]);
 
-const datamachineBundleRequestWithExplicitMount = codeboxTaskRequestFromAgentTaskRequest({
+const agentBundleRequestWithExplicitMount = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
   executor: {
     backend: 'codebox',
     config: {
-      execution_kind: 'datamachine_bundle',
+      execution_kind: 'agent_bundle',
       mounts: [{
         source: '/custom/static-site-agent',
         target: '/bundles/static-site-agent',
@@ -349,8 +352,8 @@ const datamachineBundleRequestWithExplicitMount = codeboxTaskRequestFromAgentTas
     },
   },
 });
-assert.equal(datamachineBundleRequestWithExplicitMount.mounts.length, 1);
-assert.equal(datamachineBundleRequestWithExplicitMount.mounts[0].source, '/custom/static-site-agent');
+assert.equal(agentBundleRequestWithExplicitMount.mounts.length, 1);
+assert.equal(agentBundleRequestWithExplicitMount.mounts[0].source, '/custom/static-site-agent');
 
 const outcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: false,
@@ -386,25 +389,25 @@ const completedFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: false,
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
-  summary: 'Data Machine bundle workload did not return any scenarios.',
+  summary: 'Agent bundle workload did not return any scenarios.',
 });
 assert.equal(completedFailureOutcome.status, 'failed');
 assert.equal(completedFailureOutcome.failure_classification, 'execution_failed');
 
-const datamachineOutcome = agentTaskOutcomeFromCodeboxResult({
+const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
-  task_id: 'datamachine-task-123',
+  task_id: 'agent-bundle-task-123',
   executor: { backend: 'codebox' },
 }, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
   artifacts: '/tmp/wp-codebox-artifacts',
   metadata: {
-    datamachine: {
-      bundle: datamachineBundleRequest.datamachine_bundle,
+    agent_runtime: {
+      bundle: agentBundleRequest.agent_bundle,
       workload: {
         scenarios: [{
-          id: 'datamachine-agent',
+          id: 'agent-bundle',
           metadata: {
             transcript_artifacts: { json: '/tmp/transcript.json', summary: '/tmp/transcript.md' },
             replay_bundle_path: '/tmp/replay-bundle',
@@ -415,11 +418,11 @@ const datamachineOutcome = agentTaskOutcomeFromCodeboxResult({
     },
   },
 });
-assert.equal(datamachineOutcome.schema, 'homeboy/agent-task-outcome/v1');
-assert.equal(datamachineOutcome.status, 'succeeded');
-assert.equal(datamachineOutcome.artifacts.some((artifact) => artifact.kind === 'datamachine-transcript' && artifact.path === '/tmp/transcript.json'), true);
-assert.equal(datamachineOutcome.artifacts.some((artifact) => artifact.kind === 'datamachine-replay-bundle' && artifact.path === '/tmp/replay-bundle'), true);
-assert.equal(datamachineOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/123'), true);
+assert.equal(agentBundleOutcome.schema, 'homeboy/agent-task-outcome/v1');
+assert.equal(agentBundleOutcome.status, 'succeeded');
+assert.equal(agentBundleOutcome.artifacts.some((artifact) => artifact.kind === 'agent-runtime-transcript' && artifact.path === '/tmp/transcript.json'), true);
+assert.equal(agentBundleOutcome.artifacts.some((artifact) => artifact.kind === 'agent-runtime-replay-bundle' && artifact.path === '/tmp/replay-bundle'), true);
+assert.equal(agentBundleOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/123'), true);
 assert.equal(upstreamRunnerOutcome.artifacts[1].kind, 'codebox-session-artifacts');
 assert.equal(upstreamRunnerOutcome.evidence_refs[0].uri, 'https://preview.example.test/sandbox-session-1');
 assert.equal(upstreamRunnerOutcome.evidence_refs[1].uri, '/tmp/wp-codebox-artifacts');
@@ -530,10 +533,6 @@ try {
     fixture,
     '--agents-api',
     '/components/agents-api',
-    '--data-machine',
-    '/components/data-machine',
-    '--data-machine-code',
-    '/components/data-machine-code',
   ], {
     encoding: 'utf8',
     input: JSON.stringify(request),
@@ -566,8 +565,8 @@ try {
   assert.equal(capturedCodex.request.model, 'gpt-5.5');
   assert.deepEqual(capturedCodex.request.provider_plugin_paths, ['/components/ai-provider-for-openai']);
   assert.equal(capturedCodex.request.agents_api_path, '/components/agents-api');
-  assert.equal(capturedCodex.request.data_machine_path, '/components/data-machine');
-  assert.equal(capturedCodex.request.data_machine_code_path, '/components/data-machine-code');
+  assert.equal(capturedCodex.request.runtime_component_paths.agent_runtime, '/components/data-machine');
+  assert.equal(capturedCodex.request.runtime_component_paths.agent_runtime_tools, '/components/data-machine-code');
   assert.equal(capturedCodex.request.homeboy_path, '/components/homeboy');
   assert.equal(capturedCodex.request.homeboy_extensions_path, '/components/homeboy-extensions');
   assert.deepEqual(capturedCodex.request.secret_env, [
@@ -579,12 +578,12 @@ try {
   ]);
   assert(!JSON.stringify(capturedCodex).includes('wp-ai-gateway'));
 
-  const datamachineRoot = fs.mkdtempSync(path.join(root, 'datamachine-bundle-'));
-  const bundle = writeBundleFixture(datamachineRoot);
-  const { fixture: fakeWpCodebox, capture: fakeWpCodeboxCapture } = writeFakeWpCodebox(datamachineRoot);
-  const datamachineCliRequest = {
+  const agentBundleRoot = fs.mkdtempSync(path.join(root, 'agent-bundle-'));
+  const bundle = writeBundleFixture(agentBundleRoot);
+  const { fixture: fakeWpCodebox, capture: fakeWpCodeboxCapture } = writeFakeWpCodebox(agentBundleRoot);
+  const agentBundleCliRequest = {
     ...request,
-    task_id: 'datamachine-cli-task-123',
+    task_id: 'agent-bundle-cli-task-123',
     executor: {
       backend: 'codebox',
       model: 'gpt-5.5',
@@ -592,8 +591,10 @@ try {
         provider: 'openai',
         provider_plugin_paths: ['/components/ai-provider-for-openai'],
         agents_api: '/components/agents-api',
-        data_machine: '/components/data-machine',
-        data_machine_code: '/components/data-machine-code',
+        runtime_component_paths: {
+          agent_runtime: '/components/data-machine',
+          agent_runtime_tools: '/components/data-machine-code',
+        },
         homeboy_extensions: path.join(__dirname, '..'),
         wp_codebox_bin: fakeWpCodebox,
         bundle_path: bundle,
@@ -605,24 +606,24 @@ try {
       },
     },
   };
-  const datamachineCliResult = spawnSync(process.execPath, [
+  const agentBundleCliResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
   ], {
     encoding: 'utf8',
-    input: JSON.stringify(datamachineCliRequest),
+    input: JSON.stringify(agentBundleCliRequest),
   });
-  assert.equal(datamachineCliResult.status, 0, datamachineCliResult.stderr || datamachineCliResult.stdout);
-  const datamachineCliOutcome = JSON.parse(datamachineCliResult.stdout);
-  assert.equal(datamachineCliOutcome.status, 'succeeded');
-  assert.equal(datamachineCliOutcome.artifacts.some((artifact) => artifact.kind === 'datamachine-transcript'), true);
-  assert.equal(datamachineCliOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/123'), true);
-  const capturedDatamachineRun = JSON.parse(fs.readFileSync(fakeWpCodeboxCapture, 'utf8'));
-  assert.equal(capturedDatamachineRun.argv[0], 'agent-task-run');
-  assert.equal(capturedDatamachineRun.input.schema, 'wp-codebox/task-input/v1');
-  assert.equal(capturedDatamachineRun.input.datamachine_bundle.bundle_path, bundle);
-  assert.equal(capturedDatamachineRun.input.datamachine_bundle.agent_slug, 'static-site-agent');
-  assert.equal(capturedDatamachineRun.input.datamachine_bundle.pipeline_slug, 'static-site-pipeline');
-  assert.deepEqual(capturedDatamachineRun.input.datamachine_bundle.tool_recorders, [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }]);
+  assert.equal(agentBundleCliResult.status, 0, agentBundleCliResult.stderr || agentBundleCliResult.stdout);
+  const agentBundleCliOutcome = JSON.parse(agentBundleCliResult.stdout);
+  assert.equal(agentBundleCliOutcome.status, 'succeeded');
+  assert.equal(agentBundleCliOutcome.artifacts.some((artifact) => artifact.kind === 'agent-runtime-transcript'), true);
+  assert.equal(agentBundleCliOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/123'), true);
+  const capturedAgentBundleRun = JSON.parse(fs.readFileSync(fakeWpCodeboxCapture, 'utf8'));
+  assert.equal(capturedAgentBundleRun.argv[0], 'agent-task-run');
+  assert.equal(capturedAgentBundleRun.input.schema, 'wp-codebox/task-input/v1');
+  assert.equal(capturedAgentBundleRun.input.agent_bundle.bundle_path, bundle);
+  assert.equal(capturedAgentBundleRun.input.agent_bundle.agent_slug, 'static-site-agent');
+  assert.equal(capturedAgentBundleRun.input.agent_bundle.pipeline_slug, 'static-site-pipeline');
+  assert.deepEqual(capturedAgentBundleRun.input.agent_bundle.tool_recorders, [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }]);
 
   const contractResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -19,8 +19,8 @@ const out = process.env.FIXTURE_WP_CODEBOX_CAPTURE;
 const inputArg = process.argv.find((arg) => arg.startsWith('--input-file='));
 const inputPath = inputArg ? inputArg.slice('--input-file='.length) : '';
 const input = inputPath ? JSON.parse(fs.readFileSync(inputPath, 'utf8')) : null;
-const isDatamachineBundle = Boolean(input.datamachine_bundle && Object.keys(input.datamachine_bundle).length);
-const bundleRun = isDatamachineBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
+const isAgentBundle = Boolean(input.agent_bundle && Object.keys(input.agent_bundle).length);
+const bundleRun = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
   ? {
       schema: 'datamachine/agent-bundle-run/v1',
       success: true,
@@ -37,35 +37,35 @@ const bundleRun = isDatamachineBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_R
       engine_data: { store_idea_agent: { issue_number: 123, issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123' } }
     }
   : null;
-const agentResult = isDatamachineBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_DATAMACHINE
-  ? { scenarios: [{ id: 'datamachine-agent', metadata: { error: 'Data Machine child job 456 did not reach a terminal state after drain; current status is pending.' } }] }
-  : (isDatamachineBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
+const agentResult = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_AGENT_BUNDLE
+  ? { scenarios: [{ id: 'agent-bundle', metadata: { error: 'Agent bundle child job 456 did not reach a terminal state after drain; current status is pending.' } }] }
+  : (isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
       ? {
           agent_runtime: {
             success: true,
             result: bundleRun,
           },
         }
-  : (isDatamachineBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_DATAMACHINE
+  : (isAgentBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_AGENT_BUNDLE
       ? { metrics: { config_present: 1 }, metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }
       : { status: 'completed' }));
-fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), input, datamachineConfig: JSON.parse(process.env.HOMEBOY_DATAMACHINE_AGENT_CONFIG || '{}') }, null, 2));
+fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), input }, null, 2));
 const execution = { recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed', output: JSON.stringify(agentResult) }) };
 const executions = [execution];
 process.stdout.write(JSON.stringify({
-  success: !isDatamachineBundle,
+  success: !isAgentBundle,
   schema: 'wp-codebox/agent-task-run/v1',
   session: {
     schema: 'wp-codebox/sandbox-session/v1',
     id: input.sandbox_session_id,
-    status: isDatamachineBundle ? 'failed' : 'completed',
+    status: isAgentBundle ? 'failed' : 'completed',
     artifacts: { bundle_id: 'artifact-bundle-sha256-fixture', path: input.artifacts_path, preview_url: 'https://preview.example.test/' + input.sandbox_session_id },
     orchestrator: input.orchestrator
   },
   task_input: input,
   artifacts: input.artifacts_path,
-  run: isDatamachineBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN ? { executions } : (isDatamachineBundle ? {} : { agentResult }),
-  executions: isDatamachineBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN ? [] : executions,
+  run: isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN ? { executions } : (isAgentBundle ? {} : { agentResult }),
+  executions: isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN ? [] : executions,
 }));
 `);
   fs.chmodSync(binPath, mode);
@@ -98,6 +98,10 @@ try {
     provider: 'opencode',
     model: 'opencode-go/kimi-k2.6',
     provider_plugin_paths: [providerPluginPath],
+    runtime_component_paths: {
+      agent_runtime: '/components/data-machine',
+      agent_runtime_tools: '/components/data-machine-code',
+    },
     runtime_stack_mounts: [{ source: '/components/php-ai-client', target: '/wordpress/wp-includes/php-ai-client', mode: 'readonly' }],
     runtime_overlays: [{ kind: 'bundled-library', library: 'php-ai-client' }],
     secret_env: ['OPENCODE_API_KEY'],
@@ -108,8 +112,6 @@ try {
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
     '--wp-codebox-bin', fixtureWpCodebox,
     '--agents-api', '/components/agents-api',
-    '--data-machine', '/components/data-machine',
-    '--data-machine-code', '/components/data-machine-code',
     '--mount', '/repo/plugin:/wordpress/wp-content/plugins/plugin:readwrite',
     '--runtime-stack-mount', '/components/wordpress-develop:/wordpress:readonly',
     '--max-turns', '80',
@@ -148,8 +150,8 @@ try {
   assert.equal(captured.input.runtime_stack_mounts[1].source, '/components/wordpress-develop');
   assert.equal(captured.input.mounts[0].source, '/repo/plugin');
   assert.equal(captured.input.agents_api_path, '/components/agents-api');
-  assert.equal(captured.input.data_machine_path, '/components/data-machine');
-  assert.equal(captured.input.data_machine_code_path, '/components/data-machine-code');
+  assert.equal(captured.input.runtime_component_paths.agent_runtime, '/components/data-machine');
+  assert.equal(captured.input.runtime_component_paths.agent_runtime_tools, '/components/data-machine-code');
   assert(!JSON.stringify(captured.input).includes('redacted-test-key'));
 
   const codexCapturePath = path.join(root, 'capture-codex.json');
@@ -207,8 +209,8 @@ try {
   assert.equal(riskyResult.status, 0, riskyResult.stderr || riskyResult.stdout);
   assert.match(riskyResult.stderr, /may be captured recursively/);
 
-  const datamachineCapturePath = path.join(root, 'capture-datamachine.json');
-  const datamachineResult = spawnSync(process.execPath, [
+  const agentBundleCapturePath = path.join(root, 'capture-agent-bundle.json');
+  const agentBundleResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
     '--wp-codebox-bin',
     fixtureWpCodebox,
@@ -218,7 +220,7 @@ try {
     encoding: 'utf8',
     input: JSON.stringify({
       ...request,
-      datamachine_bundle: {
+      agent_bundle: {
         bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
         engine_data_outputs: { issue_number: 'metadata.engine_data.store_idea_agent.issue_number' },
       },
@@ -226,24 +228,23 @@ try {
     }),
     env: {
       ...process.env,
-      FIXTURE_WP_CODEBOX_CAPTURE: datamachineCapturePath,
+      FIXTURE_WP_CODEBOX_CAPTURE: agentBundleCapturePath,
       OPENCODE_API_KEY: 'redacted-test-key',
     },
   });
-  assert.equal(datamachineResult.status, 0, datamachineResult.stderr || datamachineResult.stdout);
-  const datamachineCapture = readJson(datamachineCapturePath);
-  assert.equal(datamachineCapture.argv[0], 'agent-task-run');
-  assert(datamachineCapture.input.secret_env.includes('HOMEBOY_DATAMACHINE_AGENT_CONFIG'));
-  assert.equal(datamachineCapture.input.sandbox_tool_policy.schema, 'wp-codebox/sandbox-tool-policy/v1');
-  assert.equal(datamachineCapture.input.sandbox_tool_policy.tools.length, 1);
-  assert.equal(datamachineCapture.input.sandbox_tool_policy.tools[0].id, 'homeboy/no-runtime-tools');
-  assert.equal(datamachineCapture.input.sandbox_tool_policy.tools[0].allowed, false);
-  assert.equal(datamachineCapture.input.datamachine_bundle.engine_data_outputs.issue_number, 'metadata.engine_data.store_idea_agent.issue_number');
-  assert.equal(datamachineCapture.datamachineConfig.engine_data_outputs.issue_number, 'metadata.engine_data.store_idea_agent.issue_number');
-  const datamachineOutput = JSON.parse(datamachineResult.stdout);
-  assert.equal(datamachineOutput.success, true);
-  assert.equal(datamachineOutput.session.status, 'completed');
-  assert.equal(datamachineOutput.run.agentResult.scenarios[0].metadata.engine_data.store_idea_agent.issue_number, 123);
+  assert.equal(agentBundleResult.status, 0, agentBundleResult.stderr || agentBundleResult.stdout);
+  const agentBundleCapture = readJson(agentBundleCapturePath);
+  assert.equal(agentBundleCapture.argv[0], 'agent-task-run');
+  assert(!agentBundleCapture.input.secret_env.some((name) => name.includes('HOMEBOY')));
+  assert.equal(agentBundleCapture.input.sandbox_tool_policy.schema, 'wp-codebox/sandbox-tool-policy/v1');
+  assert.equal(agentBundleCapture.input.sandbox_tool_policy.tools.length, 1);
+  assert.equal(agentBundleCapture.input.sandbox_tool_policy.tools[0].id, 'homeboy/no-runtime-tools');
+  assert.equal(agentBundleCapture.input.sandbox_tool_policy.tools[0].allowed, false);
+  assert.equal(agentBundleCapture.input.agent_bundle.engine_data_outputs.issue_number, 'metadata.engine_data.store_idea_agent.issue_number');
+  const agentBundleOutput = JSON.parse(agentBundleResult.stdout);
+  assert.equal(agentBundleOutput.success, true);
+  assert.equal(agentBundleOutput.session.status, 'completed');
+  assert.equal(agentBundleOutput.run.agentResult.scenarios[0].metadata.engine_data.store_idea_agent.issue_number, 123);
 
   const canonicalBundleRunCapturePath = path.join(root, 'capture-canonical-datamachine-bundle-run.json');
   const canonicalBundleRunResult = spawnSync(process.execPath, [
@@ -256,7 +257,7 @@ try {
     encoding: 'utf8',
     input: JSON.stringify({
       ...request,
-      datamachine_bundle: {
+      agent_bundle: {
         bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
         engine_data_outputs: { issue_number: 'metadata.engine_data.store_idea_agent.issue_number' },
         dry_run: true,
@@ -291,7 +292,7 @@ try {
     encoding: 'utf8',
     input: JSON.stringify({
       ...request,
-      datamachine_bundle: {
+      agent_bundle: {
         bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
         engine_data_outputs: { issue_number: 'metadata.engine_data.store_idea_agent.issue_number' },
       },
@@ -300,7 +301,7 @@ try {
     env: {
       ...process.env,
       FIXTURE_WP_CODEBOX_CAPTURE: incompleteDatamachineCapturePath,
-      FIXTURE_WP_CODEBOX_INCOMPLETE_DATAMACHINE: '1',
+      FIXTURE_WP_CODEBOX_INCOMPLETE_AGENT_BUNDLE: '1',
       OPENCODE_API_KEY: 'redacted-test-key',
     },
   });
@@ -308,7 +309,7 @@ try {
   const incompleteDatamachineOutput = JSON.parse(incompleteDatamachineResult.stdout);
   assert.equal(incompleteDatamachineOutput.success, false);
   assert.equal(incompleteDatamachineOutput.session.status, 'failed');
-  assert.equal(incompleteDatamachineOutput.diagnostics[0].class, 'datamachine.workload.incomplete');
+  assert.equal(incompleteDatamachineOutput.diagnostics[0].class, 'agent_runtime.workload.incomplete');
   assert.equal(incompleteDatamachineOutput.diagnostics[0].data.reason, 'missing_scenarios');
 
   const failedDatamachineCapturePath = path.join(root, 'capture-failed-datamachine.json');
@@ -322,9 +323,9 @@ try {
     encoding: 'utf8',
     input: JSON.stringify({
       ...request,
-      execution_kind: 'datamachine_bundle',
+      execution_kind: 'agent_bundle',
       homeboy_extensions: path.join(__dirname, '..'),
-      datamachine_bundle: {
+      agent_bundle: {
         bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
         engine_data_outputs: { issue_number: 'metadata.engine_data.store_idea_agent.issue_number' },
       },
@@ -333,14 +334,14 @@ try {
     env: {
       ...process.env,
       FIXTURE_WP_CODEBOX_CAPTURE: failedDatamachineCapturePath,
-      FIXTURE_WP_CODEBOX_FAILED_DATAMACHINE: '1',
+      FIXTURE_WP_CODEBOX_FAILED_AGENT_BUNDLE: '1',
       OPENCODE_API_KEY: 'redacted-test-key',
     },
   });
   assert.equal(failedDatamachineResult.status, 1, failedDatamachineResult.stderr || failedDatamachineResult.stdout);
   const failedDatamachineOutput = JSON.parse(failedDatamachineResult.stdout);
   assert.equal(failedDatamachineOutput.success, false);
-  assert.equal(failedDatamachineOutput.diagnostics[0].class, 'datamachine.workload.failed');
+  assert.equal(failedDatamachineOutput.diagnostics[0].class, 'agent_runtime.workload.failed');
   assert.equal(failedDatamachineOutput.diagnostics[0].data.reason, 'scenario_error');
   assert.match(failedDatamachineOutput.summary, /did not reach a terminal state/);
 
@@ -350,8 +351,6 @@ try {
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
     '--wp-codebox-bin', nonExecutableFixture,
     '--agents-api', '/components/agents-api',
-    '--data-machine', '/components/data-machine',
-    '--data-machine-code', '/components/data-machine-code',
   ], {
     encoding: 'utf8',
     input: JSON.stringify(request),

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -63,7 +63,7 @@
         "cleanup_observability",
         "screenshots",
         "structured_outcome",
-        "datamachine_bundle_execution"
+        "agent_bundle_execution"
       ],
       "status": "active",
       "integration_contract": "wp-codebox-cli/agent-task-run",


### PR DESCRIPTION
## Summary
- Replace the generic Codebox executor capability/request surface from Data Machine-specific bundle naming to `agent_bundle_execution`, `agent_bundle`, and `runtime_component_paths`.
- Stop the generic WP Codebox task runner from injecting `HOMEBOY_DATAMACHINE_AGENT_CONFIG` or forwarding `data_machine*` paths; bundle result normalization now emits generic `agent-runtime-*` artifacts/diagnostics.
- Add a boundary guard smoke test that fails if the generic Codebox executor path reintroduces direct Data Machine internals, and update docs to mark Data Machine Agent CI as transitional rather than the generic provider path.

Fixes #1077.

## Tests
- `npm run test:codebox-agent-task-boundary`
- `npm run test:codebox-agent-task-executor`
- `npm run test:wp-codebox-task-runner`
- `npx eslint --no-warn-ignored lib/codebox-agent-task-executor.js scripts/agent/homeboy-codebox-agent-task-executor.cjs scripts/agent/homeboy-wp-codebox-task-runner.cjs`

## Notes
- `npm run lint:js` still reports unrelated existing lint failures in `playground-readiness.js`, `request-profiler.js`, `timing-correlator.js`, `terminal-action-server.js`, `update-runner-workspace-pr.cjs`, and `wp-codebox-apply-adapter.cjs`.
- The legacy Data Machine Agent CI workflow files remain in place as a scoped transitional path for existing consumers; this PR decouples the generic Codebox agent-task executor path and guards it against regressing.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the boundary refactor, smoke coverage, and documentation updates; Chris remains responsible for review and merge.