### PR TITLE
fix(wp-codebox): preserve provider failure outcomes

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -1441,7 +1441,7 @@ function agentBundleConfigFromAgentTaskRequest(request, config, inputs) {
   return Object.fromEntries(Object.entries(bundleConfig).filter(([, value]) => value !== undefined && value !== ''));
 }
 
-function normalizeStatus(result) {
+function normalizeStatus(result, exitStatus = 0) {
   if (recipeRunFailedPhase(recipeRunFromResult(result))) {
     return 'failed';
   }
@@ -1449,6 +1449,21 @@ function normalizeStatus(result) {
     return 'failed';
   }
   if (agentRuntimeFailure(result)) {
+    return 'failed';
+  }
+  if (result?.status === 'failed' || result?.status === 'provider_error' || result?.status === 'timeout' || result?.status === 'unable_to_remediate') {
+    return result.status;
+  }
+  if (result?.unable_to_remediate) {
+    return 'unable_to_remediate';
+  }
+  if (result?.timeout) {
+    return 'timeout';
+  }
+  if (result?.provider_error) {
+    return 'provider_error';
+  }
+  if ((exitStatus ?? 0) !== 0) {
     return 'failed';
   }
   if (AGENT_TASK_OUTCOME_STATUSES.includes(result?.status)) {
@@ -1465,15 +1480,6 @@ function normalizeStatus(result) {
   }
   if (result?.outcome === 'no_op' || result?.no_op) {
     return 'no_op';
-  }
-  if (result?.unable_to_remediate) {
-    return 'unable_to_remediate';
-  }
-  if (result?.timeout) {
-    return 'timeout';
-  }
-  if (result?.provider_error) {
-    return 'provider_error';
   }
   return result?.success === true ? 'succeeded' : 'failed';
 }

--- a/agent-runtimes/wp-codebox/lib/provider-outcome-normalizer.js
+++ b/agent-runtimes/wp-codebox/lib/provider-outcome-normalizer.js
@@ -34,10 +34,7 @@ function normalizeProviderTaskOutcome(request, result = {}, options = {}) {
 }
 
 function normalizeProviderStatus(result = {}, exitStatus = 0) {
-  if (result.status === 'completed') {
-    return result.success === false ? 'failed' : 'succeeded';
-  }
-  if (result.status === 'succeeded' || result.status === 'failed' || result.status === 'provider_error' || result.status === 'timeout' || result.status === 'no_op' || result.status === 'unable_to_remediate') {
+  if (result.status === 'failed' || result.status === 'provider_error' || result.status === 'timeout' || result.status === 'unable_to_remediate') {
     return result.status;
   }
   if (result.provider_error) {
@@ -49,14 +46,20 @@ function normalizeProviderStatus(result = {}, exitStatus = 0) {
   if (result.unable_to_remediate) {
     return 'unable_to_remediate';
   }
+  if (result.success === false || exitStatus !== 0) {
+    return 'failed';
+  }
+  if (result.status === 'completed') {
+    return 'succeeded';
+  }
+  if (result.status === 'succeeded' || result.status === 'no_op') {
+    return result.status;
+  }
   if (result.outcome === 'no_op' || result.no_op) {
     return 'no_op';
   }
   if (result.success === true) {
     return 'succeeded';
-  }
-  if (result.success === false || exitStatus !== 0) {
-    return 'failed';
   }
   return 'succeeded';
 }

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -97,6 +97,25 @@ process.stdout.write(JSON.stringify({
   return { fixture, capture };
 }
 
+function writeCompletedJsonFailingTaskRunner(root) {
+  const fixture = path.join(root, 'completed-json-failing-task-runner.cjs');
+  fs.writeFileSync(fixture, `#!/usr/bin/env node
+'use strict';
+process.stdout.write(JSON.stringify({
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  summary: 'Semantic output was produced before provider exit failure.',
+  outputs: { issue_url: 'https://github.com/example/repo/issues/456' },
+  artifacts: [{ id: 'semantic-artifact', kind: 'codebox-patch', path: '/tmp/semantic.patch' }],
+  session: { id: 'sandbox-session-failed-exit', status: 'completed' }
+}));
+process.exit(7);
+`);
+  fs.chmodSync(fixture, 0o755);
+  return fixture;
+}
+
 function writeHangingTaskRunner(root) {
   const fixture = path.join(root, 'hanging-task-runner.cjs');
   fs.writeFileSync(fixture, `#!/usr/bin/env node
@@ -1513,9 +1532,9 @@ const normalizedCompletedOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   },
   session: { id: 'sandbox-session-1', status: 'completed' },
 }, { exitStatus: 1 });
-assert.equal(normalizedCompletedOutcome.status, 'succeeded');
+assert.equal(normalizedCompletedOutcome.status, 'failed');
 assert.equal(normalizedCompletedOutcome.outputs.issue_number, 123);
-assert.equal(normalizedCompletedOutcome.failure_classification, undefined);
+assert.equal(normalizedCompletedOutcome.failure_classification, 'execution_failed');
 
 const completedFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: false,
@@ -2220,6 +2239,23 @@ try {
   assert.equal(normalizedOutcome.artifacts.some((artifact) => artifact.kind === 'recipe-probe-result' && artifact.path === '/tmp/fixture-normalized/recipe-probe.json'), true);
   assert.equal(normalizedOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'fixture.normalizer'), true);
   assert.equal(normalizedOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'fixture.recipe_normalizer'), true);
+
+  const failingCompletedRunner = writeCompletedJsonFailingTaskRunner(root);
+  const failingCompletedResult = spawnSync(process.execPath, [
+    wpCodeboxRuntimeExecutor,
+    '--task-runner',
+    failingCompletedRunner,
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(request),
+    env: fixtureEnv({ HOMEBOY_WP_CODEBOX_CORE_MODULE: fixtureCodeboxCoreModule }),
+  });
+  assert.equal(failingCompletedResult.status, 1, failingCompletedResult.stderr || failingCompletedResult.stdout);
+  const failingCompletedOutcome = JSON.parse(failingCompletedResult.stdout);
+  assert.equal(failingCompletedOutcome.status, 'failed');
+  assert.equal(failingCompletedOutcome.failure_classification, 'execution_failed');
+  assert.equal(failingCompletedOutcome.outputs.issue_url, 'https://github.com/example/repo/issues/456');
+  assert.equal(failingCompletedOutcome.artifacts.some((artifact) => artifact.path === '/tmp/semantic.patch'), true);
 
   const captured = JSON.parse(fs.readFileSync(capture, 'utf8'));
   assert.equal(captured.request.schema, 'wp-codebox/task-input/v1');

--- a/wordpress/tests/provider-outcome-normalizer.test.js
+++ b/wordpress/tests/provider-outcome-normalizer.test.js
@@ -32,17 +32,20 @@ assert.equal(legacyProviderError.diagnostics[0].class, 'provider.auth');
 assert.equal(legacyProviderError.metadata.provider, 'example.provider');
 assert.equal(legacyProviderError.metadata.integration_contract, 'example/provider-task/v1');
 
-const completedDespiteNonZeroExit = normalizeProviderTaskOutcome(request, {
+const completedWithNonZeroExit = normalizeProviderTaskOutcome(request, {
   success: true,
   status: 'completed',
   outputs: { issue_url: 'https://github.com/example/repo/issues/12' },
   evidence_refs: [{ kind: 'issue', uri: 'https://github.com/example/repo/issues/12', label: 'Issue' }],
 }, { exitStatus: 1 });
 
-assert.equal(completedDespiteNonZeroExit.status, 'succeeded');
-assert.equal(completedDespiteNonZeroExit.failure_classification, undefined);
-assert.equal(completedDespiteNonZeroExit.outputs.issue_url, 'https://github.com/example/repo/issues/12');
-assert.equal(completedDespiteNonZeroExit.evidence_refs[0].kind, 'issue');
+assert.equal(completedWithNonZeroExit.status, 'failed');
+assert.equal(completedWithNonZeroExit.failure_classification, 'execution_failed');
+assert.equal(completedWithNonZeroExit.outputs.issue_url, 'https://github.com/example/repo/issues/12');
+assert.equal(completedWithNonZeroExit.evidence_refs[0].kind, 'issue');
+
+assert.equal(normalizeProviderStatus({ success: true, status: 'completed' }, 1), 'failed');
+assert.equal(normalizeProviderStatus({ success: true, status: 'succeeded' }, 1), 'failed');
 
 const normalizedRuntimeFailure = normalizeProviderTaskOutcome(request, {
   success: false,


### PR DESCRIPTION
## Summary
- Preserve upstream WP Codebox failure/timeout/provider-error statuses before local success normalization.
- Treat non-zero provider/task-runner exits as failed even when semantic outputs, artifacts, or completed JSON exist.
- Keep semantic outputs and artifacts attached as evidence instead of allowing them to promote the outcome to succeeded.

## Tests
- `node wordpress/tests/provider-outcome-normalizer.test.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the minimal consumer-side WP Codebox outcome normalization fix and targeted Node test updates; Chris remains responsible for review and validation.