### PR TITLE
Generalize runtime profile defaults

### DIFF
--- a/.github/scripts/datamachine-agent-ci/materialize-dependencies.cjs
+++ b/.github/scripts/datamachine-agent-ci/materialize-dependencies.cjs
@@ -3,7 +3,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { capture, normalizeProviderPlugin, requireRepo, run, splitCsv } = require('./lib/common.cjs');
+const { capture, normalizeProviderPlugin, parseJsonInput, requireRepo, run, splitCsv } = require('./lib/common.cjs');
 const { resolveRuntimeProvider } = require('../../../agent-runtimes/lib/runtime-provider-resolver.cjs');
 
 function main() {
@@ -28,10 +28,13 @@ function dependencyEntries(env) {
   const runtime = resolveRuntimeProvider(runtimeId, { env });
   const entries = [{ repo: runtime.checkout.repo, ref: runtime.checkout.ref, target: runtime.checkout.target }];
   const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || 'openai', true);
+  const runtimeDependencies = runtimeDependencyEntries(env.RUNTIME_DEPENDENCIES || '');
   if (env.INCLUDE_AGENT_RUNTIME_DEPENDENCIES === 'true') {
-    entries.push(`Automattic/agents-api@${env.AGENTS_API_REF || 'main'}`);
-    entries.push(`Extra-Chill/data-machine@${env.DATA_MACHINE_REF || 'main'}`);
-    entries.push(`Extra-Chill/data-machine-code@${env.DATA_MACHINE_CODE_REF || 'main'}`);
+    entries.push(...(runtimeDependencies.length > 0 ? runtimeDependencies : [
+      `Automattic/agents-api@${env.AGENTS_API_REF || 'main'}`,
+      `Extra-Chill/data-machine@${env.DATA_MACHINE_REF || 'main'}`,
+      `Extra-Chill/data-machine-code@${env.DATA_MACHINE_CODE_REF || 'main'}`,
+    ]));
     if ((env.PROVIDER || 'openai') === 'openai' && !providerPlugin.repo) {
       entries.push(`WordPress/ai-provider-for-openai@${env.OPENAI_PROVIDER_REF || 'trunk'}`);
     }
@@ -41,6 +44,16 @@ function dependencyEntries(env) {
   }
   entries.push(...splitCsv(env.VALIDATION_DEPENDENCIES || ''));
   return entries;
+}
+
+function runtimeDependencyEntries(value) {
+  if (!value || String(value).trim() === '') {
+    return [];
+  }
+  if (String(value).trim().startsWith('[')) {
+    return parseJsonInput('runtime_dependencies', value, 'array', []);
+  }
+  return splitCsv(value);
 }
 
 function resolvePlan(entries, offline) {

--- a/.github/workflows/datamachine-agent-ci.yml
+++ b/.github/workflows/datamachine-agent-ci.yml
@@ -91,6 +91,10 @@ name: Data Machine Agent CI (reusable)
         description: "Include the standard WordPress agent runtime stack: Agents API, Data Machine, and Data Machine Code."
         type: boolean
         default: true
+      runtime_dependencies:
+        description: JSON array or comma-separated OWNER/REPO@REF entries checked out under .ci when include_agent_runtime_dependencies is true. Empty uses this adapter's Data Machine stack defaults.
+        type: string
+        default: ""
       agent_runtime:
         description: Runtime substrate id. Currently only wp-codebox is supported.
         type: string
@@ -143,6 +147,10 @@ name: Data Machine Agent CI (reusable)
         description: JSON array of runtime component contracts forwarded to WP Codebox.
         type: string
         default: "[]"
+      runtime_components:
+        description: JSON object of runtime component paths forwarded to WP Codebox. Values override adapter defaults such as agents_api, data_machine, and data_machine_code.
+        type: string
+        default: "{}"
       success_requires_pr:
         type: boolean
         default: true
@@ -475,6 +483,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           VALIDATION_DEPENDENCIES: ${{ inputs.validation_dependencies }}
           INCLUDE_AGENT_RUNTIME_DEPENDENCIES: ${{ inputs.include_agent_runtime_dependencies }}
+          RUNTIME_DEPENDENCIES: ${{ inputs.runtime_dependencies }}
           AGENT_RUNTIME: ${{ inputs.agent_runtime }}
           AGENT_RUNTIME_REF: ${{ inputs.agent_runtime_ref }}
           AGENTS_API_REF: ${{ inputs.agents_api_ref }}
@@ -556,6 +565,7 @@ jobs:
           ABILITY_INPUT: ${{ inputs.ability_input }}
           OUTPUT_MAPPINGS: ${{ inputs.output_mappings }}
           COMPONENT_CONTRACTS: ${{ inputs.component_contracts }}
+          RUNTIME_COMPONENTS: ${{ inputs.runtime_components }}
           SUCCESS_REQUIRES_PR: ${{ inputs.success_requires_pr }}
           SUCCESS_COMPLETION_OUTCOMES: ${{ inputs.success_completion_outcomes }}
           MAX_TURNS: ${{ inputs.max_turns }}

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -459,7 +459,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     runtime_env: {
       ...firstNonEmptyObject(config.runtime_env, config.runtimeEnv, config.wp_codebox_runtime_env, runtimeOptions.runtimeEnv, defaults.runtimeEnv, {}),
       ...homeboyAgentToolContractEnv(),
-      ...datamachineHostToolPolicyEnv(),
+      ...runtimeEnvAliasesFromSourceEnv(runtimeOptions.runtimeEnvAliases),
     },
     runtime_state_mounts: firstDefined(config.runtime_state_mounts, config.runtimeStateMounts, config.wp_codebox_runtime_state_mounts, runtimeOptions.runtimeStateMounts, defaults.runtimeStateMounts, []),
     runtime_config_mounts: firstDefined(config.runtime_config_mounts, config.runtimeConfigMounts, config.wp_codebox_runtime_config_mounts, runtimeOptions.runtimeConfigMounts, defaults.runtimeConfigMounts, []),
@@ -514,6 +514,7 @@ function runtimeOptionsFromExecutorConfig(config = {}, options = {}) {
     providerPluginPaths: providerPluginPathsFromRuntimeProfile(runtimeRequirements, runtimeProfile, options),
     runtimeOverlays: firstDefined(runtimeRequirements.runtime_overlays, runtimeProfile.runtime_overlays, options.runtimeOverlays),
     runtimeEnv: firstNonEmptyObject(runtimeRequirements.env, runtimeRequirements.runtime_env, runtimeProfile.env, runtimeProfile.runtime_env, options.runtimeEnv, options.runtime_env),
+    runtimeEnvAliases: firstObject(runtimeRequirements.runtime_env_aliases, runtimeRequirements.runtimeEnvAliases, runtimeProfile.runtime_env_aliases, runtimeProfile.runtimeEnvAliases, options.runtimeEnvAliases, options.runtime_env_aliases),
     runtimeStateMounts: firstDefined(runtimeRequirements.runtime_state_mounts, runtimeProfile.runtime_state_mounts, options.runtimeStateMounts, options.runtime_state_mounts),
     runtimeConfigMounts: firstDefined(runtimeRequirements.runtime_config_mounts, runtimeProfile.runtime_config_mounts, options.runtimeConfigMounts, options.runtime_config_mounts),
     callbackData: firstDefined(runtimeRequirements.callback_data, runtimeRequirements.callbackData, runtimeProfile.callback_data, runtimeProfile.callbackData, options.callbackData, options.callback_data),
@@ -877,14 +878,23 @@ function homeboyAgentToolContractEnv() {
   ].map((name) => [name, process.env[name]]).filter(([, value]) => typeof value === 'string' && value !== ''));
 }
 
-function datamachineHostToolPolicyEnv() {
-  const policyJson = process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON;
-  if (typeof policyJson !== 'string' || policyJson === '') {
+function runtimeEnvAliasesFromSourceEnv(aliases = {}) {
+  if (!aliases || typeof aliases !== 'object' || Array.isArray(aliases)) {
     return {};
   }
-  return {
-    DATAMACHINE_HOST_TOOL_POLICY_JSON: policyJson,
-  };
+  const env = {};
+  for (const [sourceName, targetNames] of Object.entries(aliases)) {
+    const value = process.env[sourceName];
+    if (typeof value !== 'string' || value === '') {
+      continue;
+    }
+    for (const targetName of normalizeArray(targetNames)) {
+      if (typeof targetName === 'string' && targetName !== '') {
+        env[targetName] = value;
+      }
+    }
+  }
+  return env;
 }
 
 function sandboxToolPolicyFromHomeboyAgentToolPolicy(policy) {
@@ -1117,11 +1127,11 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
   const discovery = runtimeComponentDiscovery(options);
   const workspaceRoot = resolveWorkspaceRoot(request, config, inputs, settings, options);
   const workspaceBase = workspaceRoot ? path.dirname(workspaceRoot) : process.cwd();
-  const dataMachinePath = firstExistingPath(
+  const agentRuntimePath = firstExistingPath(
     options.agentRuntime,
     ...componentDiscoveryCandidates('agent_runtime', discovery, settings, workspaceBase),
   );
-  const dataMachineCodePath = firstExistingPath(
+  const agentRuntimeToolsPath = firstExistingPath(
     options.agentRuntimeTools,
     ...componentDiscoveryCandidates('agent_runtime_tools', discovery, settings, workspaceBase),
   );
@@ -1135,14 +1145,16 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
   const model = config.model || options.model || defaultModelForProvider(provider, settings, providerConfig);
   const agentsApiPath = firstExistingPath(
     options.agentsApi,
-    ...componentDiscoveryCandidates('agents_api', discovery, settings, workspaceBase, { agent_runtime: dataMachinePath }),
+    ...componentDiscoveryCandidates('agents_api', discovery, settings, workspaceBase, { agent_runtime: agentRuntimePath }),
   );
   const phpAiClientPath = defaultPhpAiClientPath(settings, options);
 
   return {
     agentsApi: agentsApiPath,
-    legacyRuntime: dataMachinePath,
-    legacyRuntimeTools: dataMachineCodePath,
+    agentRuntime: agentRuntimePath,
+    agentRuntimeTools: agentRuntimeToolsPath,
+    legacyRuntime: agentRuntimePath,
+    legacyRuntimeTools: agentRuntimeToolsPath,
     providerPluginPaths: defaultProviderPluginPaths(provider, config, options, settings, providerConfig, providerPluginPath),
     provider,
     model,

--- a/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
+++ b/datamachine-agent-ci/lib/datamachine-agent-ci-plan.js
@@ -43,6 +43,7 @@ const DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS = {
       'config_path:agent_runtime',
       'config:data_machine',
       'config_path:data_machine',
+      'option:agentRuntime',
       'option:legacyRuntime',
     ],
     agent_runtime_tools: [
@@ -54,6 +55,7 @@ const DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS = {
       'config_path:agent_runtime_tools',
       'config:data_machine_code',
       'config_path:data_machine_code',
+      'option:agentRuntimeTools',
       'option:legacyRuntimeTools',
     ],
   },
@@ -118,6 +120,10 @@ const DATAMACHINE_AGENT_CI_ABILITY_REQUIREMENTS = [
   'comment_github_pull_request',
 ];
 
+const DATAMACHINE_AGENT_CI_RUNTIME_ENV_ALIASES = {
+  HOMEBOY_AGENT_TOOL_POLICY_JSON: ['DATAMACHINE_HOST_TOOL_POLICY_JSON'],
+};
+
 const DATAMACHINE_AGENT_CI_RUNTIME_PROFILE = {
   schema: 'homeboy/runtime-profile/v1',
   id: DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID,
@@ -127,6 +133,7 @@ const DATAMACHINE_AGENT_CI_RUNTIME_PROFILE = {
   workspace_tools: DATAMACHINE_AGENT_CI_WORKSPACE_TOOLS,
   capabilities: DATAMACHINE_AGENT_CI_CAPABILITIES,
   ability_requirements: DATAMACHINE_AGENT_CI_ABILITY_REQUIREMENTS,
+  runtime_env_aliases: DATAMACHINE_AGENT_CI_RUNTIME_ENV_ALIASES,
 };
 
 const DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_PRESETS = {
@@ -251,6 +258,7 @@ module.exports = {
   DATAMACHINE_AGENT_CI_ABILITY_REQUIREMENTS,
   DATAMACHINE_AGENT_CI_COMPONENT_PATH_DEFAULTS,
   DATAMACHINE_AGENT_CI_RUNTIME_PROFILE,
+  DATAMACHINE_AGENT_CI_RUNTIME_ENV_ALIASES,
   DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID,
   DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_PRESET,
   DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_PRESETS,

--- a/tests/datamachine-agent-ci-primitives-smoke.mjs
+++ b/tests/datamachine-agent-ci-primitives-smoke.mjs
@@ -62,6 +62,18 @@ assert.deepEqual(
 );
 assert.ok(dependencyPlan.some((entry) => entry.repo === 'WordPress/ai-provider-for-openai'));
 
+const customRuntimeDependencyPlan = JSON.parse(run('materialize-dependencies.cjs', ['--print-plan'], {
+  VALIDATION_DEPENDENCIES: '',
+  INCLUDE_AGENT_RUNTIME_DEPENDENCIES: 'true',
+  RUNTIME_DEPENDENCIES: '[{"repo":"Example/runtime-core","ref":"stable","target":".ci/runtime-core"}]',
+  AGENT_RUNTIME: 'wp-codebox',
+  AGENT_RUNTIME_REF: 'main',
+  PROVIDER: 'codex',
+  PROVIDER_PLUGIN: '{}',
+}));
+assert.ok(customRuntimeDependencyPlan.some((entry) => entry.repo === 'Example/runtime-core' && entry.target === '.ci/runtime-core'));
+assert.equal(customRuntimeDependencyPlan.some((entry) => entry.repo === 'Extra-Chill/data-machine'), false);
+
 fs.writeFileSync(githubOutput, '');
 run('build-runner-config.cjs', [], {
   GITHUB_OUTPUT: githubOutput,

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -175,5 +175,9 @@ assert.deepEqual(
   adapterConfig.runtime_profiles[datamachineAgentCi.DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID].ability_requirements,
   datamachineAgentCi.DATAMACHINE_AGENT_CI_ABILITY_REQUIREMENTS
 );
+assert.deepEqual(
+  adapterConfig.runtime_profiles[datamachineAgentCi.DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID].runtime_env_aliases,
+  datamachineAgentCi.DATAMACHINE_AGENT_CI_RUNTIME_ENV_ALIASES
+);
 
 console.log('runtime agent CI contract smoke passed');

--- a/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
+++ b/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { codeboxTaskRequestFromAgentTaskRequest } = require(
+	path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'codebox-agent-task-executor.js')
+);
+
+const previousPolicy = process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON;
+
+try {
+	process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON = '{"schema":"homeboy/agent-tool-policy/v1","tools":{}}';
+
+	const taskInput = codeboxTaskRequestFromAgentTaskRequest({
+		schema: 'homeboy/agent-task-request/v1',
+		task_id: 'wp-codebox-runtime-profile-defaults-smoke',
+		instructions: 'Validate profile-driven runtime defaults.',
+		executor: {
+			backend: 'codebox',
+			config: {
+				provider: 'codex',
+				model: 'gpt-5.5',
+				runtime_task: {
+					ability: 'example/run-task',
+					input: {},
+				},
+				runtime_profile: 'example-runtime',
+				runtime_profiles: {
+					'example-runtime': {
+						schema: 'homeboy/runtime-profile/v1',
+						id: 'example-runtime',
+						runtime_task_ability: 'example/run-task',
+						runtime_env_aliases: {
+							HOMEBOY_AGENT_TOOL_POLICY_JSON: ['EXAMPLE_RUNTIME_TOOL_POLICY_JSON'],
+						},
+					},
+				},
+			},
+		},
+	});
+
+	assert.equal(taskInput.runtime_env.EXAMPLE_RUNTIME_TOOL_POLICY_JSON, process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON);
+	assert.equal(taskInput.runtime_env.DATAMACHINE_HOST_TOOL_POLICY_JSON, undefined);
+	console.log('wp-codebox runtime profile defaults smoke passed');
+} finally {
+	if (previousPolicy === undefined) {
+		delete process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON;
+	} else {
+		process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON = previousPolicy;
+	}
+}

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -205,9 +205,10 @@ assert.equal(homeboyToolPolicyTaskInput.allowed_tools.includes('github_issue_pub
 assert.equal(homeboyToolPolicyTaskInput.allowed_tools.includes('github_pull_request_publish'), false);
 assert.equal(homeboyToolPolicyTaskInput.runtime_env.HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA, 'homeboy/agent-tool-request/v1');
 assert.deepEqual(
-  JSON.parse(homeboyToolPolicyTaskInput.runtime_env.DATAMACHINE_HOST_TOOL_POLICY_JSON),
+  JSON.parse(homeboyToolPolicyTaskInput.runtime_env.HOMEBOY_AGENT_TOOL_POLICY_JSON),
   JSON.parse(homeboyAgentToolPolicyJson)
 );
+assert.equal(homeboyToolPolicyTaskInput.runtime_env.DATAMACHINE_HOST_TOOL_POLICY_JSON, undefined);
 const homeboySandboxTools = Object.fromEntries(homeboyToolPolicyTaskInput.sandbox_tool_policy.tools.map((tool) => [tool.id, tool]));
 assert.equal(homeboyToolPolicyTaskInput.sandbox_tool_policy.metadata.source, 'homeboy_agent_tool_policy');
 assert.equal(homeboySandboxTools.workspace_read.allowed, true);


### PR DESCRIPTION
## Summary
- move host tool policy env aliasing into generic Codebox runtime profile defaults
- keep the Data Machine compatibility env alias declared by the Data Machine adapter profile
- expose runtime dependency and component path overrides as caller-facing workflow inputs
- add smoke coverage for dependency overrides, runtime profile env aliases, and adapter profile exports

## Verification
- `node tests/datamachine-agent-ci-primitives-smoke.mjs`
- `node tests/runtime-agent-ci-contract-smoke.mjs`
- `node tests/wp-codebox-runtime-profile-defaults-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `git diff --check`

## Notes
- `node wordpress/tests/codebox-agent-task-executor-smoke.js` currently fails on an existing callback-data runtime env assertion: `HOMEBOY_CALLBACK_DATA_PATH` is present in `runtime_env` where the test expects only the configured env object.
- ESLint is package-scoped under `wordpress/`; root-level changed files are ignored by that config and there is no root ESLint config.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the code changes, tests, and verification commands for Chris to review.