### PR TITLE
fix: use production Composer autoload for WP Codebox

### DIFF
--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -400,7 +400,7 @@ append_phpunit_component_composer_prepare_step() {
         --argjson steps "$WP_CODEBOX_PREPARE_STEPS_JSON" \
         '$steps + [{
             command: "composer",
-            args: ["install", "--no-interaction", "--no-progress", "--prefer-dist"]
+            args: ["install", "--no-dev", "--no-interaction", "--no-progress", "--prefer-dist"]
         }]')
 }
 

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -230,7 +230,7 @@ if [ ! -s "$ARGS_FILE" ]; then
     exit 1
 fi
 
-if ! grep -q -- 'install --no-interaction --no-progress --prefer-dist' "$COMPOSER_LOG"; then
+if ! grep -q -- 'install --no-dev --no-interaction --no-progress --prefer-dist' "$COMPOSER_LOG"; then
     echo "Expected WP Codebox runner to prepare missing component Composer autoload" >&2
     cat "$COMPOSER_LOG" >&2 || true
     exit 1


### PR DESCRIPTION
## Summary
- switch automatic WP Codebox Composer preparation to production autoload with `--no-dev`
- keep explicit `wp_codebox_prepare_steps` available for callers that need dev dependencies
- update the mount smoke expectation so the default runtime path cannot regress to dev autoload

Fixes #1394.

## Testing
- `bash wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh && bash -n wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the WP Codebox dev-autoload collision, implementing the minimal fix, and running focused verification.
