### PR TITLE
Add WordPress bench state sampling helpers

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -224,6 +224,42 @@ If a workload writes its own detailed step-series file, attach it predictably as
 that artifact reference in `series.json`, so Homeboy evidence and reporting can
 discover either inline rows or workload-owned row files through the same key.
 
+### WordPress benchmark state sampling helpers
+
+Bench workloads that need to sample WordPress option or transient growth can use
+the generic state sampling helper mounted with the WordPress extension:
+
+```php
+<?php
+require_once '/homeboy-extension/scripts/bench/lib/wordpress-state-sampling.php';
+
+$before = homeboy_wordpress_bench_sample_transient('example_cache', [
+    'sample_index' => 0,
+    'label' => 'before',
+]);
+
+// Run the workload operation that may change option or transient state.
+
+$after = homeboy_wordpress_bench_sample_transient('example_cache', [
+    'sample_index' => 1,
+    'label' => 'after',
+]);
+
+return [
+    'metadata' => [
+        'state_samples' => [$before, $after],
+        'state_delta' => homeboy_wordpress_bench_sample_delta($before, $after),
+    ],
+];
+```
+
+`homeboy_wordpress_bench_sample_option($name, $context)` samples a named option.
+`homeboy_wordpress_bench_sample_transient($name, $context)` samples the backing
+transient option row without workload SQL. Both helpers report existence/missing
+state, serialized byte size, value type, array entry count when applicable, and
+sample context such as `sample_index`, `label`, and `sampled_at_unix_ms`. Pass
+`network => true` in the transient context to sample a site transient.
+
 Playground grader workloads may also return a normalized reward payload:
 
 ```json

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -37,6 +37,7 @@
     "test:codebox-memory-report": "node tests/codebox-memory-report-smoke.js",
     "test:wp-codebox-apply-adapter": "node tests/wp-codebox-apply-adapter-smoke.js",
     "test:wp-codebox-browser-metrics": "node tests/wp-codebox-browser-metrics-smoke.js",
+    "test:wordpress-bench-state-sampling": "php tests/wordpress-bench-state-sampling-helper-smoke.php",
     "test:audit-wp-codebox-fanout": "node tests/audit-wp-codebox-fanout-smoke.js",
     "test:audit-wp-codebox-execute": "node tests/audit-wp-codebox-fanout-smoke.js",
     "test:wp-codebox-task-runner": "node tests/wp-codebox-task-runner-smoke.js",

--- a/wordpress/scripts/bench/lib/wordpress-state-sampling.php
+++ b/wordpress/scripts/bench/lib/wordpress-state-sampling.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Generic WordPress option/transient sampling helpers for bench workloads.
+ *
+ * Workloads can require this file from the mounted extension path:
+ * /homeboy-extension/scripts/bench/lib/wordpress-state-sampling.php
+ */
+
+if ( ! function_exists('homeboy_wordpress_bench_sample_option') ) {
+	/**
+	 * Sample a WordPress option row without exposing SQL details to workloads.
+	 *
+	 * @param string              $option_name Option name.
+	 * @param array<string,mixed> $context Optional sample context.
+	 * @return array<string,mixed>
+	 */
+	function homeboy_wordpress_bench_sample_option(string $option_name, array $context = array()): array {
+		$row = homeboy_wordpress_bench_read_option_row($option_name);
+		return homeboy_wordpress_bench_format_option_sample('option', $option_name, $option_name, $row, $context);
+	}
+}
+
+if ( ! function_exists('homeboy_wordpress_bench_sample_transient') ) {
+	/**
+	 * Sample a WordPress transient option row.
+	 *
+	 * @param string              $transient Transient name without the _transient_ prefix.
+	 * @param array<string,mixed> $context Optional sample context. Pass network=true for site transients.
+	 * @return array<string,mixed>
+	 */
+	function homeboy_wordpress_bench_sample_transient(string $transient, array $context = array()): array {
+		$network     = ! empty($context['network']);
+		$option_name = ( $network ? '_site_transient_' : '_transient_' ) . $transient;
+		$row         = $network ? homeboy_wordpress_bench_read_site_option_row($option_name) : homeboy_wordpress_bench_read_option_row($option_name);
+
+		$sample                    = homeboy_wordpress_bench_format_option_sample('transient', $transient, $option_name, $row, $context);
+		$sample['transient_scope'] = $network ? 'site' : 'single-site';
+
+		return $sample;
+	}
+}
+
+if ( ! function_exists('homeboy_wordpress_bench_sample_delta') ) {
+	/**
+	 * Return a small numeric delta between two option/transient samples.
+	 *
+	 * @param array<string,mixed> $before Earlier sample.
+	 * @param array<string,mixed> $after Later sample.
+	 * @return array<string,mixed>
+	 */
+	function homeboy_wordpress_bench_sample_delta(array $before, array $after): array {
+		return array(
+			'kind'                      => $after['kind'] ?? $before['kind'] ?? 'option',
+			'name'                      => $after['name'] ?? $before['name'] ?? '',
+			'option_name'               => $after['option_name'] ?? $before['option_name'] ?? '',
+			'before_exists'             => (bool) ( $before['exists'] ?? false ),
+			'after_exists'              => (bool) ( $after['exists'] ?? false ),
+			'exists_changed'            => (bool) ( $before['exists'] ?? false ) !== (bool) ( $after['exists'] ?? false ),
+			'serialized_bytes_delta'    => homeboy_wordpress_bench_nullable_number_delta($before['serialized_bytes'] ?? null, $after['serialized_bytes'] ?? null),
+			'array_entry_count_delta'   => homeboy_wordpress_bench_nullable_number_delta($before['array_entry_count'] ?? null, $after['array_entry_count'] ?? null),
+			'before_sample_index'       => $before['sample_index'] ?? null,
+			'after_sample_index'        => $after['sample_index'] ?? null,
+			'before_sampled_at_unix_ms' => $before['sampled_at_unix_ms'] ?? null,
+			'after_sampled_at_unix_ms'  => $after['sampled_at_unix_ms'] ?? null,
+		);
+	}
+}
+
+if ( ! function_exists('homeboy_wordpress_bench_read_option_row') ) {
+	/**
+	 * Read a raw option row through wpdb.
+	 *
+	 * @param string $option_name Option name.
+	 * @return array<string,string>|null
+	 */
+	function homeboy_wordpress_bench_read_option_row(string $option_name): ?array {
+		if ( '' === $option_name || empty($GLOBALS['wpdb']) ) {
+			return null;
+		}
+
+		global $wpdb;
+		if ( empty($wpdb->options) || ! method_exists($wpdb, 'prepare') || ! method_exists($wpdb, 'get_row') ) {
+			return null;
+		}
+
+		$format = defined('ARRAY_A') ? ARRAY_A : 'ARRAY_A';
+		$row    = $wpdb->get_row(
+			$wpdb->prepare("SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1", $option_name),
+			$format
+		);
+
+		return is_array($row) ? $row : null;
+	}
+}
+
+if ( ! function_exists('homeboy_wordpress_bench_read_site_option_row') ) {
+	/**
+	 * Read a raw site option row through wpdb.
+	 *
+	 * @param string $option_name Site option name.
+	 * @return array<string,string>|null
+	 */
+	function homeboy_wordpress_bench_read_site_option_row(string $option_name): ?array {
+		if ( ! function_exists('is_multisite') || ! is_multisite() ) {
+			return homeboy_wordpress_bench_read_option_row($option_name);
+		}
+		if ( '' === $option_name || empty($GLOBALS['wpdb']) ) {
+			return null;
+		}
+
+		global $wpdb;
+		if ( empty($wpdb->sitemeta) || ! method_exists($wpdb, 'prepare') || ! method_exists($wpdb, 'get_row') ) {
+			return null;
+		}
+
+		$network_id = function_exists('get_current_network_id') ? (int) get_current_network_id() : 1;
+		$format     = defined('ARRAY_A') ? ARRAY_A : 'ARRAY_A';
+		$row        = $wpdb->get_row(
+			$wpdb->prepare("SELECT meta_value AS option_value FROM {$wpdb->sitemeta} WHERE site_id = %d AND meta_key = %s LIMIT 1", $network_id, $option_name),
+			$format
+		);
+
+		return is_array($row) ? $row : null;
+	}
+}
+
+if ( ! function_exists('homeboy_wordpress_bench_format_option_sample') ) {
+	/**
+	 * Format a raw option row as a bench artifact-friendly sample.
+	 *
+	 * @param string                    $kind Sample kind.
+	 * @param string                    $name Public sample name.
+	 * @param string                    $option_name Backing option row name.
+	 * @param array<string,string>|null $row Raw option row.
+	 * @param array<string,mixed>       $context Optional sample context.
+	 * @return array<string,mixed>
+	 */
+	function homeboy_wordpress_bench_format_option_sample(string $kind, string $name, string $option_name, ?array $row, array $context): array {
+		$exists        = null !== $row && array_key_exists('option_value', $row);
+		$raw_value     = $exists ? (string) $row['option_value'] : null;
+		$value         = $exists ? homeboy_wordpress_bench_maybe_unserialize($raw_value) : null;
+		$sampled_at_ms = array_key_exists('sampled_at_unix_ms', $context)
+			? $context['sampled_at_unix_ms']
+			: (int) floor(microtime(true) * 1000);
+
+		$sample = array(
+			'kind'               => $kind,
+			'name'               => $name,
+			'option_name'        => $option_name,
+			'exists'             => $exists,
+			'missing'            => ! $exists,
+			'serialized_bytes'   => $exists ? strlen($raw_value) : null,
+			'value_type'         => $exists ? gettype($value) : null,
+			'array_entry_count'  => is_array($value) ? count($value) : null,
+			'sampled_at_unix_ms' => is_numeric($sampled_at_ms) ? (int) $sampled_at_ms : null,
+		);
+
+		if ( array_key_exists('sample_index', $context) ) {
+			$sample['sample_index'] = is_numeric($context['sample_index']) ? (int) $context['sample_index'] : $context['sample_index'];
+		}
+
+		if ( isset($context['label']) && is_string($context['label']) && '' !== $context['label'] ) {
+			$sample['label'] = $context['label'];
+		}
+
+		return $sample;
+	}
+}
+
+if ( ! function_exists('homeboy_wordpress_bench_nullable_number_delta') ) {
+	/**
+	 * Return after-before when both values are numeric; otherwise null.
+	 *
+	 * @param mixed $before Earlier value.
+	 * @param mixed $after Later value.
+	 * @return int|float|null
+	 */
+	function homeboy_wordpress_bench_nullable_number_delta($before, $after) {
+		if ( ! is_numeric($before) || ! is_numeric($after) ) {
+			return null;
+		}
+
+		return $after - $before;
+	}
+}
+
+if ( ! function_exists('homeboy_wordpress_bench_maybe_unserialize') ) {
+	/**
+	 * Unserialize WordPress option payloads without requiring WordPress in smoke tests.
+	 *
+	 * @param string $value Raw option_value payload.
+	 * @return mixed
+	 */
+	function homeboy_wordpress_bench_maybe_unserialize(string $value) {
+		if ( function_exists('maybe_unserialize') ) {
+			return maybe_unserialize($value);
+		}
+
+		return $value;
+	}
+}

--- a/wordpress/tests/wordpress-bench-state-sampling-helper-smoke.php
+++ b/wordpress/tests/wordpress-bench-state-sampling-helper-smoke.php
@@ -1,0 +1,136 @@
+<?php
+/** Smoke test for generic WordPress bench state sampling helpers. */
+
+if ( ! defined('ARRAY_A') ) {
+	define('ARRAY_A', 'ARRAY_A');
+}
+
+class Homeboy_WordPress_Bench_State_Sampling_WPDB {
+	/** @var string */
+	public $options = 'wp_options';
+
+	/** @var string */
+	public $sitemeta = 'wp_sitemeta';
+
+	/** @var array<string,string> */
+	private $rows;
+
+	/** @var array<string,string> */
+	private $site_rows;
+
+	/**
+	 * @param array<string,string> $rows Rows keyed by option_name.
+	 * @param array<string,string> $site_rows Site rows keyed by meta_key.
+	 */
+	public function __construct(array $rows, array $site_rows = array()) {
+		$this->rows      = $rows;
+		$this->site_rows = $site_rows;
+	}
+
+	public function prepare($query, ...$args) {
+		return array('query' => $query, 'args' => $args);
+	}
+
+	public function get_row($prepared, $format = ARRAY_A) {
+		$option_name = $prepared['args'][0] ?? '';
+		if ( count($prepared['args']) > 1 ) {
+			$option_name = $prepared['args'][1];
+			if ( ! array_key_exists($option_name, $this->site_rows) ) {
+				return null;
+			}
+
+			return array('option_value' => $this->site_rows[ $option_name ]);
+		}
+
+		if ( ! array_key_exists($option_name, $this->rows) ) {
+			return null;
+		}
+
+		return array('option_value' => $this->rows[ $option_name ]);
+	}
+}
+
+function maybe_unserialize($value) {
+	$unserialized = @unserialize($value);
+	if ( false !== $unserialized || 'b:0;' === $value ) {
+		return $unserialized;
+	}
+
+	return $value;
+}
+
+function is_multisite() {
+	return true;
+}
+
+function get_current_network_id() {
+	return 1;
+}
+
+$GLOBALS['wpdb'] = new Homeboy_WordPress_Bench_State_Sampling_WPDB(array(
+	'plain_option'             => 'plain value',
+	'array_option'             => serialize(array('one' => 1, 'two' => 2, 'three' => 3)),
+	'_transient_fixture_cache'  => serialize(array('alpha' => true, 'beta' => false)),
+), array(
+	'_site_transient_network_fixture_cache' => serialize(array('global' => true)),
+));
+
+require_once __DIR__ . '/../scripts/bench/lib/wordpress-state-sampling.php';
+
+$plain = homeboy_wordpress_bench_sample_option('plain_option', array('sample_index' => 7, 'sampled_at_unix_ms' => 123456));
+if ( true !== $plain['exists'] || false !== $plain['missing'] ) {
+	fwrite(STDERR, "Expected existing plain option sample.\n");
+	exit(1);
+}
+if ( 'string' !== $plain['value_type'] || null !== $plain['array_entry_count'] ) {
+	fwrite(STDERR, "Expected plain option to report string type and no array count.\n");
+	exit(1);
+}
+if ( strlen('plain value') !== $plain['serialized_bytes'] || 7 !== $plain['sample_index'] || 123456 !== $plain['sampled_at_unix_ms'] ) {
+	fwrite(STDERR, "Expected plain option bytes and sample context to round-trip.\n");
+	exit(1);
+}
+
+$array = homeboy_wordpress_bench_sample_option('array_option', array('sample_index' => 8));
+if ( 'array' !== $array['value_type'] || 3 !== $array['array_entry_count'] ) {
+	fwrite(STDERR, "Expected serialized array option to report array entry count.\n");
+	exit(1);
+}
+
+$missing = homeboy_wordpress_bench_sample_option('missing_option');
+if ( false !== $missing['exists'] || true !== $missing['missing'] || null !== $missing['serialized_bytes'] ) {
+	fwrite(STDERR, "Expected missing option sample with null byte size.\n");
+	exit(1);
+}
+
+$transient = homeboy_wordpress_bench_sample_transient('fixture_cache', array('sample_index' => 9));
+if ( 'transient' !== $transient['kind'] || '_transient_fixture_cache' !== $transient['option_name'] ) {
+	fwrite(STDERR, "Expected transient helper to resolve backing option name.\n");
+	exit(1);
+}
+if ( 2 !== $transient['array_entry_count'] || 'single-site' !== $transient['transient_scope'] ) {
+	fwrite(STDERR, "Expected transient helper to report array count and scope.\n");
+	exit(1);
+}
+
+$site_transient = homeboy_wordpress_bench_sample_transient('network_fixture_cache', array('network' => true));
+if ( '_site_transient_network_fixture_cache' !== $site_transient['option_name'] || 'site' !== $site_transient['transient_scope'] ) {
+	fwrite(STDERR, "Expected site transient helper to resolve backing site option name and scope.\n");
+	exit(1);
+}
+if ( 1 !== $site_transient['array_entry_count'] ) {
+	fwrite(STDERR, "Expected site transient helper to read from sitemeta rows.\n");
+	exit(1);
+}
+
+$delta = homeboy_wordpress_bench_sample_delta($plain, $array);
+if ( strlen(serialize(array('one' => 1, 'two' => 2, 'three' => 3))) - strlen('plain value') !== $delta['serialized_bytes_delta'] ) {
+	fwrite(STDERR, "Expected serialized byte delta.\n");
+	exit(1);
+}
+if ( null !== $delta['array_entry_count_delta'] || false !== $delta['exists_changed'] ) {
+	fwrite(STDERR, "Expected null array delta and unchanged existence.\n");
+	exit(1);
+}
+
+echo "wordpress bench state sampling helper smoke passed\n";


### PR DESCRIPTION
## Summary
- Add generic WordPress bench helpers for sampling option and transient backing rows without duplicating workload SQL.
- Report existence, serialized byte size, value type, array entry count, sample context, and before/after deltas for benchmark metadata.
- Document a minimal workload example and add standalone smoke coverage for options, transients, missing rows, multisite site transients, and deltas.

Closes #1119.

## Verification
- `composer run lint -- scripts/bench/lib/wordpress-state-sampling.php`
- `php -l scripts/bench/lib/wordpress-state-sampling.php && php -l tests/wordpress-bench-state-sampling-helper-smoke.php`
- `npm run test:wordpress-bench-state-sampling`
- `npm run test:wp-codebox-bench-recipe-builder`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation, tests, and PR drafting under Chris review