### PR TITLE
fix: default Codebox agent task model

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -182,7 +182,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     agent: config.agent || options.agent || 'wp-codebox-sandbox',
     mode: config.mode || options.mode || 'sandbox',
     provider: config.provider || options.provider || defaults.provider || '',
-    model: request.executor.model || config.model || options.model || '',
+    model: request.executor.model || config.model || options.model || defaults.model || '',
     provider_plugin_paths: config.provider_plugin_paths || options.providerPluginPaths || defaults.providerPluginPaths || [],
     agent_bundles: config.agent_bundles || config.agentBundles || options.agentBundles || [],
     runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
@@ -252,6 +252,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     siblingPath(workspaceBase, 'ai-provider-for-openai-main'),
   );
   const provider = config.provider || options.provider || defaultProviderForPluginPath(providerPluginPath);
+  const model = config.model || options.model || defaultModelForProvider(provider, settings);
   const agentsApiPath = firstExistingPath(
     options.agentsApi,
     settings.wp_codebox_agents_api_path,
@@ -266,6 +267,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     legacyRuntimeTools: dataMachineCodePath,
     providerPluginPaths: normalizeArray(settings.wp_codebox_provider_plugin_paths || settings.provider_plugin_paths || (providerPluginPath ? [providerPluginPath] : [])),
     provider,
+    model,
     secretEnv: defaultSecretEnv(provider, settings),
     mounts: defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options),
     workspaces: defaultWorkspaces(config, inputs, options),
@@ -333,6 +335,14 @@ function defaultProviderForPluginPath(providerPluginPath) {
     return '';
   }
   return path.basename(providerPluginPath).startsWith('ai-provider-for-openai') ? 'openai' : '';
+}
+
+function defaultModelForProvider(provider, settings) {
+  const explicit = settings.wp_codebox_model || settings.model || process.env.HOMEBOY_WP_CODEBOX_MODEL;
+  if (explicit) {
+    return explicit;
+  }
+  return provider === 'openai' || provider === 'codex' ? 'gpt-4.1-mini' : '';
 }
 
 function resolveWorkspaceRoot(request, config, inputs, settings, options) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -405,6 +405,38 @@ try {
   assert.equal(openAiDefaultedRequest.model, 'gpt-4.1-mini');
   assert.deepEqual(openAiDefaultedRequest.secret_env, ['OPENAI_API_KEY']);
 
+  const bareOpenAiDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'bare-default-openai-provider-task-123',
+    executor: {
+      backend: 'codebox',
+      config: {},
+    },
+    inputs: {
+      target: { root: workspaceRoot },
+    },
+  }, {
+    settings: {},
+  });
+  assert.equal(bareOpenAiDefaultedRequest.provider, 'openai');
+  assert.equal(bareOpenAiDefaultedRequest.model, 'gpt-4.1-mini');
+  assert.deepEqual(bareOpenAiDefaultedRequest.secret_env, ['OPENAI_API_KEY']);
+
+  const settingsModelRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'settings-model-default-task-123',
+    executor: {
+      backend: 'codebox',
+      config: {},
+    },
+    inputs: {
+      target: { root: workspaceRoot },
+    },
+  }, {
+    settings: { wp_codebox_model: 'gpt-4.1-mini' },
+  });
+  assert.equal(settingsModelRequest.model, 'gpt-4.1-mini');
+
   fs.rmSync(bundledAgentsApiPath, { recursive: true, force: true });
   fs.mkdirSync(alternateBundledAgentsApiPath, { recursive: true });
   const alternateDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({


### PR DESCRIPTION
## Summary
- Default Codebox agent-task requests to a usable OpenAI/Codex model when callers omit `--model`.
- Preserve explicit request/config/settings/env model overrides before falling back to `gpt-4.1-mini`.
- Extend the Codebox executor smoke coverage for bare default dispatch and settings-based model defaults.

## Verification
- `npm run test:codebox-agent-task-executor`
- `npm run lint:js -- lib/codebox-agent-task-executor.js --no-warn-ignored`
- `homeboy agent-task dispatch --run-id proof-homeboy-multicell-default-small-model-20260607-001 --cwd /Users/chubes/Developer/wp-coding-agents --repo wp-coding-agents --task-url https://github.com/Extra-Chill/wp-coding-agents/issues/190 --secret-env OPENAI_API_KEY --concurrency 2 --attempts 1 ...`
- Homeboy proof result: 2/2 cells succeeded, runtime cleanup observed, changed files count 0, patch bytes 0.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small defaulting fix, smoke coverage, and Homeboy proof runs; Chris remains responsible for review and merge.