### PR TITLE
Thin WP Codebox adapter contracts

### DIFF
--- a/agent-runtimes/wp-codebox/index.js
+++ b/agent-runtimes/wp-codebox/index.js
@@ -2,7 +2,10 @@
 
 module.exports = {
 	...require('./lib/codebox-agent-task-executor'),
+	...require('./lib/codebox-artifact-contract'),
+	...require('./lib/codebox-runtime-profile'),
 	...require('./lib/delegated-run-contract'),
+	...require('./lib/wp-codebox-adapter-contract'),
 	...require('./lib/provider-preflight-manifest'),
 	...require('./lib/provider-outcome-normalizer'),
 };

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -29,6 +29,7 @@ const {
 const {
   artifactNameFromDeclaration,
   artifactPath,
+  artifactRoleFromCodeboxArtifact,
   normalizeTypedArtifactEntry: normalizeCodeboxTypedArtifactEntry,
   normalizeTypedArtifacts: normalizeCodeboxTypedArtifacts,
   typedArtifactFileRefs: codeboxTypedArtifactFileRefs,
@@ -47,6 +48,7 @@ const {
   WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES,
   WP_CODEBOX_ROLE_ALIASES,
   WP_CODEBOX_TASK_REQUEST_SCHEMA,
+  WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
   wpCodeboxProviderRuntimeInvocationContract,
   wpCodeboxProviderRuntimeOperationConfig,
   wpCodeboxProviderRuntimeOperationEntry,
@@ -150,6 +152,7 @@ function providerContract(options = {}) {
     provider_preflight: runtimeProviderPreflight(),
     provider_runtime_invocation: providerRuntimeInvocationContract(),
     role_aliases: WP_CODEBOX_ROLE_ALIASES,
+    upstream_primitive_requirements: WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
     status: 'active',
     integration_contract: 'homeboy-wordpress-agent-task/v1',
     runtime_gap_trackers: WP_CODEBOX_RUNTIME_GAP_TRACKERS,
@@ -2222,7 +2225,7 @@ function normalizeCodeboxArtifactOutcome(artifact, rawArtifact = {}) {
     return artifact;
   }
   const nativeKind = rawArtifact.kind || rawArtifact.type || artifact.kind || '';
-  const role = providerNeutralArtifactRole({ ...artifact, kind: nativeKind });
+  const role = artifactRoleFromCodeboxArtifact({ ...artifact, kind: nativeKind }, WP_CODEBOX_ROLE_ALIASES);
   const metadata = artifact.metadata && typeof artifact.metadata === 'object' && !Array.isArray(artifact.metadata)
     ? artifact.metadata
     : {};
@@ -2239,50 +2242,6 @@ function normalizeCodeboxArtifactOutcome(artifact, rawArtifact = {}) {
       },
     }),
   };
-}
-
-function providerNeutralArtifactRole(artifact = {}) {
-  const label = `${artifact.kind || ''} ${artifact.name || ''} ${artifact.id || ''} ${artifact.path || ''} ${artifact.url || ''}`;
-  if (/patch|diff/i.test(label)) {
-    return 'patch';
-  }
-  if (/changed[-_ ]?files/i.test(label)) {
-    return 'changed_files';
-  }
-  if (/transcript|conversation|messages/i.test(label)) {
-    return 'transcript';
-  }
-  if (/typed[-_ ]?bundle[-_ ]?output|typed[-_ ]?artifact/i.test(label)) {
-    return 'typed_artifact';
-  }
-  if (/replay[-_ ]?bundle/i.test(label)) {
-    return 'replay_bundle';
-  }
-  if (/pull[-_ ]?request/i.test(label)) {
-    return 'pull_request';
-  }
-  if (/screenshot/i.test(label)) {
-    return 'screenshot';
-  }
-  if (/probe/i.test(label)) {
-    return 'probe_result';
-  }
-  if (/side[-_ ]?effects?/i.test(label)) {
-    return 'side_effects';
-  }
-  if (/command[-_ ]?evidence|agent[-_ ]?task[-_ ]?input|homeboy-codebox-task-runner\.json/i.test(label)) {
-    return 'preflight_evidence';
-  }
-  if (/command[-_ ]?log/i.test(label)) {
-    return 'command_log';
-  }
-  if (/runtime[-_ ]?log|startup[-_ ]?log/i.test(label)) {
-    return 'runtime_log';
-  }
-  if (/artifact[-_ ]?bundle|artifact[-_ ]?directory|session[-_ ]?artifacts/i.test(label)) {
-    return 'artifact_bundle';
-  }
-  return 'artifact';
 }
 
 function pathValue(source, dottedPath) {

--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -2,6 +2,22 @@
 
 const TYPED_ARTIFACT_SCHEMA = 'homeboy/agent-task-typed-artifact/v1';
 
+const ARTIFACT_ROLE_FALLBACK_PATTERNS = [
+  ['patch', /patch|diff/i],
+  ['changed_files', /changed[-_ ]?files/i],
+  ['transcript', /transcript|conversation|messages/i],
+  ['typed_artifact', /typed[-_ ]?bundle[-_ ]?output|typed[-_ ]?artifact/i],
+  ['replay_bundle', /replay[-_ ]?bundle/i],
+  ['pull_request', /pull[-_ ]?request/i],
+  ['screenshot', /screenshot/i],
+  ['probe_result', /probe/i],
+  ['side_effects', /side[-_ ]?effects?/i],
+  ['preflight_evidence', /command[-_ ]?evidence|agent[-_ ]?task[-_ ]?input|homeboy-codebox-task-runner\.json/i],
+  ['command_log', /command[-_ ]?log/i],
+  ['runtime_log', /runtime[-_ ]?log|startup[-_ ]?log/i],
+  ['artifact_bundle', /artifact[-_ ]?bundle|artifact[-_ ]?directory|session[-_ ]?artifacts/i],
+];
+
 function normalizeTypedArtifactEntry(name, artifact, options = {}) {
   if (!plainObject(artifact)) {
     return null;
@@ -66,8 +82,63 @@ function artifactPath(root, relativePath) {
   return `${String(root).replace(/\/$/, '')}/${String(relativePath).replace(/^\//, '')}`;
 }
 
+function artifactRoleFromCodeboxArtifact(artifact = {}, roleAliases = {}) {
+  const labels = artifactLabels(artifact);
+  const explicitRole = roleFromAliases(labels, roleAliases);
+  if (explicitRole) {
+    return explicitRole;
+  }
+  const fallbackLabel = labels.join(' ');
+  const fallback = ARTIFACT_ROLE_FALLBACK_PATTERNS.find(([, pattern]) => pattern.test(fallbackLabel));
+  return fallback?.[0] || 'artifact';
+}
+
+function roleFromAliases(labels, roleAliases = {}) {
+  const normalizedLabels = labels.map(normalizeLabel).filter(Boolean);
+  const aliasGroups = [
+    roleAliases.artifact_roles,
+    roleAliases.artifact_kinds,
+    roleAliases.artifact_filenames,
+  ].filter(plainObject);
+  for (const aliases of aliasGroups) {
+    for (const [role, values] of Object.entries(aliases)) {
+      if (normalizeArray(values).map(normalizeLabel).some((alias) => normalizedLabels.includes(alias))) {
+        return role;
+      }
+    }
+  }
+  return '';
+}
+
+function artifactLabels(artifact = {}) {
+  return [
+    artifact.role,
+    artifact.kind,
+    artifact.type,
+    artifact.name,
+    artifact.id,
+    artifact.path,
+    artifact.url,
+    artifact.file,
+    artifact.directory,
+    basename(artifact.path || artifact.url || artifact.file || artifact.directory || ''),
+  ].filter(Boolean).map(String);
+}
+
+function basename(value) {
+  return String(value).split(/[\\/]/).filter(Boolean).pop() || '';
+}
+
+function normalizeLabel(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
 function plainObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
 }
 
 function cleanObject(value) {
@@ -77,6 +148,7 @@ function cleanObject(value) {
 
 module.exports = {
   TYPED_ARTIFACT_SCHEMA,
+  artifactRoleFromCodeboxArtifact,
   artifactNameFromDeclaration,
   artifactPath,
   normalizeTypedArtifactEntry,

--- a/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
@@ -26,6 +26,18 @@ function codeboxRuntimeProfilePayload({
   const normalizedProfile = plainObject(profile);
   const normalizedRuntimeRequirements = plainObject(runtimeRequirements);
   const runtimeProfileDependencies = runtimeProfileDependencyFields(normalizedProfile, normalizedRuntimeRequirements);
+  const normalizedRuntimeOverlays = uniqueObjectsByRuntimeIdentity([
+    ...normalizeArray(normalizedProfile.runtime_overlays),
+    ...normalizeArray(normalizedRuntimeRequirements.runtime_overlays),
+    ...normalizeArray(runtimeOverlays),
+  ]);
+  const normalizedRuntimeEnv = {
+    ...plainObject(normalizedProfile.env),
+    ...plainObject(normalizedProfile.runtime_env),
+    ...plainObject(normalizedRuntimeRequirements.env),
+    ...plainObject(normalizedRuntimeRequirements.runtime_env),
+    ...plainObject(runtimeEnv),
+  };
   const normalizedComponentContracts = uniqueObjectsByRuntimeIdentity([
     ...normalizeArray(normalizedProfile.component_contracts),
     ...normalizeArray(normalizedRuntimeRequirements.component_contracts),
@@ -33,8 +45,8 @@ function codeboxRuntimeProfilePayload({
     ...normalizeArray(componentContracts),
   ]);
   const normalizedProviderPlugins = uniqueObjectsByRuntimeIdentity([
-    ...normalizeArray(normalizedProfile.provider_plugins),
-    ...normalizeArray(normalizedRuntimeRequirements.provider_plugins),
+    ...providerPluginEntries(normalizedProfile.provider_plugins),
+    ...providerPluginEntries(normalizedRuntimeRequirements.provider_plugins),
     ...providerPluginPaths.map((pluginPath) => ({ path: pluginPath })),
   ]);
   return withoutEmptyObjectValues({
@@ -46,12 +58,21 @@ function codeboxRuntimeProfilePayload({
     ...runtimeProfileDependencies,
     component_contracts: normalizedComponentContracts,
     extra_plugins: normalizedComponentContracts,
-    runtime_overlays: runtimeOverlays,
-    env: runtimeEnv,
+    runtime_overlays: normalizedRuntimeOverlays,
+    env: normalizedRuntimeEnv,
     provider_plugins: normalizedProviderPlugins,
     runtime_state_mounts: runtimeStateMounts,
     runtime_config_mounts: runtimeConfigMounts,
     ...parentToolBridgeProfileFields(normalizedProfile, normalizedRuntimeRequirements, runtimeProfileDependencies, normalizedComponentContracts),
+  });
+}
+
+function providerPluginEntries(value) {
+  return normalizeArray(value).flatMap((entry) => {
+    if (typeof entry === 'string') {
+      return [{ path: entry }];
+    }
+    return entry;
   });
 }
 

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -105,6 +105,37 @@ const WP_CODEBOX_ROLE_ALIASES = {
   },
 };
 
+const WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS = [
+  {
+    id: 'runtime-profile',
+    schema: 'wp-codebox/runtime-profile/v1',
+    owner: 'wp-codebox',
+    adapter_behavior: 'forward_profile_payload',
+    requirement: 'Consume generic runtime dependencies, provider plugins, overlays, env, and mounts without Homeboy expanding Codebox orchestration internals.',
+  },
+  {
+    id: 'parent-tool-bridge',
+    schema: 'wp-codebox/parent-tool-bridge/v1',
+    owner: 'wp-codebox',
+    adapter_behavior: 'declare_requirement_when_missing',
+    requirement: 'Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component instead of Homeboy injecting bridge implementation details.',
+  },
+  {
+    id: 'provider-runtime-invocation',
+    schema: WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
+    owner: 'wp-codebox',
+    adapter_behavior: 'declare_task_and_ability_names',
+    requirement: 'Provide runner workspace, transcript recording, and artifact handoff operations behind stable task/ability names.',
+  },
+  {
+    id: 'artifact-result-envelope',
+    schema: WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS.evidence_artifact_envelope,
+    owner: 'wp-codebox',
+    adapter_behavior: 'normalize_declared_artifacts',
+    requirement: 'Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts.',
+  },
+];
+
 function wpCodeboxProviderRuntimeInvocationContract() {
   return {
     schema: WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
@@ -162,6 +193,7 @@ module.exports = {
   WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES,
   WP_CODEBOX_ROLE_ALIASES,
   WP_CODEBOX_TASK_REQUEST_SCHEMA,
+  WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
   wpCodeboxProviderRuntimeInvocationContract,
   wpCodeboxProviderRuntimeOperationConfig,
   wpCodeboxProviderRuntimeOperationEntry,

--- a/agent-runtimes/wp-codebox/package.json
+++ b/agent-runtimes/wp-codebox/package.json
@@ -7,8 +7,10 @@
     ".": "./index.js",
     "./codebox-artifact-contract": "./lib/codebox-artifact-contract.js",
     "./codebox-agent-task-executor": "./lib/codebox-agent-task-executor.js",
+    "./codebox-runtime-profile": "./lib/codebox-runtime-profile.js",
     "./delegated-run-contract": "./lib/delegated-run-contract.js",
-    "./provider-outcome-normalizer": "./lib/provider-outcome-normalizer.js"
+    "./provider-outcome-normalizer": "./lib/provider-outcome-normalizer.js",
+    "./wp-codebox-adapter-contract": "./lib/wp-codebox-adapter-contract.js"
   },
   "bin": {
     "homeboy-codebox-agent-task-executor": "./scripts/agent/homeboy-codebox-agent-task-executor.cjs"

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -359,6 +359,36 @@
           "provider_run_result": ["codebox_run_result"]
         }
       },
+      "upstream_primitive_requirements": [
+        {
+          "id": "runtime-profile",
+          "schema": "wp-codebox/runtime-profile/v1",
+          "owner": "wp-codebox",
+          "adapter_behavior": "forward_profile_payload",
+          "requirement": "Consume generic runtime dependencies, provider plugins, overlays, env, and mounts without Homeboy expanding Codebox orchestration internals."
+        },
+        {
+          "id": "parent-tool-bridge",
+          "schema": "wp-codebox/parent-tool-bridge/v1",
+          "owner": "wp-codebox",
+          "adapter_behavior": "declare_requirement_when_missing",
+          "requirement": "Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component instead of Homeboy injecting bridge implementation details."
+        },
+        {
+          "id": "provider-runtime-invocation",
+          "schema": "wp-codebox/provider-runtime-invocation-contract/v1",
+          "owner": "wp-codebox",
+          "adapter_behavior": "declare_task_and_ability_names",
+          "requirement": "Provide runner workspace, transcript recording, and artifact handoff operations behind stable task/ability names."
+        },
+        {
+          "id": "artifact-result-envelope",
+          "schema": "wp-codebox/evidence-artifact-envelope/v1",
+          "owner": "wp-codebox",
+          "adapter_behavior": "normalize_declared_artifacts",
+          "requirement": "Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts."
+        }
+      ],
       "status": "active",
       "integration_contract": "homeboy-wordpress-agent-task/v1",
       "runtime_gap_trackers": []

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -15,6 +15,7 @@ const {
 	WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES,
 	WP_CODEBOX_ROLE_ALIASES,
 	WP_CODEBOX_TASK_REQUEST_SCHEMA,
+	WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
 	wpCodeboxProviderRuntimeInvocationContract,
 	wpCodeboxProviderRuntimeOperationConfig,
 	wpCodeboxProviderRuntimeOperationEntry,
@@ -57,5 +58,11 @@ assert.deepEqual(wpCodeboxProviderRuntimeOperationConfig('toolCallTranscriptReco
 });
 
 assert.deepEqual(WP_CODEBOX_ROLE_ALIASES.artifact_roles.patch, ['codebox-patch']);
+assert.deepEqual(WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.map((requirement) => requirement.id), [
+	'runtime-profile',
+	'parent-tool-bridge',
+	'provider-runtime-invocation',
+	'artifact-result-envelope',
+]);
 
 console.log('wp-codebox adapter contract smoke passed');

--- a/tests/wp-codebox-artifact-contract-smoke.mjs
+++ b/tests/wp-codebox-artifact-contract-smoke.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 const require = createRequire(import.meta.url);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const {
+  artifactRoleFromCodeboxArtifact,
   artifactNameFromDeclaration,
   artifactPath,
   normalizeTypedArtifactEntry,
@@ -17,6 +18,8 @@ const {
 assert.equal(artifactPath('/tmp/artifacts/', '/files/transcript.json'), '/tmp/artifacts/files/transcript.json');
 assert.equal(artifactPath('', 'files/transcript.json'), '');
 assert.equal(artifactNameFromDeclaration({ id: 'transcript' }), 'transcript');
+assert.equal(artifactRoleFromCodeboxArtifact({ kind: 'codebox-patch' }, { artifact_roles: { patch: ['codebox-patch'] } }), 'patch');
+assert.equal(artifactRoleFromCodeboxArtifact({ path: '/tmp/files/changed-files.json' }), 'changed_files');
 
 assert.deepEqual(typedArtifactFileRefs({ fileRefs: [{ path: 'artifact.json' }] }), [{ path: 'artifact.json' }]);
 

--- a/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
+++ b/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
@@ -9,6 +9,9 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const { codeboxTaskRequestFromAgentTaskRequest } = require(
 	path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'codebox-agent-task-executor.js')
 );
+const { codeboxRuntimeProfilePayload } = require(
+	path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'codebox-runtime-profile.js')
+);
 
 const previousPolicy = process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON;
 
@@ -102,6 +105,37 @@ try {
 	assert.equal(genericProfileTaskInput.runtime_requirements.homeboy_parent_tool_bridge, undefined);
 	assert.deepEqual(genericProfileTaskInput.runtime_requirements.provider_plugins, [{ path: '/runtime/provider-plugin' }]);
 	assert.equal(genericProfileTaskInput.runtime_requirements.env.EXAMPLE_RUNTIME, '1');
+
+	const mergedProfile = codeboxRuntimeProfilePayload({
+		profile: {
+			id: 'shared-profile-helper',
+			runtime_overlays: [{ kind: 'library', library: 'php-ai-client', source: '/runtime/php-ai-client' }],
+			env: { PROFILE_ENV: '1', SHARED_ENV: 'profile' },
+			provider_plugins: ['/runtime/provider-from-profile'],
+		},
+		runtimeRequirements: {
+			runtime_overlays: [{ kind: 'plugin', slug: 'agents-api', source: '/runtime/agents-api' }],
+			env: { REQUIREMENT_ENV: '1', SHARED_ENV: 'requirement' },
+		},
+		runtimeOverlays: [{ kind: 'mu-plugin', slug: 'runtime-tools', source: '/runtime/runtime-tools' }],
+		runtimeEnv: { REQUEST_ENV: '1', SHARED_ENV: 'request' },
+		providerPluginPaths: ['/runtime/provider-from-request'],
+	});
+	assert.deepEqual(mergedProfile.runtime_overlays.map((overlay) => overlay.source), [
+		'/runtime/php-ai-client',
+		'/runtime/agents-api',
+		'/runtime/runtime-tools',
+	]);
+	assert.deepEqual(mergedProfile.env, {
+		PROFILE_ENV: '1',
+		SHARED_ENV: 'request',
+		REQUIREMENT_ENV: '1',
+		REQUEST_ENV: '1',
+	});
+	assert.deepEqual(mergedProfile.provider_plugins, [
+		{ path: '/runtime/provider-from-profile' },
+		{ path: '/runtime/provider-from-request' },
+	]);
 
 	console.log('wp-codebox runtime profile defaults smoke passed');
 } finally {

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -71,9 +71,9 @@ assert.deepEqual(provider.runner_readiness, [{
     env: ['HOMEBOY_WP_CODEBOX_BIN'],
     candidates: ['wp-codebox'],
     version_command: ['--version'],
-    install_hint: 'Install WP Codebox or set HOMEBOY_WP_CODEBOX_BIN to the wp-codebox executable path.',
+    install_hint: 'Install WP Codebox or set the generic runtime_bin executor config; HOMEBOY_WP_CODEBOX_BIN remains a legacy compatibility env alias.',
   },
-  remediation: 'Install WP Codebox or set HOMEBOY_WP_CODEBOX_BIN to the wp-codebox executable path.',
+  remediation: 'Install WP Codebox or set the generic runtime_bin executor config; HOMEBOY_WP_CODEBOX_BIN remains a legacy compatibility env alias.',
 }]);
 assert.deepEqual(secretEnvRequirementForProvider(runtime.agent_task_executors[0], 'codex').env, codexSecretEnv);
 assert.equal(provider.capabilities.includes('tool:wpsg_materialize_packet'), false);


### PR DESCRIPTION
## Summary
- move Codebox artifact role classification into shared contract helpers
- merge runtime overlays, env, and provider plugins through the runtime profile helper
- export shared Codebox contract helpers and document upstream primitive requirements

## Dependency
- Aligns with the upstream Codebox lifecycle/contract direction: https://github.com/Automattic/wp-codebox/pull/1220

## Tests
- node tests/wp-codebox-runtime-profile-defaults-smoke.mjs
- node tests/wp-codebox-adapter-contract-smoke.mjs
- node tests/wp-codebox-artifact-contract-smoke.mjs
- npm run test:codebox-agent-task-executor-boundary
- npm run test:codebox-agent-task-executor
- node tests/codebox-delegated-run-normalizer-smoke.mjs
- node tests/wp-codebox-provider-plugin-defaults-smoke.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing Codebox orchestration overlap, drafting adapter contract cleanup, and running verification; Chris remains responsible for review and landing.