### PR TITLE
Add WP Codebox artifact manifest resolver

### DIFF
--- a/wordpress/lib/wp-codebox-artifacts.js
+++ b/wordpress/lib/wp-codebox-artifacts.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 
 function wpCodeboxArtifactDirectory(codeboxResult, fallbackDirectory) {
   return codeboxResult?.artifacts?.directory
+    || codeboxResult?.artifactsDir
     || codeboxResult?.artifacts?.path
     || codeboxResult?.artifactsDirectory
     || codeboxResult?.artifacts_directory
@@ -24,6 +25,95 @@ function wpCodeboxArtifactPath(artifact) {
     return '';
   }
   return artifact.path || artifact.file || artifact.href || '';
+}
+
+function normalizeWpCodeboxArtifactPathname(value) {
+  return String(value || '').replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function wpCodeboxArtifactManifestFiles(source) {
+  const candidates = [
+    source?.artifacts?.files,
+    source?.artifacts?.manifest?.files,
+    source?.manifest?.artifacts?.files,
+    source?.manifest?.files,
+  ];
+
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) {
+      return candidate;
+    }
+    if (candidate && typeof candidate === 'object') {
+      return Object.entries(candidate).map(([name, value]) => (
+        typeof value === 'string'
+          ? { name, path: value }
+          : { name, ...value }
+      ));
+    }
+  }
+
+  return [];
+}
+
+function wpCodeboxArtifactManifestEntryPath(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return '';
+  }
+
+  return entry.path || entry.pathname || entry.file || entry.relativePath || entry.relative_path || '';
+}
+
+function wpCodeboxArtifactManifestEntryMatches(entry, relativePath) {
+  const wanted = normalizeWpCodeboxArtifactPathname(relativePath);
+  const values = [
+    entry?.path,
+    entry?.pathname,
+    entry?.file,
+    entry?.relativePath,
+    entry?.relative_path,
+    entry?.name,
+    entry?.id,
+    entry?.label,
+  ].map(normalizeWpCodeboxArtifactPathname).filter(Boolean);
+
+  return values.some((value) => value === wanted || value.endsWith(`/${wanted}`));
+}
+
+function wpCodeboxArtifactManifestV1(source = {}) {
+  return {
+    version: 1,
+    directory: wpCodeboxArtifactDirectory(source, ''),
+    files: wpCodeboxArtifactManifestFiles(source),
+  };
+}
+
+function resolveWpCodeboxManifestArtifactPath(source, relativePath) {
+  const artifactDirectory = wpCodeboxArtifactDirectory(source, '');
+  if (!artifactDirectory) {
+    return '';
+  }
+
+  const entry = wpCodeboxArtifactManifestFiles(source).find((candidate) => (
+    wpCodeboxArtifactManifestEntryMatches(candidate, relativePath)
+  ));
+  const entryPath = wpCodeboxArtifactManifestEntryPath(entry);
+  if (entryPath) {
+    return path.isAbsolute(entryPath) ? entryPath : path.join(artifactDirectory, entryPath);
+  }
+
+  return path.join(artifactDirectory, relativePath);
+}
+
+function wpCodeboxBrowserArtifacts(source, names = []) {
+  const result = {
+    directory: resolveWpCodeboxManifestArtifactPath(source, 'files/browser'),
+  };
+
+  for (const name of names) {
+    result[name] = resolveWpCodeboxManifestArtifactPath(source, `files/browser/${name}`);
+  }
+
+  return result;
 }
 
 function wpCodeboxArtifactByKey(source, key) {
@@ -67,7 +157,11 @@ function resolveWpCodeboxArtifactPath({
 
 module.exports = {
   resolveWpCodeboxArtifactPath,
+  resolveWpCodeboxManifestArtifactPath,
+  wpCodeboxArtifactManifestV1,
   wpCodeboxArtifactByKey,
   wpCodeboxArtifactDirectory,
+  wpCodeboxArtifactManifestFiles,
   wpCodeboxArtifactPath,
+  wpCodeboxBrowserArtifacts,
 };

--- a/wordpress/tests/wp-codebox-artifacts-smoke.js
+++ b/wordpress/tests/wp-codebox-artifacts-smoke.js
@@ -4,9 +4,12 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 const {
   resolveWpCodeboxArtifactPath,
+  resolveWpCodeboxManifestArtifactPath,
   wpCodeboxArtifactByKey,
   wpCodeboxArtifactDirectory,
+  wpCodeboxArtifactManifestV1,
   wpCodeboxArtifactPath,
+  wpCodeboxBrowserArtifacts,
 } = require('../lib/wp-codebox-artifacts');
 
 const codeboxResult = {
@@ -44,5 +47,40 @@ assert.equal(resolveWpCodeboxArtifactPath({
 }), '/tmp/already-absolute.png');
 assert.throws(() => resolveWpCodeboxArtifactPath({ artifact: 'relative.json' }), /without artifact directory/);
 assert.throws(() => resolveWpCodeboxArtifactPath({ codeboxResult, key: 'missing' }), /Unable to resolve WP Codebox artifact: missing/);
+
+const browserOutput = { artifacts: { directory: '/tmp/wp-codebox-artifacts' } };
+assert.equal(
+  resolveWpCodeboxManifestArtifactPath(browserOutput, 'files/browser/summary.json'),
+  path.join('/tmp/wp-codebox-artifacts', 'files/browser/summary.json')
+);
+assert.deepEqual(wpCodeboxBrowserArtifacts(browserOutput, ['summary.json', 'network.jsonl']), {
+  directory: path.join('/tmp/wp-codebox-artifacts', 'files/browser'),
+  'summary.json': path.join('/tmp/wp-codebox-artifacts', 'files/browser/summary.json'),
+  'network.jsonl': path.join('/tmp/wp-codebox-artifacts', 'files/browser/network.jsonl'),
+});
+
+const manifestOutput = {
+  artifacts: {
+    directory: '/tmp/wp-codebox-artifacts',
+    files: [
+      { path: 'browser/summary.actual.json', relativePath: 'files/browser/summary.json' },
+      { path: '/external/browser/network.actual.json', relativePath: 'files/browser/network.jsonl' },
+    ],
+  },
+};
+assert.deepEqual(wpCodeboxArtifactManifestV1(manifestOutput), {
+  version: 1,
+  directory: '/tmp/wp-codebox-artifacts',
+  files: manifestOutput.artifacts.files,
+});
+assert.equal(
+  resolveWpCodeboxManifestArtifactPath(manifestOutput, 'files/browser/summary.json'),
+  path.join('/tmp/wp-codebox-artifacts', 'browser/summary.actual.json')
+);
+assert.equal(
+  resolveWpCodeboxManifestArtifactPath(manifestOutput, 'files/browser/network.jsonl'),
+  '/external/browser/network.actual.json'
+);
+assert.equal(resolveWpCodeboxManifestArtifactPath({}, 'files/browser/summary.json'), '');
 
 console.log('✓ WP Codebox artifact helper smoke test PASSED');


### PR DESCRIPTION
## Summary
- Add a generic WP Codebox artifact manifest v1 resolver to the WordPress Homeboy extension helpers.
- Add a browser artifact helper that resolves files through manifest entries before falling back to the current artifact bundle layout.
- Cover the resolver with the existing WP Codebox artifact smoke test.

## Testing
- `npm run test:wp-codebox-artifacts`
- `npx eslint lib/wp-codebox-artifacts.js --no-warn-ignored`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the helper contract, smoke coverage, and PR preparation for Chris to review.