### PR TITLE
Refactor WP Codebox recipe execution helper

### DIFF
--- a/wordpress/scripts/lib/wp-codebox-paths.sh
+++ b/wordpress/scripts/lib/wp-codebox-paths.sh
@@ -98,3 +98,50 @@ homeboy_wp_codebox_resolved_bin_path() {
 
     printf '%s\n' "$bin"
 }
+
+homeboy_wp_codebox_run_recipe() {
+    local recipe_file="$1"
+    local artifacts_dir="$2"
+    local output_file="$3"
+    local stderr_file="${4:-}"
+    local bin="${5:-${WP_CODEBOX_BIN:-}}"
+    local had_errexit=0
+    local status
+
+    if [ -z "$bin" ]; then
+        bin="$(homeboy_wp_codebox_resolve_bin "${HOMEBOY_SETTINGS_JSON:-}")" || return 1
+    fi
+    homeboy_wp_codebox_set_command "$bin"
+
+    case $- in
+        *e*) had_errexit=1 ;;
+    esac
+    set +e
+    if [ -n "$stderr_file" ]; then
+        "${HOMEBOY_WP_CODEBOX_COMMAND[@]}" recipe-run --recipe "$recipe_file" --artifacts "$artifacts_dir" --json > "$output_file" 2> "$stderr_file"
+    else
+        "${HOMEBOY_WP_CODEBOX_COMMAND[@]}" recipe-run --recipe "$recipe_file" --artifacts "$artifacts_dir" --json > "$output_file" 2>&1
+    fi
+    status=$?
+    if [ "$had_errexit" -eq 1 ]; then
+        set -e
+    fi
+
+    return "$status"
+}
+
+homeboy_wp_codebox_recipe_last_stdout() {
+    jq -r '(.executions // [])[-1].stdout // empty' "$1" 2>/dev/null
+}
+
+homeboy_wp_codebox_recipe_last_stderr() {
+    jq -r '(.executions // [])[-1].stderr // empty' "$1" 2>/dev/null
+}
+
+homeboy_wp_codebox_recipe_succeeded() {
+    jq -e '.success == true' "$1" >/dev/null 2>&1
+}
+
+homeboy_wp_codebox_recipe_artifact_directory() {
+    jq -r '.artifacts.directory // empty' "$1" 2>/dev/null
+}

--- a/wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh
@@ -36,14 +36,7 @@ ensure_core_dev_checkout() {
     fi
 }
 
-WP_CODEBOX_BIN="${HOMEBOY_WP_CODEBOX_BIN:-}"
-if [ -z "$WP_CODEBOX_BIN" ] && [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
-    WP_CODEBOX_BIN=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_bin // empty' 2>/dev/null || true)
-fi
-WP_CODEBOX_BIN="${WP_CODEBOX_BIN:-wp-codebox}"
-if [ "$WP_CODEBOX_BIN" = "wp-codebox" ] && ! command -v wp-codebox >/dev/null 2>&1; then
-    fail "wp-codebox not found; set HOMEBOY_WP_CODEBOX_BIN, settings wp_codebox_bin, or install wp-codebox"
-fi
+WP_CODEBOX_BIN="$(homeboy_wp_codebox_resolve_bin "${HOMEBOY_SETTINGS_JSON:-}")" || exit 1
 
 SELECTED_TEST_FILE="${HOMEBOY_WORDPRESS_CORE_PHPUNIT_TEST_FILE:-}"
 PASSTHROUGH_ARGS=()
@@ -144,12 +137,6 @@ echo "  Backend: wp-codebox"
 WP_CODEBOX_TMPFILE=$(mktemp)
 PHPUNIT_STDOUT_TMPFILE=$(mktemp)
 RECIPE_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-core-wp-codebox-test-recipe.XXXXXX")
-wp_codebox_command=("$WP_CODEBOX_BIN")
-case "$WP_CODEBOX_BIN" in
-    *.js)
-        wp_codebox_command=(node "$WP_CODEBOX_BIN")
-        ;;
-esac
 
 jq -n \
     --arg wp "$WP_CODEBOX_WORDPRESS_VERSION" \
@@ -175,11 +162,7 @@ jq -n \
     }' > "$RECIPE_FILE"
 
 set +e
