### PR TITLE
Add deferred-init browser evidence helper

### DIFF
--- a/nodejs/docs/browser-bench-helpers.md
+++ b/nodejs/docs/browser-bench-helpers.md
@@ -82,3 +82,117 @@ The helper is substrate-agnostic. Assertions describe generic browser/page
 facts such as status, selectors, text, title, and artifact presence. Workloads
 can provide `sanitizeArtifacts()` or `sanitizeRawResult()` hooks to redact or
 normalize generated artifacts before returning results.
+
+## Deferred-Initialization Evidence
+
+Browser workloads can import the same helper path to prove that optional browser
+work stays idle until a feature is needed:
+
+```js
+const {
+  deferredInitBrowserMarkerScript,
+  deferredInitBrowserMarkers,
+  summarizeDeferredInitBrowserEvidence,
+} = await import(process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER);
+
+const featureId = 'lazy-widget';
+const markers = deferredInitBrowserMarkers(featureId);
+
+await page.addInitScript(deferredInitBrowserMarkerScript(featureId));
+await page.goto(target);
+await page.evaluate((featureId) => {
+  const deferred = window.__homeboyDeferredInit[featureId];
+  deferred.mark(deferred.markers.featureNotNeededReady, { state: 'idle' });
+}, featureId);
+
+await page.getByRole('button', { name: 'Show widget' }).click();
+await page.evaluate((featureId) => {
+  const deferred = window.__homeboyDeferredInit[featureId];
+  deferred.mark(deferred.markers.featureNeededTrigger, { trigger: 'button-click' });
+}, featureId);
+
+await page.waitForSelector('[data-widget-ready="true"]');
+const markerEvents = await page.evaluate((featureId) => {
+  const deferred = window.__homeboyDeferredInit[featureId];
+  deferred.mark(deferred.markers.featureNeededReady);
+  deferred.mark(deferred.markers.featureNeededSuccess);
+  return deferred.events;
+}, featureId);
+
+const summary = summarizeDeferredInitBrowserEvidence({
+  featureId,
+  markerEvents,
+  networkEntries: browserProfile.network,
+  featureRequestMatchers: ['lazy-widget'],
+  thirdPartyRequestMatchers: [/third-party\.example/],
+  maxEarlyFeatureRequests: 0,
+  maxEarlyThirdPartyRequests: 0,
+  minPostTriggerFeatureRequests: 1,
+});
+```
+
+The helper is product-neutral. The workload owns selectors, interaction steps,
+and request matchers; the helper only normalizes marker names, metrics,
+assertions, URL samples, and phase labels.
+
+Default phases:
+
+```json
+{
+  "FEATURE_NOT_NEEDED": "feature-not-needed",
+  "FEATURE_NEEDED": "feature-needed"
+}
+```
+
+Default markers use `deferred_init.<featureId>.*`:
+
+```json
+{
+  "featureNotNeededStart": "deferred_init.lazy-widget.feature_not_needed.start",
+  "featureNotNeededReady": "deferred_init.lazy-widget.feature_not_needed.ready",
+  "featureNeededTrigger": "deferred_init.lazy-widget.feature_needed.trigger",
+  "featureNeededReady": "deferred_init.lazy-widget.feature_needed.ready",
+  "featureNeededSuccess": "deferred_init.lazy-widget.feature_needed.success"
+}
+```
+
+Summary output shape:
+
+```json
+{
+  "feature_id": "lazy-widget",
+  "phases": {
+    "FEATURE_NOT_NEEDED": "feature-not-needed",
+    "FEATURE_NEEDED": "feature-needed"
+  },
+  "metrics": {
+    "lazy_widget_deferred_init_feature_not_needed_ready_ms": 125,
+    "lazy_widget_deferred_init_feature_needed_trigger_ms": 500,
+    "lazy_widget_deferred_init_feature_needed_ready_ms": 725,
+    "lazy_widget_deferred_init_feature_needed_success_ms": 750,
+    "lazy_widget_deferred_init_request_timing_available": true,
+    "lazy_widget_deferred_init_feature_request_count_before_trigger": 0,
+    "lazy_widget_deferred_init_feature_request_count_after_trigger": 2,
+    "lazy_widget_deferred_init_no_early_feature_init": true,
+    "lazy_widget_deferred_init_post_trigger_feature_requests": true,
+    "lazy_widget_deferred_init_post_trigger_success": true
+  },
+  "assertions": [
+    {
+      "id": "lazy-widget-no-early-feature-init",
+      "status": "pass",
+      "message": "Observed 0 feature request(s) before trigger; expected <= 0."
+    }
+  ],
+  "metadata": {
+    "early_feature_urls_sample": [],
+    "post_trigger_feature_urls_sample": ["https://cdn.example.test/lazy-widget.js"],
+    "early_third_party_urls_sample": [],
+    "post_trigger_third_party_urls_sample": []
+  }
+}
+```
+
+Consumers can attach `summary.metrics` to benchmark metrics and record
+`summary.assertions` in their evidence traces. Full network logs stay in the
+workload artifact; the helper returns bounded URL samples for review summaries.

