### PR TITLE
Aggregate host-smoke failures instead of failing one per run

### DIFF
--- a/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
+++ b/wordpress/scripts/test/host-smoke-wp-runner-smoke.sh
@@ -11,6 +11,46 @@ EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
+# Standalone-execution context. When homeboy core drives this self-check it
+# injects the runtime helper wrappers; running the script directly (local dev,
+# `bash -n` follow-up) needs a minimal resolve-context that derives PLUGIN_PATH
+# /EXTENSION_PATH/COMPONENT_ID from the HOMEBOY_COMPONENT_* env the runner reads.
+RESOLVE_CONTEXT_STUB="${TMPDIR}/resolve-context.sh"
+cat > "$RESOLVE_CONTEXT_STUB" <<'SH'
+homeboy_resolve_context() {
+    PLUGIN_PATH="${HOMEBOY_COMPONENT_PATH:?HOMEBOY_COMPONENT_PATH is required}"
+    EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:?HOMEBOY_EXTENSION_PATH is required}"
+    COMPONENT_ID="${HOMEBOY_COMPONENT_ID:-$(basename "$PLUGIN_PATH")}"
+}
+SH
+export HOMEBOY_RUNTIME_RESOLVE_CONTEXT="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-$RESOLVE_CONTEXT_STUB}"
+
+# Minimal runner-prelude for test-runner.sh routing cases. Homeboy core injects
+# the real prelude; standalone runs only need homeboy_runner_init to populate
+# the component-path alias from the HOMEBOY_COMPONENT_* env.
+RUNNER_PRELUDE_STUB="${TMPDIR}/runner-prelude.sh"
+cat > "$RUNNER_PRELUDE_STUB" <<'SH'
+homeboy_runner_init() {
+    local alias_var="PLUGIN_PATH"
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --component-alias)
+                shift
+                alias_var="${1:-PLUGIN_PATH}"
+                ;;
+            --bash)
+                shift
+                ;;
+        esac
+        shift
+    done
+    EXTENSION_PATH="${HOMEBOY_EXTENSION_PATH:?HOMEBOY_EXTENSION_PATH is required}"
+    COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
+    printf -v "$alias_var" '%s' "$COMPONENT_PATH"
+}
+SH
+export HOMEBOY_RUNTIME_RUNNER_PRELUDE="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-$RUNNER_PRELUDE_STUB}"
+
 assert_contains() {
     local file="$1" expected="$2"
     if ! grep -Fq "$expected" "$file"; then
@@ -187,6 +227,88 @@ FAKE_CODEBOX_CAPTURE_DIR="$CAPTURE_DIR" \
 assert_contains "${TMPDIR}/operator.out" "Backend: host-smoke-wp"
 assert_contains "${TMPDIR}/operator.out" "HOST_SMOKE_BEGIN:tests/alpha-smoke.php"
 assert_contains "${TMPDIR}/operator.out" "HOST_SMOKE_OK:tests/alpha-smoke.php"
+
+# --- Aggregation: multiple smoke files run in ONE pass. Even when an early
+# smoke fails, every remaining smoke still runs and all failures are reported
+# together (#4682), instead of stopping at the first failure (which forced an
+# iterative fix-one/rerun-CI loop). The overall status stays non-zero.
+make_aggregate_component() {
+    local target="$1"
+    mkdir -p "$target/tests"
+    for name in alpha beta gamma; do
+        cat > "$target/tests/${name}-smoke.php" <<PHP
+<?php
+echo "${name} ok\n";
+PHP
+    done
+}
+
+aggregate_component="${TMPDIR}/aggregate-component"
+make_aggregate_component "$aggregate_component"
+
+# Fake codebox that fails for any wrapper whose mounted smoke path contains a
+# blocked basename, and succeeds otherwise. Lets us fail beta + gamma while
+# alpha passes, and assert all failures surface in a single run.
+FAKE_CODEBOX_SELECTIVE="${TMPDIR}/fake-wp-codebox-selective.cjs"
+cat > "$FAKE_CODEBOX_SELECTIVE" <<'JS'
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const args = process.argv.slice(2);
+const recipeIdx = args.indexOf('--recipe');
+const recipe = JSON.parse(fs.readFileSync(args[recipeIdx + 1], 'utf8'));
+const codeFileArg = recipe.workflow.steps[0].args.find((arg) => arg.startsWith('code-file='));
+const wrapper = fs.readFileSync(codeFileArg.slice('code-file='.length), 'utf8');
+const blocked = (process.env.FAKE_CODEBOX_FAIL_BASENAMES || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+const fails = blocked.some((name) => wrapper.includes(name));
+if (fails) {
+  process.stdout.write(JSON.stringify({
+    success: false,
+    executions: [{ command: 'wordpress.run-php', exitCode: 1, stdout: '', stderr: 'smoke threw\n' }],
+  }));
+} else {
+  process.stdout.write(JSON.stringify({
+    success: true,
+    executions: [{ command: 'wordpress.run-php', exitCode: 0, stdout: 'OK fake smoke passed\n', stderr: '' }],
+  }));
+}
+JS
+
+set +e
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="aggregate-component" \
+HOMEBOY_COMPONENT_PATH="$aggregate_component" \
+HOMEBOY_WP_CODEBOX_BIN="$FAKE_CODEBOX_SELECTIVE" \
+HOMEBOY_WORDPRESS_HOST_SMOKE_FILES=$'tests/alpha-smoke.php\ntests/beta-smoke.php\ntests/gamma-smoke.php' \
+FAKE_CODEBOX_FAIL_BASENAMES="beta-smoke.php,gamma-smoke.php" \
+FAKE_CODEBOX_CAPTURE_DIR="$CAPTURE_DIR" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner-host-smoke-wp.sh" > "${TMPDIR}/aggregate.out" 2>&1
+aggregate_exit=$?
+set -e
+
+# Overall run must fail because two smokes failed.
+if [ "$aggregate_exit" -eq 0 ]; then
+    echo "Expected aggregated real-WP smoke run to fail when any smoke fails" >&2
+    sed 's/^/  /' "${TMPDIR}/aggregate.out" >&2
+    exit 1
+fi
+
+# The passing smoke still ran and passed.
+assert_contains "${TMPDIR}/aggregate.out" "HOST_SMOKE_OK:tests/alpha-smoke.php"
+# BOTH failing smokes are reported in the same run — beta did not short-circuit
+# gamma. This is the core #4682 guarantee.
+assert_contains "${TMPDIR}/aggregate.out" "HOST_SMOKE_FAIL:tests/beta-smoke.php:exit=1"
+assert_contains "${TMPDIR}/aggregate.out" "HOST_SMOKE_FAIL:tests/gamma-smoke.php:exit=1"
+# Aggregated summary counts every smoke, and the failure roster lists each one.
+assert_contains "${TMPDIR}/aggregate.out" "HOST_SMOKE_SUMMARY:passed=1 failed=2"
+assert_contains "${TMPDIR}/aggregate.out" "Real-WordPress smoke tests failed (2 of 3):"
+# Roster entries are indented with "  - "; match on the indented prefix so the
+# leading dash is never read as a grep option.
+assert_contains "${TMPDIR}/aggregate.out" "  - tests/beta-smoke.php:exit=1"
+assert_contains "${TMPDIR}/aggregate.out" "  - tests/gamma-smoke.php:exit=1"
 
 help_output="$(HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" HOMEBOY_COMPONENT_ID="component" HOMEBOY_COMPONENT_PATH="$component" HOMEBOY_COMPONENT_SHAPE="plugin" bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --help)"
 if [[ "$help_output" != *"--host-smoke-file <path>"* ]] || [[ "$help_output" != *"HOST_SMOKE_BEGIN"* ]]; then

--- a/wordpress/scripts/test/test-runner-host-smoke-wp.sh
+++ b/wordpress/scripts/test/test-runner-host-smoke-wp.sh
@@ -322,22 +322,46 @@ echo "  WordPress: ${WP_VERSION:-default}"
 echo "  Per-file timeout: ${HOST_SMOKE_TIMEOUT_SECONDS}s"
 echo ""
 
+# Run every selected smoke even after one fails, then aggregate. Stopping at
+# the first failure forced an iterative fix-one/rerun-CI loop (#4682): each run
+# surfaced only a single failing smoke. Collecting all failures lets the
+# operator fix them in one pass. The overall exit status is still non-zero when
+# any smoke failed (with the first failing exit code preserved) so CI stays red.
 passed=0
+failed=0
+failed_smokes=()
+first_failure_exit=0
 for smoke_file in "${smoke_files[@]}"; do
     rel_path="${smoke_file#"${PLUGIN_PATH}/"}"
     echo "HOST_SMOKE_BEGIN:${rel_path}"
-    if run_one_smoke "$smoke_file"; then
+    # `&&`/`||` provides an errexit-safe context: run_one_smoke toggles `set -e`
+    # internally, so calling it bare under errexit would abort the loop on the
+    # first failing smoke — exactly the one-failure-per-run bug (#4682). Capture
+    # the real exit status directly (a trailing `!`/`if` would clobber `$?`).
+    smoke_status=0
+    run_one_smoke "$smoke_file" || smoke_status=$?
+    if [ "$smoke_status" -eq 0 ]; then
         echo "HOST_SMOKE_OK:${rel_path}"
         passed=$((passed + 1))
     else
-        exit_code=$?
-        echo "HOST_SMOKE_FAIL:${rel_path}:exit=${exit_code}"
-        echo ""
-        echo "Real-WordPress smoke test failed: ${rel_path}"
-        exit "$exit_code"
+        echo "HOST_SMOKE_FAIL:${rel_path}:exit=${smoke_status}"
+        failed=$((failed + 1))
+        failed_smokes+=("${rel_path}:exit=${smoke_status}")
+        if [ "$first_failure_exit" -eq 0 ]; then
+            first_failure_exit="$smoke_status"
+        fi
     fi
 done
 
 echo ""
-echo "HOST_SMOKE_SUMMARY:passed=${passed} failed=0"
+echo "HOST_SMOKE_SUMMARY:passed=${passed} failed=${failed}"
+if [ "$failed" -gt 0 ]; then
+    echo ""
+    echo "Real-WordPress smoke tests failed (${failed} of ${#smoke_files[@]}):"
+    for failed_smoke in "${failed_smokes[@]}"; do
+        echo "  - ${failed_smoke}"
+    done
+    exit "$first_failure_exit"
+fi
+
 echo "Real-WordPress smoke test run complete."

--- a/wordpress/scripts/test/test-runner.sh
+++ b/wordpress/scripts/test/test-runner.sh
@@ -170,6 +170,11 @@ homeboy_wordpress_run_js_smoke_files() {
     echo "  Files: ${#smoke_files[@]}"
     echo ""
 
+    # Run every selected smoke even after one fails, then aggregate (#4682) so
+    # one run reports all failing smokes instead of one-per-CI-run.
+    local failed=0
+    local first_failure_exit=0
+    local failed_smokes=()
     for smoke_file in "${smoke_files[@]}"; do
         rel_path="${smoke_file#"${PLUGIN_PATH}/"}"
         echo "JS_SMOKE_BEGIN:${rel_path}"
@@ -179,14 +184,24 @@ homeboy_wordpress_run_js_smoke_files() {
         else
             exit_code=$?
             echo "JS_SMOKE_FAIL:${rel_path}:exit=${exit_code}"
-            echo ""
-            echo "JS smoke test failed: ${rel_path}"
-            exit "$exit_code"
+            failed=$((failed + 1))
+            failed_smokes+=("${rel_path}:exit=${exit_code}")
+            if [ "$first_failure_exit" -eq 0 ]; then
+                first_failure_exit="$exit_code"
+            fi
         fi
     done
 
     echo ""
-    echo "JS_SMOKE_SUMMARY:passed=${passed} failed=0"
+    echo "JS_SMOKE_SUMMARY:passed=${passed} failed=${failed}"
+    if [ "$failed" -gt 0 ]; then
+        echo ""
+        echo "JS smoke tests failed (${failed} of ${#smoke_files[@]}):"
+        for failed_smoke in "${failed_smokes[@]}"; do
+            echo "  - ${failed_smoke}"
+        done
+        exit "$first_failure_exit"
+    fi
     echo "Host JS smoke test run complete."
 }
 
@@ -227,6 +242,11 @@ homeboy_wordpress_run_shell_smoke_files() {
     echo "  Files: ${#smoke_files[@]}"
     echo ""
 
+    # Run every selected smoke even after one fails, then aggregate (#4682) so
+    # one run reports all failing smokes instead of one-per-CI-run.
+    local failed=0
+    local first_failure_exit=0
+    local failed_smokes=()
     for smoke_file in "${smoke_files[@]}"; do
         rel_path="${smoke_file#"${PLUGIN_PATH}/"}"
         echo "SHELL_SMOKE_BEGIN:${rel_path}"
@@ -236,14 +256,24 @@ homeboy_wordpress_run_shell_smoke_files() {
         else
             exit_code=$?
             echo "SHELL_SMOKE_FAIL:${rel_path}:exit=${exit_code}"
-            echo ""
-            echo "Shell smoke test failed: ${rel_path}"
-            exit "$exit_code"
+            failed=$((failed + 1))
+            failed_smokes+=("${rel_path}:exit=${exit_code}")
+            if [ "$first_failure_exit" -eq 0 ]; then
+                first_failure_exit="$exit_code"
+            fi
         fi
     done
 
     echo ""
-    echo "SHELL_SMOKE_SUMMARY:passed=${passed} failed=0"
+    echo "SHELL_SMOKE_SUMMARY:passed=${passed} failed=${failed}"
+    if [ "$failed" -gt 0 ]; then
+        echo ""
+        echo "Shell smoke tests failed (${failed} of ${#smoke_files[@]}):"
+        for failed_smoke in "${failed_smokes[@]}"; do
+            echo "  - ${failed_smoke}"
+        done
+        exit "$first_failure_exit"
+    fi
     echo "Host shell smoke test run complete."
 }
 


### PR DESCRIPTION
## Summary
- The real-WordPress host-smoke runner (`test-runner-host-smoke-wp.sh`) stopped at the **first** failing `*-smoke.php`, forcing an iterative fix-one-smoke / rerun-CI loop where each run surfaced only one failure (fix smoke A → smoke B fails → fix B → smoke C fails…).
- Now every selected smoke runs even after one fails. All failures are collected and reported together with an aggregated `HOST_SMOKE_SUMMARY:passed=N failed=M` line plus a per-file failure roster, while the overall run still exits non-zero (first failing exit code preserved) so CI stays red.
- Applied the same aggregation to the JS (`JS_SMOKE_*`) and shell (`SHELL_SMOKE_*`) host-smoke loops in `test-runner.sh`, which shared the identical first-failure short-circuit.

## Why
Closes Extra-Chill/homeboy#4682. The issue was filed against `homeboy`, but the host-smoke phase that short-circuits lives here in the WordPress extension's smoke runners — homeboy core has no per-file smoke runner. Aggregating failures makes PR triage much faster and avoids serial CI loops for unrelated smoke-harness papercuts.

## Implementation notes
- `run_one_smoke` toggles `set -e` internally, so the loop calls it via `run_one_smoke "$f" || smoke_status=$?` to stay errexit-safe and capture the real exit status without aborting the loop.
- Markers (`HOST_SMOKE_BEGIN/OK/FAIL/SUMMARY`, JS/SHELL equivalents) and per-file semantics are unchanged; only the summary now reports `failed=M` and lists failing files.

## Tests
- Extended `host-smoke-wp-runner-smoke.sh` with a multi-file aggregation case: 3 smokes where 2 fail — asserts the passing smoke still runs, **both** failing smokes are reported in one run, the summary shows `passed=1 failed=2`, the failure roster lists each failing file, and the overall run still exits non-zero.
- Added standalone resolve-context/runner-prelude stubs (gated with `:-` so homeboy's real runtime injection still wins) so the self-check runs locally as well as under homeboy.