### PR TITLE
Align standalone runtime contract fixture

### DIFF
--- a/agent-runtimes/fake-runtime/fake-runtime.json
+++ b/agent-runtimes/fake-runtime/fake-runtime.json
@@ -1,4 +1,6 @@
 {
+  "schema": "homeboy/agent-runtime-manifest/v1",
+  "id": "fake-runtime",
   "name": "Fake Agent Runtime",
   "version": "1.0.0",
   "description": "Minimal generic agent runtime fixture for Homeboy contract tests.",
@@ -56,6 +58,22 @@
           "purpose": "Optional fake credential used by the contract fixture."
         }
       ],
+      "secret_env_requirements": [
+        {
+          "schema": "homeboy/secret-env-requirement/v1",
+          "source": "provider_default",
+          "env": ["FAKE_RUNTIME_TOKEN"],
+          "when": {
+            "path": "executor.config.provider",
+            "equals": "fake-runtime"
+          }
+        }
+      ],
+      "provider_defaults": {
+        "fake-runtime": {
+          "secret_env": ["FAKE_RUNTIME_TOKEN"]
+        }
+      },
       "diagnostics": {
         "outcome_fields": [
           "diagnostics",

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -24,6 +24,9 @@ runtime modules.
 
 The manifest root must declare:
 
+- `schema`: runtime manifest schema, currently `homeboy/agent-runtime-manifest/v1`.
+- `id`: stable runtime package id. For standalone installs, Homeboy treats the
+  containing directory name as authoritative and may override this value.
 - `name`: human-readable runtime name.
 - `version`: runtime package contract version.
 - `description`: one-sentence runtime summary.

--- a/tests/agent-runtime-contract-smoke.mjs
+++ b/tests/agent-runtime-contract-smoke.mjs
@@ -10,12 +10,14 @@ const runtimeDir = path.join(rootDir, 'agent-runtimes', 'fake-runtime');
 const manifestPath = path.join(runtimeDir, 'fake-runtime.json');
 const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
 
-const requiredRootFields = ['name', 'version', 'description', 'agent_task_executors'];
+const requiredRootFields = ['schema', 'id', 'name', 'version', 'description', 'agent_task_executors'];
 for (const field of requiredRootFields) {
 	assert.ok(manifest[field], `missing root manifest field: ${field}`);
 }
 
 assert.ok(Array.isArray(manifest.agent_task_executors), 'agent_task_executors must be an array');
+assert.equal(manifest.schema, 'homeboy/agent-runtime-manifest/v1');
+assert.equal(manifest.id, 'fake-runtime');
 assert.equal(manifest.agent_task_executors.length, 1, 'fake runtime should expose one executor');
 
 const provider = manifest.agent_task_executors[0];
@@ -34,6 +36,8 @@ const requiredProviderFields = [
 	'capabilities',
 	'workspace_materialization',
 	'secret_requirements',
+	'secret_env_requirements',
+	'provider_defaults',
 	'diagnostics',
 	'status',
 	'integration_contract',
@@ -54,7 +58,11 @@ assert.ok(provider.redacted_metadata_keys.includes('secrets'));
 assert.ok(provider.capabilities.includes('structured_outcome'));
 assert.equal(provider.workspace_materialization.cwd, 'git_checkout');
 assert.equal(provider.workspace_materialization.requires_git, true);
+assert.equal(provider.workspace_materialization.write_scope, 'artifacts');
+assert.deepEqual(provider.workspace_materialization.artifact_paths, ['.homeboy/fake-runtime']);
 assert.ok(provider.secret_requirements.some((secret) => secret.name === 'FAKE_RUNTIME_TOKEN'));
+assert.deepEqual(provider.secret_env_requirements[0].env, ['FAKE_RUNTIME_TOKEN']);
+assert.deepEqual(provider.provider_defaults['fake-runtime'].secret_env, ['FAKE_RUNTIME_TOKEN']);
 assert.ok(provider.diagnostics.outcome_fields.includes('diagnostics'));
 
 const command = provider.command.replace('{{runtime_path}}', runtimeDir);


### PR DESCRIPTION
## Summary
- add core standalone runtime schema/id fields to the fake runtime fixture
- smoke-test root schema/id plus generic provider fields
- document the root schema/id contract and directory-id compatibility

## Tests
- node tests/agent-runtime-contract-smoke.mjs