### PR TITLE
fix: count successful PR creation tools

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -795,14 +795,17 @@ if ( ! function_exists( 'homeboy_datamachine_agent_pr_opened' ) ) {
             homeboy_datamachine_agent_runner_publications( $engine_data, $config )
         );
 
-        foreach ( $tool_results as $tool_result ) {
-            if ( ! is_array( $tool_result ) || empty( $tool_result['success'] ) ) {
-                continue;
-            }
+		foreach ( $tool_results as $tool_result ) {
+			if ( ! is_array( $tool_result ) || empty( $tool_result['success'] ) ) {
+				continue;
+			}
+			if ( 'create_github_pull_request' === (string) ( $tool_result['tool_name'] ?? '' ) ) {
+				return true;
+			}
 
-            $url = homeboy_datamachine_agent_first_url( $tool_result );
-            if ( str_contains( $url, '/pull/' ) ) {
-                return true;
+			$url = homeboy_datamachine_agent_first_url( $tool_result );
+			if ( str_contains( $url, '/pull/' ) ) {
+				return true;
             }
         }
 

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -170,6 +170,21 @@ namespace {
         exit( 1 );
     }
 
+    $pr_tool_opened = array(
+        'github_tool_results' => array(
+            array(
+                'tool_name' => 'create_github_pull_request',
+                'success'   => true,
+                'head'      => 'agent/no-url-branch',
+            ),
+        ),
+    );
+
+    if ( ! homeboy_datamachine_agent_pr_opened( $pr_tool_opened, $config ) ) {
+        fwrite( STDERR, "Expected successful pull-request tool result to count as pr_opened without a URL.\n" );
+        exit( 1 );
+    }
+
     if ( 'agent/change-branch' !== homeboy_datamachine_agent_pr_head_branch( $pr_opened, $config ) ) {
         fwrite( STDERR, "Expected pull-request tool result to expose the PR head branch.\n" );
         exit( 1 );


### PR DESCRIPTION
## Summary
- Count successful create_github_pull_request tool executions as pr_opened evidence even when the recorder omits a URL
- Keep recursive URL detection for fallback and artifact publication results
- Add smoke coverage for successful PR tool output without a URL

## Verification
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining WPSG metric mismatch after PR #1193, implemented the tool-name evidence fix, and ran targeted smoke checks; Chris remains responsible for review and merge.
