### PR TITLE
Fix Lab bench artifact link publishing

### DIFF
--- a/managed-preview/README.md
+++ b/managed-preview/README.md
@@ -56,6 +56,13 @@ SSH forward / Traforo / broker session alive. `managed-preview` owns the
 upstream-facing diagnostics contract so browser trace rigs can opt in without
 copying custom environment-variable glue.
 
+Relay-only preview ingress should be treated as disposable routing
+infrastructure. It must not own run state, artifact contents, viewer metadata, or
+cleanup semantics for published evidence. Operators should clean up relay
+processes, forwarding sessions, DNS/route registrations, and temporary access
+rules after the Homeboy-managed service stops, while keeping durable artifacts
+available from the artifact store until that store's retention policy expires.
+
 ## Hostname-Preserving Broker Backend
 
 Use the helper as Homeboy's backend command when a preview broker can create a reviewer-accessible session while preserving the browser-effective origin inside that session:

--- a/nodejs/docs/browser-bench-helpers.md
+++ b/nodejs/docs/browser-bench-helpers.md
@@ -28,6 +28,44 @@ without changing that API. It opens the target page, runs workload actions,
 checks page and artifact assertions, writes a stable raw result artifact, and
 returns `{ metrics, artifacts }` for the Homeboy bench runner.
 
+## Public Artifact Links
+
+Lab review runs can set `HOMEBOY_BENCH_PUBLIC_ARTIFACT_BASE_URL` to the public
+base where Homeboy publishes the run artifact directory. The generic Node.js
+bench runner uses that base to add `url` fields to relative artifact paths and
+absolute paths under `HOMEBOY_BENCH_ARTIFACTS_DIR`. Existing `http`/`https`
+artifact paths are preserved as their public URL.
+
+Workloads can attach opaque viewer metadata to any artifact. The runner keeps
+that metadata as JSON without interpreting product-specific fields:
+
+```js
+return {
+  artifacts: {
+    evidence: {
+      path: 'evidence.json',
+      kind: 'json',
+      label: 'Evidence',
+    },
+    replay: {
+      path: 'viewer-input.json',
+      kind: 'json',
+      label: 'Viewer input',
+      viewer: {
+        kind: 'example-viewer',
+        url: 'https://viewer.example/?artifact=viewer-input.json',
+        metadata: { owned_by: 'consumer' },
+      },
+    },
+  },
+};
+```
+
+Consumers should publish stable review links for at least `report.md`,
+`evidence.json`, and any viewer URLs they expose. Viewer URL construction stays
+consumer-owned; this extension only preserves the metadata and resolves artifact
+URLs from the public base.
+
 Browser profile, artifact, and bottleneck result rows use the shared
 product-neutral shapes documented in `../../docs/browser-result-shapes.md`.
 

--- a/nodejs/scripts/bench/bench-runner.mjs
+++ b/nodejs/scripts/bench/bench-runner.mjs
@@ -11,6 +11,7 @@
 //   HOMEBOY_BENCH_WARMUP_ITERATIONS — discarded warmups per workload (default 1)
 //   HOMEBOY_BENCH_RESULTS_FILE   — where to write the envelope
 //   HOMEBOY_BENCH_LIST_ONLY      — when 1, emit scenario inventory only
+//   HOMEBOY_BENCH_PUBLIC_ARTIFACT_BASE_URL — optional public URL base for artifacts
 //
 // Discovers `bench/**/*.bench.{ts,mjs,js}` under the project root.
 // Each workload file must export a default async function. The function may
@@ -41,7 +42,7 @@
 // bench/parsing.rs::BenchResults shape) to HOMEBOY_BENCH_RESULTS_FILE.
 
 import { mkdir, readdir, writeFile } from 'node:fs/promises';
-import { resolve, relative, basename, delimiter, dirname } from 'node:path';
+import { resolve, relative, basename, delimiter, dirname, isAbsolute } from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { pathToFileURL } from 'node:url';
 
