### PR TITLE
fix: resolve bundled Agents API path

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -303,7 +303,10 @@ function siblingPath(base, name) {
 }
 
 function bundledAgentsApiPath(dataMachinePath) {
-  return dataMachinePath ? path.join(dataMachinePath, 'vendor', 'automattic', 'agents-api') : '';
+  return dataMachinePath ? [
+    path.join(dataMachinePath, 'vendor', 'wordpress', 'agents-api'),
+    path.join(dataMachinePath, 'vendor', 'automattic', 'agents-api'),
+  ] : [];
 }
 
 function defaultSecretEnv(provider, settings) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -346,7 +346,8 @@ const defaultsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-agen
 try {
   const workspaceRoot = path.join(defaultsRoot, 'target-repo@issue-1161');
   const dataMachinePath = path.join(defaultsRoot, 'data-machine');
-  const bundledAgentsApiPath = path.join(dataMachinePath, 'vendor', 'automattic', 'agents-api');
+  const bundledAgentsApiPath = path.join(dataMachinePath, 'vendor', 'wordpress', 'agents-api');
+  const alternateBundledAgentsApiPath = path.join(dataMachinePath, 'vendor', 'automattic', 'agents-api');
   const dataMachineCodePath = path.join(defaultsRoot, 'data-machine-code');
   const staleStandaloneAgentsApiPath = path.join(defaultsRoot, 'agents-api');
   const providerPath = path.join(defaultsRoot, 'ai-provider-for-openai');
@@ -384,6 +385,24 @@ try {
   assert.equal(defaultedRequest.mounts[0].mode, 'readwrite');
   assert.equal(defaultedRequest.workspaces[0].target, '/workspace');
   assert(!JSON.stringify(defaultedRequest).includes(staleStandaloneAgentsApiPath));
+  assert(!JSON.stringify(defaultedRequest).includes(alternateBundledAgentsApiPath));
+
+  fs.rmSync(bundledAgentsApiPath, { recursive: true, force: true });
+  fs.mkdirSync(alternateBundledAgentsApiPath, { recursive: true });
+  const alternateDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'alternate-default-runtime-stack-task-123',
+    executor: {
+      backend: 'codebox',
+      config: { provider: 'codex' },
+    },
+    inputs: {
+      target: { root: workspaceRoot },
+    },
+  }, {
+    settings: {},
+  });
+  assert.equal(alternateDefaultedRequest.agents_api_path, alternateBundledAgentsApiPath);
 
   const explicitOverrideRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,


### PR DESCRIPTION
## Summary
- Prefer Data Machine's current `vendor/wordpress/agents-api` bundle path when deriving Codebox agent-task defaults.
- Keep `vendor/automattic/agents-api` as a fallback for alternate/legacy layouts.
- Extend executor smoke coverage so the current path is tested and the fallback remains explicit.

Closes #1163.

## Tests
- `npm run test:codebox-agent-task-executor`
- `npm run test:wp-codebox-task-runner`
- `npx eslint lib/codebox-agent-task-executor.js --no-warn-ignored`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the post-merge local canary blocker, implemented the path resolver fix, and ran focused verification.