### PR TITLE
Run agent bundles through Codebox runtime tasks

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -253,6 +253,7 @@ function stableTaskInput(input) {
     runtime_component_paths: input.runtime_component_paths || {},
     wp: input.wp_version,
     agent_bundle: isAgentBundle(input) ? agentBundleConfig(input, input.agent_bundle || {}) : {},
+    runtime_task: isAgentBundle(input) ? agentBundleRuntimeTask(input, input.agent_bundle || {}) : undefined,
     parent_request: input.parent_request,
   }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
 }
@@ -313,6 +314,20 @@ function agentBundleConfig(input, bundleConfig = {}) {
     wp_codebox_artifacts_dir: input.artifacts_path,
     wp_codebox_components: runtimeComponentPaths,
   }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
+}
+
+function agentBundleRuntimeTask(input, bundleConfig = {}) {
+  const config = agentBundleConfig(input, bundleConfig);
+  const source = config.source || config.bundle_path || config.bundle_host_path || '';
+  return {
+    ability: 'datamachine/run-agent-bundle',
+    input: Object.fromEntries(Object.entries({
+      ...config,
+      source,
+      wait_for_completion: config.wait_for_completion ?? true,
+      runtime_bundles: source ? [{ source, on_conflict: config.on_conflict || 'upgrade' }] : [],
+    }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0))),
+  };
 }
 
 function resultExecutions(result) {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -251,6 +251,10 @@ try {
   assert.equal(agentBundleCapture.input.sandbox_tool_policy.tools[0].id, 'homeboy/no-runtime-tools');
   assert.equal(agentBundleCapture.input.sandbox_tool_policy.tools[0].allowed, false);
   assert.equal(agentBundleCapture.input.agent_bundle.engine_data_outputs.issue_number, 'metadata.engine_data.store_idea_agent.issue_number');
+  assert.equal(agentBundleCapture.input.runtime_task.ability, 'datamachine/run-agent-bundle');
+  assert.equal(agentBundleCapture.input.runtime_task.input.source, '/workspace/wp-site-generator/bundles/store-idea-agent');
+  assert.equal(agentBundleCapture.input.runtime_task.input.wait_for_completion, true);
+  assert.equal(agentBundleCapture.input.runtime_task.input.runtime_bundles[0].source, '/workspace/wp-site-generator/bundles/store-idea-agent');
   const agentBundleOutput = JSON.parse(agentBundleResult.stdout);
   assert.equal(agentBundleOutput.success, true);
   assert.equal(agentBundleOutput.session.status, 'completed');


### PR DESCRIPTION
## Summary
- Translate Homeboy `agent_bundle` task input into a WP Codebox `runtime_task` for `datamachine/run-agent-bundle`.
- Keep the existing `agent_bundle` metadata for Homeboy result normalization while making WP Codebox execute the bundle runner instead of direct chat.
- Add smoke coverage that verifies the runtime task ability, source, wait behavior, and runtime bundle import source.

Closes #1094.

## Evidence
- Downstream run still failed after Data Machine permission fix: https://github.com/chubes4/wp-site-generator/actions/runs/26980375193
- Artifact transcript showed `runtime_task: null` and a direct `agents/chat` call, so the bundle runner was never invoked.

## Testing
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `npm run test:wp-codebox-task-runner` from `wordpress/`
- `npm run lint:js -- scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/wp-codebox-task-runner-smoke.js` from `wordpress/` (ESLint checked the runner; smoke file is ignored by repo config)
- `git diff --check`

Note: `homeboy lint homeboy-extensions --changed-since origin/main` cannot run locally because no Homeboy extension provider is configured for this component.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the downstream artifact transcript, implemented runtime task translation, added smoke coverage, and ran focused validation; Chris remains responsible for review and merge.