### PR TITLE
Fail fast when Codebox repo workspace is missing

### DIFF
--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -360,6 +360,66 @@ function stderrFailurePayload(result) {
   };
 }
 
+function isRepoCookingRequest(request, taskInput) {
+  const config = request.executor?.config || {};
+  const parentConfig = taskInput.parent_request?.executor?.config || {};
+  return config.task_kind === 'repo-cooking' || config.taskKind === 'repo-cooking' || parentConfig.task_kind === 'repo-cooking' || parentConfig.taskKind === 'repo-cooking';
+}
+
+function workspaceMounts(taskInput) {
+  return Array.isArray(taskInput.mounts) ? taskInput.mounts : [];
+}
+
+function hasWorkspaceMount(taskInput) {
+  return workspaceMounts(taskInput).some((mount) => {
+    if (!mount || typeof mount !== 'object') {
+      return false;
+    }
+    if (mount.metadata?.kind === 'homeboy-dmc-workspace') {
+      return Boolean(mount.source);
+    }
+    return Boolean(mount.source) && /^\/workspace(?:\/|$)/.test(String(mount.target || ''));
+  });
+}
+
+function missingWorkspacePayload(request, taskInput) {
+  if (!isRepoCookingRequest(request, taskInput) || hasWorkspaceMount(taskInput)) {
+    return null;
+  }
+
+  const config = request.executor?.config || {};
+  const message = 'WP Codebox repo-cooking task has no mounted checkout/workspace.';
+  return {
+    success: false,
+    status: 'failed',
+    failure_classification: 'execution_failed',
+    summary: message,
+    diagnostics: [{
+      class: 'codebox.preflight.missing_workspace',
+      message,
+      data: {
+        phase: 'codebox.preflight',
+        repo: config.repo || request.group_key || request.workspace?.slug || '',
+        task_kind: config.task_kind || config.taskKind || '',
+        workspace_root: config.workspace_root || config.workspaceRoot || request.workspace?.root || '',
+        mounts_count: workspaceMounts(taskInput).length,
+        workspaces_count: Array.isArray(taskInput.workspaces) ? taskInput.workspaces.length : 0,
+        workspace_materialization: request.workspace?.materialization || {},
+      },
+    }],
+    metadata: {
+      phase: 'codebox.preflight',
+      missing_workspace: true,
+      repo: config.repo || request.group_key || request.workspace?.slug || '',
+      task_kind: config.task_kind || config.taskKind || '',
+      workspace_root: config.workspace_root || config.workspaceRoot || request.workspace?.root || '',
+      mounts_count: workspaceMounts(taskInput).length,
+      workspaces_count: Array.isArray(taskInput.workspaces) ? taskInput.workspaces.length : 0,
+      workspace_materialization: request.workspace?.materialization || {},
+    },
+  };
+}
+
 async function loadCodeboxCoreNormalizers() {
   const configuredModule = process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE;
   const candidates = configuredModule ? [configuredModule] : [DEFAULT_CODEBOX_CORE_MODULE];
@@ -393,6 +453,10 @@ async function runTaskRunner(request) {
   const runner = argValue('--task-runner') || `${__dirname}/homeboy-wp-codebox-task-runner.cjs`;
   const config = request.executor?.config || {};
   const taskInput = codeboxTaskRequestFromAgentTaskRequest(request);
+  const preflightPayload = missingWorkspacePayload(request, taskInput);
+  if (preflightPayload) {
+    return agentTaskOutcomeFromCodeboxResult(request, preflightPayload, { exitStatus: 1, ...coreNormalizers });
+  }
   const configArgs = [
     ['--agents-api', config.agents_api_path || config.agentsApiPath],
     ['--homeboy', config.homeboy_path || config.homeboyPath],

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1443,6 +1443,45 @@ try {
   assert.equal(missingSecretOutcome.diagnostics[0].data.phase, 'codebox.preflight');
   assert.equal(missingSecretOutcome.metadata.codebox.missing_env[0], 'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN');
   assert(!JSON.stringify(missingSecretOutcome).includes('codex-access-token-value'));
+
+  const missingWorkspace = writeFixtureTaskRunner(root);
+  const missingWorkspaceRequest = {
+    ...request,
+    task_id: 'missing-workspace-task-123',
+    group_key: 'a8c-intelligence',
+    workspace: {
+      mode: 'existing',
+      slug: 'a8c-intelligence',
+      materialization: { repo: 'a8c-intelligence' },
+    },
+    executor: {
+      ...request.executor,
+      config: {
+        provider: 'openai',
+        task_kind: 'repo-cooking',
+        repo: 'a8c-intelligence',
+      },
+    },
+  };
+  fs.rmSync(missingWorkspace.capture, { force: true });
+  const missingWorkspaceResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+    '--task-runner',
+    missingWorkspace.fixture,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(missingWorkspaceRequest),
+  });
+  assert.equal(missingWorkspaceResult.status, 1, missingWorkspaceResult.stderr || missingWorkspaceResult.stdout);
+  assert.equal(fs.existsSync(missingWorkspace.capture), false, 'task runner should not be invoked without a workspace mount');
+  const missingWorkspaceOutcome = JSON.parse(missingWorkspaceResult.stdout);
+  assert.equal(missingWorkspaceOutcome.status, 'failed');
+  assert.equal(missingWorkspaceOutcome.failure_classification, 'execution_failed');
+  assert.equal(missingWorkspaceOutcome.diagnostics[0].class, 'codebox.preflight.missing_workspace');
+  assert.equal(missingWorkspaceOutcome.diagnostics[0].data.repo, 'a8c-intelligence');
+  assert.equal(missingWorkspaceOutcome.diagnostics[0].data.task_kind, 'repo-cooking');
+  assert.equal(missingWorkspaceOutcome.diagnostics[0].data.mounts_count, 0);
+  assert.equal(missingWorkspaceOutcome.metadata.codebox.missing_workspace, true);
 } finally {
   fs.rmSync(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- Adds a wrapper preflight that rejects repo-cooking Codebox tasks when no workspace checkout is mounted.
- Returns a structured `codebox.preflight.missing_workspace` diagnostic before the task runner can launch an empty sandbox.
- Covers the guard in the Codebox agent task executor smoke test.

Fixes #1239

## Testing
- `npm run test:codebox-agent-task-executor`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the preflight guard and smoke coverage; Chris remains responsible for review and acceptance.