### PR TITLE
Remove Data Machine agent fallback PR path

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -152,7 +152,7 @@ jobs:
 - `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`. Use it when the workflow needs app-token access to more than the target repository.
 - `require_homeboy_app_token` fails before agent setup when Homeboy App credentials are missing. Enable it for central, cross-repo, and private-target runs; leave it false for same-repo consumers that intentionally use `github.token` fallback.
 - `allowed_repos` is a JSON array of `OWNER/REPO` entries exposed to the injected GitHub profile. It defaults to `[target_repo]`.
-- `engine_key` and `tool_results_key` control where built-in GitHub tool captures and fallback PR data are written in `metadata.engine_data`.
+- `engine_key` and `tool_results_key` control where built-in GitHub tool captures are written in `metadata.engine_data`.
 - `dry_run` is intended for workflow smoke tests only; production consumers should leave it `false`.
 - `transcript_artifact_name` controls artifact upload. An empty value skips upload.
 - `extra_wp_config_defines` must be a JSON object and is merged into the runner config `wp_config_defines`.
@@ -161,9 +161,9 @@ jobs:
 - `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.
 - `tool_recorders` configures tool-result projection, forced parameters, and engine-data capture. It must be a JSON array.
 - `pipeline_step_patches` and `flow_step_patches` modify imported bundle step config before the flow runs. They must be JSON arrays.
-- `runner_workspace` provisions a Data Machine Code worktree before the agent runs. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner inspects, commits, pushes, and opens/reuses a fallback PR for captured workspace changes after completion.
+- `runner_workspace` provisions a Data Machine Code worktree before the agent runs. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner publishes captured workspace changes through the canonical Data Machine Code runner publication API after completion.
 - `runner_workspace.capture_changes` defaults to `true` only when `expose_to_agent: false`; set it explicitly to disable hidden-mode publication or to enable runner-owned capture while still exposing the workspace handle.
-- `fallback_pull_request` opens or reuses a PR when files were written but the agent did not call the PR tool. It must be a JSON object.
+- If runner-owned workspace publication is unavailable or fails, the run fails as `write_without_pr`; Homeboy does not compose alternate PR fallback calls.
 
 ## External bundle and tool recording example
 

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -270,10 +270,6 @@ name: Data Machine Agent CI (reusable)
         description: JSON object for runner-owned Data Machine Code workspace/worktree provisioning before the agent runs. Set agent_alias to expose an opaque project name instead of the real workspace handle.
         type: string
         default: "{}"
-      fallback_pull_request:
-        description: JSON object describing a fallback PR to open or reuse when files were written but the agent did not open a PR.
-        type: string
-        default: "{}"
       actions_artifact_downloads:
         description: JSON array of GitHub Actions artifacts to download before the agent run. Each item supports repo, run_id, name, and dir.
         type: string
@@ -705,7 +701,6 @@ jobs:
           PIPELINE_STEP_PATCHES: ${{ inputs.pipeline_step_patches }}
           FLOW_STEP_PATCHES: ${{ inputs.flow_step_patches }}
           RUNNER_WORKSPACE_CONFIG: ${{ inputs.runner_workspace }}
-          FALLBACK_PULL_REQUEST: ${{ inputs.fallback_pull_request }}
           EXECUTE_WORKFLOW_PATH: ${{ inputs.execute_workflow_path }}
           GITHUB_APP_TOKEN_VALUE: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY_TOKEN_VALUE: ${{ github.token }}
@@ -840,7 +835,6 @@ jobs:
           pipeline_step_patches_json="$(validate_json_input pipeline_step_patches array "$PIPELINE_STEP_PATCHES")"
           flow_step_patches_json="$(validate_json_input flow_step_patches array "$FLOW_STEP_PATCHES")"
           runner_workspace_json="$(validate_json_input runner_workspace object "$RUNNER_WORKSPACE_CONFIG")"
-          fallback_pull_request_json="$(validate_json_input fallback_pull_request object "$FALLBACK_PULL_REQUEST")"
           rules_json="$(validate_json_input rules object "$RULES")"
           general_rules_json="$(validate_json_input general_rules array "$GENERAL_RULES")"
           task_rules_json="$(validate_json_input task_rules array "$TASK_RULES")"
@@ -916,7 +910,6 @@ jobs:
             --argjson pipelineStepPatches "$pipeline_step_patches_json" \
             --argjson flowStepPatches "$flow_step_patches_json" \
             --argjson runnerWorkspace "$runner_workspace_json" \
-            --argjson fallbackPullRequest "$fallback_pull_request_json" \
             --argjson rules "$rules_json" \
             --argjson generalRules "$general_rules_json" \
             --argjson taskRules "$task_rules_json" \
@@ -990,7 +983,6 @@ jobs:
               pipeline_step_patches: $pipelineStepPatches,
               flow_step_patches: $flowStepPatches,
               runner_workspace: $runnerWorkspace,
-              fallback_pull_request: $fallbackPullRequest,
               rules: $rules,
               general_rules: $generalRules,
               task_rules: $taskRules,

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -138,8 +138,9 @@ The runner converts the agent config into a single WP Codebox sandbox run:
   consumer needs a different agent-facing tool name.
 - `pipeline_step_patches` and `flow_step_patches` can adjust imported bundle
   step configuration before execution.
-- `fallback_pull_request` can open a PR when files were written but the agent did
-  not explicitly call the PR tool.
+- Runner-owned workspace publication is handled by the canonical Data Machine
+  Code runner publication API. If that API is unavailable or publication fails,
+  the run fails as `write_without_pr` instead of composing fallback PR calls.
 
 The reusable workflow reports the selected GitHub token path as `auth_mode` and
 in the run summary. Same-repo consumers can use the repository-scoped
@@ -313,7 +314,7 @@ knobs to `run-datamachine-agent.sh`:
 - Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
 - Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`, `replay_bundle_artifact_name`.
 - Eval projection: `wp_gym_benchmark_mode` turns missing wp-gym replay/evidence references into errors.
