### PR TITLE
Fix WP Codebox bench scenario filtering

### DIFF
--- a/wordpress/scripts/bench/build-wp-codebox-bench-recipe.mjs
+++ b/wordpress/scripts/bench/build-wp-codebox-bench-recipe.mjs
@@ -16,6 +16,15 @@ if (!options.extra_plugins && options.extraPlugins) {
 	options.extra_plugins = options.extraPlugins;
 }
 
+const selectedScenarioIds = (process.env.HOMEBOY_BENCH_SCENARIOS || '')
+	.split(',')
+	.map((id) => id.trim())
+	.filter(Boolean);
+if (selectedScenarioIds.length && Array.isArray(options.workloads)) {
+	const selected = new Set(selectedScenarioIds);
+	options.workloads = options.workloads.filter((workload) => selected.has(workload?.id));
+}
+
 const recipe = buildWordPressBenchRecipe(options);
 if (options.pluginRuntime && typeof options.pluginRuntime === 'object' && !Array.isArray(options.pluginRuntime)) {
 	recipe.inputs = recipe.inputs ?? {};

--- a/wordpress/tests/fixtures/wp-codebox-core-recipe-builder.mjs
+++ b/wordpress/tests/fixtures/wp-codebox-core-recipe-builder.mjs
@@ -4,6 +4,7 @@ export function buildWordPressBenchRecipe(options = {}) {
 		inputs: {
 			mounts: normalizeRecipeMounts(options.mounts, 'readonly'),
 			extraPlugins: options.extraPlugins ?? [],
+			workloads: options.workloads ?? [],
 		},
 		runtime: {
 			blueprint: options.blueprint ?? {},

--- a/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
@@ -16,7 +16,10 @@ const input = {
 		env: { FIXTURE: '1' },
 		wpConfigDefines: { WP_DEBUG: true },
 		bootstrapFiles: ['/wordpress/wp-content/plugins/fixture-plugin/bootstrap.php'],
-		workloads: [{ id: 'fixture-workload', steps: [{ type: 'php', code: 'return [];' }] }],
+		workloads: [
+			{ id: 'fixture-workload', steps: [{ type: 'php', code: 'return [];' }] },
+			{ id: 'other-workload', steps: [{ type: 'php', code: 'return [];' }] },
+		],
 		lifecycle: { before: ['fixture'] },
 		resetPolicy: { mode: 'snapshot' },
 		pluginRuntime: {
@@ -42,6 +45,7 @@ const recipe = JSON.parse(result.stdout);
 assert.equal(recipe.schema, 'wp-codebox/workspace-recipe/v1');
 assert.equal(recipe.inputs.mounts[0].mode, 'readonly');
 assert.deepEqual(recipe.inputs.extraPlugins[0], { source: '/tmp/extra-plugin.zip', slug: 'extra-plugin', activate: true });
+assert.deepEqual(recipe.inputs.workloads.map((workload) => workload.id), ['fixture-workload', 'other-workload']);
 assert.deepEqual(recipe.inputs.pluginRuntime, input.options.pluginRuntime);
 assert.deepEqual(recipe.workflow.steps, [{
 	command: 'fixture.wordpress.bench',
@@ -51,6 +55,17 @@ assert.deepEqual(recipe.workflow.steps, [{
 		'reset-policy-json={"mode":"snapshot"}',
 	],
 }]);
+
+const filteredResult = spawnSync(process.execPath, [script], {
+	cwd: path.join(__dirname, '..'),
+	input: JSON.stringify(input),
+	encoding: 'utf8',
+	env: { ...process.env, HOMEBOY_WP_CODEBOX_CORE_MODULE: fixtureCoreModule, HOMEBOY_BENCH_SCENARIOS: 'fixture-workload' },
+});
+
+assert.equal(filteredResult.status, 0, filteredResult.stderr);
+const filteredRecipe = JSON.parse(filteredResult.stdout);
+assert.deepEqual(filteredRecipe.inputs.workloads.map((workload) => workload.id), ['fixture-workload']);
 
 const diagnosticResult = spawnSync(process.execPath, [script], {
 	cwd: path.join(__dirname, '..'),


### PR DESCRIPTION
## Summary
- Filter WP Codebox bench recipe workloads with `HOMEBOY_BENCH_SCENARIOS` before handing options to runtime-core.
- Extend the recipe-builder smoke fixture to prove selected scenario IDs trim the workload list.

## Testing
- `npm run test:wp-codebox-bench-recipe-builder`
- `npm run lint:js -- scripts/bench/build-wp-codebox-bench-recipe.mjs tests/wp-codebox-bench-recipe-builder-smoke.js tests/fixtures/wp-codebox-core-recipe-builder.mjs` (passes with existing ignored-file warnings for test fixtures)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the scenario-filter leak, drafted the adapter/test change, and ran focused verification; Chris remains responsible for review and merge.