### PR TITLE
Preflight stale Codex auth for WP Codebox

### DIFF
--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -318,7 +318,7 @@ function redactDiagnosticText(text) {
 }
 
 function missingSecretEnvNames(stderr) {
-  const match = String(stderr || '').match(/(?:Required WP Codebox secret environment variable missing|Claude Code provider auth preflight failed: missing required secret environment (?:mapping|value)):\s*([^\n\r]+)/i);
+  const match = String(stderr || '').match(/(?:Required WP Codebox secret environment variable missing|(?:Claude Code|Codex) provider auth preflight failed: missing required secret environment (?:mapping|value)):\s*([A-Z0-9_,\s]+)/i);
   if (!match) {
     return [];
   }
@@ -329,6 +329,9 @@ function missingSecretEnvNames(stderr) {
 }
 
 function preflightFailureClass(stderr, missingSecretEnv) {
+  if (/Codex provider auth preflight failed:/i.test(stderr)) {
+    return 'codebox.preflight.codex_auth';
+  }
   if (/Claude Code provider auth preflight failed:/i.test(stderr)) {
     return missingSecretEnv.length > 0
       ? 'codebox.preflight.claude_code_auth'
@@ -344,7 +347,7 @@ function stderrFailurePayload(result) {
   const missingSecretEnv = missingSecretEnvNames(stderr);
   const diagnosticClass = preflightFailureClass(stderr, missingSecretEnv);
   const message = missingSecretEnv.length > 0
-    ? `WP Codebox task runner preflight is missing required secret environment variables for ${diagnosticClass === 'codebox.preflight.claude_code_auth' ? 'Claude Code provider auth' : 'the runtime'}: ${missingSecretEnv.join(', ')}.`
+    ? `WP Codebox task runner preflight is missing required secret environment variables for ${diagnosticClass === 'codebox.preflight.claude_code_auth' ? 'Claude Code provider auth' : (diagnosticClass === 'codebox.preflight.codex_auth' ? 'Codex provider auth' : 'the runtime')}: ${missingSecretEnv.join(', ')}.`
     : 'WP Codebox task runner failed before returning a JSON outcome.';
 
   return {

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -7,9 +7,15 @@
  * External dependencies
  */
 const fs = require('node:fs');
+const http = require('node:http');
+const https = require('node:https');
 const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { URLSearchParams } = require('node:url');
+
+const CODEX_OAUTH_TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const CODEX_OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 
 function argValue(name) {
   const index = process.argv.indexOf(name);
@@ -104,8 +110,149 @@ function claudeCodeRequiredSecretEnv() {
   return ['AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN'];
 }
 
+function codexRequiredAuthEnv() {
+  return [
+    'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+    'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+    'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+    'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+  ];
+}
+
 function isClaudeCodeRequest(request) {
   return request.provider === 'claude-code';
+}
+
+function isCodexRequest(request) {
+  return request.provider === 'codex';
+}
+
+function parseUnixTimestamp(value) {
+  const raw = String(value || '').trim();
+  if (!raw) {
+    return NaN;
+  }
+  if (/^\d+$/.test(raw)) {
+    const parsed = Number.parseInt(raw, 10);
+    return parsed > 100000000000 ? Math.floor(parsed / 1000) : parsed;
+  }
+  const parsedDate = Date.parse(raw);
+  return Number.isFinite(parsedDate) ? Math.floor(parsedDate / 1000) : NaN;
+}
+
+function codexAuthGuidance() {
+  return 'Refresh Codex OAuth credentials before launching WP Codebox, for example by signing in with Codex locally so ~/.codex/auth.json contains current tokens, then pass the updated AI_PROVIDER_OPENAI_CODEX_* secret environment values to the codebox executor.';
+}
+
+function codexOAuthTokenUrl() {
+  return process.env.HOMEBOY_WP_CODEBOX_CODEX_TOKEN_URL || CODEX_OAUTH_TOKEN_URL;
+}
+
+function postForm(url, body, timeoutMs = 20000) {
+  return new Promise((resolve, reject) => {
+    let parsedUrl;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      reject(new Error('Codex provider auth preflight failed: OAuth token URL is invalid.'));
+      return;
+    }
+
+    const transport = parsedUrl.protocol === 'http:' ? http : https;
+    const encoded = new URLSearchParams(body).toString();
+    const request = transport.request(parsedUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': Buffer.byteLength(encoded),
+      },
+      timeout: timeoutMs,
+    }, (response) => {
+      let responseBody = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => {
+        responseBody += chunk;
+      });
+      response.on('end', () => {
+        resolve({ statusCode: response.statusCode || 0, body: responseBody });
+      });
+    });
+
+    request.on('timeout', () => {
+      request.destroy(new Error('Codex provider auth preflight failed: OAuth refresh timed out.'));
+    });
+    request.on('error', reject);
+    request.end(encoded);
+  });
+}
+
+async function refreshCodexAuthEnv() {
+  let response;
+  try {
+    response = await postForm(codexOAuthTokenUrl(), {
+      grant_type: 'refresh_token',
+      client_id: CODEX_OAUTH_CLIENT_ID,
+      refresh_token: process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN,
+    });
+  } catch (error) {
+    throw new Error(`Codex provider auth preflight failed: OAuth refresh request failed. ${codexAuthGuidance()}`);
+  }
+
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw new Error(`Codex provider auth preflight failed: OAuth refresh returned HTTP ${response.statusCode}. ${codexAuthGuidance()}`);
+  }
+
+  let data;
+  try {
+    data = JSON.parse(response.body);
+  } catch {
+    throw new Error(`Codex provider auth preflight failed: OAuth refresh returned invalid JSON. ${codexAuthGuidance()}`);
+  }
+
+  if (!data || typeof data !== 'object' || typeof data.access_token !== 'string' || data.access_token === '') {
+    throw new Error(`Codex provider auth preflight failed: OAuth refresh returned an invalid response. ${codexAuthGuidance()}`);
+  }
+
+  const expiresIn = Number.isFinite(Number(data.expires_in)) ? Number(data.expires_in) : 3600;
+  return Object.fromEntries(Object.entries({
+    AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: data.access_token,
+    AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: typeof data.refresh_token === 'string' && data.refresh_token !== ''
+      ? data.refresh_token
+      : process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN,
+    AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: String(Math.floor(Date.now() / 1000) + Math.trunc(expiresIn)),
+    AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: process.env.AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID,
+    AI_PROVIDER_OPENAI_CODEX_FEDRAMP: process.env.AI_PROVIDER_OPENAI_CODEX_FEDRAMP,
+  }).filter(([, value]) => value !== undefined && value !== null && value !== ''));
+}
+
+async function codexAuthPreflightEnv(request) {
+  if (!isCodexRequest(request)) {
+    return {};
+  }
+
+  const names = secretEnvNames(request);
+  const missingMapping = codexRequiredAuthEnv().filter((name) => !names.includes(name));
+  if (missingMapping.length > 0) {
+    throw new Error(`Codex provider auth preflight failed: missing required secret environment mapping: ${missingMapping.join(', ')}. ${codexAuthGuidance()}`);
+  }
+
+  const missing = codexRequiredAuthEnv().filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(`Codex provider auth preflight failed: missing required secret environment value: ${missing.join(', ')}. ${codexAuthGuidance()}`);
+  }
+
+  const expiresAt = parseUnixTimestamp(process.env.AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT);
+  if (!Number.isFinite(expiresAt) || expiresAt <= 0) {
+    throw new Error(`Codex provider auth preflight failed: AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT is malformed. ${codexAuthGuidance()}`);
+  }
+
+  const safetyWindowSeconds = 300;
+  const now = Math.floor(Date.now() / 1000);
+  if (expiresAt <= now + safetyWindowSeconds) {
+    throw new Error(`Codex provider auth preflight failed: AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT is expired or expires within ${safetyWindowSeconds} seconds. ${codexAuthGuidance()}`);
+  }
+
+  return refreshCodexAuthEnv();
 }
 
 function assertClaudeCodeAuthPreflight(request) {
@@ -1592,7 +1739,7 @@ function emptyStdoutPayloadFailure(result, artifacts) {
   );
 }
 
