### PR TITLE
Restore generic runtime agent CI workflow

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -34,8 +34,8 @@ function buildConfig(env) {
   const targetRepo = required(env.TARGET_REPO, 'TARGET_REPO');
   const componentId = env.COMPONENT_ID || path.basename(workspace);
   const componentPath = env.COMPONENT_PATH || workspace;
-  const runtimeId = env.RUNTIME_PROVIDER || DEFAULT_RUNTIME_ID;
-  const runtimeProfile = required(env.RUNTIME_PROFILE, 'RUNTIME_PROFILE');
+  const runtimeId = env.RUNTIME || env.RUNTIME_PROVIDER || env.BACKEND || DEFAULT_RUNTIME_ID;
+  const runtimeProfile = required(env.PROFILE || env.RUNTIME_PROFILE, 'PROFILE or RUNTIME_PROFILE');
   const runtimeProfiles = parseJsonInput('runtime_profiles', env.RUNTIME_PROFILES || '{}', 'object', {});
   const runtime = resolveRuntimeProvider(runtimeId, { workspace, env });
   const runtimeBin = runtime.paths.runtime_bin;
@@ -112,7 +112,7 @@ function buildConfig(env) {
     workload_id: workloadId,
     workload_label: env.WORKLOAD_LABEL || `Run ${workloadId}`,
     validation_dependencies: validationDependencies.paths,
-    runtime_id: runtimeId,
+    runtime_id: runtime.id,
     runtime_profile: runtimeProfile,
     runtime_profiles: effectiveRuntimeProfiles,
     runtime_ref: env.RUNTIME_REF || 'main',

--- a/.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
+++ b/.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
@@ -24,7 +24,7 @@ function main() {
 }
 
 function dependencyEntries(env) {
-  const runtimeId = env.RUNTIME_PROVIDER || DEFAULT_RUNTIME_ID;
+  const runtimeId = env.RUNTIME || env.RUNTIME_PROVIDER || env.BACKEND || DEFAULT_RUNTIME_ID;
   const runtime = resolveRuntimeProvider(runtimeId, { env });
   const entries = runtime.checkout.repo ? [{ repo: runtime.checkout.repo, ref: runtime.checkout.ref, target: runtime.checkout.target }] : [];
   const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || 'openai', true);

--- a/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
+++ b/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
@@ -8,7 +8,7 @@ const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../../../runtime
 
 try {
   const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
-  const runtime = resolveRuntimeProvider(process.env.RUNTIME_PROVIDER || DEFAULT_RUNTIME_ID, { workspace });
+  const runtime = resolveRuntimeProvider(process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || DEFAULT_RUNTIME_ID, { workspace });
   run('composer', ['install', '--no-interaction', '--no-progress', '--prefer-dist'], { cwd: path.join(workspace, '.ci/homeboy-extensions/wordpress') });
   run('npm', ['install'], { cwd: path.join(workspace, '.ci/homeboy-extensions/wordpress') });
   for (const command of [...runtime.setupCommands, ...runtime.buildCommands]) {

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -63,9 +63,9 @@ jobs:
   run-agent:
     uses: Extra-Chill/homeboy-extensions/.github/workflows/runtime-agent-full-run.yml@v4
     with:
-      runtime_provider: wp-codebox
+      runtime: wp-codebox
       runtime_ref: main
-      runtime_profile: example-agent
+      profile: example-agent
       runtime_profiles: |
         {
           "example-agent": {
@@ -94,7 +94,7 @@ Use this mapping when updating old wrapper workflow bodies:
 
 | Old wrapper concept | Generic `runtime-agent-full-run.yml` input |
 | --- | --- |
-| Runtime selection | `runtime_provider`, `runtime_ref`, `runtime_wordpress_version` |
+| Runtime selection | `runtime` (`runtime_provider` compatibility alias), `runtime_ref`, `runtime_wordpress_version` |
 | Flow identity | `workload_id`, `workload_label`, `callback_data` |
 | Bundle execution | `runtime_execution: {"kind":"bundle","source":"..."}` |
 | Direct ability execution | `runtime_task` or `ability_request` / `ability_input` |
@@ -179,7 +179,8 @@ jobs:
 
 ## Inputs worth calling out
 
-- Agent CI runs through the selected `runtime_provider`. Runtime metadata is discovered from `agent-runtimes/<runtime>/<runtime>.json` or another manifest JSON adjacent to the runtime.
+- Agent CI runs through the selected `runtime`. `runtime_provider` remains a compatibility alias, and `codebox` resolves to `wp-codebox` for older callers. Runtime metadata is discovered from `agent-runtimes/<runtime>/<runtime>.json` or another manifest JSON adjacent to the runtime.
+- `profile` is the preferred runtime profile selector. `runtime_profile` remains supported for existing callers.
 - `runtime_ref` controls the selected runtime ref.
 - `runtime_execution` declares bundle, workflow, or ability execution. When `runtime_task` or `ability_request` is supplied, the workflow builds a direct runtime task instead.
 - `runtime_task` forwards a generic `{ "ability", "input" }` object to the runtime task executor.

--- a/.github/workflows/runtime-agent-ci.yml
+++ b/.github/workflows/runtime-agent-ci.yml
@@ -3,11 +3,21 @@ name: Runtime Agent CI (reusable)
 on:
   workflow_call:
     inputs:
-      runtime_provider:
-        description: Runtime provider backend identifier.
+      runtime:
+        description: Agent runtime id. Preferred alias for runtime_provider.
         required: false
         type: string
-        default: codebox
+        default: ''
+      backend:
+        description: Compatibility alias for runtime_provider; use runtime for new callers.
+        required: false
+        type: string
+        default: ''
+      runtime_provider:
+        description: Runtime provider identifier. Prefer runtime for new callers.
+        required: false
+        type: string
+        default: wp-codebox
       provider:
         description: Model/provider identifier forwarded to the runtime.
         required: false
@@ -20,8 +30,14 @@ on:
         default: ''
       runtime_profile:
         description: Runtime profile id to select from runtime_profiles.
-        required: true
+        required: false
         type: string
+        default: ''
+      profile:
+        description: Preferred alias for runtime_profile.
+        required: false
+        type: string
+        default: ''
       runtime_profiles:
         description: JSON object keyed by runtime profile id.
         required: true
@@ -97,9 +113,12 @@ jobs:
         shell: bash
         env:
           RUNTIME_PROVIDER: ${{ inputs.runtime_provider }}
+          RUNTIME: ${{ inputs.runtime }}
+          BACKEND: ${{ inputs.backend }}
           PROVIDER: ${{ inputs.provider }}
           MODEL: ${{ inputs.model }}
           RUNTIME_PROFILE: ${{ inputs.runtime_profile }}
+          PROFILE: ${{ inputs.profile }}
           RUNTIME_PROFILES: ${{ inputs.runtime_profiles }}
           RUNTIME_COMPONENT_PATHS: ${{ inputs.runtime_component_paths }}
           IGNORED_WORKSPACE_PATHS: ${{ inputs.ignored_workspace_paths }}
@@ -119,6 +138,7 @@ jobs:
           const {
             runtimeAgentCiTaskExecutorConfig,
           } = require('./runtime-agent-ci');
+          const { normalizeRuntimeId } = require('./runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 
           function parseJson(name, fallback) {
             const value = process.env[name];
@@ -129,11 +149,16 @@ jobs:
           }
 
           const runtimeTask = parseJson('RUNTIME_TASK', {});
+          const runtimeProvider = normalizeRuntimeId(process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || 'wp-codebox');
+          const runtimeProfile = process.env.PROFILE || process.env.RUNTIME_PROFILE;
+          if (!runtimeProfile) {
+            throw new Error('profile or runtime_profile is required.');
+          }
           const config = runtimeAgentCiTaskExecutorConfig({
-            runtimeProvider: process.env.RUNTIME_PROVIDER,
+            runtimeProvider,
             provider: process.env.PROVIDER || undefined,
             model: process.env.MODEL || undefined,
-            runtimeProfile: process.env.RUNTIME_PROFILE,
+            runtimeProfile,
             runtimeProfiles: parseJson('RUNTIME_PROFILES', {}),
             runtimeComponentPaths: parseJson('RUNTIME_COMPONENT_PATHS', {}),
             ignoredWorkspacePaths: parseJson('IGNORED_WORKSPACE_PATHS', []),

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -12,9 +12,17 @@ name: Runtime Agent Full Run (reusable)
         type: boolean
         default: true
       runtime_provider:
-        description: Runtime provider backend identifier.
+        description: Runtime provider identifier. Prefer runtime for new callers.
         type: string
         default: wp-codebox
+      runtime:
+        description: Agent runtime id. Preferred alias for runtime_provider.
+        type: string
+        default: ''
+      backend:
+        description: Compatibility alias for runtime_provider; use runtime for new callers.
+        type: string
+        default: ''
       runtime_ref:
         description: Runtime provider ref.
         type: string
@@ -26,7 +34,11 @@ name: Runtime Agent Full Run (reusable)
       runtime_profile:
         description: Runtime profile id selected from runtime_profiles.
         type: string
-        required: true
+        default: ''
+      profile:
+        description: Preferred alias for runtime_profile.
+        type: string
+        default: ''
       runtime_profiles:
         description: JSON object keyed by runtime profile id.
         type: string
@@ -411,6 +423,8 @@ jobs:
           VALIDATION_DEPENDENCIES: ${{ inputs.validation_dependencies }}
           RUNTIME_DEPENDENCIES: ${{ inputs.runtime_dependencies }}
           RUNTIME_PROVIDER: ${{ inputs.runtime_provider }}
+          RUNTIME: ${{ inputs.runtime }}
+          BACKEND: ${{ inputs.backend }}
           AGENT_RUNTIME_REF: ${{ inputs.runtime_ref }}
           PROVIDER: ${{ inputs.provider }}
           PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
@@ -452,6 +466,8 @@ jobs:
         if: ${{ inputs.run_agent }}
         env:
           RUNTIME_PROVIDER: ${{ inputs.runtime_provider }}
+          RUNTIME: ${{ inputs.runtime }}
+          BACKEND: ${{ inputs.backend }}
           AGENT_RUNTIME_REF: ${{ inputs.runtime_ref }}
           PROVIDER: ${{ inputs.provider }}
           PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
@@ -474,9 +490,12 @@ jobs:
           PROVIDER: ${{ inputs.provider }}
           MODEL: ${{ inputs.model }}
           RUNTIME_PROVIDER: ${{ inputs.runtime_provider }}
+          RUNTIME: ${{ inputs.runtime }}
+          BACKEND: ${{ inputs.backend }}
           AGENT_RUNTIME_REF: ${{ inputs.runtime_ref }}
           RUNTIME_REF: ${{ inputs.runtime_ref }}
           RUNTIME_PROFILE: ${{ inputs.runtime_profile }}
+          PROFILE: ${{ inputs.profile }}
           RUNTIME_PROFILES: ${{ inputs.runtime_profiles }}
           RUNTIME_WORDPRESS_VERSION: ${{ inputs.runtime_wordpress_version }}
           EXECUTION_KIND: ${{ inputs.execution_kind }}

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ ability execution. Mount downloaded GitHub Actions artifacts with
 `runtime_mounts`, and enforce typed outputs with `artifact_declarations` plus
 `runtime_output_projections`.
 
+New callers should select runtimes with `runtime` and `profile`. Existing
+`runtime_provider` / `runtime_profile` callers remain supported, and the legacy
+`codebox` runtime value resolves to `wp-codebox`.
+
 Call `.github/workflows/runtime-agent-full-run.yml` directly for runtime-backed
 agent runs. Former domain-specific reusable workflow wrappers have been removed
 after active default-branch consumers migrated to the generic workflow.

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -6,6 +6,7 @@ const {
   agentTaskRunnerSpec,
   validateAgentTaskRunnerSpec,
 } = require('./agent-task-runner-contract');
+const { normalizeRuntimeId } = require('./runtime-provider-resolver.cjs');
 
 const AGENT_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
 const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
@@ -60,9 +61,11 @@ function runtimeAgentCiAbilityTaskRequest(options = {}, context = {}) {
 function runtimeAgentCiRunnerSpec(options = {}, context = {}) {
   const taskExecutorConfig = context.taskExecutorConfig || runtimeAgentCiTaskExecutorConfig;
   const config = taskExecutorConfig(options);
+  const runtime = options.runtime || options.runtimeId || options.runtime_id || options.runtimeProvider || options.runtime_provider;
+  const normalizedRuntime = runtime ? normalizeRuntimeId(runtime) : runtime;
   return agentTaskRunnerSpec({
-    backend: options.backend || options.runtimeBackend || options.runtime_backend,
-    runtime: options.runtime || options.runtimeId || options.runtime_id || options.runtimeProvider || options.runtime_provider,
+    backend: options.backend || options.runtimeBackend || options.runtime_backend || runtimeBackendForRuntime(normalizedRuntime),
+    runtime: normalizedRuntime,
     config,
     secret_env: normalizeArray(config.secret_env),
     task_timeout_seconds: config.task_timeout_seconds || options.taskTimeoutSeconds || options.task_timeout_seconds || 900,
@@ -71,8 +74,17 @@ function runtimeAgentCiRunnerSpec(options = {}, context = {}) {
   });
 }
 
+function runtimeBackendForRuntime(runtime) {
+  const normalizedRuntime = normalizeRuntimeId(runtime);
+  if (normalizedRuntime === 'wp-codebox') {
+    return 'codebox';
+  }
+  return normalizedRuntime;
+}
+
 function runtimeAgentCiTaskExecutorConfig(options = {}) {
   const runtimeProfile = resolveRuntimeAgentCiRuntimeProfile(options);
+  const runtimeProvider = options.runtime || options.runtimeId || options.runtime_id || options.runtimeProvider || options.runtime_provider;
   const runtimeExecution = normalizeRuntimeExecutionDescriptor(options.runtimeExecution || options.runtime_execution, runtimeProfile);
   const runtimeTaskInput = runtimeExecution?.input || options.abilityInput || options.ability_input || {};
   const runtimeTask = stripUndefined({
@@ -83,7 +95,7 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
     ...(options.config || {}),
     provider: options.provider,
     model: options.model,
-    runtime_provider: options.runtimeProvider || options.runtime_provider,
+    runtime_provider: runtimeProvider ? normalizeRuntimeId(runtimeProvider) : runtimeProvider,
     runtime_profile: runtimeProfile.id,
     runtime_profiles: runtimeProfilesForOptions(options, runtimeProfile),
     runtime_component_paths: options.runtimeComponentPaths || options.runtime_component_paths,
@@ -306,6 +318,7 @@ module.exports = {
   runtimeAgentCiRuntimeProfilesForOptions,
   runtimeAgentCiTaskFromRequest,
   runtimeAgentCiTaskExecutorConfig,
+  runtimeBackendForRuntime,
   normalizeRuntimeExecutionDescriptor,
   resolveRuntimeAgentCiRuntimeProfile,
   validateAgentTaskRunnerSpec,

--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -4,6 +4,9 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const DEFAULT_RUNTIME_ID = 'wp-codebox';
+const RUNTIME_ID_ALIASES = {
+	codebox: 'wp-codebox',
+};
 
 function repoRootFromHere() {
 	return path.resolve(__dirname, '..', '..');
@@ -84,8 +87,13 @@ function isRuntimeManifest(manifest) {
 	);
 }
 
-function resolveRuntimeProvider(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
+function normalizeRuntimeId(runtimeId = DEFAULT_RUNTIME_ID) {
 	const id = runtimeId || DEFAULT_RUNTIME_ID;
+	return RUNTIME_ID_ALIASES[id] || id;
+}
+
+function resolveRuntimeProvider(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
+	const id = normalizeRuntimeId(runtimeId);
 	const registry = options.registry || runtimeRegistry(options);
 	const manifest = registry[id];
 	if (!manifest) {
@@ -165,6 +173,7 @@ function executorScriptArg(provider) {
 
 module.exports = {
 	DEFAULT_RUNTIME_ID,
+	normalizeRuntimeId,
 	resolveRuntimeProvider,
 	runtimeManifestPath,
 	runtimeRegistry,

--- a/wordpress/scripts/agent/run-runtime-agent-task.cjs
+++ b/wordpress/scripts/agent/run-runtime-agent-task.cjs
@@ -170,7 +170,7 @@ function writeOutcome(outcome) {
 try {
   const configPath = readConfigPath();
   const config = readJson(configPath);
-  const runtime = resolveRuntimeProvider(config.runtime_id || process.env.RUNTIME_PROVIDER || 'wp-codebox', { repoRoot: REPO_ROOT, workspace: config.component_path || process.cwd() });
+  const runtime = resolveRuntimeProvider(config.runtime_id || process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || 'wp-codebox', { repoRoot: REPO_ROOT, workspace: config.component_path || process.cwd() });
   const request = buildAgentTaskRequest(config, configPath, runtime);
   const result = spawnSync(process.execPath, [runtime.executor.path], {
     encoding: 'utf8',

--- a/wordpress/tests/generic-agent-runtime-contract.test.js
+++ b/wordpress/tests/generic-agent-runtime-contract.test.js
@@ -6,6 +6,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const {
+	normalizeRuntimeId,
 	resolveRuntimeProvider,
 	runtimeRegistry,
 } = require('../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
@@ -30,6 +31,8 @@ assert.equal(registry['fake-runtime'], undefined);
 assert.equal(registry['local-shell'], undefined);
 assert.equal(registry['package'], undefined);
 assert.equal(registry['homeboy-agent-task-core-contract'], undefined);
+assert.equal(normalizeRuntimeId('codebox'), 'wp-codebox');
+assert.equal(resolveRuntimeProvider('codebox', { repoRoot, registry }).id, 'wp-codebox');
 
 const wpCodeboxRuntime = resolveRuntimeProvider('wp-codebox', { repoRoot, registry });
 assert.equal(wpCodeboxRuntime.id, 'wp-codebox');
@@ -87,8 +90,8 @@ try {
 		RUNNER_TEMP: path.join(configRoot, 'runner-temp'),
 		WORKLOAD_ID: 'opencode-smoke',
 		TARGET_REPO: 'Extra-Chill/example-target',
-		RUNTIME_PROVIDER: 'opencode',
-		RUNTIME_PROFILE: 'opencode-ci',
+		RUNTIME: 'opencode',
+		PROFILE: 'opencode-ci',
 		RUNTIME_PROFILES: JSON.stringify({
 			'opencode-ci': {
 				id: 'opencode-ci',
@@ -133,7 +136,6 @@ assert.throws(
 );
 assert.equal(
 	runtimeAgentCiRunnerSpec({
-		backend: 'opencode',
 		runtime: 'opencode',
 		ability: 'example/run-task',
 		runtimeProfile: 'example-runtime-ci',
@@ -143,13 +145,30 @@ assert.equal(
 );
 assert.equal(
 	runtimeAgentCiRunnerSpec({
-		backend: 'opencode',
 		runtime: 'opencode',
 		ability: 'example/run-task',
 		runtimeProfile: 'example-runtime-ci',
 		runtimeProfiles: { 'example-runtime-ci': runtimeProfile },
 	}).executor.runtime,
 	'opencode'
+);
+assert.equal(
+	runtimeAgentCiRunnerSpec({
+		runtimeProvider: 'codebox',
+		ability: 'example/run-task',
+		runtimeProfile: 'example-runtime-ci',
+		runtimeProfiles: { 'example-runtime-ci': runtimeProfile },
+	}).executor.runtime,
+	'wp-codebox'
+);
+assert.equal(
+	runtimeAgentCiRunnerSpec({
+		runtimeProvider: 'codebox',
+		ability: 'example/run-task',
+		runtimeProfile: 'example-runtime-ci',
+		runtimeProfiles: { 'example-runtime-ci': runtimeProfile },
+	}).executor.backend,
+	'codebox'
 );
 
 process.stdout.write('Generic agent runtime contract passed\n');


### PR DESCRIPTION
## Summary
- restores the generic runtime agent CI reusable workflow surface with preferred runtime/profile inputs
- keeps runtime_provider/runtime_profile and codebox compatibility aliases for existing callers
- routes WP Codebox details through runtime manifest/profile resolution instead of workflow-specific assumptions

## Verification
- node tests/generic-agent-runtime-contract.test.js
- npm run test:wordpress-runtime-task-planner
- npm run test:codebox-agent-task-executor-boundary
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and validating the runtime CI compatibility changes, resolving the rebase conflict, and preparing this PR for Chris to review.