### PR TITLE
fix: count recorded PR tool URLs

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -800,7 +800,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_pr_opened' ) ) {
                 continue;
             }
 
-            $url = (string) ( $tool_result['url'] ?? '' );
+            $url = homeboy_datamachine_agent_first_url( $tool_result );
             if ( str_contains( $url, '/pull/' ) ) {
                 return true;
             }

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -209,7 +209,10 @@ namespace {
             'success'   => true,
             'repo'      => 'owner/repo',
             'head'      => 'agent/recorded-branch',
-            'url'       => 'https://github.com/owner/repo/pull/789',
+            'result'    => array(
+                'success'  => true,
+                'html_url' => 'https://github.com/owner/repo/pull/789',
+            ),
         ),
     ) );
     $merged_recorded_results = homeboy_datamachine_agent_merge_recorded_tool_results( array(), $config );


### PR DESCRIPTION
## Summary
- Count pull request URLs nested inside recorded tool results when computing pr_opened
- Preserve existing direct URL support via the shared recursive GitHub URL extractor
- Add smoke coverage for recorded create_github_pull_request results shaped like tool-recorder output

## Verification
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WPSG strict proof metric mismatch, implemented the PR URL detection fix, and ran targeted smoke checks; Chris remains responsible for review and merge.
