### PR TITLE
Genericize adapter fixture examples

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -87,19 +87,19 @@ and whether the caller required a Homeboy App token. Tokens are never printed.
 
 ```yaml
 jobs:
-  run-static-site-agent:
+  run-example-agent:
     uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@main
     with:
-      bundle_path: bundles/static-site-agent
-      agent_slug: static-site-agent
-      pipeline_slug: static-site-pipeline
-      flow_slug: static-site-manual-flow
-      target_repo: chubes4/wp-site-generator
+      bundle_path: bundles/example-agent
+      agent_slug: example-agent
+      pipeline_slug: example-pipeline
+      flow_slug: example-manual-flow
+      target_repo: example-org/example-repo
       prompt: ${{ inputs.prompt }}
       success_requires_pr: true
-      engine_data_outputs: '{"static_site_pr_url":"metadata.engine_data.static_site_agent.pr_url"}'
+      engine_data_outputs: '{"example_pr_url":"metadata.engine_data.example_agent.pr_url"}'
       comment_pr_summary: true
-      transcript_artifact_name: static-site-agent-transcript-${{ github.run_id }}
+      transcript_artifact_name: example-agent-transcript-${{ github.run_id }}
     secrets: inherit
 ```
 

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -50,19 +50,19 @@ Use `.github/workflows/datamachine-agent-ci.yml` from a consumer workflow:
 
 ```yaml
 jobs:
-  run-static-site-agent:
+  run-example-agent:
     uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@main
     with:
-      bundle_path: bundles/static-site-agent
-      agent_slug: static-site-agent
-      pipeline_slug: static-site-pipeline
-      flow_slug: static-site-manual-flow
-      target_repo: chubes4/wp-site-generator
+      bundle_path: bundles/example-agent
+      agent_slug: example-agent
+      pipeline_slug: example-pipeline
+      flow_slug: example-manual-flow
+      target_repo: example-org/example-repo
       prompt: ${{ inputs.prompt }}
       success_requires_pr: true
-      engine_data_outputs: '{"static_site_pr_url":"metadata.engine_data.static_site_agent.pr_url"}'
+      engine_data_outputs: '{"example_pr_url":"metadata.engine_data.example_agent.pr_url"}'
       comment_pr_summary: true
-      transcript_artifact_name: static-site-agent-transcript-${{ github.run_id }}
+      transcript_artifact_name: example-agent-transcript-${{ github.run_id }}
     secrets: inherit
 ```
 
@@ -413,7 +413,7 @@ secrets: inherit
 
 The same Data Machine bundle run can be expressed as a Homeboy agent-task plan,
 which lets `homeboy agent-task run-plan --plan ...` replace a bespoke workflow
-wrapper such as `wp-site-generator`'s site-generation loop:
+wrapper with a reusable runner boundary:
 
 `homeboy/agent-task-runner-spec/v1` is the normalized runner boundary inside each
 task. It contains only generic execution details: `executor.backend`,
@@ -425,12 +425,12 @@ same spec without inheriting GitHub Actions glue.
 ```json
 {
   "schema": "homeboy/agent-task-plan/v1",
-  "plan_id": "site-generation-loop",
+  "plan_id": "example-agent-loop",
   "tasks": [
     {
       "schema": "homeboy/agent-task-request/v1",
-      "task_id": "site-generation-loop/static-site-agent",
-      "group_key": "site-generation-loop",
+      "task_id": "example-agent-loop/example-agent",
+      "group_key": "example-agent-loop",
       "executor": {
         "backend": "codebox",
         "model": "gpt-5.5",
@@ -445,30 +445,30 @@ same spec without inheriting GitHub Actions glue.
           },
           "homeboy_extensions": "/components/homeboy-extensions/wordpress",
           "wp_codebox_bin": "/components/wp-codebox/packages/wp-codebox/dist/cli.js",
-          "bundle_path": "bundles/static-site-agent",
-          "agent_slug": "static-site-agent",
-          "pipeline_slug": "static-site-pipeline",
-          "flow_slug": "static-site-manual-flow",
-          "target_repo": "chubes4/wp-site-generator",
+          "bundle_path": "bundles/example-agent",
+          "agent_slug": "example-agent",
+          "pipeline_slug": "example-pipeline",
+          "flow_slug": "example-manual-flow",
+          "target_repo": "example-org/example-repo",
           "success_requires_pr": true,
           "engine_data_outputs": {
-            "static_site_pr_url": "metadata.engine_data.static_site_agent.pr_url"
+            "example_pr_url": "metadata.engine_data.example_agent.pr_url"
           },
           "tool_recorders": [
             {
               "tool": "github/create-pull-request",
-              "engine_data_path": "static_site_agent.pr_url"
+              "engine_data_path": "example_agent.pr_url"
             }
           ],
           "pipeline_step_patches": [],
           "flow_step_patches": [],
-          "transcript_artifact_name": "static-site-agent-transcript",
-          "replay_bundle_artifact_name": "static-site-agent-replay"
+          "transcript_artifact_name": "example-agent-transcript",
+          "replay_bundle_artifact_name": "example-agent-replay"
         }
       },
-      "instructions": "Generate the requested WordPress site and open or reuse a pull request with the materialized source.",
+      "instructions": "Run the requested repository workflow and open or reuse a pull request with the materialized source.",
       "inputs": {
-        "title": "Run static site agent"
+        "title": "Run example agent"
       },
       "limits": {
         "task_timeout_seconds": 1800
@@ -486,7 +486,7 @@ same spec without inheriting GitHub Actions glue.
 Run it with:
 
 ```bash
