### PR TITLE
Fix WordPress bench dependency provenance schema

### DIFF
--- a/wordpress/scripts/bench/bench-results-artifacts-smoke.sh
+++ b/wordpress/scripts/bench/bench-results-artifacts-smoke.sh
@@ -29,13 +29,15 @@ cat > "$RESULTS_FILE" <<'JSON'
 {
   "component_id": "wp-rl-fixture",
   "iterations": 1,
-  "prepared_dependencies": [
-    {
-      "slug": "wp-codebox-fixture",
-      "source": "/tmp/wp-codebox-fixture",
-      "state": "prepared"
-    }
-  ],
+  "metadata": {
+    "prepared_dependencies": [
+      {
+        "slug": "wp-codebox-fixture",
+        "source": "/tmp/wp-codebox-fixture",
+        "state": "prepared"
+      }
+    ]
+  },
   "scenarios": [
     {
       "id": "__bootstrap",

--- a/wordpress/scripts/bench/bench-results-artifacts.sh
+++ b/wordpress/scripts/bench/bench-results-artifacts.sh
@@ -233,8 +233,8 @@ homeboy_wordpress_bench_summary_filter() {
 				artifacts: $replayArtifacts
 			},
 			dependencies: {
-				prepared: ($root.prepared_dependencies // []),
-				build_failures: ($root.dependency_build_failures // []),
+				prepared: ($root.metadata.prepared_dependencies // $root.prepared_dependencies // []),
+				build_failures: ($root.metadata.dependency_build_failures // $root.dependency_build_failures // []),
 				provenance_artifact: (if $dependencyProvenanceFile == "" then null else $dependencyProvenanceFile end)
 			},
 			artifacts: {

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -1218,7 +1218,7 @@ PREPARED_DEPENDENCIES_METADATA_FILE="${ARTIFACTS_DIR%/}/prepared-bench-dependenc
 if [ -f "$PREPARED_DEPENDENCIES_METADATA_FILE" ]; then
     PREPARED_RESULTS_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-prepared-dependencies.XXXXXX")
     if jq --slurpfile preparedDependencies "$PREPARED_DEPENDENCIES_METADATA_FILE" \
-        '. + {prepared_dependencies: ($preparedDependencies[0] // [])}' \
+        '. + {metadata: ((.metadata // {}) + {prepared_dependencies: ($preparedDependencies[0] // [])})}' \
         "$RESULTS_FILE" > "$PREPARED_RESULTS_FILE"; then
         mv "$PREPARED_RESULTS_FILE" "$RESULTS_FILE"
     else
@@ -1231,7 +1231,7 @@ FAILED_DEPENDENCIES_METADATA_FILE="${ARTIFACTS_DIR%/}/failed-bench-dependencies.
 if [ -f "$FAILED_DEPENDENCIES_METADATA_FILE" ]; then
     FAILED_DEPENDENCIES_RESULTS_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-failed-dependencies.XXXXXX")
     if jq --slurpfile failedDependencies "$FAILED_DEPENDENCIES_METADATA_FILE" \
-        '. + {dependency_build_failures: ($failedDependencies[0] // [])}' \
+        '. + {metadata: ((.metadata // {}) + {dependency_build_failures: ($failedDependencies[0] // [])})}' \
         "$RESULTS_FILE" > "$FAILED_DEPENDENCIES_RESULTS_FILE"; then
         mv "$FAILED_DEPENDENCIES_RESULTS_FILE" "$RESULTS_FILE"
     else

--- a/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
@@ -144,9 +144,10 @@ homeboy_require_bash_version() { :; }
   assert.equal(recipe.workflow.steps[0].command, 'wordpress.bench');
 
   const successResults = JSON.parse(fs.readFileSync(path.join(root, 'success-results.json'), 'utf8'));
-  assert.ok(successResults.prepared_dependencies.some((dependency) => dependency.slug === 'woocommerce' && dependency.source_path === fs.realpathSync(monorepoDependencyPath) && dependency.package_root === fs.realpathSync(monorepoPluginPath) && dependency.mounted_plugin_dir === '/wordpress/wp-content/plugins/woocommerce'), JSON.stringify(successResults.prepared_dependencies, null, 2));
-  assert.ok(successResults.prepared_dependencies.some((dependency) => dependency.slug === 'woocommerce-gateway-stripe' && dependency.source_path === fs.realpathSync(stripeDependencyPath) && dependency.package_root === fs.realpathSync(stripeDependencyPath)), JSON.stringify(successResults.prepared_dependencies, null, 2));
-  const stripePrepared = successResults.prepared_dependencies.find((dependency) => dependency.slug === 'woocommerce-gateway-stripe');
+  assert.equal(successResults.prepared_dependencies, undefined);
+  assert.ok(successResults.metadata.prepared_dependencies.some((dependency) => dependency.slug === 'woocommerce' && dependency.source_path === fs.realpathSync(monorepoDependencyPath) && dependency.package_root === fs.realpathSync(monorepoPluginPath) && dependency.mounted_plugin_dir === '/wordpress/wp-content/plugins/woocommerce'), JSON.stringify(successResults.metadata.prepared_dependencies, null, 2));
+  assert.ok(successResults.metadata.prepared_dependencies.some((dependency) => dependency.slug === 'woocommerce-gateway-stripe' && dependency.source_path === fs.realpathSync(stripeDependencyPath) && dependency.package_root === fs.realpathSync(stripeDependencyPath)), JSON.stringify(successResults.metadata.prepared_dependencies, null, 2));
+  const stripePrepared = successResults.metadata.prepared_dependencies.find((dependency) => dependency.slug === 'woocommerce-gateway-stripe');
   assert.equal(stripePrepared.source_type, 'local');
   assert.equal(stripePrepared.requested_version, '9.9.0-test');
   assert.equal(stripePrepared.requested_revision, 'fixture-revision');
@@ -183,8 +184,9 @@ homeboy_require_bash_version() { :; }
 
   assert.equal(scopedCoreResult.status, 0, scopedCoreResult.stderr || scopedCoreResult.stdout);
   const scopedCoreResults = JSON.parse(fs.readFileSync(path.join(root, 'scoped-core-results.json'), 'utf8'));
-  assert.equal(scopedCoreResults.prepared_dependencies.some((dependency) => dependency.slug === 'generic-dependency'), true);
-  assert.equal(scopedCoreResults.prepared_dependencies.some((dependency) => dependency.slug === 'gateway-build-fails'), false);
+  assert.equal(scopedCoreResults.prepared_dependencies, undefined);
+  assert.equal(scopedCoreResults.metadata.prepared_dependencies.some((dependency) => dependency.slug === 'generic-dependency'), true);
+  assert.equal(scopedCoreResults.metadata.prepared_dependencies.some((dependency) => dependency.slug === 'gateway-build-fails'), false);
   assert.equal(scopedCoreResults.dependency_build_failures, undefined);
 
   const buildFailureArtifactsDir = path.join(root, 'build-failure-artifacts');
@@ -216,15 +218,17 @@ homeboy_require_bash_version() { :; }
 
   assert.equal(buildFailureResult.status, 0, buildFailureResult.stderr || buildFailureResult.stdout);
   const buildFailureResults = JSON.parse(fs.readFileSync(path.join(root, 'build-failure-results.json'), 'utf8'));
-  assert.equal(buildFailureResults.prepared_dependencies.some((dependency) => dependency.slug === 'generic-dependency'), true);
-  assert.equal(buildFailureResults.prepared_dependencies.some((dependency) => dependency.slug === 'gateway-build-fails'), false);
-  assert.equal(buildFailureResults.dependency_build_failures.length, 1);
-  assert.equal(buildFailureResults.dependency_build_failures[0].dependency_slug, 'gateway-build-fails');
-  assert.equal(path.basename(buildFailureResults.dependency_build_failures[0].dependency_path), 'gateway-build-fails');
-  assert.match(buildFailureResults.dependency_build_failures[0].package_path, /gateway-build-fails/);
-  assert.equal(buildFailureResults.dependency_build_failures[0].engine_requirements.node, '>=99');
-  assert.match(buildFailureResults.dependency_build_failures[0].attempted_command, /composer install/);
-  assert.match(buildFailureResults.dependency_build_failures[0].stderr_tail, /EBADENGINE/);
+  assert.equal(buildFailureResults.prepared_dependencies, undefined);
+  assert.equal(buildFailureResults.dependency_build_failures, undefined);
+  assert.equal(buildFailureResults.metadata.prepared_dependencies.some((dependency) => dependency.slug === 'generic-dependency'), true);
+  assert.equal(buildFailureResults.metadata.prepared_dependencies.some((dependency) => dependency.slug === 'gateway-build-fails'), false);
+  assert.equal(buildFailureResults.metadata.dependency_build_failures.length, 1);
+  assert.equal(buildFailureResults.metadata.dependency_build_failures[0].dependency_slug, 'gateway-build-fails');
+  assert.equal(path.basename(buildFailureResults.metadata.dependency_build_failures[0].dependency_path), 'gateway-build-fails');
+  assert.match(buildFailureResults.metadata.dependency_build_failures[0].package_path, /gateway-build-fails/);
+  assert.equal(buildFailureResults.metadata.dependency_build_failures[0].engine_requirements.node, '>=99');
+  assert.match(buildFailureResults.metadata.dependency_build_failures[0].attempted_command, /composer install/);
+  assert.match(buildFailureResults.metadata.dependency_build_failures[0].stderr_tail, /EBADENGINE/);
   const buildDiagnostics = JSON.parse(fs.readFileSync(path.join(buildFailureArtifactsDir, 'wordpress-dependency-build-diagnostics.json'), 'utf8'));
   assert.equal(buildDiagnostics.diagnostics[0].code, 'wordpress-bench-dependency-build-failed');
 


### PR DESCRIPTION
## Summary
- Move WordPress bench prepared dependency provenance under the existing BenchResults `metadata` object so Homeboy core accepts the envelope.
- Store dependency build failure provenance under `metadata` for the same schema compatibility reason.
- Keep bench summary artifacts reading both the new metadata location and older top-level files.

Fixes #1362.

## Tests
- `npm run test:wp-codebox-bench-bootstrap-steps`
- `bash scripts/bench/bench-results-artifacts-smoke.sh`
- `npx eslint tests/wp-codebox-bench-bootstrap-steps-smoke.js` (file is ignored by repo ESLint config)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the schema-compatible provenance placement, updated smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.