### PR TITLE
fix: support bench extra plugin settings

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -593,6 +593,7 @@ Configure per-component in the component's homeboy/component config under
 | `bench_env` | object | `{}` | `NAME => value` env vars forwarded into the runtime (workloads/fixtures read via `getenv()`) |
 | `wp_codebox_core_module` | string | `""` | Host-side ESM module path or package specifier that exports WP Codebox recipe builders for bench recipe generation |
 | `wp_codebox_blueprint` | object | `{}` | Runtime blueprint merged into the generated WP Codebox bench recipe |
+| `wp_codebox_extra_plugins` | array | `[]` | Additional WP Codebox extra plugin entries for runtime prerequisites that are not Homeboy validation dependencies |
 | `wp_codebox_workloads` | array | `[]` | Declared bench workloads passed to `wordpress.bench` through the generated recipe after deps and component load |
 | `wp_codebox_file_mounts` | array | `[]` | Files from the component or validation dependencies mounted into explicit WordPress runtime paths |
 | `bench_browser_target` | object | `{}` | Browser bench target descriptor (see Bench runner above) |

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -743,6 +743,20 @@ if [ -n "$DEPENDENCY_PATHS" ]; then
     done <<< "$DEPENDENCY_PATHS"
 fi
 
+WP_CODEBOX_EXTRA_PLUGINS_JSON="[]"
+if [ "$settings_json" != "{}" ]; then
+    WP_CODEBOX_EXTRA_PLUGINS_JSON=$(printf '%s' "$settings_json" | jq -c '.wp_codebox_extra_plugins // []' 2>/dev/null || echo "[]")
+fi
+if printf '%s' "$WP_CODEBOX_EXTRA_PLUGINS_JSON" | jq -e 'type == "array" and all(.[]; type == "object" and (.source | type == "string" and . != ""))' >/dev/null 2>&1; then
+    EXTRA_PLUGINS_JSON=$(jq -nc --argjson plugins "$EXTRA_PLUGINS_JSON" --argjson extra "$WP_CODEBOX_EXTRA_PLUGINS_JSON" '$plugins + $extra')
+elif printf '%s' "$WP_CODEBOX_EXTRA_PLUGINS_JSON" | jq -e 'type == "array" and length == 0' >/dev/null 2>&1; then
+    :
+else
+    echo "Error: wp_codebox_extra_plugins must be an array of plugin objects with non-empty source strings." >&2
+    FAILED_STEP="WP Codebox extra plugin setup"
+    exit 1
+fi
+
 PLUGIN_DB_PHP="${PLUGIN_PATH}/db.php"
 if [ -f "$PLUGIN_DB_PHP" ]; then
     MOUNTS_JSON=$(jq -nc --argjson mounts "$MOUNTS_JSON" --arg source "$PLUGIN_DB_PHP" '$mounts + [{source: $source, target: "/wordpress/wp-content/db.php", mode: "readonly"}]')

--- a/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
@@ -67,6 +67,9 @@ homeboy_require_bash_version() { :; }
   const settings = {
     validation_dependencies: [dependencyPath],
     wp_codebox_core_module: fixtureCoreModule,
+    wp_codebox_extra_plugins: [
+      { source: '/tmp/runtime-prerequisite', slug: 'runtime-prerequisite', activate: true },
+    ],
     wp_codebox_bootstrap_steps: [
       { command: 'wordpress.wp-cli', args: ['command=option update generic_dependency_bootstrap yes'] },
     ],
@@ -97,6 +100,7 @@ homeboy_require_bash_version() { :; }
   assert.equal(successResult.status, 0, successResult.stderr || successResult.stdout);
   const recipe = JSON.parse(fs.readFileSync(successCaptureFile, 'utf8'));
   assert.equal(recipe.inputs.extra_plugins.some((plugin) => plugin.slug === 'generic-dependency'), true);
+  assert.deepEqual(recipe.inputs.extra_plugins.find((plugin) => plugin.slug === 'runtime-prerequisite'), settings.wp_codebox_extra_plugins[0]);
   assert.deepEqual(recipe.inputs.pluginRuntime.setup, settings.wp_codebox_bootstrap_steps);
   assert.equal(recipe.workflow.steps[0].command, 'wordpress.bench');
 

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1027,6 +1027,13 @@
       "description": "Runtime blueprint merged into the generated WP Codebox bench recipe. Empty object means stock WordPress."
     },
     {
+      "id": "wp_codebox_extra_plugins",
+      "label": "WP Codebox extra plugins",
+      "type": "array",
+      "default": [],
+      "description": "Additional WP Codebox extra plugin entries for bench recipes. Use for runtime prerequisites that must be installed or activated but should not be treated as Homeboy validation dependencies."
+    },
+    {
       "id": "wp_codebox_workloads",
       "label": "Bench workloads",
       "type": "array",


### PR DESCRIPTION
## Summary
- Add a `wp_codebox_extra_plugins` WordPress extension setting for WP Codebox bench recipes.
- Merge configured extra plugins after validation dependency plugins so runtime prerequisites can be installed/activated without being treated as Homeboy validation dependencies.
- Cover the setting in the WP Codebox bench bootstrap smoke test and document it.

## Why
Studio Web Workflow Bench Lab run `homeboy-lab-architecture-comparison-live-clean-source-20260608-v13` got past dependency plugin mounting, but Studio Web failed to activate because `playground-site-sync` was not installed/active in the outer Homeboy bench sandbox. `playground-site-sync` is a runtime prerequisite for Studio Web, but the only existing way to add bench extra plugins was through `validation_dependencies`, which intentionally requires Git-backed hygiene. This setting keeps those concepts separate.

## Testing
- `bash -n scripts/bench/bench-runner-wp-codebox.sh`
- `node tests/wp-codebox-bench-bootstrap-steps-smoke.js`
- `node tests/wp-codebox-bench-recipe-builder-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Lab activation failure, drafted the small setting/runner/test/doc change, and ran targeted smoke checks; Chris remains responsible for review and merge.