### PR TITLE
Run host pnpm checks through corepack

### DIFF
--- a/wordpress/scripts/agent/run-host-runner-lifecycle-smoke.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle-smoke.cjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { prepareRunnerCommand, runShellCommand } = require('./run-host-runner-lifecycle.cjs');
+
+assert.equal(prepareRunnerCommand('pnpm verify'), 'corepack pnpm verify');
+assert.equal(prepareRunnerCommand(' pnpm install --frozen-lockfile '), 'corepack pnpm install --frozen-lockfile');
+assert.equal(prepareRunnerCommand('npm test'), 'npm test');
+
+const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-host-runner-lifecycle-'));
+try {
+  const check = runShellCommand(
+    { command: 'pnpm verify', description: 'Verify generated docs' },
+    workspace,
+    'verification_commands'
+  );
+  assert.equal(check.command, 'pnpm verify');
+  assert.equal(check.prepared_command, 'corepack pnpm verify');
+  assert.equal(check.executed_command, 'bash -lc "corepack pnpm verify"');
+  assert.equal(typeof check.exit_code, 'number');
+  assert.equal(check.workspace, workspace);
+} finally {
+  fs.rmSync(workspace, { recursive: true, force: true });
+}
+
+console.log('Host runner lifecycle smoke passed.');

--- a/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
@@ -47,9 +47,15 @@ function run(command, args, options = {}) {
   });
 }
 
+function prepareRunnerCommand(command) {
+  const trimmed = String(command || '').trim();
+  return /^pnpm(\s|$)/.test(trimmed) ? `corepack ${trimmed}` : trimmed;
+}
+
 function runShellCommand(commandConfig, workspace, key) {
   const started = process.hrtime.bigint();
-  const result = run('bash', ['-lc', commandConfig.command], { cwd: workspace });
+  const preparedCommand = prepareRunnerCommand(commandConfig.command);
+  const result = run('bash', ['-lc', preparedCommand], { cwd: workspace });
   const elapsedMs = Number(process.hrtime.bigint() - started) / 1000000;
   const exitCode = typeof result.status === 'number' ? result.status : 1;
   const stdout = (result.stdout || '').trim();
@@ -59,8 +65,8 @@ function runShellCommand(commandConfig, workspace, key) {
 
   return {
     command: commandConfig.command,
-    prepared_command: commandConfig.command,
-    executed_command: `bash -lc ${JSON.stringify(commandConfig.command)}`,
+    prepared_command: preparedCommand,
+    executed_command: `bash -lc ${JSON.stringify(preparedCommand)}`,
     description: commandConfig.description,
     exit_code: exitCode,
     success: exitCode === 0,
@@ -319,9 +325,16 @@ function main() {
   }
 }
 
-try {
-  main();
-} catch (error) {
-  console.error(error.message);
-  process.exit(1);
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
 }
+
+module.exports = {
+  prepareRunnerCommand,
+  runShellCommand,
+};


### PR DESCRIPTION
## Summary
- Prepare host runner lifecycle `pnpm ...` commands as `corepack pnpm ...`, matching the previous runner command behavior.
- Preserve the configured command separately from the prepared/executed command in verification results.
- Add a focused smoke for host lifecycle command preparation and result shape.

## Verification
- `node --check wordpress/scripts/agent/run-host-runner-lifecycle.cjs`
- `node --check wordpress/scripts/agent/run-host-runner-lifecycle-smoke.cjs`
- `node wordpress/scripts/agent/run-host-runner-lifecycle-smoke.cjs`
- `php wordpress/scripts/agent/datamachine-agent-write-without-pr-smoke.php`

Fixes follow-up from #1291 / #1292.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the host lifecycle command preparation fix and smoke coverage; Chris remains responsible for review and merge.