### PR TITLE
Fix host runner publication base ref

### DIFF
--- a/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
@@ -139,6 +139,33 @@ function renderTemplate(template, values) {
   });
 }
 
+function normalizeBaseRef(value) {
+  const ref = String(value || '').trim();
+  if (!ref) {
+    return '';
+  }
+  return ref
+    .replace(/^refs\/heads\//, '')
+    .replace(/^remotes\/origin\//, '')
+    .replace(/^origin\//, '');
+}
+
+function publicationBase(config) {
+  const artifactExport = plainObject(config.artifact_export) ? config.artifact_export : {};
+  const workspaceConfig = plainObject(config.runner_workspace) ? config.runner_workspace : {};
+  return normalizeBaseRef(
+    workspaceConfig.base
+      || workspaceConfig.base_branch
+      || workspaceConfig.base_ref
+      || workspaceConfig.from
+      || artifactExport.base
+      || artifactExport.base_branch
+      || artifactExport.base_ref
+      || process.env.GITHUB_BASE_REF
+      || 'main',
+  ) || 'main';
+}
+
 function publicationTemplates(config, values) {
   const artifactExport = plainObject(config.artifact_export) ? config.artifact_export : {};
   const workspaceConfig = plainObject(config.runner_workspace) ? config.runner_workspace : {};
@@ -159,7 +186,7 @@ function publicationTemplates(config, values) {
       artifactExport.pr_body_template || '## Result\n\nData Machine agent workspace changes are ready for review.\n',
       values,
     ),
-    base: workspaceConfig.base || workspaceConfig.base_branch || process.env.GITHUB_BASE_REF || 'main',
+    base: publicationBase(config),
   };
 }
 

--- a/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
+++ b/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
@@ -77,7 +77,7 @@ function makeRunFiles(tmp, config) {
     provider: 'openai',
     model: 'gpt-5.5',
     workload_id: 'developer-docs',
-    runner_workspace: { branch: 'agent-artifacts/docs-agent-host-lifecycle', base: 'main' },
+    runner_workspace: { branch: 'agent-artifacts/docs-agent-host-lifecycle', from: 'origin/trunk' },
     artifact_export: {
       commit_message_template: 'chore: persist generated docs',
       pr_title_template: 'Persist generated docs',
@@ -112,7 +112,7 @@ function makeRunFiles(tmp, config) {
   assert.equal(scenario.metrics.drift_checks_succeeded, 1);
   assert.equal(scenario.metrics.pr_opened, 1);
   assert.equal(scenario.metadata.runner_workspace_publication.url, 'https://github.com/owner/repo/pull/1291');
-  assert.match(fs.readFileSync(gh.log, 'utf8'), /pr create/);
+  assert.match(fs.readFileSync(gh.log, 'utf8'), /pr create .*--base trunk/);
 }
 
 {


### PR DESCRIPTION
## Summary
- Normalize host runner PR publication base refs from runner workspace and artifact export config.
- Preserve configured refs like `origin/trunk` as GitHub PR bases like `trunk` instead of falling back to `main`.
- Cover the Build with WordPress-style `from: origin/trunk` path in the host lifecycle smoke.

## Verification
- `node wordpress/scripts/agent/run-host-runner-lifecycle-smoke.cjs`
- `node wordpress/tests/datamachine-agent-host-lifecycle-smoke.js`
- `npm run test:datamachine-agent-host-lifecycle`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the host runner PR publication base-ref failure, drafted the fix and smoke coverage, and ran local verification.