### PR TITLE
Honor agent bundle output failures

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -275,6 +275,9 @@ function agentBundleConfigFromAgentTaskRequest(request, config, inputs) {
 }
 
 function normalizeStatus(result) {
+  if (result?.outputs && typeof result.outputs === 'object' && result.outputs.success === false) {
+    return 'failed';
+  }
   const workload = agentRuntimeWorkload(result);
   if (workload && workload.success === false) {
     return 'failed';

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -431,6 +431,23 @@ const nestedAgentRuntimeFailureOutcome = agentTaskOutcomeFromCodeboxResult(reque
 assert.equal(nestedAgentRuntimeFailureOutcome.status, 'failed');
 assert.equal(nestedAgentRuntimeFailureOutcome.failure_classification, 'execution_failed');
 
+const nestedAgentRuntimeOutputFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  summary: 'Outer runner completed.',
+  outputs: {
+    success: false,
+    status: 'completed_no_items',
+    completion_outcome: {
+      status: 'completed_no_items',
+      success: false,
+    },
+  },
+});
+assert.equal(nestedAgentRuntimeOutputFailureOutcome.status, 'failed');
+assert.equal(nestedAgentRuntimeOutputFailureOutcome.failure_classification, 'execution_failed');
+
 const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
   task_id: 'agent-bundle-task-123',


### PR DESCRIPTION
## Summary
- Treat WP Codebox agent-task runs as failed when the nested Data Machine bundle result in `outputs` reports `success:false`.
- Add regression coverage for the observed `completed_no_items` result shape from Site Generation Loop artifacts.

## Testing
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the post-merge Site Generation Loop artifact shape, drafting the follow-up propagation fix and regression coverage, and running focused smoke tests. Chris remains responsible for review and acceptance.