### PR TITLE
Add experimental OpenCode agent runtime contract

### DIFF
--- a/agent-runtimes/opencode/index.js
+++ b/agent-runtimes/opencode/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+	...require('./lib/opencode-agent-task-executor'),
+};

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
+const AGENT_TASK_OUTCOME_SCHEMA = 'homeboy/agent-task-outcome/v1';
+const OPENCODE_PROVIDER_ID = 'opencode.agent-task-executor';
+const OPENCODE_PROVIDER_LABEL = 'OpenCode agent task executor';
+const OPENCODE_SECRET_ENV = [
+	'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+	'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+	'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+	'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+	'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+];
+
+const OPENCODE_CAPABILITIES = [
+	'cli_runtime',
+	'repo_workspace',
+	'workspace_tools',
+	'patch_artifacts',
+	'report_artifacts',
+	'structured_outcome',
+	'provider_owned_auth',
+	'provider_owned_session',
+	'provider_owned_cancellation',
+];
+
+const AGENT_TASK_OUTCOME_STATUSES = [
+	'succeeded',
+	'failed',
+	'no_op',
+	'unable_to_remediate',
+	'timeout',
+	'provider_error',
+];
+
+const AGENT_TASK_FAILURE_CLASSIFICATIONS = [
+	'provider',
+	'timeout',
+	'execution_failed',
+];
+
+const AGENT_TASK_REDACTED_METADATA_KEYS = [
+	'secret_env_values',
+	'secretEnvValues',
+	'secrets',
+	'codex_auth',
+	'opencode_auth',
+];
+
+function providerContract(options = {}) {
+	return {
+		schema: 'homeboy/agent-task-executor-provider/v1',
+		id: options.id || OPENCODE_PROVIDER_ID,
+		label: options.label || OPENCODE_PROVIDER_LABEL,
+		backend: 'opencode',
+		command: options.command || 'node {{runtime_path}}/scripts/agent/homeboy-opencode-agent-task-executor.cjs',
+		request_schema: AGENT_TASK_REQUEST_SCHEMA,
+		outcome_schema: AGENT_TASK_OUTCOME_SCHEMA,
+		request_required_fields: ['schema', 'task_id', 'executor.backend', 'instructions'],
+		outcome_statuses: AGENT_TASK_OUTCOME_STATUSES,
+		failure_classifications: AGENT_TASK_FAILURE_CLASSIFICATIONS,
+		redacted_metadata_keys: AGENT_TASK_REDACTED_METADATA_KEYS,
+		secret_env_requirements: [providerSecretEnvRequirement('codex', OPENCODE_SECRET_ENV)],
+		capabilities: OPENCODE_CAPABILITIES,
+		workspace_materialization: {
+			cwd: 'git_checkout',
+		},
+		provider_defaults: {
+			codex: {
+				model: 'gpt-5.5',
+				secret_env: [...OPENCODE_SECRET_ENV],
+			},
+		},
+		lifecycle: {
+			completion: 'synchronous_process',
+			cancellation: 'provider_signal',
+			max_concurrency_default: 1,
+		},
+		artifact_contract: {
+			patch: ['git-diff', 'patch'],
+			report: ['json', 'markdown'],
+		},
+		status: 'experimental',
+		integration_contract: 'homeboy-opencode-agent-task/v1',
+		runtime_gap_trackers: ['https://github.com/Extra-Chill/homeboy-extensions/issues/967'],
+	};
+}
+
+function providerSecretEnvRequirement(provider, env) {
+	return {
+		schema: 'homeboy/secret-env-requirement/v1',
+		source: 'provider_default',
+		env,
+		when: {
+			any: [
+				{ path: 'executor.config.provider', equals: provider },
+				{ path: 'executor.provider', equals: provider },
+				{ path: 'provider', equals: provider },
+			],
+		},
+	};
+}
+
+function experimentalOutcome(request = {}) {
+	return {
+		schema: AGENT_TASK_OUTCOME_SCHEMA,
+		task_id: request.task_id || '',
+		status: 'provider_error',
+		failure_classification: 'provider',
+		failure_code: 'agent_task.opencode_executor_not_implemented',
+		summary: 'OpenCode agent task executor is registered as an experimental provider contract only; process execution is not implemented yet.',
+		artifacts: [],
+		evidence_refs: [],
+		metadata: {
+			provider: OPENCODE_PROVIDER_ID,
+			issue: 'https://github.com/Extra-Chill/homeboy-extensions/issues/967',
+		},
+	};
+}
+
+module.exports = {
+	OPENCODE_PROVIDER_ID,
+	OPENCODE_PROVIDER_LABEL,
+	OPENCODE_SECRET_ENV,
+	experimentalOutcome,
+	providerContract,
+};

--- a/agent-runtimes/opencode/package.json
+++ b/agent-runtimes/opencode/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "homeboy-agent-runtime-opencode",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./opencode-agent-task-executor": "./lib/opencode-agent-task-executor.js"
+  },
+  "bin": {
+    "homeboy-opencode-agent-task-executor": "./scripts/agent/homeboy-opencode-agent-task-executor.cjs"
+  },
+  "scripts": {
+    "test:opencode-agent-task-executor-boundary": "node ../../wordpress/tests/opencode-agent-task-executor-boundary.test.js"
+  },
+  "engines": {
+    "node": ">=18.12.0"
+  }
+}

