### PR TITLE
fix: expose writable workspace tools for read-write Codebox agent tasks

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -28,10 +28,21 @@ const PROVIDER_CAPABILITIES = [
   'recipe_probe_artifacts',
 ];
 
-const DEFAULT_WORKSPACE_ALLOWED_TOOLS = [
+const DEFAULT_WORKSPACE_READONLY_TOOLS = [
   'workspace_ls',
   'workspace_read',
   'workspace_git_status',
+];
+
+// Additional workspace tools exposed when the repo workspace is mounted
+// read-write, so a coding task can actually edit files instead of only
+// inspecting them. These ids are registered by the data-machine-code runtime.
+const DEFAULT_WORKSPACE_WRITE_TOOLS = [
+  'workspace_write',
+  'workspace_edit',
+  'workspace_apply_patch',
+  'workspace_delete',
+  'workspace_git_add',
 ];
 
 const CODEX_SECRET_ENV = [
@@ -292,8 +303,8 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     runtimeOverlayProfiles: defaultRuntimeOverlayProfiles(provider),
     mounts: defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options),
     workspaces: defaultWorkspaces(config, inputs, options),
-    allowedTools: defaultWorkspaceAllowedTools(workspaceRoot),
-    sandboxToolPolicy: defaultWorkspaceSandboxToolPolicy(workspaceRoot),
+    allowedTools: defaultWorkspaceAllowedTools(workspaceRoot, workspaceMode(request, config, inputs)),
+    sandboxToolPolicy: defaultWorkspaceSandboxToolPolicy(workspaceRoot, workspaceMode(request, config, inputs)),
   };
 }
 
@@ -427,18 +438,28 @@ function readJsonFile(filePath) {
   }
 }
 
