### PR TITLE
Require explicit generic runner backend

### DIFF
--- a/agent-runtimes/lib/agent-task-runner-contract.js
+++ b/agent-runtimes/lib/agent-task-runner-contract.js
@@ -8,7 +8,7 @@ function agentTaskRunnerSpec(options = {}) {
     throw new Error('config is required.');
   }
 
-  const backend = requiredString(options.backend || 'codebox', 'backend');
+  const backend = requiredString(options.backend, 'backend');
   const taskTimeoutSeconds = options.taskTimeoutSeconds || options.task_timeout_seconds;
   const limits = stripUndefined({
     ...(taskTimeoutSeconds ? { task_timeout_seconds: taskTimeoutSeconds } : {}),

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -56,6 +56,10 @@ Runtime-specific fields are allowed, but they should be additive. A runtime
 should not require Homeboy core to understand backend-private settings just to
 invoke the provider.
 
+Generic runner specs must declare `executor.backend` explicitly. Runtime-specific
+planners may provide their own defaults, but the shared contract does not assume
+WP Codebox or any other backend.
+
 ## `runtime_path` Interpolation
 
 Provider commands should reference runtime-local files with `{{runtime_path}}`:

--- a/tests/agent-task-provider-contract-smoke.mjs
+++ b/tests/agent-task-provider-contract-smoke.mjs
@@ -87,6 +87,10 @@ const runnerSpec = agentTaskRunnerSpec({
 	expectedArtifacts: ['patch'],
 });
 assert.equal(runnerSpec.schema, AGENT_TASK_RUNNER_SPEC_SCHEMA);
+assert.throws(
+	() => agentTaskRunnerSpec({ config: { provider: 'codex' } }),
+	/backend is required/,
+);
 assert.deepEqual(agentTaskRequestFromRunnerSpec({ runnerSpec }), {
 	executor: {
 		backend: 'codebox',


### PR DESCRIPTION
## Summary
- require generic agent task runner specs to declare `backend` explicitly
- document that shared runner specs do not assume WP Codebox or any other backend
- assert missing backend validation in the focused provider contract smoke test

## Verification
- `node tests/agent-task-provider-contract-smoke.mjs` — passed
- `git diff --check` — passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected the existing patch, reran focused verification, committed the prepared changes, and opened this PR.