### PR TITLE
Surface provider secret env requirements

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -71,6 +71,12 @@ const CLAUDE_CODE_SECRET_ENV = [
   'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN',
 ];
 
+const PROVIDER_SECRET_ENV_REQUIREMENTS = [
+  providerSecretEnvRequirement('openai', ['OPENAI_API_KEY']),
+  providerSecretEnvRequirement('codex', CODEX_SECRET_ENV),
+  providerSecretEnvRequirement('claude-code', CLAUDE_CODE_SECRET_ENV),
+];
+
 const DEFAULT_CODEX_MODEL = 'gpt-5.5';
 const CODEX_PROVIDER_PLUGIN_GUIDANCE = `Codex tasks require a Codex-capable provider plugin checkout, such as the Codex PR branch for ai-provider-for-openai. Released ai-provider-for-openai trunk registers openai, not codex, and unrelated provider defaults such as ${['ai-provider-for', ['open', 'code'].join('')].join('-')} will not work.`;
 const CODEX_PHP_AI_CLIENT_GUIDANCE = 'Codex tasks require a php-ai-client checkout that supports RequestAuthenticationMethod::bearerToken and has Composer vendor dependencies installed before WP Codebox prepares the runtime overlay.';
@@ -196,6 +202,7 @@ function providerContract(options = {}) {
     outcome_statuses: AGENT_TASK_OUTCOME_STATUSES,
     failure_classifications: AGENT_TASK_FAILURE_CLASSIFICATIONS,
     redacted_metadata_keys: AGENT_TASK_REDACTED_METADATA_KEYS,
+    secret_env_requirements: PROVIDER_SECRET_ENV_REQUIREMENTS,
     capabilities: PROVIDER_CAPABILITIES,
     workspace_materialization: {
       cwd: 'git_checkout',
@@ -204,6 +211,21 @@ function providerContract(options = {}) {
     status: 'active',
     integration_contract: 'homeboy-wordpress-agent-task/v1',
     runtime_gap_trackers: WP_CODEBOX_RUNTIME_GAP_TRACKERS,
+  };
+}
+
+function providerSecretEnvRequirement(provider, env) {
+  return {
+    schema: 'homeboy/secret-env-requirement/v1',
+    source: 'provider_default',
+    env,
+    when: {
+      any: [
+        { path: 'executor.config.provider', equals: provider },
+        { path: 'executor.provider', equals: provider },
+        { path: 'provider', equals: provider },
+      ],
+    },
   };
 }
 

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -583,6 +583,12 @@ failure classifications, capability list, and metadata redaction keys so Lab
 offload and runner transport consumers can select providers without importing
 Codebox-specific request or recipe details.
 
+Discovery also exposes `secret_env_requirements`: generic env-name requirements
+activated by request/config selectors. Codex-backed requests declare the required
+`AI_PROVIDER_OPENAI_CODEX_*` names there, which lets Homeboy preflight runner
+readiness before dispatch while keeping provider and runtime semantics in the
+extension and WP Codebox.
+
 Provider stacks stay generic at the Homeboy boundary. Executor config, options,
 or `HOMEBOY_SETTINGS_JSON` may provide `runtime_env`, `runtime_state_mounts`,
 and `runtime_config_mounts` (or the settings names `wp_codebox_runtime_env`,

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -184,6 +184,14 @@ Provider discovery uses `homeboy/agent-task-executor-provider/v1`:
   "outcome_statuses": ["succeeded", "failed", "no_op", "unable_to_remediate", "timeout", "provider_error"],
   "failure_classifications": ["provider", "timeout", "execution_failed"],
   "redacted_metadata_keys": ["secret_env_values", "secretEnvValues", "secrets"],
+  "secret_env_requirements": [
+    {
+      "schema": "homeboy/secret-env-requirement/v1",
+      "source": "provider_default",
+      "env": ["AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN", "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN"],
+      "when": { "any": [{ "path": "executor.config.provider", "equals": "codex" }] }
+    }
+  ],
   "capabilities": ["browser_runtime", "wordpress_sandbox", "workspace_mounts", "workspace_tools", "artifact_materialization", "patch_artifacts", "verification_artifacts", "run_registry", "cleanup_observability", "screenshots", "structured_outcome", "agent_bundle_execution"],
   "status": "active",
   "integration_contract": "wp-codebox-cli/agent-task-run",
@@ -207,6 +215,10 @@ Discovery fields mean:
   corresponding outcome evidence.
 - `outcome_statuses`, `failure_classifications`, and `redacted_metadata_keys`
   document the stable vocabulary consumers can use without knowing the backend.
+- `secret_env_requirements` declares provider-derived env names that must be
+  available before dispatch. Each requirement uses generic `when` selectors over
+  request/config paths, so Homeboy can preflight the selected runner without
+  learning provider, WordPress, or Codebox semantics.
 - `status` marks maturity. `active` means the provider uses the stable backend
   contract advertised by `integration_contract`.
 - `runtime_gap_trackers` lists active upstream runtime blockers. Closed blockers
@@ -268,6 +280,13 @@ Backends may include secret env names for traceability, but values and secret
 bags must be redacted recursively. The current public redaction keys are
 `secret_env_values`, `secretEnvValues`, and `secrets`; adapters should extend the
 provider discovery list if they add another secret-bearing metadata key.
+
+`secret_env_requirements` carries only environment variable names and generic
+selectors. It must not include secret values. For example, a Codex-backed task
+advertises the required `AI_PROVIDER_OPENAI_CODEX_*` names when the request
+selects `executor.config.provider: "codex"`; Homeboy core can consume those names
+for runner readiness while the WordPress extension and WP Codebox still own the
+provider/runtime details.
 
 Artifacts and evidence refs are Homeboy-owned shapes even when their content is
 backend-specific. Artifacts should include `kind`, and where available `id`,

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -11,12 +11,26 @@ const {
 } = require('../../agent-runtimes/wp-codebox');
 
 const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wordpress-agent-boundary-'));
+const codexSecretEnv = [
+  'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+  'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+  'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+];
+
+function secretEnvRequirementForProvider(contract, provider) {
+  return contract.secret_env_requirements.find((requirement) => (
+    requirement.when.any.some((selector) => selector.path === 'executor.config.provider' && selector.equals === provider)
+  ));
+}
 
 const provider = providerContract();
 assert.equal(provider.id, 'wordpress.codebox-agent-task-executor');
 assert.equal(provider.label, 'WP Codebox agent task executor');
 assert.equal(provider.backend, 'codebox');
 assert.equal(provider.integration_contract, 'homeboy-wordpress-agent-task/v1');
+assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, codexSecretEnv);
 
 const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'wordpress.json'), 'utf8'));
 assert.equal(manifest.agent_task_executors, undefined);
