### PR TITLE
Keep Codebox runtime stack generic

### DIFF
--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -299,12 +299,12 @@ The provider shells through `wp-codebox agent-task-run --input-file=<json>
 artifact capture behind that stable command; Homeboy keeps only request/outcome
 adaptation and redaction logic in this extension.
 
-When Codex subscription credentials are available, the provider selects WP
-Codebox's reusable `codex-subscription` runtime overlay profile through the
-generic `runtime_overlay_profiles` field. Homeboy does not expand that profile
-into provider plugin paths or bundled-library overlays; WP Codebox owns the
-profile example and callers can use the same field for other reusable runtime
-stacks.
+When Codex subscription credentials are available, the provider expands the
+Codex defaults into WP Codebox's generic provider stack primitives: explicit
+`provider_plugin_paths`, a `php-ai-client` bundled-library `runtime_overlays`
+entry when configured, and the Codex credential `secret_env` keys. WP Codebox
+owns sandbox recipe expansion and artifact capture; Homeboy owns these
+caller-specific defaults.
 
 ## Runner config surface
 

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -299,12 +299,10 @@ The provider shells through `wp-codebox agent-task-run --input-file=<json>
 artifact capture behind that stable command; Homeboy keeps only request/outcome
 adaptation and redaction logic in this extension.
 
-When Codex subscription credentials are available, the provider expands the
-Codex defaults into WP Codebox's generic provider stack primitives: explicit
-`provider_plugin_paths`, a `php-ai-client` bundled-library `runtime_overlays`
-entry when configured, and the Codex credential `secret_env` keys. WP Codebox
-owns sandbox recipe expansion and artifact capture; Homeboy owns these
-caller-specific defaults.
+Callers that need a provider stack supply WP Codebox's generic fields directly:
+`provider_plugin_paths`, `runtime_overlays`, `runtime_overlay_profiles`, and
+`secret_env`. HBEX forwards those fields without expanding provider-specific
+runtime stacks; WP Codebox owns sandbox recipe expansion and artifact capture.
 
 ## Runner config surface
 

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -227,7 +227,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     agent_bundles: config.agent_bundles || config.agentBundles || options.agentBundles || [],
     runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
     runtime_overlay_profiles: config.runtime_overlay_profiles || config.runtimeOverlayProfiles || options.runtimeOverlayProfiles || defaults.runtimeOverlayProfiles || [],
-    runtime_overlays: config.runtime_overlays || options.runtimeOverlays || defaults.runtimeOverlays || [],
+    runtime_overlays: config.runtime_overlays || options.runtimeOverlays || [],
     secret_env: explicitSecretEnv.length > 0 ? Array.from(new Set(explicitSecretEnv)) : defaults.secretEnv || [],
     // Post-agent verification gate (recipe workflow.after). Supplied as WP
     // Codebox recipe steps; a non-zero exit fails the run so the orchestrator
@@ -313,20 +313,6 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     siblingPath(workspaceBase, 'ai-provider-for-openai'),
     siblingPath(workspaceBase, 'ai-provider-for-openai-main'),
   );
-  const codexProviderPluginPath = firstExistingPath(
-    settings.wp_codebox_codex_provider_plugin_path,
-    settings.wp_codebox_codex_provider_plugin,
-    process.env.WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH,
-    process.env.HOMEBOY_WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH,
-    providerPluginPath,
-  );
-  const phpAiClientPath = firstExistingPath(
-    settings.wp_codebox_php_ai_client_path,
-    settings.php_ai_client_path,
-    process.env.WP_CODEBOX_PHP_AI_CLIENT_PATH,
-    process.env.HOMEBOY_WP_CODEBOX_PHP_AI_CLIENT_PATH,
-    siblingPath(workspaceBase, 'php-ai-client'),
-  );
   const provider = config.provider || options.provider || defaultProvider(settings, providerPluginPath);
   const model = config.model || options.model || defaultModelForProvider(provider, settings);
   const agentsApiPath = firstExistingPath(
@@ -341,13 +327,12 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     agentsApi: agentsApiPath,
     legacyRuntime: dataMachinePath,
     legacyRuntimeTools: dataMachineCodePath,
-    providerPluginPaths: defaultProviderPluginPaths(provider, settings, providerPluginPath, codexProviderPluginPath),
+    providerPluginPaths: defaultProviderPluginPaths(provider, settings, providerPluginPath),
     provider,
     model,
     secretEnv: defaultSecretEnv(provider, settings),
     wpCodeboxBin: firstValue(settings.wp_codebox_bin, settings.wpCodeboxBin, process.env.HOMEBOY_WP_CODEBOX_BIN, ''),
     runtimeOverlayProfiles: [],
-    runtimeOverlays: defaultRuntimeOverlays(provider, phpAiClientPath),
     mounts: defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options),
     workspaces: defaultWorkspaces(config, inputs, options),
     allowedTools: defaultWorkspaceAllowedTools(workspaceRoot, workspaceMode(request, config, inputs)),
