### PR TITLE
Add public preview preflight helper

### DIFF
--- a/managed-preview/README.md
+++ b/managed-preview/README.md
@@ -4,6 +4,58 @@
 
 Homeboy core owns the generic lifecycle contract: start a local service, supervise an optional backend command, record logs, and expose a `homeboy/preview-url/v1` artifact. This extension owns provider command glue that can be used with Homeboy's generic `--public-tunnel-backend command` seam.
 
+## Browser Trace Public Preview Preflight
+
+Browser trace workloads that require a public HTTPS origin can use
+`scripts/public-preview-preflight.mjs` as the shared contract between the runtime,
+the tunnel operator, and the trace runner. The helper accepts or allocates a
+selected preview port, normalizes the local preview origin and public URL,
+preflights both routes, and writes redacted `homeboy/public-preview-preflight/v1`
+metadata for trace artifacts.
+
+Prepare a runtime port before the service starts:
+
+```sh
+node scripts/public-preview-preflight.mjs \
+  --allocate-port \
+  --prepare-only \
+  --metadata-file "$HOMEBOY_TRACE_ARTIFACT_DIR/public-preview-prepared.json"
+```
+
+The prepared metadata has `status: "prepared"`; pass its
+`local_preview.port` back into the runtime and tunnel command. Before browser
+launch, rerun the helper with the selected port and public URL so it can fail
+fast on routing mismatches.
+
+```sh
+node scripts/public-preview-preflight.mjs \
+  --preview-port 49822 \
+  --local-url http://127.0.0.1:49822 \
+  --public-url https://public-preview.example/runs/run-123 \
+  --tunnel-provider traforo \
+  --tunnel-session-id run-123 \
+  --preflight-path / \
+  --metadata-file "$HOMEBOY_TRACE_ARTIFACT_DIR/public-preview.json"
+```
+
+The helper fails before browser launch when:
+
+- the public URL is not HTTPS;
+- the selected preview port does not match the local runtime URL;
+- the local runtime is not reachable on the selected port;
+- the public URL does not return a successful preflight response; or
+- an expected status/text check does not match both local and public routes.
+
+The metadata intentionally records only redacted URLs, origins, port/session
+identifiers, response status, content type, body byte counts, and body hashes.
+Probe bodies, credentials, query strings, and fragments are not written.
+
+This helper does **not** own tunnel process lifecycle. Homeboy core, an operator
+wrapper, or a future tunnel provider is responsible for starting and keeping the
+SSH forward / Traforo / broker session alive. `managed-preview` owns the
+upstream-facing diagnostics contract so browser trace rigs can opt in without
+copying custom environment-variable glue.
+
 ## Hostname-Preserving Broker Backend
 
 Use the helper as Homeboy's backend command when a preview broker can create a reviewer-accessible session while preserving the browser-effective origin inside that session:

--- a/managed-preview/managed-preview.json
+++ b/managed-preview/managed-preview.json
@@ -7,11 +7,26 @@
   "author": "Extra Chill",
   "provides": {
     "file_extensions": ["json", "mjs", "sh"],
-    "capabilities": ["preview-backend"]
+    "capabilities": ["preview-backend", "public-preview-preflight"]
   },
   "scripts": {
     "validate": "tests/public-preview-backend-smoke.mjs"
   },
