### PR TITLE
Enable Codebox workspace inspection tools by default

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -28,6 +28,12 @@ const PROVIDER_CAPABILITIES = [
   'recipe_probe_artifacts',
 ];
 
+const DEFAULT_WORKSPACE_ALLOWED_TOOLS = [
+  'workspace_ls',
+  'workspace_read',
+  'workspace_git_status',
+];
+
 const AGENT_BUNDLE_CONFIG_FIELDS = [
   'bundle_path',
   'bundle_host_path',
@@ -152,7 +158,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const mounts = agentBundleMounts(agentBundle, config.mounts || defaults.mounts || options.mounts || []);
   const components = runtimeComponentPaths(config, { ...defaults, ...options });
   const runtimeTask = inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || options.runtimeTask;
-  const sandboxToolPolicy = inputs.sandbox_tool_policy || inputs.sandboxToolPolicy || config.sandbox_tool_policy || config.sandboxToolPolicy || options.sandboxToolPolicy;
+  const sandboxToolPolicy = firstDefined(inputs.sandbox_tool_policy, inputs.sandboxToolPolicy, config.sandbox_tool_policy, config.sandboxToolPolicy, options.sandboxToolPolicy, defaults.sandboxToolPolicy);
+  const allowedTools = firstDefined(inputs.allowed_tools, inputs.allowedTools, config.allowed_tools, config.allowedTools, options.allowedTools, defaults.allowedTools);
   const timeoutSeconds = request.limits?.task_timeout_seconds || request.limits?.taskTimeoutSeconds;
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
   const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
@@ -170,7 +177,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     schema: WP_CODEBOX_TASK_REQUEST_SCHEMA,
     goal: request.instructions,
     target: inputs.target || request.workspace || {},
-    allowed_tools: inputs.allowed_tools || inputs.allowedTools || [],
+    allowed_tools: allowedTools || [],
     expected_artifacts: request.expected_artifacts || [],
     policy: request.policy || {},
     context,
@@ -236,6 +243,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     settings.wp_codebox_data_machine_path,
     settings.data_machine_path,
     process.env.HOMEBOY_DATA_MACHINE_PATH,
+    activeSitePluginPath('data-machine'),
     siblingPath(workspaceBase, 'data-machine'),
   );
   const dataMachineCodePath = firstExistingPath(
@@ -243,6 +251,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     settings.wp_codebox_data_machine_code_path,
     settings.data_machine_code_path,
     process.env.HOMEBOY_DATA_MACHINE_CODE_PATH,
+    activeSitePluginPath('data-machine-code'),
     siblingPath(workspaceBase, 'data-machine-code'),
   );
   const providerPluginPath = firstExistingPath(
@@ -271,7 +280,13 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     secretEnv: defaultSecretEnv(provider, settings),
     mounts: defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options),
     workspaces: defaultWorkspaces(config, inputs, options),
+    allowedTools: defaultWorkspaceAllowedTools(workspaceRoot),
+    sandboxToolPolicy: defaultWorkspaceSandboxToolPolicy(workspaceRoot),
   };
