### PR TITLE
Wire Codebox fanout to Codex subscription

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -34,6 +34,16 @@ const DEFAULT_WORKSPACE_ALLOWED_TOOLS = [
   'workspace_git_status',
 ];
 
+const CODEX_SECRET_ENV = [
+  'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+  'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+  'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+];
+
+const DEFAULT_CODEX_MODEL = 'gpt-5.5';
+
 const AGENT_BUNDLE_CONFIG_FIELDS = [
   'bundle_path',
   'bundle_host_path',
@@ -193,7 +203,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     provider_plugin_paths: config.provider_plugin_paths || options.providerPluginPaths || defaults.providerPluginPaths || [],
     agent_bundles: config.agent_bundles || config.agentBundles || options.agentBundles || [],
     runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
-    runtime_overlays: config.runtime_overlays || options.runtimeOverlays || [],
+    runtime_overlays: config.runtime_overlays || options.runtimeOverlays || defaults.runtimeOverlays || [],
     secret_env: config.secret_env || options.secretEnv || defaults.secretEnv || [],
     mounts,
     workspaces: inputs.workspaces || config.workspaces || options.workspaces || defaults.workspaces || [],
@@ -260,8 +270,9 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     siblingPath(workspaceBase, 'ai-provider-for-openai'),
     siblingPath(workspaceBase, 'ai-provider-for-openai-main'),
   );
-  const provider = config.provider || options.provider || defaultProviderForPluginPath(providerPluginPath);
+  const provider = config.provider || options.provider || defaultProvider(settings, providerPluginPath);
   const model = config.model || options.model || defaultModelForProvider(provider, settings);
+  const phpAiClientPath = defaultPhpAiClientPath(provider, settings, workspaceBase);
   const agentsApiPath = firstExistingPath(
     options.agentsApi,
     settings.wp_codebox_agents_api_path,
@@ -274,15 +285,59 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     agentsApi: agentsApiPath,
     legacyRuntime: dataMachinePath,
     legacyRuntimeTools: dataMachineCodePath,
-    providerPluginPaths: normalizeArray(settings.wp_codebox_provider_plugin_paths || settings.provider_plugin_paths || (providerPluginPath ? [providerPluginPath] : [])),
+    providerPluginPaths: defaultProviderPluginPaths(provider, settings, workspaceBase, providerPluginPath),
     provider,
     model,
     secretEnv: defaultSecretEnv(provider, settings),
+    runtimeOverlays: defaultRuntimeOverlays(provider, phpAiClientPath),
     mounts: defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options),
     workspaces: defaultWorkspaces(config, inputs, options),
     allowedTools: defaultWorkspaceAllowedTools(workspaceRoot),
     sandboxToolPolicy: defaultWorkspaceSandboxToolPolicy(workspaceRoot),
   };
