### PR TITLE
Stop auto-running PHP smoke scripts in WordPress tests

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -131,10 +131,11 @@ Available factories from the WordPress test framework: `user`, `post`,
 
 ### Real-WordPress host smokes
 
-Standalone smoke files matching `tests/**/*-smoke.php` run through the same WP
-Codebox-backed real WordPress harness as CI. Each file is mounted with the
-component and executed via `wordpress.run-php`, so WordPress functions and
-runtime dependencies are available.
+Standalone smoke files matching `tests/**/*-smoke.php` are diagnostic/operator
+targets, not default release gates. Run one explicitly through the same WP
+Codebox-backed real WordPress harness when you need it. The selected file is
+mounted with the component and executed via `wordpress.run-php`, so WordPress
+functions and runtime dependencies are available.
 
 To rerun one existing smoke on demand before pushing:
 
@@ -142,8 +143,8 @@ To rerun one existing smoke on demand before pushing:
 homeboy test <component-id> -- --host-smoke-file tests/example-smoke.php
 ```
 
-The focused command is opt-in and does not change default test discovery or add
-smokes to CI. Output preserves the machine-readable `HOST_SMOKE_BEGIN`,
+The focused command does not change default test discovery or add smokes to CI.
+Output preserves the machine-readable `HOST_SMOKE_BEGIN`,
 `HOST_SMOKE_PROGRESS`, `HOST_SMOKE_OK`, `HOST_SMOKE_FAIL`, and
 `HOST_SMOKE_SUMMARY` markers.
 

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -25,9 +25,10 @@ homeboy test <component-id> -- --host-smoke-file tests/example-smoke.php
 ```
 
 Tests run through `scripts/test/test-runner.sh`, which dispatches to the WP
-Codebox runner for WordPress PHPUnit and real-WordPress host smokes. The runner
-mounts the component under `/wordpress/wp-content/plugins/<slug>`, boots
-WordPress in-process, discovers test files, and routes files by type.
+Codebox runner for WordPress PHPUnit by default. The runner mounts the component
+under `/wordpress/wp-content/plugins/<slug>`, boots WordPress in-process,
+discovers PHPUnit test files, and routes explicitly selected diagnostic files by
+type.
 
 ## Requirements
 
@@ -44,20 +45,17 @@ rejected with a clear error.
 
 ## Real-WordPress host smokes
 
-Standalone PHP smoke files can live under `tests/**/*-smoke.php`. They run
-through WP Codebox against real WordPress, using the same component mounts,
-dependency mounts, drop-in handling, WordPress version selection, and
-`wordpress.run-php` recipe execution path CI uses.
-
-The default test command discovers existing smoke files when present. To rerun
-one failed smoke without the full CI loop, pass the file explicitly:
+Standalone PHP smoke files can live under `tests/**/*-smoke.php`. They are
+diagnostic/operator targets, not default release gates. Run one explicitly
+through WP Codebox against real WordPress when you need the same component
+mounts, dependency mounts, drop-in handling, WordPress version selection, and
+`wordpress.run-php` recipe execution path CI uses:
 
 ```bash
 homeboy test <component-id> -- --host-smoke-file tests/example-smoke.php
 ```
 
-This focused path is opt-in and does not add default smokes or broaden CI
-coverage. It preserves the machine-readable `HOST_SMOKE_BEGIN`,
+This focused path preserves the machine-readable `HOST_SMOKE_BEGIN`,
 `HOST_SMOKE_PROGRESS`, `HOST_SMOKE_OK`, `HOST_SMOKE_FAIL`, and
 `HOST_SMOKE_SUMMARY` markers, and fails fast with the selected script name.
 
@@ -81,10 +79,10 @@ For full CI agent runs on the WP Codebox WordPress execution substrate, see
 
 ## WP Codebox test runtime status
 
-WordPress PHPUnit and standalone `tests/**/*-smoke.php` files run through WP
-Codebox by default. The WP Codebox path owns the same component mounts,
-dependency mounts, drop-ins, file routing, WordPress version selection, and
-artifact parsing contract that the direct Playground runner previously handled.
+WordPress PHPUnit files run through WP Codebox by default. Explicitly selected
+standalone `tests/**/*-smoke.php` files use the same WP Codebox path for
+component mounts, dependency mounts, drop-ins, file routing, WordPress version
+selection, and artifact parsing when an operator chooses to run one.
 
 ## Dependencies
 

--- a/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
+++ b/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
@@ -65,11 +65,24 @@ PHP
 component="${TMPDIR}/component"
 make_component "$component"
 
+# --- Default backend run: no implicit discovery of ad hoc smoke files.
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$component" \
+HOMEBOY_WP_CODEBOX_BIN="$FAKE_CODEBOX" \
+FAKE_CODEBOX_CAPTURE_DIR="$CAPTURE_DIR" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner-host-smoke-wp.sh" > "${TMPDIR}/default.out"
+
+assert_contains "${TMPDIR}/default.out" "Backend: host-smoke-wp"
+assert_contains "${TMPDIR}/default.out" "Skipping real-WordPress smoke tests: no smoke files requested."
+assert_not_contains "${TMPDIR}/default.out" "HOST_SMOKE_BEGIN:tests/alpha-smoke.php"
+
 # --- Direct backend run: builds a wordpress.run-php recipe mounting the plugin.
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_WP_CODEBOX_BIN="$FAKE_CODEBOX" \
+HOMEBOY_WORDPRESS_HOST_SMOKE_FILE="tests/alpha-smoke.php" \
 FAKE_CODEBOX_CAPTURE_DIR="$CAPTURE_DIR" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner-host-smoke-wp.sh" > "${TMPDIR}/direct.out"
 
