### PR TITLE
Fix prefixed WP Codebox workload output parsing

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -165,6 +165,8 @@ const output = {
     dry_run: 1,
   },
   metadata: {
+    success_status: 'write_without_pr',
+    file_written: true,
     provider: 'example-provider',
     model: 'example-model',
     agent_slug: 'wp-codebox-smoke-agent',
@@ -178,6 +180,7 @@ const output = {
     },
   },
 }
+const warningPrefixedOutput = '<br />\n<b>Warning</b>: fixture warning before JSON<br />\n' + JSON.stringify(output)
 const transcript = {
   schema: 'wp-codebox/agent-transcript/v1',
   executions: includeLegacyOutput ? [{
@@ -185,9 +188,9 @@ const transcript = {
     command: 'wordpress.run-php',
     recipeCommand: 'wp-codebox.agent-sandbox-run',
     exitCode: 0,
-    stdout: JSON.stringify({ output: JSON.stringify(output) }),
+    stdout: JSON.stringify({ output: warningPrefixedOutput }),
     stderr: '',
-    parsed: { output: JSON.stringify(output) },
+    parsed: { output: warningPrefixedOutput },
   }] : [],
 }
 const agentResult = {
@@ -309,7 +312,9 @@ runtime_manifest_artifact=$(jq -r "$scenario | .artifacts.wp_codebox_runtime_ref
 runtime_manifest_schema=$(jq -r "$scenario | .metadata.wp_codebox.runtime_reference_manifest.schema // \"missing\"" "$RESULTS_TMPFILE")
 runtime_manifest_secret=$(jq -r "$scenario | .metadata.wp_codebox.runtime_reference_manifest.apiToken // \"missing\"" "$RESULTS_TMPFILE")
 canonical_transcript_path=$(jq -r "$scenario | .metadata.wp_codebox.canonical_artifacts.transcript // \"\"" "$RESULTS_TMPFILE")
-if [ "$wp_codebox_success" != "true" ] || [ -z "$artifact_dir" ] || [ "$review_schema" != "wp-codebox/artifact-review/v1" ] || [ "$changed_files_schema" != "wp-codebox/changed-files/v1" ] || [ "$review_artifact" != "review" ] || [ "$patch_artifact" != "patch" ] || [ "$runtime_manifest_artifact" != "runtime-reference-manifest" ] || [ "$runtime_manifest_schema" != "wp-codebox/runtime-reference-manifest-fixture/v1" ] || [ "$runtime_manifest_secret" != "[redacted]" ] || [ "$canonical_transcript_path" != "$TRANSCRIPT_HOST_DIR/transcript.json" ]; then
+success_status=$(jq -r "$scenario | .metadata.success_status // \"missing\"" "$RESULTS_TMPFILE")
+file_written=$(jq -r "$scenario | .metadata.file_written // false" "$RESULTS_TMPFILE")
+if [ "$wp_codebox_success" != "true" ] || [ -z "$artifact_dir" ] || [ "$review_schema" != "wp-codebox/artifact-review/v1" ] || [ "$changed_files_schema" != "wp-codebox/changed-files/v1" ] || [ "$review_artifact" != "review" ] || [ "$patch_artifact" != "patch" ] || [ "$runtime_manifest_artifact" != "runtime-reference-manifest" ] || [ "$runtime_manifest_schema" != "wp-codebox/runtime-reference-manifest-fixture/v1" ] || [ "$runtime_manifest_secret" != "[redacted]" ] || [ "$canonical_transcript_path" != "$TRANSCRIPT_HOST_DIR/transcript.json" ] || [ "$success_status" != "write_without_pr" ] || [ "$file_written" != "true" ]; then
     echo "ERROR: wp_codebox metadata missing (success=$wp_codebox_success artifact_dir=$artifact_dir)" >&2
     cat "$RESULTS_TMPFILE" >&2
     exit 1

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -412,10 +412,12 @@ PHP
         --slurpfile run "$wp_codebox_output" \
         --slurpfile wpCodeboxArtifacts "$wp_codebox_artifacts_json" \
         '
+        def workload_json_from_string:
+            (fromjson? // (capture("(?s)(?<json>\\{.*\\})").json | fromjson? // {}));
         def workload_from_record($record):
             if ($record | type) != "object" then {}
             elif (($record.metrics? // null) != null) or (($record.metadata? // null) != null) then $record
-            elif ($record.output? | type) == "string" then (($record.output | fromjson? // {}) | workload_from_record(.))
+            elif ($record.output? | type) == "string" then (($record.output | workload_json_from_string) | workload_from_record(.))
             elif ($record.output? | type) == "object" then workload_from_record($record.output)
             elif ($record.result? | type) == "object" then workload_from_record($record.result)
             else {}
@@ -423,7 +425,7 @@ PHP
         def parsed_workload:
             ($wpCodeboxArtifacts[0].transcript // {}) as $transcript
             | [
-                (($run[0].executions // [])[]?.stdout? | fromjson? // {}),
+                (($run[0].executions // [])[]?.stdout? | workload_json_from_string),
                 ($run[0].agentTaskResult // {}),
                 ($run[0].agentTaskResult.raw.result // {}),
                 ($run[0].agentTaskResult.outputs // {}),


### PR DESCRIPTION
## Summary
- Recovers Data Machine workload JSON from WP Codebox stdout/output strings that have PHP warning text before the JSON object.
- Preserves inner workload metadata such as `write_without_pr`, `file_written`, and verification failures instead of falling back to synthetic `no_changes`.
- Extends the WP Codebox runner smoke fixture to cover warning-prefixed workload output.

## Context
Build with WordPress developer-docs run 27345630013 wrote docs files and the inner workload reported `write_without_pr`, but the outer result projection lost that metadata because transcript output had a PHP warning prefix before the JSON payload.

## Testing
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the Build with WordPress run artifacts, identifying the WP Codebox projection parser gap, drafting the parser fix, and running the targeted smoke test.