### PR TITLE
Fix WP Codebox bench default runtime

### DIFF
--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -216,7 +216,7 @@ PHP
         --arg providerSlugs "$provider_slugs_csv" \
         '{
             schema: "wp-codebox/workspace-recipe/v1",
-            runtime: {wp: $wp, blueprint: {steps: []}},
+            runtime: ({blueprint: {steps: []}} + (if $wp == "" then {} else {wp: $wp} end)),
             inputs: {extraPlugins: $extraPlugins, mounts: $mounts, secretEnv: $secretEnv},
             workflow: {steps: [{command: "wp-codebox.agent-sandbox-run", args: ["task=" + $task, "code-file=" + $codeFile, "provider-plugin-slugs=" + $providerSlugs]}]}
         }' >"$recipe_file"
@@ -901,7 +901,7 @@ fi
 
 WORKLOAD_ID=$(jq -r '.workload_id // "datamachine-agent"' "$CONFIG_PATH")
 WORKLOAD_LABEL=$(jq -r '.workload_label // "Run Data Machine agent"' "$CONFIG_PATH")
-WP_CODEBOX_WORDPRESS_VERSION=$(jq -r '.wp_codebox_wordpress_version // "7.0"' "$CONFIG_PATH")
+WP_CODEBOX_WORDPRESS_VERSION=$(jq -r '.wp_codebox_wordpress_version // ""' "$CONFIG_PATH")
 ENABLE_TERMINAL_ACTIONS=$(jq -r 'if (.enable_terminal_actions // .enable_wp_cli_tool // false) then "1" else "0" end' <<<"$CONFIG_JSON")
 if [ "$ENABLE_TERMINAL_ACTIONS" = "1" ]; then
     if [ -z "$RUNTIME_DIR" ]; then

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -615,7 +615,7 @@ homeboy_wp_codebox_compile_bootstrap_files
 homeboy_wp_codebox_compile_bootstrap_steps
 homeboy_wp_codebox_compile_prepare_steps
 
-WP_CODEBOX_WORDPRESS_VERSION="7.0"
+WP_CODEBOX_WORDPRESS_VERSION="latest"
 if [ "$settings_json" != "{}" ]; then
     extracted=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_wordpress_version // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_WORDPRESS_VERSION="$extracted"

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -648,6 +648,7 @@ fi
 if [ -z "$ARTIFACTS_DIR" ]; then
     ARTIFACTS_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-bench-artifacts.XXXXXX")
 fi
+mkdir -p "$ARTIFACTS_DIR"
 
 homeboy_wp_codebox_run_prepare_steps
 
@@ -896,7 +897,7 @@ homeboy_wp_codebox_emit_memory_fatal_diagnostic() {
     echo "  Raw output: $output_artifact" >&2
 }
 
-RECIPE_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-bench-recipe.XXXXXX")
+RECIPE_FILE=$(mktemp "${ARTIFACTS_DIR}/homeboy-wp-codebox-bench-recipe.XXXXXX")
 jq -n \
     --arg wpCodeboxBin "$WP_CODEBOX_RESOLVED_BIN" \
     --arg wp "$WP_CODEBOX_WORDPRESS_VERSION" \
@@ -933,7 +934,7 @@ jq -n \
         }
     }' | node "$BENCH_RECIPE_BUILDER" > "$RECIPE_FILE"
 
-WP_CODEBOX_TMPFILE=$(mktemp)
+WP_CODEBOX_TMPFILE=$(mktemp "${ARTIFACTS_DIR}/homeboy-wp-codebox-output.XXXXXX")
 set +e
 "${wp_codebox_command[@]}" recipe-run \
     --recipe "$RECIPE_FILE" \

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -615,7 +615,7 @@ homeboy_wp_codebox_compile_bootstrap_files
 homeboy_wp_codebox_compile_bootstrap_steps
 homeboy_wp_codebox_compile_prepare_steps
 
