### PR TITLE
Forward generic Codebox runtime config

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -530,10 +530,10 @@ extension handles the audit source with:
 homeboy refactor <component> \
   --from audit \
   --setting refactor.audit.extension=wordpress \
-  --setting wp_codebox_provider=opencode \
-  --setting wp_codebox_model=opencode-go/kimi-k2.6 \
-  --setting wp_codebox_provider_plugin_paths=/Users/chubes/Developer/ai-provider-for-opencode \
-  --setting wp_codebox_secret_env=OPENCODE_API_KEY
+  --setting wp_codebox_provider=provider-slug \
+  --setting wp_codebox_model=provider/model \
+  --setting wp_codebox_provider_plugin_paths=/components/ai-provider-example \
+  --setting wp_codebox_secret_env=PROVIDER_API_KEY
 ```
 
 `scripts/agent/homeboy-audit-wp-codebox-fanout.cjs` turns a structured audit
@@ -562,6 +562,15 @@ Discovery exposes the required request fields, outcome status vocabulary,
 failure classifications, capability list, and metadata redaction keys so Lab
 offload and runner transport consumers can select providers without importing
 Codebox-specific request or recipe details.
+
+Provider stacks stay generic at the Homeboy boundary. Executor config, options,
+or `HOMEBOY_SETTINGS_JSON` may provide `runtime_env`, `runtime_state_mounts`,
+and `runtime_config_mounts` (or the settings names `wp_codebox_runtime_env`,
+`wp_codebox_runtime_state_mounts`, and `wp_codebox_runtime_config_mounts`). The
+executor forwards those values unchanged to the WP Codebox task input alongside
+`provider_plugin_paths`, `runtime_overlays`, `runtime_overlay_profiles`, and
+`secret_env`; provider plugins own any model/auth/config discovery inside the
+sandbox.
 
 The outcome preserves the Homeboy decision evidence needed for Codebox worker
 canaries: why the Codebox executor was selected, which capabilities were used,

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -300,12 +300,44 @@ artifact capture behind that stable command; Homeboy keeps only request/outcome
 adaptation and redaction logic in this extension.
 
 Callers that need a provider stack supply WP Codebox's generic fields directly:
-`provider_plugin_paths`, `runtime_overlays`, `runtime_overlay_profiles`, and
+`provider_plugin_paths`, `runtime_overlays`, `runtime_overlay_profiles`,
+`runtime_env`, `runtime_state_mounts`, `runtime_config_mounts`, and
 `secret_env`. HBEX forwards those fields without expanding provider-specific
-runtime stacks; WP Codebox owns sandbox recipe expansion and artifact capture.
-The same generic fields can live in Homeboy/global settings as
+runtime stacks; WP Codebox owns sandbox recipe expansion, runtime mounting, and
+artifact capture. The same generic fields can live in Homeboy/global settings as
 `wp_codebox_provider_plugin_paths`, `wp_codebox_runtime_overlays`,
-`wp_codebox_runtime_overlay_profiles`, and `wp_codebox_secret_env`.
+`wp_codebox_runtime_overlay_profiles`, `wp_codebox_runtime_env`,
+`wp_codebox_runtime_state_mounts`, `wp_codebox_runtime_config_mounts`, and
+`wp_codebox_secret_env`.
+
+Example global settings payload:
+
+```json
+{
+  "wp_codebox_provider": "provider-slug",
+  "wp_codebox_model": "provider/model",
+  "wp_codebox_provider_plugin_paths": ["/components/ai-provider-example"],
+  "wp_codebox_runtime_env": {
+    "PROVIDER_CONFIG": "/runtime/provider/config.json",
+    "XDG_DATA_HOME": "/runtime/provider/data"
+  },
+  "wp_codebox_runtime_state_mounts": [
+    {
+      "source": "/host/provider/state.json",
+      "target": "/runtime/provider/state.json",
+      "mode": "readonly"
+    }
+  ],
+  "wp_codebox_runtime_config_mounts": [
+    {
+      "source": "/host/provider/config.json",
+      "target": "/runtime/provider/config.json",
+      "mode": "readonly"
+    }
+  ],
+  "wp_codebox_secret_env": ["PROVIDER_API_KEY"]
+}
+```
 
 ## Runner config surface
 

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -226,6 +226,9 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
     runtime_overlay_profiles: config.runtime_overlay_profiles || config.runtimeOverlayProfiles || options.runtimeOverlayProfiles || defaults.runtimeOverlayProfiles || [],
     runtime_overlays: config.runtime_overlays || options.runtimeOverlays || defaults.runtimeOverlays || [],
+    runtime_env: firstDefined(config.runtime_env, config.runtimeEnv, config.wp_codebox_runtime_env, options.runtimeEnv, defaults.runtimeEnv, {}),
+    runtime_state_mounts: firstDefined(config.runtime_state_mounts, config.runtimeStateMounts, config.wp_codebox_runtime_state_mounts, options.runtimeStateMounts, defaults.runtimeStateMounts, []),
+    runtime_config_mounts: firstDefined(config.runtime_config_mounts, config.runtimeConfigMounts, config.wp_codebox_runtime_config_mounts, options.runtimeConfigMounts, defaults.runtimeConfigMounts, []),
     secret_env: explicitSecretEnv.length > 0 ? Array.from(new Set(explicitSecretEnv)) : defaults.secretEnv || [],
     // Post-agent verification gate (recipe workflow.after). Supplied as WP
     // Codebox recipe steps; a non-zero exit fails the run so the orchestrator
@@ -345,6 +348,9 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     wpCodeboxBin: firstValue(settings.wp_codebox_bin, settings.wpCodeboxBin, process.env.HOMEBOY_WP_CODEBOX_BIN, ''),
     runtimeOverlayProfiles: defaultRuntimeOverlayProfiles(settings),
     runtimeOverlays: defaultRuntimeOverlays(settings),
+    runtimeEnv: defaultRuntimeEnv(settings),
+    runtimeStateMounts: defaultRuntimeStateMounts(settings),
+    runtimeConfigMounts: defaultRuntimeConfigMounts(settings),
     mounts: defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options),
     workspaces: defaultWorkspaces(config, inputs, options),
     allowedTools: defaultWorkspaceAllowedTools(workspaceRoot, workspaceMode(request, config, inputs)),
@@ -369,6 +375,18 @@ function defaultRuntimeOverlayProfiles(settings) {
 
 function defaultRuntimeOverlays(settings) {
   return normalizeArray(settings.wp_codebox_runtime_overlays || settings.runtime_overlays);
+}
+
+function defaultRuntimeEnv(settings) {
+  return firstObject(settings.wp_codebox_runtime_env, settings.runtime_env) || {};
+}
+
+function defaultRuntimeStateMounts(settings) {
+  return normalizeArray(settings.wp_codebox_runtime_state_mounts || settings.runtime_state_mounts);
+}
+
+function defaultRuntimeConfigMounts(settings) {
+  return normalizeArray(settings.wp_codebox_runtime_config_mounts || settings.runtime_config_mounts);
 }
 
 function firstDefined(...values) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -289,6 +289,9 @@ assert.deepEqual(codeboxRequest.runtime_overlays, [{
   target: '/wordpress/wp-includes/php-ai-client',
   metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
 }]);
+assert.deepEqual(codeboxRequest.runtime_env, {});
+assert.deepEqual(codeboxRequest.runtime_state_mounts, []);
+assert.deepEqual(codeboxRequest.runtime_config_mounts, []);
 assert.deepEqual(codeboxRequest.secret_env, ['OPENAI_API_KEY']);
 assert.equal(codeboxRequest.max_turns, 8);
 assert.equal(codeboxRequest.task_timeout_seconds, 120);
@@ -382,6 +385,95 @@ const abilityBridgeRequest = codeboxTaskRequestFromAgentTaskRequest({
 assert.equal(abilityBridgeRequest.runtime_task.ability, 'example/validate-artifact');
 assert.deepEqual(abilityBridgeRequest.runtime_task.input, { artifact: { slug: 'example-site' }, report: '/artifacts/import-report.json' });
 assert.equal(abilityBridgeRequest.parent_request.executor.config.output_mappings.validation_result, 'result.import_validation_result');
+
+const genericRuntimeEnv = {
+  GENERIC_PROVIDER_CONFIG: '/runtime/provider/config.json',
+  XDG_DATA_HOME: '/runtime/provider/data',
+};
+const genericRuntimeStateMounts = [{
+  source: '/host/provider/state.json',
+  target: '/runtime/provider/state.json',
+  mode: 'readonly',
+  metadata: { purpose: 'provider-state' },
+}];
+const genericRuntimeConfigMounts = [{
+  source: '/host/provider/config.json',
+  target: '/runtime/provider/config.json',
+  mode: 'readonly',
+  metadata: { purpose: 'provider-config' },
+}];
+const genericProviderRuntimeRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'generic-runtime-env-task-123',
+  executor: {
+    backend: 'codebox',
+    config: {
+      provider: 'fixture-provider',
+      runtime_env: genericRuntimeEnv,
+      runtime_state_mounts: genericRuntimeStateMounts,
+      runtime_config_mounts: genericRuntimeConfigMounts,
+      provider_plugin_paths: ['/providers/fixture-provider'],
+      runtime_overlays: [{ type: 'fixture-overlay', source: '/overlays/fixture' }],
+      runtime_overlay_profiles: ['fixture-profile'],
+      secret_env: ['FIXTURE_PROVIDER_SECRET'],
+    },
+  },
+});
+assert.equal(genericProviderRuntimeRequest.provider, 'fixture-provider');
+assert.deepEqual(genericProviderRuntimeRequest.runtime_env, genericRuntimeEnv);
+assert.deepEqual(genericProviderRuntimeRequest.runtime_state_mounts, genericRuntimeStateMounts);
+assert.deepEqual(genericProviderRuntimeRequest.runtime_config_mounts, genericRuntimeConfigMounts);
+assert.deepEqual(genericProviderRuntimeRequest.provider_plugin_paths, ['/providers/fixture-provider']);
+assert.deepEqual(genericProviderRuntimeRequest.runtime_overlays, [{ type: 'fixture-overlay', source: '/overlays/fixture' }]);
+assert.deepEqual(genericProviderRuntimeRequest.runtime_overlay_profiles, ['fixture-profile']);
+assert.deepEqual(genericProviderRuntimeRequest.secret_env, ['FIXTURE_PROVIDER_SECRET']);
+
+const optionsRuntimeRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'options-runtime-env-task-123',
+  executor: {
+    backend: 'codebox',
+    config: { provider: 'another-fixture-provider' },
+  },
+}, {
+  runtimeEnv: { OPTIONS_PROVIDER_HOME: '/runtime/options-provider' },
+  runtimeStateMounts: [{ source: '/host/options-state', target: '/runtime/options-state', mode: 'readonly' }],
+  runtimeConfigMounts: [{ source: '/host/options-config', target: '/runtime/options-config', mode: 'readonly' }],
+});
+assert.equal(optionsRuntimeRequest.provider, 'another-fixture-provider');
+assert.deepEqual(optionsRuntimeRequest.runtime_env, { OPTIONS_PROVIDER_HOME: '/runtime/options-provider' });
+assert.deepEqual(optionsRuntimeRequest.runtime_state_mounts, [{ source: '/host/options-state', target: '/runtime/options-state', mode: 'readonly' }]);
+assert.deepEqual(optionsRuntimeRequest.runtime_config_mounts, [{ source: '/host/options-config', target: '/runtime/options-config', mode: 'readonly' }]);
+
+const previousHomeboySettingsJson = process.env.HOMEBOY_SETTINGS_JSON;
+process.env.HOMEBOY_SETTINGS_JSON = JSON.stringify({
+  wp_codebox_provider: 'settings-fixture-provider',
+  wp_codebox_runtime_env: { SETTINGS_PROVIDER_HOME: '/runtime/settings-provider' },
+  wp_codebox_runtime_state_mounts: [{ source: '/host/settings-state', target: '/runtime/settings-state', mode: 'readonly' }],
+  wp_codebox_runtime_config_mounts: [{ source: '/host/settings-config', target: '/runtime/settings-config', mode: 'readonly' }],
+});
+try {
+  const settingsRuntimeRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'settings-runtime-env-task-123',
+    executor: {
+      backend: 'codebox',
+      config: {},
+    },
+  });
+  assert.equal(settingsRuntimeRequest.provider, 'settings-fixture-provider');
+  assert.deepEqual(settingsRuntimeRequest.runtime_env, { SETTINGS_PROVIDER_HOME: '/runtime/settings-provider' });
+  assert.deepEqual(settingsRuntimeRequest.runtime_state_mounts, [{ source: '/host/settings-state', target: '/runtime/settings-state', mode: 'readonly' }]);
+  assert.deepEqual(settingsRuntimeRequest.runtime_config_mounts, [{ source: '/host/settings-config', target: '/runtime/settings-config', mode: 'readonly' }]);
+} finally {
+  if (previousHomeboySettingsJson === undefined) {
+    delete process.env.HOMEBOY_SETTINGS_JSON;
+  } else {
+    process.env.HOMEBOY_SETTINGS_JSON = previousHomeboySettingsJson;
+  }
+}
+
+assert.equal(fs.readFileSync(path.join(__dirname, '..', 'lib', 'codebox-agent-task-executor.js'), 'utf8').includes('opencode'), false);
 
 const recipePackRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,


### PR DESCRIPTION
## Summary
- Forward generic WP Codebox runtime provider fields (`runtime_env`, `runtime_state_mounts`, and `runtime_config_mounts`) from executor config, options, and `HOMEBOY_SETTINGS_JSON` into task input unchanged.
- Preserve existing provider stack fields while documenting the generic Homeboy-to-WP-Codebox handoff.
- Add smoke coverage proving arbitrary provider runtime config passes through without OpenCode-specific logic.

Fixes #1341

## Tests
- `npm run test:codebox-agent-task-executor`
- `npx eslint lib/codebox-agent-task-executor.js`
- `npx eslint --no-warn-ignored lib/codebox-agent-task-executor.js tests/codebox-agent-task-executor-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the generic passthrough implementation, tests, and documentation updates; Chris remains responsible for review and validation.