### PR TITLE
fix: improve host smoke diagnostics

### DIFF
--- a/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
+++ b/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
@@ -1,14 +1,16 @@
 /**
  * External dependencies
  */
-import { resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { existsSync, readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
+const RUNTIME_CORE_ENTRY = 'packages/runtime-core/dist/index.js';
 
 export async function loadCodeboxRecipeBuilder(requiredExport) {
 	const configuredModule = process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE;
-	const candidates = configuredModule ? [configuredModule] : [DEFAULT_CODEBOX_CORE_MODULE];
+	const candidates = configuredModule ? [configuredModule] : discoverCodeboxCoreModuleCandidates();
 	const errors = [];
 
 	for (const candidate of candidates) {
@@ -27,10 +29,57 @@ export async function loadCodeboxRecipeBuilder(requiredExport) {
 
 	throw new Error([
 		`WP Codebox recipe builder export ${requiredExport} is unavailable.`,
-		`Install a WP Codebox core module that exports ${requiredExport}, or set HOMEBOY_WP_CODEBOX_CORE_MODULE to its built ESM entrypoint.`,
+		`Install/build a WP Codebox runtime-core module that exports ${requiredExport}.`,
+		`Fallback: set HOMEBOY_WP_CODEBOX_CORE_MODULE to the built ESM entrypoint, for example /path/to/wp-codebox/${RUNTIME_CORE_ENTRY}.`,
 		'Homeboy Extensions no longer falls back to bundled WP Codebox recipe builders because that stale local copy can drift from the Codebox recipe contract.',
+		`Tried ${candidates.length} candidate(s):`,
 		...errors.map((error) => `- ${error}`),
 	].join('\n'));
+}
+
+function discoverCodeboxCoreModuleCandidates() {
+	const candidates = [DEFAULT_CODEBOX_CORE_MODULE];
+	const roots = workspaceRoots();
+
+	for (const root of roots) {
+		for (const repoPath of codeboxRepoCandidates(root)) {
+			const runtimeCore = resolve(repoPath, RUNTIME_CORE_ENTRY);
+			if (existsSync(runtimeCore) && !candidates.includes(runtimeCore)) {
+				candidates.push(runtimeCore);
+			}
+		}
+	}
+
+	return candidates;
+}
+
+function workspaceRoots() {
+	const scriptDir = dirname(fileURLToPath(import.meta.url));
+	const repoRoot = resolve(scriptDir, '../../..');
+	const roots = [
+		process.env.HOMEBOY_WORKSPACE_ROOT,
+		process.env.HOMEBOY_DEVELOPER_WORKSPACE,
+		dirname(repoRoot),
+	];
+
+	return [...new Set(roots.filter(Boolean))];
+}
+
+function codeboxRepoCandidates(root) {
+	const exact = resolve(root, 'wp-codebox');
+	const candidates = existsSync(exact) ? [exact] : [];
+
+	try {
+		const siblingWorktrees = readdirSync(root, { withFileTypes: true })
+			.filter((entry) => entry.isDirectory() && entry.name.startsWith('wp-codebox@'))
+			.map((entry) => resolve(root, entry.name))
+			.sort();
+		candidates.push(...siblingWorktrees);
+	} catch {
+		// A missing or unreadable workspace root simply contributes no candidates.
+	}
+
+	return candidates;
 }
 
 async function importModule(specifier) {

--- a/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
+++ b/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
@@ -73,6 +73,7 @@ FAKE_CODEBOX_CAPTURE_DIR="$CAPTURE_DIR" \
 
 assert_contains "${TMPDIR}/direct.out" "Backend: host-smoke-wp"
 assert_contains "${TMPDIR}/direct.out" "HOST_SMOKE_BEGIN:tests/alpha-smoke.php"
+assert_contains "${TMPDIR}/direct.out" "HOST_SMOKE_PROGRESS:tests/alpha-smoke.php:phase=recipe-created"
 assert_contains "${TMPDIR}/direct.out" "HOST_SMOKE_OK:tests/alpha-smoke.php"
 assert_contains "${TMPDIR}/direct.out" "HOST_SMOKE_SUMMARY:passed=1 failed=0"
 
@@ -109,6 +110,37 @@ if [ "$fail_exit" -eq 0 ]; then
     exit 1
 fi
 assert_contains "${TMPDIR}/direct-fail.out" "HOST_SMOKE_FAIL:tests/alpha-smoke.php"
+assert_contains "${TMPDIR}/direct-fail.out" "HOST_SMOKE_OUTPUT_BEGIN:tests/alpha-smoke.php"
+assert_contains "${TMPDIR}/direct-fail.out" "smoke threw"
+assert_contains "${TMPDIR}/direct-fail.out" "HOST_SMOKE_OUTPUT_END:tests/alpha-smoke.php:artifacts="
+
+# --- Timeout diagnostics: a hung recipe-run is bounded per file and reports the
+# phase/artifact directory before returning the conventional timeout status.
+FAKE_CODEBOX_HANG="${TMPDIR}/fake-wp-codebox-hang.cjs"
+cat > "$FAKE_CODEBOX_HANG" <<'JS'
+#!/usr/bin/env node
+'use strict';
+setTimeout(() => {}, 10000);
+JS
+
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_WP_CODEBOX_BIN="$FAKE_CODEBOX_HANG" \
+HOMEBOY_WORDPRESS_HOST_SMOKE_TIMEOUT_SECONDS=1 \
+FAKE_CODEBOX_CAPTURE_DIR="$CAPTURE_DIR" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner-host-smoke-wp.sh" > "${TMPDIR}/direct-timeout.out" 2>&1
+timeout_exit=$?
+set -e
+if [ "$timeout_exit" -ne 124 ]; then
+    echo "Expected real-WP smoke runner to exit 124 on timeout, got ${timeout_exit}" >&2
+    sed 's/^/  /' "${TMPDIR}/direct-timeout.out" >&2
+    exit 1
+fi
+assert_contains "${TMPDIR}/direct-timeout.out" "HOST_SMOKE_TIMEOUT:tests/alpha-smoke.php:phase=wp-codebox-recipe-run"
+assert_contains "${TMPDIR}/direct-timeout.out" "HOST_SMOKE_FAIL:tests/alpha-smoke.php:exit=124"
+assert_contains "${TMPDIR}/direct-timeout.out" "artifacts="
 
 # --- Routing: the dispatcher routes *-smoke.php to this real-WP smoke backend
 # purely by file type (no test_backend toggle). A --file smoke run goes straight

--- a/wordpress/scripts/test/test-runner-host-smoke-wp.sh
+++ b/wordpress/scripts/test/test-runner-host-smoke-wp.sh
@@ -39,6 +39,8 @@ TEST_DIR="${PLUGIN_PATH}/tests"
 PLUGIN_SLUG="${COMPONENT_ID:-$(basename "$PLUGIN_PATH")}"
 TARGET_SMOKE_FILE="${HOMEBOY_WORDPRESS_HOST_SMOKE_FILE:-}"
 TARGET_SMOKE_FILES="${HOMEBOY_WORDPRESS_HOST_SMOKE_FILES:-}"
+HOST_SMOKE_TIMEOUT_SECONDS="${HOMEBOY_WORDPRESS_HOST_SMOKE_TIMEOUT_SECONDS:-120}"
+HOST_SMOKE_EXCERPT_BYTES="${HOMEBOY_WORDPRESS_HOST_SMOKE_EXCERPT_BYTES:-65536}"
 
 homeboy_wordpress_host_smoke_abs() {
     local raw_path="$1"
@@ -148,14 +150,16 @@ run_one_smoke() {
     local smoke_file="$1"
     local rel_path="${smoke_file#"${PLUGIN_PATH}/"}"
     local sandbox_smoke_path="/wordpress/wp-content/plugins/${PLUGIN_SLUG}/${rel_path}"
-    local wrapper_file recipe_file output_file artifacts_dir status
+    local wrapper_file recipe_file output_file stderr_file artifacts_dir status started_at elapsed
 
-    wrapper_file="$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-smoke-wrapper.XXXXXX")"
-    recipe_file="$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-smoke-recipe.XXXXXX")"
-    output_file="$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-smoke-output.XXXXXX")"
     artifacts_dir="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-smoke-artifacts.XXXXXX")"
+    wrapper_file="${artifacts_dir}/wrapper.php"
+    recipe_file="${artifacts_dir}/recipe.json"
+    output_file="${artifacts_dir}/recipe-run.json"
+    stderr_file="${artifacts_dir}/wp-codebox.stderr"
 
     homeboy_wordpress_smoke_wrapper "$sandbox_smoke_path" > "$wrapper_file"
+    echo "HOST_SMOKE_PROGRESS:${rel_path}:phase=wrapper-created artifacts=${artifacts_dir}"
 
     jq -n \
         --arg wp "$WP_VERSION" \
@@ -167,24 +171,104 @@ run_one_smoke() {
             inputs: {mounts: $mounts},
             workflow: {steps: [{command: "wordpress.run-php", args: ["code-file=" + $codeFile]}]}
         }' > "$recipe_file"
+    echo "HOST_SMOKE_PROGRESS:${rel_path}:phase=recipe-created artifacts=${artifacts_dir}"
 
     set +e
-    "${WP_CODEBOX_COMMAND[@]}" recipe-run --recipe "$recipe_file" --artifacts "$artifacts_dir" --json > "$output_file" 2>/dev/null
+    started_at="$(date +%s)"
+    echo "HOST_SMOKE_PROGRESS:${rel_path}:phase=wp-codebox-recipe-run timeout=${HOST_SMOKE_TIMEOUT_SECONDS}s artifacts=${artifacts_dir}"
+    homeboy_wordpress_smoke_run_with_timeout "$output_file" "$stderr_file" \
+        "${WP_CODEBOX_COMMAND[@]}" recipe-run --recipe "$recipe_file" --artifacts "$artifacts_dir" --json
     status=$?
+    elapsed=$(( $(date +%s) - started_at ))
     set -e
+    echo "HOST_SMOKE_PROGRESS:${rel_path}:phase=output-parsing exit=${status} elapsed=${elapsed}s artifacts=${artifacts_dir}"
 
-    # Surface the smoke's own stdout (the OK / failure text) for the operator.
-    jq -r '(.executions // [])[-1].stdout // empty' "$output_file" 2>/dev/null || true
+    if [ "$status" -eq 124 ]; then
+        echo "HOST_SMOKE_TIMEOUT:${rel_path}:phase=wp-codebox-recipe-run elapsed=${elapsed}s timeout=${HOST_SMOKE_TIMEOUT_SECONDS}s artifacts=${artifacts_dir}"
+        homeboy_wordpress_smoke_print_failure_output "$rel_path" "$output_file" "$stderr_file" "$artifacts_dir"
+        return 124
+    fi
+
     if [ "$status" -eq 0 ] && ! jq -e '.success == true' "$output_file" >/dev/null 2>&1; then
         status=1
     fi
     if [ "$status" -ne 0 ]; then
-        jq -r '(.executions // [])[-1].stderr // empty' "$output_file" 2>/dev/null >&2 || true
+        homeboy_wordpress_smoke_print_failure_output "$rel_path" "$output_file" "$stderr_file" "$artifacts_dir"
+    else
+        jq -r '(.executions // [])[-1].stdout // empty' "$output_file" 2>/dev/null || true
+        rm -rf "$artifacts_dir"
     fi
 
-    rm -f "$wrapper_file" "$recipe_file" "$output_file"
-    rm -rf "$artifacts_dir"
     return "$status"
+}
+
+homeboy_wordpress_smoke_run_with_timeout() {
+    local output_file="$1"
+    local stderr_file="$2"
+    shift 2
+
+    node -e '
+        const fs = require("node:fs");
+        const { spawnSync } = require("node:child_process");
+        const [timeoutSeconds, stdoutFile, stderrFile, ...command] = process.argv.slice(1);
+        const result = spawnSync(command[0], command.slice(1), {
+            encoding: "utf8",
+            maxBuffer: 50 * 1024 * 1024,
+            timeout: Number(timeoutSeconds) * 1000,
+        });
+        fs.writeFileSync(stdoutFile, result.stdout || "");
+        fs.writeFileSync(stderrFile, result.stderr || "");
+        if (result.error && result.error.code === "ETIMEDOUT") {
+            process.exit(124);
+        }
+        if (result.error) {
+            fs.appendFileSync(stderrFile, `${result.error.message}\n`);
+            process.exit(1);
+        }
+        process.exit(result.status === null ? 1 : result.status);
+    ' "$HOST_SMOKE_TIMEOUT_SECONDS" "$output_file" "$stderr_file" "$@"
+}
+
+homeboy_wordpress_smoke_print_failure_output() {
+    local rel_path="$1"
+    local output_file="$2"
+    local stderr_file="$3"
+    local artifacts_dir="$4"
+    local smoke_stdout="${artifacts_dir}/smoke.stdout.txt"
+    local smoke_stderr="${artifacts_dir}/smoke.stderr.txt"
+
+    jq -r '(.executions // [])[-1].stdout // empty' "$output_file" > "$smoke_stdout" 2>/dev/null || true
+    jq -r '(.executions // [])[-1].stderr // empty' "$output_file" > "$smoke_stderr" 2>/dev/null || true
+
+    echo "HOST_SMOKE_OUTPUT_BEGIN:${rel_path}"
+    homeboy_wordpress_smoke_print_excerpt "stdout" "$smoke_stdout"
+    homeboy_wordpress_smoke_print_excerpt "stderr" "$smoke_stderr"
+    homeboy_wordpress_smoke_print_excerpt "wp-codebox-stderr" "$stderr_file"
+    if [ ! -s "$smoke_stdout" ] && [ ! -s "$smoke_stderr" ] && [ -s "$output_file" ]; then
+        homeboy_wordpress_smoke_print_excerpt "wp-codebox-json" "$output_file"
+    fi
+    echo "HOST_SMOKE_OUTPUT_END:${rel_path}:artifacts=${artifacts_dir}"
+}
+
+homeboy_wordpress_smoke_print_excerpt() {
+    local label="$1"
+    local file="$2"
+
+    [ -s "$file" ] || return 0
+    echo "--- ${label} (${file}) ---"
+    python3 - "$file" "$HOST_SMOKE_EXCERPT_BYTES" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+limit = int(sys.argv[2])
+data = path.read_bytes()
+sys.stdout.buffer.write(data[:limit])
+if data and not data.endswith(b"\n"):
+    sys.stdout.write("\n")
+if len(data) > limit:
+    sys.stdout.write(f"[truncated {len(data) - limit} bytes; full output retained at {path}]\n")
+PY
 }
 
 echo "Running real-WordPress smoke tests..."
@@ -233,6 +317,7 @@ RECIPE_MOUNTS="$(homeboy_wordpress_smoke_recipe_mounts)"
 
 echo "  Files: ${#smoke_files[@]}"
 echo "  WordPress: ${WP_VERSION:-default}"
+echo "  Per-file timeout: ${HOST_SMOKE_TIMEOUT_SECONDS}s"
 echo ""
 
 passed=0

--- a/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
@@ -1,5 +1,7 @@
 const assert = require('node:assert/strict');
 const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const script = path.join(__dirname, '..', 'scripts', 'test', 'build-wp-codebox-phpunit-recipe.mjs');
@@ -52,6 +54,26 @@ const diagnosticResult = spawnSync(process.execPath, [script], {
 assert.notEqual(diagnosticResult.status, 0);
 assert.match(diagnosticResult.stderr, /WP Codebox recipe builder export buildWordPressPhpunitRecipe is unavailable/);
 assert.match(diagnosticResult.stderr, /no longer falls back to bundled WP Codebox recipe builders/);
+assert.match(diagnosticResult.stderr, /HOMEBOY_WP_CODEBOX_CORE_MODULE/);
 assert.match(diagnosticResult.stderr, /\/missing\/wp-codebox-core\.mjs/);
+
+const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-workspace-'));
+const discoveredModule = path.join(workspaceRoot, 'wp-codebox', 'packages', 'runtime-core', 'dist', 'index.js');
+fs.mkdirSync(path.dirname(discoveredModule), { recursive: true });
+fs.copyFileSync(fixtureCoreModule, discoveredModule);
+
+const discoveredResult = spawnSync(process.execPath, [script], {
+	cwd: path.join(__dirname, '..'),
+	input: JSON.stringify(input),
+	encoding: 'utf8',
+	env: {
+		...process.env,
+		HOMEBOY_WORKSPACE_ROOT: workspaceRoot,
+		HOMEBOY_WP_CODEBOX_CORE_MODULE: '',
+	},
+});
+
+assert.equal(discoveredResult.status, 0, discoveredResult.stderr);
+assert.equal(JSON.parse(discoveredResult.stdout).schema, 'wp-codebox/workspace-recipe/v1');
 
 console.log('wp-codebox phpunit recipe builder smoke passed');


### PR DESCRIPTION
## Summary
- Print captured stdout/stderr excerpts and retained artifact paths when real-WordPress host smokes fail.
- Add per-file timeout/progress markers around wrapper creation, recipe creation, WP Codebox execution, and output parsing.
- Auto-discover sibling WP Codebox runtime-core builds before falling back to an explicit `HOMEBOY_WP_CODEBOX_CORE_MODULE` diagnostic.

## Tracked Issues
- Addresses Extra-Chill/homeboy#3807
- Addresses Extra-Chill/homeboy#3808
- Addresses Extra-Chill/homeboy#3809

## Testing
- `bash scripts/test/host-smoke-wp-runner-smoke.sh`
- `node tests/wp-codebox-phpunit-recipe-builder-smoke.js`
- `node tests/wp-codebox-bench-recipe-builder-smoke.js`
- `bash -n scripts/test/test-runner-host-smoke-wp.sh scripts/test/host-smoke-wp-runner-smoke.sh`
- `node --check scripts/bench/wp-codebox-recipe-builder-loader.mjs && node --check tests/wp-codebox-phpunit-recipe-builder-smoke.js`
- `npm run lint:js -- scripts/bench/wp-codebox-recipe-builder-loader.mjs --no-warn-ignored`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the host-smoke diagnostics, WP Codebox runtime-core discovery, and smoke coverage; Chris remains responsible for review and merge.