### PR TITLE
Declare Codebox agent-task cwd materialization

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -168,6 +168,9 @@ function providerContract(options = {}) {
     failure_classifications: AGENT_TASK_FAILURE_CLASSIFICATIONS,
     redacted_metadata_keys: AGENT_TASK_REDACTED_METADATA_KEYS,
     capabilities: PROVIDER_CAPABILITIES,
+    workspace_materialization: {
+      cwd: 'git_checkout',
+    },
     status: 'active',
     integration_contract: 'wp-codebox-cli/agent-task-run',
     runtime_gap_trackers: WP_CODEBOX_RUNTIME_GAP_TRACKERS,

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -226,6 +226,7 @@ assert.deepEqual(provider.request_required_fields, ['schema', 'task_id', 'execut
 assert.deepEqual(provider.outcome_statuses, ['succeeded', 'failed', 'no_op', 'unable_to_remediate', 'timeout', 'provider_error']);
 assert.deepEqual(provider.failure_classifications, ['provider', 'timeout', 'execution_failed']);
 assert.deepEqual(provider.redacted_metadata_keys, ['secret_env_values', 'secretEnvValues', 'secrets']);
+assert.deepEqual(provider.workspace_materialization, { cwd: 'git_checkout' });
 assert.equal(provider.status, 'active');
 assert.equal(provider.integration_contract, 'wp-codebox-cli/agent-task-run');
 assert.equal(provider.capabilities.includes('browser_runtime'), true);

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -65,6 +65,9 @@
         "structured_outcome",
         "agent_bundle_execution"
       ],
+      "workspace_materialization": {
+        "cwd": "git_checkout"
+      },
       "status": "active",
       "integration_contract": "wp-codebox-cli/agent-task-run",
       "runtime_gap_trackers": []


### PR DESCRIPTION
## Summary
- Declares the Codebox agent-task provider's `--cwd` materialization requirement in provider metadata: `workspace_materialization.cwd = git_checkout`.
- Mirrors the manifest field in the provider contract helper and smoke test.

Part of the follow-up refactor for Extra-Chill/homeboy#4010 after Extra-Chill/homeboy#4014: Codebox-specific materialization policy belongs in the extension provider contract, not Homeboy core.

## Tests
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refactoring the provider contract declaration and updating targeted tests. Chris remains responsible for review and testing.