### PR TITLE
fix agent bundle outcome normalization

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -274,12 +274,12 @@ function agentBundleConfigFromAgentTaskRequest(request, config, inputs) {
   return Object.fromEntries(Object.entries(bundleConfig).filter(([, value]) => value !== undefined && value !== ''));
 }
 
-function normalizeStatus(result, exitStatus = 0) {
+function normalizeStatus(result) {
   if (AGENT_TASK_OUTCOME_STATUSES.includes(result?.status)) {
     return result.status;
   }
   if (result?.status === 'completed') {
-    return result?.success === true && exitStatus === 0 ? 'succeeded' : 'failed';
+    return result?.success === true ? 'succeeded' : 'failed';
   }
   const agentResult = result?.run?.agentResult || result?.agentResult || result?.agent_result || result?.metadata?.recipe_run?.agentResult || result?.metadata?.recipe_run?.run?.agentResult;
   const changedFileCount = agentResult?.changedFiles?.count;
@@ -299,7 +299,7 @@ function normalizeStatus(result, exitStatus = 0) {
   if (result?.provider_error) {
     return 'provider_error';
   }
-  return result?.success === true && exitStatus === 0 ? 'succeeded' : 'failed';
+  return result?.success === true ? 'succeeded' : 'failed';
 }
 
 function appendUniqueArtifact(artifacts, artifact) {
@@ -453,6 +453,9 @@ function pathValue(source, dottedPath) {
 }
 
 function normalizeOutputs(result) {
+  if (result.outputs && typeof result.outputs === 'object' && !Array.isArray(result.outputs)) {
+    return sanitizePublicMetadata(result.outputs);
+  }
   const workload = result.metadata?.agent_runtime?.workload || result.run?.agentResult || result.agentResult || result.agent_result || {};
   if (workload.outputs && typeof workload.outputs === 'object' && !Array.isArray(workload.outputs)) {
     return sanitizePublicMetadata(workload.outputs);

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -387,6 +387,21 @@ assert.equal(upstreamRunnerOutcome.status, 'succeeded');
 assert.equal(upstreamRunnerOutcome.artifacts[0].kind, 'codebox-artifact-directory');
 assert.equal(upstreamRunnerOutcome.artifacts[0].path, '/tmp/wp-codebox-artifacts');
 
+const normalizedCompletedOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  summary: 'WP Codebox agent task succeeded.',
+  outputs: {
+    issue_number: 123,
+    issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123',
+  },
+  session: { id: 'sandbox-session-1', status: 'completed' },
+}, { exitStatus: 1 });
+assert.equal(normalizedCompletedOutcome.status, 'succeeded');
+assert.equal(normalizedCompletedOutcome.outputs.issue_number, 123);
+assert.equal(normalizedCompletedOutcome.failure_classification, undefined);
+
 const completedFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: false,
   schema: 'wp-codebox/agent-task-run/v1',


### PR DESCRIPTION
## Summary
- Treat normalized successful Codebox/Data Machine task payloads as successful Homeboy outcomes even when an underlying executor exit status is nonzero.
- Prefer top-level normalized task outputs before falling back to agent-runtime workload outputs.
- Add executor smoke coverage for completed normalized payloads with semantic outputs.

## Validation
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `npm run lint:js -- lib/codebox-agent-task-executor.js scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/codebox-agent-task-executor-smoke.js tests/wp-codebox-task-runner-smoke.js` (0 errors; existing ignored-test warnings)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the follow-up wp-site-generator loop failure, drafted the Homeboy outcome-normalization fix and smoke coverage, and ran focused validation for Chris to review.