### PR TITLE
fix(wordpress): neutralize runtime version setting

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -302,7 +302,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     homeboy_path: config.homeboy || config.homeboy_path || runtimeOptions.homeboy || '',
     homeboy_extensions_path: config.homeboy_extensions || config.homeboy_extensions_path || runtimeOptions.homeboyExtensions || '',
     wp_codebox_bin: firstValue(config.runtime_bin, config.wp_codebox_bin, config.wpCodeboxBin, runtimeOptions.wpCodeboxBin, defaults.wpCodeboxBin, ''),
-    wp: config.runtime_wordpress_version || config.wp_codebox_wordpress_version || config.wpCodeboxWordpressVersion || config.wp || config.wordpress_version || runtimeOptions.wpCodeboxWordpressVersion || '',
+    wp: config.runtime_wordpress_version || config.wordpress_runtime_version || config.wordpress_version || config.wp_codebox_wordpress_version || config.wpCodeboxWordpressVersion || config.wp || runtimeOptions.wpCodeboxWordpressVersion || '',
     artifacts_path: config.artifacts || config.artifacts_path || runtimeOptions.artifacts || '',
     max_turns: config.max_turns || runtimeOptions.maxTurns,
     task_timeout_seconds: config.task_timeout_seconds || timeoutSeconds || timeoutFromMs || runtimeOptions.taskTimeoutSeconds,

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -1129,7 +1129,7 @@ function runnerInput(request, artifacts) {
     component_contracts: uniqueComponentContracts((request.component_contracts || []).map(remapRuntimeComponentContract)),
     homeboy_path: argValue('--homeboy') || request.homeboy_path || request.homeboy || '',
     homeboy_extensions_path: argValue('--homeboy-extensions') || request.homeboy_extensions_path || request.homeboy_extensions || path.resolve(__dirname, '..', '..'),
-    wp_version: request.wp_codebox_wordpress_version || request.wp_version || request.wp || undefined,
+    wp_version: request.wordpress_runtime_version || request.wordpress_version || request.wp_codebox_wordpress_version || request.wp_version || request.wp || undefined,
     agent_bundle: requestAgentBundle(request),
   }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
 }

--- a/wordpress/docs/AGENT_CI_WP_CODEBOX.md
+++ b/wordpress/docs/AGENT_CI_WP_CODEBOX.md
@@ -368,7 +368,7 @@ knobs to `homeboy-codebox-agent-task-executor.cjs` through the quarantined
 - Bundle location: `bundle_path`, `bundle_repo`, `bundle_ref`, `bundle_path_in_repo`.
 - Agent selection: `agent_slug`, `pipeline_slug`, `flow_slug`, `prompt`, `provider`, `model`.
 - Provider plugin: `provider_plugin`, with OpenAI defaults preserved when omitted for `provider: openai`.
-- WordPress runtime: `include_agent_runtime_dependencies`, runtime dependency refs, `wp_codebox_wordpress_version`, `wp_codebox_ref`, `extra_wp_config_defines`, `extra_wp_codebox_mounts`, `workload_run_before`, `workload_run_after`.
+- WordPress runtime: `include_agent_runtime_dependencies`, runtime dependency refs, `wordpress_runtime_version`, `wp_codebox_ref`, `extra_wp_config_defines`, `extra_wp_codebox_mounts`, `workload_run_before`, `workload_run_after`.
 - GitHub access: `target_repo`, `app_token_repos`, `require_homeboy_app_token`, `allowed_repos`, `engine_key`, `tool_results_key`.
 - Agent limits: `max_turns`, `step_budget`, `time_budget_ms`.
 - Assertions and outputs: `success_requires_pr`, `success_completion_outcomes`, `engine_data_outputs`, `artifact_export_config`, `transcript_artifact_name`, `replay_bundle_artifact_name`.

--- a/wordpress/docs/PLAYGROUND_DROPIN.md
+++ b/wordpress/docs/PLAYGROUND_DROPIN.md
@@ -155,7 +155,7 @@ during build).
   schema.
 
 - **WP version pinning.** The WordPress test runner defaults to `6.9`, and
-  the `wp_codebox_wordpress_version` setting can pass a different WordPress version.
+  the `wordpress_runtime_version` setting can pass a different WordPress version.
   The selected WordPress version must
   match the `wp-phpunit` package version. Don't forget to update both when
   bumping WordPress. A mismatch often manifests as missing `WP_UnitTestCase`

