### PR TITLE
Add visual parity workload helper

### DIFF
--- a/nodejs/docs/workload-utils.md
+++ b/nodejs/docs/workload-utils.md
@@ -20,6 +20,7 @@ concepts:
 - `metric(value, fallback)` coerces finite numeric values.
 - `runCommand(command, args, options)` runs a subprocess with redacted output by default.
 - `runPackageScriptBench(options)` runs a `package.json` script with optional spec args and returns the standard bench workload shape: `{ metrics, artifacts, metadata }`.
+- `runVisualParityWorkload(options)` runs a WP Codebox `wordpress.visual-compare` recipe and returns the standard bench workload shape with a typed `homeboy/VisualParityArtifact/v1` JSON artifact.
 - `writeJson(file, data)` and `writeText(file, data)` create parent directories and redact common secrets.
 - `runId(name)` creates a sanitized run identifier.
 - `artifactDir(name)` returns a directory under `HOMEBOY_BENCH_SHARED_STATE` or the OS temp directory.
@@ -27,6 +28,73 @@ concepts:
 - `percentile(values, pct)` uses R-7 linear interpolation.
 
 Use `{ redact: false }` with `runCommand()`, `writeJson()`, or `writeText()` only when a workload needs raw output for parsing before writing a redacted artifact.
+
+## Visual Parity Workloads
+
+`runVisualParityWorkload()` is the reusable primitive for visual comparison
+workloads that already have a WP Codebox CLI available. It accepts a source URL
+or local source path, a candidate WordPress context, viewport/threshold settings,
+and emits a normalized `homeboy/VisualParityArtifact/v1` artifact while preserving
+the underlying WP Codebox artifact references.
+
+```js
+const { runVisualParityWorkload } = await import(process.env.HOMEBOY_NODEJS_WORKLOAD_UTILS);
+
+export default async function () {
+  return runVisualParityWorkload({
+    id: 'homepage-parity',
+    wpCodeboxCli: process.env.WP_CODEBOX_CLI,
+    source: {
+      path: './dist/site',
+      ref: process.env.GITHUB_SHA,
+      label: 'static-source',
+      port: 4173,
+    },
+    candidate: {
+      url: '/',
+      label: 'wordpress-candidate',
+      context: { runtime: 'playground' },
+      recipe: {
+        runtime: { wp: 'latest' },
+        inputs: { mounts: [] },
+      },
+    },
+    viewport: { width: 1280, height: 1600 },
+    threshold: 0.015,
+    pixelThreshold: 0.1,
+    waitFor: 'domcontentloaded',
+  });
+}
+```
+
+The helper stays product-neutral. Callers own site-specific import steps,
+scoring, PR comments, retry policy, and reviewer gates. Homeboy Extensions owns
+the reusable recipe invocation and artifact normalization shape:
+
+```json
+{
+  "schema": "homeboy/VisualParityArtifact/v1",
+  "source": { "label": "static-source", "ref": "...", "path": "...", "url": "..." },
+  "candidate": { "label": "wordpress-candidate", "ref": "...", "url": "/", "context": {} },
+  "summary": {
+    "status": "passed",
+    "pass": true,
+    "threshold": 0.015,
+    "mismatch_ratio": 0,
+    "mismatch_pixels": 0,
+    "total_pixels": 2048000,
+    "dimension_mismatch": false,
+    "region_count": 0
+  },
+  "artifacts": {
+    "directory": "...",
+    "visual_diff": "files/browser/visual-compare/visual-diff.json",
+    "source_screenshot": "files/browser/visual-compare/source.png",
+    "candidate_screenshot": "files/browser/visual-compare/candidate.png",
+    "diff_screenshot": "files/browser/visual-compare/diff.png"
+  }
+}
+```
 
 Typed setting helpers use the same precedence as `setting()`: values in
 `HOMEBOY_SETTINGS_JSON` win when the key exists and is not `null`; otherwise the

--- a/nodejs/scripts/bench/lib/workload-utils.mjs
+++ b/nodejs/scripts/bench/lib/workload-utils.mjs
@@ -1,6 +1,8 @@
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { createReadStream } from 'node:fs';
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
@@ -252,6 +254,91 @@ export async function runPackageScriptBench(options = {}) {
     };
 }
 
