### PR TITLE
fix: load agent runtime components as mu-plugins

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -93,8 +93,8 @@ if (recipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === 'php-ai-clien
   throw new Error('WP AI Client is provided by WordPress core and must not be mounted as a WP Codebox extra plugin')
 }
 for (const slug of ['agents-api', 'data-machine', 'data-machine-code']) {
-  if (!recipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === slug && plugin.activate === true)) {
-    throw new Error(`expected ${slug} to be activated before the agent workload runs`)
+  if (!recipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === slug && plugin.activate === false && plugin.loadAs === 'mu-plugin')) {
+    throw new Error(`expected ${slug} to load as a runtime mu-plugin before the agent workload runs`)
   }
 }
 if (!recipe.inputs?.secretEnv?.includes('HOMEBOY_DATAMACHINE_AGENT_CONFIG')) {

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -162,9 +162,9 @@ PHP
         --arg datamachine "$data_machine_path" \
         --arg code "$data_machine_code_path" \
         '[
-            {source: $agents, slug: "agents-api", activate: true},
-            {source: $datamachine, slug: "data-machine", activate: true},
-            {source: $code, slug: "data-machine-code", activate: true}
+            {source: $agents, slug: "agents-api", activate: false, loadAs: "mu-plugin"},
+            {source: $datamachine, slug: "data-machine", activate: false, loadAs: "mu-plugin"},
+            {source: $code, slug: "data-machine-code", activate: false, loadAs: "mu-plugin"}
         ]')
     mounts_json=$(jq -nc --arg source "$EXTENSION_PATH" '[{type: "directory", source: $source, target: "/homeboy-extension", mode: "readonly"}]')
     provider_slugs_csv=""


### PR DESCRIPTION
## Summary
- Load Agents API, Data Machine, and Data Machine Code as WP Codebox runtime mu-plugins in the direct Data Machine agent recipe.
- Update the WP Codebox runner smoke to assert runtime components use `loadAs: "mu-plugin"` with activation disabled.

## Why
The direct Homeboy recipe path should match WP Codebox's maintained runner contract for runtime components. Loading these components as normal activated plugins can allow stale/runtime plugin ordering to win before agent bundle extension hooks are available.

## Testing
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WP Codebox/Homeboy recipe mismatch, drafted the small shell/smoke update, and ran targeted verification. Chris remains responsible for review and merge.