+}
+
+function firstDefined(...values) {
+  return values.find((value) => value !== undefined);
 }
 
 function parseJsonObject(value) {
@@ -304,6 +319,11 @@ function firstExistingPath(...candidates) {
 
 function siblingPath(base, name) {
   return base && name ? path.join(base, name) : '';
+}
+
+function activeSitePluginPath(slug) {
+  const candidate = path.join(process.cwd(), 'wp-content', 'plugins', slug);
+  return fs.existsSync(candidate) ? candidate : '';
 }
 
 function bundledAgentsApiPath(dataMachinePath) {
@@ -345,6 +365,32 @@ function defaultModelForProvider(provider, settings) {
   return provider === 'openai' || provider === 'codex' ? 'gpt-4.1-mini' : '';
 }
 
+function defaultWorkspaceAllowedTools(workspaceRoot) {
+  return workspaceRoot ? DEFAULT_WORKSPACE_ALLOWED_TOOLS : [];
+}
+
+function defaultWorkspaceSandboxToolPolicy(workspaceRoot) {
+  if (!workspaceRoot) {
+    return undefined;
+  }
+  return {
+    schema: 'wp-codebox/sandbox-tool-policy/v1',
+    version: 1,
+    tools: DEFAULT_WORKSPACE_ALLOWED_TOOLS.map((tool) => ({
+      id: tool,
+      runtime_tool_id: tool,
+      execution_location: 'sandbox',
+      transport_visibility: 'sandbox',
+      allowed: true,
+      runtime: {
+        environment: 'runtime_local',
+        capability_scope: 'runtime_local',
+      },
+    })),
+    metadata: { source: 'homeboy.codebox-agent-task.default-workspace-tools' },
+  };
+}
+
 function resolveWorkspaceRoot(request, config, inputs, settings, options) {
   const candidates = [
     options.workspaceRoot,
@@ -367,18 +413,32 @@ function workspaceMode(request, config, inputs) {
 
 function defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options) {
   const explicit = config.mounts || options.mounts || [];
-  if (!workspaceRoot || explicit.some((mount) => mount?.target === '/workspace' || mount?.source === workspaceRoot)) {
+  const workspaceTarget = defaultWorkspaceTarget(workspaceRoot);
+  if (!workspaceRoot || explicit.some((mount) => mount?.target === workspaceTarget || mount?.source === workspaceRoot)) {
     return explicit;
   }
   return [
     ...explicit,
     {
       source: workspaceRoot,
-      target: '/workspace',
+      target: workspaceTarget,
       mode: workspaceMode(request, config, inputs),
-      metadata: { kind: 'homeboy-dmc-workspace' },
+      metadata: { kind: 'homeboy-dmc-workspace', workspace_slug: workspaceSlug(workspaceRoot) },
     },
   ];
+}
+
+function defaultWorkspaceTarget(workspaceRoot) {
+  const slug = workspaceSlug(workspaceRoot);
+  return slug ? `/workspace/${slug}` : '/workspace';
+}
+
+function workspaceSlug(workspaceRoot) {
+  if (!workspaceRoot) {
+    return '';
+  }
+  const slug = path.basename(workspaceRoot).split('@')[0].replace(/[^A-Za-z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
+  return slug || 'workspace';
 }
 
 function defaultWorkspaces(config, inputs, options) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -381,8 +381,9 @@ try {
     'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
   ]);
   assert.equal(defaultedRequest.mounts[0].source, workspaceRoot);
-  assert.equal(defaultedRequest.mounts[0].target, '/workspace');
+  assert.equal(defaultedRequest.mounts[0].target, '/workspace/target-repo');
   assert.equal(defaultedRequest.mounts[0].mode, 'readwrite');
+  assert.equal(defaultedRequest.mounts[0].metadata.workspace_slug, 'target-repo');
   assert.deepEqual(defaultedRequest.workspaces, []);
   assert(!JSON.stringify(defaultedRequest).includes(staleStandaloneAgentsApiPath));
   assert(!JSON.stringify(defaultedRequest).includes(alternateBundledAgentsApiPath));
@@ -421,6 +422,16 @@ try {
   assert.equal(bareOpenAiDefaultedRequest.provider, 'openai');
   assert.equal(bareOpenAiDefaultedRequest.model, 'gpt-4.1-mini');
   assert.deepEqual(bareOpenAiDefaultedRequest.secret_env, ['OPENAI_API_KEY']);
+  assert.deepEqual(bareOpenAiDefaultedRequest.allowed_tools, ['workspace_ls', 'workspace_read', 'workspace_git_status']);
+  assert.equal(bareOpenAiDefaultedRequest.sandbox_tool_policy.schema, 'wp-codebox/sandbox-tool-policy/v1');
+  assert.deepEqual(
+    bareOpenAiDefaultedRequest.sandbox_tool_policy.tools.map((tool) => tool.runtime_tool_id),
+    ['workspace_ls', 'workspace_read', 'workspace_git_status'],
+  );
+  assert.deepEqual(
+    bareOpenAiDefaultedRequest.sandbox_tool_policy.tools.map((tool) => tool.runtime.environment),
+    ['runtime_local', 'runtime_local', 'runtime_local'],
+  );
 
   const settingsModelRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,
@@ -436,6 +447,30 @@ try {
     settings: { wp_codebox_model: 'gpt-4.1-mini' },
   });
   assert.equal(settingsModelRequest.model, 'gpt-4.1-mini');
+
+  const explicitEmptyToolsRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'explicit-empty-tools-task-123',
+    executor: {
+      backend: 'codebox',
+      config: {
+        allowed_tools: [],
+        sandbox_tool_policy: {
+          schema: 'wp-codebox/sandbox-tool-policy/v1',
+          version: 1,
+          tools: [{ id: 'deny-all', runtime_tool_id: 'deny-all', execution_location: 'parent', transport_visibility: 'hidden', allowed: false }],
+          metadata: { source: 'test' },
+        },
+      },
+    },
+    inputs: {
+      target: { root: workspaceRoot },
+    },
+  }, {
+    settings: {},
+  });
+  assert.deepEqual(explicitEmptyToolsRequest.allowed_tools, []);
+  assert.equal(explicitEmptyToolsRequest.sandbox_tool_policy.tools[0].id, 'deny-all');
 
   fs.rmSync(bundledAgentsApiPath, { recursive: true, force: true });
   fs.mkdirSync(alternateBundledAgentsApiPath, { recursive: true });


### PR DESCRIPTION
## Summary
- Enables default `workspace_ls`, `workspace_read`, and `workspace_git_status` tools for repo-backed Codebox agent tasks.
- Mounts repo workspaces at a slugged `/workspace/<repo>` target so sandbox agents can address the active repository consistently.
- Prefers active-site runtime plugin paths before stale sibling checkouts when building the default Codebox stack.

## Verification
- `npm run test:codebox-agent-task-executor`
- `npm run lint:js -- lib/codebox-agent-task-executor.js --no-warn-ignored`
- Homeboy proof: `proof-homeboy-multicell-active-site-runtime-20260607-001` succeeded 2/2 with empty patches, zero changed files, destroyed runtimes, and workspace tool evidence reading `VERSION` as `1.2.2`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the provider default/tool-policy changes under Chris's direction.