### PR TITLE
fix(wp-codebox): normalize agent task outcomes

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -23,7 +23,7 @@ const {
   providerDefaultsContract,
 } = require('../../lib/agent-task-provider-contract');
 const {
-  normalizeProviderTaskOutcome,
+  normalizeAgentTaskOutcome,
   providerFailureClassification,
 } = require('./provider-outcome-normalizer');
 
@@ -2442,7 +2442,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   const recipeFailedPhase = recipeSummary?.failed_phase || recipeSummary?.metadata?.failure_phase || recipeRunFailedPhase(recipeRun);
   const runtimeFailureDiagnostic = agentRuntimeFailureDiagnostic(result);
   const providerDiagnostic = providerNotRegisteredDiagnostic(request, result);
-  const outcome = normalizeProviderTaskOutcome(request, result, {
+  const outcome = normalizeAgentTaskOutcome(request, result, {
     schema: AGENT_TASK_OUTCOME_SCHEMA,
     provider: 'wordpress.codebox-agent-task-executor',
     providerLabel: 'WP Codebox agent',

--- a/agent-runtimes/wp-codebox/lib/provider-outcome-normalizer.js
+++ b/agent-runtimes/wp-codebox/lib/provider-outcome-normalizer.js
@@ -2,15 +2,17 @@
 
 const DEFAULT_OUTCOME_SCHEMA = 'homeboy/agent-task-outcome/v1';
 
-function normalizeProviderTaskOutcome(request, result = {}, options = {}) {
+const TERMINAL_FAILURE_STATUSES = ['failed', 'provider_error', 'timeout', 'unable_to_remediate'];
+
+function normalizeAgentTaskOutcome(request, result = {}, options = {}) {
   if (!request || typeof request !== 'object' || Array.isArray(request)) {
-    throw new TypeError('normalizeProviderTaskOutcome requires a request object.');
+    throw new TypeError('normalizeAgentTaskOutcome requires a request object.');
   }
   if (!request.task_id) {
-    throw new Error('normalizeProviderTaskOutcome requires request.task_id.');
+    throw new Error('normalizeAgentTaskOutcome requires request.task_id.');
   }
 
-  const status = options.status || normalizeProviderStatus(result, options.exitStatus ?? 0);
+  const status = normalizeAgentTaskStatus(result, options);
   const output = {
     schema: options.schema || DEFAULT_OUTCOME_SCHEMA,
     task_id: request.task_id,
@@ -33,8 +35,41 @@ function normalizeProviderTaskOutcome(request, result = {}, options = {}) {
   return output;
 }
 
+function normalizeProviderTaskOutcome(request, result = {}, options = {}) {
+  return normalizeAgentTaskOutcome(request, result, options);
+}
+
+function normalizeAgentTaskStatus(result = {}, options = {}) {
+  const exitStatus = options.exitStatus ?? 0;
+  const explicitStatus = options.status;
+  const resultStatus = result && typeof result === 'object' ? result.status : undefined;
+
+  if (TERMINAL_FAILURE_STATUSES.includes(resultStatus)) {
+    return resultStatus;
+  }
+  if (result?.provider_error) {
+    return 'provider_error';
+  }
+  if (result?.timeout) {
+    return 'timeout';
+  }
+  if (result?.unable_to_remediate) {
+    return 'unable_to_remediate';
+  }
+  if (result?.success === false || exitStatus !== 0) {
+    return 'failed';
+  }
+  if (TERMINAL_FAILURE_STATUSES.includes(explicitStatus)) {
+    return explicitStatus;
+  }
+  if (explicitStatus) {
+    return explicitStatus;
+  }
+  return normalizeProviderStatus(result, exitStatus);
+}
+
 function normalizeProviderStatus(result = {}, exitStatus = 0) {
-  if (result.status === 'failed' || result.status === 'provider_error' || result.status === 'timeout' || result.status === 'unable_to_remediate') {
+  if (TERMINAL_FAILURE_STATUSES.includes(result.status)) {
     return result.status;
   }
   if (result.provider_error) {
@@ -61,7 +96,7 @@ function normalizeProviderStatus(result = {}, exitStatus = 0) {
   if (result.success === true) {
     return 'succeeded';
   }
-  return 'succeeded';
+  return Object.keys(result || {}).length > 0 ? 'succeeded' : 'failed';
 }
 
 function providerFailureClassification(classification, status) {
@@ -151,6 +186,8 @@ function plainObject(value) {
 }
 
 module.exports = {
+  normalizeAgentTaskOutcome,
+  normalizeAgentTaskStatus,
   normalizeProviderTaskOutcome,
   normalizeProviderStatus,
   providerFailureClassification,

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1387,7 +1387,6 @@ assert.equal(upstreamRunnerOutcome.artifacts[0].kind, 'codebox-artifact-director
 assert.equal(upstreamRunnerOutcome.artifacts[0].path, '/tmp/wp-codebox-artifacts');
 
 const failedUpstreamRunnerOutcome = agentTaskOutcomeFromCodeboxResult(request, {
-  success: false,
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'failed',
   session: { id: 'sandbox-session-1', status: 'failed' },
@@ -1402,6 +1401,26 @@ assert.equal(
   failedUpstreamRunnerOutcome.evidence_refs.some((ref) => ref.kind === 'codebox-command-evidence' && ref.uri === '/tmp/wp-codebox-artifacts/wp-codebox-command-evidence.json'),
   true
 );
+
+const failedStatusBeatsSuccessfulNormalizerOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'failed',
+  summary: 'WP Codebox reported failure without success false.',
+}, {
+  normalizeAgentTaskRunResult: () => ({
+    schema: 'wp-codebox/agent-task-run-result/v1',
+    status: 'succeeded',
+    success: true,
+    summary: 'Misleading normalizer success.',
+    artifacts: [],
+    diagnostics: [],
+    metadata: {},
+    refs: {},
+  }),
+  exitStatus: 0,
+});
+assert.equal(failedStatusBeatsSuccessfulNormalizerOutcome.status, 'failed');
+assert.equal(failedStatusBeatsSuccessfulNormalizerOutcome.failure_classification, 'execution_failed');
 
 const emptyRunSummaryOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: false,

--- a/wordpress/tests/provider-outcome-normalizer.test.js
+++ b/wordpress/tests/provider-outcome-normalizer.test.js
@@ -3,6 +3,8 @@
 const assert = require('node:assert/strict');
 
 const {
+  normalizeAgentTaskOutcome,
+  normalizeAgentTaskStatus,
   normalizeProviderTaskOutcome,
   normalizeProviderStatus,
   providerFailureClassification,
@@ -57,6 +59,38 @@ const normalizedRuntimeFailure = normalizeProviderTaskOutcome(request, {
 assert.equal(normalizedRuntimeFailure.status, 'failed');
 assert.equal(normalizedRuntimeFailure.failure_classification, 'execution_failed');
 assert.equal(normalizedRuntimeFailure.diagnostics[0].class, 'runtime.no_session');
+
+const failedStatusWithoutSuccess = normalizeAgentTaskOutcome(request, {
+  status: 'failed',
+  summary: 'Provider reported a terminal failure without success false.',
+}, { status: 'succeeded' });
+assert.equal(failedStatusWithoutSuccess.status, 'failed');
+assert.equal(failedStatusWithoutSuccess.failure_classification, 'execution_failed');
+
+const providerErrorWithoutSuccess = normalizeAgentTaskOutcome(request, {
+  status: 'provider_error',
+  summary: 'Provider failed before runtime startup.',
+});
+assert.equal(providerErrorWithoutSuccess.status, 'provider_error');
+assert.equal(providerErrorWithoutSuccess.failure_classification, 'provider');
+
+const timeoutWithoutSuccess = normalizeAgentTaskOutcome(request, {
+  timeout: true,
+  summary: 'Timed out.',
+});
+assert.equal(timeoutWithoutSuccess.status, 'timeout');
+assert.equal(timeoutWithoutSuccess.failure_classification, 'timeout');
+
+const emptyJsonOutcome = normalizeAgentTaskOutcome(request, {});
+assert.equal(emptyJsonOutcome.status, 'failed');
+assert.equal(emptyJsonOutcome.failure_classification, 'execution_failed');
+
+const noOpOutcome = normalizeAgentTaskOutcome(request, { success: true, outcome: 'no_op' });
+assert.equal(noOpOutcome.status, 'no_op');
+assert.equal(noOpOutcome.failure_classification, undefined);
+
+assert.equal(normalizeAgentTaskStatus({ status: 'completed' }), 'succeeded');
+assert.equal(normalizeAgentTaskStatus({ success: false }), 'failed');
 
 assert.equal(normalizeProviderStatus({ success: true, outcome: 'no_op' }), 'no_op');
 assert.equal(providerFailureClassification('task', 'failed'), 'execution_failed');


### PR DESCRIPTION
## Summary
- Adds canonical WP Codebox agent task outcome normalization via normalizeAgentTaskOutcome.
- Ensures terminal failed/provider_error/timeout statuses win even when success is absent or a downstream normalizer reports success.
- Covers failed status without success:false, provider error, timeout, empty JSON, no-op, and existing successful shapes.

## Tests
- npm run test:provider-outcome-normalizer
- npm run test:codebox-agent-task-executor
- npm run test:wp-codebox-task-runner

## Caveats
- npm run lint:js -- ../agent-runtimes/wp-codebox/lib/provider-outcome-normalizer.js ../agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js tests/provider-outcome-normalizer.test.js tests/codebox-agent-task-executor-smoke.js exits with ignored-file warnings because the package ESLint config ignores these paths/outside-base files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested canonical Codebox task outcome normalization.