### PR TITLE
Extract generic replay envelope primitives

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -94,7 +94,8 @@
     "test:codebox-agent-task-matrix": "node tests/codebox-agent-task-matrix-smoke.js",
     "test:wordpress-runtime-task-planner": "node tests/wordpress-runtime-task-planner-smoke.js",
     "test:wordpress-public-export-boundary": "node tests/wordpress-public-export-boundary.test.js",
-    "test:refactor-source-wp-codebox": "node tests/refactor-source-wp-codebox-smoke.js"
+    "test:refactor-source-wp-codebox": "node tests/refactor-source-wp-codebox-smoke.js",
+    "test:replay-envelope": "node tests/replay-envelope-smoke.js"
   },
   "devDependencies": {
     "@wordpress/eslint-plugin": "^25.3.0",

--- a/wordpress/scripts/agent/build-replay-bundle-smoke.sh
+++ b/wordpress/scripts/agent/build-replay-bundle-smoke.sh
@@ -133,7 +133,7 @@ if [ "$action_row" != "client/search_docs sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	cat "$EPISODE_PATH" >&2
 	exit 1
 fi
-if [[ "$missing_seams" != *"datamachine_provenance"* ]] || [[ "$missing_seams" != *"datamachine_code_policy_attestation"* ]]; then
+if [[ "$missing_seams" != *"runtime_provenance"* ]] || [[ "$missing_seams" != *"workspace_policy_attestation"* ]]; then
 	echo "ERROR: expected missing provenance/policy seams to remain explicit" >&2
 	cat "$BUNDLE_PATH" >&2
 	exit 1

--- a/wordpress/scripts/agent/build-replay-bundle.js
+++ b/wordpress/scripts/agent/build-replay-bundle.js
@@ -7,9 +7,22 @@
  */
 const fs = require('fs');
 const path = require('path');
-const crypto = require('crypto');
 
-const SECRET_KEY_PATTERN = /(secret|token|password|passwd|authorization|cookie|nonce|api[_-]?key|access[_-]?key|private[_-]?key|github[_-]?token|openai[_-]?api[_-]?key)/i;
+/**
+ * Internal dependencies
+ */
+const {
+	SECRET_KEY_PATTERN,
+	safeId,
+	redact,
+	compactObject,
+	sha256Buffer,
+	sha256Json,
+	artifactReferences,
+	hashArtifactReferences,
+	writeEpisodeJsonl,
+	buildSealedEnvelope,
+} = require('./replay-envelope');
 
 function usage() {
 	console.error('Usage: build-replay-bundle.js --results <path> --scenario <id> --config <path> --output-dir <dir> [--update-results]');
@@ -39,63 +52,6 @@ function parseArgs(argv) {
 
 function readJson(filePath) {
 	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-}
-
-function safeId(value) {
-	return String(value || 'scenario')
-		.toLowerCase()
-		.replace(/[^a-z0-9._-]+/g, '-')
-		.replace(/^-+|-+$/g, '') || 'scenario';
-}
-
-function redact(value, key = '') {
-	if (SECRET_KEY_PATTERN.test(key)) {
-		return '[redacted]';
-	}
-	if (Array.isArray(value)) {
-		return value.map((entry) => redact(entry));
-	}
-	if (value && typeof value === 'object') {
-		return Object.fromEntries(Object.entries(value).map(([entryKey, entryValue]) => [entryKey, redact(entryValue, entryKey)]));
-	}
-	return value;
-}
-
-function compactObject(entries) {
-	return Object.fromEntries(Object.entries(entries).filter(([, value]) => value !== undefined && value !== null && value !== ''));
-}
-
-function stableValue(value) {
-	if (Array.isArray(value)) {
-		return value.map((entry) => stableValue(entry));
-	}
-	if (value && typeof value === 'object') {
-		return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableValue(value[key])]));
-	}
-	return value;
-}
-
-function sha256Buffer(buffer) {
-	return `sha256:${crypto.createHash('sha256').update(buffer).digest('hex')}`;
-}
-
-function sha256Json(value) {
-	return sha256Buffer(Buffer.from(JSON.stringify(stableValue(value)), 'utf8'));
-}
-
-function fileSha256(filePath) {
-	return sha256Buffer(fs.readFileSync(filePath));
-}
-
-function isRemoteReference(referencePath) {
-	return /^https?:\/\//i.test(String(referencePath || ''));
-}
-
-function resolveLocalArtifactPath(referencePath, resultsPath) {
-	if (!referencePath || path.isAbsolute(referencePath) || isRemoteReference(referencePath)) {
-		return referencePath || '';
-	}
-	return path.resolve(path.dirname(resultsPath), referencePath);
 }
 
 function resolveReviewUrl(config, scenario) {
@@ -135,130 +91,6 @@ function transcriptReferences(config, scenario) {
 	}
 
 	return references;
-}
-
-function artifactReferences(scenario, config, bundlePath, episodeJsonlPath = '') {
-	const artifacts = scenario.artifacts && typeof scenario.artifacts === 'object' ? scenario.artifacts : {};
-	const references = [];
-
-	for (const [name, artifact] of Object.entries(artifacts)) {
-		if (artifact && typeof artifact === 'object' && artifact.path) {
-			references.push({ name, path: artifact.path, kind: artifact.kind || 'artifact', required: /transcript|episode|replay|grade/i.test(name) });
-		}
-	}
-
-	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
-	const transcriptArtifacts = metadata.transcript_artifacts && typeof metadata.transcript_artifacts === 'object' ? metadata.transcript_artifacts : {};
-	for (const [name, referencePath] of Object.entries({
-		transcript_json: metadata.transcript_json,
-		transcript_summary: metadata.transcript_summary,
-		action_log: metadata.action_log,
-		transcript_artifact_json: transcriptArtifacts.json,
-		transcript_artifact_summary: transcriptArtifacts.summary,
-	})) {
-		if (referencePath) {
-			references.push({ name, path: referencePath, kind: 'metadata', required: /transcript|action/.test(name) });
-		}
-	}
-
-	if (config.transcript_dir) {
-		references.push({ name: 'transcript_dir', path: config.transcript_dir, kind: 'directory', required: false });
-	}
-	if (bundlePath) {
-		references.push({ name: 'replay_bundle', path: bundlePath, kind: 'json', required: false });
-	}
-	if (episodeJsonlPath) {
-		references.push({ name: 'episode_jsonl', path: episodeJsonlPath, kind: 'jsonl', required: true });
-	}
-
-	return references;
-}
-
-function hashArtifactReferences(references, resultsPath) {
-	const hashes = {};
-	const issues = [];
-	for (const reference of references) {
-		if (!reference.path) {
-			continue;
-		}
-		const normalizedPath = String(reference.path);
-		if (isRemoteReference(normalizedPath)) {
-			if (reference.required) {
-				issues.push({ type: 'remote_required_artifact', name: reference.name, path: normalizedPath });
-			}
-			continue;
-		}
-
-		const localPath = resolveLocalArtifactPath(normalizedPath, resultsPath);
-		if (!fs.existsSync(localPath) || !fs.statSync(localPath).isFile()) {
-			if (reference.required) {
-				issues.push({ type: 'missing_required_artifact', name: reference.name, path: normalizedPath });
-			}
-			continue;
-		}
-
-		hashes[reference.name] = {
-			path: normalizedPath,
-			sha256: fileSha256(localPath),
-			bytes: fs.statSync(localPath).size,
-		};
-	}
-
-	return { hashes, issues };
-}
-
-function normalizeToolAuditEvents(metadata) {
-	const evalArtifact = metadata.eval_artifact && typeof metadata.eval_artifact === 'object' ? metadata.eval_artifact : {};
-	const replay = evalArtifact.replay && typeof evalArtifact.replay === 'object' ? evalArtifact.replay : {};
-	const candidates = [metadata.tool_audit_events, replay.tool_audit_events];
-	const events = candidates.find((entry) => Array.isArray(entry)) || [];
-
-	return events.filter((event) => event && typeof event === 'object').map((event, index) => compactObject({
-		schema_version: event.schema_version || 1,
-		type: event.type || 'tool_call',
-		step_index: index,
-		actor: event.actor || 'agent',
-		observation_channels: Array.isArray(event.observation_channels) ? event.observation_channels : undefined,
-		turn_count: event.turn_count,
-		tool_name: event.tool_name || event.action_name,
-		tool_source: event.tool_source,
-		parameters_sha256: event.parameters_sha256 || event.args_sha256,
-		parameters_redacted: event.parameters_redacted !== false,
-		success: event.success === true,
-		result_status: event.result_status || (event.success === true ? 'success' : 'error'),
-		result_sha256: event.result_sha256,
-		error_type: event.error_type,
-	}));
-}
-
-function replaySharedMetadata(scenario, config, metadata, evalArtifact) {
-	const fingerprints = metadata.fingerprints && typeof metadata.fingerprints === 'object' ? metadata.fingerprints : {};
-	const evalHashes = evalArtifact.hashes && typeof evalArtifact.hashes === 'object' ? evalArtifact.hashes : {};
-	const toolPolicy = {
-		required_abilities: config.required_abilities || [],
-		ability_tools: config.ability_tools || [],
-		tool_recorders: config.tool_recorders || [],
-		pipeline_step_patches: config.pipeline_step_patches || [],
-		flow_step_patches: config.flow_step_patches || [],
-		runner_workspace: config.runner_workspace || {},
-		success_requires_pr: config.success_requires_pr === true,
-		success_completion_outcomes: config.success_completion_outcomes || [],
-	};
-
-	return compactObject({
-		scenario_id: scenario.id,
-		task_id: metadata.task_id || config.task_id || config.workload_id || scenario.id,
-		job_id: metadata.job_id || (evalArtifact.run && evalArtifact.run.job_id),
-		reset_hash: config.reset_hash || metadata.reset_hash,
-		prompt_sha256: (fingerprints.prompt && fingerprints.prompt.sha256) || (evalHashes.prompt && evalHashes.prompt.sha256) || (config.prompt ? sha256Buffer(Buffer.from(config.prompt, 'utf8')) : undefined),
-		bundle_sha256: (fingerprints.bundle && fingerprints.bundle.sha256) || (evalHashes.bundle && evalHashes.bundle.sha256),
-		tool_policy_sha256: (fingerprints.tool_policy && fingerprints.tool_policy.sha256) || (evalHashes.tool_policy && evalHashes.tool_policy.sha256) || sha256Json(toolPolicy),
-	});
-}
-
-function replayObservationChannels(metadata, config) {
-	const channels = metadata.observation_channels || config.observation_channels || [];
-	return Array.isArray(channels) ? channels.filter((channel) => typeof channel === 'string' && channel.length > 0) : [];
 }
 
 function objectValue(value) {
@@ -358,138 +190,6 @@ function buildWpGymProjection(scenario, config, metadata, evalArtifact) {
 	});
 }
 
