### PR TITLE
Pass agent-task secrets through Codebox executor

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -181,6 +181,11 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const runtimeTask = inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || options.runtimeTask;
   const sandboxToolPolicy = firstDefined(inputs.sandbox_tool_policy, inputs.sandboxToolPolicy, config.sandbox_tool_policy, config.sandboxToolPolicy, options.sandboxToolPolicy, defaults.sandboxToolPolicy);
   const allowedTools = firstDefined(inputs.allowed_tools, inputs.allowedTools, config.allowed_tools, config.allowedTools, options.allowedTools, defaults.allowedTools);
+  const explicitSecretEnv = [
+    ...normalizeArray(request.executor?.secret_env),
+    ...normalizeArray(config.secret_env),
+    ...normalizeArray(options.secretEnv),
+  ];
   const timeoutSeconds = request.limits?.task_timeout_seconds || request.limits?.taskTimeoutSeconds;
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
   const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
@@ -216,7 +221,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
     runtime_overlay_profiles: config.runtime_overlay_profiles || config.runtimeOverlayProfiles || options.runtimeOverlayProfiles || defaults.runtimeOverlayProfiles || [],
     runtime_overlays: config.runtime_overlays || options.runtimeOverlays || [],
-    secret_env: config.secret_env || options.secretEnv || defaults.secretEnv || [],
+    secret_env: explicitSecretEnv.length > 0 ? Array.from(new Set(explicitSecretEnv)) : defaults.secretEnv || [],
     // Post-agent verification gate (recipe workflow.after). Supplied as WP
     // Codebox recipe steps; a non-zero exit fails the run so the orchestrator
     // refuses to report success until the gates are green.
@@ -230,7 +235,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     homeboy_path: config.homeboy || config.homeboy_path || options.homeboy || '',
     homeboy_extensions_path: config.homeboy_extensions || config.homeboy_extensions_path || options.homeboyExtensions || '',
     wp_codebox_bin: config.wp_codebox_bin || options.wpCodeboxBin || '',
-    wp: config.wp_codebox_wordpress_version || config.wpCodeboxWordpressVersion || options.wpCodeboxWordpressVersion || '',
+    wp: config.wp_codebox_wordpress_version || config.wpCodeboxWordpressVersion || config.wp || config.wordpress_version || options.wpCodeboxWordpressVersion || '',
     artifacts_path: config.artifacts || config.artifacts_path || options.artifacts || '',
     max_turns: config.max_turns || options.maxTurns,
     task_timeout_seconds: config.task_timeout_seconds || timeoutSeconds || timeoutFromMs || options.taskTimeoutSeconds,

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -253,6 +253,31 @@ assert.equal(codeboxRequest.orchestrator.agent_task_id, 'task-123');
 assert.equal(codeboxRequest.context.audit_findings[0].id, 'finding-1');
 assert.deepEqual(codeboxRequest.agent_bundle, {});
 
+const executorSecretEnvRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'executor-secret-env-task-123',
+  executor: {
+    backend: 'codebox',
+    model: 'claude-sonnet-4-6',
+    secret_env: [
+      'AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN',
+      'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN',
+      'AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT',
+    ],
+    config: {
+      provider: 'claude-code',
+      wp: '7.0',
+      provider_plugin_paths: ['/providers/claude-code'],
+    },
+  },
+});
+assert.deepEqual(executorSecretEnvRequest.secret_env, [
+  'AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN',
+  'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN',
+  'AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT',
+]);
+assert.equal(executorSecretEnvRequest.wp, '7.0');
+
 const runtimeTaskRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
   task_id: 'runtime-task-123',


### PR DESCRIPTION
## Summary
- Passes `request.executor.secret_env` through the WordPress Codebox executor so Homeboy `agent-task loop --secret-env` reaches WP Codebox `agent-task-run` input.
- Allows provider config `wp` / `wordpress_version` to set the WP Codebox WordPress version override.
- Adds smoke coverage for Claude Code-shaped executor secret env and `wp` propagation.

## Testing
- `npm run test:codebox-agent-task-executor`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Homeboy/WP Codebox loop blocker, drafted the executor fix and smoke test; Chris reviews and owns the change.