### PR TITLE
fix: forward runtime component paths to Codebox

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -72,6 +72,8 @@ const AGENT_BUNDLE_TRIGGER_FIELDS = AGENT_BUNDLE_CONFIG_FIELDS.filter((field) =>
 ].includes(field));
 
 const LEGACY_RUNTIME_PREFIX = ['data', 'machine'].join('_');
+const WP_CODEBOX_RUNTIME_PATH_KEY = `${LEGACY_RUNTIME_PREFIX}_path`;
+const WP_CODEBOX_RUNTIME_TOOLS_PATH_KEY = `${LEGACY_RUNTIME_PREFIX}_code_path`;
 const LEGACY_BUNDLE_KEYS = [
   `${LEGACY_RUNTIME_PREFIX}_bundle`,
   `${LEGACY_RUNTIME_PREFIX}Bundle`,
@@ -138,6 +140,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const inputs = request.inputs || {};
   const agentBundle = agentBundleConfigFromAgentTaskRequest(request, config, inputs);
   const mounts = agentBundleMounts(agentBundle, config.mounts || options.mounts || []);
+  const components = runtimeComponentPaths(config, options);
   const timeoutSeconds = request.limits?.task_timeout_seconds || request.limits?.taskTimeoutSeconds;
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
   const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
@@ -172,8 +175,10 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     secret_env: config.secret_env || options.secretEnv || [],
     mounts,
     workspaces: config.workspaces || options.workspaces || [],
-    agents_api_path: config.agents_api || config.agents_api_path || options.agentsApi || '',
-    runtime_component_paths: runtimeComponentPaths(config, options),
+    agents_api_path: components.agents_api || config.agents_api || config.agents_api_path || options.agentsApi || '',
+    [WP_CODEBOX_RUNTIME_PATH_KEY]: components.agent_runtime || '',
+    [WP_CODEBOX_RUNTIME_TOOLS_PATH_KEY]: components.agent_runtime_tools || '',
+    runtime_component_paths: components,
     homeboy_path: config.homeboy || config.homeboy_path || options.homeboy || '',
     homeboy_extensions_path: config.homeboy_extensions || config.homeboy_extensions_path || options.homeboyExtensions || '',
     wp_codebox_bin: config.wp_codebox_bin || options.wpCodeboxBin || '',

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -154,6 +154,8 @@ function writePreflightEvidence(artifacts, evidence) {
 }
 
 const LEGACY_RUNTIME_PREFIX = ['data', 'machine'].join('_');
+const WP_CODEBOX_RUNTIME_PATH_KEY = `${LEGACY_RUNTIME_PREFIX}_path`;
+const WP_CODEBOX_RUNTIME_TOOLS_PATH_KEY = `${LEGACY_RUNTIME_PREFIX}_code_path`;
 const LEGACY_BUNDLE_KEYS = [
   `${LEGACY_RUNTIME_PREFIX}_bundle`,
   `${LEGACY_RUNTIME_PREFIX}Bundle`,
@@ -250,6 +252,8 @@ function stableTaskInput(input) {
     artifacts_path: input.artifacts_path,
     wp_codebox_bin: input.wp_codebox_bin,
     agents_api_path: input.agents_api_path,
+    [WP_CODEBOX_RUNTIME_PATH_KEY]: input.runtime_component_paths?.agent_runtime,
+    [WP_CODEBOX_RUNTIME_TOOLS_PATH_KEY]: input.runtime_component_paths?.agent_runtime_tools,
     runtime_component_paths: input.runtime_component_paths || {},
     wp: input.wp_version,
     agent_bundle: isAgentBundle(input) ? agentBundleConfig(input, input.agent_bundle || {}) : {},

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -600,6 +600,8 @@ try {
   assert.equal(capturedCodex.request.model, 'gpt-5.5');
   assert.deepEqual(capturedCodex.request.provider_plugin_paths, ['/components/ai-provider-for-openai']);
   assert.equal(capturedCodex.request.agents_api_path, '/components/agents-api');
+  assert.equal(capturedCodex.request.data_machine_path, '/components/data-machine');
+  assert.equal(capturedCodex.request.data_machine_code_path, '/components/data-machine-code');
   assert.equal(capturedCodex.request.runtime_component_paths.agent_runtime, '/components/data-machine');
   assert.equal(capturedCodex.request.runtime_component_paths.agent_runtime_tools, '/components/data-machine-code');
   assert.equal(capturedCodex.request.homeboy_path, '/components/homeboy');

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -160,6 +160,8 @@ try {
   assert.equal(captured.input.runtime_stack_mounts[1].source, '/components/wordpress-develop');
   assert.equal(captured.input.mounts[0].source, '/repo/plugin');
   assert.equal(captured.input.agents_api_path, '/components/agents-api');
+  assert.equal(captured.input.data_machine_path, '/components/data-machine');
+  assert.equal(captured.input.data_machine_code_path, '/components/data-machine-code');
   assert.equal(captured.input.runtime_component_paths.agent_runtime, '/components/data-machine');
   assert.equal(captured.input.runtime_component_paths.agent_runtime_tools, '/components/data-machine-code');
   assert(!JSON.stringify(captured.input).includes('redacted-test-key'));


### PR DESCRIPTION
## Summary
- Forward generic `runtime_component_paths` into the WP Codebox CLI component path keys so generic agent-task runs mount Agents API, Data Machine, and Data Machine Code.
- Preserve the generic runtime path contract in Homeboy while adapting to the current WP Codebox CLI field names at the edge.
- Add smoke coverage for both executor and task-runner request shapes.

Fixes #1099.

## Testing
- `node tests/codebox-agent-task-executor-smoke.js`
- `node tests/wp-codebox-task-runner-smoke.js`
- `node tests/codebox-agent-task-boundary-smoke.js`
- `node --check scripts/agent/homeboy-wp-codebox-task-runner.cjs scripts/agent/homeboy-codebox-agent-task-executor.cjs lib/codebox-agent-task-executor.js tests/wp-codebox-task-runner-smoke.js tests/codebox-agent-task-executor-smoke.js tests/codebox-agent-task-boundary-smoke.js`

## Live validation
- Ran `homeboy agent-task run-plan` with a generic Codebox task and the same runtime component stack used by the failed minion runs.
- Validation showed `agents-api/agents-api.php`, `data-machine/data-machine.php`, `data-machine-code/data-machine-code.php`, and the OpenAI provider plugin mounted and active.
- The prior blocker `The canonical agents/chat ability is not available inside the sandbox.` was not reproduced.
- The validation then failed later with `Agent not found`, which is a separate runtime/agent seed issue rather than the runtime component mount failure tracked by #1099.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runtime component mount adapter gap, drafted the fix and smoke coverage, and ran focused plus live validation. Chris remains responsible for review and merge.