### PR TITLE
Add delegated run contract scaffold

### DIFF
--- a/agent-runtimes/wp-codebox/README.md
+++ b/agent-runtimes/wp-codebox/README.md
@@ -19,3 +19,18 @@ The JavaScript executor consumes these manifest fields instead of owning product
 policy in code. Existing Data Machine and GitHub-oriented defaults remain declared
 there for compatibility, while alternate callers can supply their own generic
 manifest values without adding new runtime-specific branches.
+
+## Delegated Run Preparation
+
+`lib/delegated-run-contract.js` defines neutral `homeboy/delegated-run-request/v1`
+and `homeboy/delegated-run-result/v1` normalization helpers for a future generic
+delegated command or agent-run capability. The helpers intentionally use only
+backend-neutral fields such as `execution.type`, `execution.argv`,
+`execution.agent`, `input`, `workspace`, `limits`, `artifacts`, `diagnostics`, and
+`metadata`.
+
+The runtime manifest does not advertise a delegated-run capability yet. The
+current executable path still targets the existing task-input runner contract, so
+Homeboy should not select this runtime for generic delegated command execution
+until the substrate accepts the neutral request shape and returns the neutral
+result shape directly.

--- a/agent-runtimes/wp-codebox/index.js
+++ b/agent-runtimes/wp-codebox/index.js
@@ -2,5 +2,6 @@
 
 module.exports = {
 	...require('./lib/codebox-agent-task-executor'),
+	...require('./lib/delegated-run-contract'),
 	...require('./lib/provider-outcome-normalizer'),
 };

