### PR TITLE
Speed up Rust test targeting

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -50,6 +50,20 @@
   },
   "settings": [
     {
+      "id": "rust_test_runner",
+      "label": "Rust test runner",
+      "type": "string",
+      "default": "cargo",
+      "description": "Select the Rust extension test runner: cargo or nextest. Set HOMEBOY_RUST_TEST_RUNNER=nextest or configure this setting to use cargo nextest run."
+    },
+    {
+      "id": "rust_nextest_fallback",
+      "label": "Rust nextest fallback",
+      "type": "boolean",
+      "default": true,
+      "description": "When cargo-nextest is selected but unavailable, fall back to cargo test. Set false or HOMEBOY_RUST_NEXTEST_FALLBACK=0 to fail with an install diagnostic instead."
+    },
+    {
       "id": "bench_criterion",
       "label": "Criterion bench adapter",
       "type": "boolean",

--- a/rust/scripts/rust-changed-scope-smoke.sh
+++ b/rust/scripts/rust-changed-scope-smoke.sh
@@ -172,3 +172,85 @@ if [[ "$OUTPUT" != *"2 passed"* || "$OUTPUT" != *"1 passed"* ]]; then
     printf 'Expected full fallback to run top-level and inline tests. Output:\n%s\n' "$OUTPUT" >&2
     exit 1
 fi
+
+WORKSPACE_DIR="$WORKDIR/workspace"
+mkdir -p "$WORKSPACE_DIR/crates/targeted/src" "$WORKSPACE_DIR/crates/skipped/src"
+
+cat > "$WORKSPACE_DIR/Cargo.toml" <<'EOF'
+[workspace]
+members = ["crates/targeted", "crates/skipped"]
+resolver = "2"
+EOF
+
+cat > "$WORKSPACE_DIR/crates/targeted/Cargo.toml" <<'EOF'
+[package]
+name = "targeted-pkg"
+version = "0.1.0"
+edition = "2021"
+EOF
+
+cat > "$WORKSPACE_DIR/crates/targeted/src/lib.rs" <<'EOF'
+pub fn value() -> u8 {
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn targeted_package_runs() {
+        assert_eq!(super::value(), 1);
+    }
+}
+EOF
+
+cat > "$WORKSPACE_DIR/crates/skipped/Cargo.toml" <<'EOF'
+[package]
+name = "skipped-pkg"
+version = "0.1.0"
+edition = "2021"
+EOF
+
+cat > "$WORKSPACE_DIR/crates/skipped/src/lib.rs" <<'EOF'
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn skipped_package_would_fail() {
+        panic!("full workspace cargo test should not run this package");
+    }
+}
+EOF
+
+OUTPUT=$(
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$WORKSPACE_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_CHANGED_TEST_FILES='crates/targeted/src/lib.rs' \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    bash "$SCRIPT_DIR/test-runner.sh"
+)
+
+if [[ "$OUTPUT" != *"Rust test scope: Scoped to changed Cargo package: targeted-pkg."* ]]; then
+    printf 'Expected changed package scope. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+if [[ "$OUTPUT" != *"1 passed"* || "$OUTPUT" == *"full workspace cargo test should not run this package"* ]]; then
+    printf 'Expected package-scoped cargo test to avoid the failing sibling package. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+OUTPUT=$(
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_CHANGED_TEST_FILES='Cargo.toml' \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    bash "$SCRIPT_DIR/test-runner.sh"
+)
+
+if [[ "$OUTPUT" != *"Rust test scope fallback: Changed path is cross-cutting for Cargo: Cargo.toml"* ]]; then
+    printf 'Expected explicit Cargo.toml fallback. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi

