### PR TITLE
Define generic agent runtime package contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Agent runtimes live under `agent-runtimes/`. The WP Codebox runtime is exposed a
 `agent-runtimes/wp-codebox`, while the WordPress extension also carries the
 runtime payload needed by its installed provider command.
 
+Generic runtime package requirements are documented in
+[`docs/agent-runtime-package-contract.md`](docs/agent-runtime-package-contract.md).
+Use the `agent-runtimes/fake-runtime` fixture as the minimal contract example;
+WP Codebox is a concrete backend, not the generic template.
+
 ## Available Extensions
 
 | Extension | Description |

--- a/agent-runtimes/fake-runtime/README.md
+++ b/agent-runtimes/fake-runtime/README.md
@@ -1,0 +1,13 @@
+# Fake Agent Runtime
+
+This fixture is a minimal generic runtime package used by contract tests. It is
+not an operator runtime and should not be installed for real agent tasks.
+
+It demonstrates:
+
+- Required manifest fields.
+- `{{runtime_path}}` provider command interpolation.
+- Secret names declared without values.
+- Capability and workspace materialization declarations.
+- A provider command that reads an AgentTaskRequest from stdin and writes a
+  normalized AgentTaskOutcome to stdout.

--- a/agent-runtimes/fake-runtime/fake-runtime.json
+++ b/agent-runtimes/fake-runtime/fake-runtime.json
@@ -1,0 +1,73 @@
+{
+  "name": "Fake Agent Runtime",
+  "version": "1.0.0",
+  "description": "Minimal generic agent runtime fixture for Homeboy contract tests.",
+  "agent_task_executors": [
+    {
+      "schema": "homeboy/agent-task-executor-provider/v1",
+      "id": "fake-runtime.agent-task-executor",
+      "label": "Fake agent task executor",
+      "backend": "fake-runtime",
+      "command": "node {{runtime_path}}/scripts/agent/fake-agent-task-executor.cjs",
+      "request_schema": "homeboy/agent-task-request/v1",
+      "outcome_schema": "homeboy/agent-task-outcome/v1",
+      "request_required_fields": [
+        "schema",
+        "task_id",
+        "executor.backend",
+        "instructions"
+      ],
+      "outcome_statuses": [
+        "succeeded",
+        "failed",
+        "no_op",
+        "timeout",
+        "provider_error"
+      ],
+      "failure_classifications": [
+        "request_validation",
+        "provider",
+        "timeout",
+        "execution_failed"
+      ],
+      "redacted_metadata_keys": [
+        "secret_env_values",
+        "secretEnvValues",
+        "secrets",
+        "fake_runtime_token"
+      ],
+      "capabilities": [
+        "workspace_materialization",
+        "structured_outcome",
+        "diagnostic_artifacts"
+      ],
+      "workspace_materialization": {
+        "cwd": "git_checkout",
+        "requires_git": true,
+        "write_scope": "artifacts",
+        "artifact_paths": [
+          ".homeboy/fake-runtime"
+        ]
+      },
+      "secret_requirements": [
+        {
+          "name": "FAKE_RUNTIME_TOKEN",
+          "required": false,
+          "purpose": "Optional fake credential used by the contract fixture."
+        }
+      ],
+      "diagnostics": {
+        "outcome_fields": [
+          "diagnostics",
+          "artifacts",
+          "metadata"
+        ],
+        "artifact_kinds": [
+          "fake-runtime-diagnostic"
+        ]
+      },
+      "status": "experimental",
+      "integration_contract": "homeboy-generic-agent-runtime/v1"
+    }
+  ]
+}