@@ -26,6 +40,7 @@ assert.equal(runtime.agent_task_executors.length, 1);
 assert.deepEqual(runtime.agent_task_executors[0], providerContract({
   command: 'node {{extension_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs',
 }));
+assert.deepEqual(secretEnvRequirementForProvider(runtime.agent_task_executors[0], 'codex').env, codexSecretEnv);
 assert.equal(provider.capabilities.includes('tool:wpsg_materialize_packet'), false);
 assert.equal(provider.capabilities.includes('ability:wpsg_materialize_packet'), false);
 

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -30,6 +30,12 @@ const repoLoopCapabilities = [
   'ability:github_pull_request_publish',
 ];
 
+function secretEnvRequirementForProvider(contract, provider) {
+  return contract.secret_env_requirements.find((requirement) => (
+    requirement.when.any.some((selector) => selector.path === 'executor.config.provider' && selector.equals === provider)
+  ));
+}
+
 function fixtureEnv(overrides = {}) {
   const env = { ...process.env, ...overrides };
   if (!Object.hasOwn(overrides, 'HOMEBOY_WP_CODEBOX_CORE_MODULE')) {
@@ -266,6 +272,16 @@ assert.deepEqual(provider.request_required_fields, ['schema', 'task_id', 'execut
 assert.deepEqual(provider.outcome_statuses, ['succeeded', 'failed', 'no_op', 'unable_to_remediate', 'timeout', 'provider_error']);
 assert.deepEqual(provider.failure_classifications, ['provider', 'timeout', 'execution_failed']);
 assert.deepEqual(provider.redacted_metadata_keys, ['secret_env_values', 'secretEnvValues', 'secrets']);
+assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, codexSecretEnv);
+assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').when, {
+  any: [
+    { path: 'executor.config.provider', equals: 'codex' },
+    { path: 'executor.provider', equals: 'codex' },
+    { path: 'provider', equals: 'codex' },
+  ],
+});
+assert.deepEqual(secretEnvRequirementForProvider(provider, 'openai').env, ['OPENAI_API_KEY']);
+assert.deepEqual(secretEnvRequirementForProvider(provider, 'claude-code').env, [claudeCodeRefreshTokenEnv]);
 assert.deepEqual(provider.workspace_materialization, { cwd: 'git_checkout' });
 assert.deepEqual(provider.role_aliases, {
   artifact_kinds: {
@@ -302,6 +318,7 @@ const manifestProvider = manifestRuntime.agent_task_executors.find((executor) =>
 assert.deepEqual(manifestProvider, providerContract({
   command: 'node {{extension_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs',
 }));
+assert.deepEqual(secretEnvRequirementForProvider(manifestProvider, 'codex').env, codexSecretEnv);
 for (const capability of repoLoopCapabilities) {
   assert.equal(manifestProvider.capabilities.includes(capability), true);
 }

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -55,6 +55,81 @@
         "secretEnvValues",
         "secrets"
       ],
+      "secret_env_requirements": [
+        {
+          "schema": "homeboy/secret-env-requirement/v1",
+          "source": "provider_default",
+          "env": [
+            "OPENAI_API_KEY"
+          ],
+          "when": {
+            "any": [
+              {
+                "path": "executor.config.provider",
+                "equals": "openai"
+              },
+              {
+                "path": "executor.provider",
+                "equals": "openai"
+              },
+              {
+                "path": "provider",
+                "equals": "openai"
+              }
+            ]
+          }
+        },
+        {
+          "schema": "homeboy/secret-env-requirement/v1",
+          "source": "provider_default",
+          "env": [
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT",
+            "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID",
+            "AI_PROVIDER_OPENAI_CODEX_FEDRAMP"
+          ],
+          "when": {
+            "any": [
+              {
+                "path": "executor.config.provider",
+                "equals": "codex"
+              },
+              {
+                "path": "executor.provider",
+                "equals": "codex"
+              },
+              {
+                "path": "provider",
+                "equals": "codex"
+              }
+            ]
+          }
+        },
+        {
+          "schema": "homeboy/secret-env-requirement/v1",
+          "source": "provider_default",
+          "env": [
+            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"
+          ],
+          "when": {
+            "any": [
+              {
+                "path": "executor.config.provider",
+                "equals": "claude-code"
+              },
+              {
+                "path": "executor.provider",
+                "equals": "claude-code"
+              },
+              {
+                "path": "provider",
+                "equals": "claude-code"
+              }
+            ]
+          }
+        }
+      ],
       "capabilities": [
         "browser_runtime",
         "wordpress_sandbox",


### PR DESCRIPTION
## Summary
- Add generic `secret_env_requirements` metadata to the WP Codebox agent-task executor provider contract.
- Declare provider-default env-name requirements for `openai`, `codex`, and `claude-code`, including the required `AI_PROVIDER_OPENAI_CODEX_*` names for Codex-backed tasks.
- Update the checked-in WordPress manifest, docs, and provider contract tests so Homeboy can preflight declared env names without learning WP Codebox/Codex details.

Fixes #1444.
Aligns with Extra-Chill/homeboy#4838.

## Verification
- `npm run test:codebox-agent-task-executor-boundary`
- `npm run test:codebox-agent-task-executor`
- `npm run test:agent-runtime-command-path`
- `npm run lint:js` fails on pre-existing unrelated lint errors in `wordpress/lib/playground-readiness.js`, `wordpress/lib/timing-correlator.js`, and several `wordpress/scripts/*` files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the provider contract metadata, tests, docs, and verification notes for Chris to review.