### PR TITLE
Decouple agent runtime selection from Codebox

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -40,8 +40,8 @@ function buildConfig(env) {
   const runtimeProfiles = parseJsonInput('runtime_profiles', env.RUNTIME_PROFILES || '{}', 'object', {});
   const runtime = resolveRuntimeProvider(runtimeId, { workspace, env });
   const runtimeBin = runtime.paths.runtime_bin;
-  if (!fs.existsSync(runtimeBin)) {
-    throw new Error(`Runtime CLI build missing at ${runtimeBin}`);
+  if (runtimePathRequired(runtime, 'runtime_bin') && (!runtimeBin || !fs.existsSync(runtimeBin))) {
+    throw new Error(`Runtime CLI build missing at ${runtimeBin || 'runtime.paths.runtime_bin'}`);
   }
 
   const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || '', false);
@@ -76,17 +76,18 @@ function buildConfig(env) {
   const runtimeEnv = parseJsonInput('runtime_env', env.RUNTIME_ENV || '{}', 'object', {});
   const runtimeConfig = parseJsonInput('runtime_config', env.RUNTIME_CONFIG || '{}', 'object', {});
   const providerPluginPaths = validationDependencies.providerPluginHostPath ? [validationDependencies.providerPluginHostPath] : [];
-  const codeboxRuntimeProfile = codeboxRuntimeProfilePayload({
+  const resolvedRuntimeProfile = runtimeProfiles[runtimeProfile] || {};
+  const effectiveRuntimeProfile = isCodeboxRuntime(runtime) ? codeboxRuntimeProfilePayload({
     id: runtimeProfile,
-    profile: runtimeProfiles[runtimeProfile],
+    profile: resolvedRuntimeProfile,
     componentContracts,
     runtimeOverlays,
     runtimeEnv,
     providerPluginPaths,
-  });
+  }) : resolvedRuntimeProfile;
   const effectiveRuntimeProfiles = {
     ...runtimeProfiles,
-    [runtimeProfile]: codeboxRuntimeProfile,
+    [runtimeProfile]: effectiveRuntimeProfile,
   };
   const runnerWorkspace = parseJsonInput('runner_workspace', env.RUNNER_WORKSPACE_CONFIG || '{}', 'object', {});
   const runnerWorkspaceRepo = targetRepo.split('/')[1].replace(/\.git$/, '');
@@ -131,14 +132,14 @@ function buildConfig(env) {
     model: env.MODEL || '',
     provider_register_function: providerPlugin.register_function || '',
     provider_credentials: providerCredentials,
-    runtime_bin: runtimeBin,
+    ...(runtimeBin ? { runtime_bin: runtimeBin } : {}),
     runtime_components: {
-      runtime: runtime.paths.runtime_component,
+      ...(runtime.paths.runtime_component ? { runtime: runtime.paths.runtime_component } : {}),
       ...runtimeComponents,
     },
     runtime_component_paths: runtimeComponents,
     provider_plugin_paths: providerPluginPaths,
-    runtime_requirements: codeboxRuntimeProfile,
+    runtime_requirements: effectiveRuntimeProfile,
     github_token_env: 'HOMEBOY_GITHUB_APP_TOKEN',
     github_repository_token_env: 'GITHUB_TOKEN',
     github_profile_id: env.GITHUB_PROFILE_ID || `${workloadId}-ci`,
@@ -232,6 +233,15 @@ function runtimeTaskFromEnv(env) {
   );
 }
 
+function isCodeboxRuntime(runtime) {
+  return runtime?.id === 'wp-codebox' || runtime?.executor?.backend === 'codebox';
+}
+
+function runtimePathRequired(runtime, pathName) {
+  const requiredPaths = runtime?.manifest?.ci_materialization?.required_paths;
+  return isCodeboxRuntime(runtime) || (Array.isArray(requiredPaths) && requiredPaths.includes(pathName));
+}
+
 function withoutInternalKeys(config) {
   return Object.fromEntries(Object.entries(config).filter(([key]) => !key.startsWith('_')));
 }
@@ -243,11 +253,13 @@ function required(value, name) {
   return value;
 }
 
-try {
-  main();
-} catch (error) {
-  process.stderr.write(`${error.message}\n`);
-  process.exit(1);
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  }
 }
 
-module.exports = { buildConfig };
+module.exports = { buildConfig, isCodeboxRuntime, runtimePathRequired };

--- a/agent-runtimes/lib/agent-task-runner-contract.js
+++ b/agent-runtimes/lib/agent-task-runner-contract.js
@@ -8,7 +8,7 @@ function agentTaskRunnerSpec(options = {}) {
     throw new Error('config is required.');
   }
 
-  const backend = requiredString(options.backend || 'codebox', 'backend');
+  const backend = requiredString(options.backend, 'backend');
   const taskTimeoutSeconds = options.taskTimeoutSeconds || options.task_timeout_seconds;
   const limits = stripUndefined({
     ...(taskTimeoutSeconds ? { task_timeout_seconds: taskTimeoutSeconds } : {}),

--- a/agent-runtimes/lib/runtime-provider-resolver.cjs
+++ b/agent-runtimes/lib/runtime-provider-resolver.cjs
@@ -19,10 +19,54 @@ function runtimeManifestPath(runtimeId, repoRoot = repoRootFromHere()) {
 
 function runtimeRegistry(options = {}) {
 	const repoRoot = options.repoRoot || repoRootFromHere();
-	const manifests = {
-		[DEFAULT_RUNTIME_ID]: readJson(runtimeManifestPath(DEFAULT_RUNTIME_ID, repoRoot)),
-	};
+	const manifests = {};
+	const runtimesRoot = path.join(repoRoot, 'agent-runtimes');
+	for (const manifestPath of runtimeManifestPaths(runtimesRoot)) {
+		let manifest;
+		try {
+			manifest = readJson(manifestPath);
+		} catch {
+			continue;
+		}
+		if (!isRuntimeManifest(manifest)) {
+			continue;
+		}
+		manifests[manifest.id] = manifest;
+	}
 	return manifests;
+}
+
+function runtimeManifestPaths(runtimesRoot) {
+	let entries;
+	try {
+		entries = fs.readdirSync(runtimesRoot, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	return entries
+		.filter((entry) => entry.isDirectory())
+		.flatMap((entry) => {
+			const runtimeDir = path.join(runtimesRoot, entry.name);
+			try {
+				return fs.readdirSync(runtimeDir, { withFileTypes: true })
+					.filter((candidate) => candidate.isFile() && candidate.name.endsWith('.json'))
+					.map((candidate) => path.join(runtimeDir, candidate.name));
+			} catch {
+				return [];
+			}
+		});
+}
+
+function isRuntimeManifest(manifest) {
+	return Boolean(
+		manifest &&
+		typeof manifest === 'object' &&
+		!Array.isArray(manifest) &&
+		manifest.schema === 'homeboy/agent-runtime-manifest/v1' &&
+		typeof manifest.id === 'string' &&
+		manifest.id.trim() !== '' &&
+		Array.isArray(manifest.agent_task_executors)
+	);
 }
 
 function resolveRuntimeProvider(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
@@ -87,12 +131,21 @@ function resolvePaths(paths, workspace) {
 
 function resolveExecutor(manifest, repoRoot) {
 	const provider = Array.isArray(manifest.agent_task_executors) ? manifest.agent_task_executors[0] : null;
-	const argv = provider?.invocation?.argv || [];
-	const scriptArg = argv.find((arg) => typeof arg === 'string' && arg.includes('{{runtime_path}}')) || '';
+	const scriptArg = executorScriptArg(provider);
 	return {
 		backend: provider?.backend || '',
 		path: scriptArg ? scriptArg.replace('{{runtime_path}}', path.join(repoRoot, 'agent-runtimes', manifest.id)) : '',
 	};
+}
+
+function executorScriptArg(provider) {
+	const argv = provider?.invocation?.argv || [];
+	const invocationArg = argv.find((arg) => typeof arg === 'string' && arg.includes('{{runtime_path}}')) || '';
+	if (invocationArg) {
+		return invocationArg;
+	}
+	const command = provider?.command || '';
+	return command.split(/\s+/).find((arg) => arg.includes('{{runtime_path}}')) || '';
 }
 
 module.exports = {

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -60,7 +60,7 @@ function runtimeAgentCiRunnerSpec(options = {}, context = {}) {
   const taskExecutorConfig = context.taskExecutorConfig || runtimeAgentCiTaskExecutorConfig;
   const config = taskExecutorConfig(options);
   return agentTaskRunnerSpec({
-    backend: options.backend || options.runtimeProvider || options.runtime_provider || 'codebox',
+    backend: options.backend || options.runtimeBackend || options.runtime_backend,
     config,
     secret_env: normalizeArray(config.secret_env),
     task_timeout_seconds: config.task_timeout_seconds || options.taskTimeoutSeconds || options.task_timeout_seconds || 900,

--- a/tests/datamachine-agent-ci-build-runner-config-smoke.mjs
+++ b/tests/datamachine-agent-ci-build-runner-config-smoke.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { buildConfig } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/build-runner-config.cjs'));
+
+const runtimeProfile = {
+  schema: 'homeboy/runtime-profile/v1',
+  id: 'datamachine-agent-ci',
+  runtime_task_ability: 'datamachine/run-agent-bundle',
+  ability_requirements: ['datamachine/run-agent-bundle'],
+};
+
+function baseEnv(workspace, runnerTemp) {
+  return {
+    GITHUB_WORKSPACE: workspace,
+    RUNNER_TEMP: runnerTemp,
+    WORKLOAD_ID: 'datamachine-agent-ci-smoke',
+    TARGET_REPO: 'example/repo',
+    RUNTIME_PROFILE: runtimeProfile.id,
+    RUNTIME_PROFILES: JSON.stringify({ [runtimeProfile.id]: runtimeProfile }),
+  };
+}
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-datamachine-agent-ci-config-'));
+const codeboxWorkspace = path.join(root, 'codebox-workspace');
+const fakeWorkspace = path.join(root, 'fake-workspace');
+const runnerTemp = path.join(root, 'runner-temp');
+fs.mkdirSync(path.join(codeboxWorkspace, '.ci/wp-codebox/packages/cli/dist'), { recursive: true });
+fs.mkdirSync(fakeWorkspace, { recursive: true });
+fs.mkdirSync(runnerTemp, { recursive: true });
+fs.writeFileSync(path.join(codeboxWorkspace, '.ci/wp-codebox/packages/cli/dist/index.js'), '#!/usr/bin/env node\n');
+
+const codeboxConfig = buildConfig({
+  ...baseEnv(codeboxWorkspace, runnerTemp),
+  RUNTIME_PROVIDER: 'wp-codebox',
+});
+
+assert.equal(codeboxConfig.runtime_profiles[runtimeProfile.id].schema, 'wp-codebox/runtime-profile/v1');
+assert.equal(codeboxConfig.runtime_profiles[runtimeProfile.id].homeboy_profile_schema, 'homeboy/runtime-profile/v1');
+assert.equal(codeboxConfig.runtime_requirements.schema, 'wp-codebox/runtime-profile/v1');
+assert.equal(codeboxConfig.runtime_bin, path.join(codeboxWorkspace, '.ci/wp-codebox/packages/cli/dist/index.js'));
+
+const fakeConfig = buildConfig({
+  ...baseEnv(fakeWorkspace, runnerTemp),
+  RUNTIME_PROVIDER: 'fake-runtime',
+});
+
+assert.equal(fakeConfig.runtime_profiles[runtimeProfile.id].schema, 'homeboy/runtime-profile/v1');
+assert.deepEqual(fakeConfig.runtime_requirements, runtimeProfile);
+assert.equal(Object.hasOwn(fakeConfig, 'runtime_bin'), false);
+assert.equal(JSON.stringify(fakeConfig).includes('wp-codebox/'), false);
+
+console.log('datamachine agent CI build runner config smoke passed');

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -140,6 +140,8 @@ assert.equal(genericWorkflowConfig.runtime_task.input.dry_run, true);
 
 const genericRequest = runtimeAgentCi.runtimeAgentCiAbilityTaskRequest({
   taskId: 'task-1',
+  backend: 'codebox',
+  runtimeProvider: 'codebox',
   runtimeProfile: runtimeProfile.id,
   runtimeProfiles: { [runtimeProfile.id]: runtimeProfile },
   ability: 'example/run-task',

--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -20,6 +20,7 @@ module.exports = {
 	...require('./lib/static-site-fanout-adapter'),
 	...require('./lib/agent-terminal-actions'),
 	...require('./lib/agent-task-runner-spec'),
+	...require('./lib/datamachine-agent-ci-codebox-adapter'),
 	...require('./lib/datamachine-agent-ci-plan'),
 	...require('./lib/wp-codebox-apply-adapter'),
 	...require('./lib/wp-codebox-recipe-helper'),

--- a/wordpress/lib/datamachine-agent-ci-codebox-adapter.js
+++ b/wordpress/lib/datamachine-agent-ci-codebox-adapter.js
@@ -19,8 +19,11 @@ function datamachineAgentCiCodeboxExecutorConfig(config = {}) {
   };
 }
 
+const datamachineAgentCiExecutorConfig = datamachineAgentCiCodeboxExecutorConfig;
+
 module.exports = {
   DATAMACHINE_AGENT_CI_RUNTIME_PROFILE,
   DATAMACHINE_AGENT_CI_RUNTIME_PROFILE_ID,
+  datamachineAgentCiExecutorConfig,
   datamachineAgentCiCodeboxExecutorConfig,
 };

--- a/wordpress/lib/datamachine-agent-ci-plan.js
+++ b/wordpress/lib/datamachine-agent-ci-plan.js
@@ -9,21 +9,28 @@ const {
 const datamachineAgentCi = require('../../datamachine-agent-ci');
 
 function datamachineAgentCiBundleTaskRequest(options = {}) {
-  return datamachineAgentCi.datamachineAgentCiBundleTaskRequest(options, {
+  return datamachineAgentCi.datamachineAgentCiBundleTaskRequest(datamachineAgentCiCodeboxOptions(options), {
     taskExecutorConfig: datamachineAgentCiTaskExecutorConfig,
   });
 }
 
 function datamachineAgentCiAbilityTaskRequest(options = {}) {
-  return datamachineAgentCi.datamachineAgentCiAbilityTaskRequest(options, {
+  return datamachineAgentCi.datamachineAgentCiAbilityTaskRequest(datamachineAgentCiCodeboxOptions(options), {
     taskExecutorConfig: datamachineAgentCiTaskExecutorConfig,
   });
 }
 
 function datamachineAgentCiRunnerSpec(options = {}) {
-  return datamachineAgentCi.datamachineAgentCiRunnerSpec(options, {
+  return datamachineAgentCi.datamachineAgentCiRunnerSpec(datamachineAgentCiCodeboxOptions(options), {
     taskExecutorConfig: datamachineAgentCiTaskExecutorConfig,
   });
+}
+
+function datamachineAgentCiCodeboxOptions(options = {}) {
+  return {
+    ...options,
+    backend: options.backend || options.runtimeBackend || options.runtime_backend || 'codebox',
+  };
 }
 
 function datamachineAgentCiTaskExecutorConfig(options = {}) {

--- a/wordpress/lib/static-site-fanout-adapter.js
+++ b/wordpress/lib/static-site-fanout-adapter.js
@@ -17,9 +17,9 @@ const RECONCILIATION_SCHEMA = 'homeboy/static-site-fanout-reconciliation/v1';
 const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
 const WP_CODEBOX_TASK_SCHEMA = 'wp-codebox/task-input/v1';
 const DEFAULT_PRESET = 'static-site/import-validation';
+const COMPATIBILITY_AGENT_TASK_BACKEND = 'codebox';
 const DEFAULT_AGENT_TASK_PRESET = {
   runtime_task: 'static-site/import-validation',
-  backend: 'codebox',
 };
 
 function createStaticSiteFanoutPlan(input = {}) {
@@ -59,7 +59,7 @@ function createStaticSiteFanoutPlan(input = {}) {
 
 function normalizeOrchestrator(input) {
   const preset = input.preset || input.controller?.preset || DEFAULT_PRESET;
-  return {
+  return stripUndefined({
     id: input.orchestrator_id || input.orchestrator?.id || 'homeboy-extensions/static-site-fanout-adapter',
     run_id: input.run_id || input.orchestrator?.run_id || input.controller?.run_id || 'static-site-fanout-run',
     plan_id: input.plan_id || input.orchestrator?.plan_id || input.controller?.loop_id || 'static-site-fanout-plan',
@@ -69,10 +69,11 @@ function normalizeOrchestrator(input) {
     parent_plan_id: input.parent_plan_id || input.parentPlanId || input.orchestrator?.parent_plan_id || '',
     provider: input.provider || '',
     model: input.model || '',
+    backend: input.backend || input.runtime_backend || input.runtimeBackend || input.agent_runtime_backend || input.agentRuntimeBackend || undefined,
     provider_plugin_paths: normalizeArray(input.provider_plugin_paths || input.providerPluginPaths),
     secret_env: normalizeArray(input.secret_env || input.secretEnv),
     request_schema: requestSchema(input.request_kind || input.requestKind || 'agent-task'),
-  };
+  });
 }
 
 function normalizeFindings(findings) {
@@ -142,6 +143,7 @@ function createTaskRequest(group, orchestrator, options = {}) {
 function createAgentTaskRequest(group, orchestrator, options = {}) {
   const runtime = {
     ...DEFAULT_AGENT_TASK_PRESET,
+    backend: orchestrator.backend || COMPATIBILITY_AGENT_TASK_BACKEND,
     ...(options.agent_task || options.agentTask || {}),
   };
   const taskId = taskIdForGroup(group, orchestrator, 'static-site');
@@ -159,7 +161,7 @@ function createAgentTaskRequest(group, orchestrator, options = {}) {
     group_key: group.key,
     parent_plan_id: orchestrator.parent_plan_id || orchestrator.plan_id,
     executor: stripUndefined({
-      backend: runtime.backend || 'codebox',
+      backend: runtime.backend || COMPATIBILITY_AGENT_TASK_BACKEND,
       secret_env: orchestrator.secret_env.length > 0 ? orchestrator.secret_env : undefined,
       config: stripUndefined({
         provider: orchestrator.provider || undefined,
@@ -481,6 +483,7 @@ module.exports = {
   AGENT_TASK_REQUEST_SCHEMA,
   WP_CODEBOX_TASK_SCHEMA,
   DEFAULT_PRESET,
+  COMPATIBILITY_AGENT_TASK_BACKEND,
   createStaticSiteFanoutPlan,
   executeStaticSiteFanout,
   normalizeArtifactRefs,

--- a/wordpress/lib/wordpress-runtime-task-planner.js
+++ b/wordpress/lib/wordpress-runtime-task-planner.js
@@ -17,7 +17,8 @@ const {
 } = require('../../agent-runtimes/lib/agent-task-runner-contract');
 
 const WORDPRESS_RUNTIME_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
-const WORDPRESS_RUNTIME_TASK_DEFAULT_BACKEND = 'codebox';
+const WORDPRESS_RUNTIME_TASK_COMPATIBILITY_BACKEND = 'codebox';
+const WORDPRESS_RUNTIME_TASK_DEFAULT_BACKEND = WORDPRESS_RUNTIME_TASK_COMPATIBILITY_BACKEND;
 const WORDPRESS_RUNTIME_TASK_DEFAULT_POLICY = {
 	read: 'sandbox',
 	write: 'sandbox',
@@ -26,10 +27,12 @@ const WORDPRESS_RUNTIME_TASK_DEFAULT_POLICY = {
 
 function wordpressRuntimeTaskPlan(options = {}) {
 	const planId = requiredString(options.planId || options.plan_id, 'planId');
+	const backend = wordpressRuntimeTaskBackend(options);
 	const taskOptions = normalizeTaskOptions(options);
 	const tasks = taskOptions.map((taskOption, index) => wordpressRuntimeTaskRequest({
 		...options,
 		...taskOption,
+		backend: wordpressRuntimeTaskBackend({ ...options, ...taskOption }, backend),
 		planId,
 		parentPlanId: planId,
 		taskId: taskOption.taskId || taskOption.task_id || taskIdForPlan(planId, index, taskOption),
@@ -48,7 +51,7 @@ function wordpressRuntimeTaskPlan(options = {}) {
 			...(options.metadata || {}),
 			planner: 'homeboy-extension-wordpress/wordpress-runtime-task-planner',
 			runtime: options.runtime || options.runtimeId || options.runtime_id,
-			backend: options.backend || WORDPRESS_RUNTIME_TASK_DEFAULT_BACKEND,
+			backend,
 		}),
 	});
 }
@@ -94,13 +97,17 @@ function wordpressRuntimeTaskRequest(options = {}) {
 function wordpressRuntimeTaskRunnerSpec(options = {}) {
 	const config = wordpressRuntimeTaskExecutorConfig(options);
 	return agentTaskRunnerSpec({
-		backend: options.backend || WORDPRESS_RUNTIME_TASK_DEFAULT_BACKEND,
+		backend: wordpressRuntimeTaskBackend(options),
 		config,
 		secret_env: normalizeArray(options.secretEnv || options.secret_env),
 		task_timeout_seconds: numberOrUndefined(options.taskTimeoutSeconds || options.task_timeout_seconds || options.timeoutSeconds || options.timeout_seconds),
 		limits: options.limits,
 		expected_artifacts: options.expectedArtifacts || options.expected_artifacts,
 	});
+}
+
+function wordpressRuntimeTaskBackend(options = {}, fallback = WORDPRESS_RUNTIME_TASK_COMPATIBILITY_BACKEND) {
+	return options.backend || options.runtimeBackend || options.runtime_backend || options.agentRuntimeBackend || options.agent_runtime_backend || fallback;
 }
 
 function wordpressRuntimeTaskExecutorConfig(options = {}) {
@@ -207,8 +214,10 @@ function stripUndefined(value) {
 
 module.exports = {
 	WORDPRESS_RUNTIME_TASK_DEFAULT_BACKEND,
+	WORDPRESS_RUNTIME_TASK_COMPATIBILITY_BACKEND,
 	WORDPRESS_RUNTIME_TASK_DEFAULT_POLICY,
 	WORDPRESS_RUNTIME_TASK_PLAN_SCHEMA,
+	wordpressRuntimeTaskBackend,
 	wordpressRuntimeTaskExecutorConfig,
 	wordpressRuntimeTaskPlan,
 	wordpressRuntimeTaskRequest,

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -21,6 +21,8 @@
     "./agent-terminal-actions": "./lib/agent-terminal-actions.js",
     "./agent-task-runner-spec": "./lib/agent-task-runner-spec.js",
     "./datamachine-agent-ci-plan": "./lib/datamachine-agent-ci-plan.js",
+    "./datamachine-agent-ci-codebox-adapter": "./lib/datamachine-agent-ci-codebox-adapter.js",
+    "./datamachine-agent-ci-runtime-adapter": "./lib/datamachine-agent-ci-codebox-adapter.js",
     "./timing-correlator": "./lib/timing-correlator.js",
     "./codebox-memory-report": "./lib/codebox-memory-report.js",
     "./wp-codebox-apply-adapter": "./lib/wp-codebox-apply-adapter.js",

--- a/wordpress/scripts/agent/run-runtime-agent-task.cjs
+++ b/wordpress/scripts/agent/run-runtime-agent-task.cjs
@@ -65,7 +65,7 @@ function expectedArtifactsFromConfig(config) {
     .filter(Boolean);
 }
 
-function buildAgentTaskRequest(config, configPath) {
+function buildAgentTaskRequest(config, configPath, runtime) {
   const taskId = config.task_id || config.workload_id || 'runtime-agent-full-run';
   const timeoutMs = Number.parseInt(config.time_budget_ms || '', 10);
   const timeoutSeconds = Number.parseInt(config.task_timeout_seconds || config.taskTimeoutSeconds || '', 10);
@@ -112,7 +112,7 @@ function buildAgentTaskRequest(config, configPath) {
       },
     },
     executor: {
-      backend: 'codebox',
+      backend: runtime.executor.backend,
       model: config.model || '',
       config: executorConfig,
       secret_env: config.secret_env || [],
@@ -171,7 +171,7 @@ try {
   const configPath = readConfigPath();
   const config = readJson(configPath);
   const runtime = resolveRuntimeProvider(config.runtime_id || process.env.RUNTIME_PROVIDER || 'wp-codebox', { repoRoot: REPO_ROOT, workspace: config.component_path || process.cwd() });
-  const request = buildAgentTaskRequest(config, configPath);
+  const request = buildAgentTaskRequest(config, configPath, runtime);
   const result = spawnSync(process.execPath, [runtime.executor.path], {
     encoding: 'utf8',
     input: JSON.stringify(request),

--- a/wordpress/tests/datamachine-agent-ci-plan-smoke.js
+++ b/wordpress/tests/datamachine-agent-ci-plan-smoke.js
@@ -149,6 +149,15 @@ assert.deepEqual(agentTaskRequestFromRunnerSpec({ runnerSpec: bundleRunnerSpec }
 });
 assert.equal(validateAgentTaskRunnerSpec(bundleRunnerSpec), bundleRunnerSpec);
 
+assert.equal(datamachineAgentCiRunnerSpec({
+  taskId: 'wp-codebox-runtime-id',
+  runtimeProvider: 'wp-codebox',
+  source: '/workspace/example-repo/bundles/concept-agent',
+  agentSlug: 'concept-agent',
+  pipelineSlug: 'concept-pipeline',
+  flowSlug: 'concept-flow',
+}).executor.backend, 'codebox');
+
 const abilityTask = datamachineAgentCiAbilityTaskRequest({
   taskId: 'validate-artifact',
   ability: 'example/validate-artifact',

--- a/wordpress/tests/generic-agent-runtime-contract.test.js
+++ b/wordpress/tests/generic-agent-runtime-contract.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+	resolveRuntimeProvider,
+	runtimeRegistry,
+} = require('../../agent-runtimes/lib/runtime-provider-resolver.cjs');
+const {
+	agentTaskRunnerSpec,
+} = require('../../agent-runtimes/lib/agent-task-runner-contract');
+const {
+	runtimeAgentCiRunnerSpec,
+} = require('../../runtime-agent-ci');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const registry = runtimeRegistry({ repoRoot });
+
+assert.equal(registry['wp-codebox'].id, 'wp-codebox');
+assert.equal(registry['fake-runtime'].id, 'fake-runtime');
+assert.equal(registry['package'], undefined);
+assert.equal(registry['homeboy-agent-task-core-contract'], undefined);
+
+const fakeRuntime = resolveRuntimeProvider('fake-runtime', { repoRoot, registry });
+assert.equal(fakeRuntime.id, 'fake-runtime');
+assert.equal(fakeRuntime.executor.backend, 'fake-runtime');
+assert.equal(fakeRuntime.executor.path, path.join(repoRoot, 'agent-runtimes/fake-runtime/scripts/agent/fake-agent-task-executor.cjs'));
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-runtime-registry-'));
+try {
+	const runtimesRoot = path.join(tmpRoot, 'agent-runtimes');
+	fs.mkdirSync(path.join(runtimesRoot, 'valid-runtime'), { recursive: true });
+	fs.mkdirSync(path.join(runtimesRoot, 'invalid-runtime'), { recursive: true });
+	fs.writeFileSync(path.join(runtimesRoot, 'valid-runtime', 'valid-runtime.json'), JSON.stringify({
+		schema: 'homeboy/agent-runtime-manifest/v1',
+		id: 'valid-runtime',
+		agent_task_executors: [],
+	}));
+	fs.writeFileSync(path.join(runtimesRoot, 'invalid-runtime', 'invalid-runtime.json'), JSON.stringify({
+		schema: 'homeboy/agent-runtime-manifest/v1',
+		name: 'missing id and executors',
+	}));
+	fs.writeFileSync(path.join(runtimesRoot, 'invalid-runtime', 'broken.json'), '{');
+
+	const isolatedRegistry = runtimeRegistry({ repoRoot: tmpRoot });
+	assert.deepEqual(Object.keys(isolatedRegistry), ['valid-runtime']);
+} finally {
+	fs.rmSync(tmpRoot, { recursive: true, force: true });
+}
+
+assert.throws(
+	() => agentTaskRunnerSpec({ config: {} }),
+	/backend is required/
+);
+assert.equal(
+	agentTaskRunnerSpec({ backend: 'fake-runtime', config: {} }).executor.backend,
+	'fake-runtime'
+);
+
+const runtimeProfile = {
+	id: 'example-runtime-ci',
+	runtime_task_ability: 'example/run-task',
+};
+assert.throws(
+	() => runtimeAgentCiRunnerSpec({
+		ability: 'example/run-task',
+		runtimeProfile: 'example-runtime-ci',
+		runtimeProfiles: { 'example-runtime-ci': runtimeProfile },
+	}),
+	/backend is required/
+);
+assert.equal(
+	runtimeAgentCiRunnerSpec({
+		backend: 'fake-runtime',
+		ability: 'example/run-task',
+		runtimeProfile: 'example-runtime-ci',
+		runtimeProfiles: { 'example-runtime-ci': runtimeProfile },
+	}).executor.backend,
+	'fake-runtime'
+);
+
+process.stdout.write('Generic agent runtime contract passed\n');

--- a/wordpress/tests/static-site-fanout-adapter-smoke.js
+++ b/wordpress/tests/static-site-fanout-adapter-smoke.js
@@ -37,6 +37,14 @@ async function main() {
   assert.equal(plan.task_requests[0].inputs.finding_ids.length, 2);
   assert.equal(plan.task_requests[0].inputs.artifact_refs[0].kind, 'diagnostic');
 
+  const genericBackendPlan = createStaticSiteFanoutPlan({
+    run_id: 'generic-backend-run',
+    backend: 'opencode',
+    findings: [findings[0]],
+  });
+  assert.equal(genericBackendPlan.orchestrator.backend, 'opencode');
+  assert.equal(genericBackendPlan.task_requests[0].executor.backend, 'opencode');
+
   const codeboxPlan = createStaticSiteFanoutPlan({
     run_id: 'fixture-run',
     request_kind: 'wp-codebox',

--- a/wordpress/tests/wordpress-runtime-task-planner-smoke.js
+++ b/wordpress/tests/wordpress-runtime-task-planner-smoke.js
@@ -59,6 +59,16 @@ for (const task of plan.tasks) {
 assert.deepEqual(plan.tasks.map((task) => task.metadata.fanout.scenario), ['import', 'verify']);
 assert(!JSON.stringify(plan).includes('/Users/'), 'planner must not inject local user paths');
 
+const genericBackendPlan = wordpressRuntimeTaskPlan({
+	planId: 'runtime-task-generic-backend-smoke',
+	ability: 'datamachine/run-runtime-task',
+	runtimeBackend: 'opencode',
+	runtimeId: 'opencode-local',
+});
+assert.equal(genericBackendPlan.metadata.backend, 'opencode');
+assert.equal(genericBackendPlan.tasks[0].executor.backend, 'opencode');
+assert.equal(genericBackendPlan.tasks[0].executor.config.runtime_id, 'opencode-local');
+
 const request = wordpressRuntimeTaskRequest({
 	taskId: 'single-runtime-task-smoke',
 	ability: 'example/materialize-artifact',


### PR DESCRIPTION
## Summary
- discover agent runtime manifests instead of registering only wp-codebox
- require explicit generic executor backends while preserving WordPress/Codebox compatibility defaults at domain boundaries
- pass non-Codebox runtime profiles through without emitting wp-codebox schemas, and execute runtime tasks with the selected manifest backend

## Tests
- node tests/runtime-provider-resolver-smoke.mjs
- node tests/runtime-agent-ci-contract-smoke.mjs
- node tests/datamachine-agent-ci-build-runner-config-smoke.mjs
- node wordpress/tests/generic-agent-runtime-contract.test.js
- npm run test:wordpress-runtime-task-planner
- npm run test:static-site-fanout-adapter
- npm run test:datamachine-agent-ci-plan

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated Codebox coupling, drafted the refactor, integrated scoped agent outputs, and ran targeted verification. Chris remains responsible for review and merge.