### PR TITLE
Resolve relative Codebox mount sources

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -819,7 +819,15 @@ jobs:
           verification_commands_json="$(normalize_command_list verification_commands "$VERIFICATION_COMMANDS")"
           drift_checks_json="$(normalize_command_list drift_checks "$DRIFT_CHECKS")"
           extra_wp_config_defines_json="$(validate_json_input extra_wp_config_defines object "$EXTRA_WP_CONFIG_DEFINES")"
-          extra_wp_codebox_mounts_json="$(validate_json_input extra_wp_codebox_mounts array "$EXTRA_WP_CODEBOX_MOUNTS")"
+          extra_wp_codebox_mounts_json="$(validate_json_input extra_wp_codebox_mounts array "$EXTRA_WP_CODEBOX_MOUNTS" | jq -c --arg workspace "$GITHUB_WORKSPACE" '
+            map(
+              if type == "object" and (.source? | type == "string") and (.source | startswith("/") | not) then
+                .source = ($workspace + "/" + .source)
+              else
+                .
+              end
+            )
+          ')"
           workload_run_before_json="$(validate_json_input workload_run_before array "$WORKLOAD_RUN_BEFORE")"
           workload_run_after_json="$(validate_json_input workload_run_after array "$WORKLOAD_RUN_AFTER")"
           extra_required_abilities_json="$(validate_json_input extra_required_abilities array "$EXTRA_REQUIRED_ABILITIES")"


### PR DESCRIPTION
## Summary
- Resolve relative object-form `extra_wp_codebox_mounts[*].source` values against `$GITHUB_WORKSPACE` before writing the runner config.
- Preserve absolute object-form sources and existing string-form mount entries.

## Why
Docs Agent needs to mount a policy file checked out under the workflow workspace. The runner accepted relative mount sources but passed them through to WP Codebox, where recipe validation resolved them from the recipe temp context instead of the GitHub workspace.

Fixes #1230.

Failed downstream run: https://github.com/Automattic/build-with-wordpress/actions/runs/27304581623

## Verification
- jq smoke check confirms `.ci/docs-agent/ci/docs-agent-workspace-policy.php` becomes `/home/runner/work/build-with-wordpress/build-with-wordpress/.ci/docs-agent/ci/docs-agent-workspace-policy.php`.
- jq smoke check confirms `/tmp/already-absolute.php` and legacy string entries are preserved.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); puts "ok"'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the downstream recipe validation failure, drafted the mount-source normalization, and ran local smoke checks. Chris remains responsible for review and merge.