-function defaultWorkspaceAllowedTools(workspaceRoot) {
-  return workspaceRoot ? DEFAULT_WORKSPACE_ALLOWED_TOOLS : [];
+function defaultWorkspaceToolIds(workspaceRoot, workspaceModeValue) {
+  if (!workspaceRoot) {
+    return [];
+  }
+  if (workspaceModeValue === 'readwrite') {
+    return [...DEFAULT_WORKSPACE_READONLY_TOOLS, ...DEFAULT_WORKSPACE_WRITE_TOOLS];
+  }
+  return [...DEFAULT_WORKSPACE_READONLY_TOOLS];
 }
 
-function defaultWorkspaceSandboxToolPolicy(workspaceRoot) {
+function defaultWorkspaceAllowedTools(workspaceRoot, workspaceModeValue) {
+  return defaultWorkspaceToolIds(workspaceRoot, workspaceModeValue);
+}
+
+function defaultWorkspaceSandboxToolPolicy(workspaceRoot, workspaceModeValue) {
   if (!workspaceRoot) {
     return undefined;
   }
   return {
     schema: 'wp-codebox/sandbox-tool-policy/v1',
     version: 1,
-    tools: DEFAULT_WORKSPACE_ALLOWED_TOOLS.map((tool) => ({
+    tools: defaultWorkspaceToolIds(workspaceRoot, workspaceModeValue).map((tool) => ({
       id: tool,
       runtime_tool_id: tool,
       execution_location: 'sandbox',

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -464,15 +464,50 @@ try {
   assert.equal(bareOpenAiDefaultedRequest.provider, 'openai');
   assert.equal(bareOpenAiDefaultedRequest.model, '');
   assert.deepEqual(bareOpenAiDefaultedRequest.secret_env, ['OPENAI_API_KEY']);
-  assert.deepEqual(bareOpenAiDefaultedRequest.allowed_tools, ['workspace_ls', 'workspace_read', 'workspace_git_status']);
+  // A bare repo workspace defaults to a read-write mount, so coding-capable
+  // workspace tools must be exposed alongside the read-only inspection tools.
+  const writableWorkspaceTools = [
+    'workspace_ls',
+    'workspace_read',
+    'workspace_git_status',
+    'workspace_write',
+    'workspace_edit',
+    'workspace_apply_patch',
+    'workspace_delete',
+    'workspace_git_add',
+  ];
+  assert.deepEqual(bareOpenAiDefaultedRequest.allowed_tools, writableWorkspaceTools);
   assert.equal(bareOpenAiDefaultedRequest.sandbox_tool_policy.schema, 'wp-codebox/sandbox-tool-policy/v1');
   assert.deepEqual(
     bareOpenAiDefaultedRequest.sandbox_tool_policy.tools.map((tool) => tool.runtime_tool_id),
-    ['workspace_ls', 'workspace_read', 'workspace_git_status'],
+    writableWorkspaceTools,
   );
   assert.deepEqual(
     bareOpenAiDefaultedRequest.sandbox_tool_policy.tools.map((tool) => tool.runtime.environment),
-    ['runtime_local', 'runtime_local', 'runtime_local'],
+    writableWorkspaceTools.map(() => 'runtime_local'),
+  );
+
+  // A read-only repo workspace must remain restricted to inspection tools.
+  const readonlyWorkspaceRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'readonly-workspace-task-123',
+    executor: {
+      backend: 'codebox',
+      config: {},
+    },
+    inputs: {
+      target: { root: workspaceRoot, mode: 'readonly' },
+    },
+  }, {
+    settings: { wp_codebox_codex_enabled: false },
+  });
+  assert.deepEqual(
+    readonlyWorkspaceRequest.allowed_tools,
+    ['workspace_ls', 'workspace_read', 'workspace_git_status'],
+  );
+  assert.deepEqual(
+    readonlyWorkspaceRequest.sandbox_tool_policy.tools.map((tool) => tool.runtime_tool_id),
+    ['workspace_ls', 'workspace_read', 'workspace_git_status'],
   );
 
   const settingsModelRequest = codeboxTaskRequestFromAgentTaskRequest({


### PR DESCRIPTION
## Summary

Codebox `agent-task` runs could not make code changes because the default sandbox tool policy only granted **read-only** workspace tools, even when the repo workspace was mounted read-write. The data-machine-code runtime already registers write-capable workspace tools, but they were never added to `allowed_tools` / `sandbox_tool_policy`.

This gates the default workspace tool set on the resolved workspace mode:
- **read-write** mount → inspection tools **+** `workspace_write`, `workspace_edit`, `workspace_apply_patch`, `workspace_delete`, `workspace_git_add`
- **read-only** mount → inspection tools only (`workspace_ls`, `workspace_read`, `workspace_git_status`)

Fixes #1189.

## Root cause

`wordpress/lib/codebox-agent-task-executor.js` hardcoded a single read-only tool list (`DEFAULT_WORKSPACE_ALLOWED_TOOLS`) and applied it regardless of mount mode via `defaultWorkspaceAllowedTools()` and `defaultWorkspaceSandboxToolPolicy()`.

## Reproduction (before)

A Codebox agent-task with a `readwrite` repo-workspace mount and a write task returned `succeeded` but produced `0` changed files and a `0`-byte patch. The model's transcript explained it had no write tool available — only the three read-only inspection tools were in the contract.

Discovered while validating the `ai-provider-for-claude-code` carried provider (Extra-Chill/wp-coding-agents#197). The provider, OAuth, and model execution (Claude Opus 4.8) all worked; this tool-policy gap was the only blocker to real coding tasks.

## Changes

- Split the default tool list into `DEFAULT_WORKSPACE_READONLY_TOOLS` and `DEFAULT_WORKSPACE_WRITE_TOOLS`.
- Thread the resolved `workspaceMode(...)` into both the allowed-tools and sandbox-tool-policy builders.
- Extended `codebox-agent-task-executor-smoke.js`:
  - The bare (default read-write) request now asserts the full writable tool set in both `allowed_tools` and `sandbox_tool_policy`.
  - Added a read-only workspace case asserting tools stay restricted to the inspection triplet.

## Testing

- `node wordpress/tests/codebox-agent-task-executor-smoke.js` → `Codebox agent task executor smoke passed`
- Followed by an end-to-end Codebox coding-task canary (results posted on wp-coding-agents#197).

## Note on a pre-existing, unrelated failure

`wordpress/tests/codebox-agent-task-boundary-smoke.js` currently fails on `origin/main` because the executor already references `settings.data_machine_path` / `settings.data_machine_code_path` (added before this branch). This PR adds **no** forbidden tokens and does not touch those lines; the boundary failure is out of scope here and should be tracked separately.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Root-caused the read-only tool policy, implemented the mode-gated writable tool set, added smoke coverage, and ran the end-to-end canary; Chris directed the work and remains responsible for review/testing.