### PR TITLE
Use WP Codebox runner workspace preparation

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -837,13 +837,12 @@ jobs:
           runner_workspace_json="$(validate_json_input runner_workspace object "$RUNNER_WORKSPACE_CONFIG")"
           runner_workspace_repo="${TARGET_REPO#*/}"
           runner_workspace_repo="${runner_workspace_repo%.git}"
-          datamachine_workspace_guest_root="/homeboy-datamachine-workspace"
-          datamachine_workspace_guest_primary="${datamachine_workspace_guest_root}/${runner_workspace_repo}"
+          runner_workspace_guest_root="/homeboy-runner-workspace"
+          runner_workspace_guest_checkout="${runner_workspace_guest_root}/${runner_workspace_repo}"
           runner_workspace_mounts_json="[]"
           if jq -e '.enabled == true' <<< "$runner_workspace_json" >/dev/null; then
-            runner_workspace_mounts_json="$(jq -nc --arg source "$GITHUB_WORKSPACE" --arg target "$datamachine_workspace_guest_primary" '[{type: "directory", source: $source, target: $target, mode: "readwrite"}]')"
-            runner_workspace_json="$(jq -c --arg seed "$datamachine_workspace_guest_primary" '. + {local_seed_path: $seed}' <<< "$runner_workspace_json")"
-            extra_wp_config_defines_json="$(jq -c --arg root "$datamachine_workspace_guest_root" '. + {DATAMACHINE_WORKSPACE_PATH: $root}' <<< "$extra_wp_config_defines_json")"
+            runner_workspace_mounts_json="$(jq -nc --arg source "$GITHUB_WORKSPACE" --arg target "$runner_workspace_guest_checkout" '[{type: "directory", source: $source, target: $target, mode: "readwrite"}]')"
+            runner_workspace_json="$(jq -c --arg checkout "$runner_workspace_guest_checkout" '. + {checkout_path: $checkout}' <<< "$runner_workspace_json")"
           fi
           rules_json="$(validate_json_input rules object "$RULES")"
           general_rules_json="$(validate_json_input general_rules array "$GENERAL_RULES")"

