### PR TITLE
Fix Data Machine agent publication hygiene

### DIFF
--- a/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
@@ -127,11 +127,6 @@ function changedFiles(workspace) {
     .filter((file) => file && !file.startsWith('.ci/'));
 }
 
-function currentBranch(workspace) {
-  const branch = (git(workspace, ['rev-parse', '--abbrev-ref', 'HEAD'], { check: false }).stdout || '').trim();
-  return branch && branch !== 'HEAD' ? branch : '';
-}
-
 function renderTemplate(template, values) {
   return String(template || '').replace(/\{([^}]+)\}/g, (_, key) => {
     const value = values[key.trim()];
@@ -190,6 +185,56 @@ function publicationTemplates(config, values) {
   };
 }
 
+function copyFile(source, destination) {
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.copyFileSync(source, destination);
+}
+
+function preserveWorkspaceFiles(workspace, files) {
+  const temp = fs.mkdtempSync(path.join(
+    process.env.RUNNER_TEMP || process.env.TMPDIR || '/tmp',
+    'homeboy-runner-workspace.',
+  ));
+  const entries = [];
+  for (const file of files) {
+    const source = path.join(workspace, file);
+    const backup = path.join(temp, file);
+    if (fs.existsSync(source) && fs.statSync(source).isFile()) {
+      copyFile(source, backup);
+      entries.push({ file, backup, deleted: false });
+    } else {
+      entries.push({ file, deleted: true });
+    }
+  }
+  return { temp, entries };
+}
+
+function restoreWorkspaceFiles(workspace, preserved) {
+  for (const entry of preserved.entries) {
+    const target = path.join(workspace, entry.file);
+    if (entry.deleted) {
+      fs.rmSync(target, { force: true });
+      continue;
+    }
+    copyFile(entry.backup, target);
+  }
+  fs.rmSync(preserved.temp, { recursive: true, force: true });
+}
+
+function resetPublicationBranch(workspace, branch, base, files) {
+  const preserved = preserveWorkspaceFiles(workspace, files);
+  const fetch = git(
+    workspace,
+    ['fetch', 'origin', `+refs/heads/${base}:refs/remotes/origin/${base}`],
+    { check: false },
+  );
+  const baseRef = fetch.status === 0 ? `origin/${base}` : base;
+  git(workspace, ['reset', '--hard', 'HEAD']);
+  git(workspace, ['clean', '-fd']);
+  git(workspace, ['checkout', '-B', branch, baseRef]);
+  restoreWorkspaceFiles(workspace, preserved);
+}
+
 function pushWorkspaceBranch(workspace, branch) {
   const fetch = git(workspace, ['fetch', 'origin', `+refs/heads/${branch}:refs/remotes/origin/${branch}`], { check: false });
   const args = ['push', '-u', 'origin', `HEAD:${branch}`];
@@ -197,6 +242,49 @@ function pushWorkspaceBranch(workspace, branch) {
     args.splice(1, 0, `--force-with-lease=refs/heads/${branch}`);
   }
   git(workspace, args);
+}
+
+function pullRequestForBranch(workspace, branch) {
+  const result = gh(workspace, ['pr', 'view', branch, '--json', 'number,state,url', '--jq', '.'], { check: false });
+  if (result.status !== 0) {
+    return null;
+  }
+  try {
+    return JSON.parse(result.stdout || '{}');
+  } catch {
+    return null;
+  }
+}
+
+function ensurePullRequest(workspace, branch, templates) {
+  const existing = pullRequestForBranch(workspace, branch);
+  if (existing?.state === 'OPEN' && existing.url) {
+    gh(
+      workspace,
+      ['pr', 'edit', String(existing.number || branch), '--title', templates.title, '--body', templates.body],
+      { check: false },
+    );
+    return { url: existing.url, action: 'updated', number: existing.number || null, state: 'OPEN' };
+  }
+
+  if (existing?.state === 'CLOSED' && existing.number) {
+    gh(workspace, ['pr', 'reopen', String(existing.number)]);
+    gh(
+      workspace,
+      ['pr', 'edit', String(existing.number), '--title', templates.title, '--body', templates.body],
+      { check: false },
+    );
+    return { url: existing.url || '', action: 'reopened', number: existing.number, state: 'OPEN' };
+  }
+
+  const url = gh(workspace, [
+    'pr', 'create',
+    '--head', branch,
+    '--base', templates.base,
+    '--title', templates.title,
+    '--body', templates.body,
+  ]).stdout.trim();
+  return { url, action: 'created', number: null, state: 'OPEN' };
 }
 
 function publishWorkspace(config, results, scenario, workspace, files) {
@@ -226,9 +314,8 @@ function publishWorkspace(config, results, scenario, workspace, files) {
     return { opened: false, changed: true, dry_run: true, head: branch, files };
   }
 
-  if (currentBranch(workspace) !== branch) {
-    git(workspace, ['checkout', '-B', branch]);
-  }
+  resetPublicationBranch(workspace, branch, templates.base, files);
+  files = changedFiles(workspace);
 
   git(workspace, ['add', '--', ...files]);
   const staged = git(workspace, ['diff', '--cached', '--name-only'], { check: false }).stdout.trim().split('\n').filter(Boolean);
@@ -241,15 +328,8 @@ function publishWorkspace(config, results, scenario, workspace, files) {
   git(workspace, ['commit', '-m', templates.commitMessage]);
   pushWorkspaceBranch(workspace, branch);
 
-  const existing = gh(workspace, ['pr', 'view', branch, '--json', 'url', '--jq', '.url'], { check: false });
-  const existingUrl = existing.status === 0 ? existing.stdout.trim() : '';
-  const url = existingUrl || gh(workspace, [
-    'pr', 'create',
-    '--head', branch,
-    '--base', templates.base,
-    '--title', templates.title,
-    '--body', templates.body,
-  ]).stdout.trim();
+  const pullRequest = ensurePullRequest(workspace, branch, templates);
+  const url = pullRequest.url;
 
   return {
     opened: Boolean(url),
@@ -261,6 +341,9 @@ function publishWorkspace(config, results, scenario, workspace, files) {
     head: branch,
     base: templates.base,
     url,
+    action: pullRequest.action,
+    pr_number: pullRequest.number,
+    pr_state: pullRequest.state,
     files: staged,
   };
 }

--- a/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
+++ b/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
@@ -35,7 +35,7 @@ function makeRepo(tmp) {
   const repo = path.join(tmp, 'repo');
   const origin = path.join(tmp, 'origin.git');
   fs.mkdirSync(repo, { recursive: true });
-  checked('git', ['init', '-b', 'main'], { cwd: repo });
+  checked('git', ['init', '-b', 'trunk'], { cwd: repo });
   checked('git', ['config', 'user.name', 'Fixture User'], { cwd: repo });
   checked('git', ['config', 'user.email', 'fixture@example.test'], { cwd: repo });
   fs.writeFileSync(path.join(repo, 'README.md'), '# Fixture\n');
@@ -43,11 +43,11 @@ function makeRepo(tmp) {
   checked('git', ['commit', '-m', 'Initial commit'], { cwd: repo });
   checked('git', ['init', '--bare', origin]);
   checked('git', ['remote', 'add', 'origin', origin], { cwd: repo });
-  checked('git', ['push', '-u', 'origin', 'main'], { cwd: repo });
+  checked('git', ['push', '-u', 'origin', 'trunk'], { cwd: repo });
   return repo;
 }
 
-function makeGhFixture(tmp) {
+function makeGhFixture(tmp, options = {}) {
   const bin = path.join(tmp, 'bin');
   const log = path.join(tmp, 'gh.log');
   fs.mkdirSync(bin, { recursive: true });
@@ -56,11 +56,18 @@ function makeGhFixture(tmp) {
 'use strict';
 const fs = require('node:fs');
 fs.appendFileSync(${JSON.stringify(log)}, process.argv.slice(2).join(' ') + '\\n');
-if (process.argv[2] === 'pr' && process.argv[3] === 'view') process.exit(1);
+const existing = ${JSON.stringify(options.existingPullRequest || null)};
+if (process.argv[2] === 'pr' && process.argv[3] === 'view') {
+  if (!existing) process.exit(1);
+  process.stdout.write(JSON.stringify(existing) + '\\n');
+  process.exit(0);
+}
 if (process.argv[2] === 'pr' && process.argv[3] === 'create') {
   process.stdout.write('https://github.com/owner/repo/pull/1291\\n');
   process.exit(0);
 }
+if (process.argv[2] === 'pr' && process.argv[3] === 'reopen') process.exit(0);
+if (process.argv[2] === 'pr' && process.argv[3] === 'edit') process.exit(0);
 process.stderr.write('unexpected gh call: ' + process.argv.slice(2).join(' '));
 process.exit(1);
 `);
@@ -101,7 +108,7 @@ function makeRunFiles(tmp, config) {
   checked('git', ['add', 'stale.txt'], { cwd: repo });
   checked('git', ['commit', '-m', 'Stale generated docs'], { cwd: repo });
   checked('git', ['push', '-u', 'origin', 'agent-artifacts/docs-agent-host-lifecycle'], { cwd: repo });
-  checked('git', ['checkout', 'main'], { cwd: repo });
+  checked('git', ['checkout', 'trunk'], { cwd: repo });
   fs.writeFileSync(path.join(repo, 'generated.txt'), 'hello from agent\n');
   const { configPath, resultsPath } = makeRunFiles(tmp, {
     verification_commands: [{ command: 'test -f generated.txt', description: 'Generated file exists' }],
@@ -119,6 +126,52 @@ function makeRunFiles(tmp, config) {
   assert.equal(scenario.metrics.pr_opened, 1);
   assert.equal(scenario.metadata.runner_workspace_publication.url, 'https://github.com/owner/repo/pull/1291');
   assert.match(fs.readFileSync(gh.log, 'utf8'), /pr create .*--base trunk/);
+  checked('git', ['fetch', 'origin', 'agent-artifacts/docs-agent-host-lifecycle'], { cwd: repo });
+  const publishedFiles = checked(
+    'git',
+    ['ls-tree', '-r', '--name-only', 'origin/agent-artifacts/docs-agent-host-lifecycle'],
+    { cwd: repo },
+  ).stdout;
+  assert.match(publishedFiles, /generated\.txt/);
+  assert.doesNotMatch(publishedFiles, /stale\.txt/);
+}
+
+{
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-host-lifecycle-closed-pr.'));
+  const repo = makeRepo(tmp);
+  const gh = makeGhFixture(tmp, {
+    existingPullRequest: { number: 47, state: 'CLOSED', url: 'https://github.com/owner/repo/pull/47' },
+  });
+  checked('git', ['checkout', '-B', 'agent-artifacts/docs-agent-host-lifecycle'], { cwd: repo });
+  fs.writeFileSync(path.join(repo, 'stale.txt'), 'old branch content\n');
+  checked('git', ['add', 'stale.txt'], { cwd: repo });
+  checked('git', ['commit', '-m', 'Stale generated docs'], { cwd: repo });
+  checked('git', ['push', '-u', 'origin', 'agent-artifacts/docs-agent-host-lifecycle'], { cwd: repo });
+  fs.writeFileSync(path.join(repo, 'generated.txt'), 'hello from agent on stale branch\n');
+  const { configPath, resultsPath } = makeRunFiles(tmp, {
+    verification_commands: [{ command: 'test -f generated.txt', description: 'Generated file exists' }],
+  });
+
+  const result = run('node', [script, '--results', resultsPath, '--config', configPath, '--scenario', 'developer-docs', '--workspace', repo], {
+    env: { PATH: `${gh.bin}${path.delimiter}${process.env.PATH}`, GITHUB_RUN_ID: '12345', GH_TOKEN: 'fixture' },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const output = readJson(resultsPath);
+  const publication = output.scenarios[0].metadata.runner_workspace_publication;
+  assert.equal(publication.url, 'https://github.com/owner/repo/pull/47');
+  assert.equal(publication.action, 'reopened');
+  assert.equal(publication.pr_state, 'OPEN');
+  const ghLog = fs.readFileSync(gh.log, 'utf8');
+  assert.match(ghLog, /pr reopen 47/);
+  assert.doesNotMatch(ghLog, /pr create/);
+  checked('git', ['fetch', 'origin', 'agent-artifacts/docs-agent-host-lifecycle'], { cwd: repo });
+  const publishedFiles = checked(
+    'git',
+    ['ls-tree', '-r', '--name-only', 'origin/agent-artifacts/docs-agent-host-lifecycle'],
+    { cwd: repo },
+  ).stdout;
+  assert.match(publishedFiles, /generated\.txt/);
+  assert.doesNotMatch(publishedFiles, /stale\.txt/);
 }
 
 {


### PR DESCRIPTION
## Summary
- Rebuilds the runner publication branch from the configured base before committing current agent output, preserving only the current uncommitted agent changes.
- Handles existing PR state explicitly: updates open PRs, reopens closed PRs, and creates a PR when none exists.
- Extends the host lifecycle smoke test to cover stale branch cleanup and closed PR reopening.

## Testing
- `npm run test:datamachine-agent-host-lifecycle`
- `git diff --check`
- `npm run lint:js -- scripts/agent/run-host-runner-lifecycle.cjs tests/datamachine-agent-host-lifecycle-smoke.js` could not run locally because dependencies are not installed in this worktree (`eslint: command not found`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runner publication failure, drafted the branch/PR hygiene fix, and added smoke coverage. Chris remains responsible for review and validation.