@@ -355,27 +340,15 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
   };
 }
 
-function defaultProviderPluginPaths(provider, settings, fallbackProviderPluginPath, codexProviderPluginPath = '') {
+function defaultProviderPluginPaths(provider, settings, fallbackProviderPluginPath) {
   const explicit = normalizeArray(settings.wp_codebox_provider_plugin_paths || settings.provider_plugin_paths);
   if (explicit.length > 0) {
     return explicit;
   }
   if (provider === 'codex') {
-    return codexProviderPluginPath ? [codexProviderPluginPath] : [];
-  }
-  return fallbackProviderPluginPath ? [fallbackProviderPluginPath] : [];
-}
-
-function defaultRuntimeOverlays(provider, phpAiClientPath) {
-  if (provider !== 'codex' || !phpAiClientPath) {
     return [];
   }
-  return [{
-    type: 'bundled-library',
-    library: 'php-ai-client',
-    source: phpAiClientPath,
-    target: '/wordpress/wp-includes/php-ai-client',
-  }];
+  return fallbackProviderPluginPath ? [fallbackProviderPluginPath] : [];
 }
 
 function firstDefined(...values) {

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -227,7 +227,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     agent_bundles: config.agent_bundles || config.agentBundles || options.agentBundles || [],
     runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
     runtime_overlay_profiles: config.runtime_overlay_profiles || config.runtimeOverlayProfiles || options.runtimeOverlayProfiles || defaults.runtimeOverlayProfiles || [],
-    runtime_overlays: config.runtime_overlays || options.runtimeOverlays || [],
+    runtime_overlays: config.runtime_overlays || options.runtimeOverlays || defaults.runtimeOverlays || [],
     secret_env: explicitSecretEnv.length > 0 ? Array.from(new Set(explicitSecretEnv)) : defaults.secretEnv || [],
     // Post-agent verification gate (recipe workflow.after). Supplied as WP
     // Codebox recipe steps; a non-zero exit fails the run so the orchestrator
@@ -313,6 +313,20 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     siblingPath(workspaceBase, 'ai-provider-for-openai'),
     siblingPath(workspaceBase, 'ai-provider-for-openai-main'),
   );
+  const codexProviderPluginPath = firstExistingPath(
+    settings.wp_codebox_codex_provider_plugin_path,
+    settings.wp_codebox_codex_provider_plugin,
+    process.env.WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH,
+    process.env.HOMEBOY_WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH,
+    providerPluginPath,
+  );
+  const phpAiClientPath = firstExistingPath(
+    settings.wp_codebox_php_ai_client_path,
+    settings.php_ai_client_path,
+    process.env.WP_CODEBOX_PHP_AI_CLIENT_PATH,
+    process.env.HOMEBOY_WP_CODEBOX_PHP_AI_CLIENT_PATH,
+    siblingPath(workspaceBase, 'php-ai-client'),
+  );
   const provider = config.provider || options.provider || defaultProvider(settings, providerPluginPath);
   const model = config.model || options.model || defaultModelForProvider(provider, settings);
   const agentsApiPath = firstExistingPath(
@@ -327,12 +341,13 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     agentsApi: agentsApiPath,
     legacyRuntime: dataMachinePath,
     legacyRuntimeTools: dataMachineCodePath,
-    providerPluginPaths: defaultProviderPluginPaths(provider, settings, providerPluginPath),
+    providerPluginPaths: defaultProviderPluginPaths(provider, settings, providerPluginPath, codexProviderPluginPath),
     provider,
     model,
     secretEnv: defaultSecretEnv(provider, settings),
     wpCodeboxBin: firstValue(settings.wp_codebox_bin, settings.wpCodeboxBin, process.env.HOMEBOY_WP_CODEBOX_BIN, ''),
-    runtimeOverlayProfiles: defaultRuntimeOverlayProfiles(provider),
+    runtimeOverlayProfiles: [],
+    runtimeOverlays: defaultRuntimeOverlays(provider, phpAiClientPath),
     mounts: defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options),
     workspaces: defaultWorkspaces(config, inputs, options),
     allowedTools: defaultWorkspaceAllowedTools(workspaceRoot, workspaceMode(request, config, inputs)),
@@ -340,19 +355,27 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
   };
 }
 
