### PR TITLE
Preserve WP Codebox mount metadata

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
+++ b/wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh
@@ -115,6 +115,9 @@ if (!recipe.inputs?.mounts?.some((mount) => mount.type === 'file' && mount.sourc
 if (!recipe.inputs?.mounts?.some((mount) => mount.type === 'directory' && mount.source.endsWith('/fixture-directory-mount') && mount.target === '/wordpress/wp-content/plugins/example/fixtures' && mount.mode === 'readwrite')) {
   throw new Error('missing typed directory mount in recipe')
 }
+if (!recipe.inputs?.mounts?.some((mount) => mount.source.endsWith('/fixture-directory-mount') && JSON.stringify(mount.metadata?.artifactExcludePaths ?? []) === JSON.stringify(['.ci/**']))) {
+  throw new Error('missing typed directory mount artifact exclusion metadata in recipe')
+}
 
 const artifactRoot = path.join(valueAfter('--artifacts'), 'runtime-smoke')
 const filesRoot = path.join(artifactRoot, 'files')
@@ -279,7 +282,7 @@ jq -n \
         },
         wp_codebox_mounts: [
             {type: "file", source: $fileMount, target: "/wordpress/wp-content/plugins/example/fixture-config.json", mode: "readonly"},
-            ($dirMount + ":/wordpress/wp-content/plugins/example/fixtures:readwrite")
+            {type: "directory", source: $dirMount, target: "/wordpress/wp-content/plugins/example/fixtures", mode: "readwrite", metadata: {artifactExcludePaths: [".ci/**"]}}
         ]
     }' > "$CONFIG_TMPFILE"
 

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -81,6 +81,11 @@ homeboy_datamachine_agent_add_wp_codebox_mount() {
     local target="${2:-}"
     local mode="${3:-readwrite}"
     local type="${4:-}"
+    local metadata="{}"
+
+    if [ "$#" -ge 5 ]; then
+        metadata="$5"
+    fi
 
     if [ -z "$source" ] || [ -z "$target" ]; then
         return 0
@@ -102,7 +107,8 @@ homeboy_datamachine_agent_add_wp_codebox_mount() {
         --arg source "$source" \
         --arg target "$target" \
         --arg mode "$mode" \
-        '$mounts + [{type: $type, source: $source, target: $target, mode: $mode}]')
+        --arg metadata "$metadata" \
+        '($metadata | fromjson? | select(type == "object") // {}) as $mountMetadata | $mounts + [({type: $type, source: $source, target: $target, mode: $mode} + (if $mountMetadata == {} then {} else {metadata: $mountMetadata} end))]')
 }
 
 homeboy_datamachine_agent_wp_codebox_run() {
@@ -196,7 +202,8 @@ PHP
         mount_target=$(jq -r '.target // .to // empty' <<<"$extra_mount")
         mount_mode=$(jq -r '.mode // "readwrite"' <<<"$extra_mount")
         mount_type=$(jq -r '.type // empty' <<<"$extra_mount")
-        homeboy_datamachine_agent_add_wp_codebox_mount "$mount_source" "$mount_target" "$mount_mode" "$mount_type"
+        mount_metadata=$(jq -c '.metadata // {}' <<<"$extra_mount")
+        homeboy_datamachine_agent_add_wp_codebox_mount "$mount_source" "$mount_target" "$mount_mode" "$mount_type" "$mount_metadata"
     done < <(jq -c '.wp_codebox_mounts? // [] | .[]?' <<<"$CONFIG_JSON")
 
     local provider_plugin_path provider_slug


### PR DESCRIPTION
## Summary
- Preserve object-style `wp_codebox_mounts[*].metadata` when building WP Codebox recipes.
- Cover `artifactExcludePaths` propagation in the WP Codebox runner smoke so `.ci/**` exclusions reach mounted artifact capture.

## Verification
- `bash wordpress/scripts/agent/datamachine-agent-wp-codebox-runner-smoke.sh`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `bash -n wordpress/scripts/agent/run-datamachine-agent.sh`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runner metadata propagation bug, drafted the patch and smoke coverage, and ran focused verification. Chris remains responsible for review and merge.