### PR TITLE
Use Codebox recipe run summaries

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -712,10 +712,28 @@ function codeboxRunSummary(result, options = {}) {
   }
 }
 
-function normalizeArtifacts(result, runSummary = null) {
+function codeboxRecipeRunSummary(result, options = {}) {
+  if (typeof options.normalizeRecipeRunSummary !== 'function') {
+    return null;
+  }
+  const recipeRun = recipeRunFromResult(result);
+  if (!recipeRun || Object.keys(recipeRun).length === 0) {
+    return null;
+  }
+  try {
+    return options.normalizeRecipeRunSummary(recipeRun, { exitStatus: options.exitStatus ?? 0 });
+  } catch {
+    return null;
+  }
+}
+
+function normalizeArtifacts(result, runSummary = null, recipeSummary = null) {
   const normalizedArtifacts = Array.isArray(runSummary?.artifacts)
     ? runSummary.artifacts.map(artifactFromCodeboxArtifact)
     : [];
+  if (Array.isArray(recipeSummary?.artifacts)) {
+    recipeSummary.artifacts.map(artifactFromCodeboxArtifact).forEach((artifact) => appendUniqueArtifact(normalizedArtifacts, artifact));
+  }
 
   if (result?.schema === 'wp-codebox/agent-task-run/v1') {
     const artifacts = [...normalizedArtifacts];
@@ -744,8 +762,10 @@ function normalizeArtifacts(result, runSummary = null) {
     for (const artifact of agentRuntimeBundleArtifacts(result)) {
       appendUniqueArtifact(artifacts, artifact);
     }
-    for (const artifact of recipeRunArtifacts(result)) {
-      appendUniqueArtifact(artifacts, artifact);
+    if (!recipeSummary) {
+      for (const artifact of recipeRunArtifacts(result)) {
+        appendUniqueArtifact(artifacts, artifact);
+      }
     }
     return artifacts.map(artifactFromCodeboxArtifact);
   }
@@ -757,7 +777,7 @@ function normalizeArtifacts(result, runSummary = null) {
   return mappedArtifacts;
 }
 
-function normalizeEvidenceRefs(result, runSummary = null) {
+function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) {
   if (result?.schema === 'wp-codebox/agent-task-run/v1') {
     const refs = [
       result.session?.artifacts?.preview_url ? {
@@ -785,14 +805,23 @@ function normalizeEvidenceRefs(result, runSummary = null) {
         label: artifact.kind.replace(/^agent-runtime-/, 'Agent runtime ').replace(/-/g, ' '),
       });
     }
-    for (const artifact of recipeRunArtifacts(result)) {
+    if (!recipeSummary) {
+      for (const artifact of recipeRunArtifacts(result)) {
+        appendUniqueEvidenceRef(refs, {
+          kind: artifact.kind,
+          uri: artifact.path || artifact.url,
+          label: artifact.kind.replace(/^codebox-recipe-/, 'WP Codebox recipe ').replace(/-/g, ' '),
+        });
+      }
+    }
+    for (const artifact of runSummary?.artifacts || []) {
       appendUniqueEvidenceRef(refs, {
         kind: artifact.kind,
         uri: artifact.path || artifact.url,
-        label: artifact.kind.replace(/^codebox-recipe-/, 'WP Codebox recipe ').replace(/-/g, ' '),
+        label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
       });
     }
-    for (const artifact of runSummary?.artifacts || []) {
+    for (const artifact of recipeSummary?.artifacts || []) {
       appendUniqueEvidenceRef(refs, {
         kind: artifact.kind,
         uri: artifact.path || artifact.url,
@@ -859,13 +888,13 @@ function agentRuntimeBundleArtifacts(result) {
   return artifacts;
 }
 
-function codeboxDecisionEvidence(result, runSummary = null) {
+function codeboxDecisionEvidence(result, runSummary = null, recipeSummary = null) {
   const agentResult = result.run?.agentResult || result.agentResult || result.agent_result || result.metadata?.recipe_run?.agentResult || result.metadata?.recipe_run?.run?.agentResult || {};
   const completionOutcome = result.completionOutcome || result.completion_outcome || result.metadata?.recipe_run?.completionOutcome || {};
   const runtime = result.run?.runtime || result.metadata?.recipe_run?.run?.runtime || {};
   const run = result.run || result.metadata?.recipe_run?.run || {};
   const recipeRun = recipeRunFromResult(result);
-  const recipeFailedPhase = recipeRunFailedPhase(recipeRun);
+  const recipeFailedPhase = recipeSummary?.failed_phase || recipeSummary?.metadata?.failure_phase || recipeRunFailedPhase(recipeRun);
   return Object.fromEntries(Object.entries({
     selected_backend: 'codebox',
     selected_executor: 'wordpress.codebox-agent-task-executor',
@@ -895,22 +924,23 @@ function codeboxDecisionEvidence(result, runSummary = null) {
 function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   assertAgentTaskRequest(request);
   const runSummary = codeboxRunSummary(result, options);
+  const recipeSummary = codeboxRecipeRunSummary(result, options);
   const localStatus = normalizeStatus(result, options.exitStatus ?? 0);
-  const status = localStatus === 'failed' ? localStatus : (runSummary?.status || localStatus);
-  const failureClassification = homeboyFailureClassification(result.failure_classification || runSummary?.failure_classification, status);
+  const status = recipeSummary?.status && recipeSummary.status !== 'succeeded' ? recipeSummary.status : (localStatus === 'failed' ? localStatus : (runSummary?.status || recipeSummary?.status || localStatus));
+  const failureClassification = homeboyFailureClassification(result.failure_classification || recipeSummary?.metadata?.failure_classification || runSummary?.failure_classification, status);
   const outputs = normalizeOutputs(result);
   const recipeRun = recipeRunFromResult(result);
-  const recipeSummary = recipeRunFailureSummary(recipeRun);
-  const recipeFailedPhase = recipeRunFailedPhase(recipeRun);
+  const fallbackRecipeSummary = recipeRunFailureSummary(recipeRun);
+  const recipeFailedPhase = recipeSummary?.failed_phase || recipeSummary?.metadata?.failure_phase || recipeRunFailedPhase(recipeRun);
   const outcome = {
     schema: AGENT_TASK_OUTCOME_SCHEMA,
     task_id: request.task_id,
     status,
-    summary: recipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
-    artifacts: normalizeArtifacts(result, runSummary),
-    evidence_refs: normalizeEvidenceRefs(result, runSummary),
+    summary: recipeSummary?.failure_summary || fallbackRecipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
+    artifacts: normalizeArtifacts(result, runSummary, recipeSummary),
+    evidence_refs: normalizeEvidenceRefs(result, runSummary, recipeSummary),
     outputs,
-    diagnostics: [recipeRunFailureDiagnostic(recipeRun), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
+    diagnostics: [recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
       message: diagnostic.message || String(diagnostic),
       data: sanitizePublicMetadata(diagnostic.data || {}),
@@ -919,8 +949,9 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
       provider: 'wordpress.codebox-agent-task-executor',
       codebox: sanitizePublicMetadata(result.metadata || result),
       codebox_run_result: runSummary ? sanitizePublicMetadata(runSummary) : undefined,
+      codebox_recipe_run_summary: recipeSummary ? sanitizePublicMetadata(recipeSummary) : undefined,
       integration_contract: 'wp-codebox-cli/agent-task-run',
-      decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result, runSummary)),
+      decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result, runSummary, recipeSummary)),
       recipe_failed_phase: recipeFailedPhase || undefined,
     },
   };

--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -313,22 +313,25 @@ function stderrFailurePayload(result) {
   };
 }
 
-async function loadCodeboxAgentTaskRunResultNormalizer() {
+async function loadCodeboxCoreNormalizers() {
   const configuredModule = process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE;
   const candidates = configuredModule ? [configuredModule] : [DEFAULT_CODEBOX_CORE_MODULE];
 
   for (const candidate of candidates) {
     try {
       const module = await importModule(candidate);
-      if (typeof module.normalizeAgentTaskRunResult === 'function') {
-        return module.normalizeAgentTaskRunResult;
+      if (typeof module.normalizeAgentTaskRunResult === 'function' || typeof module.normalizeRecipeRunSummary === 'function') {
+        return {
+          normalizeAgentTaskRunResult: typeof module.normalizeAgentTaskRunResult === 'function' ? module.normalizeAgentTaskRunResult : null,
+          normalizeRecipeRunSummary: typeof module.normalizeRecipeRunSummary === 'function' ? module.normalizeRecipeRunSummary : null,
+        };
       }
     } catch {
       // Fall back to the local compatibility path when Codebox core is not installed yet.
     }
   }
 
-  return null;
+  return {};
 }
 
 function importModule(specifier) {
@@ -339,7 +342,7 @@ function importModule(specifier) {
 }
 
 async function runTaskRunner(request) {
-  const normalizeAgentTaskRunResult = await loadCodeboxAgentTaskRunResultNormalizer();
+  const coreNormalizers = await loadCodeboxCoreNormalizers();
   const runner = argValue('--task-runner') || `${__dirname}/homeboy-wp-codebox-task-runner.cjs`;
   const config = request.executor?.config || {};
   const configArgs = [
@@ -368,7 +371,7 @@ async function runTaskRunner(request) {
   let payload = {};
   if (result.error && result.error.code === 'ETIMEDOUT') {
     payload = timeoutPayload(requestTimeoutMs(request), request);
-    return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: 1, normalizeAgentTaskRunResult });
+    return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: 1, ...coreNormalizers });
   }
   if (result.stdout.trim()) {
     try {
@@ -399,7 +402,7 @@ async function runTaskRunner(request) {
     payload = stderrFailurePayload(result);
   }
 
-  return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: result.status ?? 1, normalizeAgentTaskRunResult });
+  return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: result.status ?? 1, ...coreNormalizers });
 }
 
 (async () => {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -37,6 +37,11 @@ process.stdout.write(JSON.stringify({
       patch: { bytes: 123, sha256: 'fixture-patch-sha' }
     }
   },
+  recipe_run: {
+    pack: 'fixture-recipes',
+    name: 'fixture-recipe',
+    probe: { success: true }
+  },
   metadata: { run_id: 'codebox-run-1' }
 }));
 `);
@@ -826,11 +831,14 @@ try {
   assert.equal(normalizedResult.status, 0, normalizedResult.stderr || normalizedResult.stdout);
   const normalizedOutcome = JSON.parse(normalizedResult.stdout);
   assert.equal(normalizedOutcome.metadata.codebox_run_result.schema, 'wp-codebox/agent-task-run-result/v1');
+  assert.equal(normalizedOutcome.metadata.codebox_recipe_run_summary.schema, 'wp-codebox/recipe-run-summary/v1');
   assert.equal(normalizedOutcome.metadata.decision_evidence.run_id, 'fixture-run-1');
   assert.equal(normalizedOutcome.metadata.decision_evidence.runtime_status, 'destroyed');
   assert.equal(normalizedOutcome.metadata.decision_evidence.patch_sha256, 'fixture-patch-sha');
   assert.equal(normalizedOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-patch' && artifact.path === '/tmp/fixture-normalized/patch.diff'), true);
+  assert.equal(normalizedOutcome.artifacts.some((artifact) => artifact.kind === 'recipe-probe-result' && artifact.path === '/tmp/fixture-normalized/recipe-probe.json'), true);
   assert.equal(normalizedOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'fixture.normalizer'), true);
+  assert.equal(normalizedOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'fixture.recipe_normalizer'), true);
 
   const captured = JSON.parse(fs.readFileSync(capture, 'utf8'));
   assert.equal(captured.request.schema, 'wp-codebox/task-input/v1');

--- a/wordpress/tests/fixtures/wp-codebox-core-agent-task-normalizer.mjs
+++ b/wordpress/tests/fixtures/wp-codebox-core-agent-task-normalizer.mjs
@@ -41,3 +41,41 @@ export function normalizeAgentTaskRunResult(raw, options = {}) {
     failure_classification: status === 'failed' ? 'runtime' : undefined,
   };
 }
+
+export function normalizeRecipeRunSummary(raw, options = {}) {
+  const result = raw && typeof raw === 'object' ? raw : {};
+  const failedPhase = result.failed_phase || (result.probe?.success === false ? 'probe' : undefined);
+  const status = failedPhase ? 'failed' : 'succeeded';
+
+  return {
+    schema: 'wp-codebox/recipe-run-summary/v1',
+    status,
+    success: status === 'succeeded',
+    failed_phase: failedPhase,
+    failure_summary: failedPhase ? `fixture recipe ${failedPhase} failed` : undefined,
+    artifacts: [{
+      id: 'fixture-normalized-recipe-probe',
+      kind: 'recipe-probe-result',
+      path: '/tmp/fixture-normalized/recipe-probe.json',
+    }],
+    refs: {
+      startup_logs: [],
+      probe_json: [],
+      screenshots: [],
+      side_effects: [],
+      declared_artifacts: [],
+      artifact_bundles: [],
+      changed_files: [],
+      patches: [],
+      transcripts: [],
+      logs: [],
+      runtimes: [],
+    },
+    diagnostics: [{ class: 'fixture.recipe_normalizer', message: 'Fixture recipe normalizer was used.', data: { exitStatus: options.exitStatus } }],
+    metadata: {
+      failure_phase: failedPhase,
+      recipe_pack: result.pack,
+      recipe_name: result.name,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Load Codebox core normalizers as a shared primitive set, including `normalizeRecipeRunSummary()` when available.
- Use normalized recipe-run summaries for status, diagnostics, artifacts, evidence refs, and decision evidence while retaining the existing local parser as an older-core fallback.
- Extend the Codebox agent task executor smoke fixture to prove recipe-run summary normalization is consumed through `HOMEBOY_WP_CODEBOX_CORE_MODULE`.

Closes #1148.

## Testing
- `npm run test:codebox-agent-task-executor`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the provider cleanup, updated smoke fixtures, and ran targeted verification. Chris remains responsible for review and merge.