### PR TITLE
Add Data Machine runtime profile for Codebox

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -296,16 +296,39 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
 
 function runtimeOptionsFromExecutorConfig(config = {}, options = {}) {
   const directComponentPathDefaults = firstObject(config.component_path_defaults, config.componentPathDefaults);
+  const runtimeProfile = runtimeProfileFromExecutorConfig(config, options);
   const runtimeRequirements = firstObject(config.runtime_requirements, config.runtimeRequirements) || {};
-  const componentPathDefaults = directComponentPathDefaults || firstObject(options.componentPathDefaults, options.component_path_defaults, runtimeRequirements.component_path_defaults, runtimeRequirements.componentPathDefaults);
+  const componentPathDefaults = directComponentPathDefaults || firstObject(options.componentPathDefaults, options.component_path_defaults, runtimeRequirements.component_path_defaults, runtimeRequirements.componentPathDefaults, runtimeProfile.component_path_defaults, runtimeProfile.componentPathDefaults);
   return {
     ...options,
-    workspaceTools: firstObject(options.workspaceTools, options.workspace_tools, config.workspace_tools, config.workspaceTools, runtimeRequirements.workspace_tools, runtimeRequirements.workspaceTools),
+    runtimeProfile,
+    workspaceTools: firstObject(options.workspaceTools, options.workspace_tools, config.workspace_tools, config.workspaceTools, runtimeRequirements.workspace_tools, runtimeRequirements.workspaceTools, runtimeProfile.workspace_tools, runtimeProfile.workspaceTools),
     componentPathDefaults,
     componentPathAliases: firstObject(options.componentPathAliases, options.component_path_aliases, config.component_path_aliases, config.componentPathAliases, componentPathDefaults?.path_aliases, runtimeRequirements.component_path_aliases, runtimeRequirements.componentPathAliases),
     componentContractSlugMap: firstObject(options.componentContractSlugMap, options.component_contract_slug_map, config.component_contract_slug_map, config.componentContractSlugMap, componentPathDefaults?.contract_slug_map, runtimeRequirements.component_contract_slug_map, runtimeRequirements.componentContractSlugMap),
     componentDiscovery: firstObject(options.componentDiscovery, options.component_discovery, config.component_discovery, config.componentDiscovery, componentPathDefaults?.discovery, runtimeRequirements.component_discovery, runtimeRequirements.componentDiscovery),
+    abilityRequirements: uniqueStrings([
+      ...normalizeArray(options.abilityRequirements),
+      ...normalizeArray(options.ability_requirements),
+      ...normalizeArray(runtimeRequirements.ability_requirements),
+      ...normalizeArray(runtimeRequirements.abilityRequirements),
+      ...normalizeArray(runtimeProfile.ability_requirements),
+      ...normalizeArray(runtimeProfile.abilityRequirements),
+    ]),
   };
+}
+
+function runtimeProfileFromExecutorConfig(config = {}, options = {}) {
+  const runtimeProfile = firstDefined(config.runtime_profile, config.runtimeProfile, options.runtimeProfile, options.runtime_profile);
+  if (runtimeProfile && typeof runtimeProfile === 'object' && !Array.isArray(runtimeProfile)) {
+    return runtimeProfile;
+  }
+  if (typeof runtimeProfile !== 'string' || runtimeProfile.trim() === '') {
+    return {};
+  }
+  const profiles = firstObject(config.runtime_profiles, config.runtimeProfiles, options.runtimeProfiles, options.runtime_profiles) || {};
+  const namedProfile = profiles[runtimeProfile] || profiles[runtimeProfile.trim()];
+  return firstObject(namedProfile) || {};
 }
 
 function artifactDeclarationsFromAgentTaskRequest(request, config = {}, inputs = {}, options = {}) {
@@ -577,6 +600,8 @@ function allowedToolsFromAgentTaskRequest(request, config, inputs, options, defa
     ...normalizeArray(config.abilities),
     ...normalizeArray(config.ability_requirements),
     ...normalizeArray(config.abilityRequirements),
+    ...normalizeArray(options.abilityRequirements),
+    ...normalizeArray(options.ability_requirements),
   ]);
   return uniqueStrings([...(defaults.allowedTools || []), ...declared]);
 }

