### PR TITLE
Honor WP Codebox bench overrides in list discovery

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
@@ -261,8 +261,10 @@ bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
 jq -e '
     .component_id == "wp-site-generator"
     and .iterations == 0
+    and (.scenarios | length == 4)
     and (.scenarios[] | select(.id == "website-generation" and .file == "tests/bench/website-generation.php" and .source == "component"))
     and (.scenarios[] | select(.id == "rig-workload" and .file == "tests/bench/rig-workload.php" and .source == "rig"))
+    and ([.scenarios[] | select(.id == "rig-workload")] | length == 1)
     and (.scenarios[] | select(.id == "ssi-import" and .source == "configured"))
     and (.scenarios[] | select(.id == "manifest-navigation" and .source == "scenario-manifest"))
 ' "$LIST_RESULTS_FILE" >/dev/null

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -503,6 +503,7 @@ homeboy_wp_codebox_configured_workload_scenarios_json() {
     printf '%s' "$workloads_json" | jq -c '
         if type == "array" then . else [] end
         | map(select((.id? | type) == "string" and .id != ""))
+        | map(select((.metadata? // {}).homeboy_bench_workload_source != "rig"))
         | map(
             {
                 id: .id,
@@ -512,6 +513,15 @@ homeboy_wp_codebox_configured_workload_scenarios_json() {
             }
             + (if (.label? | type) == "string" and .label != "" then {label: .label} else {} end)
         )
+    '
+}
+
+homeboy_wp_codebox_configured_override_scenario_ids_json() {
+    local workloads_json="$1"
+    printf '%s' "$workloads_json" | jq -c '
+        if type == "array" then . else [] end
+        | map(select((.id? | type) == "string" and .id != "" and .overridesDiscovered == true))
+        | reduce .[] as $workload ({}; .[$workload.id] = true)
     '
 }
 
@@ -910,10 +920,12 @@ if [ "${HOMEBOY_BENCH_LIST_ONLY:-}" = "1" ]; then
     jq -n \
         --arg component "$COMPONENT_ID" \
         --argjson selectedScenarios "$(homeboy_wp_codebox_selected_scenarios_json)" \
+        --argjson overrideScenarios "$(homeboy_wp_codebox_configured_override_scenario_ids_json "$WP_CODEBOX_WORKLOADS_JSON")" \
         --argjson componentScenarios "$(homeboy_wp_codebox_component_workload_scenarios_json)" \
         --argjson extraScenarios "$(homeboy_wp_codebox_extra_workload_scenarios_json)" \
         --argjson configuredScenarios "$(homeboy_wp_codebox_configured_workload_scenarios_json "$WP_CODEBOX_WORKLOADS_JSON")" \
-        '$componentScenarios + $extraScenarios + $configuredScenarios as $scenarios |
+        '($componentScenarios | map(select($overrideScenarios[.id] != true)))
+        + $extraScenarios + $configuredScenarios as $scenarios |
         $scenarios
         | map(select(($selectedScenarios | length) == 0 or ($selectedScenarios[.id] == true)))
         | {component_id: $component, iterations: 0, scenarios: .}' > "$RESULTS_FILE"


### PR DESCRIPTION
## Summary
- Applies `overridesDiscovered` semantics to the WP Codebox runner's direct list-only discovery JSON.
- Skips Homeboy rig extra workloads when projecting generic configured workload scenarios, avoiding duplicate rig/configured rows for the same ID.
- Tightens static-source smoke coverage so selected list-only discovery emits a single rig workload and unfiltered discovery has no duplicate rig workload rows.

## Tests
- `bash wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- `git diff --check`

## Context
After #1276, selected discovery was scoped correctly, but runner-side `homeboy bench list --scenario rest-product-batch-import` still failed because list-only JSON contained two selected scenarios: the in-tree workload and the rig override. Homeboy rejected the duplicate selected ID before execution.

The direct runner-side repro was:

```sh
homeboy runner exec homeboy-lab -- /home/chubes/.cargo/bin/homeboy --force-hot bench list --rig woocommerce-performance --scenario rest-product-batch-import --path /home/chubes/Developer/woocommerce-pr65595/plugins/woocommerce
```

It failed with duplicate `rest-product-batch-import` from `tests/bench/rest-product-batch-import.php` and `<unknown>`, proving the remaining issue is selected override discovery, not unrelated scenario filtering.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Ran the runner-side list-only repro, identified the missing list-only override semantics, drafted the fix and smoke assertions, and ran targeted verification. Chris remains responsible for review and merge.

Fixes #1266