@@ -64,6 +65,10 @@ const ITERATIONS = Math.max(1, Number(process.env.HOMEBOY_BENCH_ITERATIONS) || 1
 const LIST_ONLY = process.env.HOMEBOY_BENCH_LIST_ONLY === '1';
 const WARMUP = LIST_ONLY ? 0 : parseWarmupIterations(process.env.HOMEBOY_BENCH_WARMUP_ITERATIONS);
 const DEBUG = process.env.HOMEBOY_DEBUG === '1';
+const ARTIFACTS_DIR = process.env.HOMEBOY_BENCH_ARTIFACTS_DIR
+    ? resolve(process.env.HOMEBOY_BENCH_ARTIFACTS_DIR)
+    : undefined;
+const PUBLIC_ARTIFACT_BASE_URL = publicArtifactBaseUrl();
 
 const TIMING_METRIC_KEYS = new Set([
     'mean_ms',
@@ -172,14 +177,75 @@ function validateWorkloadArtifacts(artifacts, iterationLabel) {
         if (artifact.label !== undefined && typeof artifact.label !== 'string') {
             throw new Error(`${iterationLabel} returned artifact "${key}" with non-string label`);
         }
+        if (artifact.url !== undefined && typeof artifact.url !== 'string') {
+            throw new Error(`${iterationLabel} returned artifact "${key}" with non-string url`);
+        }
 
         const normalized = { path: artifact.path };
         if (artifact.kind !== undefined) normalized.kind = artifact.kind;
         if (artifact.label !== undefined) normalized.label = artifact.label;
+        for (const [field, value] of Object.entries(artifact)) {
+            if (field === 'path' || field === 'kind' || field === 'label' || field === 'url') {
+                continue;
+            }
+            normalized[field] = validateJsonField(value, `${iterationLabel} returned artifact "${key}" field "${field}"`);
+        }
+        const publicUrl = artifact.url || resolvePublicArtifactUrl(artifact.path);
+        if (publicUrl) normalized.url = publicUrl;
         validated[key] = normalized;
     }
 
     return validated;
+}
+
+function validateJsonField(value, label) {
+    try {
+        return JSON.parse(JSON.stringify(value));
+    } catch (err) {
+        throw new Error(`${label} that is not JSON-serializable: ${err.message}`);
+    }
+}
+
+function publicArtifactBaseUrl() {
+    return (
+        process.env.HOMEBOY_BENCH_PUBLIC_ARTIFACT_BASE_URL
+        || process.env.HOMEBOY_PUBLIC_ARTIFACT_BASE_URL
+        || process.env.HOMEBOY_ARTIFACT_PUBLIC_BASE_URL
+        || ''
+    ).trim();
+}
+
+function resolvePublicArtifactUrl(artifactPath) {
+    if (/^https?:\/\//i.test(artifactPath)) {
+        return artifactPath;
+    }
+    if (!PUBLIC_ARTIFACT_BASE_URL) {
+        return undefined;
+    }
+
+    const relativePath = publicArtifactRelativePath(artifactPath);
+    if (!relativePath) {
+        return undefined;
+    }
+
+    const base = PUBLIC_ARTIFACT_BASE_URL.endsWith('/') ? PUBLIC_ARTIFACT_BASE_URL : `${PUBLIC_ARTIFACT_BASE_URL}/`;
+    return new URL(relativePath.split('/').map(encodeURIComponent).join('/'), base).toString();
+}
+
+function publicArtifactRelativePath(artifactPath) {
+    if (!isAbsolute(artifactPath)) {
+        return artifactPath.replace(/^\.\//, '').replace(/^\/+/, '');
+    }
+    if (!ARTIFACTS_DIR) {
+        return undefined;
+    }
+
+    const resolvedArtifactPath = resolve(artifactPath);
+    const relativePath = relative(ARTIFACTS_DIR, resolvedArtifactPath);
+    if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+        return undefined;
+    }
+    return relativePath.split(/[/\\]+/).join('/');
 }
 
 function aggregateCustomMetrics(iterationMetrics) {

--- a/nodejs/scripts/bench/lib/artifact-context.mjs
+++ b/nodejs/scripts/bench/lib/artifact-context.mjs
@@ -39,6 +39,8 @@ export function createBenchArtifactContext(options = {}) {
             path: file,
             ...(descriptorOptions.kind ? { kind: descriptorOptions.kind } : {}),
             ...(descriptorOptions.label ? { label: descriptorOptions.label } : {}),
+            ...(descriptorOptions.url ? { url: descriptorOptions.url } : {}),
+            ...(descriptorOptions.viewer ? { viewer: descriptorOptions.viewer } : {}),
         };
     }
 

--- a/nodejs/scripts/bench/nodejs-bench-artifact-context-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-bench-artifact-context-smoke.sh
@@ -46,6 +46,15 @@ if (descriptor.kind !== 'json') throw new Error('writeJson descriptor kind missi
 if (descriptor.label !== 'Raw result') throw new Error('writeJson descriptor label missing');
 if (context.artifacts.raw_result.path !== descriptor.path) throw new Error('descriptor not recorded on context');
 
+const viewerDescriptor = context.addArtifact('viewer_input', join(context.artifactDir, 'viewer-input.json'), {
+  kind: 'json',
+  label: 'Viewer input',
+  url: 'https://artifacts.example.test/runs/smoke/viewer-input.json',
+  viewer: { kind: 'opaque-viewer', url: 'https://viewer.example.test/runs/smoke' },
+});
+if (viewerDescriptor.url !== 'https://artifacts.example.test/runs/smoke/viewer-input.json') throw new Error('artifact URL not preserved');
+if (viewerDescriptor.viewer.kind !== 'opaque-viewer') throw new Error('viewer metadata not preserved');
+
 const written = JSON.parse(await readFile(descriptor.path, 'utf8'));
 if (written.elapsed_ms !== null) throw new Error('non-finite number was not normalized');
 if (written.url.includes('abc123')) throw new Error('URL token was not redacted in JSON artifact');

--- a/nodejs/scripts/bench/nodejs-bench-artifacts-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-bench-artifacts-smoke.sh
@@ -32,7 +32,8 @@ EOF
 assert_json() {
     local file="$1"
     local script="$2"
-    node -e "const fs = require('fs'); const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); ${script}" "$file"
+    shift 2
+    node -e "const fs = require('fs'); const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); ${script}" "$file" "$@"
 }
 
 make_project() {
@@ -46,11 +47,14 @@ make_project() {
 run_runner() {
     local project_dir="$1"
     local results_file="$2"
+    local artifacts_dir="${3:-}"
     HOMEBOY_RUNTIME_BENCH_HELPER_JS="$HELPER_JS" \
     HOMEBOY_COMPONENT_PATH="$project_dir" \
     HOMEBOY_COMPONENT_ID="node-bench-artifacts-smoke" \
     HOMEBOY_BENCH_ITERATIONS="1" \
     HOMEBOY_BENCH_WARMUP_ITERATIONS="0" \
+    HOMEBOY_BENCH_ARTIFACTS_DIR="$artifacts_dir" \
+    HOMEBOY_BENCH_PUBLIC_ARTIFACT_BASE_URL="${HOMEBOY_BENCH_PUBLIC_ARTIFACT_BASE_URL:-}" \
     HOMEBOY_BENCH_RESULTS_FILE="$results_file" \
         node "$SCRIPT_DIR/bench-runner.mjs"
 }
@@ -71,30 +75,49 @@ if (Object.prototype.hasOwnProperty.call(scenario, "artifacts")) throw new Error
 '
 
 ARTIFACT_PROJECT="$(make_project artifacts)"
+ARTIFACTS_DIR="$TMP_DIR/published-artifacts"
+mkdir -p "$ARTIFACTS_DIR"
 cat > "$ARTIFACT_PROJECT/bench/artifacts.bench.mjs" <<'EOF'
 export default async function () {
+  const artifactsDir = process.env.HOMEBOY_BENCH_ARTIFACTS_DIR;
   return {
     metrics: { success_rate: 1 },
     artifacts: {
-      raw_result: { path: '/tmp/result.json', kind: 'json', label: 'Raw result' },
+      raw_result: {
+        path: `${artifactsDir}/result.json`,
+        kind: 'json',
+        label: 'Raw result',
+        viewer: {
+          kind: 'opaque-review-viewer',
+          url: 'https://viewer.example.test/runs/fixture',
+          nested: { preserved: true },
+        },
+      },
       site_path: { path: '/tmp/site', kind: 'directory', label: 'Generated site' },
       bare_path: '/tmp/bare.txt',
+      relative_evidence: { path: 'evidence.json', kind: 'json', label: 'Evidence' },
     },
   };
 }
 EOF
 
 ARTIFACT_RESULTS="$TMP_DIR/artifact-results.json"
-run_runner "$ARTIFACT_PROJECT" "$ARTIFACT_RESULTS" >/dev/null
+HOMEBOY_BENCH_PUBLIC_ARTIFACT_BASE_URL="https://artifacts.example.test/runs/run-123" \
+run_runner "$ARTIFACT_PROJECT" "$ARTIFACT_RESULTS" "$ARTIFACTS_DIR" >/dev/null
 assert_json "$ARTIFACT_RESULTS" '
 const artifacts = data.scenarios[0].artifacts;
 if (!artifacts) throw new Error("scenario artifacts missing");
-if (artifacts.raw_result.path !== "/tmp/result.json") throw new Error("raw_result path missing");
+if (artifacts.raw_result.path !== process.argv[2] + "/result.json") throw new Error("raw_result path missing");
 if (artifacts.raw_result.kind !== "json") throw new Error("raw_result kind missing");
 if (artifacts.raw_result.label !== "Raw result") throw new Error("raw_result label missing");
+if (artifacts.raw_result.url !== "https://artifacts.example.test/runs/run-123/result.json") throw new Error("raw_result public URL missing");
+if (artifacts.raw_result.viewer.kind !== "opaque-review-viewer") throw new Error("viewer kind missing");
+if (artifacts.raw_result.viewer.url !== "https://viewer.example.test/runs/fixture") throw new Error("viewer URL missing");
+if (artifacts.raw_result.viewer.nested.preserved !== true) throw new Error("viewer metadata was not preserved");
 if (artifacts.site_path.kind !== "directory") throw new Error("site_path kind missing");
 if (artifacts.bare_path.path !== "/tmp/bare.txt") throw new Error("bare path was not normalized");
-'
+if (artifacts.relative_evidence.url !== "https://artifacts.example.test/runs/run-123/evidence.json") throw new Error("relative evidence public URL missing");
+' "$ARTIFACTS_DIR"
 
 INVALID_PROJECT="$(make_project invalid-artifact)"
 cat > "$INVALID_PROJECT/bench/invalid.bench.mjs" <<'EOF'


### PR DESCRIPTION
## Summary
- Accept `HOMEBOY_BENCH_PUBLIC_ARTIFACT_BASE_URL` in the generic Node.js bench runner and publish stable artifact `url` fields for relative artifacts or files under `HOMEBOY_BENCH_ARTIFACTS_DIR`.
- Preserve opaque artifact metadata such as `viewer` without adding WordPress, WP Codebox, or Studio Web-specific behavior.
- Document Lab review link expectations and relay-only preview ingress cleanup boundaries.

Fixes #1353.

## Verification
- `nodejs/scripts/bench/nodejs-bench-artifacts-smoke.sh`
- `nodejs/scripts/bench/nodejs-bench-artifact-context-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic runner/docs/test changes; Chris requested the issue implementation and PR.