### PR TITLE
Normalize runner publication status

### DIFF
--- a/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
+++ b/wordpress/scripts/agent/run-host-runner-lifecycle.cjs
@@ -735,9 +735,20 @@ function recordLifecycle(results, scenario, lifecycle) {
   scenario.metrics.writable_paths_satisfied = !lifecycle.writablePaths.enabled || lifecycle.writablePaths.success ? 1 : 0;
   scenario.metrics.workspace_contract_satisfied = !lifecycle.workspaceContract.enabled || lifecycle.workspaceContract.success ? 1 : 0;
   scenario.metrics.pr_opened = lifecycle.publication.opened ? 1 : 0;
+  scenario.metrics.pr_opened_mean = scenario.metrics.pr_opened;
   scenario.metrics.file_written = lifecycle.capture.changed ? 1 : 0;
+  scenario.metrics.file_written_mean = scenario.metrics.file_written;
   if (lifecycle.success && lifecycle.publication.opened) {
     metadata.success_status = 'pr_opened';
+  }
+  if (metadata.success_status) {
+    metadata.engine_data.success_status = metadata.success_status;
+    if (plainObject(metadata.engine_data.eval_artifact)) {
+      metadata.engine_data.eval_artifact.run = plainObject(metadata.engine_data.eval_artifact.run)
+        ? metadata.engine_data.eval_artifact.run
+        : {};
+      metadata.engine_data.eval_artifact.run.success_status = metadata.success_status;
+    }
   }
   if (!lifecycle.success) {
     scenario.status = 'failed';

--- a/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
+++ b/wordpress/tests/datamachine-agent-host-lifecycle-smoke.js
@@ -132,7 +132,9 @@ function makeRunFiles(tmp, config) {
   assert.equal(scenario.metrics.drift_checks_succeeded, 1);
   assert.equal(scenario.metrics.writable_paths_satisfied, 1);
   assert.equal(scenario.metrics.pr_opened, 1);
+  assert.equal(scenario.metrics.pr_opened_mean, 1);
   assert.equal(scenario.metadata.success_status, 'pr_opened');
+  assert.equal(scenario.metadata.engine_data.success_status, 'pr_opened');
   assert.equal(scenario.metadata.runner_workspace_publication.url, 'https://github.com/owner/repo/pull/1291');
   assert.match(fs.readFileSync(gh.log, 'utf8'), /pr create .*--base trunk/);
   checked('git', ['fetch', 'origin', 'agent-artifacts/docs-agent-host-lifecycle'], { cwd: repo });
@@ -323,7 +325,14 @@ function makeRunFiles(tmp, config) {
   checked('git', ['push', '-u', 'origin', 'agent-artifacts/docs-agent-host-lifecycle'], { cwd: repo });
   fs.writeFileSync(path.join(repo, 'generated.txt'), 'hello from agent on stale branch\n');
   const { configPath, resultsPath } = makeRunFiles(tmp, {
-    initial_metadata: { success_status: 'write_without_pr', completion_outcome_satisfied: false },
+    initial_metadata: {
+      success_status: 'write_without_pr',
+      completion_outcome_satisfied: false,
+      engine_data: {
+        success_status: 'write_without_pr',
+        eval_artifact: { run: { success_status: 'write_without_pr' } },
+      },
+    },
     verification_commands: [{ command: 'test -f generated.txt', description: 'Generated file exists' }],
   });
 
@@ -333,6 +342,8 @@ function makeRunFiles(tmp, config) {
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const output = readJson(resultsPath);
   assert.equal(output.scenarios[0].metadata.success_status, 'pr_opened');
+  assert.equal(output.scenarios[0].metadata.engine_data.success_status, 'pr_opened');
+  assert.equal(output.scenarios[0].metadata.engine_data.eval_artifact.run.success_status, 'pr_opened');
   assert.equal(output.scenarios[0].metadata.completion_outcome_satisfied, false);
   const publication = output.scenarios[0].metadata.runner_workspace_publication;
   assert.equal(publication.url, 'https://github.com/owner/repo/pull/47');


### PR DESCRIPTION
## Summary
- Normalize legacy `pr_opened_mean` and `file_written_mean` after host lifecycle publication updates.
- Mirror the final lifecycle `success_status` into engine data and nested eval artifact metadata so exported evidence does not disagree with runner publication.
- Add smoke coverage for stale `write_without_pr` metadata becoming `pr_opened` after a PR is reopened.

## Testing
- `node wordpress/tests/datamachine-agent-host-lifecycle-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed contradictory runner evidence fields, drafted the normalization patch, and added smoke coverage for Chris to review.