### PR TITLE
Add static site import validation adapter

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -27,7 +27,10 @@ const PROVIDER_CAPABILITIES = [
   'typed_bundle_outputs',
   'external_recipe_packs',
   'recipe_probe_artifacts',
+  'static_site_import_validation_adapter',
 ];
+
+const STATIC_SITE_IMPORT_VALIDATION_ADAPTER = 'static_site_import_validation_adapter';
 
 const DEFAULT_WORKSPACE_READONLY_TOOLS = [
   'workspace_ls',
@@ -179,7 +182,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const recipe = recipeConfigFromAgentTaskRequest(request, config, inputs);
   const mounts = agentBundleMounts(agentBundle, config.mounts || defaults.mounts || options.mounts || []);
   const components = runtimeComponentPaths(config, { ...defaults, ...options });
-  const runtimeTask = inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || options.runtimeTask;
+  const validationAdapter = staticSiteImportValidationAdapterConfig(request, config, inputs, defaults, options);
+  const runtimeTask = validationAdapter.runtime_task || inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || options.runtimeTask;
   const sandboxToolPolicy = firstDefined(inputs.sandbox_tool_policy, inputs.sandboxToolPolicy, config.sandbox_tool_policy, config.sandboxToolPolicy, options.sandboxToolPolicy, defaults.sandboxToolPolicy);
   const allowedTools = firstDefined(inputs.allowed_tools, inputs.allowedTools, config.allowed_tools, config.allowedTools, options.allowedTools, defaults.allowedTools);
   const explicitSecretEnv = [
@@ -218,6 +222,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     provider: config.provider || options.provider || defaults.provider || '',
     model: request.executor.model || config.model || options.model || defaults.model || '',
     provider_plugin_paths: config.provider_plugin_paths || options.providerPluginPaths || defaults.providerPluginPaths || [],
+    extra_plugins: validationAdapter.extra_plugins || config.extra_plugins || config.extraPlugins || options.extraPlugins || [],
     agent_bundles: config.agent_bundles || config.agentBundles || options.agentBundles || [],
     runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
     runtime_overlay_profiles: config.runtime_overlay_profiles || config.runtimeOverlayProfiles || options.runtimeOverlayProfiles || defaults.runtimeOverlayProfiles || [],
@@ -247,6 +252,10 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
       source_refs: request.source_refs || [],
     },
     agent_bundle: agentBundle,
+    execution_kind: validationAdapter.execution_kind || config.execution_kind || inputs.execution_kind,
+    candidate_artifact: validationAdapter.candidate_artifact,
+    artifact_outputs: validationAdapter.artifact_outputs,
+    engine_data_outputs: validationAdapter.engine_data_outputs,
     parent_request: request,
   };
 }
@@ -301,6 +310,33 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     process.env.HOMEBOY_WP_CODEBOX_AGENTS_API_PATH,
     bundledAgentsApiPath(dataMachinePath),
   );
+  const staticSiteImporterPath = firstExistingPath(
+    options.staticSiteImporter,
+    settings.wp_codebox_static_site_importer_path,
+    settings.static_site_importer_path,
+    process.env.HOMEBOY_STATIC_SITE_IMPORTER_PATH,
+    process.env.HOMEBOY_WP_CODEBOX_STATIC_SITE_IMPORTER_PATH,
+    activeSitePluginPath('static-site-importer'),
+    siblingPath(workspaceBase, 'static-site-importer'),
+  );
+  const blockArtifactCompilerPath = firstExistingPath(
+    options.blockArtifactCompiler,
+    settings.wp_codebox_block_artifact_compiler_path,
+    settings.block_artifact_compiler_path,
+    process.env.HOMEBOY_BLOCK_ARTIFACT_COMPILER_PATH,
+    process.env.HOMEBOY_WP_CODEBOX_BLOCK_ARTIFACT_COMPILER_PATH,
+    activeSitePluginPath('block-artifact-compiler'),
+    siblingPath(workspaceBase, 'block-artifact-compiler'),
+  );
+  const blockFormatBridgePath = firstExistingPath(
+    options.blockFormatBridge,
+    settings.wp_codebox_block_format_bridge_path,
+    settings.block_format_bridge_path,
+    process.env.HOMEBOY_BLOCK_FORMAT_BRIDGE_PATH,
+    process.env.HOMEBOY_WP_CODEBOX_BLOCK_FORMAT_BRIDGE_PATH,
+    activeSitePluginPath('block-format-bridge'),
+    siblingPath(workspaceBase, 'block-format-bridge'),
+  );
 
   return {
     agentsApi: agentsApiPath,
@@ -311,11 +347,49 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     model,
     secretEnv: defaultSecretEnv(provider, settings),
     runtimeOverlayProfiles: defaultRuntimeOverlayProfiles(provider),
+    staticSiteImporterPath,
+    blockArtifactCompilerPath,
+    blockFormatBridgePath,
     mounts: defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options),
     workspaces: defaultWorkspaces(config, inputs, options),
     allowedTools: defaultWorkspaceAllowedTools(workspaceRoot, workspaceMode(request, config, inputs)),
     sandboxToolPolicy: defaultWorkspaceSandboxToolPolicy(workspaceRoot, workspaceMode(request, config, inputs)),
   };
