### PR TITLE
Delegate Data Machine agent CI primitives

### DIFF
--- a/.github/scripts/datamachine-agent-ci/build-runner-config.cjs
+++ b/.github/scripts/datamachine-agent-ci/build-runner-config.cjs
@@ -15,6 +15,11 @@ const {
 } = require('./lib/common.cjs');
 const { resolveRuntimeProvider } = require('../../../agent-runtimes/lib/runtime-provider-resolver.cjs');
 const { codeboxRuntimeProfilePayload } = require('../../../agent-runtimes/wp-codebox/lib/codebox-runtime-profile');
+const {
+  runtimeAgentCiFirstNonEmptyArray,
+  runtimeAgentCiFirstNonEmptyObject,
+  runtimeAgentCiTaskFromRequest,
+} = require('../../../runtime-agent-ci');
 
 function main() {
   const config = buildConfig(process.env);
@@ -79,17 +84,13 @@ function buildConfig(env) {
   const extraRequiredAbilities = parseJsonInput('extra_required_abilities', env.EXTRA_REQUIRED_ABILITIES || '[]', 'array', []);
   const runtimeTask = runtimeTaskFromEnv(env);
   const runtimeTaskAbility = env.RUNTIME_TASK_ABILITY || runtimeProfiles[runtimeProfile]?.runtime_task_ability || 'datamachine/run-agent-bundle';
-  const runtimeOutputProjections = parseJsonInputWithLegacyObject(
-    'runtime_output_projections',
-    env.RUNTIME_OUTPUT_PROJECTIONS || '{}',
-    'engine_data_outputs',
-    env.ENGINE_DATA_OUTPUTS || '{}'
+  const runtimeOutputProjections = runtimeAgentCiFirstNonEmptyObject(
+    parseJsonInput('runtime_output_projections', env.RUNTIME_OUTPUT_PROJECTIONS || '{}', 'object', {}),
+    parseJsonInput('engine_data_outputs', env.ENGINE_DATA_OUTPUTS || '{}', 'object', {})
   );
-  const evidenceProjections = parseJsonInputWithLegacyArray(
-    'evidence_projections',
-    env.EVIDENCE_PROJECTIONS || '[]',
-    'tool_recorders',
-    env.TOOL_RECORDERS || '[]'
+  const evidenceProjections = runtimeAgentCiFirstNonEmptyArray(
+    parseJsonInput('evidence_projections', env.EVIDENCE_PROJECTIONS || '[]', 'array', []),
+    parseJsonInput('tool_recorders', env.TOOL_RECORDERS || '[]', 'array', [])
   );
   const runtimeAbilityRequirements = Array.isArray(runtimeProfiles[runtimeProfile]?.ability_requirements)
     ? runtimeProfiles[runtimeProfile].ability_requirements
@@ -285,44 +286,15 @@ function resolveExecuteWorkflowMounts(executeWorkflowPath, workspace, componentS
 }
 
 function runtimeTaskFromEnv(env) {
-  const runtimeTask = parseJsonInput('runtime_task', env.RUNTIME_TASK || '{}', 'object', {});
-  if (Object.keys(runtimeTask).length > 0) {
-    if (!runtimeTask.ability || typeof runtimeTask.ability !== 'string') {
-      throw new Error('runtime_task.ability is required when runtime_task is supplied.');
-    }
-    return runtimeTask;
-  }
-
-  const abilityRequest = parseJsonInput('ability_request', env.ABILITY_REQUEST || '{}', 'object', {});
-  const abilityInput = parseJsonInput('ability_input', env.ABILITY_INPUT || '{}', 'object', {});
-  if (Object.keys(abilityRequest).length === 0 && Object.keys(abilityInput).length === 0) {
-    return null;
-  }
-  if (!abilityRequest.ability || typeof abilityRequest.ability !== 'string') {
-    throw new Error('ability_request.ability is required when ability_request or ability_input is supplied.');
-  }
-
-  return {
-    ...abilityRequest,
-    input: {
-      ...(abilityRequest.input && typeof abilityRequest.input === 'object' && !Array.isArray(abilityRequest.input) ? abilityRequest.input : {}),
-      ...abilityInput,
-    },
-  };
+  return runtimeAgentCiTaskFromRequest(
+    parseJsonInput('runtime_task', env.RUNTIME_TASK || '{}', 'object', {}),
+    parseJsonInput('ability_request', env.ABILITY_REQUEST || '{}', 'object', {}),
+    parseJsonInput('ability_input', env.ABILITY_INPUT || '{}', 'object', {})
+  );
 }
 
 function withoutInternalKeys(config) {
   return Object.fromEntries(Object.entries(config).filter(([key]) => !key.startsWith('_')));
-}
-
-function parseJsonInputWithLegacyObject(name, value, legacyName, legacyValue) {
-  const parsed = parseJsonInput(name, value, 'object', {});
-  return Object.keys(parsed).length > 0 ? parsed : parseJsonInput(legacyName, legacyValue, 'object', {});
-}
-
-function parseJsonInputWithLegacyArray(name, value, legacyName, legacyValue) {
-  const parsed = parseJsonInput(name, value, 'array', []);
-  return parsed.length > 0 ? parsed : parseJsonInput(legacyName, legacyValue, 'array', []);
 }
 
 function required(value, name) {

--- a/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
+++ b/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
@@ -6,6 +6,7 @@ const {
   AGENT_TASK_REQUEST_SCHEMA,
   agentTaskRequestFromRunnerSpec,
   runtimeAgentCiAbilityTaskRequest,
+  runtimeAgentCiBundleRuntimeExecution,
   runtimeAgentCiPlan,
   runtimeAgentCiRuntimeProfilesForOptions,
   runtimeAgentCiRunnerSpec,
@@ -140,29 +141,12 @@ function datamachineAgentCiBundleTaskRequest(options = {}, context = {}) {
   const pipelineSlug = requiredString(options.pipelineSlug || options.pipeline_slug, 'pipelineSlug');
   const flowSlug = requiredString(options.flowSlug || options.flow_slug, 'flowSlug');
 
-  const runtimeTaskInput = stripUndefined({
+  const runtimeTaskInput = datamachineAgentCiBundleInput({
+    ...options,
     source,
-    agent_slug: agentSlug,
-    pipeline_slug: pipelineSlug,
-    flow_slug: flowSlug,
-    target_repo: options.targetRepo || options.target_repo,
-    prompt: options.prompt || '',
-    wait_for_completion: options.waitForCompletion ?? options.wait_for_completion ?? true,
-    success_requires_pr: options.successRequiresPr ?? options.success_requires_pr,
-    success_completion_outcomes: options.successCompletionOutcomes || options.success_completion_outcomes,
-    artifact_outputs: options.artifactOutputs || options.artifact_outputs,
-    flow_step_patches: options.flowStepPatches || options.flow_step_patches,
-    evidence_projections: options.evidenceProjections || options.evidence_projections,
-    tool_recorders: options.toolRecorders || options.tool_recorders,
-    runtime_output_projections: options.runtimeOutputProjections || options.runtime_output_projections,
-    engine_data_outputs: options.engineDataOutputs || options.engine_data_outputs,
-    transcript_artifact_name: options.transcriptArtifactName || options.transcript_artifact_name,
-    artifacts: options.artifactsPath || options.artifacts,
-    max_turns: options.maxTurns || options.max_turns,
-    step_budget: options.stepBudget || options.step_budget,
-    time_budget_ms: options.timeBudgetMs || options.time_budget_ms,
-    complexity_policy: options.complexityPolicy || options.complexity_policy,
-    ...stripUndefined(options.runtimeTaskInput || options.runtime_task_input || {}),
+    agentSlug,
+    pipelineSlug,
+    flowSlug,
   });
 
   return datamachineAgentCiAbilityTaskRequest({
@@ -170,11 +154,7 @@ function datamachineAgentCiBundleTaskRequest(options = {}, context = {}) {
     taskId,
     ability: options.ability,
     abilityInput: runtimeTaskInput,
-    runtimeExecution: options.runtimeExecution || options.runtime_execution || {
-      kind: 'bundle',
-      ability: options.ability,
-      input: runtimeTaskInput,
-    },
+    runtimeExecution: options.runtimeExecution || options.runtime_execution || runtimeAgentCiBundleRuntimeExecution(options, runtimeTaskInput),
   }, context);
 }
 
@@ -213,36 +193,34 @@ function datamachineAgentCiRuntimeOptions(options = {}) {
 }
 
 function datamachineAgentCiRuntimeExecution(options = {}) {
-  const source = options.source || options.bundle;
-  if (!source) {
-    return null;
-  }
-  return {
-    kind: 'bundle',
-    ability: options.ability,
-    input: stripUndefined({
-      source,
-      agent_slug: options.agentSlug || options.agent_slug,
-      pipeline_slug: options.pipelineSlug || options.pipeline_slug,
-      flow_slug: options.flowSlug || options.flow_slug,
-      target_repo: options.targetRepo || options.target_repo,
-      prompt: options.prompt || '',
-      wait_for_completion: options.waitForCompletion ?? options.wait_for_completion ?? true,
-      success_requires_pr: options.successRequiresPr ?? options.success_requires_pr,
-      success_completion_outcomes: options.successCompletionOutcomes || options.success_completion_outcomes,
-      artifact_outputs: options.artifactOutputs || options.artifact_outputs,
-      flow_step_patches: options.flowStepPatches || options.flow_step_patches,
-      tool_recorders: options.toolRecorders || options.tool_recorders,
-      engine_data_outputs: options.engineDataOutputs || options.engine_data_outputs,
-      transcript_artifact_name: options.transcriptArtifactName || options.transcript_artifact_name,
-      artifacts: options.artifactsPath || options.artifacts,
-      max_turns: options.maxTurns || options.max_turns,
-      step_budget: options.stepBudget || options.step_budget,
-      time_budget_ms: options.timeBudgetMs || options.time_budget_ms,
-      complexity_policy: options.complexityPolicy || options.complexity_policy,
-      ...stripUndefined(options.runtimeTaskInput || options.runtime_task_input || {}),
-    }),
-  };
+  return runtimeAgentCiBundleRuntimeExecution(options, datamachineAgentCiBundleInput(options));
+}
+
+function datamachineAgentCiBundleInput(options = {}) {
+  return stripUndefined({
+    source: options.source || options.bundle,
+    agent_slug: options.agentSlug || options.agent_slug,
+    pipeline_slug: options.pipelineSlug || options.pipeline_slug,
+    flow_slug: options.flowSlug || options.flow_slug,
+    target_repo: options.targetRepo || options.target_repo,
+    prompt: options.prompt || '',
+    wait_for_completion: options.waitForCompletion ?? options.wait_for_completion ?? true,
+    success_requires_pr: options.successRequiresPr ?? options.success_requires_pr,
+    success_completion_outcomes: options.successCompletionOutcomes || options.success_completion_outcomes,
+    artifact_outputs: options.artifactOutputs || options.artifact_outputs,
+    flow_step_patches: options.flowStepPatches || options.flow_step_patches,
+    evidence_projections: options.evidenceProjections || options.evidence_projections,
+    tool_recorders: options.toolRecorders || options.tool_recorders,
+    runtime_output_projections: options.runtimeOutputProjections || options.runtime_output_projections,
+    engine_data_outputs: options.engineDataOutputs || options.engine_data_outputs,
+    transcript_artifact_name: options.transcriptArtifactName || options.transcript_artifact_name,
+    artifacts: options.artifactsPath || options.artifacts,
+    max_turns: options.maxTurns || options.max_turns,
+    step_budget: options.stepBudget || options.step_budget,
+    time_budget_ms: options.timeBudgetMs || options.time_budget_ms,
+    complexity_policy: options.complexityPolicy || options.complexity_policy,
+    ...stripUndefined(options.runtimeTaskInput || options.runtime_task_input || {}),
+  });
 }
 
 function datamachineAgentCiPlan(options = {}) {

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -132,6 +132,57 @@ function normalizeRuntimeExecutionDescriptor(descriptor, runtimeProfile = {}) {
   });
 }
 
+function runtimeAgentCiBundleRuntimeExecution(options = {}, input = {}) {
+  const bundle = options.bundle && typeof options.bundle === 'object' && !Array.isArray(options.bundle) ? options.bundle : {};
+  const source = options.source || options.bundlePath || options.bundle_path || bundle.source || bundle.path || bundle.bundle_path || (typeof options.bundle === 'string' ? options.bundle : undefined);
+  if (!source) {
+    return null;
+  }
+  return {
+    kind: 'bundle',
+    ability: options.ability,
+    input: stripUndefined({
+      source,
+      ...input,
+      ...stripUndefined(options.runtimeTaskInput || options.runtime_task_input || {}),
+    }),
+  };
+}
+
+function runtimeAgentCiTaskFromRequest(runtimeTask = {}, abilityRequest = {}, abilityInput = {}) {
+  if (runtimeTask && typeof runtimeTask === 'object' && !Array.isArray(runtimeTask) && Object.keys(runtimeTask).length > 0) {
+    if (!runtimeTask.ability || typeof runtimeTask.ability !== 'string') {
+      throw new Error('runtime_task.ability is required when runtime_task is supplied.');
+    }
+    return runtimeTask;
+  }
+
+  const hasAbilityRequest = abilityRequest && typeof abilityRequest === 'object' && !Array.isArray(abilityRequest) && Object.keys(abilityRequest).length > 0;
+  const hasAbilityInput = abilityInput && typeof abilityInput === 'object' && !Array.isArray(abilityInput) && Object.keys(abilityInput).length > 0;
+  if (!hasAbilityRequest && !hasAbilityInput) {
+    return null;
+  }
+  if (!abilityRequest.ability || typeof abilityRequest.ability !== 'string') {
+    throw new Error('ability_request.ability is required when ability_request or ability_input is supplied.');
+  }
+
+  return {
+    ...abilityRequest,
+    input: {
+      ...(abilityRequest.input && typeof abilityRequest.input === 'object' && !Array.isArray(abilityRequest.input) ? abilityRequest.input : {}),
+      ...abilityInput,
+    },
+  };
+}
+
+function runtimeAgentCiFirstNonEmptyObject(primary = {}, legacy = {}) {
+  return primary && typeof primary === 'object' && !Array.isArray(primary) && Object.keys(primary).length > 0 ? primary : legacy;
+}
+
+function runtimeAgentCiFirstNonEmptyArray(primary = [], legacy = []) {
+  return Array.isArray(primary) && primary.length > 0 ? primary : legacy;
+}
+
 function abilityForRuntimeExecutionKind(kind, runtimeProfile = {}) {
   if (kind === 'bundle') {
     return runtimeProfile.runtime_bundle_ability || runtimeProfile.runtime_task_ability;
@@ -244,10 +295,14 @@ module.exports = {
   RUNTIME_AGENT_CI_RUNTIME_PROFILE_ID,
   agentTaskRequestFromRunnerSpec,
   runtimeAgentCiAbilityTaskRequest,
+  runtimeAgentCiBundleRuntimeExecution,
+  runtimeAgentCiFirstNonEmptyArray,
+  runtimeAgentCiFirstNonEmptyObject,
   runtimeAgentCiPlan,
   runtimeAgentCiRunnerSpec,
   runtimeAgentCiRuntimeTaskRequest,
   runtimeAgentCiRuntimeProfilesForOptions,
+  runtimeAgentCiTaskFromRequest,
   runtimeAgentCiTaskExecutorConfig,
   normalizeRuntimeExecutionDescriptor,
   resolveRuntimeAgentCiRuntimeProfile,

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -72,6 +72,23 @@ assert.deepEqual(genericConfig.artifact_slots, [{ name: 'packet', required: true
 assert.deepEqual(genericConfig.transcript_slots, [{ name: 'main', required: true }]);
 assert.deepEqual(genericConfig.provider_runtime_invocation, { operations: ['workspaceCommand'] });
 
+assert.deepEqual(
+  runtimeAgentCi.runtimeAgentCiTaskFromRequest(
+    {},
+    { ability: 'example/process', input: { source: 'artifact.json' } },
+    { mode: 'typed' }
+  ),
+  { ability: 'example/process', input: { source: 'artifact.json', mode: 'typed' } }
+);
+assert.deepEqual(
+  runtimeAgentCi.runtimeAgentCiFirstNonEmptyObject({}, { legacy: true }),
+  { legacy: true }
+);
+assert.deepEqual(
+  runtimeAgentCi.runtimeAgentCiFirstNonEmptyArray([], [{ legacy: true }]),
+  [{ legacy: true }]
+);
+
 const genericBundleConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
   runtimeProfile: runtimeProfile.id,
   runtimeProfiles: { [runtimeProfile.id]: runtimeProfile },


### PR DESCRIPTION
## Summary
- move generic bundle runtime execution and runtime task shorthand helpers into runtime-agent-ci
- make datamachine-agent-ci delegate bundle execution construction and legacy projection/task translation to the generic helpers
- keep Data Machine-specific runtime profile/defaults in the adapter while preserving legacy workflow inputs

## Verification
- node tests/runtime-agent-ci-contract-smoke.mjs
- node tests/datamachine-agent-ci-primitives-smoke.mjs
- node wordpress/tests/datamachine-agent-ci-plan-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic helper extraction, Data Machine adapter delegation, and targeted smoke-test updates; Chris remains responsible for review and merge.