### PR TITLE
Enforce host runner writable paths

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -78,6 +78,10 @@ name: Data Machine Agent CI (reusable)
         description: JSON array of generated-output drift checks to run in the target workspace after verification. Entries may be strings or {command, description} objects.
         type: string
         default: "[]"
+      writable_paths:
+        description: Comma-separated or JSON array of target workspace paths the agent may change. Empty disables host-side path enforcement.
+        type: string
+        default: ""
       include_agent_runtime_dependencies:
         description: "Include the standard WordPress agent runtime stack: Agents API, Data Machine, and Data Machine Code."
         type: boolean
@@ -667,6 +671,7 @@ jobs:
           CONTEXT_REPOSITORIES: ${{ inputs.context_repositories }}
           VERIFICATION_COMMANDS: ${{ inputs.verification_commands }}
           DRIFT_CHECKS: ${{ inputs.drift_checks }}
+          WRITABLE_PATHS: ${{ inputs.writable_paths }}
           PROMPT: ${{ inputs.prompt }}
           PROVIDER: ${{ inputs.provider }}
           MODEL: ${{ inputs.model }}
@@ -813,6 +818,14 @@ jobs:
           }
           verification_commands_json="$(normalize_command_list verification_commands "$VERIFICATION_COMMANDS")"
           drift_checks_json="$(normalize_command_list drift_checks "$DRIFT_CHECKS")"
