### PR TITLE
Avoid default WP Codebox sandbox agent

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -226,6 +226,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const sandboxToolPolicy = sandboxToolPolicyFromAgentTaskRequest(config, inputs, options, defaults, allowedTools);
   const provider = config.provider || options.provider || defaults.provider || '';
   const model = request.executor.model || config.model || options.model || defaults.model || '';
+  const agent = firstValue(config.agent, options.agent, '');
   const runtimeTask = runtimeTaskWithExecutionDefaults(
     inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(request, config, inputs) || options.runtimeTask,
     { provider, model, agentBundles }
@@ -266,7 +267,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     structured_artifacts: structuredArtifacts,
     sandbox_session_id: config.sandbox_session_id || request.task_id,
     session_id: config.session_id || config.sessionId || '',
-    agent: config.agent || options.agent || 'wp-codebox-sandbox',
+    ...(agent ? { agent } : {}),
     mode: config.mode || options.mode || 'sandbox',
     provider,
     model,

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -606,7 +606,7 @@ function runnerInput(request, artifacts) {
   };
   return Object.fromEntries(Object.entries({
     parent_request: request,
-    agent: argValue('--agent') || request.agent || 'wp-codebox-sandbox',
+    agent: argValue('--agent') || request.agent || '',
     mode: argValue('--mode') || request.mode || 'sandbox',
     provider: argValue('--provider') || request.provider || '',
     model: argValue('--model') || request.model || '',
@@ -720,6 +720,7 @@ function stableTaskInput(input) {
     policy: input.parent_request?.policy || input.parent_request?.task?.policy || {},
     context: input.parent_request?.context || input.parent_request?.task?.context || {},
     recipe: input.recipe || input.parent_request?.recipe || {},
+    agent: input.agent,
     provider: input.provider,
     model: input.model,
     provider_plugin_paths: input.provider_plugin_paths || [],

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -55,6 +55,7 @@ const taskInput = codeboxTaskRequestFromAgentTaskRequest({
 
 assert.equal(taskInput.schema, 'wp-codebox/task-input/v1');
 assert.equal(taskInput.parent_request.executor.backend, 'wordpress');
+assert.equal(Object.hasOwn(taskInput, 'agent'), false);
 assert.deepEqual(taskInput.runtime_task, {
   ability: 'wordpress/site-health',
   input: { include_debug: false },
@@ -209,6 +210,19 @@ const legacyTaskInput = codeboxTaskRequestFromAgentTaskRequest({
 });
 
 assert.equal(legacyTaskInput.schema, 'wp-codebox/task-input/v1');
+
+const explicitAgentTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'explicit-agent-codebox-task-1',
+  executor: {
+    backend: 'codebox',
+    config: { provider: 'openai', agent: 'custom-sandbox-agent' },
+  },
+  instructions: 'Run with an explicitly selected sandbox agent.',
+  inputs: {},
+});
+
+assert.equal(explicitAgentTaskInput.agent, 'custom-sandbox-agent');
 
 const previousHomeboySettingsJson = process.env.HOMEBOY_SETTINGS_JSON;
 process.env.HOMEBOY_SETTINGS_JSON = JSON.stringify({

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -689,7 +689,7 @@ const codexAgentRequest = {
   },
 };
 const codexRequest = codeboxTaskRequestFromAgentTaskRequest(codexAgentRequest);
-assert.equal(codexRequest.agent, 'wp-codebox-sandbox');
+assert.equal(Object.hasOwn(codexRequest, 'agent'), false);
 assert.equal(codexRequest.mode, 'sandbox');
 assert.equal(codexRequest.provider, 'codex');
 assert.equal(codexRequest.model, 'gpt-5.5');
@@ -2205,6 +2205,8 @@ try {
   const capturedAgentBundleRun = JSON.parse(fs.readFileSync(fakeWpCodeboxCapture, 'utf8'));
   assert.equal(capturedAgentBundleRun.argv[0], 'agent-task-run');
   assert.equal(capturedAgentBundleRun.input.schema, 'wp-codebox/task-input/v1');
+  assert.equal(Object.hasOwn(capturedAgentBundleRun.input, 'agent'), false);
+  assert.equal(Object.hasOwn(capturedAgentBundleRun.input.parent_request, 'agent'), false);
   assert.deepEqual(capturedAgentBundleRun.input.runtime_env, fullRunnerRuntimeEnv);
   assert.deepEqual(capturedAgentBundleRun.input.runtime_state_mounts, fullRunnerRuntimeStateMounts);
   assert.deepEqual(capturedAgentBundleRun.input.runtime_config_mounts, fullRunnerRuntimeConfigMounts);
@@ -2239,6 +2241,7 @@ try {
   assert.equal(recipeWpCodeboxResult.status, 0, recipeWpCodeboxResult.stderr || recipeWpCodeboxResult.stdout);
   const capturedRecipeWpCodeboxRun = JSON.parse(fs.readFileSync(recipeFakeWpCodeboxCapture, 'utf8'));
   assert.equal(capturedRecipeWpCodeboxRun.argv[0], 'agent-task-run');
+  assert.equal(Object.hasOwn(capturedRecipeWpCodeboxRun.input, 'agent'), false);
   assert.equal(capturedRecipeWpCodeboxRun.input.recipe.pack, 'example-codebox-recipes');
   assert.equal(capturedRecipeWpCodeboxRun.input.recipe.name, 'minimal-runtime');
   assert.equal(capturedRecipeWpCodeboxRun.input.recipe.target_ref, 'Extra-Chill/example#42');

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -268,6 +268,7 @@ try {
   assert.equal(captured.input.schema, 'wp-codebox/task-input/v1');
   assert.equal(captured.input.version, 1);
   assert.equal(captured.input.goal, 'Fix the finding.');
+  assert.equal(Object.hasOwn(captured.input, 'agent'), false);
   assert.equal(captured.input.sandbox_tool_policy.schema, 'wp-codebox/sandbox-tool-policy/v1');
   assert.equal(captured.input.sandbox_tool_policy.version, 1);
   assert.equal(captured.input.sandbox_tool_policy.tools[0].id, 'homeboy/no-runtime-tools');
@@ -330,6 +331,21 @@ try {
   assert.equal(nestedOnlyInput.component_contracts.find((contract) => contract.slug === 'nested-only-domain-component').path, '/workspace/nested-only-domain-component');
   assert.equal(nestedOnlyInput.component_contracts.find((contract) => contract.slug === 'nested-only-domain-component').activate, true);
   assert.equal(nestedOnlyInput.component_contracts.filter((contract) => contract.slug === 'nested-only-domain-component').length, 1);
+
+  const explicitAgentCapturePath = path.join(root, 'capture-explicit-agent.json');
+  const explicitAgentResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      agent: 'custom-sandbox-agent',
+    }),
+    env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: explicitAgentCapturePath, OPENCODE_API_KEY: 'redacted-test-key' },
+  });
+  assert.equal(explicitAgentResult.status, 0, explicitAgentResult.stderr || explicitAgentResult.stdout);
+  assert.equal(readJson(explicitAgentCapturePath).input.agent, 'custom-sandbox-agent');
 
   // Verification gate flows through to the agent-task-run input so WP Codebox
   // can emit it as a recipe workflow.after step and fail the run if it is red.


### PR DESCRIPTION
## Summary
- Stop injecting the Homeboy-specific `wp-codebox-sandbox` agent into generic WP Codebox agent-task requests.
- Preserve explicit agent selection from executor config or runner CLI/request input.
- Add focused coverage for default omission and explicit passthrough in the runtime request builder and task runner.

Fixes #1101

## Verification
- `npm run test:codebox-agent-task-executor-boundary`
- `npm run test:codebox-agent-task-executor`
- `npm run test:wp-codebox-task-runner`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runtime adapter/test changes and ran targeted verification; Chris remains responsible for review and merge.