### PR TITLE
Use runner exec for remote helper scripts

### DIFF
--- a/scripts/bootstrap-standard-extensions.sh
+++ b/scripts/bootstrap-standard-extensions.sh
@@ -18,8 +18,7 @@ Install the standard Homeboy extension set on the local machine or an SSH
 reachable remote runner.
 
 Options:
-  --target <ssh-host>         SSH target such as homeboy-lab or user@host.
-                             Omit for local bootstrap.
+  --target <runner-id>        Runner ID such as homeboy-lab. Omit for local bootstrap.
   --extensions "<ids>"       Space-separated extension IDs to install.
                              Default: nodejs rust wordpress go swift.
   --repo <url-or-path>        Extension monorepo URL or path.
@@ -34,10 +33,6 @@ Examples:
   scripts/bootstrap-standard-extensions.sh --target chubes@homeboy-lab --extensions "nodejs rust wordpress"
   scripts/bootstrap-standard-extensions.sh --repo /path/to/homeboy-extensions --extensions "rust" --dry-run
 USAGE
-}
-
-shell_quote() {
-    printf "'%s'" "$(printf "%s" "$1" | sed "s/'/'\\\\''/g")"
 }
 
 while [ "$#" -gt 0 ]; do
@@ -89,38 +84,31 @@ if [ -z "$HOMEBOY_BIN" ]; then
     exit 2
 fi
 
-REMOTE_SCRIPT="set -euo pipefail
-HOMEBOY_BIN=$(shell_quote "$HOMEBOY_BIN")
-REPO=$(shell_quote "$REPO")
-EXTENSIONS=$(shell_quote "$EXTENSIONS")
+RUNNER_ID="${TARGET:-local}"
+RUNNER_ARGS=(runner exec "$RUNNER_ID" --script-file - --raw --env "HOMEBOY_BIN=$HOMEBOY_BIN" --env "REPO=$REPO" --env "EXTENSIONS=$EXTENSIONS")
 
-command -v \"\$HOMEBOY_BIN\" >/dev/null 2>&1 || {
-    echo \"Homeboy executable not found on target: \$HOMEBOY_BIN\" >&2
+if [ -n "$TARGET" ]; then
+    RUNNER_ARGS+=(--ssh)
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    RUNNER_ARGS+=(--dry-run)
+fi
+
+"$HOMEBOY_BIN" "${RUNNER_ARGS[@]}" <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+command -v "$HOMEBOY_BIN" >/dev/null 2>&1 || {
+    echo "Homeboy executable not found on target: $HOMEBOY_BIN" >&2
     exit 127
 }
 
-for EXTENSION_ID in \$EXTENSIONS; do
-    echo \"Installing Homeboy extension: \$EXTENSION_ID\"
-    \"\$HOMEBOY_BIN\" extension install \"\$REPO\" --id \"\$EXTENSION_ID\"
-    \"\$HOMEBOY_BIN\" extension show \"\$EXTENSION_ID\" >/dev/null
+for EXTENSION_ID in $EXTENSIONS; do
+    echo "Installing Homeboy extension: $EXTENSION_ID"
+    "$HOMEBOY_BIN" extension install "$REPO" --id "$EXTENSION_ID"
+    "$HOMEBOY_BIN" extension show "$EXTENSION_ID" >/dev/null
 done
 
-echo \"Installed Homeboy extensions:\"
-\"\$HOMEBOY_BIN\" extension list
-"
-
-if [ "$DRY_RUN" -eq 1 ]; then
-    if [ -n "$TARGET" ]; then
-        echo "# Target: $TARGET"
-    else
-        echo "# Target: local"
-    fi
-    printf "%s" "$REMOTE_SCRIPT"
-    exit 0
-fi
-
-if [ -n "$TARGET" ]; then
-    printf "%s" "$REMOTE_SCRIPT" | ssh "$TARGET" 'bash -s'
-else
-    bash -s <<<"$REMOTE_SCRIPT"
-fi
+echo "Installed Homeboy extensions:"
+"$HOMEBOY_BIN" extension list
+REMOTE_SCRIPT

--- a/wordpress/scripts/build/update-wp-codebox-cache.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache.sh
@@ -16,8 +16,8 @@ Usage: scripts/update-wp-codebox-cache.sh [options]
 Update the WP Codebox source cache used by Homeboy lab runners.
 
 Options:
