### PR TITLE
Honor nested agent bundle failures

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -275,6 +275,10 @@ function agentBundleConfigFromAgentTaskRequest(request, config, inputs) {
 }
 
 function normalizeStatus(result) {
+  const workload = agentRuntimeWorkload(result);
+  if (workload && workload.success === false) {
+    return 'failed';
+  }
   if (AGENT_TASK_OUTCOME_STATUSES.includes(result?.status)) {
     return result.status;
   }
@@ -300,6 +304,10 @@ function normalizeStatus(result) {
     return 'provider_error';
   }
   return result?.success === true ? 'succeeded' : 'failed';
+}
+
+function agentRuntimeWorkload(result) {
+  return result?.metadata?.agent_runtime?.workload || result?.run?.agentResult || result?.agentResult || result?.agent_result || null;
 }
 
 function appendUniqueArtifact(artifacts, artifact) {
@@ -456,7 +464,7 @@ function normalizeOutputs(result) {
   if (result.outputs && typeof result.outputs === 'object' && !Array.isArray(result.outputs)) {
     return sanitizePublicMetadata(result.outputs);
   }
-  const workload = result.metadata?.agent_runtime?.workload || result.run?.agentResult || result.agentResult || result.agent_result || {};
+  const workload = agentRuntimeWorkload(result) || {};
   if (workload.outputs && typeof workload.outputs === 'object' && !Array.isArray(workload.outputs)) {
     return sanitizePublicMetadata(workload.outputs);
   }
@@ -566,7 +574,7 @@ function normalizeEvidenceRefs(result) {
 
 function agentRuntimeBundleArtifacts(result) {
   const artifacts = [];
-  const workload = result.metadata?.agent_runtime?.workload || result.run?.agentResult || result.agentResult || {};
+  const workload = agentRuntimeWorkload(result) || {};
   const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
   for (const scenario of scenarios) {
     const metadata = scenario?.metadata || {};

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -412,6 +412,25 @@ const completedFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
 assert.equal(completedFailureOutcome.status, 'failed');
 assert.equal(completedFailureOutcome.failure_classification, 'execution_failed');
 
+const nestedAgentRuntimeFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  summary: 'Outer runner completed.',
+  run: {
+    agentResult: {
+      success: false,
+      status: 'completed_no_items',
+      completion_outcome: {
+        status: 'completed_no_items',
+        success: false,
+      },
+    },
+  },
+});
+assert.equal(nestedAgentRuntimeFailureOutcome.status, 'failed');
+assert.equal(nestedAgentRuntimeFailureOutcome.failure_classification, 'execution_failed');
+
 const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
   task_id: 'agent-bundle-task-123',


### PR DESCRIPTION
## Summary
- Treat nested Data Machine agent bundle `success:false` results as failed Homeboy Extension outcomes even when the outer WP Codebox runner completed.
- Reuse the nested agent runtime workload shape for output/artifact extraction.
- Add regression coverage for `completed_no_items` nested bundle results.

## Testing
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing Site Generation Loop artifacts, drafting the nested outcome propagation fix and regression coverage, and running focused smoke tests. Chris remains responsible for review and acceptance.