### PR TITLE
Publish WordPress bench review summaries

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -303,6 +303,18 @@ The generated recipe is the single WP Codebox entry point for benchmarks:
 `wp_codebox_blueprint` becomes `runtime.blueprint`, dependencies become recipe
 plugin inputs, and scenario manifests compile into configured workloads.
 
+Each run also emits `${HOMEBOY_BENCH_RESULTS_ARTIFACT_DIR}/bench-summary.json`
+when result artifacts are enabled. The summary is the canonical reviewer
+entry point: it records pass/fail score, replayability status, dependency
+provenance, core artifact paths, and any caller-provided next-step commands.
+Dependency inputs are also captured in `bench-dependency-provenance.json` so
+reviewers can see which WP Codebox plugin inputs, mounts, and declared
+dependency paths shaped the run.
+
+`bench_env` must be a JSON object and is the extension-level setting forwarded
+into the WP Codebox runtime. Unknown caller/orchestrator settings remain opaque;
+the runner only validates the shape of settings it consumes directly.
+
 The browser bench target is a two-extension handoff: the WordPress
 extension prepares/describes the WordPress target by writing
 `${HOMEBOY_BENCH_SHARED_STATE}/browser-target.json`; a Node-side browser

--- a/wordpress/scripts/bench/bench-results-artifacts-smoke.sh
+++ b/wordpress/scripts/bench/bench-results-artifacts-smoke.sh
@@ -29,6 +29,13 @@ cat > "$RESULTS_FILE" <<'JSON'
 {
   "component_id": "wp-rl-fixture",
   "iterations": 1,
+  "prepared_dependencies": [
+    {
+      "slug": "wp-codebox-fixture",
+      "source": "/tmp/wp-codebox-fixture",
+      "state": "prepared"
+    }
+  ],
   "scenarios": [
     {
       "id": "__bootstrap",
@@ -79,7 +86,8 @@ cat > "$RESULTS_FILE" <<'JSON'
               "value": { "source": "public-artifact-url" },
               "encoding": "url"
             }
-          }
+          },
+          "status": "partial"
         },
         "runtime_url": { "path": "https://example.test", "kind": "url" }
       }
@@ -128,6 +136,7 @@ homeboy_wordpress_emit_bench_results_artifacts "$RESULTS_FILE"
 JSONL_FILE="${TMP_ROOT}/results.jsonl"
 LEADERBOARD_FILE="${TMP_ROOT}/leaderboard.md"
 SERIES_FILE="${TMP_ROOT}/series.json"
+SUMMARY_FILE="${TMP_ROOT}/bench-summary.json"
 WEBPERF_SUMMARY_JSON_FILE="${TMP_ROOT}/webperf-evidence-summary.json"
 WEBPERF_SUMMARY_MARKDOWN_FILE="${TMP_ROOT}/webperf-evidence-summary.md"
 PUBLIC_ROOT="${TMP_ROOT}/public"
@@ -143,6 +152,10 @@ if [ ! -s "$LEADERBOARD_FILE" ]; then
 fi
 if [ ! -s "$SERIES_FILE" ]; then
     echo "ERROR: missing series.json artifact" >&2
+    exit 1
+fi
+if [ ! -s "$SUMMARY_FILE" ]; then
+    echo "ERROR: missing bench-summary.json artifact" >&2
     exit 1
 fi
 if [ ! -s "$WEBPERF_SUMMARY_JSON_FILE" ] || [ ! -s "$WEBPERF_SUMMARY_MARKDOWN_FILE" ]; then
