### PR TITLE
Add context repository inputs to Data Machine agent CI

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -66,6 +66,18 @@ name: Data Machine Agent CI (reusable)
         description: Comma-separated additional OWNER/REPO or OWNER/REPO@REF entries checked out under .ci/<repo>. Entries without @REF use the repository default branch.
         type: string
         default: ""
+      context_repositories:
+        description: JSON array of read-only DMC context repositories. Each entry is {repo, ref, alias, paths} where paths is optional.
+        type: string
+        default: "[]"
+      verification_commands:
+        description: JSON array of deterministic shell commands to run in the target workspace after the agent run. Entries may be strings or {command, description} objects.
+        type: string
+        default: "[]"
+      drift_checks:
+        description: JSON array of generated-output drift checks to run in the target workspace after verification. Entries may be strings or {command, description} objects.
+        type: string
+        default: "[]"
       include_agent_runtime_dependencies:
         description: "Include the standard WordPress agent runtime stack: Agents API, Data Machine, and Data Machine Code."
         type: boolean
@@ -365,9 +377,19 @@ jobs:
         env:
           APP_TOKEN_REPOS: ${{ inputs.app_token_repos }}
           TARGET_REPO: ${{ inputs.target_repo }}
+          CONTEXT_REPOSITORIES: ${{ inputs.context_repositories }}
         run: |
           set -euo pipefail
+          context_repos="$(printf '%s' "$CONTEXT_REPOSITORIES" | jq -r '
+            if (gsub("^\\s+|\\s+$"; "") | length) == 0 then [] else fromjson end
+            | if type == "array" then . else error("context_repositories must be a JSON array") end
+            | .[]
+            | if type == "object" and (.repo? | type == "string") and (.repo | test("^[^/[:space:]]+/[^/[:space:]]+$")) then .repo else error("context_repositories entries require repo as OWNER/REPO") end
+          ' | paste -sd, -)"
           repos_input="${APP_TOKEN_REPOS:-$TARGET_REPO}"
+          if [ -z "$APP_TOKEN_REPOS" ] && [ -n "$context_repos" ]; then
+            repos_input="${repos_input},${context_repos}"
+          fi
           IFS=',' read -ra entries <<< "$repos_input"
           owner=""
           repositories=()
@@ -416,6 +438,7 @@ jobs:
           APP_TOKEN_REPOSITORIES: ${{ steps.token-scope.outputs.repositories }}
           APP_TOKEN_REPOS_INPUT: ${{ inputs.app_token_repos }}
           TARGET_REPO: ${{ inputs.target_repo }}
+          CONTEXT_REPOSITORIES: ${{ inputs.context_repositories }}
           REQUIRE_HOMEBOY_APP_TOKEN: ${{ inputs.require_homeboy_app_token }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
@@ -440,6 +463,8 @@ jobs:
             printf -- '- Target repository: `%s`\n' "$TARGET_REPO"
             printf -- '- Token scope: `%s`\n' "$token_scope"
             printf -- '- Homeboy App token repos input: `%s`\n' "${APP_TOKEN_REPOS_INPUT:-default target_repo}"
+            context_count="$(printf '%s' "$CONTEXT_REPOSITORIES" | jq -r 'if (gsub("^\\s+|\\s+$"; "") | length) == 0 then [] else fromjson end | length')"
+            printf -- '- Context repositories: `%s`\n' "$context_count"
             printf -- '- Require Homeboy App token: `%s`\n' "$REQUIRE_HOMEBOY_APP_TOKEN"
             printf -- '- Note: %s\n' "$token_note"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -642,6 +667,9 @@ jobs:
           BUNDLE_REF: ${{ inputs.bundle_ref }}
           BUNDLE_PATH_IN_REPO: ${{ inputs.bundle_path_in_repo }}
           TARGET_REPO: ${{ inputs.target_repo }}
+          CONTEXT_REPOSITORIES: ${{ inputs.context_repositories }}
+          VERIFICATION_COMMANDS: ${{ inputs.verification_commands }}
+          DRIFT_CHECKS: ${{ inputs.drift_checks }}
           PROMPT: ${{ inputs.prompt }}
           PROVIDER: ${{ inputs.provider }}
           MODEL: ${{ inputs.model }}
@@ -756,6 +784,39 @@ jobs:
               return 1
             fi
           }
