### PR TITLE
Prove generic shell agent runtime contract

### DIFF
--- a/agent-runtimes/fake-runtime/README.md
+++ b/agent-runtimes/fake-runtime/README.md
@@ -1,30 +1,13 @@
-# Fake Agent Runtime
+# Fake Agent Runtime Fixture
 
-This fixture is a minimal generic runtime package used by contract tests. It is
-not an operator runtime and should not be installed for real agent tasks.
+This experimental fixture is a tiny local shell-style provider for the generic
+Homeboy agent runtime contract.
 
-It demonstrates:
+It accepts one `homeboy/agent-task-request/v1` JSON object on stdin, validates an
+explicit `executor.backend` value of `fake-runtime`, writes
+`.homeboy/fake-runtime/outcome.json` and `.homeboy/fake-runtime/transcript.log`,
+then emits one `homeboy/agent-task-outcome/v1` JSON object on stdout.
 
-- Required manifest fields.
-- `{{runtime_path}}` provider command interpolation.
-- Secret names declared without values.
-- Capability and workspace materialization declarations.
-- Runtime-neutral `tool_presets` expansion for runner workspace and publication
-  tools.
-- A provider command that reads an AgentTaskRequest from stdin and writes a
-  normalized AgentTaskOutcome to stdout.
-
-## Tool Presets
-
-Generic runtime manifests can advertise `tool_presets` instead of copying a
-product-specific tool list into every provider. The shared contract currently
-defines:
-
-- `runner_workspace`: read-only workspace inspection plus read-write command,
-  file edit, patch, delete, and git-add tool ids.
-- `publication`: preparation, publish, and status tool ids for runtimes that can
-  expose reviewer-facing output.
-
-The expanded fields are plain `workspace_tools` and `publication_tools` entries.
-They intentionally avoid product-specific names so shell, OpenCode, Codex,
-Claude, or other harnesses can map the ids to their own local implementation.
+The fixture has no secret inputs. Its manifest declares generic workspace and
+publication tool preset capabilities so contract tests can verify preset
+expansion without relying on a domain-specific runtime.

--- a/agent-runtimes/fake-runtime/fake-runtime.json
+++ b/agent-runtimes/fake-runtime/fake-runtime.json
@@ -35,8 +35,7 @@
       "redacted_metadata_keys": [
         "secret_env_values",
         "secretEnvValues",
-        "secrets",
-        "fake_runtime_token"
+        "secrets"
       ],
       "capabilities": [
         "workspace_materialization",
@@ -75,27 +74,11 @@
           ".homeboy/fake-runtime"
         ]
       },
-      "secret_requirements": [
-        {
-          "name": "FAKE_RUNTIME_TOKEN",
-          "required": false,
-          "purpose": "Optional fake credential used by the contract fixture."
-        }
-      ],
-      "secret_env_requirements": [
-        {
-          "schema": "homeboy/secret-env-requirement/v1",
-          "source": "provider_default",
-          "env": ["FAKE_RUNTIME_TOKEN"],
-          "when": {
-            "path": "executor.config.provider",
-            "equals": "fake-runtime"
-          }
-        }
-      ],
+      "secret_requirements": [],
+      "secret_env_requirements": [],
       "provider_defaults": {
         "fake-runtime": {
-          "secret_env": ["FAKE_RUNTIME_TOKEN"]
+          "secret_env": []
         }
       },
       "diagnostics": {
@@ -105,7 +88,8 @@
           "metadata"
         ],
         "artifact_kinds": [
-          "fake-runtime-diagnostic"
+          "fake-runtime-outcome",
+          "fake-runtime-transcript"
         ]
       },
       "status": "experimental",

--- a/agent-runtimes/fake-runtime/scripts/agent/fake-agent-task-executor.cjs
+++ b/agent-runtimes/fake-runtime/scripts/agent/fake-agent-task-executor.cjs
@@ -2,13 +2,34 @@
 'use strict';
 
 const fs = require('node:fs');
