### PR TITLE
Make Swift setup capability-aware

### DIFF
--- a/swift/scripts/setup.sh
+++ b/swift/scripts/setup.sh
@@ -3,10 +3,9 @@ set -euo pipefail
 
 echo "Setting up Swift test infrastructure..."
 
-# Verify Swift is available
 if ! command -v swift &> /dev/null; then
-    echo "Error: Swift not found. Please install Xcode or Swift toolchain."
-    exit 1
+    echo "Swift unavailable; Swift extension installed but not ready on this runner. Install Xcode or Swift toolchain to enable Swift workflows."
+    exit 0
 fi
 
 SWIFT_VERSION=$(swift --version 2>&1 | head -1)

--- a/swift/tests/swift-extension-smoke.sh
+++ b/swift/tests/swift-extension-smoke.sh
@@ -54,3 +54,15 @@ assert_true(manifest.get("test", {}).get("extension_script") == "scripts/test-ru
 
 print("swift manifest smoke passed")
 PY
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PATH="$TMP_DIR" /bin/bash "$ROOT_DIR/swift/scripts/setup.sh" > "$TMP_DIR/setup.out"
+if ! grep -Fq "Swift unavailable; Swift extension installed but not ready on this runner" "$TMP_DIR/setup.out"; then
+    echo "Expected Swift setup to explain unsupported runner capability" >&2
+    sed 's/^/  /' "$TMP_DIR/setup.out" >&2
+    exit 1
+fi
+
+echo "swift setup capability smoke passed"


### PR DESCRIPTION
## Summary
- Make Swift extension setup succeed with a clear unsupported-runner message when `swift` is not installed.
- Preserve Swift capability enforcement through the existing `ready_check`, so Swift workflows still report the extension as not ready until the toolchain exists.
- Add smoke coverage for the no-Swift setup path so runner extension sync can install/update Swift without contaminating unrelated non-Swift runner upgrades.

Fixes Extra-Chill/homeboy#4575.

## Tests
- `bash swift/tests/swift-extension-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Read the Homeboy issue history, identified the extension-owned setup failure path, drafted the minimal Swift setup change, and added focused smoke coverage for Chris to review.