--- a/rust/scripts/rust-nextest-runner-smoke.sh
+++ b/rust/scripts/rust-nextest-runner-smoke.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PROJECT_DIR="$WORKDIR/project"
+HELPER_DIR="$WORKDIR/helpers"
+BIN_DIR="$WORKDIR/bin"
+SIDECAR_DIR="$WORKDIR/sidecars"
+mkdir -p "$PROJECT_DIR/tests" "$HELPER_DIR" "$BIN_DIR" "$SIDECAR_DIR"
+
+cat > "$PROJECT_DIR/Cargo.toml" <<'EOF'
+[package]
+name = "rust-nextest-smoke"
+version = "0.1.0"
+edition = "2021"
+EOF
+
+cat > "$PROJECT_DIR/tests/integration_scope.rs" <<'EOF'
+#[test]
+fn integration_scope_runs() {
+    assert_eq!(1, 1);
+}
+EOF
+
+cat > "$HELPER_DIR/resolve-context.sh" <<'EOF'
+homeboy_resolve_context() {
+    PROJECT_PATH="${HOMEBOY_COMPONENT_PATH}"
+    EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH}"
+}
+EOF
+
+cat > "$HELPER_DIR/runner-steps.sh" <<'EOF'
+should_run_step() {
+    return 0
+}
+EOF
+
+cat > "$HELPER_DIR/sidecar-writer.sh" <<'EOF'
+homeboy_sidecar_merge() {
+    local target="$1"
+    local source="$2"
+    local safe_target="${target//[^A-Za-z0-9_.-]/_}"
+    cp "$source" "${HOMEBOY_SIDECAR_DIR}/${safe_target}.json"
+}
+EOF
+
+cat > "$BIN_DIR/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "nextest" ] && [ "${2:-}" = "--version" ]; then
+    echo "cargo-nextest 0.9.0"
+    exit 0
+fi
+
+printf '%s\n' "$@" > "${HOMEBOY_FAKE_CARGO_ARGS}"
+echo "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out"
+EOF
+chmod +x "$BIN_DIR/cargo"
+
+OUTPUT=$(
+    PATH="$BIN_DIR:$PATH" \
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_RUST_TEST_RUNNER=nextest \
+    HOMEBOY_CHANGED_TEST_FILES='tests/integration_scope.rs' \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    HOMEBOY_RUNTIME_SIDECAR_WRITER="$HELPER_DIR/sidecar-writer.sh" \
+    HOMEBOY_SIDECAR_DIR="$SIDECAR_DIR" \
+    HOMEBOY_FAKE_CARGO_ARGS="$WORKDIR/cargo-args.txt" \
+    bash "$SCRIPT_DIR/test-runner.sh"
+)
+
+if [[ "$OUTPUT" != *"Running cargo nextest"* ]]; then
+    printf 'Expected nextest runner selection. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+EXPECTED_ARGS=$'nextest\nrun\n--manifest-path\n'"$PROJECT_DIR"$'/Cargo.toml\n-p\nrust-nextest-smoke\n--test\nintegration_scope'
+ACTUAL_ARGS="$(cat "$WORKDIR/cargo-args.txt")"
+if [ "$ACTUAL_ARGS" != "$EXPECTED_ARGS" ]; then
+    printf 'Expected nextest command shape:\n%s\nActual:\n%s\n' "$EXPECTED_ARGS" "$ACTUAL_ARGS" >&2
+    exit 1
+fi
+
+if [ ! -f "$SIDECAR_DIR/test.results.json" ]; then
+    printf 'Expected test.results sidecar metadata. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+python3 - "$SIDECAR_DIR/test.results.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+
+record = data[0]
+assert record["runner"] == "nextest", record
+assert record["scope"] == "file", record
+assert record["package"] == "rust-nextest-smoke", record
+assert record["test_target"] == "integration_scope", record
+assert record["args"] == ["-p", "rust-nextest-smoke", "--test", "integration_scope"], record
+PY
+
+cat > "$BIN_DIR/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "nextest" ] && [ "${2:-}" = "--version" ]; then
+    exit 1
+fi
+
+echo "unexpected cargo invocation: $*" >&2
+exit 2
+EOF
+chmod +x "$BIN_DIR/cargo"
+
+OUTPUT=$(
+    PATH="$BIN_DIR:$PATH" \
+    HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
+    HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
+    HOMEBOY_SKIP_LINT=1 \
+    HOMEBOY_RUST_TEST_RUNNER=nextest \
+    HOMEBOY_RUST_NEXTEST_FALLBACK=0 \
+    HOMEBOY_CHANGED_TEST_FILES='tests/integration_scope.rs' \
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
+    bash "$SCRIPT_DIR/test-runner.sh" 2>&1 || true
+)
+
+if [[ "$OUTPUT" != *"Error: cargo-nextest requested but not available."* ]]; then
+    printf 'Expected actionable missing nextest diagnostic. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+echo "rust nextest runner smoke ok"

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -19,11 +19,271 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMMAND_CAPTURE_HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-${SCRIPT_DIR}/lib/command-capture.sh}"
 RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/lib/runner-prelude.sh}"
+SETTINGS_HELPER="${SCRIPT_DIR}/lib/settings.sh"
 # shellcheck source=/dev/null
 source "$RUNNER_PRELUDE"
 homeboy_runner_init --steps --failure-trap --sidecar-writer
 # shellcheck source=./lib/command-capture.sh
 source "${COMMAND_CAPTURE_HELPER}"
