### PR TITLE
Fix agent bundle wrapper status normalization

### DIFF
--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -66,10 +66,11 @@ fs.writeFileSync(${JSON.stringify(capture)}, JSON.stringify({ argv: process.argv
 process.stdout.write(JSON.stringify({
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
+  status: 'failed',
   session: {
     schema: 'wp-codebox/sandbox-session/v1',
     id: input.sandbox_session_id,
-    status: 'completed',
+    status: 'failed',
     artifacts: { bundle_id: 'fake-artifact-bundle', path: input.artifacts_path, preview_url: 'https://preview.example.test/fake' },
     orchestrator: input.orchestrator
   },


### PR DESCRIPTION
## Summary
- Normalize the WP Codebox agent-bundle wrapper's top-level status from validated semantic workload success instead of preserving stale failed runtime status.
- Add smoke coverage for valid agent-bundle outputs returned with stale failed wrapper/session status.

## Verification
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Site Generation Loop status propagation failure, drafted the normalization fix, and ran focused smoke tests; Chris remains responsible for review and landing.