### PR TITLE
Add Codebox typed artifact declarations to Agent CI

### DIFF
--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -136,6 +136,14 @@ name: Data Machine Agent CI (reusable)
         description: JSON map of output_name to jq path, collected into engine_data_json.
         type: string
         default: "{}"
+      expected_artifacts:
+        description: JSON array of generic expected artifact names forwarded to WP Codebox.
+        type: string
+        default: "[]"
+      artifact_declarations:
+        description: JSON array of typed artifact declarations forwarded to WP Codebox. Required declarations are enforced in the normalized Homeboy outcome.
+        type: string
+        default: "[]"
       transcript_artifact_name:
         description: Empty string disables transcript artifact upload.
         type: string
@@ -686,6 +694,8 @@ jobs:
           MAX_TURNS: ${{ inputs.max_turns }}
           STEP_BUDGET: ${{ inputs.step_budget }}
           TIME_BUDGET_MS: ${{ inputs.time_budget_ms }}
+          EXPECTED_ARTIFACTS: ${{ inputs.expected_artifacts }}
+          ARTIFACT_DECLARATIONS: ${{ inputs.artifact_declarations }}
           ARTIFACT_EXPORT_CONFIG: ${{ inputs.artifact_export_config }}
           RULES: ${{ inputs.rules }}
           GENERAL_RULES: ${{ inputs.general_rules }}
@@ -846,6 +856,8 @@ jobs:
           workload_run_after_json="$(validate_json_input workload_run_after array "$WORKLOAD_RUN_AFTER")"
           extra_required_abilities_json="$(validate_json_input extra_required_abilities array "$EXTRA_REQUIRED_ABILITIES")"
           success_completion_outcomes_json="$(validate_json_input success_completion_outcomes array "$SUCCESS_COMPLETION_OUTCOMES")"
+          expected_artifacts_json="$(validate_json_input expected_artifacts array "$EXPECTED_ARTIFACTS")"
+          artifact_declarations_json="$(validate_json_input artifact_declarations array "$ARTIFACT_DECLARATIONS")"
           allowed_repos_json="$(validate_json_input allowed_repos array "$ALLOWED_REPOS")"
           app_token_repos_json="$(jq -Rsc 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != ""))' <<< "${APP_TOKEN_REPOS:-$TARGET_REPO}")"
           effective_allowed_repos_json="$(jq -nc --arg target "$TARGET_REPO" --argjson allowed "$allowed_repos_json" --argjson appTokenRepos "$app_token_repos_json" 'if ($allowed | length) > 0 then $allowed elif ($appTokenRepos | length) > 0 then $appTokenRepos else [$target] end')"
@@ -924,6 +936,8 @@ jobs:
             --argjson maxTurns "$MAX_TURNS" \
             --argjson stepBudget "$STEP_BUDGET" \
             --argjson timeBudgetMs "$TIME_BUDGET_MS" \
+            --argjson expectedArtifacts "$expected_artifacts_json" \
+            --argjson artifactDeclarations "$artifact_declarations_json" \
             --argjson dryRun "$DRY_RUN" \
             --argjson extraWpConfigDefines "$extra_wp_config_defines_json" \
             --argjson extraWpCodeboxMounts "$extra_wp_codebox_mounts_json" \
@@ -1013,6 +1027,8 @@ jobs:
               prompt: $prompt,
               step_budget: $stepBudget,
               time_budget_ms: $timeBudgetMs,
+              expected_artifacts: $expectedArtifacts,
+              artifact_declarations: $artifactDeclarations,
               ability_tools: $abilityTools,
               tool_recorders: $toolRecorders,
               pipeline_step_patches: $pipelineStepPatches,

--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -219,6 +219,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const components = runtimeComponentPaths(config, { ...defaults, ...options, componentContracts });
   const agentBundles = firstDefined(inputs.agent_bundles, inputs.agentBundles, config.agent_bundles, config.agentBundles, options.agentBundles, []);
   const structuredArtifacts = firstDefined(inputs.structured_artifacts, inputs.structuredArtifacts, config.structured_artifacts, config.structuredArtifacts, options.structuredArtifacts, []);
