### PR TITLE
Add WP Codebox provider preflight manifests

### DIFF
--- a/agent-runtimes/wp-codebox/index.js
+++ b/agent-runtimes/wp-codebox/index.js
@@ -3,5 +3,6 @@
 module.exports = {
 	...require('./lib/codebox-agent-task-executor'),
 	...require('./lib/delegated-run-contract'),
+	...require('./lib/provider-preflight-manifest'),
 	...require('./lib/provider-outcome-normalizer'),
 };

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -140,6 +140,7 @@ function providerContract(options = {}) {
     workspace_tools: runtimeWorkspaceTools(options),
     component_path_defaults: runtimeComponentPathDefaults(options),
     provider_defaults: providerDefaultsContract(runtimeProviderDefaults()),
+    provider_preflight: runtimeProviderPreflight(),
     role_aliases: WP_CODEBOX_ROLE_ALIASES,
     status: 'active',
     integration_contract: 'homeboy-wordpress-agent-task/v1',
@@ -189,6 +190,10 @@ function runtimeComponentDiscovery(options = {}) {
 
 function runtimeProviderDefaults() {
   return firstObject(runtimeExecutorManifest().provider_defaults) || {};
+}
+
+function runtimeProviderPreflight() {
+  return firstObject(runtimeExecutorManifest().provider_preflight) || {};
 }
 
 function runtimeRunnerReadiness(options = {}) {

--- a/agent-runtimes/wp-codebox/lib/provider-preflight-manifest.js
+++ b/agent-runtimes/wp-codebox/lib/provider-preflight-manifest.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const RUNTIME_MANIFEST_PATH = path.resolve(__dirname, '..', 'wp-codebox.json');
+
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function runtimeExecutorManifest() {
+  return readJsonFile(RUNTIME_MANIFEST_PATH)?.agent_task_executors?.[0] || {};
+}
+
+function providerPreflightManifests() {
+  const manifests = runtimeExecutorManifest().provider_preflight;
+  return manifests && typeof manifests === 'object' && !Array.isArray(manifests) ? manifests : {};
+}
+
+function providerPreflightManifest(provider) {
+  const manifest = providerPreflightManifests()[provider];
+  return manifest && typeof manifest === 'object' && !Array.isArray(manifest) ? manifest : null;
+}
+
+function normalizeStringArray(value) {
+  if (Array.isArray(value)) {
+    return value.filter((item) => typeof item === 'string' && item.trim()).map((item) => item.trim());
+  }
+  return typeof value === 'string' && value.trim() ? [value.trim()] : [];
+}
+
+function providerRequiredSecretEnv(provider) {
+  return normalizeStringArray(providerPreflightManifest(provider)?.required_secret_env);
+}
+
+function providerOptionalSecretEnv(provider) {
+  return normalizeStringArray(providerPreflightManifest(provider)?.optional_secret_env);
+}
+
+function providerSecretEnv(provider) {
+  return Array.from(new Set([
+    ...providerRequiredSecretEnv(provider),
+    ...providerOptionalSecretEnv(provider),
+  ]));
+}
+
+function providerAuthEnvSources(provider) {
+  const sources = providerPreflightManifest(provider)?.auth_env_sources;
+  return sources && typeof sources === 'object' && !Array.isArray(sources) ? sources : {};
+}
+
+function providerDiagnosticClass(provider) {
+  return providerPreflightManifest(provider)?.diagnostic_class || '';
+}
+
+function providerLabel(provider) {
+  return providerPreflightManifest(provider)?.label || provider;
+}
+
+function providerGuidance(provider) {
+  return providerPreflightManifest(provider)?.guidance || '';
+}
+
+function providerPluginValidation(provider) {
+  const validation = providerPreflightManifest(provider)?.provider_plugin_validation;
+  return validation && typeof validation === 'object' && !Array.isArray(validation) ? validation : null;
+}
+
+function secretEnvNames(request) {
+  return Array.from(new Set([
+    ...normalizeStringArray(request?.secret_env),
+    ...normalizeStringArray(request?.recipe?.secret_env),
+  ]));
+}
+
+function missingRequiredSecretEnvMapping(request, provider) {
+  const names = secretEnvNames(request);
+  return providerRequiredSecretEnv(provider).filter((name) => !names.includes(name));
+}
+
+function missingRequiredSecretEnvValues(provider, env = process.env) {
+  return providerRequiredSecretEnv(provider).filter((name) => !env[name]);
+}
+
+function providerAuthError(provider, message, missing = []) {
+  const guidance = providerGuidance(provider);
+  const suffix = guidance ? ` ${guidance}` : '';
+  const error = new Error(`${providerLabel(provider)} provider auth preflight failed: ${message}${suffix}`);
+  error.provider = provider;
+  error.diagnosticClass = providerDiagnosticClass(provider);
+  error.missingEnv = missing;
+  return error;
+}
+
+function assertProviderSecretEnvPreflight(request, provider, env = process.env) {
+  const missingMapping = missingRequiredSecretEnvMapping(request, provider);
+  if (missingMapping.length > 0) {
+    throw providerAuthError(provider, `missing required secret environment mapping: ${missingMapping.join(', ')}`, missingMapping);
+  }
+
+  const missing = missingRequiredSecretEnvValues(provider, env);
+  if (missing.length > 0) {
+    throw providerAuthError(provider, `missing required secret environment value: ${missing.join(', ')}`, missing);
+  }
+}
+
+module.exports = {
+  providerAuthEnvSources,
+  providerDiagnosticClass,
+  providerGuidance,
+  providerLabel,
+  providerOptionalSecretEnv,
+  providerPluginValidation,
+  providerPreflightManifest,
+  providerPreflightManifests,
+  providerRequiredSecretEnv,
+  providerSecretEnv,
+  assertProviderSecretEnvPreflight,
+  missingRequiredSecretEnvMapping,
+  missingRequiredSecretEnvValues,
+  normalizeStringArray,
+};

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -19,18 +19,17 @@ const {
   codeboxTaskRequestFromAgentTaskRequest,
   providerContract,
 } = require('../../lib/codebox-agent-task-executor');
+const {
+  normalizeStringArray,
+  providerAuthEnvSources,
+  providerDiagnosticClass,
+  providerLabel,
+  providerPluginValidation,
+  providerSecretEnv,
+} = require('../../lib/provider-preflight-manifest');
 
 const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
 const DEFAULT_TASK_RUNNER = path.resolve(__dirname, 'homeboy-wp-codebox-task-runner.cjs');
-const CODEX_SECRET_ENV = [
-  'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
-  'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
-  'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
-  'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
-  'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
-];
-const CODEX_PROVIDER_PLUGIN_GUIDANCE = 'Codex tasks require a Codex-capable provider plugin checkout, such as the Codex PR branch for ai-provider-for-openai. Released ai-provider-for-openai trunk registers openai, not codex, and unrelated provider defaults such as ai-provider-for-opencode will not work.';
-
 function argValue(name) {
   const index = process.argv.indexOf(name);
   return index >= 0 ? process.argv[index + 1] : '';
@@ -76,6 +75,19 @@ function defaultCodexAuthPath() {
   return process.env.HOME ? path.join(process.env.HOME, '.codex', 'auth.json') : '';
 }
 
+function defaultAuthPath(source) {
+  if (source?.path_env && process.env[source.path_env]) {
+    return process.env[source.path_env];
+  }
+  if (source?.path === '~/.codex/auth.json') {
+    return defaultCodexAuthPath();
+  }
+  if (typeof source?.path === 'string' && source.path.startsWith('~/') && process.env.HOME) {
+    return path.join(process.env.HOME, source.path.slice(2));
+  }
+  return source?.path || '';
+}
+
 function jwtExpiration(token) {
   const payload = String(token || '').split('.')[1];
   if (!payload) {
@@ -90,26 +102,72 @@ function jwtExpiration(token) {
   }
 }
 
-function codexAuthEnv(taskInput) {
-  if (taskInput?.provider !== 'codex') {
+function nestedField(value, field) {
+  return String(field || '').split('.').reduce((current, key) => {
+    if (!current || typeof current !== 'object') {
+      return undefined;
+    }
+    return current[key];
+  }, value);
+}
+
+function sourceValue(source, auth) {
+  for (const field of [source.field, ...normalizeStringArray(source.fallback_fields)]) {
+    const value = nestedField(auth, field);
+    if (value !== undefined && value !== null && value !== '') {
+      return value;
+    }
+  }
+  return source.value;
+}
+
+function providerAuthEnv(taskInput) {
+  const provider = taskInput?.provider || '';
+  const secretEnv = providerSecretEnv(provider);
+  const sources = providerAuthEnvSources(provider);
+  if (secretEnv.length === 0 || Object.keys(sources).length === 0) {
     return {};
   }
-  if (CODEX_SECRET_ENV.slice(0, 4).every((name) => Boolean(process.env[name]))) {
+  if (secretEnv.every((name) => Boolean(process.env[name]))) {
     return {};
   }
-  const authPath = process.env.HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH || defaultCodexAuthPath();
-  const auth = readJsonIfAvailable(authPath);
-  const tokens = auth?.tokens || {};
-  if (!tokens.access_token || !tokens.refresh_token || !tokens.account_id) {
+
+  const authByPath = new Map();
+  const env = {};
+  for (const [name, source] of Object.entries(sources)) {
+    if (!secretEnv.includes(name)) {
+      continue;
+    }
+    const authPath = defaultAuthPath(source);
+    if (!authPath) {
+      continue;
+    }
+    if (!authByPath.has(authPath)) {
+      authByPath.set(authPath, readJsonIfAvailable(authPath));
+    }
+    const auth = authByPath.get(authPath);
+    if (source.source === 'json-file-jwt-expiration') {
+      const fallbackValue = normalizeStringArray(source.fallback_fields)
+        .map((field) => nestedField(auth, field))
+        .find((value) => value !== undefined && value !== null && value !== '');
+      if (fallbackValue !== undefined) {
+        env[name] = String(fallbackValue);
+        continue;
+      }
+      const token = nestedField(auth, source.field);
+      env[name] = jwtExpiration(token);
+      continue;
+    }
+    const value = sourceValue(source, auth);
+    if (value !== undefined && value !== null && value !== '') {
+      env[name] = String(value);
+    }
+  }
+  const required = secretEnv.filter((name) => name !== 'AI_PROVIDER_OPENAI_CODEX_FEDRAMP');
+  if (!required.every((name) => Boolean(env[name] || process.env[name]))) {
     return {};
   }
-  return Object.fromEntries(Object.entries({
-    AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: tokens.access_token,
-    AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: tokens.refresh_token,
-    AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: tokens.expires_at || tokens.expiresAt || jwtExpiration(tokens.access_token),
-    AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: tokens.account_id,
-    AI_PROVIDER_OPENAI_CODEX_FEDRAMP: tokens.fedramp === undefined ? 'false' : String(tokens.fedramp),
-  }).filter(([name, value]) => CODEX_SECRET_ENV.includes(name) && value !== undefined && value !== null && value !== ''));
+  return env;
 }
 
 function directorySizeBytes(directory) {
@@ -329,13 +387,11 @@ function missingSecretEnvNames(stderr) {
 }
 
 function preflightFailureClass(stderr, missingSecretEnv) {
-  if (/Codex provider auth preflight failed:/i.test(stderr)) {
-    return 'codebox.preflight.codex_auth';
-  }
-  if (/Claude Code provider auth preflight failed:/i.test(stderr)) {
-    return missingSecretEnv.length > 0
-      ? 'codebox.preflight.claude_code_auth'
-      : 'codebox.preflight.stderr';
+  for (const provider of ['codex', 'claude-code']) {
+    const label = providerLabel(provider).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    if (new RegExp(`${label} provider auth preflight failed:`, 'i').test(stderr)) {
+      return providerDiagnosticClass(provider) || 'codebox.preflight.stderr';
+    }
   }
   return missingSecretEnv.length > 0
     ? 'codebox.preflight.missing_secret_env'
@@ -434,13 +490,6 @@ function missingWorkspacePayload(request, taskInput) {
   };
 }
 
-function normalizeStringArray(value) {
-  if (Array.isArray(value)) {
-    return value.filter((item) => typeof item === 'string' && item.trim()).map((item) => item.trim());
-  }
-  return typeof value === 'string' && value.trim() ? [value.trim()] : [];
-}
-
 function collectProviderProbeFiles(providerPath, maxFiles = 200) {
   const files = [];
   const queue = [{ filePath: providerPath, depth: 0 }];
@@ -471,9 +520,9 @@ function collectProviderProbeFiles(providerPath, maxFiles = 200) {
   return files;
 }
 
-function codexProviderPluginInspection(providerPath) {
+function providerPluginInspection(providerPath, validation) {
   const slug = path.basename(providerPath).toLowerCase();
-  if (slug === 'ai-provider-for-opencode' || slug.includes('opencode')) {
+  if (normalizeStringArray(validation.invalid_slug_patterns).some((pattern) => slug.includes(pattern.toLowerCase()))) {
     return { status: 'invalid', reason: 'opencode_provider_plugin' };
   }
   if (!fs.existsSync(providerPath)) {
@@ -486,22 +535,23 @@ function codexProviderPluginInspection(providerPath) {
     } catch {
       continue;
     }
-    if (/codex/i.test(contents)) {
+    if (new RegExp(validation.marker_pattern || validation.markerPattern || 'codex', 'i').test(contents)) {
       return { status: 'valid', reason: 'codex_marker_found', marker_path: filePath };
     }
   }
   return { status: 'invalid', reason: 'no_codex_marker_found' };
 }
 
-function codexProviderPluginPreflightPayload(request, taskInput) {
-  if (taskInput?.provider !== 'codex') {
+function providerPluginPreflightPayload(request, taskInput) {
+  const validation = providerPluginValidation(taskInput?.provider || '');
+  if (!validation) {
     return null;
   }
 
   const providerPluginPaths = normalizeStringArray(taskInput.provider_plugin_paths);
   const inspections = providerPluginPaths.map((providerPath) => ({
     path: providerPath,
-    ...codexProviderPluginInspection(providerPath),
+    ...providerPluginInspection(providerPath, validation),
   }));
   const invalidInspections = inspections.filter((inspection) => inspection.status === 'invalid');
   if (providerPluginPaths.length > 0 && invalidInspections.length === 0) {
@@ -509,23 +559,23 @@ function codexProviderPluginPreflightPayload(request, taskInput) {
   }
 
   const message = providerPluginPaths.length === 0
-    ? `WP Codebox Codex task has no provider_plugin_paths configured. ${CODEX_PROVIDER_PLUGIN_GUIDANCE}`
-    : `WP Codebox Codex task selected provider plugin path(s) that do not look Codex-capable. ${CODEX_PROVIDER_PLUGIN_GUIDANCE}`;
+    ? `WP Codebox ${providerLabel(taskInput.provider)} task has no provider_plugin_paths configured. ${validation.guidance}`
+    : `WP Codebox ${providerLabel(taskInput.provider)} task selected provider plugin path(s) that do not look ${providerLabel(taskInput.provider)}-capable. ${validation.guidance}`;
   return {
     success: false,
     status: 'failed',
     failure_classification: 'provider',
     summary: message,
     diagnostics: [{
-      class: 'codebox.preflight.codex_provider_plugin_path',
+      class: validation.diagnostic_class || 'codebox.preflight.provider_plugin_path',
       message,
       data: {
         phase: 'codebox.preflight',
         provider: taskInput.provider,
         provider_plugin_paths: providerPluginPaths,
         inspections,
-        expected: 'Codex-capable ai-provider-for-openai checkout from the Codex provider branch/PR.',
-        guidance: CODEX_PROVIDER_PLUGIN_GUIDANCE,
+        expected: validation.expected || '',
+        guidance: validation.guidance || '',
       },
     }],
     metadata: {
@@ -533,7 +583,7 @@ function codexProviderPluginPreflightPayload(request, taskInput) {
       provider: taskInput.provider,
       provider_plugin_paths: providerPluginPaths,
       inspections,
-      codex_provider_plugin_required: true,
+      provider_plugin_required: true,
     },
   };
 }
@@ -628,9 +678,9 @@ async function runTaskRunner(request) {
   if (missingModelPayload) {
     return agentTaskOutcomeFromCodeboxResult(request, missingModelPayload, { exitStatus: 1, ...coreNormalizers });
   }
-  const codexProviderPluginPayload = codexProviderPluginPreflightPayload(request, taskInput);
-  if (codexProviderPluginPayload) {
-    return agentTaskOutcomeFromCodeboxResult(request, codexProviderPluginPayload, { exitStatus: 1, ...coreNormalizers });
+  const providerPluginPayload = providerPluginPreflightPayload(request, taskInput);
+  if (providerPluginPayload) {
+    return agentTaskOutcomeFromCodeboxResult(request, providerPluginPayload, { exitStatus: 1, ...coreNormalizers });
   }
   const preflightPayload = missingWorkspacePayload(request, taskInput);
   if (preflightPayload) {
@@ -650,7 +700,7 @@ async function runTaskRunner(request) {
   const result = spawnSync(process.execPath, [runner, ...args, ...configArgs], {
     encoding: 'utf8',
     input: JSON.stringify(taskInput),
-    env: { ...process.env, ...codexAuthEnv(taskInput) },
+    env: { ...process.env, ...providerAuthEnv(taskInput) },
     maxBuffer: 1024 * 1024 * 20,
     timeout: requestTimeoutMs(request),
   });

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -14,6 +14,13 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const { URLSearchParams } = require('node:url');
 
+const {
+  assertProviderSecretEnvPreflight,
+  normalizeStringArray,
+  providerGuidance,
+  providerPreflightManifest,
+} = require('../../lib/provider-preflight-manifest');
+
 const CODEX_OAUTH_TOKEN_URL = 'https://auth.openai.com/oauth/token';
 const CODEX_OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 
@@ -106,25 +113,11 @@ function secretEnvNames(request) {
   return Array.from(new Set([...(request.secret_env || []), ...(request.recipe?.secret_env || []), ...argValues('--secret-env')].filter(Boolean)));
 }
 
-function claudeCodeRequiredSecretEnv() {
-  return ['AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN'];
-}
-
-function codexRequiredAuthEnv() {
-  return [
-    'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
-    'AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN',
-    'AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT',
-    'AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID',
-  ];
-}
-
-function isClaudeCodeRequest(request) {
-  return request.provider === 'claude-code';
-}
-
-function isCodexRequest(request) {
-  return request.provider === 'codex';
+function requestWithCliSecretEnv(request) {
+  return {
+    ...request,
+    secret_env: secretEnvNames(request),
+  };
 }
 
 function parseUnixTimestamp(value) {
@@ -141,7 +134,7 @@ function parseUnixTimestamp(value) {
 }
 
 function codexAuthGuidance() {
-  return 'Refresh Codex OAuth credentials before launching WP Codebox, for example by signing in with Codex locally so ~/.codex/auth.json contains current tokens, then pass the updated AI_PROVIDER_OPENAI_CODEX_* secret environment values to the codebox executor.';
+  return providerGuidance('codex');
 }
 
 function codexOAuthTokenUrl() {
@@ -262,50 +255,31 @@ function persistRefreshedCodexAuth(refreshedEnv) {
 }
 
 async function codexAuthPreflightEnv(request) {
-  if (!isCodexRequest(request)) {
+  const manifest = providerPreflightManifest(request.provider);
+  if (request.provider !== 'codex' || !manifest) {
     return {};
   }
 
-  const names = secretEnvNames(request);
-  const missingMapping = codexRequiredAuthEnv().filter((name) => !names.includes(name));
-  if (missingMapping.length > 0) {
-    throw new Error(`Codex provider auth preflight failed: missing required secret environment mapping: ${missingMapping.join(', ')}. ${codexAuthGuidance()}`);
+  assertProviderSecretEnvPreflight(requestWithCliSecretEnv(request), request.provider, process.env);
+
+  if (normalizeStringArray(manifest.validation_hooks).includes('codex-token-expiration')) {
+    const expiresAt = parseUnixTimestamp(process.env.AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT);
+    if (!Number.isFinite(expiresAt) || expiresAt <= 0) {
+      throw new Error(`Codex provider auth preflight failed: AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT is malformed. ${codexAuthGuidance()}`);
+    }
+
+    const safetyWindowSeconds = 300;
+    const now = Math.floor(Date.now() / 1000);
+    if (expiresAt > now + safetyWindowSeconds) {
+      return {};
+    }
   }
 
-  const missing = codexRequiredAuthEnv().filter((name) => !process.env[name]);
-  if (missing.length > 0) {
-    throw new Error(`Codex provider auth preflight failed: missing required secret environment value: ${missing.join(', ')}. ${codexAuthGuidance()}`);
+  if (manifest.refresh_hook === 'codex-oauth-refresh') {
+    return refreshCodexAuthEnv();
   }
 
-  const expiresAt = parseUnixTimestamp(process.env.AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT);
-  if (!Number.isFinite(expiresAt) || expiresAt <= 0) {
-    throw new Error(`Codex provider auth preflight failed: AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT is malformed. ${codexAuthGuidance()}`);
-  }
-
-  const safetyWindowSeconds = 300;
-  const now = Math.floor(Date.now() / 1000);
-  if (expiresAt > now + safetyWindowSeconds) {
-    return {};
-  }
-
-  return refreshCodexAuthEnv();
-}
-
-function assertClaudeCodeAuthPreflight(request) {
-  if (!isClaudeCodeRequest(request)) {
-    return;
-  }
-
-  const names = secretEnvNames(request);
-  const missingMapping = claudeCodeRequiredSecretEnv().filter((name) => !names.includes(name));
-  if (missingMapping.length > 0) {
-    throw new Error(`Claude Code provider auth preflight failed: missing required secret environment mapping: ${missingMapping.join(', ')}`);
-  }
-
-  const missing = claudeCodeRequiredSecretEnv().filter((name) => !process.env[name]);
-  if (missing.length > 0) {
-    throw new Error(`Claude Code provider auth preflight failed: missing required secret environment value: ${missing.join(', ')}`);
-  }
+  return {};
 }
 
 function assertRequiredSecretEnvAvailable(request) {
@@ -1908,7 +1882,9 @@ function runWpCodeboxParentTask(request, envOverrides = {}) {
 try {
   const request = readTaskRequest();
   const codexEnv = await codexAuthPreflightEnv(request);
-  assertClaudeCodeAuthPreflight(request);
+  if (request.provider === 'claude-code') {
+    assertProviderSecretEnvPreflight(requestWithCliSecretEnv(request), request.provider, process.env);
+  }
   assertRequiredSecretEnvAvailable(request);
   process.exitCode = runWpCodeboxParentTask(request, codexEnv);
 } catch (error) {

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -214,6 +214,68 @@
           }
         }
       },
+      "provider_preflight": {
+        "codex": {
+          "label": "Codex",
+          "diagnostic_class": "codebox.preflight.codex_auth",
+          "required_secret_env": [
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT",
+            "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID"
+          ],
+          "optional_secret_env": ["AI_PROVIDER_OPENAI_CODEX_FEDRAMP"],
+          "refresh_hook": "codex-oauth-refresh",
+          "validation_hooks": ["codex-token-expiration"],
+          "guidance": "Refresh Codex OAuth credentials before launching WP Codebox, for example by signing in with Codex locally so ~/.codex/auth.json contains current tokens, then pass the updated AI_PROVIDER_OPENAI_CODEX_* secret environment values to the codebox executor.",
+          "auth_env_sources": {
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN": {
+              "source": "json-file",
+              "path_env": "HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH",
+              "path": "~/.codex/auth.json",
+              "field": "tokens.access_token"
+            },
+            "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN": {
+              "source": "json-file",
+              "path_env": "HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH",
+              "path": "~/.codex/auth.json",
+              "field": "tokens.refresh_token"
+            },
+            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT": {
+              "source": "json-file-jwt-expiration",
+              "path_env": "HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH",
+              "path": "~/.codex/auth.json",
+              "field": "tokens.access_token",
+              "fallback_fields": ["tokens.expires_at", "tokens.expiresAt"]
+            },
+            "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID": {
+              "source": "json-file",
+              "path_env": "HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH",
+              "path": "~/.codex/auth.json",
+              "field": "tokens.account_id"
+            },
+            "AI_PROVIDER_OPENAI_CODEX_FEDRAMP": {
+              "source": "json-file",
+              "path_env": "HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH",
+              "path": "~/.codex/auth.json",
+              "field": "tokens.fedramp",
+              "value": "false"
+            }
+          },
+          "provider_plugin_validation": {
+            "diagnostic_class": "codebox.preflight.codex_provider_plugin_path",
+            "marker_pattern": "codex",
+            "invalid_slug_patterns": ["opencode"],
+            "guidance": "Codex tasks require a Codex-capable provider plugin checkout, such as the Codex PR branch for ai-provider-for-openai. Released ai-provider-for-openai trunk registers openai, not codex, and unrelated provider defaults such as ai-provider-for-opencode will not work.",
+            "expected": "Codex-capable ai-provider-for-openai checkout from the Codex provider branch/PR."
+          }
+        },
+        "claude-code": {
+          "label": "Claude Code",
+          "diagnostic_class": "codebox.preflight.claude_code_auth",
+          "required_secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"]
+        }
+      },
       "role_aliases": {
         "artifact_kinds": {
           "patch": ["codebox-patch"]

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -9,7 +9,12 @@ const { spawnSync } = require('node:child_process');
 const {
   agentTaskOutcomeFromCodeboxResult,
   codeboxTaskRequestFromAgentTaskRequest,
+  missingRequiredSecretEnvMapping,
+  missingRequiredSecretEnvValues,
   providerContract,
+  providerPreflightManifest,
+  providerRequiredSecretEnv,
+  providerSecretEnv,
 } = require('../../agent-runtimes/wp-codebox');
 const {
   datamachineAgentCiCodeboxExecutorConfig,
@@ -378,6 +383,13 @@ assert.deepEqual(provider.provider_defaults, {
     },
   },
 });
+assert.deepEqual(providerRequiredSecretEnv('codex'), codexSecretEnv.slice(0, 4));
+assert.deepEqual(providerSecretEnv('codex'), codexSecretEnv);
+assert.deepEqual(providerRequiredSecretEnv('claude-code'), [claudeCodeRefreshTokenEnv]);
+assert.equal(providerPreflightManifest('codex').refresh_hook, 'codex-oauth-refresh');
+assert.equal(providerPreflightManifest('codex').provider_plugin_validation.diagnostic_class, 'codebox.preflight.codex_provider_plugin_path');
+assert.deepEqual(missingRequiredSecretEnvMapping({ secret_env: codexSecretEnv.slice(0, 3) }, 'codex'), ['AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID']);
+assert.deepEqual(missingRequiredSecretEnvValues('claude-code', {}), [claudeCodeRefreshTokenEnv]);
 assert.deepEqual(provider.role_aliases, {
   artifact_kinds: {
     patch: ['codebox-patch'],


### PR DESCRIPTION
## Summary
- Add a WP Codebox provider_preflight manifest for provider-specific auth/env/capability checks.
- Route existing Codex auth env hydration, Codex provider plugin validation, and Claude/Codex required env validation through the manifest seam.
- Add smoke coverage for manifest-driven provider env validation helpers.

## Tests
- npm run test:codebox-agent-task-executor-boundary
- npm run test:codebox-agent-task-executor
- node ../../wordpress/tests/wp-codebox-task-runner-smoke.js
- node ../../wordpress/tests/codebox-codex-auth-preflight-smoke.js
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested provider preflight manifest seam.