### PR TITLE
fix: avoid default seedless Codebox workspaces

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -266,7 +266,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     providerPluginPaths: normalizeArray(settings.wp_codebox_provider_plugin_paths || settings.provider_plugin_paths || (providerPluginPath ? [providerPluginPath] : [])),
     secretEnv: defaultSecretEnv(config.provider || options.provider || '', settings),
     mounts: defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options),
-    workspaces: defaultWorkspaces(workspaceRoot, request, config, inputs, options),
+    workspaces: defaultWorkspaces(config, inputs, options),
   };
 }
 
@@ -362,18 +362,9 @@ function defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options)
   ];
 }
 
-function defaultWorkspaces(workspaceRoot, request, config, inputs, options) {
+function defaultWorkspaces(config, inputs, options) {
   const explicit = inputs.workspaces || config.workspaces || options.workspaces || [];
-  if (!workspaceRoot || explicit.some((workspace) => workspace?.target === '/workspace')) {
-    return explicit;
-  }
-  return [
-    ...explicit,
-    {
-      target: '/workspace',
-      mode: workspaceMode(request, config, inputs),
-    },
-  ];
+  return explicit;
 }
 
 function agentBundleMounts(bundleConfig, explicitMounts = []) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -383,7 +383,7 @@ try {
   assert.equal(defaultedRequest.mounts[0].source, workspaceRoot);
   assert.equal(defaultedRequest.mounts[0].target, '/workspace');
   assert.equal(defaultedRequest.mounts[0].mode, 'readwrite');
-  assert.equal(defaultedRequest.workspaces[0].target, '/workspace');
+  assert.deepEqual(defaultedRequest.workspaces, []);
   assert(!JSON.stringify(defaultedRequest).includes(staleStandaloneAgentsApiPath));
   assert(!JSON.stringify(defaultedRequest).includes(alternateBundledAgentsApiPath));
 


### PR DESCRIPTION
## Summary
- Keep default repo-cooking `/workspace` as a mount only instead of also emitting a seedless WP Codebox workspace entry.
- Preserve explicit workspace overrides from task inputs, executor config, or options.
- Update the Codebox agent-task executor smoke to assert the default recipe shape avoids generated `workspaces` entries.

## Testing
- `npm run test:codebox-agent-task-executor`
- `npx eslint lib/codebox-agent-task-executor.js --no-warn-ignored`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the post-#1164 Homeboy Codebox canary failure, drafted the minimal provider fix, and ran local verification. Chris remains responsible for review and merge.

Closes #1165