### PR TITLE
Adopt Codebox agent task result normalizer

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -585,6 +585,16 @@ function recipeRunArtifacts(result) {
   return artifacts;
 }
 
+function homeboyFailureClassification(classification, status) {
+  if (classification === 'provider' || classification === 'timeout') {
+    return classification;
+  }
+  if (classification === 'runtime' || classification === 'task') {
+    return 'execution_failed';
+  }
+  return classification || failureClassificationForStatus(status);
+}
+
 function failureClassificationForStatus(status) {
   if (status === 'provider_error') {
     return 'provider';
@@ -638,9 +648,6 @@ function pathValue(source, dottedPath) {
 }
 
 function normalizeOutputs(result) {
-  if (result.outputs && typeof result.outputs === 'object' && !Array.isArray(result.outputs)) {
-    return sanitizePublicMetadata(result.outputs);
-  }
   const workload = agentRuntimeWorkload(result) || {};
   if (workload.outputs && typeof workload.outputs === 'object' && !Array.isArray(workload.outputs)) {
     return sanitizePublicMetadata(workload.outputs);
@@ -648,6 +655,9 @@ function normalizeOutputs(result) {
 
   const bundle = result.metadata?.agent_runtime?.bundle || result.task_input?.agent_bundle || {};
   const configuredOutputs = bundle.engine_data_outputs && typeof bundle.engine_data_outputs === 'object' ? bundle.engine_data_outputs : {};
+  if (Object.keys(configuredOutputs).length === 0 && result.outputs && typeof result.outputs === 'object' && !Array.isArray(result.outputs)) {
+    return sanitizePublicMetadata(result.outputs);
+  }
   const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
   const configuredOutputSources = [
     ...scenarios,
@@ -674,7 +684,7 @@ function normalizeOutputs(result) {
       }
     }
   }
-  return sanitizePublicMetadata(outputs);
+  return sanitizePublicMetadata(Object.keys(outputs).length > 0 ? outputs : result.outputs || {});
 }
 
 function outputEvidenceRefs(outputs) {
@@ -687,9 +697,24 @@ function outputEvidenceRefs(outputs) {
     }));
 }
 
-function normalizeArtifacts(result) {
+function codeboxRunSummary(result, options = {}) {
+  if (typeof options.normalizeAgentTaskRunResult !== 'function') {
+    return null;
+  }
+  try {
+    return options.normalizeAgentTaskRunResult(result, { exitStatus: options.exitStatus ?? 0 });
+  } catch {
+    return null;
+  }
+}
+
+function normalizeArtifacts(result, runSummary = null) {
+  const normalizedArtifacts = Array.isArray(runSummary?.artifacts)
+    ? runSummary.artifacts.map(artifactFromCodeboxArtifact)
+    : [];
+
   if (result?.schema === 'wp-codebox/agent-task-run/v1') {
-    const artifacts = [];
+    const artifacts = [...normalizedArtifacts];
     if (typeof result.artifacts === 'string' && result.artifacts) {
       artifacts.push({
         id: result.session?.artifacts?.bundle_id || 'wp-codebox-artifacts',
@@ -723,10 +748,12 @@ function normalizeArtifacts(result) {
   const artifacts = Array.isArray(result?.artifacts)
     ? result.artifacts
     : Object.values(result?.artifacts || {}).filter((value) => value && typeof value === 'object');
-  return artifacts.map(artifactFromCodeboxArtifact);
+  const mappedArtifacts = [...normalizedArtifacts];
+  artifacts.map(artifactFromCodeboxArtifact).forEach((artifact) => appendUniqueArtifact(mappedArtifacts, artifact));
+  return mappedArtifacts;
 }
 
-function normalizeEvidenceRefs(result) {
+function normalizeEvidenceRefs(result, runSummary = null) {
   if (result?.schema === 'wp-codebox/agent-task-run/v1') {
     const refs = [
       result.session?.artifacts?.preview_url ? {
@@ -759,6 +786,13 @@ function normalizeEvidenceRefs(result) {
         kind: artifact.kind,
         uri: artifact.path || artifact.url,
         label: artifact.kind.replace(/^codebox-recipe-/, 'WP Codebox recipe ').replace(/-/g, ' '),
+      });
+    }
+    for (const artifact of runSummary?.artifacts || []) {
+      appendUniqueEvidenceRef(refs, {
+        kind: artifact.kind,
+        uri: artifact.path || artifact.url,
+        label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
       });
     }
     for (const ref of outputEvidenceRefs(normalizeOutputs(result))) {
@@ -821,7 +855,7 @@ function agentRuntimeBundleArtifacts(result) {
   return artifacts;
 }
 
-function codeboxDecisionEvidence(result) {
+function codeboxDecisionEvidence(result, runSummary = null) {
   const agentResult = result.run?.agentResult || result.agentResult || result.agent_result || result.metadata?.recipe_run?.agentResult || result.metadata?.recipe_run?.run?.agentResult || {};
   const completionOutcome = result.completionOutcome || result.completion_outcome || result.metadata?.recipe_run?.completionOutcome || {};
   const runtime = result.run?.runtime || result.metadata?.recipe_run?.run?.runtime || {};
@@ -833,19 +867,19 @@ function codeboxDecisionEvidence(result) {
     selected_executor: 'wordpress.codebox-agent-task-executor',
     capabilities_used: PROVIDER_CAPABILITIES,
     runtime_gap_trackers: WP_CODEBOX_RUNTIME_GAP_TRACKERS,
-    run_id: run.runId,
-    run_status: run.status,
-    runtime_id: runtime.id,
-    runtime_status: runtime.status,
+    run_id: runSummary?.metadata?.run_id || run.runId,
+    run_status: runSummary?.metadata?.run_status || run.status,
+    runtime_id: runSummary?.metadata?.runtime_id || runtime.id,
+    runtime_status: runSummary?.metadata?.runtime_status || runtime.status,
     heartbeat_at: run.heartbeatAt,
-    cleanup_observed: runtime.status === 'destroyed' ? 'runtime_destroyed' : '',
-    changed_files_count: agentResult.changedFiles?.count,
-    patch_bytes: agentResult.patch?.bytes,
-    patch_sha256: agentResult.patch?.sha256,
-    no_op_reason: agentResult.noOpReason,
-    completion_status: completionOutcome.status,
-    completion_next_action: completionOutcome.nextAction,
-    confidence: completionOutcome.confidence,
+    cleanup_observed: (runSummary?.metadata?.runtime_status || runtime.status) === 'destroyed' ? 'runtime_destroyed' : '',
+    changed_files_count: runSummary?.metadata?.changed_files_count ?? agentResult.changedFiles?.count,
+    patch_bytes: runSummary?.metadata?.patch_bytes ?? agentResult.patch?.bytes,
+    patch_sha256: runSummary?.metadata?.patch_sha256 || agentResult.patch?.sha256,
+    no_op_reason: runSummary?.metadata?.no_op_reason || agentResult.noOpReason,
+    completion_status: runSummary?.metadata?.completion_status || completionOutcome.status,
+    completion_next_action: runSummary?.metadata?.completion_next_action || completionOutcome.nextAction,
+    confidence: runSummary?.metadata?.confidence || completionOutcome.confidence,
     recipe_pack: recipeRun.pack || recipeRun.recipe_pack || recipeRun.recipePack,
     recipe_name: recipeRun.name || recipeRun.recipe,
     recipe_ref: recipeRun.ref,
@@ -856,8 +890,10 @@ function codeboxDecisionEvidence(result) {
 
 function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   assertAgentTaskRequest(request);
-  const status = normalizeStatus(result, options.exitStatus ?? 0);
-  const failureClassification = result.failure_classification || failureClassificationForStatus(status);
+  const runSummary = codeboxRunSummary(result, options);
+  const localStatus = normalizeStatus(result, options.exitStatus ?? 0);
+  const status = localStatus === 'failed' ? localStatus : (runSummary?.status || localStatus);
+  const failureClassification = homeboyFailureClassification(result.failure_classification || runSummary?.failure_classification, status);
   const outputs = normalizeOutputs(result);
   const recipeRun = recipeRunFromResult(result);
   const recipeSummary = recipeRunFailureSummary(recipeRun);
@@ -866,11 +902,11 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     schema: AGENT_TASK_OUTCOME_SCHEMA,
     task_id: request.task_id,
     status,
-    summary: recipeSummary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
-    artifacts: normalizeArtifacts(result),
-    evidence_refs: normalizeEvidenceRefs(result),
+    summary: recipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
+    artifacts: normalizeArtifacts(result, runSummary),
+    evidence_refs: normalizeEvidenceRefs(result, runSummary),
     outputs,
-    diagnostics: [recipeRunFailureDiagnostic(recipeRun), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
+    diagnostics: [recipeRunFailureDiagnostic(recipeRun), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
       message: diagnostic.message || String(diagnostic),
       data: sanitizePublicMetadata(diagnostic.data || {}),
@@ -878,8 +914,9 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     metadata: {
       provider: 'wordpress.codebox-agent-task-executor',
       codebox: sanitizePublicMetadata(result.metadata || result),
+      codebox_run_result: runSummary ? sanitizePublicMetadata(runSummary) : undefined,
       integration_contract: 'wp-codebox-cli/agent-task-run',
-      decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result)),
+      decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result, runSummary)),
       recipe_failed_phase: recipeFailedPhase || undefined,
     },
   };

--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -9,6 +9,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { pathToFileURL } = require('node:url');
 
 /**
  * Internal dependencies
@@ -18,6 +19,8 @@ const {
   codeboxTaskRequestFromAgentTaskRequest,
   providerContract,
 } = require('../../lib/codebox-agent-task-executor');
+
+const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
 
 function argValue(name) {
   const index = process.argv.indexOf(name);
@@ -310,7 +313,33 @@ function stderrFailurePayload(result) {
   };
 }
 
-function runTaskRunner(request) {
+async function loadCodeboxAgentTaskRunResultNormalizer() {
+  const configuredModule = process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE;
+  const candidates = configuredModule ? [configuredModule] : [DEFAULT_CODEBOX_CORE_MODULE];
+
+  for (const candidate of candidates) {
+    try {
+      const module = await importModule(candidate);
+      if (typeof module.normalizeAgentTaskRunResult === 'function') {
+        return module.normalizeAgentTaskRunResult;
+      }
+    } catch {
+      // Fall back to the local compatibility path when Codebox core is not installed yet.
+    }
+  }
+
+  return null;
+}
+
+function importModule(specifier) {
+  if (specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('file:')) {
+    return import(specifier.startsWith('file:') ? specifier : pathToFileURL(path.resolve(specifier)).href);
+  }
+  return import(specifier);
+}
+
+async function runTaskRunner(request) {
+  const normalizeAgentTaskRunResult = await loadCodeboxAgentTaskRunResultNormalizer();
   const runner = argValue('--task-runner') || `${__dirname}/homeboy-wp-codebox-task-runner.cjs`;
   const config = request.executor?.config || {};
   const configArgs = [
@@ -339,7 +368,7 @@ function runTaskRunner(request) {
   let payload = {};
   if (result.error && result.error.code === 'ETIMEDOUT') {
     payload = timeoutPayload(requestTimeoutMs(request), request);
-    return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: 1 });
+    return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: 1, normalizeAgentTaskRunResult });
   }
   if (result.stdout.trim()) {
     try {
@@ -370,20 +399,22 @@ function runTaskRunner(request) {
     payload = stderrFailurePayload(result);
   }
 
-  return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: result.status ?? 1 });
+  return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: result.status ?? 1, normalizeAgentTaskRunResult });
 }
 
-try {
-  if (hasFlag('--print-contract')) {
-    process.stdout.write(`${JSON.stringify(providerContract(), null, 2)}\n`);
-    process.exit(0);
+(async () => {
+  try {
+    if (hasFlag('--print-contract')) {
+      process.stdout.write(`${JSON.stringify(providerContract(), null, 2)}\n`);
+      process.exit(0);
+    }
+
+    const request = readRequest();
+    const outcome = await runTaskRunner(request);
+    process.stdout.write(`${JSON.stringify(outcome, null, 2)}\n`);
+    process.exitCode = outcome.status === 'succeeded' || outcome.status === 'no_op' ? 0 : 1;
+  } catch (error) {
+    console.error(error && error.message ? error.message : String(error));
+    process.exitCode = 1;
   }
-
-  const request = readRequest();
-  const outcome = runTaskRunner(request);
-  process.stdout.write(`${JSON.stringify(outcome, null, 2)}\n`);
-  process.exitCode = outcome.status === 'succeeded' || outcome.status === 'no_op' ? 0 : 1;
-} catch (error) {
-  console.error(error && error.message ? error.message : String(error));
-  process.exitCode = 1;
-}
+})();

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -12,6 +12,8 @@ const {
   providerContract,
 } = require('../lib/codebox-agent-task-executor');
 
+const fixtureCodeboxCoreModule = path.join(__dirname, 'fixtures', 'wp-codebox-core-agent-task-normalizer.mjs');
+
 function writeFixtureTaskRunner(root) {
   const fixture = path.join(root, 'fixture-task-runner.cjs');
   const capture = path.join(root, 'capture.json');
@@ -22,9 +24,19 @@ const fs = require('node:fs');
 fs.writeFileSync(${JSON.stringify(capture)}, JSON.stringify({ argv: process.argv.slice(2), request }, null, 2));
 process.stdout.write(JSON.stringify({
   success: true,
+  status: 'completed',
   summary: 'Sandbox completed.',
   artifacts: [{ id: 'artifact-1', kind: 'screenshot', path: '/artifacts/screenshot.png' }],
   evidence_refs: [{ kind: 'preview', uri: 'https://example.test/preview', label: 'Preview' }],
+  run: {
+    runId: 'fixture-run-1',
+    status: 'succeeded',
+    runtime: { id: 'fixture-runtime-1', status: 'destroyed' },
+    agentResult: {
+      changedFiles: { count: 2 },
+      patch: { bytes: 123, sha256: 'fixture-patch-sha' }
+    }
+  },
   metadata: { run_id: 'codebox-run-1' }
 }));
 `);
@@ -776,6 +788,24 @@ try {
   assert.equal(cliOutcome.status, 'succeeded');
   assert.equal(cliOutcome.artifacts[0].kind, 'screenshot');
   assert.equal(cliOutcome.evidence_refs[0].uri, 'https://example.test/preview');
+
+  const normalizedResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+    '--task-runner',
+    fixture,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(request),
+    env: { ...process.env, HOMEBOY_WP_CODEBOX_CORE_MODULE: fixtureCodeboxCoreModule },
+  });
+  assert.equal(normalizedResult.status, 0, normalizedResult.stderr || normalizedResult.stdout);
+  const normalizedOutcome = JSON.parse(normalizedResult.stdout);
+  assert.equal(normalizedOutcome.metadata.codebox_run_result.schema, 'wp-codebox/agent-task-run-result/v1');
+  assert.equal(normalizedOutcome.metadata.decision_evidence.run_id, 'fixture-run-1');
+  assert.equal(normalizedOutcome.metadata.decision_evidence.runtime_status, 'destroyed');
+  assert.equal(normalizedOutcome.metadata.decision_evidence.patch_sha256, 'fixture-patch-sha');
+  assert.equal(normalizedOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-patch' && artifact.path === '/tmp/fixture-normalized/patch.diff'), true);
+  assert.equal(normalizedOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'fixture.normalizer'), true);
 
   const captured = JSON.parse(fs.readFileSync(capture, 'utf8'));
   assert.equal(captured.request.schema, 'wp-codebox/task-input/v1');

--- a/wordpress/tests/fixtures/wp-codebox-core-agent-task-normalizer.mjs
+++ b/wordpress/tests/fixtures/wp-codebox-core-agent-task-normalizer.mjs
@@ -1,0 +1,43 @@
+export function normalizeAgentTaskRunResult(raw, options = {}) {
+  const result = raw && typeof raw === 'object' ? raw : {};
+  const runtime = result.run?.runtime || {};
+  const agentResult = result.run?.agentResult || result.agentResult || result.agent_result || {};
+  const patch = agentResult.patch || {};
+  const changedFiles = agentResult.changedFiles || {};
+  const status = result.timeout
+    ? 'timeout'
+    : (result.success === true && result.status === 'completed' && options.exitStatus === 0 ? 'succeeded' : 'failed');
+
+  return {
+    schema: 'wp-codebox/agent-task-run-result/v1',
+    status,
+    success: status === 'succeeded',
+    summary: result.summary || `fixture normalized ${status}`,
+    artifacts: [{
+      id: 'fixture-normalized-patch',
+      kind: 'codebox-patch',
+      path: '/tmp/fixture-normalized/patch.diff',
+      sha256: patch.sha256,
+    }],
+    refs: {
+      artifact_bundles: [],
+      changed_files: [],
+      patches: [],
+      transcripts: [],
+      logs: [],
+      runtimes: [],
+    },
+    diagnostics: [{ class: 'fixture.normalizer', message: 'Fixture normalizer was used.', data: { exitStatus: options.exitStatus } }],
+    metadata: {
+      run_id: result.run?.runId,
+      run_status: result.run?.status,
+      runtime_id: runtime.id,
+      runtime_status: runtime.status,
+      changed_files_count: changedFiles.count,
+      patch_bytes: patch.bytes,
+      patch_sha256: patch.sha256,
+    },
+    no_op: { detected: false },
+    failure_classification: status === 'failed' ? 'runtime' : undefined,
+  };
+}


### PR DESCRIPTION
## Summary
- Consume WP Codebox's agent task run result normalizer when a core module is available.
- Preserve Homeboy's provider-neutral outcome envelope and local compatibility fallback.
- Add smoke coverage for the explicit Codebox core module path.

## Verification
- `npm run test:codebox-agent-task-executor`
- `npm run lint:js -- lib/codebox-agent-task-executor.js scripts/agent/homeboy-codebox-agent-task-executor.cjs --no-warn-ignored`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the normalizer adoption changes and smoke coverage; Chris remains responsible for review and landing.