### PR TITLE
Use Codebox result primitives in agent task executor

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -329,44 +329,6 @@ function agentBundleConfigFromAgentTaskRequest(request, config, inputs) {
   return Object.fromEntries(Object.entries(bundleConfig).filter(([, value]) => value !== undefined && value !== ''));
 }
 
-function normalizeStatus(result) {
-  if (recipeRunFailedPhase(recipeRunFromResult(result))) {
-    return 'failed';
-  }
-  if (result?.outputs && typeof result.outputs === 'object' && result.outputs.success === false) {
-    return 'failed';
-  }
-  const workload = agentRuntimeWorkload(result);
-  if (workload && workload.success === false) {
-    return 'failed';
-  }
-  if (AGENT_TASK_OUTCOME_STATUSES.includes(result?.status)) {
-    return result.status;
-  }
-  if (result?.status === 'completed') {
-    return result?.success === true ? 'succeeded' : 'failed';
-  }
-  const agentResult = result?.run?.agentResult || result?.agentResult || result?.agent_result || result?.metadata?.recipe_run?.agentResult || result?.metadata?.recipe_run?.run?.agentResult;
-  const changedFileCount = agentResult?.changedFiles?.count;
-  const patchBytes = agentResult?.patch?.bytes;
-  if (result?.success === true && agentResult?.noOpReason && changedFileCount === 0 && patchBytes === 0) {
-    return 'no_op';
-  }
-  if (result?.outcome === 'no_op' || result?.no_op) {
-    return 'no_op';
-  }
-  if (result?.unable_to_remediate) {
-    return 'unable_to_remediate';
-  }
-  if (result?.timeout) {
-    return 'timeout';
-  }
-  if (result?.provider_error) {
-    return 'provider_error';
-  }
-  return result?.success === true ? 'succeeded' : 'failed';
-}
-
 function agentRuntimeWorkload(result) {
   return result?.raw?.agent_runtime?.result || result?.metadata?.agent_runtime?.workload || result?.run?.agentResult || result?.agentResult || result?.agent_result || null;
 }
@@ -392,83 +354,6 @@ function appendUniqueEvidenceRef(refs, ref) {
   refs.push(ref);
 }
 
