### PR TITLE
Prepare WP Codebox trace dependency plugins

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -309,7 +309,7 @@ homeboy_get_validation_dependency_slug() {
     dir_slug="$(basename "$plugin_path")"
 
     local canonical_dir_slug="${dir_slug%%@*}"
-    if [ "$canonical_dir_slug" = "$dir_slug" ]; then
+    if [ "$canonical_dir_slug" = "$dir_slug" ] && [ "$dir_slug" != "root" ]; then
         printf '%s\n' "$dir_slug"
         return 0
     fi
@@ -325,6 +325,10 @@ homeboy_get_validation_dependency_slug() {
         local main_slug
         main_slug="$(basename "$main_file" .php)"
         if [ "$main_slug" = "$canonical_dir_slug" ]; then
+            printf '%s\n' "$main_slug"
+            return 0
+        fi
+        if [ "$dir_slug" = "root" ]; then
             printf '%s\n' "$main_slug"
             return 0
         fi
@@ -1837,6 +1841,34 @@ homeboy_prepare_validation_dependency_paths_for_wp_codebox_bench() {
             echo "Warning: WordPress bench dependency provider skipped failed dependency: ${dependency_path}" >&2
         fi
     done <<< "$dependency_paths"
+}
+
+homeboy_prepare_validation_dependency_for_wp_codebox_runtime() {
+    homeboy_prepare_validation_dependency_for_wp_codebox_bench "$@"
+}
+
+homeboy_prepare_validation_dependency_paths_for_wp_codebox_runtime() {
+    local dependency_paths="${1:-}"
+    local artifacts_dir="${2:-}"
+    local context="${3:-wordpress}"
+
+    [ -n "$dependency_paths" ] || return 0
+    [ -n "$artifacts_dir" ] || return 1
+
+    local dependency_path prepared_path failed
+    failed=0
+    while IFS= read -r dependency_path; do
+        [ -n "$dependency_path" ] || continue
+        [ -d "$dependency_path" ] || continue
+        if prepared_path=$(homeboy_prepare_validation_dependency_for_wp_codebox_runtime "$dependency_path" "$artifacts_dir"); then
+            [ -n "$prepared_path" ] && printf '%s\n' "$prepared_path"
+        else
+            echo "Error: WordPress ${context} dependency provider could not prepare runtime-complete plugin input: ${dependency_path}" >&2
+            failed=1
+        fi
+    done <<< "$dependency_paths"
+
+    [ "$failed" -eq 0 ]
 }
 
 homeboy_export_validation_dependency_paths() {

--- a/wordpress/scripts/trace/trace-runner-smoke.sh
+++ b/wordpress/scripts/trace/trace-runner-smoke.sh
@@ -53,9 +53,47 @@ assert_json_field() {
 }
 
 fixture="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wordpress-trace.XXXXXX")"
-trap 'rm -rf "$fixture"' EXIT
+if [ "${HOMEBOY_KEEP_SMOKE_FIXTURE:-0}" = "1" ]; then
+    printf 'Keeping smoke fixture: %s\n' "$fixture" >&2
+else
+    trap 'rm -rf "$fixture"' EXIT
+fi
 
 mkdir -p "$fixture/traces" "$fixture/tests/traces" "$fixture/scripts/trace"
+dependency_fixture="$fixture/dependency-plugin"
+stubs_dir="$fixture/stubs"
+composer_log="$fixture/composer.log"
+mkdir -p "$dependency_fixture" "$stubs_dir"
+
+cat >"$dependency_fixture/dependency-plugin.php" <<'PHP'
+<?php
+/*
+Plugin Name: Dependency Plugin
+*/
+PHP
+cat >"$dependency_fixture/composer.json" <<'JSON'
+{"autoload":{"classmap":["includes/"]}}
+JSON
+
+cat >"$stubs_dir/composer" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${COMPOSER_LOG:?}"
+working_dir="$(pwd)"
+install_requested=0
+for arg in "$@"; do
+    case "$arg" in
+        --working-dir=*) working_dir="${arg#--working-dir=}" ;;
+        install) install_requested=1 ;;
+    esac
+done
+if [ "$install_requested" -eq 1 ]; then
+    cd "$working_dir"
+    mkdir -p vendor
+    printf '<?php // prepared trace autoload\n' > vendor/autoload.php
+fi
+SH
+chmod +x "$stubs_dir/composer"
 
 fake_wp_codebox="$fixture/wp-codebox.cjs"
 fake_wp_codebox_capture="$fixture/wp-codebox-capture.json"
