### PR TITLE
Align WP Codebox Codex secret source metadata

### DIFF
--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -145,9 +145,9 @@
               "field": "tokens.refresh_token"
             },
             "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT": {
-              "source": "json-file",
+              "source": "json-file-jwt-expiration",
               "path": "~/.codex/auth.json",
-              "field": "tokens.expires_at"
+              "field": "tokens.access_token"
             },
             "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID": {
               "source": "json-file",
@@ -157,7 +157,8 @@
             "AI_PROVIDER_OPENAI_CODEX_FEDRAMP": {
               "source": "json-file",
               "path": "~/.codex/auth.json",
-              "field": "tokens.fedramp"
+              "field": "tokens.fedramp",
+              "value": "false"
             }
           }
         },


### PR DESCRIPTION
## Summary
- derive Codex expires_at from the access token JWT in the WP Codebox runtime manifest
- default Codex fedramp to false when the auth file omits it
- align runtime metadata with the executor behavior in `codexAuthEnv()`

## Testing
- node tests/agent-runtime-contract-smoke.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the mismatch between WP Codebox runtime metadata and executor behavior, drafted the manifest update, and ran focused verification. Chris retains responsibility for review and merge.