### PR TITLE
Declare WordPress trace toolchain provenance

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -919,7 +919,15 @@
     "extension_script": "scripts/bench/bench-runner.sh"
   },
   "trace": {
-    "extension_script": "scripts/trace/trace-runner.sh"
+    "extension_script": "scripts/trace/trace-runner.sh",
+    "toolchain_provenance": [
+      {
+        "id": "wp-codebox",
+        "label": "WP Codebox",
+        "legacy_field": "wp_codebox",
+        "env_keys": ["HOMEBOY_WP_CODEBOX_BIN", "HOMEBOY_SETTINGS_WP_CODEBOX_BIN"]
+      }
+    ]
   },
   "testing": {
     "backend": "wp-codebox",


### PR DESCRIPTION
## Summary
- Declare the WP Codebox trace toolchain provenance env keys in the WordPress extension manifest.
- Preserve current WP Codebox canonical trace behavior through manifest metadata owned by the extension.

## Context
- Pairs with Extra-Chill/homeboy#4473 for Extra-Chill/homeboy#4438.
- Parent tracker: Extra-Chill/homeboy#4303.
- Related operational tracker: Extra-Chill/homeboy#4140.

## Testing
- `jq empty wordpress/wordpress.json`
- `git diff --check HEAD~1..HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the manifest declaration that keeps WP Codebox-specific provenance outside Homeboy core; Chris requested and will review/own the final change.