### PR TITLE
fix: emit component_contracts for WP Codebox 0.8.0 runtime components

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -239,6 +239,19 @@ function runtimeComponentExtraPlugins(input) {
   });
 }
 
+function componentContracts(input) {
+  // Translate the runtime component paths (agents-api, data-machine,
+  // data-machine-code) into the WP Codebox 0.8.0 `component_contracts` shape:
+  // `{ slug, path, loadAs, activate }`. WP Codebox mounts these as mu-plugins so
+  // Data Machine loads its own vendored Agents API and registers agents/chat.
+  return runtimeComponentExtraPlugins(input).map((plugin) => ({
+    slug: plugin.slug,
+    path: plugin.source,
+    loadAs: plugin.loadAs || 'mu-plugin',
+    activate: Boolean(plugin.activate),
+  }));
+}
+
 function extraPlugins(input) {
   const explicit = input.parent_request?.extra_plugins || input.parent_request?.extraPlugins || [];
   const plugins = [...runtimeComponentExtraPlugins(input), ...(Array.isArray(explicit) ? explicit : [])];
@@ -271,6 +284,11 @@ function stableTaskInput(input) {
     model: input.model,
     provider_plugin_paths: input.provider_plugin_paths || [],
     extra_plugins: extraPlugins(input),
+    // WP Codebox 0.8.0 reads runtime component plugins (agents-api, data-machine,
+    // data-machine-code) from `component_contracts`, not the legacy
+    // `runtime_component_paths` / `data_machine_path` fields. Without this the
+    // components never mount and agents/chat is unavailable in the sandbox.
+    component_contracts: componentContracts(input),
     runtime_overlay_profiles: input.runtime_overlay_profiles || [],
     secret_env: secretEnv,
     mounts: input.mounts || [],

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -190,6 +190,13 @@ try {
   assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'data-machine-code').source, '/components/data-machine-code');
   assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'data-machine').loadAs, 'mu-plugin');
   assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'data-machine-code').activate, false);
+  // WP Codebox 0.8.0 mounts runtime components from `component_contracts`
+  // ({ slug, path }), not the legacy `runtime_component_paths` fields.
+  assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'agents-api').path, '/components/agents-api');
+  assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'data-machine').path, '/components/data-machine');
+  assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'data-machine-code').path, '/components/data-machine-code');
+  assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'data-machine').loadAs, 'mu-plugin');
+  assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'data-machine-code').activate, false);
   assert(!JSON.stringify(captured.input).includes('redacted-test-key'));
 
   const runtimeTaskCapturePath = path.join(root, 'capture-runtime-task.json');


### PR DESCRIPTION
## Summary

WP Codebox 0.8.0 changed `buildAgentTaskRecipe` to read runtime component plugins (agents-api, data-machine, data-machine-code) from **`input.component_contracts`**, and no longer from the legacy `runtime_component_paths` / `data_machine_path` / `agents_api_path` fields. The Homeboy Extensions task runner still emitted only the legacy fields, so:

- `component_contracts` was empty
- `componentPlugins([])` returned `[]`
- the runtime components **never mounted** in the sandbox
- `agents/chat` was unavailable → coding agents failed before any tool resolution

This was the true end-to-end blocker for WP Codebox coding agents.

## Root cause (verified)

wp-codebox 0.8.0 `agent-task-run.ts`:
```ts
extraPlugins: [
  ...componentPlugins(input.component_contracts, artifacts),
  ...providerPlugins,
]
```
`componentPlugins` reads `{ slug|component|name, path|source, activate, loadAs }`. The runner emitted none of these for the runtime components.

Deterministic confirmation: running wp-codebox 0.8.0's `prepareRecipeExtraPlugins` against the legacy input shape returned only the provider plugin; the live `runtime.log` showed only the provider plugin mounted, and the sandbox reported `agents_api_loaded: false`.

## Fix

Emit `component_contracts` ({ slug, path, loadAs, activate }) derived from the resolved runtime component paths, alongside the retained legacy fields for backward compatibility.

## Verification

- `node wordpress/tests/wp-codebox-task-runner-smoke.js` — passes, with new `component_contracts` assertions
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh` — passes
- `node wordpress/tests/codebox-agent-task-executor-smoke.js` — passes
- **End-to-end:** with this fix, all components mount as `wp-codebox-runtime` mu-plugins, `agents/chat` is available, the agent emits a structured `workspace_write` tool call, and the tool executes successfully (`{"success":true,"path":"CC_CONTRACTS.md","created":true}`).

## Related

- Closes the real cause behind Automattic/wp-codebox#831 (which I closed — the original "double-load" analysis was wrong; no wp-codebox change needed)
- Completes the WP Codebox Claude Code coding-agent path alongside: wp-coding-agents#197 (provider), homeboy-extensions#1190 (writable tools), data-machine-code#606 (project write tools), data-machine#2601 (resolver regression test)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Deterministically traced the component-mount drop to the wp-codebox 0.8.0 contract change, implemented the `component_contracts` emission, added smoke coverage, and verified end to end; Chris directs the work and remains responsible for review/testing.