### PR TITLE
Preserve Codebox failure evidence refs

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -1296,6 +1296,13 @@ function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) 
     for (const ref of outputEvidenceRefs(normalizeOutputs(result))) {
       appendUniqueEvidenceRef(refs, ref);
     }
+    for (const ref of result?.evidence_refs || result?.evidence || []) {
+      appendUniqueEvidenceRef(refs, {
+        kind: ref.kind || ref.type || 'codebox_evidence',
+        uri: ref.uri || ref.url || ref.path,
+        label: ref.label || ref.name,
+      });
+    }
     return refs;
   }
   const evidenceRefs = result?.evidence_refs || result?.evidence || [];

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -765,6 +765,23 @@ assert.equal(upstreamRunnerOutcome.status, 'succeeded');
 assert.equal(upstreamRunnerOutcome.artifacts[0].kind, 'codebox-artifact-directory');
 assert.equal(upstreamRunnerOutcome.artifacts[0].path, '/tmp/wp-codebox-artifacts');
 
+const failedUpstreamRunnerOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: false,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'failed',
+  session: { id: 'sandbox-session-1', status: 'failed' },
+  evidence_refs: [{
+    kind: 'codebox-command-evidence',
+    uri: '/tmp/wp-codebox-artifacts/wp-codebox-command-evidence.json',
+    label: 'codebox command evidence',
+  }],
+});
+assert.equal(failedUpstreamRunnerOutcome.status, 'failed');
+assert.equal(
+  failedUpstreamRunnerOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-command-evidence' && ref.uri === '/tmp/wp-codebox-artifacts/wp-codebox-command-evidence.json'),
+  true
+);
+
 const recipeProbeFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',


### PR DESCRIPTION
## Summary
- Preserve top-level `evidence_refs` from failed `wp-codebox/agent-task-run/v1` payloads when normalizing Homeboy agent-task outcomes.
- Add smoke coverage for failed Codebox runner payloads carrying `codebox-command-evidence` refs.

## Why
A merged-main Lab run (`site-generation-loop-merged-main-20260610-ability-bridge`) failed first-stage WP Codebox tasks, but `homeboy agent-task artifacts` only exposed downstream scheduler skip refs. The WP Codebox task runner attaches command evidence on failure; the outcome normalizer was dropping those top-level refs for `wp-codebox/agent-task-run/v1` payloads.

## Tests
- `npm --prefix wordpress run test:codebox-agent-task-executor`
- `npx eslint lib/codebox-agent-task-executor.js --no-warn-ignored`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the dropped evidence-ref path, drafted the normalizer fix and regression smoke, and ran local verification; Chris remains responsible for review and merge.