### PR TITLE
fix(lint): make sidecar writer available to standalone lint runs

### DIFF
--- a/scripts/lib/sidecar-writer.sh
+++ b/scripts/lib/sidecar-writer.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+
+# Direct-invocation fallback for Homeboy core's shared JSON sidecar writer.
+# Keep this file aligned with homeboy/src/core/extension/runtime/sidecar-writer.sh.
+#
+# Homeboy-invoked runners receive this helper via HOMEBOY_RUNTIME_SIDECAR_WRITER.
+# Standalone invocations (e.g. `homeboy lint <component>` outside a release run)
+# do not export that env var, so runner-prelude.sh falls back to sourcing this
+# co-located copy. Without it, lint/test runners that request --sidecar-writer
+# silently lack homeboy_sidecar_* and hard-fail when HOMEBOY_LINT_FINDINGS_FILE /
+# HOMEBOY_ANNOTATIONS_DIR are set (homeboy-extensions#1415).
+#
+# The helper owns the common "sidecar is a JSON array" file mechanics used by
+# lint findings, test failures, fix results, and annotation files. Callers still build the
+# domain-specific JSON object; this helper validates it, writes atomically, and
+# keeps empty/missing target env vars as no-ops for legacy compatibility.
+#
+# Usage:
+#   source "${HOMEBOY_RUNTIME_SIDECAR_WRITER}"
+#   homeboy_sidecar_emit lint.finding '{"tool":"eslint","message":"...","fingerprint":"..."}'
+#   homeboy_sidecar_write test.failures "$failure_json"
+#   homeboy_sidecar_merge annotation.phpcs "$tmp_annotations"
+
+homeboy_sidecar_python() {
+    if command -v python3 >/dev/null 2>&1; then
+        command -v python3
+        return 0
+    fi
+    if command -v python >/dev/null 2>&1; then
+        command -v python
+        return 0
+    fi
+    echo "[sidecar-writer] python3 or python is required" >&2
+    return 1
+}
+
+homeboy_sidecar_write_json_array() {
+    local target="${1:-}"
+    shift || true
+
+    if [ -z "$target" ]; then
+        return 0
+    fi
+
+    local python_bin
+    python_bin="$(homeboy_sidecar_python)" || return 1
+
+    "$python_bin" - "$target" "$@" <<'PYEOF'
+import json
+import os
+import sys
+import tempfile
+
+target = sys.argv[1]
+items = [json.loads(raw) for raw in sys.argv[2:]]
+directory = os.path.dirname(target) or "."
+os.makedirs(directory, exist_ok=True)
+fd, tmp = tempfile.mkstemp(prefix=".homeboy-sidecar-", suffix=".json", dir=directory)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(items, handle, separators=(",", ":"), ensure_ascii=False)
+        handle.write("\n")
+    os.replace(tmp, target)
+except Exception:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+PYEOF
+}
+
+homeboy_sidecar_write_json_object() {
+    local target="${1:-}"
+    local item="${2:-}"
+
+    if [ -z "$target" ]; then
+        return 0
+    fi
+
+    local python_bin
+    python_bin="$(homeboy_sidecar_python)" || return 1
+
+    "$python_bin" - "$target" "$item" <<'PYEOF'
+import json
+import os
+import sys
+import tempfile
+
+target = sys.argv[1]
+item = json.loads(sys.argv[2])
+if not isinstance(item, dict):
+    raise ValueError("sidecar must contain a JSON object")
+directory = os.path.dirname(target) or "."
+os.makedirs(directory, exist_ok=True)
+fd, tmp = tempfile.mkstemp(prefix=".homeboy-sidecar-", suffix=".json", dir=directory)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(item, handle, separators=(",", ":"), ensure_ascii=False)
+        handle.write("\n")
+    os.replace(tmp, target)
+except Exception:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+PYEOF
+}
+
+homeboy_sidecar_append_json() {
+    local target="${1:-}"
+    local item="${2:-}"
+
+    if [ -z "$target" ]; then
+        return 0
+    fi
+
+    local python_bin
+    python_bin="$(homeboy_sidecar_python)" || return 1
+
+    "$python_bin" - "$target" "$item" <<'PYEOF'
+import json
+import os
+import sys
+import tempfile
+
+target = sys.argv[1]
+item = json.loads(sys.argv[2])
+items = []
+if os.path.exists(target) and os.path.getsize(target) > 0:
+    with open(target, "r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if isinstance(loaded, list):
+        items = loaded
+    else:
+        raise ValueError(f"sidecar must contain a JSON array: {target}")
+items.append(item)
+directory = os.path.dirname(target) or "."
+os.makedirs(directory, exist_ok=True)
+fd, tmp = tempfile.mkstemp(prefix=".homeboy-sidecar-", suffix=".json", dir=directory)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(items, handle, separators=(",", ":"), ensure_ascii=False)
+        handle.write("\n")
+    os.replace(tmp, target)
+except Exception:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+PYEOF
+}
+
+homeboy_sidecar_merge_json_array() {
+    local target="${1:-}"
+    local source="${2:-}"
+
+    if [ -z "$target" ] || [ -z "$source" ] || [ ! -s "$source" ]; then
+        return 0
+    fi
+
+    local python_bin
+    python_bin="$(homeboy_sidecar_python)" || return 1
+
+    "$python_bin" - "$target" "$source" <<'PYEOF'
+import json
+import os
+import sys
+import tempfile
+
+target = sys.argv[1]
+source = sys.argv[2]
+items = []
+if os.path.exists(target) and os.path.getsize(target) > 0:
+    with open(target, "r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if isinstance(loaded, list):
+        items = loaded
+    else:
+        raise ValueError(f"sidecar must contain a JSON array: {target}")
+with open(source, "r", encoding="utf-8") as handle:
+    incoming = json.load(handle)
+if not isinstance(incoming, list):
+    raise ValueError(f"source sidecar must contain a JSON array: {source}")
+items.extend(incoming)
+directory = os.path.dirname(target) or "."
+os.makedirs(directory, exist_ok=True)
+fd, tmp = tempfile.mkstemp(prefix=".homeboy-sidecar-", suffix=".json", dir=directory)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(items, handle, separators=(",", ":"), ensure_ascii=False)
+        handle.write("\n")
+    os.replace(tmp, target)
+except Exception:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+PYEOF
+}
+
+homeboy_sidecar_target_for_type() {
+    local type="${1:-}"
+
+    case "$type" in
+        lint.finding|lint.findings)
+            printf '%s\n' "${HOMEBOY_LINT_FINDINGS_FILE:-}"
+            ;;
+        test.failure|test.failures)
+            printf '%s\n' "${HOMEBOY_TEST_FAILURES_FILE:-}"
+            ;;
+        test.result|test.results)
+            printf '%s\n' "${HOMEBOY_TEST_RESULTS_FILE:-}"
+            ;;
+        fix.result|fix.results)
+            printf '%s\n' "${HOMEBOY_FIX_RESULTS_FILE:-}"
+            ;;
+        annotation.*|annotations.*)
+            local name="${type#annotation.}"
+            name="${name#annotations.}"
+            if [ -z "${HOMEBOY_ANNOTATIONS_DIR:-}" ] || [ -z "$name" ]; then
+                printf '\n'
+                return 0
+            fi
+            name="$(printf '%s' "$name" | tr -c 'A-Za-z0-9_.-' '-')"
+            printf '%s/%s.json\n' "${HOMEBOY_ANNOTATIONS_DIR%/}" "$name"
+            ;;
+        *)
+            echo "[sidecar-writer] unknown sidecar type: $type" >&2
+            return 1
+            ;;
+    esac
+}
+
+homeboy_sidecar_write() {
+    local type="${1:-}"
+    shift || true
+
+    local target
+    target="$(homeboy_sidecar_target_for_type "$type")" || return 1
+    case "$type" in
+        test.result|test.results)
+            homeboy_sidecar_write_json_object "$target" "${1:-}"
+            return $?
+            ;;
+    esac
+    homeboy_sidecar_write_json_array "$target" "$@"
+}
+
+homeboy_sidecar_emit() {
+    local type="${1:-}"
+    local item="${2:-}"
+
+    local target
+    target="$(homeboy_sidecar_target_for_type "$type")" || return 1
+    homeboy_sidecar_append_json "$target" "$item"
+}
+
+homeboy_sidecar_merge() {
+    local type="${1:-}"
+    local source="${2:-}"
+
+    local target
+    target="$(homeboy_sidecar_target_for_type "$type")" || return 1
+    homeboy_sidecar_merge_json_array "$target" "$source"
+}
+
+homeboy_annotation_file() {
+    local source="${1:-}"
+    homeboy_sidecar_target_for_type "annotation.$source"
+}
+
+homeboy_write_lint_findings() {
+    homeboy_sidecar_write lint.findings "$@"
+}
+
+homeboy_append_lint_finding() {
+    homeboy_sidecar_emit lint.finding "$1"
+}
+
+homeboy_merge_lint_findings() {
+    homeboy_sidecar_merge lint.findings "$1"
+}
+
+homeboy_write_test_failures() {
+    homeboy_sidecar_write test.failures "$@"
+}
+
+homeboy_write_test_results_json() {
+    homeboy_sidecar_write test.results "$1"
+}
+
+homeboy_append_test_failure() {
+    homeboy_sidecar_emit test.failure "$1"
+}
+
+homeboy_merge_test_failures() {
+    homeboy_sidecar_merge test.failures "$1"
+}
+
+homeboy_write_fix_results() {
+    homeboy_sidecar_write fix.results "$@"
+}
+
+homeboy_append_fix_result() {
+    homeboy_sidecar_emit fix.result "$1"
+}
+
+homeboy_merge_fix_results() {
+    homeboy_sidecar_merge fix.results "$1"
+}
+
+homeboy_write_annotations() {
+    local source="${1:-}"
+    shift || true
+
+    homeboy_sidecar_write "annotation.$source" "$@"
+}
+
+homeboy_append_annotation() {
+    local source="${1:-}"
+    local item="${2:-}"
+
+    homeboy_sidecar_emit "annotation.$source" "$item"
+}
+
+homeboy_merge_annotations() {
+    local source="${1:-}"
+    local file="${2:-}"
+
+    homeboy_sidecar_merge "annotation.$source" "$file"
+}