--- a/agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs
+++ b/agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+'use strict';
+
+/* eslint-disable no-console */
+
+const fs = require('node:fs');
+const {
+	experimentalOutcome,
+	providerContract,
+} = require('../../lib/opencode-agent-task-executor');
+
+function readStdin() {
+	try {
+		return fs.readFileSync(0, 'utf8');
+	} catch {
+		return '';
+	}
+}
+
+if (process.argv.includes('--provider-contract')) {
+	process.stdout.write(`${JSON.stringify(providerContract(), null, 2)}\n`);
+	process.exit(0);
+}
+
+let request = {};
+const raw = process.env.HOMEBOY_AGENT_TASK_REQUEST || readStdin();
+if (raw.trim()) {
+	try {
+		request = JSON.parse(raw);
+	} catch (error) {
+		console.error(`Invalid AgentTaskRequest JSON: ${error.message}`);
+		process.exit(1);
+	}
+}
+
+process.stdout.write(`${JSON.stringify(experimentalOutcome(request), null, 2)}\n`);
+process.exit(1);

--- a/wordpress/lib/opencode-agent-task-executor.js
+++ b/wordpress/lib/opencode-agent-task-executor.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../../agent-runtimes/opencode/lib/opencode-agent-task-executor');

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -71,6 +71,7 @@
     "test:codebox-agent-task-executor-boundary": "node tests/codebox-agent-task-executor-boundary.test.js",
     "test:codebox-agent-task-executor": "node tests/codebox-agent-task-executor-smoke.js",
     "test:codebox-agent-task-matrix": "node tests/codebox-agent-task-matrix-smoke.js",
+    "test:opencode-agent-task-executor-boundary": "node tests/opencode-agent-task-executor-boundary.test.js",
     "test:datamachine-agent-host-lifecycle": "node tests/datamachine-agent-host-lifecycle-smoke.js",
     "test:refactor-source-wp-codebox": "node tests/refactor-source-wp-codebox-smoke.js"
   },

--- a/wordpress/scripts/agent/homeboy-opencode-agent-task-executor.cjs
+++ b/wordpress/scripts/agent/homeboy-opencode-agent-task-executor.cjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+'use strict';
+
+require('../../../agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs');

