### PR TITLE
Fix host runner success projection

### DIFF
--- a/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
@@ -414,6 +414,9 @@ function recordLifecycle(results, scenario, lifecycle) {
   scenario.metrics.drift_checks_succeeded = !lifecycle.drift.enabled || lifecycle.drift.success ? 1 : 0;
   scenario.metrics.pr_opened = lifecycle.publication.opened ? 1 : 0;
   scenario.metrics.file_written = lifecycle.capture.changed ? 1 : 0;
+  if (lifecycle.success && lifecycle.publication.opened) {
+    metadata.success_status = 'pr_opened';
+  }
   if (!lifecycle.success) {
     scenario.status = 'failed';
     scenario.summary = lifecycle.error;

--- a/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
+++ b/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
@@ -100,7 +100,7 @@ function makeRunFiles(tmp, config) {
   });
   writeJson(resultsPath, {
     component_id: 'datamachine-agent-ci-driver',
-    scenarios: [{ id: 'developer-docs', metrics: {}, metadata: { engine_data: {} } }],
+    scenarios: [{ id: 'developer-docs', metrics: {}, metadata: { engine_data: {}, ...(config.initial_metadata || {}) } }],
   });
   return { configPath, resultsPath };
 }
@@ -130,6 +130,7 @@ function makeRunFiles(tmp, config) {
   assert.equal(scenario.metrics.verification_commands_succeeded, 1);
   assert.equal(scenario.metrics.drift_checks_succeeded, 1);
   assert.equal(scenario.metrics.pr_opened, 1);
+  assert.equal(scenario.metadata.success_status, 'pr_opened');
   assert.equal(scenario.metadata.runner_workspace_publication.url, 'https://github.com/owner/repo/pull/1291');
   assert.match(fs.readFileSync(gh.log, 'utf8'), /pr create .*--base trunk/);
   checked('git', ['fetch', 'origin', 'agent-artifacts/docs-agent-host-lifecycle'], { cwd: repo });
@@ -155,6 +156,7 @@ function makeRunFiles(tmp, config) {
   checked('git', ['push', '-u', 'origin', 'agent-artifacts/docs-agent-host-lifecycle'], { cwd: repo });
   fs.writeFileSync(path.join(repo, 'generated.txt'), 'hello from agent on stale branch\n');
   const { configPath, resultsPath } = makeRunFiles(tmp, {
+    initial_metadata: { success_status: 'write_without_pr', completion_outcome_satisfied: false },
     verification_commands: [{ command: 'test -f generated.txt', description: 'Generated file exists' }],
   });
 
@@ -163,6 +165,8 @@ function makeRunFiles(tmp, config) {
   });
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const output = readJson(resultsPath);
+  assert.equal(output.scenarios[0].metadata.success_status, 'pr_opened');
+  assert.equal(output.scenarios[0].metadata.completion_outcome_satisfied, false);
   const publication = output.scenarios[0].metadata.runner_workspace_publication;
   assert.equal(publication.url, 'https://github.com/owner/repo/pull/47');
   assert.equal(publication.action, 'reopened');


### PR DESCRIPTION
## Summary
- Mark host runner lifecycle results as `pr_opened` after successful host-side PR publication.
- Cover the case where the agent-side workload initially classified the run as `write_without_pr`, but the host lifecycle later opens/reopens the PR.

## Testing
- `node wordpress/tests/datamachine-agent-host-lifecycle-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Docs Agent run classification mismatch, drafted the Homeboy fix and smoke assertions, and ran focused verification.