### PR TITLE
fix: advertise wordpress manifest capabilities

### DIFF
--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -21,6 +21,14 @@ const codexSecretEnv = [
   'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
 ];
 const claudeCodeRefreshTokenEnv = 'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN';
+const repoLoopCapabilities = [
+  'tool:datamachine/run-agent-bundle',
+  'tool:github_pull_request_publish',
+  'tool:wpsg_materialize_packet',
+  'ability:datamachine/run-agent-bundle',
+  'ability:github_pull_request_publish',
+  'ability:wpsg_materialize_packet',
+];
 
 function fixtureEnv(overrides = {}) {
   const env = { ...process.env, ...overrides };
@@ -280,12 +288,14 @@ assert.equal(provider.capabilities.includes('agent_bundle_execution'), true);
 assert.equal(provider.capabilities.includes('typed_bundle_outputs'), true);
 assert.equal(provider.capabilities.includes('external_recipe_packs'), true);
 assert.equal(provider.capabilities.includes('recipe_probe_artifacts'), true);
-assert.equal(provider.capabilities.includes('tool:datamachine/run-agent-bundle'), true);
-assert.equal(provider.capabilities.includes('tool:github_pull_request_publish'), true);
-assert.equal(provider.capabilities.includes('tool:wpsg_materialize_packet'), true);
-assert.equal(provider.capabilities.includes('ability:datamachine/run-agent-bundle'), true);
-assert.equal(provider.capabilities.includes('ability:github_pull_request_publish'), true);
-assert.equal(provider.capabilities.includes('ability:wpsg_materialize_packet'), true);
+for (const capability of repoLoopCapabilities) {
+  assert.equal(provider.capabilities.includes(capability), true);
+}
+const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'wordpress.json'), 'utf8'));
+const manifestProvider = manifest.agent_task_executors.find((executor) => executor.id === provider.id);
+for (const capability of repoLoopCapabilities) {
+  assert.equal(manifestProvider.capabilities.includes(capability), true);
+}
 assert.deepEqual(provider.runtime_gap_trackers, []);
 
 const codeboxRequest = codeboxTaskRequestFromAgentTaskRequest(request);

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -63,7 +63,17 @@
         "cleanup_observability",
         "screenshots",
         "structured_outcome",
-        "agent_bundle_execution"
+        "agent_bundle_execution",
+        "tool:datamachine/run-agent-bundle",
+        "tool:github_issue_publish",
+        "tool:github_pull_request_publish",
+        "tool:comment_github_pull_request",
+        "tool:wpsg_materialize_packet",
+        "ability:datamachine/run-agent-bundle",
+        "ability:github_issue_publish",
+        "ability:github_pull_request_publish",
+        "ability:comment_github_pull_request",
+        "ability:wpsg_materialize_packet"
       ],
       "workspace_materialization": {
         "cwd": "git_checkout"


### PR DESCRIPTION
## Summary
- Add repo-loop tool/ability capabilities to the static WordPress extension manifest that Homeboy provider discovery reads.
- Extend the codebox agent-task executor test to verify both the runtime provider contract and `wordpress.json` manifest expose those capabilities.

## Context
PR #1408 updated the runtime provider module, but `homeboy agent-task providers` reads `agent_task_executors` from `wordpress.json`. After updating the installed WordPress extension to v2.121.50, provider discovery still omitted `tool:datamachine/run-agent-bundle`, `tool:github_pull_request_publish`, and `tool:wpsg_materialize_packet`, so the WPSG/Homeboy controller E2E would still fail at capability selection.

## Verification
- `jq empty wordpress.json`
- `npm run test:codebox-agent-task-executor`
- `npm run lint:js -- lib/codebox-agent-task-executor.js --no-warn-ignored`