### PR TITLE
Expose typed Codebox bundle outputs

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -24,6 +24,7 @@ const PROVIDER_CAPABILITIES = [
   'screenshots',
   'structured_outcome',
   'agent_bundle_execution',
+  'typed_bundle_outputs',
   'external_recipe_packs',
   'recipe_probe_artifacts',
 ];
@@ -949,6 +950,116 @@ function sanitizePublicMetadata(value) {
   }));
 }
 
+function normalizeTypedArtifactEntry(name, artifact) {
+  if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) {
+    return null;
+  }
+  const artifactName = artifact.name || name;
+  if (!artifactName) {
+    return null;
+  }
+  const fileRefs = typedArtifactOutputFileRefs(artifact);
+  return sanitizePublicMetadata(Object.fromEntries(Object.entries({
+    schema: 'homeboy/agent-task-typed-artifact/v1',
+    name: artifactName,
+    type: artifact.type || artifact.kind || artifact.artifact_type || artifact.artifactType,
+    artifact_schema: artifact.artifact_schema || artifact.artifactSchema || artifact.schema,
+    payload: artifact.payload !== undefined ? artifact.payload : artifact.data,
+    provenance: artifact.provenance && typeof artifact.provenance === 'object' && !Array.isArray(artifact.provenance) ? artifact.provenance : {},
+    file_refs: fileRefs,
+    metadata: artifact.metadata && typeof artifact.metadata === 'object' && !Array.isArray(artifact.metadata) ? artifact.metadata : {},
+  }).filter(([, value]) => value !== undefined && value !== '' && !(Array.isArray(value) && value.length === 0))));
+}
+
+function typedArtifactOutputFileRefs(artifact) {
+  if (Array.isArray(artifact.file_refs)) {
+    return artifact.file_refs;
+  }
+  if (Array.isArray(artifact.fileRefs)) {
+    return artifact.fileRefs;
+  }
+  return [];
+}
+
+function normalizeTypedArtifacts(value) {
+  if (Array.isArray(value)) {
+    return Object.fromEntries(value
+      .map((artifact, index) => normalizeTypedArtifactEntry(artifact?.name || artifact?.id || `artifact_${index + 1}`, artifact))
+      .filter(Boolean)
+      .map((artifact) => [artifact.name, artifact]));
+  }
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+  return Object.fromEntries(Object.entries(value)
+    .map(([name, artifact]) => normalizeTypedArtifactEntry(name, artifact))
+    .filter(Boolean)
+    .map((artifact) => [artifact.name, artifact]));
+}
+
+function typedArtifactsFromResult(result) {
+  const workload = agentRuntimeWorkload(result) || {};
+  const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
+  const candidates = [
+    result.outputs?.typed_artifacts,
+    result.outputs?.typedArtifacts,
+    result.run?.agentResult?.typed_artifacts,
+    result.run?.agentResult?.typedArtifacts,
+    result.run?.agentResult?.outputs?.typed_artifacts,
+    result.run?.agentResult?.outputs?.typedArtifacts,
+    result.agentResult?.outputs?.typed_artifacts,
+    result.agentResult?.outputs?.typedArtifacts,
+    result.agent_result?.outputs?.typed_artifacts,
+    result.agent_result?.outputs?.typedArtifacts,
+    result.metadata?.agent_runtime?.result?.typed_artifacts,
+    result.metadata?.agent_runtime?.result?.typedArtifacts,
+    result.metadata?.agent_runtime?.result?.outputs?.typed_artifacts,
+    result.metadata?.agent_runtime?.result?.outputs?.typedArtifacts,
+    workload.typed_artifacts,
+    workload.typedArtifacts,
+    workload.outputs?.typed_artifacts,
+    workload.outputs?.typedArtifacts,
+    ...scenarios.map((scenario) => scenario?.typed_artifacts),
+    ...scenarios.map((scenario) => scenario?.typedArtifacts),
+    ...scenarios.map((scenario) => scenario?.metadata?.typed_artifacts),
+    ...scenarios.map((scenario) => scenario?.metadata?.typedArtifacts),
+  ];
+  return Object.assign({}, ...candidates.map(normalizeTypedArtifacts));
+}
+
+function typedArtifactFileRefs(typedArtifact) {
+  const refs = Array.isArray(typedArtifact.file_refs) ? typedArtifact.file_refs : [];
+  const directRefs = [typedArtifact.path, typedArtifact.url, typedArtifact.file, typedArtifact.directory].filter(Boolean);
+  return [
+    ...directRefs.map((ref) => ({ path: ref })),
+    ...refs,
+  ];
+}
+
+function typedBundleOutputArtifacts(result) {
+  return Object.values(typedArtifactsFromResult(result)).flatMap((typedArtifact) => typedArtifactFileRefs(typedArtifact).map((ref, index) => {
+    const fileRef = typeof ref === 'string' ? { path: ref } : ref;
+    if (!fileRef || typeof fileRef !== 'object') {
+      return null;
+    }
+    return {
+      id: fileRef.id || `${typedArtifact.name}-${index + 1}`,
+      kind: 'typed-bundle-output',
+      name: typedArtifact.name,
+      path: fileRef.path || fileRef.file || fileRef.directory,
+      url: fileRef.url,
+      mime: fileRef.mime,
+      sha256: fileRef.sha256,
+      metadata: {
+        type: typedArtifact.type,
+        artifact_schema: typedArtifact.artifact_schema,
+        provenance: typedArtifact.provenance,
+        file_ref: fileRef,
+      },
+    };
+  }).filter(Boolean));
+}
+
 function artifactFromCodeboxArtifact(artifact, index) {
   const id = artifact.id || artifact.sha256 || artifact.path || artifact.url || `codebox-artifact-${index + 1}`;
   return {
@@ -971,14 +1082,24 @@ function pathValue(source, dottedPath) {
 
 function normalizeOutputs(result) {
   const workload = agentRuntimeWorkload(result) || {};
-  if (workload.outputs && typeof workload.outputs === 'object' && !Array.isArray(workload.outputs)) {
-    return sanitizePublicMetadata(workload.outputs);
-  }
+  const typedArtifacts = typedArtifactsFromResult(result);
+  const appendTypedArtifacts = (outputs) => Object.keys(typedArtifacts).length > 0
+    ? {
+        ...outputs,
+        typed_artifacts: {
+          ...(outputs.typed_artifacts && typeof outputs.typed_artifacts === 'object' && !Array.isArray(outputs.typed_artifacts) ? outputs.typed_artifacts : {}),
+          ...typedArtifacts,
+        },
+      }
+    : outputs;
 
   const bundle = result.metadata?.agent_runtime?.bundle || result.task_input?.agent_bundle || {};
   const configuredOutputs = bundle.engine_data_outputs && typeof bundle.engine_data_outputs === 'object' ? bundle.engine_data_outputs : {};
+  if (Object.keys(configuredOutputs).length === 0 && workload.outputs && typeof workload.outputs === 'object' && !Array.isArray(workload.outputs)) {
+    return sanitizePublicMetadata(appendTypedArtifacts(workload.outputs));
+  }
   if (Object.keys(configuredOutputs).length === 0 && result.outputs && typeof result.outputs === 'object' && !Array.isArray(result.outputs)) {
-    return sanitizePublicMetadata(result.outputs);
+    return sanitizePublicMetadata(appendTypedArtifacts(result.outputs));
   }
   const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
   const configuredOutputSources = [
@@ -1006,7 +1127,10 @@ function normalizeOutputs(result) {
       }
     }
   }
-  return sanitizePublicMetadata(Object.keys(outputs).length > 0 ? outputs : result.outputs || {});
+  const fallbackOutputs = workload.outputs && typeof workload.outputs === 'object' && !Array.isArray(workload.outputs)
+    ? workload.outputs
+    : result.outputs || {};
+  return sanitizePublicMetadata(appendTypedArtifacts(Object.keys(outputs).length > 0 ? outputs : fallbackOutputs));
 }
 
 function outputEvidenceRefs(outputs) {
@@ -1080,6 +1204,9 @@ function normalizeArtifacts(result, runSummary = null, recipeSummary = null) {
     for (const artifact of agentRuntimeBundleArtifacts(result)) {
       appendUniqueArtifact(artifacts, artifact);
     }
+    for (const artifact of typedBundleOutputArtifacts(result)) {
+      appendUniqueArtifact(artifacts, artifact);
+    }
     if (!recipeSummary) {
       for (const artifact of recipeRunArtifacts(result)) {
         appendUniqueArtifact(artifacts, artifact);
@@ -1121,6 +1248,13 @@ function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) 
         kind: artifact.kind,
         uri: artifact.path || artifact.url,
         label: artifact.kind.replace(/^agent-runtime-/, 'Agent runtime ').replace(/-/g, ' '),
+      });
+    }
+    for (const artifact of typedBundleOutputArtifacts(result)) {
+      appendUniqueEvidenceRef(refs, {
+        kind: artifact.kind,
+        uri: artifact.path || artifact.url,
+        label: `Typed bundle output ${artifact.name || ''}`.trim(),
       });
     }
     if (!recipeSummary) {
@@ -1275,6 +1409,10 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
       codebox_recipe_run_summary: recipeSummary ? sanitizePublicMetadata(recipeSummary) : undefined,
       integration_contract: 'wp-codebox-cli/agent-task-run',
       decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result, runSummary, recipeSummary)),
+      sandbox_policy: sanitizePublicMetadata({
+        policy: result.task_input?.policy,
+        sandbox_tool_policy: result.task_input?.sandbox_tool_policy,
+      }),
       recipe_failed_phase: recipeFailedPhase || undefined,
     },
   };

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -535,6 +535,67 @@ function plainObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value);
 }
 
