### PR TITLE
Expose generic Data Machine runtime tasks

### DIFF
--- a/.github/scripts/datamachine-agent-ci/build-runner-config.cjs
+++ b/.github/scripts/datamachine-agent-ci/build-runner-config.cjs
@@ -27,7 +27,7 @@ function buildConfig(env) {
   const agentSlug = required(env.AGENT_SLUG, 'AGENT_SLUG');
   const flowSlug = required(env.FLOW_SLUG, 'FLOW_SLUG');
   const targetRepo = required(env.TARGET_REPO, 'TARGET_REPO');
-  const bundlePath = required(env.BUNDLE_PATH, 'BUNDLE_PATH');
+  const bundlePath = env.BUNDLE_PATH || '';
   const componentSlug = path.basename(workspace);
   const transcriptHostDir = path.join(workspace, 'datamachine-agent-artifacts', agentSlug);
   const transcriptGuestDir = `/wordpress/wp-content/plugins/${componentSlug}/datamachine-agent-artifacts/${agentSlug}`;
@@ -76,9 +76,16 @@ function buildConfig(env) {
   const workloadRunBefore = parseJsonInput('workload_run_before', env.WORKLOAD_RUN_BEFORE || '[]', 'array', []);
   const workloadRunAfter = parseJsonInput('workload_run_after', env.WORKLOAD_RUN_AFTER || '[]', 'array', []);
   const extraRequiredAbilities = parseJsonInput('extra_required_abilities', env.EXTRA_REQUIRED_ABILITIES || '[]', 'array', []);
-  const executeRequiredAbilities = executeWorkflow.path
-    ? ['datamachine/import-agent', 'datamachine/execute-workflow', 'datamachine/drain-job']
-    : ['datamachine/import-agent', 'datamachine/run-flow', 'datamachine/drain-job'];
+  const runtimeTask = runtimeTaskFromEnv(env);
+  const executionKind = env.EXECUTION_KIND || (runtimeTask ? 'runtime_task' : 'agent_bundle');
+  if (executionKind === 'agent_bundle' && !bundlePath) {
+    throw new Error('BUNDLE_PATH is required for agent_bundle execution. Set execution_kind=runtime_task with runtime_task or ability_request for direct ability execution.');
+  }
+  const executeRequiredAbilities = runtimeTask
+    ? [runtimeTask.ability]
+    : executeWorkflow.path
+      ? ['datamachine/import-agent', 'datamachine/execute-workflow', 'datamachine/drain-job']
+      : ['datamachine/import-agent', 'datamachine/run-flow', 'datamachine/drain-job'];
 
   return {
     _configPath: path.join(runnerTemp, 'datamachine-agent-config.json'),
@@ -88,6 +95,7 @@ function buildConfig(env) {
     workload_label: `Run ${agentSlug} Data Machine agent`,
     validation_dependencies: validationDependencies.paths,
     runtime_id: runtimeId,
+    execution_kind: executionKind,
     runtime_ref: env.AGENT_RUNTIME_REF || 'main',
     runtime_wordpress_version: env.RUNTIME_WORDPRESS_VERSION || '7.0',
     runtime_mounts: [
@@ -106,7 +114,7 @@ function buildConfig(env) {
     workload_run_before: workloadRunBefore,
     workload_run_after: workloadRunAfter,
     required_abilities: Array.from(new Set([...executeRequiredAbilities, ...extraRequiredAbilities])),
-    bundle_path: path.join(workspace, bundlePath),
+    ...(bundlePath ? { bundle_path: path.join(workspace, bundlePath) } : {}),
     bundle_repo: env.BUNDLE_REPO || `https://github.com/${targetRepo}.git`,
     bundle_ref: env.BUNDLE_REF || env.GITHUB_SHA,
     bundle_path_in_repo: env.BUNDLE_PATH_IN_REPO || bundlePath,
@@ -156,6 +164,9 @@ function buildConfig(env) {
     time_budget_ms: Number(env.TIME_BUDGET_MS || 600000),
     expected_artifacts: parseJsonInput('expected_artifacts', env.EXPECTED_ARTIFACTS || '[]', 'array', []),
     artifact_declarations: parseJsonInput('artifact_declarations', env.ARTIFACT_DECLARATIONS || '[]', 'array', []),
+    output_mappings: parseJsonInput('output_mappings', env.OUTPUT_MAPPINGS || '{}', 'object', {}),
+    component_contracts: parseJsonInput('component_contracts', env.COMPONENT_CONTRACTS || '[]', 'array', []),
+    ...(runtimeTask ? { runtime_task: runtimeTask } : {}),
     ability_tools: parseJsonInput('ability_tools', env.ABILITY_TOOLS || '[]', 'array', []),
     tool_recorders: parseJsonInput('tool_recorders', env.TOOL_RECORDERS || '[]', 'array', []),
     pipeline_step_patches: parseJsonInput('pipeline_step_patches', env.PIPELINE_STEP_PATCHES || '[]', 'array', []),
@@ -228,6 +239,33 @@ function resolveExecuteWorkflowMounts(executeWorkflowPath, workspace, componentS
   const type = fs.existsSync(hostPath) && fs.statSync(hostPath).isFile() ? 'file' : 'directory';
   const guestPath = `/wordpress/wp-content/plugins/${componentSlug}/${executeWorkflowPath}`;
   return { path: guestPath, mounts: [{ type, source: hostPath, target: guestPath, mode: 'readonly' }] };
+}
+
+function runtimeTaskFromEnv(env) {
+  const runtimeTask = parseJsonInput('runtime_task', env.RUNTIME_TASK || '{}', 'object', {});
+  if (Object.keys(runtimeTask).length > 0) {
+    if (!runtimeTask.ability || typeof runtimeTask.ability !== 'string') {
+      throw new Error('runtime_task.ability is required when runtime_task is supplied.');
+    }
+    return runtimeTask;
+  }
+
+  const abilityRequest = parseJsonInput('ability_request', env.ABILITY_REQUEST || '{}', 'object', {});
+  const abilityInput = parseJsonInput('ability_input', env.ABILITY_INPUT || '{}', 'object', {});
+  if (Object.keys(abilityRequest).length === 0 && Object.keys(abilityInput).length === 0) {
+    return null;
+  }
+  if (!abilityRequest.ability || typeof abilityRequest.ability !== 'string') {
+    throw new Error('ability_request.ability is required when ability_request or ability_input is supplied.');
+  }
+
+  return {
+    ...abilityRequest,
+    input: {
+      ...(abilityRequest.input && typeof abilityRequest.input === 'object' && !Array.isArray(abilityRequest.input) ? abilityRequest.input : {}),
+      ...abilityInput,
+    },
+  };
 }
 
 function withoutInternalKeys(config) {

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,10 +44,12 @@ mark with `if: always()` after the validation job starts producing reviewer
 evidence.
 
 `datamachine-agent-ci.yml` wraps the common GitHub Actions shape for running a
-Data Machine agent bundle in a disposable WordPress execution substrate.
-Consumers provide bundle and flow identifiers, a prompt, and optional output
-projections. Agent runs use the WP Codebox substrate; the legacy direct
-Playground runner is no longer selectable by callers.
+Data Machine agent bundle or a direct runtime task in a disposable WordPress
+execution substrate. Bundle consumers provide bundle and flow identifiers, a
+prompt, and optional output projections. Runtime-task consumers provide
+`execution_kind: runtime_task` plus `runtime_task` or the `ability_request` /
+`ability_input` shorthand. Agent runs use the WP Codebox substrate; the legacy
+direct Playground runner is no longer selectable by callers.
 See [`wordpress/docs/AGENT_CI_WP_CODEBOX.md`](../../wordpress/docs/AGENT_CI_WP_CODEBOX.md)
 for the WP Codebox contract, runtime surface, and evaluation notes.
 
@@ -153,12 +155,17 @@ jobs:
 
 - Agent CI runs through the selected `agent_runtime`. Today the only supported value is `wp-codebox`, and the workflow checks out/builds `Automattic/wp-codebox` for that runtime.
 - `agent_runtime_ref` controls the selected runtime ref.
+- `execution_kind` defaults to `agent_bundle`; when `runtime_task` or `ability_request` is supplied, the workflow builds a direct runtime task instead.
+- `runtime_task` forwards a generic `{ "ability", "input" }` object to the runtime task executor.
+- `ability_request` and `ability_input` are a shorthand for direct ability execution. `ability_input` is merged into `ability_request.input`.
+- `output_mappings` maps named outputs to dotted paths in the runtime task result, and those outputs are validated when they are also listed in `engine_data_outputs`.
+- `component_contracts` forwards explicit runtime component/plugin contracts to WP Codebox. Use it for caller-owned fixture ability providers or runtime components that are not part of the default Data Machine stack.
 - Generic WP Codebox executor paths accept caller-supplied component contracts, runtime overlays, mounts, task payload, provider defaults, and declarative runtime requirements. Data Machine Agent CI policy lives in this reusable workflow and runner adapter, not in the generic WP Codebox provider manifest.
 - `include_agent_runtime_dependencies` defaults to `true` and checks out the Data Machine Agent CI stack: `Automattic/agents-api`, `Extra-Chill/data-machine`, `Extra-Chill/data-machine-code`, and the provider plugin. The runner adapter forwards those paths to WP Codebox as explicit runtime component requirements.
 - `agents_api_ref`, `data_machine_ref`, `data_machine_code_ref`, and `openai_provider_ref` control runtime dependency refs. `openai_provider_ref` defaults to `trunk` for the built-in OpenAI preset.
 - `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `credentials` keys. When `provider: openai`, an empty object preserves the existing OpenAI provider defaults.
 - `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.
-- `bundle_path` is resolved relative to the consumer checkout.
+- `bundle_path` is resolved relative to the consumer checkout for bundle runs. It is optional for `execution_kind: runtime_task`.
 - `bundle_repo`, `bundle_ref`, and `bundle_path_in_repo` let a consumer run against a bundle stored in another repository. The runner clones that repository before mounting the bundle into the WordPress substrate.
 - `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`. Use it when the workflow needs app-token access to more than the target repository.
 - `require_homeboy_app_token` fails before agent setup when Homeboy App credentials are missing. Enable it for central, cross-repo, and private-target runs; leave it false for same-repo consumers that intentionally use `github.token` fallback.

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -11,8 +11,9 @@ name: Data Machine Agent CI (reusable)
   workflow_call:
     inputs:
       bundle_path:
+        description: Bundle path for datamachine/run-agent-bundle runs. Leave empty when execution_kind=runtime_task and runtime_task or ability_request is supplied.
         type: string
-        required: true
+        default: ""
       homeboy_extensions_ref:
         description: Ref of Extra-Chill/homeboy-extensions to check out for runner scripts.
         type: string
@@ -118,6 +119,30 @@ name: Data Machine Agent CI (reusable)
         description: WordPress version used by the selected WordPress-capable runtime.
         type: string
         default: "7.0"
+      execution_kind:
+        description: Executor mode. Defaults to agent_bundle unless runtime_task or ability_request is supplied; use runtime_task for direct ability execution.
+        type: string
+        default: ""
+      runtime_task:
+        description: JSON object forwarded to the runtime task executor, typically {"ability":"example/process-artifact","input":{...}}.
+        type: string
+        default: "{}"
+      ability_request:
+        description: JSON object shorthand for runtime_task. Supports {"ability":"example/process-artifact","input":{...}}.
+        type: string
+        default: "{}"
+      ability_input:
+        description: JSON object merged into ability_request.input when building a runtime_task shorthand.
+        type: string
+        default: "{}"
+      output_mappings:
+        description: JSON object mapping workflow output names to dotted paths in the runtime task result.
+        type: string
+        default: "{}"
+      component_contracts:
+        description: JSON array of runtime component contracts forwarded to WP Codebox.
+        type: string
+        default: "[]"
       success_requires_pr:
         type: boolean
         default: true
@@ -517,6 +542,12 @@ jobs:
           AGENT_RUNTIME: ${{ inputs.agent_runtime }}
           AGENT_RUNTIME_REF: ${{ inputs.agent_runtime_ref }}
           RUNTIME_WORDPRESS_VERSION: ${{ inputs.runtime_wordpress_version }}
+          EXECUTION_KIND: ${{ inputs.execution_kind }}
+          RUNTIME_TASK: ${{ inputs.runtime_task }}
+          ABILITY_REQUEST: ${{ inputs.ability_request }}
+          ABILITY_INPUT: ${{ inputs.ability_input }}
+          OUTPUT_MAPPINGS: ${{ inputs.output_mappings }}
+          COMPONENT_CONTRACTS: ${{ inputs.component_contracts }}
           SUCCESS_REQUIRES_PR: ${{ inputs.success_requires_pr }}
           SUCCESS_COMPLETION_OUTCOMES: ${{ inputs.success_completion_outcomes }}
           MAX_TURNS: ${{ inputs.max_turns }}

--- a/README.md
+++ b/README.md
@@ -129,6 +129,44 @@ stdin and writes `homeboy/agent-task-promotion-apply-response/v1` JSON on
 stdout. It keeps the DMC-specific `studio wp datamachine-code ...` shellouts in
 Homeboy Extensions instead of Homeboy core.
 
+### Data Machine Agent CI runtime tasks
+
+The reusable `.github/workflows/datamachine-agent-ci.yml` workflow can run a
+generic WordPress ability directly through WP Codebox, without importing an
+agent bundle. Use `execution_kind: runtime_task` with either `runtime_task` or
+the `ability_request`/`ability_input` shorthand. Downloaded GitHub Actions
+artifacts can be mounted into the sandbox with `runtime_mounts`, and typed
+outputs can be enforced with `artifact_declarations` plus `output_mappings`:
+
+```yaml
+jobs:
+  process-artifact:
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@main
+    with:
+      homeboy_extensions_ref: main
+      target_repo: Example/project
+      agent_slug: artifact-processor
+      pipeline_slug: artifact-pipeline
+      flow_slug: artifact-flow
+      execution_kind: runtime_task
+      actions_artifact_downloads: >-
+        [{"repo":"Example/project","run_id":"123456789","name":"source-packet","dir":".ci/actions-artifacts/source-packet"}]
+      runtime_mounts: >-
+        [{"source":".ci/actions-artifacts/source-packet","target":"/workspace/input","mode":"readonly"}]
+      ability_request: >-
+        {"ability":"example/process-artifact","input":{"source_artifact":"/workspace/input/source.json"}}
+      output_mappings: >-
+        {"processed_packet":"result.processed_packet"}
+      artifact_declarations: >-
+        [{"name":"processed_packet","type":"example-packet","schema":"example/processed-packet/v1","required":true}]
+      expected_artifacts: '["processed_packet"]'
+```
+
+Use `component_contracts` only when the ability provider plugin or runtime
+component must be mounted explicitly. Keep ability names, schemas, and artifact
+types owned by the caller; Homeboy Extensions only forwards the generic runtime
+task contract.
+
 Each extension also exposes a CLI binding for direct use against a project or component:
 
 ```bash

--- a/tests/datamachine-agent-ci-primitives-smoke.mjs
+++ b/tests/datamachine-agent-ci-primitives-smoke.mjs
@@ -118,6 +118,82 @@ assert.equal(config.runner_workspace.checkout_path, '/workspace/homeboy-extensio
 assert.deepEqual(config.writable_paths, ['src', 'tests']);
 assert.equal(config.provider_credentials.connectors_ai_openai_api_key, 'OPENAI_API_KEY');
 
+fs.writeFileSync(githubOutput, '');
+run('build-runner-config.cjs', [], {
+  GITHUB_OUTPUT: githubOutput,
+  GITHUB_WORKSPACE: workspace,
+  RUNNER_TEMP: runnerTemp,
+  GITHUB_SHA: 'abc123',
+  AGENT_SLUG: 'artifact-processor',
+  PIPELINE_SLUG: 'artifact-pipeline',
+  FLOW_SLUG: 'artifact-flow',
+  BUNDLE_PATH: '',
+  TARGET_REPO: 'Extra-Chill/homeboy-extensions',
+  CONTEXT_REPOSITORIES: '[]',
+  VERIFICATION_COMMANDS: '[]',
+  DRIFT_CHECKS: '[]',
+  WRITABLE_PATHS: '',
+  WORKSPACE_CONTRACT_CHECKS: '{}',
+  PROVIDER: 'openai',
+  MODEL: 'gpt-5.5',
+  AGENT_RUNTIME: 'wp-codebox',
+  AGENT_RUNTIME_REF: 'main',
+  RUNTIME_WORDPRESS_VERSION: '7.0',
+  EXECUTION_KIND: 'runtime_task',
+  ABILITY_REQUEST: '{"ability":"example/process-artifact","input":{"source_artifact":"/workspace/input/example-packet.json"}}',
+  ABILITY_INPUT: '{"mode":"typed-artifact"}',
+  RUNTIME_TASK: '{}',
+  OUTPUT_MAPPINGS: '{"processed_packet":"result.processed_packet"}',
+  COMPONENT_CONTRACTS: '[{"slug":"example-fixture-plugin","path":"/workspace/plugins/example-fixture-plugin","activate":true}]',
+  SUCCESS_REQUIRES_PR: 'false',
+  SUCCESS_COMPLETION_OUTCOMES: '[]',
+  MAX_TURNS: '1',
+  STEP_BUDGET: '1',
+  TIME_BUDGET_MS: '60000',
+  EXPECTED_ARTIFACTS: '["processed_packet"]',
+  ARTIFACT_DECLARATIONS: '[{"name":"processed_packet","type":"example-packet","schema":"example/processed-packet/v1","required":true}]',
+  ARTIFACT_EXPORT_CONFIG: '{}',
+  RULES: '{}',
+  GENERAL_RULES: '[]',
+  TASK_RULES: '[]',
+  PROBES: '{}',
+  WP_GYM_BENCHMARK_MODE: 'false',
+  DRY_RUN: 'true',
+  EXTRA_WP_CONFIG_DEFINES: '{}',
+  RUNTIME_MOUNTS: '[{"source":".ci/actions-artifacts/source-packet","target":"/workspace/input","mode":"readonly"}]',
+  RUNTIME_OVERLAYS: '[]',
+  WORKLOAD_RUN_BEFORE: '[]',
+  WORKLOAD_RUN_AFTER: '[]',
+  DAILY_MEMORY_ENABLED: 'false',
+  DISABLE_DATAMACHINE_DIRECTIVES: 'false',
+  EXTRA_REQUIRED_ABILITIES: '["example/process-artifact"]',
+  APP_TOKEN_REPOS: '',
+  ALLOWED_REPOS: '[]',
+  TOOL_RESULTS_KEY: 'github_tool_results',
+  ABILITY_TOOLS: '[]',
+  TOOL_RECORDERS: '[]',
+  ENABLE_TERMINAL_ACTIONS: 'false',
+  WP_CLI_TOOL_NAME: 'run_wp_cli',
+  PIPELINE_STEP_PATCHES: '[]',
+  FLOW_STEP_PATCHES: '[]',
+  RUNNER_WORKSPACE_CONFIG: '{}',
+  PROVIDER_PLUGIN: '{}',
+});
+const runtimeTaskConfig = JSON.parse(fs.readFileSync(path.join(runnerTemp, 'datamachine-agent-config.json'), 'utf8'));
+assert.equal(runtimeTaskConfig.execution_kind, 'runtime_task');
+assert.deepEqual(runtimeTaskConfig.runtime_task, {
+  ability: 'example/process-artifact',
+  input: {
+    source_artifact: '/workspace/input/example-packet.json',
+    mode: 'typed-artifact',
+  },
+});
+assert.deepEqual(runtimeTaskConfig.output_mappings, { processed_packet: 'result.processed_packet' });
+assert.deepEqual(runtimeTaskConfig.component_contracts, [{ slug: 'example-fixture-plugin', path: '/workspace/plugins/example-fixture-plugin', activate: true }]);
+assert.equal(runtimeTaskConfig.runtime_mounts.some((mount) => mount.target === '/workspace/input' && mount.mode === 'readonly'), true);
+assert.deepEqual(runtimeTaskConfig.artifact_declarations, [{ name: 'processed_packet', type: 'example-packet', schema: 'example/processed-packet/v1', required: true }]);
+assert.deepEqual(runtimeTaskConfig.required_abilities, ['example/process-artifact']);
+
 const resultsFile = path.join(tempRoot, 'results.json');
 fs.writeFileSync(resultsFile, JSON.stringify({ scenarios: [{ id: 'flow', metadata: { job_status: 'completed', engine_data: { value: 7 } } }] }));
 fs.writeFileSync(githubOutput, '');


### PR DESCRIPTION
## Summary
- Expose generic Data Machine runtime-task execution through the reusable agent CI workflow.
- Forward `execution_kind`, `runtime_task`, `ability_request`, `ability_input`, `output_mappings`, and `component_contracts` into the existing WP Codebox executor contract.
- Document generic artifact handoff via downloaded Actions artifacts mounted into the sandbox, with typed artifact declarations.
- Add smoke coverage for a generic fixture ability consuming mounted artifact input and emitting typed artifacts.

## Tests
- `node tests/datamachine-agent-ci-primitives-smoke.mjs`
- `npm run test:datamachine-agent-ci-plan` from `wordpress/`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the workflow/config/docs/test changes; Chris remains responsible for review and validation.
