### PR TITLE
Configure WP Codebox core module during setup

### DIFF
--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -14,7 +14,7 @@ SOURCE_GITHUB_ENV_FILE="${TMPDIR}/source-github-env"
 ARTIFACT_ROOT="${TMPDIR}/artifact-root"
 ARTIFACT_PATH="${TMPDIR}/wp-codebox-cli-linux-x64.tar.gz"
 
-mkdir -p "${FAKE_BIN}" "${HOME_DIR}" "${EXTENSION_DIR}" "${ARTIFACT_ROOT}/wp-codebox-cli/bin"
+mkdir -p "${FAKE_BIN}" "${HOME_DIR}" "${EXTENSION_DIR}" "${ARTIFACT_ROOT}/wp-codebox-cli/bin" "${ARTIFACT_ROOT}/wp-codebox-cli/packages/runtime-core/dist"
 
 cat > "${ARTIFACT_ROOT}/wp-codebox-cli/bin/wp-codebox" <<'SH'
 #!/usr/bin/env bash
@@ -22,6 +22,7 @@ set -euo pipefail
 printf '%s\n' 'wp-codebox release stub'
 SH
 chmod +x "${ARTIFACT_ROOT}/wp-codebox-cli/bin/wp-codebox"
+printf '%s\n' 'export const fixture = true;' > "${ARTIFACT_ROOT}/wp-codebox-cli/packages/runtime-core/dist/index.js"
 tar -czf "${ARTIFACT_PATH}" -C "${ARTIFACT_ROOT}" wp-codebox-cli
 
 cat > "${FAKE_BIN}/curl" <<SH
@@ -76,8 +77,9 @@ while [ "$#" -gt 0 ]; do
             exit 0
             ;;
         run)
-            mkdir -p "${prefix}/packages/cli/dist"
+            mkdir -p "${prefix}/packages/cli/dist" "${prefix}/packages/runtime-core/dist"
             printf '%s\n' 'console.log("wp-codebox source stub")' > "${prefix}/packages/cli/dist/index.js"
+            printf '%s\n' 'export const fixture = true;' > "${prefix}/packages/runtime-core/dist/index.js"
             exit 0
             ;;
         *)
@@ -99,6 +101,11 @@ chmod +x "${FAKE_BIN}/npm"
 
 if ! grep -q '^HOMEBOY_WP_CODEBOX_BIN=' "${GITHUB_ENV_FILE}"; then
     echo "Expected setup to export HOMEBOY_WP_CODEBOX_BIN" >&2
+    exit 1
+fi
+
+if ! grep -q '^HOMEBOY_WP_CODEBOX_CORE_MODULE=' "${GITHUB_ENV_FILE}"; then
+    echo "Expected setup to export HOMEBOY_WP_CODEBOX_CORE_MODULE" >&2
     exit 1
 fi
 
