### PR TITLE
Expose generic runtime execution descriptors in agent CI

### DIFF
--- a/.github/workflows/runtime-agent-ci.yml
+++ b/.github/workflows/runtime-agent-ci.yml
@@ -37,9 +37,15 @@ on:
         type: string
         default: '[]'
       runtime_task:
-        description: JSON object with ability and input keys.
-        required: true
+        description: JSON object with ability and input keys. Use runtime_execution for generic bundle or workflow descriptors.
+        required: false
         type: string
+        default: '{}'
+      runtime_execution:
+        description: JSON object describing a generic ability, bundle, or workflow execution.
+        required: false
+        type: string
+        default: '{}'
       ability_requirements:
         description: JSON array of required ability/tool identifiers.
         required: false
@@ -88,6 +94,7 @@ jobs:
           RUNTIME_COMPONENT_PATHS: ${{ inputs.runtime_component_paths }}
           IGNORED_WORKSPACE_PATHS: ${{ inputs.ignored_workspace_paths }}
           RUNTIME_TASK: ${{ inputs.runtime_task }}
+          RUNTIME_EXECUTION: ${{ inputs.runtime_execution }}
           ABILITY_REQUIREMENTS: ${{ inputs.ability_requirements }}
           ABILITY_TOOLS: ${{ inputs.ability_tools }}
           ARTIFACT_SLOTS: ${{ inputs.artifact_slots }}
@@ -109,6 +116,7 @@ jobs:
             return JSON.parse(value);
           }
 
+          const runtimeTask = parseJson('RUNTIME_TASK', {});
           const config = runtimeAgentCiTaskExecutorConfig({
             runtimeProvider: process.env.RUNTIME_PROVIDER,
             provider: process.env.PROVIDER || undefined,
@@ -117,8 +125,9 @@ jobs:
             runtimeProfiles: parseJson('RUNTIME_PROFILES', {}),
             runtimeComponentPaths: parseJson('RUNTIME_COMPONENT_PATHS', {}),
             ignoredWorkspacePaths: parseJson('IGNORED_WORKSPACE_PATHS', []),
-            abilityInput: parseJson('RUNTIME_TASK', {}).input || {},
-            ability: parseJson('RUNTIME_TASK', {}).ability,
+            runtimeExecution: parseJson('RUNTIME_EXECUTION', {}),
+            abilityInput: runtimeTask.input || {},
+            ability: runtimeTask.ability,
             abilityRequirements: parseJson('ABILITY_REQUIREMENTS', []),
             abilityTools: parseJson('ABILITY_TOOLS', []),
             artifactSlots: parseJson('ARTIFACT_SLOTS', []),

--- a/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
+++ b/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
@@ -168,6 +168,11 @@ function datamachineAgentCiBundleTaskRequest(options = {}, context = {}) {
     taskId,
     ability: options.ability,
     abilityInput: runtimeTaskInput,
+    runtimeExecution: options.runtimeExecution || options.runtime_execution || {
+      kind: 'bundle',
+      ability: options.ability,
+      input: runtimeTaskInput,
+    },
   }, context);
 }
 
