### PR TITLE
Thin runtime agent adapter boundaries

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -85,14 +85,13 @@ jobs:
     secrets: inherit
 ```
 
-### Migrating Old Data Machine Bundle Callers
+### Migrating Old Wrapper Callers
 
-The former `datamachine-agent-ci.yml` reusable workflow has been removed after
-active default-branch callers migrated. Existing Data Machine bundle callers
-should call `runtime-agent-full-run.yml` directly and provide their runtime stack
-as explicit generic inputs.
+Removed domain-specific wrappers should migrate to `runtime-agent-full-run.yml`
+directly and provide their runtime stack as explicit generic inputs. Data Machine
+examples live in [`docs/integrations/datamachine.md`](../../docs/integrations/datamachine.md).
 
-Use this mapping when updating old workflow bodies:
+Use this mapping when updating old wrapper workflow bodies:
 
 | Old wrapper concept | Generic `runtime-agent-full-run.yml` input |
 | --- | --- |
@@ -131,55 +130,6 @@ The workflow keeps two GitHub authentication modes:
 The run summary includes the selected auth mode, target repository, token scope,
 and whether the caller required a Homeboy App token. Tokens are never printed.
 
-## Data Machine Bundle Example
-
-Workflows that need a Data Machine runtime can pass the runtime profile,
-dependencies, WordPress sandbox configuration, pre-run bootstrap work, and extra
-ability assertions through generic full-run inputs.
-
-```yaml
-jobs:
-  run-world-creator:
-    uses: Extra-Chill/homeboy-extensions/.github/workflows/runtime-agent-full-run.yml@v4
-    with:
-      runtime_provider: wp-codebox
-      runtime_ref: main
-      runtime_profile: datamachine-agent-ci
-      runtime_profiles: >-
-        {"datamachine-agent-ci":{"id":"datamachine-agent-ci","runtime_task_ability":"datamachine/run-agent-bundle","runtime_bundle_ability":"datamachine/run-agent-bundle","ability_requirements":["datamachine/run-agent-bundle"]}}
-      runtime_dependencies: '["Automattic/agents-api@main","Extra-Chill/data-machine@main","Extra-Chill/data-machine-code@main"]'
-      workload_id: world-creator-day-cycle-flow
-      workload_label: Run world-creator Data Machine agent
-      target_repo: chubes4/world-of-wordpress
-      prompt: ${{ inputs.prompt }}
-      runtime_execution: '{"kind":"bundle","source":"bundles/world-creator"}'
-      validation_dependencies: chubes4/world-of-wordpress@main,chubes4/markdown-database-integration@main
-      runtime_wordpress_version: beta
-      max_turns: 16
-      step_budget: 20
-      time_budget_ms: 900000
-      extra_wp_config_defines: |
-        {
-          "MARKDOWN_DB_MODE": "primary",
-          "MARKDOWN_DB_CONTENT_DIR": "/wordpress/wp-content/plugins/world-of-wordpress/content"
-        }
-      runtime_mounts: |
-        [
-          "${{ github.workspace }}/.ci/markdown-database-integration/db.php:/wordpress/wp-content/db.php:readonly"
-        ]
-      workload_run_before: |
-        [
-          { "type": "php", "file": "world-creator-bootstrap.php" }
-        ]
-      runtime_config: '{"daily_memory_enabled":true}'
-      required_abilities: |
-        ["datamachine/create-or-update-github-file", "datamachine/daily-memory-write"]
-      success_requires_pr: true
-      runtime_output_projections: '{"world_creator_pr_url":"metadata.engine_data.world_creator.pr_url"}'
-      transcript_artifact_name: world-creator-transcript-${{ github.run_id }}
-    secrets: inherit
-```
-
 ## Inputs worth calling out
 
 - Agent CI runs through the selected `runtime_provider`. Runtime metadata is discovered from `agent-runtimes/<runtime>/<runtime>.json` or another manifest JSON adjacent to the runtime.
@@ -189,7 +139,7 @@ jobs:
 - `ability_request` and `ability_input` are a shorthand for direct ability execution. `ability_input` is merged into `ability_request.input`.
 - `runtime_output_projections` maps named outputs to dotted paths in the provider runtime result.
 - Generic `runtime-agent-full-run.yml` callers can use `runtime_execution` for ability, bundle, or workflow descriptors and pass `runtime_output_projections` / `evidence_projections` through to the selected runtime config. Bundle/package descriptors derive the runtime task ability from the selected runtime profile, so callers do not need to provide `runtime_task.ability` for generic package runs.
-- `component_contracts` forwards explicit runtime component/plugin contracts to WP Codebox through the `wp-codebox/runtime-profile/v1` payload. Use it for caller-owned fixture ability providers or runtime components that are not part of the default Data Machine stack.
+- `component_contracts` forwards explicit runtime component/plugin contracts to WP Codebox through the `wp-codebox/runtime-profile/v1` payload. Use it for caller-owned fixture ability providers or runtime components that are not part of the selected runtime profile.
 - Generic WP Codebox executor paths accept caller-supplied component contracts, runtime overlays, mounts, task payload, provider defaults, and declarative runtime requirements. Domain policy belongs in caller inputs and runtime profiles, not in the generic WP Codebox provider manifest.
 - `runtime_dependencies` checks out the explicit runtime component stack and forwards those paths to WP Codebox as runtime component requirements.
 - `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `credentials` keys. When `provider: openai`, an empty object preserves the existing OpenAI provider defaults.
