### PR TITLE
Fix WP Codebox canary core module path

### DIFF
--- a/.github/workflows/wp-codebox-test-runtime-canary.yml
+++ b/.github/workflows/wp-codebox-test-runtime-canary.yml
@@ -51,4 +51,5 @@ jobs:
       - name: Run WP Codebox-backed test runner canary
         env:
           HOMEBOY_WP_CODEBOX_BIN: ${{ github.workspace }}/.ci/wp-codebox/packages/cli/dist/index.js
+          HOMEBOY_WP_CODEBOX_CORE_MODULE: ${{ github.workspace }}/.ci/wp-codebox/packages/runtime-core/dist/index.js
         run: bash wordpress/scripts/test/playground-db-activation-smoke.sh


### PR DESCRIPTION
## Summary
- Pass the built WP Codebox runtime-core ESM entrypoint into the canary as `HOMEBOY_WP_CODEBOX_CORE_MODULE`.
- Keeps the no-fallback recipe builder loader intact while allowing the canary's checked-out/built WP Codebox copy to satisfy `buildWordPressPhpunitRecipe`.

## Verification
- `npm run test:wp-codebox-phpunit-recipe-builder`
- `npm run test:wp-codebox-bench-recipe-builder`

## Canary
- The failed canary should be rerun on this PR because the workflow environment is the changed surface.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspected the merged canary failure, made the workflow env fix, ran targeted smoke tests, and drafted this PR description for Chris to review.