### PR TITLE
Fix closed runner PR replacement

### DIFF
--- a/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
@@ -244,6 +244,10 @@ function pushWorkspaceBranch(workspace, branch) {
   git(workspace, args);
 }
 
+function pushNewWorkspaceBranch(workspace, branch) {
+  git(workspace, ['push', '-u', 'origin', `HEAD:${branch}`]);
+}
+
 function pullRequestForBranch(workspace, branch) {
   const result = gh(workspace, ['pr', 'view', branch, '--json', 'number,state,url', '--jq', '.'], { check: false });
   if (result.status !== 0) {
@@ -254,6 +258,21 @@ function pullRequestForBranch(workspace, branch) {
   } catch {
     return null;
   }
+}
+
+function createPullRequest(workspace, branch, templates) {
+  return gh(workspace, [
+    'pr', 'create',
+    '--head', branch,
+    '--base', templates.base,
+    '--title', templates.title,
+    '--body', templates.body,
+  ]).stdout.trim();
+}
+
+function replacementBranchName(branch) {
+  const suffix = process.env.GITHUB_RUN_ID || Date.now();
+  return `${branch}-run-${suffix}`.replace(/[^A-Za-z0-9._/-]+/g, '-').replace(/^-+|-+$/g, '');
 }
 
 function ensurePullRequest(workspace, branch, templates) {
@@ -268,23 +287,33 @@ function ensurePullRequest(workspace, branch, templates) {
   }
 
   if (existing?.state === 'CLOSED' && existing.number) {
-    gh(workspace, ['pr', 'reopen', String(existing.number)]);
-    gh(
-      workspace,
-      ['pr', 'edit', String(existing.number), '--title', templates.title, '--body', templates.body],
-      { check: false },
-    );
-    return { url: existing.url || '', action: 'reopened', number: existing.number, state: 'OPEN' };
+    const reopened = gh(workspace, ['pr', 'reopen', String(existing.number)], { check: false });
+    if (reopened.status === 0) {
+      gh(
+        workspace,
+        ['pr', 'edit', String(existing.number), '--title', templates.title, '--body', templates.body],
+        { check: false },
+      );
+      return { url: existing.url || '', action: 'reopened', head: branch, number: existing.number, state: 'OPEN' };
+    }
+
+    const replacementBranch = replacementBranchName(branch);
+    pushNewWorkspaceBranch(workspace, replacementBranch);
+    const url = createPullRequest(workspace, replacementBranch, templates);
+    return {
+      url,
+      action: 'created_after_closed_pr',
+      head: replacementBranch,
+      number: null,
+      state: 'OPEN',
+      closed_pr_number: existing.number,
+      closed_pr_url: existing.url || '',
+      reopen_error: (reopened.stderr || reopened.stdout || '').trim(),
+    };
   }
 
-  const url = gh(workspace, [
-    'pr', 'create',
-    '--head', branch,
-    '--base', templates.base,
-    '--title', templates.title,
-    '--body', templates.body,
-  ]).stdout.trim();
-  return { url, action: 'created', number: null, state: 'OPEN' };
+  const url = createPullRequest(workspace, branch, templates);
+  return { url, action: 'created', head: branch, number: null, state: 'OPEN' };
 }
 
 function publishWorkspace(config, results, scenario, workspace, files) {
@@ -338,12 +367,15 @@ function publishWorkspace(config, results, scenario, workspace, files) {
     source: 'host_runner_lifecycle',
     success: Boolean(url),
     repo: config.target_repo || process.env.GITHUB_REPOSITORY || '',
-    head: branch,
+    head: pullRequest.head || branch,
     base: templates.base,
     url,
     action: pullRequest.action,
     pr_number: pullRequest.number,
     pr_state: pullRequest.state,
+    closed_pr_number: pullRequest.closed_pr_number,
+    closed_pr_url: pullRequest.closed_pr_url,
+    reopen_error: pullRequest.reopen_error,
     files: staged,
   };
 }

--- a/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
+++ b/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
@@ -66,7 +66,13 @@ if (process.argv[2] === 'pr' && process.argv[3] === 'create') {
   process.stdout.write('https://github.com/owner/repo/pull/1291\\n');
   process.exit(0);
 }
-if (process.argv[2] === 'pr' && process.argv[3] === 'reopen') process.exit(0);
+if (process.argv[2] === 'pr' && process.argv[3] === 'reopen') {
+  if (${JSON.stringify(Boolean(options.failReopen))}) {
+    process.stderr.write('API call failed: GraphQL: Could not open the pull request. (reopenPullRequest)');
+    process.exit(1);
+  }
+  process.exit(0);
+}
 if (process.argv[2] === 'pr' && process.argv[3] === 'edit') process.exit(0);
 process.stderr.write('unexpected gh call: ' + process.argv.slice(2).join(' '));
 process.exit(1);
@@ -168,6 +174,47 @@ function makeRunFiles(tmp, config) {
   const publishedFiles = checked(
     'git',
     ['ls-tree', '-r', '--name-only', 'origin/agent-artifacts/docs-agent-host-lifecycle'],
+    { cwd: repo },
+  ).stdout;
+  assert.match(publishedFiles, /generated\.txt/);
+  assert.doesNotMatch(publishedFiles, /stale\.txt/);
+}
+
+{
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-host-lifecycle-closed-pr-replacement.'));
+  const repo = makeRepo(tmp);
+  const gh = makeGhFixture(tmp, {
+    existingPullRequest: { number: 47, state: 'CLOSED', url: 'https://github.com/owner/repo/pull/47' },
+    failReopen: true,
+  });
+  checked('git', ['checkout', '-B', 'agent-artifacts/docs-agent-host-lifecycle'], { cwd: repo });
+  fs.writeFileSync(path.join(repo, 'stale.txt'), 'old branch content\n');
+  checked('git', ['add', 'stale.txt'], { cwd: repo });
+  checked('git', ['commit', '-m', 'Stale generated docs'], { cwd: repo });
+  checked('git', ['push', '-u', 'origin', 'agent-artifacts/docs-agent-host-lifecycle'], { cwd: repo });
+  fs.writeFileSync(path.join(repo, 'generated.txt'), 'hello from replacement branch\n');
+  const { configPath, resultsPath } = makeRunFiles(tmp, {
+    verification_commands: [{ command: 'test -f generated.txt', description: 'Generated file exists' }],
+  });
+
+  const result = run('node', [script, '--results', resultsPath, '--config', configPath, '--scenario', 'developer-docs', '--workspace', repo], {
+    env: { PATH: `${gh.bin}${path.delimiter}${process.env.PATH}`, GITHUB_RUN_ID: '12345', GH_TOKEN: 'fixture' },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const output = readJson(resultsPath);
+  const publication = output.scenarios[0].metadata.runner_workspace_publication;
+  assert.equal(publication.url, 'https://github.com/owner/repo/pull/1291');
+  assert.equal(publication.action, 'created_after_closed_pr');
+  assert.equal(publication.head, 'agent-artifacts/docs-agent-host-lifecycle-run-12345');
+  assert.equal(publication.closed_pr_number, 47);
+  assert.match(publication.reopen_error, /Could not open the pull request/);
+  const ghLog = fs.readFileSync(gh.log, 'utf8');
+  assert.match(ghLog, /pr reopen 47/);
+  assert.match(ghLog, /pr create --head agent-artifacts\/docs-agent-host-lifecycle-run-12345 --base trunk/);
+  checked('git', ['fetch', 'origin', 'agent-artifacts/docs-agent-host-lifecycle-run-12345'], { cwd: repo });
+  const publishedFiles = checked(
+    'git',
+    ['ls-tree', '-r', '--name-only', 'origin/agent-artifacts/docs-agent-host-lifecycle-run-12345'],
     { cwd: repo },
   ).stdout;
   assert.match(publishedFiles, /generated\.txt/);


### PR DESCRIPTION
## Summary
- Falls back to a deterministic replacement branch when a closed runner-owned PR cannot be reopened by GitHub.
- Preserves metadata for the closed PR and reopen error while opening a fresh reviewable PR from the clean generated commit.
- Adds smoke coverage for the exact `reopenPullRequest` failure seen in the Build with WordPress developer-docs run.

## Testing
- `npm run test:datamachine-agent-host-lifecycle`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the failed `reopenPullRequest` path, drafted the deterministic replacement-branch fix, and added smoke coverage. Chris remains responsible for review and validation.