### PR TITLE
Add WordPress admin scale sweep normalization

### DIFF
--- a/wordpress/lib/admin-page-scenarios.js
+++ b/wordpress/lib/admin-page-scenarios.js
@@ -1,6 +1,11 @@
 'use strict';
 
 /**
+ * External dependencies
+ */
+const { readFile } = require('node:fs/promises');
+
+/**
  * Internal dependencies
  */
 const {
@@ -27,6 +32,8 @@ const WORDPRESS_ADMIN_REST_GATE = {
 	restAfterReadyCount: { warn: 1, fail: 5 },
 	restNetworkCount: { warn: 20, fail: 40 },
 };
+
+const WORDPRESS_ADMIN_SCALE_SWEEP_DEFAULT_READY = { selector: '#wpbody-content, body.wp-admin', timeout: 120000 };
 
 const DEFAULT_SCENARIO_RESOURCES = {
 	includeResourceSubstrings: WORDPRESS_RESOURCE_INCLUDE,
@@ -153,8 +160,31 @@ const WORDPRESS_ADMIN_PAGE_PROFILE_SCENARIO_IDS = [
 	'site-editor-root',
 ];
 
+const WORDPRESS_ADMIN_SCALE_SWEEP_DEFAULT_PAGES = [
+	{ id: 'dashboard', path: '/wp-admin/index.php' },
+	{ id: 'plugins', path: '/wp-admin/plugins.php' },
+	{ id: 'themes', path: '/wp-admin/themes.php', ready: { selector: '.theme-browser, #wpbody-content', timeout: 120000 } },
+	{ id: 'posts', path: '/wp-admin/edit.php' },
+	{ id: 'add-post', path: '/wp-admin/post-new.php', ready: { selector: '.edit-post-layout, #editor, body.wp-admin', timeout: 120000 } },
+];
+
 function clone(value) {
 	return JSON.parse(JSON.stringify(value));
+}
+
+function pageIdFromPath(pagePath) {
+	return String(pagePath || '')
+		.replace(/^https?:\/\/[^/]+/i, '')
+		.replace(/^\/+/, '')
+		.replace(/[^A-Za-z0-9_.:-]+/g, '-')
+		.replace(/^-|-$/g, '') || 'wordpress-admin-page';
+}
+
+function metricId(value) {
+	return String(value || 'page')
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '_')
+		.replace(/^_+|_+$/g, '') || 'page';
 }
 
 function replaceParams(value, params, missing) {
@@ -243,6 +273,55 @@ function createWordPressAdminPageScenarioManifest(options = {}) {
 			...(overrides[page.id] || {}),
 		})),
 	};
