### PR TITLE
fix: advertise wordpress loop capabilities

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -29,6 +29,16 @@ const PROVIDER_CAPABILITIES = [
   'typed_bundle_outputs',
   'external_recipe_packs',
   'recipe_probe_artifacts',
+  'tool:datamachine/run-agent-bundle',
+  'tool:github_issue_publish',
+  'tool:github_pull_request_publish',
+  'tool:comment_github_pull_request',
+  'tool:wpsg_materialize_packet',
+  'ability:datamachine/run-agent-bundle',
+  'ability:github_issue_publish',
+  'ability:github_pull_request_publish',
+  'ability:comment_github_pull_request',
+  'ability:wpsg_materialize_packet',
 ];
 
 const DEFAULT_WORKSPACE_READONLY_TOOLS = [

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -280,6 +280,12 @@ assert.equal(provider.capabilities.includes('agent_bundle_execution'), true);
 assert.equal(provider.capabilities.includes('typed_bundle_outputs'), true);
 assert.equal(provider.capabilities.includes('external_recipe_packs'), true);
 assert.equal(provider.capabilities.includes('recipe_probe_artifacts'), true);
+assert.equal(provider.capabilities.includes('tool:datamachine/run-agent-bundle'), true);
+assert.equal(provider.capabilities.includes('tool:github_pull_request_publish'), true);
+assert.equal(provider.capabilities.includes('tool:wpsg_materialize_packet'), true);
+assert.equal(provider.capabilities.includes('ability:datamachine/run-agent-bundle'), true);
+assert.equal(provider.capabilities.includes('ability:github_pull_request_publish'), true);
+assert.equal(provider.capabilities.includes('ability:wpsg_materialize_packet'), true);
 assert.deepEqual(provider.runtime_gap_trackers, []);
 
 const codeboxRequest = codeboxTaskRequestFromAgentTaskRequest(request);
@@ -2078,7 +2084,7 @@ try {
   ], { encoding: 'utf8' });
   assert.equal(contractResult.status, 0, contractResult.stderr || contractResult.stdout);
   const printedContract = JSON.parse(contractResult.stdout);
-  assert.equal(printedContract.id, 'wordpress.codebox-agent-task-executor');
+  assert.equal(printedContract.id, provider.id);
   assert.deepEqual(printedContract.outcome_statuses, provider.outcome_statuses);
   assert.deepEqual(printedContract.failure_classifications, provider.failure_classifications);
 


### PR DESCRIPTION
## Summary
- Advertise the WordPress loop tool/ability capabilities handled by the WordPress agent-task executor.
- Cover the capabilities in the provider contract test and align the printed-contract id assertion with the provider contract.

## Context
A real Homeboy/WPSG controller run reached dispatch and failed because the installed WordPress provider rejected repo-declared workflow capabilities such as `tool:datamachine/run-agent-bundle`, `tool:github_pull_request_publish`, and `tool:wpsg_materialize_packet` as missing.

## Verification
- `npm run test:codebox-agent-task-executor`
- `npm run lint:js -- lib/codebox-agent-task-executor.js --no-warn-ignored`