### PR TITLE
Keep project script helpers extension-owned

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Generic runtime package requirements are documented in
 Use the `agent-runtimes/fake-runtime` fixture as the minimal contract example;
 WP Codebox is a concrete backend, not the generic template.
 
+Generic project-root, package-manager, and named-script execution helpers live in
+[`scripts/lib/project-scripts.sh`](scripts/lib/project-scripts.sh) and are
+documented in [`docs/project-script-runtime.md`](docs/project-script-runtime.md).
+They are extension-owned until Homeboy core grows an ecosystem-neutral runtime
+helper contract.
+
 ## Available Extensions
 
 | Extension | Description |

--- a/docs/project-script-runtime.md
+++ b/docs/project-script-runtime.md
@@ -1,0 +1,67 @@
+# Project Script Runtime Helpers
+
+`scripts/lib/project-scripts.sh` is the generic project-root, package-manager,
+and project-script helper for Homeboy extension runners. It is intentionally kept
+in Homeboy Extensions while Homeboy core only dispatches extension capabilities.
+
+## Contract
+
+Extension scripts source the helper and initialize it for the ecosystem they are
+about to run:
+
+```bash
+source "$HOMEBOY_EXTENSION_PATH/scripts/lib/project-scripts.sh"
+homeboy_project_init --ecosystem node --path "$PROJECT_PATH"
+```
+
+The helper sets these generic variables:
+
+| Variable | Meaning |
+| --- | --- |
+| `HOMEBOY_PROJECT_ECOSYSTEM` | Ecosystem adapter selected by the extension. |
+| `HOMEBOY_PROJECT_ROOT` | Root discovered from the input path. |
+| `HOMEBOY_PROJECT_SCRIPT_FILE` | Script manifest path, such as `package.json`. |
+| `HOMEBOY_PROJECT_PACKAGE_MANAGER` | Ecosystem package manager selected from project files. |
+| `HOMEBOY_PROJECT_RUN_CMD` | Command prefix for running named project scripts. |
+| `HOMEBOY_PROJECT_EXEC_CMD` | Command prefix for running ecosystem binaries. |
+
+The helper exposes these generic functions:
+
+| Function | Purpose |
+| --- | --- |
+| `homeboy_project_init --ecosystem <id> --path <path>` | Select an ecosystem adapter and discover the project root. |
+| `homeboy_project_has_script <name>` | Return success when the named project script exists. |
+| `homeboy_project_run_script_command <name>` | Print the shell command prefix for the named script. |
+| `homeboy_project_run_script <name> [args...]` | Run a named project script from `HOMEBOY_PROJECT_ROOT`. |
+| `homeboy_project_exec_command <binary> [args...]` | Print the shell command prefix for an ecosystem binary. |
+| `homeboy_project_exec <binary> [args...]` | Run an ecosystem binary from `HOMEBOY_PROJECT_ROOT`. |
+| `homeboy_project_ensure_dependencies` | Install dependencies for runner snapshots when supported. |
+
+## Current Adapters
+
+The current adapter is `node` / `nodejs`. It finds the nearest `package.json` at
+or above the input path and selects the package manager from committed project
+signals in this order:
+
+1. `pnpm-lock.yaml` -> `pnpm`
+2. `yarn.lock` -> `yarn`
+3. otherwise -> `npm`
+
+Lockfiles are authoritative even when the corresponding executable is missing on
+the current host. That keeps discovery deterministic; execution then fails with a
+normal missing-tool error instead of silently running the wrong package manager.
+
+## Homeboy Core Seam
+
+This helper is the extension-owned implementation seam for a future Homeboy core
+runtime helper. A core contract can expose the same concepts without taking an
+ecosystem dependency:
+
+1. project root discovery result
+2. script manifest path
+3. package/tool runner command descriptors
+4. named-script existence checks
+5. dependency preparation hook
+
+Until that contract exists in Homeboy core, generic script execution belongs here
+so core primitives stay ecosystem-agnostic.

