### PR TITLE
Add WordPress bench query profiler helper

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -48,6 +48,7 @@
     "test:wp-codebox-apply-adapter": "node tests/wp-codebox-apply-adapter-smoke.js",
     "test:wp-codebox-browser-metrics": "node tests/wp-codebox-browser-metrics-smoke.js",
     "test:wordpress-bench-state-sampling": "php tests/wordpress-bench-state-sampling-helper-smoke.php",
+    "test:wordpress-db-query-profiler": "php scripts/bench/wordpress-db-query-profiler-smoke.php",
     "test:audit-wp-codebox-fanout": "node tests/audit-wp-codebox-fanout-smoke.js",
     "test:audit-wp-codebox-execute": "node tests/audit-wp-codebox-fanout-smoke.js",
     "test:wp-codebox-task-runner": "node tests/wp-codebox-task-runner-smoke.js",

--- a/wordpress/scripts/bench/lib/wordpress-db-query-profiler.php
+++ b/wordpress/scripts/bench/lib/wordpress-db-query-profiler.php
@@ -1,0 +1,458 @@
+<?php
+/**
+ * Generic WordPress database query profiling helpers for bench workloads.
+ *
+ * Workloads can require this file from the mounted extension path:
+ * /homeboy-extension/scripts/bench/lib/wordpress-db-query-profiler.php
+ */
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_start' ) ) {
+	/**
+	 * Start collecting SQL query profile counters through WordPress' query filter.
+	 *
+	 * @param string              $label Profile label.
+	 * @param array<string,mixed> $options Profiler options.
+	 * @return array<string,mixed>
+	 */
+	function homeboy_wordpress_bench_query_profiler_start( string $label = '', array $options = array() ): array {
+		global $wpdb;
+
+		if ( isset( $GLOBALS['homeboy_wordpress_bench_query_profiler_state']['active'] ) ) {
+			homeboy_wordpress_bench_query_profiler_stop();
+		}
+
+		$state = array(
+			'label'               => $label,
+			'options'             => $options,
+			'started_at_unix_ms'  => (int) floor( microtime( true ) * 1000 ),
+			'started_at'          => microtime( true ),
+			'query_before'        => isset( $wpdb ) && isset( $wpdb->num_queries ) ? (int) $wpdb->num_queries : 0,
+			'operations'          => array_fill_keys( array( 'select', 'insert', 'update', 'delete', 'replace', 'alter', 'create', 'drop', 'show', 'other' ), 0 ),
+			'tables'              => array(),
+			'operation_tables'    => array(),
+			'categories'          => array(),
+			'option_names'        => array(),
+			'meta_keys'           => array(),
+			'meta_key_operations' => array(),
+			'signatures'          => array(),
+			'queries_seen'        => 0,
+		);
+
+		$GLOBALS['homeboy_wordpress_bench_query_profiler_state'] = array( 'active' => $state );
+		if ( function_exists( 'add_filter' ) ) {
+			add_filter( 'query', 'homeboy_wordpress_bench_query_profiler_record_query', 10, 1 );
+		}
+
+		return homeboy_wordpress_bench_query_profiler_snapshot();
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_stop' ) ) {
+	/**
+	 * Stop profiling and return the final snapshot.
+	 *
+	 * @return array<string,mixed>
+	 */
+	function homeboy_wordpress_bench_query_profiler_stop(): array {
+		$snapshot = homeboy_wordpress_bench_query_profiler_snapshot();
+		if ( function_exists( 'remove_filter' ) ) {
+			remove_filter( 'query', 'homeboy_wordpress_bench_query_profiler_record_query', 10 );
+		}
+		unset( $GLOBALS['homeboy_wordpress_bench_query_profiler_state']['active'] );
+
+		return $snapshot;
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_snapshot' ) ) {
+	/**
+	 * Return the current profile snapshot with deterministic top-N truncation.
+	 *
+	 * @return array<string,mixed>
+	 */
+	function homeboy_wordpress_bench_query_profiler_snapshot(): array {
+		global $wpdb;
+
+		$state = $GLOBALS['homeboy_wordpress_bench_query_profiler_state']['active'] ?? null;
+		if ( ! is_array( $state ) ) {
+			return array(
+				'label'        => '',
+				'active'       => false,
+				'query_count'  => 0,
+				'queries_seen' => 0,
+			);
+		}
+
+		$elapsed_ms  = max( 0, ( microtime( true ) - (float) $state['started_at'] ) * 1000 );
+		$query_count = isset( $wpdb ) && isset( $wpdb->num_queries )
+			? max( 0, (int) $wpdb->num_queries - (int) $state['query_before'] )
+			: (int) $state['queries_seen'];
+		$top         = isset( $state['options']['top'] ) && is_numeric( $state['options']['top'] )
+			? max( 1, (int) $state['options']['top'] )
+			: 30;
+
+		return array(
+			'label'               => (string) $state['label'],
+			'active'              => true,
+			'started_at_unix_ms'  => (int) $state['started_at_unix_ms'],
+			'elapsed_ms'          => $elapsed_ms,
+			'query_count'         => $query_count,
+			'queries_seen'        => (int) $state['queries_seen'],
+			'operations'          => homeboy_wordpress_bench_query_profiler_top_counts( $state['operations'], $top ),
+			'tables'              => homeboy_wordpress_bench_query_profiler_top_counts( $state['tables'], $top ),
+			'operation_tables'    => homeboy_wordpress_bench_query_profiler_top_counts( $state['operation_tables'], $top ),
+			'categories'          => homeboy_wordpress_bench_query_profiler_top_counts( $state['categories'], $top ),
+			'option_names'        => homeboy_wordpress_bench_query_profiler_top_counts( $state['option_names'], $top ),
+			'meta_keys'           => homeboy_wordpress_bench_query_profiler_top_counts( $state['meta_keys'], $top ),
+			'meta_key_operations' => homeboy_wordpress_bench_query_profiler_top_counts( $state['meta_key_operations'], $top ),
+			'signatures'          => homeboy_wordpress_bench_query_profiler_top_counts( $state['signatures'], $top ),
+		);
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_profile_call' ) ) {
+	/**
+	 * Profile a callable and return its result with the query profile.
+	 *
+	 * @param string              $label Profile label.
+	 * @param callable            $callback Workload callback.
+	 * @param array<string,mixed> $options Profiler options.
+	 * @return array{result:mixed,profile:array<string,mixed>}
+	 */
+	function homeboy_wordpress_bench_query_profiler_profile_call( string $label, callable $callback, array $options = array() ): array {
+		homeboy_wordpress_bench_query_profiler_start( $label, $options );
+		try {
+			$result = $callback();
+		} finally {
+			$profile = homeboy_wordpress_bench_query_profiler_stop();
+		}
+
+		return array(
+			'result'  => $result,
+			'profile' => $profile,
+		);
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_record_query' ) ) {
+	/**
+	 * WordPress query filter callback.
+	 *
+	 * @param string $query SQL query.
+	 * @return string
+	 */
+	function homeboy_wordpress_bench_query_profiler_record_query( string $query ): string {
+		if ( empty( $GLOBALS['homeboy_wordpress_bench_query_profiler_state']['active'] ) ) {
+			return $query;
+		}
+
+		$profile =& $GLOBALS['homeboy_wordpress_bench_query_profiler_state']['active'];
+		++$profile['queries_seen'];
+
+		$operation = homeboy_wordpress_bench_query_profiler_operation( $query );
+		$tables    = homeboy_wordpress_bench_query_profiler_tables( $query );
+		$category  = homeboy_wordpress_bench_query_profiler_category( $query, $operation, $tables, $profile['options'] ?? array() );
+
+		homeboy_wordpress_bench_query_profiler_increment( $profile['operations'], $operation );
+		foreach ( $tables as $table ) {
+			homeboy_wordpress_bench_query_profiler_increment( $profile['tables'], $table );
+			homeboy_wordpress_bench_query_profiler_increment( $profile['operation_tables'], $operation . ':' . $table );
+		}
+		homeboy_wordpress_bench_query_profiler_increment( $profile['categories'], $category );
+		homeboy_wordpress_bench_query_profiler_collect_named_values( $profile['option_names'], $query, '/option_name\s*=\s*[\'\"]([^\'\"]+)[\'\"]/i' );
+		homeboy_wordpress_bench_query_profiler_collect_named_values( $profile['meta_keys'], $query, '/meta_key\s*=\s*[\'\"]([^\'\"]+)[\'\"]/i' );
+
+		$meta_operation = homeboy_wordpress_bench_query_profiler_meta_operation( $query, $operation );
+		if ( null !== $meta_operation ) {
+			homeboy_wordpress_bench_query_profiler_increment( $profile['meta_key_operations'], $meta_operation );
+		}
+
+		homeboy_wordpress_bench_query_profiler_increment(
+			$profile['signatures'],
+			homeboy_wordpress_bench_query_profiler_signature( $query )
+		);
+
+		return $query;
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_metric' ) ) {
+	/**
+	 * Read a count from a profile section.
+	 *
+	 * @param array<string,mixed> $profile Query profile.
+	 * @param string              $section Section name.
+	 * @param string              $key Counter key.
+	 * @return int
+	 */
+	function homeboy_wordpress_bench_query_profiler_metric( array $profile, string $section, string $key ): int {
+		return (int) ( $profile[ $section ][ $key ] ?? 0 );
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_metric_per_item' ) ) {
+	/**
+	 * Read a count from a profile section divided by item count.
+	 *
+	 * @param array<string,mixed> $profile Query profile.
+	 * @param string              $section Section name.
+	 * @param string              $key Counter key.
+	 * @param int|float           $items Item count.
+	 * @return float
+	 */
+	function homeboy_wordpress_bench_query_profiler_metric_per_item( array $profile, string $section, string $key, $items ): float {
+		$items = max( 1, (float) $items );
+		return homeboy_wordpress_bench_query_profiler_metric( $profile, $section, $key ) / $items;
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_table_counts' ) ) {
+	/**
+	 * Return row counts for table names or labels mapped to table names.
+	 *
+	 * @param array<int|string,string> $tables Tables to count.
+	 * @return array<string,int>
+	 */
+	function homeboy_wordpress_bench_query_profiler_table_counts( array $tables ): array {
+		global $wpdb;
+
+		$counts = array();
+		foreach ( $tables as $label => $table ) {
+			$key = is_string( $label ) ? $label : homeboy_wordpress_bench_query_profiler_table_key( (string) $table );
+			if ( ! isset( $wpdb ) || ! homeboy_wordpress_bench_query_profiler_table_exists( (string) $table ) ) {
+				$counts[ $key ] = 0;
+				continue;
+			}
+			$counts[ $key ] = (int) $wpdb->get_var( 'SELECT COUNT(*) FROM `' . esc_sql( (string) $table ) . '`' );
+		}
+
+		return $counts;
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_count_deltas' ) ) {
+	/**
+	 * Return numeric after-before deltas for two count maps.
+	 *
+	 * @param array<string,int|float> $before Earlier counts.
+	 * @param array<string,int|float> $after Later counts.
+	 * @return array<string,int|float>
+	 */
+	function homeboy_wordpress_bench_query_profiler_count_deltas( array $before, array $after ): array {
+		$keys   = array_unique( array_merge( array_keys( $before ), array_keys( $after ) ) );
+		$deltas = array();
+		foreach ( $keys as $key ) {
+			$deltas[ $key ] = ( $after[ $key ] ?? 0 ) - ( $before[ $key ] ?? 0 );
+		}
+
+		return $deltas;
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_invariant' ) ) {
+	/**
+	 * Format an invariant failure when a condition is false.
+	 *
+	 * @param string              $name Invariant name.
+	 * @param bool                $passed Whether the invariant passed.
+	 * @param array<string,mixed> $context Failure context.
+	 * @return array<string,mixed>|null
+	 */
+	function homeboy_wordpress_bench_query_profiler_invariant( string $name, bool $passed, array $context = array() ): ?array {
+		if ( $passed ) {
+			return null;
+		}
+
+		return array(
+			'name'    => $name,
+			'context' => $context,
+		);
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_increment' ) ) {
+	/**
+	 * Increment a counter map key.
+	 *
+	 * @param array<string,int> $map Counter map.
+	 * @param string            $key Counter key.
+	 */
+	function homeboy_wordpress_bench_query_profiler_increment( array &$map, string $key ): void {
+		$map[ $key ] = (int) ( $map[ $key ] ?? 0 ) + 1;
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_operation' ) ) {
+	function homeboy_wordpress_bench_query_profiler_operation( string $query ): string {
+		if ( preg_match( '/^\s*(SELECT|INSERT|UPDATE|DELETE|REPLACE|ALTER|CREATE|DROP|SHOW)\b/i', $query, $match ) ) {
+			return strtolower( $match[1] );
+		}
+
+		return 'other';
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_tables' ) ) {
+	/**
+	 * Extract normalized table keys from common SQL clauses.
+	 *
+	 * @param string $query SQL query.
+	 * @return array<int,string>
+	 */
+	function homeboy_wordpress_bench_query_profiler_tables( string $query ): array {
+		$tables = array();
+		if ( preg_match_all( '/(?:FROM|JOIN|INTO|UPDATE|TABLE)\s+`?([a-zA-Z0-9_]+)`?/i', $query, $matches ) ) {
+			foreach ( $matches[1] as $table ) {
+				$tables[] = homeboy_wordpress_bench_query_profiler_table_key( $table );
+			}
+		}
+
+		$tables = array_values( array_unique( array_filter( $tables ) ) );
+		return empty( $tables ) ? array( 'unknown' ) : $tables;
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_table_key' ) ) {
+	function homeboy_wordpress_bench_query_profiler_table_key( string $table ): string {
+		global $wpdb;
+
+		$prefix = isset( $wpdb ) && isset( $wpdb->prefix ) ? (string) $wpdb->prefix : '';
+		if ( '' !== $prefix && 0 === strpos( $table, $prefix ) ) {
+			return substr( $table, strlen( $prefix ) );
+		}
+
+		return $table;
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_category' ) ) {
+	/**
+	 * Classify a query into generic WordPress bench evidence buckets.
+	 *
+	 * @param string              $query SQL query.
+	 * @param string              $operation SQL operation.
+	 * @param array<int,string>   $tables Normalized table keys.
+	 * @param array<string,mixed> $options Profiler options.
+	 * @return string
+	 */
+	function homeboy_wordpress_bench_query_profiler_category( string $query, string $operation, array $tables, array $options ): string {
+		if ( ! empty( $options['classifiers'] ) && is_array( $options['classifiers'] ) ) {
+			foreach ( $options['classifiers'] as $classifier ) {
+				if ( is_callable( $classifier ) ) {
+					$classified = $classifier( $query, $operation, $tables );
+					if ( is_string( $classified ) && '' !== $classified ) {
+						return $classified;
+					}
+				}
+			}
+		}
+
+		$first_table = $tables[0] ?? 'unknown';
+		if ( preg_match( '/_transient_[a-zA-Z0-9_\-]+/', $query ) ) {
+			return 'transient_option';
+		}
+		if ( false !== strpos( $query, 'actionscheduler_' ) ) {
+			return 'action_scheduler';
+		}
+		if ( 'postmeta' === $first_table && 'select' === $operation && preg_match( '/SELECT\s+meta_id\s+FROM/i', $query ) ) {
+			return 'meta_exists';
+		}
+		if ( 'postmeta' === $first_table && 'insert' === $operation ) {
+			return 'meta_insert';
+		}
+		if ( 'postmeta' === $first_table && 'update' === $operation ) {
+			return 'meta_update';
+		}
+		if ( 'postmeta' === $first_table ) {
+			return 'meta_read';
+		}
+		if ( in_array( 'terms', $tables, true ) || in_array( 'term_taxonomy', $tables, true ) || in_array( 'term_relationships', $tables, true ) ) {
+			return 'term_lookup';
+		}
+		if ( 'options' === $first_table ) {
+			return 'option';
+		}
+		if ( 'posts' === $first_table ) {
+			return 'post';
+		}
+
+		return 'other';
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_meta_operation' ) ) {
+	function homeboy_wordpress_bench_query_profiler_meta_operation( string $query, string $operation ): ?string {
+		if ( ! preg_match( '/meta_key\s*=\s*[\'\"]([^\'\"]+)[\'\"]/i', $query, $match ) ) {
+			if ( 'insert' === $operation && preg_match( '/INSERT\s+INTO\s+`?[a-zA-Z0-9_]*postmeta`?.*VALUES\s*\([^,]+,\s*[\'\"]([^\'\"]+)[\'\"]/i', $query, $match ) ) {
+				return 'insert:' . $match[1];
+			}
+			return null;
+		}
+
+		$meta_operation = $operation;
+		if ( 'select' === $operation && preg_match( '/SELECT\s+meta_id\s+FROM/i', $query ) ) {
+			$meta_operation = 'exists';
+		}
+
+		return $meta_operation . ':' . $match[1];
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_collect_named_values' ) ) {
+	function homeboy_wordpress_bench_query_profiler_collect_named_values( array &$map, string $query, string $pattern ): void {
+		if ( ! preg_match_all( $pattern, $query, $matches ) ) {
+			return;
+		}
+		foreach ( $matches[1] as $value ) {
+			homeboy_wordpress_bench_query_profiler_increment( $map, (string) $value );
+		}
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_signature' ) ) {
+	function homeboy_wordpress_bench_query_profiler_signature( string $query ): string {
+		$signature = preg_replace( '/\s+/', ' ', trim( $query ) );
+		$signature = preg_replace( '/\b\d+\b/', '?', (string) $signature );
+		$signature = preg_replace( "/'[^']*'/", '?', (string) $signature );
+		$signature = preg_replace( '/"[^"]*"/', '?', (string) $signature );
+
+		return substr( (string) $signature, 0, 220 );
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_top_counts' ) ) {
+	/**
+	 * Sort counts descending, then by key for deterministic ties, and truncate.
+	 *
+	 * @param array<string,int> $counts Counter map.
+	 * @param int               $limit Max entries.
+	 * @return array<string,int>
+	 */
+	function homeboy_wordpress_bench_query_profiler_top_counts( array $counts, int $limit ): array {
+		uksort(
+			$counts,
+			static function ( string $left, string $right ) use ( $counts ): int {
+				$left_count  = (int) $counts[ $left ];
+				$right_count = (int) $counts[ $right ];
+				if ( $left_count === $right_count ) {
+					return strcmp( $left, $right );
+				}
+				return $right_count <=> $left_count;
+			}
+		);
+
+		return array_slice( $counts, 0, $limit, true );
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_query_profiler_table_exists' ) ) {
+	function homeboy_wordpress_bench_query_profiler_table_exists( string $table ): bool {
+		global $wpdb;
+
+		if ( ! isset( $wpdb ) || ! method_exists( $wpdb, 'prepare' ) ) {
+			return false;
+		}
+
+		return (string) $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table;
+	}
+}

--- a/wordpress/scripts/bench/wordpress-db-query-profiler-smoke.php
+++ b/wordpress/scripts/bench/wordpress-db-query-profiler-smoke.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Lightweight smoke coverage for the WordPress DB query profiler helper.
+ */
+
+require_once __DIR__ . '/lib/wordpress-db-query-profiler.php';
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
+		unset( $hook_name, $callback, $priority, $accepted_args );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'remove_filter' ) ) {
+	function remove_filter( $hook_name, $callback, $priority = 10 ) {
+		unset( $hook_name, $callback, $priority );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'esc_sql' ) ) {
+	function esc_sql( $value ) {
+		return str_replace( '`', '', (string) $value );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, $flags = 0 ) {
+		return json_encode( $value, $flags ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- WordPress is stubbed in this smoke.
+	}
+}
+
+// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- The smoke uses a fake wpdb outside WordPress.
+$GLOBALS['wpdb'] = new class() {
+	public string $prefix   = 'wp_';
+	public string $posts    = 'wp_posts';
+	public string $postmeta = 'wp_postmeta';
+	public string $options  = 'wp_options';
+	public int $num_queries = 0;
+
+	public function prepare( string $query, ...$args ): string {
+		return vsprintf( str_replace( '%s', "'%s'", $query ), $args );
+	}
+
+	public function get_var( string $query ) {
+		unset( $query );
+		++$this->num_queries;
+		return 'wp_posts';
+	}
+};
+
+homeboy_wordpress_bench_query_profiler_start( 'smoke', array( 'top' => 10 ) );
+
+$queries = array(
+	"SELECT option_value FROM wp_options WHERE option_name = '_transient_smoke' LIMIT 1",
+	"SELECT meta_id FROM wp_postmeta WHERE post_id = 123 AND meta_key = '_smoke_key' LIMIT 1",
+	"INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES (123, '_smoke_key', 'one')",
+	"UPDATE wp_postmeta SET meta_value = 'two' WHERE post_id = 123 AND meta_key = '_smoke_key'",
+	"SELECT ID FROM wp_posts WHERE post_name = 'smoke' LIMIT 1",
+);
+
+foreach ( $queries as $query ) {
+	++$GLOBALS['wpdb']->num_queries;
+	homeboy_wordpress_bench_query_profiler_record_query( $query );
+}
+
+$profile = homeboy_wordpress_bench_query_profiler_stop();
+
+$assert = static function ( bool $condition, string $message ) use ( $profile ): void {
+	if ( $condition ) {
+		return;
+	}
+	error_log( "ERROR: {$message}\n" . wp_json_encode( $profile, JSON_PRETTY_PRINT ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- CLI smoke assertion output.
+	exit( 1 );
+};
+
+$assert( 'smoke' === $profile['label'], 'profile label was not preserved' );
+$assert( 5 === (int) $profile['query_count'], 'query_count did not match recorded queries' );
+$assert( 3 === homeboy_wordpress_bench_query_profiler_metric( $profile, 'tables', 'postmeta' ), 'postmeta table count missing' );
+$assert( 1 === homeboy_wordpress_bench_query_profiler_metric( $profile, 'categories', 'transient_option' ), 'transient category missing' );
+$assert( 1 === homeboy_wordpress_bench_query_profiler_metric( $profile, 'meta_key_operations', 'exists:_smoke_key' ), 'meta exists operation missing' );
+$assert( 1 === homeboy_wordpress_bench_query_profiler_metric( $profile, 'meta_key_operations', 'insert:_smoke_key' ), 'meta insert operation missing' );
+$assert( 1 === homeboy_wordpress_bench_query_profiler_metric( $profile, 'meta_key_operations', 'update:_smoke_key' ), 'meta update operation missing' );
+
+echo "WordPress DB query profiler smoke passed\n";

--- a/wordpress/scripts/bench/wp-codebox-bench-query-profiler-smoke.sh
+++ b/wordpress/scripts/bench/wp-codebox-bench-query-profiler-smoke.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# WP Codebox WordPress DB query profiler helper smoke test (homeboy-extensions#1213).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
+BASH_PREFLIGHT_HELPER="${HOMEBOY_RUNTIME_BASH_PREFLIGHT:-${HOMEBOY_CORE_DIR}/src/core/extension/runtime/bash-preflight.sh}"
+FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-query-profiler"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "ERROR: fixture not found at $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+if [ -z "${HOMEBOY_WP_CODEBOX_BIN:-}" ] && ! command -v wp-codebox >/dev/null 2>&1; then
+    echo "ERROR: wp-codebox not installed." >&2
+    echo "Set HOMEBOY_WP_CODEBOX_BIN or run wordpress/scripts/build/setup.sh" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq required for JSON assertions in this smoke." >&2
+    exit 1
+fi
+
+RESULTS_TMPFILE=$(mktemp "${TMPDIR:-/tmp}/bench-query-profiler-smoke.XXXXXX")
+
+cleanup() {
+    rm -f "$RESULTS_TMPFILE"
+}
+trap cleanup EXIT
+
+echo "============================================"
+echo "WP Codebox bench query profiler smoke test"
+echo "============================================"
+echo "Fixture:    $FIXTURE_DIR"
+echo "Iterations: 2 (per workload)"
+echo ""
+
+HOMEBOY_BENCH_RESULTS_FILE="$RESULTS_TMPFILE" \
+HOMEBOY_BENCH_ITERATIONS=2 \
+HOMEBOY_COMPONENT_ID=bench-query-profiler \
+HOMEBOY_COMPONENT_PATH="$FIXTURE_DIR" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_RUNTIME_BASH_PREFLIGHT="$BASH_PREFLIGHT_HELPER" \
+    bash "${SCRIPT_DIR}/bench-runner.sh"
+
+if [ ! -s "$RESULTS_TMPFILE" ]; then
+    echo "ERROR: results file empty or missing at $RESULTS_TMPFILE" >&2
+    exit 1
+fi
+
+echo ""
+echo "--- Results envelope ---"
+cat "$RESULTS_TMPFILE"
+echo ""
+
+query_profiler='.scenarios[] | select(.id == "query-profiler")'
+
+query_count=$(jq -r "$query_profiler | .metrics.query_count_mean // 0" "$RESULTS_TMPFILE")
+if ! jq -e --argjson value "$query_count" '$value > 0' >/dev/null; then
+    echo "ERROR: expected query_count_mean > 0, got ${query_count}" >&2
+    exit 1
+fi
+echo "✓ query_count_mean > 0"
+
+postmeta_queries=$(jq -r "$query_profiler | .metrics.postmeta_queries_mean // 0" "$RESULTS_TMPFILE")
+if ! jq -e --argjson value "$postmeta_queries" '$value > 0' >/dev/null; then
+    echo "ERROR: expected postmeta_queries_mean > 0, got ${postmeta_queries}" >&2
+    exit 1
+fi
+echo "✓ postmeta table queries captured"
+
+invariant_failures=$(jq -r "$query_profiler | .metrics.invariant_failure_count_mean // -1" "$RESULTS_TMPFILE")
+if [ "$invariant_failures" != "0" ]; then
+    echo "ERROR: expected invariant_failure_count_mean == 0, got ${invariant_failures}" >&2
+    exit 1
+fi
+echo "✓ profiler invariants passed"
+
+profile_label=$(jq -r "$query_profiler | .metadata.profile.label // \"missing\"" "$RESULTS_TMPFILE")
+if [ "$profile_label" != "wp-core-write-read" ]; then
+    echo "ERROR: expected metadata.profile.label == wp-core-write-read, got ${profile_label}" >&2
+    exit 1
+fi
+echo "✓ profile metadata attached"
+
+echo ""
+echo "============================================"
+echo "✓ WP Codebox query profiler smoke test PASSED"
+echo "============================================"

--- a/wordpress/tests/fixtures/bench-query-profiler/bench-query-profiler.php
+++ b/wordpress/tests/fixtures/bench-query-profiler/bench-query-profiler.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Plugin Name: Homeboy Bench Query Profiler Fixture
+ * Description: Fixture plugin for the WordPress DB query profiler bench helper.
+ */

--- a/wordpress/tests/fixtures/bench-query-profiler/tests/bench/query-profiler.php
+++ b/wordpress/tests/fixtures/bench-query-profiler/tests/bench/query-profiler.php
@@ -1,0 +1,81 @@
+<?php
+/** Workload that exercises the generic WordPress DB query profiler helper. */
+require_once '/homeboy-extension/scripts/bench/lib/wordpress-db-query-profiler.php';
+
+return function (): array {
+	global $wpdb;
+
+	$run_id = 'homeboy-query-profiler-' . getmypid() . '-' . time();
+	$tables_before = homeboy_wordpress_bench_query_profiler_table_counts(
+		array(
+			'posts'    => $wpdb->posts,
+			'postmeta' => $wpdb->postmeta,
+			'options'  => $wpdb->options,
+		)
+	);
+
+	$profiled = homeboy_wordpress_bench_query_profiler_profile_call(
+		'wp-core-write-read',
+		static function () use ( $run_id ): array {
+			update_option( $run_id . '_option', 'one', false );
+			set_transient( $run_id . '_transient', 'two', 60 );
+
+			$post_id = wp_insert_post(
+				array(
+					'post_title'   => 'Homeboy Query Profiler ' . $run_id,
+					'post_name'    => $run_id,
+					'post_status'  => 'publish',
+					'post_type'    => 'post',
+					'post_content' => 'Query profiler fixture.',
+				),
+				true
+			);
+			if ( is_wp_error( $post_id ) ) {
+				throw new RuntimeException( 'Failed to create profiler fixture post: ' . $post_id->get_error_message() );
+			}
+
+			add_post_meta( (int) $post_id, '_homeboy_profiler_key', 'first', true );
+			update_post_meta( (int) $post_id, '_homeboy_profiler_key', 'second' );
+			get_post_meta( (int) $post_id, '_homeboy_profiler_key', true );
+
+			return array( 'post_id' => (int) $post_id );
+		},
+		array( 'top' => 50 )
+	);
+
+	$profile      = $profiled['profile'];
+	$tables_after = homeboy_wordpress_bench_query_profiler_table_counts(
+		array(
+			'posts'    => $wpdb->posts,
+			'postmeta' => $wpdb->postmeta,
+			'options'  => $wpdb->options,
+		)
+	);
+	$deltas = homeboy_wordpress_bench_query_profiler_count_deltas( $tables_before, $tables_after );
+
+	$invariant_failures = array_values(
+		array_filter(
+			array(
+				homeboy_wordpress_bench_query_profiler_invariant( 'profile_saw_queries', (int) $profile['query_count'] > 0 ),
+				homeboy_wordpress_bench_query_profiler_invariant( 'post_row_created', (int) ( $deltas['posts'] ?? 0 ) >= 1, array( 'deltas' => $deltas ) ),
+				homeboy_wordpress_bench_query_profiler_invariant( 'postmeta_seen', homeboy_wordpress_bench_query_profiler_metric( $profile, 'tables', 'postmeta' ) > 0, array( 'tables' => $profile['tables'] ?? array() ) ),
+			)
+		)
+	);
+
+	return array(
+		'metrics'  => array(
+			'query_count'             => (int) $profile['query_count'],
+			'operation_select_queries'=> homeboy_wordpress_bench_query_profiler_metric( $profile, 'operations', 'select' ),
+			'postmeta_queries'        => homeboy_wordpress_bench_query_profiler_metric( $profile, 'tables', 'postmeta' ),
+			'option_queries'          => homeboy_wordpress_bench_query_profiler_metric( $profile, 'tables', 'options' ),
+			'transient_option_queries'=> homeboy_wordpress_bench_query_profiler_metric( $profile, 'categories', 'transient_option' ),
+			'invariant_failure_count' => count( $invariant_failures ),
+		),
+		'metadata' => array(
+			'profile'            => $profile,
+			'table_count_deltas' => $deltas,
+			'invariant_failures' => $invariant_failures,
+		),
+	);
+};


### PR DESCRIPTION
## Summary
- Adds `wordpress/scripts/bench/lib/wordpress-db-query-profiler.php`, a reusable WordPress bench helper that profiles SQL through the WordPress `query` filter without requiring `SAVEQUERIES`.
- Provides deterministic operation, table, category, option, meta-key, meta-operation, signature, row-count delta, invariant, and per-item metric helpers for BenchResults evidence.
- Adds non-WooCommerce smoke coverage plus a WP Codebox bench fixture/workload for full runner coverage when the local Codebox core module is available.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/1213

## Verification
- `npm run test:wordpress-db-query-profiler`
- `./vendor/bin/phpcs "scripts/bench/lib/wordpress-db-query-profiler.php" "scripts/bench/wordpress-db-query-profiler-smoke.php" "tests/fixtures/bench-query-profiler/bench-query-profiler.php" "tests/fixtures/bench-query-profiler/tests/bench/query-profiler.php"`
- `php -l "scripts/bench/lib/wordpress-db-query-profiler.php"`
- `php -l "tests/fixtures/bench-query-profiler/tests/bench/query-profiler.php"`

## Verification note
- `wordpress/scripts/bench/wp-codebox-bench-query-profiler-smoke.sh` is included but was not runnable in this local checkout because the WP Codebox recipe builder export was unavailable: `@automattic/wp-codebox-core` was not installed and `HOMEBOY_WP_CODEBOX_CORE_MODULE` was not set.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the reusable profiler helper, smoke coverage, and WP Codebox fixture, then ran targeted lint/smoke/syntax verification. Chris remains responsible for review and merge.