--- a/agent-runtimes/fake-runtime/scripts/agent/fake-agent-task-executor.cjs
+++ b/agent-runtimes/fake-runtime/scripts/agent/fake-agent-task-executor.cjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+
+function readStdin() {
+	return fs.readFileSync(0, 'utf8');
+}
+
+function emit(outcome) {
+	process.stdout.write(`${JSON.stringify(outcome)}\n`);
+}
+
+function failure(taskId, summary, details) {
+	emit({
+		schema: 'homeboy/agent-task-outcome/v1',
+		task_id: taskId || null,
+		status: 'provider_error',
+		summary,
+		diagnostics: [
+			{
+				classification: 'request_validation',
+				message: details,
+			},
+		],
+		artifacts: [],
+		metadata: {
+			provider: 'fake-runtime',
+		},
+	});
+}
+
+let request;
+try {
+	request = JSON.parse(readStdin());
+} catch (error) {
+	failure(null, 'Invalid JSON request.', error.message);
+	process.exit(0);
+}
+
+if (request.schema !== 'homeboy/agent-task-request/v1') {
+	failure(request.task_id, 'Unsupported request schema.', `Received ${request.schema || 'missing schema'}.`);
+	process.exit(0);
+}
+
+if (!request.task_id || request.executor?.backend !== 'fake-runtime' || !request.instructions) {
+	failure(request.task_id, 'Request is missing required fake-runtime fields.', 'Expected task_id, executor.backend=fake-runtime, and instructions.');
+	process.exit(0);
+}
+
+emit({
+	schema: 'homeboy/agent-task-outcome/v1',
+	task_id: request.task_id,
+	status: 'succeeded',
+	summary: 'Fake runtime accepted the request.',
+	diagnostics: [
+		{
+			classification: 'provider',
+			message: 'Provider command contract fixture executed successfully.',
+		},
+	],
+	artifacts: [
+		{
+			kind: 'fake-runtime-diagnostic',
+			path: '.homeboy/fake-runtime/outcome.json',
+		},
+	],
+	metadata: {
+		provider: 'fake-runtime',
+		secret_env_names: process.env.FAKE_RUNTIME_TOKEN ? ['FAKE_RUNTIME_TOKEN'] : [],
+	},
+});

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -1,0 +1,178 @@
+# Agent Runtime Package Contract
+
+Agent runtime packages live under `agent-runtimes/<runtime-id>/`. They expose
+provider commands that Homeboy can invoke without encoding backend-specific
+knowledge in core or in domain extensions.
+
+This contract is intentionally backend-neutral. WP Codebox is one runtime, not
+the template every future runtime should copy.
+
+## Package Layout
+
+Each runtime package should include:
+
+- `<runtime-id>.json`: package manifest.
+- `README.md`: runtime-specific operator notes and provider setup.
+- Runnable provider command files referenced by the manifest.
+- Tests or fixtures proving the manifest and provider command contract.
+
+The package may include implementation libraries, but Homeboy selects runtimes
+through the manifest and provider command contract, not by importing private
+runtime modules.
+
+## Manifest Fields
+
+The manifest root must declare:
+
+- `name`: human-readable runtime name.
+- `version`: runtime package contract version.
+- `description`: one-sentence runtime summary.
+- `agent_task_executors`: non-empty list of provider declarations.
+
+Each `agent_task_executors[]` entry must declare:
+
+- `schema`: provider declaration schema, currently `homeboy/agent-task-executor-provider/v1`.
+- `id`: stable provider id. Use a namespaced id such as `runtime-id.provider-id`.
+- `label`: human-readable provider label.
+- `backend`: backend selector value used by requests, for example `fake-runtime` or `codebox`.
+- `command`: shell command Homeboy runs after interpolation.
+- `request_schema`: accepted request schema, currently `homeboy/agent-task-request/v1`.
+- `outcome_schema`: emitted outcome schema, currently `homeboy/agent-task-outcome/v1`.
+- `request_required_fields`: request paths the provider requires before execution.
+- `outcome_statuses`: statuses the provider may emit.
+- `failure_classifications`: normalized failure classes used for diagnostics.
+- `redacted_metadata_keys`: metadata keys that must never expose secret values.
+- `capabilities`: explicit capabilities orchestration may rely on.
+- `workspace_materialization`: workspace shape required by the provider.
+- `secret_requirements`: environment variable names or groups the provider needs.
+- `diagnostics`: diagnostic artifacts and metadata the provider writes or returns.
+- `status`: lifecycle state, usually `active`, `experimental`, or `deprecated`.
+- `integration_contract`: higher-level contract name when the provider serves a domain extension.
+
+Runtime-specific fields are allowed, but they should be additive. A runtime
+should not require Homeboy core to understand backend-private settings just to
+invoke the provider.
+
+## `runtime_path` Interpolation
+
+Provider commands should reference runtime-local files with `{{runtime_path}}`:
+
+```json
+{
+  "command": "node {{runtime_path}}/scripts/agent/example-agent-task-executor.cjs"
+}
+```
+
+Homeboy owns interpolation and replaces `{{runtime_path}}` with the installed
+runtime package directory before execution. Runtime packages should keep command
+paths relative to that directory so linked installs, extracted installs, and
+remote runners resolve the same files.
+
+Provider commands may use normal shell syntax, but portable single-executable
+commands are preferred. Avoid commands that depend on the monorepo checkout
+layout unless that layout is part of the package contract.
+
+## Provider Command Contract
+
+A provider command must:
+
+- Read one JSON request from stdin.
+- Validate `schema`, `task_id`, `executor.backend`, and the fields declared in `request_required_fields`.
+- Execute using only the request, environment variables, and files under the materialized workspace/runtime paths.
+- Write one JSON outcome to stdout.
+- Write human diagnostics to stderr only when useful; stderr must not contain secrets.
+- Exit `0` after emitting a well-formed terminal outcome, including normalized failure outcomes.
+- Exit non-zero only for command-level failures where no valid outcome can be produced.
+
+The emitted outcome must use `outcome_schema` and one of `outcome_statuses`.
+Failure outcomes should include a normalized classification from
+`failure_classifications` plus enough diagnostic context for Homeboy to route the
+result without parsing backend-native logs.
+
+## Secret Requirements
+
+Runtime manifests should declare secret inputs by name, never by value:
+
+```json
+{
+  "secret_requirements": [
+    {
+      "name": "FAKE_RUNTIME_TOKEN",
+      "required": false,
+      "purpose": "Authenticates optional fake runtime provider calls."
+    }
+  ]
+}
+```
+
+Provider commands receive secret values through environment variables or the
+request's secret-name declarations. They must redact secret-like metadata in
+outcomes and diagnostics. If a runtime adds a secret-bearing metadata key, it
+must add that key to `redacted_metadata_keys`.
+
+## Capability Declarations
+
+Capabilities are selection and orchestration promises. Declare a capability only
+when the provider can satisfy it for every request accepted by that provider.
+
+Use stable, backend-neutral names where possible, such as:
+
+- `workspace_materialization`
+- `structured_outcome`
+- `diagnostic_artifacts`
+- `patch_artifacts`
+- `verification_artifacts`
+- `browser_runtime`
+
+Backend-specific capabilities are acceptable when they are intentionally part of
+selection, but they should not replace the generic capability when a generic one
+applies.
+
+## Workspace Materialization
+
+`workspace_materialization` declares what the provider expects before it starts.
+Common fields:
+
+- `cwd`: working-directory mode, such as `git_checkout`, `runtime_package`, or `request_workspace`.
+- `requires_git`: whether the workspace must be a git checkout.
+- `write_scope`: where the provider may write, such as `workspace`, `artifacts`, or `none`.
+- `artifact_paths`: relative paths the provider may create or update.
+
+The provider must not infer workspace shape from WP Codebox, WordPress, or any
+other current runtime unless that shape is declared here.
+
+## Outcome And Diagnostic Contracts
+
+Provider outcomes should include:
+
+- `schema`: the outcome schema.
+- `task_id`: copied from the request.
+- `status`: terminal status from `outcome_statuses`.
+- `summary`: concise human-readable result.
+- `diagnostics`: structured diagnostics suitable for logs, PR comments, and issue routing.
+- `artifacts`: typed artifact references when files are produced.
+- `metadata`: redacted provider metadata.
+
+Diagnostics should distinguish provider setup failures, request validation
+failures, execution failures, timeouts, and successful no-op outcomes. Backend
+native logs can be attached as artifacts, but the normalized outcome is the
+contract Homeboy consumes.
+
+## Default-Backend Policy Ownership
+
+Runtime packages declare what they can do. They do not decide which backend is
+the default for a domain workflow.
+
+Default-backend policy belongs to the caller that understands the domain and
+deployment context, for example a Homeboy extension, workflow, component config,
+or operator-supplied setting. A WordPress workflow may choose WP Codebox by
+default; a different workflow may choose another runtime with the same generic
+capabilities. Homeboy core should route explicit requests and evaluate declared
+capabilities, not hard-code a global default backend.
+
+## Fake Runtime Fixture
+
+`agent-runtimes/fake-runtime` is the smallest reference fixture for this
+contract. It exists to prove future runtimes can satisfy Homeboy's generic
+runtime package shape without copying WP Codebox package structure or WordPress
+behavior.

