### PR TITLE
Extract provider outcome normalizer

### DIFF
--- a/agent-runtimes/wp-codebox/index.js
+++ b/agent-runtimes/wp-codebox/index.js
@@ -2,4 +2,5 @@
 
 module.exports = {
 	...require('./lib/codebox-agent-task-executor'),
+	...require('./lib/provider-outcome-normalizer'),
 };

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -22,6 +22,10 @@ const {
   agentTaskProviderContractFields,
   providerDefaultsContract,
 } = require('../../lib/agent-task-provider-contract');
+const {
+  normalizeProviderTaskOutcome,
+  providerFailureClassification,
+} = require('./provider-outcome-normalizer');
 
 const WP_CODEBOX_TASK_REQUEST_SCHEMA = 'wp-codebox/task-input/v1';
 const WP_CODEBOX_PROVIDER_ID = 'wordpress.codebox-agent-task-executor';
@@ -1637,29 +1641,7 @@ function recipeRunArtifacts(result) {
 }
 
 function homeboyFailureClassification(classification, status) {
-  if (classification === 'provider' || classification === 'timeout') {
-    return classification;
-  }
-  if (classification === 'runtime' || classification === 'task') {
-    return 'execution_failed';
-  }
-  return classification || failureClassificationForStatus(status);
-}
-
-function failureClassificationForStatus(status) {
-  if (status === 'provider_error') {
-    return 'provider';
-  }
-  if (status === 'timeout') {
-    return 'timeout';
-  }
-  if (status === 'unable_to_remediate') {
-    return 'execution_failed';
-  }
-  if (status === 'failed') {
-    return 'execution_failed';
-  }
-  return undefined;
+  return providerFailureClassification(classification, status);
 }
 
 function sanitizePublicMetadata(value) {
@@ -2301,13 +2283,15 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   const recipeFailedPhase = recipeSummary?.failed_phase || recipeSummary?.metadata?.failure_phase || recipeRunFailedPhase(recipeRun);
   const runtimeFailureDiagnostic = agentRuntimeFailureDiagnostic(result);
   const providerDiagnostic = providerNotRegisteredDiagnostic(request, result);
-  const outcome = {
+  const outcome = normalizeProviderTaskOutcome(request, result, {
     schema: AGENT_TASK_OUTCOME_SCHEMA,
-    task_id: request.task_id,
+    provider: 'wordpress.codebox-agent-task-executor',
+    providerLabel: 'WP Codebox agent',
+    integrationContract: 'wp-codebox-cli/agent-task-run',
     status,
     summary: missingRequiredTypedArtifacts?.message || runtimeFailureDiagnostic?.message || recipeSummary?.failure_summary || fallbackRecipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
     artifacts: normalizeArtifacts(result, runSummary, recipeSummary),
-    evidence_refs: normalizeEvidenceRefs(result, runSummary, recipeSummary),
+    evidenceRefs: normalizeEvidenceRefs(result, runSummary, recipeSummary),
     outputs,
     diagnostics: [providerDiagnostic, missingRequiredTypedArtifacts, runtimeFailureDiagnostic, recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
@@ -2315,11 +2299,9 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
       data: sanitizePublicMetadata(diagnostic.data || {}),
     })),
     metadata: {
-      provider: 'wordpress.codebox-agent-task-executor',
       codebox: sanitizePublicMetadata(result.metadata || result),
       codebox_run_result: runSummary ? sanitizePublicMetadata(runSummary) : undefined,
       codebox_recipe_run_summary: recipeSummary ? sanitizePublicMetadata(recipeSummary) : undefined,
-      integration_contract: 'wp-codebox-cli/agent-task-run',
       decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result, runSummary, recipeSummary)),
       artifact_declarations: sanitizePublicMetadata(artifactDeclarationsMetadataFromRequest(request)),
       typed_artifacts: sanitizePublicMetadata(outputs.typed_artifacts || {}),
@@ -2329,7 +2311,8 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
       }),
       recipe_failed_phase: recipeFailedPhase || undefined,
     },