+          context_repositories_json="$(printf '%s' "$CONTEXT_REPOSITORIES" | jq -Rse '
+            if (gsub("^\\s+|\\s+$"; "") | length) == 0 then [] else fromjson end
+            | if type == "array" then . else error("expected array, got " + type) end
+            | map(
+                if type != "object" then error("context_repositories entries must be objects") else . end
+                | .repo as $repo
+                | if ($repo | type) != "string" or ($repo | test("^[^/[:space:]]+/[^/[:space:]]+$") | not) then error("context_repositories[].repo must be OWNER/REPO") else . end
+                | .alias as $alias
+                | if has("alias") and (($alias | type) != "string" or ($alias | test("^[A-Za-z0-9][A-Za-z0-9._-]*$") | not)) then error("context_repositories[].alias must be a stable slug") else . end
+                | .ref as $ref
+                | if has("ref") and (($ref | type) != "string" or ($ref | length) == 0) then error("context_repositories[].ref must be a non-empty string") else . end
+                | .paths as $paths
+                | if has("paths") and (($paths | type) != "array" or any($paths[]; type != "string" or length == 0)) then error("context_repositories[].paths must be an array of non-empty strings") else . end
+                | {repo, ref: (.ref // ""), alias: (.alias // (.repo | split("/")[1])), paths: (.paths // [])}
+              )
+          ')"
+          normalize_command_list() {
+            local name="$1"
+            local value="$2"
+            printf '%s' "$value" | jq -Rse --arg name "$name" '
+              if (gsub("^\\s+|\\s+$"; "") | length) == 0 then [] else fromjson end
+              | if type == "array" then . else error($name + " must be a JSON array") end
+              | map(
+                  if type == "string" then {command: ., description: ""}
+                  elif type == "object" then {command: (.command // ""), description: (.description // "")}
+                  else error($name + " entries must be strings or objects") end
+                  | if (.command | type) != "string" or (.command | length) == 0 then error($name + " entries require a non-empty command") else . end
+                  | if (.description | type) != "string" then error($name + " descriptions must be strings") else . end
+                )
+            '
+          }
+          verification_commands_json="$(normalize_command_list verification_commands "$VERIFICATION_COMMANDS")"
+          drift_checks_json="$(normalize_command_list drift_checks "$DRIFT_CHECKS")"
           extra_wp_config_defines_json="$(validate_json_input extra_wp_config_defines object "$EXTRA_WP_CONFIG_DEFINES")"
           extra_wp_codebox_mounts_json="$(validate_json_input extra_wp_codebox_mounts array "$EXTRA_WP_CODEBOX_MOUNTS")"
           workload_run_before_json="$(validate_json_input workload_run_before array "$WORKLOAD_RUN_BEFORE")"
@@ -800,6 +861,9 @@ jobs:
             --arg pipelineSlug "$PIPELINE_SLUG" \
             --arg flowSlug "$FLOW_SLUG" \
             --arg targetRepo "$TARGET_REPO" \
+            --argjson contextRepositories "$context_repositories_json" \
+            --argjson verificationCommands "$verification_commands_json" \
+            --argjson driftChecks "$drift_checks_json" \
             --arg prompt "$PROMPT" \
             --arg provider "$PROVIDER" \
             --arg model "$MODEL" \
@@ -889,6 +953,19 @@ jobs:
               github_repository_token_env: "GITHUB_TOKEN",
               github_profile_id: ($agentSlug + "-ci"),
               target_repo: $targetRepo,
+              context_repositories: $contextRepositories,
+              verification_commands: $verificationCommands,
+              drift_checks: $driftChecks,
+              datamachine_code_policy_attestation: {
+                schema: "homeboy/datamachine-agent-ci-dmc-policy/v1",
+                target_repo: $targetRepo,
+                write_boundary: $targetRepo,
+                context_repositories: $contextRepositories,
+                context_repository_api: {
+                  upstream_issue: "https://github.com/Extra-Chill/data-machine-code/issues/617",
+                  status: (if ($contextRepositories | length) > 0 then "blocked_until_available" else "not_requested" end)
+                }
+              },
               allowed_repos: (if ($allowedRepos | length) > 0 then $allowedRepos else [$targetRepo] end),
               engine_key: $engineKey,
               tool_results_key: $toolResultsKey,

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -467,16 +467,19 @@ if ( ! function_exists( 'homeboy_datamachine_agent_fingerprints' ) ) {
     }
 
     function homeboy_datamachine_agent_tool_policy_fingerprint( array $config ): array {
-        $policy = array(
-            'required_abilities'     => $config['required_abilities'] ?? array(),
-            'ability_tools'          => $config['ability_tools'] ?? array(),
-            'tool_recorders'         => $config['tool_recorders'] ?? array(),
-            'pipeline_step_patches'  => $config['pipeline_step_patches'] ?? array(),
-            'flow_step_patches'      => $config['flow_step_patches'] ?? array(),
-            'runner_workspace'       => $config['runner_workspace'] ?? array(),
-            'success_requires_pr'    => ! empty( $config['success_requires_pr'] ),
-            'success_completion_outcomes' => $config['success_completion_outcomes'] ?? array(),
-        );
+		$policy = array(
+			'required_abilities'     => $config['required_abilities'] ?? array(),
+			'ability_tools'          => $config['ability_tools'] ?? array(),
+			'tool_recorders'         => $config['tool_recorders'] ?? array(),
+			'pipeline_step_patches'  => $config['pipeline_step_patches'] ?? array(),
+			'flow_step_patches'      => $config['flow_step_patches'] ?? array(),
+			'runner_workspace'       => $config['runner_workspace'] ?? array(),
+			'context_repositories'   => $config['context_repositories'] ?? array(),
+			'verification_commands'  => $config['verification_commands'] ?? array(),
+			'drift_checks'           => $config['drift_checks'] ?? array(),
+			'success_requires_pr'    => ! empty( $config['success_requires_pr'] ),
+			'success_completion_outcomes' => $config['success_completion_outcomes'] ?? array(),
+		);
 
         return array(
             'sha256' => homeboy_datamachine_agent_json_sha256( $policy ),
@@ -491,6 +494,205 @@ if ( ! function_exists( 'homeboy_datamachine_agent_fingerprints' ) ) {
             'tool_policy' => homeboy_datamachine_agent_tool_policy_fingerprint( $config ),
         );
     }
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_context_repositories' ) ) {
+	function homeboy_datamachine_agent_context_repositories( array $config ): array {
+		$repositories = is_array( $config['context_repositories'] ?? null ) ? $config['context_repositories'] : array();
+		$normalized   = array();
+
+		foreach ( $repositories as $repository ) {
+			if ( ! is_array( $repository ) ) {
+				continue;
+			}
+
+			$repo = isset( $repository['repo'] ) && is_scalar( $repository['repo'] ) ? trim( (string) $repository['repo'] ) : '';
+			if ( '' === $repo ) {
+				continue;
+			}
+
+			$alias = isset( $repository['alias'] ) && is_scalar( $repository['alias'] ) ? trim( (string) $repository['alias'] ) : '';
+			if ( '' === $alias ) {
+				$alias = basename( $repo );
+			}
+
+			$paths = array();
+			if ( is_array( $repository['paths'] ?? null ) ) {
+				foreach ( $repository['paths'] as $path ) {
+					if ( is_scalar( $path ) && '' !== trim( (string) $path ) ) {
+						$paths[] = trim( (string) $path );
+					}
+				}
+			}
+
+			$normalized[] = array(
+				'repo'  => $repo,
+				'ref'   => isset( $repository['ref'] ) && is_scalar( $repository['ref'] ) ? trim( (string) $repository['ref'] ) : '',
+				'alias' => $alias,
+				'paths' => $paths,
+			);
+		}
+
+		return $normalized;
+	}
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_provision_context_repositories' ) ) {
+	function homeboy_datamachine_agent_provision_context_repositories( array $config, array $runner_workspace ): array {
+		$repositories = homeboy_datamachine_agent_context_repositories( $config );
+		if ( empty( $repositories ) ) {
+			return array( 'enabled' => false, 'repositories' => array() );
+		}
+
+		$api_ability = 'datamachine-code/workspace-context-repositories';
+		$input       = array(
+			'target_repo'     => homeboy_datamachine_agent_scalar( $config, 'target_repo' ),
+			'target_workspace' => (string) ( $runner_workspace['handle'] ?? '' ),
+			'repositories'     => $repositories,
+			'access'           => 'readonly',
+		);
+
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $api_ability ) : null;
+		if ( ! $ability ) {
+			return array(
+				'enabled'        => true,
+				'success'        => false,
+				'blocked'        => true,
+				'ability'        => $api_ability,
+				'upstream_issue' => 'https://github.com/Extra-Chill/data-machine-code/issues/617',
+				'error'          => 'DMC context repository API is not available; context_repositories is blocked on Extra-Chill/data-machine-code#617.',
+				'input'          => $input,
+				'repositories'   => $repositories,
+			);
+		}
+
+		$result = $ability->execute( $input );
+		if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
+			return array(
+				'enabled'      => true,
+				'success'      => false,
+				'ability'      => $api_ability,
+				'error'        => $result->get_error_message(),
+				'input'        => $input,
+				'repositories' => $repositories,
+			);
+		}
+
+		return array(
+			'enabled'      => true,
+			'success'      => is_array( $result ) ? ! empty( $result['success'] ) : false,
+			'ability'      => $api_ability,
+			'input'        => $input,
+			'result'       => $result,
+			'repositories' => $repositories,
+		);
+	}
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_command_list' ) ) {
+	function homeboy_datamachine_agent_command_list( array $config, string $key ): array {
+		$commands = is_array( $config[ $key ] ?? null ) ? $config[ $key ] : array();
+		$normalized = array();
+
+		foreach ( $commands as $command_config ) {
+			if ( is_string( $command_config ) ) {
+				$command_config = array( 'command' => $command_config );
+			}
+			if ( ! is_array( $command_config ) ) {
+				continue;
+			}
+			$command = isset( $command_config['command'] ) && is_scalar( $command_config['command'] ) ? trim( (string) $command_config['command'] ) : '';
+			if ( '' === $command ) {
+				continue;
+			}
+			$normalized[] = array(
+				'command'     => $command,
+				'description' => isset( $command_config['description'] ) && is_scalar( $command_config['description'] ) ? trim( (string) $command_config['description'] ) : '',
+			);
+		}
+
+		return $normalized;
+	}
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_run_shell_command' ) ) {
+	function homeboy_datamachine_agent_run_shell_command( string $command, string $cwd ): array {
+		$started = hrtime( true );
+		$descriptor_spec = array(
+			0 => array( 'pipe', 'r' ),
+			1 => array( 'pipe', 'w' ),
+			2 => array( 'pipe', 'w' ),
+		);
+
+		$process = proc_open( array( 'bash', '-lc', $command ), $descriptor_spec, $pipes, $cwd );
+		if ( ! is_resource( $process ) ) {
+			return array(
+				'command'    => $command,
+				'exit_code'  => 127,
+				'success'    => false,
+				'error'      => 'Unable to start command process.',
+				'elapsed_ms' => ( hrtime( true ) - $started ) / 1000000,
+			);
+		}
+
+		fclose( $pipes[0] );
+		$stdout = stream_get_contents( $pipes[1] );
+		$stderr = stream_get_contents( $pipes[2] );
+		fclose( $pipes[1] );
+		fclose( $pipes[2] );
+		$exit_code = proc_close( $process );
+
+		return array(
+			'command'    => $command,
+			'exit_code'  => $exit_code,
+			'success'    => 0 === $exit_code,
+			'stdout'     => is_string( $stdout ) ? trim( $stdout ) : '',
+			'stderr'     => is_string( $stderr ) ? trim( $stderr ) : '',
+			'elapsed_ms' => ( hrtime( true ) - $started ) / 1000000,
+		);
+	}
+}
+
+if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
+	function homeboy_datamachine_agent_run_command_checks( array $config, array $runner_workspace, string $key ): array {
+		$commands = homeboy_datamachine_agent_command_list( $config, $key );
+		if ( empty( $commands ) ) {
+			return array( 'enabled' => false, 'checks' => array() );
+		}
+
+		$cwd = isset( $runner_workspace['path'] ) && is_scalar( $runner_workspace['path'] ) ? trim( (string) $runner_workspace['path'] ) : '';
+		if ( '' === $cwd || ! is_dir( $cwd ) ) {
+			return array(
+				'enabled' => true,
+				'success' => false,
+				'error'   => $key . ' requires a provisioned DMC target workspace path.',
+				'checks'  => $commands,
+			);
+		}
+
+		$results = array();
+		foreach ( $commands as $command_config ) {
+			$result = homeboy_datamachine_agent_run_shell_command( $command_config['command'], $cwd );
+			$result['description'] = $command_config['description'];
+			$results[] = $result;
+			if ( empty( $result['success'] ) ) {
+				return array(
+					'enabled' => true,
+					'success' => false,
+					'cwd'     => $cwd,
+					'checks'  => $results,
+					'error'   => $key . ' failed: ' . $command_config['command'],
+				);
+			}
+		}
+
+		return array(
+			'enabled' => true,
+			'success' => true,
+			'cwd'     => $cwd,
+			'checks'  => $results,
+		);
+	}
 }
 
 if ( ! function_exists( 'homeboy_datamachine_agent_path_value' ) ) {
@@ -2867,6 +3069,9 @@ if ( ! empty( $config['dry_run'] ) ) {
 			'provider'            => homeboy_datamachine_agent_scalar( $config, 'provider', 'openai' ),
 			'model'               => homeboy_datamachine_agent_scalar( $config, 'model', 'gpt-5.5' ),
 			'prompt'              => homeboy_datamachine_agent_scalar( $config, 'prompt' ),
+			'context_repositories' => homeboy_datamachine_agent_context_repositories( $config ),
+			'verification_commands' => homeboy_datamachine_agent_command_list( $config, 'verification_commands' ),
+			'drift_checks'        => homeboy_datamachine_agent_command_list( $config, 'drift_checks' ),
 			'tool_audit_events'   => is_array( $config['tool_audit_events'] ?? null ) ? $config['tool_audit_events'] : array(),
 			'datamachine_provenance' => is_array( $config['datamachine_provenance'] ?? null ) ? $config['datamachine_provenance'] : array(),
 			'datamachine_code_policy_attestation' => is_array( $config['datamachine_code_policy_attestation'] ?? null ) ? $config['datamachine_code_policy_attestation'] : array(),
@@ -2895,6 +3100,9 @@ $metadata = array(
 	'task_id'      => homeboy_datamachine_agent_scalar( $config, 'task_id', homeboy_datamachine_agent_scalar( $config, 'workload_id' ) ),
 	'task_label'   => homeboy_datamachine_agent_scalar( $config, 'task_label', homeboy_datamachine_agent_scalar( $config, 'workload_label' ) ),
 	'prompt'        => $prompt,
+	'context_repositories' => homeboy_datamachine_agent_context_repositories( $config ),
+	'verification_commands' => homeboy_datamachine_agent_command_list( $config, 'verification_commands' ),
+	'drift_checks'  => homeboy_datamachine_agent_command_list( $config, 'drift_checks' ),
 	'fingerprints'  => homeboy_datamachine_agent_fingerprints( $config, $prompt, $bundle_path ),
 	'runtime_versions' => homeboy_datamachine_agent_runtime_versions(),
 	'bundle_exists' => '' !== $bundle_path && is_dir( $bundle_path ),
@@ -2924,12 +3132,36 @@ if ( null !== $bootstrap_error ) {
 
 $runner_workspace = homeboy_datamachine_agent_provision_workspace( $config );
 if ( ! empty( $runner_workspace['enabled'] ) ) {
-    $metadata['runner_workspace'] = $runner_workspace;
-    if ( empty( $runner_workspace['success'] ) ) {
-        return homeboy_datamachine_agent_result( array( 'runner_workspace_provisioned' => 0 ), $metadata, (string) ( $runner_workspace['error'] ?? 'Runner workspace provisioning failed' ) );
-    }
-    $config['runner_workspace_result'] = $runner_workspace;
-    list( $config, $prompt ) = homeboy_datamachine_agent_apply_runner_workspace( $config, $prompt, $runner_workspace );
+	$metadata['runner_workspace'] = $runner_workspace;
+	if ( empty( $runner_workspace['success'] ) ) {
+		return homeboy_datamachine_agent_result( array( 'runner_workspace_provisioned' => 0 ), $metadata, (string) ( $runner_workspace['error'] ?? 'Runner workspace provisioning failed' ) );
+	}
+	$config['runner_workspace_result'] = $runner_workspace;
+	list( $config, $prompt ) = homeboy_datamachine_agent_apply_runner_workspace( $config, $prompt, $runner_workspace );
+}
+
+$context_repositories = homeboy_datamachine_agent_provision_context_repositories( $config, $runner_workspace );
+if ( ! empty( $context_repositories['enabled'] ) ) {
+	$metadata['context_repositories_result'] = $context_repositories;
+	if ( empty( $context_repositories['success'] ) ) {
+		return homeboy_datamachine_agent_result( array( 'context_repositories_provisioned' => 0 ), $metadata, (string) ( $context_repositories['error'] ?? 'Context repository provisioning failed' ) );
+	}
+
+	$repository_lines = array();
+	foreach ( homeboy_datamachine_agent_context_repositories( $config ) as $repository ) {
+		$line = '- `' . (string) $repository['alias'] . '` => `' . (string) $repository['repo'] . '`';
+		if ( '' !== (string) $repository['ref'] ) {
+			$line .= '@`' . (string) $repository['ref'] . '`';
+		}
+		if ( ! empty( $repository['paths'] ) ) {
+			$line .= ' paths: `' . implode( '`, `', array_map( 'strval', $repository['paths'] ) ) . '`';
+		}
+		$repository_lines[] = $line;
+	}
+	if ( ! empty( $repository_lines ) ) {
+		$context_prompt = "Read-only context repositories are available through the Data Machine Code context repository API. Treat them as evidence only; the target repository remains the only write and pull-request boundary.\n" . implode( "\n", $repository_lines );
+		$prompt = '' === trim( $prompt ) ? $context_prompt : $context_prompt . "\n\n" . $prompt;
+	}
 }
 
 $required_abilities = is_array( $config['required_abilities'] ?? null )
@@ -3152,6 +3384,15 @@ $runner_workspace_capture = homeboy_datamachine_agent_capture_runner_workspace( 
 if ( is_array( $runner_workspace_capture['engine_data'] ?? null ) ) {
 	$engine_data = $runner_workspace_capture['engine_data'];
 }
+$verification_results = homeboy_datamachine_agent_run_command_checks( $config, is_array( $config['runner_workspace_result'] ?? null ) ? $config['runner_workspace_result'] : array(), 'verification_commands' );
+$drift_check_results  = empty( $verification_results['enabled'] ) || ! empty( $verification_results['success'] )
+	? homeboy_datamachine_agent_run_command_checks( $config, is_array( $config['runner_workspace_result'] ?? null ) ? $config['runner_workspace_result'] : array(), 'drift_checks' )
+	: array( 'enabled' => false, 'checks' => array(), 'skipped_reason' => 'verification_commands_failed' );
+$engine_data['runner_verification_results'] = $verification_results;
+$engine_data['runner_drift_check_results']  = $drift_check_results;
+if ( isset( $context_repositories ) ) {
+	$engine_data['runner_context_repositories'] = $context_repositories;
+}
 $transcript_dir = homeboy_datamachine_agent_scalar( $config, 'transcript_dir' );
 $transcript_artifacts = homeboy_datamachine_agent_export_transcript( $job_id, $engine_data, $transcript_dir );
 $pr_opened = homeboy_datamachine_agent_pr_opened( $engine_data, $config );
@@ -3215,8 +3456,10 @@ $metadata += array(
     'success_status'        => $success_status,
     'success_requires_pr'   => $success_requires_pr,
     'fallback_pull_request' => $fallback_pull_request,
-    'runner_workspace_capture' => $runner_workspace_capture,
-    'completion_outcome_satisfied' => $completion_outcome_satisfied,
+	'runner_workspace_capture' => $runner_workspace_capture,
+	'verification_results' => $verification_results,
+	'drift_check_results' => $drift_check_results,
+	'completion_outcome_satisfied' => $completion_outcome_satisfied,
     'file_written'          => $file_written,
     'job_artifact_exports'    => $job_artifact_exports,
 );
@@ -3234,7 +3477,15 @@ if ( ! empty( $general_rule_failures ) ) {
 }
 
 if ( ! empty( $runner_workspace_capture['enabled'] ) && ! empty( $runner_workspace_capture['error'] ) && empty( $runner_workspace_capture['changed'] ) ) {
-    return homeboy_datamachine_agent_result( array( 'runner_workspace_captured' => 0 ), $metadata, (string) $runner_workspace_capture['error'] );
+	return homeboy_datamachine_agent_result( array( 'runner_workspace_captured' => 0 ), $metadata, (string) $runner_workspace_capture['error'] );
+}
+
+if ( ! empty( $verification_results['enabled'] ) && empty( $verification_results['success'] ) ) {
+	return homeboy_datamachine_agent_result( array( 'verification_commands_succeeded' => 0 ), $metadata, (string) ( $verification_results['error'] ?? 'verification_commands failed' ) );
+}
+
+if ( ! empty( $drift_check_results['enabled'] ) && empty( $drift_check_results['success'] ) ) {
+	return homeboy_datamachine_agent_result( array( 'drift_checks_succeeded' => 0 ), $metadata, (string) ( $drift_check_results['error'] ?? 'drift_checks failed' ) );
 }
 
 if ( $file_written && ! $pr_opened ) {
@@ -3269,7 +3520,10 @@ return homeboy_datamachine_agent_result(
 		'import_elapsed_ms'           => $import_elapsed_ms,
 		'agent_resolved'              => 1,
 		'runner_workspace_provisioned' => empty( $runner_workspace['enabled'] ) || ! empty( $runner_workspace['success'] ) ? 1 : 0,
+		'context_repositories_provisioned' => empty( $context_repositories['enabled'] ) || ! empty( $context_repositories['success'] ) ? 1 : 0,
 		'runner_workspace_captured'    => empty( $runner_workspace_capture['enabled'] ) || empty( $runner_workspace_capture['error'] ) ? 1 : 0,
+		'verification_commands_succeeded' => empty( $verification_results['enabled'] ) || ! empty( $verification_results['success'] ) ? 1 : 0,
+		'drift_checks_succeeded'       => empty( $drift_check_results['enabled'] ) || ! empty( $drift_check_results['success'] ) ? 1 : 0,
 		'pipeline_resolved'           => '' !== $execute_workflow_path || '' === $pipeline_slug || $pipeline_id > 0 ? 1 : 0,
 		'flow_resolved'               => 1,
 		'run_flow_succeeded'          => 1,

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -704,5 +704,45 @@ namespace {
         exit( 1 );
     }
 
+    $context_config = array(
+        'target_repo'          => 'owner/repo',
+        'context_repositories' => array(
+            array(
+                'repo'  => 'owner/context',
+                'ref'   => 'main',
+                'alias' => 'context',
+                'paths' => array( 'docs/**' ),
+            ),
+        ),
+    );
+    $context_result = homeboy_datamachine_agent_provision_context_repositories( $context_config, array( 'handle' => 'repo@branch' ) );
+    if ( empty( $context_result['blocked'] ) || 'https://github.com/Extra-Chill/data-machine-code/issues/617' !== ( $context_result['upstream_issue'] ?? '' ) ) {
+        fwrite( STDERR, "Expected context repositories to report a DMC #617 blocked state when the API is unavailable.\n" );
+        exit( 1 );
+    }
+
+    $command_workspace = sys_get_temp_dir() . '/homeboy-command-check-' . uniqid();
+    mkdir( $command_workspace );
+    $verification_result = homeboy_datamachine_agent_run_command_checks(
+        array( 'verification_commands' => array( array( 'command' => 'printf ok > verification.txt', 'description' => 'Write verification marker' ) ) ),
+        array( 'path' => $command_workspace ),
+        'verification_commands'
+    );
+    if ( empty( $verification_result['success'] ) || ! is_file( $command_workspace . '/verification.txt' ) ) {
+        fwrite( STDERR, "Expected verification_commands to run in the target workspace.\n" );
+        exit( 1 );
+    }
+    $drift_result = homeboy_datamachine_agent_run_command_checks(
+        array( 'drift_checks' => array( array( 'command' => 'test -f verification.txt', 'description' => 'Generated outputs are present' ) ) ),
+        array( 'path' => $command_workspace ),
+        'drift_checks'
+    );
+    if ( empty( $drift_result['success'] ) ) {
+        fwrite( STDERR, "Expected drift_checks to run after verification in the target workspace.\n" );
+        exit( 1 );
+    }
+    unlink( $command_workspace . '/verification.txt' );
+    rmdir( $command_workspace );
+
     fwrite( STDOUT, "Data Machine agent write-without-PR smoke passed.\n" );
 }


### PR DESCRIPTION
## Summary
- Adds canonical reusable workflow inputs for `context_repositories`, `verification_commands`, and `drift_checks` with strict JSON validation.
- Threads context repository policy into the Data Machine agent runner as DMC-facing metadata and engine data while keeping `target_repo` as the write/PR boundary.
- Runs verification and drift command checks only inside the DMC-managed target workspace and records results for transcripts/artifacts.

## Upstream dependency
Blocked on Extra-Chill/data-machine-code#617 for the actual read-only context repository API. Until that ability is available, runs that configure `context_repositories` fail with a clear blocked-on-DMC error instead of cloning or mounting context repos through runner-only policy.

## Tests
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `npm run test:datamachine-agent-wp-codebox-runner`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); puts "workflow YAML parsed"'`

Refs #1221.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the workflow/runner implementation, validation logic, and targeted smoke coverage; Chris remains responsible for review and merge.