### PR TITLE
Support external Codebox recipe pack evidence

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -18,6 +18,8 @@ const PROVIDER_CAPABILITIES = [
   'screenshots',
   'structured_outcome',
   'agent_bundle_execution',
+  'external_recipe_packs',
+  'recipe_probe_artifacts',
 ];
 
 const AGENT_BUNDLE_CONFIG_FIELDS = [
@@ -139,6 +141,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const config = request.executor.config || {};
   const inputs = request.inputs || {};
   const agentBundle = agentBundleConfigFromAgentTaskRequest(request, config, inputs);
+  const recipe = recipeConfigFromAgentTaskRequest(request, config, inputs);
   const mounts = agentBundleMounts(agentBundle, config.mounts || options.mounts || []);
   const components = runtimeComponentPaths(config, options);
   const timeoutSeconds = request.limits?.task_timeout_seconds || request.limits?.taskTimeoutSeconds;
@@ -162,6 +165,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     expected_artifacts: request.expected_artifacts || [],
     policy: request.policy || {},
     context,
+    recipe,
     sandbox_session_id: config.sandbox_session_id || request.task_id,
     session_id: config.session_id || config.sessionId || '',
     agent: config.agent || options.agent || 'wp-codebox-sandbox',
@@ -233,6 +237,53 @@ function agentBundleMounts(bundleConfig, explicitMounts = []) {
   ];
 }
 
