### PR TITLE
Add generic trace workload helper

### DIFF
--- a/nodejs/docs/trace-helpers.md
+++ b/nodejs/docs/trace-helpers.md
@@ -6,19 +6,27 @@ window lifecycle scenarios. Scenarios can import them from
 
 ```js
 const helperDir = process.env.HOMEBOY_TRACE_HELPER_DIR;
-const { createTraceRecorder } = await import(`${helperDir}/timeline.mjs`);
+const { createTraceWorkload } = await import(`${helperDir}/timeline.mjs`);
 const { launchProcess, captureProcessTree, waitForExit } = await import(`${helperDir}/process.mjs`);
 const { pollHttp } = await import(`${helperDir}/probes.mjs`);
+
+const trace = createTraceWorkload();
 ```
 
 ## Stable Helpers
 
 - `timeline.mjs` records timestamped events, assertions, artifacts, and writes
-  the final Homeboy trace JSON envelope. `TraceRecorder#recordCheck()` maps a
-  boolean check to a pass/fail assertion, and `TraceRecorder#writeArtifact()`
-  writes an artifact under `HOMEBOY_TRACE_ARTIFACT_DIR` while registering it in
-  the result envelope. Timeline, assertion, artifact, and envelope rows use the
-  shared product-neutral shapes documented in `../../docs/browser-result-shapes.md`.
+  the final Homeboy trace JSON envelope. `createTraceWorkload()` is the default
+  workload-facing surface: use `trace.event(source, event, data)`,
+  `trace.artifact(label, path, kind)`, `trace.assertion(id, status, message,
+  data)`, `trace.check(id, ok, message, data)`, `trace.pass(metrics, options)`,
+  and `trace.fail(error, metrics, options)` so artifact registration and result
+  envelope writing stay centralized. `createTraceRecorder()` remains available
+  for direct recorder access. `TraceRecorder#recordCheck()` maps a boolean check
+  to a pass/fail assertion, and `TraceRecorder#writeArtifact()` writes an
+  artifact under `HOMEBOY_TRACE_ARTIFACT_DIR` while registering it in the result
+  envelope. Timeline, assertion, artifact, and envelope rows use the shared
+  product-neutral shapes documented in `../../docs/browser-result-shapes.md`.
 - `process.mjs` launches black-box commands, captures a best-effort process
   tree artifact on macOS/Linux, waits for exits, and cleans up spawned process
   groups on process exit/signals.

--- a/nodejs/scripts/trace/README.md
+++ b/nodejs/scripts/trace/README.md
@@ -7,26 +7,26 @@ Node.js trace workloads can import reusable helpers from the directory exposed a
 import { pathToFileURL } from 'node:url';
 
 const helperDir = process.env.HOMEBOY_TRACE_HELPER_DIR;
-const { createTraceRecorder } = await import(pathToFileURL(`${helperDir}/timeline.mjs`).href);
+const { createTraceWorkload } = await import(pathToFileURL(`${helperDir}/timeline.mjs`).href);
 const { createHttpStatusHistory, pollHttp, pollJsonFile, pollProcess, parseLogLines } = await import(pathToFileURL(`${helperDir}/probes.mjs`).href);
 
-const recorder = createTraceRecorder();
-const onEvent = recorder.recordEvent.bind(recorder);
+const trace = createTraceWorkload();
 
 await pollHttp('http://127.0.0.1:3000/', {
-    readyStatus: [200, 399],
-    timeoutMs: 30000,
-    intervalMs: 250,
-    requestTimeoutMs: 1000,
-    onEvent,
+	readyStatus: [200, 399],
+	timeoutMs: 30000,
+	intervalMs: 250,
+	requestTimeoutMs: 1000,
+	onEvent: trace.event,
 });
 
