### PR TITLE
Resolve Codebox helpers from installed runtime

### DIFF
--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -28,7 +28,26 @@ const {
 } = require('../../lib/provider-preflight-manifest');
 const {
   loadWpCodeboxCore,
-} = require('../../../../wordpress/lib/wp-codebox-core-loader');
+} = requireWpCodeboxCoreLoader();
+
+function requireWpCodeboxCoreLoader() {
+  const candidates = [
+    path.resolve(__dirname, '../../../../wordpress/lib/wp-codebox-core-loader'),
+    path.resolve(__dirname, '../../../../extensions/wordpress/lib/wp-codebox-core-loader'),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      return require(candidate);
+    } catch (error) {
+      if (!error || error.code !== 'MODULE_NOT_FOUND') {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error(`Unable to resolve wp-codebox-core-loader from ${candidates.join(', ')}`);
+}
 
 const DEFAULT_TASK_RUNNER = path.resolve(__dirname, 'homeboy-wp-codebox-task-runner.cjs');
 function argValue(name) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -2343,6 +2343,38 @@ assert(missingProviderPluginDiagnostic);
 assert.equal(missingProviderPluginDiagnostic.data.missing_provider_plugin_path, true);
 assert.deepEqual(missingProviderPluginDiagnostic.data.provider_plugin_paths, []);
 
+const installedLayoutRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-agent-runtime-install-'));
+try {
+  const installedRuntime = path.join(installedLayoutRoot, 'agent-runtimes', 'wp-codebox');
+  fs.mkdirSync(path.join(installedRuntime, 'scripts', 'agent'), { recursive: true });
+  fs.mkdirSync(path.join(installedRuntime, 'lib'), { recursive: true });
+  fs.mkdirSync(path.join(installedLayoutRoot, 'extensions', 'wordpress', 'lib'), { recursive: true });
+  fs.copyFileSync(wpCodeboxRuntimeExecutor, path.join(installedRuntime, 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs'));
+  fs.writeFileSync(path.join(installedRuntime, 'lib', 'codebox-agent-task-executor.js'), `module.exports = {
+  agentTaskOutcomeFromCodeboxResult() { return {}; },
+  codeboxTaskRequestFromAgentTaskRequest() { return {}; },
+  providerContract() { return {}; },
+};\n`);
+  fs.writeFileSync(path.join(installedRuntime, 'lib', 'provider-preflight-manifest.js'), `module.exports = {
+  normalizeStringArray(value) { return Array.isArray(value) ? value : []; },
+  providerAuthEnvSources() { return {}; },
+  providerDiagnosticClass() { return 'fixture'; },
+  providerLabel() { return 'fixture'; },
+  providerPluginValidation() { return null; },
+  providerSecretEnv() { return []; },
+};\n`);
+  fs.writeFileSync(path.join(installedLayoutRoot, 'extensions', 'wordpress', 'lib', 'wp-codebox-core-loader.js'), `module.exports = { async loadWpCodeboxCore() { return {}; } };\n`);
+  const installedLayoutResult = spawnSync(process.execPath, [path.join(installedRuntime, 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs')], {
+    encoding: 'utf8',
+    env: fixtureEnv(),
+  });
+  assert.equal(installedLayoutResult.status, 1);
+  assert.match(installedLayoutResult.stderr, /AgentTaskRequest JSON is required/);
+  assert.doesNotMatch(installedLayoutResult.stderr, /wp-codebox-core-loader|MODULE_NOT_FOUND/);
+} finally {
+  fs.rmSync(installedLayoutRoot, { recursive: true, force: true });
+}
+
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-agent-task-executor-'));
 try {
   const { fixture, capture } = writeFixtureTaskRunner(root);


### PR DESCRIPTION
## Summary
- resolve the WP Codebox core loader from both the monorepo layout and Homeboy's installed extension layout
- prevent installed shared runtime executors from failing before they can emit a JSON outcome
- add an installed-layout smoke fixture for the runtime executor bootstrap

## Testing
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the Lab-installed runtime helper resolution failure, drafted the fallback resolver and installed-layout smoke test, and ran targeted verification.