### PR TITLE
Fix WP Codebox Lab validation dependency paths

### DIFF
--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -50,6 +50,35 @@ function readTaskRequest() {
   return request;
 }
 
+function labWorkspaceMapping() {
+  const raw = process.env.HOMEBOY_LAB_OFFLOAD_JSON;
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    const workspaces = parsed?.workspace_mapping?.workspaces;
+    return Array.isArray(workspaces) ? workspaces : [];
+  } catch {
+    return [];
+  }
+}
+
+function remapLabWorkspacePath(candidate, componentSlug) {
+  if (!candidate || fs.existsSync(candidate)) {
+    return candidate;
+  }
+  const normalizedCandidate = String(candidate).replace(/\\/g, '/');
+  const candidateName = path.basename(normalizedCandidate);
+  const expectedName = componentSlug || candidateName;
+  const entry = labWorkspaceMapping().find((workspace) => {
+    const localName = path.basename(String(workspace?.local_path || '').replace(/\\/g, '/'));
+    const remoteName = path.basename(String(workspace?.remote_path || '').replace(/\\/g, '/'));
+    return workspace?.remote_path && (localName === expectedName || remoteName === expectedName);
+  });
+  return entry?.remote_path || candidate;
+}
+
 function secretEnvNames(request) {
   return Array.from(new Set([...(request.secret_env || []), ...(request.recipe?.secret_env || []), ...argValues('--secret-env')].filter(Boolean)));
 }
@@ -568,13 +597,16 @@ function requestRuntimeComponents(request, mounts = []) {
     : {};
   const contractPaths = runtimeComponentPathsFromContracts(request.component_contracts || []);
   const workspaceRoot = workspaceRootFromMounts(mounts);
-  const agentRuntimePath = explicit.agent_runtime || contractPaths.agent_runtime || legacyValue(request) || firstExistingPath(siblingPath(workspaceRoot, 'data-machine'));
+  const agentRuntimePath = remapLabWorkspacePath(
+    explicit.agent_runtime || contractPaths.agent_runtime || legacyValue(request) || firstExistingPath(siblingPath(workspaceRoot, 'data-machine')),
+    'data-machine'
+  );
   return Object.fromEntries(Object.entries({
     ...contractPaths,
     ...explicit,
-    agents_api: explicit.agents_api || contractPaths.agents_api || request.agents_api_path || request.agents_api || bundledAgentsApiPath(agentRuntimePath),
+    agents_api: remapLabWorkspacePath(explicit.agents_api || contractPaths.agents_api || request.agents_api_path || request.agents_api || bundledAgentsApiPath(agentRuntimePath), 'agents-api'),
     agent_runtime: agentRuntimePath,
-    agent_runtime_tools: explicit.agent_runtime_tools || contractPaths.agent_runtime_tools || legacyValue(request, 'code') || firstExistingPath(siblingPath(workspaceRoot, 'data-machine-code')),
+    agent_runtime_tools: remapLabWorkspacePath(explicit.agent_runtime_tools || contractPaths.agent_runtime_tools || legacyValue(request, 'code') || firstExistingPath(siblingPath(workspaceRoot, 'data-machine-code')), 'data-machine-code'),
   }).filter(([, value]) => value !== '' && value !== undefined));
 }
 

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -616,6 +616,56 @@ try {
   assert.equal(implicitRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'data-machine').source, defaultDataMachinePath);
   assert.equal(implicitRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'data-machine-code').source, defaultDataMachineCodePath);
 
+  const labRuntimeRoot = path.join(root, 'lab-runtime-components');
+  const labAgentsApi = path.join(labRuntimeRoot, 'agents-api');
+  const labDataMachine = path.join(labRuntimeRoot, 'data-machine');
+  const labDataMachineCode = path.join(labRuntimeRoot, 'data-machine-code');
+  fs.mkdirSync(labAgentsApi, { recursive: true });
+  fs.mkdirSync(labDataMachine, { recursive: true });
+  fs.mkdirSync(labDataMachineCode, { recursive: true });
+  fs.writeFileSync(path.join(labAgentsApi, 'agents-api.php'), "<?php\n/* Plugin Name: Agents API */\n");
+  fs.writeFileSync(path.join(labDataMachine, 'data-machine.php'), "<?php\n/* Plugin Name: Data Machine */\n");
+  fs.writeFileSync(path.join(labDataMachineCode, 'data-machine-code.php'), "<?php\n/* Plugin Name: Data Machine Code */\n");
+  const labRuntimeCapturePath = path.join(root, 'capture-lab-runtime-components.json');
+  const labRuntimeArtifacts = path.join(root, 'lab-runtime-artifacts');
+  const labRuntimeResult = spawnSync(process.execPath, [
+    wpCodeboxTaskRunner,
+    '--wp-codebox-bin', fixtureWpCodebox,
+    '--artifacts', labRuntimeArtifacts,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      runtime_component_paths: {
+        agents_api: '.ci/agents-api',
+        agent_runtime: '.ci/data-machine',
+        agent_runtime_tools: '.ci/data-machine-code',
+      },
+      component_contracts: [],
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: labRuntimeCapturePath,
+      OPENCODE_API_KEY: 'redacted-test-key',
+      HOMEBOY_LAB_OFFLOAD_JSON: JSON.stringify({
+        workspace_mapping: {
+          workspaces: [
+            { role: 'dependency', local_path: '/Users/chubes/Developer/agents-api', remote_path: labAgentsApi },
+            { role: 'dependency', local_path: '/Users/chubes/Developer/data-machine', remote_path: labDataMachine },
+            { role: 'dependency', local_path: '/Users/chubes/Developer/data-machine-code', remote_path: labDataMachineCode },
+          ],
+        },
+      }),
+    },
+  });
+  assert.equal(labRuntimeResult.status, 0, labRuntimeResult.stderr || labRuntimeResult.stdout);
+  const labRuntimeInput = readJson(labRuntimeCapturePath).input;
+  const preparedLabDataMachine = path.join(labRuntimeArtifacts, 'prepared-plugins', 'data-machine');
+  assert.equal(labRuntimeInput.runtime_component_paths.agent_runtime, preparedLabDataMachine);
+  assert.equal(labRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'agents-api').source, path.join(labRuntimeArtifacts, 'prepared-plugins', 'agents-api'));
+  assert.equal(labRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'data-machine-code').source, path.join(labRuntimeArtifacts, 'prepared-plugins', 'data-machine-code'));
+  assert.equal(fs.existsSync(path.join(preparedLabDataMachine, 'data-machine.php')), true);
+
   const runtimeComponentSource = path.join(root, 'runtime-components', 'data-machine-code');
   const runtimeComponentArtifacts = path.join(root, 'prepared-runtime-component-artifacts');
   fs.mkdirSync(runtimeComponentSource, { recursive: true });


### PR DESCRIPTION
## Summary
- Remap missing WP Codebox runtime component paths through Homeboy Lab workspace metadata.
- Allows relative CI paths like `.ci/data-machine` to resolve to synced Lab validation dependency workspaces before recipe preparation.
- Adds smoke coverage for Lab-synced `agents-api`, `data-machine`, and `data-machine-code` runtime components.

## Testing
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WP Codebox Lab path remapping failure, drafted the runtime fix and smoke coverage, and ran local verification. Chris remains responsible for review and final validation.