### PR TITLE
Preflight Claude Code Codebox auth

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -54,6 +54,10 @@ const CODEX_SECRET_ENV = [
   'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
 ];
 
+const CLAUDE_CODE_SECRET_ENV = [
+  'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN',
+];
+
 const DEFAULT_CODEX_MODEL = 'gpt-5.5';
 
 const AGENT_BUNDLE_CONFIG_FIELDS = [
@@ -401,6 +405,9 @@ function defaultSecretEnv(provider, settings) {
   }
   if (provider === 'codex') {
     return CODEX_SECRET_ENV;
+  }
+  if (provider === 'claude-code') {
+    return CLAUDE_CODE_SECRET_ENV;
   }
   return provider === 'openai' ? ['OPENAI_API_KEY'] : [];
 }

--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -316,7 +316,7 @@ function redactDiagnosticText(text) {
 }
 
 function missingSecretEnvNames(stderr) {
-  const match = String(stderr || '').match(/Required WP Codebox secret environment variable missing:\s*([^\n\r]+)/i);
+  const match = String(stderr || '').match(/(?:Required WP Codebox secret environment variable missing|Claude Code provider auth preflight failed: missing required secret environment (?:mapping|value)):\s*([^\n\r]+)/i);
   if (!match) {
     return [];
   }
@@ -326,14 +326,23 @@ function missingSecretEnvNames(stderr) {
     .filter((name) => /^[A-Z0-9_]+$/.test(name));
 }
 
+function preflightFailureClass(stderr, missingSecretEnv) {
+  if (/Claude Code provider auth preflight failed:/i.test(stderr)) {
+    return missingSecretEnv.length > 0
+      ? 'codebox.preflight.claude_code_auth'
+      : 'codebox.preflight.stderr';
+  }
+  return missingSecretEnv.length > 0
+    ? 'codebox.preflight.missing_secret_env'
+    : 'codebox.preflight.stderr';
+}
+
 function stderrFailurePayload(result) {
   const stderr = redactDiagnosticText(result.stderr || '');
   const missingSecretEnv = missingSecretEnvNames(stderr);
-  const diagnosticClass = missingSecretEnv.length > 0
-    ? 'codebox.preflight.missing_secret_env'
-    : 'codebox.preflight.stderr';
+  const diagnosticClass = preflightFailureClass(stderr, missingSecretEnv);
   const message = missingSecretEnv.length > 0
-    ? `WP Codebox task runner preflight is missing required secret environment variables: ${missingSecretEnv.join(', ')}.`
+    ? `WP Codebox task runner preflight is missing required secret environment variables for ${diagnosticClass === 'codebox.preflight.claude_code_auth' ? 'Claude Code provider auth' : 'the runtime'}: ${missingSecretEnv.join(', ')}.`
     : 'WP Codebox task runner failed before returning a JSON outcome.';
 
   return {

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -54,6 +54,31 @@ function secretEnvNames(request) {
   return Array.from(new Set([...(request.secret_env || []), ...(request.recipe?.secret_env || []), ...argValues('--secret-env')].filter(Boolean)));
 }
 
+function claudeCodeRequiredSecretEnv() {
+  return ['AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN'];
+}
+
+function isClaudeCodeRequest(request) {
+  return request.provider === 'claude-code';
+}
+
+function assertClaudeCodeAuthPreflight(request) {
+  if (!isClaudeCodeRequest(request)) {
+    return;
+  }
+
+  const names = secretEnvNames(request);
+  const missingMapping = claudeCodeRequiredSecretEnv().filter((name) => !names.includes(name));
+  if (missingMapping.length > 0) {
+    throw new Error(`Claude Code provider auth preflight failed: missing required secret environment mapping: ${missingMapping.join(', ')}`);
+  }
+
+  const missing = claudeCodeRequiredSecretEnv().filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(`Claude Code provider auth preflight failed: missing required secret environment value: ${missing.join(', ')}`);
+  }
+}
+
 function assertRequiredSecretEnvAvailable(request) {
   const missing = secretEnvNames(request).filter((name) => !process.env[name]);
   if (missing.length > 0) {
@@ -1201,6 +1226,7 @@ function runWpCodeboxParentTask(request) {
 
 try {
   const request = readTaskRequest();
+  assertClaudeCodeAuthPreflight(request);
   assertRequiredSecretEnvAvailable(request);
   process.exitCode = runWpCodeboxParentTask(request);
 } catch (error) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -20,6 +20,7 @@ const codexSecretEnv = [
   'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
   'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
 ];
+const claudeCodeRefreshTokenEnv = 'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN';
 
 function writeFixtureTaskRunner(root) {
   const fixture = path.join(root, 'fixture-task-runner.cjs');
@@ -278,6 +279,20 @@ assert.deepEqual(executorSecretEnvRequest.secret_env, [
   'AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT',
 ]);
 assert.equal(executorSecretEnvRequest.wp, '7.0');
+
+const claudeCodeDefaultSecretEnvRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'claude-code-default-secret-env-task-123',
+  executor: {
+    backend: 'codebox',
+    model: 'claude-sonnet-4-6',
+    config: {
+      provider: 'claude-code',
+      provider_plugin_paths: ['/providers/claude-code'],
+    },
+  },
+});
+assert.deepEqual(claudeCodeDefaultSecretEnvRequest.secret_env, [claudeCodeRefreshTokenEnv]);
 
 const runtimeTaskRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
@@ -1443,6 +1458,64 @@ try {
   assert.equal(missingSecretOutcome.diagnostics[0].data.phase, 'codebox.preflight');
   assert.equal(missingSecretOutcome.metadata.codebox.missing_env[0], 'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN');
   assert(!JSON.stringify(missingSecretOutcome).includes('codex-access-token-value'));
+
+  const claudeCodeBaseRequest = {
+    ...request,
+    task_id: 'claude-code-preflight-task',
+    executor: {
+      backend: 'codebox',
+      model: 'claude-sonnet-4-6',
+      config: {
+        provider: 'claude-code',
+        provider_plugin_paths: ['/components/ai-provider-for-claude-code'],
+        wp_codebox_bin: '/bin/should-not-launch-wp-codebox',
+      },
+    },
+  };
+  const claudeMissingValueResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(claudeCodeBaseRequest),
+    env: {
+      ...process.env,
+      [claudeCodeRefreshTokenEnv]: '',
+    },
+  });
+  assert.equal(claudeMissingValueResult.status, 1, claudeMissingValueResult.stderr || claudeMissingValueResult.stdout);
+  const claudeMissingValueOutcome = JSON.parse(claudeMissingValueResult.stdout);
+  assert.equal(claudeMissingValueOutcome.status, 'failed');
+  assert.equal(claudeMissingValueOutcome.failure_classification, 'provider');
+  assert.equal(claudeMissingValueOutcome.diagnostics[0].class, 'codebox.preflight.claude_code_auth');
+  assert.deepEqual(claudeMissingValueOutcome.diagnostics[0].data.missing_env, [claudeCodeRefreshTokenEnv]);
+  assert(!JSON.stringify(claudeMissingValueOutcome).includes('claude-refresh-token-value'));
+
+  const claudeMissingMappingResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...claudeCodeBaseRequest,
+      task_id: 'claude-code-missing-mapping-task',
+      executor: {
+        ...claudeCodeBaseRequest.executor,
+        secret_env: ['AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN'],
+      },
+    }),
+    env: {
+      ...process.env,
+      AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN: 'claude-access-token-value',
+      [claudeCodeRefreshTokenEnv]: 'claude-refresh-token-value',
+    },
+  });
+  assert.equal(claudeMissingMappingResult.status, 1, claudeMissingMappingResult.stderr || claudeMissingMappingResult.stdout);
+  const claudeMissingMappingOutcome = JSON.parse(claudeMissingMappingResult.stdout);
+  assert.equal(claudeMissingMappingOutcome.status, 'failed');
+  assert.equal(claudeMissingMappingOutcome.failure_classification, 'provider');
+  assert.equal(claudeMissingMappingOutcome.diagnostics[0].class, 'codebox.preflight.claude_code_auth');
+  assert.deepEqual(claudeMissingMappingOutcome.diagnostics[0].data.missing_env, [claudeCodeRefreshTokenEnv]);
+  assert(!JSON.stringify(claudeMissingMappingOutcome).includes('claude-access-token-value'));
+  assert(!JSON.stringify(claudeMissingMappingOutcome).includes('claude-refresh-token-value'));
 } finally {
   fs.rmSync(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- Add Claude Code's required refresh-token env as the default Codebox secret env for `provider: claude-code`.
- Fail Codebox task-runner preflight before launching `wp-codebox` when Claude Code auth is not mapped into `secret_env` or the mapped refresh token is absent/empty.
- Normalize Claude Code preflight failures into structured `codebox.preflight.claude_code_auth` diagnostics without exposing token values.

## Limits
- This validates local mapping and presence only. It intentionally does not make a Claude OAuth refresh call before runtime launch because a refresh can rotate credentials and would require handling updated token material outside the provider/runtime.
- Stale or rejected refresh tokens can still only be confirmed by the Claude Code provider when it contacts Claude; those failures remain provider/runtime auth failures.

## Verification
- `npm run test:codebox-agent-task-executor`
- `npm run test:datamachine-agent-wp-codebox-runner`
- `npx eslint --no-warn-ignored lib/codebox-agent-task-executor.js scripts/agent/homeboy-codebox-agent-task-executor.cjs scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/codebox-agent-task-executor-smoke.js`

Fixes #1238

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Codebox Claude Code auth path, drafted the preflight implementation and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.