### PR TITLE
Run pnpm verification through corepack

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -616,9 +616,19 @@ if ( ! function_exists( 'homeboy_datamachine_agent_command_list' ) ) {
 }
 
 if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
+	function homeboy_datamachine_agent_prepare_runner_command( string $command ): string {
+		$trimmed = trim( $command );
+		if ( preg_match( '/^pnpm(\s|$)/', $trimmed ) ) {
+			return 'corepack ' . $trimmed;
+		}
+
+		return $command;
+	}
+
 	function homeboy_datamachine_agent_run_workspace_command( array $runner_workspace, array $command_config, string $key ): array {
 		$ability_name = 'wp-codebox/run-runner-workspace-command';
 		$handle       = isset( $runner_workspace['handle'] ) && is_scalar( $runner_workspace['handle'] ) ? trim( (string) $runner_workspace['handle'] ) : '';
+		$command      = homeboy_datamachine_agent_prepare_runner_command( (string) ( $command_config['command'] ?? '' ) );
 		if ( '' === $handle ) {
 			return array(
 				'success'        => false,
@@ -651,7 +661,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
 				'workspace_path'   => isset( $runner_workspace['path'] ) && is_scalar( $runner_workspace['path'] ) ? (string) $runner_workspace['path'] : '',
 				'workspace_backend' => isset( $runner_workspace['backend'] ) && is_scalar( $runner_workspace['backend'] ) ? (string) $runner_workspace['backend'] : '',
 				'runner_workspace' => $runner_workspace,
-				'command'          => $command_config['command'],
+				'command'          => $command,
 				'description'      => $command_config['description'],
 				'kind'             => $key,
 			)

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -615,6 +615,9 @@ namespace {
                 if ( 'test -f verification.txt' === ( $input['command'] ?? '' ) ) {
                     return array( 'success' => isset( $workspace_files['verification.txt'] ), 'exit_code' => isset( $workspace_files['verification.txt'] ) ? 0 : 1 );
                 }
+				if ( 'corepack pnpm verify' === ( $input['command'] ?? '' ) ) {
+					return array( 'status' => 'completed', 'exit_code' => 0, 'stdout' => 'verified', 'stderr' => '' );
+				}
                 return array( 'success' => false, 'error' => 'Unexpected command.' );
             }
         ),
@@ -637,6 +640,17 @@ namespace {
         fwrite( STDERR, "Expected drift_checks to run after verification through WP Codebox.\n" );
         exit( 1 );
     }
+
+	$pnpm_result = homeboy_datamachine_agent_run_command_checks(
+		array( 'verification_commands' => array( array( 'command' => 'pnpm verify', 'description' => 'Verify generated docs' ) ) ),
+		array( 'handle' => 'repo@branch', 'path' => '/workspace/repo@branch', 'backend' => 'local_git' ),
+		'verification_commands'
+	);
+	$last_command_call = end( $workspace_command_calls );
+	if ( empty( $pnpm_result['success'] ) || 'corepack pnpm verify' !== ( $last_command_call['command'] ?? '' ) || 'pnpm verify' !== ( $pnpm_result['checks'][0]['command'] ?? '' ) ) {
+		fwrite( STDERR, "Expected pnpm verification commands to run through corepack while preserving the reported command.\n" );
+		exit( 1 );
+	}
 
     $GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array();
     $missing_verification_api = homeboy_datamachine_agent_run_command_checks(


### PR DESCRIPTION
## Summary
- Runs runner workspace `pnpm ...` verification commands through `corepack pnpm ...` so package-manager shims do not need to be pre-enabled in the WP Codebox command environment.
- Preserves the original verification command in result metadata while changing only the executed command.

## Testing
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php`
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php && php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner command wrapper and smoke coverage; Chris remains responsible for review and testing.