### PR TITLE
Upload Codebox transcript artifacts

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -1049,8 +1049,8 @@ jobs:
             --results "$RESULTS_FILE" \
             --scenario "${{ inputs.flow_slug }}" \
             --field job_status=metadata.job_status \
-            --field transcript_json='(.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].json? // "") elif type == "object" then (.json? // "") else "" end)' \
-            --field transcript_summary='(.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].summary? // "") elif type == "object" then (.summary? // "") else "" end)' \
+            --field transcript_json='(.metadata.evidence_references.references.transcript_artifact.path // "")' \
+            --field transcript_summary='(.metadata.evidence_references.references.transcript_artifact.label // "")' \
             --required-status "" \
             --to-github-output
 
@@ -1166,14 +1166,6 @@ jobs:
             candidate="${TRANSCRIPT_HOST_DIR}/$(basename "$TRANSCRIPT_JSON")"
             if [ -f "$candidate" ]; then
               transcript_path="$candidate"
-            fi
-          fi
-          if [ -z "$transcript_path" ] && [ -f "$RESULTS_FILE" ]; then
-            transcript_content_path="${RUNNER_TEMP}/datamachine-agent-transcripts/$(basename "${TRANSCRIPT_JSON:-job-transcript.json}")"
-            if jq -e --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | (.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].content? // empty) elif type == "object" then (.content? // empty) else empty end)' "$RESULTS_FILE" >/dev/null; then
-              mkdir -p "$(dirname "$transcript_content_path")"
-              jq -r --arg scenario "$FLOW_SLUG" '.scenarios[] | select(.id == $scenario) | (.metadata.transcript_artifacts | if type == "array" then (flatten | map(select(type == "object")) | .[0].content? // "") elif type == "object" then (.content? // "") else "" end)' "$RESULTS_FILE" > "$transcript_content_path"
-              transcript_path="$transcript_content_path"
             fi
           fi
           if [ -z "$transcript_path" ]; then