-function buildEpisodeRows(scenario, config) {
-	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
-	const evalArtifact = metadata.eval_artifact && typeof metadata.eval_artifact === 'object' ? metadata.eval_artifact : {};
-	const toolAuditEvents = normalizeToolAuditEvents(metadata);
-	const shared = replaySharedMetadata(scenario, config, metadata, evalArtifact);
-	const observationChannels = replayObservationChannels(metadata, config);
-	const rows = [];
-
-	for (const event of toolAuditEvents) {
-		rows.push(redact(compactObject({
-			schema_name: 'homeboy.agent_episode_step',
-			schema_version: 1,
-			step_index: rows.length,
-			row_type: 'action',
-			actor: event.actor || 'agent',
-			observation_channels: event.observation_channels || observationChannels,
-			action_name: event.tool_name,
-			tool_name: event.tool_name,
-			tool_source: event.tool_source,
-			args_sha256: event.parameters_sha256,
-			args_redacted: event.parameters_redacted !== false,
-			result_status: event.result_status || (event.success === true ? 'success' : 'error'),
-			result_sha256: event.result_sha256,
-			error_type: event.error_type,
-			shared,
-		})));
-	}
-
-	const grade = evalArtifact.grade || metadata.grade || {};
-	const failureReasons = evalArtifact.failure_reasons || metadata.failure_reasons || [];
-	const reward = metadata.reward ?? metadata.score ?? (grade.reward ?? grade.score);
-	rows.push(redact(compactObject({
-		schema_name: 'homeboy.agent_episode_step',
-		schema_version: 1,
-		step_index: rows.length,
-		row_type: 'grader',
-		actor: 'grader',
-		terminal: true,
-		observation_channels: ['grader'],
-		action_name: 'terminal_grader',
-		result_status: metadata.job_status || (evalArtifact.run && evalArtifact.run.job_status) || 'unknown',
-		reward,
-		failure_reasons: Array.isArray(failureReasons) ? failureReasons : [],
-		grade,
-		shared,
-	})));
-
-	return rows;
-}
-
-function writeEpisodeJsonl(filePath, scenario, config) {
-	const rows = buildEpisodeRows(scenario, config);
-	fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`);
-	return rows;
-}
-
-function buildSealedEnvelope(results, scenario, config, bundlePath, artifactIntegrity, episodeJsonlPath, episodeRows) {
-	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
-	const evalArtifact = metadata.eval_artifact && typeof metadata.eval_artifact === 'object' ? metadata.eval_artifact : {};
-	const fingerprints = metadata.fingerprints && typeof metadata.fingerprints === 'object' ? metadata.fingerprints : {};
-	const toolAuditEvents = normalizeToolAuditEvents(metadata);
-	const missingSeams = [];
-	const attestation = evalArtifact.attestation && typeof evalArtifact.attestation === 'object' ? evalArtifact.attestation : {};
-	const existingSeams = Array.isArray(attestation.integration_seams) ? attestation.integration_seams : [];
-	missingSeams.push(...existingSeams);
-	if (!attestation.runtime_provenance || Object.keys(attestation.runtime_provenance).length === 0) {
-		missingSeams.push('runtime_provenance');
-	}
-	if (!attestation.workspace_policy_attestation || Object.keys(attestation.workspace_policy_attestation).length === 0) {
-		missingSeams.push('workspace_policy_attestation');
-	}
-	if (toolAuditEvents.length === 0) {
-		missingSeams.push('agents_api_tool_audit_events');
-	}
-	const workflowRunUrl = metadata.workflow_run_url || (evalArtifact.run && evalArtifact.run.workflow_run_url) || (
-		process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
-			? `${process.env.GITHUB_SERVER_URL || 'https://github.com'}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
-			: ''
-	);
-	const wpGym = buildWpGymProjection(scenario, config, metadata, evalArtifact);
-
-	return redact({
-		schema_name: 'homeboy.sealed_eval_artifact',
-		schema_version: 1,
-		generated_at: new Date().toISOString(),
-		status: artifactIntegrity.issues.length === 0 && toolAuditEvents.length > 0 ? 'ready_for_replay' : 'incomplete',
-		runner: compactObject({
-			ref: process.env.GITHUB_SHA || config.runner_ref || metadata.runner_ref,
-			workflow_run_url: workflowRunUrl,
-			job_id: process.env.GITHUB_JOB || config.github_job,
-		}),
-		run: compactObject({
-			job_id: metadata.job_id || (evalArtifact.run && evalArtifact.run.job_id),
-			job_status: metadata.job_status || (evalArtifact.run && evalArtifact.run.job_status),
-			success_status: metadata.success_status || (evalArtifact.run && evalArtifact.run.success_status),
-		}),
-		task: compactObject({
-			id: metadata.task_id || config.task_id || config.workload_id || scenario.id,
-			label: metadata.task_label || config.task_label || config.workload_label || scenario.label,
-		}),
-		model: compactObject({
-			provider: config.provider || metadata.provider,
-			model: config.model || metadata.model,
-		}),
-		hashes: compactObject({
-			prompt: fingerprints.prompt || (evalArtifact.hashes && evalArtifact.hashes.prompt) || (config.prompt ? { sha256: `sha256:${crypto.createHash('sha256').update(config.prompt).digest('hex')}`, bytes: Buffer.byteLength(config.prompt) } : undefined),
-			bundle: fingerprints.bundle || (evalArtifact.hashes && evalArtifact.hashes.bundle),
-			tool_policy: fingerprints.tool_policy || (evalArtifact.hashes && evalArtifact.hashes.tool_policy),
-			reset: config.reset_hash || metadata.reset_hash || undefined,
-			artifact_hashes: artifactIntegrity.hashes,
-		}),
-		grade: evalArtifact.grade || metadata.grade || {},
-		failure_reasons: evalArtifact.failure_reasons || metadata.failure_reasons || [],
-		termination: evalArtifact.termination || compactObject({ state: metadata.job_status, truncated: metadata.truncated === true }),
-		replay: {
-			format: 'jsonl',
-			episode_jsonl: episodeJsonlPath,
-			episode_row_count: episodeRows.length,
-			tool_audit_events_source: 'Agents API result.tool_audit_events',
-			tool_audit_event_count: toolAuditEvents.length,
-			tool_audit_events: toolAuditEvents,
-		},
-		artifacts: {
-			references: artifactReferences(scenario, config, bundlePath, episodeJsonlPath),
-			hashes: artifactIntegrity.hashes,
-			issues: artifactIntegrity.issues,
-		},
-		wp_gym: wpGym,
-		integration_seams: Array.from(new Set(missingSeams.filter(Boolean))),
-	});
-}
-
 function buildBundle(results, scenario, config, bundlePath, resultsPath, episodeJsonlPath, episodeRows) {
 	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
 	const reviewUrl = resolveReviewUrl(config, scenario);
@@ -499,7 +199,11 @@ function buildBundle(results, scenario, config, bundlePath, resultsPath, episode
 	return redact({
 		schema_version: 1,
 		generated_at: new Date().toISOString(),
-		sealed_eval_artifact: buildSealedEnvelope(results, scenario, config, bundlePath, artifactIntegrity, episodeJsonlPath, episodeRows),
+		sealed_eval_artifact: buildSealedEnvelope(results, scenario, config, bundlePath, artifactIntegrity, episodeJsonlPath, episodeRows, {
+			projections: ({ scenario: projectionScenario, config: projectionConfig, metadata: projectionMetadata, evalArtifact }) => ({
+				wp_gym: buildWpGymProjection(projectionScenario, projectionConfig, projectionMetadata, evalArtifact),
+			}),
+		}),
 		scenario_id: scenario.id,
 		component_id: results.component_id || results.component,
 		replay_bundle_path: bundlePath,

--- a/wordpress/scripts/agent/replay-envelope.js
+++ b/wordpress/scripts/agent/replay-envelope.js
@@ -1,0 +1,345 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const SECRET_KEY_PATTERN = /(secret|token|password|passwd|authorization|cookie|nonce|api[_-]?key|access[_-]?key|private[_-]?key|github[_-]?token|openai[_-]?api[_-]?key)/i;
+
+function safeId(value) {
+	return String(value || 'scenario')
+		.toLowerCase()
+		.replace(/[^a-z0-9._-]+/g, '-')
+		.replace(/^-+|-+$/g, '') || 'scenario';
+}
+
+function redact(value, key = '') {
+	if (SECRET_KEY_PATTERN.test(key)) {
+		return '[redacted]';
+	}
+	if (Array.isArray(value)) {
+		return value.map((entry) => redact(entry));
+	}
+	if (value && typeof value === 'object') {
+		return Object.fromEntries(Object.entries(value).map(([entryKey, entryValue]) => [entryKey, redact(entryValue, entryKey)]));
+	}
+	return value;
+}
+
+function compactObject(entries) {
+	return Object.fromEntries(Object.entries(entries).filter(([, value]) => value !== undefined && value !== null && value !== ''));
+}
+
+function stableValue(value) {
+	if (Array.isArray(value)) {
+		return value.map((entry) => stableValue(entry));
+	}
+	if (value && typeof value === 'object') {
+		return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableValue(value[key])]));
+	}
+	return value;
+}
+
+function sha256Buffer(buffer) {
+	return `sha256:${crypto.createHash('sha256').update(buffer).digest('hex')}`;
+}
+
+function sha256Json(value) {
+	return sha256Buffer(Buffer.from(JSON.stringify(stableValue(value)), 'utf8'));
+}
+
+function fileSha256(filePath) {
+	return sha256Buffer(fs.readFileSync(filePath));
+}
+
+function isRemoteReference(referencePath) {
+	return /^https?:\/\//i.test(String(referencePath || ''));
+}
+
+function resolveLocalArtifactPath(referencePath, resultsPath) {
+	if (!referencePath || path.isAbsolute(referencePath) || isRemoteReference(referencePath)) {
+		return referencePath || '';
+	}
+	return path.resolve(path.dirname(resultsPath), referencePath);
+}
+
+function artifactReferences(scenario, config, bundlePath, episodeJsonlPath = '') {
+	const artifacts = scenario.artifacts && typeof scenario.artifacts === 'object' ? scenario.artifacts : {};
+	const references = [];
+
+	for (const [name, artifact] of Object.entries(artifacts)) {
+		if (artifact && typeof artifact === 'object' && artifact.path) {
+			references.push({ name, path: artifact.path, kind: artifact.kind || 'artifact', required: /transcript|episode|replay|grade/i.test(name) });
+		}
+	}
+
+	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
+	const transcriptArtifacts = metadata.transcript_artifacts && typeof metadata.transcript_artifacts === 'object' ? metadata.transcript_artifacts : {};
+	for (const [name, referencePath] of Object.entries({
+		transcript_json: metadata.transcript_json,
+		transcript_summary: metadata.transcript_summary,
+		action_log: metadata.action_log,
+		transcript_artifact_json: transcriptArtifacts.json,
+		transcript_artifact_summary: transcriptArtifacts.summary,
+	})) {
+		if (referencePath) {
+			references.push({ name, path: referencePath, kind: 'metadata', required: /transcript|action/.test(name) });
+		}
+	}
+
+	if (config.transcript_dir) {
+		references.push({ name: 'transcript_dir', path: config.transcript_dir, kind: 'directory', required: false });
+	}
+	if (bundlePath) {
+		references.push({ name: 'replay_bundle', path: bundlePath, kind: 'json', required: false });
+	}
+	if (episodeJsonlPath) {
+		references.push({ name: 'episode_jsonl', path: episodeJsonlPath, kind: 'jsonl', required: true });
+	}
+
+	return references;
+}
+
+function hashArtifactReferences(references, resultsPath) {
+	const hashes = {};
+	const issues = [];
+	for (const reference of references) {
+		if (!reference.path) {
+			continue;
+		}
+		const normalizedPath = String(reference.path);
+		if (isRemoteReference(normalizedPath)) {
+			if (reference.required) {
+				issues.push({ type: 'remote_required_artifact', name: reference.name, path: normalizedPath });
+			}
+			continue;
+		}
+
+		const localPath = resolveLocalArtifactPath(normalizedPath, resultsPath);
+		if (!fs.existsSync(localPath) || !fs.statSync(localPath).isFile()) {
+			if (reference.required) {
+				issues.push({ type: 'missing_required_artifact', name: reference.name, path: normalizedPath });
+			}
+			continue;
+		}
+
+		hashes[reference.name] = {
+			path: normalizedPath,
+			sha256: fileSha256(localPath),
+			bytes: fs.statSync(localPath).size,
+		};
+	}
+
+	return { hashes, issues };
+}
+
+function normalizeToolAuditEvents(metadata) {
+	const evalArtifact = metadata.eval_artifact && typeof metadata.eval_artifact === 'object' ? metadata.eval_artifact : {};
+	const replay = evalArtifact.replay && typeof evalArtifact.replay === 'object' ? evalArtifact.replay : {};
+	const candidates = [metadata.tool_audit_events, replay.tool_audit_events];
+	const events = candidates.find((entry) => Array.isArray(entry)) || [];
+
+	return events.filter((event) => event && typeof event === 'object').map((event, index) => compactObject({
+		schema_version: event.schema_version || 1,
+		type: event.type || 'tool_call',
+		step_index: index,
+		actor: event.actor || 'agent',
+		observation_channels: Array.isArray(event.observation_channels) ? event.observation_channels : undefined,
+		turn_count: event.turn_count,
+		tool_name: event.tool_name || event.action_name,
+		tool_source: event.tool_source,
+		parameters_sha256: event.parameters_sha256 || event.args_sha256,
+		parameters_redacted: event.parameters_redacted !== false,
+		success: event.success === true,
+		result_status: event.result_status || (event.success === true ? 'success' : 'error'),
+		result_sha256: event.result_sha256,
+		error_type: event.error_type,
+	}));
+}
+
+function replaySharedMetadata(scenario, config, metadata, evalArtifact) {
+	const fingerprints = metadata.fingerprints && typeof metadata.fingerprints === 'object' ? metadata.fingerprints : {};
+	const evalHashes = evalArtifact.hashes && typeof evalArtifact.hashes === 'object' ? evalArtifact.hashes : {};
+	const toolPolicy = {
+		required_abilities: config.required_abilities || [],
+		ability_tools: config.ability_tools || [],
+		tool_recorders: config.tool_recorders || [],
+		pipeline_step_patches: config.pipeline_step_patches || [],
+		flow_step_patches: config.flow_step_patches || [],
+		runner_workspace: config.runner_workspace || {},
+		success_requires_pr: config.success_requires_pr === true,
+		success_completion_outcomes: config.success_completion_outcomes || [],
+	};
+
+	return compactObject({
+		scenario_id: scenario.id,
+		task_id: metadata.task_id || config.task_id || config.workload_id || scenario.id,
+		job_id: metadata.job_id || (evalArtifact.run && evalArtifact.run.job_id),
+		reset_hash: config.reset_hash || metadata.reset_hash,
+		prompt_sha256: (fingerprints.prompt && fingerprints.prompt.sha256) || (evalHashes.prompt && evalHashes.prompt.sha256) || (config.prompt ? sha256Buffer(Buffer.from(config.prompt, 'utf8')) : undefined),
+		bundle_sha256: (fingerprints.bundle && fingerprints.bundle.sha256) || (evalHashes.bundle && evalHashes.bundle.sha256),
+		tool_policy_sha256: (fingerprints.tool_policy && fingerprints.tool_policy.sha256) || (evalHashes.tool_policy && evalHashes.tool_policy.sha256) || sha256Json(toolPolicy),
+	});
+}
+
+function replayObservationChannels(metadata, config) {
+	const channels = metadata.observation_channels || config.observation_channels || [];
+	return Array.isArray(channels) ? channels.filter((channel) => typeof channel === 'string' && channel.length > 0) : [];
+}
+
+function buildEpisodeRows(scenario, config) {
+	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
+	const evalArtifact = metadata.eval_artifact && typeof metadata.eval_artifact === 'object' ? metadata.eval_artifact : {};
+	const toolAuditEvents = normalizeToolAuditEvents(metadata);
+	const shared = replaySharedMetadata(scenario, config, metadata, evalArtifact);
+	const observationChannels = replayObservationChannels(metadata, config);
+	const rows = [];
+
+	for (const event of toolAuditEvents) {
+		rows.push(redact(compactObject({
+			schema_name: 'homeboy.agent_episode_step',
+			schema_version: 1,
+			step_index: rows.length,
+			row_type: 'action',
+			actor: event.actor || 'agent',
+			observation_channels: event.observation_channels || observationChannels,
+			action_name: event.tool_name,
+			tool_name: event.tool_name,
+			tool_source: event.tool_source,
+			args_sha256: event.parameters_sha256,
+			args_redacted: event.parameters_redacted !== false,
+			result_status: event.result_status || (event.success === true ? 'success' : 'error'),
+			result_sha256: event.result_sha256,
+			error_type: event.error_type,
+			shared,
+		})));
+	}
+
+	const grade = evalArtifact.grade || metadata.grade || {};
+	const failureReasons = evalArtifact.failure_reasons || metadata.failure_reasons || [];
+	const reward = metadata.reward ?? metadata.score ?? (grade.reward ?? grade.score);
+	rows.push(redact(compactObject({
+		schema_name: 'homeboy.agent_episode_step',
+		schema_version: 1,
+		step_index: rows.length,
+		row_type: 'grader',
+		actor: 'grader',
+		terminal: true,
+		observation_channels: ['grader'],
+		action_name: 'terminal_grader',
+		result_status: metadata.job_status || (evalArtifact.run && evalArtifact.run.job_status) || 'unknown',
+		reward,
+		failure_reasons: Array.isArray(failureReasons) ? failureReasons : [],
+		grade,
+		shared,
+	})));
+
+	return rows;
+}
+
+function writeEpisodeJsonl(filePath, scenario, config) {
+	const rows = buildEpisodeRows(scenario, config);
+	fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`);
+	return rows;
+}
+
+function buildSealedEnvelope(results, scenario, config, bundlePath, artifactIntegrity, episodeJsonlPath, episodeRows, adapters = {}) {
+	const metadata = scenario.metadata && typeof scenario.metadata === 'object' ? scenario.metadata : {};
+	const evalArtifact = metadata.eval_artifact && typeof metadata.eval_artifact === 'object' ? metadata.eval_artifact : {};
+	const fingerprints = metadata.fingerprints && typeof metadata.fingerprints === 'object' ? metadata.fingerprints : {};
+	const toolAuditEvents = normalizeToolAuditEvents(metadata);
+	const missingSeams = [];
+	const attestation = evalArtifact.attestation && typeof evalArtifact.attestation === 'object' ? evalArtifact.attestation : {};
+	const existingSeams = Array.isArray(attestation.integration_seams) ? attestation.integration_seams : [];
+	missingSeams.push(...existingSeams);
+	if (!attestation.runtime_provenance || Object.keys(attestation.runtime_provenance).length === 0) {
+		missingSeams.push('runtime_provenance');
+	}
+	if (!attestation.workspace_policy_attestation || Object.keys(attestation.workspace_policy_attestation).length === 0) {
+		missingSeams.push('workspace_policy_attestation');
+	}
+	if (toolAuditEvents.length === 0) {
+		missingSeams.push('agents_api_tool_audit_events');
+	}
+	const env = adapters.env || process.env;
+	const workflowRunUrl = metadata.workflow_run_url || (evalArtifact.run && evalArtifact.run.workflow_run_url) || (
+		env.GITHUB_REPOSITORY && env.GITHUB_RUN_ID
+			? `${env.GITHUB_SERVER_URL || 'https://github.com'}/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}`
+			: ''
+	);
+	const projections = typeof adapters.projections === 'function'
+		? adapters.projections({ results, scenario, config, metadata, evalArtifact })
+		: {};
+
+	return redact({
+		schema_name: 'homeboy.sealed_eval_artifact',
+		schema_version: 1,
+		generated_at: new Date().toISOString(),
+		status: artifactIntegrity.issues.length === 0 && toolAuditEvents.length > 0 ? 'ready_for_replay' : 'incomplete',
+		runner: compactObject({
+			ref: env.GITHUB_SHA || config.runner_ref || metadata.runner_ref,
+			workflow_run_url: workflowRunUrl,
+			job_id: env.GITHUB_JOB || config.github_job,
+		}),
+		run: compactObject({
+			job_id: metadata.job_id || (evalArtifact.run && evalArtifact.run.job_id),
+			job_status: metadata.job_status || (evalArtifact.run && evalArtifact.run.job_status),
+			success_status: metadata.success_status || (evalArtifact.run && evalArtifact.run.success_status),
+		}),
+		task: compactObject({
+			id: metadata.task_id || config.task_id || config.workload_id || scenario.id,
+			label: metadata.task_label || config.task_label || config.workload_label || scenario.label,
+		}),
+		model: compactObject({
+			provider: config.provider || metadata.provider,
+			model: config.model || metadata.model,
+		}),
+		hashes: compactObject({
+			prompt: fingerprints.prompt || (evalArtifact.hashes && evalArtifact.hashes.prompt) || (config.prompt ? { sha256: sha256Buffer(Buffer.from(config.prompt, 'utf8')), bytes: Buffer.byteLength(config.prompt) } : undefined),
+			bundle: fingerprints.bundle || (evalArtifact.hashes && evalArtifact.hashes.bundle),
+			tool_policy: fingerprints.tool_policy || (evalArtifact.hashes && evalArtifact.hashes.tool_policy),
+			reset: config.reset_hash || metadata.reset_hash || undefined,
+			artifact_hashes: artifactIntegrity.hashes,
+		}),
+		grade: evalArtifact.grade || metadata.grade || {},
+		failure_reasons: evalArtifact.failure_reasons || metadata.failure_reasons || [],
+		termination: evalArtifact.termination || compactObject({ state: metadata.job_status, truncated: metadata.truncated === true }),
+		replay: {
+			format: 'jsonl',
+			episode_jsonl: episodeJsonlPath,
+			episode_row_count: episodeRows.length,
+			tool_audit_events_source: 'Agents API result.tool_audit_events',
+			tool_audit_event_count: toolAuditEvents.length,
+			tool_audit_events: toolAuditEvents,
+		},
+		artifacts: {
+			references: artifactReferences(scenario, config, bundlePath, episodeJsonlPath),
+			hashes: artifactIntegrity.hashes,
+			issues: artifactIntegrity.issues,
+		},
+		...projections,
+		integration_seams: Array.from(new Set(missingSeams.filter(Boolean))),
+	});
+}
+
+module.exports = {
+	SECRET_KEY_PATTERN,
+	safeId,
+	redact,
+	compactObject,
+	sha256Buffer,
+	sha256Json,
+	isRemoteReference,
+	resolveLocalArtifactPath,
+	artifactReferences,
+	hashArtifactReferences,
+	normalizeToolAuditEvents,
+	replaySharedMetadata,
+	replayObservationChannels,
+	buildEpisodeRows,
+	writeEpisodeJsonl,
+	buildSealedEnvelope,
+};

--- a/wordpress/tests/replay-envelope-smoke.js
+++ b/wordpress/tests/replay-envelope-smoke.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+	redact,
+	sha256Json,
+	artifactReferences,
+	hashArtifactReferences,
+	buildEpisodeRows,
+	writeEpisodeJsonl,
+	buildSealedEnvelope,
+} = require('../scripts/agent/replay-envelope');
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-replay-envelope-'));
+
+try {
+	const resultsPath = path.join(tmpRoot, 'results.json');
+	const transcriptPath = path.join(tmpRoot, 'transcript.jsonl');
+	const episodePath = path.join(tmpRoot, 'episode.jsonl');
+	fs.writeFileSync(resultsPath, '{}\n');
+	fs.writeFileSync(transcriptPath, '{"role":"user","content":"Run it."}\n');
+
+	const scenario = {
+		id: 'portable-runtime-failure',
+		artifacts: {
+			transcript_json: { path: transcriptPath, kind: 'jsonl' },
+		},
+		metadata: {
+			provider: 'example-provider',
+			model: 'example-model',
+			job_status: 'failed',
+			api_token: 'must-not-leak',
+			tool_audit_events: [
+				{
+					tool_name: 'generic/search',
+					parameters_sha256: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+					success: true,
+					result_status: 'success',
+				},
+			],
+		},
+	};
+	const config = {
+		provider: 'example-provider',
+		model: 'example-model',
+		prompt: 'Reproduce the failure.',
+		secret: 'must-not-leak',
+	};
+
+	assert.deepEqual(redact({ nested: { github_token: 'must-not-leak', safe: 'visible' } }), {
+		nested: { github_token: '[redacted]', safe: 'visible' },
+	});
+	assert.equal(sha256Json({ b: 2, a: 1 }), sha256Json({ a: 1, b: 2 }));
+
+	const references = artifactReferences(scenario, config, 'bundle.json', 'episode.jsonl');
+	assert.equal(references.some((reference) => reference.name === 'transcript_json'), true);
+	assert.equal(references.some((reference) => reference.name === 'episode_jsonl' && reference.required === true), true);
+
+	const integrity = hashArtifactReferences(references, resultsPath);
+	assert.equal(integrity.hashes.transcript_json.bytes, fs.statSync(transcriptPath).size);
+	assert.equal(integrity.issues.some((issue) => issue.name === 'episode_jsonl'), true);
+
+	const episodeRows = buildEpisodeRows(scenario, config);
+	assert.equal(episodeRows.length, 2);
+	assert.equal(episodeRows[0].row_type, 'action');
+	assert.equal(episodeRows[0].action_name, 'generic/search');
+	assert.equal(episodeRows[1].row_type, 'grader');
+	assert.equal(JSON.stringify(episodeRows).includes('must-not-leak'), false);
+
+	const writtenRows = writeEpisodeJsonl(episodePath, scenario, config);
+	assert.equal(writtenRows.length, 2);
+	assert.equal(fs.readFileSync(episodePath, 'utf8').trim().split('\n').length, 2);
+
+	const completeReferences = artifactReferences(scenario, config, 'bundle.json', episodePath);
+	const completeIntegrity = hashArtifactReferences(completeReferences, resultsPath);
+	const envelope = buildSealedEnvelope({}, scenario, config, 'bundle.json', completeIntegrity, episodePath, writtenRows, {
+		env: {
+			GITHUB_REPOSITORY: 'Extra-Chill/homeboy-extensions',
+			GITHUB_RUN_ID: '123',
+			GITHUB_SHA: 'abc123',
+		},
+		projections: () => ({ runtime_projection: { id: 'example-runtime' } }),
+	});
+
+	assert.equal(envelope.status, 'ready_for_replay');
+	assert.equal(envelope.runner.workflow_run_url, 'https://github.com/Extra-Chill/homeboy-extensions/actions/runs/123');
+	assert.equal(envelope.runtime_projection.id, 'example-runtime');
+	assert.equal(JSON.stringify(envelope).includes('must-not-leak'), false);
+} finally {
+	fs.rmSync(tmpRoot, { recursive: true, force: true });
+}
+
+process.stdout.write('Replay envelope smoke passed\n');


### PR DESCRIPTION
## Summary
- Extracts reusable replay envelope primitives into a generic `replay-envelope.js` module for redaction, stable hashes, artifact refs, integrity checks, episode JSONL, and sealed envelope construction.
- Keeps WP Gym projection and WP Codebox replay bundle shape in `build-replay-bundle.js` as adapters around the generic envelope.
- Adds a focused replay envelope smoke test and keeps the existing replay bundle smoke pointed at portable seam names.

## Tests
- `npm run test:replay-envelope`
- `bash scripts/agent/build-replay-bundle-smoke.sh`
- `npx eslint scripts/agent/build-replay-bundle.js scripts/agent/replay-envelope.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the extraction, adapter wiring, and focused smoke coverage; Chris remains responsible for review and acceptance.
