### PR TITLE
Run verification through WP Codebox runner workspace

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -163,6 +163,7 @@ jobs:
 - `pipeline_step_patches` and `flow_step_patches` modify imported bundle step config before the flow runs. They must be JSON arrays.
 - `runner_workspace` provisions a WP Codebox-managed runner workspace before the agent runs. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner publishes captured workspace changes through the WP Codebox runner publication API after completion.
 - `runner_workspace.capture_changes` defaults to `true` only when `expose_to_agent: false`; set it explicitly to disable hidden-mode publication or to enable runner-owned capture while still exposing the workspace handle.
+- `verification_commands` and `drift_checks` run through the WP Codebox runner workspace command API, so remote runner workspaces do not require Homeboy to know backend-local paths.
 - If runner-owned workspace publication is unavailable or fails, the run fails as `write_without_pr`; Homeboy does not compose alternate PR fallback calls.
 
 ## External bundle and tool recording example

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -126,6 +126,9 @@ The runner converts the agent config into a single WP Codebox sandbox run:
   mode. It preserves the natural task prompt, keeps workspace tool calls scoped
   to the provisioned handle when those tools are used, then asks WP Codebox to
   capture and publish the final runner workspace after the run.
+- `verification_commands` and `drift_checks` execute through the WP Codebox
+  runner workspace command API, preserving verification metadata without
+  requiring Homeboy to resolve backend-local workspace paths.
 - `ability_tools` can expose additional WordPress abilities as tools during the
   agent run.
 - `enable_terminal_actions` exposes terminal actions through the WordPress

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -615,82 +615,101 @@ if ( ! function_exists( 'homeboy_datamachine_agent_command_list' ) ) {
 	}
 }
 
