### PR TITLE
fix: keep Codex provider stack explicit

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -11,6 +11,17 @@ Homeboy core may pass `HOMEBOY_COMPONENT_SHAPE=core-dev` for registered componen
 
 The core-dev runner expects WordPress core's own dependencies and config. It installs missing npm/composer dependencies, builds `src/` into `build/`, and runs PHPUnit through core's `vendor/bin/phpunit`. If `wp-tests-config.php` is missing, set `HOMEBOY_WP_TESTS_DB_NAME`, `HOMEBOY_WP_TESTS_DB_USER`, `HOMEBOY_WP_TESTS_DB_PASSWORD`, and optionally `HOMEBOY_WP_TESTS_DB_HOST` so the runner can write it from the sample config.
 
+## Codex WP Codebox Stack
+
+Codex WP Codebox tasks require an explicit provider/runtime stack. Homeboy does not infer these paths from local worktree names, and it does not fetch provider PR branches itself before dispatch.
+
+Configure the Codex pair with task config, global settings, or environment variables:
+
+- `provider_plugin_paths` / `wp_codebox_provider_plugin_paths` / `HOMEBOY_WP_CODEBOX_PROVIDER_PLUGIN_PATH`: a Codex-capable provider plugin checkout, such as the Codex provider branch of `ai-provider-for-openai`.
+- `runtime_overlays` / `wp_codebox_runtime_overlays`, or `wp_codebox_php_ai_client_path` / `HOMEBOY_WP_CODEBOX_PHP_AI_CLIENT_PATH`: a prepared `php-ai-client` checkout mounted to `/wordpress/wp-includes/php-ai-client`.
+
+The `php-ai-client` checkout must include bearer-token auth support (`RequestAuthenticationMethod::bearerToken`) and Composer vendor dependencies (`vendor/autoload.php`). If the stack is incomplete, the executor emits diagnostics for the missing Codex provider plugin, missing bearer-token auth, or missing Composer vendor preparation.
+
 ## Test failure sidecar
 
 When Homeboy sets `HOMEBOY_TEST_FAILURES_FILE`, the WordPress PHPUnit runners write a JSON sidecar with parsed failure details. Existing Homeboy analysis fields are preserved, and each failure also includes normalized sidecar fields for cross-runner consumers:

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -73,6 +73,7 @@ const CLAUDE_CODE_SECRET_ENV = [
 
 const DEFAULT_CODEX_MODEL = 'gpt-5.5';
 const CODEX_PROVIDER_PLUGIN_GUIDANCE = `Codex tasks require a Codex-capable provider plugin checkout, such as the Codex PR branch for ai-provider-for-openai. Released ai-provider-for-openai trunk registers openai, not codex, and unrelated provider defaults such as ${['ai-provider-for', ['open', 'code'].join('')].join('-')} will not work.`;
+const CODEX_PHP_AI_CLIENT_GUIDANCE = 'Codex tasks require a php-ai-client checkout that supports RequestAuthenticationMethod::bearerToken and has Composer vendor dependencies installed before WP Codebox prepares the runtime overlay.';
 
 const AGENT_BUNDLE_CONFIG_FIELDS = [
   'bundle_path',
@@ -530,8 +531,6 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
   const providerPluginPath = firstExistingPath(
     settings.wp_codebox_provider_plugin_path,
     process.env.HOMEBOY_WP_CODEBOX_PROVIDER_PLUGIN_PATH,
-    siblingPath(workspaceBase, 'ai-provider-for-openai'),
-    siblingPath(workspaceBase, 'ai-provider-for-openai-main'),
   );
   const provider = config.provider || options.provider || defaultProvider(settings, providerPluginPath);
   const model = config.model || options.model || defaultModelForProvider(provider, settings);
@@ -542,7 +541,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     process.env.HOMEBOY_WP_CODEBOX_AGENTS_API_PATH,
     bundledAgentsApiPath(dataMachinePath),
   );
-  const phpAiClientPath = defaultPhpAiClientPath(settings, workspaceBase, options);
+  const phpAiClientPath = defaultPhpAiClientPath(settings, options);
 
   return {
     agentsApi: agentsApiPath,
@@ -596,20 +595,13 @@ function defaultRuntimeOverlays(settings, phpAiClientPath = '') {
   }] : [];
 }
 
