### PR TITLE
fix: prefer runtime helpers in extension wrappers

### DIFF
--- a/nodejs/scripts/lib/command-capture.sh
+++ b/nodejs/scripts/lib/command-capture.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
-# Direct-invocation fallback wrapper. Homeboy-invoked runners receive the core
-# helper via HOMEBOY_RUNTIME_COMMAND_CAPTURE; direct runs share one local copy.
+# Direct-invocation fallback wrapper. Prefer the core runtime helper when the
+# caller provided it; direct runs without Homeboy still share one local copy.
 
-# shellcheck source=../../../scripts/lib/command-capture.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/command-capture.sh"
+HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-}"
+if [ -n "$HELPER" ] && [ "$HELPER" != "${BASH_SOURCE[0]}" ]; then
+    # shellcheck source=/dev/null
+    source "$HELPER"
+else
+    # shellcheck source=../../../scripts/lib/command-capture.sh
+    source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/command-capture.sh"
+fi

--- a/nodejs/scripts/lib/resolve-context.sh
+++ b/nodejs/scripts/lib/resolve-context.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
-COMMON_RESOLVE_CONTEXT_HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/scripts/lib/resolve-context.sh"
-# shellcheck source=/dev/null
-source "$COMMON_RESOLVE_CONTEXT_HELPER"
+HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-}"
+if [ -n "$HELPER" ] && [ "$HELPER" != "${BASH_SOURCE[0]}" ]; then
+    # shellcheck source=/dev/null
+    source "$HELPER"
+else
+    COMMON_RESOLVE_CONTEXT_HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/scripts/lib/resolve-context.sh"
+    # shellcheck source=/dev/null
+    source "$COMMON_RESOLVE_CONTEXT_HELPER"
+fi

--- a/nodejs/scripts/lib/runner-prelude.sh
+++ b/nodejs/scripts/lib/runner-prelude.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
-# Direct-invocation fallback wrapper. Homeboy-invoked runners receive the core
-# helper via HOMEBOY_RUNTIME_RUNNER_PRELUDE; direct runs share one local copy.
+# Direct-invocation fallback wrapper. Prefer the core runtime helper when the
+# caller provided it; direct runs without Homeboy still share one local copy.
 
-# shellcheck source=../../../scripts/lib/runner-prelude.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/runner-prelude.sh"
+HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-}"
+if [ -n "$HELPER" ] && [ "$HELPER" != "${BASH_SOURCE[0]}" ]; then
+    # shellcheck source=/dev/null
+    source "$HELPER"
+else
+    # shellcheck source=../../../scripts/lib/runner-prelude.sh
+    source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/runner-prelude.sh"
+fi

--- a/rust/scripts/lib/command-capture.sh
+++ b/rust/scripts/lib/command-capture.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
-# Direct-invocation fallback wrapper. Homeboy-invoked runners receive the core
-# helper via HOMEBOY_RUNTIME_COMMAND_CAPTURE; direct runs share one local copy.
+# Direct-invocation fallback wrapper. Prefer the core runtime helper when the
+# caller provided it; direct runs without Homeboy still share one local copy.
 
-# shellcheck source=../../../scripts/lib/command-capture.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/command-capture.sh"
+HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-}"
+if [ -n "$HELPER" ] && [ "$HELPER" != "${BASH_SOURCE[0]}" ]; then
+    # shellcheck source=/dev/null
+    source "$HELPER"
+else
+    # shellcheck source=../../../scripts/lib/command-capture.sh
+    source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/command-capture.sh"
+fi

--- a/rust/scripts/lib/resolve-context.sh
+++ b/rust/scripts/lib/resolve-context.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
-COMMON_RESOLVE_CONTEXT_HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/scripts/lib/resolve-context.sh"
-# shellcheck source=/dev/null
-source "$COMMON_RESOLVE_CONTEXT_HELPER"
+HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-}"
+if [ -n "$HELPER" ] && [ "$HELPER" != "${BASH_SOURCE[0]}" ]; then
+    # shellcheck source=/dev/null
+    source "$HELPER"
+else
+    COMMON_RESOLVE_CONTEXT_HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/scripts/lib/resolve-context.sh"
+    # shellcheck source=/dev/null
+    source "$COMMON_RESOLVE_CONTEXT_HELPER"
+fi

--- a/rust/scripts/lib/runner-prelude.sh
+++ b/rust/scripts/lib/runner-prelude.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
-# Direct-invocation fallback wrapper. Homeboy-invoked runners receive the core
-# helper via HOMEBOY_RUNTIME_RUNNER_PRELUDE; direct runs share one local copy.
+# Direct-invocation fallback wrapper. Prefer the core runtime helper when the
+# caller provided it; direct runs without Homeboy still share one local copy.
 