--- a/tests/agent-runtime-contract-smoke.mjs
+++ b/tests/agent-runtime-contract-smoke.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const runtimeDir = path.join(rootDir, 'agent-runtimes', 'fake-runtime');
+const manifestPath = path.join(runtimeDir, 'fake-runtime.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+const requiredRootFields = ['name', 'version', 'description', 'agent_task_executors'];
+for (const field of requiredRootFields) {
+	assert.ok(manifest[field], `missing root manifest field: ${field}`);
+}
+
+assert.ok(Array.isArray(manifest.agent_task_executors), 'agent_task_executors must be an array');
+assert.equal(manifest.agent_task_executors.length, 1, 'fake runtime should expose one executor');
+
+const provider = manifest.agent_task_executors[0];
+const requiredProviderFields = [
+	'schema',
+	'id',
+	'label',
+	'backend',
+	'command',
+	'request_schema',
+	'outcome_schema',
+	'request_required_fields',
+	'outcome_statuses',
+	'failure_classifications',
+	'redacted_metadata_keys',
+	'capabilities',
+	'workspace_materialization',
+	'secret_requirements',
+	'diagnostics',
+	'status',
+	'integration_contract',
+];
+
+for (const field of requiredProviderFields) {
+	assert.ok(provider[field], `missing provider field: ${field}`);
+}
+
+assert.equal(provider.schema, 'homeboy/agent-task-executor-provider/v1');
+assert.equal(provider.request_schema, 'homeboy/agent-task-request/v1');
+assert.equal(provider.outcome_schema, 'homeboy/agent-task-outcome/v1');
+assert.match(provider.command, /\{\{runtime_path\}\}/, 'provider command must use runtime_path interpolation');
+assert.ok(provider.request_required_fields.includes('executor.backend'));
+assert.ok(provider.outcome_statuses.includes('succeeded'));
+assert.ok(provider.failure_classifications.includes('request_validation'));
+assert.ok(provider.redacted_metadata_keys.includes('secrets'));
+assert.ok(provider.capabilities.includes('structured_outcome'));
+assert.equal(provider.workspace_materialization.cwd, 'git_checkout');
+assert.equal(provider.workspace_materialization.requires_git, true);
+assert.ok(provider.secret_requirements.some((secret) => secret.name === 'FAKE_RUNTIME_TOKEN'));
+assert.ok(provider.diagnostics.outcome_fields.includes('diagnostics'));
+
+const command = provider.command.replace('{{runtime_path}}', runtimeDir);
+assert.equal(command, `node ${runtimeDir}/scripts/agent/fake-agent-task-executor.cjs`);
+
+const request = {
+	schema: provider.request_schema,
+	task_id: 'fake-runtime-contract-smoke',
+	executor: {
+		backend: provider.backend,
+	},
+	instructions: 'Validate the generic runtime provider command contract.',
+};
+
+const result = spawnSync('node', [path.join(runtimeDir, 'scripts', 'agent', 'fake-agent-task-executor.cjs')], {
+	input: JSON.stringify(request),
+	encoding: 'utf8',
+	env: {
+		...process.env,
+		FAKE_RUNTIME_TOKEN: 'redacted-fixture-token',
+	},
+});
+
+assert.equal(result.status, 0, result.stderr);
+assert.equal(result.stderr, '', 'fake provider should not write stderr on success');
+
+const outcome = JSON.parse(result.stdout);
+assert.equal(outcome.schema, provider.outcome_schema);
+assert.equal(outcome.task_id, request.task_id);
+assert.ok(provider.outcome_statuses.includes(outcome.status));
+assert.equal(outcome.status, 'succeeded');
+assert.equal(outcome.metadata.provider, provider.backend);
+assert.deepEqual(outcome.metadata.secret_env_names, ['FAKE_RUNTIME_TOKEN']);
+assert.doesNotMatch(result.stdout, /redacted-fixture-token/, 'provider outcome leaked secret value');
+
+console.log('agent runtime contract smoke passed');


### PR DESCRIPTION
## Summary
- Document the generic agent runtime package contract outside of WP Codebox-specific docs.
- Add a minimal fake runtime fixture that exercises required manifest fields, runtime_path interpolation, secret declarations, capabilities, workspace materialization, and diagnostics.
- Add a smoke test that validates the fake runtime manifest and provider command outcome contract.

## Verification
- `node tests/agent-runtime-contract-smoke.mjs`
- `bash tests/runtime-helpers-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the contract documentation, fake runtime fixture, and smoke test; Chris retains responsibility for review and merge.