### PR TITLE
Declare Codebox agent task role aliases

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -120,6 +120,21 @@ const LEGACY_BUNDLE_KEYS = [
 
 const WP_CODEBOX_RUNTIME_GAP_TRACKERS = [];
 
+const WP_CODEBOX_ROLE_ALIASES = {
+  artifact_kinds: {
+    patch: ['codebox-patch'],
+  },
+  artifact_filenames: {
+    preflight_evidence: ['homeboy-codebox-task-runner.json'],
+  },
+  outputs: {
+    provider_run_result: ['codebox_run_result'],
+  },
+  metadata: {
+    provider_run_result: ['codebox_run_result'],
+  },
+};
+
 const AGENT_TASK_OUTCOME_STATUSES = [
   'succeeded',
   'failed',
@@ -170,6 +185,7 @@ function providerContract(options = {}) {
     workspace_materialization: {
       cwd: 'git_checkout',
     },
+    role_aliases: WP_CODEBOX_ROLE_ALIASES,
     status: 'active',
     integration_contract: 'wp-codebox-cli/agent-task-run',
     runtime_gap_trackers: WP_CODEBOX_RUNTIME_GAP_TRACKERS,

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -256,6 +256,20 @@ assert.deepEqual(provider.outcome_statuses, ['succeeded', 'failed', 'no_op', 'un
 assert.deepEqual(provider.failure_classifications, ['provider', 'timeout', 'execution_failed']);
 assert.deepEqual(provider.redacted_metadata_keys, ['secret_env_values', 'secretEnvValues', 'secrets']);
 assert.deepEqual(provider.workspace_materialization, { cwd: 'git_checkout' });
+assert.deepEqual(provider.role_aliases, {
+  artifact_kinds: {
+    patch: ['codebox-patch'],
+  },
+  artifact_filenames: {
+    preflight_evidence: ['homeboy-codebox-task-runner.json'],
+  },
+  outputs: {
+    provider_run_result: ['codebox_run_result'],
+  },
+  metadata: {
+    provider_run_result: ['codebox_run_result'],
+  },
+});
 assert.equal(provider.status, 'active');
 assert.equal(provider.integration_contract, 'wp-codebox-cli/agent-task-run');
 assert.equal(provider.capabilities.includes('browser_runtime'), true);

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -68,6 +68,20 @@
       "workspace_materialization": {
         "cwd": "git_checkout"
       },
+      "role_aliases": {
+        "artifact_kinds": {
+          "patch": ["codebox-patch"]
+        },
+        "artifact_filenames": {
+          "preflight_evidence": ["homeboy-codebox-task-runner.json"]
+        },
+        "outputs": {
+          "provider_run_result": ["codebox_run_result"]
+        },
+        "metadata": {
+          "provider_run_result": ["codebox_run_result"]
+        }
+      },
       "status": "active",
       "integration_contract": "wp-codebox-cli/agent-task-run",
       "runtime_gap_trackers": []


### PR DESCRIPTION
## Summary
- Declare Codebox agent-task artifact/result aliases in the WordPress extension provider manifest.
- Keep `providerContract()` aligned with `wordpress.json` so discovery and direct contract consumers expose the same role aliases.
- Cover the Codebox alias contract in the existing smoke test.

## Testing
- `node tests/codebox-agent-task-executor-smoke.js`

## Links
- Companion to Extra-Chill/homeboy#4475
- Supports Extra-Chill/homeboy#4435
- Parent tracker: Extra-Chill/homeboy#4303

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Adding provider-declared Codebox role aliases and smoke-test coverage. Chris reviewed and owns the final submission.