### PR TITLE
Harden Data Machine agent CI boundary quarantine

### DIFF
--- a/tests/architectural-boundary-quarantine.json
+++ b/tests/architectural-boundary-quarantine.json
@@ -1,0 +1,17 @@
+{
+  "agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js": "WP Codebox generic executor still carries Data Machine host-tool-policy compatibility env until runtime callers consume the generic Homeboy policy contract directly.",
+  "agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs": "WP Codebox task runner still carries legacy Data Machine component and bundle compatibility while callers migrate to generic runtime profiles.",
+  "datamachine-agent-ci/index.js": "Data Machine Agent CI compatibility package entrypoint; quarantine until callers migrate to runtime-agent-ci.",
+  "datamachine-agent-ci/lib/datamachine-agent-ci-plan.js": "Data Machine Agent CI adapter constants and option mapping around generic runtime-agent-ci primitives.",
+  ".github/scripts/datamachine-agent-ci/artifacts-and-comments.cjs": "Reusable Data Machine Agent CI workflow comment and artifact adapter script.",
+  ".github/scripts/datamachine-agent-ci/auth.cjs": "Reusable Data Machine Agent CI workflow auth reporting adapter script.",
+  ".github/scripts/datamachine-agent-ci/build-runner-config.cjs": "Reusable Data Machine Agent CI workflow config adapter that maps legacy inputs to generic runtime-agent-ci config.",
+  ".github/scripts/datamachine-agent-ci/materialize-dependencies.cjs": "Reusable Data Machine Agent CI workflow dependency adapter for the legacy Data Machine runtime stack.",
+  ".github/workflows/datamachine-agent-ci-self-smoke.yml": "Self-smoke workflow for the quarantined Data Machine Agent CI reusable workflow.",
+  ".github/workflows/datamachine-agent-ci.yml": "Quarantined reusable Data Machine Agent CI workflow kept while callers migrate to generic runtime-agent-ci.",
+  "wordpress/lib/datamachine-agent-ci-codebox-adapter.js": "WordPress Codebox adapter shim that injects the Data Machine Agent CI runtime profile.",
+  "wordpress/lib/datamachine-agent-ci-plan.js": "WordPress package compatibility wrapper around the quarantined Data Machine Agent CI adapter.",
+  "wordpress/scripts/agent/build-replay-bundle.js": "Replay bundle projection keeps Data Machine provenance fields for legacy agent-ci evidence bundles.",
+  "wordpress/scripts/agent/project-wpgym-eval-row.js": "WP Gym eval row projection keeps Data Machine provenance fields from legacy agent-ci evidence bundles.",
+  "wordpress/scripts/agent/run-datamachine-agent-task.cjs": "WordPress runner entrypoint for the quarantined Data Machine Agent CI workflow."
+}

