### PR TITLE
Add WordPress bench crawl helper

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -416,6 +416,41 @@ It can contain credentials or auto-login URLs; runners must not print it to logs
 or publish it with benchmark results without redacting the fields listed in
 `artifactPolicy.secretFields`.
 
+## WordPress bench crawl helper
+
+`scripts/bench/lib/wordpress-bench-crawl.php` provides a generic helper for
+benchmark workloads that need to crawl a bounded ordered list of WordPress URLs
+or routes through the WordPress HTTP API. It is intended for WP Codebox-backed
+WordPress workloads and does not require browser automation.
+
+Minimal workload:
+
+```php
+<?php
+require_once '/homeboy-extension/scripts/bench/lib/wordpress-bench-crawl.php';
+
+return function (): array {
+    return homeboy_wordpress_bench_crawl_payload(
+        [
+            '/',
+            '/sample-page/',
+            [ 'route' => '/wp-json/', 'method' => 'GET' ],
+        ],
+        [
+            'batch_index' => 0,
+            'max_requests' => 3,
+            'timeout' => 10,
+        ]
+    );
+};
+```
+
+The payload includes numeric crawl metrics for normal bench aggregation and
+structured metadata under `metadata.wordpress_bench_crawl.rows`. Each row
+contains `batch_index`, `request_index`, `url`, optional `route`, `method`,
+`status`, `http_status`, `elapsed_ms`, optional `response_bytes`, and optional
+`failure_message`.
+
 ## Playground HTTP readiness
 
 `lib/playground-readiness.js` exports a Node helper for callers that boot a

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -41,6 +41,7 @@
     "test:audit-wp-codebox-execute": "node tests/audit-wp-codebox-fanout-smoke.js",
     "test:wp-codebox-task-runner": "node tests/wp-codebox-task-runner-smoke.js",
     "test:wp-codebox-bench-recipe-builder": "node tests/wp-codebox-bench-recipe-builder-smoke.js",
+    "test:wp-codebox-bench-crawl-helper": "bash scripts/bench/wp-codebox-bench-crawl-helper-smoke.sh",
     "test:wp-codebox-prepared-dependency-cache": "bash tests/prepared-bench-dependency-cache-smoke.sh",
     "test:dependency-plugin-preflight": "bash tests/dependency-plugin-preflight-smoke.sh",
     "test:wp-codebox-bench-bootstrap-steps": "node tests/wp-codebox-bench-bootstrap-steps-smoke.js",

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -701,6 +701,7 @@ else
     EXTRA_PLUGINS_JSON="[]"
     MOUNTS_JSON=$(jq -nc --arg source "$PLUGIN_PATH" --arg target "/wordpress/wp-content/plugins/${PLUGIN_SLUG}" '[{source: $source, target: $target, mode: "readonly"}]')
 fi
+MOUNTS_JSON=$(jq -nc --argjson mounts "$MOUNTS_JSON" --arg source "$EXTENSION_DIR" '$mounts + [{source: $source, target: "/homeboy-extension", mode: "readonly"}]')
 DEPENDENCY_SLUGS=()
 if [ -n "$DEPENDENCY_PATHS" ]; then
     while IFS= read -r dep_path; do

