### PR TITLE
fix: mount agent task runtime plugins

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -224,6 +224,35 @@ function runnerInput(request, artifacts) {
   }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
 }
 
+function runtimeComponentExtraPlugins(input) {
+  const components = {
+    agents_api: input.agents_api_path,
+    ...(input.runtime_component_paths || {}),
+  };
+  return [
+    { key: 'agents_api', slug: 'agents-api' },
+    { key: 'agent_runtime', slug: 'data-machine' },
+    { key: 'agent_runtime_tools', slug: 'data-machine-code' },
+  ].flatMap(({ key, slug }) => {
+    const source = components[key];
+    return source ? [{ source, slug, loadAs: 'mu-plugin', activate: false }] : [];
+  });
+}
+
+function extraPlugins(input) {
+  const explicit = input.parent_request?.extra_plugins || input.parent_request?.extraPlugins || [];
+  const plugins = [...runtimeComponentExtraPlugins(input), ...(Array.isArray(explicit) ? explicit : [])];
+  const seen = new Set();
+  return plugins.filter((plugin) => {
+    const key = `${plugin.slug || ''}:${plugin.source || ''}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
 function stableTaskInput(input) {
   const allowedTools = input.parent_request?.allowed_tools || input.parent_request?.task?.allowed_tools || [];
   const secretEnv = input.secret_env || [];
@@ -241,6 +270,7 @@ function stableTaskInput(input) {
     provider: input.provider,
     model: input.model,
     provider_plugin_paths: input.provider_plugin_paths || [],
+    extra_plugins: extraPlugins(input),
     runtime_overlay_profiles: input.runtime_overlay_profiles || [],
     secret_env: secretEnv,
     mounts: input.mounts || [],

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -185,6 +185,11 @@ try {
   assert.equal(captured.input.data_machine_code_path, '/components/data-machine-code');
   assert.equal(captured.input.runtime_component_paths.agent_runtime, '/components/data-machine');
   assert.equal(captured.input.runtime_component_paths.agent_runtime_tools, '/components/data-machine-code');
+  assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'agents-api').source, '/components/agents-api');
+  assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'data-machine').source, '/components/data-machine');
+  assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'data-machine-code').source, '/components/data-machine-code');
+  assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'data-machine').loadAs, 'mu-plugin');
+  assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'data-machine-code').activate, false);
   assert(!JSON.stringify(captured.input).includes('redacted-test-key'));
 
   const runtimeTaskCapturePath = path.join(root, 'capture-runtime-task.json');


### PR DESCRIPTION
## Summary
- Synthesize `extra_plugins` for Agents API, Data Machine, and Data Machine Code from resolved runtime component paths
- Load those runtime components as mu-plugins for WP Codebox agent-task runs
- Add smoke coverage proving task-runner input includes the runtime plugin mounts

Fixes #1197.

## Verification
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed failed Homeboy minion dispatch artifacts, implemented runtime plugin mount synthesis, and ran focused smoke checks; Chris remains responsible for review and merge.