@@ -127,9 +134,15 @@ fi
 )
 
 source_wp_codebox_bin="$(grep '^HOMEBOY_WP_CODEBOX_BIN=' "${SOURCE_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
+source_wp_codebox_core_module="$(grep '^HOMEBOY_WP_CODEBOX_CORE_MODULE=' "${SOURCE_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
 
 if [ "$("${source_wp_codebox_bin}")" != "wp-codebox source stub" ]; then
     echo "Expected source fallback wrapper to execute built CLI" >&2
+    exit 1
+fi
+
+if [ ! -f "${source_wp_codebox_core_module}" ]; then
+    echo "Expected source fallback to export built runtime core module" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -13,19 +13,45 @@ set -euo pipefail
 EXTENSION_PATH="$(pwd)"
 
 install_wp_codebox() {
+    write_github_env() {
+        local name="$1"
+        local value="$2"
+
+        if [ -n "${GITHUB_ENV:-}" ]; then
+            echo "${name}=${value}" >> "${GITHUB_ENV}"
+        fi
+    }
+
+    configure_core_module() {
+        local module_path="$1"
+
+        if [ ! -f "${module_path}" ]; then
+            return 1
+        fi
+
+        export HOMEBOY_WP_CODEBOX_CORE_MODULE="${module_path}"
+        write_github_env "HOMEBOY_WP_CODEBOX_CORE_MODULE" "${module_path}"
+        echo "WP Codebox core module configured: ${module_path}"
+        return 0
+    }
+
     if [ -n "${HOMEBOY_WP_CODEBOX_BIN:-}" ] && [ -x "${HOMEBOY_WP_CODEBOX_BIN}" ]; then
         echo "WP Codebox already configured: ${HOMEBOY_WP_CODEBOX_BIN}"
-        return 0
+        if [ -n "${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}" ] && configure_core_module "${HOMEBOY_WP_CODEBOX_CORE_MODULE}"; then
+            return 0
+        fi
+        echo "WP Codebox CLI is configured without a runtime core module; installing source module" >&2
     fi
 
     if command -v wp-codebox >/dev/null 2>&1; then
         local detected_bin
         detected_bin="$(command -v wp-codebox)"
         echo "WP Codebox already available: ${detected_bin}"
-        if [ -n "${GITHUB_ENV:-}" ]; then
-            echo "HOMEBOY_WP_CODEBOX_BIN=${detected_bin}" >> "${GITHUB_ENV}"
+        write_github_env "HOMEBOY_WP_CODEBOX_BIN" "${detected_bin}"
+        if [ -n "${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}" ] && configure_core_module "${HOMEBOY_WP_CODEBOX_CORE_MODULE}"; then
+            return 0
         fi
-        return 0
+        echo "WP Codebox CLI is available without a runtime core module; installing source module" >&2
     fi
 
     local install_mode install_root bin_dir bin_path platform arch artifact_name download_url artifact_path extract_dir
@@ -35,6 +61,7 @@ install_wp_codebox() {
     bin_path="${bin_dir}/wp-codebox"
 
     if [ "${install_mode}" != "source" ]; then
+        local release_artifact_downloaded=0
         platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
         arch="$(uname -m)"
         case "${platform}" in
@@ -54,6 +81,7 @@ install_wp_codebox() {
         mkdir -p "${install_root}" "${bin_dir}"
 
         if command -v curl >/dev/null 2>&1 && curl -fsSL "${download_url}" -o "${artifact_path}"; then
+            release_artifact_downloaded=1
             rm -rf "${extract_dir}"
             mkdir -p "${extract_dir}"
             tar -xzf "${artifact_path}" -C "${extract_dir}"
@@ -69,16 +97,21 @@ exec "${extract_dir}/wp-codebox-cli/bin/wp-codebox" "\$@"
 EOF
             chmod +x "${bin_path}"
 
-            if [ -n "${GITHUB_ENV:-}" ]; then
-                echo "HOMEBOY_WP_CODEBOX_BIN=${bin_path}" >> "${GITHUB_ENV}"
-                echo "PATH=${bin_dir}:${PATH}" >> "${GITHUB_ENV}"
-            fi
+            write_github_env "HOMEBOY_WP_CODEBOX_BIN" "${bin_path}"
+            write_github_env "PATH" "${bin_dir}:${PATH}"
 
             echo "WP Codebox installed: ${bin_path}"
-            return 0
+            if configure_core_module "${extract_dir}/wp-codebox-cli/packages/runtime-core/dist/index.js" || \
+                configure_core_module "${extract_dir}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js"; then
+                return 0
+            fi
+
+            echo "WP Codebox release artifact did not include a runtime core module; falling back to source install" >&2
         fi
 
-        echo "WP Codebox release artifact unavailable; falling back to source install" >&2
+        if [ "${release_artifact_downloaded}" -eq 0 ]; then
+            echo "WP Codebox release artifact unavailable; falling back to source install" >&2
+        fi
     fi
 
     local source ref repo_dir
@@ -100,16 +133,19 @@ EOF
     npm --prefix "${repo_dir}" install --quiet --no-fund --no-audit --omit=optional
     npm --prefix "${repo_dir}" run build --silent
 
+    configure_core_module "${repo_dir}/packages/runtime-core/dist/index.js" || {
+        echo "Built WP Codebox source did not contain packages/runtime-core/dist/index.js" >&2
+        exit 1
+    }
+
     cat > "${bin_path}" <<EOF
 #!/usr/bin/env bash
 exec node "${repo_dir}/packages/cli/dist/index.js" "\$@"
 EOF
     chmod +x "${bin_path}"
 
-    if [ -n "${GITHUB_ENV:-}" ]; then
-        echo "HOMEBOY_WP_CODEBOX_BIN=${bin_path}" >> "${GITHUB_ENV}"
-        echo "PATH=${bin_dir}:${PATH}" >> "${GITHUB_ENV}"
-    fi
+    write_github_env "HOMEBOY_WP_CODEBOX_BIN" "${bin_path}"
+    write_github_env "PATH" "${bin_dir}:${PATH}"
 
     echo "WP Codebox installed: ${bin_path}"
 }


### PR DESCRIPTION
## Summary
- Export `HOMEBOY_WP_CODEBOX_CORE_MODULE` during WordPress extension setup when WP Codebox is installed from release or source.
- Fall back to a source install when the release CLI artifact does not include the reusable runtime-core module required by recipe builders.
- Extend setup smoke coverage so hosted WordPress PHPUnit jobs get both the WP Codebox CLI and core module paths.

Fixes #1176.

## Verification
- `bash scripts/build/setup-wp-codebox-smoke.sh`
- `node tests/wp-codebox-phpunit-recipe-builder-smoke.js`
- `node tests/wp-codebox-bench-recipe-builder-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the hosted CI recipe-builder failure, implementing the setup fix, and running targeted smoke verification.