### PR TITLE
Avoid importing directory-backed Data Machine agent bundles

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -319,13 +319,14 @@ function agentBundleConfig(input, bundleConfig = {}) {
 function agentBundleRuntimeTask(input, bundleConfig = {}) {
   const config = agentBundleConfig(input, bundleConfig);
   const source = config.source || config.bundle_path || config.bundle_host_path || '';
+  const runtimeBundles = Array.isArray(config.runtime_bundles) ? config.runtime_bundles : [];
   return {
     ability: 'datamachine/run-agent-bundle',
     input: Object.fromEntries(Object.entries({
       ...config,
       source,
       wait_for_completion: config.wait_for_completion ?? true,
-      runtime_bundles: source ? [{ source, on_conflict: config.on_conflict || 'upgrade' }] : [],
+      runtime_bundles: runtimeBundles,
     }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0))),
   };
 }

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -254,7 +254,7 @@ try {
   assert.equal(agentBundleCapture.input.runtime_task.ability, 'datamachine/run-agent-bundle');
   assert.equal(agentBundleCapture.input.runtime_task.input.source, '/workspace/wp-site-generator/bundles/store-idea-agent');
   assert.equal(agentBundleCapture.input.runtime_task.input.wait_for_completion, true);
-  assert.equal(agentBundleCapture.input.runtime_task.input.runtime_bundles[0].source, '/workspace/wp-site-generator/bundles/store-idea-agent');
+  assert.equal(agentBundleCapture.input.runtime_task.input.runtime_bundles, undefined);
   const agentBundleOutput = JSON.parse(agentBundleResult.stdout);
   assert.equal(agentBundleOutput.success, true);
   assert.equal(agentBundleOutput.session.status, 'completed');


### PR DESCRIPTION
## Summary
- Stops synthesizing `runtime_bundles` from the Data Machine bundle directory `source`.
- Keeps `runtime_bundles` available only when explicitly supplied by callers.
- Updates the WP Codebox task runner smoke test to lock the directory-backed run contract.

Fixes #1097.

## Evidence
- Failed downstream run before this fix: https://github.com/chubes4/wp-site-generator/actions/runs/26981950356
- Observed runtime error: `wp_agent_runtime_bundle_source_invalid_json` because `/workspace/wp-site-generator/bundles/store-idea-agent` was passed to the generic runtime importer as JSON source.

## Validation
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `npm run test:wp-codebox-task-runner` from `wordpress/`
- `npm run lint:js -- scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/wp-codebox-task-runner-smoke.js` from `wordpress/` (passes with existing ignored-test-file warning)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the downstream run artifact failure, drafted the focused runner fix and smoke assertion, and ran validation commands for Chris to review.