### PR TITLE
Extract Codebox artifact contract helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,19 @@ types owned by the caller; Homeboy Extensions only forwards the generic runtime
 task contract.
 
 WP Codebox is expected to consume a `wp-codebox/runtime-profile/v1` payload with
-`component_contracts`, `extra_plugins`, `runtime_overlays`, `env`, and
-`provider_plugins`. Homeboy Extensions declares the temporary
-`homeboy_parent_tool_bridge` compatibility field in that payload only when a
-profile does not already expose a Codebox-owned `wp-codebox/parent-tool-bridge/v1`
-component or `parent_tool_bridge` declaration. The expected upstream primitive is
-a Codebox-owned parent-tool bridge that maps parent-owned tools into
+generic runtime dependencies such as `components`, `plugins`, `mu_plugins`,
+`themes`, `overlays`, `runtime_overlays`, `env`, and `provider_plugins`.
+Homeboy Extensions forwards those shapes as Codebox-owned runtime profile data
+and derives `component_contracts` / `extra_plugins` only as adapter
+compatibility for Codebox agent-task entry points that still consume component
+contracts directly. Data Machine ability selection, tool policy, hook/tool
+registration, and Homeboy schemas stay in Homeboy Extensions.
+
+Homeboy Extensions declares the temporary `homeboy_parent_tool_bridge`
+compatibility field in the runtime profile only when the profile does not already
+expose a Codebox-owned `wp-codebox/parent-tool-bridge/v1`, `parent_tool_bridge`,
+or generic parent-tool bridge component descriptor. The expected upstream
+primitive is a Codebox-owned parent-tool bridge that maps parent-owned tools into
 sandbox-visible descriptors without Homeboy injecting the bridge env directly.
 
 Each extension also exposes a CLI binding for direct use against a project or component:

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -28,6 +28,7 @@ const {
 } = require('./provider-outcome-normalizer');
 const {
   codeboxRuntimeProfilePayload,
+  componentContractsFromRuntimeProfileDependencies,
 } = require('./codebox-runtime-profile');
 
 const WP_CODEBOX_TASK_REQUEST_SCHEMA = 'wp-codebox/task-input/v1';
@@ -704,6 +705,8 @@ function componentContractsFromAgentTaskRequest(request, config, options = {}) {
     ...normalizeArray(config.runtime_requirements?.extra_plugins),
     ...normalizeArray(options.runtimeProfile?.component_contracts),
     ...normalizeArray(options.runtimeProfile?.extra_plugins),
+    ...componentContractsFromRuntimeProfileDependencies(options.runtimeProfile),
+    ...componentContractsFromRuntimeProfileDependencies(config.runtime_requirements),
     ...normalizeArray(options.componentContracts),
   ]);
 }

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -27,6 +27,13 @@ const {
   providerFailureClassification,
 } = require('./provider-outcome-normalizer');
 const {
+  artifactNameFromDeclaration,
+  artifactPath,
+  normalizeTypedArtifactEntry: normalizeCodeboxTypedArtifactEntry,
+  normalizeTypedArtifacts: normalizeCodeboxTypedArtifacts,
+  typedArtifactFileRefs: codeboxTypedArtifactFileRefs,
+} = require('./codebox-artifact-contract');
+const {
   codeboxRuntimeProfilePayload,
   componentContractsFromRuntimeProfileDependencies,
 } = require('./codebox-runtime-profile');
@@ -1860,13 +1867,6 @@ function appendUniqueEvidenceRef(refs, ref) {
   refs.push(ref);
 }
 
