### PR TITLE
Fix WP Codebox runner ability registration in agent runtime

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -947,6 +947,7 @@ jobs:
               provider_credentials: $providerCredentials,
               wp_codebox_bin: $wpCodeboxBin,
               wp_codebox_components: ({
+                wp_codebox: ($componentPath + "/.ci/wp-codebox/packages/wordpress-plugin"),
                 agents_api: ($componentPath + "/.ci/agents-api"),
                 data_machine: ($componentPath + "/.ci/data-machine"),
                 data_machine_code: ($componentPath + "/.ci/data-machine-code")

--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -17,6 +17,7 @@ REPLAY_BUNDLE_DIR="$RUNTIME_DIR/replay-bundles"
 FAKE_WP_CODEBOX="$RUNTIME_DIR/wp-codebox.js"
 FAKE_ARGS_FILE="$RUNTIME_DIR/wp-codebox-args.txt"
 BUNDLE_DIR="$RUNTIME_DIR/bundle"
+WP_CODEBOX_PLUGIN_DIR="$RUNTIME_DIR/wp-codebox/packages/wordpress-plugin"
 AGENTS_API_DIR="$RUNTIME_DIR/agents-api"
 DATA_MACHINE_DIR="$RUNTIME_DIR/data-machine"
 DATA_MACHINE_CODE_DIR="$RUNTIME_DIR/data-machine-code"
@@ -29,7 +30,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$BUNDLE_DIR" "$AGENTS_API_DIR" "$DATA_MACHINE_DIR" "$DATA_MACHINE_CODE_DIR" "$DIR_MOUNT_PATH"
+mkdir -p "$BUNDLE_DIR" "$WP_CODEBOX_PLUGIN_DIR" "$AGENTS_API_DIR" "$DATA_MACHINE_DIR" "$DATA_MACHINE_CODE_DIR" "$DIR_MOUNT_PATH"
 printf '{"agent":{"slug":"wp-codebox-smoke-agent"}}\n' > "$BUNDLE_DIR/manifest.json"
 printf '{"ok":true}\n' > "$FILE_MOUNT_PATH"
 
@@ -86,7 +87,7 @@ const valueAfter = (name) => {
 const recipePath = valueAfter('--recipe')
 const recipe = JSON.parse(fs.readFileSync(recipePath, 'utf8'))
 const recipeText = JSON.stringify(recipe)
-for (const expected of ['wp-codebox.agent-sandbox-run', 'HOMEBOY_DATAMACHINE_AGENT_CONFIG', '/homeboy-extension', 'agents-api', 'data-machine', 'data-machine-code']) {
+for (const expected of ['wp-codebox.agent-sandbox-run', 'HOMEBOY_DATAMACHINE_AGENT_CONFIG', '/homeboy-extension', 'wp-codebox', 'agents-api', 'data-machine', 'data-machine-code']) {
   if (!recipeText.includes(expected)) {
     throw new Error(`missing expected wp-codebox recipe value: ${expected}`)
   }
@@ -94,7 +95,7 @@ for (const expected of ['wp-codebox.agent-sandbox-run', 'HOMEBOY_DATAMACHINE_AGE
 if (recipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === 'php-ai-client')) {
   throw new Error('WP AI Client is provided by WordPress core and must not be mounted as a WP Codebox extra plugin')
 }
-for (const slug of ['agents-api', 'data-machine', 'data-machine-code']) {
+for (const slug of ['wp-codebox', 'agents-api', 'data-machine', 'data-machine-code']) {
   if (!recipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === slug && plugin.activate === false && plugin.loadAs === 'mu-plugin')) {
     throw new Error(`expected ${slug} to load as a runtime mu-plugin before the agent workload runs`)
   }
@@ -244,6 +245,7 @@ chmod +x "$FAKE_WP_CODEBOX"
 
 jq -n \
     --arg bundle "$BUNDLE_DIR" \
+    --arg wpCodebox "$WP_CODEBOX_PLUGIN_DIR" \
     --arg agentsApi "$AGENTS_API_DIR" \
     --arg dataMachine "$DATA_MACHINE_DIR" \
     --arg dataMachineCode "$DATA_MACHINE_CODE_DIR" \
@@ -270,6 +272,7 @@ jq -n \
         transcript_host_dir: $transcriptHostDir,
         ability_tools: [{name: "fixture_tool", apiToken: "fixture-tool-secret"}],
         wp_codebox_components: {
+            wp_codebox: $wpCodebox,
             agents_api: $agentsApi,
             data_machine: $dataMachine,
             data_machine_code: $dataMachineCode

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -139,6 +139,10 @@ PHP
     local agents_api_path="${HOMEBOY_AGENTS_API_PATH:-${AGENTS_API_PATH:-}}"
     local data_machine_path="${HOMEBOY_DATA_MACHINE_PATH:-${DATA_MACHINE_PATH:-}}"
     local data_machine_code_path="${HOMEBOY_DATA_MACHINE_CODE_PATH:-${DATA_MACHINE_CODE_PATH:-}}"
+    local wp_codebox_plugin_path="${HOMEBOY_WP_CODEBOX_PLUGIN_PATH:-${WP_CODEBOX_PLUGIN_PATH:-}}"
+    if [ -z "$wp_codebox_plugin_path" ]; then
+        wp_codebox_plugin_path=$(jq -r '.wp_codebox_components.wp_codebox // .wp_codebox_plugin_path // empty' "$CONFIG_PATH")
+    fi
     if [ -z "$agents_api_path" ]; then
         agents_api_path=$(jq -r '.wp_codebox_components.agents_api // .wp_codebox_agents_api_path // empty' "$CONFIG_PATH")
     fi
@@ -152,6 +156,10 @@ PHP
         echo "ERROR: wp-codebox runtime requires Agents API, Data Machine, and Data Machine Code paths via env or config" >&2
         exit 1
     fi
+    if [ -z "$wp_codebox_plugin_path" ]; then
+        echo "ERROR: wp-codebox runtime requires the WP Codebox WordPress plugin path via env or config" >&2
+        exit 1
+    fi
 
     local recipe_file
     recipe_file=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-agent-recipe.XXXXXX")
@@ -161,7 +169,9 @@ PHP
         --arg agents "$agents_api_path" \
         --arg datamachine "$data_machine_path" \
         --arg code "$data_machine_code_path" \
+        --arg wpcodebox "$wp_codebox_plugin_path" \
         '[
+            {source: $wpcodebox, slug: "wp-codebox", activate: false, loadAs: "mu-plugin"},
             {source: $agents, slug: "agents-api", activate: false, loadAs: "mu-plugin"},
             {source: $datamachine, slug: "data-machine", activate: false, loadAs: "mu-plugin"},
             {source: $code, slug: "data-machine-code", activate: false, loadAs: "mu-plugin"}


### PR DESCRIPTION
## Summary
- Load the checked-out WP Codebox WordPress plugin into the WP Codebox agent runtime so in-sandbox `wp-codebox/*` abilities are registered.
- Pass the plugin path through the reusable workflow config and assert the runtime recipe includes it as a mu-plugin.

## Verification
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the missing runtime plugin boundary and drafted the Homeboy workflow/runtime patch for human review.