--- a/wordpress/scripts/lib/sidecar-writer.sh
+++ b/wordpress/scripts/lib/sidecar-writer.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Direct-invocation fallback wrapper. Homeboy-invoked runners receive the core
+# helper via HOMEBOY_RUNTIME_SIDECAR_WRITER; direct runs share one local copy.
+
+# shellcheck source=../../../scripts/lib/sidecar-writer.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/sidecar-writer.sh"

--- a/wordpress/scripts/lint/eslint-runner.sh
+++ b/wordpress/scripts/lint/eslint-runner.sh
@@ -22,7 +22,10 @@ fi
 # Resolve execution context (shared helper)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/../lib/resolve-context.sh}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
+# Standalone `homeboy lint` runs do not export HOMEBOY_RUNTIME_SIDECAR_WRITER;
+# fall back to the co-located direct-invocation copy so the sidecar writer is
+# available outside a release run (homeboy-extensions#1415).
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${SCRIPT_DIR}/../lib/sidecar-writer.sh}"
 # shellcheck source=../lib/resolve-context.sh
 source "${RESOLVE_CONTEXT_HELPER}"
 homeboy_resolve_context --component-alias PLUGIN_PATH

--- a/wordpress/scripts/lint/phpstan-runner.sh
+++ b/wordpress/scripts/lint/phpstan-runner.sh
@@ -5,7 +5,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPENDENCY_HELPER="${HOMEBOY_WORDPRESS_DEPENDENCY_HELPER:-${SCRIPT_DIR}/../lib/validation-dependencies.sh}"
 # shellcheck source=../lib/validation-dependencies.sh
 source "${DEPENDENCY_HELPER}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
