### PR TITLE
Fix host runner stable branch publication

### DIFF
--- a/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
@@ -190,6 +190,15 @@ function publicationTemplates(config, values) {
   };
 }
 
+function pushWorkspaceBranch(workspace, branch) {
+  const fetch = git(workspace, ['fetch', 'origin', `+refs/heads/${branch}:refs/remotes/origin/${branch}`], { check: false });
+  const args = ['push', '-u', 'origin', `HEAD:${branch}`];
+  if (fetch.status === 0) {
+    args.splice(1, 0, `--force-with-lease=refs/heads/${branch}`);
+  }
+  git(workspace, args);
+}
+
 function publishWorkspace(config, results, scenario, workspace, files) {
   if (files.length === 0) {
     return { opened: false, changed: false };
@@ -230,7 +239,7 @@ function publishWorkspace(config, results, scenario, workspace, files) {
   git(workspace, ['config', 'user.name', 'homeboy-agent-ci']);
   git(workspace, ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com']);
   git(workspace, ['commit', '-m', templates.commitMessage]);
-  git(workspace, ['push', '-u', 'origin', `HEAD:${branch}`]);
+  pushWorkspaceBranch(workspace, branch);
 
   const existing = gh(workspace, ['pr', 'view', branch, '--json', 'url', '--jq', '.url'], { check: false });
   const existingUrl = existing.status === 0 ? existing.stdout.trim() : '';

--- a/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
+++ b/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
@@ -96,6 +96,12 @@ function makeRunFiles(tmp, config) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-host-lifecycle-success.'));
   const repo = makeRepo(tmp);
   const gh = makeGhFixture(tmp);
+  checked('git', ['checkout', '-B', 'agent-artifacts/docs-agent-host-lifecycle'], { cwd: repo });
+  fs.writeFileSync(path.join(repo, 'stale.txt'), 'old branch content\n');
+  checked('git', ['add', 'stale.txt'], { cwd: repo });
+  checked('git', ['commit', '-m', 'Stale generated docs'], { cwd: repo });
+  checked('git', ['push', '-u', 'origin', 'agent-artifacts/docs-agent-host-lifecycle'], { cwd: repo });
+  checked('git', ['checkout', 'main'], { cwd: repo });
   fs.writeFileSync(path.join(repo, 'generated.txt'), 'hello from agent\n');
   const { configPath, resultsPath } = makeRunFiles(tmp, {
     verification_commands: [{ command: 'test -f generated.txt', description: 'Generated file exists' }],


### PR DESCRIPTION
## Summary
- Fetch existing runner-owned publication branches before pushing.
- Use `--force-with-lease` only when the canonical branch already exists, so stable Docs Agent branches can be refreshed without non-fast-forward failures.
- Extend host lifecycle smoke coverage with a pre-existing divergent remote docs branch.

## Verification
- `node wordpress/scripts/agent/run-host-runner-lifecycle-smoke.cjs`
- `npm run test:datamachine-agent-host-lifecycle`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the stable-branch push rejection, drafted the branch publication fix and smoke coverage, and ran local verification.