### PR TITLE
Fix WordPress PHPStan release preflight stability

### DIFF
--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -301,6 +301,7 @@ homeboy_resolve_phpstan_context_directories() {
     local candidate
 
     find "$component_path" -mindepth 1 -maxdepth 1 -type d \
+        -not -name '.homeboy-build' \
         -not -name 'vendor' \
         -not -name 'vendor_prefixed' \
         -not -name 'node_modules' \
@@ -350,6 +351,7 @@ generate_scoped_context_config() {
             fi
             printf '        - %s\n' "$(printf '%s' "$context_file" | jq -Rsa .)"
         done < <(find "$PLUGIN_PATH" -type f -name '*.php' \
+            -not -path "*/.homeboy-build/*" \
             -not -path "*/vendor/*" \
             -not -path "*/vendor_prefixed/*" \
             -not -path "*/node_extensions/*" \
@@ -443,6 +445,7 @@ resolve_phpstan_targets() {
                 printf '%s\0' "$target_path"
             elif [ -d "$target_path" ]; then
                 find "$target_path" -type f -name '*.php' \
+                    -not -path "*/.homeboy-build/*" \
                     -not -path "*/vendor/*" \
                     -not -path "*/vendor_prefixed/*" \
                     -not -path "*/node_extensions/*" \
@@ -472,6 +475,7 @@ resolve_phpstan_full_targets() {
             printf '%s\0' "$target_path"
         fi
     done < <(find "$PLUGIN_PATH" -type f -name '*.php' \
+        -not -path "*/.homeboy-build/*" \
         -not -path "*/vendor/*" \
         -not -path "*/vendor_prefixed/*" \
         -not -path "*/node_extensions/*" \
@@ -649,6 +653,11 @@ phpstan_args+=(--no-progress)
 PHPSTAN_MAX_PROCESSES=""
 if [ -n "${HOMEBOY_PHPSTAN_THREADS:-}" ]; then
     PHPSTAN_MAX_PROCESSES="${HOMEBOY_PHPSTAN_THREADS}"
+elif [ -n "$DEPENDENCY_CONFIG" ] && [ -n "${HOMEBOY_PHP_VERSION:-}" ]; then
+    # Release preflight adds phpVersion on top of generated dependency/baseline
+    # configs; keep that layered config in-process so WP override scanFiles stay
+    # stable instead of depending on worker bootstrap behavior.
+    PHPSTAN_MAX_PROCESSES="1"
 elif [ "$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)" -le 2 ]; then
     PHPSTAN_MAX_PROCESSES="1"
 fi

--- a/wordpress/scripts/lint/phpstan-scoped-smoke.sh
+++ b/wordpress/scripts/lint/phpstan-scoped-smoke.sh
@@ -25,12 +25,19 @@ OUTPUT_FILE="${TMPDIR}/phpstan-output.txt"
 FINDINGS_FILE="${TMPDIR}/phpstan-findings.json"
 PRODUCER_METADATA_FILE="${TMPDIR}/phpstan-producer-metadata.json"
 
-mkdir -p "${EXTENSION_DIR}/vendor/bin" "${COMPONENT_DIR}/tests" "${COMPONENT_DIR}/assets" "${COMPONENT_DIR}/includes" "${COMPONENT_DIR}/vendor_prefixed"
+mkdir -p \
+    "${EXTENSION_DIR}/vendor/bin" \
+    "${COMPONENT_DIR}/tests" \
+    "${COMPONENT_DIR}/assets" \
+    "${COMPONENT_DIR}/includes" \
+    "${COMPONENT_DIR}/vendor_prefixed" \
+    "${COMPONENT_DIR}/.homeboy-build/static-site-importer/includes"
 touch "${EXTENSION_DIR}/phpstan.neon.dist"
 printf '%s\n' '<?php missing_function();' > "${COMPONENT_DIR}/main.php"
 printf '%s\n' 'parameters:' '    ignoreErrors: []' > "${COMPONENT_DIR}/phpstan-baseline.neon"
 touch "${COMPONENT_DIR}/tests/FooTest.php" "${COMPONENT_DIR}/assets/app.js"
 touch "${COMPONENT_DIR}/includes/interface-example.php" "${COMPONENT_DIR}/includes/extra.php" "${COMPONENT_DIR}/vendor_prefixed/autoload.php"
+touch "${COMPONENT_DIR}/.homeboy-build/static-site-importer/includes/stale-copy.php"
 
 cat > "$DEPENDENCY_HELPER" <<'SH'
 homeboy_resolve_validation_dependency_paths() {
@@ -172,6 +179,13 @@ assert metadata["phpstan_level"] == "5", metadata
 assert metadata["phpstan_level_source"] == "env", metadata
 PY
 rm -f "${COMPONENT_DIR}/phpstan.neon.dist"
+
+HOMEBOY_PHP_VERSION=8.1 run_phpstan
+assert_contains "--configuration=" "release-style PHP version run still passes a generated PHPStan config"
+assert_file_contains "$CONFIG_CAPTURE" "maximumNumberOfProcesses: 1" "release-style generated dependency config forces single-process PHPStan by default"
+assert_file_contains "$CONFIG_CAPTURE" "phpVersion: 80100" "release-style generated dependency config preserves PHP version override"
+assert_not_contains ".homeboy-build" "full-component PHPStan run excludes Homeboy release build artifacts"
+assert_file_not_contains "$CONFIG_CAPTURE" ".homeboy-build" "release-style PHPStan context excludes Homeboy release build artifacts"
 
 HOMEBOY_LINT_GLOB='{main.php,assets/app.js,includes/extra.php}' run_phpstan
 assert_contains "${COMPONENT_DIR}/main.php" "glob scope includes matching PHP source file"


### PR DESCRIPTION
## Summary
- Excludes Homeboy release build artifacts from WordPress PHPStan target and context discovery.
- Keeps release-preflight-style generated dependency/baseline PHPStan configs single-process when a PHP version override is layered on top.
- Extends the PHPStan scoped smoke to cover generated baseline config, PHP version env handling, and `.homeboy-build` exclusion without requiring `HOMEBOY_PHPSTAN_THREADS`.

## Testing
- `bash wordpress/scripts/lint/phpstan-scoped-smoke.sh`
- `bash wordpress/tests/phpstan-wordpress-api-stubs-smoke.sh`
- `bash wordpress/tests/phpstan-temp-config-suffix-smoke.sh`
- `bash wordpress/scripts/lint/wordpress-lint-role-smoke.sh`
- `HOMEBOY_EXTENSION_PATH="/Users/chubes/Developer/homeboy-extensions@fix-wp-phpstan-abspath-stub-20260604/wordpress" HOMEBOY_COMPONENT_PATH="/Users/chubes/Developer/static-site-importer-release-clean" HOMEBOY_COMPONENT_ID="static-site-importer" HOMEBOY_SUMMARY_MODE=1 HOMEBOY_PHP_VERSION=8.1 "/Users/chubes/Developer/homeboy-extensions@fix-wp-phpstan-abspath-stub-20260604/wordpress/scripts/lint/phpstan-runner.sh"`

## Notes
- `homeboy release static-site-importer --path /Users/chubes/Developer/static-site-importer-release-clean --bump patch --dry-run` could not reach release preflight because the SSI release checkout currently has uncommitted Composer vendor files and `.homeboy-build/` state.
- `bash wordpress/tests/validation-dependencies-smoke.sh` failed in an existing Composer dependency-cache expectation unrelated to this patch.

Fixes #1081.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5 / openai/gpt-5.5)
- **Used for:** Diagnosed the remaining release-preflight PHPStan path, implemented the runner/smoke updates, and ran targeted verification.