### PR TITLE
Fix Codex provider plugin path defaults

### DIFF
--- a/wordpress/lib/codebox-agent-task-executor.js
+++ b/wordpress/lib/codebox-agent-task-executor.js
@@ -744,12 +744,12 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
 }
 
 function defaultProviderPluginPaths(provider, settings, fallbackProviderPluginPath) {
+  if (provider === 'codex') {
+    return [];
+  }
   const explicit = normalizeArray(settings.wp_codebox_provider_plugin_paths || settings.provider_plugin_paths);
   if (explicit.length > 0) {
     return explicit;
-  }
-  if (provider === 'codex') {
-    return [];
   }
   return fallbackProviderPluginPath ? [fallbackProviderPluginPath] : [];
 }

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -175,4 +175,26 @@ const legacyTaskInput = codeboxTaskRequestFromAgentTaskRequest({
 
 assert.equal(legacyTaskInput.schema, 'wp-codebox/task-input/v1');
 
+const previousHomeboySettingsJson = process.env.HOMEBOY_SETTINGS_JSON;
+process.env.HOMEBOY_SETTINGS_JSON = JSON.stringify({
+  provider_plugin_paths: ['/missing/stale-openai-provider'],
+});
+let codexTaskInput;
+try {
+  codexTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+    schema: 'homeboy/agent-task-request/v1',
+    task_id: 'codex-codebox-task-1',
+    executor: { backend: 'wordpress', config: { provider: 'codex' } },
+    instructions: 'Run a Codex-backed Codebox task.',
+    inputs: {},
+  });
+} finally {
+  if (previousHomeboySettingsJson === undefined) {
+    delete process.env.HOMEBOY_SETTINGS_JSON;
+  } else {
+    process.env.HOMEBOY_SETTINGS_JSON = previousHomeboySettingsJson;
+  }
+}
+assert.deepEqual(codexTaskInput.provider_plugin_paths, []);
+
 console.log('Codebox agent-task executor boundary contract passed');


### PR DESCRIPTION
## Summary
- keep Codex-backed Codebox tasks from inheriting global/default provider plugin paths
- preserve explicit per-request provider_plugin_paths behavior
- add a boundary regression for stale global provider plugin path settings

Refs Extra-Chill/homeboy#4829

## Testing
- npm run test:codebox-agent-task-executor-boundary
- npx eslint lib/codebox-agent-task-executor.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the minimal provider-path defaulting fix and regression test; Chris identified the blocker and reviewed the intended boundary.