### PR TITLE
Add generic WP Codebox ability bridge

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -179,7 +179,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const recipe = recipeConfigFromAgentTaskRequest(request, config, inputs);
   const mounts = agentBundleMounts(agentBundle, config.mounts || defaults.mounts || options.mounts || []);
   const components = runtimeComponentPaths(config, { ...defaults, ...options });
-  const runtimeTask = inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || options.runtimeTask;
+  const runtimeTask = inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(config, inputs) || options.runtimeTask;
   const sandboxToolPolicy = firstDefined(inputs.sandbox_tool_policy, inputs.sandboxToolPolicy, config.sandbox_tool_policy, config.sandboxToolPolicy, options.sandboxToolPolicy, defaults.sandboxToolPolicy);
   const allowedTools = firstDefined(inputs.allowed_tools, inputs.allowedTools, config.allowed_tools, config.allowedTools, options.allowedTools, defaults.allowedTools);
   const explicitSecretEnv = [
@@ -249,6 +249,19 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     agent_bundle: agentBundle,
     parent_request: request,
   };
+}
+
+function abilityRuntimeTaskFromAgentTaskRequest(config, inputs) {
+  const executionKind = firstValue(inputs.execution_kind, inputs.executionKind, config.execution_kind, config.executionKind);
+  if (!['wp_codebox_ability', 'wordpress_ability'].includes(executionKind)) {
+    return null;
+  }
+  const ability = firstValue(inputs.ability, inputs.ability_name, inputs.abilityName, config.ability, config.ability_name, config.abilityName);
+  if (!ability || typeof ability !== 'string') {
+    return null;
+  }
+  const input = firstObject(inputs.ability_input, inputs.abilityInput, inputs.input, config.ability_input, config.abilityInput, config.input) || {};
+  return { ability, input };
 }
 
 function runtimeComponentPaths(config, options = {}) {

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -649,6 +649,14 @@ function runtimeTask(input) {
   return undefined;
 }
 
+function parentAgentTaskConfig(input) {
+  return input.parent_request?.parent_request?.executor?.config || input.parent_request?.executor?.config || {};
+}
+
+function isRuntimeTask(input) {
+  return plainObject(input.runtime_task) || plainObject(input.parent_request?.runtime_task) || plainObject(input.parent_request?.runtimeTask);
+}
+
 function agentBundleConfig(input, bundleConfig = {}) {
   const runtimeComponentPaths = input.runtime_component_paths || {};
   return Object.fromEntries(Object.entries({
@@ -688,17 +696,17 @@ function resultExecutions(result) {
 }
 
 function normalizeAgentTaskRun(input, result) {
-  if (!isAgentBundle(input)) {
+  if (!isAgentBundle(input) && !isRuntimeTask(input)) {
     return result;
   }
 
   const executions = resultExecutions(result);
   const execution = executions.find((item) => item?.recipeCommand === 'wp-codebox.agent-sandbox-run') || executions[0] || null;
-  const agentBundle = agentBundleConfig(input, input.agent_bundle || {});
-  const stdoutWorkload = agentRuntimeWorkloadFromExecutionStdout(execution, agentBundle);
+  const config = isAgentBundle(input) ? agentBundleConfig(input, input.agent_bundle || {}) : parentAgentTaskConfig(input);
+  const stdoutWorkload = agentRuntimeWorkloadFromExecutionStdout(execution, config);
   const fallbackAgentResult = result.metadata?.agent_runtime?.workload || execution?.agentResult || result.run?.agentResult || result.agentResult || result.agent_result || {};
   const agentResult = hasSemanticWorkload(stdoutWorkload) ? stdoutWorkload : fallbackAgentResult;
-  const bundleValidation = validateAgentRuntimeWorkload(agentResult, agentBundle);
+  const bundleValidation = isAgentBundle(input) ? validateAgentRuntimeWorkload(agentResult, config) : validateRuntimeTaskWorkload(agentResult, config);
   const success = !bundleValidation;
   const diagnostics = [
     ...(result.diagnostics || []),
@@ -725,7 +733,8 @@ function normalizeAgentTaskRun(input, result) {
       ...(result.metadata || {}),
       agent_runtime: {
         ...(result.metadata?.agent_runtime || {}),
-        bundle: agentBundle,
+        bundle: isAgentBundle(input) ? config : undefined,
+        runtime_task: isRuntimeTask(input) ? runtimeTask(input) : undefined,
         workload: agentResult,
       },
     },
@@ -754,6 +763,9 @@ function agentRuntimeWorkloadFromExecutionStdout(execution, config) {
   if (bundleRun?.schema && String(bundleRun.schema).endsWith('/agent-bundle-run/v1')) {
     return agentRuntimeWorkloadFromBundleRun(bundleRun, config);
   }
+  if (plainObject(workload.agent_runtime)) {
+    return agentRuntimeWorkloadFromRuntimeTask(workload.agent_runtime, config);
+  }
   if (Array.isArray(workload.scenarios)) {
     return workload;
   }
@@ -770,6 +782,56 @@ function agentRuntimeWorkloadFromExecutionStdout(execution, config) {
     };
   }
   return null;
+}
+
+function agentRuntimeWorkloadFromRuntimeTask(agentRuntime, config) {
+  const outputs = outputMappingsFromSource(agentRuntime, config.output_mappings || config.outputMappings || {});
+  return Object.fromEntries(Object.entries({
+    id: config.workload_id || config.ability || config.ability_name || 'runtime-task',
+    success: agentRuntime.success,
+    status: agentRuntime.success === false ? 'failed' : 'completed',
+    summary: agentRuntime.success === false
+      ? (agentRuntime.error?.message || 'Runtime task failed.')
+      : 'Runtime task completed.',
+    outputs,
+    diagnostics: agentRuntime.error ? [{
+      class: agentRuntime.error.code || 'runtime_task.failed',
+      message: agentRuntime.error.message || 'Runtime task failed.',
+      data: agentRuntime.error.data || {},
+    }] : [],
+    metadata: {
+      input: agentRuntime.input,
+      result: agentRuntime.result,
+    },
+  }).filter(([, value]) => value !== undefined && !(Array.isArray(value) && value.length === 0)));
+}
+
+function outputMappingsFromSource(source, mappings) {
+  if (!plainObject(mappings)) {
+    return {};
+  }
+  const outputs = {};
+  const typedArtifacts = {};
+  for (const [name, dottedPath] of Object.entries(mappings)) {
+    if (typeof dottedPath !== 'string' || dottedPath === '') {
+      continue;
+    }
+    const value = pathValue(source, dottedPath);
+    if (value === undefined || value === null || value === '') {
+      continue;
+    }
+    outputs[name] = value;
+    if (plainObject(value) && (value.schema || value.artifact_type || value.artifactType)) {
+      typedArtifacts[name] = {
+        name,
+        type: value.artifact_type || value.artifactType || name,
+        artifact_schema: value.schema,
+        payload: value,
+        provenance: plainObject(value.provenance) ? value.provenance : {},
+      };
+    }
+  }
+  return mergeTypedArtifactOutputs(outputs, typedArtifacts);
 }
 
 function isSingleResultWorkload(workload) {
@@ -939,6 +1001,32 @@ function validateAgentRuntimeWorkload(workload, config) {
     };
   }
 
+  return null;
+}
+
+function validateRuntimeTaskWorkload(workload, config) {
+  if (workload?.success === false) {
+    return {
+      class: 'runtime_task.failed',
+      message: workload.summary || 'Runtime task failed.',
+      data: { reason: 'runtime_task_failed', diagnostics: workload.diagnostics || [] },
+    };
+  }
+  const outputs = config.engine_data_outputs && typeof config.engine_data_outputs === 'object' ? config.engine_data_outputs : {};
+  const missing = [];
+  for (const name of Object.keys(outputs)) {
+    if (workload?.outputs?.[name] !== undefined && workload.outputs[name] !== null && workload.outputs[name] !== '') {
+      continue;
+    }
+    missing.push(name);
+  }
+  if (missing.length > 0) {
+    return {
+      class: 'runtime_task.outputs_missing',
+      message: `Runtime task did not produce required outputs: ${missing.join(', ')}.`,
+      data: { reason: 'missing_runtime_task_outputs', missing },
+    };
+  }
   return null;
 }
 

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -304,6 +304,28 @@ assert.equal(runtimeTaskRequest.sandbox_tool_policy.tools[0].id, 'homeboy-canary
 assert.equal(runtimeTaskRequest.runtime_task.ability, 'homeboy-canary/write-file');
 assert.equal(runtimeTaskRequest.workspaces[0].target, '/workspace/codebox-canary');
 
+const abilityBridgeRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'ability-bridge-task-123',
+  executor: {
+    backend: 'codebox',
+    config: {
+      execution_kind: 'wp_codebox_ability',
+      ability: 'example/validate-artifact',
+      ability_input: { artifact: { slug: 'example-site' }, report: '/artifacts/import-report.json' },
+      output_mappings: {
+        validation_result: 'result.import_validation_result',
+      },
+      engine_data_outputs: {
+        validation_result: 'metadata.artifacts.ImportValidationResult',
+      },
+    },
+  },
+});
+assert.equal(abilityBridgeRequest.runtime_task.ability, 'example/validate-artifact');
+assert.deepEqual(abilityBridgeRequest.runtime_task.input, { artifact: { slug: 'example-site' }, report: '/artifacts/import-report.json' });
+assert.equal(abilityBridgeRequest.parent_request.executor.config.output_mappings.validation_result, 'result.import_validation_result');
+
 const recipePackRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
   task_id: 'recipe-task-123',

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -60,6 +60,7 @@ if (process.env.FIXTURE_WP_CODEBOX_JSON_VALIDATION_FAILURE) {
   process.exit(0);
 }
 const isAgentBundle = Boolean(input.agent_bundle && Object.keys(input.agent_bundle).length);
+const isRuntimeTask = Boolean(input.runtime_task && Object.keys(input.runtime_task).length && input.runtime_task.ability !== 'datamachine/run-agent-bundle');
 const bundleRun = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
   ? {
       schema: 'datamachine/agent-bundle-run/v1',
@@ -103,7 +104,32 @@ const bundleRun = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
         : { store_idea_agent: { issue_number: 123, issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123' } }
     }
   : null;
-const agentResult = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_AGENT_BUNDLE
+const runtimeTaskResult = isRuntimeTask
+  ? {
+      agent_runtime: {
+        success: true,
+        input: input.runtime_task.input || {},
+        result: {
+          success: true,
+          import_validation_result: {
+            schema: 'example/import-validation-result/v1',
+            artifact_type: 'ImportValidationResult',
+            status: 'passed',
+            counts: { fallback_blocks: 0 }
+          },
+          finding_packets: {
+            schema: 'example/finding-packets/v1',
+            artifact_type: 'FindingPacketSet',
+            count: 0,
+            packets: []
+          }
+        }
+      }
+    }
+  : null;
+const agentResult = isRuntimeTask
+  ? runtimeTaskResult
+  : (isAgentBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_AGENT_BUNDLE
   ? { scenarios: [{ id: 'agent-bundle', metadata: { error: 'Agent bundle child job 456 did not reach a terminal state after drain; current status is pending.' } }] }
   : (isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
       ? {
@@ -124,7 +150,7 @@ const agentResult = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_AGENT
         }
   : (isAgentBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_AGENT_BUNDLE
       ? { metrics: { config_present: 1 }, metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }
-      : { status: 'completed' })));
+      : { status: 'completed' }))));
 fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), input }, null, 2));
 const execution = { recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed', output: JSON.stringify(agentResult) }) };
 const executions = [execution];
@@ -288,6 +314,75 @@ try {
   assert.equal(runtimeTaskCaptured.input.sandbox_tool_policy.tools[0].id, 'homeboy-canary/write-file');
   assert.equal(runtimeTaskCaptured.input.runtime_task.ability, 'homeboy-canary/write-file');
   assert.equal(runtimeTaskCaptured.input.workspaces[0].target, '/workspace/codebox-canary');
+
+  const abilityBridgeResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      runtime_task: {
+        ability: 'example/validate-artifact',
+        input: { artifact: { slug: 'example-site' } },
+      },
+      parent_request: {
+        executor: {
+          config: {
+            ability: 'example/validate-artifact',
+            output_mappings: {
+              import_validation_result: 'result.import_validation_result',
+              finding_packets: 'result.finding_packets',
+            },
+            engine_data_outputs: {
+              import_validation_result: 'outputs.import_validation_result',
+              finding_packets: 'outputs.finding_packets',
+            },
+          },
+        },
+      },
+    }),
+    env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: path.join(root, 'capture-ability-bridge.json'), OPENCODE_API_KEY: 'redacted-test-key' },
+  });
+  assert.equal(abilityBridgeResult.status, 0, abilityBridgeResult.stderr || abilityBridgeResult.stdout);
+  const abilityBridgeOutput = JSON.parse(abilityBridgeResult.stdout);
+  assert.equal(abilityBridgeOutput.success, true);
+  assert.equal(abilityBridgeOutput.outputs.import_validation_result.status, 'passed');
+  assert.equal(abilityBridgeOutput.outputs.finding_packets.count, 0);
+  assert.equal(abilityBridgeOutput.outputs.typed_artifacts.import_validation_result.type, 'ImportValidationResult');
+  assert.equal(abilityBridgeOutput.outputs.typed_artifacts.finding_packets.artifact_schema, 'example/finding-packets/v1');
+
+  const missingRuntimeOutputResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      runtime_task: {
+        ability: 'example/validate-artifact',
+        input: { artifact: { slug: 'example-site' } },
+      },
+      parent_request: {
+        executor: {
+          config: {
+            ability: 'example/validate-artifact',
+            output_mappings: {
+              import_validation_result: 'result.import_validation_result',
+            },
+            engine_data_outputs: {
+              missing_validation_output: 'outputs.missing_validation_output',
+            },
+          },
+        },
+      },
+    }),
+    env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: path.join(root, 'capture-missing-runtime-output.json'), OPENCODE_API_KEY: 'redacted-test-key' },
+  });
+  assert.equal(missingRuntimeOutputResult.status, 1, missingRuntimeOutputResult.stderr || missingRuntimeOutputResult.stdout);
+  const missingRuntimeOutput = JSON.parse(missingRuntimeOutputResult.stdout);
+  assert.equal(missingRuntimeOutput.success, false);
+  assert.equal(missingRuntimeOutput.diagnostics[0].class, 'runtime_task.outputs_missing');
 
   const codexCapturePath = path.join(root, 'capture-codex.json');
   const codexSecretEnv = [


### PR DESCRIPTION
## Summary
- Add a generic `wp_codebox_ability` / `wordpress_ability` executor config path that maps Homeboy agent-task config to WP Codebox `runtime_task` ability execution.
- Normalize runtime-task outputs with configurable `output_mappings`, including typed artifact wrapping and required-output failure diagnostics.
- Preserve canonical agent-bundle normalization while covering the new runtime-task bridge in smoke tests.

## Tests
- `npm --prefix wordpress run test:wp-codebox-task-runner`
- `npm --prefix wordpress run test:codebox-agent-task-executor`
- `npx eslint lib/codebox-agent-task-executor.js scripts/agent/homeboy-wp-codebox-task-runner.cjs --no-warn-ignored`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the bridge implementation, smoke coverage, and local verification steps; Chris remains responsible for review and merge.