### PR TITLE
fix: consume core test scope in runners

### DIFF
--- a/go/scripts/test-runner.sh
+++ b/go/scripts/test-runner.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 PROJECT_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../../scripts/lib/runner-prelude.sh}"
 # shellcheck source=/dev/null
-if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
-    source "$SIDECAR_WRITER_HELPER"
-fi
+source "$RUNNER_PRELUDE"
+homeboy_runner_init --sidecar-writer
 OUTPUT_FILE="$(mktemp)"
 trap 'rm -f "$OUTPUT_FILE"' EXIT
 

--- a/rust/scripts/rust-changed-scope-smoke.sh
+++ b/rust/scripts/rust-changed-scope-smoke.sh
@@ -91,7 +91,7 @@ OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
     HOMEBOY_SKIP_LINT=1 \
-    HOMEBOY_CHANGED_TEST_FILES='tests/integration_scope.rs' \
+    HOMEBOY_TEST_SCOPE_KIND='rust_integration' \
     HOMEBOY_TEST_SCOPE_MESSAGE='Scoped to changed integration tests: integration_scope' \
     HOMEBOY_TEST_RUNNER_ARGS=$'--test\nintegration_scope' \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
@@ -113,7 +113,7 @@ OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
     HOMEBOY_SKIP_LINT=1 \
-    HOMEBOY_CHANGED_TEST_FILES='tests/core/daemon_test.rs' \
+    HOMEBOY_TEST_SCOPE_KIND='rust_filter' \
     HOMEBOY_TEST_SCOPE_MESSAGE='Scoped to changed files: core::daemon::daemon_test' \
     HOMEBOY_TEST_RUNNER_ARGS=$'--\ncore::daemon::daemon_test' \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
@@ -135,7 +135,7 @@ OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
     HOMEBOY_SKIP_LINT=1 \
-    HOMEBOY_CHANGED_TEST_FILES=$'tests/core/daemon_test.rs\ntests/core/service_test.rs' \
+    HOMEBOY_TEST_SCOPE_KIND='full' \
     HOMEBOY_TEST_SCOPE_MESSAGE='Changed files include multiple inline test modules; running full cargo test.' \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
@@ -156,7 +156,7 @@ OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
     HOMEBOY_SKIP_LINT=1 \
-    HOMEBOY_CHANGED_TEST_FILES='tests/core/unknown_nested_test.rs' \
+    HOMEBOY_TEST_SCOPE_KIND='full' \
     HOMEBOY_TEST_SCOPE_MESSAGE='Changed files include nested tests without a direct Cargo target; running full cargo test.' \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
@@ -224,7 +224,9 @@ OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
     HOMEBOY_COMPONENT_PATH="$WORKSPACE_DIR" \
     HOMEBOY_SKIP_LINT=1 \
-    HOMEBOY_CHANGED_TEST_FILES='crates/targeted/src/lib.rs' \
+    HOMEBOY_TEST_SCOPE_KIND='args' \
+    HOMEBOY_TEST_SCOPE_MESSAGE='Scoped to changed Cargo package: targeted-pkg.' \
+    HOMEBOY_TEST_RUNNER_ARGS=$'-p\ntargeted-pkg' \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh"
@@ -244,13 +246,14 @@ OUTPUT=$(
     HOMEBOY_EXTENSION_PATH="$(cd "$SCRIPT_DIR/.." && pwd)" \
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
     HOMEBOY_SKIP_LINT=1 \
-    HOMEBOY_CHANGED_TEST_FILES='Cargo.toml' \
+    HOMEBOY_TEST_SCOPE_KIND='full' \
+    HOMEBOY_TEST_SCOPE_MESSAGE='Changed path is cross-cutting for Cargo: Cargo.toml' \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh"
 )
 
-if [[ "$OUTPUT" != *"Rust test scope fallback: Changed path is cross-cutting for Cargo: Cargo.toml"* ]]; then
+if [[ "$OUTPUT" != *"Rust test scope: Changed path is cross-cutting for Cargo: Cargo.toml"* ]]; then
     printf 'Expected explicit Cargo.toml fallback. Output:\n%s\n' "$OUTPUT" >&2
     exit 1
 fi

--- a/rust/scripts/rust-nextest-runner-smoke.sh
+++ b/rust/scripts/rust-nextest-runner-smoke.sh
@@ -45,6 +45,14 @@ homeboy_sidecar_merge() {
     local safe_target="${target//[^A-Za-z0-9_.-]/_}"
     cp "$source" "${HOMEBOY_SIDECAR_DIR}/${safe_target}.json"
 }
