### PR TITLE
Add generic agent task runner spec

### DIFF
--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -415,6 +415,13 @@ The same Data Machine bundle run can be expressed as a Homeboy agent-task plan,
 which lets `homeboy agent-task run-plan --plan ...` replace a bespoke workflow
 wrapper such as `wp-site-generator`'s site-generation loop:
 
+`homeboy/agent-task-runner-spec/v1` is the normalized runner boundary inside each
+task. It contains only generic execution details: `executor.backend`,
+`executor.config`, optional `executor.secret_env`, `limits`, and
+`expected_artifacts`. Caller-specific policy, evaluation semantics, and workflow
+outputs stay outside this object so a future Homeboy core command can consume the
+same spec without inheriting GitHub Actions glue.
+
 ```json
 {
   "schema": "homeboy/agent-task-plan/v1",

--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -18,6 +18,7 @@ module.exports = {
 	...require('./lib/webperf-evidence-summary'),
 	...require('./lib/benchmark-matrix-report'),
 	...require('./lib/agent-terminal-actions'),
+	...require('./lib/agent-task-runner-spec'),
 	...require('./lib/datamachine-agent-ci-plan'),
 	...require('./lib/wp-codebox-apply-adapter'),
 	...require('./lib/wp-codebox-recipe-helper'),

--- a/wordpress/lib/agent-task-runner-spec.js
+++ b/wordpress/lib/agent-task-runner-spec.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const AGENT_TASK_RUNNER_SPEC_SCHEMA = 'homeboy/agent-task-runner-spec/v1';
+
+function agentTaskRunnerSpec(options = {}) {
+  const executorConfig = options.config || options.executorConfig || options.executor_config;
+  if (!executorConfig || typeof executorConfig !== 'object' || Array.isArray(executorConfig)) {
+    throw new Error('config is required.');
+  }
+
+  const backend = requiredString(options.backend || 'codebox', 'backend');
+  const taskTimeoutSeconds = options.taskTimeoutSeconds || options.task_timeout_seconds;
+  const limits = stripUndefined({
+    ...(taskTimeoutSeconds ? { task_timeout_seconds: taskTimeoutSeconds } : {}),
+    ...(options.limits || {}),
+  });
+
+  const spec = stripUndefined({
+    schema: AGENT_TASK_RUNNER_SPEC_SCHEMA,
+    executor: stripUndefined({
+      backend,
+      ...(normalizeArray(options.secretEnv || options.secret_env).length > 0
+        ? { secret_env: normalizeArray(options.secretEnv || options.secret_env) }
+        : {}),
+      config: executorConfig,
+    }),
+    limits,
+    expected_artifacts: normalizeArray(options.expectedArtifacts || options.expected_artifacts),
+  });
+
+  validateAgentTaskRunnerSpec(spec);
+  return spec;
+}
+
+function agentTaskRequestFromRunnerSpec(options = {}) {
+  const runnerSpec = validateAgentTaskRunnerSpec(options.runnerSpec || options.runner_spec);
+  return stripUndefined({
+    executor: runnerSpec.executor,
+    limits: runnerSpec.limits,
+    expected_artifacts: runnerSpec.expected_artifacts,
+  });
+}
+
+function validateAgentTaskRunnerSpec(spec) {
+  if (!spec || typeof spec !== 'object' || Array.isArray(spec)) {
+    throw new Error('runner spec must be an object.');
+  }
+  if (spec.schema !== AGENT_TASK_RUNNER_SPEC_SCHEMA) {
+    throw new Error(`runner spec schema must be ${AGENT_TASK_RUNNER_SPEC_SCHEMA}.`);
+  }
+  if (!spec.executor || typeof spec.executor !== 'object' || Array.isArray(spec.executor)) {
+    throw new Error('runner spec executor is required.');
+  }
+  requiredString(spec.executor.backend, 'runner spec executor.backend');
+  if (!spec.executor.config || typeof spec.executor.config !== 'object' || Array.isArray(spec.executor.config)) {
+    throw new Error('runner spec executor.config is required.');
+  }
+  if (spec.executor.secret_env !== undefined && !Array.isArray(spec.executor.secret_env)) {
+    throw new Error('runner spec executor.secret_env must be an array.');
+  }
+  if (spec.limits !== undefined && (typeof spec.limits !== 'object' || Array.isArray(spec.limits))) {
+    throw new Error('runner spec limits must be an object.');
+  }
+  if (spec.expected_artifacts !== undefined && !Array.isArray(spec.expected_artifacts)) {
+    throw new Error('runner spec expected_artifacts must be an array.');
+  }
+  return spec;
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function requiredString(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function stripUndefined(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  );
+}
+
+module.exports = {
+  AGENT_TASK_RUNNER_SPEC_SCHEMA,
+  agentTaskRequestFromRunnerSpec,
+  agentTaskRunnerSpec,
+  validateAgentTaskRunnerSpec,
+};

--- a/wordpress/lib/datamachine-agent-ci-plan.js
+++ b/wordpress/lib/datamachine-agent-ci-plan.js
@@ -1,8 +1,17 @@
 'use strict';
 
+/**
+ * Internal dependencies
+ */
 const {
   datamachineAgentCiCodeboxExecutorConfig,
 } = require('./datamachine-agent-ci-codebox-adapter');
+const {
+  AGENT_TASK_RUNNER_SPEC_SCHEMA,
+  agentTaskRequestFromRunnerSpec,
+  agentTaskRunnerSpec,
+  validateAgentTaskRunnerSpec,
+} = require('./agent-task-runner-spec');
 
 const AGENT_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
 const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
@@ -49,8 +58,11 @@ function datamachineAgentCiBundleTaskRequest(options = {}) {
 function datamachineAgentCiAbilityTaskRequest(options = {}) {
   const taskId = requiredString(options.taskId || options.task_id, 'taskId');
   const ability = requiredString(options.ability, 'ability');
-  const config = datamachineAgentCiTaskExecutorConfig(options);
-  const secretEnv = normalizeArray(config.secret_env);
+  const runnerSpec = datamachineAgentCiRunnerSpec({
+    ...options,
+    ability,
+  });
+  const runnerRequest = agentTaskRequestFromRunnerSpec({ runnerSpec });
 
   return stripUndefined({
     schema: AGENT_TASK_REQUEST_SCHEMA,
@@ -60,21 +72,26 @@ function datamachineAgentCiAbilityTaskRequest(options = {}) {
     cwd: options.cwd,
     repo: options.repo,
     workspace: options.workspace,
-    executor: {
-      backend: options.backend || 'codebox',
-      ...(secretEnv.length > 0 ? { secret_env: secretEnv } : {}),
-      config,
-    },
+    executor: runnerRequest.executor,
     instructions: options.instructions || '',
     inputs: {
       ...(options.inputs || {}),
       ...(options.title ? { title: options.title } : {}),
     },
-    limits: {
-      task_timeout_seconds: config.task_timeout_seconds || options.taskTimeoutSeconds || options.task_timeout_seconds || 900,
-      ...(options.limits || {}),
-    },
-    expected_artifacts: normalizeArray(options.expectedArtifacts || options.expected_artifacts),
+    limits: runnerRequest.limits,
+    expected_artifacts: runnerRequest.expected_artifacts,
+  });
+}
+
+function datamachineAgentCiRunnerSpec(options = {}) {
+  const config = datamachineAgentCiTaskExecutorConfig(options);
+  return agentTaskRunnerSpec({
+    backend: options.backend || 'codebox',
+    config,
+    secret_env: normalizeArray(config.secret_env),
+    task_timeout_seconds: config.task_timeout_seconds || options.taskTimeoutSeconds || options.task_timeout_seconds || 900,
+    limits: options.limits,
+    expected_artifacts: options.expectedArtifacts || options.expected_artifacts,
   });
 }
 
@@ -147,9 +164,13 @@ function stripUndefined(value) {
 module.exports = {
   AGENT_TASK_PLAN_SCHEMA,
   AGENT_TASK_REQUEST_SCHEMA,
+  AGENT_TASK_RUNNER_SPEC_SCHEMA,
   DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY,
+  agentTaskRequestFromRunnerSpec,
   datamachineAgentCiAbilityTaskRequest,
   datamachineAgentCiBundleTaskRequest,
   datamachineAgentCiPlan,
+  datamachineAgentCiRunnerSpec,
   datamachineAgentCiTaskExecutorConfig,
+  validateAgentTaskRunnerSpec,
 };

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -19,6 +19,7 @@
     "./editor-canvas-probes": "./lib/editor-canvas-probes.js",
     "./fidelity-comparison": "./lib/fidelity-comparison.js",
     "./agent-terminal-actions": "./lib/agent-terminal-actions.js",
+    "./agent-task-runner-spec": "./lib/agent-task-runner-spec.js",
     "./datamachine-agent-ci-plan": "./lib/datamachine-agent-ci-plan.js",
     "./timing-correlator": "./lib/timing-correlator.js",
     "./codebox-memory-report": "./lib/codebox-memory-report.js",

--- a/wordpress/tests/datamachine-agent-ci-plan-smoke.js
+++ b/wordpress/tests/datamachine-agent-ci-plan-smoke.js
@@ -3,9 +3,13 @@
 const assert = require('node:assert/strict');
 
 const {
+  AGENT_TASK_RUNNER_SPEC_SCHEMA,
+  agentTaskRequestFromRunnerSpec,
   datamachineAgentCiAbilityTaskRequest,
   datamachineAgentCiBundleTaskRequest,
   datamachineAgentCiPlan,
+  datamachineAgentCiRunnerSpec,
+  validateAgentTaskRunnerSpec,
 } = require('../lib/datamachine-agent-ci-plan');
 
 const bundleTask = datamachineAgentCiBundleTaskRequest({
@@ -67,6 +71,28 @@ assert.equal(bundleTask.executor.config.runtime_requirements.component_path_defa
 assert.equal(bundleTask.limits.task_timeout_seconds, 1200);
 assert.deepEqual(bundleTask.expected_artifacts, ['datamachine-transcript', 'ConceptPacket']);
 
+const bundleRunnerSpec = datamachineAgentCiRunnerSpec({
+  taskId: 'concept-agent',
+  source: '/workspace/example-repo/bundles/concept-agent',
+  agentSlug: 'concept-agent',
+  pipelineSlug: 'concept-pipeline',
+  flowSlug: 'concept-flow',
+  provider: 'openai',
+  secretEnv: ['AI_PROVIDER_OPENAI_API_KEY'],
+  expectedArtifacts: ['datamachine-transcript'],
+});
+
+assert.equal(bundleRunnerSpec.schema, AGENT_TASK_RUNNER_SPEC_SCHEMA);
+assert.equal(bundleRunnerSpec.executor.backend, 'codebox');
+assert.equal(bundleRunnerSpec.executor.config.provider, 'openai');
+assert.deepEqual(bundleRunnerSpec.executor.secret_env, ['AI_PROVIDER_OPENAI_API_KEY']);
+assert.deepEqual(agentTaskRequestFromRunnerSpec({ runnerSpec: bundleRunnerSpec }), {
+  executor: bundleRunnerSpec.executor,
+  limits: { task_timeout_seconds: 900 },
+  expected_artifacts: ['datamachine-transcript'],
+});
+assert.equal(validateAgentTaskRunnerSpec(bundleRunnerSpec), bundleRunnerSpec);
+
 const abilityTask = datamachineAgentCiAbilityTaskRequest({
   taskId: 'validate-artifact',
   ability: 'example/validate-artifact',
@@ -98,4 +124,8 @@ assert.throws(
 assert.throws(
   () => datamachineAgentCiPlan({ planId: 'empty-plan', tasks: [] }),
   /tasks must contain at least one task request/
+);
+assert.throws(
+  () => validateAgentTaskRunnerSpec({ schema: AGENT_TASK_RUNNER_SPEC_SCHEMA }),
+  /runner spec executor is required/
 );


### PR DESCRIPTION
## Summary
- Add a generic `homeboy/agent-task-runner-spec/v1` builder and validator for normalized executor config, limits, and expected artifacts.
- Route the Data Machine Agent CI task request helper through that runner spec boundary.
- Document the normalized runner spec as the future Homeboy core replacement seam.

## Tests
- `npm run test:datamachine-agent-ci-plan`
- `npm run test:codebox-agent-task-executor-boundary`
- `npm run lint:js -- --no-warn-ignored lib/agent-task-runner-spec.js lib/datamachine-agent-ci-plan.js tests/datamachine-agent-ci-plan-smoke.js index.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the runner-spec helper, Data Machine CI plan wiring, documentation note, and smoke test updates for Chris to review and verify.