### PR TITLE
Support runtime component profiles

### DIFF
--- a/.github/scripts/datamachine-agent-ci/build-runner-config.cjs
+++ b/.github/scripts/datamachine-agent-ci/build-runner-config.cjs
@@ -32,6 +32,8 @@ function buildConfig(env) {
   const transcriptHostDir = path.join(workspace, 'datamachine-agent-artifacts', agentSlug);
   const transcriptGuestDir = `/wordpress/wp-content/plugins/${componentSlug}/datamachine-agent-artifacts/${agentSlug}`;
   const runtimeId = env.AGENT_RUNTIME || 'wp-codebox';
+  const runtimeProfile = env.RUNTIME_PROFILE || 'datamachine-agent-ci';
+  const runtimeProfiles = parseJsonInput('runtime_profiles', env.RUNTIME_PROFILES || '{}', 'object', {});
 
   if (runtimeId !== 'wp-codebox') {
     throw new Error(`Unsupported agent_runtime: ${runtimeId}. Only wp-codebox is currently supported.`);
@@ -77,6 +79,10 @@ function buildConfig(env) {
   const workloadRunAfter = parseJsonInput('workload_run_after', env.WORKLOAD_RUN_AFTER || '[]', 'array', []);
   const extraRequiredAbilities = parseJsonInput('extra_required_abilities', env.EXTRA_REQUIRED_ABILITIES || '[]', 'array', []);
   const runtimeTask = runtimeTaskFromEnv(env);
+  const runtimeTaskAbility = env.RUNTIME_TASK_ABILITY || runtimeProfiles[runtimeProfile]?.runtime_task_ability || 'datamachine/run-agent-bundle';
+  const runtimeAbilityRequirements = Array.isArray(runtimeProfiles[runtimeProfile]?.ability_requirements)
+    ? runtimeProfiles[runtimeProfile].ability_requirements
+    : [runtimeTaskAbility];
   const executionKind = env.EXECUTION_KIND || (runtimeTask ? 'runtime_task' : 'agent_bundle');
   if (executionKind === 'agent_bundle' && !bundlePath) {
     throw new Error('BUNDLE_PATH is required for agent_bundle execution. Set execution_kind=runtime_task with runtime_task or ability_request for direct ability execution.');
@@ -85,7 +91,10 @@ function buildConfig(env) {
     ? [runtimeTask.ability]
     : executeWorkflow.path
       ? ['datamachine/import-agent', 'datamachine/execute-workflow', 'datamachine/drain-job']
-      : ['datamachine/import-agent', 'datamachine/run-flow', 'datamachine/drain-job'];
+      : runtimeProfile === 'datamachine-agent-ci'
+        ? ['datamachine/import-agent', 'datamachine/run-flow', 'datamachine/drain-job']
+        : runtimeAbilityRequirements;
+  const runtimeComponents = parseJsonInput('runtime_components', env.RUNTIME_COMPONENTS || '{}', 'object', {});
 
   return {
     _configPath: path.join(runnerTemp, 'datamachine-agent-config.json'),
@@ -95,6 +104,8 @@ function buildConfig(env) {
     workload_label: `Run ${agentSlug} Data Machine agent`,
     validation_dependencies: validationDependencies.paths,
     runtime_id: runtimeId,
+    runtime_profile: runtimeProfile,
+    ...(Object.keys(runtimeProfiles).length > 0 ? { runtime_profiles: runtimeProfiles } : {}),
     execution_kind: executionKind,
     runtime_ref: env.AGENT_RUNTIME_REF || 'main',
     runtime_wordpress_version: env.RUNTIME_WORDPRESS_VERSION || '7.0',
@@ -131,6 +142,7 @@ function buildConfig(env) {
       agents_api: path.join(workspace, '.ci/agents-api'),
       data_machine: path.join(workspace, '.ci/data-machine'),
       data_machine_code: path.join(workspace, '.ci/data-machine-code'),
+      ...runtimeComponents,
     },
     provider_plugin_paths: validationDependencies.providerPluginHostPath ? [validationDependencies.providerPluginHostPath] : [],
     github_token_env: 'HOMEBOY_GITHUB_APP_TOKEN',

--- a/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
+++ b/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
@@ -11,6 +11,7 @@ const AGENT_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
 const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
 const DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY = 'datamachine/run-agent-bundle';
 const DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID = 'datamachine-agent-ci';
+const DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_PRESET = 'datamachine';
 
 const DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS = {
   contract_slug_map: {
@@ -114,10 +115,17 @@ const DATAMACHINE_AGENT_CI_ABILITY_REQUIREMENTS = [
 const DATAMACHINE_AGENT_CI_RUNTIME_PROFILE = {
   schema: 'homeboy/runtime-profile/v1',
   id: DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID,
+  preset: DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_PRESET,
+  runtime_task_ability: DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY,
   component_path_defaults: DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
   workspace_tools: DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
   capabilities: DATAMACHINE_AGENT_CI_CAPABILITIES,
   ability_requirements: DATAMACHINE_AGENT_CI_ABILITY_REQUIREMENTS,
+};
+
+const DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_PRESETS = {
+  [DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_PRESET]: DATAMACHINE_AGENT_CI_RUNTIME_PROFILE,
+  [DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID]: DATAMACHINE_AGENT_CI_RUNTIME_PROFILE,
 };
 
 function datamachineAgentCiBundleTaskRequest(options = {}, context = {}) {
@@ -150,10 +158,12 @@ function datamachineAgentCiBundleTaskRequest(options = {}, context = {}) {
     ...stripUndefined(options.runtimeTaskInput || options.runtime_task_input || {}),
   });
 
+  const runtimeProfile = resolveDatamachineAgentCiRuntimeProfile(options);
+
   return datamachineAgentCiAbilityTaskRequest({
     ...options,
     taskId,
-    ability: DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY,
+    ability: runtimeProfile.runtime_task_ability,
     abilityInput: runtimeTaskInput,
   }, context);
 }
@@ -200,15 +210,18 @@ function datamachineAgentCiRunnerSpec(options = {}, context = {}) {
 }
 
 function datamachineAgentCiTaskExecutorConfig(options = {}) {
+  const runtimeProfile = resolveDatamachineAgentCiRuntimeProfile(options);
   const runtimeTaskInput = options.abilityInput || options.ability_input || {};
   const runtimeTask = stripUndefined({
-    ability: options.ability,
+    ability: options.ability || runtimeProfile.runtime_task_ability,
     input: runtimeTaskInput,
   });
   return stripUndefined({
     ...(options.config || {}),
     provider: options.provider,
     model: options.model,
+    runtime_profile: runtimeProfile.id,
+    runtime_profiles: runtimeProfilesForOptions(options, runtimeProfile),
     runtime_component_paths: options.runtimeComponentPaths || options.runtime_component_paths,
     component_contracts: options.componentContracts || options.component_contracts,
     homeboy_extensions: options.homeboyExtensions || options.homeboy_extensions,
@@ -226,6 +239,34 @@ function datamachineAgentCiTaskExecutorConfig(options = {}) {
     runtime_id: options.runtimeId || options.runtime_id,
     runtime_bin: options.runtimeBin || options.runtime_bin,
   });
+}
+
+function resolveDatamachineAgentCiRuntimeProfile(options = {}) {
+  const runtimeProfiles = options.runtimeProfiles || options.runtime_profiles || options.config?.runtime_profiles || options.config?.runtimeProfiles || {};
+  const requestedProfile = options.runtimeProfile || options.runtime_profile || options.config?.runtime_profile || options.config?.runtimeProfile || DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID;
+  const presetProfile = DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_PRESETS[requestedProfile];
+  const profile = runtimeProfiles[requestedProfile] || presetProfile;
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+    throw new Error(`runtime profile ${requestedProfile} is not configured.`);
+  }
+
+  const id = requiredString(profile.id || requestedProfile, 'runtime profile id');
+  return {
+    ...profile,
+    id,
+    runtime_task_ability: requiredString(
+      options.runtimeTaskAbility || options.runtime_task_ability || profile.runtime_task_ability || DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY,
+      'runtime task ability'
+    ),
+  };
+}
+
+function runtimeProfilesForOptions(options, runtimeProfile) {
+  return {
+    ...(options.config?.runtime_profiles || options.config?.runtimeProfiles || {}),
+    ...(options.runtimeProfiles || options.runtime_profiles || {}),
+    [runtimeProfile.id]: runtimeProfile,
+  };
 }
 
 function datamachineAgentCiPlan(options = {}) {
@@ -272,6 +313,8 @@ module.exports = {
   DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
   DATAMACHINE_AGENT_CI_RUNTIME_PROFILE,
   DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID,
+  DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_PRESET,
+  DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_PRESETS,
   DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
   DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY,
   agentTaskRequestFromRunnerSpec,

--- a/tests/datamachine-agent-ci-primitives-smoke.mjs
+++ b/tests/datamachine-agent-ci-primitives-smoke.mjs
@@ -117,6 +117,9 @@ assert.equal(config.runtime_id, 'wp-codebox');
 assert.equal(config.runner_workspace.checkout_path, '/workspace/homeboy-extensions');
 assert.deepEqual(config.writable_paths, ['src', 'tests']);
 assert.equal(config.provider_credentials.connectors_ai_openai_api_key, 'OPENAI_API_KEY');
+assert.equal(config.runtime_profile, 'datamachine-agent-ci');
+assert.equal(config.runtime_components.data_machine, path.join(workspace, '.ci/data-machine'));
+assert.deepEqual(config.required_abilities, ['datamachine/import-agent', 'datamachine/run-flow', 'datamachine/drain-job']);
 
 fs.writeFileSync(githubOutput, '');
 run('build-runner-config.cjs', [], {
@@ -193,6 +196,84 @@ assert.deepEqual(runtimeTaskConfig.component_contracts, [{ slug: 'example-fixtur
 assert.equal(runtimeTaskConfig.runtime_mounts.some((mount) => mount.target === '/workspace/input' && mount.mode === 'readonly'), true);
 assert.deepEqual(runtimeTaskConfig.artifact_declarations, [{ name: 'processed_packet', type: 'example-packet', schema: 'example/processed-packet/v1', required: true }]);
 assert.deepEqual(runtimeTaskConfig.required_abilities, ['example/process-artifact']);
+
+fs.writeFileSync(githubOutput, '');
+run('build-runner-config.cjs', [], {
+  GITHUB_OUTPUT: githubOutput,
+  GITHUB_WORKSPACE: workspace,
+  RUNNER_TEMP: runnerTemp,
+  GITHUB_SHA: 'abc123',
+  AGENT_SLUG: 'example-agent',
+  PIPELINE_SLUG: 'example-pipeline',
+  FLOW_SLUG: 'example-flow',
+  BUNDLE_PATH: 'bundle',
+  TARGET_REPO: 'Extra-Chill/homeboy-extensions',
+  PROVIDER: 'openai',
+  MODEL: 'gpt-5.5',
+  AGENT_RUNTIME: 'wp-codebox',
+  AGENT_RUNTIME_REF: 'main',
+  RUNTIME_PROFILE: 'example-agent-ci',
+  RUNTIME_PROFILES: JSON.stringify({
+    'example-agent-ci': {
+      schema: 'homeboy/runtime-profile/v1',
+      id: 'example-agent-ci',
+      runtime_task_ability: 'example/run-agent-bundle',
+      component_path_defaults: {
+        contract_slug_map: { 'example-agents': 'agent_runtime' },
+        path_aliases: { agent_runtime: ['contract:agent_runtime'] },
+      },
+      ability_requirements: ['example/run-agent-bundle'],
+    },
+  }),
+  RUNTIME_COMPONENTS: JSON.stringify({
+    example_agents: '/workspace/components/example-agents',
+  }),
+  COMPONENT_CONTRACTS: '[{"slug":"example-agents","path":"/workspace/components/example-agents","activate":true}]',
+  CONTEXT_REPOSITORIES: '[]',
+  VERIFICATION_COMMANDS: '[]',
+  DRIFT_CHECKS: '[]',
+  WRITABLE_PATHS: '',
+  WORKSPACE_CONTRACT_CHECKS: '{}',
+  SUCCESS_REQUIRES_PR: 'false',
+  SUCCESS_COMPLETION_OUTCOMES: '[]',
+  MAX_TURNS: '1',
+  STEP_BUDGET: '1',
+  TIME_BUDGET_MS: '60000',
+  EXPECTED_ARTIFACTS: '[]',
+  ARTIFACT_DECLARATIONS: '[]',
+  ARTIFACT_EXPORT_CONFIG: '{}',
+  RULES: '{}',
+  GENERAL_RULES: '[]',
+  TASK_RULES: '[]',
+  PROBES: '{}',
+  WP_GYM_BENCHMARK_MODE: 'false',
+  DRY_RUN: 'true',
+  EXTRA_WP_CONFIG_DEFINES: '{}',
+  RUNTIME_MOUNTS: '[]',
+  RUNTIME_OVERLAYS: '[]',
+  WORKLOAD_RUN_BEFORE: '[]',
+  WORKLOAD_RUN_AFTER: '[]',
+  DAILY_MEMORY_ENABLED: 'false',
+  DISABLE_DATAMACHINE_DIRECTIVES: 'false',
+  EXTRA_REQUIRED_ABILITIES: '[]',
+  APP_TOKEN_REPOS: '',
+  ALLOWED_REPOS: '[]',
+  TOOL_RESULTS_KEY: 'github_tool_results',
+  ABILITY_TOOLS: '[]',
+  TOOL_RECORDERS: '[]',
+  ENABLE_TERMINAL_ACTIONS: 'false',
+  WP_CLI_TOOL_NAME: 'run_wp_cli',
+  PIPELINE_STEP_PATCHES: '[]',
+  FLOW_STEP_PATCHES: '[]',
+  RUNNER_WORKSPACE_CONFIG: '{}',
+  PROVIDER_PLUGIN: '{}',
+});
+const customProfileConfig = JSON.parse(fs.readFileSync(path.join(runnerTemp, 'datamachine-agent-config.json'), 'utf8'));
+assert.equal(customProfileConfig.runtime_profile, 'example-agent-ci');
+assert.equal(customProfileConfig.runtime_profiles['example-agent-ci'].runtime_task_ability, 'example/run-agent-bundle');
+assert.equal(customProfileConfig.runtime_components.example_agents, '/workspace/components/example-agents');
+assert.deepEqual(customProfileConfig.component_contracts, [{ slug: 'example-agents', path: '/workspace/components/example-agents', activate: true }]);
+assert.deepEqual(customProfileConfig.required_abilities, ['example/run-agent-bundle']);
 
 const resultsFile = path.join(tempRoot, 'results.json');
 fs.writeFileSync(resultsFile, JSON.stringify({ scenarios: [{ id: 'flow', metadata: { job_status: 'completed', engine_data: { value: 7 } } }] }));

--- a/wordpress/tests/datamachine-agent-ci-plan-smoke.js
+++ b/wordpress/tests/datamachine-agent-ci-plan-smoke.js
@@ -84,6 +84,47 @@ assert.equal(bundleTask.executor.config.runtime_profiles['datamachine-agent-ci']
 assert.equal(bundleTask.limits.task_timeout_seconds, 1200);
 assert.deepEqual(bundleTask.expected_artifacts, ['datamachine-transcript', 'ConceptPacket']);
 
+const customRuntimeProfile = {
+  schema: 'homeboy/runtime-profile/v1',
+  id: 'example-agent-ci',
+  runtime_task_ability: 'example/run-agent-bundle',
+  component_path_defaults: {
+    contract_slug_map: {
+      'example-agents': 'agent_runtime',
+      'example-tools': 'agent_runtime_tools',
+    },
+    path_aliases: {
+      agent_runtime: ['contract:agent_runtime'],
+      agent_runtime_tools: ['contract:agent_runtime_tools'],
+    },
+  },
+  ability_requirements: ['example/run-agent-bundle'],
+};
+const customBundleTask = datamachineAgentCiBundleTaskRequest({
+  taskId: 'example-agent',
+  source: '/workspace/example-repo/bundles/example-agent',
+  agentSlug: 'example-agent',
+  pipelineSlug: 'example-pipeline',
+  flowSlug: 'example-flow',
+  runtimeProfile: 'example-agent-ci',
+  runtimeProfiles: { 'example-agent-ci': customRuntimeProfile },
+  componentContracts: [
+    { slug: 'example-agents', path: '/components/example-agents' },
+    { slug: 'example-tools', path: '/components/example-tools' },
+  ],
+});
+
+assert.equal(customBundleTask.executor.config.runtime_profile, 'example-agent-ci');
+assert.equal(customBundleTask.executor.config.runtime_task.ability, 'example/run-agent-bundle');
+assert.deepEqual(customBundleTask.executor.config.runtime_profiles['example-agent-ci'].component_path_defaults.contract_slug_map, {
+  'example-agents': 'agent_runtime',
+  'example-tools': 'agent_runtime_tools',
+});
+assert.deepEqual(customBundleTask.executor.config.component_contracts, [
+  { slug: 'example-agents', path: '/components/example-agents' },
+  { slug: 'example-tools', path: '/components/example-tools' },
+]);
+
 const bundleRunnerSpec = datamachineAgentCiRunnerSpec({
   taskId: 'concept-agent',
   source: '/workspace/example-repo/bundles/concept-agent',


### PR DESCRIPTION
## Summary
- Add runtime profile resolution to Data Machine Agent CI plan generation so bundle tasks can use profile-supplied runtime task abilities.
- Preserve the existing Data Machine profile/preset as the default legacy behavior.
- Let the GitHub runner config accept custom runtime profiles and runtime component mappings while keeping legacy Data Machine component paths.

## Tests
- npm run test:datamachine-agent-ci-plan
- node tests/datamachine-agent-ci-primitives-smoke.mjs
- npm run test:codebox-agent-task-executor-boundary
- npx eslint lib/datamachine-agent-ci-plan.js --no-warn-ignored
- node --check .github/scripts/datamachine-agent-ci/build-runner-config.cjs
- node --check datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
- node --check wordpress/tests/datamachine-agent-ci-plan-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested runtime component profile decoupling.