### PR TITLE
fix(wordpress): repair DB-activation PHPUnit smoke canary on main

### DIFF
--- a/.github/workflows/wp-codebox-test-runtime-canary.yml
+++ b/.github/workflows/wp-codebox-test-runtime-canary.yml
@@ -29,6 +29,13 @@ jobs:
           ref: main
           path: .ci/wp-codebox
 
+      - name: Checkout Homeboy core
+        uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/homeboy
+          ref: main
+          path: .ci/homeboy
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -52,6 +59,7 @@ jobs:
         env:
           HOMEBOY_WP_CODEBOX_BIN: ${{ github.workspace }}/.ci/wp-codebox/packages/cli/dist/index.js
           HOMEBOY_WP_CODEBOX_CORE_MODULE: ${{ github.workspace }}/.ci/wp-codebox/packages/runtime-core/dist/index.js
+          HOMEBOY_CORE_DIR: ${{ github.workspace }}/.ci/homeboy
         run: bash wordpress/scripts/test/playground-db-activation-smoke.sh
 
       - name: Run raw extra_plugins Composer autoload canary

--- a/wordpress/scripts/test/playground-db-activation-smoke.sh
+++ b/wordpress/scripts/test/playground-db-activation-smoke.sh
@@ -27,8 +27,26 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOMEBOY_CORE_DIR="${HOMEBOY_CORE_DIR:-$(cd "${EXTENSION_PATH}/../.." && pwd)/homeboy}"
+CORE_RUNTIME_DIR="${HOMEBOY_CORE_DIR}/src/core/extension/runtime"
+# The test runner chain (test-runner.sh -> test-runner-wp-codebox.sh) sources the
+# core runtime helpers and hard-requires their HOMEBOY_RUNTIME_* env vars. The
+# shared-core fallbacks were removed in homeboy-extensions e0f604a4, so direct
+# (non-`homeboy test`) invocations must point those vars at the core helpers,
+# matching the bench/build smokes. `homeboy test` exports these automatically.
+RUNNER_PRELUDE_HELPER="${HOMEBOY_RUNTIME_RUNNER_PRELUDE:-${CORE_RUNTIME_DIR}/runner-prelude.sh}"
+RESOLVE_CONTEXT_HELPER="${HOMEBOY_RUNTIME_RESOLVE_CONTEXT:-${CORE_RUNTIME_DIR}/resolve-context.sh}"
+RUNNER_STEPS_HELPER="${HOMEBOY_RUNTIME_RUNNER_STEPS:-${CORE_RUNTIME_DIR}/runner-steps.sh}"
 HOST_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/test-db-activation-host"
 DEP_FIXTURE_DIR="${EXTENSION_PATH}/tests/fixtures/bench-db-activation-dep"
+
+for core_helper in "$RUNNER_PRELUDE_HELPER" "$RESOLVE_CONTEXT_HELPER" "$RUNNER_STEPS_HELPER"; do
+    if [ ! -f "$core_helper" ]; then
+        echo "ERROR: core runtime helper not found at $core_helper" >&2
+        echo "Set the HOMEBOY_RUNTIME_* helper vars or check out homeboy core at $HOMEBOY_CORE_DIR" >&2
+        exit 1
+    fi
+done
 
 if [ ! -d "$HOST_FIXTURE_DIR" ]; then
     echo "ERROR: host fixture not found at $HOST_FIXTURE_DIR" >&2
@@ -63,6 +81,9 @@ echo ""
 HOMEBOY_COMPONENT_ID=test-db-activation-host \
 HOMEBOY_COMPONENT_PATH="$HOST_FIXTURE_DIR" \
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_RUNTIME_RUNNER_PRELUDE="$RUNNER_PRELUDE_HELPER" \
+HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_CONTEXT_HELPER" \
+HOMEBOY_RUNTIME_RUNNER_STEPS="$RUNNER_STEPS_HELPER" \
 HOMEBOY_SETTINGS_JSON="$SETTINGS_JSON" \
     bash "${SCRIPT_DIR}/test-runner.sh"
 


### PR DESCRIPTION
## Summary
The **DB activation PHPUnit smoke** CI check (`wp-codebox-test-runtime-canary.yml`, step "Run WP Codebox-backed test runner canary") was RED on every recent `main` run, blocking all homeboy-extensions PRs.

## Root cause
`playground-db-activation-smoke.sh` invokes the WordPress `test-runner.sh` chain directly (outside `homeboy test`). Commit `e0f604a4` ("fix: remove shared core helper fallbacks") changed the runner scripts from *fallback-defaulting* their runtime helpers to *hard-requiring* the `HOMEBOY_RUNTIME_*` env vars:

- `test-runner.sh` -> `HOMEBOY_RUNTIME_RUNNER_PRELUDE` (`:?`)
- `test-runner-wp-codebox.sh` -> `HOMEBOY_RUNTIME_RESOLVE_CONTEXT` + `HOMEBOY_RUNTIME_RUNNER_STEPS` (`:?`)

That PR updated the bench/build smokes to resolve these from `HOMEBOY_CORE_DIR`, but missed this canary. Result, the canary died immediately with:

```
test-runner.sh: line 10: HOMEBOY_RUNTIME_RUNNER_PRELUDE: HOMEBOY_RUNTIME_RUNNER_PRELUDE is required
```

## Fix
- **Smoke script**: resolve `HOMEBOY_CORE_DIR` and pass `HOMEBOY_RUNTIME_RUNNER_PRELUDE`, `HOMEBOY_RUNTIME_RESOLVE_CONTEXT`, and `HOMEBOY_RUNTIME_RUNNER_STEPS` to the runner chain (mirrors the bench/build smokes; `homeboy test` exports these automatically). Fails fast with a clear message if a core helper is missing.
- **Canary workflow**: check out `Extra-Chill/homeboy` core to `.ci/homeboy` and set `HOMEBOY_CORE_DIR` so the helpers resolve in CI.

Not a skip/delete — the underlying breakage is repaired so the DB-activation smoke runs for real.

## Validation (local, full CI-equivalent env)
- Reproduced the exact CI error first, then fixed it.
- Built `Automattic/wp-codebox` (`npm install`) + `composer install` in `wordpress/`, ran the canary against the real WP Codebox runtime:
  - `OK (3 tests, 7 assertions)` -> `✓ Test runner DB-touching activation smoke PASSED` (exit 0)
- Re-ran the sibling canary `wp-codebox-extra-plugins-autoload-smoke.sh` -> PASSED (no regression).
- `bash -n` on the changed script and YAML lint both pass.