--- a/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
+++ b/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
@@ -10,6 +10,7 @@ const {
 const AGENT_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
 const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
 const DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY = 'datamachine/run-agent-bundle';
+const DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID = 'datamachine-agent-ci';
 
 const DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS = {
   contract_slug_map: {
@@ -102,6 +103,22 @@ const DATAMACHINE_AGENT_CI_CAPABILITIES = [
   'ability:github_pull_request_publish',
   'ability:comment_github_pull_request',
 ];
+
+const DATAMACHINE_AGENT_CI_ABILITY_REQUIREMENTS = [
+  DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY,
+  'github_issue_publish',
+  'github_pull_request_publish',
+  'comment_github_pull_request',
+];
+
+const DATAMACHINE_AGENT_CI_RUNTIME_PROFILE = {
+  schema: 'homeboy/runtime-profile/v1',
+  id: DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID,
+  component_path_defaults: DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
+  workspace_tools: DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
+  capabilities: DATAMACHINE_AGENT_CI_CAPABILITIES,
+  ability_requirements: DATAMACHINE_AGENT_CI_ABILITY_REQUIREMENTS,
+};
 
 function datamachineAgentCiBundleTaskRequest(options = {}, context = {}) {
   const taskId = requiredString(options.taskId || options.task_id, 'taskId');
@@ -251,7 +268,10 @@ module.exports = {
   AGENT_TASK_REQUEST_SCHEMA,
   AGENT_TASK_RUNNER_SPEC_SCHEMA,
   DATAMACHINE_AGENT_CI_CAPABILITIES,
+  DATAMACHINE_AGENT_CI_ABILITY_REQUIREMENTS,
   DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
+  DATAMACHINE_AGENT_CI_RUNTIME_PROFILE,
+  DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID,
   DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
   DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY,
   agentTaskRequestFromRunnerSpec,

--- a/wordpress/lib/datamachine-agent-ci-codebox-adapter.js
+++ b/wordpress/lib/datamachine-agent-ci-codebox-adapter.js
@@ -4,39 +4,23 @@
  * Internal dependencies
  */
 const {
-  DATAMACHINE_AGENT_CI_CAPABILITIES,
-  DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
-  DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
+  DATAMACHINE_AGENT_CI_RUNTIME_PROFILE,
+  DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID,
 } = require('../../datamachine-agent-ci');
 
 function datamachineAgentCiCodeboxExecutorConfig(config = {}) {
   return {
     ...config,
-    runtime_requirements: {
-      ...(config.runtime_requirements || {}),
-      component_path_defaults: config.component_path_defaults || DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
-      workspace_tools: config.workspace_tools || DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
-      capabilities: uniqueStrings([
-        ...DATAMACHINE_AGENT_CI_CAPABILITIES,
-        ...normalizeArray(config.runtime_requirements?.capabilities),
-      ]),
+    runtime_profile: config.runtime_profile || config.runtimeProfile || DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID,
+    runtime_profiles: {
+      ...(config.runtime_profiles || config.runtimeProfiles || {}),
+      [DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID]: DATAMACHINE_AGENT_CI_RUNTIME_PROFILE,
     },
-    component_path_defaults: config.component_path_defaults || DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
-    workspace_tools: config.workspace_tools || DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
   };
 }
 
-function normalizeArray(value) {
-  return Array.isArray(value) ? value.filter(Boolean) : [];
-}
-
-function uniqueStrings(values) {
-  return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.trim() !== '')));
-}
-
 module.exports = {
-  DATAMACHINE_AGENT_CI_CAPABILITIES,
-  DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
-  DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
+  DATAMACHINE_AGENT_CI_RUNTIME_PROFILE,
+  DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID,
   datamachineAgentCiCodeboxExecutorConfig,
 };

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -10,8 +10,8 @@ const {
   providerContract,
 } = require('../../agent-runtimes/wp-codebox');
 const {
-  DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
-  DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
+  DATAMACHINE_AGENT_CI_RUNTIME_PROFILE,
+  DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID,
   datamachineAgentCiCodeboxExecutorConfig,
 } = require('../lib/datamachine-agent-ci-codebox-adapter');
 
@@ -82,11 +82,10 @@ assert.equal(provider.capabilities.includes('tool:datamachine/run-agent-bundle')
 assert.equal(provider.capabilities.includes('ability:datamachine/run-agent-bundle'), false);
 
 const datamachineAdapterConfig = datamachineAgentCiCodeboxExecutorConfig({ provider: 'openai' });
-assert.equal(datamachineAdapterConfig.component_path_defaults.contract_slug_map['data-machine'], 'agent_runtime');
-assert.equal(datamachineAdapterConfig.component_path_defaults.path_aliases.agent_runtime.includes('runtime_component:data_machine'), true);
-assert.deepEqual(datamachineAdapterConfig.workspace_tools, DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS);
-assert.deepEqual(datamachineAdapterConfig.runtime_requirements.component_path_defaults, DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS);
-assert.equal(datamachineAdapterConfig.runtime_requirements.capabilities.includes('ability:datamachine/run-agent-bundle'), true);
+assert.equal(datamachineAdapterConfig.runtime_profile, DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID);
+assert.deepEqual(datamachineAdapterConfig.runtime_profiles[DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID], DATAMACHINE_AGENT_CI_RUNTIME_PROFILE);
+assert.equal(datamachineAdapterConfig.runtime_profiles[DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID].component_path_defaults.contract_slug_map['data-machine'], 'agent_runtime');
+assert.equal(datamachineAdapterConfig.runtime_profiles[DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID].capabilities.includes('ability:datamachine/run-agent-bundle'), true);
 
 const customContract = providerContract({
   capabilities: ['wordpress_sandbox', 'tool:example/run-workflow'],
@@ -178,6 +177,43 @@ assert.deepEqual(customRuntimePolicyTaskInput.allowed_tools, [
 ]);
 assert.equal(customRuntimePolicyTaskInput.runtime_component_paths.agent_runtime, '/components/example-runtime');
 assert.equal(customRuntimePolicyTaskInput.runtime_component_paths.agent_runtime_tools, '/components/example-tools');
+
+const customRuntimeProfileTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'custom-runtime-profile-task-1',
+  executor: {
+    backend: 'codebox',
+    config: {
+      provider: 'openai',
+      runtime_profile: 'example-runtime-profile',
+      runtime_profiles: {
+        'example-runtime-profile': {
+          schema: 'homeboy/runtime-profile/v1',
+          id: 'example-runtime-profile',
+          workspace_tools: {
+            readonly: ['profile_workspace_read'],
+            readwrite: ['profile_workspace_write'],
+          },
+          component_path_defaults: {
+            contract_slug_map: { 'example-profile-runtime': 'agent_runtime' },
+            path_aliases: { agent_runtime: ['contract:agent_runtime'] },
+          },
+          ability_requirements: ['example/run-profile-workflow'],
+        },
+      },
+      component_contracts: [{ slug: 'example-profile-runtime', path: '/components/example-profile-runtime' }],
+    },
+  },
+  instructions: 'Run against a named runtime profile.',
+  workspace: { root: workspaceRoot, mode: 'readwrite' },
+});
+
+assert.deepEqual(customRuntimeProfileTaskInput.allowed_tools, [
+  'profile_workspace_read',
+  'profile_workspace_write',
+  'example/run-profile-workflow',
+]);
+assert.equal(customRuntimeProfileTaskInput.runtime_component_paths.agent_runtime, '/components/example-profile-runtime');
 
 const repoLoopBundleTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
@@ -273,6 +309,8 @@ assert(repoLoopWorkspaceMount, 'repo-loop cwd is translated into a Codebox works
 assert.equal(repoLoopWorkspaceMount.source, repoLoopWorkspaceRoot);
 assert.equal(repoLoopWorkspaceMount.target, `/workspace/${path.basename(repoLoopWorkspaceRoot)}`);
 assert.equal(repoLoopWorkspaceMount.mode, 'readwrite');
+assert.equal(repoLoopWorkspaceTaskInput.allowed_tools.includes('datamachine/run-agent-bundle'), true);
+assert.equal(repoLoopWorkspaceTaskInput.allowed_tools.includes('workspace_apply_patch'), true);
 assert.deepEqual(repoLoopWorkspaceTaskInput.workspace_materialization, {
   repo: 'wp-site-generator@canonical-loop-main-20260616',
   cwd: repoLoopWorkspaceRoot,

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -11,6 +11,9 @@ const {
   codeboxTaskRequestFromAgentTaskRequest,
   providerContract,
 } = require('../../agent-runtimes/wp-codebox');
+const {
+  datamachineAgentCiCodeboxExecutorConfig,
+} = require('../lib/datamachine-agent-ci-codebox-adapter');
 
 const fixtureCodeboxCoreModule = path.join(__dirname, 'fixtures', 'wp-codebox-core-agent-task-normalizer.mjs');
 const wpCodeboxRuntimeRoot = path.join(__dirname, '..', '..', 'agent-runtimes', 'wp-codebox');
@@ -279,9 +282,9 @@ const codexSecretEnvSources = {
     field: 'tokens.refresh_token',
   },
   AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: {
-    source: 'json-file',
+    source: 'json-file-jwt-expiration',
     path: '~/.codex/auth.json',
-    field: 'tokens.expires_at',
+    field: 'tokens.access_token',
   },
   AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: {
     source: 'json-file',
@@ -292,6 +295,7 @@ const codexSecretEnvSources = {
     source: 'json-file',
     path: '~/.codex/auth.json',
     field: 'tokens.fedramp',
+    value: 'false',
   },
 };
 assert.equal(provider.id, 'wordpress.codebox-agent-task-executor');
@@ -375,7 +379,7 @@ assert.equal(provider.capabilities.includes('typed_bundle_outputs'), true);
 assert.equal(provider.capabilities.includes('external_recipe_packs'), true);
 assert.equal(provider.capabilities.includes('recipe_probe_artifacts'), true);
 for (const capability of repoLoopCapabilities) {
-  assert.equal(provider.capabilities.includes(capability), true);
+  assert.equal(provider.capabilities.includes(capability), false);
 }
 const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'wordpress.json'), 'utf8'));
 assert.equal(manifest.agent_task_executors, undefined);
@@ -387,7 +391,7 @@ const manifestProvider = runtimeManifest.agent_task_executors.find((executor) =>
 assert.deepEqual(manifestProvider, providerContract());
 assert.deepEqual(secretEnvRequirementForProvider(manifestProvider, 'codex').env, codexSecretEnv);
 for (const capability of repoLoopCapabilities) {
-  assert.equal(manifestProvider.capabilities.includes(capability), true);
+  assert.equal(manifestProvider.capabilities.includes(capability), false);
 }
 assert.equal(provider.capabilities.includes('tool:wpsg_materialize_packet'), false);
 assert.equal(provider.capabilities.includes('ability:wpsg_materialize_packet'), false);
@@ -794,7 +798,7 @@ const codexAgentRequest = {
   executor: {
     backend: 'codebox',
     model: 'gpt-5.5',
-    config: {
+    config: datamachineAgentCiCodeboxExecutorConfig({
       provider: 'codex',
       provider_plugin_paths: ['/components/ai-provider-for-openai'],
       secret_env: [
@@ -811,7 +815,7 @@ const codexAgentRequest = {
       homeboy_extensions: '/components/homeboy-extensions',
       wp_codebox_bin: '/bin/wp-codebox',
       max_turns: 8,
-    },
+    }),
   },
 };
 const codexRequest = codeboxTaskRequestFromAgentTaskRequest(codexAgentRequest);
@@ -845,7 +849,7 @@ const workflowStyleConfigRequest = codeboxTaskRequestFromAgentTaskRequest({
   executor: {
     backend: 'codebox',
     model: 'gpt-5.5',
-    config: {
+    config: datamachineAgentCiCodeboxExecutorConfig({
       provider: 'codex',
       runtime_bin: '/bin/wp-codebox-runtime',
       runtime_wordpress_version: 'beta',
@@ -861,7 +865,7 @@ const workflowStyleConfigRequest = codeboxTaskRequestFromAgentTaskRequest({
         data_machine: '/components/data-machine',
         data_machine_code: '/components/data-machine-code',
       },
-    },
+    }),
   },
 });
 assert.equal(workflowStyleConfigRequest.wp_codebox_bin, '/bin/wp-codebox-runtime');
@@ -898,7 +902,7 @@ try {
     task_id: 'default-runtime-stack-task-123',
     executor: {
       backend: 'codebox',
-      config: { provider: 'codex' },
+      config: datamachineAgentCiCodeboxExecutorConfig({ provider: 'codex' }),
     },
     inputs: {
       target: { root: workspaceRoot },
@@ -1084,7 +1088,7 @@ try {
     task_id: 'alternate-default-runtime-stack-task-123',
     executor: {
       backend: 'codebox',
-      config: { provider: 'codex' },
+      config: datamachineAgentCiCodeboxExecutorConfig({ provider: 'codex' }),
     },
     inputs: {
       target: { root: workspaceRoot },
@@ -1169,7 +1173,7 @@ try {
       task_id: 'lab-no-target-default-runtime-stack-task-123',
       executor: {
         backend: 'codebox',
-        config: { provider: 'codex' },
+        config: datamachineAgentCiCodeboxExecutorConfig({ provider: 'codex' }),
       },
       inputs: {},
     }, {
@@ -1186,7 +1190,7 @@ try {
     task_id: 'explicit-runtime-stack-task-123',
     executor: {
       backend: 'codebox',
-      config: {
+      config: datamachineAgentCiCodeboxExecutorConfig({
         provider: 'codex',
         agents_api: staleStandaloneAgentsApiPath,
         runtime_component_paths: {
@@ -1199,7 +1203,7 @@ try {
         secret_env: ['EXPLICIT_SECRET'],
         mounts: [{ source: '/explicit/worktree', target: '/workspace', mode: 'readonly' }],
         workspaces: [{ target: '/explicit-workspace', mode: 'readonly' }],
-      },
+      }),
     },
     inputs: {
       target: { root: workspaceRoot },
@@ -1220,12 +1224,12 @@ try {
     task_id: 'legacy-runtime-alias-task-123',
     executor: {
       backend: 'codebox',
-      config: {
+      config: datamachineAgentCiCodeboxExecutorConfig({
         provider: 'codex',
         agents_api_path: staleStandaloneAgentsApiPath,
         data_machine_path: '/legacy/data-machine',
         data_machine_code_path: '/legacy/data-machine-code',
-      },
+      }),
     },
     inputs: {
       target: { root: workspaceRoot },
@@ -1264,7 +1268,7 @@ const agentBundleRequest = codeboxTaskRequestFromAgentTaskRequest({
   executor: {
     backend: 'codebox',
     model: 'gpt-5.5',
-    config: {
+    config: datamachineAgentCiCodeboxExecutorConfig({
       execution_kind: 'agent_bundle',
       provider: 'openai',
       provider_plugin_paths: ['/components/ai-provider-for-openai'],
@@ -1287,7 +1291,7 @@ const agentBundleRequest = codeboxTaskRequestFromAgentTaskRequest({
       transcript_artifact_name: 'static-site-agent-transcript',
       replay_bundle_artifact_name: 'static-site-agent-replay',
       runner_workspace: { handle: 'wp-site-generator@site-loop', expose_to_agent: false },
-    },
+    }),
   },
 });
 assert.equal(agentBundleRequest.agent_bundle.bundle_path, '/bundles/static-site-agent');

--- a/wordpress/tests/datamachine-agent-ci-plan-smoke.js
+++ b/wordpress/tests/datamachine-agent-ci-plan-smoke.js
@@ -21,6 +21,8 @@ assert.equal(
   datamachineAgentCi.DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS.path_aliases.agent_runtime.includes('runtime_component:data_machine'),
   true
 );
+assert.equal(datamachineAgentCi.DATAMACHINE_AGENT_CI_RUNTIME_PROFILE.id, 'datamachine-agent-ci');
+assert.equal(datamachineAgentCi.DATAMACHINE_AGENT_CI_RUNTIME_PROFILE.ability_requirements.includes('datamachine/run-agent-bundle'), true);
 
 const bundleTask = datamachineAgentCiBundleTaskRequest({
   taskId: 'concept-agent',
@@ -77,7 +79,8 @@ assert.deepEqual(bundleTask.executor.config.runtime_task.input, {
     },
   },
 });
-assert.equal(bundleTask.executor.config.runtime_requirements.component_path_defaults.path_aliases.agent_runtime.includes('runtime_component:data_machine'), true);
+assert.equal(bundleTask.executor.config.runtime_profile, 'datamachine-agent-ci');
+assert.equal(bundleTask.executor.config.runtime_profiles['datamachine-agent-ci'].component_path_defaults.path_aliases.agent_runtime.includes('runtime_component:data_machine'), true);
 assert.equal(bundleTask.limits.task_timeout_seconds, 1200);
 assert.deepEqual(bundleTask.expected_artifacts, ['datamachine-transcript', 'ConceptPacket']);
 


### PR DESCRIPTION
## Summary
- Add a reusable `homeboy/runtime-profile/v1` Data Machine Agent CI profile containing component path defaults, workspace tools, capabilities, and ability requirements.
- Update the Data Machine Codebox adapter to publish/reference the named profile instead of copying Data Machine requirements into Codebox-specific fields.
- Teach WP Codebox to resolve named or inline runtime profiles generically and apply profile-provided workspace tools, component defaults, and ability requirements.

## Tests
- `npm run test:datamachine-agent-ci-plan`
- `npm run test:codebox-agent-task-executor-boundary`
- `npm run test:codebox-agent-task-executor`
- `npm run lint:js` attempted; fails on pre-existing unrelated lint errors in files outside this change, including `wordpress/lib/playground-readiness.js`, `wordpress/lib/timing-correlator.js`, and several `wordpress/scripts/*` files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5
- **Used for:** Implemented the runtime profile refactor, adjusted tests, and ran verification; Chris remains responsible for review and merge.