### PR TITLE
Summarize webperf evidence artifacts

### DIFF
--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -15,6 +15,7 @@ module.exports = {
 	...require('./lib/wordpress-helper-consumer'),
 	...require('./lib/fixture-setup'),
 	...require('./lib/codebox-memory-report'),
+	...require('./lib/webperf-evidence-summary'),
 	...require('./lib/agent-terminal-actions'),
 	...require('./lib/wp-codebox-apply-adapter'),
 };

--- a/wordpress/lib/webperf-evidence-summary.js
+++ b/wordpress/lib/webperf-evidence-summary.js
@@ -1,0 +1,380 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const fs = require('node:fs');
+
+const DEFAULT_OPTIONS = Object.freeze({ parityPercent: 2, regressionPercent: 5, maxSamples: 9 });
+const HIGHER_IS_BETTER_PATTERNS = [/success/i, /pass/i, /reward/i, /score/i];
+
+function isPlainObject(value) {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asArray(value) {
+	if (Array.isArray(value)) {
+		return value;
+	}
+	if (typeof value === 'string' && value.trim() !== '') {
+		return value.split(',').map((item) => item.trim()).filter(Boolean);
+	}
+	return [];
+}
+
+function finiteNumber(value) {
+	return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function round(value, places = 3) {
+	const number = finiteNumber(value);
+	if (number === null) {
+		return null;
+	}
+	const factor = 10 ** places;
+	return Math.round(number * factor) / factor;
+}
+
+function median(values) {
+	const numbers = asArray(values).map(finiteNumber).filter((value) => value !== null).sort((a, b) => a - b);
+	if (numbers.length === 0) {
+		return null;
+	}
+	const middle = Math.floor(numbers.length / 2);
+	return numbers.length % 2 === 1 ? numbers[middle] : (numbers[middle - 1] + numbers[middle]) / 2;
+}
+
+function percentDelta(baseline, candidate) {
+	if (baseline === null || candidate === null || baseline === 0) {
+		return null;
+	}
+	return ((candidate - baseline) / Math.abs(baseline)) * 100;
+}
+
+function metricDirection(metric, options) {
+	if (options.higherIsBetterMetricSet.has(metric)) {
+		return 'higher';
+	}
+	if (options.lowerIsBetterMetricSet.has(metric)) {
+		return 'lower';
+	}
+	return HIGHER_IS_BETTER_PATTERNS.some((pattern) => pattern.test(metric)) ? 'higher' : 'lower';
+}
+
+function classifyComparableMetric(row, options) {
+	if (row.baseline_median === null || row.candidate_median === null || row.percent_delta === null) {
+		return 'safety';
+	}
+	const effectiveDelta = row.direction === 'higher' ? row.percent_delta * -1 : row.percent_delta;
+	if (effectiveDelta > options.regressionPercent) {
+		return 'regression';
+	}
+	if (effectiveDelta < options.parityPercent * -1) {
+		return 'improvement';
+	}
+	return 'parity';
+}
+
+function extractScenarios(input) {
+	if (Array.isArray(input?.scenarios)) {
+		return input.scenarios;
+	}
+	if (Array.isArray(input?.results)) {
+		return input.results;
+	}
+	if (Array.isArray(input?.comparisons)) {
+		return input.comparisons;
+	}
+	return [];
+}
+
+function metricSamples(value, candidateValue) {
+	if (isPlainObject(value)) {
+		return {
+			baselineSamples: asArray(value.baseline_samples || value.baselineSamples || value.before_samples || value.beforeSamples),
+			candidateSamples: asArray(value.candidate_samples || value.candidateSamples || value.after_samples || value.afterSamples),
+		};
+	}
+	return {
+		baselineSamples: Array.isArray(value) ? value : [],
+		candidateSamples: Array.isArray(candidateValue) ? candidateValue : [],
+	};
+}
+
+function normalizeMetricRow({ scenario, metric, value = {}, baselineValue, candidateValue, options }) {
+	const samples = metricSamples(value, candidateValue);
+	const baseline = finiteNumber(baselineValue)
+		?? finiteNumber(value.baseline)
+		?? finiteNumber(value.before)
+		?? median(samples.baselineSamples);
+	const candidate = finiteNumber(candidateValue)
+		?? finiteNumber(value.candidate)
+		?? finiteNumber(value.after)
+		?? median(samples.candidateSamples)
+		?? (finiteNumber(value) !== null ? value : null);
+	const delta = baseline !== null && candidate !== null ? candidate - baseline : null;
+	const row = {
+		kind: 'measurement',
+		scenario_id: scenario.id || 'unknown',
+		metric,
+		direction: metricDirection(metric, options),
+		baseline_median: round(baseline),
+		candidate_median: round(candidate),
+		delta: round(delta),
+		percent_delta: round(finiteNumber(value.percentDelta) ?? finiteNumber(value.percent_delta) ?? percentDelta(baseline, candidate)),
+		baseline_samples: samples.baselineSamples.slice(0, options.maxSamples),
+		candidate_samples: samples.candidateSamples.slice(0, options.maxSamples),
+	};
+	row.verdict = classifyComparableMetric(row, options);
+	return row;
+}
+
+function metricNamesForScenario(baselineScenario, candidateScenario, options) {
+	if (options.metricSet.size > 0) {
+		return [...options.metricSet];
+	}
+	return [...new Set([
+		...Object.keys(baselineScenario?.metrics || {}),
+		...Object.keys(candidateScenario?.metrics || {}),
+	])];
+}
+
+function rowsFromBaselineCandidate({ baseline, candidate, options }) {
+	const baselineById = new Map(extractScenarios(baseline).map((scenario) => [scenario.id, scenario]));
+	const rows = [];
+	for (const candidateScenario of extractScenarios(candidate)) {
+		if (options.scenarioSet.size > 0 && !options.scenarioSet.has(candidateScenario.id)) {
+			continue;
+		}
+		const baselineScenario = baselineById.get(candidateScenario.id);
+		if (!baselineScenario) {
+			continue;
+		}
+		for (const metric of metricNamesForScenario(baselineScenario, candidateScenario, options)) {
+			const baselineValue = baselineScenario.metrics?.[metric];
+			const candidateValue = candidateScenario.metrics?.[metric];
+			if (finiteNumber(baselineValue) === null && finiteNumber(candidateValue) === null) {
+				continue;
+			}
+			rows.push(normalizeMetricRow({ scenario: candidateScenario, metric, baselineValue, candidateValue, options }));
+		}
+	}
+	return rows;
+}
+
+function rowsFromCompareArtifact(input, options) {
+	const rows = [];
+	for (const scenario of extractScenarios(input)) {
+		if (options.scenarioSet.size > 0 && !options.scenarioSet.has(scenario.id)) {
+			continue;
+		}
+		for (const [metric, value] of Object.entries(scenario.metrics || {})) {
+			if (options.metricSet.size > 0 && !options.metricSet.has(metric)) {
+				continue;
+			}
+			if (isPlainObject(value) || finiteNumber(value) !== null) {
+				rows.push(normalizeMetricRow({ scenario, metric, value, options }));
+			}
+		}
+	}
+	return rows;
+}
+
+function extractArtifacts(source, scenarioIds) {
+	const artifacts = [];
+	const addArtifacts = (scope, value) => {
+		if (!isPlainObject(value)) {
+			return;
+		}
+		for (const [name, artifact] of Object.entries(value)) {
+			if (typeof artifact === 'string') {
+				artifacts.push({ kind: 'artifact', scope, name, path: artifact });
+			} else if (isPlainObject(artifact)) {
+				artifacts.push({ kind: 'artifact', scope, name, ...artifact });
+			}
+		}
+	};
+	addArtifacts('run', source?.artifacts);
+	for (const scenario of extractScenarios(source)) {
+		if (scenarioIds.size > 0 && !scenarioIds.has(scenario.id)) {
+			continue;
+		}
+		addArtifacts(`scenario:${scenario.id}`, scenario.artifacts);
+	}
+	return artifacts;
+}
+
+function summarizeVerdict(rows) {
+	const comparable = rows.filter((row) => row.baseline_median !== null && row.candidate_median !== null);
+	if (comparable.some((row) => row.verdict === 'regression')) {
+		return 'regression';
+	}
+	if (comparable.some((row) => row.verdict === 'improvement')) {
+		return 'improvement';
+	}
+	if (comparable.length > 0) {
+		return 'parity';
+	}
+	return rows.length > 0 ? 'safety' : 'no_measurements';
+}
+
+function normalizeOptions(options) {
+	const normalized = { ...DEFAULT_OPTIONS, ...options };
+	if (!Number.isFinite(normalized.parityPercent)) {
+		normalized.parityPercent = DEFAULT_OPTIONS.parityPercent;
+	}
+	if (!Number.isFinite(normalized.regressionPercent)) {
+		normalized.regressionPercent = DEFAULT_OPTIONS.regressionPercent;
+	}
+	if (!Number.isFinite(normalized.maxSamples)) {
+		normalized.maxSamples = DEFAULT_OPTIONS.maxSamples;
+	}
+	normalized.metricSet = new Set(asArray(normalized.metrics));
+	normalized.scenarioSet = new Set(asArray(normalized.scenarios));
+	normalized.higherIsBetterMetricSet = new Set(asArray(normalized.higherIsBetterMetrics));
+	normalized.lowerIsBetterMetricSet = new Set(asArray(normalized.lowerIsBetterMetrics));
+	return normalized;
+}
+
+function summarizeWebperfEvidence(input, options = {}) {
+	const normalizedOptions = normalizeOptions(options);
+	const rows = input?.baseline && input?.candidate
+		? rowsFromBaselineCandidate({ baseline: input.baseline, candidate: input.candidate, options: normalizedOptions })
+		: rowsFromCompareArtifact(input, normalizedOptions);
+	const scenarioIds = new Set(rows.map((row) => row.scenario_id));
+	const sourceForArtifacts = input?.candidate || input;
+	const caveats = [];
+	if (normalizedOptions.metricSet.size > 0) {
+		const present = new Set(rows.map((row) => row.metric));
+		for (const metric of normalizedOptions.metricSet) {
+			if (!present.has(metric)) {
+				caveats.push(`Requested metric not found in comparable measurements: ${metric}.`);
+			}
+		}
+	}
+	if (!rows.some((row) => row.baseline_median !== null && row.candidate_median !== null)) {
+		caveats.push('No baseline/candidate metric pair was available; this summary can only support behavioral safety, not a performance win.');
+	}
+
+	return {
+		schema: 'homeboy/webperf-evidence-summary/v1',
+		verdict: summarizeVerdict(rows),
+		metric_focus: [...normalizedOptions.metricSet],
+		scenario_focus: [...normalizedOptions.scenarioSet],
+		thresholds: {
+			parity_percent: normalizedOptions.parityPercent,
+			regression_percent: normalizedOptions.regressionPercent,
+		},
+		measurement_rows: rows,
+		artifacts: extractArtifacts(sourceForArtifacts, scenarioIds),
+		provenance: {
+			component_id: input?.candidate?.component_id || input?.component_id || null,
+			baseline_component_id: input?.baseline?.component_id || null,
+			generated_from: input?.baseline && input?.candidate ? 'baseline-candidate-results' : 'compare-artifact',
+		},
+		caveats,
+	};
+}
+
+function formatValue(value, suffix = '') {
+	return value === null || value === undefined ? 'n/a' : `${value}${suffix}`;
+}
+
+function formatWebperfEvidenceSummaryMarkdown(summary) {
+	const lines = [
+		'# Web Performance Evidence Summary',
+		'',
+		`Verdict: **${summary.verdict}**`,
+		'',
+		'| Scenario | Metric | Baseline median | Candidate median | Delta | Delta % | Result |',
+		'|---|---|---:|---:|---:|---:|---|',
+	];
+	for (const row of summary.measurement_rows) {
+		lines.push(`| ${row.scenario_id} | ${row.metric} | ${formatValue(row.baseline_median)} | ${formatValue(row.candidate_median)} | ${formatValue(row.delta)} | ${formatValue(row.percent_delta, '%')} | ${row.verdict} |`);
+	}
+	if (summary.measurement_rows.length === 0) {
+		lines.push('| n/a | n/a | n/a | n/a | n/a | n/a | no_measurements |');
+	}
+	if (summary.artifacts.length > 0) {
+		lines.push('', '## Artifacts', '', '| Scope | Name | Path |', '|---|---|---|');
+		for (const artifact of summary.artifacts) {
+			lines.push(`| ${artifact.scope || 'run'} | ${artifact.name || artifact.label || 'artifact'} | ${artifact.path || artifact.url || ''} |`);
+		}
+	}
+	if (summary.caveats.length > 0) {
+		lines.push('', '## Caveats', '');
+		for (const caveat of summary.caveats) {
+			lines.push(`- ${caveat}`);
+		}
+	}
+	return `${lines.join('\n')}\n`;
+}
+
+function readJsonFile(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function parseCli(argv) {
+	const args = {};
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (!arg.startsWith('--')) {
+			continue;
+		}
+		const key = arg.slice(2);
+		const next = argv[index + 1];
+		if (!next || next.startsWith('--')) {
+			args[key] = true;
+			continue;
+		}
+		args[key] = next;
+		index += 1;
+	}
+	return args;
+}
+
+function parseJsonOption(value, fallback) {
+	return value ? JSON.parse(value) : fallback;
+}
+
+function runCli(argv = process.argv.slice(2)) {
+	const args = parseCli(argv);
+	if (!args.input && (!args.baseline || !args.candidate)) {
+		throw new Error('Usage: node webperf-evidence-summary.js --input <compare.json> OR --baseline <baseline-results.json> --candidate <candidate-results.json>');
+	}
+	const input = args.baseline && args.candidate
+		? { baseline: readJsonFile(args.baseline), candidate: readJsonFile(args.candidate) }
+		: readJsonFile(args.input);
+	const summary = summarizeWebperfEvidence(input, {
+		metrics: parseJsonOption(args.metrics, undefined),
+		scenarios: parseJsonOption(args.scenarios, undefined),
+		higherIsBetterMetrics: parseJsonOption(args['higher-is-better'], undefined),
+		lowerIsBetterMetrics: parseJsonOption(args['lower-is-better'], undefined),
+		parityPercent: args['parity-percent'] ? Number(args['parity-percent']) : undefined,
+		regressionPercent: args['regression-percent'] ? Number(args['regression-percent']) : undefined,
+	});
+	if (args['output-json']) {
+		fs.writeFileSync(args['output-json'], `${JSON.stringify(summary, null, 2)}\n`);
+	}
+	const markdown = formatWebperfEvidenceSummaryMarkdown(summary);
+	if (args['output-markdown']) {
+		fs.writeFileSync(args['output-markdown'], markdown);
+	} else {
+		process.stdout.write(markdown);
+	}
+	return 0;
+}
+
+if (require.main === module) {
+	try {
+		process.exitCode = runCli();
+	} catch (error) {
+		process.stderr.write(`${error.message}\n`);
+		process.exitCode = 2;
+	}
+}
+
+module.exports = {
+	formatWebperfEvidenceSummaryMarkdown,
+	summarizeWebperfEvidence,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -23,6 +23,7 @@
     "./codebox-memory-report": "./lib/codebox-memory-report.js",
     "./wp-codebox-apply-adapter": "./lib/wp-codebox-apply-adapter.js",
     "./wp-codebox-browser-metrics": "./lib/wp-codebox-browser-metrics.js",
+    "./webperf-evidence-summary": "./lib/webperf-evidence-summary.js",
     "./audit-wp-codebox-fanout": "./lib/audit-wp-codebox-fanout.js",
     "./codebox-agent-task-executor": "./lib/codebox-agent-task-executor.js"
   },
@@ -47,6 +48,7 @@
     "test:codebox-memory-report": "node tests/codebox-memory-report-smoke.js",
     "test:wp-codebox-apply-adapter": "node tests/wp-codebox-apply-adapter-smoke.js",
     "test:wp-codebox-browser-metrics": "node tests/wp-codebox-browser-metrics-smoke.js",
+    "test:webperf-evidence-summary": "node tests/webperf-evidence-summary-smoke.js",
     "test:wordpress-bench-state-sampling": "php tests/wordpress-bench-state-sampling-helper-smoke.php",
     "test:wordpress-db-query-profiler": "php scripts/bench/wordpress-db-query-profiler-smoke.php",
     "test:audit-wp-codebox-fanout": "node tests/audit-wp-codebox-fanout-smoke.js",

--- a/wordpress/scripts/bench/bench-results-artifacts-smoke.sh
+++ b/wordpress/scripts/bench/bench-results-artifacts-smoke.sh
@@ -17,6 +17,7 @@ cleanup() {
 trap cleanup EXIT
 
 RESULTS_FILE="${TMP_ROOT}/bench-results.json"
+BASELINE_RESULTS_FILE="${TMP_ROOT}/bench-baseline-results.json"
 
 cat > "$RESULTS_FILE" <<'JSON'
 {
@@ -81,11 +82,34 @@ cat > "$RESULTS_FILE" <<'JSON'
 }
 JSON
 
+cat > "$BASELINE_RESULTS_FILE" <<'JSON'
+{
+  "component_id": "wp-rl-fixture",
+  "iterations": 1,
+  "scenarios": [
+    {
+      "id": "block-markup/navigation-001",
+      "iterations": 1,
+      "metrics": { "mean_ms": 1400, "reward_mean": 1, "success_mean": 1, "turns_mean": 8 }
+    },
+    {
+      "id": "block-markup/query-002",
+      "iterations": 1,
+      "metrics": { "mean_ms": 500, "reward_mean": 0 }
+    }
+  ]
+}
+JSON
+
+HOMEBOY_BENCH_BASELINE_RESULTS_FILE="$BASELINE_RESULTS_FILE" \
+HOMEBOY_BENCH_WEBPERF_SUMMARY_METRICS_JSON='["mean_ms","reward_mean"]' \
 homeboy_wordpress_emit_bench_results_artifacts "$RESULTS_FILE"
 
 JSONL_FILE="${TMP_ROOT}/results.jsonl"
 LEADERBOARD_FILE="${TMP_ROOT}/leaderboard.md"
 SERIES_FILE="${TMP_ROOT}/series.json"
+WEBPERF_SUMMARY_JSON_FILE="${TMP_ROOT}/webperf-evidence-summary.json"
+WEBPERF_SUMMARY_MARKDOWN_FILE="${TMP_ROOT}/webperf-evidence-summary.md"
 
 if [ ! -s "$JSONL_FILE" ]; then
     echo "ERROR: missing results.jsonl artifact" >&2
@@ -97,6 +121,10 @@ if [ ! -s "$LEADERBOARD_FILE" ]; then
 fi
 if [ ! -s "$SERIES_FILE" ]; then
     echo "ERROR: missing series.json artifact" >&2
+    exit 1
+fi
+if [ ! -s "$WEBPERF_SUMMARY_JSON_FILE" ] || [ ! -s "$WEBPERF_SUMMARY_MARKDOWN_FILE" ]; then
+    echo "ERROR: missing webperf evidence summary artifacts" >&2
     exit 1
 fi
 
@@ -143,6 +171,22 @@ artifact_path=$(jq -r '.series[] | select(.scenario_id == "block-markup/query-00
 if [ "$series_schema" != "homeboy/wordpress-bench-step-series/v1" ] || [ "$series_count" -ne 2 ] || [ "$request_success" != "true" ] || [ "$option_failure" != "transient grew past budget" ] || [ "$artifact_path" != "artifacts/query-series.json" ]; then
     echo "ERROR: series.json did not preserve normalized step-series rows and artifact refs" >&2
     cat "$SERIES_FILE" >&2
+    exit 1
+fi
+
+webperf_schema=$(jq -r '.schema' "$WEBPERF_SUMMARY_JSON_FILE")
+webperf_verdict=$(jq -r '.verdict' "$WEBPERF_SUMMARY_JSON_FILE")
+webperf_row_count=$(jq -r '.measurement_rows | length' "$WEBPERF_SUMMARY_JSON_FILE")
+webperf_mean_result=$(jq -r '.measurement_rows[] | select(.scenario_id == "block-markup/navigation-001" and .metric == "mean_ms") | .verdict' "$WEBPERF_SUMMARY_JSON_FILE")
+
+if [ "$webperf_schema" != "homeboy/webperf-evidence-summary/v1" ] || [ "$webperf_verdict" != "improvement" ] || [ "$webperf_row_count" -ne 4 ] || [ "$webperf_mean_result" != "improvement" ]; then
+    echo "ERROR: webperf summary did not capture focused baseline/candidate measurements" >&2
+    cat "$WEBPERF_SUMMARY_JSON_FILE" >&2
+    exit 1
+fi
+if ! grep -q 'Web Performance Evidence Summary' "$WEBPERF_SUMMARY_MARKDOWN_FILE"; then
+    echo "ERROR: webperf markdown summary missing title" >&2
+    cat "$WEBPERF_SUMMARY_MARKDOWN_FILE" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/bench/bench-results-artifacts.sh
+++ b/wordpress/scripts/bench/bench-results-artifacts.sh
@@ -156,6 +156,10 @@ homeboy_wordpress_emit_bench_results_artifacts() {
 	local baseline_results_file
 	local codebox_memory_report_file
 	local codebox_thresholds_json
+	local webperf_summary_json_file
+	local webperf_summary_markdown_file
+	local webperf_summary_metrics_json
+	local webperf_summary_scenarios_json
 
     if [ -z "$bench_results_file" ] || [ ! -s "$bench_results_file" ]; then
         return 0
@@ -168,6 +172,8 @@ homeboy_wordpress_emit_bench_results_artifacts() {
 	leaderboard_file="${artifact_dir}/leaderboard.md"
 	series_file="${artifact_dir}/series.json"
 	codebox_memory_report_file="${artifact_dir}/codebox-browser-memory-comparison.md"
+	webperf_summary_json_file="${artifact_dir}/webperf-evidence-summary.json"
+	webperf_summary_markdown_file="${artifact_dir}/webperf-evidence-summary.md"
 
     if ! homeboy_wordpress_bench_jsonl_filter < "$bench_results_file" > "$jsonl_file"; then
         echo "ERROR: failed to emit bench results JSONL artifact at $jsonl_file" >&2
@@ -195,6 +201,19 @@ homeboy_wordpress_emit_bench_results_artifacts() {
 			echo "ERROR: failed to emit Codebox browser memory comparison at $codebox_memory_report_file" >&2
 			return 1
 		fi
+
+		webperf_summary_metrics_json="${HOMEBOY_WEBPERF_SUMMARY_METRICS_JSON:-${HOMEBOY_BENCH_WEBPERF_SUMMARY_METRICS_JSON:-[]}}"
+		webperf_summary_scenarios_json="${HOMEBOY_WEBPERF_SUMMARY_SCENARIOS_JSON:-${HOMEBOY_BENCH_WEBPERF_SUMMARY_SCENARIOS_JSON:-[]}}"
+		if ! node "${SCRIPT_DIR}/../../lib/webperf-evidence-summary.js" \
+			--baseline "$baseline_results_file" \
+			--candidate "$bench_results_file" \
+			--metrics "$webperf_summary_metrics_json" \
+			--scenarios "$webperf_summary_scenarios_json" \
+			--output-json "$webperf_summary_json_file" \
+			--output-markdown "$webperf_summary_markdown_file"; then
+			echo "ERROR: failed to emit webperf evidence summary at $webperf_summary_json_file" >&2
+			return 1
+		fi
 	fi
 
 	if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
@@ -202,5 +221,6 @@ homeboy_wordpress_emit_bench_results_artifacts() {
 		echo "DEBUG: [bench] Leaderboard: $leaderboard_file"
 		echo "DEBUG: [bench] Step series: $series_file"
 		[ -s "$codebox_memory_report_file" ] && echo "DEBUG: [bench] Codebox browser memory comparison: $codebox_memory_report_file"
+		[ -s "$webperf_summary_json_file" ] && echo "DEBUG: [bench] Webperf evidence summary: $webperf_summary_json_file"
 	fi
 }

--- a/wordpress/tests/webperf-evidence-summary-smoke.js
+++ b/wordpress/tests/webperf-evidence-summary-smoke.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const {
+	formatWebperfEvidenceSummaryMarkdown,
+	summarizeWebperfEvidence,
+} = require('../lib/webperf-evidence-summary');
+
+function writeJson(filePath, value) {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function withTempDirectory(callback) {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'webperf-evidence-summary-'));
+	try {
+		callback(root);
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+}
+
+const baseline = {
+	component_id: 'fixture-plugin',
+	scenarios: [
+		{
+			id: 'site-editor',
+			metrics: {
+				ready_ms: 1000,
+				rest_request_count: 8,
+				success_mean: 1,
+			},
+		},
+		{
+			id: 'checkout',
+			metrics: { ready_ms: 1200 },
+		},
+	],
+};
+const candidate = {
+	component_id: 'fixture-plugin',
+	artifacts: {
+		compare_json: { path: 'compare.json', kind: 'json' },
+	},
+	scenarios: [
+		{
+			id: 'site-editor',
+			metrics: {
+				ready_ms: 850,
+				rest_request_count: 5,
+				success_mean: 1,
+			},
+			artifacts: {
+				trace: { path: 'traces/site-editor.trace.json', kind: 'json' },
+			},
+		},
+		{
+			id: 'checkout',
+			metrics: { ready_ms: 1210 },
+		},
+	],
+};
+
+const focused = summarizeWebperfEvidence({ baseline, candidate }, {
+	metrics: ['ready_ms', 'rest_request_count'],
+	scenarios: ['site-editor'],
+});
+assert.equal(focused.schema, 'homeboy/webperf-evidence-summary/v1');
+assert.equal(focused.verdict, 'improvement');
+assert.equal(focused.measurement_rows.length, 2);
+assert.equal(focused.measurement_rows.find((row) => row.metric === 'ready_ms').percent_delta, -15);
+assert.equal(focused.measurement_rows.find((row) => row.metric === 'rest_request_count').verdict, 'improvement');
+assert.equal(focused.artifacts.some((artifact) => artifact.name === 'compare_json'), true);
+assert.equal(focused.artifacts.some((artifact) => artifact.scope === 'scenario:site-editor' && artifact.name === 'trace'), true);
+assert.equal(focused.caveats.length, 0);
+assert.match(formatWebperfEvidenceSummaryMarkdown(focused), /Verdict: \*\*improvement\*\*/);
+assert.match(formatWebperfEvidenceSummaryMarkdown(focused), /site-editor/);
+
+const safety = summarizeWebperfEvidence({
+	component_id: 'fixture-plugin',
+	scenarios: [{ id: 'site-editor', metrics: { ready_ms: 850 } }],
+}, { metrics: ['ready_ms', 'missing_metric'] });
+assert.equal(safety.verdict, 'safety');
+assert.equal(safety.caveats.some((caveat) => caveat.includes('No baseline/candidate metric pair')), true);
+assert.equal(safety.caveats.some((caveat) => caveat.includes('missing_metric')), true);
+
+const regression = summarizeWebperfEvidence({ baseline, candidate: {
+	...candidate,
+	scenarios: [{ id: 'site-editor', metrics: { ready_ms: 1110 } }],
+} }, { metrics: ['ready_ms'] });
+assert.equal(regression.verdict, 'regression');
+
+withTempDirectory((root) => {
+	const baselinePath = path.join(root, 'baseline.json');
+	const candidatePath = path.join(root, 'candidate.json');
+	const jsonPath = path.join(root, 'summary.json');
+	const markdownPath = path.join(root, 'summary.md');
+	writeJson(baselinePath, baseline);
+	writeJson(candidatePath, candidate);
+	const result = spawnSync(process.execPath, [
+		path.join(__dirname, '..', 'lib', 'webperf-evidence-summary.js'),
+		'--baseline', baselinePath,
+		'--candidate', candidatePath,
+		'--metrics', JSON.stringify(['ready_ms']),
+		'--scenarios', JSON.stringify(['site-editor']),
+		'--output-json', jsonPath,
+		'--output-markdown', markdownPath,
+	], { encoding: 'utf8' });
+	assert.equal(result.status, 0, result.stderr);
+	assert.equal(JSON.parse(fs.readFileSync(jsonPath, 'utf8')).verdict, 'improvement');
+	assert.match(fs.readFileSync(markdownPath, 'utf8'), /Web Performance Evidence Summary/);
+});
+
+console.log('✓ Webperf evidence summary smoke test PASSED');


### PR DESCRIPTION
## Summary
- Adds a reusable `webperf-evidence-summary` helper/CLI that summarizes compare-shaped artifacts or baseline/candidate bench results into structured JSON and concise Markdown.
- Emits `webperf-evidence-summary.json` and `webperf-evidence-summary.md` from WordPress bench artifact generation when a baseline results file is supplied.
- Supports declared metric/scenario focus, separates measurement rows from provenance/artifacts, and reports improvement, parity, regression, safety, or no-measurements verdicts with caveats.

Closes #1246.

## Tests
- `npm run test:webperf-evidence-summary`
- `bash scripts/bench/bench-results-artifacts-smoke.sh`
- `npm run test:wp-codebox-browser-metrics`
- `npx eslint lib/webperf-evidence-summary.js index.js`

## Caveats
- `npm run lint:js` still fails on pre-existing unrelated lint errors in `lib/playground-readiness.js`, `lib/timing-correlator.js`, and `scripts/agent/*`; the new helper is clean under targeted ESLint.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the webperf evidence summary helper, bench artifact integration, tests, and verification notes for Chris to review.