--- a/nodejs/scripts/bench/browser-helper.mjs
+++ b/nodejs/scripts/bench/browser-helper.mjs
@@ -14,9 +14,150 @@ import {
 export { buildBrowserBenchResult };
 
 const DEFAULT_NETWORK_IDLE_TIMEOUT_MS = 5000;
+const DEFAULT_DEFERRED_INIT_MARKER_PREFIX = 'deferred_init';
 const BROWSER_PERFORMANCE_STATE = new WeakMap();
 const SECRET_HEADER_PATTERN = /^(authorization|cookie|set-cookie|proxy-authorization|x-api-key|x-auth-token|x-csrf-token|x-xsrf-token)$/i;
 const SECRET_HEADER_PART_PATTERN = /(token|secret|session|cookie|credential|password|key)/i;
+
+export const DEFERRED_INIT_BROWSER_PHASES = Object.freeze({
+    FEATURE_NOT_NEEDED: 'feature-not-needed',
+    FEATURE_NEEDED: 'feature-needed',
+});
+
+export function deferredInitBrowserMarkers(featureId, options = {}) {
+    const normalizedFeatureId = normalizeDeferredInitFeatureId(featureId, 'deferredInitBrowserMarkers');
+    const prefix = normalizeDeferredInitMarkerPrefix(options.prefix);
+
+    return Object.freeze({
+        featureNotNeededStart: deferredInitMarkerName(prefix, normalizedFeatureId, 'feature_not_needed.start'),
+        featureNotNeededReady: deferredInitMarkerName(prefix, normalizedFeatureId, 'feature_not_needed.ready'),
+        featureNeededTrigger: deferredInitMarkerName(prefix, normalizedFeatureId, 'feature_needed.trigger'),
+        featureNeededReady: deferredInitMarkerName(prefix, normalizedFeatureId, 'feature_needed.ready'),
+        featureNeededSuccess: deferredInitMarkerName(prefix, normalizedFeatureId, 'feature_needed.success'),
+    });
+}
+
+export function deferredInitBrowserMarkerScript(featureId, options = {}) {
+    const normalizedFeatureId = normalizeDeferredInitFeatureId(featureId, 'deferredInitBrowserMarkerScript');
+    const markers = deferredInitBrowserMarkers(normalizedFeatureId, options);
+
+    return `(() => {
+  const startedAt = performance.now();
+  const events = [];
+  const elapsed = () => Math.round(performance.now() - startedAt);
+  const mark = (name, data = {}) => {
+    const event = { name, t_ms: elapsed(), data };
+    events.push(event);
+    try { performance.mark(name); } catch {}
+    return event;
+  };
+  window.__homeboyDeferredInit = window.__homeboyDeferredInit || {};
+  window.__homeboyDeferredInit[${JSON.stringify(normalizedFeatureId)}] = {
+    featureId: ${JSON.stringify(normalizedFeatureId)},
+    markers: ${JSON.stringify(markers)},
+    events,
+    mark,
+  };
+  mark(${JSON.stringify(markers.featureNotNeededStart)});
+})();`;
+}
+
+export function summarizeDeferredInitBrowserEvidence(options = {}) {
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+        throw new Error('summarizeDeferredInitBrowserEvidence requires an options object.');
+    }
+
+    const featureId = normalizeDeferredInitFeatureId(options.featureId, 'summarizeDeferredInitBrowserEvidence');
+    const featureMatchers = normalizeDeferredInitMatchers(options.featureRequestMatchers, 'featureRequestMatchers', true);
+    const thirdPartyMatchers = normalizeDeferredInitMatchers(options.thirdPartyRequestMatchers, 'thirdPartyRequestMatchers', false);
+    const markerEvents = Array.isArray(options.markerEvents) ? options.markerEvents : [];
+    const networkEntries = Array.isArray(options.networkEntries) ? options.networkEntries : [];
+    const maxEarlyFeatureRequests = finiteNonNegativeNumber(options.maxEarlyFeatureRequests) ?? 0;
+    const maxEarlyThirdPartyRequests = options.maxEarlyThirdPartyRequests === undefined || options.maxEarlyThirdPartyRequests === null
+        ? null
+        : finiteNonNegativeNumber(options.maxEarlyThirdPartyRequests);
+    const minPostTriggerFeatureRequests = finiteNonNegativeNumber(options.minPostTriggerFeatureRequests) ?? 1;
+    const metricsPrefix = sanitizeMetricName(options.metricsPrefix || `${featureId}_deferred_init`);
+    const markers = deferredInitBrowserMarkers(featureId, { prefix: options.markerPrefix });
+    const notNeededReadyMs = findDeferredInitMarkerTime(markerEvents, markers.featureNotNeededReady);
+    const triggerMs = findDeferredInitMarkerTime(markerEvents, markers.featureNeededTrigger);
+    const neededReadyMs = findDeferredInitMarkerTime(markerEvents, markers.featureNeededReady);
+    const successMs = findDeferredInitMarkerTime(markerEvents, markers.featureNeededSuccess);
+    const hasRequestTiming = networkEntries.some((entry) => deferredInitRequestTime(entry) !== null);
+    const beforeTrigger = (entry) => {
+        const time = deferredInitRequestTime(entry);
+        return triggerMs !== null && time !== null && time < triggerMs;
+    };
+    const afterTrigger = (entry) => {
+        const time = deferredInitRequestTime(entry);
+        return triggerMs !== null && time !== null && time >= triggerMs;
+    };
+    const earlyFeatureRequests = countDeferredInitRequests(networkEntries, featureMatchers, beforeTrigger);
+    const postTriggerFeatureRequests = countDeferredInitRequests(networkEntries, featureMatchers, afterTrigger);
+    const earlyThirdPartyRequests = thirdPartyMatchers.length > 0 ? countDeferredInitRequests(networkEntries, thirdPartyMatchers, beforeTrigger) : null;
+    const postTriggerThirdPartyRequests = thirdPartyMatchers.length > 0 ? countDeferredInitRequests(networkEntries, thirdPartyMatchers, afterTrigger) : null;
+    const featureRequestCount = countDeferredInitRequests(networkEntries, featureMatchers);
+    const thirdPartyRequestCount = thirdPartyMatchers.length > 0 ? countDeferredInitRequests(networkEntries, thirdPartyMatchers) : null;
+    const earlyFeaturePass = hasRequestTiming && triggerMs !== null && earlyFeatureRequests <= maxEarlyFeatureRequests;
+    const postTriggerFeaturePass = hasRequestTiming && triggerMs !== null && postTriggerFeatureRequests >= minPostTriggerFeatureRequests;
+    const thirdPartyEarlyPass = maxEarlyThirdPartyRequests === null || (
+        hasRequestTiming && triggerMs !== null && earlyThirdPartyRequests <= maxEarlyThirdPartyRequests
+    );
+    const successPass = options.success === true || successMs !== null;
+
+    return stableJson({
+        feature_id: featureId,
+        phases: DEFERRED_INIT_BROWSER_PHASES,
+        markers,
+        metrics: {
+            [`${metricsPrefix}_feature_not_needed_ready_ms`]: notNeededReadyMs,
+            [`${metricsPrefix}_feature_needed_trigger_ms`]: triggerMs,
+            [`${metricsPrefix}_feature_needed_ready_ms`]: neededReadyMs,
+            [`${metricsPrefix}_feature_needed_success_ms`]: successMs,
+            [`${metricsPrefix}_request_timing_available`]: hasRequestTiming,
+            [`${metricsPrefix}_feature_request_count`]: featureRequestCount,
+            [`${metricsPrefix}_feature_request_count_before_trigger`]: earlyFeatureRequests,
+            [`${metricsPrefix}_feature_request_count_after_trigger`]: postTriggerFeatureRequests,
+            [`${metricsPrefix}_third_party_request_count`]: thirdPartyRequestCount,
+            [`${metricsPrefix}_third_party_request_count_before_trigger`]: earlyThirdPartyRequests,
+            [`${metricsPrefix}_third_party_request_count_after_trigger`]: postTriggerThirdPartyRequests,
+            [`${metricsPrefix}_no_early_feature_init`]: earlyFeaturePass,
+            [`${metricsPrefix}_post_trigger_feature_requests`]: postTriggerFeaturePass,
+            [`${metricsPrefix}_post_trigger_success`]: successPass,
+        },
+        assertions: [
+            deferredInitAssertion(
+                `${featureId}-no-early-feature-init`,
+                earlyFeaturePass ? 'pass' : 'fail',
+                `Observed ${earlyFeatureRequests} feature request(s) before trigger; expected <= ${maxEarlyFeatureRequests}.`
+            ),
+            deferredInitAssertion(
+                `${featureId}-post-trigger-feature-requests`,
+                postTriggerFeaturePass ? 'pass' : 'fail',
+                `Observed ${postTriggerFeatureRequests} feature request(s) after trigger; expected >= ${minPostTriggerFeatureRequests}.`
+            ),
+            deferredInitAssertion(
+                `${featureId}-post-trigger-success`,
+                successPass ? 'pass' : 'fail',
+                successPass ? 'Feature reported post-trigger success.' : 'Feature did not report post-trigger success.'
+            ),
+            ...(maxEarlyThirdPartyRequests === null ? [] : [
+                deferredInitAssertion(
+                    `${featureId}-no-early-third-party-init`,
+                    thirdPartyEarlyPass ? 'pass' : 'fail',
+                    `Observed ${earlyThirdPartyRequests} third-party request(s) before trigger; expected <= ${maxEarlyThirdPartyRequests}.`
+                ),
+            ]),
+        ],
+        metadata: {
+            marker_events: markerEvents,
+            early_feature_urls_sample: sampleDeferredInitUrls(networkEntries, featureMatchers, beforeTrigger),
+            post_trigger_feature_urls_sample: sampleDeferredInitUrls(networkEntries, featureMatchers, afterTrigger),
+            early_third_party_urls_sample: thirdPartyMatchers.length > 0 ? sampleDeferredInitUrls(networkEntries, thirdPartyMatchers, beforeTrigger) : [],
+            post_trigger_third_party_urls_sample: thirdPartyMatchers.length > 0 ? sampleDeferredInitUrls(networkEntries, thirdPartyMatchers, afterTrigger) : [],
+        },
+    });
+}
 
 export async function runBrowserActions(page, actions, options = {}) {
     if (!Array.isArray(actions) || actions.length === 0) {
@@ -1869,6 +2010,92 @@ function pickRounded(source, keys) {
         out[normalizedKey] = typeof source[key] === 'number' ? roundNumber(source[key]) : source[key];
     }
     return stableJson(out);
+}
+
+function normalizeDeferredInitFeatureId(featureId, caller) {
+    if (typeof featureId !== 'string' || featureId.trim() === '') {
+        throw new Error(`${caller} requires a non-empty string featureId.`);
+    }
+    return featureId.trim();
+}
+
+function normalizeDeferredInitMarkerPrefix(prefix) {
+    if (prefix === undefined || prefix === null || prefix === '') return DEFAULT_DEFERRED_INIT_MARKER_PREFIX;
+    return String(prefix).trim() || DEFAULT_DEFERRED_INIT_MARKER_PREFIX;
+}
+
+function deferredInitMarkerName(prefix, featureId, name) {
+    return `${prefix}.${featureId}.${name}`;
+}
+
+function normalizeDeferredInitMatchers(matchers, label, required) {
+    const values = Array.isArray(matchers) ? matchers : [];
+    if (required && values.length === 0) {
+        throw new Error(`summarizeDeferredInitBrowserEvidence requires at least one ${label}.`);
+    }
+    return values.map((matcher) => compileDeferredInitMatcher(matcher));
+}
+
+function compileDeferredInitMatcher(matcher) {
+    if (typeof matcher === 'function') return matcher;
+    if (matcher instanceof RegExp) return (entry) => matcher.test(deferredInitRequestUrl(entry));
+    if (typeof matcher === 'string') return (entry) => deferredInitRequestUrl(entry).includes(matcher);
+    throw new Error(`Unsupported deferred-init request matcher: ${String(matcher)}`);
+}
+
+function findDeferredInitMarkerTime(markerEvents, marker) {
+    const event = markerEvents.find((candidate) => candidate?.name === marker);
+    return deferredInitEventTime(event);
+}
+
+function deferredInitEventTime(event) {
+    return finiteNumberOrNull(event?.t_ms ?? event?.time_ms ?? event?.timestamp_ms ?? event?.startTime ?? event?.start_time_ms);
+}
+
+function deferredInitRequestTime(entry) {
+    return finiteNumberOrNull(
+        entry?.t_ms ??
+        entry?.time_ms ??
+        entry?.timestamp_ms ??
+        entry?.startTime ??
+        entry?.start_time_ms ??
+        entry?.request?.startTime ??
+        entry?.request?.start_time_ms
+    );
+}
+
+function deferredInitRequestUrl(entry) {
+    return entry?.url || entry?.request?.url || entry?.response?.url || '';
+}
+
+function countDeferredInitRequests(entries, matchers, predicate = () => true) {
+    return entries.filter((entry) => predicate(entry) && matchesAnyDeferredInitMatcher(entry, matchers)).length;
+}
+
+function sampleDeferredInitUrls(entries, matchers, predicate = () => true, limit = 20) {
+    return entries
+        .filter((entry) => predicate(entry) && matchesAnyDeferredInitMatcher(entry, matchers))
+        .map(deferredInitRequestUrl)
+        .filter(Boolean)
+        .slice(0, limit);
+}
+
+function matchesAnyDeferredInitMatcher(entry, matchers) {
+    return matchers.some((matcher) => matcher(entry));
+}
+
+function deferredInitAssertion(id, status, message) {
+    return { id, message, status };
+}
+
+function finiteNonNegativeNumber(value) {
+    const number = Number(value);
+    return Number.isFinite(number) && number >= 0 ? number : null;
+}
+
+function finiteNumberOrNull(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? roundNumber(number) : null;
 }
 
 function stableJson(value) {

--- a/tests/deferred-init-browser-helper-smoke.mjs
+++ b/tests/deferred-init-browser-helper-smoke.mjs
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import vm from 'node:vm';
+
+import {
+    DEFERRED_INIT_BROWSER_PHASES,
+    deferredInitBrowserMarkerScript,
+    deferredInitBrowserMarkers,
+    summarizeDeferredInitBrowserEvidence,
+} from '../nodejs/scripts/bench/browser-helper.mjs';
+
+test('deferredInitBrowserMarkerScript installs a product-neutral browser channel', () => {
+    const script = deferredInitBrowserMarkerScript('lazy-widget');
+    const marks = [];
+    const context = {
+        performance: {
+            now: () => 10,
+            mark: (name) => marks.push(name),
+        },
+        window: {},
+    };
+
+    vm.runInNewContext(script, context);
+
+    const channel = context.window.__homeboyDeferredInit['lazy-widget'];
+    assert.equal(channel.featureId, 'lazy-widget');
+    assert.deepEqual(JSON.parse(JSON.stringify(channel.markers)), deferredInitBrowserMarkers('lazy-widget'));
+    assert.deepEqual(JSON.parse(JSON.stringify(channel.events)), [
+        {
+            data: {},
+            name: 'deferred_init.lazy-widget.feature_not_needed.start',
+            t_ms: 0,
+        },
+    ]);
+    assert.deepEqual(marks, ['deferred_init.lazy-widget.feature_not_needed.start']);
+});
+
+test('summarizeDeferredInitBrowserEvidence emits phase metrics and passing assertions', () => {
+    const markers = deferredInitBrowserMarkers('lazy-widget');
+    const summary = summarizeDeferredInitBrowserEvidence({
+        featureId: 'lazy-widget',
+        markerEvents: [
+            { name: markers.featureNotNeededReady, t_ms: 125 },
+            { name: markers.featureNeededTrigger, t_ms: 500 },
+            { name: markers.featureNeededReady, t_ms: 725 },
+            { name: markers.featureNeededSuccess, t_ms: 750 },
+        ],
+        networkEntries: [
+            { url: 'https://example.test/page', start_time_ms: 10 },
+            { url: 'https://cdn.example.test/lazy-widget.js', start_time_ms: 525 },
+            { url: 'https://api.example.test/lazy-widget/config', start_time_ms: 620 },
+            { url: 'https://third-party.example.test/tag.js', start_time_ms: 650 },
+        ],
+        featureRequestMatchers: ['lazy-widget'],
+        thirdPartyRequestMatchers: [/third-party\.example/],
+        maxEarlyFeatureRequests: 0,
+        maxEarlyThirdPartyRequests: 0,
+        minPostTriggerFeatureRequests: 2,
+    });
+
+    assert.equal(summary.feature_id, 'lazy-widget');
+    assert.deepEqual(summary.phases, DEFERRED_INIT_BROWSER_PHASES);
+    assert.equal(summary.metrics.lazy_widget_deferred_init_feature_not_needed_ready_ms, 125);
+    assert.equal(summary.metrics.lazy_widget_deferred_init_feature_needed_trigger_ms, 500);
+    assert.equal(summary.metrics.lazy_widget_deferred_init_feature_request_count_before_trigger, 0);
+    assert.equal(summary.metrics.lazy_widget_deferred_init_feature_request_count_after_trigger, 2);
+    assert.equal(summary.metrics.lazy_widget_deferred_init_third_party_request_count_before_trigger, 0);
+    assert.equal(summary.metrics.lazy_widget_deferred_init_no_early_feature_init, true);
+    assert.deepEqual(summary.assertions, [
+        {
+            id: 'lazy-widget-no-early-feature-init',
+            message: 'Observed 0 feature request(s) before trigger; expected <= 0.',
+            status: 'pass',
+        },
+        {
+            id: 'lazy-widget-post-trigger-feature-requests',
+            message: 'Observed 2 feature request(s) after trigger; expected >= 2.',
+            status: 'pass',
+        },
+        {
+            id: 'lazy-widget-post-trigger-success',
+            message: 'Feature reported post-trigger success.',
+            status: 'pass',
+        },
+        {
+            id: 'lazy-widget-no-early-third-party-init',
+            message: 'Observed 0 third-party request(s) before trigger; expected <= 0.',
+            status: 'pass',
+        },
+    ]);
+    assert.deepEqual(summary.metadata.post_trigger_feature_urls_sample, [
+        'https://cdn.example.test/lazy-widget.js',
+        'https://api.example.test/lazy-widget/config',
+    ]);
+});
+
+test('summarizeDeferredInitBrowserEvidence reports early initialization failures', () => {
+    const markers = deferredInitBrowserMarkers('lazy-widget');
+    const summary = summarizeDeferredInitBrowserEvidence({
+        featureId: 'lazy-widget',
+        markerEvents: [{ name: markers.featureNeededTrigger, t_ms: 500 }],
+        networkEntries: [
+            { url: 'https://cdn.example.test/lazy-widget.js', start_time_ms: 100 },
+            { url: 'https://third-party.example.test/tag.js', start_time_ms: 150 },
+        ],
+        featureRequestMatchers: ['lazy-widget'],
+        thirdPartyRequestMatchers: ['third-party.example'],
+        maxEarlyFeatureRequests: 0,
+        maxEarlyThirdPartyRequests: 0,
+    });
+
+    assert.equal(summary.metrics.lazy_widget_deferred_init_feature_request_count_before_trigger, 1);
+    assert.equal(summary.metrics.lazy_widget_deferred_init_third_party_request_count_before_trigger, 1);
+    assert.equal(summary.metrics.lazy_widget_deferred_init_no_early_feature_init, false);
+    assert.equal(summary.metrics.lazy_widget_deferred_init_post_trigger_success, false);
+    assert.deepEqual(summary.assertions.map((assertion) => assertion.status), ['fail', 'fail', 'fail', 'fail']);
+    assert.deepEqual(summary.metadata.early_feature_urls_sample, ['https://cdn.example.test/lazy-widget.js']);
+    assert.deepEqual(summary.metadata.early_third_party_urls_sample, ['https://third-party.example.test/tag.js']);
+});


### PR DESCRIPTION
## Summary
- add product-neutral deferred-init marker and summary helpers to the Node.js browser bench helper
- document the expected phase, marker, metric, assertion, and metadata shapes
- add smoke coverage for marker script install plus pass/fail deferred-init evidence summaries

## Tests
- `node --test tests/deferred-init-browser-helper-smoke.mjs`
- `node --test tests/browser-result-shapes-smoke.mjs`
- `bash nodejs/scripts/bench/nodejs-browser-page-scenario-smoke.sh`
- `bash nodejs/scripts/bench/nodejs-browser-helper-smoke.sh`
- `node --test tests/*.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** extracting a reusable deferred-init browser evidence helper and tests/docs