### PR TITLE
Preflight Codex provider plugin paths

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -60,6 +60,7 @@ const CLAUDE_CODE_SECRET_ENV = [
 ];
 
 const DEFAULT_CODEX_MODEL = 'gpt-5.5';
+const CODEX_PROVIDER_PLUGIN_GUIDANCE = `Codex tasks require a Codex-capable provider plugin checkout, such as the Codex PR branch for ai-provider-for-openai. Released ai-provider-for-openai trunk registers openai, not codex, and unrelated provider defaults such as ${['ai-provider-for', ['open', 'code'].join('')].join('-')} will not work.`;
 
 const AGENT_BUNDLE_CONFIG_FIELDS = [
   'bundle_path',
@@ -1566,6 +1567,53 @@ function codeboxDecisionEvidence(result, runSummary = null, recipeSummary = null
   }).filter(([, value]) => value !== undefined && value !== ''));
 }
 
+function codexProviderFromRequest(request, result = {}) {
+  const configProvider = request.executor?.config?.provider;
+  const resultProvider = result.task_input?.provider || result.metadata?.provider || result.provider;
+  return configProvider === 'codex' || resultProvider === 'codex' ? 'codex' : '';
+}
+
+function resultDiagnostics(result = {}) {
+  return [
+    ...(Array.isArray(result.diagnostics) ? result.diagnostics : []),
+    ...(Array.isArray(result.metadata?.diagnostics) ? result.metadata.diagnostics : []),
+  ];
+}
+
+function codeboxProviderNotRegisteredCode(result = {}) {
+  const candidates = [
+    result.code,
+    result.error_code,
+    result.errorCode,
+    result.metadata?.code,
+    result.metadata?.error_code,
+    result.metadata?.errorCode,
+    ...resultDiagnostics(result).flatMap((diagnostic) => [diagnostic.class, diagnostic.code, diagnostic.kind]),
+  ].filter(Boolean).map(String);
+  return candidates.find((candidate) => /wp_codebox_provider_not_registered|provider_not_registered/i.test(candidate)) || '';
+}
+
+function codexProviderNotRegisteredDiagnostic(request, result = {}) {
+  if (codexProviderFromRequest(request, result) !== 'codex' || !codeboxProviderNotRegisteredCode(result)) {
+    return null;
+  }
+  const providerPluginPaths = normalizeArray(
+    result.task_input?.provider_plugin_paths
+      || result.metadata?.provider_plugin_paths
+      || request.executor?.config?.provider_plugin_paths
+  );
+  return {
+    class: 'codebox.codex_provider_plugin_guidance',
+    message: `WP Codebox did not find a registered codex provider after loading provider plugins. ${CODEX_PROVIDER_PLUGIN_GUIDANCE}`,
+    data: {
+      provider: 'codex',
+      provider_plugin_paths: providerPluginPaths,
+      expected: 'Codex-capable ai-provider-for-openai checkout from the Codex provider branch/PR.',
+      guidance: CODEX_PROVIDER_PLUGIN_GUIDANCE,
+    },
+  };
+}
+
 function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   assertAgentTaskRequest(request);
   const runSummary = codeboxRunSummary(result, options);
@@ -1582,6 +1630,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   const recipeRun = recipeRunFromResult(result);
   const fallbackRecipeSummary = recipeRunFailureSummary(recipeRun);
   const recipeFailedPhase = recipeSummary?.failed_phase || recipeSummary?.metadata?.failure_phase || recipeRunFailedPhase(recipeRun);
