### PR TITLE
Add generic fanout reconcile workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ documented in [`docs/project-script-runtime.md`](docs/project-script-runtime.md)
 They are extension-owned until Homeboy core grows an ecosystem-neutral runtime
 helper contract.
 
+Generic fanout/reconcile JSON planning is documented in
+[`docs/generic-fanout-reconcile-workflow.md`](docs/generic-fanout-reconcile-workflow.md).
+
 ## Available Extensions
 
 | Extension | Description |

--- a/docs/generic-fanout-reconcile-workflow.md
+++ b/docs/generic-fanout-reconcile-workflow.md
@@ -1,0 +1,51 @@
+# Generic Fanout/Reconcile Workflow
+
+`wordpress/scripts/agent/homeboy-generic-fanout-reconcile.cjs` exposes the shared fanout/reconcile runner through JSON files. It is domain-neutral: callers provide item artifacts, grouping rules, task request templates, and runtime execution descriptors.
+
+## Plan
+
+```bash
+node wordpress/scripts/agent/homeboy-generic-fanout-reconcile.cjs \
+  --config fanout-config.json \
+  --items items.json \
+  --output fanout-plan.json
+```
+
+Minimal config:
+
+```json
+{
+  "schema": "homeboy/generic-fanout-reconcile-config/v1",
+  "orchestrator": { "id": "example", "run_id": "run-1", "plan_id": "plan-1" },
+  "group_key_path": "category",
+  "task_request_template": {
+    "id": "task-{{group.key}}",
+    "group_key": "{{group.key}}",
+    "item_ids": "{{group.item_ids}}",
+    "instructions": "Process {{group.key}} with {{group.item_count}} item(s).",
+    "inputs": { "items": "{{group.items}}" }
+  },
+  "runtime_execution": {
+    "backend": "caller-provided-runtime",
+    "task": { "name": "process-generic-group", "group": "{{group.key}}" }
+  }
+}
+```
+
+Supported template values include `{{group.key}}`, `{{group.index}}`, `{{group.items}}`, `{{group.item_count}}`, `{{group.item_ids}}`, and `{{orchestrator.<field>}}`. If the whole string is a template expression, arrays and objects remain typed instead of being stringified.
+
+## Reconcile
+
+After a caller executes the task requests using its chosen runtime, pass records back in:
+
+```bash
+node wordpress/scripts/agent/homeboy-generic-fanout-reconcile.cjs \
+  --config fanout-config.json \
+  --plan fanout-plan.json \
+  --records task-records.json \
+  --output fanout-result.json
+```
+
+Records are matched by `id`, `task_id`, `sandbox_session_id`, or `group_key`. Successful statuses default to `completed`, `success`, and `passed`; override with `success_statuses` in config. Outcomes default to the record `outcome` field; override with `outcome_path`.
+
+Runtime-specific descriptors are caller-owned. Keep provider names, credentials, WordPress setup, sandbox recipes, and repository-specific instructions in caller config or workflow examples, not in this generic helper.

