### PR TITLE
Add WordPress runtime task planner

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -576,6 +576,16 @@ WordPress assumptions to Homeboy core.
 `homeboy/agent-task-outcome/v1` outcome with normalized status, artifacts,
 evidence refs, diagnostics, and failure classification.
 
+### WordPress runtime task planner
+
+`lib/wordpress-runtime-task-planner.js` and
+`scripts/agent/homeboy-wordpress-runtime-task-plan.cjs` keep WordPress/Codebox/DLA
+orchestration in this extension by projecting runtime-task intent into Homeboy's
+generic `homeboy/agent-task-plan/v1` and `homeboy/agent-task-request/v1` contract.
+Callers provide the ability, ability input, backend/provider/runtime selection,
+fanout/concurrency metadata, expected artifacts, timeout, and optional DLA URL
+shorthand; Homeboy core only sees generic durable agent-task plans.
+
 `../agent-runtimes/wp-codebox` is the runtime package surface for imports
 and runtime-path dispatch; it forwards to the WordPress payload so both monorepo
 and installed extension layouts use the same implementation.

--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -25,4 +25,5 @@ module.exports = {
 	...require('./lib/wp-codebox-artifacts'),
 	...require('./lib/wordpress-workload-profile'),
 	...require('./lib/static-visual-parity'),
+	...require('./lib/wordpress-runtime-task-planner'),
 };

