### PR TITLE
Project Homeboy agent tool policy into WP Codebox

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -215,8 +215,10 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const agentBundles = firstDefined(inputs.agent_bundles, inputs.agentBundles, config.agent_bundles, config.agentBundles, runtimeOptions.agentBundles, []);
   const structuredArtifacts = firstDefined(inputs.structured_artifacts, inputs.structuredArtifacts, config.structured_artifacts, config.structuredArtifacts, runtimeOptions.structuredArtifacts, []);
   const artifactDeclarations = artifactDeclarationsFromAgentTaskRequest(request, config, inputs, runtimeOptions);
+  const homeboyToolPolicy = homeboyAgentToolPolicy();
   const allowedTools = allowedToolsFromAgentTaskRequest(request, config, inputs, runtimeOptions, defaults);
-  const sandboxToolPolicy = sandboxToolPolicyFromAgentTaskRequest(config, inputs, runtimeOptions, defaults, allowedTools);
+  const sandboxToolPolicy = sandboxToolPolicyFromAgentTaskRequest(config, inputs, runtimeOptions, defaults, allowedTools, homeboyToolPolicy);
+  const sandboxAllowedTools = allowedToolsForSandboxPolicy(allowedTools, sandboxToolPolicy);
   const provider = config.provider || runtimeOptions.provider || defaults.provider || '';
   const model = request.executor.model || config.model || runtimeOptions.model || defaults.model || '';
   const homeboySecretEnvPlan = homeboyAgentTaskSecretEnvPlan();
@@ -250,7 +252,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     goal: request.instructions,
     target,
     workspace_materialization: workspaceMaterialization,
-    allowed_tools: allowedTools || [],
+    allowed_tools: sandboxAllowedTools || [],
     expected_artifacts: request.expected_artifacts || [],
     artifact_declarations: artifactDeclarations,
     policy: request.policy || {},
@@ -276,7 +278,10 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     runtime_stack_mounts: config.runtime_stack_mounts || runtimeOptions.runtimeStackMounts || [],
     runtime_overlay_profiles: config.runtime_overlay_profiles || config.runtimeOverlayProfiles || runtimeOptions.runtimeOverlayProfiles || defaults.runtimeOverlayProfiles || [],
     runtime_overlays: runtimeOverlays,
-    runtime_env: firstDefined(config.runtime_env, config.runtimeEnv, config.wp_codebox_runtime_env, runtimeOptions.runtimeEnv, defaults.runtimeEnv, {}),
+    runtime_env: {
+      ...firstDefined(config.runtime_env, config.runtimeEnv, config.wp_codebox_runtime_env, runtimeOptions.runtimeEnv, defaults.runtimeEnv, {}),
+      ...homeboyAgentToolContractEnv(),
+    },
     runtime_state_mounts: firstDefined(config.runtime_state_mounts, config.runtimeStateMounts, config.wp_codebox_runtime_state_mounts, runtimeOptions.runtimeStateMounts, defaults.runtimeStateMounts, []),
     runtime_config_mounts: firstDefined(config.runtime_config_mounts, config.runtimeConfigMounts, config.wp_codebox_runtime_config_mounts, runtimeOptions.runtimeConfigMounts, defaults.runtimeConfigMounts, []),
     secret_env: explicitSecretEnv.length > 0 ? Array.from(new Set(explicitSecretEnv)) : defaults.secretEnv || [],
@@ -618,12 +623,98 @@ function allowedToolsFromAgentTaskRequest(request, config, inputs, options, defa
   return uniqueStrings([...(defaults.allowedTools || []), ...declared]);
 }
 