@@ -207,56 +157,19 @@ jobs:
 - `workload_run_before`, `workload_run_after`, and `required_abilities` must be JSON arrays.
 - `workload_run_after` runs post-agent verifier hooks in the same WordPress scenario, so consumers can assert the agent left WordPress in a valid state.
 - `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.
-- `evidence_projections` maps provider operation results to named runtime outputs or artifact refs. `tool_recorders` remains a legacy alias for existing Data Machine bundle callers that also need forced parameters.
+- `evidence_projections` maps provider operation results to named runtime outputs or artifact refs. `tool_recorders` remains a legacy alias for callers that also need forced parameters.
 - `pipeline_step_patches` and `flow_step_patches` modify imported bundle step config before the flow runs. They must be JSON arrays.
 - `runner_workspace` provisions a WP Codebox-managed runner workspace before the agent runs. By default it is agent-visible: the runner prepends the workspace handle and branch to the prompt and forces workspace tools to that handle. Set `expose_to_agent: false` for runner-owned capture mode; the natural prompt is preserved, workspace tools remain scoped when used, and the runner publishes captured workspace changes through the WP Codebox runner publication API after completion.
 - `runner_workspace.capture_changes` defaults to `true` only when `expose_to_agent: false`; set it explicitly to disable hidden-mode publication or to enable runner-owned capture while still exposing the workspace handle.
 - `verification_commands` and `drift_checks` run through the WP Codebox runner workspace command API, so remote runner workspaces do not require Homeboy to know backend-local paths.
 - If runner-owned workspace publication is unavailable or fails, the run fails as `write_without_pr`; Homeboy does not compose alternate PR fallback calls.
 
-## External Bundle And Tool Recording Example
+## External Bundle And Tool Recording
 
-Consumers such as `docs-agent` can keep the agent bundle in one repository while
-running it against another repository. The reusable workflow handles the bundle
-checkout and passes tool recorder config to the WordPress runner.
-
-```yaml
-jobs:
-  run-docs-agent:
-    uses: Extra-Chill/homeboy-extensions/.github/workflows/runtime-agent-full-run.yml@v4
-    with:
-      runtime_provider: wp-codebox
-      runtime_ref: main
-      runtime_profile: datamachine-agent-ci
-      runtime_profiles: >-
-        {"datamachine-agent-ci":{"id":"datamachine-agent-ci","runtime_task_ability":"datamachine/run-agent-bundle","runtime_bundle_ability":"datamachine/run-agent-bundle","ability_requirements":["datamachine/run-agent-bundle"]}}
-      runtime_dependencies: '["Automattic/agents-api@main","Extra-Chill/data-machine@main","Extra-Chill/data-machine-code@main"]'
-      runtime_execution: '{"kind":"bundle","source":".ci/docs-agent/bundles/docs-agent"}'
-      workload_id: docs-agent-flow
-      workload_label: Run docs-agent Data Machine agent
-      target_repo: Automattic/agents-api
-      validation_dependencies: Automattic/docs-agent@main
-      app_token_repos: Automattic/agents-api,Automattic/docs-agent
-      require_homeboy_app_token: true
-      allowed_repos: '["Automattic/agents-api", "Automattic/docs-agent"]'
-      tool_results_key: github_tool_results
-      evidence_projections: |
-        [
-          {
-            "operation": "create_or_update_github_file",
-            "outputs": {
-              "path": "parameters.path",
-              "commit_sha": "result.commit.sha"
-            }
-          }
-        ]
-      success_requires_pr: false
-      transcript_artifact_name: docs-agent-transcript-${{ github.run_id }}
-    secrets: inherit
-```
-
-Use `evidence_projections` when a consumer needs selected provider operation
-results copied into stable runner outputs.
+Consumers can keep an agent bundle in one repository while running it against
+another repository. The reusable workflow handles bundle checkout and passes tool
+recorder config to the runtime. Use `evidence_projections` when a consumer needs
+selected provider operation results copied into stable runner outputs.
 
 ## Provider plugin examples
 
@@ -279,9 +192,9 @@ jobs:
     secrets: inherit
 ```
 
-Non-OpenAI providers supply the plugin checkout and Data Machine credential
-mapping explicitly. Map each Data Machine option to one of the generic provider
-secret env names, then pass that secret in the reusable workflow call:
+Non-OpenAI providers supply the plugin checkout and credential mapping
+explicitly. Map each runtime option to one of the generic provider secret env
+names, then pass that secret in the reusable workflow call:
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ helper contract.
 Generic fanout/reconcile JSON planning is documented in
 [`docs/generic-fanout-reconcile-workflow.md`](docs/generic-fanout-reconcile-workflow.md).
 