-# shellcheck source=../../../scripts/lib/runner-prelude.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/runner-prelude.sh"
+HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-}"
+if [ -n "$HELPER" ] && [ "$HELPER" != "${BASH_SOURCE[0]}" ]; then
+    # shellcheck source=/dev/null
+    source "$HELPER"
+else
+    # shellcheck source=../../../scripts/lib/runner-prelude.sh
+    source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/runner-prelude.sh"
+fi

--- a/swift/scripts/lib/resolve-context.sh
+++ b/swift/scripts/lib/resolve-context.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
-COMMON_RESOLVE_CONTEXT_HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/scripts/lib/resolve-context.sh"
-# shellcheck source=/dev/null
-source "$COMMON_RESOLVE_CONTEXT_HELPER"
+HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-}"
+if [ -n "$HELPER" ] && [ "$HELPER" != "${BASH_SOURCE[0]}" ]; then
+    # shellcheck source=/dev/null
+    source "$HELPER"
+else
+    COMMON_RESOLVE_CONTEXT_HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/scripts/lib/resolve-context.sh"
+    # shellcheck source=/dev/null
+    source "$COMMON_RESOLVE_CONTEXT_HELPER"
+fi

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -13,6 +13,18 @@ RUNNER_PRELUDE_HELPERS=(
     "${ROOT_DIR}/rust/scripts/lib/runner-prelude.sh"
     "${ROOT_DIR}/wordpress/scripts/lib/runner-prelude.sh"
 )
+RESOLVE_CONTEXT_HELPERS=(
+    "${ROOT_DIR}/nodejs/scripts/lib/resolve-context.sh"
+    "${ROOT_DIR}/rust/scripts/lib/resolve-context.sh"
+    "${ROOT_DIR}/wordpress/scripts/lib/resolve-context.sh"
+    "${ROOT_DIR}/swift/scripts/lib/resolve-context.sh"
+)
+RUNNER_STEPS_HELPERS=(
+    "${ROOT_DIR}/wordpress/scripts/lib/runner-steps.sh"
+)
+SIDECAR_WRITER_HELPERS=(
+    "${ROOT_DIR}/wordpress/scripts/lib/sidecar-writer.sh"
+)
 FIX_RESULTS_HELPERS=(
     "${ROOT_DIR}/nodejs/scripts/lib/fix-results.sh"
     "${ROOT_DIR}/rust/scripts/lib/fix-results.sh"
@@ -116,6 +128,24 @@ fi
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+
+RUNTIME_STUB="$TMP_DIR/runtime-stub.sh"
+printf 'HOMEBOY_WRAPPER_USED=runtime\n' > "$RUNTIME_STUB"
+for runner_prelude_helper in "${RUNNER_PRELUDE_HELPERS[@]}"; do
+    HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNTIME_STUB" bash -c 'source "$1"; [ "$HOMEBOY_WRAPPER_USED" = runtime ]' _ "$runner_prelude_helper"
+done
+for resolve_context_helper in "${RESOLVE_CONTEXT_HELPERS[@]}"; do
+    HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RUNTIME_STUB" bash -c 'source "$1"; [ "$HOMEBOY_WRAPPER_USED" = runtime ]' _ "$resolve_context_helper"
+done
+for runner_steps_helper in "${RUNNER_STEPS_HELPERS[@]}"; do
+    HOMEBOY_RUNTIME_RUNNER_STEPS="$RUNTIME_STUB" bash -c 'source "$1"; [ "$HOMEBOY_WRAPPER_USED" = runtime ]' _ "$runner_steps_helper"
+done
+for command_capture_helper in "${COMMAND_CAPTURE_HELPERS[@]:1}"; do
+    HOMEBOY_RUNTIME_COMMAND_CAPTURE="$RUNTIME_STUB" bash -c 'source "$1"; [ "$HOMEBOY_WRAPPER_USED" = runtime ]' _ "$command_capture_helper"
+done
+for sidecar_writer_helper in "${SIDECAR_WRITER_HELPERS[@]}"; do
+    HOMEBOY_RUNTIME_SIDECAR_WRITER="$RUNTIME_STUB" bash -c 'source "$1"; [ "$HOMEBOY_WRAPPER_USED" = runtime ]' _ "$sidecar_writer_helper"
+done
 
 ANNOTATIONS_DIR="$TMP_DIR/annotations"
 ANNOTATIONS_SOURCE="$TMP_DIR/extra-annotations.json"

--- a/wordpress/scripts/lib/command-capture.sh
+++ b/wordpress/scripts/lib/command-capture.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
-# Direct-invocation fallback wrapper. Homeboy-invoked runners receive the core
-# helper via HOMEBOY_RUNTIME_COMMAND_CAPTURE; direct runs share one local copy.
+# Direct-invocation fallback wrapper. Prefer the core runtime helper when the
+# caller provided it; direct runs without Homeboy still share one local copy.
 
-# shellcheck source=../../../scripts/lib/command-capture.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/command-capture.sh"
+HELPER="${HOMEBOY_RUNTIME_COMMAND_CAPTURE:-}"
+if [ -n "$HELPER" ] && [ "$HELPER" != "${BASH_SOURCE[0]}" ]; then
+    # shellcheck source=/dev/null
+    source "$HELPER"
+else
+    # shellcheck source=../../../scripts/lib/command-capture.sh
+    source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/command-capture.sh"
+fi

--- a/wordpress/scripts/lib/resolve-context.sh
+++ b/wordpress/scripts/lib/resolve-context.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
+HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-}"
 COMMON_RESOLVE_CONTEXT_HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/scripts/lib/resolve-context.sh"
