### PR TITLE
Keep WordPress bench prepare steps explicit

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -159,7 +159,7 @@ homeboy_wp_codebox_compile_bootstrap_steps() {
 homeboy_wp_codebox_compile_prepare_steps() {
     local steps_json
     steps_json=$(printf '%s' "$settings_json" | jq -c '
-        .wp_codebox_prepare_steps // .plugin_prepare // .bench_prepare // []
+        .wp_codebox_prepare_steps // []
         | if type == "array" then . else [] end
     ' 2>/dev/null || echo '[]')
 


### PR DESCRIPTION
## Summary
- Removes the loose `plugin_prepare` and `bench_prepare` aliases from the newly landed WordPress bench prepare-step setting.
- Keeps host-side prepare execution behind the explicit `wp_codebox_prepare_steps` key only, avoiding accidental execution from generic config names.

Follow-up to #1083 / #1079.

## Verification
- `npm run test:wp-codebox-bench-prepare-steps`
- `bash -n scripts/bench/bench-runner-wp-codebox.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Identified the loose-alias footgun and drafted the one-line follow-up plus PR description; Chris remains responsible for review and merge.