### PR TITLE
Expose terminal engine data in agent results

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php
@@ -143,5 +143,11 @@ namespace {
         exit( 1 );
     }
 
+    $workload_source = file_get_contents( __DIR__ . '/datamachine-agent-workload.php' ) ?: '';
+    if ( ! str_contains( $workload_source, "\$metadata['engine_data'] = \$terminal_engine_data" ) ) {
+        fwrite( STDERR, "Expected terminal failure results to expose final engine_data.\n" );
+        exit( 1 );
+    }
+
     fwrite( STDOUT, "Data Machine agent terminal state smoke passed.\n" );
 }

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -3277,10 +3277,14 @@ $metadata['child_drain_results'] = $child_drain_summary['drain_results'];
 
 $job = $jobs->get_job( $job_id );
 $job_status = is_array( $job ) ? (string) ( $job['status'] ?? '' ) : '';
+$terminal_engine_data = function_exists( 'datamachine_get_engine_data' ) ? datamachine_get_engine_data( $job_id ) : array();
+$terminal_engine_data = homeboy_datamachine_agent_merge_recorded_tool_results( $terminal_engine_data, $config );
+$terminal_engine_data = homeboy_datamachine_agent_merge_child_engine_data( $terminal_engine_data, $child_drain_summary['children'], $config );
 $terminal_error = homeboy_datamachine_agent_job_terminal_error( $job_id, $job_status );
 if ( '' !== $terminal_error ) {
     $metadata['job_id'] = $job_id;
     $metadata['job_status'] = $job_status;
+    $metadata['engine_data'] = $terminal_engine_data;
     return homeboy_datamachine_agent_result(
         array(
             'job_completed' => 0,
@@ -3301,6 +3305,7 @@ foreach ( $child_drain_summary['children'] as $child_job ) {
     if ( '' !== $child_error ) {
         $metadata['job_id'] = $job_id;
         $metadata['job_status'] = $job_status;
+        $metadata['engine_data'] = $terminal_engine_data;
         return homeboy_datamachine_agent_result(
             array(
                 'job_completed' => 1,


### PR DESCRIPTION
## Summary
- Includes final Data Machine `engine_data` in runner metadata before returning terminal job failures.
- Keeps failed tool diagnostics visible to downstream CI artifacts instead of stopping at `failed - tool_result_failed`.

## Testing
- `php wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php && php -l wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the terminal failure metadata patch and smoke coverage; Chris remains responsible for review and testing.