### PR TITLE
Preserve embedded runtime failures in Codebox tasks

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -1245,6 +1245,9 @@ function normalizeStatus(result) {
 
 function agentRuntimeResultCandidates(result) {
   return [
+    result?.outputs?.agent_runtime?.result,
+    result?.outputs?.agent_runtime?.workload,
+    result?.outputs?.agent_runtime,
     result?.raw?.agent_runtime,
     result?.raw?.agent_runtime?.result,
     result?.raw?.agent_runtime?.workload,
@@ -1259,6 +1262,8 @@ function agentRuntimeResultCandidates(result) {
 
 function agentRuntimeWorkload(result) {
   return firstObject(
+    result?.outputs?.agent_runtime?.result,
+    result?.outputs?.agent_runtime?.workload,
     result?.raw?.agent_runtime?.result,
     result?.raw?.agent_runtime?.workload,
     result?.metadata?.agent_runtime?.result,

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1477,6 +1477,40 @@ assert.equal(metadataAgentRuntimeTerminalFailureOutcome.status, 'failed');
 assert.equal(metadataAgentRuntimeTerminalFailureOutcome.diagnostics[0].class, 'agent_runtime.failed');
 assert.equal(metadataAgentRuntimeTerminalFailureOutcome.diagnostics[0].data.reason, 'provider_auth_failed');
 
+const outputAgentRuntimeFailureWithoutTypedArtifactsOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  summary: 'WP Codebox agent task succeeded.',
+  outputs: {
+    agent_runtime: {
+      success: false,
+      result: {
+        success: false,
+        error_reason: 'ai_processing_failed',
+        error_message: 'Embedded runtime failed before emitting typed artifacts.',
+        terminal_status: 'failed - ai_processing_failed',
+        outputs: {},
+      },
+    },
+  },
+}, {
+  normalizeAgentTaskRunResult: () => ({
+    schema: 'wp-codebox/agent-task-run-result/v1',
+    status: 'succeeded',
+    artifacts: [],
+    diagnostics: [],
+    metadata: {},
+    refs: {},
+  }),
+});
+assert.equal(outputAgentRuntimeFailureWithoutTypedArtifactsOutcome.status, 'failed');
+assert.equal(outputAgentRuntimeFailureWithoutTypedArtifactsOutcome.summary, 'Embedded runtime failed before emitting typed artifacts.');
+assert.equal(outputAgentRuntimeFailureWithoutTypedArtifactsOutcome.failure_classification, 'execution_failed');
+assert.equal(outputAgentRuntimeFailureWithoutTypedArtifactsOutcome.diagnostics[0].class, 'agent_runtime.failed');
+assert.equal(outputAgentRuntimeFailureWithoutTypedArtifactsOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.required_typed_artifacts_missing'), false);
+assert.deepEqual(outputAgentRuntimeFailureWithoutTypedArtifactsOutcome.metadata.typed_artifacts, {});
+
 const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
   task_id: 'agent-bundle-task-123',


### PR DESCRIPTION
## Summary
- Treat embedded runtime results exposed via Codebox outputs as runtime adapter failure sources.
- Prefer detailed embedded runtime result/workload data over wrapper envelopes when building failure diagnostics.
- Add a focused regression proving an embedded runtime failure cannot normalize to success just because no typed artifacts were produced.

Fixes #1445.

## Verification
- `npm run test:codebox-agent-task-executor`
- `npm run test:codebox-agent-task-executor-boundary`
- `npm run test:codebox-agent-task-boundary`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runtime-adapter failure normalization fix, added the focused regression test, and ran targeted verification. Chris remains responsible for review and merge.