### PR TITLE
Pass component contracts through codebox executor

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -200,7 +200,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const agentBundle = agentBundleConfigFromAgentTaskRequest(request, config, inputs);
   const recipe = recipeConfigFromAgentTaskRequest(request, config, inputs);
   const mounts = agentBundleMounts(agentBundle, config.mounts || defaults.mounts || options.mounts || []);
-  const components = runtimeComponentPaths(config, { ...defaults, ...options });
+  const componentContracts = componentContractsFromAgentTaskRequest(request, config, options);
+  const components = runtimeComponentPaths(config, { ...defaults, ...options, componentContracts });
   const agentBundles = firstDefined(inputs.agent_bundles, inputs.agentBundles, config.agent_bundles, config.agentBundles, options.agentBundles, []);
   const structuredArtifacts = firstDefined(inputs.structured_artifacts, inputs.structuredArtifacts, config.structured_artifacts, config.structuredArtifacts, options.structuredArtifacts, []);
   const sandboxToolPolicy = firstDefined(inputs.sandbox_tool_policy, inputs.sandboxToolPolicy, config.sandbox_tool_policy, config.sandboxToolPolicy, options.sandboxToolPolicy, defaults.sandboxToolPolicy);
@@ -263,7 +264,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     mounts,
     workspaces: inputs.workspaces || config.workspaces || options.workspaces || defaults.workspaces || [],
     runtime_component_paths: components,
-    component_contracts: Array.isArray(config.component_contracts) ? config.component_contracts : [],
+    component_contracts: componentContracts,
     homeboy_path: config.homeboy || config.homeboy_path || options.homeboy || '',
     homeboy_extensions_path: config.homeboy_extensions || config.homeboy_extensions_path || options.homeboyExtensions || '',
     wp_codebox_bin: firstValue(config.wp_codebox_bin, config.wpCodeboxBin, options.wpCodeboxBin, defaults.wpCodeboxBin, ''),
@@ -280,6 +281,29 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     agent_bundle: agentBundle,
     parent_request: request,
   };