@@ -199,8 +204,42 @@ function datamachineAgentCiRuntimeOptions(options = {}) {
   return {
     ...options,
     ability: options.ability || runtimeProfile.runtime_task_ability,
+    runtimeExecution: options.runtimeExecution || options.runtime_execution || datamachineAgentCiRuntimeExecution(options),
     runtimeProfile: runtimeProfile.id,
     runtimeProfiles: runtimeAgentCiRuntimeProfilesForOptions(options, runtimeProfile),
+  };
+}
+
+function datamachineAgentCiRuntimeExecution(options = {}) {
+  const source = options.source || options.bundle;
+  if (!source) {
+    return null;
+  }
+  return {
+    kind: 'bundle',
+    ability: options.ability,
+    input: stripUndefined({
+      source,
+      agent_slug: options.agentSlug || options.agent_slug,
+      pipeline_slug: options.pipelineSlug || options.pipeline_slug,
+      flow_slug: options.flowSlug || options.flow_slug,
+      target_repo: options.targetRepo || options.target_repo,
+      prompt: options.prompt || '',
+      wait_for_completion: options.waitForCompletion ?? options.wait_for_completion ?? true,
+      success_requires_pr: options.successRequiresPr ?? options.success_requires_pr,
+      success_completion_outcomes: options.successCompletionOutcomes || options.success_completion_outcomes,
+      artifact_outputs: options.artifactOutputs || options.artifact_outputs,
+      flow_step_patches: options.flowStepPatches || options.flow_step_patches,
+      tool_recorders: options.toolRecorders || options.tool_recorders,
+      engine_data_outputs: options.engineDataOutputs || options.engine_data_outputs,
+      transcript_artifact_name: options.transcriptArtifactName || options.transcript_artifact_name,
+      artifacts: options.artifactsPath || options.artifacts,
+      max_turns: options.maxTurns || options.max_turns,
+      step_budget: options.stepBudget || options.step_budget,
+      time_budget_ms: options.timeBudgetMs || options.time_budget_ms,
+      complexity_policy: options.complexityPolicy || options.complexity_policy,
+      ...stripUndefined(options.runtimeTaskInput || options.runtime_task_input || {}),
+    }),
   };
 }
 

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -14,15 +14,17 @@ const RUNTIME_AGENT_CI_RUNTIME_PROFILE_ID = 'runtime-agent-ci';
 function runtimeAgentCiRuntimeTaskRequest(options = {}, context = {}) {
   const taskId = requiredString(options.taskId || options.task_id, 'taskId');
   const runtimeProfile = resolveRuntimeAgentCiRuntimeProfile(options);
-  const runtimeTaskInput = stripUndefined({
+  const runtimeExecution = normalizeRuntimeExecutionDescriptor(options.runtimeExecution || options.runtime_execution, runtimeProfile);
+  const runtimeTaskInput = runtimeExecution?.input || stripUndefined({
     ...(options.runtimeTaskInput || options.runtime_task_input || {}),
   });
 
   return runtimeAgentCiAbilityTaskRequest({
     ...options,
     taskId,
-    ability: options.ability || runtimeProfile.runtime_task_ability,
+    ability: runtimeExecution?.ability || options.ability || runtimeProfile.runtime_task_ability,
     abilityInput: runtimeTaskInput,
+    runtimeExecution: runtimeExecution || options.runtimeExecution || options.runtime_execution,
   }, context);
 }
 
@@ -69,9 +71,10 @@ function runtimeAgentCiRunnerSpec(options = {}, context = {}) {
 
 function runtimeAgentCiTaskExecutorConfig(options = {}) {
   const runtimeProfile = resolveRuntimeAgentCiRuntimeProfile(options);
-  const runtimeTaskInput = options.abilityInput || options.ability_input || {};
+  const runtimeExecution = normalizeRuntimeExecutionDescriptor(options.runtimeExecution || options.runtime_execution, runtimeProfile);
+  const runtimeTaskInput = runtimeExecution?.input || options.abilityInput || options.ability_input || {};
   const runtimeTask = stripUndefined({
-    ability: options.ability || runtimeProfile.runtime_task_ability,
+    ability: runtimeExecution?.ability || options.ability || runtimeProfile.runtime_task_ability,
     input: runtimeTaskInput,
   });
   return stripUndefined({
@@ -91,6 +94,7 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
     ability_requirements: options.abilityRequirements || options.ability_requirements || runtimeProfile.ability_requirements,
     artifact_slots: options.artifactSlots || options.artifact_slots,
     transcript_slots: options.transcriptSlots || options.transcript_slots,
+    runtime_execution: runtimeExecution,
     structured_artifacts: options.structuredArtifacts || options.structured_artifacts,
     task_timeout_seconds: options.taskTimeoutSeconds || options.task_timeout_seconds,
     max_turns: options.maxTurns || options.max_turns,
@@ -102,6 +106,64 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
     provider_runtime_invocation: options.providerRuntimeInvocation || options.provider_runtime_invocation || options.runtimeInvocation || options.runtime_invocation,
     runtime_id: options.runtimeId || options.runtime_id,
     runtime_bin: options.runtimeBin || options.runtime_bin,
+  });
+}
+
+function normalizeRuntimeExecutionDescriptor(descriptor, runtimeProfile = {}) {
+  if (!descriptor || typeof descriptor !== 'object' || Array.isArray(descriptor)) {
+    return null;
+  }
+  if (Object.keys(descriptor).length === 0) {
+    return null;
+  }
+  const kind = descriptor.kind || descriptor.type || (descriptor.workflow ? 'workflow' : descriptor.bundle || descriptor.source || descriptor.path ? 'bundle' : 'ability');
+  const ability = descriptor.ability || abilityForRuntimeExecutionKind(kind, runtimeProfile);
+  const input = runtimeExecutionInput(descriptor, kind);
+  return stripUndefined({
+    schema: descriptor.schema,
+    kind,
+    ability,
+    input,
+    outputs: descriptor.outputs,
+    metadata: descriptor.metadata,
+  });
+}
+
+function abilityForRuntimeExecutionKind(kind, runtimeProfile = {}) {
+  if (kind === 'bundle') {
+    return runtimeProfile.runtime_bundle_ability || runtimeProfile.runtime_task_ability;
+  }
+  if (kind === 'workflow') {
+    return runtimeProfile.runtime_workflow_ability || runtimeProfile.runtime_task_ability;
+  }
+  return runtimeProfile.runtime_task_ability;
+}
+
+function runtimeExecutionInput(descriptor, kind) {
+  const explicitInput = descriptor.input && typeof descriptor.input === 'object' && !Array.isArray(descriptor.input)
+    ? descriptor.input
+    : {};
+  const bundle = descriptor.bundle && typeof descriptor.bundle === 'object' && !Array.isArray(descriptor.bundle)
+    ? descriptor.bundle
+    : {};
+  const workflow = descriptor.workflow && typeof descriptor.workflow === 'object' && !Array.isArray(descriptor.workflow)
+    ? descriptor.workflow
+    : descriptor.workflow;
+  const source = descriptor.source || descriptor.path || bundle.source || bundle.path || bundle.bundle_path;
+  const normalizedBundle = Object.keys(bundle).length > 0 ? bundle : undefined;
+  const normalizedWorkflow = workflow && (typeof workflow !== 'object' || Object.keys(workflow).length > 0) ? workflow : undefined;
+  return stripUndefined({
+    ...(kind === 'bundle' ? {
+      source,
+      bundle: normalizedBundle,
+      workflow: normalizedWorkflow,
+    } : {}),
+    ...(kind === 'workflow' ? {
+      source,
+      path: descriptor.path,
+      workflow: normalizedWorkflow,
+    } : {}),
+    ...explicitInput,
   });
 }
 
@@ -118,11 +180,13 @@ function resolveRuntimeAgentCiRuntimeProfile(options = {}) {
   return {
     ...profile,
     id,
-    runtime_task_ability: requiredString(
-      options.runtimeTaskAbility || options.runtime_task_ability || profile.runtime_task_ability,
-      'runtime task ability'
-    ),
+    runtime_task_ability: runtimeProfileAbility(options.runtimeTaskAbility || options.runtime_task_ability || profile.runtime_task_ability, profile),
   };
+}
+
+function runtimeProfileAbility(value, profile) {
+  const ability = value || profile.runtime_bundle_ability || profile.runtime_workflow_ability;
+  return requiredString(ability, 'runtime task ability');
 }
 
 function runtimeAgentCiRuntimeProfilesForOptions(options, runtimeProfile) {
@@ -182,6 +246,7 @@ module.exports = {
   runtimeAgentCiRuntimeTaskRequest,
   runtimeAgentCiRuntimeProfilesForOptions,
   runtimeAgentCiTaskExecutorConfig,
+  normalizeRuntimeExecutionDescriptor,
   resolveRuntimeAgentCiRuntimeProfile,
   validateAgentTaskRunnerSpec,
 };

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -30,6 +30,8 @@ const runtimeProfile = {
   schema: 'homeboy/runtime-profile/v1',
   id: 'example-agent-ci',
   runtime_task_ability: 'example/run-task',
+  runtime_bundle_ability: 'runtime/run-agent-bundle',
+  runtime_workflow_ability: 'runtime/execute-workflow',
   component_path_defaults: {
     contract_slug_map: { 'example-runtime': 'agent_runtime' },
     path_aliases: { agent_runtime: ['contract:agent_runtime'] },
@@ -64,6 +66,38 @@ assert.deepEqual(genericConfig.artifact_slots, [{ name: 'packet', required: true
 assert.deepEqual(genericConfig.transcript_slots, [{ name: 'main', required: true }]);
 assert.deepEqual(genericConfig.provider_runtime_invocation, { operations: ['workspaceCommand'] });
 
+const genericBundleConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
+  runtimeProfile: runtimeProfile.id,
+  runtimeProfiles: { [runtimeProfile.id]: runtimeProfile },
+  runtimeExecution: {
+    kind: 'bundle',
+    source: '/workspace/example-repo/bundles/example-agent',
+    workflow: { name: 'materialize-artifact' },
+    input: { prompt: 'Cook a packet.' },
+  },
+});
+
+assert.equal(genericBundleConfig.runtime_task.ability, 'runtime/run-agent-bundle');
+assert.equal(genericBundleConfig.runtime_task.input.source, '/workspace/example-repo/bundles/example-agent');
+assert.deepEqual(genericBundleConfig.runtime_task.input.workflow, { name: 'materialize-artifact' });
+assert.equal(genericBundleConfig.runtime_task.input.prompt, 'Cook a packet.');
+assert.equal(genericBundleConfig.runtime_execution.kind, 'bundle');
+assert.notEqual(genericBundleConfig.runtime_task.ability, 'datamachine/run-agent-bundle');
+
+const genericWorkflowConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
+  runtimeProfile: runtimeProfile.id,
+  runtimeProfiles: { [runtimeProfile.id]: runtimeProfile },
+  runtimeExecution: {
+    kind: 'workflow',
+    workflow: { path: '.ci/workflows/materialize.json' },
+    input: { dry_run: true },
+  },
+});
+
+assert.equal(genericWorkflowConfig.runtime_task.ability, 'runtime/execute-workflow');
+assert.deepEqual(genericWorkflowConfig.runtime_task.input.workflow, { path: '.ci/workflows/materialize.json' });
+assert.equal(genericWorkflowConfig.runtime_task.input.dry_run, true);
+
 const genericRequest = runtimeAgentCi.runtimeAgentCiAbilityTaskRequest({
   taskId: 'task-1',
   runtimeProfile: runtimeProfile.id,
@@ -91,6 +125,8 @@ assert.equal(
   adapterConfig.runtime_profiles[datamachineAgentCi.DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID].runtime_task_ability,
   datamachineAgentCi.DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY
 );
+assert.equal(adapterConfig.runtime_execution.kind, 'bundle');
+assert.equal(adapterConfig.runtime_task.ability, datamachineAgentCi.DATAMACHINE_RUN_AGENT_BUNDLE_ABILITY);
 assert.deepEqual(
   adapterConfig.runtime_profiles[datamachineAgentCi.DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID].component_path_defaults,
   datamachineAgentCi.DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS

--- a/wordpress/tests/datamachine-agent-ci-plan-smoke.js
+++ b/wordpress/tests/datamachine-agent-ci-plan-smoke.js
@@ -64,6 +64,7 @@ assert.equal(bundleTask.schema, 'homeboy/agent-task-request/v1');
 assert.equal(bundleTask.executor.backend, 'codebox');
 assert.deepEqual(bundleTask.executor.secret_env, ['AI_PROVIDER_OPENAI_API_KEY']);
 assert.equal(bundleTask.executor.config.runtime_task.ability, 'datamachine/run-agent-bundle');
+assert.equal(bundleTask.executor.config.runtime_execution.kind, 'bundle');
 assert.deepEqual(bundleTask.executor.config.runtime_task.input, {
   source: '/workspace/example-repo/bundles/concept-agent',
   agent_slug: 'concept-agent',
@@ -116,6 +117,7 @@ const customBundleTask = datamachineAgentCiBundleTaskRequest({
 
 assert.equal(customBundleTask.executor.config.runtime_profile, 'example-agent-ci');
 assert.equal(customBundleTask.executor.config.runtime_task.ability, 'example/run-agent-bundle');
+assert.equal(customBundleTask.executor.config.runtime_execution.kind, 'bundle');
 assert.deepEqual(customBundleTask.executor.config.runtime_profiles['example-agent-ci'].component_path_defaults.contract_slug_map, {
   'example-agents': 'agent_runtime',
   'example-tools': 'agent_runtime_tools',


### PR DESCRIPTION
## Summary
- Adds a generic runtime_execution descriptor to runtime-agent-ci for ability, bundle, and workflow executions.
- Lets runtime profiles provide bundle/workflow abilities without hard-coding adapter-specific ability names in the generic planner.
- Keeps Data Machine adapter compatibility by emitting runtime_execution alongside the existing runtime_task shape.

## Verification
- node tests/runtime-agent-ci-contract-smoke.mjs
- node tests/datamachine-agent-ci-plan-smoke.js (from wordpress/)
- node tests/codebox-agent-task-executor-boundary.test.js (from wordpress/)
- node tests/codebox-agent-task-executor-smoke.js (from wordpress/)
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runtime execution descriptor implementation and focused tests; Chris remains responsible for review and validation.