### PR TITLE
Add browser bench result helper

### DIFF
--- a/docs/browser-result-shapes.md
+++ b/docs/browser-result-shapes.md
@@ -24,6 +24,11 @@ preload attribution, and route grouping remain in `wordpress`.
   `phase`, `message`, and optional `data`.
 - `normalizeTraceEvent()`, `normalizeTraceAssertion()`, and
   `normalizeTraceEnvelope()` describe generic trace timelines and assertions.
+- `buildBenchResultsEnvelope()` and `buildBenchScenarioResult()` emit the
+  parseable `homeboy/bench-results/v1` envelope and scenario shape.
+- `buildBrowserBenchResult()` emits the `{ metrics, artifacts, metadata }`
+  workload result shape used by browser evidence producers, with browser
+  artifacts normalized to Homeboy core artifact fields.
 
 ## Shape Boundary
 

--- a/nodejs/docs/browser-bench-helpers.md
+++ b/nodejs/docs/browser-bench-helpers.md
@@ -4,10 +4,10 @@ Browser benchmark workloads can import the helper path exported by
 `HOMEBOY_NODEJS_BROWSER_BENCH_HELPER`.
 
 ```js
-const { runBrowserPageScenario } = await import(process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER);
+const { buildBrowserBenchResult, runBrowserPageScenario } = await import(process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER);
 
 export default async function () {
-  return runBrowserPageScenario({
+  const browserResult = await runBrowserPageScenario({
     id: 'homepage',
     target: 'https://example.test/',
     assertions: [
@@ -20,6 +20,11 @@ export default async function () {
       await mark('heading_visible');
     },
   });
+
+  return buildBrowserBenchResult({
+    browserResult,
+    metrics: { success_rate: 1 },
+  });
 }
 ```
 
