### PR TITLE
Honor raw agent bundle failures

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -310,7 +310,7 @@ function normalizeStatus(result) {
 }
 
 function agentRuntimeWorkload(result) {
-  return result?.metadata?.agent_runtime?.workload || result?.run?.agentResult || result?.agentResult || result?.agent_result || null;
+  return result?.raw?.agent_runtime?.result || result?.metadata?.agent_runtime?.workload || result?.run?.agentResult || result?.agentResult || result?.agent_result || null;
 }
 
 function appendUniqueArtifact(artifacts, artifact) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -448,6 +448,28 @@ const nestedAgentRuntimeOutputFailureOutcome = agentTaskOutcomeFromCodeboxResult
 assert.equal(nestedAgentRuntimeOutputFailureOutcome.status, 'failed');
 assert.equal(nestedAgentRuntimeOutputFailureOutcome.failure_classification, 'execution_failed');
 
+const rawNestedAgentRuntimeFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  summary: 'WP Codebox agent task succeeded.',
+  raw: {
+    agent_runtime: {
+      success: true,
+      result: {
+        success: false,
+        status: 'completed_no_items',
+        completion_outcome: {
+          status: 'completed_no_items',
+          success: false,
+        },
+      },
+    },
+  },
+});
+assert.equal(rawNestedAgentRuntimeFailureOutcome.status, 'failed');
+assert.equal(rawNestedAgentRuntimeFailureOutcome.failure_classification, 'execution_failed');
+
 const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
   task_id: 'agent-bundle-task-123',


### PR DESCRIPTION
## Summary
- Treat the canonical raw Data Machine bundle result from `raw.agent_runtime.result` as the nested agent runtime workload.
- Mark Homeboy Extension outcomes failed when that raw bundle result reports `success:false`.
- Cover the observed Site Generation Loop `completed_no_items` shape in smoke tests.

## Testing
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing latest Site Generation Loop artifacts, identifying the raw nested bundle result shape, drafting the HBE propagation fix and regression coverage, and running focused smoke tests. Chris remains responsible for review and acceptance.