--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -565,7 +565,7 @@ if (result.status === 'process_exited') {
 
 ## Known gaps
 
-- **WP version defaults to 6.9.** Override `wp_codebox_wordpress_version` to pass
+- **WP version defaults to 6.9.** Override `wordpress_runtime_version` to pass
   a different WordPress version to WP Codebox. Mismatched versions produce
   missing-class errors.
 - **Multisite is opt-in.** Set `HOMEBOY_WORDPRESS_MULTISITE=1` or

--- a/wordpress/scripts/agent/run-datamachine-agent.sh
+++ b/wordpress/scripts/agent/run-datamachine-agent.sh
@@ -1003,7 +1003,7 @@ fi
 
 WORKLOAD_ID=$(jq -r '.workload_id // "datamachine-agent"' "$CONFIG_PATH")
 WORKLOAD_LABEL=$(jq -r '.workload_label // "Run Data Machine agent"' "$CONFIG_PATH")
-WP_CODEBOX_WORDPRESS_VERSION=$(jq -r '.wp_codebox_wordpress_version // ""' "$CONFIG_PATH")
+WP_CODEBOX_WORDPRESS_VERSION=$(jq -r '.wordpress_runtime_version // .wp_codebox_wordpress_version // ""' "$CONFIG_PATH")
 ENABLE_TERMINAL_ACTIONS=$(jq -r 'if (.enable_terminal_actions // .enable_wp_cli_tool // false) then "1" else "0" end' <<<"$CONFIG_JSON")
 if [ "$ENABLE_TERMINAL_ACTIONS" = "1" ]; then
     if [ -z "$RUNTIME_DIR" ]; then

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -829,7 +829,7 @@ homeboy_wp_codebox_filter_scoped_validation_dependencies
 
 WP_CODEBOX_WORDPRESS_VERSION=""
 if [ "$settings_json" != "{}" ]; then
-    extracted=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_wordpress_version // empty' 2>/dev/null || true)
+    extracted=$(printf '%s' "$settings_json" | jq -r '.wordpress_runtime_version // .wp_codebox_wordpress_version // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_WORDPRESS_VERSION="$extracted"
 fi
 

--- a/wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh
@@ -104,7 +104,7 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.wp_config_defines // {}' 2>/dev/null || echo "{}")
     [ -n "$extracted" ] && WP_CONFIG_DEFINES_JSON="$extracted"
 
-    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_wordpress_version // empty' 2>/dev/null || true)
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wordpress_runtime_version // .wp_codebox_wordpress_version // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_WORDPRESS_VERSION="$extracted"
 
     if [ -z "$WP_CODEBOX_MULTISITE" ]; then

--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -325,7 +325,7 @@ HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
-HOMEBOY_SETTINGS_JSON='{"wp_codebox_bin":"'"${TMPDIR}/stubs/wp-codebox.sh"'","wp_codebox_wordpress_version":"latest"}' \
+HOMEBOY_SETTINGS_JSON='{"wp_codebox_bin":"'"${TMPDIR}/stubs/wp-codebox.sh"'","wordpress_runtime_version":"latest"}' \
 WP_CODEBOX_ARGS_FILE="${TMPDIR}/wp-codebox-settings-args.txt" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/Unit/ImportAgentAbilityTest.php > "${TMPDIR}/wp-codebox-settings.out"
 

--- a/wordpress/scripts/test/test-runner-host-smoke-wp.sh
+++ b/wordpress/scripts/test/test-runner-host-smoke-wp.sh
@@ -88,7 +88,7 @@ homeboy_wordpress_smoke_wp_version() {
     local version=""
     if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
         local extracted
-        extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_wordpress_version // empty' 2>/dev/null || true)
+        extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wordpress_runtime_version // .wp_codebox_wordpress_version // empty' 2>/dev/null || true)
         [ -n "$extracted" ] && [ "$extracted" != "null" ] && version="$extracted"
     fi
     printf '%s\n' "$version"

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -639,7 +639,7 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.phpunit_no_tests // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && PHPUNIT_NO_TESTS="$extracted"
 
-    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_wordpress_version // empty' 2>/dev/null || true)
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wordpress_runtime_version // .wp_codebox_wordpress_version // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_WORDPRESS_VERSION="$extracted"
 
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_multisite // empty' 2>/dev/null || true)

--- a/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh
@@ -178,7 +178,7 @@ SETTINGS_JSON=$(jq -nc \
     --argjson wpConfig '{"WP_DEBUG":true,"CUSTOM_NUMBER":7}' \
     --argjson benchEnv '{"HOMEBOY_FLAG":"yes"}' \
     '{
-        wp_codebox_wordpress_version: "6.10",
+        wordpress_runtime_version: "6.10",
         wp_config_defines: $wpConfig,
         bench_env: $benchEnv,
         wp_codebox_file_mounts: [

--- a/wordpress/scripts/trace/trace-runner.sh
+++ b/wordpress/scripts/trace/trace-runner.sh
@@ -76,7 +76,7 @@ homeboy_wordpress_trace_wp_version() {
     local extracted=""
 
     if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then
-        extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_wordpress_version // empty' 2>/dev/null || true)
+        extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wordpress_runtime_version // .wp_codebox_wordpress_version // empty' 2>/dev/null || true)
         [ -n "$extracted" ] && [ "$extracted" != "null" ] && version="$extracted"
     fi
 

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -888,7 +888,7 @@ const workflowStyleConfigRequest = codeboxTaskRequestFromAgentTaskRequest({
     config: datamachineAgentCiCodeboxExecutorConfig({
       provider: 'codex',
       runtime_bin: '/bin/wp-codebox-runtime',
-      runtime_wordpress_version: 'beta',
+      wordpress_runtime_version: 'beta',
       runtime_mounts: [{
         type: 'file',
         source: '/host/driver.php',
@@ -918,6 +918,19 @@ assert.equal(workflowStyleConfigRequest.runtime_component_paths.agent_runtime, '
 assert.equal(workflowStyleConfigRequest.runtime_component_paths.agent_runtime_tools, '/components/data-machine-code');
 assert.equal(Object.hasOwn(workflowStyleConfigRequest.runtime_component_paths, 'data_machine'), false);
 assert.equal(Object.hasOwn(workflowStyleConfigRequest.runtime_component_paths, 'data_machine_code'), false);
+
+const deprecatedWordPressRuntimeVersionRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'runtime-contract-task-deprecated-wordpress-version',
+  executor: {
+    backend: 'codebox',
+    config: datamachineAgentCiCodeboxExecutorConfig({
+      provider: 'codex',
+      wp_codebox_wordpress_version: '6.9',
+    }),
+  },
+});
+assert.equal(deprecatedWordPressRuntimeVersionRequest.wp, '6.9');
 
 const defaultsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-agent-task-defaults-'));
 try {

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1041,11 +1041,11 @@
       "description": "Optional browser bench target descriptor. Set {\"enabled\": true} to write HOMEBOY_BENCH_SHARED_STATE/browser-target.json. Include baseUrl/adminUrl for an already-running site; otherwise the file is metadata-only because the WP Codebox bench command exits after workloads complete. Login supports method plus username/password or password_env; raw target files are handoff artifacts and must not be published in reports."
     },
     {
-      "id": "wp_codebox_wordpress_version",
+      "id": "wordpress_runtime_version",
       "label": "WordPress runtime version",
       "type": "string",
       "default": "",
-      "description": "Optional WordPress core version passed to WP Codebox test and bench runners. Leave empty for the runner default. Use this when a component needs classes or behavior from a newer WordPress core build."
+      "description": "Optional WordPress core version passed to WordPress test and bench runtime providers. Leave empty for the runner default. Use this when a component needs classes or behavior from a newer WordPress core build."
     },
     {
       "id": "wp_codebox_php_memory_limit",


### PR DESCRIPTION
## Summary
- replace the generic WordPress extension setting `wp_codebox_wordpress_version` with provider-neutral `wordpress_runtime_version`
- keep `wp_codebox_wordpress_version` as a deprecated fallback at WP Codebox adapter boundaries
- update docs and smoke coverage for the new key

## Verification
- `npm run test:codebox-agent-task-executor`
- `bash scripts/test/wp-codebox-mount-translation-smoke.sh`
- `node --check agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js && node --check agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs && node --check wordpress/tests/codebox-agent-task-executor-smoke.js`
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/scripts/bench/bench-runner-wp-codebox.sh wordpress/scripts/agent/run-datamachine-agent.sh wordpress/scripts/trace/trace-runner.sh wordpress/scripts/test/test-runner-core-dev-wp-codebox.sh wordpress/scripts/test/test-runner-host-smoke-wp.sh wordpress/scripts/test/test-runner-file-routing-smoke.sh wordpress/scripts/test/wp-codebox-mount-translation-smoke.sh`
- `node -e "JSON.parse(require('node:fs').readFileSync('wordpress/wordpress.json','utf8'))"`
- `git diff --check`

## Notes
- `npm run lint:js` still fails on pre-existing unrelated lint errors in untouched files.
- `HOMEBOY_CORE_DIR=/Users/chubes/Developer/homeboy HOMEBOY_RUNTIME_RUNNER_PRELUDE=/Users/chubes/Developer/homeboy/src/core/extension/runtime/runner-prelude.sh bash scripts/test/test-runner-file-routing-smoke.sh` still fails before the changed setting assertion because `HOST_SMOKE_BEGIN` is missing from the mixed-file routing assertion.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scoped setting rename, compatibility fallback, docs/test updates, and verification commands for Chris to review.