### PR TITLE
Add WordPress bench JSON artifact helper

### DIFF
--- a/wordpress/docs/BENCHMARK_WORKLOAD_HELPERS.md
+++ b/wordpress/docs/BENCHMARK_WORKLOAD_HELPERS.md
@@ -1,0 +1,46 @@
+# WordPress Benchmark Workload Helpers
+
+WordPress benchmark workloads can require reusable PHP helpers from the mounted Homeboy extension path. For WP Codebox benchmark runs, the extension is available at `/homeboy-extension`.
+
+## JSON Artifacts
+
+Use `homeboy_bench_write_json_artifact( $scenario, $name, $payload )` when a workload needs to persist structured evidence that is too large or detailed for numeric metrics.
+
+```php
+<?php
+require_once '/homeboy-extension/scripts/bench/lib/wordpress-bench-artifacts.php';
+
+return function (): array {
+	$artifact = homeboy_bench_write_json_artifact(
+		'route-latency',
+		'step-series',
+		array(
+			'rows' => array(
+				array('route' => '/', 'elapsed_ms' => 42.5),
+			),
+		)
+	);
+
+	return array(
+		'metrics' => array(
+			'route_latency_samples' => 1,
+		),
+		'artifacts' => array(
+			'step_series' => $artifact,
+		),
+	);
+};
+```
+
+The helper reads `HOMEBOY_BENCH_SHARED_STATE`, creates `artifacts/<scenario>/`, writes pretty-printed JSON, and returns a descriptor like:
+
+```json
+{
+  "path": "artifacts/route-latency/step-series.json",
+  "kind": "json",
+  "label": "step-series",
+  "mime_type": "application/json"
+}
+```
+
+Scenario and name values are sanitized into safe path segments. The helper throws a `RuntimeException` when shared state is unavailable or the artifact cannot be written.

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -64,6 +64,7 @@
     "test:webperf-evidence-summary": "node tests/webperf-evidence-summary-smoke.js",
     "test:benchmark-matrix-report": "node tests/benchmark-matrix-report-smoke.js",
     "test:wordpress-bench-state-sampling": "php tests/wordpress-bench-state-sampling-helper-smoke.php",
+    "test:wordpress-bench-artifacts": "php tests/wordpress-bench-artifact-helper-smoke.php",
     "test:wordpress-bench-woocommerce-fixtures": "php tests/wordpress-bench-woocommerce-fixtures-smoke.php",
     "test:wordpress-db-query-profiler": "php scripts/bench/wordpress-db-query-profiler-smoke.php",
     "test:audit-wp-codebox-fanout": "node tests/audit-wp-codebox-fanout-smoke.js",