-  --target <ssh-host>       SSH target such as homeboy-lab. Omit to run locally.
-  --runner <ssh-host>       Alias for --target.
+  --target <runner-id>      Runner ID such as homeboy-lab. Omit to run locally.
+  --runner <runner-id>      Alias for --target.
   --source <git-url>        WP Codebox repository URL.
                            Default: https://github.com/Automattic/wp-codebox.git
   --ref <git-ref>           Branch, tag, or SHA to fetch/reset to. When omitted,
@@ -33,10 +33,6 @@ Examples:
   scripts/update-wp-codebox-cache.sh --runner homeboy-lab --ref main
   scripts/update-wp-codebox-cache.sh --source git@github.com:Automattic/wp-codebox.git --ref afe6890
 USAGE
-}
-
-shell_quote() {
-    printf "'%s'" "$(printf "%s" "$1" | sed "s/'/'\\''/g")"
 }
 
 while [ "$#" -gt 0 ]; do
@@ -87,11 +83,18 @@ if [ -z "$NPM_BIN" ]; then
     exit 2
 fi
 
-REMOTE_SCRIPT="SOURCE=$(shell_quote "$SOURCE")
-REQUESTED_REF=$(shell_quote "$REF")
-CACHE_DIR=$(shell_quote "$CACHE_DIR")
-NPM_BIN=$(shell_quote "$NPM_BIN")
-$(cat <<'REMOTE'
+RUNNER_ID="${TARGET:-local}"
+RUNNER_ARGS=(runner exec "$RUNNER_ID" --script-file - --raw --env "SOURCE=$SOURCE" --env "REQUESTED_REF=$REF" --env "CACHE_DIR=$CACHE_DIR" --env "NPM_BIN=$NPM_BIN")
+
+if [ -n "$TARGET" ]; then
+    RUNNER_ARGS+=(--ssh)
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    RUNNER_ARGS+=(--dry-run)
+fi
+
+homeboy "${RUNNER_ARGS[@]}" <<'REMOTE_SCRIPT'
 set -euo pipefail
 
 fail() {
@@ -143,21 +146,4 @@ echo "Building WP Codebox packages..."
 
 SHA="$(git -C "$CACHE_DIR" rev-parse HEAD)" || fail "failed to read resulting WP Codebox SHA"
 echo "WP Codebox cache SHA: $SHA"
-REMOTE
-)"
-
-if [ "$DRY_RUN" -eq 1 ]; then
-    if [ -n "$TARGET" ]; then
-        echo "# Target: $TARGET"
-    else
-        echo "# Target: local"
-    fi
-    printf "%s" "$REMOTE_SCRIPT"
-    exit 0
-fi
-
-if [ -n "$TARGET" ]; then
-    printf "%s" "$REMOTE_SCRIPT" | ssh "$TARGET" 'bash -s'
-else
-    bash -s <<<"$REMOTE_SCRIPT"
-fi
+REMOTE_SCRIPT


### PR DESCRIPTION
## Summary
- Migrate `scripts/bootstrap-standard-extensions.sh` to execute through `homeboy runner exec --script-file -` instead of hand-rolled SSH/script quoting.
- Migrate `wordpress/scripts/build/update-wp-codebox-cache.sh` to the same runner exec transport and env injection path.
- Keep dry-run behavior by relying on the new runner exec dry-run script output.

## Dependency
- Depends on Extra-Chill/homeboy#4953.

## Verification
- `git diff --check`
- `bash -n scripts/bootstrap-standard-extensions.sh`
- `bash -n wordpress/scripts/build/update-wp-codebox-cache.sh`
- `PATH="/Users/chubes/Developer/homeboy@primitive-runner-exec-script/target/debug:$PATH" scripts/bootstrap-standard-extensions.sh --homeboy /Users/chubes/Developer/homeboy@primitive-runner-exec-script/target/debug/homeboy --extensions "rust" --dry-run`
- `PATH="/Users/chubes/Developer/homeboy@primitive-runner-exec-script/target/debug:$PATH" wordpress/scripts/build/update-wp-codebox-cache.sh --source https://example.com/repo.git --ref main --cache-dir /tmp/wp-codebox-cache --dry-run`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the script migrations, verification commands, and PR description; Chris remains responsible for review and merge.