### PR TITLE
Add generic runtime callback data

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -432,6 +432,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     recipe,
     sandbox_tool_policy: sandboxToolPolicy,
     runtime_task: runtimeTask,
+    callback_data: firstDefined(inputs.callback_data, inputs.callbackData, config.callback_data, config.callbackData, runtimeOptions.callbackData),
     provider_runtime_invocation: providerRuntimeInvocation,
     ability_tools: firstDefined(inputs.ability_tools, inputs.abilityTools, config.ability_tools, config.abilityTools, runtimeOptions.abilityTools, []),
     structured_artifacts: structuredArtifacts,
@@ -512,6 +513,7 @@ function runtimeOptionsFromExecutorConfig(config = {}, options = {}) {
     runtimeEnv: firstNonEmptyObject(runtimeRequirements.env, runtimeRequirements.runtime_env, runtimeProfile.env, runtimeProfile.runtime_env, options.runtimeEnv, options.runtime_env),
     runtimeStateMounts: firstDefined(runtimeRequirements.runtime_state_mounts, runtimeProfile.runtime_state_mounts, options.runtimeStateMounts, options.runtime_state_mounts),
     runtimeConfigMounts: firstDefined(runtimeRequirements.runtime_config_mounts, runtimeProfile.runtime_config_mounts, options.runtimeConfigMounts, options.runtime_config_mounts),
+    callbackData: firstDefined(runtimeRequirements.callback_data, runtimeRequirements.callbackData, runtimeProfile.callback_data, runtimeProfile.callbackData, options.callbackData, options.callback_data),
   };
 }
 

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -675,6 +675,113 @@ function writeHomeboyRuntimeToolBridgePlugin(pluginDir, endpoint = '') {
   fs.writeFileSync(path.join(pluginDir, 'homeboy-runtime-tool-bridge.php'), homeboyRuntimeToolBridgePluginSource(endpoint));
 }
 
