### PR TITLE
Consume Homeboy secret env plans in WP Codebox

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -209,15 +209,17 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const sandboxToolPolicy = sandboxToolPolicyFromAgentTaskRequest(config, inputs, runtimeOptions, defaults, allowedTools);
   const provider = config.provider || runtimeOptions.provider || defaults.provider || '';
   const model = request.executor.model || config.model || runtimeOptions.model || defaults.model || '';
+  const homeboySecretEnvPlan = homeboyAgentTaskSecretEnvPlan();
+  const plannedSecretEnv = secretEnvNamesFromPlan(homeboySecretEnvPlan);
   const agent = firstValue(config.agent, runtimeOptions.agent, '');
   const runtimeTask = runtimeTaskWithExecutionDefaults(
     inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(request, config, inputs) || runtimeOptions.runtimeTask,
     { provider, model, agentBundles }
   );
   const explicitSecretEnv = [
-    ...normalizeArray(request.executor?.secret_env),
+    ...(plannedSecretEnv.length > 0 ? plannedSecretEnv : normalizeArray(request.executor?.secret_env)),
     ...normalizeArray(config.secret_env),
-    ...normalizeArray(runtimeOptions.secretEnv),
+    ...(plannedSecretEnv.length > 0 ? [] : normalizeArray(runtimeOptions.secretEnv)),
   ];
   const timeoutSeconds = request.limits?.task_timeout_seconds || request.limits?.taskTimeoutSeconds;
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
@@ -888,6 +890,20 @@ function parseJsonObject(value) {
   } catch {
     return null;
   }
+}
+
+function homeboyAgentTaskSecretEnvPlan() {
+  return parseJsonObject(process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON);
+}
+
+function secretEnvNamesFromPlan(plan) {
+  if (!plan || plan.schema !== 'homeboy/secret-env-plan/v1') {
+    return [];
+  }
+  return uniquePaths([
+    ...normalizeArray(plan.secret_env_names),
+    ...Object.values(plan.env_name_mapping || {}).flatMap(normalizeArray),
+  ]);
 }
 
 function normalizeArray(value) {

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -392,6 +392,39 @@ try {
 assert.deepEqual(codexTaskInput.provider_plugin_paths, ['/missing/stale-openai-provider']);
 assert.deepEqual(codexTaskInput.secret_env, provider.provider_defaults.codex.secret_env);
 
+const previousSecretEnvPlan = process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON;
+process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON = JSON.stringify({
+  schema: 'homeboy/secret-env-plan/v1',
+  secret_env_names: ['HOMEBOY_PLANNED_CODEBOX_SECRET'],
+  env_name_mapping: {
+    'wordpress.codebox-agent-task-executor': ['HOMEBOY_PLANNED_CODEBOX_SECRET'],
+  },
+  status: [{ name: 'HOMEBOY_PLANNED_CODEBOX_SECRET', configured: true, source: 'env' }],
+});
+let plannedSecretEnvTaskInput;
+try {
+  plannedSecretEnvTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+    schema: 'homeboy/agent-task-request/v1',
+    task_id: 'planned-secret-env-codebox-task-1',
+    executor: {
+      backend: 'codebox',
+      config: { provider: 'codex', secret_env: ['EXPLICIT_CODEBOX_SECRET'] },
+    },
+    instructions: 'Run a Codex-backed Codebox task with Homeboy-planned secret env.',
+    inputs: {},
+  });
+} finally {
+  if (previousSecretEnvPlan === undefined) {
+    delete process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON;
+  } else {
+    process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON = previousSecretEnvPlan;
+  }
+}
+assert.deepEqual(plannedSecretEnvTaskInput.secret_env, [
+  'HOMEBOY_PLANNED_CODEBOX_SECRET',
+  'EXPLICIT_CODEBOX_SECRET',
+]);
+
 const claudeCodeTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'claude-code-codebox-task-1',


### PR DESCRIPTION
## Summary
- make WP Codebox consume `HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON` when Homeboy provides a canonical `SecretEnvPlan`
- use planned env names instead of recomputing provider-default secret env merges in the executor path
- keep legacy local merging as a fallback for older Homeboy versions and preserve explicit `config.secret_env`
- add boundary coverage for the Homeboy plan handoff

Depends on Extra-Chill/homeboy#5031 for the provider-facing plan env var.

## Tests
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`

## Notes
- `node wordpress/tests/codebox-agent-task-executor-smoke.js` was also run and still fails on existing stale expectations unrelated to this change: current `wp-codebox.json` Codex secret source metadata and repo-loop capability assertions do not match the smoke fixture.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the WP Codebox consumer change, boundary test, and PR preparation; Chris remains responsible for review and merge.
