### PR TITLE
Pass component contracts to Codebox task requests

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -263,6 +263,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     mounts,
     workspaces: inputs.workspaces || config.workspaces || options.workspaces || defaults.workspaces || [],
     runtime_component_paths: components,
+    component_contracts: Array.isArray(config.component_contracts) ? config.component_contracts : [],
     homeboy_path: config.homeboy || config.homeboy_path || options.homeboy || '',
     homeboy_extensions_path: config.homeboy_extensions || config.homeboy_extensions_path || options.homeboyExtensions || '',
     wp_codebox_bin: firstValue(config.wp_codebox_bin, config.wpCodeboxBin, options.wpCodeboxBin, defaults.wpCodeboxBin, ''),

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -443,6 +443,7 @@ const abilityBridgeRequest = codeboxTaskRequestFromAgentTaskRequest({
       output_mappings: {
         validation_result: 'result.import_validation_result',
       },
+      component_contracts: [{ slug: 'wp-site-generator', path: '/workspace/wp-site-generator', activate: true }],
       engine_data_outputs: {
         validation_result: 'metadata.artifacts.ImportValidationResult',
       },
@@ -452,6 +453,7 @@ const abilityBridgeRequest = codeboxTaskRequestFromAgentTaskRequest({
 assert.equal(abilityBridgeRequest.runtime_task.ability, 'example/validate-artifact');
 assert.deepEqual(abilityBridgeRequest.runtime_task.input, { artifact: { slug: 'example-site' }, report: '/artifacts/import-report.json' });
 assert.equal(abilityBridgeRequest.parent_request.executor.config.output_mappings.validation_result, 'result.import_validation_result');
+assert.deepEqual(abilityBridgeRequest.component_contracts, [{ slug: 'wp-site-generator', path: '/workspace/wp-site-generator', activate: true }]);
 
 const genericRuntimeEnv = {
   GENERIC_PROVIDER_CONFIG: '/runtime/provider/config.json',


### PR DESCRIPTION
## Summary
- Preserve task-level `component_contracts` when Homeboy Extensions builds WP Codebox task requests.
- This lets callers load domain components as plugins for runtime-local abilities and tools without hardcoding caller behavior in Homeboy Extensions.

## Tests
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified the missing generic pass-through, drafted the minimal executor change, and added focused smoke coverage for Chris to review.