### PR TITLE
fix: align Codebox agent task provider contract

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -10,6 +10,8 @@ const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
 const AGENT_TASK_OUTCOME_SCHEMA = 'homeboy/agent-task-outcome/v1';
 const AGENT_TASK_ARTIFACT_SCHEMA = 'homeboy/agent-task-artifact/v1';
 const WP_CODEBOX_TASK_REQUEST_SCHEMA = 'wp-codebox/task-input/v1';
+const WP_CODEBOX_PROVIDER_ID = 'wordpress.codebox-agent-task-executor';
+const WP_CODEBOX_PROVIDER_LABEL = 'WP Codebox agent task executor';
 const HOMEBOY_WORDPRESS_BACKEND = 'wordpress';
 const LEGACY_CODEBOX_BACKEND = 'codebox';
 
@@ -33,12 +35,10 @@ const PROVIDER_CAPABILITIES = [
   'tool:github_issue_publish',
   'tool:github_pull_request_publish',
   'tool:comment_github_pull_request',
-  'tool:wpsg_materialize_packet',
   'ability:datamachine/run-agent-bundle',
   'ability:github_issue_publish',
   'ability:github_pull_request_publish',
   'ability:comment_github_pull_request',
-  'ability:wpsg_materialize_packet',
 ];
 
 const DEFAULT_WORKSPACE_READONLY_TOOLS = [
@@ -186,9 +186,9 @@ function assertAgentTaskRequest(request) {
 function providerContract(options = {}) {
   return {
     schema: 'homeboy/agent-task-executor-provider/v1',
-    id: options.id || 'wordpress.agent-task-executor',
-    label: options.label || 'WordPress agent task executor',
-    backend: HOMEBOY_WORDPRESS_BACKEND,
+    id: options.id || WP_CODEBOX_PROVIDER_ID,
+    label: options.label || WP_CODEBOX_PROVIDER_LABEL,
+    backend: LEGACY_CODEBOX_BACKEND,
     command: options.command || 'node {{extension_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs',
     request_schema: AGENT_TASK_REQUEST_SCHEMA,
     outcome_schema: AGENT_TASK_OUTCOME_SCHEMA,

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -13,10 +13,16 @@ const {
 const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wordpress-agent-boundary-'));
 
 const provider = providerContract();
-assert.equal(provider.id, 'wordpress.agent-task-executor');
-assert.equal(provider.label, 'WordPress agent task executor');
-assert.equal(provider.backend, 'wordpress');
+assert.equal(provider.id, 'wordpress.codebox-agent-task-executor');
+assert.equal(provider.label, 'WP Codebox agent task executor');
+assert.equal(provider.backend, 'codebox');
 assert.equal(provider.integration_contract, 'homeboy-wordpress-agent-task/v1');
+
+const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'wordpress.json'), 'utf8'));
+assert.equal(manifest.agent_task_executors.length, 1);
+assert.deepEqual(manifest.agent_task_executors[0], provider);
+assert.equal(provider.capabilities.includes('tool:wpsg_materialize_packet'), false);
+assert.equal(provider.capabilities.includes('ability:wpsg_materialize_packet'), false);
 
 const taskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -24,10 +24,8 @@ const claudeCodeRefreshTokenEnv = 'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN';
 const repoLoopCapabilities = [
   'tool:datamachine/run-agent-bundle',
   'tool:github_pull_request_publish',
-  'tool:wpsg_materialize_packet',
   'ability:datamachine/run-agent-bundle',
   'ability:github_pull_request_publish',
-  'ability:wpsg_materialize_packet',
 ];
 
 function fixtureEnv(overrides = {}) {
@@ -256,7 +254,9 @@ const request = {
 };
 
 const provider = providerContract();
-assert.equal(provider.backend, 'wordpress');
+assert.equal(provider.id, 'wordpress.codebox-agent-task-executor');
+assert.equal(provider.label, 'WP Codebox agent task executor');
+assert.equal(provider.backend, 'codebox');
 assert.equal(provider.request_schema, 'homeboy/agent-task-request/v1');
 assert.equal(provider.outcome_schema, 'homeboy/agent-task-outcome/v1');
 assert.deepEqual(provider.request_required_fields, ['schema', 'task_id', 'executor.backend', 'instructions']);
@@ -293,9 +293,12 @@ for (const capability of repoLoopCapabilities) {
 }
 const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'wordpress.json'), 'utf8'));
 const manifestProvider = manifest.agent_task_executors.find((executor) => executor.id === provider.id);
+assert.deepEqual(manifestProvider, provider);
 for (const capability of repoLoopCapabilities) {
   assert.equal(manifestProvider.capabilities.includes(capability), true);
 }
+assert.equal(provider.capabilities.includes('tool:wpsg_materialize_packet'), false);
+assert.equal(provider.capabilities.includes('ability:wpsg_materialize_packet'), false);
 assert.deepEqual(provider.runtime_gap_trackers, []);
 
 const codeboxRequest = codeboxTaskRequestFromAgentTaskRequest(request);

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -21,9 +21,9 @@
   "agent_task_executors": [
     {
       "schema": "homeboy/agent-task-executor-provider/v1",
-      "id": "wordpress.agent-task-executor",
-      "label": "WordPress agent task executor",
-      "backend": "wordpress",
+      "id": "wordpress.codebox-agent-task-executor",
+      "label": "WP Codebox agent task executor",
+      "backend": "codebox",
       "command": "node {{extension_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs",
       "request_schema": "homeboy/agent-task-request/v1",
       "outcome_schema": "homeboy/agent-task-outcome/v1",
@@ -64,16 +64,17 @@
         "screenshots",
         "structured_outcome",
         "agent_bundle_execution",
+        "typed_bundle_outputs",
+        "external_recipe_packs",
+        "recipe_probe_artifacts",
         "tool:datamachine/run-agent-bundle",
         "tool:github_issue_publish",
         "tool:github_pull_request_publish",
         "tool:comment_github_pull_request",
-        "tool:wpsg_materialize_packet",
         "ability:datamachine/run-agent-bundle",
         "ability:github_issue_publish",
         "ability:github_pull_request_publish",
-        "ability:comment_github_pull_request",
-        "ability:wpsg_materialize_packet"
+        "ability:comment_github_pull_request"
       ],
       "workspace_materialization": {
         "cwd": "git_checkout"


### PR DESCRIPTION
## Summary
- Advertise the WordPress agent-task executor as the Codebox provider expected by Lab runner preflight.
- Keep the Homeboy Extensions provider boundary generic by removing WPSG-specific materialization tool/ability capabilities from the advertised contract.
- Add exact manifest-vs-providerContract assertions so the manifest and JS contract cannot drift again.

Fixes #1425.

## Tests
- npm run test:codebox-agent-task-executor-boundary
- npm run test:codebox-agent-task-executor
- node --check lib/codebox-agent-task-executor.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the provider contract alignment, manifest drift assertions, and focused test updates; Chris remains responsible for review and acceptance.