### PR TITLE
Verify agent-task contract drift against Homeboy core

### DIFF
--- a/agent-runtimes/fixtures/homeboy-agent-task-core-contract.json
+++ b/agent-runtimes/fixtures/homeboy-agent-task-core-contract.json
@@ -1,0 +1,187 @@
+{
+  "schema": "homeboy/agent-task-core-contract/v1",
+  "schemas": {
+    "request": "homeboy/agent-task-request/v1",
+    "outcome": "homeboy/agent-task-outcome/v1",
+    "artifact": "homeboy/agent-task-artifact/v1",
+    "artifact_declaration": "homeboy/agent-task-artifact-declaration/v1",
+    "evidence_ref": "homeboy/agent-task-evidence-ref/v1",
+    "workflow": "homeboy/agent-task-workflow/v1",
+    "plan": "homeboy/agent-task-plan/v1",
+    "aggregate": "homeboy/agent-task-aggregate/v1",
+    "matrix_plan": "homeboy/agent-task-matrix-plan/v1",
+    "matrix_aggregate": "homeboy/agent-task-matrix-aggregate/v1",
+    "provider": "homeboy/agent-task-executor-provider/v1",
+    "provider_capability_contract": "homeboy/agent-task-provider-capability-contract/v1",
+    "gate_report": "homeboy/agent-task-gate-report/v1",
+    "promotion_report": "homeboy/agent-task-promotion-report/v1",
+    "cook_loop_report": "homeboy/agent-task-cook-loop-report/v1",
+    "loop_controller": "homeboy/agent-task-loop-controller/v1",
+    "loop_controller_status": "homeboy/agent-task-loop-controller-status/v1",
+    "secret_env_plan": "homeboy/secret-env-plan/v1",
+    "secret_env_requirement": "homeboy/secret-env-requirement/v1"
+  },
+  "provider_capability": {
+    "schema": "homeboy/agent-task-provider-capability-contract/v1",
+    "provider_schema": "homeboy/agent-task-executor-provider/v1",
+    "request_schema": "homeboy/agent-task-request/v1",
+    "outcome_schema": "homeboy/agent-task-outcome/v1",
+    "request_required_fields": [
+      "schema",
+      "task_id",
+      "executor.backend",
+      "instructions"
+    ],
+    "outcome_statuses": [
+      "succeeded",
+      "no_op",
+      "unable_to_remediate",
+      "provider_error",
+      "timeout",
+      "failed",
+      "follow_up_issue",
+      "cancelled"
+    ],
+    "failure_classifications": [
+      "provider",
+      "timeout",
+      "policy_denied",
+      "capability_missing",
+      "invalid_input",
+      "execution_failed",
+      "unknown"
+    ],
+    "redacted_metadata_keys": [
+      "secret_env_values",
+      "secretEnvValues",
+      "secrets"
+    ],
+    "provider_capability_fields": [
+      "schema",
+      "provider_schema",
+      "request_schema",
+      "outcome_schema",
+      "request_required_fields",
+      "outcome_statuses",
+      "failure_classifications",
+      "redacted_metadata_keys"
+    ],
+    "executor_provider_fields": [
+      "schema",
+      "id",
+      "label",
+      "backend",
+      "default_backend",
+      "command",
+      "request_schema",
+      "outcome_schema",
+      "capabilities",
+      "secret_requirements",
+      "secret_env_requirements",
+      "workspace_materialization",
+      "provider_defaults",
+      "runner_readiness",
+      "runner_sources",
+      "dependency_failure_patterns",
+      "timeout_artifact_discovery",
+      "role_aliases",
+      "extension_id",
+      "extension_path",
+      "runtime_id",
+      "runtime_path",
+      "extra"
+    ]
+  },
+  "enums": {
+    "execution_state": [
+      "queued",
+      "running",
+      "waiting",
+      "succeeded",
+      "failed",
+      "cancelled"
+    ],
+    "task_state": [
+      "queued",
+      "blocked",
+      "skipped",
+      "running",
+      "succeeded",
+      "failed",
+      "cancelled",
+      "timed_out"
+    ],
+    "run_state": [
+      "queued",
+      "running",
+      "succeeded",
+      "partial_failure",
+      "failed",
+      "cancelled"
+    ],
+    "aggregate_status": [
+      "succeeded",
+      "partial_failure",
+      "failed",
+      "cancelled"
+    ],
+    "outcome_status": [
+      "succeeded",
+      "no_op",
+      "unable_to_remediate",
+      "provider_error",
+      "timeout",
+      "failed",
+      "follow_up_issue",
+      "cancelled"
+    ],
+    "failure_classification": [
+      "provider",
+      "timeout",
+      "policy_denied",
+      "capability_missing",
+      "invalid_input",
+      "execution_failed",
+      "unknown"
+    ],
+    "workflow_step_status": [
+      "pending",
+      "running",
+      "succeeded",
+      "failed",
+      "skipped",
+      "cancelled"
+    ]
+  },
+  "redaction_defaults": {
+    "replacement": "[REDACTED]",
+    "sensitive_keys": [
+      "api_key",
+      "apikey",
+      "auth",
+      "authorization",
+      "bearer",
+      "client_secret",
+      "cookie",
+      "key",
+      "nonce",
+      "passwd",
+      "password",
+      "refresh_token",
+      "secret",
+      "session",
+      "sid",
+      "token"
+    ],
+    "sensitive_headers": [
+      "authorization",
+      "cookie",
+      "proxy-authorization",
+      "set-cookie",
+      "x-api-key",
+      "x-auth-token",
+      "x-csrf-token",
+      "x-wp-nonce"
+    ]
+  }
+}

