### PR TITLE
Expose Codebox provider secret defaults

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -71,6 +71,18 @@ const CLAUDE_CODE_SECRET_ENV = [
   'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN',
 ];
 
+const PROVIDER_DEFAULTS = {
+  openai: {
+    secret_env: ['OPENAI_API_KEY'],
+  },
+  codex: {
+    secret_env: CODEX_SECRET_ENV,
+  },
+  'claude-code': {
+    secret_env: CLAUDE_CODE_SECRET_ENV,
+  },
+};
+
 const DEFAULT_CODEX_MODEL = 'gpt-5.5';
 const CODEX_PROVIDER_PLUGIN_GUIDANCE = `Codex tasks require a Codex-capable provider plugin checkout, such as the Codex PR branch for ai-provider-for-openai. Released ai-provider-for-openai trunk registers openai, not codex, and unrelated provider defaults such as ${['ai-provider-for', ['open', 'code'].join('')].join('-')} will not work.`;
 const CODEX_PHP_AI_CLIENT_GUIDANCE = 'Codex tasks require a php-ai-client checkout that supports RequestAuthenticationMethod::bearerToken and has Composer vendor dependencies installed before WP Codebox prepares the runtime overlay.';
@@ -200,11 +212,19 @@ function providerContract(options = {}) {
     workspace_materialization: {
       cwd: 'git_checkout',
     },
+    provider_defaults: providerDefaultsContract(),
     role_aliases: WP_CODEBOX_ROLE_ALIASES,
     status: 'active',
     integration_contract: 'homeboy-wordpress-agent-task/v1',
     runtime_gap_trackers: WP_CODEBOX_RUNTIME_GAP_TRACKERS,
   };
+}
+
+function providerDefaultsContract() {
+  return Object.fromEntries(Object.entries(PROVIDER_DEFAULTS).map(([provider, defaults]) => [provider, {
+    ...defaults,
+    secret_env: normalizeArray(defaults.secret_env),
+  }]));
 }
 
 function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
@@ -867,7 +887,7 @@ function defaultSecretEnv(provider, settings) {
   if (provider === 'claude-code') {
     return CLAUDE_CODE_SECRET_ENV;
   }
-  return provider === 'openai' ? ['OPENAI_API_KEY'] : [];
+  return normalizeArray(PROVIDER_DEFAULTS[provider]?.secret_env);
 }
 
 function defaultProvider(settings, providerPluginPath) {

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -63,6 +63,23 @@
       "workspace_materialization": {
         "cwd": "git_checkout"
       },
+      "provider_defaults": {
+        "openai": {
+          "secret_env": ["OPENAI_API_KEY"]
+        },
+        "codex": {
+          "secret_env": [
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT",
+            "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID",
+            "AI_PROVIDER_OPENAI_CODEX_FEDRAMP"
+          ]
+        },
+        "claude-code": {
+          "secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"]
+        }
+      },
       "role_aliases": {
         "artifact_kinds": {
           "patch": ["codebox-patch"]

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -28,6 +28,17 @@ assert.deepEqual(runtime.agent_task_executors[0], providerContract({
 }));
 assert.equal(provider.capabilities.includes('tool:wpsg_materialize_packet'), false);
 assert.equal(provider.capabilities.includes('ability:wpsg_materialize_packet'), false);
+assert.deepEqual(provider.provider_defaults.openai.secret_env, ['OPENAI_API_KEY']);
+assert.deepEqual(provider.provider_defaults.codex.secret_env, [
+  'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+  'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+  'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+]);
+assert.deepEqual(provider.provider_defaults['claude-code'].secret_env, [
+  'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN',
+]);
 
 const taskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
@@ -231,5 +242,21 @@ try {
   }
 }
 assert.deepEqual(codexTaskInput.provider_plugin_paths, []);
+assert.deepEqual(codexTaskInput.secret_env, provider.provider_defaults.codex.secret_env);
+
+const claudeCodeTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'claude-code-codebox-task-1',
+  executor: {
+    backend: 'wordpress',
+    config: {
+      provider: 'claude-code',
+      model: 'opus-4.7',
+    },
+  },
+  instructions: 'Run a Claude Code backed Codebox task.',
+  inputs: {},
+});
+assert.deepEqual(claudeCodeTaskInput.secret_env, provider.provider_defaults['claude-code'].secret_env);
 
 console.log('Codebox agent-task executor boundary contract passed');

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -267,6 +267,23 @@ assert.deepEqual(provider.outcome_statuses, ['succeeded', 'failed', 'no_op', 'un
 assert.deepEqual(provider.failure_classifications, ['provider', 'timeout', 'execution_failed']);
 assert.deepEqual(provider.redacted_metadata_keys, ['secret_env_values', 'secretEnvValues', 'secrets']);
 assert.deepEqual(provider.workspace_materialization, { cwd: 'git_checkout' });
+assert.deepEqual(provider.provider_defaults, {
+  openai: {
+    secret_env: ['OPENAI_API_KEY'],
+  },
+  codex: {
+    secret_env: [
+      'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+      'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+      'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+      'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+      'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+    ],
+  },
+  'claude-code': {
+    secret_env: ['AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN'],
+  },
+});
 assert.deepEqual(provider.role_aliases, {
   artifact_kinds: {
     patch: ['codebox-patch'],
@@ -354,6 +371,32 @@ assert.deepEqual(codeboxRequest.runtime_env, {});
 assert.deepEqual(codeboxRequest.runtime_state_mounts, []);
 assert.deepEqual(codeboxRequest.runtime_config_mounts, []);
 assert.deepEqual(codeboxRequest.secret_env, ['OPENAI_API_KEY']);
+
+const providerDefaultSecretRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'provider-default-secret-task-123',
+  executor: {
+    backend: 'wordpress',
+    config: {
+      provider: 'claude-code',
+      model: 'opus-4.7',
+    },
+  },
+});
+assert.deepEqual(providerDefaultSecretRequest.secret_env, provider.provider_defaults['claude-code'].secret_env);
+
+const codexDefaultSecretRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'codex-default-secret-task-123',
+  executor: {
+    backend: 'wordpress',
+    config: {
+      provider: 'codex',
+      model: 'gpt-5.5',
+    },
+  },
+});
+assert.deepEqual(codexDefaultSecretRequest.secret_env, provider.provider_defaults.codex.secret_env);
 assert.equal(codeboxRequest.max_turns, 8);
 assert.equal(codeboxRequest.task_timeout_seconds, 120);
 assert.equal(codeboxRequest.expected_artifacts[0], 'screenshot');

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -83,6 +83,23 @@
       "workspace_materialization": {
         "cwd": "git_checkout"
       },
+      "provider_defaults": {
+        "openai": {
+          "secret_env": ["OPENAI_API_KEY"]
+        },
+        "codex": {
+          "secret_env": [
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT",
+            "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID",
+            "AI_PROVIDER_OPENAI_CODEX_FEDRAMP"
+          ]
+        },
+        "claude-code": {
+          "secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"]
+        }
+      },
       "role_aliases": {
         "artifact_kinds": {
           "patch": ["codebox-patch"]


### PR DESCRIPTION
## Summary
- Declare WP Codebox provider default secret_env requirements in the executor provider contract.
- Keep Codebox task request secret_env normalization aligned with the provider contract defaults.
- Update runtime manifests and tests so Homeboy can inspect provider defaults before Codebox execution.

Fixes #1444.

## Verification
- npm run test:codebox-agent-task-executor-boundary
- npm run test:codebox-agent-task-executor
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, focused tests, and PR description; Chris remains responsible for review and final validation.