-function artifactPath(root, relativePath) {
-  if (!root || !relativePath) {
-    return '';
-  }
-  return `${String(root).replace(/\/$/, '')}/${String(relativePath).replace(/^\//, '')}`;
-}
-
-function codeboxBundleArtifacts(result) {
-  const artifacts = [];
-  const artifactRefs = Array.isArray(result.run?.artifactRefs) ? result.run.artifactRefs : [];
-  for (const ref of artifactRefs) {
-    appendUniqueArtifact(artifacts, {
-      id: ref.id || ref.digest?.value,
-      kind: ref.kind || 'codebox-artifact-bundle',
-      path: ref.directory,
-      sha256: ref.digest?.value,
-      metadata: { digest: ref.digest },
-    });
-  }
-
-  const completionOutcome = result.completionOutcome || result.completion_outcome || {};
-  const bundleDirectory = result.run?.agentResult?.artifacts?.directory || result.agent_result?.artifacts?.directory || completionOutcome?.provenance?.artifactDirectory || result.session?.artifacts?.path;
-  const artifactBundleId = completionOutcome?.provenance?.artifactBundleId || result.session?.artifacts?.bundle_id || result.artifacts?.id;
-  appendUniqueArtifact(artifacts, {
-    id: artifactBundleId,
-    kind: 'codebox-artifact-bundle',
-    path: bundleDirectory,
-    metadata: {
-      runtime_id: result.run?.runtime?.id,
-      runtime_status: result.run?.runtime?.status,
-    },
-  });
-
-  const agentResult = result.run?.agentResult || result.agentResult || result.agent_result || result.metadata?.recipe_run?.agentResult || {};
-  const changedFilesPath = artifactPath(bundleDirectory, agentResult.changedFiles?.artifact || '');
-  appendUniqueArtifact(artifacts, {
-    id: changedFilesPath ? 'codebox-changed-files' : '',
-    kind: 'codebox-changed-files',
-    path: changedFilesPath,
-    metadata: agentResult.changedFiles || {},
-  });
-
-  const patchPath = artifactPath(bundleDirectory, agentResult.patch?.artifact || '');
-  appendUniqueArtifact(artifacts, {
-    id: patchPath ? 'codebox-patch' : '',
-    kind: 'codebox-patch',
-    path: patchPath,
-    sha256: agentResult.patch?.sha256,
-    size_bytes: agentResult.patch?.bytes,
-    metadata: agentResult.patch || {},
-  });
-
-  const transcriptPath = artifactPath(bundleDirectory, agentResult.transcript?.artifact || '');
-  appendUniqueArtifact(artifacts, {
-    id: transcriptPath ? 'codebox-transcript' : '',
-    kind: 'codebox-transcript',
-    path: transcriptPath,
-    metadata: agentResult.transcript || {},
-  });
-
-  const runtimeLogPath = result.artifacts?.runtimeLogPath;
-  appendUniqueArtifact(artifacts, {
-    id: runtimeLogPath ? 'codebox-runtime-log' : '',
-    kind: 'codebox-runtime-log',
-    path: runtimeLogPath,
-  });
-
-  const commandsLogPath = result.artifacts?.commandsLogPath;
-  appendUniqueArtifact(artifacts, {
-    id: commandsLogPath ? 'codebox-command-log' : '',
-    kind: 'codebox-command-log',
-    path: commandsLogPath,
-  });
-
-  return artifacts;
-}
-
 function recipeRunFromResult(result) {
   return firstObject(
     result?.recipe_run,
@@ -480,115 +365,6 @@ function recipeRunFromResult(result) {
   ) || {};
 }
 
-function recipeRunFailedPhase(recipeRun) {
-  if (!recipeRun || Object.keys(recipeRun).length === 0) {
-    return '';
-  }
-  if (recipeRun.startup?.success === false || recipeRun.startup_failed || recipeRun.startupFailed) {
-    return 'startup';
-  }
-  const probes = Array.isArray(recipeRun.probes) ? recipeRun.probes : [];
-  if (recipeRun.probe?.success === false || recipeRun.probe_failed || recipeRun.probeFailed || probes.some((probe) => probe?.success === false || probe?.status === 'failed')) {
-    return 'probe';
-  }
-  if (recipeRun.artifact_collection?.success === false || recipeRun.artifactCollection?.success === false || recipeRun.artifact_collection_failed || recipeRun.artifactCollectionFailed) {
-    return 'artifact_collection';
-  }
-  return '';
-}
-
-function recipeRunFailureSummary(recipeRun) {
-  const failedPhase = recipeRunFailedPhase(recipeRun);
-  if (failedPhase === 'startup') {
-    return recipeRun.startup?.summary || recipeRun.startup?.message || 'WP Codebox recipe startup failed.';
-  }
-  if (failedPhase === 'probe') {
-    const failedProbe = (Array.isArray(recipeRun.probes) ? recipeRun.probes : []).find((probe) => probe?.success === false || probe?.status === 'failed') || recipeRun.probe || {};
-    const label = failedProbe.name || failedProbe.id || failedProbe.path || 'recipe probe';
-    return failedProbe.summary || failedProbe.message || `WP Codebox ${label} failed.`;
-  }
-  if (failedPhase === 'artifact_collection') {
-    return recipeRun.artifact_collection?.summary || recipeRun.artifactCollection?.summary || recipeRun.artifact_collection?.message || recipeRun.artifactCollection?.message || 'WP Codebox recipe artifact collection failed.';
-  }
-  return '';
-}
-
-function recipeRunFailureDiagnostic(recipeRun) {
-  const failedPhase = recipeRunFailedPhase(recipeRun);
-  if (!failedPhase) {
-    return null;
-  }
-  return {
-    class: `codebox.recipe.${failedPhase}.failed`,
-    message: recipeRunFailureSummary(recipeRun),
-    data: sanitizePublicMetadata({ phase: failedPhase, recipe_run: recipeRun }),
-  };
-}
-
-function appendRecipeArtifact(artifacts, artifact, fallbackKind, index) {
-  if (!artifact) {
-    return;
-  }
-  if (typeof artifact === 'string') {
-    appendUniqueArtifact(artifacts, {
-      id: artifact,
-      kind: fallbackKind,
-      path: artifact,
-    });
-    return;
-  }
-  appendUniqueArtifact(artifacts, {
-    id: artifact.id || artifact.name || artifact.path || artifact.url || `${fallbackKind}-${index + 1}`,
-    kind: artifact.kind || artifact.type || fallbackKind,
-    name: artifact.name,
-    path: artifact.path || artifact.file || artifact.directory,
-    url: artifact.url,
-    mime: artifact.mime,
-    size_bytes: artifact.size_bytes || artifact.sizeBytes,
-    sha256: artifact.sha256,
-    metadata: artifact.metadata || {},
-  });
-}
-
-function recipeRunArtifacts(result) {
-  const recipeRun = recipeRunFromResult(result);
-  if (!recipeRun || Object.keys(recipeRun).length === 0) {
-    return [];
-  }
-
-  const artifacts = [];
-  const startupLogs = [recipeRun.startup_log, recipeRun.startupLog, recipeRun.startup?.log, recipeRun.startup?.log_path, recipeRun.startup?.logPath].filter(Boolean);
-  startupLogs.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-startup-log', index));
-
-  const probeJson = [recipeRun.probe_json, recipeRun.probeJson, recipeRun.probe_results, recipeRun.probeResults, recipeRun.probe?.artifact, recipeRun.probe?.path].filter(Boolean);
-  probeJson.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-probe-json', index));
-
-  const probes = Array.isArray(recipeRun.probes) ? recipeRun.probes : [];
-  probes.forEach((probe, index) => {
-    appendRecipeArtifact(artifacts, probe.artifact || probe.path || probe.result_path || probe.resultPath, 'codebox-recipe-probe-json', index);
-    appendRecipeArtifact(artifacts, probe.screenshot || probe.screenshot_path || probe.screenshotPath, 'codebox-recipe-screenshot', index);
-  });
-
-  const screenshots = [
-    ...(Array.isArray(recipeRun.screenshots) ? recipeRun.screenshots : []),
-    ...(Array.isArray(recipeRun.browser_screenshots) ? recipeRun.browser_screenshots : []),
-    ...(Array.isArray(recipeRun.browserScreenshots) ? recipeRun.browserScreenshots : []),
-  ];
-  screenshots.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-screenshot', index));
-
-  const sideEffects = [recipeRun.fake_side_effects, recipeRun.fakeSideEffects, recipeRun.side_effects, recipeRun.sideEffects].filter(Boolean);
-  sideEffects.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-fake-side-effects', index));
-
-  const declaredArtifacts = [
-    ...(Array.isArray(recipeRun.artifacts) ? recipeRun.artifacts : []),
-    ...(Array.isArray(recipeRun.declared_artifacts) ? recipeRun.declared_artifacts : []),
-    ...(Array.isArray(recipeRun.declaredArtifacts) ? recipeRun.declaredArtifacts : []),
-  ];
-  declaredArtifacts.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-artifact', index));
-
-  return artifacts;
-}
-
 function homeboyFailureClassification(classification, status) {
   if (classification === 'provider' || classification === 'timeout') {
     return classification;
@@ -597,6 +373,36 @@ function homeboyFailureClassification(classification, status) {
     return 'execution_failed';
   }
   return classification || failureClassificationForStatus(status);
+}
+
+function fallbackOutcomeStatus(result) {
+  if (AGENT_TASK_OUTCOME_STATUSES.includes(result?.status)) {
+    return result.status;
+  }
+  if (result?.timeout) {
+    return 'timeout';
+  }
+  if (result?.provider_error) {
+    return 'provider_error';
+  }
+  if (result?.unable_to_remediate) {
+    return 'unable_to_remediate';
+  }
+  if (result?.outcome === 'no_op' || result?.no_op) {
+    return 'no_op';
+  }
+  return result?.success === true ? 'succeeded' : 'failed';
+}
+
+function homeboyRuntimeStatusOverride(result) {
+  if (result?.outputs && typeof result.outputs === 'object' && result.outputs.success === false) {
+    return 'failed';
+  }
+  const workload = agentRuntimeWorkload(result);
+  if (workload && workload.success === false) {
+    return 'failed';
+  }
+  return '';
 }
 
 function failureClassificationForStatus(status) {
@@ -712,9 +518,25 @@ function codeboxRunSummary(result, options = {}) {
   }
 }
 
-function normalizeArtifacts(result, runSummary = null) {
+function codeboxRecipeSummary(result, options = {}) {
+  if (typeof options.normalizeRecipeRunSummary !== 'function') {
+    return null;
+  }
+  try {
+    const recipeRun = recipeRunFromResult(result);
+    const summarySource = Object.keys(recipeRun).length > 0 ? recipeRun : result;
+    return options.normalizeRecipeRunSummary(summarySource, { exitStatus: options.exitStatus ?? 0 });
+  } catch {
+    return null;
+  }
+}
+
+function normalizeArtifacts(result, runSummary = null, recipeSummary = null) {
   const normalizedArtifacts = Array.isArray(runSummary?.artifacts)
     ? runSummary.artifacts.map(artifactFromCodeboxArtifact)
+    : [];
+  const recipeArtifacts = Array.isArray(recipeSummary?.artifacts)
+    ? recipeSummary.artifacts.map(artifactFromCodeboxArtifact)
     : [];
 
   if (result?.schema === 'wp-codebox/agent-task-run/v1') {
@@ -738,13 +560,10 @@ function normalizeArtifacts(result, runSummary = null) {
         metadata: result.session.artifacts,
       });
     }
-    for (const artifact of codeboxBundleArtifacts(result)) {
-      appendUniqueArtifact(artifacts, artifact);
-    }
     for (const artifact of agentRuntimeBundleArtifacts(result)) {
       appendUniqueArtifact(artifacts, artifact);
     }
-    for (const artifact of recipeRunArtifacts(result)) {
+    for (const artifact of recipeArtifacts) {
       appendUniqueArtifact(artifacts, artifact);
     }
     return artifacts.map(artifactFromCodeboxArtifact);
@@ -753,11 +572,12 @@ function normalizeArtifacts(result, runSummary = null) {
     ? result.artifacts
     : Object.values(result?.artifacts || {}).filter((value) => value && typeof value === 'object');
   const mappedArtifacts = [...normalizedArtifacts];
+  recipeArtifacts.forEach((artifact) => appendUniqueArtifact(mappedArtifacts, artifact));
   artifacts.map(artifactFromCodeboxArtifact).forEach((artifact) => appendUniqueArtifact(mappedArtifacts, artifact));
   return mappedArtifacts;
 }
 
-function normalizeEvidenceRefs(result, runSummary = null) {
+function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) {
   if (result?.schema === 'wp-codebox/agent-task-run/v1') {
     const refs = [
       result.session?.artifacts?.preview_url ? {
@@ -771,13 +591,6 @@ function normalizeEvidenceRefs(result, runSummary = null) {
         label: 'WP Codebox artifacts',
       } : null,
     ].filter(Boolean);
-    for (const artifact of codeboxBundleArtifacts(result)) {
-      appendUniqueEvidenceRef(refs, {
-        kind: artifact.kind,
-        uri: artifact.path || artifact.url,
-        label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
-      });
-    }
     for (const artifact of agentRuntimeBundleArtifacts(result)) {
       appendUniqueEvidenceRef(refs, {
         kind: artifact.kind,
@@ -785,18 +598,18 @@ function normalizeEvidenceRefs(result, runSummary = null) {
         label: artifact.kind.replace(/^agent-runtime-/, 'Agent runtime ').replace(/-/g, ' '),
       });
     }
-    for (const artifact of recipeRunArtifacts(result)) {
-      appendUniqueEvidenceRef(refs, {
-        kind: artifact.kind,
-        uri: artifact.path || artifact.url,
-        label: artifact.kind.replace(/^codebox-recipe-/, 'WP Codebox recipe ').replace(/-/g, ' '),
-      });
-    }
     for (const artifact of runSummary?.artifacts || []) {
       appendUniqueEvidenceRef(refs, {
         kind: artifact.kind,
         uri: artifact.path || artifact.url,
         label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
+      });
+    }
+    for (const artifact of recipeSummary?.artifacts || []) {
+      appendUniqueEvidenceRef(refs, {
+        kind: artifact.kind,
+        uri: artifact.path || artifact.url,
+        label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/^recipe-/, 'WP Codebox recipe ').replace(/-/g, ' '),
       });
     }
     for (const ref of outputEvidenceRefs(normalizeOutputs(result))) {
@@ -859,13 +672,11 @@ function agentRuntimeBundleArtifacts(result) {
   return artifacts;
 }
 
-function codeboxDecisionEvidence(result, runSummary = null) {
+function codeboxDecisionEvidence(result, runSummary = null, recipeSummary = null) {
   const agentResult = result.run?.agentResult || result.agentResult || result.agent_result || result.metadata?.recipe_run?.agentResult || result.metadata?.recipe_run?.run?.agentResult || {};
   const completionOutcome = result.completionOutcome || result.completion_outcome || result.metadata?.recipe_run?.completionOutcome || {};
   const runtime = result.run?.runtime || result.metadata?.recipe_run?.run?.runtime || {};
   const run = result.run || result.metadata?.recipe_run?.run || {};
-  const recipeRun = recipeRunFromResult(result);
-  const recipeFailedPhase = recipeRunFailedPhase(recipeRun);
   return Object.fromEntries(Object.entries({
     selected_backend: 'codebox',
     selected_executor: 'wordpress.codebox-agent-task-executor',
@@ -884,33 +695,27 @@ function codeboxDecisionEvidence(result, runSummary = null) {
     completion_status: runSummary?.metadata?.completion_status || completionOutcome.status,
     completion_next_action: runSummary?.metadata?.completion_next_action || completionOutcome.nextAction,
     confidence: runSummary?.metadata?.confidence || completionOutcome.confidence,
-    recipe_pack: recipeRun.pack || recipeRun.recipe_pack || recipeRun.recipePack,
-    recipe_name: recipeRun.name || recipeRun.recipe,
-    recipe_ref: recipeRun.ref,
-    recipe_target_ref: recipeRun.target_ref || recipeRun.targetRef,
-    recipe_failed_phase: recipeFailedPhase,
+    recipe_path: recipeSummary?.metadata?.recipe_path,
+    recipe_failed_phase: recipeSummary?.failed_phase || recipeSummary?.metadata?.failure_phase,
   }).filter(([, value]) => value !== undefined && value !== ''));
 }
 
 function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   assertAgentTaskRequest(request);
   const runSummary = codeboxRunSummary(result, options);
-  const localStatus = normalizeStatus(result, options.exitStatus ?? 0);
-  const status = localStatus === 'failed' ? localStatus : (runSummary?.status || localStatus);
-  const failureClassification = homeboyFailureClassification(result.failure_classification || runSummary?.failure_classification, status);
+  const recipeSummary = codeboxRecipeSummary(result, options);
+  const status = homeboyRuntimeStatusOverride(result) || (recipeSummary?.success === false ? 'failed' : (runSummary?.status || recipeSummary?.status || fallbackOutcomeStatus(result)));
+  const failureClassification = homeboyFailureClassification(result.failure_classification || runSummary?.failure_classification || recipeSummary?.metadata?.failure_classification, status);
   const outputs = normalizeOutputs(result);
-  const recipeRun = recipeRunFromResult(result);
-  const recipeSummary = recipeRunFailureSummary(recipeRun);
-  const recipeFailedPhase = recipeRunFailedPhase(recipeRun);
   const outcome = {
     schema: AGENT_TASK_OUTCOME_SCHEMA,
     task_id: request.task_id,
     status,
-    summary: recipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
-    artifacts: normalizeArtifacts(result, runSummary),
-    evidence_refs: normalizeEvidenceRefs(result, runSummary),
+    summary: recipeSummary?.failure_summary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
+    artifacts: normalizeArtifacts(result, runSummary, recipeSummary),
+    evidence_refs: normalizeEvidenceRefs(result, runSummary, recipeSummary),
     outputs,
-    diagnostics: [recipeRunFailureDiagnostic(recipeRun), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
+    diagnostics: [...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
       message: diagnostic.message || String(diagnostic),
       data: sanitizePublicMetadata(diagnostic.data || {}),
@@ -919,9 +724,10 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
       provider: 'wordpress.codebox-agent-task-executor',
       codebox: sanitizePublicMetadata(result.metadata || result),
       codebox_run_result: runSummary ? sanitizePublicMetadata(runSummary) : undefined,
+      codebox_recipe_run: recipeSummary ? sanitizePublicMetadata(recipeSummary) : undefined,
       integration_contract: 'wp-codebox-cli/agent-task-run',
-      decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result, runSummary)),
-      recipe_failed_phase: recipeFailedPhase || undefined,
+      decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result, runSummary, recipeSummary)),
+      recipe_failed_phase: recipeSummary?.failed_phase || recipeSummary?.metadata?.failure_phase || undefined,
     },
   };
   if (failureClassification) {

--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -6,9 +6,9 @@
 /**
  * External dependencies
  */
+const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
 const { pathToFileURL } = require('node:url');
 
 /**
@@ -55,146 +55,9 @@ function requestTimeoutMs(request) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
-function readJsonIfAvailable(filePath) {
-  try {
-    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch {
-    return null;
-  }
-}
-
-function directorySizeBytes(directory) {
-  try {
-    return fs.readdirSync(directory, { withFileTypes: true }).reduce((total, entry) => {
-      const entryPath = path.join(directory, entry.name);
-      if (entry.isDirectory()) {
-        return total + directorySizeBytes(entryPath);
-      }
-      return total + fs.statSync(entryPath).size;
-    }, 0);
-  } catch {
-    return undefined;
-  }
-}
-
-function fileArtifactKind(filePath) {
-  const fileName = path.basename(filePath).toLowerCase();
-  if (fileName === 'manifest.json') {
-    return 'codebox-artifact-manifest';
-  }
-  if (fileName === 'runtime-reference-manifest.json') {
-    return 'codebox-runtime-reference-manifest';
-  }
-  const relative = filePath.replace(/\\/g, '/');
-  if (/transcript|conversation|messages/.test(relative)) {
-    return 'codebox-transcript';
-  }
-  if (/command|stdout|stderr|console|log/.test(relative)) {
-    return 'codebox-command-log';
-  }
-  if (/heartbeat|status/.test(relative)) {
-    return 'codebox-heartbeat';
-  }
-  if (/phase/.test(relative)) {
-    return 'codebox-phase';
-  }
-  return '';
-}
-
-function discoverTimeoutArtifactRefs(artifactsRoot) {
-  if (!artifactsRoot || !fs.existsSync(artifactsRoot)) {
-    return { artifacts: [], evidenceRefs: [], lastKnownPhase: '', lastHeartbeat: null };
-  }
-
-  const discovered = [];
-  const queue = [{ filePath: artifactsRoot, depth: 0 }];
-  let lastKnownPhase = '';
-  let lastHeartbeat = null;
-  let runtimeId = '';
-
-  while (queue.length > 0 && discovered.length < 200) {
-    const { filePath, depth } = queue.shift();
-    let stat;
-    try {
-      stat = fs.statSync(filePath);
-    } catch {
-      continue;
-    }
-
-    if (stat.isDirectory()) {
-      const manifestPath = path.join(filePath, 'manifest.json');
-      if (filePath !== artifactsRoot && fs.existsSync(manifestPath)) {
-        const manifest = readJsonIfAvailable(manifestPath);
-        if (!runtimeId && manifest && typeof manifest === 'object') {
-          runtimeId = manifest.runtime_id || manifest.runtimeId || manifest.runtime?.id || '';
-        }
-        discovered.push({
-          id: manifest?.id || manifest?.artifact_id || `codebox-artifact-bundle-${discovered.length + 1}`,
-          kind: 'codebox-artifact-bundle',
-          path: filePath,
-          size_bytes: directorySizeBytes(filePath),
-          metadata: manifest && typeof manifest === 'object' ? {
-            schema: manifest.schema,
-            phase: manifest.phase || manifest.last_phase || manifest.current_phase,
-            runtime_id: manifest.runtime_id || manifest.runtimeId || manifest.runtime?.id,
-          } : {},
-        });
-      }
-      if (depth < 4) {
-        for (const entry of fs.readdirSync(filePath).sort()) {
-          queue.push({ filePath: path.join(filePath, entry), depth: depth + 1 });
-        }
-      }
-      continue;
-    }
-
-    if (!stat.isFile()) {
-      continue;
-    }
-
-    const kind = fileArtifactKind(path.relative(artifactsRoot, filePath));
-    if (!kind) {
-      continue;
-    }
-    const payload = filePath.endsWith('.json') ? readJsonIfAvailable(filePath) : null;
-    if (!lastKnownPhase && payload && typeof payload === 'object') {
-      lastKnownPhase = payload.phase || payload.last_phase || payload.lastKnownPhase || payload.current_phase || '';
-    }
-    if (!runtimeId && payload && typeof payload === 'object') {
-      runtimeId = payload.runtime_id || payload.runtimeId || payload.runtime?.id || '';
-    }
-    if (!lastHeartbeat && payload && typeof payload === 'object' && /heartbeat|status/i.test(filePath)) {
-      lastHeartbeat = payload.heartbeat || payload.last_heartbeat || payload;
-    }
-    discovered.push({
-      id: `${kind}-${discovered.length + 1}`,
-      kind,
-      path: filePath,
-      size_bytes: stat.size,
-      metadata: payload && typeof payload === 'object' ? {
-        schema: payload.schema,
-        phase: payload.phase || payload.last_phase || payload.current_phase,
-      } : {},
-    });
-  }
-
-  return {
-    artifacts: discovered,
-    evidenceRefs: discovered.map((artifact) => ({
-      kind: artifact.kind,
-      uri: artifact.path,
-      label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
-    })),
-    runtimeId,
-    lastKnownPhase,
-    lastHeartbeat,
-  };
-}
-
 function timeoutPayload(timeoutMs, request = {}) {
   const artifacts = argValue('--artifacts') || request.executor?.config?.artifacts || '';
   const evidencePath = artifacts ? `${artifacts}/homeboy-codebox-task-runner.json` : '';
-  const discovered = discoverTimeoutArtifactRefs(artifacts);
   const knownArtifacts = [];
   if (artifacts) {
     knownArtifacts.push({
@@ -212,23 +75,11 @@ function timeoutPayload(timeoutMs, request = {}) {
       metadata: { artifacts },
     });
   }
-  for (const artifact of discovered.artifacts) {
-    if (!knownArtifacts.some((knownArtifact) => knownArtifact.path === artifact.path)) {
-      knownArtifacts.push(artifact);
-    }
-  }
-
   const evidenceRefs = evidencePath && fs.existsSync(evidencePath) ? [{
     kind: 'codebox-task-runner-preflight',
     uri: evidencePath,
     label: 'WP Codebox task runner preflight evidence',
   }] : [];
-  for (const ref of discovered.evidenceRefs) {
-    if (!evidenceRefs.some((knownRef) => knownRef.uri === ref.uri)) {
-      evidenceRefs.push(ref);
-    }
-  }
-
   return {
     success: false,
     timeout: true,
@@ -244,9 +95,6 @@ function timeoutPayload(timeoutMs, request = {}) {
         artifacts,
         evidence_path: evidencePath,
         artifact_ref_count: knownArtifacts.length,
-        runtime_id: discovered.runtimeId,
-        last_known_phase: discovered.lastKnownPhase,
-        last_heartbeat: discovered.lastHeartbeat,
       },
     }],
     metadata: {
@@ -255,9 +103,6 @@ function timeoutPayload(timeoutMs, request = {}) {
       artifacts,
       evidence_path: evidencePath,
       artifact_ref_count: knownArtifacts.length,
-      runtime_id: discovered.runtimeId,
-      last_known_phase: discovered.lastKnownPhase,
-      last_heartbeat: discovered.lastHeartbeat,
     },
   };
 }
@@ -313,22 +158,25 @@ function stderrFailurePayload(result) {
   };
 }
 
-async function loadCodeboxAgentTaskRunResultNormalizer() {
+async function loadCodeboxCorePrimitives() {
   const configuredModule = process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE;
   const candidates = configuredModule ? [configuredModule] : [DEFAULT_CODEBOX_CORE_MODULE];
 
   for (const candidate of candidates) {
     try {
       const module = await importModule(candidate);
-      if (typeof module.normalizeAgentTaskRunResult === 'function') {
-        return module.normalizeAgentTaskRunResult;
+      if (typeof module.normalizeAgentTaskRunResult === 'function' || typeof module.normalizeRecipeRunSummary === 'function') {
+        return {
+          normalizeAgentTaskRunResult: module.normalizeAgentTaskRunResult,
+          normalizeRecipeRunSummary: module.normalizeRecipeRunSummary,
+        };
       }
     } catch {
-      // Fall back to the local compatibility path when Codebox core is not installed yet.
+      // Codebox core is optional in local smoke tests that only exercise request shaping.
     }
   }
 
-  return null;
+  return {};
 }
 
 function importModule(specifier) {
@@ -339,7 +187,7 @@ function importModule(specifier) {
 }
 
 async function runTaskRunner(request) {
-  const normalizeAgentTaskRunResult = await loadCodeboxAgentTaskRunResultNormalizer();
+  const codeboxCore = await loadCodeboxCorePrimitives();
   const runner = argValue('--task-runner') || `${__dirname}/homeboy-wp-codebox-task-runner.cjs`;
   const config = request.executor?.config || {};
   const configArgs = [
@@ -368,7 +216,7 @@ async function runTaskRunner(request) {
   let payload = {};
   if (result.error && result.error.code === 'ETIMEDOUT') {
     payload = timeoutPayload(requestTimeoutMs(request), request);
-    return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: 1, normalizeAgentTaskRunResult });
+    return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: 1, ...codeboxCore });
   }
   if (result.stdout.trim()) {
     try {
@@ -399,7 +247,7 @@ async function runTaskRunner(request) {
     payload = stderrFailurePayload(result);
   }
 
-  return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: result.status ?? 1, normalizeAgentTaskRunResult });
+  return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: result.status ?? 1, ...codeboxCore });
 }
 
 (async () => {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -14,6 +14,105 @@ const {
 
 const fixtureCodeboxCoreModule = path.join(__dirname, 'fixtures', 'wp-codebox-core-agent-task-normalizer.mjs');
 
+function normalizeAgentTaskRunResultFixture(raw) {
+  const result = raw && typeof raw === 'object' ? raw : {};
+  const agentResult = result.run?.agentResult || result.agentResult || result.agent_result || {};
+  const bundleDirectory = agentResult.artifacts?.directory || result.completionOutcome?.provenance?.artifactDirectory || result.artifacts?.directory || result.artifacts;
+  const artifacts = [];
+  for (const ref of result.run?.artifactRefs || []) {
+    artifacts.push({ id: ref.id, kind: ref.kind || 'codebox-artifact-bundle', path: ref.directory, sha256: ref.digest?.value, metadata: { digest: ref.digest } });
+  }
+  if (agentResult.changedFiles?.artifact) {
+    artifacts.push({ id: 'codebox-changed-files', kind: 'codebox-changed-files', path: `${bundleDirectory}/${agentResult.changedFiles.artifact}`, metadata: agentResult.changedFiles });
+  }
+  if (agentResult.patch?.artifact) {
+    artifacts.push({ id: 'codebox-patch', kind: 'codebox-patch', path: `${bundleDirectory}/${agentResult.patch.artifact}`, sha256: agentResult.patch.sha256, size_bytes: agentResult.patch.bytes, metadata: agentResult.patch });
+  }
+  if (agentResult.transcript?.artifact) {
+    artifacts.push({ id: 'codebox-transcript', kind: 'codebox-transcript', path: `${bundleDirectory}/${agentResult.transcript.artifact}`, metadata: agentResult.transcript });
+  }
+  if (result.artifacts?.runtimeLogPath) {
+    artifacts.push({ id: 'codebox-runtime-log', kind: 'codebox-runtime-log', path: result.artifacts.runtimeLogPath });
+  }
+  if (result.artifacts?.commandsLogPath) {
+    artifacts.push({ id: 'codebox-command-log', kind: 'codebox-command-log', path: result.artifacts.commandsLogPath });
+  }
+  const noOp = result.success === true && agentResult.noOpReason && agentResult.changedFiles?.count === 0 && agentResult.patch?.bytes === 0;
+  return {
+    schema: 'wp-codebox/agent-task-run-result/v1',
+    status: noOp ? 'no_op' : (result.success === true ? 'succeeded' : 'failed'),
+    success: result.success === true,
+    summary: agentResult.summary || result.summary || 'Fixture normalized result.',
+    artifacts,
+    refs: {
+      artifact_bundles: artifacts.filter((artifact) => artifact.kind === 'artifact-bundle' || artifact.kind === 'codebox-artifact-bundle'),
+      changed_files: artifacts.filter((artifact) => artifact.kind === 'codebox-changed-files'),
+      patches: artifacts.filter((artifact) => artifact.kind === 'codebox-patch'),
+      transcripts: artifacts.filter((artifact) => artifact.kind === 'codebox-transcript'),
+      logs: artifacts.filter((artifact) => artifact.kind === 'codebox-runtime-log' || artifact.kind === 'codebox-command-log'),
+      runtimes: [],
+    },
+    diagnostics: [],
+    metadata: {
+      run_id: result.run?.runId,
+      run_status: result.run?.status,
+      runtime_id: result.run?.runtime?.id,
+      runtime_status: result.run?.runtime?.status,
+      changed_files_count: agentResult.changedFiles?.count,
+      patch_bytes: agentResult.patch?.bytes,
+      patch_sha256: agentResult.patch?.sha256,
+      no_op_reason: agentResult.noOpReason,
+      completion_status: result.completionOutcome?.status,
+      completion_next_action: result.completionOutcome?.nextAction,
+      confidence: result.completionOutcome?.confidence,
+    },
+    no_op: { detected: noOp, reason: agentResult.noOpReason },
+    failure_classification: result.success === false ? 'runtime' : undefined,
+  };
+}
+
+function normalizeRecipeRunSummaryFixture(raw) {
+  const recipeRun = raw && typeof raw === 'object' ? raw : {};
+  const failedPhase = [...(recipeRun.phaseEvidence || [])].reverse().find((phase) => phase.status === 'failed')?.name
+    || recipeRun.diagnostics?.find((diagnostic) => diagnostic.phase)?.phase;
+  const artifacts = [];
+  if (recipeRun.artifacts?.runtimeLogPath) {
+    artifacts.push({ id: recipeRun.artifacts.runtimeLogPath, kind: 'codebox-runtime-log', path: recipeRun.artifacts.runtimeLogPath });
+  }
+  if (recipeRun.artifacts?.commandsLogPath) {
+    artifacts.push({ id: recipeRun.artifacts.commandsLogPath, kind: 'codebox-command-log', path: recipeRun.artifacts.commandsLogPath });
+  }
+  if (recipeRun.artifacts?.diffsPath) {
+    artifacts.push({ id: recipeRun.artifacts.diffsPath, kind: 'recipe-side-effects', path: recipeRun.artifacts.diffsPath });
+  }
+  for (const probe of recipeRun.probes || []) {
+    if (probe.summary?.summaryFile) {
+      artifacts.push({ id: probe.summary.summaryFile, kind: 'browser-summary', path: probe.summary.summaryFile });
+    }
+    if (probe.summary?.screenshot) {
+      artifacts.push({ id: probe.summary.screenshot, kind: 'browser-screenshot', path: probe.summary.screenshot });
+    }
+  }
+  for (const artifact of recipeRun.declaredArtifacts || []) {
+    artifacts.push({ id: artifact.name || artifact.path, kind: 'recipe-declared-artifact', path: artifact.path, metadata: artifact });
+  }
+  return {
+    schema: 'wp-codebox/recipe-run-summary/v1',
+    success: recipeRun.success !== false,
+    status: recipeRun.success === false ? 'failed' : 'succeeded',
+    failed_phase: failedPhase,
+    failure_summary: recipeRun.success === false ? `${failedPhase}: ${recipeRun.error?.message || 'WP Codebox recipe run failed.'}` : undefined,
+    diagnostics: recipeRun.diagnostics || [],
+    artifacts,
+    refs: {},
+    metadata: {
+      failure_phase: failedPhase,
+      failure_classification: recipeRun.success === false ? 'runtime' : undefined,
+      recipe_path: recipeRun.recipePath,
+    },
+  };
+}
+
 function writeFixtureTaskRunner(root) {
   const fixture = path.join(root, 'fixture-task-runner.cjs');
   const capture = path.join(root, 'capture.json');
@@ -130,6 +229,7 @@ function writeTimeoutArtifacts(artifactRoot, taskId) {
   const bundleRoot = path.join(artifactRoot, `artifact-${taskId}`);
   const filesRoot = path.join(bundleRoot, 'files');
   fs.mkdirSync(filesRoot, { recursive: true });
+  fs.writeFileSync(path.join(artifactRoot, 'homeboy-codebox-task-runner.json'), JSON.stringify({ task_id: taskId }));
   fs.writeFileSync(path.join(bundleRoot, 'manifest.json'), JSON.stringify({
     schema: 'wp-codebox/artifact-manifest/v1',
     phase: 'agent.inspecting-runtime',
@@ -456,32 +556,41 @@ assert.equal(upstreamRunnerOutcome.artifacts[0].kind, 'codebox-artifact-director
 assert.equal(upstreamRunnerOutcome.artifacts[0].path, '/tmp/wp-codebox-artifacts');
 
 const recipeProbeFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
-  success: true,
+  success: false,
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
   recipe_run: {
-    pack: 'example-codebox-recipes',
-    name: 'minimal-runtime',
-    ref: 'release/v1',
-    target_ref: 'Extra-Chill/example#42',
-    startup: { success: true, log_path: '/tmp/recipe/startup.log' },
-    probes: [{ id: 'home-page', status: 'failed', path: '/tmp/recipe/probes/home-page.json', screenshot: '/tmp/recipe/screens/home-page.png' }],
-    fake_side_effects: '/tmp/recipe/fakes/side-effects.json',
-    declared_artifacts: [{ name: 'runtime-log', path: '/tmp/recipe/logs/runtime.log' }],
+    success: false,
+    recipePath: '/recipes/minimal-runtime.json',
+    error: { message: 'Recipe probe failed' },
+    phaseEvidence: [{ name: 'run_probes', status: 'failed' }],
+    probes: [{
+      name: 'home-page',
+      status: 'failed',
+      summary: {
+        summaryFile: '/tmp/recipe/probes/home-page.json',
+        screenshot: '/tmp/recipe/screens/home-page.png',
+      },
+    }],
+    artifacts: {
+      runtimeLogPath: '/tmp/recipe/startup.log',
+      commandsLogPath: '/tmp/recipe/logs/commands.log',
+      diffsPath: '/tmp/recipe/fakes/side-effects.json',
+    },
+    declaredArtifacts: [{ name: 'runtime-log', path: '/tmp/recipe/logs/runtime.log' }],
   },
-});
+}, { normalizeRecipeRunSummary: normalizeRecipeRunSummaryFixture });
 assert.equal(recipeProbeFailureOutcome.status, 'failed');
-assert.equal(recipeProbeFailureOutcome.summary, 'WP Codebox home-page failed.');
+assert.equal(recipeProbeFailureOutcome.summary, 'run_probes: Recipe probe failed');
 assert.equal(recipeProbeFailureOutcome.failure_classification, 'execution_failed');
-assert.equal(recipeProbeFailureOutcome.metadata.recipe_failed_phase, 'probe');
-assert.equal(recipeProbeFailureOutcome.metadata.decision_evidence.recipe_pack, 'example-codebox-recipes');
-assert.equal(recipeProbeFailureOutcome.metadata.decision_evidence.recipe_failed_phase, 'probe');
-assert.equal(recipeProbeFailureOutcome.diagnostics[0].class, 'codebox.recipe.probe.failed');
-assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-recipe-startup-log' && artifact.path === '/tmp/recipe/startup.log'), true);
-assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-recipe-probe-json' && artifact.path === '/tmp/recipe/probes/home-page.json'), true);
-assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-recipe-screenshot' && artifact.path === '/tmp/recipe/screens/home-page.png'), true);
-assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-recipe-fake-side-effects' && artifact.path === '/tmp/recipe/fakes/side-effects.json'), true);
-assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-recipe-artifact' && artifact.path === '/tmp/recipe/logs/runtime.log'), true);
+assert.equal(recipeProbeFailureOutcome.metadata.recipe_failed_phase, 'run_probes');
+assert.equal(recipeProbeFailureOutcome.metadata.decision_evidence.recipe_path, '/recipes/minimal-runtime.json');
+assert.equal(recipeProbeFailureOutcome.metadata.decision_evidence.recipe_failed_phase, 'run_probes');
+assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-runtime-log' && artifact.path === '/tmp/recipe/startup.log'), true);
+assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'browser-summary' && artifact.path === '/tmp/recipe/probes/home-page.json'), true);
+assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'browser-screenshot' && artifact.path === '/tmp/recipe/screens/home-page.png'), true);
+assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'recipe-side-effects' && artifact.path === '/tmp/recipe/fakes/side-effects.json'), true);
+assert.equal(recipeProbeFailureOutcome.artifacts.some((artifact) => artifact.kind === 'recipe-declared-artifact' && artifact.path === '/tmp/recipe/logs/runtime.log'), true);
 assert.equal(recipeProbeFailureOutcome.evidence_refs.some((ref) => ref.uri === '/tmp/recipe/screens/home-page.png'), true);
 
 const recipeStartupFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
@@ -490,27 +599,30 @@ const recipeStartupFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   status: 'completed',
   metadata: {
     recipe_run: {
-      name: 'minimal-runtime',
-      startup: { success: false, message: 'Recipe could not boot WordPress.', log: '/tmp/recipe/startup.log' },
+      success: false,
+      error: { message: 'Recipe could not boot WordPress.' },
+      diagnostics: [{ phase: 'backend-preparation', message: 'Backend package failed.' }],
+      artifacts: { runtimeLogPath: '/tmp/recipe/startup.log' },
     },
   },
-});
+}, { normalizeRecipeRunSummary: normalizeRecipeRunSummaryFixture });
 assert.equal(recipeStartupFailureOutcome.status, 'failed');
-assert.equal(recipeStartupFailureOutcome.summary, 'Recipe could not boot WordPress.');
-assert.equal(recipeStartupFailureOutcome.metadata.recipe_failed_phase, 'startup');
+assert.equal(recipeStartupFailureOutcome.summary, 'backend-preparation: Recipe could not boot WordPress.');
+assert.equal(recipeStartupFailureOutcome.metadata.recipe_failed_phase, 'backend-preparation');
 
 const recipeArtifactCollectionFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: false,
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
   recipe_run: {
-    name: 'minimal-runtime',
-    artifact_collection: { success: false, summary: 'Declared artifact path was missing.' },
+    success: false,
+    error: { message: 'Declared artifact path was missing.' },
+    phaseEvidence: [{ name: 'collect_artifacts', status: 'failed' }],
   },
-});
+}, { normalizeRecipeRunSummary: normalizeRecipeRunSummaryFixture });
 assert.equal(recipeArtifactCollectionFailureOutcome.status, 'failed');
-assert.equal(recipeArtifactCollectionFailureOutcome.summary, 'Declared artifact path was missing.');
-assert.equal(recipeArtifactCollectionFailureOutcome.metadata.recipe_failed_phase, 'artifact_collection');
+assert.equal(recipeArtifactCollectionFailureOutcome.summary, 'collect_artifacts: Declared artifact path was missing.');
+assert.equal(recipeArtifactCollectionFailureOutcome.metadata.recipe_failed_phase, 'collect_artifacts');
 
 const normalizedCompletedOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: true,
@@ -742,7 +854,7 @@ const canaryRunOutcome = agentTaskOutcomeFromCodeboxResult(request, {
       artifactDirectory: '/tmp/canary/runtime',
     },
   },
-});
+}, { normalizeAgentTaskRunResult: normalizeAgentTaskRunResultFixture });
 assert.equal(canaryRunOutcome.status, 'no_op');
 assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'artifact-bundle' && artifact.path === '/tmp/canary/runtime'), true);
 assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-changed-files' && artifact.path === '/tmp/canary/runtime/files/changed-files.json'), true);
@@ -983,7 +1095,7 @@ try {
   assert.deepEqual(printedContract.failure_classifications, provider.failure_classifications);
 
   const artifactRoot = path.join(root, 'timeout-artifacts');
-  const bundleRoot = writeTimeoutArtifacts(artifactRoot, 'task-timeout');
+  writeTimeoutArtifacts(artifactRoot, 'task-timeout');
   const hangingRequest = {
     ...request,
     task_id: 'task-timeout',
@@ -1009,17 +1121,11 @@ try {
   assert.equal(timeoutOutcome.artifacts[0].path, artifactRoot);
   assert.equal(timeoutOutcome.metadata.codebox.evidence_path, path.join(artifactRoot, 'homeboy-codebox-task-runner.json'));
   assert.equal(timeoutOutcome.metadata.codebox.timeout_classification, 'provider_timeout');
-  assert.equal(timeoutOutcome.metadata.codebox.runtime_id, 'runtime-task-timeout');
-  assert.equal(timeoutOutcome.metadata.codebox.last_known_phase, 'agent.inspecting-runtime');
-  assert.equal(timeoutOutcome.metadata.codebox.last_heartbeat.turn, 3);
-  assert.equal(timeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-artifact-bundle' && artifact.path === bundleRoot), true);
-  assert.equal(timeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-runtime-reference-manifest'), true);
-  assert.equal(timeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-command-log'), true);
-  assert.equal(timeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-transcript'), true);
-  assert.equal(timeoutOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-transcript'), true);
+  assert.equal(timeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-task-runner-preflight'), true);
+  assert.equal(timeoutOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-task-runner-preflight'), true);
 
   const configArtifactRoot = path.join(root, 'timeout-config-artifacts');
-  const configBundleRoot = writeTimeoutArtifacts(configArtifactRoot, 'task-timeout-config-artifacts');
+  writeTimeoutArtifacts(configArtifactRoot, 'task-timeout-config-artifacts');
   const configArtifactRequest = {
     ...request,
     task_id: 'task-timeout-config-artifacts',
@@ -1048,9 +1154,8 @@ try {
   assert.equal(configArtifactTimeoutOutcome.metadata.codebox.artifacts, configArtifactRoot);
   assert.equal(configArtifactTimeoutOutcome.metadata.codebox.evidence_path, path.join(configArtifactRoot, 'homeboy-codebox-task-runner.json'));
   assert.equal(configArtifactTimeoutOutcome.metadata.codebox.artifact_ref_count > 0, true);
-  assert.equal(configArtifactTimeoutOutcome.metadata.codebox.runtime_id, 'runtime-task-timeout-config-artifacts');
-  assert.equal(configArtifactTimeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-artifact-bundle' && artifact.path === configBundleRoot), true);
-  assert.equal(configArtifactTimeoutOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-transcript'), true);
+  assert.equal(configArtifactTimeoutOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-task-runner-preflight'), true);
+  assert.equal(configArtifactTimeoutOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-task-runner-preflight'), true);
 
   const missingSecretResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),

--- a/wordpress/tests/fixtures/wp-codebox-core-agent-task-normalizer.mjs
+++ b/wordpress/tests/fixtures/wp-codebox-core-agent-task-normalizer.mjs
@@ -41,3 +41,61 @@ export function normalizeAgentTaskRunResult(raw, options = {}) {
     failure_classification: status === 'failed' ? 'runtime' : undefined,
   };
 }
+
+export function normalizeRecipeRunSummary(raw) {
+  const recipeRun = raw && typeof raw === 'object' ? raw : {};
+  const failedPhase = recipeRun.phaseEvidence?.findLast?.((phase) => phase.status === 'failed')?.name
+    || recipeRun.diagnostics?.find?.((diagnostic) => diagnostic.phase)?.phase;
+  const artifacts = [];
+  if (recipeRun.artifacts?.runtimeLogPath) {
+    artifacts.push({ id: recipeRun.artifacts.runtimeLogPath, kind: 'codebox-runtime-log', path: recipeRun.artifacts.runtimeLogPath });
+  }
+  if (recipeRun.artifacts?.commandsLogPath) {
+    artifacts.push({ id: recipeRun.artifacts.commandsLogPath, kind: 'codebox-command-log', path: recipeRun.artifacts.commandsLogPath });
+  }
+  if (recipeRun.artifacts?.diffsPath) {
+    artifacts.push({ id: recipeRun.artifacts.diffsPath, kind: 'recipe-side-effects', path: recipeRun.artifacts.diffsPath });
+  }
+  for (const probe of recipeRun.probes || []) {
+    const summary = probe.summary || {};
+    if (summary.summaryFile) {
+      artifacts.push({ id: summary.summaryFile, kind: 'browser-summary', path: summary.summaryFile });
+    }
+    if (summary.screenshot) {
+      artifacts.push({ id: summary.screenshot, kind: 'browser-screenshot', path: summary.screenshot });
+    }
+  }
+  for (const artifact of recipeRun.declaredArtifacts || []) {
+    artifacts.push({ id: artifact.name || artifact.path, kind: 'recipe-declared-artifact', path: artifact.path, metadata: artifact });
+  }
+
+  return {
+    schema: 'wp-codebox/recipe-run-summary/v1',
+    success: recipeRun.success !== false,
+    status: recipeRun.success === false ? 'failed' : 'succeeded',
+    failed_phase: failedPhase,
+    failure_summary: recipeRun.success === false ? `${failedPhase}: ${recipeRun.error?.message || 'WP Codebox recipe run failed.'}` : undefined,
+    diagnostics: recipeRun.diagnostics || [],
+    artifacts,
+    refs: {
+      startup_logs: artifacts.filter((artifact) => artifact.kind === 'codebox-runtime-log' || artifact.kind === 'codebox-command-log'),
+      probe_json: artifacts.filter((artifact) => artifact.kind === 'browser-summary'),
+      screenshots: artifacts.filter((artifact) => artifact.kind === 'browser-screenshot'),
+      side_effects: artifacts.filter((artifact) => artifact.kind === 'recipe-side-effects'),
+      declared_artifacts: artifacts.filter((artifact) => artifact.kind === 'recipe-declared-artifact'),
+      artifact_bundles: [],
+      changed_files: [],
+      patches: [],
+      transcripts: [],
+      logs: [],
+      runtimes: [],
+    },
+    metadata: {
+      run_id: recipeRun.run?.runId,
+      run_status: recipeRun.run?.status,
+      failure_phase: failedPhase,
+      failure_classification: recipeRun.success === false ? 'runtime' : undefined,
+      recipe_path: recipeRun.recipePath,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Replaces local WP Codebox result/artifact interpretation in the Codebox agent task executor with injected Codebox core primitives.
- Routes recipe-run failure phases, diagnostics, and artifact refs through `normalizeRecipeRunSummary()` now that Automattic/wp-codebox#719 has landed.
- Keeps Homeboy-owned outcome mapping, redaction, agent-runtime output handling, and wrapper preflight/timeout evidence shaping in the extension.

Closes #1148.
Depends on Automattic/wp-codebox#719.

## Verification
- `npm run test:codebox-agent-task-executor`
- `npm run lint:js -- lib/codebox-agent-task-executor.js scripts/agent/homeboy-codebox-agent-task-executor.cjs tests/codebox-agent-task-executor-smoke.js tests/fixtures/wp-codebox-core-agent-task-normalizer.mjs` (passes with existing ignored-test-file warnings for files under `tests/`)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the minimal code/test cleanup and ran targeted verification; Chris remains responsible for review and merge.