### PR TITLE
Consume canonical WordPress runtime settings

### DIFF
--- a/wordpress/lib/wordpress-workload-profile.js
+++ b/wordpress/lib/wordpress-workload-profile.js
@@ -135,7 +135,7 @@ function workflowInputsFromWordPressWorkloadProfile(profile) {
 		extra_wp_config_defines: JSON.stringify(normalized.wp_config_defines),
 		runtime_mounts: JSON.stringify(normalized.mounts),
 		workload_run_before: JSON.stringify(normalized.run_before),
-		wp_codebox_workloads: JSON.stringify(normalized.workloads),
+		wordpress_runtime_workloads: JSON.stringify(normalized.workloads),
 		workload_run_after: JSON.stringify(runAfter),
 		metadata: {
 			profile_id: normalized.id,

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -74,8 +74,10 @@ homeboy_wp_codebox_validate_bench_settings() {
         [
             ["bench_env", "object"],
             ["wp_config_defines", "object"],
+            ["wordpress_runtime_blueprint", "object"],
             ["wp_codebox_blueprint", "object"],
             ["playground_blueprint", "object"],
+            ["wordpress_runtime_workloads", "array"],
             ["wp_codebox_workloads", "array"],
             ["playground_workloads", "array"],
             ["wp_codebox_file_mounts", "array"],
@@ -896,7 +898,7 @@ WP_CODEBOX_WORKLOADS_JSON="[]"
 if [ "$settings_json" != "{}" ]; then
     WP_CONFIG_DEFINES_JSON=$(printf '%s' "$settings_json" | jq -c '.wp_config_defines // {}' 2>/dev/null || echo "{}")
     BENCH_ENV_JSON=$(printf '%s' "$settings_json" | jq -c '.bench_env // {}' 2>/dev/null || echo "{}")
-    WP_CODEBOX_WORKLOADS_JSON=$(printf '%s' "$settings_json" | jq -c '.wp_codebox_workloads // .playground_workloads // []' 2>/dev/null || echo "[]")
+    WP_CODEBOX_WORKLOADS_JSON=$(printf '%s' "$settings_json" | jq -c '.wordpress_runtime_workloads // .wp_codebox_workloads // .playground_workloads // []' 2>/dev/null || echo "[]")
 fi
 WP_CODEBOX_WORKLOADS_JSON=$(jq -nc --argjson declared "$WP_CODEBOX_WORKLOADS_JSON" --argjson scenarios "$SCENARIO_MANIFEST_WORKLOADS_JSON" '$declared + $scenarios')
 homeboy_wp_codebox_append_extra_bench_workloads_configured_json
@@ -1063,7 +1065,7 @@ fi
 
 WP_CODEBOX_BLUEPRINT_JSON="{}"
 if [ "$settings_json" != "{}" ]; then
-    WP_CODEBOX_BLUEPRINT_JSON=$(printf '%s' "$settings_json" | jq -c '.wp_codebox_blueprint // .playground_blueprint // {}' 2>/dev/null || echo "{}")
+    WP_CODEBOX_BLUEPRINT_JSON=$(printf '%s' "$settings_json" | jq -c '.wordpress_runtime_blueprint // .wp_codebox_blueprint // .playground_blueprint // {}' 2>/dev/null || echo "{}")
 fi
 RUNTIME_BLUEPRINT_JSON=$(jq -nc \
     --argjson base "$WP_CODEBOX_BLUEPRINT_JSON" \
@@ -1184,7 +1186,7 @@ homeboy_wp_codebox_emit_dependency_provenance() {
                 keys: ($settings | keys | sort),
                 has_bench_env: (($settings.bench_env // null) != null),
                 has_wp_config_defines: (($settings.wp_config_defines // null) != null),
-                has_configured_workloads: ((($settings.wp_codebox_workloads // $settings.playground_workloads // []) | length) > 0),
+                has_configured_workloads: ((($settings.wordpress_runtime_workloads // $settings.wp_codebox_workloads // $settings.playground_workloads // []) | length) > 0),
                 has_scenario_manifests: ((($settings.wp_codebox_scenario_manifests // $settings.scenario_manifests // []) | length) > 0)
             }
         }' > "$provenance_file"

--- a/wordpress/tests/fixtures/wp-codebox-core-bench-runner.mjs
+++ b/wordpress/tests/fixtures/wp-codebox-core-bench-runner.mjs
@@ -5,6 +5,7 @@ export function buildWordPressBenchRecipe(options = {}) {
 			mounts: options.mounts ?? [],
 			extra_plugins: options.extra_plugins ?? [],
 			pluginRuntime: options.pluginRuntime ?? {},
+			workloads: options.workloads ?? [],
 		},
 		runtime: {
 			blueprint: options.blueprint ?? {},

--- a/wordpress/tests/wordpress-workload-profile-smoke.js
+++ b/wordpress/tests/wordpress-workload-profile-smoke.js
@@ -60,7 +60,8 @@ assert.equal(inputs.validation_dependencies, 'example/content-importer@main,exam
 assert.deepEqual(JSON.parse(inputs.extra_wp_config_defines), { WP_DEBUG: true });
 assert.deepEqual(JSON.parse(inputs.runtime_mounts), normalized.mounts);
 assert.deepEqual(JSON.parse(inputs.workload_run_before), normalized.run_before);
-assert.deepEqual(JSON.parse(inputs.wp_codebox_workloads), normalized.workloads);
+assert.deepEqual(JSON.parse(inputs.wordpress_runtime_workloads), normalized.workloads);
+assert.equal(Object.hasOwn(inputs, 'wp_codebox_workloads'), false);
 assert.deepEqual(JSON.parse(inputs.workload_run_after), [
 	{ type: 'wp-cli', command: 'option get home' },
 	{

--- a/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
@@ -109,6 +109,10 @@ homeboy_resolve_context() {
       },
     ],
     wp_codebox_core_module: fixtureCoreModule,
+    wordpress_runtime_blueprint: { features: { canonicalRuntimeSettings: true } },
+    wordpress_runtime_workloads: [
+      { id: 'canonical-workload', steps: [{ type: 'php', code: 'return [];' }] },
+    ],
     wp_codebox_extra_plugins: [
       { source: '/tmp/runtime-prerequisite', slug: 'runtime-prerequisite', activate: true },
     ],
@@ -155,6 +159,8 @@ homeboy_resolve_context() {
   assert.equal(recipe.inputs.extra_plugins.some((plugin) => plugin.slug === 'woocommerce-gateway-stripe'), true);
   assert.deepEqual(recipe.inputs.extra_plugins.find((plugin) => plugin.slug === 'runtime-prerequisite'), settings.wp_codebox_extra_plugins[0]);
   assert.deepEqual(recipe.inputs.pluginRuntime.setup, settings.wp_codebox_bootstrap_steps);
+  assert.deepEqual(recipe.runtime.blueprint.features, { canonicalRuntimeSettings: true });
+  assert.deepEqual(recipe.inputs.workloads, settings.wordpress_runtime_workloads);
   assert.equal(recipe.workflow.steps[0].command, 'wordpress.bench');
 
   const successResults = JSON.parse(fs.readFileSync(path.join(root, 'success-results.json'), 'utf8'));

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -957,11 +957,18 @@
       "description": "How the WP Codebox PHPUnit backend treats successful WordPress install/activation when discovery finds zero PHPUnit files. Use 'skipped' for components that intentionally test through smoke scripts, or 'failed' when the component expects PHPUnit coverage. Components with phpunit.xml(.dist) still fail on zero discovery."
     },
     {
+      "id": "wordpress_runtime_blueprint",
+      "label": "WordPress runtime blueprint",
+      "type": "object",
+      "default": {},
+      "description": "Backend-neutral WordPress runtime blueprint merged into the selected runtime adapter recipe. Empty object means stock WordPress. Runtime adapters normalize this canonical setting to backend-specific fields."
+    },
+    {
       "id": "wp_codebox_blueprint",
       "label": "WP Codebox blueprint",
       "type": "object",
       "default": {},
-      "description": "Runtime blueprint merged into the generated WP Codebox bench recipe. Empty object means stock WordPress."
+      "description": "Legacy compatibility alias for wordpress_runtime_blueprint. Prefer wordpress_runtime_blueprint for new configuration."
     },
     {
       "id": "wp_codebox_extra_plugins",
@@ -971,11 +978,18 @@
       "description": "Additional WP Codebox extra plugin entries for bench recipes. Use for runtime prerequisites that must be installed or activated but should not be treated as Homeboy validation dependencies."
     },
     {
+      "id": "wordpress_runtime_workloads",
+      "label": "WordPress runtime workloads",
+      "type": "array",
+      "default": [],
+      "description": "Backend-neutral WordPress workload declarations passed to the selected runtime adapter after dependency mounts and component load. Each workload declares an id, optional label, run steps ({type: 'php', code|file}, {type: 'ability', ability|name, input}, or {type: 'wp-cli', command}), and optional metrics/artifacts/metadata."
+    },
+    {
       "id": "wp_codebox_workloads",
       "label": "Bench workloads",
       "type": "array",
       "default": [],
-      "description": "Config-declared WordPress bench workloads passed to wordpress.bench through the generated WP Codebox recipe after dependency mounts and component load. Each workload declares an id, optional label, run steps ({type: 'php', code|file}, {type: 'ability', ability|name, input}, or {type: 'wp-cli', command}), and optional metrics/artifacts/metadata. Step returns use the same {metrics, artifacts, metadata} shape as Node.js bench workloads."
+      "description": "Legacy compatibility alias for wordpress_runtime_workloads. Prefer wordpress_runtime_workloads for new configuration."
     },
     {
       "id": "wp_codebox_bootstrap_files",


### PR DESCRIPTION
## Summary
- Add backend-neutral `wordpress_runtime_blueprint` and `wordpress_runtime_workloads` settings to the WordPress extension manifest.
- Make the WP Codebox bench adapter consume canonical runtime fields first, with legacy `wp_codebox_*` / `playground_*` aliases normalized only inside the adapter.
- Update workload profile workflow inputs to emit `wordpress_runtime_workloads` instead of the WP Codebox compatibility alias.

## Tests
- `node wordpress/tests/wordpress-workload-profile-smoke.js`
- `node wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the runtime-settings adapter change, tests, and PR description; Chris remains responsible for review and validation.