### PR TITLE
Fix WordPress host-smoke diagnostics in web PHP runtimes

### DIFF
--- a/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
+++ b/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
@@ -43,6 +43,8 @@ const recipeIdx = args.indexOf('--recipe');
 const recipe = JSON.parse(fs.readFileSync(args[recipeIdx + 1], 'utf8'));
 const captureDir = process.env.FAKE_CODEBOX_CAPTURE_DIR;
 fs.writeFileSync(`${captureDir}/recipe-${Date.now()}-${Math.random().toString(36).slice(2)}.json`, JSON.stringify(recipe, null, 2));
+const codeFileArg = recipe.workflow.steps[0].args.find((arg) => arg.startsWith('code-file='));
+fs.copyFileSync(codeFileArg.slice('code-file='.length), `${captureDir}/wrapper.php`);
 // The run-php step's code-file is a wrapper that requires the smoke; we emit a
 // successful run with an OK stdout to mirror a passing smoke.
 process.stdout.write(JSON.stringify({
@@ -83,6 +85,9 @@ captured_recipe="$(ls "${CAPTURE_DIR}"/recipe-*.json | head -1)"
 assert_contains "$captured_recipe" "wordpress.run-php"
 assert_contains "$captured_recipe" "/wordpress/wp-content/plugins/component"
 assert_contains "$captured_recipe" "workspace-recipe/v1"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "\$homeboy_smoke_stderr = defined(\"STDERR\") ? STDERR : fopen(\"php://stderr\", \"w\");"
+assert_contains "${CAPTURE_DIR}/wrapper.php" "fwrite(\$homeboy_smoke_stderr"
+assert_not_contains "${CAPTURE_DIR}/wrapper.php" "fwrite(STDERR"
 
 # --- Failure propagation: a fake codebox returning success=false fails the run.
 FAKE_CODEBOX_FAIL="${TMPDIR}/fake-wp-codebox-fail.cjs"

--- a/wordpress/scripts/test/test-runner-host-smoke-wp.sh
+++ b/wordpress/scripts/test/test-runner-host-smoke-wp.sh
@@ -140,9 +140,11 @@ homeboy_wordpress_smoke_wrapper() {
         $smoke = $argv[1];
         echo "<?php\n";
         echo "\$smoke = " . var_export($smoke, true) . ";\n";
-        echo "if (!file_exists(\$smoke)) { fwrite(STDERR, \"smoke file missing in sandbox: \" . \$smoke . \"\\n\"); exit(3); }\n";
+        echo "\$homeboy_smoke_stderr = defined(\"STDERR\") ? STDERR : fopen(\"php://stderr\", \"w\");\n";
+        echo "if (!is_resource(\$homeboy_smoke_stderr)) { \$homeboy_smoke_stderr = fopen(\"php://output\", \"w\"); }\n";
+        echo "if (!file_exists(\$smoke)) { fwrite(\$homeboy_smoke_stderr, \"smoke file missing in sandbox: \" . \$smoke . \"\\n\"); exit(3); }\n";
         echo "register_shutdown_function(function () { \$e = error_get_last(); if (\$e && in_array(\$e[\"type\"], array(E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR), true)) { exit(1); } });\n";
-        echo "try { require \$smoke; } catch (\\Throwable \$e) { fwrite(STDERR, \"smoke threw: \" . \$e->getMessage() . \"\\n\"); exit(1); }\n";
+        echo "try { require \$smoke; } catch (\\Throwable \$e) { fwrite(\$homeboy_smoke_stderr, \"smoke threw: \" . \$e->getMessage() . \"\\n\"); exit(1); }\n";
     ' "$sandbox_smoke_path"
 }
 


### PR DESCRIPTION
## Summary
- Harden the WordPress host-smoke wrapper so harness diagnostics write through a runtime-safe stream when `STDERR` is not predefined.
- Extend the existing host-smoke runner harness check to capture the generated wrapper and assert diagnostic writes no longer call `fwrite(STDERR, ...)` directly.

Fixes #1387.

## Verification
- `bash wordpress/scripts/test/host-smoke-wp-runner-smoke.sh`
- `bash -n wordpress/scripts/test/test-runner-host-smoke-wp.sh`
- `bash -n wordpress/scripts/test/host-smoke-wp-runner-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the minimal wrapper hardening and focused harness assertion; Chris remains responsible for review and merge.