### PR TITLE
Enforce Data Machine agent workspace contract checks

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -82,6 +82,10 @@ name: Data Machine Agent CI (reusable)
         description: Comma-separated or JSON array of target workspace paths the agent may change. Empty disables host-side path enforcement.
         type: string
         default: ""
+      workspace_contract_checks:
+        description: JSON object of generic host-side post-run workspace checks. Supports paths_exist and glob_min_count.
+        type: string
+        default: "{}"
       include_agent_runtime_dependencies:
         description: "Include the standard WordPress agent runtime stack: Agents API, Data Machine, and Data Machine Code."
         type: boolean
@@ -672,6 +676,7 @@ jobs:
           VERIFICATION_COMMANDS: ${{ inputs.verification_commands }}
           DRIFT_CHECKS: ${{ inputs.drift_checks }}
           WRITABLE_PATHS: ${{ inputs.writable_paths }}
+          WORKSPACE_CONTRACT_CHECKS: ${{ inputs.workspace_contract_checks }}
           PROMPT: ${{ inputs.prompt }}
           PROVIDER: ${{ inputs.provider }}
           MODEL: ${{ inputs.model }}
@@ -826,6 +831,7 @@ jobs:
               end
             | map(if type == "string" and length > 0 then . else error("writable_paths entries must be non-empty strings") end)
           ')"
+          workspace_contract_checks_json="$(validate_json_input workspace_contract_checks object "$WORKSPACE_CONTRACT_CHECKS")"
           extra_wp_config_defines_json="$(validate_json_input extra_wp_config_defines object "$EXTRA_WP_CONFIG_DEFINES")"
           extra_wp_codebox_mounts_json="$(validate_json_input extra_wp_codebox_mounts array "$EXTRA_WP_CODEBOX_MOUNTS" | jq -c --arg workspace "$GITHUB_WORKSPACE" '
             map(
@@ -890,6 +896,7 @@ jobs:
             --argjson verificationCommands "$verification_commands_json" \
             --argjson driftChecks "$drift_checks_json" \
             --argjson writablePaths "$writable_paths_json" \
+            --argjson workspaceContractChecks "$workspace_contract_checks_json" \
             --arg prompt "$PROMPT" \
             --arg provider "$PROVIDER" \
             --arg model "$MODEL" \
@@ -985,6 +992,7 @@ jobs:
               verification_commands: $verificationCommands,
               drift_checks: $driftChecks,
               writable_paths: $writablePaths,
+              workspace_contract_checks: $workspaceContractChecks,
               host_runner_lifecycle: true,
               datamachine_code_policy_attestation: {
                 schema: "homeboy/datamachine-agent-ci-dmc-policy/v1",

--- a/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
@@ -146,8 +146,13 @@ function globPatternToRegExp(pattern) {
     const char = normalized[index];
     const next = normalized[index + 1];
     if (char === '*' && next === '*') {
-      source += '.*';
-      index += 1;
+      if (normalized[index + 2] === '/') {
+        source += '(?:.*/)?';
+        index += 2;
+      } else {
+        source += '.*';
+        index += 1;
+      }
     } else if (char === '*') {
       source += '[^/]*';
     } else if (char === '?') {
@@ -177,6 +182,115 @@ function validateWritablePaths(config, files) {
     patterns,
     rejected_files: rejected,
     error: success ? '' : `Changed files outside writable_paths: ${rejected.join(', ')}`,
+  };
+}
+
+function workspaceContractConfig(config) {
+  return plainObject(config.workspace_contract_checks) ? config.workspace_contract_checks : {};
+}
+
+function contractPathEntries(config, key) {
+  const checks = Array.isArray(config[key]) ? config[key] : [];
+  return checks.flatMap((entry) => {
+    const checkPath = typeof entry === 'string' ? entry : entry?.path;
+    if (typeof checkPath !== 'string' || checkPath.trim() === '') {
+      return [];
+    }
+    return [{
+      path: normalizePathPattern(checkPath),
+      description: typeof entry?.description === 'string' ? entry.description.trim() : '',
+    }];
+  }).filter((entry) => entry.path);
+}
+
+function contractGlobEntries(config) {
+  const checks = Array.isArray(config.glob_min_count) ? config.glob_min_count : [];
+  return checks.flatMap((entry) => {
+    if (!plainObject(entry)) {
+      return [];
+    }
+    const glob = typeof entry.glob === 'string' ? normalizePathPattern(entry.glob) : '';
+    const min = Number(entry.min);
+    if (!glob || !Number.isInteger(min) || min < 0) {
+      return [];
+    }
+    return [{
+      glob,
+      min,
+      description: typeof entry.description === 'string' ? entry.description.trim() : '',
+    }];
+  });
+}
+
+function safeWorkspacePath(workspace, relativePath) {
+  const normalized = normalizePathPattern(relativePath);
+  if (!normalized || normalized.split('/').includes('..')) {
+    return null;
+  }
+  const resolved = path.resolve(workspace, normalized);
+  const workspaceRoot = path.resolve(workspace);
+  if (resolved !== workspaceRoot && !resolved.startsWith(`${workspaceRoot}${path.sep}`)) {
+    return null;
+  }
+  return resolved;
+}
+
+function workspaceFileList(workspace) {
+  const files = [];
+  const excludedDirectories = new Set(['.git', '.ci', 'datamachine-agent-artifacts']);
+  function visit(directory, prefix = '') {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (entry.isDirectory() && excludedDirectories.has(entry.name)) {
+        continue;
+      }
+      const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+      const fullPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath, relative);
+      } else if (entry.isFile()) {
+        files.push(normalizePathPattern(relative));
+      }
+    }
+  }
+  visit(workspace);
+  return files;
+}
+
+function evaluateWorkspaceContract(config, workspace) {
+  const contract = workspaceContractConfig(config);
+  const pathChecks = contractPathEntries(contract, 'paths_exist');
+  const globChecks = contractGlobEntries(contract);
+  if (pathChecks.length === 0 && globChecks.length === 0) {
+    return { enabled: false, success: true, paths_exist: [], glob_min_count: [] };
+  }
+
+  const pathsExist = pathChecks.map((entry) => {
+    const resolved = safeWorkspacePath(workspace, entry.path);
+    const exists = Boolean(resolved && fs.existsSync(resolved));
+    return { ...entry, exists, success: exists };
+  });
+  const workspaceFiles = globChecks.length > 0 ? workspaceFileList(workspace) : [];
+  const globMinCount = globChecks.map((entry) => {
+    const matcher = globPatternToRegExp(entry.glob);
+    const matches = workspaceFiles.filter((file) => matcher.test(file));
+    return {
+      ...entry,
+      count: matches.length,
+      matches,
+      success: matches.length >= entry.min,
+    };
+  });
+  const failures = [
+    ...pathsExist.filter((entry) => !entry.success).map((entry) => `missing path ${entry.path}`),
+    ...globMinCount.filter((entry) => !entry.success).map((entry) => `glob ${entry.glob} matched ${entry.count}, expected at least ${entry.min}`),
+  ];
+  const success = failures.length === 0;
+  return {
+    enabled: true,
+    success,
+    paths_exist: pathsExist,
+    glob_min_count: globMinCount,
+    error: success ? '' : `workspace_contract_checks failed: ${failures.join('; ')}`,
   };
 }
 