--- a/wordpress/lib/generic-fanout-reconcile-workflow.js
+++ b/wordpress/lib/generic-fanout-reconcile-workflow.js
@@ -1,0 +1,235 @@
+'use strict';
+
+/* eslint-disable camelcase */
+
+/**
+ * Internal dependencies
+ */
+const {
+  createFanoutReconcilePlan,
+  executeFanoutReconcileRun,
+  groupFanoutItems,
+} = require('./fanout-reconcile-runner');
+
+const CONFIG_SCHEMA = 'homeboy/generic-fanout-reconcile-config/v1';
+const RESULT_SCHEMA = 'homeboy/generic-fanout-reconcile-result/v1';
+
+function createGenericFanoutReconcilePlan(input = {}) {
+  const config = normalizeConfig(input.config || input);
+  const items = normalizeItems(input.items || config.items || []);
+  const groups = normalizeGroups(input.groups || config.groups, items, config);
+  const orchestrator = config.orchestrator || {};
+
+  return createFanoutReconcilePlan({
+    schema: config.plan_schema || config.planSchema,
+    orchestrator,
+    groups,
+    summary: {
+      config_schema: config.schema || CONFIG_SCHEMA,
+      item_count: groups.reduce((count, group) => count + group.items.length, 0),
+      group_count: groups.length,
+      ...(config.summary || {}),
+    },
+    render_task_request: (group) => renderTaskRequest(group, orchestrator, config),
+    reconcile_plan: ({ groups: planGroups, task_requests }) => reconcileRecords({
+      groups: planGroups,
+      task_requests,
+      records: [],
+      config,
+    }),
+  });
+}
+
+async function createGenericFanoutReconcileResult(input = {}) {
+  const config = normalizeConfig(input.config || {});
+  const plan = input.plan || createGenericFanoutReconcilePlan(input);
+  const records = normalizeRecords(input.records || []);
+  const recordsById = new Map(records.map((record) => [taskId(record), record]));
+
+  return executeFanoutReconcileRun({
+    plan,
+    concurrency: plan.task_requests.length || 1,
+    run_schema: config.result_schema || config.resultSchema || RESULT_SCHEMA,
+    base_run: config.base_run || {},
+    include_summary: config.include_summary !== false,
+    task_id: taskId,
+    execute_task_request: async (taskRequest) => recordsById.get(taskId(taskRequest)) || {
+      id: taskId(taskRequest),
+      group_key: taskRequest.group_key || '',
+      status: 'missing_record',
+    },
+    classify_outcome: (record) => getPath(record, config.outcome_path || config.outcomePath || 'outcome'),
+    is_record_successful: (record) => isRecordSuccessful(record, config),
+    reconcile: ({ records: runRecords, outcomes }) => reconcileRecords({
+      groups: plan.groups,
+      task_requests: plan.task_requests,
+      records: runRecords,
+      outcomes,
+      config,
+    }),
+  });
+}
+
+function normalizeConfig(config) {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    return {};
+  }
+  return config;
+}
+
+function normalizeItems(items) {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items.map((item, index) => (item && typeof item === 'object' ? { ...item, index } : { value: item, index }));
+}
+
+function normalizeRecords(records) {
+  if (!Array.isArray(records)) {
+    return [];
+  }
+  return records.map((record, index) => (record && typeof record === 'object' ? record : { id: `record-${index + 1}`, value: record }));
+}
+
+function normalizeGroups(groups, items, config) {
+  if (Array.isArray(groups) && groups.length > 0) {
+    return groups.map((group, index) => ({
+      key: text(group.key) || text(group.group_key) || text(group.id) || `group-${index + 1}`,
+      index,
+      items: normalizeItems(group.items || []),
+    }));
+  }
+
+  const groupPath = config.group_key_path || config.groupKeyPath || config.group_by || config.groupBy || 'group_key';
+  return groupFanoutItems(items, {
+    group_key: (item) => text(getPath(item, groupPath)) || text(item.groupKey) || text(item.kind) || text(item.id) || 'default',
+  });
+}
+
+function renderTaskRequest(group, orchestrator, config) {
+  const template = config.task_request_template || config.taskRequestTemplate || {};
+  const request = renderValue(template, { group, orchestrator, config });
+  const id = text(request.id) || text(request.task_id) || stableTaskId(group, orchestrator);
+  const runtime = config.runtime || config.runtime_execution || config.runtimeExecution || config.executor || {};
+
+  return stripUndefined({
+    id,
+    group_key: text(request.group_key) || group.key,
+    ...request,
+    orchestrator: {
+      ...orchestrator,
+      group_index: group.index,
+      ...(request.orchestrator || {}),
+    },
+    ...(Object.keys(runtime).length > 0 ? { runtime_execution: renderValue(runtime, { group, orchestrator, config }) } : {}),
+  });
+}
+
+function reconcileRecords({ groups = [], task_requests = [], records = [], outcomes = [], config = {} }) {
+  const successCount = records.filter((record) => isRecordSuccessful(record, config)).length;
+  const failedRecords = records.filter((record) => !isRecordSuccessful(record, config));
+  return {
+    schema: config.reconciliation_schema || config.reconciliationSchema || 'homeboy/generic-fanout-reconcile-reconciliation/v1',
+    group_count: groups.length,
+    task_count: task_requests.length,
+    record_count: records.length,
+    success_count: successCount,
+    failure_count: failedRecords.length,
+    outcome_count: outcomes.length,
+    failed_task_ids: failedRecords.map(taskId).filter(Boolean),
+  };
+}
+
+function isRecordSuccessful(record, config = {}) {
+  const successStatuses = Array.isArray(config.success_statuses) ? config.success_statuses : ['completed', 'success', 'passed'];
+  if (record.success === true) {
+    return true;
+  }
+  return successStatuses.includes(text(record.status));
+}
+
+function taskId(value) {
+  return text(value.id) || text(value.task_id) || text(value.sandbox_session_id) || text(value.group_key);
+}
+
+function stableTaskId(group, orchestrator) {
+  const prefix = text(orchestrator.run_id) || text(orchestrator.plan_id) || 'fanout';
+  return `${prefix}-${group.key}`.replace(/[^a-zA-Z0-9._-]+/g, '-');
+}
+
+function renderValue(value, context) {
+  if (typeof value === 'string') {
+    return renderString(value, context);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => renderValue(entry, context));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, renderValue(entry, context)]));
+  }
+  return value;
+}
+
+function renderString(value, context) {
+  const exact = value.match(/^\{\{\s*([^}]+)\s*\}\}$/);
+  if (exact) {
+    return templateValue(exact[1], context);
+  }
+  return value.replace(/\{\{\s*([^}]+)\s*\}\}/g, (_match, expression) => stringifyTemplateValue(templateValue(expression, context)));
+}
+
+function templateValue(expression, context) {
+  const path = expression.trim();
+  if (path === 'group.item_count') {
+    return context.group.items.length;
+  }
+  if (path === 'group.item_ids') {
+    return context.group.items.map((item) => text(item.id) || text(item.key) || String(item.index + 1));
+  }
+  return getPath(context, path);
+}
+
+function stringifyTemplateValue(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+function getPath(value, pathExpression) {
+  if (!pathExpression) {
+    return undefined;
+  }
+  return String(pathExpression).split('.').reduce((current, part) => {
+    if (current === undefined || current === null) {
+      return undefined;
+    }
+    return current[part];
+  }, value);
+}
+
+function stripUndefined(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function text(value) {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return '';
+}
+
+module.exports = {
+  CONFIG_SCHEMA,
+  RESULT_SCHEMA,
+  createGenericFanoutReconcilePlan,
+  createGenericFanoutReconcileResult,
+  normalizeGroups,
+  renderTaskRequest,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -33,6 +33,7 @@
     "./webperf-evidence-summary": "./lib/webperf-evidence-summary.js",
     "./benchmark-matrix-report": "./lib/benchmark-matrix-report.js",
     "./fanout-reconcile-runner": "./lib/fanout-reconcile-runner.js",
+    "./generic-fanout-reconcile-workflow": "./lib/generic-fanout-reconcile-workflow.js",
     "./static-site-fanout-adapter": "./lib/static-site-fanout-adapter.js",
     "./audit-wp-codebox-fanout": "./lib/audit-wp-codebox-fanout.js",
     "./wordpress-runtime-task-planner": "./lib/wordpress-runtime-task-planner.js"
@@ -67,6 +68,7 @@
     "test:webperf-evidence-summary": "node tests/webperf-evidence-summary-smoke.js",
     "test:benchmark-matrix-report": "node tests/benchmark-matrix-report-smoke.js",
     "test:fanout-reconcile-runner": "node tests/fanout-reconcile-runner-smoke.js",
+    "test:generic-fanout-reconcile-workflow": "node tests/generic-fanout-reconcile-workflow-smoke.js",
     "test:static-site-fanout-adapter": "node tests/static-site-fanout-adapter-smoke.js",
     "test:wordpress-bench-state-sampling": "php tests/wordpress-bench-state-sampling-helper-smoke.php",
     "test:wordpress-bench-artifacts": "php tests/wordpress-bench-artifact-helper-smoke.php",

--- a/wordpress/scripts/agent/homeboy-generic-fanout-reconcile.cjs
+++ b/wordpress/scripts/agent/homeboy-generic-fanout-reconcile.cjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+'use strict';
+
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Internal dependencies
+ */
+const {
+  createGenericFanoutReconcilePlan,
+  createGenericFanoutReconcileResult,
+} = require('../../lib/generic-fanout-reconcile-workflow');
+
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : '';
+}
+
+function hasFlag(name) {
+  return process.argv.includes(name);
+}
+
+function usage() {
+  console.error('Usage: homeboy-generic-fanout-reconcile.cjs --config <config.json> [--items <items.json>] [--records <records.json>] [--plan <plan.json>] [--output <plan-or-result.json>]');
+  process.exit(1);
+}
+
+function readJson(filePath, fallback) {
+  if (!filePath) {
+    return fallback;
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  if (!filePath) {
+    console.log(JSON.stringify(value, null, 2));
+    return;
+  }
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function main() {
+  const configPath = argValue('--config');
+  if (!configPath || hasFlag('--help')) {
+    usage();
+  }
+
+  const config = readJson(configPath, {});
+  const items = readJson(argValue('--items'), config.items || []);
+  const planPath = argValue('--plan');
+  const recordsPath = argValue('--records');
+  const outputPath = argValue('--output');
+
+  if (recordsPath) {
+    const plan = readJson(planPath, null) || createGenericFanoutReconcilePlan({ config, items });
+    const result = await createGenericFanoutReconcileResult({
+      config,
+      plan,
+      records: readJson(recordsPath, []),
+    });
+    writeJson(outputPath, result);
+    return;
+  }
+
+  const plan = createGenericFanoutReconcilePlan({ config, items });
+  writeJson(outputPath || planPath, plan);
+}
+
+main().catch((error) => {
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+});

--- a/wordpress/tests/generic-fanout-reconcile-workflow-smoke.js
+++ b/wordpress/tests/generic-fanout-reconcile-workflow-smoke.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const {
+  createGenericFanoutReconcilePlan,
+  createGenericFanoutReconcileResult,
+} = require('../lib/generic-fanout-reconcile-workflow');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function main() {
+  const config = {
+    schema: 'homeboy/generic-fanout-reconcile-config/v1',
+    orchestrator: {
+      id: 'fixture-orchestrator',
+      run_id: 'fixture-run',
+      plan_id: 'fixture-plan',
+    },
+    group_key_path: 'category',
+    task_request_template: {
+      id: 'task-{{group.key}}',
+      group_key: '{{group.key}}',
+      item_ids: '{{group.item_ids}}',
+      item_count: '{{group.item_count}}',
+      instructions: 'Process {{group.key}} with {{group.item_count}} item(s).',
+      inputs: {
+        items: '{{group.items}}',
+      },
+    },
+    runtime_execution: {
+      backend: 'caller-provided-runtime',
+      task: {
+        name: 'process-generic-group',
+        group: '{{group.key}}',
+      },
+    },
+  };
+  const items = [
+    { id: 'a1', category: 'alpha', payload: { value: 1 } },
+    { id: 'a2', category: 'alpha', payload: { value: 2 } },
+    { id: 'b1', category: 'beta', payload: { value: 3 } },
+  ];
+  const plan = createGenericFanoutReconcilePlan({ config, items });
+
+  assert.equal(plan.schema, 'homeboy/fanout-reconcile-plan/v1');
+  assert.deepEqual(plan.groups.map((group) => group.key), ['alpha', 'beta']);
+  assert.deepEqual(plan.task_requests.map((request) => request.id), ['task-alpha', 'task-beta']);
+  assert.deepEqual(plan.task_requests[0].item_ids, ['a1', 'a2']);
+  assert.equal(plan.task_requests[0].item_count, 2);
+  assert.equal(plan.task_requests[0].runtime_execution.backend, 'caller-provided-runtime');
+  assert.equal(plan.reconciliation.record_count, 0);
+
+  const result = await createGenericFanoutReconcileResult({
+    config,
+    plan,
+    records: [
+      { id: 'task-alpha', group_key: 'alpha', status: 'completed', outcome: { kind: 'processed', item_ids: ['a1', 'a2'] } },
+      { id: 'task-beta', group_key: 'beta', status: 'needs_review', outcome: { kind: 'review', item_ids: ['b1'] } },
+    ],
+  });
+  assert.equal(result.schema, 'homeboy/generic-fanout-reconcile-result/v1');
+  assert.equal(result.status, 'failed');
+  assert.deepEqual(result.records.map((record) => record.id), ['task-alpha', 'task-beta']);
+  assert.equal(result.reconciliation.success_count, 1);
+  assert.deepEqual(result.reconciliation.failed_task_ids, ['task-beta']);
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-generic-fanout-reconcile-'));
+  try {
+    const configPath = path.join(root, 'config.json');
+    const itemsPath = path.join(root, 'items.json');
+    const recordsPath = path.join(root, 'records.json');
+    const planPath = path.join(root, 'plan.json');
+    const resultPath = path.join(root, 'result.json');
+    writeJson(configPath, config);
+    writeJson(itemsPath, items);
+    writeJson(recordsPath, result.records);
+
+    const cliPath = path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-generic-fanout-reconcile.cjs');
+    const planRun = spawnSync(process.execPath, [cliPath, '--config', configPath, '--items', itemsPath, '--output', planPath], { encoding: 'utf8' });
+    assert.equal(planRun.status, 0, planRun.stderr);
+    assert.deepEqual(readJson(planPath), plan);
+
+    const resultRun = spawnSync(process.execPath, [cliPath, '--config', configPath, '--plan', planPath, '--records', recordsPath, '--output', resultPath], { encoding: 'utf8' });
+    assert.equal(resultRun.status, 0, resultRun.stderr);
+    assert.equal(readJson(resultPath).reconciliation.failure_count, 1);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+
+  console.log('Homeboy generic fanout reconcile workflow smoke passed');
+}
+
+main().catch((error) => {
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a domain-neutral generic fanout/reconcile JSON wrapper around the existing runner
- expose a public Node CLI that writes deterministic plans and reconciles caller-supplied task records
- document config/templates/runtime descriptors and add focused smoke coverage

## Tests
- npm run test:generic-fanout-reconcile-workflow
- npm run test:fanout-reconcile-runner
- npm run lint:js -- lib/generic-fanout-reconcile-workflow.js scripts/agent/homeboy-generic-fanout-reconcile.cjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic wrapper, CLI, smoke test, and docs; Chris remains responsible for review and validation.