-function defaultPhpAiClientPath(settings, workspaceBase, options = {}) {
+function defaultPhpAiClientPath(settings, options = {}) {
   return firstExistingPath(
     options.phpAiClient,
     settings.wp_codebox_php_ai_client_path,
     settings.php_ai_client_path,
     process.env.HOMEBOY_WP_CODEBOX_PHP_AI_CLIENT_PATH,
     process.env.PHP_AI_CLIENT_PATH,
-    siblingPath(workspaceBase, 'php-ai-client'),
-    siblingPath(path.dirname(workspaceBase), 'php-ai-client@custom-provider-auth-live'),
-    siblingPath(path.dirname(workspaceBase), 'php-ai-client@custom-provider-auth'),
-    siblingPath(path.dirname(workspaceBase), 'php-ai-client'),
-    siblingPath(path.dirname(path.dirname(workspaceBase)), 'php-ai-client@custom-provider-auth-live'),
-    siblingPath(path.dirname(path.dirname(workspaceBase)), 'php-ai-client@custom-provider-auth'),
-    siblingPath(path.dirname(path.dirname(workspaceBase)), 'php-ai-client'),
   );
 }
 
@@ -1776,7 +1768,74 @@ function codexProviderNotRegisteredDiagnostic(request, result = {}) {
       provider: 'codex',
       provider_plugin_paths: providerPluginPaths,
       expected: 'Codex-capable ai-provider-for-openai checkout from the Codex provider branch/PR.',
+      missing_provider_plugin_path: providerPluginPaths.length === 0,
       guidance: CODEX_PROVIDER_PLUGIN_GUIDANCE,
+    },
+  };
+}
+
+function codexDiagnosticText(result = {}) {
+  const diagnostics = resultDiagnostics(result).flatMap((diagnostic) => [
+    diagnostic.message,
+    diagnostic.code,
+    diagnostic.class,
+    diagnostic.kind,
+    diagnostic.data?.stderr,
+    diagnostic.data?.stdout,
+    diagnostic.data?.message,
+  ]);
+  return [
+    result.summary,
+    result.message,
+    result.error,
+    result.stderr,
+    result.stdout,
+    result.code,
+    result.error_code,
+    result.errorCode,
+    result.metadata?.summary,
+    result.metadata?.message,
+    result.metadata?.error,
+    result.metadata?.stderr,
+    result.metadata?.stdout,
+    ...diagnostics,
+  ].filter(Boolean).map(String).join('\n');
+}
+
+function codexPhpAiClientBearerTokenDiagnostic(request, result = {}) {
+  if (codexProviderFromRequest(request, result) !== 'codex') {
+    return null;
+  }
+  const text = codexDiagnosticText(result);
+  if (!/RequestAuthenticationMethod::bearerToken|bearerToken\(\).*does not exist|undefined method .*bearerToken/i.test(text)) {
+    return null;
+  }
+  return {
+    class: 'codebox.codex_php_ai_client_missing_bearer_token_auth',
+    message: `Codex provider loaded, but php-ai-client does not expose bearer-token auth. ${CODEX_PHP_AI_CLIENT_GUIDANCE}`,
+    data: {
+      provider: 'codex',
+      expected: 'php-ai-client with RequestAuthenticationMethod::bearerToken support.',
+      guidance: CODEX_PHP_AI_CLIENT_GUIDANCE,
+    },
+  };
+}
+
+function codexPhpAiClientVendorDiagnostic(request, result = {}) {
+  if (codexProviderFromRequest(request, result) !== 'codex') {
+    return null;
+  }
+  const text = codexDiagnosticText(result);
+  if (!/php-ai-client[\s\S]*(vendor\/autoload\.php|vendor(?:\/|\\\\)|composer install|Composer vendor|vendor.*missing)|vendor(?:\/|\\\\).*php-ai-client/i.test(text)) {
+    return null;
+  }
+  return {
+    class: 'codebox.codex_php_ai_client_vendor_missing',
+    message: `WP Codebox could not prepare the php-ai-client runtime overlay because Composer vendor dependencies are missing. ${CODEX_PHP_AI_CLIENT_GUIDANCE}`,
+    data: {
+      provider: 'codex',
+      expected: 'Prepared php-ai-client checkout with vendor/autoload.php present.',
+      guidance: CODEX_PHP_AI_CLIENT_GUIDANCE,
     },
   };
 }
