### PR TITLE
Fail Codebox tasks on embedded runtime failure

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -1244,6 +1244,8 @@ function normalizeStatus(result) {
 }
 
 function agentRuntimeResultCandidates(result) {
+  const workload = agentRuntimeWorkload(result) || {};
+  const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
   return [
     result?.raw?.agent_runtime,
     result?.raw?.agent_runtime?.result,
@@ -1254,6 +1256,12 @@ function agentRuntimeResultCandidates(result) {
     result?.run?.agentResult,
     result?.agentResult,
     result?.agent_result,
+    result?.outputs,
+    workload,
+    workload.outputs,
+    ...scenarios,
+    ...scenarios.map((scenario) => scenario?.metadata),
+    ...scenarios.map((scenario) => scenario?.outputs),
   ].filter((candidate) => candidate && typeof candidate === 'object' && !Array.isArray(candidate));
 }
 
@@ -1270,18 +1278,21 @@ function agentRuntimeWorkload(result) {
 }
 
 function agentRuntimeFailure(result) {
-  return agentRuntimeResultCandidates(result).find((candidate) => {
-    const terminalStatus = String(candidate.terminal_status || candidate.terminalStatus || '').toLowerCase();
-    const status = String(candidate.status || candidate.outcome || '').toLowerCase();
-    const completionStatus = String(candidate.completion_outcome?.status || candidate.completionOutcome?.status || '').toLowerCase();
-    return candidate.success === false
-      || candidate.completion_outcome?.success === false
-      || candidate.completionOutcome?.success === false
-      || terminalStatus === 'failed'
-      || terminalStatus.startsWith('failed ')
-      || status === 'failed'
-      || completionStatus === 'failed';
-  }) || null;
+  return agentRuntimeResultCandidates(result).find(agentRuntimeCandidateFailed) || null;
+}
+
+function agentRuntimeCandidateFailed(candidate) {
+  const terminalStatus = String(candidate.terminal_status || candidate.terminalStatus || '').toLowerCase();
+  const status = String(candidate.status || candidate.outcome || '').toLowerCase();
+  const completionStatus = String(candidate.completion_outcome?.status || candidate.completionOutcome?.status || '').toLowerCase();
+  return candidate.success === false
+    || candidate.completion_outcome?.success === false
+    || candidate.completionOutcome?.success === false
+    || terminalStatus === 'failed'
+    || terminalStatus.startsWith('failed ')
+    || status === 'failed'
+    || completionStatus === 'failed'
+    || Boolean(candidate.error_reason || candidate.errorReason || candidate.error_step_id || candidate.errorStepId);
 }
 
 function agentRuntimeFailureReason(runtimeFailure) {
@@ -1319,6 +1330,7 @@ function agentRuntimeFailureDiagnostic(result) {
       status: runtimeFailure.status,
       terminal_status: runtimeFailure.terminal_status || runtimeFailure.terminalStatus,
       error_reason: runtimeFailure.error_reason || runtimeFailure.errorReason,
+      error_step_id: runtimeFailure.error_step_id || runtimeFailure.errorStepId,
     }),
   };
 }