+  "browser_trace_helpers": [
+    {
+      "schema": "homeboy/public-preview-preflight-helper/v1",
+      "id": "managed-preview.public-preview-preflight",
+      "label": "Public preview preflight for browser trace workloads",
+      "command": "node {{extension_path}}/scripts/public-preview-preflight.mjs",
+      "contract": {
+        "accepts_env": ["HOMEBOY_LOCAL_PREVIEW_URL", "HOMEBOY_PUBLIC_PREVIEW_URL", "HOMEBOY_PUBLIC_PREVIEW_PORT", "HOMEBOY_TUNNEL_PUBLIC_URL", "HOMEBOY_TUNNEL_SESSION_ID"],
+        "records_metadata_schema": "homeboy/public-preview-preflight/v1",
+        "redacts_url_credentials_query_and_fragments": true,
+        "owns_tunnel_lifecycle": false
+      },
+      "capabilities": ["preview-port-selection", "public-url-preflight", "browser-trace-metadata"]
+    }
+  ],
   "preview_backends": [
     {
       "schema": "homeboy/managed-preview-backend-command/v1",

--- a/managed-preview/scripts/public-preview-preflight.mjs
+++ b/managed-preview/scripts/public-preview-preflight.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import net from 'node:net';
+import { dirname } from 'node:path';
+import { URL } from 'node:url';
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const previewPort = await resolvePreviewPort(options);
+  const localUrl = resolveLocalUrl(options, previewPort);
+  const publicUrlValue = options.publicUrl || process.env.HOMEBOY_PUBLIC_PREVIEW_URL || process.env.HOMEBOY_TUNNEL_PUBLIC_URL || '';
+  const publicUrl = publicUrlValue ? parseUrl(publicUrlValue, 'public URL') : null;
+
+  if (!options.prepareOnly && !publicUrl) {
+    throw statusError('missing_public_url', 'Missing public URL');
+  }
+
+  if (publicUrl && publicUrl.protocol !== 'https:' && !options.allowInsecurePublicUrl) {
+    throw statusError('public_url_not_https', 'Public preview URL must use HTTPS. Pass --allow-insecure-public-url only for local smoke tests.');
+  }
+
+  if (Number(localUrl.port || defaultPort(localUrl)) !== previewPort) {
+    throw statusError('local_port_mismatch', `Local preview URL port ${localUrl.port || defaultPort(localUrl)} does not match selected preview port ${previewPort}.`);
+  }
+
+  const preflightPath = options.preflightPath || process.env.HOMEBOY_PUBLIC_PREVIEW_PREFLIGHT_PATH || '/';
+  if (options.prepareOnly) {
+    const metadata = buildPreparedMetadata({ options, previewPort, localUrl, publicUrl, preflightPath });
+    await writeMetadata(options.metadataFile, metadata);
+    process.stdout.write(`${JSON.stringify(metadata, null, 2)}\n`);
+    return;
+  }
+
+  const timeoutMs = Number(options.timeoutMs || process.env.HOMEBOY_PUBLIC_PREVIEW_TIMEOUT_MS || 5000);
+  const localProbeUrl = withPath(localUrl, preflightPath);
+  const publicProbeUrl = withPath(publicUrl, preflightPath);
+  const expectedStatus = options.expectedStatus ? Number(options.expectedStatus) : null;
+  const expectedText = options.expectedText || process.env.HOMEBOY_PUBLIC_PREVIEW_EXPECT_TEXT || '';
+
+  const localProbe = await probe(localProbeUrl, timeoutMs);
+  const publicProbe = await probe(publicProbeUrl, timeoutMs);
+
+  if (!localProbe.ok) {
+    throw statusError('local_preflight_failed', `Local preview preflight failed for selected port ${previewPort}: ${localProbe.error || `HTTP ${localProbe.status}`}`);
+  }
+  if (!publicProbe.ok) {
+    throw statusError('public_preflight_failed', `Public preview preflight failed before browser trace launch: ${publicProbe.error || `HTTP ${publicProbe.status}`}`);
+  }
+  if (expectedStatus !== null && publicProbe.status !== expectedStatus) {
+    throw statusError('public_status_mismatch', `Public preview returned HTTP ${publicProbe.status}; expected ${expectedStatus}.`);
+  }
+  if (expectedStatus === null && publicProbe.status !== localProbe.status) {
+    throw statusError('public_local_status_mismatch', `Public preview returned HTTP ${publicProbe.status}; local selected port returned HTTP ${localProbe.status}.`);
+  }
+  if (expectedText && (!localProbe.body.includes(expectedText) || !publicProbe.body.includes(expectedText))) {
+    throw statusError('expected_text_missing', 'Expected preflight text was not present in both local and public preview responses.');
+  }
+
+  const metadata = buildMetadata({
+    options,
+    previewPort,
+    localUrl,
+    publicUrl,
+    localProbe,
+    publicProbe,
+    preflightPath,
+  });
+
+  if (options.metadataFile) {
+    await writeMetadata(options.metadataFile, metadata);
+  }
+
+  process.stdout.write(`${JSON.stringify(metadata, null, 2)}\n`);
+}
+
+async function writeMetadata(metadataFile, metadata) {
+  if (!metadataFile) {
+    return;
+  }
+  await mkdir(dirname(metadataFile), { recursive: true });
+  await writeFile(metadataFile, `${JSON.stringify(metadata, null, 2)}\n`);
+}
+
+async function resolvePreviewPort(options) {
+  const explicit = options.previewPort || options.runtimePort || process.env.HOMEBOY_PUBLIC_PREVIEW_PORT || process.env.HOMEBOY_RUNTIME_PREVIEW_PORT;
+  if (explicit) {
+    return parsePort(explicit, 'preview port');
+  }
+  if (options.localUrl || process.env.HOMEBOY_LOCAL_PREVIEW_URL || process.env.HOMEBOY_SERVICE_LOCAL_URL) {
+    const localUrl = parseUrl(options.localUrl || process.env.HOMEBOY_LOCAL_PREVIEW_URL || process.env.HOMEBOY_SERVICE_LOCAL_URL, 'local URL');
+    return parsePort(localUrl.port || defaultPort(localUrl), 'local URL port');
+  }
+  if (options.allocatePort) {
+    return allocatePort(options.host || process.env.HOMEBOY_PUBLIC_PREVIEW_HOST || '127.0.0.1');
+  }
+  throw statusError('missing_preview_port', 'Pass --preview-port, --runtime-port, --local-url, or --allocate-port.');
+}
+
+function resolveLocalUrl(options, previewPort) {
+  const value = options.localUrl || process.env.HOMEBOY_LOCAL_PREVIEW_URL || process.env.HOMEBOY_SERVICE_LOCAL_URL;
+  if (value) {
+    return parseUrl(value, 'local URL');
+  }
+  const host = options.host || process.env.HOMEBOY_PUBLIC_PREVIEW_HOST || '127.0.0.1';
+  return parseUrl(`http://${host}:${previewPort}`, 'local URL');
+}
+
+function allocatePort(host) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, host, () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function probe(url, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url.href, { signal: controller.signal, redirect: 'manual' });
+    const body = await response.text();
+    return {
+      ok: response.status >= 200 && response.status < 500,
+      status: response.status,
+      content_type: response.headers.get('content-type') || null,
+      body,
+      body_bytes: Buffer.byteLength(body),
+      body_sha256: createHash('sha256').update(body).digest('hex'),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: null,
+      content_type: null,
+      body: '',
+      body_bytes: 0,
+      body_sha256: null,
+      error: error.name === 'AbortError' ? `Timed out after ${timeoutMs}ms` : error.message,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function buildMetadata({ options, previewPort, localUrl, publicUrl, localProbe, publicProbe, preflightPath }) {
+  return {
+    schema: 'homeboy/public-preview-preflight/v1',
+    status: 'ready',
+    lifecycle_boundary: 'Homeboy Extensions validates and records the public preview contract; the caller or Homeboy core owns tunnel process lifecycle.',
+    local_preview: {
+      origin: localUrl.origin,
+      url: redactUrl(localUrl),
+      host: localUrl.hostname,
+      port: previewPort,
+    },
+    public_preview: {
+      url: redactUrl(publicUrl),
+      origin: publicUrl.origin,
+      provider: options.tunnelProvider || process.env.HOMEBOY_PUBLIC_PREVIEW_PROVIDER || process.env.HOMEBOY_TUNNEL_PROVIDER || null,
+      session_id: options.tunnelSessionId || process.env.HOMEBOY_PUBLIC_PREVIEW_SESSION_ID || process.env.HOMEBOY_TUNNEL_SESSION_ID || null,
+    },
+    preflight: {
+      path: preflightPath,
+      local: redactProbe(localProbe),
+      public: redactProbe(publicProbe),
+    },
+    artifact_policy: {
+      publish_raw: true,
+      secret_fields: [],
+      note: 'Probe bodies, credentials, query strings, and URL fragments are intentionally omitted.',
+    },
+  };
+}
+
+function buildPreparedMetadata({ options, previewPort, localUrl, publicUrl, preflightPath }) {
+  return {
+    schema: 'homeboy/public-preview-preflight/v1',
+    status: 'prepared',
+    lifecycle_boundary: 'Homeboy Extensions selected the preview port and recorded the public preview contract; the caller must start the runtime/tunnel and rerun without --prepare-only before browser launch.',
+    local_preview: {
+      origin: localUrl.origin,
+      url: redactUrl(localUrl),
+      host: localUrl.hostname,
+      port: previewPort,
+    },
+    public_preview: publicUrl ? {
+      url: redactUrl(publicUrl),
+      origin: publicUrl.origin,
+      provider: options.tunnelProvider || process.env.HOMEBOY_PUBLIC_PREVIEW_PROVIDER || process.env.HOMEBOY_TUNNEL_PROVIDER || null,
+      session_id: options.tunnelSessionId || process.env.HOMEBOY_PUBLIC_PREVIEW_SESSION_ID || process.env.HOMEBOY_TUNNEL_SESSION_ID || null,
+    } : null,
+    preflight: {
+      path: preflightPath,
+      local: null,
+      public: null,
+    },
+    artifact_policy: {
+      publish_raw: true,
+      secret_fields: [],
+      note: 'Probe bodies, credentials, query strings, and URL fragments are intentionally omitted.',
+    },
+  };
+}
+
+function redactProbe(probeResult) {
+  return {
+    ok: probeResult.ok,
+    status: probeResult.status,
+    content_type: probeResult.content_type,
+    body_bytes: probeResult.body_bytes,
+    body_sha256: probeResult.body_sha256,
+    error: probeResult.error || null,
+  };
+}
+
+function withPath(url, path) {
+  const next = new URL(url.href);
+  next.pathname = path.startsWith('/') ? path : `/${path}`;
+  next.search = '';
+  next.hash = '';
+  return next;
+}
+
+function redactUrl(url) {
+  const next = new URL(url.href);
+  next.username = '';
+  next.password = '';
+  next.search = '';
+  next.hash = '';
+  return next.href;
+}
+
+function parseUrl(value, label) {
+  if (!value) {
+    throw statusError(`missing_${slug(label)}`, `Missing ${label}`);
+  }
+  try {
+    return new URL(value);
+  } catch (_error) {
+    throw statusError(`invalid_${slug(label)}`, `Invalid ${label}: ${value}`);
+  }
+}
+
+function parsePort(value, label) {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw statusError(`invalid_${slug(label)}`, `Invalid ${label}: ${value}`);
+  }
+  return port;
+}
+
+function defaultPort(url) {
+  if (url.protocol === 'https:') {
+    return '443';
+  }
+  if (url.protocol === 'http:') {
+    return '80';
+  }
+  return '';
+}
+
+function statusError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function parseArgs(args) {
+  const options = {};
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--allocate-port') {
+      options.allocatePort = true;
+      continue;
+    }
+    if (arg === '--allow-insecure-public-url') {
+      options.allowInsecurePublicUrl = true;
+      continue;
+    }
+    if (arg === '--prepare-only') {
+      options.prepareOnly = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) {
+      throw statusError('unexpected_argument', `Unexpected positional argument: ${arg}`);
+    }
+    const key = toCamelCase(arg.slice(2));
+    const value = args[i + 1];
+    if (!value || value.startsWith('--')) {
+      throw statusError('missing_argument_value', `Missing value for ${arg}`);
+    }
+    options[key] = value;
+    i += 1;
+  }
+  return options;
+}
+
+function toCamelCase(value) {
+  return value.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+}
+
+function slug(value) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+}
+
+main().catch((error) => {
+  process.stderr.write(`${JSON.stringify({
+    schema: 'homeboy/public-preview-preflight-error/v1',
+    status: 'failed',
+    code: error.code || 'public_preview_preflight_failed',
+    error: error.message,
+  }, null, 2)}\n`);
+  process.exitCode = 1;
+});

