### PR TITLE
Fix Data Machine agent publication status checks

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -1139,11 +1139,11 @@ jobs:
             exit 1
           fi
 
-          if [ "$job_status" = "completed" ] || [ "$success_status" = "pr_opened" ] || [ "$completion_outcome_satisfied" = "true" ] || { [ "$success_status" = "no_changes" ] && [ "$no_changes_allowed" = "true" ]; }; then
+          if [ "$success_status" = "pr_opened" ] || [ "$completion_outcome_satisfied" = "true" ] || { [ "$success_status" = "no_changes" ] && [ "$no_changes_allowed" = "true" ]; }; then
             exit 0
           fi
 
-          printf 'ERROR: scenario %s expected completed job, opened PR, satisfied completion outcome, or allowed no-changes result, got job_status=%s success_status=%s completion_outcome_satisfied=%s no_changes_allowed=%s\n' \
+          printf 'ERROR: scenario %s expected opened PR, satisfied completion outcome, or allowed no-changes result, got job_status=%s success_status=%s completion_outcome_satisfied=%s no_changes_allowed=%s\n' \
             "${{ inputs.flow_slug }}" \
             "$job_status" \
             "$success_status" \

--- a/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php
@@ -138,6 +138,10 @@ namespace {
 		fwrite( STDERR, "Expected reusable workflow success assertion to accept opened PRs and satisfied completion outcomes.\n" );
 		exit( 1 );
 	}
+	if ( str_contains( $workflow_source, '[ "$job_status" = "completed" ] || [ "$success_status" = "pr_opened" ]' ) ) {
+		fwrite( STDERR, "Did not expect reusable workflow success assertion to treat any completed job as success.\n" );
+		exit( 1 );
+	}
 	if ( ! str_contains( $workflow_source, 'error_message="$(jq -r' ) || ! str_contains( $workflow_source, 'if [ -n "$error_message" ]; then' ) ) {
 		fwrite( STDERR, "Expected reusable workflow success assertion to fail when the agent reports an error message.\n" );
 		exit( 1 );

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1090,6 +1090,24 @@ if ( ! function_exists( 'homeboy_datamachine_agent_completion_outcome_satisfied'
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_success_status' ) ) {
+    function homeboy_datamachine_agent_success_status( bool $pr_opened, bool $completion_outcome_satisfied, bool $file_written ): string {
+        if ( $pr_opened ) {
+            return 'pr_opened';
+        }
+
+        if ( $completion_outcome_satisfied ) {
+            return 'completion_outcome_satisfied';
+        }
+
+        if ( $file_written ) {
+            return 'write_without_pr';
+        }
+
+        return 'no_changes';
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_bundle_path_in_repo' ) ) {
     function homeboy_datamachine_agent_bundle_path_in_repo( array $config ): string {
         $configured = trim( (string) ( $config['bundle_path_in_repo'] ?? '' ), '/' );
@@ -3407,7 +3425,7 @@ if ( $file_written && ! $pr_opened && empty( $runner_workspace_capture['changed'
     }
 }
 $completion_outcome_satisfied = homeboy_datamachine_agent_completion_outcome_satisfied( $engine_data, $config );
-$success_status = $pr_opened ? 'pr_opened' : ( $completion_outcome_satisfied ? 'completion_outcome_satisfied' : 'no_changes' );
+$success_status = homeboy_datamachine_agent_success_status( $pr_opened, $completion_outcome_satisfied, $file_written );
 $artifact_pr_context = array(
     'success_status'           => $success_status,
     'success_requires_pr'      => $success_requires_pr,
@@ -3440,6 +3458,7 @@ if ( is_array( $job_artifact_exports['engine_data'] ?? null ) ) {
     $engine_data = $job_artifact_exports['engine_data'];
     $pr_opened   = true;
 }
+$success_status = homeboy_datamachine_agent_success_status( $pr_opened, $completion_outcome_satisfied, $file_written );
 
 $metadata += array(
     'agent_id'             => $agent_id,

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -154,6 +154,16 @@ namespace {
         exit( 1 );
     }
 
+    if ( 'write_without_pr' !== homeboy_datamachine_agent_success_status( false, false, true ) ) {
+        fwrite( STDERR, "Expected file writes without PR publication to be classified as write_without_pr.\n" );
+        exit( 1 );
+    }
+
+    if ( 'no_changes' !== homeboy_datamachine_agent_success_status( false, false, false ) ) {
+        fwrite( STDERR, "Expected no writes and no PR publication to be classified as no_changes.\n" );
+        exit( 1 );
+    }
+
     $pr_opened = array(
         'github_tool_results' => array(
             array(


### PR DESCRIPTION
## Summary
- Classify file writes without a PR/publication as `write_without_pr` instead of `no_changes`.
- Stop treating any completed Data Machine job as a successful reusable workflow outcome.
- Add smoke coverage for the status classification and workflow assertion guard.

## Context
Build with WordPress developer-docs bootstrap run 27324620660 wrote docs files but surfaced as a green `no_changes` run after verification failed with `verification_commands requires a provisioned DMC target workspace path.` This keeps that class of incomplete write from being accepted as a no-op.

## Testing
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-child-drain-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the failed docs-agent bootstrap evidence, drafting the runner status fix, and running targeted smoke tests. Chris reviewed/approved committing and opening this PR.