### PR TITLE
Fix WP Codebox cache updater npm path

### DIFF
--- a/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
@@ -15,8 +15,13 @@ FAKE_BIN="${WORK_DIR}/bin"
 mkdir -p "$FAKE_BIN"
 
 cat > "${FAKE_BIN}/npm" <<'NPM'
+#!/usr/bin/env node
+NPM
+
+cat > "${FAKE_BIN}/node" <<'NODE'
 #!/usr/bin/env bash
 set -euo pipefail
+shift
 prefix=""
 args=()
 while [ "$#" -gt 0 ]; do
@@ -45,8 +50,8 @@ case "${args[*]}" in
         exit 2
         ;;
 esac
-NPM
-chmod +x "${FAKE_BIN}/npm"
+NODE
+chmod +x "${FAKE_BIN}/npm" "${FAKE_BIN}/node"
 
 git init --bare --quiet "$REMOTE_REPO"
 git clone --quiet "$REMOTE_REPO" "$SOURCE_WORK"
@@ -93,6 +98,17 @@ case "$DRY_RUN_OUTPUT" in
     *)
         echo "Dry-run output did not include target and ref" >&2
         echo "$DRY_RUN_OUTPUT" >&2
+        exit 1
+        ;;
+esac
+
+PATH_WITHOUT_FAKE_BIN="$(printf '%s' "$PATH" | tr ':' '\n' | grep -v -F "$FAKE_BIN" | paste -sd ':' -)"
+OUTPUT="$(PATH="$PATH_WITHOUT_FAKE_BIN" "$SCRIPT" --source "$REMOTE_REPO" --ref fixture-ref --cache-dir "$CACHE_DIR" --npm "${FAKE_BIN}/npm")"
+case "$OUTPUT" in
+    *"WP Codebox cache SHA: ${UPDATED_SHA}"*) ;;
+    *)
+        echo "Expected absolute npm path run to succeed" >&2
+        echo "$OUTPUT" >&2
         exit 1
         ;;
 esac

--- a/wordpress/scripts/build/update-wp-codebox-cache.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache.sh
@@ -104,6 +104,14 @@ fail() {
 command -v git >/dev/null 2>&1 || fail "git is required to update WP Codebox cache"
 command -v "$NPM_BIN" >/dev/null 2>&1 || fail "npm executable not found on runner: $NPM_BIN"
 
+case "$NPM_BIN" in
+    */*)
+        NPM_DIR="$(cd "$(dirname "$NPM_BIN")" && pwd -P)" || fail "failed to resolve npm executable directory: $NPM_BIN"
+        PATH="$NPM_DIR:$PATH"
+        export PATH
+        ;;
+esac
+
 if [ -d "$CACHE_DIR" ] && [ ! -d "$CACHE_DIR/.git" ]; then
     fail "cache dir exists but is not a git checkout: $CACHE_DIR"
 fi


### PR DESCRIPTION
## Summary
- Prepend the provided absolute npm executable directory to `PATH` in the WP Codebox cache updater.
- Cover npm-style `#!/usr/bin/env node` executables in the updater smoke test.

## Why
Lab runner shells may not expose Node/npm on non-interactive SSH PATH. Passing `--npm /absolute/path/npm` found npm, but npm's env-based shebang still could not find sibling `node`.

## Testing
- `bash -n wordpress/scripts/build/update-wp-codebox-cache.sh wordpress/scripts/build/update-wp-codebox-cache-smoke.sh`
- `bash wordpress/scripts/build/update-wp-codebox-cache-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runner cache refresh blocker, drafted the minimal updater fix, and ran focused smoke coverage. Chris remains responsible for review and merge.