-homeboy agent-task run-plan --plan .homeboy/plans/site-generation-loop.json
+homeboy agent-task run-plan --plan .homeboy/plans/example-agent-loop.json
 ```
 
 For bundle repositories outside the target checkout, use `bundle_repo`,

--- a/wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php
+++ b/wordpress/scripts/agent/datamachine-agent-terminal-state-smoke.php
@@ -118,16 +118,16 @@ namespace {
     $result = homeboy_datamachine_agent_result(
         array( 'job_completed' => 1 ),
         array(
-            'task_id'     => 'store-idea-agent',
+            'task_id'     => 'example-agent',
             'engine_data' => array(
-                'store_idea_agent' => array(
+                'example_agent' => array(
                     'issue_number' => 123,
                 ),
             ),
         )
     );
 
-    if ( 123 !== ( $result['scenarios'][0]['metadata']['engine_data']['store_idea_agent']['issue_number'] ?? 0 ) ) {
+    if ( 123 !== ( $result['scenarios'][0]['metadata']['engine_data']['example_agent']['issue_number'] ?? 0 ) ) {
         fwrite( STDERR, "Expected workload result scenarios to expose engine_data.\n" );
         exit( 1 );
     }

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -292,7 +292,7 @@ const repoLoopBundleTaskInput = codeboxTaskRequestFromAgentTaskRequest({
     outputs: {
       concept_packet: {
         type: 'ConceptPacket',
-        schema: 'static-site-generator/concept-packet/v1',
+        schema: 'example/concept-packet/v1',
         required: true,
       },
     },
@@ -301,8 +301,8 @@ const repoLoopBundleTaskInput = codeboxTaskRequestFromAgentTaskRequest({
     ability_request: { name: 'datamachine/run-agent-bundle' },
     client_context: {
       inputs: {
-        source: 'bundles/store-idea-agent',
-        flow: 'store-idea-artifact-flow',
+        source: 'bundles/example-agent',
+        flow: 'example-artifact-flow',
         wait_for_completion: true,
       },
     },
@@ -311,15 +311,15 @@ const repoLoopBundleTaskInput = codeboxTaskRequestFromAgentTaskRequest({
 
 assert.equal(repoLoopBundleTaskInput.runtime_task.ability, 'datamachine/run-agent-bundle');
 assert.deepEqual(repoLoopBundleTaskInput.runtime_task.input, {
-  source: 'bundles/store-idea-agent',
-  flow: 'store-idea-artifact-flow',
+  source: 'bundles/example-agent',
+  flow: 'example-artifact-flow',
   wait_for_completion: true,
 });
 assert.deepEqual(repoLoopBundleTaskInput.artifact_declarations, [{
   schema: 'wp-codebox/artifact-declaration/v1',
   name: 'concept_packet',
   type: 'ConceptPacket',
-  artifact_schema: 'static-site-generator/concept-packet/v1',
+  artifact_schema: 'example/concept-packet/v1',
   required: true,
 }]);
 
@@ -356,7 +356,7 @@ const repoLoopWorkspaceTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'repo-loop-workspace-task-1',
   cwd: repoLoopWorkspaceRoot,
-  repo: 'wp-site-generator@canonical-loop-main-20260616',
+  repo: 'example-repo@example-loop-main-20260616',
   executor: {
     backend: 'codebox',
     config: datamachineAgentCiCodeboxExecutorConfig({
@@ -380,7 +380,7 @@ assert.equal(repoLoopWorkspaceMount.mode, 'readwrite');
 assert.equal(repoLoopWorkspaceTaskInput.allowed_tools.includes('datamachine/run-agent-bundle'), true);
 assert.equal(repoLoopWorkspaceTaskInput.allowed_tools.includes('workspace_apply_patch'), true);
 assert.deepEqual(repoLoopWorkspaceTaskInput.workspace_materialization, {
-  repo: 'wp-site-generator@canonical-loop-main-20260616',
+  repo: 'example-repo@example-loop-main-20260616',
   cwd: repoLoopWorkspaceRoot,
   root: repoLoopWorkspaceRoot,
 });
@@ -398,7 +398,7 @@ const repoLoopTypedOutputsTaskInput = codeboxTaskRequestFromAgentTaskRequest({
     typed_artifacts: [{
       name: 'concept_packet',
       type: 'ConceptPacket',
-      artifact_schema: 'static-site-generator/concept-packet/v1',
+      artifact_schema: 'example/concept-packet/v1',
     }],
   },
   inputs: {
@@ -410,7 +410,7 @@ assert.deepEqual(repoLoopTypedOutputsTaskInput.artifact_declarations, [{
   schema: 'wp-codebox/artifact-declaration/v1',
   name: 'concept_packet',
   type: 'ConceptPacket',
-  artifact_schema: 'static-site-generator/concept-packet/v1',
+  artifact_schema: 'example/concept-packet/v1',
   required: true,
 }]);
 

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -204,7 +204,7 @@ process.stdout.write(JSON.stringify({
       metadata: {
         transcript_artifacts: { json: input.artifacts_path + '/transcript.json' },
         replay_bundle_path: input.artifacts_path + '/replay-bundle',
-        engine_data: { static_site_agent: { pr_url: 'https://github.com/chubes4/wp-site-generator/pull/123' } }
+        engine_data: { example_agent: { pr_url: 'https://github.com/example-org/example-repo/pull/123' } }
       }
     }]
   },
@@ -217,7 +217,7 @@ process.stdout.write(JSON.stringify({
           metadata: {
             transcript_artifacts: { json: input.artifacts_path + '/transcript.json' },
             replay_bundle_path: input.artifacts_path + '/replay-bundle',
-            engine_data: { static_site_agent: { pr_url: 'https://github.com/chubes4/wp-site-generator/pull/123' } }
+            engine_data: { example_agent: { pr_url: 'https://github.com/example-org/example-repo/pull/123' } }
           }
         }]
       }
@@ -230,7 +230,7 @@ process.stdout.write(JSON.stringify({
 }
 
 function writeBundleFixture(root) {
-  const bundle = path.join(root, 'static-site-agent');
+  const bundle = path.join(root, 'example-agent');
   fs.mkdirSync(bundle, { recursive: true });
   fs.writeFileSync(path.join(bundle, 'manifest.json'), '{}\n');
   return bundle;
@@ -683,7 +683,7 @@ const abilityBridgeRequest = codeboxTaskRequestFromAgentTaskRequest({
       output_mappings: {
         validation_result: 'result.import_validation_result',
       },
-      component_contracts: [{ slug: 'wp-site-generator', path: '/workspace/wp-site-generator', activate: true }],
+      component_contracts: [{ slug: 'example-repo', path: '/workspace/example-repo', activate: true }],
       engine_data_outputs: {
         validation_result: 'metadata.artifacts.ImportValidationResult',
       },
@@ -693,7 +693,7 @@ const abilityBridgeRequest = codeboxTaskRequestFromAgentTaskRequest({
 assert.equal(abilityBridgeRequest.runtime_task.ability, 'example/validate-artifact');
 assert.deepEqual(abilityBridgeRequest.runtime_task.input, { artifact: { slug: 'example-site' }, report: '/artifacts/import-report.json' });
 assert.equal(abilityBridgeRequest.parent_request.executor.config.output_mappings.validation_result, 'result.import_validation_result');
-assert.deepEqual(abilityBridgeRequest.component_contracts, [{ slug: 'wp-site-generator', path: '/workspace/wp-site-generator', activate: true }]);
+assert.deepEqual(abilityBridgeRequest.component_contracts, [{ slug: 'example-repo', path: '/workspace/example-repo', activate: true }]);
 
 const topLevelComponentContractsRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
@@ -1200,7 +1200,7 @@ try {
   assert.equal(explicitPhpAiClientRequest.runtime_overlays[0].strategy, 'wordpress-scoped-bundle');
 
   const originalCwd = process.cwd();
-  const labOffloadCwd = path.join(defaultsRoot, '_lab_workspaces', 'wp-site-generator-pilot-homeboy-ssi-loop');
+  const labOffloadCwd = path.join(defaultsRoot, '_lab_workspaces', 'example-repo-pilot-homeboy-agent-loop');
   fs.mkdirSync(labOffloadCwd, { recursive: true });
   try {
     process.chdir(labOffloadCwd);
@@ -1314,36 +1314,36 @@ const agentBundleRequest = codeboxTaskRequestFromAgentTaskRequest({
         agent_runtime_tools: '/components/data-machine-code',
       },
       homeboy_extensions: '/components/homeboy-extensions/wordpress',
-      bundle_path: '/bundles/static-site-agent',
-      bundle_host_path: '/home/runner/work/wp-site-generator/wp-site-generator/bundles/static-site-agent',
-      agent_slug: 'static-site-agent',
-      pipeline_slug: 'static-site-pipeline',
-      flow_slug: 'static-site-manual-flow',
-      target_repo: 'chubes4/wp-site-generator',
+      bundle_path: '/bundles/example-agent',
+      bundle_host_path: '/home/runner/work/example-repo/example-repo/bundles/example-agent',
+      agent_slug: 'example-agent',
+      pipeline_slug: 'example-pipeline',
+      flow_slug: 'example-manual-flow',
+      target_repo: 'example-org/example-repo',
       pipeline_step_patches: [{ slug: 'generate', config: { max_turns: 4 } }],
       flow_step_patches: [{ slug: 'run-pipeline', config: { step_budget: 12 } }],
-      tool_recorders: [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }],
-      engine_data_outputs: { static_site_pr_url: 'metadata.engine_data.static_site_agent.pr_url' },
-      transcript_artifact_name: 'static-site-agent-transcript',
-      replay_bundle_artifact_name: 'static-site-agent-replay',
-      runner_workspace: { handle: 'wp-site-generator@site-loop', expose_to_agent: false },
+      tool_recorders: [{ tool: 'github/create-pull-request', engine_data_path: 'example_agent.pr_url' }],
+      engine_data_outputs: { example_pr_url: 'metadata.engine_data.example_agent.pr_url' },
+      transcript_artifact_name: 'example-agent-transcript',
+      replay_bundle_artifact_name: 'example-agent-replay',
+      runner_workspace: { handle: 'example-repo@example-loop', expose_to_agent: false },
     }),
   },
 });
-assert.equal(agentBundleRequest.agent_bundle.bundle_path, '/bundles/static-site-agent');
-assert.equal(agentBundleRequest.agent_bundle.agent_slug, 'static-site-agent');
-assert.equal(agentBundleRequest.agent_bundle.pipeline_slug, 'static-site-pipeline');
-assert.equal(agentBundleRequest.agent_bundle.flow_slug, 'static-site-manual-flow');
+assert.equal(agentBundleRequest.agent_bundle.bundle_path, '/bundles/example-agent');
+assert.equal(agentBundleRequest.agent_bundle.agent_slug, 'example-agent');
+assert.equal(agentBundleRequest.agent_bundle.pipeline_slug, 'example-pipeline');
+assert.equal(agentBundleRequest.agent_bundle.flow_slug, 'example-manual-flow');
 assert.deepEqual(agentBundleRequest.agent_bundle.pipeline_step_patches, [{ slug: 'generate', config: { max_turns: 4 } }]);
 assert.deepEqual(agentBundleRequest.agent_bundle.flow_step_patches, [{ slug: 'run-pipeline', config: { step_budget: 12 } }]);
-assert.deepEqual(agentBundleRequest.agent_bundle.tool_recorders, [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }]);
-assert.deepEqual(agentBundleRequest.agent_bundle.engine_data_outputs, { static_site_pr_url: 'metadata.engine_data.static_site_agent.pr_url' });
+assert.deepEqual(agentBundleRequest.agent_bundle.tool_recorders, [{ tool: 'github/create-pull-request', engine_data_path: 'example_agent.pr_url' }]);
+assert.deepEqual(agentBundleRequest.agent_bundle.engine_data_outputs, { example_pr_url: 'metadata.engine_data.example_agent.pr_url' });
 assert.equal(agentBundleRequest.runtime_component_paths.agent_runtime, '/components/data-machine');
 assert.equal(agentBundleRequest.runtime_component_paths.agent_runtime_tools, '/components/data-machine-code');
 assert.equal(agentBundleRequest.homeboy_extensions_path, '/components/homeboy-extensions/wordpress');
 assert.deepEqual(agentBundleRequest.mounts, [{
-  source: '/home/runner/work/wp-site-generator/wp-site-generator/bundles/static-site-agent',
-  target: '/bundles/static-site-agent',
+  source: '/home/runner/work/example-repo/example-repo/bundles/example-agent',
+  target: '/bundles/example-agent',
   mode: 'readonly',
   metadata: { kind: 'agent-bundle' },
 }]);
@@ -1355,18 +1355,18 @@ const agentBundleRequestWithExplicitMount = codeboxTaskRequestFromAgentTaskReque
     config: {
       execution_kind: 'agent_bundle',
       mounts: [{
-        source: '/custom/static-site-agent',
-        target: '/bundles/static-site-agent',
+        source: '/custom/example-agent',
+        target: '/bundles/example-agent',
         mode: 'readonly',
         metadata: { kind: 'custom' },
       }],
-      bundle_path: '/bundles/static-site-agent',
-      bundle_host_path: '/home/runner/work/wp-site-generator/wp-site-generator/bundles/static-site-agent',
+      bundle_path: '/bundles/example-agent',
+      bundle_host_path: '/home/runner/work/example-repo/example-repo/bundles/example-agent',
     },
   },
 });
 assert.equal(agentBundleRequestWithExplicitMount.mounts.length, 1);
-assert.equal(agentBundleRequestWithExplicitMount.mounts[0].source, '/custom/static-site-agent');
+assert.equal(agentBundleRequestWithExplicitMount.mounts[0].source, '/custom/example-agent');
 
 const outcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: false,
@@ -1559,7 +1559,7 @@ const normalizedCompletedOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   summary: 'WP Codebox agent task succeeded.',
   outputs: {
     issue_number: 123,
-    issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123',
+    issue_url: 'https://github.com/example-org/example-repo/issues/123',
   },
   session: { id: 'sandbox-session-1', status: 'completed' },
 }, { exitStatus: 1 });
@@ -1769,13 +1769,13 @@ const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
       workload: {
         outputs: {
           typed_artifacts: {
-            static_site_candidate: {
+            example_review: {
               schema: 'homeboy/agent-task-typed-artifact/v1',
-              type: 'StaticSiteCandidate',
-              artifact_schema: 'static-site-importer/static-site-candidate/v1',
-              payload: { slug: 'issue-1222-transformer-loop', import_ready: true },
-              provenance: { bundle_slug: 'static-site-agent', task_id: 'agent-bundle-task-123' },
-              file_refs: [{ path: '/tmp/wp-codebox-artifacts/static-site-candidate.json', mime: 'application/json' }],
+              type: 'ExampleReviewArtifact',
+              artifact_schema: 'example/review-artifact/v1',
+              payload: { slug: 'issue-1222-transformer-loop', review_ready: true },
+              provenance: { bundle_slug: 'example-agent', task_id: 'agent-bundle-task-123' },
+              file_refs: [{ path: '/tmp/wp-codebox-artifacts/example-review.json', mime: 'application/json' }],
             },
           },
         },
@@ -1784,7 +1784,7 @@ const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
           metadata: {
             transcript_artifacts: { json: '/tmp/transcript.json', summary: '/tmp/transcript.md' },
             replay_bundle_path: '/tmp/replay-bundle',
-            engine_data: { static_site_agent: { pr_url: 'https://github.com/chubes4/wp-site-generator/pull/123' } },
+            engine_data: { example_agent: { pr_url: 'https://github.com/example-org/example-repo/pull/123' } },
           },
         }],
       },
@@ -1793,15 +1793,15 @@ const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
 });
 assert.equal(agentBundleOutcome.schema, 'homeboy/agent-task-outcome/v1');
 assert.equal(agentBundleOutcome.status, 'succeeded');
-assert.equal(agentBundleOutcome.outputs.static_site_pr_url, 'https://github.com/chubes4/wp-site-generator/pull/123');
-assert.equal(agentBundleOutcome.outputs.typed_artifacts.static_site_candidate.type, 'StaticSiteCandidate');
-assert.equal(agentBundleOutcome.outputs.typed_artifacts.static_site_candidate.artifact_schema, 'static-site-importer/static-site-candidate/v1');
-assert.equal(agentBundleOutcome.outputs.typed_artifacts.static_site_candidate.payload.import_ready, true);
-assert.equal(agentBundleOutcome.artifacts.some((artifact) => artifact.kind === 'typed-bundle-output' && artifact.name === 'static_site_candidate' && artifact.path === '/tmp/wp-codebox-artifacts/static-site-candidate.json'), true);
+assert.equal(agentBundleOutcome.outputs.example_pr_url, 'https://github.com/example-org/example-repo/pull/123');
+assert.equal(agentBundleOutcome.outputs.typed_artifacts.example_review.type, 'ExampleReviewArtifact');
+assert.equal(agentBundleOutcome.outputs.typed_artifacts.example_review.artifact_schema, 'example/review-artifact/v1');
+assert.equal(agentBundleOutcome.outputs.typed_artifacts.example_review.payload.review_ready, true);
+assert.equal(agentBundleOutcome.artifacts.some((artifact) => artifact.kind === 'typed-bundle-output' && artifact.name === 'example_review' && artifact.path === '/tmp/wp-codebox-artifacts/example-review.json'), true);
 assert.equal(agentBundleOutcome.artifacts.some((artifact) => artifact.kind === 'agent-runtime-transcript' && artifact.path === '/tmp/transcript.json'), true);
 assert.equal(agentBundleOutcome.artifacts.some((artifact) => artifact.kind === 'agent-runtime-replay-bundle' && artifact.path === '/tmp/replay-bundle'), true);
-assert.equal(agentBundleOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/123'), true);
-assert.equal(agentBundleOutcome.evidence_refs.some((ref) => ref.uri === '/tmp/wp-codebox-artifacts/static-site-candidate.json'), true);
+assert.equal(agentBundleOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/example-org/example-repo/pull/123'), true);
+assert.equal(agentBundleOutcome.evidence_refs.some((ref) => ref.uri === '/tmp/wp-codebox-artifacts/example-review.json'), true);
 assert.equal(agentBundleOutcome.metadata.sandbox_policy.policy.apply, 'review');
 assert.equal(agentBundleOutcome.metadata.sandbox_policy.sandbox_tool_policy.tools[0].allowed, false);
 assert.equal(upstreamRunnerOutcome.artifacts[1].kind, 'codebox-session-artifacts');
@@ -1844,7 +1844,7 @@ const missingGenericRepoLoopArtifactOutcome = agentTaskOutcomeFromCodeboxResult(
     outputs: {
       concept_packet: {
         type: 'ConceptPacket',
-        schema: 'static-site-generator/concept-packet/v1',
+        schema: 'example/concept-packet/v1',
       },
     },
   },
@@ -1866,7 +1866,7 @@ assert.equal(missingGenericRepoLoopArtifactOutcome.status, 'failed');
 assert.equal(missingGenericRepoLoopArtifactOutcome.failure_classification, 'execution_failed');
 assert.equal(missingGenericRepoLoopArtifactOutcome.diagnostics[0].class, 'codebox.required_typed_artifacts_missing');
 assert.equal(missingGenericRepoLoopArtifactOutcome.diagnostics[0].data.missing[0].name, 'concept_packet');
-assert.equal(missingGenericRepoLoopArtifactOutcome.diagnostics[0].data.missing[0].artifact_schema, 'static-site-generator/concept-packet/v1');
+assert.equal(missingGenericRepoLoopArtifactOutcome.diagnostics[0].data.missing[0].artifact_schema, 'example/concept-packet/v1');
 
 const canonicalTopLevelAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
@@ -1880,9 +1880,9 @@ const canonicalTopLevelAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
     agent_runtime: {
       bundle: {
         engine_data_outputs: {
-          static_site_branch: 'metadata.engine_data.static_site_agent.branch',
-          static_site_pr_url: 'metadata.engine_data.static_site_agent.pr_url',
-          static_site_slug: 'metadata.engine_data.static_site_agent.slug',
+          example_branch: 'metadata.engine_data.example_agent.branch',
+          example_pr_url: 'metadata.engine_data.example_agent.pr_url',
+          example_slug: 'metadata.engine_data.example_agent.slug',
         },
       },
       workload: {
@@ -1892,28 +1892,28 @@ const canonicalTopLevelAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   },
   outputs: {
     engine_data: {
-      static_site_agent: {
-        branch: 'static/issue-451-design-direction',
-        pr_url: 'https://github.com/chubes4/wp-site-generator/pull/453',
+      example_agent: {
+        branch: 'example/issue-451-design-direction',
+        pr_url: 'https://github.com/example-org/example-repo/pull/453',
         slug: 'issue-451-design-direction',
       },
     },
   },
 });
 assert.equal(canonicalTopLevelAgentBundleOutcome.status, 'succeeded');
-assert.equal(canonicalTopLevelAgentBundleOutcome.outputs.static_site_branch, 'static/issue-451-design-direction');
-assert.equal(canonicalTopLevelAgentBundleOutcome.outputs.static_site_pr_url, 'https://github.com/chubes4/wp-site-generator/pull/453');
-assert.equal(canonicalTopLevelAgentBundleOutcome.outputs.static_site_slug, 'issue-451-design-direction');
-assert.equal(canonicalTopLevelAgentBundleOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/453'), true);
+assert.equal(canonicalTopLevelAgentBundleOutcome.outputs.example_branch, 'example/issue-451-design-direction');
+assert.equal(canonicalTopLevelAgentBundleOutcome.outputs.example_pr_url, 'https://github.com/example-org/example-repo/pull/453');
+assert.equal(canonicalTopLevelAgentBundleOutcome.outputs.example_slug, 'issue-451-design-direction');
+assert.equal(canonicalTopLevelAgentBundleOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/example-org/example-repo/pull/453'), true);
 
 const projectedTypedArtifactBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
   task_id: 'projected-typed-artifact-bundle-task-123',
   artifact_declarations: [{
     schema: 'wp-codebox/artifact-declaration/v1',
-    name: 'static_site_candidate',
-    type: 'StaticSiteCandidate',
-    artifact_schema: 'static-site-importer/static-site-candidate/v1',
+    name: 'example_review',
+    type: 'ExampleReviewArtifact',
+    artifact_schema: 'example/review-artifact/v1',
     required: true,
   }],
   executor: { backend: 'codebox' },
@@ -1925,7 +1925,7 @@ const projectedTypedArtifactBundleOutcome = agentTaskOutcomeFromCodeboxResult({
     agent_runtime: {
       bundle: {
         engine_data_outputs: {
-          static_site_candidate: 'outputs.typed_artifacts.static_site_candidate.payload',
+          example_review: 'outputs.typed_artifacts.example_review.payload',
         },
       },
       workload: {
@@ -1935,13 +1935,13 @@ const projectedTypedArtifactBundleOutcome = agentTaskOutcomeFromCodeboxResult({
             schema: 'datamachine/agent-bundle-run/v1',
             outputs: {
               typed_artifacts: {
-                static_site_candidate: {
+                example_review: {
                   schema: 'homeboy/agent-task-typed-artifact/v1',
-                  type: 'StaticSiteCandidate',
-                  artifact_schema: 'static-site-importer/static-site-candidate/v1',
-                  payload: { slug: 'projected-candidate', import_ready: true },
-                  provenance: { bundle_slug: 'static-site-agent' },
-                  file_refs: [{ path: '/tmp/wp-codebox-artifacts/projected-candidate.json', mime: 'application/json' }],
+                  type: 'ExampleReviewArtifact',
+                  artifact_schema: 'example/review-artifact/v1',
+                  payload: { slug: 'projected-review', review_ready: true },
+                  provenance: { bundle_slug: 'example-agent' },
+                  file_refs: [{ path: '/tmp/wp-codebox-artifacts/projected-review.json', mime: 'application/json' }],
                 },
               },
             },
@@ -1952,11 +1952,11 @@ const projectedTypedArtifactBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   },
 });
 assert.equal(projectedTypedArtifactBundleOutcome.status, 'succeeded');
-assert.equal(projectedTypedArtifactBundleOutcome.outputs.static_site_candidate.import_ready, true);
-assert.equal(projectedTypedArtifactBundleOutcome.outputs.typed_artifacts.static_site_candidate.type, 'StaticSiteCandidate');
-assert.equal(projectedTypedArtifactBundleOutcome.outputs.typed_artifacts.static_site_candidate.payload.slug, 'projected-candidate');
+assert.equal(projectedTypedArtifactBundleOutcome.outputs.example_review.review_ready, true);
+assert.equal(projectedTypedArtifactBundleOutcome.outputs.typed_artifacts.example_review.type, 'ExampleReviewArtifact');
+assert.equal(projectedTypedArtifactBundleOutcome.outputs.typed_artifacts.example_review.payload.slug, 'projected-review');
 assert.equal(projectedTypedArtifactBundleOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.required_typed_artifacts_missing'), false);
-assert.equal(projectedTypedArtifactBundleOutcome.artifacts.some((artifact) => artifact.kind === 'typed-bundle-output' && artifact.path === '/tmp/wp-codebox-artifacts/projected-candidate.json'), true);
+assert.equal(projectedTypedArtifactBundleOutcome.artifacts.some((artifact) => artifact.kind === 'typed-bundle-output' && artifact.path === '/tmp/wp-codebox-artifacts/projected-review.json'), true);
 
 const failedProjectedTypedArtifactBundleOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
@@ -2005,14 +2005,14 @@ const singleResultAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
     agent_runtime: {
       bundle: {
         engine_data_outputs: {
-          issue_number: 'metadata.engine_data.store_idea_agent.issue_number',
-          issue_url: 'metadata.engine_data.store_idea_agent.issue_url',
+          issue_number: 'metadata.engine_data.example_agent.issue_number',
+          issue_url: 'metadata.engine_data.example_agent.issue_url',
         },
       },
       workload: {
         outputs: {
           issue_number: 123,
-          issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123',
+          issue_url: 'https://github.com/example-org/example-repo/issues/123',
         },
         diagnostics: [{ class: 'agent_runtime.output', message: 'Semantic outputs captured.' }],
       },
@@ -2022,8 +2022,8 @@ const singleResultAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
 assert.equal(singleResultAgentBundleOutcome.schema, 'homeboy/agent-task-outcome/v1');
 assert.equal(singleResultAgentBundleOutcome.status, 'succeeded');
 assert.equal(singleResultAgentBundleOutcome.outputs.issue_number, 123);
-assert.equal(singleResultAgentBundleOutcome.outputs.issue_url, 'https://github.com/chubes4/wp-site-generator/issues/123');
-assert.equal(singleResultAgentBundleOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/issues/123'), true);
+assert.equal(singleResultAgentBundleOutcome.outputs.issue_url, 'https://github.com/example-org/example-repo/issues/123');
+assert.equal(singleResultAgentBundleOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/example-org/example-repo/issues/123'), true);
 
 const canaryRunOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: true,
@@ -2549,11 +2549,11 @@ try {
         homeboy_extensions: path.join(__dirname, '..'),
         wp_codebox_bin: fakeWpCodebox,
         bundle_path: bundle,
-        agent_slug: 'static-site-agent',
-        pipeline_slug: 'static-site-pipeline',
-        flow_slug: 'static-site-manual-flow',
-        tool_recorders: [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }],
-        engine_data_outputs: { static_site_pr_url: 'metadata.engine_data.static_site_agent.pr_url' },
+        agent_slug: 'example-agent',
+        pipeline_slug: 'example-pipeline',
+        flow_slug: 'example-manual-flow',
+        tool_recorders: [{ tool: 'github/create-pull-request', engine_data_path: 'example_agent.pr_url' }],
+        engine_data_outputs: { example_pr_url: 'metadata.engine_data.example_agent.pr_url' },
       },
     },
   };
@@ -2568,7 +2568,7 @@ try {
   const agentBundleCliOutcome = JSON.parse(agentBundleCliResult.stdout);
   assert.equal(agentBundleCliOutcome.status, 'succeeded');
   assert.equal(agentBundleCliOutcome.artifacts.some((artifact) => artifact.kind === 'agent-runtime-transcript'), true);
-  assert.equal(agentBundleCliOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/chubes4/wp-site-generator/pull/123'), true);
+  assert.equal(agentBundleCliOutcome.evidence_refs.some((ref) => ref.uri === 'https://github.com/example-org/example-repo/pull/123'), true);
   const capturedAgentBundleRun = JSON.parse(fs.readFileSync(fakeWpCodeboxCapture, 'utf8'));
   assert.equal(capturedAgentBundleRun.argv[0], 'agent-task-run');
   assert.equal(capturedAgentBundleRun.input.schema, 'wp-codebox/task-input/v1');
@@ -2578,9 +2578,9 @@ try {
   assert.deepEqual(capturedAgentBundleRun.input.runtime_state_mounts, fullRunnerRuntimeStateMounts);
   assert.deepEqual(capturedAgentBundleRun.input.runtime_config_mounts, fullRunnerRuntimeConfigMounts);
   assert.equal(capturedAgentBundleRun.input.agent_bundle.bundle_path, bundle);
-  assert.equal(capturedAgentBundleRun.input.agent_bundle.agent_slug, 'static-site-agent');
-  assert.equal(capturedAgentBundleRun.input.agent_bundle.pipeline_slug, 'static-site-pipeline');
-  assert.deepEqual(capturedAgentBundleRun.input.agent_bundle.tool_recorders, [{ tool: 'github/create-pull-request', engine_data_path: 'static_site_agent.pr_url' }]);
+  assert.equal(capturedAgentBundleRun.input.agent_bundle.agent_slug, 'example-agent');
+  assert.equal(capturedAgentBundleRun.input.agent_bundle.pipeline_slug, 'example-pipeline');
+  assert.deepEqual(capturedAgentBundleRun.input.agent_bundle.tool_recorders, [{ tool: 'github/create-pull-request', engine_data_path: 'example_agent.pr_url' }]);
 
   const recipeWpCodeboxRoot = fs.mkdtempSync(path.join(root, 'recipe-wp-codebox-'));
   const { fixture: recipeFakeWpCodebox, capture: recipeFakeWpCodeboxCapture } = writeFakeWpCodebox(recipeWpCodeboxRoot);

--- a/wordpress/tests/datamachine-agent-ci-plan-smoke.js
+++ b/wordpress/tests/datamachine-agent-ci-plan-smoke.js
@@ -150,24 +150,24 @@ assert.equal(validateAgentTaskRunnerSpec(bundleRunnerSpec), bundleRunnerSpec);
 const abilityTask = datamachineAgentCiAbilityTaskRequest({
   taskId: 'validate-artifact',
   ability: 'example/validate-artifact',
-  abilityInput: { artifact: '{{outputs.static_site_candidate}}' },
+  abilityInput: { artifact: '{{outputs.example_review}}' },
   instructions: 'Validate the artifact.',
 });
 
 assert.equal(abilityTask.executor.config.runtime_task.ability, 'example/validate-artifact');
 assert.deepEqual(abilityTask.executor.config.runtime_task.input, {
-  artifact: '{{outputs.static_site_candidate}}',
+  artifact: '{{outputs.example_review}}',
 });
 
 const plan = datamachineAgentCiPlan({
-  planId: 'site-generation-loop-123',
+  planId: 'example-agent-loop-123',
   tasks: [bundleTask, abilityTask],
   options: { max_concurrency: 1 },
   metadata: { source: 'example' },
 });
 
 assert.equal(plan.schema, 'homeboy/agent-task-plan/v1');
-assert.equal(plan.plan_id, 'site-generation-loop-123');
+assert.equal(plan.plan_id, 'example-agent-loop-123');
 assert.equal(plan.tasks.length, 2);
 assert.deepEqual(plan.options, { max_concurrency: 1 });
 

--- a/wordpress/tests/wordpress-workload-profile-smoke.js
+++ b/wordpress/tests/wordpress-workload-profile-smoke.js
@@ -9,10 +9,10 @@ const {
 
 const profile = {
 	schema: WORKLOAD_PROFILE_SCHEMA,
-	id: 'static-import-visual-check',
-	label: 'Static import visual check',
+	id: 'content-import-visual-check',
+	label: 'Content import visual check',
 	dependencies: [
-		'example/static-importer@main',
+		'example/content-importer@main',
 		{ repo: 'example/block-transformer', ref: 'trunk' },
 	],
 	wp_config_defines: { WP_DEBUG: true },
@@ -28,7 +28,7 @@ const profile = {
 			id: 'import-and-snapshot',
 			label: 'Import and snapshot',
 			run: [
-				{ type: 'ability', ability: 'example/import-static-site', input: { source: '/wordpress/wp-content/uploads/source' } },
+				{ type: 'ability', ability: 'example/import-content', input: { source: '/wordpress/wp-content/uploads/source' } },
 			],
 			artifacts: {
 				import_report: { path: 'wp-content/uploads/import-report.json', kind: 'json' },
@@ -56,7 +56,7 @@ assert.equal(normalized.mounts[0].mode, 'readonly');
 assert.equal(normalized.visual_comparisons[0].artifacts_directory, 'artifacts/visual/home-page');
 
 const inputs = workflowInputsFromWordPressWorkloadProfile(profile);
-assert.equal(inputs.validation_dependencies, 'example/static-importer@main,example/block-transformer@trunk');
+assert.equal(inputs.validation_dependencies, 'example/content-importer@main,example/block-transformer@trunk');
 assert.deepEqual(JSON.parse(inputs.extra_wp_config_defines), { WP_DEBUG: true });
 assert.deepEqual(JSON.parse(inputs.runtime_mounts), normalized.mounts);
 assert.deepEqual(JSON.parse(inputs.workload_run_before), normalized.run_before);
@@ -73,8 +73,8 @@ assert.deepEqual(JSON.parse(inputs.workload_run_after), [
 	},
 ]);
 assert.deepEqual(inputs.metadata, {
-	profile_id: 'static-import-visual-check',
-	profile_label: 'Static import visual check',
+	profile_id: 'content-import-visual-check',
+	profile_label: 'Content import visual check',
 	fixture: 'portable',
 });
 

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -80,17 +80,17 @@ const bundleRun = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
       job_id: 1,
       job_status: 'completed',
       bundle: {
-        bundle_slug: 'store-idea-agent',
-        flow_slug: 'static-site-manual-flow',
-        pipeline_slug: 'static-site-pipeline',
+        bundle_slug: 'example-agent',
+        flow_slug: 'example-manual-flow',
+        pipeline_slug: 'example-pipeline',
       },
       typed_artifacts: {
-        static_site_candidate: {
-          schema: 'static-site-importer/static-site-candidate/v1',
-          type: 'StaticSiteCandidate',
-          payload: { slug: 'store-idea-agent', import_ready: true },
-          provenance: { bundle_slug: 'store-idea-agent', task_id: input.orchestrator.agent_task_id },
-          file_refs: [{ path: input.artifacts_path + '/static-site-candidate.json', mime: 'application/json' }]
+        example_review: {
+          schema: 'example/review-artifact/v1',
+          type: 'ExampleReviewArtifact',
+          payload: { slug: 'example-agent', review_ready: true },
+          provenance: { bundle_slug: 'example-agent', task_id: input.orchestrator.agent_task_id },
+          file_refs: [{ path: input.artifacts_path + '/example-review.json', mime: 'application/json' }]
         }
       },
       workflow: { steps: [{ step_type: 'ai' }] },
@@ -105,14 +105,14 @@ const bundleRun = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
                   tool_result_data: {
                     data: {
                       issue_number: 123,
-                      issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123'
+                      issue_url: 'https://github.com/example-org/example-repo/issues/123'
                     }
                   }
                 }
               }]
             }
           }
-        : { store_idea_agent: { issue_number: 123, issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123' } }
+        : { example_agent: { issue_number: 123, issue_url: 'https://github.com/example-org/example-repo/issues/123' } }
     }
   : null;
 const runtimeTaskResult = isRuntimeTask
@@ -168,12 +168,12 @@ const agentResult = isRuntimeTask
           summary: 'Created issue 123.',
           outputs: {
             issue_number: 123,
-            issue_url: 'https://github.com/chubes4/wp-site-generator/issues/123'
+            issue_url: 'https://github.com/example-org/example-repo/issues/123'
           },
           diagnostics: [{ class: 'agent_runtime.output', message: 'Semantic outputs captured.' }]
         }
   : (isAgentBundle && !process.env.FIXTURE_WP_CODEBOX_INCOMPLETE_AGENT_BUNDLE
-      ? { metrics: { config_present: 1 }, metadata: { engine_data: { store_idea_agent: { issue_number: 123 } } } }
+      ? { metrics: { config_present: 1 }, metadata: { engine_data: { example_agent: { issue_number: 123 } } } }
       : { status: 'completed' })))));
 fs.writeFileSync(out, JSON.stringify({
   argv: process.argv.slice(2),
@@ -643,14 +643,14 @@ try {
     input: JSON.stringify({
       ...request,
       agent_bundle: {
-        source: 'bundles/store-idea-agent',
-        flow_slug: 'store-idea-artifact-flow',
+        source: 'bundles/example-agent',
+        flow_slug: 'example-artifact-flow',
       },
       artifact_declarations: [{
         schema: 'wp-codebox/artifact-declaration/v1',
         name: 'concept_packet',
         type: 'ConceptPacket',
-        artifact_schema: 'static-site-generator/concept-packet/v1',
+        artifact_schema: 'example/concept-packet/v1',
         required: true,
       }],
     }),
@@ -960,8 +960,8 @@ try {
     input: JSON.stringify({
       ...request,
       agent_bundle: {
-        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
-        engine_data_outputs: { issue_number: 'metadata.engine_data.store_idea_agent.issue_number' },
+        bundle_path: '/workspace/example-repo/bundles/example-agent',
+        engine_data_outputs: { issue_number: 'metadata.engine_data.example_agent.issue_number' },
       },
       provider_plugin_paths: [],
     }),
@@ -981,15 +981,15 @@ try {
   assert.equal(agentBundleCapture.input.sandbox_tool_policy.tools[0].allowed, false);
   assert.equal(agentBundleCapture.input.sandbox_tool_policy.tools[0].runtime.environment, 'control_plane');
   assert.equal(agentBundleCapture.input.sandbox_tool_policy.tools[0].runtime.capability_scope, 'control_plane');
-  assert.equal(agentBundleCapture.input.agent_bundle.engine_data_outputs.issue_number, 'metadata.engine_data.store_idea_agent.issue_number');
+  assert.equal(agentBundleCapture.input.agent_bundle.engine_data_outputs.issue_number, 'metadata.engine_data.example_agent.issue_number');
   assert.equal(agentBundleCapture.input.runtime_task.ability, 'datamachine/run-agent-bundle');
-  assert.equal(agentBundleCapture.input.runtime_task.input.source, '/workspace/wp-site-generator/bundles/store-idea-agent');
+  assert.equal(agentBundleCapture.input.runtime_task.input.source, '/workspace/example-repo/bundles/example-agent');
   assert.equal(agentBundleCapture.input.runtime_task.input.wait_for_completion, true);
   assert.equal(agentBundleCapture.input.runtime_task.input.runtime_bundles, undefined);
   const agentBundleOutput = JSON.parse(agentBundleResult.stdout);
   assert.equal(agentBundleOutput.success, true);
   assert.equal(agentBundleOutput.session.status, 'completed');
-  assert.equal(agentBundleOutput.run.agentResult.scenarios[0].metadata.engine_data.store_idea_agent.issue_number, 123);
+  assert.equal(agentBundleOutput.run.agentResult.scenarios[0].metadata.engine_data.example_agent.issue_number, 123);
 
   const singleResultCapturePath = path.join(root, 'capture-single-result-datamachine.json');
   const singleResult = spawnSync(process.execPath, [
@@ -1003,10 +1003,10 @@ try {
     input: JSON.stringify({
       ...request,
       agent_bundle: {
-        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
+        bundle_path: '/workspace/example-repo/bundles/example-agent',
         engine_data_outputs: {
-          issue_number: 'metadata.engine_data.store_idea_agent.issue_number',
-          issue_url: 'metadata.engine_data.store_idea_agent.issue_url',
+          issue_number: 'metadata.engine_data.example_agent.issue_number',
+          issue_url: 'metadata.engine_data.example_agent.issue_url',
         },
       },
       provider_plugin_paths: [],
@@ -1023,7 +1023,7 @@ try {
   assert.equal(singleResultOutput.success, true);
   assert.equal(singleResultOutput.session.status, 'completed');
   assert.equal(singleResultOutput.run.agentResult.outputs.issue_number, 123);
-  assert.equal(singleResultOutput.run.agentResult.outputs.issue_url, 'https://github.com/chubes4/wp-site-generator/issues/123');
+  assert.equal(singleResultOutput.run.agentResult.outputs.issue_url, 'https://github.com/example-org/example-repo/issues/123');
   assert.equal(Array.isArray(singleResultOutput.run.agentResult.scenarios), false);
   assert.equal(singleResultOutput.diagnostics.some((diagnostic) => diagnostic.class === 'agent_runtime.output'), true);
 
@@ -1039,8 +1039,8 @@ try {
     input: JSON.stringify({
       ...request,
       agent_bundle: {
-        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
-        engine_data_outputs: { issue_number: 'metadata.engine_data.store_idea_agent.issue_number' },
+        bundle_path: '/workspace/example-repo/bundles/example-agent',
+        engine_data_outputs: { issue_number: 'metadata.engine_data.example_agent.issue_number' },
         dry_run: true,
       },
       provider_plugin_paths: [],
@@ -1058,12 +1058,12 @@ try {
   assert.equal(canonicalBundleRunOutput.session.status, 'completed');
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.schema, 'datamachine/agent-bundle-run/v1');
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.job_status, 'completed');
-  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.engine_data.store_idea_agent.issue_number, 123);
+  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.engine_data.example_agent.issue_number, 123);
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.dry_run, true);
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metrics.workflow_step_count, 1);
-  assert.equal(canonicalBundleRunOutput.outputs.typed_artifacts.static_site_candidate.type, 'StaticSiteCandidate');
-  assert.equal(canonicalBundleRunOutput.outputs.typed_artifacts.static_site_candidate.artifact_schema, 'static-site-importer/static-site-candidate/v1');
-  assert.equal(canonicalBundleRunOutput.outputs.typed_artifacts.static_site_candidate.payload.import_ready, true);
+  assert.equal(canonicalBundleRunOutput.outputs.typed_artifacts.example_review.type, 'ExampleReviewArtifact');
+  assert.equal(canonicalBundleRunOutput.outputs.typed_artifacts.example_review.artifact_schema, 'example/review-artifact/v1');
+  assert.equal(canonicalBundleRunOutput.outputs.typed_artifacts.example_review.payload.review_ready, true);
 
   const recorderBundleRunCapturePath = path.join(root, 'capture-recorder-datamachine-bundle-run.json');
   const recorderBundleRunResult = spawnSync(process.execPath, [
@@ -1077,15 +1077,15 @@ try {
     input: JSON.stringify({
       ...request,
       agent_bundle: {
-        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
+        bundle_path: '/workspace/example-repo/bundles/example-agent',
         engine_data_outputs: {
-          issue_number: 'metadata.engine_data.store_idea_agent.issue_number',
-          issue_url: 'metadata.engine_data.store_idea_agent.issue_url',
+          issue_number: 'metadata.engine_data.example_agent.issue_number',
+          issue_url: 'metadata.engine_data.example_agent.issue_url',
         },
         tool_recorders: [{
           tool: 'github_issue_publish',
           record: {
-            engine_key: 'store_idea_agent',
+            engine_key: 'example_agent',
             fields: {
               issue_number: 'data.issue_number',
               issue_url: 'data.issue_url',
@@ -1108,9 +1108,9 @@ try {
   assert.equal(recorderBundleRunOutput.success, true);
   assert.equal(recorderBundleRunOutput.status, 'completed');
   assert.equal(recorderBundleRunOutput.outputs.issue_number, 123);
-  assert.equal(recorderBundleRunOutput.outputs.issue_url, 'https://github.com/chubes4/wp-site-generator/issues/123');
+  assert.equal(recorderBundleRunOutput.outputs.issue_url, 'https://github.com/example-org/example-repo/issues/123');
   assert.equal(recorderBundleRunOutput.run.agentResult.outputs.issue_number, 123);
-  assert.equal(recorderBundleRunOutput.run.agentResult.outputs.issue_url, 'https://github.com/chubes4/wp-site-generator/issues/123');
+  assert.equal(recorderBundleRunOutput.run.agentResult.outputs.issue_url, 'https://github.com/example-org/example-repo/issues/123');
 
   const completedBundleNonzeroExitCapturePath = path.join(root, 'capture-completed-bundle-nonzero-exit.json');
   const completedBundleNonzeroExitResult = spawnSync(process.execPath, [
@@ -1124,15 +1124,15 @@ try {
     input: JSON.stringify({
       ...request,
       agent_bundle: {
-        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
+        bundle_path: '/workspace/example-repo/bundles/example-agent',
         engine_data_outputs: {
-          issue_number: 'metadata.engine_data.store_idea_agent.issue_number',
-          issue_url: 'metadata.engine_data.store_idea_agent.issue_url',
+          issue_number: 'metadata.engine_data.example_agent.issue_number',
+          issue_url: 'metadata.engine_data.example_agent.issue_url',
         },
         tool_recorders: [{
           tool: 'github_issue_publish',
           record: {
-            engine_key: 'store_idea_agent',
+            engine_key: 'example_agent',
             fields: {
               issue_number: 'data.issue_number',
               issue_url: 'data.issue_url',
@@ -1170,8 +1170,8 @@ try {
     input: JSON.stringify({
       ...request,
       agent_bundle: {
-        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
-        engine_data_outputs: { issue_number: 'metadata.engine_data.store_idea_agent.issue_number' },
+        bundle_path: '/workspace/example-repo/bundles/example-agent',
+        engine_data_outputs: { issue_number: 'metadata.engine_data.example_agent.issue_number' },
       },
       provider_plugin_paths: [],
     }),
@@ -1204,8 +1204,8 @@ try {
       execution_kind: 'agent_bundle',
       homeboy_extensions: path.join(__dirname, '..'),
       agent_bundle: {
-        bundle_path: '/workspace/wp-site-generator/bundles/store-idea-agent',
-        engine_data_outputs: { issue_number: 'metadata.engine_data.store_idea_agent.issue_number' },
+        bundle_path: '/workspace/example-repo/bundles/example-agent',
+        engine_data_outputs: { issue_number: 'metadata.engine_data.example_agent.issue_number' },
       },
       provider_plugin_paths: [],
     }),


### PR DESCRIPTION
## Summary
- Replace WPSG/static-site-specific examples in generic Data Machine/WP Codebox adapter docs with neutral example-agent/example-repo fixtures.
- Rename generic adapter smoke fixture values from store/static-site names to example-agent/example_review artifacts.
- Keep dedicated static-site fanout fixtures intact as the downstream static-site-specific coverage.

## Tests
- `npm run test:codebox-agent-task-executor-boundary`
- `npm run test:codebox-agent-task-executor`
- `npm run test:wp-codebox-task-runner`
- `npm run test:datamachine-agent-ci-plan`
- `npm run test:wordpress-workload-profile`
- `php scripts/agent/datamachine-agent-terminal-state-smoke.php`

## Caveats
- `npm run lint:js` still fails on pre-existing unrelated lint violations in files not touched by this PR, including `wordpress/lib/playground-readiness.js`, `wordpress/lib/timing-correlator.js`, and several `wordpress/scripts/...` files.
- Scoped `npx eslint` on changed tests reports those test files are ignored by the repo ESLint config.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** genericized adapter fixtures and removed WPSG domain leakage.