### PR TITLE
Carry managed preview proof target metadata

### DIFF
--- a/managed-preview/README.md
+++ b/managed-preview/README.md
@@ -23,6 +23,20 @@ Homeboy injects `HOMEBOY_SERVICE_LOCAL_URL` and `HOMEBOY_TUNNEL_PUBLIC_URL` into
 
 The broker response must prove `capabilities.hostname_preserving_browser_origin === true` and return browser-origin evidence matching the requested effective origin. A plain port tunnel that changes `window.location.origin` is rejected.
 
+Use `--target-id`, `--target-url`, and repeated `--route name=url` values to carry workload-owned proof targets into broker evidence without teaching this extension product semantics. For WPCOM, the rig can keep the exact `wordpress.com/ai` landing-page proof separate from Calypso `/start` and `/setup/ai-site-builder` proof:
+
+```sh
+node scripts/public-preview-backend.mjs \
+  --target-id wpcom-ai-landing \
+  --target-url https://wordpress.com/ai/ \
+  --route landing=https://wordpress.com/ai/ \
+  --route builder_handoff=https://wordpress.com/setup/ai-site-builder \
+  --local-url http://127.0.0.1:7331 \
+  --public-url https://preview-broker.example/runs/run-123 \
+  --broker-url https://preview-broker.example/api/managed-previews \
+  --dry-run
+```
+
 ## Hostname-Sensitive Proofs
 
 Some consumers need the browser-effective origin to remain the local development origin. The WPCOM Calypso `/start` proof is one of these: it expects `http://calypso.localhost:3000`, not a tunnel origin.
@@ -31,6 +45,10 @@ For those consumers, pass `--expected-effective-origin` and `--require-host-pres
 
 ```sh
 node scripts/public-preview-backend.mjs \
+  --target-id calypso-start \
+  --target-url http://calypso.localhost:3000/start \
+  --route start=http://calypso.localhost:3000/start \
+  --route builder_handoff=http://calypso.localhost:3000/setup/ai-site-builder \
   --local-url http://calypso.localhost:3000 \
   --public-url https://preview-broker.example/runs/run-123 \
   --broker-url https://preview-broker.example/api/managed-previews \

