### PR TITLE
fix: source Codex auth from OpenCode OAuth

### DIFF
--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -75,6 +75,10 @@ function defaultCodexAuthPath() {
   return process.env.HOME ? path.join(process.env.HOME, '.codex', 'auth.json') : '';
 }
 
+function defaultOpenCodeAuthPath() {
+  return process.env.HOME ? path.join(process.env.HOME, '.local', 'share', 'opencode', 'auth.json') : '';
+}
+
 function jwtExpiration(token) {
   const payload = String(token || '').split('.')[1];
   if (!payload) {
@@ -96,9 +100,7 @@ function codexAuthEnv(taskInput) {
   if (CODEX_SECRET_ENV.slice(0, 4).every((name) => Boolean(process.env[name]))) {
     return {};
   }
-  const authPath = process.env.HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH || defaultCodexAuthPath();
-  const auth = readJsonIfAvailable(authPath);
-  const tokens = auth?.tokens || {};
+  const tokens = codexTokensFromOpenCodeAuth() || codexTokensFromCodexAuth();
   if (!tokens.access_token || !tokens.refresh_token || !tokens.account_id) {
     return {};
   }
@@ -109,6 +111,36 @@ function codexAuthEnv(taskInput) {
     AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: tokens.account_id,
     AI_PROVIDER_OPENAI_CODEX_FEDRAMP: tokens.fedramp === undefined ? 'false' : String(tokens.fedramp),
   }).filter(([name, value]) => CODEX_SECRET_ENV.includes(name) && value !== undefined && value !== null && value !== ''));
+}
+
+function codexTokensFromOpenCodeAuth() {
+  const authPath = process.env.HOMEBOY_WP_CODEBOX_OPENCODE_AUTH_PATH || defaultOpenCodeAuthPath();
+  const auth = readJsonIfAvailable(authPath);
+  const openai = auth?.openai || {};
+  if (openai.type !== 'oauth' || !openai.access || !openai.refresh || !openai.accountId) {
+    return null;
+  }
+  return {
+    access_token: openai.access,
+    refresh_token: openai.refresh,
+    expires_at: openCodeExpiresAt(openai.expires) || jwtExpiration(openai.access),
+    account_id: openai.accountId,
+    fedramp: openai.fedramp,
+  };
+}
+
+function codexTokensFromCodexAuth() {
+  const authPath = process.env.HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH || defaultCodexAuthPath();
+  const auth = readJsonIfAvailable(authPath);
+  return auth?.tokens || {};
+}
+
+function openCodeExpiresAt(value) {
+  if (!Number.isFinite(Number(value))) {
+    return '';
+  }
+  const numeric = Number(value);
+  return String(numeric > 100000000000 ? Math.floor(numeric / 1000) : Math.floor(numeric));
 }
 
 function directorySizeBytes(directory) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -42,6 +42,7 @@ fs.writeFileSync(${JSON.stringify(capture)}, JSON.stringify({
   argv: process.argv.slice(2),
   request,
   env_presence: Object.fromEntries(codexSecretEnv.map((name) => [name, Boolean(process.env[name])])),
+  codex_env: Object.fromEntries(codexSecretEnv.map((name) => [name, process.env[name] || ''])),
 }, null, 2));
 process.stdout.write(JSON.stringify({
   success: true,
@@ -1657,13 +1658,24 @@ try {
 
   const fakeCodexHome = path.join(root, 'fake-codex-home');
   const fakeCodexDirectory = path.join(fakeCodexHome, '.codex');
+  const fakeOpenCodeDirectory = path.join(fakeCodexHome, '.local', 'share', 'opencode');
   fs.mkdirSync(fakeCodexDirectory, { recursive: true });
+  fs.mkdirSync(fakeOpenCodeDirectory, { recursive: true });
   fs.writeFileSync(path.join(fakeCodexDirectory, 'auth.json'), JSON.stringify({
     tokens: {
       access_token: 'fixture-codex-access-token',
       refresh_token: 'fixture-codex-refresh-token',
       expires_at: '1780000000',
       account_id: 'fixture-codex-account-id',
+    },
+  }));
+  fs.writeFileSync(path.join(fakeOpenCodeDirectory, 'auth.json'), JSON.stringify({
+    openai: {
+      type: 'oauth',
+      access: 'fixture-opencode-access-token',
+      refresh: 'fixture-opencode-refresh-token',
+      expires: 1780000000123,
+      accountId: 'fixture-opencode-account-id',
     },
   }));
 
@@ -1700,6 +1712,10 @@ try {
     'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
   ]);
   assert.deepEqual(capturedCodex.env_presence, Object.fromEntries(codexSecretEnv.map((name) => [name, true])));
+  assert.equal(capturedCodex.codex_env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN, 'fixture-opencode-access-token');
+  assert.equal(capturedCodex.codex_env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN, 'fixture-opencode-refresh-token');
+  assert.equal(capturedCodex.codex_env.AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT, '1780000000');
+  assert.equal(capturedCodex.codex_env.AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID, 'fixture-opencode-account-id');
   assert(!JSON.stringify(capturedCodex).includes('wp-ai-gateway'));
   assert(!JSON.stringify(capturedCodex).includes('fixture-codex-access-token'));
 


### PR DESCRIPTION
## Summary
- Source Codex provider env from OpenCode's `openai` OAuth record before falling back to `~/.codex/auth.json`.
- Map OpenCode's `access`, `refresh`, millisecond `expires`, and `accountId` fields into the `AI_PROVIDER_OPENAI_CODEX_*` env contract.
- Add smoke coverage proving OpenCode OAuth wins over stale Codex CLI auth.

## Testing
- `npm run test:codebox-agent-task-executor`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Codex auth source mismatch and drafted the executor/test changes; Chris reviewed direction through the thread.