+}
+
+function componentContractsFromAgentTaskRequest(request, config, options = {}) {
+  return uniqueComponentContracts([
+    ...normalizeArray(request.component_contracts),
+    ...normalizeArray(config.component_contracts),
+    ...normalizeArray(options.componentContracts),
+  ]);
+}
+
+function uniqueComponentContracts(contracts) {
+  const seen = new Set();
+  return contracts.filter((contract) => {
+    if (!contract || typeof contract !== 'object' || Array.isArray(contract)) {
+      return false;
+    }
+    const key = `${contract.slug || ''}:${contract.path || contract.source || ''}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
 }
 
 function abilityRuntimeTaskFromAgentTaskRequest(config, inputs) {

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -550,6 +550,21 @@ function runtimeComponentPathsFromContracts(contracts) {
     .filter(([key, value]) => key && value));
 }
 
+function uniqueComponentContracts(contracts) {
+  const seen = new Set();
+  return contracts.filter((contract) => {
+    if (!contract || typeof contract !== 'object' || Array.isArray(contract)) {
+      return false;
+    }
+    const key = `${contract.slug || ''}:${contract.path || contract.source || ''}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
 function runnerInput(request, artifacts) {
   const mounts = mountEntries(request);
   const runtimeComponentPaths = {
@@ -582,6 +597,7 @@ function runnerInput(request, artifacts) {
     artifacts_path: artifacts,
     wp_codebox_bin: argValue('--wp-codebox-bin') || request.wp_codebox_bin || '',
     runtime_component_paths: runtimeComponentPaths,
+    component_contracts: uniqueComponentContracts(request.component_contracts || []),
     homeboy_path: argValue('--homeboy') || request.homeboy_path || request.homeboy || '',
     homeboy_extensions_path: argValue('--homeboy-extensions') || request.homeboy_extensions_path || request.homeboy_extensions || path.resolve(__dirname, '..', '..'),
     wp_version: request.wp_codebox_wordpress_version || request.wp_version || request.wp || undefined,
@@ -606,12 +622,13 @@ function componentContracts(input) {
   // `component_contracts` shape:
   // `{ slug, path, loadAs, activate }`. WP Codebox mounts these as mu-plugins so
   // the runtime stack can register its tools and agent/chat surfaces.
-  return runtimeComponentExtraPlugins(input).map((plugin) => ({
+  const runtimeContracts = runtimeComponentExtraPlugins(input).map((plugin) => ({
     slug: plugin.slug,
     path: plugin.source,
     loadAs: plugin.loadAs || 'mu-plugin',
     activate: Boolean(plugin.activate),
   }));
+  return uniqueComponentContracts([...(input.component_contracts || []), ...runtimeContracts]);
 }
 
 function verifySteps(input) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -455,6 +455,22 @@ assert.deepEqual(abilityBridgeRequest.runtime_task.input, { artifact: { slug: 'e
 assert.equal(abilityBridgeRequest.parent_request.executor.config.output_mappings.validation_result, 'result.import_validation_result');
 assert.deepEqual(abilityBridgeRequest.component_contracts, [{ slug: 'wp-site-generator', path: '/workspace/wp-site-generator', activate: true }]);
 
+const topLevelComponentContractsRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'top-level-component-contracts-task-123',
+  component_contracts: [{ slug: 'domain-component', path: '/workspace/domain-component', activate: true }],
+  executor: {
+    backend: 'codebox',
+    config: {
+      component_contracts: [{ slug: 'config-component', path: '/workspace/config-component', activate: false }],
+    },
+  },
+});
+assert.deepEqual(topLevelComponentContractsRequest.component_contracts, [
+  { slug: 'domain-component', path: '/workspace/domain-component', activate: true },
+  { slug: 'config-component', path: '/workspace/config-component', activate: false },
+]);
+
 const genericRuntimeEnv = {
   GENERIC_PROVIDER_CONFIG: '/runtime/provider/config.json',
   XDG_DATA_HOME: '/runtime/provider/data',

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -213,6 +213,7 @@ try {
       agent_runtime: '/components/data-machine',
       agent_runtime_tools: '/components/data-machine-code',
     },
+    component_contracts: [{ slug: 'domain-component', path: '/workspace/domain-component', activate: true }],
     runtime_env: {
       GENERIC_PROVIDER_CONFIG: '/runtime/provider/config.json',
       XDG_DATA_HOME: '/runtime/provider/data',
@@ -299,6 +300,29 @@ try {
   assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'data-machine-code').path, '/components/data-machine-code');
   assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'data-machine').loadAs, 'mu-plugin');
   assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'data-machine-code').activate, false);
+  assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'domain-component').path, '/workspace/domain-component');
+  assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'domain-component').activate, true);
+
+  const nestedOnlyCapturePath = path.join(root, 'capture-nested-component-contracts.json');
+  const requestWithoutComponentContracts = { ...request };
+  delete requestWithoutComponentContracts.component_contracts;
+  const nestedOnlyResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+    '--agents-api', '/components/agents-api',
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...requestWithoutComponentContracts,
+      parent_request: {
+        component_contracts: [{ slug: 'nested-only-domain-component', path: '/workspace/nested-only-domain-component', activate: true }],
+      },
+    }),
+    env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: nestedOnlyCapturePath, OPENCODE_API_KEY: 'redacted-test-key' },
+  });
+  assert.equal(nestedOnlyResult.status, 0, nestedOnlyResult.stderr || nestedOnlyResult.stdout);
+  const nestedOnlyInput = readJson(nestedOnlyCapturePath).input;
+  assert.equal(nestedOnlyInput.component_contracts.some((contract) => contract.slug === 'nested-only-domain-component'), false);
 
   // Verification gate flows through to the agent-task-run input so WP Codebox
   // can emit it as a recipe workflow.after step and fail the run if it is red.


### PR DESCRIPTION
## Summary
- Normalize top-level request, executor config, and option-provided `component_contracts` into the WP Codebox task request top-level contract lane.
- Carry explicit component contracts through the task runner and merge them with derived runtime component contracts in the final stable input.
- Add smoke coverage for top-level/config contracts and for rejecting nested-only parent contracts as the canonical lane.

## Tests
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`

Closes #1397