### PR TITLE
Default PHP AI Client overlay for Codebox tasks

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -374,6 +374,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     process.env.HOMEBOY_WP_CODEBOX_AGENTS_API_PATH,
     bundledAgentsApiPath(dataMachinePath),
   );
+  const phpAiClientPath = defaultPhpAiClientPath(settings, workspaceBase, options);
 
   return {
     agentsApi: agentsApiPath,
@@ -385,7 +386,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     secretEnv: defaultSecretEnv(provider, settings),
     wpCodeboxBin: firstValue(settings.wp_codebox_bin, settings.wpCodeboxBin, process.env.HOMEBOY_WP_CODEBOX_BIN, ''),
     runtimeOverlayProfiles: defaultRuntimeOverlayProfiles(settings),
-    runtimeOverlays: defaultRuntimeOverlays(settings),
+    runtimeOverlays: defaultRuntimeOverlays(settings, phpAiClientPath),
     runtimeEnv: defaultRuntimeEnv(settings),
     runtimeStateMounts: defaultRuntimeStateMounts(settings),
     runtimeConfigMounts: defaultRuntimeConfigMounts(settings),
@@ -411,8 +412,32 @@ function defaultRuntimeOverlayProfiles(settings) {
   return normalizeArray(settings.wp_codebox_runtime_overlay_profiles || settings.runtime_overlay_profiles);
 }
 
-function defaultRuntimeOverlays(settings) {
-  return normalizeArray(settings.wp_codebox_runtime_overlays || settings.runtime_overlays);
+function defaultRuntimeOverlays(settings, phpAiClientPath = '') {
+  const explicit = normalizeArray(settings.wp_codebox_runtime_overlays || settings.runtime_overlays);
+  if (explicit.length > 0) {
+    return explicit;
+  }
+
+  return phpAiClientPath ? [{
+    type: 'bundled-library',
+    library: 'php-ai-client',
+    source: phpAiClientPath,
+    target: '/wordpress/wp-includes/php-ai-client',
+    metadata: { component: 'php-ai-client', source: 'homeboy-extensions-default' },
+  }] : [];
+}
+
+function defaultPhpAiClientPath(settings, workspaceBase, options = {}) {
+  return firstExistingPath(
+    options.phpAiClient,
+    settings.wp_codebox_php_ai_client_path,
+    settings.php_ai_client_path,
+    process.env.HOMEBOY_WP_CODEBOX_PHP_AI_CLIENT_PATH,
+    process.env.PHP_AI_CLIENT_PATH,
+    siblingPath(workspaceBase, 'php-ai-client'),
+    siblingPath(path.dirname(workspaceBase), 'php-ai-client@custom-provider-auth-live'),
+    siblingPath(path.dirname(workspaceBase), 'php-ai-client'),
+  );
 }
 
 function defaultRuntimeEnv(settings) {

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -419,10 +419,11 @@ function defaultRuntimeOverlays(settings, phpAiClientPath = '') {
   }
 
   return phpAiClientPath ? [{
-    type: 'bundled-library',
+    kind: 'bundled-library',
     library: 'php-ai-client',
     source: phpAiClientPath,
     target: '/wordpress/wp-includes/php-ai-client',
+    strategy: 'wordpress-scoped-bundle',
     metadata: { component: 'php-ai-client', source: 'homeboy-extensions-default' },
   }] : [];
 }

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -616,7 +616,15 @@ try {
   const dataMachineCodePath = path.join(defaultsRoot, 'data-machine-code');
   const staleStandaloneAgentsApiPath = path.join(defaultsRoot, 'agents-api');
   const providerPath = path.join(defaultsRoot, 'ai-provider-for-openai');
-  for (const directory of [workspaceRoot, bundledAgentsApiPath, dataMachineCodePath, staleStandaloneAgentsApiPath, providerPath]) {
+  const phpAiClientPath = path.join(defaultsRoot, 'php-ai-client');
+  const defaultPhpAiClientOverlay = [{
+    type: 'bundled-library',
+    library: 'php-ai-client',
+    source: phpAiClientPath,
+    target: '/wordpress/wp-includes/php-ai-client',
+    metadata: { component: 'php-ai-client', source: 'homeboy-extensions-default' },
+  }];
+  for (const directory of [workspaceRoot, bundledAgentsApiPath, dataMachineCodePath, staleStandaloneAgentsApiPath, providerPath, phpAiClientPath]) {
     fs.mkdirSync(directory, { recursive: true });
   }
 
@@ -638,7 +646,7 @@ try {
   assert.equal(defaultedRequest.runtime_component_paths.agent_runtime_tools, dataMachineCodePath);
   assert.deepEqual(defaultedRequest.provider_plugin_paths, []);
   assert.deepEqual(defaultedRequest.runtime_overlay_profiles, []);
-  assert.deepEqual(defaultedRequest.runtime_overlays, []);
+  assert.deepEqual(defaultedRequest.runtime_overlays, defaultPhpAiClientOverlay);
   assert.deepEqual(defaultedRequest.secret_env, [
     'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
     'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
@@ -681,7 +689,7 @@ try {
   assert.equal(codexSubscriptionDefaultedRequest.model, 'gpt-5.5');
   assert.deepEqual(codexSubscriptionDefaultedRequest.provider_plugin_paths, []);
   assert.deepEqual(codexSubscriptionDefaultedRequest.runtime_overlay_profiles, []);
-  assert.deepEqual(codexSubscriptionDefaultedRequest.runtime_overlays, []);
+  assert.deepEqual(codexSubscriptionDefaultedRequest.runtime_overlays, defaultPhpAiClientOverlay);
   assert.deepEqual(codexSubscriptionDefaultedRequest.secret_env, codexSecretEnv);
 
   const openAiDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -618,10 +618,11 @@ try {
   const providerPath = path.join(defaultsRoot, 'ai-provider-for-openai');
   const phpAiClientPath = path.join(defaultsRoot, 'php-ai-client');
   const defaultPhpAiClientOverlay = [{
-    type: 'bundled-library',
+    kind: 'bundled-library',
     library: 'php-ai-client',
     source: phpAiClientPath,
     target: '/wordpress/wp-includes/php-ai-client',
+    strategy: 'wordpress-scoped-bundle',
     metadata: { component: 'php-ai-client', source: 'homeboy-extensions-default' },
   }];
   for (const directory of [workspaceRoot, bundledAgentsApiPath, dataMachineCodePath, staleStandaloneAgentsApiPath, providerPath, phpAiClientPath]) {


### PR DESCRIPTION
## Summary
- Default WP Codebox agent tasks to overlay a local `php-ai-client` checkout when one is available.
- Preserve explicit runtime overlay settings so callers can still override the default.
- Cover the default overlay behavior in the Codebox agent task executor smoke test.

## Testing
- `node --check lib/codebox-agent-task-executor.js`
- `node tests/codebox-agent-task-executor-smoke.js`
- `node tests/wp-codebox-task-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Codebox/PHP AI Client overlay defaulting gap, drafted the implementation and smoke coverage, and ran targeted verification. Chris reviewed and directed the runtime behavior.