-function artifactPath(root, relativePath) {
-  if (!root || !relativePath) {
-    return '';
-  }
-  return `${String(root).replace(/\/$/, '')}/${String(relativePath).replace(/^\//, '')}`;
-}
-
 function codeboxBundleArtifacts(result) {
   const artifacts = [];
   const artifactRefs = Array.isArray(result.run?.artifactRefs) ? result.run.artifactRefs : [];
@@ -2078,50 +2078,11 @@ function sanitizePublicMetadata(value) {
 }
 
 function normalizeTypedArtifactEntry(name, artifact) {
-  if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) {
-    return null;
-  }
-  const artifactName = artifact.name || name;
-  if (!artifactName) {
-    return null;
-  }
-  const fileRefs = typedArtifactOutputFileRefs(artifact);
-  return sanitizePublicMetadata(Object.fromEntries(Object.entries({
-    schema: 'homeboy/agent-task-typed-artifact/v1',
-    name: artifactName,
-    type: artifact.type || artifact.kind || artifact.artifact_type || artifact.artifactType,
-    artifact_schema: artifact.artifact_schema || artifact.artifactSchema || artifact.schema,
-    payload: artifact.payload !== undefined ? artifact.payload : artifact.data,
-    provenance: artifact.provenance && typeof artifact.provenance === 'object' && !Array.isArray(artifact.provenance) ? artifact.provenance : {},
-    file_refs: fileRefs,
-    metadata: artifact.metadata && typeof artifact.metadata === 'object' && !Array.isArray(artifact.metadata) ? artifact.metadata : {},
-  }).filter(([, value]) => value !== undefined && value !== '' && !(Array.isArray(value) && value.length === 0))));
-}
-
-function typedArtifactOutputFileRefs(artifact) {
-  if (Array.isArray(artifact.file_refs)) {
-    return artifact.file_refs;
-  }
-  if (Array.isArray(artifact.fileRefs)) {
-    return artifact.fileRefs;
-  }
-  return [];
+  return normalizeCodeboxTypedArtifactEntry(name, artifact, { sanitize: sanitizePublicMetadata });
 }
 
 function normalizeTypedArtifacts(value) {
-  if (Array.isArray(value)) {
-    return Object.fromEntries(value
-      .map((artifact, index) => normalizeTypedArtifactEntry(artifact?.name || artifact?.id || `artifact_${index + 1}`, artifact))
-      .filter(Boolean)
-      .map((artifact) => [artifact.name, artifact]));
-  }
-  if (!value || typeof value !== 'object') {
-    return {};
-  }
-  return Object.fromEntries(Object.entries(value)
-    .map(([name, artifact]) => normalizeTypedArtifactEntry(name, artifact))
-    .filter(Boolean)
-    .map((artifact) => [artifact.name, artifact]));
+  return normalizeCodeboxTypedArtifacts(value, { sanitize: sanitizePublicMetadata });
 }
 
 function typedArtifactsFromResult(result) {
@@ -2269,7 +2230,7 @@ function typedArtifactProjectionFromOutputPath(outputPath, value, typedArtifacts
 }
 
 function typedArtifactFileRefs(typedArtifact) {
-  const refs = Array.isArray(typedArtifact.file_refs) ? typedArtifact.file_refs : [];
+  const refs = codeboxTypedArtifactFileRefs(typedArtifact);
   const directRefs = [typedArtifact.path, typedArtifact.url, typedArtifact.file, typedArtifact.directory].filter(Boolean);
   return [
     ...directRefs.map((ref) => ({ path: ref })),
@@ -2278,13 +2239,7 @@ function typedArtifactFileRefs(typedArtifact) {
 }
 
 function typedArtifactNameFromDeclaration(declaration) {
-  if (typeof declaration === 'string') {
-    return declaration;
-  }
-  if (!declaration || typeof declaration !== 'object' || Array.isArray(declaration)) {
-    return '';
-  }
-  return declaration.name || declaration.id || '';
+  return artifactNameFromDeclaration(declaration);
 }
 
 function requiredArtifactDeclarationsFromRequest(request) {

--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const TYPED_ARTIFACT_SCHEMA = 'homeboy/agent-task-typed-artifact/v1';
+
+function normalizeTypedArtifactEntry(name, artifact, options = {}) {
+  if (!plainObject(artifact)) {
+    return null;
+  }
+  const artifactName = artifact.name || name;
+  if (!artifactName) {
+    return null;
+  }
+  const entry = cleanObject({
+    schema: TYPED_ARTIFACT_SCHEMA,
+    name: artifactName,
+    type: artifact.type || artifact.kind || artifact.artifact_type || artifact.artifactType,
+    artifact_schema: artifact.artifact_schema || artifact.artifactSchema || artifact.schema,
+    payload: artifact.payload !== undefined ? artifact.payload : artifact.data,
+    provenance: plainObject(artifact.provenance) ? artifact.provenance : {},
+    file_refs: typedArtifactFileRefs(artifact),
+    metadata: plainObject(artifact.metadata) ? artifact.metadata : {},
+  });
+  return typeof options.sanitize === 'function' ? options.sanitize(entry) : entry;
+}
+
+function normalizeTypedArtifacts(value, options = {}) {
+  if (Array.isArray(value)) {
+    return Object.fromEntries(value
+      .map((artifact, index) => normalizeTypedArtifactEntry(artifact?.name || artifact?.id || `artifact_${index + 1}`, artifact, options))
+      .filter(Boolean)
+      .map((artifact) => [artifact.name, artifact]));
+  }
+  if (!plainObject(value)) {
+    return {};
+  }
+  return Object.fromEntries(Object.entries(value)
+    .map(([name, artifact]) => normalizeTypedArtifactEntry(name, artifact, options))
+    .filter(Boolean)
+    .map((artifact) => [artifact.name, artifact]));
+}
+
+function typedArtifactFileRefs(artifact) {
+  if (Array.isArray(artifact?.file_refs)) {
+    return artifact.file_refs;
+  }
+  if (Array.isArray(artifact?.fileRefs)) {
+    return artifact.fileRefs;
+  }
+  return [];
+}
+
+function artifactNameFromDeclaration(declaration) {
+  if (typeof declaration === 'string') {
+    return declaration;
+  }
+  if (!plainObject(declaration)) {
+    return '';
+  }
+  return declaration.name || declaration.id || '';
+}
+
+function artifactPath(root, relativePath) {
+  if (!root || !relativePath) {
+    return '';
+  }
+  return `${String(root).replace(/\/$/, '')}/${String(relativePath).replace(/^\//, '')}`;
+}
+
+function plainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cleanObject(value) {
+  return Object.fromEntries(Object.entries(value)
+    .filter(([, entry]) => entry !== undefined && entry !== '' && !(Array.isArray(entry) && entry.length === 0)));
+}
+
+module.exports = {
+  TYPED_ARTIFACT_SCHEMA,
+  artifactNameFromDeclaration,
+  artifactPath,
+  normalizeTypedArtifactEntry,
+  normalizeTypedArtifacts,
+  typedArtifactFileRefs,
+};

--- a/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
@@ -3,6 +3,8 @@
 const WP_CODEBOX_RUNTIME_PROFILE_SCHEMA = 'wp-codebox/runtime-profile/v1';
 const WP_CODEBOX_PARENT_TOOL_BRIDGE_SCHEMA = 'wp-codebox/parent-tool-bridge/v1';
 
+const RUNTIME_PROFILE_DEPENDENCY_FIELDS = ['components', 'plugins', 'mu_plugins', 'themes', 'overlays'];
+
 const HOMEBOY_PARENT_TOOL_BRIDGE_ENV = [
   'HOMEBOY_AGENT_TOOL_POLICY_JSON',
   'HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA',
@@ -23,28 +25,80 @@ function codeboxRuntimeProfilePayload({
 } = {}) {
   const normalizedProfile = plainObject(profile);
   const normalizedRuntimeRequirements = plainObject(runtimeRequirements);
+  const runtimeProfileDependencies = runtimeProfileDependencyFields(normalizedProfile, normalizedRuntimeRequirements);
+  const normalizedComponentContracts = uniqueObjectsByRuntimeIdentity([
+    ...normalizeArray(normalizedProfile.component_contracts),
+    ...normalizeArray(normalizedRuntimeRequirements.component_contracts),
+    ...componentContractsFromRuntimeProfileDependencies(runtimeProfileDependencies),
+    ...normalizeArray(componentContracts),
+  ]);
+  const normalizedProviderPlugins = uniqueObjectsByRuntimeIdentity([
+    ...normalizeArray(normalizedProfile.provider_plugins),
+    ...normalizeArray(normalizedRuntimeRequirements.provider_plugins),
+    ...providerPluginPaths.map((pluginPath) => ({ path: pluginPath })),
+  ]);
   return withoutEmptyObjectValues({
     ...normalizedProfile,
     ...normalizedRuntimeRequirements,
     schema: WP_CODEBOX_RUNTIME_PROFILE_SCHEMA,
     id: normalizedRuntimeRequirements.id || normalizedProfile.id || id,
     homeboy_profile_schema: normalizedProfile.schema && normalizedProfile.schema !== WP_CODEBOX_RUNTIME_PROFILE_SCHEMA ? normalizedProfile.schema : undefined,
-    component_contracts: componentContracts,
-    extra_plugins: componentContracts,
+    ...runtimeProfileDependencies,
+    component_contracts: normalizedComponentContracts,
+    extra_plugins: normalizedComponentContracts,
     runtime_overlays: runtimeOverlays,
     env: runtimeEnv,
-    provider_plugins: providerPluginPaths.map((pluginPath) => ({ path: pluginPath })),
+    provider_plugins: normalizedProviderPlugins,
     runtime_state_mounts: runtimeStateMounts,
     runtime_config_mounts: runtimeConfigMounts,
-    ...parentToolBridgeProfileFields(normalizedProfile, normalizedRuntimeRequirements, componentContracts),
+    ...parentToolBridgeProfileFields(normalizedProfile, normalizedRuntimeRequirements, runtimeProfileDependencies, normalizedComponentContracts),
   });
 }
 
-function parentToolBridgeProfileFields(profile = {}, runtimeRequirements = {}, componentContracts = []) {
-  if (hasCodeboxParentToolBridge(profile, runtimeRequirements, componentContracts)) {
+function parentToolBridgeProfileFields(profile = {}, runtimeRequirements = {}, runtimeProfileDependencies = {}, componentContracts = []) {
+  if (hasCodeboxParentToolBridge(profile, runtimeRequirements, runtimeProfileDependencies, componentContracts)) {
     return { homeboy_parent_tool_bridge: undefined };
   }
   return { homeboy_parent_tool_bridge: homeboyParentToolBridgeRequirement() };
+}
+
+function runtimeProfileDependencyFields(profile = {}, runtimeRequirements = {}) {
+  return Object.fromEntries(RUNTIME_PROFILE_DEPENDENCY_FIELDS.map((field) => [
+    field,
+    uniqueObjectsByRuntimeIdentity([
+      ...normalizeArray(profile[field]),
+      ...normalizeArray(runtimeRequirements[field]),
+    ]),
+  ]));
+}
+
+function componentContractsFromRuntimeProfileDependencies(dependencies = {}) {
+  return [
+    ...normalizeArray(dependencies.components).map((dependency) => componentContractFromDependency(dependency, 'mu-plugin')),
+    ...normalizeArray(dependencies.mu_plugins).map((dependency) => componentContractFromDependency(dependency, 'mu-plugin')),
+    ...normalizeArray(dependencies.plugins).map((dependency) => componentContractFromDependency(dependency, 'plugin')),
+  ].filter(Boolean);
+}
+
+function componentContractFromDependency(dependency, loadAs) {
+  if (!dependency || typeof dependency !== 'object' || Array.isArray(dependency)) {
+    return null;
+  }
+  const source = dependency.source || dependency.path;
+  if (!dependency.slug || !source) {
+    return null;
+  }
+  return withoutEmptyObjectValues({
+    slug: dependency.slug,
+    path: dependency.path || source,
+    source,
+    pluginFile: dependency.pluginFile || dependency.plugin_file,
+    loadAs: dependency.loadAs || dependency.load_as || loadAs,
+    activate: dependency.activate,
+    required: dependency.required,
+    readiness_probe: dependency.readiness_probe || dependency.readinessProbe,
+    metadata: dependency.metadata,
+  });
 }
 
 function hasCodeboxParentToolBridge(...values) {
@@ -57,19 +111,38 @@ function hasCodeboxParentToolBridge(...values) {
     if (value.schema === WP_CODEBOX_PARENT_TOOL_BRIDGE_SCHEMA) {
       return true;
     }
+    if (parentToolBridgeDescriptor(value)) {
+      return true;
+    }
     if (value.parent_tool_bridge && typeof value.parent_tool_bridge === 'object') {
       return true;
     }
     if (Array.isArray(value.parent_tool_bridges) && value.parent_tool_bridges.length > 0) {
       return true;
     }
-    for (const key of ['components', 'runtime_components', 'component_contracts', 'extra_plugins']) {
+    for (const key of [...RUNTIME_PROFILE_DEPENDENCY_FIELDS, 'runtime_components', 'component_contracts', 'extra_plugins']) {
       if (Array.isArray(value[key])) {
         queue.push(...value[key]);
       }
     }
   }
   return false;
+}
+
+function parentToolBridgeDescriptor(value) {
+  const identifiers = [
+    value.kind,
+    value.type,
+    value.id,
+    value.slug,
+    value.capability,
+    value.metadata?.kind,
+    value.metadata?.type,
+  ].filter(Boolean).map((entry) => String(entry).toLowerCase());
+  return identifiers.some((entry) => entry === 'parent-tool-bridge' || entry === 'parent_tool_bridge' || entry === 'parent_tool_bridge_component')
+    || value.metadata?.parent_tool_bridge === true
+    || value.metadata?.parentToolBridge === true
+    || normalizeArray(value.capabilities).some((capability) => String(capability).toLowerCase() === 'parent_tool_bridge' || String(capability).toLowerCase() === 'parent-tool-bridge');
 }
 
 function homeboyParentToolBridgeRequirement() {
@@ -83,6 +156,28 @@ function homeboyParentToolBridgeRequirement() {
 
 function plainObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function uniqueObjectsByRuntimeIdentity(entries) {
+  const seen = new Set();
+  return normalizeArray(entries).filter((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return false;
+    }
+    const key = [entry.slug, entry.id, entry.path || entry.source || entry.target, entry.kind, entry.type].filter(Boolean).join(':');
+    if (!key) {
+      return true;
+    }
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
 }
 
 function withoutEmptyObjectValues(value) {
@@ -101,6 +196,7 @@ module.exports = {
   WP_CODEBOX_PARENT_TOOL_BRIDGE_SCHEMA,
   WP_CODEBOX_RUNTIME_PROFILE_SCHEMA,
   codeboxRuntimeProfilePayload,
+  componentContractsFromRuntimeProfileDependencies,
   hasCodeboxParentToolBridge,
   homeboyParentToolBridgeRequirement,
 };

--- a/agent-runtimes/wp-codebox/package.json
+++ b/agent-runtimes/wp-codebox/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "exports": {
     ".": "./index.js",
+    "./codebox-artifact-contract": "./lib/codebox-artifact-contract.js",
     "./codebox-agent-task-executor": "./lib/codebox-agent-task-executor.js",
     "./delegated-run-contract": "./lib/delegated-run-contract.js",
     "./provider-outcome-normalizer": "./lib/provider-outcome-normalizer.js"

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -20,6 +20,13 @@ const {
   providerGuidance,
   providerPreflightManifest,
 } = require('../../lib/provider-preflight-manifest');
+const {
+  artifactNameFromDeclaration,
+  artifactPath,
+  normalizeTypedArtifactEntry,
+  normalizeTypedArtifacts,
+  typedArtifactFileRefs,
+} = require('../../lib/codebox-artifact-contract');
 
 const CODEX_OAUTH_TOKEN_URL = 'https://auth.openai.com/oauth/token';
 const CODEX_OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
@@ -1500,45 +1507,8 @@ function plainObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value);
 }
 
-function normalizeTypedArtifactEntry(name, artifact) {
-  if (!plainObject(artifact)) {
-    return null;
-  }
-  const artifactName = artifact.name || name;
-  if (!artifactName) {
-    return null;
-  }
-  const fileRefs = typedArtifactFileRefs(artifact);
-  return Object.fromEntries(Object.entries({
-    schema: 'homeboy/agent-task-typed-artifact/v1',
-    name: artifactName,
-    type: artifact.type || artifact.kind || artifact.artifact_type || artifact.artifactType,
-    artifact_schema: artifact.artifact_schema || artifact.artifactSchema || artifact.schema,
-    payload: artifact.payload !== undefined ? artifact.payload : artifact.data,
-    provenance: plainObject(artifact.provenance) ? artifact.provenance : {},
-    file_refs: fileRefs,
-    metadata: plainObject(artifact.metadata) ? artifact.metadata : {},
-  }).filter(([, value]) => value !== undefined && value !== '' && !(Array.isArray(value) && value.length === 0)));
-}
-
-function typedArtifactFileRefs(artifact) {
-  if (Array.isArray(artifact.file_refs)) {
-    return artifact.file_refs;
-  }
-  if (Array.isArray(artifact.fileRefs)) {
-    return artifact.fileRefs;
-  }
-  return [];
-}
-
 function artifactDeclarationName(declaration) {
-  if (typeof declaration === 'string') {
-    return declaration;
-  }
-  if (!plainObject(declaration)) {
-    return '';
-  }
-  return declaration.name || declaration.id || '';
+  return artifactNameFromDeclaration(declaration);
 }
 
 function requiredArtifactDeclarations(input, config = {}) {
@@ -1576,22 +1546,6 @@ function missingRequiredTypedArtifactDiagnostic(input, workload, config = {}) {
   };
 }
 
-function normalizeTypedArtifacts(value) {
-  if (Array.isArray(value)) {
-    return Object.fromEntries(value
-      .map((artifact, index) => normalizeTypedArtifactEntry(artifact?.name || artifact?.id || `artifact_${index + 1}`, artifact))
-      .filter(Boolean)
-      .map((artifact) => [artifact.name, artifact]));
-  }
-  if (!plainObject(value)) {
-    return {};
-  }
-  return Object.fromEntries(Object.entries(value)
-    .map(([name, artifact]) => normalizeTypedArtifactEntry(name, artifact))
-    .filter(Boolean)
-    .map((artifact) => [artifact.name, artifact]));
-}
-
 function mergeTypedArtifactOutputs(outputs, ...candidates) {
   const typedArtifacts = Object.assign({}, ...candidates.map(normalizeTypedArtifacts));
   if (Object.keys(typedArtifacts).length === 0) {
@@ -1611,13 +1565,6 @@ function isTranscriptArtifactDeclaration(declaration) {
   const type = declaration?.type || declaration?.kind || declaration?.artifact_type || declaration?.artifactType || '';
   const schema = declaration?.artifact_schema || declaration?.artifactSchema || declaration?.schema || '';
   return /transcript|conversation|messages/i.test(`${name} ${type} ${schema}`);
-}
-
-function artifactPath(root, relativePath) {
-  if (!root || !relativePath) {
-    return '';
-  }
-  return `${String(root).replace(/\/$/, '')}/${String(relativePath).replace(/^\//, '')}`;
 }
 
 function transcriptTypedArtifactsFromAgentResult(input, agentResult, config = {}) {

--- a/tests/wp-codebox-artifact-contract-smoke.mjs
+++ b/tests/wp-codebox-artifact-contract-smoke.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+  artifactNameFromDeclaration,
+  artifactPath,
+  normalizeTypedArtifactEntry,
+  normalizeTypedArtifacts,
+  typedArtifactFileRefs,
+} = require(path.join(repoRoot, 'agent-runtimes/wp-codebox/lib/codebox-artifact-contract'));
+
+assert.equal(artifactPath('/tmp/artifacts/', '/files/transcript.json'), '/tmp/artifacts/files/transcript.json');
+assert.equal(artifactPath('', 'files/transcript.json'), '');
+assert.equal(artifactNameFromDeclaration({ id: 'transcript' }), 'transcript');
+
+assert.deepEqual(typedArtifactFileRefs({ fileRefs: [{ path: 'artifact.json' }] }), [{ path: 'artifact.json' }]);
+
+assert.deepEqual(normalizeTypedArtifactEntry('packet', {
+  kind: 'json',
+  schema: 'example/schema/v1',
+  data: { ok: true },
+  file_refs: [{ path: 'packet.json' }],
+  metadata: { visible: true },
+}), {
+  schema: 'homeboy/agent-task-typed-artifact/v1',
+  name: 'packet',
+  type: 'json',
+  artifact_schema: 'example/schema/v1',
+  payload: { ok: true },
+  provenance: {},
+  file_refs: [{ path: 'packet.json' }],
+  metadata: { visible: true },
+});
+
+assert.deepEqual(Object.keys(normalizeTypedArtifacts([{ id: 'one' }, { name: 'two' }])).sort(), ['one', 'two']);
+console.log('wp-codebox artifact contract smoke passed');

--- a/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
+++ b/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
@@ -45,6 +45,64 @@ try {
 
 	assert.equal(taskInput.runtime_env.EXAMPLE_RUNTIME_TOOL_POLICY_JSON, process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON);
 	assert.equal(taskInput.runtime_env.DATAMACHINE_HOST_TOOL_POLICY_JSON, undefined);
+
+	const genericProfileTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+		schema: 'homeboy/agent-task-request/v1',
+		task_id: 'wp-codebox-generic-runtime-profile-smoke',
+		instructions: 'Validate generic WP Codebox runtime profile primitives.',
+		executor: {
+			backend: 'codebox',
+			config: {
+				provider: 'codex',
+				model: 'gpt-5.5',
+				runtime_task: {
+					ability: 'example/run-task',
+					input: {},
+				},
+				runtime_profile: {
+					schema: 'wp-codebox/runtime-profile/v1',
+					id: 'generic-codebox-runtime',
+					components: [
+						{ kind: 'component', slug: 'agents-api', source: '/runtime/agents-api', pluginFile: 'agents-api/agents-api.php' },
+						{ kind: 'parent-tool-bridge', slug: 'codebox-parent-tools', source: '/runtime/codebox-parent-tools' },
+					],
+					mu_plugins: [
+						{ kind: 'mu_plugin', slug: 'runtime-tools', source: '/runtime/runtime-tools' },
+					],
+					plugins: [
+						{ kind: 'plugin', slug: 'provider-plugin', source: '/runtime/provider-plugin', activate: true },
+					],
+					env: { EXAMPLE_RUNTIME: '1' },
+					provider_plugins: [{ path: '/runtime/provider-plugin' }],
+				},
+			},
+		},
+	});
+
+	assert.equal(genericProfileTaskInput.runtime_requirements.schema, 'wp-codebox/runtime-profile/v1');
+	assert.equal(genericProfileTaskInput.runtime_requirements.id, 'generic-codebox-runtime');
+	assert.deepEqual(genericProfileTaskInput.runtime_requirements.components.map((component) => component.slug), [
+		'agents-api',
+		'codebox-parent-tools',
+	]);
+	assert.deepEqual(genericProfileTaskInput.runtime_requirements.component_contracts.map((contract) => contract.slug), [
+		'agents-api',
+		'codebox-parent-tools',
+		'runtime-tools',
+		'provider-plugin',
+	]);
+	assert.deepEqual(genericProfileTaskInput.component_contracts.map((contract) => contract.slug), [
+		'agents-api',
+		'codebox-parent-tools',
+		'runtime-tools',
+		'provider-plugin',
+	]);
+	assert.equal(genericProfileTaskInput.runtime_requirements.component_contracts[0].loadAs, 'mu-plugin');
+	assert.equal(genericProfileTaskInput.runtime_requirements.component_contracts[3].loadAs, 'plugin');
+	assert.equal(genericProfileTaskInput.runtime_requirements.homeboy_parent_tool_bridge, undefined);
+	assert.deepEqual(genericProfileTaskInput.runtime_requirements.provider_plugins, [{ path: '/runtime/provider-plugin' }]);
+	assert.equal(genericProfileTaskInput.runtime_requirements.env.EXAMPLE_RUNTIME, '1');
+
 	console.log('wp-codebox runtime profile defaults smoke passed');
 } finally {
 	if (previousPolicy === undefined) {


### PR DESCRIPTION
## Summary
- Extract shared Codebox artifact contract helpers for typed artifact normalization, file refs, declaration naming, and path joining.
- Replace duplicated implementations in the Homeboy Codebox adapter and sandbox runner.
- Export the helper and add focused smoke coverage.

## Testing
- `node tests/wp-codebox-artifact-contract-smoke.mjs`
- `node tests/wp-codebox-callback-data-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node tests/wp-codebox-runtime-profile-defaults-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the helper extraction and smoke coverage; Chris remains responsible for review and validation.