--- a/wordpress/tests/opencode-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/opencode-agent-task-executor-boundary.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+/**
+ * Internal dependencies
+ */
+const {
+	OPENCODE_SECRET_ENV,
+	experimentalOutcome,
+	providerContract,
+} = require('../../agent-runtimes/opencode');
+
+function secretEnvRequirementForProvider(contract, provider) {
+	return contract.secret_env_requirements.find((requirement) => (
+		requirement.when.any.some((selector) => selector.path === 'executor.config.provider' && selector.equals === provider)
+	));
+}
+
+const provider = providerContract();
+assert.equal(provider.id, 'opencode.agent-task-executor');
+assert.equal(provider.backend, 'opencode');
+assert.equal(provider.status, 'experimental');
+assert.equal(provider.integration_contract, 'homeboy-opencode-agent-task/v1');
+assert.equal(provider.lifecycle.max_concurrency_default, 1);
+assert.equal(provider.lifecycle.cancellation, 'provider_signal');
+assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, OPENCODE_SECRET_ENV);
+assert.deepEqual(provider.provider_defaults.codex.secret_env, OPENCODE_SECRET_ENV);
+assert.equal(provider.provider_defaults.codex.model, 'gpt-5.5');
+assert.equal(provider.redacted_metadata_keys.includes('opencode_auth'), true);
+assert.equal(provider.capabilities.includes('repo_workspace'), true);
+assert.equal(provider.capabilities.includes('patch_artifacts'), true);
+assert.equal(provider.capabilities.includes('browser_runtime'), false);
+
+const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'wordpress.json'), 'utf8'));
+const runtime = manifest.agent_runtimes.find((candidate) => candidate.id === 'opencode');
+assert(runtime, 'WordPress manifest declares the OpenCode agent runtime');
+assert.equal(runtime.label, 'OpenCode');
+assert.equal(runtime.agent_task_executors.length, 1);
+assert.deepEqual(runtime.agent_task_executors[0], providerContract({
+	command: 'node {{extension_path}}/scripts/agent/homeboy-opencode-agent-task-executor.cjs',
+}));
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-opencode-provider-contract-'));
+try {
+	const extensionsRoot = path.join(root, 'extensions');
+	const extensionPath = path.join(extensionsRoot, 'wordpress');
+	fs.mkdirSync(extensionsRoot, { recursive: true });
+	fs.symlinkSync(path.join(__dirname, '..'), extensionPath, 'dir');
+
+	const command = runtime.agent_task_executors[0].command.replaceAll('{{extension_path}}', extensionPath);
+	const [, scriptPath] = command.match(/^node\s+(.+)$/) || [];
+	assert(scriptPath, 'provider command should be a node script command');
+	assert.equal(
+		path.normalize(scriptPath),
+		path.join(extensionPath, 'scripts', 'agent', 'homeboy-opencode-agent-task-executor.cjs')
+	);
+	assert.equal(fs.existsSync(scriptPath), true, `provider command target should exist: ${scriptPath}`);
+
+	const contractResult = spawnSync(process.execPath, [scriptPath, '--provider-contract'], { encoding: 'utf8' });
+	assert.equal(contractResult.status, 0, contractResult.stderr);
+	assert.deepEqual(JSON.parse(contractResult.stdout), providerContract());
+
+	const runResult = spawnSync(process.execPath, [scriptPath], {
+		encoding: 'utf8',
+		input: JSON.stringify({
+			schema: 'homeboy/agent-task-request/v1',
+			task_id: 'opencode-contract-only',
+			executor: { backend: 'opencode', config: { provider: 'codex' } },
+			instructions: 'Prove the OpenCode provider boundary without running a model.',
+		}),
+	});
+	assert.notEqual(runResult.status, 0, 'experimental provider should fail fast until execution is implemented');
+	assert.deepEqual(JSON.parse(runResult.stdout), experimentalOutcome({ task_id: 'opencode-contract-only' }));
+	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN'), false);
+} finally {
+	fs.rmSync(root, { recursive: true, force: true });
+}
+
+process.stdout.write('OpenCode agent task executor boundary passed\n');

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -197,6 +197,122 @@
       "runtime_gap_trackers": []
         }
       ]
