### PR TITLE
Route runner publication through WP Codebox boundary

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -161,7 +161,7 @@ jobs:
 - `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.
 - `tool_recorders` configures tool-result projection, forced parameters, and engine-data capture. It must be a JSON array.
 - `pipeline_step_patches` and `flow_step_patches` modify imported bundle step config before the flow runs. They must be JSON arrays.
-- `runner_workspace` provisions a Data Machine Code worktree before the agent runs. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner publishes captured workspace changes through the canonical Data Machine Code runner publication API after completion.
+- `runner_workspace` provisions a WP Codebox-managed runner workspace before the agent runs. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner publishes captured workspace changes through the WP Codebox runner publication API after completion.
 - `runner_workspace.capture_changes` defaults to `true` only when `expose_to_agent: false`; set it explicitly to disable hidden-mode publication or to enable runner-owned capture while still exposing the workspace handle.
 - If runner-owned workspace publication is unavailable or fails, the run fails as `write_without_pr`; Homeboy does not compose alternate PR fallback calls.
 

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -180,7 +180,7 @@ name: Data Machine Agent CI (reusable)
         type: string
         default: "[]"
       engine_key:
-        description: Optional engine data key used by built-in tool result capture and fallback pull request recording.
+        description: Optional engine data key used by built-in tool result capture and runner publication metadata.
         type: string
         default: ""
       tool_results_key:

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -114,18 +114,18 @@ The runner converts the agent config into a single WP Codebox sandbox run:
 - `workload_run_before` and `workload_run_after` attach setup and verifier hooks
   around the agent run inside the same sandbox scenario.
 - `transcript_dir` controls where exported conversation artifacts are written.
-- `success_requires_pr` can require the agent to open or reuse a pull request.
+- `success_requires_pr` can require a published pull request outcome.
 - `tool_recorders` can force tool parameters and project tool results into
   `metadata.engine_data`.
-- `engine_key` and `tool_results_key` control where built-in tool capture and
-  fallback pull request data are recorded.
-- `runner_workspace` can provision a Data Machine Code worktree. The default
+- `engine_key` and `tool_results_key` control where built-in tool capture is
+  recorded.
+- `runner_workspace` can provision a WP Codebox-managed runner workspace. The default
   mode prepends the workspace handle to the agent prompt so current consumers
-  can explicitly ask the agent to work in that checkout and open a PR.
+  can explicitly ask the agent to work in that checkout.
 - `runner_workspace.expose_to_agent: false` enables runner-owned capture
   mode. It preserves the natural task prompt, keeps workspace tool calls scoped
-  to the provisioned handle when those tools are used, then captures final git
-  status/diff, commits, pushes, and opens or reuses a fallback PR after the run.
+  to the provisioned handle when those tools are used, then asks WP Codebox to
+  capture and publish the final runner workspace after the run.
 - `ability_tools` can expose additional WordPress abilities as tools during the
   agent run.
 - `enable_terminal_actions` exposes terminal actions through the WordPress

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -1920,13 +1920,13 @@ if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_publication_
     }
 
     function homeboy_datamachine_agent_publish_runner_workspace( array $engine_data, array $config, array $runner_workspace, array $template_values, array $paths ): array {
-        $ability_name = 'datamachine-code/publish-runner-workspace';
+        $ability_name = 'wp-codebox/publish-runner-workspace';
         $input        = homeboy_datamachine_agent_runner_workspace_publication_input( $config, $runner_workspace, $template_values, $paths );
         if ( '' === (string) ( $input['workspace'] ?? '' ) || '' === (string) ( $input['repo'] ?? '' ) ) {
             return array(
                 'opened'         => false,
                 'ability'        => $ability_name,
-                'upstream_issue' => 'https://github.com/Extra-Chill/data-machine-code/issues/625',
+                'upstream_issue' => 'https://github.com/Automattic/wp-codebox/issues/873',
                 'error'          => 'Runner workspace publication requires a workspace handle and target repo.',
                 'input'          => $input,
             );
@@ -1937,8 +1937,8 @@ if ( ! function_exists( 'homeboy_datamachine_agent_runner_workspace_publication_
             return array(
                 'opened'         => false,
                 'ability'        => $ability_name,
-                'upstream_issue' => 'https://github.com/Extra-Chill/data-machine-code/issues/625',
-                'error'          => $ability_name . ' is not available; runner workspace publication is blocked on Extra-Chill/data-machine-code#625.',
+                'upstream_issue' => 'https://github.com/Automattic/wp-codebox/issues/873',
+                'error'          => $ability_name . ' is not available; runner workspace publication is blocked on Automattic/wp-codebox#873.',
                 'input'          => $input,
             );
         }
@@ -1992,10 +1992,28 @@ if ( ! function_exists( 'homeboy_datamachine_agent_capture_runner_workspace' ) )
             return array( 'enabled' => true, 'changed' => false, 'engine_data' => $engine_data, 'error' => 'Runner workspace capture requires a provisioned workspace handle.' );
         }
 
-        $status = homeboy_datamachine_agent_execute_workspace_ability( 'datamachine/workspace-git-status', array( 'name' => $handle ) );
-        if ( empty( $status['success'] ) ) {
-            return array( 'enabled' => true, 'changed' => false, 'engine_data' => $engine_data, 'status' => $status, 'error' => (string) ( $status['error'] ?? 'Workspace status failed.' ) );
+        $capture = homeboy_datamachine_agent_execute_workspace_ability(
+            'wp-codebox/capture-runner-workspace',
+            array(
+                'workspace'        => $handle,
+                'handle'           => $handle,
+                'repo'             => homeboy_datamachine_agent_scalar( $config, 'target_repo' ),
+                'runner_workspace' => $runner_workspace,
+            )
+        );
+        if ( empty( $capture['success'] ) ) {
+            return array(
+                'enabled'        => true,
+                'changed'        => true,
+                'engine_data'    => $engine_data,
+                'status'         => array( 'handle' => $handle, 'branch' => (string) ( $runner_workspace['branch'] ?? '' ) ),
+                'upstream_issue' => 'https://github.com/Automattic/wp-codebox/issues/873',
+                'error'          => (string) ( $capture['error'] ?? 'WP Codebox runner workspace capture API is unavailable.' ),
+                'capture'        => $capture,
+            );
         }
+
+        $status = is_array( $capture['status'] ?? null ) ? $capture['status'] : $capture;
         $status['branch'] = (string) ( $runner_workspace['branch'] ?? '' );
         $status['handle'] = $handle;
 
@@ -2004,7 +2022,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_capture_runner_workspace' ) )
             return array( 'enabled' => true, 'changed' => false, 'engine_data' => $engine_data, 'status' => $status );
         }
 
-        $diff = homeboy_datamachine_agent_execute_workspace_ability( 'datamachine/workspace-git-diff', array( 'name' => $handle ) );
+        $diff = is_array( $capture['diff'] ?? null ) ? $capture['diff'] : array();
 
         return array(
             'enabled'               => true,
@@ -2012,6 +2030,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_capture_runner_workspace' ) )
             'engine_data'           => $engine_data,
             'status'                => $status,
             'diff'                  => $diff,
+            'capture'               => $capture,
         );
     }
 }

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -269,24 +269,22 @@ namespace {
     $runner_capture_calls = array();
     $publication_input    = array();
     $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
-        'datamachine/workspace-git-status' => new Homeboy_Datamachine_Agent_Fake_Ability(
+        'wp-codebox/capture-runner-workspace' => new Homeboy_Datamachine_Agent_Fake_Ability(
             function ( array $input ) use ( &$runner_capture_calls ): array {
-                $runner_capture_calls[] = array( 'ability' => 'status', 'input' => $input );
+                $runner_capture_calls[] = array( 'ability' => 'capture', 'input' => $input );
                 return array(
                     'success' => true,
-                    'dirty'   => 1,
-                    'files'   => array( 'docs/generated.md' ),
+                    'status'  => array(
+                        'dirty' => 1,
+                        'files' => array( 'docs/generated.md' ),
+                    ),
+                    'diff'    => array(
+                        'diff' => "diff --git a/docs/generated.md b/docs/generated.md\n",
+                    ),
                 );
             }
         ),
-        'datamachine/workspace-git-diff' => new Homeboy_Datamachine_Agent_Fake_Ability(
-            fn( array $input ) => array(
-                'success' => true,
-                'name'    => $input['name'] ?? '',
-                'diff'    => "diff --git a/docs/generated.md b/docs/generated.md\n",
-            )
-        ),
-        'datamachine-code/publish-runner-workspace' => new Homeboy_Datamachine_Agent_Fake_Ability(
+        'wp-codebox/publish-runner-workspace' => new Homeboy_Datamachine_Agent_Fake_Ability(
             function ( array $input ) use ( &$publication_input ): array {
                 $publication_input = $input;
                 return array(
@@ -362,7 +360,7 @@ namespace {
     );
 
     if ( empty( $runner_capture['changed'] ) || empty( $runner_publication['opened'] ) ) {
-        fwrite( STDERR, "Expected hidden runner workspace capture to publish through the canonical DMC API after context assembly.\n" );
+        fwrite( STDERR, "Expected hidden runner workspace capture to publish through the WP Codebox runner API after context assembly.\n" );
         exit( 1 );
     }
     if ( 'agent/hidden-run' !== ( $publication_input['head'] ?? null ) || 'owner/repo' !== ( $publication_input['repo'] ?? null ) || 'repo@hidden-run' !== ( $publication_input['workspace'] ?? null ) ) {
@@ -379,23 +377,12 @@ namespace {
             exit( 1 );
         }
     }
-    if ( 'repo@hidden-run' !== ( $runner_capture_calls[0]['input']['name'] ?? null ) || ! empty( $runner_capture_calls[1] ?? null ) ) {
-        fwrite( STDERR, "Expected runner workspace capture to inspect the provisioned handle without staging changes locally.\n" );
+    if ( 'repo@hidden-run' !== ( $runner_capture_calls[0]['input']['workspace'] ?? null ) || ! empty( $runner_capture_calls[1] ?? null ) ) {
+        fwrite( STDERR, "Expected runner workspace capture to use the WP Codebox capture API once.\n" );
         exit( 1 );
     }
 
-    $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
-        'datamachine/workspace-git-status' => new Homeboy_Datamachine_Agent_Fake_Ability(
-            fn() => array(
-                'success' => true,
-                'dirty'   => 1,
-                'files'   => array( 'docs/generated.md' ),
-            )
-        ),
-        'datamachine/workspace-git-diff' => new Homeboy_Datamachine_Agent_Fake_Ability(
-            fn() => array( 'success' => true, 'diff' => "diff --git a/docs/generated.md b/docs/generated.md\n" )
-        ),
-    );
+    $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array();
     $unavailable_publication = homeboy_datamachine_agent_publish_runner_workspace(
         $runner_engine_data,
         $runner_config,
@@ -403,8 +390,8 @@ namespace {
         $runner_template_values,
         array( 'docs/generated.md' )
     );
-    if ( empty( $unavailable_publication['error'] ) || 'https://github.com/Extra-Chill/data-machine-code/issues/625' !== ( $unavailable_publication['upstream_issue'] ?? '' ) ) {
-        fwrite( STDERR, "Expected missing DMC publication API to fail loudly with the DMC #625 integration point.\n" );
+    if ( empty( $unavailable_publication['error'] ) || 'https://github.com/Automattic/wp-codebox/issues/873' !== ( $unavailable_publication['upstream_issue'] ?? '' ) ) {
+        fwrite( STDERR, "Expected missing WP Codebox publication API to fail loudly with the WP Codebox #873 integration point.\n" );
         exit( 1 );
     }
 


### PR DESCRIPTION
## Summary
- Replaces direct runner capture/publication calls to Data Machine Code with WP Codebox runner API boundary names.
- Preserves the no-fallback behavior from #1255: no `fallback_pull_request`, no agent PR tool requirement, and no synthetic `no_changes` when runner capture/publication is unavailable.
- Updates smoke coverage and docs so Homeboy waits on the WP Codebox API from Automattic/wp-codebox#873.

## Integration wait
- Waiting on: https://github.com/Automattic/wp-codebox/issues/873
- Expected Homeboy-facing abilities:
  - `wp-codebox/capture-runner-workspace`
  - `wp-codebox/publish-runner-workspace`
- Homeboy no longer names `datamachine-code/publish-runner-workspace` or DMC workspace-git abilities as the runner publication integration point.

## Tests
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`

Fixes #1256

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Homeboy-side boundary correction, updated smoke tests/docs, and ran targeted verification; Chris remains responsible for review and merge.