-"${wp_codebox_command[@]}" recipe-run \
-    --recipe "$RECIPE_FILE" \
-    --artifacts "$ARTIFACTS_DIR" \
-    --json \
-    > "$WP_CODEBOX_TMPFILE" 2>&1
+homeboy_wp_codebox_run_recipe "$RECIPE_FILE" "$ARTIFACTS_DIR" "$WP_CODEBOX_TMPFILE" "" "$WP_CODEBOX_BIN"
 wp_codebox_exit=$?
 set -e
 
@@ -187,14 +170,14 @@ rm -f "$RECIPE_FILE"
 
 WP_CODEBOX_OUTPUT=$(cat "$WP_CODEBOX_TMPFILE")
 if [ -n "$WP_CODEBOX_OUTPUT" ]; then
-    jq -r '(.executions // [])[-1].stdout // empty' "$WP_CODEBOX_TMPFILE" 2>/dev/null || cat "$WP_CODEBOX_TMPFILE"
+    homeboy_wp_codebox_recipe_last_stdout "$WP_CODEBOX_TMPFILE" || cat "$WP_CODEBOX_TMPFILE"
 fi
 
 PHPUNIT_OUTPUT=""
 if [ -f "$RESULT_FILE" ]; then
     PHPUNIT_OUTPUT=$(cat "$RESULT_FILE")
 fi
-PHPUNIT_STDOUT=$(jq -r '(.executions // [])[-1].stdout // empty' "$WP_CODEBOX_TMPFILE" 2>/dev/null || true)
+PHPUNIT_STDOUT=$(homeboy_wp_codebox_recipe_last_stdout "$WP_CODEBOX_TMPFILE" || true)
 printf '%s\n' "$PHPUNIT_STDOUT" > "$PHPUNIT_STDOUT_TMPFILE"
 
 PARSE_RESULTS="${EXTENSION_PATH}/scripts/test/parse-test-results.sh"

--- a/wordpress/scripts/test/wp-codebox-recipe-helper-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-recipe-helper-smoke.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WP_CODEBOX_HELPER="${SCRIPT_DIR}/../lib/wp-codebox-paths.sh"
+
+# shellcheck source=../lib/wp-codebox-paths.sh
+source "$WP_CODEBOX_HELPER"
+
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-wp-codebox-recipe-helper.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+fake_wp_codebox="${fixture}/wp-codebox.cjs"
+recipe_file="${fixture}/recipe.json"
+artifacts_dir="${fixture}/artifacts"
+output_file="${fixture}/recipe-output.json"
+stderr_file="${fixture}/recipe-stderr.txt"
+capture_file="${fixture}/capture.txt"
+mkdir -p "$artifacts_dir"
+
+cat > "$fake_wp_codebox" <<'NODE'
+#!/usr/bin/env node
+const fs = require('node:fs');
+
+fs.writeFileSync(process.env.FAKE_WP_CODEBOX_CAPTURE, process.argv.slice(2).join('\n') + '\n');
+process.stdout.write(JSON.stringify({
+  success: true,
+  executions: [{ stdout: 'helper stdout\n', stderr: 'helper stderr\n' }],
+  artifacts: { directory: process.argv[process.argv.indexOf('--artifacts') + 1] },
+}, null, 2));
+NODE
+chmod +x "$fake_wp_codebox"
+
+printf '{"schema":"wp-codebox/workspace-recipe/v1","workflow":{"steps":[]}}\n' > "$recipe_file"
+
+FAKE_WP_CODEBOX_CAPTURE="$capture_file" \
+    homeboy_wp_codebox_run_recipe "$recipe_file" "$artifacts_dir" "$output_file" "$stderr_file" "$fake_wp_codebox"
+
+if ! grep -Fxq 'recipe-run' "$capture_file"; then
+    echo "Expected helper to invoke wp-codebox recipe-run" >&2
+    exit 1
+fi
+
+if [ "$(homeboy_wp_codebox_recipe_last_stdout "$output_file")" != "helper stdout" ]; then
+    echo "Expected helper to extract last execution stdout" >&2
+    exit 1
+fi
+
+if [ "$(homeboy_wp_codebox_recipe_last_stderr "$output_file")" != "helper stderr" ]; then
+    echo "Expected helper to extract last execution stderr" >&2
+    exit 1
+fi
+
+if ! homeboy_wp_codebox_recipe_succeeded "$output_file"; then
+    echo "Expected helper to report successful recipe result" >&2
+    exit 1
+fi
+
+if [ "$(homeboy_wp_codebox_recipe_artifact_directory "$output_file")" != "$artifacts_dir" ]; then
+    echo "Expected helper to extract artifact directory" >&2
+    exit 1
+fi
+
+echo "WP Codebox recipe helper smoke passed."