--- a/wordpress/scripts/bench/lib/wordpress-bench-artifacts.php
+++ b/wordpress/scripts/bench/lib/wordpress-bench-artifacts.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Generic JSON artifact helpers for WordPress bench workloads.
+ *
+ * Workloads can require this file from the mounted extension path:
+ * /homeboy-extension/scripts/bench/lib/wordpress-bench-artifacts.php
+ */
+
+if ( ! function_exists('homeboy_bench_write_json_artifact') ) {
+	/**
+	 * Write a JSON artifact under the shared bench state directory.
+	 *
+	 * @param string $scenario Scenario id used as the artifact subdirectory.
+	 * @param string $name Artifact name used as the JSON filename.
+	 * @param mixed  $payload JSON-serializable artifact payload.
+	 * @return array<string,string> Standard bench artifact descriptor.
+	 */
+	function homeboy_bench_write_json_artifact(string $scenario, string $name, $payload): array {
+		$shared_state = homeboy_bench_shared_state_path();
+		$scenario_slug = homeboy_bench_artifact_slug($scenario);
+		$name_slug = homeboy_bench_artifact_slug(preg_replace('/\.json$/i', '', $name) ?? $name);
+
+		if ( '' === $scenario_slug ) {
+			throw new InvalidArgumentException('Bench artifact scenario must contain at least one safe filename character.');
+		}
+		if ( '' === $name_slug ) {
+			throw new InvalidArgumentException('Bench artifact name must contain at least one safe filename character.');
+		}
+
+		$relative_path = 'artifacts/' . $scenario_slug . '/' . $name_slug . '.json';
+		$artifact_path = rtrim($shared_state, '/\\') . '/' . $relative_path;
+		$artifact_dir = dirname($artifact_path);
+
+		if ( ! is_dir($artifact_dir) && ! mkdir($artifact_dir, 0777, true) && ! is_dir($artifact_dir) ) {
+			throw new RuntimeException('Failed to create bench artifact directory: ' . $artifact_dir);
+		}
+
+		$json = homeboy_bench_json_encode($payload);
+		$tmp_path = $artifact_path . '.tmp.' . getmypid() . '.' . bin2hex(random_bytes(6));
+		if ( false === file_put_contents($tmp_path, $json . "\n", LOCK_EX) ) {
+			throw new RuntimeException('Failed to write bench artifact: ' . $artifact_path);
+		}
+		if ( ! rename($tmp_path, $artifact_path) ) {
+			@unlink($tmp_path);
+			throw new RuntimeException('Failed to finalize bench artifact: ' . $artifact_path);
+		}
+
+		return array(
+			'path'      => $relative_path,
+			'kind'      => 'json',
+			'label'     => $name,
+			'mime_type' => 'application/json',
+		);
+	}
+}
+
+if ( ! function_exists('homeboy_bench_shared_state_path') ) {
+	/**
+	 * Resolve the shared state path exposed to the workload runtime.
+	 *
+	 * @return string Absolute path inside the workload runtime.
+	 */
+	function homeboy_bench_shared_state_path(): string {
+		$env_value = getenv('HOMEBOY_BENCH_SHARED_STATE');
+		$shared_state = is_string($env_value) ? trim($env_value) : '';
+		if ( '' === $shared_state && defined('HOMEBOY_BENCH_SHARED_STATE') ) {
+			$shared_state = trim((string) constant('HOMEBOY_BENCH_SHARED_STATE'));
+		}
+
+		if ( '' === $shared_state ) {
+			throw new RuntimeException('HOMEBOY_BENCH_SHARED_STATE is required to write bench artifacts.');
+		}
+
+		return $shared_state;
+	}
+}
+
+if ( ! function_exists('homeboy_bench_artifact_slug') ) {
+	/**
+	 * Convert workload-provided ids to safe path segments.
+	 *
+	 * @param string $value Raw path segment.
+	 * @return string Safe path segment.
+	 */
+	function homeboy_bench_artifact_slug(string $value): string {
+		$slug = strtolower(trim($value));
+		$slug = preg_replace('/[^a-z0-9._-]+/', '-', $slug) ?? '';
+		$slug = trim($slug, '.-_');
+
+		return $slug;
+	}
+}
+
+if ( ! function_exists('homeboy_bench_json_encode') ) {
+	/**
+	 * Encode artifact payloads with WordPress when available.
+	 *
+	 * @param mixed $payload JSON-serializable payload.
+	 * @return string Encoded JSON.
+	 */
+	function homeboy_bench_json_encode($payload): string {
+		$flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
+		$json = function_exists('wp_json_encode')
+			? wp_json_encode($payload, $flags)
+			: json_encode($payload, $flags);
+
+		if ( ! is_string($json) || '' === $json ) {
+			$message = function_exists('json_last_error_msg') ? json_last_error_msg() : 'unknown JSON encoding error';
+			throw new RuntimeException('Failed to encode bench artifact JSON: ' . $message);
+		}
+
+		return $json;
+	}
+}

