### PR TITLE
Add generic Codebox runtime invocation config

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -31,6 +31,76 @@ const WP_CODEBOX_TASK_REQUEST_SCHEMA = 'wp-codebox/task-input/v1';
 const WP_CODEBOX_PROVIDER_ID = 'wordpress.codebox-agent-task-executor';
 const WP_CODEBOX_PROVIDER_LABEL = 'WP Codebox agent task executor';
 const WP_CODEBOX_BACKEND = 'codebox';
+const WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA = 'wp-codebox/provider-runtime-invocation-contract/v1';
+
+const WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES = {
+  workspaceCapture: 'wp-codebox.runner-workspace.capture',
+  workspaceCommand: 'wp-codebox.runner-workspace.command',
+  workspacePublish: 'wp-codebox.runner-workspace.publish',
+  toolCallTranscriptRecord: 'wp-codebox.tool-call-transcript.record',
+  artifactHandoff: 'wp-codebox.artifact-handoff',
+};
+
+const WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES = {
+  workspaceCapture: 'wp-codebox/runner-workspace-capture',
+  workspaceCommand: 'wp-codebox/runner-workspace-command',
+  workspacePublish: 'wp-codebox/runner-workspace-publish',
+  toolCallTranscriptRecord: 'wp-codebox/record-tool-call-transcript',
+  artifactHandoff: 'wp-codebox/handoff-artifacts',
+};
+
+const WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS = {
+  workspace_capture: 'wp-codebox/runner-workspace-capture-result/v1',
+  workspace_command: 'wp-codebox/runner-workspace-command-result/v1',
+  workspace_publication: 'wp-codebox/runner-workspace-publication-result/v1',
+  tool_call_transcript: 'wp-codebox/tool-call-transcript/v1',
+  evidence_artifact_envelope: 'wp-codebox/evidence-artifact-envelope/v1',
+};
+
+const WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMA_KEYS = {
+  workspaceCapture: 'workspace_capture',
+  workspaceCommand: 'workspace_command',
+  workspacePublish: 'workspace_publication',
+  toolCallTranscriptRecord: 'tool_call_transcript',
+  artifactHandoff: 'evidence_artifact_envelope',
+};
+
+const WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES = Object.fromEntries(Object.entries({
+  workspaceCapture: [
+    'workspaceCapture',
+    'workspace_capture',
+    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.workspaceCapture,
+    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.workspaceCapture,
+  ],
+  workspaceCommand: [
+    'workspaceCommand',
+    'workspace_command',
+    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.workspaceCommand,
+    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.workspaceCommand,
+  ],
+  workspacePublish: [
+    'workspacePublish',
+    'workspace_publish',
+    'workspacePublication',
+    'workspace_publication',
+    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.workspacePublish,
+    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.workspacePublish,
+  ],
+  toolCallTranscriptRecord: [
+    'toolCallTranscriptRecord',
+    'tool_call_transcript_record',
+    'toolCallTranscript',
+    'tool_call_transcript',
+    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.toolCallTranscriptRecord,
+    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.toolCallTranscriptRecord,
+  ],
+  artifactHandoff: [
+    'artifactHandoff',
+    'artifact_handoff',
+    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.artifactHandoff,
+    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.artifactHandoff,
+  ],
+}).flatMap(([key, aliases]) => aliases.map((alias) => [alias, key])));
 
 const RUNTIME_MANIFEST_PATH = path.resolve(__dirname, '..', 'wp-codebox.json');
 const RUNTIME_OVERLAY_CANONICAL_SHAPE = 'runtime_overlays entries must be objects with a non-empty string kind, for example { "kind": "bundled-library", "library": "php-ai-client", "source": "/path/to/php-ai-client" }. The legacy type field is not accepted.';
