### PR TITLE
Prioritize Codebox runner command tool

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -39,12 +39,12 @@ const DEFAULT_WORKSPACE_READONLY_TOOLS = [
 // read-write, so a coding task can actually edit files instead of only
 // inspecting them. These ids are registered by the data-machine-code runtime.
 const DEFAULT_WORKSPACE_WRITE_TOOLS = [
+  'workspace_run_runner_command',
   'workspace_write',
   'workspace_edit',
   'workspace_apply_patch',
   'workspace_delete',
   'workspace_git_add',
-  'workspace_run_runner_command',
 ];
 
 const CODEX_SECRET_ENV = [

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -671,12 +671,12 @@ try {
     'workspace_ls',
     'workspace_read',
     'workspace_git_status',
+    'workspace_run_runner_command',
     'workspace_write',
     'workspace_edit',
     'workspace_apply_patch',
     'workspace_delete',
     'workspace_git_add',
-    'workspace_run_runner_command',
   ];
   assert.deepEqual(bareOpenAiDefaultedRequest.allowed_tools, writableWorkspaceTools);
   assert.equal(bareOpenAiDefaultedRequest.sandbox_tool_policy.schema, 'wp-codebox/sandbox-tool-policy/v1');


### PR DESCRIPTION
## Summary
- Moves `workspace_run_runner_command` ahead of lower-priority writable workspace tools in the default read-write WP Codebox sandbox policy.
- Preserves the existing writable tool set while making proof/verification command execution survive provider/runtime tool-count limits.
- Updates smoke coverage for the expected tool order.

Fixes #1349.

## Verification
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`

## Evidence
- Conductor retry20 showed `workspace_run_runner_command` in policy/input controls, but the model-facing callable tool list contained only the first eight workspace tools and omitted the ninth tool.
- Retry20 task run: `conductor-full-loop-proof-retry20-20260613`
- Retry20 artifact bundle: `/home/chubes/Developer/.tmp/homeboy-wp-codebox-artifacts-3yWKLP/runtime-mqcmoibe-jibxcm`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the retry20 tool materialization evidence, made the minimal ordering change, and ran targeted smoke tests. Chris remains responsible for review and merge.