### PR TITLE
Stabilize WP Codebox artifact helper

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -30,10 +30,14 @@ The `php-ai-client` checkout must include bearer-token auth support (`RequestAut
 ## WP Codebox Artifact Lookup
 
 WordPress helpers that consume WP Codebox browser or recipe artifacts should use
-`wordpress/lib/wp-codebox-artifacts.js` instead of parsing bundle directory
-layouts directly. The helper resolves artifact references from returned runtime
-metadata (`artifacts`, `files`, nested `artifact.files`, or fallback paths) to
-absolute files under the artifact bundle directory.
+the exported `homeboy-extension-wordpress/wp-codebox-artifacts` module instead
+of parsing bundle directory layouts directly. The helper resolves artifact
+references from returned runtime metadata (`artifacts`, `files`,
+`artifactFiles`, nested `artifact.files`, summary file maps, or fallback paths)
+to absolute files under the artifact bundle directory. It accepts canonical
+directory aliases including `artifacts.directory`, `artifacts.path`,
+`artifactsDirectory`, `artifacts_directory`, `artifactDirectory`, and
+`artifact_directory`.
 
 This keeps extension helpers product-neutral: workloads and probes can name the
 artifact they need, while runtime-specific bundle layouts remain behind one

--- a/wordpress/lib/wp-codebox-artifacts.js
+++ b/wordpress/lib/wp-codebox-artifacts.js
@@ -7,6 +7,9 @@ const path = require('node:path');
 
 function wpCodeboxArtifactDirectory(codeboxResult, fallbackDirectory) {
   return codeboxResult?.artifacts?.directory
+    || codeboxResult?.artifacts?.path
+    || codeboxResult?.artifactsDirectory
+    || codeboxResult?.artifacts_directory
     || codeboxResult?.artifactDirectory
     || codeboxResult?.artifact_directory
     || fallbackDirectory
@@ -29,6 +32,8 @@ function wpCodeboxArtifactByKey(source, key) {
   }
   return source?.artifacts?.[key]
     || source?.files?.[key]
+    || source?.artifactFiles?.[key]
+    || source?.artifact_files?.[key]
     || source?.artifact?.files?.[key]
     || source?.summary?.files?.[key]
     || source?.artifact?.summary?.files?.[key]

--- a/wordpress/tests/wp-codebox-artifacts-smoke.js
+++ b/wordpress/tests/wp-codebox-artifacts-smoke.js
@@ -20,11 +20,16 @@ const codeboxResult = {
 };
 
 assert.equal(wpCodeboxArtifactDirectory(codeboxResult, '/tmp/fallback'), '/tmp/codebox-artifacts');
+assert.equal(wpCodeboxArtifactDirectory({ artifacts: { path: '/tmp/codebox-artifacts-path' } }, ''), '/tmp/codebox-artifacts-path');
+assert.equal(wpCodeboxArtifactDirectory({ artifactsDirectory: '/tmp/camel-artifacts' }, ''), '/tmp/camel-artifacts');
+assert.equal(wpCodeboxArtifactDirectory({ artifacts_directory: '/tmp/snake-artifacts' }, ''), '/tmp/snake-artifacts');
 assert.equal(wpCodeboxArtifactDirectory({}, '/tmp/fallback'), '/tmp/fallback');
 assert.equal(wpCodeboxArtifactPath({ path: 'artifact.json' }), 'artifact.json');
 assert.equal(wpCodeboxArtifactPath('artifact.json'), 'artifact.json');
 assert.deepEqual(wpCodeboxArtifactByKey(codeboxResult, 'summary'), { path: 'summary.json', kind: 'json' });
 assert.equal(wpCodeboxArtifactByKey(codeboxResult, 'visualDiff'), 'files/browser/visual-compare/visual-diff.json');
+assert.equal(wpCodeboxArtifactByKey({ artifactFiles: { report: 'report.json' } }, 'report'), 'report.json');
+assert.equal(wpCodeboxArtifactByKey({ artifact_files: { report: 'snake-report.json' } }, 'report'), 'snake-report.json');
 assert.equal(resolveWpCodeboxArtifactPath({
   codeboxResult,
   key: 'visualDiff',


### PR DESCRIPTION
## Summary
- Extend the WP Codebox artifact helper to accept canonical artifact directory aliases.
- Cover canonical directory and file-map aliases in the focused smoke test.
- Document the stable consumer module path for rigs: `homeboy-extension-wordpress/wp-codebox-artifacts`.

## Tests
- `npm run test:wp-codebox-artifacts`
- `npm run lint:js -- --no-warn-ignored lib/wp-codebox-artifacts.js tests/wp-codebox-artifacts-smoke.js`
- `node -e "const helper = require('homeboy-extension-wordpress/wp-codebox-artifacts'); if (typeof helper.resolveWpCodeboxArtifactPath !== 'function') process.exit(1);"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** stabilizing the WP Codebox artifact helper and coverage.