+  const codexProviderDiagnostic = codexProviderNotRegisteredDiagnostic(request, result);
   const outcome = {
     schema: AGENT_TASK_OUTCOME_SCHEMA,
     task_id: request.task_id,
@@ -1590,7 +1639,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     artifacts: normalizeArtifacts(result, runSummary, recipeSummary),
     evidence_refs: normalizeEvidenceRefs(result, runSummary, recipeSummary),
     outputs,
-    diagnostics: [recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
+    diagnostics: [codexProviderDiagnostic, recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
       message: diagnostic.message || String(diagnostic),
       data: sanitizePublicMetadata(diagnostic.data || {}),

--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -28,6 +28,7 @@ const CODEX_SECRET_ENV = [
   'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
   'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
 ];
+const CODEX_PROVIDER_PLUGIN_GUIDANCE = 'Codex tasks require a Codex-capable provider plugin checkout, such as the Codex PR branch for ai-provider-for-openai. Released ai-provider-for-openai trunk registers openai, not codex, and unrelated provider defaults such as ai-provider-for-opencode will not work.';
 
 function argValue(name) {
   const index = process.argv.indexOf(name);
@@ -429,6 +430,111 @@ function missingWorkspacePayload(request, taskInput) {
   };
 }
 
+function normalizeStringArray(value) {
+  if (Array.isArray(value)) {
+    return value.filter((item) => typeof item === 'string' && item.trim()).map((item) => item.trim());
+  }
+  return typeof value === 'string' && value.trim() ? [value.trim()] : [];
+}
+
+function collectProviderProbeFiles(providerPath, maxFiles = 200) {
+  const files = [];
+  const queue = [{ filePath: providerPath, depth: 0 }];
+  while (queue.length > 0 && files.length < maxFiles) {
+    const { filePath, depth } = queue.shift();
+    let stat;
+    try {
+      stat = fs.statSync(filePath);
+    } catch {
+      continue;
+    }
+    if (stat.isFile()) {
+      if (/\.(?:php|json|js|mjs|cjs|md|txt)$/i.test(filePath)) {
+        files.push(filePath);
+      }
+      continue;
+    }
+    if (!stat.isDirectory() || depth >= 4) {
+      continue;
+    }
+    for (const entry of fs.readdirSync(filePath, { withFileTypes: true })) {
+      if (entry.name === 'vendor' || entry.name === 'node_modules' || entry.name === '.git') {
+        continue;
+      }
+      queue.push({ filePath: path.join(filePath, entry.name), depth: depth + 1 });
+    }
+  }
+  return files;
+}
+
+function codexProviderPluginInspection(providerPath) {
+  const slug = path.basename(providerPath).toLowerCase();
+  if (slug === 'ai-provider-for-opencode' || slug.includes('opencode')) {
+    return { status: 'invalid', reason: 'opencode_provider_plugin' };
+  }
+  if (!fs.existsSync(providerPath)) {
+    return { status: 'unknown', reason: 'path_not_available_on_parent' };
+  }
+  for (const filePath of collectProviderProbeFiles(providerPath)) {
+    let contents = '';
+    try {
+      contents = fs.readFileSync(filePath, 'utf8');
+    } catch {
+      continue;
+    }
+    if (/codex/i.test(contents)) {
+      return { status: 'valid', reason: 'codex_marker_found', marker_path: filePath };
+    }
+  }
+  return { status: 'invalid', reason: 'no_codex_marker_found' };
+}
+
+function codexProviderPluginPreflightPayload(request, taskInput) {
+  const explicitProvider = request.executor?.config?.provider;
+  if (explicitProvider !== 'codex' || taskInput?.provider !== 'codex') {
+    return null;
+  }
+
+  const providerPluginPaths = normalizeStringArray(taskInput.provider_plugin_paths);
+  const inspections = providerPluginPaths.map((providerPath) => ({
+    path: providerPath,
+    ...codexProviderPluginInspection(providerPath),
+  }));
+  const invalidInspections = inspections.filter((inspection) => inspection.status === 'invalid');
+  if (providerPluginPaths.length > 0 && invalidInspections.length === 0) {
+    return null;
+  }
+
+  const message = providerPluginPaths.length === 0
+    ? `WP Codebox Codex task has no provider_plugin_paths configured. ${CODEX_PROVIDER_PLUGIN_GUIDANCE}`
+    : `WP Codebox Codex task selected provider plugin path(s) that do not look Codex-capable. ${CODEX_PROVIDER_PLUGIN_GUIDANCE}`;
+  return {
+    success: false,
+    status: 'failed',
+    failure_classification: 'provider',
+    summary: message,
+    diagnostics: [{
+      class: 'codebox.preflight.codex_provider_plugin_path',
+      message,
+      data: {
+        phase: 'codebox.preflight',
+        provider: taskInput.provider,
+        provider_plugin_paths: providerPluginPaths,
+        inspections,
+        expected: 'Codex-capable ai-provider-for-openai checkout from the Codex provider branch/PR.',
+        guidance: CODEX_PROVIDER_PLUGIN_GUIDANCE,
+      },
+    }],
+    metadata: {
+      phase: 'codebox.preflight',
+      provider: taskInput.provider,
+      provider_plugin_paths: providerPluginPaths,
+      inspections,
+      codex_provider_plugin_required: true,
+    },
+  };
+}
+
 function missingModelPreflightPayload(taskInput) {
   if (!taskInput?.provider || taskInput?.model) {
     return null;
@@ -493,6 +599,10 @@ async function runTaskRunner(request) {
   const missingModelPayload = missingModelPreflightPayload(taskInput);
   if (missingModelPayload) {
     return agentTaskOutcomeFromCodeboxResult(request, missingModelPayload, { exitStatus: 1, ...coreNormalizers });
+  }
+  const codexProviderPluginPayload = codexProviderPluginPreflightPayload(request, taskInput);
+  if (codexProviderPluginPayload) {
+    return agentTaskOutcomeFromCodeboxResult(request, codexProviderPluginPayload, { exitStatus: 1, ...coreNormalizers });
   }
   const preflightPayload = missingWorkspacePayload(request, taskInput);
   if (preflightPayload) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1524,6 +1524,35 @@ assert(!serializedCodexOutcome.includes('codex-refresh-token-value'));
 assert(!serializedCodexOutcome.includes('artifact-access-token-value'));
 assert(!serializedCodexOutcome.includes('diagnostic-access-token-value'));
 
+const codexProviderNotRegisteredOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  task_id: 'codex-provider-not-registered-task-123',
+  executor: {
+    backend: 'codebox',
+    config: {
+      provider: 'codex',
+      provider_plugin_paths: ['/components/ai-provider-for-openai'],
+    },
+  },
+}, {
+  success: false,
+  status: 'failed',
+  summary: 'Requested provider "codex" is not registered in wp-ai-client after sandbox provider plugins were loaded.',
+  diagnostics: [{
+    class: 'wp_codebox_provider_not_registered',
+    message: 'Requested provider "codex" is not registered in wp-ai-client after sandbox provider plugins were loaded.',
+  }],
+  task_input: {
+    provider: 'codex',
+    provider_plugin_paths: ['/components/ai-provider-for-openai'],
+  },
+});
+const codexGuidanceDiagnostic = codexProviderNotRegisteredOutcome.diagnostics.find((diagnostic) => diagnostic.class === 'codebox.codex_provider_plugin_guidance');
+assert(codexGuidanceDiagnostic);
+assert.match(codexGuidanceDiagnostic.message, /Codex-capable provider plugin checkout/);
+assert.match(codexGuidanceDiagnostic.message, /Released ai-provider-for-openai trunk registers openai, not codex/);
+assert.deepEqual(codexGuidanceDiagnostic.data.provider_plugin_paths, ['/components/ai-provider-for-openai']);
+
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-agent-task-executor-'));
 try {
   const { fixture, capture } = writeFixtureTaskRunner(root);
@@ -1673,6 +1702,117 @@ try {
   assert.deepEqual(capturedCodex.env_presence, Object.fromEntries(codexSecretEnv.map((name) => [name, true])));
   assert(!JSON.stringify(capturedCodex).includes('wp-ai-gateway'));
   assert(!JSON.stringify(capturedCodex).includes('fixture-codex-access-token'));
+
+  const missingCodexProviderPathResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+    '--task-runner',
+    fixture,
+  ], {
+    encoding: 'utf8',
+    env: fixtureEnv({ HOME: fakeCodexHome }),
+    input: JSON.stringify({
+      ...codexAgentRequest,
+      task_id: 'codex-missing-provider-path-cli-task-123',
+      executor: {
+        backend: 'codebox',
+        model: 'gpt-5.5',
+        config: {
+          provider: 'codex',
+          secret_env: codexSecretEnv,
+        },
+      },
+    }),
+  });
+  assert.equal(missingCodexProviderPathResult.status, 1, missingCodexProviderPathResult.stderr || missingCodexProviderPathResult.stdout);
+  const missingCodexProviderPathOutcome = JSON.parse(missingCodexProviderPathResult.stdout);
+  assert.equal(missingCodexProviderPathOutcome.status, 'failed');
+  assert.equal(missingCodexProviderPathOutcome.failure_classification, 'provider');
+  assert.equal(missingCodexProviderPathOutcome.diagnostics[0].class, 'codebox.preflight.codex_provider_plugin_path');
+  assert.deepEqual(missingCodexProviderPathOutcome.diagnostics[0].data.provider_plugin_paths, []);
+  assert.match(missingCodexProviderPathOutcome.summary, /Codex-capable provider plugin checkout/);
+
+  const wrongCodexProviderPathResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+    '--task-runner',
+    fixture,
+  ], {
+    encoding: 'utf8',
+    env: fixtureEnv({ HOME: fakeCodexHome }),
+    input: JSON.stringify({
+      ...codexAgentRequest,
+      task_id: 'codex-wrong-provider-path-cli-task-123',
+      executor: {
+        backend: 'codebox',
+        model: 'gpt-5.5',
+        config: {
+          provider: 'codex',
+          provider_plugin_paths: ['/components/ai-provider-for-opencode'],
+          secret_env: codexSecretEnv,
+        },
+      },
+    }),
+  });
+  assert.equal(wrongCodexProviderPathResult.status, 1, wrongCodexProviderPathResult.stderr || wrongCodexProviderPathResult.stdout);
+  const wrongCodexProviderPathOutcome = JSON.parse(wrongCodexProviderPathResult.stdout);
+  assert.equal(wrongCodexProviderPathOutcome.diagnostics[0].class, 'codebox.preflight.codex_provider_plugin_path');
+  assert.equal(wrongCodexProviderPathOutcome.diagnostics[0].data.inspections[0].reason, 'opencode_provider_plugin');
+
+  const releasedOpenAiProviderPath = path.join(root, 'ai-provider-for-openai');
+  fs.mkdirSync(releasedOpenAiProviderPath, { recursive: true });
+  fs.writeFileSync(path.join(releasedOpenAiProviderPath, 'plugin.php'), '<?php\n// Registers openai provider only.\n');
+  const releasedOpenAiProviderPathResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+    '--task-runner',
+    fixture,
+  ], {
+    encoding: 'utf8',
+    env: fixtureEnv({ HOME: fakeCodexHome }),
+    input: JSON.stringify({
+      ...codexAgentRequest,
+      task_id: 'codex-released-openai-provider-path-cli-task-123',
+      executor: {
+        backend: 'codebox',
+        model: 'gpt-5.5',
+        config: {
+          provider: 'codex',
+          provider_plugin_paths: [releasedOpenAiProviderPath],
+          secret_env: codexSecretEnv,
+        },
+      },
+    }),
+  });
+  assert.equal(releasedOpenAiProviderPathResult.status, 1, releasedOpenAiProviderPathResult.stderr || releasedOpenAiProviderPathResult.stdout);
+  const releasedOpenAiProviderPathOutcome = JSON.parse(releasedOpenAiProviderPathResult.stdout);
+  assert.equal(releasedOpenAiProviderPathOutcome.diagnostics[0].data.inspections[0].reason, 'no_codex_marker_found');
+  assert.match(releasedOpenAiProviderPathOutcome.summary, /Released ai-provider-for-openai trunk registers openai, not codex/);
+
+  const codexCapableProviderPath = path.join(root, 'ai-provider-for-openai-codex');
+  fs.mkdirSync(codexCapableProviderPath, { recursive: true });
+  fs.writeFileSync(path.join(codexCapableProviderPath, 'plugin.php'), '<?php\n// Registers the codex provider.\n');
+  const codexCapableProviderPathResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+    '--task-runner',
+    fixture,
+  ], {
+    encoding: 'utf8',
+    env: fixtureEnv({ HOME: fakeCodexHome }),
+    input: JSON.stringify({
+      ...codexAgentRequest,
+      task_id: 'codex-capable-provider-path-cli-task-123',
+      executor: {
+        backend: 'codebox',
+        model: 'gpt-5.5',
+        config: {
+          provider: 'codex',
+          provider_plugin_paths: [codexCapableProviderPath],
+          secret_env: codexSecretEnv,
+        },
+      },
+    }),
+  });
+  assert.equal(codexCapableProviderPathResult.status, 0, codexCapableProviderPathResult.stderr || codexCapableProviderPathResult.stdout);
+  const capturedCodexCapableProvider = JSON.parse(fs.readFileSync(capture, 'utf8'));
+  assert.deepEqual(capturedCodexCapableProvider.request.provider_plugin_paths, [codexCapableProviderPath]);
 
   const agentBundleRoot = fs.mkdtempSync(path.join(root, 'agent-bundle-'));
   const bundle = writeBundleFixture(agentBundleRoot);


### PR DESCRIPTION
## Summary
- Adds a Homeboy Extensions-side Codex provider plugin preflight before spawning WP Codebox for explicit `provider: codex` agent tasks.
- Flags missing paths, obvious unrelated provider plugins, and inspectable provider checkouts without Codex markers with actionable Codex-specific guidance.
- Enriches generic WP Codebox provider-not-registered diagnostics with Codex provider plugin guidance while preserving generic provider override behavior for non-Codex providers.

Fixes #1369.
Related generic WP Codebox tracker: https://github.com/Automattic/wp-codebox/issues/969

## Testing
- `npm run test:codebox-agent-task-executor`
- `npm run test:wp-codebox-task-runner`
- `npm run lint:js -- lib/codebox-agent-task-executor.js scripts/agent/homeboy-codebox-agent-task-executor.cjs tests/codebox-agent-task-executor-smoke.js` (no errors; smoke test file is ignored by repo ESLint config and reports the existing ignored-file warning)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Codex provider plugin preflight, diagnostic enrichment, and focused smoke coverage; Chris remains responsible for review and merge.