@@ -141,6 +211,7 @@ function providerContract(options = {}) {
     component_path_defaults: runtimeComponentPathDefaults(options),
     provider_defaults: providerDefaultsContract(runtimeProviderDefaults()),
     provider_preflight: runtimeProviderPreflight(),
+    provider_runtime_invocation: providerRuntimeInvocationContract(),
     role_aliases: WP_CODEBOX_ROLE_ALIASES,
     status: 'active',
     integration_contract: 'homeboy-wordpress-agent-task/v1',
@@ -188,6 +259,98 @@ function runtimeComponentDiscovery(options = {}) {
   return firstObject(options.componentDiscovery, runtimeComponentPathDefaults(options).discovery) || {};
 }
 
+function providerRuntimeInvocationContract() {
+  return {
+    schema: WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
+    version: 1,
+    tasks: { ...WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES },
+    abilities: { ...WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES },
+    result_schemas: { ...WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS },
+  };
+}
+
+function providerRuntimeInvocationFromConfig(config = {}, inputs = {}, options = {}) {
+  const requested = firstDefined(
+    inputs.provider_runtime_invocation,
+    inputs.providerRuntimeInvocation,
+    inputs.runtime_invocation,
+    inputs.runtimeInvocation,
+    config.provider_runtime_invocation,
+    config.providerRuntimeInvocation,
+    config.runtime_invocation,
+    config.runtimeInvocation,
+    options.providerRuntimeInvocation,
+    options.provider_runtime_invocation,
+    options.runtimeInvocation,
+    options.runtime_invocation,
+  );
+  if (requested === undefined) {
+    return providerRuntimeInvocationContract();
+  }
+
+  const contract = providerRuntimeInvocationContract();
+  const operationEntries = providerRuntimeOperationEntries(requested);
+  if (operationEntries.length === 0) {
+    return contract;
+  }
+
+  return {
+    ...contract,
+    operations: Object.fromEntries(operationEntries),
+  };
+}
+
+function providerRuntimeOperationEntries(requested) {
+  if (Array.isArray(requested)) {
+    return requested
+      .map((operation) => providerRuntimeOperationEntry(operation))
+      .filter(Boolean);
+  }
+  if (!requested || typeof requested !== 'object') {
+    return [];
+  }
+  const operations = requested.operations || requested.provider_operations || requested.providerOperations || requested.tasks || requested.abilities || requested;
+  if (Array.isArray(operations)) {
+    return operations
+      .map((operation) => providerRuntimeOperationEntry(operation))
+      .filter(Boolean);
+  }
+  if (!operations || typeof operations !== 'object') {
+    return [];
+  }
+  return Object.entries(operations)
+    .map(([key, operation]) => providerRuntimeOperationEntry(operation, key))
+    .filter(Boolean);
+}
+
+function providerRuntimeOperationEntry(operation, fallbackKey = '') {
+  const rawName = typeof operation === 'string'
+    ? operation
+    : firstValue(operation?.key, operation?.operation, operation?.task, operation?.ability, fallbackKey);
+  const key = WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES[rawName] || WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES[fallbackKey];
+  if (!key) {
+    return null;
+  }
+  return [key, providerRuntimeOperationConfig(key, operation)];
+}
+
+function providerRuntimeOperationConfig(key, operation) {
+  const resultSchemaKey = WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMA_KEYS[key];
+  const explicitConfig = operation && typeof operation === 'object' && !Array.isArray(operation)
+    ? firstObject(operation.config, operation.input, operation.args) || {}
+    : {};
+  return withoutUndefinedValues({
+    task: WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES[key],
+    ability: WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES[key],
+    result_schema: WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS[resultSchemaKey],
+    config: Object.keys(explicitConfig).length > 0 ? explicitConfig : undefined,
+  });
+}
+
+function withoutUndefinedValues(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
 function runtimeProviderDefaults() {
   return firstObject(runtimeExecutorManifest().provider_defaults) || {};
 }
@@ -233,6 +396,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(request, config, inputs) || runtimeOptions.runtimeTask,
     { provider, model, agentBundles }
   );
+  const providerRuntimeInvocation = providerRuntimeInvocationFromConfig(config, inputs, runtimeOptions);
   const explicitSecretEnv = [
     ...(plannedSecretEnv.length > 0 ? plannedSecretEnv : normalizeArray(request.executor?.secret_env)),
     ...normalizeArray(config.secret_env),
@@ -265,6 +429,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     recipe,
     sandbox_tool_policy: sandboxToolPolicy,
     runtime_task: runtimeTask,
+    provider_runtime_invocation: providerRuntimeInvocation,
     ability_tools: firstDefined(inputs.ability_tools, inputs.abilityTools, config.ability_tools, config.abilityTools, runtimeOptions.abilityTools, []),
     structured_artifacts: structuredArtifacts,
     sandbox_session_id: config.sandbox_session_id || request.task_id,
@@ -2494,7 +2659,12 @@ module.exports = {
   AGENT_TASK_FAILURE_CLASSIFICATIONS,
   AGENT_TASK_REDACTED_METADATA_KEYS,
   WP_CODEBOX_BACKEND,
+  WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES,
+  WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
+  WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS,
+  WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES,
   providerContract,
+  providerRuntimeInvocationContract,
   codeboxTaskRequestFromAgentTaskRequest,
   agentTaskOutcomeFromCodeboxResult,
 };

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -304,6 +304,31 @@
           "required_secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"]
         }
       },
