### PR TITLE
Ignore runner artifacts in writable path checks

### DIFF
--- a/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
@@ -128,7 +128,7 @@ function changedFiles(workspace) {
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => line.slice(3).trim())
-    .filter((file) => file && !file.startsWith('.ci/'));
+    .filter((file) => file && !file.startsWith('.ci/') && !file.startsWith('datamachine-agent-artifacts/'));
 }
 
 function normalizePathPattern(value) {

--- a/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
+++ b/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
@@ -150,7 +150,9 @@ function makeRunFiles(tmp, config) {
   const repo = makeRepo(tmp);
   const gh = makeGhFixture(tmp);
   fs.mkdirSync(path.join(repo, 'plugins', 'amp'), { recursive: true });
+  fs.mkdirSync(path.join(repo, 'datamachine-agent-artifacts', 'technical-docs-agent'), { recursive: true });
   fs.writeFileSync(path.join(repo, 'plugins', 'amp', 'AGENTS.md'), 'invalid docs lane output\n');
+  fs.writeFileSync(path.join(repo, 'datamachine-agent-artifacts', 'technical-docs-agent', 'transcript.json'), '{}\n');
   const { configPath, resultsPath } = makeRunFiles(tmp, {
     writable_paths: ['README.md', 'docs/**', 'plugins/**/README.md'],
     verification_commands: [{ command: 'test -f plugins/amp/AGENTS.md', description: 'Out-of-policy file exists' }],


### PR DESCRIPTION
## Summary
- Exclude `datamachine-agent-artifacts/**` from host lifecycle changed-file policy checks.
- Preserve writable path enforcement for actual target workspace changes, including out-of-scope docs files.

## Testing
- `node wordpress/tests/datamachine-agent-host-lifecycle-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the BWW enforcement false positive for runner transcript artifacts, drafted the exclusion and smoke coverage.