### PR TITLE
fix agent bundle runner success normalization

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -367,6 +367,7 @@ function normalizeAgentTaskRun(input, result) {
   return {
     ...result,
     success,
+    outputs: plainObject(agentResult.outputs) ? agentResult.outputs : result.outputs,
     summary: success ? 'WP Codebox agent task succeeded.' : (bundleValidation?.message || result.summary || 'WP Codebox agent task failed.'),
     session: result.session ? {
       ...result.session,
@@ -699,7 +700,7 @@ function runWpCodeboxParentTask(request) {
     try {
       const payload = normalizeAgentTaskRun(input, JSON.parse(result.stdout));
       process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-      return payload.success === false ? 1 : (result.status ?? 0);
+      return payload.success === false ? 1 : 0;
     } catch {
       process.stdout.write(result.stdout);
     }

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -94,6 +94,9 @@ process.stdout.write(JSON.stringify({
   run: isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN ? { executions } : (isAgentBundle ? {} : { agentResult }),
   executions: isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN ? [] : executions,
 }));
+if (process.env.FIXTURE_WP_CODEBOX_EXIT_CODE) {
+  process.exitCode = Number(process.env.FIXTURE_WP_CODEBOX_EXIT_CODE);
+}
 `);
   fs.chmodSync(binPath, mode);
   return binPath;
@@ -391,8 +394,55 @@ try {
   assert.equal(recorderBundleRunResult.status, 0, recorderBundleRunResult.stderr || recorderBundleRunResult.stdout);
   const recorderBundleRunOutput = JSON.parse(recorderBundleRunResult.stdout);
   assert.equal(recorderBundleRunOutput.success, true);
+  assert.equal(recorderBundleRunOutput.outputs.issue_number, 123);
+  assert.equal(recorderBundleRunOutput.outputs.issue_url, 'https://github.com/chubes4/wp-site-generator/issues/123');
   assert.equal(recorderBundleRunOutput.run.agentResult.outputs.issue_number, 123);
   assert.equal(recorderBundleRunOutput.run.agentResult.outputs.issue_url, 'https://github.com/chubes4/wp-site-generator/issues/123');
+
+  const completedBundleNonzeroExitCapturePath = path.join(root, 'capture-completed-bundle-nonzero-exit.json');
+  const completedBundleNonzeroExitResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin',
+    fixtureWpCodebox,
+    '--artifacts',
+    path.join(root, 'completed-bundle-nonzero-exit-artifacts'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      agent_bundle: {
+        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
+        engine_data_outputs: {
+          issue_number: 'metadata.engine_data.store_idea_agent.issue_number',
+          issue_url: 'metadata.engine_data.store_idea_agent.issue_url',
+        },
+        tool_recorders: [{
+          tool: 'github_issue_publish',
+          record: {
+            engine_key: 'store_idea_agent',
+            fields: {
+              issue_number: 'data.issue_number',
+              issue_url: 'data.issue_url',
+            },
+          },
+        }],
+      },
+      provider_plugin_paths: [],
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: completedBundleNonzeroExitCapturePath,
+      FIXTURE_WP_CODEBOX_BUNDLE_RUN: '1',
+      FIXTURE_WP_CODEBOX_BUNDLE_RUN_TOOL_RECORDERS: '1',
+      FIXTURE_WP_CODEBOX_EXIT_CODE: '1',
+      OPENCODE_API_KEY: 'redacted-test-key',
+    },
+  });
+  assert.equal(completedBundleNonzeroExitResult.status, 0, completedBundleNonzeroExitResult.stderr || completedBundleNonzeroExitResult.stdout);
+  const completedBundleNonzeroExitOutput = JSON.parse(completedBundleNonzeroExitResult.stdout);
+  assert.equal(completedBundleNonzeroExitOutput.success, true);
+  assert.equal(completedBundleNonzeroExitOutput.outputs.issue_number, 123);
+  assert.equal(completedBundleNonzeroExitOutput.session.status, 'completed');
 
   const incompleteDatamachineCapturePath = path.join(root, 'capture-incomplete-datamachine.json');
   const incompleteDatamachineResult = spawnSync(process.execPath, [


### PR DESCRIPTION
## Summary
- Promote normalized Data Machine bundle outputs to top-level Homeboy task outputs.
- Treat a normalized successful bundle run as wrapper success even when the underlying Codebox process exits nonzero after queued tool work completes.
- Add smoke coverage for recorder-derived outputs and the completed-bundle/nonzero-exit regression.

## Validation
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `npm run lint:js -- scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/wp-codebox-task-runner-smoke.js` (0 errors; existing ignored-test warning)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the failing wp-site-generator Homeboy loop from run logs, drafted the runner normalization fix and smoke coverage, and ran focused validation for Chris to review.