### PR TITLE
Fix WP Codebox repo-loop workspace mapping

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -212,6 +212,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const config = request.executor.config || {};
   const inputs = request.inputs || {};
   const defaults = defaultCodeboxRuntimeConfig(request, config, inputs, options);
+  const workspaceMaterialization = defaultWorkspaceMaterialization(defaults.workspaceRoot, request, config, inputs, options);
+  const target = defaultWorkspaceTargetPayload(inputs.target || request.workspace || {}, workspaceMaterialization);
   const agentBundle = agentBundleConfigFromAgentTaskRequest(request, config, inputs);
   const recipe = recipeConfigFromAgentTaskRequest(request, config, inputs);
   const mounts = agentBundleMounts(agentBundle, config.runtime_mounts || config.mounts || defaults.mounts || options.mounts || []);
@@ -250,7 +252,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   return {
     schema: WP_CODEBOX_TASK_REQUEST_SCHEMA,
     goal: request.instructions,
-    target: inputs.target || request.workspace || {},
+    target,
+    workspace_materialization: workspaceMaterialization,
     allowed_tools: allowedTools || [],
     expected_artifacts: request.expected_artifacts || [],
     artifact_declarations: artifactDeclarations,
@@ -740,6 +743,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     runtimeEnv: defaultRuntimeEnv(settings),
     runtimeStateMounts: defaultRuntimeStateMounts(settings),
     runtimeConfigMounts: defaultRuntimeConfigMounts(settings),
+    workspaceRoot,
     mounts: defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options),
     workspaces: defaultWorkspaces(config, inputs, options),
     allowedTools: defaultWorkspaceAllowedTools(workspaceRoot, workspaceMode(request, config, inputs)),
@@ -959,18 +963,98 @@ function defaultWorkspaceSandboxToolPolicy(workspaceRoot, workspaceModeValue) {
 }
 
 function resolveWorkspaceRoot(request, config, inputs, settings, options) {
+  const workspaceContext = genericWorkspaceContext(request, config, inputs, options);
   const candidates = [
     options.workspaceRoot,
+    workspaceContext.cwd,
     inputs.target?.root,
     inputs.target?.path,
     request.workspace?.root,
     request.workspace?.path,
     config.workspace_root,
     config.workspaceRoot,
+    config.cwd,
     settings.wp_codebox_workspace_root,
     process.env.HOMEBOY_COMPONENT_PATH,
   ];
   return firstExistingPath(...candidates) || '';
+}
+
+function defaultWorkspaceMaterialization(workspaceRoot, request, config, inputs, options) {
+  const context = genericWorkspaceContext(request, config, inputs, options);
+  const repo = firstValue(
+    context.repo,
+    request.workspace?.materialization?.repo,
+    request.workspace?.repo,
+    request.workspace?.slug,
+    config.repo,
+    config.repository,
+  );
+  const cwd = firstValue(context.cwd, workspaceRoot);
+  return Object.fromEntries(Object.entries({
+    ...request.workspace?.materialization,
+    repo,
+    cwd,
+    root: workspaceRoot || undefined,
+  }).filter(([, value]) => value !== undefined && value !== ''));
+}
+
+function defaultWorkspaceTargetPayload(target, workspaceMaterialization) {
+  if (!workspaceMaterialization || Object.keys(workspaceMaterialization).length === 0) {
+    return target;
+  }
+  return {
+    ...target,
+    materialization: {
+      ...(target.materialization || {}),
+      ...workspaceMaterialization,
+    },
+  };
+}
+
+function genericWorkspaceContext(request, config, inputs, options) {
+  const clientContext = firstObject(
+    inputs.client_context,
+    inputs.clientContext,
+    request.client_context,
+    request.clientContext,
+    config.client_context,
+    config.clientContext,
+    options.clientContext,
+  ) || {};
+  const context = firstObject(inputs.context, request.context, config.context, options.context) || {};
+  const workspace = firstObject(request.workspace, inputs.workspace, config.workspace, options.workspace) || {};
+  const clientInputs = firstObject(clientContext.inputs) || {};
+
+  return {
+    cwd: firstValue(
+      options.cwd,
+      inputs.cwd,
+      inputs.workspace_cwd,
+      inputs.workspaceCwd,
+      request.cwd,
+      request.working_directory,
+      request.workingDirectory,
+      context.cwd,
+      clientContext.cwd,
+      clientInputs.cwd,
+      workspace.cwd,
+      config.cwd,
+    ),
+    repo: firstValue(
+      options.repo,
+      inputs.repo,
+      inputs.repository,
+      request.repo,
+      request.repository,
+      context.repo,
+      clientContext.repo,
+      clientInputs.repo,
+      workspace.repo,
+      config.repo,
+      config.repository,
+    ),
+  };
 }
 
 function workspaceMode(request, config, inputs) {

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -139,6 +139,42 @@ assert.deepEqual(genericRepoLoopTaskInput.runtime_task.input, {
   dry_run: false,
 });
 
+const repoLoopWorkspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wordpress-repo-loop-workspace-'));
+const repoLoopWorkspaceTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'repo-loop-workspace-task-1',
+  cwd: repoLoopWorkspaceRoot,
+  repo: 'wp-site-generator@canonical-loop-main-20260616',
+  executor: {
+    backend: 'wordpress',
+    config: {
+      provider: 'openai',
+      task_kind: 'repo-cooking',
+    },
+  },
+  instructions: 'Run a repo-loop workflow against the current checkout.',
+  inputs: {
+    ability_request: { name: 'datamachine/run-agent-bundle' },
+  },
+});
+
+const repoLoopWorkspaceMount = repoLoopWorkspaceTaskInput.mounts.find(
+  (mount) => mount.metadata?.kind === 'homeboy-dmc-workspace'
+);
+assert(repoLoopWorkspaceMount, 'repo-loop cwd is translated into a Codebox workspace mount');
+assert.equal(repoLoopWorkspaceMount.source, repoLoopWorkspaceRoot);
+assert.equal(repoLoopWorkspaceMount.target, `/workspace/${path.basename(repoLoopWorkspaceRoot)}`);
+assert.equal(repoLoopWorkspaceMount.mode, 'readwrite');
+assert.deepEqual(repoLoopWorkspaceTaskInput.workspace_materialization, {
+  repo: 'wp-site-generator@canonical-loop-main-20260616',
+  cwd: repoLoopWorkspaceRoot,
+  root: repoLoopWorkspaceRoot,
+});
+assert.deepEqual(
+  repoLoopWorkspaceTaskInput.target.materialization,
+  repoLoopWorkspaceTaskInput.workspace_materialization
+);
+
 const repoLoopTypedOutputsTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'repo-loop-typed-outputs-task-1',


### PR DESCRIPTION
## Summary
- Map generic Homeboy repo/cwd context into WP Codebox workspace materialization.
- Use generic cwd context as the default Codebox workspace root so repo-cooking tasks receive a mounted checkout.
- Add boundary coverage for repo-loop cwd/repo context becoming Codebox mount/materialization data.

Fixes #1441.

## Tests
- npm run test:codebox-agent-task-executor-boundary
- npm run test:codebox-agent-task-boundary
- npm run test:codebox-agent-task-executor

## Notes
- Full npm run lint:js still fails on existing unrelated lint errors in playground-readiness, timing-correlator, and agent scripts.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the adapter mapping, regression coverage, and test/PR workflow; Chris remains responsible for review and merge.