### PR TITLE
fix: use DMC workspace abilities in agent runner

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
@@ -64,9 +64,25 @@ namespace {
 
     if ( ! function_exists( 'wp_get_ability' ) ) {
         function wp_get_ability( string $ability_name ): object {
-            return new class {
+            $GLOBALS['homeboy_forced_parameters_ability_names'][] = $ability_name;
+            return new class( $ability_name ) {
+                private string $ability_name;
+
+                public function __construct( string $ability_name ) {
+                    $this->ability_name = $ability_name;
+                }
+
                 public function execute( array $args ): array {
                     $GLOBALS['homeboy_forced_parameters_args'] = $args;
+                    if ( 'datamachine-code/workspace-worktree-add' === $this->ability_name ) {
+                        return array(
+                            'success' => true,
+                            'handle'  => $args['repo'] . '@' . str_replace( '/', '-', (string) $args['branch'] ),
+                            'branch'  => (string) $args['branch'],
+                            'path'    => '/tmp/' . $args['repo'],
+                            'args'    => $args,
+                        );
+                    }
                     return array(
                         'success' => true,
                         'args'    => $args,
@@ -376,6 +392,39 @@ namespace {
     if ( '.agent-workspace/current-project/plugins/sample.php' !== ( $scoped_parameters['path'] ?? null ) ) {
         fwrite( STDERR, "Expected alias runner workspace mode to scope workspace file paths before dispatch.\n" );
         exit( 1 );
+    }
+
+    $GLOBALS['homeboy_forced_parameters_ability_names'] = array();
+    $provisioned_workspace = homeboy_datamachine_agent_provision_workspace(
+        array(
+            'runner_workspace' => array(
+                'enabled'       => true,
+                'repo'          => 'html-to-blocks-converter',
+                'branch'        => 'agent/iterator-repair',
+                'allow_stale'   => true,
+                'rebase_base'   => true,
+                'clone_url'     => 'https://github.com/chubes4/html-to-blocks-converter.git',
+            ),
+        )
+    );
+
+    if ( empty( $provisioned_workspace['success'] ) || 'html-to-blocks-converter@agent-iterator-repair' !== ( $provisioned_workspace['handle'] ?? null ) ) {
+        fwrite( STDERR, "Expected runner workspace provisioning to create a DMC worktree.\n" );
+        exit( 1 );
+    }
+
+    foreach ( array( 'datamachine-code/workspace-show', 'datamachine-code/workspace-clone', 'datamachine-code/workspace-worktree-add' ) as $expected_ability ) {
+        if ( ! in_array( $expected_ability, $GLOBALS['homeboy_forced_parameters_ability_names'], true ) ) {
+            fwrite( STDERR, "Expected runner workspace provisioning to resolve {$expected_ability}.\n" );
+            exit( 1 );
+        }
+    }
+
+    foreach ( $GLOBALS['homeboy_forced_parameters_ability_names'] as $ability_name ) {
+        if ( str_starts_with( $ability_name, 'datamachine/workspace-' ) ) {
+            fwrite( STDERR, "Runner workspace provisioning used stale workspace ability namespace.\n" );
+            exit( 1 );
+        }
     }
 
     $sanitized_response = homeboy_datamachine_agent_sanitize_runner_workspace_alias_result(

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -2407,9 +2407,9 @@ if ( ! function_exists( 'homeboy_datamachine_agent_provision_workspace' ) ) {
         }
 
         $required = array(
-            'datamachine/workspace-show',
-            'datamachine/workspace-clone',
-            'datamachine/workspace-worktree-add',
+            'datamachine-code/workspace-show',
+            'datamachine-code/workspace-clone',
+            'datamachine-code/workspace-worktree-add',
         );
         foreach ( $required as $ability_name ) {
             if ( ! wp_get_ability( $ability_name ) ) {
@@ -2417,7 +2417,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_provision_workspace' ) ) {
             }
         }
 
-        $show = wp_get_ability( 'datamachine/workspace-show' )->execute( array( 'name' => $repo ) );
+        $show = wp_get_ability( 'datamachine-code/workspace-show' )->execute( array( 'name' => $repo ) );
         if ( function_exists( 'is_wp_error' ) && is_wp_error( $show ) ) {
             $clone_url = isset( $workspace['clone_url'] ) && is_scalar( $workspace['clone_url'] ) ? trim( (string) $workspace['clone_url'] ) : '';
             if ( '' === $clone_url ) {
@@ -2433,7 +2433,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_provision_workspace' ) ) {
                 $clone_input['auth_token_env'] = $github_token_env;
             }
 
-            $clone = wp_get_ability( 'datamachine/workspace-clone' )->execute(
+            $clone = wp_get_ability( 'datamachine-code/workspace-clone' )->execute(
                 array_filter(
                     $clone_input,
                     static fn( $value ) => '' !== $value
@@ -2462,7 +2462,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_provision_workspace' ) ) {
             'force'          => homeboy_datamachine_agent_bool_config( $workspace, 'force', false ),
         );
 
-        $worktree = wp_get_ability( 'datamachine/workspace-worktree-add' )->execute( $input );
+        $worktree = wp_get_ability( 'datamachine-code/workspace-worktree-add' )->execute( $input );
         if ( function_exists( 'is_wp_error' ) && is_wp_error( $worktree ) ) {
             return array( 'enabled' => true, 'success' => false, 'error' => $worktree->get_error_message(), 'input' => $input );
         }


### PR DESCRIPTION
## Summary
- Switch runner-workspace provisioning from the stale `datamachine/...` workspace ability namespace to `datamachine-code/...`.
- Add smoke coverage that provisions a runner worktree through the DMC ability names and rejects the stale namespace.

## Tests
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified the namespace mismatch while debugging iterator workspace provisioning, drafted the patch, and ran local smoke coverage; Chris remains responsible for review and merge.