### PR TITLE
Fix WooCommerce PHPUnit preparation in WP Codebox

### DIFF
--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -333,6 +333,166 @@ compile_phpunit_bootstrap_files() {
 
 compile_phpunit_bootstrap_files
 
+compile_phpunit_prepare_steps() {
+    local settings_json="${HOMEBOY_SETTINGS_JSON:-}"
+    [ -n "$settings_json" ] || settings_json="{}"
+    local steps_json
+    steps_json=$(printf '%s' "$settings_json" | jq -c '
+        .wp_codebox_prepare_steps // []
+        | if type == "array" then . else [] end
+    ' 2>/dev/null || echo '[]')
+
+    WP_CODEBOX_PREPARE_STEPS_JSON="[]"
+    if ! printf '%s' "$steps_json" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if ! printf '%s' "$steps_json" | jq -e '
+        all(.[];
+            type == "object"
+            and (.command | type == "string" and . != "")
+            and ((.args // []) | type == "array" and all(.[]; type == "string"))
+            and ((.cwd // "") | type == "string")
+        )
+    ' >/dev/null 2>&1; then
+        echo "Error: wp_codebox_prepare_steps entries require command plus optional string args and cwd." >&2
+        FAILED_STEP="WP Codebox PHPUnit prepare setup"
+        exit 1
+    fi
+
+    WP_CODEBOX_PREPARE_STEPS_JSON="$steps_json"
+}
+
+apply_phpunit_component_prepare_profile() {
+    case "$PLUGIN_SLUG" in
+        woocommerce)
+            if [ -f "${PLUGIN_PATH}/bin/generate-feature-config.php" ]; then
+                WP_CODEBOX_PREPARE_STEPS_JSON=$(jq -nc \
+                    --argjson steps "$WP_CODEBOX_PREPARE_STEPS_JSON" \
+                    '$steps + [{command: "php", args: ["bin/generate-feature-config.php"]}]')
+            fi
+            ;;
+    esac
+}
+
+phpunit_prepare_step_cwd() {
+    local cwd_ref="${1:-}"
+    local cwd_host
+
+    if [ -z "$cwd_ref" ]; then
+        printf '%s\n' "$PLUGIN_PATH"
+        return 0
+    fi
+    if [[ "$cwd_ref" = /* ]] || [[ "$cwd_ref" == *..* ]]; then
+        return 1
+    fi
+
+    cwd_host="${PLUGIN_PATH}/${cwd_ref}"
+    case "$cwd_host" in
+        "$PLUGIN_PATH"|"$PLUGIN_PATH"/*)
+            [ -d "$cwd_host" ] || return 1
+            printf '%s\n' "$cwd_host"
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+emit_phpunit_prepare_failure_diagnostic() {
+    local step_index="$1"
+    local command_name="$2"
+    local cwd_host="$3"
+    local output_file="$4"
+    local exit_code="$5"
+    local diagnostics_file="${ARTIFACTS_DIR}/wp-codebox-phpunit-prepare-diagnostics.json"
+    local output_artifact="${ARTIFACTS_DIR}/wp-codebox-phpunit-prepare-step-${step_index}-output.txt"
+
+    mkdir -p "$ARTIFACTS_DIR"
+    cp "$output_file" "$output_artifact"
+
+    jq -n \
+        --arg schema "homeboy/wordpress-phpunit-diagnostic/v1" \
+        --arg code "wp-codebox-phpunit-prepare-failed" \
+        --arg message "WP Codebox PHPUnit prepare step failed before the plugin was mounted into WordPress." \
+        --arg command "$command_name" \
+        --arg cwd "$cwd_host" \
+        --argjson stepIndex "$step_index" \
+        --argjson exitCode "$exit_code" \
+        --arg artifactsDir "$ARTIFACTS_DIR" \
+        --arg outputArtifact "$output_artifact" \
+        '{
+            schema: $schema,
+            diagnostics: [{
+                code: $code,
+                severity: "error",
+                phase: "prepare",
+                message: $message,
+                step_index: $stepIndex,
+                command: $command,
+                cwd: $cwd,
+                exit_code: $exitCode,
+                artifacts: {
+                    directory: $artifactsDir,
+                    output: $outputArtifact
+                }
+            }]
+        }' > "$diagnostics_file"
+
+    echo "WP Codebox PHPUnit prepare step failed before plugin runtime launch." >&2
+    echo "  Step: ${step_index}" >&2
+    echo "  Command: ${command_name}" >&2
+    echo "  CWD: ${cwd_host}" >&2
+    echo "  Exit code: ${exit_code}" >&2
+    echo "  Diagnostics: ${diagnostics_file}" >&2
+    echo "  Raw output: ${output_artifact}" >&2
+}
+
+run_phpunit_prepare_steps() {
+    if ! printf '%s' "$WP_CODEBOX_PREPARE_STEPS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+        return 0
+    fi
+
+    local index=0
+    local step_json command_name cwd_ref cwd_host output_file exit_code
+    while IFS= read -r step_json; do
+        command_name=$(printf '%s' "$step_json" | jq -r '.command')
+        cwd_ref=$(printf '%s' "$step_json" | jq -r '.cwd // empty')
+        if ! cwd_host=$(phpunit_prepare_step_cwd "$cwd_ref"); then
+            echo "Error: wp_codebox_prepare_steps[$index].cwd must be a directory under component root." >&2
+            FAILED_STEP="WP Codebox PHPUnit prepare setup"
+            exit 1
+        fi
+
+        output_file=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-phpunit-prepare-${index}.XXXXXX")
+        echo "Preparing WordPress PHPUnit plugin source: ${command_name}" >&2
+        set +e
+        (
+            cd "$cwd_host"
+            step_args=()
+            while IFS= read -r step_arg; do
+                step_args+=("$step_arg")
+            done < <(printf '%s' "$step_json" | jq -r '(.args // [])[]')
+            "$command_name" "${step_args[@]}"
+        ) >"$output_file" 2>&1
+        exit_code=$?
+        set -e
+
+        if [ "$exit_code" -ne 0 ]; then
+            emit_phpunit_prepare_failure_diagnostic "$index" "$command_name" "$cwd_host" "$output_file" "$exit_code"
+            rm -f "$output_file"
+            FAILED_STEP="WP Codebox PHPUnit prepare step"
+            exit "$exit_code"
+        fi
+
+        rm -f "$output_file"
+        index=$((index + 1))
+    done < <(printf '%s' "$WP_CODEBOX_PREPARE_STEPS_JSON" | jq -c '.[]')
+}
+
+compile_phpunit_prepare_steps
+apply_phpunit_component_prepare_profile
+
 detect_phpunit_project_bootstrap() {
     local config_file
     for config_file in "${PLUGIN_PATH}/phpunit.xml" "${PLUGIN_PATH}/phpunit.xml.dist"; do
@@ -595,6 +755,8 @@ fi
 if [ -z "$ARTIFACTS_DIR" ]; then
     ARTIFACTS_DIR=$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-test-artifacts.XXXXXX")
 fi
+
+run_phpunit_prepare_steps
 
 echo "Running PHPUnit tests via WP Codebox..."
 echo "  Plugin: ${PLUGIN_SLUG} (${PLUGIN_PATH})"

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1062,10 +1062,10 @@
     },
     {
       "id": "wp_codebox_prepare_steps",
-      "label": "WP Codebox bench prepare steps",
+      "label": "WP Codebox prepare steps",
       "type": "array",
       "default": [],
-      "description": "Explicit host-side commands to run before WP Codebox mounts and loads the plugin for wordpress.bench. Each step is an object with command, optional string args, and optional component-relative cwd. Use this for bounded source-checkout generation such as WooCommerce feature config files; no package scripts run implicitly."
+      "description": "Explicit host-side commands to run before WP Codebox mounts and loads the plugin for wordpress.bench or wordpress.phpunit. Each step is an object with command, optional string args, and optional component-relative cwd. Use this for bounded source-checkout generation such as WooCommerce feature config files; no package scripts run implicitly."
     },
     {
       "id": "wp_codebox_scenario_manifests",


### PR DESCRIPTION
## Summary
- Run WP Codebox PHPUnit prepare steps before mounting/loading the plugin, matching the host-side preparation path already available to bench workflows.
- Add a WooCommerce PHPUnit prepare profile that generates `includes/react-admin/feature-config.php` when `bin/generate-feature-config.php` exists.
- Update the `wp_codebox_prepare_steps` setting description so it covers both `wordpress.bench` and `wordpress.phpunit`.

## Verification
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh`
- `node tests/wp-codebox-phpunit-recipe-builder-smoke.js`
- `homeboy test --runner homeboy-lab --force-hot --extension wordpress --path "/Users/chubes/Developer/woocommerce@fix-rest-variation-slug-collisions/plugins/woocommerce" woocommerce -- tests/legacy/unit-tests/product/data-store.php`
  - Result: `37 passed, 0 failed, 0 skipped`
  - Evidence: runner output included `Preparing WordPress PHPUnit plugin source: php`, then `OK (37 tests, 147 assertions)`

## Context
This completes the WP Codebox PHPUnit path for WooCommerce after `wp-codebox v0.8.1` added recipe/runtime support. Without this extension-side preparation, Woo's project bootstrap fails before tests run because `includes/react-admin/feature-config.php` is generated and ignored by git.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the WordPress extension runner patch, ran targeted validation, and drafted this PR description for Chris to review.