@@ -467,14 +581,17 @@ function recordLifecycle(results, scenario, lifecycle) {
   metadata.engine_data.runner_workspace_capture = lifecycle.capture;
   metadata.engine_data.runner_workspace_publication = lifecycle.publication;
   metadata.engine_data.runner_writable_path_policy = lifecycle.writablePaths;
+  metadata.engine_data.runner_workspace_contract = lifecycle.workspaceContract;
   metadata.runner_workspace_capture = lifecycle.capture;
   metadata.runner_workspace_publication = lifecycle.publication;
   metadata.runner_writable_path_policy = lifecycle.writablePaths;
+  metadata.runner_workspace_contract = lifecycle.workspaceContract;
   metadata.verification_results = lifecycle.verification;
   metadata.drift_check_results = lifecycle.drift;
   scenario.metrics.verification_commands_succeeded = !lifecycle.verification.enabled || lifecycle.verification.success ? 1 : 0;
   scenario.metrics.drift_checks_succeeded = !lifecycle.drift.enabled || lifecycle.drift.success ? 1 : 0;
   scenario.metrics.writable_paths_satisfied = !lifecycle.writablePaths.enabled || lifecycle.writablePaths.success ? 1 : 0;
+  scenario.metrics.workspace_contract_satisfied = !lifecycle.workspaceContract.enabled || lifecycle.workspaceContract.success ? 1 : 0;
   scenario.metrics.pr_opened = lifecycle.publication.opened ? 1 : 0;
   scenario.metrics.file_written = lifecycle.capture.changed ? 1 : 0;
   if (lifecycle.success && lifecycle.publication.opened) {
@@ -515,6 +632,7 @@ function main() {
   const workspaceFiles = changedFiles(workspace);
   const files = agentFiles;
   const writablePaths = validateWritablePaths(config, files);
+  const workspaceContract = evaluateWorkspaceContract(config, workspace);
   const verificationSideEffectFiles = differenceFiles(workspaceFiles, agentFiles);
   const capture = {
     enabled: true,
@@ -527,7 +645,8 @@ function main() {
   let publication = { opened: false };
   let success = (!verification.enabled || verification.success)
     && (!drift.enabled || drift.success)
-    && (!writablePaths.enabled || writablePaths.success);
+    && (!writablePaths.enabled || writablePaths.success)
+    && (!workspaceContract.enabled || workspaceContract.success);
   let error = '';
 
   if (!success) {
@@ -535,6 +654,8 @@ function main() {
       error = verification.error || 'verification_commands failed';
     } else if (drift.enabled && !drift.success) {
       error = drift.error || 'drift_checks failed';
+    } else if (workspaceContract.enabled && !workspaceContract.success) {
+      error = workspaceContract.error || 'workspace_contract_checks failed';
     } else {
       error = writablePaths.error || 'writable_paths policy failed';
     }
@@ -555,7 +676,7 @@ function main() {
     }
   }
 
-  recordLifecycle(results, scenario, { verification, drift, writablePaths, capture, publication, success, error });
+  recordLifecycle(results, scenario, { verification, drift, writablePaths, workspaceContract, capture, publication, success, error });
   writeJson(resultsPath, results);
   if (!success) {
     throw new Error(error);
@@ -572,6 +693,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  evaluateWorkspaceContract,
   prepareRunnerCommand,
   runShellCommand,
 };

--- a/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
+++ b/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
@@ -146,6 +146,63 @@ function makeRunFiles(tmp, config) {
 }
 
 {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-host-lifecycle-workspace-contract-success.'));
+  const repo = makeRepo(tmp);
+  const gh = makeGhFixture(tmp);
+  fs.mkdirSync(path.join(repo, 'docs', 'reference'), { recursive: true });
+  fs.writeFileSync(path.join(repo, 'docs', 'architecture.md'), '# Architecture\n');
+  fs.writeFileSync(path.join(repo, 'docs', 'reference', 'api.md'), '# API\n');
+  const { configPath, resultsPath } = makeRunFiles(tmp, {
+    writable_paths: ['docs/**'],
+    workspace_contract_checks: {
+      paths_exist: ['docs/architecture.md'],
+      glob_min_count: [{ glob: 'docs/**/*.md', min: 2 }],
+    },
+  });
+
+  const result = run('node', [script, '--results', resultsPath, '--config', configPath, '--scenario', 'developer-docs', '--workspace', repo], {
+    env: { PATH: `${gh.bin}${path.delimiter}${process.env.PATH}`, GITHUB_RUN_ID: '12345', GH_TOKEN: 'fixture' },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const output = readJson(resultsPath);
+  const scenario = output.scenarios[0];
+  assert.equal(scenario.metrics.workspace_contract_satisfied, 1);
+  assert.equal(scenario.metrics.pr_opened, 1);
+  assert.equal(scenario.metadata.runner_workspace_contract.paths_exist[0].success, true);
+  assert.equal(scenario.metadata.runner_workspace_contract.glob_min_count[0].count, 2);
+}
+
+{
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-host-lifecycle-workspace-contract-failure.'));
+  const repo = makeRepo(tmp);
+  const gh = makeGhFixture(tmp);
+  fs.mkdirSync(path.join(repo, 'docs'), { recursive: true });
+  fs.writeFileSync(path.join(repo, 'docs', 'architecture.md'), '# Architecture\n');
+  const { configPath, resultsPath } = makeRunFiles(tmp, {
+    writable_paths: ['docs/**'],
+    workspace_contract_checks: {
+      paths_exist: ['docs/index.md'],
+      glob_min_count: [{ glob: 'docs/**/*.md', min: 2 }],
+    },
+  });
+
+  const result = run('node', [script, '--results', resultsPath, '--config', configPath, '--scenario', 'developer-docs', '--workspace', repo], {
+    env: { PATH: `${gh.bin}${path.delimiter}${process.env.PATH}`, GITHUB_RUN_ID: '12345', GH_TOKEN: 'fixture' },
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /workspace_contract_checks failed/);
+  assert.match(result.stderr, /missing path docs\/index\.md/);
+  const output = readJson(resultsPath);
+  const scenario = output.scenarios[0];
+  assert.equal(output.status, 'failed');
+  assert.equal(scenario.metrics.workspace_contract_satisfied, 0);
+  assert.equal(scenario.metrics.pr_opened, 0);
+  assert.equal(scenario.metadata.runner_workspace_contract.paths_exist[0].success, false);
+  assert.equal(scenario.metadata.runner_workspace_contract.glob_min_count[0].success, false);
+  assert.equal(fs.existsSync(gh.log), false);
+}
+
+{
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-host-lifecycle-writable-paths.'));
   const repo = makeRepo(tmp);
   const gh = makeGhFixture(tmp);


### PR DESCRIPTION
## Summary
- Adds reusable `workspace_contract_checks` JSON input for Data Machine Agent CI host lifecycle runs.
- Evaluates generic `paths_exist` and `glob_min_count` checks before workspace publication so incomplete output fails before opening/updating a PR.
- Records contract metadata/metrics and covers success/failure paths in the host lifecycle smoke test.

## Verification
- `node wordpress/tests/datamachine-agent-host-lifecycle-smoke.js`

Closes #1314.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the host lifecycle contract checks, workflow plumbing, and smoke test coverage; Chris remains responsible for review and merge.