### PR TITLE
fix: propagate failed agent runtime outcomes

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -1036,8 +1036,7 @@ function normalizeStatus(result) {
   if (result?.outputs && typeof result.outputs === 'object' && result.outputs.success === false) {
     return 'failed';
   }
-  const workload = agentRuntimeWorkload(result);
-  if (workload && workload.success === false) {
+  if (agentRuntimeFailure(result)) {
     return 'failed';
   }
   if (AGENT_TASK_OUTCOME_STATUSES.includes(result?.status)) {
@@ -1067,8 +1066,84 @@ function normalizeStatus(result) {
   return result?.success === true ? 'succeeded' : 'failed';
 }
 
+function agentRuntimeResultCandidates(result) {
+  return [
+    result?.raw?.agent_runtime,
+    result?.raw?.agent_runtime?.result,
+    result?.raw?.agent_runtime?.workload,
+    result?.metadata?.agent_runtime,
+    result?.metadata?.agent_runtime?.result,
+    result?.metadata?.agent_runtime?.workload,
+    result?.run?.agentResult,
+    result?.agentResult,
+    result?.agent_result,
+  ].filter((candidate) => candidate && typeof candidate === 'object' && !Array.isArray(candidate));
+}
+
 function agentRuntimeWorkload(result) {
-  return result?.raw?.agent_runtime?.result || result?.metadata?.agent_runtime?.workload || result?.run?.agentResult || result?.agentResult || result?.agent_result || null;
+  return firstObject(
+    result?.raw?.agent_runtime?.result,
+    result?.raw?.agent_runtime?.workload,
+    result?.metadata?.agent_runtime?.result,
+    result?.metadata?.agent_runtime?.workload,
+    result?.run?.agentResult,
+    result?.agentResult,
+    result?.agent_result,
+  );
+}
+
+function agentRuntimeFailure(result) {
+  return agentRuntimeResultCandidates(result).find((candidate) => {
+    const terminalStatus = String(candidate.terminal_status || candidate.terminalStatus || '').toLowerCase();
+    const status = String(candidate.status || candidate.outcome || '').toLowerCase();
+    const completionStatus = String(candidate.completion_outcome?.status || candidate.completionOutcome?.status || '').toLowerCase();
+    return candidate.success === false
+      || candidate.completion_outcome?.success === false
+      || candidate.completionOutcome?.success === false
+      || terminalStatus === 'failed'
+      || terminalStatus.startsWith('failed ')
+      || status === 'failed'
+      || completionStatus === 'failed';
+  }) || null;
+}
+
+function agentRuntimeFailureReason(runtimeFailure) {
+  if (!runtimeFailure) {
+    return '';
+  }
+  const terminalStatus = String(runtimeFailure.terminal_status || runtimeFailure.terminalStatus || '');
+  return firstValue(
+    runtimeFailure.error_reason,
+    runtimeFailure.errorReason,
+    runtimeFailure.reason,
+    runtimeFailure.completion_outcome?.reason,
+    runtimeFailure.completionOutcome?.reason,
+    terminalStatus.startsWith('failed - ') ? terminalStatus.slice('failed - '.length).trim() : '',
+    runtimeFailure.status,
+  );
+}
+
+function agentRuntimeFailureDiagnostic(result) {
+  const runtimeFailure = agentRuntimeFailure(result);
+  if (!runtimeFailure) {
+    return null;
+  }
+  const reason = agentRuntimeFailureReason(runtimeFailure);
+  const message = runtimeFailure.error_message
+    || runtimeFailure.errorMessage
+    || runtimeFailure.message
+    || runtimeFailure.summary
+    || (reason ? `Embedded agent runtime failed: ${reason}.` : 'Embedded agent runtime failed.');
+  return {
+    class: 'agent_runtime.failed',
+    message,
+    data: sanitizePublicMetadata({
+      reason,
+      status: runtimeFailure.status,
+      terminal_status: runtimeFailure.terminal_status || runtimeFailure.terminalStatus,
+      error_reason: runtimeFailure.error_reason || runtimeFailure.errorReason,
+    }),
+  };
 }
 
 function appendUniqueArtifact(artifacts, artifact) {
@@ -1863,6 +1938,7 @@ function codeboxDecisionEvidence(result, runSummary = null, recipeSummary = null
     recipe_ref: recipeRun.ref,
     recipe_target_ref: recipeRun.target_ref || recipeRun.targetRef,
     recipe_failed_phase: recipeFailedPhase,
+    agent_runtime_failure_reason: agentRuntimeFailureReason(agentRuntimeFailure(result)),
   }).filter(([, value]) => value !== undefined && value !== ''));
 }
 
@@ -2000,6 +2076,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   const recipeRun = recipeRunFromResult(result);
   const fallbackRecipeSummary = recipeRunFailureSummary(recipeRun);
   const recipeFailedPhase = recipeSummary?.failed_phase || recipeSummary?.metadata?.failure_phase || recipeRunFailedPhase(recipeRun);
+  const runtimeFailureDiagnostic = agentRuntimeFailureDiagnostic(result);
   const codexProviderDiagnostic = codexProviderNotRegisteredDiagnostic(request, result);
   const codexBearerTokenDiagnostic = codexPhpAiClientBearerTokenDiagnostic(request, result);
   const codexVendorDiagnostic = codexPhpAiClientVendorDiagnostic(request, result);
@@ -2007,11 +2084,11 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     schema: AGENT_TASK_OUTCOME_SCHEMA,
     task_id: request.task_id,
     status,
-    summary: missingRequiredTypedArtifacts?.message || recipeSummary?.failure_summary || fallbackRecipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
+    summary: missingRequiredTypedArtifacts?.message || runtimeFailureDiagnostic?.message || recipeSummary?.failure_summary || fallbackRecipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
     artifacts: normalizeArtifacts(result, runSummary, recipeSummary),
     evidence_refs: normalizeEvidenceRefs(result, runSummary, recipeSummary),
     outputs,
-    diagnostics: [codexProviderDiagnostic, codexBearerTokenDiagnostic, codexVendorDiagnostic, missingRequiredTypedArtifacts, recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
+    diagnostics: [codexProviderDiagnostic, codexBearerTokenDiagnostic, codexVendorDiagnostic, missingRequiredTypedArtifacts, runtimeFailureDiagnostic, recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
       message: diagnostic.message || String(diagnostic),
       data: sanitizePublicMetadata(diagnostic.data || {}),

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1384,6 +1384,48 @@ const rawNestedAgentRuntimeFailureOutcome = agentTaskOutcomeFromCodeboxResult(re
 assert.equal(rawNestedAgentRuntimeFailureOutcome.status, 'failed');
 assert.equal(rawNestedAgentRuntimeFailureOutcome.failure_classification, 'execution_failed');
 
+const metadataAgentRuntimeFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  summary: 'WP Codebox agent task succeeded.',
+  metadata: {
+    agent_runtime: {
+      result: {
+        error_message: 'Codex OAuth refresh failed.',
+        error_reason: 'ai_processing_failed',
+        terminal_status: 'failed - ai_processing_failed',
+        reason: 'empty_data_packet_returned',
+        outputs: {
+          error_step_id: 'ephemeral_step_0',
+        },
+      },
+    },
+  },
+});
+assert.equal(metadataAgentRuntimeFailureOutcome.status, 'failed');
+assert.equal(metadataAgentRuntimeFailureOutcome.summary, 'Codex OAuth refresh failed.');
+assert.equal(metadataAgentRuntimeFailureOutcome.failure_classification, 'execution_failed');
+assert.equal(metadataAgentRuntimeFailureOutcome.diagnostics[0].class, 'agent_runtime.failed');
+assert.equal(metadataAgentRuntimeFailureOutcome.diagnostics[0].data.reason, 'ai_processing_failed');
+assert.equal(metadataAgentRuntimeFailureOutcome.metadata.decision_evidence.agent_runtime_failure_reason, 'ai_processing_failed');
+
+const metadataAgentRuntimeTerminalFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  metadata: {
+    agent_runtime: {
+      result: {
+        terminalStatus: 'failed - provider_auth_failed',
+      },
+    },
+  },
+});
+assert.equal(metadataAgentRuntimeTerminalFailureOutcome.status, 'failed');
+assert.equal(metadataAgentRuntimeTerminalFailureOutcome.diagnostics[0].class, 'agent_runtime.failed');
+assert.equal(metadataAgentRuntimeTerminalFailureOutcome.diagnostics[0].data.reason, 'provider_auth_failed');
+
 const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
   task_id: 'agent-bundle-task-123',


### PR DESCRIPTION
## Summary
- Propagate embedded Data Machine/agent-runtime failure envelopes to the Homeboy task outcome even when WP Codebox itself reports completion.
- Surface generic `agent_runtime.failed` diagnostics with terminal status/reason metadata.
- Add focused smoke coverage for `metadata.agent_runtime.result` failure payloads, including `terminal_status: failed - ...` and `error_step_id`-only outputs.

Fixes #1426.

## Testing
- `npm run test:codebox-agent-task-executor`
- `npm run test:codebox-agent-task-executor-boundary`
- `npm run lint:js -- lib/codebox-agent-task-executor.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic status propagation fix, added focused coverage, and ran targeted verification. Chris remains responsible for review and merge.