+Integration-specific examples, including Data Machine Code promotion and Data
+Machine runtime-agent callers, live under [`docs/integrations/`](docs/integrations/).
+
 ## Available Extensions
 
 | Extension | Description |
@@ -115,62 +118,18 @@ homeboy test
 homeboy release
 ```
 
-### Data Machine Code promotion provider
-
-Homeboy core can promote agent-task patch artifacts through an external
-workspace provider command. This repo provides a Data Machine Code-backed
-provider script for environments that use managed DMC worktrees:
-
-```bash
-homeboy agent-task promote aggregate.json \
-  --to-worktree repo@branch-slug \
-  --provider-command ./scripts/datamachine-code-promotion-provider.sh
-```
-
-The provider reads `homeboy/agent-task-promotion-apply-request/v1` JSON on
-stdin and writes `homeboy/agent-task-promotion-apply-response/v1` JSON on
-stdout. It keeps the DMC-specific `studio wp datamachine-code ...` shellouts in
-Homeboy Extensions instead of Homeboy core.
-
 ### Runtime agent full-run tasks
 
 The reusable `.github/workflows/runtime-agent-full-run.yml` workflow is the
-recommended entrypoint for full runtime-backed agent and ability runs. It can
-run a generic WordPress ability directly through WP Codebox without importing an
-agent bundle. Use `runtime_task` or the `ability_request`/`ability_input`
-shorthand. Downloaded GitHub Actions artifacts can be mounted into the sandbox
-with `runtime_mounts`, and typed outputs can be enforced with
-`artifact_declarations` plus `runtime_output_projections`:
-
-```yaml
-jobs:
-  process-artifact:
-    uses: Extra-Chill/homeboy-extensions/.github/workflows/runtime-agent-full-run.yml@main
-    with:
-      homeboy_extensions_ref: main
-      runtime_provider: wp-codebox
-      runtime_ref: main
-      runtime_profile: artifact-processor
-      runtime_profiles: >-
-        {"artifact-processor":{"id":"artifact-processor","runtime_task_ability":"example/process-artifact","ability_requirements":["example/process-artifact"]}}
-      target_repo: Example/project
-      workload_id: artifact-flow
-      actions_artifact_downloads: >-
-        [{"repo":"Example/project","run_id":"123456789","name":"source-packet","dir":".ci/actions-artifacts/source-packet"}]
-      runtime_mounts: >-
-        [{"source":".ci/actions-artifacts/source-packet","target":"/workspace/input","mode":"readonly"}]
-      ability_request: >-
-        {"ability":"example/process-artifact","input":{"source_artifact":"/workspace/input/source.json"}}
-      runtime_output_projections: >-
-        {"processed_packet":"result.processed_packet"}
-      artifact_declarations: >-
-        [{"name":"processed_packet","type":"example-packet","schema":"example/processed-packet/v1","required":true}]
-      expected_artifacts: '["processed_packet"]'
-```
+recommended entrypoint for full runtime-backed agent and ability runs. Use
+`runtime_task` or the `ability_request`/`ability_input` shorthand for direct
+ability execution. Mount downloaded GitHub Actions artifacts with
+`runtime_mounts`, and enforce typed outputs with `artifact_declarations` plus
+`runtime_output_projections`.
 
 Call `.github/workflows/runtime-agent-full-run.yml` directly for runtime-backed
-agent runs. The former Data Machine-specific reusable workflow wrapper has been
-removed after active default-branch consumers migrated to the generic workflow.
+agent runs. See [`.github/workflows/README.md`](.github/workflows/README.md) for
+workflow inputs and integration examples.
 
 Use `component_contracts` only when the ability provider plugin or runtime
 component must be mounted explicitly. Keep ability names, schemas, and artifact

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -30,81 +30,20 @@ const {
   codeboxRuntimeProfilePayload,
   componentContractsFromRuntimeProfileDependencies,
 } = require('./codebox-runtime-profile');
-
-const WP_CODEBOX_TASK_REQUEST_SCHEMA = 'wp-codebox/task-input/v1';
-const WP_CODEBOX_PROVIDER_ID = 'wordpress.codebox-agent-task-executor';
-const WP_CODEBOX_PROVIDER_LABEL = 'WP Codebox agent task executor';
-const WP_CODEBOX_BACKEND = 'codebox';
-const WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA = 'wp-codebox/provider-runtime-invocation-contract/v1';
-
-const WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES = {
-  workspaceCapture: 'wp-codebox.runner-workspace.capture',
-  workspaceCommand: 'wp-codebox.runner-workspace.command',
-  workspacePublish: 'wp-codebox.runner-workspace.publish',
-  toolCallTranscriptRecord: 'wp-codebox.tool-call-transcript.record',
-  artifactHandoff: 'wp-codebox.artifact-handoff',
-};
-
-const WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES = {
-  workspaceCapture: 'wp-codebox/runner-workspace-capture',
-  workspaceCommand: 'wp-codebox/runner-workspace-command',
-  workspacePublish: 'wp-codebox/runner-workspace-publish',
-  toolCallTranscriptRecord: 'wp-codebox/record-tool-call-transcript',
-  artifactHandoff: 'wp-codebox/handoff-artifacts',
-};
-
-const WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS = {
-  workspace_capture: 'wp-codebox/runner-workspace-capture-result/v1',
-  workspace_command: 'wp-codebox/runner-workspace-command-result/v1',
-  workspace_publication: 'wp-codebox/runner-workspace-publication-result/v1',
-  tool_call_transcript: 'wp-codebox/tool-call-transcript/v1',
-  evidence_artifact_envelope: 'wp-codebox/evidence-artifact-envelope/v1',
-};
-
-const WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMA_KEYS = {
-  workspaceCapture: 'workspace_capture',
-  workspaceCommand: 'workspace_command',
-  workspacePublish: 'workspace_publication',
-  toolCallTranscriptRecord: 'tool_call_transcript',
-  artifactHandoff: 'evidence_artifact_envelope',
-};
-
-const WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES = Object.fromEntries(Object.entries({
-  workspaceCapture: [
-    'workspaceCapture',
-    'workspace_capture',
-    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.workspaceCapture,
-    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.workspaceCapture,
-  ],
-  workspaceCommand: [
-    'workspaceCommand',
-    'workspace_command',
-    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.workspaceCommand,
-    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.workspaceCommand,
-  ],
-  workspacePublish: [
-    'workspacePublish',
-    'workspace_publish',
-    'workspacePublication',
-    'workspace_publication',
-    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.workspacePublish,
-    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.workspacePublish,
-  ],
-  toolCallTranscriptRecord: [
-    'toolCallTranscriptRecord',
-    'tool_call_transcript_record',
-    'toolCallTranscript',
-    'tool_call_transcript',
-    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.toolCallTranscriptRecord,
-    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.toolCallTranscriptRecord,
-  ],
-  artifactHandoff: [
-    'artifactHandoff',
-    'artifact_handoff',
-    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.artifactHandoff,
-    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.artifactHandoff,
-  ],
-}).flatMap(([key, aliases]) => aliases.map((alias) => [alias, key])));
+const {
+  WP_CODEBOX_BACKEND,
+  WP_CODEBOX_PROVIDER_ID,
+  WP_CODEBOX_PROVIDER_LABEL,
+  WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES,
+  WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
+  WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS,
+  WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES,
+  WP_CODEBOX_ROLE_ALIASES,
+  WP_CODEBOX_TASK_REQUEST_SCHEMA,
+  wpCodeboxProviderRuntimeInvocationContract,
+  wpCodeboxProviderRuntimeOperationConfig,
+  wpCodeboxProviderRuntimeOperationEntry,
+} = require('./wp-codebox-adapter-contract');
 
 const RUNTIME_MANIFEST_PATH = path.resolve(__dirname, '..', 'wp-codebox.json');
 const RUNTIME_OVERLAY_CANONICAL_SHAPE = 'runtime_overlays entries must be objects. WP Codebox owns the runtime overlay schema and reports field-level validation.';
@@ -169,36 +108,6 @@ const LEGACY_BUNDLE_KEYS = [
 ];
 
 const WP_CODEBOX_RUNTIME_GAP_TRACKERS = [];
-
-const WP_CODEBOX_ROLE_ALIASES = {
-  artifact_roles: {
-    artifact_bundle: ['codebox-artifact-bundle', 'artifact-bundle', 'codebox-artifact-directory', 'codebox-session-artifacts'],
-    changed_files: ['codebox-changed-files'],
-    patch: ['codebox-patch'],
-    transcript: ['codebox-transcript', 'agent-runtime-transcript', 'agent-runtime-transcript-summary'],
-    runtime_log: ['codebox-runtime-log', 'codebox-recipe-startup-log'],
-    command_log: ['codebox-command-log'],
-    typed_artifact: ['typed-bundle-output'],
-    replay_bundle: ['agent-runtime-replay-bundle'],
-    pull_request: ['agent-runtime-pull-request'],
-    probe_result: ['codebox-recipe-probe-json', 'recipe-probe-result'],
-    screenshot: ['codebox-recipe-screenshot'],
-    side_effects: ['codebox-recipe-fake-side-effects'],
-    preflight_evidence: ['codebox-command-evidence', 'codebox-agent-task-input'],
-  },
-  artifact_kinds: {
-    patch: ['codebox-patch'],
-  },
-  artifact_filenames: {
-    preflight_evidence: ['homeboy-codebox-task-runner.json'],
-  },
-  outputs: {
-    provider_run_result: ['codebox_run_result'],
-  },
-  metadata: {
-    provider_run_result: ['codebox_run_result'],
-  },
-};
 
 function assertAgentTaskRequest(request) {
   if (!request || request.schema !== AGENT_TASK_REQUEST_SCHEMA) {
@@ -281,13 +190,7 @@ function runtimeComponentDiscovery(options = {}) {
 }
 
 function providerRuntimeInvocationContract() {
-  return {
-    schema: WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
-    version: 1,
-    tasks: { ...WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES },
-    abilities: { ...WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES },
-    result_schemas: { ...WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS },
-  };
+  return wpCodeboxProviderRuntimeInvocationContract();
 }
 
 function providerRuntimeInvocationFromConfig(config = {}, inputs = {}, options = {}) {
@@ -345,27 +248,11 @@ function providerRuntimeOperationEntries(requested) {
 }
 
 function providerRuntimeOperationEntry(operation, fallbackKey = '') {
-  const rawName = typeof operation === 'string'
-    ? operation
-    : firstValue(operation?.key, operation?.operation, operation?.task, operation?.ability, fallbackKey);
-  const key = WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES[rawName] || WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES[fallbackKey];
-  if (!key) {
-    return null;
-  }
-  return [key, providerRuntimeOperationConfig(key, operation)];
+  return wpCodeboxProviderRuntimeOperationEntry(operation, fallbackKey);
 }
 
 function providerRuntimeOperationConfig(key, operation) {
-  const resultSchemaKey = WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMA_KEYS[key];
-  const explicitConfig = operation && typeof operation === 'object' && !Array.isArray(operation)
-    ? firstObject(operation.config, operation.input, operation.args) || {}
-    : {};
-  return withoutUndefinedValues({
-    task: WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES[key],
-    ability: WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES[key],
-    result_schema: WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS[resultSchemaKey],
-    config: Object.keys(explicitConfig).length > 0 ? explicitConfig : undefined,
-  });
+  return wpCodeboxProviderRuntimeOperationConfig(key, operation);
 }
 
 function withoutUndefinedValues(value) {

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const WP_CODEBOX_TASK_REQUEST_SCHEMA = 'wp-codebox/task-input/v1';
+const WP_CODEBOX_PROVIDER_ID = 'wordpress.codebox-agent-task-executor';
+const WP_CODEBOX_PROVIDER_LABEL = 'WP Codebox agent task executor';
+const WP_CODEBOX_BACKEND = 'codebox';
+const WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA = 'wp-codebox/provider-runtime-invocation-contract/v1';
+
+const WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES = {
+  workspaceCapture: 'wp-codebox.runner-workspace.capture',
+  workspaceCommand: 'wp-codebox.runner-workspace.command',
+  workspacePublish: 'wp-codebox.runner-workspace.publish',
+  toolCallTranscriptRecord: 'wp-codebox.tool-call-transcript.record',
+  artifactHandoff: 'wp-codebox.artifact-handoff',
+};
+
+const WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES = {
+  workspaceCapture: 'wp-codebox/runner-workspace-capture',
+  workspaceCommand: 'wp-codebox/runner-workspace-command',
+  workspacePublish: 'wp-codebox/runner-workspace-publish',
+  toolCallTranscriptRecord: 'wp-codebox/record-tool-call-transcript',
+  artifactHandoff: 'wp-codebox/handoff-artifacts',
+};
+
+const WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS = {
+  workspace_capture: 'wp-codebox/runner-workspace-capture-result/v1',
+  workspace_command: 'wp-codebox/runner-workspace-command-result/v1',
+  workspace_publication: 'wp-codebox/runner-workspace-publication-result/v1',
+  tool_call_transcript: 'wp-codebox/tool-call-transcript/v1',
+  evidence_artifact_envelope: 'wp-codebox/evidence-artifact-envelope/v1',
+};
+
+const WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMA_KEYS = {
+  workspaceCapture: 'workspace_capture',
+  workspaceCommand: 'workspace_command',
+  workspacePublish: 'workspace_publication',
+  toolCallTranscriptRecord: 'tool_call_transcript',
+  artifactHandoff: 'evidence_artifact_envelope',
+};
+
+const WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES = Object.fromEntries(Object.entries({
+  workspaceCapture: [
+    'workspaceCapture',
+    'workspace_capture',
+    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.workspaceCapture,
+    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.workspaceCapture,
+  ],
+  workspaceCommand: [
+    'workspaceCommand',
+    'workspace_command',
+    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.workspaceCommand,
+    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.workspaceCommand,
+  ],
+  workspacePublish: [
+    'workspacePublish',
+    'workspace_publish',
+    'workspacePublication',
+    'workspace_publication',
+    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.workspacePublish,
+    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.workspacePublish,
+  ],
+  toolCallTranscriptRecord: [
+    'toolCallTranscriptRecord',
+    'tool_call_transcript_record',
+    'toolCallTranscript',
+    'tool_call_transcript',
+    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.toolCallTranscriptRecord,
+    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.toolCallTranscriptRecord,
+  ],
+  artifactHandoff: [
+    'artifactHandoff',
+    'artifact_handoff',
+    WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES.artifactHandoff,
+    WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES.artifactHandoff,
+  ],
+}).flatMap(([key, aliases]) => aliases.map((alias) => [alias, key])));
+
+const WP_CODEBOX_ROLE_ALIASES = {
+  artifact_roles: {
+    artifact_bundle: ['codebox-artifact-bundle', 'artifact-bundle', 'codebox-artifact-directory', 'codebox-session-artifacts'],
+    changed_files: ['codebox-changed-files'],
+    patch: ['codebox-patch'],
+    transcript: ['codebox-transcript', 'agent-runtime-transcript', 'agent-runtime-transcript-summary'],
+    runtime_log: ['codebox-runtime-log', 'codebox-recipe-startup-log'],
+    command_log: ['codebox-command-log'],
+    typed_artifact: ['typed-bundle-output'],
+    replay_bundle: ['agent-runtime-replay-bundle'],
+    pull_request: ['agent-runtime-pull-request'],
+    probe_result: ['codebox-recipe-probe-json', 'recipe-probe-result'],
+    screenshot: ['codebox-recipe-screenshot'],
+    side_effects: ['codebox-recipe-fake-side-effects'],
+    preflight_evidence: ['codebox-command-evidence', 'codebox-agent-task-input'],
+  },
+  artifact_kinds: {
+    patch: ['codebox-patch'],
+  },
+  artifact_filenames: {
+    preflight_evidence: ['homeboy-codebox-task-runner.json'],
+  },
+  outputs: {
+    provider_run_result: ['codebox_run_result'],
+  },
+  metadata: {
+    provider_run_result: ['codebox_run_result'],
+  },
+};
+
+function wpCodeboxProviderRuntimeInvocationContract() {
+  return {
+    schema: WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
+    version: 1,
+    tasks: { ...WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES },
+    abilities: { ...WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES },
+    result_schemas: { ...WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS },
+  };
+}
+
+function wpCodeboxProviderRuntimeOperationEntry(operation, fallbackKey = '') {
+  const rawName = typeof operation === 'string'
+    ? operation
+    : firstValue(operation?.key, operation?.operation, operation?.task, operation?.ability, fallbackKey);
+  const key = WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES[rawName] || WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES[fallbackKey];
+  if (!key) {
+    return null;
+  }
+  return [key, wpCodeboxProviderRuntimeOperationConfig(key, operation)];
+}
+
+function wpCodeboxProviderRuntimeOperationConfig(key, operation) {
+  const resultSchemaKey = WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMA_KEYS[key];
+  const explicitConfig = operation && typeof operation === 'object' && !Array.isArray(operation)
+    ? firstObject(operation.config, operation.input, operation.args) || {}
+    : {};
+  return withoutUndefinedValues({
+    task: WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES[key],
+    ability: WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES[key],
+    result_schema: WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS[resultSchemaKey],
+    config: Object.keys(explicitConfig).length > 0 ? explicitConfig : undefined,
+  });
+}
+
+function firstValue(...values) {
+  return values.find((value) => value !== undefined && value !== null && value !== '');
+}
+
+function firstObject(...values) {
+  return values.find((value) => value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function withoutUndefinedValues(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+module.exports = {
+  WP_CODEBOX_BACKEND,
+  WP_CODEBOX_PROVIDER_ID,
+  WP_CODEBOX_PROVIDER_LABEL,
+  WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES,
+  WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
+  WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES,
+  WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS,
+  WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES,
+  WP_CODEBOX_ROLE_ALIASES,
+  WP_CODEBOX_TASK_REQUEST_SCHEMA,
+  wpCodeboxProviderRuntimeInvocationContract,
+  wpCodeboxProviderRuntimeOperationConfig,
+  wpCodeboxProviderRuntimeOperationEntry,
+};

--- a/docs/integrations/datamachine.md
+++ b/docs/integrations/datamachine.md
@@ -1,0 +1,56 @@
+# Data Machine Integrations
+
+Homeboy Extensions keeps Data Machine caller examples out of the generic runtime
+contract docs. These examples show how Data Machine environments can use generic
+Homeboy seams without making Data Machine policy part of the base contract.
+
+## Data Machine Code Promotion Provider
+
+Homeboy core can promote agent-task patch artifacts through an external
+workspace provider command. This repo provides a Data Machine Code-backed
+provider script for environments that use managed DMC worktrees:
+
+```bash
+homeboy agent-task promote aggregate.json \
+  --to-worktree repo@branch-slug \
+  --provider-command ./scripts/datamachine-code-promotion-provider.sh
+```
+
+The provider reads `homeboy/agent-task-promotion-apply-request/v1` JSON on
+stdin and writes `homeboy/agent-task-promotion-apply-response/v1` JSON on
+stdout. It keeps the DMC-specific `studio wp datamachine-code ...` shellouts in
+Homeboy Extensions instead of Homeboy core.
+
+## Runtime Agent Full-Run Callers
+
+Data Machine bundle callers should call `.github/workflows/runtime-agent-full-run.yml`
+directly and provide their runtime stack as explicit generic inputs.
+
+```yaml
+jobs:
+  run-world-creator:
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/runtime-agent-full-run.yml@v4
+    with:
+      runtime_provider: wp-codebox
+      runtime_ref: main
+      runtime_profile: datamachine-agent-ci
+      runtime_profiles: >-
+        {"datamachine-agent-ci":{"id":"datamachine-agent-ci","runtime_task_ability":"datamachine/run-agent-bundle","runtime_bundle_ability":"datamachine/run-agent-bundle","ability_requirements":["datamachine/run-agent-bundle"]}}
+      runtime_dependencies: '["Automattic/agents-api@main","Extra-Chill/data-machine@main","Extra-Chill/data-machine-code@main"]'
+      workload_id: world-creator-day-cycle-flow
+      workload_label: Run world-creator Data Machine agent
+      target_repo: chubes4/world-of-wordpress
+      prompt: ${{ inputs.prompt }}
+      runtime_execution: '{"kind":"bundle","source":"bundles/world-creator"}'
+      runtime_wordpress_version: beta
+      required_abilities: |
+        ["datamachine/create-or-update-github-file", "datamachine/daily-memory-write"]
+      success_requires_pr: true
+      runtime_output_projections: '{"world_creator_pr_url":"metadata.engine_data.world_creator.pr_url"}'
+      transcript_artifact_name: world-creator-transcript-${{ github.run_id }}
+    secrets: inherit
+```
+
+Data Machine-specific ability names, source bundles, tool policy, and runtime
+dependencies belong in caller inputs or runtime profiles. Homeboy Extensions only
+forwards the generic runtime task contract.

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -61,7 +61,7 @@ function runtimeAgentCiRunnerSpec(options = {}, context = {}) {
   const config = taskExecutorConfig(options);
   return agentTaskRunnerSpec({
     backend: options.backend || options.runtimeBackend || options.runtime_backend,
-    runtime: options.runtime || options.runtimeId || options.runtime_id,
+    runtime: options.runtime || options.runtimeId || options.runtime_id || options.runtimeProvider || options.runtime_provider,
     config,
     secret_env: normalizeArray(config.secret_env),
     task_timeout_seconds: config.task_timeout_seconds || options.taskTimeoutSeconds || options.task_timeout_seconds || 900,

--- a/tests/agent-task-provider-contract-smoke.mjs
+++ b/tests/agent-task-provider-contract-smoke.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
@@ -39,6 +40,19 @@ const fields = agentTaskProviderContractFields();
 assert.equal(fields.request_schema, 'homeboy/agent-task-request/v1');
 assert.equal(fields.outcome_schema, 'homeboy/agent-task-outcome/v1');
 assert.deepEqual(fields.redacted_metadata_keys, AGENT_TASK_REDACTED_METADATA_KEYS);
+
+const coreContract = JSON.parse(fs.readFileSync(
+	path.join(rootDir, 'agent-runtimes', 'fixtures', 'homeboy-agent-task-core-contract.json'),
+	'utf8'
+));
+assert.deepEqual(fields, {
+	request_schema: coreContract.provider_capability.request_schema,
+	outcome_schema: coreContract.provider_capability.outcome_schema,
+	request_required_fields: coreContract.provider_capability.request_required_fields,
+	outcome_statuses: coreContract.provider_capability.outcome_statuses,
+	failure_classifications: coreContract.provider_capability.failure_classifications,
+	redacted_metadata_keys: coreContract.provider_capability.redacted_metadata_keys,
+});
 
 const extendedRedactionKeys = extendRedactedMetadataKeys('secrets', ['provider_auth', 'codex_auth']);
 assert.deepEqual(extendedRedactionKeys, ['secret_env_values', 'secretEnvValues', 'secrets', 'provider_auth', 'codex_auth']);
@@ -106,6 +120,7 @@ assert.throws(
 
 const runnerSpec = agentTaskRunnerSpec({
 	backend: 'codebox',
+	runtime: 'wp-codebox',
 	config: { provider: 'codex' },
 	secretEnv: ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN'],
 	taskTimeoutSeconds: 900,
@@ -119,6 +134,7 @@ assert.throws(
 assert.deepEqual(agentTaskRequestFromRunnerSpec({ runnerSpec }), {
 	executor: {
 		backend: 'codebox',
+		runtime: 'wp-codebox',
 		secret_env: ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN'],
 		config: { provider: 'codex' },
 	},

--- a/tests/architectural-boundary-quarantine.json
+++ b/tests/architectural-boundary-quarantine.json
@@ -3,6 +3,7 @@
   "datamachine-agent-ci/index.js": "Data Machine Agent CI compatibility-only package entrypoint; quarantine until callers migrate to runtime-agent-ci.",
   "datamachine-agent-ci/lib/datamachine-agent-ci-plan.js": "Data Machine Agent CI adapter constants and option mapping around generic runtime-agent-ci primitives.",
   "wordpress/lib/datamachine-agent-ci-codebox-adapter.js": "WordPress Codebox adapter shim that injects the Data Machine Agent CI runtime profile.",
+  "wordpress/lib/datamachine-agent-ci-runtime-adapter.js": "WordPress runtime adapter shim that maps Data Machine Agent CI inputs onto generic runtime-agent-ci primitives.",
   "wordpress/lib/datamachine-agent-ci-plan.js": "WordPress package compatibility wrapper around the quarantined Data Machine Agent CI adapter.",
   "wordpress/scripts/agent/build-replay-bundle.js": "Replay bundle projection keeps Data Machine provenance fields for legacy agent-ci evidence bundles.",
   "wordpress/scripts/agent/project-wpgym-eval-row.js": "WP Gym eval row projection keeps Data Machine provenance fields from legacy agent-ci evidence bundles.",

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -151,6 +151,7 @@ const genericRequest = runtimeAgentCi.runtimeAgentCiAbilityTaskRequest({
 
 assert.equal(genericRequest.schema, 'homeboy/agent-task-request/v1');
 assert.equal(genericRequest.executor.backend, 'codebox');
+assert.equal(genericRequest.executor.runtime, 'codebox');
 assert.deepEqual(genericRequest.expected_artifacts, ['packet']);
 assert.deepEqual(genericRequest.executor.config.runtime_task, { ability: 'example/run-task', input: { prompt: 'Cook.' } });
 

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+	WP_CODEBOX_BACKEND,
+	WP_CODEBOX_PROVIDER_ID,
+	WP_CODEBOX_PROVIDER_LABEL,
+	WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES,
+	WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS,
+	WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES,
+	WP_CODEBOX_ROLE_ALIASES,
+	WP_CODEBOX_TASK_REQUEST_SCHEMA,
+	wpCodeboxProviderRuntimeInvocationContract,
+	wpCodeboxProviderRuntimeOperationConfig,
+	wpCodeboxProviderRuntimeOperationEntry,
+} = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'wp-codebox-adapter-contract.js'));
+
+assert.equal(WP_CODEBOX_BACKEND, 'codebox');
+assert.equal(WP_CODEBOX_PROVIDER_ID, 'wordpress.codebox-agent-task-executor');
+assert.equal(WP_CODEBOX_PROVIDER_LABEL, 'WP Codebox agent task executor');
+assert.equal(WP_CODEBOX_TASK_REQUEST_SCHEMA, 'wp-codebox/task-input/v1');
+
+const invocationContract = wpCodeboxProviderRuntimeInvocationContract();
+assert.equal(invocationContract.schema, 'wp-codebox/provider-runtime-invocation-contract/v1');
+assert.deepEqual(invocationContract.tasks, WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES);
+assert.deepEqual(invocationContract.result_schemas, WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS);
+
+assert.equal(WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES.workspaceCapture, 'workspaceCapture');
+assert.equal(WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES['wp-codebox/runner-workspace-command'], 'workspaceCommand');
+assert.deepEqual(wpCodeboxProviderRuntimeOperationEntry('workspace_publication'), [
+	'workspacePublish',
+	{
+		task: 'wp-codebox.runner-workspace.publish',
+		ability: 'wp-codebox/runner-workspace-publish',
+		result_schema: 'wp-codebox/runner-workspace-publication-result/v1',
+	},
+]);
+assert.deepEqual(wpCodeboxProviderRuntimeOperationEntry({ ability: 'wp-codebox/handoff-artifacts', config: { required: true } }), [
+	'artifactHandoff',
+	{
+		task: 'wp-codebox.artifact-handoff',
+		ability: 'wp-codebox/handoff-artifacts',
+		result_schema: 'wp-codebox/evidence-artifact-envelope/v1',
+		config: { required: true },
+	},
+]);
+assert.equal(wpCodeboxProviderRuntimeOperationEntry('unknown-operation'), null);
+assert.deepEqual(wpCodeboxProviderRuntimeOperationConfig('toolCallTranscriptRecord'), {
+	task: 'wp-codebox.tool-call-transcript.record',
+	ability: 'wp-codebox/record-tool-call-transcript',
+	result_schema: 'wp-codebox/tool-call-transcript/v1',
+});
+
+assert.deepEqual(WP_CODEBOX_ROLE_ALIASES.artifact_roles.patch, ['codebox-patch']);
+
+console.log('wp-codebox adapter contract smoke passed');


### PR DESCRIPTION
## Summary
- Move Data Machine-specific examples out of the generic README/workflow docs into integration docs.
- Extract WP Codebox provider constants, operation aliases, role aliases, and invocation contract helpers into a named adapter module.
- Add fixture-backed contract smoke coverage for stable generic exports and focused WP Codebox adapter alias coverage.
- Preserve the small scope before upstream Homeboy/Codebox primitives land.

## Tests
- `node tests/agent-task-provider-contract-smoke.mjs`
- `node tests/wp-codebox-adapter-contract-smoke.mjs`
- `node tests/generic-agent-runtime-boundary-smoke.mjs`
- `node tests/wp-codebox-agent-runtime-command-contract-smoke.mjs`
- `node tests/wp-codebox-runtime-profile-defaults-smoke.mjs`
- `node tests/wp-codebox-provider-plugin-defaults-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node wordpress/tests/generic-agent-runtime-contract.test.js`
- `node tests/runtime-agent-ci-contract-smoke.mjs`
- `node tests/architectural-boundary-smoke.mjs`
- `bash tests/runtime-agent-full-run-boundary-smoke.sh`
- `git diff --check`

## Blockers
- `homeboy lint` did not run because the component has no extension provider configured for `homeboy-extensions` in the current Homeboy setup.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting the scoped docs, adapter extraction, and smoke-test updates; Chris remains responsible for review and validation.