-  };
+    failureClassification,
+  });
   if (failureClassification) {
     outcome.failure_classification = failureClassification;
   } else if (missingRequiredTypedArtifacts) {

--- a/agent-runtimes/wp-codebox/lib/provider-outcome-normalizer.js
+++ b/agent-runtimes/wp-codebox/lib/provider-outcome-normalizer.js
@@ -1,0 +1,154 @@
+'use strict';
+
+const DEFAULT_OUTCOME_SCHEMA = 'homeboy/agent-task-outcome/v1';
+
+function normalizeProviderTaskOutcome(request, result = {}, options = {}) {
+  if (!request || typeof request !== 'object' || Array.isArray(request)) {
+    throw new TypeError('normalizeProviderTaskOutcome requires a request object.');
+  }
+  if (!request.task_id) {
+    throw new Error('normalizeProviderTaskOutcome requires request.task_id.');
+  }
+
+  const status = options.status || normalizeProviderStatus(result, options.exitStatus ?? 0);
+  const output = {
+    schema: options.schema || DEFAULT_OUTCOME_SCHEMA,
+    task_id: request.task_id,
+    status,
+    summary: options.summary || result.summary || result.message || defaultSummary(status, options.providerLabel),
+    artifacts: normalizeProviderArtifacts(options.artifacts ?? result.artifacts),
+    evidence_refs: normalizeProviderEvidenceRefs(options.evidenceRefs ?? result.evidence_refs),
+    outputs: normalizeProviderOutputs(options.outputs ?? result.outputs),
+    diagnostics: normalizeProviderDiagnostics(options.diagnostics ?? result.diagnostics),
+    metadata: normalizeProviderMetadata(result, options),
+  };
+
+  const failureClassification = options.failureClassification !== undefined
+    ? options.failureClassification
+    : providerFailureClassification(result.failure_classification, status);
+  if (failureClassification) {
+    output.failure_classification = failureClassification;
+  }
+
+  return output;
+}
+
+function normalizeProviderStatus(result = {}, exitStatus = 0) {
+  if (result.status === 'completed') {
+    return result.success === false ? 'failed' : 'succeeded';
+  }
+  if (result.status === 'succeeded' || result.status === 'failed' || result.status === 'provider_error' || result.status === 'timeout' || result.status === 'no_op' || result.status === 'unable_to_remediate') {
+    return result.status;
+  }
+  if (result.provider_error) {
+    return 'provider_error';
+  }
+  if (result.timeout) {
+    return 'timeout';
+  }
+  if (result.unable_to_remediate) {
+    return 'unable_to_remediate';
+  }
+  if (result.outcome === 'no_op' || result.no_op) {
+    return 'no_op';
+  }
+  if (result.success === true) {
+    return 'succeeded';
+  }
+  if (result.success === false || exitStatus !== 0) {
+    return 'failed';
+  }
+  return 'succeeded';
+}
+
+function providerFailureClassification(classification, status) {
+  if (classification === 'provider' || classification === 'timeout') {
+    return classification;
+  }
+  if (classification === 'runtime' || classification === 'task') {
+    return 'execution_failed';
+  }
+  if (classification) {
+    return classification;
+  }
+  if (status === 'provider_error') {
+    return 'provider';
+  }
+  if (status === 'timeout') {
+    return 'timeout';
+  }
+  if (status === 'failed' || status === 'unable_to_remediate') {
+    return 'execution_failed';
+  }
+  return undefined;
+}
+
+function normalizeProviderArtifacts(value) {
+  if (Array.isArray(value)) {
+    return value.filter(Boolean);
+  }
+  if (typeof value === 'string' && value !== '') {
+    return [{ id: 'provider-artifacts', kind: 'provider-artifact-directory', path: value }];
+  }
+  if (plainObject(value)) {
+    return Object.entries(value).map(([name, artifact]) => normalizeProviderArtifact(name, artifact)).filter(Boolean);
+  }
+  return [];
+}
+
+function normalizeProviderArtifact(name, artifact) {
+  if (typeof artifact === 'string' && artifact !== '') {
+    return { id: name, kind: 'provider-artifact', path: artifact };
+  }
+  if (!plainObject(artifact)) {
+    return null;
+  }
+  return Object.fromEntries(Object.entries({
+    id: artifact.id || name,
+    kind: artifact.kind || artifact.type || 'provider-artifact',
+    path: artifact.path || artifact.directory || artifact.file,
+    name: artifact.name,
+    metadata: artifact.metadata,
+  }).filter(([, entry]) => entry !== undefined && entry !== ''));
+}
+
+function normalizeProviderEvidenceRefs(value) {
+  return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function normalizeProviderOutputs(value) {
+  return plainObject(value) ? value : {};
+}
+
+function normalizeProviderDiagnostics(value) {
+  return (Array.isArray(value) ? value : []).filter(Boolean).map((diagnostic) => ({
+    class: diagnostic.class || diagnostic.kind || diagnostic.code || 'provider',
+    message: diagnostic.message || String(diagnostic),
+    data: plainObject(diagnostic.data) ? diagnostic.data : {},
+  }));
+}
+
+function normalizeProviderMetadata(result, options = {}) {
+  return Object.fromEntries(Object.entries({
+    provider: options.provider,
+    integration_contract: options.integrationContract,
+    ...(plainObject(options.metadata) ? options.metadata : {}),
+    provider_result: options.includeProviderResult === true ? result : undefined,
+  }).filter(([, entry]) => entry !== undefined));
+}
+
+function defaultSummary(status, providerLabel = 'Provider') {
+  return status === 'succeeded' || status === 'no_op'
+    ? `${providerLabel} task succeeded.`
+    : `${providerLabel} task failed.`;
+}
+
+function plainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+module.exports = {
+  normalizeProviderTaskOutcome,
+  normalizeProviderStatus,
+  providerFailureClassification,
+};

--- a/agent-runtimes/wp-codebox/package.json
+++ b/agent-runtimes/wp-codebox/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "exports": {
     ".": "./index.js",
-    "./codebox-agent-task-executor": "./lib/codebox-agent-task-executor.js"
+    "./codebox-agent-task-executor": "./lib/codebox-agent-task-executor.js",
+    "./provider-outcome-normalizer": "./lib/provider-outcome-normalizer.js"
   },
   "bin": {
     "homeboy-codebox-agent-task-executor": "./scripts/agent/homeboy-codebox-agent-task-executor.cjs"

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -78,6 +78,7 @@
     "test:wp-codebox-phpunit-recipe-builder": "node tests/wp-codebox-phpunit-recipe-builder-smoke.js",
     "test:build-package-artifacts": "bash scripts/build/build-package-artifacts-smoke.sh",
     "test:codebox-agent-task-executor-boundary": "node tests/codebox-agent-task-executor-boundary.test.js",
+    "test:provider-outcome-normalizer": "node tests/provider-outcome-normalizer.test.js",
     "test:codebox-agent-task-executor": "node tests/codebox-agent-task-executor-smoke.js",
     "test:codebox-agent-task-matrix": "node tests/codebox-agent-task-matrix-smoke.js",
     "test:opencode-agent-task-executor-boundary": "node tests/opencode-agent-task-executor-boundary.test.js",

--- a/wordpress/tests/provider-outcome-normalizer.test.js
+++ b/wordpress/tests/provider-outcome-normalizer.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+const {
+  normalizeProviderTaskOutcome,
+  normalizeProviderStatus,
+  providerFailureClassification,
+} = require('../../agent-runtimes/wp-codebox/lib/provider-outcome-normalizer');
+
+const request = { task_id: 'provider-task-123' };
+
+const legacyProviderError = normalizeProviderTaskOutcome(request, {
+  success: false,
+  provider_error: true,
+  summary: 'Provider failed before runtime startup.',
+  artifacts: { bundle: { id: 'bundle-1', directory: '/tmp/provider-artifacts' } },
+  diagnostics: [{ kind: 'provider.auth', message: 'OAuth refresh failed.', data: { provider: 'example' } }],
+}, {
+  provider: 'example.provider',
+  integrationContract: 'example/provider-task/v1',
+});
+
+assert.equal(legacyProviderError.schema, 'homeboy/agent-task-outcome/v1');
+assert.equal(legacyProviderError.task_id, 'provider-task-123');
+assert.equal(legacyProviderError.status, 'provider_error');
+assert.equal(legacyProviderError.failure_classification, 'provider');
+assert.equal(legacyProviderError.summary, 'Provider failed before runtime startup.');
+assert.equal(legacyProviderError.artifacts[0].id, 'bundle-1');
+assert.equal(legacyProviderError.artifacts[0].path, '/tmp/provider-artifacts');
+assert.equal(legacyProviderError.diagnostics[0].class, 'provider.auth');
+assert.equal(legacyProviderError.metadata.provider, 'example.provider');
+assert.equal(legacyProviderError.metadata.integration_contract, 'example/provider-task/v1');
+
+const completedDespiteNonZeroExit = normalizeProviderTaskOutcome(request, {
+  success: true,
+  status: 'completed',
+  outputs: { issue_url: 'https://github.com/example/repo/issues/12' },
+  evidence_refs: [{ kind: 'issue', uri: 'https://github.com/example/repo/issues/12', label: 'Issue' }],
+}, { exitStatus: 1 });
+
+assert.equal(completedDespiteNonZeroExit.status, 'succeeded');
+assert.equal(completedDespiteNonZeroExit.failure_classification, undefined);
+assert.equal(completedDespiteNonZeroExit.outputs.issue_url, 'https://github.com/example/repo/issues/12');
+assert.equal(completedDespiteNonZeroExit.evidence_refs[0].kind, 'issue');
+
+const normalizedRuntimeFailure = normalizeProviderTaskOutcome(request, {
+  success: false,
+  status: 'failed',
+  failure_classification: 'runtime',
+  diagnostics: [{ code: 'runtime.no_session', message: 'Runtime failed before creating a session.' }],
+});
+
+assert.equal(normalizedRuntimeFailure.status, 'failed');
+assert.equal(normalizedRuntimeFailure.failure_classification, 'execution_failed');
+assert.equal(normalizedRuntimeFailure.diagnostics[0].class, 'runtime.no_session');
+
+assert.equal(normalizeProviderStatus({ success: true, outcome: 'no_op' }), 'no_op');
+assert.equal(providerFailureClassification('task', 'failed'), 'execution_failed');
+assert.throws(() => normalizeProviderTaskOutcome({}, {}), /request.task_id/);
+
+console.log('✓ provider outcome normalizer boundary test PASSED');


### PR DESCRIPTION
## Summary
- Adds a generic provider outcome normalizer for `homeboy/agent-task-outcome/v1` assembly.
- Routes the WP Codebox outcome shim through that normalizer while keeping existing Codebox-specific status, artifact, evidence, output, metadata, and diagnostic extraction behavior intact.
- Adds a focused boundary test for representative legacy provider shapes: provider error, completed success with non-zero exit, and runtime/task failure classification.

## Tests
- `npm run test:provider-outcome-normalizer`
- `npm run test:codebox-agent-task-executor-boundary`
- `node --check ../agent-runtimes/wp-codebox/lib/provider-outcome-normalizer.js`
- `node --check ../agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js`

Attempted broader check:
- `npm run test:codebox-agent-task-executor` currently fails before outcome-normalizer assertions on a provider-defaults expectation mismatch for Codex `AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT` / `AI_PROVIDER_OPENAI_CODEX_FEDRAMP` metadata. This appears unrelated to this slice and should be handled separately.

## Upstream canonical output follow-up
- Follow up by moving the canonical provider output shape into the upstream provider contract/runtime surface so executors return `homeboy/agent-task-outcome/v1` directly and Homeboy Extensions can delete the remaining Codebox compatibility adapters instead of translating legacy result envelopes locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Extracted the normalizer boundary, drafted tests, and ran local verification; Chris remains responsible for review and acceptance.
