### PR TITLE
Run Data Machine agent lifecycle on the host

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -844,12 +844,6 @@ jobs:
             runner_workspace_mounts_json="$(jq -nc --arg source "$GITHUB_WORKSPACE" --arg target "$runner_workspace_guest_checkout" '[{type: "directory", source: $source, target: $target, mode: "readwrite", metadata: {kind: "runner-workspace", artifactExcludePaths: [".ci/**"]}}]')"
             runner_workspace_json="$(jq -c --arg checkout "$runner_workspace_guest_checkout" '. + {checkout_path: $checkout}' <<< "$runner_workspace_json")"
           fi
-          runner_command_mounts_json="[]"
-          node_bin="$(command -v node || true)"
-          if [ -n "$node_bin" ]; then
-            node_tool_root="$(cd "$(dirname "$node_bin")/.." && pwd -P)"
-            runner_command_mounts_json="$(jq -nc --arg source "$node_tool_root" '[{type: "directory", source: $source, target: $source, mode: "readonly", metadata: {kind: "runner-command-toolchain"}}]')"
-          fi
           rules_json="$(validate_json_input rules object "$RULES")"
           general_rules_json="$(validate_json_input general_rules array "$GENERAL_RULES")"
           task_rules_json="$(validate_json_input task_rules array "$TASK_RULES")"
@@ -900,7 +894,6 @@ jobs:
             --arg executeWorkflowPath "$execute_workflow_guest_path" \
             --arg providerRegisterFunction "$provider_register_function" \
             --arg wpCliToolName "$WP_CLI_TOOL_NAME" \
-            --arg runnerCommandPath "${PATH:-}" \
             --argjson validationDependencies "$validation_json" \
             --argjson providerCredentials "$provider_credentials_json" \
             --argjson providerBenchEnv "$provider_bench_env_json" \
@@ -915,7 +908,6 @@ jobs:
             --argjson extraWpCodeboxMounts "$extra_wp_codebox_mounts_json" \
             --argjson executeWorkflowMounts "$execute_workflow_mounts_json" \
             --argjson runnerWorkspaceMounts "$runner_workspace_mounts_json" \
-            --argjson runnerCommandMounts "$runner_command_mounts_json" \
             --argjson workloadRunBefore "$workload_run_before_json" \
             --argjson workloadRunAfter "$workload_run_after_json" \
             --argjson dailyMemoryEnabled "$DAILY_MEMORY_ENABLED" \
@@ -947,7 +939,7 @@ jobs:
                   target: "/wordpress/wp-content/plugins/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php",
                   mode: "readonly"
                 }
-              ] + $extraWpCodeboxMounts + $executeWorkflowMounts + $runnerWorkspaceMounts + $runnerCommandMounts),
+              ] + $extraWpCodeboxMounts + $executeWorkflowMounts + $runnerWorkspaceMounts),
               wp_config_defines: $extraWpConfigDefines,
               workload_run_before: $workloadRunBefore,
               workload_run_after: $workloadRunAfter,
@@ -978,7 +970,7 @@ jobs:
               context_repositories: $contextRepositories,
               verification_commands: $verificationCommands,
               drift_checks: $driftChecks,
-              runner_command_env: (if $runnerCommandPath != "" then {PATH: $runnerCommandPath} else {} end),
+              host_runner_lifecycle: true,
               datamachine_code_policy_attestation: {
                 schema: "homeboy/datamachine-agent-ci-dmc-policy/v1",
                 target_repo: $targetRepo,
@@ -1051,6 +1043,21 @@ jobs:
           HOMEBOY_DATAMACHINE_AGENT_RESULTS_FILE: ${{ runner.temp }}/run-results.json
           HOMEBOY_DATAMACHINE_AGENT_REPLAY_BUNDLE_DIR: ${{ inputs.replay_bundle_artifact_name != '' && format('{0}/datamachine-agent-replay-bundles', runner.temp) || '' }}
         run: bash .ci/homeboy-extensions/wordpress/scripts/agent/run-datamachine-agent.sh "${{ steps.config.outputs.config_path }}"
+
+      - name: Run host runner lifecycle
+        if: ${{ inputs.run_agent && ! inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          RESULTS_FILE: ${{ runner.temp }}/run-results.json
+          CONFIG_FILE: ${{ steps.config.outputs.config_path }}
+        run: |
+          set -euo pipefail
+          node .ci/homeboy-extensions/wordpress/scripts/agent/run-host-runner-lifecycle.cjs \
+            --results "$RESULTS_FILE" \
+            --config "$CONFIG_FILE" \
+            --scenario "${{ inputs.flow_slug }}" \
+            --workspace "$GITHUB_WORKSPACE"
 
       - name: Extract scenario outputs
         id: extract

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -124,11 +124,12 @@ The runner converts the agent config into a single WP Codebox sandbox run:
   can explicitly ask the agent to work in that checkout.
 - `runner_workspace.expose_to_agent: false` enables runner-owned capture
   mode. It preserves the natural task prompt, keeps workspace tool calls scoped
-  to the provisioned handle when those tools are used, then asks WP Codebox to
-  capture and publish the final runner workspace after the run.
-- `verification_commands` and `drift_checks` execute through the WP Codebox
-  runner workspace command API, preserving verification metadata without
-  requiring Homeboy to resolve backend-local workspace paths.
+  to the provisioned handle when those tools are used, then lets the host
+  lifecycle capture and publish the final runner workspace after the run.
+- `verification_commands` and `drift_checks` execute on the GitHub Actions /
+  Homeboy host after WP Codebox returns from the WordPress/Data Machine agent
+  run. This keeps project CI commands in the checked-out target repository where
+  Node, pnpm, git auth, and workflow checkout state naturally live.
 - `ability_tools` can expose additional WordPress abilities as tools during the
   agent run.
 - `enable_terminal_actions` exposes terminal actions through the WordPress
@@ -141,9 +142,11 @@ The runner converts the agent config into a single WP Codebox sandbox run:
   consumer needs a different agent-facing tool name.
 - `pipeline_step_patches` and `flow_step_patches` can adjust imported bundle
   step configuration before execution.
-- Runner-owned workspace publication is handled by the canonical Data Machine
-  Code runner publication API. If that API is unavailable or publication fails,
-  the run fails as `write_without_pr` instead of composing fallback PR calls.
+- Runner-owned workspace publication is handled by the host lifecycle after
+  successful verification and drift checks. If publication fails after files are
+  written, the run fails as `write_without_pr`. The WP Codebox sandbox remains
+  responsible for WordPress runtime primitives, transcript/review artifacts, and
+  Data Machine API access.
 
 The reusable workflow reports the selected GitHub token path as `auth_mode` and
 in the run summary. Same-repo consumers can use the repository-scoped

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -66,6 +66,7 @@
     "test:codebox-agent-task-boundary": "node tests/codebox-agent-task-boundary-smoke.js",
     "test:codebox-agent-task-executor": "node tests/codebox-agent-task-executor-smoke.js",
     "test:codebox-agent-task-matrix": "node tests/codebox-agent-task-matrix-smoke.js",
+    "test:datamachine-agent-host-lifecycle": "node tests/datamachine-agent-host-lifecycle-smoke.js",
     "test:refactor-source-wp-codebox": "node tests/refactor-source-wp-codebox-smoke.js"
   },
   "devDependencies": {

--- a/wordpress/scripts/agent/datamachine-agent-workload.php
+++ b/wordpress/scripts/agent/datamachine-agent-workload.php
@@ -617,11 +617,6 @@ if ( ! function_exists( 'homeboy_datamachine_agent_command_list' ) ) {
 
 if ( ! function_exists( 'homeboy_datamachine_agent_run_command_checks' ) ) {
 	function homeboy_datamachine_agent_prepare_runner_command( string $command ): string {
-		$trimmed = trim( $command );
-		if ( preg_match( '/^pnpm(\s|$)/', $trimmed ) ) {
-			return 'corepack ' . $trimmed;
-		}
-
 		return $command;
 	}
 
@@ -2602,6 +2597,12 @@ if ( ! function_exists( 'homeboy_datamachine_agent_bool_config' ) ) {
     }
 }
 
+if ( ! function_exists( 'homeboy_datamachine_agent_host_runner_lifecycle_enabled' ) ) {
+    function homeboy_datamachine_agent_host_runner_lifecycle_enabled( array $config ): bool {
+        return homeboy_datamachine_agent_bool_config( $config, 'host_runner_lifecycle', false );
+    }
+}
+
 if ( ! function_exists( 'homeboy_datamachine_agent_slug' ) ) {
     function homeboy_datamachine_agent_slug( string $value ): string {
         $slug = strtolower( preg_replace( '/[^a-zA-Z0-9]+/', '-', $value ) ?? '' );
@@ -3361,10 +3362,15 @@ $runner_workspace_capture = homeboy_datamachine_agent_capture_runner_workspace( 
 if ( is_array( $runner_workspace_capture['engine_data'] ?? null ) ) {
 	$engine_data = $runner_workspace_capture['engine_data'];
 }
-$verification_results = homeboy_datamachine_agent_run_command_checks( $config, is_array( $config['runner_workspace_result'] ?? null ) ? $config['runner_workspace_result'] : array(), 'verification_commands' );
-$drift_check_results  = empty( $verification_results['enabled'] ) || ! empty( $verification_results['success'] )
-	? homeboy_datamachine_agent_run_command_checks( $config, is_array( $config['runner_workspace_result'] ?? null ) ? $config['runner_workspace_result'] : array(), 'drift_checks' )
-	: array( 'enabled' => false, 'checks' => array(), 'skipped_reason' => 'verification_commands_failed' );
+$host_runner_lifecycle = homeboy_datamachine_agent_host_runner_lifecycle_enabled( $config );
+$verification_results = $host_runner_lifecycle
+	? array( 'enabled' => false, 'checks' => array(), 'skipped_reason' => 'host_runner_lifecycle' )
+	: homeboy_datamachine_agent_run_command_checks( $config, is_array( $config['runner_workspace_result'] ?? null ) ? $config['runner_workspace_result'] : array(), 'verification_commands' );
+$drift_check_results  = $host_runner_lifecycle
+	? array( 'enabled' => false, 'checks' => array(), 'skipped_reason' => 'host_runner_lifecycle' )
+	: ( empty( $verification_results['enabled'] ) || ! empty( $verification_results['success'] )
+		? homeboy_datamachine_agent_run_command_checks( $config, is_array( $config['runner_workspace_result'] ?? null ) ? $config['runner_workspace_result'] : array(), 'drift_checks' )
+		: array( 'enabled' => false, 'checks' => array(), 'skipped_reason' => 'verification_commands_failed' ) );
 $engine_data['runner_verification_results'] = $verification_results;
 $engine_data['runner_drift_check_results']  = $drift_check_results;
 if ( isset( $context_repositories ) ) {
@@ -3386,7 +3392,7 @@ $artifact_pr_context = array(
     'runner_workspace_publication' => $runner_workspace_publication,
     'error_message'            => (string) ( $engine_data['error_message'] ?? '' ),
 );
-if ( ! empty( $runner_workspace_capture['changed'] ) && ! $pr_opened ) {
+if ( ! $host_runner_lifecycle && ! empty( $runner_workspace_capture['changed'] ) && ! $pr_opened ) {
     $runner_workspace = is_array( $config['runner_workspace_result'] ?? null ) ? $config['runner_workspace_result'] : array();
     $template_values  = homeboy_datamachine_agent_artifact_pr_context(
         $job_id,
@@ -3409,7 +3415,9 @@ if ( ! empty( $runner_workspace_capture['changed'] ) && ! $pr_opened ) {
     }
     $artifact_pr_context['runner_workspace_publication'] = $runner_workspace_publication;
 }
-$job_artifact_exports = homeboy_datamachine_agent_export_job_artifacts( $job_id, $config, $pr_opened, $engine_data, $artifact_pr_context );
+$job_artifact_exports = $host_runner_lifecycle
+	? array( 'skipped_reason' => 'host_runner_lifecycle' )
+	: homeboy_datamachine_agent_export_job_artifacts( $job_id, $config, $pr_opened, $engine_data, $artifact_pr_context );
 if ( is_array( $job_artifact_exports['engine_data'] ?? null ) ) {
     $engine_data = $job_artifact_exports['engine_data'];
     $pr_opened   = true;
@@ -3463,7 +3471,7 @@ if ( ! empty( $drift_check_results['enabled'] ) && empty( $drift_check_results['
 	return homeboy_datamachine_agent_result( array( 'drift_checks_succeeded' => 0 ), $metadata, (string) ( $drift_check_results['error'] ?? 'drift_checks failed' ) );
 }
 
-if ( $file_written && ! $pr_opened ) {
+if ( ! $host_runner_lifecycle && $file_written && ! $pr_opened ) {
     $metadata['success_status'] = 'write_without_pr';
     $publication_error = is_array( $runner_workspace_publication ) ? (string) ( $runner_workspace_publication['error'] ?? '' ) : '';
     $capture_error  = is_array( $runner_workspace_capture ) ? (string) ( $runner_workspace_capture['error'] ?? '' ) : '';
@@ -3480,7 +3488,7 @@ if ( ! empty( $job_artifact_exports['error'] ) ) {
     return homeboy_datamachine_agent_result( array( 'job_artifact_exported' => 0 ), $metadata, (string) $job_artifact_exports['error'] );
 }
 
-if ( $success_requires_pr && ! $pr_opened && ! $completion_outcome_satisfied ) {
+if ( ! $host_runner_lifecycle && $success_requires_pr && ! $pr_opened && ! $completion_outcome_satisfied ) {
     return homeboy_datamachine_agent_result( array( 'pr_opened' => 0 ), $metadata, 'Agent completed without opening a pull request' );
 }
 

--- a/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php
@@ -615,7 +615,7 @@ namespace {
                 if ( 'test -f verification.txt' === ( $input['command'] ?? '' ) ) {
                     return array( 'success' => isset( $workspace_files['verification.txt'] ), 'exit_code' => isset( $workspace_files['verification.txt'] ) ? 0 : 1 );
                 }
-				if ( 'corepack pnpm verify' === ( $input['command'] ?? '' ) ) {
+				if ( 'pnpm verify' === ( $input['command'] ?? '' ) ) {
 					return array( 'status' => 'completed', 'exit_code' => 0, 'stdout' => 'verified', 'stderr' => '' );
 				}
                 return array( 'success' => false, 'error' => 'Unexpected command.' );
@@ -650,8 +650,8 @@ namespace {
 		'verification_commands'
 	);
 	$last_command_call = end( $workspace_command_calls );
-	if ( empty( $pnpm_result['success'] ) || 'corepack pnpm verify' !== ( $last_command_call['command'] ?? '' ) || '/opt/hostedtoolcache/node/bin:/usr/bin' !== ( $last_command_call['env']['PATH'] ?? '' ) || 'pnpm verify' !== ( $pnpm_result['checks'][0]['command'] ?? '' ) || 'corepack pnpm verify' !== ( $pnpm_result['checks'][0]['executed_command'] ?? '' ) ) {
-		fwrite( STDERR, "Expected pnpm verification commands to run through corepack while preserving the reported command.\n" );
+	if ( empty( $pnpm_result['success'] ) || 'pnpm verify' !== ( $last_command_call['command'] ?? '' ) || '/opt/hostedtoolcache/node/bin:/usr/bin' !== ( $last_command_call['env']['PATH'] ?? '' ) || 'pnpm verify' !== ( $pnpm_result['checks'][0]['command'] ?? '' ) || 'pnpm verify' !== ( $pnpm_result['checks'][0]['executed_command'] ?? '' ) ) {
+		fwrite( STDERR, "Expected pnpm verification commands to preserve the configured command without sandbox-side corepack wrapping.\n" );
 		exit( 1 );
 	}
 
@@ -662,7 +662,7 @@ namespace {
 					'success'   => false,
 					'command'   => (string) ( $input['command'] ?? '' ),
 					'exit_code' => 127,
-					'stderr'    => 'corepack: not found',
+					'stderr'    => 'pnpm: not found',
 				);
 			}
 		),
@@ -672,7 +672,7 @@ namespace {
 		array( 'handle' => 'repo@branch', 'path' => '/workspace/repo@branch', 'backend' => 'local_git' ),
 		'verification_commands'
 	);
-	if ( ! empty( $failed_pnpm_result['success'] ) || 'corepack pnpm verify' !== ( $failed_pnpm_result['checks'][0]['executed_command'] ?? '' ) || 'corepack: not found' !== ( $failed_pnpm_result['error'] ?? '' ) ) {
+	if ( ! empty( $failed_pnpm_result['success'] ) || 'pnpm verify' !== ( $failed_pnpm_result['checks'][0]['executed_command'] ?? '' ) || 'pnpm: not found' !== ( $failed_pnpm_result['error'] ?? '' ) ) {
 		fwrite( STDERR, "Expected failed pnpm verification commands to expose executed command and stderr.\n" );
 		exit( 1 );
 	}

--- a/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+'use strict';
+
+/* eslint-disable no-console */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+function argValue(name, fallback = '') {
+  const index = process.argv.indexOf(name);
+  return index >= 0 && process.argv[index + 1] ? process.argv[index + 1] : fallback;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function plainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function commandList(config, key) {
+  const commands = Array.isArray(config[key]) ? config[key] : [];
+  return commands.flatMap((entry) => {
+    const command = typeof entry === 'string' ? entry : entry?.command;
+    if (typeof command !== 'string' || command.trim() === '') {
+      return [];
+    }
+    return [{
+      command: command.trim(),
+      description: typeof entry?.description === 'string' ? entry.description.trim() : '',
+    }];
+  });
+}
+
+function run(command, args, options = {}) {
+  return spawnSync(command, args, {
+    cwd: options.cwd,
+    env: { ...process.env, ...(options.env || {}) },
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024 * 20,
+  });
+}
+
+function runShellCommand(commandConfig, workspace, key) {
+  const started = process.hrtime.bigint();
+  const result = run('bash', ['-lc', commandConfig.command], { cwd: workspace });
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1000000;
+  const exitCode = typeof result.status === 'number' ? result.status : 1;
+  const stdout = (result.stdout || '').trim();
+  const stderr = (result.stderr || '').trim();
+  const spawnError = result.error ? result.error.message : '';
+  const failureDetails = spawnError || stderr || stdout || `${key} exited ${exitCode}`;
+
+  return {
+    command: commandConfig.command,
+    prepared_command: commandConfig.command,
+    executed_command: `bash -lc ${JSON.stringify(commandConfig.command)}`,
+    description: commandConfig.description,
+    exit_code: exitCode,
+    success: exitCode === 0,
+    stdout,
+    stderr,
+    elapsed_ms: elapsedMs,
+    workspace,
+    error: exitCode === 0 ? spawnError : failureDetails,
+  };
+}
+
+function runCommandChecks(config, workspace, key) {
+  const commands = commandList(config, key);
+  if (commands.length === 0) {
+    return { enabled: false, checks: [] };
+  }
+
+  const checks = [];
+  for (const commandConfig of commands) {
+    const check = runShellCommand(commandConfig, workspace, key);
+    checks.push(check);
+    if (!check.success) {
+      return {
+        enabled: true,
+        success: false,
+        workspace,
+        checks,
+        error: check.error || `${key} failed: ${commandConfig.command}`,
+      };
+    }
+  }
+
+  return { enabled: true, success: true, workspace, checks };
+}
+
+function git(workspace, args, options = {}) {
+  const result = run('git', args, { cwd: workspace, env: options.env });
+  if (options.check !== false && result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `git ${args.join(' ')} failed`).trim());
+  }
+  return result;
+}
+
+function gh(workspace, args, options = {}) {
+  const result = run('gh', args, { cwd: workspace, env: options.env });
+  if (options.check !== false && result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `gh ${args.join(' ')} failed`).trim());
+  }
+  return result;
+}
+
+function changedFiles(workspace) {
+  const status = git(workspace, ['status', '--porcelain', '--untracked-files=all']).stdout || '';
+  return status.split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.slice(3).trim())
+    .filter((file) => file && !file.startsWith('.ci/'));
+}
+
+function currentBranch(workspace) {
+  const branch = (git(workspace, ['rev-parse', '--abbrev-ref', 'HEAD'], { check: false }).stdout || '').trim();
+  return branch && branch !== 'HEAD' ? branch : '';
+}
+
+function renderTemplate(template, values) {
+  return String(template || '').replace(/\{([^}]+)\}/g, (_, key) => {
+    const value = values[key.trim()];
+    return value === undefined || value === null ? '' : String(value);
+  });
+}
+
+function publicationTemplates(config, values) {
+  const artifactExport = plainObject(config.artifact_export) ? config.artifact_export : {};
+  const workspaceConfig = plainObject(config.runner_workspace) ? config.runner_workspace : {};
+  return {
+    branch: renderTemplate(
+      workspaceConfig.branch || artifactExport.branch_template || 'agent-artifacts/{agent_slug}-{run_id}',
+      values,
+    ),
+    commitMessage: renderTemplate(
+      workspaceConfig.commit_message || artifactExport.commit_message_template || 'chore: persist Data Machine agent workspace changes',
+      values,
+    ),
+    title: renderTemplate(
+      artifactExport.pr_title_template || 'Persist Data Machine agent workspace changes',
+      values,
+    ),
+    body: renderTemplate(
+      artifactExport.pr_body_template || '## Result\n\nData Machine agent workspace changes are ready for review.\n',
+      values,
+    ),
+    base: workspaceConfig.base || workspaceConfig.base_branch || process.env.GITHUB_BASE_REF || 'main',
+  };
+}
+
+function publishWorkspace(config, results, scenario, workspace, files) {
+  if (files.length === 0) {
+    return { opened: false, changed: false };
+  }
+
+  const metadata = scenario.metadata || {};
+  const values = {
+    agent_slug: config.agent_slug || 'datamachine-agent',
+    run_id: process.env.GITHUB_RUN_ID || metadata.run_id || metadata.job_id || 'run',
+    provider: config.provider || '',
+    model: config.model || '',
+    model_label: config.model || '',
+    job_id: metadata.job_id || '',
+    task_id: config.workload_id || scenario.id || '',
+    result_label: 'workspace changes',
+    result_table: '',
+    checks_table: '',
+    tools_table: '',
+    links_table: '',
+  };
+  const templates = publicationTemplates(config, values);
+  const branch = templates.branch.replace(/[^A-Za-z0-9._/-]+/g, '-').replace(/^-+|-+$/g, '') || `agent-artifacts/${values.agent_slug}-${values.run_id}`;
+
+  if (process.env.HOMEBOY_HOST_LIFECYCLE_DRY_RUN === '1' || config.dry_run) {
+    return { opened: false, changed: true, dry_run: true, head: branch, files };
+  }
+
+  if (currentBranch(workspace) !== branch) {
+    git(workspace, ['checkout', '-B', branch]);
+  }
+
+  git(workspace, ['add', '--', ...files]);
+  const staged = git(workspace, ['diff', '--cached', '--name-only'], { check: false }).stdout.trim().split('\n').filter(Boolean);
+  if (staged.length === 0) {
+    return { opened: false, changed: false, head: branch, files: [] };
+  }
+
+  git(workspace, ['config', 'user.name', 'homeboy-agent-ci']);
+  git(workspace, ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com']);
+  git(workspace, ['commit', '-m', templates.commitMessage]);
+  git(workspace, ['push', '-u', 'origin', `HEAD:${branch}`]);
+
+  const existing = gh(workspace, ['pr', 'view', branch, '--json', 'url', '--jq', '.url'], { check: false });
+  const existingUrl = existing.status === 0 ? existing.stdout.trim() : '';
+  const url = existingUrl || gh(workspace, [
+    'pr', 'create',
+    '--head', branch,
+    '--base', templates.base,
+    '--title', templates.title,
+    '--body', templates.body,
+  ]).stdout.trim();
+
+  return {
+    opened: Boolean(url),
+    changed: true,
+    tool_name: 'host_runner_workspace_publication',
+    source: 'host_runner_lifecycle',
+    success: Boolean(url),
+    repo: config.target_repo || process.env.GITHUB_REPOSITORY || '',
+    head: branch,
+    base: templates.base,
+    url,
+    files: staged,
+  };
+}
+
+function scenarioById(results, scenarioId) {
+  const scenarios = Array.isArray(results.scenarios) ? results.scenarios : [];
+  return scenarios.find((item) => item && item.id === scenarioId) || scenarios[0];
+}
+
+function ensureMetadata(scenario) {
+  scenario.metrics = plainObject(scenario.metrics) ? scenario.metrics : {};
+  scenario.metadata = plainObject(scenario.metadata) ? scenario.metadata : {};
+  scenario.metadata.engine_data = plainObject(scenario.metadata.engine_data) ? scenario.metadata.engine_data : {};
+  return scenario.metadata;
+}
+
+function completionOutcomeSatisfied(scenario) {
+  return Boolean(
+    scenario?.metadata?.completion_outcome_satisfied
+      || scenario?.metadata?.engine_data?.completion_outcome_satisfied
+      || scenario?.metrics?.completion_outcome_satisfied,
+  );
+}
+
+function recordLifecycle(results, scenario, lifecycle) {
+  const metadata = ensureMetadata(scenario);
+  metadata.engine_data.runner_verification_results = lifecycle.verification;
+  metadata.engine_data.runner_drift_check_results = lifecycle.drift;
+  metadata.engine_data.runner_workspace_capture = lifecycle.capture;
+  metadata.engine_data.runner_workspace_publication = lifecycle.publication;
+  metadata.runner_workspace_capture = lifecycle.capture;
+  metadata.runner_workspace_publication = lifecycle.publication;
+  metadata.verification_results = lifecycle.verification;
+  metadata.drift_check_results = lifecycle.drift;
+  scenario.metrics.verification_commands_succeeded = !lifecycle.verification.enabled || lifecycle.verification.success ? 1 : 0;
+  scenario.metrics.drift_checks_succeeded = !lifecycle.drift.enabled || lifecycle.drift.success ? 1 : 0;
+  scenario.metrics.pr_opened = lifecycle.publication.opened ? 1 : 0;
+  scenario.metrics.file_written = lifecycle.capture.changed ? 1 : 0;
+  if (!lifecycle.success) {
+    scenario.status = 'failed';
+    scenario.summary = lifecycle.error;
+    metadata.error_message = lifecycle.error;
+  }
+  results.status = lifecycle.success ? (results.status || 'completed') : 'failed';
+}
+
+function main() {
+  const resultsPath = argValue('--results');
+  const configPath = argValue('--config');
+  const scenarioId = argValue('--scenario');
+  const workspace = path.resolve(argValue('--workspace', process.cwd()));
+  if (!resultsPath || !configPath) {
+    throw new Error('Usage: run-host-runner-lifecycle.cjs --results <path> --config <path> --scenario <id> [--workspace <path>]');
+  }
+
+  const results = readJson(resultsPath);
+  const config = readJson(configPath);
+  const scenario = scenarioById(results, scenarioId);
+  if (!scenario) {
+    throw new Error(`Scenario not found in results: ${scenarioId || '(first scenario)'}`);
+  }
+
+  const verification = runCommandChecks(config, workspace, 'verification_commands');
+  const drift = verification.enabled && !verification.success
+    ? { enabled: false, checks: [], skipped_reason: 'verification_commands_failed' }
+    : runCommandChecks(config, workspace, 'drift_checks');
+  const files = changedFiles(workspace);
+  const capture = { enabled: true, changed: files.length > 0, files, workspace };
+  let publication = { opened: false };
+  let success = (!verification.enabled || verification.success) && (!drift.enabled || drift.success);
+  let error = '';
+
+  if (!success) {
+    error = verification.enabled && !verification.success
+      ? (verification.error || 'verification_commands failed')
+      : (drift.error || 'drift_checks failed');
+  } else {
+    try {
+      publication = publishWorkspace(config, results, scenario, workspace, files);
+      if (capture.changed && !publication.opened && !publication.dry_run) {
+        success = false;
+        error = 'Agent wrote files without opening a pull request';
+      } else if (config.success_requires_pr && !publication.opened && !completionOutcomeSatisfied(scenario)) {
+        success = false;
+        error = 'Agent completed without opening a pull request';
+      }
+    } catch (publicationError) {
+      success = false;
+      error = publicationError.message;
+      publication = { opened: false, success: false, error };
+    }
+  }
+
+  recordLifecycle(results, scenario, { verification, drift, capture, publication, success, error });
+  writeJson(resultsPath, results);
+  if (!success) {
+    throw new Error(error);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}

--- a/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
+++ b/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const root = path.join(__dirname, '..');
+const script = path.join(root, 'scripts', 'agent', 'run-host-runner-lifecycle.cjs');
+
+function run(command, args, options = {}) {
+  return spawnSync(command, args, {
+    cwd: options.cwd,
+    env: { ...process.env, ...(options.env || {}) },
+    encoding: 'utf8',
+  });
+}
+
+function checked(command, args, options = {}) {
+  const result = run(command, args, options);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result;
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function makeRepo(tmp) {
+  const repo = path.join(tmp, 'repo');
+  const origin = path.join(tmp, 'origin.git');
+  fs.mkdirSync(repo, { recursive: true });
+  checked('git', ['init', '-b', 'main'], { cwd: repo });
+  checked('git', ['config', 'user.name', 'Fixture User'], { cwd: repo });
+  checked('git', ['config', 'user.email', 'fixture@example.test'], { cwd: repo });
+  fs.writeFileSync(path.join(repo, 'README.md'), '# Fixture\n');
+  checked('git', ['add', 'README.md'], { cwd: repo });
+  checked('git', ['commit', '-m', 'Initial commit'], { cwd: repo });
+  checked('git', ['init', '--bare', origin]);
+  checked('git', ['remote', 'add', 'origin', origin], { cwd: repo });
+  checked('git', ['push', '-u', 'origin', 'main'], { cwd: repo });
+  return repo;
+}
+
+function makeGhFixture(tmp) {
+  const bin = path.join(tmp, 'bin');
+  const log = path.join(tmp, 'gh.log');
+  fs.mkdirSync(bin, { recursive: true });
+  const gh = path.join(bin, 'gh');
+  fs.writeFileSync(gh, `#!/usr/bin/env node
+'use strict';
+const fs = require('node:fs');
+fs.appendFileSync(${JSON.stringify(log)}, process.argv.slice(2).join(' ') + '\\n');
+if (process.argv[2] === 'pr' && process.argv[3] === 'view') process.exit(1);
+if (process.argv[2] === 'pr' && process.argv[3] === 'create') {
+  process.stdout.write('https://github.com/owner/repo/pull/1291\\n');
+  process.exit(0);
+}
+process.stderr.write('unexpected gh call: ' + process.argv.slice(2).join(' '));
+process.exit(1);
+`);
+  fs.chmodSync(gh, 0o755);
+  return { bin, log };
+}
+
+function makeRunFiles(tmp, config) {
+  const configPath = path.join(tmp, 'config.json');
+  const resultsPath = path.join(tmp, 'results.json');
+  writeJson(configPath, {
+    target_repo: 'owner/repo',
+    agent_slug: 'docs-agent',
+    provider: 'openai',
+    model: 'gpt-5.5',
+    workload_id: 'developer-docs',
+    runner_workspace: { branch: 'agent-artifacts/docs-agent-host-lifecycle', base: 'main' },
+    artifact_export: {
+      commit_message_template: 'chore: persist generated docs',
+      pr_title_template: 'Persist generated docs',
+      pr_body_template: '## Result\nGenerated docs are ready.\n',
+    },
+    ...config,
+  });
+  writeJson(resultsPath, {
+    component_id: 'datamachine-agent-ci-driver',
+    scenarios: [{ id: 'developer-docs', metrics: {}, metadata: { engine_data: {} } }],
+  });
+  return { configPath, resultsPath };
+}
+
+{
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-host-lifecycle-success.'));
+  const repo = makeRepo(tmp);
+  const gh = makeGhFixture(tmp);
+  fs.writeFileSync(path.join(repo, 'generated.txt'), 'hello from agent\n');
+  const { configPath, resultsPath } = makeRunFiles(tmp, {
+    verification_commands: [{ command: 'test -f generated.txt', description: 'Generated file exists' }],
+    drift_checks: [{ command: 'grep -q hello generated.txt', description: 'Generated file contains expected content' }],
+  });
+
+  const result = run('node', [script, '--results', resultsPath, '--config', configPath, '--scenario', 'developer-docs', '--workspace', repo], {
+    env: { PATH: `${gh.bin}${path.delimiter}${process.env.PATH}`, GITHUB_RUN_ID: '12345', GH_TOKEN: 'fixture' },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const output = readJson(resultsPath);
+  const scenario = output.scenarios[0];
+  assert.equal(scenario.metrics.verification_commands_succeeded, 1);
+  assert.equal(scenario.metrics.drift_checks_succeeded, 1);
+  assert.equal(scenario.metrics.pr_opened, 1);
+  assert.equal(scenario.metadata.runner_workspace_publication.url, 'https://github.com/owner/repo/pull/1291');
+  assert.match(fs.readFileSync(gh.log, 'utf8'), /pr create/);
+}
+
+{
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-host-lifecycle-fail.'));
+  const repo = makeRepo(tmp);
+  const gh = makeGhFixture(tmp);
+  fs.writeFileSync(path.join(repo, 'generated.txt'), 'hello from agent\n');
+  const { configPath, resultsPath } = makeRunFiles(tmp, {
+    verification_commands: [{ command: 'printf useful-output && grep -q missing generated.txt', description: 'Generated file has missing content' }],
+    drift_checks: [{ command: 'printf should-not-run', description: 'Skipped drift check' }],
+  });
+
+  const result = run('node', [script, '--results', resultsPath, '--config', configPath, '--scenario', 'developer-docs', '--workspace', repo], {
+    env: { PATH: `${gh.bin}${path.delimiter}${process.env.PATH}`, GITHUB_RUN_ID: '12345', GH_TOKEN: 'fixture' },
+  });
+  assert.notEqual(result.status, 0);
+  const output = readJson(resultsPath);
+  const check = output.scenarios[0].metadata.verification_results.checks[0];
+  assert.equal(output.status, 'failed');
+  assert.equal(output.scenarios[0].metrics.verification_commands_succeeded, 0);
+  assert.equal(output.scenarios[0].metadata.drift_check_results.skipped_reason, 'verification_commands_failed');
+  assert.equal(check.command, 'printf useful-output && grep -q missing generated.txt');
+  assert.equal(check.prepared_command, 'printf useful-output && grep -q missing generated.txt');
+  assert.equal(check.exit_code, 1);
+  assert.equal(check.stdout, 'useful-output');
+  assert.equal(fs.existsSync(gh.log), false);
+}
+
+console.log('Data Machine agent host lifecycle smoke passed');


### PR DESCRIPTION
## Summary
- Moves reusable Data Machine agent CI verification, drift checks, capture, and runner workspace publication into a host-side lifecycle step after WP Codebox returns.
- Keeps WP Codebox focused on the WordPress/Data Machine sandbox by removing the runner command PATH/toolchain mount workaround from the reusable workflow.
- Adds host lifecycle smoke coverage for agent-written files, successful verification + drift + publication, failed verification details, and publication gating.

Fixes #1291.

## Verification
- `node wordpress/tests/datamachine-agent-host-lifecycle-smoke.js` passed.
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php` passed.
- `npm run test:datamachine-agent-host-lifecycle` passed.
- `npm run test:codebox-agent-task-boundary` passed.
- `git diff --check` passed.

## Notes
- `npm run lint:js` could not run in this checkout because `eslint` is not installed (`sh: eslint: command not found`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the host lifecycle runner refactor, smoke coverage, documentation updates, and local verification under Chris's requested issue scope.