### PR TITLE
feat(wp-codebox): declare executable readiness

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -136,6 +136,7 @@ function providerContract(options = {}) {
     workspace_materialization: {
       cwd: 'git_checkout',
     },
+    runner_readiness: runtimeRunnerReadiness(options),
     workspace_tools: runtimeWorkspaceTools(options),
     component_path_defaults: runtimeComponentPathDefaults(options),
     provider_defaults: providerDefaultsContract(runtimeProviderDefaults()),
@@ -188,6 +189,10 @@ function runtimeComponentDiscovery(options = {}) {
 
 function runtimeProviderDefaults() {
   return firstObject(runtimeExecutorManifest().provider_defaults) || {};
+}
+
+function runtimeRunnerReadiness(options = {}) {
+  return normalizeArray(options.runnerReadiness || options.runner_readiness || runtimeExecutorManifest().runner_readiness);
 }
 
 function runtimeSecretEnvRequirements() {

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -367,7 +367,14 @@ function executable(filePath) {
 }
 
 function configuredBinaryDiagnostic(filePath) {
-  if (!filePath || !path.isAbsolute(filePath)) {
+  if (!filePath) {
+    return {
+      class: 'wp-codebox.config.missing_binary',
+      message: 'WP Codebox binary is not configured. Set wp_codebox_bin or let Homeboy inject HOMEBOY_WP_CODEBOX_BIN from the provider runner_readiness executable contract.',
+      data: { phase: 'codebox.config', wp_codebox_bin: '', reason: 'missing' },
+    };
+  }
+  if (!path.isAbsolute(filePath)) {
     return null;
   }
   if (!fs.existsSync(filePath)) {
@@ -1750,7 +1757,7 @@ function runWpCodeboxParentTask(request, envOverrides = {}) {
   }
 
   const input = runnerInput(request, artifacts);
-  const wpCodeboxBin = input.wp_codebox_bin || process.env.HOMEBOY_WP_CODEBOX_BIN || 'wp-codebox';
+  const wpCodeboxBin = input.wp_codebox_bin || process.env.HOMEBOY_WP_CODEBOX_BIN || '';
   const binaryDiagnostic = configuredBinaryDiagnostic(wpCodeboxBin);
   if (binaryDiagnostic) {
     process.stdout.write(`${JSON.stringify(configuredBinaryFailurePayload(input, artifacts, binaryDiagnostic), null, 2)}\n`);

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -119,6 +119,19 @@
       "workspace_materialization": {
         "cwd": "git_checkout"
       },
+      "runner_readiness": [
+        {
+          "id": "wp-codebox.executable",
+          "label": "WP Codebox executable",
+          "executable": {
+            "env": ["HOMEBOY_WP_CODEBOX_BIN"],
+            "candidates": ["wp-codebox"],
+            "version_command": ["--version"],
+            "install_hint": "Install WP Codebox or set HOMEBOY_WP_CODEBOX_BIN to the wp-codebox executable path."
+          },
+          "remediation": "Install WP Codebox or set HOMEBOY_WP_CODEBOX_BIN to the wp-codebox executable path."
+        }
+      ],
       "workspace_tools": {
         "readonly": [
           "workspace_ls",

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -50,6 +50,17 @@ assert.equal(manifest.agent_task.runtime_requirements.integration_contract, 'hom
 const runtime = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'agent-runtimes', 'wp-codebox', 'wp-codebox.json'), 'utf8'));
 assert.equal(runtime.agent_task_executors.length, 1);
 assert.deepEqual(runtime.agent_task_executors[0], providerContract());
+assert.deepEqual(provider.runner_readiness, [{
+  id: 'wp-codebox.executable',
+  label: 'WP Codebox executable',
+  executable: {
+    env: ['HOMEBOY_WP_CODEBOX_BIN'],
+    candidates: ['wp-codebox'],
+    version_command: ['--version'],
+    install_hint: 'Install WP Codebox or set HOMEBOY_WP_CODEBOX_BIN to the wp-codebox executable path.',
+  },
+  remediation: 'Install WP Codebox or set HOMEBOY_WP_CODEBOX_BIN to the wp-codebox executable path.',
+}]);
 assert.deepEqual(secretEnvRequirementForProvider(runtime.agent_task_executors[0], 'codex').env, codexSecretEnv);
 assert.equal(provider.capabilities.includes('tool:wpsg_materialize_packet'), false);
 assert.equal(provider.capabilities.includes('ability:wpsg_materialize_packet'), false);


### PR DESCRIPTION
## Summary
- Declare the WP Codebox executable readiness contract in the agent runtime manifest.
- Mirror runner_readiness through the JS provider contract so generated/default manifests stay aligned.
- Make the WP Codebox task runner consume Homeboy-injected HOMEBOY_WP_CODEBOX_BIN instead of falling back to its own bare wp-codebox lookup.

## Dependency
- Depends on Extra-Chill/homeboy#5035 for provider executable readiness resolution and env injection.

## Tests
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js
- node wordpress/tests/wp-codebox-task-runner-smoke.js

## Notes
-  was not used as verification because current main has unrelated stale assertions for Codex auth-source defaults and runtime-component aliases.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, tests, and PR description; Chris remains responsible for review and validation.
