### PR TITLE
Add Data Machine Code promotion provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,23 @@ homeboy test
 homeboy release
 ```
 
+### Data Machine Code promotion provider
+
+Homeboy core can promote agent-task patch artifacts through an external
+workspace provider command. This repo provides a Data Machine Code-backed
+provider script for environments that use managed DMC worktrees:
+
+```bash
+homeboy agent-task promote aggregate.json \
+  --to-worktree repo@branch-slug \
+  --provider-command ./scripts/datamachine-code-promotion-provider.sh
+```
+
+The provider reads `homeboy/agent-task-promotion-apply-request/v1` JSON on
+stdin and writes `homeboy/agent-task-promotion-apply-response/v1` JSON on
+stdout. It keeps the DMC-specific `studio wp datamachine-code ...` shellouts in
+Homeboy Extensions instead of Homeboy core.
+
 Each extension also exposes a CLI binding for direct use against a project or component:
 
 ```bash

--- a/scripts/datamachine-code-promotion-provider.sh
+++ b/scripts/datamachine-code-promotion-provider.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Homeboy agent-task promotion provider backed by Data Machine Code workspaces.
+# Reads homeboy/agent-task-promotion-apply-request/v1 JSON on stdin and writes
+# homeboy/agent-task-promotion-apply-response/v1 JSON on stdout.
+
+REQUEST_SCHEMA="homeboy/agent-task-promotion-apply-request/v1"
+RESPONSE_SCHEMA="homeboy/agent-task-promotion-apply-response/v1"
+
+require_tool() {
+    local tool="$1"
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "Missing required tool: $tool" >&2
+        exit 127
+    fi
+}
+
+json_command_array() {
+    local first=1
+    printf '['
+    local arg
+    for arg in "$@"; do
+        if [ "$first" -eq 1 ]; then
+            first=0
+        else
+            printf ','
+        fi
+        printf '%s' "$arg" | jq -Rsa .
+    done
+    printf ']'
+}
+
+append_evidence() {
+    local evidence_file="$1"
+    local command_json="$2"
+    local exit_code="$3"
+    local stdout_file="$4"
+    local stderr_file="$5"
+    local entry_file
+    entry_file="$(mktemp)"
+    jq -n \
+        --argjson command "$command_json" \
+        --argjson exit_code "$exit_code" \
+        --rawfile stdout "$stdout_file" \
+        --rawfile stderr "$stderr_file" \
+        '{command:$command,exit_code:$exit_code,stdout:$stdout,stderr:$stderr}' >"$entry_file"
+    jq -s '.[0] + [.[1]]' "$evidence_file" "$entry_file" >"${evidence_file}.next"
+    mv "${evidence_file}.next" "$evidence_file"
+    rm -f "$entry_file"
+}
+
+run_dmc_command() {
+    local evidence_file="$1"
+    local capture="$2"
+    shift 2
+    local stdout_file stderr_file command_json exit_code
+    stdout_file="$(mktemp)"
+    stderr_file="$(mktemp)"
+    command_json="$(json_command_array "$@")"
+    if "$@" >"$stdout_file" 2>"$stderr_file"; then
+        exit_code=0
+    else
+        exit_code=$?
+    fi
+    if [ "$capture" = "yes" ]; then
+        append_evidence "$evidence_file" "$command_json" "$exit_code" "$stdout_file" "$stderr_file"
+    fi
+    if [ "$exit_code" -ne 0 ]; then
+        cat "$stderr_file" >&2
+        rm -f "$stdout_file" "$stderr_file"
+        exit "$exit_code"
+    fi
+    cat "$stdout_file"
+    rm -f "$stdout_file" "$stderr_file"
+}
+
+worktree_path_from_list() {
+    local rows="$1"
+    local handle="$2"
+    jq -r --arg handle "$handle" '
+        if type != "array" then empty
+        else (.[] | select(.handle == $handle) | .path) // empty
+        end
+    ' <<<"$rows"
+}
+
+require_tool jq
+
+REQUEST_JSON="$(cat)"
+schema="$(jq -r '.schema // empty' <<<"$REQUEST_JSON")"
+if [ -n "$schema" ] && [ "$schema" != "$REQUEST_SCHEMA" ]; then
+    echo "Expected request schema $REQUEST_SCHEMA, got $schema" >&2
+    exit 64
+fi
+
+to_workspace="$(jq -r '.to_workspace // empty' <<<"$REQUEST_JSON")"
+patch_path="$(jq -r '.patch_path // empty' <<<"$REQUEST_JSON")"
+if [ -z "$to_workspace" ]; then
+    echo "Request must include to_workspace" >&2
+    exit 64
+fi
+if [ -z "$patch_path" ]; then
+    echo "Request must include patch_path" >&2
+    exit 64
+fi
+if [ ! -f "$patch_path" ]; then
+    echo "Patch path does not exist: $patch_path" >&2
+    exit 66
+fi
+if [[ "$to_workspace" != *@* ]]; then
+    echo "Data Machine Code promotion provider expects to_workspace as <repo>@<branch-slug>" >&2
+    exit 64
+fi
+
+repo="${to_workspace%@*}"
+branch="${to_workspace#*@}"
+if [ -z "$repo" ] || [ -z "$branch" ]; then
+    echo "Data Machine Code promotion provider expects non-empty repo and branch in to_workspace" >&2
+    exit 64
+fi
+
+EVIDENCE_FILE="$(mktemp)"
+trap 'rm -f "$EVIDENCE_FILE"' EXIT
+printf '[]\n' >"$EVIDENCE_FILE"
+
+list_output="$(run_dmc_command "$EVIDENCE_FILE" no studio wp datamachine-code workspace worktree list "$repo" --format=json)"
+workspace_path="$(worktree_path_from_list "$list_output" "$to_workspace")"
+
+if [ -z "$workspace_path" ]; then
+    run_dmc_command "$EVIDENCE_FILE" yes studio wp datamachine-code workspace worktree add "$repo" "$branch" >/dev/null
+    list_output="$(run_dmc_command "$EVIDENCE_FILE" no studio wp datamachine-code workspace worktree list "$repo" --format=json)"
+    workspace_path="$(worktree_path_from_list "$list_output" "$to_workspace")"
+fi
+
+if [ -z "$workspace_path" ]; then
+    echo "Managed workspace $to_workspace was not found after creation" >&2
+    exit 1
+fi
+
+run_dmc_command "$EVIDENCE_FILE" yes studio wp datamachine-code workspace patch apply "$to_workspace" "--patch=@${patch_path}" --format=json >/dev/null
+
+jq -n \
+    --arg schema "$RESPONSE_SCHEMA" \
+    --arg workspace_path "$workspace_path" \
+    --slurpfile command_evidence "$EVIDENCE_FILE" \
+    '{schema:$schema,workspace_path:$workspace_path,command_evidence:$command_evidence[0]}'

