### PR TITLE
Fix agent CI context repository parsing

### DIFF
--- a/.github/workflows/datamachine-agent-ci-self-smoke.yml
+++ b/.github/workflows/datamachine-agent-ci-self-smoke.yml
@@ -4,7 +4,7 @@ name: Data Machine Agent CI self-smoke
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
 

--- a/.github/workflows/datamachine-agent-ci-self-smoke.yml
+++ b/.github/workflows/datamachine-agent-ci-self-smoke.yml
@@ -17,6 +17,7 @@ jobs:
       pipeline_slug: self-smoke-pipeline
       flow_slug: self-smoke-flow
       target_repo: Extra-Chill/homeboy-extensions
+      context_repositories: '[{"repo":"Automattic/studio","ref":"trunk"},{"repo":"WordPress/agent-skills","ref":"trunk"}]'
       prompt: Acknowledge this self-smoke run with a single line and stop. Do not call any GitHub tools.
       success_requires_pr: false
       dry_run: true

--- a/.github/workflows/datamachine-agent-ci-self-smoke.yml
+++ b/.github/workflows/datamachine-agent-ci-self-smoke.yml
@@ -17,7 +17,11 @@ jobs:
       pipeline_slug: self-smoke-pipeline
       flow_slug: self-smoke-flow
       target_repo: Extra-Chill/homeboy-extensions
-      context_repositories: '[{"repo":"Automattic/studio","ref":"trunk"},{"repo":"WordPress/agent-skills","ref":"trunk"}]'
+      context_repositories: |
+        [
+          {"repo":"Automattic/studio","ref":"trunk"},
+          {"repo":"WordPress/agent-skills","ref":"trunk"}
+        ]
       prompt: Acknowledge this self-smoke run with a single line and stop. Do not call any GitHub tools.
       success_requires_pr: false
       dry_run: true

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -380,8 +380,9 @@ jobs:
           CONTEXT_REPOSITORIES: ${{ inputs.context_repositories }}
         run: |
           set -euo pipefail
-          context_repos="$(printf '%s' "$CONTEXT_REPOSITORIES" | jq -r '
-            if (gsub("^\\s+|\\s+$"; "") | length) == 0 then [] else fromjson end
+          context_repos="$(printf '%s' "$CONTEXT_REPOSITORIES" | jq -Rse '
+            gsub("^\\s+|\\s+$"; "")
+            | if length == 0 then [] else fromjson end
             | if type == "array" then . else error("context_repositories must be a JSON array") end
             | .[]
             | if type == "object" and (.repo? | type == "string") and (.repo | test("^[^/[:space:]]+/[^/[:space:]]+$")) then .repo else error("context_repositories entries require repo as OWNER/REPO") end
@@ -463,7 +464,7 @@ jobs:
             printf -- '- Target repository: `%s`\n' "$TARGET_REPO"
             printf -- '- Token scope: `%s`\n' "$token_scope"
             printf -- '- Homeboy App token repos input: `%s`\n' "${APP_TOKEN_REPOS_INPUT:-default target_repo}"
-            context_count="$(printf '%s' "$CONTEXT_REPOSITORIES" | jq -r 'if (gsub("^\\s+|\\s+$"; "") | length) == 0 then [] else fromjson end | length')"
+            context_count="$(printf '%s' "$CONTEXT_REPOSITORIES" | jq -Rse 'gsub("^\\s+|\\s+$"; "") | if length == 0 then [] else fromjson end | if type == "array" then length else error("context_repositories must be a JSON array") end')"
             printf -- '- Context repositories: `%s`\n' "$context_count"
             printf -- '- Require Homeboy App token: `%s`\n' "$REQUIRE_HOMEBOY_APP_TOKEN"
             printf -- '- Note: %s\n' "$token_note"


### PR DESCRIPTION
## Summary
- Parse `context_repositories` as raw JSON in the Data Machine Agent CI token-scope resolver.
- Use the same raw JSON normalization in the auth summary context repository count.
- Add context repository input to the Data Machine Agent CI self-smoke workflow.
- Fix the self-smoke caller permissions so the reusable workflow can request `contents: write` and schedule instead of failing during startup validation.

## Why
A downstream `Automattic/build-with-wordpress` skills-agent run failed before checkout because the auth summary step called `gsub` on an already-parsed JSON array.

Fixes #1228.

## Verification
- `CONTEXT_REPOSITORIES='[{"repo":"Automattic/studio"},{"repo":"WordPress/agent-skills"}]'` jq smoke check returns `Automattic/studio,WordPress/agent-skills` and count `2`.
- Empty `CONTEXT_REPOSITORIES` jq smoke check returns count `0`.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); YAML.load_file(".github/workflows/datamachine-agent-ci-self-smoke.yml"); puts "ok"'`
- Data Machine Agent CI self-smoke passed on this branch: https://github.com/Extra-Chill/homeboy-extensions/actions/runs/27303587576

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the failed reusable workflow step, drafted the minimal workflow parsing fix, added self-smoke coverage, fixed the self-smoke permission gate, and ran local/hosted smoke checks. Chris remains responsible for review and merge.