-await recorder.writeTraceResults({ summary: 'Trace completed' });
+trace.assertion('app-ready', 'pass', 'App became ready.');
+await trace.pass({}, { summary: 'Trace completed' });
 ```
 
 ## Helper Modules
 
-- `timeline.mjs` — `createTraceRecorder()` writes timeline JSONL, assertions, artifacts, and the final trace envelope.
+- `timeline.mjs` — `createTraceWorkload()` exposes generic `event`, `artifact`, `assertion`, `check`, `pass`, and `fail` helpers for workloads. `createTraceRecorder()` remains available when a workload needs direct recorder access. Both paths write timeline JSONL, assertions, artifacts, and the final trace envelope through the same normalized shapes.
 - `process.mjs` — process launch, cleanup, exit waiting, and process-tree capture helpers.
 - `desktop.mjs` — best-effort desktop observation helpers for local trace evidence.
 - `probes.mjs` — app-agnostic polling and bridge helpers for common trace observations.

--- a/nodejs/scripts/trace/lib/timeline.mjs
+++ b/nodejs/scripts/trace/lib/timeline.mjs
@@ -141,6 +141,54 @@ export function createTraceReporter(options = {}) {
     };
 }
 
+export function createTraceWorkload(options = {}) {
+    const reporter = createTraceReporter(options);
+
+    return {
+        get recorder() {
+            return reporter.recorder;
+        },
+        get timeline() {
+            return reporter.timeline;
+        },
+        get assertions() {
+            return reporter.assertions;
+        },
+        get artifacts() {
+            return reporter.artifacts;
+        },
+        event(source, event, data = {}) {
+            return reporter.mark(event, data, source);
+        },
+        mark(name, data = {}, source = 'scenario') {
+            return reporter.mark(name, data, source);
+        },
+        artifact(labelOrOptions, path = undefined, kind = undefined) {
+            if (labelOrOptions && typeof labelOrOptions === 'object' && !Array.isArray(labelOrOptions)) {
+                return reporter.artifact(labelOrOptions);
+            }
+
+            return reporter.artifact({ label: labelOrOptions, path, kind });
+        },
+        assertion(idOrOptions, status = undefined, message = undefined, data = undefined) {
+            if (idOrOptions && typeof idOrOptions === 'object' && !Array.isArray(idOrOptions)) {
+                return reporter.assertion(idOrOptions);
+            }
+
+            return reporter.assertion({ id: idOrOptions, status, message, data });
+        },
+        check(id, ok, message, data = undefined) {
+            return reporter.assertion({ id, status: ok ? 'pass' : 'fail', message, data });
+        },
+        pass(metrics = {}, options = {}) {
+            return reporter.pass(metrics, options);
+        },
+        fail(error, metrics = {}, options = {}) {
+            return reporter.fail(error, metrics, options);
+        },
+    };
+}
+
 function deriveStatus(assertions) {
     if (assertions.some((assertion) => assertion.status === 'fail')) return 'fail';
     if (assertions.length > 0 && assertions.every((assertion) => assertion.status === 'skip')) return 'skip';

--- a/nodejs/scripts/trace/trace-helpers-smoke.mjs
+++ b/nodejs/scripts/trace/trace-helpers-smoke.mjs
@@ -9,7 +9,7 @@ const resultsFile = path.join(root, 'trace-results.json');
 process.env.HOMEBOY_TRACE_ARTIFACT_DIR = artifactDir;
 
 try {
-    const { createTraceReporter } = await import('./lib/timeline.mjs');
+    const { createTraceReporter, createTraceWorkload } = await import('./lib/timeline.mjs');
     const { createBrowserWaterfallCollector, normalizeBrowserWaterfall } = await import('./lib/browser-waterfall.mjs');
 
     const artifactPath = path.join(artifactDir, 'metrics.json');
@@ -47,6 +47,22 @@ try {
     const failEnvelope = await failReporter.fail(new Error('boom'), { failed: true });
     assert.equal(failEnvelope.status, 'fail');
     assert.equal(failEnvelope.failure.message, 'boom');
+
+    const workload = createTraceWorkload({
+        componentId: 'fixture-component',
+        scenarioId: 'fixture-workload',
+        resultsFile: path.join(root, 'trace-workload.json'),
+    });
+    workload.event('fixture', 'workload.start', { cookie: 'secret-cookie', ok: true });
+    workload.artifact('Workload metrics', artifactPath, 'json');
+    workload.assertion('workload-direct-assertion', 'pass', 'Direct assertion passed.');
+    workload.check('workload-check-helper', true, 'Check helper passed.', { authorization: 'bearer secret' });
+    const workloadEnvelope = await workload.pass({ visible: true }, { summary: 'Workload helper trace passed.' });
+    assert.equal(workloadEnvelope.status, 'pass');
+    assert.equal(workloadEnvelope.timeline[0].source, 'fixture');
+    assert.equal(workloadEnvelope.timeline[0].data.cookie, '[Redacted]');
+    assert.equal(workloadEnvelope.artifacts.find((artifact) => artifact.label === 'Workload metrics')?.path, 'metrics.json');
+    assert.equal(workloadEnvelope.assertions.find((assertion) => assertion.id === 'workload-check-helper')?.data.authorization, '[Redacted]');
 
     const snapshot = {
         page_url: 'https://example.test/wp-admin/site-editor.php',


### PR DESCRIPTION
## Summary
- Add createTraceWorkload() as a small generic surface over the existing trace recorder/reporter.
- Centralize event, artifact, assertion, check, pass, and fail helpers on the shared normalized trace envelope path.
- Document the workload-facing API and extend trace helper smoke coverage.

## Verification
- node nodejs/scripts/trace/trace-helpers-smoke.mjs
- node tests/structured-sidecars-smoke.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the helper API, docs, and targeted smoke coverage; Chris remains responsible for review and testing.