### PR TITLE
Keep runner dependencies out of workspace capture

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php
@@ -138,5 +138,10 @@ namespace {
         exit( 1 );
     }
 
+    if ( ! homeboy_datamachine_agent_job_status_terminal( 'failed - tool_result_failed' ) ) {
+        fwrite( STDERR, "Expected Data Machine failed sub-statuses to be treated as terminal.\n" );
+        exit( 1 );
+    }
+
     fwrite( STDOUT, "Data Machine agent terminal state smoke passed.\n" );
 }

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -2023,6 +2023,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_capture_runner_workspace' ) )
                 'handle'           => $handle,
                 'repo'             => homeboy_datamachine_agent_scalar( $config, 'target_repo' ),
                 'runner_workspace' => $runner_workspace,
+                'exclude_paths'    => array( '.ci/**' ),
             )
         );
         if ( empty( $capture['success'] ) ) {
@@ -2856,7 +2857,8 @@ if ( ! function_exists( 'homeboy_datamachine_agent_export_transcript' ) ) {
 
 if ( ! function_exists( 'homeboy_datamachine_agent_job_status_terminal' ) ) {
     function homeboy_datamachine_agent_job_status_terminal( string $job_status ): bool {
-        return in_array( $job_status, array( 'completed', 'failed', 'cancelled' ), true );
+        $status = trim( $job_status );
+        return in_array( $status, array( 'completed', 'failed', 'cancelled' ), true ) || str_starts_with( $status, 'failed ' ) || str_starts_with( $status, 'cancelled ' );
     }
 
     function homeboy_datamachine_agent_job_terminal_error( int $job_id, string $job_status, string $label = 'Data Machine job' ): string {

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -381,6 +381,10 @@ namespace {
         fwrite( STDERR, "Expected runner workspace capture to use the WP Codebox capture API once.\n" );
         exit( 1 );
     }
+    if ( array( '.ci/**' ) !== ( $runner_capture_calls[0]['input']['exclude_paths'] ?? array() ) ) {
+        fwrite( STDERR, "Expected runner workspace capture to exclude runner dependency checkouts.\n" );
+        exit( 1 );
+    }
 
     $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array();
     $unavailable_publication = homeboy_datamachine_agent_publish_runner_workspace(


### PR DESCRIPTION
## Summary
- Treat Data Machine failed sub-statuses such as `failed - tool_result_failed` as terminal so the runner reports the real failure immediately.
- Pass `.ci/**` as an excluded capture path to `wp-codebox/capture-runner-workspace`, keeping runtime dependency checkouts out of target repo publication evidence.
- Add smoke coverage for terminal sub-statuses and runner dependency capture exclusions.

## Upstream dependency
- Depends on WP Codebox capture exclusion support: https://github.com/Automattic/wp-codebox/pull/887

## Verification
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Data Machine terminal-state and runner capture-boundary issues, drafted the runner changes and smoke coverage, and ran local verification; Chris remains responsible for review and merge.