### PR TITLE
Fix WP Codebox sandbox tool policy metadata

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -557,6 +557,7 @@ function sandboxToolPolicy(input, allowedTools) {
             execution_location: 'sandbox',
             transport_visibility: 'sandbox',
             allowed: true,
+            runtime: { environment: 'runtime_local', capability_scope: 'runtime_local' },
             metadata: { source: 'homeboy_allowed_tools' },
           };
         })
@@ -566,6 +567,7 @@ function sandboxToolPolicy(input, allowedTools) {
           execution_location: 'external',
           transport_visibility: 'hidden',
           allowed: false,
+          runtime: { environment: 'control_plane', capability_scope: 'control_plane' },
           metadata: { source: 'homeboy_default_empty_policy' },
         }],
     metadata: { source: 'homeboy-wp-codebox-task-runner' },

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -219,6 +219,8 @@ try {
   assert.equal(captured.input.sandbox_tool_policy.version, 1);
   assert.equal(captured.input.sandbox_tool_policy.tools[0].id, 'homeboy/no-runtime-tools');
   assert.equal(captured.input.sandbox_tool_policy.tools[0].allowed, false);
+  assert.equal(captured.input.sandbox_tool_policy.tools[0].runtime.environment, 'control_plane');
+  assert.equal(captured.input.sandbox_tool_policy.tools[0].runtime.capability_scope, 'control_plane');
   assert.equal(captured.input.provider, 'opencode');
   assert.equal(captured.input.model, 'opencode-go/kimi-k2.6');
   assert.deepEqual(captured.input.secret_env, ['OPENCODE_API_KEY']);
@@ -382,6 +384,8 @@ try {
   assert.equal(agentBundleCapture.input.sandbox_tool_policy.tools.length, 1);
   assert.equal(agentBundleCapture.input.sandbox_tool_policy.tools[0].id, 'homeboy/no-runtime-tools');
   assert.equal(agentBundleCapture.input.sandbox_tool_policy.tools[0].allowed, false);
+  assert.equal(agentBundleCapture.input.sandbox_tool_policy.tools[0].runtime.environment, 'control_plane');
+  assert.equal(agentBundleCapture.input.sandbox_tool_policy.tools[0].runtime.capability_scope, 'control_plane');
   assert.equal(agentBundleCapture.input.agent_bundle.engine_data_outputs.issue_number, 'metadata.engine_data.store_idea_agent.issue_number');
   assert.equal(agentBundleCapture.input.runtime_task.ability, 'datamachine/run-agent-bundle');
   assert.equal(agentBundleCapture.input.runtime_task.input.source, '/workspace/wp-site-generator/bundles/store-idea-agent');


### PR DESCRIPTION
## Summary
- Include required runtime metadata on generated WP Codebox sandbox tool policy entries.
- Mark generated allowed tools as `runtime_local` and the hidden no-runtime-tools denial as `control_plane` so WP Codebox validation accepts the request.
- Add smoke assertions for the default no-runtime-tools policy used by agent bundle runs.

## Verification
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- Full Lab plan `site-generation-loop-controller-after-output-parser` completed with 6 succeeded, 0 failed, 0 skipped after relinking the Lab runner to this fixed extension snapshot.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the WP Codebox validation failure from preserved task input, drafted the sandbox policy metadata fix and smoke assertions, and ran verification; Chris reviewed and directed the Lab proof.