### PR TITLE
Stabilize Rust release gates

### DIFF
--- a/rust/rust.json
+++ b/rust/rust.json
@@ -97,6 +97,20 @@
       "type": "string",
       "default": "",
       "description": "Optional Rust linker acceleration knob owned by the Rust extension. Set HOMEBOY_RUST_LINKER=mold or lld, or rust_linker to the same value; the provider appends the matching -C link-arg=-fuse-ld flag only when the requested linker binary is on PATH."
+    },
+    {
+      "id": "rust_cargo_test_threads",
+      "label": "Cargo test threads",
+      "type": "integer",
+      "default": 0,
+      "description": "Optional Cargo libtest thread count. Set to 1 for suites that mutate process-global environment and need deterministic serial execution. Zero preserves Cargo's default parallelism."
+    },
+    {
+      "id": "clippy_all",
+      "label": "Enable clippy::all",
+      "type": "boolean",
+      "default": false,
+      "description": "Opt into passing -W clippy::all during Rust lint. By default the Rust extension runs cargo clippy with the toolchain's default lint set so warning-only toolchain drift does not block release gates."
     }
   ],
   "audit": {

--- a/rust/scripts/lint-runner.sh
+++ b/rust/scripts/lint-runner.sh
@@ -15,7 +15,8 @@ set -euo pipefail
 #   HOMEBOY_CHANGED_SINCE   — git ref to scope fmt check to changed files only
 #   HOMEBOY_LINT_GLOB       — file glob (currently unused for Rust — cargo operates on crates)
 #   HOMEBOY_LINT_FILE       — single file (currently unused for Rust)
-#   HOMEBOY_ERRORS_ONLY     — if "1", only show errors (suppresses warnings in clippy)
+#   HOMEBOY_ERRORS_ONLY     — if "1", treat warnings as errors with `-D warnings`
+#   HOMEBOY_CLIPPY_ALL      — if "1", opt into `-W clippy::all` warning expansion
 #   HOMEBOY_STEP            — comma-separated steps to run (fmt, clippy)
 #   HOMEBOY_SKIP            — comma-separated steps to skip
 #   HOMEBOY_DEBUG           — if "1", show debug output
@@ -47,6 +48,26 @@ write_fix_results_sidecar() {
     if [ "${HOMEBOY_FIX_ONLY:-}" = "1" ] && [ -n "${HOMEBOY_FIX_RESULTS_FILE:-}" ]; then
         homeboy_fix_results_write
     fi
+}
+
+clippy_all_enabled() {
+    if [ "${HOMEBOY_CLIPPY_ALL:-}" = "1" ]; then
+        return 0
+    fi
+
+    python3 - <<'PY'
+import json
+import os
+import sys
+
+try:
+    settings = json.loads(os.environ.get("HOMEBOY_SETTINGS_JSON", "{}"))
+except json.JSONDecodeError:
+    settings = {}
+
+enabled = settings.get("clippy_all") is True
+sys.exit(0 if enabled else 1)
+PY
 }
 
 write_lint_findings_from_output() {
@@ -316,8 +337,10 @@ if should_run_step "clippy"; then
 
     if [ "${HOMEBOY_ERRORS_ONLY:-}" = "1" ]; then
         CLIPPY_ARGS+=(-D warnings)
-    else
+    elif clippy_all_enabled; then
         CLIPPY_ARGS+=(-W clippy::all)
+    else
+        :
     fi
 
     if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -50,6 +50,16 @@ rust_nextest_fallback_enabled() {
     [ "$(homeboy_setting_bool rust_nextest_fallback true '.rust_nextest_fallback // .nextest_fallback')" = "true" ]
 }
 
+rust_cargo_test_threads() {
+    local value
+    value="${HOMEBOY_RUST_CARGO_TEST_THREADS:-$(homeboy_setting rust_cargo_test_threads '.rust_cargo_test_threads // .cargo_test_threads' '')}"
+    case "$value" in
+        ''|0) return 1 ;;
+        *[!0-9]*) return 1 ;;
+        *) printf '%s' "$value" ;;
+    esac
+}
+
 rust_resolve_changed_scope_json() {
     python3 - "$PROJECT_PATH" "${HOMEBOY_CHANGED_TEST_FILES:-}" "${HOMEBOY_TEST_RUNNER_ARGS:-}" <<'PY'
 import json
@@ -479,6 +489,13 @@ rust_append_scope_args "$SCOPE_JSON"
 
 COMMAND_LABEL="cargo test"
 COMMAND_BINARY=(cargo "${TEST_ARGS[@]}")
+
+if [ "$SELECTED_RUNNER" = "cargo" ]; then
+    CARGO_TEST_THREADS="$(rust_cargo_test_threads || true)"
+    if [ -n "$CARGO_TEST_THREADS" ]; then
+        COMMAND_BINARY+=(-- --test-threads="$CARGO_TEST_THREADS")
+    fi
+fi
 
 if [ "$SELECTED_RUNNER" = "nextest" ]; then
     NEXTEST_ARGS=(


### PR DESCRIPTION
## Summary
- Makes `clippy::all` opt-in for the Rust extension so toolchain warning drift no longer blocks release gates by default.
- Preserves strict `-D warnings` behavior for errors-only runs and adds `rust_cargo_test_threads` for components that need serialized test execution.
- Supports Homeboy's release gate by allowing Homeboy to run Rust tests serially without changing the extension default for other components.

## Verification
- Verified through Homeboy release-gate run from `Extra-Chill/homeboy` branch `fix/main-release-gates-20260615`.
- `homeboy lint`
- `homeboy test` (`4708 total`, `4685 passed`, `0 failed`, `23 skipped`)