+# Standalone `homeboy lint` runs do not export HOMEBOY_RUNTIME_SIDECAR_WRITER;
+# fall back to the co-located direct-invocation copy so the sidecar writer is
+# available outside a release run (homeboy-extensions#1415).
+SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-${SCRIPT_DIR}/../lib/sidecar-writer.sh}"
 # shellcheck source=/dev/null
 if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
     source "$SIDECAR_WRITER_HELPER"


### PR DESCRIPTION
## Summary

Standalone `homeboy lint <component>` failed with `Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write annotations` (exit 1) **even when the lint ran cleanly** — making the documented pre-release self-check unusable outside a full `homeboy release` run, and pushing people toward `--skip-checks`.

Closes #1415.

## Root cause

During a standalone `homeboy lint`, the homeboy Rust runner **sets** `HOMEBOY_ANNOTATIONS_DIR` and `HOMEBOY_LINT_FINDINGS_FILE` (so the sidecar-writing blocks are entered) but leaves **`HOMEBOY_RUNTIME_SIDECAR_WRITER`** and **`HOMEBOY_RUNTIME_RUNNER_PRELUDE`** unset (confirmed via runtime probe).

The runners then fall back to their co-located prelude wrapper, whose `runtime_dir` resolves to `scripts/lib/`. `runner-prelude.sh` sources `${runtime_dir}/sidecar-writer.sh` as **optional** — and there was **no `sidecar-writer.sh` in `scripts/lib/`**, so the source silently no-op'd and `homeboy_sidecar_merge` / `homeboy_sidecar_merge_json_array` were never defined. Every writer site (`annotations`, `lint findings`, `eslint findings`) then hit its `is required` guard and `exit 1`.