@@ -75,6 +113,13 @@ const codeFile = step.args.find((arg) => arg.startsWith('code-file=')).slice('co
 const wrapper = fs.readFileSync(codeFile, 'utf8');
 const runMount = recipe.inputs.mounts.find((mount) => mount.target === '/homeboy-trace-run');
 const componentMount = recipe.inputs.mounts.find((mount) => mount.target.startsWith('/wordpress/wp-content/plugins/'));
+const dependencyMount = recipe.inputs.mounts.find((mount) => mount.target === '/wordpress/wp-content/plugins/dependency-plugin');
+if (!dependencyMount) {
+  throw new Error('missing prepared dependency plugin mount');
+}
+if (!fs.existsSync(path.join(dependencyMount.source, 'vendor/autoload.php'))) {
+  throw new Error(`dependency Composer autoload was not prepared before trace mount: ${dependencyMount.source}`);
+}
 const resultPath = wrapper.match(/HOMEBOY_TRACE_RESULTS_FILE=([^']+)/)[1].replace('/homeboy-trace-run', runMount.source);
 const artifactDir = wrapper.match(/HOMEBOY_TRACE_ARTIFACT_DIR=([^']+)/)[1].replace('/homeboy-trace-run', runMount.source);
 
@@ -195,6 +240,9 @@ HOMEBOY_TRACE_RESULTS_FILE="$php_results" \
 HOMEBOY_TRACE_ARTIFACT_DIR="$run_dir/artifacts/php" \
 HOMEBOY_RUN_DIR="$run_dir" \
 HOMEBOY_WP_CODEBOX_BIN="$fake_wp_codebox" \
+HOMEBOY_WORDPRESS_DEPENDENCY_PATHS="$dependency_fixture" \
+COMPOSER_LOG="$composer_log" \
+PATH="$stubs_dir:$PATH" \
 FAKE_WP_CODEBOX_CAPTURE="$fake_wp_codebox_capture" \
 bash "$RUNNER"
 
@@ -209,6 +257,7 @@ assert_json_field "$php_results" "has-timeline" "PHP scenario timeline"
 assert_file "$fake_wp_codebox_capture" "WP Codebox recipe capture"
 assert_contains "$(php -r '$json = json_decode(file_get_contents($argv[1]), true); echo $json["recipe"]["workflow"]["steps"][0]["command"] ?? "";' "$fake_wp_codebox_capture")" "wordpress.run-php" "WP Codebox PHP trace command"
 assert_contains "$(php -r '$json = json_decode(file_get_contents($argv[1]), true); echo $json["runMount"]["target"] ?? "";' "$fake_wp_codebox_capture")" "/homeboy-trace-run" "WP Codebox run mount"
+assert_contains "$(cat "$composer_log")" "--no-dev --no-interaction --no-progress --prefer-dist --classmap-authoritative" "trace dependency Composer prepare"
 
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_PATH="$fixture" \

--- a/wordpress/scripts/trace/trace-runner.sh
+++ b/wordpress/scripts/trace/trace-runner.sh
@@ -127,7 +127,7 @@ homeboy_trace_run_php_scenario_wp_codebox() {
     local scenario_rel="$1"
     local stdout_file="$2"
     local stderr_file="$3"
-    local codebox_bin wp_version plugin_slug run_mount_host runtime_run_dir runtime_results runtime_artifacts runtime_scenario wrapper_file recipe_file output_file codebox_artifacts_dir status
+    local codebox_bin wp_version plugin_slug run_mount_host runtime_run_dir runtime_results runtime_artifacts runtime_scenario wrapper_file recipe_file output_file codebox_artifacts_dir status mounts_json dep_path dep_slug dep_source
 
     codebox_bin="$(homeboy_wordpress_resolve_wp_codebox_bin)" || return 1
     wp_version="$(homeboy_wordpress_trace_wp_version)"
@@ -160,20 +160,38 @@ homeboy_trace_run_php_scenario_wp_codebox() {
     codebox_artifacts_dir="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-trace-artifacts.XXXXXX")"
     PLUGIN_SLUG="$plugin_slug" homeboy_wordpress_trace_php_wrapper "$runtime_scenario" "$runtime_results" "$runtime_artifacts" "$runtime_run_dir" > "$wrapper_file"
 
-    jq -n \
-        --arg wp "$wp_version" \
+    mounts_json=$(jq -nc \
         --arg componentSource "$(homeboy_wp_codebox_resolve_mount_path "$HOMEBOY_COMPONENT_PATH")" \
         --arg componentTarget "/wordpress/wp-content/plugins/${plugin_slug}" \
         --arg runSource "$run_mount_host" \
         --arg runTarget "$runtime_run_dir" \
+        '[
+            {source: $componentSource, target: $componentTarget, mode: "readwrite"},
+            {source: $runSource, target: $runTarget, mode: "readwrite"}
+        ]')
+
+    if [ -n "${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}" ]; then
+        while IFS= read -r dep_path; do
+            [ -n "$dep_path" ] || continue
+            [ -d "$dep_path" ] || continue
+            dep_slug="$(homeboy_get_validation_dependency_slug "$dep_path" || basename "$dep_path")"
+            dep_source="$(homeboy_wp_codebox_resolve_mount_path "$dep_path")"
+            mounts_json=$(jq -nc \
+                --argjson mounts "$mounts_json" \
+                --arg source "$dep_source" \
+                --arg target "/wordpress/wp-content/plugins/${dep_slug}" \
+                '$mounts + [{source: $source, target: $target, mode: "readwrite"}]')
+        done <<< "$HOMEBOY_WORDPRESS_DEPENDENCY_PATHS"
+    fi
+
+    jq -n \
+        --arg wp "$wp_version" \
+        --argjson mounts "$mounts_json" \
         --arg codeFile "$wrapper_file" \
         '{
             schema: "wp-codebox/workspace-recipe/v1",
             runtime: ({blueprint: {steps: []}} + (if $wp == "" then {} else {wp: $wp} end)),
-            inputs: {mounts: [
-                {source: $componentSource, target: $componentTarget, mode: "readwrite"},
-                {source: $runSource, target: $runTarget, mode: "readwrite"}
-            ]},
+            inputs: {mounts: $mounts},
             workflow: {steps: [{command: "wordpress.run-php", args: ["code-file=" + $codeFile]}]}
         }' > "$recipe_file"
 
@@ -355,6 +373,13 @@ if type homeboy_preflight_declared_validation_dependency_paths &>/dev/null; then
 fi
 if type homeboy_export_validation_dependency_paths &>/dev/null; then
     homeboy_export_validation_dependency_paths "$HOMEBOY_COMPONENT_PATH"
+fi
+if [ -n "${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}" ] && type homeboy_prepare_validation_dependency_paths_for_wp_codebox_runtime &>/dev/null; then
+    if ! HOMEBOY_WORDPRESS_DEPENDENCY_PATHS=$(homeboy_prepare_validation_dependency_paths_for_wp_codebox_runtime "$HOMEBOY_WORDPRESS_DEPENDENCY_PATHS" "$HOMEBOY_TRACE_ARTIFACT_DIR" "trace"); then
+        homeboy_trace_write_failure "fail" "WordPress dependency plugin preparation failed before WP Codebox dispatch"
+        exit 1
+    fi
+    export HOMEBOY_WORDPRESS_DEPENDENCY_PATHS
 fi
 if [ -n "${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}" ] && type homeboy_preflight_wordpress_dependency_plugins &>/dev/null; then
     if ! homeboy_preflight_wordpress_dependency_plugins "$HOMEBOY_WORDPRESS_DEPENDENCY_PATHS" "$HOMEBOY_TRACE_ARTIFACT_DIR" "trace"; then


### PR DESCRIPTION
## Summary
- Prepare WordPress dependency plugin inputs before WP Codebox trace dispatch when Composer runtime autoload artifacts are missing.
- Mount prepared dependency plugin paths into the trace WP Codebox recipe instead of handing raw source checkouts to the runtime.
- Preserve Homeboy core boundaries: this fix lives in the WordPress/Homeboy Extensions WP Codebox layer and does not add product-specific WooCommerce or Stripe behavior.

Related: Extra-Chill/homeboy#4600

## Verification
- `git diff --check`
- `bash -n wordpress/scripts/lib/validation-dependencies.sh wordpress/scripts/trace/trace-runner.sh wordpress/scripts/trace/trace-runner-smoke.sh`
- `bash wordpress/scripts/trace/trace-runner-smoke.sh` -> `WordPress trace runner smoke passed (27 assertions).`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted implementation and smoke coverage; Chris remains responsible for review and merge.