### PR TITLE
Exclude runner dependencies from artifact capture

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -841,7 +841,7 @@ jobs:
           runner_workspace_guest_checkout="${runner_workspace_guest_root}/${runner_workspace_repo}"
           runner_workspace_mounts_json="[]"
           if jq -e '.enabled == true' <<< "$runner_workspace_json" >/dev/null; then
-            runner_workspace_mounts_json="$(jq -nc --arg source "$GITHUB_WORKSPACE" --arg target "$runner_workspace_guest_checkout" '[{type: "directory", source: $source, target: $target, mode: "readwrite"}]')"
+            runner_workspace_mounts_json="$(jq -nc --arg source "$GITHUB_WORKSPACE" --arg target "$runner_workspace_guest_checkout" '[{type: "directory", source: $source, target: $target, mode: "readwrite", metadata: {kind: "runner-workspace", artifactExcludePaths: [".ci/**"]}}]')"
             runner_workspace_json="$(jq -c --arg checkout "$runner_workspace_guest_checkout" '. + {checkout_path: $checkout}' <<< "$runner_workspace_json")"
           fi
           rules_json="$(validate_json_input rules object "$RULES")"


### PR DESCRIPTION
## Summary
- Mark the runner workspace mount with `metadata.artifactExcludePaths: [".ci/**"]`.
- Keeps runtime dependency checkouts out of WP Codebox artifact bundle changed-files and patches.

## Upstream dependency
- Depends on WP Codebox per-mount artifact exclusions: https://github.com/Automattic/wp-codebox/pull/888

## Verification
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runner dependency artifact-capture leak, wired Homeboy to the explicit WP Codebox mount exclusion contract, and ran local verification; Chris remains responsible for review and merge.