### PR TITLE
fix: delegate shared runtime helpers

### DIFF
--- a/scripts/lib/resolve-context.sh
+++ b/scripts/lib/resolve-context.sh
@@ -1,63 +1,10 @@
 #!/usr/bin/env bash
 
-# Direct-invocation fallback for Homeboy core's shared resolve-context helper.
-# Keep this file aligned with homeboy/src/core/extension/runtime/resolve-context.sh.
+# Bootstrap Homeboy core's shared resolve context helper for direct extension invocation.
 
-homeboy_resolve_context() {
-    local project_alias="PROJECT_PATH"
-    local component_alias=""
+__homeboy_runtime_bootstrap_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./runtime-helper-bootstrap.sh
+source "${__homeboy_runtime_bootstrap_dir}/runtime-helper-bootstrap.sh"
+unset __homeboy_runtime_bootstrap_dir
 
-    while [ "$#" -gt 0 ]; do
-        case "$1" in
-            --project-alias)
-                project_alias="${2:-}"
-                shift 2
-                ;;
-            --component-alias)
-                component_alias="${2:-}"
-                shift 2
-                ;;
-            *)
-                echo "homeboy_resolve_context: unknown argument: $1" >&2
-                return 2
-                ;;
-        esac
-    done
-
-    if [ -n "${HOMEBOY_EXTENSION_PATH:-}" ]; then
-        EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
-    else
-        if [ -z "${SCRIPT_DIR:-}" ]; then
-            echo "homeboy_resolve_context: SCRIPT_DIR is required when HOMEBOY_EXTENSION_PATH is unset" >&2
-            return 2
-        fi
-
-        local search_dir="$SCRIPT_DIR"
-        while [ "$search_dir" != "/" ] && [ -n "$search_dir" ]; do
-            if compgen -G "$search_dir/*.json" >/dev/null; then
-                EXTENSION_PATH="$search_dir"
-                break
-            fi
-            search_dir="$(dirname "$search_dir")"
-        done
-
-        if [ -z "${EXTENSION_PATH:-}" ]; then
-            echo "homeboy_resolve_context: could not find extension manifest above SCRIPT_DIR=$SCRIPT_DIR" >&2
-            return 2
-        fi
-    fi
-
-    COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
-    COMPONENT_ID="${HOMEBOY_COMPONENT_ID:-$(basename "$COMPONENT_PATH")}"
-    PROJECT_PATH="${HOMEBOY_PROJECT_PATH:-$COMPONENT_PATH}"
-
-    export EXTENSION_PATH COMPONENT_PATH COMPONENT_ID PROJECT_PATH
-
-    if [ -n "$project_alias" ] && [ "$project_alias" != "PROJECT_PATH" ]; then
-        export "$project_alias=$PROJECT_PATH"
-    fi
-
-    if [ -n "$component_alias" ]; then
-        export "$component_alias=$COMPONENT_PATH"
-    fi
-}
+homeboy_source_core_runtime_helper HOMEBOY_RUNTIME_RESOLVE_CONTEXT resolve-context.sh

--- a/scripts/lib/runner-steps.sh
+++ b/scripts/lib/runner-steps.sh
@@ -1,35 +1,10 @@
 #!/usr/bin/env bash
 
-# Direct-invocation fallback for Homeboy core's shared runner-step helper.
-# Keep this file aligned with homeboy/src/core/extension/runtime/runner-steps.sh.
-#
-# Reads HOMEBOY_STEP / HOMEBOY_SKIP as comma-separated step names and exposes
-# should_run_step <name> with the same semantics as Homeboy core's
-# RunnerStepFilter:
-# - HOMEBOY_STEP present => only listed steps run
-# - HOMEBOY_SKIP present => listed steps are skipped
-# - empty step name => runs by default
+# Bootstrap Homeboy core's shared runner step helper for direct extension invocation.
 
-should_run_step() {
-    local step_name="${1:-}"
-    step_name="$(printf '%s' "$step_name" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+__homeboy_runtime_bootstrap_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./runtime-helper-bootstrap.sh
+source "${__homeboy_runtime_bootstrap_dir}/runtime-helper-bootstrap.sh"
+unset __homeboy_runtime_bootstrap_dir
 
-    if [ -z "$step_name" ]; then
-        return 0
-    fi
-
-    if [ -n "${HOMEBOY_STEP:-}" ]; then
-        case ",${HOMEBOY_STEP}," in
-            *",${step_name},"*) ;;
-            *) return 1 ;;
-        esac
-    fi
-
-    if [ -n "${HOMEBOY_SKIP:-}" ]; then
-        case ",${HOMEBOY_SKIP}," in
-            *",${step_name},"*) return 1 ;;
-        esac
-    fi
-
-    return 0
-}
+homeboy_source_core_runtime_helper HOMEBOY_RUNTIME_RUNNER_STEPS runner-steps.sh


### PR DESCRIPTION
## Summary
- Replace duplicated `scripts/lib/resolve-context.sh` implementation with a wrapper that sources Homeboy core via `runtime-helper-bootstrap.sh`.
- Replace duplicated `scripts/lib/runner-steps.sh` implementation with the same core runtime-helper delegation pattern used by `runner-prelude.sh` and `command-capture.sh`.
- Keeps Homeboy Extensions aligned with core originals under `homeboy/src/core/extension/runtime`.

## Verification
- `HOMEBOY_CORE_DIR="/Users/chubes/Developer/homeboy@audit-main-20260616" bash tests/runner-steps-smoke.sh`
- `HOMEBOY_CORE_DIR="/Users/chubes/Developer/homeboy@audit-main-20260616" bash tests/runtime-helpers-smoke.sh`
- `HOMEBOY_CORE_DIR="/Users/chubes/Developer/homeboy@audit-main-20260616" bash wordpress/scripts/build/build-helper-smoke.sh`
- `HOMEBOY_CORE_DIR="/Users/chubes/Developer/homeboy@audit-main-20260616" SCRIPT_DIR="/Users/chubes/Developer/homeboy-extensions@fix-runtime-helper-delegation/scripts/lib" HOMEBOY_COMPONENT_PATH="/tmp/homeboy-component" bash -c 'source scripts/lib/resolve-context.sh && homeboy_resolve_context --component-alias COMPONENT_ALIAS && test "$COMPONENT_ALIAS" = "/tmp/homeboy-component"'`\n- `HOMEBOY_CORE_DIR="/Users/chubes/Developer/homeboy@audit-main-20260616" HOMEBOY_STEP="lint,test" HOMEBOY_SKIP="test" bash -c 'source scripts/lib/runner-steps.sh && should_run_step lint && ! should_run_step test && ! should_run_step build'`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** OpenCode (openai/gpt-5.5)\n- **Used for:** Implemented the wrapper delegation change and ran targeted verification; Chris to review and own the final change.