### PR TITLE
Shrink Data Machine agent CI adapter

### DIFF
--- a/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
+++ b/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
@@ -7,8 +7,10 @@ const {
   agentTaskRequestFromRunnerSpec,
   runtimeAgentCiAbilityTaskRequest,
   runtimeAgentCiPlan,
+  runtimeAgentCiRuntimeProfilesForOptions,
   runtimeAgentCiRunnerSpec,
   runtimeAgentCiTaskExecutorConfig,
+  resolveRuntimeAgentCiRuntimeProfile,
   validateAgentTaskRunnerSpec,
 } = require('../../runtime-agent-ci');
 
@@ -170,13 +172,8 @@ function datamachineAgentCiBundleTaskRequest(options = {}, context = {}) {
 }
 
 function datamachineAgentCiAbilityTaskRequest(options = {}, context = {}) {
-  const runtimeProfile = resolveDatamachineAgentCiRuntimeProfile(options);
-  return runtimeAgentCiAbilityTaskRequest({
-    ...options,
-    ability: options.ability || runtimeProfile.runtime_task_ability,
-    runtimeProfile: runtimeProfile.id,
-    runtimeProfiles: runtimeProfilesForOptions(options, runtimeProfile),
-  }, context);
+  const runtimeOptions = datamachineAgentCiRuntimeOptions(options);
+  return runtimeAgentCiAbilityTaskRequest(runtimeOptions, context);
 }
 
 function datamachineAgentCiRunnerSpec(options = {}, context = {}) {
@@ -185,39 +182,25 @@ function datamachineAgentCiRunnerSpec(options = {}, context = {}) {
 }
 
 function datamachineAgentCiTaskExecutorConfig(options = {}) {
-  const runtimeProfile = resolveDatamachineAgentCiRuntimeProfile(options);
-  return runtimeAgentCiTaskExecutorConfig({
+  return runtimeAgentCiTaskExecutorConfig(datamachineAgentCiRuntimeOptions(options));
+}
+
+function datamachineAgentCiRuntimeOptions(options = {}) {
+  const runtimeProfile = resolveRuntimeAgentCiRuntimeProfile({
     ...options,
-    runtimeProfile: runtimeProfile.id,
-    runtimeProfiles: runtimeProfilesForOptions(options, runtimeProfile),
+    runtimeProfile: options.runtimeProfile || options.runtime_profile || options.config?.runtime_profile || options.config?.runtimeProfile || DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID,
+    runtimeProfilePresets: {
+      ...DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_PRESETS,
+      ...(options.config?.runtime_profile_presets || options.config?.runtimeProfilePresets || {}),
+      ...(options.runtimeProfilePresets || options.runtime_profile_presets || {}),
+    },
   });
-}
 
-function resolveDatamachineAgentCiRuntimeProfile(options = {}) {
-  const runtimeProfiles = options.runtimeProfiles || options.runtime_profiles || options.config?.runtime_profiles || options.config?.runtimeProfiles || {};
-  const requestedProfile = options.runtimeProfile || options.runtime_profile || options.config?.runtime_profile || options.config?.runtimeProfile || DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID;
-  const presetProfile = DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_PRESETS[requestedProfile];
-  const profile = runtimeProfiles[requestedProfile] || presetProfile;
-  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
-    throw new Error(`runtime profile ${requestedProfile} is not configured.`);
-  }
-
-  const id = requiredString(profile.id || requestedProfile, 'runtime profile id');
   return {
-    ...profile,
-    id,
-    runtime_task_ability: requiredString(
-      options.runtimeTaskAbility || options.runtime_task_ability || profile.runtime_task_ability || DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY,
-      'runtime task ability'
-    ),
-  };
-}
-
-function runtimeProfilesForOptions(options, runtimeProfile) {
-  return {
-    ...(options.config?.runtime_profiles || options.config?.runtimeProfiles || {}),
-    ...(options.runtimeProfiles || options.runtime_profiles || {}),
-    [runtimeProfile.id]: runtimeProfile,
+    ...options,
+    ability: options.ability || runtimeProfile.runtime_task_ability,
+    runtimeProfile: runtimeProfile.id,
+    runtimeProfiles: runtimeAgentCiRuntimeProfilesForOptions(options, runtimeProfile),
   };
 }
 

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -106,8 +106,9 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
 
 function resolveRuntimeAgentCiRuntimeProfile(options = {}) {
   const runtimeProfiles = options.runtimeProfiles || options.runtime_profiles || options.config?.runtime_profiles || options.config?.runtimeProfiles || {};
+  const runtimeProfilePresets = options.runtimeProfilePresets || options.runtime_profile_presets || options.config?.runtime_profile_presets || options.config?.runtimeProfilePresets || {};
   const requestedProfile = options.runtimeProfile || options.runtime_profile || options.config?.runtime_profile || options.config?.runtimeProfile || RUNTIME_AGENT_CI_RUNTIME_PROFILE_ID;
-  const profile = runtimeProfiles[requestedProfile] || options.runtimeProfileConfig || options.runtime_profile_config;
+  const profile = runtimeProfiles[requestedProfile] || runtimeProfilePresets[requestedProfile] || options.runtimeProfileConfig || options.runtime_profile_config;
   if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
     throw new Error(`runtime profile ${requestedProfile} is not configured.`);
   }
@@ -123,13 +124,15 @@ function resolveRuntimeAgentCiRuntimeProfile(options = {}) {
   };
 }
 
-function runtimeProfilesForOptions(options, runtimeProfile) {
+function runtimeAgentCiRuntimeProfilesForOptions(options, runtimeProfile) {
   return {
     ...(options.config?.runtime_profiles || options.config?.runtimeProfiles || {}),
     ...(options.runtimeProfiles || options.runtime_profiles || {}),
     [runtimeProfile.id]: runtimeProfile,
   };
 }
+
+const runtimeProfilesForOptions = runtimeAgentCiRuntimeProfilesForOptions;
 
 function runtimeAgentCiPlan(options = {}) {
   const planId = requiredString(options.planId || options.plan_id, 'planId');
@@ -176,6 +179,7 @@ module.exports = {
   runtimeAgentCiPlan,
   runtimeAgentCiRunnerSpec,
   runtimeAgentCiRuntimeTaskRequest,
+  runtimeAgentCiRuntimeProfilesForOptions,
   runtimeAgentCiTaskExecutorConfig,
   resolveRuntimeAgentCiRuntimeProfile,
   validateAgentTaskRunnerSpec,

--- a/tests/architectural-boundary-smoke.mjs
+++ b/tests/architectural-boundary-smoke.mjs
@@ -23,7 +23,6 @@ const scannedFiles = [
 const allowedTransitionalAdapters = [
   /^datamachine-agent-ci\//,
   /^wordpress\/lib\/datamachine-agent-ci(?:-|$)/,
-  /^agent-runtimes\/wp-codebox\//,
 ];
 
 function isAllowedTransitionalAdapter(relativePath) {


### PR DESCRIPTION
## Summary
- Let runtime-agent-ci resolve caller-provided runtime profile presets and export its runtime profile map helper.
- Refactor datamachine-agent-ci to supply only its Data Machine profile presets/default and delegate generic config construction to runtime-agent-ci.
- Tighten the architectural boundary smoke allowlist by removing the stale wp-codebox exception from this scan.

## Verification
- `node tests/runtime-agent-ci-contract-smoke.mjs`
- `node tests/datamachine-agent-ci-primitives-smoke.mjs`
- `node tests/architectural-boundary-smoke.mjs`
- `npm run test:datamachine-agent-ci-plan` from `wordpress/`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the adapter refactor, boundary test update, and local verification; Chris remains responsible for review and acceptance.