### PR TITLE
Filter selected WP Codebox bench discovery results

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
@@ -267,6 +267,27 @@ jq -e '
     and (.scenarios[] | select(.id == "manifest-navigation" and .source == "scenario-manifest"))
 ' "$LIST_RESULTS_FILE" >/dev/null
 
+SELECTED_LIST_RESULTS_FILE="${TMP_ROOT}/bench-list-selected-results.json"
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \
+HOMEBOY_RUNTIME_BENCH_HELPER_SH="$BENCH_HELPER" \
+HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+HOMEBOY_SMOKE_SOURCE_ROOT="$SOURCE_ROOT" \
+HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
+HOMEBOY_BENCH_EXTRA_WORKLOADS="$EXTRA_WORKLOAD" \
+HOMEBOY_BENCH_SCENARIOS="rig-workload" \
+HOMEBOY_BENCH_RESULTS_FILE="$SELECTED_LIST_RESULTS_FILE" \
+HOMEBOY_RUNTIME_FAILURE_TRAP="" \
+HOMEBOY_BENCH_LIST_ONLY=1 \
+bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
+
+jq -e '
+    .component_id == "wp-site-generator"
+    and .iterations == 0
+    and (.scenarios | length == 1)
+    and (.scenarios[0].id == "rig-workload")
+    and (.scenarios[0].source == "rig")
+' "$SELECTED_LIST_RESULTS_FILE" >/dev/null
+
 PLUGIN_ROOT="${TMP_ROOT}/plugin-component"
 mkdir -p "$PLUGIN_ROOT/scenarios"
 printf '<?php\n/**\n * Plugin Name: Fixture Component\n */\n' > "${PLUGIN_ROOT}/plugin-main.php"

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -387,6 +387,22 @@ homeboy_wp_codebox_workload_scenario_id() {
     printf '%s\n' "$scenario_id"
 }
 
+homeboy_wp_codebox_selected_scenarios_json() {
+    local selected_value="${HOMEBOY_BENCH_SCENARIOS:-}"
+    if [ -z "$selected_value" ]; then
+        printf '{}\n'
+        return 0
+    fi
+
+    jq -Rnc '
+        input
+        | split(",")
+        | map(gsub("^\\s+|\\s+$"; ""))
+        | map(select(. != ""))
+        | reduce .[] as $id ({}; .[$id] = true)
+    ' <<< "$selected_value"
+}
+
 homeboy_wp_codebox_filter_extra_bench_workloads() {
     local workloads_value="${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}"
     local selected_value="${HOMEBOY_BENCH_SCENARIOS:-}"
@@ -893,11 +909,14 @@ if [ "${HOMEBOY_BENCH_LIST_ONLY:-}" = "1" ]; then
     mkdir -p "$(dirname "$RESULTS_FILE")"
     jq -n \
         --arg component "$COMPONENT_ID" \
+        --argjson selectedScenarios "$(homeboy_wp_codebox_selected_scenarios_json)" \
         --argjson componentScenarios "$(homeboy_wp_codebox_component_workload_scenarios_json)" \
         --argjson extraScenarios "$(homeboy_wp_codebox_extra_workload_scenarios_json)" \
         --argjson configuredScenarios "$(homeboy_wp_codebox_configured_workload_scenarios_json "$WP_CODEBOX_WORKLOADS_JSON")" \
         '$componentScenarios + $extraScenarios + $configuredScenarios as $scenarios |
-        {component_id: $component, iterations: 0, scenarios: $scenarios}' > "$RESULTS_FILE"
+        $scenarios
+        | map(select(($selectedScenarios | length) == 0 or ($selectedScenarios[.id] == true)))
+        | {component_id: $component, iterations: 0, scenarios: .}' > "$RESULTS_FILE"
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
- Filters WP Codebox runner list-only bench results by `HOMEBOY_BENCH_SCENARIOS` before writing `bench-results.json`.
- Keeps unselected component/configured workloads out of selected discovery output, including unrelated duplicate scenario IDs.
- Adds smoke coverage for selected list-only discovery returning only the selected rig workload.

## Tests
- `bash wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`

## Context
Extra-Chill/homeboy#4066 ensures Homeboy passes selected scenario IDs into extension-backed discovery. The WP Codebox runner still had a separate list-only path that generated discovery JSON directly from component, rig, and configured workload declarations without applying `HOMEBOY_BENCH_SCENARIOS`. That allowed unrelated duplicate `checkout-concurrent-create-order` entries to reach Homeboy parsing during a targeted `rest-product-batch-import` run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Traced the remaining list-only discovery output path, drafted the shell filtering fix and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.

Fixes #1266