### PR TITLE
Persist refreshed Codex auth for WP Codebox

### DIFF
--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -148,6 +148,10 @@ function codexOAuthTokenUrl() {
   return process.env.HOMEBOY_WP_CODEBOX_CODEX_TOKEN_URL || CODEX_OAUTH_TOKEN_URL;
 }
 
+function codexAuthPath() {
+  return process.env.HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH || (process.env.HOME ? path.join(process.env.HOME, '.codex', 'auth.json') : '');
+}
+
 function postForm(url, body, timeoutMs = 20000) {
   return new Promise((resolve, reject) => {
     let parsedUrl;
@@ -214,7 +218,7 @@ async function refreshCodexAuthEnv() {
   }
 
   const expiresIn = Number.isFinite(Number(data.expires_in)) ? Number(data.expires_in) : 3600;
-  return Object.fromEntries(Object.entries({
+  const refreshedEnv = Object.fromEntries(Object.entries({
     AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: data.access_token,
     AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: typeof data.refresh_token === 'string' && data.refresh_token !== ''
       ? data.refresh_token
@@ -223,6 +227,38 @@ async function refreshCodexAuthEnv() {
     AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: process.env.AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID,
     AI_PROVIDER_OPENAI_CODEX_FEDRAMP: process.env.AI_PROVIDER_OPENAI_CODEX_FEDRAMP,
   }).filter(([, value]) => value !== undefined && value !== null && value !== ''));
+  persistRefreshedCodexAuth(refreshedEnv);
+  return refreshedEnv;
+}
+
+function persistRefreshedCodexAuth(refreshedEnv) {
+  const authPath = codexAuthPath();
+  if (!authPath || (!process.env.HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH && !fs.existsSync(authPath))) {
+    return;
+  }
+
+  const auth = readJsonIfAvailable(authPath) || {};
+  const next = {
+    ...auth,
+    tokens: {
+      ...(plainObject(auth.tokens) ? auth.tokens : {}),
+      access_token: refreshedEnv.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN,
+      refresh_token: refreshedEnv.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN,
+      expires_at: refreshedEnv.AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT,
+      account_id: refreshedEnv.AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID,
+      fedramp: refreshedEnv.AI_PROVIDER_OPENAI_CODEX_FEDRAMP,
+    },
+  };
+  try {
+    fs.mkdirSync(path.dirname(authPath), { recursive: true, mode: 0o700 });
+    const tempPath = `${authPath}.${process.pid}.tmp`;
+    fs.writeFileSync(tempPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+    fs.renameSync(tempPath, authPath);
+    fs.chmodSync(authPath, 0o600);
+  } catch {
+    // Auth refresh is still valid for this run. A later run will surface stale
+    // credentials if the host cannot persist the rotated refresh token.
+  }
 }
 
 async function codexAuthPreflightEnv(request) {

--- a/wordpress/tests/codebox-codex-auth-preflight-smoke.js
+++ b/wordpress/tests/codebox-codex-auth-preflight-smoke.js
@@ -16,6 +16,16 @@ const wpCodeboxRuntimeExecutor = path.join(
   'agent',
   'homeboy-codebox-agent-task-executor.cjs'
 );
+const wpCodeboxTaskRunner = path.join(
+  __dirname,
+  '..',
+  '..',
+  'agent-runtimes',
+  'wp-codebox',
+  'scripts',
+  'agent',
+  'homeboy-wp-codebox-task-runner.cjs'
+);
 
 const codexSecretEnv = [
   'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
@@ -51,6 +61,33 @@ const server = http.createServer((request, response) => {
   request.resume();
   response.writeHead(401, { 'Content-Type': 'application/json' });
   response.end(JSON.stringify({ error: 'invalid_grant' }));
+});
+server.listen(0, '127.0.0.1', () => {
+  fs.writeFileSync(portPath, String(server.address().port));
+});
+`);
+  const child = spawn(process.execPath, [script, portPath], { stdio: ['ignore', 'ignore', 'pipe'] });
+  const port = waitForFile(portPath);
+  return {
+    url: `http://127.0.0.1:${port}/oauth/token`,
+    stop() {
+      child.kill();
+    },
+  };
+}
+
+function createRotatingOAuthServer() {
+  const script = path.join(root, 'fixture-rotating-codex-oauth-server.js');
+  const portPath = path.join(root, 'fixture-rotating-codex-oauth-port');
+  fs.writeFileSync(script, `#!/usr/bin/env node
+'use strict';
+const fs = require('node:fs');
+const http = require('node:http');
+const portPath = process.argv[2];
+const server = http.createServer((request, response) => {
+  request.resume();
+  response.writeHead(200, { 'Content-Type': 'application/json' });
+  response.end(JSON.stringify({ access_token: 'fresh-access-token-value', refresh_token: 'fresh-refresh-token-value', expires_in: 3600 }));
 });
 server.listen(0, '127.0.0.1', () => {
   fs.writeFileSync(portPath, String(server.address().port));
@@ -110,6 +147,59 @@ try {
   assert.match(outcome.diagnostics[0].data.stderr, /Refresh Codex OAuth credentials/);
   assert(!JSON.stringify(outcome).includes('stale-access-token-value'));
   assert(!JSON.stringify(outcome).includes('stale-refresh-token-value'));
+
+  oauthServer.stop();
+  oauthServer = createRotatingOAuthServer();
+  const authPath = path.join(root, 'codex-auth.json');
+  fs.writeFileSync(authPath, JSON.stringify({
+    tokens: {
+      access_token: 'stale-access-token-value',
+      refresh_token: 'stale-refresh-token-value',
+      expires_at: '4102444800',
+      account_id: 'account-id-value',
+      fedramp: '0',
+    },
+    preserved: true,
+  }, null, 2));
+
+  const refreshResult = spawnSync(process.execPath, [wpCodeboxTaskRunner], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      schema: 'wp-codebox/task-input/v1',
+      version: 1,
+      goal: 'Refresh Codex auth before launching WP Codebox.',
+      target: {},
+      allowed_tools: [],
+      expected_artifacts: [],
+      structured_artifacts: [],
+      agent_bundles: [],
+      sandbox_tool_policy: {},
+      policy: {},
+      context: {},
+      provider: 'codex',
+      model: 'gpt-5.5',
+      secret_env: codexSecretEnv,
+      wp_codebox_bin: '/bin/false',
+    }),
+    env: {
+      ...process.env,
+      AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'stale-access-token-value',
+      AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'stale-refresh-token-value',
+      AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '4102444800',
+      AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'account-id-value',
+      AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
+      HOMEBOY_WP_CODEBOX_CODEX_TOKEN_URL: oauthServer.url,
+      HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH: authPath,
+    },
+  });
+  assert.notEqual(refreshResult.status, 0, 'fake WP Codebox command should fail after auth preflight');
+  const persisted = JSON.parse(fs.readFileSync(authPath, 'utf8'));
+  assert.equal(persisted.preserved, true);
+  assert.equal(persisted.tokens.access_token, 'fresh-access-token-value');
+  assert.equal(persisted.tokens.refresh_token, 'fresh-refresh-token-value');
+  assert.equal(persisted.tokens.account_id, 'account-id-value');
+  assert.equal(persisted.tokens.expires_at.length > 0, true);
+  assert(!`${refreshResult.stdout}${refreshResult.stderr}`.includes('fresh-refresh-token-value'));
 } finally {
   if (oauthServer) {
     oauthServer.stop();


### PR DESCRIPTION
## Summary
- Persists successfully refreshed Codex OAuth credentials back to the configured Codex auth file.
- Uses an atomic temp-file replace and `0600` permissions.
- Preserves existing auth-file metadata while updating rotated access/refresh tokens.
- Extends the Codex auth preflight smoke to cover both stale-token 401 redaction and successful refresh persistence.

## Why
WP Codebox refreshed Codex credentials into the child process env only. If the OAuth response rotates the refresh token, the next run still reads the old refresh token from `~/.codex/auth.json` and eventually fails with HTTP 401.

## Tests
- `node tests/codebox-codex-auth-preflight-smoke.js`
- `npm run test:codebox-agent-task-executor-boundary`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the recurring Codex OAuth refresh-token persistence gap and drafted the WP Codebox runtime fix and smoke coverage; Chris remains responsible for review and verification.