--- a/wordpress/scripts/trace/trace-runner.sh
+++ b/wordpress/scripts/trace/trace-runner.sh
@@ -68,19 +68,7 @@ homeboy_wordpress_export_context() {
 }
 
 homeboy_wordpress_resolve_wp_codebox_bin() {
-    local bin="${HOMEBOY_WP_CODEBOX_BIN:-}"
-
-    if [ -z "$bin" ] && [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
-        bin=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_bin // empty' 2>/dev/null || true)
-    fi
-
-    bin="${bin:-wp-codebox}"
-    if [ "$bin" = "wp-codebox" ] && ! command -v wp-codebox >/dev/null 2>&1; then
-        echo "Error: wp-codebox not found; set HOMEBOY_WP_CODEBOX_BIN, settings wp_codebox_bin, or install wp-codebox." >&2
-        return 1
-    fi
-
-    printf '%s\n' "$bin"
+    homeboy_wp_codebox_resolve_bin "${HOMEBOY_SETTINGS_JSON:-}"
 }
 
 homeboy_wordpress_trace_wp_version() {
@@ -195,24 +183,17 @@ homeboy_trace_run_php_scenario_wp_codebox() {
             workflow: {steps: [{command: "wordpress.run-php", args: ["code-file=" + $codeFile]}]}
         }' > "$recipe_file"
 
-    wp_codebox_command=("$codebox_bin")
-    case "$codebox_bin" in
-        *.js|*.cjs)
-            wp_codebox_command=(node "$codebox_bin")
-            ;;
-    esac
-
     set +e
-    "${wp_codebox_command[@]}" recipe-run --recipe "$recipe_file" --artifacts "$codebox_artifacts_dir" --json > "$output_file" 2>"$stderr_file"
+    homeboy_wp_codebox_run_recipe "$recipe_file" "$codebox_artifacts_dir" "$output_file" "$stderr_file" "$codebox_bin"
     status=$?
     set -e
 
-    jq -r '(.executions // [])[-1].stdout // empty' "$output_file" > "$stdout_file" 2>/dev/null || true
+    homeboy_wp_codebox_recipe_last_stdout "$output_file" > "$stdout_file" || true
     if [ ! -s "$stderr_file" ]; then
-        jq -r '(.executions // [])[-1].stderr // empty' "$output_file" > "$stderr_file" 2>/dev/null || true
+        homeboy_wp_codebox_recipe_last_stderr "$output_file" > "$stderr_file" || true
     fi
 
-    if [ "$status" -eq 0 ] && ! jq -e '.success == true' "$output_file" >/dev/null 2>&1; then
+    if [ "$status" -eq 0 ] && ! homeboy_wp_codebox_recipe_succeeded "$output_file"; then
         status=1
     fi
 


### PR DESCRIPTION
## Summary
- Add reusable WP Codebox helper functions for recipe execution and recipe-run JSON extraction.
- Reuse the shared helper in the WordPress trace runner and core-dev WP Codebox test runner.
- Add a focused smoke test covering command wrapping, recipe-run invocation, and result extraction.

## Verification
- `bash wordpress/scripts/test/wp-codebox-recipe-helper-smoke.sh`
- `bash wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `HOMEBOY_RUNTIME_RESOLVE_CONTEXT=<installed resolve-context helper> bash wordpress/scripts/trace/trace-runner-smoke.sh`
- `bash -n wordpress/scripts/lib/wp-codebox-paths.sh wordpress/scripts/trace/trace-runner.sh wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh wordpress/scripts/test/wp-codebox-recipe-helper-smoke.sh`

Not run:
- Benchmarks, per request.
- `shellcheck`, not installed in this environment.

Known unrelated local smoke issue:
- `wordpress/scripts/test/test-runner-file-routing-smoke.sh` fails on an existing host-smoke routing expectation before exercising these changes.
- `wordpress/scripts/test/core-dev-shape-smoke.sh` fails on an existing core-dev routing expectation in `test-runner.sh` before reaching the migrated core-dev runner path.

## Follow-up callers
- `wordpress/scripts/test/test-runner-wp-codebox.sh`
- `wordpress/scripts/bench/bench-runner-wp-codebox.sh`
- `wordpress/scripts/test/test-runner-host-smoke-wp.sh`
- `wordpress/scripts/agent/run-datamachine-agent.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5
- **Used for:** Implemented the shared WP Codebox helper, migrated the initial callers, added the focused smoke test, and ran verification commands under Chris's direction.
