### PR TITLE
Validate WordPress runtime overlays before Codebox dispatch

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -18,7 +18,7 @@ Codex WP Codebox tasks require an explicit provider/runtime stack. Homeboy does 
 Configure the Codex pair with task config, global settings, or environment variables:
 
 - `provider_plugin_paths` / `wp_codebox_provider_plugin_paths` / `HOMEBOY_WP_CODEBOX_PROVIDER_PLUGIN_PATH`: a Codex-capable provider plugin checkout, such as the Codex provider branch of `ai-provider-for-openai`.
-- `runtime_overlays` / `wp_codebox_runtime_overlays`, or `wp_codebox_php_ai_client_path` / `HOMEBOY_WP_CODEBOX_PHP_AI_CLIENT_PATH`: a prepared `php-ai-client` checkout mounted to `/wordpress/wp-includes/php-ai-client`.
+- `runtime_overlays` / `wp_codebox_runtime_overlays`, or `wp_codebox_php_ai_client_path` / `HOMEBOY_WP_CODEBOX_PHP_AI_CLIENT_PATH`: a prepared `php-ai-client` checkout mounted to `/wordpress/wp-includes/php-ai-client`. Explicit runtime overlay entries must use the canonical `kind` field, for example `{ "kind": "bundled-library", "library": "php-ai-client", "source": "/abs/path/to/php-ai-client" }`; legacy `type` entries are rejected before WP Codebox dispatch.
 
 The `php-ai-client` checkout must include bearer-token auth support (`RequestAuthenticationMethod::bearerToken`) and Composer vendor dependencies (`vendor/autoload.php`). If the stack is incomplete, the executor emits diagnostics for the missing Codex provider plugin, missing bearer-token auth, or missing Composer vendor preparation.
 

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -74,6 +74,7 @@ const CLAUDE_CODE_SECRET_ENV = [
 const DEFAULT_CODEX_MODEL = 'gpt-5.5';
 const CODEX_PROVIDER_PLUGIN_GUIDANCE = `Codex tasks require a Codex-capable provider plugin checkout, such as the Codex PR branch for ai-provider-for-openai. Released ai-provider-for-openai trunk registers openai, not codex, and unrelated provider defaults such as ${['ai-provider-for', ['open', 'code'].join('')].join('-')} will not work.`;
 const CODEX_PHP_AI_CLIENT_GUIDANCE = 'Codex tasks require a php-ai-client checkout that supports RequestAuthenticationMethod::bearerToken and has Composer vendor dependencies installed before WP Codebox prepares the runtime overlay.';
+const RUNTIME_OVERLAY_CANONICAL_SHAPE = 'runtime_overlays entries must be objects with a non-empty string kind, for example { "kind": "bundled-library", "library": "php-ai-client", "source": "/path/to/php-ai-client" }. The legacy type field is not accepted.';
 
 const AGENT_BUNDLE_CONFIG_FIELDS = [
   'bundle_path',
@@ -234,6 +235,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const timeoutSeconds = request.limits?.task_timeout_seconds || request.limits?.taskTimeoutSeconds;
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
   const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
+  const runtimeOverlays = runtimeOverlaysFromConfig(config, options, defaults);
   const context = {
     ...(inputs.context || {}),
     agent_task_id: request.task_id,
@@ -267,7 +269,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     agent_bundles: agentBundles,
     runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
     runtime_overlay_profiles: config.runtime_overlay_profiles || config.runtimeOverlayProfiles || options.runtimeOverlayProfiles || defaults.runtimeOverlayProfiles || [],
-    runtime_overlays: config.runtime_overlays || options.runtimeOverlays || defaults.runtimeOverlays || [],
+    runtime_overlays: runtimeOverlays,
     runtime_env: firstDefined(config.runtime_env, config.runtimeEnv, config.wp_codebox_runtime_env, options.runtimeEnv, defaults.runtimeEnv, {}),
     runtime_state_mounts: firstDefined(config.runtime_state_mounts, config.runtimeStateMounts, config.wp_codebox_runtime_state_mounts, options.runtimeStateMounts, defaults.runtimeStateMounts, []),
     runtime_config_mounts: firstDefined(config.runtime_config_mounts, config.runtimeConfigMounts, config.wp_codebox_runtime_config_mounts, options.runtimeConfigMounts, defaults.runtimeConfigMounts, []),
@@ -295,6 +297,64 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     },
     agent_bundle: agentBundle,
     parent_request: request,
+  };
+}
+
+class RuntimeOverlayConfigError extends Error {
+  constructor(diagnostics) {
+    super(diagnostics[0]?.message || 'Invalid WordPress executor runtime overlay config.');
+    this.name = 'RuntimeOverlayConfigError';
+    this.diagnostics = diagnostics;
+  }
+}
+
+function runtimeOverlaysFromConfig(config, options = {}, defaults = {}) {
+  return validateRuntimeOverlays(firstDefined(
+    config.runtime_overlays,
+    options.runtimeOverlays,
+    defaults.runtimeOverlays,
+    []
+  ));
+}
+
+function validateRuntimeOverlays(value) {
+  const overlays = normalizeArray(value);
+  const diagnostics = [];
+
+  overlays.forEach((overlay, index) => {
+    const pathPrefix = `runtime_overlays[${index}]`;
+    if (!overlay || typeof overlay !== 'object' || Array.isArray(overlay)) {
+      diagnostics.push(runtimeOverlayDiagnostic(index, pathPrefix, 'entry', overlay, 'Runtime overlay entries must be objects.'));
+      return;
+    }
+
+    if (Object.hasOwn(overlay, 'type')) {
+      diagnostics.push(runtimeOverlayDiagnostic(index, `${pathPrefix}.type`, 'type', overlay.type, 'Runtime overlay config uses legacy field "type"; use canonical field "kind" instead.'));
+    }
+
+    if (typeof overlay.kind !== 'string' || overlay.kind.trim() === '') {
+      diagnostics.push(runtimeOverlayDiagnostic(index, `${pathPrefix}.kind`, 'kind', overlay.kind, 'Runtime overlay config requires canonical field "kind" as a non-empty string.'));
+    }
+  });
+
+  if (diagnostics.length > 0) {
+    throw new RuntimeOverlayConfigError(diagnostics);
+  }
+
+  return overlays;
+}
+
+function runtimeOverlayDiagnostic(index, field, offendingField, value, message) {
+  return {
+    class: 'codebox.runtime_overlay_config_invalid',
+    message: `Invalid WordPress executor runtime overlay config at runtime_overlays[${index}]: ${message} ${RUNTIME_OVERLAY_CANONICAL_SHAPE}`,
+    data: {
+      overlay_index: index,
+      field,
+      offending_field: offendingField,
+      offending_value: value,
+      expected: RUNTIME_OVERLAY_CANONICAL_SHAPE,
+    },
   };
 }
 