-- Extension points: `extra_required_abilities`, `ability_tools`, `tool_recorders`, `enable_terminal_actions`, `wp_cli_tool_name`, `pipeline_step_patches`, `flow_step_patches`, `runner_workspace`, `fallback_pull_request`.
+- Extension points: `extra_required_abilities`, `ability_tools`, `tool_recorders`, `enable_terminal_actions`, `wp_cli_tool_name`, `pipeline_step_patches`, `flow_step_patches`, `runner_workspace`.
 
 `bundle_repo` is for cross-repo consumers. The shell runner clones the bundle
 repository, points `bundle_path` at the cloned bundle inside WP Codebox, and adds

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -89,7 +89,6 @@ const AGENT_BUNDLE_CONFIG_FIELDS = [
   'replay_bundle_artifact_name',
   'replay_bundle_dir',
   'runner_workspace',
-  'fallback_pull_request',
   'extra_required_abilities',
   'enable_terminal_actions',
   'enable_wp_cli_tool',
@@ -1361,7 +1360,10 @@ function agentRuntimeBundleArtifacts(result) {
         metadata: { ...exported, scenario_id: scenario.id },
       });
     }
-    const pullRequestUrl = metadata.fallback_pull_request?.url || metadata.engine_data?.pull_request?.url || metadata.engine_data?.static_site_agent?.pr_url;
+    const runnerPublicationUrl = Array.isArray(metadata.engine_data?.runner_publications)
+      ? metadata.engine_data.runner_publications.find((publication) => publication?.url)?.url
+      : '';
+    const pullRequestUrl = metadata.runner_workspace_publication?.url || metadata.runner_workspace_publication?.html_url || metadata.runner_workspace_publication?.result?.url || metadata.runner_workspace_publication?.result?.html_url || runnerPublicationUrl || metadata.engine_data?.pull_request?.url || metadata.engine_data?.static_site_agent?.pr_url;
     appendUniqueArtifact(artifacts, {
       id: pullRequestUrl ? 'agent-runtime-pull-request' : '',
       kind: 'agent-runtime-pull-request',

--- a/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
@@ -443,52 +443,5 @@ namespace {
         exit( 1 );
     }
 
-    $implicit_fallback = homeboy_datamachine_agent_open_fallback_pr(
-        array(),
-        array(
-            'target_repo'             => 'owner/demo',
-            'agent_slug'              => 'demo-agent',
-            'model'                   => 'gpt-5.5',
-            'runner_workspace_result' => array(
-                'success' => true,
-                'branch'  => 'agent/run',
-            ),
-        )
-    );
-
-    if ( ! empty( $implicit_fallback['opened'] ) ) {
-        fwrite( STDERR, "Did not expect runner workspace fallback PR to open without explicit fallback config.\n" );
-        exit( 1 );
-    }
-
-    $fallback = homeboy_datamachine_agent_open_fallback_pr(
-        array(),
-        array(
-            'target_repo'             => 'owner/demo',
-            'agent_slug'              => 'demo-agent',
-            'model'                   => 'gpt-5.5',
-            'fallback_pull_request'   => array(
-                'repo'  => 'owner/demo',
-                'head'  => 'agent/run',
-                'title' => 'Fallback PR',
-            ),
-            'runner_workspace_result' => array(
-                'success' => true,
-                'branch'  => 'agent/run',
-            ),
-        )
-    );
-
-    if ( empty( $fallback['opened'] ) ) {
-        fwrite( STDERR, "Expected explicit fallback PR to open.\n" );
-        exit( 1 );
-    }
-
-    $fallback_args = $GLOBALS['homeboy_forced_parameters_args'] ?? array();
-    if ( 'agent/run' !== ( $fallback_args['head'] ?? null ) || 'owner/demo' !== ( $fallback_args['repo'] ?? null ) ) {
-        fwrite( STDERR, "Expected fallback PR to target the runner workspace branch.\n" );
-        exit( 1 );
-    }
-
     fwrite( STDOUT, "Data Machine agent forced parameters smoke passed.\n" );
 }

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -171,7 +171,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_eval_artifact' ) ) {
             'artifacts'       => array_filter(
                 array(
                     'job_artifact_exports' => $exports,
-                    'fallback_pull_request' => is_array( $metadata['fallback_pull_request'] ?? null ) ? $metadata['fallback_pull_request'] : array(),
+                    'runner_workspace_publication' => is_array( $metadata['runner_workspace_publication'] ?? null ) ? $metadata['runner_workspace_publication'] : array(),
                 )
             ),
         );
@@ -1502,7 +1502,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_job_artifacts' ) ) {
         }
 
         $file_ability = wp_get_ability( 'datamachine/create-or-update-github-file' );
-        $pr_ability   = wp_get_ability( 'datamachine/create-github-pull-request' );
+        $pr_ability   = wp_get_ability( 'datamachine-code/create-github-pull-request' );
         $get_ability  = wp_get_ability( 'datamachine/get-github-file' );
         if ( ! $file_ability || ! $pr_ability || ! $get_ability ) {
             return array( 'error' => 'GitHub file or pull request ability unavailable.' );
@@ -1632,155 +1632,6 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_job_artifacts' ) ) {
                 'engine_data' => homeboy_datamachine_agent_record_artifact_pr_result( $engine_data, $config, $pr_url, $branch, $written ),
             )
         );
