### PR TITLE
fix: keep WP Codebox secretEnv recipe key

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -97,6 +97,12 @@ for (const slug of ['agents-api', 'data-machine', 'data-machine-code']) {
     throw new Error(`expected ${slug} to be activated before the agent workload runs`)
   }
 }
+if (!recipe.inputs?.secretEnv?.includes('HOMEBOY_DATAMACHINE_AGENT_CONFIG')) {
+  throw new Error('expected HOMEBOY_DATAMACHINE_AGENT_CONFIG to be exposed through recipe inputs.secretEnv')
+}
+if (recipe.inputs?.secret_env) {
+  throw new Error('WP Codebox recipes require camelCase inputs.secretEnv for secret names')
+}
 if (!recipe.inputs?.mounts?.some((mount) => mount.source.endsWith('/bundle') && mount.target === '/wordpress/wp-content/plugins/bundle' && mount.mode === 'readonly')) {
   throw new Error('missing bundle readonly mount in recipe')
 }

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -217,7 +217,7 @@ PHP
         '{
             schema: "wp-codebox/workspace-recipe/v1",
             runtime: ({blueprint: {steps: []}} + (if $wp == "" then {} else {wp: $wp} end)),
-            inputs: {extra_plugins: $extraPlugins, mounts: $mounts, secret_env: $secretEnv},
+            inputs: {extra_plugins: $extraPlugins, mounts: $mounts, secretEnv: $secretEnv},
             workflow: {steps: [{command: "wp-codebox.agent-sandbox-run", args: ["task=" + $task, "code-file=" + $codeFile, "provider-plugin-slugs=" + $providerSlugs]}]}
         }' >"$recipe_file"
 


### PR DESCRIPTION
## Summary
- Keep WP Codebox agent recipes on `inputs.secretEnv` while using the supported `inputs.extra_plugins` plugin mount key.
- Add smoke assertions that the agent config secret is exposed through `secretEnv` and the unsupported `secret_env` key is not emitted.

## Tests
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the missing `HOMEBOY_DATAMACHINE_AGENT_CONFIG` runtime secret after iterator reruns, checked WP Codebox schema, drafted the precise recipe-key fix, and ran targeted smoke coverage; Chris remains responsible for review and merge.