### PR TITLE
Normalize agent task semantic outputs

### DIFF
--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -240,6 +240,9 @@ Generic `homeboy/agent-task-outcome/v1` outcomes must include:
 - `artifacts`: zero or more `homeboy/agent-task-artifact/v1` records.
 - `evidence_refs`: clickable or resolvable references to artifacts, previews,
   logs, transcripts, issues, PRs, runs, or replay bundles.
+- `outputs`: semantic task outputs such as `issue_number`, `issue_url`, or
+  `pull_request_url` that consumers can read without backend-specific path
+  knowledge.
 - `diagnostics`: structured diagnostics with `class`, `message`, and redacted
   `data`.
 - `metadata`: public, redacted metadata for dashboards and decision evidence.

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -424,6 +424,42 @@ function artifactFromCodeboxArtifact(artifact, index) {
   };
 }
 
+function pathValue(source, dottedPath) {
+  return String(dottedPath || '').split('.').filter(Boolean).reduce((value, key) => (value && typeof value === 'object' ? value[key] : undefined), source);
+}
+
+function normalizeOutputs(result) {
+  const workload = result.metadata?.agent_runtime?.workload || result.run?.agentResult || result.agentResult || result.agent_result || {};
+  if (workload.outputs && typeof workload.outputs === 'object' && !Array.isArray(workload.outputs)) {
+    return sanitizePublicMetadata(workload.outputs);
+  }
+
+  const bundle = result.metadata?.agent_runtime?.bundle || result.task_input?.agent_bundle || {};
+  const configuredOutputs = bundle.engine_data_outputs && typeof bundle.engine_data_outputs === 'object' ? bundle.engine_data_outputs : {};
+  const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
+  const outputs = {};
+  for (const [name, outputPath] of Object.entries(configuredOutputs)) {
+    for (const scenario of scenarios) {
+      const value = pathValue(scenario, outputPath);
+      if (value !== undefined && value !== null && value !== '') {
+        outputs[name] = value;
+        break;
+      }
+    }
+  }
+  return sanitizePublicMetadata(outputs);
+}
+
+function outputEvidenceRefs(outputs) {
+  return Object.entries(outputs || {})
+    .filter(([name, value]) => /(?:^|_)url$/i.test(name) && typeof value === 'string' && /^https?:\/\//i.test(value))
+    .map(([name, value]) => ({
+      kind: `agent-output-${name.replace(/_/g, '-')}`,
+      uri: value,
+      label: name.replace(/_/g, ' '),
+    }));
+}
+
 function normalizeArtifacts(result) {
   if (result?.schema === 'wp-codebox/agent-task-run/v1') {
     const artifacts = [];
@@ -487,6 +523,9 @@ function normalizeEvidenceRefs(result) {
         uri: artifact.path || artifact.url,
         label: artifact.kind.replace(/^agent-runtime-/, 'Agent runtime ').replace(/-/g, ' '),
       });
+    }
+    for (const ref of outputEvidenceRefs(normalizeOutputs(result))) {
+      appendUniqueEvidenceRef(refs, ref);
     }
     return refs;
   }
@@ -575,6 +614,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   assertAgentTaskRequest(request);
   const status = normalizeStatus(result, options.exitStatus ?? 0);
   const failureClassification = result.failure_classification || failureClassificationForStatus(status);