-    }
-}
-
-if ( ! function_exists( 'homeboy_datamachine_agent_open_fallback_pr' ) ) {
-    function homeboy_datamachine_agent_record_pr_tool_result( array $engine_data, array $config, array $tool_result ): array {
-        $tool_results_key = homeboy_datamachine_agent_scalar( $config, 'tool_results_key', 'github_tool_results' );
-        $engine_key       = homeboy_datamachine_agent_scalar( $config, 'engine_key' );
-        if ( '' !== $engine_key ) {
-            if ( ! isset( $engine_data[ $engine_key ] ) || ! is_array( $engine_data[ $engine_key ] ) ) {
-                $engine_data[ $engine_key ] = array();
-            }
-            if ( ! isset( $engine_data[ $engine_key ][ $tool_results_key ] ) || ! is_array( $engine_data[ $engine_key ][ $tool_results_key ] ) ) {
-                $engine_data[ $engine_key ][ $tool_results_key ] = array();
-            }
-            $engine_data[ $engine_key ][ $tool_results_key ][] = $tool_result;
-            return $engine_data;
-        }
-
-        if ( ! isset( $engine_data[ $tool_results_key ] ) || ! is_array( $engine_data[ $tool_results_key ] ) ) {
-            $engine_data[ $tool_results_key ] = array();
-        }
-        $engine_data[ $tool_results_key ][] = $tool_result;
-
-        return $engine_data;
-    }
-
-    function homeboy_datamachine_agent_existing_fallback_pr( string $repo, string $head, string $base ): array {
-        $ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/list-github-pulls' ) : null;
-        if ( ! $ability ) {
-            return array();
-        }
-
-        $result = $ability->execute(
-            array(
-                'repo'     => $repo,
-                'state'    => 'open',
-                'per_page' => 100,
-            )
-        );
-        if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
-            return array();
-        }
-        if ( ! is_array( $result ) || empty( $result['success'] ) || ! is_array( $result['pulls'] ?? null ) ) {
-            return array();
-        }
-
-        foreach ( $result['pulls'] as $pull ) {
-            if ( ! is_array( $pull ) ) {
-                continue;
-            }
-            if ( $head !== (string) ( $pull['head'] ?? $pull['head_ref'] ?? '' ) ) {
-                continue;
-            }
-            if ( '' !== $base && $base !== (string) ( $pull['base'] ?? $pull['base_ref'] ?? '' ) ) {
-                continue;
-            }
-            if ( '' !== homeboy_datamachine_agent_first_url( $pull ) ) {
-                return $pull;
-            }
-        }
-
-        return array();
-    }
-
-    function homeboy_datamachine_agent_open_fallback_pr( array $engine_data, array $config ): array {
-        $fallback = is_array( $config['fallback_pull_request'] ?? null ) ? $config['fallback_pull_request'] : array();
-        if ( empty( $fallback ) ) {
-            return array( 'opened' => false );
-        }
-
-        $repo  = homeboy_datamachine_agent_scalar( $fallback, 'repo', homeboy_datamachine_agent_scalar( $config, 'target_repo' ) );
-        $title = homeboy_datamachine_agent_scalar( $fallback, 'title' );
-        $head  = homeboy_datamachine_agent_scalar( $fallback, 'head' );
-        if ( '' === $repo || '' === $title || '' === $head ) {
-            return array( 'opened' => false, 'error' => 'fallback_pull_request requires repo, title, and head.' );
-        }
-
-        $base        = homeboy_datamachine_agent_scalar( $fallback, 'base' );
-        $existing_pr = homeboy_datamachine_agent_existing_fallback_pr( $repo, $head, $base );
-        if ( ! empty( $existing_pr ) ) {
-            $tool_result = array(
-                'tool_name' => 'create_github_pull_request',
-                'source'    => 'runner_fallback_pull_request',
-                'success'   => true,
-                'repo'      => $repo,
-                'head'      => $head,
-                'base'      => $base,
-                'url'       => homeboy_datamachine_agent_first_url( $existing_pr ),
-                'result'    => array(
-                    'success'      => true,
-                    'pull_request' => $existing_pr,
-                    'pull_number'  => (int) ( $existing_pr['number'] ?? 0 ),
-                    'html_url'     => homeboy_datamachine_agent_first_url( $existing_pr ),
-                    'message'      => sprintf( 'Reused existing pull request #%d in %s.', (int) ( $existing_pr['number'] ?? 0 ), $repo ),
-                ),
-            );
-
-            return array(
-                'opened'      => true,
-                'reused'      => true,
-                'result'      => $tool_result['result'],
-                'input'       => array( 'repo' => $repo, 'title' => $title, 'head' => $head, 'base' => $base ),
-                'engine_data' => homeboy_datamachine_agent_record_runner_publication( $engine_data, $config, $tool_result ),
-            );
-        }
-
-        $ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/create-github-pull-request' ) : null;
-        if ( ! $ability ) {
-            return array( 'opened' => false, 'error' => 'datamachine/create-github-pull-request ability is not available.' );
-        }
-
-        $input = array(
-            'repo'                  => $repo,
-            'title'                 => $title,
-            'head'                  => $head,
-            'body'                  => (string) ( $fallback['body'] ?? '' ),
-            'draft'                 => ! empty( $fallback['draft'] ),
-            'maintainer_can_modify' => array_key_exists( 'maintainer_can_modify', $fallback ) ? (bool) $fallback['maintainer_can_modify'] : true,
-        );
-        if ( '' !== $base ) {
-            $input['base'] = $base;
-        }
-
-        $result = $ability->execute( $input );
-        if ( is_wp_error( $result ) ) {
-            return array( 'opened' => false, 'error' => $result->get_error_message(), 'input' => $input );
-        }
-        if ( ! is_array( $result ) || empty( $result['success'] ) ) {
-            $error = is_array( $result ) ? (string) ( $result['error'] ?? 'Fallback pull request creation failed.' ) : 'Fallback pull request creation failed.';
-            if ( is_array( $result ) && ! empty( $result['message'] ) && ! str_contains( $error, (string) $result['message'] ) ) {
-                $error .= ': ' . (string) $result['message'];
-            }
-            return array( 'opened' => false, 'error' => $error, 'input' => $input, 'result' => $result );
-        }
-
-        $tool_result = array(
-            'tool_name' => 'create_github_pull_request',
-            'source'    => 'runner_fallback_pull_request',
-            'success'   => true,
-            'repo'      => $repo,
-            'head'      => $head,
-            'base'      => (string) ( $input['base'] ?? '' ),
-            'url'       => (string) ( $result['html_url'] ?? '' ),
-            'result'    => $result,
-        );
-
-        $engine_data = homeboy_datamachine_agent_record_runner_publication( $engine_data, $config, $tool_result );
-
-        return array( 'opened' => true, 'result' => $result, 'input' => $input, 'engine_data' => $engine_data );
     }
 }
 
@@ -2027,30 +1878,105 @@ if ( ! function_exists( 'homeboy_datamachine_agent_execute_workspace_ability' ) 
     }
 }
 
