### PR TITLE
Materialize WordPress bench dependency plugin packages

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -100,6 +100,11 @@ homeboy_get_validation_dependency_slug() {
         return 0
     fi
 
+    if [ -f "${plugin_path}/plugins/${canonical_dir_slug}/${canonical_dir_slug}.php" ] || [ -f "${plugin_path}/plugins/${canonical_dir_slug}/plugin.php" ]; then
+        printf '%s\n' "$canonical_dir_slug"
+        return 0
+    fi
+
     local main_file
     main_file=$(find "$plugin_path" -maxdepth 1 -name "*.php" -exec grep -l "Plugin Name:" {} \; 2>/dev/null | head -1)
     if [ -n "$main_file" ]; then
@@ -155,6 +160,29 @@ homeboy_find_validation_dependency_plugin_main_file() {
             return 0
         fi
     done
+
+    return 1
+}
+
+homeboy_find_validation_dependency_plugin_package_root() {
+    local plugin_path="${1:-}"
+    local dependency_slug="${2:-}"
+    local plugin_file
+
+    [ -n "$plugin_path" ] && [ -d "$plugin_path" ] || return 1
+
+    plugin_file=$(homeboy_find_validation_dependency_plugin_main_file "$plugin_path" || true)
+    if [ -n "$plugin_file" ]; then
+        printf '%s\n' "$plugin_path"
+        return 0
+    fi
+
+    [ -n "$dependency_slug" ] || dependency_slug=$(homeboy_get_validation_dependency_slug "$plugin_path" || basename "$plugin_path")
+    plugin_file=$(_homeboy_wordpress_dependency_preflight_source_checkout_plugin_file "$plugin_path" "$dependency_slug" || true)
+    if [ -n "$plugin_file" ]; then
+        dirname "$plugin_file"
+        return 0
+    fi
 
     return 1
 }
@@ -388,6 +416,16 @@ homeboy_preflight_wordpress_dependency_plugins() {
             continue
         fi
 
+        if [ "$context" = "bench" ]; then
+            local package_root
+            package_root=$(homeboy_find_validation_dependency_plugin_package_root "$dependency_path" "$dependency_slug" || true)
+            if [ -n "$package_root" ] && [ "$package_root" != "$dependency_path" ]; then
+                dependency_path="$package_root"
+                dependency_slug=$(homeboy_get_validation_dependency_slug "$dependency_path" || basename "$dependency_path")
+                expected_plugin_file="${dependency_path%/}/${dependency_slug}.php"
+            fi
+        fi
+
         plugin_file=$(homeboy_find_validation_dependency_plugin_main_file "$dependency_path" || true)
         if [ -z "$plugin_file" ]; then
             nested_plugin_file=$(_homeboy_wordpress_dependency_preflight_source_checkout_plugin_file "$dependency_path" "$dependency_slug" || true)
@@ -403,6 +441,10 @@ homeboy_preflight_wordpress_dependency_plugins() {
             fi
             echo "  Use a packaged plugin build for WordPress runtime bench/trace evidence." >&2
             failed=1
+            continue
+        fi
+
+        if [ "$context" = "bench" ]; then
             continue
         fi
 
@@ -1130,21 +1172,30 @@ _homeboy_prepared_dependency_cache_metadata() {
     local prepare_root="${2:-}"
     local relative_plugin_path="${3:-}"
     local dependency_slug="${4:-}"
-    local php_version source_realpath prepare_realpath git_state composer_json_hash composer_lock_hash
+    local package_root="${5:-}"
+    local mounted_plugin_dir="${6:-}"
+    local php_version source_realpath prepare_realpath package_realpath git_state composer_json_hash composer_lock_hash
 
     source_realpath=$(cd "$dependency_path" && pwd -P)
     prepare_realpath=$(cd "$prepare_root" && pwd -P)
+    if [ -n "$package_root" ] && [ -d "$package_root" ]; then
+        package_realpath=$(cd "$package_root" && pwd -P)
+    else
+        package_realpath="$source_realpath"
+    fi
     php_version=$(_homeboy_prepared_dependency_php_version)
     git_state=$(_homeboy_prepared_dependency_git_state "$prepare_root")
-    composer_json_hash=$(_homeboy_sha256_file "${dependency_path}/composer.json")
-    composer_lock_hash=$(_homeboy_sha256_file "${dependency_path}/composer.lock")
+    composer_json_hash=$(_homeboy_sha256_file "${package_realpath}/composer.json")
+    composer_lock_hash=$(_homeboy_sha256_file "${package_realpath}/composer.lock")
 
     jq -n \
         --arg schema 'homeboy/prepared-wordpress-bench-dependency/v1' \
         --arg slug "$dependency_slug" \
         --arg source_path "$source_realpath" \
         --arg prepare_root "$prepare_realpath" \
+        --arg package_root "$package_realpath" \
         --arg relative_plugin_path "$relative_plugin_path" \
+        --arg mounted_plugin_dir "$mounted_plugin_dir" \
         --arg git_state "$git_state" \
         --arg composer_json_hash "$composer_json_hash" \
         --arg composer_lock_hash "$composer_lock_hash" \
@@ -1154,7 +1205,9 @@ _homeboy_prepared_dependency_cache_metadata() {
             slug: $slug,
             source_path: $source_path,
             prepare_root: $prepare_root,
+            package_root: $package_root,
             relative_plugin_path: $relative_plugin_path,
+            mounted_plugin_dir: $mounted_plugin_dir,
             git_state: $git_state,
             composer_json_hash: $composer_json_hash,
             composer_lock_hash: $composer_lock_hash,
@@ -1165,7 +1218,7 @@ _homeboy_prepared_dependency_cache_metadata() {
 _homeboy_prepared_dependency_cache_key() {
     local metadata_json="${1:-}"
 
-    printf '%s' "$metadata_json" | jq -c '{source_path, prepare_root, relative_plugin_path, git_state, composer_json_hash, composer_lock_hash, php_version}' | _homeboy_sha256_string
+    printf '%s' "$metadata_json" | jq -c '{source_path, prepare_root, package_root, relative_plugin_path, mounted_plugin_dir, git_state, composer_json_hash, composer_lock_hash, php_version}' | _homeboy_sha256_string
 }
 
 _homeboy_record_prepared_dependency_metadata() {
@@ -1202,8 +1255,22 @@ homeboy_prepare_validation_dependency_for_wp_codebox_bench() {
 
     [ -n "$dependency_path" ] && [ -d "$dependency_path" ] || return 1
 
-    if ! homeboy_dependency_needs_composer_prepare "$dependency_path"; then
-        printf '%s\n' "$dependency_path"
+    local dependency_slug package_root
+    dependency_slug=$(homeboy_get_validation_dependency_slug "$dependency_path" || basename "$dependency_path")
+    package_root=$(homeboy_find_validation_dependency_plugin_package_root "$dependency_path" "$dependency_slug" || true)
+    [ -n "$package_root" ] && [ -d "$package_root" ] || package_root="$dependency_path"
+
+    if ! homeboy_dependency_needs_composer_prepare "$package_root"; then
+        local source_realpath package_realpath relative_source_plugin_path metadata_json
+        source_realpath=$(cd "$dependency_path" && pwd -P)
+        package_realpath=$(cd "$package_root" && pwd -P)
+        relative_source_plugin_path=""
+        if [ "$package_realpath" != "$source_realpath" ]; then
+            relative_source_plugin_path="${package_realpath#"$source_realpath"/}"
+        fi
+        metadata_json=$(_homeboy_prepared_dependency_cache_metadata "$dependency_path" "$dependency_path" "$relative_source_plugin_path" "$dependency_slug" "$package_root" "/wordpress/wp-content/plugins/${dependency_slug}")
+        _homeboy_record_prepared_dependency_metadata "$artifacts_dir" "$metadata_json" "source-package-root" "$package_root" "source"
+        printf '%s\n' "$package_root"
         return 0
     fi
 
@@ -1212,11 +1279,8 @@ homeboy_prepare_validation_dependency_for_wp_codebox_bench() {
         return 1
     fi
 
-    local dependency_slug
-    dependency_slug=$(homeboy_get_validation_dependency_slug "$dependency_path" || basename "$dependency_path")
-
     local prepare_root
-    prepare_root="$(_homeboy_dependency_repo_root "$dependency_path")"
+    prepare_root="$(_homeboy_dependency_repo_root "$package_root")"
     [ -n "$prepare_root" ] && [ -d "$prepare_root" ] || prepare_root="$dependency_path"
 
     local dependency_realpath prepare_realpath relative_plugin_path
@@ -1237,7 +1301,7 @@ homeboy_prepare_validation_dependency_for_wp_codebox_bench() {
     esac
 
     local cache_metadata cache_key cache_dir cache_entry prepared_root prepared_plugin_path metadata_file
-    cache_metadata=$(_homeboy_prepared_dependency_cache_metadata "$dependency_path" "$prepare_root" "$relative_plugin_path" "$dependency_slug")
+    cache_metadata=$(_homeboy_prepared_dependency_cache_metadata "$dependency_path" "$prepare_root" "$relative_plugin_path" "$dependency_slug" "$package_root" "/wordpress/wp-content/plugins/${dependency_slug}")
     cache_key=$(_homeboy_prepared_dependency_cache_key "$cache_metadata")
     cache_dir=$(_homeboy_prepared_dependency_cache_dir "$artifacts_dir")
     cache_entry="${cache_dir%/}/${dependency_slug}-${cache_key}"

--- a/wordpress/tests/dependency-plugin-preflight-smoke.sh
+++ b/wordpress/tests/dependency-plugin-preflight-smoke.sh
@@ -44,12 +44,20 @@ cat > "${WOOCOMMERCE_SOURCE}/plugins/woocommerce/woocommerce.php" <<'PHP'
 PHP
 
 MISSING_MAIN_ARTIFACTS="${TMP_ROOT}/missing-main-artifacts"
-if homeboy_preflight_wordpress_dependency_plugins "$WOOCOMMERCE_SOURCE" "$MISSING_MAIN_ARTIFACTS" "bench"; then
-    echo "ERROR: expected source checkout without root plugin main file to fail." >&2
+homeboy_preflight_wordpress_dependency_plugins "$WOOCOMMERCE_SOURCE" "$MISSING_MAIN_ARTIFACTS" "bench"
+if [ -f "${MISSING_MAIN_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" ]; then
+    echo "ERROR: materializable source checkout dependency should not emit bench preflight diagnostics." >&2
+    jq '.' "${MISSING_MAIN_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" >&2 || true
+    exit 1
+fi
+
+MISSING_MAIN_VALIDATION_ARTIFACTS="${TMP_ROOT}/missing-main-validation-artifacts"
+if homeboy_preflight_wordpress_dependency_plugins "$WOOCOMMERCE_SOURCE" "$MISSING_MAIN_VALIDATION_ARTIFACTS" "wordpress"; then
+    echo "ERROR: expected source checkout without root plugin main file to fail outside bench materialization." >&2
     exit 1
 fi
 assert_diagnostic \
-    "${MISSING_MAIN_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" \
+    "${MISSING_MAIN_VALIDATION_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" \
     '(.diagnostics | length) == 1 and .diagnostics[0].code == "wordpress-dependency-plugin-main-file-missing" and .diagnostics[0].package_required == true and (.diagnostics[0].source_checkout_plugin_file | endswith("/plugins/woocommerce/woocommerce.php"))' \
     'missing main file diagnostic did not identify source-checkout package requirement.'
 
@@ -64,12 +72,20 @@ require_once __DIR__ . '/includes/react-admin/feature-config.php';
 PHP
 
 LOAD_FATAL_ARTIFACTS="${TMP_ROOT}/load-fatal-artifacts"
-if homeboy_preflight_wordpress_dependency_plugins "$FATAL_DEP" "$LOAD_FATAL_ARTIFACTS" "bench"; then
-    echo "ERROR: expected plugin load fatal preflight to fail." >&2
+homeboy_preflight_wordpress_dependency_plugins "$FATAL_DEP" "$LOAD_FATAL_ARTIFACTS" "bench"
+if [ -f "${LOAD_FATAL_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" ]; then
+    echo "ERROR: bench dependency load preflight should defer plugin activation to WP Codebox." >&2
+    jq '.' "${LOAD_FATAL_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" >&2 || true
+    exit 1
+fi
+
+LOAD_FATAL_VALIDATION_ARTIFACTS="${TMP_ROOT}/load-fatal-validation-artifacts"
+if homeboy_preflight_wordpress_dependency_plugins "$FATAL_DEP" "$LOAD_FATAL_VALIDATION_ARTIFACTS" "wordpress"; then
+    echo "ERROR: expected plugin load fatal preflight to fail outside bench materialization." >&2
     exit 1
 fi
 assert_diagnostic \
-    "${LOAD_FATAL_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" \
+    "${LOAD_FATAL_VALIDATION_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" \
     '(.diagnostics | length) == 1 and .diagnostics[0].code == "wordpress-dependency-plugin-load-fatal" and .diagnostics[0].package_required == true and (.diagnostics[0].missing_include | endswith("/includes/react-admin/feature-config.php"))' \
     'load fatal diagnostic did not identify the missing build artifact.'
 

--- a/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
@@ -12,12 +12,19 @@ try {
   const extensionPath = path.join(__dirname, '..');
   const componentPath = path.join(root, 'bootstrap-steps-fixture');
   const dependencyPath = path.join(root, 'generic-dependency');
+  const monorepoDependencyPath = path.join(root, 'woocommerce@fix-test-branch');
+  const monorepoPluginPath = path.join(monorepoDependencyPath, 'plugins', 'woocommerce');
+  const stripeDependencyPath = path.join(root, 'woocommerce-gateway-stripe');
   const fixtureCoreModule = path.join(__dirname, 'fixtures', 'wp-codebox-core-bench-runner.mjs');
   const benchDir = path.join(componentPath, 'tests', 'bench');
   fs.mkdirSync(benchDir, { recursive: true });
   fs.mkdirSync(dependencyPath, { recursive: true });
+  fs.mkdirSync(monorepoPluginPath, { recursive: true });
+  fs.mkdirSync(stripeDependencyPath, { recursive: true });
   fs.writeFileSync(path.join(componentPath, 'bootstrap-steps-fixture.php'), "<?php\n/* Plugin Name: Bootstrap Steps Fixture */\n");
   fs.writeFileSync(path.join(dependencyPath, 'generic-dependency.php'), "<?php\n/* Plugin Name: Generic Dependency */\n");
+  fs.writeFileSync(path.join(monorepoPluginPath, 'woocommerce.php'), "<?php\n/* Plugin Name: WooCommerce */\n");
+  fs.writeFileSync(path.join(stripeDependencyPath, 'woocommerce-gateway-stripe.php'), "<?php\n/* Plugin Name: WooCommerce Stripe Gateway */\nhomeboy_missing_wordpress_runtime_function();\n");
   fs.writeFileSync(path.join(benchDir, 'assert-bootstrap.php'), "<?php\nreturn static fn() => ['metrics' => ['bootstrap_seen' => 1]];\n");
 
   const successCaptureFile = path.join(root, 'captured-success-recipe.json');
@@ -65,7 +72,7 @@ homeboy_require_bash_version() { :; }
 `);
 
   const settings = {
-    validation_dependencies: [dependencyPath],
+    validation_dependencies: [dependencyPath, monorepoDependencyPath, stripeDependencyPath],
     wp_codebox_core_module: fixtureCoreModule,
     wp_codebox_extra_plugins: [
       { source: '/tmp/runtime-prerequisite', slug: 'runtime-prerequisite', activate: true },
@@ -100,9 +107,17 @@ homeboy_require_bash_version() { :; }
   assert.equal(successResult.status, 0, successResult.stderr || successResult.stdout);
   const recipe = JSON.parse(fs.readFileSync(successCaptureFile, 'utf8'));
   assert.equal(recipe.inputs.extra_plugins.some((plugin) => plugin.slug === 'generic-dependency'), true);
+  const woocommercePlugin = recipe.inputs.extra_plugins.find((plugin) => plugin.slug === 'woocommerce');
+  assert.equal(woocommercePlugin.source, monorepoPluginPath);
+  assert.equal(woocommercePlugin.pluginFile, 'woocommerce/woocommerce.php');
+  assert.equal(recipe.inputs.extra_plugins.some((plugin) => plugin.slug === 'woocommerce-gateway-stripe'), true);
   assert.deepEqual(recipe.inputs.extra_plugins.find((plugin) => plugin.slug === 'runtime-prerequisite'), settings.wp_codebox_extra_plugins[0]);
   assert.deepEqual(recipe.inputs.pluginRuntime.setup, settings.wp_codebox_bootstrap_steps);
   assert.equal(recipe.workflow.steps[0].command, 'wordpress.bench');
+
+  const successResults = JSON.parse(fs.readFileSync(path.join(root, 'success-results.json'), 'utf8'));
+  assert.ok(successResults.prepared_dependencies.some((dependency) => dependency.slug === 'woocommerce' && dependency.source_path === fs.realpathSync(monorepoDependencyPath) && dependency.package_root === fs.realpathSync(monorepoPluginPath) && dependency.mounted_plugin_dir === '/wordpress/wp-content/plugins/woocommerce'), JSON.stringify(successResults.prepared_dependencies, null, 2));
+  assert.ok(successResults.prepared_dependencies.some((dependency) => dependency.slug === 'woocommerce-gateway-stripe' && dependency.source_path === fs.realpathSync(stripeDependencyPath) && dependency.package_root === fs.realpathSync(stripeDependencyPath)), JSON.stringify(successResults.prepared_dependencies, null, 2));
 
   const failureResult = spawnSync('bash', [path.join(extensionPath, 'scripts', 'bench', 'bench-runner.sh')], {
     cwd: componentPath,


### PR DESCRIPTION
## Summary
- Materialize WP Codebox bench dependencies to runnable plugin package roots before recipe generation, including WooCommerce monorepo roots with `plugins/woocommerce`.
- Preserve source path, package root, prepared artifact path, git state, and mounted plugin dir in `prepared-bench-dependencies.json`.
- Defer bench dependency PHP load fatals to WP Codebox activation while keeping non-bench preflight diagnostics strict.

Fixes the Homeboy Rigs gateway-matrix dependency materialization blocker tracked from https://github.com/chubes4/homeboy-rigs/issues/255#issuecomment-4696897434.

## Verification
- `npm run test:wp-codebox-bench-bootstrap-steps`
- `npm run test:wp-codebox-prepared-dependency-cache`
- `npm run test:dependency-plugin-preflight`
- `bash -n wordpress/scripts/lib/validation-dependencies.sh wordpress/tests/dependency-plugin-preflight-smoke.sh`
- `npm run lint:js -- --no-warn-ignored tests/wp-codebox-bench-bootstrap-steps-smoke.js`

## Notes
- Local operator verification confirmed the materializer maps a WooCommerce worktree root to `plugins/woocommerce` and Composer-prepares a Stripe gateway checkout into a cached runnable package while recording metadata.
- End-to-end gateway matrix dispatch should run in CI/Lab with this branch installed as the active Homeboy Extensions revision; the local `homeboy bench list` command still uses the installed extension revision.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the dependency materialization fix, updated focused smoke tests, and ran verification commands. Chris remains responsible for review and merge.