### PR TITLE
Explain missing WP Codebox core module setup

### DIFF
--- a/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
+++ b/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
@@ -30,7 +30,9 @@ export async function loadCodeboxRecipeBuilder(requiredExport) {
 	throw new Error([
 		`WP Codebox recipe builder export ${requiredExport} is unavailable.`,
 		`Install/build a WP Codebox runtime-core module that exports ${requiredExport}.`,
-		`Fallback: set HOMEBOY_WP_CODEBOX_CORE_MODULE to the built ESM entrypoint, for example /path/to/wp-codebox/${RUNTIME_CORE_ENTRY}.`,
+		`Pass --setting wp_codebox_core_module=/path/to/wp-codebox/${RUNTIME_CORE_ENTRY}, or set HOMEBOY_WP_CODEBOX_CORE_MODULE to that built ESM entrypoint.`,
+		`Fallback discovery also checks sibling wp-codebox checkouts for ${RUNTIME_CORE_ENTRY}.`,
+		'This is separate from HOMEBOY_WP_CODEBOX_BIN / wp_codebox_bin, which only selects the wp-codebox CLI.',
 		'Homeboy Extensions no longer falls back to bundled WP Codebox recipe builders because that stale local copy can drift from the Codebox recipe contract.',
 		`Tried ${candidates.length} candidate(s):`,
 		...errors.map((error) => `- ${error}`),

--- a/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
@@ -61,6 +61,9 @@ const diagnosticResult = spawnSync(process.execPath, [script], {
 
 assert.notEqual(diagnosticResult.status, 0);
 assert.match(diagnosticResult.stderr, /WP Codebox recipe builder export buildWordPressBenchRecipe is unavailable/);
+assert.match(diagnosticResult.stderr, /--setting wp_codebox_core_module=\/path\/to\/wp-codebox\/packages\/runtime-core\/dist\/index\.js/);
+assert.match(diagnosticResult.stderr, /HOMEBOY_WP_CODEBOX_CORE_MODULE/);
+assert.match(diagnosticResult.stderr, /HOMEBOY_WP_CODEBOX_BIN \/ wp_codebox_bin/);
 assert.match(diagnosticResult.stderr, /no longer falls back to bundled WP Codebox recipe builders/);
 assert.match(diagnosticResult.stderr, /\/missing\/wp-codebox-core\.mjs/);
 

--- a/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
@@ -53,6 +53,7 @@ const diagnosticResult = spawnSync(process.execPath, [script], {
 
 assert.notEqual(diagnosticResult.status, 0);
 assert.match(diagnosticResult.stderr, /WP Codebox recipe builder export buildWordPressPhpunitRecipe is unavailable/);
+assert.match(diagnosticResult.stderr, /--setting wp_codebox_core_module=\/path\/to\/wp-codebox\/packages\/runtime-core\/dist\/index\.js/);
 assert.match(diagnosticResult.stderr, /no longer falls back to bundled WP Codebox recipe builders/);
 assert.match(diagnosticResult.stderr, /HOMEBOY_WP_CODEBOX_CORE_MODULE/);
 assert.match(diagnosticResult.stderr, /\/missing\/wp-codebox-core\.mjs/);


### PR DESCRIPTION
## Summary
- Expands missing WP Codebox recipe-builder diagnostics to name the `wp_codebox_core_module` setting and `HOMEBOY_WP_CODEBOX_CORE_MODULE` env var.
- Distinguishes the recipe-builder module from `HOMEBOY_WP_CODEBOX_BIN` / `wp_codebox_bin`, which only selects the CLI.
- Tightens bench and phpunit recipe-builder smokes around the setup hint.

Fixes #1215

## Testing
- `node --check wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js`
- `node --check wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs`
- `node wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js`
- `node wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the diagnostic text and smoke assertions; Chris remains responsible for review and merge.