### PR TITLE
Normalize WP Codebox runtime component vocabulary

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -111,8 +111,6 @@ const AGENT_BUNDLE_TRIGGER_FIELDS = AGENT_BUNDLE_CONFIG_FIELDS.filter((field) =>
 ].includes(field));
 
 const LEGACY_RUNTIME_PREFIX = ['data', 'machine'].join('_');
-const WP_CODEBOX_RUNTIME_PATH_KEY = `${LEGACY_RUNTIME_PREFIX}_path`;
-const WP_CODEBOX_RUNTIME_TOOLS_PATH_KEY = `${LEGACY_RUNTIME_PREFIX}_code_path`;
 const LEGACY_BUNDLE_KEYS = [
   `${LEGACY_RUNTIME_PREFIX}_bundle`,
   `${LEGACY_RUNTIME_PREFIX}Bundle`,
@@ -235,9 +233,6 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     verify_steps: inputs.verify_steps || config.verify_steps || options.verifySteps || [],
     mounts,
     workspaces: inputs.workspaces || config.workspaces || options.workspaces || defaults.workspaces || [],
-    agents_api_path: components.agents_api || config.agents_api || config.agents_api_path || options.agentsApi || '',
-    [WP_CODEBOX_RUNTIME_PATH_KEY]: components.agent_runtime || '',
-    [WP_CODEBOX_RUNTIME_TOOLS_PATH_KEY]: components.agent_runtime_tools || '',
     runtime_component_paths: components,
     homeboy_path: config.homeboy || config.homeboy_path || options.homeboy || '',
     homeboy_extensions_path: config.homeboy_extensions || config.homeboy_extensions_path || options.homeboyExtensions || '',
@@ -274,15 +269,31 @@ function runtimeComponentPaths(config, options = {}) {
   const explicit = config.runtime_component_paths && typeof config.runtime_component_paths === 'object'
     ? config.runtime_component_paths
     : {};
+  const contractPaths = runtimeComponentPathsFromContracts(config.component_contracts || options.componentContracts || []);
   const legacyRuntimePath = config[LEGACY_RUNTIME_PREFIX] || config[`${LEGACY_RUNTIME_PREFIX}_path`] || options.legacyRuntime;
   const legacyToolsKey = `${LEGACY_RUNTIME_PREFIX}_code`;
   const legacyRuntimeToolsPath = config[legacyToolsKey] || config[`${legacyToolsKey}_path`] || options.legacyRuntimeTools;
   return Object.fromEntries(Object.entries({
+    ...contractPaths,
     ...explicit,
-    agents_api: explicit.agents_api || config.agents_api || config.agents_api_path || options.agentsApi,
-    agent_runtime: explicit.agent_runtime || config.agent_runtime || config.agent_runtime_path || legacyRuntimePath,
-    agent_runtime_tools: explicit.agent_runtime_tools || config.agent_runtime_tools || config.agent_runtime_tools_path || legacyRuntimeToolsPath,
+    agents_api: explicit.agents_api || contractPaths.agents_api || config.agents_api || config.agents_api_path || options.agentsApi,
+    agent_runtime: explicit.agent_runtime || contractPaths.agent_runtime || config.agent_runtime || config.agent_runtime_path || legacyRuntimePath,
+    agent_runtime_tools: explicit.agent_runtime_tools || contractPaths.agent_runtime_tools || config.agent_runtime_tools_path || config.agent_runtime_tools || legacyRuntimeToolsPath,
   }).filter(([, value]) => value !== undefined && value !== ''));
+}
+
+function runtimeComponentPathsFromContracts(contracts) {
+  if (!Array.isArray(contracts)) {
+    return {};
+  }
+  const slugToKey = new Map([
+    ['agents-api', 'agents_api'],
+    ['data-machine', 'agent_runtime'],
+    ['data-machine-code', 'agent_runtime_tools'],
+  ]);
+  return Object.fromEntries(contracts
+    .map((contract) => [slugToKey.get(contract?.slug), contract?.path || contract?.source])
+    .filter(([key, value]) => key && value));
 }
 
 function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -419,8 +419,6 @@ function attachFailureEvidence(payload, evidence) {
 }
 
 const LEGACY_RUNTIME_PREFIX = ['data', 'machine'].join('_');
-const WP_CODEBOX_RUNTIME_PATH_KEY = `${LEGACY_RUNTIME_PREFIX}_path`;
-const WP_CODEBOX_RUNTIME_TOOLS_PATH_KEY = `${LEGACY_RUNTIME_PREFIX}_code_path`;
 const LEGACY_BUNDLE_KEYS = [
   `${LEGACY_RUNTIME_PREFIX}_bundle`,
   `${LEGACY_RUNTIME_PREFIX}Bundle`,
@@ -450,19 +448,38 @@ function requestRuntimeComponents(request, mounts = []) {
   const explicit = request.runtime_component_paths && typeof request.runtime_component_paths === 'object'
     ? request.runtime_component_paths
     : {};
+  const contractPaths = runtimeComponentPathsFromContracts(request.component_contracts || []);
   const workspaceRoot = workspaceRootFromMounts(mounts);
-  const dataMachinePath = explicit.agent_runtime || legacyValue(request) || firstExistingPath(siblingPath(workspaceRoot, 'data-machine'));
+  const agentRuntimePath = explicit.agent_runtime || contractPaths.agent_runtime || legacyValue(request) || firstExistingPath(siblingPath(workspaceRoot, 'data-machine'));
   return Object.fromEntries(Object.entries({
+    ...contractPaths,
     ...explicit,
-    agents_api: explicit.agents_api || request.agents_api_path || request.agents_api || bundledAgentsApiPath(dataMachinePath),
-    agent_runtime: dataMachinePath,
-    agent_runtime_tools: explicit.agent_runtime_tools || legacyValue(request, 'code') || firstExistingPath(siblingPath(workspaceRoot, 'data-machine-code')),
+    agents_api: explicit.agents_api || contractPaths.agents_api || request.agents_api_path || request.agents_api || bundledAgentsApiPath(agentRuntimePath),
+    agent_runtime: agentRuntimePath,
+    agent_runtime_tools: explicit.agent_runtime_tools || contractPaths.agent_runtime_tools || legacyValue(request, 'code') || firstExistingPath(siblingPath(workspaceRoot, 'data-machine-code')),
   }).filter(([, value]) => value !== '' && value !== undefined));
+}
+
+function runtimeComponentPathsFromContracts(contracts) {
+  if (!Array.isArray(contracts)) {
+    return {};
+  }
+  const slugToKey = new Map([
+    ['agents-api', 'agents_api'],
+    ['data-machine', 'agent_runtime'],
+    ['data-machine-code', 'agent_runtime_tools'],
+  ]);
+  return Object.fromEntries(contracts
+    .map((contract) => [slugToKey.get(contract?.slug), contract?.path || contract?.source])
+    .filter(([key, value]) => key && value));
 }
 
 function runnerInput(request, artifacts) {
   const mounts = mountEntries(request);
-  const runtimeComponentPaths = requestRuntimeComponents(request, mounts);
+  const runtimeComponentPaths = {
+    ...requestRuntimeComponents(request, mounts),
+    ...(argValue('--agents-api') ? { agents_api: argValue('--agents-api') } : {}),
+  };
   return Object.fromEntries(Object.entries({
     parent_request: request,
     agent: argValue('--agent') || request.agent || 'wp-codebox-sandbox',
@@ -483,7 +500,6 @@ function runnerInput(request, artifacts) {
     runtime_task: request.runtime_task || request.runtimeTask,
     artifacts_path: artifacts,
     wp_codebox_bin: argValue('--wp-codebox-bin') || request.wp_codebox_bin || '',
-    agents_api_path: argValue('--agents-api') || request.agents_api_path || request.agents_api || '',
     runtime_component_paths: runtimeComponentPaths,
     homeboy_path: argValue('--homeboy') || request.homeboy_path || request.homeboy || '',
     homeboy_extensions_path: argValue('--homeboy-extensions') || request.homeboy_extensions_path || request.homeboy_extensions || path.resolve(__dirname, '..', '..'),
@@ -493,10 +509,7 @@ function runnerInput(request, artifacts) {
 }
 
 function runtimeComponentExtraPlugins(input) {
-  const components = {
-    agents_api: input.agents_api_path,
-    ...(input.runtime_component_paths || {}),
-  };
+  const components = input.runtime_component_paths || {};
   return [
     { key: 'agents_api', slug: 'agents-api' },
     { key: 'agent_runtime', slug: 'data-machine' },
@@ -508,10 +521,10 @@ function runtimeComponentExtraPlugins(input) {
 }
 
 function componentContracts(input) {
-  // Translate the runtime component paths (agents-api, data-machine,
-  // data-machine-code) into the WP Codebox 0.8.0 `component_contracts` shape:
+  // Translate normalized runtime component paths into the WP Codebox 0.8.0
+  // `component_contracts` shape:
   // `{ slug, path, loadAs, activate }`. WP Codebox mounts these as mu-plugins so
-  // Data Machine loads its own vendored Agents API and registers agents/chat.
+  // the runtime stack can register its tools and agent/chat surfaces.
   return runtimeComponentExtraPlugins(input).map((plugin) => ({
     slug: plugin.slug,
     path: plugin.source,
@@ -570,10 +583,9 @@ function stableTaskInput(input) {
     model: input.model,
     provider_plugin_paths: input.provider_plugin_paths || [],
     extra_plugins: extraPlugins(input),
-    // WP Codebox 0.8.0 reads runtime component plugins (agents-api, data-machine,
-    // data-machine-code) from `component_contracts`, not the legacy
-    // `runtime_component_paths` / legacy runtime path fields. Without this the
-    // components never mount and agents/chat is unavailable in the sandbox.
+    // WP Codebox 0.8.0 reads runtime component plugins from
+    // `component_contracts`; keep `runtime_component_paths` as neutral
+    // orchestration metadata and avoid emitting legacy runtime path aliases.
     component_contracts: componentContracts(input),
     // Post-agent verification gate. WP Codebox emits these as recipe
     // `workflow.after` steps that run once the agent finishes editing; any
@@ -595,9 +607,6 @@ function stableTaskInput(input) {
     orchestrator: input.orchestrator || {},
     artifacts_path: input.artifacts_path,
     wp_codebox_bin: input.wp_codebox_bin,
-    agents_api_path: input.agents_api_path,
-    [WP_CODEBOX_RUNTIME_PATH_KEY]: input.runtime_component_paths?.agent_runtime,
-    [WP_CODEBOX_RUNTIME_TOOLS_PATH_KEY]: input.runtime_component_paths?.agent_runtime_tools,
     runtime_component_paths: input.runtime_component_paths || {},
     wp: input.wp_version,
     agent_bundle: isAgentBundle(input) ? agentBundleConfig(input, input.agent_bundle || {}) : {},

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -443,9 +443,12 @@ assert.equal(codexRequest.mode, 'sandbox');
 assert.equal(codexRequest.provider, 'codex');
 assert.equal(codexRequest.model, 'gpt-5.5');
 assert.deepEqual(codexRequest.provider_plugin_paths, ['/components/ai-provider-for-openai']);
-assert.equal(codexRequest.agents_api_path, '/components/agents-api');
+assert.equal(codexRequest.runtime_component_paths.agents_api, '/components/agents-api');
 assert.equal(codexRequest.runtime_component_paths.agent_runtime, '/components/data-machine');
 assert.equal(codexRequest.runtime_component_paths.agent_runtime_tools, '/components/data-machine-code');
+assert.equal(Object.hasOwn(codexRequest, 'agents_api_path'), false);
+assert.equal(Object.hasOwn(codexRequest, 'data_machine_path'), false);
+assert.equal(Object.hasOwn(codexRequest, 'data_machine_code_path'), false);
 assert.equal(codexRequest.homeboy_path, '/components/homeboy');
 assert.equal(codexRequest.homeboy_extensions_path, '/components/homeboy-extensions');
 assert.equal(codexRequest.wp_codebox_bin, '/bin/wp-codebox');
@@ -485,7 +488,6 @@ try {
   }, {
     settings: {},
   });
-  assert.equal(defaultedRequest.agents_api_path, bundledAgentsApiPath);
   assert.equal(defaultedRequest.runtime_component_paths.agents_api, bundledAgentsApiPath);
   assert.equal(defaultedRequest.runtime_component_paths.agent_runtime, dataMachinePath);
   assert.equal(defaultedRequest.runtime_component_paths.agent_runtime_tools, dataMachineCodePath);
@@ -669,7 +671,7 @@ try {
   }, {
     settings: {},
   });
-  assert.equal(alternateDefaultedRequest.agents_api_path, alternateBundledAgentsApiPath);
+  assert.equal(alternateDefaultedRequest.runtime_component_paths.agents_api, alternateBundledAgentsApiPath);
 
   const explicitOverrideRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,
@@ -693,13 +695,35 @@ try {
       target: { root: workspaceRoot },
     },
   });
-  assert.equal(explicitOverrideRequest.agents_api_path, staleStandaloneAgentsApiPath);
+  assert.equal(explicitOverrideRequest.runtime_component_paths.agents_api, staleStandaloneAgentsApiPath);
   assert.equal(explicitOverrideRequest.runtime_component_paths.agent_runtime, '/explicit/data-machine');
   assert.equal(explicitOverrideRequest.runtime_component_paths.agent_runtime_tools, '/explicit/data-machine-code');
   assert.deepEqual(explicitOverrideRequest.provider_plugin_paths, ['/explicit/provider']);
   assert.deepEqual(explicitOverrideRequest.secret_env, ['EXPLICIT_SECRET']);
   assert.deepEqual(explicitOverrideRequest.mounts, [{ source: '/explicit/worktree', target: '/workspace', mode: 'readonly' }]);
   assert.deepEqual(explicitOverrideRequest.workspaces, [{ target: '/explicit-workspace', mode: 'readonly' }]);
+
+  const legacyAliasRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'legacy-runtime-alias-task-123',
+    executor: {
+      backend: 'codebox',
+      config: {
+        provider: 'codex',
+        agents_api_path: staleStandaloneAgentsApiPath,
+        data_machine_path: '/legacy/data-machine',
+        data_machine_code_path: '/legacy/data-machine-code',
+      },
+    },
+    inputs: {
+      target: { root: workspaceRoot },
+    },
+  });
+  assert.equal(legacyAliasRequest.runtime_component_paths.agents_api, staleStandaloneAgentsApiPath);
+  assert.equal(legacyAliasRequest.runtime_component_paths.agent_runtime, '/legacy/data-machine');
+  assert.equal(legacyAliasRequest.runtime_component_paths.agent_runtime_tools, '/legacy/data-machine-code');
+  assert.equal(Object.hasOwn(legacyAliasRequest, 'data_machine_path'), false);
+  assert.equal(Object.hasOwn(legacyAliasRequest, 'data_machine_code_path'), false);
 } finally {
   fs.rmSync(defaultsRoot, { recursive: true, force: true });
 }
@@ -1397,11 +1421,12 @@ try {
   assert.equal(capturedCodex.request.provider, 'codex');
   assert.equal(capturedCodex.request.model, 'gpt-5.5');
   assert.deepEqual(capturedCodex.request.provider_plugin_paths, ['/components/ai-provider-for-openai']);
-  assert.equal(capturedCodex.request.agents_api_path, '/components/agents-api');
-  assert.equal(capturedCodex.request.data_machine_path, '/components/data-machine');
-  assert.equal(capturedCodex.request.data_machine_code_path, '/components/data-machine-code');
+  assert.equal(capturedCodex.request.runtime_component_paths.agents_api, '/components/agents-api');
   assert.equal(capturedCodex.request.runtime_component_paths.agent_runtime, '/components/data-machine');
   assert.equal(capturedCodex.request.runtime_component_paths.agent_runtime_tools, '/components/data-machine-code');
+  assert.equal(Object.hasOwn(capturedCodex.request, 'agents_api_path'), false);
+  assert.equal(Object.hasOwn(capturedCodex.request, 'data_machine_path'), false);
+  assert.equal(Object.hasOwn(capturedCodex.request, 'data_machine_code_path'), false);
   assert.equal(capturedCodex.request.homeboy_path, '/components/homeboy');
   assert.equal(capturedCodex.request.homeboy_extensions_path, '/components/homeboy-extensions');
   assert.deepEqual(capturedCodex.request.secret_env, [

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -263,18 +263,18 @@ try {
   assert.equal(captured.input.runtime_stack_mounts[0].source, '/components/php-ai-client');
   assert.equal(captured.input.runtime_stack_mounts[1].source, '/components/wordpress-develop');
   assert.equal(captured.input.mounts[0].source, '/repo/plugin');
-  assert.equal(captured.input.agents_api_path, '/components/agents-api');
-  assert.equal(captured.input.data_machine_path, '/components/data-machine');
-  assert.equal(captured.input.data_machine_code_path, '/components/data-machine-code');
+  assert.equal(captured.input.runtime_component_paths.agents_api, '/components/agents-api');
   assert.equal(captured.input.runtime_component_paths.agent_runtime, '/components/data-machine');
   assert.equal(captured.input.runtime_component_paths.agent_runtime_tools, '/components/data-machine-code');
+  assert.equal(Object.hasOwn(captured.input, 'agents_api_path'), false);
+  assert.equal(Object.hasOwn(captured.input, 'data_machine_path'), false);
+  assert.equal(Object.hasOwn(captured.input, 'data_machine_code_path'), false);
   assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'agents-api').source, '/components/agents-api');
   assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'data-machine').source, '/components/data-machine');
   assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'data-machine-code').source, '/components/data-machine-code');
   assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'data-machine').loadAs, 'mu-plugin');
   assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'data-machine-code').activate, false);
-  // WP Codebox 0.8.0 mounts runtime components from `component_contracts`
-  // ({ slug, path }), not the legacy `runtime_component_paths` fields.
+  // WP Codebox 0.8.0 mounts runtime components from `component_contracts`.
   assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'agents-api').path, '/components/agents-api');
   assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'data-machine').path, '/components/data-machine');
   assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'data-machine-code').path, '/components/data-machine-code');
