### PR TITLE
fix: surface Node bench warning result counts

### DIFF
--- a/nodejs/scripts/bench/bench-runner.mjs
+++ b/nodejs/scripts/bench/bench-runner.mjs
@@ -206,6 +206,21 @@ function aggregateMetadata(iterationMetadata) {
     return Object.assign({}, ...iterationMetadata);
 }
 
+function resultCountMetrics(metadata) {
+    const resultCounts = metadata.result_counts;
+    if (!resultCounts || typeof resultCounts !== 'object' || Array.isArray(resultCounts)) {
+        return {};
+    }
+
+    const metrics = {};
+    for (const [status, count] of Object.entries(resultCounts)) {
+        if (typeof count === 'number' && Number.isFinite(count)) {
+            metrics[`${status}_count`] = count;
+        }
+    }
+    return metrics;
+}
+
 async function discoverWorkloads(dir) {
     const found = [];
     async function walk(d) {
@@ -345,19 +360,20 @@ async function main() {
             max_ms: t[t.length - 1],
         };
 
+        const metadata = result.customMetadata;
         const scenario = {
             id,
             file: rel,
             source,
             iterations: t.length,
-            metrics: { ...timingMetrics, ...result.customMetrics },
+            metrics: { ...timingMetrics, ...resultCountMetrics(metadata), ...result.customMetrics },
             memory: { peak_bytes: result.peakRss },
         };
         if (Object.keys(result.customArtifacts).length > 0) {
             scenario.artifacts = result.customArtifacts;
         }
-        if (Object.keys(result.customMetadata).length > 0) {
-            scenario.metadata = result.customMetadata;
+        if (Object.keys(metadata).length > 0) {
+            scenario.metadata = metadata;
         }
         scenarios.push(scenario);
 

--- a/tests/nodejs-bench-metadata-smoke.sh
+++ b/tests/nodejs-bench-metadata-smoke.sh
@@ -25,6 +25,7 @@ export default async function () {
             prompt_variant: 'studio-code',
             prompt_file: 'file:///tmp/prompts/site-build/studio-code.md',
             prompt_category: 'site-build',
+            result_counts: { warning: 1 },
         },
     };
 }
@@ -57,6 +58,12 @@ if (scenario.metadata?.prompt_category !== 'site-build') {
 }
 if (scenario.metrics?.custom_metric !== 7) {
     throw new Error(`custom metrics regressed: ${JSON.stringify(scenario.metrics)}`);
+}
+if (scenario.metrics?.warning_count !== 1) {
+    throw new Error(`warning result count was not surfaced as a metric: ${JSON.stringify(scenario.metrics)}`);
+}
+if (scenario.metadata?.result_counts?.warning !== 1) {
+    throw new Error(`result_counts metadata was not persisted: ${JSON.stringify(scenario.metadata)}`);
 }
 NODE
 


### PR DESCRIPTION
## Summary
- Convert numeric Node bench `metadata.result_counts.*` entries into `*_count` metrics on the scenario payload.
- Preserve the original `result_counts` metadata while surfacing `warning_count` for gate summaries.
- Extends the Node bench metadata smoke to cover warning result count projection.

## Tests
- `HOMEBOY_CORE_DIR="/Users/chubes/Developer/homeboy@fix-issue-1242-bench-warning-counts" bash tests/nodejs-bench-metadata-smoke.sh`

## Related
- Fixes #1242
- Depends on Extra-Chill/homeboy#3987 for the Homeboy core gate message change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Node bench result-count metric projection and focused smoke coverage; Chris remains responsible for review and merge.