### PR TITLE
fix: use npm install for gitignored lockfiles instead of npm ci

### DIFF
--- a/scripts/lib/project-scripts.sh
+++ b/scripts/lib/project-scripts.sh
@@ -181,7 +181,15 @@ homeboy_project_ensure_dependencies() {
             (cd "$_dir" && yarn install --frozen-lockfile)
             ;;
         npm|*)
-            if [ -f "$_dir/package-lock.json" ]; then
+            # `npm ci` only makes sense for a committed, authoritative
+            # lockfile. A gitignored/untracked package-lock.json is a local
+            # artifact that nothing keeps in sync with package.json, so a stale
+            # leftover would make `npm ci` fail on an unfixable desync. Use
+            # `npm install` to refresh it in that case.
+            if [ -f "$_dir/package-lock.json" ] \
+                && command -v git >/dev/null 2>&1 \
+                && git -C "$_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+                && git -C "$_dir" ls-files --error-unmatch package-lock.json >/dev/null 2>&1; then
                 (cd "$_dir" && npm ci)
             else
                 (cd "$_dir" && npm install)

--- a/wordpress/scripts/build/build-helper-smoke.sh
+++ b/wordpress/scripts/build/build-helper-smoke.sh
@@ -78,4 +78,90 @@ JSON
 
 assert_contains "$npm_log" "install --no-audit --no-fund --legacy-peer-deps"
 
+assert_not_contains() {
+    local file="$1"
+    local unexpected="$2"
+    if grep -Fq -- "$unexpected" "$file"; then
+        echo "Expected $file to NOT contain: $unexpected" >&2
+        sed 's/^/  /' "$file" >&2
+        exit 1
+    fi
+}
+
+# Lockfile-aware install command selection.
+#
+# A committed package-lock.json is authoritative → `npm ci` (strict).
+# A gitignored/untracked package-lock.json is a local artifact → `npm install`
+# (refresh), because nothing keeps an ignored lockfile in sync with
+# package.json and `npm ci` would fail on an unfixable desync.
+make_lockfile_component() {
+    local dir="$1"
+    mkdir -p "$dir"
+    cat > "${dir}/plugin.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Lockfile Plugin
+ * Version: 1.0.0
+ */
+PHP
+    cat > "${dir}/package.json" <<'JSON'
+{
+  "scripts": {
+    "build": "wp-scripts build"
+  },
+  "devDependencies": {
+    "@wordpress/scripts": "^30.0.0"
+  }
+}
+JSON
+    printf '{"lockfileVersion":3}\n' > "${dir}/package-lock.json"
+}
+
+run_build() {
+    local dir="$1"
+    local log="$2"
+    (
+        cd "$dir"
+        PATH="${fake_bin}:$PATH" \
+        NPM_LOG="$log" \
+        HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+        HOMEBOY_COMPONENT_ID="lockfile-plugin" \
+        HOMEBOY_SKIP_TESTS=1 \
+            bash "${EXTENSION_DIR}/scripts/build/build.sh" >/dev/null
+    )
+}
+
+# Case 1: committed lockfile → npm ci
+committed_dir="${TMP_DIR}/committed-lockfile"
+committed_log="${TMP_DIR}/committed-npm.log"
+make_lockfile_component "$committed_dir"
+(
+    cd "$committed_dir"
+    git init -q
+    git config user.email smoke@example.com
+    git config user.name smoke
+    git add -A
+    git commit -qm "initial"
+)
+run_build "$committed_dir" "$committed_log"
+assert_contains "$committed_log" "ci --no-audit --no-fund"
+assert_not_contains "$committed_log" "install --no-audit --no-fund"
+
+# Case 2: gitignored lockfile → npm install (refresh), never npm ci
+ignored_dir="${TMP_DIR}/ignored-lockfile"
+ignored_log="${TMP_DIR}/ignored-npm.log"
+make_lockfile_component "$ignored_dir"
+printf 'package-lock.json\nnode_modules/\n' > "${ignored_dir}/.gitignore"
+(
+    cd "$ignored_dir"
+    git init -q
+    git config user.email smoke@example.com
+    git config user.name smoke
+    git add -A
+    git commit -qm "initial"
+)
+run_build "$ignored_dir" "$ignored_log"
+assert_contains "$ignored_log" "install --no-audit --no-fund"
+assert_not_contains "$ignored_log" "ci --no-audit --no-fund"
+
 echo "WordPress build helper smoke passed."