@@ -440,6 +440,30 @@ try {
   assert.equal(implicitRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'agents-api').source, defaultAgentsApiPath);
   assert.equal(implicitRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'data-machine').source, defaultDataMachinePath);
   assert.equal(implicitRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'data-machine-code').source, defaultDataMachineCodePath);
+
+  const legacyRuntimeCapturePath = path.join(root, 'capture-legacy-runtime-stack.json');
+  const legacyRuntimeResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      runtime_component_paths: undefined,
+      agents_api_path: '/legacy/agents-api',
+      data_machine_path: '/legacy/data-machine',
+      data_machine_code_path: '/legacy/data-machine-code',
+    }),
+    env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: legacyRuntimeCapturePath, OPENCODE_API_KEY: 'redacted-test-key' },
+  });
+  assert.equal(legacyRuntimeResult.status, 0, legacyRuntimeResult.stderr || legacyRuntimeResult.stdout);
+  const legacyRuntimeInput = readJson(legacyRuntimeCapturePath).input;
+  assert.equal(legacyRuntimeInput.runtime_component_paths.agents_api, '/legacy/agents-api');
+  assert.equal(legacyRuntimeInput.runtime_component_paths.agent_runtime, '/legacy/data-machine');
+  assert.equal(legacyRuntimeInput.runtime_component_paths.agent_runtime_tools, '/legacy/data-machine-code');
+  assert.equal(legacyRuntimeInput.component_contracts.find((contract) => contract.slug === 'agents-api').path, '/legacy/agents-api');
+  assert.equal(Object.hasOwn(legacyRuntimeInput, 'data_machine_path'), false);
+  assert.equal(Object.hasOwn(legacyRuntimeInput, 'data_machine_code_path'), false);
 
   const sourceRoot = path.join(root, 'source-plugin');
   fs.mkdirSync(sourceRoot, { recursive: true });


### PR DESCRIPTION
## Summary
- Normalize WordPress agent-task runtime component paths through `runtime_component_paths` and `component_contracts` instead of emitting legacy Data Machine path fields.
- Keep legacy `data_machine*` and `agents_api_path` inputs accepted at normalization edges for compatibility.
- Update smoke coverage for generic runtime component output and retained legacy alias input behavior.

Fixes #1329

## Tests
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-boundary-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused code/test changes and ran targeted smoke verification; Chris remains responsible for review and merge.