### PR TITLE
Accept zero-exit WP Codebox runner workspace commands

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -666,11 +666,13 @@ if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
 		}
 
 		$response = is_array( $result ) ? $result : array();
+		$exit_code = (int) ( $response['exit_code'] ?? $response['code'] ?? ( empty( $response['success'] ) ? 1 : 0 ) );
+		$completed = ! empty( $response['success'] ) || 0 === $exit_code || 'completed' === (string) ( $response['status'] ?? '' );
 		return array(
 			'command'        => $command_config['command'],
 			'description'    => $command_config['description'],
-			'exit_code'      => (int) ( $response['exit_code'] ?? $response['status'] ?? ( empty( $response['success'] ) ? 1 : 0 ) ),
-			'success'        => ! empty( $response['success'] ),
+			'exit_code'      => $exit_code,
+			'success'        => $completed,
 			'stdout'         => is_scalar( $response['stdout'] ?? null ) ? trim( (string) $response['stdout'] ) : '',
 			'stderr'         => is_scalar( $response['stderr'] ?? null ) ? trim( (string) $response['stderr'] ) : '',
 			'elapsed_ms'     => isset( $response['elapsed_ms'] ) ? (float) $response['elapsed_ms'] : ( hrtime( true ) - $started ) / 1000000,

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -601,10 +601,10 @@ namespace {
                 if ( 'repo@branch' !== ( $input['workspace'] ?? '' ) ) {
                     return array( 'success' => false, 'error' => 'Unexpected workspace handle.' );
                 }
-                if ( 'printf ok > verification.txt' === ( $input['command'] ?? '' ) ) {
-                    $workspace_files['verification.txt'] = 'ok';
-                    return array( 'success' => true, 'exit_code' => 0, 'stdout' => '', 'stderr' => '' );
-                }
+				if ( 'printf ok > verification.txt' === ( $input['command'] ?? '' ) ) {
+					$workspace_files['verification.txt'] = 'ok';
+					return array( 'status' => 'completed', 'exit_code' => 0, 'stdout' => '', 'stderr' => '' );
+				}
                 if ( 'test -f verification.txt' === ( $input['command'] ?? '' ) ) {
                     return array( 'success' => isset( $workspace_files['verification.txt'] ), 'exit_code' => isset( $workspace_files['verification.txt'] ) ? 0 : 1 );
                 }


### PR DESCRIPTION
## Summary
- Treat WP Codebox runner workspace command responses with `exit_code: 0` or `status: completed` as successful even when the response omits `success`.
- Add smoke coverage for a successful command response shaped like the Build with WordPress verification run.

## Verification
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runner verification result-shape mismatch and drafted the normalization fix for human review.