### PR TITLE
fix: declare WordPress release token preflight

### DIFF
--- a/wordpress/scripts/release/preflight-publish-token.sh
+++ b/wordpress/scripts/release/preflight-publish-token.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  jq -cn '{success:false,status:"missing_tool",reason:"gh CLI is required to publish WordPress release assets and mirror branches."}'
+  exit 0
+fi
+
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  jq -cn '{success:true,token_source:"GH_TOKEN"}'
+  exit 0
+fi
+
+if gh auth token >/dev/null 2>&1; then
+  jq -cn '{success:true,token_source:"gh auth token"}'
+  exit 0
+fi
+
+jq -cn '{success:false,status:"missing_secret",reason:"GH_TOKEN is required to push the WordPress release-latest mirror. Set GH_TOKEN with `export GH_TOKEN=\"$(gh auth token)\"`, or run `gh auth login` and rerun the release."}'

--- a/wordpress/scripts/release/publish.sh
+++ b/wordpress/scripts/release/publish.sh
@@ -101,6 +101,18 @@ apply_github_host_env() {
   done < <(echo "${PAYLOAD}" | jq -r --arg host "${host}" '.config.github.hosts[$host].env // {} | to_entries[] | [.key, .value] | @tsv')
 }
 
+resolve_github_token() {
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    return 0
+  fi
+
+  local token=""
+  token="$(gh auth token 2>/dev/null || true)"
+  if [[ -n "${token}" ]]; then
+    export GH_TOKEN="${token}"
+  fi
+}
+
 if ! command -v gh >/dev/null 2>&1; then
   echo "Error: gh CLI is required to upload release assets" >&2
   exit 1
@@ -167,6 +179,7 @@ if [[ -z "${REPO_SLUG}" ]]; then
 fi
 
 apply_github_host_env "${GITHUB_HOST}"
+resolve_github_token
 
 # Assert the artifact's internal version matches the release tag before
 # uploading. This is the last chokepoint before a ZIP becomes the GitHub

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1106,7 +1106,25 @@
       "description": "Component-relative glob patterns for intentional package ZIP artifacts that should be included in the production build even though arbitrary *.zip files are excluded by default. Each declared pattern must match at least one file."
     }
   ],
+  "release_preflights": [
+    {
+      "id": "publish_token",
+      "label": "Validate WordPress release publish token",
+      "action": "release.preflight.publish-token",
+      "needs": ["preflight.bump_policy"]
+    }
+  ],
   "actions": [
+    {
+      "id": "release.preflight.publish-token",
+      "label": "Validate WordPress release publish token",
+      "type": "command",
+      "command": "bash \"{{extension_path}}/scripts/release/preflight-publish-token.sh\"",
+      "payload": {
+        "release": "{{payload.release}}",
+        "config": "{{payload.config}}"
+      }
+    },
     {
       "id": "release.package",
       "label": "Build WordPress plugin/theme ZIP",


### PR DESCRIPTION
## Summary
- Declares WordPress publish-token validation via the new Homeboy `release_preflights` manifest contract.
- Adds a WordPress-owned preflight script that validates `GH_TOKEN` or `gh auth token` availability without requiring Homeboy core to know about WordPress.
- Keeps publish behavior working after Homeboy removes core token injection by resolving `GH_TOKEN` from `gh auth token` inside the WordPress publish script when needed.

## Related
- Depends on https://github.com/Extra-Chill/homeboy/pull/4470
- Part of https://github.com/Extra-Chill/homeboy/issues/4434
- Parent tracker: https://github.com/Extra-Chill/homeboy/issues/4303

## Tests
- `jq empty wordpress/wordpress.json`
- `bash -n wordpress/scripts/release/preflight-publish-token.sh && bash -n wordpress/scripts/release/publish.sh`
- `GH_TOKEN=dummy wordpress/scripts/release/preflight-publish-token.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the WordPress extension manifest declaration and release-token scripts; Chris remains responsible for review and merge.