--- a/tests/architectural-boundary-smoke.mjs
+++ b/tests/architectural-boundary-smoke.mjs
@@ -6,12 +6,20 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const boundaryTerms = /Data Machine|DataMachine|datamachine|data-machine|wp-site-generator|WPSG|site-generator|site generator/;
-const productionExtensions = new Set(['.js', '.cjs', '.mjs', '.ts', '.tsx']);
+const productionExtensions = new Set(['.js', '.cjs', '.mjs', '.ts', '.tsx', '.yml', '.yaml']);
+const quarantineManifestPath = 'tests/architectural-boundary-quarantine.json';
+const quarantineManifest = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, quarantineManifestPath), 'utf8')
+);
 
 const scannedRoots = [
+  '.github/scripts',
+  '.github/workflows',
+  'datamachine-agent-ci',
   'runtime-agent-ci',
   'wordpress/lib',
-  'agent-runtimes/lib',
+  'wordpress/scripts/agent',
+  'agent-runtimes',
 ];
 
 const scannedFiles = [
@@ -19,15 +27,6 @@ const scannedFiles = [
   'wordpress/scripts/agent/run-host-runner-lifecycle.cjs',
   'agent-runtimes/lib/runtime-provider-resolver.cjs',
 ];
-
-const allowedTransitionalAdapters = [
-  /^datamachine-agent-ci\//,
-  /^wordpress\/lib\/datamachine-agent-ci(?:-|$)/,
-];
-
-function isAllowedTransitionalAdapter(relativePath) {
-  return allowedTransitionalAdapters.some((pattern) => pattern.test(relativePath));
-}
 
 function walkProductionFiles(relativeDir) {
   const absoluteDir = path.join(repoRoot, relativeDir);
@@ -50,23 +49,70 @@ const files = new Set([
   ...scannedRoots.flatMap(walkProductionFiles),
   ...scannedFiles,
 ]);
+const quarantinedFiles = new Set(Object.keys(quarantineManifest));
 
-const violations = [];
-for (const relativePath of files) {
-  if (isAllowedTransitionalAdapter(relativePath)) {
-    continue;
+const manifestViolations = [];
+for (const [relativePath, justification] of Object.entries(quarantineManifest)) {
+  if (typeof justification !== 'string' || justification.trim() === '') {
+    manifestViolations.push(`${relativePath} is missing a file-level justification`);
   }
-  const absolutePath = path.join(repoRoot, relativePath);
-  const content = fs.readFileSync(absolutePath, 'utf8');
-  if (boundaryTerms.test(content)) {
-    violations.push(relativePath);
+  if (!fs.existsSync(path.join(repoRoot, relativePath))) {
+    manifestViolations.push(`${relativePath} does not exist`);
   }
 }
+
+const violations = [];
+const quarantinedTermFiles = [];
+for (const relativePath of files) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  const content = fs.readFileSync(absolutePath, 'utf8');
+  if (!boundaryTerms.test(content)) {
+    continue;
+  }
+  if (quarantinedFiles.has(relativePath)) {
+    quarantinedTermFiles.push(relativePath);
+    continue;
+  }
+  violations.push(relativePath);
+}
+
+const staleQuarantineEntries = [...quarantinedFiles].filter((relativePath) => {
+  const absolutePath = path.join(repoRoot, relativePath);
+  return fs.existsSync(absolutePath) && !boundaryTerms.test(fs.readFileSync(absolutePath, 'utf8'));
+});
+
+assert.deepEqual(
+  manifestViolations,
+  [],
+  `Boundary quarantine manifest entries must name existing files and include file-level justifications. Violations: ${manifestViolations.join(', ')}`,
+);
 
 assert.deepEqual(
   violations,
   [],
-  `Generic Homeboy Extensions production code must not reference Data Machine or wp-site-generator terms. Quarantine them in datamachine-agent-ci or WP Codebox provider adapters. Violations: ${violations.join(', ')}`,
+  `Generic Homeboy Extensions production code must not reference Data Machine or wp-site-generator terms outside ${quarantineManifestPath}. Violations: ${violations.join(', ')}`,
 );
+
+assert.deepEqual(
+  staleQuarantineEntries,
+  [],
+  `Boundary quarantine entries must be removed when the file no longer contains Data Machine or wp-site-generator terms. Stale entries: ${staleQuarantineEntries.join(', ')}`,
+);
+
+const quarantineCounts = quarantinedTermFiles.reduce((counts, relativePath) => {
+  const parts = relativePath.split('/');
+  const root = parts[0] === '.github'
+    ? parts.slice(0, parts[1] === 'scripts' ? 3 : 2).join('/')
+    : parts[0];
+  counts[root] = (counts[root] || 0) + 1;
+  return counts;
+}, {});
+
+console.log('architectural boundary quarantine report:', JSON.stringify({
+  quarantined_files: quarantinedFiles.size,
+  quarantined_files_with_boundary_terms: quarantinedTermFiles.length,
+  counts_by_root: quarantineCounts,
+  files: quarantinedTermFiles.sort(),
+}, null, 2));
 
 console.log('architectural boundary smoke passed');


### PR DESCRIPTION
## Summary
- Replace regex-based Data Machine adapter exemptions with an explicit quarantine manifest that requires file-level justifications.
- Expand boundary scanning across workflow, script, runtime, and adapter production paths so generic paths fail unless explicitly quarantined.
- Report remaining quarantined adapter files and counts during the architectural boundary smoke test.

## Verification
- `node tests/architectural-boundary-smoke.mjs`
- `node tests/runtime-agent-ci-contract-smoke.mjs`
- `node tests/datamachine-agent-ci-primitives-smoke.mjs`
- `node wordpress/tests/datamachine-agent-ci-plan-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the boundary test and quarantine manifest changes; Chris remains responsible for review and landing.