+      "provider_runtime_invocation": {
+        "schema": "wp-codebox/provider-runtime-invocation-contract/v1",
+        "version": 1,
+        "tasks": {
+          "workspaceCapture": "wp-codebox.runner-workspace.capture",
+          "workspaceCommand": "wp-codebox.runner-workspace.command",
+          "workspacePublish": "wp-codebox.runner-workspace.publish",
+          "toolCallTranscriptRecord": "wp-codebox.tool-call-transcript.record",
+          "artifactHandoff": "wp-codebox.artifact-handoff"
+        },
+        "abilities": {
+          "workspaceCapture": "wp-codebox/runner-workspace-capture",
+          "workspaceCommand": "wp-codebox/runner-workspace-command",
+          "workspacePublish": "wp-codebox/runner-workspace-publish",
+          "toolCallTranscriptRecord": "wp-codebox/record-tool-call-transcript",
+          "artifactHandoff": "wp-codebox/handoff-artifacts"
+        },
+        "result_schemas": {
+          "workspace_capture": "wp-codebox/runner-workspace-capture-result/v1",
+          "workspace_command": "wp-codebox/runner-workspace-command-result/v1",
+          "workspace_publication": "wp-codebox/runner-workspace-publication-result/v1",
+          "tool_call_transcript": "wp-codebox/tool-call-transcript/v1",
+          "evidence_artifact_envelope": "wp-codebox/evidence-artifact-envelope/v1"
+        }
+      },
       "role_aliases": {
         "artifact_kinds": {
           "patch": ["codebox-patch"]

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -99,6 +99,7 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
     runtime_env: options.runtimeEnv || options.runtime_env,
     runtime_config_mounts: options.runtimeConfigMounts || options.runtime_config_mounts,
     runtime_state_mounts: options.runtimeStateMounts || options.runtime_state_mounts,
+    provider_runtime_invocation: options.providerRuntimeInvocation || options.provider_runtime_invocation || options.runtimeInvocation || options.runtime_invocation,
     runtime_id: options.runtimeId || options.runtime_id,
     runtime_bin: options.runtimeBin || options.runtime_bin,
   });

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -50,6 +50,7 @@ const genericConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
   abilityTools: [{ name: 'example_tool' }],
   artifactSlots: [{ name: 'packet', required: true }],
   transcriptSlots: [{ name: 'main', required: true }],
+  runtimeInvocation: { operations: ['workspaceCommand'] },
 });
 
 assert.equal(genericConfig.runtime_provider, 'codebox');
@@ -61,6 +62,7 @@ assert.deepEqual(genericConfig.ability_requirements, ['example/run-task', 'examp
 assert.deepEqual(genericConfig.ability_tools, [{ name: 'example_tool' }]);
 assert.deepEqual(genericConfig.artifact_slots, [{ name: 'packet', required: true }]);
 assert.deepEqual(genericConfig.transcript_slots, [{ name: 'main', required: true }]);
+assert.deepEqual(genericConfig.provider_runtime_invocation, { operations: ['workspaceCommand'] });
 
 const genericRequest = runtimeAgentCi.runtimeAgentCiAbilityTaskRequest({
   taskId: 'task-1',

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -8,6 +8,7 @@ const path = require('node:path');
 const {
   codeboxTaskRequestFromAgentTaskRequest,
   providerContract,
+  providerRuntimeInvocationContract,
 } = require('../../agent-runtimes/wp-codebox');
 const {
   DATAMACHINE_AGENT_CI_RUNTIME_PROFILE,
@@ -48,6 +49,10 @@ assert.equal(provider.id, 'wordpress.codebox-agent-task-executor');
 assert.equal(provider.label, 'WP Codebox agent task executor');
 assert.equal(provider.backend, 'codebox');
 assert.equal(provider.integration_contract, 'homeboy-wordpress-agent-task/v1');
+assert.deepEqual(provider.provider_runtime_invocation, providerRuntimeInvocationContract());
+assert.equal(provider.provider_runtime_invocation.tasks.workspaceCommand, 'wp-codebox.runner-workspace.command');
+assert.equal(provider.provider_runtime_invocation.abilities.workspaceCommand, 'wp-codebox/runner-workspace-command');
+assert.doesNotMatch(JSON.stringify(provider.provider_runtime_invocation), /datamachine|data machine|wp-site-generator|wpsg|site generator/i);
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, codexSecretEnv);
 
 const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'wordpress.json'), 'utf8'));
@@ -58,6 +63,7 @@ assert.equal(manifest.agent_task.runtime_requirements.integration_contract, 'hom
 const runtime = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'agent-runtimes', 'wp-codebox', 'wp-codebox.json'), 'utf8'));
 assert.equal(runtime.agent_task_executors.length, 1);
 assert.deepEqual(runtime.agent_task_executors[0], providerContract());
