### PR TITLE
Standardize WordPress bench step-series artifacts

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -140,6 +140,90 @@ Numeric metrics are aggregated across measured iterations with the same
 mean/p50/p95/p99/min/max suffixes used by PHP bench files. Artifacts and metadata
 are carried into the Homeboy BenchResults scenario envelope.
 
+### WordPress benchmark step-series artifacts
+
+WordPress bench workloads that need row-level proof data can attach a generic
+step-series artifact without changing top-level benchmark metrics. Return rows
+under `metadata.step_series`; the WordPress bench artifact post-processor emits a
+stable `series.json` next to `results.jsonl` and `leaderboard.md`:
+
+```php
+return [
+    'metrics'  => [ 'transient_count' => 42 ],
+    'metadata' => [
+        'step_series' => [
+            [
+                'type'        => 'request',
+                'label'       => 'GET /shop/',
+                'url'         => '/shop/',
+                'status'      => 'pass',
+                'status_code' => 200,
+                'elapsed_ms'  => 25.5,
+                'metrics'     => [ 'db_queries' => 12 ],
+                'metadata'    => [ 'cache_state' => 'cold' ],
+            ],
+            [
+                'type'     => 'option_sample',
+                'label'    => 'Layered nav transient count',
+                'option'   => '_transient_wc_layered_nav_counts',
+                'status'   => 'fail',
+                'failure'  => [ 'message' => 'transient grew past budget' ],
+                'metadata' => [ 'transient_count' => 42, 'budget' => 30 ],
+            ],
+        ],
+    ],
+];
+```
+
+`series.json` uses schema `homeboy/wordpress-bench-step-series/v1`:
+
+```json
+{
+  "schema": "homeboy/wordpress-bench-step-series/v1",
+  "component_id": "example-plugin",
+  "generated_from": "homeboy/bench-results/v1",
+  "series": [
+    {
+      "scenario_id": "layered-nav-cache",
+      "label": "Layered nav cache",
+      "source": "component",
+      "artifact": null,
+      "rows": [
+        {
+          "scenario_id": "layered-nav-cache",
+          "index": 0,
+          "type": "request",
+          "label": "GET /shop/",
+          "url": "/shop/",
+          "status": "pass",
+          "success": true,
+          "status_code": 200,
+          "elapsed_ms": 25.5,
+          "metrics": { "db_queries": 12 },
+          "metadata": { "cache_state": "cold" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Recommended row fields:
+
+- `type`: short category such as `request`, `crawl`, `option_sample`, `transient_sample`, or a domain-specific value.
+- `label`: human-readable step label for reports.
+- `elapsed_ms`: step elapsed time when applicable.
+- `status` and `success`: row outcome. `status` values `pass`, `passed`, and `ok` normalize to `success: true`; `fail`, `failed`, and `error` normalize to `success: false`.
+- `failure`: string or object with failure details.
+- `metrics`: numeric or structured measurements for the row.
+- `metadata`: arbitrary domain metadata, such as option keys, transient counts, cache state, request method, crawl depth, or fixture identifiers.
+
+If a workload writes its own detailed step-series file, attach it predictably as
+`artifacts.step_series` with `kind: "json"` and
+`schema: "homeboy/wordpress-bench-step-series/v1"`. The post-processor preserves
+that artifact reference in `series.json`, so Homeboy evidence and reporting can
+discover either inline rows or workload-owned row files through the same key.
+
 Playground grader workloads may also return a normalized reward payload:
 
 ```json

--- a/wordpress/scripts/bench/bench-results-artifacts-smoke.sh
+++ b/wordpress/scripts/bench/bench-results-artifacts-smoke.sh
@@ -36,7 +36,27 @@ cat > "$RESULTS_FILE" <<'JSON'
         "provider": "openai",
         "model": "gpt-5.5",
         "seed": 1,