--- a/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -591,11 +591,36 @@ function importModule(specifier) {
   return import(specifier);
 }
 
+function runtimeOverlayConfigFailurePayload(error) {
+  if (!Array.isArray(error?.diagnostics) || error.diagnostics.length === 0) {
+    return null;
+  }
+  return {
+    success: false,
+    status: 'failed',
+    summary: error.message || 'Invalid WordPress executor runtime overlay config.',
+    failure_classification: 'provider',
+    diagnostics: error.diagnostics,
+    metadata: {
+      phase: 'homeboy.wordpress.runtime_overlay_validation',
+    },
+  };
+}
+
 async function runTaskRunner(request) {
   const coreNormalizers = await loadCodeboxCoreNormalizers();
   const runner = argValue('--task-runner') || `${__dirname}/homeboy-wp-codebox-task-runner.cjs`;
   const config = request.executor?.config || {};
-  const taskInput = codeboxTaskRequestFromAgentTaskRequest(request);
+  let taskInput;
+  try {
+    taskInput = codeboxTaskRequestFromAgentTaskRequest(request);
+  } catch (error) {
+    const validationPayload = runtimeOverlayConfigFailurePayload(error);
+    if (validationPayload) {
+      return agentTaskOutcomeFromCodeboxResult(request, validationPayload, { exitStatus: 1, ...coreNormalizers });
+    }
+    throw error;
+  }
   const missingModelPayload = missingModelPreflightPayload(taskInput);
   if (missingModelPayload) {
     return agentTaskOutcomeFromCodeboxResult(request, missingModelPayload, { exitStatus: 1, ...coreNormalizers });

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -232,7 +232,7 @@ const request = {
         metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
       }],
       runtime_overlays: [{
-        type: 'bundled-library',
+        kind: 'bundled-library',
         library: 'php-ai-client',
         source: '/components/php-ai-client',
         target: '/wordpress/wp-includes/php-ai-client',
@@ -313,12 +313,32 @@ assert.deepEqual(codeboxRequest.runtime_stack_mounts, [{
   metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
 }]);
 assert.deepEqual(codeboxRequest.runtime_overlays, [{
-  type: 'bundled-library',
+  kind: 'bundled-library',
   library: 'php-ai-client',
   source: '/components/php-ai-client',
   target: '/wordpress/wp-includes/php-ai-client',
   metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
 }]);
+assert.throws(() => codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'invalid-runtime-overlay-type-task-123',
+  executor: {
+    ...request.executor,
+    config: {
+      ...request.executor.config,
+      runtime_overlays: [{ type: 'bundled-library', library: 'php-ai-client', source: '/components/php-ai-client' }],
+    },
+  },
+}), (error) => {
+  assert.equal(error.name, 'RuntimeOverlayConfigError');
+  assert.equal(error.diagnostics[0].class, 'codebox.runtime_overlay_config_invalid');
+  assert.equal(error.diagnostics[0].data.overlay_index, 0);
+  assert.equal(error.diagnostics[0].data.field, 'runtime_overlays[0].type');
+  assert.equal(error.diagnostics[0].data.offending_field, 'type');
+  assert.match(error.diagnostics[0].message, /use canonical field "kind"/);
+  assert.match(error.diagnostics[0].data.expected, /"kind": "bundled-library"/);
+  return true;
+});
 assert.deepEqual(codeboxRequest.runtime_env, {});
 assert.deepEqual(codeboxRequest.runtime_state_mounts, []);
 assert.deepEqual(codeboxRequest.runtime_config_mounts, []);
@@ -527,7 +547,7 @@ const genericProviderRuntimeRequest = codeboxTaskRequestFromAgentTaskRequest({
       runtime_state_mounts: genericRuntimeStateMounts,
       runtime_config_mounts: genericRuntimeConfigMounts,
       provider_plugin_paths: ['/providers/fixture-provider'],
-      runtime_overlays: [{ type: 'fixture-overlay', source: '/overlays/fixture' }],
+      runtime_overlays: [{ kind: 'fixture-overlay', source: '/overlays/fixture' }],
       runtime_overlay_profiles: ['fixture-profile'],
       secret_env: ['FIXTURE_PROVIDER_SECRET'],
     },
@@ -538,7 +558,7 @@ assert.deepEqual(genericProviderRuntimeRequest.runtime_env, genericRuntimeEnv);
 assert.deepEqual(genericProviderRuntimeRequest.runtime_state_mounts, genericRuntimeStateMounts);
 assert.deepEqual(genericProviderRuntimeRequest.runtime_config_mounts, genericRuntimeConfigMounts);
 assert.deepEqual(genericProviderRuntimeRequest.provider_plugin_paths, ['/providers/fixture-provider']);
-assert.deepEqual(genericProviderRuntimeRequest.runtime_overlays, [{ type: 'fixture-overlay', source: '/overlays/fixture' }]);
+assert.deepEqual(genericProviderRuntimeRequest.runtime_overlays, [{ kind: 'fixture-overlay', source: '/overlays/fixture' }]);
 assert.deepEqual(genericProviderRuntimeRequest.runtime_overlay_profiles, ['fixture-profile']);
 assert.deepEqual(genericProviderRuntimeRequest.secret_env, ['FIXTURE_PROVIDER_SECRET']);
 
@@ -888,7 +908,7 @@ try {
   const configuredProviderPath = path.join(defaultsRoot, 'configured-provider');
   const configuredLibraryPath = path.join(defaultsRoot, 'configured-library');
   const configuredRuntimeOverlays = [{
-    type: 'bundled-library',
+    kind: 'bundled-library',
     library: 'php-ai-client',
     source: configuredLibraryPath,
     target: '/wordpress/wp-includes/php-ai-client',
@@ -970,7 +990,7 @@ try {
         },
         provider_plugin_paths: ['/explicit/provider'],
         runtime_overlay_profiles: ['explicit-profile'],
-        runtime_overlays: [{ type: 'bundled-library', library: 'php-ai-client', source: '/explicit/php-ai-client' }],
+        runtime_overlays: [{ kind: 'bundled-library', library: 'php-ai-client', source: '/explicit/php-ai-client' }],
         secret_env: ['EXPLICIT_SECRET'],
         mounts: [{ source: '/explicit/worktree', target: '/workspace', mode: 'readonly' }],
         workspaces: [{ target: '/explicit-workspace', mode: 'readonly' }],
@@ -985,7 +1005,7 @@ try {
   assert.equal(explicitOverrideRequest.runtime_component_paths.agent_runtime_tools, '/explicit/data-machine-code');
   assert.deepEqual(explicitOverrideRequest.provider_plugin_paths, ['/explicit/provider']);
   assert.deepEqual(explicitOverrideRequest.runtime_overlay_profiles, ['explicit-profile']);
-  assert.deepEqual(explicitOverrideRequest.runtime_overlays, [{ type: 'bundled-library', library: 'php-ai-client', source: '/explicit/php-ai-client' }]);
+  assert.deepEqual(explicitOverrideRequest.runtime_overlays, [{ kind: 'bundled-library', library: 'php-ai-client', source: '/explicit/php-ai-client' }]);
   assert.deepEqual(explicitOverrideRequest.secret_env, ['EXPLICIT_SECRET']);
   assert.deepEqual(explicitOverrideRequest.mounts, [{ source: '/explicit/worktree', target: '/workspace', mode: 'readonly' }]);
   assert.deepEqual(explicitOverrideRequest.workspaces, [{ target: '/explicit-workspace', mode: 'readonly' }]);
@@ -1696,6 +1716,36 @@ try {
   assert.match(missingModelOutcome.summary, /provider-config\.model/);
   assert.equal(fs.existsSync(capture), false);
 
+  const invalidOverlayResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
+    '--task-runner',
+    fixture,
+  ], {
+    encoding: 'utf8',
+    env: fixtureEnv(),
+    input: JSON.stringify({
+      ...request,
+      task_id: 'invalid-runtime-overlay-cli-task-123',
+      executor: {
+        ...request.executor,
+        config: {
+          ...request.executor.config,
+          runtime_overlays: [{ type: 'bundled-library', library: 'php-ai-client', source: '/components/php-ai-client' }],
+        },
+      },
+    }),
+  });
+  assert.equal(invalidOverlayResult.status, 1, invalidOverlayResult.stderr || invalidOverlayResult.stdout);
+  const invalidOverlayOutcome = JSON.parse(invalidOverlayResult.stdout);
+  assert.equal(invalidOverlayOutcome.status, 'failed');
+  assert.equal(invalidOverlayOutcome.failure_classification, 'provider');
+  assert.equal(invalidOverlayOutcome.diagnostics[0].class, 'codebox.runtime_overlay_config_invalid');
+  assert.equal(invalidOverlayOutcome.diagnostics[0].data.overlay_index, 0);
+  assert.equal(invalidOverlayOutcome.diagnostics[0].data.field, 'runtime_overlays[0].type');
+  assert.match(invalidOverlayOutcome.diagnostics[0].message, /legacy field "type"/);
+  assert.match(invalidOverlayOutcome.diagnostics[0].data.expected, /"kind": "bundled-library"/);
+  assert.equal(fs.existsSync(capture), false);
+
   const result = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),
     '--task-runner',
@@ -1737,7 +1787,7 @@ try {
   const captured = JSON.parse(fs.readFileSync(capture, 'utf8'));
   assert.equal(captured.request.schema, 'wp-codebox/task-input/v1');
   assert.equal(captured.request.orchestrator.agent_task_id, 'task-123');
-  assert.equal(captured.request.runtime_overlays[0].type, 'bundled-library');
+  assert.equal(captured.request.runtime_overlays[0].kind, 'bundled-library');
 
   const recipeCliResult = spawnSync(process.execPath, [
     path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'),


### PR DESCRIPTION
## Summary
- validate WordPress executor runtime overlays before building the WP Codebox task input
- reject legacy runtime overlay `type` fields with indexed diagnostics that point to canonical `kind` config
- keep WP Codebox overlay mapping in HBEX and document the canonical explicit overlay shape

Fixes #1416.

## Tests
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the validation path, updated focused smoke coverage/docs, and ran verification. Chris remains responsible for review and merge.