### PR TITLE
Consume generic Codebox runtime profile dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,19 @@ types owned by the caller; Homeboy Extensions only forwards the generic runtime
 task contract.
 
 WP Codebox is expected to consume a `wp-codebox/runtime-profile/v1` payload with
-`component_contracts`, `extra_plugins`, `runtime_overlays`, `env`, and
-`provider_plugins`. Homeboy Extensions declares the temporary
-`homeboy_parent_tool_bridge` compatibility field in that payload only when a
-profile does not already expose a Codebox-owned `wp-codebox/parent-tool-bridge/v1`
-component or `parent_tool_bridge` declaration. The expected upstream primitive is
-a Codebox-owned parent-tool bridge that maps parent-owned tools into
+generic runtime dependencies such as `components`, `plugins`, `mu_plugins`,
+`themes`, `overlays`, `runtime_overlays`, `env`, and `provider_plugins`.
+Homeboy Extensions forwards those shapes as Codebox-owned runtime profile data
+and derives `component_contracts` / `extra_plugins` only as adapter
+compatibility for Codebox agent-task entry points that still consume component
+contracts directly. Data Machine ability selection, tool policy, hook/tool
+registration, and Homeboy schemas stay in Homeboy Extensions.
+
+Homeboy Extensions declares the temporary `homeboy_parent_tool_bridge`
+compatibility field in the runtime profile only when the profile does not already
+expose a Codebox-owned `wp-codebox/parent-tool-bridge/v1`, `parent_tool_bridge`,
+or generic parent-tool bridge component descriptor. The expected upstream
+primitive is a Codebox-owned parent-tool bridge that maps parent-owned tools into
 sandbox-visible descriptors without Homeboy injecting the bridge env directly.
 
 Each extension also exposes a CLI binding for direct use against a project or component:

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -28,6 +28,7 @@ const {
 } = require('./provider-outcome-normalizer');
 const {
   codeboxRuntimeProfilePayload,
+  componentContractsFromRuntimeProfileDependencies,
 } = require('./codebox-runtime-profile');
 
 const WP_CODEBOX_TASK_REQUEST_SCHEMA = 'wp-codebox/task-input/v1';
@@ -704,6 +705,8 @@ function componentContractsFromAgentTaskRequest(request, config, options = {}) {
     ...normalizeArray(config.runtime_requirements?.extra_plugins),
     ...normalizeArray(options.runtimeProfile?.component_contracts),
     ...normalizeArray(options.runtimeProfile?.extra_plugins),
+    ...componentContractsFromRuntimeProfileDependencies(options.runtimeProfile),
+    ...componentContractsFromRuntimeProfileDependencies(config.runtime_requirements),
     ...normalizeArray(options.componentContracts),
   ]);
 }

--- a/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
@@ -3,6 +3,8 @@
 const WP_CODEBOX_RUNTIME_PROFILE_SCHEMA = 'wp-codebox/runtime-profile/v1';
 const WP_CODEBOX_PARENT_TOOL_BRIDGE_SCHEMA = 'wp-codebox/parent-tool-bridge/v1';
 