+}
+
+function normalizeWordPressAdminScaleSweepManifest(manifest, options = {}) {
+	assertPlainObject(options, 'options');
+	assertPlainObject(manifest, 'WordPress admin scale sweep manifest');
+	if (!Array.isArray(manifest.pages) || manifest.pages.length === 0) {
+		throw new Error('WordPress admin scale sweep manifest requires a non-empty pages array');
+	}
+	const resourceInclude = options.resourceInclude || options.pageProfiler?.DEFAULT_RESOURCE_INCLUDE || WORDPRESS_RESOURCE_INCLUDE;
+
+	return {
+		...manifest,
+		pages: manifest.pages.map((page, index) => {
+			assertPlainObject(page, `WordPress admin scale sweep page ${index + 1}`);
+			if (!page.path || typeof page.path !== 'string') {
+				throw new Error(`WordPress admin scale sweep page ${index + 1} requires a path`);
+			}
+
+			const id = page.id || pageIdFromPath(page.path);
+			const ready = page.ready || WORDPRESS_ADMIN_SCALE_SWEEP_DEFAULT_READY;
+			return {
+				...page,
+				id,
+				metricId: page.metricId || metricId(id),
+				label: page.label || id,
+				ready,
+				resources: {
+					includeResourceSubstrings: resourceInclude,
+					...(page.resources || {}),
+				},
+				timeout: Number(page.timeout || ready.timeout || 120000),
+				interactions: Array.isArray(page.interactions) ? page.interactions : [],
+			};
+		}),
+	};
+}
+
+async function loadWordPressAdminScaleSweepManifest(options = {}) {
+	assertPlainObject(options, 'options');
+	const rawJson = options.json || process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_MANIFEST_JSON;
+	const manifestPath = options.path || process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_MANIFEST;
+	if (rawJson) {
+		return normalizeWordPressAdminScaleSweepManifest(JSON.parse(rawJson), options);
+	}
+	if (manifestPath) {
+		return normalizeWordPressAdminScaleSweepManifest(JSON.parse(await readFile(manifestPath, 'utf8')), options);
+	}
+
+	return normalizeWordPressAdminScaleSweepManifest({ pages: clone(WORDPRESS_ADMIN_SCALE_SWEEP_DEFAULT_PAGES) }, options);
 }
 
 function metricName(value) {
@@ -336,12 +415,16 @@ module.exports = {
 	WORDPRESS_ADMIN_PAGE_PROFILE_SCENARIO_IDS,
 	WORDPRESS_ADMIN_PAGE_SCENARIOS,
 	WORDPRESS_ADMIN_RESOURCE_EXCLUDE,
+	WORDPRESS_ADMIN_SCALE_SWEEP_DEFAULT_PAGES,
+	WORDPRESS_ADMIN_SCALE_SWEEP_DEFAULT_READY,
 	WORDPRESS_RESOURCE_INCLUDE,
 	WORDPRESS_ADMIN_REST_GATE,
 	createWordPressAdminPageScenarioMetrics,
 	createWordPressAdminPageScenarioManifest,
 	getWordPressAdminPageScenario,
 	listWordPressAdminPageScenarios,
+	loadWordPressAdminScaleSweepManifest,
+	normalizeWordPressAdminScaleSweepManifest,
 	normalizeWordPressAdminPageScenarioInput,
 	profileWordPressAdminPageScenario,
 	profileWordPressAdminPageScenarios,

--- a/wordpress/tests/admin-page-scenarios-smoke.js
+++ b/wordpress/tests/admin-page-scenarios-smoke.js
@@ -17,11 +17,14 @@ const {
 	WORDPRESS_ADMIN_PAGE_SCENARIO_IDS,
 	WORDPRESS_ADMIN_PAGE_PROFILE_SCENARIO_IDS,
 	WORDPRESS_ADMIN_PAGE_SCENARIOS,
+	WORDPRESS_ADMIN_SCALE_SWEEP_DEFAULT_PAGES,
 	WORDPRESS_RESOURCE_INCLUDE,
 	createWordPressAdminPageScenarioMetrics,
 	createWordPressAdminPageScenarioManifest,
 	getWordPressAdminPageScenario,
 	listWordPressAdminPageScenarios,
+	loadWordPressAdminScaleSweepManifest,
+	normalizeWordPressAdminScaleSweepManifest,
 	normalizeWordPressAdminPageScenarioInput,
 	normalizePageManifest,
 	profileWordPressAdminPageScenario,
@@ -120,6 +123,7 @@ const expectedIds = [
 assert.deepEqual(WORDPRESS_ADMIN_PAGE_SCENARIO_IDS, expectedIds);
 assert.deepEqual(WORDPRESS_ADMIN_PAGE_PROFILE_SCENARIO_IDS, ['dashboard', 'add-themes', 'site-editor-root']);
 assert.equal(WORDPRESS_ADMIN_PAGE_SCENARIOS.length, expectedIds.length);
+assert.deepEqual(WORDPRESS_ADMIN_SCALE_SWEEP_DEFAULT_PAGES.map((page) => page.id), ['dashboard', 'plugins', 'themes', 'posts', 'add-post']);
 
 for (const scenario of WORDPRESS_ADMIN_PAGE_SCENARIOS) {
 	assert.equal(typeof scenario.id, 'string');
@@ -197,9 +201,41 @@ assert.deepEqual(manifest.pages.map((scenario) => scenario.id), ['dashboard', 'a
 assert.equal(manifest.pages[3].restObservationMs, 0);
 assert.equal(normalizePageManifest(manifest).length, 4);
 
+const scaleSweepManifest = normalizeWordPressAdminScaleSweepManifest({
+	pages: [
+		{ path: '/wp-admin/admin.php?page=custom-settings' },
+		{ id: 'custom-metric', metricId: 'explicit_metric', path: '/wp-admin/tools.php', interactions: [{ type: 'click', selector: '#submit' }] },
+	],
+});
+assert.deepEqual(scaleSweepManifest.pages.map((page) => page.id), ['wp-admin-admin.php-page-custom-settings', 'custom-metric']);
+assert.equal(scaleSweepManifest.pages[0].metricId, 'wp_admin_admin_php_page_custom_settings');
+assert.equal(scaleSweepManifest.pages[0].label, 'wp-admin-admin.php-page-custom-settings');
+assert.equal(scaleSweepManifest.pages[0].ready.selector, '#wpbody-content, body.wp-admin');
+assert.equal(scaleSweepManifest.pages[0].timeout, 120000);
+assert.deepEqual(scaleSweepManifest.pages[0].interactions, []);
+assert.equal(scaleSweepManifest.pages[0].resources.includeResourceSubstrings.includes('/wp-json/'), true);
+assert.equal(scaleSweepManifest.pages[1].metricId, 'explicit_metric');
+assert.equal(scaleSweepManifest.pages[1].interactions.length, 1);
+assert.deepEqual(normalizeWordPressAdminScaleSweepManifest({ pages: [{ path: '/wp-admin/index.php' }] }, {
+	pageProfiler: { DEFAULT_RESOURCE_INCLUDE: ['/custom-resource/'] },
+}).pages[0].resources.includeResourceSubstrings, ['/custom-resource/']);
+
 assert.throws(() => getWordPressAdminPageScenario('missing'), /Unknown WordPress admin page scenario/);
 
 async function main() {
+	const defaultScaleSweepManifest = await loadWordPressAdminScaleSweepManifest();
+	assert.deepEqual(defaultScaleSweepManifest.pages.map((page) => page.id), ['dashboard', 'plugins', 'themes', 'posts', 'add-post']);
+
+	const manifestPath = path.join(os.tmpdir(), `homeboy-admin-scale-sweep-${process.pid}.json`);
+	try {
+		writeJson(manifestPath, { pages: [{ id: 'tools', path: '/wp-admin/tools.php' }] });
+		const loadedScaleSweepManifest = await loadWordPressAdminScaleSweepManifest({ path: manifestPath });
+		assert.deepEqual(loadedScaleSweepManifest.pages.map((page) => page.id), ['tools']);
+		assert.equal(loadedScaleSweepManifest.pages[0].metricId, 'tools');
+	} finally {
+		fs.rmSync(manifestPath, { force: true });
+	}
+
 	const marks = [];
 	const page = new FakePage([
 		{ name: 'https://example.test/wp-admin/load-styles.php', startTime: 1, duration: 10 },


### PR DESCRIPTION
## Summary
- Moves WordPress admin scale sweep manifest normalization into the reusable WordPress admin scenario helper layer.
- Preserves the existing five-page default sweep coverage and resource include override behavior used by Studio rigs.
- Adds smoke coverage for default loading, custom manifest normalization, metric IDs, interactions, and resource defaults.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/1149

## Verification
- `npm run test:admin-page-scenarios`
- `npm run lint:js -- lib/admin-page-scenarios.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the helper extraction, smoke coverage, and verification steps; Chris remains responsible for review and merge.