### PR TITLE
Preserve bench artifact viewer metadata

### DIFF
--- a/wordpress/scripts/bench/bench-results-artifacts-smoke.sh
+++ b/wordpress/scripts/bench/bench-results-artifacts-smoke.sh
@@ -61,6 +61,20 @@ cat > "$RESULTS_FILE" <<'JSON'
       },
       "artifacts": {
         "transcript": { "path": "artifacts/transcript.json", "kind": "json" },
+        "blueprint.after": {
+          "path": "artifacts/blueprint.after.json",
+          "kind": "json",
+          "label": "Generated site replay",
+          "viewer": {
+            "kind": "wordpress-playground-blueprint",
+            "base": "https://playground.wordpress.net/",
+            "query": {
+              "parameter": "blueprint-url",
+              "value": { "source": "public-artifact-url" },
+              "encoding": "url"
+            }
+          }
+        },
         "runtime_url": { "path": "https://example.test", "kind": "url" }
       }
     },
@@ -142,9 +156,15 @@ success=$(jq -r "$scenario | .success" "$JSONL_FILE")
 reward=$(jq -r "$scenario | .reward" "$JSONL_FILE")
 duration=$(jq -r "$scenario | .duration_ms" "$JSONL_FILE")
 artifact=$(jq -r "$scenario | .artifacts.transcript.path" "$JSONL_FILE")
+viewer_source=$(jq -r "$scenario | .artifacts[\"blueprint.after\"].viewer.query.value.source" "$JSONL_FILE")
 
 if [ "$provider" != "openai" ] || [ "$model" != "gpt-5.5" ] || [ "$success" != "true" ] || [ "$reward" != "1" ] || [ "$duration" != "1234" ] || [ "$artifact" != "artifacts/transcript.json" ]; then
     echo "ERROR: JSONL row missing expected scenario fields" >&2
+    cat "$JSONL_FILE" >&2
+    exit 1
+fi
+if [ "$viewer_source" != "public-artifact-url" ]; then
+    echo "ERROR: JSONL row did not preserve generated-site viewer metadata" >&2
     cat "$JSONL_FILE" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary
- Add Workflow Bench artifact smoke coverage for generated-site `viewer` metadata.
- Prove HBEX preserves WP Codebox replay metadata in machine-readable bench artifact output so Homeboy can project public viewer URLs into reports.

## Testing
- `bash wordpress/scripts/bench/bench-results-artifacts-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added focused smoke coverage and verified the generic viewer metadata pass-through path; Chris remains responsible for review and validation.