### PR TITLE
Split Codebox runtime from Data Machine CI policy

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -146,7 +146,8 @@ jobs:
 
 - Agent CI runs through the selected `agent_runtime`. Today the only supported value is `wp-codebox`, and the workflow checks out/builds `Automattic/wp-codebox` for that runtime.
 - `agent_runtime_ref` controls the selected runtime ref.
-- `include_agent_runtime_dependencies` defaults to `true` and checks out the standard WordPress agent runtime stack: `Automattic/agents-api`, `Extra-Chill/data-machine`, `Extra-Chill/data-machine-code`, and the provider plugin.
+- Generic WP Codebox executor paths accept caller-supplied component contracts, runtime overlays, mounts, task payload, provider defaults, and declarative runtime requirements. Data Machine Agent CI policy lives in this reusable workflow and runner adapter, not in the generic WP Codebox provider manifest.
+- `include_agent_runtime_dependencies` defaults to `true` and checks out the Data Machine Agent CI stack: `Automattic/agents-api`, `Extra-Chill/data-machine`, `Extra-Chill/data-machine-code`, and the provider plugin. The runner adapter forwards those paths to WP Codebox as explicit runtime component requirements.
 - `agents_api_ref`, `data_machine_ref`, `data_machine_code_ref`, and `openai_provider_ref` control runtime dependency refs. `openai_provider_ref` defaults to `trunk` for the built-in OpenAI preset.
 - `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `credentials` keys. When `provider: openai`, an empty object preserves the existing OpenAI provider defaults.
 - `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -152,7 +152,7 @@ function runtimeProviderCapabilities() {
 }
 
 function runtimeWorkspaceTools(options = {}) {
-  const configured = firstObject(options.workspaceTools, runtimeExecutorManifest().workspace_tools) || {};
+  const configured = firstObject(options.workspaceTools, options.workspace_tools, runtimeExecutorManifest().workspace_tools) || {};
   return {
     readonly: normalizeArray(configured.readonly),
     readwrite: normalizeArray(configured.readwrite),
@@ -160,7 +160,7 @@ function runtimeWorkspaceTools(options = {}) {
 }
 
 function runtimeComponentPathDefaults(options = {}) {
-  return firstObject(options.componentPathDefaults, runtimeExecutorManifest().component_path_defaults) || {};
+  return firstObject(options.componentPathDefaults, options.component_path_defaults, runtimeExecutorManifest().component_path_defaults) || {};
 }
 
 function runtimeComponentPathAliases(options = {}) {
@@ -186,36 +186,37 @@ function runtimeSecretEnvRequirements() {
 function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   assertAgentTaskRequest(request);
   const config = request.executor.config || {};
+  const runtimeOptions = runtimeOptionsFromExecutorConfig(config, options);
   const inputs = request.inputs || {};
-  const defaults = defaultCodeboxRuntimeConfig(request, config, inputs, options);
-  const workspaceMaterialization = defaultWorkspaceMaterialization(defaults.workspaceRoot, request, config, inputs, options);
+  const defaults = defaultCodeboxRuntimeConfig(request, config, inputs, runtimeOptions);
+  const workspaceMaterialization = defaultWorkspaceMaterialization(defaults.workspaceRoot, request, config, inputs, runtimeOptions);
   const target = defaultWorkspaceTargetPayload(inputs.target || request.workspace || {}, workspaceMaterialization);
   const agentBundle = agentBundleConfigFromAgentTaskRequest(request, config, inputs);
   const recipe = recipeConfigFromAgentTaskRequest(request, config, inputs);
-  const mounts = agentBundleMounts(agentBundle, config.runtime_mounts || config.mounts || defaults.mounts || options.mounts || []);
-  const componentContracts = componentContractsFromAgentTaskRequest(request, config, options);
-  const components = runtimeComponentPaths(config, { ...defaults, ...options, componentContracts });
-  const agentBundles = firstDefined(inputs.agent_bundles, inputs.agentBundles, config.agent_bundles, config.agentBundles, options.agentBundles, []);
-  const structuredArtifacts = firstDefined(inputs.structured_artifacts, inputs.structuredArtifacts, config.structured_artifacts, config.structuredArtifacts, options.structuredArtifacts, []);
-  const artifactDeclarations = artifactDeclarationsFromAgentTaskRequest(request, config, inputs, options);
-  const allowedTools = allowedToolsFromAgentTaskRequest(request, config, inputs, options, defaults);
-  const sandboxToolPolicy = sandboxToolPolicyFromAgentTaskRequest(config, inputs, options, defaults, allowedTools);
-  const provider = config.provider || options.provider || defaults.provider || '';
-  const model = request.executor.model || config.model || options.model || defaults.model || '';
-  const agent = firstValue(config.agent, options.agent, '');
+  const mounts = agentBundleMounts(agentBundle, config.runtime_mounts || config.mounts || defaults.mounts || runtimeOptions.mounts || []);
+  const componentContracts = componentContractsFromAgentTaskRequest(request, config, runtimeOptions);
+  const components = runtimeComponentPaths(config, { ...defaults, ...runtimeOptions, componentContracts });
+  const agentBundles = firstDefined(inputs.agent_bundles, inputs.agentBundles, config.agent_bundles, config.agentBundles, runtimeOptions.agentBundles, []);
+  const structuredArtifacts = firstDefined(inputs.structured_artifacts, inputs.structuredArtifacts, config.structured_artifacts, config.structuredArtifacts, runtimeOptions.structuredArtifacts, []);
+  const artifactDeclarations = artifactDeclarationsFromAgentTaskRequest(request, config, inputs, runtimeOptions);
+  const allowedTools = allowedToolsFromAgentTaskRequest(request, config, inputs, runtimeOptions, defaults);
+  const sandboxToolPolicy = sandboxToolPolicyFromAgentTaskRequest(config, inputs, runtimeOptions, defaults, allowedTools);
+  const provider = config.provider || runtimeOptions.provider || defaults.provider || '';
+  const model = request.executor.model || config.model || runtimeOptions.model || defaults.model || '';
+  const agent = firstValue(config.agent, runtimeOptions.agent, '');
   const runtimeTask = runtimeTaskWithExecutionDefaults(
-    inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(request, config, inputs) || options.runtimeTask,
+    inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(request, config, inputs) || runtimeOptions.runtimeTask,
     { provider, model, agentBundles }
   );
   const explicitSecretEnv = [
     ...normalizeArray(request.executor?.secret_env),
     ...normalizeArray(config.secret_env),
-    ...normalizeArray(options.secretEnv),
+    ...normalizeArray(runtimeOptions.secretEnv),
   ];
   const timeoutSeconds = request.limits?.task_timeout_seconds || request.limits?.taskTimeoutSeconds;
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
   const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
-  const runtimeOverlays = runtimeOverlaysFromConfig(config, options, defaults);
+  const runtimeOverlays = runtimeOverlaysFromConfig(config, runtimeOptions, defaults);
   const context = {
     ...(inputs.context || {}),
     agent_task_id: request.task_id,
@@ -239,43 +240,43 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     recipe,
     sandbox_tool_policy: sandboxToolPolicy,
     runtime_task: runtimeTask,
-    ability_tools: firstDefined(inputs.ability_tools, inputs.abilityTools, config.ability_tools, config.abilityTools, options.abilityTools, []),
+    ability_tools: firstDefined(inputs.ability_tools, inputs.abilityTools, config.ability_tools, config.abilityTools, runtimeOptions.abilityTools, []),
     structured_artifacts: structuredArtifacts,
     sandbox_session_id: config.sandbox_session_id || request.task_id,
     session_id: config.session_id || config.sessionId || '',
     ...(agent ? { agent } : {}),
-    mode: config.mode || options.mode || 'sandbox',
+    mode: config.mode || runtimeOptions.mode || 'sandbox',
     provider,
     model,
     provider_plugin_paths: firstNonEmptyArray(
       config.provider_plugin_paths,
-      options.providerPluginPaths,
+      runtimeOptions.providerPluginPaths,
       defaults.providerPluginPaths,
       []
     ),
     agent_bundles: agentBundles,
-    runtime_stack_mounts: config.runtime_stack_mounts || options.runtimeStackMounts || [],
-    runtime_overlay_profiles: config.runtime_overlay_profiles || config.runtimeOverlayProfiles || options.runtimeOverlayProfiles || defaults.runtimeOverlayProfiles || [],
+    runtime_stack_mounts: config.runtime_stack_mounts || runtimeOptions.runtimeStackMounts || [],
+    runtime_overlay_profiles: config.runtime_overlay_profiles || config.runtimeOverlayProfiles || runtimeOptions.runtimeOverlayProfiles || defaults.runtimeOverlayProfiles || [],
     runtime_overlays: runtimeOverlays,
-    runtime_env: firstDefined(config.runtime_env, config.runtimeEnv, config.wp_codebox_runtime_env, options.runtimeEnv, defaults.runtimeEnv, {}),
-    runtime_state_mounts: firstDefined(config.runtime_state_mounts, config.runtimeStateMounts, config.wp_codebox_runtime_state_mounts, options.runtimeStateMounts, defaults.runtimeStateMounts, []),
-    runtime_config_mounts: firstDefined(config.runtime_config_mounts, config.runtimeConfigMounts, config.wp_codebox_runtime_config_mounts, options.runtimeConfigMounts, defaults.runtimeConfigMounts, []),
+    runtime_env: firstDefined(config.runtime_env, config.runtimeEnv, config.wp_codebox_runtime_env, runtimeOptions.runtimeEnv, defaults.runtimeEnv, {}),
+    runtime_state_mounts: firstDefined(config.runtime_state_mounts, config.runtimeStateMounts, config.wp_codebox_runtime_state_mounts, runtimeOptions.runtimeStateMounts, defaults.runtimeStateMounts, []),
+    runtime_config_mounts: firstDefined(config.runtime_config_mounts, config.runtimeConfigMounts, config.wp_codebox_runtime_config_mounts, runtimeOptions.runtimeConfigMounts, defaults.runtimeConfigMounts, []),
     secret_env: explicitSecretEnv.length > 0 ? Array.from(new Set(explicitSecretEnv)) : defaults.secretEnv || [],
     // Post-agent verification gate (recipe workflow.after). Supplied as WP
     // Codebox recipe steps; a non-zero exit fails the run so the orchestrator
     // refuses to report success until the gates are green.
-    verify_steps: inputs.verify_steps || config.verify_steps || options.verifySteps || [],
+    verify_steps: inputs.verify_steps || config.verify_steps || runtimeOptions.verifySteps || [],
     mounts,
-    workspaces: inputs.workspaces || config.workspaces || options.workspaces || defaults.workspaces || [],
+    workspaces: inputs.workspaces || config.workspaces || runtimeOptions.workspaces || defaults.workspaces || [],
     runtime_component_paths: components,
     component_contracts: componentContracts,
-    homeboy_path: config.homeboy || config.homeboy_path || options.homeboy || '',
-    homeboy_extensions_path: config.homeboy_extensions || config.homeboy_extensions_path || options.homeboyExtensions || '',
-    wp_codebox_bin: firstValue(config.runtime_bin, config.wp_codebox_bin, config.wpCodeboxBin, options.wpCodeboxBin, defaults.wpCodeboxBin, ''),
-    wp: config.runtime_wordpress_version || config.wp_codebox_wordpress_version || config.wpCodeboxWordpressVersion || config.wp || config.wordpress_version || options.wpCodeboxWordpressVersion || '',
-    artifacts_path: config.artifacts || config.artifacts_path || options.artifacts || '',
-    max_turns: config.max_turns || options.maxTurns,
-    task_timeout_seconds: config.task_timeout_seconds || timeoutSeconds || timeoutFromMs || options.taskTimeoutSeconds,
+    homeboy_path: config.homeboy || config.homeboy_path || runtimeOptions.homeboy || '',
+    homeboy_extensions_path: config.homeboy_extensions || config.homeboy_extensions_path || runtimeOptions.homeboyExtensions || '',
+    wp_codebox_bin: firstValue(config.runtime_bin, config.wp_codebox_bin, config.wpCodeboxBin, runtimeOptions.wpCodeboxBin, defaults.wpCodeboxBin, ''),
+    wp: config.runtime_wordpress_version || config.wp_codebox_wordpress_version || config.wpCodeboxWordpressVersion || config.wp || config.wordpress_version || runtimeOptions.wpCodeboxWordpressVersion || '',
+    artifacts_path: config.artifacts || config.artifacts_path || runtimeOptions.artifacts || '',
+    max_turns: config.max_turns || runtimeOptions.maxTurns,
+    task_timeout_seconds: config.task_timeout_seconds || timeoutSeconds || timeoutFromMs || runtimeOptions.taskTimeoutSeconds,
     orchestrator: {
       ...(inputs.orchestrator || {}),
       agent_task_id: request.task_id,
@@ -284,6 +285,20 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     },
     agent_bundle: agentBundle,
     parent_request: request,
+  };
+}
+
+function runtimeOptionsFromExecutorConfig(config = {}, options = {}) {
+  const directComponentPathDefaults = firstObject(config.component_path_defaults, config.componentPathDefaults);
+  const runtimeRequirements = firstObject(config.runtime_requirements, config.runtimeRequirements) || {};
+  const componentPathDefaults = directComponentPathDefaults || firstObject(options.componentPathDefaults, options.component_path_defaults, runtimeRequirements.component_path_defaults, runtimeRequirements.componentPathDefaults);
+  return {
+    ...options,
+    workspaceTools: firstObject(options.workspaceTools, options.workspace_tools, config.workspace_tools, config.workspaceTools, runtimeRequirements.workspace_tools, runtimeRequirements.workspaceTools),
+    componentPathDefaults,
+    componentPathAliases: firstObject(options.componentPathAliases, options.component_path_aliases, config.component_path_aliases, config.componentPathAliases, componentPathDefaults?.path_aliases, runtimeRequirements.component_path_aliases, runtimeRequirements.componentPathAliases),
+    componentContractSlugMap: firstObject(options.componentContractSlugMap, options.component_contract_slug_map, config.component_contract_slug_map, config.componentContractSlugMap, componentPathDefaults?.contract_slug_map, runtimeRequirements.component_contract_slug_map, runtimeRequirements.componentContractSlugMap),
+    componentDiscovery: firstObject(options.componentDiscovery, options.component_discovery, config.component_discovery, config.componentDiscovery, componentPathDefaults?.discovery, runtimeRequirements.component_discovery, runtimeRequirements.componentDiscovery),
   };
 }
 

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -100,15 +100,7 @@
         "agent_bundle_execution",
         "typed_bundle_outputs",
         "external_recipe_packs",
-        "recipe_probe_artifacts",
-        "tool:datamachine/run-agent-bundle",
-        "tool:github_issue_publish",
-        "tool:github_pull_request_publish",
-        "tool:comment_github_pull_request",
-        "ability:datamachine/run-agent-bundle",
-        "ability:github_issue_publish",
-        "ability:github_pull_request_publish",
-        "ability:comment_github_pull_request"
+        "recipe_probe_artifacts"
       ],
       "workspace_materialization": {
         "cwd": "git_checkout"
@@ -128,70 +120,7 @@
           "workspace_git_add"
         ]
       },
-      "component_path_defaults": {
-        "contract_slug_map": {
-          "agents-api": "agents_api",
-          "data-machine": "agent_runtime",
-          "data-machine-code": "agent_runtime_tools"
-        },
-        "path_aliases": {
-          "agents_api": [
-            "explicit:agents_api",
-            "runtime_component:agents_api",
-            "contract:agents_api",
-            "config:agents_api",
-            "config_path:agents_api",
-            "option:agentsApi"
-          ],
-          "agent_runtime": [
-            "explicit:agent_runtime",
-            "runtime_component:agent_runtime",
-            "runtime_component:data_machine",
-            "contract:agent_runtime",
-            "config:agent_runtime",
-            "config_path:agent_runtime",
-            "config:data_machine",
-            "config_path:data_machine",
-            "option:legacyRuntime"
-          ],
-          "agent_runtime_tools": [
-            "explicit:agent_runtime_tools",
-            "runtime_component:agent_runtime_tools",
-            "runtime_component:data_machine_code",
-            "contract:agent_runtime_tools",
-            "config:agent_runtime_tools",
-            "config_path:agent_runtime_tools",
-            "config:data_machine_code",
-            "config_path:data_machine_code",
-            "option:legacyRuntimeTools"
-          ]
-        },
-        "discovery": {
-          "agents_api": [
-            { "settings": ["wp_codebox_agents_api_path", "agents_api_path"] },
-            { "env": "HOMEBOY_WP_CODEBOX_AGENTS_API_PATH" },
-            {
-              "bundled_provider": "agent_runtime",
-              "paths": [
-                "vendor/wordpress/agents-api",
-                "vendor/automattic/agents-api"
-              ]
-            }
-          ],
-          "agent_runtime": [
-            { "settings": ["wp_codebox_data_machine_path", "data_machine_path"] },
-            { "env": "HOMEBOY_DATA_MACHINE_PATH" },
-            { "active_plugin": "data-machine" },
-            { "sibling": "data-machine" }
-          ],
-          "agent_runtime_tools": [
-            { "settings": ["wp_codebox_data_machine_code_path", "data_machine_code_path"] },
-            { "env": "HOMEBOY_DATA_MACHINE_CODE_PATH" },
-            { "active_plugin": "data-machine-code" },
-            { "sibling": "data-machine-code" }
-          ]
-        }
-      },
+      "component_path_defaults": {},
       "provider_defaults": {
         "openai": {
           "secret_env": ["OPENAI_API_KEY"]

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -144,6 +144,11 @@ Common fields:
 The provider must not infer workspace shape from WP Codebox, WordPress, or any
 other current runtime unless that shape is declared here.
 
+Caller-owned wrappers should pass domain-specific runtime requirements explicitly.
+For example, Data Machine Agent CI supplies its Agents API, Data Machine, Data
+Machine Code, workspace-tool, and ability-policy defaults before invoking the
+generic WP Codebox provider.
+
 ## Outcome And Diagnostic Contracts
 
 Provider outcomes should include:

--- a/wordpress/lib/datamachine-agent-ci-codebox-adapter.js
+++ b/wordpress/lib/datamachine-agent-ci-codebox-adapter.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS = {
+  contract_slug_map: {
+    'agents-api': 'agents_api',
+    'data-machine': 'agent_runtime',
+    'data-machine-code': 'agent_runtime_tools',
+  },
+  path_aliases: {
+    agents_api: [
+      'explicit:agents_api',
+      'runtime_component:agents_api',
+      'contract:agents_api',
+      'config:agents_api',
+      'config_path:agents_api',
+      'option:agentsApi',
+    ],
+    agent_runtime: [
+      'explicit:agent_runtime',
+      'runtime_component:agent_runtime',
+      'runtime_component:data_machine',
+      'contract:agent_runtime',
+      'config:agent_runtime',
+      'config_path:agent_runtime',
+      'config:data_machine',
+      'config_path:data_machine',
+      'option:legacyRuntime',
+    ],
+    agent_runtime_tools: [
+      'explicit:agent_runtime_tools',
+      'runtime_component:agent_runtime_tools',
+      'runtime_component:data_machine_code',
+      'contract:agent_runtime_tools',
+      'config:agent_runtime_tools',
+      'config_path:agent_runtime_tools',
+      'config:data_machine_code',
+      'config_path:data_machine_code',
+      'option:legacyRuntimeTools',
+    ],
+  },
+  discovery: {
+    agents_api: [
+      { settings: ['wp_codebox_agents_api_path', 'agents_api_path'] },
+      { env: 'HOMEBOY_WP_CODEBOX_AGENTS_API_PATH' },
+      {
+        bundled_provider: 'agent_runtime',
+        paths: [
+          'vendor/wordpress/agents-api',
+          'vendor/automattic/agents-api',
+        ],
+      },
+    ],
+    agent_runtime: [
+      { settings: ['wp_codebox_data_machine_path', 'data_machine_path'] },
+      { env: 'HOMEBOY_DATA_MACHINE_PATH' },
+      { active_plugin: 'data-machine' },
+      { sibling: 'data-machine' },
+    ],
+    agent_runtime_tools: [
+      { settings: ['wp_codebox_data_machine_code_path', 'data_machine_code_path'] },
+      { env: 'HOMEBOY_DATA_MACHINE_CODE_PATH' },
+      { active_plugin: 'data-machine-code' },
+      { sibling: 'data-machine-code' },
+    ],
+  },
+};
+
+const DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS = {
+  readonly: [
+    'workspace_ls',
+    'workspace_read',
+    'workspace_git_status',
+  ],
+  readwrite: [
+    'workspace_run_runner_command',
+    'workspace_write',
+    'workspace_edit',
+    'workspace_apply_patch',
+    'workspace_delete',
+    'workspace_git_add',
+  ],
+};
+
+const DATAMACHINE_AGENT_CI_CAPABILITIES = [
+  'tool:datamachine/run-agent-bundle',
+  'tool:github_issue_publish',
+  'tool:github_pull_request_publish',
+  'tool:comment_github_pull_request',
+  'ability:datamachine/run-agent-bundle',
+  'ability:github_issue_publish',
+  'ability:github_pull_request_publish',
+  'ability:comment_github_pull_request',
+];
+
+function datamachineAgentCiCodeboxExecutorConfig(config = {}) {
+  return {
+    ...config,
+    runtime_requirements: {
+      ...(config.runtime_requirements || {}),
+      component_path_defaults: config.component_path_defaults || DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
+      workspace_tools: config.workspace_tools || DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
+      capabilities: uniqueStrings([
+        ...DATAMACHINE_AGENT_CI_CAPABILITIES,
+        ...normalizeArray(config.runtime_requirements?.capabilities),
+      ]),
+    },
+    component_path_defaults: config.component_path_defaults || DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
+    workspace_tools: config.workspace_tools || DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
+  };
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function uniqueStrings(values) {
+  return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.trim() !== '')));
+}
+
+module.exports = {
+  DATAMACHINE_AGENT_CI_CAPABILITIES,
+  DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
+  DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
+  datamachineAgentCiCodeboxExecutorConfig,
+};

--- a/wordpress/scripts/agent/run-datamachine-agent-task.cjs
+++ b/wordpress/scripts/agent/run-datamachine-agent-task.cjs
@@ -10,6 +10,13 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
+/**
+ * Internal dependencies
+ */
+const {
+  datamachineAgentCiCodeboxExecutorConfig,
+} = require('../../lib/datamachine-agent-ci-codebox-adapter');
+
 const SCRIPT_DIR = __dirname;
 const EXTENSION_PATH = path.resolve(SCRIPT_DIR, '..', '..');
 const EXECUTOR = path.resolve(SCRIPT_DIR, '..', '..', '..', 'agent-runtimes', 'wp-codebox', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs');
@@ -71,7 +78,7 @@ function buildAgentTaskRequest(config, configPath) {
     agent_runtime_tools: config.agent_runtime_tools || config.agent_runtime_tools_path || runtimeComponents.data_machine_code,
     runtime: runtimeComponents.runtime,
   }).filter(([, value]) => nonEmpty(value)));
