### PR TITLE
Implement OpenCode agent task executor

### DIFF
--- a/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
+++ b/agent-runtimes/opencode/lib/opencode-agent-task-executor.js
@@ -1,9 +1,15 @@
 'use strict';
 
 /**
+ * External dependencies
+ */
+const { spawnSync } = require('node:child_process');
+
+/**
  * Internal dependencies
  */
 const {
+	AGENT_TASK_REQUEST_SCHEMA,
 	AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
 	AGENT_TASK_OUTCOME_SCHEMA,
 	agentTaskProviderContractFields,
@@ -65,33 +71,174 @@ function providerContract(options = {}) {
 			patch: ['git-diff', 'patch'],
 			report: ['json', 'markdown'],
 		},
-		status: 'experimental',
+		status: 'available',
 		integration_contract: 'homeboy-opencode-agent-task/v1',
-		runtime_gap_trackers: ['https://github.com/Extra-Chill/homeboy-extensions/issues/967'],
 	};
 }
 
-function experimentalOutcome(request = {}) {
+function outcome(request = {}, values = {}) {
 	return {
 		schema: AGENT_TASK_OUTCOME_SCHEMA,
 		task_id: request.task_id || '',
-		status: 'provider_error',
-		failure_classification: 'provider',
-		failure_code: 'agent_task.opencode_executor_not_implemented',
-		summary: 'OpenCode agent task executor is registered as an experimental provider contract only; process execution is not implemented yet.',
+		status: values.status || 'provider_error',
+		...(values.failure_classification ? { failure_classification: values.failure_classification } : {}),
+		...(values.failure_code ? { failure_code: values.failure_code } : {}),
+		summary: values.summary || 'OpenCode agent task executor failed before producing a detailed outcome.',
+		diagnostics: values.diagnostics || [],
 		artifacts: [],
 		evidence_refs: [],
 		metadata: {
 			provider: OPENCODE_PROVIDER_ID,
-			issue: 'https://github.com/Extra-Chill/homeboy-extensions/issues/967',
+			...(values.metadata || {}),
 		},
 	};
+}
+
+function validationFailure(request, message) {
+	return outcome(request, {
+		status: 'provider_error',
+		failure_classification: 'invalid_input',
+		failure_code: 'agent_task.invalid_opencode_request',
+		summary: 'OpenCode request validation failed.',
+		diagnostics: [{ classification: 'request_validation', message }],
+	});
+}
+
+function executeOpenCodeAgentTask(request = {}, options = {}) {
+	const validationError = validateRequest(request);
+	if (validationError) {
+		return validationFailure(request, validationError);
+	}
+
+	const config = request.executor.config || {};
+	const commandSpec = resolveCommandSpec(config, options);
+	if (commandSpec.error) {
+		return outcome(request, {
+			status: 'provider_error',
+			failure_classification: 'provider',
+			failure_code: 'agent_task.invalid_opencode_command',
+			summary: 'OpenCode command configuration is invalid.',
+			diagnostics: [{ classification: 'provider_setup', message: commandSpec.error }],
+		});
+	}
+
+	const args = [
+		...commandSpec.args,
+		'run',
+		...(config.model ? ['--model', config.model] : []),
+		...(config.agent ? ['--agent', config.agent] : []),
+		...(config.variant ? ['--variant', config.variant] : []),
+		...(config.title ? ['--title', config.title] : []),
+		request.instructions,
+	];
+	const timeoutSeconds = Number(request.limits?.task_timeout_seconds || config.timeout_seconds || 0);
+	const spawnResult = spawnSync(commandSpec.command, args, {
+		cwd: resolveCwd(request, config),
+		env: process.env,
+		encoding: 'utf8',
+		maxBuffer: options.maxBuffer || 10 * 1024 * 1024,
+		...(timeoutSeconds > 0 ? { timeout: timeoutSeconds * 1000 } : {}),
+	});
+
+	if (spawnResult.error?.code === 'ENOENT') {
+		return outcome(request, {
+			status: 'provider_error',
+			failure_classification: 'provider',
+			failure_code: 'agent_task.opencode_command_not_found',
+			summary: 'OpenCode command was not found.',
+			diagnostics: [{ classification: 'provider_setup', message: 'Install opencode or configure executor.config.command.' }],
+		});
+	}
+
+	if (spawnResult.error) {
+		const timedOut = spawnResult.error.code === 'ETIMEDOUT';
+		return outcome(request, {
+			status: timedOut ? 'timeout' : 'provider_error',
+			failure_classification: timedOut ? 'timeout' : 'provider',
+			failure_code: timedOut ? 'agent_task.opencode_timeout' : 'agent_task.opencode_spawn_failed',
+			summary: timedOut ? 'OpenCode execution timed out.' : 'OpenCode process failed to start or complete.',
+			diagnostics: [{ classification: timedOut ? 'timeout' : 'provider_setup', message: spawnResult.error.message }],
+		});
+	}
+
+	if (spawnResult.status === 0) {
+		return outcome(request, {
+			status: 'succeeded',
+			summary: 'OpenCode completed successfully.',
+			diagnostics: [{ classification: 'provider', message: 'OpenCode CLI exited with status 0.' }],
+			metadata: { exit_code: 0 },
+		});
+	}
+
+	return outcome(request, {
+		status: 'failed',
+		failure_classification: 'execution_failed',
+		failure_code: 'agent_task.opencode_failed',
+		summary: 'OpenCode execution failed.',
+		diagnostics: [{ classification: 'execution_failed', message: `OpenCode CLI exited with status ${spawnResult.status}.` }],
+		metadata: {
+			exit_code: spawnResult.status,
+			...(spawnResult.signal ? { signal: spawnResult.signal } : {}),
+		},
+	});
+}
+
+function validateRequest(request) {
+	if (!request || typeof request !== 'object' || Array.isArray(request)) {
+		return 'Request must be a JSON object.';
+	}
+	if (request.schema !== AGENT_TASK_REQUEST_SCHEMA) {
+		return `Request schema must be ${AGENT_TASK_REQUEST_SCHEMA}.`;
+	}
+	if (!request.task_id || typeof request.task_id !== 'string') {
+		return 'Request task_id is required.';
+	}
+	if (request.executor?.backend !== 'opencode') {
+		return 'Request executor.backend must be opencode.';
+	}
+	if (!request.executor.config || typeof request.executor.config !== 'object' || Array.isArray(request.executor.config)) {
+		return 'Request executor.config is required.';
+	}
+	if (!request.instructions || typeof request.instructions !== 'string') {
+		return 'Request instructions are required.';
+	}
+	return null;
+}
+
+function resolveCommandSpec(config = {}, options = {}) {
+	const configuredCommand = options.command || config.command || process.env.HOMEBOY_OPENCODE_COMMAND || 'opencode';
+	const configuredArgs = options.commandArgs || config.command_args || parseEnvCommandArgs();
+	if (typeof configuredCommand !== 'string' || configuredCommand.trim() === '') {
+		return { error: 'executor.config.command must be a non-empty string when provided.' };
+	}
+	if (!Array.isArray(configuredArgs) || configuredArgs.some((arg) => typeof arg !== 'string')) {
+		return { error: 'executor.config.command_args must be an array of strings when provided.' };
+	}
+	return { command: configuredCommand.trim(), args: configuredArgs };
+}
+
+function parseEnvCommandArgs() {
+	if (!process.env.HOMEBOY_OPENCODE_COMMAND_ARGS) {
+		return [];
+	}
+	try {
+		const value = JSON.parse(process.env.HOMEBOY_OPENCODE_COMMAND_ARGS);
+		return Array.isArray(value) ? value : [];
+	} catch {
+		return [];
+	}
+}
+
+function resolveCwd(request = {}, config = {}) {
+	return config.cwd || request.workspace_path || request.workspace?.path || process.cwd();
 }
 
 module.exports = {
 	OPENCODE_PROVIDER_ID,
 	OPENCODE_PROVIDER_LABEL,
 	OPENCODE_SECRET_ENV,
-	experimentalOutcome,
+	executeOpenCodeAgentTask,
+	outcome,
 	providerContract,
+	validationFailure,
 };

--- a/agent-runtimes/opencode/opencode.json
+++ b/agent-runtimes/opencode/opencode.json
@@ -3,7 +3,7 @@
   "id": "opencode",
   "name": "OpenCode",
   "version": "1.0.0",
-  "description": "Experimental OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.",
+  "description": "OpenCode agent runtime for nested orchestration and repository-scoped agent tasks.",
   "agent_task_executors": [
     {
       "schema": "homeboy/agent-task-executor-provider/v1",
@@ -102,11 +102,8 @@
         "patch": ["git-diff", "patch"],
         "report": ["json", "markdown"]
       },
-      "status": "experimental",
-      "integration_contract": "homeboy-opencode-agent-task/v1",
-      "runtime_gap_trackers": [
-        "https://github.com/Extra-Chill/homeboy-extensions/issues/967"
-      ]
+      "status": "available",
+      "integration_contract": "homeboy-opencode-agent-task/v1"
     }
   ]
 }