--- a/tests/datamachine-code-promotion-provider-smoke.sh
+++ b/tests/datamachine-code-promotion-provider-smoke.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROVIDER="${ROOT_DIR}/scripts/datamachine-code-promotion-provider.sh"
+
+if [ ! -f "$PROVIDER" ]; then
+    echo "Missing provider script: $PROVIDER" >&2
+    exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required for this smoke test" >&2
+    exit 127
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PATCH_FILE="${TMP_DIR}/changes.patch"
+FAKE_BIN="${TMP_DIR}/bin"
+STATE_DIR="${TMP_DIR}/state"
+LOG_FILE="${TMP_DIR}/studio.log"
+mkdir -p "$FAKE_BIN" "$STATE_DIR"
+
+cat >"$PATCH_FILE" <<'PATCH'
+diff --git a/src/lib.rs b/src/lib.rs
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1 +1 @@
+-old
++new
+PATCH
+
+cat >"${FAKE_BIN}/studio" <<'STUDIO'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${STUDIO_LOG:?}"
+
+if [ "$1" != "wp" ] || [ "$2" != "datamachine-code" ] || [ "$3" != "workspace" ]; then
+    echo "unexpected command prefix: $*" >&2
+    exit 2
+fi
+
+case "$4 $5" in
+    "worktree list")
+        repo="$6"
+        if [ -f "${STUDIO_STATE:?}/${repo}.added" ]; then
+            jq -n --arg handle "${repo}@fix-3690" --arg path "/tmp/${repo}@fix-3690" '[{handle:$handle,path:$path}]'
+        else
+            printf '[]\n'
+        fi
+        ;;
+    "worktree add")
+        repo="$6"
+        branch="$7"
+        if [ "$repo" != "homeboy" ] || [ "$branch" != "fix-3690" ]; then
+            echo "unexpected add target: $repo $branch" >&2
+            exit 3
+        fi
+        touch "${STUDIO_STATE:?}/${repo}.added"
+        printf '{"created":true}\n'
+        ;;
+    "patch apply")
+        handle="$6"
+        patch_arg="$7"
+        format_arg="$8"
+        if [ "$handle" != "homeboy@fix-3690" ]; then
+            echo "unexpected patch handle: $handle" >&2
+            exit 4
+        fi
+        case "$patch_arg" in
+            --patch=@*) ;;
+            *) echo "unexpected patch arg: $patch_arg" >&2; exit 5 ;;
+        esac
+        if [ "$format_arg" != "--format=json" ]; then
+            echo "unexpected format arg: $format_arg" >&2
+            exit 6
+        fi
+        printf '{"applied":true}\n'
+        ;;
+    *)
+        echo "unexpected workspace operation: $4 $5" >&2
+        exit 7
+        ;;
+esac
+STUDIO
+chmod +x "${FAKE_BIN}/studio"
+
+REQUEST="$(jq -n \
+    --arg patch_path "$PATCH_FILE" \
+    '{
+        schema:"homeboy/agent-task-promotion-apply-request/v1",
+        to_workspace:"homeboy@fix-3690",
+        patch_path:$patch_path,
+        changed_files:["src/lib.rs"]
+    }')"
+
+RESPONSE="$(PATH="${FAKE_BIN}:$PATH" STUDIO_LOG="$LOG_FILE" STUDIO_STATE="$STATE_DIR" "$PROVIDER" <<<"$REQUEST")"
+
+if ! jq -e '.schema == "homeboy/agent-task-promotion-apply-response/v1"' <<<"$RESPONSE" >/dev/null; then
+    echo "Unexpected response schema: $RESPONSE" >&2
+    exit 1
+fi
+if ! jq -e '.workspace_path == "/tmp/homeboy@fix-3690"' <<<"$RESPONSE" >/dev/null; then
+    echo "Unexpected workspace path: $RESPONSE" >&2
+    exit 1
+fi
+if ! jq -e '.command_evidence | length == 2' <<<"$RESPONSE" >/dev/null; then
+    echo "Expected add and apply command evidence: $RESPONSE" >&2
+    exit 1
+fi
+if ! grep -Fq 'wp datamachine-code workspace worktree list homeboy --format=json' "$LOG_FILE"; then
+    echo "Expected worktree list command in log" >&2
+    exit 1
+fi
+if ! grep -Fq 'wp datamachine-code workspace worktree add homeboy fix-3690' "$LOG_FILE"; then
+    echo "Expected worktree add command in log" >&2
+    exit 1
+fi
+if ! grep -Fq 'wp datamachine-code workspace patch apply homeboy@fix-3690' "$LOG_FILE"; then
+    echo "Expected patch apply command in log" >&2
+    exit 1
+fi
+
+printf 'ok\n'


### PR DESCRIPTION
## Summary
- Adds `scripts/datamachine-code-promotion-provider.sh`, an external provider command for Homeboy agent-task promotion.
- The provider reads Homeboy's generic promotion apply request JSON on stdin and returns the generic promotion apply response JSON on stdout.
- Keeps DMC-specific `studio wp datamachine-code ...` command construction in Homeboy Extensions instead of Homeboy core.
- Adds a smoke test with a fake `studio` binary covering worktree list/add and patch apply command behavior.

Companion to Extra-Chill/homeboy#3691 and Extra-Chill/homeboy#3690.

## Tests
- `tests/datamachine-code-promotion-provider-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the provider script, smoke test, and README docs for Chris to review.