@@ -105,6 +118,7 @@ HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_WP_CODEBOX_BIN="$FAKE_CODEBOX_FAIL" \
+HOMEBOY_WORDPRESS_HOST_SMOKE_FILE="tests/alpha-smoke.php" \
 FAKE_CODEBOX_CAPTURE_DIR="$CAPTURE_DIR" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner-host-smoke-wp.sh" > "${TMPDIR}/direct-fail.out" 2>&1
 fail_exit=$?
@@ -134,6 +148,7 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_WP_CODEBOX_BIN="$FAKE_CODEBOX_HANG" \
 HOMEBOY_WORDPRESS_HOST_SMOKE_TIMEOUT_SECONDS=1 \
+HOMEBOY_WORDPRESS_HOST_SMOKE_FILE="tests/alpha-smoke.php" \
 FAKE_CODEBOX_CAPTURE_DIR="$CAPTURE_DIR" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner-host-smoke-wp.sh" > "${TMPDIR}/direct-timeout.out" 2>&1
 timeout_exit=$?

--- a/wordpress/scripts/test/test-runner-host-smoke-wp.sh
+++ b/wordpress/scripts/test/test-runner-host-smoke-wp.sh
@@ -298,12 +298,12 @@ elif [ -n "$TARGET_SMOKE_FILE" ]; then
     fi
     smoke_files=("$target_abs")
 else
-    mapfile -t smoke_files < <(find "$TEST_DIR" -type f -name '*-smoke.php' | sort)
+    smoke_files=()
 fi
 
 if [ "${#smoke_files[@]}" -eq 0 ]; then
     echo ""
-    echo "Skipping real-WordPress smoke tests: no files matched ${TEST_DIR}/**/*-smoke.php"
+    echo "Skipping real-WordPress smoke tests: no smoke files requested. Use --host-smoke-file or HOMEBOY_WORDPRESS_HOST_SMOKE_FILES to run one explicitly."
     exit 0
 fi
 

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -26,12 +26,10 @@ if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
     echo "DEBUG: Component path: ${COMPONENT_PATH:-$(pwd)}"
 fi
 
-# WordPress tests run through WP Codebox against real WordPress, routed purely by
-# file type: tests/**/*Test.php and tests/**/test-*.php run via the PHPUnit
-# backend, and tests/**/*-smoke.php standalone scripts run via the real-WordPress
-# smoke backend (wordpress.run-php with WordPress booted). There is no
-# bare-host/no-WordPress backend and no test_backend toggle; the runtime is
-# always WP Codebox.
+# WordPress tests run through WP Codebox against real WordPress. The default
+# suite is PHPUnit. Standalone smoke scripts are diagnostic/operator targets and
+# run only when selected explicitly with --file, --host-smoke-file, or the
+# HOMEBOY_WORDPRESS_HOST_SMOKE_FILES scope environment.
 
 show_usage() {
     cat <<'EOF'
@@ -360,30 +358,7 @@ if [ -n "$TARGET_FILE" ]; then
     esac
 fi
 
-# Full-suite run (no --file, no changed-file scope): run every test the
-# component carries, routed by file type. PHPUnit (tests/**/*Test.php,
-# tests/**/test-*.php) runs through the WP Codebox PHPUnit backend; standalone
-# tests/**/*-smoke.php scripts run through the real-WordPress smoke backend. Both
-# run against real WordPress in WP Codebox. A component may carry one or both;
-# each backend skips cleanly when it finds no matching files.
-TEST_ROOT="${PLUGIN_PATH}/tests"
-has_smoke_files=0
-if [ -d "$TEST_ROOT" ] && [ -n "$(find "$TEST_ROOT" -type f -name '*-smoke.php' -print -quit 2>/dev/null)" ]; then
-    has_smoke_files=1
-fi
-
-# Run the PHPUnit backend (it discovers *Test.php / test-*.php and falls back to
-# a composer test script, and is the canonical default path). When the component
-# also carries standalone smoke scripts, run the real-WordPress smoke backend
-# after it. A non-zero exit from either backend fails the whole run, so neither
-# can mask the other's failure.
-if [ "$has_smoke_files" -eq 1 ]; then
-    bash "$WP_CODEBOX_RUNNER" "${PASSTHROUGH_ARGS[@]}"
-    phpunit_status=$?
-    if [ "$phpunit_status" -ne 0 ]; then
-        exit "$phpunit_status"
-    fi
-    exec bash "$SMOKE_RUNNER" "${PASSTHROUGH_ARGS[@]}"
-fi
-
+# Full-suite run (no --file, no changed-file scope): run the canonical PHPUnit
+# backend only. Ad hoc PHP smoke scripts are intentionally not release gates;
+# rerun one explicitly with --host-smoke-file or --file when diagnosing it.
 exec bash "$WP_CODEBOX_RUNNER" "${PASSTHROUGH_ARGS[@]}"


### PR DESCRIPTION
## Summary
- Stop the WordPress full-suite test path from auto-discovering every tests/**/*-smoke.php file as a real-WordPress release gate.
- Keep explicit diagnostic execution through --file, --host-smoke-file, and HOMEBOY_WORDPRESS_HOST_SMOKE_FILES.
- Update runner regression coverage and docs to match the narrower contract.

## Testing
- bash wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
- bash -n wordpress/scripts/test/test-runner.sh wordpress/scripts/test/test-runner-host-smoke-wp.sh wordpress/scripts/test/host-smoke-wp-runner-smoke.sh

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the release-gate smoke discovery issue and drafted the runner/docs/test update; Chris remains responsible for review and merge.