+const path = require('node:path');
+
+const ARTIFACT_DIR = path.join(process.cwd(), '.homeboy', 'fake-runtime');
+const OUTCOME_PATH = path.join(ARTIFACT_DIR, 'outcome.json');
+const TRANSCRIPT_PATH = path.join(ARTIFACT_DIR, 'transcript.log');
 
 function readStdin() {
 	return fs.readFileSync(0, 'utf8');
 }
 
 function emit(outcome) {
+	writeArtifactFiles(outcome);
 	process.stdout.write(`${JSON.stringify(outcome)}\n`);
+}
+
+function writeArtifactFiles(outcome) {
+	fs.mkdirSync(ARTIFACT_DIR, { recursive: true });
+	fs.writeFileSync(OUTCOME_PATH, `${JSON.stringify(outcome, null, 2)}\n`);
+	fs.writeFileSync(TRANSCRIPT_PATH, transcriptForOutcome(outcome));
+}
+
+function transcriptForOutcome(outcome) {
+	return [
+		`task_id=${outcome.task_id || ''}`,
+		`status=${outcome.status}`,
+		`summary=${outcome.summary}`,
+		'',
+	].join('\n');
 }
 
 function failure(taskId, summary, details) {
@@ -23,11 +44,32 @@ function failure(taskId, summary, details) {
 				message: details,
 			},
 		],
-		artifacts: [],
+		artifacts: artifactRefs(),
 		metadata: {
 			provider: 'fake-runtime',
 		},
 	});
+}
+
+function artifactRefs() {
+	return [
+		{
+			schema: 'homeboy/agent-task-artifact/v1',
+			id: 'fake-runtime-outcome',
+			kind: 'fake-runtime-outcome',
+			name: 'Fake runtime outcome',
+			path: '.homeboy/fake-runtime/outcome.json',
+			mime: 'application/json',
+		},
+		{
+			schema: 'homeboy/agent-task-artifact/v1',
+			id: 'fake-runtime-transcript',
+			kind: 'fake-runtime-transcript',
+			name: 'Fake runtime transcript',
+			path: '.homeboy/fake-runtime/transcript.log',
+			mime: 'text/plain',
+		},
+	];
 }
 
 let request;
@@ -59,14 +101,8 @@ emit({
 			message: 'Provider command contract fixture executed successfully.',
 		},
 	],
-	artifacts: [
-		{
-			kind: 'fake-runtime-diagnostic',
-			path: '.homeboy/fake-runtime/outcome.json',
-		},
-	],
+	artifacts: artifactRefs(),
 	metadata: {
 		provider: 'fake-runtime',
-		secret_env_names: process.env.FAKE_RUNTIME_TOKEN ? ['FAKE_RUNTIME_TOKEN'] : [],
 	},
 });

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -4,8 +4,9 @@ Agent runtime packages live under `agent-runtimes/<runtime-id>/`. They expose
 provider commands that Homeboy can invoke without encoding backend-specific
 knowledge in core or in domain extensions.
 
-This contract is intentionally backend-neutral. WP Codebox is one runtime, not
-the template every future runtime should copy.
+This contract is intentionally backend-neutral. A browser sandbox runtime, a
+local shell fixture, or a CLI agent runtime can all satisfy the same request and
+outcome schemas.
 
 ## Package Layout
 
@@ -58,7 +59,7 @@ invoke the provider.
 
 Generic runner specs must declare `executor.backend` explicitly. Runtime-specific
 planners may provide their own defaults, but the shared contract does not assume
-WP Codebox or any other backend.
+any particular backend.
 
 ## `runtime_path` Interpolation
 
@@ -109,14 +110,13 @@ Reusable CI callers that need to describe a runner without embedding workflow
 glue should consume `agent-runtimes/lib/agent-task-runner-contract.js`. That
 adapter owns `homeboy/agent-task-runner-spec/v1` validation and projection into
 the generic request fields consumed by executor providers. Extension-specific
-exports, such as the WordPress `agent-task-runner-spec` module, should re-export
-that adapter instead of copying schema and lifecycle validation logic.
+exports should re-export that adapter instead of copying schema and lifecycle
+validation logic.
 
 Runtime packages may add backend-specific capabilities, secret names, role
 aliases, and metadata keys, but should extend the adapter output instead of