--- a/wordpress/scripts/bench/lib/wordpress-bench-crawl.php
+++ b/wordpress/scripts/bench/lib/wordpress-bench-crawl.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * Generic WordPress URL crawl helper for bench workloads.
+ *
+ * Workloads can require this file from the mounted extension path:
+ * /homeboy-extension/scripts/bench/lib/wordpress-bench-crawl.php
+ */
+
+if (!function_exists('homeboy_wordpress_bench_crawl_normalize_entries')) {
+    /**
+     * Normalize string/object URL entries while preserving order.
+     *
+     * @param array<int,mixed> $entries Ordered crawl entries.
+     * @return array<int,array<string,mixed>> Normalized crawl entries.
+     */
+    function homeboy_wordpress_bench_crawl_normalize_entries(array $entries): array {
+        $normalized = [];
+
+        foreach ($entries as $entry) {
+            if (is_string($entry)) {
+                $normalized[] = ['route' => $entry];
+                continue;
+            }
+
+            if (!is_array($entry)) {
+                $normalized[] = [
+                    'failure_message' => 'Crawl entry must be a string route/URL or an array.',
+                ];
+                continue;
+            }
+
+            $normalized[] = $entry;
+        }
+
+        return $normalized;
+    }
+}
+
+if (!function_exists('homeboy_wordpress_bench_crawl_url_for_entry')) {
+    /**
+     * Resolve a crawl entry into a URL and optional route label.
+     *
+     * @param array<string,mixed> $entry Crawl entry.
+     * @return array{url:string,route:string|null,failure_message:string|null}
+     */
+    function homeboy_wordpress_bench_crawl_url_for_entry(array $entry): array {
+        $route = null;
+        $url = '';
+
+        if (isset($entry['url']) && is_scalar($entry['url'])) {
+            $url = trim((string) $entry['url']);
+        } elseif (isset($entry['route']) && is_scalar($entry['route'])) {
+            $route = trim((string) $entry['route']);
+            $url = $route;
+        }
+
+        if ($url === '') {
+            return [
+                'url' => '',
+                'route' => $route,
+                'failure_message' => isset($entry['failure_message']) && is_string($entry['failure_message'])
+                    ? $entry['failure_message']
+                    : 'Crawl entry is missing a url or route.',
+            ];
+        }
+
+        if (preg_match('#^https?://#i', $url) !== 1) {
+            $route = $route ?? $url;
+            $url = function_exists('home_url') ? home_url($route) : $url;
+        }
+
+        return [
+            'url' => $url,
+            'route' => $route,
+            'failure_message' => null,
+        ];
+    }
+}
+
+if (!function_exists('homeboy_wordpress_bench_crawl_request_args')) {
+    /**
+     * Build WordPress HTTP API arguments for a crawl entry.
+     *
+     * @param array<string,mixed> $entry Crawl entry.
+     * @param array<string,mixed> $options Crawl options.
+     * @return array<string,mixed> Request arguments.
+     */
+    function homeboy_wordpress_bench_crawl_request_args(array $entry, array $options): array {
+        $method = isset($entry['method']) && is_scalar($entry['method'])
+            ? strtoupper((string) $entry['method'])
+            : strtoupper((string) ($options['method'] ?? 'GET'));
+        $timeout = isset($entry['timeout']) && is_numeric($entry['timeout'])
+            ? (float) $entry['timeout']
+            : (float) ($options['timeout'] ?? 15);
+
+        $args = [
+            'method' => $method,
+            'timeout' => $timeout,
+            'redirection' => isset($options['redirection']) && is_numeric($options['redirection'])
+                ? (int) $options['redirection']
+                : 5,
+        ];
+
+        if (isset($entry['headers']) && is_array($entry['headers'])) {
+            $args['headers'] = $entry['headers'];
+        } elseif (isset($options['headers']) && is_array($options['headers'])) {
+            $args['headers'] = $options['headers'];
+        }
+
+        if (array_key_exists('body', $entry)) {
+            $args['body'] = $entry['body'];
+        }
+
+        return $args;
+    }
+}
+
+if (!function_exists('homeboy_wordpress_bench_crawl')) {
+    /**
+     * Crawl a bounded ordered list of WordPress URLs/routes and return rows.
+     *
+     * Supported entries:
+     * - '/route/'
+     * - 'https://example.test/absolute-url/'
+     * - ['route' => '/route/', 'method' => 'GET']
+     * - ['url' => 'https://example.test/absolute-url/', 'headers' => [...]]
+     *
+     * Supported options:
+     * - batch_index: batch number attached to each row. Defaults to 0.
+     * - max_requests: upper bound on crawled entries. Defaults to the list length.
+     * - timeout: per-request timeout in seconds. Defaults to 15.
+     * - method: default HTTP method. Defaults to GET.
+     * - include_response_bytes: attach strlen(body) when true. Defaults to true.
+     *
+     * @param array<int,mixed>    $entries Ordered crawl entries.
+     * @param array<string,mixed> $options Crawl options.
+     * @return array<int,array<string,mixed>> Per-request crawl rows.
+     */
+    function homeboy_wordpress_bench_crawl(array $entries, array $options = []): array {
+        $normalized = homeboy_wordpress_bench_crawl_normalize_entries($entries);
+        $max_requests = isset($options['max_requests']) && is_numeric($options['max_requests'])
+            ? max(0, (int) $options['max_requests'])
+            : count($normalized);
+        $batch_index = isset($options['batch_index']) && is_numeric($options['batch_index'])
+            ? (int) $options['batch_index']
+            : 0;
+        $include_response_bytes = array_key_exists('include_response_bytes', $options)
+            ? (bool) $options['include_response_bytes']
+            : true;
+
+        $rows = [];
+        $bounded_entries = array_slice($normalized, 0, $max_requests);
+
+        foreach ($bounded_entries as $request_index => $entry) {
+            $resolved = homeboy_wordpress_bench_crawl_url_for_entry($entry);
+            $args = homeboy_wordpress_bench_crawl_request_args($entry, $options);
+            $row = [
+                'batch_index' => $batch_index,
+                'request_index' => $request_index,
+                'url' => $resolved['url'],
+                'method' => $args['method'],
+                'status' => 'not_requested',
+                'http_status' => null,
+                'elapsed_ms' => 0.0,
+            ];
+            if ($resolved['route'] !== null) {
+                $row['route'] = $resolved['route'];
+            }
+
+            if ($resolved['failure_message'] !== null) {
+                $row['status'] = 'request_error';
+                $row['failure_message'] = $resolved['failure_message'];
+                $rows[] = $row;
+                continue;
+            }
+
+            $started = microtime(true);
+            $response = wp_remote_request($resolved['url'], $args);
+            $row['elapsed_ms'] = round((microtime(true) - $started) * 1000, 3);
+
+            if (is_wp_error($response)) {
+                $row['status'] = 'request_error';
+                $row['failure_message'] = $response->get_error_message();
+                $rows[] = $row;
+                continue;
+            }
+
+            $http_status = (int) wp_remote_retrieve_response_code($response);
+            $row['http_status'] = $http_status;
+            $row['status'] = $http_status >= 200 && $http_status < 400 ? 'ok' : 'http_error';
+
+            if ($include_response_bytes) {
+                $body = wp_remote_retrieve_body($response);
+                $row['response_bytes'] = is_string($body) ? strlen($body) : null;
+            }
+            if ($row['status'] === 'http_error') {
+                $row['failure_message'] = 'HTTP ' . $http_status;
+            }
+
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+}
+
+if (!function_exists('homeboy_wordpress_bench_crawl_payload')) {
+    /**
+     * Return a bench payload with numeric crawl metrics and structured rows.
+     *
+     * @param array<int,mixed>    $entries Ordered crawl entries.
+     * @param array<string,mixed> $options Crawl options.
+     * @return array<string,array<string,mixed>> Workload payload.
+     */
+    function homeboy_wordpress_bench_crawl_payload(array $entries, array $options = []): array {
+        $rows = homeboy_wordpress_bench_crawl($entries, $options);
+        $metrics = [
+            'crawl_requests' => count($rows),
+            'crawl_successes' => 0,
+            'crawl_failures' => 0,
+            'crawl_2xx' => 0,
+            'crawl_3xx' => 0,
+            'crawl_4xx' => 0,
+            'crawl_5xx' => 0,
+            'crawl_elapsed_ms_total' => 0.0,
+            'crawl_response_bytes_total' => 0,
+        ];
+
+        foreach ($rows as $row) {
+            $status = isset($row['status']) ? (string) $row['status'] : '';
+            if ($status === 'ok') {
+                $metrics['crawl_successes']++;
+            } else {
+                $metrics['crawl_failures']++;
+            }
+
+            $http_status = isset($row['http_status']) && is_numeric($row['http_status']) ? (int) $row['http_status'] : 0;
+            if ($http_status >= 200 && $http_status < 300) {
+                $metrics['crawl_2xx']++;
+            } elseif ($http_status >= 300 && $http_status < 400) {
+                $metrics['crawl_3xx']++;
+            } elseif ($http_status >= 400 && $http_status < 500) {
+                $metrics['crawl_4xx']++;
+            } elseif ($http_status >= 500 && $http_status < 600) {
+                $metrics['crawl_5xx']++;
+            }
+
+            $metrics['crawl_elapsed_ms_total'] += isset($row['elapsed_ms']) && is_numeric($row['elapsed_ms']) ? (float) $row['elapsed_ms'] : 0.0;
+            $metrics['crawl_response_bytes_total'] += isset($row['response_bytes']) && is_numeric($row['response_bytes']) ? (int) $row['response_bytes'] : 0;
+        }
+
+        return [
+            'metrics' => $metrics,
+            'metadata' => [
+                'wordpress_bench_crawl' => [
+                    'schema' => 'homeboy/wordpress-bench-crawl/v1',
+                    'rows' => $rows,
+                ],
+            ],
+        ];
+    }
+}

--- a/wordpress/scripts/bench/wp-codebox-bench-crawl-helper-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-crawl-helper-smoke.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# WP Codebox generic WordPress crawl helper smoke test (homeboy-extensions#1118).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/bash-preflight.sh}"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-crawl-helper"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ -z "${HOMEBOY_WP_CODEBOX_BIN:-}" ] && ! command -v wp-codebox >/dev/null 2>&1; then
+    echo "ERROR: wp-codebox not installed." >&2
+    echo "Set HOMEBOY_WP_CODEBOX_BIN or run wordpress/scripts/build/setup.sh" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    echo "Install: brew install jq (macOS) or your package manager." >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-crawl-helper-smoke.XXXXXX")
+
+cleanup() {
+    rm -f "$RESULTS_TMPFILE"
+}
+trap cleanup EXIT
+
+echo "============================================"
+echo "WP Codebox bench crawl helper smoke test"
+echo "============================================"
+echo "Fixture:    $FIXTURE_DIR"
+echo "Iterations: 1"
+echo ""
+
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_COMPONENT_ID=bench-crawl-helper \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_RUNTIME_BASH_PREFLIGHT="$BASH_PREFLIGHT_HELPER" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+scenario='.scenarios[] | select(.id == "crawl")'
+scenario_count=$(jq -r '.scenarios | length' "$RESULTS_TMPFILE")
+if [ "$scenario_count" -ne 1 ]; then
+    echo "ERROR: expected 1 fixture workload scenario, got $scenario_count" >&2
+    exit 1
+fi
+echo "✓ scenarios length == 1 fixture workload"
+
+rows_path="$scenario | .metadata.wordpress_bench_crawl.rows"
+rows_count=$(jq -r "$rows_path | length" "$RESULTS_TMPFILE")
+if [ "$rows_count" -ne 2 ]; then
+    echo "ERROR: expected bounded crawl rows length 2, got $rows_count" >&2
+    exit 1
+fi
+echo "✓ max_requests bounds ordered crawl rows"
+
+schema=$(jq -r "$scenario | .metadata.wordpress_bench_crawl.schema" "$RESULTS_TMPFILE")
+if [ "$schema" != "homeboy/wordpress-bench-crawl/v1" ]; then
+    echo "ERROR: unexpected crawl schema $schema" >&2
+    exit 1
+fi
+echo "✓ crawl metadata schema emitted"
+
+first_route=$(jq -r "$rows_path | .[0].route" "$RESULTS_TMPFILE")
+first_request_index=$(jq -r "$rows_path | .[0].request_index" "$RESULTS_TMPFILE")
+first_batch_index=$(jq -r "$rows_path | .[0].batch_index" "$RESULTS_TMPFILE")
+if [ "$first_route" != "/" ] || [ "$first_request_index" != "0" ] || [ "$first_batch_index" != "7" ]; then
+    echo "ERROR: first row did not preserve route/request/batch indexes" >&2
+    exit 1
+fi
+echo "✓ first row preserves route, request index, and batch index"
+
+first_status=$(jq -r "$rows_path | .[0].status" "$RESULTS_TMPFILE")
+first_http_status=$(jq -r "$rows_path | .[0].http_status" "$RESULTS_TMPFILE")
+if [ "$first_status" != "ok" ] || [ "$first_http_status" -lt 200 ] || [ "$first_http_status" -ge 400 ]; then
+    echo "ERROR: first row expected ok 2xx/3xx status, got status=$first_status http=$first_http_status" >&2
+    exit 1
+fi
+echo "✓ first row captures successful HTTP result"
+
+second_status=$(jq -r "$rows_path | .[1].status" "$RESULTS_TMPFILE")
+second_http_status=$(jq -r "$rows_path | .[1].http_status" "$RESULTS_TMPFILE")
+second_failure=$(jq -r "$rows_path | .[1].failure_message" "$RESULTS_TMPFILE")
+if [ "$second_status" != "http_error" ] || [ "$second_http_status" -lt 400 ] || [ "$second_failure" = "null" ]; then
+    echo "ERROR: second row expected HTTP failure evidence, got status=$second_status http=$second_http_status failure=$second_failure" >&2
+    exit 1
+fi
+echo "✓ second row captures HTTP failure evidence"
+
+elapsed_rows=$(jq -r "$rows_path | map(select((.elapsed_ms | type) == \"number\" and .elapsed_ms >= 0)) | length" "$RESULTS_TMPFILE")
+byte_rows=$(jq -r "$rows_path | map(select(has(\"response_bytes\") and ((.response_bytes | type) == \"number\" or .response_bytes == null))) | length" "$RESULTS_TMPFILE")
+if [ "$elapsed_rows" -ne 2 ] || [ "$byte_rows" -ne 2 ]; then
+    echo "ERROR: expected elapsed_ms and optional response_bytes on both rows" >&2
+    exit 1
+fi
+echo "✓ rows include elapsed milliseconds and optional response byte counts"
+
+for metric in crawl_requests crawl_successes crawl_failures crawl_elapsed_ms_total; do
+    value=$(jq -r "$scenario | .metrics.${metric}.samples.mean // \"missing\"" "$RESULTS_TMPFILE")
+    if [ "$value" = "missing" ] || [ "$value" = "null" ]; then
+        echo "ERROR: crawl metric ${metric} missing" >&2
+        exit 1
+    fi
+done
+echo "✓ crawl metrics aggregate into bench result metrics"
+
+echo ""
+echo "============================================"
+echo "✓ WP Codebox bench crawl helper smoke test PASSED"
+echo "============================================"

--- a/wordpress/tests/fixtures/bench-crawl-helper/bench-crawl-helper.php
+++ b/wordpress/tests/fixtures/bench-crawl-helper/bench-crawl-helper.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Plugin Name: Bench Crawl Helper Fixture
+ * Description: Fixture for the generic WordPress bench crawl helper smoke test.
+ */

--- a/wordpress/tests/fixtures/bench-crawl-helper/tests/bench/crawl.php
+++ b/wordpress/tests/fixtures/bench-crawl-helper/tests/bench/crawl.php
@@ -1,0 +1,19 @@
+<?php
+/** Workload that exercises the generic WordPress bench crawl helper. */
+
+require_once '/homeboy-extension/scripts/bench/lib/wordpress-bench-crawl.php';
+
+return function (): array {
+    return homeboy_wordpress_bench_crawl_payload(
+        [
+            '/',
+            '/__homeboy-bench-crawl-helper-missing',
+            '/__homeboy-bench-crawl-helper-skipped-by-bound',
+        ],
+        [
+            'batch_index' => 7,
+            'max_requests' => 2,
+            'timeout' => 10,
+        ]
+    );
+};


### PR DESCRIPTION
## Summary
- Add a generic WordPress bench crawl helper that accepts ordered routes/URLs and returns structured per-request evidence rows.
- Mount the WordPress extension into WP Codebox bench recipes at `/homeboy-extension` so reusable bench helper libraries are available to workloads.
- Add a WP Codebox smoke fixture plus docs showing a minimal crawl workload.

Closes #1118.

## Verification
- `php -l wordpress/scripts/bench/lib/wordpress-bench-crawl.php && php -l wordpress/tests/fixtures/bench-crawl-helper/tests/bench/crawl.php && php -l wordpress/tests/fixtures/bench-crawl-helper/bench-crawl-helper.php`
- `npm run test:wp-codebox-bench-recipe-builder`
- `HOMEBOY_CORE_DIR=/Users/chubes/Developer/homeboy@fix-main-failing-tests-20260605 npm run test:wp-codebox-bench-crawl-helper`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation, tests, and PR drafting under Chris review.