+function normalizeTypedArtifactEntry(name, artifact) {
+  if (!plainObject(artifact)) {
+    return null;
+  }
+  const artifactName = artifact.name || name;
+  if (!artifactName) {
+    return null;
+  }
+  const fileRefs = typedArtifactFileRefs(artifact);
+  return Object.fromEntries(Object.entries({
+    schema: 'homeboy/agent-task-typed-artifact/v1',
+    name: artifactName,
+    type: artifact.type || artifact.kind || artifact.artifact_type || artifact.artifactType,
+    artifact_schema: artifact.artifact_schema || artifact.artifactSchema || artifact.schema,
+    payload: artifact.payload !== undefined ? artifact.payload : artifact.data,
+    provenance: plainObject(artifact.provenance) ? artifact.provenance : {},
+    file_refs: fileRefs,
+    metadata: plainObject(artifact.metadata) ? artifact.metadata : {},
+  }).filter(([, value]) => value !== undefined && value !== '' && !(Array.isArray(value) && value.length === 0)));
+}
+
+function typedArtifactFileRefs(artifact) {
+  if (Array.isArray(artifact.file_refs)) {
+    return artifact.file_refs;
+  }
+  if (Array.isArray(artifact.fileRefs)) {
+    return artifact.fileRefs;
+  }
+  return [];
+}
+
+function normalizeTypedArtifacts(value) {
+  if (Array.isArray(value)) {
+    return Object.fromEntries(value
+      .map((artifact, index) => normalizeTypedArtifactEntry(artifact?.name || artifact?.id || `artifact_${index + 1}`, artifact))
+      .filter(Boolean)
+      .map((artifact) => [artifact.name, artifact]));
+  }
+  if (!plainObject(value)) {
+    return {};
+  }
+  return Object.fromEntries(Object.entries(value)
+    .map(([name, artifact]) => normalizeTypedArtifactEntry(name, artifact))
+    .filter(Boolean)
+    .map((artifact) => [artifact.name, artifact]));
+}
+
+function mergeTypedArtifactOutputs(outputs, ...candidates) {
+  const typedArtifacts = Object.assign({}, ...candidates.map(normalizeTypedArtifacts));
+  if (Object.keys(typedArtifacts).length === 0) {
+    return outputs;
+  }
+  return {
+    ...outputs,
+    typed_artifacts: {
+      ...(plainObject(outputs.typed_artifacts) ? outputs.typed_artifacts : {}),
+      ...typedArtifacts,
+    },
+  };
+}
+
 function sandboxToolPolicy(input, allowedTools) {
   const explicit = input.parent_request?.sandbox_tool_policy
     || input.parent_request?.sandboxToolPolicy
@@ -727,6 +788,7 @@ function agentRuntimeWorkloadFromSingleResult(workload, config) {
   } else if (plainObject(workload.output)) {
     outputs = workload.output;
   }
+  outputs = mergeTypedArtifactOutputs(outputs, workload.typed_artifacts, workload.typedArtifacts, outputs.typed_artifacts, outputs.typedArtifacts);
   return Object.fromEntries(Object.entries({
     id: config.workload_id || config.agent_slug || config.flow_slug || 'agent-bundle',
     success: workload.success,
@@ -742,10 +804,10 @@ function agentRuntimeWorkloadFromSingleResult(workload, config) {
 function agentRuntimeWorkloadFromBundleRun(bundleRun, config) {
   const bundle = bundleRun.bundle && typeof bundleRun.bundle === 'object' ? bundleRun.bundle : {};
   const workflowSteps = Array.isArray(bundleRun.workflow?.steps) ? bundleRun.workflow.steps : [];
-  const outputs = {
+  const outputs = mergeTypedArtifactOutputs({
     ...(plainObject(bundleRun.outputs) ? bundleRun.outputs : {}),
     ...toolRecorderOutputs(bundleRun.engine_data, config),
-  };
+  }, bundleRun.typed_artifacts, bundleRun.typedArtifacts, bundleRun.outputs?.typed_artifacts, bundleRun.outputs?.typedArtifacts);
   return {
     outputs,
     scenarios: [{

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -220,6 +220,7 @@ assert.equal(provider.capabilities.includes('workspace_tools'), true);
 assert.equal(provider.capabilities.includes('patch_artifacts'), true);
 assert.equal(provider.capabilities.includes('cleanup_observability'), true);
 assert.equal(provider.capabilities.includes('agent_bundle_execution'), true);
+assert.equal(provider.capabilities.includes('typed_bundle_outputs'), true);
 assert.equal(provider.capabilities.includes('external_recipe_packs'), true);
 assert.equal(provider.capabilities.includes('recipe_probe_artifacts'), true);
 assert.deepEqual(provider.runtime_gap_trackers, []);
@@ -889,10 +890,29 @@ const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
   artifacts: '/tmp/wp-codebox-artifacts',
+  task_input: {
+    policy: { write: 'sandbox', apply: 'review' },
+    sandbox_tool_policy: {
+      schema: 'wp-codebox/sandbox-tool-policy/v1',
+      tools: [{ id: 'homeboy/no-runtime-tools', allowed: false }],
+    },
+  },
   metadata: {
     agent_runtime: {
       bundle: agentBundleRequest.agent_bundle,
       workload: {
+        outputs: {
+          typed_artifacts: {
+            static_site_candidate: {
+              schema: 'homeboy/agent-task-typed-artifact/v1',
+              type: 'StaticSiteCandidate',
+              artifact_schema: 'static-site-importer/static-site-candidate/v1',
+              payload: { slug: 'issue-1222-transformer-loop', import_ready: true },
+              provenance: { bundle_slug: 'static-site-agent', task_id: 'agent-bundle-task-123' },
+              file_refs: [{ path: '/tmp/wp-codebox-artifacts/static-site-candidate.json', mime: 'application/json' }],
+            },
+          },
+        },
         scenarios: [{
           id: 'agent-bundle',
           metadata: {
@@ -908,9 +928,16 @@ const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
 assert.equal(agentBundleOutcome.schema, 'homeboy/agent-task-outcome/v1');
 assert.equal(agentBundleOutcome.status, 'succeeded');
 assert.equal(agentBundleOutcome.outputs.static_site_pr_url, 'https://github.com/chubes4/wp-site-generator/pull/123');
+assert.equal(agentBundleOutcome.outputs.typed_artifacts.static_site_candidate.type, 'StaticSiteCandidate');
+assert.equal(agentBundleOutcome.outputs.typed_artifacts.static_site_candidate.artifact_schema, 'static-site-importer/static-site-candidate/v1');
+assert.equal(agentBundleOutcome.outputs.typed_artifacts.static_site_candidate.payload.import_ready, true);
+assert.equal(agentBundleOutcome.artifacts.some((artifact) => artifact.kind === 'typed-bundle-output' && artifact.name === 'static_site_candidate' && artifact.path === '/tmp/wp-codebox-artifacts/static-site-candidate.json'), true);
 assert.equal(agentBundleOutcome.artifacts.some((artifact) => artifact.kind === 'agent-runtime-transcript' && artifact.path === '/tmp/transcript.json'), true);
 assert.equal(agentBundleOutcome.artifacts.some((artifact) => artifact.kind === 'agent-runtime-replay-bundle' && artifact.path === '/tmp/replay-bundle'), true);
 assert.equal(agentBundleOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/123'), true);
+assert.equal(agentBundleOutcome.evidence_refs.some((ref) => ref.uri === '/tmp/wp-codebox-artifacts/static-site-candidate.json'), true);
+assert.equal(agentBundleOutcome.metadata.sandbox_policy.policy.apply, 'review');
+assert.equal(agentBundleOutcome.metadata.sandbox_policy.sandbox_tool_policy.tools[0].allowed, false);
 assert.equal(upstreamRunnerOutcome.artifacts[1].kind, 'codebox-session-artifacts');
 assert.equal(upstreamRunnerOutcome.evidence_refs[0].uri, 'https://preview.example.test/sandbox-session-1');
 assert.equal(upstreamRunnerOutcome.evidence_refs[1].uri, '/tmp/wp-codebox-artifacts');

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -72,6 +72,15 @@ const bundleRun = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
         flow_slug: 'static-site-manual-flow',
         pipeline_slug: 'static-site-pipeline',
       },
+      typed_artifacts: {
+        static_site_candidate: {
+          schema: 'static-site-importer/static-site-candidate/v1',
+          type: 'StaticSiteCandidate',
+          payload: { slug: 'store-idea-agent', import_ready: true },
+          provenance: { bundle_slug: 'store-idea-agent', task_id: input.orchestrator.agent_task_id },
+          file_refs: [{ path: input.artifacts_path + '/static-site-candidate.json', mime: 'application/json' }]
+        }
+      },
       workflow: { steps: [{ step_type: 'ai' }] },
       wait_result: { success: true, terminal_state: 'completed' },
       engine_data: process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN_TOOL_RECORDERS
@@ -466,6 +475,9 @@ try {
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.engine_data.store_idea_agent.issue_number, 123);
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.dry_run, true);
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metrics.workflow_step_count, 1);
+  assert.equal(canonicalBundleRunOutput.outputs.typed_artifacts.static_site_candidate.type, 'StaticSiteCandidate');
+  assert.equal(canonicalBundleRunOutput.outputs.typed_artifacts.static_site_candidate.artifact_schema, 'static-site-importer/static-site-candidate/v1');
+  assert.equal(canonicalBundleRunOutput.outputs.typed_artifacts.static_site_candidate.payload.import_ready, true);
 
   const recorderBundleRunCapturePath = path.join(root, 'capture-recorder-datamachine-bundle-run.json');
   const recorderBundleRunResult = spawnSync(process.execPath, [


### PR DESCRIPTION
## Summary
- Exposes Codebox bundle-provided typed artifacts as named `outputs.typed_artifacts` entries in Homeboy agent-task outcomes.
- Mirrors file-backed typed artifacts into `artifacts` / `evidence_refs` as `typed-bundle-output` records while preserving existing patch artifact behavior.
- Keeps sandbox policy and sandbox tool policy metadata visible in the outcome for controller/scheduler auditing.

Fixes #1222

## Verification
- `npm --prefix wordpress run test:wp-codebox-task-runner`
- `npm --prefix wordpress run test:codebox-agent-task-executor`
- `cd wordpress && npx eslint lib/codebox-agent-task-executor.js scripts/agent/homeboy-wp-codebox-task-runner.cjs --no-warn-ignored`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the Codebox typed artifact normalization, updated targeted smoke coverage, and ran local verification; Chris remains responsible for review and merge.