### PR TITLE
fix: keep generic Codebox tasks out of bundle mode

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -64,6 +64,13 @@ const AGENT_BUNDLE_CONFIG_FIELDS = [
   'time_budget_ms',
 ];
 
+const AGENT_BUNDLE_TRIGGER_FIELDS = AGENT_BUNDLE_CONFIG_FIELDS.filter((field) => ![
+  'provider',
+  'model',
+  'prompt',
+  'provider_plugin_paths',
+].includes(field));
+
 const LEGACY_RUNTIME_PREFIX = ['data', 'machine'].join('_');
 const LEGACY_BUNDLE_KEYS = [
   `${LEGACY_RUNTIME_PREFIX}_bundle`,
@@ -222,14 +229,26 @@ function agentBundleMounts(bundleConfig, explicitMounts = []) {
 }
 
 function agentBundleConfigFromAgentTaskRequest(request, config, inputs) {
-  const candidateSources = [
+  const explicitBundleSources = [
     inputs.agent_bundle,
     inputs.agentBundle,
     ...LEGACY_BUNDLE_KEYS.map((key) => inputs[key]),
-    inputs,
     config.agent_bundle,
     config.agentBundle,
     ...LEGACY_BUNDLE_KEYS.map((key) => config[key]),
+  ].filter((value) => value && typeof value === 'object');
+  const requestedBundle = config.execution_kind === 'agent_bundle'
+    || inputs.execution_kind === 'agent_bundle'
+    || explicitBundleSources.length > 0
+    || AGENT_BUNDLE_TRIGGER_FIELDS.some((field) => inputs[field] !== undefined || config[field] !== undefined);
+
+  if (!requestedBundle) {
+    return {};
+  }
+
+  const candidateSources = [
+    ...explicitBundleSources,
+    inputs,
     config,
   ].filter((value) => value && typeof value === 'object');
   const bundleConfig = {};

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -219,6 +219,7 @@ assert.equal(codeboxRequest.task_timeout_seconds, 120);
 assert.equal(codeboxRequest.expected_artifacts[0], 'screenshot');
 assert.equal(codeboxRequest.orchestrator.agent_task_id, 'task-123');
 assert.equal(codeboxRequest.context.audit_findings[0].id, 'finding-1');
+assert.deepEqual(codeboxRequest.agent_bundle, {});
 
 const codexAgentRequest = {
   ...request,
@@ -265,6 +266,7 @@ assert.deepEqual(codexRequest.secret_env, [
   'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
   'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
 ]);
+assert.deepEqual(codexRequest.agent_bundle, {});
 assert(!JSON.stringify(codexRequest).includes('wp-ai-gateway'));
 assert.equal(codeboxTaskRequestFromAgentTaskRequest({
   ...request,


### PR DESCRIPTION
## Summary
- Keep generic Codebox agent-task requests from being converted into agent-bundle workloads when only provider/model/prompt fields are present.
- Preserve explicit agent-bundle behavior when callers provide bundle-specific fields or `execution_kind: \"agent_bundle\"`.
- Add smoke assertions covering generic OpenAI/Codex requests with empty `agent_bundle` payloads.

## Testing
- `node tests/codebox-agent-task-executor-smoke.js`
- `node tests/codebox-agent-task-boundary-smoke.js`
- `node --check lib/codebox-agent-task-executor.js scripts/agent/homeboy-codebox-agent-task-executor.cjs scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/codebox-agent-task-executor-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the generic agent-task dispatch regression, drafted the targeted fix and smoke coverage, and ran focused verification. Chris remains responsible for review and merge.