### PR TITLE
fix(wp-codebox): declare Codex credential sources

### DIFF
--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -71,7 +71,11 @@
         {
           "schema": "homeboy/secret-env-requirement/v1",
           "source": "provider_default",
-          "env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"],
+          "env": [
+            "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN",
+            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN",
+            "AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT"
+          ],
           "when": {
             "any": [
               { "path": "executor.config.provider", "equals": "claude-code" },
@@ -229,7 +233,31 @@
           }
         },
         "claude-code": {
-          "secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"]
+          "secret_env": [
+            "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN",
+            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN",
+            "AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT"
+          ],
+          "secret_env_sources": {
+            "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN": {
+              "source": "keychain-bundle",
+              "scope": "agent-task",
+              "name": "claude-code-oauth",
+              "field": "access_token"
+            },
+            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN": {
+              "source": "keychain-bundle",
+              "scope": "agent-task",
+              "name": "claude-code-oauth",
+              "field": "refresh_token"
+            },
+            "AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT": {
+              "source": "keychain-bundle",
+              "scope": "agent-task",
+              "name": "claude-code-oauth",
+              "field": "expires_at"
+            }
+          }
         }
       },
       "role_aliases": {

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -199,7 +199,34 @@
             "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT",
             "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID",
             "AI_PROVIDER_OPENAI_CODEX_FEDRAMP"
-          ]
+          ],
+          "secret_env_sources": {
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN": {
+              "source": "json-file",
+              "path": "~/.codex/auth.json",
+              "field": "tokens.access_token"
+            },
+            "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN": {
+              "source": "json-file",
+              "path": "~/.codex/auth.json",
+              "field": "tokens.refresh_token"
+            },
+            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT": {
+              "source": "json-file",
+              "path": "~/.codex/auth.json",
+              "field": "tokens.expires_at"
+            },
+            "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID": {
+              "source": "json-file",
+              "path": "~/.codex/auth.json",
+              "field": "tokens.account_id"
+            },
+            "AI_PROVIDER_OPENAI_CODEX_FEDRAMP": {
+              "source": "json-file",
+              "path": "~/.codex/auth.json",
+              "field": "tokens.fedramp"
+            }
+          }
         },
         "claude-code": {
           "secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"]

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -51,6 +51,11 @@ assert.deepEqual(provider.provider_defaults.codex.secret_env, [
   'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
   'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
 ]);
+assert.deepEqual(provider.provider_defaults.codex.secret_env_sources.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN, {
+  source: 'json-file',
+  path: '~/.codex/auth.json',
+  field: 'tokens.access_token',
+});
 assert.deepEqual(provider.provider_defaults['claude-code'].secret_env, [
   'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN',
 ]);

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -18,6 +18,11 @@ const codexSecretEnv = [
   'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
   'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
 ];
