### PR TITLE
Fix Codex provider plugin path config

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -754,16 +754,25 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
 function defaultProviderPluginPaths(provider, settings, fallbackProviderPluginPath) {
   const explicitCodebox = normalizeArray(settings.wp_codebox_provider_plugin_paths);
   if (explicitCodebox.length > 0) {
-    return explicitCodebox;
-  }
-  if (provider === 'codex') {
-    return [];
+    return provider === 'codex'
+      ? explicitCodebox.filter(codexProviderPluginPathLooksUsable)
+      : explicitCodebox;
   }
   const explicit = normalizeArray(settings.provider_plugin_paths);
+  if (provider === 'codex') {
+    return explicit.filter(codexProviderPluginPathLooksUsable);
+  }
   if (explicit.length > 0) {
     return explicit;
   }
   return fallbackProviderPluginPath ? [fallbackProviderPluginPath] : [];
+}
+
+function codexProviderPluginPathLooksUsable(providerPath) {
+  if (!providerPath || !fs.existsSync(providerPath)) {
+    return false;
+  }
+  return fs.existsSync(path.join(providerPath, 'src', 'Codex', 'CodexProvider.php'));
 }
 
 function defaultRuntimeOverlayProfiles(settings) {

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -232,4 +232,32 @@ try {
 }
 assert.deepEqual(codexTaskInput.provider_plugin_paths, []);
 
+const codexProviderRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codex-provider-'));
+const codexProviderPath = path.join(codexProviderRoot, 'ai-provider-for-openai');
+fs.mkdirSync(path.join(codexProviderPath, 'src', 'Codex'), { recursive: true });
+fs.writeFileSync(
+  path.join(codexProviderPath, 'src', 'Codex', 'CodexProvider.php'),
+  '<?php\n// Registers the codex provider.\n'
+);
+process.env.HOMEBOY_SETTINGS_JSON = JSON.stringify({
+  provider_plugin_paths: [codexProviderPath],
+});
+let configuredCodexTaskInput;
+try {
+  configuredCodexTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+    schema: 'homeboy/agent-task-request/v1',
+    task_id: 'configured-codex-codebox-task-1',
+    executor: { backend: 'wordpress', config: { provider: 'codex' } },
+    instructions: 'Run a Codex-backed Codebox task with the configured provider checkout.',
+    inputs: {},
+  });
+} finally {
+  if (previousHomeboySettingsJson === undefined) {
+    delete process.env.HOMEBOY_SETTINGS_JSON;
+  } else {
+    process.env.HOMEBOY_SETTINGS_JSON = previousHomeboySettingsJson;
+  }
+}
+assert.deepEqual(configuredCodexTaskInput.provider_plugin_paths, [codexProviderPath]);
+
 console.log('Codebox agent-task executor boundary contract passed');

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -970,7 +970,9 @@ try {
   });
   assert.equal(alternateDefaultedRequest.runtime_component_paths.agents_api, alternateBundledAgentsApiPath);
 
-  const configuredProviderPath = path.join(defaultsRoot, 'configured-provider');
+  const configuredProviderPath = path.join(defaultsRoot, 'ai-provider-for-openai');
+  fs.mkdirSync(path.join(configuredProviderPath, 'src', 'Codex'), { recursive: true });
+  fs.writeFileSync(path.join(configuredProviderPath, 'src', 'Codex', 'CodexProvider.php'), '<?php\n// Registers the codex provider.\n');
   const configuredLibraryPath = path.join(defaultsRoot, 'configured-library');
   const configuredRuntimeOverlays = [{
     kind: 'bundled-library',


### PR DESCRIPTION
## Summary
- honor configured provider_plugin_paths for Codex when they point at the Codex-capable ai-provider-for-openai PR branch shape
- keep stale/missing provider plugin paths filtered for Codex so the previous missing-path blocker stays fixed
- add boundary/smoke coverage for configured Codex provider plugin paths

Refs Extra-Chill/homeboy#4834

## Testing
- HOMEBOY_RELEASE_GATE_LOCAL_HOT=allowed HOMEBOY_NODE_TEST_COMMAND="npm run test:codebox-agent-task-executor-boundary" homeboy --force-hot --allow-local-hot test --extension nodejs --path /Users/chubes/Developer/homeboy-extensions@fix-4834-codex-provider-plugin-materialization/wordpress --skip-lint
- npm run test:codebox-agent-task-executor
- npx eslint lib/codebox-agent-task-executor.js

Note: the full executor script fails under Homeboy's injected package workspace env due an existing mount assertion unrelated to this change; the direct package script passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused fix and regression coverage after Chris pointed back to the existing AI provider PR branch and WP Codebox Codex example.