### PR TITLE
fix: preflight Codebox agent task model config

### DIFF
--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -360,6 +360,34 @@ function stderrFailurePayload(result) {
   };
 }
 
+function missingModelPreflightPayload(taskInput) {
+  if (!taskInput?.provider || taskInput?.model) {
+    return null;
+  }
+
+  const message = `WP Codebox agent task requires an AI model for provider "${taskInput.provider}". Pass --model or set provider-config.model.`;
+  return {
+    success: false,
+    status: 'failed',
+    failure_classification: 'provider',
+    summary: message,
+    diagnostics: [{
+      class: 'codebox.preflight.missing_model',
+      message,
+      data: {
+        phase: 'codebox.preflight',
+        provider: taskInput.provider,
+        model_sources: ['--model', 'provider-config.model'],
+      },
+    }],
+    metadata: {
+      phase: 'codebox.preflight',
+      provider: taskInput.provider,
+      model_required: true,
+    },
+  };
+}
+
 async function loadCodeboxCoreNormalizers() {
   const configuredModule = process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE;
   const candidates = configuredModule ? [configuredModule] : [DEFAULT_CODEBOX_CORE_MODULE];
@@ -393,6 +421,10 @@ async function runTaskRunner(request) {
   const runner = argValue('--task-runner') || `${__dirname}/homeboy-wp-codebox-task-runner.cjs`;
   const config = request.executor?.config || {};
   const taskInput = codeboxTaskRequestFromAgentTaskRequest(request);
+  const missingModelPayload = missingModelPreflightPayload(taskInput);
+  if (missingModelPayload) {
+    return agentTaskOutcomeFromCodeboxResult(request, missingModelPayload, { exitStatus: 1, ...coreNormalizers });
+  }
   const configArgs = [
     ['--agents-api', config.agents_api_path || config.agentsApiPath],
     ['--homeboy', config.homeboy_path || config.homeboyPath],

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1151,6 +1151,33 @@ assert(!serializedCodexOutcome.includes('diagnostic-access-token-value'));
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-agent-task-executor-'));
 try {
   const { fixture, capture } = writeFixtureTaskRunner(root);
+  const missingModelResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+    '--task-runner',
+    fixture,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      task_id: 'missing-model-cli-task-123',
+      executor: {
+        backend: 'codebox',
+        config: {
+          provider: 'claude-code',
+          provider_plugin_paths: ['/providers/claude-code'],
+        },
+      },
+    }),
+  });
+  assert.equal(missingModelResult.status, 1, missingModelResult.stderr || missingModelResult.stdout);
+  const missingModelOutcome = JSON.parse(missingModelResult.stdout);
+  assert.equal(missingModelOutcome.status, 'failed');
+  assert.equal(missingModelOutcome.failure_classification, 'provider');
+  assert.equal(missingModelOutcome.diagnostics[0].class, 'codebox.preflight.missing_model');
+  assert.match(missingModelOutcome.summary, /--model/);
+  assert.match(missingModelOutcome.summary, /provider-config\.model/);
+  assert.equal(fs.existsSync(capture), false);
+
   const result = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
     '--task-runner',


### PR DESCRIPTION
## Summary
- Fail Codebox agent-task execution before launching WP Codebox when a selected provider has no resolved model.
- Return a Homeboy executor diagnostic that points operators to `--model` or `provider-config.model`.
- Cover the Claude Code missing-model path and assert the task runner is not invoked.

Fixes #1237.

## Testing
- `npm run test:codebox-agent-task-executor`
- `npm run test:codebox-agent-task-matrix`
- `npm run lint:js -- scripts/agent/homeboy-codebox-agent-task-executor.cjs`

## Notes
- `npm run test:codebox-agent-task-boundary` still fails on existing `data_machine_path` / `data_machine_code_path` forbidden-pattern matches in files outside this patch.
- `npm run lint:js -- scripts/agent/homeboy-codebox-agent-task-executor.cjs tests/codebox-agent-task-executor-smoke.js` reports the smoke test file is ignored by ESLint config; linting the changed executor script passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the executor path, drafted the preflight patch and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.