### PR TITLE
Add explicit runtime execution descriptors

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -55,6 +55,7 @@ const {
 
 const RUNTIME_MANIFEST_PATH = path.resolve(__dirname, '..', 'wp-codebox.json');
 const RUNTIME_OVERLAY_CANONICAL_SHAPE = 'runtime_overlays entries must be objects. WP Codebox owns the runtime overlay schema and reports field-level validation.';
+const RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
 const PROVIDER_CAPABILITIES = runtimeProviderCapabilities();
 
 const AGENT_BUNDLE_CONFIG_FIELDS = [
@@ -138,6 +139,7 @@ function providerContract(options = {}) {
     id: options.id || WP_CODEBOX_PROVIDER_ID,
     label: options.label || WP_CODEBOX_PROVIDER_LABEL,
     backend: WP_CODEBOX_BACKEND,
+    runtime_id: options.runtimeId || options.runtime_id || runtimeManifest().id || 'wp-codebox',
     command: options.command || 'node {{runtime_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs',
     invocation: runtimeCommandInvocation(options),
     ...agentTaskProviderContractFields(),
@@ -297,8 +299,8 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const agentBundle = agentBundleConfigFromAgentTaskRequest(request, config, inputs);
   const recipe = recipeConfigFromAgentTaskRequest(request, config, inputs);
   const mounts = agentBundleMounts(agentBundle, config.runtime_mounts || config.mounts || defaults.mounts || runtimeOptions.mounts || []);
-  const componentContracts = componentContractsFromAgentTaskRequest(request, config, runtimeOptions);
-  const components = runtimeComponentPaths(config, { ...defaults, ...runtimeOptions, componentContracts });
+  let componentContracts = componentContractsFromAgentTaskRequest(request, config, runtimeOptions);
+  let components = runtimeComponentPaths(config, { ...defaults, ...runtimeOptions, componentContracts });
   const agentBundles = firstDefined(inputs.agent_bundles, inputs.agentBundles, config.agent_bundles, config.agentBundles, runtimeOptions.agentBundles, []);
   const structuredArtifacts = firstDefined(inputs.structured_artifacts, inputs.structuredArtifacts, config.structured_artifacts, config.structuredArtifacts, runtimeOptions.structuredArtifacts, []);
   const artifactDeclarations = artifactDeclarationsFromAgentTaskRequest(request, config, inputs, runtimeOptions);
@@ -326,6 +328,11 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
   const runtimeOverlays = runtimeOverlaysFromConfig(config, runtimeOptions, defaults);
   const runtimeRequirements = codeboxRuntimeRequirementsFromAgentTaskRequest(config, runtimeOptions, defaults, componentContracts, runtimeOverlays);
+  componentContracts = uniqueComponentContracts([
+    ...componentContracts,
+    ...normalizeArray(runtimeRequirements.component_contracts),
+  ]);
+  components = runtimeComponentPaths(config, { ...defaults, ...runtimeOptions, componentContracts });
   const context = {
     ...(inputs.context || {}),
     agent_task_id: request.task_id,
@@ -718,12 +725,93 @@ function genericAbilityRuntimeTask(request, config, inputs) {
 }
 
 function runtimeTaskInputFromAgentTaskRequest(request, config, inputs, declared = {}) {
-  const workflowInputs = workflowInputsFromAgentTaskRequest(request, config, inputs);
+  const defaultInput = firstObject(
+    declared?.input_defaults,
+    declared?.inputDefaults,
+    inputs.ability_input_defaults,
+    inputs.abilityInputDefaults,
+    config.ability_input_defaults,
+    config.abilityInputDefaults,
+  ) || {};
+  const mappedInput = runtimeMappedInputFromAgentTaskRequest(request, config, inputs, declared);
+  const legacyWorkflowInputs = legacyWorkflowInputsFromAgentTaskRequest(request, config, inputs, declared);
   const explicitInput = firstObject(declared?.input, declared?.args, inputs.ability_input, inputs.abilityInput, inputs.input, config.ability_input, config.abilityInput, config.input) || {};
-  return { ...workflowInputs, ...explicitInput };
+  return { ...defaultInput, ...mappedInput, ...legacyWorkflowInputs, ...explicitInput };
 }
 
-function workflowInputsFromAgentTaskRequest(request, config, inputs) {
+function runtimeMappedInputFromAgentTaskRequest(request, config, inputs, declared = {}) {
+  const mappings = normalizeArray(firstDefined(
+    declared?.input_mapping,
+    declared?.inputMapping,
+    declared?.context_mapping,
+    declared?.contextMapping,
+    inputs.runtime_input_mapping,
+    inputs.runtimeInputMapping,
+    inputs.context_mapping,
+    inputs.contextMapping,
+    config.runtime_input_mapping,
+    config.runtimeInputMapping,
+    config.context_mapping,
+    config.contextMapping,
+  ));
+  if (mappings.length === 0) {
+    return {};
+  }
+  const sources = runtimeInputMappingSources(request, config, inputs);
+  return mappings.reduce((mapped, mapping) => {
+    const entry = runtimeInputMappingEntry(mapping);
+    if (!entry) {
+      return mapped;
+    }
+    const value = valueAtPath(sources, entry.from);
+    if (value === undefined) {
+      if (entry.default !== undefined) {
+        setValueAtPath(mapped, entry.to, entry.default);
+      }
+      return mapped;
+    }
+    setValueAtPath(mapped, entry.to, value);
+    return mapped;
+  }, {});
+}
+
+function runtimeInputMappingSources(request, config, inputs) {
+  return {
+    request,
+    inputs,
+    config,
+    client_context: firstObject(inputs.client_context, inputs.clientContext, request.client_context, request.clientContext, config.client_context, config.clientContext) || {},
+    context: firstObject(inputs.context, request.context, config.context) || {},
+  };
+}
+
+function runtimeInputMappingEntry(mapping) {
+  if (typeof mapping === 'string' && mapping.trim()) {
+    return { from: mapping.trim(), to: pathLeaf(mapping.trim()) };
+  }
+  if (!mapping || typeof mapping !== 'object' || Array.isArray(mapping)) {
+    return null;
+  }
+  const from = firstValue(mapping.from, mapping.source, mapping.path);
+  const to = firstValue(mapping.to, mapping.target, mapping.name, mapping.input);
+  if (!from || !to) {
+    return null;
+  }
+  return { from, to, default: mapping.default };
+}
+
+function legacyWorkflowInputsFromAgentTaskRequest(request, config, inputs, declared = {}) {
+  const legacyMerge = firstDefined(
+    declared?.allow_legacy_client_context_input_merge,
+    declared?.allowLegacyClientContextInputMerge,
+    inputs.allow_legacy_client_context_input_merge,
+    inputs.allowLegacyClientContextInputMerge,
+    config.allow_legacy_client_context_input_merge,
+    config.allowLegacyClientContextInputMerge,
+  );
+  if (legacyMerge !== true) {
+    return {};
+  }
   return firstObject(
     inputs.client_context?.inputs,
     inputs.clientContext?.inputs,
@@ -732,6 +820,38 @@ function workflowInputsFromAgentTaskRequest(request, config, inputs) {
     config.client_context?.inputs,
     config.clientContext?.inputs,
   ) || {};
+}
+
+function valueAtPath(source, fieldPath) {
+  if (!fieldPath || typeof fieldPath !== 'string') {
+    return undefined;
+  }
+  return fieldPath.split('.').filter(Boolean).reduce((value, segment) => {
+    if (value === undefined || value === null || typeof value !== 'object') {
+      return undefined;
+    }
+    return value[segment];
+  }, source);
+}
+
+function setValueAtPath(target, fieldPath, value) {
+  const segments = String(fieldPath || '').split('.').filter(Boolean);
+  if (segments.length === 0) {
+    return;
+  }
+  let cursor = target;
+  segments.slice(0, -1).forEach((segment) => {
+    if (!cursor[segment] || typeof cursor[segment] !== 'object' || Array.isArray(cursor[segment])) {
+      cursor[segment] = {};
+    }
+    cursor = cursor[segment];
+  });
+  cursor[segments[segments.length - 1]] = value;
+}
+
+function pathLeaf(fieldPath) {
+  const segments = String(fieldPath || '').split('.').filter(Boolean);
+  return segments[segments.length - 1] || fieldPath;
 }
 
 function allowedToolsFromAgentTaskRequest(request, config, inputs, options, defaults) {
@@ -2674,6 +2794,7 @@ module.exports = {
   WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
   WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS,
   WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES,
+  RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA,
   providerContract,
   providerRuntimeInvocationContract,
   codeboxTaskRequestFromAgentTaskRequest,

--- a/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
@@ -36,6 +36,7 @@ function codeboxRuntimeProfilePayload({
     ...normalizeArray(normalizedProfile.component_contracts),
     ...normalizeArray(normalizedRuntimeRequirements.component_contracts),
     ...normalizeArray(componentContracts),
+    ...componentContractsFromDependencies(runtimeProfileDependencies),
   ]);
   const normalizedExtraPlugins = uniqueObjectsByRuntimeIdentity([
     ...normalizeArray(normalizedProfile.extra_plugins),
@@ -62,6 +63,36 @@ function codeboxRuntimeProfilePayload({
     runtime_config_mounts: runtimeConfigMounts,
     ...parentToolBridgeProfileFields(normalizedProfile, normalizedRuntimeRequirements, runtimeProfileDependencies, normalizedComponentContracts),
   });
+}
+
+function componentContractsFromDependencies(runtimeProfileDependencies = {}) {
+  return [
+    ...dependencyComponentContracts(runtimeProfileDependencies.components, 'mu-plugin'),
+    ...dependencyComponentContracts(runtimeProfileDependencies.mu_plugins, 'mu-plugin'),
+    ...dependencyComponentContracts(runtimeProfileDependencies.plugins, 'plugin'),
+    ...dependencyComponentContracts(runtimeProfileDependencies.themes, 'theme'),
+    ...dependencyComponentContracts(runtimeProfileDependencies.overlays),
+  ];
+}
+
+function dependencyComponentContracts(entries, defaultLoadAs) {
+  return normalizeArray(entries).map((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return null;
+    }
+    const slug = entry.slug || entry.id || entry.name;
+    const contractPath = entry.path || entry.source || entry.target;
+    if (!slug || !contractPath) {
+      return null;
+    }
+    return withoutEmptyObjectValues({
+      slug,
+      path: contractPath,
+      loadAs: entry.loadAs || entry.load_as || defaultLoadAs,
+      pluginFile: entry.pluginFile || entry.plugin_file,
+      metadata: entry.metadata,
+    });
+  }).filter(Boolean);
 }
 
 function providerPluginEntries(value) {

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -38,6 +38,7 @@
       "id": "wordpress.codebox-agent-task-executor",
       "label": "WP Codebox agent task executor",
       "backend": "codebox",
+      "runtime_id": "wp-codebox",
       "command": "node {{runtime_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs",
       "invocation": {
         "schema": "homeboy/command-invocation/v1",

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -10,6 +10,7 @@ const {
 const AGENT_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
 const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
 const RUNTIME_AGENT_CI_RUNTIME_PROFILE_ID = 'runtime-agent-ci';
+const RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
 
 function runtimeAgentCiRuntimeTaskRequest(options = {}, context = {}) {
   const taskId = requiredString(options.taskId || options.task_id, 'taskId');
@@ -124,7 +125,7 @@ function normalizeRuntimeExecutionDescriptor(descriptor, runtimeProfile = {}) {
   const ability = descriptor.ability || abilityForRuntimeExecutionKind(kind, runtimeProfile);
   const input = runtimeExecutionInput(descriptor, kind);
   return stripUndefined({
-    schema: descriptor.schema,
+    schema: descriptor.schema || RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA,
     kind,
     ability,
     input,

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -100,6 +100,7 @@ const genericBundleConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
 });
 
 assert.equal(genericBundleConfig.runtime_task.ability, 'runtime/run-agent-bundle');
+assert.equal(genericBundleConfig.runtime_execution.schema, 'homeboy/runtime-execution/v1');
 assert.equal(genericBundleConfig.runtime_task.input.source, '/workspace/example-repo/bundles/example-agent');
 assert.deepEqual(genericBundleConfig.runtime_task.input.workflow, { name: 'materialize-artifact' });
 assert.equal(genericBundleConfig.runtime_task.input.prompt, 'Cook a packet.');

--- a/tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
+++ b/tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
@@ -11,6 +11,8 @@ const provider = manifest.agent_task_executors[0];
 
 assert.equal(provider.schema, 'homeboy/agent-task-executor-provider/v1');
 assert.equal(provider.invocation.schema, 'homeboy/command-invocation/v1');
+assert.equal(provider.backend, 'codebox');
+assert.equal(provider.runtime_id, 'wp-codebox');
 assert.deepEqual(provider.invocation.argv, [
 	'node',
 	'{{runtime_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs',

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -43,6 +43,7 @@ const provider = providerContract();
 assert.equal(provider.id, 'wordpress.codebox-agent-task-executor');
 assert.equal(provider.label, 'WP Codebox agent task executor');
 assert.equal(provider.backend, 'codebox');
+assert.equal(provider.runtime_id, 'wp-codebox');
 assert.equal(provider.integration_contract, 'homeboy-wordpress-agent-task/v1');
 assert.deepEqual(provider.provider_runtime_invocation, providerRuntimeInvocationContract());
 assert.equal(provider.provider_runtime_invocation.tasks.workspaceCommand, 'wp-codebox.runner-workspace.command');
@@ -112,6 +113,7 @@ const customContract = providerContract({
     path_aliases: { agent_runtime: ['runtime_component:example_runtime'] },
   },
 });
+assert.equal(customContract.runtime_id, 'wp-codebox');
 assert.deepEqual(customContract.capabilities, ['wordpress_sandbox', 'tool:example/run-workflow']);
 assert.deepEqual(customContract.workspace_tools.readwrite, ['example_workspace_write']);
 assert.deepEqual(customContract.component_path_defaults.contract_slug_map, { 'example-runtime': 'agent_runtime' });
@@ -239,9 +241,9 @@ const runtimeProfileDependencyTaskInput = codeboxTaskRequestFromAgentTaskRequest
 });
 assert.deepEqual(runtimeProfileDependencyTaskInput.runtime_requirements.components, [{ slug: 'runtime-component', path: '/components/runtime-component' }]);
 assert.deepEqual(runtimeProfileDependencyTaskInput.runtime_requirements.plugins, [{ slug: 'runtime-plugin', path: '/plugins/runtime-plugin' }]);
-assert.equal(runtimeProfileDependencyTaskInput.runtime_requirements.component_contracts, undefined);
+assert.deepEqual(runtimeProfileDependencyTaskInput.runtime_requirements.component_contracts.map((contract) => contract.slug), ['runtime-component', 'runtime-plugin']);
 assert.equal(runtimeProfileDependencyTaskInput.runtime_requirements.extra_plugins, undefined);
-assert.deepEqual(runtimeProfileDependencyTaskInput.component_contracts, []);
+assert.deepEqual(runtimeProfileDependencyTaskInput.component_contracts.map((contract) => contract.slug), ['runtime-component', 'runtime-plugin']);
 assert.equal(runtimeProfileDependencyTaskInput.runtime_requirements.upstream_primitive_requirements[0].id, 'parent-tool-bridge');
 assert.equal(runtimeProfileDependencyTaskInput.runtime_requirements.upstream_primitive_requirements[0].adapter_behavior, 'declare_requirement_only');
 
@@ -361,6 +363,11 @@ const repoLoopBundleTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   },
   inputs: {
     ability_request: { name: 'example/run-agent-bundle' },
+    runtime_input_mapping: [
+      { from: 'client_context.inputs.source', to: 'source' },
+      { from: 'client_context.inputs.flow', to: 'flow' },
+      { from: 'client_context.inputs.wait_for_completion', to: 'wait_for_completion' },
+    ],
     client_context: {
       inputs: {
         source: 'bundles/example-agent',
@@ -399,6 +406,11 @@ const genericRepoLoopTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   inputs: {
     ability_request: {
       name: 'example/materialize-artifact',
+      input_defaults: { dry_run: true, format: 'json' },
+      input_mapping: [
+        { from: 'client_context.inputs.packet', to: 'packet' },
+        { from: 'client_context.inputs.dry_run', to: 'dry_run' },
+      ],
       input: { dry_run: false },
     },
     context: {
@@ -410,6 +422,51 @@ const genericRepoLoopTaskInput = codeboxTaskRequestFromAgentTaskRequest({
 assert.equal(genericRepoLoopTaskInput.runtime_task.ability, 'example/materialize-artifact');
 assert.deepEqual(genericRepoLoopTaskInput.runtime_task.input, {
   packet: 'artifact-42',
+  format: 'json',
+  dry_run: false,
+});
+
+const noImplicitClientContextTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'generic-ability-no-ambient-client-context-task-1',
+  executor: { backend: 'codebox', config: { provider: 'openai' } },
+  instructions: 'Run a generic declared ability without ambient client context merge.',
+  client_context: {
+    inputs: {
+      packet: 'ambient-artifact',
+      dry_run: true,
+    },
+  },
+  inputs: {
+    ability_request: {
+      name: 'example/materialize-artifact',
+      input: { explicit: true },
+    },
+  },
+});
+assert.deepEqual(noImplicitClientContextTaskInput.runtime_task.input, { explicit: true });
+
+const legacyClientContextTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'generic-ability-legacy-client-context-task-1',
+  executor: { backend: 'codebox', config: { provider: 'openai' } },
+  instructions: 'Run a queued legacy declared ability with explicit legacy context merge.',
+  client_context: {
+    inputs: {
+      packet: 'legacy-artifact',
+      dry_run: true,
+    },
+  },
+  inputs: {
+    allow_legacy_client_context_input_merge: true,
+    ability_request: {
+      name: 'example/materialize-artifact',
+      input: { dry_run: false },
+    },
+  },
+});
+assert.deepEqual(legacyClientContextTaskInput.runtime_task.input, {
+  packet: 'legacy-artifact',
   dry_run: false,
 });
 


### PR DESCRIPTION
## Summary
- add explicit runtime input defaults and context mappings for generic WP Codebox ability execution
- gate legacy client_context.inputs merging behind an explicit compatibility flag
- expose runtime_id separately from executor.backend in the WP Codebox runtime manifest and provider contract
- synthesize generic component contracts from runtime profile dependency descriptors

## Tests
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js
- node tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
- node tests/wp-codebox-runtime-profile-defaults-smoke.mjs
- node tests/runtime-agent-ci-contract-smoke.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, focused smoke coverage, and PR description for Chris to review and test.