### PR TITLE
Fix WP Codebox CLI release fallback

### DIFF
--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -11,6 +11,7 @@ HOME_DIR="${TMPDIR}/home"
 EXTENSION_DIR="${TMPDIR}/extension"
 GITHUB_ENV_FILE="${TMPDIR}/github-env"
 SOURCE_GITHUB_ENV_FILE="${TMPDIR}/source-github-env"
+MISSING_RELEASE_GITHUB_ENV_FILE="${TMPDIR}/missing-release-github-env"
 ARTIFACT_ROOT="${TMPDIR}/artifact-root"
 ARTIFACT_PATH="${TMPDIR}/wp-codebox-cli-linux-x64.tar.gz"
 
@@ -28,6 +29,19 @@ tar -czf "${ARTIFACT_PATH}" -C "${ARTIFACT_ROOT}" wp-codebox-cli
 cat > "${FAKE_BIN}/curl" <<SH
 #!/usr/bin/env bash
 set -euo pipefail
+
+if [ "\${FAKE_WP_CODEBOX_RELEASE_MISSING:-}" = "1" ]; then
+    if [ "\$#" -ge 2 ] && [ "\${1}" = "-fsIL" ]; then
+        exit 22
+    fi
+
+    printf 'unexpected download after missing release probe: %s\n' "\$*" >&2
+    exit 1
+fi
+
+if [ "\$#" -ge 2 ] && [ "\${1}" = "-fsIL" ]; then
+    exit 0
+fi
 
 if [ "\$#" -lt 4 ] || [ "\${3}" != "-o" ]; then
     printf 'unexpected curl invocation: %s\n' "\$*" >&2
@@ -143,6 +157,31 @@ fi
 
 if [ ! -f "${source_wp_codebox_core_module}" ]; then
     echo "Expected source fallback to export built runtime core module" >&2
+    exit 1
+fi
+
+(
+    cd "${EXTENSION_DIR}"
+    HOME="${HOME_DIR}" \
+    PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" \
+    GITHUB_ENV="${MISSING_RELEASE_GITHUB_ENV_FILE}" \
+    FAKE_WP_CODEBOX_RELEASE_MISSING="1" \
+    HOMEBOY_WP_CODEBOX_INSTALL_DIR="${TMPDIR}/missing-release-install" \
+    HOMEBOY_WP_CODEBOX_DOWNLOAD_URL="https://example.test/wp-codebox-cli-linux-x64.tar.gz" \
+    HOMEBOY_WP_CODEBOX_SOURCE="https://example.test/wp-codebox.git" \
+    HOMEBOY_WP_CODEBOX_REF="main" \
+    bash "${ROOT_DIR}/scripts/build/setup.sh" > "${TMPDIR}/missing-release-setup.out" 2> "${TMPDIR}/missing-release-setup.err"
+)
+
+missing_release_wp_codebox_bin="$(grep '^HOMEBOY_WP_CODEBOX_BIN=' "${MISSING_RELEASE_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
+
+if [ "$("${missing_release_wp_codebox_bin}")" != "wp-codebox source stub" ]; then
+    echo "Expected missing release artifact to fall back to built CLI" >&2
+    exit 1
+fi
+
+if ! grep -q 'WP Codebox release artifact not published' "${TMPDIR}/missing-release-setup.err"; then
+    echo "Expected missing release artifact message" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -80,7 +80,7 @@ install_wp_codebox() {
         echo "Installing WP Codebox CLI from release artifact (${download_url})..."
         mkdir -p "${install_root}" "${bin_dir}"
 
-        if command -v curl >/dev/null 2>&1 && curl -fsSL "${download_url}" -o "${artifact_path}"; then
+        if command -v curl >/dev/null 2>&1 && curl -fsIL "${download_url}" >/dev/null 2>&1 && curl -fsSL "${download_url}" -o "${artifact_path}"; then
             release_artifact_downloaded=1
             rm -rf "${extract_dir}"
             mkdir -p "${extract_dir}"
@@ -110,7 +110,7 @@ EOF
         fi
 
         if [ "${release_artifact_downloaded}" -eq 0 ]; then
-            echo "WP Codebox release artifact unavailable; falling back to source install" >&2
+            echo "WP Codebox release artifact not published at ${download_url}; falling back to source install" >&2
         fi
     fi
 


### PR DESCRIPTION
## Summary
- Probe the expected WP Codebox CLI release artifact before trying to download it.
- Fall back directly to the source install path when the latest WP Codebox release has no matching CLI asset.
- Extend the WP Codebox setup smoke test to cover missing release assets without attempting the failed download body.

## Verification
- `bash wordpress/scripts/build/setup-wp-codebox-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the missing release asset failure, drafted the installer fallback change, and added focused smoke coverage; Chris remains responsible for review and merge.