@@ -1798,6 +1857,8 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   const fallbackRecipeSummary = recipeRunFailureSummary(recipeRun);
   const recipeFailedPhase = recipeSummary?.failed_phase || recipeSummary?.metadata?.failure_phase || recipeRunFailedPhase(recipeRun);
   const codexProviderDiagnostic = codexProviderNotRegisteredDiagnostic(request, result);
+  const codexBearerTokenDiagnostic = codexPhpAiClientBearerTokenDiagnostic(request, result);
+  const codexVendorDiagnostic = codexPhpAiClientVendorDiagnostic(request, result);
   const outcome = {
     schema: AGENT_TASK_OUTCOME_SCHEMA,
     task_id: request.task_id,
@@ -1806,7 +1867,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     artifacts: normalizeArtifacts(result, runSummary, recipeSummary),
     evidence_refs: normalizeEvidenceRefs(result, runSummary, recipeSummary),
     outputs,
-    diagnostics: [codexProviderDiagnostic, recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
+    diagnostics: [codexProviderDiagnostic, codexBearerTokenDiagnostic, codexVendorDiagnostic, recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
       message: diagnostic.message || String(diagnostic),
       data: sanitizePublicMetadata(diagnostic.data || {}),

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -665,14 +665,6 @@ try {
   const staleStandaloneAgentsApiPath = path.join(defaultsRoot, 'agents-api');
   const providerPath = path.join(defaultsRoot, 'ai-provider-for-openai');
   const phpAiClientPath = path.join(defaultsRoot, 'php-ai-client');
-  const defaultPhpAiClientOverlay = [{
-    kind: 'bundled-library',
-    library: 'php-ai-client',
-    source: phpAiClientPath,
-    target: '/wordpress/wp-includes/php-ai-client',
-    strategy: 'wordpress-scoped-bundle',
-    metadata: { component: 'php-ai-client', source: 'homeboy-extensions-default' },
-  }];
   for (const directory of [workspaceRoot, bundledAgentsApiPath, dataMachineCodePath, staleStandaloneAgentsApiPath, providerPath, phpAiClientPath]) {
     fs.mkdirSync(directory, { recursive: true });
   }
@@ -695,7 +687,7 @@ try {
   assert.equal(defaultedRequest.runtime_component_paths.agent_runtime_tools, dataMachineCodePath);
   assert.deepEqual(defaultedRequest.provider_plugin_paths, []);
   assert.deepEqual(defaultedRequest.runtime_overlay_profiles, []);
-  assert.deepEqual(defaultedRequest.runtime_overlays, defaultPhpAiClientOverlay);
+  assert.deepEqual(defaultedRequest.runtime_overlays, []);
   assert.deepEqual(defaultedRequest.secret_env, [
     'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
     'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
@@ -708,6 +700,8 @@ try {
   assert.equal(defaultedRequest.mounts[0].mode, 'readwrite');
   assert.equal(defaultedRequest.mounts[0].metadata.workspace_slug, 'target-repo');
   assert.deepEqual(defaultedRequest.workspaces, []);
+  assert(!JSON.stringify(defaultedRequest).includes(providerPath));
+  assert(!JSON.stringify(defaultedRequest).includes(phpAiClientPath));
   assert(!JSON.stringify(defaultedRequest).includes(staleStandaloneAgentsApiPath));
   assert(!JSON.stringify(defaultedRequest).includes(alternateBundledAgentsApiPath));
 
@@ -738,7 +732,7 @@ try {
   assert.equal(codexSubscriptionDefaultedRequest.model, 'gpt-5.5');
   assert.deepEqual(codexSubscriptionDefaultedRequest.provider_plugin_paths, []);
   assert.deepEqual(codexSubscriptionDefaultedRequest.runtime_overlay_profiles, []);
-  assert.deepEqual(codexSubscriptionDefaultedRequest.runtime_overlays, defaultPhpAiClientOverlay);
+  assert.deepEqual(codexSubscriptionDefaultedRequest.runtime_overlays, []);
   assert.deepEqual(codexSubscriptionDefaultedRequest.secret_env, codexSecretEnv);
 
   const openAiDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
@@ -755,9 +749,9 @@ try {
   }, {
     settings: { wp_codebox_codex_enabled: false },
   });
-  assert.equal(openAiDefaultedRequest.provider, 'openai');
+  assert.equal(openAiDefaultedRequest.provider, '');
   assert.equal(openAiDefaultedRequest.model, 'gpt-5.5');
-  assert.deepEqual(openAiDefaultedRequest.secret_env, ['OPENAI_API_KEY']);
+  assert.deepEqual(openAiDefaultedRequest.secret_env, []);
 
   const bareOpenAiDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,
@@ -772,9 +766,9 @@ try {
   }, {
     settings: { wp_codebox_codex_enabled: false },
   });
-  assert.equal(bareOpenAiDefaultedRequest.provider, 'openai');
+  assert.equal(bareOpenAiDefaultedRequest.provider, '');
   assert.equal(bareOpenAiDefaultedRequest.model, '');
-  assert.deepEqual(bareOpenAiDefaultedRequest.secret_env, ['OPENAI_API_KEY']);
+  assert.deepEqual(bareOpenAiDefaultedRequest.secret_env, []);
   // A bare repo workspace defaults to a read-write mount, so coding-capable
   // workspace tools must be exposed alongside the read-only inspection tools.
   const writableWorkspaceTools = [
@@ -909,25 +903,23 @@ try {
   assert.deepEqual(configuredGenericStackRequest.runtime_overlays, configuredRuntimeOverlays);
   assert.deepEqual(configuredGenericStackRequest.secret_env, ['CONFIGURED_SECRET']);
 
-  const labWorkspaceRoot = path.join(defaultsRoot, '_lab_workspaces', 'target-repo@issue-1161');
-  const labPhpAiClientPath = path.join(defaultsRoot, 'php-ai-client@custom-provider-auth');
-  fs.mkdirSync(labWorkspaceRoot, { recursive: true });
-  fs.mkdirSync(labPhpAiClientPath, { recursive: true });
-  const labDefaultedRequest = codeboxTaskRequestFromAgentTaskRequest({
+  const explicitPhpAiClientPath = path.join(defaultsRoot, 'explicit-php-ai-client');
+  fs.mkdirSync(explicitPhpAiClientPath, { recursive: true });
+  const explicitPhpAiClientRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,
-    task_id: 'lab-default-runtime-stack-task-123',
+    task_id: 'explicit-php-ai-client-runtime-stack-task-123',
     executor: {
       backend: 'codebox',
       config: { provider: 'codex' },
     },
     inputs: {
-      target: { root: labWorkspaceRoot },
+      target: { root: workspaceRoot },
     },
   }, {
-    settings: {},
+    settings: { wp_codebox_php_ai_client_path: explicitPhpAiClientPath },
   });
-  assert.equal(fs.realpathSync(labDefaultedRequest.runtime_overlays[0].source), fs.realpathSync(labPhpAiClientPath));
-  assert.equal(labDefaultedRequest.runtime_overlays[0].strategy, 'wordpress-scoped-bundle');
+  assert.equal(fs.realpathSync(explicitPhpAiClientRequest.runtime_overlays[0].source), fs.realpathSync(explicitPhpAiClientPath));
+  assert.equal(explicitPhpAiClientRequest.runtime_overlays[0].strategy, 'wordpress-scoped-bundle');
 
   const originalCwd = process.cwd();
   const labOffloadCwd = path.join(defaultsRoot, '_lab_workspaces', 'wp-site-generator-pilot-homeboy-ssi-loop');
@@ -945,8 +937,8 @@ try {
     }, {
       settings: {},
     });
-    assert.equal(fs.realpathSync(labNoTargetDefaultedRequest.runtime_overlays[0].source), fs.realpathSync(labPhpAiClientPath));
-    assert.equal(labNoTargetDefaultedRequest.runtime_overlays[0].strategy, 'wordpress-scoped-bundle');
+    assert.deepEqual(labNoTargetDefaultedRequest.runtime_overlays, []);
+    assert(!JSON.stringify(labNoTargetDefaultedRequest).includes('php-ai-client@custom-provider-auth'));
   } finally {
     process.chdir(originalCwd);
   }
@@ -1600,6 +1592,65 @@ assert(codexGuidanceDiagnostic);
 assert.match(codexGuidanceDiagnostic.message, /Codex-capable provider plugin checkout/);
 assert.match(codexGuidanceDiagnostic.message, /Released ai-provider-for-openai trunk registers openai, not codex/);
 assert.deepEqual(codexGuidanceDiagnostic.data.provider_plugin_paths, ['/components/ai-provider-for-openai']);
+
+const codexMissingProviderPluginOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  task_id: 'codex-missing-provider-plugin-task-123',
+  executor: {
+    backend: 'codebox',
+    config: { provider: 'codex' },
+  },
+}, {
+  success: false,
+  status: 'failed',
+  summary: 'Requested provider "codex" is not registered in wp-ai-client after sandbox provider plugins were loaded.',
+  diagnostics: [{ class: 'wp_codebox_provider_not_registered' }],
+  task_input: {
+    provider: 'codex',
+    provider_plugin_paths: [],
+  },
+});
+const codexMissingProviderPluginDiagnostic = codexMissingProviderPluginOutcome.diagnostics.find((diagnostic) => diagnostic.class === 'codebox.codex_provider_plugin_guidance');
+assert(codexMissingProviderPluginDiagnostic);
+assert.equal(codexMissingProviderPluginDiagnostic.data.missing_provider_plugin_path, true);
+assert.deepEqual(codexMissingProviderPluginDiagnostic.data.provider_plugin_paths, []);
+
+const codexBearerTokenOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  task_id: 'codex-bearer-token-task-123',
+  executor: {
+    backend: 'codebox',
+    config: { provider: 'codex' },
+  },
+}, {
+  success: false,
+  status: 'failed',
+  summary: 'Fatal error: Call to undefined method WordPress\\AiClient\\Authentication\\RequestAuthenticationMethod::bearerToken()',
+  task_input: { provider: 'codex' },
+});
+const codexBearerTokenDiagnostic = codexBearerTokenOutcome.diagnostics.find((diagnostic) => diagnostic.class === 'codebox.codex_php_ai_client_missing_bearer_token_auth');
+assert(codexBearerTokenDiagnostic);
+assert.match(codexBearerTokenDiagnostic.message, /bearer-token auth/);
+
+const codexVendorOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  task_id: 'codex-vendor-task-123',
+  executor: {
+    backend: 'codebox',
+    config: { provider: 'codex' },
+  },
+}, {
+  success: false,
+  status: 'failed',
+  diagnostics: [{
+    class: 'wp_codebox_overlay_prepare_failed',
+    message: 'Unable to prepare php-ai-client overlay: vendor/autoload.php missing; run composer install before dispatch.',
+  }],
+  task_input: { provider: 'codex' },
+});
+const codexVendorDiagnostic = codexVendorOutcome.diagnostics.find((diagnostic) => diagnostic.class === 'codebox.codex_php_ai_client_vendor_missing');
+assert(codexVendorDiagnostic);
+assert.match(codexVendorDiagnostic.message, /Composer vendor dependencies are missing/);
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-agent-task-executor-'));
 try {


### PR DESCRIPTION
## Summary
- Remove local sibling worktree-name fallback discovery for Codex provider plugins and php-ai-client runtime overlays.
- Add Codex diagnostics for missing provider plugin paths, php-ai-client missing bearer-token auth, and php-ai-client missing Composer vendor preparation.
- Document the explicit Codex WP Codebox provider/runtime pair and extend smoke coverage.

## Testing
- npm run test:codebox-agent-task-executor
- npm run test:wp-codebox-task-runner
- npx eslint lib/codebox-agent-task-executor.js --no-warn-ignored

## Notes
- Did not run Cargo locally per issue constraints.
- Full npm run lint:js is blocked by existing unrelated lint errors in playground-readiness.js, timing-correlator.js, and several scripts/ files.

Fixes #1411