### PR TITLE
Preserve Codebox runtime task inputs

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -144,6 +144,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const recipe = recipeConfigFromAgentTaskRequest(request, config, inputs);
   const mounts = agentBundleMounts(agentBundle, config.mounts || options.mounts || []);
   const components = runtimeComponentPaths(config, options);
+  const runtimeTask = inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || options.runtimeTask;
+  const sandboxToolPolicy = inputs.sandbox_tool_policy || inputs.sandboxToolPolicy || config.sandbox_tool_policy || config.sandboxToolPolicy || options.sandboxToolPolicy;
   const timeoutSeconds = request.limits?.task_timeout_seconds || request.limits?.taskTimeoutSeconds;
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
   const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
@@ -166,6 +168,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     policy: request.policy || {},
     context,
     recipe,
+    sandbox_tool_policy: sandboxToolPolicy,
+    runtime_task: runtimeTask,
     sandbox_session_id: config.sandbox_session_id || request.task_id,
     session_id: config.session_id || config.sessionId || '',
     agent: config.agent || options.agent || 'wp-codebox-sandbox',
@@ -178,7 +182,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     runtime_overlays: config.runtime_overlays || options.runtimeOverlays || [],
     secret_env: config.secret_env || options.secretEnv || [],
     mounts,
-    workspaces: config.workspaces || options.workspaces || [],
+    workspaces: inputs.workspaces || config.workspaces || options.workspaces || [],
     agents_api_path: components.agents_api || config.agents_api || config.agents_api_path || options.agentsApi || '',
     [WP_CODEBOX_RUNTIME_PATH_KEY]: components.agent_runtime || '',
     [WP_CODEBOX_RUNTIME_TOOLS_PATH_KEY]: components.agent_runtime_tools || '',

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -211,6 +211,7 @@ function runnerInput(request, artifacts) {
     sandbox_session_id: request.sandbox_session_id || '',
     orchestrator: request.orchestrator || {},
     recipe: request.recipe || {},
+    runtime_task: request.runtime_task || request.runtimeTask,
     artifacts_path: artifacts,
     wp_codebox_bin: argValue('--wp-codebox-bin') || request.wp_codebox_bin || '',
     agents_api_path: argValue('--agents-api') || request.agents_api_path || request.agents_api || '',
@@ -259,7 +260,7 @@ function stableTaskInput(input) {
     runtime_component_paths: input.runtime_component_paths || {},
     wp: input.wp_version,
     agent_bundle: isAgentBundle(input) ? agentBundleConfig(input, input.agent_bundle || {}) : {},
-    runtime_task: isAgentBundle(input) ? agentBundleRuntimeTask(input, input.agent_bundle || {}) : undefined,
+    runtime_task: runtimeTask(input),
     parent_request: input.parent_request,
   }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
 }
