### PR TITLE
Expose runner command failure details

### DIFF
--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -633,6 +633,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
 			return array(
 				'success'        => false,
 				'command'        => $command_config['command'],
+				'executed_command' => $command,
 				'description'    => $command_config['description'],
 				'error'          => $key . ' requires a WP Codebox runner workspace handle.',
 				'ability'        => $ability_name,
@@ -645,6 +646,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
 			return array(
 				'success'        => false,
 				'command'        => $command_config['command'],
+				'executed_command' => $command,
 				'description'    => $command_config['description'],
 				'workspace'      => $handle,
 				'error'          => $ability_name . ' is not available; runner workspace command execution is blocked on WP Codebox runner verification support.',
@@ -670,6 +672,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
 			return array(
 				'success'        => false,
 				'command'        => $command_config['command'],
+				'executed_command' => $command,
 				'description'    => $command_config['description'],
 				'workspace'      => $handle,
 				'error'          => $result->get_error_message(),
@@ -678,20 +681,26 @@ if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
 			);
 		}
 
-		$response = is_array( $result ) ? $result : array();
-		$exit_code = (int) ( $response['exit_code'] ?? $response['code'] ?? ( empty( $response['success'] ) ? 1 : 0 ) );
-		$completed = ! empty( $response['success'] ) || 0 === $exit_code || 'completed' === (string) ( $response['status'] ?? '' );
+		$response         = is_array( $result ) ? $result : array();
+		$exit_code        = (int) ( $response['exit_code'] ?? $response['code'] ?? ( empty( $response['success'] ) ? 1 : 0 ) );
+		$completed        = ! empty( $response['success'] ) || 0 === $exit_code || 'completed' === (string) ( $response['status'] ?? '' );
+		$stdout           = is_scalar( $response['stdout'] ?? null ) ? trim( (string) $response['stdout'] ) : '';
+		$stderr           = is_scalar( $response['stderr'] ?? null ) ? trim( (string) $response['stderr'] ) : '';
+		$response_error   = is_scalar( $response['error'] ?? null ) ? trim( (string) $response['error'] ) : ( is_array( $response['error'] ?? null ) ? wp_json_encode( $response['error'] ) : '' );
+		$failure_details  = '' !== $response_error ? $response_error : ( '' !== $stderr ? $stderr : $stdout );
+		$executed_command = is_scalar( $response['command'] ?? null ) && '' !== trim( (string) $response['command'] ) ? trim( (string) $response['command'] ) : $command;
 		return array(
 			'command'        => $command_config['command'],
+			'executed_command' => $executed_command,
 			'description'    => $command_config['description'],
 			'exit_code'      => $exit_code,
 			'success'        => $completed,
-			'stdout'         => is_scalar( $response['stdout'] ?? null ) ? trim( (string) $response['stdout'] ) : '',
-			'stderr'         => is_scalar( $response['stderr'] ?? null ) ? trim( (string) $response['stderr'] ) : '',
+			'stdout'         => $stdout,
+			'stderr'         => $stderr,
 			'elapsed_ms'     => isset( $response['elapsed_ms'] ) ? (float) $response['elapsed_ms'] : ( hrtime( true ) - $started ) / 1000000,
 			'workspace'      => $handle,
 			'ability'        => $ability_name,
-			'error'          => is_scalar( $response['error'] ?? null ) ? (string) $response['error'] : ( is_array( $response['error'] ?? null ) ? wp_json_encode( $response['error'] ) : '' ),
+			'error'          => $completed ? $response_error : $failure_details,
 			'upstream_issue' => is_scalar( $response['upstream_issue'] ?? null ) ? (string) $response['upstream_issue'] : '',
 		);
 	}

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -647,8 +647,30 @@ namespace {
 		'verification_commands'
 	);
 	$last_command_call = end( $workspace_command_calls );
-	if ( empty( $pnpm_result['success'] ) || 'corepack pnpm verify' !== ( $last_command_call['command'] ?? '' ) || 'pnpm verify' !== ( $pnpm_result['checks'][0]['command'] ?? '' ) ) {
+	if ( empty( $pnpm_result['success'] ) || 'corepack pnpm verify' !== ( $last_command_call['command'] ?? '' ) || 'pnpm verify' !== ( $pnpm_result['checks'][0]['command'] ?? '' ) || 'corepack pnpm verify' !== ( $pnpm_result['checks'][0]['executed_command'] ?? '' ) ) {
 		fwrite( STDERR, "Expected pnpm verification commands to run through corepack while preserving the reported command.\n" );
+		exit( 1 );
+	}
+
+	$GLOBALS['homeboy_datamachine_agent_fake_abilities'] = array(
+		'wp-codebox/run-runner-workspace-command' => new Homeboy_Datamachine_Agent_Fake_Ability(
+			function ( array $input ): array {
+				return array(
+					'success'   => false,
+					'command'   => (string) ( $input['command'] ?? '' ),
+					'exit_code' => 127,
+					'stderr'    => 'corepack: not found',
+				);
+			}
+		),
+	);
+	$failed_pnpm_result = homeboy_datamachine_agent_run_command_checks(
+		array( 'verification_commands' => array( array( 'command' => 'pnpm verify', 'description' => 'Verify generated docs' ) ) ),
+		array( 'handle' => 'repo@branch', 'path' => '/workspace/repo@branch', 'backend' => 'local_git' ),
+		'verification_commands'
+	);
+	if ( ! empty( $failed_pnpm_result['success'] ) || 'corepack pnpm verify' !== ( $failed_pnpm_result['checks'][0]['executed_command'] ?? '' ) || 'corepack: not found' !== ( $failed_pnpm_result['error'] ?? '' ) ) {
+		fwrite( STDERR, "Expected failed pnpm verification commands to expose executed command and stderr.\n" );
 		exit( 1 );
 	}
 


### PR DESCRIPTION
## Summary
- Record the actual executed runner command separately from the configured/display command.
- Preserve stderr/stdout as failure detail when runner verification commands fail without an explicit error.
- Extend the write-without-PR smoke to cover Corepack-wrapped pnpm failures.

## Verification
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner diagnostics patch and smoke coverage; Chris remains responsible for review and merge.