### PR TITLE
fix: use WP Codebox recipe input keys

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -89,11 +89,11 @@ for (const expected of ['wp-codebox.agent-sandbox-run', 'HOMEBOY_DATAMACHINE_AGE
     throw new Error(`missing expected wp-codebox recipe value: ${expected}`)
   }
 }
-if (recipe.inputs?.extraPlugins?.some((plugin) => plugin.slug === 'php-ai-client')) {
+if (recipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === 'php-ai-client')) {
   throw new Error('WP AI Client is provided by WordPress core and must not be mounted as a WP Codebox extra plugin')
 }
 for (const slug of ['agents-api', 'data-machine', 'data-machine-code']) {
-  if (!recipe.inputs?.extraPlugins?.some((plugin) => plugin.slug === slug && plugin.activate === true)) {
+  if (!recipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === slug && plugin.activate === true)) {
     throw new Error(`expected ${slug} to be activated before the agent workload runs`)
   }
 }

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -217,7 +217,7 @@ PHP
         '{
             schema: "wp-codebox/workspace-recipe/v1",
             runtime: ({blueprint: {steps: []}} + (if $wp == "" then {} else {wp: $wp} end)),
-            inputs: {extraPlugins: $extraPlugins, mounts: $mounts, secretEnv: $secretEnv},
+            inputs: {extra_plugins: $extraPlugins, mounts: $mounts, secret_env: $secretEnv},
             workflow: {steps: [{command: "wp-codebox.agent-sandbox-run", args: ["task=" + $task, "code-file=" + $codeFile, "provider-plugin-slugs=" + $providerSlugs]}]}
         }' >"$recipe_file"
 


### PR DESCRIPTION
## Summary
- Emit WP Codebox agent recipes with `inputs.extra_plugins` and `inputs.secret_env` instead of the rejected legacy camelCase keys.
- Update the agent runner smoke to assert the supported recipe shape.

## Tests
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WP Codebox recipe validation failure from WPSG iterator runs, drafted the compatibility fix, and ran targeted smoke coverage; Chris remains responsible for review and merge.