### PR TITLE
Forward Codebox runtime profiles

### DIFF
--- a/.github/scripts/datamachine-agent-ci/build-runner-config.cjs
+++ b/.github/scripts/datamachine-agent-ci/build-runner-config.cjs
@@ -93,6 +93,22 @@ function buildConfig(env) {
         ? ['datamachine/import-agent', 'datamachine/run-flow', 'datamachine/drain-job']
         : runtimeAbilityRequirements;
   const runtimeComponents = parseJsonInput('runtime_components', env.RUNTIME_COMPONENTS || '{}', 'object', {});
+  const runtimeOverlays = normalizePathSources(parseJsonInput('runtime_overlays', env.RUNTIME_OVERLAYS || '[]', 'array', []), workspace);
+  const componentContracts = parseJsonInput('component_contracts', env.COMPONENT_CONTRACTS || '[]', 'array', []);
+  const providerPluginPaths = validationDependencies.providerPluginHostPath ? [validationDependencies.providerPluginHostPath] : [];
+  const runtimeEnv = parseJsonInput('runtime_env', env.RUNTIME_ENV || '{}', 'object', {});
+  const codeboxRuntimeProfile = codeboxRuntimeProfilePayload({
+    id: runtimeProfile,
+    profile: runtimeProfiles[runtimeProfile],
+    componentContracts,
+    runtimeOverlays,
+    runtimeEnv,
+    providerPluginPaths,
+  });
+  const effectiveRuntimeProfiles = {
+    ...runtimeProfiles,
+    [runtimeProfile]: codeboxRuntimeProfile,
+  };
 
   return {
     _configPath: path.join(runnerTemp, 'datamachine-agent-config.json'),
@@ -103,7 +119,7 @@ function buildConfig(env) {
     validation_dependencies: validationDependencies.paths,
     runtime_id: runtimeId,
     runtime_profile: runtimeProfile,
-    ...(Object.keys(runtimeProfiles).length > 0 ? { runtime_profiles: runtimeProfiles } : {}),
+    runtime_profiles: effectiveRuntimeProfiles,
     execution_kind: executionKind,
     runtime_ref: env.AGENT_RUNTIME_REF || 'main',
     runtime_wordpress_version: env.RUNTIME_WORDPRESS_VERSION || '7.0',
@@ -119,7 +135,7 @@ function buildConfig(env) {
       ...runnerWorkspaceMounts,
     ],
     wp_config_defines: parseJsonInput('extra_wp_config_defines', env.EXTRA_WP_CONFIG_DEFINES || '{}', 'object', {}),
-    runtime_overlays: normalizePathSources(parseJsonInput('runtime_overlays', env.RUNTIME_OVERLAYS || '[]', 'array', []), workspace),
+    runtime_overlays: runtimeOverlays,
     workload_run_before: workloadRunBefore,
     workload_run_after: workloadRunAfter,
     required_abilities: Array.from(new Set([...executeRequiredAbilities, ...extraRequiredAbilities])),
@@ -142,7 +158,8 @@ function buildConfig(env) {
       data_machine_code: path.join(workspace, '.ci/data-machine-code'),
       ...runtimeComponents,
     },
-    provider_plugin_paths: validationDependencies.providerPluginHostPath ? [validationDependencies.providerPluginHostPath] : [],
+    provider_plugin_paths: providerPluginPaths,
+    runtime_requirements: codeboxRuntimeProfile,
     github_token_env: 'HOMEBOY_GITHUB_APP_TOKEN',
     github_repository_token_env: 'GITHUB_TOKEN',
     github_profile_id: `${agentSlug}-ci`,
@@ -175,7 +192,7 @@ function buildConfig(env) {
     expected_artifacts: parseJsonInput('expected_artifacts', env.EXPECTED_ARTIFACTS || '[]', 'array', []),
     artifact_declarations: parseJsonInput('artifact_declarations', env.ARTIFACT_DECLARATIONS || '[]', 'array', []),
     output_mappings: parseJsonInput('output_mappings', env.OUTPUT_MAPPINGS || '{}', 'object', {}),
-    component_contracts: parseJsonInput('component_contracts', env.COMPONENT_CONTRACTS || '[]', 'array', []),
+    component_contracts: componentContracts,
     ...(runtimeTask ? { runtime_task: runtimeTask } : {}),
     ability_tools: parseJsonInput('ability_tools', env.ABILITY_TOOLS || '[]', 'array', []),
     tool_recorders: parseJsonInput('tool_recorders', env.TOOL_RECORDERS || '[]', 'array', []),
@@ -277,6 +294,43 @@ function runtimeTaskFromEnv(env) {
       ...abilityInput,
     },
   };
+}
+
+function codeboxRuntimeProfilePayload({ id, profile = {}, componentContracts = [], runtimeOverlays = [], runtimeEnv = {}, providerPluginPaths = [] }) {
+  return withoutEmptyObjectValues({
+    ...profile,
+    schema: 'wp-codebox/runtime-profile/v1',
+    id: profile.id || id,
+    homeboy_profile_schema: profile.schema && profile.schema !== 'wp-codebox/runtime-profile/v1' ? profile.schema : undefined,
+    component_contracts: componentContracts,
+    extra_plugins: componentContracts,
+    runtime_overlays: runtimeOverlays,
+    env: runtimeEnv,
+    provider_plugins: providerPluginPaths.map((pluginPath) => ({ path: pluginPath })),
+    homeboy_parent_tool_bridge: {
+      schema: 'wp-codebox/parent-tool-bridge/v1',
+      status: 'declared-compatibility-bridge',
+      env: [
+        'HOMEBOY_AGENT_TOOL_POLICY_JSON',
+        'HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA',
+        'HOMEBOY_AGENT_TOOL_RESULT_SCHEMA',
+        'HOMEBOY_AGENT_TOOL_POLICY_SCHEMA',
+      ],
+      upstream_expected: 'Codebox runtime profiles should expose a parent-tool bridge component that maps parent-owned tools into sandbox-visible tool descriptors without Homeboy injecting bridge env directly.',
+    },
+  });
+}
+
+function withoutEmptyObjectValues(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => {
+    if (Array.isArray(entry)) {
+      return entry.length > 0;
+    }
+    if (entry && typeof entry === 'object') {
+      return Object.keys(entry).length > 0;
+    }
+    return entry !== undefined && entry !== '';
+  }));
 }
 
 function withoutInternalKeys(config) {

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -159,7 +159,7 @@ jobs:
 - `runtime_task` forwards a generic `{ "ability", "input" }` object to the runtime task executor.
 - `ability_request` and `ability_input` are a shorthand for direct ability execution. `ability_input` is merged into `ability_request.input`.
 - `output_mappings` maps named outputs to dotted paths in the runtime task result, and those outputs are validated when they are also listed in `engine_data_outputs`.
-- `component_contracts` forwards explicit runtime component/plugin contracts to WP Codebox. Use it for caller-owned fixture ability providers or runtime components that are not part of the default Data Machine stack.
+- `component_contracts` forwards explicit runtime component/plugin contracts to WP Codebox through the `wp-codebox/runtime-profile/v1` payload. Use it for caller-owned fixture ability providers or runtime components that are not part of the default Data Machine stack.
 - Generic WP Codebox executor paths accept caller-supplied component contracts, runtime overlays, mounts, task payload, provider defaults, and declarative runtime requirements. Data Machine Agent CI policy lives in this reusable workflow and runner adapter, not in the generic WP Codebox provider manifest.
 - `include_agent_runtime_dependencies` defaults to `true` and checks out the Data Machine Agent CI stack: `Automattic/agents-api`, `Extra-Chill/data-machine`, `Extra-Chill/data-machine-code`, and the provider plugin. The runner adapter forwards those paths to WP Codebox as explicit runtime component requirements.
 - `agents_api_ref`, `data_machine_ref`, `data_machine_code_ref`, and `openai_provider_ref` control runtime dependency refs. `openai_provider_ref` defaults to `trunk` for the built-in OpenAI preset.
@@ -175,7 +175,7 @@ jobs:
 - `transcript_artifact_name` controls artifact upload. An empty value skips upload.
 - `extra_wp_config_defines` must be a JSON object and is merged into the runner config `wp_config_defines`.
 - `runtime_mounts` adds selected-runtime mounts. It must be a JSON array.
-- `runtime_overlays` forwards runtime overlay entries to the runner config. It must be a JSON array.
+- `runtime_overlays` forwards runtime overlay entries to the Codebox runtime profile payload. It must be a JSON array; WP Codebox owns field-level overlay schema validation.
 - `workload_run_before`, `workload_run_after`, and `extra_required_abilities` must be JSON arrays.
 - `workload_run_after` runs post-agent verifier hooks in the same WordPress scenario, so consumers can assert the agent left WordPress in a valid state.
 - `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ component must be mounted explicitly. Keep ability names, schemas, and artifact
 types owned by the caller; Homeboy Extensions only forwards the generic runtime
 task contract.
 
+WP Codebox is expected to consume a `wp-codebox/runtime-profile/v1` payload with
+`component_contracts`, `extra_plugins`, `runtime_overlays`, `env`, and
+`provider_plugins`. Homeboy Extensions also declares the temporary
+`wp-codebox/parent-tool-bridge/v1` compatibility component in that payload; the
+expected upstream primitive is a Codebox-owned parent-tool bridge that maps
+parent-owned tools into sandbox-visible descriptors without Homeboy injecting the
+bridge env directly.
+
 Each extension also exposes a CLI binding for direct use against a project or component:
 
 ```bash

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -33,7 +33,7 @@ const WP_CODEBOX_PROVIDER_LABEL = 'WP Codebox agent task executor';
 const WP_CODEBOX_BACKEND = 'codebox';
 
 const RUNTIME_MANIFEST_PATH = path.resolve(__dirname, '..', 'wp-codebox.json');
-const RUNTIME_OVERLAY_CANONICAL_SHAPE = 'runtime_overlays entries must be objects with a non-empty string kind, for example { "kind": "bundled-library", "library": "php-ai-client", "source": "/path/to/php-ai-client" }. The legacy type field is not accepted.';
+const RUNTIME_OVERLAY_CANONICAL_SHAPE = 'runtime_overlays entries must be objects. WP Codebox owns the runtime overlay schema and reports field-level validation.';
 const PROVIDER_CAPABILITIES = runtimeProviderCapabilities();
 
 const AGENT_BUNDLE_CONFIG_FIELDS = [
@@ -242,6 +242,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
   const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
   const runtimeOverlays = runtimeOverlaysFromConfig(config, runtimeOptions, defaults);
+  const runtimeRequirements = codeboxRuntimeRequirementsFromAgentTaskRequest(config, runtimeOptions, defaults, componentContracts, runtimeOverlays);
   const context = {
     ...(inputs.context || {}),
     agent_task_id: request.task_id,
@@ -283,8 +284,9 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     runtime_stack_mounts: config.runtime_stack_mounts || runtimeOptions.runtimeStackMounts || [],
     runtime_overlay_profiles: config.runtime_overlay_profiles || config.runtimeOverlayProfiles || runtimeOptions.runtimeOverlayProfiles || defaults.runtimeOverlayProfiles || [],
     runtime_overlays: runtimeOverlays,
+    runtime_requirements: runtimeRequirements,
     runtime_env: {
-      ...firstDefined(config.runtime_env, config.runtimeEnv, config.wp_codebox_runtime_env, runtimeOptions.runtimeEnv, defaults.runtimeEnv, {}),
+      ...firstNonEmptyObject(config.runtime_env, config.runtimeEnv, config.wp_codebox_runtime_env, runtimeOptions.runtimeEnv, defaults.runtimeEnv, {}),
       ...homeboyAgentToolContractEnv(),
       ...datamachineHostToolPolicyEnv(),
     },
@@ -338,6 +340,11 @@ function runtimeOptionsFromExecutorConfig(config = {}, options = {}) {
       ...normalizeArray(runtimeProfile.ability_requirements),
       ...normalizeArray(runtimeProfile.abilityRequirements),
     ]),
+    providerPluginPaths: providerPluginPathsFromRuntimeProfile(runtimeRequirements, runtimeProfile, options),
+    runtimeOverlays: firstDefined(runtimeRequirements.runtime_overlays, runtimeProfile.runtime_overlays, options.runtimeOverlays),
+    runtimeEnv: firstNonEmptyObject(runtimeRequirements.env, runtimeRequirements.runtime_env, runtimeProfile.env, runtimeProfile.runtime_env, options.runtimeEnv, options.runtime_env),
+    runtimeStateMounts: firstDefined(runtimeRequirements.runtime_state_mounts, runtimeProfile.runtime_state_mounts, options.runtimeStateMounts, options.runtime_state_mounts),
+    runtimeConfigMounts: firstDefined(runtimeRequirements.runtime_config_mounts, runtimeProfile.runtime_config_mounts, options.runtimeConfigMounts, options.runtime_config_mounts),
   };
 }
 
