### PR TITLE
Preserve WordPress PHPStan overrides in generated configs

### DIFF
--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -230,6 +230,7 @@ generate_dependency_config() {
     local has_component_context=0
     local context_path
     local scan_file_count=0
+    local wordpress_api_overrides="${EXTENSION_PATH}/stubs/wordpress-api-overrides.stub.php"
 
     tmpfile=$(homeboy_mktemp 'phpstan-dependencies.XXXXXX.neon')
 
@@ -276,6 +277,14 @@ generate_dependency_config() {
                 has_component_context=1
                 printf '        - %s\n' "$context_path"
             done < <(homeboy_resolve_phpstan_context_files "$PLUGIN_PATH")
+        fi
+
+        if [ -f "$wordpress_api_overrides" ]; then
+            if [ "$scan_file_count" -eq 0 ]; then
+                printf '%s\n' '    scanFiles:'
+            fi
+            scan_file_count=$((scan_file_count + 1))
+            printf '        - %s\n' "$wordpress_api_overrides"
         fi
     } > "$tmpfile"
 


### PR DESCRIPTION
## Summary
- Adds the WordPress API override stub to generated PHPStan dependency/baseline configs with an absolute `scanFiles` path.
- Keeps ABSPATH guard semantics intact when a component baseline or dependency config causes PHPStan to analyze through Homeboy's temporary config chain.

## Testing
- `bash wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh`
- `/Users/chubes/.config/homeboy/extensions/wordpress/vendor/bin/phpstan clear-result-cache && HOMEBOY_DEBUG=1 HOMEBOY_PHPSTAN_THREADS=1 homeboy --force-hot lint static-site-importer --path "/Users/chubes/Developer/static-site-importer-release-clean" --summary`

Fixes #1081.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5 / openai/gpt-5.5)
- **Used for:** Diagnosed the generated PHPStan config path mismatch, wrote the runner patch, and verified it against the SSI release blocker.