+}
+
+function defaultProviderPluginPaths(provider, settings, workspaceBase, fallbackProviderPluginPath) {
+  const explicit = normalizeArray(settings.wp_codebox_provider_plugin_paths || settings.provider_plugin_paths);
+  if (explicit.length > 0) {
+    return explicit;
+  }
+  if (provider === 'codex') {
+    return normalizeArray(firstExistingPath(
+      settings.wp_codebox_codex_provider_plugin_path,
+      process.env.HOMEBOY_WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH,
+      siblingPath(workspaceBase, 'ai-provider-for-openai@codex-oauth-provider'),
+      fallbackProviderPluginPath,
+    ));
+  }
+  return fallbackProviderPluginPath ? [fallbackProviderPluginPath] : [];
+}
+
+function defaultPhpAiClientPath(provider, settings, workspaceBase) {
+  if (provider !== 'codex') {
+    return '';
+  }
+  return firstExistingPath(
+    settings.wp_codebox_php_ai_client_path,
+    settings.php_ai_client_path,
+    process.env.HOMEBOY_WP_CODEBOX_PHP_AI_CLIENT_PATH,
+    siblingPath(workspaceBase, 'php-ai-client@custom-provider-auth'),
+    siblingPath(workspaceBase, 'php-ai-client'),
+  );
+}
+
+function defaultRuntimeOverlays(provider, phpAiClientPath) {
+  if (provider !== 'codex' || !phpAiClientPath) {
+    return [];
+  }
+  return [{
+    kind: 'bundled-library',
+    library: 'php-ai-client',
+    source: phpAiClientPath,
+    target: '/wordpress/wp-includes/php-ai-client',
+    strategy: 'wordpress-scoped-bundle',
+    metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
+  }];
 }
 
 function firstDefined(...values) {
@@ -339,15 +394,17 @@ function defaultSecretEnv(provider, settings) {
     return explicit;
   }
   if (provider === 'codex') {
-    return [
-      'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
-      'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
-      'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
-      'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
-      'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
-    ];
+    return CODEX_SECRET_ENV;
   }
   return provider === 'openai' ? ['OPENAI_API_KEY'] : [];
+}
+
+function defaultProvider(settings, providerPluginPath) {
+  const explicit = settings.wp_codebox_provider || settings.provider || process.env.HOMEBOY_WP_CODEBOX_PROVIDER;
+  if (explicit) {
+    return explicit;
+  }
+  return hasCodexSubscriptionAuth(settings) ? 'codex' : defaultProviderForPluginPath(providerPluginPath);
 }
 
 function defaultProviderForPluginPath(providerPluginPath) {
@@ -358,11 +415,44 @@ function defaultProviderForPluginPath(providerPluginPath) {
 }
 
 function defaultModelForProvider(provider, settings) {
-	const explicit = settings.wp_codebox_model || settings.model || process.env.HOMEBOY_WP_CODEBOX_MODEL;
-	if (explicit) {
-		return explicit;
-	}
-	return '';
+  const explicit = settings.wp_codebox_model || settings.model || process.env.HOMEBOY_WP_CODEBOX_MODEL;
+  if (explicit) {
+    return explicit;
+  }
+  const codexModel = settings.wp_codebox_codex_model || process.env.HOMEBOY_WP_CODEBOX_CODEX_MODEL;
+  if (provider === 'codex' && hasCodexSubscriptionAuth(settings)) {
+    return codexModel || DEFAULT_CODEX_MODEL;
+  }
+  return '';
+}
+
+function hasCodexSubscriptionAuth(settings = {}) {
+  if (settings.wp_codebox_codex_enabled === false || settings.wp_codebox_codex_enabled === 'false') {
+    return false;
+  }
+  const envHasTokens = CODEX_SECRET_ENV.slice(0, 4).every((name) => Boolean(process.env[name]));
+  if (envHasTokens) {
+    return true;
+  }
+  const authPath = settings.wp_codebox_codex_auth_path || process.env.HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH || defaultCodexAuthPath();
+  const auth = readJsonFile(authPath);
+  return Boolean(auth?.tokens?.access_token && auth?.tokens?.refresh_token && auth?.tokens?.account_id);
+}
+
+function defaultCodexAuthPath() {
+  const home = process.env.HOME;
+  return home ? path.join(home, '.codex', 'auth.json') : '';
+}
+
+function readJsonFile(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
 }
 
 function defaultWorkspaceAllowedTools(workspaceRoot) {

--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -21,6 +21,13 @@ const {
 } = require('../../lib/codebox-agent-task-executor');
 
 const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
+const CODEX_SECRET_ENV = [
+  'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+  'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+  'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+];
 
 function argValue(name) {
   const index = process.argv.indexOf(name);
@@ -61,6 +68,46 @@ function readJsonIfAvailable(filePath) {
   } catch {
     return null;
   }
+}
+
+function defaultCodexAuthPath() {
+  return process.env.HOME ? path.join(process.env.HOME, '.codex', 'auth.json') : '';
+}
+
+function jwtExpiration(token) {
+  const payload = String(token || '').split('.')[1];
+  if (!payload) {
+    return '';
+  }
+  try {
+    const decoded = Buffer.from(payload.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8');
+    const parsed = JSON.parse(decoded);
+    return parsed?.exp ? String(parsed.exp) : '';
+  } catch {
+    return '';
+  }
+}
+
+function codexAuthEnv(taskInput) {
+  if (taskInput?.provider !== 'codex') {
+    return {};
+  }
+  if (CODEX_SECRET_ENV.slice(0, 4).every((name) => Boolean(process.env[name]))) {
+    return {};
+  }
+  const authPath = process.env.HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH || defaultCodexAuthPath();
+  const auth = readJsonIfAvailable(authPath);
+  const tokens = auth?.tokens || {};
+  if (!tokens.access_token || !tokens.refresh_token || !tokens.account_id) {
+    return {};
+  }
+  return Object.fromEntries(Object.entries({
+    AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: tokens.access_token,
+    AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: tokens.refresh_token,
+    AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: tokens.expires_at || tokens.expiresAt || jwtExpiration(tokens.access_token),
+    AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: tokens.account_id,
+    AI_PROVIDER_OPENAI_CODEX_FEDRAMP: tokens.fedramp === undefined ? 'false' : String(tokens.fedramp),
+  }).filter(([name, value]) => CODEX_SECRET_ENV.includes(name) && value !== undefined && value !== null && value !== ''));
 }
 
 function directorySizeBytes(directory) {
@@ -345,6 +392,7 @@ async function runTaskRunner(request) {
   const coreNormalizers = await loadCodeboxCoreNormalizers();
   const runner = argValue('--task-runner') || `${__dirname}/homeboy-wp-codebox-task-runner.cjs`;
   const config = request.executor?.config || {};
+  const taskInput = codeboxTaskRequestFromAgentTaskRequest(request);
   const configArgs = [
     ['--agents-api', config.agents_api_path || config.agentsApiPath],
     ['--homeboy', config.homeboy_path || config.homeboyPath],
@@ -358,8 +406,8 @@ async function runTaskRunner(request) {
   });
   const result = spawnSync(process.execPath, [runner, ...args, ...configArgs], {
     encoding: 'utf8',
-    input: JSON.stringify(codeboxTaskRequestFromAgentTaskRequest(request)),
-    env: process.env,
+    input: JSON.stringify(taskInput),
+    env: { ...process.env, ...codexAuthEnv(taskInput) },
     maxBuffer: 1024 * 1024 * 20,
     timeout: requestTimeoutMs(request),
   });

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -13,6 +13,13 @@ const {
 } = require('../lib/codebox-agent-task-executor');
 
 const fixtureCodeboxCoreModule = path.join(__dirname, 'fixtures', 'wp-codebox-core-agent-task-normalizer.mjs');
+const codexSecretEnv = [
+  'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+  'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+  'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+];
 
 function writeFixtureTaskRunner(root) {
   const fixture = path.join(root, 'fixture-task-runner.cjs');
@@ -21,7 +28,12 @@ function writeFixtureTaskRunner(root) {
 'use strict';
 const fs = require('node:fs');
   const request = JSON.parse(fs.readFileSync(0, 'utf8'));
-fs.writeFileSync(${JSON.stringify(capture)}, JSON.stringify({ argv: process.argv.slice(2), request }, null, 2));
+const codexSecretEnv = ${JSON.stringify(codexSecretEnv)};
+fs.writeFileSync(${JSON.stringify(capture)}, JSON.stringify({
+  argv: process.argv.slice(2),
+  request,
+  env_presence: Object.fromEntries(codexSecretEnv.map((name) => [name, Boolean(process.env[name])])),
+}, null, 2));
 process.stdout.write(JSON.stringify({
   success: true,
   status: 'completed',
@@ -351,7 +363,9 @@ try {
   const dataMachineCodePath = path.join(defaultsRoot, 'data-machine-code');
   const staleStandaloneAgentsApiPath = path.join(defaultsRoot, 'agents-api');
   const providerPath = path.join(defaultsRoot, 'ai-provider-for-openai');
-  for (const directory of [workspaceRoot, bundledAgentsApiPath, dataMachineCodePath, staleStandaloneAgentsApiPath, providerPath]) {
+  const codexProviderPath = path.join(defaultsRoot, 'ai-provider-for-openai@codex-oauth-provider');
+  const phpAiClientPath = path.join(defaultsRoot, 'php-ai-client@custom-provider-auth');
+  for (const directory of [workspaceRoot, bundledAgentsApiPath, dataMachineCodePath, staleStandaloneAgentsApiPath, providerPath, codexProviderPath, phpAiClientPath]) {
     fs.mkdirSync(directory, { recursive: true });
   }
 
@@ -372,7 +386,15 @@ try {
   assert.equal(defaultedRequest.runtime_component_paths.agents_api, bundledAgentsApiPath);
   assert.equal(defaultedRequest.runtime_component_paths.agent_runtime, dataMachinePath);
   assert.equal(defaultedRequest.runtime_component_paths.agent_runtime_tools, dataMachineCodePath);
-  assert.deepEqual(defaultedRequest.provider_plugin_paths, [providerPath]);
+  assert.deepEqual(defaultedRequest.provider_plugin_paths, [codexProviderPath]);
+  assert.deepEqual(defaultedRequest.runtime_overlays, [{
+    kind: 'bundled-library',
+    library: 'php-ai-client',
+    source: phpAiClientPath,
+    target: '/wordpress/wp-includes/php-ai-client',
+    strategy: 'wordpress-scoped-bundle',
+    metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
+  }]);
   assert.deepEqual(defaultedRequest.secret_env, [
     'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
     'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
@@ -388,6 +410,33 @@ try {
   assert(!JSON.stringify(defaultedRequest).includes(staleStandaloneAgentsApiPath));
   assert(!JSON.stringify(defaultedRequest).includes(alternateBundledAgentsApiPath));
 
+  const codexAuthPath = path.join(defaultsRoot, 'codex-auth.json');
+  fs.writeFileSync(codexAuthPath, JSON.stringify({
+    tokens: {
+      access_token: 'fixture-access-token',
+      refresh_token: 'fixture-refresh-token',
+      account_id: 'fixture-account-id',
+    },
+  }));
+  const codexSubscriptionDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'codex-subscription-default-task-123',
+    executor: {
+      backend: 'codebox',
+      config: {},
+    },
+    inputs: {
+      target: { root: workspaceRoot },
+    },
+  }, {
+    settings: { wp_codebox_codex_auth_path: codexAuthPath },
+  });
+  assert.equal(codexSubscriptionDefaultedRequest.provider, 'codex');
+  assert.equal(codexSubscriptionDefaultedRequest.model, 'gpt-5.5');
+  assert.deepEqual(codexSubscriptionDefaultedRequest.provider_plugin_paths, [codexProviderPath]);
+  assert.equal(codexSubscriptionDefaultedRequest.runtime_overlays[0].source, phpAiClientPath);
+  assert.deepEqual(codexSubscriptionDefaultedRequest.secret_env, codexSecretEnv);
+
   const openAiDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,
     task_id: 'default-openai-provider-task-123',
@@ -400,7 +449,7 @@ try {
       target: { root: workspaceRoot },
     },
   }, {
-    settings: {},
+    settings: { wp_codebox_codex_enabled: false },
   });
   assert.equal(openAiDefaultedRequest.provider, 'openai');
   assert.equal(openAiDefaultedRequest.model, 'gpt-5.5');
@@ -417,7 +466,7 @@ try {
       target: { root: workspaceRoot },
     },
   }, {
-    settings: {},
+    settings: { wp_codebox_codex_enabled: false },
   });
   assert.equal(bareOpenAiDefaultedRequest.provider, 'openai');
   assert.equal(bareOpenAiDefaultedRequest.model, '');
@@ -1052,12 +1101,25 @@ try {
   assert.equal(capturedRecipe.request.recipe.name, 'minimal-runtime');
   assert.equal(capturedRecipe.request.recipe.target_ref, 'Extra-Chill/example#42');
 
+  const fakeCodexHome = path.join(root, 'fake-codex-home');
+  const fakeCodexDirectory = path.join(fakeCodexHome, '.codex');
+  fs.mkdirSync(fakeCodexDirectory, { recursive: true });
+  fs.writeFileSync(path.join(fakeCodexDirectory, 'auth.json'), JSON.stringify({
+    tokens: {
+      access_token: 'fixture-codex-access-token',
+      refresh_token: 'fixture-codex-refresh-token',
+      expires_at: '1780000000',
+      account_id: 'fixture-codex-account-id',
+    },
+  }));
+
   const codexResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
     '--task-runner',
     fixture,
   ], {
     encoding: 'utf8',
+    env: { ...process.env, HOME: fakeCodexHome },
     input: JSON.stringify({
       ...codexAgentRequest,
       task_id: 'codex-cli-task-123',
@@ -1082,7 +1144,9 @@ try {
     'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
     'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
   ]);
+  assert.deepEqual(capturedCodex.env_presence, Object.fromEntries(codexSecretEnv.map((name) => [name, true])));
   assert(!JSON.stringify(capturedCodex).includes('wp-ai-gateway'));
+  assert(!JSON.stringify(capturedCodex).includes('fixture-codex-access-token'));
 
   const agentBundleRoot = fs.mkdtempSync(path.join(root, 'agent-bundle-'));
   const bundle = writeBundleFixture(agentBundleRoot);


### PR DESCRIPTION
## Summary
- Defaults Codebox fanout to `provider=codex` and `gpt-5.5` when a Codex subscription auth source is available.
- Hydrates `AI_PROVIDER_OPENAI_CODEX_*` for the task-runner subprocess from `~/.codex/auth.json` without putting token values in task request JSON or artifacts.
- Adds Codex-only defaults for the OpenAI provider PR overlay and php-ai-client request-auth runtime overlay.

## Verification
- `npm run test:codebox-agent-task-executor`
- `npm run lint:js -- lib/codebox-agent-task-executor.js scripts/agent/homeboy-codebox-agent-task-executor.cjs --no-warn-ignored`
- `proof-homeboy-codex-subscription-fanout-20260607-002` reached the Codex subscription provider, registered `codex`, completed successfully, produced zero changed files and empty patch artifacts, and destroyed the runtime.

## Follow-up
- The current upstream Codex provider PR emits text only, so model-written workspace tool calls are not emitted as structured tool calls yet. That needs to be fixed in the Codex provider / AI client tool-call layer for full workspace-tool fanout parity.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the Codex fanout wiring under Chris's direction.