### PR TITLE
Use shared Codebox core loader

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -175,7 +175,16 @@ const LEGACY_BUNDLE_KEYS = [
   `${LEGACY_RUNTIME_PREFIX}Bundle`,
 ];
 
-const WP_CODEBOX_RUNTIME_GAP_TRACKERS = [];
+const WP_CODEBOX_RUNTIME_GAP_TRACKERS = [
+  {
+    gap: 'runtime-profile-normalizer',
+    needed_primitive: 'WP Codebox should export a stable runtime-profile builder/normalizer that accepts Homeboy-provided component contracts, provider plugin paths, runtime env, overlays, and parent-tool bridge declarations without Homeboy reshaping dependency fields locally.',
+  },
+  {
+    gap: 'typed-artifact-dto-normalizer',
+    needed_primitive: 'WP Codebox should export a stable typed-artifact DTO normalizer compatible with Homeboy agent-task typed artifact declarations, including file_refs/fileRefs and artifact_schema/artifactSchema aliases while allowing caller-owned metadata redaction policy.',
+  },
+];
 
 const WP_CODEBOX_ROLE_ALIASES = {
   artifact_kinds: {

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -9,7 +9,6 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
-const { pathToFileURL } = require('node:url');
 
 /**
  * Internal dependencies
@@ -27,8 +26,10 @@ const {
   providerPluginValidation,
   providerSecretEnv,
 } = require('../../lib/provider-preflight-manifest');
+const {
+  loadWpCodeboxCore,
+} = require('../../../../wordpress/lib/wp-codebox-core-loader');
 
-const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
 const DEFAULT_TASK_RUNNER = path.resolve(__dirname, 'homeboy-wp-codebox-task-runner.cjs');
 function argValue(name) {
   const index = process.argv.indexOf(name);
@@ -617,31 +618,15 @@ function missingModelPreflightPayload(taskInput) {
 }
 
 async function loadCodeboxCoreNormalizers() {
-  const configuredModule = process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE;
-  const candidates = configuredModule ? [configuredModule] : [DEFAULT_CODEBOX_CORE_MODULE];
-
-  for (const candidate of candidates) {
-    try {
-      const module = await importModule(candidate);
-      if (typeof module.normalizeAgentTaskRunResult === 'function' || typeof module.normalizeRecipeRunSummary === 'function') {
-        return {
-          normalizeAgentTaskRunResult: typeof module.normalizeAgentTaskRunResult === 'function' ? module.normalizeAgentTaskRunResult : null,
-          normalizeRecipeRunSummary: typeof module.normalizeRecipeRunSummary === 'function' ? module.normalizeRecipeRunSummary : null,
-        };
-      }
-    } catch {
-      // Fall back to the local compatibility path when Codebox core is not installed yet.
-    }
+  const module = await loadWpCodeboxCore();
+  if (typeof module?.normalizeAgentTaskRunResult === 'function' || typeof module?.normalizeRecipeRunSummary === 'function') {
+    return {
+      normalizeAgentTaskRunResult: typeof module.normalizeAgentTaskRunResult === 'function' ? module.normalizeAgentTaskRunResult : null,
+      normalizeRecipeRunSummary: typeof module.normalizeRecipeRunSummary === 'function' ? module.normalizeRecipeRunSummary : null,
+    };
   }
 
   return {};
-}
-
-function importModule(specifier) {
-  if (specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('file:')) {
-    return import(specifier.startsWith('file:') ? specifier : pathToFileURL(path.resolve(specifier)).href);
-  }
-  return import(specifier);
 }
 
 function runtimeOverlayConfigFailurePayload(error) {

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -345,7 +345,16 @@
       },
       "status": "active",
       "integration_contract": "homeboy-wordpress-agent-task/v1",
-      "runtime_gap_trackers": []
+      "runtime_gap_trackers": [
+        {
+          "gap": "runtime-profile-normalizer",
+          "needed_primitive": "WP Codebox should export a stable runtime-profile builder/normalizer that accepts Homeboy-provided component contracts, provider plugin paths, runtime env, overlays, and parent-tool bridge declarations without Homeboy reshaping dependency fields locally."
+        },
+        {
+          "gap": "typed-artifact-dto-normalizer",
+          "needed_primitive": "WP Codebox should export a stable typed-artifact DTO normalizer compatible with Homeboy agent-task typed artifact declarations, including file_refs/fileRefs and artifact_schema/artifactSchema aliases while allowing caller-owned metadata redaction policy."
+        }
+      ]
     }
   ]
 }

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -91,6 +91,8 @@ process.stdout.write(JSON.stringify({
     }
   },
   recipe_run: {
+    success: true,
+    status: 'completed',
     pack: 'fixture-recipes',
     name: 'fixture-recipe',
     probe: { success: true }
@@ -431,7 +433,7 @@ for (const capability of repoLoopCapabilities) {
 }
 assert.equal(provider.capabilities.includes('tool:wpsg_materialize_packet'), false);
 assert.equal(provider.capabilities.includes('ability:wpsg_materialize_packet'), false);
-assert.deepEqual(provider.runtime_gap_trackers, []);
+assert.deepEqual(provider.runtime_gap_trackers.map((tracker) => tracker.gap), ['runtime-profile-normalizer', 'typed-artifact-dto-normalizer']);
 
 const codeboxRequest = codeboxTaskRequestFromAgentTaskRequest(request);
 assert.equal(codeboxRequest.schema, 'wp-codebox/task-input/v1');
@@ -2147,7 +2149,7 @@ assert.equal(canaryRunOutcome.metadata.decision_evidence.runtime_status, 'destro
 assert.equal(canaryRunOutcome.metadata.decision_evidence.cleanup_observed, 'runtime_destroyed');
 assert.equal(canaryRunOutcome.metadata.decision_evidence.no_op_reason, 'no_file_changes');
 assert.equal(canaryRunOutcome.metadata.decision_evidence.patch_bytes, 0);
-assert.deepEqual(canaryRunOutcome.metadata.decision_evidence.runtime_gap_trackers, []);
+assert.deepEqual(canaryRunOutcome.metadata.decision_evidence.runtime_gap_trackers.map((tracker) => tracker.gap), ['runtime-profile-normalizer', 'typed-artifact-dto-normalizer']);
 
 const canaryTranscriptRequiredOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,


### PR DESCRIPTION
## Summary
- replace the local Codebox core normalizer loader with the shared wp-codebox-core-loader
- consume Codebox run/recipe normalizers when available
- preserve Homeboy-owned policy, redaction, preflight, outcome enrichment, and fallback behavior
- document remaining Codebox runtime/profile and typed-artifact primitive gaps

Related upstream contract work: https://github.com/Automattic/wp-codebox/pull/1229.

## Testing
- node tests/wp-codebox-runtime-profile-defaults-smoke.mjs
- node tests/wp-codebox-artifact-contract-smoke.mjs
- node tests/codebox-delegated-run-normalizer-smoke.mjs
- node tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
- node wordpress/tests/codebox-agent-task-executor-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the loader cleanup, smoke-test updates, gap metadata, and PR description; Chris remains responsible for review and validation.