### PR TITLE
fix: default validation dependencies to array

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -608,7 +608,7 @@ Configure per-component in the component's homeboy/component config under
 | Setting | Type | Default | Purpose |
 |---|---|---|---|
 | `test_backend` | string | `wp-codebox` | `wp-codebox` (default) or `host-smoke` for standalone non-WordPress smoke scripts |
-| `validation_dependencies` | string | `""` | Comma / newline / JSON list of local components to mount during PHPStan, autoload validation, and PHPUnit |
+| `validation_dependencies` | array | `[]` | Component IDs, paths, or scoped objects to mount during PHPStan, autoload validation, PHPUnit, and bench |
 | `user` | string | `""` | WP-CLI user (email/login/ID); appended as `--user` when set |
 | `wp_config_defines` | object | `{}` | `CONSTANT_NAME => value` map appended to the runtime `wp-tests-config.php`; PHP type preserved via `var_export` |
 | `bench_env` | object | `{}` | `NAME => value` env vars forwarded into the runtime (workloads/fixtures read via `getenv()`) |

--- a/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
@@ -109,6 +109,12 @@ homeboy_require_bash_version() { :; }
       { command: 'wordpress.wp-cli', args: ['command=option update generic_dependency_bootstrap yes'] },
     ],
   };
+
+  const extensionManifest = JSON.parse(fs.readFileSync(path.join(extensionPath, 'wordpress.json'), 'utf8'));
+  const validationDependenciesSetting = extensionManifest.settings.find((setting) => setting.id === 'validation_dependencies');
+  assert.equal(validationDependenciesSetting.type, 'array');
+  assert.deepEqual(validationDependenciesSetting.default, []);
+
   const baseEnv = {
     ...process.env,
     HOMEBOY_BENCH_ITERATIONS: '1',

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -975,9 +975,9 @@
     {
       "id": "validation_dependencies",
       "label": "Validation Dependencies",
-      "type": "string",
-      "default": "",
-      "description": "Local component IDs or paths to load during PHPStan, autoload validation, PHPUnit, and bench. Accepts comma-separated, newline-separated, JSON-array string values, or bench-scoped array objects shaped like {dependency,path|slug,scenarios,profiles,profile_env}. Scoped objects let selected bench scenarios/profiles opt into expensive gateway dependencies without blocking unrelated profiles."
+      "type": "array",
+      "default": [],
+      "description": "Local component IDs or paths to load during PHPStan, autoload validation, PHPUnit, and bench. Accepts an array of component IDs, paths, or bench-scoped objects shaped like {dependency,path|slug,scenarios,profiles,profile_env}. Scoped objects let selected bench scenarios/profiles opt into expensive gateway dependencies without blocking unrelated profiles."
     },
     {
       "id": "user",


### PR DESCRIPTION
## Summary
- Change the WordPress extension `validation_dependencies` setting metadata to an array with default `[]`.
- Update README setting docs to match the bench runner contract.
- Add a smoke assertion so the WP Codebox bench path catches a string default regression.

Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/1367.

## Testing
- `node tests/wp-codebox-bench-bootstrap-steps-smoke.js`
- `npm run test:wp-codebox-bench-bootstrap-steps`

## Known unrelated validation
- `npm run lint:js` still fails on pre-existing unrelated files such as `lib/playground-readiness.js`, `lib/timing-correlator.js`, and several `scripts/agent/*` files. This PR does not touch those files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Woo evidence blocker, drafted the metadata/default fix, and ran targeted validation for Chris to review.