### PR TITLE
Mount runner checkouts under WP Codebox workspace

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -837,7 +837,7 @@ jobs:
           runner_workspace_json="$(validate_json_input runner_workspace object "$RUNNER_WORKSPACE_CONFIG")"
           runner_workspace_repo="${TARGET_REPO#*/}"
           runner_workspace_repo="${runner_workspace_repo%.git}"
-          runner_workspace_guest_root="/homeboy-runner-workspace"
+          runner_workspace_guest_root="/workspace"
           runner_workspace_guest_checkout="${runner_workspace_guest_root}/${runner_workspace_repo}"
           runner_workspace_mounts_json="[]"
           if jq -e '.enabled == true' <<< "$runner_workspace_json" >/dev/null; then


### PR DESCRIPTION
## Summary
- Mount the Actions checkout under WP Codebox's sandbox workspace root (`/workspace`) before calling `wp-codebox/prepare-runner-workspace`.
- Keeps the checkout path inside the workspace root that WP Codebox defines for DMC during agent sandbox boot, so backend adoption succeeds without Homeboy setting DMC-specific constants.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/datamachine-agent-ci.yml"); puts "workflow yaml ok"'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runner workspace adoption failure after PR #1274 and drafted the minimal workflow mount-path fix; Chris remains responsible for review and merge.