### PR TITLE
Require agent runtime inputs for Data Machine agent CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -114,7 +114,9 @@ jobs:
       target_repo: chubes4/world-of-wordpress
       prompt: ${{ inputs.prompt }}
       validation_dependencies: chubes4/world-of-wordpress@main,chubes4/markdown-database-integration@main
-      wp_codebox_wordpress_version: beta
+      agent_runtime: wp-codebox
+      agent_runtime_ref: main
+      runtime_wordpress_version: beta
       max_turns: 16
       step_budget: 20
       time_budget_ms: 900000
@@ -123,7 +125,7 @@ jobs:
           "MARKDOWN_DB_MODE": "primary",
           "MARKDOWN_DB_CONTENT_DIR": "/wordpress/wp-content/plugins/world-of-wordpress/content"
         }
-      extra_wp_codebox_mounts: |
+      runtime_mounts: |
         [
           "${{ github.workspace }}/.ci/markdown-database-integration/db.php:/wordpress/wp-content/db.php:readonly"
         ]
@@ -142,9 +144,8 @@ jobs:
 
 ## Inputs worth calling out
 
-- Agent CI always runs through WP Codebox. The workflow checks out and builds `Automattic/wp-codebox` whenever `run_agent` is true; `wp_codebox_ref` controls the ref.
-- `agent_runtime` and `runtime_id` are runtime-neutral names for the execution substrate. Today the only supported value is `wp-codebox`, which remains the default.
-- `agent_runtime_ref` and `runtime_ref` are runtime-neutral names for the substrate ref. They override `wp_codebox_ref` when set; existing callers can keep using `wp_codebox_ref` unchanged.
+- Agent CI runs through the selected `agent_runtime`. Today the only supported value is `wp-codebox`, and the workflow checks out/builds `Automattic/wp-codebox` for that runtime.
+- `agent_runtime_ref` controls the selected runtime ref.
 - `include_agent_runtime_dependencies` defaults to `true` and checks out the standard WordPress agent runtime stack: `Automattic/agents-api`, `Extra-Chill/data-machine`, `Extra-Chill/data-machine-code`, and the provider plugin.
 - `agents_api_ref`, `data_machine_ref`, `data_machine_code_ref`, and `openai_provider_ref` control runtime dependency refs. `openai_provider_ref` defaults to `trunk` for the built-in OpenAI preset.
 - `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `credentials` keys. When `provider: openai`, an empty object preserves the existing OpenAI provider defaults.
@@ -158,9 +159,9 @@ jobs:
 - `dry_run` is intended for workflow smoke tests only; production consumers should leave it `false`.
 - `transcript_artifact_name` controls artifact upload. An empty value skips upload.
 - `extra_wp_config_defines` must be a JSON object and is merged into the runner config `wp_config_defines`.
-- `runtime_mounts` is the runtime-neutral alias for additional runtime mounts. It is appended alongside `extra_wp_codebox_mounts`; both inputs must be JSON arrays.
+- `runtime_mounts` adds selected-runtime mounts. It must be a JSON array.
 - `runtime_overlays` forwards runtime overlay entries to the runner config. It must be a JSON array.
-- `extra_wp_codebox_mounts`, `workload_run_before`, `workload_run_after`, and `extra_required_abilities` must be JSON arrays.
+- `workload_run_before`, `workload_run_after`, and `extra_required_abilities` must be JSON arrays.
 - `workload_run_after` runs post-agent verifier hooks in the same WordPress scenario, so consumers can assert the agent left WordPress in a valid state.
 - `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.
 - `tool_recorders` configures tool-result projection, forced parameters, and engine-data capture. It must be a JSON array.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -143,6 +143,8 @@ jobs:
 ## Inputs worth calling out
 
 - Agent CI always runs through WP Codebox. The workflow checks out and builds `Automattic/wp-codebox` whenever `run_agent` is true; `wp_codebox_ref` controls the ref.
