### PR TITLE
Expose Codebox runner command tool

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -44,6 +44,7 @@ const DEFAULT_WORKSPACE_WRITE_TOOLS = [
   'workspace_apply_patch',
   'workspace_delete',
   'workspace_git_add',
+  'workspace_run_runner_command',
 ];
 
 const CODEX_SECRET_ENV = [

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -676,6 +676,7 @@ try {
     'workspace_apply_patch',
     'workspace_delete',
     'workspace_git_add',
+    'workspace_run_runner_command',
   ];
   assert.deepEqual(bareOpenAiDefaultedRequest.allowed_tools, writableWorkspaceTools);
   assert.equal(bareOpenAiDefaultedRequest.sandbox_tool_policy.schema, 'wp-codebox/sandbox-tool-policy/v1');


### PR DESCRIPTION
## Summary
- Exposes the existing Data Machine Code `workspace_run_runner_command` tool in read-write WP Codebox sandbox policies.
- Keeps read-only Codebox workspace policies restricted to inspection tools.
- Adds smoke coverage for the writable default policy.

Fixes #1347.

## Verification
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`

## Evidence
- Conductor retry17 reached WP Codebox/OpenCode successfully but could not execute the repo proof command because the sandbox policy lacked a command-running tool.
- Retry17 artifact bundle: `/home/chubes/Developer/.tmp/homeboy-wp-codebox-artifacts-ml7AjV/runtime-mqcm697d-lxdy8s`
- Retry17 task run: `conductor-full-loop-proof-retry17-20260613`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the missing generic sandbox tool from retry evidence, made the minimal policy/test change, and ran targeted smoke tests. Chris remains responsible for review and merge.