@@ -199,6 +212,20 @@ artifact_path=$(jq -r '.series[] | select(.scenario_id == "block-markup/query-00
 if [ "$series_schema" != "homeboy/wordpress-bench-step-series/v1" ] || [ "$series_count" -ne 2 ] || [ "$request_success" != "true" ] || [ "$option_failure" != "transient grew past budget" ] || [ "$artifact_path" != "artifacts/query-series.json" ]; then
     echo "ERROR: series.json did not preserve normalized step-series rows and artifact refs" >&2
     cat "$SERIES_FILE" >&2
+    exit 1
+fi
+
+summary_schema=$(jq -r '.schema' "$SUMMARY_FILE")
+summary_verdict=$(jq -r '.verdict' "$SUMMARY_FILE")
+summary_rate=$(jq -r '.score.rate' "$SUMMARY_FILE")
+summary_replay_status=$(jq -r '.replayability.status' "$SUMMARY_FILE")
+summary_replay_artifact=$(jq -r '.replayability.artifacts[] | select(.name == "blueprint.after") | .path' "$SUMMARY_FILE")
+summary_dependency_slug=$(jq -r '.dependencies.prepared[0].slug' "$SUMMARY_FILE")
+summary_artifact_command=$(jq -r '.next_steps.artifact_fetch_command' "$SUMMARY_FILE")
+
+if [ "$summary_schema" != "homeboy/wordpress-bench-summary/v1" ] || [ "$summary_verdict" != "fail" ] || [ "$summary_rate" != "0.5" ] || [ "$summary_replay_status" != "partial" ] || [ "$summary_replay_artifact" != "artifacts/blueprint.after.json" ] || [ "$summary_dependency_slug" != "wp-codebox-fixture" ] || [ "$summary_artifact_command" != "null" ]; then
+    echo "ERROR: bench-summary.json did not capture canonical result state" >&2
+    cat "$SUMMARY_FILE" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/bench/bench-results-artifacts.sh
+++ b/wordpress/scripts/bench/bench-results-artifacts.sh
@@ -147,12 +147,118 @@ homeboy_wordpress_bench_step_series_filter() {
         '
 }
 
+homeboy_wordpress_bench_summary_filter() {
+	local artifact_dir="$1"
+	local jsonl_file="$2"
+	local leaderboard_file="$3"
+	local series_file="$4"
+	local dependency_provenance_file="$5"
+
+	jq \
+		--arg schema "homeboy/wordpress-bench-summary/v1" \
+		--arg artifactDir "$artifact_dir" \
+		--arg jsonlFile "$jsonl_file" \
+		--arg leaderboardFile "$leaderboard_file" \
+		--arg seriesFile "$series_file" \
+		--arg dependencyProvenanceFile "$dependency_provenance_file" \
+		--arg runId "${HOMEBOY_BENCH_RUN_ID:-${HOMEBOY_RUN_ID:-${HOMEBOY_BENCH_INSTANCE_ID:-}}}" \
+		--arg artifactsCommand "${HOMEBOY_BENCH_ARTIFACTS_COMMAND:-}" \
+		--arg rerunCommand "${HOMEBOY_BENCH_RERUN_COMMAND:-}" \
+		--arg dependencyRefreshCommand "${HOMEBOY_BENCH_DEPENDENCY_REFRESH_COMMAND:-}" \
+		'
+		def scenarios: (.scenarios // []) | map(select((.id // null) != "__bootstrap"));
+		def artifact_entries($scenario):
+			($scenario.artifacts // {})
+			| if type == "object" then to_entries else [] end
+			| map(. + {scenario_id: ($scenario.id // null)});
+		def artifact_path($artifact): ($artifact.path // $artifact.url // null);
+		def replay_status_from($value):
+			if ($value | type) == "object" then
+				$value.status // $value.replayability.status // $value.metadata.replayability.status // null
+			else null end;
+		def replay_artifact($entry):
+			($entry.value // {}) as $artifact
+			| select(
+				(($entry.key | tostring) | test("replay|blueprint\\.after|after-notes"; "i"))
+				or ((artifact_path($artifact) // "") | test("replay|blueprint\\.after|after-notes"; "i"))
+			)
+			| {
+				scenario_id: $entry.scenario_id,
+				name: ($entry.key | tostring),
+				kind: ($artifact.kind // null),
+				label: ($artifact.label // null),
+				path: ($artifact.path // null),
+				url: ($artifact.url // null),
+				viewer: ($artifact.viewer // null),
+				status: replay_status_from($artifact)
+			};
+		. as $root
+		| (scenarios) as $scenarios
+		| ($scenarios | length) as $total
+		| ($scenarios | map(select(
+			(.success == true)
+			or ((.metrics.success_mean? // null) == 1)
+			or ((.metrics.pass_mean? // null) == 1)
+		)) | length) as $passed
+		| ($scenarios | map(select(
+			(.success == false)
+			or (.error != null)
+			or (.failure != null)
+			or ((.metrics.success_mean? // null) == 0)
+			or ((.metrics.pass_mean? // null) == 0)
+		)) | length) as $failed
+		| ([$scenarios[] | artifact_entries(.)[] | replay_artifact(.)]) as $replayArtifacts
+		| ($replayArtifacts | map(.status) | map(select(. != null))) as $replayStatuses
+		| {
+			schema: $schema,
+			component_id: ($root.component_id // null),
+			run_id: (if $runId == "" then null else $runId end),
+			verdict: (if $failed > 0 then "fail" elif $total > 0 and $passed == $total then "pass" else "partial" end),
+			score: {
+				passed: $passed,
+				failed: $failed,
+				total: $total,
+				rate: (if $total == 0 then null else $passed / $total end)
+			},
+			replayability: {
+				status: (
+					$root.replayability.status
+					// (if ($replayStatuses | length) > 0 then
+						if any($replayStatuses[]; test("partial|incomplete|missing|fail"; "i")) then "partial"
+						elif any($replayStatuses[]; test("ready|pass|complete"; "i")) then "ready"
+						else "reported" end
+					elif ($replayArtifacts | length) > 0 then "artifact_available"
+					else "not_reported" end)
+				),
+				artifacts: $replayArtifacts
+			},
+			dependencies: {
+				prepared: ($root.prepared_dependencies // []),
+				build_failures: ($root.dependency_build_failures // []),
+				provenance_artifact: (if $dependencyProvenanceFile == "" then null else $dependencyProvenanceFile end)
+			},
+			artifacts: {
+				directory: $artifactDir,
+				results_jsonl: $jsonlFile,
+				leaderboard_markdown: $leaderboardFile,
+				step_series_json: $seriesFile
+			},
+			next_steps: {
+				artifact_fetch_command: (if $artifactsCommand != "" then $artifactsCommand elif $runId != "" then "homeboy runs artifacts " + $runId else null end),
+				rerun_command: (if $rerunCommand == "" then null else $rerunCommand end),
+				dependency_refresh_command: (if $dependencyRefreshCommand == "" then null else $dependencyRefreshCommand end)
+			}
+		}
+		'
+}
+
 homeboy_wordpress_emit_bench_results_artifacts() {
 	local bench_results_file="$1"
 	local artifact_dir
 	local jsonl_file
 	local leaderboard_file
 	local series_file
+	local summary_file
 	local baseline_results_file
 	local codebox_memory_report_file
 	local codebox_thresholds_json
@@ -160,6 +266,8 @@ homeboy_wordpress_emit_bench_results_artifacts() {
 	local webperf_summary_markdown_file
 	local webperf_summary_metrics_json
 	local webperf_summary_scenarios_json
+	local dependency_provenance_file
+	local dependency_provenance_reference
 
     if [ -z "$bench_results_file" ] || [ ! -s "$bench_results_file" ]; then
         return 0
@@ -171,6 +279,10 @@ homeboy_wordpress_emit_bench_results_artifacts() {
 	jsonl_file="${artifact_dir}/results.jsonl"
 	leaderboard_file="${artifact_dir}/leaderboard.md"
 	series_file="${artifact_dir}/series.json"
+	summary_file="${artifact_dir}/bench-summary.json"
+	dependency_provenance_file="${artifact_dir}/bench-dependency-provenance.json"
+	dependency_provenance_reference=""
+	[ -s "$dependency_provenance_file" ] && dependency_provenance_reference="$dependency_provenance_file"
 	codebox_memory_report_file="${artifact_dir}/codebox-browser-memory-comparison.md"
 	webperf_summary_json_file="${artifact_dir}/webperf-evidence-summary.json"
 	webperf_summary_markdown_file="${artifact_dir}/webperf-evidence-summary.md"
@@ -187,6 +299,11 @@ homeboy_wordpress_emit_bench_results_artifacts() {
 
 	if ! homeboy_wordpress_bench_step_series_filter < "$bench_results_file" > "$series_file"; then
 		echo "ERROR: failed to emit bench step-series artifact at $series_file" >&2
+		return 1
+	fi
+
+	if ! homeboy_wordpress_bench_summary_filter "$artifact_dir" "$jsonl_file" "$leaderboard_file" "$series_file" "$dependency_provenance_reference" < "$bench_results_file" > "$summary_file"; then
+		echo "ERROR: failed to emit bench summary artifact at $summary_file" >&2
 		return 1
 	fi
 
@@ -220,6 +337,7 @@ homeboy_wordpress_emit_bench_results_artifacts() {
 		echo "DEBUG: [bench] Results JSONL: $jsonl_file"
 		echo "DEBUG: [bench] Leaderboard: $leaderboard_file"
 		echo "DEBUG: [bench] Step series: $series_file"
+		echo "DEBUG: [bench] Summary: $summary_file"
 		[ -s "$codebox_memory_report_file" ] && echo "DEBUG: [bench] Codebox browser memory comparison: $codebox_memory_report_file"
 		[ -s "$webperf_summary_json_file" ] && echo "DEBUG: [bench] Webperf evidence summary: $webperf_summary_json_file"
 	fi

--- a/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
@@ -185,7 +185,7 @@ HOMEBOY_BENCH_ITERATIONS=1 \
 HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
 bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
 
-jq -e --arg sourceRoot "$SOURCE_ROOT" '
+if ! jq -e --arg sourceRoot "$SOURCE_ROOT" '
     .recipe.inputs.extraPlugins == []
     and (.recipe.inputs.mounts[] | select(.source == $sourceRoot and .target == "/wordpress/wp-content/plugins/wp-site-generator" and .mode == "readonly"))
     and (.recipe.inputs.mounts[] | select(.source | endswith("/rig-workloads/rig-workload.php")) | .target == "/wordpress/wp-content/plugins/wp-site-generator/.homeboy/bench-rig/rig-workload.php")
@@ -195,7 +195,11 @@ jq -e --arg sourceRoot "$SOURCE_ROOT" '
     and (.recipe.workflow.steps[0].args[] | select(startswith("bootstrap-files-json=") and contains("bootstrap.php")))
     and (.recipe.workflow.steps[0].args[] | select(startswith("workloads-json=") and contains("static-site-importer import-theme")))
     and (.recipe.workflow.steps[0].args[] | select(startswith("workloads-json=") and contains("manifest-navigation") and contains("scenario-manifest")))
-' "$CAPTURE_FILE" >/dev/null
+' "$CAPTURE_FILE" >/dev/null; then
+    echo "ERROR: generated WP Codebox recipe did not include expected static-source bench inputs" >&2
+    cat "$CAPTURE_FILE" >&2
+    exit 1
+fi
 
 SELECTED_CAPTURE_FILE="${TMP_ROOT}/selected-extra-workload-capture.json"
 HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \
@@ -394,5 +398,41 @@ jq -e --arg pluginRoot "$PLUGIN_ROOT" --arg dependencyRoot "${DEPENDENCY_ROOT}/p
         {source: $dependencyRoot, slug: "wp-codebox", pluginFile: "wp-codebox/wp-codebox.php", activate: false}
     ]
 ' "$DEPENDENCY_CAPTURE_FILE" >/dev/null
+
+DEPENDENCY_PROVENANCE_FILE="${TMP_ROOT}/dependency-artifacts/bench-dependency-provenance.json"
+if [ ! -s "$DEPENDENCY_PROVENANCE_FILE" ]; then
+    echo "ERROR: missing bench dependency provenance artifact" >&2
+    exit 1
+fi
+jq -e --arg dependencyRoot "${DEPENDENCY_ROOT}/packages/wordpress-plugin" '
+    .schema == "homeboy/wordpress-bench-dependency-provenance/v1"
+    and (.dependency_slugs == ["wp-codebox"])
+    and (.plugin_inputs[] | select(.source == $dependencyRoot and .slug == "wp-codebox" and .pluginFile == "wp-codebox/wp-codebox.php"))
+    and (.settings.has_bench_env == true)
+' "$DEPENDENCY_PROVENANCE_FILE" >/dev/null
+
+INVALID_SETTINGS_OUTPUT="${TMP_ROOT}/invalid-settings-output.txt"
+INVALID_SETTINGS_JSON=$(jq -nc '{bench_env: ["HOMEBOY_FIXTURE_ENV=yes"]}')
+set +e
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \
+HOMEBOY_RUNTIME_BENCH_HELPER_SH="$BENCH_HELPER" \
+HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
+HOMEBOY_SMOKE_SOURCE_ROOT="$PLUGIN_ROOT" \
+HOMEBOY_SETTINGS_JSON="$INVALID_SETTINGS_JSON" \
+HOMEBOY_WP_CODEBOX_BIN="$WP_CODEBOX_BIN" \
+HOMEBOY_WP_CODEBOX_CORE_MODULE="$WP_CODEBOX_CORE_MODULE" \
+HOMEBOY_BENCH_RESULTS_FILE="${TMP_ROOT}/invalid-settings-results.json" \
+HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR="${TMP_ROOT}/invalid-settings-artifacts" \
+HOMEBOY_RUNTIME_FAILURE_TRAP="" \
+HOMEBOY_BENCH_ITERATIONS=1 \
+HOMEBOY_BENCH_WARMUP_ITERATIONS=0 \
+bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >"$INVALID_SETTINGS_OUTPUT" 2>&1
+invalid_settings_status=$?
+set -e
+if [ "$invalid_settings_status" -eq 0 ] || ! grep -q 'bench_env must be a JSON object' "$INVALID_SETTINGS_OUTPUT"; then
+    echo "ERROR: invalid bench_env settings shape was not rejected with an actionable error" >&2
+    cat "$INVALID_SETTINGS_OUTPUT" >&2
+    exit 1
+fi
 
 echo "WP Codebox static-source bench smoke passed"

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -61,6 +61,45 @@ WP_CODEBOX_BIN="$(homeboy_wp_codebox_resolve_bin "${HOMEBOY_SETTINGS_JSON:-}")" 
 settings_json="${HOMEBOY_SETTINGS_JSON:-}"
 [ -n "$settings_json" ] || settings_json="{}"
 
+homeboy_wp_codebox_validate_bench_settings() {
+    local invalid_type
+
+    if ! printf '%s' "$settings_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        echo "Error: HOMEBOY_SETTINGS_JSON for wordpress.bench must be a JSON object." >&2
+        FAILED_STEP="WP Codebox bench settings validation"
+        exit 1
+    fi
+
+    invalid_type=$(jq -nr --argjson settings "$settings_json" '
+        [
+            ["bench_env", "object"],
+            ["wp_config_defines", "object"],
+            ["wp_codebox_blueprint", "object"],
+            ["playground_blueprint", "object"],
+            ["wp_codebox_workloads", "array"],
+            ["playground_workloads", "array"],
+            ["wp_codebox_file_mounts", "array"],
+            ["playground_file_mounts", "array"],
+            ["wp_codebox_extra_plugins", "array"],
+            ["validation_dependencies", "array"],
+            ["wp_codebox_prepare_steps", "array"],
+            ["wp_codebox_bootstrap_steps", "array"],
+            ["wp_codebox_scenario_manifests", "array"],
+            ["scenario_manifests", "array"]
+        ]
+        | map(select(($settings[.[0]] // null) != null and (($settings[.[0]] | type) != .[1])))
+        | first
+        | if . == null then "" else .[0] + " must be a JSON " + .[1] end
+    ' 2>/dev/null || true)
+    if [ -n "$invalid_type" ]; then
+        echo "Error: $invalid_type." >&2
+        FAILED_STEP="WP Codebox bench settings validation"
+        exit 1
+    fi
+}
+
+homeboy_wp_codebox_validate_bench_settings
+
 WP_CODEBOX_CORE_MODULE="${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}"
 if [ -z "$WP_CODEBOX_CORE_MODULE" ] && [ "$settings_json" != "{}" ]; then
     WP_CODEBOX_CORE_MODULE=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_core_module // empty' 2>/dev/null || true)
@@ -1068,7 +1107,45 @@ homeboy_wp_codebox_emit_memory_fatal_diagnostic() {
     echo "  Raw output: $output_artifact" >&2
 }
 
+homeboy_wp_codebox_emit_dependency_provenance() {
+    local provenance_file="${ARTIFACTS_DIR%/}/bench-dependency-provenance.json"
+    local declared_dependency_paths_json
+
+    declared_dependency_paths_json=$(printf '%s\n' "$DEPENDENCY_PATHS" | jq -R -s 'split("\n") | map(select(. != ""))')
+
+    jq -n \
+        --arg schema "homeboy/wordpress-bench-dependency-provenance/v1" \
+        --arg component "$COMPONENT_ID" \
+        --arg pluginSlug "$PLUGIN_SLUG" \
+        --arg wpCodeboxBin "$WP_CODEBOX_RESOLVED_BIN" \
+        --arg artifactsDir "$ARTIFACTS_DIR" \
+        --argjson declaredDependencyPaths "$declared_dependency_paths_json" \
+        --argjson dependencySlugs "$(printf '%s\n' "$DEPENDENCY_SLUGS_CSV" | jq -R 'split(",") | map(select(. != ""))')" \
+        --argjson extraPlugins "$EXTRA_PLUGINS_JSON" \
+        --argjson mounts "$MOUNTS_JSON" \
+        --argjson settings "$settings_json" \
+        '{
+            schema: $schema,
+            component_id: $component,
+            plugin_slug: $pluginSlug,
+            wp_codebox_bin: $wpCodeboxBin,
+            artifacts_dir: $artifactsDir,
+            dependency_slugs: $dependencySlugs,
+            declared_dependency_paths: $declaredDependencyPaths,
+            plugin_inputs: ($extraPlugins | map({slug, pluginFile, source, activate})),
+            mounts: ($mounts | map({target, mode, source})),
+            settings: {
+                keys: ($settings | keys | sort),
+                has_bench_env: (($settings.bench_env // null) != null),
+                has_wp_config_defines: (($settings.wp_config_defines // null) != null),
+                has_configured_workloads: ((($settings.wp_codebox_workloads // $settings.playground_workloads // []) | length) > 0),
+                has_scenario_manifests: ((($settings.wp_codebox_scenario_manifests // $settings.scenario_manifests // []) | length) > 0)
+            }
+        }' > "$provenance_file"
+}
+
 RECIPE_FILE=$(mktemp "${ARTIFACTS_DIR}/homeboy-wp-codebox-bench-recipe.XXXXXX")
+homeboy_wp_codebox_emit_dependency_provenance
 jq -n \
     --arg wpCodeboxBin "$WP_CODEBOX_RESOLVED_BIN" \
     --arg wp "$WP_CODEBOX_WORDPRESS_VERSION" \


### PR DESCRIPTION
## Summary
- Emit a canonical `bench-summary.json` artifact with verdict, score, replayability status, dependency metadata, artifact paths, and caller-provided next-step commands.
- Validate only the WordPress bench settings consumed by this extension, leaving unknown caller/orchestrator settings opaque.
- Publish generic WP Codebox dependency provenance for bench recipe inputs and cover the contract in focused smokes.

Fixes #1358.

## Verification
- `bash wordpress/scripts/bench/bench-results-artifacts-smoke.sh`
- `bash wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- `node wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic bench summary/provenance contract, diagnosed and split the upstream smoke fixture blocker into #1359/#1360, and ran focused verification; Chris directed the layering constraints and reviewed the cross-layer boundary.