+# shellcheck source=./lib/settings.sh
+source "${SETTINGS_HELPER}"
+
+rust_test_runner() {
+    case "${HOMEBOY_RUST_TEST_RUNNER:-$(homeboy_setting rust_test_runner '.rust_test_runner // .test_runner' cargo)}" in
+        nextest|cargo-nextest|cargo_nextest)
+            printf 'nextest'
+            ;;
+        *)
+            printf 'cargo'
+            ;;
+    esac
+}
+
+rust_nextest_fallback_enabled() {
+    if [ -n "${HOMEBOY_RUST_NEXTEST_FALLBACK:-}" ]; then
+        case "${HOMEBOY_RUST_NEXTEST_FALLBACK}" in
+            1|true|TRUE|yes|YES|on|ON) return 0 ;;
+            *) return 1 ;;
+        esac
+    fi
+
+    [ "$(homeboy_setting_bool rust_nextest_fallback true '.rust_nextest_fallback // .nextest_fallback')" = "true" ]
+}
+
+rust_resolve_changed_scope_json() {
+    python3 - "$PROJECT_PATH" "${HOMEBOY_CHANGED_TEST_FILES:-}" "${HOMEBOY_TEST_RUNNER_ARGS:-}" <<'PY'
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+project = Path(sys.argv[1]).resolve()
+changed_raw = sys.argv[2]
+runner_args_raw = sys.argv[3]
+
+
+def cargo_package_name(manifest: Path):
+    try:
+        try:
+            import tomllib
+            data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+            package = data.get("package") if isinstance(data, dict) else None
+            name = package.get("name") if isinstance(package, dict) else None
+            return str(name) if name else None
+        except Exception:
+            text = manifest.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    in_package = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == "[package]":
+            in_package = True
+            continue
+        if stripped.startswith("[") and stripped != "[package]":
+            in_package = False
+        if in_package:
+            match = re.match(r'name\s*=\s*["\']([^"\']+)["\']', stripped)
+            if match:
+                return match.group(1)
+    return None
+
+
+def nearest_manifest(path: Path):
+    current = path if path.is_dir() else path.parent
+    while True:
+        if project not in [current, *current.parents]:
+            return None
+        manifest = current / "Cargo.toml"
+        if manifest.exists():
+            return manifest
+        if current == project:
+            return None
+        current = current.parent
+
+
+changed = []
+for raw in changed_raw.splitlines():
+    raw = raw.strip()
+    if not raw:
+        continue
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        try:
+            rel = candidate.resolve().relative_to(project)
+        except ValueError:
+            print(json.dumps({
+                "kind": "fallback",
+                "reason": f"Changed path is outside the Cargo project: {raw}",
+                "args": [],
+                "package": None,
+                "test_target": None,
+            }))
+            sys.exit(0)
+    else:
+        rel = candidate
+    changed.append(rel)
+
+existing_args = [line for line in runner_args_raw.splitlines() if line]
+if not changed:
+    print(json.dumps({
+        "kind": "workspace",
+        "reason": "No changed-file scope was provided; running the default Cargo test command.",
+        "args": existing_args,
+        "package": None,
+        "test_target": None,
+    }))
+    sys.exit(0)
+
+cross_cutting_names = {"Cargo.toml", "Cargo.lock", "rust-toolchain", "rust-toolchain.toml", "build.rs"}
+cross_cutting_dirs = {".cargo"}
+packages = {}
+test_target = None
+
+for rel in changed:
+    parts = rel.parts
+    if not parts:
+        continue
+    if parts[0] in cross_cutting_dirs or rel.name in cross_cutting_names:
+        print(json.dumps({
+            "kind": "fallback",
+            "reason": f"Changed path is cross-cutting for Cargo: {rel.as_posix()}",
+            "args": existing_args,
+            "package": None,
+            "test_target": None,
+        }))
+        sys.exit(0)
+
+    absolute = (project / rel).resolve()
+    manifest = nearest_manifest(absolute)
+    if manifest is None:
+        print(json.dumps({
+            "kind": "fallback",
+            "reason": f"Changed path is not inside a Cargo package: {rel.as_posix()}",
+            "args": existing_args,
+            "package": None,
+            "test_target": None,
+        }))
+        sys.exit(0)
+
+    package = cargo_package_name(manifest)
+    if not package:
+        print(json.dumps({
+            "kind": "fallback",
+            "reason": f"Could not resolve Cargo package name for {rel.as_posix()}",
+            "args": existing_args,
+            "package": None,
+            "test_target": None,
+        }))
+        sys.exit(0)
+
+    packages[package] = manifest
+
+    try:
+        package_rel = absolute.relative_to(manifest.parent)
+    except ValueError:
+        package_rel = rel
+    package_parts = package_rel.parts
+    if len(changed) == 1 and len(package_parts) == 2 and package_parts[0] == "tests" and package_rel.suffix == ".rs":
+        test_target = package_rel.stem
+
+if len(packages) != 1:
+    print(json.dumps({
+        "kind": "fallback",
+        "reason": "Changed files span multiple Cargo packages; running the default Cargo test command.",
+        "args": existing_args,
+        "package": None,
+        "test_target": None,
+    }))
+    sys.exit(0)
+
+package = next(iter(packages))
+args = ["-p", package]
+if test_target and not existing_args:
+    args.extend(["--test", test_target])
+args.extend(existing_args)
+
+if test_target and not existing_args:
+    kind = "file"
+    reason = f"Scoped to changed integration test target: {test_target} in package {package}."
+else:
+    kind = "package"
+    reason = f"Scoped to changed Cargo package: {package}."
+
+print(json.dumps({
+    "kind": kind,
+    "reason": reason,
+    "args": args,
+    "package": package,
+    "test_target": test_target,
+}))
+PY
+}
+
+rust_append_scope_args() {
+    local scope_json="$1"
+    while IFS= read -r scope_arg; do
+        [ -n "$scope_arg" ] || continue
+        TEST_ARGS+=("$scope_arg")
+    done < <(printf '%s' "$scope_json" | jq -r '.args[]?')
+}
+
+rust_nextest_args_from_cargo_args() {
+    local saw_separator=0
+    for scope_arg in "${TEST_ARGS[@]:3}"; do
+        if [ "$scope_arg" = "--" ]; then
+            saw_separator=1
+            continue
+        fi
+        NEXTEST_ARGS+=("$scope_arg")
+    done
+    [ "$saw_separator" -eq 0 ] || return 0
+}
+
+rust_emit_test_plan() {
+    local runner="$1"
+    local runner_command="$2"
+    local scope_json="$3"
+    local status="$4"
+    local exit_code="${5:-0}"
+    local plan_tmp
+
+    if ! type homeboy_sidecar_merge >/dev/null 2>&1; then
+        return 0
+    fi
+
+    plan_tmp="$(mktemp)"
+    python3 - "$runner" "$runner_command" "$scope_json" "$status" "$exit_code" "$plan_tmp" <<'PY'
+import json
+import sys
+
+runner, command, scope_raw, status, exit_code, target = sys.argv[1:]
+try:
+    scope = json.loads(scope_raw)
+except json.JSONDecodeError:
+    scope = {"kind": "workspace", "reason": "Scope metadata was not available.", "args": []}
+
+record = {
+    "type": "rust-test-command",
+    "runner": runner,
+    "command": command,
+    "scope": scope.get("kind") or "workspace",
+    "scope_reason": scope.get("reason") or "",
+    "package": scope.get("package"),
+    "test_target": scope.get("test_target"),
+    "args": scope.get("args") or [],
+    "status": status,
+    "exit_code": int(exit_code or 0),
+}
+with open(target, "w", encoding="utf-8") as handle:
+    json.dump([record], handle, indent=2)
+    handle.write("\n")
+PY
+    homeboy_sidecar_merge test.results "$plan_tmp" || true
+    rm -f "$plan_tmp"
+}
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Rust Test Environment:"
@@ -178,7 +438,33 @@ print(json.dumps(result, indent=2))
     fi
 fi
 
