### PR TITLE
fix: align WordPress bench dependency Composer preparation

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -1370,7 +1370,7 @@ homeboy_prepare_validation_dependency_for_wp_codebox_bench() {
     fi
 
     if ! command -v composer >/dev/null 2>&1; then
-        _homeboy_record_bench_dependency_build_failure "$artifacts_dir" "$dependency_slug" "$dependency_path" "$package_root" "$package_root" "$package_root" 'composer install --no-dev --no-interaction --no-progress --prefer-dist' 127 ''
+        _homeboy_record_bench_dependency_build_failure "$artifacts_dir" "$dependency_slug" "$dependency_path" "$package_root" "$package_root" "$package_root" 'composer install --no-dev --no-interaction --no-progress --prefer-dist --classmap-authoritative' 127 ''
         echo "Error: WordPress bench dependency '${dependency_path}' has composer.json but no vendor autoload files, and composer is not available." >&2
         return 1
     fi
@@ -1438,12 +1438,12 @@ homeboy_prepare_validation_dependency_for_wp_codebox_bench() {
     local composer_output composer_exit
     composer_output=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-bench-dependency-composer-${dependency_slug}.XXXXXX")
     set +e
-    composer install --working-dir="$tmp_prepared_plugin_path" --no-dev --no-interaction --no-progress --prefer-dist >"$composer_output" 2>&1
+    composer install --working-dir="$tmp_prepared_plugin_path" --no-dev --no-interaction --no-progress --prefer-dist --classmap-authoritative >"$composer_output" 2>&1
     composer_exit=$?
     set -e
     if [ "$composer_exit" -ne 0 ]; then
         cat "$composer_output" >&2
-        _homeboy_record_bench_dependency_build_failure "$artifacts_dir" "$dependency_slug" "$dependency_path" "$package_root" "$prepare_root" "$tmp_prepared_plugin_path" "composer install --working-dir=${tmp_prepared_plugin_path} --no-dev --no-interaction --no-progress --prefer-dist" "$composer_exit" "$composer_output"
+        _homeboy_record_bench_dependency_build_failure "$artifacts_dir" "$dependency_slug" "$dependency_path" "$package_root" "$prepare_root" "$tmp_prepared_plugin_path" "composer install --working-dir=${tmp_prepared_plugin_path} --no-dev --no-interaction --no-progress --prefer-dist --classmap-authoritative" "$composer_exit" "$composer_output"
         rm -rf "$tmp_entry"
         rm -f "$composer_output"
         echo "Error: Could not prepare WordPress bench dependency '${dependency_slug}' with Composer at ${tmp_prepared_plugin_path}." >&2


### PR DESCRIPTION
## Summary
- Aligns the generic HBEX WordPress bench dependency materialization contract with the proven Woo Stripe ECE rig setup from Homeboy Rigs PR #220.
- Adds `--classmap-authoritative` to the cached Composer install command and to structured dependency build diagnostics.
- Keeps Homeboy core agnostic while moving the reusable dependency-provider behavior into the WordPress extension instead of duplicating rig-local setup.

Follow-up to https://github.com/Extra-Chill/homeboy-extensions/pull/1324 for https://github.com/Extra-Chill/homeboy-extensions/issues/1321.

## Homeboy Rigs prior art inspected
- https://github.com/chubes4/homeboy-rigs/pull/176
- https://github.com/chubes4/homeboy-rigs/pull/178
- https://github.com/chubes4/homeboy-rigs/pull/183
- https://github.com/chubes4/homeboy-rigs/pull/184
- https://github.com/chubes4/homeboy-rigs/pull/193
- https://github.com/chubes4/homeboy-rigs/pull/197
- https://github.com/chubes4/homeboy-rigs/pull/219
- https://github.com/chubes4/homeboy-rigs/pull/220
- https://github.com/chubes4/homeboy-rigs/pull/235
- https://github.com/chubes4/homeboy-rigs/pull/236
- https://github.com/chubes4/homeboy-rigs/pull/238
- https://github.com/chubes4/homeboy-rigs/pull/265

## Verification
- `cd wordpress && npm run test:wp-codebox-prepared-dependency-cache`
- `cd wordpress && npm run test:wp-codebox-bench-bootstrap-steps`
- `bash -n wordpress/scripts/lib/validation-dependencies.sh`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the Homeboy Rigs Stripe ECE prior art, aligning the generic HBEX dependency materialization command, and running targeted verification.