### PR TITLE
fix: re-derive WP Codebox core module from disk on cold-cache CI runs

### DIFF
--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -146,4 +146,64 @@ if [ ! -f "${source_wp_codebox_core_module}" ]; then
     exit 1
 fi
 
+# Cold-cache regression: a later CI step picks up a cached wp-codebox CLI via
+# HOMEBOY_WP_CODEBOX_BIN, but HOMEBOY_WP_CODEBOX_CORE_MODULE did not survive the
+# step/process boundary. The runtime-core module is still on disk from the
+# earlier install. Setup must re-derive the core module from the known install
+# locations instead of leaving it unset (which made the recipe loader hard-fail
+# with "@automattic/wp-codebox-core not found" and "No tests ran"). The CLI bin
+# is already present, so this path must NOT trigger a network install.
+COLD_HOME="${TMPDIR}/cold-home"
+COLD_INSTALL_DIR="${TMPDIR}/cold-install"
+COLD_GITHUB_ENV_FILE="${TMPDIR}/cold-github-env"
+COLD_BIN="${COLD_HOME}/.local/bin/wp-codebox"
+
+mkdir -p \
+    "${COLD_HOME}/.local/bin" \
+    "${COLD_INSTALL_DIR}/source/packages/runtime-core/dist"
+
+cat > "${COLD_BIN}" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'wp-codebox cached stub'
+SH
+chmod +x "${COLD_BIN}"
+printf '%s\n' 'export const fixture = true;' > "${COLD_INSTALL_DIR}/source/packages/runtime-core/dist/index.js"
+
+# A network would be a hard failure here: the bin already exists, so no curl/git
+# install should run. Point curl/git at stubs that fail loudly if invoked.
+cat > "${FAKE_BIN}/curl-fail" <<'SH'
+#!/usr/bin/env bash
+printf 'cold-cache path must not download via curl: %s\n' "$*" >&2
+exit 1
+SH
+chmod +x "${FAKE_BIN}/curl-fail"
+
+(
+    cd "${EXTENSION_DIR}"
+    HOME="${COLD_HOME}" \
+    PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" \
+    GITHUB_ENV="${COLD_GITHUB_ENV_FILE}" \
+    HOMEBOY_WP_CODEBOX_BIN="${COLD_BIN}" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${COLD_INSTALL_DIR}" \
+    bash "${ROOT_DIR}/scripts/build/setup.sh" > "${TMPDIR}/cold-setup.out"
+)
+
+if ! grep -q '^HOMEBOY_WP_CODEBOX_CORE_MODULE=' "${COLD_GITHUB_ENV_FILE}"; then
+    echo "Expected cold-cache setup to re-derive and export HOMEBOY_WP_CODEBOX_CORE_MODULE" >&2
+    cat "${TMPDIR}/cold-setup.out" >&2
+    exit 1
+fi
+
+cold_core_module="$(grep '^HOMEBOY_WP_CODEBOX_CORE_MODULE=' "${COLD_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
+if [ "${cold_core_module}" != "${COLD_INSTALL_DIR}/source/packages/runtime-core/dist/index.js" ]; then
+    echo "Expected cold-cache setup to resolve the on-disk runtime core module, got: ${cold_core_module}" >&2
+    exit 1
+fi
+
+if grep -qi 'Installing WP Codebox CLI' "${TMPDIR}/cold-setup.out"; then
+    echo "Cold-cache path must not reinstall the CLI when a cached bin and module exist" >&2
+    cat "${TMPDIR}/cold-setup.out" >&2
+    exit 1
+fi
+
 echo "WP Codebox setup smoke passed"

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -35,12 +35,35 @@ install_wp_codebox() {
         return 0
     }
 
+    # Re-derive the core runtime module from the deterministic install
+    # locations on disk. The CLI binary is persisted across GitHub Actions
+    # steps via GITHUB_ENV, but HOMEBOY_WP_CODEBOX_CORE_MODULE does not always
+    # survive process/step boundaries (e.g. `homeboy extension setup` runs in a
+    # child process, and a cached bin can be picked up in a later step where the
+    # earlier export is gone). The recipe loader hard-fails without the module,
+    # so probe the known on-disk paths instead of trusting the env var.
+    resolve_core_module_from_known_locations() {
+        local probe_root="${HOMEBOY_WP_CODEBOX_INSTALL_DIR:-${HOME}/.cache/homeboy/wp-codebox}"
+        local candidate
+        for candidate in \
+            "${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}" \
+            "${probe_root}/source/packages/runtime-core/dist/index.js" \
+            "${probe_root}/source/node_modules/@automattic/wp-codebox-core/dist/index.js" \
+            "${probe_root}/release/wp-codebox-cli/packages/runtime-core/dist/index.js" \
+            "${probe_root}/release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js"; do
+            if [ -n "${candidate}" ] && configure_core_module "${candidate}"; then
+                return 0
+            fi
+        done
+        return 1
+    }
+
     if [ -n "${HOMEBOY_WP_CODEBOX_BIN:-}" ] && [ -x "${HOMEBOY_WP_CODEBOX_BIN}" ]; then
         echo "WP Codebox already configured: ${HOMEBOY_WP_CODEBOX_BIN}"
-        if [ -n "${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}" ] && configure_core_module "${HOMEBOY_WP_CODEBOX_CORE_MODULE}"; then
+        if resolve_core_module_from_known_locations; then
             return 0
         fi
-        echo "WP Codebox CLI is configured without a runtime core module; installing source module" >&2
+        echo "WP Codebox CLI is configured without a runtime core module; (re)installing source module" >&2
     fi
 
     if command -v wp-codebox >/dev/null 2>&1; then
@@ -48,10 +71,10 @@ install_wp_codebox() {
         detected_bin="$(command -v wp-codebox)"
         echo "WP Codebox already available: ${detected_bin}"
         write_github_env "HOMEBOY_WP_CODEBOX_BIN" "${detected_bin}"
-        if [ -n "${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}" ] && configure_core_module "${HOMEBOY_WP_CODEBOX_CORE_MODULE}"; then
+        if resolve_core_module_from_known_locations; then
             return 0
         fi
-        echo "WP Codebox CLI is available without a runtime core module; installing source module" >&2
+        echo "WP Codebox CLI is available without a runtime core module; (re)installing source module" >&2
     fi
 
     local install_mode install_root bin_dir bin_path platform arch artifact_name download_url artifact_path extract_dir


### PR DESCRIPTION
## Summary

Fixes the org-wide CI outage where `homeboy / Test` fails **before any test runs** with:

```
Error: WP Codebox recipe builder export buildWordPressPhpunitRecipe is unavailable.
Install a WP Codebox core module that exports buildWordPressPhpunitRecipe, or set
HOMEBOY_WP_CODEBOX_CORE_MODULE to its built ESM entrypoint.
- @automattic/wp-codebox-core: Cannot find package '@automattic/wp-codebox-core'
"No tests ran — the runner failed before producing results."
"test_failure_count": 0
```

Tracked in homeboy-action#250. Observed red on `data-machine` PRs **and** `main` pushes (the exact same merged commit passed as a PR at 12:22 and failed on `main` at 13:29 — outcome flipped purely on runner cache state).

## Root cause

`"Remove bundled Codebox recipe fallback"` (3f8e5a02) made the recipe loader **hard-fail** when it cannot resolve a WP Codebox core module — by design, to avoid a stale bundled copy drifting from the recipe contract. `"Configure WP Codebox core module during setup"` (60a42b6d) then tried to supply that module via `setup.sh`, but the wiring is fragile:

- `setup.sh` only configured the module when `HOMEBOY_WP_CODEBOX_CORE_MODULE` was **already exported**.
- That env var does **not reliably survive process/step boundaries**:
  - `homeboy extension setup` runs `setup.sh` in a **child process**.
  - A cached `wp-codebox` bin is persisted across GitHub Actions steps via `GITHUB_ENV` (as `HOMEBOY_WP_CODEBOX_BIN`), so a **later step** (the one that runs `homeboy test`) picks up the bin via the early-return path — but the earlier `export HOMEBOY_WP_CODEBOX_CORE_MODULE` is gone in that fresh shell.
- On those early-return paths the module stayed unset → the loader fell back to importing the unresolvable `@automattic/wp-codebox-core` package → threw → **zero tests ran**.

The non-determinism is explained by the homeboy cache: runs that restored a **pre-removal** `homeboy-<ver>-wordpress-<os>-<arch>` cache (which still had the bundled fallback) went green; cold-cache runs hit the new loader with no module and died.

CI log confirming the sequence (from the failing data-machine run):

```
13:43:51  source install (child process) → npm run build → "WP Codebox installed"
13:44:26  later step: "WP Codebox already configured: …/wp-codebox"  ← early return, module env lost
13:44:55  test runs → @automattic/wp-codebox-core not found → THROW, No tests ran
```

## Fix

Add `resolve_core_module_from_known_locations()` to `setup.sh`, which probes the **deterministic on-disk install locations** in addition to the env var:

- `${HOMEBOY_WP_CODEBOX_CORE_MODULE}` (if set)
- `<install-dir>/source/packages/runtime-core/dist/index.js`
- `<install-dir>/source/node_modules/@automattic/wp-codebox-core/dist/index.js`
- `<install-dir>/release/wp-codebox-cli/packages/runtime-core/dist/index.js`
- `<install-dir>/release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js`

The cached-bin and on-PATH early-return paths now call this helper instead of trusting the env var, and only `return 0` once the module is **actually resolvable** on disk. If it isn't, they fall through to the existing self-healing (re)install. No network install runs when a cached bin **and** module already exist.

This keeps the deliberate "no bundled fallback" design from 3f8e5a02 intact — it just makes the module the loader needs reliably present regardless of step/process boundaries.

## Tests

Adds a cold-cache regression case to `setup-wp-codebox-smoke.sh` that reproduces the exact failure:

- Pre-set `HOMEBOY_WP_CODEBOX_BIN` (cached bin), `HOMEBOY_WP_CODEBOX_CORE_MODULE` **unset**, runtime-core module present on disk from a prior install.
- Asserts setup **re-derives and exports** `HOMEBOY_WP_CODEBOX_CORE_MODULE` to the correct on-disk path.
- Asserts it does **not** reinstall the CLI (no "Installing WP Codebox CLI") when a cached bin + module already exist.

### Verification

```
bash -n wordpress/scripts/build/setup.sh                       # syntax OK
bash wordpress/scripts/build/setup-wp-codebox-smoke.sh         # PASS (incl. new cold-cache case)
node wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js  # PASS
node wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js    # PASS
# all wordpress/scripts/build/*smoke*.sh → PASS
```