+  const artifactDeclarations = artifactDeclarationsFromAgentTaskRequest(request, config, inputs, options);
   const allowedTools = allowedToolsFromAgentTaskRequest(request, config, inputs, options, defaults);
   const sandboxToolPolicy = sandboxToolPolicyFromAgentTaskRequest(config, inputs, options, defaults, allowedTools);
   const provider = config.provider || options.provider || defaults.provider || '';
@@ -252,6 +253,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     target: inputs.target || request.workspace || {},
     allowed_tools: allowedTools || [],
     expected_artifacts: request.expected_artifacts || [],
+    artifact_declarations: artifactDeclarations,
     policy: request.policy || {},
     context,
     recipe,
@@ -298,6 +300,20 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     agent_bundle: agentBundle,
     parent_request: request,
   };
+}
+
+function artifactDeclarationsFromAgentTaskRequest(request, config = {}, inputs = {}, options = {}) {
+  const declarations = firstDefined(
+    request.artifact_declarations,
+    request.artifactDeclarations,
+    inputs.artifact_declarations,
+    inputs.artifactDeclarations,
+    config.artifact_declarations,
+    config.artifactDeclarations,
+    options.artifactDeclarations,
+    []
+  );
+  return Array.isArray(declarations) ? declarations : [];
 }
 
 class RuntimeOverlayConfigError extends Error {
@@ -1384,6 +1400,52 @@ function typedArtifactFileRefs(typedArtifact) {
   ];
 }
 