--- a/managed-preview/tests/public-preview-backend-smoke.mjs
+++ b/managed-preview/tests/public-preview-backend-smoke.mjs
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
-import { dirname, resolve } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const extensionRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const scriptPath = resolve(extensionRoot, 'scripts/public-preview-backend.mjs');
+const preflightScriptPath = resolve(extensionRoot, 'scripts/public-preview-preflight.mjs');
 
 const planned = run([
   scriptPath,
@@ -93,9 +97,118 @@ assert.equal(preservedJson.registration.request.target.id, 'calypso-start');
 assert.equal(preservedJson.registration.request.target.routes.start, 'http://calypso.localhost:3000/start');
 assert.equal(preservedJson.registration.request.target.routes.builder_handoff, 'http://calypso.localhost:3000/setup/ai-site-builder');
 
+const runtimeServer = await listen('runtime-ready');
+const mismatchServer = await listen('fetch failed');
+const tmpRoot = mkdtempSync(join(os.tmpdir(), 'homeboy-public-preview-'));
+try {
+  const prepared = await runAsync([
+    preflightScriptPath,
+    '--allocate-port',
+    '--prepare-only',
+  ]);
+
+  assert.equal(prepared.status, 0, prepared.stderr);
+  const preparedJson = JSON.parse(prepared.stdout);
+  assert.equal(preparedJson.schema, 'homeboy/public-preview-preflight/v1');
+  assert.equal(preparedJson.status, 'prepared');
+  assert.equal(typeof preparedJson.local_preview.port, 'number');
+  assert.equal(preparedJson.public_preview, null);
+
+  const metadataFile = resolve(tmpRoot, 'public-preview.json');
+  const preflight = await runAsync([
+    preflightScriptPath,
+    '--preview-port',
+    String(runtimeServer.port),
+    '--local-url',
+    `http://127.0.0.1:${runtimeServer.port}`,
+    '--public-url',
+    `http://127.0.0.1:${runtimeServer.port}/?token=secret`,
+    '--allow-insecure-public-url',
+    '--tunnel-provider',
+    'smoke',
+    '--tunnel-session-id',
+    'session-123',
+    '--expected-text',
+    'runtime-ready',
+    '--metadata-file',
+    metadataFile,
+  ]);
+
+  assert.equal(preflight.status, 0, preflight.stderr);
+  const preflightJson = JSON.parse(preflight.stdout);
+  const metadataJson = JSON.parse(readFileSync(metadataFile, 'utf8'));
+  assert.equal(preflightJson.schema, 'homeboy/public-preview-preflight/v1');
+  assert.equal(preflightJson.local_preview.port, runtimeServer.port);
+  assert.equal(preflightJson.public_preview.url, `http://127.0.0.1:${runtimeServer.port}/`);
+  assert.equal(preflightJson.public_preview.provider, 'smoke');
+  assert.equal(preflightJson.public_preview.session_id, 'session-123');
+  assert.equal(preflightJson.public_preview.url.includes('secret'), false);
+  assert.equal(preflightJson.preflight.public.body_sha256, preflightJson.preflight.local.body_sha256);
+  assert.deepEqual(metadataJson, preflightJson);
+
+  const mismatch = await runAsync([
+    preflightScriptPath,
+    '--preview-port',
+    String(runtimeServer.port),
+    '--local-url',
+    `http://127.0.0.1:${runtimeServer.port}`,
+    '--public-url',
+    `http://127.0.0.1:${mismatchServer.port}`,
+    '--allow-insecure-public-url',
+    '--expected-text',
+    'runtime-ready',
+  ]);
+
+  assert.equal(mismatch.status, 1, mismatch.stderr);
+  const mismatchJson = JSON.parse(mismatch.stderr);
+  assert.equal(mismatchJson.schema, 'homeboy/public-preview-preflight-error/v1');
+  assert.equal(mismatchJson.code, 'expected_text_missing');
+} finally {
+  runtimeServer.server.close();
+  mismatchServer.server.close();
+  rmSync(tmpRoot, { recursive: true, force: true });
+}
+
 function run(args) {
   return spawnSync(process.execPath, args, {
     encoding: 'utf8',
     env: { ...process.env },
+  });
+}
+
+function runAsync(args) {
+  return new Promise((resolveRun) => {
+    const child = spawn(process.execPath, args, {
+      env: { ...process.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('close', (status) => {
+      resolveRun({ status, stdout, stderr });
+    });
+  });
+}
+
+function listen(body) {
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/plain' });
+    response.end(body);
+  });
+
+  return new Promise((resolveListen, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolveListen({ server, port: address.port });
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Add a `managed-preview` public preview preflight helper for browser trace workloads that prepares or accepts a selected runtime preview port.
- Preflight local and public preview routing before browser launch, fail fast on mismatches, and write redacted `homeboy/public-preview-preflight/v1` metadata.
- Document that Homeboy Extensions owns the reusable diagnostics/contract while Homeboy core or an operator-owned tunnel provider owns tunnel process lifecycle.

Closes https://github.com/Extra-Chill/homeboy-extensions/issues/1271

## Verification
- `node --check managed-preview/scripts/public-preview-preflight.mjs`
- `jq empty managed-preview/managed-preview.json`
- `node managed-preview/tests/public-preview-backend-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the managed-preview helper, documentation, smoke coverage, and targeted verification. Chris remains responsible for review and merge.