### PR TITLE
fix: default Codebox provider from plugin path

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -181,7 +181,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     session_id: config.session_id || config.sessionId || '',
     agent: config.agent || options.agent || 'wp-codebox-sandbox',
     mode: config.mode || options.mode || 'sandbox',
-    provider: config.provider || options.provider || '',
+    provider: config.provider || options.provider || defaults.provider || '',
     model: request.executor.model || config.model || options.model || '',
     provider_plugin_paths: config.provider_plugin_paths || options.providerPluginPaths || defaults.providerPluginPaths || [],
     agent_bundles: config.agent_bundles || config.agentBundles || options.agentBundles || [],
@@ -251,6 +251,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     siblingPath(workspaceBase, 'ai-provider-for-openai'),
     siblingPath(workspaceBase, 'ai-provider-for-openai-main'),
   );
+  const provider = config.provider || options.provider || defaultProviderForPluginPath(providerPluginPath);
   const agentsApiPath = firstExistingPath(
     options.agentsApi,
     settings.wp_codebox_agents_api_path,
@@ -264,7 +265,8 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     legacyRuntime: dataMachinePath,
     legacyRuntimeTools: dataMachineCodePath,
     providerPluginPaths: normalizeArray(settings.wp_codebox_provider_plugin_paths || settings.provider_plugin_paths || (providerPluginPath ? [providerPluginPath] : [])),
-    secretEnv: defaultSecretEnv(config.provider || options.provider || '', settings),
+    provider,
+    secretEnv: defaultSecretEnv(provider, settings),
     mounts: defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options),
     workspaces: defaultWorkspaces(config, inputs, options),
   };
@@ -324,6 +326,13 @@ function defaultSecretEnv(provider, settings) {
     ];
   }
   return provider === 'openai' ? ['OPENAI_API_KEY'] : [];
+}
+
+function defaultProviderForPluginPath(providerPluginPath) {
+  if (!providerPluginPath) {
+    return '';
+  }
+  return path.basename(providerPluginPath).startsWith('ai-provider-for-openai') ? 'openai' : '';
 }
 
 function resolveWorkspaceRoot(request, config, inputs, settings, options) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -387,6 +387,24 @@ try {
   assert(!JSON.stringify(defaultedRequest).includes(staleStandaloneAgentsApiPath));
   assert(!JSON.stringify(defaultedRequest).includes(alternateBundledAgentsApiPath));
 
+  const openAiDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'default-openai-provider-task-123',
+    executor: {
+      backend: 'codebox',
+      model: 'gpt-4.1-mini',
+      config: {},
+    },
+    inputs: {
+      target: { root: workspaceRoot },
+    },
+  }, {
+    settings: {},
+  });
+  assert.equal(openAiDefaultedRequest.provider, 'openai');
+  assert.equal(openAiDefaultedRequest.model, 'gpt-4.1-mini');
+  assert.deepEqual(openAiDefaultedRequest.secret_env, ['OPENAI_API_KEY']);
+
   fs.rmSync(bundledAgentsApiPath, { recursive: true, force: true });
   fs.mkdirSync(alternateBundledAgentsApiPath, { recursive: true });
   const alternateDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({


### PR DESCRIPTION
## Summary
- Infer the default Codebox runtime provider from the resolved provider plugin path when no explicit provider was supplied.
- Keep explicit task/config provider values authoritative.
- Add smoke coverage for the bare repo-cooking shape that mounts `ai-provider-for-openai` and requests `gpt-4.1-mini`.

## Testing
- `npm run test:codebox-agent-task-executor`
- `npx eslint lib/codebox-agent-task-executor.js --no-warn-ignored`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the post-#1166 bare Homeboy Codebox canary failure, drafted the minimal provider-default fix, and ran local verification. Chris remains responsible for review and merge.

Closes #1167