### PR TITLE
fix: preserve WP Codebox JSON failure evidence

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -1014,7 +1014,16 @@ function runWpCodeboxParentTask(request) {
   if (result.stdout) {
     try {
       const payload = normalizeAgentTaskRun(input, JSON.parse(result.stdout));
-      const enrichedPayload = failureEvidence ? attachFailureEvidence(payload, failureEvidence) : payload;
+      const payloadFailed = payload.success === false || payload.status === 'failed' || payload.session?.status === 'failed';
+      const payloadEvidence = failureEvidence || (payloadFailed ? preserveWpCodeboxFailureEvidence({
+        artifacts,
+        inputPath,
+        result,
+        command: resolved.command,
+        args: resolved.args,
+        secretNames: input.secret_env || [],
+      }) : null);
+      const enrichedPayload = payloadEvidence ? attachFailureEvidence(payload, payloadEvidence) : payload;
       process.stdout.write(`${JSON.stringify(enrichedPayload, null, 2)}\n`);
       return payload.success === false ? 1 : 0;
     } catch {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -34,6 +34,31 @@ if (process.env.FIXTURE_WP_CODEBOX_VALIDATION_FAILURE) {
   process.stderr.write('Generated recipe: ' + generatedRecipePath + '\\n');
   process.exit(1);
 }
+if (process.env.FIXTURE_WP_CODEBOX_JSON_VALIDATION_FAILURE) {
+  const generatedRoot = fs.mkdtempSync(require('node:path').join(require('node:os').tmpdir(), 'wp-codebox-agent-task-recipe-'));
+  const generatedRecipePath = require('node:path').join(generatedRoot, 'recipe.json');
+  fs.writeFileSync(generatedRecipePath, JSON.stringify({
+    schema: 'wp-codebox/recipe/v1',
+    secret: process.env.OPENCODE_API_KEY,
+    workflow: { steps: [{ command: '', args: [] }] }
+  }, null, 2));
+  fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), input }, null, 2));
+  process.stdout.write(JSON.stringify({
+    success: false,
+    schema: 'wp-codebox/agent-task-run/v1',
+    status: 'failed',
+    summary: 'WP Codebox agent task failed.',
+    diagnostics: [{ class: 'wp-codebox.agent_task_run_failed', message: 'Recipe validation failed with 2 issues.', data: { exit_code: 1 } }],
+    artifacts: input.artifacts_path,
+    metadata: {
+      run: {
+        error: { name: 'RecipeValidationError', message: 'Recipe validation failed with 2 issues.' },
+        replay: { recipePath: generatedRecipePath }
+      }
+    }
+  }));
+  process.exit(0);
+}
 const isAgentBundle = Boolean(input.agent_bundle && Object.keys(input.agent_bundle).length);
 const bundleRun = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
   ? {
@@ -641,6 +666,34 @@ try {
   assert.match(fs.readFileSync(evidence.stderr_path, 'utf8'), /workflow\.steps\[0\]\.command is required/);
   assert(!fs.readFileSync(evidence.input_evidence_path, 'utf8').includes('super-secret-validation-key'));
   assert(!fs.readFileSync(evidence.copied_generated_paths[0].path, 'utf8').includes('super-secret-validation-key'));
+
+  const jsonValidationArtifacts = path.join(root, 'json-validation-failure-artifacts');
+  const jsonValidationCapturePath = path.join(root, 'capture-json-validation-failure.json');
+  const jsonValidationFailureResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+    '--artifacts', jsonValidationArtifacts,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(request),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: jsonValidationCapturePath,
+      FIXTURE_WP_CODEBOX_JSON_VALIDATION_FAILURE: '1',
+      OPENCODE_API_KEY: 'super-secret-json-validation-key',
+    },
+  });
+  assert.equal(jsonValidationFailureResult.status, 1, jsonValidationFailureResult.stderr || jsonValidationFailureResult.stdout);
+  const jsonValidationOutput = JSON.parse(jsonValidationFailureResult.stdout);
+  assert.equal(jsonValidationOutput.success, false);
+  assert.equal(jsonValidationOutput.diagnostics.some((diagnostic) => diagnostic.class === 'wp-codebox.command.evidence_preserved'), true);
+  const jsonEvidence = readJson(path.join(jsonValidationArtifacts, 'wp-codebox-command-evidence.json'));
+  assert.equal(fs.existsSync(jsonEvidence.stdout_path), true);
+  assert.equal(fs.existsSync(jsonEvidence.input_evidence_path), true);
+  assert.equal(jsonEvidence.copied_generated_paths.length, 1);
+  assert.match(fs.readFileSync(jsonEvidence.stdout_path, 'utf8'), /RecipeValidationError/);
+  assert(!fs.readFileSync(jsonEvidence.stdout_path, 'utf8').includes('super-secret-json-validation-key'));
+  assert(!fs.readFileSync(jsonEvidence.copied_generated_paths[0].path, 'utf8').includes('super-secret-json-validation-key'));
 
   const missingSecretResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),


### PR DESCRIPTION
## Summary
- Preserve WP Codebox command evidence when `agent-task-run` returns a parsed JSON failure even if the CLI process exits successfully.
- Attach the same redacted stdout/stable-input/generated-recipe evidence refs to `success:false` / failed session payloads.
- Add smoke coverage for the JSON failure shape observed in the SSI #322 lab retry.

Follow-up to Extra-Chill/homeboy-extensions#1207 and Extra-Chill/homeboy-extensions#1206.

## Evidence
- SSI retry `ssi-322-script-artifacts-retry-evidence-1` returned `Recipe validation failed with 2 issues.` as a parsed WP Codebox failure while the runner did not preserve command evidence because the child process exited successfully.

## Testing
- `node --check wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs`
- `node --check wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the parsed-failure evidence patch and smoke coverage; Chris remains responsible for review and merge.