### PR TITLE
Detect PHP AI Client overlay from Lab cwd

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -439,6 +439,9 @@ function defaultPhpAiClientPath(settings, workspaceBase, options = {}) {
     siblingPath(path.dirname(workspaceBase), 'php-ai-client@custom-provider-auth-live'),
     siblingPath(path.dirname(workspaceBase), 'php-ai-client@custom-provider-auth'),
     siblingPath(path.dirname(workspaceBase), 'php-ai-client'),
+    siblingPath(path.dirname(path.dirname(workspaceBase)), 'php-ai-client@custom-provider-auth-live'),
+    siblingPath(path.dirname(path.dirname(workspaceBase)), 'php-ai-client@custom-provider-auth'),
+    siblingPath(path.dirname(path.dirname(workspaceBase)), 'php-ai-client'),
   );
 }
 

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -878,8 +878,30 @@ try {
   }, {
     settings: {},
   });
-  assert.equal(labDefaultedRequest.runtime_overlays[0].source, labPhpAiClientPath);
+  assert.equal(fs.realpathSync(labDefaultedRequest.runtime_overlays[0].source), fs.realpathSync(labPhpAiClientPath));
   assert.equal(labDefaultedRequest.runtime_overlays[0].strategy, 'wordpress-scoped-bundle');
+
+  const originalCwd = process.cwd();
+  const labOffloadCwd = path.join(defaultsRoot, '_lab_workspaces', 'wp-site-generator-pilot-homeboy-ssi-loop');
+  fs.mkdirSync(labOffloadCwd, { recursive: true });
+  try {
+    process.chdir(labOffloadCwd);
+    const labNoTargetDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
+      ...request,
+      task_id: 'lab-no-target-default-runtime-stack-task-123',
+      executor: {
+        backend: 'codebox',
+        config: { provider: 'codex' },
+      },
+      inputs: {},
+    }, {
+      settings: {},
+    });
+    assert.equal(fs.realpathSync(labNoTargetDefaultedRequest.runtime_overlays[0].source), fs.realpathSync(labPhpAiClientPath));
+    assert.equal(labNoTargetDefaultedRequest.runtime_overlays[0].strategy, 'wordpress-scoped-bundle');
+  } finally {
+    process.chdir(originalCwd);
+  }
 
   const explicitOverrideRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,


### PR DESCRIPTION
## Summary
- Detect the default PHP AI Client overlay when a Codebox task has no explicit target root and runs from a Lab materialized workspace.
- Preserve the WP Codebox `wordpress-scoped-bundle` runtime overlay contract.
- Add smoke coverage for Lab offload tasks that omit `inputs.target.root`.

## Testing
- `node --check lib/codebox-agent-task-executor.js`
- `node tests/codebox-agent-task-executor-smoke.js`
- `node tests/wp-codebox-task-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed why the merged default overlay was not applied for no-target Lab tasks, drafted the fallback and coverage, and ran targeted verification.