### PR TITLE
Add Node trace reporter and browser waterfall helpers

### DIFF
--- a/nodejs/scripts/trace/lib/browser-waterfall.mjs
+++ b/nodejs/scripts/trace/lib/browser-waterfall.mjs
@@ -1,0 +1,140 @@
+import {
+    collectBrowserPhases,
+    normalizeBrowserNetworkRequest,
+    normalizeBrowserPerformanceProfile,
+    normalizeBrowserProfileTimings,
+    normalizeBrowserTiming,
+    stableJson,
+} from '../../../../scripts/lib/browser-result-shapes.mjs';
+
+export async function collectBrowserWaterfall(page, options = {}) {
+    if (!page || typeof page.evaluate !== 'function') {
+        throw new Error('collectBrowserWaterfall requires a Playwright/Puppeteer-like page with evaluate().');
+    }
+
+    const snapshot = await page.evaluate(browserWaterfallSnapshot);
+    return normalizeBrowserWaterfall(snapshot, options);
+}
+
+export function createBrowserWaterfallCollector(options = {}) {
+    return {
+        async collect(page = options.page, overrides = {}) {
+            return collectBrowserWaterfall(page, { ...options, ...overrides });
+        },
+        normalize(snapshot, overrides = {}) {
+            return normalizeBrowserWaterfall(snapshot, { ...options, ...overrides });
+        },
+    };
+}
+
+export function normalizeBrowserWaterfall(snapshot, options = {}) {
+    const source = snapshot && typeof snapshot === 'object' && !Array.isArray(snapshot) ? snapshot : {};
+    const resources = Array.isArray(source.resources) ? source.resources : [];
+    const network = Array.isArray(source.network) ? source.network : [];
+    const phaseMarks = Array.isArray(source.phase_marks) ? source.phase_marks : [];
+    const profile = normalizeBrowserPerformanceProfile({
+        ...source,
+        resources,
+        network,
+        phase_marks: phaseMarks,
+        phases: source.phases || collectBrowserPhases(phaseMarks),
+    });
+    const rows = normalizeBrowserProfileTimings(profile, options)
+        .map((entry) => normalizeBrowserTiming(entry, options))
+        .filter(Boolean)
+        .map((entry) => normalizeWaterfallRow(entry))
+        .sort(compareRows);
+
+    return stableJson({
+        schema: 'homeboy/browser-waterfall/v1',
+        page_url: source.page_url || source.url || '',
+        summary: summarizeWaterfall(rows, profile),
+        rows,
+        profile,
+    });
+}
+
+export function browserWaterfallSnapshot() {
+    const serializeTiming = (entry) => {
+        const json = typeof entry.toJSON === 'function' ? entry.toJSON() : {};
+        return {
+            ...json,
+            name: entry.name,
+            initiatorType: entry.initiatorType,
+            startTime: entry.startTime,
+            duration: entry.duration,
+            fetchStart: entry.fetchStart,
+            requestStart: entry.requestStart,
+            responseStart: entry.responseStart,
+            responseEnd: entry.responseEnd,
+            transferSize: entry.transferSize,
+            encodedBodySize: entry.encodedBodySize,
+            decodedBodySize: entry.decodedBodySize,
+        };
+    };
+    const navigation = performance.getEntriesByType('navigation').map(serializeTiming);
+    const resources = performance.getEntriesByType('resource').map(serializeTiming);
+    const paints = performance.getEntriesByType('paint').map(serializeTiming);
+
+    return {
+        page_url: window.location.href,
+        navigation,
+        resources,
+        paints,
+        phase_marks: [
+            { name: 'navigation_start', start_time_ms: 0 },
+            ...paints.map((entry) => ({ name: entry.name, start_time_ms: entry.startTime })),
+        ],
+        summary: {
+            navigation_count: navigation.length,
+            resource_count: resources.length,
+            paint_count: paints.length,
+        },
+    };
+}
+
+function normalizeWaterfallRow(entry) {
+    const request = normalizeBrowserNetworkRequest(entry);
+    return stableJson({
+        url: entry.url,
+        normalized_url: entry.normalizedUrl,
+        method: request.method || entry.method,
+        status: request.status ?? entry.status,
+        failed: Boolean(entry.failed),
+        resource_type: request.resource_type || entry.initiatorType,
+        initiator_type: entry.initiatorType,
+        phase: entry.phase,
+        start_time_ms: entry.startTime,
+        ttfb_ms: entry.ttfbMs,
+        duration_ms: entry.durationMs,
+        transfer_size_bytes: finiteOrNull(entry.raw?.transferSize ?? entry.transferSize),
+        encoded_body_size_bytes: finiteOrNull(entry.raw?.encodedBodySize ?? entry.encodedBodySize),
+        decoded_body_size_bytes: finiteOrNull(entry.raw?.decodedBodySize ?? entry.decodedBodySize),
+    });
+}
+
+function summarizeWaterfall(rows, profile) {
+    const failedRows = rows.filter((row) => row.failed || (typeof row.status === 'number' && row.status >= 400));
+    const totalTransferSize = rows.reduce((total, row) => total + (row.transfer_size_bytes || 0), 0);
+    const slowest = rows.reduce((current, row) => {
+        if (!current || (row.duration_ms || 0) > (current.duration_ms || 0)) return row;
+        return current;
+    }, null);
+
+    return stableJson({
+        request_count: rows.length,
+        failed_request_count: failedRows.length,
+        transfer_size_bytes: totalTransferSize,
+        slowest_request_ms: slowest?.duration_ms ?? null,
+        slowest_request_url: slowest?.normalized_url || slowest?.url || null,
+        resource_count: Array.isArray(profile.resources) ? profile.resources.length : rows.length,
+    });
+}
+
+function compareRows(a, b) {
+    return (a.start_time_ms ?? 0) - (b.start_time_ms ?? 0) || String(a.url).localeCompare(String(b.url));
+}
+
+function finiteOrNull(value) {
+    return typeof value === 'number' && Number.isFinite(value) ? Math.round(value * 1000) / 1000 : null;
+}