+
+homeboy_merge_annotations() {
+    local target="$1"
+    local source="$2"
+    local safe_target="annotation.${target}"
+    safe_target="${safe_target//[^A-Za-z0-9_.-]/_}"
+    cp "$source" "${HOMEBOY_SIDECAR_DIR}/${safe_target}.json"
+}
 EOF
 
 cat > "$BIN_DIR/cargo" <<'EOF'
@@ -67,7 +75,9 @@ OUTPUT=$(
     HOMEBOY_COMPONENT_PATH="$PROJECT_DIR" \
     HOMEBOY_SKIP_LINT=1 \
     HOMEBOY_RUST_TEST_RUNNER=nextest \
-    HOMEBOY_CHANGED_TEST_FILES='tests/integration_scope.rs' \
+    HOMEBOY_TEST_SCOPE_KIND='rust_integration' \
+    HOMEBOY_TEST_SCOPE_MESSAGE='Scoped to changed integration tests: integration_scope' \
+    HOMEBOY_TEST_RUNNER_ARGS=$'--test\nintegration_scope' \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     HOMEBOY_RUNTIME_SIDECAR_WRITER="$HELPER_DIR/sidecar-writer.sh" \
@@ -81,19 +91,24 @@ if [[ "$OUTPUT" != *"Running cargo nextest"* ]]; then
     exit 1
 fi
 
-EXPECTED_ARGS=$'nextest\nrun\n--manifest-path\n'"$PROJECT_DIR"$'/Cargo.toml\n-p\nrust-nextest-smoke\n--test\nintegration_scope'
+EXPECTED_ARGS=$'nextest\nrun\n--manifest-path\n'"$PROJECT_DIR"$'/Cargo.toml\n--test\nintegration_scope'
 ACTUAL_ARGS="$(cat "$WORKDIR/cargo-args.txt")"
 if [ "$ACTUAL_ARGS" != "$EXPECTED_ARGS" ]; then
     printf 'Expected nextest command shape:\n%s\nActual:\n%s\n' "$EXPECTED_ARGS" "$ACTUAL_ARGS" >&2
     exit 1
 fi
 
-if [ ! -f "$SIDECAR_DIR/test.results.json" ]; then
-    printf 'Expected test.results sidecar metadata. Output:\n%s\n' "$OUTPUT" >&2
+if [ -f "$SIDECAR_DIR/test.results.json" ]; then
+    printf 'Command plan metadata must not be written to test.results. Output:\n%s\n' "$OUTPUT" >&2
     exit 1
 fi
 
-python3 - "$SIDECAR_DIR/test.results.json" <<'PY'
+if [ ! -f "$SIDECAR_DIR/annotation.rust-test-plan.json" ]; then
+    printf 'Expected rust-test-plan annotation metadata. Output:\n%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+python3 - "$SIDECAR_DIR/annotation.rust-test-plan.json" <<'PY'
 import json
 import sys
 
@@ -102,10 +117,8 @@ with open(sys.argv[1], encoding="utf-8") as handle:
 
 record = data[0]
 assert record["runner"] == "nextest", record
-assert record["scope"] == "file", record
-assert record["package"] == "rust-nextest-smoke", record
-assert record["test_target"] == "integration_scope", record
-assert record["args"] == ["-p", "rust-nextest-smoke", "--test", "integration_scope"], record
+assert record["scope"] == "rust_integration", record
+assert record["args"] == ["--test", "integration_scope"], record
 PY
 
 cat > "$BIN_DIR/cargo" <<'EOF'
@@ -128,7 +141,8 @@ OUTPUT=$(
     HOMEBOY_SKIP_LINT=1 \
     HOMEBOY_RUST_TEST_RUNNER=nextest \
     HOMEBOY_RUST_NEXTEST_FALLBACK=0 \
-    HOMEBOY_CHANGED_TEST_FILES='tests/integration_scope.rs' \
+    HOMEBOY_TEST_SCOPE_KIND='rust_integration' \
+    HOMEBOY_TEST_RUNNER_ARGS=$'--test\nintegration_scope' \
     HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$HELPER_DIR/resolve-context.sh" \
     HOMEBOY_RUNTIME_RUNNER_STEPS="$HELPER_DIR/runner-steps.sh" \
     bash "$SCRIPT_DIR/test-runner.sh" 2>&1 || true

--- a/rust/scripts/test-runner.sh
+++ b/rust/scripts/test-runner.sh
@@ -60,174 +60,20 @@ rust_cargo_test_threads() {
     esac
 }
 
-rust_resolve_changed_scope_json() {
-    python3 - "$PROJECT_PATH" "${HOMEBOY_CHANGED_TEST_FILES:-}" "${HOMEBOY_TEST_RUNNER_ARGS:-}" <<'PY'
+rust_test_scope_json() {
+    python3 - "${HOMEBOY_TEST_SCOPE_KIND:-workspace}" "${HOMEBOY_TEST_SCOPE_MESSAGE:-}" "${HOMEBOY_TEST_RUNNER_ARGS:-}" <<'PY'
 import json
-import os
-import re
 import sys
-from pathlib import Path
 
-project = Path(sys.argv[1]).resolve()
-changed_raw = sys.argv[2]
-runner_args_raw = sys.argv[3]
-
-
-def cargo_package_name(manifest: Path):
-    try:
-        try:
-            import tomllib
-            data = tomllib.loads(manifest.read_text(encoding="utf-8"))
-            package = data.get("package") if isinstance(data, dict) else None
-            name = package.get("name") if isinstance(package, dict) else None
-            return str(name) if name else None
-        except Exception:
-            text = manifest.read_text(encoding="utf-8")
-    except OSError:
-        return None
-
-    in_package = False
-    for line in text.splitlines():
-        stripped = line.strip()
-        if stripped == "[package]":
-            in_package = True
-            continue
-        if stripped.startswith("[") and stripped != "[package]":
-            in_package = False
-        if in_package:
-            match = re.match(r'name\s*=\s*["\']([^"\']+)["\']', stripped)
-            if match:
-                return match.group(1)
-    return None
-
-
-def nearest_manifest(path: Path):
-    current = path if path.is_dir() else path.parent
-    while True:
-        if project not in [current, *current.parents]:
-            return None
-        manifest = current / "Cargo.toml"
-        if manifest.exists():
-            return manifest
-        if current == project:
-            return None
-        current = current.parent
-
-
-changed = []
-for raw in changed_raw.splitlines():
-    raw = raw.strip()
-    if not raw:
-        continue
-    candidate = Path(raw)
-    if candidate.is_absolute():
-        try:
-            rel = candidate.resolve().relative_to(project)
-        except ValueError:
-            print(json.dumps({
-                "kind": "fallback",
-                "reason": f"Changed path is outside the Cargo project: {raw}",
-                "args": [],
-                "package": None,
-                "test_target": None,
-            }))
-            sys.exit(0)
-    else:
-        rel = candidate
-    changed.append(rel)
-
-existing_args = [line for line in runner_args_raw.splitlines() if line]
-if not changed:
-    print(json.dumps({
-        "kind": "workspace",
-        "reason": "No changed-file scope was provided; running the default Cargo test command.",
-        "args": existing_args,
-        "package": None,
-        "test_target": None,
-    }))
-    sys.exit(0)
-
-cross_cutting_names = {"Cargo.toml", "Cargo.lock", "rust-toolchain", "rust-toolchain.toml", "build.rs"}
-cross_cutting_dirs = {".cargo"}
-packages = {}
-test_target = None
-
-for rel in changed:
-    parts = rel.parts
-    if not parts:
-        continue
-    if parts[0] in cross_cutting_dirs or rel.name in cross_cutting_names:
-        print(json.dumps({
-            "kind": "fallback",
-            "reason": f"Changed path is cross-cutting for Cargo: {rel.as_posix()}",
-            "args": existing_args,
-            "package": None,
-            "test_target": None,
-        }))
-        sys.exit(0)
-
-    absolute = (project / rel).resolve()
-    manifest = nearest_manifest(absolute)
-    if manifest is None:
-        print(json.dumps({
-            "kind": "fallback",
-            "reason": f"Changed path is not inside a Cargo package: {rel.as_posix()}",
-            "args": existing_args,
-            "package": None,
-            "test_target": None,
-        }))
-        sys.exit(0)
-
-    package = cargo_package_name(manifest)
-    if not package:
-        print(json.dumps({
-            "kind": "fallback",
-            "reason": f"Could not resolve Cargo package name for {rel.as_posix()}",
-            "args": existing_args,
-            "package": None,
-            "test_target": None,
-        }))
-        sys.exit(0)
-
-    packages[package] = manifest
-
-    try:
-        package_rel = absolute.relative_to(manifest.parent)
-    except ValueError:
-        package_rel = rel
-    package_parts = package_rel.parts
-    if len(changed) == 1 and len(package_parts) == 2 and package_parts[0] == "tests" and package_rel.suffix == ".rs":
-        test_target = package_rel.stem
-
-if len(packages) != 1:
-    print(json.dumps({
-        "kind": "fallback",
-        "reason": "Changed files span multiple Cargo packages; running the default Cargo test command.",
-        "args": existing_args,
-        "package": None,
-        "test_target": None,
-    }))
-    sys.exit(0)
-
-package = next(iter(packages))
-args = ["-p", package]
-if test_target and not existing_args:
-    args.extend(["--test", test_target])
-args.extend(existing_args)
-
-if test_target and not existing_args:
-    kind = "file"
-    reason = f"Scoped to changed integration test target: {test_target} in package {package}."
-else:
-    kind = "package"
-    reason = f"Scoped to changed Cargo package: {package}."
+kind, message, runner_args_raw = sys.argv[1:]
+args = [line for line in runner_args_raw.splitlines() if line]
+if not kind or kind == "full":
+    kind = "workspace"
 
 print(json.dumps({
     "kind": kind,
-    "reason": reason,
+    "reason": message,
     "args": args,
-    "package": package,
-    "test_target": test_target,
 }))
 PY
 }
@@ -260,7 +106,7 @@ rust_emit_test_plan() {
     local exit_code="${5:-0}"
     local plan_tmp
 
-    if ! type homeboy_sidecar_merge >/dev/null 2>&1; then
+    if ! type homeboy_merge_annotations >/dev/null 2>&1; then
         return 0
     fi
 
@@ -281,8 +127,6 @@ record = {
     "command": command,
     "scope": scope.get("kind") or "workspace",
     "scope_reason": scope.get("reason") or "",
-    "package": scope.get("package"),
-    "test_target": scope.get("test_target"),
     "args": scope.get("args") or [],
     "status": status,
     "exit_code": int(exit_code or 0),
@@ -291,7 +135,7 @@ with open(target, "w", encoding="utf-8") as handle:
     json.dump([record], handle, indent=2)
     handle.write("\n")
 PY
-    homeboy_sidecar_merge test.results "$plan_tmp" || true
+    homeboy_merge_annotations rust-test-plan "$plan_tmp" || true
     rm -f "$plan_tmp"
 }
 
@@ -449,7 +293,7 @@ print(json.dumps(result, indent=2))
 fi
 
 SELECTED_RUNNER="$(rust_test_runner)"
-SCOPE_JSON="$(rust_resolve_changed_scope_json)"
+SCOPE_JSON="$(rust_test_scope_json)"
 SCOPE_KIND="$(printf '%s' "$SCOPE_JSON" | jq -r '.kind // "workspace"')"
 SCOPE_REASON="$(printf '%s' "$SCOPE_JSON" | jq -r '.reason // empty')"
 

--- a/swift/scripts/test-runner.sh
+++ b/swift/scripts/test-runner.sh
@@ -2,15 +2,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${SCRIPT_DIR}/lib/resolve-context.sh}"
-SIDECAR_WRITER_HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
+RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${SCRIPT_DIR}/../../scripts/lib/runner-prelude.sh}"
 # shellcheck source=/dev/null
-source "$RESOLVE_CONTEXT_HELPER"
-homeboy_resolve_context
-# shellcheck source=/dev/null
-if [ -n "$SIDECAR_WRITER_HELPER" ] && [ -f "$SIDECAR_WRITER_HELPER" ]; then
-    source "$SIDECAR_WRITER_HELPER"
-fi
+source "$RUNNER_PRELUDE"
+homeboy_runner_init --component-alias COMPONENT_PATH --sidecar-writer
 
 # Debug environment variables (only shown when HOMEBOY_DEBUG=1)
 if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then


### PR DESCRIPTION
## Summary
- make the Rust test runner consume authoritative HOMEBOY_TEST_SCOPE_KIND and HOMEBOY_TEST_RUNNER_ARGS instead of recomputing changed-file scope
- move Rust command-plan metadata out of canonical test.results and into rust-test-plan annotations
- source the shared runner prelude/init path in Go and Swift before writing test failure sidecars

## Tests
- bash rust/scripts/rust-changed-scope-smoke.sh
- bash rust/scripts/rust-nextest-runner-smoke.sh
- HOMEBOY_CORE_DIR=/Users/chubes/Developer/homeboy bash tests/runtime-helpers-smoke.sh
- bash -n rust/scripts/test-runner.sh go/scripts/test-runner.sh swift/scripts/test-runner.sh rust/scripts/rust-changed-scope-smoke.sh rust/scripts/rust-nextest-runner-smoke.sh

## Follow-ups
- Node parser extraction intentionally left out; handle in a separate small PR if still desired.