@@ -474,6 +481,8 @@ class RuntimeOverlayConfigError extends Error {
 function runtimeOverlaysFromConfig(config, options = {}, defaults = {}) {
   return validateRuntimeOverlays(firstDefined(
     config.runtime_overlays,
+    config.runtime_requirements?.runtime_overlays,
+    options.runtimeProfile?.runtime_overlays,
     options.runtimeOverlays,
     defaults.runtimeOverlays,
     []
@@ -491,13 +500,6 @@ function validateRuntimeOverlays(value) {
       return;
     }
 
-    if (Object.hasOwn(overlay, 'type')) {
-      diagnostics.push(runtimeOverlayDiagnostic(index, `${pathPrefix}.type`, 'type', overlay.type, 'Runtime overlay config uses legacy field "type"; use canonical field "kind" instead.'));
-    }
-
-    if (typeof overlay.kind !== 'string' || overlay.kind.trim() === '') {
-      diagnostics.push(runtimeOverlayDiagnostic(index, `${pathPrefix}.kind`, 'kind', overlay.kind, 'Runtime overlay config requires canonical field "kind" as a non-empty string.'));
-    }
   });
 
   if (diagnostics.length > 0) {
@@ -525,8 +527,74 @@ function componentContractsFromAgentTaskRequest(request, config, options = {}) {
   return uniqueComponentContracts([
     ...normalizeArray(request.component_contracts),
     ...normalizeArray(config.component_contracts),
+    ...normalizeArray(config.runtime_requirements?.component_contracts),
+    ...normalizeArray(config.runtime_requirements?.extra_plugins),
+    ...normalizeArray(options.runtimeProfile?.component_contracts),
+    ...normalizeArray(options.runtimeProfile?.extra_plugins),
     ...normalizeArray(options.componentContracts),
   ]);
+}
+
+function codeboxRuntimeRequirementsFromAgentTaskRequest(config, options = {}, defaults = {}, componentContracts = [], runtimeOverlays = []) {
+  const runtimeProfile = firstObject(options.runtimeProfile) || {};
+  const runtimeRequirements = firstObject(config.runtime_requirements, config.runtimeRequirements) || {};
+  const runtimeEnv = firstNonEmptyObject(config.runtime_env, config.runtimeEnv, config.wp_codebox_runtime_env, runtimeRequirements.env, runtimeRequirements.runtime_env, runtimeProfile.env, runtimeProfile.runtime_env, options.runtimeEnv, defaults.runtimeEnv) || {};
+  const providerPluginPaths = firstNonEmptyArray(
+    config.provider_plugin_paths,
+    providerPluginPathsFromRuntimeProfile(runtimeRequirements, runtimeProfile, options),
+    defaults.providerPluginPaths,
+    []
+  );
+  return withoutEmptyObjectValues({
+    ...runtimeProfile,
+    ...runtimeRequirements,
+    schema: 'wp-codebox/runtime-profile/v1',
+    id: runtimeRequirements.id || runtimeProfile.id || config.runtime_profile || config.runtimeProfile,
+    homeboy_profile_schema: runtimeProfile.schema && runtimeProfile.schema !== 'wp-codebox/runtime-profile/v1' ? runtimeProfile.schema : undefined,
+    component_contracts: componentContracts,
+    extra_plugins: componentContracts,
+    runtime_overlays: runtimeOverlays,
+    env: runtimeEnv,
+    provider_plugins: providerPluginPaths.map((pluginPath) => ({ path: pluginPath })),
+    runtime_state_mounts: firstDefined(config.runtime_state_mounts, config.runtimeStateMounts, config.wp_codebox_runtime_state_mounts, runtimeRequirements.runtime_state_mounts, runtimeProfile.runtime_state_mounts, options.runtimeStateMounts, defaults.runtimeStateMounts),
+    runtime_config_mounts: firstDefined(config.runtime_config_mounts, config.runtimeConfigMounts, config.wp_codebox_runtime_config_mounts, runtimeRequirements.runtime_config_mounts, runtimeProfile.runtime_config_mounts, options.runtimeConfigMounts, defaults.runtimeConfigMounts),
+    homeboy_parent_tool_bridge: homeboyParentToolBridgeRequirement(),
+  });
+}
+
+function providerPluginPathsFromRuntimeProfile(runtimeRequirements = {}, runtimeProfile = {}, options = {}) {
+  return uniquePaths([
+    ...providerPluginPathEntries(runtimeRequirements.provider_plugins),
+    ...providerPluginPathEntries(runtimeProfile.provider_plugins),
+    ...normalizeArray(options.providerPluginPaths),
+    ...normalizeArray(options.provider_plugin_paths),
+  ]);
+}
+
+function providerPluginPathEntries(value) {
+  return normalizeArray(value).flatMap((entry) => {
+    if (typeof entry === 'string') {
+      return [entry];
+    }
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return [];
+    }
+    return [entry.path, entry.source].filter(Boolean);
+  });
+}
+
+function homeboyParentToolBridgeRequirement() {
+  return {
+    schema: 'wp-codebox/parent-tool-bridge/v1',
+    status: 'declared-compatibility-bridge',
+    env: [
+      'HOMEBOY_AGENT_TOOL_POLICY_JSON',
+      'HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA',
+      'HOMEBOY_AGENT_TOOL_RESULT_SCHEMA',
+      'HOMEBOY_AGENT_TOOL_POLICY_SCHEMA',
+    ],
+    upstream_expected: 'Codebox runtime profiles should expose a parent-tool bridge component that maps parent-owned tools into sandbox-visible tool descriptors without Homeboy injecting bridge env directly.',
+  };
 }
 
 function uniqueComponentContracts(contracts) {
@@ -997,6 +1065,18 @@ function firstDefined(...values) {
   return values.find((value) => value !== undefined);
 }
 
+function withoutEmptyObjectValues(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => {
+    if (Array.isArray(entry)) {
+      return entry.length > 0;
+    }
+    if (entry && typeof entry === 'object') {
+      return Object.keys(entry).length > 0;
+    }
+    return entry !== undefined && entry !== '';
+  }));
+}
+
 function parseJsonObject(value) {
   if (!value || typeof value !== 'string') {
     return null;
@@ -1360,6 +1440,10 @@ function agentBundleMounts(bundleConfig, explicitMounts = []) {
 
 function firstObject(...candidates) {
   return candidates.find((candidate) => candidate && typeof candidate === 'object' && !Array.isArray(candidate)) || null;
+}
+
+function firstNonEmptyObject(...candidates) {
+  return candidates.find((candidate) => candidate && typeof candidate === 'object' && !Array.isArray(candidate) && Object.keys(candidate).length > 0) || null;
 }
 
 function firstValue(...candidates) {

--- a/tests/datamachine-agent-ci-primitives-smoke.mjs
+++ b/tests/datamachine-agent-ci-primitives-smoke.mjs
@@ -122,6 +122,9 @@ assert.equal(config.runner_workspace.checkout_path, '/workspace/homeboy-extensio
 assert.deepEqual(config.writable_paths, ['src', 'tests']);
 assert.equal(config.provider_credentials.connectors_ai_openai_api_key, 'OPENAI_API_KEY');
 assert.equal(config.runtime_profile, 'datamachine-agent-ci');
+assert.equal(config.runtime_profiles['datamachine-agent-ci'].schema, 'wp-codebox/runtime-profile/v1');
+assert.equal(config.runtime_profiles['datamachine-agent-ci'].homeboy_parent_tool_bridge.schema, 'wp-codebox/parent-tool-bridge/v1');
+assert.deepEqual(config.runtime_requirements, config.runtime_profiles['datamachine-agent-ci']);
 assert.equal(config.runtime_bin, path.join(workspace, '.ci/wp-codebox/packages/cli/dist/index.js'));
 assert.equal(config.runtime_components.runtime, path.join(workspace, '.ci/wp-codebox/packages/wordpress-plugin'));
 assert.equal(config.runtime_components.data_machine, path.join(workspace, '.ci/data-machine'));
@@ -199,6 +202,8 @@ assert.deepEqual(runtimeTaskConfig.runtime_task, {
 });
 assert.deepEqual(runtimeTaskConfig.output_mappings, { processed_packet: 'result.processed_packet' });
 assert.deepEqual(runtimeTaskConfig.component_contracts, [{ slug: 'example-fixture-plugin', path: '/workspace/plugins/example-fixture-plugin', activate: true }]);
+assert.deepEqual(runtimeTaskConfig.runtime_requirements.component_contracts, runtimeTaskConfig.component_contracts);
+assert.deepEqual(runtimeTaskConfig.runtime_requirements.extra_plugins, runtimeTaskConfig.component_contracts);
 assert.equal(runtimeTaskConfig.runtime_mounts.some((mount) => mount.target === '/workspace/input' && mount.mode === 'readonly'), true);
 assert.deepEqual(runtimeTaskConfig.artifact_declarations, [{ name: 'processed_packet', type: 'example-packet', schema: 'example/processed-packet/v1', required: true }]);
 assert.deepEqual(runtimeTaskConfig.required_abilities, ['example/process-artifact']);
@@ -279,6 +284,10 @@ assert.equal(customProfileConfig.runtime_profile, 'example-agent-ci');
 assert.equal(customProfileConfig.runtime_profiles['example-agent-ci'].runtime_task_ability, 'example/run-agent-bundle');
 assert.equal(customProfileConfig.runtime_components.example_agents, '/workspace/components/example-agents');
 assert.deepEqual(customProfileConfig.component_contracts, [{ slug: 'example-agents', path: '/workspace/components/example-agents', activate: true }]);
+assert.equal(customProfileConfig.runtime_requirements.schema, 'wp-codebox/runtime-profile/v1');
+assert.equal(customProfileConfig.runtime_requirements.homeboy_profile_schema, 'homeboy/runtime-profile/v1');
+assert.deepEqual(customProfileConfig.runtime_requirements.component_contracts, customProfileConfig.component_contracts);
+assert.deepEqual(customProfileConfig.runtime_requirements.extra_plugins, customProfileConfig.component_contracts);
 assert.deepEqual(customProfileConfig.required_abilities, ['example/run-agent-bundle']);
 
 const resultsFile = path.join(tempRoot, 'results.json');

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -454,7 +454,23 @@ assert.deepEqual(codeboxRequest.runtime_overlays, [{
   target: '/wordpress/wp-includes/php-ai-client',
   metadata: { component: 'php-ai-client', ref: 'custom-provider-auth' },
 }]);
-assert.throws(() => codeboxTaskRequestFromAgentTaskRequest({
+assert.deepEqual(codeboxRequest.runtime_requirements, {
+  schema: 'wp-codebox/runtime-profile/v1',
+  runtime_overlays: codeboxRequest.runtime_overlays,
+  provider_plugins: [{ path: '/providers/openai' }],
+  homeboy_parent_tool_bridge: {
+    schema: 'wp-codebox/parent-tool-bridge/v1',
+    status: 'declared-compatibility-bridge',
+    env: [
+      'HOMEBOY_AGENT_TOOL_POLICY_JSON',
+      'HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA',
+      'HOMEBOY_AGENT_TOOL_RESULT_SCHEMA',
+      'HOMEBOY_AGENT_TOOL_POLICY_SCHEMA',
+    ],
+    upstream_expected: 'Codebox runtime profiles should expose a parent-tool bridge component that maps parent-owned tools into sandbox-visible tool descriptors without Homeboy injecting bridge env directly.',
+  },
+});
+const legacyOverlayNameRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
   task_id: 'invalid-runtime-overlay-type-task-123',
   executor: {
@@ -464,16 +480,8 @@ assert.throws(() => codeboxTaskRequestFromAgentTaskRequest({
       runtime_overlays: [{ type: 'bundled-library', library: 'php-ai-client', source: '/components/php-ai-client' }],
     },
   },
-}), (error) => {
-  assert.equal(error.name, 'RuntimeOverlayConfigError');
-  assert.equal(error.diagnostics[0].class, 'codebox.runtime_overlay_config_invalid');
-  assert.equal(error.diagnostics[0].data.overlay_index, 0);
-  assert.equal(error.diagnostics[0].data.field, 'runtime_overlays[0].type');
-  assert.equal(error.diagnostics[0].data.offending_field, 'type');
-  assert.match(error.diagnostics[0].message, /use canonical field "kind"/);
-  assert.match(error.diagnostics[0].data.expected, /"kind": "bundled-library"/);
-  return true;
 });
+assert.deepEqual(legacyOverlayNameRequest.runtime_overlays, [{ type: 'bundled-library', library: 'php-ai-client', source: '/components/php-ai-client' }]);
 assert.deepEqual(codeboxRequest.runtime_env, {});
 assert.deepEqual(codeboxRequest.runtime_state_mounts, []);
 assert.deepEqual(codeboxRequest.runtime_config_mounts, []);
@@ -710,6 +718,8 @@ assert.deepEqual(topLevelComponentContractsRequest.component_contracts, [
   { slug: 'domain-component', path: '/workspace/domain-component', activate: true },
   { slug: 'config-component', path: '/workspace/config-component', activate: false },
 ]);
+assert.deepEqual(topLevelComponentContractsRequest.runtime_requirements.component_contracts, topLevelComponentContractsRequest.component_contracts);
+assert.deepEqual(topLevelComponentContractsRequest.runtime_requirements.extra_plugins, topLevelComponentContractsRequest.component_contracts);
 
 const genericRuntimeEnv = {
   GENERIC_PROVIDER_CONFIG: '/runtime/provider/config.json',
@@ -750,6 +760,25 @@ assert.deepEqual(genericProviderRuntimeRequest.runtime_state_mounts, genericRunt
 assert.deepEqual(genericProviderRuntimeRequest.runtime_config_mounts, genericRuntimeConfigMounts);
 assert.deepEqual(genericProviderRuntimeRequest.provider_plugin_paths, ['/providers/fixture-provider']);
 assert.deepEqual(genericProviderRuntimeRequest.runtime_overlays, [{ kind: 'fixture-overlay', source: '/overlays/fixture' }]);
+assert.deepEqual(genericProviderRuntimeRequest.runtime_requirements, {
+  schema: 'wp-codebox/runtime-profile/v1',
+  runtime_overlays: [{ kind: 'fixture-overlay', source: '/overlays/fixture' }],
+  env: genericRuntimeEnv,
+  provider_plugins: [{ path: '/providers/fixture-provider' }],
+  runtime_state_mounts: genericRuntimeStateMounts,
+  runtime_config_mounts: genericRuntimeConfigMounts,
+  homeboy_parent_tool_bridge: {
+    schema: 'wp-codebox/parent-tool-bridge/v1',
+    status: 'declared-compatibility-bridge',
+    env: [
+      'HOMEBOY_AGENT_TOOL_POLICY_JSON',
+      'HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA',
+      'HOMEBOY_AGENT_TOOL_RESULT_SCHEMA',
+      'HOMEBOY_AGENT_TOOL_POLICY_SCHEMA',
+    ],
+    upstream_expected: 'Codebox runtime profiles should expose a parent-tool bridge component that maps parent-owned tools into sandbox-visible tool descriptors without Homeboy injecting bridge env directly.',
+  },
+});
 assert.deepEqual(genericProviderRuntimeRequest.runtime_overlay_profiles, ['fixture-profile']);
 assert.deepEqual(genericProviderRuntimeRequest.secret_env, ['FIXTURE_PROVIDER_SECRET']);
 
@@ -2216,6 +2245,7 @@ try {
   assert.match(missingModelOutcome.summary, /provider-config\.model/);
   assert.equal(fs.existsSync(capture), false);
 
+  fs.rmSync(capture, { force: true });
   const invalidOverlayResult = spawnSync(process.execPath, [
     wpCodeboxRuntimeExecutor,
     '--task-runner',
@@ -2235,16 +2265,9 @@ try {
       },
     }),
   });
-  assert.equal(invalidOverlayResult.status, 1, invalidOverlayResult.stderr || invalidOverlayResult.stdout);
-  const invalidOverlayOutcome = JSON.parse(invalidOverlayResult.stdout);
-  assert.equal(invalidOverlayOutcome.status, 'failed');
-  assert.equal(invalidOverlayOutcome.failure_classification, 'provider');
-  assert.equal(invalidOverlayOutcome.diagnostics[0].class, 'codebox.runtime_overlay_config_invalid');
-  assert.equal(invalidOverlayOutcome.diagnostics[0].data.overlay_index, 0);
-  assert.equal(invalidOverlayOutcome.diagnostics[0].data.field, 'runtime_overlays[0].type');
-  assert.match(invalidOverlayOutcome.diagnostics[0].message, /legacy field "type"/);
-  assert.match(invalidOverlayOutcome.diagnostics[0].data.expected, /"kind": "bundled-library"/);
-  assert.equal(fs.existsSync(capture), false);
+  assert.equal(invalidOverlayResult.status, 0, invalidOverlayResult.stderr || invalidOverlayResult.stdout);
+  const invalidOverlayCapture = JSON.parse(fs.readFileSync(capture, 'utf8'));
+  assert.deepEqual(invalidOverlayCapture.request.runtime_overlays, [{ type: 'bundled-library', library: 'php-ai-client', source: '/components/php-ai-client' }]);
 
   const result = spawnSync(process.execPath, [
     wpCodeboxRuntimeExecutor,


### PR DESCRIPTION
## Summary
- Forward runtime requirements using the shared wp-codebox/runtime-profile/v1 payload shape.
- Move runtime overlay field-level validation expectations back to WP Codebox.
- Declare the remaining Homeboy parent-tool bridge as a temporary Codebox runtime profile component.

## Dependency
- Aligns with https://github.com/Automattic/wp-codebox/pull/1209 for the upstream Codebox runtime profile contract.

## Testing
- node tests/datamachine-agent-ci-primitives-smoke.mjs
- node wordpress/tests/codebox-agent-task-executor-smoke.js
- node tests/wp-codebox-provider-plugin-defaults-smoke.mjs
- node tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the runtime profile forwarding changes and smoke coverage; Chris remains responsible for review and merge.