### PR TITLE
Publish WordPress page profiling helper paths

### DIFF
--- a/tests/nodejs-wordpress-helper-discovery-smoke.sh
+++ b/tests/nodejs-wordpress-helper-discovery-smoke.sh
@@ -47,6 +47,8 @@ export default async function () {
     assert.equal(process.env.HOMEBOY_WORDPRESS_REQUEST_PROFILER_HELPER, manifest.helpers.requestProfiler);
     assert.equal(process.env.HOMEBOY_WORDPRESS_TIMING_CORRELATOR_HELPER, manifest.helpers.timingCorrelator);
     assert.equal(process.env.HOMEBOY_WORDPRESS_BOOTSTRAP_TIMELINE_HELPER, manifest.helpers.bootstrapTimeline);
+    assert.ok(manifest.helpers.pageProfiler, 'page profiler helper is published');
+    assert.ok(manifest.helpers.adminPageScenarios, 'admin page scenarios helper is published');
 
     for (const helperPath of Object.values(manifest.helpers)) {
         assert.ok(existsSync(helperPath), `helper exists at ${helperPath}`);
@@ -74,7 +76,7 @@ import { readFileSync } from 'node:fs';
 const results = JSON.parse(readFileSync(process.argv[2], 'utf8'));
 const scenario = results.scenarios?.[0];
 if (!scenario) throw new Error('missing scenario');
-if (scenario.metrics?.helper_count !== 7) {
+if (scenario.metrics?.helper_count !== 12) {
     throw new Error(`helper count metric regressed: ${JSON.stringify(scenario.metrics)}`);
 }
 if (!scenario.metadata?.wordpress_helper_manifest?.endsWith('/wordpress/lib/helper-manifest.js')) {

--- a/wordpress/lib/helper-manifest.js
+++ b/wordpress/lib/helper-manifest.js
@@ -12,6 +12,8 @@ const HELPER_PATHS = Object.freeze({
 	timingCorrelator: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'timing-correlator.js'),
 	wordpressRouteLatency: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'wordpress-route-latency.js'),
 	bootstrapTimeline: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'wordpress-bootstrap-timeline.js'),
+	pageProfiler: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'page-profiler.js'),
+	adminPageScenarios: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'admin-page-scenarios.js'),
 	blockQuality: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'block-quality.js'),
 	materializedSiteQuality: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'materialized-site-quality.js'),
 	editorCanvasProbes: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'editor-canvas-probes.js'),

--- a/wordpress/tests/helper-manifest-smoke.js
+++ b/wordpress/tests/helper-manifest-smoke.js
@@ -33,6 +33,14 @@ assert.equal(
 	path.resolve(__dirname, '..', 'lib', 'wordpress-bootstrap-timeline.js')
 );
 assert.equal(
+	manifest.helpers.pageProfiler,
+	path.resolve(__dirname, '..', 'lib', 'page-profiler.js')
+);
+assert.equal(
+	manifest.helpers.adminPageScenarios,
+	path.resolve(__dirname, '..', 'lib', 'admin-page-scenarios.js')
+);
+assert.equal(
 	manifest.helpers.blockQuality,
 	path.resolve(__dirname, '..', 'lib', 'block-quality.js')
 );

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",


### PR DESCRIPTION
## Summary
- publish page profiler and admin page scenario helpers in the WordPress helper manifest
- bump the WordPress extension patch version
- extend helper discovery smoke coverage for the promoted helpers

## Tests
- node wordpress/tests/helper-manifest-smoke.js
- node wordpress/tests/wordpress-helper-consumer-smoke.mjs
- HOMEBOY_CORE_DIR=/Users/chubes/Developer/homeboy bash tests/nodejs-wordpress-helper-discovery-smoke.sh