+const RUNTIME_PROFILE_DEPENDENCY_FIELDS = ['components', 'plugins', 'mu_plugins', 'themes', 'overlays'];
+
 const HOMEBOY_PARENT_TOOL_BRIDGE_ENV = [
   'HOMEBOY_AGENT_TOOL_POLICY_JSON',
   'HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA',
@@ -23,28 +25,80 @@ function codeboxRuntimeProfilePayload({
 } = {}) {
   const normalizedProfile = plainObject(profile);
   const normalizedRuntimeRequirements = plainObject(runtimeRequirements);
+  const runtimeProfileDependencies = runtimeProfileDependencyFields(normalizedProfile, normalizedRuntimeRequirements);
+  const normalizedComponentContracts = uniqueObjectsByRuntimeIdentity([
+    ...normalizeArray(normalizedProfile.component_contracts),
+    ...normalizeArray(normalizedRuntimeRequirements.component_contracts),
+    ...componentContractsFromRuntimeProfileDependencies(runtimeProfileDependencies),
+    ...normalizeArray(componentContracts),
+  ]);
+  const normalizedProviderPlugins = uniqueObjectsByRuntimeIdentity([
+    ...normalizeArray(normalizedProfile.provider_plugins),
+    ...normalizeArray(normalizedRuntimeRequirements.provider_plugins),
+    ...providerPluginPaths.map((pluginPath) => ({ path: pluginPath })),
+  ]);
   return withoutEmptyObjectValues({
     ...normalizedProfile,
     ...normalizedRuntimeRequirements,
     schema: WP_CODEBOX_RUNTIME_PROFILE_SCHEMA,
     id: normalizedRuntimeRequirements.id || normalizedProfile.id || id,
     homeboy_profile_schema: normalizedProfile.schema && normalizedProfile.schema !== WP_CODEBOX_RUNTIME_PROFILE_SCHEMA ? normalizedProfile.schema : undefined,
-    component_contracts: componentContracts,
-    extra_plugins: componentContracts,
+    ...runtimeProfileDependencies,
+    component_contracts: normalizedComponentContracts,
+    extra_plugins: normalizedComponentContracts,
     runtime_overlays: runtimeOverlays,
     env: runtimeEnv,
-    provider_plugins: providerPluginPaths.map((pluginPath) => ({ path: pluginPath })),
+    provider_plugins: normalizedProviderPlugins,
     runtime_state_mounts: runtimeStateMounts,
     runtime_config_mounts: runtimeConfigMounts,
-    ...parentToolBridgeProfileFields(normalizedProfile, normalizedRuntimeRequirements, componentContracts),
+    ...parentToolBridgeProfileFields(normalizedProfile, normalizedRuntimeRequirements, runtimeProfileDependencies, normalizedComponentContracts),
   });
 }
 
-function parentToolBridgeProfileFields(profile = {}, runtimeRequirements = {}, componentContracts = []) {
-  if (hasCodeboxParentToolBridge(profile, runtimeRequirements, componentContracts)) {
+function parentToolBridgeProfileFields(profile = {}, runtimeRequirements = {}, runtimeProfileDependencies = {}, componentContracts = []) {
+  if (hasCodeboxParentToolBridge(profile, runtimeRequirements, runtimeProfileDependencies, componentContracts)) {
     return { homeboy_parent_tool_bridge: undefined };
   }
   return { homeboy_parent_tool_bridge: homeboyParentToolBridgeRequirement() };
+}
+
+function runtimeProfileDependencyFields(profile = {}, runtimeRequirements = {}) {
+  return Object.fromEntries(RUNTIME_PROFILE_DEPENDENCY_FIELDS.map((field) => [
+    field,
+    uniqueObjectsByRuntimeIdentity([
+      ...normalizeArray(profile[field]),
+      ...normalizeArray(runtimeRequirements[field]),
+    ]),
+  ]));
+}
+
+function componentContractsFromRuntimeProfileDependencies(dependencies = {}) {
+  return [
+    ...normalizeArray(dependencies.components).map((dependency) => componentContractFromDependency(dependency, 'mu-plugin')),
+    ...normalizeArray(dependencies.mu_plugins).map((dependency) => componentContractFromDependency(dependency, 'mu-plugin')),
+    ...normalizeArray(dependencies.plugins).map((dependency) => componentContractFromDependency(dependency, 'plugin')),
+  ].filter(Boolean);
+}
+
+function componentContractFromDependency(dependency, loadAs) {
+  if (!dependency || typeof dependency !== 'object' || Array.isArray(dependency)) {
+    return null;
+  }
+  const source = dependency.source || dependency.path;
+  if (!dependency.slug || !source) {
+    return null;
+  }
+  return withoutEmptyObjectValues({
+    slug: dependency.slug,
+    path: dependency.path || source,
+    source,
+    pluginFile: dependency.pluginFile || dependency.plugin_file,
+    loadAs: dependency.loadAs || dependency.load_as || loadAs,
+    activate: dependency.activate,
+    required: dependency.required,
+    readiness_probe: dependency.readiness_probe || dependency.readinessProbe,
+    metadata: dependency.metadata,
+  });
 }
 
 function hasCodeboxParentToolBridge(...values) {
@@ -57,19 +111,38 @@ function hasCodeboxParentToolBridge(...values) {
     if (value.schema === WP_CODEBOX_PARENT_TOOL_BRIDGE_SCHEMA) {
       return true;
     }
+    if (parentToolBridgeDescriptor(value)) {
+      return true;
+    }
     if (value.parent_tool_bridge && typeof value.parent_tool_bridge === 'object') {
       return true;
     }
     if (Array.isArray(value.parent_tool_bridges) && value.parent_tool_bridges.length > 0) {
       return true;
     }
-    for (const key of ['components', 'runtime_components', 'component_contracts', 'extra_plugins']) {
+    for (const key of [...RUNTIME_PROFILE_DEPENDENCY_FIELDS, 'runtime_components', 'component_contracts', 'extra_plugins']) {
       if (Array.isArray(value[key])) {
         queue.push(...value[key]);
       }
     }
   }
   return false;
+}
+
+function parentToolBridgeDescriptor(value) {
+  const identifiers = [
+    value.kind,
+    value.type,
+    value.id,
+    value.slug,
+    value.capability,
+    value.metadata?.kind,
+    value.metadata?.type,
+  ].filter(Boolean).map((entry) => String(entry).toLowerCase());
+  return identifiers.some((entry) => entry === 'parent-tool-bridge' || entry === 'parent_tool_bridge' || entry === 'parent_tool_bridge_component')
+    || value.metadata?.parent_tool_bridge === true
+    || value.metadata?.parentToolBridge === true
+    || normalizeArray(value.capabilities).some((capability) => String(capability).toLowerCase() === 'parent_tool_bridge' || String(capability).toLowerCase() === 'parent-tool-bridge');
 }
 
 function homeboyParentToolBridgeRequirement() {
@@ -83,6 +156,28 @@ function homeboyParentToolBridgeRequirement() {
 
 function plainObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function uniqueObjectsByRuntimeIdentity(entries) {
+  const seen = new Set();
+  return normalizeArray(entries).filter((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return false;
+    }
+    const key = [entry.slug, entry.id, entry.path || entry.source || entry.target, entry.kind, entry.type].filter(Boolean).join(':');
+    if (!key) {
+      return true;
+    }
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
 }
 
 function withoutEmptyObjectValues(value) {
@@ -101,6 +196,7 @@ module.exports = {
   WP_CODEBOX_PARENT_TOOL_BRIDGE_SCHEMA,
   WP_CODEBOX_RUNTIME_PROFILE_SCHEMA,
   codeboxRuntimeProfilePayload,
+  componentContractsFromRuntimeProfileDependencies,
   hasCodeboxParentToolBridge,
   homeboyParentToolBridgeRequirement,
 };

--- a/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
+++ b/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
@@ -45,6 +45,64 @@ try {
 
 	assert.equal(taskInput.runtime_env.EXAMPLE_RUNTIME_TOOL_POLICY_JSON, process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON);
 	assert.equal(taskInput.runtime_env.DATAMACHINE_HOST_TOOL_POLICY_JSON, undefined);
+
+	const genericProfileTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+		schema: 'homeboy/agent-task-request/v1',
+		task_id: 'wp-codebox-generic-runtime-profile-smoke',
+		instructions: 'Validate generic WP Codebox runtime profile primitives.',
+		executor: {
+			backend: 'codebox',
+			config: {
+				provider: 'codex',
+				model: 'gpt-5.5',
+				runtime_task: {
+					ability: 'example/run-task',
+					input: {},
+				},
+				runtime_profile: {
+					schema: 'wp-codebox/runtime-profile/v1',
+					id: 'generic-codebox-runtime',
+					components: [
+						{ kind: 'component', slug: 'agents-api', source: '/runtime/agents-api', pluginFile: 'agents-api/agents-api.php' },
+						{ kind: 'parent-tool-bridge', slug: 'codebox-parent-tools', source: '/runtime/codebox-parent-tools' },
+					],
+					mu_plugins: [
+						{ kind: 'mu_plugin', slug: 'runtime-tools', source: '/runtime/runtime-tools' },
+					],
+					plugins: [
+						{ kind: 'plugin', slug: 'provider-plugin', source: '/runtime/provider-plugin', activate: true },
+					],
+					env: { EXAMPLE_RUNTIME: '1' },
+					provider_plugins: [{ path: '/runtime/provider-plugin' }],
+				},
+			},
+		},
+	});
+
+	assert.equal(genericProfileTaskInput.runtime_requirements.schema, 'wp-codebox/runtime-profile/v1');
+	assert.equal(genericProfileTaskInput.runtime_requirements.id, 'generic-codebox-runtime');
+	assert.deepEqual(genericProfileTaskInput.runtime_requirements.components.map((component) => component.slug), [
+		'agents-api',
+		'codebox-parent-tools',
+	]);
+	assert.deepEqual(genericProfileTaskInput.runtime_requirements.component_contracts.map((contract) => contract.slug), [
+		'agents-api',
+		'codebox-parent-tools',
+		'runtime-tools',
+		'provider-plugin',
+	]);
+	assert.deepEqual(genericProfileTaskInput.component_contracts.map((contract) => contract.slug), [
+		'agents-api',
+		'codebox-parent-tools',
+		'runtime-tools',
+		'provider-plugin',
+	]);
+	assert.equal(genericProfileTaskInput.runtime_requirements.component_contracts[0].loadAs, 'mu-plugin');
+	assert.equal(genericProfileTaskInput.runtime_requirements.component_contracts[3].loadAs, 'plugin');
+	assert.equal(genericProfileTaskInput.runtime_requirements.homeboy_parent_tool_bridge, undefined);
+	assert.deepEqual(genericProfileTaskInput.runtime_requirements.provider_plugins, [{ path: '/runtime/provider-plugin' }]);
+	assert.equal(genericProfileTaskInput.runtime_requirements.env.EXAMPLE_RUNTIME, '1');
+
 	console.log('wp-codebox runtime profile defaults smoke passed');
 } finally {
 	if (previousPolicy === undefined) {


### PR DESCRIPTION
## Summary
- Preserve generic `wp-codebox/runtime-profile/v1` dependency fields in Homeboy Codebox task payloads.
- Derive `component_contracts` / `extra_plugins` compatibility entries from generic Codebox runtime dependencies.
- Suppress the Homeboy parent-tool bridge compatibility field when a generic Codebox parent-tool bridge descriptor is present.

## Related
- Complements https://github.com/Automattic/wp-codebox/pull/1216 by keeping Homeboy on generic Codebox-owned runtime profile shapes.

## Verification
- `node tests/wp-codebox-runtime-profile-defaults-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `npm run test:codebox-agent-task-executor-boundary` from `agent-runtimes/wp-codebox`
- `npm run test:codebox-agent-task-executor` from `agent-runtimes/wp-codebox`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the adapter alignment and smoke coverage; Chris remains responsible for review and validation.