### PR TITLE
Add static-site fanout adapter

### DIFF
--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -17,6 +17,7 @@ module.exports = {
 	...require('./lib/codebox-memory-report'),
 	...require('./lib/webperf-evidence-summary'),
 	...require('./lib/benchmark-matrix-report'),
+	...require('./lib/static-site-fanout-adapter'),
 	...require('./lib/agent-terminal-actions'),
 	...require('./lib/agent-task-runner-spec'),
 	...require('./lib/datamachine-agent-ci-plan'),

--- a/wordpress/lib/static-site-fanout-adapter.js
+++ b/wordpress/lib/static-site-fanout-adapter.js
@@ -1,0 +1,489 @@
+'use strict';
+
+/* eslint-disable camelcase */
+
+/**
+ * Internal dependencies
+ */
+const {
+  createFanoutReconcilePlan,
+  executeFanoutReconcileRun,
+  groupFanoutItems,
+} = require('./fanout-reconcile-runner');
+const {
+  datamachineAgentCiBundleTaskRequest,
+} = require('./datamachine-agent-ci-plan');
+
+const PLAN_SCHEMA = 'homeboy/static-site-fanout-plan/v1';
+const RUN_SCHEMA = 'homeboy/static-site-fanout-run/v1';
+const RECONCILIATION_SCHEMA = 'homeboy/static-site-fanout-reconciliation/v1';
+const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
+const WP_CODEBOX_TASK_SCHEMA = 'wp-codebox/task-input/v1';
+const DEFAULT_PRESET = 'static-site/import-validation';
+const DEFAULT_AGENT_TASK_PRESET = {
+  source: 'bundles/static-site-import-validation-agent',
+  agent_slug: 'static-site-import-validation-agent',
+  pipeline_slug: 'static-site-import-validation-pipeline',
+  flow_slug: 'static-site-import-validation-flow',
+};
+
+function createStaticSiteFanoutPlan(input = {}) {
+  const findings = normalizeFindings(input.findings || input.finding_artifacts || input.finding_packets || input.packets || []);
+  const groups = normalizeFanoutGroups(input.groups || input.fanout_groups || input.controller?.fanout_groups, findings, input);
+  const orchestrator = normalizeOrchestrator(input);
+  const requestKind = input.request_kind || input.requestKind || 'agent-task';
+  const plan = createFanoutReconcilePlan({
+    schema: PLAN_SCHEMA,
+    orchestrator,
+    groups,
+    summary: {
+      preset: orchestrator.preset,
+      finding_count: groups.reduce((count, group) => count + group.items.length, 0),
+      no_actionable_findings: groups.length === 0,
+    },
+    render_task_request: (group) => createTaskRequest(group, orchestrator, { ...input, request_kind: requestKind }),
+    reconcile_plan: ({ groups: fanoutGroups, task_requests }) => staticSiteReconciliation({
+      plan: { task_requests, summary: { group_count: fanoutGroups.length } },
+      records: [],
+      outcomes: [],
+      groups: fanoutGroups,
+    }),
+  });
+
+  return {
+    ...plan,
+    static_site: {
+      preset: orchestrator.preset,
+      finding_count: plan.summary.finding_count,
+      group_count: groups.length,
+      task_count: plan.task_requests.length,
+      no_actionable_findings: groups.length === 0,
+    },
+  };
+}
+
+function normalizeOrchestrator(input) {
+  const preset = input.preset || input.controller?.preset || DEFAULT_PRESET;
+  return {
+    id: input.orchestrator_id || input.orchestrator?.id || 'homeboy-extensions/static-site-fanout-adapter',
+    run_id: input.run_id || input.orchestrator?.run_id || input.controller?.run_id || 'static-site-fanout-run',
+    plan_id: input.plan_id || input.orchestrator?.plan_id || input.controller?.loop_id || 'static-site-fanout-plan',
+    controller_id: input.controller_id || input.controller?.loop_id || input.controller?.id || '',
+    source: input.source || input.orchestrator?.source || 'static-site/import-validation',
+    preset,
+    parent_plan_id: input.parent_plan_id || input.parentPlanId || input.orchestrator?.parent_plan_id || '',
+    provider: input.provider || '',
+    model: input.model || '',
+    provider_plugin_paths: normalizeArray(input.provider_plugin_paths || input.providerPluginPaths),
+    secret_env: normalizeArray(input.secret_env || input.secretEnv),
+    request_schema: requestSchema(input.request_kind || input.requestKind || 'agent-task'),
+  };
+}
+
+function normalizeFindings(findings) {
+  return normalizeArray(findings).map((finding, index) => normalizeFinding(finding, index));
+}
+
+function normalizeFinding(finding, index) {
+  const raw = finding && typeof finding === 'object' ? finding : { id: String(finding || `finding-${index + 1}`) };
+  const id = text(raw.id) || text(raw.finding_id) || text(raw.diagnostic_id) || `finding-${index + 1}`;
+  const kind = text(raw.kind) || text(raw.category) || 'static_site_finding';
+  const category = text(raw.category) || kind;
+  const path = text(raw.path) || text(raw.source_path) || '';
+  const reason = text(raw.reason) || text(raw.message) || text(raw.excerpt) || text(raw.preview) || '';
+  const group_key = text(raw.group_key) || text(raw.groupKey) || text(raw.suggested_repair_class) || text(raw.candidate_repo) || category;
+
+  return {
+    id,
+    kind,
+    category,
+    group_key,
+    path,
+    source_path: text(raw.source_path) || path,
+    selector: text(raw.selector),
+    severity: text(raw.severity) || 'warning',
+    reason,
+    repair_mode: text(raw.repair_mode),
+    artifact_refs: normalizeArtifactRefs([
+      ...(normalizeArray(raw.artifact_refs || raw.artifacts).map((ref) => ({ source: 'finding', ...objectRef(ref) }))),
+      ...normalizeArray(raw.diagnostic_refs).map((ref) => ({ artifact_id: ref, kind: 'diagnostic' })),
+      ...normalizeArray(raw.asset_map_refs).map((ref) => ({ artifact_id: ref, kind: 'asset_map' })),
+    ]),
+    raw,
+    index,
+  };
+}
+
+function normalizeFanoutGroups(groups, findings, input = {}) {
+  if (Array.isArray(groups) && groups.length > 0) {
+    return groups.map((group, index) => normalizeFanoutGroup(group, index));
+  }
+  return groupFanoutItems(findings, {
+    group_key: typeof input.group_key === 'function'
+      ? input.group_key
+      : (finding) => finding.group_key || finding.kind || finding.id,
+  });
+}
+
+function normalizeFanoutGroup(group, index) {
+  const key = text(group.key) || text(group.group_key) || text(group.id) || `group-${index + 1}`;
+  const items = normalizeFindings(group.items || group.findings || group.packets || []);
+  return {
+    key,
+    index,
+    items,
+    artifact_refs: normalizeArtifactRefs(group.artifact_refs || group.artifacts || []),
+    raw: group,
+  };
+}
+
+function createTaskRequest(group, orchestrator, options = {}) {
+  if ((options.request_kind || options.requestKind) === 'wp-codebox') {
+    return createWpCodeboxTaskRequest(group, orchestrator, options);
+  }
+  return createAgentTaskRequest(group, orchestrator, options);
+}
+
+function createAgentTaskRequest(group, orchestrator, options = {}) {
+  const runtime = {
+    ...DEFAULT_AGENT_TASK_PRESET,
+    ...(options.agent_task || options.agentTask || {}),
+  };
+  const taskId = taskIdForGroup(group, orchestrator, 'static-site');
+  return datamachineAgentCiBundleTaskRequest({
+    taskId,
+    groupKey: group.key,
+    parentPlanId: orchestrator.parent_plan_id || orchestrator.plan_id,
+    source: runtime.source || runtime.bundle,
+    agentSlug: runtime.agent_slug || runtime.agentSlug,
+    pipelineSlug: runtime.pipeline_slug || runtime.pipelineSlug,
+    flowSlug: runtime.flow_slug || runtime.flowSlug,
+    provider: orchestrator.provider,
+    model: orchestrator.model,
+    provider_plugin_paths: orchestrator.provider_plugin_paths,
+    secret_env: orchestrator.secret_env,
+    prompt: staticSitePrompt(group),
+    instructions: options.instructions || staticSiteInstructions(group),
+    expectedArtifacts: options.expected_artifacts || options.expectedArtifacts || ['typed-artifact-refs', 'datamachine-transcript'],
+    artifactOutputs: options.artifact_outputs || options.artifactOutputs || [
+      { schema: 'homeboy/static-site-revalidation-outcome/v1', path: '/artifacts/static-site-revalidation-outcome.json' },
+    ],
+    inputs: {
+      title: `Resolve static-site validation group ${group.key}`,
+      preset: orchestrator.preset,
+      controller_id: orchestrator.controller_id,
+      finding_ids: group.items.map((finding) => finding.id),
+      findings: group.items.map(publicFinding),
+      artifact_refs: groupArtifactRefs(group),
+      ...(options.inputs || {}),
+    },
+    runtimeTaskInput: {
+      prompt: staticSitePrompt(group),
+      ...(runtime.runtime_task_input || runtime.runtimeTaskInput || {}),
+    },
+  });
+}
+
+function createWpCodeboxTaskRequest(group, orchestrator, options = {}) {
+  const taskId = taskIdForGroup(group, orchestrator, 'static-site-codebox');
+  return stripUndefined({
+    schema: WP_CODEBOX_TASK_SCHEMA,
+    id: taskId,
+    sandbox_session_id: taskId,
+    group_key: group.key,
+    goal: staticSitePrompt(group),
+    expected_artifacts: options.expected_artifacts || options.expectedArtifacts || ['typed-artifact-refs', 'patch', 'review'],
+    policy: { kind: orchestrator.preset },
+    orchestrator: {
+      id: orchestrator.id,
+      run_id: orchestrator.run_id,
+      plan_id: orchestrator.plan_id,
+      controller_id: orchestrator.controller_id,
+      source: orchestrator.source,
+      group_index: group.index,
+    },
+    context: {
+      preset: orchestrator.preset,
+      findings: group.items.map(publicFinding),
+      artifact_refs: groupArtifactRefs(group),
+      ...(options.context || {}),
+    },
+    task: {
+      title: `Resolve static-site validation group ${group.key}`,
+      prompt: staticSitePrompt(group),
+    },
+    provider: orchestrator.provider || undefined,
+    model: orchestrator.model || undefined,
+    provider_plugin_paths: orchestrator.provider_plugin_paths.length > 0 ? orchestrator.provider_plugin_paths : undefined,
+    secret_env: orchestrator.secret_env.length > 0 ? orchestrator.secret_env : undefined,
+  });
+}
+
+function staticSiteInstructions(group) {
+  return [
+    `Resolve static-site import validation group ${group.key}.`,
+    'Return typed artifact references for every issue, pull request, patch, revalidation result, or no-op decision produced by the task.',
+    'If the group has no actionable findings, return the no_actionable_findings outcome with a concise justification.',
+  ].join('\n');
+}
+
+function staticSitePrompt(group) {
+  if (!group.items.length) {
+    return 'No actionable static-site validation findings were supplied. Finish with the no_actionable_findings outcome.';
+  }
+  return [
+    `Process static-site import validation group ${group.key}.`,
+    'Findings:',
+    JSON.stringify(group.items.map(publicFinding), null, 2),
+    'Artifact refs:',
+    JSON.stringify(groupArtifactRefs(group), null, 2),
+  ].join('\n\n');
+}
+
+function publicFinding(finding) {
+  return {
+    id: finding.id,
+    kind: finding.kind,
+    category: finding.category,
+    severity: finding.severity,
+    path: finding.path,
+    source_path: finding.source_path,
+    selector: finding.selector,
+    reason: finding.reason,
+    repair_mode: finding.repair_mode,
+    artifact_refs: finding.artifact_refs,
+  };
+}
+
+function groupArtifactRefs(group) {
+  return normalizeArtifactRefs([
+    ...(group.artifact_refs || []),
+    ...group.items.flatMap((finding) => finding.artifact_refs || []),
+  ]);
+}
+
+async function executeStaticSiteFanout(input = {}) {
+  const plan = input.plan || createStaticSiteFanoutPlan(input);
+  const executeTaskRequest = staticSiteTaskExecutor(input, plan);
+
+  return executeFanoutReconcileRun({
+    ...input,
+    plan,
+    run_schema: input.run_schema || RUN_SCHEMA,
+    base_run: { static_site: plan.static_site },
+    runs_output_path: input.runsOutputPath || input.runs_output_path,
+    execute_task_request: executeTaskRequest,
+    classify_outcome: (record) => record.outcome,
+    reconcile: ({ records, outcomes }) => staticSiteReconciliation({ plan, records, outcomes, groups: plan.groups }),
+    is_record_successful: (record) => record.status === 'completed' || successfulOutcome(record.outcome),
+    task_id: taskRequestId,
+    running_entry: runningGroup,
+    progress_event: staticSiteProgressEvent,
+    task_order: (record) => taskOrder(plan, record),
+  });
+}
+
+function staticSiteTaskExecutor(input, plan) {
+  if (typeof input.execute_task_request === 'function') {
+    return input.execute_task_request;
+  }
+  if ((plan.task_requests || []).length === 0) {
+    return async () => ({ status: 'completed', outcome: noActionableFindingsOutcome('No actionable findings were supplied.') });
+  }
+  throw new Error('static-site fanout execution requires execute_task_request for non-empty plans');
+}
+
+function staticSiteReconciliation({ plan, records = [], outcomes = [], groups = [] }) {
+  const taskRequests = plan.task_requests || [];
+  const no_actionable_findings = taskRequests.length === 0 || outcomes.some((outcome) => outcome?.kind === 'no_actionable_findings');
+  const groupRecords = taskRequests.map((taskRequest, index) => {
+    const record = records.find((candidate) => taskRequestId(candidate) === taskRequestId(taskRequest));
+    const outcome = record?.outcome || outcomes.find((candidate) => candidate?.group_key === taskRequest.group_key) || null;
+    return {
+      group_key: taskRequest.group_key,
+      task_id: taskRequestId(taskRequest),
+      status: record?.status || (outcome ? outcome.kind : 'pending'),
+      finding_ids: findingIdsForTaskRequest(taskRequest),
+      outcome_kind: outcome?.kind || '',
+      artifact_refs: normalizeArtifactRefs([
+        ...artifactRefsFromTaskRequest(taskRequest),
+        ...artifactRefsFromOutcome(outcome),
+        ...artifactRefsFromRecord(record),
+      ]),
+      group_index: index,
+    };
+  });
+
+  return {
+    schema: RECONCILIATION_SCHEMA,
+    status: no_actionable_findings && taskRequests.length === 0 ? 'no_actionable_findings' : 'reconciled',
+    no_actionable_findings,
+    group_count: groups.length,
+    task_count: taskRequests.length,
+    groups: groupRecords,
+    artifact_refs: normalizeArtifactRefs(groupRecords.flatMap((group) => group.artifact_refs)),
+  };
+}
+
+function noActionableFindingsOutcome(reason) {
+  return {
+    schema: 'homeboy/static-site-fanout-outcome/v1',
+    kind: 'no_actionable_findings',
+    reason,
+    artifact_refs: [],
+  };
+}
+
+function successfulOutcome(outcome) {
+  return ['artifact_refs', 'fix_artifact', 'fix_pr', 'no_actionable_findings', 'noop_artifact'].includes(outcome?.kind);
+}
+
+function artifactRefsFromTaskRequest(taskRequest) {
+  return normalizeArtifactRefs(taskRequest.inputs?.artifact_refs || taskRequest.context?.artifact_refs || []);
+}
+
+function artifactRefsFromRecord(record) {
+  if (!record) {
+    return [];
+  }
+  return normalizeArtifactRefs([
+    ...(record.artifact_refs || []),
+    ...(record.artifact ? [record.artifact] : []),
+    ...(record.result?.artifacts ? [record.result.artifacts] : []),
+  ]);
+}
+
+function artifactRefsFromOutcome(outcome) {
+  if (!outcome) {
+    return [];
+  }
+  return normalizeArtifactRefs([
+    ...(outcome.artifact_refs || []),
+    ...(outcome.artifacts ? [outcome.artifacts] : []),
+    ...(outcome.artifact ? [outcome.artifact] : []),
+    ...(outcome.pr_url ? [{ artifact_id: outcome.pr_url, kind: 'pull_request', url: outcome.pr_url }] : []),
+    ...(outcome.issue_url ? [{ artifact_id: outcome.issue_url, kind: 'issue', url: outcome.issue_url }] : []),
+  ]);
+}
+
+function normalizeArtifactRefs(refs) {
+  const seen = new Set();
+  return normalizeArray(refs).flatMap((ref) => {
+    const normalized = normalizeArtifactRef(ref);
+    if (!normalized) {
+      return [];
+    }
+    const key = `${normalized.kind}:${normalized.artifact_id || normalized.path || normalized.url}`;
+    if (seen.has(key)) {
+      return [];
+    }
+    seen.add(key);
+    return [normalized];
+  });
+}
+
+function normalizeArtifactRef(ref) {
+  const value = objectRef(ref);
+  const artifact_id = text(value.artifact_id) || text(value.artifactId) || text(value.id) || text(value.url) || text(value.path);
+  const path = text(value.path) || text(value.file) || text(value.directory);
+  const url = text(value.url) || text(value.pr_url) || text(value.issue_url) || (/^https?:\/\//.test(artifact_id) ? artifact_id : '');
+  if (!artifact_id && !path && !url) {
+    return null;
+  }
+  return stripUndefined({
+    schema: value.schema || 'homeboy/artifact-ref/v1',
+    artifact_id,
+    kind: text(value.kind) || text(value.type) || 'artifact',
+    path,
+    url,
+    source: text(value.source),
+    role: text(value.role),
+  });
+}
+
+function taskIdForGroup(group, orchestrator, prefix) {
+  return `${prefix}-${safeSlug(orchestrator.run_id)}-${safeSlug(group.key)}`;
+}
+
+function taskRequestId(taskRequest) {
+  return taskRequest.task_id || taskRequest.id || taskRequest.sandbox_session_id || taskRequest.group_key;
+}
+
+function findingIdsForTaskRequest(taskRequest) {
+  return normalizeArray(taskRequest.inputs?.finding_ids || taskRequest.context?.findings || [])
+    .map((finding) => (typeof finding === 'string' ? finding : finding.id))
+    .filter(Boolean);
+}
+
+function runningGroup(taskRequest) {
+  return {
+    task_id: taskRequestId(taskRequest),
+    group_key: taskRequest.group_key,
+    finding_ids: findingIdsForTaskRequest(taskRequest),
+  };
+}
+
+function staticSiteProgressEvent(status, taskRequest, plan, record = null) {
+  return {
+    schema: 'homeboy/static-site-fanout-progress/v1',
+    status,
+    task_id: taskRequestId(taskRequest),
+    group_key: taskRequest.group_key,
+    group_index: Number(taskRequest.orchestrator?.group_index || 0) + 1,
+    group_count: Number(plan.summary?.group_count || plan.task_requests.length || 0),
+    outcome_kind: record?.outcome?.kind || '',
+  };
+}
+
+function taskOrder(plan, record) {
+  return plan.task_requests.findIndex((taskRequest) => taskRequestId(taskRequest) === taskRequestId(record));
+}
+
+function requestSchema(kind) {
+  return kind === 'wp-codebox' ? WP_CODEBOX_TASK_SCHEMA : AGENT_TASK_REQUEST_SCHEMA;
+}
+
+function safeSlug(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '') || 'static-site';
+}
+
+function objectRef(value) {
+  if (value && typeof value === 'object') {
+    return value;
+  }
+  return { artifact_id: String(value || '') };
+}
+
+function text(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function stripUndefined(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+module.exports = {
+  PLAN_SCHEMA,
+  RUN_SCHEMA,
+  RECONCILIATION_SCHEMA,
+  AGENT_TASK_REQUEST_SCHEMA,
+  WP_CODEBOX_TASK_SCHEMA,
+  DEFAULT_PRESET,
+  createStaticSiteFanoutPlan,
+  executeStaticSiteFanout,
+  normalizeArtifactRefs,
+  normalizeFinding,
+  normalizeFindings,
+  normalizeFanoutGroups,
+  noActionableFindingsOutcome,
+  staticSiteReconciliation,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -33,6 +33,7 @@
     "./webperf-evidence-summary": "./lib/webperf-evidence-summary.js",
     "./benchmark-matrix-report": "./lib/benchmark-matrix-report.js",
     "./fanout-reconcile-runner": "./lib/fanout-reconcile-runner.js",
+    "./static-site-fanout-adapter": "./lib/static-site-fanout-adapter.js",
     "./audit-wp-codebox-fanout": "./lib/audit-wp-codebox-fanout.js",
     "./wordpress-runtime-task-planner": "./lib/wordpress-runtime-task-planner.js"
   },
@@ -66,6 +67,7 @@
     "test:webperf-evidence-summary": "node tests/webperf-evidence-summary-smoke.js",
     "test:benchmark-matrix-report": "node tests/benchmark-matrix-report-smoke.js",
     "test:fanout-reconcile-runner": "node tests/fanout-reconcile-runner-smoke.js",
+    "test:static-site-fanout-adapter": "node tests/static-site-fanout-adapter-smoke.js",
     "test:wordpress-bench-state-sampling": "php tests/wordpress-bench-state-sampling-helper-smoke.php",
     "test:wordpress-bench-artifacts": "php tests/wordpress-bench-artifact-helper-smoke.php",
     "test:wordpress-bench-woocommerce-fixtures": "php tests/wordpress-bench-woocommerce-fixtures-smoke.php",

--- a/wordpress/tests/fixtures/static-site-fanout-adapter/finding-packets.json
+++ b/wordpress/tests/fixtures/static-site-fanout-adapter/finding-packets.json
@@ -1,0 +1,49 @@
+[
+  {
+    "diagnostic_id": "diag-001-unsupported-html-fallback-home-html",
+    "site": "demo-store",
+    "source_path": "home.html",
+    "severity": "warning",
+    "category": "fallback_block",
+    "kind": "unsupported_html_fallback",
+    "reason_code": "unsupported_custom_element",
+    "suggested_repair_class": "converter-support",
+    "candidate_repo": "chubes4/html-to-blocks-converter",
+    "selector": ".hero fancy-card",
+    "source_html_preview": "<fancy-card><h1>Shop</h1></fancy-card>",
+    "reason": "Unsupported custom element fell back during DOM-to-block conversion.",
+    "diagnostic_refs": ["diag-001-unsupported-html-fallback-home-html"],
+    "asset_map_refs": []
+  },
+  {
+    "diagnostic_id": "diag-002-core-html-block-product-card",
+    "site": "demo-store",
+    "source_path": "patterns/page-home.php",
+    "severity": "warning",
+    "category": "fallback_block",
+    "kind": "core_html_block",
+    "reason_code": "generated_document_contains_core_html",
+    "suggested_repair_class": "converter-support",
+    "candidate_repo": "chubes4/html-to-blocks-converter",
+    "selector": ".product-card",
+    "source_html_preview": "<article class=\"product-card\"><p>$10</p></article>",
+    "reason": "Generated block document contains core/html for product-card markup.",
+    "diagnostic_refs": ["diag-002-core-html-block-product-card"],
+    "asset_map_refs": ["asset-map-product-card"]
+  },
+  {
+    "diagnostic_id": "visual-parity-demo-store",
+    "site": "demo-store",
+    "candidate_repo": "chubes4/wp-site-generator",
+    "kind": "visual_parity_mismatch",
+    "source_path": "visual-parity-artifacts/demo-store/visual-diff.json",
+    "path": "visual-parity-artifacts/demo-store/visual-diff.json",
+    "severity": "warning",
+    "category": "visual_parity",
+    "reason_code": "visual_parity_mismatch",
+    "suggested_repair_class": "visual-parity-policy",
+    "selector": "section.hero",
+    "reason": "Imported WordPress screenshot differs from source static HTML screenshot.",
+    "diagnostic_refs": []
+  }
+]

--- a/wordpress/tests/fixtures/static-site-fanout-adapter/golden-agent-plan-summary.json
+++ b/wordpress/tests/fixtures/static-site-fanout-adapter/golden-agent-plan-summary.json
@@ -1,0 +1,323 @@
+{
+  "schema": "homeboy/static-site-fanout-plan/v1",
+  "orchestrator": {
+    "id": "homeboy-extensions/static-site-fanout-adapter",
+    "run_id": "fixture-run",
+    "plan_id": "static-site-fanout-plan",
+    "controller_id": "",
+    "source": "static-site/import-validation",
+    "preset": "static-site/import-validation",
+    "parent_plan_id": "fixture-parent-plan",
+    "provider": "codex",
+    "model": "gpt-5.5",
+    "provider_plugin_paths": [],
+    "secret_env": [
+      "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN"
+    ],
+    "request_schema": "homeboy/agent-task-request/v1"
+  },
+  "summary": {
+    "item_count": 3,
+    "group_count": 2,
+    "task_count": 2,
+    "preset": "static-site/import-validation",
+    "finding_count": 3,
+    "no_actionable_findings": false
+  },
+  "groups": [
+    {
+      "key": "converter-support",
+      "index": 0,
+      "item_count": 2
+    },
+    {
+      "key": "visual-parity-policy",
+      "index": 1,
+      "item_count": 1
+    }
+  ],
+  "task_requests": [
+    {
+      "schema": "homeboy/agent-task-request/v1",
+      "task_id": "static-site-fixture-run-converter-support",
+      "group_key": "converter-support",
+      "parent_plan_id": "fixture-parent-plan",
+      "executor_backend": "codebox",
+      "executor_secret_env": [
+        "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN"
+      ],
+      "runtime_task": {
+        "ability": "datamachine/run-agent-bundle",
+        "input": {
+          "source": "bundles/php-transformer-iterator-agent",
+          "agent_slug": "php-transformer-iterator-agent",
+          "pipeline_slug": "php-transformer-iterator-pipeline",
+          "flow_slug": "php-transformer-iterator-manual-flow",
+          "prompt": "Process static-site import validation group converter-support.\n\nFindings:\n\n[\n  {\n    \"id\": \"diag-001-unsupported-html-fallback-home-html\",\n    \"kind\": \"unsupported_html_fallback\",\n    \"category\": \"fallback_block\",\n    \"severity\": \"warning\",\n    \"path\": \"home.html\",\n    \"source_path\": \"home.html\",\n    \"selector\": \".hero fancy-card\",\n    \"reason\": \"Unsupported custom element fell back during DOM-to-block conversion.\",\n    \"repair_mode\": \"\",\n    \"artifact_refs\": [\n      {\n        \"schema\": \"homeboy/artifact-ref/v1\",\n        \"artifact_id\": \"diag-001-unsupported-html-fallback-home-html\",\n        \"kind\": \"diagnostic\",\n        \"path\": \"\",\n        \"url\": \"\",\n        \"source\": \"\",\n        \"role\": \"\"\n      }\n    ]\n  },\n  {\n    \"id\": \"diag-002-core-html-block-product-card\",\n    \"kind\": \"core_html_block\",\n    \"category\": \"fallback_block\",\n    \"severity\": \"warning\",\n    \"path\": \"patterns/page-home.php\",\n    \"source_path\": \"patterns/page-home.php\",\n    \"selector\": \".product-card\",\n    \"reason\": \"Generated block document contains core/html for product-card markup.\",\n    \"repair_mode\": \"\",\n    \"artifact_refs\": [\n      {\n        \"schema\": \"homeboy/artifact-ref/v1\",\n        \"artifact_id\": \"diag-002-core-html-block-product-card\",\n        \"kind\": \"diagnostic\",\n        \"path\": \"\",\n        \"url\": \"\",\n        \"source\": \"\",\n        \"role\": \"\"\n      },\n      {\n        \"schema\": \"homeboy/artifact-ref/v1\",\n        \"artifact_id\": \"asset-map-product-card\",\n        \"kind\": \"asset_map\",\n        \"path\": \"\",\n        \"url\": \"\",\n        \"source\": \"\",\n        \"role\": \"\"\n      }\n    ]\n  }\n]\n\nArtifact refs:\n\n[\n  {\n    \"schema\": \"homeboy/artifact-ref/v1\",\n    \"artifact_id\": \"diag-001-unsupported-html-fallback-home-html\",\n    \"kind\": \"diagnostic\",\n    \"path\": \"\",\n    \"url\": \"\",\n    \"source\": \"\",\n    \"role\": \"\"\n  },\n  {\n    \"schema\": \"homeboy/artifact-ref/v1\",\n    \"artifact_id\": \"diag-002-core-html-block-product-card\",\n    \"kind\": \"diagnostic\",\n    \"path\": \"\",\n    \"url\": \"\",\n    \"source\": \"\",\n    \"role\": \"\"\n  },\n  {\n    \"schema\": \"homeboy/artifact-ref/v1\",\n    \"artifact_id\": \"asset-map-product-card\",\n    \"kind\": \"asset_map\",\n    \"path\": \"\",\n    \"url\": \"\",\n    \"source\": \"\",\n    \"role\": \"\"\n  }\n]",
+          "wait_for_completion": true,
+          "artifact_outputs": [
+            {
+              "schema": "homeboy/static-site-revalidation-outcome/v1",
+              "path": "/artifacts/static-site-revalidation-outcome.json"
+            }
+          ]
+        }
+      },
+      "instructions": "Resolve static-site import validation group converter-support.\nReturn typed artifact references for every issue, pull request, patch, revalidation result, or no-op decision produced by the task.\nIf the group has no actionable findings, return the no_actionable_findings outcome with a concise justification.",
+      "inputs": {
+        "title": "Resolve static-site validation group converter-support",
+        "preset": "static-site/import-validation",
+        "controller_id": "",
+        "finding_ids": [
+          "diag-001-unsupported-html-fallback-home-html",
+          "diag-002-core-html-block-product-card"
+        ],
+        "findings": [
+          {
+            "id": "diag-001-unsupported-html-fallback-home-html",
+            "kind": "unsupported_html_fallback",
+            "category": "fallback_block",
+            "severity": "warning",
+            "path": "home.html",
+            "source_path": "home.html",
+            "selector": ".hero fancy-card",
+            "reason": "Unsupported custom element fell back during DOM-to-block conversion.",
+            "repair_mode": "",
+            "artifact_refs": [
+              {
+                "schema": "homeboy/artifact-ref/v1",
+                "artifact_id": "diag-001-unsupported-html-fallback-home-html",
+                "kind": "diagnostic",
+                "path": "",
+                "url": "",
+                "source": "",
+                "role": ""
+              }
+            ]
+          },
+          {
+            "id": "diag-002-core-html-block-product-card",
+            "kind": "core_html_block",
+            "category": "fallback_block",
+            "severity": "warning",
+            "path": "patterns/page-home.php",
+            "source_path": "patterns/page-home.php",
+            "selector": ".product-card",
+            "reason": "Generated block document contains core/html for product-card markup.",
+            "repair_mode": "",
+            "artifact_refs": [
+              {
+                "schema": "homeboy/artifact-ref/v1",
+                "artifact_id": "diag-002-core-html-block-product-card",
+                "kind": "diagnostic",
+                "path": "",
+                "url": "",
+                "source": "",
+                "role": ""
+              },
+              {
+                "schema": "homeboy/artifact-ref/v1",
+                "artifact_id": "asset-map-product-card",
+                "kind": "asset_map",
+                "path": "",
+                "url": "",
+                "source": "",
+                "role": ""
+              }
+            ]
+          }
+        ],
+        "artifact_refs": [
+          {
+            "schema": "homeboy/artifact-ref/v1",
+            "artifact_id": "diag-001-unsupported-html-fallback-home-html",
+            "kind": "diagnostic",
+            "path": "",
+            "url": "",
+            "source": "",
+            "role": ""
+          },
+          {
+            "schema": "homeboy/artifact-ref/v1",
+            "artifact_id": "diag-002-core-html-block-product-card",
+            "kind": "diagnostic",
+            "path": "",
+            "url": "",
+            "source": "",
+            "role": ""
+          },
+          {
+            "schema": "homeboy/artifact-ref/v1",
+            "artifact_id": "asset-map-product-card",
+            "kind": "asset_map",
+            "path": "",
+            "url": "",
+            "source": "",
+            "role": ""
+          }
+        ]
+      },
+      "limits": {
+        "task_timeout_seconds": 900
+      },
+      "expected_artifacts": [
+        "typed-artifact-refs",
+        "datamachine-transcript"
+      ]
+    },
+    {
+      "schema": "homeboy/agent-task-request/v1",
+      "task_id": "static-site-fixture-run-visual-parity-policy",
+      "group_key": "visual-parity-policy",
+      "parent_plan_id": "fixture-parent-plan",
+      "executor_backend": "codebox",
+      "executor_secret_env": [
+        "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN"
+      ],
+      "runtime_task": {
+        "ability": "datamachine/run-agent-bundle",
+        "input": {
+          "source": "bundles/php-transformer-iterator-agent",
+          "agent_slug": "php-transformer-iterator-agent",
+          "pipeline_slug": "php-transformer-iterator-pipeline",
+          "flow_slug": "php-transformer-iterator-manual-flow",
+          "prompt": "Process static-site import validation group visual-parity-policy.\n\nFindings:\n\n[\n  {\n    \"id\": \"visual-parity-demo-store\",\n    \"kind\": \"visual_parity_mismatch\",\n    \"category\": \"visual_parity\",\n    \"severity\": \"warning\",\n    \"path\": \"visual-parity-artifacts/demo-store/visual-diff.json\",\n    \"source_path\": \"visual-parity-artifacts/demo-store/visual-diff.json\",\n    \"selector\": \"section.hero\",\n    \"reason\": \"Imported WordPress screenshot differs from source static HTML screenshot.\",\n    \"repair_mode\": \"\",\n    \"artifact_refs\": []\n  }\n]\n\nArtifact refs:\n\n[]",
+          "wait_for_completion": true,
+          "artifact_outputs": [
+            {
+              "schema": "homeboy/static-site-revalidation-outcome/v1",
+              "path": "/artifacts/static-site-revalidation-outcome.json"
+            }
+          ]
+        }
+      },
+      "instructions": "Resolve static-site import validation group visual-parity-policy.\nReturn typed artifact references for every issue, pull request, patch, revalidation result, or no-op decision produced by the task.\nIf the group has no actionable findings, return the no_actionable_findings outcome with a concise justification.",
+      "inputs": {
+        "title": "Resolve static-site validation group visual-parity-policy",
+        "preset": "static-site/import-validation",
+        "controller_id": "",
+        "finding_ids": [
+          "visual-parity-demo-store"
+        ],
+        "findings": [
+          {
+            "id": "visual-parity-demo-store",
+            "kind": "visual_parity_mismatch",
+            "category": "visual_parity",
+            "severity": "warning",
+            "path": "visual-parity-artifacts/demo-store/visual-diff.json",
+            "source_path": "visual-parity-artifacts/demo-store/visual-diff.json",
+            "selector": "section.hero",
+            "reason": "Imported WordPress screenshot differs from source static HTML screenshot.",
+            "repair_mode": "",
+            "artifact_refs": []
+          }
+        ],
+        "artifact_refs": []
+      },
+      "limits": {
+        "task_timeout_seconds": 900
+      },
+      "expected_artifacts": [
+        "typed-artifact-refs",
+        "datamachine-transcript"
+      ]
+    }
+  ],
+  "reconciliation": {
+    "schema": "homeboy/static-site-fanout-reconciliation/v1",
+    "status": "reconciled",
+    "no_actionable_findings": false,
+    "group_count": 2,
+    "task_count": 2,
+    "groups": [
+      {
+        "group_key": "converter-support",
+        "task_id": "static-site-fixture-run-converter-support",
+        "status": "pending",
+        "finding_ids": [
+          "diag-001-unsupported-html-fallback-home-html",
+          "diag-002-core-html-block-product-card"
+        ],
+        "outcome_kind": "",
+        "artifact_refs": [
+          {
+            "schema": "homeboy/artifact-ref/v1",
+            "artifact_id": "diag-001-unsupported-html-fallback-home-html",
+            "kind": "diagnostic",
+            "path": "",
+            "url": "",
+            "source": "",
+            "role": ""
+          },
+          {
+            "schema": "homeboy/artifact-ref/v1",
+            "artifact_id": "diag-002-core-html-block-product-card",
+            "kind": "diagnostic",
+            "path": "",
+            "url": "",
+            "source": "",
+            "role": ""
+          },
+          {
+            "schema": "homeboy/artifact-ref/v1",
+            "artifact_id": "asset-map-product-card",
+            "kind": "asset_map",
+            "path": "",
+            "url": "",
+            "source": "",
+            "role": ""
+          }
+        ],
+        "group_index": 0
+      },
+      {
+        "group_key": "visual-parity-policy",
+        "task_id": "static-site-fixture-run-visual-parity-policy",
+        "status": "pending",
+        "finding_ids": [
+          "visual-parity-demo-store"
+        ],
+        "outcome_kind": "",
+        "artifact_refs": [],
+        "group_index": 1
+      }
+    ],
+    "artifact_refs": [
+      {
+        "schema": "homeboy/artifact-ref/v1",
+        "artifact_id": "diag-001-unsupported-html-fallback-home-html",
+        "kind": "diagnostic",
+        "path": "",
+        "url": "",
+        "source": "",
+        "role": ""
+      },
+      {
+        "schema": "homeboy/artifact-ref/v1",
+        "artifact_id": "diag-002-core-html-block-product-card",
+        "kind": "diagnostic",
+        "path": "",
+        "url": "",
+        "source": "",
+        "role": ""
+      },
+      {
+        "schema": "homeboy/artifact-ref/v1",
+        "artifact_id": "asset-map-product-card",
+        "kind": "asset_map",
+        "path": "",
+        "url": "",
+        "source": "",
+        "role": ""
+      }
+    ]
+  },
+  "static_site": {
+    "preset": "static-site/import-validation",
+    "finding_count": 3,
+    "group_count": 2,
+    "task_count": 2,
+    "no_actionable_findings": false
+  }
+}

--- a/wordpress/tests/static-site-fanout-adapter-smoke.js
+++ b/wordpress/tests/static-site-fanout-adapter-smoke.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  createStaticSiteFanoutPlan,
+  executeStaticSiteFanout,
+  normalizeArtifactRefs,
+} = require('../lib/static-site-fanout-adapter');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+async function main() {
+  const findings = readJson(path.join(__dirname, 'fixtures', 'static-site-fanout-adapter', 'finding-packets.json'));
+  const plan = createStaticSiteFanoutPlan({
+    run_id: 'fixture-run',
+    parent_plan_id: 'fixture-parent-plan',
+    provider: 'codex',
+    model: 'gpt-5.5',
+    secret_env: ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN'],
+    findings,
+    agent_task: {
+      source: 'bundles/php-transformer-iterator-agent',
+      agent_slug: 'php-transformer-iterator-agent',
+      pipeline_slug: 'php-transformer-iterator-pipeline',
+      flow_slug: 'php-transformer-iterator-manual-flow',
+    },
+  });
+  const goldenPlan = readJson(path.join(__dirname, 'fixtures', 'static-site-fanout-adapter', 'golden-agent-plan-summary.json'));
+  assert.deepEqual(projectPlan(plan), goldenPlan);
+  assert.equal(plan.task_requests[0].schema, 'homeboy/agent-task-request/v1');
+  assert.equal(plan.task_requests[0].executor.backend, 'codebox');
+  assert.equal(plan.task_requests[0].inputs.finding_ids.length, 2);
+  assert.equal(plan.task_requests[0].inputs.artifact_refs[0].kind, 'diagnostic');
+
+  const codeboxPlan = createStaticSiteFanoutPlan({
+    run_id: 'fixture-run',
+    request_kind: 'wp-codebox',
+    groups: [
+      {
+        group_key: 'visual-parity',
+        findings: [findings[2]],
+        artifact_refs: [{ artifact_id: 'visual-diff.json', kind: 'visual_parity_artifact', path: 'artifacts/visual-diff.json' }],
+      },
+    ],
+  });
+  assert.equal(codeboxPlan.task_requests[0].schema, 'wp-codebox/task-input/v1');
+  assert.equal(codeboxPlan.task_requests[0].context.findings[0].id, 'visual-parity-demo-store');
+  assert.equal(codeboxPlan.task_requests[0].context.artifact_refs[0].kind, 'visual_parity_artifact');
+
+  const emptyPlan = createStaticSiteFanoutPlan({ run_id: 'empty-run', findings: [] });
+  assert.equal(emptyPlan.static_site.no_actionable_findings, true);
+  assert.equal(emptyPlan.task_requests.length, 0);
+  assert.equal(emptyPlan.reconciliation.status, 'no_actionable_findings');
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-static-site-fanout-adapter-'));
+  const runsOutputPath = path.join(root, 'run.json');
+  const progressEvents = [];
+  try {
+    const run = await executeStaticSiteFanout({
+      plan,
+      concurrency: 2,
+      runsOutputPath,
+      on_progress: (event) => progressEvents.push(event),
+      execute_task_request: async (taskRequest) => ({
+        task_id: taskRequest.task_id,
+        group_key: taskRequest.group_key,
+        status: 'completed',
+        outcome: {
+          kind: 'artifact_refs',
+          group_key: taskRequest.group_key,
+          artifact_refs: [
+            { artifact_id: `issue-${taskRequest.group_key}`, kind: 'issue', url: `https://github.com/example/repo/issues/${taskRequest.group_key === 'converter-support' ? '1' : '2'}` },
+          ],
+        },
+      }),
+    });
+
+    assert.equal(run.schema, 'homeboy/static-site-fanout-run/v1');
+    assert.equal(run.status, 'completed');
+    assert.equal(run.reconciliation.task_count, 2);
+    assert.equal(run.reconciliation.artifact_refs.length, 5);
+    assert.equal(progressEvents.filter((event) => event.status === 'started').length, 2);
+    assert.equal(readJson(runsOutputPath).reconciliation.artifact_refs.length, 5);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+
+  assert.deepEqual(normalizeArtifactRefs(['diag-1', { artifact_id: 'diag-1', kind: 'artifact' }]), [
+    { schema: 'homeboy/artifact-ref/v1', artifact_id: 'diag-1', kind: 'artifact', path: '', url: '', source: '', role: '' },
+  ]);
+
+  console.log('Homeboy static-site fanout adapter smoke passed');
+}
+
+function projectPlan(plan) {
+  return {
+    schema: plan.schema,
+    orchestrator: plan.orchestrator,
+    summary: plan.summary,
+    groups: plan.groups,
+    task_requests: plan.task_requests.map((request) => ({
+      schema: request.schema,
+      task_id: request.task_id,
+      group_key: request.group_key,
+      parent_plan_id: request.parent_plan_id,
+      executor_backend: request.executor?.backend,
+      executor_secret_env: request.executor?.secret_env || [],
+      runtime_task: request.executor?.config?.runtime_task,
+      instructions: request.instructions,
+      inputs: request.inputs,
+      limits: request.limits,
+      expected_artifacts: request.expected_artifacts,
+    })),
+    reconciliation: plan.reconciliation,
+    static_site: plan.static_site,
+  };
+}
+
+main().catch((error) => {
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add a reusable `static-site/import-validation` fanout adapter over the generic fanout/reconcile runner.
- Normalize typed static-site finding packets or controller fanout groups into grouped task requests.
- Emit either generic `homeboy/agent-task-request/v1` requests via the existing Data Machine Agent CI Codebox contract or legacy `wp-codebox/task-input/v1` requests.
- Reconcile typed artifact refs, dedupe refs, and handle zero-finding `no_actionable_findings` plans without requiring an executor.
- Add fixture-backed smoke coverage and a golden projected plan fixture.

## Tests
- `npm run test:static-site-fanout-adapter`
- `npm run test:fanout-reconcile-runner`
- `npm run lint:js -- lib/static-site-fanout-adapter.js`

## Caveats
- Full `npm run lint:js` still fails on pre-existing unrelated files, including `wordpress/lib/playground-readiness.js`, `wordpress/lib/timing-correlator.js`, and several `wordpress/scripts/*` files. The new adapter file passes scoped ESLint.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested static-site fanout adapter over generic runner.
