### PR TITLE
Fix fanout reconcile runner task determinism

### DIFF
--- a/wordpress/lib/fanout-reconcile-runner.js
+++ b/wordpress/lib/fanout-reconcile-runner.js
@@ -84,6 +84,7 @@ async function executeFanoutReconcileRun(input) {
     : (record) => defaultTaskOrder(plan, taskId, record);
   const onProgress = typeof input.on_progress === 'function' ? input.on_progress : () => {};
   const concurrency = normalizeConcurrency(input.concurrency);
+  const taskIds = validateTaskIds(plan, taskId);
   const records = [];
   const running = new Map();
   const runSchema = input.run_schema || RUN_SCHEMA;
@@ -122,21 +123,26 @@ async function executeFanoutReconcileRun(input) {
       return false;
     }
     const taskRequest = plan.task_requests[nextIndex];
+    const id = taskIds[nextIndex];
     nextIndex += 1;
-    const id = taskId(taskRequest);
 
     running.set(id, runningEntry(taskRequest));
     writeIncompleteRun();
 
     onProgress(progressEvent('started', taskRequest, plan));
-    const promise = Promise.resolve(executeTaskRequest(taskRequest, input)).then((record) => {
-      running.delete(id);
-      records.push(record);
-      records.sort((left, right) => taskOrder(left) - taskOrder(right));
-      onProgress(progressEvent(record.status || (isRecordSuccessful(record) ? 'completed' : 'failed'), taskRequest, plan, record));
-      writeIncompleteRun();
-      startNext();
-    });
+    const promise = Promise.resolve()
+      .then(() => executeTaskRequest(taskRequest, input))
+      .catch((error) => failedTaskRecord(taskRequest, id, error))
+      .then((record) => {
+        records.push(record);
+        records.sort((left, right) => taskOrder(left) - taskOrder(right));
+        onProgress(progressEvent(record.status || (isRecordSuccessful(record) ? 'completed' : 'failed'), taskRequest, plan, record));
+      })
+      .finally(() => {
+        running.delete(id);
+        writeIncompleteRun();
+        startNext();
+      });
     running.get(id).promise = promise;
     return true;
   };
@@ -184,6 +190,48 @@ function normalizeConcurrency(value) {
     return DEFAULT_CONCURRENCY;
   }
   return Math.min(parsed, 16);
+}
+
+function validateTaskIds(plan, taskId) {
+  const seen = new Set();
+  return plan.task_requests.map((taskRequest, index) => {
+    const id = normalizeTaskId(taskId(taskRequest));
+    if (!id) {
+      throw new Error(`fanout reconcile runner requires a non-empty task id at index ${index}`);
+    }
+    if (seen.has(id)) {
+      throw new Error(`fanout reconcile runner requires unique task ids; duplicate task id "${id}"`);
+    }
+    seen.add(id);
+    return id;
+  });
+}
+
+function normalizeTaskId(value) {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return '';
+}
+
+function failedTaskRecord(taskRequest, id, error) {
+  return {
+    id,
+    ...(taskRequest.sandbox_session_id ? { sandbox_session_id: taskRequest.sandbox_session_id } : {}),
+    group_key: taskRequest.group_key || '',
+    status: 'failed',
+    error_message: errorMessage(error),
+  };
+}
+
+function errorMessage(error) {
+  if (error && typeof error.message === 'string' && error.message.trim()) {
+    return error.message;
+  }
+  return String(error || 'Task execution failed');
 }
 
 function defaultTaskId(taskRequest) {

--- a/wordpress/tests/fanout-reconcile-runner-smoke.js
+++ b/wordpress/tests/fanout-reconcile-runner-smoke.js
@@ -105,7 +105,86 @@ async function main() {
     fs.rmSync(root, { recursive: true, force: true });
   }
 
+  await assertRejectedTaskPersistsFailedRecord(plan);
+  await assertTaskIdsAreRequiredAndUnique(plan);
+
   console.log('Homeboy fanout reconcile runner smoke passed');
+}
+
+async function assertRejectedTaskPersistsFailedRecord(plan) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-fanout-reconcile-runner-rejected-'));
+  const runsOutputPath = path.join(root, 'run.json');
+  const started = [];
+  try {
+    const run = await executeFanoutReconcileRun({
+      plan,
+      concurrency: 1,
+      runs_output_path: runsOutputPath,
+      on_progress: (event) => started.push(event),
+      execute_task_request: async (taskRequest) => {
+        if (taskRequest.group_key === 'alpha') {
+          throw new Error('provider rejected alpha');
+        }
+        return {
+          id: taskRequest.id,
+          group_key: taskRequest.group_key,
+          item_ids: taskRequest.item_ids,
+          status: 'completed',
+        };
+      },
+      is_record_successful: (record) => record.status === 'completed',
+    });
+
+    assert.equal(run.status, 'failed');
+    assert.deepEqual(run.records.map((record) => record.id), ['task-alpha', 'task-beta']);
+    assert.equal(run.records[0].status, 'failed');
+    assert.equal(run.records[0].error_message, 'provider rejected alpha');
+    assert.equal(run.records[1].status, 'completed');
+    assert.equal(started.filter((event) => event.status === 'started').length, 2);
+
+    const persisted = readJson(runsOutputPath);
+    assert.equal(persisted.status, 'failed');
+    assert.deepEqual(persisted.records.map((record) => record.status), ['failed', 'completed']);
+    assert.equal(Object.hasOwn(persisted, 'current_group'), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function assertTaskIdsAreRequiredAndUnique(plan) {
+  let executeCount = 0;
+  await assert.rejects(
+    executeFanoutReconcileRun({
+      plan: {
+        ...plan,
+        task_requests: [
+          { ...plan.task_requests[0], id: '', sandbox_session_id: '', group_key: '' },
+        ],
+      },
+      execute_task_request: async () => {
+        executeCount += 1;
+      },
+    }),
+    /non-empty task id/
+  );
+  assert.equal(executeCount, 0);
+
+  await assert.rejects(
+    executeFanoutReconcileRun({
+      plan: {
+        ...plan,
+        task_requests: [
+          { ...plan.task_requests[0], id: 'duplicate-task' },
+          { ...plan.task_requests[1], id: 'duplicate-task' },
+        ],
+      },
+      execute_task_request: async () => {
+        executeCount += 1;
+      },
+    }),
+    /unique task ids/
+  );
+  assert.equal(executeCount, 0);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- Validate fanout reconcile task IDs before execution so missing or duplicate IDs fail deterministically.
- Convert rejected task execution promises into terminal failed records while clearing running state and persisting run state.
- Extend fanout reconcile smoke coverage for rejected tasks plus missing and duplicate task IDs.

## Verification
- npm run test:fanout-reconcile-runner
- npm run test:audit-wp-codebox-fanout
- npx eslint lib/fanout-reconcile-runner.js

## Notes
- npm run lint:js still fails on existing unrelated lint issues outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner determinism fix, smoke tests, and local verification; Chris remains responsible for review and merge.