### PR TITLE
Thin Codebox artifact adapter boundary

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -29,9 +29,11 @@ const {
 const {
   artifactNameFromDeclaration,
   artifactPath,
-  artifactRoleFromCodeboxArtifact,
+  normalizeCodeboxArtifactDeclaration,
+  normalizeCodeboxArtifactOutcome: normalizeCodeboxArtifactOutcomeContract,
   normalizeTypedArtifactEntry: normalizeCodeboxTypedArtifactEntry,
   normalizeTypedArtifacts: normalizeCodeboxTypedArtifacts,
+  typedArtifactsFromCodeboxResult,
   typedArtifactFileRefs: codeboxTypedArtifactFileRefs,
 } = require('./codebox-artifact-contract');
 const {
@@ -50,7 +52,6 @@ const {
   WP_CODEBOX_TASK_REQUEST_SCHEMA,
   WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
   wpCodeboxProviderRuntimeInvocationContract,
-  wpCodeboxProviderRuntimeOperationConfig,
   wpCodeboxProviderRuntimeOperationEntry,
 } = require('./wp-codebox-adapter-contract');
 
@@ -263,14 +264,6 @@ function providerRuntimeOperationEntries(requested) {
 
 function providerRuntimeOperationEntry(operation, fallbackKey = '') {
   return wpCodeboxProviderRuntimeOperationEntry(operation, fallbackKey);
-}
-
-function providerRuntimeOperationConfig(key, operation) {
-  return wpCodeboxProviderRuntimeOperationConfig(key, operation);
-}
-
-function withoutUndefinedValues(value) {
-  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
 }
 
 function runtimeProviderDefaults() {
@@ -532,38 +525,9 @@ function wpCodeboxArtifactDeclarationFromHomeboy(declaration) {
 }
 
 function wpCodeboxArtifactDeclarationFromLegacy(defaultName, declaration) {
-  if (typeof declaration === 'string') {
-    return {
-      schema: 'wp-codebox/artifact-declaration/v1',
-      name: declaration,
-      required: true,
-    };
-  }
-  if (!declaration || typeof declaration !== 'object' || Array.isArray(declaration)) {
-    return null;
-  }
-  const name = declaration.name || declaration.id || declaration.output || declaration.artifact || defaultName;
-  if (!name || typeof name !== 'string') {
-    return null;
-  }
-  const artifactSchema = declaration.artifact_schema
-    || declaration.artifactSchema
-    || declaration.content_schema
-    || declaration.contentSchema
-    || (declaration.schema && ![
-      AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA,
-      'wp-codebox/artifact-declaration/v1',
-    ].includes(declaration.schema) ? declaration.schema : undefined);
-  return Object.fromEntries(Object.entries({
-    schema: 'wp-codebox/artifact-declaration/v1',
-    name,
-    type: declaration.type || declaration.kind || declaration.artifact_type || declaration.artifactType,
-    artifact_schema: artifactSchema,
-    path: declaration.path,
-    required: declaration.required === undefined ? true : declaration.required === true,
-    description: declaration.description,
-    metadata: declaration.metadata,
-  }).filter(([, value]) => value !== undefined));
+  return normalizeCodeboxArtifactDeclaration(defaultName, declaration, {
+    ignoredSchemas: [AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA],
+  });
 }
 
 class RuntimeOverlayConfigError extends Error {
@@ -2040,41 +2004,7 @@ function normalizeTypedArtifacts(value) {
 }
 
 function typedArtifactsFromResult(result) {
-  const workload = agentRuntimeWorkload(result) || {};
-  const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
-  const candidates = [
-    result.outputs?.typed_artifacts,
-    result.outputs?.typedArtifacts,
-    result.run?.agentResult?.typed_artifacts,
-    result.run?.agentResult?.typedArtifacts,
-    result.run?.agentResult?.outputs?.typed_artifacts,
-    result.run?.agentResult?.outputs?.typedArtifacts,
-    result.agentResult?.outputs?.typed_artifacts,
-    result.agentResult?.outputs?.typedArtifacts,
-    result.agent_result?.outputs?.typed_artifacts,
-    result.agent_result?.outputs?.typedArtifacts,
-    result.metadata?.agent_runtime?.result?.typed_artifacts,
-    result.metadata?.agent_runtime?.result?.typedArtifacts,
-    result.metadata?.agent_runtime?.result?.outputs?.typed_artifacts,
-    result.metadata?.agent_runtime?.result?.outputs?.typedArtifacts,
-    result.metadata?.agent_runtime?.result?.outputs?.outputs?.typed_artifacts,
-    result.metadata?.agent_runtime?.result?.outputs?.outputs?.typedArtifacts,
-    workload.typed_artifacts,
-    workload.typedArtifacts,
-    workload.outputs?.typed_artifacts,
-    workload.outputs?.typedArtifacts,
-    workload.outputs?.outputs?.typed_artifacts,
-    workload.outputs?.outputs?.typedArtifacts,
-    ...scenarios.map((scenario) => scenario?.typed_artifacts),
-    ...scenarios.map((scenario) => scenario?.typedArtifacts),
-    ...scenarios.map((scenario) => scenario?.outputs?.typed_artifacts),
-    ...scenarios.map((scenario) => scenario?.outputs?.typedArtifacts),
-    ...scenarios.map((scenario) => scenario?.metadata?.outputs?.typed_artifacts),
-    ...scenarios.map((scenario) => scenario?.metadata?.outputs?.typedArtifacts),
-    ...scenarios.map((scenario) => scenario?.metadata?.typed_artifacts),
-    ...scenarios.map((scenario) => scenario?.metadata?.typedArtifacts),
-  ];
-  return Object.assign({}, ...candidates.map(normalizeTypedArtifacts));
+  return typedArtifactsFromCodeboxResult(result, { sanitize: sanitizePublicMetadata });
 }
 
 function codeboxAgentResultFromResult(result) {
@@ -2270,27 +2200,10 @@ function artifactFromCodeboxArtifact(artifact, index) {
 }
 
 function normalizeCodeboxArtifactOutcome(artifact, rawArtifact = {}) {
-  if (!artifact) {
-    return artifact;
-  }
-  const nativeKind = rawArtifact.kind || rawArtifact.type || artifact.kind || '';
-  const role = artifactRoleFromCodeboxArtifact({ ...artifact, kind: nativeKind }, WP_CODEBOX_ROLE_ALIASES);
-  const metadata = artifact.metadata && typeof artifact.metadata === 'object' && !Array.isArray(artifact.metadata)
-    ? artifact.metadata
-    : {};
-  return {
-    ...artifact,
-    role,
-    metadata: sanitizePublicMetadata({
-      ...metadata,
-      wp_codebox: {
-        id: rawArtifact.id || artifact.id,
-        kind: nativeKind,
-        name: rawArtifact.name || artifact.name,
-        raw: rawArtifact,
-      },
-    }),
-  };
+  return normalizeCodeboxArtifactOutcomeContract(artifact, rawArtifact, {
+    roleAliases: WP_CODEBOX_ROLE_ALIASES,
+    sanitize: sanitizePublicMetadata,
+  });
 }
 
 function pathValue(source, dottedPath) {

--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const TYPED_ARTIFACT_SCHEMA = 'homeboy/agent-task-typed-artifact/v1';
+const WP_CODEBOX_ARTIFACT_DECLARATION_SCHEMA = 'wp-codebox/artifact-declaration/v1';
 
 const ARTIFACT_ROLE_FALLBACK_PATTERNS = [
   ['patch', /patch|diff/i],
@@ -55,6 +56,103 @@ function normalizeTypedArtifacts(value, options = {}) {
     .map((artifact) => [artifact.name, artifact]));
 }
 
+function typedArtifactsFromCodeboxResult(result, options = {}) {
+  const workload = options.workload || agentRuntimeWorkload(result) || {};
+  const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
+  const candidates = [
+    result?.outputs?.typed_artifacts,
+    result?.outputs?.typedArtifacts,
+    result?.run?.agentResult?.typed_artifacts,
+    result?.run?.agentResult?.typedArtifacts,
+    result?.run?.agentResult?.outputs?.typed_artifacts,
+    result?.run?.agentResult?.outputs?.typedArtifacts,
+    result?.agentResult?.outputs?.typed_artifacts,
+    result?.agentResult?.outputs?.typedArtifacts,
+    result?.agent_result?.outputs?.typed_artifacts,
+    result?.agent_result?.outputs?.typedArtifacts,
+    result?.metadata?.agent_runtime?.result?.typed_artifacts,
+    result?.metadata?.agent_runtime?.result?.typedArtifacts,
+    result?.metadata?.agent_runtime?.result?.outputs?.typed_artifacts,
+    result?.metadata?.agent_runtime?.result?.outputs?.typedArtifacts,
+    result?.metadata?.agent_runtime?.result?.outputs?.outputs?.typed_artifacts,
+    result?.metadata?.agent_runtime?.result?.outputs?.outputs?.typedArtifacts,
+    workload.typed_artifacts,
+    workload.typedArtifacts,
+    workload.outputs?.typed_artifacts,
+    workload.outputs?.typedArtifacts,
+    workload.outputs?.outputs?.typed_artifacts,
+    workload.outputs?.outputs?.typedArtifacts,
+    ...scenarios.map((scenario) => scenario?.typed_artifacts),
+    ...scenarios.map((scenario) => scenario?.typedArtifacts),
+    ...scenarios.map((scenario) => scenario?.outputs?.typed_artifacts),
+    ...scenarios.map((scenario) => scenario?.outputs?.typedArtifacts),
+    ...scenarios.map((scenario) => scenario?.metadata?.outputs?.typed_artifacts),
+    ...scenarios.map((scenario) => scenario?.metadata?.outputs?.typedArtifacts),
+    ...scenarios.map((scenario) => scenario?.metadata?.typed_artifacts),
+    ...scenarios.map((scenario) => scenario?.metadata?.typedArtifacts),
+  ];
+  return Object.assign({}, ...candidates.map((candidate) => normalizeTypedArtifacts(candidate, options)));
+}
+
+function normalizeCodeboxArtifactDeclaration(defaultName, declaration, options = {}) {
+  if (typeof declaration === 'string') {
+    return {
+      schema: WP_CODEBOX_ARTIFACT_DECLARATION_SCHEMA,
+      name: declaration,
+      required: true,
+    };
+  }
+  if (!plainObject(declaration)) {
+    return null;
+  }
+  const name = declaration.name || declaration.id || declaration.output || declaration.artifact || defaultName;
+  if (!name || typeof name !== 'string') {
+    return null;
+  }
+  const ignoredSchemas = new Set([
+    WP_CODEBOX_ARTIFACT_DECLARATION_SCHEMA,
+    ...normalizeArray(options.ignoredSchemas),
+  ]);
+  const artifactSchema = declaration.artifact_schema
+    || declaration.artifactSchema
+    || declaration.content_schema
+    || declaration.contentSchema
+    || (declaration.schema && !ignoredSchemas.has(declaration.schema) ? declaration.schema : undefined);
+  return cleanObject({
+    schema: WP_CODEBOX_ARTIFACT_DECLARATION_SCHEMA,
+    name,
+    type: declaration.type || declaration.kind || declaration.artifact_type || declaration.artifactType,
+    artifact_schema: artifactSchema,
+    path: declaration.path,
+    required: declaration.required === undefined ? true : declaration.required === true,
+    description: declaration.description,
+    metadata: declaration.metadata,
+  });
+}
+
+function normalizeCodeboxArtifactOutcome(artifact, rawArtifact = {}, options = {}) {
+  if (!artifact) {
+    return artifact;
+  }
+  const nativeKind = rawArtifact.kind || rawArtifact.type || artifact.kind || '';
+  const role = artifactRoleFromCodeboxArtifact({ ...artifact, kind: nativeKind }, options.roleAliases || {});
+  const metadata = plainObject(artifact.metadata) ? artifact.metadata : {};
+  const sanitize = typeof options.sanitize === 'function' ? options.sanitize : (value) => value;
+  return {
+    ...artifact,
+    role,
+    metadata: sanitize({
+      ...metadata,
+      wp_codebox: {
+        id: rawArtifact.id || artifact.id,
+        kind: nativeKind,
+        name: rawArtifact.name || artifact.name,
+        raw: rawArtifact,
+      },
+    }),
+  };
+}
+
 function typedArtifactFileRefs(artifact) {
   if (Array.isArray(artifact?.file_refs)) {
     return artifact.file_refs;
@@ -73,6 +171,10 @@ function artifactNameFromDeclaration(declaration) {
     return '';
   }
   return declaration.name || declaration.id || '';
+}
+
+function agentRuntimeWorkload(result = {}) {
+  return result.workload || result.metadata?.workload || result.metadata?.agent_runtime?.workload || result.run?.workload || {};
 }
 
 function artifactPath(root, relativePath) {
@@ -148,10 +250,14 @@ function cleanObject(value) {
 
 module.exports = {
   TYPED_ARTIFACT_SCHEMA,
+  WP_CODEBOX_ARTIFACT_DECLARATION_SCHEMA,
   artifactRoleFromCodeboxArtifact,
   artifactNameFromDeclaration,
   artifactPath,
+  normalizeCodeboxArtifactDeclaration,
+  normalizeCodeboxArtifactOutcome,
   normalizeTypedArtifactEntry,
   normalizeTypedArtifacts,
+  typedArtifactsFromCodeboxResult,
   typedArtifactFileRefs,
 };

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -131,8 +131,15 @@ const WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS = [
     id: 'artifact-result-envelope',
     schema: WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS.evidence_artifact_envelope,
     owner: 'wp-codebox',
-    adapter_behavior: 'normalize_declared_artifacts',
-    requirement: 'Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts.',
+    adapter_behavior: 'consume_when_available',
+    requirement: 'Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Until this is complete, compatibility is centralized in codebox-artifact-contract.js.',
+  },
+  {
+    id: 'artifact-apply-execution',
+    schema: 'wp-codebox/artifact-apply-result/v1',
+    owner: 'wp-codebox',
+    adapter_behavior: 'local_git_apply_until_primitive_exists',
+    requirement: 'Expose approved artifact patch application as a Codebox-owned primitive. Homeboy Extensions already delegates preflight and apply request creation when runtime-core exports are available; the remaining local code maps Homeboy worktree, commit, and publish policy around git apply.',
   },
 ];
 

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -386,8 +386,15 @@
           "id": "artifact-result-envelope",
           "schema": "wp-codebox/evidence-artifact-envelope/v1",
           "owner": "wp-codebox",
-          "adapter_behavior": "normalize_declared_artifacts",
-          "requirement": "Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts."
+          "adapter_behavior": "consume_when_available",
+          "requirement": "Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Until this is complete, compatibility is centralized in codebox-artifact-contract.js."
+        },
+        {
+          "id": "artifact-apply-execution",
+          "schema": "wp-codebox/artifact-apply-result/v1",
+          "owner": "wp-codebox",
+          "adapter_behavior": "local_git_apply_until_primitive_exists",
+          "requirement": "Expose approved artifact patch application as a Codebox-owned primitive. Homeboy Extensions already delegates preflight and apply request creation when runtime-core exports are available; the remaining local code maps Homeboy worktree, commit, and publish policy around git apply."
         }
       ],
       "status": "active",

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -7,8 +7,11 @@ const path = require('node:path');
 
 const {
   codeboxTaskRequestFromAgentTaskRequest,
+  normalizeCodeboxArtifactDeclaration,
+  normalizeCodeboxArtifactOutcome,
   providerContract,
   providerRuntimeInvocationContract,
+  typedArtifactsFromCodeboxResult,
 } = require('../../agent-runtimes/wp-codebox');
 
 const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wordpress-agent-boundary-'));
@@ -48,8 +51,40 @@ assert.equal(provider.integration_contract, 'homeboy-wordpress-agent-task/v1');
 assert.deepEqual(provider.provider_runtime_invocation, providerRuntimeInvocationContract());
 assert.equal(provider.provider_runtime_invocation.tasks.workspaceCommand, 'wp-codebox.runner-workspace.command');
 assert.equal(provider.provider_runtime_invocation.abilities.workspaceCommand, 'wp-codebox/runner-workspace-command');
+assert.equal(provider.upstream_primitive_requirements.some((requirement) => requirement.id === 'artifact-apply-execution'), true);
+assert.equal(
+  provider.upstream_primitive_requirements.find((requirement) => requirement.id === 'artifact-result-envelope').adapter_behavior,
+  'consume_when_available'
+);
 assert.doesNotMatch(JSON.stringify(provider.provider_runtime_invocation), /datamachine|data machine|wp-site-generator|wpsg|site generator/i);
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, codexSecretEnv);
+
+assert.deepEqual(normalizeCodeboxArtifactDeclaration('fallback', {
+  schema: 'homeboy/agent-task-artifact-declaration/v1',
+  id: 'review-report',
+  artifactSchema: 'example/report/v1',
+}), {
+  schema: 'wp-codebox/artifact-declaration/v1',
+  name: 'review-report',
+  artifact_schema: 'example/report/v1',
+  required: true,
+});
+assert.deepEqual(typedArtifactsFromCodeboxResult({
+  metadata: {
+    agent_runtime: {
+      result: {
+        outputs: {
+          typed_artifacts: {
+            review: { type: 'json', payload: { ok: true } },
+          },
+        },
+      },
+    },
+  },
+}).review.payload, { ok: true });
+assert.equal(normalizeCodeboxArtifactOutcome({ id: 'patch.diff', kind: 'codebox-patch' }, {}, {
+  roleAliases: provider.role_aliases,
+}).role, 'patch');
 
 const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'wordpress.json'), 'utf8'));
 assert.equal(manifest.agent_task_executors, undefined);


### PR DESCRIPTION
## Summary
- centralize Codebox artifact compatibility helpers in the WP Codebox adapter boundary
- thin executor-local artifact declaration/result normalization
- update provider metadata to distinguish existing primitives from remaining upstream blockers
- add boundary coverage for the centralized compatibility helpers

## Tests
- npm run test:codebox-agent-task-executor-boundary from wordpress/
- npm run test:wp-codebox-apply-adapter from wordpress/
- npm run test:wp-codebox-artifacts from wordpress/
- git diff --check

## Notes
- JS lint was not run because eslint is not installed/resolvable in this worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the adapter thinning changes, boundary tests, and verification notes for Chris to review.