This is the correct fix location (the **wordpress extension**, PR → `Extra-Chill/homeboy-extensions`), **not** homeboy Rust: the Rust runner legitimately omits the env var for standalone runs and relies on the extension's local fallback chain. The extension simply lacked the one fallback file. Vendoring it matches the established `runner-prelude.sh` / `runner-steps.sh` "direct-invocation fallback, keep aligned with core" pattern already in `scripts/lib/`.

## Changes

- **`scripts/lib/sidecar-writer.sh`** (new) — direct-invocation copy of homeboy core's sidecar writer, functionally identical to `homeboy/src/core/extension/runtime/sidecar-writer.sh`. This is the load-bearing fix: it lets the prelude-based runners (`wordpress/scripts/lint/lint-runner.sh` and, by sharing the same repo-root prelude, the nodejs/rust runners) resolve the writer in standalone mode.
- **`wordpress/scripts/lib/sidecar-writer.sh`** (new) — thin wrapper that sources the repo-root copy, matching the sibling `runner-prelude.sh` wrapper.
- **`wordpress/scripts/lint/eslint-runner.sh`**, **`phpstan-runner.sh`** — these source the writer directly (not via the prelude); point their `${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}` default at the co-located `../lib/sidecar-writer.sh` fallback.

`lint-runner.sh` needed no edit — it goes through `homeboy_runner_init --sidecar-writer`, which now resolves the vendored repo-root file.

## Verification

### Direct harness (Option A — no homeboy needed)

```
TEST 1 (env UNSET, standalone): writer resolves via co-located fallback
  -> homeboy_sidecar_merge DEFINED, annotation file written, EXIT 0  ✅
TEST 2 (env SET, release path): writer resolves explicitly
  -> DEFINED, lint.findings written, EXIT 0 (no regression)  ✅
NEGATIVE CONTROL (old state: env unset, no co-located writer):
  -> "Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write annotations", EXIT 1  ✅ (reproduces the bug)
```

### Integration (Option B — temporary `homeboy extension relink` to this worktree, relinked back to the primary afterward)

Standalone `homeboy lint extrachill-users` (a component with PHPCS warnings but 0 errors):

| | BEFORE (primary, unfixed) | AFTER (this branch) |
|---|---|---|
| stderr | `Error: HOMEBOY_RUNTIME_SIDECAR_WRITER is required to write annotations` | _(none)_ |
| `finding_count` | `0` (lint reported nothing) | `59` (real findings surfaced) |

Across multiple components (`extrachill-users`, `data-machine-business`, `extrachill-blog`) the sidecar error is **gone** and homeboy now reads back real finding counts to apply its baseline. The remaining non-zero exits reflect each component's actual lint debt (a separate baseline-config matter), not a crash — which is exactly the "usable self-check" outcome the issue asks for.

## Notes / follow-up

- The same latent gap exists in the **nodejs**, **rust**, **swift**, and **go** lint runners (their `lib/` dirs also lack a co-located `sidecar-writer.sh`, and swift/go use the direct `${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}` pattern). The repo-root `scripts/lib/sidecar-writer.sh` added here already covers the **prelude-based** nodejs/rust runners; swift/go would need the same one-line direct-source fallback. Scoped out of this PR (which targets the reported wordpress case) — happy to follow up.
- Host state restored: the wordpress extension symlink was relinked back to `/var/lib/datamachine/workspace/homeboy-extensions/wordpress` after testing.

PR only — no merge/release/deploy.

cc @chubes
