### PR TITLE
fix agent bundle runner status normalization

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -367,6 +367,7 @@ function normalizeAgentTaskRun(input, result) {
   return {
     ...result,
     success,
+    status: success ? 'completed' : result.status,
     outputs: plainObject(agentResult.outputs) ? agentResult.outputs : result.outputs,
     summary: success ? 'WP Codebox agent task succeeded.' : (bundleValidation?.message || result.summary || 'WP Codebox agent task failed.'),
     session: result.session ? {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -82,6 +82,7 @@ const executions = [execution];
 process.stdout.write(JSON.stringify({
   success: !isAgentBundle,
   schema: 'wp-codebox/agent-task-run/v1',
+  status: isAgentBundle ? 'failed' : 'completed',
   session: {
     schema: 'wp-codebox/sandbox-session/v1',
     id: input.sandbox_session_id,
@@ -394,6 +395,7 @@ try {
   assert.equal(recorderBundleRunResult.status, 0, recorderBundleRunResult.stderr || recorderBundleRunResult.stdout);
   const recorderBundleRunOutput = JSON.parse(recorderBundleRunResult.stdout);
   assert.equal(recorderBundleRunOutput.success, true);
+  assert.equal(recorderBundleRunOutput.status, 'completed');
   assert.equal(recorderBundleRunOutput.outputs.issue_number, 123);
   assert.equal(recorderBundleRunOutput.outputs.issue_url, 'https://github.com/chubes4/wp-site-generator/issues/123');
   assert.equal(recorderBundleRunOutput.run.agentResult.outputs.issue_number, 123);
@@ -441,6 +443,7 @@ try {
   assert.equal(completedBundleNonzeroExitResult.status, 0, completedBundleNonzeroExitResult.stderr || completedBundleNonzeroExitResult.stdout);
   const completedBundleNonzeroExitOutput = JSON.parse(completedBundleNonzeroExitResult.stdout);
   assert.equal(completedBundleNonzeroExitOutput.success, true);
+  assert.equal(completedBundleNonzeroExitOutput.status, 'completed');
   assert.equal(completedBundleNonzeroExitOutput.outputs.issue_number, 123);
   assert.equal(completedBundleNonzeroExitOutput.session.status, 'completed');
 


### PR DESCRIPTION
## Summary
- Rewrite top-level runner `status` to `completed` when a Data Machine bundle run is normalized as successful.
- Reproduce the real Codebox shape where the raw agent-bundle payload still has `status: failed` even though semantic bundle validation succeeds.
- Assert normalized bundle payloads expose `success: true`, `status: completed`, and semantic outputs.

## Validation
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `npm run lint:js -- lib/codebox-agent-task-executor.js scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/codebox-agent-task-executor-smoke.js tests/wp-codebox-task-runner-smoke.js` (0 errors; existing ignored-test warnings)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining Homeboy outcome status failure from wp-site-generator run logs, drafted the runner status-normalization fix and smoke coverage, and ran focused validation for Chris to review.