### PR TITLE
Fix WP Codebox bench dependency plugin paths

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
@@ -57,6 +57,14 @@ homeboy_export_validation_dependency_paths() {
 homeboy_get_validation_dependency_slug() {
     basename "$1"
 }
+homeboy_find_validation_dependency_plugin_main_file() {
+    local plugin_path="${1:-}"
+    if [ -f "${plugin_path}/packages/wordpress-plugin/wp-codebox.php" ]; then
+        printf '%s\n' "${plugin_path}/packages/wordpress-plugin/wp-codebox.php"
+        return 0
+    fi
+    return 1
+}
 STUB
 
 CAPTURE_FILE="${TMP_ROOT}/capture.json"
@@ -217,5 +225,33 @@ jq -e --arg sourceRoot "$PLUGIN_ROOT" '
     .recipe.inputs.extraPlugins == [{source: $sourceRoot, slug: "wp-site-generator", pluginFile: "wp-site-generator/plugin-main.php", activate: false}]
     and ([.recipe.inputs.mounts[] | select(.source == $sourceRoot and .target == "/wordpress/wp-content/plugins/wp-site-generator")] | length == 0)
 ' "$PLUGIN_CAPTURE_FILE" >/dev/null
+
+DEPENDENCY_ROOT="${TMP_ROOT}/wp-codebox-release-fixture"
+mkdir -p "${DEPENDENCY_ROOT}/packages/wordpress-plugin"
+printf '<?php\n/**\n * Plugin Name: WP Codebox Fixture\n */\n' > "${DEPENDENCY_ROOT}/packages/wordpress-plugin/wp-codebox.php"
+
+DEPENDENCY_CAPTURE_FILE="${TMP_ROOT}/dependency-capture.json"
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \
+HOMEBOY_RUNTIME_BENCH_HELPER_SH="$BENCH_HELPER" \
+HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+HOMEBOY_WORDPRESS_DEPENDENCY_PATHS="$DEPENDENCY_ROOT" \
+HOMEBOY_SMOKE_SOURCE_ROOT="$PLUGIN_ROOT" \
+HOMEBOY_SMOKE_CAPTURE_FILE="$DEPENDENCY_CAPTURE_FILE" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+HOMEBOY_WP_CODEBOX_BIN="$WP_CODEBOX_BIN" \
+HOMEBOY_WP_CODEBOX_CORE_MODULE="$WP_CODEBOX_CORE_MODULE" \
+HOMEBOY_BENCH_RESULTS_FILE="${TMP_ROOT}/dependency-bench-results.json" \
+HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="${TMP_ROOT}/dependency-artifacts" \
+HOMEBOY_RUNTIME_FAILURE_TRAP="" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
+bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
+
+jq -e --arg pluginRoot "$PLUGIN_ROOT" --arg dependencyRoot "${DEPENDENCY_ROOT}/packages/wordpress-plugin" '
+    .recipe.inputs.extraPlugins == [
+        {source: $pluginRoot, slug: "wp-site-generator", pluginFile: "wp-site-generator/plugin-main.php", activate: false},
+        {source: $dependencyRoot, slug: "wp-codebox", pluginFile: "wp-codebox/wp-codebox.php", activate: false}
+    ]
+' "$DEPENDENCY_CAPTURE_FILE" >/dev/null
 
 echo "WP Codebox static-source bench smoke passed"

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -709,8 +709,29 @@ if [ -n "$DEPENDENCY_PATHS" ]; then
     while IFS= read -r dep_path; do
         [ -n "$dep_path" ] || continue
         dep_slug="$(homeboy_get_validation_dependency_slug "$dep_path" || basename "$dep_path")"
+        dep_plugin_file=""
+        dep_plugin_relative_file=""
+        dep_plugin_source="$dep_path"
+        if type homeboy_find_validation_dependency_plugin_main_file &>/dev/null; then
+            dep_plugin_file="$(homeboy_find_validation_dependency_plugin_main_file "$dep_path" || true)"
+        fi
+        if [ -n "$dep_plugin_file" ]; then
+            dep_plugin_relative_file="${dep_plugin_file#"${dep_path%/}/"}"
+            dep_plugin_basename="$(basename "$dep_plugin_file" .php)"
+            if [ -n "$dep_plugin_basename" ] && { [ "$dep_plugin_basename" != "$dep_slug" ] || [[ "$dep_plugin_relative_file" == packages/wordpress-plugin/* ]]; }; then
+                dep_slug="$dep_plugin_basename"
+            fi
+            if [[ "$dep_plugin_relative_file" == packages/wordpress-plugin/* ]]; then
+                dep_plugin_source="$(dirname "$dep_plugin_file")"
+                dep_plugin_relative_file="$(basename "$dep_plugin_file")"
+            fi
+        fi
         DEPENDENCY_SLUGS+=("$dep_slug")
-        EXTRA_PLUGINS_JSON=$(jq -nc --argjson plugins "$EXTRA_PLUGINS_JSON" --arg source "$dep_path" --arg slug "$dep_slug" '$plugins + [{source: $source, slug: $slug, activate: false}]')
+        if [ -n "$dep_plugin_relative_file" ] && [ "$dep_plugin_relative_file" != "$dep_plugin_file" ]; then
+            EXTRA_PLUGINS_JSON=$(jq -nc --argjson plugins "$EXTRA_PLUGINS_JSON" --arg source "$dep_plugin_source" --arg slug "$dep_slug" --arg pluginFile "${dep_slug}/${dep_plugin_relative_file}" '$plugins + [{source: $source, slug: $slug, pluginFile: $pluginFile, activate: false}]')
+        else
+            EXTRA_PLUGINS_JSON=$(jq -nc --argjson plugins "$EXTRA_PLUGINS_JSON" --arg source "$dep_plugin_source" --arg slug "$dep_slug" '$plugins + [{source: $source, slug: $slug, activate: false}]')
+        fi
     done <<< "$DEPENDENCY_PATHS"
 fi
 

--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -119,7 +119,9 @@ homeboy_find_validation_dependency_plugin_main_file() {
 
     [ -n "$plugin_path" ] && [ -d "$plugin_path" ] || return 1
 
-    local candidate
+    local candidate canonical_slug
+    canonical_slug="$(basename "$plugin_path")"
+    canonical_slug="${canonical_slug%%@*}"
     for candidate in "${plugin_path}/$(basename "$plugin_path").php" "${plugin_path}/plugin.php"; do
         [ -f "$candidate" ] || continue
         if grep -q 'Plugin Name:' "$candidate"; then
@@ -129,6 +131,24 @@ homeboy_find_validation_dependency_plugin_main_file() {
     done
 
     for candidate in "$plugin_path"/*.php; do
+        [ -f "$candidate" ] || continue
+        if grep -q 'Plugin Name:' "$candidate"; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    for candidate in \
+        "${plugin_path}/packages/wordpress-plugin/${canonical_slug}.php" \
+        "${plugin_path}/packages/wordpress-plugin/plugin.php"; do
+        [ -f "$candidate" ] || continue
+        if grep -q 'Plugin Name:' "$candidate"; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    for candidate in "${plugin_path}/packages/wordpress-plugin"/*.php; do
         [ -f "$candidate" ] || continue
         if grep -q 'Plugin Name:' "$candidate"; then
             printf '%s\n' "$candidate"
@@ -269,6 +289,8 @@ if (!function_exists('plugin_dir_path')) { function plugin_dir_path($file) { ret
 if (!function_exists('plugin_dir_url')) { function plugin_dir_url($file) { return ''; } }
 if (!function_exists('plugin_basename')) { function plugin_basename($file) { return basename(dirname($file)) . '/' . basename($file); } }
 if (!function_exists('trailingslashit')) { function trailingslashit($string) { return rtrim($string, '/\\') . '/'; } }
+if (!function_exists('sanitize_key')) { function sanitize_key($key) { return preg_replace('/[^a-z0-9_\\-]/', '', strtolower((string) $key)); } }
+if (!function_exists('sanitize_text_field')) { function sanitize_text_field($str) { return trim(strip_tags((string) $str)); } }
 if (!function_exists('wp_normalize_path')) { function wp_normalize_path($path) { return str_replace('\\', '/', $path); } }
 if (!function_exists('wp_die')) { function wp_die($message = '', $title = '', $args = array()) { fwrite(STDERR, (string) $message); exit(1); } }
 if (!function_exists('__')) { function __($text, $domain = 'default') { return $text; } }

--- a/wordpress/tests/dependency-plugin-preflight-smoke.sh
+++ b/wordpress/tests/dependency-plugin-preflight-smoke.sh
@@ -90,4 +90,39 @@ if [ -f "${READY_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.js
     exit 1
 fi
 
+NESTED_PACKAGE_DEP="${TMP_ROOT}/wp-codebox-release-fixture"
+mkdir -p "${NESTED_PACKAGE_DEP}/packages/wordpress-plugin"
+cat > "${NESTED_PACKAGE_DEP}/packages/wordpress-plugin/wp-codebox.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: WP Codebox Fixture
+ */
+PHP
+
+NESTED_PACKAGE_ARTIFACTS="${TMP_ROOT}/nested-package-artifacts"
+homeboy_preflight_wordpress_dependency_plugins "$NESTED_PACKAGE_DEP" "$NESTED_PACKAGE_ARTIFACTS" "bench"
+if [ -f "${NESTED_PACKAGE_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" ]; then
+    echo "ERROR: nested package plugin dependency should not emit preflight diagnostics." >&2
+    jq '.' "${NESTED_PACKAGE_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" >&2 || true
+    exit 1
+fi
+
+SANITIZE_KEY_DEP="${TMP_ROOT}/sanitize-key-plugin"
+mkdir -p "$SANITIZE_KEY_DEP"
+cat > "${SANITIZE_KEY_DEP}/sanitize-key-plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Sanitize Key Fixture
+ */
+$fixture_key = sanitize_key('Fixture Key');
+PHP
+
+SANITIZE_KEY_ARTIFACTS="${TMP_ROOT}/sanitize-key-artifacts"
+homeboy_preflight_wordpress_dependency_plugins "$SANITIZE_KEY_DEP" "$SANITIZE_KEY_ARTIFACTS" "bench"
+if [ -f "${SANITIZE_KEY_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" ]; then
+    echo "ERROR: sanitize_key plugin dependency should not emit preflight diagnostics." >&2
+    jq '.' "${SANITIZE_KEY_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" >&2 || true
+    exit 1
+fi
+
 echo "dependency plugin preflight smoke passed"


### PR DESCRIPTION
## Summary
- Resolve nested WordPress plugin package roots during dependency preflight, including `packages/wordpress-plugin/*.php` release checkouts.
- Add minimal WordPress sanitization stubs used by lightweight plugin load preflight.
- Pass resolved dependency plugin main files into WP Codebox bench recipes so release checkouts mount/load under the correct plugin slug.

## Verification
- `bash wordpress/tests/dependency-plugin-preflight-smoke.sh`
- `bash wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- Studio Web Homeboy bench retry reached the workload phase after preflight and recipe validation passed; remaining failure is downstream in `studio-web/tests/bench/website-generation.php:30` requiring logged-in user/browser identity.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Workflow Bench/Homeboy dependency preflight and WP Codebox recipe path failures, drafted the shell changes and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.