-echo "Running cargo test..."
+SELECTED_RUNNER="$(rust_test_runner)"
+SCOPE_JSON="$(rust_resolve_changed_scope_json)"
+SCOPE_KIND="$(printf '%s' "$SCOPE_JSON" | jq -r '.kind // "workspace"')"
+SCOPE_REASON="$(printf '%s' "$SCOPE_JSON" | jq -r '.reason // empty')"
+
+if [ "$SCOPE_KIND" = "fallback" ]; then
+    echo "Rust test scope fallback: ${SCOPE_REASON}"
+elif [ -n "$SCOPE_REASON" ]; then
+    echo "Rust test scope: ${SCOPE_REASON}"
+fi
+
+if [ "$SELECTED_RUNNER" = "nextest" ]; then
+    if cargo nextest --version >/dev/null 2>&1; then
+        echo "Running cargo nextest..."
+    elif rust_nextest_fallback_enabled; then
+        echo "WARNING: cargo-nextest requested but not available; falling back to cargo test."
+        echo "  Install: cargo install cargo-nextest"
+        SELECTED_RUNNER="cargo"
+    else
+        echo "Error: cargo-nextest requested but not available."
+        echo "Install it with: cargo install cargo-nextest"
+        rust_emit_test_plan "nextest" "cargo nextest run" "$SCOPE_JSON" "missing-runner" 127
+        exit 127
+    fi
+else
+    echo "Running cargo test..."
+fi
 
 TEST_ARGS=(
     test
@@ -189,18 +475,28 @@ if [ -n "${HOMEBOY_TEST_SCOPE_MESSAGE:-}" ]; then
     echo "$HOMEBOY_TEST_SCOPE_MESSAGE"
 fi
 
-if [ -n "${HOMEBOY_TEST_RUNNER_ARGS:-}" ]; then
-    while IFS= read -r scope_arg; do
-        [ -n "$scope_arg" ] || continue
-        TEST_ARGS+=("$scope_arg")
-    done <<< "$HOMEBOY_TEST_RUNNER_ARGS"
+rust_append_scope_args "$SCOPE_JSON"
+
+COMMAND_LABEL="cargo test"
+COMMAND_BINARY=(cargo "${TEST_ARGS[@]}")
+
+if [ "$SELECTED_RUNNER" = "nextest" ]; then
+    NEXTEST_ARGS=(
+        run
+        --manifest-path "${PROJECT_PATH}/Cargo.toml"
+    )
+    rust_nextest_args_from_cargo_args
+    COMMAND_LABEL="cargo nextest run"
+    COMMAND_BINARY=(cargo nextest "${NEXTEST_ARGS[@]}")
 fi
 
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
-    echo "DEBUG: cargo ${TEST_ARGS[*]} $*"
+    echo "DEBUG: ${COMMAND_BINARY[*]} $*"
 fi
 
-homeboy_run_step_capture TEST_TMPFILE TEST_EXIT "cargo test" -- cargo "${TEST_ARGS[@]}" "$@" || true
+rust_emit_test_plan "$SELECTED_RUNNER" "$COMMAND_LABEL" "$SCOPE_JSON" "started" 0
+homeboy_run_step_capture TEST_TMPFILE TEST_EXIT "$COMMAND_LABEL" -- "${COMMAND_BINARY[@]}" "$@" || true
+rust_emit_test_plan "$SELECTED_RUNNER" "$COMMAND_LABEL" "$SCOPE_JSON" "completed" "$TEST_EXIT"
 
 # Parse test results for homeboy core (best-effort, non-blocking)
 PARSE_RESULTS="${EXTENSION_PATH}/scripts/parse-test-results.sh"
@@ -298,7 +594,7 @@ PY
         rm -f "$TEST_FAILURES_TMP"
     fi
 
-    FAILED_STEP="cargo test"
+    FAILED_STEP="$COMMAND_LABEL"
     FAILURE_REPLAY_MODE="none"
     rm -f "$TEST_TMPFILE"
     exit $TEST_EXIT
@@ -319,7 +615,7 @@ if [ "$TOTAL_PASSED" -eq 0 ]; then
         echo "Found ${TEST_FILE_COUNT} test files but no tests were executed."
         echo "This may indicate a configuration issue."
         if [ -n "${HOMEBOY_CHANGED_TEST_FILES:-}" ]; then
-            FAILED_STEP="cargo test"
+            FAILED_STEP="$COMMAND_LABEL"
             FAILURE_REPLAY_MODE="none"
             rm -f "$TEST_TMPFILE"
             exit 1


### PR DESCRIPTION
## Summary
- Resolve Rust changed-file scope inside the Rust extension into conservative Cargo package/test args.
- Add opt-in `cargo nextest run` support via Rust extension settings/env, with configurable missing-runner fallback.
- Record Rust runner/scope/command metadata in `test.results` sidecar output when the generic sidecar helper is available.

Fixes #1371.
Fixes #1372.

## Verification
- `bash -n rust/scripts/test-runner.sh rust/scripts/rust-changed-scope-smoke.sh rust/scripts/rust-nextest-runner-smoke.sh`
- `bash rust/scripts/rust-changed-scope-smoke.sh`
- `bash rust/scripts/rust-nextest-runner-smoke.sh`
- `bash rust/scripts/rust-runner-steps-direct-smoke.sh`
- `git diff --check`

## Notes
- `homeboy test --changed-since origin/main --skip-lint rust` was not usable for this worktree without mutating local Homeboy extension/component config: Homeboy resolved `rust` as a component with no configured provider, while the installed Rust extension points at `~/.config/homeboy/extensions/rust` rather than this checkout.
- No Homeboy core changes were needed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Rust extension runner changes, smoke coverage, local verification, and PR drafting for Chris to review.