-WP_CODEBOX_WORDPRESS_VERSION="latest"
+WP_CODEBOX_WORDPRESS_VERSION=""
 if [ "$settings_json" != "{}" ]; then
     extracted=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_wordpress_version // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_WORDPRESS_VERSION="$extracted"
@@ -917,8 +917,7 @@ jq -n \
     --argjson pluginRuntime "$WP_CODEBOX_PLUGIN_RUNTIME_JSON" \
     '{
         wpCodeboxBin: $wpCodeboxBin,
-        options: {
-            wordpressVersion: $wp,
+        options: ({
             blueprint: $blueprint,
             mounts: $mounts,
             extraPlugins: $extraPlugins,
@@ -932,7 +931,7 @@ jq -n \
             pluginRuntime: $pluginRuntime,
             bootstrapFiles: $bootstrapFiles,
             workloads: $workloads
-        }
+        } + (if $wp == "" then {} else {wordpressVersion: $wp} end))
     }' | node "$BENCH_RECIPE_BUILDER" > "$RECIPE_FILE"
 
 WP_CODEBOX_TMPFILE=$(mktemp "${ARTIFACTS_DIR}/homeboy-wp-codebox-output.XXXXXX")

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -615,7 +615,7 @@ homeboy_wp_codebox_compile_bootstrap_files
 homeboy_wp_codebox_compile_bootstrap_steps
 homeboy_wp_codebox_compile_prepare_steps
 
-WP_CODEBOX_WORDPRESS_VERSION="latest"
+WP_CODEBOX_WORDPRESS_VERSION="6.9"
 if [ "$settings_json" != "{}" ]; then
     extracted=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_wordpress_version // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_WORDPRESS_VERSION="$extracted"

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -646,7 +646,8 @@ if [ -z "$ARTIFACTS_DIR" ] && [ "$settings_json" != "{}" ]; then
     ARTIFACTS_DIR=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_artifacts_dir // empty' 2>/dev/null || true)
 fi
 if [ -z "$ARTIFACTS_DIR" ]; then
-    ARTIFACTS_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-bench-artifacts.XXXXXX")
+    mkdir -p "${PLUGIN_PATH}/.homeboy"
+    ARTIFACTS_DIR=$(mktemp -d "${PLUGIN_PATH}/.homeboy/wp-codebox-bench-artifacts.XXXXXX")
 fi
 mkdir -p "$ARTIFACTS_DIR"
 

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -615,7 +615,7 @@ homeboy_wp_codebox_compile_bootstrap_files
 homeboy_wp_codebox_compile_bootstrap_steps
 homeboy_wp_codebox_compile_prepare_steps
 
-WP_CODEBOX_WORDPRESS_VERSION="6.9"
+WP_CODEBOX_WORDPRESS_VERSION="latest"
 if [ "$settings_json" != "{}" ]; then
     extracted=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_wordpress_version // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_WORDPRESS_VERSION="$extracted"

--- a/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
@@ -75,6 +75,12 @@ if ! jq -e '.inputs.pluginRuntime.php.memoryLimit == "768M"' "$CAPTURED_RECIPE" 
     exit 1
 fi
 
+if ! jq -e '.runtime.wp == "latest"' "$CAPTURED_RECIPE" >/dev/null; then
+    echo "Expected generated recipe to use a valid default WordPress runtime" >&2
+    cat "$CAPTURED_RECIPE" >&2
+    exit 1
+fi
+
 DIAGNOSTICS_FILE="${ARTIFACTS_DIR}/wp-codebox-bench-diagnostics.json"
 if ! jq -e '
     .schema == "homeboy/wordpress-bench-diagnostic/v1"

