### PR TITLE
Detect custom provider auth PHP AI Client overlay

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -437,6 +437,7 @@ function defaultPhpAiClientPath(settings, workspaceBase, options = {}) {
     process.env.PHP_AI_CLIENT_PATH,
     siblingPath(workspaceBase, 'php-ai-client'),
     siblingPath(path.dirname(workspaceBase), 'php-ai-client@custom-provider-auth-live'),
+    siblingPath(path.dirname(workspaceBase), 'php-ai-client@custom-provider-auth'),
     siblingPath(path.dirname(workspaceBase), 'php-ai-client'),
   );
 }

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -861,6 +861,26 @@ try {
   assert.deepEqual(configuredGenericStackRequest.runtime_overlays, configuredRuntimeOverlays);
   assert.deepEqual(configuredGenericStackRequest.secret_env, ['CONFIGURED_SECRET']);
 
+  const labWorkspaceRoot = path.join(defaultsRoot, '_lab_workspaces', 'target-repo@issue-1161');
+  const labPhpAiClientPath = path.join(defaultsRoot, 'php-ai-client@custom-provider-auth');
+  fs.mkdirSync(labWorkspaceRoot, { recursive: true });
+  fs.mkdirSync(labPhpAiClientPath, { recursive: true });
+  const labDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'lab-default-runtime-stack-task-123',
+    executor: {
+      backend: 'codebox',
+      config: { provider: 'codex' },
+    },
+    inputs: {
+      target: { root: labWorkspaceRoot },
+    },
+  }, {
+    settings: {},
+  });
+  assert.equal(labDefaultedRequest.runtime_overlays[0].source, labPhpAiClientPath);
+  assert.equal(labDefaultedRequest.runtime_overlays[0].strategy, 'wordpress-scoped-bundle');
+
   const explicitOverrideRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,
     task_id: 'explicit-runtime-stack-task-123',


### PR DESCRIPTION
## Summary
- Detect the existing Lab `php-ai-client@custom-provider-auth` checkout as the default PHP AI Client runtime overlay source.
- Keep the WP Codebox `wordpress-scoped-bundle` overlay contract from the previous PR.
- Add smoke coverage for the Lab workspace path shape.

## Testing
- `node --check lib/codebox-agent-task-executor.js`
- `node tests/codebox-agent-task-executor-smoke.js`
- `node tests/wp-codebox-task-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Lab checkout naming mismatch, drafted the path detection fix and smoke coverage, and ran targeted verification.