### PR TITLE
Surface benchmark artifact viewer URLs

### DIFF
--- a/wordpress/lib/benchmark-matrix-report.js
+++ b/wordpress/lib/benchmark-matrix-report.js
@@ -104,6 +104,24 @@ function extractArtifactReferences(source) {
 	return artifacts;
 }
 
+function extractArtifactViewerReferences(artifacts) {
+	return asArray(artifacts)
+		.map((artifact) => {
+			const viewer = artifact?.viewer;
+			const url = viewer?.url || artifact?.viewer_url || artifact?.viewerUrl;
+			if (typeof url !== 'string' || url.trim() === '') {
+				return null;
+			}
+			return {
+				name: artifact.name || artifact.label || artifact.kind || 'viewer',
+				kind: viewer?.kind || artifact.kind || null,
+				url,
+				public_artifact_url: viewer?.public_artifact_url || viewer?.['public-artifact-url'] || artifact.url || null,
+			};
+		})
+		.filter(Boolean);
+}
+
 function stableJson(value) {
 	return JSON.stringify(value || {});
 }
@@ -336,6 +354,7 @@ function rankSlowPathCells(rows, options = {}) {
 				run_url: row.run_url,
 				artifact_path: row.artifact_path,
 				artifacts: row.artifacts || [],
+				viewers: extractArtifactViewerReferences(row.artifacts || []),
 				metric_values: {},
 				metrics: [],
 				status: 'ok',
@@ -390,8 +409,8 @@ function renderBenchmarkMatrixMarkdownReport(summaryOrRows, options = {}) {
 		'',
 		`Cells ranked: **${summary.cell_count}**`,
 		'',
-		'| Rank | Status | Scenario | Dimensions | Top metrics | Run | Artifact |',
-		'|---:|---|---|---|---|---|---|',
+		'| Rank | Status | Scenario | Dimensions | Top metrics | Run | Viewer | Artifact |',
+		'|---:|---|---|---|---|---|---|---|',
 	];
 	for (const cell of summary.ranked_cells) {
 		const metrics = cell.metrics
@@ -401,10 +420,13 @@ function renderBenchmarkMatrixMarkdownReport(summaryOrRows, options = {}) {
 			.map((row) => `${row.per_unit_value === null ? row.metric_label : row.per_unit_label}: ${formatValue(row.per_unit_value ?? row.value)}${row.percent_delta === null ? '' : ` (${formatValue(row.percent_delta, '%')})`}`)
 			.join('<br>');
 		const run = cell.run_url ? `[${cell.run_id || 'run'}](${cell.run_url})` : (cell.run_id || '');
-		lines.push(`| ${cell.rank} | ${cell.status} | ${markdownEscape(cell.label || cell.scenario_id)} | ${markdownEscape(formatDimensions(cell.dimensions))} | ${markdownEscape(metrics)} | ${run} | ${markdownEscape(cell.artifact_path || '')} |`);
+		const viewers = asArray(cell.viewers)
+			.map((viewer) => `[${markdownEscape(viewer.name || viewer.kind || 'viewer')}](${viewer.url})`)
+			.join('<br>');
+		lines.push(`| ${cell.rank} | ${cell.status} | ${markdownEscape(cell.label || cell.scenario_id)} | ${markdownEscape(formatDimensions(cell.dimensions))} | ${markdownEscape(metrics)} | ${run} | ${viewers} | ${markdownEscape(cell.artifact_path || '')} |`);
 	}
 	if (summary.ranked_cells.length === 0) {
-		lines.push('| n/a | ok | n/a | n/a | n/a | n/a | n/a |');
+		lines.push('| n/a | ok | n/a | n/a | n/a | n/a | n/a | n/a |');
 	}
 	return `${lines.join('\n')}\n`;
 }

--- a/wordpress/tests/benchmark-matrix-report-smoke.js
+++ b/wordpress/tests/benchmark-matrix-report-smoke.js
@@ -55,6 +55,17 @@ try {
 					id: 'small-catalog',
 					label: 'Small catalog',
 					metadata: { dimensions: { shape: 'small' } },
+					artifacts: {
+						'blueprint.after': {
+							kind: 'wordpress-playground-blueprint',
+							path: 'artifacts/blueprint.after.json',
+							viewer: {
+								kind: 'wordpress-playground-blueprint',
+								url: 'https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fexample.test%2Fartifacts%2Fblueprint.after.json',
+								public_artifact_url: 'https://example.test/artifacts/blueprint.after.json',
+							},
+						},
+					},
 					metrics: { duration_ms: 120, queries: 60, items: 10, guardrail_failures: 1 },
 				},
 				{
@@ -99,12 +110,21 @@ try {
 	const summary = summarizeBenchmarkMatrixReport(metricRows, { rankMetrics: ['queries', 'duration_ms'] });
 	assert.equal(summary.schema, 'homeboy/wordpress-benchmark-slow-path-matrix/v1');
 	assert.equal(summary.ranked_cells[0].run_url, 'https://example.test/runs/candidate-run');
+	assert.deepEqual(summary.ranked_cells[0].viewers, [
+		{
+			name: 'blueprint.after',
+			kind: 'wordpress-playground-blueprint',
+			url: 'https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fexample.test%2Fartifacts%2Fblueprint.after.json',
+			public_artifact_url: 'https://example.test/artifacts/blueprint.after.json',
+		},
+	]);
 
 	const markdown = renderBenchmarkMatrixMarkdownReport(summary);
 	assert.match(markdown, /# WordPress Benchmark Slow-Path Matrix/);
 	assert.match(markdown, /Small catalog/);
 	assert.match(markdown, /Queries\/item: 6/);
 	assert.match(markdown, /\[candidate-run\]\(https:\/\/example\.test\/runs\/candidate-run\)/);
+	assert.match(markdown, /\[blueprint\.after\]\(https:\/\/playground\.wordpress\.net\/\?blueprint-url=https%3A%2F%2Fexample\.test%2Fartifacts%2Fblueprint\.after\.json\)/);
 
 	console.log('WordPress benchmark matrix report smoke passed.');
 } finally {


### PR DESCRIPTION
## Summary
- Extract generic artifact `viewer.url` values into benchmark matrix ranked cells.
- Add a `Viewer` column to the markdown slow-path matrix report.
- Keep the helper domain-neutral so any benchmark producer can attach reviewer-clickable artifact viewers.

## Verification
- `node wordpress/tests/benchmark-matrix-report-smoke.js`
- `bash wordpress/scripts/bench/bench-results-artifacts-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafting the report helper/test changes; Chris remains responsible for review and acceptance.