--- a/agent-runtimes/wp-codebox/lib/delegated-run-contract.js
+++ b/agent-runtimes/wp-codebox/lib/delegated-run-contract.js
@@ -1,0 +1,202 @@
+'use strict';
+
+const { AGENT_TASK_REQUEST_SCHEMA } = require('../../lib/agent-task-provider-contract');
+
+const DELEGATED_RUN_REQUEST_SCHEMA = 'homeboy/delegated-run-request/v1';
+const DELEGATED_RUN_RESULT_SCHEMA = 'homeboy/delegated-run-result/v1';
+const DELEGATED_RUN_TYPES = ['command', 'agent_run'];
+const DELEGATED_RUN_STATUSES = ['succeeded', 'failed', 'timeout', 'cancelled', 'provider_error'];
+
+function normalizeDelegatedRunRequest(request, options = {}) {
+  assertAgentTaskRequestShape(request);
+  const config = request.executor?.config || {};
+  const inputs = request.inputs || {};
+  const declared = firstObject(
+    options.delegated_run,
+    options.delegatedRun,
+    inputs.delegated_run,
+    inputs.delegatedRun,
+    config.delegated_run,
+    config.delegatedRun
+  );
+  if (!declared) {
+    return null;
+  }
+
+  const type = normalizeType(declared.type || declared.kind || declared.execution_type || declared.executionType);
+  const execution = normalizeExecution(type, declared, request);
+  return cleanObject({
+    schema: DELEGATED_RUN_REQUEST_SCHEMA,
+    id: declared.id || request.task_id,
+    task_id: request.task_id,
+    execution,
+    instructions: declared.instructions || request.instructions || '',
+    input: plainObject(declared.input) ? declared.input : {},
+    workspace: plainObject(declared.workspace) ? declared.workspace : plainObject(request.workspace) ? request.workspace : {},
+    limits: plainObject(declared.limits) ? declared.limits : plainObject(request.limits) ? request.limits : {},
+    artifacts: Array.isArray(declared.artifacts) ? declared.artifacts : Array.isArray(request.expected_artifacts) ? request.expected_artifacts : [],
+    metadata: sanitizeMetadata({
+      ...(plainObject(declared.metadata) ? declared.metadata : {}),
+      source_schema: request.schema,
+      executor_backend: request.executor?.backend,
+    }),
+  });
+}
+
+function normalizeDelegatedRunResult(result = {}, options = {}) {
+  const raw = plainObject(result) ? result : {};
+  const status = normalizeStatus(options.status || raw.status, options.exitStatus ?? 0);
+  return cleanObject({
+    schema: DELEGATED_RUN_RESULT_SCHEMA,
+    id: raw.id || options.id || raw.task_id || options.task_id || '',
+    task_id: raw.task_id || options.task_id || '',
+    status,
+    summary: raw.summary || raw.message || defaultSummary(status),
+    outputs: plainObject(raw.outputs) ? raw.outputs : {},
+    artifacts: normalizeArtifacts(raw.artifacts),
+    diagnostics: normalizeDiagnostics(raw.diagnostics),
+    metadata: sanitizeMetadata(plainObject(raw.metadata) ? raw.metadata : {}),
+  });
+}
+
+function assertAgentTaskRequestShape(request) {
+  if (!request || typeof request !== 'object' || Array.isArray(request)) {
+    throw new TypeError('Delegated run normalization requires an agent task request object.');
+  }
+  if (request.schema !== AGENT_TASK_REQUEST_SCHEMA) {
+    throw new Error(`Delegated run normalization requires schema ${AGENT_TASK_REQUEST_SCHEMA}.`);
+  }
+  if (!request.task_id) {
+    throw new Error('Delegated run normalization requires task_id.');
+  }
+}
+
+function normalizeType(value) {
+  const type = typeof value === 'string' ? value.trim() : '';
+  if (!DELEGATED_RUN_TYPES.includes(type)) {
+    throw new Error(`Delegated run type must be one of: ${DELEGATED_RUN_TYPES.join(', ')}.`);
+  }
+  return type;
+}
+
+function normalizeExecution(type, declared, request) {
+  if (type === 'command') {
+    const argv = normalizeArgv(declared.argv || declared.command);
+    if (argv.length === 0) {
+      throw new Error('Delegated command runs require command or argv.');
+    }
+    return cleanObject({
+      type,
+      argv,
+      cwd: stringValue(declared.cwd),
+      env_names: envNames(declared.env),
+    });
+  }
+
+  const agent = stringValue(declared.agent || request.executor?.agent);
+  const instructions = stringValue(declared.instructions || request.instructions);
+  if (!agent && !instructions) {
+    throw new Error('Delegated agent runs require agent or instructions.');
+  }
+  return cleanObject({
+    type,
+    agent,
+    instructions,
+    tools: normalizeList(declared.tools || request.tools),
+  });
+}
+
+function normalizeArgv(value) {
+  if (Array.isArray(value)) {
+    return value.map(stringValue).filter(Boolean);
+  }
+  const command = stringValue(value);
+  return command ? [command] : [];
+}
+
+function normalizeStatus(status, exitStatus) {
+  if (DELEGATED_RUN_STATUSES.includes(status)) {
+    return status;
+  }
+  if (status === 'completed') {
+    return 'succeeded';
+  }
+  if (status === 'timed_out') {
+    return 'timeout';
+  }
+  return exitStatus === 0 ? 'succeeded' : 'failed';
+}
+
+function normalizeArtifacts(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(plainObject).map((artifact) => cleanObject({
+    id: artifact.id || artifact.name || artifact.path || artifact.url,
+    kind: artifact.kind || artifact.type || 'delegated-run-artifact',
+    name: artifact.name,
+    path: artifact.path,
+    url: artifact.url,
+    metadata: sanitizeMetadata(plainObject(artifact.metadata) ? artifact.metadata : {}),
+  }));
+}
+
+function normalizeDiagnostics(value) {
+  return (Array.isArray(value) ? value : []).filter(Boolean).map((diagnostic) => {
+    if (typeof diagnostic === 'string') {
+      return { class: 'delegated_run', message: diagnostic, data: {} };
+    }
+    return cleanObject({
+      class: diagnostic.class || diagnostic.kind || diagnostic.code || 'delegated_run',
+      message: diagnostic.message || String(diagnostic),
+      data: sanitizeMetadata(plainObject(diagnostic.data) ? diagnostic.data : {}),
+    });
+  });
+}
+
+function sanitizeMetadata(value) {
+  if (!plainObject(value)) {
+    return {};
+  }
+  return Object.fromEntries(Object.entries(value).filter(([key]) => !/secret|token|password|credential/i.test(key)));
+}
+
+function envNames(value) {
+  if (!plainObject(value)) {
+    return [];
+  }
+  return Object.keys(value).map(stringValue).filter(Boolean).sort();
+}
+
+function firstObject(...values) {
+  return values.find(plainObject) || null;
+}
+
+function normalizeList(value) {
+  return (Array.isArray(value) ? value : []).map(stringValue).filter(Boolean);
+}
+
+function stringValue(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function plainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cleanObject(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined && entry !== ''));
+}
+
+function defaultSummary(status) {
+  return status === 'succeeded' ? 'Delegated run succeeded.' : 'Delegated run failed.';
+}
+
+module.exports = {
+  DELEGATED_RUN_REQUEST_SCHEMA,
+  DELEGATED_RUN_RESULT_SCHEMA,
+  DELEGATED_RUN_STATUSES,
+  DELEGATED_RUN_TYPES,
+  normalizeDelegatedRunRequest,
+  normalizeDelegatedRunResult,
+};

