### PR TITLE
Fix WordPress bench scenario filtering for rig workloads

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
@@ -7,8 +7,10 @@ TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-static-source-smoke.XX
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 SOURCE_ROOT="${TMP_ROOT}/wp-site-generator"
-EXTRA_WORKLOAD="${TMP_ROOT}/rig-workload.php"
-mkdir -p "${SOURCE_ROOT}/static-sites/demo" "${SOURCE_ROOT}/.github/homeboy" "${SOURCE_ROOT}/tests/bench" "${SOURCE_ROOT}/scenarios"
+EXTRA_WORKLOAD_DIR="${TMP_ROOT}/rig-workloads"
+EXTRA_WORKLOAD="${EXTRA_WORKLOAD_DIR}/rig-workload.php"
+UNSELECTED_EXTRA_WORKLOAD="${EXTRA_WORKLOAD_DIR}/unselected-crash.php"
+mkdir -p "${SOURCE_ROOT}/static-sites/demo" "${SOURCE_ROOT}/.github/homeboy" "${SOURCE_ROOT}/tests/bench" "${SOURCE_ROOT}/scenarios" "$EXTRA_WORKLOAD_DIR"
 printf '<!doctype html><title>Demo</title>\n' > "${SOURCE_ROOT}/static-sites/demo/index.html"
 printf '<?php return array();\n' > "${SOURCE_ROOT}/.github/homeboy/ssi-import-diagnostics.php"
 printf '<?php return function (): array { return array(); };\n' > "${SOURCE_ROOT}/tests/bench/website-generation.php"
@@ -25,6 +27,7 @@ cat > "${SOURCE_ROOT}/scenarios/manifest.json" <<'JSON'
 }
 JSON
 printf '<?php return function (): array { return array(); };\n' > "$EXTRA_WORKLOAD"
+printf '<?php throw new RuntimeException("unselected workload executed");\n' > "$UNSELECTED_EXTRA_WORKLOAD"
 
 RESOLVE_HELPER="${TMP_ROOT}/resolve-context.sh"
 cat > "$RESOLVE_HELPER" <<'STUB'
@@ -159,7 +162,7 @@ bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
 jq -e --arg sourceRoot "$SOURCE_ROOT" '
     .recipe.inputs.extraPlugins == []
     and (.recipe.inputs.mounts[] | select(.source == $sourceRoot and .target == "/wordpress/wp-content/plugins/wp-site-generator" and .mode == "readonly"))
-    and (.recipe.inputs.mounts[] | select(.source == ($sourceRoot | sub("/wp-site-generator$"; ""))) | .target == "/wordpress/wp-content/plugins/wp-site-generator/tests/bench")
+    and (.recipe.inputs.mounts[] | select(.source | endswith("/rig-workloads/rig-workload.php")) | .target == "/wordpress/wp-content/plugins/wp-site-generator/tests/bench/rig-workload.php")
     and (.recipe.runtime.blueprint.steps[] | select(.step == "installPlugin" and .options.targetFolderName == "static-site-importer"))
     and (.recipe.runtime.blueprint.steps[] | select(.step == "defineWpConfigConsts" and .consts.HOMEBOY_FIXTURE_DEFINE == "yes"))
     and (.recipe.workflow.steps[0].args[] | select(startswith("env-json=") and contains("HOMEBOY_FIXTURE_ENV")))
@@ -167,6 +170,31 @@ jq -e --arg sourceRoot "$SOURCE_ROOT" '
     and (.recipe.workflow.steps[0].args[] | select(startswith("workloads-json=") and contains("static-site-importer import-theme")))
     and (.recipe.workflow.steps[0].args[] | select(startswith("workloads-json=") and contains("manifest-navigation") and contains("scenario-manifest")))
 ' "$CAPTURE_FILE" >/dev/null
