### PR TITLE
Preserve WP Codebox typed bundle outputs

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -1737,16 +1737,38 @@ function typedArtifactsFromResult(result) {
     result.metadata?.agent_runtime?.result?.typedArtifacts,
     result.metadata?.agent_runtime?.result?.outputs?.typed_artifacts,
     result.metadata?.agent_runtime?.result?.outputs?.typedArtifacts,
+    result.metadata?.agent_runtime?.result?.outputs?.outputs?.typed_artifacts,
+    result.metadata?.agent_runtime?.result?.outputs?.outputs?.typedArtifacts,
     workload.typed_artifacts,
     workload.typedArtifacts,
     workload.outputs?.typed_artifacts,
     workload.outputs?.typedArtifacts,
+    workload.outputs?.outputs?.typed_artifacts,
+    workload.outputs?.outputs?.typedArtifacts,
     ...scenarios.map((scenario) => scenario?.typed_artifacts),
     ...scenarios.map((scenario) => scenario?.typedArtifacts),
+    ...scenarios.map((scenario) => scenario?.outputs?.typed_artifacts),
+    ...scenarios.map((scenario) => scenario?.outputs?.typedArtifacts),
+    ...scenarios.map((scenario) => scenario?.metadata?.outputs?.typed_artifacts),
+    ...scenarios.map((scenario) => scenario?.metadata?.outputs?.typedArtifacts),
     ...scenarios.map((scenario) => scenario?.metadata?.typed_artifacts),
     ...scenarios.map((scenario) => scenario?.metadata?.typedArtifacts),
   ];
   return Object.assign({}, ...candidates.map(normalizeTypedArtifacts));
