### PR TITLE
Fix Codebox agent-task failure diagnostics

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -1172,10 +1172,63 @@ function codeboxRunSummary(result, options = {}) {
     return null;
   }
   try {
-    return options.normalizeAgentTaskRunResult(result, { exitStatus: options.exitStatus ?? 0 });
+    return enrichFailedCodeboxRunSummary(
+      options.normalizeAgentTaskRunResult(result, { exitStatus: options.exitStatus ?? 0 }),
+      result,
+      options,
+    );
   } catch {
     return null;
   }
+}
+
+function enrichFailedCodeboxRunSummary(runSummary, result = {}, options = {}) {
+  if (!runSummary || typeof runSummary !== 'object' || Array.isArray(runSummary)) {
+    return runSummary;
+  }
+  if (runSummary.status !== 'failed' || codeboxRunSummaryHasActionableRefs(runSummary, result)) {
+    return runSummary;
+  }
+
+  const diagnostic = {
+    class: 'codebox.no_runtime_session',
+    message: 'WP Codebox reported a failed agent task without a run id, runtime id, session id, logs, transcripts, or artifact refs.',
+    data: sanitizePublicMetadata({
+      exit_status: options.exitStatus ?? 0,
+      result_status: result.status,
+      result_schema: result.schema,
+      has_run: !!result.run,
+      has_session: !!result.session,
+    }),
+  };
+
+  return {
+    ...runSummary,
+    diagnostics: [diagnostic, ...(Array.isArray(runSummary.diagnostics) ? runSummary.diagnostics : [])],
+    metadata: {
+      ...(runSummary.metadata && typeof runSummary.metadata === 'object' && !Array.isArray(runSummary.metadata) ? runSummary.metadata : {}),
+      provider_error: {
+        code: 'codebox_no_runtime_session',
+        message: 'WP Codebox failed before reporting a runtime/session or evidence refs.',
+        exit_status: options.exitStatus ?? 0,
+      },
+    },
+  };
+}
+
+function codeboxRunSummaryHasActionableRefs(runSummary, result = {}) {
+  const metadata = runSummary.metadata && typeof runSummary.metadata === 'object' && !Array.isArray(runSummary.metadata) ? runSummary.metadata : {};
+  if ([runSummary.run_id, runSummary.runtime_id, metadata.run_id, metadata.runtime_id, result.run?.runId, result.run?.runtime?.id, result.session?.id].some(Boolean)) {
+    return true;
+  }
+  if (Array.isArray(runSummary.artifacts) && runSummary.artifacts.length > 0) {
+    return true;
+  }
+  if (Array.isArray(runSummary.diagnostics) && runSummary.diagnostics.length > 0) {
+    return true;
+  }
+  const refs = runSummary.refs && typeof runSummary.refs === 'object' && !Array.isArray(runSummary.refs) ? runSummary.refs : {};
+  return Object.values(refs).some((value) => Array.isArray(value) && value.length > 0);
 }
 
 function codeboxRecipeRunSummary(result, options = {}) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -810,6 +810,67 @@ assert.equal(
   true
 );
 
+const emptyRunSummaryOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: false,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'failed',
+}, {
+  normalizeAgentTaskRunResult: () => ({
+    schema: 'wp-codebox/agent-task-run-result/v1',
+    status: 'failed',
+    failure_classification: 'runtime',
+    artifacts: [],
+    diagnostics: [],
+    metadata: {
+      provider_error: {},
+      run_id: '',
+      run_status: '',
+      runtime_id: '',
+      runtime_status: '',
+    },
+    refs: {
+      artifact_bundles: [],
+      changed_files: [],
+      logs: [],
+      patches: [],
+      runtimes: [],
+      transcripts: [],
+    },
+  }),
+  exitStatus: 1,
+});
+assert.equal(emptyRunSummaryOutcome.status, 'failed');
+assert.equal(emptyRunSummaryOutcome.metadata.codebox_run_result.diagnostics[0].class, 'codebox.no_runtime_session');
+assert.equal(emptyRunSummaryOutcome.metadata.codebox_run_result.metadata.provider_error.code, 'codebox_no_runtime_session');
+assert.equal(emptyRunSummaryOutcome.diagnostics[0].class, 'codebox.no_runtime_session');
+
+const runtimeRefRunSummaryOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: false,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'failed',
+}, {
+  normalizeAgentTaskRunResult: () => ({
+    schema: 'wp-codebox/agent-task-run-result/v1',
+    status: 'failed',
+    failure_classification: 'runtime',
+    artifacts: [],
+    diagnostics: [],
+    metadata: {
+      run_id: 'codebox-run-1',
+      runtime_id: 'runtime-1',
+    },
+    refs: {
+      logs: ['homeboy://codebox/runs/codebox-run-1/logs'],
+      transcripts: [],
+      artifact_bundles: [],
+    },
+  }),
+  exitStatus: 1,
+});
+assert.equal(runtimeRefRunSummaryOutcome.metadata.codebox_run_result.metadata.runtime_id, 'runtime-1');
+assert.equal(runtimeRefRunSummaryOutcome.metadata.codebox_run_result.refs.logs[0], 'homeboy://codebox/runs/codebox-run-1/logs');
+assert.equal(runtimeRefRunSummaryOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.no_runtime_session'), false);
+
 const recipeProbeFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',


### PR DESCRIPTION
## Summary
- Enrich failed `wp-codebox/agent-task-run-result/v1` summaries in the WordPress Codebox agent-task provider when the upstream normalizer returns an empty failure shell.
- Add a reviewer-safe `codebox.no_runtime_session` diagnostic and `metadata.provider_error` explaining that no run/runtime/session/log/transcript/artifact refs were reported.
- Preserve existing run/runtime/log refs without adding the synthetic no-runtime diagnostic when actionable evidence is already present.

Fixes Extra-Chill/homeboy#4105.

## Tests
- `node --check lib/codebox-agent-task-executor.js && node --check tests/codebox-agent-task-executor-smoke.js`
- `node tests/codebox-agent-task-executor-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Moving the issue #4105 fix into the WordPress Codebox provider, implementing provider-side diagnostics enrichment, and adding targeted smoke coverage. Chris remains responsible for review and validation.