+function typedArtifactNameFromDeclaration(declaration) {
+  if (typeof declaration === 'string') {
+    return declaration;
+  }
+  if (!declaration || typeof declaration !== 'object' || Array.isArray(declaration)) {
+    return '';
+  }
+  return declaration.name || declaration.id || '';
+}
+
+function requiredArtifactDeclarationsFromRequest(request) {
+  const config = request.executor?.config || {};
+  return artifactDeclarationsFromAgentTaskRequest(request, config, request.inputs || {})
+    .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true && typedArtifactNameFromDeclaration(declaration));
+}
+
+function artifactDeclarationsMetadataFromRequest(request) {
+  const config = request.executor?.config || {};
+  return artifactDeclarationsFromAgentTaskRequest(request, config, request.inputs || {});
+}
+
+function missingRequiredTypedArtifactDiagnostic(request, outputs) {
+  const required = requiredArtifactDeclarationsFromRequest(request);
+  if (required.length === 0) {
+    return null;
+  }
+  const typedArtifacts = outputs?.typed_artifacts && typeof outputs.typed_artifacts === 'object' && !Array.isArray(outputs.typed_artifacts)
+    ? outputs.typed_artifacts
+    : {};
+  const missing = required
+    .map((declaration) => ({
+      name: typedArtifactNameFromDeclaration(declaration),
+      type: declaration.type || declaration.kind || declaration.artifact_type || declaration.artifactType || '',
+      artifact_schema: declaration.artifact_schema || declaration.artifactSchema || declaration.schema || '',
+    }))
+    .filter((declaration) => !typedArtifacts[declaration.name]);
+  if (missing.length === 0) {
+    return null;
+  }
+  return {
+    class: 'codebox.required_typed_artifacts_missing',
+    message: `WP Codebox agent task did not produce required typed artifacts: ${missing.map((declaration) => declaration.name).join(', ')}.`,
+    data: { reason: 'missing_required_typed_artifacts', missing },
+  };
+}
+
 function typedBundleOutputArtifacts(result) {
   return Object.values(typedArtifactsFromResult(result)).flatMap((typedArtifact) => typedArtifactFileRefs(typedArtifact).map((ref, index) => {
     const fileRef = typeof ref === 'string' ? { path: ref } : ref;
@@ -1914,6 +1976,10 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   }
   const failureClassification = homeboyFailureClassification(result.failure_classification || recipeSummary?.metadata?.failure_classification || runSummary?.failure_classification, status);
   const outputs = normalizeOutputs(result);
+  const missingRequiredTypedArtifacts = missingRequiredTypedArtifactDiagnostic(request, outputs);
+  if (status === 'succeeded' && missingRequiredTypedArtifacts) {
+    status = 'failed';
+  }
   const recipeRun = recipeRunFromResult(result);
   const fallbackRecipeSummary = recipeRunFailureSummary(recipeRun);
   const recipeFailedPhase = recipeSummary?.failed_phase || recipeSummary?.metadata?.failure_phase || recipeRunFailedPhase(recipeRun);
@@ -1924,11 +1990,11 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     schema: AGENT_TASK_OUTCOME_SCHEMA,
     task_id: request.task_id,
     status,
-    summary: recipeSummary?.failure_summary || fallbackRecipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
+    summary: missingRequiredTypedArtifacts?.message || recipeSummary?.failure_summary || fallbackRecipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
     artifacts: normalizeArtifacts(result, runSummary, recipeSummary),
     evidence_refs: normalizeEvidenceRefs(result, runSummary, recipeSummary),
     outputs,
-    diagnostics: [codexProviderDiagnostic, codexBearerTokenDiagnostic, codexVendorDiagnostic, recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
+    diagnostics: [codexProviderDiagnostic, codexBearerTokenDiagnostic, codexVendorDiagnostic, missingRequiredTypedArtifacts, recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
       message: diagnostic.message || String(diagnostic),
       data: sanitizePublicMetadata(diagnostic.data || {}),
@@ -1940,6 +2006,8 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
       codebox_recipe_run_summary: recipeSummary ? sanitizePublicMetadata(recipeSummary) : undefined,
       integration_contract: 'wp-codebox-cli/agent-task-run',
       decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result, runSummary, recipeSummary)),
+      artifact_declarations: sanitizePublicMetadata(artifactDeclarationsMetadataFromRequest(request)),
+      typed_artifacts: sanitizePublicMetadata(outputs.typed_artifacts || {}),
       sandbox_policy: sanitizePublicMetadata({
         policy: result.task_input?.policy,
         sandbox_tool_policy: result.task_input?.sandbox_tool_policy,
@@ -1949,6 +2017,8 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   };
   if (failureClassification) {
     outcome.failure_classification = failureClassification;
+  } else if (missingRequiredTypedArtifacts) {
+    outcome.failure_classification = 'execution_failed';
   }
   return outcome;
 }

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -627,6 +627,7 @@ function runnerInput(request, artifacts) {
     recipe: request.recipe || {},
     runtime_task: request.runtime_task || request.runtimeTask,
     structured_artifacts: request.structured_artifacts || request.structuredArtifacts || [],
+    artifact_declarations: request.artifact_declarations || request.artifactDeclarations || [],
     agent_bundles: request.agent_bundles || request.agentBundles || [],
     artifacts_path: artifacts,
     wp_codebox_bin: argValue('--wp-codebox-bin') || request.wp_codebox_bin || '',
@@ -712,6 +713,7 @@ function stableTaskInput(input) {
     target: input.parent_request?.target || input.parent_request?.task?.target || {},
     allowed_tools: allowedTools,
     expected_artifacts: input.parent_request?.expected_artifacts || input.parent_request?.task?.expected_artifacts || [],
+    artifact_declarations: input.artifact_declarations || input.parent_request?.artifact_declarations || input.parent_request?.artifactDeclarations || input.parent_request?.task?.artifact_declarations || [],
     structured_artifacts: input.structured_artifacts || [],
     agent_bundles: input.agent_bundles || [],
     sandbox_tool_policy: sandboxToolPolicy(input, allowedTools),
@@ -791,6 +793,51 @@ function typedArtifactFileRefs(artifact) {
     return artifact.fileRefs;
   }
   return [];
+}
+
+function artifactDeclarationName(declaration) {
+  if (typeof declaration === 'string') {
+    return declaration;
+  }
+  if (!plainObject(declaration)) {
+    return '';
+  }
+  return declaration.name || declaration.id || '';
+}
+
+function requiredArtifactDeclarations(input, config = {}) {
+  const declarations = [
+    input.artifact_declarations,
+    input.parent_request?.artifact_declarations,
+    input.parent_request?.artifactDeclarations,
+    input.parent_request?.task?.artifact_declarations,
+    config.artifact_declarations,
+    config.artifactDeclarations,
+  ].find((candidate) => Array.isArray(candidate) && candidate.length > 0) || [];
+  return declarations.filter((declaration) => plainObject(declaration) && declaration.required === true && artifactDeclarationName(declaration));
+}
+
+function missingRequiredTypedArtifactDiagnostic(input, workload, config = {}) {
+  const required = requiredArtifactDeclarations(input, config);
+  if (required.length === 0) {
+    return null;
+  }
+  const typedArtifacts = plainObject(workload?.outputs?.typed_artifacts) ? workload.outputs.typed_artifacts : {};
+  const missing = required
+    .map((declaration) => ({
+      name: artifactDeclarationName(declaration),
+      type: declaration.type || declaration.kind || declaration.artifact_type || declaration.artifactType || '',
+      artifact_schema: declaration.artifact_schema || declaration.artifactSchema || declaration.schema || '',
+    }))
+    .filter((declaration) => !typedArtifacts[declaration.name]);
+  if (missing.length === 0) {
+    return null;
+  }
+  return {
+    class: 'wp-codebox.required_typed_artifacts_missing',
+    message: `WP Codebox agent task did not produce required typed artifacts: ${missing.map((declaration) => declaration.name).join(', ')}.`,
+    data: { reason: 'missing_required_typed_artifacts', missing },
+  };
 }
 
 function normalizeTypedArtifacts(value) {
@@ -934,10 +981,12 @@ function normalizeAgentTaskRun(input, result) {
   const fallbackAgentResult = result.metadata?.agent_runtime?.workload || execution?.agentResult || result.run?.agentResult || result.agentResult || result.agent_result || {};
   const agentResult = hasSemanticWorkload(stdoutWorkload) ? stdoutWorkload : fallbackAgentResult;
   const bundleValidation = isAgentBundle(input) ? validateAgentRuntimeWorkload(agentResult, config) : validateRuntimeTaskWorkload(agentResult, config);
-  const success = !bundleValidation;
+  const artifactValidation = missingRequiredTypedArtifactDiagnostic(input, agentResult, config);
+  const success = !bundleValidation && !artifactValidation;
   const diagnostics = [
     ...(result.diagnostics || []),
     ...(bundleValidation ? [bundleValidation] : []),
+    ...(artifactValidation ? [artifactValidation] : []),
     ...(agentRuntimeDiagnostics(agentResult) || []),
   ];
 
@@ -946,7 +995,7 @@ function normalizeAgentTaskRun(input, result) {
     success,
     status: success ? 'completed' : result.status,
     outputs: plainObject(agentResult.outputs) ? agentResult.outputs : result.outputs,
-    summary: success ? 'WP Codebox agent task succeeded.' : (bundleValidation?.message || result.summary || 'WP Codebox agent task failed.'),
+    summary: success ? 'WP Codebox agent task succeeded.' : (artifactValidation?.message || bundleValidation?.message || result.summary || 'WP Codebox agent task failed.'),
     session: result.session ? {
       ...result.session,
       status: success ? 'completed' : 'failed',

--- a/wordpress/scripts/agent/run-datamachine-agent-task.cjs
+++ b/wordpress/scripts/agent/run-datamachine-agent-task.cjs
@@ -34,6 +34,31 @@ function optionalObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
 }
 
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function artifactDeclarationName(declaration) {
+  if (typeof declaration === 'string') {
+    return declaration;
+  }
+  if (!declaration || typeof declaration !== 'object' || Array.isArray(declaration)) {
+    return '';
+  }
+  return declaration.name || declaration.id || '';
+}
+
+function expectedArtifactsFromConfig(config) {
+  const expected = normalizeArray(config.expected_artifacts);
+  if (expected.length > 0) {
+    return expected;
+  }
+  return normalizeArray(config.artifact_declarations)
+    .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true)
+    .map(artifactDeclarationName)
+    .filter(Boolean);
+}
+
 function buildAgentTaskRequest(config, configPath) {
   const taskId = config.task_id || config.workload_id || config.flow_slug || 'datamachine-agent-ci';
   const timeoutMs = Number.parseInt(config.time_budget_ms || '', 10);
@@ -66,7 +91,8 @@ function buildAgentTaskRequest(config, configPath) {
       repository: config.target_repo,
       path: config.component_path,
     }).filter(([, value]) => nonEmpty(value))),
-    expected_artifacts: config.expected_artifacts || [],
+    expected_artifacts: expectedArtifactsFromConfig(config),
+    artifact_declarations: normalizeArray(config.artifact_declarations),
     policy: optionalObject(config.policy),
     limits: Object.fromEntries(Object.entries({
       timeout_ms: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : undefined,

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -350,6 +350,20 @@ assert.equal(codeboxRequest.orchestrator.agent_task_id, 'task-123');
 assert.equal(codeboxRequest.context.audit_findings[0].id, 'finding-1');
 assert.deepEqual(codeboxRequest.agent_bundle, {});
 
+const artifactDeclarationRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'artifact-declaration-task-123',
+  artifact_declarations: [{
+    schema: 'wp-codebox/artifact-declaration/v1',
+    name: 'analysis_report',
+    type: 'AnalysisReport',
+    artifact_schema: 'example/analysis-report/v1',
+    required: true,
+  }],
+});
+assert.equal(artifactDeclarationRequest.artifact_declarations[0].name, 'analysis_report');
+assert.equal(artifactDeclarationRequest.artifact_declarations[0].required, true);
+
 const codeboxRequestWithAbilityTools = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
   task_id: 'ability-tools-task-123',
@@ -1429,6 +1443,35 @@ assert.equal(agentBundleOutcome.metadata.sandbox_policy.sandbox_tool_policy.tool
 assert.equal(upstreamRunnerOutcome.artifacts[1].kind, 'codebox-session-artifacts');
 assert.equal(upstreamRunnerOutcome.evidence_refs[0].uri, 'https://preview.example.test/sandbox-session-1');
 assert.equal(upstreamRunnerOutcome.evidence_refs[1].uri, '/tmp/wp-codebox-artifacts');
+
+const missingRequiredTypedArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  task_id: 'missing-required-typed-artifact-task-123',
+  artifact_declarations: [{
+    schema: 'wp-codebox/artifact-declaration/v1',
+    name: 'required_report',
+    type: 'RequiredReport',
+    artifact_schema: 'example/required-report/v1',
+    required: true,
+  }],
+  executor: { backend: 'codebox' },
+}, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  metadata: {
+    agent_runtime: {
+      workload: {
+        outputs: {},
+        scenarios: [{ id: 'agent-bundle', metadata: {} }],
+      },
+    },
+  },
+});
+assert.equal(missingRequiredTypedArtifactOutcome.status, 'failed');
+assert.equal(missingRequiredTypedArtifactOutcome.failure_classification, 'execution_failed');
+assert.equal(missingRequiredTypedArtifactOutcome.diagnostics[0].class, 'codebox.required_typed_artifacts_missing');
+assert.equal(missingRequiredTypedArtifactOutcome.diagnostics[0].data.missing[0].name, 'required_report');
 
 const canonicalTopLevelAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,

--- a/wordpress/tests/datamachine-agent-task-runner-smoke.js
+++ b/wordpress/tests/datamachine-agent-task-runner-smoke.js
@@ -50,7 +50,19 @@ process.stdout.write(JSON.stringify({
           id: 'agent-task-smoke',
           metrics: { config_present_mean: 1 },
           metadata: { success_status: 'no_changes' }
-        }]
+        }],
+        outputs: {
+          typed_artifacts: {
+            smoke_report: {
+              schema: 'homeboy/agent-task-typed-artifact/v1',
+              name: 'smoke_report',
+              type: 'SmokeReport',
+              artifact_schema: 'example/smoke-report/v1',
+              payload: { status: 'passed' },
+              file_refs: [{ path: input.artifacts_path + '/smoke-report.json', mime: 'application/json' }]
+            }
+          }
+        }
       }
     }
   },