+}
+
+function staticSiteImportValidationAdapterConfig(request, config, inputs, defaults, options = {}) {
+  const executionKind = firstValue(inputs.execution_kind, config.execution_kind, options.executionKind);
+  if (executionKind !== STATIC_SITE_IMPORT_VALIDATION_ADAPTER) {
+    return {};
+  }
+
+  return {
+    execution_kind: STATIC_SITE_IMPORT_VALIDATION_ADAPTER,
+    candidate_artifact: firstValue(inputs.candidate_artifact, inputs.candidateArtifact, config.candidate_artifact, config.candidateArtifact, options.candidateArtifact),
+    artifact_outputs: firstObject(inputs.artifact_outputs, inputs.artifactOutputs, config.artifact_outputs, config.artifactOutputs, options.artifactOutputs) || {},
+    engine_data_outputs: firstObject(inputs.engine_data_outputs, inputs.engineDataOutputs, config.engine_data_outputs, config.engineDataOutputs, options.engineDataOutputs) || {},
+    runtime_task: { ability: 'static-site-importer/import-website-artifact' },
+    extra_plugins: staticSiteImportValidationPlugins(defaults, config, options),
+  };
+}
+
+function staticSiteImportValidationPlugins(defaults, config, options = {}) {
+  const explicit = normalizeArray(config.extra_plugins || config.extraPlugins || options.extraPlugins);
+  const plugins = [
+    ...explicit,
+    { slug: 'block-format-bridge', source: firstValue(config.block_format_bridge_path, config.blockFormatBridgePath, defaults.blockFormatBridgePath), activate: true },
+    { slug: 'block-artifact-compiler', source: firstValue(config.block_artifact_compiler_path, config.blockArtifactCompilerPath, defaults.blockArtifactCompilerPath), activate: true },
+    { slug: 'static-site-importer', source: firstValue(config.static_site_importer_path, config.staticSiteImporterPath, defaults.staticSiteImporterPath), activate: true },
+  ].filter((plugin) => plugin && typeof plugin === 'object' && plugin.source);
+  const seen = new Set();
+  return plugins.filter((plugin) => {
+    const key = `${plugin.slug || ''}:${plugin.source || ''}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
 }
 
 function defaultProviderPluginPaths(provider, settings, fallbackProviderPluginPath) {

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -350,6 +350,7 @@ const LEGACY_BUNDLE_KEYS = [
   `${LEGACY_RUNTIME_PREFIX}_bundle`,
   `${LEGACY_RUNTIME_PREFIX}Bundle`,
 ];
+const STATIC_SITE_IMPORT_VALIDATION_ADAPTER = 'static_site_import_validation_adapter';
 
 function legacyValue(source, suffix = '') {
   if (!source || typeof source !== 'object') {
@@ -410,10 +411,15 @@ function runnerInput(request, artifacts) {
     wp_codebox_bin: argValue('--wp-codebox-bin') || request.wp_codebox_bin || '',
     agents_api_path: argValue('--agents-api') || request.agents_api_path || request.agents_api || '',
     runtime_component_paths: runtimeComponentPaths,
+    extra_plugins: request.extra_plugins || request.extraPlugins || [],
     homeboy_path: argValue('--homeboy') || request.homeboy_path || request.homeboy || '',
     homeboy_extensions_path: argValue('--homeboy-extensions') || request.homeboy_extensions_path || request.homeboy_extensions || path.resolve(__dirname, '..', '..'),
     wp_version: request.wp_codebox_wordpress_version || request.wp_version || request.wp || undefined,
     agent_bundle: requestAgentBundle(request),
+    execution_kind: request.execution_kind,
+    candidate_artifact: request.candidate_artifact || request.candidateArtifact,
+    artifact_outputs: request.artifact_outputs || request.artifactOutputs,
+    engine_data_outputs: request.engine_data_outputs || request.engineDataOutputs,
   }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
 }
 
@@ -465,7 +471,8 @@ function verifySteps(input) {
 
 function extraPlugins(input) {
   const explicit = input.parent_request?.extra_plugins || input.parent_request?.extraPlugins || [];
-  const plugins = [...runtimeComponentExtraPlugins(input), ...(Array.isArray(explicit) ? explicit : [])];
+  const inputPlugins = input.extra_plugins || [];
+  const plugins = [...runtimeComponentExtraPlugins(input), ...(Array.isArray(inputPlugins) ? inputPlugins : []), ...(Array.isArray(explicit) ? explicit : [])];
   const seen = new Set();
   return plugins.filter((plugin) => {
     const key = `${plugin.slug || ''}:${plugin.source || ''}`;
@@ -527,12 +534,20 @@ function stableTaskInput(input) {
     wp: input.wp_version,
     agent_bundle: isAgentBundle(input) ? agentBundleConfig(input, input.agent_bundle || {}) : {},
     runtime_task: runtimeTask(input),
+    execution_kind: input.execution_kind,
+    candidate_artifact: input.candidate_artifact,
+    artifact_outputs: input.artifact_outputs,
+    engine_data_outputs: input.engine_data_outputs,
     parent_request: input.parent_request,
   }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
 }
 
 function plainObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function firstValue(...values) {
+  return values.find((value) => value !== undefined && value !== null && value !== '');
 }
 
 function normalizeTypedArtifactEntry(name, artifact) {
@@ -639,14 +654,155 @@ function isAgentBundle(input) {
   return Boolean(input.agent_bundle && Object.keys(input.agent_bundle).length > 0);
 }
 
+function isStaticSiteImportValidationAdapter(input) {
+  return input.execution_kind === STATIC_SITE_IMPORT_VALIDATION_ADAPTER || input.parent_request?.execution_kind === STATIC_SITE_IMPORT_VALIDATION_ADAPTER;
+}
+
+function staticSiteImportValidationCandidateSource(input) {
+  return input.candidate_artifact
+    || input.parent_request?.candidate_artifact
+    || input.parent_request?.candidateArtifact
+    || input.parent_request?.inputs?.candidate_artifact
+    || input.parent_request?.inputs?.candidateArtifact;
+}
+
+function resolveStaticSiteCandidate(input) {
+  const candidate = normalizeStaticSiteCandidate(staticSiteImportValidationCandidateSource(input));
+  if (candidate) {
+    return candidate;
+  }
+  throw staticSiteImportValidationError('missing_candidate', 'Static site import validation requires a StaticSiteCandidate typed artifact payload or file ref.');
+}
+
+function normalizeStaticSiteCandidate(value) {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed || /^\{\{.*\}\}$/.test(trimmed)) {
+      return null;
+    }
+    if (fs.existsSync(trimmed)) {
+      return normalizeStaticSiteCandidate(readJsonIfAvailable(trimmed));
+    }
+    return normalizeStaticSiteCandidate(parseJsonObject(trimmed));
+  }
+  if (!plainObject(value)) {
+    return null;
+  }
+
+  const typed = normalizeTypedArtifactEntry(value.name || value.id || 'static_site_candidate', value);
+  const candidate = typed?.type === 'StaticSiteCandidate' || typed?.artifact_schema === 'static-site-importer/static-site-candidate/v1'
+    ? typed
+    : normalizeTypedArtifactEntry('static_site_candidate', value.static_site_candidate || value.staticSiteCandidate || value.typed_artifacts?.static_site_candidate || value.typedArtifacts?.static_site_candidate);
+  if (!candidate) {
+    return null;
+  }
+  if (plainObject(candidate.payload)) {
+    return candidate;
+  }
+  for (const ref of candidate.file_refs || []) {
+    const refPath = typeof ref === 'string' ? ref : (ref?.path || ref?.file);
+    const fileCandidate = refPath ? normalizeStaticSiteCandidate(readJsonIfAvailable(refPath)) : null;
+    if (fileCandidate) {
+      return fileCandidate;
+    }
+  }
+  return candidate;
+}
+
+function websiteArtifactFromCandidate(candidate) {
+  const payload = plainObject(candidate.payload) ? candidate.payload : {};
+  const artifact = payload.website_artifact || payload.websiteArtifact || payload.artifact || payload.block_artifact || payload.blockArtifact;
+  if (plainObject(artifact)) {
+    return artifact;
+  }
+  if (payload.schema || payload.files || payload.documents || payload.blocks || payload.entrypoint || payload.entry_point || payload.website) {
+    return payload;
+  }
+  for (const ref of candidate.file_refs || []) {
+    const refPath = typeof ref === 'string' ? ref : (ref?.path || ref?.file);
+    const filePayload = refPath ? readJsonIfAvailable(refPath) : null;
+    const fileCandidate = normalizeStaticSiteCandidate(filePayload);
+    if (fileCandidate && fileCandidate !== candidate) {
+      return websiteArtifactFromCandidate(fileCandidate);
+    }
+  }
+  throw staticSiteImportValidationError('malformed_candidate', 'StaticSiteCandidate does not contain a website artifact payload.');
+}
+
+function staticSiteImportValidationError(reason, message, data = {}) {
+  const error = new Error(message);
+  error.code = 'static_site_import_validation_adapter.invalid_candidate';
+  error.reason = reason;
+  error.data = data;
+  return error;
+}
+
+function staticSiteImportValidationFailurePayload(error, artifacts) {
+  return {
+    schema: 'wp-codebox/agent-task-run/v1',
+    success: false,
+    status: 'failed',
+    summary: error.message || 'Static site import validation adapter failed.',
+    artifacts,
+    outputs: {},
+    diagnostics: [{
+      class: error.code || 'static_site_import_validation_adapter.failed',
+      message: error.message || String(error),
+      data: { reason: error.reason || 'adapter_error', ...(plainObject(error.data) ? error.data : {}) },
+    }],
+    metadata: {
+      static_site_import_validation_adapter: {
+        reason: error.reason || 'adapter_error',
+      },
+    },
+  };
+}
+
 function runtimeTask(input) {
   if (plainObject(input.runtime_task)) {
+    if (isStaticSiteImportValidationAdapter(input) && input.runtime_task.ability === 'static-site-importer/import-website-artifact') {
+      return staticSiteImportValidationRuntimeTask(input);
+    }
     return input.runtime_task;
+  }
+  if (isStaticSiteImportValidationAdapter(input)) {
+    return staticSiteImportValidationRuntimeTask(input);
   }
   if (isAgentBundle(input)) {
     return agentBundleRuntimeTask(input, input.agent_bundle || {});
   }
   return undefined;
+}
+
+function staticSiteImportValidationRuntimeTask(input) {
+  const candidate = resolveStaticSiteCandidate(input);
+  const payload = candidate.payload || {};
+  const artifact = websiteArtifactFromCandidate(candidate);
+  return {
+    ability: 'static-site-importer/import-website-artifact',
+    input: Object.fromEntries(Object.entries({
+      artifact,
+      slug: payload.slug || payload.theme_slug || payload.site_slug || input.parent_request?.slug || 'static-site-import-validation',
+      name: payload.name || payload.title || payload.theme_name || 'Static Site Import Validation',
+      activate: input.parent_request?.activate ?? true,
+      overwrite: input.parent_request?.overwrite ?? true,
+      keep_source: input.parent_request?.keep_source ?? true,
+      fail_on_quality: input.parent_request?.fail_on_quality ?? false,
+      max_fallbacks: input.parent_request?.max_fallbacks,
+      allow_missing_woocommerce: input.parent_request?.allow_missing_woocommerce ?? true,
+      report: path.join(input.artifacts_path, 'import-report.json'),
+      asset_policy: input.parent_request?.asset_policy,
+      asset_materialization_policy: input.parent_request?.asset_materialization_policy || 'copy_to_theme',
+      asset_map: payload.asset_map || input.parent_request?.asset_map,
+      compiler_options: input.parent_request?.compiler_options || {},
+      source_metadata: {
+        ...(plainObject(payload.source_metadata) ? payload.source_metadata : {}),
+        homeboy_execution_kind: STATIC_SITE_IMPORT_VALIDATION_ADAPTER,
+        candidate_name: candidate.name,
+        candidate_artifact_schema: candidate.artifact_schema,
+      },
+    }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0))),
+  };
 }
 
 function agentBundleConfig(input, bundleConfig = {}) {
@@ -688,6 +844,9 @@ function resultExecutions(result) {
 }
 
 function normalizeAgentTaskRun(input, result) {
+  if (isStaticSiteImportValidationAdapter(input)) {
+    return normalizeStaticSiteImportValidationRun(input, result);
+  }
   if (!isAgentBundle(input)) {
     return result;
   }
@@ -730,6 +889,184 @@ function normalizeAgentTaskRun(input, result) {
       },
     },
   };
+}
+
+function normalizeStaticSiteImportValidationRun(input, result) {
+  const validation = staticSiteImportValidationArtifacts(input, result);
+  const diagnostics = [
+    ...(Array.isArray(result.diagnostics) ? result.diagnostics : []),
+    ...(validation.diagnostic ? [validation.diagnostic] : []),
+  ];
+  const success = result.success !== false && result.status !== 'failed' && Boolean(validation.importValidationResult);
+  const typedArtifacts = Object.fromEntries(Object.entries({
+    import_validation_result: validation.importValidationTypedArtifact,
+    finding_packets: validation.findingPacketsTypedArtifact,
+  }).filter(([, value]) => value));
+
+  return {
+    ...result,
+    success,
+    status: success ? 'completed' : 'failed',
+    summary: success
+      ? 'Static site import validation completed through Static Site Importer.'
+      : (validation.diagnostic?.message || result.summary || 'Static site import validation failed.'),
+    outputs: {
+      ...(plainObject(result.outputs) ? result.outputs : {}),
+      import_validation_result: validation.importValidationResult,
+      typed_artifacts: {
+        ...(plainObject(result.outputs?.typed_artifacts) ? result.outputs.typed_artifacts : {}),
+        ...typedArtifacts,
+      },
+    },
+    artifacts: [...staticSiteImportValidationBaseArtifacts(result), ...validation.artifacts],
+    evidence_refs: [
+      ...(Array.isArray(result.evidence_refs) ? result.evidence_refs : []),
+      ...validation.evidenceRefs,
+    ],
+    diagnostics,
+    metadata: {
+      ...(plainObject(result.metadata) ? result.metadata : {}),
+      static_site_import_validation_adapter: {
+        candidate: validation.candidateSummary,
+        import_validation_result_path: validation.importValidationResultPath,
+        finding_packets_path: validation.findingPacketsPath,
+      },
+    },
+  };
+}
+
+function staticSiteImportValidationBaseArtifacts(result) {
+  if (Array.isArray(result.artifacts)) {
+    return result.artifacts;
+  }
+  if (typeof result.artifacts === 'string' && result.artifacts) {
+    return [{ id: 'wp-codebox-artifacts', kind: 'codebox-artifact-directory', path: result.artifacts }];
+  }
+  return [];
+}
+
+function staticSiteImportValidationArtifacts(input, result) {
+  const candidate = resolveStaticSiteCandidate(input);
+  const abilityResult = firstPlainObject(
+    result.outputs?.runtime_task_result,
+    result.outputs?.runtimeTaskResult,
+    result.outputs?.result,
+    result.run?.agentResult?.result,
+    result.run?.agentResult?.output,
+    result.agentResult?.result,
+    result.agent_result?.result,
+    result.metadata?.runtime_task_result,
+    result.metadata?.runtimeTaskResult,
+    result.result,
+  ) || {};
+  const importValidationResult = firstPlainObject(
+    result.outputs?.import_validation_result,
+    result.outputs?.importValidationResult,
+    abilityResult.import_validation_result,
+    abilityResult.importValidationResult,
+    abilityResult.result?.import_validation_result,
+    abilityResult.result?.importValidationResult,
+    readJsonIfAvailable(firstValue(
+      result.outputs?.import_validation_result_path,
+      abilityResult.import_validation_result_path,
+      abilityResult.result?.import_validation_result_path,
+      abilityResult.result?.external_import_validation_result_path,
+    )),
+  );
+  const findingPackets = firstPlainObject(
+    result.outputs?.finding_packets,
+    result.outputs?.findingPackets,
+    abilityResult.finding_packets,
+    abilityResult.findingPackets,
+    abilityResult.result?.finding_packets,
+    abilityResult.result?.findingPackets,
+    readJsonIfAvailable(firstValue(
+      result.outputs?.finding_packets_path,
+      abilityResult.finding_packets_path,
+      abilityResult.result?.finding_packets_path,
+      abilityResult.result?.external_finding_packets_path,
+    )),
+  );
+  const importValidationResultPath = firstValue(
+    result.outputs?.import_validation_result_path,
+    abilityResult.import_validation_result_path,
+    abilityResult.result?.import_validation_result_path,
+    abilityResult.result?.external_import_validation_result_path,
+    artifactOutputPath(input, 'import_validation_result'),
+  );
+  const findingPacketsPath = firstValue(
+    result.outputs?.finding_packets_path,
+    abilityResult.finding_packets_path,
+    abilityResult.result?.finding_packets_path,
+    abilityResult.result?.external_finding_packets_path,
+  );
+  const artifacts = [];
+  const evidenceRefs = [];
+  appendValidationArtifact(artifacts, evidenceRefs, 'import-validation-result', 'static-site-importer/import-validation-result', importValidationResultPath, importValidationResult);
+  appendValidationArtifact(artifacts, evidenceRefs, 'finding-packets', 'static-site-importer/finding-packets', findingPacketsPath, findingPackets);
+
+  const diagnostic = importValidationResult ? null : {
+    class: 'static_site_import_validation_adapter.missing_import_validation_result',
+    message: 'Static Site Importer completed without an import_validation_result artifact.',
+    data: { reason: 'missing_import_validation_result', ability_result: abilityResult },
+  };
+  return {
+    candidateSummary: {
+      name: candidate.name,
+      artifact_schema: candidate.artifact_schema,
+      file_refs: candidate.file_refs,
+    },
+    importValidationResult,
+    findingPackets,
+    importValidationResultPath,
+    findingPacketsPath,
+    importValidationTypedArtifact: importValidationResult ? typedValidationArtifact('import_validation_result', 'ImportValidationResult', 'static-site-importer/import-validation-result/v1', importValidationResult, importValidationResultPath, candidate) : null,
+    findingPacketsTypedArtifact: findingPackets ? typedValidationArtifact('finding_packets', 'FindingPacketSet', 'static-site-importer/finding-packets/v1', findingPackets, findingPacketsPath, candidate) : null,
+    artifacts,
+    evidenceRefs,
+    diagnostic,
+  };
+}
+
+function typedValidationArtifact(name, type, schema, payload, filePath, candidate) {
+  return Object.fromEntries(Object.entries({
+    schema: 'homeboy/agent-task-typed-artifact/v1',
+    name,
+    type,
+    artifact_schema: payload.schema || payload.artifact_schema || schema,
+    payload,
+    provenance: {
+      source: STATIC_SITE_IMPORT_VALIDATION_ADAPTER,
+      candidate_name: candidate.name,
+      candidate_artifact_schema: candidate.artifact_schema,
+    },
+    file_refs: filePath ? [{ path: filePath, mime: 'application/json' }] : [],
+  }).filter(([, value]) => value !== undefined && value !== '' && !(Array.isArray(value) && value.length === 0)));
+}
+
+function appendValidationArtifact(artifacts, evidenceRefs, id, kind, filePath, payload) {
+  if (!filePath && !payload) {
+    return;
+  }
+  const artifact = {
+    id,
+    kind,
+    path: filePath,
+    metadata: payload ? { schema: payload.schema, artifact_type: payload.artifact_type || payload.artifactType } : {},
+  };
+  artifacts.push(artifact);
+  if (filePath) {
+    evidenceRefs.push({ kind, uri: filePath, label: kind.replace(/-/g, ' ') });
+  }
+}
+
+function artifactOutputPath(input, name) {
+  const output = input.artifact_outputs?.[name] || input.parent_request?.artifact_outputs?.[name] || input.parent_request?.artifactOutputs?.[name];
+  return plainObject(output) ? output.path : '';
+}
+
+function firstPlainObject(...candidates) {
+  return candidates.find(plainObject) || null;
 }
 
 function parseJsonObject(value) {
@@ -1023,6 +1360,14 @@ function runWpCodeboxParentTask(request) {
   }
 
   const input = runnerInput(request, artifacts);
+  if (isStaticSiteImportValidationAdapter(input)) {
+    try {
+      websiteArtifactFromCandidate(resolveStaticSiteCandidate(input));
+    } catch (error) {
+      process.stdout.write(`${JSON.stringify(staticSiteImportValidationFailurePayload(error, artifacts), null, 2)}\n`);
+      return 1;
+    }
+  }
   const inputPath = writeJsonFile('homeboy-wp-codebox-agent-task-input-', stableTaskInput(input));
   const wpCodeboxBin = input.wp_codebox_bin || process.env.HOMEBOY_WP_CODEBOX_BIN || 'wp-codebox';
   const args = ['agent-task-run', `--input-file=${inputPath}`, '--json'];

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -223,6 +223,7 @@ assert.equal(provider.capabilities.includes('agent_bundle_execution'), true);
 assert.equal(provider.capabilities.includes('typed_bundle_outputs'), true);
 assert.equal(provider.capabilities.includes('external_recipe_packs'), true);
 assert.equal(provider.capabilities.includes('recipe_probe_artifacts'), true);
+assert.equal(provider.capabilities.includes('static_site_import_validation_adapter'), true);
 assert.deepEqual(provider.runtime_gap_trackers, []);
 
 const codeboxRequest = codeboxTaskRequestFromAgentTaskRequest(request);
@@ -389,7 +390,10 @@ try {
   const dataMachineCodePath = path.join(defaultsRoot, 'data-machine-code');
   const staleStandaloneAgentsApiPath = path.join(defaultsRoot, 'agents-api');
   const providerPath = path.join(defaultsRoot, 'ai-provider-for-openai');
-  for (const directory of [workspaceRoot, bundledAgentsApiPath, dataMachineCodePath, staleStandaloneAgentsApiPath, providerPath]) {
+  const staticSiteImporterPath = path.join(defaultsRoot, 'static-site-importer');
+  const blockArtifactCompilerPath = path.join(defaultsRoot, 'block-artifact-compiler');
+  const blockFormatBridgePath = path.join(defaultsRoot, 'block-format-bridge');
+  for (const directory of [workspaceRoot, bundledAgentsApiPath, dataMachineCodePath, staleStandaloneAgentsApiPath, providerPath, staticSiteImporterPath, blockArtifactCompilerPath, blockFormatBridgePath]) {
     fs.mkdirSync(directory, { recursive: true });
   }
 
@@ -621,6 +625,43 @@ try {
   assert.deepEqual(explicitOverrideRequest.secret_env, ['EXPLICIT_SECRET']);
   assert.deepEqual(explicitOverrideRequest.mounts, [{ source: '/explicit/worktree', target: '/workspace', mode: 'readonly' }]);
   assert.deepEqual(explicitOverrideRequest.workspaces, [{ target: '/explicit-workspace', mode: 'readonly' }]);
+
+  const staticValidationRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'static-validation-task-123',
+    executor: {
+      backend: 'codebox',
+      config: {
+        execution_kind: 'static_site_import_validation_adapter',
+        candidate_artifact: {
+          schema: 'homeboy/agent-task-typed-artifact/v1',
+          name: 'static_site_candidate',
+          type: 'StaticSiteCandidate',
+          artifact_schema: 'static-site-importer/static-site-candidate/v1',
+          payload: { slug: 'issue-1226', website_artifact: { schema: 'block-artifact-compiler/website-artifact/v1', files: [] } },
+        },
+        artifact_outputs: {
+          import_validation_result: { schema: 'wp-site-generator/ImportValidationResult/v1', path: '/artifacts/ImportValidationResult.json' },
+        },
+        engine_data_outputs: {
+          import_validation_result: 'metadata.artifacts.ImportValidationResult',
+        },
+      },
+    },
+    inputs: {
+      target: { root: workspaceRoot, mode: 'readonly' },
+    },
+  }, {
+    settings: {},
+  });
+  assert.equal(staticValidationRequest.execution_kind, 'static_site_import_validation_adapter');
+  assert.equal(staticValidationRequest.runtime_task.ability, 'static-site-importer/import-website-artifact');
+  assert.equal(staticValidationRequest.candidate_artifact.type, 'StaticSiteCandidate');
+  assert.equal(staticValidationRequest.artifact_outputs.import_validation_result.path, '/artifacts/ImportValidationResult.json');
+  assert.equal(staticValidationRequest.engine_data_outputs.import_validation_result, 'metadata.artifacts.ImportValidationResult');
+  assert.equal(staticValidationRequest.extra_plugins.find((plugin) => plugin.slug === 'static-site-importer').source, staticSiteImporterPath);
+  assert.equal(staticValidationRequest.extra_plugins.find((plugin) => plugin.slug === 'block-artifact-compiler').source, blockArtifactCompilerPath);
+  assert.equal(staticValidationRequest.extra_plugins.find((plugin) => plugin.slug === 'block-format-bridge').source, blockFormatBridgePath);
 } finally {
   fs.rmSync(defaultsRoot, { recursive: true, force: true });
 }

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -60,6 +60,53 @@ if (process.env.FIXTURE_WP_CODEBOX_JSON_VALIDATION_FAILURE) {
   process.exit(0);
 }
 const isAgentBundle = Boolean(input.agent_bundle && Object.keys(input.agent_bundle).length);
+if (input.execution_kind === 'static_site_import_validation_adapter') {
+  const importValidationResultPath = input.artifacts_path + '/import-validation-result.json';
+  const findingPacketsPath = input.artifacts_path + '/finding-packets.json';
+  const importValidationResult = {
+    schema: 'static-site-importer/import-validation-result/v1',
+    artifact_type: 'ImportValidationResult',
+    status: 'reported',
+    counts: { core_html_blocks: 0, fallback_blocks: 0 },
+    artifacts: { finding_packets: { path: findingPacketsPath } }
+  };
+  const findingPackets = {
+    schema: 'static-site-importer/finding-packets/v1',
+    artifact_type: 'FindingPacketSet',
+    count: 0,
+    packets: []
+  };
+  fs.mkdirSync(input.artifacts_path, { recursive: true });
+  fs.writeFileSync(importValidationResultPath, JSON.stringify(importValidationResult, null, 2));
+  fs.writeFileSync(findingPacketsPath, JSON.stringify(findingPackets, null, 2));
+  fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), input }, null, 2));
+  process.stdout.write(JSON.stringify({
+    success: true,
+    schema: 'wp-codebox/agent-task-run/v1',
+    status: 'completed',
+    session: {
+      schema: 'wp-codebox/sandbox-session/v1',
+      id: input.sandbox_session_id,
+      status: 'completed',
+      artifacts: { bundle_id: 'artifact-bundle-sha256-static-validation', path: input.artifacts_path, preview_url: 'https://preview.example.test/' + input.sandbox_session_id },
+      orchestrator: input.orchestrator
+    },
+    task_input: input,
+    artifacts: input.artifacts_path,
+    outputs: {
+      runtime_task_result: {
+        success: true,
+        result: {
+          import_validation_result: importValidationResult,
+          finding_packets: findingPackets,
+          import_validation_result_path: importValidationResultPath,
+          finding_packets_path: findingPacketsPath
+        }
+      }
+    }
+  }));
+  process.exit(0);
+}
 const bundleRun = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
   ? {
       schema: 'datamachine/agent-bundle-run/v1',
@@ -288,6 +335,83 @@ try {
   assert.equal(runtimeTaskCaptured.input.sandbox_tool_policy.tools[0].id, 'homeboy-canary/write-file');
   assert.equal(runtimeTaskCaptured.input.runtime_task.ability, 'homeboy-canary/write-file');
   assert.equal(runtimeTaskCaptured.input.workspaces[0].target, '/workspace/codebox-canary');
+
+  const staticValidationCapturePath = path.join(root, 'capture-static-validation.json');
+  const staticValidationArtifacts = path.join(root, 'static-validation-artifacts');
+  const staticValidationResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+    '--artifacts', staticValidationArtifacts,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      execution_kind: 'static_site_import_validation_adapter',
+      candidate_artifact: {
+        schema: 'homeboy/agent-task-typed-artifact/v1',
+        name: 'static_site_candidate',
+        type: 'StaticSiteCandidate',
+        artifact_schema: 'static-site-importer/static-site-candidate/v1',
+        payload: {
+          slug: 'issue-1226-static-validation',
+          name: 'Issue 1226 Static Validation',
+          website_artifact: { schema: 'block-artifact-compiler/website-artifact/v1', files: [], documents: [] },
+        },
+      },
+      artifact_outputs: {
+        import_validation_result: { schema: 'wp-site-generator/ImportValidationResult/v1', path: path.join(staticValidationArtifacts, 'import-validation-result.json') },
+      },
+      engine_data_outputs: {
+        import_validation_result: 'metadata.artifacts.ImportValidationResult',
+      },
+      extra_plugins: [
+        { slug: 'block-format-bridge', source: '/components/block-format-bridge', activate: true },
+        { slug: 'block-artifact-compiler', source: '/components/block-artifact-compiler', activate: true },
+        { slug: 'static-site-importer', source: '/components/static-site-importer', activate: true },
+      ],
+    }),
+    env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: staticValidationCapturePath, OPENCODE_API_KEY: 'redacted-test-key' },
+  });
+  assert.equal(staticValidationResult.status, 0, staticValidationResult.stderr || staticValidationResult.stdout);
+  const staticValidationCaptured = readJson(staticValidationCapturePath);
+  assert.equal(staticValidationCaptured.input.runtime_task.ability, 'static-site-importer/import-website-artifact');
+  assert.equal(staticValidationCaptured.input.runtime_task.input.artifact.schema, 'block-artifact-compiler/website-artifact/v1');
+  assert.equal(staticValidationCaptured.input.runtime_task.input.slug, 'issue-1226-static-validation');
+  assert.equal(staticValidationCaptured.input.extra_plugins.find((plugin) => plugin.slug === 'static-site-importer').source, '/components/static-site-importer');
+  assert.equal(staticValidationCaptured.input.extra_plugins.find((plugin) => plugin.slug === 'block-artifact-compiler').source, '/components/block-artifact-compiler');
+  assert.equal(staticValidationCaptured.input.extra_plugins.find((plugin) => plugin.slug === 'block-format-bridge').source, '/components/block-format-bridge');
+  const staticValidationOutput = JSON.parse(staticValidationResult.stdout);
+  assert.equal(staticValidationOutput.success, true);
+  assert.equal(staticValidationOutput.outputs.import_validation_result.schema, 'static-site-importer/import-validation-result/v1');
+  assert.equal(staticValidationOutput.outputs.typed_artifacts.import_validation_result.type, 'ImportValidationResult');
+  assert.equal(staticValidationOutput.outputs.typed_artifacts.finding_packets.type, 'FindingPacketSet');
+  assert.equal(staticValidationOutput.artifacts.some((artifact) => artifact.kind === 'static-site-importer/import-validation-result' && artifact.path.endsWith('import-validation-result.json')), true);
+  assert.equal(staticValidationOutput.evidence_refs.some((ref) => ref.kind === 'static-site-importer/finding-packets' && ref.uri.endsWith('finding-packets.json')), true);
+
+  const malformedStaticValidationResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+    '--artifacts', path.join(root, 'malformed-static-validation-artifacts'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      execution_kind: 'static_site_import_validation_adapter',
+      candidate_artifact: {
+        schema: 'homeboy/agent-task-typed-artifact/v1',
+        name: 'static_site_candidate',
+        type: 'StaticSiteCandidate',
+        artifact_schema: 'static-site-importer/static-site-candidate/v1',
+        payload: { slug: 'missing-website-artifact' },
+      },
+    }),
+    env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: path.join(root, 'capture-malformed-static-validation.json'), OPENCODE_API_KEY: 'redacted-test-key' },
+  });
+  assert.equal(malformedStaticValidationResult.status, 1, malformedStaticValidationResult.stderr || malformedStaticValidationResult.stdout);
+  const malformedStaticValidationOutput = JSON.parse(malformedStaticValidationResult.stdout);
+  assert.equal(malformedStaticValidationOutput.success, false);
+  assert.equal(malformedStaticValidationOutput.diagnostics[0].class, 'static_site_import_validation_adapter.invalid_candidate');
+  assert.equal(malformedStaticValidationOutput.diagnostics[0].data.reason, 'malformed_candidate');
 
   const codexCapturePath = path.join(root, 'capture-codex.json');
   const codexSecretEnv = [


### PR DESCRIPTION
## Summary
- Implements `static_site_import_validation_adapter` request construction for artifact-driven SSI plans, including StaticSiteCandidate handoff and SSI/BAC/BFB dependency plugin paths.
- Runs validation through the real `static-site-importer/import-website-artifact` WP Codebox runtime task and normalizes `import_validation_result` plus `finding_packets` typed artifacts/evidence.
- Fails missing or malformed StaticSiteCandidate inputs with structured diagnostics instead of reporting success.

## Verification
- `npm run lint:js -- lib/codebox-agent-task-executor.js scripts/agent/homeboy-wp-codebox-task-runner.cjs`
- `npm run test:codebox-agent-task-executor`
- `npm run test:wp-codebox-task-runner`

Closes #1226.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the adapter bridge, targeted smoke coverage, and local verification; Chris remains responsible for review and merge.