-if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_fallback_config' ) ) {
-    function homeboy_datamachine_agent_runner_workspace_fallback_config( array $config, array $runner_workspace, array $template_values = array() ): array {
-        $fallback = is_array( $config['fallback_pull_request'] ?? null ) ? $config['fallback_pull_request'] : array();
-        $repo     = homeboy_datamachine_agent_scalar( $fallback, 'repo', homeboy_datamachine_agent_scalar( $config, 'target_repo' ) );
-        $branch   = (string) ( $runner_workspace['branch'] ?? '' );
-
-        if ( '' === homeboy_datamachine_agent_scalar( $fallback, 'head' ) && '' !== $branch ) {
-            $fallback['head'] = $branch;
-        }
-        if ( '' === homeboy_datamachine_agent_scalar( $fallback, 'repo' ) && '' !== $repo ) {
-            $fallback['repo'] = $repo;
-        }
-        $export_config = is_array( $config['artifact_export'] ?? null ) ? $config['artifact_export'] : array();
-        if ( ! empty( $template_values ) && '' === homeboy_datamachine_agent_scalar( $fallback, 'title' ) && '' !== (string) ( $export_config['pr_title_template'] ?? '' ) ) {
-            $fallback['title'] = homeboy_datamachine_agent_template( (string) $export_config['pr_title_template'], $template_values );
-        }
-        if ( ! empty( $template_values ) && '' === homeboy_datamachine_agent_scalar( $fallback, 'body' ) && '' !== (string) ( $export_config['pr_body_template'] ?? '' ) ) {
-            $fallback['body'] = homeboy_datamachine_agent_template( (string) $export_config['pr_body_template'], $template_values );
-        }
-        if ( '' === homeboy_datamachine_agent_scalar( $fallback, 'title' ) ) {
-            $fallback['title'] = 'Persist Data Machine agent workspace changes';
+if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_publication_input' ) ) {
+    function homeboy_datamachine_agent_runner_workspace_publication_input( array $config, array $runner_workspace, array $template_values = array(), array $paths = array() ): array {
+        $workspace_config = homeboy_datamachine_agent_runner_workspace_config( $config );
+        $export_config    = is_array( $config['artifact_export'] ?? null ) ? $config['artifact_export'] : array();
+        $message          = isset( $workspace_config['commit_message'] ) && is_scalar( $workspace_config['commit_message'] ) ? trim( (string) $workspace_config['commit_message'] ) : '';
+        if ( '' === $message ) {
+            $message = 'chore: persist Data Machine agent workspace changes';
         }
 
-        return $fallback;
+        $title = '';
+        if ( ! empty( $template_values ) && '' !== (string) ( $export_config['pr_title_template'] ?? '' ) ) {
+            $title = homeboy_datamachine_agent_template( (string) $export_config['pr_title_template'], $template_values );
+        }
+        if ( '' === $title ) {
+            $title = 'Persist Data Machine agent workspace changes';
+        }
+
+        $body = '';
+        if ( ! empty( $template_values ) && '' !== (string) ( $export_config['pr_body_template'] ?? '' ) ) {
+            $body = homeboy_datamachine_agent_template( (string) $export_config['pr_body_template'], $template_values );
+        }
+
+        return array_filter(
+            array(
+                'workspace'             => (string) ( $runner_workspace['handle'] ?? '' ),
+                'handle'                => (string) ( $runner_workspace['handle'] ?? '' ),
+                'repo'                  => homeboy_datamachine_agent_scalar( $config, 'target_repo' ),
+                'head'                  => (string) ( $runner_workspace['branch'] ?? '' ),
+                'base'                  => (string) ( $workspace_config['base'] ?? $workspace_config['base_branch'] ?? '' ),
+                'commit_message'        => $message,
+                'title'                 => $title,
+                'body'                  => $body,
+                'paths'                 => array_values( array_filter( $paths, 'is_string' ) ),
+                'draft'                 => ! empty( $workspace_config['draft'] ),
+                'maintainer_can_modify' => array_key_exists( 'maintainer_can_modify', $workspace_config ) ? (bool) $workspace_config['maintainer_can_modify'] : true,
+                'context'               => $template_values,
+            ),
+            static fn( $value ) => ! ( '' === $value || array() === $value || null === $value )
+        );
+    }
+
+    function homeboy_datamachine_agent_publish_runner_workspace( array $engine_data, array $config, array $runner_workspace, array $template_values, array $paths ): array {
+        $ability_name = 'datamachine-code/publish-runner-workspace';
+        $input        = homeboy_datamachine_agent_runner_workspace_publication_input( $config, $runner_workspace, $template_values, $paths );
+        if ( '' === (string) ( $input['workspace'] ?? '' ) || '' === (string) ( $input['repo'] ?? '' ) ) {
+            return array(
+                'opened'         => false,
+                'ability'        => $ability_name,
+                'upstream_issue' => 'https://github.com/Extra-Chill/data-machine-code/issues/625',
+                'error'          => 'Runner workspace publication requires a workspace handle and target repo.',
+                'input'          => $input,
+            );
+        }
+
+        $ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
+        if ( ! $ability ) {
+            return array(
+                'opened'         => false,
+                'ability'        => $ability_name,
+                'upstream_issue' => 'https://github.com/Extra-Chill/data-machine-code/issues/625',
+                'error'          => $ability_name . ' is not available; runner workspace publication is blocked on Extra-Chill/data-machine-code#625.',
+                'input'          => $input,
+            );
+        }
+
+        $result = $ability->execute( $input );
+        if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
+            return array( 'opened' => false, 'ability' => $ability_name, 'error' => $result->get_error_message(), 'input' => $input );
+        }
+        if ( ! is_array( $result ) || empty( $result['success'] ) ) {
+            return array(
+                'opened' => false,
+                'ability' => $ability_name,
+                'error'  => is_array( $result ) ? (string) ( $result['error'] ?? 'Runner workspace publication failed.' ) : 'Runner workspace publication failed.',
+                'input'  => $input,
+                'result' => $result,
+            );
+        }
+
+        $publication = array(
+            'tool_name' => 'publish_runner_workspace',
+            'ability'   => $ability_name,
+            'source'    => 'runner_workspace_publication',
+            'success'   => true,
+            'repo'      => (string) ( $input['repo'] ?? '' ),
+            'head'      => (string) ( $result['head'] ?? $result['branch'] ?? $input['head'] ?? '' ),
+            'base'      => (string) ( $result['base'] ?? $input['base'] ?? '' ),
+            'url'       => homeboy_datamachine_agent_first_url( $result ),
+            'result'    => $result,
+        );
+        $engine_data = homeboy_datamachine_agent_record_runner_publication( $engine_data, $config, $publication );
+
+        return array(
+            'opened'      => str_contains( (string) $publication['url'], '/pull/' ) || ! empty( $result['pull_number'] ) || ! empty( $result['pull_request'] ),
+            'ability'     => $ability_name,
+            'result'      => $result,
+            'input'       => $input,
+            'engine_data' => $engine_data,
+        );
     }
 }
 
@@ -2079,26 +2005,6 @@ if ( ! function_exists( 'homeboy_datamachine_agent_capture_runner_workspace' ) )
         }
 
         $diff = homeboy_datamachine_agent_execute_workspace_ability( 'datamachine/workspace-git-diff', array( 'name' => $handle ) );