+- `agent_runtime` and `runtime_id` are runtime-neutral names for the execution substrate. Today the only supported value is `wp-codebox`, which remains the default.
+- `agent_runtime_ref` and `runtime_ref` are runtime-neutral names for the substrate ref. They override `wp_codebox_ref` when set; existing callers can keep using `wp_codebox_ref` unchanged.
 - `include_agent_runtime_dependencies` defaults to `true` and checks out the standard WordPress agent runtime stack: `Automattic/agents-api`, `Extra-Chill/data-machine`, `Extra-Chill/data-machine-code`, and the provider plugin.
 - `agents_api_ref`, `data_machine_ref`, `data_machine_code_ref`, and `openai_provider_ref` control runtime dependency refs. `openai_provider_ref` defaults to `trunk` for the built-in OpenAI preset.
 - `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `credentials` keys. When `provider: openai`, an empty object preserves the existing OpenAI provider defaults.
@@ -156,6 +158,8 @@ jobs:
 - `dry_run` is intended for workflow smoke tests only; production consumers should leave it `false`.
 - `transcript_artifact_name` controls artifact upload. An empty value skips upload.
 - `extra_wp_config_defines` must be a JSON object and is merged into the runner config `wp_config_defines`.
+- `runtime_mounts` is the runtime-neutral alias for additional runtime mounts. It is appended alongside `extra_wp_codebox_mounts`; both inputs must be JSON arrays.
+- `runtime_overlays` forwards runtime overlay entries to the runner config. It must be a JSON array.
 - `extra_wp_codebox_mounts`, `workload_run_before`, `workload_run_after`, and `extra_required_abilities` must be JSON arrays.
 - `workload_run_after` runs post-agent verifier hooks in the same WordPress scenario, so consumers can assert the agent left WordPress in a valid state.
 - `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -90,8 +90,24 @@ name: Data Machine Agent CI (reusable)
         description: "Include the standard WordPress agent runtime stack: Agents API, Data Machine, and Data Machine Code."
         type: boolean
         default: true
+      agent_runtime:
+        description: Runtime substrate id. Currently only wp-codebox is supported; runtime_id is an alias.
+        type: string
+        default: ""
+      runtime_id:
+        description: Alias for agent_runtime.
+        type: string
+        default: ""
+      agent_runtime_ref:
+        description: Runtime substrate ref. Overrides runtime_ref and wp_codebox_ref when set.
+        type: string
+        default: ""
+      runtime_ref:
+        description: Alias for agent_runtime_ref. Overrides wp_codebox_ref when set.
+        type: string
+        default: ""
       wp_codebox_ref:
-        description: Ref for Automattic/wp-codebox. Agent CI always checks out and builds WP Codebox when run_agent is true.
+        description: Ref for Automattic/wp-codebox. Alias for the default WP Codebox runtime ref when agent_runtime_ref/runtime_ref are empty.
         type: string
         default: main
       agents_api_ref:
@@ -219,6 +235,14 @@ name: Data Machine Agent CI (reusable)
           the default ci-driver fixture mount. Entries may be SOURCE:TARGET[:MODE]
           strings or objects with source, target, mode, and optional type
           (directory or file). Default '[]' means no extra mounts.
+        type: string
+        default: "[]"
+      runtime_mounts:
+        description: Runtime-neutral alias for extra WP Codebox mounts. JSON string array appended alongside extra_wp_codebox_mounts.
+        type: string
+        default: "[]"
+      runtime_overlays:
+        description: JSON array of runtime overlay entries forwarded to the runner config runtime_overlays.
         type: string
         default: "[]"
       workload_run_before:
@@ -496,6 +520,10 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           VALIDATION_DEPENDENCIES: ${{ inputs.validation_dependencies }}
           INCLUDE_AGENT_RUNTIME_DEPENDENCIES: ${{ inputs.include_agent_runtime_dependencies }}