-function runWpCodeboxParentTask(request) {
+function runWpCodeboxParentTask(request, envOverrides = {}) {
   const explicitArtifacts = argValue('--artifacts') || request.artifacts_path || '';
   const artifacts = explicitArtifacts || fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-artifacts-'));
   if (explicitArtifacts) {
@@ -1644,6 +1791,7 @@ function runWpCodeboxParentTask(request) {
     encoding: 'utf8',
     env: {
       ...process.env,
+      ...envOverrides,
     },
     maxBuffer: 1024 * 1024 * 20,
     timeout: timeoutMs,
@@ -1713,12 +1861,15 @@ function runWpCodeboxParentTask(request) {
   return result.status ?? 1;
 }
 
+(async () => {
 try {
   const request = readTaskRequest();
+  const codexEnv = await codexAuthPreflightEnv(request);
   assertClaudeCodeAuthPreflight(request);
   assertRequiredSecretEnvAvailable(request);
-  process.exitCode = runWpCodeboxParentTask(request);
+  process.exitCode = runWpCodeboxParentTask(request, codexEnv);
 } catch (error) {
   console.error(error && error.message ? error.message : String(error));
   process.exitCode = 1;
 }
+})();

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -104,8 +104,66 @@ function claudeCodeRequiredSecretEnv() {
   return ['AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN'];
 }
 
+function codexRequiredAuthEnv() {
+  return [
+    'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+    'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+    'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+    'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+  ];
+}
+
 function isClaudeCodeRequest(request) {
   return request.provider === 'claude-code';
+}
+
+function isCodexRequest(request) {
+  return request.provider === 'codex';
+}
+
+function parseUnixTimestamp(value) {
+  const raw = String(value || '').trim();
+  if (!raw) {
+    return NaN;
+  }
+  if (/^\d+$/.test(raw)) {
+    const parsed = Number.parseInt(raw, 10);
+    return parsed > 100000000000 ? Math.floor(parsed / 1000) : parsed;
+  }
+  const parsedDate = Date.parse(raw);
+  return Number.isFinite(parsedDate) ? Math.floor(parsedDate / 1000) : NaN;
+}
+
+function codexAuthGuidance() {
+  return 'Refresh Codex OAuth credentials before launching WP Codebox, for example by signing in with Codex locally so ~/.codex/auth.json contains current tokens, then pass the updated AI_PROVIDER_OPENAI_CODEX_* secret environment values to the codebox executor.';
+}
+
+function assertCodexAuthPreflight(request) {
+  if (!isCodexRequest(request)) {
+    return;
+  }
+
+  const names = secretEnvNames(request);
+  const missingMapping = codexRequiredAuthEnv().filter((name) => !names.includes(name));
+  if (missingMapping.length > 0) {
+    throw new Error(`Codex provider auth preflight failed: missing required secret environment mapping: ${missingMapping.join(', ')}. ${codexAuthGuidance()}`);
+  }
+
+  const missing = codexRequiredAuthEnv().filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(`Codex provider auth preflight failed: missing required secret environment value: ${missing.join(', ')}. ${codexAuthGuidance()}`);
+  }
+
+  const expiresAt = parseUnixTimestamp(process.env.AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT);
+  if (!Number.isFinite(expiresAt) || expiresAt <= 0) {
+    throw new Error(`Codex provider auth preflight failed: AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT is malformed. ${codexAuthGuidance()}`);
+  }
+
+  const safetyWindowSeconds = 300;
+  const now = Math.floor(Date.now() / 1000);
+  if (expiresAt <= now + safetyWindowSeconds) {
+    throw new Error(`Codex provider auth preflight failed: AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT is expired or expires within ${safetyWindowSeconds} seconds. ${codexAuthGuidance()}`);
+  }
 }
 
 function assertClaudeCodeAuthPreflight(request) {
@@ -1715,6 +1773,7 @@ function runWpCodeboxParentTask(request) {
 
 try {
   const request = readTaskRequest();
+  assertCodexAuthPreflight(request);
   assertClaudeCodeAuthPreflight(request);
   assertRequiredSecretEnvAvailable(request);
   process.exitCode = runWpCodeboxParentTask(request);

--- a/wordpress/tests/codebox-codex-auth-preflight-smoke.js
+++ b/wordpress/tests/codebox-codex-auth-preflight-smoke.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn, spawnSync } = require('node:child_process');
+
+const wpCodeboxRuntimeExecutor = path.join(
+  __dirname,
+  '..',
+  '..',
+  'agent-runtimes',
+  'wp-codebox',
+  'scripts',
+  'agent',
+  'homeboy-codebox-agent-task-executor.cjs'
+);
+
+const codexSecretEnv = [
+  'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+  'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+  'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+];
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-codex-auth-preflight-'));
+let oauthServer;
+
+function waitForFile(filePath) {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) {
+      return fs.readFileSync(filePath, 'utf8').trim();
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+  }
+  throw new Error(`Timed out waiting for ${filePath}`);
+}
+
+function createRejectingOAuthServer() {
+  const script = path.join(root, 'fixture-rejecting-codex-oauth-server.js');
+  const portPath = path.join(root, 'fixture-rejecting-codex-oauth-port');
+  fs.writeFileSync(script, `#!/usr/bin/env node
+'use strict';
+const fs = require('node:fs');
+const http = require('node:http');
+const portPath = process.argv[2];
+const server = http.createServer((request, response) => {
+  request.resume();
+  response.writeHead(401, { 'Content-Type': 'application/json' });
+  response.end(JSON.stringify({ error: 'invalid_grant' }));
+});
+server.listen(0, '127.0.0.1', () => {
+  fs.writeFileSync(portPath, String(server.address().port));
+});
+`);
+  const child = spawn(process.execPath, [script, portPath], { stdio: ['ignore', 'ignore', 'pipe'] });
+  const port = waitForFile(portPath);
+  return {
+    url: `http://127.0.0.1:${port}/oauth/token`,
+    stop() {
+      child.kill();
+    },
+  };
+}
+
+try {
+  oauthServer = createRejectingOAuthServer();
+  const providerPluginPath = path.join(root, 'ai-provider-for-openai');
+  fs.mkdirSync(providerPluginPath, { recursive: true });
+  fs.writeFileSync(path.join(providerPluginPath, 'ai-provider-for-openai.php'), '<?php\n/* Plugin Name: AI Provider for OpenAI Codex */\n');
+
+  const result = spawnSync(process.execPath, [wpCodeboxRuntimeExecutor], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      schema: 'homeboy/agent-task-request/v1',
+      task_id: 'codex-stale-refresh-token-preflight',
+      executor: {
+        backend: 'codebox',
+        model: 'gpt-5.5',
+        secret_env: codexSecretEnv,
+        config: {
+          provider: 'codex',
+          provider_plugin_paths: [providerPluginPath],
+          wp_codebox_bin: '/bin/should-not-launch-wp-codebox',
+        },
+      },
+      instructions: 'Verify Codex auth before launching WP Codebox.',
+      workspace: { mode: 'ephemeral' },
+    }),
+    env: {
+      ...process.env,
+      AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'stale-access-token-value',
+      AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'stale-refresh-token-value',
+      AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '4102444800',
+      AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'stale-account-id-value',
+      AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
+      HOMEBOY_WP_CODEBOX_CODEX_TOKEN_URL: oauthServer.url,
+    },
+  });
+
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  const outcome = JSON.parse(result.stdout);
+  assert.equal(outcome.status, 'failed');
+  assert.equal(outcome.failure_classification, 'provider');
+  assert.equal(outcome.diagnostics[0].class, 'codebox.preflight.codex_auth');
+  assert.match(outcome.diagnostics[0].data.stderr, /OAuth refresh returned HTTP 401/);
+  assert.match(outcome.diagnostics[0].data.stderr, /Refresh Codex OAuth credentials/);
+  assert(!JSON.stringify(outcome).includes('stale-access-token-value'));
+  assert(!JSON.stringify(outcome).includes('stale-refresh-token-value'));
+} finally {
+  if (oauthServer) {
+    oauthServer.stop();
+  }
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+console.log('Codebox Codex auth preflight smoke passed');

--- a/wordpress/tests/codebox-codex-auth-preflight-smoke.js
+++ b/wordpress/tests/codebox-codex-auth-preflight-smoke.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const wpCodeboxRuntimeExecutor = path.join(
+  __dirname,
+  '..',
+  '..',
+  'agent-runtimes',
+  'wp-codebox',
+  'scripts',
+  'agent',
+  'homeboy-codebox-agent-task-executor.cjs'
+);
+
+const codexSecretEnv = [
+  'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
+  'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
+  'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
+  'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
+];
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-codex-auth-preflight-'));
+
+try {
+  const providerPluginPath = path.join(root, 'ai-provider-for-openai');
+  fs.mkdirSync(providerPluginPath, { recursive: true });
+  fs.writeFileSync(path.join(providerPluginPath, 'ai-provider-for-openai.php'), '<?php\n/* Plugin Name: AI Provider for OpenAI Codex */\n');
+
+  const result = spawnSync(process.execPath, [wpCodeboxRuntimeExecutor], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      schema: 'homeboy/agent-task-request/v1',
+      task_id: 'codex-expired-auth-preflight',
+      executor: {
+        backend: 'codebox',
+        model: 'gpt-5.5',
+        secret_env: codexSecretEnv,
+        config: {
+          provider: 'codex',
+          provider_plugin_paths: [providerPluginPath],
+          wp_codebox_bin: '/bin/should-not-launch-wp-codebox',
+        },
+      },
+      instructions: 'Verify Codex auth before launching WP Codebox.',
+      workspace: { mode: 'ephemeral' },
+    }),
+    env: {
+      ...process.env,
+      AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'expired-access-token-value',
+      AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'expired-refresh-token-value',
+      AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '1',
+      AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'expired-account-id-value',
+      AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
+    },
+  });
+
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  const outcome = JSON.parse(result.stdout);
+  assert.equal(outcome.status, 'failed');
+  assert.equal(outcome.failure_classification, 'provider');
+  assert.equal(outcome.diagnostics[0].class, 'codebox.preflight.codex_auth');
+  assert.match(outcome.diagnostics[0].data.stderr, /AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT/);
+  assert.match(outcome.diagnostics[0].data.stderr, /Refresh Codex OAuth credentials/);
+  assert(!JSON.stringify(outcome).includes('expired-access-token-value'));
+  assert(!JSON.stringify(outcome).includes('expired-refresh-token-value'));
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+console.log('Codebox Codex auth preflight smoke passed');

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -598,6 +598,37 @@ try {
   assert(!JSON.stringify(codexInput).includes('access-token-value'));
   assert(!JSON.stringify(codexInput).includes('refresh-token-value'));
 
+  const expiredCodexCapturePath = path.join(root, 'capture-expired-codex.json');
+  const expiredCodexResult = spawnSync(process.execPath, [
+    wpCodeboxTaskRunner,
+    '--wp-codebox-bin', fixtureWpCodebox,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      provider: 'codex',
+      model: 'gpt-5.5',
+      provider_plugin_paths: ['/components/ai-provider-for-openai'],
+      secret_env: codexSecretEnv,
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: expiredCodexCapturePath,
+      AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'expired-access-token-value',
+      AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'expired-refresh-token-value',
+      AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '1',
+      AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'expired-account-id-value',
+      AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
+    },
+  });
+  assert.equal(expiredCodexResult.status, 1, expiredCodexResult.stderr || expiredCodexResult.stdout);
+  assert.match(expiredCodexResult.stderr, /Codex provider auth preflight failed/);
+  assert.match(expiredCodexResult.stderr, /AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT/);
+  assert.match(expiredCodexResult.stderr, /Refresh Codex OAuth credentials/);
+  assert(!expiredCodexResult.stderr.includes('expired-access-token-value'));
+  assert(!expiredCodexResult.stderr.includes('expired-refresh-token-value'));
+  assert(!fs.existsSync(expiredCodexCapturePath));
+
   const implicitRuntimeRequest = { ...request };
   delete implicitRuntimeRequest.runtime_component_paths;
   const implicitRuntimeCapturePath = path.join(root, 'capture-implicit-runtime-stack.json');

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
+const { spawn, spawnSync } = require('node:child_process');
 
 const wpCodeboxTaskRunner = path.join(
   __dirname,
@@ -175,7 +175,15 @@ const agentResult = isRuntimeTask
   : (isAgentBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_AGENT_BUNDLE
       ? { metrics: { config_present: 1 }, metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }
       : { status: 'completed' })))));
-fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), input }, null, 2));
+fs.writeFileSync(out, JSON.stringify({
+  argv: process.argv.slice(2),
+  input,
+  codex_env: {
+    access_refreshed: process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN === 'fresh-access-token-value',
+    refresh_refreshed: process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN === 'fresh-refresh-token-value',
+    expires_refreshed: Number(process.env.AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT || 0) > Math.floor(Date.now() / 1000),
+  },
+}, null, 2));
 const execution = { recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed', output: JSON.stringify(agentResult) }) };
 const executions = [execution];
 process.stdout.write(JSON.stringify({
@@ -202,14 +210,71 @@ if (process.env.FIXTURE_WP_CODEBOX_EXIT_CODE) {
   return binPath;
 }
 
+function waitForFile(filePath) {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) {
+      return fs.readFileSync(filePath, 'utf8').trim();
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+  }
+  throw new Error(`Timed out waiting for ${filePath}`);
+}
+
+function createCodexOAuthServer(root) {
+  const script = path.join(root, 'fixture-codex-oauth-server.js');
+  const portPath = path.join(root, 'fixture-codex-oauth-port');
+  const logPath = path.join(root, 'fixture-codex-oauth-requests.jsonl');
+  fs.writeFileSync(script, `#!/usr/bin/env node
+'use strict';
+const fs = require('node:fs');
+const http = require('node:http');
+const { URLSearchParams } = require('node:url');
+const portPath = process.argv[2];
+const logPath = process.argv[3];
+const server = http.createServer((request, response) => {
+  let body = '';
+  request.setEncoding('utf8');
+  request.on('data', (chunk) => { body += chunk; });
+  request.on('end', () => {
+    const params = Object.fromEntries(new URLSearchParams(body));
+    fs.appendFileSync(logPath, JSON.stringify({ method: request.method, url: request.url, params }) + '\\n');
+    if (params.refresh_token === 'stale-refresh-token-value') {
+      response.writeHead(401, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify({ error: 'invalid_grant' }));
+      return;
+    }
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.end(JSON.stringify({ access_token: 'fresh-access-token-value', refresh_token: 'fresh-refresh-token-value', expires_in: 3600 }));
+  });
+});
+server.listen(0, '127.0.0.1', () => {
+  fs.writeFileSync(portPath, String(server.address().port));
+});
+`);
+  const child = spawn(process.execPath, [script, portPath, logPath], {
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  const port = waitForFile(portPath);
+  return {
+    url: `http://127.0.0.1:${port}/oauth/token`,
+    logPath,
+    stop() {
+      child.kill();
+    },
+  };
+}
+
 function pathInside(parent, candidate) {
   const relative = path.relative(parent, candidate);
   return relative === '' || (Boolean(relative) && !relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-task-runner-'));
+let codexOAuthServer;
 
 try {
+  codexOAuthServer = createCodexOAuthServer(root);
   const capturePath = path.join(root, 'capture.json');
   const fixtureWpCodebox = createFixtureWpCodebox(root);
   const providerPluginPath = path.join(root, 'example-provider@feature-branch');
@@ -587,16 +652,86 @@ try {
       AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '4102444800',
       AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'account-id-value',
       AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
+      HOMEBOY_WP_CODEBOX_CODEX_TOKEN_URL: codexOAuthServer.url,
     },
   });
   assert.equal(codexResult.status, 0, codexResult.stderr || codexResult.stdout);
-  const codexInput = readJson(codexCapturePath).input;
+  const codexCapture = readJson(codexCapturePath);
+  const codexInput = codexCapture.input;
   assert.deepEqual(codexInput.secret_env, codexSecretEnv);
   assert.equal(codexInput.provider, 'codex');
   assert.equal(codexInput.model, 'gpt-5.5');
   assert.equal(codexInput.provider_plugin_paths[0], '/components/ai-provider-for-openai');
+  assert.deepEqual(codexCapture.codex_env, {
+    access_refreshed: true,
+    refresh_refreshed: true,
+    expires_refreshed: true,
+  });
   assert(!JSON.stringify(codexInput).includes('access-token-value'));
   assert(!JSON.stringify(codexInput).includes('refresh-token-value'));
+
+  const expiredCodexCapturePath = path.join(root, 'capture-expired-codex.json');
+  const expiredCodexResult = spawnSync(process.execPath, [
+    wpCodeboxTaskRunner,
+    '--wp-codebox-bin', fixtureWpCodebox,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      provider: 'codex',
+      model: 'gpt-5.5',
+      provider_plugin_paths: ['/components/ai-provider-for-openai'],
+      secret_env: codexSecretEnv,
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: expiredCodexCapturePath,
+      AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'expired-access-token-value',
+      AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'expired-refresh-token-value',
+      AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '1',
+      AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'expired-account-id-value',
+      AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
+    },
+  });
+  assert.equal(expiredCodexResult.status, 1, expiredCodexResult.stderr || expiredCodexResult.stdout);
+  assert.match(expiredCodexResult.stderr, /Codex provider auth preflight failed/);
+  assert.match(expiredCodexResult.stderr, /AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT/);
+  assert.match(expiredCodexResult.stderr, /Refresh Codex OAuth credentials/);
+  assert(!expiredCodexResult.stderr.includes('expired-access-token-value'));
+  assert(!expiredCodexResult.stderr.includes('expired-refresh-token-value'));
+  assert(!fs.existsSync(expiredCodexCapturePath));
+
+  const staleCodexCapturePath = path.join(root, 'capture-stale-codex.json');
+  const staleCodexResult = spawnSync(process.execPath, [
+    wpCodeboxTaskRunner,
+    '--wp-codebox-bin', fixtureWpCodebox,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      ...request,
+      provider: 'codex',
+      model: 'gpt-5.5',
+      provider_plugin_paths: ['/components/ai-provider-for-openai'],
+      secret_env: codexSecretEnv,
+    }),
+    env: {
+      ...process.env,
+      FIXTURE_WP_CODEBOX_CAPTURE: staleCodexCapturePath,
+      AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'stale-access-token-value',
+      AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'stale-refresh-token-value',
+      AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '4102444800',
+      AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'stale-account-id-value',
+      AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
+      HOMEBOY_WP_CODEBOX_CODEX_TOKEN_URL: codexOAuthServer.url,
+    },
+  });
+  assert.equal(staleCodexResult.status, 1, staleCodexResult.stderr || staleCodexResult.stdout);
+  assert.match(staleCodexResult.stderr, /Codex provider auth preflight failed/);
+  assert.match(staleCodexResult.stderr, /OAuth refresh returned HTTP 401/);
+  assert.match(staleCodexResult.stderr, /Refresh Codex OAuth credentials/);
+  assert(!staleCodexResult.stderr.includes('stale-access-token-value'));
+  assert(!staleCodexResult.stderr.includes('stale-refresh-token-value'));
+  assert(!fs.existsSync(staleCodexCapturePath));
 
   const implicitRuntimeRequest = { ...request };
   delete implicitRuntimeRequest.runtime_component_paths;
@@ -1131,5 +1266,8 @@ try {
 
   console.log('Homeboy WP Codebox task runner smoke passed');
 } finally {
+  if (codexOAuthServer) {
+    codexOAuthServer.stop();
+  }
   fs.rmSync(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- Add a WP Codebox runner Codex auth preflight that validates required OAuth env mappings/values and rejects malformed, expired, or near-expiry expires-at values before launching WP Codebox.
- Classify Codex auth preflight stderr as `codebox.preflight.codex_auth` in the outer codebox executor outcome.
- Cover the direct runner failure path and an executor-level stale-auth outcome without exposing token values.

Closes #1502.

## Tests
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node wordpress/tests/codebox-codex-auth-preflight-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the WP Codebox Codex auth preflight implementation, smoke coverage, and verification notes; Chris remains responsible for review and merge.