--- a/wordpress/tests/wordpress-bench-artifact-helper-smoke.php
+++ b/wordpress/tests/wordpress-bench-artifact-helper-smoke.php
@@ -1,0 +1,61 @@
+<?php
+/** Smoke test for generic WordPress bench artifact helpers. */
+
+require_once __DIR__ . '/../scripts/bench/lib/wordpress-bench-artifacts.php';
+
+$root = sys_get_temp_dir() . '/homeboy-wordpress-bench-artifacts-' . uniqid('', true);
+if ( ! mkdir($root, 0777, true) && ! is_dir($root) ) {
+	fwrite(STDERR, "Failed to create temp root.\n");
+	exit(1);
+}
+
+putenv('HOMEBOY_BENCH_SHARED_STATE=' . $root);
+
+$descriptor = homeboy_bench_write_json_artifact('Scenario One', 'step-series', array(
+	'ok'    => true,
+	'rows'  => array(array('elapsed_ms' => 12.3)),
+	'route' => '/wp-admin/',
+));
+
+$expected_descriptor = array(
+	'path'      => 'artifacts/scenario-one/step-series.json',
+	'kind'      => 'json',
+	'label'     => 'step-series',
+	'mime_type' => 'application/json',
+);
+if ( $expected_descriptor !== $descriptor ) {
+	fwrite(STDERR, "Expected standard artifact descriptor.\n");
+	exit(1);
+}
+
+$artifact_path = $root . '/' . $descriptor['path'];
+if ( ! is_file($artifact_path) ) {
+	fwrite(STDERR, "Expected artifact file to be written under shared state.\n");
+	exit(1);
+}
+
+$payload = json_decode((string) file_get_contents($artifact_path), true);
+if ( ! is_array($payload) || true !== $payload['ok'] || '/wp-admin/' !== $payload['route'] ) {
+	fwrite(STDERR, "Expected JSON payload to round-trip.\n");
+	exit(1);
+}
+
+$sanitized_descriptor = homeboy_bench_write_json_artifact('../Nested Scenario', 'unsafe/name.json', array('ok' => true));
+if ( 'artifacts/nested-scenario/unsafe-name.json' !== $sanitized_descriptor['path'] ) {
+	fwrite(STDERR, "Expected scenario and name to be sanitized into safe artifact path segments.\n");
+	exit(1);
+}
+
+putenv('HOMEBOY_BENCH_SHARED_STATE');
+$failed_without_shared_state = false;
+try {
+	homeboy_bench_write_json_artifact('scenario', 'missing-shared-state', array());
+} catch ( RuntimeException $exception ) {
+	$failed_without_shared_state = false !== strpos($exception->getMessage(), 'HOMEBOY_BENCH_SHARED_STATE');
+}
+if ( ! $failed_without_shared_state ) {
+	fwrite(STDERR, "Expected missing HOMEBOY_BENCH_SHARED_STATE to fail clearly.\n");
+	exit(1);
+}
+
+echo "wordpress bench artifact helper smoke passed\n";


### PR DESCRIPTION
## Summary
- Add a generic WordPress/PHP benchmark helper, `homeboy_bench_write_json_artifact( \, \, \ )`, that writes JSON under `HOMEBOY_BENCH_SHARED_STATE/artifacts/<scenario>/`.
- Return a standard artifact descriptor with `path`, `kind`, `label`, and `mime_type` for workload `artifacts` payloads.
- Add PHP smoke coverage and docs for benchmark workload usage.

## Tests
- `npm run test:wordpress-bench-artifacts`
- `npm run test:wordpress-bench-state-sampling`
- `php -l scripts/bench/lib/wordpress-bench-artifacts.php && php -l tests/wordpress-bench-artifact-helper-smoke.php`

## Notes
- `npm run lint:js` currently fails on existing JavaScript lint issues outside this change, including `lib/playground-readiness.js` and agent scripts.

## Rigs follow-up
- Not run locally. Follow-up should wire this helper into a representative WordPress benchmark workload and verify the generated shared-state artifact is present in the persisted Homeboy run artifacts.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the helper implementation, smoke test, docs, and PR description for Chris to review/test.