### PR TITLE
Align agent runtime contract adapters

### DIFF
--- a/agent-runtimes/lib/agent-task-provider-contract.js
+++ b/agent-runtimes/lib/agent-task-provider-contract.js
@@ -2,6 +2,9 @@
 
 const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
 const AGENT_TASK_OUTCOME_SCHEMA = 'homeboy/agent-task-outcome/v1';
+const AGENT_TASK_ARTIFACT_SCHEMA = 'homeboy/agent-task-artifact/v1';
+const AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA = 'homeboy/agent-task-artifact-declaration/v1';
+const AGENT_TASK_EVIDENCE_REF_SCHEMA = 'homeboy/agent-task-evidence-ref/v1';
 const AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA = 'homeboy/agent-task-executor-provider/v1';
 const SECRET_ENV_REQUIREMENT_SCHEMA = 'homeboy/secret-env-requirement/v1';
 
@@ -28,6 +31,31 @@ const AGENT_TASK_REDACTED_METADATA_KEYS = [
   'secrets',
 ];
 
+const AGENT_TASK_SECRET_SELECTOR_PATHS = [
+  'executor.config.provider',
+  'executor.provider',
+  'provider',
+];
+
+const AGENT_TASK_ARTIFACT_FIELDS = [
+  'schema',
+  'id',
+  'kind',
+  'name',
+  'path',
+  'url',
+  'mime',
+  'size_bytes',
+  'sha256',
+  'metadata',
+];
+
+const AGENT_TASK_EVIDENCE_REF_FIELDS = [
+  'kind',
+  'uri',
+  'label',
+];
+
 function agentTaskProviderContractFields() {
   return {
     request_schema: AGENT_TASK_REQUEST_SCHEMA,
@@ -45,12 +73,36 @@ function providerSecretEnvRequirement(provider, env) {
     source: 'provider_default',
     env,
     when: {
-      any: [
-        { path: 'executor.config.provider', equals: provider },
-        { path: 'executor.provider', equals: provider },
-        { path: 'provider', equals: provider },
-      ],
+      any: AGENT_TASK_SECRET_SELECTOR_PATHS.map((selectorPath) => ({ path: selectorPath, equals: provider })),
     },
+  };
+}
+
+function extendRedactedMetadataKeys(...keys) {
+  return Array.from(new Set([...AGENT_TASK_REDACTED_METADATA_KEYS, ...keys.flatMap(normalizeList)]));
+}
+
+function agentTaskArtifactFromRef(ref = {}, index = 0, sanitizeMetadata = passthroughObject) {
+  const id = ref.id || ref.sha256 || ref.path || ref.url || `agent-task-artifact-${index + 1}`;
+  return {
+    schema: AGENT_TASK_ARTIFACT_SCHEMA,
+    id,
+    kind: ref.kind || ref.type || 'agent_task_artifact',
+    name: ref.name,
+    path: ref.path || ref.directory,
+    url: ref.url,
+    mime: ref.mime,
+    size_bytes: ref.size_bytes,
+    sha256: ref.sha256,
+    metadata: sanitizeMetadata(ref.metadata || {}),
+  };
+}
+
+function agentTaskEvidenceRefFromRef(ref = {}, fallbackKind = 'agent_task_evidence') {
+  return {
+    kind: ref.kind || ref.type || fallbackKind,
+    uri: ref.uri || ref.url || ref.path,
+    label: ref.label || ref.name,
   };
 }
 
@@ -65,14 +117,31 @@ function normalizeArray(value) {
   return Array.isArray(value) ? value.filter((entry) => entry !== undefined && entry !== null) : [];
 }
 
+function normalizeList(value) {
+  return Array.isArray(value) ? normalizeArray(value) : normalizeArray([value]);
+}
+
+function passthroughObject(value) {
+  return value;
+}
+
 module.exports = {
+  AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA,
+  AGENT_TASK_ARTIFACT_FIELDS,
+  AGENT_TASK_ARTIFACT_SCHEMA,
+  AGENT_TASK_EVIDENCE_REF_FIELDS,
+  AGENT_TASK_EVIDENCE_REF_SCHEMA,
   AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
   AGENT_TASK_FAILURE_CLASSIFICATIONS,
   AGENT_TASK_OUTCOME_SCHEMA,
   AGENT_TASK_OUTCOME_STATUSES,
   AGENT_TASK_REDACTED_METADATA_KEYS,
   AGENT_TASK_REQUEST_SCHEMA,
+  AGENT_TASK_SECRET_SELECTOR_PATHS,
+  agentTaskArtifactFromRef,
+  agentTaskEvidenceRefFromRef,
   agentTaskProviderContractFields,
+  extendRedactedMetadataKeys,
   providerDefaultsContract,
   providerSecretEnvRequirement,
 };

--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -7,6 +7,7 @@ const {
 	AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
 	AGENT_TASK_OUTCOME_SCHEMA,
 	agentTaskProviderContractFields,
+	extendRedactedMetadataKeys,
 	providerSecretEnvRequirement,
 } = require('../../lib/agent-task-provider-contract');
 
@@ -34,7 +35,7 @@ const OPENCODE_CAPABILITIES = [
 
 function providerContract(options = {}) {
 	const contractFields = agentTaskProviderContractFields();
-	contractFields.redacted_metadata_keys.push('codex_auth', 'opencode_auth');
+	contractFields.redacted_metadata_keys = extendRedactedMetadataKeys('codex_auth', 'opencode_auth');
 
 	return {
 		schema: AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -10,17 +10,19 @@ const path = require('node:path');
  * Internal dependencies
  */
 const {
+  AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA,
   AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
   AGENT_TASK_FAILURE_CLASSIFICATIONS,
   AGENT_TASK_OUTCOME_SCHEMA,
   AGENT_TASK_OUTCOME_STATUSES,
   AGENT_TASK_REDACTED_METADATA_KEYS,
   AGENT_TASK_REQUEST_SCHEMA,
+  agentTaskArtifactFromRef,
+  agentTaskEvidenceRefFromRef,
   agentTaskProviderContractFields,
   providerDefaultsContract,
 } = require('../../lib/agent-task-provider-contract');
 
-const AGENT_TASK_ARTIFACT_SCHEMA = 'homeboy/agent-task-artifact/v1';
 const WP_CODEBOX_TASK_REQUEST_SCHEMA = 'wp-codebox/task-input/v1';
 const WP_CODEBOX_PROVIDER_ID = 'wordpress.codebox-agent-task-executor';
 const WP_CODEBOX_PROVIDER_LABEL = 'WP Codebox agent task executor';
@@ -396,7 +398,7 @@ function wpCodeboxArtifactDeclarationFromLegacy(defaultName, declaration) {
     || declaration.content_schema
     || declaration.contentSchema
     || (declaration.schema && ![
-      'homeboy/agent-task-artifact-declaration/v1',
+      AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA,
       'wp-codebox/artifact-declaration/v1',
     ].includes(declaration.schema) ? declaration.schema : undefined);
   return Object.fromEntries(Object.entries({
@@ -1855,19 +1857,15 @@ function typedBundleOutputArtifacts(result) {
 }
 
 function artifactFromCodeboxArtifact(artifact, index) {
-  const id = artifact.id || artifact.sha256 || artifact.path || artifact.url || `codebox-artifact-${index + 1}`;
-  return {
-    schema: AGENT_TASK_ARTIFACT_SCHEMA,
-    id,
-    kind: artifact.kind || artifact.type || 'codebox_artifact',
-    name: artifact.name,
-    path: artifact.path || artifact.directory,
-    url: artifact.url,
-    mime: artifact.mime,
-    size_bytes: artifact.size_bytes,
-    sha256: artifact.sha256,
-    metadata: sanitizePublicMetadata(artifact.metadata || {}),
-  };
+  return agentTaskArtifactFromRef(
+    {
+      ...artifact,
+      id: artifact.id || artifact.sha256 || artifact.path || artifact.url || `codebox-artifact-${index + 1}`,
+      kind: artifact.kind || artifact.type || 'codebox_artifact',
+    },
+    index,
+    sanitizePublicMetadata
+  );
 }
 
 function pathValue(source, dottedPath) {
@@ -2140,20 +2138,12 @@ function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) 
       appendUniqueEvidenceRef(refs, ref);
     }
     for (const ref of result?.evidence_refs || result?.evidence || []) {
-      appendUniqueEvidenceRef(refs, {
-        kind: ref.kind || ref.type || 'codebox_evidence',
-        uri: ref.uri || ref.url || ref.path,
-        label: ref.label || ref.name,
-      });
+      appendUniqueEvidenceRef(refs, agentTaskEvidenceRefFromRef(ref, 'codebox_evidence'));
     }
     return refs;
   }
   const evidenceRefs = result?.evidence_refs || result?.evidence || [];
-  return evidenceRefs.map((ref) => ({
-    kind: ref.kind || ref.type || 'codebox_evidence',
-    uri: ref.uri || ref.url || ref.path,
-    label: ref.label || ref.name,
-  })).filter((ref) => ref.uri);
+  return evidenceRefs.map((ref) => agentTaskEvidenceRefFromRef(ref, 'codebox_evidence')).filter((ref) => ref.uri);
 }
 
 function agentRuntimeBundleArtifacts(result) {

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -92,6 +92,21 @@ Failure outcomes should include a normalized classification from
 `failure_classifications` plus enough diagnostic context for Homeboy to route the
 result without parsing backend-native logs.
 
+## Homeboy Contract Adapter
+
+Extension runtime packages should consume generic Homeboy contract constants
+through `agent-runtimes/lib/agent-task-provider-contract.js`. That adapter is the
+local compatibility seam while the matching Homeboy core contracts are released.
+It owns schema identifiers, the default provider fields, secret-env requirement
+selectors, redacted metadata keys, and artifact/evidence reference projection
+helpers.
+
+Runtime packages may add backend-specific capabilities, secret names, role
+aliases, and metadata keys, but should extend the adapter output instead of
+copying schema strings or selector paths into each backend. Domain policy, such
+as WordPress or Data Machine defaults, belongs in the caller/runtime package and
+not in the generic adapter.
+
 ## Secret Requirements
 
 Runtime manifests should declare secret inputs by name, never by value:
@@ -111,7 +126,8 @@ Runtime manifests should declare secret inputs by name, never by value:
 Provider commands receive secret values through environment variables or the
 request's secret-name declarations. They must redact secret-like metadata in
 outcomes and diagnostics. If a runtime adds a secret-bearing metadata key, it
-must add that key to `redacted_metadata_keys`.
+must add that key to `redacted_metadata_keys`, preferably with
+`extendRedactedMetadataKeys()` from the adapter.
 
 ## Capability Declarations
 

--- a/tests/agent-task-provider-contract-smoke.mjs
+++ b/tests/agent-task-provider-contract-smoke.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+	AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA,
+	AGENT_TASK_ARTIFACT_FIELDS,
+	AGENT_TASK_ARTIFACT_SCHEMA,
+	AGENT_TASK_EVIDENCE_REF_FIELDS,
+	AGENT_TASK_EVIDENCE_REF_SCHEMA,
+	AGENT_TASK_REDACTED_METADATA_KEYS,
+	AGENT_TASK_SECRET_SELECTOR_PATHS,
+	agentTaskArtifactFromRef,
+	agentTaskEvidenceRefFromRef,
+	agentTaskProviderContractFields,
+	extendRedactedMetadataKeys,
+	providerSecretEnvRequirement,
+} = require(path.join(rootDir, 'agent-runtimes', 'lib', 'agent-task-provider-contract.js'));
+
+assert.equal(AGENT_TASK_ARTIFACT_SCHEMA, 'homeboy/agent-task-artifact/v1');
+assert.equal(AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA, 'homeboy/agent-task-artifact-declaration/v1');
+assert.equal(AGENT_TASK_EVIDENCE_REF_SCHEMA, 'homeboy/agent-task-evidence-ref/v1');
+assert.deepEqual(AGENT_TASK_ARTIFACT_FIELDS, ['schema', 'id', 'kind', 'name', 'path', 'url', 'mime', 'size_bytes', 'sha256', 'metadata']);
+assert.deepEqual(AGENT_TASK_EVIDENCE_REF_FIELDS, ['kind', 'uri', 'label']);
+
+const fields = agentTaskProviderContractFields();
+assert.equal(fields.request_schema, 'homeboy/agent-task-request/v1');
+assert.equal(fields.outcome_schema, 'homeboy/agent-task-outcome/v1');
+assert.deepEqual(fields.redacted_metadata_keys, AGENT_TASK_REDACTED_METADATA_KEYS);
+
+const extendedRedactionKeys = extendRedactedMetadataKeys('secrets', ['provider_auth', 'codex_auth']);
+assert.deepEqual(extendedRedactionKeys, ['secret_env_values', 'secretEnvValues', 'secrets', 'provider_auth', 'codex_auth']);
+assert.deepEqual(AGENT_TASK_REDACTED_METADATA_KEYS, ['secret_env_values', 'secretEnvValues', 'secrets']);
+
+const secretRequirement = providerSecretEnvRequirement('codex', ['CODEX_TOKEN']);
+assert.equal(secretRequirement.schema, 'homeboy/secret-env-requirement/v1');
+assert.deepEqual(secretRequirement.env, ['CODEX_TOKEN']);
+assert.deepEqual(secretRequirement.when.any, AGENT_TASK_SECRET_SELECTOR_PATHS.map((selectorPath) => ({
+	path: selectorPath,
+	equals: 'codex',
+})));
+
+const artifact = agentTaskArtifactFromRef({
+	type: 'provider-log',
+	name: 'Provider log',
+	directory: 'artifacts/logs',
+	url: 'https://example.test/logs',
+	mime: 'text/plain',
+	size_bytes: 123,
+	sha256: 'abc123',
+	metadata: { secret_env_values: { TOKEN: 'redacted' }, public: true },
+}, 2, (metadata) => ({ public: metadata.public }));
+assert.deepEqual(artifact, {
+	schema: AGENT_TASK_ARTIFACT_SCHEMA,
+	id: 'abc123',
+	kind: 'provider-log',
+	name: 'Provider log',
+	path: 'artifacts/logs',
+	url: 'https://example.test/logs',
+	mime: 'text/plain',
+	size_bytes: 123,
+	sha256: 'abc123',
+	metadata: { public: true },
+});
+
+assert.deepEqual(agentTaskEvidenceRefFromRef({ type: 'preview', path: 'artifacts/preview.html', name: 'Preview' }), {
+	kind: 'preview',
+	uri: 'artifacts/preview.html',
+	label: 'Preview',
+});
+
+console.log('agent task provider contract smoke passed');


### PR DESCRIPTION
## Summary
- Centralize generic Homeboy agent task schema IDs, secret selector paths, redaction-key extension, and artifact/evidence projection helpers in the local agent runtime contract adapter.
- Route WP Codebox and OpenCode runtime adapters through the shared boundary while preserving backend-specific policy in their runtime packages.
- Document the adapter as the compatibility seam until the matching Homeboy core contracts are released.

## Tests
- `node tests/agent-task-provider-contract-smoke.mjs`
- `node tests/agent-runtime-contract-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node tests/datamachine-agent-ci-primitives-smoke.mjs`
- `node -e "const {providerContract}=require('./agent-runtimes/opencode'); const p=providerContract(); if (!p.redacted_metadata_keys.includes('opencode_auth')) process.exit(1);"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the contract adapter changes, focused smoke coverage, and documentation updates; Chris remains responsible for review and merge.