--- a/agent-runtimes/wp-codebox/package.json
+++ b/agent-runtimes/wp-codebox/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./index.js",
     "./codebox-agent-task-executor": "./lib/codebox-agent-task-executor.js",
+    "./delegated-run-contract": "./lib/delegated-run-contract.js",
     "./provider-outcome-normalizer": "./lib/provider-outcome-normalizer.js"
   },
   "bin": {

--- a/tests/codebox-delegated-run-normalizer-smoke.mjs
+++ b/tests/codebox-delegated-run-normalizer-smoke.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+	DELEGATED_RUN_REQUEST_SCHEMA,
+	DELEGATED_RUN_RESULT_SCHEMA,
+	normalizeDelegatedRunRequest,
+	normalizeDelegatedRunResult,
+} = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox'));
+
+const commandRequest = normalizeDelegatedRunRequest({
+	schema: 'homeboy/agent-task-request/v1',
+	task_id: 'delegated-command-smoke',
+	executor: {
+		backend: 'codebox',
+		config: {
+			delegated_run: {
+				type: 'command',
+				argv: ['npm', 'test'],
+				cwd: 'workspace',
+				env: { NODE_ENV: 'test' },
+				metadata: { visible: true, secret_token: 'must-not-leak' },
+			},
+		},
+	},
+	instructions: 'Run the requested command.',
+	workspace: { root: '/workspace/project' },
+});
+
+assert.equal(commandRequest.schema, DELEGATED_RUN_REQUEST_SCHEMA);
+assert.equal(commandRequest.id, 'delegated-command-smoke');
+assert.deepEqual(commandRequest.execution, {
+	type: 'command',
+	argv: ['npm', 'test'],
+	cwd: 'workspace',
+	env_names: ['NODE_ENV'],
+});
+assert.equal(commandRequest.metadata.visible, true);
+assert.equal(Object.hasOwn(commandRequest.metadata, 'secret_token'), false);
+
+const agentRequest = normalizeDelegatedRunRequest({
+	schema: 'homeboy/agent-task-request/v1',
+	task_id: 'delegated-agent-smoke',
+	executor: { backend: 'codebox' },
+	instructions: 'Inspect the workspace and report findings.',
+	tools: ['workspace_read'],
+	inputs: {
+		delegatedRun: {
+			type: 'agent_run',
+			agent: 'reviewer',
+			input: { scope: 'changed-files' },
+		},
+	},
+});
+
+assert.equal(agentRequest.execution.type, 'agent_run');
+assert.equal(agentRequest.execution.agent, 'reviewer');
+assert.equal(agentRequest.execution.instructions, 'Inspect the workspace and report findings.');
+assert.deepEqual(agentRequest.execution.tools, ['workspace_read']);
+assert.deepEqual(agentRequest.input, { scope: 'changed-files' });
+
+const result = normalizeDelegatedRunResult({
+	task_id: 'delegated-command-smoke',
+	status: 'completed',
+	outputs: { changed: false },
+	artifacts: [{ path: '/tmp/run.json', metadata: { token: 'must-not-leak', visible: true } }],
+	diagnostics: ['finished'],
+	metadata: { credential: 'must-not-leak', visible: true },
+});
+
+assert.equal(result.schema, DELEGATED_RUN_RESULT_SCHEMA);
+assert.equal(result.status, 'succeeded');
+assert.deepEqual(result.outputs, { changed: false });
+assert.equal(result.artifacts[0].kind, 'delegated-run-artifact');
+assert.equal(result.artifacts[0].metadata.visible, true);
+assert.equal(Object.hasOwn(result.artifacts[0].metadata, 'token'), false);
+assert.equal(result.diagnostics[0].class, 'delegated_run');
+assert.equal(Object.hasOwn(result.metadata, 'credential'), false);
+
+assert.equal(normalizeDelegatedRunRequest({
+	schema: 'homeboy/agent-task-request/v1',
+	task_id: 'no-delegated-run',
+	executor: { backend: 'codebox' },
+	instructions: 'No delegated run requested.',
+}), null);
+
+console.log('codebox delegated run normalizer smoke passed');


### PR DESCRIPTION
## Summary
- add neutral delegated-run request/result normalization helpers
- export the contract from the Codebox runtime package
- document that no delegated-run capability is advertised until the substrate accepts the generic shape

## Verification
- `node tests/codebox-delegated-run-normalizer-smoke.mjs`
- `node tests/wp-codebox-agent-runtime-command-contract-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node tests/agent-runtime-contract-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the delegated-run normalization scaffold and smoke coverage; Chris remains responsible for review and testing.