+          AGENT_RUNTIME: ${{ inputs.agent_runtime }}
+          RUNTIME_ID: ${{ inputs.runtime_id }}
+          AGENT_RUNTIME_REF: ${{ inputs.agent_runtime_ref }}
+          RUNTIME_REF: ${{ inputs.runtime_ref }}
           WP_CODEBOX_REF: ${{ inputs.wp_codebox_ref }}
           AGENTS_API_REF: ${{ inputs.agents_api_ref }}
           DATA_MACHINE_REF: ${{ inputs.data_machine_ref }}
@@ -506,6 +534,16 @@ jobs:
         run: |
           set -euo pipefail
           dependency_entries=()
+          effective_runtime_id="${AGENT_RUNTIME:-${RUNTIME_ID:-wp-codebox}}"
+          if [ -n "$AGENT_RUNTIME" ] && [ -n "$RUNTIME_ID" ] && [ "$AGENT_RUNTIME" != "$RUNTIME_ID" ]; then
+            echo "agent_runtime and runtime_id must match when both are set." >&2
+            exit 1
+          fi
+          if [ "$effective_runtime_id" != "wp-codebox" ]; then
+            echo "Unsupported agent_runtime/runtime_id: $effective_runtime_id. Only wp-codebox is currently supported." >&2
+            exit 1
+          fi
+          effective_runtime_ref="${AGENT_RUNTIME_REF:-${RUNTIME_REF:-$WP_CODEBOX_REF}}"
           provider_plugin_json="$(printf '%s' "$PROVIDER_PLUGIN" | jq -Rsc --arg provider "$PROVIDER" --arg openaiRef "$OPENAI_PROVIDER_REF" '
             if (gsub("^\\s+|\\s+$"; "") | length) == 0 then {} else fromjson end
             | if type == "object" then . else error("provider_plugin must be a JSON object") end
@@ -519,7 +557,7 @@ jobs:
           ')"
           provider_plugin_repo="$(jq -r '.repo // ""' <<< "$provider_plugin_json")"
           provider_plugin_ref="$(jq -r '.ref // ""' <<< "$provider_plugin_json")"
-          dependency_entries+=("Automattic/wp-codebox@${WP_CODEBOX_REF}")
+          dependency_entries+=("Automattic/wp-codebox@${effective_runtime_ref}")
           if [ "$INCLUDE_AGENT_RUNTIME_DEPENDENCIES" = "true" ]; then
             dependency_entries+=("Automattic/agents-api@${AGENTS_API_REF}")
             dependency_entries+=("Extra-Chill/data-machine@${DATA_MACHINE_REF}")
@@ -688,6 +726,11 @@ jobs:
           PROMPT: ${{ inputs.prompt }}
           PROVIDER: ${{ inputs.provider }}
           MODEL: ${{ inputs.model }}
+          AGENT_RUNTIME: ${{ inputs.agent_runtime }}
+          RUNTIME_ID: ${{ inputs.runtime_id }}
+          AGENT_RUNTIME_REF: ${{ inputs.agent_runtime_ref }}
+          RUNTIME_REF: ${{ inputs.runtime_ref }}
+          WP_CODEBOX_REF: ${{ inputs.wp_codebox_ref }}
           WP_CODEBOX_WORDPRESS_VERSION: ${{ inputs.wp_codebox_wordpress_version }}
           SUCCESS_REQUIRES_PR: ${{ inputs.success_requires_pr }}
           SUCCESS_COMPLETION_OUTCOMES: ${{ inputs.success_completion_outcomes }}
@@ -705,6 +748,8 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           EXTRA_WP_CONFIG_DEFINES: ${{ inputs.extra_wp_config_defines }}
           EXTRA_WP_CODEBOX_MOUNTS: ${{ inputs.extra_wp_codebox_mounts }}
+          RUNTIME_MOUNTS: ${{ inputs.runtime_mounts }}
+          RUNTIME_OVERLAYS: ${{ inputs.runtime_overlays }}
           WORKLOAD_RUN_BEFORE: ${{ inputs.workload_run_before }}
           WORKLOAD_RUN_AFTER: ${{ inputs.workload_run_after }}
           DAILY_MEMORY_ENABLED: ${{ inputs.daily_memory_enabled }}
