### PR TITLE
fix: scope WordPress bench dependencies by profile

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -400,6 +400,51 @@ homeboy_wp_codebox_selected_scenarios_json() {
     ' <<< "$selected_value"
 }
 
+homeboy_wp_codebox_filter_scoped_validation_dependencies() {
+    local selected_scenarios_json
+    selected_scenarios_json="$(homeboy_wp_codebox_selected_scenarios_json)"
+
+    settings_json=$(jq -nc \
+        --argjson settings "$settings_json" \
+        --argjson selectedScenarios "$selected_scenarios_json" \
+        --arg envProfiles "${HOMEBOY_BENCH_PROFILES:-}" \
+        'def list($value):
+            if ($value | type) == "array" then $value
+            elif ($value | type) == "string" then ($value | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != "")))
+            elif $value == null then []
+            else [] end;
+        def selected_profiles($entry):
+            ($entry.profile_env // $entry.profiles_env // "WC_CHECKOUT_GATEWAY_MATRIX_PROFILES") as $envName |
+            (($settings.bench_env // {})[$envName] // env[$envName] // $envProfiles // "") | list(.);
+        def scenario_matches($entry):
+            list($entry.scenarios // $entry.scenario_ids // $entry.scenario // $entry.scenario_id // null) as $scopes |
+            ($scopes | length) == 0
+            or ($selectedScenarios | length) == 0
+            or any($scopes[]; $selectedScenarios[.] == true);
+        def profile_matches($entry):
+            list($entry.profiles // $entry.profile_ids // $entry.profile // $entry.profile_id // null) as $scopes |
+            selected_profiles($entry) as $selectedProfiles |
+            ($scopes | length) == 0
+            or ($selectedProfiles | length) == 0
+            or any($scopes[]; . as $scope | any($selectedProfiles[]; . == $scope));
+        def dependency_value($entry):
+            if ($entry | type) == "object" then ($entry.dependency // $entry.path // $entry.slug // $entry.id // $entry.source // $entry.value // empty)
+            else $entry end;
+        if (($settings.validation_dependencies? // null) | type) == "array" then
+            $settings + {
+                validation_dependencies: (
+                    $settings.validation_dependencies
+                    | map(select((type != "object") or (scenario_matches(.) and profile_matches(.))))
+                    | map(dependency_value(.))
+                    | map(select((type == "string" and . != "") or type != "string"))
+                )
+            }
+        else
+            $settings
+        end')
+    export HOMEBOY_SETTINGS_JSON="$settings_json"
+}
+
 homeboy_wp_codebox_filter_extra_bench_workloads() {
     local workloads_value="${HOMEBOY_BENCH_EXTRA_WORKLOADS:-}"
     local selected_value="${HOMEBOY_BENCH_SCENARIOS:-}"
@@ -708,6 +753,7 @@ homeboy_wp_codebox_compile_bootstrap_files
 homeboy_wp_codebox_compile_bootstrap_steps
 homeboy_wp_codebox_compile_prepare_steps
 homeboy_wp_codebox_filter_extra_bench_workloads
+homeboy_wp_codebox_filter_scoped_validation_dependencies
 
 WP_CODEBOX_WORDPRESS_VERSION=""
 if [ "$settings_json" != "{}" ]; then

--- a/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
@@ -133,18 +133,59 @@ homeboy_require_bash_version() { :; }
   assert.ok(successResults.prepared_dependencies.some((dependency) => dependency.slug === 'woocommerce' && dependency.source_path === fs.realpathSync(monorepoDependencyPath) && dependency.package_root === fs.realpathSync(monorepoPluginPath) && dependency.mounted_plugin_dir === '/wordpress/wp-content/plugins/woocommerce'), JSON.stringify(successResults.prepared_dependencies, null, 2));
   assert.ok(successResults.prepared_dependencies.some((dependency) => dependency.slug === 'woocommerce-gateway-stripe' && dependency.source_path === fs.realpathSync(stripeDependencyPath) && dependency.package_root === fs.realpathSync(stripeDependencyPath)), JSON.stringify(successResults.prepared_dependencies, null, 2));
 
+  const scopedCoreResult = spawnSync('bash', [path.join(extensionPath, 'scripts', 'bench', 'bench-runner.sh')], {
+    cwd: componentPath,
+    encoding: 'utf8',
+    env: {
+      ...baseEnv,
+      HOMEBOY_BENCH_SCENARIOS: 'assert-bootstrap',
+      HOMEBOY_BENCH_RESULTS_FILE: path.join(root, 'scoped-core-results.json'),
+      HOMEBOY_CAPTURE_RECIPE: path.join(root, 'captured-scoped-core-recipe.json'),
+      HOMEBOY_SETTINGS_JSON: JSON.stringify({
+        ...settings,
+        bench_env: { WC_CHECKOUT_GATEWAY_MATRIX_PROFILES: 'core_bacs,core_cheque,core_cod' },
+        validation_dependencies: [
+          dependencyPath,
+          {
+            dependency: failingDependencyPath,
+            scenarios: ['assert-bootstrap'],
+            profiles: ['plugin_stripe'],
+            profile_env: 'WC_CHECKOUT_GATEWAY_MATRIX_PROFILES',
+          },
+        ],
+      }),
+      PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH}`,
+    },
+  });
+
+  assert.equal(scopedCoreResult.status, 0, scopedCoreResult.stderr || scopedCoreResult.stdout);
+  const scopedCoreResults = JSON.parse(fs.readFileSync(path.join(root, 'scoped-core-results.json'), 'utf8'));
+  assert.equal(scopedCoreResults.prepared_dependencies.some((dependency) => dependency.slug === 'generic-dependency'), true);
+  assert.equal(scopedCoreResults.prepared_dependencies.some((dependency) => dependency.slug === 'gateway-build-fails'), false);
+  assert.equal(scopedCoreResults.dependency_build_failures, undefined);
+
   const buildFailureArtifactsDir = path.join(root, 'build-failure-artifacts');
   const buildFailureResult = spawnSync('bash', [path.join(extensionPath, 'scripts', 'bench', 'bench-runner.sh')], {
     cwd: componentPath,
     encoding: 'utf8',
     env: {
       ...baseEnv,
+      HOMEBOY_BENCH_SCENARIOS: 'assert-bootstrap',
       HOMEBOY_BENCH_RESULTS_FILE: path.join(root, 'build-failure-results.json'),
       HOMEBOY_CAPTURE_RECIPE: path.join(root, 'captured-build-failure-recipe.json'),
       HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR: buildFailureArtifactsDir,
       HOMEBOY_SETTINGS_JSON: JSON.stringify({
         ...settings,
-        validation_dependencies: [dependencyPath, failingDependencyPath],
+        bench_env: { WC_CHECKOUT_GATEWAY_MATRIX_PROFILES: 'plugin_stripe' },
+        validation_dependencies: [
+          dependencyPath,
+          {
+            dependency: failingDependencyPath,
+            scenarios: ['assert-bootstrap'],
+            profiles: ['plugin_stripe'],
+            profile_env: 'WC_CHECKOUT_GATEWAY_MATRIX_PROFILES',
+          },
+        ],
       }),
       PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH}`,
     },

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -977,7 +977,7 @@
       "label": "Validation Dependencies",
       "type": "string",
       "default": "",
-      "description": "Local component IDs or paths to load during PHPStan, autoload validation, and PHPUnit. Accepts comma-separated, newline-separated, or JSON-array string values."
+      "description": "Local component IDs or paths to load during PHPStan, autoload validation, PHPUnit, and bench. Accepts comma-separated, newline-separated, JSON-array string values, or bench-scoped array objects shaped like {dependency,path|slug,scenarios,profiles,profile_env}. Scoped objects let selected bench scenarios/profiles opt into expensive gateway dependencies without blocking unrelated profiles."
     },
     {
       "id": "user",


### PR DESCRIPTION
## Summary
- Adds bench-scoped `validation_dependencies` entries so expensive gateway dependencies can be limited by selected scenario and profile.
- Exports the filtered settings JSON before dependency preflight/resolution so declared dependency checks, preparation, mounts, and result metadata all see the same scoped dependency set.
- Extends WP Codebox bench bootstrap smoke coverage for core profiles skipping a Stripe-scoped failing dependency and the Stripe profile surfacing structured build-failure metadata.

Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/1336.
Blocks https://github.com/chubes4/homeboy-rigs/issues/292.

## Verification
- `bash -n wordpress/scripts/bench/bench-runner-wp-codebox.sh`
- `bash -n wordpress/scripts/lib/validation-dependencies.sh`
- `cd wordpress && npm run test:wp-codebox-bench-bootstrap-steps`
- `cd wordpress && npm run test:wp-codebox-prepared-dependency-cache`
- `cd wordpress && npm run test:wp-codebox-bench-recipe-builder`
- `cd wordpress && npm run test:dependency-plugin-preflight`
- `git diff --check origin/main...HEAD`

## Notes
- `cd wordpress && npm run lint:js` is still red on pre-existing lint failures outside this change, including `wordpress/lib/playground-readiness.js`, `wordpress/lib/timing-correlator.js`, and several agent/runtime scripts.
- `cd wordpress && bash tests/validation-dependencies-smoke.sh` is still red in this environment because dependency preparation defaults to `~/.homeboy/cache/prepared-bench-dependencies` while that smoke expects artifact-local prepared paths.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing scoped WP bench dependency filtering, extending smoke coverage, and running targeted verification.