### PR TITLE
Add generic fanout reconcile runner

### DIFF
--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -20,6 +20,9 @@ const {
   wpCodeboxApplyRequestFromBundle,
   wpCodeboxChangeArtifactFromBundle,
 } = require('./wp-codebox-apply-adapter');
+const {
+  executeFanoutReconcileRun,
+} = require('./fanout-reconcile-runner');
 const { loadWpCodeboxCoreFunction } = require('./wp-codebox-core-loader');
 
 const PLAN_SCHEMA = 'homeboy/audit-wp-codebox-fanout/v1';
@@ -1138,79 +1141,26 @@ function wpCodeboxErrorMessage(parsed) {
 
 async function executeAuditWpCodeboxFanout(input) {
   const plan = input.plan || createAuditWpCodeboxFanoutPlan(input);
-  const onProgress = typeof input.on_progress === 'function' ? input.on_progress : () => {};
-  const records = [];
-  const running = new Map();
-  const concurrency = normalizeConcurrency(input.concurrency);
-  const baseRun = {
-    schema: 'homeboy/audit-wp-codebox-execution/v1',
-    plan_schema: plan.schema,
-    orchestrator: plan.orchestrator,
-    audit: plan.audit,
-  };
-  const writeRun = (run) => {
-    if (input.runsOutputPath) {
-      writeJson(input.runsOutputPath, run);
-    }
-  };
-
-  writeRun({
-    ...baseRun,
-    records,
-    status: 'incomplete',
-    current_group: null,
+  const run = await executeFanoutReconcileRun({
+    ...input,
+    plan,
+    run_schema: 'homeboy/audit-wp-codebox-execution/v1',
+    base_run: { audit: plan.audit },
+    include_summary: false,
+    include_reconciliation: false,
+    runs_output_path: input.runsOutputPath,
+    execute_task_request: (taskRequest) => executeWpCodeboxTaskRequestAsync(taskRequest, input),
+    classify_outcome: (record) => record.outcome,
+    reconcile: () => ({
+      apply_back: plan.apply_back || [],
+      issue_reports: plan.issue_reports || [],
+    }),
+    is_record_successful: (record) => record.status === 'completed',
+    task_id: (taskRequest) => taskRequest.sandbox_session_id,
+    running_entry: runningGroup,
+    progress_event: progressEvent,
+    task_order: (record) => taskOrder(plan, record),
   });
-
-  const writeIncompleteRun = () => {
-    writeRun({
-      ...baseRun,
-      records,
-      status: 'incomplete',
-      current_group: firstRunningGroup(running),
-      current_groups: runningGroups(running),
-    });
-  };
-
-  let nextIndex = 0;
-  const startNext = () => {
-    if (nextIndex >= plan.task_requests.length) {
-      return false;
-    }
-    const taskRequest = plan.task_requests[nextIndex];
-    nextIndex += 1;
-
-    running.set(taskRequest.sandbox_session_id, runningGroup(taskRequest));
-    writeIncompleteRun();
-
-    onProgress(progressEvent('started', taskRequest, plan));
-    const promise = executeWpCodeboxTaskRequestAsync(taskRequest, input).then((record) => {
-      running.delete(taskRequest.sandbox_session_id);
-      records.push(record);
-      records.sort((left, right) => taskOrder(plan, left) - taskOrder(plan, right));
-      onProgress(progressEvent(record.status, taskRequest, plan, record));
-      writeIncompleteRun();
-      startNext();
-    });
-    running.get(taskRequest.sandbox_session_id).promise = promise;
-    return true;
-  };
-
-  while (running.size < concurrency && startNext()) {
-    // Start the first batch.
-  }
-
-  while (running.size > 0) {
-    await Promise.race(Array.from(running.values()).map((group) => group.promise));
-  }
-
-  const run = {
-    ...baseRun,
-    records,
-    outcomes: records.flatMap((record) => record.outcome ? [record.outcome] : []),
-    status: records.every((record) => record.status === 'completed') ? 'completed' : 'failed',
-  };
-
-  writeRun(run);
 
   return run;
 }
@@ -1230,14 +1180,6 @@ function executeAuditWpCodeboxFanoutFromFiles(options) {
   });
 }
 
-function normalizeConcurrency(value) {
-  const parsed = Number.parseInt(value || DEFAULT_CONCURRENCY, 10);
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    return DEFAULT_CONCURRENCY;
-  }
-  return Math.min(parsed, 16);
-}
-
 function normalizeTaskTimeoutSeconds(value) {
   const parsed = Number.parseInt(value || DEFAULT_TASK_TIMEOUT_SECONDS, 10);
   if (!Number.isFinite(parsed) || parsed < 1) {
@@ -1253,21 +1195,6 @@ function runningGroup(taskRequest) {
     finding_id: taskRequest.finding_id || taskRequest.audit_findings[0]?.id || '',
     finding_ids: taskRequest.audit_findings.map((finding) => finding.id),
   };
-}
-
-function firstRunningGroup(running) {
-  const group = runningGroups(running)[0];
-  if (!group) {
-    return null;
-  }
-  return group;
-}
-
-function runningGroups(running) {
-  return Array.from(running.values()).map((group) => {
-    const { promise, ...serializable } = group;
-    return serializable;
-  });
 }
 
 function taskOrder(plan, record) {

--- a/wordpress/lib/fanout-reconcile-runner.js
+++ b/wordpress/lib/fanout-reconcile-runner.js
@@ -1,0 +1,240 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PLAN_SCHEMA = 'homeboy/fanout-reconcile-plan/v1';
+const RUN_SCHEMA = 'homeboy/fanout-reconcile-run/v1';
+const DEFAULT_CONCURRENCY = 3;
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function groupFanoutItems(items, options = {}) {
+  const groupKey = typeof options.group_key === 'function'
+    ? options.group_key
+    : (item) => item.group_key || item.groupKey || item.kind || item.id || 'default';
+  const groupsByKey = new Map();
+
+  items.forEach((item, itemIndex) => {
+    const key = String(groupKey(item, itemIndex) || 'default');
+    if (!groupsByKey.has(key)) {
+      groupsByKey.set(key, []);
+    }
+    groupsByKey.get(key).push(item);
+  });
+
+  return Array.from(groupsByKey.entries()).map(([key, groupItems], index) => ({
+    key,
+    index,
+    items: groupItems,
+  }));
+}
+
+function createFanoutReconcilePlan(input) {
+  const items = Array.isArray(input.items) ? input.items : [];
+  const groups = Array.isArray(input.groups) ? input.groups : groupFanoutItems(items, { group_key: input.group_key });
+  const renderTaskRequest = requiredFunction(input.render_task_request, 'render_task_request');
+  const reconcilePlan = typeof input.reconcile_plan === 'function' ? input.reconcile_plan : () => ({});
+  const taskRequests = groups.map((group) => renderTaskRequest(group, input.orchestrator || {}));
+  const reconciliation = reconcilePlan({
+    groups,
+    task_requests: taskRequests,
+    orchestrator: input.orchestrator || {},
+    context: input.context || {},
+  }) || {};
+
+  return {
+    schema: input.schema || PLAN_SCHEMA,
+    orchestrator: input.orchestrator || {},
+    summary: {
+      item_count: groups.reduce((count, group) => count + group.items.length, 0),
+      group_count: groups.length,
+      task_count: taskRequests.length,
+      ...(input.summary || {}),
+    },
+    groups: groups.map((group) => ({
+      key: group.key,
+      index: group.index,
+      item_count: group.items.length,
+    })),
+    task_requests: taskRequests,
+    reconciliation,
+  };
+}
+
+async function executeFanoutReconcileRun(input) {
+  const plan = input.plan || createFanoutReconcilePlan(input);
+  const executeTaskRequest = requiredFunction(input.execute_task_request, 'execute_task_request');
+  const classifyOutcome = typeof input.classify_outcome === 'function' ? input.classify_outcome : (record) => record.outcome;
+  const reconcile = typeof input.reconcile === 'function' ? input.reconcile : () => ({});
+  const isRecordSuccessful = typeof input.is_record_successful === 'function'
+    ? input.is_record_successful
+    : (record) => record.status === 'completed' || record.success === true;
+  const taskId = typeof input.task_id === 'function' ? input.task_id : defaultTaskId;
+  const runningEntry = typeof input.running_entry === 'function' ? input.running_entry : defaultRunningEntry;
+  const progressEvent = typeof input.progress_event === 'function' ? input.progress_event : defaultProgressEvent;
+  const taskOrder = typeof input.task_order === 'function'
+    ? input.task_order
+    : (record) => defaultTaskOrder(plan, taskId, record);
+  const onProgress = typeof input.on_progress === 'function' ? input.on_progress : () => {};
+  const concurrency = normalizeConcurrency(input.concurrency);
+  const records = [];
+  const running = new Map();
+  const runSchema = input.run_schema || RUN_SCHEMA;
+  const baseRun = {
+    schema: runSchema,
+    plan_schema: plan.schema,
+    orchestrator: plan.orchestrator,
+    ...(input.include_summary === false ? {} : { summary: plan.summary }),
+    ...(input.base_run || {}),
+  };
+  const writeRun = (run) => {
+    if (input.runs_output_path) {
+      writeJson(input.runs_output_path, run);
+    }
+  };
+  const writeIncompleteRun = () => {
+    writeRun({
+      ...baseRun,
+      records,
+      status: 'incomplete',
+      current_group: firstRunningGroup(running),
+      current_groups: runningGroups(running),
+    });
+  };
+
+  writeRun({
+    ...baseRun,
+    records,
+    status: 'incomplete',
+    current_group: null,
+  });
+
+  let nextIndex = 0;
+  const startNext = () => {
+    if (nextIndex >= plan.task_requests.length) {
+      return false;
+    }
+    const taskRequest = plan.task_requests[nextIndex];
+    nextIndex += 1;
+    const id = taskId(taskRequest);
+
+    running.set(id, runningEntry(taskRequest));
+    writeIncompleteRun();
+
+    onProgress(progressEvent('started', taskRequest, plan));
+    const promise = Promise.resolve(executeTaskRequest(taskRequest, input)).then((record) => {
+      running.delete(id);
+      records.push(record);
+      records.sort((left, right) => taskOrder(left) - taskOrder(right));
+      onProgress(progressEvent(record.status || (isRecordSuccessful(record) ? 'completed' : 'failed'), taskRequest, plan, record));
+      writeIncompleteRun();
+      startNext();
+    });
+    running.get(id).promise = promise;
+    return true;
+  };
+
+  while (running.size < concurrency && startNext()) {
+    // Start the first batch.
+  }
+
+  while (running.size > 0) {
+    await Promise.race(Array.from(running.values()).map((group) => group.promise));
+  }
+
+  const outcomes = records.flatMap((record) => {
+    const outcome = classifyOutcome(record);
+    return outcome ? [outcome] : [];
+  });
+  const reconciliation = reconcile({
+    plan,
+    records,
+    outcomes,
+  }) || {};
+  const run = {
+    ...baseRun,
+    records,
+    outcomes,
+    ...(input.include_reconciliation === false ? {} : { reconciliation }),
+    status: records.every(isRecordSuccessful) ? 'completed' : 'failed',
+  };
+
+  writeRun(run);
+
+  return run;
+}
+
+function requiredFunction(value, name) {
+  if (typeof value !== 'function') {
+    throw new Error(`fanout reconcile runner requires ${name}`);
+  }
+  return value;
+}
+
+function normalizeConcurrency(value) {
+  const parsed = Number.parseInt(value || DEFAULT_CONCURRENCY, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_CONCURRENCY;
+  }
+  return Math.min(parsed, 16);
+}
+
+function defaultTaskId(taskRequest) {
+  return taskRequest.id || taskRequest.sandbox_session_id || taskRequest.group_key;
+}
+
+function defaultRunningEntry(taskRequest) {
+  return {
+    id: defaultTaskId(taskRequest),
+    group_key: taskRequest.group_key || '',
+  };
+}
+
+function firstRunningGroup(running) {
+  const group = runningGroups(running)[0];
+  if (!group) {
+    return null;
+  }
+  return group;
+}
+
+function runningGroups(running) {
+  return Array.from(running.values()).map((group) => {
+    const { promise, ...serializable } = group;
+    return serializable;
+  });
+}
+
+function defaultTaskOrder(plan, taskId, record) {
+  const recordId = record.id || record.sandbox_session_id || record.group_key;
+  return plan.task_requests.findIndex((taskRequest) => taskId(taskRequest) === recordId);
+}
+
+function defaultProgressEvent(status, taskRequest, plan, record = null) {
+  return {
+    schema: 'homeboy/fanout-reconcile-progress/v1',
+    status,
+    id: defaultTaskId(taskRequest),
+    group_key: taskRequest.group_key || '',
+    group_index: Number(taskRequest.orchestrator?.group_index || 0) + 1,
+    group_count: Number(plan.summary?.group_count || plan.task_requests.length || 0),
+    outcome_kind: record?.outcome?.kind || '',
+  };
+}
+
+module.exports = {
+  PLAN_SCHEMA,
+  RUN_SCHEMA,
+  DEFAULT_CONCURRENCY,
+  createFanoutReconcilePlan,
+  executeFanoutReconcileRun,
+  groupFanoutItems,
+  normalizeConcurrency,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -32,6 +32,7 @@
     "./static-visual-parity": "./lib/static-visual-parity.js",
     "./webperf-evidence-summary": "./lib/webperf-evidence-summary.js",
     "./benchmark-matrix-report": "./lib/benchmark-matrix-report.js",
+    "./fanout-reconcile-runner": "./lib/fanout-reconcile-runner.js",
     "./audit-wp-codebox-fanout": "./lib/audit-wp-codebox-fanout.js",
     "./wordpress-runtime-task-planner": "./lib/wordpress-runtime-task-planner.js"
   },
@@ -64,6 +65,7 @@
     "test:static-visual-parity": "node tests/static-visual-parity-smoke.js",
     "test:webperf-evidence-summary": "node tests/webperf-evidence-summary-smoke.js",
     "test:benchmark-matrix-report": "node tests/benchmark-matrix-report-smoke.js",
+    "test:fanout-reconcile-runner": "node tests/fanout-reconcile-runner-smoke.js",
     "test:wordpress-bench-state-sampling": "php tests/wordpress-bench-state-sampling-helper-smoke.php",
     "test:wordpress-bench-artifacts": "php tests/wordpress-bench-artifact-helper-smoke.php",
     "test:wordpress-bench-woocommerce-fixtures": "php tests/wordpress-bench-woocommerce-fixtures-smoke.php",

--- a/wordpress/tests/fanout-reconcile-runner-smoke.js
+++ b/wordpress/tests/fanout-reconcile-runner-smoke.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  createFanoutReconcilePlan,
+  executeFanoutReconcileRun,
+  groupFanoutItems,
+} = require('../lib/fanout-reconcile-runner');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function renderTaskRequest(group, orchestrator) {
+  return {
+    id: `task-${group.key}`,
+    group_key: group.key,
+    item_ids: group.items.map((item) => item.id),
+    goal: `Resolve ${group.key}: ${group.items.map((item) => item.id).join(', ')}`,
+    orchestrator: {
+      ...orchestrator,
+      group_index: group.index,
+    },
+  };
+}
+
+function reconcilePlan({ groups }) {
+  return {
+    targets: groups.map((group) => ({
+      group_key: group.key,
+      item_ids: group.items.map((item) => item.id),
+    })),
+  };
+}
+
+async function main() {
+  const items = [
+    { id: 'a1', group: 'alpha' },
+    { id: 'a2', group: 'alpha' },
+    { id: 'b1', group: 'beta' },
+  ];
+  const groups = groupFanoutItems(items, { group_key: (item) => item.group });
+  const plan = createFanoutReconcilePlan({
+    schema: 'fixture/fanout-plan/v1',
+    orchestrator: {
+      id: 'fixture-orchestrator',
+      run_id: 'fixture-run',
+    },
+    groups,
+    summary: { fixture: true },
+    render_task_request: renderTaskRequest,
+    reconcile_plan: reconcilePlan,
+  });
+  const goldenPlan = readJson(path.join(__dirname, 'fixtures', 'fanout-reconcile-runner', 'golden-plan.json'));
+  assert.deepEqual(plan, goldenPlan);
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-fanout-reconcile-runner-'));
+  const runsOutputPath = path.join(root, 'run.json');
+  const progressEvents = [];
+  try {
+    const run = await executeFanoutReconcileRun({
+      plan,
+      concurrency: 2,
+      runs_output_path: runsOutputPath,
+      on_progress: (event) => progressEvents.push(event),
+      execute_task_request: async (taskRequest) => ({
+        id: taskRequest.id,
+        group_key: taskRequest.group_key,
+        item_ids: taskRequest.item_ids,
+        status: taskRequest.group_key === 'beta' ? 'failed' : 'completed',
+        outcome: {
+          kind: taskRequest.group_key === 'beta' ? 'needs_review' : 'applied',
+          item_ids: taskRequest.item_ids,
+        },
+      }),
+      classify_outcome: (record) => record.outcome,
+      is_record_successful: (record) => record.status === 'completed',
+      reconcile: ({ records, outcomes }) => ({
+        completed_item_ids: records
+          .filter((record) => record.status === 'completed')
+          .flatMap((record) => record.item_ids),
+        review_item_ids: outcomes
+          .filter((outcome) => outcome.kind === 'needs_review')
+          .flatMap((outcome) => outcome.item_ids),
+      }),
+    });
+
+    assert.equal(run.schema, 'homeboy/fanout-reconcile-run/v1');
+    assert.equal(run.status, 'failed');
+    assert.deepEqual(run.records.map((record) => record.id), ['task-alpha', 'task-beta']);
+    assert.deepEqual(run.outcomes.map((outcome) => outcome.kind), ['applied', 'needs_review']);
+    assert.deepEqual(run.reconciliation.completed_item_ids, ['a1', 'a2']);
+    assert.deepEqual(run.reconciliation.review_item_ids, ['b1']);
+    assert.equal(progressEvents.filter((event) => event.status === 'started').length, 2);
+    assert.equal(progressEvents.find((event) => event.status === 'failed').group_key, 'beta');
+
+    const persisted = readJson(runsOutputPath);
+    assert.equal(persisted.status, 'failed');
+    assert.equal(Object.hasOwn(persisted, 'current_group'), false);
+    assert.deepEqual(persisted.reconciliation.review_item_ids, ['b1']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+
+  console.log('Homeboy fanout reconcile runner smoke passed');
+}
+
+main().catch((error) => {
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+});

--- a/wordpress/tests/fixtures/fanout-reconcile-runner/golden-plan.json
+++ b/wordpress/tests/fixtures/fanout-reconcile-runner/golden-plan.json
@@ -1,0 +1,71 @@
+{
+  "schema": "fixture/fanout-plan/v1",
+  "orchestrator": {
+    "id": "fixture-orchestrator",
+    "run_id": "fixture-run"
+  },
+  "summary": {
+    "item_count": 3,
+    "group_count": 2,
+    "task_count": 2,
+    "fixture": true
+  },
+  "groups": [
+    {
+      "key": "alpha",
+      "index": 0,
+      "item_count": 2
+    },
+    {
+      "key": "beta",
+      "index": 1,
+      "item_count": 1
+    }
+  ],
+  "task_requests": [
+    {
+      "id": "task-alpha",
+      "group_key": "alpha",
+      "item_ids": [
+        "a1",
+        "a2"
+      ],
+      "goal": "Resolve alpha: a1, a2",
+      "orchestrator": {
+        "id": "fixture-orchestrator",
+        "run_id": "fixture-run",
+        "group_index": 0
+      }
+    },
+    {
+      "id": "task-beta",
+      "group_key": "beta",
+      "item_ids": [
+        "b1"
+      ],
+      "goal": "Resolve beta: b1",
+      "orchestrator": {
+        "id": "fixture-orchestrator",
+        "run_id": "fixture-run",
+        "group_index": 1
+      }
+    }
+  ],
+  "reconciliation": {
+    "targets": [
+      {
+        "group_key": "alpha",
+        "item_ids": [
+          "a1",
+          "a2"
+        ]
+      },
+      {
+        "group_key": "beta",
+        "item_ids": [
+          "b1"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable fan-out/reconcile runner primitive for grouping inputs, rendering task requests, executing concurrent task records, classifying outcomes, and reconciling results
- refactor the audit WP Codebox fan-out preset to delegate execution mechanics to the generic runner while preserving its run envelope and behavior
- add a focused generic smoke test with a golden plan fixture

## Testing
- npm run test:fanout-reconcile-runner
- npm run test:audit-wp-codebox-fanout
- npx eslint lib/fanout-reconcile-runner.js lib/audit-wp-codebox-fanout.js tests/fanout-reconcile-runner-smoke.js --no-warn-ignored

## Caveats
- npm run lint:js still reports existing unrelated lint failures in files outside this change, including playground-readiness.js, timing-correlator.js, and several scripts/agent files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** extracted and tested generic fan-out/reconcile runner