### PR TITLE
fix: support WP Codebox core module for PHPUnit

### DIFF
--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -181,6 +181,17 @@ if [ "$WP_CODEBOX_BIN" = "wp-codebox" ] && ! command -v wp-codebox >/dev/null 2>
     exit 1
 fi
 
+settings_json="${HOMEBOY_SETTINGS_JSON:-}"
+[ -n "$settings_json" ] || settings_json="{}"
+
+WP_CODEBOX_CORE_MODULE="${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}"
+if [ -z "$WP_CODEBOX_CORE_MODULE" ] && [ "$settings_json" != "{}" ]; then
+    WP_CODEBOX_CORE_MODULE=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_core_module // empty' 2>/dev/null || true)
+fi
+if [ -n "$WP_CODEBOX_CORE_MODULE" ]; then
+    export HOMEBOY_WP_CODEBOX_CORE_MODULE="$WP_CODEBOX_CORE_MODULE"
+fi
+
 # Guard against a mis-resolved component path mounting the wrong directory.
 #
 # The recipe mounts PLUGIN_PATH wholesale into


### PR DESCRIPTION
## Summary
- Teaches the WordPress WP Codebox PHPUnit runner to read `wp_codebox_core_module` from `HOMEBOY_SETTINGS_JSON`.
- Mirrors the existing bench runner behavior so `homeboy test --setting wp_codebox_core_module=...` can resolve `buildWordPressPhpunitRecipe`.
- Keeps `HOMEBOY_WP_CODEBOX_CORE_MODULE` as the higher-priority explicit env override.

## Verification
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh`
- Verified with a WooCommerce checkout regression test through Homeboy WP Codebox after this plumbing change:
  - `OK (1 test, 5 assertions)`
  - `[test-results] Total: 1, Passed: 1, Failed: 0, Skipped: 0`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the bench/test setting plumbing difference, drafted the shell runner fix, and ran verification commands; Chris remains responsible for review and submission.