### PR TITLE
Fix WordPress release GitHub host proxy

### DIFF
--- a/wordpress/scripts/release/publish.sh
+++ b/wordpress/scripts/release/publish.sh
@@ -45,6 +45,62 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
+normalize_github_remote() {
+  local remote_url="$1"
+  local host=""
+  local slug=""
+
+  case "${remote_url}" in
+    git@*:*)
+      host="${remote_url#git@}"
+      host="${host%%:*}"
+      slug="${remote_url#*:}"
+      ;;
+    ssh://git@*/*)
+      local rest="${remote_url#ssh://git@}"
+      host="${rest%%/*}"
+      slug="${rest#*/}"
+      ;;
+    http://*/*|https://*/*)
+      local rest="${remote_url#http://}"
+      rest="${rest#https://}"
+      host="${rest%%/*}"
+      host="${host##*@}"
+      slug="${rest#*/}"
+      ;;
+  esac
+
+  slug="${slug%.git}"
+  slug="${slug%/}"
+  if [[ -n "${host}" && -n "${slug}" && "${slug}" == */* ]]; then
+    printf '%s\t%s\n' "${host}" "${slug}"
+  fi
+}
+
+apply_github_host_env() {
+  local host="$1"
+  local proxy=""
+  proxy="$(echo "${PAYLOAD}" | jq -r --arg host "${host}" '.config.github.hosts[$host].proxy // empty')"
+
+  if [[ "${host}" != "github.com" ]]; then
+    export GH_HOST="${host}"
+  fi
+
+  if [[ -n "${proxy}" ]]; then
+    export HTTPS_PROXY="${proxy}"
+  fi
+
+  while IFS=$'\t' read -r key value; do
+    [[ -n "${key}" ]] || continue
+    if [[ "${key}" == "GH_HOST" ]]; then
+      continue
+    fi
+    if [[ "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      export "${key}=${value}"
+    fi
+  done < <(echo "${PAYLOAD}" | jq -r --arg host "${host}" '.config.github.hosts[$host].env // {} | to_entries[] | [.key, .value] | @tsv')
+}
+
 if ! command -v gh >/dev/null 2>&1; then
   echo "Error: gh CLI is required to upload release assets" >&2
   exit 1
@@ -87,15 +143,21 @@ fi
 
 # Resolve the GitHub repository slug. Prefer the env var set by GitHub Actions;
 # fall back to parsing the origin remote so local dry-runs also work.
+GITHUB_HOST="${GH_HOST:-github.com}"
 REPO_SLUG="${GITHUB_REPOSITORY:-}"
+if [[ -n "${GITHUB_SERVER_URL:-}" ]]; then
+  GITHUB_HOST="${GITHUB_SERVER_URL#http://}"
+  GITHUB_HOST="${GITHUB_HOST#https://}"
+  GITHUB_HOST="${GITHUB_HOST%%/*}"
+fi
 if [[ -z "${REPO_SLUG}" ]]; then
   REMOTE_URL="$(git config --get remote.origin.url 2>/dev/null || true)"
   if [[ -n "${REMOTE_URL}" ]]; then
-    # Normalize both git@github.com:owner/repo.git and https://github.com/owner/repo(.git)
-    REPO_SLUG="$(echo "${REMOTE_URL}" \
-      | sed -E 's#^git@github\.com:#https://github.com/#' \
-      | sed -E 's#\.git$##' \
-      | sed -E 's#^https://github\.com/##')"
+    NORMALIZED_REMOTE="$(normalize_github_remote "${REMOTE_URL}")"
+    if [[ -n "${NORMALIZED_REMOTE}" ]]; then
+      GITHUB_HOST="${NORMALIZED_REMOTE%%$'\t'*}"
+      REPO_SLUG="${NORMALIZED_REMOTE#*$'\t'}"
+    fi
   fi
 fi
 
@@ -103,6 +165,8 @@ if [[ -z "${REPO_SLUG}" ]]; then
   echo "Error: could not determine GitHub repository (set GITHUB_REPOSITORY or configure git remote origin)" >&2
   exit 1
 fi
+
+apply_github_host_env "${GITHUB_HOST}"
 
 echo "Uploading ${ARTIFACT_PATH} to ${REPO_SLUG} release ${TAG}..." >&2
 
@@ -184,7 +248,7 @@ Branch is force-pushed on every release; do not commit here directly."
 
   # Push using a token-authenticated HTTPS URL. We never reuse the source
   # repo's remote so the source checkout's credentials are untouched.
-  REMOTE_AUTHENTICATED_URL="https://x-access-token:${GH_TOKEN}@github.com/${REPO_SLUG}.git"
+  REMOTE_AUTHENTICATED_URL="https://x-access-token:${GH_TOKEN}@${GITHUB_HOST}/${REPO_SLUG}.git"
 
   git -C "${MIRROR_REPO}" push --force "${REMOTE_AUTHENTICATED_URL}" \
     "${RELEASE_LATEST_BRANCH}:${RELEASE_LATEST_BRANCH}" >&2
@@ -198,12 +262,14 @@ fi
 # without re-reading homeboy.json.
 jq -cn \
   --arg tag "${TAG}" \
+  --arg host "${GITHUB_HOST}" \
   --arg repo "${REPO_SLUG}" \
   --arg path "${ARTIFACT_PATH}" \
   --arg branch "${PUSHED_BRANCH}" \
   '{
     target: "github-release-asset",
     tag: $tag,
+    github_host: $host,
     repository: $repo,
     artifact_path: $path,
     release_latest_branch: (if $branch == "" then null else $branch end),

--- a/wordpress/tests/release-publish-github-host-proxy-smoke.sh
+++ b/wordpress/tests/release-publish-github-host-proxy-smoke.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/release/publish.sh"
+TMP_DIR="$(mktemp -d -t homeboy-release-publish-ghe.XXXXXX)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+BIN_DIR="${TMP_DIR}/bin"
+WORK_DIR="${TMP_DIR}/work"
+CAPTURE_DIR="${TMP_DIR}/capture"
+mkdir -p "${BIN_DIR}" "${WORK_DIR}/build" "${CAPTURE_DIR}"
+
+cat > "${BIN_DIR}/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf 'GH_HOST=%s\n' "${GH_HOST:-}"
+  printf 'HTTPS_PROXY=%s\n' "${HTTPS_PROXY:-}"
+  printf 'NO_PROXY=%s\n' "${NO_PROXY:-}"
+  printf 'ARGS=%s\n' "$*"
+} > "${HOMEBOY_GH_CAPTURE}"
+SH
+chmod +x "${BIN_DIR}/gh"
+
+printf 'zip fixture\n' > "${WORK_DIR}/build/demo-plugin.zip"
+
+git -C "${WORK_DIR}" init -q
+git -C "${WORK_DIR}" remote add origin git@github.enterprise.test:owner/demo-plugin.git
+
+export PATH="${BIN_DIR}:${PATH}"
+export HOMEBOY_GH_CAPTURE="${CAPTURE_DIR}/gh.env"
+export HOMEBOY_SETTINGS_JSON='{
+  "release": {
+    "tag": "v1.2.3",
+    "component_id": "demo-plugin"
+  },
+  "config": {
+    "github": {
+      "hosts": {
+        "github.enterprise.test": {
+          "proxy": "socks5://127.0.0.1:9999",
+          "env": {
+            "NO_PROXY": "localhost,127.0.0.1"
+          }
+        }
+      }
+    }
+  }
+}'
+
+OUTPUT="$(cd "${WORK_DIR}" && bash "${SCRIPT}")"
+
+grep -q '^GH_HOST=github.enterprise.test$' "${HOMEBOY_GH_CAPTURE}"
+grep -q '^HTTPS_PROXY=socks5://127.0.0.1:9999$' "${HOMEBOY_GH_CAPTURE}"
+grep -q '^NO_PROXY=localhost,127.0.0.1$' "${HOMEBOY_GH_CAPTURE}"
+grep -q '^ARGS=release upload v1.2.3 build/demo-plugin.zip --clobber --repo owner/demo-plugin$' "${HOMEBOY_GH_CAPTURE}"
+
+printf '%s' "${OUTPUT}" | jq -e '
+  .success == true and
+  .github_host == "github.enterprise.test" and
+  .repository == "owner/demo-plugin"
+' >/dev/null
+
+printf 'release.publish GitHub host proxy smoke passed\n'


### PR DESCRIPTION
## Summary
- Parses GitHub Enterprise remotes into explicit `github_host` plus `owner/repo` for WordPress `release.publish`.
- Applies host-scoped `config.github.hosts` proxy/env settings to the `gh release upload` path while keeping `GH_HOST` authoritative from the target host.
- Uses the resolved host for release-latest mirror push URLs and adds a no-network smoke test with a stubbed `gh` command.

Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/1086

## Dependency order
- Depends on https://github.com/Extra-Chill/homeboy/pull/3533 for Homeboy core to pass `config.github.hosts` into the `release.publish` payload automatically.
- This script-level change is safe independently for existing `github.com` releases and for callers that already provide `GH_HOST`/`GITHUB_SERVER_URL`.

## Tests
- `bash -n wordpress/scripts/release/publish.sh`
- `bash -n wordpress/tests/release-publish-github-host-proxy-smoke.sh`
- `bash wordpress/tests/release-publish-github-host-proxy-smoke.sh`
- `bash wordpress/tests/release-scripts-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the WordPress publish script failure path, drafted the host-scoped remote parsing/proxy implementation and smoke coverage, and ran targeted verification. Chris remains responsible for review and acceptance.