-copying schema strings or selector paths into each backend. Domain policy, such
-as WordPress or Data Machine defaults, belongs in the caller/runtime package and
-not in the generic adapter.
+copying schema strings or selector paths into each backend. Domain policy belongs
+in the caller/runtime package and not in the generic adapter.
 
 ## Secret Requirements
 
@@ -126,9 +126,9 @@ Runtime manifests should declare secret inputs by name, never by value:
 {
   "secret_requirements": [
     {
-      "name": "FAKE_RUNTIME_TOKEN",
+      "name": "EXAMPLE_RUNTIME_TOKEN",
       "required": false,
-      "purpose": "Authenticates optional fake runtime provider calls."
+      "purpose": "Authenticates optional provider calls."
     }
   ]
 }
@@ -168,13 +168,11 @@ Common fields:
 - `write_scope`: where the provider may write, such as `workspace`, `artifacts`, or `none`.
 - `artifact_paths`: relative paths the provider may create or update.
 
-The provider must not infer workspace shape from WP Codebox, WordPress, or any
-other current runtime unless that shape is declared here.
+The provider must not infer workspace shape from any current runtime unless that
+shape is declared here.
 
-Caller-owned wrappers should pass domain-specific runtime requirements explicitly.
-For example, Data Machine Agent CI supplies its Agents API, Data Machine, Data
-Machine Code, workspace-tool, and ability-policy defaults before invoking the
-generic WP Codebox provider.
+Caller-owned wrappers should pass domain-specific runtime requirements
+explicitly before invoking the selected generic provider.
 
 ## Outcome And Diagnostic Contracts
 
@@ -200,7 +198,7 @@ the default for a domain workflow.
 
 Default-backend policy belongs to the caller that understands the domain and
 deployment context, for example a Homeboy extension, workflow, component config,
-or operator-supplied setting. A WordPress workflow may choose WP Codebox by
+or operator-supplied setting. One workflow may choose a browser sandbox by
 default; a different workflow may choose another runtime with the same generic
 capabilities. Homeboy core should route explicit requests and evaluate declared
 capabilities, not hard-code a global default backend.
@@ -208,6 +206,8 @@ capabilities, not hard-code a global default backend.
 ## Fake Runtime Fixture
 
 `agent-runtimes/fake-runtime` is the smallest reference fixture for this
-contract. It exists to prove future runtimes can satisfy Homeboy's generic
-runtime package shape without copying WP Codebox package structure or WordPress
-behavior.
+contract. It accepts `homeboy/agent-task-request/v1`, requires an explicit
+`executor.backend`, writes an outcome JSON file plus a transcript log artifact,
+and emits `homeboy/agent-task-outcome/v1` without any secret inputs. It exists to
+prove future runtimes can satisfy Homeboy's generic runtime package shape without
+copying another runtime package structure or domain behavior.

--- a/tests/agent-runtime-contract-smoke.mjs
+++ b/tests/agent-runtime-contract-smoke.mjs
@@ -2,7 +2,8 @@
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -70,10 +71,11 @@ assert.equal(provider.workspace_materialization.cwd, 'git_checkout');
 assert.equal(provider.workspace_materialization.requires_git, true);
 assert.equal(provider.workspace_materialization.write_scope, 'artifacts');
 assert.deepEqual(provider.workspace_materialization.artifact_paths, ['.homeboy/fake-runtime']);
-assert.ok(provider.secret_requirements.some((secret) => secret.name === 'FAKE_RUNTIME_TOKEN'));
-assert.deepEqual(provider.secret_env_requirements[0].env, ['FAKE_RUNTIME_TOKEN']);
-assert.deepEqual(provider.provider_defaults['fake-runtime'].secret_env, ['FAKE_RUNTIME_TOKEN']);
+assert.deepEqual(provider.secret_requirements, []);
+assert.deepEqual(provider.secret_env_requirements, []);
+assert.deepEqual(provider.provider_defaults['fake-runtime'].secret_env, []);
 assert.ok(provider.diagnostics.outcome_fields.includes('diagnostics'));