-  const executorConfig = Object.fromEntries(Object.entries({
+  const executorConfig = datamachineAgentCiCodeboxExecutorConfig(Object.fromEntries(Object.entries({
     ...config,
     execution_kind: config.execution_kind || 'agent_bundle',
     agents_api: config.agents_api || config.agents_api_path || runtimeComponents.agents_api,
@@ -79,7 +86,7 @@ function buildAgentTaskRequest(config, configPath) {
     homeboy_extensions: config.homeboy_extensions || config.homeboy_extensions_path || EXTENSION_PATH,
     artifacts: config.artifacts_path || config.artifacts,
     replay_bundle_dir: config.replay_bundle_dir || process.env.HOMEBOY_DATAMACHINE_AGENT_REPLAY_BUNDLE_DIR,
-  }).filter(([, value]) => nonEmpty(value)));
+  }).filter(([, value]) => nonEmpty(value))));
 
   return {
     schema: 'homeboy/agent-task-request/v1',

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -9,6 +9,11 @@ const {
   codeboxTaskRequestFromAgentTaskRequest,
   providerContract,
 } = require('../../agent-runtimes/wp-codebox');
+const {
+  DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
+  DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
+  datamachineAgentCiCodeboxExecutorConfig,
+} = require('../lib/datamachine-agent-ci-codebox-adapter');
 
 const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wordpress-agent-boundary-'));
 const codexSecretEnv = [
@@ -72,8 +77,16 @@ assert.deepEqual(provider.workspace_tools.readonly, [
   'workspace_read',
   'workspace_git_status',
 ]);
-assert.equal(provider.component_path_defaults.contract_slug_map['data-machine'], 'agent_runtime');
-assert.equal(provider.component_path_defaults.path_aliases.agent_runtime.includes('runtime_component:data_machine'), true);
+assert.deepEqual(provider.component_path_defaults, {});
+assert.equal(provider.capabilities.includes('tool:datamachine/run-agent-bundle'), false);
+assert.equal(provider.capabilities.includes('ability:datamachine/run-agent-bundle'), false);
+
+const datamachineAdapterConfig = datamachineAgentCiCodeboxExecutorConfig({ provider: 'openai' });
+assert.equal(datamachineAdapterConfig.component_path_defaults.contract_slug_map['data-machine'], 'agent_runtime');
+assert.equal(datamachineAdapterConfig.component_path_defaults.path_aliases.agent_runtime.includes('runtime_component:data_machine'), true);
+assert.deepEqual(datamachineAdapterConfig.workspace_tools, DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS);
+assert.deepEqual(datamachineAdapterConfig.runtime_requirements.component_path_defaults, DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS);
+assert.equal(datamachineAdapterConfig.runtime_requirements.capabilities.includes('ability:datamachine/run-agent-bundle'), true);
 
 const customContract = providerContract({
   capabilities: ['wordpress_sandbox', 'tool:example/run-workflow'],
@@ -242,10 +255,10 @@ const repoLoopWorkspaceTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   repo: 'wp-site-generator@canonical-loop-main-20260616',
   executor: {
     backend: 'codebox',
-    config: {
+    config: datamachineAgentCiCodeboxExecutorConfig({
       provider: 'openai',
       task_kind: 'repo-cooking',
-    },
+    }),
   },
   instructions: 'Run a repo-loop workflow against the current checkout.',
   inputs: {


### PR DESCRIPTION
## Summary
- remove Data Machine and Agents API defaults from the generic WP Codebox provider manifest
- allow Codebox executor requests to supply declarative runtime requirements through executor config
- add a Data Machine Agent CI Codebox adapter that supplies the DM/Agents API/DMC component, workspace-tool, and ability-policy defaults
- update boundary tests and docs for the provider/caller split

## Tests
- `npm run test:codebox-agent-task-executor-boundary`
- `npm run test:datamachine-agent-wp-codebox-runner`
- `npx eslint --no-warn-ignored lib/datamachine-agent-ci-codebox-adapter.js scripts/agent/run-datamachine-agent-task.cjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the runtime/policy split, tests, docs, and PR description for Chris to review.