--- a/nodejs/scripts/lib/project-scripts.sh
+++ b/nodejs/scripts/lib/project-scripts.sh
@@ -68,11 +68,11 @@ homeboy_project_init_node() {
     HOMEBOY_PROJECT_ROOT="$_root"
     HOMEBOY_PROJECT_SCRIPT_FILE="${_root}/package.json"
 
-    if [ -f "$_root/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
+    if [ -f "$_root/pnpm-lock.yaml" ]; then
         HOMEBOY_PROJECT_PACKAGE_MANAGER="pnpm"
         HOMEBOY_PROJECT_RUN_CMD="pnpm run"
         HOMEBOY_PROJECT_EXEC_CMD="pnpm exec"
-    elif [ -f "$_root/yarn.lock" ] && command -v yarn >/dev/null 2>&1; then
+    elif [ -f "$_root/yarn.lock" ]; then
         HOMEBOY_PROJECT_PACKAGE_MANAGER="yarn"
         HOMEBOY_PROJECT_RUN_CMD="yarn"
         HOMEBOY_PROJECT_EXEC_CMD="yarn"

--- a/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
+++ b/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 NODE_HELPERS="${ROOT_DIR}/scripts/lib/node-helpers.sh"
 PROJECT_SCRIPTS="${ROOT_DIR}/scripts/lib/project-scripts.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 test -f "$NODE_HELPERS"
 test -f "$PROJECT_SCRIPTS"
@@ -15,3 +17,18 @@ bash -c '
     type homeboy_project_run_script_command >/dev/null
     type homeboy_require_package_json >/dev/null
 ' _ "$NODE_HELPERS"
+
+PNPM_PROJECT="$TMP_DIR/pnpm-project"
+mkdir -p "$PNPM_PROJECT/subdir"
+cat > "$PNPM_PROJECT/package.json" <<'EOF'
+{"name":"packaged-project-helper","scripts":{"test":"node --test"}}
+EOF
+touch "$PNPM_PROJECT/pnpm-lock.yaml"
+
+bash -c '
+    source "$1"
+    homeboy_project_init --ecosystem node --path "$2/subdir"
+    [ "$HOMEBOY_PROJECT_ROOT" = "$2" ]
+    [ "$HOMEBOY_PROJECT_PACKAGE_MANAGER" = "pnpm" ]
+    [ "$(homeboy_project_run_script_command test)" = "pnpm run test" ]
+' _ "$PROJECT_SCRIPTS" "$PNPM_PROJECT"

--- a/scripts/lib/project-scripts.sh
+++ b/scripts/lib/project-scripts.sh
@@ -68,11 +68,11 @@ homeboy_project_init_node() {
     HOMEBOY_PROJECT_ROOT="$_root"
     HOMEBOY_PROJECT_SCRIPT_FILE="${_root}/package.json"
 
-    if [ -f "$_root/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
+    if [ -f "$_root/pnpm-lock.yaml" ]; then
         HOMEBOY_PROJECT_PACKAGE_MANAGER="pnpm"
         HOMEBOY_PROJECT_RUN_CMD="pnpm run"
         HOMEBOY_PROJECT_EXEC_CMD="pnpm exec"
-    elif [ -f "$_root/yarn.lock" ] && command -v yarn >/dev/null 2>&1; then
+    elif [ -f "$_root/yarn.lock" ]; then
         HOMEBOY_PROJECT_PACKAGE_MANAGER="yarn"
         HOMEBOY_PROJECT_RUN_CMD="yarn"
         HOMEBOY_PROJECT_EXEC_CMD="yarn"

--- a/tests/runtime-helpers-smoke.sh
+++ b/tests/runtime-helpers-smoke.sh
@@ -313,6 +313,19 @@ bash -c '
     ! homeboy_project_has_script build
 ' _ "$PROJECT_SCRIPTS_HELPER" "$PROJECT_HELPER_NODE_PROJECT"
 
+PROJECT_HELPER_PNPM_PROJECT="$TMP_DIR/project-helper-pnpm"
+mkdir -p "$PROJECT_HELPER_PNPM_PROJECT"
+cat > "$PROJECT_HELPER_PNPM_PROJECT/package.json" <<'EOF'
+{"name":"project-helper-pnpm","scripts":{"test":"node --test"}}
+EOF
+touch "$PROJECT_HELPER_PNPM_PROJECT/pnpm-lock.yaml"
+bash -c '
+    source "$1"
+    homeboy_project_init --ecosystem node --path "$2"
+    [ "$HOMEBOY_PROJECT_PACKAGE_MANAGER" = "pnpm" ]
+    [ "$(homeboy_project_run_script_command test)" = "pnpm run test" ]
+' _ "$PROJECT_SCRIPTS_HELPER" "$PROJECT_HELPER_PNPM_PROJECT"
+
 set +e
 HOMEBOY_RUNTIME_FAILURE_TRAP="$FAILURE_TRAP_HELPER" \
 HOMEBOY_EXTENSION_PATH="$ROOT_DIR/nodejs" \


### PR DESCRIPTION
## Summary
- Document the extension-owned project script runtime helper contract and Homeboy core upstreaming seam.
- Make Node package-manager detection deterministic from project lockfiles instead of host tool availability.
- Cover pnpm lockfile selection in both shared and packaged Node helper smoke tests.

## Verification
- `HOMEBOY_CORE_DIR=/Users/chubes/Developer/homeboy@feature-generic-project-runner bash tests/runtime-helpers-smoke.sh`
- `bash nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh`
- `git diff --check`

## Upstreaming path
- No Homeboy core PR in this staged change. Core can later expose an ecosystem-neutral runtime helper contract around project root, script manifest, package/tool command descriptors, script existence checks, and dependency preparation hooks; the current extension helper documents that seam and keeps implementation out of core primitives.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, documentation, smoke coverage, and PR description for Chris to review and test.