### PR TITLE
Isolate Codebox agent smoke environment

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -1135,6 +1135,49 @@ function commandFailurePayload(result, artifacts, evidence) {
   }, evidence);
 }
 
+function emptyJsonPayload(payload) {
+  if (!plainObject(payload)) {
+    return false;
+  }
+  return !payload.schema
+    && payload.success !== false
+    && !payload.status
+    && !payload.run
+    && !payload.session
+    && !payload.summary
+    && (!Array.isArray(payload.diagnostics) || payload.diagnostics.length === 0)
+    && (!Array.isArray(payload.artifacts) || payload.artifacts.length === 0)
+    && (!Array.isArray(payload.evidence_refs) || payload.evidence_refs.length === 0);
+}
+
+function emptyJsonPayloadFailure(payload, result, artifacts) {
+  const message = 'WP Codebox agent-task-run returned an empty JSON payload.';
+  return {
+    ...payload,
+    success: false,
+    status: 'failed',
+    summary: message,
+    diagnostics: [
+      ...(Array.isArray(payload.diagnostics) ? payload.diagnostics : []),
+      {
+        class: 'wp-codebox.agent_task_run_empty_json',
+        message,
+        data: {
+          status: result.status,
+          signal: result.signal,
+          artifacts,
+        },
+      },
+    ],
+    metadata: {
+      ...(plainObject(payload.metadata) ? payload.metadata : {}),
+      empty_json_payload: true,
+      status: result.status,
+      signal: result.signal,
+    },
+  };
+}
+
 function runWpCodeboxParentTask(request) {
   const explicitArtifacts = argValue('--artifacts') || request.artifacts_path || '';
   const artifacts = explicitArtifacts || fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-artifacts-'));
@@ -1201,8 +1244,10 @@ function runWpCodeboxParentTask(request) {
   if (result.stdout) {
     try {
       const payload = normalizeAgentTaskRun(input, JSON.parse(result.stdout));
+      const emptyPayload = emptyJsonPayload(payload);
+      const normalizedPayload = emptyPayload ? emptyJsonPayloadFailure(payload, result, artifacts) : payload;
       const payloadFailed = payload.success === false || payload.status === 'failed' || payload.session?.status === 'failed';
-      const payloadEvidence = failureEvidence || (payloadFailed ? preserveWpCodeboxFailureEvidence({
+      const payloadEvidence = failureEvidence || (emptyPayload || payloadFailed ? preserveWpCodeboxFailureEvidence({
         artifacts,
         inputPath,
         result,
@@ -1210,9 +1255,9 @@ function runWpCodeboxParentTask(request) {
         args: resolved.args,
         secretNames: input.secret_env || [],
       }) : null);
-      const enrichedPayload = payloadEvidence ? attachFailureEvidence(payload, payloadEvidence) : payload;
+      const enrichedPayload = payloadEvidence ? attachFailureEvidence(normalizedPayload, payloadEvidence) : normalizedPayload;
       process.stdout.write(`${JSON.stringify(enrichedPayload, null, 2)}\n`);
-      return payload.success === false ? 1 : 0;
+      return normalizedPayload.success === false ? 1 : 0;
     } catch {
       if (failureEvidence) {
         process.stdout.write(`${JSON.stringify(commandFailurePayload(result, artifacts, failureEvidence), null, 2)}\n`);

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -22,6 +22,14 @@ const codexSecretEnv = [
 ];
 const claudeCodeRefreshTokenEnv = 'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN';
 
+function fixtureEnv(overrides = {}) {
+  const env = { ...process.env, ...overrides };
+  if (!Object.hasOwn(overrides, 'HOMEBOY_WP_CODEBOX_CORE_MODULE')) {
+    delete env.HOMEBOY_WP_CODEBOX_CORE_MODULE;
+  }
+  return env;
+}
+
 function writeFixtureTaskRunner(root) {
   const fixture = path.join(root, 'fixture-task-runner.cjs');
   const capture = path.join(root, 'capture.json');
@@ -1246,6 +1254,7 @@ try {
     fixture,
   ], {
     encoding: 'utf8',
+    env: fixtureEnv(),
     input: JSON.stringify({
       ...request,
       task_id: 'missing-model-cli-task-123',
@@ -1275,6 +1284,7 @@ try {
     '/components/agents-api',
   ], {
     encoding: 'utf8',
+    env: fixtureEnv(),
     input: JSON.stringify(request),
   });
   assert.equal(result.status, 0, result.stderr || result.stdout);
@@ -1290,7 +1300,7 @@ try {
   ], {
     encoding: 'utf8',
     input: JSON.stringify(request),
-    env: { ...process.env, HOMEBOY_WP_CODEBOX_CORE_MODULE: fixtureCodeboxCoreModule },
+    env: fixtureEnv({ HOMEBOY_WP_CODEBOX_CORE_MODULE: fixtureCodeboxCoreModule }),
   });
   assert.equal(normalizedResult.status, 0, normalizedResult.stderr || normalizedResult.stdout);
   const normalizedOutcome = JSON.parse(normalizedResult.stdout);
@@ -1315,6 +1325,7 @@ try {
     fixture,
   ], {
     encoding: 'utf8',
+    env: fixtureEnv(),
     input: JSON.stringify({
       ...request,
       task_id: 'recipe-cli-task-123',
@@ -1354,7 +1365,7 @@ try {
     fixture,
   ], {
     encoding: 'utf8',
-    env: { ...process.env, HOME: fakeCodexHome },
+    env: fixtureEnv({ HOME: fakeCodexHome }),
     input: JSON.stringify({
       ...codexAgentRequest,
       task_id: 'codex-cli-task-123',
@@ -1415,6 +1426,7 @@ try {
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
   ], {
     encoding: 'utf8',
+    env: fixtureEnv(),
     input: JSON.stringify(agentBundleCliRequest),
   });
   assert.equal(agentBundleCliResult.status, 0, agentBundleCliResult.stderr || agentBundleCliResult.stdout);
@@ -1436,6 +1448,7 @@ try {
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
   ], {
     encoding: 'utf8',
+    env: fixtureEnv(),
     input: JSON.stringify({
       ...request,
       task_id: 'recipe-wp-codebox-task-123',
@@ -1465,7 +1478,7 @@ try {
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
   ], {
     encoding: 'utf8',
-    env: { ...process.env, FIXTURE_WP_CODEBOX_AGENT_TASK_FAILURE: '1' },
+    env: fixtureEnv({ FIXTURE_WP_CODEBOX_AGENT_TASK_FAILURE: '1' }),
     input: JSON.stringify({
       ...request,
       task_id: 'failed-wp-codebox-task-123',
@@ -1511,6 +1524,7 @@ try {
     artifactRoot,
   ], {
     encoding: 'utf8',
+    env: fixtureEnv(),
     input: JSON.stringify(hangingRequest),
     timeout: 3000,
   });
@@ -1552,6 +1566,7 @@ try {
     writeHangingTaskRunner(root),
   ], {
     encoding: 'utf8',
+    env: fixtureEnv(),
     input: JSON.stringify(configArtifactRequest),
     timeout: 3000,
   });
@@ -1572,6 +1587,7 @@ try {
     writeMissingSecretTaskRunner(root),
   ], {
     encoding: 'utf8',
+    env: fixtureEnv(),
     input: JSON.stringify(codexAgentRequest),
   });
   assert.equal(missingSecretResult.status, 1, missingSecretResult.stderr || missingSecretResult.stdout);
@@ -1613,6 +1629,7 @@ try {
     missingWorkspace.fixture,
   ], {
     encoding: 'utf8',
+    env: fixtureEnv(),
     input: JSON.stringify(missingWorkspaceRequest),
   });
   assert.equal(missingWorkspaceResult.status, 1, missingWorkspaceResult.stderr || missingWorkspaceResult.stdout);
@@ -1644,10 +1661,9 @@ try {
   ], {
     encoding: 'utf8',
     input: JSON.stringify(claudeCodeBaseRequest),
-    env: {
-      ...process.env,
+    env: fixtureEnv({
       [claudeCodeRefreshTokenEnv]: '',
-    },
+    }),
   });
   assert.equal(claudeMissingValueResult.status, 1, claudeMissingValueResult.stderr || claudeMissingValueResult.stdout);
   const claudeMissingValueOutcome = JSON.parse(claudeMissingValueResult.stdout);
@@ -1669,11 +1685,10 @@ try {
         secret_env: ['AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN'],
       },
     }),
-    env: {
-      ...process.env,
+    env: fixtureEnv({
       AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN: 'claude-access-token-value',
       [claudeCodeRefreshTokenEnv]: 'claude-refresh-token-value',
-    },
+    }),
   });
   assert.equal(claudeMissingMappingResult.status, 1, claudeMissingMappingResult.stderr || claudeMissingMappingResult.stdout);
   const claudeMissingMappingOutcome = JSON.parse(claudeMissingMappingResult.stdout);

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -91,6 +91,17 @@ process.exit(1);
   return fixture;
 }
 
+function writeEmptyJsonTaskRunner(root) {
+  const fixture = path.join(root, 'empty-json-task-runner.cjs');
+  fs.writeFileSync(fixture, `#!/usr/bin/env node
+'use strict';
+process.stdout.write('{}');
+process.exit(0);
+`);
+  fs.chmodSync(fixture, 0o755);
+  return fixture;
+}
+
 function writeFakeWpCodebox(root) {
   const fixture = path.join(root, 'fake-wp-cli.cjs');
   const capture = path.join(root, 'fake-wp-cli-capture.json');
@@ -1498,6 +1509,30 @@ try {
   assert.equal(failedWpCodeboxOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-agent-task-input'), true);
   assert.equal(failedWpCodeboxOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-command-evidence'), true);
   assert.equal(failedWpCodeboxOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'wp-codebox.command.evidence_preserved'), true);
+
+  const emptyJsonWpCodeboxResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+  ], {
+    encoding: 'utf8',
+    env: fixtureEnv(),
+    input: JSON.stringify({
+      ...request,
+      task_id: 'empty-json-wp-codebox-task-123',
+      executor: {
+        backend: 'codebox',
+        config: {
+          wp_codebox_bin: writeEmptyJsonTaskRunner(root),
+          homeboy_extensions: path.join(__dirname, '..'),
+        },
+      },
+    }),
+  });
+  assert.equal(emptyJsonWpCodeboxResult.status, 1, emptyJsonWpCodeboxResult.stderr || emptyJsonWpCodeboxResult.stdout);
+  const emptyJsonWpCodeboxOutcome = JSON.parse(emptyJsonWpCodeboxResult.stdout);
+  assert.equal(emptyJsonWpCodeboxOutcome.status, 'failed');
+  assert.equal(emptyJsonWpCodeboxOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'wp-codebox.agent_task_run_empty_json'), true);
+  assert.equal(emptyJsonWpCodeboxOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-command-evidence'), true);
+  assert.equal(emptyJsonWpCodeboxOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-command-evidence'), true);
 
   const contractResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),


### PR DESCRIPTION
## Summary
- Isolate `codebox-agent-task-executor-smoke.js` fixture subprocesses from ambient `HOMEBOY_WP_CODEBOX_CORE_MODULE` injected by Lab runners.
- Treat exit-0 empty JSON payloads from `wp-codebox agent-task-run --json` as failed provider results instead of passing through `{}`.
- Preserve command evidence, stderr/stdout, and redacted task input for that empty-payload path so Homeboy outcomes include actionable diagnostics for Extra-Chill/homeboy#4105.

Follow-up for Extra-Chill/homeboy#4105.

## Tests
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the Lab runner smoke failure and empty WP Codebox payload path, implementing targeted provider evidence handling, and validating the smoke coverage. Chris remains responsible for review and validation.