### PR TITLE
Pass runner command PATH env

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -894,6 +894,7 @@ jobs:
             --arg executeWorkflowPath "$execute_workflow_guest_path" \
             --arg providerRegisterFunction "$provider_register_function" \
             --arg wpCliToolName "$WP_CLI_TOOL_NAME" \
+            --arg runnerCommandPath "${PATH:-}" \
             --argjson validationDependencies "$validation_json" \
             --argjson providerCredentials "$provider_credentials_json" \
             --argjson providerBenchEnv "$provider_bench_env_json" \
@@ -970,6 +971,7 @@ jobs:
               context_repositories: $contextRepositories,
               verification_commands: $verificationCommands,
               drift_checks: $driftChecks,
+              runner_command_env: (if $runnerCommandPath != "" then {PATH: $runnerCommandPath} else {} end),
               datamachine_code_policy_attestation: {
                 schema: "homeboy/datamachine-agent-ci-dmc-policy/v1",
                 target_repo: $targetRepo,

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -625,10 +625,25 @@ if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
 		return $command;
 	}
 
-	function homeboy_datamachine_agent_run_workspace_command( array $runner_workspace, array $command_config, string $key ): array {
+	function homeboy_datamachine_agent_runner_command_env( array $config ): array {
+		$env = is_array( $config['runner_command_env'] ?? null ) ? $config['runner_command_env'] : array();
+		$clean_env = array();
+		foreach ( $env as $name => $value ) {
+			$name = trim( (string) $name );
+			if ( '' === $name || ! preg_match( '/^[A-Za-z_][A-Za-z0-9_]*$/', $name ) || ! is_scalar( $value ) ) {
+				continue;
+			}
+			$clean_env[ $name ] = (string) $value;
+		}
+
+		return $clean_env;
+	}
+
+	function homeboy_datamachine_agent_run_workspace_command( array $config, array $runner_workspace, array $command_config, string $key ): array {
 		$ability_name = 'wp-codebox/run-runner-workspace-command';
 		$handle       = isset( $runner_workspace['handle'] ) && is_scalar( $runner_workspace['handle'] ) ? trim( (string) $runner_workspace['handle'] ) : '';
 		$command      = homeboy_datamachine_agent_prepare_runner_command( (string) ( $command_config['command'] ?? '' ) );
+		$env          = homeboy_datamachine_agent_runner_command_env( $config );
 		if ( '' === $handle ) {
 			return array(
 				'success'        => false,
@@ -666,6 +681,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
 				'command'          => $command,
 				'description'      => $command_config['description'],
 				'kind'             => $key,
+				'env'              => $env,
 			)
 		);
 		if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
@@ -713,7 +729,7 @@ if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
 
 		$results = array();
 		foreach ( $commands as $command_config ) {
-			$result    = homeboy_datamachine_agent_run_workspace_command( $runner_workspace, $command_config, $key );
+			$result    = homeboy_datamachine_agent_run_workspace_command( $config, $runner_workspace, $command_config, $key );
 			$results[] = $result;
 			if ( empty( $result['success'] ) ) {
 				return array(

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -642,12 +642,15 @@ namespace {
     }
 
 	$pnpm_result = homeboy_datamachine_agent_run_command_checks(
-		array( 'verification_commands' => array( array( 'command' => 'pnpm verify', 'description' => 'Verify generated docs' ) ) ),
+		array(
+			'runner_command_env'   => array( 'PATH' => '/opt/hostedtoolcache/node/bin:/usr/bin' ),
+			'verification_commands' => array( array( 'command' => 'pnpm verify', 'description' => 'Verify generated docs' ) ),
+		),
 		array( 'handle' => 'repo@branch', 'path' => '/workspace/repo@branch', 'backend' => 'local_git' ),
 		'verification_commands'
 	);
 	$last_command_call = end( $workspace_command_calls );
-	if ( empty( $pnpm_result['success'] ) || 'corepack pnpm verify' !== ( $last_command_call['command'] ?? '' ) || 'pnpm verify' !== ( $pnpm_result['checks'][0]['command'] ?? '' ) || 'corepack pnpm verify' !== ( $pnpm_result['checks'][0]['executed_command'] ?? '' ) ) {
+	if ( empty( $pnpm_result['success'] ) || 'corepack pnpm verify' !== ( $last_command_call['command'] ?? '' ) || '/opt/hostedtoolcache/node/bin:/usr/bin' !== ( $last_command_call['env']['PATH'] ?? '' ) || 'pnpm verify' !== ( $pnpm_result['checks'][0]['command'] ?? '' ) || 'corepack pnpm verify' !== ( $pnpm_result['checks'][0]['executed_command'] ?? '' ) ) {
 		fwrite( STDERR, "Expected pnpm verification commands to run through corepack while preserving the reported command.\n" );
 		exit( 1 );
 	}


### PR DESCRIPTION
## Summary
- Capture the GitHub runner PATH after `actions/setup-node` and pass it into WP Codebox runner workspace commands.
- Let verification and drift commands resolve host-provided tools like `corepack` when they execute through the runner command boundary.
- Add smoke coverage that confirms Corepack-wrapped pnpm commands receive the configured command environment.

## Verification
- `php -l wordpress/scripts/agent/datamachine-agent-workload.php`
- `php -l wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the command environment propagation fix and smoke coverage; Chris remains responsible for review and merge.