### PR TITLE
Declare WordPress agent backend policy

### DIFF
--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -18,6 +18,9 @@
     "trace.results": true,
     "annotations": false
   },
+  "agent_task": {
+    "default_backend": "codebox"
+  },
   "agent_runtimes": [
     {
       "id": "wp-codebox",


### PR DESCRIPTION
## Summary
- Add WordPress-owned agent_task.default_backend policy for codebox.
- Keep WP Codebox runtime/provider declarations as availability/capability metadata rather than default-backend ownership.

Fixes #1453.

## Verification
- node -e "JSON.parse(require('fs').readFileSync('wordpress.json','utf8')); console.log('wordpress.json ok')"
- npm run test:agent-runtime-command-path
- npm run test:codebox-agent-task-executor-boundary

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added the extension-owned default backend policy and ran focused manifest/runtime smoke checks.