--- a/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
@@ -29,7 +29,7 @@ cat > "$FAKE_CORE_MODULE" <<'NODE'
 export function buildWordPressBenchRecipe(options) {
   return {
     schema: "wp-codebox/workspace-recipe/v1",
-    runtime: { wp: options.wordpressVersion, blueprint: options.blueprint },
+    runtime: { wp: options.wordpressVersion ?? "latest", blueprint: options.blueprint },
     inputs: { mounts: options.mounts ?? [] },
     workflow: { steps: [{ command: "wordpress.bench", args: [`plugin-slug=${options.pluginSlug}`] }] },
   }

--- a/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
@@ -12,6 +12,7 @@ FAKE_CORE_MODULE="${TMPDIR}/wp-codebox-core.mjs"
 FAKE_PREFLIGHT="${TMPDIR}/bash-preflight.sh"
 FAKE_BENCH_HELPER="${TMPDIR}/bench-helper.sh"
 CAPTURED_RECIPE="${TMPDIR}/captured-recipe.json"
+CAPTURED_RECIPE_PATH="${TMPDIR}/captured-recipe-path.txt"
 RESULTS_FILE="${TMPDIR}/bench-results.json"
 ARTIFACTS_DIR="${TMPDIR}/artifacts"
 
@@ -42,6 +43,7 @@ import { copyFileSync, writeFileSync } from "node:fs"
 const recipeIndex = process.argv.indexOf("--recipe")
 if (recipeIndex !== -1 && process.argv[recipeIndex + 1]) {
   copyFileSync(process.argv[recipeIndex + 1], process.env.CAPTURED_RECIPE)
+  writeFileSync(process.env.CAPTURED_RECIPE_PATH, process.argv[recipeIndex + 1])
 }
 writeFileSync(1, 'PHP.run() failed with exit code 255.\n\nFatal error: Allowed memory size of 268435456 bytes exhausted (tried to allocate 126976 bytes) in /internal/shared/sqlite-database-integration/wp-includes/database/sqlite/class-wp-pdo-proxy-statement.php on line 358\n')
 process.exit(255)
@@ -50,6 +52,7 @@ chmod +x "$FAKE_WP_CODEBOX"
 
 set +e
 output=$(CAPTURED_RECIPE="$CAPTURED_RECIPE" \
+    CAPTURED_RECIPE_PATH="$CAPTURED_RECIPE_PATH" \
     HOMEBOY_WP_CODEBOX_BIN="$FAKE_WP_CODEBOX" \
     HOMEBOY_WP_CODEBOX_CORE_MODULE="$FAKE_CORE_MODULE" \
     HOMEBOY_RUNTIME_BASH_PREFLIGHT="$FAKE_PREFLIGHT" \
@@ -80,6 +83,16 @@ if ! jq -e '.runtime.wp == "latest"' "$CAPTURED_RECIPE" >/dev/null; then
     cat "$CAPTURED_RECIPE" >&2
     exit 1
 fi
+
+captured_recipe_path=$(cat "$CAPTURED_RECIPE_PATH")
+case "$captured_recipe_path" in
+    "$ARTIFACTS_DIR"/*) ;;
+    *)
+        echo "Expected generated recipe scratch file to live under artifacts directory" >&2
+        echo "$captured_recipe_path" >&2
+        exit 1
+        ;;
+esac
 
 DIAGNOSTICS_FILE="${ARTIFACTS_DIR}/wp-codebox-bench-diagnostics.json"
 if ! jq -e '

--- a/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
@@ -14,7 +14,7 @@ FAKE_BENCH_HELPER="${TMPDIR}/bench-helper.sh"
 CAPTURED_RECIPE="${TMPDIR}/captured-recipe.json"
 CAPTURED_RECIPE_PATH="${TMPDIR}/captured-recipe-path.txt"
 RESULTS_FILE="${TMPDIR}/bench-results.json"
-ARTIFACTS_DIR="${TMPDIR}/artifacts"
+ARTIFACTS_DIR="${PLUGIN_PATH}/.homeboy/wp-codebox-bench-artifacts"
 
 mkdir -p "${PLUGIN_PATH}/tests/bench"
 printf '<?php\nreturn array( "metrics" => array( "noop" => 1 ) );\n' > "${PLUGIN_PATH}/tests/bench/noop.php"
@@ -61,7 +61,7 @@ output=$(CAPTURED_RECIPE="$CAPTURED_RECIPE" \
     HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
     HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
     HOMEBOY_COMPONENT_ID="bench-memory-budget" \
-    HOMEBOY_SETTINGS_JSON="{\"wp_codebox_php_memory_limit\":\"768M\",\"wp_codebox_artifacts_dir\":\"${ARTIFACTS_DIR}\"}" \
+    HOMEBOY_SETTINGS_JSON="{\"wp_codebox_php_memory_limit\":\"768M\"}" \
     bash "${SCRIPT_DIR}/bench-runner.sh" 2>&1)
 status=$?
 set -e
@@ -86,15 +86,16 @@ fi
 
 captured_recipe_path=$(cat "$CAPTURED_RECIPE_PATH")
 case "$captured_recipe_path" in
-    "$ARTIFACTS_DIR"/*) ;;
+    "$ARTIFACTS_DIR".*/*) ;;
     *)
         echo "Expected generated recipe scratch file to live under artifacts directory" >&2
         echo "$captured_recipe_path" >&2
         exit 1
         ;;
 esac
