### PR TITLE
Add Rust toolchain acceleration knobs

### DIFF
--- a/rust/docs/bench.md
+++ b/rust/docs/bench.md
@@ -55,9 +55,10 @@ The first slice emits these normalized scenarios:
 - `rust-test` — prebuilds test binaries, then measures `cargo test --no-run`.
 
 Each profile scenario includes metadata identifying `cache_mode`, `change_mode`,
-the command, and the changed file when applicable. This keeps cache/change
-semantics in the Rust extension while Homeboy core compares ordinary scenario
-metrics.
+the command, the changed file when applicable, and active Rust toolchain
+acceleration under `metadata.rust_toolchain`. This keeps cache/change and
+toolchain semantics in the Rust extension while Homeboy core compares ordinary
+scenario metrics.
 
 Set `HOMEBOY_RUST_BENCH_CHANGED_FILE=path/to/file.rs` to choose the changed-file
 profile target. When omitted, the runner uses `src/lib.rs` or `src/main.rs`.
@@ -75,3 +76,6 @@ HOMEBOY_RUST_BENCH_PROFILES=1 homeboy bench my-rust-component --iterations 5
 HOMEBOY_RUST_BENCH_PROFILES=1 homeboy bench my-rust-component --scenario rust-warm-build --iterations 10
 HOMEBOY_RUST_BENCH_CRITERION=1 homeboy bench my-rust-component --scenario criterion-my-bench
 ```
+
+For the fast local development loop and cache/linker acceleration knobs, see
+[`dev-loop.md`](dev-loop.md).

--- a/rust/docs/dev-loop.md
+++ b/rust/docs/dev-loop.md
@@ -1,0 +1,105 @@
+# Rust Development Loop
+
+The Rust extension owns Rust/Cargo toolchain acceleration. Homeboy core should
+only receive generic command environment and benchmark metadata; it should not
+grow Rust, Cargo, sccache, linker, or nextest behavior.
+
+## Shared Cargo Target Directory
+
+The Rust env provider sets a stable `CARGO_TARGET_DIR` per component identity:
+
+```bash
+${XDG_DATA_HOME:-$HOME/.local/share}/homeboy/cargo-targets/<component>-<repo-hash>
+```
+
+This keeps target artifacts reusable across primary checkouts and worktrees for
+the same repository while avoiding cross-project target collisions. If the user
+sets `CARGO_TARGET_DIR` explicitly, the provider emits `{}` and does not
+override it.
+
+## sccache
+
+Enable sccache through extension settings or the environment:
+
+```bash
+HOMEBOY_RUST_SCCACHE=1 homeboy test my-rust-component
+HOMEBOY_RUST_SCCACHE=1 homeboy lint my-rust-component
+HOMEBOY_RUST_SCCACHE=1 homeboy bench my-rust-component
+```
+
+Equivalent component setting:
+
+```json
+{
+  "extensions": {
+    "rust": {
+      "rust_sccache": true
+    }
+  }
+}
+```
+
+When enabled, the env provider sets `RUSTC_WRAPPER=sccache` only if `sccache` is
+on `PATH` and `RUSTC_WRAPPER` is not already set. Existing `RUSTC_WRAPPER` wins.
+
+## Linker Acceleration
+
+Linker acceleration is explicit because linker availability and compatibility
+vary by host:
+
+```bash
+HOMEBOY_RUST_LINKER=mold homeboy test my-rust-component
+HOMEBOY_RUST_LINKER=lld homeboy bench my-rust-component
+```
+
+Equivalent component setting:
+
+```json
+{
+  "extensions": {
+    "rust": {
+      "rust_linker": "mold"
+    }
+  }
+}
+```
+
+The provider appends the matching Rust flag only when the linker binary is on
+`PATH`:
+
+- `mold` -> `RUSTFLAGS="$RUSTFLAGS -C link-arg=-fuse-ld=mold"`
+- `lld` -> `RUSTFLAGS="$RUSTFLAGS -C link-arg=-fuse-ld=lld"`
+
+Unsupported or unavailable requests are reported through `HOMEBOY_RUST_*_STATUS`
+environment metadata and do not force Cargo to run with a broken linker flag.
+
+## Fast Local Profile
+
+For local iteration, use the narrowest command that proves the change:
+
+```bash
+HOMEBOY_RUST_SCCACHE=1 homeboy lint my-rust-component --step fmt
+HOMEBOY_RUST_SCCACHE=1 homeboy test my-rust-component --skip-lint -- --lib
+HOMEBOY_RUST_SCCACHE=1 HOMEBOY_RUST_LINKER=mold homeboy bench my-rust-component --scenario rust-warm-build --iterations 5
+```
+
+Use `HOMEBOY_RUST_BENCH_PROFILES=1` to measure the loop itself:
+
+```bash
+HOMEBOY_RUST_SCCACHE=1 HOMEBOY_RUST_BENCH_PROFILES=1 \
+  homeboy bench my-rust-component --iterations 5
+```
+
+The profile scenarios are documented in `rust/docs/bench.md` and include clean
+build, warm build, changed-file check, and test build timings.
+
+## Reporting Contract
+
+`homeboy bench` already supports generic scenario metadata, so the Rust bench
+runner records active toolchain state under `metadata.rust_toolchain` and each
+Rust profile scenario records the same data under `scenario.metadata.rust_toolchain`.
+
+Current generic metadata coverage is bench-only. There is no generic Homeboy
+contract for attaching extension-owned environment/toolchain metadata to lint or
+test result envelopes, so the Rust extension cannot surface sccache/linker state
+there without adding Rust-specific behavior to core.

--- a/rust/rust.json
+++ b/rust/rust.json
@@ -69,6 +69,20 @@
       "type": "string",
       "default": "",
       "description": "Optional changed-file profile target relative to the Cargo project root. When omitted, the runner uses src/lib.rs or src/main.rs if present."
+    },
+    {
+      "id": "rust_sccache",
+      "label": "Rust sccache wrapper",
+      "type": "boolean",
+      "default": false,
+      "description": "Opt into sccache through the Rust extension env provider. Set HOMEBOY_RUST_SCCACHE=1 or rust_sccache=true; the provider sets RUSTC_WRAPPER=sccache only when sccache is on PATH and RUSTC_WRAPPER is not already set."
+    },
+    {
+      "id": "rust_linker",
+      "label": "Rust linker acceleration",
+      "type": "string",
+      "default": "",
+      "description": "Optional Rust linker acceleration knob owned by the Rust extension. Set HOMEBOY_RUST_LINKER=mold or lld, or rust_linker to the same value; the provider appends the matching -C link-arg=-fuse-ld flag only when the requested linker binary is on PATH."
     }
   ],
   "audit": {

--- a/rust/scripts/bench/bench-runner.sh
+++ b/rust/scripts/bench/bench-runner.sh
@@ -58,12 +58,15 @@ homeboy_require_bash_version 4
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
 FAILURE_TRAP_HELPER="${HOMEBOY_RUNTIME_FAILURE_TRAP:-}"
 SETTINGS_HELPER="${HOMEBOY_RUNTIME_SETTINGS_HELPER:-${SCRIPT_DIR}/../lib/settings.sh}"
+TOOLCHAIN_ENV_HELPER="${HOMEBOY_RUST_TOOLCHAIN_ENV_HELPER:-${SCRIPT_DIR}/../lib/toolchain-env.sh}"
 BENCH_HELPER_SH="${HOMEBOY_RUNTIME_BENCH_HELPER_SH:-${HOME}/.homeboy/runtime/bench-helper.sh}"
 # shellcheck source=/dev/null
 source "$RESOLVE_CONTEXT_HELPER"
 homeboy_resolve_context
 # shellcheck source=/dev/null
 source "$SETTINGS_HELPER"
+# shellcheck source=../lib/toolchain-env.sh
+source "$TOOLCHAIN_ENV_HELPER"
 # shellcheck source=/dev/null
 if [ -n "$FAILURE_TRAP_HELPER" ] && [ -f "$FAILURE_TRAP_HELPER" ]; then
     source "$FAILURE_TRAP_HELPER"
@@ -87,6 +90,8 @@ SELECTED_SCENARIOS="${HOMEBOY_BENCH_SCENARIOS:-}"
 CRITERION_REQUEST="${HOMEBOY_RUST_BENCH_CRITERION:-0}"
 PROFILE_REQUEST="${HOMEBOY_RUST_BENCH_PROFILES:-0}"
 ARTIFACT_DIR="${HOMEBOY_BENCH_RESULTS_ARTIFACT_DIR:-$(dirname "$RESULTS_FILE")}"
+TOOLCHAIN_METADATA_JSON="$(homeboy_rust_toolchain_metadata_json)"
+export HOMEBOY_RUST_TOOLCHAIN_METADATA_JSON="$TOOLCHAIN_METADATA_JSON"
 
 now_ms() {
     python3 - <<'PYTHON_NOW' 2>/dev/null || printf '%s000\n' "$(date +%s)"
@@ -492,6 +497,7 @@ import json, os, subprocess, sys, time
 payload_file = sys.argv[1]
 iterations = int(sys.argv[2])
 metadata = json.loads(sys.argv[3])
+toolchain_metadata = json.loads(os.environ.get('HOMEBOY_RUST_TOOLCHAIN_METADATA_JSON', '{}'))
 command = sys.argv[4:]
 
 timings = []
@@ -507,6 +513,8 @@ for _ in range(iterations):
     timings.append(elapsed)
 
 with open(payload_file, 'w', encoding='utf-8') as fh:
+    if toolchain_metadata:
+        metadata.setdefault('rust_toolchain', toolchain_metadata)
     json.dump({
         'timings_ns': timings,
         'metadata': metadata,
@@ -722,15 +730,16 @@ fi
 
 PARSE_START_MS="$(now_ms)"
 BENCH_EXTRAS_FILE="${SCENARIOS_JSON_TMPDIR}/bench-extras.json"
-python3 - <<PYTHON_EXTRAS "$BENCH_EXTRAS_FILE" "$CARGO_TIMING_STATUS" "$CARGO_TIMING_NOTE" "$CARGO_TIMING_ARTIFACT" --phases "${PHASE_RECORDS[@]:-}"
+python3 - <<PYTHON_EXTRAS "$BENCH_EXTRAS_FILE" "$CARGO_TIMING_STATUS" "$CARGO_TIMING_NOTE" "$CARGO_TIMING_ARTIFACT" "$TOOLCHAIN_METADATA_JSON" --phases "${PHASE_RECORDS[@]:-}"
 import json, os, sys
 
 extras_file = sys.argv[1]
 cargo_timing_status = sys.argv[2]
 cargo_timing_note = sys.argv[3]
 cargo_timing_artifact = sys.argv[4]
+toolchain_metadata = json.loads(sys.argv[5])
 
-args = sys.argv[5:]
+args = sys.argv[6:]
 phase_records = []
 mode = None
 for arg in args:
@@ -764,7 +773,8 @@ for record in phase_records:
 metadata = {
     "rust_runner": {
         "cargo_timing_status": cargo_timing_status,
-    }
+    },
+    "rust_toolchain": toolchain_metadata,
 }
 artifacts = {}
 if cargo_timing_note:

--- a/rust/scripts/bench/rust-bench-smoke.sh
+++ b/rust/scripts/bench/rust-bench-smoke.sh
@@ -247,6 +247,8 @@ done
 assert "clean cache mode" "$(jq -r '.scenarios[] | select(.id == "rust-clean-build") | .metadata.cache_mode' "$PROFILES_TMPFILE")" "clean"
 assert "warm cache mode" "$(jq -r '.scenarios[] | select(.id == "rust-warm-build") | .metadata.cache_mode' "$PROFILES_TMPFILE")" "warm"
 assert "changed-file mode" "$(jq -r '.scenarios[] | select(.id == "rust-changed-file-check") | .metadata.change_mode' "$PROFILES_TMPFILE")" "changed_file"
+assert "profile toolchain metadata" "$(jq -r '.scenarios[] | select(.id == "rust-warm-build") | .metadata.rust_toolchain.sccache_status' "$PROFILES_TMPFILE")" "off"
+assert "envelope toolchain metadata" "$(jq -r '.metadata.rust_toolchain.sccache_status' "$PROFILES_TMPFILE")" "off"
 
 echo
 echo "── Validating Criterion adapter ──"

--- a/rust/scripts/env-provider.sh
+++ b/rust/scripts/env-provider.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 project_path="${HOMEBOY_COMPONENT_PATH:-${PWD}}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./lib/toolchain-env.sh
+source "${SCRIPT_DIR}/lib/toolchain-env.sh"
 
 if [ -n "${CARGO_TARGET_DIR:-}" ] || [ ! -f "${project_path}/Cargo.toml" ]; then
     printf '{}\n'
@@ -42,14 +46,18 @@ fi
 hash="$(hash_identity "$identity")"
 data_dir="${HOMEBOY_DATA_DIR:-${XDG_DATA_HOME:-${HOME}/.local/share}/homeboy}"
 target_dir="${data_dir}/cargo-targets/${label}-${hash:0:12}"
+toolchain_env_json="$(homeboy_rust_toolchain_env_json)"
 
-python3 - "$target_dir" <<'PY'
+python3 - "$target_dir" "$toolchain_env_json" <<'PY'
 import json
 import sys
 
 target_dir = sys.argv[1]
-print(json.dumps({
+toolchain_env = json.loads(sys.argv[2])
+env = {
     "CARGO_TARGET_DIR": target_dir,
     "HOMEBOY_CARGO_TARGET_DIR": target_dir,
-}))
+}
+env.update(toolchain_env)
+print(json.dumps(env))
 PY

--- a/rust/scripts/lib/toolchain-env.sh
+++ b/rust/scripts/lib/toolchain-env.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+
+# Rust-owned toolchain acceleration knobs. Homeboy core only asks the extension
+# for environment metadata; all Rust/Cargo/sccache/linker choices live here.
+
+homeboy_rust_truthy() {
+    case "${1:-}" in
+        1|true|TRUE|yes|YES|on|ON|auto|AUTO) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+homeboy_rust_setting() {
+    local setting_name="${1:?setting name is required}"
+    local expression="${2:-.$setting_name}"
+    local default_value="${3:-}"
+
+    if [ -z "${HOMEBOY_SETTINGS_JSON:-}" ] || ! command -v jq >/dev/null 2>&1; then
+        printf '%s' "$default_value"
+        return 0
+    fi
+
+    local value
+    value=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r "$expression" 2>/dev/null || true)
+    case "$value" in
+        ""|null) printf '%s' "$default_value" ;;
+        *) printf '%s' "$value" ;;
+    esac
+}
+
+homeboy_rust_sccache_request() {
+    if [ -n "${HOMEBOY_RUST_SCCACHE:-}" ]; then
+        printf '%s' "$HOMEBOY_RUST_SCCACHE"
+        return 0
+    fi
+
+    homeboy_rust_setting rust_sccache '.rust_sccache // .rust.sccache // false' 'false'
+}
+
+homeboy_rust_linker_request() {
+    if [ -n "${HOMEBOY_RUST_LINKER:-}" ]; then
+        printf '%s' "$HOMEBOY_RUST_LINKER"
+        return 0
+    fi
+
+    homeboy_rust_setting rust_linker '.rust_linker // .rust.linker // empty' ''
+}
+
+homeboy_rust_linker_supported() {
+    local linker="$1"
+    case "$linker" in
+        mold)
+            command -v mold >/dev/null 2>&1
+            ;;
+        lld)
+            command -v ld.lld >/dev/null 2>&1 || command -v lld >/dev/null 2>&1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+homeboy_rust_linker_flag() {
+    case "$1" in
+        mold) printf '%s' '-C link-arg=-fuse-ld=mold' ;;
+        lld) printf '%s' '-C link-arg=-fuse-ld=lld' ;;
+    esac
+}
+
+homeboy_rust_toolchain_env_json() {
+    local sccache_request sccache_status sccache_note
+    local linker_request linker_status linker_note linker_flag rustflags
+    local rustc_wrapper="${RUSTC_WRAPPER:-}"
+
+    sccache_request="$(homeboy_rust_sccache_request)"
+    sccache_status="off"
+    sccache_note=""
+    if homeboy_rust_truthy "$sccache_request"; then
+        if [ -n "$rustc_wrapper" ]; then
+            sccache_status="external"
+            sccache_note="RUSTC_WRAPPER was already set; the Rust extension did not override it."
+        elif command -v sccache >/dev/null 2>&1; then
+            rustc_wrapper="sccache"
+            sccache_status="enabled"
+        else
+            sccache_status="unavailable"
+            sccache_note="sccache was requested but is not on PATH."
+        fi
+    fi
+
+    linker_request="$(homeboy_rust_linker_request)"
+    linker_status="off"
+    linker_note=""
+    rustflags="${RUSTFLAGS:-}"
+    case "$linker_request" in
+        ""|off|OFF|none|NONE|false|FALSE|0)
+            ;;
+        mold|lld)
+            if homeboy_rust_linker_supported "$linker_request"; then
+                linker_flag="$(homeboy_rust_linker_flag "$linker_request")"
+                case " $rustflags " in
+                    *" $linker_flag "*) ;;
+                    *) rustflags="${rustflags:+$rustflags }$linker_flag" ;;
+                esac
+                linker_status="$linker_request"
+            else
+                linker_status="unavailable"
+                linker_note="${linker_request} linker was requested but no matching linker binary was found on PATH."
+            fi
+            ;;
+        *)
+            linker_status="unsupported"
+            linker_note="Unsupported HOMEBOY_RUST_LINKER value: ${linker_request}."
+            ;;
+    esac
+
+    python3 - "$rustc_wrapper" "$sccache_status" "$sccache_note" "$linker_status" "$linker_note" "$rustflags" <<'PY'
+import json
+import sys
+
+rustc_wrapper, sccache_status, sccache_note, linker_status, linker_note, rustflags = sys.argv[1:]
+env = {
+    "HOMEBOY_RUST_SCCACHE_STATUS": sccache_status,
+    "HOMEBOY_RUST_LINKER_STATUS": linker_status,
+}
+if rustc_wrapper:
+    env["RUSTC_WRAPPER"] = rustc_wrapper
+if rustflags:
+    env["RUSTFLAGS"] = rustflags
+if sccache_note:
+    env["HOMEBOY_RUST_SCCACHE_NOTE"] = sccache_note
+if linker_note:
+    env["HOMEBOY_RUST_LINKER_NOTE"] = linker_note
+print(json.dumps(env, sort_keys=True))
+PY
+}
+
+homeboy_rust_toolchain_metadata_json() {
+    python3 - <<'PY'
+import json
+import os
+
+metadata = {
+    "target_dir": os.environ.get("CARGO_TARGET_DIR") or os.environ.get("HOMEBOY_CARGO_TARGET_DIR") or "",
+    "sccache_status": os.environ.get("HOMEBOY_RUST_SCCACHE_STATUS", "external" if os.environ.get("RUSTC_WRAPPER") else "off"),
+    "linker_status": os.environ.get("HOMEBOY_RUST_LINKER_STATUS", "external" if "-fuse-ld=" in os.environ.get("RUSTFLAGS", "") else "off"),
+}
+if os.environ.get("RUSTC_WRAPPER"):
+    metadata["rustc_wrapper"] = os.environ["RUSTC_WRAPPER"]
+if os.environ.get("RUSTFLAGS"):
+    metadata["rustflags"] = os.environ["RUSTFLAGS"]
+if os.environ.get("HOMEBOY_RUST_SCCACHE_NOTE"):
+    metadata["sccache_note"] = os.environ["HOMEBOY_RUST_SCCACHE_NOTE"]
+if os.environ.get("HOMEBOY_RUST_LINKER_NOTE"):
+    metadata["linker_note"] = os.environ["HOMEBOY_RUST_LINKER_NOTE"]
+print(json.dumps(metadata, sort_keys=True))
+PY
+}

--- a/rust/tests/env-provider-smoke.sh
+++ b/rust/tests/env-provider-smoke.sh
@@ -28,6 +28,18 @@ target_dir_for() {
         | python3 -c 'import json,sys; print(json.load(sys.stdin).get("CARGO_TARGET_DIR", ""))'
 }
 
+env_for() {
+    local project="$1"
+    shift
+    env \
+        HOMEBOY_COMPONENT_ID=fixture \
+        HOMEBOY_COMPONENT_PATH="$project" \
+        HOMEBOY_EXTENSION_PATH="$EXTENSION_DIR" \
+        XDG_DATA_HOME="$WORK_DIR/data" \
+        "$@" \
+        "$EXTENSION_DIR/scripts/env-provider.sh"
+}
+
 primary="$WORK_DIR/primary"
 worktree="$WORK_DIR/worktree"
 explicit="$WORK_DIR/explicit-target"
@@ -62,6 +74,26 @@ explicit_output="$(
 )"
 if [ "$explicit_output" != '{}' ]; then
     printf 'Expected explicit CARGO_TARGET_DIR to suppress provider output, got %s\n' "$explicit_output" >&2
+    exit 1
+fi
+
+accel_output="$(
+    bin_dir="$WORK_DIR/bin"
+    mkdir -p "$bin_dir"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$bin_dir/sccache"
+    chmod +x "$bin_dir/sccache"
+    PATH="$bin_dir:$PATH" \
+        HOMEBOY_RUST_SCCACHE=1 \
+        env_for "$primary"
+)"
+
+if [ "$(printf '%s' "$accel_output" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("RUSTC_WRAPPER", ""))')" != "sccache" ]; then
+    printf 'Expected env provider to set RUSTC_WRAPPER=sccache, got %s\n' "$accel_output" >&2
+    exit 1
+fi
+
+if [ "$(printf '%s' "$accel_output" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("HOMEBOY_RUST_SCCACHE_STATUS", ""))')" != "enabled" ]; then
+    printf 'Expected sccache status enabled, got %s\n' "$accel_output" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Add Rust extension-owned sccache and linker acceleration settings via the Rust env provider.
- Document the official fast local Rust loop/profile and keep Rust/Cargo behavior out of Homeboy core.
- Surface active toolchain acceleration in Rust bench metadata using the existing generic BenchResults metadata contract.

Closes #1373.
Closes #1374.

## Testing
- `bash rust/tests/env-provider-smoke.sh`
- `bash rust/scripts/bench/rust-bench-smoke.sh`
- `bash -n rust/scripts/env-provider.sh rust/scripts/lib/toolchain-env.sh rust/scripts/bench/bench-runner.sh rust/tests/env-provider-smoke.sh rust/scripts/bench/rust-bench-smoke.sh`
- `python3 -m json.tool rust/rust.json >/dev/null`

## Contract notes
- Bench metadata is supported through the existing generic BenchResults metadata contract.
- There is still no generic Homeboy lint/test result metadata contract for extension-owned toolchain state, so the Rust extension documents that gap instead of adding Rust-specific behavior to core.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Rust extension env-provider/toolchain metadata changes and documentation; Chris remains responsible for review and merge.