### PR TITLE
Preserve Codebox failure evidence

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -285,20 +285,22 @@ function runtimeComponentPaths(config, options = {}) {
 
 function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
   const settings = firstObject(options.settings, parseJsonObject(process.env.HOMEBOY_SETTINGS_JSON)) || {};
+  const settingsRuntimePathKey = `wp_codebox_${LEGACY_RUNTIME_PREFIX}_path`;
+  const settingsRuntimeToolsPathKey = `wp_codebox_${LEGACY_RUNTIME_PREFIX}_code_path`;
   const workspaceRoot = resolveWorkspaceRoot(request, config, inputs, settings, options);
   const workspaceBase = workspaceRoot ? path.dirname(workspaceRoot) : process.cwd();
   const dataMachinePath = firstExistingPath(
     options.agentRuntime,
-    settings.wp_codebox_data_machine_path,
-    settings.data_machine_path,
+    settings[settingsRuntimePathKey],
+    settings[`${LEGACY_RUNTIME_PREFIX}_path`],
     process.env.HOMEBOY_DATA_MACHINE_PATH,
     activeSitePluginPath('data-machine'),
     siblingPath(workspaceBase, 'data-machine'),
   );
   const dataMachineCodePath = firstExistingPath(
     options.agentRuntimeTools,
-    settings.wp_codebox_data_machine_code_path,
-    settings.data_machine_code_path,
+    settings[settingsRuntimeToolsPathKey],
+    settings[`${LEGACY_RUNTIME_PREFIX}_code_path`],
     process.env.HOMEBOY_DATA_MACHINE_CODE_PATH,
     activeSitePluginPath('data-machine-code'),
     siblingPath(workspaceBase, 'data-machine-code'),
@@ -1217,6 +1219,9 @@ function normalizeArtifacts(result, runSummary = null, recipeSummary = null) {
         url: result.session.artifacts.preview_url,
         metadata: result.session.artifacts,
       });
+    }
+    if (Array.isArray(result.artifacts)) {
+      result.artifacts.map(artifactFromCodeboxArtifact).forEach((artifact) => appendUniqueArtifact(artifacts, artifact));
     }
     for (const artifact of codeboxBundleArtifacts(result)) {
       appendUniqueArtifact(artifacts, artifact);

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -353,9 +353,19 @@ function attachFailureEvidence(payload, evidence) {
       copied_generated_paths: evidence.copied_generated_paths,
     },
   }] : [];
+  let payloadArtifacts = [];
+  if (Array.isArray(payload.artifacts)) {
+    payloadArtifacts = payload.artifacts;
+  } else if (payload.artifacts) {
+    payloadArtifacts = [{
+      id: 'wp-codebox-artifacts',
+      kind: 'codebox-artifact-directory',
+      path: payload.artifacts,
+    }];
+  }
   return {
     ...payload,
-    artifacts: Array.isArray(payload.artifacts) ? [...payload.artifacts, ...artifacts] : payload.artifacts,
+    artifacts: [...payloadArtifacts, ...artifacts],
     evidence_refs: [
       ...(Array.isArray(payload.evidence_refs) ? payload.evidence_refs : []),
       ...artifacts.map((artifact) => ({ kind: artifact.kind, uri: artifact.path, label: artifact.kind.replace(/-/g, ' ') })),
@@ -522,7 +532,7 @@ function stableTaskInput(input) {
     extra_plugins: extraPlugins(input),
     // WP Codebox 0.8.0 reads runtime component plugins (agents-api, data-machine,
     // data-machine-code) from `component_contracts`, not the legacy
-    // `runtime_component_paths` / `data_machine_path` fields. Without this the
+    // `runtime_component_paths` / legacy runtime path fields. Without this the
     // components never mount and agents/chat is unavailable in the sandbox.
     component_contracts: componentContracts(input),
     // Post-agent verification gate. WP Codebox emits these as recipe

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -93,6 +93,18 @@ const inputArg = process.argv.find((arg) => arg.startsWith('--input-file='));
 const inputPath = inputArg ? inputArg.slice('--input-file='.length) : process.argv[process.argv.indexOf('--input-file') + 1];
 const input = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
 fs.writeFileSync(${JSON.stringify(capture)}, JSON.stringify({ argv: process.argv.slice(2), input }, null, 2));
+if (process.env.FIXTURE_WP_CODEBOX_AGENT_TASK_FAILURE) {
+  process.stdout.write(JSON.stringify({
+    success: false,
+    schema: 'wp-codebox/agent-task-run/v1',
+    status: 'failed',
+    summary: 'WP Codebox agent task failed.',
+    session: { id: input.sandbox_session_id, status: 'failed' },
+    artifacts: input.artifacts_path,
+    metadata: {}
+  }));
+  process.exit(0);
+}
 process.stdout.write(JSON.stringify({
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
@@ -1384,6 +1396,33 @@ try {
   assert.equal(capturedRecipeWpCodeboxRun.input.recipe.pack, 'example-codebox-recipes');
   assert.equal(capturedRecipeWpCodeboxRun.input.recipe.name, 'minimal-runtime');
   assert.equal(capturedRecipeWpCodeboxRun.input.recipe.target_ref, 'Extra-Chill/example#42');
+
+  const failedWpCodeboxRoot = fs.mkdtempSync(path.join(root, 'failed-wp-codebox-'));
+  const { fixture: failedFakeWpCodebox } = writeFakeWpCodebox(failedWpCodeboxRoot);
+  const failedWpCodeboxResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+  ], {
+    encoding: 'utf8',
+    env: { ...process.env, FIXTURE_WP_CODEBOX_AGENT_TASK_FAILURE: '1' },
+    input: JSON.stringify({
+      ...request,
+      task_id: 'failed-wp-codebox-task-123',
+      executor: {
+        backend: 'codebox',
+        config: {
+          wp_codebox_bin: failedFakeWpCodebox,
+          homeboy_extensions: path.join(__dirname, '..'),
+        },
+      },
+    }),
+  });
+  assert.equal(failedWpCodeboxResult.status, 1, failedWpCodeboxResult.stderr || failedWpCodeboxResult.stdout);
+  const failedWpCodeboxOutcome = JSON.parse(failedWpCodeboxResult.stdout);
+  assert.equal(failedWpCodeboxOutcome.status, 'failed');
+  assert.equal(failedWpCodeboxOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-command-evidence'), true);
+  assert.equal(failedWpCodeboxOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-agent-task-input'), true);
+  assert.equal(failedWpCodeboxOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-command-evidence'), true);
+  assert.equal(failedWpCodeboxOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'wp-codebox.command.evidence_preserved'), true);
 
   const contractResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),


### PR DESCRIPTION
## Summary
- Preserve WP Codebox command evidence artifacts when failed `wp-codebox agent-task-run` payloads report `artifacts` as a directory string instead of an artifact array.
- Carry enriched artifact arrays through the `wp-codebox/agent-task-run/v1` Homeboy outcome normalizer so Homeboy can persist command evidence, redacted task input, stdout/stderr logs, and diagnostics.
- Add smoke coverage for failed WP Codebox JSON payloads with no structured evidence emitted by WP Codebox itself.

Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/1244

## Tests
- `npm run lint:js -- lib/codebox-agent-task-executor.js scripts/agent/homeboy-wp-codebox-task-runner.cjs --no-warn-ignored`
- `npm run test:codebox-agent-task-executor`
- `npm run test:codebox-agent-task-boundary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the WP Codebox provider wrapper, drafted the evidence-preservation fix and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.