--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -982,11 +982,13 @@ function normalizeAgentTaskRun(input, result) {
   const agentResult = hasSemanticWorkload(stdoutWorkload) ? stdoutWorkload : fallbackAgentResult;
   const bundleValidation = isAgentBundle(input) ? validateAgentRuntimeWorkload(agentResult, config) : validateRuntimeTaskWorkload(agentResult, config);
   const artifactValidation = missingRequiredTypedArtifactDiagnostic(input, agentResult, config);
-  const success = !bundleValidation && !artifactValidation;
+  const runtimeFailure = agentRuntimeFailureDiagnostic(agentResult);
+  const success = !bundleValidation && !artifactValidation && !runtimeFailure;
   const diagnostics = [
     ...(result.diagnostics || []),
     ...(bundleValidation ? [bundleValidation] : []),
     ...(artifactValidation ? [artifactValidation] : []),
+    ...(runtimeFailure ? [runtimeFailure] : []),
     ...(agentRuntimeDiagnostics(agentResult) || []),
   ];
 
@@ -995,7 +997,7 @@ function normalizeAgentTaskRun(input, result) {
     success,
     status: success ? 'completed' : result.status,
     outputs: plainObject(agentResult.outputs) ? agentResult.outputs : result.outputs,
-    summary: success ? 'WP Codebox agent task succeeded.' : (artifactValidation?.message || bundleValidation?.message || result.summary || 'WP Codebox agent task failed.'),
+    summary: success ? 'WP Codebox agent task succeeded.' : (artifactValidation?.message || bundleValidation?.message || runtimeFailure?.message || result.summary || 'WP Codebox agent task failed.'),
     session: result.session ? {
       ...result.session,
       status: success ? 'completed' : 'failed',
@@ -1278,6 +1280,68 @@ function validateAgentRuntimeWorkload(workload, config) {
   }
 
   return null;
+}
+
+function agentRuntimeFailureCandidates(workload) {
+  const scenarios = Array.isArray(workload?.scenarios) ? workload.scenarios : [];
+  return [
+    workload,
+    workload?.outputs,
+    workload?.metadata,
+    ...scenarios,
+    ...scenarios.map((scenario) => scenario?.metadata),
+    ...scenarios.map((scenario) => scenario?.outputs),
+  ].filter(plainObject);
+}
+
+function agentRuntimeCandidateFailed(candidate) {
+  const terminalStatus = String(candidate.terminal_status || candidate.terminalStatus || '').toLowerCase();
+  const status = String(candidate.status || candidate.outcome || '').toLowerCase();
+  const completionStatus = String(candidate.completion_outcome?.status || candidate.completionOutcome?.status || '').toLowerCase();
+  return candidate.success === false
+    || candidate.completion_outcome?.success === false
+    || candidate.completionOutcome?.success === false
+    || terminalStatus === 'failed'
+    || terminalStatus.startsWith('failed ')
+    || status === 'failed'
+    || completionStatus === 'failed'
+    || Boolean(candidate.error_reason || candidate.errorReason || candidate.error_step_id || candidate.errorStepId);
+}
+
+function agentRuntimeFailureReason(candidate) {
+  const terminalStatus = String(candidate.terminal_status || candidate.terminalStatus || '');
+  return candidate.error_reason
+    || candidate.errorReason
+    || candidate.reason
+    || candidate.completion_outcome?.reason
+    || candidate.completionOutcome?.reason
+    || (terminalStatus.startsWith('failed - ') ? terminalStatus.slice('failed - '.length).trim() : '')
+    || candidate.status
+    || '';
+}
+
+function agentRuntimeFailureDiagnostic(workload) {
+  const failure = agentRuntimeFailureCandidates(workload).find(agentRuntimeCandidateFailed);
+  if (!failure) {
+    return null;
+  }
+  const reason = agentRuntimeFailureReason(failure);
+  const message = failure.error_message
+    || failure.errorMessage
+    || failure.message
+    || failure.summary
+    || (reason ? `Embedded agent runtime failed: ${reason}.` : 'Embedded agent runtime failed.');
+  return {
+    class: 'agent_runtime.failed',
+    message,
+    data: {
+      reason,
+      status: failure.status,
+      terminal_status: failure.terminal_status || failure.terminalStatus,
+      error_reason: failure.error_reason || failure.errorReason,
+      error_step_id: failure.error_step_id || failure.errorStepId,
+    },
+  };
 }
 
 function validateRuntimeTaskWorkload(workload, config) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1477,6 +1477,44 @@ assert.equal(metadataAgentRuntimeTerminalFailureOutcome.status, 'failed');
 assert.equal(metadataAgentRuntimeTerminalFailureOutcome.diagnostics[0].class, 'agent_runtime.failed');
 assert.equal(metadataAgentRuntimeTerminalFailureOutcome.diagnostics[0].data.reason, 'provider_auth_failed');
 
+const workloadScenarioRuntimeFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  metadata: {
+    agent_runtime: {
+      workload: {
+        outputs: {},
+        scenarios: [{
+          id: 'agent-bundle',
+          metadata: {
+            error_step_id: 'ephemeral_step_0',
+            error_reason: 'ai_processing_failed',
+            terminal_status: 'failed - ai_processing_failed',
+          },
+        }],
+      },
+    },
+  },
+});
+assert.equal(workloadScenarioRuntimeFailureOutcome.status, 'failed');
+assert.equal(workloadScenarioRuntimeFailureOutcome.diagnostics[0].class, 'agent_runtime.failed');
+assert.equal(workloadScenarioRuntimeFailureOutcome.diagnostics[0].data.reason, 'ai_processing_failed');
+assert.equal(workloadScenarioRuntimeFailureOutcome.diagnostics[0].data.error_step_id, 'ephemeral_step_0');
+
+const outputRuntimeFailureMetadataOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  outputs: {
+    error_step_id: 'ephemeral_step_1',
+    error_reason: 'provider_auth_failed',
+  },
+});
+assert.equal(outputRuntimeFailureMetadataOutcome.status, 'failed');
+assert.equal(outputRuntimeFailureMetadataOutcome.diagnostics[0].class, 'agent_runtime.failed');
+assert.equal(outputRuntimeFailureMetadataOutcome.diagnostics[0].data.reason, 'provider_auth_failed');
+
 const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
   task_id: 'agent-bundle-task-123',

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -131,6 +131,19 @@ const agentResult = isRuntimeTask
   ? runtimeTaskResult
   : (isAgentBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_AGENT_BUNDLE
   ? { scenarios: [{ id: 'agent-bundle', metadata: { error: 'Agent bundle child job 456 did not reach a terminal state after drain; current status is pending.' } }] }
+  : (isAgentBundle && process.env.FIXTURE_WP_CODEBOX_FAILED_RUNTIME_METADATA
+  ? {
+      outputs: {},
+      scenarios: [{
+        id: 'agent-bundle',
+        metadata: {
+          error_step_id: 'ephemeral_step_0',
+          error_reason: 'ai_processing_failed',
+          terminal_status: 'failed - ai_processing_failed',
+          message: 'Codex OAuth refresh failed.'
+        }
+      }]
+    }
   : (isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
       ? {
           agent_runtime: {
@@ -150,7 +163,7 @@ const agentResult = isRuntimeTask
         }
   : (isAgentBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_AGENT_BUNDLE
       ? { metrics: { config_present: 1 }, metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }
-      : { status: 'completed' }))));
+      : { status: 'completed' })))));
 fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), input }, null, 2));
 const execution = { recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed', output: JSON.stringify(agentResult) }) };
 const executions = [execution];
@@ -480,6 +493,39 @@ try {
   assert.equal(missingRequiredArtifactOutput.success, false);
   assert.equal(missingRequiredArtifactOutput.diagnostics[0].class, 'wp-codebox.required_typed_artifacts_missing');
   assert.equal(missingRequiredArtifactOutput.diagnostics[0].data.missing[0].name, 'missing_required_report');
+
+  const failedRuntimeMetadataResult = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
+    '--wp-codebox-bin', fixtureWpCodebox,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      agent_bundle: {
+        source: 'bundles/store-idea-agent',
+        flow_slug: 'store-idea-artifact-flow',
+      },
+      artifact_declarations: [{
+        schema: 'wp-codebox/artifact-declaration/v1',
+        name: 'concept_packet',
+        type: 'ConceptPacket',
+        artifact_schema: 'static-site-generator/concept-packet/v1',
+        required: true,
+      }],
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: path.join(root, 'capture-failed-runtime-metadata.json'),
+      FIXTURE_WP_CODEBOX_FAILED_RUNTIME_METADATA: '1',
+      OPENCODE_API_KEY: 'redacted-test-key',
+    },
+  });
+  assert.equal(failedRuntimeMetadataResult.status, 1, failedRuntimeMetadataResult.stderr || failedRuntimeMetadataResult.stdout);
+  const failedRuntimeMetadataOutput = JSON.parse(failedRuntimeMetadataResult.stdout);
+  assert.equal(failedRuntimeMetadataOutput.success, false);
+  assert.equal(failedRuntimeMetadataOutput.diagnostics.some((diagnostic) => diagnostic.class === 'agent_runtime.failed'), true);
+  assert.equal(failedRuntimeMetadataOutput.diagnostics.some((diagnostic) => diagnostic.class === 'wp-codebox.required_typed_artifacts_missing'), true);
+  assert.equal(failedRuntimeMetadataOutput.session.status, 'failed');
 
   const codexCapturePath = path.join(root, 'capture-codex.json');
   const codexSecretEnv = [


### PR DESCRIPTION
## Summary
- Fail WP Codebox agent task outcomes when embedded runtime failure metadata appears in workload, scenario, or output payloads.
- Make the task runner mark normalized Codebox payloads failed when embedded runtime terminal status/error metadata is present, even if the outer Codebox process completed.
- Preserve required typed artifact gating so missing declarations fail the root task instead of only causing downstream skips.

Fixes #1445.

## Tests
- npm run test:codebox-agent-task-executor
- npm run test:wp-codebox-task-runner
- npx eslint --no-warn-ignored scripts/agent/homeboy-wp-codebox-task-runner.cjs
- ./wordpress/node_modules/.bin/eslint --config wordpress/eslint.config.mjs agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runtime status propagation fix and smoke test coverage; Chris remains responsible for review and merge.