+          writable_paths_json="$(printf '%s' "$WRITABLE_PATHS" | jq -Rse '
+            gsub("^\\s+|\\s+$"; "") as $value
+            | if $value == "" then []
+              elif ($value | startswith("[")) then ($value | fromjson | if type == "array" then . else error("writable_paths JSON must be an array") end)
+              else ($value | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != "")))
+              end
+            | map(if type == "string" and length > 0 then . else error("writable_paths entries must be non-empty strings") end)
+          ')"
           extra_wp_config_defines_json="$(validate_json_input extra_wp_config_defines object "$EXTRA_WP_CONFIG_DEFINES")"
           extra_wp_codebox_mounts_json="$(validate_json_input extra_wp_codebox_mounts array "$EXTRA_WP_CODEBOX_MOUNTS" | jq -c --arg workspace "$GITHUB_WORKSPACE" '
             map(
@@ -876,6 +889,7 @@ jobs:
             --argjson contextRepositories "$context_repositories_json" \
             --argjson verificationCommands "$verification_commands_json" \
             --argjson driftChecks "$drift_checks_json" \
+            --argjson writablePaths "$writable_paths_json" \
             --arg prompt "$PROMPT" \
             --arg provider "$PROVIDER" \
             --arg model "$MODEL" \
@@ -970,6 +984,7 @@ jobs:
               context_repositories: $contextRepositories,
               verification_commands: $verificationCommands,
               drift_checks: $driftChecks,
+              writable_paths: $writablePaths,
               host_runner_lifecycle: true,
               datamachine_code_policy_attestation: {
                 schema: "homeboy/datamachine-agent-ci-dmc-policy/v1",

--- a/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
@@ -131,6 +131,56 @@ function changedFiles(workspace) {
     .filter((file) => file && !file.startsWith('.ci/'));
 }
 
+function normalizePathPattern(value) {
+  return String(value || '').trim().replace(/^\.\//, '').replace(/^\/+/, '').replace(/\\/g, '/');
+}
+
+function writablePathPatterns(config) {
+  const paths = Array.isArray(config.writable_paths) ? config.writable_paths : [];
+  return paths.map(normalizePathPattern).filter(Boolean);
+}
+
+function globPatternToRegExp(pattern) {
+  let source = '^';
+  const normalized = normalizePathPattern(pattern);
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+    if (char === '*' && next === '*') {
+      source += '.*';
+      index += 1;
+    } else if (char === '*') {
+      source += '[^/]*';
+    } else if (char === '?') {
+      source += '[^/]';
+    } else {
+      source += char.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+    }
+  }
+  source += '$';
+  return new RegExp(source);
+}
+
+function validateWritablePaths(config, files) {
+  const patterns = writablePathPatterns(config);
+  if (patterns.length === 0) {
+    return { enabled: false, patterns: [], rejected_files: [] };
+  }
+
+  const matchers = patterns.map(globPatternToRegExp);
+  const rejected = files
+    .map((file) => normalizePathPattern(file))
+    .filter((file) => file && !matchers.some((matcher) => matcher.test(file)));
+  const success = rejected.length === 0;
+  return {
+    enabled: true,
+    success,
+    patterns,
+    rejected_files: rejected,
+    error: success ? '' : `Changed files outside writable_paths: ${rejected.join(', ')}`,
+  };
+}
+
 function renderTemplate(template, values) {
   return String(template || '').replace(/\{([^}]+)\}/g, (_, key) => {
     const value = values[key.trim()];
@@ -410,12 +460,15 @@ function recordLifecycle(results, scenario, lifecycle) {
   metadata.engine_data.runner_drift_check_results = lifecycle.drift;
   metadata.engine_data.runner_workspace_capture = lifecycle.capture;
   metadata.engine_data.runner_workspace_publication = lifecycle.publication;
+  metadata.engine_data.runner_writable_path_policy = lifecycle.writablePaths;
   metadata.runner_workspace_capture = lifecycle.capture;
   metadata.runner_workspace_publication = lifecycle.publication;
+  metadata.runner_writable_path_policy = lifecycle.writablePaths;
   metadata.verification_results = lifecycle.verification;
   metadata.drift_check_results = lifecycle.drift;
   scenario.metrics.verification_commands_succeeded = !lifecycle.verification.enabled || lifecycle.verification.success ? 1 : 0;
   scenario.metrics.drift_checks_succeeded = !lifecycle.drift.enabled || lifecycle.drift.success ? 1 : 0;
+  scenario.metrics.writable_paths_satisfied = !lifecycle.writablePaths.enabled || lifecycle.writablePaths.success ? 1 : 0;
   scenario.metrics.pr_opened = lifecycle.publication.opened ? 1 : 0;
   scenario.metrics.file_written = lifecycle.capture.changed ? 1 : 0;
   if (lifecycle.success && lifecycle.publication.opened) {
@@ -454,15 +507,22 @@ function main() {
     ? { enabled: false, checks: [], skipped_reason: 'verification_commands_failed' }
     : runCommandChecks(config, workspace, 'drift_checks');
   const files = changedFiles(workspace);
+  const writablePaths = validateWritablePaths(config, files);
   const capture = { enabled: true, changed: files.length > 0, files, workspace };
   let publication = { opened: false };
-  let success = (!verification.enabled || verification.success) && (!drift.enabled || drift.success);
+  let success = (!verification.enabled || verification.success)
+    && (!drift.enabled || drift.success)
+    && (!writablePaths.enabled || writablePaths.success);
   let error = '';
 
   if (!success) {
-    error = verification.enabled && !verification.success
-      ? (verification.error || 'verification_commands failed')
-      : (drift.error || 'drift_checks failed');
+    if (verification.enabled && !verification.success) {
+      error = verification.error || 'verification_commands failed';
+    } else if (drift.enabled && !drift.success) {
+      error = drift.error || 'drift_checks failed';
+    } else {
+      error = writablePaths.error || 'writable_paths policy failed';
+    }
   } else {
     try {
       publication = publishWorkspace(config, results, scenario, workspace, files);
@@ -480,7 +540,7 @@ function main() {
     }
   }
 
-  recordLifecycle(results, scenario, { verification, drift, capture, publication, success, error });
+  recordLifecycle(results, scenario, { verification, drift, writablePaths, capture, publication, success, error });
   writeJson(resultsPath, results);
   if (!success) {
     throw new Error(error);

--- a/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
+++ b/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
@@ -117,6 +117,7 @@ function makeRunFiles(tmp, config) {
   checked('git', ['checkout', 'trunk'], { cwd: repo });
   fs.writeFileSync(path.join(repo, 'generated.txt'), 'hello from agent\n');
   const { configPath, resultsPath } = makeRunFiles(tmp, {
+    writable_paths: ['generated.txt'],
     verification_commands: [{ command: 'test -f generated.txt', description: 'Generated file exists' }],
     drift_checks: [{ command: 'git diff --exit-code', description: 'Verification did not create unstaged drift' }],
   });
@@ -129,6 +130,7 @@ function makeRunFiles(tmp, config) {
   const scenario = output.scenarios[0];
   assert.equal(scenario.metrics.verification_commands_succeeded, 1);
   assert.equal(scenario.metrics.drift_checks_succeeded, 1);
+  assert.equal(scenario.metrics.writable_paths_satisfied, 1);
   assert.equal(scenario.metrics.pr_opened, 1);
   assert.equal(scenario.metadata.success_status, 'pr_opened');
   assert.equal(scenario.metadata.runner_workspace_publication.url, 'https://github.com/owner/repo/pull/1291');
@@ -141,6 +143,31 @@ function makeRunFiles(tmp, config) {
   ).stdout;
   assert.match(publishedFiles, /generated\.txt/);
   assert.doesNotMatch(publishedFiles, /stale\.txt/);
+}
+
+{
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-host-lifecycle-writable-paths.'));
+  const repo = makeRepo(tmp);
+  const gh = makeGhFixture(tmp);
+  fs.mkdirSync(path.join(repo, 'plugins', 'amp'), { recursive: true });
+  fs.writeFileSync(path.join(repo, 'plugins', 'amp', 'AGENTS.md'), 'invalid docs lane output\n');
+  const { configPath, resultsPath } = makeRunFiles(tmp, {
+    writable_paths: ['README.md', 'docs/**', 'plugins/**/README.md'],
+    verification_commands: [{ command: 'test -f plugins/amp/AGENTS.md', description: 'Out-of-policy file exists' }],
+  });
+
+  const result = run('node', [script, '--results', resultsPath, '--config', configPath, '--scenario', 'developer-docs', '--workspace', repo], {
+    env: { PATH: `${gh.bin}${path.delimiter}${process.env.PATH}`, GITHUB_RUN_ID: '12345', GH_TOKEN: 'fixture' },
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Changed files outside writable_paths: plugins\/amp\/AGENTS\.md/);
+  const output = readJson(resultsPath);
+  const scenario = output.scenarios[0];
+  assert.equal(output.status, 'failed');
+  assert.equal(scenario.metrics.writable_paths_satisfied, 0);
+  assert.equal(scenario.metrics.pr_opened, 0);
+  assert.deepEqual(scenario.metadata.runner_writable_path_policy.rejected_files, ['plugins/amp/AGENTS.md']);
+  assert.equal(fs.existsSync(gh.log), false);
 }
 
 {


### PR DESCRIPTION
## Summary
- Add a `writable_paths` reusable workflow input and carry it into the Data Machine agent runner config.
- Fail host runner lifecycle before publication when changed files fall outside the configured writable path allowlist.
- Record rejected paths in metadata for actionable diagnostics.

## Testing
- `node wordpress/tests/datamachine-agent-host-lifecycle-smoke.js`
- Writable paths parser smoke with comma-separated `README.md,docs/**,plugins/**/README.md`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed out-of-policy docs publication, drafted host lifecycle enforcement and tests, and ran focused validation.