--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -171,7 +171,6 @@ const output = {
     eval_artifact: {
       run: [{ workflow_run_url: 'https://github.com/example/repo/actions/runs/456' }],
     },
-    transcript_artifacts: [[{ json: '/tmp/wp-codebox-smoke-transcript.json', summary: 'Nested transcript fixture' }]],
     job_artifact_exports: [{ pr_url: 'https://github.com/example/repo/pull/123', branch: 'agent-artifacts/example' }],
     engine_data: {
       ok: true,
@@ -306,7 +305,8 @@ patch_artifact=$(jq -r "$scenario | .artifacts.wp_codebox_patch.kind // \"missin
 runtime_manifest_artifact=$(jq -r "$scenario | .artifacts.wp_codebox_runtime_reference_manifest.kind // \"missing\"" "$RESULTS_TMPFILE")
 runtime_manifest_schema=$(jq -r "$scenario | .metadata.wp_codebox.runtime_reference_manifest.schema // \"missing\"" "$RESULTS_TMPFILE")
 runtime_manifest_secret=$(jq -r "$scenario | .metadata.wp_codebox.runtime_reference_manifest.apiToken // \"missing\"" "$RESULTS_TMPFILE")
-if [ "$wp_codebox_success" != "true" ] || [ -z "$artifact_dir" ] || [ "$review_schema" != "wp-codebox/artifact-review/v1" ] || [ "$changed_files_schema" != "wp-codebox/changed-files/v1" ] || [ "$review_artifact" != "review" ] || [ "$patch_artifact" != "patch" ] || [ "$runtime_manifest_artifact" != "runtime-reference-manifest" ] || [ "$runtime_manifest_schema" != "wp-codebox/runtime-reference-manifest-fixture/v1" ] || [ "$runtime_manifest_secret" != "[redacted]" ]; then
+canonical_transcript_path=$(jq -r "$scenario | .metadata.wp_codebox.canonical_artifacts.transcript // \"\"" "$RESULTS_TMPFILE")
+if [ "$wp_codebox_success" != "true" ] || [ -z "$artifact_dir" ] || [ "$review_schema" != "wp-codebox/artifact-review/v1" ] || [ "$changed_files_schema" != "wp-codebox/changed-files/v1" ] || [ "$review_artifact" != "review" ] || [ "$patch_artifact" != "patch" ] || [ "$runtime_manifest_artifact" != "runtime-reference-manifest" ] || [ "$runtime_manifest_schema" != "wp-codebox/runtime-reference-manifest-fixture/v1" ] || [ "$runtime_manifest_secret" != "[redacted]" ] || [ "$canonical_transcript_path" != "$artifact_dir/files/transcript.json" ]; then
     echo "ERROR: wp_codebox metadata missing (success=$wp_codebox_success artifact_dir=$artifact_dir)" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1
@@ -335,7 +335,7 @@ pull_request_value=$(jq -r "$scenario | .metadata.evidence_references.references
 workspace_branch_value=$(jq -r "$scenario | .metadata.evidence_references.references.workspace_branch.value // \"\"" "$RESULTS_TMPFILE")
 workflow_run_path=$(jq -r "$scenario | .metadata.evidence_references.references.workflow_run.path // \"\"" "$RESULTS_TMPFILE")
 trace_gap=$(jq -r "$scenario | any(.metadata.evidence_references.compatibility_gaps[]?; .field == \"runtime_episode_trace\")" "$RESULTS_TMPFILE")
-if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_available" != "true" ] || [ "$policy_available" != "true" ] || [ "$runtime_manifest_available" != "true" ] || [ "$transcript_path" != "/tmp/wp-codebox-smoke-transcript.json" ] || [ "$pull_request_value" != "https://github.com/example/repo/pull/123" ] || [ "$workspace_branch_value" != "agent-artifacts/example" ] || [ "$workflow_run_path" != "https://github.com/example/repo/actions/runs/456" ] || [ "$trace_gap" != "false" ]; then
+if [ "$evidence_schema" != "homeboy/datamachine-agent-evidence-references/v1" ] || [ "$homeboy_result_path" != "$RESULTS_TMPFILE" ] || [ "$wp_codebox_bundle_available" != "true" ] || [ "$runtime_trace_available" != "true" ] || [ "$replay_bundle_available" != "true" ] || [ "$verifier_available" != "true" ] || [ "$policy_available" != "true" ] || [ "$runtime_manifest_available" != "true" ] || [ "$transcript_path" != "$artifact_dir/files/transcript.json" ] || [ "$pull_request_value" != "https://github.com/example/repo/pull/123" ] || [ "$workspace_branch_value" != "agent-artifacts/example" ] || [ "$workflow_run_path" != "https://github.com/example/repo/actions/runs/456" ] || [ "$trace_gap" != "false" ]; then
     echo "ERROR: stable evidence references missing or incomplete" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1
@@ -349,7 +349,10 @@ HOMEBOY_DATAMACHINE_AGENT_RESULTS_FILE="$FALLBACK_RESULTS_TMPFILE" \
 
 fallback_config_present=$(jq -r "$scenario | .metrics.config_present_mean // \"missing\"" "$FALLBACK_RESULTS_TMPFILE")
 fallback_success_status=$(jq -r "$scenario | .metadata.success_status // \"missing\"" "$FALLBACK_RESULTS_TMPFILE")
-if [ "$fallback_config_present" != "1" ] || [ "$fallback_success_status" != "no_changes" ]; then
+fallback_artifact_dir=$(jq -r "$scenario | .metadata.wp_codebox.artifacts.directory // \"\"" "$FALLBACK_RESULTS_TMPFILE")
+fallback_transcript_reference=$(jq -r "$scenario | .metadata.evidence_references.references.transcript_artifact.path // \"missing\"" "$FALLBACK_RESULTS_TMPFILE")
+fallback_legacy_transcript=$(jq -r "$scenario | .metadata.transcript_artifacts.json // \"\"" "$FALLBACK_RESULTS_TMPFILE")
+if [ "$fallback_config_present" != "1" ] || [ "$fallback_success_status" != "no_changes" ] || [ -z "$fallback_artifact_dir" ] || [ -n "$fallback_legacy_transcript" ] || [ "$fallback_transcript_reference" != "$fallback_artifact_dir/files/transcript.json" ]; then
     echo "ERROR: successful WP Codebox fallback result was not projected as complete" >&2
     cat "$FALLBACK_RESULTS_TMPFILE" >&2
     exit 1

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -343,6 +343,7 @@ PHP
     fi
 
     jq -n \
+        --arg transcriptPath "$wp_codebox_transcript_path" \
         --slurpfile run "$wp_codebox_output" \
         --slurpfile review "$wp_codebox_review_input" \
         --slurpfile changedFiles "$wp_codebox_changed_files_input" \
@@ -380,6 +381,7 @@ PHP
                 diffs: ($artifacts.diffsPath // ""),
                 changed_files: ($artifacts.changedFilesPath // ""),
                 patch: ($artifacts.patchPath // ""),
+                transcript: $transcriptPath,
                 review: ($artifacts.reviewPath // ""),
                 runtime_reference_manifest: ($artifacts.runtimeReferenceManifestPath // $artifacts.runtimeReferencesManifestPath // $artifacts.runtime_reference_manifest_path // $artifacts.referenceManifestPath // $artifacts.runtimeReferencePath // $artifacts.runtimeReferencesPath // $artifacts.runtime.referenceManifestPath // "")
             } | with_entries(select(.value != "")),
@@ -774,7 +776,7 @@ homeboy_datamachine_agent_attach_evidence_references() {
             | (first_field($metadata; "workspace_policy_result") // $metadata.datamachine_code_policy_attestation // null) as $policyResult
             | ($artifacts.episode_jsonl.path // $metadata.runtime_episode_trace.path // $metadata.runtime_episode_trace // "") as $episodeTrace
             | ($artifacts.replay_bundle.path // $metadata.replay_bundle_path // "") as $replayBundle
-            | (first_field($metadata.transcript_artifacts; "json") // "") as $transcriptJson
+            | ($wpPaths.transcript // "") as $transcriptJson
             | {
                 schema: "homeboy/datamachine-agent-evidence-references/v1",
                 scope: "generic-runner-evidence",


### PR DESCRIPTION
## Summary
- Project the WP Codebox transcript file into canonical runner evidence references.
- Resolve transcript uploads from `metadata.evidence_references.references.transcript_artifact.path` instead of legacy `metadata.transcript_artifacts`.
- Remove the inline transcript-content fallback path and cover Codebox transcript upload behavior without legacy transcript metadata in the smoke fixture.

## Verification
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the transcript projection gap and drafted the canonical evidence-reference based fix and smoke coverage.