### PR TITLE
Declare Rust test filter passthrough mapping

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -32,6 +32,9 @@
   },
   "test": {
     "extension_script": "scripts/test-runner.sh",
+    "passthrough_filter": {
+      "strategy": "runner_positional"
+    },
     "changed_file_routing": {
       "strategy": "rust_cargo"
     },


### PR DESCRIPTION
## Summary
- Declare the Rust extension's `test.passthrough_filter` strategy as `runner_positional` so Homeboy's generic `--filter` passthrough can map to the runner-supported positional filter shape.
- Pairs with Extra-Chill/homeboy#3552, which adds the generic manifest contract and Homeboy-side normalization.

Related: Extra-Chill/homeboy#3543

## Verification
- `jq empty rust/rust.json`
- Paired local proof with Extra-Chill/homeboy#3552: installed this Rust extension into an isolated Homeboy config and ran `./target/debug/homeboy test homeboy --skip-lint -- --filter=positional_passthrough_translates_equals_filter_to_runner_filter`, which passed and ran one filtered test.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Added the extension metadata declaration required by the paired Homeboy generic filter contract and ran JSON/paired verification. Chris remains responsible for review and merge.