### PR TITLE
fix: resolve canonical bundle outputs

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -461,10 +461,25 @@ function normalizeOutputs(result) {
   const bundle = result.metadata?.agent_runtime?.bundle || result.task_input?.agent_bundle || {};
   const configuredOutputs = bundle.engine_data_outputs && typeof bundle.engine_data_outputs === 'object' ? bundle.engine_data_outputs : {};
   const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
+  const configuredOutputSources = [
+    ...scenarios,
+    result.run?.agentResult,
+    result.agentResult,
+    result.agent_result,
+    result.metadata?.agent_runtime?.result,
+    result.outputs,
+    result.run?.agentResult?.outputs,
+    result.agentResult?.outputs,
+    result.agent_result?.outputs,
+    result.metadata?.agent_runtime?.result?.outputs,
+    workload,
+    workload.outputs,
+  ].filter((source) => source && typeof source === 'object' && !Array.isArray(source));
+  const outputSources = configuredOutputSources.flatMap((source) => [source, { metadata: source }]);
   const outputs = {};
   for (const [name, outputPath] of Object.entries(configuredOutputs)) {
-    for (const scenario of scenarios) {
-      const value = pathValue(scenario, outputPath);
+    for (const source of outputSources) {
+      const value = pathValue(source, outputPath);
       if (value !== undefined && value !== null && value !== '') {
         outputs[name] = value;
         break;

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -430,6 +430,44 @@ assert.equal(upstreamRunnerOutcome.artifacts[1].kind, 'codebox-session-artifacts
 assert.equal(upstreamRunnerOutcome.evidence_refs[0].uri, 'https://preview.example.test/sandbox-session-1');
 assert.equal(upstreamRunnerOutcome.evidence_refs[1].uri, '/tmp/wp-codebox-artifacts');
 
+const canonicalTopLevelAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  task_id: 'canonical-top-level-agent-bundle-task-123',
+  executor: { backend: 'codebox' },
+}, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  artifacts: '/tmp/wp-codebox-artifacts',
+  metadata: {
+    agent_runtime: {
+      bundle: {
+        engine_data_outputs: {
+          static_site_branch: 'metadata.engine_data.static_site_agent.branch',
+          static_site_pr_url: 'metadata.engine_data.static_site_agent.pr_url',
+          static_site_slug: 'metadata.engine_data.static_site_agent.slug',
+        },
+      },
+      workload: {
+        outputs: [],
+      },
+    },
+  },
+  outputs: {
+    engine_data: {
+      static_site_agent: {
+        branch: 'static/issue-451-design-direction',
+        pr_url: 'https://github.com/chubes4/wp-site-generator/pull/453',
+        slug: 'issue-451-design-direction',
+      },
+    },
+  },
+});
+assert.equal(canonicalTopLevelAgentBundleOutcome.status, 'succeeded');
+assert.equal(canonicalTopLevelAgentBundleOutcome.outputs.static_site_branch, 'static/issue-451-design-direction');
+assert.equal(canonicalTopLevelAgentBundleOutcome.outputs.static_site_pr_url, 'https://github.com/chubes4/wp-site-generator/pull/453');
+assert.equal(canonicalTopLevelAgentBundleOutcome.outputs.static_site_slug, 'issue-451-design-direction');
+assert.equal(canonicalTopLevelAgentBundleOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/453'), true);
+
 const singleResultAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
   task_id: 'single-result-agent-bundle-task-123',


### PR DESCRIPTION
## Summary
- Resolve configured Data Machine bundle outputs from canonical top-level `outputs.engine_data` as well as scenario metadata.
- Preserve existing direct workload outputs and scenario-based projection.
- Add smoke coverage for static-site PR output projection (`static_site_branch`, `static_site_pr_url`, `static_site_slug`).

## Verification
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigated the failed Site Generation Loop artifacts, drafted the adapter fix, and added regression smoke coverage for Chris to review/test.