+}
+
+function typedArtifactProjectionFromOutputPath(outputPath, value, typedArtifacts) {
+  const match = String(outputPath || '').match(/(?:^|\.)typed_?artifacts\.([^.]+)\.payload$/i);
+  if (!match) {
+    return null;
+  }
+  const artifactName = match[1];
+  const existing = typedArtifacts[artifactName] || {};
+  return normalizeTypedArtifactEntry(artifactName, {
+    ...existing,
+    name: existing.name || artifactName,
+    payload: value,
+  });
 }
 
 function typedArtifactFileRefs(typedArtifact) {
@@ -1872,6 +1894,8 @@ function normalizeOutputs(result) {
   const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
   const configuredOutputSources = [
     ...scenarios,
+    ...scenarios.map((scenario) => scenario?.metadata),
+    ...scenarios.map((scenario) => scenario?.outputs),
     result.run?.agentResult,
     result.agentResult,
     result.agent_result,
@@ -1891,6 +1915,10 @@ function normalizeOutputs(result) {
       const value = pathValue(source, outputPath);
       if (value !== undefined && value !== null && value !== '') {
         outputs[name] = value;
+        const typedArtifact = typedArtifactProjectionFromOutputPath(outputPath, value, typedArtifacts);
+        if (typedArtifact) {
+          typedArtifacts[typedArtifact.name] = typedArtifact;
+        }
         break;
       }
     }

--- a/wordpress/scripts/agent/run-datamachine-agent-task.cjs
+++ b/wordpress/scripts/agent/run-datamachine-agent-task.cjs
@@ -12,7 +12,7 @@ const { spawnSync } = require('node:child_process');
 
 const SCRIPT_DIR = __dirname;
 const EXTENSION_PATH = path.resolve(SCRIPT_DIR, '..', '..');
-const EXECUTOR = path.join(SCRIPT_DIR, 'homeboy-codebox-agent-task-executor.cjs');
+const EXECUTOR = path.resolve(SCRIPT_DIR, '..', '..', '..', 'agent-runtimes', 'wp-codebox', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs');
 
 function readConfigPath() {
   const configPath = process.argv[2] || process.env.HOMEBOY_DATAMACHINE_AGENT_CONFIG_PATH || '';

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1781,6 +1781,93 @@ assert.equal(canonicalTopLevelAgentBundleOutcome.outputs.static_site_pr_url, 'ht
 assert.equal(canonicalTopLevelAgentBundleOutcome.outputs.static_site_slug, 'issue-451-design-direction');
 assert.equal(canonicalTopLevelAgentBundleOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/453'), true);
 
+const projectedTypedArtifactBundleOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  task_id: 'projected-typed-artifact-bundle-task-123',
+  artifact_declarations: [{
+    schema: 'wp-codebox/artifact-declaration/v1',
+    name: 'static_site_candidate',
+    type: 'StaticSiteCandidate',
+    artifact_schema: 'static-site-importer/static-site-candidate/v1',
+    required: true,
+  }],
+  executor: { backend: 'codebox' },
+}, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  artifacts: '/tmp/wp-codebox-artifacts',
+  metadata: {
+    agent_runtime: {
+      bundle: {
+        engine_data_outputs: {
+          static_site_candidate: 'outputs.typed_artifacts.static_site_candidate.payload',
+        },
+      },
+      workload: {
+        scenarios: [{
+          id: 'agent-bundle',
+          metadata: {
+            schema: 'datamachine/agent-bundle-run/v1',
+            outputs: {
+              typed_artifacts: {
+                static_site_candidate: {
+                  schema: 'homeboy/agent-task-typed-artifact/v1',
+                  type: 'StaticSiteCandidate',
+                  artifact_schema: 'static-site-importer/static-site-candidate/v1',
+                  payload: { slug: 'projected-candidate', import_ready: true },
+                  provenance: { bundle_slug: 'static-site-agent' },
+                  file_refs: [{ path: '/tmp/wp-codebox-artifacts/projected-candidate.json', mime: 'application/json' }],
+                },
+              },
+            },
+          },
+        }],
+      },
+    },
+  },
+});
+assert.equal(projectedTypedArtifactBundleOutcome.status, 'succeeded');
+assert.equal(projectedTypedArtifactBundleOutcome.outputs.static_site_candidate.import_ready, true);
+assert.equal(projectedTypedArtifactBundleOutcome.outputs.typed_artifacts.static_site_candidate.type, 'StaticSiteCandidate');
+assert.equal(projectedTypedArtifactBundleOutcome.outputs.typed_artifacts.static_site_candidate.payload.slug, 'projected-candidate');
+assert.equal(projectedTypedArtifactBundleOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.required_typed_artifacts_missing'), false);
+assert.equal(projectedTypedArtifactBundleOutcome.artifacts.some((artifact) => artifact.kind === 'typed-bundle-output' && artifact.path === '/tmp/wp-codebox-artifacts/projected-candidate.json'), true);
+
+const failedProjectedTypedArtifactBundleOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  task_id: 'failed-projected-typed-artifact-bundle-task-123',
+  executor: { backend: 'codebox' },
+}, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  outputs: {
+    agent_runtime: {
+      success: false,
+      result: {
+        success: false,
+        error_reason: 'empty_data_packet_returned',
+        error_message: 'Data Machine bundle returned an empty data packet.',
+        terminal_status: 'failed - empty_data_packet_returned',
+        outputs: {
+          typed_artifacts: {
+            failure_report: {
+              type: 'FailureReport',
+              artifact_schema: 'example/failure-report/v1',
+              payload: { reason: 'empty_data_packet_returned' },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+assert.equal(failedProjectedTypedArtifactBundleOutcome.status, 'failed');
+assert.equal(failedProjectedTypedArtifactBundleOutcome.diagnostics[0].class, 'agent_runtime.failed');
+assert.equal(failedProjectedTypedArtifactBundleOutcome.diagnostics[0].data.reason, 'empty_data_packet_returned');
+assert.equal(failedProjectedTypedArtifactBundleOutcome.outputs.typed_artifacts.failure_report.payload.reason, 'empty_data_packet_returned');
+assert.equal(failedProjectedTypedArtifactBundleOutcome.metadata.typed_artifacts.failure_report.artifact_schema, 'example/failure-report/v1');
+
 const singleResultAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
   task_id: 'single-result-agent-bundle-task-123',


### PR DESCRIPTION
## Summary
- Preserve Data Machine bundle-run typed artifacts from projected result shapes, including scenario metadata and nested output projections.
- Rebuild typed artifact envelopes when configured outputs map to `outputs.typed_artifacts.<name>.payload`, so required typed artifact diagnostics use the canonical `outputs.typed_artifacts` metadata.
- Fix the Data Machine agent task runner's WP Codebox executor path so its bridge smoke test invokes the packaged executor.

## Tests
- `node wordpress/tests/codebox-agent-task-executor-smoke.js` - passed
- `node wordpress/tests/datamachine-agent-task-runner-smoke.js` - passed
- `node wordpress/tests/wp-codebox-task-runner-smoke.js` - passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented typed bundle output bridge hardening and focused coverage; Chris remains responsible for review and testing.