### PR TITLE
Add runtime agent CI primitive

### DIFF
--- a/.github/workflows/runtime-agent-ci.yml
+++ b/.github/workflows/runtime-agent-ci.yml
@@ -1,0 +1,136 @@
+name: Runtime Agent CI (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      runtime_provider:
+        description: Runtime provider backend identifier.
+        required: false
+        type: string
+        default: codebox
+      provider:
+        description: Model/provider identifier forwarded to the runtime.
+        required: false
+        type: string
+        default: ''
+      model:
+        description: Model identifier forwarded to the runtime.
+        required: false
+        type: string
+        default: ''
+      runtime_profile:
+        description: Runtime profile id to select from runtime_profiles.
+        required: true
+        type: string
+      runtime_profiles:
+        description: JSON object keyed by runtime profile id.
+        required: true
+        type: string
+      runtime_component_paths:
+        description: JSON object mapping runtime component keys to workspace paths.
+        required: false
+        type: string
+        default: '{}'
+      ignored_workspace_paths:
+        description: JSON array of workspace paths ignored by drift/status checks.
+        required: false
+        type: string
+        default: '[]'
+      runtime_task:
+        description: JSON object with ability and input keys.
+        required: true
+        type: string
+      ability_requirements:
+        description: JSON array of required ability/tool identifiers.
+        required: false
+        type: string
+        default: '[]'
+      ability_tools:
+        description: JSON array of tool declarations made available to the runtime.
+        required: false
+        type: string
+        default: '[]'
+      artifact_slots:
+        description: JSON array/object declaring expected artifact slots.
+        required: false
+        type: string
+        default: '[]'
+      transcript_slots:
+        description: JSON array/object declaring transcript slots.
+        required: false
+        type: string
+        default: '[]'
+      task_timeout_seconds:
+        description: Runtime task timeout in seconds.
+        required: false
+        type: number
+        default: 900
+    outputs:
+      runtime_config_path:
+        description: Path to the validated runtime config envelope.
+        value: ${{ jobs.prepare.outputs.runtime_config_path }}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      runtime_config_path: ${{ steps.config.outputs.runtime_config_path }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: config
+        shell: bash
+        env:
+          RUNTIME_PROVIDER: ${{ inputs.runtime_provider }}
+          PROVIDER: ${{ inputs.provider }}
+          MODEL: ${{ inputs.model }}
+          RUNTIME_PROFILE: ${{ inputs.runtime_profile }}
+          RUNTIME_PROFILES: ${{ inputs.runtime_profiles }}
+          RUNTIME_COMPONENT_PATHS: ${{ inputs.runtime_component_paths }}
+          IGNORED_WORKSPACE_PATHS: ${{ inputs.ignored_workspace_paths }}
+          RUNTIME_TASK: ${{ inputs.runtime_task }}
+          ABILITY_REQUIREMENTS: ${{ inputs.ability_requirements }}
+          ABILITY_TOOLS: ${{ inputs.ability_tools }}
+          ARTIFACT_SLOTS: ${{ inputs.artifact_slots }}
+          TRANSCRIPT_SLOTS: ${{ inputs.transcript_slots }}
+          TASK_TIMEOUT_SECONDS: ${{ inputs.task_timeout_seconds }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const {
+            runtimeAgentCiTaskExecutorConfig,
+          } = require('./runtime-agent-ci');
+
+          function parseJson(name, fallback) {
+            const value = process.env[name];
+            if (!value) {
+              return fallback;
+            }
+            return JSON.parse(value);
+          }
+
+          const config = runtimeAgentCiTaskExecutorConfig({
+            runtimeProvider: process.env.RUNTIME_PROVIDER,
+            provider: process.env.PROVIDER || undefined,
+            model: process.env.MODEL || undefined,
+            runtimeProfile: process.env.RUNTIME_PROFILE,
+            runtimeProfiles: parseJson('RUNTIME_PROFILES', {}),
+            runtimeComponentPaths: parseJson('RUNTIME_COMPONENT_PATHS', {}),
+            ignoredWorkspacePaths: parseJson('IGNORED_WORKSPACE_PATHS', []),
+            abilityInput: parseJson('RUNTIME_TASK', {}).input || {},
+            ability: parseJson('RUNTIME_TASK', {}).ability,
+            abilityRequirements: parseJson('ABILITY_REQUIREMENTS', []),
+            abilityTools: parseJson('ABILITY_TOOLS', []),
+            artifactSlots: parseJson('ARTIFACT_SLOTS', []),
+            transcriptSlots: parseJson('TRANSCRIPT_SLOTS', []),
+            taskTimeoutSeconds: Number(process.env.TASK_TIMEOUT_SECONDS || 900),
+          });
+
+          const outputPath = path.join(process.cwd(), 'runtime-agent-ci-config.json');
+          fs.writeFileSync(outputPath, `${JSON.stringify(config, null, 2)}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `runtime_config_path=${outputPath}\n`);
+          NODE
+      - uses: actions/upload-artifact@v4
+        with:
+          name: runtime-agent-ci-config
+          path: runtime-agent-ci-config.json

--- a/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
+++ b/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
@@ -2,13 +2,16 @@
 
 const {
   AGENT_TASK_RUNNER_SPEC_SCHEMA,
+  AGENT_TASK_PLAN_SCHEMA,
+  AGENT_TASK_REQUEST_SCHEMA,
   agentTaskRequestFromRunnerSpec,
-  agentTaskRunnerSpec,
+  runtimeAgentCiAbilityTaskRequest,
+  runtimeAgentCiPlan,
+  runtimeAgentCiRunnerSpec,
+  runtimeAgentCiTaskExecutorConfig,
   validateAgentTaskRunnerSpec,
-} = require('../../agent-runtimes/lib/agent-task-runner-contract');
+} = require('../../runtime-agent-ci');
 
-const AGENT_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
-const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
 const DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY = 'datamachine/run-agent-bundle';
 const DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID = 'datamachine-agent-ci';
 const DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_PRESET = 'datamachine';
@@ -158,86 +161,35 @@ function datamachineAgentCiBundleTaskRequest(options = {}, context = {}) {
     ...stripUndefined(options.runtimeTaskInput || options.runtime_task_input || {}),
   });
 
-  const runtimeProfile = resolveDatamachineAgentCiRuntimeProfile(options);
-
   return datamachineAgentCiAbilityTaskRequest({
     ...options,
     taskId,
-    ability: runtimeProfile.runtime_task_ability,
+    ability: options.ability,
     abilityInput: runtimeTaskInput,
   }, context);
 }
 
 function datamachineAgentCiAbilityTaskRequest(options = {}, context = {}) {
-  const taskId = requiredString(options.taskId || options.task_id, 'taskId');
-  const ability = requiredString(options.ability, 'ability');
-  const runnerSpec = datamachineAgentCiRunnerSpec({
+  const runtimeProfile = resolveDatamachineAgentCiRuntimeProfile(options);
+  return runtimeAgentCiAbilityTaskRequest({
     ...options,
-    ability,
+    ability: options.ability || runtimeProfile.runtime_task_ability,
+    runtimeProfile: runtimeProfile.id,
+    runtimeProfiles: runtimeProfilesForOptions(options, runtimeProfile),
   }, context);
-  const runnerRequest = agentTaskRequestFromRunnerSpec({ runnerSpec });
-
-  return stripUndefined({
-    schema: AGENT_TASK_REQUEST_SCHEMA,
-    task_id: taskId,
-    group_key: options.groupKey || options.group_key,
-    parent_plan_id: options.parentPlanId || options.parent_plan_id,
-    cwd: options.cwd,
-    repo: options.repo,
-    workspace: options.workspace,
-    executor: runnerRequest.executor,
-    instructions: options.instructions || '',
-    inputs: {
-      ...(options.inputs || {}),
-      ...(options.title ? { title: options.title } : {}),
-    },
-    limits: runnerRequest.limits,
-    expected_artifacts: runnerRequest.expected_artifacts,
-  });
 }
 
 function datamachineAgentCiRunnerSpec(options = {}, context = {}) {
   const taskExecutorConfig = context.taskExecutorConfig || datamachineAgentCiTaskExecutorConfig;
-  const config = taskExecutorConfig(options);
-  return agentTaskRunnerSpec({
-    backend: options.backend || 'codebox',
-    config,
-    secret_env: normalizeArray(config.secret_env),
-    task_timeout_seconds: config.task_timeout_seconds || options.taskTimeoutSeconds || options.task_timeout_seconds || 900,
-    limits: options.limits,
-    expected_artifacts: options.expectedArtifacts || options.expected_artifacts,
-  });
+  return runtimeAgentCiRunnerSpec(options, { taskExecutorConfig });
 }
 
 function datamachineAgentCiTaskExecutorConfig(options = {}) {
   const runtimeProfile = resolveDatamachineAgentCiRuntimeProfile(options);
-  const runtimeTaskInput = options.abilityInput || options.ability_input || {};
-  const runtimeTask = stripUndefined({
-    ability: options.ability || runtimeProfile.runtime_task_ability,
-    input: runtimeTaskInput,
-  });
-  return stripUndefined({
-    ...(options.config || {}),
-    provider: options.provider,
-    model: options.model,
-    runtime_profile: runtimeProfile.id,
-    runtime_profiles: runtimeProfilesForOptions(options, runtimeProfile),
-    runtime_component_paths: options.runtimeComponentPaths || options.runtime_component_paths,
-    component_contracts: options.componentContracts || options.component_contracts,
-    homeboy_extensions: options.homeboyExtensions || options.homeboy_extensions,
-    agent_bundles: options.agentBundles || options.agent_bundles,
-    runtime_task: runtimeTask,
-    ability_tools: options.abilityTools || options.ability_tools,
-    structured_artifacts: options.structuredArtifacts || options.structured_artifacts,
-    task_timeout_seconds: options.taskTimeoutSeconds || options.task_timeout_seconds,
-    max_turns: options.maxTurns || options.max_turns,
-    provider_plugin_paths: options.providerPluginPaths || options.provider_plugin_paths,
-    secret_env: options.secretEnv || options.secret_env,
-    runtime_env: options.runtimeEnv || options.runtime_env,
-    runtime_config_mounts: options.runtimeConfigMounts || options.runtime_config_mounts,
-    runtime_state_mounts: options.runtimeStateMounts || options.runtime_state_mounts,
-    runtime_id: options.runtimeId || options.runtime_id,
-    runtime_bin: options.runtimeBin || options.runtime_bin,
+  return runtimeAgentCiTaskExecutorConfig({
+    ...options,
+    runtimeProfile: runtimeProfile.id,
+    runtimeProfiles: runtimeProfilesForOptions(options, runtimeProfile),
   });
 }
 
@@ -270,22 +222,7 @@ function runtimeProfilesForOptions(options, runtimeProfile) {
 }
 
 function datamachineAgentCiPlan(options = {}) {
-  const planId = requiredString(options.planId || options.plan_id, 'planId');
-  const tasks = normalizeArray(options.tasks);
-  if (tasks.length === 0) {
-    throw new Error('tasks must contain at least one task request.');
-  }
-  return stripUndefined({
-    schema: AGENT_TASK_PLAN_SCHEMA,
-    plan_id: planId,
-    tasks,
-    options: options.options,
-    metadata: options.metadata,
-  });
-}
-
-function normalizeArray(value) {
-  return Array.isArray(value) ? value.filter(Boolean) : [];
+  return runtimeAgentCiPlan(options);
 }
 
 function requiredString(value, name) {

--- a/runtime-agent-ci/index.js
+++ b/runtime-agent-ci/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./lib/runtime-agent-ci-plan');

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const {
+  AGENT_TASK_RUNNER_SPEC_SCHEMA,
+  agentTaskRequestFromRunnerSpec,
+  agentTaskRunnerSpec,
+  validateAgentTaskRunnerSpec,
+} = require('../../agent-runtimes/lib/agent-task-runner-contract');
+
+const AGENT_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
+const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
+const RUNTIME_AGENT_CI_RUNTIME_PROFILE_ID = 'runtime-agent-ci';
+
+function runtimeAgentCiRuntimeTaskRequest(options = {}, context = {}) {
+  const taskId = requiredString(options.taskId || options.task_id, 'taskId');
+  const runtimeProfile = resolveRuntimeAgentCiRuntimeProfile(options);
+  const runtimeTaskInput = stripUndefined({
+    ...(options.runtimeTaskInput || options.runtime_task_input || {}),
+  });
+
+  return runtimeAgentCiAbilityTaskRequest({
+    ...options,
+    taskId,
+    ability: options.ability || runtimeProfile.runtime_task_ability,
+    abilityInput: runtimeTaskInput,
+  }, context);
+}
+
+function runtimeAgentCiAbilityTaskRequest(options = {}, context = {}) {
+  const taskId = requiredString(options.taskId || options.task_id, 'taskId');
+  const ability = requiredString(options.ability, 'ability');
+  const runnerSpec = runtimeAgentCiRunnerSpec({
+    ...options,
+    ability,
+  }, context);
+  const runnerRequest = agentTaskRequestFromRunnerSpec({ runnerSpec });
+
+  return stripUndefined({
+    schema: AGENT_TASK_REQUEST_SCHEMA,
+    task_id: taskId,
+    group_key: options.groupKey || options.group_key,
+    parent_plan_id: options.parentPlanId || options.parent_plan_id,
+    cwd: options.cwd,
+    repo: options.repo,
+    workspace: options.workspace,
+    executor: runnerRequest.executor,
+    instructions: options.instructions || '',
+    inputs: {
+      ...(options.inputs || {}),
+      ...(options.title ? { title: options.title } : {}),
+    },
+    limits: runnerRequest.limits,
+    expected_artifacts: runnerRequest.expected_artifacts,
+  });
+}
+
+function runtimeAgentCiRunnerSpec(options = {}, context = {}) {
+  const taskExecutorConfig = context.taskExecutorConfig || runtimeAgentCiTaskExecutorConfig;
+  const config = taskExecutorConfig(options);
+  return agentTaskRunnerSpec({
+    backend: options.backend || options.runtimeProvider || options.runtime_provider || 'codebox',
+    config,
+    secret_env: normalizeArray(config.secret_env),
+    task_timeout_seconds: config.task_timeout_seconds || options.taskTimeoutSeconds || options.task_timeout_seconds || 900,
+    limits: options.limits,
+    expected_artifacts: options.expectedArtifacts || options.expected_artifacts,
+  });
+}
+
+function runtimeAgentCiTaskExecutorConfig(options = {}) {
+  const runtimeProfile = resolveRuntimeAgentCiRuntimeProfile(options);
+  const runtimeTaskInput = options.abilityInput || options.ability_input || {};
+  const runtimeTask = stripUndefined({
+    ability: options.ability || runtimeProfile.runtime_task_ability,
+    input: runtimeTaskInput,
+  });
+  return stripUndefined({
+    ...(options.config || {}),
+    provider: options.provider,
+    model: options.model,
+    runtime_provider: options.runtimeProvider || options.runtime_provider,
+    runtime_profile: runtimeProfile.id,
+    runtime_profiles: runtimeProfilesForOptions(options, runtimeProfile),
+    runtime_component_paths: options.runtimeComponentPaths || options.runtime_component_paths,
+    component_contracts: options.componentContracts || options.component_contracts,
+    homeboy_extensions: options.homeboyExtensions || options.homeboy_extensions,
+    agent_bundles: options.agentBundles || options.agent_bundles,
+    ignored_workspace_paths: options.ignoredWorkspacePaths || options.ignored_workspace_paths,
+    runtime_task: runtimeTask,
+    ability_tools: options.abilityTools || options.ability_tools,
+    ability_requirements: options.abilityRequirements || options.ability_requirements || runtimeProfile.ability_requirements,
+    artifact_slots: options.artifactSlots || options.artifact_slots,
+    transcript_slots: options.transcriptSlots || options.transcript_slots,
+    structured_artifacts: options.structuredArtifacts || options.structured_artifacts,
+    task_timeout_seconds: options.taskTimeoutSeconds || options.task_timeout_seconds,
+    max_turns: options.maxTurns || options.max_turns,
+    provider_plugin_paths: options.providerPluginPaths || options.provider_plugin_paths,
+    secret_env: options.secretEnv || options.secret_env,
+    runtime_env: options.runtimeEnv || options.runtime_env,
+    runtime_config_mounts: options.runtimeConfigMounts || options.runtime_config_mounts,
+    runtime_state_mounts: options.runtimeStateMounts || options.runtime_state_mounts,
+    runtime_id: options.runtimeId || options.runtime_id,
+    runtime_bin: options.runtimeBin || options.runtime_bin,
+  });
+}
+
+function resolveRuntimeAgentCiRuntimeProfile(options = {}) {
+  const runtimeProfiles = options.runtimeProfiles || options.runtime_profiles || options.config?.runtime_profiles || options.config?.runtimeProfiles || {};
+  const requestedProfile = options.runtimeProfile || options.runtime_profile || options.config?.runtime_profile || options.config?.runtimeProfile || RUNTIME_AGENT_CI_RUNTIME_PROFILE_ID;
+  const profile = runtimeProfiles[requestedProfile] || options.runtimeProfileConfig || options.runtime_profile_config;
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+    throw new Error(`runtime profile ${requestedProfile} is not configured.`);
+  }
+
+  const id = requiredString(profile.id || requestedProfile, 'runtime profile id');
+  return {
+    ...profile,
+    id,
+    runtime_task_ability: requiredString(
+      options.runtimeTaskAbility || options.runtime_task_ability || profile.runtime_task_ability,
+      'runtime task ability'
+    ),
+  };
+}
+
+function runtimeProfilesForOptions(options, runtimeProfile) {
+  return {
+    ...(options.config?.runtime_profiles || options.config?.runtimeProfiles || {}),
+    ...(options.runtimeProfiles || options.runtime_profiles || {}),
+    [runtimeProfile.id]: runtimeProfile,
+  };
+}
+
+function runtimeAgentCiPlan(options = {}) {
+  const planId = requiredString(options.planId || options.plan_id, 'planId');
+  const tasks = normalizeArray(options.tasks);
+  if (tasks.length === 0) {
+    throw new Error('tasks must contain at least one task request.');
+  }
+  return stripUndefined({
+    schema: AGENT_TASK_PLAN_SCHEMA,
+    plan_id: planId,
+    tasks,
+    options: options.options,
+    metadata: options.metadata,
+  });
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function requiredString(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function stripUndefined(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  );
+}
+
+module.exports = {
+  AGENT_TASK_PLAN_SCHEMA,
+  AGENT_TASK_REQUEST_SCHEMA,
+  AGENT_TASK_RUNNER_SPEC_SCHEMA,
+  RUNTIME_AGENT_CI_RUNTIME_PROFILE_ID,
+  agentTaskRequestFromRunnerSpec,
+  runtimeAgentCiAbilityTaskRequest,
+  runtimeAgentCiPlan,
+  runtimeAgentCiRunnerSpec,
+  runtimeAgentCiRuntimeTaskRequest,
+  runtimeAgentCiTaskExecutorConfig,
+  resolveRuntimeAgentCiRuntimeProfile,
+  validateAgentTaskRunnerSpec,
+};

--- a/tests/architectural-boundary-smoke.mjs
+++ b/tests/architectural-boundary-smoke.mjs
@@ -9,11 +9,13 @@ const boundaryTerms = /Data Machine|DataMachine|datamachine|data-machine|wp-site
 const productionExtensions = new Set(['.js', '.cjs', '.mjs', '.ts', '.tsx']);
 
 const scannedRoots = [
+  'runtime-agent-ci',
   'wordpress/lib',
   'agent-runtimes/lib',
 ];
 
 const scannedFiles = [
+  '.github/workflows/runtime-agent-ci.yml',
   'wordpress/scripts/agent/run-host-runner-lifecycle.cjs',
   'agent-runtimes/lib/runtime-provider-resolver.cjs',
 ];

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const runtimeAgentCi = require(path.join(repoRoot, 'runtime-agent-ci/index.js'));
+const datamachineAgentCi = require(path.join(repoRoot, 'datamachine-agent-ci/index.js'));
+
+const genericBoundaryTerms = /Data Machine|DataMachine|datamachine|data-machine|wp-site-generator|WPSG|site-generator|site generator/;
+const genericFiles = [
+  'runtime-agent-ci/index.js',
+  'runtime-agent-ci/lib/runtime-agent-ci-plan.js',
+  '.github/workflows/runtime-agent-ci.yml',
+];
+
+for (const relativePath of genericFiles) {
+  const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+  assert.equal(
+    genericBoundaryTerms.test(content),
+    false,
+    `${relativePath} must remain provider-neutral.`
+  );
+}
+
+const runtimeProfile = {
+  schema: 'homeboy/runtime-profile/v1',
+  id: 'example-agent-ci',
+  runtime_task_ability: 'example/run-task',
+  component_path_defaults: {
+    contract_slug_map: { 'example-runtime': 'agent_runtime' },
+    path_aliases: { agent_runtime: ['contract:agent_runtime'] },
+  },
+  ability_requirements: ['example/run-task', 'example/read-state'],
+};
+
+const genericConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
+  runtimeProvider: 'codebox',
+  provider: 'example-provider',
+  model: 'example-model',
+  runtimeProfile: runtimeProfile.id,
+  runtimeProfiles: { [runtimeProfile.id]: runtimeProfile },
+  runtimeComponentPaths: { agent_runtime: '/workspace/components/example-runtime' },
+  ignoredWorkspacePaths: ['.cache', 'tmp'],
+  ability: 'example/run-task',
+  abilityInput: { prompt: 'Cook.' },
+  abilityTools: [{ name: 'example_tool' }],
+  artifactSlots: [{ name: 'packet', required: true }],
+  transcriptSlots: [{ name: 'main', required: true }],
+});
+
+assert.equal(genericConfig.runtime_provider, 'codebox');
+assert.equal(genericConfig.runtime_profile, 'example-agent-ci');
+assert.deepEqual(genericConfig.runtime_component_paths, { agent_runtime: '/workspace/components/example-runtime' });
+assert.deepEqual(genericConfig.ignored_workspace_paths, ['.cache', 'tmp']);
+assert.deepEqual(genericConfig.runtime_task, { ability: 'example/run-task', input: { prompt: 'Cook.' } });
+assert.deepEqual(genericConfig.ability_requirements, ['example/run-task', 'example/read-state']);
+assert.deepEqual(genericConfig.ability_tools, [{ name: 'example_tool' }]);
+assert.deepEqual(genericConfig.artifact_slots, [{ name: 'packet', required: true }]);
+assert.deepEqual(genericConfig.transcript_slots, [{ name: 'main', required: true }]);
+
+const genericRequest = runtimeAgentCi.runtimeAgentCiAbilityTaskRequest({
+  taskId: 'task-1',
+  runtimeProfile: runtimeProfile.id,
+  runtimeProfiles: { [runtimeProfile.id]: runtimeProfile },
+  ability: 'example/run-task',
+  abilityInput: { prompt: 'Cook.' },
+  expectedArtifacts: ['packet'],
+});
+
+assert.equal(genericRequest.schema, 'homeboy/agent-task-request/v1');
+assert.equal(genericRequest.executor.backend, 'codebox');
+assert.deepEqual(genericRequest.expected_artifacts, ['packet']);
+assert.deepEqual(genericRequest.executor.config.runtime_task, { ability: 'example/run-task', input: { prompt: 'Cook.' } });
+
+const adapterConfig = datamachineAgentCi.datamachineAgentCiTaskExecutorConfig({
+  taskId: 'task-2',
+  source: 'bundle',
+  agentSlug: 'agent',
+  pipelineSlug: 'pipeline',
+  flowSlug: 'flow',
+});
+
+assert.equal(adapterConfig.runtime_profile, datamachineAgentCi.DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID);
+assert.equal(
+  adapterConfig.runtime_profiles[datamachineAgentCi.DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID].runtime_task_ability,
+  datamachineAgentCi.DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY
+);
+assert.deepEqual(
+  adapterConfig.runtime_profiles[datamachineAgentCi.DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID].component_path_defaults,
+  datamachineAgentCi.DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS
+);
+assert.deepEqual(
+  adapterConfig.runtime_profiles[datamachineAgentCi.DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID].ability_requirements,
+  datamachineAgentCi.DATAMACHINE_AGENT_CI_ABILITY_REQUIREMENTS
+);
+
+console.log('runtime agent CI contract smoke passed');


### PR DESCRIPTION
## Summary
- Add provider-neutral `runtime-agent-ci` primitives for task envelopes, runtime provider selection, runtime profiles, component paths, ignored workspace paths, artifact/transcript slots, and ability/tool requirements.
- Add a reusable `runtime-agent-ci.yml` workflow surface that validates and publishes the generic runtime config envelope.
- Keep `datamachine-agent-ci` as a quarantined adapter that supplies Data Machine-specific defaults before delegating to the generic primitive.
- Extend boundary tests so generic runtime CI code/workflow cannot mention Data Machine or WPSG terms.

## Verification
- `node tests/runtime-agent-ci-contract-smoke.mjs`
- `node tests/architectural-boundary-smoke.mjs`
- `node tests/datamachine-agent-ci-primitives-smoke.mjs`
- `npm --prefix wordpress run test:datamachine-agent-ci-plan`
- `npm --prefix wordpress run test:codebox-agent-task-executor-boundary`
- `git diff --check`

## Verification notes
- `npm --prefix wordpress run lint:js` currently fails on existing unrelated lint issues in `wordpress/lib/playground-readiness.js`, `wordpress/lib/timing-correlator.js`, and existing runner/helper scripts. The failures are outside this PR's touched files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runtime-agent-ci extraction, workflow surface, adapter rewiring, and smoke tests; Chris remains responsible for review and final merge decisions.