-        "tokens": { "input": 1000, "output": 500 }
+        "tokens": { "input": 1000, "output": 500 },
+        "step_series": [
+          {
+            "type": "request",
+            "label": "GET /shop/",
+            "url": "/shop/",
+            "status": "pass",
+            "status_code": 200,
+            "elapsed_ms": 25.5,
+            "metrics": { "db_queries": 12 },
+            "metadata": { "cache_state": "cold" }
+          },
+          {
+            "type": "option_sample",
+            "label": "Transient count",
+            "option": "_transient_wc_layered_nav_counts",
+            "status": "fail",
+            "failure": { "message": "transient grew past budget" },
+            "metadata": { "transient_count": 42, "budget": 30 }
+          }
+        ]
       },
       "artifacts": {
         "transcript": { "path": "artifacts/transcript.json", "kind": "json" },
@@ -48,6 +68,13 @@ cat > "$RESULTS_FILE" <<'JSON'
       "iterations": 1,
       "metrics": { "mean_ms": 500, "reward_mean": 0 },
       "metadata": { "provider": "openai", "model": "gpt-5.5", "seed": 2 },
+      "artifacts": {
+        "step_series": {
+          "path": "artifacts/query-series.json",
+          "kind": "json",
+          "schema": "homeboy/wordpress-bench-step-series/v1"
+        }
+      },
       "error": { "message": "scenario failed" }
     }
   ]
@@ -58,6 +85,7 @@ homeboy_wordpress_emit_bench_results_artifacts "$RESULTS_FILE"
 
 JSONL_FILE="${TMP_ROOT}/results.jsonl"
 LEADERBOARD_FILE="${TMP_ROOT}/leaderboard.md"
+SERIES_FILE="${TMP_ROOT}/series.json"
 
 if [ ! -s "$JSONL_FILE" ]; then
     echo "ERROR: missing results.jsonl artifact" >&2
@@ -65,6 +93,10 @@ if [ ! -s "$JSONL_FILE" ]; then
 fi
 if [ ! -s "$LEADERBOARD_FILE" ]; then
     echo "ERROR: missing leaderboard.md artifact" >&2
+    exit 1
+fi
+if [ ! -s "$SERIES_FILE" ]; then
+    echo "ERROR: missing series.json artifact" >&2
     exit 1
 fi
 
@@ -99,6 +131,18 @@ fi
 if ! grep -q '| openai | gpt-5.5 | 2 | 50% | 1 | 0.5 | 867 |' "$LEADERBOARD_FILE"; then
     echo "ERROR: leaderboard did not aggregate success/error rows as expected" >&2
     cat "$LEADERBOARD_FILE" >&2
+    exit 1
+fi
+
+series_schema=$(jq -r '.schema' "$SERIES_FILE")
+series_count=$(jq -r '.series | length' "$SERIES_FILE")
+request_success=$(jq -r '.series[] | select(.scenario_id == "block-markup/navigation-001") | .rows[] | select(.type == "request") | .success' "$SERIES_FILE")
+option_failure=$(jq -r '.series[] | select(.scenario_id == "block-markup/navigation-001") | .rows[] | select(.type == "option_sample") | .failure.message' "$SERIES_FILE")
+artifact_path=$(jq -r '.series[] | select(.scenario_id == "block-markup/query-002") | .artifact.path' "$SERIES_FILE")
+
+if [ "$series_schema" != "homeboy/wordpress-bench-step-series/v1" ] || [ "$series_count" -ne 2 ] || [ "$request_success" != "true" ] || [ "$option_failure" != "transient grew past budget" ] || [ "$artifact_path" != "artifacts/query-series.json" ]; then
+    echo "ERROR: series.json did not preserve normalized step-series rows and artifact refs" >&2
+    cat "$SERIES_FILE" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/bench/bench-results-artifacts.sh
+++ b/wordpress/scripts/bench/bench-results-artifacts.sh
@@ -93,11 +93,66 @@ homeboy_wordpress_bench_leaderboard_filter() {
     '
 }
 