--- a/agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs
+++ b/agent-runtimes/opencode/scripts/agent/homeboy-opencode-agent-task-executor.cjs
@@ -5,7 +5,8 @@
 
 const fs = require('node:fs');
 const {
-	experimentalOutcome,
+	executeOpenCodeAgentTask,
+	outcome,
 	providerContract,
 } = require('../../lib/opencode-agent-task-executor');
 
@@ -28,10 +29,16 @@ if (raw.trim()) {
 	try {
 		request = JSON.parse(raw);
 	} catch (error) {
-		console.error(`Invalid AgentTaskRequest JSON: ${error.message}`);
-		process.exit(1);
+		process.stdout.write(`${JSON.stringify(outcome({}, {
+			status: 'provider_error',
+			failure_classification: 'invalid_input',
+			failure_code: 'agent_task.invalid_json',
+			summary: 'Invalid AgentTaskRequest JSON.',
+			diagnostics: [{ classification: 'request_validation', message: error.message }],
+		}), null, 2)}\n`);
+		process.exit(0);
 	}
 }
 
-process.stdout.write(`${JSON.stringify(experimentalOutcome(request), null, 2)}\n`);
-process.exit(1);
+process.stdout.write(`${JSON.stringify(executeOpenCodeAgentTask(request), null, 2)}\n`);
+process.exit(0);

