### PR TITLE
Declare WP Codebox executor argv

### DIFF
--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -11,6 +11,14 @@
       "label": "WP Codebox agent task executor",
       "backend": "codebox",
       "command": "node {{runtime_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs",
+      "invocation": {
+        "schema": "homeboy/command-invocation/v1",
+        "argv": [
+          "node",
+          "{{runtime_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs"
+        ],
+        "display": "node {{runtime_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs"
+      },
       "request_schema": "homeboy/agent-task-request/v1",
       "outcome_schema": "homeboy/agent-task-outcome/v1",
       "request_required_fields": [

--- a/tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
+++ b/tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const manifestPath = path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'wp-codebox.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+const provider = manifest.agent_task_executors[0];
+
+assert.equal(provider.schema, 'homeboy/agent-task-executor-provider/v1');
+assert.equal(provider.invocation.schema, 'homeboy/command-invocation/v1');
+assert.deepEqual(provider.invocation.argv, [
+	'node',
+	'{{runtime_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs',
+]);
+assert.equal(
+	provider.invocation.display,
+	'node {{runtime_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs'
+);
+assert.equal(provider.command, provider.invocation.display, 'legacy command stays display-compatible during deprecation');
+
+console.log('wp-codebox agent runtime command contract smoke passed');


### PR DESCRIPTION
## Summary
- Add invocation.argv to the WP Codebox agent task executor manifest.
- Keep the legacy command string display-compatible during the deprecation window.
- Add a smoke test that enforces the WP Codebox executor command contract.

## Dependency
- Consumes the homeboy command invocation contract from Extra-Chill/homeboy#5033.

## Tests
- node tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
- node tests/wp-codebox-provider-plugin-defaults-smoke.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5
- **Used for:** Drafted the manifest migration and focused smoke test; Chris remains responsible for review and validation.