### PR TITLE
Fix host runner drift checks

### DIFF
--- a/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
@@ -102,6 +102,10 @@ function runCommandChecks(config, workspace, key) {
   return { enabled: true, success: true, workspace, checks };
 }
 
+function hasCommandChecks(config, key) {
+  return commandList(config, key).length > 0;
+}
+
 function git(workspace, args, options = {}) {
   const result = run('git', args, { cwd: workspace, env: options.env });
   if (options.check !== false && result.status !== 0) {
@@ -438,7 +442,11 @@ function main() {
     throw new Error(`Scenario not found in results: ${scenarioId || '(first scenario)'}`);
   }
 
+  const agentFiles = changedFiles(workspace);
   const verification = runCommandChecks(config, workspace, 'verification_commands');
+  if ((!verification.enabled || verification.success) && agentFiles.length > 0 && hasCommandChecks(config, 'drift_checks')) {
+    git(workspace, ['add', '--', ...agentFiles]);
+  }
   const drift = verification.enabled && !verification.success
     ? { enabled: false, checks: [], skipped_reason: 'verification_commands_failed' }
     : runCommandChecks(config, workspace, 'drift_checks');

--- a/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
+++ b/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
@@ -118,7 +118,7 @@ function makeRunFiles(tmp, config) {
   fs.writeFileSync(path.join(repo, 'generated.txt'), 'hello from agent\n');
   const { configPath, resultsPath } = makeRunFiles(tmp, {
     verification_commands: [{ command: 'test -f generated.txt', description: 'Generated file exists' }],
-    drift_checks: [{ command: 'grep -q hello generated.txt', description: 'Generated file contains expected content' }],
+    drift_checks: [{ command: 'git diff --exit-code', description: 'Verification did not create unstaged drift' }],
   });
 
   const result = run('node', [script, '--results', resultsPath, '--config', configPath, '--scenario', 'developer-docs', '--workspace', repo], {
@@ -219,6 +219,33 @@ function makeRunFiles(tmp, config) {
   ).stdout;
   assert.match(publishedFiles, /generated\.txt/);
   assert.doesNotMatch(publishedFiles, /stale\.txt/);
+}
+
+{
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-host-lifecycle-drift-fail.'));
+  const repo = makeRepo(tmp);
+  const gh = makeGhFixture(tmp);
+  fs.writeFileSync(path.join(repo, 'generated.txt'), 'hello from agent\n');
+  const { configPath, resultsPath } = makeRunFiles(tmp, {
+    verification_commands: [{
+      command: 'printf "\\nverifier drift\\n" >> README.md',
+      description: 'Verifier mutates tracked output',
+    }],
+    drift_checks: [{ command: 'git diff --exit-code', description: 'Verifier output must be committed' }],
+  });
+
+  const result = run('node', [script, '--results', resultsPath, '--config', configPath, '--scenario', 'developer-docs', '--workspace', repo], {
+    env: { PATH: `${gh.bin}${path.delimiter}${process.env.PATH}`, GITHUB_RUN_ID: '12345', GH_TOKEN: 'fixture' },
+  });
+  assert.notEqual(result.status, 0);
+  const output = readJson(resultsPath);
+  const drift = output.scenarios[0].metadata.drift_check_results.checks[0];
+  assert.equal(output.status, 'failed');
+  assert.equal(output.scenarios[0].metrics.verification_commands_succeeded, 1);
+  assert.equal(output.scenarios[0].metrics.drift_checks_succeeded, 0);
+  assert.equal(drift.command, 'git diff --exit-code');
+  assert.match(drift.stdout, /README\.md/);
+  assert.equal(fs.existsSync(gh.log), false);
 }
 
 {


### PR DESCRIPTION
## Summary
- Stages the agent's initial workspace edits before running drift checks so `git diff --exit-code` catches verifier-generated drift instead of intentional agent documentation changes.
- Keeps drift checks meaningful by preserving failures when verification mutates tracked files after the initial agent edit set.
- Extends the host lifecycle smoke coverage for both successful agent docs changes and verifier-created tracked drift.

## Testing
- `npm run test:datamachine-agent-host-lifecycle`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the BWW drift-check failure, drafted the staging fix, and added smoke coverage. Chris remains responsible for review and validation.