+homeboy_wordpress_bench_step_series_filter() {
+    jq \
+        --arg schema "homeboy/wordpress-bench-step-series/v1" \
+        '
+        def row_array($scenario):
+            (
+                $scenario.step_series
+                // $scenario.metadata.step_series
+                // $scenario.metadata.series
+                // []
+            )
+            | if type == "array" then map(select(type == "object")) else [] end;
+
+        def normalize_row($scenario; $index):
+            . as $row
+            | $row + {
+                scenario_id: ($row.scenario_id // $scenario.id // null),
+                index: ($row.index // $index)
+            }
+            | if has("success") then . else
+                if (.status // null) == "pass" or (.status // null) == "passed" or (.status // null) == "ok" then . + {success: true}
+                elif (.status // null) == "fail" or (.status // null) == "failed" or (.status // null) == "error" then . + {success: false}
+                else . end
+            end;
+
+        . as $root
+        | {
+            schema: $schema,
+            component_id: ($root.component_id // null),
+            generated_from: "homeboy/bench-results/v1",
+            series: [
+                ($root.scenarios // [])[]
+                | select((.id // null) != "__bootstrap")
+                | . as $scenario
+                | (row_array($scenario)) as $rows
+                | ($scenario.artifacts.step_series // null) as $artifact
+                | select(($rows | length) > 0 or $artifact != null)
+                | {
+                    scenario_id: ($scenario.id // null),
+                    label: ($scenario.label // null),
+                    source: ($scenario.source // null),
+                    artifact: $artifact,
+                    rows: [
+                        $rows
+                        | to_entries[]
+                        | . as $entry
+                        | $entry.value | normalize_row($scenario; $entry.key)
+                    ]
+                }
+            ]
+        }
+        '
+}
+
 homeboy_wordpress_emit_bench_results_artifacts() {
 	local bench_results_file="$1"
 	local artifact_dir
 	local jsonl_file
 	local leaderboard_file
+	local series_file
 	local baseline_results_file
 	local codebox_memory_report_file
 	local codebox_thresholds_json
@@ -111,6 +166,7 @@ homeboy_wordpress_emit_bench_results_artifacts() {
 
 	jsonl_file="${artifact_dir}/results.jsonl"
 	leaderboard_file="${artifact_dir}/leaderboard.md"
+	series_file="${artifact_dir}/series.json"
 	codebox_memory_report_file="${artifact_dir}/codebox-browser-memory-comparison.md"
 
     if ! homeboy_wordpress_bench_jsonl_filter < "$bench_results_file" > "$jsonl_file"; then
@@ -120,6 +176,11 @@ homeboy_wordpress_emit_bench_results_artifacts() {
 
 	if ! homeboy_wordpress_bench_leaderboard_filter < "$jsonl_file" > "$leaderboard_file"; then
 		echo "ERROR: failed to emit bench leaderboard artifact at $leaderboard_file" >&2
+		return 1
+	fi
+
+	if ! homeboy_wordpress_bench_step_series_filter < "$bench_results_file" > "$series_file"; then
+		echo "ERROR: failed to emit bench step-series artifact at $series_file" >&2
 		return 1
 	fi
 
@@ -139,6 +200,7 @@ homeboy_wordpress_emit_bench_results_artifacts() {
 	if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
 		echo "DEBUG: [bench] Results JSONL: $jsonl_file"
 		echo "DEBUG: [bench] Leaderboard: $leaderboard_file"
+		echo "DEBUG: [bench] Step series: $series_file"
 		[ -s "$codebox_memory_report_file" ] && echo "DEBUG: [bench] Codebox browser memory comparison: $codebox_memory_report_file"
 	fi
 }


### PR DESCRIPTION
## Summary
- Add a `homeboy/wordpress-bench-step-series/v1` artifact convention emitted as `series.json` alongside existing WordPress bench artifacts.
- Preserve existing top-level benchmark metrics while normalizing workload-provided step-series rows and preserving `artifacts.step_series` references for detailed row files.
- Document the convention and extend artifact smoke coverage for request rows, option/transient-style samples, elapsed/status/failure fields, metrics, metadata, and workload-owned artifact refs.

## Verification
- `bash wordpress/scripts/bench/bench-results-artifacts-smoke.sh`
- `bash -n wordpress/scripts/bench/bench-results-artifacts.sh wordpress/scripts/bench/bench-results-artifacts-smoke.sh`
- `npm run test:wp-codebox-bench-recipe-builder` from `wordpress/`

## Known baseline
- `npm run lint:js` from `wordpress/` currently fails on existing unrelated JS lint issues in `wordpress/lib/playground-readiness.js`, `wordpress/lib/request-profiler.js`, `wordpress/lib/timing-correlator.js`, and `wordpress/scripts/agent/*`; this PR does not touch those files.

Closes #1120.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation, tests, and PR drafting under Chris review