-        $add  = homeboy_datamachine_agent_execute_workspace_ability( 'datamachine/workspace-git-add', array( 'name' => $handle, 'paths' => empty( $files ) ? array( '.' ) : $files ) );
-        if ( empty( $add['success'] ) ) {
-            return array( 'enabled' => true, 'changed' => true, 'engine_data' => $engine_data, 'status' => $status, 'diff' => $diff, 'add' => $add, 'error' => (string) ( $add['error'] ?? 'Workspace git add failed.' ) );
-        }
-
-        $workspace_config = homeboy_datamachine_agent_runner_workspace_config( $config );
-        $message          = isset( $workspace_config['commit_message'] ) && is_scalar( $workspace_config['commit_message'] ) ? trim( (string) $workspace_config['commit_message'] ) : '';
-        if ( '' === $message ) {
-            $message = 'chore: persist Data Machine agent workspace changes';
-        }
-
-        $commit = homeboy_datamachine_agent_execute_workspace_ability( 'datamachine/workspace-git-commit', array( 'name' => $handle, 'message' => $message ) );
-        if ( empty( $commit['success'] ) ) {
-            return array( 'enabled' => true, 'changed' => true, 'engine_data' => $engine_data, 'status' => $status, 'diff' => $diff, 'add' => $add, 'commit' => $commit, 'error' => (string) ( $commit['error'] ?? 'Workspace git commit failed.' ) );
-        }
-
-        $push = homeboy_datamachine_agent_execute_workspace_ability( 'datamachine/workspace-git-push', array( 'name' => $handle, 'branch' => (string) ( $runner_workspace['branch'] ?? '' ) ) );
-        if ( empty( $push['success'] ) ) {
-            return array( 'enabled' => true, 'changed' => true, 'engine_data' => $engine_data, 'status' => $status, 'diff' => $diff, 'add' => $add, 'commit' => $commit, 'push' => $push, 'error' => (string) ( $push['error'] ?? 'Workspace git push failed.' ) );
-        }
 
         return array(
             'enabled'               => true,
@@ -2106,9 +2012,6 @@ if ( ! function_exists( 'homeboy_datamachine_agent_capture_runner_workspace' ) )
             'engine_data'           => $engine_data,
             'status'                => $status,
             'diff'                  => $diff,
-            'add'                   => $add,
-            'commit'                => $commit,
-            'push'                  => $push,
         );
     }
 }
@@ -3415,15 +3318,8 @@ $transcript_dir = homeboy_datamachine_agent_scalar( $config, 'transcript_dir' );
 $transcript_artifacts = homeboy_datamachine_agent_export_transcript( $job_id, $engine_data, $transcript_dir );
 $pr_opened = homeboy_datamachine_agent_pr_opened( $engine_data, $config );
 $file_written = homeboy_datamachine_agent_file_written( $engine_data, $config ) || ! empty( $runner_workspace_capture['changed'] );
-$fallback_pull_request = array( 'opened' => false );
+$runner_workspace_publication = array( 'opened' => false );
 $success_requires_pr = ! empty( $config['success_requires_pr'] );