+assert.deepEqual(provider.diagnostics.artifact_kinds, ['fake-runtime-outcome', 'fake-runtime-transcript']);
 
 const command = provider.command.replace('{{runtime_path}}', runtimeDir);
 assert.equal(command, `node ${runtimeDir}/scripts/agent/fake-agent-task-executor.cjs`);
@@ -87,13 +89,11 @@ const request = {
 	instructions: 'Validate the generic runtime provider command contract.',
 };
 
+const workspaceDir = mkdtempSync(path.join(os.tmpdir(), 'homeboy-fake-runtime-'));
 const result = spawnSync('node', [path.join(runtimeDir, 'scripts', 'agent', 'fake-agent-task-executor.cjs')], {
 	input: JSON.stringify(request),
 	encoding: 'utf8',
-	env: {
-		...process.env,
-		FAKE_RUNTIME_TOKEN: 'redacted-fixture-token',
-	},
+	cwd: workspaceDir,
 });
 
 assert.equal(result.status, 0, result.stderr);
@@ -105,7 +105,13 @@ assert.equal(outcome.task_id, request.task_id);
 assert.ok(provider.outcome_statuses.includes(outcome.status));
 assert.equal(outcome.status, 'succeeded');
 assert.equal(outcome.metadata.provider, provider.backend);
-assert.deepEqual(outcome.metadata.secret_env_names, ['FAKE_RUNTIME_TOKEN']);
-assert.doesNotMatch(result.stdout, /redacted-fixture-token/, 'provider outcome leaked secret value');
+assert.deepEqual(outcome.artifacts.map((artifact) => artifact.kind), ['fake-runtime-outcome', 'fake-runtime-transcript']);
+
+const writtenOutcome = JSON.parse(readFileSync(path.join(workspaceDir, '.homeboy', 'fake-runtime', 'outcome.json'), 'utf8'));
+const writtenTranscript = readFileSync(path.join(workspaceDir, '.homeboy', 'fake-runtime', 'transcript.log'), 'utf8');
+assert.deepEqual(writtenOutcome, outcome);
+assert.match(writtenTranscript, /task_id=fake-runtime-contract-smoke/);
+assert.match(writtenTranscript, /status=succeeded/);
+rmSync(workspaceDir, { recursive: true, force: true });
 
 console.log('agent runtime contract smoke passed');

--- a/tests/generic-agent-runtime-boundary-smoke.mjs
+++ b/tests/generic-agent-runtime-boundary-smoke.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const genericFiles = [
+	'docs/agent-runtime-package-contract.md',
+	'agent-runtimes/fake-runtime/README.md',
+	'agent-runtimes/fake-runtime/fake-runtime.json',
+	'agent-runtimes/fake-runtime/scripts/agent/fake-agent-task-executor.cjs',
+];
+const domainTerms = /WordPress|WP Codebox|Data Machine|WPSG|wp-site-generator|datamachine|wordpress|site-generator|site generator/;
+
+const violations = genericFiles.filter((relativePath) => {
+	const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+	return domainTerms.test(content);
+});
+
+assert.deepEqual(
+	violations,
+	[],
+	`Generic agent runtime files must stay domain-neutral. Violations: ${violations.join(', ')}`,
+);
+
+console.log('generic agent runtime boundary smoke passed');


### PR DESCRIPTION
## Summary
- Make the fake runtime fixture a concrete local shell-style provider with no secret requirements.
- Have the provider validate explicit `executor.backend`, emit `homeboy/agent-task-outcome/v1`, and write outcome/transcript artifact files referenced by the outcome.
- Document the domain-neutral runtime contract and add a boundary smoke test for generic runtime files.

## Tests
- `node tests/agent-task-provider-contract-smoke.mjs`
- `node tests/agent-runtime-contract-smoke.mjs`
- `node tests/runtime-provider-resolver-smoke.mjs`
- `node tests/generic-agent-runtime-boundary-smoke.mjs`
- `node tests/architectural-boundary-smoke.mjs`
- `node wordpress/tests/agent-task-core-contract-drift.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shell-style runtime fixture updates, contract docs, and smoke-test assertions; Chris remains responsible for review and merge.