+  const outputs = normalizeOutputs(result);
   const outcome = {
     schema: AGENT_TASK_OUTCOME_SCHEMA,
     task_id: request.task_id,
@@ -582,6 +622,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     summary: result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
     artifacts: normalizeArtifacts(result),
     evidence_refs: normalizeEvidenceRefs(result),
+    outputs,
     diagnostics: (result.diagnostics || []).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
       message: diagnostic.message || String(diagnostic),

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -335,7 +335,7 @@ function normalizeAgentTaskRun(input, result) {
   const agentBundle = agentBundleConfig(input, input.agent_bundle || {});
   const stdoutWorkload = agentRuntimeWorkloadFromExecutionStdout(execution, agentBundle);
   const fallbackAgentResult = result.metadata?.agent_runtime?.workload || execution?.agentResult || result.run?.agentResult || result.agentResult || result.agent_result || {};
-  const agentResult = hasScenarios(stdoutWorkload) ? stdoutWorkload : fallbackAgentResult;
+  const agentResult = hasSemanticWorkload(stdoutWorkload) ? stdoutWorkload : fallbackAgentResult;
   const bundleValidation = validateAgentRuntimeWorkload(agentResult, agentBundle);
   const success = !bundleValidation;
   const diagnostics = [
@@ -393,6 +393,9 @@ function agentRuntimeWorkloadFromExecutionStdout(execution, config) {
   if (Array.isArray(workload.scenarios)) {
     return workload;
   }
+  if (isSingleResultWorkload(workload)) {
+    return agentRuntimeWorkloadFromSingleResult(workload, config);
+  }
   if (workload.metadata || workload.metrics) {
     return {
       scenarios: [{
@@ -405,10 +408,40 @@ function agentRuntimeWorkloadFromExecutionStdout(execution, config) {
   return null;
 }
 
+function isSingleResultWorkload(workload) {
+  return plainObject(workload) && (
+    plainObject(workload.outputs)
+      || plainObject(workload.output)
+      || Array.isArray(workload.diagnostics)
+      || typeof workload.summary === 'string'
+  );
+}
+
+function agentRuntimeWorkloadFromSingleResult(workload, config) {
+  let outputs = {};
+  if (plainObject(workload.outputs)) {
+    outputs = workload.outputs;
+  } else if (plainObject(workload.output)) {
+    outputs = workload.output;
+  }
+  return Object.fromEntries(Object.entries({
+    id: config.workload_id || config.agent_slug || config.flow_slug || 'agent-bundle',
+    success: workload.success,
+    status: workload.status,
+    summary: workload.summary || workload.message,
+    outputs,
+    diagnostics: Array.isArray(workload.diagnostics) ? workload.diagnostics : [],
+    metrics: workload.metrics || {},
+    metadata: workload.metadata || {},
+  }).filter(([, value]) => value !== undefined && !(Array.isArray(value) && value.length === 0)));
+}
+
 function agentRuntimeWorkloadFromBundleRun(bundleRun, config) {
   const bundle = bundleRun.bundle && typeof bundleRun.bundle === 'object' ? bundleRun.bundle : {};
   const workflowSteps = Array.isArray(bundleRun.workflow?.steps) ? bundleRun.workflow.steps : [];
+  const outputs = plainObject(bundleRun.outputs) ? bundleRun.outputs : {};
   return {
+    outputs,
     scenarios: [{
       id: config.workload_id || bundle.flow_slug || bundle.bundle_slug || config.agent_slug || config.flow_slug || 'agent-bundle',
       metrics: {
@@ -433,20 +466,16 @@ function hasScenarios(value) {
   return Array.isArray(value?.scenarios) && value.scenarios.length > 0;
 }
 
+function hasSemanticWorkload(value) {
+  return hasScenarios(value) || plainObject(value?.outputs) || isSingleResultWorkload(value);
+}
+
 function pathValue(source, dottedPath) {
   return String(dottedPath || '').split('.').filter(Boolean).reduce((value, key) => (value && typeof value === 'object' ? value[key] : undefined), source);
 }
 
 function validateAgentRuntimeWorkload(workload, config) {
   const scenarios = Array.isArray(workload?.scenarios) ? workload.scenarios : [];
-  if (scenarios.length === 0) {
-    return {
-      class: 'agent_runtime.workload.incomplete',
-      message: 'Agent bundle workload did not return any scenarios.',
-      data: { reason: 'missing_scenarios' },
-    };
-  }
-
   const failedScenario = scenarios.find((scenario) => scenario?.metadata?.error || scenario?.metadata?.error_message);
   if (failedScenario) {
     return {
@@ -459,6 +488,9 @@ function validateAgentRuntimeWorkload(workload, config) {
   const outputs = config.engine_data_outputs && typeof config.engine_data_outputs === 'object' ? config.engine_data_outputs : {};
   const missing = [];
   for (const [name, outputPath] of Object.entries(outputs)) {
+    if (workload?.outputs?.[name] !== undefined && workload.outputs[name] !== null && workload.outputs[name] !== '') {
+      continue;
+    }
     const present = scenarios.some((scenario) => {
       const value = pathValue(scenario, outputPath);
       return value !== undefined && value !== null && value !== '';
@@ -471,8 +503,16 @@ function validateAgentRuntimeWorkload(workload, config) {
   if (missing.length > 0) {
     return {
       class: 'agent_runtime.workload.incomplete',
-      message: 'Agent bundle workload did not produce required engine data outputs.',
+      message: `Agent bundle workload did not produce required semantic outputs: ${missing.map((item) => item.name).join(', ')}.`,
       data: { reason: 'missing_engine_data_outputs', missing },
+    };
+  }
+
+  if (scenarios.length === 0 && (!plainObject(workload?.outputs) || Object.keys(workload.outputs).length === 0)) {
+    return {
+      class: 'agent_runtime.workload.incomplete',
+      message: 'Agent bundle workload did not produce scenarios or semantic outputs.',
+      data: { reason: 'missing_semantic_outputs' },
     };
   }
 
@@ -480,6 +520,11 @@ function validateAgentRuntimeWorkload(workload, config) {
 }
 
 function agentRuntimeDiagnostics(workload) {
+  const workloadDiagnostics = Array.isArray(workload?.diagnostics) ? workload.diagnostics.map((diagnostic) => ({
+    class: diagnostic.class || diagnostic.kind || 'agent_runtime.workload',
+    message: diagnostic.message || String(diagnostic),
+    data: diagnostic.data || {},
+  })) : [];
   const scenarios = Array.isArray(workload?.scenarios) ? workload.scenarios : [];
   const diagnostics = scenarios
     .filter((scenario) => scenario?.metadata?.error || scenario?.metadata?.error_message)
@@ -488,7 +533,8 @@ function agentRuntimeDiagnostics(workload) {
       message: scenario.metadata.error || scenario.metadata.error_message,
       data: { scenario_id: scenario.id, metadata: scenario.metadata },
     }));
-  return diagnostics.length > 0 ? diagnostics : null;
+  const allDiagnostics = [...workloadDiagnostics, ...diagnostics];
+  return allDiagnostics.length > 0 ? allDiagnostics : null;
 }
 
 function timeoutPayload(timeoutMs, artifacts, evidencePath, inputPath, command, args) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -420,12 +420,45 @@ const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
 });
 assert.equal(agentBundleOutcome.schema, 'homeboy/agent-task-outcome/v1');
 assert.equal(agentBundleOutcome.status, 'succeeded');
+assert.equal(agentBundleOutcome.outputs.static_site_pr_url, 'https://github.com/chubes4/wp-site-generator/pull/123');
 assert.equal(agentBundleOutcome.artifacts.some((artifact) => artifact.kind === 'agent-runtime-transcript' && artifact.path === '/tmp/transcript.json'), true);
 assert.equal(agentBundleOutcome.artifacts.some((artifact) => artifact.kind === 'agent-runtime-replay-bundle' && artifact.path === '/tmp/replay-bundle'), true);
 assert.equal(agentBundleOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/123'), true);
 assert.equal(upstreamRunnerOutcome.artifacts[1].kind, 'codebox-session-artifacts');
 assert.equal(upstreamRunnerOutcome.evidence_refs[0].uri, 'https://preview.example.test/sandbox-session-1');
 assert.equal(upstreamRunnerOutcome.evidence_refs[1].uri, '/tmp/wp-codebox-artifacts');
+
+const singleResultAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  task_id: 'single-result-agent-bundle-task-123',
+  executor: { backend: 'codebox' },
+}, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  artifacts: '/tmp/wp-codebox-artifacts',
+  metadata: {
+    agent_runtime: {
+      bundle: {
+        engine_data_outputs: {
+          issue_number: 'metadata.engine_data.store_idea_agent.issue_number',
+          issue_url: 'metadata.engine_data.store_idea_agent.issue_url',
+        },
+      },
+      workload: {
+        outputs: {
+          issue_number: 123,
+          issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123',
+        },
+        diagnostics: [{ class: 'agent_runtime.output', message: 'Semantic outputs captured.' }],
+      },
+    },
+  },
+});
+assert.equal(singleResultAgentBundleOutcome.schema, 'homeboy/agent-task-outcome/v1');
+assert.equal(singleResultAgentBundleOutcome.status, 'succeeded');
+assert.equal(singleResultAgentBundleOutcome.outputs.issue_number, 123);
+assert.equal(singleResultAgentBundleOutcome.outputs.issue_url, 'https://github.com/chubes4/wp-site-generator/issues/123');
+assert.equal(singleResultAgentBundleOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/issues/123'), true);
 
 const canaryRunOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: true,

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -46,9 +46,19 @@ const agentResult = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_AGENT
             result: bundleRun,
           },
         }
+  : (isAgentBundle && process.env.FIXTURE_WP_CODEBOX_SINGLE_RESULT
+      ? {
+          success: true,
+          summary: 'Created issue 123.',
+          outputs: {
+            issue_number: 123,
+            issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123'
+          },
+          diagnostics: [{ class: 'agent_runtime.output', message: 'Semantic outputs captured.' }]
+        }
   : (isAgentBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_AGENT_BUNDLE
       ? { metrics: { config_present: 1 }, metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }
-      : { status: 'completed' }));
+      : { status: 'completed' })));
 fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), input }, null, 2));
 const execution = { recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed', output: JSON.stringify(agentResult) }) };
 const executions = [execution];
@@ -246,6 +256,42 @@ try {
   assert.equal(agentBundleOutput.session.status, 'completed');
   assert.equal(agentBundleOutput.run.agentResult.scenarios[0].metadata.engine_data.store_idea_agent.issue_number, 123);
 
+  const singleResultCapturePath = path.join(root, 'capture-single-result-datamachine.json');
+  const singleResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin',
+    fixtureWpCodebox,
+    '--artifacts',
+    path.join(root, 'single-result-datamachine-artifacts'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      agent_bundle: {
+        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
+        engine_data_outputs: {
+          issue_number: 'metadata.engine_data.store_idea_agent.issue_number',
+          issue_url: 'metadata.engine_data.store_idea_agent.issue_url',
+        },
+      },
+      provider_plugin_paths: [],
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: singleResultCapturePath,
+      FIXTURE_WP_CODEBOX_SINGLE_RESULT: '1',
+      OPENCODE_API_KEY: 'redacted-test-key',
+    },
+  });
+  assert.equal(singleResult.status, 0, singleResult.stderr || singleResult.stdout);
+  const singleResultOutput = JSON.parse(singleResult.stdout);
+  assert.equal(singleResultOutput.success, true);
+  assert.equal(singleResultOutput.session.status, 'completed');
+  assert.equal(singleResultOutput.run.agentResult.outputs.issue_number, 123);
+  assert.equal(singleResultOutput.run.agentResult.outputs.issue_url, 'https://github.com/chubes4/wp-site-generator/issues/123');
+  assert.equal(Array.isArray(singleResultOutput.run.agentResult.scenarios), false);
+  assert.equal(singleResultOutput.diagnostics.some((diagnostic) => diagnostic.class === 'agent_runtime.output'), true);
+
   const canonicalBundleRunCapturePath = path.join(root, 'capture-canonical-datamachine-bundle-run.json');
   const canonicalBundleRunResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
@@ -310,7 +356,8 @@ try {
   assert.equal(incompleteDatamachineOutput.success, false);
   assert.equal(incompleteDatamachineOutput.session.status, 'failed');
   assert.equal(incompleteDatamachineOutput.diagnostics[0].class, 'agent_runtime.workload.incomplete');
-  assert.equal(incompleteDatamachineOutput.diagnostics[0].data.reason, 'missing_scenarios');
+  assert.equal(incompleteDatamachineOutput.diagnostics[0].data.reason, 'missing_engine_data_outputs');
+  assert.match(incompleteDatamachineOutput.diagnostics[0].message, /issue_number/);
 
   const failedDatamachineCapturePath = path.join(root, 'capture-failed-datamachine.json');
   const failedDatamachineResult = spawnSync(process.execPath, [


### PR DESCRIPTION
## Summary
- Accept agent-bundle single-result envelopes with `outputs` and `diagnostics` so ordinary agent tasks do not need synthetic `scenarios[0]` results.
- Expose semantic outputs such as `issue_number` and `issue_url` on the Homeboy `agent-task-outcome` and add URL outputs as evidence refs.
- Preserve scenario/eval workload compatibility and improve missing-output diagnostics to name the required semantic outputs directly.

Closes #1087.

## Testing
- `npm run test:wp-codebox-task-runner`
- `npm run test:codebox-agent-task-executor`
- `npx eslint lib/codebox-agent-task-executor.js scripts/agent/homeboy-wp-codebox-task-runner.cjs`

## Notes
- `npm run lint:js` still fails on existing unrelated lint violations in `playground-readiness.js`, `request-profiler.js`, `timing-correlator.js`, `terminal-action-server.js`, `update-runner-workspace-pr.cjs`, and `wp-codebox-apply-adapter.cjs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the normalization changes, smoke coverage, and PR text; Chris remains responsible for review and merge.