@@ -71,6 +83,14 @@ process.stdout.write(JSON.stringify({
     prompt: 'Run the generic agent task smoke.',
     provider: 'example-provider',
     model: 'example-model',
+    expected_artifacts: ['smoke_report'],
+    artifact_declarations: [{
+      schema: 'wp-codebox/artifact-declaration/v1',
+      name: 'smoke_report',
+      type: 'SmokeReport',
+      artifact_schema: 'example/smoke-report/v1',
+      required: true,
+    }],
     wp_codebox_bin: binPath,
     wp_codebox_components: {
       agents_api: agentsApiPath,
@@ -103,13 +123,17 @@ process.stdout.write(JSON.stringify({
   assert.equal(captured.input.agent_bundle.flow_slug, 'example-flow');
   assert.equal(captured.input.provider, 'example-provider');
   assert.equal(captured.input.model, 'example-model');
-  assert.equal(captured.input.agents_api_path, agentsApiPath);
+  assert.deepEqual(captured.input.expected_artifacts, ['smoke_report']);
+  assert.equal(captured.input.artifact_declarations[0].name, 'smoke_report');
+  assert.equal(captured.input.artifact_declarations[0].required, true);
+  assert.equal(captured.input.runtime_component_paths.agents_api, agentsApiPath);
   assert.equal(captured.input.runtime_component_paths.agent_runtime, dataMachinePath);
   assert.equal(captured.input.runtime_component_paths.agent_runtime_tools, dataMachineCodePath);
 
   const outcome = JSON.parse(fs.readFileSync(outcomePath, 'utf8'));
   assert.equal(outcome.schema, 'homeboy/agent-task-outcome/v1');
   assert.equal(outcome.status, 'succeeded');
+  assert.equal(outcome.outputs.typed_artifacts.smoke_report.type, 'SmokeReport');
 
   const results = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
   assert.equal(results.scenarios[0].id, 'agent-task-smoke');

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -364,6 +364,13 @@ try {
         metadata: {},
         provenance: { source: 'test' },
       }],
+      artifact_declarations: [{
+        schema: 'wp-codebox/artifact-declaration/v1',
+        name: 'import_validation_result',
+        type: 'ImportValidationResult',
+        artifact_schema: 'example/import-validation-result/v1',
+        required: false,
+      }],
       workspaces: [{ target: '/workspace/codebox-canary', mode: 'readwrite' }],
     }),
     env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: runtimeTaskCapturePath, OPENCODE_API_KEY: 'redacted-test-key' },
@@ -374,6 +381,8 @@ try {
   assert.equal(runtimeTaskCaptured.input.runtime_task.ability, 'homeboy-canary/write-file');
   assert.deepEqual(runtimeTaskCaptured.input.agent_bundles, [{ source: '/workspace/bundles/canary-agent', slug: 'canary-agent' }]);
   assert.equal(runtimeTaskCaptured.input.structured_artifacts[0].name, 'concept_packet');
+  assert.equal(runtimeTaskCaptured.input.artifact_declarations[0].name, 'import_validation_result');
+  assert.equal(runtimeTaskCaptured.input.artifact_declarations[0].required, false);
   assert.equal(runtimeTaskCaptured.input.workspaces[0].target, '/workspace/codebox-canary');
 
   const abilityBridgeResult = spawnSync(process.execPath, [
@@ -444,6 +453,33 @@ try {
   const missingRuntimeOutput = JSON.parse(missingRuntimeOutputResult.stdout);
   assert.equal(missingRuntimeOutput.success, false);
   assert.equal(missingRuntimeOutput.diagnostics[0].class, 'runtime_task.outputs_missing');
+
+  const missingRequiredArtifactResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      runtime_task: {
+        ability: 'example/validate-artifact',
+        input: { artifact: { slug: 'example-site' } },
+      },
+      artifact_declarations: [{
+        schema: 'wp-codebox/artifact-declaration/v1',
+        name: 'missing_required_report',
+        type: 'MissingRequiredReport',
+        artifact_schema: 'example/missing-required-report/v1',
+        required: true,
+      }],
+    }),
+    env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: path.join(root, 'capture-missing-required-artifact.json'), OPENCODE_API_KEY: 'redacted-test-key' },
+  });
+  assert.equal(missingRequiredArtifactResult.status, 1, missingRequiredArtifactResult.stderr || missingRequiredArtifactResult.stdout);
+  const missingRequiredArtifactOutput = JSON.parse(missingRequiredArtifactResult.stdout);
+  assert.equal(missingRequiredArtifactOutput.success, false);
+  assert.equal(missingRequiredArtifactOutput.diagnostics[0].class, 'wp-codebox.required_typed_artifacts_missing');
+  assert.equal(missingRequiredArtifactOutput.diagnostics[0].data.missing[0].name, 'missing_required_report');
 
   const codexCapturePath = path.join(root, 'capture-codex.json');
   const codexSecretEnv = [


### PR DESCRIPTION
## Summary

- Adds reusable workflow inputs for generic typed artifact declarations and expected artifact names.
- Threads `expected_artifacts` and `artifact_declarations` through Data Machine Agent CI config, `homeboy/agent-task-request/v1`, and `wp-codebox/task-input/v1`.
- Normalizes completed typed artifacts into Homeboy outcome outputs/artifacts/evidence refs using existing typed artifact paths, and records typed artifact declaration/output metadata in the outcome.
- Fails completed runs when a required typed artifact declaration is missing from normalized typed outputs.

## Reusable workflow caller shape

```yaml
jobs:
  agent-ci:
    uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@main
    with:
      # Existing required inputs omitted for brevity.
      expected_artifacts: '["analysis_report"]'
      artifact_declarations: >-
        [{
          "schema": "wp-codebox/artifact-declaration/v1",
          "name": "analysis_report",
          "type": "AnalysisReport",
          "artifact_schema": "example/analysis-report/v1",
          "required": true
        }]
```

## Dependency / pending upstream contract

- Fixes https://github.com/Extra-Chill/homeboy-extensions/issues/1421.
- Depends on https://github.com/Automattic/wp-codebox/issues/1029, which is still open at PR creation time.
- Pending upstream field names used here: `artifact_declarations` for typed artifact declarations and `expected_artifacts` for generic expected artifact names.
- No WPSG/Docs-specific logic or compatibility shim was added; this is generic Homeboy Extensions plumbing against the anticipated WP Codebox typed artifact declaration/materialization contract.

## Verification

- `npm run test:datamachine-agent-wp-codebox-runner`
- `npm run test:codebox-agent-task-executor`
- `npm run test:wp-codebox-task-runner`
- `npx eslint scripts/agent/run-datamachine-agent-task.cjs lib/codebox-agent-task-executor.js scripts/agent/homeboy-wp-codebox-task-runner.cjs --no-warn-ignored`

Note: full `npm run lint:js` is blocked by existing unrelated lint failures in files outside this change (`playground-readiness.js`, `timing-correlator.js`, host runner lifecycle scripts, terminal action server, update-runner-workspace-pr, etc.).

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the workflow/JS plumbing and tests for typed artifact declarations; Chris remains responsible for review and final acceptance.
