### PR TITLE
Add bench artifact viewer contract helper

### DIFF
--- a/wordpress/scripts/bench/bench-artifact-viewer-contract.sh
+++ b/wordpress/scripts/bench/bench-artifact-viewer-contract.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+# Shared bench artifact viewer contract helpers.
+#
+# Callers that publish generated WordPress site artifacts can source this file
+# instead of hand-rolling Playground viewer metadata and URL resolution.
+
+HOMEBOY_BENCH_VIEWER_KIND_WORDPRESS_PLAYGROUND_BLUEPRINT="wordpress-playground-blueprint"
+HOMEBOY_BENCH_WORDPRESS_PLAYGROUND_BASE_URL="${HOMEBOY_BENCH_WORDPRESS_PLAYGROUND_BASE_URL:-https://playground.wordpress.net/}"
+HOMEBOY_BENCH_WORDPRESS_PLAYGROUND_BLUEPRINT_PARAMETER="blueprint-url"
+
+homeboy_bench_artifact_public_base_url() {
+	printf '%s\n' "${HOMEBOY_BENCH_PUBLIC_ARTIFACT_BASE_URL:-${HOMEBOY_PUBLIC_ARTIFACT_BASE_URL:-${HOMEBOY_ARTIFACT_PUBLIC_BASE_URL:-}}}"
+}
+
+homeboy_bench_artifact_public_url() {
+	local artifact_path="$1"
+	local public_base_url="${2:-$(homeboy_bench_artifact_public_base_url)}"
+
+	node -e '
+const artifactPath = process.argv[1] || "";
+const publicBaseUrl = process.argv[2] || "";
+
+if (/^https?:\/\//i.test(artifactPath)) {
+  console.log(artifactPath);
+  process.exit(0);
+}
+
+if (!publicBaseUrl) {
+  console.error("public artifact base URL is required to resolve relative artifact paths");
+  process.exit(2);
+}
+
+const base = publicBaseUrl.endsWith("/") ? publicBaseUrl : `${publicBaseUrl}/`;
+const relativePath = artifactPath.replace(/^\.\//, "").replace(/^\/+/g, "");
+const encodedPath = relativePath.split("/").map(encodeURIComponent).join("/");
+console.log(new URL(encodedPath, base).toString());
+' "$artifact_path" "$public_base_url"
+}
+
+homeboy_bench_playground_blueprint_viewer_url() {
+	local public_artifact_url="$1"
+	local playground_base_url="${2:-$HOMEBOY_BENCH_WORDPRESS_PLAYGROUND_BASE_URL}"
+
+	node -e '
+const publicArtifactUrl = process.argv[1] || "";
+const playgroundBaseUrl = process.argv[2] || "https://playground.wordpress.net/";
+const url = new URL(playgroundBaseUrl);
+url.searchParams.set("blueprint-url", publicArtifactUrl);
+console.log(url.toString());
+' "$public_artifact_url" "$playground_base_url"
+}
+
+homeboy_bench_playground_blueprint_viewer_contract_json() {
+	node -e '
+const viewer = {
+  kind: "wordpress-playground-blueprint",
+  base: process.env.HOMEBOY_BENCH_WORDPRESS_PLAYGROUND_BASE_URL || "https://playground.wordpress.net/",
+  query: {
+    parameter: "blueprint-url",
+    value: { source: "public-artifact-url" },
+    encoding: "url"
+  }
+};
+console.log(JSON.stringify(viewer, null, 2));
+'
+}
+
+homeboy_bench_playground_blueprint_viewer_json() {
+	local artifact_path="$1"
+	local public_base_url="${2:-$(homeboy_bench_artifact_public_base_url)}"
+	local public_artifact_url
+	local viewer_url
+
+	public_artifact_url="$(homeboy_bench_artifact_public_url "$artifact_path" "$public_base_url")"
+	viewer_url="$(homeboy_bench_playground_blueprint_viewer_url "$public_artifact_url")"
+
+	node -e '
+const publicArtifactUrl = process.argv[1];
+const viewerUrl = process.argv[2];
+const viewer = {
+  kind: "wordpress-playground-blueprint",
+  base: process.env.HOMEBOY_BENCH_WORDPRESS_PLAYGROUND_BASE_URL || "https://playground.wordpress.net/",
+  query: {
+    parameter: "blueprint-url",
+    value: {
+      source: "public-artifact-url",
+      url: publicArtifactUrl
+    },
+    encoding: "url"
+  },
+  "public-artifact-url": publicArtifactUrl,
+  public_artifact_url: publicArtifactUrl,
+  url: viewerUrl
+};
+console.log(JSON.stringify(viewer, null, 2));
+' "$public_artifact_url" "$viewer_url"
+}
+
+homeboy_bench_require_public_artifact_reachable() {
+	local public_artifact_url="$1"
+
+	if curl -fsSIL --max-time 10 "$public_artifact_url" >/dev/null; then
+		return 0
+	fi
+
+	# Some artifact stores do not implement HEAD; fall back to a tiny GET.
+	curl -fsSL --max-time 10 --range 0-0 "$public_artifact_url" >/dev/null
+}

--- a/wordpress/scripts/bench/bench-results-artifacts-smoke.sh
+++ b/wordpress/scripts/bench/bench-results-artifacts-smoke.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=bench-results-artifacts.sh
 source "${SCRIPT_DIR}/bench-results-artifacts.sh"
+# shellcheck source=bench-artifact-viewer-contract.sh
+source "${SCRIPT_DIR}/bench-artifact-viewer-contract.sh"
 
 if ! command -v jq >/dev/null 2>&1; then
     echo "ERROR: jq required for JSON assertions in this smoke." >&2
@@ -11,7 +13,11 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/bench-results-artifacts.XXXXXX")
+PUBLIC_SERVER_PID=""
 cleanup() {
+    if [ -n "$PUBLIC_SERVER_PID" ]; then
+        kill "$PUBLIC_SERVER_PID" >/dev/null 2>&1 || true
+    fi
     rm -rf "$TMP_ROOT"
 }
 trap cleanup EXIT
@@ -124,6 +130,8 @@ LEADERBOARD_FILE="${TMP_ROOT}/leaderboard.md"
 SERIES_FILE="${TMP_ROOT}/series.json"
 WEBPERF_SUMMARY_JSON_FILE="${TMP_ROOT}/webperf-evidence-summary.json"
 WEBPERF_SUMMARY_MARKDOWN_FILE="${TMP_ROOT}/webperf-evidence-summary.md"
+PUBLIC_ROOT="${TMP_ROOT}/public"
+PUBLIC_PORT_FILE="${TMP_ROOT}/public-port"
 
 if [ ! -s "$JSONL_FILE" ]; then
     echo "ERROR: missing results.jsonl artifact" >&2
@@ -207,6 +215,87 @@ fi
 if ! grep -q 'Web Performance Evidence Summary' "$WEBPERF_SUMMARY_MARKDOWN_FILE"; then
     echo "ERROR: webperf markdown summary missing title" >&2
     cat "$WEBPERF_SUMMARY_MARKDOWN_FILE" >&2
+    exit 1
+fi
+
+mkdir -p "${PUBLIC_ROOT}/published/artifacts"
+printf '{"landingPage":"/"}\n' > "${PUBLIC_ROOT}/published/artifacts/blueprint.after.json"
+
+PUBLIC_ROOT="$PUBLIC_ROOT" PUBLIC_PORT_FILE="$PUBLIC_PORT_FILE" node -e '
+const fs = require("fs");
+const http = require("http");
+const path = require("path");
+
+const root = path.resolve(process.env.PUBLIC_ROOT);
+const portFile = process.env.PUBLIC_PORT_FILE;
+const server = http.createServer((request, response) => {
+  const requestUrl = new URL(request.url, "http://127.0.0.1");
+  const requestedPath = path.resolve(root, `.${decodeURIComponent(requestUrl.pathname)}`);
+  if (requestedPath !== root && !requestedPath.startsWith(`${root}${path.sep}`)) {
+    response.writeHead(403);
+    response.end("forbidden");
+    return;
+  }
+
+  fs.readFile(requestedPath, (error, data) => {
+    if (error) {
+      response.writeHead(404);
+      response.end("not found");
+      return;
+    }
+
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(request.method === "HEAD" ? undefined : data);
+  });
+});
+
+server.listen(0, "127.0.0.1", () => {
+  fs.writeFileSync(portFile, String(server.address().port));
+});
+' &
+PUBLIC_SERVER_PID="$!"
+
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if [ -s "$PUBLIC_PORT_FILE" ]; then
+        break
+    fi
+    sleep 0.1
+done
+
+if [ ! -s "$PUBLIC_PORT_FILE" ]; then
+    echo "ERROR: public artifact fixture server did not start" >&2
+    exit 1
+fi
+
+PUBLIC_BASE_URL="http://127.0.0.1:$(cat "$PUBLIC_PORT_FILE")/published/"
+PUBLIC_ARTIFACT_URL="$(homeboy_bench_artifact_public_url "artifacts/blueprint.after.json" "$PUBLIC_BASE_URL")"
+EXPECTED_PUBLIC_ARTIFACT_URL="${PUBLIC_BASE_URL}artifacts/blueprint.after.json"
+
+if [ "$PUBLIC_ARTIFACT_URL" != "$EXPECTED_PUBLIC_ARTIFACT_URL" ]; then
+    echo "ERROR: public artifact URL helper resolved unexpected URL" >&2
+    echo "expected: $EXPECTED_PUBLIC_ARTIFACT_URL" >&2
+    echo "actual:   $PUBLIC_ARTIFACT_URL" >&2
+    exit 1
+fi
+
+if ! homeboy_bench_require_public_artifact_reachable "$PUBLIC_ARTIFACT_URL"; then
+    echo "ERROR: public artifact URL was not reachable: $PUBLIC_ARTIFACT_URL" >&2
+    exit 1
+fi
+
+VIEWER_JSON="$(homeboy_bench_playground_blueprint_viewer_json "artifacts/blueprint.after.json" "$PUBLIC_BASE_URL")"
+VIEWER_URL="$(printf '%s\n' "$VIEWER_JSON" | jq -r '.url')"
+VIEWER_KIND="$(printf '%s\n' "$VIEWER_JSON" | jq -r '.kind')"
+VIEWER_SOURCE="$(printf '%s\n' "$VIEWER_JSON" | jq -r '.query.value.source')"
+VIEWER_PUBLIC_ARTIFACT_URL="$(printf '%s\n' "$VIEWER_JSON" | jq -r '.query.value.url')"
+VIEWER_BLUEPRINT_URL="$(node -e '
+const viewerUrl = new URL(process.argv[1]);
+console.log(viewerUrl.searchParams.get("blueprint-url"));
+' "$VIEWER_URL")"
+
+if [ "$VIEWER_KIND" != "wordpress-playground-blueprint" ] || [ "$VIEWER_SOURCE" != "public-artifact-url" ] || [ "$VIEWER_PUBLIC_ARTIFACT_URL" != "$PUBLIC_ARTIFACT_URL" ] || [ "$VIEWER_BLUEPRINT_URL" != "$PUBLIC_ARTIFACT_URL" ]; then
+    echo "ERROR: resolved viewer metadata did not point at the reachable public artifact" >&2
+    printf '%s\n' "$VIEWER_JSON" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Add a reusable WordPress bench artifact viewer contract helper for resolving public artifact URLs and Playground blueprint viewer URLs.
- Extend the bench results artifact smoke to serve a generated blueprint artifact over a temporary public-style HTTP base, verify 2xx reachability, and assert the resolved Playground URL points at that reachable artifact.

Closes #1304.
Closes #1305.

## Tests
- `bash -n wordpress/scripts/bench/bench-artifact-viewer-contract.sh`
- `bash -n wordpress/scripts/bench/bench-results-artifacts-smoke.sh`
- `bash wordpress/scripts/bench/bench-results-artifacts-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shell helper, smoke coverage, verification commands, commit, and PR body for Chris to review.