-if ( ! function_exists( 'homeboy_datamachine_agent_run_shell_command' ) ) {
-	function homeboy_datamachine_agent_run_shell_command( string $command, string $cwd ): array {
-		$started = hrtime( true );
-		$descriptor_spec = array(
-			0 => array( 'pipe', 'r' ),
-			1 => array( 'pipe', 'w' ),
-			2 => array( 'pipe', 'w' ),
-		);
-
-		$process = proc_open( array( 'bash', '-lc', $command ), $descriptor_spec, $pipes, $cwd );
-		if ( ! is_resource( $process ) ) {
+if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
+	function homeboy_datamachine_agent_run_workspace_command( array $runner_workspace, array $command_config, string $key ): array {
+		$ability_name = 'wp-codebox/run-runner-workspace-command';
+		$handle       = isset( $runner_workspace['handle'] ) && is_scalar( $runner_workspace['handle'] ) ? trim( (string) $runner_workspace['handle'] ) : '';
+		if ( '' === $handle ) {
 			return array(
-				'command'    => $command,
-				'exit_code'  => 127,
-				'success'    => false,
-				'error'      => 'Unable to start command process.',
-				'elapsed_ms' => ( hrtime( true ) - $started ) / 1000000,
+				'success'        => false,
+				'command'        => $command_config['command'],
+				'description'    => $command_config['description'],
+				'error'          => $key . ' requires a WP Codebox runner workspace handle.',
+				'ability'        => $ability_name,
+				'upstream_issue' => 'https://github.com/Automattic/wp-codebox/issues/873',
 			);
 		}
 
-		fclose( $pipes[0] );
-		$stdout = stream_get_contents( $pipes[1] );
-		$stderr = stream_get_contents( $pipes[2] );
-		fclose( $pipes[1] );
-		fclose( $pipes[2] );
-		$exit_code = proc_close( $process );
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
+		if ( ! $ability ) {
+			return array(
+				'success'        => false,
+				'command'        => $command_config['command'],
+				'description'    => $command_config['description'],
+				'workspace'      => $handle,
+				'error'          => $ability_name . ' is not available; runner workspace command execution is blocked on WP Codebox runner verification support.',
+				'ability'        => $ability_name,
+				'upstream_issue' => 'https://github.com/Automattic/wp-codebox/issues/873',
+			);
+		}
 
+		$started = hrtime( true );
+		$result  = $ability->execute(
+			array(
+				'workspace'   => $handle,
+				'handle'      => $handle,
+				'command'     => $command_config['command'],
+				'description' => $command_config['description'],
+				'kind'        => $key,
+			)
+		);
+		if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
+			return array(
+				'success'        => false,
+				'command'        => $command_config['command'],
+				'description'    => $command_config['description'],
+				'workspace'      => $handle,
+				'error'          => $result->get_error_message(),
+				'ability'        => $ability_name,
+				'upstream_issue' => 'https://github.com/Automattic/wp-codebox/issues/873',
+			);
+		}
+
+		$response = is_array( $result ) ? $result : array();
 		return array(
-			'command'    => $command,
-			'exit_code'  => $exit_code,
-			'success'    => 0 === $exit_code,
-			'stdout'     => is_string( $stdout ) ? trim( $stdout ) : '',
-			'stderr'     => is_string( $stderr ) ? trim( $stderr ) : '',
-			'elapsed_ms' => ( hrtime( true ) - $started ) / 1000000,
+			'command'        => $command_config['command'],
+			'description'    => $command_config['description'],
+			'exit_code'      => (int) ( $response['exit_code'] ?? $response['status'] ?? ( empty( $response['success'] ) ? 1 : 0 ) ),
+			'success'        => ! empty( $response['success'] ),
+			'stdout'         => is_scalar( $response['stdout'] ?? null ) ? trim( (string) $response['stdout'] ) : '',
+			'stderr'         => is_scalar( $response['stderr'] ?? null ) ? trim( (string) $response['stderr'] ) : '',
+			'elapsed_ms'     => isset( $response['elapsed_ms'] ) ? (float) $response['elapsed_ms'] : ( hrtime( true ) - $started ) / 1000000,
+			'workspace'      => $handle,
+			'ability'        => $ability_name,
+			'error'          => is_scalar( $response['error'] ?? null ) ? (string) $response['error'] : '',
+			'upstream_issue' => is_scalar( $response['upstream_issue'] ?? null ) ? (string) $response['upstream_issue'] : '',
 		);
 	}
-}
 
-if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
 	function homeboy_datamachine_agent_run_command_checks( array $config, array $runner_workspace, string $key ): array {
 		$commands = homeboy_datamachine_agent_command_list( $config, $key );
 		if ( empty( $commands ) ) {
 			return array( 'enabled' => false, 'checks' => array() );
 		}
 
-		$cwd = isset( $runner_workspace['path'] ) && is_scalar( $runner_workspace['path'] ) ? trim( (string) $runner_workspace['path'] ) : '';
-		if ( '' === $cwd || ! is_dir( $cwd ) ) {
-			return array(
-				'enabled' => true,
-				'success' => false,
-				'error'   => $key . ' requires a provisioned DMC target workspace path.',
-				'checks'  => $commands,
-			);
-		}
-
 		$results = array();
 		foreach ( $commands as $command_config ) {
-			$result = homeboy_datamachine_agent_run_shell_command( $command_config['command'], $cwd );
-			$result['description'] = $command_config['description'];
+			$result    = homeboy_datamachine_agent_run_workspace_command( $runner_workspace, $command_config, $key );
 			$results[] = $result;
 			if ( empty( $result['success'] ) ) {
 				return array(
-					'enabled' => true,
-					'success' => false,
-					'cwd'     => $cwd,
-					'checks'  => $results,
-					'error'   => $key . ' failed: ' . $command_config['command'],
+					'enabled'        => true,
+					'success'        => false,
+					'workspace'      => is_scalar( $runner_workspace['handle'] ?? null ) ? (string) $runner_workspace['handle'] : '',
+					'checks'         => $results,
+					'error'          => '' !== (string) ( $result['error'] ?? '' ) ? (string) $result['error'] : $key . ' failed: ' . $command_config['command'],
+					'ability'        => (string) ( $result['ability'] ?? 'wp-codebox/run-runner-workspace-command' ),
+					'upstream_issue' => (string) ( $result['upstream_issue'] ?? '' ),
 				);
 			}
 		}
 
 		return array(
-			'enabled' => true,
-			'success' => true,
-			'cwd'     => $cwd,
-			'checks'  => $results,
+			'enabled'   => true,
+			'success'   => true,
+			'workspace' => is_scalar( $runner_workspace['handle'] ?? null ) ? (string) $runner_workspace['handle'] : '',
+			'ability'   => 'wp-codebox/run-runner-workspace-command',
+			'checks'    => $results,
 		);
 	}
 }

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -592,28 +592,55 @@ namespace {
         exit( 1 );
     }
 