@@ -27,6 +32,10 @@ export default async function () {
 without changing that API. It opens the target page, runs workload actions,
 checks page and artifact assertions, writes a stable raw result artifact, and
 returns `{ metrics, artifacts }` for the Homeboy bench runner.
+
+`buildBrowserBenchResult()` composes those browser metrics and artifacts with
+workload-owned fields while preserving the Homeboy core `BenchScenario` result
+shape.
 
 ## Public Artifact Links
 

--- a/nodejs/scripts/bench/browser-helper.mjs
+++ b/nodejs/scripts/bench/browser-helper.mjs
@@ -5,10 +5,13 @@ import { pathToFileURL } from 'node:url';
 import { performance } from 'node:perf_hooks';
 import {
     collectBrowserPhases,
+    buildBrowserBenchResult,
     normalizeBrowserArtifact,
     normalizeBrowserBottleneck,
     normalizeBrowserPerformanceProfile,
 } from '../../../scripts/lib/browser-result-shapes.mjs';
+
+export { buildBrowserBenchResult };
 
 const DEFAULT_NETWORK_IDLE_TIMEOUT_MS = 5000;
 const BROWSER_PERFORMANCE_STATE = new WeakMap();

--- a/scripts/lib/browser-result-shapes.cjs
+++ b/scripts/lib/browser-result-shapes.cjs
@@ -1,6 +1,8 @@
 'use strict';
 
 const BROWSER_RESULT_SCHEMA_VERSION = 1;
+const HOMEBOY_BENCH_RESULTS_SCHEMA = 'homeboy/bench-results/v1';
+const HOMEBOY_BROWSER_EVIDENCE_SCHEMA = 'homeboy/browser-evidence/v1';
 
 const VALID_TRACE_ASSERTION_STATUSES = new Set(['pass', 'fail', 'skip', 'unknown']);
 const VALID_TRACE_ENVELOPE_STATUSES = new Set(['pass', 'fail', 'error', 'skip', 'unknown']);
@@ -230,6 +232,134 @@ function normalizeTraceEnvelope(envelope) {
 	return stableJson(normalized);
 }
 
+function buildBenchResultsEnvelope({ componentId, iterations = 1, scenarios = [] } = {}) {
+	const normalizedComponentId = stringValue(componentId);
+	if (!normalizedComponentId) throw new Error('buildBenchResultsEnvelope requires componentId.');
+	return stableJson({
+		schema: HOMEBOY_BENCH_RESULTS_SCHEMA,
+		component_id: normalizedComponentId,
+		iterations: positiveInteger(iterations, 1),
+		scenarios: Array.isArray(scenarios) ? scenarios.map(buildBenchScenarioResult) : [],
+	});
+}
+
+function buildBenchScenarioResult(input = {}) {
+	const source = input && typeof input === 'object' && !Array.isArray(input) ? input : {};
+	const id = stringValue(source.id ?? source.scenario_id ?? source.scenarioId);
+	if (!id) throw new Error('buildBenchScenarioResult requires id.');
+
+	const scenario = {
+		id,
+		iterations: positiveInteger(source.iterations, 1),
+		metrics: normalizeBenchMetrics(source.metrics),
+	};
+	copyOptionalString(scenario, 'file', source.file);
+	copyOptionalString(scenario, 'source', source.source);
+	copyOptionalInteger(scenario, 'default_iterations', source.default_iterations ?? source.defaultIterations);
+	copyOptionalArray(scenario, 'tags', source.tags);
+	copyOptionalObject(scenario, 'metric_groups', source.metric_groups ?? source.metricGroups);
+	copyOptionalArray(scenario, 'timeline', source.timeline);
+	copyOptionalArray(scenario, 'span_definitions', source.span_definitions ?? source.spanDefinitions);
+	copyOptionalArray(scenario, 'span_results', source.span_results ?? source.spanResults);
+	copyOptionalArray(scenario, 'gates', source.gates);
+	copyOptionalArray(scenario, 'gate_results', source.gate_results ?? source.gateResults);
+	copyOptionalObject(scenario, 'metadata', source.metadata);
+	copyOptionalObject(scenario, 'provenance', source.provenance);
+	if (source.passed !== undefined) scenario.passed = Boolean(source.passed);
+	copyOptionalObject(scenario, 'memory', source.memory);
+	const artifacts = normalizeBenchArtifacts(source.artifacts);
+	if (Object.keys(artifacts).length > 0) scenario.artifacts = artifacts;
+	copyOptionalArray(scenario, 'diagnostics', source.diagnostics);
+	copyOptionalArray(scenario, 'runs', source.runs);
+	copyOptionalObject(scenario, 'runs_summary', source.runs_summary ?? source.runsSummary);
+	return stableJson(scenario);
+}
+
+function buildBrowserBenchResult(input = {}) {
+	const source = input && typeof input === 'object' && !Array.isArray(input) ? input : {};
+	const browserResult = source.browserResult && typeof source.browserResult === 'object' && !Array.isArray(source.browserResult) ? source.browserResult : {};
+	const metrics = normalizeBenchMetrics({
+		...(browserResult.metrics || {}),
+		...(source.browserMetrics || {}),
+		...(source.metrics || {}),
+	});
+	const artifacts = normalizeBenchArtifacts({
+		...(browserResult.artifacts || {}),
+		...(source.browserArtifacts || {}),
+		...(source.rawResultArtifact ? { raw_result: source.rawResultArtifact } : {}),
+		...(source.artifacts || {}),
+	});
+	const metadata = stableJson({
+		browser_evidence_schema: HOMEBOY_BROWSER_EVIDENCE_SCHEMA,
+		...(source.metadata || {}),
+	});
+
+	return stableJson({
+		metrics,
+		...(Object.keys(artifacts).length > 0 ? { artifacts } : {}),
+		...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+	});
+}
+
+function normalizeBenchMetrics(metrics = {}) {
+	if (!metrics || typeof metrics !== 'object' || Array.isArray(metrics)) return {};
+	const normalized = {};
+	for (const [key, value] of Object.entries(metrics).sort(([a], [b]) => a.localeCompare(b))) {
+		if (typeof value === 'number' && Number.isFinite(value)) normalized[key] = roundNumber(value);
+	}
+	return normalized;
+}
+
+function normalizeBenchArtifacts(artifacts = {}) {
+	if (!artifacts || typeof artifacts !== 'object' || Array.isArray(artifacts)) return {};
+	const normalized = {};
+	for (const [key, artifact] of Object.entries(artifacts).sort(([a], [b]) => a.localeCompare(b))) {
+		const descriptor = normalizeBenchArtifact(artifact);
+		if (Object.keys(descriptor).length > 0) normalized[key] = descriptor;
+	}
+	return normalized;
+}
+
+function normalizeBenchArtifact(artifact) {
+	if (typeof artifact === 'string' && artifact.trim()) return { path: artifact.trim() };
+	if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) return {};
+	const normalized = {};
+	for (const key of ['path', 'url', 'type', 'kind', 'label', 'observation_artifact_id', 'role', 'preview_url', 'public_url', 'viewer_url', 'local_url', 'status']) {
+		copyOptionalString(normalized, key, artifact[key]);
+	}
+	for (const key of ['viewer', 'browser_origin_evidence', 'service_lifecycle']) {
+		copyOptionalObject(normalized, key, artifact[key]);
+	}
+	copyOptionalArray(normalized, 'viewer_links', artifact.viewer_links ?? artifact.viewerLinks);
+	copyOptionalString(normalized, 'expires_at', artifact.expires_at ?? artifact.expiresAt);
+	copyOptionalString(normalized, 'cleanup_status', artifact.cleanup_status ?? artifact.cleanupStatus);
+	return stableJson(normalized);
+}
+
+function copyOptionalString(target, key, value) {
+	if (typeof value === 'string' && value.trim() !== '') target[key] = value.trim();
+}
+
+function copyOptionalInteger(target, key, value) {
+	const number = Number(value);
+	if (Number.isInteger(number) && number >= 0) target[key] = number;
+}
+
+function copyOptionalArray(target, key, value) {
+	if (Array.isArray(value) && value.length > 0) target[key] = value.map(stableJson);
+}
+
+function copyOptionalObject(target, key, value) {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return;
+	const normalized = stableJson(value);
+	if (Object.keys(normalized).length > 0) target[key] = normalized;
+}
+
+function positiveInteger(value, fallback) {
+	const number = Number(value);
+	return Number.isInteger(number) && number > 0 ? number : fallback;
+}
+
 function normalizePhaseMap(phases, phaseMarks) {
 	if (!phases || typeof phases !== 'object' || Array.isArray(phases)) {
 		return collectBrowserPhases(phaseMarks);
@@ -358,6 +488,11 @@ function stableJson(value) {
 
 module.exports = {
 	BROWSER_RESULT_SCHEMA_VERSION,
+	HOMEBOY_BENCH_RESULTS_SCHEMA,
+	HOMEBOY_BROWSER_EVIDENCE_SCHEMA,
+	buildBenchResultsEnvelope,
+	buildBenchScenarioResult,
+	buildBrowserBenchResult,
 	collectBrowserPhases,
 	normalizeBrowserArtifact,
 	normalizeBrowserBottleneck,

--- a/scripts/lib/browser-result-shapes.mjs
+++ b/scripts/lib/browser-result-shapes.mjs
@@ -5,6 +5,11 @@ const shapes = require('./browser-result-shapes.cjs');
 
 export const {
     BROWSER_RESULT_SCHEMA_VERSION,
+    HOMEBOY_BENCH_RESULTS_SCHEMA,
+    HOMEBOY_BROWSER_EVIDENCE_SCHEMA,
+    buildBenchResultsEnvelope,
+    buildBenchScenarioResult,
+    buildBrowserBenchResult,
     collectBrowserPhases,
     normalizeBrowserArtifact,
     normalizeBrowserBottleneck,

--- a/tests/browser-result-shapes-smoke.mjs
+++ b/tests/browser-result-shapes-smoke.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    HOMEBOY_BENCH_RESULTS_SCHEMA,
+    HOMEBOY_BROWSER_EVIDENCE_SCHEMA,
+    buildBenchResultsEnvelope,
+    buildBrowserBenchResult,
+} from '../scripts/lib/browser-result-shapes.mjs';
+
+test('buildBenchResultsEnvelope emits Homeboy core schema shape', () => {
+    const envelope = buildBenchResultsEnvelope({
+        componentId: 'example-component',
+        iterations: 2,
+        scenarios: [
+            {
+                id: 'browser-homepage',
+                metrics: { p95_ms: 123.4567, ignored: Number.NaN },
+                artifacts: { report: { path: 'report.md', kind: 'markdown', extra: 'dropped' } },
+            },
+        ],
+    });
+
+    assert.equal(envelope.schema, HOMEBOY_BENCH_RESULTS_SCHEMA);
+    assert.equal(envelope.component_id, 'example-component');
+    assert.equal(envelope.iterations, 2);
+    assert.deepEqual(envelope.scenarios[0], {
+        id: 'browser-homepage',
+        iterations: 1,
+        metrics: { p95_ms: 123.457 },
+        artifacts: { report: { kind: 'markdown', path: 'report.md' } },
+    });
+});
+
+test('buildBrowserBenchResult composes browser evidence workload result', () => {
+    const result = buildBrowserBenchResult({
+        browserResult: {
+            metrics: { browser_request_count: 4, browser_load_ms: 98.7654 },
+            artifacts: { trace: { path: 'trace.zip', kind: 'playwright-trace' } },
+        },
+        metrics: { success_rate: 1, skipped: Infinity },
+        rawResultArtifact: { path: 'raw-result.json', kind: 'json', label: 'Raw result' },
+        artifacts: { screenshot: 'screenshot.png' },
+        metadata: { route: '/wp-admin/' },
+    });
+
+    assert.deepEqual(result.metrics, {
+        browser_load_ms: 98.765,
+        browser_request_count: 4,
+        success_rate: 1,
+    });
+    assert.deepEqual(result.artifacts, {
+        raw_result: { kind: 'json', label: 'Raw result', path: 'raw-result.json' },
+        screenshot: { path: 'screenshot.png' },
+        trace: { kind: 'playwright-trace', path: 'trace.zip' },
+    });
+    assert.deepEqual(result.metadata, {
+        browser_evidence_schema: HOMEBOY_BROWSER_EVIDENCE_SCHEMA,
+        route: '/wp-admin/',
+    });
+});


### PR DESCRIPTION
## Summary
- Add shared JS helpers for Homeboy bench result envelopes and browser evidence-shaped workload results.
- Re-export the browser workload composer from the existing Node browser bench helper path.
- Document the helper and add a focused smoke test for schema, metric, and artifact normalization.

## Verification
- `node --check scripts/lib/browser-result-shapes.cjs`
- `node --check scripts/lib/browser-result-shapes.mjs`
- `node --check nodejs/scripts/bench/browser-helper.mjs`
- `node tests/browser-result-shapes-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the helper implementation, smoke test, docs updates, and local static verification; Chris remains responsible for review and merge.