### PR TITLE
fix: expose targeted WordPress host smoke reruns

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -15,7 +15,7 @@ extension scripts for these verbs:
 
 | Homeboy verb | What it does | Entry script |
 |---|---|---|
-| `test` | PHPUnit via WP Codebox (default) or host-PHP smoke scripts | `scripts/test/test-runner.sh` |
+| `test` | PHPUnit and real-WordPress host smokes via WP Codebox | `scripts/test/test-runner.sh` |
 | `lint` | PHPCS + PHPStan (PHP) and ESLint (JS/TS) | `scripts/lint/lint-runner.sh` |
 | `build` | Production ZIP with composer `--no-dev`, asset build, syntax check | `scripts/build/build.sh` |
 | `bench` | Benchmark workloads via WP Codebox; optional browser handoff | `scripts/bench/bench-runner.sh` |
@@ -129,17 +129,23 @@ class Test_My_Feature extends WP_UnitTestCase {
 Available factories from the WordPress test framework: `user`, `post`,
 `comment`, `term`, `category`, `tag`, `attachment`.
 
-### Host-smoke backend
+### Real-WordPress host smokes
 
-Pure PHP smoke suites that don't need WordPress can opt out of WP Codebox:
+Standalone smoke files matching `tests/**/*-smoke.php` run through the same WP
+Codebox-backed real WordPress harness as CI. Each file is mounted with the
+component and executed via `wordpress.run-php`, so WordPress functions and
+runtime dependencies are available.
+
+To rerun one existing smoke on demand before pushing:
 
 ```bash
-homeboy component set <component-id> test_backend host-smoke
+homeboy test <component-id> -- --host-smoke-file tests/example-smoke.php
 ```
 
-The host-smoke backend discovers `tests/**/*-smoke.php`, runs each script
-in its own host `php` process, emits `HOST_SMOKE_*` markers, and fails
-fast with the failing script name. It does not bootstrap WordPress.
+The focused command is opt-in and does not change default test discovery or add
+smokes to CI. Output preserves the machine-readable `HOST_SMOKE_BEGIN`,
+`HOST_SMOKE_PROGRESS`, `HOST_SMOKE_OK`, `HOST_SMOKE_FAIL`, and
+`HOST_SMOKE_SUMMARY` markers.
 
 ### Runtime dependencies
 

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -19,12 +19,15 @@ homeboy test <project-id>
 
 # Verbose diagnostics
 HOMEBOY_DEBUG=1 homeboy test <component-id>
+
+# Rerun one real-WordPress host smoke through the CI-equivalent WP Codebox path
+homeboy test <component-id> -- --host-smoke-file tests/example-smoke.php
 ```
 
 Tests run through `scripts/test/test-runner.sh`, which dispatches to the WP
-Codebox runner for WordPress PHPUnit. The runner mounts the component under
-`/wordpress/wp-content/plugins/<slug>`, boots WordPress in-process, discovers
-test files, and runs PHPUnit.
+Codebox runner for WordPress PHPUnit and real-WordPress host smokes. The runner
+mounts the component under `/wordpress/wp-content/plugins/<slug>`, boots
+WordPress in-process, discovers test files, and routes files by type.
 
 ## Requirements
 
@@ -39,20 +42,24 @@ A component **must not** carry its own `tests/bootstrap.php` or
 `phpunit.xml` — the extension owns bootstrap. Local PHPUnit configs are
 rejected with a clear error.
 
-## Host smoke backend
+## Real-WordPress host smokes
 
-Pure PHP smoke suites can run directly under host PHP when they are genuinely
-standalone and do not require a WordPress bootstrap:
+Standalone PHP smoke files can live under `tests/**/*-smoke.php`. They run
+through WP Codebox against real WordPress, using the same component mounts,
+dependency mounts, drop-in handling, WordPress version selection, and
+`wordpress.run-php` recipe execution path CI uses.
+
+The default test command discovers existing smoke files when present. To rerun
+one failed smoke without the full CI loop, pass the file explicitly:
 
 ```bash
-homeboy component set <component-id> test_backend host-smoke
+homeboy test <component-id> -- --host-smoke-file tests/example-smoke.php
 ```
 
-The host-smoke backend discovers `tests/**/*-smoke.php`, runs each script in a
-separate `php` process, emits `HOST_SMOKE_*` markers, and fails fast with the
-failing script name. It remains separate because these scripts are non-WordPress
-PHP checks by contract: they do not bootstrap WordPress, connect to MySQL, or
-start a sandbox runtime.
+This focused path is opt-in and does not add default smokes or broaden CI
+coverage. It preserves the machine-readable `HOST_SMOKE_BEGIN`,
+`HOST_SMOKE_PROGRESS`, `HOST_SMOKE_OK`, `HOST_SMOKE_FAIL`, and
+`HOST_SMOKE_SUMMARY` markers, and fails fast with the selected script name.
 
 ## Data Machine agent bundle validator
 
@@ -74,11 +81,10 @@ For full CI agent runs on the WP Codebox WordPress execution substrate, see
 
 ## WP Codebox test runtime status
 
-WordPress PHPUnit runs through WP Codebox by default. The WP Codebox path owns
-the same component mounts, dependency mounts, drop-ins, file routing, WordPress
-version selection, and artifact parsing contract that the direct Playground
-runner previously handled. `host-smoke` remains available for standalone PHP
-smoke scripts that do not bootstrap WordPress.
+WordPress PHPUnit and standalone `tests/**/*-smoke.php` files run through WP
+Codebox by default. The WP Codebox path owns the same component mounts,
+dependency mounts, drop-ins, file routing, WordPress version selection, and
+artifact parsing contract that the direct Playground runner previously handled.
 
 ## Dependencies
 

--- a/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
+++ b/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
@@ -155,4 +155,24 @@ FAKE_CODEBOX_CAPTURE_DIR="$CAPTURE_DIR" \
 assert_contains "${TMPDIR}/router.out" "Backend: host-smoke-wp"
 assert_contains "${TMPDIR}/router.out" "HOST_SMOKE_OK:tests/alpha-smoke.php"
 
+# --- Operator affordance: maintainers can rerun one real-WP host smoke on
+# demand without relying on changed-file routing or running the full suite.
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_WP_CODEBOX_BIN="$FAKE_CODEBOX" \
+FAKE_CODEBOX_CAPTURE_DIR="$CAPTURE_DIR" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --host-smoke-file tests/alpha-smoke.php > "${TMPDIR}/operator.out"
+assert_contains "${TMPDIR}/operator.out" "Backend: host-smoke-wp"
+assert_contains "${TMPDIR}/operator.out" "HOST_SMOKE_BEGIN:tests/alpha-smoke.php"
+assert_contains "${TMPDIR}/operator.out" "HOST_SMOKE_OK:tests/alpha-smoke.php"
+
+help_output="$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" HOMEBOY_COMPONENT_ID="component" HOMEBOY_COMPONENT_PATH="$component" HOMEBOY_COMPONENT_SHAPE="plugin" bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --help)"
+if [[ "$help_output" != *"--host-smoke-file <path>"* ]] || [[ "$help_output" != *"HOST_SMOKE_BEGIN"* ]]; then
+    echo "Expected runner help to document --host-smoke-file and HOST_SMOKE markers" >&2
+    printf '%s\n' "$help_output" >&2
+    exit 1
+fi
+
 echo "Real-WordPress smoke runner smoke passed"

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -33,10 +33,33 @@ fi
 # bare-host/no-WordPress backend and no test_backend toggle; the runtime is
 # always WP Codebox.
 
+show_usage() {
+    cat <<'EOF'
+Usage: homeboy test <component-id> [-- --file <path>]
+       homeboy test <component-id> [-- --host-smoke-file <tests/...-smoke.php>]
+
+Options passed after `--` are handled by the WordPress extension runner:
+  --file <path>             Run one test file, routed by file type.
+  --host-smoke-file <path>  Run one real-WordPress host smoke through the same
+                            WP Codebox/wordpress.run-php harness used by CI.
+                            The file must match tests/**/*-smoke.php.
+  --help                    Show this help.
+
+Real-WordPress host smokes preserve the HOST_SMOKE_BEGIN,
+HOST_SMOKE_PROGRESS, HOST_SMOKE_OK, HOST_SMOKE_FAIL, and
+HOST_SMOKE_SUMMARY markers for machine parsing.
+EOF
+}
+
 TARGET_FILE=""
+TARGET_HOST_SMOKE_FILE=""
 PASSTHROUGH_ARGS=()
 while [ "$#" -gt 0 ]; do
     case "$1" in
+        --help|-h)
+            show_usage
+            exit 0
+            ;;
         --file)
             shift
             if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
@@ -48,12 +71,28 @@ while [ "$#" -gt 0 ]; do
         --file=*)
             TARGET_FILE="${1#--file=}"
             ;;
+        --host-smoke-file)
+            shift
+            if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
+                echo "ERROR: --host-smoke-file requires a path" >&2
+                exit 2
+            fi
+            TARGET_HOST_SMOKE_FILE="$1"
+            ;;
+        --host-smoke-file=*)
+            TARGET_HOST_SMOKE_FILE="${1#--host-smoke-file=}"
+            ;;
         *)
             PASSTHROUGH_ARGS+=("$1")
             ;;
     esac
     shift
 done
+
+if [ -n "$TARGET_FILE" ] && [ -n "$TARGET_HOST_SMOKE_FILE" ]; then
+    echo "ERROR: use either --file or --host-smoke-file, not both" >&2
+    exit 2
+fi
 
 COMPONENT_SHAPE="${HOMEBOY_COMPONENT_SHAPE:-}"
 if [ -z "$COMPONENT_SHAPE" ]; then
@@ -220,6 +259,23 @@ homeboy_wordpress_is_shell_smoke_file() {
             ;;
     esac
 }
+
+if [ -n "$TARGET_HOST_SMOKE_FILE" ]; then
+    if ! target_rel="$(homeboy_wordpress_rel_test_file "$TARGET_HOST_SMOKE_FILE")"; then
+        echo "ERROR: requested real-WordPress host smoke file not found: ${TARGET_HOST_SMOKE_FILE}" >&2
+        exit 2
+    fi
+
+    case "$target_rel" in
+        tests/*-smoke.php|tests/*/*-smoke.php|tests/*/*/*-smoke.php|tests/*/*/*/*-smoke.php)
+            HOMEBOY_WORDPRESS_HOST_SMOKE_FILE="$target_rel" exec bash "$SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
+            ;;
+        *)
+            echo "ERROR: --host-smoke-file requires tests/**/*-smoke.php, got: ${target_rel}" >&2
+            exit 2
+            ;;
+    esac
+fi
 
 if [ -z "$TARGET_FILE" ] && [ "${HOMEBOY_TEST_SCOPE_KIND:-}" = "exclusive_env" ]; then
     if [ "${HOMEBOY_TEST_SCOPE_ENV_NAME:-}" = "HOMEBOY_WORDPRESS_HOST_SMOKE_FILES" ] && [ -n "${HOMEBOY_TEST_SCOPE_ENV_VALUE:-}" ]; then


### PR DESCRIPTION
## Summary
- Adds an opt-in `--host-smoke-file` WordPress test-runner option for rerunning one existing `tests/**/*-smoke.php` through the WP Codebox/real-WordPress host-smoke harness.
- Preserves the existing `HOST_SMOKE_*` marker contract and documents the operator command for pre-push debugging.
- Keeps default discovery/CI coverage unchanged and leaves Homeboy core untouched.

Fixes #1388.

## Verification
- `bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/host-smoke-wp-runner-smoke.sh`
- `bash scripts/test/host-smoke-wp-runner-smoke.sh` from `wordpress/`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused runner option, documentation updates, and local fake-harness verification; Chris provided direction and constraints.