### PR TITLE
Require explicit Codebox model defaults

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -358,11 +358,11 @@ function defaultProviderForPluginPath(providerPluginPath) {
 }
 
 function defaultModelForProvider(provider, settings) {
-  const explicit = settings.wp_codebox_model || settings.model || process.env.HOMEBOY_WP_CODEBOX_MODEL;
-  if (explicit) {
-    return explicit;
-  }
-  return provider === 'openai' || provider === 'codex' ? 'gpt-4.1-mini' : '';
+	const explicit = settings.wp_codebox_model || settings.model || process.env.HOMEBOY_WP_CODEBOX_MODEL;
+	if (explicit) {
+		return explicit;
+	}
+	return '';
 }
 
 function defaultWorkspaceAllowedTools(workspaceRoot) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -393,7 +393,7 @@ try {
     task_id: 'default-openai-provider-task-123',
     executor: {
       backend: 'codebox',
-      model: 'gpt-4.1-mini',
+      model: 'gpt-5.5',
       config: {},
     },
     inputs: {
@@ -403,7 +403,7 @@ try {
     settings: {},
   });
   assert.equal(openAiDefaultedRequest.provider, 'openai');
-  assert.equal(openAiDefaultedRequest.model, 'gpt-4.1-mini');
+  assert.equal(openAiDefaultedRequest.model, 'gpt-5.5');
   assert.deepEqual(openAiDefaultedRequest.secret_env, ['OPENAI_API_KEY']);
 
   const bareOpenAiDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
@@ -420,7 +420,7 @@ try {
     settings: {},
   });
   assert.equal(bareOpenAiDefaultedRequest.provider, 'openai');
-  assert.equal(bareOpenAiDefaultedRequest.model, 'gpt-4.1-mini');
+  assert.equal(bareOpenAiDefaultedRequest.model, '');
   assert.deepEqual(bareOpenAiDefaultedRequest.secret_env, ['OPENAI_API_KEY']);
   assert.deepEqual(bareOpenAiDefaultedRequest.allowed_tools, ['workspace_ls', 'workspace_read', 'workspace_git_status']);
   assert.equal(bareOpenAiDefaultedRequest.sandbox_tool_policy.schema, 'wp-codebox/sandbox-tool-policy/v1');
@@ -444,9 +444,9 @@ try {
       target: { root: workspaceRoot },
     },
   }, {
-    settings: { wp_codebox_model: 'gpt-4.1-mini' },
+    settings: { wp_codebox_model: 'gpt-5.5' },
   });
-  assert.equal(settingsModelRequest.model, 'gpt-4.1-mini');
+  assert.equal(settingsModelRequest.model, 'gpt-5.5');
 
   const explicitEmptyToolsRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,


### PR DESCRIPTION
## Summary
- Removes the provider-based `gpt-4.1-mini` model fallback for Codebox agent tasks.
- Keeps explicit request/config/settings/env model selection working.
- Preserves OpenAI provider inference and workspace-tool defaults without silently choosing a weak model.

## Verification
- `npm run test:codebox-agent-task-executor`
- `npm run lint:js -- lib/codebox-agent-task-executor.js --no-warn-ignored`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the corrective fallback removal under Chris's direction.