### PR TITLE
Reject duplicate selected WP bench rig scenarios

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
@@ -196,6 +196,37 @@ jq -e '
     and ([.recipe.workflow.steps[0].args[] | select(startswith("workloads-json=") and contains("ssi-import"))] | length) == 0
 ' "$SELECTED_CAPTURE_FILE" >/dev/null
 
+printf '<?php return function (): array { return array("metrics" => array("shadow" => 1)); };\n' > "${SOURCE_ROOT}/tests/bench/rig-workload.php"
+set +e
+DUPLICATE_OUTPUT=$(HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \
+HOMEBOY_RUNTIME_BENCH_HELPER_SH="$BENCH_HELPER" \
+HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+HOMEBOY_SMOKE_SOURCE_ROOT="$SOURCE_ROOT" \
+HOMEBOY_SMOKE_CAPTURE_FILE="${TMP_ROOT}/duplicate-capture.json" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+HOMEBOY_BENCH_EXTRA_WORKLOADS="$EXTRA_WORKLOAD" \
+HOMEBOY_BENCH_SCENARIOS="rig-workload" \
+HOMEBOY_WP_CODEBOX_BIN="$WP_CODEBOX_BIN" \
+HOMEBOY_WP_CODEBOX_CORE_MODULE="$WP_CODEBOX_CORE_MODULE" \
+HOMEBOY_BENCH_RESULTS_FILE="${TMP_ROOT}/duplicate-results.json" \
+HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="${TMP_ROOT}/duplicate-artifacts" \
+HOMEBOY_RUNTIME_FAILURE_TRAP="" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
+bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" 2>&1 >/dev/null)
+DUPLICATE_STATUS=$?
+set -e
+rm -f "${SOURCE_ROOT}/tests/bench/rig-workload.php"
+if [ "$DUPLICATE_STATUS" -eq 0 ]; then
+    echo "Expected duplicate selected rig/in-tree workload ids to fail." >&2
+    exit 1
+fi
+if [[ "$DUPLICATE_OUTPUT" != *"duplicate WordPress bench scenario id 'rig-workload'"* ]]; then
+    echo "Expected duplicate selected rig/in-tree workload failure to name the scenario id." >&2
+    printf '%s\n' "$DUPLICATE_OUTPUT" >&2
+    exit 1
+fi
+
 LIST_RESULTS_FILE="${TMP_ROOT}/bench-list-results.json"
 HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \
 HOMEBOY_RUNTIME_BENCH_HELPER_SH="$BENCH_HELPER" \

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -419,6 +419,33 @@ homeboy_wp_codebox_filter_extra_bench_workloads() {
     export HOMEBOY_BENCH_EXTRA_WORKLOADS="$filtered_value"
 }
 
+homeboy_wp_codebox_fail_on_duplicate_selected_rig_workloads() {
+    local workloads_value="${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}"
+    local selected_value="${HOMEBOY_BENCH_SCENARIOS:-}"
+    [ -n "$workloads_value" ] || return 0
+    [ -n "$selected_value" ] || return 0
+
+    local bench_dir="${PLUGIN_PATH}/tests/bench"
+    [ -d "$bench_dir" ] || return 0
+
+    local workload_path workload_name scenario_id component_workload
+    IFS=':' read -r -a workload_paths <<< "$workloads_value"
+    for workload_path in "${workload_paths[@]}"; do
+        [ -n "$workload_path" ] || continue
+        workload_name="$(basename "$workload_path")"
+        scenario_id="$(homeboy_wp_codebox_workload_scenario_id "$workload_name")"
+        component_workload="${bench_dir}/${scenario_id}.php"
+        if [ -f "$component_workload" ]; then
+            echo "Error: duplicate WordPress bench scenario id '${scenario_id}' is selected from both a rig workload and an in-tree workload." >&2
+            echo "  Rig workload: ${workload_path}" >&2
+            echo "  In-tree workload: ${component_workload}" >&2
+            echo "Rename one workload or select a unique scenario id so the rig workload cannot be shadowed." >&2
+            FAILED_STEP="WP Codebox bench workload setup"
+            exit 1
+        fi
+    done
+}
+
 homeboy_wp_codebox_extra_workload_scenarios_json() {
     local workloads_value="${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}"
     local scenarios="[]"
@@ -667,6 +694,7 @@ homeboy_wp_codebox_compile_bootstrap_files
 homeboy_wp_codebox_compile_bootstrap_steps
 homeboy_wp_codebox_compile_prepare_steps
 homeboy_wp_codebox_filter_extra_bench_workloads
+homeboy_wp_codebox_fail_on_duplicate_selected_rig_workloads
 
 WP_CODEBOX_WORDPRESS_VERSION=""
 if [ "$settings_json" != "{}" ]; then


### PR DESCRIPTION
## Summary
- Fail fast when a selected WordPress bench rig workload has the same scenario id as an in-tree `tests/bench` workload.
- Keep the guard scoped to targeted runs so unfiltered bench discovery behavior remains unchanged.
- Add smoke coverage proving duplicate selected rig/in-tree IDs cannot silently proceed to WP Codebox recipe execution.

Fixes #1266.

## Tests
- `bash -n scripts/bench/bench-runner-wp-codebox.sh scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- `bash scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- `node tests/wp-codebox-bench-recipe-builder-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the duplicate selected rig/in-tree scenario guardrail, added smoke coverage, and ran targeted validation. Chris remains responsible for review and merge.