### PR TITLE
Fix Codebox provider plugin path mounting

### DIFF
--- a/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/wordpress/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -292,6 +292,7 @@ function nestedPreparedPath(source, preparedItems) {
 function runtimePreparationSources(taskInput) {
   return [
     ...(Array.isArray(taskInput.extra_plugins) ? taskInput.extra_plugins.map((plugin) => [plugin?.source, plugin?.slug]) : []),
+    ...(Array.isArray(taskInput.provider_plugin_paths) ? taskInput.provider_plugin_paths.map((source) => [source, pluginSlugFromPath(source)]) : []),
     ...(Array.isArray(taskInput.component_contracts) ? taskInput.component_contracts.map((contract) => [contract?.path || contract?.source, contract?.slug]) : []),
     ...(plainObject(taskInput.runtime_component_paths) ? Object.entries(taskInput.runtime_component_paths).map(([, source]) => [source, '']) : []),
   ]
@@ -336,10 +337,18 @@ function prepareStableTaskInput(taskInput, artifacts) {
       }))
     : taskInput.runtime_component_paths;
 
+  const providerPluginPaths = Array.isArray(taskInput.provider_plugin_paths)
+    ? taskInput.provider_plugin_paths.map((source) => {
+        const prepared = preparedBySource.get(source);
+        return prepared?.prepared ? prepared.source : source;
+      })
+    : taskInput.provider_plugin_paths;
+
   return {
     input: {
       ...taskInput,
       extra_plugins: preparedExtraPlugins,
+      provider_plugin_paths: providerPluginPaths,
       component_contracts: preparedComponentContracts,
       runtime_component_paths: runtimeComponentPaths,
     },
@@ -652,6 +661,33 @@ function runtimeComponentExtraPlugins(input) {
   });
 }
 
+function pluginSlugFromPath(pluginPath) {
+  const source = String(pluginPath || '');
+  try {
+    const composer = JSON.parse(fs.readFileSync(path.join(source, 'composer.json'), 'utf8'));
+    const packageName = typeof composer.name === 'string' ? composer.name.split('/').pop() : '';
+    if (packageName) {
+      return packageName.replace(/[^A-Za-z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
+    }
+  } catch {
+    // Composer metadata is optional for provider plugin directories.
+  }
+  return path.basename(source).split('@')[0].replace(/[^A-Za-z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function providerPluginEntries(input) {
+  return (input.provider_plugin_paths || []).flatMap((source) => {
+    const slug = pluginSlugFromPath(source);
+    return source && slug ? [{
+      source,
+      slug,
+      loadAs: 'plugin',
+      activate: true,
+      metadata: { kind: 'provider-plugin-path', provider: input.provider || '' },
+    }] : [];
+  });
+}
+
 function componentContracts(input) {
   // Translate normalized runtime component paths into the WP Codebox 0.8.0
   // `component_contracts` shape:
@@ -691,7 +727,11 @@ function verifySteps(input) {
 
 function extraPlugins(input) {
   const explicit = input.parent_request?.extra_plugins || input.parent_request?.extraPlugins || [];
-  const plugins = [...runtimeComponentExtraPlugins(input), ...(Array.isArray(explicit) ? explicit : [])];
+  const plugins = [
+    ...runtimeComponentExtraPlugins(input),
+    ...providerPluginEntries(input),
+    ...(Array.isArray(explicit) ? explicit : []),
+  ];
   const seen = new Set();
   return plugins.filter((plugin) => {
     const key = `${plugin.slug || ''}:${plugin.source || ''}`;

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -202,11 +202,14 @@ try {
   const capturePath = path.join(root, 'capture.json');
   const fixtureWpCodebox = createFixtureWpCodebox(root);
   const providerPluginPath = path.join(root, 'example-provider@feature-branch');
+  const preparedProviderPluginPath = path.join(root, 'artifacts', 'prepared-plugins', 'example-provider');
   const workspaceRoot = path.join(root, 'wp-coding-agents@proof-homeboy-fanout-a');
   const defaultDataMachinePath = path.join(root, 'data-machine');
   const defaultAgentsApiPath = path.join(defaultDataMachinePath, 'vendor', 'wordpress', 'agents-api');
   const defaultDataMachineCodePath = path.join(root, 'data-machine-code');
   fs.mkdirSync(providerPluginPath, { recursive: true });
+  fs.writeFileSync(path.join(providerPluginPath, 'example-provider.php'), '<?php\n/* Plugin Name: Example Provider */\n');
+  fs.writeFileSync(path.join(providerPluginPath, 'composer.json'), JSON.stringify({ name: 'extra-chill/example-provider' }));
   fs.mkdirSync(workspaceRoot, { recursive: true });
   fs.mkdirSync(defaultAgentsApiPath, { recursive: true });
   fs.mkdirSync(defaultDataMachineCodePath, { recursive: true });
@@ -291,7 +294,9 @@ try {
   assert.equal(captured.input.provider, 'opencode');
   assert.equal(captured.input.model, 'opencode-go/kimi-k2.6');
   assert.deepEqual(captured.input.secret_env, ['OPENCODE_API_KEY']);
-  assert.equal(captured.input.provider_plugin_paths[0], providerPluginPath);
+  assert.equal(captured.input.provider_plugin_paths[0], preparedProviderPluginPath);
+  assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'example-provider').source, preparedProviderPluginPath);
+  assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'example-provider').activate, true);
   assert.deepEqual(captured.input.runtime_env, request.runtime_env);
   assert.deepEqual(captured.input.ability_tools, request.ability_tools);
   assert.deepEqual(captured.input.runtime_state_mounts, request.runtime_state_mounts);


### PR DESCRIPTION
## Summary
- Materialize provider_plugin_paths through the WP Codebox task runner's stable prepared-plugin path handling.
- Emit provider plugin paths as explicit extra_plugins so WP Codebox mount_plugins loads them before provider registration.
- Infer stable plugin slugs from composer metadata or DMC-style checkout names such as repo@branch.

Refs Extra-Chill/homeboy#4834

## Testing
- npm run test:wp-codebox-task-runner
- npm run test:codebox-agent-task-executor-boundary
- npm run test:codebox-agent-task-executor
- npx eslint scripts/agent/homeboy-wp-codebox-task-runner.cjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and regression test; Chris remains responsible for review and validation.