+actual_artifacts_dir=$(dirname "$captured_recipe_path")
 
-DIAGNOSTICS_FILE="${ARTIFACTS_DIR}/wp-codebox-bench-diagnostics.json"
+DIAGNOSTICS_FILE="${actual_artifacts_dir}/wp-codebox-bench-diagnostics.json"
 if ! jq -e '
     .schema == "homeboy/wordpress-bench-diagnostic/v1"
     and .diagnostics[0].code == "wp-codebox-php-memory-exhausted"

--- a/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
@@ -78,7 +78,7 @@ if ! jq -e '.inputs.pluginRuntime.php.memoryLimit == "768M"' "$CAPTURED_RECIPE" 
     exit 1
 fi
 
-if ! jq -e '.runtime.wp == "latest"' "$CAPTURED_RECIPE" >/dev/null; then
+if ! jq -e '.runtime.wp == "6.9"' "$CAPTURED_RECIPE" >/dev/null; then
     echo "Expected generated recipe to use a valid default WordPress runtime" >&2
     cat "$CAPTURED_RECIPE" >&2
     exit 1

--- a/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh
@@ -78,7 +78,7 @@ if ! jq -e '.inputs.pluginRuntime.php.memoryLimit == "768M"' "$CAPTURED_RECIPE" 
     exit 1
 fi
 
-if ! jq -e '.runtime.wp == "6.9"' "$CAPTURED_RECIPE" >/dev/null; then
+if ! jq -e '.runtime.wp == "latest"' "$CAPTURED_RECIPE" >/dev/null; then
     echo "Expected generated recipe to use a valid default WordPress runtime" >&2
     cat "$CAPTURED_RECIPE" >&2
     exit 1

--- a/wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh
@@ -105,7 +105,7 @@ if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
 fi
 
 WP_CONFIG_DEFINES_JSON="{}"
-WP_CODEBOX_WORDPRESS_VERSION="6.9"
+WP_CODEBOX_WORDPRESS_VERSION=""
 WP_CODEBOX_MULTISITE="${HOMEBOY_WORDPRESS_MULTISITE:-}"
 if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.wp_config_defines // {}' 2>/dev/null || echo "{}")
@@ -160,7 +160,7 @@ jq -n \
     --arg multisite "$WP_CODEBOX_MULTISITE" \
     '{
         schema: "wp-codebox/workspace-recipe/v1",