@@ -744,6 +789,16 @@ jobs:
           component_slug="$(basename "$GITHUB_WORKSPACE")"
           transcript_host_dir="${GITHUB_WORKSPACE}/datamachine-agent-artifacts/${AGENT_SLUG}"
           transcript_guest_dir="/wordpress/wp-content/plugins/${component_slug}/datamachine-agent-artifacts/${AGENT_SLUG}"
+          effective_runtime_id="${AGENT_RUNTIME:-${RUNTIME_ID:-wp-codebox}}"
+          if [ -n "$AGENT_RUNTIME" ] && [ -n "$RUNTIME_ID" ] && [ "$AGENT_RUNTIME" != "$RUNTIME_ID" ]; then
+            echo "agent_runtime and runtime_id must match when both are set." >&2
+            exit 1
+          fi
+          if [ "$effective_runtime_id" != "wp-codebox" ]; then
+            echo "Unsupported agent_runtime/runtime_id: $effective_runtime_id. Only wp-codebox is currently supported." >&2
+            exit 1
+          fi
+          effective_runtime_ref="${AGENT_RUNTIME_REF:-${RUNTIME_REF:-$WP_CODEBOX_REF}}"
           execute_workflow_guest_path="$EXECUTE_WORKFLOW_PATH"
           execute_workflow_mounts_json="[]"
           if [ -n "$EXECUTE_WORKFLOW_PATH" ] && [[ "$EXECUTE_WORKFLOW_PATH" != /* ]]; then
@@ -843,7 +898,23 @@ jobs:
           ')"
           workspace_contract_checks_json="$(validate_json_input workspace_contract_checks object "$WORKSPACE_CONTRACT_CHECKS")"
           extra_wp_config_defines_json="$(validate_json_input extra_wp_config_defines object "$EXTRA_WP_CONFIG_DEFINES")"
-          extra_wp_codebox_mounts_json="$(validate_json_input extra_wp_codebox_mounts array "$EXTRA_WP_CODEBOX_MOUNTS" | jq -c --arg workspace "$GITHUB_WORKSPACE" '
+          normalize_mounts_input() {
+            local name="$1"
+            local value="$2"
+            validate_json_input "$name" array "$value" | jq -c --arg workspace "$GITHUB_WORKSPACE" '
+              map(
+                if type == "object" and (.source? | type == "string") and (.source | startswith("/") | not) then
+                  .source = ($workspace + "/" + .source)
+                else
+                  .
+                end
+              )
+            '
+          }
+          extra_wp_codebox_mounts_json="$(jq -cs '.[0] + .[1]' \
+            <(normalize_mounts_input extra_wp_codebox_mounts "$EXTRA_WP_CODEBOX_MOUNTS") \
+            <(normalize_mounts_input runtime_mounts "$RUNTIME_MOUNTS"))"
+          runtime_overlays_json="$(validate_json_input runtime_overlays array "$RUNTIME_OVERLAYS" | jq -c --arg workspace "$GITHUB_WORKSPACE" '
             map(
               if type == "object" and (.source? | type == "string") and (.source | startswith("/") | not) then
                 .source = ($workspace + "/" + .source)
@@ -927,6 +998,8 @@ jobs:
             --arg executeWorkflowPath "$execute_workflow_guest_path" \
             --arg providerRegisterFunction "$provider_register_function" \
             --arg wpCliToolName "$WP_CLI_TOOL_NAME" \
+            --arg runtimeId "$effective_runtime_id" \
+            --arg runtimeRef "$effective_runtime_ref" \
             --argjson validationDependencies "$validation_json" \
             --argjson providerCredentials "$provider_credentials_json" \
             --argjson providerBenchEnv "$provider_bench_env_json" \
@@ -941,6 +1014,7 @@ jobs:
             --argjson dryRun "$DRY_RUN" \
             --argjson extraWpConfigDefines "$extra_wp_config_defines_json" \
             --argjson extraWpCodeboxMounts "$extra_wp_codebox_mounts_json" \
+            --argjson runtimeOverlays "$runtime_overlays_json" \
             --argjson executeWorkflowMounts "$execute_workflow_mounts_json" \
             --argjson runnerWorkspaceMounts "$runner_workspace_mounts_json" \
             --argjson workloadRunBefore "$workload_run_before_json" \
@@ -966,6 +1040,8 @@ jobs:
               workload_id: $flowSlug,
               workload_label: ("Run " + $agentSlug + " Data Machine agent"),
               validation_dependencies: $validationDependencies,
+              runtime_id: $runtimeId,
+              runtime_ref: $runtimeRef,
               wp_codebox_wordpress_version: $wpCodeboxWordPressVersion,
               wp_codebox_mounts: ([
                 {
@@ -976,6 +1052,7 @@ jobs:
                 }
               ] + $extraWpCodeboxMounts + $executeWorkflowMounts + $runnerWorkspaceMounts),
               wp_config_defines: $extraWpConfigDefines,
+              runtime_overlays: $runtimeOverlays,
               workload_run_before: $workloadRunBefore,
               workload_run_after: $workloadRunAfter,
               required_abilities: (((if $executeWorkflowPath != "" then ["datamachine/import-agent", "datamachine/execute-workflow", "datamachine/drain-job"] else ["datamachine/import-agent", "datamachine/run-flow", "datamachine/drain-job"] end) + $extraRequiredAbilities) | reduce .[] as $ability ([]; if index($ability) then . else . + [$ability] end)),

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -91,23 +91,11 @@ name: Data Machine Agent CI (reusable)
         type: boolean
         default: true
       agent_runtime:
-        description: Runtime substrate id. Currently only wp-codebox is supported; runtime_id is an alias.
+        description: Runtime substrate id. Currently only wp-codebox is supported.
         type: string
-        default: ""
-      runtime_id:
-        description: Alias for agent_runtime.
-        type: string
-        default: ""
+        default: wp-codebox
       agent_runtime_ref:
-        description: Runtime substrate ref. Overrides runtime_ref and wp_codebox_ref when set.
-        type: string
-        default: ""
-      runtime_ref:
-        description: Alias for agent_runtime_ref. Overrides wp_codebox_ref when set.
-        type: string
-        default: ""
-      wp_codebox_ref:
-        description: Ref for Automattic/wp-codebox. Alias for the default WP Codebox runtime ref when agent_runtime_ref/runtime_ref are empty.
+        description: Runtime substrate ref. For agent_runtime=wp-codebox this is the Automattic/wp-codebox ref.
         type: string
         default: main
       agents_api_ref:
@@ -126,7 +114,8 @@ name: Data Machine Agent CI (reusable)
         description: Ref for WordPress/ai-provider-for-openai when mounting the default OpenAI provider plugin.
         type: string
         default: trunk
-      wp_codebox_wordpress_version:
+      runtime_wordpress_version:
+        description: WordPress version used by the selected WordPress-capable runtime.
         type: string
         default: "7.0"
       success_requires_pr:
@@ -229,16 +218,12 @@ name: Data Machine Agent CI (reusable)
           Default '{}' means no extra defines.
         type: string
         default: "{}"
-      extra_wp_codebox_mounts:
+      runtime_mounts:
         description: |
-          JSON string array appended to the runner config wp_codebox_mounts after
-          the default ci-driver fixture mount. Entries may be SOURCE:TARGET[:MODE]
+          JSON string array appended to the selected runtime mounts after the
+          default ci-driver fixture mount. Entries may be SOURCE:TARGET[:MODE]
           strings or objects with source, target, mode, and optional type
           (directory or file). Default '[]' means no extra mounts.
-        type: string
-        default: "[]"
-      runtime_mounts:
-        description: Runtime-neutral alias for extra WP Codebox mounts. JSON string array appended alongside extra_wp_codebox_mounts.
         type: string
         default: "[]"
       runtime_overlays:
@@ -521,10 +506,7 @@ jobs:
           VALIDATION_DEPENDENCIES: ${{ inputs.validation_dependencies }}
           INCLUDE_AGENT_RUNTIME_DEPENDENCIES: ${{ inputs.include_agent_runtime_dependencies }}
           AGENT_RUNTIME: ${{ inputs.agent_runtime }}
-          RUNTIME_ID: ${{ inputs.runtime_id }}
           AGENT_RUNTIME_REF: ${{ inputs.agent_runtime_ref }}
-          RUNTIME_REF: ${{ inputs.runtime_ref }}
-          WP_CODEBOX_REF: ${{ inputs.wp_codebox_ref }}
           AGENTS_API_REF: ${{ inputs.agents_api_ref }}
           DATA_MACHINE_REF: ${{ inputs.data_machine_ref }}
           DATA_MACHINE_CODE_REF: ${{ inputs.data_machine_code_ref }}
@@ -534,16 +516,12 @@ jobs:
         run: |
           set -euo pipefail
           dependency_entries=()
-          effective_runtime_id="${AGENT_RUNTIME:-${RUNTIME_ID:-wp-codebox}}"
-          if [ -n "$AGENT_RUNTIME" ] && [ -n "$RUNTIME_ID" ] && [ "$AGENT_RUNTIME" != "$RUNTIME_ID" ]; then
-            echo "agent_runtime and runtime_id must match when both are set." >&2
-            exit 1
-          fi
+          effective_runtime_id="$AGENT_RUNTIME"
           if [ "$effective_runtime_id" != "wp-codebox" ]; then
-            echo "Unsupported agent_runtime/runtime_id: $effective_runtime_id. Only wp-codebox is currently supported." >&2
+            echo "Unsupported agent_runtime: $effective_runtime_id. Only wp-codebox is currently supported." >&2
             exit 1
           fi
-          effective_runtime_ref="${AGENT_RUNTIME_REF:-${RUNTIME_REF:-$WP_CODEBOX_REF}}"
+          effective_runtime_ref="$AGENT_RUNTIME_REF"
           provider_plugin_json="$(printf '%s' "$PROVIDER_PLUGIN" | jq -Rsc --arg provider "$PROVIDER" --arg openaiRef "$OPENAI_PROVIDER_REF" '
             if (gsub("^\\s+|\\s+$"; "") | length) == 0 then {} else fromjson end
             | if type == "object" then . else error("provider_plugin must be a JSON object") end
@@ -727,11 +705,8 @@ jobs:
           PROVIDER: ${{ inputs.provider }}
           MODEL: ${{ inputs.model }}
           AGENT_RUNTIME: ${{ inputs.agent_runtime }}
-          RUNTIME_ID: ${{ inputs.runtime_id }}
           AGENT_RUNTIME_REF: ${{ inputs.agent_runtime_ref }}
-          RUNTIME_REF: ${{ inputs.runtime_ref }}
-          WP_CODEBOX_REF: ${{ inputs.wp_codebox_ref }}
-          WP_CODEBOX_WORDPRESS_VERSION: ${{ inputs.wp_codebox_wordpress_version }}
+          RUNTIME_WORDPRESS_VERSION: ${{ inputs.runtime_wordpress_version }}
           SUCCESS_REQUIRES_PR: ${{ inputs.success_requires_pr }}
           SUCCESS_COMPLETION_OUTCOMES: ${{ inputs.success_completion_outcomes }}
           MAX_TURNS: ${{ inputs.max_turns }}
@@ -747,7 +722,6 @@ jobs:
           WP_GYM_BENCHMARK_MODE: ${{ inputs.wp_gym_benchmark_mode }}
           DRY_RUN: ${{ inputs.dry_run }}
           EXTRA_WP_CONFIG_DEFINES: ${{ inputs.extra_wp_config_defines }}
-          EXTRA_WP_CODEBOX_MOUNTS: ${{ inputs.extra_wp_codebox_mounts }}
           RUNTIME_MOUNTS: ${{ inputs.runtime_mounts }}
           RUNTIME_OVERLAYS: ${{ inputs.runtime_overlays }}
           WORKLOAD_RUN_BEFORE: ${{ inputs.workload_run_before }}
@@ -789,16 +763,12 @@ jobs:
           component_slug="$(basename "$GITHUB_WORKSPACE")"
           transcript_host_dir="${GITHUB_WORKSPACE}/datamachine-agent-artifacts/${AGENT_SLUG}"
           transcript_guest_dir="/wordpress/wp-content/plugins/${component_slug}/datamachine-agent-artifacts/${AGENT_SLUG}"
-          effective_runtime_id="${AGENT_RUNTIME:-${RUNTIME_ID:-wp-codebox}}"
-          if [ -n "$AGENT_RUNTIME" ] && [ -n "$RUNTIME_ID" ] && [ "$AGENT_RUNTIME" != "$RUNTIME_ID" ]; then
-            echo "agent_runtime and runtime_id must match when both are set." >&2
-            exit 1
-          fi
+          effective_runtime_id="$AGENT_RUNTIME"
           if [ "$effective_runtime_id" != "wp-codebox" ]; then
-            echo "Unsupported agent_runtime/runtime_id: $effective_runtime_id. Only wp-codebox is currently supported." >&2
+            echo "Unsupported agent_runtime: $effective_runtime_id. Only wp-codebox is currently supported." >&2
             exit 1
           fi
-          effective_runtime_ref="${AGENT_RUNTIME_REF:-${RUNTIME_REF:-$WP_CODEBOX_REF}}"
+          effective_runtime_ref="$AGENT_RUNTIME_REF"
           execute_workflow_guest_path="$EXECUTE_WORKFLOW_PATH"
           execute_workflow_mounts_json="[]"
           if [ -n "$EXECUTE_WORKFLOW_PATH" ] && [[ "$EXECUTE_WORKFLOW_PATH" != /* ]]; then
@@ -911,9 +881,7 @@ jobs:
               )
             '
           }
-          extra_wp_codebox_mounts_json="$(jq -cs '.[0] + .[1]' \
-            <(normalize_mounts_input extra_wp_codebox_mounts "$EXTRA_WP_CODEBOX_MOUNTS") \
-            <(normalize_mounts_input runtime_mounts "$RUNTIME_MOUNTS"))"
+          runtime_mounts_json="$(normalize_mounts_input runtime_mounts "$RUNTIME_MOUNTS")"
           runtime_overlays_json="$(validate_json_input runtime_overlays array "$RUNTIME_OVERLAYS" | jq -c --arg workspace "$GITHUB_WORKSPACE" '
             map(
               if type == "object" and (.source? | type == "string") and (.source | startswith("/") | not) then
@@ -953,8 +921,8 @@ jobs:
           provider_register_function="$(jq -r '.register_function // ""' <<< "$provider_plugin_json")"
           provider_credentials_json="$(jq -c '.credentials // {}' <<< "$provider_plugin_json")"
           provider_bench_env_json="{}"
-          wp_codebox_bin="${GITHUB_WORKSPACE}/.ci/wp-codebox/packages/cli/dist/index.js"
-          [ -f "$wp_codebox_bin" ] || { echo "WP Codebox CLI build missing at $wp_codebox_bin" >&2; exit 1; }
+          runtime_bin="${GITHUB_WORKSPACE}/.ci/wp-codebox/packages/cli/dist/index.js"
+          [ -f "$runtime_bin" ] || { echo "Runtime CLI build missing at $runtime_bin" >&2; exit 1; }
           while IFS= read -r provider_env_name; do
             [ -n "$provider_env_name" ] || continue
             case "$provider_env_name" in
@@ -983,11 +951,11 @@ jobs:
             --arg prompt "$PROMPT" \
             --arg provider "$PROVIDER" \
             --arg model "$MODEL" \
-            --arg wpCodeboxBin "$wp_codebox_bin" \
+            --arg runtimeBin "$runtime_bin" \
             --arg providerPluginHostPath "$provider_plugin_host_path" \
             --arg engineKey "$ENGINE_KEY" \
             --arg toolResultsKey "$TOOL_RESULTS_KEY" \
-            --arg wpCodeboxWordPressVersion "$WP_CODEBOX_WORDPRESS_VERSION" \
+            --arg runtimeWordPressVersion "$RUNTIME_WORDPRESS_VERSION" \
             --arg homeboyExtensionsPath "${GITHUB_WORKSPACE}/.ci/homeboy-extensions" \
             --arg transcriptHostDir "$transcript_host_dir" \
             --arg transcriptGuestDir "$transcript_guest_dir" \
@@ -1013,7 +981,7 @@ jobs:
             --argjson artifactDeclarations "$artifact_declarations_json" \
             --argjson dryRun "$DRY_RUN" \
             --argjson extraWpConfigDefines "$extra_wp_config_defines_json" \
-            --argjson extraWpCodeboxMounts "$extra_wp_codebox_mounts_json" \
+            --argjson runtimeMounts "$runtime_mounts_json" \
             --argjson runtimeOverlays "$runtime_overlays_json" \
             --argjson executeWorkflowMounts "$execute_workflow_mounts_json" \
             --argjson runnerWorkspaceMounts "$runner_workspace_mounts_json" \
@@ -1042,15 +1010,15 @@ jobs:
               validation_dependencies: $validationDependencies,
               runtime_id: $runtimeId,
               runtime_ref: $runtimeRef,
-              wp_codebox_wordpress_version: $wpCodeboxWordPressVersion,
-              wp_codebox_mounts: ([
+              runtime_wordpress_version: $runtimeWordPressVersion,
+              runtime_mounts: ([
                 {
                   type: "file",
                   source: ($homeboyExtensionsPath + "/wordpress/tests/fixtures/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php"),
                   target: "/wordpress/wp-content/plugins/datamachine-agent-ci-driver/datamachine-agent-ci-driver.php",
                   mode: "readonly"
                 }
-              ] + $extraWpCodeboxMounts + $executeWorkflowMounts + $runnerWorkspaceMounts),
+              ] + $runtimeMounts + $executeWorkflowMounts + $runnerWorkspaceMounts),
               wp_config_defines: $extraWpConfigDefines,
               runtime_overlays: $runtimeOverlays,
               workload_run_before: $workloadRunBefore,
@@ -1067,9 +1035,9 @@ jobs:
               model: $model,
               provider_register_function: $providerRegisterFunction,
               provider_credentials: $providerCredentials,
-              wp_codebox_bin: $wpCodeboxBin,
-              wp_codebox_components: ({
-                wp_codebox: ($componentPath + "/.ci/wp-codebox/packages/wordpress-plugin"),
+              runtime_bin: $runtimeBin,
+              runtime_components: ({
+                runtime: ($componentPath + "/.ci/wp-codebox/packages/wordpress-plugin"),
                 agents_api: ($componentPath + "/.ci/agents-api"),
                 data_machine: ($componentPath + "/.ci/data-machine"),
                 data_machine_code: ($componentPath + "/.ci/data-machine-code")


### PR DESCRIPTION
## Summary
- replace WP Codebox-specific reusable workflow inputs with `agent_runtime`, `agent_runtime_ref`, `runtime_mounts`, `runtime_overlays`, and `runtime_wordpress_version`
- keep `wp-codebox` as the only supported runtime implementation today
- emit runtime-shaped runner config instead of `wp_codebox_*` config fields
- document the clean runtime input surface for consumers

Closes #1430.

## Stack
- Depends on Extra-Chill/homeboy#4826 for first-class runtime manifest discovery.
- Downstream migrations: Automattic/docs-agent#101 and chubes4/wp-site-generator#664.

## Tests
- YAML parse for `.github/workflows/datamachine-agent-ci.yml`
- `git diff --check -- .github/workflows/datamachine-agent-ci.yml .github/workflows/README.md`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added the clean runtime workflow input surface and documentation.