### PR TITLE
fix: pass bench extra plugins to WP Codebox

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -949,7 +949,7 @@ jq -n \
         options: ({
             blueprint: $blueprint,
             mounts: $mounts,
-            extraPlugins: $extraPlugins,
+            extra_plugins: $extraPlugins,
             componentId: $component,
             pluginSlug: $slug,
             iterations: $iterations,

--- a/wordpress/scripts/bench/build-wp-codebox-bench-recipe.mjs
+++ b/wordpress/scripts/bench/build-wp-codebox-bench-recipe.mjs
@@ -11,11 +11,15 @@ import { loadCodeboxRecipeBuilder } from './wp-codebox-recipe-builder-loader.mjs
 
 const input = JSON.parse(readFileSync(0, 'utf8'));
 const { builder: buildWordPressBenchRecipe } = await loadCodeboxRecipeBuilder('buildWordPressBenchRecipe');
+const options = { ...(input.options || {}) };
+if (!options.extra_plugins && options.extraPlugins) {
+	options.extra_plugins = options.extraPlugins;
+}
 
-const recipe = buildWordPressBenchRecipe(input.options);
-if (input.options?.pluginRuntime && typeof input.options.pluginRuntime === 'object' && !Array.isArray(input.options.pluginRuntime)) {
+const recipe = buildWordPressBenchRecipe(options);
+if (options.pluginRuntime && typeof options.pluginRuntime === 'object' && !Array.isArray(options.pluginRuntime)) {
 	recipe.inputs = recipe.inputs ?? {};
-	recipe.inputs.pluginRuntime = input.options.pluginRuntime;
+	recipe.inputs.pluginRuntime = options.pluginRuntime;
 }
 
 process.stdout.write(`${JSON.stringify(recipe, null, 2)}\n`);

--- a/wordpress/tests/fixtures/wp-codebox-core-bench-runner.mjs
+++ b/wordpress/tests/fixtures/wp-codebox-core-bench-runner.mjs
@@ -3,7 +3,7 @@ export function buildWordPressBenchRecipe(options = {}) {
 		schema: 'wp-codebox/workspace-recipe/v1',
 		inputs: {
 			mounts: options.mounts ?? [],
-			extraPlugins: options.extraPlugins ?? [],
+			extra_plugins: options.extra_plugins ?? [],
 			pluginRuntime: options.pluginRuntime ?? {},
 		},
 		runtime: {

--- a/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
@@ -96,7 +96,7 @@ homeboy_require_bash_version() { :; }
 
   assert.equal(successResult.status, 0, successResult.stderr || successResult.stdout);
   const recipe = JSON.parse(fs.readFileSync(successCaptureFile, 'utf8'));
-  assert.equal(recipe.inputs.extraPlugins.some((plugin) => plugin.slug === 'generic-dependency'), true);
+  assert.equal(recipe.inputs.extra_plugins.some((plugin) => plugin.slug === 'generic-dependency'), true);
   assert.deepEqual(recipe.inputs.pluginRuntime.setup, settings.wp_codebox_bootstrap_steps);
   assert.equal(recipe.workflow.steps[0].command, 'wordpress.bench');
 


### PR DESCRIPTION
## Summary
- Emit WP Codebox bench recipe plugin inputs as `extra_plugins`, matching the WP Codebox 0.8 core builder contract.
- Normalize legacy `extraPlugins` input in the bridge so older callers do not silently drop plugin dependencies.
- Update the bench bootstrap smoke fixture/assertion to prove dependency plugins are retained in generated recipes.

## Why
Studio Web Workflow Bench Lab run `homeboy-lab-architecture-comparison-live-clean-source-20260608-v12` reached WP Codebox but failed inside `wordpress.bench` because the dependency slug `agents-api` was requested while the recipe had no dependency plugin directory mounted at `/wordpress/wp-content/plugins/agents-api`. The dependency extra plugin was dropped because Homeboy Extensions passed `extraPlugins` to a core builder that expects `extra_plugins`.

## Testing
- `bash -n scripts/bench/bench-runner-wp-codebox.sh`
- `node --check scripts/bench/build-wp-codebox-bench-recipe.mjs`
- `node tests/wp-codebox-bench-recipe-builder-smoke.js`
- `node tests/wp-codebox-bench-bootstrap-steps-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Lab failure, drafted the small contract-alignment fix, and ran targeted smoke checks; Chris remains responsible for review and merge.