--- a/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php
@@ -74,9 +74,10 @@ namespace {
 
                 public function execute( array $args ): array {
                     $GLOBALS['homeboy_forced_parameters_args'] = $args;
-                    if ( 'datamachine-code/workspace-worktree-add' === $this->ability_name ) {
+                    if ( 'wp-codebox/prepare-runner-workspace' === $this->ability_name ) {
                         return array(
                             'success' => true,
+                            'backend' => 'datamachine-code',
                             'handle'  => $args['repo'] . '@' . str_replace( '/', '-', (string) $args['branch'] ),
                             'branch'  => (string) $args['branch'],
                             'path'    => '/tmp/' . $args['repo'],
@@ -403,6 +404,7 @@ namespace {
                 'branch'        => 'agent/iterator-repair',
                 'allow_stale'   => true,
                 'rebase_base'   => true,
+                'checkout_path' => '/github/workspace/html-to-blocks-converter',
                 'clone_url'     => 'https://github.com/chubes4/html-to-blocks-converter.git',
             ),
         )
@@ -413,16 +415,21 @@ namespace {
         exit( 1 );
     }
 
-    foreach ( array( 'datamachine-code/workspace-show', 'datamachine-code/workspace-clone', 'datamachine-code/workspace-worktree-add' ) as $expected_ability ) {
+    foreach ( array( 'wp-codebox/prepare-runner-workspace' ) as $expected_ability ) {
         if ( ! in_array( $expected_ability, $GLOBALS['homeboy_forced_parameters_ability_names'], true ) ) {
             fwrite( STDERR, "Expected runner workspace provisioning to resolve {$expected_ability}.\n" );
             exit( 1 );
         }
     }
 
+    if ( 'wp-codebox/runner-workspace-prepare-request/v1' !== ( $GLOBALS['homeboy_forced_parameters_args']['schema'] ?? null ) || '/github/workspace/html-to-blocks-converter' !== ( $GLOBALS['homeboy_forced_parameters_args']['checkout_path'] ?? null ) ) {
+        fwrite( STDERR, "Expected runner workspace provisioning to call the WP Codebox preparation API with the mounted checkout path.\n" );
+        exit( 1 );
+    }
+
     foreach ( $GLOBALS['homeboy_forced_parameters_ability_names'] as $ability_name ) {
-        if ( str_starts_with( $ability_name, 'datamachine/workspace-' ) ) {
-            fwrite( STDERR, "Runner workspace provisioning used stale workspace ability namespace.\n" );
+        if ( str_starts_with( $ability_name, 'datamachine-code/workspace-' ) || str_starts_with( $ability_name, 'datamachine/workspace-' ) ) {
+            fwrite( STDERR, "Runner workspace provisioning used direct backend workspace ability namespace.\n" );
             exit( 1 );
         }
     }

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -2585,104 +2585,56 @@ if ( ! function_exists( 'homeboy_datamachine_agent_provision_workspace' ) ) {
             $repo = basename( $repo );
         }
         $repo = preg_replace( '/\.git$/', '', $repo ) ?? $repo;
-        if ( '' === $repo ) {
-            return array( 'enabled' => true, 'success' => false, 'error' => 'runner_workspace.repo is required' );
-        }
+		if ( '' === $repo ) {
+			return array( 'enabled' => true, 'success' => false, 'error' => 'runner_workspace.repo is required' );
+		}
 
-		$required = array(
-			'datamachine-code/workspace-show',
-			'datamachine-code/workspace-clone',
-			'datamachine-code/workspace-worktree-add',
+		$branch = isset( $workspace['branch'] ) && is_scalar( $workspace['branch'] ) ? trim( (string) $workspace['branch'] ) : '';
+		if ( '' === $branch ) {
+			$prefix = isset( $workspace['branch_prefix'] ) && is_scalar( $workspace['branch_prefix'] ) ? trim( (string) $workspace['branch_prefix'] ) : 'agent-run';
+			$seed   = homeboy_datamachine_agent_slug( homeboy_datamachine_agent_scalar( $config, 'workload_id', 'datamachine-agent' ) );
+			$branch = rtrim( $prefix, '/' ) . '/' . gmdate( 'Y-m-d-His' ) . ( '' !== $seed ? '-' . $seed : '' );
+		}
+
+		$ability_name = 'wp-codebox/prepare-runner-workspace';
+		$ability      = wp_get_ability( $ability_name );
+		if ( ! $ability || ! is_callable( array( $ability, 'execute' ) ) ) {
+			return array( 'enabled' => true, 'success' => false, 'error' => $ability_name . ' is not registered' );
+		}
+
+		$input = array(
+			'schema'                  => 'wp-codebox/runner-workspace-prepare-request/v1',
+			'repo'                    => $repo,
+			'target_repo'             => isset( $workspace['repo'] ) && is_scalar( $workspace['repo'] ) ? trim( (string) $workspace['repo'] ) : $repo,
+			'checkout_path'           => isset( $workspace['checkout_path'] ) && is_scalar( $workspace['checkout_path'] ) ? trim( (string) $workspace['checkout_path'] ) : '',
+			'clone_url'               => isset( $workspace['clone_url'] ) && is_scalar( $workspace['clone_url'] ) ? trim( (string) $workspace['clone_url'] ) : '',
+			'branch'                  => $branch,
+			'from'                    => isset( $workspace['from'] ) && is_scalar( $workspace['from'] ) ? trim( (string) $workspace['from'] ) : 'origin/HEAD',
+			'runner_workspace_config' => $workspace,
+			'github_token_env'        => homeboy_datamachine_agent_scalar( $config, 'github_token_env', 'GITHUB_TOKEN' ),
+			'workload_id'             => homeboy_datamachine_agent_scalar( $config, 'workload_id', 'datamachine-agent' ),
 		);
-		$local_seed_path = isset( $workspace['local_seed_path'] ) && is_scalar( $workspace['local_seed_path'] ) ? trim( (string) $workspace['local_seed_path'] ) : '';
-		if ( '' !== $local_seed_path ) {
-			$required[] = 'datamachine-code/workspace-adopt';
-		}
-		foreach ( $required as $ability_name ) {
-			if ( ! wp_get_ability( $ability_name ) ) {
-				return array( 'enabled' => true, 'success' => false, 'error' => $ability_name . ' is not registered' );
-			}
-		}
 
-		if ( '' !== $local_seed_path ) {
-			$adopt = wp_get_ability( 'datamachine-code/workspace-adopt' )->execute(
-				array(
-					'path' => $local_seed_path,
-					'name' => $repo,
-				)
-			);
-			if ( function_exists( 'is_wp_error' ) && is_wp_error( $adopt ) ) {
-				return array( 'enabled' => true, 'success' => false, 'error' => $adopt->get_error_message(), 'local_seed_path' => $local_seed_path );
-			}
-			if ( ! is_array( $adopt ) || empty( $adopt['success'] ) ) {
-				return array( 'enabled' => true, 'success' => false, 'error' => 'workspace-adopt did not succeed', 'local_seed_path' => $local_seed_path, 'result' => $adopt );
-			}
+		$prepared = $ability->execute( array_filter( $input, static fn( $value ) => '' !== $value && array() !== $value ) );
+		if ( function_exists( 'is_wp_error' ) && is_wp_error( $prepared ) ) {
+			return array( 'enabled' => true, 'success' => false, 'error' => $prepared->get_error_message(), 'input' => $input );
+		}
+		if ( ! is_array( $prepared ) || empty( $prepared['success'] ) ) {
+			return array( 'enabled' => true, 'success' => false, 'error' => is_array( $prepared['error'] ?? null ) ? (string) ( $prepared['error']['message'] ?? 'prepare-runner-workspace did not succeed' ) : 'prepare-runner-workspace did not succeed', 'input' => $input, 'result' => $prepared );
 		}
 
-		$show = wp_get_ability( 'datamachine-code/workspace-show' )->execute( array( 'name' => $repo ) );
-        if ( function_exists( 'is_wp_error' ) && is_wp_error( $show ) ) {
-            $clone_url = isset( $workspace['clone_url'] ) && is_scalar( $workspace['clone_url'] ) ? trim( (string) $workspace['clone_url'] ) : '';
-            if ( '' === $clone_url ) {
-                return array( 'enabled' => true, 'success' => false, 'error' => 'workspace primary missing and runner_workspace.clone_url is empty' );
-            }
-
-            $clone_input = array(
-                'url'  => $clone_url,
-                'name' => $repo,
-            );
-            $github_token_env = homeboy_datamachine_agent_scalar( $config, 'github_token_env', 'GITHUB_TOKEN' );
-            if ( '' !== $github_token_env && '' !== trim( (string) getenv( $github_token_env ) ) && preg_match( '#^https://github\.com/#', $clone_url ) ) {
-                $clone_input['auth_token_env'] = $github_token_env;
-            }
-
-            $clone = wp_get_ability( 'datamachine-code/workspace-clone' )->execute(
-                array_filter(
-                    $clone_input,
-                    static fn( $value ) => '' !== $value
-                )
-            );
-            if ( function_exists( 'is_wp_error' ) && is_wp_error( $clone ) ) {
-                return array( 'enabled' => true, 'success' => false, 'error' => $clone->get_error_message() );
-            }
-        }
-
-        $branch = isset( $workspace['branch'] ) && is_scalar( $workspace['branch'] ) ? trim( (string) $workspace['branch'] ) : '';
-        if ( '' === $branch ) {
-            $prefix = isset( $workspace['branch_prefix'] ) && is_scalar( $workspace['branch_prefix'] ) ? trim( (string) $workspace['branch_prefix'] ) : 'agent-run';
-            $seed   = homeboy_datamachine_agent_slug( homeboy_datamachine_agent_scalar( $config, 'workload_id', 'datamachine-agent' ) );
-            $branch = rtrim( $prefix, '/' ) . '/' . gmdate( 'Y-m-d-His' ) . ( '' !== $seed ? '-' . $seed : '' );
-        }
-
-        $input = array(
-            'repo'           => $repo,
-            'branch'         => $branch,
-            'from'           => isset( $workspace['from'] ) && is_scalar( $workspace['from'] ) ? trim( (string) $workspace['from'] ) : 'origin/HEAD',
-            'inject_context' => homeboy_datamachine_agent_bool_config( $workspace, 'inject_context', true ),
-            'bootstrap'      => homeboy_datamachine_agent_bool_config( $workspace, 'bootstrap', true ),
-            'allow_stale'    => homeboy_datamachine_agent_bool_config( $workspace, 'allow_stale', false ),
-            'rebase_base'    => homeboy_datamachine_agent_bool_config( $workspace, 'rebase_base', false ),
-            'force'          => homeboy_datamachine_agent_bool_config( $workspace, 'force', false ),
-        );
-
-        $worktree = wp_get_ability( 'datamachine-code/workspace-worktree-add' )->execute( $input );
-        if ( function_exists( 'is_wp_error' ) && is_wp_error( $worktree ) ) {
-            return array( 'enabled' => true, 'success' => false, 'error' => $worktree->get_error_message(), 'input' => $input );
-        }
-        if ( ! is_array( $worktree ) || empty( $worktree['success'] ) ) {
-            return array( 'enabled' => true, 'success' => false, 'error' => 'workspace-worktree-add did not succeed', 'input' => $input, 'result' => $worktree );
-        }
-
-        return array(
-            'enabled' => true,
-            'success' => true,
-            'repo'    => $repo,
-            'branch'  => (string) ( $worktree['branch'] ?? $branch ),
-            'handle'  => (string) ( $worktree['handle'] ?? '' ),
-            'path'    => (string) ( $worktree['path'] ?? '' ),
-            'input'   => $input,
-            'result'  => $worktree,
-        );
-    }
+		return array(
+			'enabled' => true,
+			'success' => true,
+			'repo'    => $repo,
+			'branch'  => (string) ( $prepared['branch'] ?? $branch ),
+			'handle'  => (string) ( $prepared['handle'] ?? '' ),
+			'path'    => (string) ( $prepared['path'] ?? '' ),
+			'backend' => (string) ( $prepared['backend'] ?? '' ),
+			'input'   => $input,
+			'result'  => $prepared,
+		);
+	}
 }
 
 if ( ! function_exists( 'homeboy_datamachine_agent_apply_runner_workspace' ) ) {


### PR DESCRIPTION
## Summary
- Updates the Data Machine agent CI runner to call `wp-codebox/prepare-runner-workspace` instead of preparing DMC workspaces directly.
- Mounts the Actions checkout at a generic runner path and passes `checkout_path` in runner workspace config.
- Removes Homeboy's direct `DATAMACHINE_WORKSPACE_PATH`, `local_seed_path`, and DMC workspace adopt/worktree coupling from runner preparation.

Depends on https://github.com/Automattic/wp-codebox/pull/883
Related to https://github.com/Automattic/wp-codebox/issues/882

## Testing
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php && php -l wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php && php wordpress/scripts/agent/datamachine-agent-forced-parameters-smoke.php` passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the WP Codebox preparation integration, smoke updates, and PR description; Chris remains responsible for review and merge.