### PR TITLE
fix: prepare Composer autoload for WP Codebox tests

### DIFF
--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -369,6 +369,41 @@ apply_phpunit_component_prepare_profile() {
     esac
 }
 
+component_needs_composer_autoload_prepare() {
+    [ -f "${PLUGIN_PATH}/composer.json" ] || return 1
+    [ ! -f "${PLUGIN_PATH}/vendor/autoload.php" ] || return 1
+
+    local settings_json="${HOMEBOY_SETTINGS_JSON:-}"
+    [ -n "$settings_json" ] || settings_json="{}"
+    local mode
+    mode=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_composer_prepare // "auto"' 2>/dev/null || printf 'auto')
+
+    case "$mode" in
+        0|false|off|skip|disabled)
+            return 1
+            ;;
+        1|true|on|auto|enabled)
+            return 0
+            ;;
+        *)
+            echo "Error: wp_codebox_composer_prepare must be auto, true, or false (got '$mode')." >&2
+            FAILED_STEP="WP Codebox Composer prepare setup"
+            exit 1
+            ;;
+    esac
+}
+
+append_phpunit_component_composer_prepare_step() {
+    component_needs_composer_autoload_prepare || return 0
+
+    WP_CODEBOX_PREPARE_STEPS_JSON=$(jq -nc \
+        --argjson steps "$WP_CODEBOX_PREPARE_STEPS_JSON" \
+        '$steps + [{
+            command: "composer",
+            args: ["install", "--no-interaction", "--no-progress", "--prefer-dist"]
+        }]')
+}
+
 phpunit_prepare_step_cwd() {
     local cwd_ref="${1:-}"
     local cwd_host
@@ -485,6 +520,7 @@ run_phpunit_prepare_steps() {
 }
 
 compile_phpunit_prepare_steps
+append_phpunit_component_composer_prepare_step
 apply_phpunit_component_prepare_profile
 
 detect_phpunit_project_bootstrap() {

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -13,7 +13,9 @@ REMOTE_DEP_PATH="${TMPDIR}/remote/dep-plugin"
 FAKE_WP_CODEBOX="${TMPDIR}/wp-codebox.js"
 ARGS_FILE="${TMPDIR}/wp-codebox-args.txt"
 ARTIFACTS_DIR="${TMPDIR}/artifacts"
-mkdir -p "${PLUGIN_PATH}/tests" "${PLUGIN_PATH}/config" "${DEP_PATH}/fixtures" "${REMOTE_DEP_PATH}/fixtures" "$ARTIFACTS_DIR"
+STUBS_DIR="${TMPDIR}/stubs"
+COMPOSER_LOG="${TMPDIR}/composer.log"
+mkdir -p "${PLUGIN_PATH}/tests" "${PLUGIN_PATH}/config" "${DEP_PATH}/fixtures" "${REMOTE_DEP_PATH}/fixtures" "$ARTIFACTS_DIR" "$STUBS_DIR"
 
 cat > "${PLUGIN_PATH}/tests/OnlyTest.php" <<'PHP'
 <?php
@@ -22,10 +24,22 @@ PHP
 printf '<?php // component drop-in\n' > "${PLUGIN_PATH}/db.php"
 printf '<?php /*\nPlugin Name: Example\nNetwork: true\n*/\n' > "${PLUGIN_PATH}/example.php"
 printf 'component-extra\n' > "${PLUGIN_PATH}/config/component-extra.php"
+cat > "${PLUGIN_PATH}/composer.json" <<'JSON'
+{"autoload":{"psr-4":{"Example\\":"src/"}}}
+JSON
 printf '<?php /*\nPlugin Name: Dep Plugin\n*/\n' > "${DEP_PATH}/dep-plugin.php"
 printf 'dependency-extra\n' > "${DEP_PATH}/fixtures/dep-extra.php"
 printf '<?php /*\nPlugin Name: Dep Plugin Remote Lab Copy\n*/\n' > "${REMOTE_DEP_PATH}/dep-plugin.php"
 printf 'remote dependency-extra\n' > "${REMOTE_DEP_PATH}/fixtures/dep-extra.php"
+
+cat > "${STUBS_DIR}/composer" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${COMPOSER_LOG:?}"
+mkdir -p vendor
+printf '<?php // prepared autoload\n' > vendor/autoload.php
+SH
+chmod +x "${STUBS_DIR}/composer"
 
 cat > "$FAKE_WP_CODEBOX" <<'NODE'
 #!/usr/bin/env node
@@ -127,6 +141,9 @@ if (!componentMount) {
   throw new Error('component mount missing')
 }
 const componentPath = componentMount.slice(0, -':/wordpress/wp-content/plugins/example'.length)
+if (!fs.existsSync(path.join(componentPath, 'vendor/autoload.php'))) {
+  throw new Error(`component Composer autoload was not prepared before mount: ${componentPath}`)
+}
 fs.writeFileSync(path.join(componentPath, '.pg-test-result.txt'), [
   'STAGE_BEGIN:run_tests',
   'ALL TESTS PASSED',
@@ -189,6 +206,8 @@ LAB_OFFLOAD_JSON=$(jq -nc \
 bash -n "$SCRIPT_DIR/test-runner-wp-codebox.sh"
 
 output=$(FAKE_WP_CODEBOX_ARGS_FILE="$ARGS_FILE" \
+    COMPOSER_LOG="$COMPOSER_LOG" \
+    PATH="${STUBS_DIR}:${PATH}" \
     HOMEBOY_WP_CODEBOX_BIN="$FAKE_WP_CODEBOX" \
     HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
     HOMEBOY_COMPONENT_PATH="$PLUGIN_PATH" \
@@ -208,6 +227,12 @@ fi
 
 if [ ! -s "$ARGS_FILE" ]; then
     echo "Expected fake wp-codebox to capture arguments" >&2
+    exit 1
+fi
+
+if ! grep -q -- 'install --no-interaction --no-progress --prefer-dist' "$COMPOSER_LOG"; then
+    echo "Expected WP Codebox runner to prepare missing component Composer autoload" >&2
+    cat "$COMPOSER_LOG" >&2 || true
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- automatically add a Composer install prepare step for WP Codebox PHPUnit runs when a component has `composer.json` but no `vendor/autoload.php`
- keep the behavior configurable with `wp_codebox_composer_prepare=false` for callers that intentionally manage the autoload another way
- extend the WP Codebox mount smoke to prove the component autoload exists before the fake runtime sees the mounted plugin

Fixes #1383.

## Testing
- `bash wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh && bash -n wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `git diff --check`

Note: `homeboy lint homeboy-extensions --path /Users/chubes/Developer/homeboy-extensions@fix-1383-wp-codebox-composer-vendor --changed-since origin/main --force-hot --allow-local-hot` could not run because `homeboy-extensions` has no extension provider configured for Homeboy lint.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the WP Codebox PHPUnit setup failure, implementing the shell runner fix, adding smoke coverage, and preparing this PR.