--- a/wordpress/lib/wordpress-runtime-task-planner.js
+++ b/wordpress/lib/wordpress-runtime-task-planner.js
@@ -1,0 +1,216 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const crypto = require('node:crypto');
+
+/**
+ * Internal dependencies
+ */
+const {
+	AGENT_TASK_REQUEST_SCHEMA,
+} = require('../../agent-runtimes/lib/agent-task-provider-contract');
+const {
+	agentTaskRequestFromRunnerSpec,
+	agentTaskRunnerSpec,
+} = require('../../agent-runtimes/lib/agent-task-runner-contract');
+
+const WORDPRESS_RUNTIME_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
+const WORDPRESS_RUNTIME_TASK_DEFAULT_BACKEND = 'codebox';
+const WORDPRESS_RUNTIME_TASK_DEFAULT_POLICY = {
+	read: 'sandbox',
+	write: 'sandbox',
+	apply: 'review',
+};
+
+function wordpressRuntimeTaskPlan(options = {}) {
+	const planId = requiredString(options.planId || options.plan_id, 'planId');
+	const taskOptions = normalizeTaskOptions(options);
+	const tasks = taskOptions.map((taskOption, index) => wordpressRuntimeTaskRequest({
+		...options,
+		...taskOption,
+		planId,
+		parentPlanId: planId,
+		taskId: taskOption.taskId || taskOption.task_id || taskIdForPlan(planId, index, taskOption),
+		fanout: taskOption.fanout || taskOption.matrix || taskOption.metadata?.fanout,
+	}));
+
+	return stripUndefined({
+		schema: WORDPRESS_RUNTIME_TASK_PLAN_SCHEMA,
+		plan_id: planId,
+		tasks,
+		options: stripUndefined({
+			concurrency: numberOrUndefined(options.concurrency),
+			fail_fast: options.failFast ?? options.fail_fast,
+		}),
+		metadata: stripUndefined({
+			...(options.metadata || {}),
+			planner: 'homeboy-extension-wordpress/wordpress-runtime-task-planner',
+			runtime: options.runtime || options.runtimeId || options.runtime_id,
+			backend: options.backend || WORDPRESS_RUNTIME_TASK_DEFAULT_BACKEND,
+		}),
+	});
+}
+
+function wordpressRuntimeTaskRequest(options = {}) {
+	const taskId = requiredString(options.taskId || options.task_id, 'taskId');
+	const ability = requiredString(options.ability, 'ability');
+	const abilityInput = runtimeAbilityInput(options);
+	const runnerRequest = agentTaskRequestFromRunnerSpec({
+		runnerSpec: wordpressRuntimeTaskRunnerSpec({
+			...options,
+			ability,
+			abilityInput,
+		}),
+	});
+
+	return stripUndefined({
+		schema: AGENT_TASK_REQUEST_SCHEMA,
+		task_id: taskId,
+		group_key: options.groupKey || options.group_key,
+		parent_plan_id: options.parentPlanId || options.parent_plan_id || options.planId || options.plan_id,
+		cwd: options.cwd,
+		repo: options.repo,
+		workspace: options.workspace,
+		executor: runnerRequest.executor,
+		instructions: options.instructions || instructionsForAbility(ability),
+		inputs: stripUndefined({
+			...(options.inputs || {}),
+			ability,
+			ability_input: abilityInput,
+		}),
+		source_refs: normalizeArray(options.sourceRefs || options.source_refs),
+		policy: options.policy || WORDPRESS_RUNTIME_TASK_DEFAULT_POLICY,
+		limits: runnerRequest.limits,
+		expected_artifacts: runnerRequest.expected_artifacts,
+		metadata: stripUndefined({
+			...(options.metadata || {}),
+			fanout: options.fanout,
+		}),
+	});
+}
+
+function wordpressRuntimeTaskRunnerSpec(options = {}) {
+	const config = wordpressRuntimeTaskExecutorConfig(options);
+	return agentTaskRunnerSpec({
+		backend: options.backend || WORDPRESS_RUNTIME_TASK_DEFAULT_BACKEND,
+		config,
+		secret_env: normalizeArray(options.secretEnv || options.secret_env),
+		task_timeout_seconds: numberOrUndefined(options.taskTimeoutSeconds || options.task_timeout_seconds || options.timeoutSeconds || options.timeout_seconds),
+		limits: options.limits,
+		expected_artifacts: options.expectedArtifacts || options.expected_artifacts,
+	});
+}
+
+function wordpressRuntimeTaskExecutorConfig(options = {}) {
+	return stripUndefined({
+		...(options.config || {}),
+		provider: options.provider,
+		model: options.model,
+		runtime: options.runtime,
+		runtime_id: options.runtimeId || options.runtime_id,
+		runtime_bin: options.runtimeBin || options.runtime_bin,
+		provider_plugin_paths: options.providerPluginPaths || options.provider_plugin_paths,
+		homeboy_extensions: options.homeboyExtensions || options.homeboy_extensions,
+		runtime_component_paths: options.runtimeComponentPaths || options.runtime_component_paths,
+		component_contracts: options.componentContracts || options.component_contracts,
+		ability_tools: options.abilityTools || options.ability_tools,
+		structured_artifacts: options.structuredArtifacts || options.structured_artifacts,
+		runtime_env: options.runtimeEnv || options.runtime_env,
+		runtime_config_mounts: options.runtimeConfigMounts || options.runtime_config_mounts,
+		runtime_state_mounts: options.runtimeStateMounts || options.runtime_state_mounts,
+		max_turns: options.maxTurns || options.max_turns,
+		task_timeout_seconds: numberOrUndefined(options.taskTimeoutSeconds || options.task_timeout_seconds || options.timeoutSeconds || options.timeout_seconds),
+		runtime_task: {
+			ability: options.ability,
+			input: options.abilityInput || options.ability_input || {},
+		},
+	});
+}
+
+function runtimeAbilityInput(options = {}) {
+	return stripUndefined({
+		...(options.abilityInput || options.ability_input || {}),
+		...(options.dlaUrl || options.dla_url ? { dla_url: options.dlaUrl || options.dla_url } : {}),
+		...(options.provider && !hasOwn(options.abilityInput || options.ability_input || {}, 'provider') ? { provider: options.provider } : {}),
+		...(options.model && !hasOwn(options.abilityInput || options.ability_input || {}, 'model') ? { model: options.model } : {}),
+	});
+}
+
+function normalizeTaskOptions(options = {}) {
+	const tasks = normalizeArray(options.tasks);
+	if (tasks.length > 0) {
+		return tasks;
+	}
+	const fanout = normalizeArray(options.fanout);
+	if (fanout.length > 0) {
+		return fanout.map((entry) => ({
+			...entry,
+			abilityInput: {
+				...objectOrEmpty(options.abilityInput || options.ability_input),
+				...objectOrEmpty(entry.abilityInput || entry.ability_input || entry.input),
+			},
+			fanout: entry.fanout || entry.matrix || entry,
+		}));
+	}
+	return [{}];
+}
+
+function taskIdForPlan(planId, index, taskOption = {}) {
+	if (index === 0 && !taskOption.fanout && !taskOption.matrix) {
+		return `${planId}-task`;
+	}
+	const fingerprint = crypto.createHash('sha256').update(JSON.stringify(taskOption)).digest('hex').slice(0, 10);
+	return `${planId}-${index + 1}-${fingerprint}`;
+}
+
+function instructionsForAbility(ability) {
+	return `Run WordPress runtime ability ${ability} and return the declared artifacts.`;
+}
+
+function normalizeArray(value) {
+	return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function objectOrEmpty(value) {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function requiredString(value, name) {
+	if (typeof value !== 'string' || value.trim() === '') {
+		throw new Error(`${name} is required.`);
+	}
+	return value;
+}
+
+function hasOwn(value, key) {
+	return Boolean(value && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, key));
+}
+
+function numberOrUndefined(value) {
+	if (value === undefined || value === null || value === '') {
+		return undefined;
+	}
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function stripUndefined(value) {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return value;
+	}
+	return Object.fromEntries(
+		Object.entries(value).filter(([, entry]) => entry !== undefined)
+	);
+}
+
+module.exports = {
+	WORDPRESS_RUNTIME_TASK_DEFAULT_BACKEND,
+	WORDPRESS_RUNTIME_TASK_DEFAULT_POLICY,
+	WORDPRESS_RUNTIME_TASK_PLAN_SCHEMA,
+	wordpressRuntimeTaskExecutorConfig,
+	wordpressRuntimeTaskPlan,
+	wordpressRuntimeTaskRequest,
+	wordpressRuntimeTaskRunnerSpec,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -32,7 +32,8 @@
     "./static-visual-parity": "./lib/static-visual-parity.js",
     "./webperf-evidence-summary": "./lib/webperf-evidence-summary.js",
     "./benchmark-matrix-report": "./lib/benchmark-matrix-report.js",
-    "./audit-wp-codebox-fanout": "./lib/audit-wp-codebox-fanout.js"
+    "./audit-wp-codebox-fanout": "./lib/audit-wp-codebox-fanout.js",
+    "./wordpress-runtime-task-planner": "./lib/wordpress-runtime-task-planner.js"
   },
   "scripts": {
     "lint:js": "eslint",
@@ -83,6 +84,7 @@
     "test:provider-outcome-normalizer": "node tests/provider-outcome-normalizer.test.js",
     "test:codebox-agent-task-executor": "node tests/codebox-agent-task-executor-smoke.js",
     "test:codebox-agent-task-matrix": "node tests/codebox-agent-task-matrix-smoke.js",
+    "test:wordpress-runtime-task-planner": "node tests/wordpress-runtime-task-planner-smoke.js",
     "test:opencode-agent-task-executor-boundary": "node tests/opencode-agent-task-executor-boundary.test.js",
     "test:datamachine-agent-host-lifecycle": "node tests/datamachine-agent-host-lifecycle-smoke.js",
     "test:refactor-source-wp-codebox": "node tests/refactor-source-wp-codebox-smoke.js"

--- a/wordpress/scripts/agent/homeboy-wordpress-runtime-task-plan.cjs
+++ b/wordpress/scripts/agent/homeboy-wordpress-runtime-task-plan.cjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+'use strict';
+
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Internal dependencies
+ */
+const { wordpressRuntimeTaskPlan } = require('../../lib/wordpress-runtime-task-planner');
+
+function argValue(name) {
+	const index = process.argv.indexOf(name);
+	return index >= 0 ? process.argv[index + 1] : '';
+}
+
+function argValues(name) {
+	const values = [];
+	for (let index = 0; index < process.argv.length; index += 1) {
+		if (process.argv[index] === name && process.argv[index + 1]) {
+			values.push(process.argv[index + 1]);
+		}
+	}
+	return values;
+}
+
+function hasFlag(name) {
+	return process.argv.includes(name);
+}
+
+function usage() {
+	console.error('Usage: homeboy-wordpress-runtime-task-plan.cjs --plan-id <id> --ability <ability> [--ability-input <json>] [--ability-input-file <file>] [--task-id <id>] [--backend <id>] [--provider <id>] [--model <id>] [--runtime <id>] [--runtime-id <id>] [--runtime-bin <path>] [--dla-url <url>] [--expected-artifact <kind>] [--timeout-seconds <n>] [--concurrency <n>] [--fanout <json-array>] [--fanout-file <file>] [--source-ref <json>] [--metadata <json>] [--config <json>] [--output <plan.json>]');
+	process.exit(1);
+}
+
+function readJsonArg(value, label) {
+	if (!value) {
+		return undefined;
+	}
+	try {
+		return JSON.parse(value);
+	} catch (error) {
+		throw new Error(`${label} must be valid JSON: ${error.message}`);
+	}
+}
+
+function readJsonFile(filePath, label) {
+	if (!filePath) {
+		return undefined;
+	}
+	return readJsonArg(fs.readFileSync(filePath, 'utf8'), label);
+}
+
+function writeJson(filePath, payload) {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+const planId = argValue('--plan-id');
+const ability = argValue('--ability');
+if (!planId || !ability || hasFlag('--help') || hasFlag('-h')) {
+	usage();
+}
+
+try {
+	const abilityInput = readJsonFile(argValue('--ability-input-file'), 'ability input file')
+		|| readJsonArg(argValue('--ability-input'), 'ability input')
+		|| {};
+	const fanout = readJsonFile(argValue('--fanout-file'), 'fanout file')
+		|| readJsonArg(argValue('--fanout'), 'fanout');
+	const plan = wordpressRuntimeTaskPlan({
+		planId,
+		ability,
+		taskId: argValue('--task-id') || undefined,
+		abilityInput,
+		backend: argValue('--backend') || undefined,
+		provider: argValue('--provider') || undefined,
+		model: argValue('--model') || undefined,
+		runtime: argValue('--runtime') || undefined,
+		runtimeId: argValue('--runtime-id') || undefined,
+		runtimeBin: argValue('--runtime-bin') || undefined,
+		dlaUrl: argValue('--dla-url') || undefined,
+		instructions: argValue('--instructions') || undefined,
+		repo: argValue('--repo') || undefined,
+		cwd: argValue('--cwd') || undefined,
+		groupKey: argValue('--group-key') || undefined,
+		expectedArtifacts: argValues('--expected-artifact'),
+		providerPluginPaths: argValues('--provider-plugin-path'),
+		secretEnv: argValues('--secret-env'),
+		timeoutSeconds: argValue('--timeout-seconds') || undefined,
+		concurrency: argValue('--concurrency') || undefined,
+		fanout,
+		sourceRefs: argValues('--source-ref').map((value) => readJsonArg(value, 'source ref')),
+		metadata: readJsonArg(argValue('--metadata'), 'metadata') || undefined,
+		config: readJsonArg(argValue('--config'), 'config') || undefined,
+	});
+
+	const output = argValue('--output');
+	if (output) {
+		writeJson(output, plan);
+	}
+	console.log(JSON.stringify(plan, null, 2));
+} catch (error) {
+	console.error(error && error.stack ? error.stack : String(error));
+	process.exit(1);
+}

--- a/wordpress/tests/wordpress-runtime-task-planner-smoke.js
+++ b/wordpress/tests/wordpress-runtime-task-planner-smoke.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const {
+	wordpressRuntimeTaskPlan,
+	wordpressRuntimeTaskRequest,
+} = require('../lib/wordpress-runtime-task-planner');
+
+const contract = JSON.parse(fs.readFileSync(path.join(
+	__dirname,
+	'..',
+	'..',
+	'agent-runtimes',
+	'fixtures',
+	'homeboy-agent-task-core-contract.json'
+), 'utf8'));
+
+const plan = wordpressRuntimeTaskPlan({
+	planId: 'runtime-task-plan-smoke',
+	ability: 'datamachine/run-runtime-task',
+	abilityInput: { operation: 'extract' },
+	dlaUrl: 'dla://runtime/import/demo-site',
+	provider: 'codex',
+	model: 'openai/gpt-5.5',
+	runtimeId: 'wp-codebox',
+	concurrency: 2,
+	timeoutSeconds: 900,
+	expectedArtifacts: ['runtime-task-result'],
+	providerPluginPaths: ['/workspace/components/ai-provider-for-openai'],
+	secretEnv: ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN'],
+	fanout: [
+		{ taskId: 'runtime-task-plan-smoke-import', input: { site: 'import' }, matrix: { scenario: 'import' } },
+		{ taskId: 'runtime-task-plan-smoke-verify', input: { site: 'verify' }, matrix: { scenario: 'verify' } },
+	],
+});
+
+assert.equal(plan.schema, contract.schemas.plan);
+assert.equal(plan.plan_id, 'runtime-task-plan-smoke');
+assert.equal(plan.options.concurrency, 2);
+assert.equal(plan.tasks.length, 2);
+for (const task of plan.tasks) {
+	assert.equal(task.schema, contract.schemas.request);
+	assert.equal(task.executor.backend, 'codebox');
+	assert.equal(task.executor.config.runtime_id, 'wp-codebox');
+	assert.equal(task.executor.config.runtime_task.ability, 'datamachine/run-runtime-task');
+	assert.equal(task.executor.config.runtime_task.input.operation, 'extract');
+	assert.equal(task.executor.config.runtime_task.input.dla_url, 'dla://runtime/import/demo-site');
+	assert.equal(task.executor.config.runtime_task.input.provider, 'codex');
+	assert.equal(task.executor.config.runtime_task.input.model, 'openai/gpt-5.5');
+	assert.deepEqual(task.expected_artifacts, ['runtime-task-result']);
+	assert.equal(task.limits.task_timeout_seconds, 900);
+	assert.equal(task.parent_plan_id, 'runtime-task-plan-smoke');
+	assert.deepEqual(task.policy, { read: 'sandbox', write: 'sandbox', apply: 'review' });
+}
+assert.deepEqual(plan.tasks.map((task) => task.metadata.fanout.scenario), ['import', 'verify']);
+assert(!JSON.stringify(plan).includes('/Users/'), 'planner must not inject local user paths');
+
+const request = wordpressRuntimeTaskRequest({
+	taskId: 'single-runtime-task-smoke',
+	ability: 'example/materialize-artifact',
+	abilityInput: { slug: 'example' },
+	backend: 'codebox',
+});
+assert.equal(request.schema, contract.schemas.request);
+assert.equal(request.task_id, 'single-runtime-task-smoke');
+assert.equal(request.instructions, 'Run WordPress runtime ability example/materialize-artifact and return the declared artifacts.');
+assert.deepEqual(request.inputs.ability_input, { slug: 'example' });
+
+const script = path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wordpress-runtime-task-plan.cjs');
+const result = spawnSync(process.execPath, [
+	script,
+	'--plan-id', 'cli-runtime-task-plan-smoke',
+	'--ability', 'example/validate-artifact',
+	'--ability-input', '{"artifact":"report.json"}',
+	'--dla-url', 'https://dla.example/export/123',
+	'--expected-artifact', 'validation-report',
+	'--timeout-seconds', '60',
+], { encoding: 'utf8' });
+assert.equal(result.status, 0, result.stderr || result.stdout);
+const cliPlan = JSON.parse(result.stdout);
+assert.equal(cliPlan.schema, contract.schemas.plan);
+assert.equal(cliPlan.tasks[0].schema, contract.schemas.request);
+assert.equal(cliPlan.tasks[0].executor.config.runtime_task.input.dla_url, 'https://dla.example/export/123');
+assert.deepEqual(cliPlan.tasks[0].expected_artifacts, ['validation-report']);
+assert.equal(cliPlan.tasks[0].limits.task_timeout_seconds, 60);
+
+process.stdout.write('WordPress runtime task planner smoke passed\n');


### PR DESCRIPTION
## Summary
- Add an extension-owned WordPress runtime task planner that emits generic `homeboy/agent-task-plan/v1` plans with `homeboy/agent-task-request/v1` tasks.
- Add a CLI wrapper for projecting ability, ability input, backend/provider/runtime selection, fanout/concurrency metadata, expected artifacts, timeout, and DLA URL shorthand into the existing Homeboy agent-task contract.
- Export the planner from the WordPress extension and document that Homeboy core only sees generic durable agent-task plans.

## Supersedes
- Replaces the closed wrong-direction Homeboy core PR Extra-Chill/homeboy#5029 by keeping WordPress/Codebox/DLA orchestration in Homeboy Extensions instead of adding `agent_task_wordpress_runtime` or `agent-task wordpress-runtime` to Homeboy core.

## Testing
- `node --check wordpress/lib/wordpress-runtime-task-planner.js && node --check wordpress/scripts/agent/homeboy-wordpress-runtime-task-plan.cjs && node --check wordpress/tests/wordpress-runtime-task-planner-smoke.js`
- `npm run test:agent-task-core-contract-drift && npm run test:wordpress-runtime-task-planner` from `wordpress/`
- `npm run lint:js -- lib/wordpress-runtime-task-planner.js scripts/agent/homeboy-wordpress-runtime-task-plan.cjs --no-warn-ignored` from `wordpress/`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the extension-owned planner, CLI wrapper, tests, docs, and PR description; Chris remains responsible for review and testing.