--- a/agent-runtimes/lib/agent-task-provider-contract.js
+++ b/agent-runtimes/lib/agent-task-provider-contract.js
@@ -12,17 +12,23 @@ const AGENT_TASK_REQUEST_REQUIRED_FIELDS = ['schema', 'task_id', 'executor.backe
 
 const AGENT_TASK_OUTCOME_STATUSES = [
   'succeeded',
-  'failed',
   'no_op',
   'unable_to_remediate',
-  'timeout',
   'provider_error',
+  'timeout',
+  'failed',
+  'follow_up_issue',
+  'cancelled',
 ];
 
 const AGENT_TASK_FAILURE_CLASSIFICATIONS = [
   'provider',
   'timeout',
+  'policy_denied',
+  'capability_missing',
+  'invalid_input',
   'execution_failed',
+  'unknown',
 ];
 
 const AGENT_TASK_REDACTED_METADATA_KEYS = [

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -129,6 +129,7 @@ function providerContract(options = {}) {
     label: options.label || WP_CODEBOX_PROVIDER_LABEL,
     backend: WP_CODEBOX_BACKEND,
     command: options.command || 'node {{runtime_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs',
+    invocation: runtimeCommandInvocation(options),
     ...agentTaskProviderContractFields(),
     secret_env_requirements: options.secretEnvRequirements || runtimeSecretEnvRequirements(),
     capabilities: normalizeArray(options.capabilities || PROVIDER_CAPABILITIES),
@@ -151,6 +152,10 @@ function runtimeManifest() {
 
 function runtimeExecutorManifest() {
   return runtimeManifest().agent_task_executors?.[0] || {};
+}
+
+function runtimeCommandInvocation(options = {}) {
+  return firstObject(options.invocation, runtimeExecutorManifest().invocation);
 }
 
 function runtimeProviderCapabilities() {

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -29,16 +29,22 @@
       ],
       "outcome_statuses": [
         "succeeded",
-        "failed",
         "no_op",
         "unable_to_remediate",
+        "provider_error",
         "timeout",
-        "provider_error"
+        "failed",
+        "follow_up_issue",
+        "cancelled"
       ],
       "failure_classifications": [
         "provider",
         "timeout",
-        "execution_failed"
+        "policy_denied",
+        "capability_missing",
+        "invalid_input",
+        "execution_failed",
+        "unknown"
       ],
       "redacted_metadata_keys": [
         "secret_env_values",

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -78,6 +78,7 @@
     "test:wp-codebox-bench-prepare-steps": "node tests/wp-codebox-bench-prepare-steps-smoke.js",
     "test:wp-codebox-phpunit-recipe-builder": "node tests/wp-codebox-phpunit-recipe-builder-smoke.js",
     "test:build-package-artifacts": "bash scripts/build/build-package-artifacts-smoke.sh",
+    "test:agent-task-core-contract-drift": "node tests/agent-task-core-contract-drift.test.js",
     "test:codebox-agent-task-executor-boundary": "node tests/codebox-agent-task-executor-boundary.test.js",
     "test:provider-outcome-normalizer": "node tests/provider-outcome-normalizer.test.js",
     "test:codebox-agent-task-executor": "node tests/codebox-agent-task-executor-smoke.js",

--- a/wordpress/tests/agent-task-core-contract-drift.test.js
+++ b/wordpress/tests/agent-task-core-contract-drift.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA,
+  AGENT_TASK_ARTIFACT_SCHEMA,
+  AGENT_TASK_EVIDENCE_REF_SCHEMA,
+  AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
+  AGENT_TASK_FAILURE_CLASSIFICATIONS,
+  AGENT_TASK_OUTCOME_SCHEMA,
+  AGENT_TASK_OUTCOME_STATUSES,
+  AGENT_TASK_REDACTED_METADATA_KEYS,
+  AGENT_TASK_REQUEST_SCHEMA,
+  agentTaskProviderContractFields,
+} = require('../../agent-runtimes/lib/agent-task-provider-contract');
+const { providerContract } = require('../../agent-runtimes/wp-codebox');
+
+const contract = JSON.parse(fs.readFileSync(path.join(
+  __dirname,
+  '..',
+  '..',
+  'agent-runtimes',
+  'fixtures',
+  'homeboy-agent-task-core-contract.json'
+), 'utf8'));
+const wpCodeboxManifest = JSON.parse(fs.readFileSync(path.join(
+  __dirname,
+  '..',
+  '..',
+  'agent-runtimes',
+  'wp-codebox',
+  'wp-codebox.json'
+), 'utf8'));
+const wpCodeboxProvider = wpCodeboxManifest.agent_task_executors[0];
+const providerFields = contract.provider_capability;
+
+assert.equal(contract.schema, 'homeboy/agent-task-core-contract/v1');
+assert.equal(AGENT_TASK_REQUEST_SCHEMA, contract.schemas.request);
+assert.equal(AGENT_TASK_OUTCOME_SCHEMA, contract.schemas.outcome);
+assert.equal(AGENT_TASK_ARTIFACT_SCHEMA, contract.schemas.artifact);
+assert.equal(AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA, contract.schemas.artifact_declaration);
+assert.equal(AGENT_TASK_EVIDENCE_REF_SCHEMA, contract.schemas.evidence_ref);
+assert.equal(AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA, contract.schemas.provider);
+assert.deepEqual(AGENT_TASK_OUTCOME_STATUSES, providerFields.outcome_statuses);
+assert.deepEqual(AGENT_TASK_FAILURE_CLASSIFICATIONS, providerFields.failure_classifications);
+assert.deepEqual(AGENT_TASK_REDACTED_METADATA_KEYS, providerFields.redacted_metadata_keys);
+assert.deepEqual(agentTaskProviderContractFields(), {
+  request_schema: providerFields.request_schema,
+  outcome_schema: providerFields.outcome_schema,
+  request_required_fields: providerFields.request_required_fields,
+  outcome_statuses: providerFields.outcome_statuses,
+  failure_classifications: providerFields.failure_classifications,
+  redacted_metadata_keys: providerFields.redacted_metadata_keys,
+});
+assert.equal(wpCodeboxProvider.schema, providerFields.provider_schema);
+assert.equal(wpCodeboxProvider.request_schema, providerFields.request_schema);
+assert.equal(wpCodeboxProvider.outcome_schema, providerFields.outcome_schema);
+assert.deepEqual(wpCodeboxProvider.request_required_fields, providerFields.request_required_fields);
+assert.deepEqual(wpCodeboxProvider.outcome_statuses, providerFields.outcome_statuses);
+assert.deepEqual(wpCodeboxProvider.failure_classifications, providerFields.failure_classifications);
+assert.deepEqual(wpCodeboxProvider.redacted_metadata_keys, providerFields.redacted_metadata_keys);
+assert.deepEqual(providerContract(), wpCodeboxProvider);
+
+process.stdout.write('Agent task core contract drift check passed\n');

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -14,6 +14,11 @@ const {
 const {
   datamachineAgentCiCodeboxExecutorConfig,
 } = require('../lib/datamachine-agent-ci-codebox-adapter');
+const {
+  AGENT_TASK_FAILURE_CLASSIFICATIONS,
+  AGENT_TASK_OUTCOME_STATUSES,
+  AGENT_TASK_REDACTED_METADATA_KEYS,
+} = require('../../agent-runtimes/lib/agent-task-provider-contract');
 
 const fixtureCodeboxCoreModule = path.join(__dirname, 'fixtures', 'wp-codebox-core-agent-task-normalizer.mjs');
 const wpCodeboxRuntimeRoot = path.join(__dirname, '..', '..', 'agent-runtimes', 'wp-codebox');
@@ -305,9 +310,9 @@ assert.equal(provider.command, 'node {{runtime_path}}/scripts/agent/homeboy-code
 assert.equal(provider.request_schema, 'homeboy/agent-task-request/v1');
 assert.equal(provider.outcome_schema, 'homeboy/agent-task-outcome/v1');
 assert.deepEqual(provider.request_required_fields, ['schema', 'task_id', 'executor.backend', 'instructions']);
-assert.deepEqual(provider.outcome_statuses, ['succeeded', 'failed', 'no_op', 'unable_to_remediate', 'timeout', 'provider_error']);
-assert.deepEqual(provider.failure_classifications, ['provider', 'timeout', 'execution_failed']);
-assert.deepEqual(provider.redacted_metadata_keys, ['secret_env_values', 'secretEnvValues', 'secrets']);
+assert.deepEqual(provider.outcome_statuses, AGENT_TASK_OUTCOME_STATUSES);
+assert.deepEqual(provider.failure_classifications, AGENT_TASK_FAILURE_CLASSIFICATIONS);
+assert.deepEqual(provider.redacted_metadata_keys, AGENT_TASK_REDACTED_METADATA_KEYS);
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, codexSecretEnv);
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').when, {
   any: [


### PR DESCRIPTION
## Summary
- add a checked Homeboy agent-task core contract fixture generated from Extra-Chill/homeboy#5034
- compare shared runtime constants and the WP Codebox provider manifest against the core contract fixture
- align provider status and failure-classification arrays with the exported Homeboy contract

## Dependency
- Depends on Extra-Chill/homeboy#5034 for the upstream contract export fields represented by the fixture.

## Tests
- npm run test:agent-task-core-contract-drift
- npm run test:codebox-agent-task-executor-boundary
- node --check tests/agent-task-core-contract-drift.test.js && node --check tests/codebox-agent-task-executor-smoke.js
- node --check agent-runtimes/lib/agent-task-provider-contract.js

## Known unrelated blockers
- npm run test:codebox-agent-task-executor currently fails on existing provider-contract smoke expectations outside this drift check: first Codex secret-source metadata expectations, then component-path materialization for agents-api after those are adjusted.
- npm run test:opencode-agent-task-executor-boundary currently fails before exercising these changes because wordpress.json has no agent_runtimes array.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted implementation and tests; Chris reviews and owns the change.