### PR TITLE
Consume canonical agent-task artifact declarations

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -324,24 +324,26 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
 }
 
 function artifactDeclarationsFromAgentTaskRequest(request, config = {}, inputs = {}, options = {}) {
-  const declarations = firstDefined(
+  const declarations = firstNonEmptyArray(
     request.artifact_declarations,
+    options.artifactDeclarations,
+    []
+  );
+  if (declarations.length > 0) {
+    return declarations
+      .map((declaration) => wpCodeboxArtifactDeclarationFromHomeboy(declaration))
+      .filter(Boolean);
+  }
+  return legacyArtifactDeclarationsFromAgentTaskRequest(request, config, inputs, options);
+}
+
+function legacyArtifactDeclarationsFromAgentTaskRequest(request, config = {}, inputs = {}, options = {}) {
+  const declarations = [
     request.artifactDeclarations,
     inputs.artifact_declarations,
     inputs.artifactDeclarations,
     config.artifact_declarations,
     config.artifactDeclarations,
-    options.artifactDeclarations,
-    []
-  );
-  if (Array.isArray(declarations) && declarations.length > 0) {
-    return declarations;
-  }
-  return genericArtifactDeclarationsFromAgentTaskRequest(request, config, inputs, options);
-}
-
-function genericArtifactDeclarationsFromAgentTaskRequest(request, config = {}, inputs = {}, options = {}) {
-  const declarations = [
     request.artifact_outputs,
     request.artifactOutputs,
     request.output_artifacts,
@@ -377,7 +379,7 @@ function genericArtifactDeclarationsFromAgentTaskRequest(request, config = {}, i
     options.outputArtifacts,
   ].flatMap(genericArtifactDeclarationEntries);
   return declarations
-    .map(([name, declaration]) => wpCodeboxArtifactDeclarationFromGeneric(name, declaration))
+    .map(([name, declaration]) => wpCodeboxArtifactDeclarationFromLegacy(name, declaration))
     .filter(Boolean);
 }
 
@@ -391,7 +393,11 @@ function genericArtifactDeclarationEntries(value) {
   return Object.entries(value);
 }
 
-function wpCodeboxArtifactDeclarationFromGeneric(defaultName, declaration) {
+function wpCodeboxArtifactDeclarationFromHomeboy(declaration) {
+  return wpCodeboxArtifactDeclarationFromLegacy('', declaration);
+}
+
+function wpCodeboxArtifactDeclarationFromLegacy(defaultName, declaration) {
   if (typeof declaration === 'string') {
     return {
       schema: 'wp-codebox/artifact-declaration/v1',
@@ -410,12 +416,16 @@ function wpCodeboxArtifactDeclarationFromGeneric(defaultName, declaration) {
     || declaration.artifactSchema
     || declaration.content_schema
     || declaration.contentSchema
-    || (declaration.schema && declaration.schema !== 'wp-codebox/artifact-declaration/v1' ? declaration.schema : undefined);
+    || (declaration.schema && ![
+      'homeboy/agent-task-artifact-declaration/v1',
+      'wp-codebox/artifact-declaration/v1',
+    ].includes(declaration.schema) ? declaration.schema : undefined);
   return Object.fromEntries(Object.entries({
     schema: 'wp-codebox/artifact-declaration/v1',
     name,
     type: declaration.type || declaration.kind || declaration.artifact_type || declaration.artifactType,
     artifact_schema: artifactSchema,
+    path: declaration.path,
     required: declaration.required === undefined ? true : declaration.required === true,
     description: declaration.description,
     metadata: declaration.metadata,

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -478,15 +478,31 @@ const artifactDeclarationRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
   task_id: 'artifact-declaration-task-123',
   artifact_declarations: [{
-    schema: 'wp-codebox/artifact-declaration/v1',
+    schema: 'homeboy/agent-task-artifact-declaration/v1',
     name: 'analysis_report',
     type: 'AnalysisReport',
     artifact_schema: 'example/analysis-report/v1',
+    path: 'artifacts/analysis-report.json',
     required: true,
   }],
 });
+assert.equal(artifactDeclarationRequest.artifact_declarations[0].schema, 'wp-codebox/artifact-declaration/v1');
 assert.equal(artifactDeclarationRequest.artifact_declarations[0].name, 'analysis_report');
+assert.equal(artifactDeclarationRequest.artifact_declarations[0].path, 'artifacts/analysis-report.json');
 assert.equal(artifactDeclarationRequest.artifact_declarations[0].required, true);
+
+const legacyArtifactDeclarationRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'legacy-artifact-declaration-task-123',
+  artifactDeclarations: [{
+    name: 'legacy_report',
+    kind: 'LegacyReport',
+    contentSchema: 'example/legacy-report/v1',
+  }],
+});
+assert.equal(legacyArtifactDeclarationRequest.artifact_declarations[0].name, 'legacy_report');
+assert.equal(legacyArtifactDeclarationRequest.artifact_declarations[0].type, 'LegacyReport');
+assert.equal(legacyArtifactDeclarationRequest.artifact_declarations[0].artifact_schema, 'example/legacy-report/v1');
 
 const codeboxRequestWithAbilityTools = codeboxTaskRequestFromAgentTaskRequest({
   ...request,


### PR DESCRIPTION
## Summary
- Prefer canonical Homeboy `artifact_declarations` when building WP Codebox task requests.
- Convert canonical declarations into the WP Codebox declaration schema, including `path`.
- Keep broad legacy alias handling only as a fallback for direct callers or older Homeboy core versions.

## Dependency
- Depends on Extra-Chill/homeboy#4950 for the canonical request normalization path.

## Verification
- `node --test wordpress/tests/codebox-agent-task-executor-smoke.js wordpress/tests/codebox-agent-task-executor-boundary.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and focused tests; Chris remains responsible for review and validation.
