### PR TITLE
fix: unify WP Codebox recipe builder loading

### DIFF
--- a/wordpress/lib/wp-codebox-core-loader.js
+++ b/wordpress/lib/wp-codebox-core-loader.js
@@ -10,6 +10,8 @@ const { pathToFileURL } = require('node:url');
 
 const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
 const RUNTIME_CORE_ENTRY = 'packages/runtime-core/dist/index.js';
+const DEFAULT_CORE_PACKAGE_CANDIDATES = [DEFAULT_CODEBOX_CORE_MODULE];
+const DEFAULT_RUNTIME_CORE_ENTRIES = [RUNTIME_CORE_ENTRY];
 
 function coreModuleSpecifier(options = {}) {
 	const explicit = options.wpCodeboxCoreModule || options.coreModule || process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE || process.env.WP_CODEBOX_CORE_MODULE;
@@ -38,7 +40,9 @@ function coreModuleCandidates(options = {}) {
 		return [normalizeCoreModuleSpecifier(explicit)];
 	}
 
-	const candidates = [DEFAULT_CODEBOX_CORE_MODULE];
+	const packageCandidates = options.packageCandidates || DEFAULT_CORE_PACKAGE_CANDIDATES;
+	const runtimeCoreEntries = options.runtimeCoreEntries || DEFAULT_RUNTIME_CORE_ENTRIES;
+	const candidates = [...packageCandidates];
 	for (const candidate of setupCacheCoreModuleCandidates(options)) {
 		if (existsSync(candidate) && !candidates.includes(candidate)) {
 			candidates.push(candidate);
@@ -47,9 +51,11 @@ function coreModuleCandidates(options = {}) {
 
 	for (const root of workspaceRoots(options)) {
 		for (const repoPath of codeboxRepoCandidates(root)) {
-			const runtimeCore = path.resolve(repoPath, RUNTIME_CORE_ENTRY);
-			if (existsSync(runtimeCore) && !candidates.includes(runtimeCore)) {
-				candidates.push(runtimeCore);
+			for (const entry of runtimeCoreEntries) {
+				const runtimeCore = path.resolve(repoPath, entry);
+				if (existsSync(runtimeCore) && !candidates.includes(runtimeCore)) {
+					candidates.push(runtimeCore);
+				}
 			}
 		}
 	}
@@ -59,12 +65,18 @@ function coreModuleCandidates(options = {}) {
 
 function setupCacheCoreModuleCandidates(options = {}) {
 	const installRoot = options.wpCodeboxInstallDir || process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.resolve(homedir(), '.cache/homeboy/wp-codebox');
-	return [
-		path.resolve(installRoot, 'source', RUNTIME_CORE_ENTRY),
-		path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist/index.js'),
-		path.resolve(installRoot, 'release/wp-codebox-cli', RUNTIME_CORE_ENTRY),
-		path.resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js'),
-	];
+	const runtimeCoreEntries = options.runtimeCoreEntries || DEFAULT_RUNTIME_CORE_ENTRIES;
+	const packageDistEntries = options.packageDistEntries || ['index.js'];
+	const candidates = [];
+	for (const entry of runtimeCoreEntries) {
+		candidates.push(path.resolve(installRoot, 'source', entry));
+		candidates.push(path.resolve(installRoot, 'release/wp-codebox-cli', entry));
+	}
+	for (const entry of packageDistEntries) {
+		candidates.push(path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist', entry));
+		candidates.push(path.resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist', entry));
+	}
+	return candidates;
 }
 
 function workspaceRoots(options = {}) {

--- a/wordpress/lib/wp-codebox-core-loader.js
+++ b/wordpress/lib/wp-codebox-core-loader.js
@@ -4,42 +4,151 @@
  * External dependencies
  */
 const path = require('node:path');
+const { existsSync, readdirSync } = require('node:fs');
+const { homedir } = require('node:os');
 const { pathToFileURL } = require('node:url');
 
+const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
+const RUNTIME_CORE_ENTRY = 'packages/runtime-core/dist/index.js';
+
 function coreModuleSpecifier(options = {}) {
-  const explicit = options.wpCodeboxCoreModule || options.coreModule || process.env.WP_CODEBOX_CORE_MODULE;
-  if (!explicit) {
-    return '@automattic/wp-codebox-core';
-  }
-  if (explicit.startsWith('file:') || explicit.startsWith('node:')) {
-    return explicit;
-  }
-  if (explicit.startsWith('.') || explicit.startsWith('/') || explicit.includes(path.sep)) {
-    return pathToFileURL(path.resolve(explicit)).href;
-  }
-  return explicit;
+	const explicit = options.wpCodeboxCoreModule || options.coreModule || process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE || process.env.WP_CODEBOX_CORE_MODULE;
+	if (!explicit) {
+		return DEFAULT_CODEBOX_CORE_MODULE;
+	}
+	return normalizeCoreModuleSpecifier(explicit);
+}
+
+function normalizeCoreModuleSpecifier(specifier) {
+	if (!specifier) {
+		return specifier;
+	}
+	if (specifier.startsWith('file:') || specifier.startsWith('node:')) {
+		return specifier;
+	}
+	if (specifier.startsWith('.') || specifier.startsWith('/') || specifier.includes(path.sep)) {
+		return pathToFileURL(path.resolve(specifier)).href;
+	}
+	return specifier;
+}
+
+function coreModuleCandidates(options = {}) {
+	const explicit = options.wpCodeboxCoreModule || options.coreModule || process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE || process.env.WP_CODEBOX_CORE_MODULE;
+	if (explicit) {
+		return [normalizeCoreModuleSpecifier(explicit)];
+	}
+
+	const candidates = [DEFAULT_CODEBOX_CORE_MODULE];
+	for (const candidate of setupCacheCoreModuleCandidates(options)) {
+		if (existsSync(candidate) && !candidates.includes(candidate)) {
+			candidates.push(candidate);
+		}
+	}
+
+	for (const root of workspaceRoots(options)) {
+		for (const repoPath of codeboxRepoCandidates(root)) {
+			const runtimeCore = path.resolve(repoPath, RUNTIME_CORE_ENTRY);
+			if (existsSync(runtimeCore) && !candidates.includes(runtimeCore)) {
+				candidates.push(runtimeCore);
+			}
+		}
+	}
+
+	return candidates.map(normalizeCoreModuleSpecifier);
+}
+
+function setupCacheCoreModuleCandidates(options = {}) {
+	const installRoot = options.wpCodeboxInstallDir || process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.resolve(homedir(), '.cache/homeboy/wp-codebox');
+	return [
+		path.resolve(installRoot, 'source', RUNTIME_CORE_ENTRY),
+		path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist/index.js'),
+		path.resolve(installRoot, 'release/wp-codebox-cli', RUNTIME_CORE_ENTRY),
+		path.resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js'),
+	];
+}
+
+function workspaceRoots(options = {}) {
+	const repoRoot = path.resolve(__dirname, '..');
+	const roots = [
+		options.workspaceRoot,
+		process.env.HOMEBOY_WORKSPACE_ROOT,
+		process.env.HOMEBOY_DEVELOPER_WORKSPACE,
+		path.dirname(repoRoot),
+	];
+
+	return [...new Set(roots.filter(Boolean))];
+}
+
+function codeboxRepoCandidates(root) {
+	const exact = path.resolve(root, 'wp-codebox');
+	const candidates = existsSync(exact) ? [exact] : [];
+
+	try {
+		const siblingWorktrees = readdirSync(root, { withFileTypes: true })
+			.filter((entry) => entry.isDirectory() && entry.name.startsWith('wp-codebox@'))
+			.map((entry) => path.resolve(root, entry.name))
+			.sort();
+		candidates.push(...siblingWorktrees);
+	} catch {
+		// A missing or unreadable workspace root simply contributes no candidates.
+	}
+
+	return candidates;
 }
 
 async function loadWpCodeboxCore(options = {}) {
-  const specifier = coreModuleSpecifier(options);
-  try {
-    return await import(specifier);
-  } catch (error) {
-    if (options.required) {
-      throw error;
-    }
-    return null;
-  }
+	const errors = [];
+	for (const specifier of coreModuleCandidates(options)) {
+		try {
+			return await import(specifier);
+		} catch (error) {
+			errors.push({ specifier, error });
+		}
+	}
+
+	if (options.required) {
+		const error = errors[0]?.error || new Error('WP Codebox core module is unavailable.');
+		error.wpCodeboxCoreErrors = errors;
+		throw error;
+	}
+	return null;
 }
 
 async function loadWpCodeboxCoreFunction(name, options = {}) {
-  const core = await loadWpCodeboxCore(options);
-  const fn = core && core[name];
-  return typeof fn === 'function' ? fn : null;
+	const result = await loadWpCodeboxCoreExport(name, options);
+	return result ? result.value : null;
+}
+
+async function loadWpCodeboxCoreExport(name, options = {}) {
+	const errors = [];
+	for (const specifier of coreModuleCandidates(options)) {
+		try {
+			const core = await import(specifier);
+			const value = core && core[name];
+			if (typeof value !== 'function') {
+				errors.push({ specifier, message: `missing ${name} export` });
+				continue;
+			}
+
+			return { value, source: specifier };
+		} catch (error) {
+			errors.push({ specifier, error, message: error.message });
+		}
+	}
+
+	if (options.required) {
+		const error = new Error(`WP Codebox core export ${name} is unavailable.`);
+		error.wpCodeboxCoreErrors = errors;
+		throw error;
+	}
+	return null;
 }
 
 module.exports = {
-  coreModuleSpecifier,
-  loadWpCodeboxCore,
-  loadWpCodeboxCoreFunction,
+	coreModuleSpecifier,
+	coreModuleCandidates,
+	loadWpCodeboxCore,
+	loadWpCodeboxCoreExport,
+	loadWpCodeboxCoreFunction,
+	RUNTIME_CORE_ENTRY,
 };

--- a/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
+++ b/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
@@ -1,108 +1,36 @@
 /**
  * External dependencies
  */
-import { existsSync, readdirSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
 
-const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
-const RUNTIME_CORE_ENTRY = 'packages/runtime-core/dist/index.js';
+const require = createRequire(import.meta.url);
+const {
+	coreModuleCandidates,
+	loadWpCodeboxCoreExport,
+	RUNTIME_CORE_ENTRY,
+} = require('../../lib/wp-codebox-core-loader.js');
 
 export async function loadCodeboxRecipeBuilder(requiredExport) {
-	const configuredModule = process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE;
-	const candidates = configuredModule ? [configuredModule] : discoverCodeboxCoreModuleCandidates();
-	const errors = [];
-
-	for (const candidate of candidates) {
-		try {
-			const module = await importModule(candidate);
-			if (typeof module[requiredExport] !== 'function') {
-				errors.push(`${candidate}: missing ${requiredExport} export`);
-				continue;
-			}
-
-			return { builder: module[requiredExport], source: candidate };
-		} catch (error) {
-			errors.push(`${candidate}: ${error.message}`);
-		}
-	}
-
-	throw new Error([
-		`WP Codebox recipe builder export ${requiredExport} is unavailable.`,
-		`Install/build a WP Codebox runtime-core module that exports ${requiredExport}.`,
-		`Pass --setting wp_codebox_core_module=/path/to/wp-codebox/${RUNTIME_CORE_ENTRY}, or set HOMEBOY_WP_CODEBOX_CORE_MODULE to that built ESM entrypoint.`,
-		`Fallback discovery also checks sibling wp-codebox checkouts for ${RUNTIME_CORE_ENTRY}.`,
-		'This is separate from HOMEBOY_WP_CODEBOX_BIN / wp_codebox_bin, which only selects the wp-codebox CLI.',
-		'Homeboy Extensions no longer falls back to bundled WP Codebox recipe builders because that stale local copy can drift from the Codebox recipe contract.',
-		`Tried ${candidates.length} candidate(s):`,
-		...errors.map((error) => `- ${error}`),
-	].join('\n'));
-}
-
-function discoverCodeboxCoreModuleCandidates() {
-	const candidates = [DEFAULT_CODEBOX_CORE_MODULE];
-	for (const candidate of setupCacheCoreModuleCandidates()) {
-		if (existsSync(candidate) && !candidates.includes(candidate)) {
-			candidates.push(candidate);
-		}
-	}
-	const roots = workspaceRoots();
-
-	for (const root of roots) {
-		for (const repoPath of codeboxRepoCandidates(root)) {
-			const runtimeCore = resolve(repoPath, RUNTIME_CORE_ENTRY);
-			if (existsSync(runtimeCore) && !candidates.includes(runtimeCore)) {
-				candidates.push(runtimeCore);
-			}
-		}
-	}
-
-	return candidates;
-}
-
-function setupCacheCoreModuleCandidates() {
-	const installRoot = process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || resolve(homedir(), '.cache/homeboy/wp-codebox');
-	return [
-		resolve(installRoot, 'source', RUNTIME_CORE_ENTRY),
-		resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist/index.js'),
-		resolve(installRoot, 'release/wp-codebox-cli', RUNTIME_CORE_ENTRY),
-		resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js'),
-	];
-}
-
-function workspaceRoots() {
-	const scriptDir = dirname(fileURLToPath(import.meta.url));
-	const repoRoot = resolve(scriptDir, '../../..');
-	const roots = [
-		process.env.HOMEBOY_WORKSPACE_ROOT,
-		process.env.HOMEBOY_DEVELOPER_WORKSPACE,
-		dirname(repoRoot),
-	];
-
-	return [...new Set(roots.filter(Boolean))];
-}
-
-function codeboxRepoCandidates(root) {
-	const exact = resolve(root, 'wp-codebox');
-	const candidates = existsSync(exact) ? [exact] : [];
-
 	try {
-		const siblingWorktrees = readdirSync(root, { withFileTypes: true })
-			.filter((entry) => entry.isDirectory() && entry.name.startsWith('wp-codebox@'))
-			.map((entry) => resolve(root, entry.name))
-			.sort();
-		candidates.push(...siblingWorktrees);
-	} catch {
-		// A missing or unreadable workspace root simply contributes no candidates.
-	}
+		const result = await loadWpCodeboxCoreExport(requiredExport, { required: true });
+		return { builder: result.value, source: result.source };
+	} catch (error) {
+		const candidates = coreModuleCandidates();
+		const errors = (error.wpCodeboxCoreErrors || []).map(formatCoreLoaderError);
 
-	return candidates;
+		throw new Error([
+			`WP Codebox recipe builder export ${requiredExport} is unavailable.`,
+			`Install/build a WP Codebox runtime-core module that exports ${requiredExport}.`,
+			`Pass --setting wp_codebox_core_module=/path/to/wp-codebox/${RUNTIME_CORE_ENTRY}, or set HOMEBOY_WP_CODEBOX_CORE_MODULE to that built ESM entrypoint.`,
+			`Fallback discovery also checks sibling wp-codebox checkouts for ${RUNTIME_CORE_ENTRY}.`,
+			'This is separate from HOMEBOY_WP_CODEBOX_BIN / wp_codebox_bin, which only selects the wp-codebox CLI.',
+			'Homeboy Extensions no longer falls back to bundled WP Codebox recipe builders because that stale local copy can drift from the Codebox recipe contract.',
+			`Tried ${candidates.length} candidate(s):`,
+			...errors.map((error) => `- ${error}`),
+		].join('\n'));
+	}
 }
 
-async function importModule(specifier) {
-	if (specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('file:')) {
-		return import(specifier.startsWith('file:') ? specifier : pathToFileURL(resolve(specifier)).href);
-	}
-	return import(specifier);
+function formatCoreLoaderError(error) {
+	return `${error.specifier}: ${error.message}`;
 }

--- a/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
+++ b/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
@@ -10,19 +10,30 @@ const {
 	RUNTIME_CORE_ENTRY,
 } = require('../../lib/wp-codebox-core-loader.js');
 
+const RECIPE_BUILDER_MODULE_OPTIONS = {
+	packageCandidates: [
+		'@automattic/wp-codebox-core/recipe-builders',
+		'wp-codebox-workspace/recipe-builders',
+		'@automattic/wp-codebox-core',
+	],
+	packageDistEntries: ['recipe-builders.js', 'index.js'],
+	runtimeCoreEntries: ['packages/runtime-core/dist/recipe-builders.js', RUNTIME_CORE_ENTRY],
+};
+
 export async function loadCodeboxRecipeBuilder(requiredExport) {
 	try {
-		const result = await loadWpCodeboxCoreExport(requiredExport, { required: true });
+		const result = await loadWpCodeboxCoreExport(requiredExport, { ...RECIPE_BUILDER_MODULE_OPTIONS, required: true });
 		return { builder: result.value, source: result.source };
 	} catch (error) {
-		const candidates = coreModuleCandidates();
+		const candidates = coreModuleCandidates(RECIPE_BUILDER_MODULE_OPTIONS);
 		const errors = (error.wpCodeboxCoreErrors || []).map(formatCoreLoaderError);
 
 		throw new Error([
 			`WP Codebox recipe builder export ${requiredExport} is unavailable.`,
-			`Install/build a WP Codebox runtime-core module that exports ${requiredExport}.`,
-			`Pass --setting wp_codebox_core_module=/path/to/wp-codebox/${RUNTIME_CORE_ENTRY}, or set HOMEBOY_WP_CODEBOX_CORE_MODULE to that built ESM entrypoint.`,
-			`Fallback discovery also checks sibling wp-codebox checkouts for ${RUNTIME_CORE_ENTRY}.`,
+			`Install/build a WP Codebox recipe-builder module that exports ${requiredExport}.`,
+			'Use @automattic/wp-codebox-core/recipe-builders or wp-codebox-workspace/recipe-builders when the stable WP Codebox API is available.',
+			`Pass --setting wp_codebox_core_module=/path/to/wp-codebox/packages/runtime-core/dist/recipe-builders.js, or set HOMEBOY_WP_CODEBOX_CORE_MODULE to that built ESM entrypoint.`,
+			`Fallback discovery also checks sibling wp-codebox checkouts for packages/runtime-core/dist/recipe-builders.js and ${RUNTIME_CORE_ENTRY}.`,
 			'This is separate from HOMEBOY_WP_CODEBOX_BIN / wp_codebox_bin, which only selects the wp-codebox CLI.',
 			'Homeboy Extensions no longer falls back to bundled WP Codebox recipe builders because that stale local copy can drift from the Codebox recipe contract.',
 			`Tried ${candidates.length} candidate(s):`,

--- a/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
@@ -104,7 +104,7 @@ const diagnosticResult = spawnSync(process.execPath, [script], {
 
 assert.notEqual(diagnosticResult.status, 0);
 assert.match(diagnosticResult.stderr, /WP Codebox recipe builder export buildWordPressBenchRecipe is unavailable/);
-assert.match(diagnosticResult.stderr, /--setting wp_codebox_core_module=\/path\/to\/wp-codebox\/packages\/runtime-core\/dist\/index\.js/);
+assert.match(diagnosticResult.stderr, /--setting wp_codebox_core_module=\/path\/to\/wp-codebox\/packages\/runtime-core\/dist\/recipe-builders\.js/);
 assert.match(diagnosticResult.stderr, /HOMEBOY_WP_CODEBOX_CORE_MODULE/);
 assert.match(diagnosticResult.stderr, /HOMEBOY_WP_CODEBOX_BIN \/ wp_codebox_bin/);
 assert.match(diagnosticResult.stderr, /no longer falls back to bundled WP Codebox recipe builders/);

--- a/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
@@ -53,7 +53,7 @@ const diagnosticResult = spawnSync(process.execPath, [script], {
 
 assert.notEqual(diagnosticResult.status, 0);
 assert.match(diagnosticResult.stderr, /WP Codebox recipe builder export buildWordPressPhpunitRecipe is unavailable/);
-assert.match(diagnosticResult.stderr, /--setting wp_codebox_core_module=\/path\/to\/wp-codebox\/packages\/runtime-core\/dist\/index\.js/);
+assert.match(diagnosticResult.stderr, /--setting wp_codebox_core_module=\/path\/to\/wp-codebox\/packages\/runtime-core\/dist\/recipe-builders\.js/);
 assert.match(diagnosticResult.stderr, /no longer falls back to bundled WP Codebox recipe builders/);
 assert.match(diagnosticResult.stderr, /HOMEBOY_WP_CODEBOX_CORE_MODULE/);
 assert.match(diagnosticResult.stderr, /\/missing\/wp-codebox-core\.mjs/);


### PR DESCRIPTION
## Summary
- Moves WP Codebox recipe-builder discovery into the shared `wordpress/lib/wp-codebox-core-loader.js` surface.
- Updates bench and PHPUnit recipe builders to load required recipe exports through that shared loader instead of maintaining a second package-layout discovery path.
- Prefers the stable recipe-builder imports from Automattic/wp-codebox#926 (`@automattic/wp-codebox-core/recipe-builders` and `wp-codebox-workspace/recipe-builders`) while retaining current runtime-core `index.js` fallbacks for existing installs.
- Keeps recipe-builder diagnostics actionable and points users at `wp_codebox_core_module` / `HOMEBOY_WP_CODEBOX_CORE_MODULE` when the runtime-core export is unavailable.

## Remaining upstream gap
- Automattic/wp-codebox#926 is still the long-term fix: WP Codebox needs a stable documented recipe-builder API so Homeboy does not need to know `packages/runtime-core/dist/index.js` or release/cache layouts. This PR now prefers that API when available and isolates legacy fallbacks behind the shared Homeboy loader until that API is released everywhere.

## Verification
- `node tests/wp-codebox-bench-recipe-builder-smoke.js`
- `node tests/wp-codebox-phpunit-recipe-builder-smoke.js`
- `node --check lib/wp-codebox-core-loader.js && node --check scripts/bench/wp-codebox-recipe-builder-loader.mjs && node --check scripts/bench/build-wp-codebox-bench-recipe.mjs && node --check scripts/test/build-wp-codebox-phpunit-recipe.mjs && node --check tests/wp-codebox-bench-recipe-builder-smoke.js && node --check tests/wp-codebox-phpunit-recipe-builder-smoke.js`

Fixes #1327
Related #1169
Related Automattic/wp-codebox#925
Related Automattic/wp-codebox#926

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the loader consolidation, coordinated the Homeboy-side loader with the stable WP Codebox recipe-builder API, updated diagnostics, ran targeted smoke/syntax verification, and prepared this PR body for Chris to review.