-    $command_workspace = sys_get_temp_dir() . '/homeboy-command-check-' . uniqid();
-    mkdir( $command_workspace );
+    $workspace_command_calls = array();
+    $workspace_files         = array();
+    $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
+        'wp-codebox/run-runner-workspace-command' => new Homeboy_Datamachine_Agent_Fake_Ability(
+            function ( array $input ) use ( &$workspace_command_calls, &$workspace_files ): array {
+                $workspace_command_calls[] = $input;
+                if ( 'repo@branch' !== ( $input['workspace'] ?? '' ) ) {
+                    return array( 'success' => false, 'error' => 'Unexpected workspace handle.' );
+                }
+                if ( 'printf ok > verification.txt' === ( $input['command'] ?? '' ) ) {
+                    $workspace_files['verification.txt'] = 'ok';
+                    return array( 'success' => true, 'exit_code' => 0, 'stdout' => '', 'stderr' => '' );
+                }
+                if ( 'test -f verification.txt' === ( $input['command'] ?? '' ) ) {
+                    return array( 'success' => isset( $workspace_files['verification.txt'] ), 'exit_code' => isset( $workspace_files['verification.txt'] ) ? 0 : 1 );
+                }
+                return array( 'success' => false, 'error' => 'Unexpected command.' );
+            }
+        ),
+    );
     $verification_result = homeboy_datamachine_agent_run_command_checks(
         array( 'verification_commands' => array( array( 'command' => 'printf ok > verification.txt', 'description' => 'Write verification marker' ) ) ),
-        array( 'path' => $command_workspace ),
+        array( 'handle' => 'repo@branch' ),
         'verification_commands'
     );
-    if ( empty( $verification_result['success'] ) || ! is_file( $command_workspace . '/verification.txt' ) ) {
-        fwrite( STDERR, "Expected verification_commands to run in the target workspace.\n" );
+    if ( empty( $verification_result['success'] ) || empty( $workspace_files['verification.txt'] ) || 'wp-codebox/run-runner-workspace-command' !== ( $verification_result['ability'] ?? '' ) ) {
+        fwrite( STDERR, "Expected verification_commands to run through the WP Codebox runner workspace API.\n" );
         exit( 1 );
     }
     $drift_result = homeboy_datamachine_agent_run_command_checks(
         array( 'drift_checks' => array( array( 'command' => 'test -f verification.txt', 'description' => 'Generated outputs are present' ) ) ),
-        array( 'path' => $command_workspace ),
+        array( 'handle' => 'repo@branch' ),
         'drift_checks'
     );
-    if ( empty( $drift_result['success'] ) ) {
-        fwrite( STDERR, "Expected drift_checks to run after verification in the target workspace.\n" );
+    if ( empty( $drift_result['success'] ) || 2 !== count( $workspace_command_calls ) ) {
+        fwrite( STDERR, "Expected drift_checks to run after verification through WP Codebox.\n" );
         exit( 1 );
     }
-    unlink( $command_workspace . '/verification.txt' );
-    rmdir( $command_workspace );
+
+    $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array();
+    $missing_verification_api = homeboy_datamachine_agent_run_command_checks(
+        array( 'verification_commands' => array( array( 'command' => 'pnpm verify', 'description' => 'Verify generated docs' ) ) ),
+        array( 'handle' => 'repo@branch' ),
+        'verification_commands'
+    );
+    if ( ! empty( $missing_verification_api['success'] ) || 'https://github.com/Automattic/wp-codebox/issues/873' !== ( $missing_verification_api['upstream_issue'] ?? '' ) ) {
+        fwrite( STDERR, "Expected missing WP Codebox verification API to fail loudly with the WP Codebox integration point.\n" );
+        exit( 1 );
+    }
 
     fwrite( STDOUT, "Data Machine agent write-without-PR smoke passed.\n" );
 }


### PR DESCRIPTION
## Summary
- Routes `verification_commands` and `drift_checks` through `wp-codebox/run-runner-workspace-command` instead of requiring a backend-local runner workspace path.
- Preserves verification/drift metadata shape for PR body evidence: `enabled`, `success`, `checks`, command output, workspace, ability, and errors.
- Keeps the #1255/#1257 behavior: no fallback PR path, no agent PR requirement, and no synthetic `no_changes` masking.

## Live-run blocker
- Fixes the failure from Build with WordPress run 27367200124: `verification_commands requires a provisioned DMC target workspace path.`
- Run: https://github.com/Automattic/build-with-wordpress/actions/runs/27367200124

## WP Codebox boundary
- Homeboy now expects verification to execute through `wp-codebox/run-runner-workspace-command`.
- If the WP Codebox command API is unavailable, Homeboy fails loudly with WP Codebox boundary metadata instead of requiring a DMC-local path.

## Tests
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`

Fixes #1259

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Homeboy-side verification boundary fix, updated smoke coverage/docs, and ran targeted verification; Chris remains responsible for review and merge.