### PR TITLE
Fix WP Codebox parent component contracts

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -628,7 +628,12 @@ function componentContracts(input) {
     loadAs: plugin.loadAs || 'mu-plugin',
     activate: Boolean(plugin.activate),
   }));
-  return uniqueComponentContracts([...(input.component_contracts || []), ...runtimeContracts]);
+  return uniqueComponentContracts([
+    ...(input.component_contracts || []),
+    ...(input.parent_request?.component_contracts || []),
+    ...(input.parent_request?.parent_request?.component_contracts || []),
+    ...runtimeContracts,
+  ]);
 }
 
 function verifySteps(input) {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -315,14 +315,19 @@ try {
     input: JSON.stringify({
       ...requestWithoutComponentContracts,
       parent_request: {
-        component_contracts: [{ slug: 'nested-only-domain-component', path: '/workspace/nested-only-domain-component', activate: true }],
+        component_contracts: [
+          { slug: 'nested-only-domain-component', path: '/workspace/nested-only-domain-component', activate: true },
+          { slug: 'nested-only-domain-component', path: '/workspace/nested-only-domain-component', activate: true },
+        ],
       },
     }),
     env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: nestedOnlyCapturePath, OPENCODE_API_KEY: 'redacted-test-key' },
   });
   assert.equal(nestedOnlyResult.status, 0, nestedOnlyResult.stderr || nestedOnlyResult.stdout);
   const nestedOnlyInput = readJson(nestedOnlyCapturePath).input;
-  assert.equal(nestedOnlyInput.component_contracts.some((contract) => contract.slug === 'nested-only-domain-component'), false);
+  assert.equal(nestedOnlyInput.component_contracts.find((contract) => contract.slug === 'nested-only-domain-component').path, '/workspace/nested-only-domain-component');
+  assert.equal(nestedOnlyInput.component_contracts.find((contract) => contract.slug === 'nested-only-domain-component').activate, true);
+  assert.equal(nestedOnlyInput.component_contracts.filter((contract) => contract.slug === 'nested-only-domain-component').length, 1);
 
   // Verification gate flows through to the agent-task-run input so WP Codebox
   // can emit it as a recipe workflow.after step and fail the run if it is red.


### PR DESCRIPTION
## Summary
- Preserve domain component contracts supplied under parent requests when building stable WP Codebox task input.
- Keep runtime component contracts merged through the existing generic de-dupe path.
- Update WP Codebox task runner smoke coverage for parent-request-only component contracts.

Fixes #1404

## Testing
- npm run test:wp-codebox-task-runner
- node --check scripts/agent/homeboy-wp-codebox-task-runner.cjs
- node --check tests/wp-codebox-task-runner-smoke.js

## Notes
- npm run lint:js currently fails on unrelated existing lint errors outside this change.