-        runtime: {wp: $wp, blueprint: {steps: []}},
+        runtime: ({blueprint: {steps: []}} + (if $wp == "" then {} else {wp: $wp} end)),
         inputs: {mounts: $mounts},
         workflow: {steps: [{command: "wordpress.core-phpunit", args: [
             "core-root=/wordpress",

--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -283,7 +283,7 @@ assert_contains "${TMPDIR}/wp-codebox-args.txt" "recipe-run"
 assert_contains "${TMPDIR}/wp-codebox-args.txt" "--recipe"
 assert_contains "${TMPDIR}/wp-codebox-args.txt" "wordpress.phpunit"
 assert_contains "${TMPDIR}/wp-codebox-args.txt" "autoload-file=/wp-codebox-vendor/autoload.php"
-assert_contains "${TMPDIR}/wp-codebox-args.txt" "6.9"
+assert_not_contains "${TMPDIR}/wp-codebox-args.txt" "6.9"
 assert_contains "${TMPDIR}/wp-codebox-args.txt" '"target": "/wordpress/wp-content/plugins/component"'
 
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -419,7 +419,7 @@ WP_CONFIG_DEFINES_JSON="{}"
 BENCH_ENV_JSON="{}"
 WP_CODEBOX_FILE_MOUNTS_JSON="[]"
 PHPUNIT_NO_TESTS="skipped"
-WP_CODEBOX_WORDPRESS_VERSION="6.9"
+WP_CODEBOX_WORDPRESS_VERSION=""
 WP_CODEBOX_MULTISITE=""
 if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.wp_config_defines // {}' 2>/dev/null || echo "{}")
@@ -621,8 +621,7 @@ jq -n \
     --arg projectBootstrap "$WP_CODEBOX_PHPUNIT_PROJECT_BOOTSTRAP" \
     --arg dependencyMounts "$WP_CODEBOX_DEP_MOUNTS" \
     --arg multisite "$WP_CODEBOX_MULTISITE" \
-    '{
-        wordpressVersion: $wp,
+    '({
         mounts: $mounts,
         pluginSlug: $pluginSlug,
         selectedTestFile: $selectedTestFile,
@@ -637,7 +636,7 @@ jq -n \
         testsDir: "/wp-codebox-vendor/wp-phpunit/wp-phpunit",
         dependencyMounts: ($dependencyMounts | split("\n") | map(select(. != ""))),
         multisite: (if (($multisite | ascii_downcase) as $v | $v == "1" or $v == "true" or $v == "yes" or $v == "on") then true else false end)
-    }' > "$RECIPE_OPTIONS_FILE"
+    } + (if $wp == "" then {} else {wordpressVersion: $wp} end))' > "$RECIPE_OPTIONS_FILE"
 
 if [ ! -f "$PHPUNIT_RECIPE_BUILDER" ]; then
     echo "Error: WP Codebox PHPUnit recipe builder not found: ${PHPUNIT_RECIPE_BUILDER}" >&2

--- a/wordpress/scripts/trace/trace-runner.sh
+++ b/wordpress/scripts/trace/trace-runner.sh
@@ -84,7 +84,7 @@ homeboy_wordpress_resolve_wp_codebox_bin() {
 }
 
 homeboy_wordpress_trace_wp_version() {
-    local version="6.9"
+    local version=""
     local extracted=""
 
     if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
@@ -169,7 +169,7 @@ homeboy_trace_run_php_scenario_wp_codebox() {
         --arg codeFile "$wrapper_file" \
         '{
             schema: "wp-codebox/workspace-recipe/v1",
-            runtime: {wp: $wp, blueprint: {steps: []}},
+            runtime: ({blueprint: {steps: []}} + (if $wp == "" then {} else {wp: $wp} end)),
             inputs: {mounts: [
                 {source: $componentSource, target: $componentTarget, mode: "readwrite"},
                 {source: $runSource, target: $runTarget, mode: "readwrite"}


### PR DESCRIPTION
## Summary
- Keep WP Codebox bench scratch/output files under the configured artifacts directory instead of tmpfs.
- Stop Homeboy's WP Codebox bench, test, trace, and Data Machine-agent runners from owning a WordPress runtime default.
- Pass `wp_codebox_wordpress_version` only when explicitly configured so WP Codebox remains the single source of truth for the default WordPress runtime.

## Testing
- `bash wordpress/scripts/bench/wp-codebox-bench-memory-budget-smoke.sh`
- `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the lab bench runtime failure, drafted the artifact-dir and runtime-default deferral changes, and ran targeted smoke validation.