### PR TITLE
Default provider for runtime bundle tasks

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -184,11 +184,16 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const recipe = recipeConfigFromAgentTaskRequest(request, config, inputs);
   const mounts = agentBundleMounts(agentBundle, config.mounts || defaults.mounts || options.mounts || []);
   const components = runtimeComponentPaths(config, { ...defaults, ...options });
-  const runtimeTask = inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(config, inputs) || options.runtimeTask;
   const agentBundles = firstDefined(inputs.agent_bundles, inputs.agentBundles, config.agent_bundles, config.agentBundles, options.agentBundles, []);
   const structuredArtifacts = firstDefined(inputs.structured_artifacts, inputs.structuredArtifacts, config.structured_artifacts, config.structuredArtifacts, options.structuredArtifacts, []);
   const sandboxToolPolicy = firstDefined(inputs.sandbox_tool_policy, inputs.sandboxToolPolicy, config.sandbox_tool_policy, config.sandboxToolPolicy, options.sandboxToolPolicy, defaults.sandboxToolPolicy);
   const allowedTools = firstDefined(inputs.allowed_tools, inputs.allowedTools, config.allowed_tools, config.allowedTools, options.allowedTools, defaults.allowedTools);
+  const provider = config.provider || options.provider || defaults.provider || '';
+  const model = request.executor.model || config.model || options.model || defaults.model || '';
+  const runtimeTask = runtimeTaskWithExecutionDefaults(
+    inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(config, inputs) || options.runtimeTask,
+    { provider, model, agentBundles }
+  );
   const explicitSecretEnv = [
     ...normalizeArray(request.executor?.secret_env),
     ...normalizeArray(config.secret_env),
@@ -223,8 +228,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     session_id: config.session_id || config.sessionId || '',
     agent: config.agent || options.agent || 'wp-codebox-sandbox',
     mode: config.mode || options.mode || 'sandbox',
-    provider: config.provider || options.provider || defaults.provider || '',
-    model: request.executor.model || config.model || options.model || defaults.model || '',
+    provider,
+    model,
     provider_plugin_paths: config.provider_plugin_paths || options.providerPluginPaths || defaults.providerPluginPaths || [],
     agent_bundles: agentBundles,
     runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
@@ -270,6 +275,35 @@ function abilityRuntimeTaskFromAgentTaskRequest(config, inputs) {
   }
   const input = firstObject(inputs.ability_input, inputs.abilityInput, inputs.input, config.ability_input, config.abilityInput, config.input) || {};
   return { ability, input };
+}
+
+function runtimeTaskWithExecutionDefaults(runtimeTask, defaults = {}) {
+  if (!runtimeTask || typeof runtimeTask !== 'object' || Array.isArray(runtimeTask)) {
+    return runtimeTask;
+  }
+  if (!Array.isArray(defaults.agentBundles) || defaults.agentBundles.length === 0) {
+    return runtimeTask;
+  }
+
+  const input = runtimeTask.input && typeof runtimeTask.input === 'object' && !Array.isArray(runtimeTask.input)
+    ? runtimeTask.input
+    : {};
+  const defaultInput = Object.fromEntries(Object.entries({
+    provider: defaults.provider,
+    model: defaults.model,
+  }).filter(([, value]) => value !== '' && value !== undefined));
+
+  if (Object.keys(defaultInput).length === 0) {
+    return runtimeTask;
+  }
+
+  return {
+    ...runtimeTask,
+    input: {
+      ...defaultInput,
+      ...input,
+    },
+  };
 }
 
 function runtimeComponentPaths(config, options = {}) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -375,6 +375,48 @@ assert.deepEqual(runtimeTaskRequest.agent_bundles, [{ source: '/workspace/bundle
 assert.equal(runtimeTaskRequest.structured_artifacts[0].name, 'concept_packet');
 assert.equal(runtimeTaskRequest.workspaces[0].target, '/workspace/codebox-canary');
 
+const runtimeTaskProviderDefaultRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'runtime-task-provider-defaults-123',
+  executor: {
+    backend: 'codebox',
+    model: 'openai/gpt-5.5',
+    config: {
+      provider: 'opencode',
+      agent_bundles: [{ source: '/workspace/bundles/canary-agent', slug: 'canary-agent' }],
+    },
+  },
+  inputs: {
+    runtime_task: {
+      ability: 'runtime/run-agent-bundle',
+      input: { source: '/workspace/bundles/canary-agent' },
+    },
+  },
+});
+assert.equal(runtimeTaskProviderDefaultRequest.runtime_task.input.provider, 'opencode', 'agent bundle runtime tasks inherit the selected provider');
+assert.equal(runtimeTaskProviderDefaultRequest.runtime_task.input.model, 'openai/gpt-5.5', 'agent bundle runtime tasks inherit the selected model');
+
+const runtimeTaskExplicitProviderRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'runtime-task-explicit-provider-123',
+  executor: {
+    backend: 'codebox',
+    model: 'openai/gpt-5.5',
+    config: {
+      provider: 'opencode',
+      agent_bundles: [{ source: '/workspace/bundles/canary-agent', slug: 'canary-agent' }],
+    },
+  },
+  inputs: {
+    runtime_task: {
+      ability: 'runtime/run-agent-bundle',
+      input: { source: '/workspace/bundles/canary-agent', provider: 'explicit-provider', model: 'explicit-model' },
+    },
+  },
+});
+assert.equal(runtimeTaskExplicitProviderRequest.runtime_task.input.provider, 'explicit-provider', 'explicit runtime task provider wins');
+assert.equal(runtimeTaskExplicitProviderRequest.runtime_task.input.model, 'explicit-model', 'explicit runtime task model wins');
+
 const abilityBridgeRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
   task_id: 'ability-bridge-task-123',


### PR DESCRIPTION
## Summary
- Propagate the resolved Codebox provider/model into explicit runtime tasks when the task also declares runtime agent bundles.
- Preserve explicit `runtime_task.input.provider` and `runtime_task.input.model` overrides.
- Leave non-bundle runtime ability tasks unchanged so generic ability inputs are not polluted.

## Testing
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosing provider/model default propagation, drafting the generic executor change, adding smoke coverage, and running validation. Chris identified the required `opencode` provider with `openai/gpt-5.5` model routing.