### PR TITLE
Mark rig bench workloads as explicit overrides

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
@@ -215,7 +215,7 @@ jq -e '
     and ([.recipe.inputs.mounts[] | select(.source | endswith("/rig-workloads/unselected-crash.php"))] | length) == 0
     and ([.recipe.inputs.mounts[] | select(.target == "/wordpress/wp-content/plugins/wp-site-generator/tests/bench")] | length) == 0
     and ([.recipe.workflow.steps[0].args[] | select(startswith("workloads-json=") and contains("ssi-import"))] | length) == 0
-    and ([.recipe.workflow.steps[0].args[] | select(startswith("workloads-json=") and contains("\"source\":\"rig\"") and contains(".homeboy/bench-rig/rig-workload.php"))] | length) == 1
+    and ([.recipe.workflow.steps[0].args[] | select(startswith("workloads-json=") and contains("\"source\":\"rig\"") and contains("\"overridesDiscovered\":true") and contains(".homeboy/bench-rig/rig-workload.php"))] | length) == 1
     and ([.recipe.workflow.steps[0].args[] | select(startswith("scenario-ids-json=") and contains("rig-workload"))] | length) == 1
 ' "$SELECTED_CAPTURE_FILE" >/dev/null
 
@@ -328,7 +328,7 @@ bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
 jq -e '
     .recipe.inputs.extraPlugins[0].pluginFile == "wp-site-generator/plugin-main.php"
     and (.recipe.inputs.mounts[] | select(.source | endswith("/rig-workloads/rig-workload.php") and .target == "/wordpress/wp-content/plugins/wp-site-generator/.homeboy/bench-rig/rig-workload.php"))
-    and ([.recipe.workflow.steps[0].args[] | select(startswith("workloads-json=") and contains("\"source\":\"rig\"") and contains(".homeboy/bench-rig/rig-workload.php"))] | length) == 1
+    and ([.recipe.workflow.steps[0].args[] | select(startswith("workloads-json=") and contains("\"source\":\"rig\"") and contains("\"overridesDiscovered\":true") and contains(".homeboy/bench-rig/rig-workload.php"))] | length) == 1
     and ([.recipe.workflow.steps[0].args[] | select(startswith("scenario-ids-json=") and contains("rig-workload"))] | length) == 1
 ' "$PLUGIN_DUPLICATE_CAPTURE_FILE" >/dev/null
 jq -e '

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -433,7 +433,7 @@ homeboy_wp_codebox_append_extra_bench_workloads_configured_json() {
             --argjson workloads "$WP_CODEBOX_WORKLOADS_JSON" \
             --arg id "$scenario_id" \
             --arg file ".homeboy/bench-rig/${workload_name}" \
-            '$workloads + [{id: $id, source: "rig", run: [{type: "php", file: $file}], metadata: {homeboy_bench_workload_source: "rig"}}]')
+            '$workloads + [{id: $id, source: "rig", overridesDiscovered: true, run: [{type: "php", file: $file}], metadata: {homeboy_bench_workload_source: "rig"}}]')
     done
 }
 


### PR DESCRIPTION
## Summary
- Set WP Codebox's generic `overridesDiscovered: true` flag on rig-provided bench workloads.
- Keep `source: \"rig\"` as Homeboy provenance only; WP Codebox uses the generic override flag for execution behavior.
- Update static-source smoke assertions to prove the generated recipe includes the override flag for selected rig workloads.

Follow-up for #1266 after #1269 merged before the generic override contract adjustment.

Depends on WP Codebox PR: https://github.com/Automattic/wp-codebox/pull/881

## Tests
- `bash -n scripts/bench/bench-runner-wp-codebox.sh scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- `bash scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- `node tests/wp-codebox-bench-recipe-builder-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Added the Homeboy Extensions side of WP Codebox's generic explicit workload override contract and ran targeted validation. Chris remains responsible for review and merge.