### PR TITLE
Add generic finding packet fanout helpers

### DIFF
--- a/docs/generic-fanout-reconcile-workflow.md
+++ b/docs/generic-fanout-reconcile-workflow.md
@@ -50,4 +50,15 @@ node wordpress/scripts/agent/homeboy-generic-fanout-reconcile.cjs \
 
 Records are matched by `id`, `task_id`, `sandbox_session_id`, or `group_key`. Successful statuses default to `completed`, `success`, and `passed`; override with `success_statuses` in config. Outcomes default to the record `outcome` field; override with `outcome_path`.
 
+## Finding Packets
+
+`wordpress/lib/generic-fanout-reconcile-workflow.js` also exports helpers for diagnostic/finding packet inputs:
+
+- `normalizeFindingPacketItems(packets, policy)` flattens packet-level `findings` or `diagnostics` arrays into generic items with stable packet/finding IDs.
+- `materializeFindingPacketFanoutConfig({ packets, policy, ...config })` applies policy-driven grouping and returns the generic config/groups/items needed by the planner.
+- `createFindingPacketFanoutPlan(input)` creates the fanout plan directly from packets.
+- `createFindingPacketReconcileInput({ packets, policy, plan, records })` normalizes executed task records into the input shape accepted by `createGenericFanoutReconcileResult()`.
+
+Grouping policy is data-driven. By default packets group by `finding.type` and `finding.severity`; callers can pass `group_by`/`groupBy` path arrays or a `group_key_template` such as `{{finding.type}}:{{finding.severity}}`. The default task request carries generic `item_ids`, `packet_ids`, `finding_count`, and `inputs.findings`; callers can still provide their own `task_request_template` and opaque `runtime_execution` descriptor.
+
 Execution descriptors are caller-owned and opaque to this helper. Keep provider names, credentials, WordPress setup, sandbox recipes, repository-specific instructions, and provider-specific request details such as `wp-codebox/task-input/v1` in caller config or implementation-specific workflow examples, not in this generic reconcile helper.

--- a/wordpress/lib/generic-fanout-reconcile-workflow.js
+++ b/wordpress/lib/generic-fanout-reconcile-workflow.js
@@ -13,6 +13,7 @@ const {
 
 const CONFIG_SCHEMA = 'homeboy/generic-fanout-reconcile-config/v1';
 const RESULT_SCHEMA = 'homeboy/generic-fanout-reconcile-result/v1';
+const FINDING_PACKET_CONFIG_SCHEMA = 'homeboy/generic-finding-packet-fanout-config/v1';
 
 function createGenericFanoutReconcilePlan(input = {}) {
   const config = normalizeConfig(input.config || input);
@@ -38,6 +39,58 @@ function createGenericFanoutReconcilePlan(input = {}) {
       config,
     }),
   });