-function defaultProviderPluginPaths(provider, settings, fallbackProviderPluginPath) {
+function defaultProviderPluginPaths(provider, settings, fallbackProviderPluginPath, codexProviderPluginPath = '') {
   const explicit = normalizeArray(settings.wp_codebox_provider_plugin_paths || settings.provider_plugin_paths);
   if (explicit.length > 0) {
     return explicit;
   }
   if (provider === 'codex') {
-    return [];
+    return codexProviderPluginPath ? [codexProviderPluginPath] : [];
   }
   return fallbackProviderPluginPath ? [fallbackProviderPluginPath] : [];
 }
 
-function defaultRuntimeOverlayProfiles(provider) {
-  return provider === 'codex' ? ['codex-subscription'] : [];
+function defaultRuntimeOverlays(provider, phpAiClientPath) {
+  if (provider !== 'codex' || !phpAiClientPath) {
+    return [];
+  }
+  return [{
+    type: 'bundled-library',
+    library: 'php-ai-client',
+    source: phpAiClientPath,
+    target: '/wordpress/wp-includes/php-ai-client',
+  }];
 }
 
 function firstDefined(...values) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -468,9 +468,7 @@ try {
   const dataMachineCodePath = path.join(defaultsRoot, 'data-machine-code');
   const staleStandaloneAgentsApiPath = path.join(defaultsRoot, 'agents-api');
   const providerPath = path.join(defaultsRoot, 'ai-provider-for-openai');
-  const codexProviderPath = path.join(defaultsRoot, 'ai-provider-for-openai@codex-oauth-provider');
-  const phpAiClientPath = path.join(defaultsRoot, 'php-ai-client@custom-provider-auth');
-  for (const directory of [workspaceRoot, bundledAgentsApiPath, dataMachineCodePath, staleStandaloneAgentsApiPath, providerPath, codexProviderPath, phpAiClientPath]) {
+  for (const directory of [workspaceRoot, bundledAgentsApiPath, dataMachineCodePath, staleStandaloneAgentsApiPath, providerPath]) {
     fs.mkdirSync(directory, { recursive: true });
   }
 
@@ -491,7 +489,7 @@ try {
   assert.equal(defaultedRequest.runtime_component_paths.agents_api, bundledAgentsApiPath);
   assert.equal(defaultedRequest.runtime_component_paths.agent_runtime, dataMachinePath);
   assert.equal(defaultedRequest.runtime_component_paths.agent_runtime_tools, dataMachineCodePath);
-  assert.deepEqual(defaultedRequest.provider_plugin_paths, [providerPath]);
+  assert.deepEqual(defaultedRequest.provider_plugin_paths, []);
   assert.deepEqual(defaultedRequest.runtime_overlay_profiles, []);
   assert.deepEqual(defaultedRequest.runtime_overlays, []);
   assert.deepEqual(defaultedRequest.secret_env, [
@@ -519,7 +517,7 @@ try {
   }));
   const codexSubscriptionDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,
-    task_id: 'codex-generic-stack-default-task-123',
+    task_id: 'codex-secret-default-task-123',
     executor: {
       backend: 'codebox',
       config: {},
@@ -530,20 +528,13 @@ try {
   }, {
     settings: {
       wp_codebox_codex_auth_path: codexAuthPath,
-      wp_codebox_codex_provider_plugin_path: codexProviderPath,
-      wp_codebox_php_ai_client_path: phpAiClientPath,
     },
   });
   assert.equal(codexSubscriptionDefaultedRequest.provider, 'codex');
   assert.equal(codexSubscriptionDefaultedRequest.model, 'gpt-5.5');
-  assert.deepEqual(codexSubscriptionDefaultedRequest.provider_plugin_paths, [codexProviderPath]);
+  assert.deepEqual(codexSubscriptionDefaultedRequest.provider_plugin_paths, []);
   assert.deepEqual(codexSubscriptionDefaultedRequest.runtime_overlay_profiles, []);
-  assert.deepEqual(codexSubscriptionDefaultedRequest.runtime_overlays, [{
-    type: 'bundled-library',
-    library: 'php-ai-client',
-    source: phpAiClientPath,
-    target: '/wordpress/wp-includes/php-ai-client',
-  }]);
+  assert.deepEqual(codexSubscriptionDefaultedRequest.runtime_overlays, []);
   assert.deepEqual(codexSubscriptionDefaultedRequest.secret_env, codexSecretEnv);
 
   const openAiDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
@@ -695,6 +686,8 @@ try {
           agent_runtime_tools: '/explicit/data-machine-code',
         },
         provider_plugin_paths: ['/explicit/provider'],
+        runtime_overlay_profiles: ['explicit-profile'],
+        runtime_overlays: [{ type: 'bundled-library', library: 'php-ai-client', source: '/explicit/php-ai-client' }],
         secret_env: ['EXPLICIT_SECRET'],
         mounts: [{ source: '/explicit/worktree', target: '/workspace', mode: 'readonly' }],
         workspaces: [{ target: '/explicit-workspace', mode: 'readonly' }],
@@ -708,6 +701,8 @@ try {
   assert.equal(explicitOverrideRequest.runtime_component_paths.agent_runtime, '/explicit/data-machine');
   assert.equal(explicitOverrideRequest.runtime_component_paths.agent_runtime_tools, '/explicit/data-machine-code');
   assert.deepEqual(explicitOverrideRequest.provider_plugin_paths, ['/explicit/provider']);
+  assert.deepEqual(explicitOverrideRequest.runtime_overlay_profiles, ['explicit-profile']);
+  assert.deepEqual(explicitOverrideRequest.runtime_overlays, [{ type: 'bundled-library', library: 'php-ai-client', source: '/explicit/php-ai-client' }]);
   assert.deepEqual(explicitOverrideRequest.secret_env, ['EXPLICIT_SECRET']);
   assert.deepEqual(explicitOverrideRequest.mounts, [{ source: '/explicit/worktree', target: '/workspace', mode: 'readonly' }]);
   assert.deepEqual(explicitOverrideRequest.workspaces, [{ target: '/explicit-workspace', mode: 'readonly' }]);

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -468,7 +468,9 @@ try {
   const dataMachineCodePath = path.join(defaultsRoot, 'data-machine-code');
   const staleStandaloneAgentsApiPath = path.join(defaultsRoot, 'agents-api');
   const providerPath = path.join(defaultsRoot, 'ai-provider-for-openai');
-  for (const directory of [workspaceRoot, bundledAgentsApiPath, dataMachineCodePath, staleStandaloneAgentsApiPath, providerPath]) {
+  const codexProviderPath = path.join(defaultsRoot, 'ai-provider-for-openai@codex-oauth-provider');
+  const phpAiClientPath = path.join(defaultsRoot, 'php-ai-client@custom-provider-auth');
+  for (const directory of [workspaceRoot, bundledAgentsApiPath, dataMachineCodePath, staleStandaloneAgentsApiPath, providerPath, codexProviderPath, phpAiClientPath]) {
     fs.mkdirSync(directory, { recursive: true });
   }
 
@@ -489,8 +491,8 @@ try {
   assert.equal(defaultedRequest.runtime_component_paths.agents_api, bundledAgentsApiPath);
   assert.equal(defaultedRequest.runtime_component_paths.agent_runtime, dataMachinePath);
   assert.equal(defaultedRequest.runtime_component_paths.agent_runtime_tools, dataMachineCodePath);
-  assert.deepEqual(defaultedRequest.provider_plugin_paths, []);
-  assert.deepEqual(defaultedRequest.runtime_overlay_profiles, ['codex-subscription']);
+  assert.deepEqual(defaultedRequest.provider_plugin_paths, [providerPath]);
+  assert.deepEqual(defaultedRequest.runtime_overlay_profiles, []);
   assert.deepEqual(defaultedRequest.runtime_overlays, []);
   assert.deepEqual(defaultedRequest.secret_env, [
     'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
@@ -517,7 +519,7 @@ try {
   }));
   const codexSubscriptionDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,
-    task_id: 'codex-subscription-default-task-123',
+    task_id: 'codex-generic-stack-default-task-123',
     executor: {
       backend: 'codebox',
       config: {},
@@ -526,13 +528,22 @@ try {
       target: { root: workspaceRoot },
     },
   }, {
-    settings: { wp_codebox_codex_auth_path: codexAuthPath },
+    settings: {
+      wp_codebox_codex_auth_path: codexAuthPath,
+      wp_codebox_codex_provider_plugin_path: codexProviderPath,
+      wp_codebox_php_ai_client_path: phpAiClientPath,
+    },
   });
   assert.equal(codexSubscriptionDefaultedRequest.provider, 'codex');
   assert.equal(codexSubscriptionDefaultedRequest.model, 'gpt-5.5');
-  assert.deepEqual(codexSubscriptionDefaultedRequest.provider_plugin_paths, []);
-  assert.deepEqual(codexSubscriptionDefaultedRequest.runtime_overlay_profiles, ['codex-subscription']);
-  assert.deepEqual(codexSubscriptionDefaultedRequest.runtime_overlays, []);
+  assert.deepEqual(codexSubscriptionDefaultedRequest.provider_plugin_paths, [codexProviderPath]);
+  assert.deepEqual(codexSubscriptionDefaultedRequest.runtime_overlay_profiles, []);
+  assert.deepEqual(codexSubscriptionDefaultedRequest.runtime_overlays, [{
+    type: 'bundled-library',
+    library: 'php-ai-client',
+    source: phpAiClientPath,
+    target: '/wordpress/wp-includes/php-ai-client',
+  }]);
   assert.deepEqual(codexSubscriptionDefaultedRequest.secret_env, codexSecretEnv);
 
   const openAiDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({


### PR DESCRIPTION
## Summary
- Remove HBEX's default `runtime_overlay_profiles: ["codex-subscription"]` behavior for Codebox agent tasks.
- Keep HBEX generic by forwarding explicit Codebox fields (`provider_plugin_paths`, `runtime_overlays`, `runtime_overlay_profiles`, and `secret_env`) without provider-specific stack discovery or assembly.
- Allow the same generic Codebox stack fields to come from Homeboy/global settings (`wp_codebox_provider_plugin_paths`, `wp_codebox_runtime_overlays`, `wp_codebox_runtime_overlay_profiles`, and `wp_codebox_secret_env`).
- Update docs/tests to assert that Codex credentials no longer inject a runtime overlay profile, while explicit generic runtime fields are forwarded unchanged.

Fixes #1319.

## Testing
- `npm run test:codebox-agent-task-executor`
- `npm run test:wp-codebox-task-runner`
- `npm run lint:js -- lib/codebox-agent-task-executor.js` could not run in the clean PR worktree because eslint dependencies were not installed (`sh: eslint: command not found`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Corrected the PR boundary to keep Homeboy Extensions generic, removed Codex-specific runtime stack defaults/path discovery, added generic global Codebox settings forwarding, updated tests/docs, and ran focused verification. Chris remains responsible for review and merge.
