### PR TITLE
Centralize agent provider contract helpers

### DIFF
--- a/.github/scripts/normalize-provider-plugin.cjs
+++ b/.github/scripts/normalize-provider-plugin.cjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * External dependencies
+ */
+const fs = require('node:fs');
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const input = args.input === '-' ? fs.readFileSync(0, 'utf8') : args.input || '';
+  const provider = args.provider || '';
+  const includeCredentials = args.includeCredentials === 'true';
+  const providerPlugin = parseProviderPlugin(input);
+  const normalized = {
+    repo: jqAlternative(providerPlugin.repo, ''),
+    ref: jqAlternative(providerPlugin.ref, ''),
+    path: jqAlternative(providerPlugin.path, '.'),
+    register_function: jqAlternative(providerPlugin.register_function, ''),
+  };
+
+  if (includeCredentials) {
+    const credentials = jqAlternative(providerPlugin.credentials, provider === 'openai' ? { connectors_ai_openai_api_key: 'OPENAI_API_KEY' } : {});
+    if (!credentials || Array.isArray(credentials) || typeof credentials !== 'object') {
+      throw new Error('provider_plugin.credentials must be a JSON object');
+    }
+    normalized.credentials = credentials;
+  }
+
+  process.stdout.write(`${JSON.stringify(normalized)}\n`);
+}
+
+function parseArgs(args) {
+  const parsed = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+    const key = arg.slice(2);
+    const next = args[index + 1];
+    parsed[key] = next || '';
+    index += 1;
+  }
+  return parsed;
+}
+
+function parseProviderPlugin(rawInput) {
+  const trimmed = String(rawInput || '').trim();
+  if (!trimmed) {
+    return {};
+  }
+
+  const parsed = JSON.parse(trimmed);
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+    throw new Error('provider_plugin must be a JSON object');
+  }
+  return parsed;
+}
+
+function jqAlternative(value, fallback) {
+  return value === undefined || value === null || value === false ? fallback : value;
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+}

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -522,17 +522,7 @@ jobs:
             exit 1
           fi
           effective_runtime_ref="$AGENT_RUNTIME_REF"
