### PR TITLE
Forward repo-loop inputs to runtime tasks

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -225,7 +225,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const provider = config.provider || options.provider || defaults.provider || '';
   const model = request.executor.model || config.model || options.model || defaults.model || '';
   const runtimeTask = runtimeTaskWithExecutionDefaults(
-    inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(config, inputs) || options.runtimeTask,
+    inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(request, config, inputs) || options.runtimeTask,
     { provider, model, agentBundles }
   );
   const explicitSecretEnv = [
@@ -397,8 +397,8 @@ function uniqueComponentContracts(contracts) {
   });
 }
 
-function abilityRuntimeTaskFromAgentTaskRequest(config, inputs) {
-  const genericAbilityTask = genericAbilityRuntimeTask(config, inputs);
+function abilityRuntimeTaskFromAgentTaskRequest(request, config, inputs) {
+  const genericAbilityTask = genericAbilityRuntimeTask(request, config, inputs);
   if (genericAbilityTask) {
     return genericAbilityTask;
   }
@@ -411,11 +411,11 @@ function abilityRuntimeTaskFromAgentTaskRequest(config, inputs) {
   if (!ability || typeof ability !== 'string') {
     return null;
   }
-  const input = firstObject(inputs.ability_input, inputs.abilityInput, inputs.input, config.ability_input, config.abilityInput, config.input) || {};
+  const input = runtimeTaskInputFromAgentTaskRequest(request, config, inputs);
   return { ability, input };
 }
 
-function genericAbilityRuntimeTask(config, inputs) {
+function genericAbilityRuntimeTask(request, config, inputs) {
   const rawAbility = firstValue(inputs.ability, config.ability);
   const abilityRequest = firstObject(
     inputs.ability_request,
@@ -430,8 +430,25 @@ function genericAbilityRuntimeTask(config, inputs) {
   if (!ability || typeof ability !== 'string') {
     return null;
   }
-  const input = firstObject(declared?.input, declared?.args, inputs.ability_input, inputs.abilityInput, inputs.input, config.ability_input, config.abilityInput, config.input) || {};
+  const input = runtimeTaskInputFromAgentTaskRequest(request, config, inputs, declared);
   return { ability, input };
+}
+
+function runtimeTaskInputFromAgentTaskRequest(request, config, inputs, declared = {}) {
+  const workflowInputs = workflowInputsFromAgentTaskRequest(request, config, inputs);
+  const explicitInput = firstObject(declared?.input, declared?.args, inputs.ability_input, inputs.abilityInput, inputs.input, config.ability_input, config.abilityInput, config.input) || {};
+  return { ...workflowInputs, ...explicitInput };
+}
+
+function workflowInputsFromAgentTaskRequest(request, config, inputs) {
+  return firstObject(
+    inputs.client_context?.inputs,
+    inputs.clientContext?.inputs,
+    request.client_context?.inputs,
+    request.clientContext?.inputs,
+    config.client_context?.inputs,
+    config.clientContext?.inputs,
+  ) || {};
 }
 
 function allowedToolsFromAgentTaskRequest(request, config, inputs, options, defaults) {

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -60,6 +60,58 @@ assert.equal(
   true
 );
 
+const repoLoopBundleTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'repo-loop-agent-bundle-task-1',
+  executor: { backend: 'wordpress', config: { provider: 'openai' } },
+  instructions: 'Run a repo-loop bundle workflow.',
+  inputs: {
+    ability_request: { name: 'datamachine/run-agent-bundle' },
+    client_context: {
+      inputs: {
+        source: 'bundles/store-idea-agent',
+        flow: 'store-idea-artifact-flow',
+        wait_for_completion: true,
+      },
+    },
+  },
+});
+
+assert.equal(repoLoopBundleTaskInput.runtime_task.ability, 'datamachine/run-agent-bundle');
+assert.deepEqual(repoLoopBundleTaskInput.runtime_task.input, {
+  source: 'bundles/store-idea-agent',
+  flow: 'store-idea-artifact-flow',
+  wait_for_completion: true,
+});
+
+const genericRepoLoopTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'repo-loop-generic-ability-task-1',
+  executor: { backend: 'wordpress', config: { provider: 'openai' } },
+  instructions: 'Run a generic declared ability with workflow inputs.',
+  client_context: {
+    inputs: {
+      packet: 'artifact-42',
+      dry_run: true,
+    },
+  },
+  inputs: {
+    ability_request: {
+      name: 'example/materialize-artifact',
+      input: { dry_run: false },
+    },
+    context: {
+      inputs: { secret: 'not-forwarded-from-ambient-context' },
+    },
+  },
+});
+
+assert.equal(genericRepoLoopTaskInput.runtime_task.ability, 'example/materialize-artifact');
+assert.deepEqual(genericRepoLoopTaskInput.runtime_task.input, {
+  packet: 'artifact-42',
+  dry_run: false,
+});
+
 const legacyTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'legacy-codebox-task-1',


### PR DESCRIPTION
## Summary
- Forward explicit repo-loop client_context.inputs into generic WP Codebox ability runtime_task.input.
- Preserve explicit ability input precedence over workflow inputs.
- Cover datamachine/run-agent-bundle and a non-WPSG generic ability task in the boundary test.

Fixes #1423

## Verification
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js
- node wordpress/tests/codebox-agent-task-executor-smoke.js
- npm run lint:js -- lib/codebox-agent-task-executor.js

Note: linting the boundary test directly reports it is ignored by the repo ESLint config.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the adapter seam, added focused tests, and ran verification. Chris remains responsible for review and merge.