### PR TITLE
Register OpenCode agent runtime

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -31,6 +31,7 @@ const OPENCODE_CAPABILITIES = [
 	'provider_owned_auth',
 	'provider_owned_session',
 	'provider_owned_cancellation',
+	'nested_orchestrator',
 ];
 
 function providerContract(options = {}) {

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -1,0 +1,111 @@
+{
+  "schema": "homeboy/agent-runtime-manifest/v1",
+  "id": "opencode",
+  "name": "OpenCode",
+  "version": "1.0.0",
+  "description": "Experimental OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.",
+  "agent_task_executors": [
+    {
+      "schema": "homeboy/agent-task-executor-provider/v1",
+      "id": "opencode.agent-task-executor",
+      "label": "OpenCode agent task executor",
+      "backend": "opencode",
+      "command": "node {{runtime_path}}/scripts/agent/homeboy-opencode-agent-task-executor.cjs",
+      "request_schema": "homeboy/agent-task-request/v1",
+      "outcome_schema": "homeboy/agent-task-outcome/v1",
+      "request_required_fields": [
+        "schema",
+        "task_id",
+        "executor.backend",
+        "instructions"
+      ],
+      "outcome_statuses": [
+        "succeeded",
+        "no_op",
+        "unable_to_remediate",
+        "provider_error",
+        "timeout",
+        "failed",
+        "follow_up_issue",
+        "cancelled"
+      ],
+      "failure_classifications": [
+        "provider",
+        "timeout",
+        "policy_denied",
+        "capability_missing",
+        "invalid_input",
+        "execution_failed",
+        "unknown"
+      ],
+      "redacted_metadata_keys": [
+        "secret_env_values",
+        "secretEnvValues",
+        "secrets",
+        "codex_auth",
+        "opencode_auth"
+      ],
+      "secret_env_requirements": [
+        {
+          "schema": "homeboy/secret-env-requirement/v1",
+          "source": "provider_default",
+          "env": [
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT",
+            "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID",
+            "AI_PROVIDER_OPENAI_CODEX_FEDRAMP"
+          ],
+          "when": {
+            "any": [
+              { "path": "executor.config.provider", "equals": "codex" },
+              { "path": "executor.provider", "equals": "codex" },
+              { "path": "provider", "equals": "codex" }
+            ]
+          }
+        }
+      ],
+      "capabilities": [
+        "cli_runtime",
+        "repo_workspace",
+        "workspace_tools",
+        "patch_artifacts",
+        "report_artifacts",
+        "structured_outcome",
+        "provider_owned_auth",
+        "provider_owned_session",
+        "provider_owned_cancellation",
+        "nested_orchestrator"
+      ],
+      "workspace_materialization": {
+        "cwd": "git_checkout"
+      },
+      "provider_defaults": {
+        "codex": {
+          "model": "gpt-5.5",
+          "secret_env": [
+            "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN",
+            "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT",
+            "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID",
+            "AI_PROVIDER_OPENAI_CODEX_FEDRAMP"
+          ]
+        }
+      },
+      "lifecycle": {
+        "completion": "synchronous_process",
+        "cancellation": "provider_signal",
+        "max_concurrency_default": 1
+      },
+      "artifact_contract": {
+        "patch": ["git-diff", "patch"],
+        "report": ["json", "markdown"]
+      },
+      "status": "experimental",
+      "integration_contract": "homeboy-opencode-agent-task/v1",
+      "runtime_gap_trackers": [
+        "https://github.com/Extra-Chill/homeboy-extensions/issues/967"
+      ]
+    }
+  ]
+}

--- a/tests/runtime-provider-resolver-smoke.mjs
+++ b/tests/runtime-provider-resolver-smoke.mjs
@@ -16,6 +16,7 @@ const {
 const registry = runtimeRegistry({ repoRoot: rootDir });
 assert.equal(DEFAULT_RUNTIME_ID, 'wp-codebox');
 assert.ok(registry['wp-codebox'], 'wp-codebox is registered as the default runtime provider');
+assert.ok(registry.opencode, 'opencode is registered as a selectable runtime provider');
 
 const runtime = resolveRuntimeProvider('wp-codebox', {
 	repoRoot: rootDir,
@@ -34,6 +35,17 @@ assert.equal(runtime.paths.runtime_bin, path.join(workspace, '.ci/wp-codebox/pac
 assert.equal(runtime.paths.runtime_component, path.join(workspace, '.ci/wp-codebox/packages/wordpress-plugin'));
 assert.equal(runtime.executor.backend, 'codebox');
 assert.equal(runtime.executor.path, path.join(rootDir, 'agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs'));
+
+const opencodeRuntime = resolveRuntimeProvider('opencode', {
+	repoRoot: rootDir,
+	workspace,
+});
+assert.equal(opencodeRuntime.id, 'opencode');
+assert.equal(opencodeRuntime.checkout.repo, '');
+assert.equal(opencodeRuntime.executor.backend, 'opencode');
+assert.equal(opencodeRuntime.executor.path, path.join(rootDir, 'agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs'));
+assert.equal(opencodeRuntime.manifest.agent_task_executors[0].status, 'experimental');
+assert.equal(opencodeRuntime.manifest.agent_task_executors[0].capabilities.includes('nested_orchestrator'), true);
 
 assert.throws(
 	() => resolveRuntimeProvider('missing-runtime', { repoRoot: rootDir, workspace }),

--- a/wordpress/tests/opencode-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/opencode-agent-task-executor-boundary.test.js
@@ -39,28 +39,32 @@ assert.equal(provider.capabilities.includes('repo_workspace'), true);
 assert.equal(provider.capabilities.includes('patch_artifacts'), true);
 assert.equal(provider.capabilities.includes('browser_runtime'), false);
 
-const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'wordpress.json'), 'utf8'));
-const runtime = manifest.agent_runtimes.find((candidate) => candidate.id === 'opencode');
-assert(runtime, 'WordPress manifest declares the OpenCode agent runtime');
-assert.equal(runtime.label, 'OpenCode');
-assert.equal(runtime.agent_task_executors.length, 1);
-assert.deepEqual(runtime.agent_task_executors[0], providerContract({
-	command: 'node {{extension_path}}/scripts/agent/homeboy-opencode-agent-task-executor.cjs',
-}));
+const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'agent-runtimes', 'opencode', 'opencode.json'), 'utf8'));
+assert.equal(manifest.id, 'opencode');
+assert.equal(manifest.name, 'OpenCode');
+assert.equal(manifest.agent_task_executors.length, 1);
+assert.equal(manifest.agent_task_executors[0].capabilities.includes('nested_orchestrator'), true);
+assert.deepEqual(manifest.agent_task_executors[0], providerContract());
+
+const runtime = {
+  agent_task_executors: [providerContract({
+    command: 'node {{runtime_path}}/scripts/agent/homeboy-opencode-agent-task-executor.cjs',
+  })],
+};
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-opencode-provider-contract-'));
 try {
-	const extensionsRoot = path.join(root, 'extensions');
-	const extensionPath = path.join(extensionsRoot, 'wordpress');
-	fs.mkdirSync(extensionsRoot, { recursive: true });
-	fs.symlinkSync(path.join(__dirname, '..'), extensionPath, 'dir');
+	const runtimesRoot = path.join(root, 'agent-runtimes');
+	const runtimePath = path.join(runtimesRoot, 'opencode');
+	fs.mkdirSync(runtimesRoot, { recursive: true });
+	fs.symlinkSync(path.join(__dirname, '..', '..', 'agent-runtimes', 'opencode'), runtimePath, 'dir');
 
-	const command = runtime.agent_task_executors[0].command.replaceAll('{{extension_path}}', extensionPath);
+	const command = runtime.agent_task_executors[0].command.replaceAll('{{runtime_path}}', runtimePath);
 	const [, scriptPath] = command.match(/^node\s+(.+)$/) || [];
 	assert(scriptPath, 'provider command should be a node script command');
 	assert.equal(
 		path.normalize(scriptPath),
-		path.join(extensionPath, 'scripts', 'agent', 'homeboy-opencode-agent-task-executor.cjs')
+		path.join(runtimePath, 'scripts', 'agent', 'homeboy-opencode-agent-task-executor.cjs')
 	);
 	assert.equal(fs.existsSync(scriptPath), true, `provider command target should exist: ${scriptPath}`);
 


### PR DESCRIPTION
## Summary
- add an experimental OpenCode agent runtime manifest
- register OpenCode as a selectable runtime without changing the default WP Codebox worker runtime
- mark OpenCode as nested-orchestrator-capable and keep execution fail-fast until implementation lands
- update resolver and boundary tests to use the runtime manifest path

## Tests
- node tests/runtime-provider-resolver-smoke.mjs
- node wordpress/tests/opencode-agent-task-executor-boundary.test.js
- node wordpress/tests/generic-agent-runtime-contract.test.js
- npm run test:datamachine-agent-ci-plan
- node tests/datamachine-agent-ci-build-runner-config-smoke.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added the OpenCode runtime manifest, adjusted resolver/boundary tests, and ran targeted verification. Chris remains responsible for review and merge.