-          provider_plugin_json="$(printf '%s' "$PROVIDER_PLUGIN" | jq -Rsc --arg provider "$PROVIDER" --arg openaiRef "$OPENAI_PROVIDER_REF" '
-            if (gsub("^\\s+|\\s+$"; "") | length) == 0 then {} else fromjson end
-            | if type == "object" then . else error("provider_plugin must be a JSON object") end
-            | {
-                repo: (.repo // ""),
-                ref: (.ref // ""),
-                path: (.path // "."),
-                register_function: (.register_function // ""),
-                credentials: (.credentials // (if $provider == "openai" then {connectors_ai_openai_api_key: "OPENAI_API_KEY"} else {} end))
-              }
-          ')"
+          provider_plugin_json="$(printf '%s' "$PROVIDER_PLUGIN" | node .ci/homeboy-extensions/.github/scripts/normalize-provider-plugin.cjs --input - --provider "$PROVIDER" --includeCredentials true)"
           provider_plugin_repo="$(jq -r '.repo // ""' <<< "$provider_plugin_json")"
           provider_plugin_ref="$(jq -r '.ref // ""' <<< "$provider_plugin_json")"
           dependency_entries+=("Automattic/wp-codebox@${effective_runtime_ref}")
@@ -660,14 +650,7 @@ jobs:
             [ "$component_dir" != ".ci/homeboy-extensions/wordpress" ] || continue
             composer install --working-dir="$component_dir" --no-interaction --no-progress --prefer-dist
           done
-          provider_plugin_json="$(printf '%s' "$PROVIDER_PLUGIN" | jq -Rsc --arg provider "$PROVIDER" --arg openaiRef "$OPENAI_PROVIDER_REF" '
-            if (gsub("^\\s+|\\s+$"; "") | length) == 0 then {} else fromjson end
-            | if type == "object" then . else error("provider_plugin must be a JSON object") end
-            | {
-                repo: (.repo // ""),
-                path: (.path // ".")
-              }
-          ')"
+          provider_plugin_json="$(printf '%s' "$PROVIDER_PLUGIN" | node .ci/homeboy-extensions/.github/scripts/normalize-provider-plugin.cjs --input - --provider "$PROVIDER" --includeCredentials false)"
           provider_plugin_repo="$(jq -r '.repo // ""' <<< "$provider_plugin_json")"
           provider_plugin_path="$(jq -r '.path // "."' <<< "$provider_plugin_json")"
           if [ -n "$provider_plugin_repo" ]; then
@@ -781,18 +764,7 @@ jobs:
             execute_workflow_mounts_json="$(jq -nc --arg type "$execute_workflow_mount_type" --arg source "$execute_workflow_host_path" --arg target "$execute_workflow_guest_path" '[{type: $type, source: $source, target: $target, mode: "readonly"}]')"
           fi
           mapfile -t validation_paths < <(find "${GITHUB_WORKSPACE}/.ci" -mindepth 1 -maxdepth 1 -type d | sort)
-          provider_plugin_json="$(printf '%s' "$PROVIDER_PLUGIN" | jq -Rsc --arg provider "$PROVIDER" --arg openaiRef "$OPENAI_PROVIDER_REF" '
-            if (gsub("^\\s+|\\s+$"; "") | length) == 0 then {} else fromjson end
-            | if type == "object" then . else error("provider_plugin must be a JSON object") end
-            | {
-                repo: (.repo // ""),
-                ref: (.ref // ""),
-                path: (.path // "."),
-                register_function: (.register_function // ""),
-                credentials: (.credentials // (if $provider == "openai" then {connectors_ai_openai_api_key: "OPENAI_API_KEY"} else {} end))
-              }
-              | if (.credentials | type) == "object" then . else error("provider_plugin.credentials must be a JSON object") end
-          ')"
+          provider_plugin_json="$(printf '%s' "$PROVIDER_PLUGIN" | node .ci/homeboy-extensions/.github/scripts/normalize-provider-plugin.cjs --input - --provider "$PROVIDER" --includeCredentials true)"
           provider_plugin_repo="$(jq -r '.repo // ""' <<< "$provider_plugin_json")"
           provider_plugin_path="$(jq -r '.path // "."' <<< "$provider_plugin_json")"
           provider_plugin_host_path=""

--- a/agent-runtimes/lib/agent-task-provider-contract.js
+++ b/agent-runtimes/lib/agent-task-provider-contract.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
+const AGENT_TASK_OUTCOME_SCHEMA = 'homeboy/agent-task-outcome/v1';
+const AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA = 'homeboy/agent-task-executor-provider/v1';
+const SECRET_ENV_REQUIREMENT_SCHEMA = 'homeboy/secret-env-requirement/v1';
+
+const AGENT_TASK_REQUEST_REQUIRED_FIELDS = ['schema', 'task_id', 'executor.backend', 'instructions'];
+
+const AGENT_TASK_OUTCOME_STATUSES = [
+  'succeeded',
+  'failed',
+  'no_op',
+  'unable_to_remediate',
+  'timeout',
+  'provider_error',
+];
+
+const AGENT_TASK_FAILURE_CLASSIFICATIONS = [
+  'provider',
+  'timeout',
+  'execution_failed',
+];
+
+const AGENT_TASK_REDACTED_METADATA_KEYS = [
+  'secret_env_values',
+  'secretEnvValues',
+  'secrets',
+];
+
+function agentTaskProviderContractFields() {
+  return {
+    request_schema: AGENT_TASK_REQUEST_SCHEMA,
+    outcome_schema: AGENT_TASK_OUTCOME_SCHEMA,
+    request_required_fields: [...AGENT_TASK_REQUEST_REQUIRED_FIELDS],
+    outcome_statuses: [...AGENT_TASK_OUTCOME_STATUSES],
+    failure_classifications: [...AGENT_TASK_FAILURE_CLASSIFICATIONS],
+    redacted_metadata_keys: [...AGENT_TASK_REDACTED_METADATA_KEYS],
+  };
+}
+
+function providerSecretEnvRequirement(provider, env) {
+  return {
+    schema: SECRET_ENV_REQUIREMENT_SCHEMA,
+    source: 'provider_default',
+    env,
+    when: {
+      any: [
+        { path: 'executor.config.provider', equals: provider },
+        { path: 'executor.provider', equals: provider },
+        { path: 'provider', equals: provider },
+      ],
+    },
+  };
+}
+
+function providerDefaultsContract(providerDefaults = {}) {
+  return Object.fromEntries(Object.entries(providerDefaults).map(([provider, defaults]) => [provider, {
+    ...defaults,
+    secret_env: normalizeArray(defaults.secret_env),
+  }]));
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value.filter((entry) => entry !== undefined && entry !== null) : [];
+}
+
+module.exports = {
+  AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
+  AGENT_TASK_FAILURE_CLASSIFICATIONS,
+  AGENT_TASK_OUTCOME_SCHEMA,
+  AGENT_TASK_OUTCOME_STATUSES,
+  AGENT_TASK_REDACTED_METADATA_KEYS,
+  AGENT_TASK_REQUEST_SCHEMA,
+  agentTaskProviderContractFields,
+  providerDefaultsContract,
+  providerSecretEnvRequirement,
+};

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -1,7 +1,15 @@
 'use strict';
 
-const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
-const AGENT_TASK_OUTCOME_SCHEMA = 'homeboy/agent-task-outcome/v1';
+/**
+ * Internal dependencies
+ */
+const {
+	AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
+	AGENT_TASK_OUTCOME_SCHEMA,
+	agentTaskProviderContractFields,
+	providerSecretEnvRequirement,
+} = require('../../lib/agent-task-provider-contract');
+
 const OPENCODE_PROVIDER_ID = 'opencode.agent-task-executor';
 const OPENCODE_PROVIDER_LABEL = 'OpenCode agent task executor';
 const OPENCODE_SECRET_ENV = [
@@ -24,42 +32,17 @@ const OPENCODE_CAPABILITIES = [
 	'provider_owned_cancellation',
 ];
 
-const AGENT_TASK_OUTCOME_STATUSES = [
-	'succeeded',
-	'failed',
-	'no_op',
-	'unable_to_remediate',
-	'timeout',
-	'provider_error',
-];
-
-const AGENT_TASK_FAILURE_CLASSIFICATIONS = [
-	'provider',
-	'timeout',
-	'execution_failed',
-];
-
-const AGENT_TASK_REDACTED_METADATA_KEYS = [
-	'secret_env_values',
-	'secretEnvValues',
-	'secrets',
-	'codex_auth',
-	'opencode_auth',
-];
-
 function providerContract(options = {}) {
+	const contractFields = agentTaskProviderContractFields();
+	contractFields.redacted_metadata_keys.push('codex_auth', 'opencode_auth');
+
 	return {
-		schema: 'homeboy/agent-task-executor-provider/v1',
+		schema: AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
 		id: options.id || OPENCODE_PROVIDER_ID,
 		label: options.label || OPENCODE_PROVIDER_LABEL,
 		backend: 'opencode',
 		command: options.command || 'node {{runtime_path}}/scripts/agent/homeboy-opencode-agent-task-executor.cjs',
-		request_schema: AGENT_TASK_REQUEST_SCHEMA,
-		outcome_schema: AGENT_TASK_OUTCOME_SCHEMA,
-		request_required_fields: ['schema', 'task_id', 'executor.backend', 'instructions'],
-		outcome_statuses: AGENT_TASK_OUTCOME_STATUSES,
-		failure_classifications: AGENT_TASK_FAILURE_CLASSIFICATIONS,
-		redacted_metadata_keys: AGENT_TASK_REDACTED_METADATA_KEYS,
+		...contractFields,
 		secret_env_requirements: [providerSecretEnvRequirement('codex', OPENCODE_SECRET_ENV)],
 		capabilities: OPENCODE_CAPABILITIES,
 		workspace_materialization: {
@@ -83,21 +66,6 @@ function providerContract(options = {}) {
 		status: 'experimental',
 		integration_contract: 'homeboy-opencode-agent-task/v1',
 		runtime_gap_trackers: ['https://github.com/Extra-Chill/homeboy-extensions/issues/967'],
-	};
-}
-
-function providerSecretEnvRequirement(provider, env) {
-	return {
-		schema: 'homeboy/secret-env-requirement/v1',
-		source: 'provider_default',
-		env,
-		when: {
-			any: [
-				{ path: 'executor.config.provider', equals: provider },
-				{ path: 'executor.provider', equals: provider },
-				{ path: 'provider', equals: provider },
-			],
-		},
 	};
 }
 

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -6,8 +6,20 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
-const AGENT_TASK_OUTCOME_SCHEMA = 'homeboy/agent-task-outcome/v1';
+/**
+ * Internal dependencies
+ */
+const {
+  AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
+  AGENT_TASK_FAILURE_CLASSIFICATIONS,
+  AGENT_TASK_OUTCOME_SCHEMA,
+  AGENT_TASK_OUTCOME_STATUSES,
+  AGENT_TASK_REDACTED_METADATA_KEYS,
+  AGENT_TASK_REQUEST_SCHEMA,
+  agentTaskProviderContractFields,
+  providerDefaultsContract,
+} = require('../../lib/agent-task-provider-contract');
+
 const AGENT_TASK_ARTIFACT_SCHEMA = 'homeboy/agent-task-artifact/v1';
 const WP_CODEBOX_TASK_REQUEST_SCHEMA = 'wp-codebox/task-input/v1';
 const WP_CODEBOX_PROVIDER_ID = 'wordpress.codebox-agent-task-executor';
@@ -91,27 +103,6 @@ const WP_CODEBOX_ROLE_ALIASES = {
   },
 };
 
-const AGENT_TASK_OUTCOME_STATUSES = [
-  'succeeded',
-  'failed',
-  'no_op',
-  'unable_to_remediate',
-  'timeout',
-  'provider_error',
-];
-
-const AGENT_TASK_FAILURE_CLASSIFICATIONS = [
-  'provider',
-  'timeout',
-  'execution_failed',
-];
-
-const AGENT_TASK_REDACTED_METADATA_KEYS = [
-  'secret_env_values',
-  'secretEnvValues',
-  'secrets',
-];
-
 function assertAgentTaskRequest(request) {
   if (!request || request.schema !== AGENT_TASK_REQUEST_SCHEMA) {
     throw new Error(`Agent task request must use schema ${AGENT_TASK_REQUEST_SCHEMA}.`);
@@ -127,17 +118,12 @@ function assertAgentTaskRequest(request) {
 
 function providerContract(options = {}) {
   return {
-    schema: 'homeboy/agent-task-executor-provider/v1',
+    schema: AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
     id: options.id || WP_CODEBOX_PROVIDER_ID,
     label: options.label || WP_CODEBOX_PROVIDER_LABEL,
     backend: WP_CODEBOX_BACKEND,
     command: options.command || 'node {{runtime_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs',
-    request_schema: AGENT_TASK_REQUEST_SCHEMA,
-    outcome_schema: AGENT_TASK_OUTCOME_SCHEMA,
-    request_required_fields: ['schema', 'task_id', 'executor.backend', 'instructions'],
-    outcome_statuses: AGENT_TASK_OUTCOME_STATUSES,
-    failure_classifications: AGENT_TASK_FAILURE_CLASSIFICATIONS,
-    redacted_metadata_keys: AGENT_TASK_REDACTED_METADATA_KEYS,
+    ...agentTaskProviderContractFields(),
     secret_env_requirements: options.secretEnvRequirements || runtimeSecretEnvRequirements(),
     capabilities: normalizeArray(options.capabilities || PROVIDER_CAPABILITIES),
     workspace_materialization: {
@@ -145,34 +131,12 @@ function providerContract(options = {}) {
     },
     workspace_tools: runtimeWorkspaceTools(options),
     component_path_defaults: runtimeComponentPathDefaults(options),
-    provider_defaults: providerDefaultsContract(),
+    provider_defaults: providerDefaultsContract(runtimeProviderDefaults()),
     role_aliases: WP_CODEBOX_ROLE_ALIASES,
     status: 'active',
     integration_contract: 'homeboy-wordpress-agent-task/v1',
     runtime_gap_trackers: WP_CODEBOX_RUNTIME_GAP_TRACKERS,
   };
-}
-
-function providerSecretEnvRequirement(provider, env) {
-  return {
-    schema: 'homeboy/secret-env-requirement/v1',
-    source: 'provider_default',
-    env,
-    when: {
-      any: [
-        { path: 'executor.config.provider', equals: provider },
-        { path: 'executor.provider', equals: provider },
-        { path: 'provider', equals: provider },
-      ],
-    },
-  };
-}
-
-function providerDefaultsContract(providerDefaults = runtimeProviderDefaults()) {
-  return Object.fromEntries(Object.entries(providerDefaults).map(([provider, defaults]) => [provider, {
-    ...defaults,
-    secret_env: normalizeArray(defaults.secret_env),
-  }]));
 }
 
 function runtimeManifest() {


### PR DESCRIPTION
## Summary
- Centralize shared agent-task provider contract fields and provider default/secret-env helpers for OpenCode and WP Codebox runtimes.
- Replace repeated provider_plugin normalization blocks in datamachine-agent-ci with a checked-in workflow helper.
- Preserve runtime provider contract output for OpenCode and WP Codebox exactly.

## Verification
- npm run test:codebox-agent-task-executor-boundary
- npm run test:codebox-agent-task-executor
- node provider contract load check
- node provider plugin normalization helper checks, including invalid credentials failure
- provider contract equivalence check against origin/main
- wordpress/node_modules/.bin/eslint --config wordpress/eslint.config.mjs agent-runtimes/lib/agent-task-provider-contract.js agent-runtimes/opencode/lib/opencode-agent-task-executor.js .github/scripts/normalize-provider-plugin.cjs

## Notes
- Full wordpress npm run lint:js still reports existing unrelated lint errors in files outside this change.
- npm run test:opencode-agent-task-executor-boundary currently fails before exercising this change because wordpress.json no longer exposes manifest.agent_runtimes for that test fixture.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the helper extraction, workflow normalization helper, tests/verification commands, and PR description for Chris to review.