### PR TITLE
Add Conductor transfer rig workloads

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -140,6 +140,62 @@ Numeric metrics are aggregated across measured iterations with the same
 mean/p50/p95/p99/min/max suffixes used by PHP bench files. Artifacts and metadata
 are carried into the Homeboy BenchResults scenario envelope.
 
+### Conductor transfer rig workloads
+
+The WordPress extension can compile Conductor transfer rig specs into configured
+WP Codebox workloads without adding Conductor semantics to Homeboy core. Declare
+one or more specs with `conductor_transfer_rigs` in the WordPress extension
+settings:
+
+```json
+{
+  "extensions": {
+    "wordpress": {
+      "settings": {
+        "conductor_transfer_rigs": ["rigs/synthetic-transfer.json"]
+      }
+    }
+  }
+}
+```
+
+Each spec may include `source_manifest`, `target_manifest`, and
+`sandbox_manifest` paths relative to the spec file. Captured-site manifests are
+sanitized and bounded before seeding. The adapter records seeded, skipped,
+blocked, and unavailable items in workload metadata, then emits normal Homeboy
+bench metrics/artifacts including a `transfer_report` artifact ref.
+
+Supported rig step types are the same configured workload surfaces:
+
+- `php` with `file` or `code`
+- `wp-cli` with `command`
+- `ability` with `ability` and optional `input`
+
+For convenience, specs may also provide `inventory_command`,
+`apply_plan_command`, `apply_command`, `review_command`, and
+`transfer_proof_command`; these become ordered `wp-cli` workload steps. Missing
+specs, missing captured manifests, or invalid setup fail before WP Codebox recipe
+generation with `conductor-transfer-rig-diagnostics.json` in the artifacts
+directory.
+
+Captured-site manifests accept simple content, options, and plugin-owned state:
+
+```json
+{
+  "posts": [
+    { "type": "page", "title": "Source page", "slug": "source-page", "content": "..." }
+  ],
+  "options": { "blogname": "Source Site" },
+  "plugin_state": [
+    { "plugin": "example-plugin", "state": { "enabled": true } }
+  ]
+}
+```
+
+Secrets, raw credentials, local paths, and private URLs are rejected from the seed
+payload. Large strings and unsupported values are skipped or marked unavailable
+instead of being written into the WP Codebox workload.
+
 Playground grader workloads may also return a normalized reward payload:
 
 ```json

--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -12,4 +12,6 @@ module.exports = {
 	...require('./lib/codebox-memory-report'),
 	...require('./lib/agent-terminal-actions'),
 	...require('./lib/wp-codebox-apply-adapter'),
+	...require('./lib/captured-site-seeding'),
+	...require('./lib/conductor-transfer-workload'),
 };

--- a/wordpress/lib/captured-site-seeding.js
+++ b/wordpress/lib/captured-site-seeding.js
@@ -1,0 +1,259 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Internal dependencies
+ */
+const { isPlainObject } = require('./shared');
+
+const DEFAULT_LIMITS = Object.freeze({
+	maxPosts: 25,
+	maxOptions: 25,
+	maxPluginState: 25,
+	maxStringBytes: 16 * 1024,
+});
+
+const SECRET_KEY_PATTERN = /(secret|token|password|passwd|credential|cookie|authorization|private[_-]?key|access[_-]?key|client[_-]?secret)/i;
+const LOCAL_PATH_PATTERN = /(^|[\s"'])((?:file:\/\/)?\/(?:Users|home|var\/www|srv|private|tmp)\/[^\s"']*)/i;
+const PRIVATE_URL_PATTERN = /https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[01])\.\d+\.\d+|[^\s/]+\.(?:local|test|internal|lan))(?:[/:?#]|$)/i;
+
+function readCapturedSiteManifest(manifestPath) {
+	if (typeof manifestPath !== 'string' || manifestPath.trim() === '') {
+		throw new TypeError('captured-site manifest path must be a non-empty string');
+	}
+	const resolved = path.resolve(manifestPath);
+	if (!fs.existsSync(resolved)) {
+		throw new Error(`captured-site manifest not found: ${resolved}`);
+	}
+	return {
+		path: resolved,
+		manifest: JSON.parse(fs.readFileSync(resolved, 'utf8')),
+	};
+}
+
+function normalizeCapturedSiteManifest(manifest, options = {}) {
+	if (!isPlainObject(manifest)) {
+		throw new TypeError('captured-site manifest must be an object');
+	}
+	const limits = { ...DEFAULT_LIMITS, ...(options.limits || {}) };
+	const summary = {
+		schema: 'homeboy/wordpress-captured-site-seed/v1',
+		role: options.role || manifest.role || 'site',
+		seeded: [],
+		skipped: [],
+		blocked: [],
+		unavailable: [],
+	};
+
+	const posts = normalizePosts(readArray(manifest, ['posts', 'content.posts', 'resources.posts']), limits, summary);
+	const optionsList = normalizeOptions(readOptions(manifest), limits, summary);
+	const pluginState = normalizePluginState(readArray(manifest, ['plugin_state', 'pluginState', 'resources.plugin_state', 'plugins']), limits, summary);
+
+	return {
+		schema: 'homeboy/wordpress-captured-site-seed/v1',
+		role: summary.role,
+		posts,
+		options: optionsList,
+		pluginState,
+		summary,
+	};
+}
+
+function buildCapturedSiteSeedWorkloadStep(seed, options = {}) {
+	if (!isPlainObject(seed) || seed.schema !== 'homeboy/wordpress-captured-site-seed/v1') {
+		throw new TypeError('captured-site seed must be normalized with normalizeCapturedSiteManifest()');
+	}
+	return {
+		type: 'php',
+		label: options.label || `Seed ${seed.role} captured site`,
+		code: buildSeedPhp(seed, options),
+	};
+}
+
+function buildCapturedSiteSeedRecipeSteps(seed) {
+	return [buildCapturedSiteSeedWorkloadStep(seed)];
+}
+
+function normalizePosts(posts, limits, summary) {
+	return posts.slice(0, limits.maxPosts).map((post, index) => {
+		if (!isPlainObject(post)) {
+			summary.skipped.push({ kind: 'post', index, reason: 'entry is not an object' });
+			return null;
+		}
+		const candidate = {
+			post_type: safeScalar(post.post_type || post.type || 'post', `posts[${index}].post_type`, summary, limits),
+			post_title: safeScalar(post.post_title || post.title || `Captured post ${index + 1}`, `posts[${index}].post_title`, summary, limits),
+			post_name: safeScalar(post.post_name || post.slug || '', `posts[${index}].post_name`, summary, limits),
+			post_status: safeScalar(post.post_status || post.status || 'publish', `posts[${index}].post_status`, summary, limits),
+			post_content: safeScalar(post.post_content || post.content || '', `posts[${index}].post_content`, summary, limits),
+		};
+		if (Object.values(candidate).some((value) => value === null)) {
+			summary.blocked.push({ kind: 'post', index, reason: 'contains private or oversized data' });
+			return null;
+		}
+		summary.seeded.push({ kind: 'post', index, post_type: candidate.post_type, post_name: candidate.post_name });
+		return candidate;
+	}).filter(Boolean);
+}
+
+function normalizeOptions(options, limits, summary) {
+	return options.slice(0, limits.maxOptions).map((entry, index) => {
+		const name = safeScalar(entry.name, `options[${index}].name`, summary, limits);
+		if (name && SECRET_KEY_PATTERN.test(name)) {
+			summary.blocked.push({ kind: 'option', index, name, reason: 'sensitive key rejected' });
+			return null;
+		}
+		const value = safeValue(entry.value, `options[${index}].value`, summary, limits);
+		if (!name || value === null) {
+			summary.blocked.push({ kind: 'option', index, name: name || '', reason: 'contains private or oversized data' });
+			return null;
+		}
+		summary.seeded.push({ kind: 'option', index, name });
+		return { name, value };
+	}).filter(Boolean);
+}
+
+function normalizePluginState(entries, limits, summary) {
+	return entries.slice(0, limits.maxPluginState).map((entry, index) => {
+		if (!isPlainObject(entry)) {
+			summary.skipped.push({ kind: 'plugin_state', index, reason: 'entry is not an object' });
+			return null;
+		}
+		const plugin = safeScalar(entry.plugin || entry.slug || entry.name || `plugin-${index + 1}`, `plugin_state[${index}].plugin`, summary, limits);
+		const state = safeValue(entry.state || entry.data || entry.options || {}, `plugin_state[${index}].state`, summary, limits);
+		if (!plugin || state === null) {
+			summary.blocked.push({ kind: 'plugin_state', index, plugin: plugin || '', reason: 'contains private or oversized data' });
+			return null;
+		}
+		summary.seeded.push({ kind: 'plugin_state', index, plugin });
+		return { plugin, state };
+	}).filter(Boolean);
+}
+
+function readOptions(manifest) {
+	const value = readPath(manifest, 'options') || readPath(manifest, 'resources.options') || [];
+	if (Array.isArray(value)) {
+		return value.map((entry) => isPlainObject(entry) ? entry : { name: '', value: entry });
+	}
+	if (isPlainObject(value)) {
+		return Object.entries(value).map(([name, optionValue]) => ({ name, value: optionValue }));
+	}
+	return [];
+}
+
+function readArray(manifest, paths) {
+	for (const candidate of paths) {
+		const value = readPath(manifest, candidate);
+		if (Array.isArray(value)) {
+			return value;
+		}
+		if (isPlainObject(value)) {
+			return Object.entries(value).map(([name, state]) => ({ name, state }));
+		}
+	}
+	return [];
+}
+
+function readPath(object, dottedPath) {
+	return dottedPath.split('.').reduce((value, key) => isPlainObject(value) ? value[key] : undefined, object);
+}
+
+function safeScalar(value, location, summary, limits) {
+	const text = String(value ?? '');
+	return safeValue(text, location, summary, limits);
+}
+
+function safeValue(value, location, summary, limits) {
+	if (value === undefined) {
+		return '';
+	}
+	if (value === null || typeof value === 'number' || typeof value === 'boolean') {
+		return value;
+	}
+	if (typeof value === 'string') {
+		if (Buffer.byteLength(value, 'utf8') > limits.maxStringBytes) {
+			summary.unavailable.push({ location, reason: 'string exceeds bounded seed size' });
+			return null;
+		}
+		if (LOCAL_PATH_PATTERN.test(value) || PRIVATE_URL_PATTERN.test(value)) {
+			summary.blocked.push({ location, reason: 'contains local path or private URL' });
+			return null;
+		}
+		return value;
+	}
+	if (Array.isArray(value)) {
+		const next = [];
+		for (let index = 0; index < value.length; index += 1) {
+			const child = safeValue(value[index], `${location}[${index}]`, summary, limits);
+			if (child === null) {
+				return null;
+			}
+			next.push(child);
+		}
+		return next;
+	}
+	if (isPlainObject(value)) {
+		const next = {};
+		for (const [key, childValue] of Object.entries(value)) {
+			if (SECRET_KEY_PATTERN.test(key)) {
+				summary.blocked.push({ location: `${location}.${key}`, reason: 'sensitive key rejected' });
+				return null;
+			}
+			const child = safeValue(childValue, `${location}.${key}`, summary, limits);
+			if (child === null) {
+				return null;
+			}
+			next[key] = child;
+		}
+		return next;
+	}
+	summary.skipped.push({ location, reason: `unsupported value type ${typeof value}` });
+	return null;
+}
+
+function buildSeedPhp(seed, options = {}) {
+	const summaryOption = options.summaryOption || `homeboy_captured_site_seed_${seed.role}`;
+	const payload = JSON.stringify(seed);
+	return `
+$seed = json_decode('${phpSingleQuoted(payload)}', true);
+$summary = $seed['summary'];
+foreach ($seed['posts'] as $post) {
+    wp_insert_post($post, true);
+}
+foreach ($seed['options'] as $option) {
+    update_option($option['name'], $option['value'], false);
+}
+foreach ($seed['pluginState'] as $state) {
+    update_option('homeboy_seed_' . sanitize_key($seed['role']) . '_' . sanitize_key($state['plugin']), $state['state'], false);
+}
+update_option('${phpSingleQuoted(summaryOption)}', $summary, false);
+return array(
+    'metrics' => array(
+        'seeded_posts' => count($seed['posts']),
+        'seeded_options' => count($seed['options']),
+        'seeded_plugin_state' => count($seed['pluginState']),
+        'blocked_seed_items' => count($summary['blocked']),
+        'skipped_seed_items' => count($summary['skipped']),
+    ),
+    'metadata' => array(
+        'captured_site_seed' => $summary,
+    ),
+);
+`;
+}
+
+function phpSingleQuoted(value) {
+	return String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+module.exports = {
+	buildCapturedSiteSeedRecipeSteps,
+	buildCapturedSiteSeedWorkloadStep,
+	normalizeCapturedSiteManifest,
+	readCapturedSiteManifest,
+};

--- a/wordpress/lib/conductor-transfer-workload.js
+++ b/wordpress/lib/conductor-transfer-workload.js
@@ -1,0 +1,268 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Internal dependencies
+ */
+const {
+	buildCapturedSiteSeedWorkloadStep,
+	normalizeCapturedSiteManifest,
+	readCapturedSiteManifest,
+} = require('./captured-site-seeding');
+const { isPlainObject } = require('./shared');
+
+function compileConductorTransferRigs(options = {}) {
+	const componentPath = path.resolve(requiredString(options.componentPath, 'componentPath'));
+	const entries = normalizeEntries(options.rigs || options.specs || []);
+	const workloads = [];
+	const diagnostics = [];
+
+	for (const [index, entry] of entries.entries()) {
+		const { spec, specPath } = loadRigSpec(entry, componentPath, index);
+		workloads.push(buildConductorTransferWorkload(spec, {
+			componentPath,
+			specPath,
+			artifactDir: options.artifactDir,
+			index,
+			diagnostics,
+		}));
+	}
+
+	return {
+		schema: 'homeboy/wordpress-conductor-transfer-rigs/v1',
+		workloads,
+		diagnostics,
+	};
+}
+
+function buildConductorTransferWorkload(spec, context = {}) {
+	if (!isPlainObject(spec)) {
+		throw new TypeError('Conductor transfer rig spec must be an object');
+	}
+	const id = sanitizeId(spec.id || spec.slug || spec.label || `conductor-transfer-${context.index + 1}`);
+	const run = [];
+	const metadata = {
+		adapter: 'homeboy-wordpress-conductor-transfer-rig',
+		adapter_schema: 'homeboy/wordpress-conductor-transfer-workload/v1',
+		family: spec.family || 'synthetic-transfer',
+		spec_path: context.specPath ? path.relative(context.componentPath, context.specPath) : '',
+	};
+
+	for (const role of ['source', 'target', 'sandbox']) {
+		const manifestPath = manifestPathForRole(spec, role);
+		if (!manifestPath) {
+			continue;
+		}
+		const manifestBasePath = context.specPath ? path.dirname(context.specPath) : context.componentPath;
+		const resolved = resolveUnderComponent(context.componentPath, manifestBasePath, manifestPath, `${role} captured-site manifest`);
+		const { manifest } = readCapturedSiteManifest(resolved);
+		const seed = normalizeCapturedSiteManifest(manifest, { role });
+		run.push(buildCapturedSiteSeedWorkloadStep(seed, { label: `Seed ${role} runtime` }));
+		metadata[`${role}_seed`] = seed.summary;
+	}
+
+	for (const step of normalizeRigSteps(spec)) {
+		run.push(normalizeRigStep(step));
+	}
+
+	if (run.length === 0) {
+		run.push({
+			type: 'php',
+			label: 'Synthetic Conductor transfer fixture',
+			code: syntheticTransferPhp(id),
+		});
+	}
+
+	run.push({
+		type: 'php',
+		role: 'grader',
+		label: 'Conductor transfer workload summary',
+		code: summaryPhp(id),
+	});
+
+	return {
+		id,
+		label: spec.label || id,
+		run,
+		artifacts: {
+			transfer_report: {
+				path: `wp-content/homeboy-conductor-transfer/${id}-report.json`,
+				kind: 'json',
+				label: 'Conductor transfer workload report',
+			},
+			...(isPlainObject(spec.artifacts) ? spec.artifacts : {}),
+		},
+		metadata: {
+			...metadata,
+			...(isPlainObject(spec.metadata) ? spec.metadata : {}),
+		},
+	};
+}
+
+function normalizeRigSteps(spec) {
+	let explicit = [];
+	if (Array.isArray(spec.run)) {
+		explicit = spec.run;
+	} else if (Array.isArray(spec.steps)) {
+		explicit = spec.steps;
+	}
+	const derived = [];
+	for (const [field, label] of [
+		['inventory_command', 'Playground Site Sync inventory'],
+		['apply_plan_command', 'Playground Site Sync apply plan'],
+		['apply_command', 'Playground Site Sync apply'],
+		['review_command', 'Conductor review'],
+		['transfer_proof_command', 'WP Codebox transfer proof'],
+	]) {
+		if (typeof spec[field] === 'string' && spec[field].trim()) {
+			derived.push({ type: 'wp-cli', command: spec[field], label });
+		}
+	}
+	return [...derived, ...explicit];
+}
+
+function normalizeRigStep(step) {
+	if (!isPlainObject(step)) {
+		throw new TypeError('Conductor transfer rig steps must be objects');
+	}
+	let type = step.type;
+	if (!type && step.ability) {
+		type = 'ability';
+	} else if (!type && step.command) {
+		type = 'wp-cli';
+	} else if (!type) {
+		type = 'php';
+	}
+	if (type === 'wp-cli') {
+		return copyStep(step, ['type', 'command', 'label', 'role', 'grader']);
+	}
+	if (type === 'ability') {
+		return copyStep(step, ['type', 'ability', 'input', 'user', 'label', 'role', 'grader']);
+	}
+	if (type === 'php') {
+		if (!step.file && !step.code) {
+			throw new Error('Conductor transfer rig PHP steps require file or code');
+		}
+		return copyStep(step, ['type', 'file', 'code', 'label', 'role', 'grader']);
+	}
+	throw new Error(`Unsupported Conductor transfer rig step type: ${type}`);
+}
+
+function manifestPathForRole(spec, role) {
+	const manifests = spec.captured_manifests || spec.capturedManifests || spec.manifests || {};
+	return spec[`${role}_manifest`] || spec[`${role}Manifest`] || manifests[role];
+}
+
+function loadRigSpec(entry, componentPath, index) {
+	if (typeof entry === 'string') {
+		const specPath = resolveUnderComponent(componentPath, componentPath, entry, `Conductor transfer rig spec ${index + 1}`);
+		return { specPath, spec: JSON.parse(fs.readFileSync(specPath, 'utf8')) };
+	}
+	if (isPlainObject(entry) && typeof entry.path === 'string') {
+		const specPath = resolveUnderComponent(componentPath, componentPath, entry.path, `Conductor transfer rig spec ${index + 1}`);
+		const spec = { ...JSON.parse(fs.readFileSync(specPath, 'utf8')), ...(isPlainObject(entry.overrides) ? entry.overrides : {}) };
+		return { specPath, spec };
+	}
+	if (isPlainObject(entry)) {
+		return { specPath: '', spec: entry };
+	}
+	throw new TypeError(`Conductor transfer rig entry ${index + 1} must be a path string or object`);
+}
+
+function resolveUnderComponent(componentPath, basePath, ref, label) {
+	if (typeof ref !== 'string' || ref.trim() === '') {
+		throw new TypeError(`${label} must be a non-empty path string`);
+	}
+	const resolved = path.resolve(path.isAbsolute(ref) ? ref : path.join(basePath, ref));
+	if (resolved !== componentPath && !resolved.startsWith(`${componentPath}${path.sep}`)) {
+		throw new Error(`${label} must stay under component root: ${ref}`);
+	}
+	if (!fs.existsSync(resolved)) {
+		throw new Error(`${label} not found: ${resolved}`);
+	}
+	return resolved;
+}
+
+function normalizeEntries(entries) {
+	if (entries === undefined || entries === null || entries === '') {
+		return [];
+	}
+	if (Array.isArray(entries)) {
+		return entries;
+	}
+	return [entries];
+}
+
+function copyStep(source, keys) {
+	const target = {};
+	for (const key of keys) {
+		if (source[key] !== undefined) {
+			target[key] = source[key];
+		}
+	}
+	return target;
+}
+
+function requiredString(value, name) {
+	if (typeof value !== 'string' || value.trim() === '') {
+		throw new TypeError(`${name} must be a non-empty string`);
+	}
+	return value;
+}
+
+function sanitizeId(value) {
+	return String(value).trim().toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'conductor-transfer';
+}
+
+function syntheticTransferPhp(id) {
+	return `
+update_option('homeboy_conductor_transfer_${phpSingleQuoted(id)}_synthetic_ready', 1, false);
+return array(
+    'metrics' => array('synthetic_transfer_ready' => 1),
+    'metadata' => array('conductor_transfer_family' => 'synthetic-transfer'),
+);
+`;
+}
+
+function summaryPhp(id) {
+	return `
+$report_dir = WP_CONTENT_DIR . '/homeboy-conductor-transfer';
+if (!is_dir($report_dir)) {
+    wp_mkdir_p($report_dir);
+}
+$report = array(
+    'schema' => 'homeboy/wordpress-conductor-transfer-report/v1',
+    'id' => '${phpSingleQuoted(id)}',
+    'generated_at' => gmdate('c'),
+    'status' => 'passed',
+);
+file_put_contents($report_dir . '/${phpSingleQuoted(id)}-report.json', wp_json_encode($report, JSON_PRETTY_PRINT));
+return array(
+    'success' => true,
+    'reward' => 1,
+    'done' => true,
+    'grade' => array(
+        'score' => 1,
+        'max_score' => 1,
+        'checks' => array(array('id' => 'conductor_transfer_workload_completed', 'passed' => true, 'score' => 1, 'max_score' => 1)),
+    ),
+    'metrics' => array('conductor_transfer_completed' => 1),
+    'artifacts' => array('transfer_report' => 'wp-content/homeboy-conductor-transfer/${phpSingleQuoted(id)}-report.json'),
+    'metadata' => array('conductor_transfer_report' => $report),
+);
+`;
+}
+
+function phpSingleQuoted(value) {
+	return String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+module.exports = {
+	buildConductorTransferWorkload,
+	compileConductorTransferRigs,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -19,7 +19,9 @@
     "./wp-codebox-apply-adapter": "./lib/wp-codebox-apply-adapter.js",
     "./wp-codebox-browser-metrics": "./lib/wp-codebox-browser-metrics.js",
     "./audit-wp-codebox-fanout": "./lib/audit-wp-codebox-fanout.js",
-    "./codebox-agent-task-executor": "./lib/codebox-agent-task-executor.js"
+    "./codebox-agent-task-executor": "./lib/codebox-agent-task-executor.js",
+    "./captured-site-seeding": "./lib/captured-site-seeding.js",
+    "./conductor-transfer-workload": "./lib/conductor-transfer-workload.js"
   },
   "scripts": {
     "lint:js": "eslint",
@@ -44,6 +46,8 @@
     "test:wp-codebox-prepared-dependency-cache": "bash tests/prepared-bench-dependency-cache-smoke.sh",
     "test:dependency-plugin-preflight": "bash tests/dependency-plugin-preflight-smoke.sh",
     "test:wp-codebox-bench-bootstrap-steps": "node tests/wp-codebox-bench-bootstrap-steps-smoke.js",
+    "test:captured-site-seeding": "node tests/captured-site-seeding-smoke.js",
+    "test:conductor-transfer-workload": "node tests/conductor-transfer-workload-smoke.js",
     "test:wp-codebox-bench-prepare-steps": "node tests/wp-codebox-bench-prepare-steps-smoke.js",
     "test:wp-codebox-phpunit-recipe-builder": "node tests/wp-codebox-phpunit-recipe-builder-smoke.js",
     "test:build-package-artifacts": "bash scripts/build/build-package-artifacts-smoke.sh",

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -10,6 +10,7 @@ FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 BENCH_HELPER_SH="${HOMEBOY_RUNTIME_BENCH_HELPER_SH:-${HOME}/.homeboy/runtime/bench-helper.sh}"
 BENCH_RESULTS_ARTIFACTS_HELPER="${SCRIPT_DIR}/bench-results-artifacts.sh"
 BENCH_BROWSER_METRICS_HELPER="${EXTENSION_DIR}/lib/wp-codebox-browser-metrics.js"
+CONDUCTOR_TRANSFER_RIG_COMPILER="${SCRIPT_DIR}/compile-conductor-transfer-rigs.mjs"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
 BENCH_BROWSER_TARGET_HELPER="${SCRIPT_DIR}/browser-target.sh"
 BENCH_RECIPE_BUILDER="${SCRIPT_DIR}/build-wp-codebox-bench-recipe.mjs"
@@ -610,6 +611,72 @@ homeboy_wp_codebox_compile_scenario_manifests() {
     done < <(printf '%s' "$entries_json" | jq -c '.[]')
 }
 
+homeboy_wp_codebox_compile_conductor_transfer_rigs() {
+    local entries_json
+    entries_json=$(printf '%s' "$settings_json" | jq -c '
+        .conductor_transfer_rigs // .conductor_transfer_specs // .wp_codebox_conductor_transfer_rigs // []
+        | if type == "array" then . elif type == "string" or type == "object" then [.] else [] end
+    ' 2>/dev/null || echo '[]')
+
+    CONDUCTOR_TRANSFER_WORKLOADS_JSON="[]"
+    if ! printf '%s' "$entries_json" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+        return 0
+    fi
+    if [ ! -f "$CONDUCTOR_TRANSFER_RIG_COMPILER" ]; then
+        echo "Error: Conductor transfer rig compiler not found: ${CONDUCTOR_TRANSFER_RIG_COMPILER}" >&2
+        FAILED_STEP="Conductor transfer rig setup"
+        exit 1
+    fi
+
+    local compiler_input compiler_output compiler_error
+    compiler_input=$(mktemp "${TMPDIR:-/tmp}/homeboy-conductor-transfer-input.XXXXXX")
+    compiler_output=$(mktemp "${TMPDIR:-/tmp}/homeboy-conductor-transfer-output.XXXXXX")
+    compiler_error=$(mktemp "${TMPDIR:-/tmp}/homeboy-conductor-transfer-error.XXXXXX")
+    jq -n \
+        --arg componentPath "$PLUGIN_PATH" \
+        --arg artifactDir "$ARTIFACTS_DIR" \
+        --argjson rigs "$entries_json" \
+        '{componentPath: $componentPath, artifactDir: $artifactDir, rigs: $rigs}' > "$compiler_input"
+
+    if ! node "$CONDUCTOR_TRANSFER_RIG_COMPILER" < "$compiler_input" > "$compiler_output" 2> "$compiler_error"; then
+        mkdir -p "$ARTIFACTS_DIR"
+        cp "$compiler_error" "${ARTIFACTS_DIR}/conductor-transfer-rig-setup-error.txt"
+        jq -n \
+            --arg schema "homeboy/wordpress-bench-diagnostic/v1" \
+            --arg code "conductor-transfer-rig-setup-failed" \
+            --arg message "Conductor transfer rig setup failed before WP Codebox recipe generation." \
+            --arg stderrArtifact "${ARTIFACTS_DIR}/conductor-transfer-rig-setup-error.txt" \
+            '{
+                schema: $schema,
+                diagnostics: [{
+                    code: $code,
+                    severity: "error",
+                    phase: "setup",
+                    message: $message,
+                    artifacts: {stderr: $stderrArtifact}
+                }]
+            }' > "${ARTIFACTS_DIR}/conductor-transfer-rig-diagnostics.json"
+        echo "Conductor transfer rig setup failed before WP Codebox recipe generation." >&2
+        cat "$compiler_error" >&2
+        rm -f "$compiler_input" "$compiler_output" "$compiler_error"
+        FAILED_STEP="Conductor transfer rig setup"
+        exit 1
+    fi
+
+    if ! jq -e '.schema == "homeboy/wordpress-conductor-transfer-rigs/v1" and (.workloads | type == "array")' "$compiler_output" >/dev/null 2>&1; then
+        echo "Error: Conductor transfer rig compiler returned an invalid payload." >&2
+        cat "$compiler_output" >&2
+        rm -f "$compiler_input" "$compiler_output" "$compiler_error"
+        FAILED_STEP="Conductor transfer rig setup"
+        exit 1
+    fi
+
+    mkdir -p "$ARTIFACTS_DIR"
+    cp "$compiler_output" "${ARTIFACTS_DIR}/conductor-transfer-rig-workloads.json"
+    CONDUCTOR_TRANSFER_WORKLOADS_JSON=$(jq -c '.workloads' "$compiler_output")
+    rm -f "$compiler_input" "$compiler_output" "$compiler_error"
+}
+
 homeboy_wp_codebox_compile_scenario_manifests
 homeboy_wp_codebox_compile_bootstrap_files
 homeboy_wp_codebox_compile_bootstrap_steps
@@ -692,6 +759,8 @@ if [ "$settings_json" != "{}" ]; then
     WP_CODEBOX_WORKLOADS_JSON=$(printf '%s' "$settings_json" | jq -c '.wp_codebox_workloads // .playground_workloads // []' 2>/dev/null || echo "[]")
 fi
 WP_CODEBOX_WORKLOADS_JSON=$(jq -nc --argjson declared "$WP_CODEBOX_WORKLOADS_JSON" --argjson scenarios "$SCENARIO_MANIFEST_WORKLOADS_JSON" '$declared + $scenarios')
+homeboy_wp_codebox_compile_conductor_transfer_rigs
+WP_CODEBOX_WORKLOADS_JSON=$(jq -nc --argjson declared "$WP_CODEBOX_WORKLOADS_JSON" --argjson conductor "$CONDUCTOR_TRANSFER_WORKLOADS_JSON" '$declared + $conductor')
 
 MOUNTS_JSON="[]"
 COMPONENT_PLUGIN_FILE="$(homeboy_wp_codebox_find_plugin_file "$PLUGIN_PATH" || true)"

--- a/wordpress/scripts/bench/compile-conductor-transfer-rigs.mjs
+++ b/wordpress/scripts/bench/compile-conductor-transfer-rigs.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+/**
+ * External dependencies
+ */
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Internal dependencies
+ */
+const require = createRequire(import.meta.url);
+const { compileConductorTransferRigs } = require('../../lib/conductor-transfer-workload.js');
+
+const input = JSON.parse(readFileSync(0, 'utf8'));
+const output = compileConductorTransferRigs(input);
+process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);

--- a/wordpress/tests/captured-site-seeding-smoke.js
+++ b/wordpress/tests/captured-site-seeding-smoke.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+const {
+  buildCapturedSiteSeedWorkloadStep,
+  normalizeCapturedSiteManifest,
+} = require('../lib/captured-site-seeding');
+
+const seed = normalizeCapturedSiteManifest({
+  posts: [{ type: 'page', title: 'Public captured page', slug: 'captured-page', content: '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->' }],
+  options: {
+    blogname: 'Captured Site',
+    api_token: 'redacted-but-sensitive-key',
+    local_preview: 'http://localhost:8881/private',
+  },
+  plugin_state: [{ plugin: 'demo-plugin', state: { enabled: true, count: 3 } }],
+}, { role: 'source' });
+
+assert.equal(seed.role, 'source');
+assert.equal(seed.posts.length, 1);
+assert.equal(seed.options.length, 1);
+assert.equal(seed.options[0].name, 'blogname');
+assert.equal(seed.pluginState.length, 1);
+assert.equal(seed.summary.blocked.length >= 2, true);
+
+const step = buildCapturedSiteSeedWorkloadStep(seed);
+assert.equal(step.type, 'php');
+assert.match(step.code, /wp_insert_post/);
+assert.match(step.code, /homeboy_captured_site_seed_source/);
+assert.match(step.code, /blocked_seed_items/);
+
+console.log('captured-site seeding smoke passed');

--- a/wordpress/tests/conductor-transfer-workload-smoke.js
+++ b/wordpress/tests/conductor-transfer-workload-smoke.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { compileConductorTransferRigs } = require('../lib/conductor-transfer-workload');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-conductor-transfer-'));
+
+try {
+  const extensionPath = path.join(__dirname, '..');
+  const componentPath = path.join(root, 'conductor-transfer-fixture');
+  fs.mkdirSync(path.join(componentPath, 'rigs'), { recursive: true });
+  fs.mkdirSync(path.join(componentPath, 'tests', 'bench'), { recursive: true });
+  fs.writeFileSync(path.join(componentPath, 'conductor-transfer-fixture.php'), "<?php\n/* Plugin Name: Conductor Transfer Fixture */\n");
+
+  fs.writeFileSync(path.join(componentPath, 'rigs', 'source.json'), JSON.stringify({
+    posts: [{ type: 'page', title: 'Source page', slug: 'source-page', content: 'source' }],
+    options: { blogname: 'Source' },
+  }, null, 2));
+  fs.writeFileSync(path.join(componentPath, 'rigs', 'target.json'), JSON.stringify({
+    posts: [{ type: 'page', title: 'Target page', slug: 'target-page', content: 'target' }],
+    plugin_state: [{ plugin: 'demo-transfer-plugin', state: { imported: true } }],
+  }, null, 2));
+  fs.writeFileSync(path.join(componentPath, 'rigs', 'sandbox.json'), JSON.stringify({
+    options: { blogdescription: 'Sandbox' },
+  }, null, 2));
+  fs.writeFileSync(path.join(componentPath, 'rigs', 'transfer.json'), JSON.stringify({
+    id: 'synthetic-transfer',
+    label: 'Synthetic transfer',
+    source_manifest: 'source.json',
+    target_manifest: 'target.json',
+    sandbox_manifest: 'sandbox.json',
+    run: [{ type: 'php', code: "return ['metrics' => ['transfer_step_seen' => 1]];" }],
+  }, null, 2));
+
+  const compiled = compileConductorTransferRigs({ componentPath, rigs: ['rigs/transfer.json'] });
+  assert.equal(compiled.schema, 'homeboy/wordpress-conductor-transfer-rigs/v1');
+  assert.equal(compiled.workloads.length, 1);
+  assert.equal(compiled.workloads[0].id, 'synthetic-transfer');
+  assert.equal(compiled.workloads[0].run.filter((step) => step.type === 'php').length >= 5, true);
+  assert.equal(compiled.workloads[0].metadata.source_seed.seeded.some((entry) => entry.kind === 'post'), true);
+
+  const captureFile = path.join(root, 'captured-recipe.json');
+  const fakeWpCodebox = path.join(root, 'fixture-wp-codebox.js');
+  fs.writeFileSync(fakeWpCodebox, `#!/usr/bin/env node
+const fs = require('node:fs');
+const recipeIndex = process.argv.indexOf('--recipe');
+if (process.argv[2] !== 'recipe-run' || recipeIndex < 0) {
+  process.exit(2);
+}
+const recipe = JSON.parse(fs.readFileSync(process.argv[recipeIndex + 1], 'utf8'));
+fs.writeFileSync(process.env.HOMEBOY_CAPTURE_RECIPE, JSON.stringify(recipe, null, 2) + '\\n');
+process.stdout.write(JSON.stringify({
+  success: true,
+  benchResults: {
+    component_id: 'conductor-transfer-fixture',
+    iterations: 1,
+    warmup_iterations: 0,
+    scenarios: [{ id: 'synthetic-transfer', metrics: { conductor_transfer_completed: 1 } }]
+  }
+}) + '\\n');
+`);
+  fs.chmodSync(fakeWpCodebox, 0o755);
+
+  const benchHelper = path.join(root, 'bench-helper.sh');
+  fs.writeFileSync(benchHelper, `#!/usr/bin/env bash
+homeboy_write_empty_bench_results() {
+  local component="$1"
+  local iterations="$2"
+  local results_file="$3"
+  printf '{"component_id":"%s","iterations":%s,"scenarios":[]}\n' "$component" "$iterations" > "$results_file"
+}
+`);
+  const preflightHelper = path.join(root, 'preflight-helper.sh');
+  fs.writeFileSync(preflightHelper, `#!/usr/bin/env bash
+homeboy_require_bash_version() { :; }
+`);
+
+  const successResult = spawnSync('bash', [path.join(extensionPath, 'scripts', 'bench', 'bench-runner.sh')], {
+    cwd: componentPath,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOMEBOY_BENCH_RESULTS_FILE: path.join(root, 'results.json'),
+      HOMEBOY_BENCH_ITERATIONS: '1',
+      HOMEBOY_BENCH_WARMUP_ITERATIONS: '0',
+      HOMEBOY_CAPTURE_RECIPE: captureFile,
+      HOMEBOY_COMPONENT_ID: 'conductor-transfer-fixture',
+      HOMEBOY_COMPONENT_PATH: componentPath,
+      HOMEBOY_EXTENSION_PATH: extensionPath,
+      HOMEBOY_RUNTIME_BASH_PREFLIGHT: preflightHelper,
+      HOMEBOY_RUNTIME_BENCH_HELPER_SH: benchHelper,
+      HOMEBOY_SETTINGS_JSON: JSON.stringify({ conductor_transfer_rigs: ['rigs/transfer.json'] }),
+      HOMEBOY_WP_CODEBOX_BIN: fakeWpCodebox,
+    },
+  });
+
+  assert.equal(successResult.status, 0, successResult.stderr || successResult.stdout);
+  const recipe = JSON.parse(fs.readFileSync(captureFile, 'utf8'));
+  const workloadsArg = recipe.workflow.steps[0].args.find((arg) => arg.startsWith('workloads-json='));
+  assert.ok(workloadsArg, 'expected workloads-json arg');
+  const workloads = JSON.parse(workloadsArg.slice('workloads-json='.length));
+  assert.equal(workloads[0].metadata.adapter, 'homeboy-wordpress-conductor-transfer-rig');
+  assert.equal(workloads[0].artifacts.transfer_report.kind, 'json');
+  assert.equal(workloads[0].run.some((step) => step.label === 'Seed source runtime'), true);
+
+  fs.writeFileSync(path.join(componentPath, 'rigs', 'private-source.json'), JSON.stringify({
+    options: { auth_token: 'not allowed' },
+  }, null, 2));
+  fs.writeFileSync(path.join(componentPath, 'rigs', 'private-transfer.json'), JSON.stringify({
+    id: 'private-transfer',
+    source_manifest: 'private-source.json',
+  }, null, 2));
+  const failureArtifactsDir = path.join(root, 'failure-artifacts');
+  const failureResult = spawnSync('bash', [path.join(extensionPath, 'scripts', 'bench', 'bench-runner.sh')], {
+    cwd: componentPath,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOMEBOY_BENCH_RESULTS_FILE: path.join(root, 'failure-results.json'),
+      HOMEBOY_BENCH_ITERATIONS: '1',
+      HOMEBOY_BENCH_WARMUP_ITERATIONS: '0',
+      HOMEBOY_CAPTURE_RECIPE: captureFile,
+      HOMEBOY_COMPONENT_ID: 'conductor-transfer-fixture',
+      HOMEBOY_COMPONENT_PATH: componentPath,
+      HOMEBOY_EXTENSION_PATH: extensionPath,
+      HOMEBOY_RUNTIME_BASH_PREFLIGHT: preflightHelper,
+      HOMEBOY_RUNTIME_BENCH_HELPER_SH: benchHelper,
+      HOMEBOY_SETTINGS_JSON: JSON.stringify({ conductor_transfer_rigs: ['rigs/private-transfer.json'] }),
+      HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: failureArtifactsDir,
+      HOMEBOY_WP_CODEBOX_BIN: fakeWpCodebox,
+    },
+  });
+
+  assert.equal(failureResult.status, 0, failureResult.stderr || failureResult.stdout);
+  const privateRecipe = JSON.parse(fs.readFileSync(captureFile, 'utf8'));
+  const privateWorkloadsArg = privateRecipe.workflow.steps[0].args.find((arg) => arg.startsWith('workloads-json='));
+  const privateWorkloads = JSON.parse(privateWorkloadsArg.slice('workloads-json='.length));
+  assert.equal(privateWorkloads[0].metadata.source_seed.blocked.some((entry) => /sensitive key/.test(entry.reason)), true);
+
+  console.log('conductor transfer workload smoke passed');
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- Adds WordPress extension helpers to sanitize bounded captured-site manifests and turn them into WP Codebox workload seed steps.
- Adds a Conductor transfer rig adapter that compiles rig/spec paths into existing configured WP Codebox bench workloads, metrics, metadata, and artifact refs.
- Wires `conductor_transfer_rigs` settings into the WP Codebox bench runner with setup diagnostics before recipe generation.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/1125
Closes https://github.com/Extra-Chill/homeboy-extensions/issues/1126

## Verification
- `npm run test:captured-site-seeding`
- `npm run test:conductor-transfer-workload`
- `npm run test:wp-codebox-bench-recipe-builder`
- `npm run test:wp-codebox-bench-bootstrap-steps`
- `npm run test:wp-codebox-bench-prepare-steps`
- `npm run lint:js -- lib/captured-site-seeding.js lib/conductor-transfer-workload.js scripts/bench/compile-conductor-transfer-rigs.mjs`

## Notes
- `npm run lint:js` still reports pre-existing baseline violations in unrelated files (`lib/playground-readiness.js`, `lib/request-profiler.js`, `lib/timing-correlator.js`, and agent scripts). The new/changed helper files pass targeted lint.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the WordPress extension adapter/helpers, runner integration, docs, and smoke coverage; Chris remains responsible for review and final acceptance.