+function homeboyCallbackDataPluginSource() {
+  return `<?php
+/**
+ * Homeboy runtime callback data helper.
+ *
+ * Plugin Name: Homeboy Runtime Callback Data
+ * Description: Lets runtime code exchange structured callback data with the Homeboy task runner.
+ *
+ * @package HomeboyCodeboxRuntime
+ */
+
+if ( ! function_exists( 'homeboy_callback_data_path' ) ) {
+	function homeboy_callback_data_path() {
+		$path = getenv( 'HOMEBOY_CALLBACK_DATA_PATH' );
+		return is_string( $path ) ? $path : '';
+	}
+}
+
+if ( ! function_exists( 'homeboy_callback_data_read_all' ) ) {
+	function homeboy_callback_data_read_all() {
+		$path = homeboy_callback_data_path();
+		if ( '' === $path || ! is_readable( $path ) ) {
+			return array( 'data' => array(), 'events' => array() );
+		}
+		$decoded = json_decode( (string) file_get_contents( $path ), true );
+		if ( ! is_array( $decoded ) ) {
+			return array( 'data' => array(), 'events' => array() );
+		}
+		return array(
+			'data'   => isset( $decoded['data'] ) && is_array( $decoded['data'] ) ? $decoded['data'] : array(),
+			'events' => isset( $decoded['events'] ) && is_array( $decoded['events'] ) ? $decoded['events'] : array(),
+		);
+	}
+}
+
+if ( ! function_exists( 'homeboy_callback_data_write_all' ) ) {
+	function homeboy_callback_data_write_all( array $payload ) {
+		$path = homeboy_callback_data_path();
+		if ( '' === $path ) {
+			return false;
+		}
+		$dir = dirname( $path );
+		if ( ! is_dir( $dir ) ) {
+			wp_mkdir_p( $dir );
+		}
+		return false !== file_put_contents( $path, wp_json_encode( $payload, JSON_PRETTY_PRINT ) . "\n", LOCK_EX );
+	}
+}
+
+if ( ! function_exists( 'homeboy_callback_data_get' ) ) {
+	function homeboy_callback_data_get( $key = null, $default = null ) {
+		$data = homeboy_callback_data_read_all()['data'];
+		if ( null === $key || '' === $key ) {
+			return $data;
+		}
+		return array_key_exists( $key, $data ) ? $data[ $key ] : $default;
+	}
+}
+
+if ( ! function_exists( 'homeboy_callback_data_set' ) ) {
+	function homeboy_callback_data_set( $key, $value ) {
+		$payload = homeboy_callback_data_read_all();
+		$payload['data'][ (string) $key ] = $value;
+		return homeboy_callback_data_write_all( $payload );
+	}
+}
+
+if ( ! function_exists( 'homeboy_callback_data_merge' ) ) {
+	function homeboy_callback_data_merge( array $values ) {
+		$payload = homeboy_callback_data_read_all();
+		$payload['data'] = array_merge( $payload['data'], $values );
+		return homeboy_callback_data_write_all( $payload );
+	}
+}
+
+if ( ! function_exists( 'homeboy_callback_data_append' ) ) {
+	function homeboy_callback_data_append( $key, $value ) {
+		$payload = homeboy_callback_data_read_all();
+		$key     = (string) $key;
+		if ( ! isset( $payload['data'][ $key ] ) || ! is_array( $payload['data'][ $key ] ) ) {
+			$payload['data'][ $key ] = array();
+		}
+		$payload['data'][ $key ][] = $value;
+		return homeboy_callback_data_write_all( $payload );
+	}
+}
+
+if ( ! function_exists( 'homeboy_callback_data_output_event' ) ) {
+	function homeboy_callback_data_output_event( $name, $payload = array(), array $metadata = array() ) {
+		$envelope = homeboy_callback_data_read_all();
+		$envelope['events'][] = array(
+			'schema'     => 'homeboy/runtime-callback-event/v1',
+			'name'       => (string) $name,
+			'payload'    => $payload,
+			'metadata'   => $metadata,
+			'created_at' => gmdate( 'c' ),
+		);
+		return homeboy_callback_data_write_all( $envelope );
+	}
+}
+`;
+}
+
+function writeHomeboyCallbackDataPlugin(pluginDir) {
+  fs.writeFileSync(path.join(pluginDir, 'homeboy-runtime-callback-data.php'), homeboyCallbackDataPluginSource());
+}
+
 function homeboyRuntimeToolBridgeServerSource() {
   return `#!/usr/bin/env node
 'use strict';
@@ -803,6 +910,107 @@ function injectHomeboyRuntimeToolBridge(taskInput, artifacts) {
     bridge: {
       plugin_dir: pluginDir,
       server_script: writeTextFile('homeboy-runtime-tool-bridge-server-', 'server.js', homeboyRuntimeToolBridgeServerSource()),
+    },
+  };
+}
+
+function callbackDataConfig(taskInput) {
+  const configured = taskInput.callback_data || taskInput.callbackData || taskInput.parent_request?.callback_data || taskInput.parent_request?.callbackData;
+  if (configured === false || configured?.enabled === false) {
+    return { enabled: false };
+  }
+  return { enabled: true, ...(plainObject(configured) ? configured : {}) };
+}
+
+function callbackDataPath(artifacts, config = {}) {
+  return config.path || config.file || path.join(artifacts, 'homeboy-runtime-callback-data.json');
+}
+
+function injectHomeboyCallbackDataHelper(taskInput, artifacts) {
+  const config = callbackDataConfig(taskInput);
+  if (!config.enabled) {
+    return { input: taskInput, callback_data: null };
+  }
+
+  const callbackPath = callbackDataPath(artifacts, config);
+  fs.mkdirSync(path.dirname(callbackPath), { recursive: true });
+  fs.writeFileSync(callbackPath, `${JSON.stringify({ data: plainObject(config.initial) ? config.initial : {}, events: [] }, null, 2)}\n`);
+
+  const pluginRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-runtime-callback-data-'));
+  const pluginDir = path.join(pluginRoot, 'homeboy-runtime-callback-data');
+  fs.mkdirSync(pluginDir, { recursive: true });
+  writeHomeboyCallbackDataPlugin(pluginDir);
+
+  return {
+    input: {
+      ...taskInput,
+      extra_plugins: [
+        ...(Array.isArray(taskInput.extra_plugins) ? taskInput.extra_plugins : []),
+        {
+          source: pluginDir,
+          slug: 'homeboy-runtime-callback-data',
+          pluginFile: 'homeboy-runtime-callback-data/homeboy-runtime-callback-data.php',
+          loadAs: 'mu-plugin',
+          activate: false,
+          metadata: { source: 'homeboy-runtime-callback-data' },
+        },
+      ],
+      runtime_env: {
+        ...(plainObject(taskInput.runtime_env) ? taskInput.runtime_env : {}),
+        HOMEBOY_CALLBACK_DATA_PATH: callbackPath,
+      },
+    },
+    callback_data: {
+      path: callbackPath,
+      plugin_dir: pluginDir,
+    },
+  };
+}
+
+function readCallbackData(callbackData) {
+  if (!callbackData?.path) {
+    return null;
+  }
+  const payload = readJsonIfAvailable(callbackData.path);
+  if (!plainObject(payload)) {
+    return null;
+  }
+  return {
+    path: callbackData.path,
+    data: plainObject(payload.data) ? payload.data : {},
+    events: Array.isArray(payload.events) ? payload.events : [],
+  };
+}
+
+function withCallbackDataEnvelope(payload, callbackData) {
+  if (!callbackData || (Object.keys(callbackData.data).length === 0 && callbackData.events.length === 0)) {
+    return payload;
+  }
+  const artifact = {
+    id: 'homeboy-runtime-callback-data',
+    kind: 'runtime-callback-data',
+    path: callbackData.path,
+  };
+  return {
+    ...payload,
+    outputs: {
+      ...(plainObject(payload.outputs) ? payload.outputs : {}),
+      callback_data: callbackData.data,
+      callback_events: callbackData.events,
+    },
+    artifacts: [
+      ...(Array.isArray(payload.artifacts) ? payload.artifacts : []),
+      artifact,
+    ],
+    evidence_refs: [
+      ...(Array.isArray(payload.evidence_refs) ? payload.evidence_refs : []),
+      { kind: artifact.kind, uri: artifact.path, label: 'Runtime callback data' },
+    ],
+    metadata: {
+      ...(plainObject(payload.metadata) ? payload.metadata : {}),
+      callback_data: callbackData.data,
+      callback_events: callbackData.events,
+      callback_data_path: callbackData.path,
     },
   };
 }
@@ -1114,6 +1322,7 @@ function runnerInput(request, artifacts) {
     ability_tools: request.ability_tools || request.abilityTools || [],
     runtime_state_mounts: request.runtime_state_mounts || request.runtimeStateMounts || [],
     runtime_config_mounts: request.runtime_config_mounts || request.runtimeConfigMounts || [],
+    callback_data: request.callback_data || request.callbackData,
     max_turns: Number.parseInt(argValue('--max-turns') || request.max_turns || request.maxTurns || 0, 10) || undefined,
     task_timeout_seconds: Number.parseInt(argValue('--task-timeout-seconds') || request.task_timeout_seconds || request.taskTimeoutSeconds || 0, 10) || undefined,
     sandbox_session_id: request.sandbox_session_id || '',
@@ -1269,6 +1478,7 @@ function stableTaskInput(input) {
     ability_tools: input.ability_tools || [],
     runtime_state_mounts: input.runtime_state_mounts || [],
     runtime_config_mounts: input.runtime_config_mounts || [],
+    callback_data: input.callback_data || input.parent_request?.callback_data || input.parent_request?.callbackData,
     max_turns: input.max_turns,
     task_timeout_seconds: input.task_timeout_seconds,
     sandbox_session_id: input.sandbox_session_id,
@@ -2085,7 +2295,8 @@ function runWpCodeboxParentTask(request, envOverrides = {}) {
     return 1;
   }
 
-  const bridgedInput = injectHomeboyRuntimeToolBridge(stableTaskInput(input), artifacts);
+  const callbackInput = injectHomeboyCallbackDataHelper(stableTaskInput(input), artifacts);
+  const bridgedInput = injectHomeboyRuntimeToolBridge(callbackInput.input, artifacts);
   const bridgeServer = startHomeboyRuntimeToolBridge(bridgedInput.bridge);
   if (bridgeServer && bridgedInput.bridge?.plugin_dir) {
     writeHomeboyRuntimeToolBridgePlugin(bridgedInput.bridge.plugin_dir, bridgeServer.url);
@@ -2169,9 +2380,10 @@ function runWpCodeboxParentTask(request, envOverrides = {}) {
         args: resolved.args,
         secretNames: input.secret_env || [],
       }) : null);
-      const enrichedPayload = payloadEvidence ? attachFailureEvidence(normalizedPayload, payloadEvidence) : normalizedPayload;
+      const callbackPayload = withCallbackDataEnvelope(normalizedPayload, readCallbackData(callbackInput.callback_data));
+      const enrichedPayload = payloadEvidence ? attachFailureEvidence(callbackPayload, payloadEvidence) : callbackPayload;
       process.stdout.write(`${JSON.stringify(enrichedPayload, null, 2)}\n`);
-      return normalizedPayload.success === false ? 1 : 0;
+      return callbackPayload.success === false ? 1 : 0;
     } catch {
       if (failureEvidence) {
         process.stdout.write(`${JSON.stringify(commandFailurePayload(result, artifacts, failureEvidence), null, 2)}\n`);

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -96,6 +96,7 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
     transcript_slots: options.transcriptSlots || options.transcript_slots,
     runtime_execution: runtimeExecution,
     runtime_output_projections: options.runtimeOutputProjections || options.runtime_output_projections,
+    callback_data: options.callbackData || options.callback_data,
     evidence_projections: options.evidenceProjections || options.evidence_projections,
     structured_artifacts: options.structuredArtifacts || options.structured_artifacts,
     task_timeout_seconds: options.taskTimeoutSeconds || options.task_timeout_seconds,

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -51,6 +51,7 @@ const genericConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
   abilityInput: { prompt: 'Cook.' },
   abilityTools: [{ name: 'example_tool' }],
   runtimeOutputProjections: { packet_url: 'metadata.artifacts.packet.url' },
+  callbackData: { initial: { seed: 'value' } },
   evidenceProjections: [{ operation: 'workspacePublish', outputs: { pr_url: 'result.pr.url' } }],
   artifactSlots: [{ name: 'packet', required: true }],
   transcriptSlots: [{ name: 'main', required: true }],
@@ -65,6 +66,7 @@ assert.deepEqual(genericConfig.runtime_task, { ability: 'example/run-task', inpu
 assert.deepEqual(genericConfig.ability_requirements, ['example/run-task', 'example/read-state']);
 assert.deepEqual(genericConfig.ability_tools, [{ name: 'example_tool' }]);
 assert.deepEqual(genericConfig.runtime_output_projections, { packet_url: 'metadata.artifacts.packet.url' });
+assert.deepEqual(genericConfig.callback_data, { initial: { seed: 'value' } });
 assert.deepEqual(genericConfig.evidence_projections, [{ operation: 'workspacePublish', outputs: { pr_url: 'result.pr.url' } }]);
 assert.deepEqual(genericConfig.artifact_slots, [{ name: 'packet', required: true }]);
 assert.deepEqual(genericConfig.transcript_slots, [{ name: 'main', required: true }]);

--- a/tests/wp-codebox-callback-data-smoke.mjs
+++ b/tests/wp-codebox-callback-data-smoke.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const runnerPath = path.join(repoRoot, 'agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs');
+const runnerSource = fs.readFileSync(runnerPath, 'utf8');
+const callbackHelperSource = runnerSource.slice(
+  runnerSource.indexOf('function homeboyCallbackDataPluginSource()'),
+  runnerSource.indexOf('function writeHomeboyCallbackDataPlugin')
+);
+
+assert.match(callbackHelperSource, /homeboy_callback_data_get/);
+assert.match(callbackHelperSource, /homeboy_callback_data_set/);
+assert.match(callbackHelperSource, /homeboy_callback_data_append/);
+assert.match(callbackHelperSource, /homeboy_callback_data_output_event/);
+assert.equal(/Data Machine|DataMachine|datamachine|data-machine|wp-site-generator|WPSG|site-generator|site generator/.test(callbackHelperSource), false);
+assert.equal(/datamachine_(?:merge|get)_engine_data/.test(runnerSource), false);
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-callback-data-'));
+const fakeBin = path.join(tempRoot, 'fake-wp-codebox.cjs');
+const artifactRoot = path.join(tempRoot, 'artifacts');
+
+fs.writeFileSync(fakeBin, `#!/usr/bin/env node
+const fs = require('node:fs');
+const inputArg = process.argv.find((arg) => arg.startsWith('--input-file='));
+const input = JSON.parse(fs.readFileSync(inputArg.slice('--input-file='.length), 'utf8'));
+const callbackPath = input.runtime_env.HOMEBOY_CALLBACK_DATA_PATH;
+const helper = input.extra_plugins.find((plugin) => plugin.slug === 'homeboy-runtime-callback-data');
+if (!callbackPath || !helper || !fs.existsSync(callbackPath)) {
+  throw new Error('callback data helper was not injected');
+}
+const initial = JSON.parse(fs.readFileSync(callbackPath, 'utf8'));
+fs.writeFileSync(callbackPath, JSON.stringify({
+  data: { ...initial.data, packet_url: 'https://example.com/packet.json', count: 2 },
+  events: [{ schema: 'homeboy/runtime-callback-event/v1', name: 'packet.ready', payload: { id: 'packet-1' } }],
+}, null, 2));
+process.stdout.write(JSON.stringify({
+  schema: 'wp-codebox/agent-task-run/v1',
+  success: true,
+  status: 'completed',
+  run: { agentResult: { outputs: { direct_output: 'ok' } } },
+}));
+`);
+
+const request = {
+  schema: 'wp-codebox/task-input/v1',
+  goal: 'Exercise callback data.',
+  wp_codebox_bin: fakeBin,
+  artifacts_path: artifactRoot,
+  runtime_task: { ability: 'example/callback-data', input: {} },
+  callback_data: { initial: { seed: 'starter' } },
+};
+
+const result = spawnSync(process.execPath, [runnerPath], {
+  cwd: repoRoot,
+  env: {
+    ...process.env,
+    HOMEBOY_WP_CODEBOX_TASK_REQUEST: JSON.stringify(request),
+  },
+  encoding: 'utf8',
+});
+
+assert.equal(result.status, 0, `runner failed\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+const payload = JSON.parse(result.stdout);
+assert.equal(payload.outputs.direct_output, 'ok');
+assert.deepEqual(payload.outputs.callback_data, {
+  seed: 'starter',
+  packet_url: 'https://example.com/packet.json',
+  count: 2,
+});
+assert.equal(payload.outputs.callback_events[0].name, 'packet.ready');
+assert.equal(payload.metadata.callback_data.packet_url, 'https://example.com/packet.json');
+assert.equal(payload.artifacts.some((artifact) => artifact.kind === 'runtime-callback-data'), true);
+assert.equal(payload.evidence_refs.some((ref) => ref.kind === 'runtime-callback-data'), true);
+
+fs.rmSync(tempRoot, { recursive: true, force: true });
+console.log('wp-codebox callback data smoke passed');


### PR DESCRIPTION
## Summary
- add generic runtime callback data config through runtime-agent-ci and the WP Codebox task request
- inject a neutral WP helper exposing homeboy_callback_data_get/set/merge/append/output_event inside runtime tasks
- fold callback data and events into generic runtime outputs, metadata, artifacts, and evidence refs

## Testing
- node tests/runtime-agent-ci-contract-smoke.mjs
- node tests/wp-codebox-callback-data-smoke.mjs
- node tests/datamachine-agent-ci-primitives-smoke.mjs
- node tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
- node tests/codebox-delegated-run-normalizer-smoke.mjs
- node tests/wp-codebox-provider-plugin-defaults-smoke.mjs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runtime callback-data implementation and smoke tests; Chris remains responsible for review and validation.