-if [ -f "$COMMON_RESOLVE_CONTEXT_HELPER" ]; then
+if [ -n "$HELPER" ] && [ "$HELPER" != "${BASH_SOURCE[0]}" ]; then
+    # shellcheck source=/dev/null
+    source "$HELPER"
+elif [ -f "$COMMON_RESOLVE_CONTEXT_HELPER" ]; then
     # shellcheck source=/dev/null
     source "$COMMON_RESOLVE_CONTEXT_HELPER"
 else

--- a/wordpress/scripts/lib/runner-prelude.sh
+++ b/wordpress/scripts/lib/runner-prelude.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
-# Direct-invocation fallback wrapper. Homeboy-invoked runners receive the core
-# helper via HOMEBOY_RUNTIME_RUNNER_PRELUDE; direct runs share one local copy.
+# Direct-invocation fallback wrapper. Prefer the core runtime helper when the
+# caller provided it; direct runs without Homeboy still share one local copy.
 
-# shellcheck source=../../../scripts/lib/runner-prelude.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/runner-prelude.sh"
+HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-}"
+if [ -n "$HELPER" ] && [ "$HELPER" != "${BASH_SOURCE[0]}" ]; then
+    # shellcheck source=/dev/null
+    source "$HELPER"
+else
+    # shellcheck source=../../../scripts/lib/runner-prelude.sh
+    source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/runner-prelude.sh"
+fi

--- a/wordpress/scripts/lib/runner-steps.sh
+++ b/wordpress/scripts/lib/runner-steps.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
-COMMON_RUNNER_STEPS_HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/scripts/lib/runner-steps.sh"
-# shellcheck source=/dev/null
-source "$COMMON_RUNNER_STEPS_HELPER"
+HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-}"
+if [ -n "$HELPER" ] && [ "$HELPER" != "${BASH_SOURCE[0]}" ]; then
+    # shellcheck source=/dev/null
+    source "$HELPER"
+else
+    COMMON_RUNNER_STEPS_HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/scripts/lib/runner-steps.sh"
+    # shellcheck source=/dev/null
+    source "$COMMON_RUNNER_STEPS_HELPER"
+fi

--- a/wordpress/scripts/lib/sidecar-writer.sh
+++ b/wordpress/scripts/lib/sidecar-writer.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
-# Direct-invocation fallback wrapper. Homeboy-invoked runners receive the core
-# helper via HOMEBOY_RUNTIME_SIDECAR_WRITER; direct runs share one local copy.
+# Direct-invocation fallback wrapper. Prefer the core runtime helper when the
+# caller provided it; direct runs without Homeboy still share one local copy.
 
-# shellcheck source=../../../scripts/lib/sidecar-writer.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/sidecar-writer.sh"
+HELPER="${HOMEBOY_RUNTIME_SIDECAR_WRITER:-}"
+if [ -n "$HELPER" ] && [ "$HELPER" != "${BASH_SOURCE[0]}" ]; then
+    # shellcheck source=/dev/null
+    source "$HELPER"
+else
+    # shellcheck source=../../../scripts/lib/sidecar-writer.sh
+    source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib" && pwd)/sidecar-writer.sh"
+fi


### PR DESCRIPTION
## Summary
- Prefer HOMEBOY_RUNTIME_* helpers from extension-local core-helper wrappers when provided
- Keep explicit top-level scripts/lib fallbacks for direct invocation without Homeboy runtime env
- Add runtime-helper smoke coverage for env-helper preference

Fixes #1466

## Tests
- bash tests/runtime-helpers-smoke.sh
- bash tests/runner-steps-smoke.sh
- bash -n nodejs/scripts/lib/runner-prelude.sh nodejs/scripts/lib/command-capture.sh nodejs/scripts/lib/resolve-context.sh rust/scripts/lib/runner-prelude.sh rust/scripts/lib/command-capture.sh rust/scripts/lib/resolve-context.sh swift/scripts/lib/resolve-context.sh wordpress/scripts/lib/runner-prelude.sh wordpress/scripts/lib/command-capture.sh wordpress/scripts/lib/resolve-context.sh wordpress/scripts/lib/runner-steps.sh wordpress/scripts/lib/sidecar-writer.sh tests/runtime-helpers-smoke.sh
- cargo test self_checks (in /Users/chubes/Developer/homeboy)