+/**
+ * Run a WP Codebox wordpress.visual-compare recipe and emit a normalized,
+ * product-neutral visual parity artifact for Homeboy bench workloads.
+ */
+export async function runVisualParityWorkload(options = {}) {
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+        throw new Error('runVisualParityWorkload requires an options object.');
+    }
+
+    const id = sanitizeSegment(options.id || 'visual-parity');
+    const cwd = resolvePath(options.cwd || process.env.HOMEBOY_COMPONENT_PATH || process.cwd());
+    const context = options.artifactContext || createArtifactContext({
+        id,
+        sharedState: options.sharedState,
+        runId: options.runId,
+        artifactsDir: options.artifactsDir,
+    });
+    const artifactDirectory = options.codeboxArtifactsDir
+        ? resolvePath(options.codeboxArtifactsDir, { baseDir: cwd })
+        : path.join(context.artifactDir, 'codebox');
+    const source = normalizeVisualParitySource(options.source, { cwd });
+    const candidate = normalizeVisualParityCandidate(options.candidate);
+    const compare = normalizeVisualParityCompareOptions(options);
+    const recipe = buildVisualParityRecipe({ artifactDirectory, candidate, compare, source });
+    const recipePath = context.artifactPath(`${id}-wp-codebox-recipe`, { kind: 'json', extension: 'json' });
+    await writeJson(recipePath, recipe, { redact: false });
+
+    const server = source.server ? createStaticFileServer(source.server.root) : undefined;
+    if (server) await listen(server, source.server.port);
+
+    let codeboxResult;
+    try {
+        const wpCodeboxCli = options.wpCodeboxCli || process.env.WP_CODEBOX_CLI;
+        if (!wpCodeboxCli) {
+            throw new Error('runVisualParityWorkload requires wpCodeboxCli or WP_CODEBOX_CLI.');
+        }
+        const result = await runNode([wpCodeboxCli, 'recipe-run', '--recipe', recipePath, '--json'], {
+            cwd,
+            timeoutMs: options.timeoutMs,
+            redact: false,
+        });
+        codeboxResult = parseJsonOutput(result.stdout, 'WP Codebox recipe output');
+    } finally {
+        if (server) server.close();
+    }
+
+    const visualDiffRef = findVisualCompareArtifactRef(codeboxResult) || 'files/browser/visual-compare/visual-diff.json';
+    const visualDiffPath = path.join(artifactDirectory, visualDiffRef);
+    const visualDiff = parseJsonOutput(await readFile(visualDiffPath, 'utf8'), visualDiffPath);
+    const normalized = normalizeVisualParityArtifact({
+        artifactDirectory,
+        candidate,
+        codeboxResult,
+        compare,
+        recipePath,
+        source,
+        visualDiff,
+        visualDiffRef,
+    });
+    const artifact = await context.writeJson(options.artifactName || 'visual-parity-artifact', normalized, {
+        label: options.artifactLabel || 'Visual parity artifact',
+        kind: 'visual-parity-artifact',
+        redact: false,
+    });
+
+    return {
+        metrics: {
+            visual_parity_pass: normalized.summary.pass ? 1 : 0,
+            visual_parity_mismatch_ratio: metric(normalized.summary.mismatch_ratio),
+            visual_parity_mismatch_pixels: metric(normalized.summary.mismatch_pixels),
+            visual_parity_total_pixels: metric(normalized.summary.total_pixels),
+            visual_parity_dimension_mismatch: normalized.summary.dimension_mismatch ? 1 : 0,
+        },
+        artifacts: {
+            visualParity: artifact,
+        },
+        metadata: {
+            visual_parity_schema: normalized.schema,
+            visual_parity_status: normalized.summary.status,
+            visual_parity_threshold: normalized.summary.threshold,
+            codebox_recipe: recipePath,
+        },
+    };
+}
+
 export async function detectPackageManager(cwd = process.env.HOMEBOY_COMPONENT_PATH || process.cwd()) {
     const root = resolvePath(cwd);
     if (await fileExists(path.join(root, 'pnpm-lock.yaml'))) return 'pnpm';
@@ -313,6 +400,248 @@ function sanitizeSegment(value) {
         .replace(/[^A-Za-z0-9._-]+/g, '-')
         .replace(/^-+|-+$/g, '');
     return segment || 'workload';
+}
+
+function normalizeVisualParitySource(source, options = {}) {
+    if (!source || typeof source !== 'object' || Array.isArray(source)) {
+        throw new Error('runVisualParityWorkload requires source to be an object.');
+    }
+    const label = String(source.label || source.ref || 'source');
+    if (source.url) {
+        return { label, ref: source.ref || null, url: String(source.url), path: source.path || null };
+    }
+    if (!source.path) {
+        throw new Error('runVisualParityWorkload source requires url or path.');
+    }
+    const root = resolvePath(source.path, { baseDir: options.cwd });
+    const port = Number(source.port || source.serverPort || 4173);
+    if (!Number.isInteger(port) || port <= 0) {
+        throw new Error(`runVisualParityWorkload source port must be a positive integer: ${source.port}`);
+    }
+    const entry = source.entry || 'index.html';
+    return {
+        label,
+        ref: source.ref || null,
+        path: root,
+        url: `http://127.0.0.1:${port}/${String(entry).replace(/^\/+/, '')}`,
+        server: { root, port },
+    };
+}
+
+function normalizeVisualParityCandidate(candidate) {
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+        throw new Error('runVisualParityWorkload requires candidate to be an object.');
+    }
+    if (!candidate.url) {
+        throw new Error('runVisualParityWorkload candidate requires url.');
+    }
+    return {
+        label: String(candidate.label || candidate.ref || 'candidate'),
+        ref: candidate.ref || null,
+        url: String(candidate.url),
+        recipe: candidate.recipe && typeof candidate.recipe === 'object' && !Array.isArray(candidate.recipe) ? candidate.recipe : {},
+        context: candidate.context && typeof candidate.context === 'object' && !Array.isArray(candidate.context) ? candidate.context : {},
+    };
+}
+
+function normalizeVisualParityCompareOptions(options) {
+    const viewport = normalizeViewport(options.viewport || { width: options.width, height: options.height });
+    const threshold = Number(options.threshold ?? options.maxMismatchRatio ?? 0.015);
+    if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+        throw new Error(`runVisualParityWorkload threshold must be between 0 and 1: ${threshold}`);
+    }
+    return {
+        viewport,
+        threshold,
+        pixelThreshold: Number(options.pixelThreshold ?? 0.1),
+        fullPage: options.fullPage !== false,
+        waitFor: String(options.waitFor || 'domcontentloaded'),
+        includeAA: Boolean(options.includeAA),
+        maxRegions: positiveInteger(options.maxRegions, 8),
+    };
+}
+
+function normalizeViewport(viewport) {
+    const width = Number(viewport?.width ?? 1280);
+    const height = Number(viewport?.height ?? 1600);
+    if (!Number.isInteger(width) || width <= 0 || !Number.isInteger(height) || height <= 0) {
+        throw new Error(`runVisualParityWorkload viewport must include positive integer width and height: ${JSON.stringify(viewport)}`);
+    }
+    return { width, height };
+}
+
+function positiveInteger(value, fallback) {
+    const parsed = Number(value ?? fallback);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function buildVisualParityRecipe({ artifactDirectory, candidate, compare, source }) {
+    const visualCompareStep = {
+        command: 'wordpress.visual-compare',
+        args: [
+            `source-url=${source.url}`,
+            `candidate-url=${candidate.url}`,
+            `source-label=${source.label}`,
+            `candidate-label=${candidate.label}`,
+            `viewport=${compare.viewport.width}x${compare.viewport.height}`,
+            `full-page=${compare.fullPage ? 'true' : 'false'}`,
+            `wait-for=${compare.waitFor}`,
+            `threshold=${compare.pixelThreshold}`,
+            `include-aa=${compare.includeAA ? 'true' : 'false'}`,
+            `max-regions=${compare.maxRegions}`,
+        ],
+    };
+    const base = {
+        schema: 'wp-codebox/workspace-recipe/v1',
+        workflow: {},
+        artifacts: { directory: artifactDirectory },
+    };
+    const recipe = deepMerge(base, candidate.recipe);
+    const setupSteps = Array.isArray(candidate.recipe?.workflow?.steps) ? candidate.recipe.workflow.steps : [];
+    return {
+        ...recipe,
+        workflow: {
+            ...(recipe.workflow || {}),
+            steps: [...setupSteps, visualCompareStep],
+        },
+        artifacts: {
+            ...(recipe.artifacts || {}),
+            directory: artifactDirectory,
+        },
+    };
+}
+
+function normalizeVisualParityArtifact({ artifactDirectory, candidate, codeboxResult, compare, recipePath, source, visualDiff, visualDiffRef }) {
+    const comparison = visualDiff.comparison || {};
+    const mismatchPixels = metric(comparison.mismatchPixels);
+    const totalPixels = metric(comparison.totalPixels);
+    const mismatchRatio = totalPixels > 0 ? metric(comparison.mismatchRatio, mismatchPixels / totalPixels) : metric(comparison.mismatchRatio);
+    const dimensionMismatch = Boolean(comparison.dimensionMismatch);
+    const status = mismatchRatio <= compare.threshold && !dimensionMismatch ? 'passed' : 'failed';
+    const files = visualDiff.files || {};
+    return {
+        schema: 'homeboy/VisualParityArtifact/v1',
+        source: {
+            label: source.label,
+            ref: source.ref,
+            path: source.path,
+            url: source.url,
+        },
+        candidate: {
+            label: candidate.label,
+            ref: candidate.ref,
+            url: candidate.url,
+            context: candidate.context,
+        },
+        summary: {
+            status,
+            pass: status === 'passed',
+            threshold: compare.threshold,
+            mismatch_ratio: mismatchRatio,
+            mismatch_pixels: mismatchPixels,
+            total_pixels: totalPixels,
+            dimension_mismatch: dimensionMismatch,
+            region_count: Array.isArray(comparison.regions) ? comparison.regions.length : 0,
+        },
+        viewport: visualDiff.viewport || compare.viewport,
+        options: {
+            wait_for: compare.waitFor,
+            full_page: compare.fullPage,
+            pixel_threshold: compare.pixelThreshold,
+            include_aa: compare.includeAA,
+            max_regions: compare.maxRegions,
+        },
+        artifacts: {
+            directory: artifactDirectory,
+            visual_diff: visualDiffRef,
+            source_screenshot: files.sourceScreenshot || null,
+            candidate_screenshot: files.candidateScreenshot || null,
+            diff_screenshot: files.diffScreenshot || null,
+            summary: files.summary || null,
+            explanation: files.visualExplanation || null,
+        },
+        codebox: {
+            schema: visualDiff.schema || null,
+            status: visualDiff.status || null,
+            recipe: recipePath,
+            success: codeboxResult?.success === true,
+        },
+        raw: {
+            comparison,
+            limitations: visualDiff.limitations || [],
+        },
+    };
+}
+
+function findVisualCompareArtifactRef(codeboxResult) {
+    const commands = Array.isArray(codeboxResult?.commands) ? codeboxResult.commands : [];
+    for (const command of commands) {
+        const artifact = command?.artifact || command?.result?.artifact;
+        const ref = artifact?.files?.visualDiff;
+        if (typeof ref === 'string' && ref) return ref;
+    }
+    return undefined;
+}
+
+function parseJsonOutput(value, label) {
+    try {
+        return JSON.parse(value);
+    } catch (error) {
+        throw new Error(`Unable to parse ${label} as JSON: ${error.message}`);
+    }
+}
+
+function deepMerge(base, override) {
+    if (!override || typeof override !== 'object' || Array.isArray(override)) return base;
+    const merged = { ...base };
+    for (const [key, value] of Object.entries(override)) {
+        if (value && typeof value === 'object' && !Array.isArray(value) && base[key] && typeof base[key] === 'object' && !Array.isArray(base[key])) {
+            merged[key] = deepMerge(base[key], value);
+        } else {
+            merged[key] = value;
+        }
+    }
+    return merged;
+}
+
+function createStaticFileServer(root) {
+    const contentTypes = new Map([
+        ['.css', 'text/css; charset=utf-8'],
+        ['.html', 'text/html; charset=utf-8'],
+        ['.js', 'text/javascript; charset=utf-8'],
+        ['.json', 'application/json; charset=utf-8'],
+        ['.png', 'image/png'],
+        ['.jpg', 'image/jpeg'],
+        ['.jpeg', 'image/jpeg'],
+        ['.svg', 'image/svg+xml'],
+        ['.webp', 'image/webp'],
+    ]);
+    return createServer((request, response) => {
+        const url = new URL(request.url || '/', `http://${request.headers.host || '127.0.0.1'}`);
+        const requestedPath = decodeURIComponent(url.pathname === '/' ? '/index.html' : url.pathname);
+        const resolved = path.normalize(path.join(root, requestedPath));
+        if (!resolved.startsWith(root)) {
+            response.writeHead(403);
+            response.end('Forbidden');
+            return;
+        }
+        createReadStream(resolved)
+            .on('error', () => {
+                response.writeHead(404);
+                response.end('Not found');
+            })
+            .once('open', () => {
+                response.writeHead(200, { 'content-type': contentTypes.get(path.extname(resolved).toLowerCase()) || 'application/octet-stream' });
+            })
+            .pipe(response);
+    });
+}
+
+function listen(server, port) {
+    return new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(port, '127.0.0.1', resolve);
+    });
 }
 
 async function readPackageJson(cwd, packageJsonPath) {

--- a/nodejs/scripts/bench/nodejs-workload-utils-smoke.sh
+++ b/nodejs/scripts/bench/nodejs-workload-utils-smoke.sh
@@ -15,7 +15,7 @@ HOMEBOY_SETTINGS_ENV_LIST='one, two,,three' \
 HOMEBOY_SETTINGS_ENV_JSON='{"source":"env"}' \
 WORKLOAD_UTILS_UNDER_TEST="$SCRIPT_DIR/lib/workload-utils.mjs" \
 node --input-type=module - <<'EOF'
-import { readFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const utils = await import(process.env.WORKLOAD_UTILS_UNDER_TEST);
@@ -115,6 +115,76 @@ if (utils.percentile([1, Number.NaN, 3], 50) !== 2) throw new Error('percentile 
 const context = utils.createArtifactContext({ id: 'Utility Smoke', runId: 'utility-run', artifactsDir: join(process.env.HOMEBOY_COMPONENT_PATH, 'context-artifacts') });
 const descriptor = await context.writeJson('raw result', { token: 'abc', keep: 'visible' });
 if (descriptor.kind !== 'json') throw new Error('artifact context wrapper did not write JSON artifact');
+
+const sourceDir = join(process.env.HOMEBOY_COMPONENT_PATH, 'source-site');
+await mkdir(sourceDir, { recursive: true });
+await writeFile(join(sourceDir, 'index.html'), '<main>Source</main>');
+const fakeCli = join(process.env.HOMEBOY_COMPONENT_PATH, 'fake-wp-codebox-cli.mjs');
+await writeFile(fakeCli, `#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const recipePath = process.argv[process.argv.indexOf('--recipe') + 1];
+const recipe = JSON.parse(await readFile(recipePath, 'utf8'));
+const compareStep = recipe.workflow.steps.find((step) => step.command === 'wordpress.visual-compare');
+const args = compareStep.args;
+const arg = (name) => args.find((item) => item.startsWith(name + '='))?.slice(name.length + 1);
+const sourceResponse = await fetch(arg('source-url'));
+if (!sourceResponse.ok) throw new Error('source URL was not served');
+const dir = join(recipe.artifacts.directory, 'files/browser/visual-compare');
+await mkdir(dir, { recursive: true });
+await writeFile(join(dir, 'source.png'), 'source');
+await writeFile(join(dir, 'candidate.png'), 'candidate');
+await writeFile(join(dir, 'diff.png'), 'diff');
+const visual = {
+  schema: 'wp-codebox/visual-compare/v1',
+  status: 'different',
+  files: {
+    sourceScreenshot: 'files/browser/visual-compare/source.png',
+    candidateScreenshot: 'files/browser/visual-compare/candidate.png',
+    diffScreenshot: 'files/browser/visual-compare/diff.png',
+    visualDiff: 'files/browser/visual-compare/visual-diff.json',
+    summary: 'files/browser/visual-compare/summary.json'
+  },
+  viewport: { width: 640, height: 480 },
+  comparison: { mismatchPixels: 10, totalPixels: 1000, mismatchRatio: 0.01, dimensionMismatch: false, regions: [{ x: 1, y: 2, width: 3, height: 4 }] }
+};
+await writeFile(join(dir, 'visual-diff.json'), JSON.stringify(visual, null, 2));
+await writeFile(join(dir, 'summary.json'), JSON.stringify(visual, null, 2));
+process.stdout.write(JSON.stringify({
+  success: true,
+  commands: [{ artifact: { files: { visualDiff: 'files/browser/visual-compare/visual-diff.json' } } }]
+}));
+`);
+await chmod(fakeCli, 0o755);
+
+const visualResult = await utils.runVisualParityWorkload({
+  id: 'Visual Contract',
+  artifactsDir: join(process.env.HOMEBOY_COMPONENT_PATH, 'visual-artifacts'),
+  runId: 'visual-run',
+  wpCodeboxCli: fakeCli,
+  source: { path: sourceDir, ref: 'source-ref', label: 'static-source', port: 48531 },
+  candidate: {
+    url: '/',
+    ref: 'candidate-ref',
+    label: 'candidate-wordpress',
+    context: { runtime: 'playground' },
+    recipe: { runtime: { wp: 'latest' }, inputs: { mounts: [] }, workflow: { steps: [{ command: 'wordpress.setup', args: [] }] } },
+  },
+  viewport: { width: 640, height: 480 },
+  threshold: 0.02,
+});
+if (visualResult.metrics.visual_parity_pass !== 1) throw new Error('visual parity pass metric was not set');
+if (visualResult.metrics.visual_parity_mismatch_ratio !== 0.01) throw new Error('visual parity mismatch ratio metric was not normalized');
+const visualArtifact = JSON.parse(await readFile(visualResult.artifacts.visualParity.path, 'utf8'));
+if (visualArtifact.schema !== 'homeboy/VisualParityArtifact/v1') throw new Error('visual artifact schema mismatch');
+if (visualArtifact.source.ref !== 'source-ref' || visualArtifact.candidate.ref !== 'candidate-ref') throw new Error('visual artifact refs were not preserved');
+if (visualArtifact.summary.status !== 'passed' || visualArtifact.summary.region_count !== 1) throw new Error('visual artifact summary was not normalized');
+if (visualArtifact.artifacts.visual_diff !== 'files/browser/visual-compare/visual-diff.json') throw new Error('visual diff artifact ref was not preserved');
+const recipeArtifact = JSON.parse(await readFile(visualResult.metadata.codebox_recipe, 'utf8'));
+if (recipeArtifact.runtime.wp !== 'latest') throw new Error('candidate recipe runtime was not merged');
+if (recipeArtifact.workflow.steps[0].command !== 'wordpress.setup') throw new Error('candidate setup step was not preserved before visual compare');
+if (!recipeArtifact.workflow.steps[1].args.includes('viewport=640x480')) throw new Error('visual compare viewport was not forwarded');
 EOF
 
 echo "Node.js workload utils smoke passed."


### PR DESCRIPTION
## Summary
- Add `runVisualParityWorkload()` to the Node.js workload utilities.
- Build a WP Codebox `wordpress.visual-compare` recipe from a source URL/path, candidate WordPress recipe/context, viewport, and thresholds.
- Emit a normalized `homeboy/VisualParityArtifact/v1` artifact while preserving the underlying WP Codebox artifact references.
- Document the generic contract and cover it with a fake WP Codebox CLI smoke test.

## Tests
- `bash nodejs/scripts/bench/nodejs-workload-utils-smoke.sh`
- `bash nodejs/scripts/bench/nodejs-browser-page-scenario-smoke.sh`
- `git diff --check`

## Notes
- WP Codebox already owns the generic `wordpress.visual-compare` browser command and artifact files. This PR keeps the reusable workload normalization in Homeboy Extensions without adding site-specific WPSG policy.
- No companion WP Codebox PR is needed for this foundation. WPSG can consume this helper and delete its local normalization wrapper in a follow-up.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated ownership across WPSG, WP Codebox, and Homeboy Extensions; drafted the helper, smoke coverage, and documentation for Chris to review.