### PR TITLE
Add static site import validation adapter

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -10,6 +10,8 @@ const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
 const AGENT_TASK_OUTCOME_SCHEMA = 'homeboy/agent-task-outcome/v1';
 const AGENT_TASK_ARTIFACT_SCHEMA = 'homeboy/agent-task-artifact/v1';
 const WP_CODEBOX_TASK_REQUEST_SCHEMA = 'wp-codebox/task-input/v1';
+const STATIC_SITE_IMPORT_VALIDATION_KIND = 'static_site_import_validation_adapter';
+const STATIC_SITE_IMPORT_ABILITY = 'static-site-importer/import-website-artifact';
 
 const PROVIDER_CAPABILITIES = [
   'browser_runtime',
@@ -27,6 +29,7 @@ const PROVIDER_CAPABILITIES = [
   'typed_bundle_outputs',
   'external_recipe_packs',
   'recipe_probe_artifacts',
+  'static_site_import_validation',
 ];
 
 const DEFAULT_WORKSPACE_READONLY_TOOLS = [
@@ -210,7 +213,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     context,
     recipe,
     sandbox_tool_policy: sandboxToolPolicy,
-    runtime_task: runtimeTask,
+    runtime_task: runtimeTask || staticSiteImportValidationRuntimeTask(request, config, inputs),
     sandbox_session_id: config.sandbox_session_id || request.task_id,
     session_id: config.session_id || config.sessionId || '',
     agent: config.agent || options.agent || 'wp-codebox-sandbox',
@@ -227,6 +230,11 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     // Codebox recipe steps; a non-zero exit fails the run so the orchestrator
     // refuses to report success until the gates are green.
     verify_steps: inputs.verify_steps || config.verify_steps || options.verifySteps || [],
+    execution_kind: config.execution_kind || inputs.execution_kind || '',
+    candidate_artifact: firstDefined(inputs.candidate_artifact, inputs.candidateArtifact, config.candidate_artifact, config.candidateArtifact),
+    artifact_outputs: firstDefined(inputs.artifact_outputs, inputs.artifactOutputs, config.artifact_outputs, config.artifactOutputs),
+    engine_data_outputs: firstDefined(inputs.engine_data_outputs, inputs.engineDataOutputs, config.engine_data_outputs, config.engineDataOutputs),
+    extra_plugins: extraPluginsForAgentTask(request, config, inputs, options),
     mounts,
     workspaces: inputs.workspaces || config.workspaces || options.workspaces || defaults.workspaces || [],
     agents_api_path: components.agents_api || config.agents_api || config.agents_api_path || options.agentsApi || '',
@@ -249,6 +257,102 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     agent_bundle: agentBundle,
     parent_request: request,
   };
+}
+
+function staticSiteImportValidationRuntimeTask(request, config, inputs) {
+  const executionKind = config.execution_kind || inputs.execution_kind || '';
+  if (executionKind !== STATIC_SITE_IMPORT_VALIDATION_KIND) {
+    return undefined;
+  }
+
+  const candidateArtifact = firstDefined(inputs.candidate_artifact, inputs.candidateArtifact, config.candidate_artifact, config.candidateArtifact);
+  const artifact = staticSiteCandidatePayload(candidateArtifact);
+  const fileRefs = typedArtifactFileRefs(candidateArtifact || {});
+  return {
+    ability: STATIC_SITE_IMPORT_ABILITY,
+    input: Object.fromEntries(Object.entries({
+      artifact,
+      slug: staticSiteCandidateString(candidateArtifact, 'slug') || config.slug || inputs.slug || request.task_id,
+      name: staticSiteCandidateString(candidateArtifact, 'name') || config.name || inputs.name || request.task_id,
+      activate: config.activate === true,
+      overwrite: config.overwrite !== false,
+      keep_source: config.keep_source !== false,
+      fail_on_quality: config.fail_on_quality === true,
+      max_fallbacks: config.max_fallbacks,
+      allow_missing_woocommerce: config.allow_missing_woocommerce === true,
+      report: config.report || inputs.report || '',
+      asset_policy: config.asset_policy || inputs.asset_policy || '',
+      asset_materialization_policy: config.asset_materialization_policy || inputs.asset_materialization_policy || '',
+      asset_map: config.asset_map || inputs.asset_map,
+      compiler_options: config.compiler_options || inputs.compiler_options,
+      source_metadata: {
+        adapter: STATIC_SITE_IMPORT_VALIDATION_KIND,
+        task_id: request.task_id,
+        candidate_artifact: sanitizePublicMetadata(candidateArtifact || {}),
+        candidate_file_refs: fileRefs,
+      },
+    }).filter(([, value]) => value !== undefined && value !== '' && !(Array.isArray(value) && value.length === 0))),
+  };
+}
+
+function staticSiteCandidatePayload(candidateArtifact) {
+  if (!candidateArtifact || typeof candidateArtifact !== 'object' || Array.isArray(candidateArtifact)) {
+    return {};
+  }
+  if (candidateArtifact.payload && typeof candidateArtifact.payload === 'object' && !Array.isArray(candidateArtifact.payload)) {
+    return candidateArtifact.payload;
+  }
+  if (candidateArtifact.data && typeof candidateArtifact.data === 'object' && !Array.isArray(candidateArtifact.data)) {
+    return candidateArtifact.data;
+  }
+  if (candidateArtifact.artifact && typeof candidateArtifact.artifact === 'object' && !Array.isArray(candidateArtifact.artifact)) {
+    return candidateArtifact.artifact;
+  }
+  return candidateArtifact;
+}
+
+function staticSiteCandidateString(candidateArtifact, key) {
+  const payload = staticSiteCandidatePayload(candidateArtifact);
+  const value = payload?.[key] || candidateArtifact?.[key];
+  return typeof value === 'string' ? value : '';
+}
+
+function extraPluginsForAgentTask(request, config, inputs, options = {}) {
+  const explicit = [
+    ...normalizeArray(inputs.extra_plugins || inputs.extraPlugins),
+    ...normalizeArray(config.extra_plugins || config.extraPlugins),
+    ...normalizeArray(options.extraPlugins),
+  ];
+  const validationPlugins = config.execution_kind === STATIC_SITE_IMPORT_VALIDATION_KIND || inputs.execution_kind === STATIC_SITE_IMPORT_VALIDATION_KIND
+    ? staticSiteImportPluginComponents(request, config, inputs, options)
+    : [];
+  const seen = new Set();
+  return [...explicit, ...validationPlugins].filter((plugin) => {
+    if (!plugin || typeof plugin !== 'object') {
+      return false;
+    }
+    const key = `${plugin.slug || ''}:${plugin.source || plugin.path || ''}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function staticSiteImportPluginComponents(request, config, inputs, options = {}) {
+  const settings = firstObject(options.settings, parseJsonObject(process.env.HOMEBOY_SETTINGS_JSON)) || {};
+  const workspaceRoot = resolveWorkspaceRoot(request, config, inputs, settings, options);
+  const workspaceBase = workspaceRoot ? path.dirname(workspaceRoot) : process.cwd();
+  const component = (slug, ...candidates) => {
+    const source = firstExistingPath(...candidates);
+    return source ? { slug, source, activate: true } : null;
+  };
+  return [
+    component('static-site-importer', config.static_site_importer_path, settings.static_site_importer_path, process.env.HOMEBOY_STATIC_SITE_IMPORTER_PATH, activeSitePluginPath('static-site-importer'), siblingPath(workspaceBase, 'static-site-importer')),
+    component('block-artifact-compiler', config.block_artifact_compiler_path, settings.block_artifact_compiler_path, process.env.HOMEBOY_BLOCK_ARTIFACT_COMPILER_PATH, activeSitePluginPath('block-artifact-compiler'), siblingPath(workspaceBase, 'block-artifact-compiler')),
+    component('block-format-bridge', config.block_format_bridge_path, settings.block_format_bridge_path, process.env.HOMEBOY_BLOCK_FORMAT_BRIDGE_PATH, activeSitePluginPath('block-format-bridge'), siblingPath(workspaceBase, 'block-format-bridge')),
+  ].filter(Boolean);
 }
 
 function runtimeComponentPaths(config, options = {}) {

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -346,6 +346,8 @@ function attachFailureEvidence(payload, evidence) {
 const LEGACY_RUNTIME_PREFIX = ['data', 'machine'].join('_');
 const WP_CODEBOX_RUNTIME_PATH_KEY = `${LEGACY_RUNTIME_PREFIX}_path`;
 const WP_CODEBOX_RUNTIME_TOOLS_PATH_KEY = `${LEGACY_RUNTIME_PREFIX}_code_path`;
+const STATIC_SITE_IMPORT_VALIDATION_KIND = 'static_site_import_validation_adapter';
+const STATIC_SITE_IMPORT_ABILITY = 'static-site-importer/import-website-artifact';
 const LEGACY_BUNDLE_KEYS = [
   `${LEGACY_RUNTIME_PREFIX}_bundle`,
   `${LEGACY_RUNTIME_PREFIX}Bundle`,
@@ -605,6 +607,23 @@ function sandboxToolPolicy(input, allowedTools) {
     return explicit;
   }
 
+  if (isStaticSiteImportValidationAdapter(input)) {
+    return {
+      schema: 'wp-codebox/sandbox-tool-policy/v1',
+      version: 1,
+      tools: [{
+        id: STATIC_SITE_IMPORT_ABILITY,
+        runtime_tool_id: STATIC_SITE_IMPORT_ABILITY.replace(/[^A-Za-z0-9_]+/g, '_'),
+        execution_location: 'sandbox',
+        transport_visibility: 'sandbox',
+        allowed: true,
+        runtime: { environment: 'runtime_local', capability_scope: 'runtime_local' },
+        metadata: { source: STATIC_SITE_IMPORT_VALIDATION_KIND },
+      }],
+      metadata: { source: 'homeboy-wp-codebox-task-runner' },
+    };
+  }
+
   const tools = Array.isArray(allowedTools) ? allowedTools.filter((tool) => typeof tool === 'string' && tool.trim() !== '') : [];
   return {
     schema: 'wp-codebox/sandbox-tool-policy/v1',
@@ -639,14 +658,76 @@ function isAgentBundle(input) {
   return Boolean(input.agent_bundle && Object.keys(input.agent_bundle).length > 0);
 }
 
+function isStaticSiteImportValidationAdapter(input) {
+  return input.parent_request?.execution_kind === STATIC_SITE_IMPORT_VALIDATION_KIND
+    || input.parent_request?.executor?.config?.execution_kind === STATIC_SITE_IMPORT_VALIDATION_KIND;
+}
+
 function runtimeTask(input) {
   if (plainObject(input.runtime_task)) {
     return input.runtime_task;
+  }
+  if (isStaticSiteImportValidationAdapter(input)) {
+    return staticSiteImportValidationRuntimeTask(input);
   }
   if (isAgentBundle(input)) {
     return agentBundleRuntimeTask(input, input.agent_bundle || {});
   }
   return undefined;
+}
+
+function staticSiteImportValidationRuntimeTask(input) {
+  const config = input.parent_request?.executor?.config || input.parent_request || {};
+  const candidateArtifact = input.parent_request?.candidate_artifact || config.candidate_artifact || config.candidateArtifact || {};
+  const artifact = staticSiteCandidatePayload(candidateArtifact);
+  const fileRefs = typedArtifactFileRefs(candidateArtifact);
+  return {
+    ability: STATIC_SITE_IMPORT_ABILITY,
+    input: Object.fromEntries(Object.entries({
+      artifact,
+      slug: staticSiteCandidateString(candidateArtifact, 'slug') || config.slug || input.parent_request?.orchestrator?.agent_task_id || input.sandbox_session_id,
+      name: staticSiteCandidateString(candidateArtifact, 'name') || config.name || input.parent_request?.goal || input.sandbox_session_id,
+      activate: config.activate === true,
+      overwrite: config.overwrite !== false,
+      keep_source: config.keep_source !== false,
+      fail_on_quality: config.fail_on_quality === true,
+      max_fallbacks: config.max_fallbacks,
+      allow_missing_woocommerce: config.allow_missing_woocommerce === true,
+      report: config.report || (input.artifacts_path ? path.join(input.artifacts_path, 'import-validation-report.json') : ''),
+      asset_policy: config.asset_policy || '',
+      asset_materialization_policy: config.asset_materialization_policy || '',
+      asset_map: config.asset_map,
+      compiler_options: config.compiler_options,
+      source_metadata: {
+        adapter: STATIC_SITE_IMPORT_VALIDATION_KIND,
+        task_id: input.parent_request?.orchestrator?.agent_task_id || input.sandbox_session_id,
+        candidate_artifact: candidateArtifact,
+        candidate_file_refs: fileRefs,
+      },
+    }).filter(([, value]) => value !== undefined && value !== '' && !(Array.isArray(value) && value.length === 0))),
+  };
+}
+
+function staticSiteCandidatePayload(candidateArtifact) {
+  if (!plainObject(candidateArtifact)) {
+    return {};
+  }
+  if (plainObject(candidateArtifact.payload)) {
+    return candidateArtifact.payload;
+  }
+  if (plainObject(candidateArtifact.data)) {
+    return candidateArtifact.data;
+  }
+  if (plainObject(candidateArtifact.artifact)) {
+    return candidateArtifact.artifact;
+  }
+  return candidateArtifact;
+}
+
+function staticSiteCandidateString(candidateArtifact, key) {
+  const payload = staticSiteCandidatePayload(candidateArtifact);
+  const value = payload?.[key] || candidateArtifact?.[key];
+  return typeof value === 'string' ? value : '';
 }
 
 function agentBundleConfig(input, bundleConfig = {}) {
@@ -688,6 +769,10 @@ function resultExecutions(result) {
 }
 
 function normalizeAgentTaskRun(input, result) {
+  if (isStaticSiteImportValidationAdapter(input)) {
+    return normalizeStaticSiteImportValidationRun(input, result);
+  }
+
   if (!isAgentBundle(input)) {
     return result;
   }
@@ -730,6 +815,144 @@ function normalizeAgentTaskRun(input, result) {
       },
     },
   };
+}
+
+function normalizeStaticSiteImportValidationRun(input, result) {
+  const abilityResult = staticSiteImportAbilityResult(result);
+  const typedArtifact = importValidationTypedArtifact(input, abilityResult, result);
+  const success = result.success !== false && result.status !== 'failed' && abilityResult.success !== false;
+  const diagnostics = [
+    ...(Array.isArray(result.diagnostics) ? result.diagnostics : []),
+    ...(abilityResult.success === false ? [{
+      class: 'static_site_import_validation.import_failed',
+      message: abilityResult.error?.message || 'Static Site Importer website artifact import failed.',
+      data: abilityResult.error || {},
+    }] : []),
+  ];
+  return {
+    ...result,
+    success,
+    status: success ? 'completed' : 'failed',
+    summary: success ? 'Static Site Importer validation completed.' : (abilityResult.error?.message || result.summary || 'Static Site Importer validation failed.'),
+    session: result.session ? {
+      ...result.session,
+      status: success ? 'completed' : 'failed',
+    } : result.session,
+    outputs: {
+      ...(plainObject(result.outputs) ? result.outputs : {}),
+      import_validation_result: typedArtifact,
+      typed_artifacts: {
+        ...(plainObject(result.outputs?.typed_artifacts) ? result.outputs.typed_artifacts : {}),
+        import_validation_result: typedArtifact,
+      },
+    },
+    diagnostics,
+    metadata: {
+      ...(plainObject(result.metadata) ? result.metadata : {}),
+      artifacts: {
+        ...(plainObject(result.metadata?.artifacts) ? result.metadata.artifacts : {}),
+        ImportValidationResult: typedArtifact,
+      },
+      static_site_import_validation: {
+        ability: STATIC_SITE_IMPORT_ABILITY,
+        result: abilityResult,
+      },
+    },
+  };
+}
+
+function staticSiteImportAbilityResult(result) {
+  const candidates = [
+    result.outputs?.ability_result,
+    result.outputs?.import_result,
+    result.outputs?.result,
+    result.run?.agentResult,
+    result.run?.agent_result,
+    result.agentResult,
+    result.agent_result,
+    result.metadata?.runtime_task?.result,
+    result.metadata?.agent_runtime?.result,
+    result.raw?.agent_runtime?.result,
+  ];
+  for (const candidate of candidates) {
+    if (plainObject(candidate)) {
+      if (plainObject(candidate.result) && (candidate.success !== undefined || candidate.result.import_report_summary)) {
+        return candidate;
+      }
+      if (candidate.import_report_summary || candidate.error || candidate.success !== undefined) {
+        return candidate;
+      }
+    }
+  }
+  return plainObject(result.outputs?.import_validation_result?.payload) ? result.outputs.import_validation_result.payload : {};
+}
+
+function importValidationTypedArtifact(input, abilityResult, result) {
+  const importResult = plainObject(abilityResult.result) ? abilityResult.result : abilityResult;
+  const summary = importResult.import_report_summary || abilityResult.import_report_summary || {};
+  const payload = {
+    schema: 'wp-site-generator/ImportValidationResult/v1',
+    type: 'ImportValidationResult',
+    success: abilityResult.success !== false && result.success !== false,
+    status: summary.status || (abilityResult.success === false ? 'failed' : 'completed'),
+    quality_pass: summary.quality_pass,
+    fallback_count: summary.fallback_count,
+    core_html_block_count: summary.core_html_block_count,
+    freeform_block_count: summary.freeform_block_count,
+    invalid_block_count: summary.invalid_block_count,
+    content_loss_count: summary.content_loss_count,
+    diagnostic_count: summary.diagnostic_count,
+    failure_reasons: Array.isArray(summary.failure_reasons) ? summary.failure_reasons : [],
+    diagnostics: Array.isArray(summary.diagnostics) ? summary.diagnostics : [],
+    import_report_summary: summary,
+    import_result: importResult,
+    candidate_artifact: input.parent_request?.candidate_artifact || {},
+  };
+  const fileRefs = importValidationFileRefs(importResult, abilityResult, result);
+  return Object.fromEntries(Object.entries({
+    schema: 'homeboy/agent-task-typed-artifact/v1',
+    name: 'import_validation_result',
+    type: 'ImportValidationResult',
+    artifact_schema: 'wp-site-generator/ImportValidationResult/v1',
+    payload,
+    provenance: {
+      adapter: STATIC_SITE_IMPORT_VALIDATION_KIND,
+      ability: STATIC_SITE_IMPORT_ABILITY,
+      task_id: input.parent_request?.orchestrator?.agent_task_id || input.sandbox_session_id,
+    },
+    file_refs: fileRefs,
+    metadata: {
+      artifact_outputs: input.parent_request?.artifact_outputs || {},
+      engine_data_outputs: input.parent_request?.engine_data_outputs || {},
+    },
+  }).filter(([, value]) => value !== undefined && value !== '' && !(Array.isArray(value) && value.length === 0)));
+}
+
+function importValidationFileRefs(importResult, abilityResult, result) {
+  const refs = [];
+  const addPath = (filePath, kind, label) => {
+    if (typeof filePath === 'string' && filePath !== '') {
+      refs.push({ path: filePath, kind, label, mime: 'application/json' });
+    }
+  };
+  addPath(importResult.external_report_path, 'ssi-import-report', 'Static Site Importer external import report');
+  addPath(importResult.report_path, 'ssi-import-report', 'Static Site Importer theme import report');
+  for (const ref of [...(Array.isArray(abilityResult.file_refs) ? abilityResult.file_refs : []), ...(Array.isArray(result.file_refs) ? result.file_refs : [])]) {
+    refs.push(typeof ref === 'string' ? { path: ref } : ref);
+  }
+  for (const artifact of [...(Array.isArray(abilityResult.artifacts) ? abilityResult.artifacts : []), ...(Array.isArray(result.artifacts) ? result.artifacts : [])]) {
+    if (plainObject(artifact) && (artifact.path || artifact.url)) {
+      refs.push({
+        id: artifact.id,
+        path: artifact.path,
+        url: artifact.url,
+        kind: artifact.kind || artifact.type || 'ssi-artifact',
+        label: artifact.label || artifact.name,
+        mime: artifact.mime,
+      });
+    }
+  }
+  return refs.filter((ref, index) => ref && (ref.path || ref.url) && refs.findIndex((candidate) => (candidate.path || candidate.url) === (ref.path || ref.url)) === index);
 }
 
 function parseJsonObject(value) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -223,6 +223,7 @@ assert.equal(provider.capabilities.includes('agent_bundle_execution'), true);
 assert.equal(provider.capabilities.includes('typed_bundle_outputs'), true);
 assert.equal(provider.capabilities.includes('external_recipe_packs'), true);
 assert.equal(provider.capabilities.includes('recipe_probe_artifacts'), true);
+assert.equal(provider.capabilities.includes('static_site_import_validation'), true);
 assert.deepEqual(provider.runtime_gap_trackers, []);
 
 const codeboxRequest = codeboxTaskRequestFromAgentTaskRequest(request);
@@ -713,6 +714,58 @@ const agentBundleRequestWithExplicitMount = codeboxTaskRequestFromAgentTaskReque
 assert.equal(agentBundleRequestWithExplicitMount.mounts.length, 1);
 assert.equal(agentBundleRequestWithExplicitMount.mounts[0].source, '/custom/static-site-agent');
 
+const staticValidationRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-static-import-validation-'));
+try {
+  const staticSiteImporterPath = path.join(staticValidationRoot, 'static-site-importer');
+  const blockArtifactCompilerPath = path.join(staticValidationRoot, 'block-artifact-compiler');
+  const blockFormatBridgePath = path.join(staticValidationRoot, 'block-format-bridge');
+  for (const directory of [staticSiteImporterPath, blockArtifactCompilerPath, blockFormatBridgePath]) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+  const candidateArtifact = {
+    schema: 'homeboy/agent-task-typed-artifact/v1',
+    name: 'static_site_candidate',
+    type: 'StaticSiteCandidate',
+    artifact_schema: 'wp-site-generator/StaticSiteCandidate/v1',
+    payload: { slug: 'cedar-studio', name: 'Cedar Studio', website: { pages: [] } },
+    file_refs: [{ path: '/tmp/static-site-candidate.json', mime: 'application/json' }],
+  };
+  const staticValidationRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'validate-static-site-candidate-123',
+    executor: {
+      backend: 'codebox',
+      config: {
+        execution_kind: 'static_site_import_validation_adapter',
+        candidate_artifact: candidateArtifact,
+        artifact_outputs: {
+          import_validation_result: { schema: 'wp-site-generator/ImportValidationResult/v1' },
+        },
+        engine_data_outputs: {
+          import_validation_result: 'metadata.artifacts.ImportValidationResult',
+        },
+        static_site_importer_path: staticSiteImporterPath,
+        block_artifact_compiler_path: blockArtifactCompilerPath,
+        block_format_bridge_path: blockFormatBridgePath,
+      },
+    },
+  });
+  assert.equal(staticValidationRequest.execution_kind, 'static_site_import_validation_adapter');
+  assert.equal(staticValidationRequest.runtime_task.ability, 'static-site-importer/import-website-artifact');
+  assert.equal(staticValidationRequest.runtime_task.input.artifact.slug, 'cedar-studio');
+  assert.equal(staticValidationRequest.runtime_task.input.slug, 'cedar-studio');
+  assert.equal(staticValidationRequest.runtime_task.input.name, 'Cedar Studio');
+  assert.equal(staticValidationRequest.runtime_task.input.source_metadata.candidate_file_refs[0].path, '/tmp/static-site-candidate.json');
+  assert.equal(staticValidationRequest.candidate_artifact.payload.slug, 'cedar-studio');
+  assert.equal(staticValidationRequest.artifact_outputs.import_validation_result.schema, 'wp-site-generator/ImportValidationResult/v1');
+  assert.equal(staticValidationRequest.engine_data_outputs.import_validation_result, 'metadata.artifacts.ImportValidationResult');
+  assert.equal(staticValidationRequest.extra_plugins.find((plugin) => plugin.slug === 'static-site-importer').source, staticSiteImporterPath);
+  assert.equal(staticValidationRequest.extra_plugins.find((plugin) => plugin.slug === 'block-artifact-compiler').source, blockArtifactCompilerPath);
+  assert.equal(staticValidationRequest.extra_plugins.find((plugin) => plugin.slug === 'block-format-bridge').source, blockFormatBridgePath);
+} finally {
+  fs.rmSync(staticValidationRoot, { recursive: true, force: true });
+}
+
 const outcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: false,
   provider_error: true,
@@ -941,6 +994,41 @@ assert.equal(agentBundleOutcome.metadata.sandbox_policy.sandbox_tool_policy.tool
 assert.equal(upstreamRunnerOutcome.artifacts[1].kind, 'codebox-session-artifacts');
 assert.equal(upstreamRunnerOutcome.evidence_refs[0].uri, 'https://preview.example.test/sandbox-session-1');
 assert.equal(upstreamRunnerOutcome.evidence_refs[1].uri, '/tmp/wp-codebox-artifacts');
+
+const staticValidationOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  task_id: 'validate-static-site-candidate-123',
+  executor: { backend: 'codebox' },
+}, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  artifacts: '/tmp/wp-codebox-artifacts',
+  outputs: {
+    import_validation_result: {
+      schema: 'homeboy/agent-task-typed-artifact/v1',
+      name: 'import_validation_result',
+      type: 'ImportValidationResult',
+      artifact_schema: 'wp-site-generator/ImportValidationResult/v1',
+      payload: { fallback_count: 0, import_report_summary: { status: 'completed', quality_pass: true } },
+      file_refs: [{ path: '/tmp/wp-codebox-artifacts/import-validation-report.json', mime: 'application/json' }],
+    },
+    typed_artifacts: {
+      import_validation_result: {
+        schema: 'homeboy/agent-task-typed-artifact/v1',
+        name: 'import_validation_result',
+        type: 'ImportValidationResult',
+        artifact_schema: 'wp-site-generator/ImportValidationResult/v1',
+        payload: { fallback_count: 0, import_report_summary: { status: 'completed', quality_pass: true } },
+        file_refs: [{ path: '/tmp/wp-codebox-artifacts/import-validation-report.json', mime: 'application/json' }],
+      },
+    },
+  },
+});
+assert.equal(staticValidationOutcome.status, 'succeeded');
+assert.equal(staticValidationOutcome.outputs.import_validation_result.type, 'ImportValidationResult');
+assert.equal(staticValidationOutcome.outputs.typed_artifacts.import_validation_result.artifact_schema, 'wp-site-generator/ImportValidationResult/v1');
+assert.equal(staticValidationOutcome.artifacts.some((artifact) => artifact.kind === 'typed-bundle-output' && artifact.name === 'import_validation_result' && artifact.path === '/tmp/wp-codebox-artifacts/import-validation-report.json'), true);
+assert.equal(staticValidationOutcome.evidence_refs.some((ref) => ref.uri === '/tmp/wp-codebox-artifacts/import-validation-report.json'), true);
 
 const canonicalTopLevelAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -60,6 +60,28 @@ if (process.env.FIXTURE_WP_CODEBOX_JSON_VALIDATION_FAILURE) {
   process.exit(0);
 }
 const isAgentBundle = Boolean(input.agent_bundle && Object.keys(input.agent_bundle).length);
+const isStaticImportValidation = input.runtime_task && input.runtime_task.ability === 'static-site-importer/import-website-artifact';
+const staticImportValidationResult = isStaticImportValidation
+  ? {
+      success: true,
+      result: {
+        theme_slug: input.runtime_task.input.slug,
+        report_path: input.artifacts_path + '/theme/import-report.json',
+        external_report_path: input.runtime_task.input.report,
+        import_report_summary: {
+          status: 'completed',
+          quality_pass: true,
+          fallback_count: 0,
+          core_html_block_count: 0,
+          freeform_block_count: 0,
+          invalid_block_count: 0,
+          content_loss_count: 0,
+          diagnostic_count: 0,
+          diagnostics: []
+        }
+      }
+    }
+  : null;
 const bundleRun = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
   ? {
       schema: 'datamachine/agent-bundle-run/v1',
@@ -103,7 +125,9 @@ const bundleRun = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
         : { store_idea_agent: { issue_number: 123, issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123' } }
     }
   : null;
-const agentResult = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_AGENT_BUNDLE
+const agentResult = isStaticImportValidation
+  ? staticImportValidationResult
+  : (isAgentBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_AGENT_BUNDLE
   ? { scenarios: [{ id: 'agent-bundle', metadata: { error: 'Agent bundle child job 456 did not reach a terminal state after drain; current status is pending.' } }] }
   : (isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
       ? {
@@ -124,7 +148,7 @@ const agentResult = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_AGENT
         }
   : (isAgentBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_AGENT_BUNDLE
       ? { metrics: { config_present: 1 }, metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }
-      : { status: 'completed' })));
+      : { status: 'completed' }))));
 fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), input }, null, 2));
 const execution = { recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed', output: JSON.stringify(agentResult) }) };
 const executions = [execution];
@@ -288,6 +312,53 @@ try {
   assert.equal(runtimeTaskCaptured.input.sandbox_tool_policy.tools[0].id, 'homeboy-canary/write-file');
   assert.equal(runtimeTaskCaptured.input.runtime_task.ability, 'homeboy-canary/write-file');
   assert.equal(runtimeTaskCaptured.input.workspaces[0].target, '/workspace/codebox-canary');
+
+  const staticValidationCapturePath = path.join(root, 'capture-static-import-validation.json');
+  const staticValidationArtifacts = path.join(root, 'static-import-validation-artifacts');
+  const staticValidationResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+    '--artifacts', staticValidationArtifacts,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      execution_kind: 'static_site_import_validation_adapter',
+      candidate_artifact: {
+        schema: 'homeboy/agent-task-typed-artifact/v1',
+        name: 'static_site_candidate',
+        type: 'StaticSiteCandidate',
+        artifact_schema: 'wp-site-generator/StaticSiteCandidate/v1',
+        payload: { slug: 'cedar-studio', name: 'Cedar Studio', website: { pages: [] } },
+        file_refs: [{ path: '/tmp/static-site-candidate.json', mime: 'application/json' }],
+      },
+      artifact_outputs: { import_validation_result: { schema: 'wp-site-generator/ImportValidationResult/v1' } },
+      engine_data_outputs: { import_validation_result: 'metadata.artifacts.ImportValidationResult' },
+      extra_plugins: [
+        { slug: 'static-site-importer', source: '/components/static-site-importer', activate: true },
+        { slug: 'block-artifact-compiler', source: '/components/block-artifact-compiler', activate: true },
+        { slug: 'block-format-bridge', source: '/components/block-format-bridge', activate: true },
+      ],
+    }),
+    env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: staticValidationCapturePath, OPENCODE_API_KEY: 'redacted-test-key' },
+  });
+  assert.equal(staticValidationResult.status, 0, staticValidationResult.stderr || staticValidationResult.stdout);
+  const staticValidationCaptured = readJson(staticValidationCapturePath);
+  assert.equal(staticValidationCaptured.input.runtime_task.ability, 'static-site-importer/import-website-artifact');
+  assert.equal(staticValidationCaptured.input.runtime_task.input.artifact.slug, 'cedar-studio');
+  assert.equal(staticValidationCaptured.input.runtime_task.input.report, path.join(staticValidationArtifacts, 'import-validation-report.json'));
+  assert.equal(staticValidationCaptured.input.runtime_task.input.source_metadata.candidate_file_refs[0].path, '/tmp/static-site-candidate.json');
+  assert.equal(staticValidationCaptured.input.sandbox_tool_policy.tools[0].id, 'static-site-importer/import-website-artifact');
+  assert.equal(staticValidationCaptured.input.extra_plugins.find((plugin) => plugin.slug === 'static-site-importer').source, '/components/static-site-importer');
+  assert.equal(staticValidationCaptured.input.extra_plugins.find((plugin) => plugin.slug === 'block-artifact-compiler').source, '/components/block-artifact-compiler');
+  assert.equal(staticValidationCaptured.input.extra_plugins.find((plugin) => plugin.slug === 'block-format-bridge').source, '/components/block-format-bridge');
+  const staticValidationOutput = JSON.parse(staticValidationResult.stdout);
+  assert.equal(staticValidationOutput.success, true);
+  assert.equal(staticValidationOutput.outputs.import_validation_result.type, 'ImportValidationResult');
+  assert.equal(staticValidationOutput.outputs.typed_artifacts.import_validation_result.artifact_schema, 'wp-site-generator/ImportValidationResult/v1');
+  assert.equal(staticValidationOutput.outputs.import_validation_result.payload.import_report_summary.quality_pass, true);
+  assert.equal(staticValidationOutput.outputs.import_validation_result.file_refs.some((ref) => ref.path === path.join(staticValidationArtifacts, 'import-validation-report.json')), true);
+  assert.equal(staticValidationOutput.metadata.artifacts.ImportValidationResult.type, 'ImportValidationResult');
 
   const codexCapturePath = path.join(root, 'capture-codex.json');
   const codexSecretEnv = [


### PR DESCRIPTION
## Summary
- Adds the `static_site_import_validation_adapter` bridge for Homeboy plan tasks by routing through WP Codebox runtime task execution of `static-site-importer/import-website-artifact`.
- Preserves `StaticSiteCandidate` typed artifact payload/file refs, mounts Static Site Importer plus Block Artifact Compiler and Block Format Bridge components when available, and emits a typed `ImportValidationResult` output.
- Extends WP Codebox executor and runner smoke coverage for adapter request construction, runtime-task normalization, and typed output artifacts without changing the existing `agent_bundle` path.

## Verification
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the adapter implementation and targeted smoke tests; Chris remains responsible for review and validation.