### PR TITLE
fix: preserve WP Codebox validation evidence

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -173,6 +173,176 @@ function writePreflightEvidence(artifacts, evidence) {
   }
 }
 
+function secretEnvValues(secretNames) {
+  return Object.fromEntries(secretNames
+    .filter((name) => typeof name === 'string' && name !== '' && process.env[name])
+    .map((name) => [name, process.env[name]]));
+}
+
+function redactString(value, secrets) {
+  return Object.entries(secrets).reduce((redacted, [name, secret]) => {
+    if (!secret) {
+      return redacted;
+    }
+    return redacted.split(secret).join(`[REDACTED:${name}]`);
+  }, String(value));
+}
+
+function redactedValue(value, secrets) {
+  if (typeof value === 'string') {
+    return redactString(value, secrets);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactedValue(item, secrets));
+  }
+  if (plainObject(value)) {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => {
+      if (/secret|token|password|credential|api[_-]?key/i.test(key)) {
+        return [key, item ? '[REDACTED]' : item];
+      }
+      return [key, redactedValue(item, secrets)];
+    }));
+  }
+  return value;
+}
+
+function writeEvidenceFile(artifacts, fileName, contents) {
+  try {
+    fs.mkdirSync(artifacts, { recursive: true });
+    const filePath = path.join(artifacts, fileName);
+    fs.writeFileSync(filePath, contents);
+    return filePath;
+  } catch {
+    return '';
+  }
+}
+
+function readJsonIfAvailable(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function pathEvidenceCandidates(...texts) {
+  const candidates = new Set();
+  const pattern = /(?:[A-Za-z]:)?\/[^\s'"`]+(?:wp-codebox-agent-task-recipe|homeboy-wp-codebox-agent-task-input)[^\s'"`)]*/g;
+  for (const text of texts) {
+    for (const match of String(text || '').matchAll(pattern)) {
+      candidates.add(match[0].replace(/[.,;:]+$/, ''));
+    }
+  }
+  return [...candidates];
+}
+
+function copiedEvidencePathName(sourcePath, index) {
+  const parent = path.basename(path.dirname(sourcePath)).replace(/[^A-Za-z0-9_.-]+/g, '-');
+  const base = path.basename(sourcePath).replace(/[^A-Za-z0-9_.-]+/g, '-');
+  return `captured-wp-codebox-path-${index + 1}-${parent}-${base}`;
+}
+
+function copyGeneratedEvidencePaths(artifacts, candidates, secrets) {
+  const copied = [];
+  candidates.forEach((candidate, index) => {
+    try {
+      if (!fs.existsSync(candidate) || !fs.statSync(candidate).isFile()) {
+        return;
+      }
+      const parsed = candidate.endsWith('.json') ? readJsonIfAvailable(candidate) : null;
+      const contents = parsed
+        ? `${JSON.stringify(redactedValue(parsed, secrets), null, 2)}\n`
+        : redactString(fs.readFileSync(candidate, 'utf8'), secrets);
+      const target = writeEvidenceFile(artifacts, copiedEvidencePathName(candidate, index), contents);
+      if (target) {
+        copied.push({ source: candidate, path: target });
+      }
+    } catch {
+      // Best-effort evidence capture must not mask the actual WP Codebox failure.
+    }
+  });
+  return copied;
+}
+
+function preserveWpCodeboxFailureEvidence({ artifacts, inputPath, result, command, args, secretNames }) {
+  const secrets = secretEnvValues(secretNames);
+  const stdoutPath = result.stdout
+    ? writeEvidenceFile(artifacts, 'wp-codebox-command-stdout.txt', redactString(result.stdout, secrets))
+    : '';
+  const stderrPath = result.stderr
+    ? writeEvidenceFile(artifacts, 'wp-codebox-command-stderr.txt', redactString(result.stderr, secrets))
+    : '';
+  const stableInput = readJsonIfAvailable(inputPath);
+  const inputEvidencePath = stableInput
+    ? writeEvidenceFile(artifacts, 'wp-codebox-agent-task-input.redacted.json', `${JSON.stringify(redactedValue(stableInput, secrets), null, 2)}\n`)
+    : '';
+  const generatedPathCandidates = pathEvidenceCandidates(result.stdout, result.stderr);
+  const copiedGeneratedPaths = copyGeneratedEvidencePaths(artifacts, generatedPathCandidates, secrets);
+  const summary = {
+    schema: 'homeboy/wp-codebox-command-evidence/v1',
+    command,
+    args,
+    status: result.status,
+    signal: result.signal,
+    error: result.error ? result.error.message : '',
+    input_path: inputPath,
+    input_evidence_path: inputEvidencePath,
+    stdout_path: stdoutPath,
+    stderr_path: stderrPath,
+    generated_path_candidates: generatedPathCandidates,
+    copied_generated_paths: copiedGeneratedPaths,
+  };
+  const summaryPath = writeEvidenceFile(artifacts, 'wp-codebox-command-evidence.json', `${JSON.stringify(summary, null, 2)}\n`);
+  return {
+    ...summary,
+    summary_path: summaryPath,
+  };
+}
+
+function evidenceArtifacts(evidence) {
+  return [
+    { id: 'wp-codebox-command-evidence', kind: 'codebox-command-evidence', path: evidence.summary_path },
+    { id: 'wp-codebox-agent-task-input', kind: 'codebox-agent-task-input', path: evidence.input_evidence_path },
+    { id: 'wp-codebox-command-stdout', kind: 'codebox-command-log', path: evidence.stdout_path },
+    { id: 'wp-codebox-command-stderr', kind: 'codebox-command-log', path: evidence.stderr_path },
+    ...evidence.copied_generated_paths.map((item, index) => ({
+      id: `wp-codebox-generated-evidence-${index + 1}`,
+      kind: 'codebox-generated-input',
+      path: item.path,
+      metadata: { source: item.source },
+    })),
+  ].filter((artifact) => artifact.path);
+}
+
+function attachFailureEvidence(payload, evidence) {
+  const artifacts = evidenceArtifacts(evidence);
+  const diagnostics = evidence.summary_path ? [{
+    class: 'wp-codebox.command.evidence_preserved',
+    message: 'WP Codebox command stdout, stderr, and redacted task input were preserved for failure diagnosis.',
+    data: {
+      evidence_path: evidence.summary_path,
+      stdout_path: evidence.stdout_path,
+      stderr_path: evidence.stderr_path,
+      input_evidence_path: evidence.input_evidence_path,
+      generated_path_candidates: evidence.generated_path_candidates,
+      copied_generated_paths: evidence.copied_generated_paths,
+    },
+  }] : [];
+  return {
+    ...payload,
+    artifacts: Array.isArray(payload.artifacts) ? [...payload.artifacts, ...artifacts] : payload.artifacts,
+    evidence_refs: [
+      ...(Array.isArray(payload.evidence_refs) ? payload.evidence_refs : []),
+      ...artifacts.map((artifact) => ({ kind: artifact.kind, uri: artifact.path, label: artifact.kind.replace(/-/g, ' ') })),
+    ],
+    diagnostics: [...(Array.isArray(payload.diagnostics) ? payload.diagnostics : []), ...diagnostics],
+    metadata: {
+      ...(plainObject(payload.metadata) ? payload.metadata : {}),
+      wp_codebox_command_evidence: evidence.summary_path,
+    },
+  };
+}
+
 const LEGACY_RUNTIME_PREFIX = ['data', 'machine'].join('_');
 const WP_CODEBOX_RUNTIME_PATH_KEY = `${LEGACY_RUNTIME_PREFIX}_path`;
 const WP_CODEBOX_RUNTIME_TOOLS_PATH_KEY = `${LEGACY_RUNTIME_PREFIX}_code_path`;
@@ -752,6 +922,32 @@ function timeoutPayload(timeoutMs, artifacts, evidencePath, inputPath, command, 
   };
 }
 
+function commandFailurePayload(result, artifacts, evidence) {
+  const message = result.stderr || result.stdout || result.error?.message || 'WP Codebox agent-task-run failed.';
+  return attachFailureEvidence({
+    success: false,
+    status: 'failed',
+    summary: message.split('\n').find((line) => line.trim() !== '') || 'WP Codebox agent-task-run failed.',
+    artifacts: [],
+    evidence_refs: [],
+    diagnostics: [{
+      class: 'wp-codebox.agent_task_run_failed',
+      message: message.trim() || 'WP Codebox agent-task-run failed.',
+      data: {
+        status: result.status,
+        signal: result.signal,
+        error: result.error ? result.error.message : '',
+        artifacts,
+      },
+    }],
+    metadata: {
+      status: result.status,
+      signal: result.signal,
+      error: result.error ? result.error.message : '',
+    },
+  }, evidence);
+}
+
 function runWpCodeboxParentTask(request) {
   const explicitArtifacts = argValue('--artifacts') || request.artifacts_path || '';
   const artifacts = explicitArtifacts || fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-artifacts-'));
@@ -800,6 +996,15 @@ function runWpCodeboxParentTask(request) {
     maxBuffer: 1024 * 1024 * 20,
     timeout: timeoutMs,
   });
+  const shouldPreserveEvidence = Boolean(result.error) || result.status !== 0;
+  const failureEvidence = shouldPreserveEvidence ? preserveWpCodeboxFailureEvidence({
+    artifacts,
+    inputPath,
+    result,
+    command: resolved.command,
+    args: resolved.args,
+    secretNames: input.secret_env || [],
+  }) : null;
 
   if (result.error && result.error.code === 'ETIMEDOUT') {
     process.stdout.write(`${JSON.stringify(timeoutPayload(timeoutMs, artifacts, evidencePath, inputPath, resolved.command, resolved.args), null, 2)}\n`);
@@ -809,13 +1014,22 @@ function runWpCodeboxParentTask(request) {
   if (result.stdout) {
     try {
       const payload = normalizeAgentTaskRun(input, JSON.parse(result.stdout));
-      process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+      const enrichedPayload = failureEvidence ? attachFailureEvidence(payload, failureEvidence) : payload;
+      process.stdout.write(`${JSON.stringify(enrichedPayload, null, 2)}\n`);
       return payload.success === false ? 1 : 0;
     } catch {
+      if (failureEvidence) {
+        process.stdout.write(`${JSON.stringify(commandFailurePayload(result, artifacts, failureEvidence), null, 2)}\n`);
+        return result.status ?? 1;
+      }
       process.stdout.write(result.stdout);
     }
   }
   if (result.stderr) {
+    if (failureEvidence) {
+      process.stdout.write(`${JSON.stringify(commandFailurePayload(result, artifacts, failureEvidence), null, 2)}\n`);
+      return result.status ?? 1;
+    }
     process.stderr.write(result.stderr);
   }
   if (result.error) {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -19,6 +19,21 @@ const out = process.env.FIXTURE_WP_CODEBOX_CAPTURE;
 const inputArg = process.argv.find((arg) => arg.startsWith('--input-file='));
 const inputPath = inputArg ? inputArg.slice('--input-file='.length) : '';
 const input = inputPath ? JSON.parse(fs.readFileSync(inputPath, 'utf8')) : null;
+if (process.env.FIXTURE_WP_CODEBOX_VALIDATION_FAILURE) {
+  const generatedRoot = fs.mkdtempSync(require('node:path').join(require('node:os').tmpdir(), 'wp-codebox-agent-task-recipe-'));
+  const generatedRecipePath = require('node:path').join(generatedRoot, 'recipe.json');
+  fs.writeFileSync(generatedRecipePath, JSON.stringify({
+    schema: 'wp-codebox/recipe/v1',
+    secret: process.env.OPENCODE_API_KEY,
+    workflow: { steps: [{ command: '', args: [] }] }
+  }, null, 2));
+  fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), input }, null, 2));
+  process.stderr.write('RecipeValidationError: Recipe validation failed with 2 issues.\\n');
+  process.stderr.write('Issue 1: workflow.steps[0].command is required.\\n');
+  process.stderr.write('Issue 2: provider plugin path is invalid.\\n');
+  process.stderr.write('Generated recipe: ' + generatedRecipePath + '\\n');
+  process.exit(1);
+}
 const isAgentBundle = Boolean(input.agent_bundle && Object.keys(input.agent_bundle).length);
 const bundleRun = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
   ? {
@@ -596,6 +611,36 @@ try {
   const nonExecutableCapture = readJson(nonExecutableCapturePath);
   assert.equal(nonExecutableCapture.argv[0], 'agent-task-run');
   assert.equal(pathInside(root, nonExecutableCapture.input.artifacts_path), false);
+
+  const validationArtifacts = path.join(root, 'validation-failure-artifacts');
+  const validationCapturePath = path.join(root, 'capture-validation-failure.json');
+  const validationFailureResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+    '--artifacts', validationArtifacts,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(request),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: validationCapturePath,
+      FIXTURE_WP_CODEBOX_VALIDATION_FAILURE: '1',
+      OPENCODE_API_KEY: 'super-secret-validation-key',
+    },
+  });
+  assert.equal(validationFailureResult.status, 1, validationFailureResult.stderr || validationFailureResult.stdout);
+  const validationOutput = JSON.parse(validationFailureResult.stdout);
+  assert.equal(validationOutput.success, false);
+  assert.equal(validationOutput.diagnostics[0].class, 'wp-codebox.agent_task_run_failed');
+  assert.match(validationOutput.diagnostics[0].message, /RecipeValidationError/);
+  assert.equal(validationOutput.diagnostics.some((diagnostic) => diagnostic.class === 'wp-codebox.command.evidence_preserved'), true);
+  const evidence = readJson(path.join(validationArtifacts, 'wp-codebox-command-evidence.json'));
+  assert.equal(fs.existsSync(evidence.stderr_path), true);
+  assert.equal(fs.existsSync(evidence.input_evidence_path), true);
+  assert.equal(evidence.copied_generated_paths.length, 1);
+  assert.match(fs.readFileSync(evidence.stderr_path, 'utf8'), /workflow\.steps\[0\]\.command is required/);
+  assert(!fs.readFileSync(evidence.input_evidence_path, 'utf8').includes('super-secret-validation-key'));
+  assert(!fs.readFileSync(evidence.copied_generated_paths[0].path, 'utf8').includes('super-secret-validation-key'));
 
   const missingSecretResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),


### PR DESCRIPTION
## Summary
- Preserve WP Codebox command stdout/stderr, redacted stable task input, and generated recipe/input paths when `agent-task-run` exits non-zero.
- Return structured Homeboy failure JSON for raw/non-JSON WP Codebox validation failures instead of opaque passthrough output.
- Add smoke coverage for `RecipeValidationError` evidence preservation and secret redaction.

Fixes Extra-Chill/homeboy-extensions#1206.

## Testing
- `node --check wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs`
- `node --check wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the evidence-preservation patch and smoke coverage; Chris remains responsible for review and merge.