-if ( $file_written && ! $pr_opened && empty( $runner_workspace_capture['changed'] ) ) {
-    $fallback_pull_request = homeboy_datamachine_agent_open_fallback_pr( $engine_data, $config );
-    if ( ! empty( $fallback_pull_request['opened'] ) && is_array( $fallback_pull_request['engine_data'] ?? null ) ) {
-        $engine_data = $fallback_pull_request['engine_data'];
-        $pr_opened   = true;
-    }
-}
 $completion_outcome_satisfied = homeboy_datamachine_agent_completion_outcome_satisfied( $engine_data, $config );
 $success_status = homeboy_datamachine_agent_success_status( $pr_opened, $completion_outcome_satisfied, $file_written );
 $artifact_pr_context = array(
@@ -3431,7 +3327,7 @@ $artifact_pr_context = array(
     'success_requires_pr'      => $success_requires_pr,
     'transcript_artifacts'     => $transcript_artifacts,
     'runner_workspace_capture' => $runner_workspace_capture,
-    'fallback_pull_request'    => $fallback_pull_request,
+    'runner_workspace_publication' => $runner_workspace_publication,
     'error_message'            => (string) ( $engine_data['error_message'] ?? '' ),
 );
 if ( ! empty( $runner_workspace_capture['changed'] ) && ! $pr_opened ) {
@@ -3444,14 +3340,18 @@ if ( ! empty( $runner_workspace_capture['changed'] ) && ! $pr_opened ) {
         homeboy_datamachine_agent_runner_workspace_written_paths( $runner_workspace_capture ),
         $artifact_pr_context
     );
-    $capture_config                          = $config;
-    $capture_config['fallback_pull_request'] = homeboy_datamachine_agent_runner_workspace_fallback_config( $config, $runner_workspace, $template_values );
-    $fallback_pull_request                   = homeboy_datamachine_agent_open_fallback_pr( $engine_data, $capture_config );
-    if ( ! empty( $fallback_pull_request['opened'] ) && is_array( $fallback_pull_request['engine_data'] ?? null ) ) {
-        $engine_data = $fallback_pull_request['engine_data'];
+    $runner_workspace_publication = homeboy_datamachine_agent_publish_runner_workspace(
+        $engine_data,
+        $config,
+        $runner_workspace,
+        $template_values,
+        homeboy_datamachine_agent_runner_workspace_written_paths( $runner_workspace_capture )
+    );
+    if ( ! empty( $runner_workspace_publication['opened'] ) && is_array( $runner_workspace_publication['engine_data'] ?? null ) ) {
+        $engine_data = $runner_workspace_publication['engine_data'];
         $pr_opened   = true;
     }
-    $artifact_pr_context['fallback_pull_request'] = $fallback_pull_request;
+    $artifact_pr_context['runner_workspace_publication'] = $runner_workspace_publication;
 }
 $job_artifact_exports = homeboy_datamachine_agent_export_job_artifacts( $job_id, $config, $pr_opened, $engine_data, $artifact_pr_context );
 if ( is_array( $job_artifact_exports['engine_data'] ?? null ) ) {
@@ -3474,7 +3374,7 @@ $metadata += array(
     'error_message'         => (string) ( $engine_data['error_message'] ?? '' ),
     'success_status'        => $success_status,
     'success_requires_pr'   => $success_requires_pr,
-    'fallback_pull_request' => $fallback_pull_request,
+    'runner_workspace_publication' => $runner_workspace_publication,
 	'runner_workspace_capture' => $runner_workspace_capture,
 	'verification_results' => $verification_results,
 	'drift_check_results' => $drift_check_results,
@@ -3509,11 +3409,11 @@ if ( ! empty( $drift_check_results['enabled'] ) && empty( $drift_check_results['
 
 if ( $file_written && ! $pr_opened ) {
     $metadata['success_status'] = 'write_without_pr';
-    $fallback_error = is_array( $fallback_pull_request ) ? (string) ( $fallback_pull_request['error'] ?? '' ) : '';
+    $publication_error = is_array( $runner_workspace_publication ) ? (string) ( $runner_workspace_publication['error'] ?? '' ) : '';
     $capture_error  = is_array( $runner_workspace_capture ) ? (string) ( $runner_workspace_capture['error'] ?? '' ) : '';
     $error_message  = 'Agent wrote files without opening a pull request';
-    if ( '' !== $fallback_error ) {
-        $error_message .= ': ' . $fallback_error;
+    if ( '' !== $publication_error ) {
+        $error_message .= ': ' . $publication_error;
     } elseif ( '' !== $capture_error ) {
         $error_message .= ': ' . $capture_error;
     }

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -266,92 +266,8 @@ namespace {
         exit( 1 );
     }
 
-    $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
-        'datamachine/list-github-pulls' => new Homeboy_Datamachine_Agent_Fake_Ability(
-            fn() => array(
-                'success' => true,
-                'pulls'   => array(
-                    array(
-                        'number'   => 321,
-                        'html_url' => 'https://github.com/owner/repo/pull/321',
-                        'head'     => 'agent/existing-pr-branch',
-                        'base'     => 'main',
-                    ),
-                ),
-            )
-        ),
-        'datamachine/create-github-pull-request' => new Homeboy_Datamachine_Agent_Fake_Ability(
-            function (): array {
-                fwrite( STDERR, "Did not expect fallback PR creation when an existing PR matches the head branch.\n" );
-                exit( 1 );
-            }
-        ),
-    );
-    $existing_fallback = homeboy_datamachine_agent_open_fallback_pr(
-        array(),
-        array(
-            'tool_results_key'      => 'github_tool_results',
-            'fallback_pull_request' => array(
-                'repo'  => 'owner/repo',
-                'title' => 'Fallback PR',
-                'head'  => 'agent/existing-pr-branch',
-                'base'  => 'main',
-            ),
-        )
-    );
-    if ( empty( $existing_fallback['opened'] ) || empty( $existing_fallback['reused'] ) ) {
-        fwrite( STDERR, "Expected fallback PR handling to reuse an existing open PR.\n" );
-        exit( 1 );
-    }
-    if ( ! empty( $existing_fallback['engine_data']['github_tool_results'] ?? array() ) ) {
-        fwrite( STDERR, "Did not expect runner-owned fallback PR reuse to be recorded as a task-facing tool result.\n" );
-        exit( 1 );
-    }
-    if ( ! homeboy_datamachine_agent_pr_opened( $existing_fallback['engine_data'] ?? array(), $config ) ) {
-        fwrite( STDERR, "Expected reused fallback PR to be recorded as pr_opened.\n" );
-        exit( 1 );
-    }
-
-    $fallback_pr_input = array();
-    $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
-        'datamachine/list-github-pulls' => new Homeboy_Datamachine_Agent_Fake_Ability(
-            fn() => array(
-                'success' => true,
-                'pulls'   => array(),
-            )
-        ),
-        'datamachine/create-github-pull-request' => new Homeboy_Datamachine_Agent_Fake_Ability(
-            function ( array $input ) use ( &$fallback_pr_input ): array {
-                $fallback_pr_input = $input;
-                return array(
-                    'success'  => true,
-                    'html_url' => 'https://github.com/owner/repo/pull/654',
-                );
-            }
-        ),
-    );
-    $created_fallback = homeboy_datamachine_agent_open_fallback_pr(
-        array(),
-        array(
-            'tool_results_key'      => 'github_tool_results',
-            'fallback_pull_request' => array(
-                'repo'  => 'owner/repo',
-                'title' => 'Fallback PR',
-                'head'  => 'agent/new-pr-branch',
-            ),
-        )
-    );
-    if ( empty( $created_fallback['opened'] ) ) {
-        fwrite( STDERR, "Expected fallback PR handling to create a PR when no existing PR matches.\n" );
-        exit( 1 );
-    }
-    if ( array_key_exists( 'base', $fallback_pr_input ) ) {
-        fwrite( STDERR, "Expected fallback PR creation to omit an empty base parameter.\n" );
-        exit( 1 );
-    }
-
     $runner_capture_calls = array();
-    $fallback_pr_input    = array();
+    $publication_input    = array();
     $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
         'datamachine/workspace-git-status' => new Homeboy_Datamachine_Agent_Fake_Ability(
             function ( array $input ) use ( &$runner_capture_calls ): array {
@@ -370,27 +286,14 @@ namespace {
                 'diff'    => "diff --git a/docs/generated.md b/docs/generated.md\n",
             )
         ),
-        'datamachine/workspace-git-add' => new Homeboy_Datamachine_Agent_Fake_Ability(
-            function ( array $input ) use ( &$runner_capture_calls ): array {
-                $runner_capture_calls[] = array( 'ability' => 'add', 'input' => $input );
-                return array( 'success' => true, 'paths' => $input['paths'] ?? array() );
-            }
-        ),
-        'datamachine/workspace-git-commit' => new Homeboy_Datamachine_Agent_Fake_Ability(
-            fn( array $input ) => array( 'success' => true, 'commit' => 'abc123', 'message' => $input['message'] ?? '' )
-        ),
-        'datamachine/workspace-git-push' => new Homeboy_Datamachine_Agent_Fake_Ability(
-            fn( array $input ) => array( 'success' => true, 'branch' => $input['branch'] ?? '', 'html_url' => 'https://github.com/owner/repo/tree/agent/hidden-run' )
-        ),
-        'datamachine/list-github-pulls' => new Homeboy_Datamachine_Agent_Fake_Ability(
-            fn() => array( 'success' => true, 'pulls' => array() )
-        ),
-        'datamachine/create-github-pull-request' => new Homeboy_Datamachine_Agent_Fake_Ability(
-            function ( array $input ) use ( &$fallback_pr_input ): array {
-                $fallback_pr_input = $input;
+        'datamachine-code/publish-runner-workspace' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            function ( array $input ) use ( &$publication_input ): array {
+                $publication_input = $input;
                 return array(
-                    'success'  => true,
-                    'html_url' => 'https://github.com/owner/repo/pull/987',
+                    'success'     => true,
+                    'html_url'    => 'https://github.com/owner/repo/pull/987',
+                    'pull_number' => 987,
+                    'head'        => $input['head'] ?? '',
                 );
             }
         ),
@@ -434,8 +337,8 @@ namespace {
         $runner_config
     );
 
-    if ( ! empty( $fallback_pr_input ) ) {
-        fwrite( STDERR, "Did not expect runner workspace capture to open the fallback PR before artifact context is assembled.\n" );
+    if ( ! empty( $publication_input ) ) {
+        fwrite( STDERR, "Did not expect runner workspace capture to publish before artifact context is assembled.\n" );
         exit( 1 );
     }
     $runner_template_values = homeboy_datamachine_agent_artifact_pr_context(
@@ -450,87 +353,58 @@ namespace {
             'runner_workspace_capture' => $runner_capture,
         )
     );
-    $runner_capture_config = $runner_config;
-    $runner_capture_config['fallback_pull_request'] = homeboy_datamachine_agent_runner_workspace_fallback_config(
+    $runner_publication = homeboy_datamachine_agent_publish_runner_workspace(
+        $runner_engine_data,
         $runner_config,
         $runner_config['runner_workspace_result'],
-        $runner_template_values
+        $runner_template_values,
+        homeboy_datamachine_agent_runner_workspace_written_paths( $runner_capture )
     );
-    $runner_fallback = homeboy_datamachine_agent_open_fallback_pr( $runner_engine_data, $runner_capture_config );
 
-    if ( empty( $runner_capture['changed'] ) || empty( $runner_fallback['opened'] ) ) {
-        fwrite( STDERR, "Expected hidden runner workspace capture to commit, push, and open a fallback PR after context assembly.\n" );
+    if ( empty( $runner_capture['changed'] ) || empty( $runner_publication['opened'] ) ) {
+        fwrite( STDERR, "Expected hidden runner workspace capture to publish through the canonical DMC API after context assembly.\n" );
         exit( 1 );
     }
-    if ( 'agent/hidden-run' !== ( $fallback_pr_input['head'] ?? null ) || 'owner/repo' !== ( $fallback_pr_input['repo'] ?? null ) ) {
-        fwrite( STDERR, "Expected runner workspace capture fallback PR to use the captured branch.\n" );
+    if ( 'agent/hidden-run' !== ( $publication_input['head'] ?? null ) || 'owner/repo' !== ( $publication_input['repo'] ?? null ) || 'repo@hidden-run' !== ( $publication_input['workspace'] ?? null ) ) {
+        fwrite( STDERR, "Expected runner workspace publication to use the captured workspace and branch.\n" );
         exit( 1 );
     }
-    if ( '[runner-agent] runner-task - agent/hidden-run - completion_outcome_satisfied' !== ( $fallback_pr_input['title'] ?? '' ) ) {
-        fwrite( STDERR, "Expected runner workspace fallback PR to use the final artifact PR title context.\n" );
+    if ( '[runner-agent] runner-task - agent/hidden-run - completion_outcome_satisfied' !== ( $publication_input['title'] ?? '' ) ) {
+        fwrite( STDERR, "Expected runner workspace publication to use the final artifact PR title context.\n" );
         exit( 1 );
     }
-    foreach ( array( 'Branch: agent/hidden-run', 'Handle: repo@hidden-run', 'Status: runner-workspace-status', 'Custom: custom fallback value', 'runner_check', 'https://github.com/owner/repo/actions/runs/123456', 'artifacts/runner-transcript.json', 'docs/generated.md' ) as $expected_fallback_body_fragment ) {
-        if ( ! str_contains( (string) ( $fallback_pr_input['body'] ?? '' ), $expected_fallback_body_fragment ) ) {
-            fwrite( STDERR, "Expected runner workspace fallback PR body to include {$expected_fallback_body_fragment}.\n" );
+    foreach ( array( 'Branch: agent/hidden-run', 'Handle: repo@hidden-run', 'Status: runner-workspace-status', 'Custom: custom fallback value', 'runner_check', 'https://github.com/owner/repo/actions/runs/123456', 'artifacts/runner-transcript.json', 'docs/generated.md' ) as $expected_publication_body_fragment ) {
+        if ( ! str_contains( (string) ( $publication_input['body'] ?? '' ), $expected_publication_body_fragment ) ) {
+            fwrite( STDERR, "Expected runner workspace publication body to include {$expected_publication_body_fragment}.\n" );
             exit( 1 );
         }
     }
-    if ( 'repo@hidden-run' !== ( $runner_capture_calls[0]['input']['name'] ?? null ) || array( 'docs/generated.md' ) !== ( $runner_capture_calls[1]['input']['paths'] ?? null ) ) {
-        fwrite( STDERR, "Expected runner workspace capture to inspect and stage the provisioned handle.\n" );
+    if ( 'repo@hidden-run' !== ( $runner_capture_calls[0]['input']['name'] ?? null ) || ! empty( $runner_capture_calls[1] ?? null ) ) {
+        fwrite( STDERR, "Expected runner workspace capture to inspect the provisioned handle without staging changes locally.\n" );
         exit( 1 );
     }
 
-    $fallback_pr_input = array();
-    $explicit_runner_config = array(
-        'target_repo'              => 'owner/repo',
-        'tool_results_key'         => 'github_tool_results',
-        'fallback_pull_request'    => array(
-            'title' => 'Explicit fallback title',
-            'body'  => 'Explicit fallback body',
+    $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
+        'datamachine/workspace-git-status' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            fn() => array(
+                'success' => true,
+                'dirty'   => 1,
+                'files'   => array( 'docs/generated.md' ),
+            )
         ),
-        'artifact_export'          => array(
-            'pr_title_template' => 'Templated {task_id}',
-            'pr_body_template'  => 'Templated {workspace_branch}',
-        ),
-        'runner_workspace'         => array(
-            'enabled'         => true,
-            'expose_to_agent' => false,
-        ),
-        'runner_workspace_result'  => array(
-            'success' => true,
-            'handle'  => 'repo@explicit-run',
-            'branch'  => 'agent/explicit-run',
+        'datamachine/workspace-git-diff' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            fn() => array( 'success' => true, 'diff' => "diff --git a/docs/generated.md b/docs/generated.md\n" )
         ),
     );
-    $explicit_runner_capture = homeboy_datamachine_agent_capture_runner_workspace(
-        array(),
-        $explicit_runner_config
+    $unavailable_publication = homeboy_datamachine_agent_publish_runner_workspace(
+        $runner_engine_data,
+        $runner_config,
+        $runner_config['runner_workspace_result'],
+        $runner_template_values,
+        array( 'docs/generated.md' )
     );
-    $explicit_runner_template_values = homeboy_datamachine_agent_artifact_pr_context(
-        43,
-        $explicit_runner_config,
-        array(),
-        array(),
-        array(),
-        array(
-            'success_status'           => 'no_changes',
-            'runner_workspace_capture' => $explicit_runner_capture,
-        )
-    );
-    $explicit_runner_capture_config = $explicit_runner_config;
-    $explicit_runner_capture_config['fallback_pull_request'] = homeboy_datamachine_agent_runner_workspace_fallback_config(
-        $explicit_runner_config,
-        $explicit_runner_config['runner_workspace_result'],
-        $explicit_runner_template_values
-    );
-    $explicit_runner_fallback = homeboy_datamachine_agent_open_fallback_pr( array(), $explicit_runner_capture_config );
-    if ( empty( $explicit_runner_fallback['opened'] ) ) {
-        fwrite( STDERR, "Expected explicit runner workspace fallback PR to open.\n" );
-        exit( 1 );
-    }
-    if ( 'Explicit fallback title' !== ( $fallback_pr_input['title'] ?? '' ) || 'Explicit fallback body' !== ( $fallback_pr_input['body'] ?? '' ) ) {
-        fwrite( STDERR, "Expected explicit runner workspace fallback PR title/body to take precedence over artifact templates.\n" );
+    if ( empty( $unavailable_publication['error'] ) || 'https://github.com/Extra-Chill/data-machine-code/issues/625' !== ( $unavailable_publication['upstream_issue'] ?? '' ) ) {
+        fwrite( STDERR, "Expected missing DMC publication API to fail loudly with the DMC #625 integration point.\n" );
         exit( 1 );
     }
 
@@ -542,7 +416,7 @@ namespace {
                 return array( 'success' => true, 'html_url' => 'https://github.com/owner/repo/commit/artifact' );
             }
         ),
-        'datamachine/create-github-pull-request' => new Homeboy_Datamachine_Agent_Fake_Ability(
+        'datamachine-code/create-github-pull-request' => new Homeboy_Datamachine_Agent_Fake_Ability(
             function ( array $input ) use ( &$artifact_export_calls ): array {
                 $artifact_export_calls[] = array( 'ability' => 'pr', 'input' => $input );
                 return array( 'success' => true, 'html_url' => 'https://github.com/owner/repo/pull/988' );

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -686,7 +686,7 @@ homeboy_datamachine_agent_attach_evidence_references() {
                 ($metadata.engine_data[]? | objects | .runner_publications? // [] | .[]?)
             ];
         def first_runner_publication_pr_url($metadata):
-            (runner_publications($metadata) | map(select(.tool_name == "create_github_pull_request" and .success == true and (.url // "") != "") | .url) | first) // "";
+            (runner_publications($metadata) | map(select(.success == true and (.url // "") != "") | .url) | first) // "";
         def runner_evidence($scenario):
             ($scenario.metadata // {}) as $metadata
             | ($metadata.wp_codebox.canonical_artifacts // {}) as $wpPaths
@@ -758,8 +758,8 @@ homeboy_datamachine_agent_attach_evidence_references() {
             ] | map(select(.tool_name == "create_github_pull_request" and .success == true and (.url // "") != "") | .url) | first) // "";
         def pr_url($metadata):
             first_field($metadata.job_artifact_exports; "pr_url")
-            // first_field($metadata.fallback_pull_request; "html_url")
-            // first_field($metadata.fallback_pull_request; "url")
+            // first_field($metadata.runner_workspace_publication; "html_url")
+            // first_field($metadata.runner_workspace_publication; "url")
             // first_runner_publication_pr_url($metadata)
             // first_tool_pr_url($metadata)
             // "";
@@ -767,7 +767,7 @@ homeboy_datamachine_agent_attach_evidence_references() {
             first_field($metadata.runner_workspace_capture; "branch")
             // first_field($metadata.runner_workspace; "branch")
             // first_field($metadata.job_artifact_exports; "branch")
-            // first_field($metadata.fallback_pull_request; "head")
+            // first_field($metadata.runner_workspace_publication; "head")
             // "";
         def eval_workflow_run_url($metadata):
             if ($metadata.eval_artifact.run? | type) == "object" then

--- a/wordpress/scripts/agent/update-runner-workspace-pr.cjs
+++ b/wordpress/scripts/agent/update-runner-workspace-pr.cjs
@@ -69,8 +69,8 @@ if (!scenario) {
 }
 
 const metadata = scenario.metadata || {};
-const fallback = metadata.fallback_pull_request || {};
-const pullUrl = fallback.url || fallback.html_url || getPath(fallback, 'result.html_url') || getPath(fallback, 'result.url');
+const publication = metadata.runner_workspace_publication || {};
+const pullUrl = publication.url || publication.html_url || getPath(publication, 'result.html_url') || getPath(publication, 'result.url');
 if (!pullUrl) {
   console.log('No runner workspace pull request found to update.');
   process.exit(0);
@@ -157,7 +157,7 @@ const values = {
   grade_score: scalar(grade.score),
   grade_max_score: scalar(grade.max_score),
   workflow_run_url: workflowUrl,
-  workspace_branch: runnerStatus.branch || getPath(fallback, 'result.pull_request.head') || '',
+  workspace_branch: runnerStatus.branch || getPath(publication, 'result.pull_request.head') || getPath(publication, 'result.head') || '',
   workspace_handle: runnerStatus.handle || runnerStatus.name || '',
   workspace_changed: runnerCapture.changed ? 'yes' : 'no',
   changed_file_count: scalar(runnerStatus.dirty || (Array.isArray(runnerStatus.files) ? runnerStatus.files.length : '')),


### PR DESCRIPTION
## Summary
- Deletes the Data Machine agent runner `fallback_pull_request` workflow/config path and old `datamachine/create-github-pull-request` assumption.
- Leaves runner-owned workspace changes on a single publication path: `datamachine-code/publish-runner-workspace`.
- Fails loudly as `write_without_pr` with a link to Extra-Chill/data-machine-code#625 when the DMC publication API is unavailable.

## DMC integration point
- Waiting on: https://github.com/Extra-Chill/data-machine-code/issues/625
- Expected ability: `datamachine-code/publish-runner-workspace`
- This PR does not add a fallback or compatibility shim; missing publication remains a hard runner failure.

## Tests
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`

Fixes #1253

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Homeboy-side refactor, updated smoke tests/docs, and ran targeted verification; Chris remains responsible for review and merge.