### PR TITLE
Fix WP Codebox Lab runtime component contracts

### DIFF
--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -79,6 +79,23 @@ function remapLabWorkspacePath(candidate, componentSlug) {
   return entry?.remote_path || candidate;
 }
 
+function runtimeComponentSlug(contract) {
+  if (!contract || typeof contract !== 'object') {
+    return '';
+  }
+  return ['agents-api', 'data-machine', 'data-machine-code'].includes(contract.slug) ? contract.slug : '';
+}
+
+function remapRuntimeComponentContract(contract) {
+  const slug = runtimeComponentSlug(contract);
+  if (!slug) {
+    return contract;
+  }
+  const source = contract.path || contract.source || '';
+  const remapped = remapLabWorkspacePath(source, slug);
+  return remapped && remapped !== source ? { ...contract, path: remapped } : contract;
+}
+
 function secretEnvNames(request) {
   return Array.from(new Set([...(request.secret_env || []), ...(request.recipe?.secret_env || []), ...argValues('--secret-env')].filter(Boolean)));
 }
@@ -673,7 +690,7 @@ function runnerInput(request, artifacts) {
     artifacts_path: artifacts,
     wp_codebox_bin: argValue('--wp-codebox-bin') || request.wp_codebox_bin || '',
     runtime_component_paths: runtimeComponentPaths,
-    component_contracts: uniqueComponentContracts(request.component_contracts || []),
+    component_contracts: uniqueComponentContracts((request.component_contracts || []).map(remapRuntimeComponentContract)),
     homeboy_path: argValue('--homeboy') || request.homeboy_path || request.homeboy || '',
     homeboy_extensions_path: argValue('--homeboy-extensions') || request.homeboy_extensions_path || request.homeboy_extensions || path.resolve(__dirname, '..', '..'),
     wp_version: request.wp_codebox_wordpress_version || request.wp_version || request.wp || undefined,
@@ -732,9 +749,9 @@ function componentContracts(input) {
     activate: Boolean(plugin.activate),
   }));
   return uniqueComponentContracts([
-    ...(input.component_contracts || []),
-    ...(input.parent_request?.component_contracts || []),
-    ...(input.parent_request?.parent_request?.component_contracts || []),
+    ...(input.component_contracts || []).map(remapRuntimeComponentContract),
+    ...(input.parent_request?.component_contracts || []).map(remapRuntimeComponentContract),
+    ...(input.parent_request?.parent_request?.component_contracts || []).map(remapRuntimeComponentContract),
     ...runtimeContracts,
   ]);
 }

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -641,7 +641,9 @@ try {
         agent_runtime: '.ci/data-machine',
         agent_runtime_tools: '.ci/data-machine-code',
       },
-      component_contracts: [],
+      component_contracts: [
+        { slug: 'agents-api', path: '.ci/agents-api', loadAs: 'mu-plugin', activate: false },
+      ],
     }),
     env: {
       ...process.env,
@@ -663,6 +665,7 @@ try {
   const preparedLabDataMachine = path.join(labRuntimeArtifacts, 'prepared-plugins', 'data-machine');
   assert.equal(labRuntimeInput.runtime_component_paths.agent_runtime, preparedLabDataMachine);
   assert.equal(labRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'agents-api').source, path.join(labRuntimeArtifacts, 'prepared-plugins', 'agents-api'));
+  assert.equal(labRuntimeInput.component_contracts.find((contract) => contract.slug === 'agents-api').path, path.join(labRuntimeArtifacts, 'prepared-plugins', 'agents-api'));
   assert.equal(labRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'data-machine-code').source, path.join(labRuntimeArtifacts, 'prepared-plugins', 'data-machine-code'));
   assert.equal(fs.existsSync(path.join(preparedLabDataMachine, 'data-machine.php')), true);
 


### PR DESCRIPTION
## Summary
- Remap WP Codebox runtime component contract paths through Homeboy Lab workspace metadata.
- Prevent parent request contracts such as `.ci/agents-api` from reintroducing missing recipe-local paths after runtime component paths have been remapped.
- Extends the Lab runtime component smoke coverage to include component contracts.

## Testing
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining WP Codebox Lab component contract remapping failure, drafted the follow-up runtime fix and smoke coverage, and ran local verification. Chris remains responsible for review and final validation.