-function sandboxToolPolicyFromAgentTaskRequest(config, inputs, options, defaults, allowedTools) {
+function sandboxToolPolicyFromAgentTaskRequest(config, inputs, options, defaults, allowedTools, homeboyToolPolicy) {
   const explicit = firstDefined(inputs.sandbox_tool_policy, inputs.sandboxToolPolicy, config.sandbox_tool_policy, config.sandboxToolPolicy, options.sandboxToolPolicy);
   if (explicit !== undefined) {
     return explicit;
   }
-  return workspaceSandboxToolPolicyWithAllowedTools(defaults.sandboxToolPolicy, allowedTools);
+  const homeboySandboxPolicy = sandboxToolPolicyFromHomeboyAgentToolPolicy(homeboyToolPolicy);
+  return workspaceSandboxToolPolicyWithAllowedTools(homeboySandboxPolicy || defaults.sandboxToolPolicy, allowedTools);
+}
+
+function homeboyAgentToolPolicy() {
+  const policy = parseJsonObject(process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON);
+  if (!policy || policy.schema !== 'homeboy/agent-tool-policy/v1') {
+    return null;
+  }
+  return policy;
+}
+
+function homeboyAgentToolContractEnv() {
+  return Object.fromEntries([
+    'HOMEBOY_AGENT_TOOL_POLICY_JSON',
+    'HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA',
+    'HOMEBOY_AGENT_TOOL_RESULT_SCHEMA',
+    'HOMEBOY_AGENT_TOOL_POLICY_SCHEMA',
+  ].map((name) => [name, process.env[name]]).filter(([, value]) => typeof value === 'string' && value !== ''));
+}
+
+function sandboxToolPolicyFromHomeboyAgentToolPolicy(policy) {
+  const tools = Object.entries(policy?.tools || {})
+    .map(([toolId, rule]) => sandboxToolFromHomeboyToolPolicyRule(toolId, rule, policy))
+    .filter(Boolean);
+  if (tools.length === 0) {
+    return null;
+  }
+  return {
+    schema: 'wp-codebox/sandbox-tool-policy/v1',
+    version: 1,
+    tools,
+    metadata: {
+      source: 'homeboy_agent_tool_policy',
+      homeboy_policy_schema: policy.schema,
+      homeboy_default_location: policy.default_location || 'disabled',
+    },
+  };
+}
+
+function sandboxToolFromHomeboyToolPolicyRule(toolId, rule = {}, policy = {}) {
+  const id = typeof toolId === 'string' ? toolId.trim() : '';
+  if (!id) {
+    return null;
+  }
+  const location = rule.execution_location || policy.default_location || 'disabled';
+  const runnerOwned = location === 'runner';
+  const controlPlaneOwned = location === 'control_plane';
+  return {
+    id,
+    runtime_tool_id: runtimeToolIdFromHomeboyToolId(id),
+    execution_location: runnerOwned ? 'sandbox' : 'parent',
+    transport_visibility: runnerOwned ? 'sandbox' : controlPlaneOwned ? 'parent' : 'hidden',
+    allowed: runnerOwned,
+    runtime: {
+      environment: runnerOwned ? 'runtime_local' : 'control_plane',
+      capability_scope: runnerOwned ? 'runtime_local' : 'control_plane',
+    },
+    metadata: Object.fromEntries(Object.entries({
+      source: 'homeboy_agent_tool_policy',
+      homeboy_execution_location: location,
+      timeout_ms: rule.timeout_ms,
+      reason: rule.reason,
+    }).filter(([, value]) => value !== undefined && value !== '')),
+  };
+}
+
+function runtimeToolIdFromHomeboyToolId(toolId) {
+  return String(toolId || '').replace(/[^A-Za-z0-9_]+/g, '_').replace(/^_+|_+$/g, '') || 'homeboy_tool';
+}
+
+function allowedToolsForSandboxPolicy(allowedTools, sandboxToolPolicy) {
+  if (!Array.isArray(allowedTools) || !sandboxToolPolicy || sandboxToolPolicy.metadata?.source !== 'homeboy_agent_tool_policy') {
+    return allowedTools;
+  }
+  const explicitHomeboyTools = new Map((sandboxToolPolicy.tools || [])
+    .filter((tool) => tool?.metadata?.source === 'homeboy_agent_tool_policy')
+    .flatMap((tool) => [[tool.id, tool], [tool.runtime_tool_id, tool]]));
+  return allowedTools.filter((tool) => {
+    const policyTool = explicitHomeboyTools.get(tool) || explicitHomeboyTools.get(runtimeToolIdFromHomeboyToolId(tool));
+    if (!policyTool) {
+      return true;
+    }
+    return policyTool.allowed === true
+      && policyTool.runtime?.environment === 'runtime_local'
+      && policyTool.runtime?.capability_scope === 'runtime_local';
+  });
 }
 
 function normalizeToolIds(value) {
@@ -654,7 +745,7 @@ function workspaceSandboxToolPolicyWithAllowedTools(basePolicy, allowedTools) {
   if (!basePolicy || typeof basePolicy !== 'object' || !Array.isArray(allowedTools)) {
     return basePolicy;
   }
-  const existingRuntimeToolIds = new Set((basePolicy.tools || []).map((tool) => tool?.runtime_tool_id || tool?.id).filter(Boolean));
+  const existingRuntimeToolIds = new Set((basePolicy.tools || []).flatMap((tool) => [tool?.id, tool?.runtime_tool_id]).filter(Boolean));
   const extraTools = allowedTools
     .filter((tool) => !existingRuntimeToolIds.has(tool))
     .map((tool) => ({

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -29,6 +29,14 @@ const claudeCodeSecretEnv = [
   'AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT',
 ];
 
+function restoreEnv(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
 function secretEnvRequirementForProvider(contract, provider) {
   return contract.secret_env_requirements.find((requirement) => (
     requirement.when.any.some((selector) => selector.path === 'executor.config.provider' && selector.equals === provider)
@@ -155,6 +163,50 @@ assert.equal(
   taskInput.sandbox_tool_policy.tools.some((tool) => tool.id === 'wordpress.read-post'),
   true
 );
+
+const originalToolPolicyEnv = process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON;
+const originalToolRequestSchemaEnv = process.env.HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA;
+const originalToolResultSchemaEnv = process.env.HOMEBOY_AGENT_TOOL_RESULT_SCHEMA;
+const originalToolPolicySchemaEnv = process.env.HOMEBOY_AGENT_TOOL_POLICY_SCHEMA;
+process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON = JSON.stringify({
+  schema: 'homeboy/agent-tool-policy/v1',
+  default_location: 'disabled',
+  tools: {
+    workspace_read: { execution_location: 'runner', reason: 'safe in sandbox' },
+    github_issue_publish: { execution_location: 'control_plane', timeout_ms: 30000, reason: 'host owns GitHub credentials' },
+    github_pull_request_publish: { execution_location: 'disabled', reason: 'not needed in this run' },
+  },
+});
+process.env.HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA = 'homeboy/agent-tool-request/v1';
+process.env.HOMEBOY_AGENT_TOOL_RESULT_SCHEMA = 'homeboy/agent-tool-result/v1';
+process.env.HOMEBOY_AGENT_TOOL_POLICY_SCHEMA = 'homeboy/agent-tool-policy/v1';
+const homeboyToolPolicyTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'homeboy-tool-policy-task-1',
+  executor: { backend: 'codebox', config: { provider: 'openai' } },
+  instructions: 'Run with host-owned GitHub tools.',
+  workspace: { root: workspaceRoot, mode: 'readwrite' },
+  tools: ['workspace_read', 'github_issue_publish', 'github_pull_request_publish'],
+});
+restoreEnv('HOMEBOY_AGENT_TOOL_POLICY_JSON', originalToolPolicyEnv);
+restoreEnv('HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA', originalToolRequestSchemaEnv);
+restoreEnv('HOMEBOY_AGENT_TOOL_RESULT_SCHEMA', originalToolResultSchemaEnv);
+restoreEnv('HOMEBOY_AGENT_TOOL_POLICY_SCHEMA', originalToolPolicySchemaEnv);
+
+assert.equal(homeboyToolPolicyTaskInput.allowed_tools.includes('workspace_read'), true);
+assert.equal(homeboyToolPolicyTaskInput.allowed_tools.includes('github_issue_publish'), false);
+assert.equal(homeboyToolPolicyTaskInput.allowed_tools.includes('github_pull_request_publish'), false);
+assert.equal(homeboyToolPolicyTaskInput.runtime_env.HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA, 'homeboy/agent-tool-request/v1');
+const homeboySandboxTools = Object.fromEntries(homeboyToolPolicyTaskInput.sandbox_tool_policy.tools.map((tool) => [tool.id, tool]));
+assert.equal(homeboyToolPolicyTaskInput.sandbox_tool_policy.metadata.source, 'homeboy_agent_tool_policy');
+assert.equal(homeboySandboxTools.workspace_read.allowed, true);
+assert.equal(homeboySandboxTools.workspace_read.runtime.environment, 'runtime_local');
+assert.equal(homeboySandboxTools.github_issue_publish.allowed, false);
+assert.equal(homeboySandboxTools.github_issue_publish.execution_location, 'parent');
+assert.equal(homeboySandboxTools.github_issue_publish.transport_visibility, 'parent');
+assert.equal(homeboySandboxTools.github_issue_publish.runtime.environment, 'control_plane');
+assert.equal(homeboySandboxTools.github_issue_publish.metadata.timeout_ms, 30000);
+assert.equal(homeboySandboxTools.github_pull_request_publish.transport_visibility, 'hidden');
 
 const customRuntimePolicyTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',


### PR DESCRIPTION
## Summary
- Projects `HOMEBOY_AGENT_TOOL_POLICY_JSON` into WP Codebox `sandbox_tool_policy` entries.
- Marks Homeboy `runner` tools as sandbox-visible and `control_plane`/`disabled` tools as parent/hidden control-plane tools.
- Filters sandbox `allowed_tools` only for explicitly named Homeboy policy tools and forwards the generic Homeboy tool schema env to the runtime.

Follow-up for Extra-Chill/homeboy#5017.

## Tests
- `npm run test:codebox-agent-task-executor-boundary`
- `git diff --check`

Note: `npx eslint --no-ignore ../agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js tests/codebox-agent-task-executor-boundary.test.js` still reports the existing test-file dependency-group/no-console warnings and ignores the runtime file as outside the ESLint base path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the WP Codebox/Homeboy tool policy projection and boundary-test coverage; Chris remains responsible for review and verification.