### PR TITLE
Support declared WordPress bench prepare steps

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -44,6 +44,7 @@
     "test:wp-codebox-prepared-dependency-cache": "bash tests/prepared-bench-dependency-cache-smoke.sh",
     "test:dependency-plugin-preflight": "bash tests/dependency-plugin-preflight-smoke.sh",
     "test:wp-codebox-bench-bootstrap-steps": "node tests/wp-codebox-bench-bootstrap-steps-smoke.js",
+    "test:wp-codebox-bench-prepare-steps": "node tests/wp-codebox-bench-prepare-steps-smoke.js",
     "test:wp-codebox-phpunit-recipe-builder": "node tests/wp-codebox-phpunit-recipe-builder-smoke.js",
     "test:build-package-artifacts": "bash scripts/build/build-package-artifacts-smoke.sh",
     "test:codebox-agent-task-executor": "node tests/codebox-agent-task-executor-smoke.js",

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -156,6 +156,149 @@ homeboy_wp_codebox_compile_bootstrap_steps() {
     WP_CODEBOX_BOOTSTRAP_STEPS_JSON="$steps_json"
 }
 
+homeboy_wp_codebox_compile_prepare_steps() {
+    local steps_json
+    steps_json=$(printf '%s' "$settings_json" | jq -c '
+        .wp_codebox_prepare_steps // .plugin_prepare // .bench_prepare // []
+        | if type == "array" then . else [] end
+    ' 2>/dev/null || echo '[]')
+
+    WP_CODEBOX_PREPARE_STEPS_JSON="[]"
+    if ! printf '%s' "$steps_json" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if ! printf '%s' "$steps_json" | jq -e '
+        all(.[];
+            type == "object"
+            and (.command | type == "string" and . != "")
+            and ((.args // []) | type == "array" and all(.[]; type == "string"))
+            and ((.cwd // "") | type == "string")
+        )
+    ' >/dev/null 2>&1; then
+        echo "Error: wp_codebox_prepare_steps entries require command plus optional string args and cwd." >&2
+        FAILED_STEP="WP Codebox bench prepare setup"
+        exit 1
+    fi
+
+    WP_CODEBOX_PREPARE_STEPS_JSON="$steps_json"
+}
+
+homeboy_wp_codebox_prepare_step_cwd() {
+    local cwd_ref="${1:-}"
+    local cwd_host
+
+    if [ -z "$cwd_ref" ]; then
+        printf '%s\n' "$PLUGIN_PATH"
+        return 0
+    fi
+    if [[ "$cwd_ref" = /* ]] || [[ "$cwd_ref" == *..* ]]; then
+        return 1
+    fi
+
+    cwd_host="${PLUGIN_PATH}/${cwd_ref}"
+    case "$cwd_host" in
+        "$PLUGIN_PATH"|"$PLUGIN_PATH"/*)
+            [ -d "$cwd_host" ] || return 1
+            printf '%s\n' "$cwd_host"
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+homeboy_wp_codebox_emit_prepare_failure_diagnostic() {
+    local step_index="$1"
+    local command_name="$2"
+    local cwd_host="$3"
+    local output_file="$4"
+    local exit_code="$5"
+    local diagnostics_file="${ARTIFACTS_DIR}/wp-codebox-bench-prepare-diagnostics.json"
+    local output_artifact="${ARTIFACTS_DIR}/wp-codebox-prepare-step-${step_index}-output.txt"
+
+    mkdir -p "$ARTIFACTS_DIR"
+    cp "$output_file" "$output_artifact"
+
+    jq -n \
+        --arg schema "homeboy/wordpress-bench-diagnostic/v1" \
+        --arg code "wp-codebox-bench-prepare-failed" \
+        --arg message "WP Codebox bench prepare step failed before the plugin was mounted into WordPress." \
+        --arg command "$command_name" \
+        --arg cwd "$cwd_host" \
+        --argjson stepIndex "$step_index" \
+        --argjson exitCode "$exit_code" \
+        --arg artifactsDir "$ARTIFACTS_DIR" \
+        --arg outputArtifact "$output_artifact" \
+        '{
+            schema: $schema,
+            diagnostics: [{
+                code: $code,
+                severity: "error",
+                phase: "prepare",
+                message: $message,
+                step_index: $stepIndex,
+                command: $command,
+                cwd: $cwd,
+                exit_code: $exitCode,
+                artifacts: {
+                    directory: $artifactsDir,
+                    output: $outputArtifact
+                }
+            }]
+        }' > "$diagnostics_file"
+
+    echo "WP Codebox bench prepare step failed before plugin runtime launch." >&2
+    echo "  Step: ${step_index}" >&2
+    echo "  Command: ${command_name}" >&2
+    echo "  CWD: ${cwd_host}" >&2
+    echo "  Exit code: ${exit_code}" >&2
+    echo "  Diagnostics: ${diagnostics_file}" >&2
+    echo "  Raw output: ${output_artifact}" >&2
+}
+
+homeboy_wp_codebox_run_prepare_steps() {
+    if ! printf '%s' "$WP_CODEBOX_PREPARE_STEPS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+        return 0
+    fi
+
+    local index=0
+    local step_json command_name cwd_ref cwd_host output_file exit_code
+    while IFS= read -r step_json; do
+        command_name=$(printf '%s' "$step_json" | jq -r '.command')
+        cwd_ref=$(printf '%s' "$step_json" | jq -r '.cwd // empty')
+        if ! cwd_host=$(homeboy_wp_codebox_prepare_step_cwd "$cwd_ref"); then
+            echo "Error: wp_codebox_prepare_steps[$index].cwd must be a directory under component root." >&2
+            FAILED_STEP="WP Codebox bench prepare setup"
+            exit 1
+        fi
+
+        output_file=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-prepare-${index}.XXXXXX")
+        echo "Preparing WordPress bench plugin source: ${command_name}" >&2
+        set +e
+        (
+            cd "$cwd_host"
+            step_args=()
+            while IFS= read -r step_arg; do
+                step_args+=("$step_arg")
+            done < <(printf '%s' "$step_json" | jq -r '(.args // [])[]')
+            "$command_name" "${step_args[@]}"
+        ) >"$output_file" 2>&1
+        exit_code=$?
+        set -e
+
+        if [ "$exit_code" -ne 0 ]; then
+            homeboy_wp_codebox_emit_prepare_failure_diagnostic "$index" "$command_name" "$cwd_host" "$output_file" "$exit_code"
+            rm -f "$output_file"
+            FAILED_STEP="WP Codebox bench prepare step"
+            exit "$exit_code"
+        fi
+
+        rm -f "$output_file"
+        index=$((index + 1))
+    done < <(printf '%s' "$WP_CODEBOX_PREPARE_STEPS_JSON" | jq -c '.[]')
+}
+
 homeboy_wp_codebox_output_has_bootstrap_failure() {
     local output_file="$1"
 
@@ -470,6 +613,7 @@ homeboy_wp_codebox_compile_scenario_manifests() {
 homeboy_wp_codebox_compile_scenario_manifests
 homeboy_wp_codebox_compile_bootstrap_files
 homeboy_wp_codebox_compile_bootstrap_steps
+homeboy_wp_codebox_compile_prepare_steps
 
 WP_CODEBOX_WORDPRESS_VERSION="7.0"
 if [ "$settings_json" != "{}" ]; then
@@ -504,6 +648,8 @@ fi
 if [ -z "$ARTIFACTS_DIR" ]; then
     ARTIFACTS_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-bench-artifacts.XXXXXX")
 fi
+
+homeboy_wp_codebox_run_prepare_steps
 
 if type homeboy_preflight_declared_validation_dependency_paths &>/dev/null; then
     if ! homeboy_preflight_declared_validation_dependency_paths "$ARTIFACTS_DIR" "bench"; then

--- a/wordpress/tests/wp-codebox-bench-prepare-steps-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-prepare-steps-smoke.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-prepare-steps-'));
+
+try {
+  const extensionPath = path.join(__dirname, '..');
+  const componentPath = path.join(root, 'prepare-steps-fixture');
+  const benchDir = path.join(componentPath, 'tests', 'bench');
+  const generatedPath = path.join(componentPath, 'includes', 'react-admin', 'feature-config.php');
+  fs.mkdirSync(benchDir, { recursive: true });
+  fs.writeFileSync(path.join(componentPath, 'prepare-steps-fixture.php'), "<?php\n/* Plugin Name: Prepare Steps Fixture */\n");
+  fs.writeFileSync(path.join(benchDir, 'assert-prepare.php'), "<?php\nreturn static fn() => ['metrics' => ['prepared' => 1]];\n");
+
+  const fakeWpCodebox = path.join(root, 'fixture-wp-codebox.js');
+  fs.writeFileSync(fakeWpCodebox, `#!/usr/bin/env node
+const fs = require('node:fs');
+const recipeIndex = process.argv.indexOf('--recipe');
+if (process.argv[2] !== 'recipe-run' || recipeIndex < 0) {
+  process.exit(2);
+}
+const recipe = JSON.parse(fs.readFileSync(process.argv[recipeIndex + 1], 'utf8'));
+const plugin = recipe.inputs.extraPlugins.find((entry) => entry.slug === 'prepare-steps-fixture');
+if (!plugin || !fs.existsSync(plugin.source + '/includes/react-admin/feature-config.php')) {
+  process.stderr.write('generated feature config missing before wp-codebox launch\\n');
+  process.exit(8);
+}
+process.stdout.write(JSON.stringify({
+  success: true,
+  benchResults: {
+    component_id: 'prepare-steps-fixture',
+    iterations: 1,
+    warmup_iterations: 0,
+    scenarios: [{ id: 'assert-prepare', metrics: { prepared: 1 } }]
+  }
+}) + '\\n');
+`);
+  fs.chmodSync(fakeWpCodebox, 0o755);
+
+  const benchHelper = path.join(root, 'bench-helper.sh');
+  fs.writeFileSync(benchHelper, `#!/usr/bin/env bash
+homeboy_write_empty_bench_results() {
+  local component="$1"
+  local iterations="$2"
+  local results_file="$3"
+  printf '{"component_id":"%s","iterations":%s,"scenarios":[]}\n' "$component" "$iterations" > "$results_file"
+}
+`);
+  const preflightHelper = path.join(root, 'preflight-helper.sh');
+  fs.writeFileSync(preflightHelper, `#!/usr/bin/env bash
+homeboy_require_bash_version() { :; }
+`);
+  const prepareScript = path.join(componentPath, 'bin', 'generate-feature-config.php');
+  fs.mkdirSync(path.dirname(prepareScript), { recursive: true });
+  fs.writeFileSync(prepareScript, `#!/usr/bin/env php
+<?php
+$target = __DIR__ . '/../includes/react-admin/feature-config.php';
+if (!is_dir(dirname($target))) {
+    mkdir(dirname($target), 0777, true);
+}
+file_put_contents($target, "<?php return ['prepared' => true];\n");
+`);
+  fs.chmodSync(prepareScript, 0o755);
+
+  const baseEnv = {
+    ...process.env,
+    HOMEBOY_BENCH_ITERATIONS: '1',
+    HOMEBOY_BENCH_WARMUP_ITERATIONS: '0',
+    HOMEBOY_COMPONENT_ID: 'prepare-steps-fixture',
+    HOMEBOY_COMPONENT_PATH: componentPath,
+    HOMEBOY_EXTENSION_PATH: extensionPath,
+    HOMEBOY_RUNTIME_BASH_PREFLIGHT: preflightHelper,
+    HOMEBOY_RUNTIME_BENCH_HELPER_SH: benchHelper,
+    HOMEBOY_WP_CODEBOX_BIN: fakeWpCodebox,
+  };
+
+  const successResult = spawnSync('bash', [path.join(extensionPath, 'scripts', 'bench', 'bench-runner.sh')], {
+    cwd: componentPath,
+    encoding: 'utf8',
+    env: {
+      ...baseEnv,
+      HOMEBOY_BENCH_RESULTS_FILE: path.join(root, 'success-results.json'),
+      HOMEBOY_SETTINGS_JSON: JSON.stringify({
+        wp_codebox_prepare_steps: [
+          { command: 'php', args: ['bin/generate-feature-config.php'] },
+        ],
+      }),
+    },
+  });
+
+  assert.equal(successResult.status, 0, successResult.stderr || successResult.stdout);
+  assert.equal(fs.existsSync(generatedPath), true);
+
+  fs.rmSync(generatedPath, { force: true });
+  const failureArtifactsDir = path.join(root, 'failure-artifacts');
+  const failureResult = spawnSync('bash', [path.join(extensionPath, 'scripts', 'bench', 'bench-runner.sh')], {
+    cwd: componentPath,
+    encoding: 'utf8',
+    env: {
+      ...baseEnv,
+      HOMEBOY_BENCH_RESULTS_FILE: path.join(root, 'failure-results.json'),
+      HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: failureArtifactsDir,
+      HOMEBOY_SETTINGS_JSON: JSON.stringify({
+        wp_codebox_prepare_steps: [
+          { command: 'php', args: ['missing-generate-feature-config.php'] },
+        ],
+      }),
+    },
+  });
+
+  assert.equal(failureResult.status, 1);
+  assert.match(failureResult.stderr, /WP Codebox bench prepare step failed before plugin runtime launch/);
+  const diagnostics = JSON.parse(fs.readFileSync(path.join(failureArtifactsDir, 'wp-codebox-bench-prepare-diagnostics.json'), 'utf8'));
+  assert.equal(diagnostics.diagnostics[0].code, 'wp-codebox-bench-prepare-failed');
+  assert.equal(diagnostics.diagnostics[0].phase, 'prepare');
+  assert.equal(diagnostics.diagnostics[0].command, 'php');
+
+  console.log('WP Codebox bench prepare steps smoke passed');
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1041,6 +1041,13 @@
       "description": "Generic WP Codebox recipe steps to run during pluginRuntime.setup after dependency activation and before measured bench workloads. Use this for dependency setup that must be prepared outside workload timing."
     },
     {
+      "id": "wp_codebox_prepare_steps",
+      "label": "WP Codebox bench prepare steps",
+      "type": "array",
+      "default": [],
+      "description": "Explicit host-side commands to run before WP Codebox mounts and loads the plugin for wordpress.bench. Each step is an object with command, optional string args, and optional component-relative cwd. Use this for bounded source-checkout generation such as WooCommerce feature config files; no package scripts run implicitly."
+    },
+    {
       "id": "wp_codebox_scenario_manifests",
       "label": "WP Codebox scenario manifests",
       "type": "array",


### PR DESCRIPTION
## Summary
- Adds explicit `wp_codebox_prepare_steps` for host-side WordPress bench source preparation before WP Codebox mounts and loads the plugin.
- Keeps preparation opt-in and bounded with `command`, optional string `args`, and component-relative `cwd`; failed steps emit structured diagnostics and captured output artifacts.
- Adds a smoke test covering generated-file preparation and failure diagnostics.

Fixes #1079.

## Verification
- `npm ci`
- `npm run test:wp-codebox-bench-prepare-steps`
- `npm run test:wp-codebox-bench-bootstrap-steps`
- `bash -n scripts/bench/bench-runner-wp-codebox.sh`
- `npm run lint:js -- tests/wp-codebox-bench-prepare-steps-smoke.js` (exits 0; repo config ignores `tests/` and reports the existing ignore warning)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the WordPress bench prepare-step runner implementation, smoke test, and PR description; Chris remains responsible for review and merge.