### PR TITLE
Fix WP Codebox provider plugin path defaults

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -283,7 +283,12 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     mode: config.mode || options.mode || 'sandbox',
     provider,
     model,
-    provider_plugin_paths: config.provider_plugin_paths || options.providerPluginPaths || defaults.providerPluginPaths || [],
+    provider_plugin_paths: firstNonEmptyArray(
+      config.provider_plugin_paths,
+      options.providerPluginPaths,
+      defaults.providerPluginPaths,
+      []
+    ),
     agent_bundles: agentBundles,
     runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
     runtime_overlay_profiles: config.runtime_overlay_profiles || config.runtimeOverlayProfiles || options.runtimeOverlayProfiles || defaults.runtimeOverlayProfiles || [],
@@ -897,6 +902,16 @@ function componentDiscoveryCandidates(componentKey, discovery, settings, workspa
     }
     return [];
   });
+}
+
+function firstNonEmptyArray(...values) {
+  for (const value of values) {
+    const normalized = normalizeArray(value);
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+  return [];
 }
 
 function firstExistingPath(...candidates) {

--- a/tests/wp-codebox-provider-plugin-defaults-smoke.mjs
+++ b/tests/wp-codebox-provider-plugin-defaults-smoke.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { codeboxTaskRequestFromAgentTaskRequest } = require(
+	path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'codebox-agent-task-executor.js')
+);
+
+const providerDir = mkdtempSync(path.join(tmpdir(), 'homeboy-wp-codebox-provider-'));
+const explicitProviderDir = mkdtempSync(path.join(tmpdir(), 'homeboy-wp-codebox-explicit-provider-'));
+
+try {
+	const taskRequest = {
+		schema: 'homeboy/agent-task-request/v1',
+		task_id: 'wp-codebox-provider-plugin-defaults-smoke',
+		instructions: 'Validate provider plugin path defaults.',
+		executor: {
+			backend: 'codebox',
+			config: {
+				provider: 'codex',
+				model: 'gpt-5.5',
+				provider_plugin_paths: [],
+			},
+		},
+	};
+	const options = {
+		settings: {
+			provider_plugin_paths: [providerDir],
+		},
+	};
+
+	const taskInput = codeboxTaskRequestFromAgentTaskRequest(taskRequest, options);
+
+	assert.deepEqual(taskInput.provider_plugin_paths, [providerDir]);
+
+	const explicitTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+		...taskRequest,
+		executor: {
+			...taskRequest.executor,
+			config: {
+				...taskRequest.executor.config,
+				provider_plugin_paths: [explicitProviderDir],
+			},
+		},
+	}, options);
+
+	assert.deepEqual(explicitTaskInput.provider_plugin_paths, [explicitProviderDir]);
+	console.log('wp-codebox provider plugin defaults smoke passed');
+} finally {
+	rmSync(providerDir, { recursive: true, force: true });
+	rmSync(explicitProviderDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- Preserve configured WP Codebox provider plugin path defaults when request config supplies an empty provider_plugin_paths array.
- Keep non-empty explicit provider_plugin_paths as the winning value.
- Add focused regression coverage for codeboxTaskRequestFromAgentTaskRequest.

## Verification
- node tests/wp-codebox-provider-plugin-defaults-smoke.mjs
- node tests/agent-runtime-contract-smoke.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the focused provider plugin path fallback fix, expanded regression coverage, and ran verification.