### PR TITLE
Add runtime provider resolver groundwork

### DIFF
--- a/.github/scripts/datamachine-agent-ci/build-runner-config.cjs
+++ b/.github/scripts/datamachine-agent-ci/build-runner-config.cjs
@@ -13,6 +13,7 @@ const {
   splitCsv,
   writeGithubOutput,
 } = require('./lib/common.cjs');
+const { resolveRuntimeProvider } = require('../../../agent-runtimes/lib/runtime-provider-resolver.cjs');
 
 function main() {
   const config = buildConfig(process.env);
@@ -34,14 +35,11 @@ function buildConfig(env) {
   const runtimeId = env.AGENT_RUNTIME || 'wp-codebox';
   const runtimeProfile = env.RUNTIME_PROFILE || 'datamachine-agent-ci';
   const runtimeProfiles = parseJsonInput('runtime_profiles', env.RUNTIME_PROFILES || '{}', 'object', {});
-
-  if (runtimeId !== 'wp-codebox') {
-    throw new Error(`Unsupported agent_runtime: ${runtimeId}. Only wp-codebox is currently supported.`);
-  }
+  const runtime = resolveRuntimeProvider(runtimeId, { workspace, env });
 
   const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || 'openai', true);
   const validationDependencies = validationPaths(workspace, providerPlugin, env.PROVIDER || 'openai');
-  const runtimeBin = path.join(workspace, '.ci/wp-codebox/packages/cli/dist/index.js');
+  const runtimeBin = runtime.paths.runtime_bin;
   if (!fs.existsSync(runtimeBin)) {
     throw new Error(`Runtime CLI build missing at ${runtimeBin}`);
   }
@@ -138,7 +136,7 @@ function buildConfig(env) {
     provider_credentials: providerCredentials,
     runtime_bin: runtimeBin,
     runtime_components: {
-      runtime: path.join(workspace, '.ci/wp-codebox/packages/wordpress-plugin'),
+      runtime: runtime.paths.runtime_component,
       agents_api: path.join(workspace, '.ci/agents-api'),
       data_machine: path.join(workspace, '.ci/data-machine'),
       data_machine_code: path.join(workspace, '.ci/data-machine-code'),

--- a/.github/scripts/datamachine-agent-ci/materialize-dependencies.cjs
+++ b/.github/scripts/datamachine-agent-ci/materialize-dependencies.cjs
@@ -4,6 +4,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { capture, normalizeProviderPlugin, requireRepo, run, splitCsv } = require('./lib/common.cjs');
+const { resolveRuntimeProvider } = require('../../../agent-runtimes/lib/runtime-provider-resolver.cjs');
 
 function main() {
   const printPlan = process.argv.includes('--print-plan');
@@ -24,10 +25,8 @@ function main() {
 
 function dependencyEntries(env) {
   const runtimeId = env.AGENT_RUNTIME || 'wp-codebox';
-  if (runtimeId !== 'wp-codebox') {
-    throw new Error(`Unsupported agent_runtime: ${runtimeId}. Only wp-codebox is currently supported.`);
-  }
-  const entries = [`Automattic/wp-codebox@${env.AGENT_RUNTIME_REF || 'main'}`];
+  const runtime = resolveRuntimeProvider(runtimeId, { env });
+  const entries = [{ repo: runtime.checkout.repo, ref: runtime.checkout.ref, target: runtime.checkout.target }];
   const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || 'openai', true);
   if (env.INCLUDE_AGENT_RUNTIME_DEPENDENCIES === 'true') {
     entries.push(`Automattic/agents-api@${env.AGENTS_API_REF || 'main'}`);
@@ -48,17 +47,13 @@ function resolvePlan(entries, offline) {
   const seen = new Set();
   const plan = [];
   for (const rawEntry of entries) {
-    const entry = rawEntry.trim();
-    if (!entry) {
+    const entry = normalizeDependencyEntry(rawEntry);
+    if (!entry.repo) {
       continue;
     }
-    const atIndex = entry.lastIndexOf('@');
-    const repo = atIndex === -1 ? entry : entry.slice(0, atIndex);
-    let ref = atIndex === -1 ? '' : entry.slice(atIndex + 1);
+    const { repo, target } = entry;
+    let { ref } = entry;
     requireRepo(repo, 'validation_dependencies entries');
-    if (atIndex !== -1 && !ref) {
-      throw new Error(`validation_dependencies entries must include a non-empty ref after @: ${entry}`);
-    }
     if (!ref) {
       if (offline) {
         ref = '<default-branch>';
@@ -74,9 +69,30 @@ function resolvePlan(entries, offline) {
       continue;
     }
     seen.add(key);
-    plan.push({ repo, ref, target: path.join('.ci', repo.split('/')[1]) });
+    plan.push({ repo, ref, target: target || path.join('.ci', repo.split('/')[1]) });
   }
   return plan;
+}
+
+function normalizeDependencyEntry(rawEntry) {
+  if (rawEntry && !Array.isArray(rawEntry) && typeof rawEntry === 'object') {
+    return {
+      repo: rawEntry.repo || '',
+      ref: rawEntry.ref || '',
+      target: rawEntry.target || '',
+    };
+  }
+  const entry = String(rawEntry || '').trim();
+  if (!entry) {
+    return { repo: '', ref: '', target: '' };
+  }
+  const atIndex = entry.lastIndexOf('@');
+  const repo = atIndex === -1 ? entry : entry.slice(0, atIndex);
+  const ref = atIndex === -1 ? '' : entry.slice(atIndex + 1);
+  if (atIndex !== -1 && !ref) {
+    throw new Error(`validation_dependencies entries must include a non-empty ref after @: ${entry}`);
+  }
+  return { repo, ref, target: '' };
 }
 
 try {

--- a/.github/scripts/datamachine-agent-ci/setup-runtime.cjs
+++ b/.github/scripts/datamachine-agent-ci/setup-runtime.cjs
@@ -4,13 +4,16 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { normalizeProviderPlugin, run } = require('./lib/common.cjs');
+const { resolveRuntimeProvider } = require('../../../agent-runtimes/lib/runtime-provider-resolver.cjs');
 
 try {
   const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+  const runtime = resolveRuntimeProvider(process.env.AGENT_RUNTIME || 'wp-codebox', { workspace });
   run('composer', ['install', '--no-interaction', '--no-progress', '--prefer-dist'], { cwd: path.join(workspace, '.ci/homeboy-extensions/wordpress') });
   run('npm', ['install'], { cwd: path.join(workspace, '.ci/homeboy-extensions/wordpress') });
-  run('npm', ['install'], { cwd: path.join(workspace, '.ci/wp-codebox') });
-  run('npm', ['run', 'build'], { cwd: path.join(workspace, '.ci/wp-codebox') });
+  for (const command of [...runtime.setupCommands, ...runtime.buildCommands]) {
+    run(command.command, command.args, { cwd: path.join(workspace, command.cwd) });
+  }
   installCheckedOutPhpDependencies(workspace);
 } catch (error) {
   process.stderr.write(`${error.message}\n`);

--- a/agent-runtimes/lib/runtime-provider-resolver.cjs
+++ b/agent-runtimes/lib/runtime-provider-resolver.cjs
@@ -1,0 +1,102 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_RUNTIME_ID = 'wp-codebox';
+
+function repoRootFromHere() {
+	return path.resolve(__dirname, '..', '..');
+}
+
+function readJson(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function runtimeManifestPath(runtimeId, repoRoot = repoRootFromHere()) {
+	return path.join(repoRoot, 'agent-runtimes', runtimeId, `${runtimeId}.json`);
+}
+
+function runtimeRegistry(options = {}) {
+	const repoRoot = options.repoRoot || repoRootFromHere();
+	const manifests = {
+		[DEFAULT_RUNTIME_ID]: readJson(runtimeManifestPath(DEFAULT_RUNTIME_ID, repoRoot)),
+	};
+	return manifests;
+}
+
+function resolveRuntimeProvider(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
+	const id = runtimeId || DEFAULT_RUNTIME_ID;
+	const registry = options.registry || runtimeRegistry(options);
+	const manifest = registry[id];
+	if (!manifest) {
+		throw new Error(`Unsupported agent_runtime: ${id}. Registered runtimes: ${Object.keys(registry).sort().join(', ') || '(none)'}.`);
+	}
+
+	const materialization = manifest.ci_materialization || {};
+	const workspace = options.workspace || process.env.GITHUB_WORKSPACE || process.cwd();
+	const refEnv = materialization.checkout?.ref_env || 'AGENT_RUNTIME_REF';
+	const checkoutTarget = materialization.checkout?.target || path.join('.ci', id);
+	const checkout = {
+		repo: materialization.checkout?.repo || '',
+		ref: options.env?.[refEnv] || process.env[refEnv] || materialization.checkout?.default_ref || 'main',
+		target: checkoutTarget,
+		targetPath: path.join(workspace, checkoutTarget),
+	};
+
+	return {
+		id,
+		manifest,
+		checkout,
+		setupCommands: normalizeCommands(materialization.setup_commands || []),
+		buildCommands: normalizeCommands(materialization.build_commands || []),
+		paths: resolvePaths(materialization.paths || {}, workspace),
+		executor: resolveExecutor(manifest, options.repoRoot || repoRootFromHere()),
+	};
+}
+
+function normalizeCommands(commands) {
+	if (!Array.isArray(commands)) {
+		throw new Error('runtime ci_materialization commands must be an array');
+	}
+	return commands.map((command) => {
+		if (!command || Array.isArray(command) || typeof command !== 'object') {
+			throw new Error('runtime ci_materialization command entries must be objects');
+		}
+		if (!command.command || typeof command.command !== 'string') {
+			throw new Error('runtime ci_materialization command entries require a command');
+		}
+		const args = command.args || [];
+		if (!Array.isArray(args) || args.some((arg) => typeof arg !== 'string')) {
+			throw new Error('runtime ci_materialization command args must be strings');
+		}
+		return {
+			command: command.command,
+			args,
+			cwd: command.cwd || '.',
+		};
+	});
+}
+
+function resolvePaths(paths, workspace) {
+	return Object.fromEntries(Object.entries(paths).map(([key, value]) => [
+		key,
+		typeof value === 'string' && value.length > 0 ? path.join(workspace, value) : value,
+	]));
+}
+
+function resolveExecutor(manifest, repoRoot) {
+	const provider = Array.isArray(manifest.agent_task_executors) ? manifest.agent_task_executors[0] : null;
+	const argv = provider?.invocation?.argv || [];
+	const scriptArg = argv.find((arg) => typeof arg === 'string' && arg.includes('{{runtime_path}}')) || '';
+	return {
+		backend: provider?.backend || '',
+		path: scriptArg ? scriptArg.replace('{{runtime_path}}', path.join(repoRoot, 'agent-runtimes', manifest.id)) : '',
+	};
+}
+
+module.exports = {
+	DEFAULT_RUNTIME_ID,
+	resolveRuntimeProvider,
+	runtimeRegistry,
+};

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -4,6 +4,34 @@
   "name": "WP Codebox",
   "version": "1.1.0",
   "description": "WP Codebox agent runtime for Homeboy agent tasks.",
+  "ci_materialization": {
+    "checkout": {
+      "repo": "Automattic/wp-codebox",
+      "target": ".ci/wp-codebox",
+      "ref_env": "AGENT_RUNTIME_REF",
+      "default_ref": "main"
+    },
+    "setup_commands": [
+      {
+        "command": "npm",
+        "args": ["install"],
+        "cwd": ".ci/wp-codebox"
+      }
+    ],
+    "build_commands": [
+      {
+        "command": "npm",
+        "args": ["run", "build"],
+        "cwd": ".ci/wp-codebox"
+      }
+    ],
+    "paths": {
+      "checkout": ".ci/wp-codebox",
+      "runtime_bin": ".ci/wp-codebox/packages/cli/dist/index.js",
+      "runtime_component": ".ci/wp-codebox/packages/wordpress-plugin",
+      "runtime_core_module": ".ci/wp-codebox/packages/runtime-core/dist/index.js"
+    }
+  },
   "agent_task_executors": [
     {
       "schema": "homeboy/agent-task-executor-provider/v1",

--- a/tests/datamachine-agent-ci-primitives-smoke.mjs
+++ b/tests/datamachine-agent-ci-primitives-smoke.mjs
@@ -56,6 +56,10 @@ const dependencyPlan = JSON.parse(run('materialize-dependencies.cjs', ['--print-
   PROVIDER_PLUGIN: '{}',
 }));
 assert.equal(dependencyPlan.filter((entry) => entry.repo === 'Extra-Chill/example').length, 1);
+assert.deepEqual(
+  dependencyPlan.find((entry) => entry.repo === 'Automattic/wp-codebox'),
+  { repo: 'Automattic/wp-codebox', ref: 'main', target: path.join('.ci', 'wp-codebox') }
+);
 assert.ok(dependencyPlan.some((entry) => entry.repo === 'WordPress/ai-provider-for-openai'));
 
 fs.writeFileSync(githubOutput, '');
@@ -118,6 +122,8 @@ assert.equal(config.runner_workspace.checkout_path, '/workspace/homeboy-extensio
 assert.deepEqual(config.writable_paths, ['src', 'tests']);
 assert.equal(config.provider_credentials.connectors_ai_openai_api_key, 'OPENAI_API_KEY');
 assert.equal(config.runtime_profile, 'datamachine-agent-ci');
+assert.equal(config.runtime_bin, path.join(workspace, '.ci/wp-codebox/packages/cli/dist/index.js'));
+assert.equal(config.runtime_components.runtime, path.join(workspace, '.ci/wp-codebox/packages/wordpress-plugin'));
 assert.equal(config.runtime_components.data_machine, path.join(workspace, '.ci/data-machine'));
 assert.deepEqual(config.required_abilities, ['datamachine/import-agent', 'datamachine/run-flow', 'datamachine/drain-job']);
 

--- a/tests/runtime-provider-resolver-smoke.mjs
+++ b/tests/runtime-provider-resolver-smoke.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const workspace = path.join(rootDir, 'fixture-workspace');
+const {
+	DEFAULT_RUNTIME_ID,
+	resolveRuntimeProvider,
+	runtimeRegistry,
+} = require('../agent-runtimes/lib/runtime-provider-resolver.cjs');
+
+const registry = runtimeRegistry({ repoRoot: rootDir });
+assert.equal(DEFAULT_RUNTIME_ID, 'wp-codebox');
+assert.ok(registry['wp-codebox'], 'wp-codebox is registered as the default runtime provider');
+
+const runtime = resolveRuntimeProvider('wp-codebox', {
+	repoRoot: rootDir,
+	workspace,
+	env: { AGENT_RUNTIME_REF: 'feature/runtime-ref' },
+});
+
+assert.equal(runtime.id, 'wp-codebox');
+assert.equal(runtime.checkout.repo, 'Automattic/wp-codebox');
+assert.equal(runtime.checkout.ref, 'feature/runtime-ref');
+assert.equal(runtime.checkout.target, '.ci/wp-codebox');
+assert.equal(runtime.checkout.targetPath, path.join(workspace, '.ci/wp-codebox'));
+assert.deepEqual(runtime.setupCommands, [{ command: 'npm', args: ['install'], cwd: '.ci/wp-codebox' }]);
+assert.deepEqual(runtime.buildCommands, [{ command: 'npm', args: ['run', 'build'], cwd: '.ci/wp-codebox' }]);
+assert.equal(runtime.paths.runtime_bin, path.join(workspace, '.ci/wp-codebox/packages/cli/dist/index.js'));
+assert.equal(runtime.paths.runtime_component, path.join(workspace, '.ci/wp-codebox/packages/wordpress-plugin'));
+assert.equal(runtime.executor.backend, 'codebox');
+assert.equal(runtime.executor.path, path.join(rootDir, 'agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs'));
+
+assert.throws(
+	() => resolveRuntimeProvider('missing-runtime', { repoRoot: rootDir, workspace }),
+	/Unsupported agent_runtime: missing-runtime\./
+);
+
+console.log('runtime provider resolver smoke passed');

--- a/wordpress/scripts/agent/run-datamachine-agent-task.cjs
+++ b/wordpress/scripts/agent/run-datamachine-agent-task.cjs
@@ -16,10 +16,11 @@ const { spawnSync } = require('node:child_process');
 const {
   datamachineAgentCiCodeboxExecutorConfig,
 } = require('../../lib/datamachine-agent-ci-codebox-adapter');
+const { resolveRuntimeProvider } = require('../../../agent-runtimes/lib/runtime-provider-resolver.cjs');
 
 const SCRIPT_DIR = __dirname;
 const EXTENSION_PATH = path.resolve(SCRIPT_DIR, '..', '..');
-const EXECUTOR = path.resolve(SCRIPT_DIR, '..', '..', '..', 'agent-runtimes', 'wp-codebox', 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs');
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '..', '..', '..');
 
 function readConfigPath() {
   const configPath = process.argv[2] || process.env.HOMEBOY_DATAMACHINE_AGENT_CONFIG_PATH || '';
@@ -176,8 +177,9 @@ function writeOutcome(outcome) {
 try {
   const configPath = readConfigPath();
   const config = readJson(configPath);
+  const runtime = resolveRuntimeProvider(config.runtime_id || process.env.AGENT_RUNTIME || 'wp-codebox', { repoRoot: REPO_ROOT, workspace: config.component_path || process.cwd() });
   const request = buildAgentTaskRequest(config, configPath);
-  const result = spawnSync(process.execPath, [EXECUTOR], {
+  const result = spawnSync(process.execPath, [runtime.executor.path], {
     encoding: 'utf8',
     input: JSON.stringify(request),
     env: process.env,


### PR DESCRIPTION
## Summary
- Add a manifest-backed runtime provider resolver with the existing wp-codebox runtime registered first.
- Move WP Codebox CI checkout, setup/build commands, runtime binary, runtime component, and task executor paths into the runtime manifest/resolver path.
- Route Data Machine Agent CI materialization, setup, runner config, and task execution through the resolver while preserving current wp-codebox defaults.
- Add smoke coverage for resolver behavior and existing wp-codebox defaults.

## Verification
- node tests/runtime-provider-resolver-smoke.mjs
- node tests/datamachine-agent-ci-primitives-smoke.mjs
- node tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
- npm run test:codebox-agent-task-executor-boundary
- npx eslint scripts/agent/run-datamachine-agent-task.cjs
- node --check agent-runtimes/lib/runtime-provider-resolver.cjs
- node --check .github/scripts/datamachine-agent-ci/setup-runtime.cjs && node --check .github/scripts/datamachine-agent-ci/materialize-dependencies.cjs && node --check .github/scripts/datamachine-agent-ci/build-runner-config.cjs && node --check wordpress/scripts/agent/run-datamachine-agent-task.cjs

## Notes
- Broad `npm run lint:js` from `wordpress` still fails on existing unrelated lint debt in files not touched by this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the resolver/materialization groundwork, updated smoke coverage, and ran focused verification; Chris remains responsible for review and acceptance.