### PR TITLE
Preserve Codebox evidence for empty stdout

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -1150,8 +1150,7 @@ function emptyJsonPayload(payload) {
     && (!Array.isArray(payload.evidence_refs) || payload.evidence_refs.length === 0);
 }
 
-function emptyJsonPayloadFailure(payload, result, artifacts) {
-  const message = 'WP Codebox agent-task-run returned an empty JSON payload.';
+function emptyOutputFailurePayload(payload, result, artifacts, message, diagnosticClass) {
   return {
     ...payload,
     success: false,
@@ -1160,7 +1159,7 @@ function emptyJsonPayloadFailure(payload, result, artifacts) {
     diagnostics: [
       ...(Array.isArray(payload.diagnostics) ? payload.diagnostics : []),
       {
-        class: 'wp-codebox.agent_task_run_empty_json',
+        class: diagnosticClass,
         message,
         data: {
           status: result.status,
@@ -1171,11 +1170,31 @@ function emptyJsonPayloadFailure(payload, result, artifacts) {
     ],
     metadata: {
       ...(plainObject(payload.metadata) ? payload.metadata : {}),
-      empty_json_payload: true,
+      empty_output: true,
       status: result.status,
       signal: result.signal,
     },
   };
+}
+
+function emptyJsonPayloadFailure(payload, result, artifacts) {
+  return emptyOutputFailurePayload(
+    payload,
+    result,
+    artifacts,
+    'WP Codebox agent-task-run returned an empty JSON payload.',
+    'wp-codebox.agent_task_run_empty_json',
+  );
+}
+
+function emptyStdoutPayloadFailure(result, artifacts) {
+  return emptyOutputFailurePayload(
+    {},
+    result,
+    artifacts,
+    'WP Codebox agent-task-run exited successfully without stdout.',
+    'wp-codebox.agent_task_run_empty_stdout',
+  );
 }
 
 function runWpCodeboxParentTask(request) {
@@ -1275,6 +1294,18 @@ function runWpCodeboxParentTask(request) {
   }
   if (result.error) {
     process.stderr.write(`${result.error.message}\n`);
+  }
+  if ((result.status ?? 0) === 0) {
+    const evidence = preserveWpCodeboxFailureEvidence({
+      artifacts,
+      inputPath,
+      result,
+      command: resolved.command,
+      args: resolved.args,
+      secretNames: input.secret_env || [],
+    });
+    process.stdout.write(`${JSON.stringify(attachFailureEvidence(emptyStdoutPayloadFailure(result, artifacts), evidence), null, 2)}\n`);
+    return 1;
   }
   return result.status ?? 1;
 }

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -102,6 +102,16 @@ process.exit(0);
   return fixture;
 }
 
+function writeEmptyStdoutTaskRunner(root) {
+  const fixture = path.join(root, 'empty-stdout-task-runner.cjs');
+  fs.writeFileSync(fixture, `#!/usr/bin/env node
+'use strict';
+process.exit(0);
+`);
+  fs.chmodSync(fixture, 0o755);
+  return fixture;
+}
+
 function writeFakeWpCodebox(root) {
   const fixture = path.join(root, 'fake-wp-cli.cjs');
   const capture = path.join(root, 'fake-wp-cli-capture.json');
@@ -1533,6 +1543,30 @@ try {
   assert.equal(emptyJsonWpCodeboxOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'wp-codebox.agent_task_run_empty_json'), true);
   assert.equal(emptyJsonWpCodeboxOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-command-evidence'), true);
   assert.equal(emptyJsonWpCodeboxOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-command-evidence'), true);
+
+  const emptyStdoutWpCodeboxResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+  ], {
+    encoding: 'utf8',
+    env: fixtureEnv(),
+    input: JSON.stringify({
+      ...request,
+      task_id: 'empty-stdout-wp-codebox-task-123',
+      executor: {
+        backend: 'codebox',
+        config: {
+          wp_codebox_bin: writeEmptyStdoutTaskRunner(root),
+          homeboy_extensions: path.join(__dirname, '..'),
+        },
+      },
+    }),
+  });
+  assert.equal(emptyStdoutWpCodeboxResult.status, 1, emptyStdoutWpCodeboxResult.stderr || emptyStdoutWpCodeboxResult.stdout);
+  const emptyStdoutWpCodeboxOutcome = JSON.parse(emptyStdoutWpCodeboxResult.stdout);
+  assert.equal(emptyStdoutWpCodeboxOutcome.status, 'failed');
+  assert.equal(emptyStdoutWpCodeboxOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'wp-codebox.agent_task_run_empty_stdout'), true);
+  assert.equal(emptyStdoutWpCodeboxOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-command-evidence'), true);
+  assert.equal(emptyStdoutWpCodeboxOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-command-evidence'), true);
 
   const contractResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),


### PR DESCRIPTION
## Summary
- Treat `wp-codebox agent-task-run --json` exiting `0` without stdout as a failed provider result instead of allowing a blank Homeboy outcome.
- Preserve command evidence, stderr/stdout paths, and redacted task input for the empty-stdout path.
- Extend the Codebox agent-task smoke test to cover both exit-0 `{}` and exit-0/no-stdout failures.

Follow-up for Extra-Chill/homeboy#4105 after `conductor-full-loop-proof-retry7-20260612` showed the merged empty-JSON fix did not cover an exit-0/no-stdout runner result.

## Tests
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the retry7 empty-output failure path, implementing targeted provider evidence handling, and validating smoke coverage. Chris remains responsible for review and validation.