+
+SELECTED_CAPTURE_FILE="${TMP_ROOT}/selected-extra-workload-capture.json"
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \
+HOMEBOY_RUNTIME_BENCH_HELPER_SH="$BENCH_HELPER" \
+HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+HOMEBOY_SMOKE_SOURCE_ROOT="$SOURCE_ROOT" \
+HOMEBOY_SMOKE_CAPTURE_FILE="$SELECTED_CAPTURE_FILE" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+HOMEBOY_BENCH_EXTRA_WORKLOADS="${EXTRA_WORKLOAD}:${UNSELECTED_EXTRA_WORKLOAD}" \
+HOMEBOY_BENCH_SCENARIOS="rig-workload" \
+HOMEBOY_WP_CODEBOX_BIN="$WP_CODEBOX_BIN" \
+HOMEBOY_WP_CODEBOX_CORE_MODULE="$WP_CODEBOX_CORE_MODULE" \
+HOMEBOY_BENCH_RESULTS_FILE="${TMP_ROOT}/selected-extra-workload-results.json" \
+HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="${TMP_ROOT}/selected-extra-workload-artifacts" \
+HOMEBOY_RUNTIME_FAILURE_TRAP="" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
+bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
+
+jq -e '
+    ([.recipe.inputs.mounts[] | select(.source | endswith("/rig-workloads/rig-workload.php"))] | length) == 1
+    and ([.recipe.inputs.mounts[] | select(.source | endswith("/rig-workloads/unselected-crash.php"))] | length) == 0
+    and ([.recipe.inputs.mounts[] | select(.target == "/wordpress/wp-content/plugins/wp-site-generator/tests/bench")] | length) == 0
+    and ([.recipe.workflow.steps[0].args[] | select(startswith("workloads-json=") and contains("ssi-import"))] | length) == 0
+' "$SELECTED_CAPTURE_FILE" >/dev/null
 
 LIST_RESULTS_FILE="${TMP_ROOT}/bench-list-results.json"
 HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -358,7 +358,7 @@ homeboy_wp_codebox_mount_extra_bench_workloads() {
     local workloads_value="${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}"
     [ -n "$workloads_value" ] || return 0
 
-    local workload_path
+    local workload_path workload_name
     IFS=':' read -r -a workload_paths <<< "$workloads_value"
     for workload_path in "${workload_paths[@]}"; do
         [ -n "$workload_path" ] || continue
@@ -367,12 +367,56 @@ homeboy_wp_codebox_mount_extra_bench_workloads() {
             FAILED_STEP="WP Codebox bench workload setup"
             exit 1
         fi
+        workload_name="$(basename "$workload_path")"
         MOUNTS_JSON=$(jq -nc \
             --argjson mounts "$MOUNTS_JSON" \
-            --arg source "$(dirname "$workload_path")" \
-            --arg target "/wordpress/wp-content/plugins/${PLUGIN_SLUG}/tests/bench" \
+            --arg source "$workload_path" \
+            --arg target "/wordpress/wp-content/plugins/${PLUGIN_SLUG}/tests/bench/${workload_name}" \
             '$mounts + [{source: $source, target: $target, mode: "readonly"}]')
     done
+}
+
+homeboy_wp_codebox_workload_scenario_id() {
+    local workload_name="$1"
+    local scenario_id
+    if [[ "$workload_name" == *.bench.* ]]; then
+        scenario_id="${workload_name%%.bench.*}"
+    else
+        scenario_id="${workload_name%.*}"
+    fi
+    printf '%s\n' "$scenario_id"
+}
+
+homeboy_wp_codebox_filter_extra_bench_workloads() {
+    local workloads_value="${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}"
+    local selected_value="${HOMEBOY_BENCH_SCENARIOS:-}"
+    [ -n "$workloads_value" ] || return 0
+    [ -n "$selected_value" ] || return 0
+
+    local filtered_paths=()
+    local selected_ids=()
+    local workload_path workload_name scenario_id selected_id
+    IFS=':' read -r -a workload_paths <<< "$workloads_value"
+    for workload_path in "${workload_paths[@]}"; do
+        [ -n "$workload_path" ] || continue
+        workload_name="$(basename "$workload_path")"
+        scenario_id="$(homeboy_wp_codebox_workload_scenario_id "$workload_name")"
+        IFS=',' read -r -a selected_ids <<< "$selected_value"
+        for selected_id in "${selected_ids[@]}"; do
+            selected_id="${selected_id#${selected_id%%[![:space:]]*}}"
+            selected_id="${selected_id%${selected_id##*[![:space:]]}}"
+            if [ "$scenario_id" = "$selected_id" ]; then
+                filtered_paths+=("$workload_path")
+                break
+            fi
+        done
+    done
+
+    local filtered_value=""
+    if [ ${#filtered_paths[@]} -gt 0 ]; then
+        filtered_value=$(IFS=':'; printf '%s' "${filtered_paths[*]}")
+    fi
+    export HOMEBOY_BENCH_EXTRA_WORKLOADS="$filtered_value"
 }
 
 homeboy_wp_codebox_extra_workload_scenarios_json() {
@@ -388,7 +432,7 @@ homeboy_wp_codebox_extra_workload_scenarios_json() {
     for workload_path in "${workload_paths[@]}"; do
         [ -n "$workload_path" ] || continue
         workload_name="$(basename "$workload_path")"
-        scenario_id="${workload_name%.*}"
+        scenario_id="$(homeboy_wp_codebox_workload_scenario_id "$workload_name")"
         scenarios=$(jq -nc \
             --argjson scenarios "$scenarios" \
             --arg id "$scenario_id" \
@@ -622,6 +666,7 @@ homeboy_wp_codebox_compile_scenario_manifests
 homeboy_wp_codebox_compile_bootstrap_files
 homeboy_wp_codebox_compile_bootstrap_steps
 homeboy_wp_codebox_compile_prepare_steps
+homeboy_wp_codebox_filter_extra_bench_workloads
 
 WP_CODEBOX_WORDPRESS_VERSION=""
 if [ "$settings_json" != "{}" ]; then


### PR DESCRIPTION
## Summary
- Filters `HOMEBOY_BENCH_EXTRA_WORKLOADS` inside `wordpress.bench` when `HOMEBOY_BENCH_SCENARIOS` selects specific scenarios.
- Mounts selected rig workload files individually instead of mounting their parent directory, so sibling workload files cannot be discovered or executed by WP Codebox.
- Extends the WP Codebox static-source bench smoke to prove an unselected crashing sibling workload is excluded from the generated recipe.

Fixes #1262.

## Tests
- `npm run test:wp-codebox-bench-recipe-builder`
- `bash scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- `bash -n scripts/bench/bench-runner-wp-codebox.sh scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementation and verification assistance for the WordPress bench scenario filtering fix and regression smoke coverage.