+    },
+    {
+      "id": "opencode",
+      "label": "OpenCode",
+      "agent_task_executors": [
+        {
+          "schema": "homeboy/agent-task-executor-provider/v1",
+          "id": "opencode.agent-task-executor",
+          "label": "OpenCode agent task executor",
+          "backend": "opencode",
+          "command": "node {{extension_path}}/scripts/agent/homeboy-opencode-agent-task-executor.cjs",
+          "request_schema": "homeboy/agent-task-request/v1",
+          "outcome_schema": "homeboy/agent-task-outcome/v1",
+          "request_required_fields": [
+            "schema",
+            "task_id",
+            "executor.backend",
+            "instructions"
+          ],
+          "outcome_statuses": [
+            "succeeded",
+            "failed",
+            "no_op",
+            "unable_to_remediate",
+            "timeout",
+            "provider_error"
+          ],
+          "failure_classifications": [
+            "provider",
+            "timeout",
+            "execution_failed"
+          ],
+          "redacted_metadata_keys": [
+            "secret_env_values",
+            "secretEnvValues",
+            "secrets",
+            "codex_auth",
+            "opencode_auth"
+          ],
+          "secret_env_requirements": [
+            {
+              "schema": "homeboy/secret-env-requirement/v1",
+              "source": "provider_default",
+              "env": [
+                "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN",
+                "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN",
+                "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT",
+                "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID",
+                "AI_PROVIDER_OPENAI_CODEX_FEDRAMP"
+              ],
+              "when": {
+                "any": [
+                  {
+                    "path": "executor.config.provider",
+                    "equals": "codex"
+                  },
+                  {
+                    "path": "executor.provider",
+                    "equals": "codex"
+                  },
+                  {
+                    "path": "provider",
+                    "equals": "codex"
+                  }
+                ]
+              }
+            }
+          ],
+          "capabilities": [
+            "cli_runtime",
+            "repo_workspace",
+            "workspace_tools",
+            "patch_artifacts",
+            "report_artifacts",
+            "structured_outcome",
+            "provider_owned_auth",
+            "provider_owned_session",
+            "provider_owned_cancellation"
+          ],
+          "workspace_materialization": {
+            "cwd": "git_checkout"
+          },
+          "provider_defaults": {
+            "codex": {
+              "model": "gpt-5.5",
+              "secret_env": [
+                "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN",
+                "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN",
+                "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT",
+                "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID",
+                "AI_PROVIDER_OPENAI_CODEX_FEDRAMP"
+              ]
+            }
+          },
+          "lifecycle": {
+            "completion": "synchronous_process",
+            "cancellation": "provider_signal",
+            "max_concurrency_default": 1
+          },
+          "artifact_contract": {
+            "patch": [
+              "git-diff",
+              "patch"
+            ],
+            "report": [
+              "json",
+              "markdown"
+            ]
+          },
+          "status": "experimental",
+          "integration_contract": "homeboy-opencode-agent-task/v1",
+          "runtime_gap_trackers": [
+            "https://github.com/Extra-Chill/homeboy-extensions/issues/967"
+          ]
+        }
+      ]
     }
   ],
   "scripts": {


### PR DESCRIPTION
## Summary
- Adds an experimental OpenCode/Codex agent runtime contract under agent-runtimes/opencode.
- Registers the provider in the WordPress extension manifest without implementing a full runtime.
- Adds a boundary test that proves the manifest/provider shape, secret redaction, command path, and fail-fast behavior.

Refs #967.

## Verification
- npm run test:opencode-agent-task-executor-boundary
- npm run test:agent-runtime-command-path
- npm run test:codebox-agent-task-executor-boundary
- npx eslint --no-ignore --no-warn-ignored tests/opencode-agent-task-executor-boundary.test.js lib/opencode-agent-task-executor.js scripts/agent/homeboy-opencode-agent-task-executor.cjs ../agent-runtimes/opencode/index.js ../agent-runtimes/opencode/lib/opencode-agent-task-executor.js ../agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs

## Remaining follow-ups
- Implement the actual OpenCode process runner once the runtime contract is accepted.
- Confirm Homeboy core discovery for nested agent_runtimes providers; the inspected core checkout still discovers top-level agent_task_executors only.
- Add provider-owned cancellation/session mapping and artifact collection tests with a fake OpenCode process before real model execution.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the experimental OpenCode provider contract skeleton, tests, and PR notes; Chris remains responsible for review and merge.