### PR TITLE
fix: configure WP Codebox core bench module

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -591,6 +591,7 @@ Configure per-component in the component's homeboy/component config under
 | `user` | string | `""` | WP-CLI user (email/login/ID); appended as `--user` when set |
 | `wp_config_defines` | object | `{}` | `CONSTANT_NAME => value` map appended to the runtime `wp-tests-config.php`; PHP type preserved via `var_export` |
 | `bench_env` | object | `{}` | `NAME => value` env vars forwarded into the runtime (workloads/fixtures read via `getenv()`) |
+| `wp_codebox_core_module` | string | `""` | Host-side ESM module path or package specifier that exports WP Codebox recipe builders for bench recipe generation |
 | `wp_codebox_blueprint` | object | `{}` | Runtime blueprint merged into the generated WP Codebox bench recipe |
 | `wp_codebox_workloads` | array | `[]` | Declared bench workloads passed to `wordpress.bench` through the generated recipe after deps and component load |
 | `wp_codebox_file_mounts` | array | `[]` | Files from the component or validation dependencies mounted into explicit WordPress runtime paths |

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -64,6 +64,14 @@ fi
 settings_json="${HOMEBOY_SETTINGS_JSON:-}"
 [ -n "$settings_json" ] || settings_json="{}"
 
+WP_CODEBOX_CORE_MODULE="${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}"
+if [ -z "$WP_CODEBOX_CORE_MODULE" ] && [ "$settings_json" != "{}" ]; then
+    WP_CODEBOX_CORE_MODULE=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_core_module // empty' 2>/dev/null || true)
+fi
+if [ -n "$WP_CODEBOX_CORE_MODULE" ]; then
+    export HOMEBOY_WP_CODEBOX_CORE_MODULE="$WP_CODEBOX_CORE_MODULE"
+fi
+
 homeboy_wp_codebox_resolve_host_path() {
     local base_dir="$1"
     local path_value="$2"

--- a/wordpress/tests/fixtures/wp-codebox-core-bench-runner.mjs
+++ b/wordpress/tests/fixtures/wp-codebox-core-bench-runner.mjs
@@ -1,0 +1,16 @@
+export function buildWordPressBenchRecipe(options = {}) {
+	return {
+		schema: 'wp-codebox/workspace-recipe/v1',
+		inputs: {
+			mounts: options.mounts ?? [],
+			extraPlugins: options.extraPlugins ?? [],
+			pluginRuntime: options.pluginRuntime ?? {},
+		},
+		runtime: {
+			blueprint: options.blueprint ?? {},
+		},
+		workflow: {
+			steps: [{ command: 'wordpress.bench', args: [] }],
+		},
+	};
+}

--- a/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
@@ -12,6 +12,7 @@ try {
   const extensionPath = path.join(__dirname, '..');
   const componentPath = path.join(root, 'bootstrap-steps-fixture');
   const dependencyPath = path.join(root, 'generic-dependency');
+  const fixtureCoreModule = path.join(__dirname, 'fixtures', 'wp-codebox-core-bench-runner.mjs');
   const benchDir = path.join(componentPath, 'tests', 'bench');
   fs.mkdirSync(benchDir, { recursive: true });
   fs.mkdirSync(dependencyPath, { recursive: true });
@@ -65,6 +66,7 @@ homeboy_require_bash_version() { :; }
 
   const settings = {
     validation_dependencies: [dependencyPath],
+    wp_codebox_core_module: fixtureCoreModule,
     wp_codebox_bootstrap_steps: [
       { command: 'wordpress.wp-cli', args: ['command=option update generic_dependency_bootstrap yes'] },
     ],

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1006,6 +1006,13 @@
       "description": "Map of NAME => value forwarded into the WordPress runtime as environment variables. Workloads (bench) and test fixtures (test runner) read them via getenv() / $_ENV. Required because host shell env doesn't cross the sandbox boundary; without this seam, getenv('MY_KNOB') returns false regardless of what the parent shell set. Values are coerced to strings (via json_encode for non-scalars) per PHP env-var convention. Component declares static defaults; matrix drivers can synthesize HOMEBOY_SETTINGS_JSON inline to override per-cell."
     },
     {
+      "id": "wp_codebox_core_module",
+      "label": "WP Codebox core module",
+      "type": "string",
+      "default": "",
+      "description": "Host-side ESM module path or package specifier that exports WP Codebox recipe builders. Used by the bench recipe builder before sandbox launch; distinct from bench_env, which is forwarded into the WordPress runtime."
+    },
+    {
       "id": "phpunit_no_tests",
       "label": "No PHPUnit tests discovered",
       "type": "string",


### PR DESCRIPTION
## Summary
- Add a host-side `wp_codebox_core_module` WordPress extension setting for WP Codebox bench recipe generation.
- Export the configured module path before invoking the bench recipe builder, keeping the stale bundled fallback disabled.
- Cover the setting path in the WP Codebox bench bootstrap smoke test.

## Why
Studio Web Workflow Bench Lab runs failed before benchmark execution because Homeboy Extensions could not load `buildWordPressBenchRecipe` unless `@automattic/wp-codebox-core` was installed ambiently in the extension runtime. This lets Lab runs point at the explicit built WP Codebox core module from the validation dependency.

## Testing
- `bash -n scripts/bench/bench-runner-wp-codebox.sh`
- `node tests/wp-codebox-bench-recipe-builder-smoke.js`
- `node tests/wp-codebox-bench-bootstrap-steps-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small setting/runner/test/doc change and ran targeted smoke checks; Chris remains responsible for review and merge.