### PR TITLE
Seed local runner workspaces for Data Machine agent CI

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -835,6 +835,16 @@ jobs:
           pipeline_step_patches_json="$(validate_json_input pipeline_step_patches array "$PIPELINE_STEP_PATCHES")"
           flow_step_patches_json="$(validate_json_input flow_step_patches array "$FLOW_STEP_PATCHES")"
           runner_workspace_json="$(validate_json_input runner_workspace object "$RUNNER_WORKSPACE_CONFIG")"
+          runner_workspace_repo="${TARGET_REPO#*/}"
+          runner_workspace_repo="${runner_workspace_repo%.git}"
+          datamachine_workspace_guest_root="/homeboy-datamachine-workspace"
+          datamachine_workspace_guest_primary="${datamachine_workspace_guest_root}/${runner_workspace_repo}"
+          runner_workspace_mounts_json="[]"
+          if jq -e '.enabled == true' <<< "$runner_workspace_json" >/dev/null; then
+            runner_workspace_mounts_json="$(jq -nc --arg source "$GITHUB_WORKSPACE" --arg target "$datamachine_workspace_guest_primary" '[{type: "directory", source: $source, target: $target, mode: "readwrite"}]')"
+            runner_workspace_json="$(jq -c --arg seed "$datamachine_workspace_guest_primary" '. + {local_seed_path: $seed}' <<< "$runner_workspace_json")"
+            extra_wp_config_defines_json="$(jq -c --arg root "$datamachine_workspace_guest_root" '. + {DATAMACHINE_WORKSPACE_PATH: $root}' <<< "$extra_wp_config_defines_json")"
+          fi
           rules_json="$(validate_json_input rules object "$RULES")"
           general_rules_json="$(validate_json_input general_rules array "$GENERAL_RULES")"
           task_rules_json="$(validate_json_input task_rules array "$TASK_RULES")"
@@ -898,6 +908,7 @@ jobs:
             --argjson extraWpConfigDefines "$extra_wp_config_defines_json" \
             --argjson extraWpCodeboxMounts "$extra_wp_codebox_mounts_json" \
             --argjson executeWorkflowMounts "$execute_workflow_mounts_json" \
+            --argjson runnerWorkspaceMounts "$runner_workspace_mounts_json" \
             --argjson workloadRunBefore "$workload_run_before_json" \
             --argjson workloadRunAfter "$workload_run_after_json" \
             --argjson dailyMemoryEnabled "$DAILY_MEMORY_ENABLED" \
@@ -929,7 +940,7 @@ jobs:
                   target: "/wordpress/wp-content/plugins/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php",
                   mode: "readonly"
                 }
-              ] + $extraWpCodeboxMounts + $executeWorkflowMounts),
+              ] + $extraWpCodeboxMounts + $executeWorkflowMounts + $runnerWorkspaceMounts),
               wp_config_defines: $extraWpConfigDefines,
               workload_run_before: $workloadRunBefore,
               workload_run_after: $workloadRunAfter,

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -646,11 +646,14 @@ if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
 		$started = hrtime( true );
 		$result  = $ability->execute(
 			array(
-				'workspace'   => $handle,
-				'handle'      => $handle,
-				'command'     => $command_config['command'],
-				'description' => $command_config['description'],
-				'kind'        => $key,
+				'workspace'        => $handle,
+				'handle'           => $handle,
+				'workspace_path'   => isset( $runner_workspace['path'] ) && is_scalar( $runner_workspace['path'] ) ? (string) $runner_workspace['path'] : '',
+				'workspace_backend' => isset( $runner_workspace['backend'] ) && is_scalar( $runner_workspace['backend'] ) ? (string) $runner_workspace['backend'] : '',
+				'runner_workspace' => $runner_workspace,
+				'command'          => $command_config['command'],
+				'description'      => $command_config['description'],
+				'kind'             => $key,
 			)
 		);
 		if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
@@ -678,7 +681,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
 			'elapsed_ms'     => isset( $response['elapsed_ms'] ) ? (float) $response['elapsed_ms'] : ( hrtime( true ) - $started ) / 1000000,
 			'workspace'      => $handle,
 			'ability'        => $ability_name,
-			'error'          => is_scalar( $response['error'] ?? null ) ? (string) $response['error'] : '',
+			'error'          => is_scalar( $response['error'] ?? null ) ? (string) $response['error'] : ( is_array( $response['error'] ?? null ) ? wp_json_encode( $response['error'] ) : '' ),
 			'upstream_issue' => is_scalar( $response['upstream_issue'] ?? null ) ? (string) $response['upstream_issue'] : '',
 		);
 	}
@@ -2586,18 +2589,37 @@ if ( ! function_exists( 'homeboy_datamachine_agent_provision_workspace' ) ) {
             return array( 'enabled' => true, 'success' => false, 'error' => 'runner_workspace.repo is required' );
         }
 
-        $required = array(
-            'datamachine-code/workspace-show',
-            'datamachine-code/workspace-clone',
-            'datamachine-code/workspace-worktree-add',
-        );
-        foreach ( $required as $ability_name ) {
-            if ( ! wp_get_ability( $ability_name ) ) {
-                return array( 'enabled' => true, 'success' => false, 'error' => $ability_name . ' is not registered' );
-            }
-        }
+		$required = array(
+			'datamachine-code/workspace-show',
+			'datamachine-code/workspace-clone',
+			'datamachine-code/workspace-worktree-add',
+		);
+		$local_seed_path = isset( $workspace['local_seed_path'] ) && is_scalar( $workspace['local_seed_path'] ) ? trim( (string) $workspace['local_seed_path'] ) : '';
+		if ( '' !== $local_seed_path ) {
+			$required[] = 'datamachine-code/workspace-adopt';
+		}
+		foreach ( $required as $ability_name ) {
+			if ( ! wp_get_ability( $ability_name ) ) {
+				return array( 'enabled' => true, 'success' => false, 'error' => $ability_name . ' is not registered' );
+			}
+		}
 
