### PR TITLE
Document Codebox Codex profile boundary

### DIFF
--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -292,6 +292,13 @@ The provider shells through `wp-codebox agent-task-run --input-file=<json>
 artifact capture behind that stable command; Homeboy keeps only request/outcome
 adaptation and redaction logic in this extension.
 
+When Codex subscription credentials are available, the provider selects WP
+Codebox's reusable `codex-subscription` runtime overlay profile through the
+generic `runtime_overlay_profiles` field. Homeboy does not expand that profile
+into provider plugin paths or bundled-library overlays; WP Codebox owns the
+profile example and callers can use the same field for other reusable runtime
+stacks.
+
 ## Runner config surface
 
 Most consumers should use `.github/workflows/datamachine-agent-ci.yml` rather than


### PR DESCRIPTION
## Summary
- Documents that Homeboy selects WP Codebox's `codex-subscription` profile through generic `runtime_overlay_profiles`.
- Clarifies that Homeboy keeps request/outcome adaptation while Codebox owns profile expansion and sandbox lifecycle.

## Testing
- `npm run test:codebox-agent-task-executor`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the boundary documentation update; Chris reviewed the architectural framing and requested the PR.