### PR TITLE
fix: prepare nested runtime components

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -270,6 +270,35 @@ function preparePluginDirectory(source, slug, preparedRoot, artifacts) {
   return { source: target, prepared: true, original_source: source, slug: safeSlug };
 }
 
+function sourceDepth(source) {
+  return String(source || '').split(path.sep).filter(Boolean).length;
+}
+
+function nestedPreparedPath(source, preparedItems) {
+  for (const item of preparedItems) {
+    if (!item.prepared || !item.original_source || item.original_source === source || !pathInside(item.original_source, source)) {
+      continue;
+    }
+    return {
+      source: path.join(item.source, path.relative(item.original_source, source)),
+      prepared: true,
+      original_source: source,
+      nested_under: item.original_source,
+    };
+  }
+  return null;
+}
+
+function runtimePreparationSources(taskInput) {
+  return [
+    ...(Array.isArray(taskInput.extra_plugins) ? taskInput.extra_plugins.map((plugin) => [plugin?.source, plugin?.slug]) : []),
+    ...(Array.isArray(taskInput.component_contracts) ? taskInput.component_contracts.map((contract) => [contract?.path || contract?.source, contract?.slug]) : []),
+    ...(plainObject(taskInput.runtime_component_paths) ? Object.entries(taskInput.runtime_component_paths).map(([, source]) => [source, '']) : []),
+  ]
+    .filter(([source]) => source && path.isAbsolute(source))
+    .sort(([left], [right]) => sourceDepth(left) - sourceDepth(right));
+}
+
 function prepareStableTaskInput(taskInput, artifacts) {
   const preparedRoot = path.join(artifacts, 'prepared-plugins');
   const preparedBySource = new Map();
@@ -277,10 +306,14 @@ function prepareStableTaskInput(taskInput, artifacts) {
     if (!source || preparedBySource.has(source)) {
       return preparedBySource.get(source) || { source, prepared: false };
     }
-    const prepared = preparePluginDirectory(source, slug, preparedRoot, artifacts);
+    const prepared = nestedPreparedPath(source, preparedBySource.values()) || preparePluginDirectory(source, slug, preparedRoot, artifacts);
     preparedBySource.set(source, prepared);
     return prepared;
   };
+
+  for (const [source, slug] of runtimePreparationSources(taskInput)) {
+    prepare(source, slug);
+  }
 
   const preparedExtraPlugins = Array.isArray(taskInput.extra_plugins)
     ? taskInput.extra_plugins.map((plugin) => {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -527,6 +527,39 @@ try {
   assert.equal(preparedRuntimeInput.runtime_component_paths.agent_runtime_tools, preparedRuntimePath);
   assert.equal(fs.existsSync(path.join(preparedRuntimePath, 'data-machine-code.php')), true);
 
+  const nestedRuntimeRoot = path.join(root, 'nested-runtime-components');
+  const nestedDataMachine = path.join(nestedRuntimeRoot, 'data-machine');
+  const nestedAgentsApi = path.join(nestedDataMachine, 'vendor', 'wordpress', 'agents-api');
+  const nestedArtifacts = path.join(root, 'prepared-nested-runtime-component-artifacts');
+  fs.mkdirSync(nestedAgentsApi, { recursive: true });
+  fs.writeFileSync(path.join(nestedDataMachine, 'data-machine.php'), "<?php\n/* Plugin Name: Data Machine */\n");
+  fs.writeFileSync(path.join(nestedAgentsApi, 'agents-api.php'), "<?php\n/* Plugin Name: Agents API */\n");
+  const nestedRuntimeCapturePath = path.join(root, 'capture-nested-prepared-runtime-component.json');
+  const nestedRuntimeResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+    '--artifacts', nestedArtifacts,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      runtime_component_paths: {
+        agents_api: nestedAgentsApi,
+        agent_runtime: nestedDataMachine,
+      },
+    }),
+    env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: nestedRuntimeCapturePath, OPENCODE_API_KEY: 'redacted-test-key' },
+  });
+  assert.equal(nestedRuntimeResult.status, 0, nestedRuntimeResult.stderr || nestedRuntimeResult.stdout);
+  const nestedRuntimeInput = readJson(nestedRuntimeCapturePath).input;
+  const preparedDataMachine = path.join(nestedArtifacts, 'prepared-plugins', 'data-machine');
+  const preparedAgentsApi = path.join(preparedDataMachine, 'vendor', 'wordpress', 'agents-api');
+  assert.equal(nestedRuntimeInput.runtime_component_paths.agent_runtime, preparedDataMachine);
+  assert.equal(nestedRuntimeInput.runtime_component_paths.agents_api, preparedAgentsApi);
+  assert.equal(nestedRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'agents-api').source, preparedAgentsApi);
+  assert.equal(nestedRuntimeInput.component_contracts.find((contract) => contract.slug === 'agents-api').path, preparedAgentsApi);
+  assert.equal(fs.existsSync(path.join(preparedAgentsApi, 'agents-api.php')), true);
+
   const legacyRuntimeCapturePath = path.join(root, 'capture-legacy-runtime-stack.json');
   const legacyRuntimeResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),


### PR DESCRIPTION
## Summary
- Prepare runtime component sources in parent-first order.
- Map nested runtime components, such as `agents-api` inside `data-machine`, into the prepared parent copy instead of a missing sibling prepared path.
- Add smoke coverage for nested runtime component paths.

## Context
The WPSG/Homeboy controller E2E now reaches WP Codebox with a mounted workspace, but WP Codebox failed while lstat-ing `prepared-plugins/agents-api`. The runner had prepared `data-machine` and `data-machine-code`, while `agents-api` is nested under `data-machine/vendor/wordpress/agents-api`; its path must resolve inside the prepared `data-machine` tree.

## Verification
- `npm run test:wp-codebox-task-runner`
- `npm run lint:js -- scripts/agent/homeboy-wp-codebox-task-runner.cjs tests/wp-codebox-task-runner-smoke.js --no-warn-ignored`