--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -127,6 +127,29 @@ npm_install_flags() {
     printf '%s\n' "${flags[@]}"
 }
 
+# Decide whether package-lock.json is an authoritative, committed artifact.
+#
+# `npm ci` strictly enforces that package.json and package-lock.json are in
+# sync and aborts otherwise. That guarantee is only meaningful when the
+# lockfile is committed to git — then it is the reproducible source of truth.
+#
+# When the lockfile is gitignored (or otherwise untracked), it is just a local
+# build artifact that nothing keeps in sync with package.json. A stale leftover
+# lockfile from a prior install then makes `npm ci` fail for a desync that no
+# committed change could ever fix (e.g. a dependency was bumped in package.json
+# but the ignored lockfile was never regenerated). In that case `npm install`
+# is correct: it refreshes the local lockfile to match package.json.
+#
+# Returns 0 (true) when package-lock.json is tracked by git → use `npm ci`.
+# Returns 1 (false) when missing, untracked, or gitignored → use `npm install`.
+npm_lockfile_is_committed() {
+    [ -f "package-lock.json" ] || return 1
+    command -v git >/dev/null 2>&1 || return 1
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+    # A tracked file is listed by ls-files; gitignored/untracked files are not.
+    [ -n "$(git ls-files --error-unmatch package-lock.json 2>/dev/null)" ]
+}
+
 run_npm_install() {
     local command_name="$1"
     shift
@@ -367,9 +390,17 @@ install_frontend_dependencies() {
     fi
 
     if [ "$need_install" -eq 1 ]; then
-        if [ -f "package-lock.json" ]; then
+        # Only use `npm ci` when the lockfile is a committed, authoritative
+        # artifact. A gitignored/untracked lockfile is a local leftover that
+        # nothing keeps in sync with package.json — `npm ci` would fail on a
+        # desync no committed change could fix. Fall back to `npm install`,
+        # which refreshes the local lockfile to match package.json.
+        if npm_lockfile_is_committed; then
             run_npm_install ci 2>&1
         else
+            if [ -f "package-lock.json" ]; then
+                print_warning "${scope_label}package-lock.json is not committed (gitignored or untracked); using 'npm install' to refresh it instead of 'npm ci'."
+            fi
             run_npm_install install 2>&1
         fi
         print_success "${scope_label}npm dependencies ready"


### PR DESCRIPTION
Closes #1322.

## Problem

Build extensions chose `npm ci` vs `npm install` based on whether `package-lock.json` exists **on disk**, ignoring whether it is a committed, authoritative artifact. For repos that **gitignore** the lockfile, a stale leftover in the working tree makes `npm ci` abort on a desync no committed change can fix:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Invalid: lock file's ajv@6.14.0 does not satisfy ajv@8.20.0
```

This blocked `homeboy release` for `extrachill-admin-tools` and `extrachill-analytics` today (lockfile gitignored; stale primary copy predated the `ajv ^8` pin).

## Fix

Detect whether `package-lock.json` is tracked by git, and select the install command accordingly:

- **Committed lockfile** → `npm ci` (strict, reproducible) — unchanged.
- **Gitignored / untracked / missing** → `npm install` (refreshes the local lockfile to match `package.json`).

Applied in:
- `wordpress/scripts/build/build.sh` — `install_frontend_dependencies()` via new `npm_lockfile_is_committed()` helper.
- `scripts/lib/project-scripts.sh` — `homeboy_project_ensure_dependencies()` npm branch (runner-snapshot path).

## Verification

- `wordpress/scripts/build/build-helper-smoke.sh` extended with two new cases, both passing:
  - committed lockfile → asserts `npm ci`, asserts NOT `npm install`.
  - gitignored lockfile → asserts `npm install`, asserts NOT `npm ci`.
- `bash -n` clean on both modified scripts.
- Pre-existing `tests/runtime-helpers-smoke.sh` failure (sidecar JSON) is unrelated — reproduces identically on untouched `main`.

## Out of scope

pnpm/yarn `--frozen-lockfile` branches have the same theoretical issue for gitignored pnpm/yarn lockfiles; not addressed here (npm is what bit us). Noted in #1322 as a follow-up.