--- a/wordpress/tests/opencode-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/opencode-agent-task-executor-boundary.test.js
@@ -14,7 +14,7 @@ const { spawnSync } = require('node:child_process');
  */
 const {
 	OPENCODE_SECRET_ENV,
-	experimentalOutcome,
+	executeOpenCodeAgentTask,
 	providerContract,
 } = require('../../agent-runtimes/opencode');
 
@@ -27,7 +27,7 @@ function secretEnvRequirementForProvider(contract, provider) {
 const provider = providerContract();
 assert.equal(provider.id, 'opencode.agent-task-executor');
 assert.equal(provider.backend, 'opencode');
-assert.equal(provider.status, 'experimental');
+assert.equal(provider.status, 'available');
 assert.equal(provider.integration_contract, 'homeboy-opencode-agent-task/v1');
 assert.equal(provider.lifecycle.max_concurrency_default, 1);
 assert.equal(provider.lifecycle.cancellation, 'provider_signal');
@@ -68,22 +68,57 @@ try {
 	);
 	assert.equal(fs.existsSync(scriptPath), true, `provider command target should exist: ${scriptPath}`);
 
+	const mockCliPath = path.join(root, 'mock-opencode.cjs');
+	fs.writeFileSync(mockCliPath, `#!/usr/bin/env node
+const assert = require('node:assert/strict');
+assert.equal(process.argv[2], 'run');
+assert.equal(process.argv.at(-1), 'Prove the OpenCode provider boundary without leaking secrets.');
+process.stdout.write(process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN || 'missing secret');
+process.stderr.write(process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN || 'missing secret');
+process.exit(0);
+`);
+
 	const contractResult = spawnSync(process.execPath, [scriptPath, '--provider-contract'], { encoding: 'utf8' });
 	assert.equal(contractResult.status, 0, contractResult.stderr);
 	assert.deepEqual(JSON.parse(contractResult.stdout), providerContract());
 
 	const runResult = spawnSync(process.execPath, [scriptPath], {
 		encoding: 'utf8',
+		env: {
+			...process.env,
+			AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: 'refresh-token-must-not-leak',
+			AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: 'access-token-must-not-leak',
+		},
 		input: JSON.stringify({
 			schema: 'homeboy/agent-task-request/v1',
-			task_id: 'opencode-contract-only',
-			executor: { backend: 'opencode', config: { provider: 'codex' } },
-			instructions: 'Prove the OpenCode provider boundary without running a model.',
+			task_id: 'opencode-real-executor',
+			executor: {
+				backend: 'opencode',
+				config: {
+					provider: 'codex',
+					command: process.execPath,
+					command_args: [mockCliPath],
+				},
+			},
+			instructions: 'Prove the OpenCode provider boundary without leaking secrets.',
 		}),
 	});
-	assert.notEqual(runResult.status, 0, 'experimental provider should fail fast until execution is implemented');
-	assert.deepEqual(JSON.parse(runResult.stdout), experimentalOutcome({ task_id: 'opencode-contract-only' }));
-	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN'), false);
+	assert.equal(runResult.status, 0, runResult.stderr);
+	assert.deepEqual(JSON.parse(runResult.stdout), executeOpenCodeAgentTask({
+		schema: 'homeboy/agent-task-request/v1',
+		task_id: 'opencode-real-executor',
+		executor: {
+			backend: 'opencode',
+			config: {
+				provider: 'codex',
+				command: process.execPath,
+				command_args: [mockCliPath],
+			},
+		},
+		instructions: 'Prove the OpenCode provider boundary without leaking secrets.',
+	}));
+	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('refresh-token-must-not-leak'), false);
+	assert.equal(`${runResult.stdout}\n${runResult.stderr}`.includes('access-token-must-not-leak'), false);
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- Implement the real OpenCode agent task executor boundary.
- Promote the OpenCode provider status to available.
- Keep normalized outcomes from copying child stdout/stderr or command arguments.

## Verification
- `node wordpress/tests/opencode-agent-task-executor-boundary.test.js`
- `node tests/agent-task-provider-contract-smoke.mjs`
- `node tests/agent-runtime-contract-smoke.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the executor implementation, tests, and PR description; Chris remains responsible for review and validation.
