### PR TITLE
Run selected WP bench rig workload overlays

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
@@ -116,6 +116,14 @@ process.stdout.write(JSON.stringify({
     schema: 'homeboy/bench-results/v1',
     component_id: 'wp-site-generator',
     benchmarks: [],
+    scenarios: [{
+      id: 'rig-workload',
+      source: 'in_tree',
+      file: 'tests/bench/rig-workload.php',
+      iterations: 1,
+      metrics: {},
+      provenance: {workload_file: 'tests/bench/rig-workload.php'}
+    }],
     warmup_iterations: 1
   }
 }));
@@ -197,35 +205,32 @@ jq -e '
 ' "$SELECTED_CAPTURE_FILE" >/dev/null
 
 printf '<?php return function (): array { return array("metrics" => array("shadow" => 1)); };\n' > "${SOURCE_ROOT}/tests/bench/rig-workload.php"
-set +e
-DUPLICATE_OUTPUT=$(HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \
+DUPLICATE_CAPTURE_FILE="${TMP_ROOT}/duplicate-capture.json"
+DUPLICATE_RESULTS_FILE="${TMP_ROOT}/duplicate-results.json"
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \
 HOMEBOY_RUNTIME_BENCH_HELPER_SH="$BENCH_HELPER" \
 HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
 HOMEBOY_SMOKE_SOURCE_ROOT="$SOURCE_ROOT" \
-HOMEBOY_SMOKE_CAPTURE_FILE="${TMP_ROOT}/duplicate-capture.json" \
+HOMEBOY_SMOKE_CAPTURE_FILE="$DUPLICATE_CAPTURE_FILE" \
 HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
 HOMEBOY_BENCH_EXTRA_WORKLOADS="$EXTRA_WORKLOAD" \
 HOMEBOY_BENCH_SCENARIOS="rig-workload" \
 HOMEBOY_WP_CODEBOX_BIN="$WP_CODEBOX_BIN" \
 HOMEBOY_WP_CODEBOX_CORE_MODULE="$WP_CODEBOX_CORE_MODULE" \
-HOMEBOY_BENCH_RESULTS_FILE="${TMP_ROOT}/duplicate-results.json" \
+HOMEBOY_BENCH_RESULTS_FILE="$DUPLICATE_RESULTS_FILE" \
 HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="${TMP_ROOT}/duplicate-artifacts" \
 HOMEBOY_RUNTIME_FAILURE_TRAP="" \
 HOMEBOY_BENCH_ITERATIONS=1 \
 HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
-bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" 2>&1 >/dev/null)
-DUPLICATE_STATUS=$?
-set -e
+bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
 rm -f "${SOURCE_ROOT}/tests/bench/rig-workload.php"
-if [ "$DUPLICATE_STATUS" -eq 0 ]; then
-    echo "Expected duplicate selected rig/in-tree workload ids to fail." >&2
-    exit 1
-fi
-if [[ "$DUPLICATE_OUTPUT" != *"duplicate WordPress bench scenario id 'rig-workload'"* ]]; then
-    echo "Expected duplicate selected rig/in-tree workload failure to name the scenario id." >&2
-    printf '%s\n' "$DUPLICATE_OUTPUT" >&2
-    exit 1
-fi
+jq -e --arg sourceRoot "$SOURCE_ROOT" '
+    (.recipe.inputs.mounts[] | select(.source | endswith("/component-plugin-rig-workload-overlay") and .target == "/wordpress/wp-content/plugins/wp-site-generator" and .mode == "readonly"))
+    and ([.recipe.inputs.mounts[] | select(.source | endswith("/rig-workloads/rig-workload.php"))] | length) == 0
+' "$DUPLICATE_CAPTURE_FILE" >/dev/null
+jq -e '
+    (.scenarios[] | select(.id == "rig-workload" and .source == "rig" and .provenance.source == "rig-overlay"))
+' "$DUPLICATE_RESULTS_FILE" >/dev/null
 
 LIST_RESULTS_FILE="${TMP_ROOT}/bench-list-results.json"
 HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \
@@ -284,6 +289,36 @@ jq -e --arg sourceRoot "$PLUGIN_ROOT" '
     .recipe.inputs.extraPlugins == [{source: $sourceRoot, slug: "wp-site-generator", pluginFile: "wp-site-generator/plugin-main.php", activate: false}]
     and ([.recipe.inputs.mounts[] | select(.source == $sourceRoot and .target == "/wordpress/wp-content/plugins/wp-site-generator")] | length == 0)
 ' "$PLUGIN_CAPTURE_FILE" >/dev/null
+
+mkdir -p "${PLUGIN_ROOT}/tests/bench"
+printf '<?php return function (): array { return array("metrics" => array("shadow" => 1)); };\n' > "${PLUGIN_ROOT}/tests/bench/rig-workload.php"
+PLUGIN_DUPLICATE_CAPTURE_FILE="${TMP_ROOT}/plugin-duplicate-capture.json"
+PLUGIN_DUPLICATE_RESULTS_FILE="${TMP_ROOT}/plugin-duplicate-results.json"
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \
+HOMEBOY_RUNTIME_BENCH_HELPER_SH="$BENCH_HELPER" \
+HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+HOMEBOY_SMOKE_SOURCE_ROOT="$PLUGIN_ROOT" \
+HOMEBOY_SMOKE_CAPTURE_FILE="$PLUGIN_DUPLICATE_CAPTURE_FILE" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+HOMEBOY_BENCH_EXTRA_WORKLOADS="$EXTRA_WORKLOAD" \
+HOMEBOY_BENCH_SCENARIOS="rig-workload" \
+HOMEBOY_WP_CODEBOX_BIN="$WP_CODEBOX_BIN" \
+HOMEBOY_WP_CODEBOX_CORE_MODULE="$WP_CODEBOX_CORE_MODULE" \
+HOMEBOY_BENCH_RESULTS_FILE="$PLUGIN_DUPLICATE_RESULTS_FILE" \
+HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="${TMP_ROOT}/plugin-duplicate-artifacts" \
+HOMEBOY_RUNTIME_FAILURE_TRAP="" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
+bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
+
+jq -e '
+    (.recipe.inputs.extraPlugins[0].source | endswith("/component-plugin-rig-workload-overlay"))
+    and .recipe.inputs.extraPlugins[0].pluginFile == "wp-site-generator/plugin-main.php"
+    and ([.recipe.inputs.mounts[] | select(.source | endswith("/rig-workloads/rig-workload.php"))] | length) == 0
+' "$PLUGIN_DUPLICATE_CAPTURE_FILE" >/dev/null
+jq -e '
+    (.scenarios[] | select(.id == "rig-workload" and .source == "rig" and .provenance.source == "rig-overlay"))
+' "$PLUGIN_DUPLICATE_RESULTS_FILE" >/dev/null
 
 DEPENDENCY_ROOT="${TMP_ROOT}/wp-codebox-release-fixture"
 mkdir -p "${DEPENDENCY_ROOT}/packages/wordpress-plugin"

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -419,7 +419,7 @@ homeboy_wp_codebox_filter_extra_bench_workloads() {
     export HOMEBOY_BENCH_EXTRA_WORKLOADS="$filtered_value"
 }
 
-homeboy_wp_codebox_fail_on_duplicate_selected_rig_workloads() {
+homeboy_wp_codebox_apply_selected_rig_workload_overlays() {
     local workloads_value="${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}"
     local selected_value="${HOMEBOY_BENCH_SCENARIOS:-}"
     [ -n "$workloads_value" ] || return 0
@@ -428,7 +428,10 @@ homeboy_wp_codebox_fail_on_duplicate_selected_rig_workloads() {
     local bench_dir="${PLUGIN_PATH}/tests/bench"
     [ -d "$bench_dir" ] || return 0
 
-    local workload_path workload_name scenario_id component_workload
+    local overlay_path=""
+    local overlaid_ids=()
+    local remaining_paths=()
+    local workload_path workload_name scenario_id component_workload overlay_workload
     IFS=':' read -r -a workload_paths <<< "$workloads_value"
     for workload_path in "${workload_paths[@]}"; do
         [ -n "$workload_path" ] || continue
@@ -436,14 +439,35 @@ homeboy_wp_codebox_fail_on_duplicate_selected_rig_workloads() {
         scenario_id="$(homeboy_wp_codebox_workload_scenario_id "$workload_name")"
         component_workload="${bench_dir}/${scenario_id}.php"
         if [ -f "$component_workload" ]; then
-            echo "Error: duplicate WordPress bench scenario id '${scenario_id}' is selected from both a rig workload and an in-tree workload." >&2
+            if [ -z "$overlay_path" ]; then
+                overlay_path="${ARTIFACTS_DIR%/}/component-plugin-rig-workload-overlay"
+                mkdir -p "$overlay_path"
+                cp -R "${PLUGIN_PATH}/." "$overlay_path/"
+            fi
+            overlay_workload="${overlay_path}/tests/bench/${scenario_id}.php"
+            mkdir -p "$(dirname "$overlay_workload")"
+            cp "$workload_path" "$overlay_workload"
+            overlaid_ids+=("$scenario_id")
+            echo "Using selected rig workload '${scenario_id}' over duplicate in-tree workload." >&2
             echo "  Rig workload: ${workload_path}" >&2
             echo "  In-tree workload: ${component_workload}" >&2
-            echo "Rename one workload or select a unique scenario id so the rig workload cannot be shadowed." >&2
-            FAILED_STEP="WP Codebox bench workload setup"
-            exit 1
+        else
+            remaining_paths+=("$workload_path")
         fi
     done
+
+    if [ ${#overlaid_ids[@]} -gt 0 ]; then
+        PLUGIN_PATH="$overlay_path"
+        export PLUGIN_PATH
+        HOMEBOY_BENCH_RIG_OVERLAY_SCENARIOS=$(IFS=','; printf '%s' "${overlaid_ids[*]}")
+        export HOMEBOY_BENCH_RIG_OVERLAY_SCENARIOS
+
+        local remaining_value=""
+        if [ ${#remaining_paths[@]} -gt 0 ]; then
+            remaining_value=$(IFS=':'; printf '%s' "${remaining_paths[*]}")
+        fi
+        export HOMEBOY_BENCH_EXTRA_WORKLOADS="$remaining_value"
+    fi
 }
 
 homeboy_wp_codebox_extra_workload_scenarios_json() {
@@ -694,7 +718,6 @@ homeboy_wp_codebox_compile_bootstrap_files
 homeboy_wp_codebox_compile_bootstrap_steps
 homeboy_wp_codebox_compile_prepare_steps
 homeboy_wp_codebox_filter_extra_bench_workloads
-homeboy_wp_codebox_fail_on_duplicate_selected_rig_workloads
 
 WP_CODEBOX_WORDPRESS_VERSION=""
 if [ "$settings_json" != "{}" ]; then
@@ -731,6 +754,8 @@ if [ -z "$ARTIFACTS_DIR" ]; then
     ARTIFACTS_DIR=$(mktemp -d "${PLUGIN_PATH}/.homeboy/wp-codebox-bench-artifacts.XXXXXX")
 fi
 mkdir -p "$ARTIFACTS_DIR"
+
+homeboy_wp_codebox_apply_selected_rig_workload_overlays
 
 homeboy_wp_codebox_run_prepare_steps
 
@@ -1082,6 +1107,26 @@ fi
 
 mkdir -p "$(dirname "$RESULTS_FILE")"
 jq '.benchResults | del(.warmup_iterations)' "$WP_CODEBOX_TMPFILE" > "$RESULTS_FILE"
+
+if [ -n "${HOMEBOY_BENCH_RIG_OVERLAY_SCENARIOS:-}" ]; then
+    OVERLAY_RESULTS_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-rig-overlay-results.XXXXXX")
+    if jq --arg scenarios "$HOMEBOY_BENCH_RIG_OVERLAY_SCENARIOS" '
+        ($scenarios | split(",") | map(select(. != ""))) as $rigIds
+        | .scenarios = ((.scenarios // []) | map(
+            if (.id as $id | $rigIds | index($id)) then
+                .source = "rig"
+                | .provenance = ((.provenance // {}) + {source: "rig-overlay"})
+            else
+                .
+            end
+        ))
+    ' "$RESULTS_FILE" > "$OVERLAY_RESULTS_FILE"; then
+        mv "$OVERLAY_RESULTS_FILE" "$RESULTS_FILE"
+    else
+        rm -f "$OVERLAY_RESULTS_FILE"
+        echo "Warning: failed to mark selected rig overlay scenarios in bench results." >&2
+    fi
+fi
 
 PREPARED_DEPENDENCIES_METADATA_FILE="${ARTIFACTS_DIR%/}/prepared-bench-dependencies.json"
 if [ -f "$PREPARED_DEPENDENCIES_METADATA_FILE" ]; then


### PR DESCRIPTION
## Summary
- Replace the duplicate selected rig/in-tree fail-fast path with a rig overlay execution path.
- When a selected rig workload duplicates an in-tree `tests/bench/<scenario>.php`, copy the component plugin into the run artifacts directory, replace that workload with the rig-owned file, and run WP Codebox against the overlay so the rig workload actually executes.
- Mark overlayed scenarios as `source: rig` in the bench results, and remove the overlaid workload from nested file mounts so plugin-root `extraPlugins` installs cannot shadow it again.
- Extend the static-source smoke to cover both directory-mounted components and plugin-root `extraPlugins` components, matching the WooCommerce lab path from the reopened evidence.

Follow-up for #1266 after #1267 did not fix the Woo rig shadowing path.

Evidence: https://github.com/Extra-Chill/homeboy-extensions/issues/1266#issuecomment-4684136531

## Tests
- `bash -n scripts/bench/bench-runner-wp-codebox.sh scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- `bash scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- `node tests/wp-codebox-bench-recipe-builder-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the selected rig workload overlay path, expanded smoke coverage for the Woo-style plugin-root path, and ran targeted validation. Chris remains responsible for review and merge.