--- a/managed-preview/scripts/public-preview-backend.mjs
+++ b/managed-preview/scripts/public-preview-backend.mjs
@@ -12,6 +12,7 @@ async function main() {
   const expectedEffectiveOrigin = options.expectedEffectiveOrigin || process.env.HOMEBOY_EXPECTED_EFFECTIVE_ORIGIN || '';
   const expectedConfigHostname = options.expectedConfigHostname || process.env.HOMEBOY_EXPECTED_CONFIG_HOSTNAME || '';
   const requireHostPreservation = Boolean(options.requireHostPreservation || expectedEffectiveOrigin || expectedConfigHostname);
+  const target = buildTargetMetadata(options);
 
   const brokerUrl = brokerUrlValue ? parseUrl(brokerUrlValue, 'broker URL') : null;
   const plan = buildPlan({ provider, localUrl, publicUrl, brokerUrl, options });
@@ -50,6 +51,7 @@ async function main() {
     localUrl,
     publicUrl,
     preservation,
+    target,
   });
 
   const startEvidence = {
@@ -58,6 +60,7 @@ async function main() {
     provider,
     local_url: localUrl.href,
     public_url: publicUrl.href,
+    target,
     command: plan.command,
     args: plan.args,
     host_preservation: preservation,
@@ -148,12 +151,13 @@ function evaluateHostPreservation({
   };
 }
 
-async function registerPreview({ dryRun, brokerUrl, provider, localUrl, publicUrl, preservation }) {
+async function registerPreview({ dryRun, brokerUrl, provider, localUrl, publicUrl, preservation, target }) {
   const request = {
     schema: 'homeboy/managed-preview-broker-request/v1',
     provider,
     local_url: localUrl.href,
     public_url: publicUrl.href,
+    target,
     host_preservation: preservation,
   };
 
@@ -180,6 +184,35 @@ async function registerPreview({ dryRun, brokerUrl, provider, localUrl, publicUr
     throw new Error('Preview broker response did not prove hostname-preserving browser-origin capability');
   }
   return payload;
+}
+
+function buildTargetMetadata(options) {
+  const routes = {};
+  for (const route of options.routes || []) {
+    const separator = route.indexOf('=');
+    if (separator <= 0) {
+      throw new Error(`Invalid --route value: ${route}`);
+    }
+    const name = route.slice(0, separator);
+    const value = route.slice(separator + 1);
+    routes[name] = parseUrl(value, `route ${name}`).href;
+  }
+
+  const target = {
+    id: options.targetId || process.env.HOMEBOY_PREVIEW_TARGET_ID || null,
+    url: options.targetUrl || process.env.HOMEBOY_PREVIEW_TARGET_URL || null,
+    routes,
+  };
+
+  if (target.url) {
+    target.url = parseUrl(target.url, 'target URL').href;
+  }
+
+  if (!target.id && !target.url && Object.keys(routes).length === 0) {
+    return null;
+  }
+
+  return target;
 }
 
 function parseUrl(value, label) {
@@ -213,7 +246,12 @@ function parseArgs(args) {
     if (!value || value.startsWith('--')) {
       throw new Error(`Missing value for ${arg}`);
     }
-    options[key] = value;
+    if (key === 'route') {
+      options.routes ||= [];
+      options.routes.push(value);
+    } else {
+      options[key] = value;
+    }
     i += 1;
   }
   return options;

--- a/managed-preview/tests/public-preview-backend-smoke.mjs
+++ b/managed-preview/tests/public-preview-backend-smoke.mjs
@@ -18,6 +18,14 @@ const planned = run([
   'https://preview-broker.example/runs/run-123',
   '--broker-url',
   'https://preview-broker.example/api/managed-previews',
+  '--target-id',
+  'wpcom-ai-landing',
+  '--target-url',
+  'https://wordpress.com/ai/',
+  '--route',
+  'landing=https://wordpress.com/ai/',
+  '--route',
+  'builder_handoff=https://wordpress.com/setup/ai-site-builder',
   '--dry-run',
 ]);
 
@@ -28,6 +36,10 @@ assert.equal(plannedJson.status, 'planned');
 assert.equal(plannedJson.provider, 'external-broker');
 assert.equal(plannedJson.registration.status, 'planned');
 assert.equal(plannedJson.registration.broker_url, 'https://preview-broker.example/api/managed-previews');
+assert.equal(plannedJson.target.id, 'wpcom-ai-landing');
+assert.equal(plannedJson.target.url, 'https://wordpress.com/ai/');
+assert.equal(plannedJson.target.routes.landing, 'https://wordpress.com/ai/');
+assert.equal(plannedJson.target.routes.builder_handoff, 'https://wordpress.com/setup/ai-site-builder');
 
 const blocked = run([
   scriptPath,
@@ -57,6 +69,14 @@ const preserved = run([
   'https://preview-broker.example/runs/run-123',
   '--broker-url',
   'https://preview-broker.example/api/managed-previews',
+  '--target-id',
+  'calypso-start',
+  '--target-url',
+  'http://calypso.localhost:3000/start',
+  '--route',
+  'start=http://calypso.localhost:3000/start',
+  '--route',
+  'builder_handoff=http://calypso.localhost:3000/setup/ai-site-builder',
   '--expected-effective-origin',
   'http://calypso.localhost:3000',
   '--expected-config-hostname',
@@ -69,6 +89,9 @@ assert.equal(preserved.status, 0, preserved.stderr);
 const preservedJson = JSON.parse(preserved.stdout);
 assert.equal(preservedJson.host_preservation.supported, true);
 assert.equal(preservedJson.host_preservation.mode, 'broker-must-prove-host-preservation');
+assert.equal(preservedJson.registration.request.target.id, 'calypso-start');
+assert.equal(preservedJson.registration.request.target.routes.start, 'http://calypso.localhost:3000/start');
+assert.equal(preservedJson.registration.request.target.routes.builder_handoff, 'http://calypso.localhost:3000/setup/ai-site-builder');
 
 function run(args) {
   return spawnSync(process.execPath, args, {


### PR DESCRIPTION
## Summary
- Adds generic proof target metadata to the managed-preview broker helper so workloads can name first-class proof targets and route handoffs.
- Keeps WPCOM semantics outside Homeboy Extensions while allowing WPCOM rigs to distinguish exact `https://wordpress.com/ai/` landing evidence from Calypso `/start` and `/setup/ai-site-builder` handoff evidence.
- Avoids conflating `/ai`, `/ai-website-builder`, and `/setup/ai-site-builder` in backend/ingress evidence.

Refs #1181.
Follow-up to #1182, which merged before this target metadata update landed.

## Verification
- `node managed-preview/tests/public-preview-backend-smoke.mjs`
- `node -e "for (const f of ['managed-preview/managed-preview.json']) JSON.parse(require('fs').readFileSync(f, 'utf8'))"`

## WPCOM target scope
The helper now carries these generic target/route fields into the broker request/evidence:

- `target.id`
- `target.url`
- `target.routes`

The smoke test covers:

- `wpcom-ai-landing` with exact `https://wordpress.com/ai/` and `builder_handoff=https://wordpress.com/setup/ai-site-builder`.
- `calypso-start` with `http://calypso.localhost:3000/start` and local `builder_handoff=http://calypso.localhost:3000/setup/ai-site-builder`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the target metadata follow-up, smoke coverage, docs, and verification notes for Chris to review/test.