### PR TITLE
Map repo-loop artifacts to Codebox declarations

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -313,7 +313,92 @@ function artifactDeclarationsFromAgentTaskRequest(request, config = {}, inputs =
     options.artifactDeclarations,
     []
   );
-  return Array.isArray(declarations) ? declarations : [];
+  if (Array.isArray(declarations) && declarations.length > 0) {
+    return declarations;
+  }
+  return genericArtifactDeclarationsFromAgentTaskRequest(request, config, inputs, options);
+}
+
+function genericArtifactDeclarationsFromAgentTaskRequest(request, config = {}, inputs = {}, options = {}) {
+  const declarations = [
+    request.artifact_outputs,
+    request.artifactOutputs,
+    request.output_artifacts,
+    request.outputArtifacts,
+    request.artifacts?.outputs,
+    request.artifacts?.output_artifacts,
+    request.artifacts?.outputArtifacts,
+    request.outputs?.artifacts,
+    request.outputs?.artifact_outputs,
+    request.outputs?.artifactOutputs,
+    request.outputs?.typed_artifacts,
+    request.outputs?.typedArtifacts,
+    inputs.artifact_outputs,
+    inputs.artifactOutputs,
+    inputs.output_artifacts,
+    inputs.outputArtifacts,
+    inputs.artifacts?.outputs,
+    inputs.artifacts?.output_artifacts,
+    inputs.artifacts?.outputArtifacts,
+    inputs.outputs?.artifacts,
+    inputs.outputs?.artifact_outputs,
+    inputs.outputs?.artifactOutputs,
+    inputs.outputs?.typed_artifacts,
+    inputs.outputs?.typedArtifacts,
+    config.artifact_outputs,
+    config.artifactOutputs,
+    config.output_artifacts,
+    config.outputArtifacts,
+    config.artifacts?.outputs,
+    config.artifacts?.output_artifacts,
+    config.artifacts?.outputArtifacts,
+    options.artifactOutputs,
+    options.outputArtifacts,
+  ].flatMap(genericArtifactDeclarationEntries);
+  return declarations
+    .map(([name, declaration]) => wpCodeboxArtifactDeclarationFromGeneric(name, declaration))
+    .filter(Boolean);
+}
+
+function genericArtifactDeclarationEntries(value) {
+  if (Array.isArray(value)) {
+    return value.map((declaration) => ['', declaration]);
+  }
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+  return Object.entries(value);
+}
+
+function wpCodeboxArtifactDeclarationFromGeneric(defaultName, declaration) {
+  if (typeof declaration === 'string') {
+    return {
+      schema: 'wp-codebox/artifact-declaration/v1',
+      name: declaration,
+      required: true,
+    };
+  }
+  if (!declaration || typeof declaration !== 'object' || Array.isArray(declaration)) {
+    return null;
+  }
+  const name = declaration.name || declaration.id || declaration.output || declaration.artifact || defaultName;
+  if (!name || typeof name !== 'string') {
+    return null;
+  }
+  const artifactSchema = declaration.artifact_schema
+    || declaration.artifactSchema
+    || declaration.content_schema
+    || declaration.contentSchema
+    || (declaration.schema && declaration.schema !== 'wp-codebox/artifact-declaration/v1' ? declaration.schema : undefined);
+  return Object.fromEntries(Object.entries({
+    schema: 'wp-codebox/artifact-declaration/v1',
+    name,
+    type: declaration.type || declaration.kind || declaration.artifact_type || declaration.artifactType,
+    artifact_schema: artifactSchema,
+    required: declaration.required === undefined ? true : declaration.required === true,
+    description: declaration.description,
+    metadata: declaration.metadata,
+  }).filter(([, value]) => value !== undefined));
 }
 
 class RuntimeOverlayConfigError extends Error {

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -71,6 +71,15 @@ const repoLoopBundleTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   task_id: 'repo-loop-agent-bundle-task-1',
   executor: { backend: 'wordpress', config: { provider: 'openai' } },
   instructions: 'Run a repo-loop bundle workflow.',
+  artifacts: {
+    outputs: {
+      concept_packet: {
+        type: 'ConceptPacket',
+        schema: 'static-site-generator/concept-packet/v1',
+        required: true,
+      },
+    },
+  },
   inputs: {
     ability_request: { name: 'datamachine/run-agent-bundle' },
     client_context: {
@@ -89,6 +98,13 @@ assert.deepEqual(repoLoopBundleTaskInput.runtime_task.input, {
   flow: 'store-idea-artifact-flow',
   wait_for_completion: true,
 });
+assert.deepEqual(repoLoopBundleTaskInput.artifact_declarations, [{
+  schema: 'wp-codebox/artifact-declaration/v1',
+  name: 'concept_packet',
+  type: 'ConceptPacket',
+  artifact_schema: 'static-site-generator/concept-packet/v1',
+  required: true,
+}]);
 
 const genericRepoLoopTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
@@ -117,6 +133,31 @@ assert.deepEqual(genericRepoLoopTaskInput.runtime_task.input, {
   packet: 'artifact-42',
   dry_run: false,
 });
+
+const repoLoopTypedOutputsTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'repo-loop-typed-outputs-task-1',
+  executor: { backend: 'wordpress', config: { provider: 'openai' } },
+  instructions: 'Run a repo-loop step that declares typed outputs generically.',
+  outputs: {
+    typed_artifacts: [{
+      name: 'concept_packet',
+      type: 'ConceptPacket',
+      artifact_schema: 'static-site-generator/concept-packet/v1',
+    }],
+  },
+  inputs: {
+    ability_request: { name: 'datamachine/run-agent-bundle' },
+  },
+});
+
+assert.deepEqual(repoLoopTypedOutputsTaskInput.artifact_declarations, [{
+  schema: 'wp-codebox/artifact-declaration/v1',
+  name: 'concept_packet',
+  type: 'ConceptPacket',
+  artifact_schema: 'static-site-generator/concept-packet/v1',
+  required: true,
+}]);
 
 const legacyTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1518,6 +1518,37 @@ assert.equal(missingRequiredTypedArtifactOutcome.failure_classification, 'execut
 assert.equal(missingRequiredTypedArtifactOutcome.diagnostics[0].class, 'codebox.required_typed_artifacts_missing');
 assert.equal(missingRequiredTypedArtifactOutcome.diagnostics[0].data.missing[0].name, 'required_report');
 
+const missingGenericRepoLoopArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  task_id: 'missing-generic-repo-loop-artifact-task-123',
+  artifacts: {
+    outputs: {
+      concept_packet: {
+        type: 'ConceptPacket',
+        schema: 'static-site-generator/concept-packet/v1',
+      },
+    },
+  },
+  executor: { backend: 'codebox' },
+}, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  metadata: {
+    agent_runtime: {
+      workload: {
+        outputs: {},
+        scenarios: [{ id: 'agent-bundle', metadata: {} }],
+      },
+    },
+  },
+});
+assert.equal(missingGenericRepoLoopArtifactOutcome.status, 'failed');
+assert.equal(missingGenericRepoLoopArtifactOutcome.failure_classification, 'execution_failed');
+assert.equal(missingGenericRepoLoopArtifactOutcome.diagnostics[0].class, 'codebox.required_typed_artifacts_missing');
+assert.equal(missingGenericRepoLoopArtifactOutcome.diagnostics[0].data.missing[0].name, 'concept_packet');
+assert.equal(missingGenericRepoLoopArtifactOutcome.diagnostics[0].data.missing[0].artifact_schema, 'static-site-generator/concept-packet/v1');
+
 const canonicalTopLevelAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
   task_id: 'canonical-top-level-agent-bundle-task-123',


### PR DESCRIPTION
## Summary
- Convert generic repo-loop artifact output declarations into WP Codebox artifact_declarations at the HBEX provider boundary.
- Preserve explicit WP Codebox artifact_declarations precedence and existing workflow input forwarding behavior.
- Reuse the mapped declarations for missing required typed artifact failure handling.

Fixes #1431

## Verification
- node tests/codebox-agent-task-executor-boundary.test.js
- node tests/codebox-agent-task-executor-smoke.js
- npm run lint:js -- lib/codebox-agent-task-executor.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the HBEX adapter mapping, added focused boundary/outcome tests, and ran verification. Chris remains responsible for review and merge.