### PR TITLE
Declare WordPress test result parser adapter

### DIFF
--- a/wordpress/scripts/test/parse-test-results.sh
+++ b/wordpress/scripts/test/parse-test-results.sh
@@ -22,6 +22,7 @@ OUTPUT_FILE="${1:-}"
 if [ -z "$OUTPUT_FILE" ]; then
     exit 0
 fi
+shift || true
 
 if [ -d "$OUTPUT_FILE" ] && [ -f "$OUTPUT_FILE/files/test-results.json" ]; then
     OUTPUT_FILE="$OUTPUT_FILE/files/test-results.json"
@@ -40,4 +41,8 @@ fi
 ADAPTERS_HELPER="${HOMEBOY_RUNTIME_TEST_RESULT_ADAPTERS:-${SCRIPT_DIR}/../lib/test-result-adapters.sh}"
 # shellcheck source=../lib/test-result-adapters.sh
 source "$ADAPTERS_HELPER"
-homeboy_parse_test_results_with_adapters "$OUTPUT_FILE" wp-codebox-json host-smoke phpunit phpunit-testdox
+if [ "$#" -gt 0 ]; then
+    homeboy_parse_test_results_with_adapters "$OUTPUT_FILE" "$@"
+else
+    homeboy_parse_test_results_with_adapters "$OUTPUT_FILE" wp-codebox-json host-smoke phpunit phpunit-testdox
+fi

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -900,6 +900,10 @@
     ]
   },
   "test": {
+    "result_parse": {
+      "extension_script": "scripts/test/parse-test-results.sh",
+      "adapters": ["wp-codebox-json"]
+    },
     "changed_file_routing": {
       "strategy": "exclusive_env",
       "exclusive_env": {


### PR DESCRIPTION
## Summary
- Declare the WordPress test result parser script through `test.result_parse.extension_script`.
- Declare the `wp-codebox-json` adapter in the WordPress extension manifest.
- Let `parse-test-results.sh` honor adapter names passed by Homeboy while preserving the current default adapter list for direct/manual invocations.

## Tracking
- Supports https://github.com/Extra-Chill/homeboy/issues/4437
- Requires Homeboy parser contract PR: https://github.com/Extra-Chill/homeboy/pull/4474

## Tests
- `node -e "JSON.parse(require('fs').readFileSync('wordpress/wordpress.json','utf8')); console.log('wordpress.json ok')"`
- `bash wordpress/scripts/test/parse-wp-codebox-artifacts-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementation, focused test updates, and PR description drafting; Chris remains responsible for review and merge decisions.