+const claudeCodeSecretEnv = [
+  'AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN',
+  'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN',
+  'AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT',
+];
 
 function secretEnvRequirementForProvider(contract, provider) {
   return contract.secret_env_requirements.find((requirement) => (
@@ -56,9 +61,13 @@ assert.deepEqual(provider.provider_defaults.codex.secret_env_sources.AI_PROVIDER
   path: '~/.codex/auth.json',
   field: 'tokens.access_token',
 });
-assert.deepEqual(provider.provider_defaults['claude-code'].secret_env, [
-  'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN',
-]);
+assert.deepEqual(provider.provider_defaults['claude-code'].secret_env, claudeCodeSecretEnv);
+assert.deepEqual(provider.provider_defaults['claude-code'].secret_env_sources.AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN, {
+  source: 'keychain-bundle',
+  scope: 'agent-task',
+  name: 'claude-code-oauth',
+  field: 'refresh_token',
+});
 assert.deepEqual(provider.workspace_tools.readonly, [
   'workspace_ls',
   'workspace_read',

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -262,6 +262,33 @@ const request = {
 };
 
 const provider = providerContract();
+const codexSecretEnvSources = {
+  AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: {
+    source: 'json-file',
+    path: '~/.codex/auth.json',
+    field: 'tokens.access_token',
+  },
+  AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: {
+    source: 'json-file',
+    path: '~/.codex/auth.json',
+    field: 'tokens.refresh_token',
+  },
+  AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: {
+    source: 'json-file',
+    path: '~/.codex/auth.json',
+    field: 'tokens.expires_at',
+  },
+  AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: {
+    source: 'json-file',
+    path: '~/.codex/auth.json',
+    field: 'tokens.account_id',
+  },
+  AI_PROVIDER_OPENAI_CODEX_FEDRAMP: {
+    source: 'json-file',
+    path: '~/.codex/auth.json',
+    field: 'tokens.fedramp',
+  },
+};
 assert.equal(provider.id, 'wordpress.codebox-agent-task-executor');
 assert.equal(provider.label, 'WP Codebox agent task executor');
 assert.equal(provider.backend, 'codebox');
@@ -295,6 +322,7 @@ assert.deepEqual(provider.provider_defaults, {
       'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
       'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
     ],
+    secret_env_sources: codexSecretEnvSources,
   },
   'claude-code': {
     secret_env: ['AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN'],

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -22,6 +22,11 @@ const codexSecretEnv = [
   'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
   'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
 ];
+const claudeCodeSecretEnv = [
+  'AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN',
+  'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN',
+  'AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT',
+];
 const claudeCodeRefreshTokenEnv = 'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN';
 const repoLoopCapabilities = [
   'tool:datamachine/run-agent-bundle',
@@ -308,7 +313,7 @@ assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').when, {
   ],
 });
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'openai').env, ['OPENAI_API_KEY']);
-assert.deepEqual(secretEnvRequirementForProvider(provider, 'claude-code').env, [claudeCodeRefreshTokenEnv]);
+assert.deepEqual(secretEnvRequirementForProvider(provider, 'claude-code').env, claudeCodeSecretEnv);
 assert.deepEqual(provider.workspace_materialization, { cwd: 'git_checkout' });
 assert.deepEqual(provider.provider_defaults, {
   openai: {
@@ -325,7 +330,27 @@ assert.deepEqual(provider.provider_defaults, {
     secret_env_sources: codexSecretEnvSources,
   },
   'claude-code': {
-    secret_env: ['AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN'],
+    secret_env: claudeCodeSecretEnv,
+    secret_env_sources: {
+      AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN: {
+        source: 'keychain-bundle',
+        scope: 'agent-task',
+        name: 'claude-code-oauth',
+        field: 'access_token',
+      },
+      AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN: {
+        source: 'keychain-bundle',
+        scope: 'agent-task',
+        name: 'claude-code-oauth',
+        field: 'refresh_token',
+      },
+      AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT: {
+        source: 'keychain-bundle',
+        scope: 'agent-task',
+        name: 'claude-code-oauth',
+        field: 'expires_at',
+      },
+    },
   },
 });
 assert.deepEqual(provider.role_aliases, {
@@ -513,7 +538,7 @@ const claudeCodeDefaultSecretEnvRequest = codeboxTaskRequestFromAgentTaskRequest
     },
   },
 });
-assert.deepEqual(claudeCodeDefaultSecretEnvRequest.secret_env, [claudeCodeRefreshTokenEnv]);
+assert.deepEqual(claudeCodeDefaultSecretEnvRequest.secret_env, claudeCodeSecretEnv);
 
 const runtimeTaskRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,


### PR DESCRIPTION
## Summary
- declare Codex provider defaults with non-secret JSON auth-file sources
- map Codex OAuth env names to fields in the provider-owned ~/.codex/auth.json bundle
- update wp-codebox runtime contract tests for the credential source metadata

## Tests
- npm run test:codebox-agent-task-executor-boundary
- npm run test:codebox-agent-task-executor

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the wp-codebox runtime manifest update and focused contract test updates for Codex credential source hints; Chris remains responsible for review and validation.