-        $show = wp_get_ability( 'datamachine-code/workspace-show' )->execute( array( 'name' => $repo ) );
+		if ( '' !== $local_seed_path ) {
+			$adopt = wp_get_ability( 'datamachine-code/workspace-adopt' )->execute(
+				array(
+					'path' => $local_seed_path,
+					'name' => $repo,
+				)
+			);
+			if ( function_exists( 'is_wp_error' ) && is_wp_error( $adopt ) ) {
+				return array( 'enabled' => true, 'success' => false, 'error' => $adopt->get_error_message(), 'local_seed_path' => $local_seed_path );
+			}
+			if ( ! is_array( $adopt ) || empty( $adopt['success'] ) ) {
+				return array( 'enabled' => true, 'success' => false, 'error' => 'workspace-adopt did not succeed', 'local_seed_path' => $local_seed_path, 'result' => $adopt );
+			}
+		}
+
+		$show = wp_get_ability( 'datamachine-code/workspace-show' )->execute( array( 'name' => $repo ) );
         if ( function_exists( 'is_wp_error' ) && is_wp_error( $show ) ) {
             $clone_url = isset( $workspace['clone_url'] ) && is_scalar( $workspace['clone_url'] ) ? trim( (string) $workspace['clone_url'] ) : '';
             if ( '' === $clone_url ) {

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -601,6 +601,9 @@ namespace {
                 if ( 'repo@branch' !== ( $input['workspace'] ?? '' ) ) {
                     return array( 'success' => false, 'error' => 'Unexpected workspace handle.' );
                 }
+				if ( '/workspace/repo@branch' !== ( $input['workspace_path'] ?? '' ) ) {
+					return array( 'success' => false, 'error' => 'Unexpected workspace path.' );
+				}
 				if ( 'printf ok > verification.txt' === ( $input['command'] ?? '' ) ) {
 					$workspace_files['verification.txt'] = 'ok';
 					return array( 'status' => 'completed', 'exit_code' => 0, 'stdout' => '', 'stderr' => '' );
@@ -614,7 +617,7 @@ namespace {
     );
     $verification_result = homeboy_datamachine_agent_run_command_checks(
         array( 'verification_commands' => array( array( 'command' => 'printf ok > verification.txt', 'description' => 'Write verification marker' ) ) ),
-        array( 'handle' => 'repo@branch' ),
+        array( 'handle' => 'repo@branch', 'path' => '/workspace/repo@branch', 'backend' => 'local_git' ),
         'verification_commands'
     );
     if ( empty( $verification_result['success'] ) || empty( $workspace_files['verification.txt'] ) || 'wp-codebox/run-runner-workspace-command' !== ( $verification_result['ability'] ?? '' ) ) {
@@ -623,7 +626,7 @@ namespace {
     }
     $drift_result = homeboy_datamachine_agent_run_command_checks(
         array( 'drift_checks' => array( array( 'command' => 'test -f verification.txt', 'description' => 'Generated outputs are present' ) ) ),
-        array( 'handle' => 'repo@branch' ),
+        array( 'handle' => 'repo@branch', 'path' => '/workspace/repo@branch', 'backend' => 'local_git' ),
         'drift_checks'
     );
     if ( empty( $drift_result['success'] ) || 2 !== count( $workspace_command_calls ) ) {
@@ -641,6 +644,30 @@ namespace {
         fwrite( STDERR, "Expected missing WP Codebox verification API to fail loudly with the WP Codebox integration point.\n" );
         exit( 1 );
     }
+
+	$GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
+		'wp-codebox/run-runner-workspace-command' => new Homeboy_Datamachine_Agent_Fake_Ability(
+			function (): array {
+				return array(
+					'success'   => false,
+					'exit_code' => 1,
+					'error'     => array(
+						'code'    => 'wp_codebox_runner_workspace_backend_unavailable',
+						'message' => 'Runner workspace backend ability is not available for this operation.',
+					),
+				);
+			}
+		),
+	);
+	$structured_error_result = homeboy_datamachine_agent_run_command_checks(
+		array( 'verification_commands' => array( array( 'command' => 'pnpm verify', 'description' => 'Verify generated docs' ) ) ),
+		array( 'handle' => 'repo@branch', 'path' => 'github://owner/repo#branch' ),
+		'verification_commands'
+	);
+	if ( ! str_contains( (string) ( $structured_error_result['error'] ?? '' ), 'wp_codebox_runner_workspace_backend_unavailable' ) ) {
+		fwrite( STDERR, "Expected structured WP Codebox command errors to be preserved.\n" );
+		exit( 1 );
+	}
 
     fwrite( STDOUT, "Data Machine agent write-without-PR smoke passed.\n" );
 }


### PR DESCRIPTION
## Summary
- Mount the GitHub Actions consumer checkout into the WP Codebox runtime as the DMC workspace primary whenever runner workspaces are enabled.
- Adopt that mounted checkout before creating the runner worktree, so agent writes and command verification share a local workspace contract.
- Forward workspace path/backend metadata into WP Codebox command checks and preserve structured command errors in results.

## Testing
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `npm run test:datamachine-agent-wp-codebox-runner`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); puts "workflow yaml ok"'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runner workspace verification gap, drafted the Homeboy Extensions workflow/runtime changes, and ran targeted smoke checks; Chris remains responsible for review and merge.