### PR TITLE
fix: count PR execution summaries

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -806,11 +806,25 @@ if ( ! function_exists( 'homeboy_datamachine_agent_pr_opened' ) ) {
 			$url = homeboy_datamachine_agent_first_url( $tool_result );
 			if ( str_contains( $url, '/pull/' ) ) {
 				return true;
-            }
-        }
+			}
+		}
 
-        return false;
-    }
+		$sources    = array( $engine_data );
+		$engine_key = homeboy_datamachine_agent_scalar( $config, 'engine_key' );
+		if ( '' !== $engine_key && is_array( $engine_data[ $engine_key ] ?? null ) ) {
+			$sources[] = $engine_data[ $engine_key ];
+		}
+		foreach ( $sources as $source ) {
+			$summaries = is_array( $source['tool_execution_summary'] ?? null ) ? $source['tool_execution_summary'] : array();
+			foreach ( $summaries as $summary ) {
+				if ( is_array( $summary ) && ! empty( $summary['success'] ) && 'create_github_pull_request' === (string) ( $summary['tool_name'] ?? '' ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
 }
 
 if ( ! function_exists( 'homeboy_datamachine_agent_file_written' ) ) {

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -185,6 +185,21 @@ namespace {
         exit( 1 );
     }
 
+    $pr_summary_opened = array(
+        'tool_execution_summary' => array(
+            array(
+                'tool_name' => 'create_github_pull_request',
+                'success'   => true,
+                'summary'   => 'Pull request #789 opened in owner/repo.',
+            ),
+        ),
+    );
+
+    if ( ! homeboy_datamachine_agent_pr_opened( $pr_summary_opened, $config ) ) {
+        fwrite( STDERR, "Expected successful pull-request execution summary to count as pr_opened.\n" );
+        exit( 1 );
+    }
+
     if ( 'agent/change-branch' !== homeboy_datamachine_agent_pr_head_branch( $pr_opened, $config ) ) {
         fwrite( STDERR, "Expected pull-request tool result to expose the PR head branch.\n" );
         exit( 1 );


### PR DESCRIPTION
## Summary
- Count successful create_github_pull_request entries in tool_execution_summary as pr_opened evidence
- Keep URL-based and tool-result-based PR detection intact
- Add smoke coverage for the WPSG iterator artifact shape where the PR appears in the execution summary stream

## Verification
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected the WPSG iterator run artifact, identified the metric source stream, implemented the summary-based PR detection, and ran targeted smoke checks; Chris remains responsible for review and merge.
