### PR TITLE
Fix agent bundle tool recorder outputs

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -459,7 +459,10 @@ function agentRuntimeWorkloadFromSingleResult(workload, config) {
 function agentRuntimeWorkloadFromBundleRun(bundleRun, config) {
   const bundle = bundleRun.bundle && typeof bundleRun.bundle === 'object' ? bundleRun.bundle : {};
   const workflowSteps = Array.isArray(bundleRun.workflow?.steps) ? bundleRun.workflow.steps : [];
-  const outputs = plainObject(bundleRun.outputs) ? bundleRun.outputs : {};
+  const outputs = {
+    ...(plainObject(bundleRun.outputs) ? bundleRun.outputs : {}),
+    ...toolRecorderOutputs(bundleRun.engine_data, config),
+  };
   return {
     outputs,
     scenarios: [{
@@ -492,6 +495,61 @@ function hasSemanticWorkload(value) {
 
 function pathValue(source, dottedPath) {
   return String(dottedPath || '').split('.').filter(Boolean).reduce((value, key) => (value && typeof value === 'object' ? value[key] : undefined), source);
+}
+
+function stepDataPackets(engineData) {
+  const packetsByStep = plainObject(engineData?.direct_step_data_packets) ? engineData.direct_step_data_packets : {};
+  return Object.values(packetsByStep).flatMap((packets) => (Array.isArray(packets) ? packets : []));
+}
+
+function toolRecorderOutputs(engineData, config) {
+  if (!plainObject(engineData) || !Array.isArray(config.tool_recorders)) {
+    return {};
+  }
+
+  const outputs = {};
+  const packets = stepDataPackets(engineData);
+  for (const recorder of config.tool_recorders) {
+    if (!plainObject(recorder) || typeof recorder.tool !== 'string') {
+      continue;
+    }
+
+    const record = plainObject(recorder.record) ? recorder.record : {};
+    const fields = plainObject(record.fields) ? record.fields : {};
+    if (Object.keys(fields).length === 0) {
+      continue;
+    }
+
+    const packet = packets.find((candidate) => {
+      const metadata = plainObject(candidate?.metadata) ? candidate.metadata : {};
+      return metadata.tool_name === recorder.tool && metadata.step_execution_success === true;
+    });
+    if (!packet) {
+      continue;
+    }
+
+    const metadata = plainObject(packet.metadata) ? packet.metadata : {};
+    const sources = [
+      metadata.tool_result_data,
+      metadata.tool_result_envelope,
+      metadata.tool_result_envelope?.result,
+    ].filter(plainObject);
+
+    for (const [outputName, resultPath] of Object.entries(fields)) {
+      if (outputs[outputName] !== undefined || typeof resultPath !== 'string') {
+        continue;
+      }
+      for (const source of sources) {
+        const value = pathValue(source, resultPath);
+        if (value !== undefined && value !== null && value !== '') {
+          outputs[outputName] = value;
+          break;
+        }
+      }
+    }
+  }
+
+  return outputs;
 }
 
 function validateAgentRuntimeWorkload(workload, config) {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -34,7 +34,24 @@ const bundleRun = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
       },
       workflow: { steps: [{ step_type: 'ai' }] },
       wait_result: { success: true, terminal_state: 'completed' },
-      engine_data: { store_idea_agent: { issue_number: 123, issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123' } }
+      engine_data: process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN_TOOL_RECORDERS
+        ? {
+            direct_step_data_packets: {
+              ephemeral_step_1: [{
+                metadata: {
+                  step_execution_success: true,
+                  tool_name: 'github_issue_publish',
+                  tool_result_data: {
+                    data: {
+                      issue_number: 123,
+                      issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123'
+                    }
+                  }
+                }
+              }]
+            }
+          }
+        : { store_idea_agent: { issue_number: 123, issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123' } }
     }
   : null;
 const agentResult = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_AGENT_BUNDLE
@@ -332,6 +349,50 @@ try {
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.engine_data.store_idea_agent.issue_number, 123);
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.dry_run, true);
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metrics.workflow_step_count, 1);
+
+  const recorderBundleRunCapturePath = path.join(root, 'capture-recorder-datamachine-bundle-run.json');
+  const recorderBundleRunResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin',
+    fixtureWpCodebox,
+    '--artifacts',
+    path.join(root, 'recorder-datamachine-bundle-run-artifacts'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      agent_bundle: {
+        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
+        engine_data_outputs: {
+          issue_number: 'metadata.engine_data.store_idea_agent.issue_number',
+          issue_url: 'metadata.engine_data.store_idea_agent.issue_url',
+        },
+        tool_recorders: [{
+          tool: 'github_issue_publish',
+          record: {
+            engine_key: 'store_idea_agent',
+            fields: {
+              issue_number: 'data.issue_number',
+              issue_url: 'data.issue_url',
+            },
+          },
+        }],
+      },
+      provider_plugin_paths: [],
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: recorderBundleRunCapturePath,
+      FIXTURE_WP_CODEBOX_BUNDLE_RUN: '1',
+      FIXTURE_WP_CODEBOX_BUNDLE_RUN_TOOL_RECORDERS: '1',
+      OPENCODE_API_KEY: 'redacted-test-key',
+    },
+  });
+  assert.equal(recorderBundleRunResult.status, 0, recorderBundleRunResult.stderr || recorderBundleRunResult.stdout);
+  const recorderBundleRunOutput = JSON.parse(recorderBundleRunResult.stdout);
+  assert.equal(recorderBundleRunOutput.success, true);
+  assert.equal(recorderBundleRunOutput.run.agentResult.outputs.issue_number, 123);
+  assert.equal(recorderBundleRunOutput.run.agentResult.outputs.issue_url, 'https://github.com/chubes4/wp-site-generator/issues/123');
 
   const incompleteDatamachineCapturePath = path.join(root, 'capture-incomplete-datamachine.json');
   const incompleteDatamachineResult = spawnSync(process.execPath, [


### PR DESCRIPTION
## Summary
- Derive Homeboy semantic outputs from Data Machine agent-bundle `tool_recorders` when successful handler tool results are stored in `direct_step_data_packets`.
- Keep existing engine-data output validation intact while allowing `/outputs/*` bindings to be satisfied directly from recorded tool results.
- Add a smoke fixture for the real `github_issue_publish` result shape observed in wp-site-generator.

## Verification
- `node tests/wp-codebox-task-runner-smoke.js`
- `npm run lint:js -- scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/wp-codebox-task-runner-smoke.js` (0 errors; existing ignored-test warning)
- `git diff --check`

## Evidence
- Downstream wp-site-generator run `27014124304` shows `github_issue_publish` succeeded and created issues #411/#412, with result data recorded under `engine_data.direct_step_data_packets[*].metadata.tool_result_data.data`, but Homeboy skipped downstream tasks because `/outputs/issue_number` and `/outputs/issue_url` were not populated.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the failed output extraction evidence, drafted the adapter fix and smoke coverage, and ran focused validation. Chris remains responsible for review and merge.