### PR TITLE
Enforce full workspace contract checks

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -83,7 +83,7 @@ name: Data Machine Agent CI (reusable)
         type: string
         default: ""
       workspace_contract_checks:
-        description: JSON object of generic host-side post-run workspace checks. Supports paths_exist and glob_min_count.
+        description: JSON object of generic host-side post-run workspace checks. Supports paths_exist, glob_min_count, entry_points, and forbidden_phrases.
         type: string
         default: "{}"
       include_agent_runtime_dependencies:

--- a/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
@@ -222,6 +222,44 @@ function contractGlobEntries(config) {
   });
 }
 
+function contractEntryPointEntries(config) {
+  const checks = Array.isArray(config.entry_points) ? config.entry_points : [];
+  return checks.flatMap((entry) => {
+    if (!plainObject(entry)) {
+      return [];
+    }
+    const entryPath = typeof entry.path === 'string'
+      ? entry.path
+      : (typeof entry.entry_path === 'string' ? entry.entry_path : entry.entry);
+    const mustLinkTo = Array.isArray(entry.must_link_to) ? entry.must_link_to : [entry.must_link_to];
+    const targets = mustLinkTo
+      .map((target) => normalizePathPattern(target))
+      .filter(Boolean);
+    if (typeof entryPath !== 'string' || entryPath.trim() === '' || targets.length === 0) {
+      return [];
+    }
+    return [{
+      path: normalizePathPattern(entryPath),
+      must_link_to: targets,
+      description: typeof entry.description === 'string' ? entry.description.trim() : '',
+    }];
+  }).filter((entry) => entry.path);
+}
+
+function contractForbiddenPhraseEntries(config) {
+  const checks = Array.isArray(config.forbidden_phrases) ? config.forbidden_phrases : [];
+  return checks.flatMap((entry) => {
+    const phrase = typeof entry === 'string' ? entry : entry?.phrase;
+    if (typeof phrase !== 'string' || phrase.trim() === '') {
+      return [];
+    }
+    return [{
+      phrase: phrase.trim(),
+      description: typeof entry?.description === 'string' ? entry.description.trim() : '',
+    }];
+  });
+}
+
 function safeWorkspacePath(workspace, relativePath) {
   const normalized = normalizePathPattern(relativePath);
   if (!normalized || normalized.split('/').includes('..')) {
@@ -256,12 +294,105 @@ function workspaceFileList(workspace) {
   return files;
 }
 
+function isWorkspaceTextFile(file) {
+  return /\.(md|markdown|mdx|txt|text)$/i.test(file);
+}
+
+function scopedContractFiles(config, contract, workspace, workspaceFiles, pathChecks, globChecks, entryChecks) {
+  const explicitScope = Array.isArray(contract.scope) ? contract.scope : [];
+  const scopePatterns = [
+    ...explicitScope.map(normalizePathPattern),
+    ...writablePathPatterns(config),
+    ...globChecks.map((entry) => entry.glob),
+  ].filter(Boolean);
+  const scopeMatchers = scopePatterns.map(globPatternToRegExp);
+  const explicitFiles = new Set([
+    ...pathChecks.map((entry) => entry.path),
+    ...entryChecks.map((entry) => entry.path),
+  ].filter(Boolean));
+
+  return workspaceFiles.filter((file) => {
+    if (!isWorkspaceTextFile(file)) {
+      return false;
+    }
+    if (scopeMatchers.length === 0 && explicitFiles.size === 0) {
+      return true;
+    }
+    if (explicitFiles.has(file)) {
+      return true;
+    }
+    return scopeMatchers.some((matcher) => matcher.test(file));
+  }).filter((file) => Boolean(safeWorkspacePath(workspace, file)));
+}
+
+function entryPointLinksTo(content, target, entryPath) {
+  const normalized = normalizePathPattern(target);
+  const relativeFromEntry = normalizePathPattern(path.posix.relative(path.posix.dirname(entryPath), normalized));
+  const candidates = new Set([
+    target,
+    normalized,
+    `./${normalized}`,
+    relativeFromEntry,
+    `./${relativeFromEntry}`,
+    encodeURI(normalized),
+    `./${encodeURI(normalized)}`,
+    encodeURI(relativeFromEntry),
+    `./${encodeURI(relativeFromEntry)}`,
+  ].filter(Boolean));
+  for (const candidate of candidates) {
+    if (content.includes(candidate)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function evaluateEntryPoints(entries, workspace) {
+  return entries.map((entry) => {
+    const resolved = safeWorkspacePath(workspace, entry.path);
+    const exists = Boolean(resolved && fs.existsSync(resolved) && fs.statSync(resolved).isFile());
+    const content = exists ? fs.readFileSync(resolved, 'utf8') : '';
+    const missing_targets = exists
+      ? entry.must_link_to.filter((target) => !entryPointLinksTo(content, target, entry.path))
+      : [...entry.must_link_to];
+    return {
+      ...entry,
+      exists,
+      missing_targets,
+      success: exists && missing_targets.length === 0,
+    };
+  });
+}
+
+function evaluateForbiddenPhrases(entries, workspace, scopedFiles) {
+  return entries.map((entry) => {
+    const matching_files = [];
+    for (const file of scopedFiles) {
+      const resolved = safeWorkspacePath(workspace, file);
+      if (!resolved || !fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) {
+        continue;
+      }
+      const content = fs.readFileSync(resolved, 'utf8');
+      if (content.includes(entry.phrase)) {
+        matching_files.push(file);
+      }
+    }
+    return {
+      ...entry,
+      matching_files,
+      success: matching_files.length === 0,
+    };
+  });
+}
+
 function evaluateWorkspaceContract(config, workspace) {
   const contract = workspaceContractConfig(config);
   const pathChecks = contractPathEntries(contract, 'paths_exist');
   const globChecks = contractGlobEntries(contract);
-  if (pathChecks.length === 0 && globChecks.length === 0) {
-    return { enabled: false, success: true, paths_exist: [], glob_min_count: [] };
+  const entryChecks = contractEntryPointEntries(contract);
+  const forbiddenPhraseChecks = contractForbiddenPhraseEntries(contract);
+  if (pathChecks.length === 0 && globChecks.length === 0 && entryChecks.length === 0 && forbiddenPhraseChecks.length === 0) {
+    return { enabled: false, success: true, paths_exist: [], glob_min_count: [], entry_points: [], forbidden_phrases: [] };
   }
 
   const pathsExist = pathChecks.map((entry) => {
@@ -269,7 +400,8 @@ function evaluateWorkspaceContract(config, workspace) {
     const exists = Boolean(resolved && fs.existsSync(resolved));
     return { ...entry, exists, success: exists };
   });
-  const workspaceFiles = globChecks.length > 0 ? workspaceFileList(workspace) : [];
+  const needsWorkspaceFiles = globChecks.length > 0 || forbiddenPhraseChecks.length > 0;
+  const workspaceFiles = needsWorkspaceFiles ? workspaceFileList(workspace) : [];
   const globMinCount = globChecks.map((entry) => {
     const matcher = globPatternToRegExp(entry.glob);
     const matches = workspaceFiles.filter((file) => matcher.test(file));
@@ -280,9 +412,16 @@ function evaluateWorkspaceContract(config, workspace) {
       success: matches.length >= entry.min,
     };
   });
+  const entryPoints = evaluateEntryPoints(entryChecks, workspace);
+  const forbiddenPhraseFiles = forbiddenPhraseChecks.length > 0
+    ? scopedContractFiles(config, contract, workspace, workspaceFiles, pathChecks, globChecks, entryChecks)
+    : [];
+  const forbiddenPhrases = evaluateForbiddenPhrases(forbiddenPhraseChecks, workspace, forbiddenPhraseFiles);
   const failures = [
     ...pathsExist.filter((entry) => !entry.success).map((entry) => `missing path ${entry.path}`),
     ...globMinCount.filter((entry) => !entry.success).map((entry) => `glob ${entry.glob} matched ${entry.count}, expected at least ${entry.min}`),
+    ...entryPoints.filter((entry) => !entry.success).map((entry) => `entry_points ${entry.path} missing links: ${entry.missing_targets.join(', ')}`),
+    ...forbiddenPhrases.filter((entry) => !entry.success).map((entry) => `forbidden phrase ${JSON.stringify(entry.phrase)} found in ${entry.matching_files.join(', ')}`),
   ];
   const success = failures.length === 0;
   return {
@@ -290,6 +429,9 @@ function evaluateWorkspaceContract(config, workspace) {
     success,
     paths_exist: pathsExist,
     glob_min_count: globMinCount,
+    entry_points: entryPoints,
+    forbidden_phrases: forbiddenPhrases,
+    forbidden_phrase_files: forbiddenPhraseFiles,
     error: success ? '' : `workspace_contract_checks failed: ${failures.join('; ')}`,
   };
 }

--- a/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
+++ b/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
@@ -150,6 +150,7 @@ function makeRunFiles(tmp, config) {
   const repo = makeRepo(tmp);
   const gh = makeGhFixture(tmp);
   fs.mkdirSync(path.join(repo, 'docs', 'reference'), { recursive: true });
+  fs.writeFileSync(path.join(repo, 'docs', 'index.md'), '# Docs\n\n- [Architecture](architecture.md)\n- [API](reference/api.md)\n');
   fs.writeFileSync(path.join(repo, 'docs', 'architecture.md'), '# Architecture\n');
   fs.writeFileSync(path.join(repo, 'docs', 'reference', 'api.md'), '# API\n');
   const { configPath, resultsPath } = makeRunFiles(tmp, {
@@ -157,6 +158,8 @@ function makeRunFiles(tmp, config) {
     workspace_contract_checks: {
       paths_exist: ['docs/architecture.md'],
       glob_min_count: [{ glob: 'docs/**/*.md', min: 2 }],
+      entry_points: [{ path: 'docs/index.md', must_link_to: ['docs/architecture.md', 'docs/reference/api.md'] }],
+      forbidden_phrases: ['TODO_GENERATED_DOCS'],
     },
   });
 
@@ -169,7 +172,11 @@ function makeRunFiles(tmp, config) {
   assert.equal(scenario.metrics.workspace_contract_satisfied, 1);
   assert.equal(scenario.metrics.pr_opened, 1);
   assert.equal(scenario.metadata.runner_workspace_contract.paths_exist[0].success, true);
-  assert.equal(scenario.metadata.runner_workspace_contract.glob_min_count[0].count, 2);
+  assert.equal(scenario.metadata.runner_workspace_contract.glob_min_count[0].count, 3);
+  assert.equal(scenario.metadata.runner_workspace_contract.entry_points[0].success, true);
+  assert.deepEqual(scenario.metadata.runner_workspace_contract.entry_points[0].missing_targets, []);
+  assert.equal(scenario.metadata.runner_workspace_contract.forbidden_phrases[0].success, true);
+  assert.deepEqual(scenario.metadata.runner_workspace_contract.forbidden_phrases[0].matching_files, []);
 }
 
 {
@@ -177,12 +184,15 @@ function makeRunFiles(tmp, config) {
   const repo = makeRepo(tmp);
   const gh = makeGhFixture(tmp);
   fs.mkdirSync(path.join(repo, 'docs'), { recursive: true });
-  fs.writeFileSync(path.join(repo, 'docs', 'architecture.md'), '# Architecture\n');
+  fs.writeFileSync(path.join(repo, 'docs', 'index.md'), '# Docs\n\n- [Architecture](architecture.md)\n');
+  fs.writeFileSync(path.join(repo, 'docs', 'architecture.md'), '# Architecture\n\nTODO_GENERATED_DOCS\n');
   const { configPath, resultsPath } = makeRunFiles(tmp, {
     writable_paths: ['docs/**'],
     workspace_contract_checks: {
       paths_exist: ['docs/index.md'],
-      glob_min_count: [{ glob: 'docs/**/*.md', min: 2 }],
+      glob_min_count: [{ glob: 'docs/**/*.md', min: 3 }],
+      entry_points: [{ path: 'docs/index.md', must_link_to: ['docs/architecture.md', 'docs/reference/api.md'] }],
+      forbidden_phrases: ['TODO_GENERATED_DOCS'],
     },
   });
 
@@ -191,14 +201,20 @@ function makeRunFiles(tmp, config) {
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /workspace_contract_checks failed/);
-  assert.match(result.stderr, /missing path docs\/index\.md/);
+  assert.match(result.stderr, /glob docs\/\*\*\/\*\.md matched 2, expected at least 3/);
+  assert.match(result.stderr, /entry_points docs\/index\.md missing links: docs\/reference\/api\.md/);
+  assert.match(result.stderr, /forbidden phrase "TODO_GENERATED_DOCS" found in docs\/architecture\.md/);
   const output = readJson(resultsPath);
   const scenario = output.scenarios[0];
   assert.equal(output.status, 'failed');
   assert.equal(scenario.metrics.workspace_contract_satisfied, 0);
   assert.equal(scenario.metrics.pr_opened, 0);
-  assert.equal(scenario.metadata.runner_workspace_contract.paths_exist[0].success, false);
+  assert.equal(scenario.metadata.runner_workspace_contract.paths_exist[0].success, true);
   assert.equal(scenario.metadata.runner_workspace_contract.glob_min_count[0].success, false);
+  assert.equal(scenario.metadata.runner_workspace_contract.entry_points[0].success, false);
+  assert.deepEqual(scenario.metadata.runner_workspace_contract.entry_points[0].missing_targets, ['docs/reference/api.md']);
+  assert.equal(scenario.metadata.runner_workspace_contract.forbidden_phrases[0].success, false);
+  assert.deepEqual(scenario.metadata.runner_workspace_contract.forbidden_phrases[0].matching_files, ['docs/architecture.md']);
   assert.equal(fs.existsSync(gh.log), false);
 }
 


### PR DESCRIPTION
## Summary
- Enforces `entry_points` by reading each declared entry file and verifying every `must_link_to` target is linked, including workspace-root targets linked relatively from the entry file.
- Enforces `forbidden_phrases` by scanning scoped markdown/text workspace files and reporting only phrases plus matching file paths.
- Extends host lifecycle smoke coverage for success and failure cases while preserving existing `paths_exist` and `glob_min_count` behavior.

Fixes #1316.

## Testing
- `node wordpress/tests/datamachine-agent-host-lifecycle-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner enforcement, smoke tests, and verification steps; Chris remains responsible for review and merge.