+function firstObject(...candidates) {
+  return candidates.find((candidate) => candidate && typeof candidate === 'object' && !Array.isArray(candidate)) || null;
+}
+
+function firstValue(...candidates) {
+  return candidates.find((candidate) => candidate !== undefined && candidate !== null && candidate !== '');
+}
+
+function recipeConfigFromAgentTaskRequest(request, config, inputs) {
+  const explicit = firstObject(
+    inputs.recipe,
+    inputs.recipe_pack,
+    inputs.recipePack,
+    config.recipe,
+    config.recipe_pack,
+    config.recipePack,
+  ) || {};
+  const recipeValue = firstValue(
+    inputs.recipe,
+    inputs.recipe_name,
+    inputs.recipeName,
+    config.recipe,
+    config.recipe_name,
+    config.recipeName,
+  );
+  const sourceRefs = Array.isArray(request.source_refs) ? request.source_refs : [];
+  const sourceRef = sourceRefs.find((ref) => ref && typeof ref === 'object' && (ref.kind === 'pull_request' || ref.kind === 'branch' || ref.kind === 'commit' || ref.uri || ref.ref)) || {};
+
+  const recipe = Object.fromEntries(Object.entries({
+    schema: 'wp-codebox/external-recipe-request/v1',
+    pack: explicit.pack || explicit.package || firstValue(inputs.recipe_pack, inputs.recipePack, config.recipe_pack, config.recipePack),
+    name: explicit.name || (typeof recipeValue === 'string' ? recipeValue : undefined),
+    ref: explicit.ref || firstValue(inputs.recipe_ref, inputs.recipeRef, config.recipe_ref, config.recipeRef),
+    path: explicit.path || firstValue(inputs.recipe_path, inputs.recipePath, config.recipe_path, config.recipePath),
+    repository: explicit.repository || explicit.repo || firstValue(inputs.recipe_repo, inputs.recipeRepo, config.recipe_repo, config.recipeRepo),
+    target_ref: explicit.target_ref || explicit.targetRef || firstValue(inputs.target_ref, inputs.targetRef, config.target_ref, config.targetRef, request.ref, sourceRef.ref, sourceRef.uri),
+    target_repo: explicit.target_repo || explicit.targetRepo || firstValue(inputs.target_repo, inputs.targetRepo, config.target_repo, config.targetRepo, sourceRef.repo),
+    target_pr: explicit.target_pr || explicit.targetPr || firstValue(inputs.target_pr, inputs.targetPr, config.target_pr, config.targetPr, sourceRef.pr, sourceRef.number),
+    target_branch: explicit.target_branch || explicit.targetBranch || firstValue(inputs.target_branch, inputs.targetBranch, config.target_branch, config.targetBranch),
+    inputs: explicit.inputs || inputs.recipe_inputs || inputs.recipeInputs || config.recipe_inputs || config.recipeInputs,
+    secret_env: explicit.secret_env || explicit.secretEnv || inputs.recipe_secret_env || inputs.recipeSecretEnv || config.recipe_secret_env || config.recipeSecretEnv,
+    metadata: explicit.metadata,
+  }).filter(([, value]) => value !== undefined && value !== '' && !(Array.isArray(value) && value.length === 0)));
+
+  return recipe.pack || recipe.name || recipe.path || recipe.repository || recipe.target_ref ? recipe : {};
+}
+
 function agentBundleConfigFromAgentTaskRequest(request, config, inputs) {
   const explicitBundleSources = [
     inputs.agent_bundle,
@@ -275,6 +326,9 @@ function agentBundleConfigFromAgentTaskRequest(request, config, inputs) {
 }
 
 function normalizeStatus(result) {
+  if (recipeRunFailedPhase(recipeRunFromResult(result))) {
+    return 'failed';
+  }
   if (result?.outputs && typeof result.outputs === 'object' && result.outputs.success === false) {
     return 'failed';
   }
@@ -411,6 +465,126 @@ function codeboxBundleArtifacts(result) {
   return artifacts;
 }
 
+function recipeRunFromResult(result) {
+  return firstObject(
+    result?.recipe_run,
+    result?.recipeRun,
+    result?.metadata?.recipe_run,
+    result?.metadata?.recipeRun,
+    result?.run?.recipe_run,
+    result?.run?.recipeRun,
+  ) || {};
+}
+
+function recipeRunFailedPhase(recipeRun) {
+  if (!recipeRun || Object.keys(recipeRun).length === 0) {
+    return '';
+  }
+  if (recipeRun.startup?.success === false || recipeRun.startup_failed || recipeRun.startupFailed) {
+    return 'startup';
+  }
+  const probes = Array.isArray(recipeRun.probes) ? recipeRun.probes : [];
+  if (recipeRun.probe?.success === false || recipeRun.probe_failed || recipeRun.probeFailed || probes.some((probe) => probe?.success === false || probe?.status === 'failed')) {
+    return 'probe';
+  }
+  if (recipeRun.artifact_collection?.success === false || recipeRun.artifactCollection?.success === false || recipeRun.artifact_collection_failed || recipeRun.artifactCollectionFailed) {
+    return 'artifact_collection';
+  }
+  return '';
+}
+
+function recipeRunFailureSummary(recipeRun) {
+  const failedPhase = recipeRunFailedPhase(recipeRun);
+  if (failedPhase === 'startup') {
+    return recipeRun.startup?.summary || recipeRun.startup?.message || 'WP Codebox recipe startup failed.';
+  }
+  if (failedPhase === 'probe') {
+    const failedProbe = (Array.isArray(recipeRun.probes) ? recipeRun.probes : []).find((probe) => probe?.success === false || probe?.status === 'failed') || recipeRun.probe || {};
+    const label = failedProbe.name || failedProbe.id || failedProbe.path || 'recipe probe';
+    return failedProbe.summary || failedProbe.message || `WP Codebox ${label} failed.`;
+  }
+  if (failedPhase === 'artifact_collection') {
+    return recipeRun.artifact_collection?.summary || recipeRun.artifactCollection?.summary || recipeRun.artifact_collection?.message || recipeRun.artifactCollection?.message || 'WP Codebox recipe artifact collection failed.';
+  }
+  return '';
+}
+
+function recipeRunFailureDiagnostic(recipeRun) {
+  const failedPhase = recipeRunFailedPhase(recipeRun);
+  if (!failedPhase) {
+    return null;
+  }
+  return {
+    class: `codebox.recipe.${failedPhase}.failed`,
+    message: recipeRunFailureSummary(recipeRun),
+    data: sanitizePublicMetadata({ phase: failedPhase, recipe_run: recipeRun }),
+  };
+}
+
+function appendRecipeArtifact(artifacts, artifact, fallbackKind, index) {
+  if (!artifact) {
+    return;
+  }
+  if (typeof artifact === 'string') {
+    appendUniqueArtifact(artifacts, {
+      id: artifact,
+      kind: fallbackKind,
+      path: artifact,
+    });
+    return;
+  }
+  appendUniqueArtifact(artifacts, {
+    id: artifact.id || artifact.name || artifact.path || artifact.url || `${fallbackKind}-${index + 1}`,
+    kind: artifact.kind || artifact.type || fallbackKind,
+    name: artifact.name,
+    path: artifact.path || artifact.file || artifact.directory,
+    url: artifact.url,
+    mime: artifact.mime,
+    size_bytes: artifact.size_bytes || artifact.sizeBytes,
+    sha256: artifact.sha256,
+    metadata: artifact.metadata || {},
+  });
+}
+
+function recipeRunArtifacts(result) {
+  const recipeRun = recipeRunFromResult(result);
+  if (!recipeRun || Object.keys(recipeRun).length === 0) {
+    return [];
+  }
+
+  const artifacts = [];
+  const startupLogs = [recipeRun.startup_log, recipeRun.startupLog, recipeRun.startup?.log, recipeRun.startup?.log_path, recipeRun.startup?.logPath].filter(Boolean);
+  startupLogs.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-startup-log', index));
+
+  const probeJson = [recipeRun.probe_json, recipeRun.probeJson, recipeRun.probe_results, recipeRun.probeResults, recipeRun.probe?.artifact, recipeRun.probe?.path].filter(Boolean);
+  probeJson.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-probe-json', index));
+
+  const probes = Array.isArray(recipeRun.probes) ? recipeRun.probes : [];
+  probes.forEach((probe, index) => {
+    appendRecipeArtifact(artifacts, probe.artifact || probe.path || probe.result_path || probe.resultPath, 'codebox-recipe-probe-json', index);
+    appendRecipeArtifact(artifacts, probe.screenshot || probe.screenshot_path || probe.screenshotPath, 'codebox-recipe-screenshot', index);
+  });
+
+  const screenshots = [
+    ...(Array.isArray(recipeRun.screenshots) ? recipeRun.screenshots : []),
+    ...(Array.isArray(recipeRun.browser_screenshots) ? recipeRun.browser_screenshots : []),
+    ...(Array.isArray(recipeRun.browserScreenshots) ? recipeRun.browserScreenshots : []),
+  ];
+  screenshots.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-screenshot', index));
+
+  const sideEffects = [recipeRun.fake_side_effects, recipeRun.fakeSideEffects, recipeRun.side_effects, recipeRun.sideEffects].filter(Boolean);
+  sideEffects.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-fake-side-effects', index));
+
+  const declaredArtifacts = [
+    ...(Array.isArray(recipeRun.artifacts) ? recipeRun.artifacts : []),
+    ...(Array.isArray(recipeRun.declared_artifacts) ? recipeRun.declared_artifacts : []),
+    ...(Array.isArray(recipeRun.declaredArtifacts) ? recipeRun.declaredArtifacts : []),
+  ];
+  declaredArtifacts.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-artifact', index));
+
+  return artifacts;
+}
+
 function failureClassificationForStatus(status) {
   if (status === 'provider_error') {
     return 'provider';
@@ -526,6 +700,9 @@ function normalizeArtifacts(result) {
     for (const artifact of agentRuntimeBundleArtifacts(result)) {
       appendUniqueArtifact(artifacts, artifact);
     }
+    for (const artifact of recipeRunArtifacts(result)) {
+      appendUniqueArtifact(artifacts, artifact);
+    }
     return artifacts.map(artifactFromCodeboxArtifact);
   }
   const artifacts = Array.isArray(result?.artifacts)
@@ -560,6 +737,13 @@ function normalizeEvidenceRefs(result) {
         kind: artifact.kind,
         uri: artifact.path || artifact.url,
         label: artifact.kind.replace(/^agent-runtime-/, 'Agent runtime ').replace(/-/g, ' '),
+      });
+    }
+    for (const artifact of recipeRunArtifacts(result)) {
+      appendUniqueEvidenceRef(refs, {
+        kind: artifact.kind,
+        uri: artifact.path || artifact.url,
+        label: artifact.kind.replace(/^codebox-recipe-/, 'WP Codebox recipe ').replace(/-/g, ' '),
       });
     }
     for (const ref of outputEvidenceRefs(normalizeOutputs(result))) {
@@ -627,6 +811,8 @@ function codeboxDecisionEvidence(result) {
   const completionOutcome = result.completionOutcome || result.completion_outcome || result.metadata?.recipe_run?.completionOutcome || {};
   const runtime = result.run?.runtime || result.metadata?.recipe_run?.run?.runtime || {};
   const run = result.run || result.metadata?.recipe_run?.run || {};
+  const recipeRun = recipeRunFromResult(result);
+  const recipeFailedPhase = recipeRunFailedPhase(recipeRun);
   return Object.fromEntries(Object.entries({
     selected_backend: 'codebox',
     selected_executor: 'wordpress.codebox-agent-task-executor',
@@ -645,6 +831,11 @@ function codeboxDecisionEvidence(result) {
     completion_status: completionOutcome.status,
     completion_next_action: completionOutcome.nextAction,
     confidence: completionOutcome.confidence,
+    recipe_pack: recipeRun.pack || recipeRun.recipe_pack || recipeRun.recipePack,
+    recipe_name: recipeRun.name || recipeRun.recipe,
+    recipe_ref: recipeRun.ref,
+    recipe_target_ref: recipeRun.target_ref || recipeRun.targetRef,
+    recipe_failed_phase: recipeFailedPhase,
   }).filter(([, value]) => value !== undefined && value !== ''));
 }
 
@@ -653,15 +844,18 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   const status = normalizeStatus(result, options.exitStatus ?? 0);
   const failureClassification = result.failure_classification || failureClassificationForStatus(status);
   const outputs = normalizeOutputs(result);
+  const recipeRun = recipeRunFromResult(result);
+  const recipeSummary = recipeRunFailureSummary(recipeRun);
+  const recipeFailedPhase = recipeRunFailedPhase(recipeRun);
   const outcome = {
     schema: AGENT_TASK_OUTCOME_SCHEMA,
     task_id: request.task_id,
     status,
-    summary: result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
+    summary: recipeSummary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
     artifacts: normalizeArtifacts(result),
     evidence_refs: normalizeEvidenceRefs(result),
     outputs,
-    diagnostics: (result.diagnostics || []).map((diagnostic) => ({
+    diagnostics: [recipeRunFailureDiagnostic(recipeRun), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
       message: diagnostic.message || String(diagnostic),
       data: sanitizePublicMetadata(diagnostic.data || {}),
@@ -671,6 +865,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
       codebox: sanitizePublicMetadata(result.metadata || result),
       integration_contract: 'wp-codebox-cli/agent-task-run',
       decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result)),
+      recipe_failed_phase: recipeFailedPhase || undefined,
     },
   };
   if (failureClassification) {

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -51,7 +51,7 @@ function readTaskRequest() {
 }
 
 function secretEnvNames(request) {
-  return Array.from(new Set([...(request.secret_env || []), ...argValues('--secret-env')].filter(Boolean)));
+  return Array.from(new Set([...(request.secret_env || []), ...(request.recipe?.secret_env || []), ...argValues('--secret-env')].filter(Boolean)));
 }
 
 function assertRequiredSecretEnvAvailable(request) {
@@ -210,6 +210,7 @@ function runnerInput(request, artifacts) {
     task_timeout_seconds: Number.parseInt(argValue('--task-timeout-seconds') || request.task_timeout_seconds || request.taskTimeoutSeconds || 0, 10) || undefined,
     sandbox_session_id: request.sandbox_session_id || '',
     orchestrator: request.orchestrator || {},
+    recipe: request.recipe || {},
     artifacts_path: artifacts,
     wp_codebox_bin: argValue('--wp-codebox-bin') || request.wp_codebox_bin || '',
     agents_api_path: argValue('--agents-api') || request.agents_api_path || request.agents_api || '',
@@ -234,6 +235,7 @@ function stableTaskInput(input) {
     sandbox_tool_policy: sandboxToolPolicy(input, allowedTools),
     policy: input.parent_request?.policy || input.parent_request?.task?.policy || {},
     context: input.parent_request?.context || input.parent_request?.task?.context || {},
+    recipe: input.recipe || input.parent_request?.recipe || {},
     provider: input.provider,
     model: input.model,
     provider_plugin_paths: input.provider_plugin_paths || [],

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -66,11 +66,11 @@ fs.writeFileSync(${JSON.stringify(capture)}, JSON.stringify({ argv: process.argv
 process.stdout.write(JSON.stringify({
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
-  status: 'failed',
+  status: 'completed',
   session: {
     schema: 'wp-codebox/sandbox-session/v1',
     id: input.sandbox_session_id,
-    status: 'failed',
+    status: 'completed',
     artifacts: { bundle_id: 'fake-artifact-bundle', path: input.artifacts_path, preview_url: 'https://preview.example.test/fake' },
     orchestrator: input.orchestrator
   },
@@ -191,6 +191,8 @@ assert.equal(provider.capabilities.includes('workspace_tools'), true);
 assert.equal(provider.capabilities.includes('patch_artifacts'), true);
 assert.equal(provider.capabilities.includes('cleanup_observability'), true);
 assert.equal(provider.capabilities.includes('agent_bundle_execution'), true);
+assert.equal(provider.capabilities.includes('external_recipe_packs'), true);
+assert.equal(provider.capabilities.includes('recipe_probe_artifacts'), true);
 assert.deepEqual(provider.runtime_gap_trackers, []);
 
 const codeboxRequest = codeboxTaskRequestFromAgentTaskRequest(request);
@@ -221,6 +223,34 @@ assert.equal(codeboxRequest.expected_artifacts[0], 'screenshot');
 assert.equal(codeboxRequest.orchestrator.agent_task_id, 'task-123');
 assert.equal(codeboxRequest.context.audit_findings[0].id, 'finding-1');
 assert.deepEqual(codeboxRequest.agent_bundle, {});
+
+const recipePackRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'recipe-task-123',
+  executor: {
+    backend: 'codebox',
+    model: 'gpt-5.5',
+    config: {
+      recipe_pack: 'example-codebox-recipes',
+      recipe_ref: 'release/v1',
+      recipe: 'minimal-runtime',
+      target_ref: 'Extra-Chill/example#42',
+      recipe_secret_env: ['EXAMPLE_RECIPE_TOKEN'],
+    },
+  },
+  inputs: {
+    recipe_inputs: { fixture: 'minimal' },
+  },
+});
+assert.deepEqual(recipePackRequest.recipe, {
+  schema: 'wp-codebox/external-recipe-request/v1',
+  pack: 'example-codebox-recipes',
+  name: 'minimal-runtime',
+  ref: 'release/v1',
+  target_ref: 'Extra-Chill/example#42',
+  inputs: { fixture: 'minimal' },
+  secret_env: ['EXAMPLE_RECIPE_TOKEN'],
+});
 
 const codexAgentRequest = {
   ...request,
@@ -387,6 +417,63 @@ const upstreamRunnerOutcome = agentTaskOutcomeFromCodeboxResult(request, {
 assert.equal(upstreamRunnerOutcome.status, 'succeeded');
 assert.equal(upstreamRunnerOutcome.artifacts[0].kind, 'codebox-artifact-directory');
 assert.equal(upstreamRunnerOutcome.artifacts[0].path, '/tmp/wp-codebox-artifacts');
+
+const recipeProbeFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  recipe_run: {
+    pack: 'example-codebox-recipes',
+    name: 'minimal-runtime',
+    ref: 'release/v1',
+    target_ref: 'Extra-Chill/example#42',
+    startup: { success: true, log_path: '/tmp/recipe/startup.log' },
+    probes: [{ id: 'home-page', status: 'failed', path: '/tmp/recipe/probes/home-page.json', screenshot: '/tmp/recipe/screens/home-page.png' }],
+    fake_side_effects: '/tmp/recipe/fakes/side-effects.json',
+    declared_artifacts: [{ name: 'runtime-log', path: '/tmp/recipe/logs/runtime.log' }],
+  },
+});
+assert.equal(recipeProbeFailureOutcome.status, 'failed');
+assert.equal(recipeProbeFailureOutcome.summary, 'WP Codebox home-page failed.');
+assert.equal(recipeProbeFailureOutcome.failure_classification, 'execution_failed');
+assert.equal(recipeProbeFailureOutcome.metadata.recipe_failed_phase, 'probe');
+assert.equal(recipeProbeFailureOutcome.metadata.decision_evidence.recipe_pack, 'example-codebox-recipes');
+assert.equal(recipeProbeFailureOutcome.metadata.decision_evidence.recipe_failed_phase, 'probe');
+assert.equal(recipeProbeFailureOutcome.diagnostics[0].class, 'codebox.recipe.probe.failed');
+assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-recipe-startup-log' && artifact.path === '/tmp/recipe/startup.log'), true);
+assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-recipe-probe-json' && artifact.path === '/tmp/recipe/probes/home-page.json'), true);
+assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-recipe-screenshot' && artifact.path === '/tmp/recipe/screens/home-page.png'), true);
+assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-recipe-fake-side-effects' && artifact.path === '/tmp/recipe/fakes/side-effects.json'), true);
+assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-recipe-artifact' && artifact.path === '/tmp/recipe/logs/runtime.log'), true);
+assert.equal(recipeProbeFailureOutcome.evidence_refs.some((ref) => ref.uri === '/tmp/recipe/screens/home-page.png'), true);
+
+const recipeStartupFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: false,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  metadata: {
+    recipe_run: {
+      name: 'minimal-runtime',
+      startup: { success: false, message: 'Recipe could not boot WordPress.', log: '/tmp/recipe/startup.log' },
+    },
+  },
+});
+assert.equal(recipeStartupFailureOutcome.status, 'failed');
+assert.equal(recipeStartupFailureOutcome.summary, 'Recipe could not boot WordPress.');
+assert.equal(recipeStartupFailureOutcome.metadata.recipe_failed_phase, 'startup');
+
+const recipeArtifactCollectionFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: false,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  recipe_run: {
+    name: 'minimal-runtime',
+    artifact_collection: { success: false, summary: 'Declared artifact path was missing.' },
+  },
+});
+assert.equal(recipeArtifactCollectionFailureOutcome.status, 'failed');
+assert.equal(recipeArtifactCollectionFailureOutcome.summary, 'Declared artifact path was missing.');
+assert.equal(recipeArtifactCollectionFailureOutcome.metadata.recipe_failed_phase, 'artifact_collection');
 
 const normalizedCompletedOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: true,
@@ -657,6 +744,33 @@ try {
   assert.equal(captured.request.orchestrator.agent_task_id, 'task-123');
   assert.equal(captured.request.runtime_overlays[0].type, 'bundled-library');
 
+  const recipeCliResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+    '--task-runner',
+    fixture,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      task_id: 'recipe-cli-task-123',
+      executor: {
+        backend: 'codebox',
+        config: {
+          recipe_pack: 'example-codebox-recipes',
+          recipe_ref: 'release/v1',
+          recipe: 'minimal-runtime',
+          target_ref: 'Extra-Chill/example#42',
+          recipe_secret_env: [],
+        },
+      },
+    }),
+  });
+  assert.equal(recipeCliResult.status, 0, recipeCliResult.stderr || recipeCliResult.stdout);
+  const capturedRecipe = JSON.parse(fs.readFileSync(capture, 'utf8'));
+  assert.equal(capturedRecipe.request.recipe.pack, 'example-codebox-recipes');
+  assert.equal(capturedRecipe.request.recipe.name, 'minimal-runtime');
+  assert.equal(capturedRecipe.request.recipe.target_ref, 'Extra-Chill/example#42');
+
   const codexResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
     '--task-runner',
@@ -735,6 +849,35 @@ try {
   assert.equal(capturedAgentBundleRun.input.agent_bundle.agent_slug, 'static-site-agent');
   assert.equal(capturedAgentBundleRun.input.agent_bundle.pipeline_slug, 'static-site-pipeline');
   assert.deepEqual(capturedAgentBundleRun.input.agent_bundle.tool_recorders, [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }]);
+
+  const recipeWpCodeboxRoot = fs.mkdtempSync(path.join(root, 'recipe-wp-codebox-'));
+  const { fixture: recipeFakeWpCodebox, capture: recipeFakeWpCodeboxCapture } = writeFakeWpCodebox(recipeWpCodeboxRoot);
+  const recipeWpCodeboxResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      task_id: 'recipe-wp-codebox-task-123',
+      executor: {
+        backend: 'codebox',
+        config: {
+          wp_codebox_bin: recipeFakeWpCodebox,
+          recipe_pack: 'example-codebox-recipes',
+          recipe_ref: 'release/v1',
+          recipe: 'minimal-runtime',
+          target_ref: 'Extra-Chill/example#42',
+          recipe_secret_env: [],
+        },
+      },
+    }),
+  });
+  assert.equal(recipeWpCodeboxResult.status, 0, recipeWpCodeboxResult.stderr || recipeWpCodeboxResult.stdout);
+  const capturedRecipeWpCodeboxRun = JSON.parse(fs.readFileSync(recipeFakeWpCodeboxCapture, 'utf8'));
+  assert.equal(capturedRecipeWpCodeboxRun.argv[0], 'agent-task-run');
+  assert.equal(capturedRecipeWpCodeboxRun.input.recipe.pack, 'example-codebox-recipes');
+  assert.equal(capturedRecipeWpCodeboxRun.input.recipe.name, 'minimal-runtime');
+  assert.equal(capturedRecipeWpCodeboxRun.input.recipe.target_ref, 'Extra-Chill/example#42');
 
   const contractResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),


### PR DESCRIPTION
## Summary
- Add a generic Codebox recipe request seam so Homeboy agent-task requests can pass external recipe pack, recipe ref/path, target branch/PR/ref, recipe inputs, and recipe secret declarations through to `wp-codebox agent-task-run`.
- Preserve generic recipe evidence from Codebox results as Homeboy artifacts/evidence refs, including startup logs, probe JSON, screenshots, declared artifacts, and fake side-effect artifacts.
- Distinguish recipe startup, probe, and artifact collection failures in task summaries, diagnostics, and decision metadata.

## Linked Issues
- Closes https://github.com/Extra-Chill/homeboy-extensions/issues/1115
- Closes https://github.com/Extra-Chill/homeboy-extensions/issues/1114

## Dependency Status
- Depends on the generic WP Codebox external recipe substrate tracked in https://github.com/Automattic/wp-codebox/issues/647.
- This PR intentionally stays behind a narrow adapter seam: Homeboy passes a generic `recipe` request object and consumes a generic `recipe_run` result envelope, without hardcoding any distribution or recipe pack semantics.

## Tests
- `npm run test:codebox-agent-task-executor`
- `npm run test:codebox-agent-task-boundary`
- `npm run test:wp-codebox-task-runner`
- `npm run lint:js -- lib/codebox-agent-task-executor.js scripts/agent/homeboy-wp-codebox-task-runner.cjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the generic Codebox recipe request/evidence adapter, adding smoke coverage, and drafting this PR description. Chris remains responsible for review and validation.