+assert.deepEqual(runtime.agent_task_executors[0].provider_runtime_invocation, providerRuntimeInvocationContract());
 assert.deepEqual(provider.runner_readiness, [{
   id: 'wp-codebox.executable',
   label: 'WP Codebox executable',
@@ -245,6 +251,36 @@ assert.deepEqual(customRuntimePolicyTaskInput.allowed_tools, [
 ]);
 assert.equal(customRuntimePolicyTaskInput.runtime_component_paths.agent_runtime, '/components/example-runtime');
 assert.equal(customRuntimePolicyTaskInput.runtime_component_paths.agent_runtime_tools, '/components/example-tools');
+
+const runtimeInvocationTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'generic-provider-runtime-invocation-task-1',
+  executor: {
+    backend: 'codebox',
+    config: {
+      provider: 'codex',
+      provider_runtime_invocation: {
+        operations: {
+          workspaceCommand: { config: { timeout_ms: 30000 } },
+          artifactHandoff: true,
+          'wp-codebox/runner-workspace-capture': {},
+        },
+      },
+    },
+  },
+  instructions: 'Run with generic WP Codebox provider runtime invocation names.',
+  workspace: { root: workspaceRoot, mode: 'readwrite' },
+});
+assert.equal(runtimeInvocationTaskInput.provider_runtime_invocation.schema, 'wp-codebox/provider-runtime-invocation-contract/v1');
+assert.deepEqual(runtimeInvocationTaskInput.provider_runtime_invocation.operations.workspaceCommand, {
+  task: 'wp-codebox.runner-workspace.command',
+  ability: 'wp-codebox/runner-workspace-command',
+  result_schema: 'wp-codebox/runner-workspace-command-result/v1',
+  config: { timeout_ms: 30000 },
+});
+assert.equal(runtimeInvocationTaskInput.provider_runtime_invocation.operations.artifactHandoff.ability, 'wp-codebox/handoff-artifacts');
+assert.equal(runtimeInvocationTaskInput.provider_runtime_invocation.operations.workspaceCapture.task, 'wp-codebox.runner-workspace.capture');
+assert.doesNotMatch(JSON.stringify(runtimeInvocationTaskInput.provider_runtime_invocation), /datamachine|data machine|wp-site-generator|wpsg|site generator/i);
 
 const customRuntimeProfileTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',


### PR DESCRIPTION
## Summary
- expose the WP Codebox provider runtime invocation contract through the Codebox executor manifest and provider contract
- let runtime-agent-ci callers pass generic runtime invocation config through to Codebox task config
- map WP Codebox generic operation identifiers into task/ability/result-schema entries without adding Data Machine or WPSG names to generic runtime code

## Verification
- `node tests/runtime-agent-ci-contract-smoke.mjs`
- `npm run test:codebox-agent-task-executor-boundary`
- `npm run test:codebox-agent-task-executor`
- `npm run test:wp-codebox-task-runner`
- `npm run test:datamachine-agent-ci-plan`
- `git diff --check`

## Notes
- `npm run lint:js` in `wordpress/` still fails on pre-existing unrelated files outside this diff, including `wordpress/lib/playground-readiness.js`, `wordpress/lib/timing-correlator.js`, and several scripts under `wordpress/scripts/`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected the runtime-agent-ci and WP Codebox provider boundary, drafted the generic invocation mapping and tests, and ran focused verification; Chris remains responsible for review and merge.