@@ -307,6 +308,16 @@ function sandboxToolPolicy(input, allowedTools) {
 
 function isAgentBundle(input) {
   return Boolean(input.agent_bundle && Object.keys(input.agent_bundle).length > 0);
+}
+
+function runtimeTask(input) {
+  if (plainObject(input.runtime_task)) {
+    return input.runtime_task;
+  }
+  if (isAgentBundle(input)) {
+    return agentBundleRuntimeTask(input, input.agent_bundle || {});
+  }
+  return undefined;
 }
 
 function agentBundleConfig(input, bundleConfig = {}) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -236,6 +236,31 @@ assert.equal(codeboxRequest.orchestrator.agent_task_id, 'task-123');
 assert.equal(codeboxRequest.context.audit_findings[0].id, 'finding-1');
 assert.deepEqual(codeboxRequest.agent_bundle, {});
 
+const runtimeTaskRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'runtime-task-123',
+  executor: {
+    backend: 'codebox',
+    config: {
+      sandbox_tool_policy: {
+        schema: 'wp-codebox/sandbox-tool-policy/v1',
+        version: 1,
+        tools: [{ id: 'homeboy-canary/write-file', allowed: true }],
+      },
+    },
+  },
+  inputs: {
+    runtime_task: {
+      ability: 'homeboy-canary/write-file',
+      input: { path: '/workspace/codebox-canary/CANARY.md', content: 'after\n' },
+    },
+    workspaces: [{ target: '/workspace/codebox-canary', mode: 'readwrite' }],
+  },
+});
+assert.equal(runtimeTaskRequest.sandbox_tool_policy.tools[0].id, 'homeboy-canary/write-file');
+assert.equal(runtimeTaskRequest.runtime_task.ability, 'homeboy-canary/write-file');
+assert.equal(runtimeTaskRequest.workspaces[0].target, '/workspace/codebox-canary');
+
 const recipePackRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
   task_id: 'recipe-task-123',

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -187,6 +187,33 @@ try {
   assert.equal(captured.input.runtime_component_paths.agent_runtime_tools, '/components/data-machine-code');
   assert(!JSON.stringify(captured.input).includes('redacted-test-key'));
 
+  const runtimeTaskCapturePath = path.join(root, 'capture-runtime-task.json');
+  const runtimeTaskResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      sandbox_tool_policy: {
+        schema: 'wp-codebox/sandbox-tool-policy/v1',
+        version: 1,
+        tools: [{ id: 'homeboy-canary/write-file', allowed: true }],
+      },
+      runtime_task: {
+        ability: 'homeboy-canary/write-file',
+        input: { path: '/workspace/codebox-canary/CANARY.md', content: 'after\n' },
+      },
+      workspaces: [{ target: '/workspace/codebox-canary', mode: 'readwrite' }],
+    }),
+    env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: runtimeTaskCapturePath, OPENCODE_API_KEY: 'redacted-test-key' },
+  });
+  assert.equal(runtimeTaskResult.status, 0, runtimeTaskResult.stderr || runtimeTaskResult.stdout);
+  const runtimeTaskCaptured = readJson(runtimeTaskCapturePath);
+  assert.equal(runtimeTaskCaptured.input.sandbox_tool_policy.tools[0].id, 'homeboy-canary/write-file');
+  assert.equal(runtimeTaskCaptured.input.runtime_task.ability, 'homeboy-canary/write-file');
+  assert.equal(runtimeTaskCaptured.input.workspaces[0].target, '/workspace/codebox-canary');
+
   const codexCapturePath = path.join(root, 'capture-codex.json');
   const codexSecretEnv = [
     'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',


### PR DESCRIPTION
## Summary
- Preserve direct WP Codebox runtime task controls from Homeboy agent-task inputs/config into the Codebox task runner.
- Keep existing agent-bundle runtime-task generation while allowing explicit runtime tasks for deterministic run-plan canaries.
- Add smoke coverage for runtime task, sandbox tool policy, and workspace preservation.

## Verification
- `npm run test:codebox-agent-task-executor`
- `npm run test:wp-codebox-task-runner`
- `HOME=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-extension-home-1042 homeboy agent-task run-plan --plan - --artifact-root /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-codebox-canary-QdQTCJ/homeboy-fixed-artifacts --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-codebox-canary-QdQTCJ/homeboy-run-plan-fixed-output.json`
- `wp-codebox artifacts verify --bundle /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-codebox-canary-QdQTCJ/run-plan-fixed-artifacts/runtime-mq33bxaf-f0sv03 --json`
- `wp-codebox artifacts apply-preflight --bundle /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-codebox-canary-QdQTCJ/run-plan-fixed-artifacts/runtime-mq33bxaf-f0sv03 --approved-file /workspace/codebox-canary/CANARY.md --json`

Canary result: Homeboy selected `wordpress.codebox-agent-task-executor`, produced one changed file, generated a 236-byte patch, observed runtime cleanup (`runtime_destroyed`), verified the artifact bundle, and apply-preflight returned ready.

Closes #1042.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the Homeboy-to-Codebox mapper gap, drafting the code/test updates, and running local verification. Chris remains responsible for review and merge.