### PR TITLE
Project Codebox transcripts as typed artifacts

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -2154,7 +2154,57 @@ function codeboxAgentResultFromResult(result) {
 function codeboxBundleDirectoryFromResult(result) {
   const completionOutcome = result.completionOutcome || result.completion_outcome || {};
   const agentResult = codeboxAgentResultFromResult(result);
-  return agentResult.artifacts?.directory || completionOutcome?.provenance?.artifactDirectory || result.session?.artifacts?.path || '';
+  return agentResult.artifacts?.directory
+    || completionOutcome?.provenance?.artifactDirectory
+    || result.session?.artifacts?.path
+    || result.session?.artifacts?.directory
+    || (typeof result.artifacts === 'string' ? result.artifacts : '')
+    || '';
+}
+
+function firstTranscriptArtifactRefFromResult(result) {
+  const agentResult = codeboxAgentResultFromResult(result);
+  const directPath = artifactPath(codeboxBundleDirectoryFromResult(result), agentResult.transcript?.artifact || '');
+  if (directPath) {
+    return {
+      kind: 'codebox-transcript',
+      path: directPath,
+      mime: 'application/json',
+      metadata: agentResult.transcript || {},
+      schema: agentResult.transcript?.schema,
+    };
+  }
+
+  const candidates = [
+    ...(Array.isArray(result.artifacts) ? result.artifacts : Object.values(result.artifacts || {}).filter((value) => value && typeof value === 'object')),
+    ...agentRuntimeBundleArtifacts(result),
+  ];
+  const transcriptArtifact = candidates
+    .map((artifact) => artifactFromCodeboxArtifact(artifact))
+    .find((artifact) => artifact?.path && /transcript|conversation|messages/i.test(`${artifact.kind || ''} ${artifact.name || ''} ${artifact.path || ''}`));
+  if (transcriptArtifact) {
+    return {
+      kind: transcriptArtifact.kind || 'codebox-transcript',
+      path: transcriptArtifact.path,
+      url: transcriptArtifact.url,
+      mime: transcriptArtifact.mime || 'application/json',
+      metadata: transcriptArtifact.metadata || {},
+      schema: transcriptArtifact.metadata?.schema || transcriptArtifact.metadata?.artifact_schema,
+    };
+  }
+
+  const bundleDirectory = codeboxBundleDirectoryFromResult(result);
+  const fallbackPath = artifactPath(bundleDirectory, 'files/transcript.json');
+  if (fallbackPath && fs.existsSync(fallbackPath)) {
+    return {
+      kind: 'codebox-transcript',
+      path: fallbackPath,
+      mime: 'application/json',
+      metadata: { source: 'codebox_artifact_directory' },
+    };
+  }
+
+  return null;
 }
 
 function isTranscriptArtifactDeclaration(declaration) {
@@ -2172,9 +2222,8 @@ function transcriptTypedArtifactsFromCodeboxResult(request, result, existingType
   if (requiredTranscriptArtifacts.length === 0) {
     return {};
   }
-  const agentResult = codeboxAgentResultFromResult(result);
-  const transcriptPath = artifactPath(codeboxBundleDirectoryFromResult(result), agentResult.transcript?.artifact || '');
-  if (!transcriptPath) {
+  const transcriptRef = firstTranscriptArtifactRefFromResult(result);
+  if (!transcriptRef?.path && !transcriptRef?.url) {
     return {};
   }
   return Object.fromEntries(requiredTranscriptArtifacts
@@ -2183,9 +2232,9 @@ function transcriptTypedArtifactsFromCodeboxResult(request, result, existingType
     .map((name) => [name, normalizeTypedArtifactEntry(name, {
       name,
       type: 'transcript',
-      artifact_schema: agentResult.transcript?.schema || 'wp-codebox/agent-transcript/v1',
-      file_refs: [{ kind: 'codebox-transcript', path: transcriptPath, mime: 'application/json' }],
-      metadata: agentResult.transcript || {},
+      artifact_schema: transcriptRef.schema || 'wp-codebox/agent-transcript/v1',
+      file_refs: [{ kind: transcriptRef.kind || 'codebox-transcript', path: transcriptRef.path, url: transcriptRef.url, mime: transcriptRef.mime || 'application/json' }],
+      metadata: transcriptRef.metadata || {},
     })])
     .filter(([, artifact]) => artifact));
 }

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -2147,6 +2147,49 @@ function typedArtifactsFromResult(result) {
   return Object.assign({}, ...candidates.map(normalizeTypedArtifacts));
 }
 
+function codeboxAgentResultFromResult(result) {
+  return result.run?.agentResult || result.agentResult || result.agent_result || result.metadata?.recipe_run?.agentResult || {};
+}
+
+function codeboxBundleDirectoryFromResult(result) {
+  const completionOutcome = result.completionOutcome || result.completion_outcome || {};
+  const agentResult = codeboxAgentResultFromResult(result);
+  return agentResult.artifacts?.directory || completionOutcome?.provenance?.artifactDirectory || result.session?.artifacts?.path || '';
+}
+
+function isTranscriptArtifactDeclaration(declaration) {
+  const name = typedArtifactNameFromDeclaration(declaration);
+  const type = declaration?.type || declaration?.kind || declaration?.artifact_type || declaration?.artifactType || '';
+  const schema = declaration?.artifact_schema || declaration?.artifactSchema || declaration?.schema || '';
+  return /transcript|conversation|messages/i.test(`${name} ${type} ${schema}`);
+}
+
+function transcriptTypedArtifactsFromCodeboxResult(request, result, existingTypedArtifacts = {}) {
+  if (!request) {
+    return {};
+  }
+  const requiredTranscriptArtifacts = requiredArtifactDeclarationsFromRequest(request).filter(isTranscriptArtifactDeclaration);
+  if (requiredTranscriptArtifacts.length === 0) {
+    return {};
+  }
+  const agentResult = codeboxAgentResultFromResult(result);
+  const transcriptPath = artifactPath(codeboxBundleDirectoryFromResult(result), agentResult.transcript?.artifact || '');
+  if (!transcriptPath) {
+    return {};
+  }
+  return Object.fromEntries(requiredTranscriptArtifacts
+    .map((declaration) => typedArtifactNameFromDeclaration(declaration))
+    .filter((name) => name && !existingTypedArtifacts[name])
+    .map((name) => [name, normalizeTypedArtifactEntry(name, {
+      name,
+      type: 'transcript',
+      artifact_schema: agentResult.transcript?.schema || 'wp-codebox/agent-transcript/v1',
+      file_refs: [{ kind: 'codebox-transcript', path: transcriptPath, mime: 'application/json' }],
+      metadata: agentResult.transcript || {},
+    })])
+    .filter(([, artifact]) => artifact));
+}
+
 function typedArtifactProjectionFromOutputPath(outputPath, value, typedArtifacts) {
   const match = String(outputPath || '').match(/(?:^|\.)typed_?artifacts\.([^.]+)\.payload$/i);
   if (!match) {
@@ -2260,9 +2303,10 @@ function firstPlainObject(...candidates) {
   return candidates.find((candidate) => candidate && typeof candidate === 'object' && !Array.isArray(candidate));
 }
 
-function normalizeOutputs(result) {
+function normalizeOutputs(result, request = null) {
   const workload = agentRuntimeWorkload(result) || {};
   const typedArtifacts = typedArtifactsFromResult(result);
+  Object.assign(typedArtifacts, transcriptTypedArtifactsFromCodeboxResult(request, result, typedArtifacts));
   const appendTypedArtifacts = (outputs) => Object.keys(typedArtifacts).length > 0
     ? {
         ...outputs,
@@ -2679,7 +2723,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     status = localStatus;
   }
   const failureClassification = homeboyFailureClassification(result.failure_classification || recipeSummary?.metadata?.failure_classification || runSummary?.failure_classification, status);
-  const outputs = normalizeOutputs(result);
+  const outputs = normalizeOutputs(result, request);
   const missingRequiredTypedArtifacts = missingRequiredTypedArtifactDiagnostic(request, outputs);
   if (status === 'succeeded' && missingRequiredTypedArtifacts) {
     status = 'failed';

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -1606,6 +1606,42 @@ function mergeTypedArtifactOutputs(outputs, ...candidates) {
   };
 }
 
+function isTranscriptArtifactDeclaration(declaration) {
+  const name = artifactDeclarationName(declaration);
+  const type = declaration?.type || declaration?.kind || declaration?.artifact_type || declaration?.artifactType || '';
+  const schema = declaration?.artifact_schema || declaration?.artifactSchema || declaration?.schema || '';
+  return /transcript|conversation|messages/i.test(`${name} ${type} ${schema}`);
+}
+
+function artifactPath(root, relativePath) {
+  if (!root || !relativePath) {
+    return '';
+  }
+  return `${String(root).replace(/\/$/, '')}/${String(relativePath).replace(/^\//, '')}`;
+}
+
+function transcriptTypedArtifactsFromAgentResult(input, agentResult, config = {}) {
+  const requiredTranscriptArtifacts = requiredArtifactDeclarations(input, config).filter(isTranscriptArtifactDeclaration);
+  if (requiredTranscriptArtifacts.length === 0) {
+    return {};
+  }
+  const transcriptPath = artifactPath(agentResult?.artifacts?.directory, agentResult?.transcript?.artifact || '');
+  if (!transcriptPath) {
+    return {};
+  }
+  return Object.fromEntries(requiredTranscriptArtifacts
+    .map((declaration) => artifactDeclarationName(declaration))
+    .filter(Boolean)
+    .map((name) => [name, normalizeTypedArtifactEntry(name, {
+      name,
+      type: 'transcript',
+      artifact_schema: agentResult?.transcript?.schema || 'wp-codebox/agent-transcript/v1',
+      file_refs: [{ kind: 'codebox-transcript', path: transcriptPath, mime: 'application/json' }],
+      metadata: agentResult?.transcript || {},
+    })])
+    .filter(([, artifact]) => artifact));
+}
+
 function sandboxToolPolicy(input, allowedTools) {
   const explicit = input.parent_request?.sandbox_tool_policy
     || input.parent_request?.sandboxToolPolicy
@@ -1715,7 +1751,16 @@ function normalizeAgentTaskRun(input, result) {
   const config = isAgentBundle(input) ? agentBundleConfig(input, input.agent_bundle || {}) : parentAgentTaskConfig(input);
   const stdoutWorkload = agentRuntimeWorkloadFromExecutionStdout(execution, config);
   const fallbackAgentResult = result.metadata?.agent_runtime?.workload || execution?.agentResult || result.run?.agentResult || result.agentResult || result.agent_result || {};
-  const agentResult = hasSemanticWorkload(stdoutWorkload) ? stdoutWorkload : fallbackAgentResult;
+  let agentResult = hasSemanticWorkload(stdoutWorkload) ? stdoutWorkload : fallbackAgentResult;
+  if (plainObject(agentResult)) {
+    agentResult = {
+      ...agentResult,
+      outputs: mergeTypedArtifactOutputs(
+        plainObject(agentResult.outputs) ? agentResult.outputs : {},
+        transcriptTypedArtifactsFromAgentResult(input, agentResult, config),
+      ),
+    };
+  }
   const bundleValidation = isAgentBundle(input) ? validateAgentRuntimeWorkload(agentResult, config) : validateRuntimeTaskWorkload(agentResult, config);
   const artifactValidation = missingRequiredTypedArtifactDiagnostic(input, agentResult, config);
   const runtimeFailure = agentRuntimeFailureDiagnostic(agentResult);

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -2149,6 +2149,32 @@ assert.equal(canaryRunOutcome.metadata.decision_evidence.no_op_reason, 'no_file_
 assert.equal(canaryRunOutcome.metadata.decision_evidence.patch_bytes, 0);
 assert.deepEqual(canaryRunOutcome.metadata.decision_evidence.runtime_gap_trackers, []);
 
+const canaryTranscriptRequiredOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  artifact_declarations: [{
+    name: 'datamachine-transcript',
+    type: 'transcript',
+    required: true,
+  }],
+}, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  run: {
+    runId: 'run-canary-transcript-required',
+    status: 'succeeded',
+    agentResult: {
+      changedFiles: { count: 0, paths: [], artifact: 'files/changed-files.json' },
+      patch: { bytes: 0, sha256: 'empty-patch-sha', artifact: 'files/patch.diff' },
+      transcript: { artifact: 'files/transcript.json', executionCount: 1 },
+      artifacts: { directory: '/tmp/canary/runtime' },
+      noOpReason: 'no_file_changes',
+    },
+  },
+});
+assert.equal(canaryTranscriptRequiredOutcome.status, 'no_op');
+assert.equal(canaryTranscriptRequiredOutcome.outputs.typed_artifacts['datamachine-transcript'].file_refs[0].path, '/tmp/canary/runtime/files/transcript.json');
+assert.equal(canaryTranscriptRequiredOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.required_typed_artifacts_missing'), false);
+
 const codexOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: true,
   summary: 'Codex task completed.',

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -2175,6 +2175,39 @@ assert.equal(canaryTranscriptRequiredOutcome.status, 'no_op');
 assert.equal(canaryTranscriptRequiredOutcome.outputs.typed_artifacts['datamachine-transcript'].file_refs[0].path, '/tmp/canary/runtime/files/transcript.json');
 assert.equal(canaryTranscriptRequiredOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.required_typed_artifacts_missing'), false);
 
+const labArtifactRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-lab-artifacts-'));
+const labRuntimeRoot = path.join(labArtifactRoot, 'runtime-fixture-123');
+fs.mkdirSync(path.join(labRuntimeRoot, 'files'), { recursive: true });
+fs.writeFileSync(path.join(labRuntimeRoot, 'files', 'transcript.json'), '{"schema":"wp-codebox/agent-transcript/v1"}\n');
+const labTranscriptRequiredOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  artifact_declarations: [{
+    name: 'datamachine-transcript',
+    type: 'transcript',
+    required: true,
+  }],
+}, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  session: {
+    id: 'lab-session-transcript-required',
+    status: 'completed',
+    artifacts: {
+      bundle_id: 'lab-artifact-bundle',
+      directory: labRuntimeRoot,
+    },
+  },
+  artifacts: [{
+    id: 'lab-codebox-transcript',
+    kind: 'codebox-transcript',
+    path: path.join(labRuntimeRoot, 'files', 'transcript.json'),
+    mime: 'application/json',
+  }],
+  outputs: {},
+});
+assert.equal(labTranscriptRequiredOutcome.outputs.typed_artifacts['datamachine-transcript'].file_refs[0].path, path.join(labRuntimeRoot, 'files', 'transcript.json'));
+assert.equal(labTranscriptRequiredOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.required_typed_artifacts_missing'), false);
+
 const codexOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: true,
   summary: 'Codex task completed.',

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -373,7 +373,9 @@ try {
   assert.equal(captured.input.provider_plugin_paths[0], preparedProviderPluginPath);
   assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'example-provider').source, preparedProviderPluginPath);
   assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'example-provider').activate, true);
-  assert.deepEqual(captured.input.runtime_env, request.runtime_env);
+  assert.equal(captured.input.runtime_env.GENERIC_PROVIDER_CONFIG, request.runtime_env.GENERIC_PROVIDER_CONFIG);
+  assert.equal(captured.input.runtime_env.XDG_DATA_HOME, request.runtime_env.XDG_DATA_HOME);
+  assert.match(captured.input.runtime_env.HOMEBOY_CALLBACK_DATA_PATH, /homeboy-runtime-callback-data\.json$/);
   assert.deepEqual(captured.input.ability_tools, request.ability_tools);
   assert.deepEqual(captured.input.runtime_state_mounts, request.runtime_state_mounts);
   assert.deepEqual(captured.input.runtime_config_mounts, request.runtime_config_mounts);


### PR DESCRIPTION
## Summary
- project WP Codebox transcript files into required transcript-like typed artifacts
- preserve existing typed artifacts and only synthesize missing transcript declarations
- update WP Codebox smoke tests for runtime callback env handling and required transcript artifacts

## Testing
- node wordpress/tests/codebox-agent-task-executor-smoke.js
- node wordpress/tests/wp-codebox-task-runner-smoke.js
- node --check agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Lab artifact mismatch, drafted the provider/runtime transcript projection, and ran focused local verification. Chris remains responsible for review and merge.