--- a/nodejs/scripts/trace/lib/timeline.mjs
+++ b/nodejs/scripts/trace/lib/timeline.mjs
@@ -26,7 +26,7 @@ export class TraceRecorder {
     }
 
     async recordEvent(source, event, data = {}) {
-        const entry = normalizeTraceEvent(source || 'scenario', event, data, this.timestampMs());
+        const entry = normalizeTraceEvent(source || 'scenario', event, redactSensitiveValue(data), this.timestampMs());
 
         this.timeline.push(entry);
         await mkdir(dirname(this.timelinePath), { recursive: true });
@@ -36,7 +36,7 @@ export class TraceRecorder {
     }
 
     recordAssertion(id, status, message, data = undefined) {
-        const assertion = normalizeTraceAssertion(id, status, message, data);
+        const assertion = normalizeTraceAssertion(id, status, message, redactSensitiveValue(data));
         this.assertions.push(assertion);
         return assertion;
     }
@@ -46,6 +46,10 @@ export class TraceRecorder {
     }
 
     addArtifact(label, path, kind = undefined) {
+        if (!path || typeof path !== 'string') {
+            throw new Error('Trace artifact requires a non-empty path.');
+        }
+
         const artifact = normalizeBrowserArtifact({ label, path: artifactRelativePath(path), kind });
 
         if (!this.artifacts.some((existing) => existing.label === artifact.label && existing.path === artifact.path)) {
@@ -74,7 +78,8 @@ export class TraceRecorder {
             timeline: this.timeline,
             assertions: this.assertions,
             artifacts: this.artifacts,
-            failure: options.failure,
+            metrics: redactSensitiveValue(options.metrics),
+            failure: normalizeFailure(options.failure),
         });
 
         await mkdir(dirname(this.resultsFile), { recursive: true });
@@ -85,6 +90,55 @@ export class TraceRecorder {
 
 export function createTraceRecorder(options = {}) {
     return new TraceRecorder(options);
+}
+
+export function createTraceReporter(options = {}) {
+    const recorder = new TraceRecorder(options);
+    const pendingEvents = [];
+
+    return {
+        get recorder() {
+            return recorder;
+        },
+        get timeline() {
+            return recorder.timeline;
+        },
+        get assertions() {
+            return recorder.assertions;
+        },
+        get artifacts() {
+            return recorder.artifacts;
+        },
+        mark(name, data = {}, source = 'scenario') {
+            const promise = recorder.recordEvent(source, name, data);
+            pendingEvents.push(promise);
+            return promise;
+        },
+        artifact({ path, kind, label } = {}) {
+            return recorder.addArtifact(label || kind || 'artifact', path, kind);
+        },
+        assertion({ id, status, message, data } = {}) {
+            return recorder.recordAssertion(id, status, message, data);
+        },
+        async pass(metrics = {}, options = {}) {
+            await Promise.all(pendingEvents);
+            return recorder.writeTraceResults({
+                ...options,
+                status: 'pass',
+                metrics,
+            });
+        },
+        async fail(error, metrics = {}, options = {}) {
+            await Promise.all(pendingEvents);
+            return recorder.writeTraceResults({
+                ...options,
+                status: options.status || 'fail',
+                summary: options.summary || failureMessage(error),
+                failure: error,
+                metrics,
+            });
+        },
+    };
 }
 
 function deriveStatus(assertions) {
@@ -102,4 +156,39 @@ function defaultSummary(status) {
         case 'error': return 'Trace errored';
         default: return 'Trace completed with unknown evidence';
     }
+}
+
+function normalizeFailure(error) {
+    if (error === undefined || error === null) return undefined;
+    if (error instanceof Error) {
+        return redactSensitiveValue({
+            name: error.name,
+            message: error.message,
+            stack: error.stack,
+        });
+    }
+    if (typeof error === 'object') return redactSensitiveValue(error);
+    return { message: String(error) };
+}
+
+function failureMessage(error) {
+    if (error instanceof Error) return error.message;
+    return String(error || 'Trace failed');
+}
+
+function redactSensitiveValue(value, depth = 0) {
+    if (depth > 8) return '[Redacted:depth]';
+    if (Array.isArray(value)) return value.map((item) => redactSensitiveValue(item, depth + 1));
+    if (!value || typeof value !== 'object') return value;
+
+    return Object.fromEntries(
+        Object.entries(value).map(([key, item]) => [
+            key,
+            isSensitiveKey(key) ? '[Redacted]' : redactSensitiveValue(item, depth + 1),
+        ])
+    );
+}
+
+function isSensitiveKey(key) {
+    return /(?:token|secret|password|passwd|authorization|cookie|api[_-]?key|private[_-]?key|credential)/i.test(String(key));
 }

--- a/nodejs/scripts/trace/trace-helpers-smoke.mjs
+++ b/nodejs/scripts/trace/trace-helpers-smoke.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const root = await mkdtemp(path.join(tmpdir(), 'homeboy-node-trace-helpers-'));
+const artifactDir = path.join(root, 'artifacts');
+const resultsFile = path.join(root, 'trace-results.json');
+process.env.HOMEBOY_TRACE_ARTIFACT_DIR = artifactDir;
+
+try {
+    const { createTraceReporter } = await import('./lib/timeline.mjs');
+    const { createBrowserWaterfallCollector, normalizeBrowserWaterfall } = await import('./lib/browser-waterfall.mjs');
+
+    const artifactPath = path.join(artifactDir, 'metrics.json');
+    await mkdir(artifactDir, { recursive: true });
+    await writeFile(artifactPath, '{"ok":true}\n');
+
+    const reporter = createTraceReporter({
+        componentId: 'fixture-component',
+        scenarioId: 'fixture-scenario',
+        resultsFile,
+    });
+
+    reporter.mark('start', { token: 'secret-token', safe: 'value' });
+    reporter.artifact({ label: 'Metrics', path: artifactPath, kind: 'json' });
+    reporter.assertion({ id: 'fixture-check', status: 'pass', message: 'Fixture passed.', data: { password: 'secret', visible: true } });
+    assert.throws(() => reporter.artifact({ label: 'Missing path' }), /non-empty path/);
+    const passEnvelope = await reporter.pass({ request_count: 2, apiKey: 'secret-key' }, { summary: 'Fixture trace passed.' });
+
+    assert.equal(passEnvelope.status, 'pass');
+    assert.equal(passEnvelope.component_id, 'fixture-component');
+    assert.equal(passEnvelope.artifacts.find((artifact) => artifact.label === 'Metrics')?.path, 'metrics.json');
+    assert.equal(passEnvelope.artifacts.find((artifact) => artifact.label === 'timeline')?.path, 'trace.jsonl');
+    assert.equal(passEnvelope.timeline[0].data.token, '[Redacted]');
+    assert.equal(passEnvelope.assertions[0].data.password, '[Redacted]');
+    assert.equal(passEnvelope.metrics.apiKey, '[Redacted]');
+
+    const written = JSON.parse(await readFile(resultsFile, 'utf8'));
+    assert.deepEqual(written, passEnvelope);
+
+    const failReporter = createTraceReporter({
+        componentId: 'fixture-component',
+        scenarioId: 'fixture-fail',
+        resultsFile: path.join(root, 'trace-fail.json'),
+    });
+    const failEnvelope = await failReporter.fail(new Error('boom'), { failed: true });
+    assert.equal(failEnvelope.status, 'fail');
+    assert.equal(failEnvelope.failure.message, 'boom');
+
+    const snapshot = {
+        page_url: 'https://example.test/wp-admin/site-editor.php',
+        resources: [
+            {
+                name: 'https://example.test/wp-json/wp/v2/pages?context=edit',
+                initiatorType: 'fetch',
+                startTime: 120,
+                requestStart: 122,
+                responseStart: 150,
+                responseEnd: 210,
+                duration: 90,
+                transferSize: 2048,
+                encodedBodySize: 1024,
+                decodedBodySize: 4096,
+            },
+            {
+                name: 'https://example.test/wp-content/app.js',
+                initiatorType: 'script',
+                startTime: 30,
+                responseStart: 35,
+                responseEnd: 55,
+                duration: 25,
+                transferSize: 512,
+            },
+        ],
+        phase_marks: [
+            { name: 'boot', start_time_ms: 0 },
+            { name: 'editor_ready', start_time_ms: 100 },
+        ],
+    };
+
+    const waterfall = normalizeBrowserWaterfall(snapshot);
+    assert.equal(waterfall.schema, 'homeboy/browser-waterfall/v1');
+    assert.equal(waterfall.summary.request_count, 2);
+    assert.equal(waterfall.summary.transfer_size_bytes, 2560);
+    assert.equal(waterfall.rows[0].resource_type, 'script');
+    assert.equal(waterfall.rows[1].phase, 'editor_ready');
+    assert.equal(waterfall.rows[1].ttfb_ms, 30);
+
+    const fakePage = {
+        async evaluate(fn) {
+            assert.equal(fn.name, 'browserWaterfallSnapshot');
+            return snapshot;
+        },
+    };
+    const collector = createBrowserWaterfallCollector({ page: fakePage });
+    const collected = await collector.collect();
+    assert.deepEqual(collected, waterfall);
+
+    console.log('nodejs trace helpers smoke passed');
+} finally {
+    await rm(root, { recursive: true, force: true });
+}

--- a/scripts/lib/browser-result-shapes.cjs
+++ b/scripts/lib/browser-result-shapes.cjs
@@ -225,6 +225,7 @@ function normalizeTraceEnvelope(envelope) {
 		assertions: Array.isArray(source.assertions) ? source.assertions.map((assertion) => stableJson(assertion)) : [],
 		artifacts: Array.isArray(source.artifacts) ? source.artifacts.map(normalizeBrowserArtifact) : [],
 	};
+	if (source.metrics !== undefined) normalized.metrics = stableJson(source.metrics);
 	if (source.failure !== undefined) normalized.failure = source.failure;
 	return stableJson(normalized);
 }


### PR DESCRIPTION
## Summary
- Add reusable Node trace reporter helpers on top of the existing trace recorder, including metrics, artifacts, assertions, failure envelopes, and sensitive-key redaction.
- Add a reusable browser waterfall collector/normalizer for Playwright/Puppeteer-style pages and raw browser performance snapshots.
- Add a Node smoke that covers pass/fail envelopes, relative artifacts, redaction, un-awaited marks, assertion handling, and waterfall collection.

## Notes
- Closes #1133.
- Refs #1132 per the requested tracker scope, but #1132 currently describes WordPress fixture plugin install/restore rather than browser waterfall helpers. This PR implements the requested waterfall/reporter scope without closing the fixture-plugin tracker.
- Aligns with Extra-Chill/homeboy#3594 by keeping the schema product-neutral and extending the existing browser-result-shapes envelope with metrics.

## Testing
- `node nodejs/scripts/trace/trace-helpers-smoke.mjs`
- `node nodejs/scripts/bench/browser-profile-diff-smoke.mjs`
- `node tests/structured-sidecars-smoke.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the reusable Node/browser waterfall collector helpers, trace reporter wrapper, and smoke coverage; Chris remains responsible for review and merge.