+}
+
+function createFindingPacketFanoutPlan(input = {}) {
+  const materialized = materializeFindingPacketFanoutConfig(input);
+  return createGenericFanoutReconcilePlan({
+    config: materialized.config,
+    groups: materialized.groups,
+  });
+}
+
+function materializeFindingPacketFanoutConfig(input = {}) {
+  const baseConfig = normalizeConfig(input.config || {});
+  const policy = normalizeFindingPolicy(input.policy || baseConfig.finding_policy || baseConfig.findingPolicy || {});
+  const packets = input.packets || input.finding_packets || input.findingPackets || baseConfig.packets || baseConfig.finding_packets || [];
+  const items = normalizeFindingPacketItems(packets, policy);
+  const groups = groupFindingPacketItems(items, policy);
+  const orchestrator = input.orchestrator || baseConfig.orchestrator || {};
+  const taskRequestTemplate = input.task_request_template || input.taskRequestTemplate || baseConfig.task_request_template || baseConfig.taskRequestTemplate || defaultFindingPacketTaskTemplate(policy);
+
+  return {
+    config: {
+      ...baseConfig,
+      schema: baseConfig.schema || FINDING_PACKET_CONFIG_SCHEMA,
+      orchestrator,
+      task_request_template: taskRequestTemplate,
+      runtime_execution: baseConfig.runtime_execution || baseConfig.runtimeExecution || baseConfig.runtime || input.runtime_execution || input.runtimeExecution || input.runtime,
+      summary: {
+        packet_count: countFindingPackets(packets),
+        finding_count: items.length,
+        grouping: {
+          strategy: policy.group_key_template ? 'template' : 'paths',
+          paths: policy.group_by,
+        },
+        ...(baseConfig.summary || {}),
+      },
+      finding_policy: policy,
+    },
+    groups,
+    items,
+  };
+}
+
+function createFindingPacketReconcileInput(input = {}) {
+  const materialized = materializeFindingPacketFanoutConfig(input);
+  return {
+    config: materialized.config,
+    plan: input.plan || createGenericFanoutReconcilePlan({
+      config: materialized.config,
+      groups: materialized.groups,
+    }),
+    records: normalizeFindingPacketRecords(input.records || []),
+  };
 }
 
 async function createGenericFanoutReconcileResult(input = {}) {
@@ -89,6 +142,116 @@ function normalizeRecords(records) {
     return [];
   }
   return records.map((record, index) => (record && typeof record === 'object' ? record : { id: `record-${index + 1}`, value: record }));
+}
+
+function normalizeFindingPolicy(policy) {
+  const normalized = normalizeConfig(policy);
+  const groupBy = normalized.group_by || normalized.groupBy || normalized.group_key_paths || normalized.groupKeyPaths;
+  return {
+    packet_id_path: normalized.packet_id_path || normalized.packetIdPath || 'id',
+    findings_path: normalized.findings_path || normalized.findingsPath || 'findings',
+    finding_id_path: normalized.finding_id_path || normalized.findingIdPath || 'id',
+    group_by: Array.isArray(groupBy) && groupBy.length > 0 ? groupBy : ['finding.type', 'finding.severity'],
+    group_key_template: text(normalized.group_key_template || normalized.groupKeyTemplate),
+    fallback_group_key: text(normalized.fallback_group_key || normalized.fallbackGroupKey) || 'default',
+    include_packet: normalized.include_packet !== false,
+  };
+}
+
+function normalizeFindingPacketItems(packets, policy = {}) {
+  policy = normalizeFindingPolicy(policy);
+  if (!Array.isArray(packets)) {
+    return [];
+  }
+
+  return packets.flatMap((packet, packetIndex) => {
+    const packetObject = packet && typeof packet === 'object' ? packet : { value: packet };
+    const packetId = text(getPath(packetObject, policy.packet_id_path)) || text(packetObject.packet_id) || text(packetObject.key) || `packet-${packetIndex + 1}`;
+    const findings = packetFindings(packetObject, policy);
+
+    return findings.map((finding, findingIndex) => {
+      const findingObject = finding && typeof finding === 'object' ? finding : { value: finding };
+      const findingId = text(getPath(findingObject, policy.finding_id_path)) || text(findingObject.finding_id) || text(findingObject.rule_id) || text(findingObject.code) || `finding-${findingIndex + 1}`;
+      const item = stripUndefined({
+        id: `${packetId}:${findingId}`,
+        packet_id: packetId,
+        finding_id: findingId,
+        index: findingIndex,
+        packet_index: packetIndex,
+        group_key: findingGroupKey(packetObject, findingObject, policy),
+        type: text(findingObject.type) || text(findingObject.kind) || text(findingObject.rule_id),
+        severity: text(findingObject.severity),
+        path: text(findingObject.path) || text(findingObject.file),
+        message: text(findingObject.message) || text(findingObject.description),
+        finding: findingObject,
+      });
+
+      if (policy.include_packet) {
+        item.packet = packetObject;
+      }
+
+      return item;
+    });
+  });
+}
+
+function packetFindings(packet, policy) {
+  const configured = getPath(packet, policy.findings_path);
+  if (Array.isArray(configured)) {
+    return configured;
+  }
+  if (Array.isArray(packet.findings)) {
+    return packet.findings;
+  }
+  if (Array.isArray(packet.diagnostics)) {
+    return packet.diagnostics;
+  }
+  if (packet.finding && typeof packet.finding === 'object') {
+    return [packet.finding];
+  }
+  return [];
+}
+
+function groupFindingPacketItems(items, policy = {}) {
+  policy = normalizeFindingPolicy(policy);
+  return groupFanoutItems(items, {
+    group_key: (item) => text(item.group_key) || findingGroupKey(item.packet || {}, item.finding || item, policy),
+  });
+}
+
+function findingGroupKey(packet, finding, policy = {}) {
+  const context = { packet, finding };
+  if (policy.group_key_template) {
+    return text(renderString(policy.group_key_template, context)) || policy.fallback_group_key || 'default';
+  }
+
+  const parts = policy.group_by
+    .map((pathExpression) => text(getPath(context, pathExpression)))
+    .filter(Boolean);
+  return parts.length > 0 ? parts.join(':') : policy.fallback_group_key || 'default';
+}
+
+function defaultFindingPacketTaskTemplate() {
+  return {
+    id: 'finding-packet-{{group.key}}',
+    group_key: '{{group.key}}',
+    item_ids: '{{group.item_ids}}',
+    packet_ids: '{{group.packet_ids}}',
+    finding_count: '{{group.item_count}}',
+    inputs: {
+      findings: '{{group.items}}',
+    },
+  };
+}
+
+function normalizeFindingPacketRecords(records) {
+  return normalizeRecords(records).map((record) => stripUndefined({
+    ...record,
+    id: taskId(record),
+    group_key: text(record.group_key) || text(record.groupKey),
+    finding_ids: Array.isArray(record.finding_ids) ? record.finding_ids : undefined,
+    packet_ids: Array.isArray(record.packet_ids) ? record.packet_ids : undefined,
+  }));
 }
 
 function normalizeGroups(groups, items, config) {
@@ -186,6 +349,12 @@ function templateValue(expression, context) {
   if (path === 'group.item_ids') {
     return context.group.items.map((item) => text(item.id) || text(item.key) || String(item.index + 1));
   }
+  if (path === 'group.packet_ids') {
+    return unique(context.group.items.map((item) => text(item.packet_id)).filter(Boolean));
+  }
+  if (path === 'group.finding_ids') {
+    return context.group.items.map((item) => text(item.finding_id) || text(item.id) || String(item.index + 1));
+  }
   return getPath(context, path);
 }
 
@@ -215,6 +384,14 @@ function stripUndefined(value) {
   return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
 }
 
+function unique(values) {
+  return Array.from(new Set(values));
+}
+
+function countFindingPackets(packets) {
+  return Array.isArray(packets) ? packets.length : 0;
+}
+
 function text(value) {
   if (typeof value === 'string') {
     return value.trim();
@@ -227,9 +404,15 @@ function text(value) {
 
 module.exports = {
   CONFIG_SCHEMA,
+  FINDING_PACKET_CONFIG_SCHEMA,
   RESULT_SCHEMA,
+  createFindingPacketFanoutPlan,
+  createFindingPacketReconcileInput,
   createGenericFanoutReconcilePlan,
   createGenericFanoutReconcileResult,
+  groupFindingPacketItems,
+  materializeFindingPacketFanoutConfig,
+  normalizeFindingPacketItems,
   normalizeGroups,
   renderTaskRequest,
 };

--- a/wordpress/tests/generic-fanout-reconcile-workflow-smoke.js
+++ b/wordpress/tests/generic-fanout-reconcile-workflow-smoke.js
@@ -6,8 +6,12 @@ const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const {
+  createFindingPacketFanoutPlan,
+  createFindingPacketReconcileInput,
   createGenericFanoutReconcilePlan,
   createGenericFanoutReconcileResult,
+  materializeFindingPacketFanoutConfig,
+  normalizeFindingPacketItems,
 } = require('../lib/generic-fanout-reconcile-workflow');
 
 function readJson(filePath) {
@@ -99,6 +103,76 @@ async function main() {
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+
+  const packets = [
+    {
+      id: 'packet-a',
+      source: 'lint',
+      findings: [
+        { id: 'a1', type: 'syntax', severity: 'error', path: 'src/a.js', message: 'Unexpected token' },
+        { id: 'a2', type: 'style', severity: 'warning', path: 'src/b.js', message: 'Use const' },
+      ],
+    },
+    {
+      id: 'packet-b',
+      source: 'static-analysis',
+      diagnostics: [
+        { id: 'b1', type: 'syntax', severity: 'error', path: 'src/c.js', message: 'Missing semicolon' },
+      ],
+    },
+  ];
+  const packetPolicy = {
+    group_by: ['finding.type', 'finding.severity'],
+  };
+  const packetItems = normalizeFindingPacketItems(packets, packetPolicy);
+  assert.deepEqual(packetItems.map((item) => item.id), ['packet-a:a1', 'packet-a:a2', 'packet-b:b1']);
+  assert.deepEqual(packetItems.map((item) => item.group_key), ['syntax:error', 'style:warning', 'syntax:error']);
+
+  const materialized = materializeFindingPacketFanoutConfig({
+    packets,
+    policy: packetPolicy,
+    orchestrator: { run_id: 'finding-run' },
+  });
+  assert.equal(materialized.config.schema, 'homeboy/generic-finding-packet-fanout-config/v1');
+  assert.equal(materialized.config.summary.packet_count, 2);
+  assert.equal(materialized.config.summary.finding_count, 3);
+  assert.deepEqual(materialized.groups.map((group) => group.key), ['syntax:error', 'style:warning']);
+
+  const templated = materializeFindingPacketFanoutConfig({
+    packets,
+    policy: {
+      group_key_template: '{{packet.source}}/{{finding.severity}}',
+    },
+  });
+  assert.deepEqual(templated.groups.map((group) => group.key), ['lint/error', 'lint/warning', 'static-analysis/error']);
+
+  const packetPlan = createFindingPacketFanoutPlan({
+    packets,
+    policy: packetPolicy,
+    orchestrator: { run_id: 'finding-run' },
+  });
+  assert.deepEqual(packetPlan.task_requests.map((request) => request.id), ['finding-packet-syntax:error', 'finding-packet-style:warning']);
+  assert.deepEqual(packetPlan.task_requests[0].item_ids, ['packet-a:a1', 'packet-b:b1']);
+  assert.deepEqual(packetPlan.task_requests[0].packet_ids, ['packet-a', 'packet-b']);
+  assert.equal(packetPlan.task_requests[0].finding_count, 2);
+  assert.deepEqual(packetPlan.task_requests[0].inputs.findings.map((finding) => finding.finding_id), ['a1', 'b1']);
+  assert.equal(Object.hasOwn(packetPlan.task_requests[0], 'sandbox_session_id'), false);
+  assert.equal(Object.hasOwn(packetPlan.task_requests[0], 'wp_codebox_command'), false);
+
+  const reconcileInput = createFindingPacketReconcileInput({
+    packets,
+    policy: packetPolicy,
+    plan: packetPlan,
+    records: [
+      { id: 'finding-packet-syntax:error', status: 'completed', outcome: { applied: ['packet-a:a1', 'packet-b:b1'] } },
+      { id: 'finding-packet-style:warning', status: 'completed', outcome: { applied: ['packet-a:a2'] } },
+    ],
+  });
+  assert.equal(reconcileInput.plan, packetPlan);
+  assert.deepEqual(reconcileInput.records.map((record) => record.id), ['finding-packet-syntax:error', 'finding-packet-style:warning']);
+  const packetResult = await createGenericFanoutReconcileResult(reconcileInput);
+  assert.equal(packetResult.status, 'completed');
+  assert.equal(packetResult.reconciliation.success_count, 2);
 
   console.log('Homeboy generic fanout reconcile workflow smoke passed');
 }


### PR DESCRIPTION
## Summary
- Add generic diagnostic/finding packet helpers on top of the existing fanout/reconcile workflow.
- Support policy-driven packet flattening/grouping, materialized fanout config, packet fanout planning, and reconcile input normalization.
- Document the neutral packet helper API and cover it in the generic fanout smoke test.

## Tests
- `npm run test:generic-fanout-reconcile-workflow`
- `npm run lint:js -- lib/generic-fanout-reconcile-workflow.js`
- `npm run lint:js -- lib/generic-fanout-reconcile-workflow.js tests/generic-fanout-reconcile-workflow-smoke.js` (library passed; smoke test is ignored by repo ESLint config)

## Notes
- Did not run cargo or benchmarks.
- `node tests/generic-agent-runtime-boundary-smoke.mjs` currently fails on a pre-existing `docs/agent-runtime-package-contract.md` domain-neutrality violation outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the generic finding-packet helper implementation, focused smoke coverage, docs, and PR description for Chris to review/test.