### PR TITLE
Fix agent task runtime component fallback

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -81,6 +81,26 @@ function mountEntries(request) {
   ];
 }
 
+function firstExistingPath(...candidates) {
+  return candidates.find((candidate) => candidate && fs.existsSync(candidate)) || '';
+}
+
+function siblingPath(workspaceRoot, sibling) {
+  return workspaceRoot ? path.join(path.dirname(workspaceRoot), sibling) : '';
+}
+
+function workspaceRootFromMounts(mounts) {
+  const mountedWorkspace = mounts.find((mount) => mount?.metadata?.kind === 'homeboy-dmc-workspace') || mounts[0];
+  return mountedWorkspace?.source || '';
+}
+
+function bundledAgentsApiPath(dataMachinePath) {
+  return firstExistingPath(
+    path.join(dataMachinePath || '', 'vendor', 'wordpress', 'agents-api'),
+    path.join(dataMachinePath || '', 'vendor', 'automattic', 'agents-api'),
+  );
+}
+
 function runtimeStackMountEntries(request) {
   return [
     ...(request.runtime_stack_mounts || []),
@@ -181,20 +201,23 @@ function requestAgentBundle(request) {
   return {};
 }
 
-function requestRuntimeComponents(request) {
+function requestRuntimeComponents(request, mounts = []) {
   const explicit = request.runtime_component_paths && typeof request.runtime_component_paths === 'object'
     ? request.runtime_component_paths
     : {};
+  const workspaceRoot = workspaceRootFromMounts(mounts);
+  const dataMachinePath = explicit.agent_runtime || legacyValue(request) || firstExistingPath(siblingPath(workspaceRoot, 'data-machine'));
   return Object.fromEntries(Object.entries({
     ...explicit,
-    agents_api: explicit.agents_api || request.agents_api_path || request.agents_api,
-    agent_runtime: explicit.agent_runtime || legacyValue(request),
-    agent_runtime_tools: explicit.agent_runtime_tools || legacyValue(request, 'code'),
+    agents_api: explicit.agents_api || request.agents_api_path || request.agents_api || bundledAgentsApiPath(dataMachinePath),
+    agent_runtime: dataMachinePath,
+    agent_runtime_tools: explicit.agent_runtime_tools || legacyValue(request, 'code') || firstExistingPath(siblingPath(workspaceRoot, 'data-machine-code')),
   }).filter(([, value]) => value !== '' && value !== undefined));
 }
 
 function runnerInput(request, artifacts) {
-  const runtimeComponentPaths = requestRuntimeComponents(request);
+  const mounts = mountEntries(request);
+  const runtimeComponentPaths = requestRuntimeComponents(request, mounts);
   return Object.fromEntries(Object.entries({
     parent_request: request,
     agent: argValue('--agent') || request.agent || 'wp-codebox-sandbox',
@@ -204,7 +227,7 @@ function runnerInput(request, artifacts) {
     provider_plugin_paths: [...(request.provider_plugin_paths || []), ...argValues('--provider-plugin-path')],
     runtime_overlay_profiles: request.runtime_overlay_profiles || request.runtimeOverlayProfiles || [],
     secret_env: secretEnvNames(request),
-    mounts: mountEntries(request),
+    mounts,
     runtime_stack_mounts: runtimeStackMountEntries(request),
     runtime_overlays: runtimeOverlayEntries(request),
     max_turns: Number.parseInt(argValue('--max-turns') || request.max_turns || request.maxTurns || 0, 10) || undefined,

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -115,8 +115,13 @@ try {
   const fixtureWpCodebox = createFixtureWpCodebox(root);
   const providerPluginPath = path.join(root, 'example-provider@feature-branch');
   const workspaceRoot = path.join(root, 'wp-coding-agents@proof-homeboy-fanout-a');
+  const defaultDataMachinePath = path.join(root, 'data-machine');
+  const defaultAgentsApiPath = path.join(defaultDataMachinePath, 'vendor', 'wordpress', 'agents-api');
+  const defaultDataMachineCodePath = path.join(root, 'data-machine-code');
   fs.mkdirSync(providerPluginPath, { recursive: true });
   fs.mkdirSync(workspaceRoot, { recursive: true });
+  fs.mkdirSync(defaultAgentsApiPath, { recursive: true });
+  fs.mkdirSync(defaultDataMachineCodePath, { recursive: true });
 
   const request = {
     schema: 'wp-codebox/task-input/v1',
@@ -257,6 +262,24 @@ try {
   assert.equal(codexInput.provider_plugin_paths[0], '/components/ai-provider-for-openai');
   assert(!JSON.stringify(codexInput).includes('access-token-value'));
   assert(!JSON.stringify(codexInput).includes('refresh-token-value'));
+
+  const implicitRuntimeRequest = { ...request };
+  delete implicitRuntimeRequest.runtime_component_paths;
+  const implicitRuntimeCapturePath = path.join(root, 'capture-implicit-runtime-stack.json');
+  const implicitRuntimeResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+    '--mount', `${workspaceRoot}:/workspace/wp-coding-agents:readwrite`,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(implicitRuntimeRequest),
+    env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: implicitRuntimeCapturePath, OPENCODE_API_KEY: 'redacted-test-key' },
+  });
+  assert.equal(implicitRuntimeResult.status, 0, implicitRuntimeResult.stderr || implicitRuntimeResult.stdout);
+  const implicitRuntimeInput = readJson(implicitRuntimeCapturePath).input;
+  assert.equal(implicitRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'agents-api').source, defaultAgentsApiPath);
+  assert.equal(implicitRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'data-machine').source, defaultDataMachinePath);
+  assert.equal(implicitRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'data-machine-code').source, defaultDataMachineCodePath);
 
   const sourceRoot = path.join(root, 'source-plugin');
   fs.mkdirSync(sourceRoot, { recursive: true });


### PR DESCRIPTION
## Summary
- infer missing agent-task runtime component paths from the mounted workspace at the final WP Codebox task-runner boundary
- mount inferred Agents API, Data Machine, and Data Machine Code runtime plugins as extra plugins when explicit runtime_component_paths are absent
- add smoke coverage for the exact local failure shape: provider plugin present, mounted workspace present, runtime components omitted

## Important caveat
This PR is from the local diagnostic path, not a lab-dispatch proof. It should be reviewed as a candidate orchestrator-side fix for missing runtime stack propagation. The underlying lab/offload path still needs authoritative verification.

## Testing
- node wordpress/tests/wp-codebox-task-runner-smoke.js
- node wordpress/tests/codebox-agent-task-executor-smoke.js
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the local diagnostic patch, smoke coverage, and PR description; Chris remains responsible for review and validation.