### PR TITLE
Generate REST request cases from route schemas

### DIFF
--- a/wordpress/lib/rest-route-matrix.js
+++ b/wordpress/lib/rest-route-matrix.js
@@ -8,6 +8,8 @@ const { isPlainObject } = require('./shared');
 const DEFAULT_METHODS = Object.freeze(['GET']);
 const DEFAULT_ARG_LIMIT = 12;
 const DEFAULT_SCHEMA_PROPERTY_LIMIT = 12;
+const DEFAULT_REST_REQUEST_CASE_LIMIT = 24;
+const PAGINATION_ARG_NAMES = Object.freeze(['page', 'per_page', 'offset']);
 
 function normalizeRestRouteMethod(method) {
 	const normalized = String(method || 'GET').trim().toUpperCase();
@@ -72,6 +74,12 @@ function routeDisplayPath(routeKey) {
 		.replace(/\/+$/g, '') || '/';
 }
 
+function routePathParamNames(routeKey) {
+	return [...String(routeKey || '').matchAll(/\(\?P<([^>]+)>[^)]+\)/g)]
+		.map((match) => match[1])
+		.filter(Boolean);
+}
+
 function restRouteMatrixKey({ method, route }) {
 	const routePart = routeDisplayPath(route)
 		.replace(/^\/+/, '')
@@ -129,6 +137,98 @@ function summarizeArg(name, arg = {}) {
 	};
 }
 
+function argType(arg = {}) {
+	const type = arg.type || arg.schema?.type;
+	return Array.isArray(type) ? type[0] : type || 'unknown';
+}
+
+function argEnumValues(arg = {}) {
+	if (Array.isArray(arg.enum)) {
+		return arg.enum;
+	}
+	if (Array.isArray(arg.schema?.enum)) {
+		return arg.schema.enum;
+	}
+	return [];
+}
+
+function hasOwn(value, key) {
+	return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function seededScore(value, seed) {
+	const input = `${seed}:${value}`;
+	let hash = 2166136261;
+	for (let index = 0; index < input.length; index += 1) {
+		hash ^= input.charCodeAt(index);
+		hash = Math.imul(hash, 16777619);
+	}
+	return hash >>> 0;
+}
+
+function stableSeededSort(values, seed) {
+	return [...values].sort((a, b) => {
+		const scoreA = seededScore(JSON.stringify(a), seed);
+		const scoreB = seededScore(JSON.stringify(b), seed);
+		return scoreA === scoreB ? JSON.stringify(a).localeCompare(JSON.stringify(b)) : scoreA - scoreB;
+	});
+}
+
+function safeValueForArg(name, arg = {}, options = {}) {
+	const enums = argEnumValues(arg);
+	if (enums.length > 0) {
+		return stableSeededSort(enums, options.seed ?? 'rest-request-cases')[0];
+	}
+	if (hasOwn(arg, 'default')) {
+		return arg.default;
+	}
+	if (hasOwn(arg.schema || {}, 'default')) {
+		return arg.schema.default;
+	}
+
+	const type = argType(arg);
+	if (type === 'integer') {
+		return Number.isFinite(Number(arg.minimum)) ? Number(arg.minimum) : 1;
+	}
+	if (type === 'number') {
+		return Number.isFinite(Number(arg.minimum)) ? Number(arg.minimum) : 1;
+	}
+	if (type === 'boolean') {
+		return true;
+	}
+	if (type === 'array') {
+		return [];
+	}
+	if (type === 'object') {
+		return {};
+	}
+	if (type === 'string') {
+		return name === 'context' ? 'view' : 'test';
+	}
+	return undefined;
+}
+
+function endpointSupportsMethod(endpoint = {}, method) {
+	const methods = endpoint?.methods || [];
+	return methods.map(normalizeRestRouteMethod).includes(normalizeRestRouteMethod(method));
+}
+
+function routeArgsForMethod(route = {}, method) {
+	const argsByName = new Map();
+	for (const [name, arg] of Object.entries(route.args || {})) {
+		argsByName.set(name, arg);
+	}
+	for (const endpoint of route.endpoints || []) {
+		if (!endpointSupportsMethod(endpoint, method)) {
+			continue;
+		}
+		for (const [name, arg] of Object.entries(endpoint?.args || {})) {
+			argsByName.set(name, arg);
+		}
+	}
+	return [...argsByName.entries()].sort(([a], [b]) => a.localeCompare(b));
+}
+
 function summarizeRouteArgs(route = {}, options = {}) {
 	const limit = Math.max(0, Math.floor(Number(options.maxArgs ?? DEFAULT_ARG_LIMIT)));
 	const argsByName = new Map();
@@ -183,6 +283,176 @@ function routeSchema(route = {}) {
 	return undefined;
 }
 
+function caseKey(baseId, variant, parts = []) {
+	return [baseId, ...[variant, ...parts]
+		.map((part) => String(part).trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''))]
+		.filter(Boolean)
+		.join(':');
+}
+
+function applyPathParams(path, pathParams = {}) {
+	return String(path).replace(/\{([^}]+)\}/g, (match, name) => {
+		const value = pathParams[name];
+		return value === undefined ? match : encodeURIComponent(String(value));
+	});
+}
+
+function splitArgsByLocation(routeKey, args) {
+	const pathParamNames = new Set(routePathParamNames(routeKey));
+	const pathArgs = [];
+	const requestArgs = [];
+	for (const entry of args) {
+		(pathParamNames.has(entry[0]) ? pathArgs : requestArgs).push(entry);
+	}
+	return { pathArgs, requestArgs };
+}
+
+function buildRequestCase(matrixEntry, variant, values = {}, metadata = {}) {
+	const path = applyPathParams(matrixEntry.path, values.pathParams);
+	const method = normalizeRestRouteMethod(matrixEntry.method);
+	const query = method === 'GET' || method === 'DELETE' ? values.args || {} : {};
+	const body = method === 'GET' || method === 'DELETE' ? undefined : values.args || {};
+	const { parts, ...caseMetadata } = metadata;
+	return {
+		id: caseKey(matrixEntry.id, variant, parts || []),
+		key: caseKey(matrixEntry.id, variant, parts || []),
+		matrixId: matrixEntry.id,
+		variant,
+		label: `${matrixEntry.label} (${variant})`,
+		method,
+		path,
+		route: matrixEntry.route,
+		namespace: matrixEntry.namespace,
+		request: {
+			method,
+			path,
+			...(Object.keys(query).length > 0 ? { query } : {}),
+			...(body === undefined || Object.keys(body).length === 0 ? {} : { body }),
+		},
+		metadata: caseMetadata,
+	};
+}
+
+function plannedCase(kind, argName, reason, details = {}) {
+	return {
+		kind,
+		arg: argName,
+		reason,
+		...details,
+	};
+}
+
+function normalizeCaseLimit(value) {
+	const limit = Math.floor(Number(value ?? DEFAULT_REST_REQUEST_CASE_LIMIT));
+	return Number.isFinite(limit) && limit > 0 ? limit : DEFAULT_REST_REQUEST_CASE_LIMIT;
+}
+
+function generateWordPressRestRequestCasesForEntry(matrixEntry, route = {}, options = {}) {
+	if (!isPlainObject(matrixEntry)) {
+		throw new TypeError('REST request case entries must be normalized route matrix objects');
+	}
+	const seed = String(options.seed ?? 'rest-request-cases');
+	const maxCases = normalizeCaseLimit(options.maxCases);
+	const args = routeArgsForMethod(route, matrixEntry.method);
+	const { pathArgs, requestArgs } = splitArgsByLocation(matrixEntry.route, args);
+	const pathParams = {};
+	const cases = [];
+	const plannedCases = [];
+
+	for (const [name, arg] of pathArgs) {
+		const value = safeValueForArg(name, arg, { seed });
+		if (value === undefined) {
+			plannedCases.push(plannedCase('required-path-arg', name, 'No generic safe path value is available.', { type: argType(arg) }));
+		} else {
+			pathParams[name] = value;
+		}
+	}
+
+	cases.push(buildRequestCase(matrixEntry, 'baseline', { pathParams }, { seed, plannedCases: [] }));
+
+	const requiredValues = {};
+	for (const [name, arg] of requestArgs) {
+		if (arg.required !== true) {
+			continue;
+		}
+		const value = safeValueForArg(name, arg, { seed });
+		if (value === undefined) {
+			plannedCases.push(plannedCase('required-arg', name, 'Required arg is not executable without a generic safe value.', { type: argType(arg) }));
+		} else {
+			requiredValues[name] = value;
+		}
+	}
+	if (Object.keys(requiredValues).length > 0) {
+		cases.push(buildRequestCase(matrixEntry, 'required-args', { pathParams, args: requiredValues }, { seed, args: Object.keys(requiredValues) }));
+	}
+
+	for (const [name, arg] of requestArgs) {
+		if (PAGINATION_ARG_NAMES.includes(name)) {
+			const value = name === 'per_page' ? 1 : 2;
+			cases.push(buildRequestCase(matrixEntry, 'pagination', { pathParams, args: { ...requiredValues, [name]: value } }, { seed, arg: name, parts: [name] }));
+		}
+
+		if (hasOwn(arg, 'default') || hasOwn(arg.schema || {}, 'default')) {
+			cases.push(buildRequestCase(matrixEntry, 'default', {
+				pathParams,
+				args: { ...requiredValues, [name]: hasOwn(arg, 'default') ? arg.default : arg.schema.default },
+			}, { seed, arg: name, parts: [name] }));
+		}
+
+		for (const value of stableSeededSort(argEnumValues(arg), `${seed}:${name}`).slice(0, 2)) {
+			cases.push(buildRequestCase(matrixEntry, 'enum', { pathParams, args: { ...requiredValues, [name]: value } }, { seed, arg: name, value, parts: [name, value] }));
+		}
+
+		if (arg.required === true) {
+			plannedCases.push(plannedCase('missing-required-arg', name, 'Missing required arg is a negative case; execute only when the caller opts into unsafe requests.', { type: argType(arg) }));
+		}
+		if (argEnumValues(arg).length > 0) {
+			plannedCases.push(plannedCase('invalid-enum', name, 'Invalid enum value is tracked as planned metadata by default.', { allowed: argEnumValues(arg) }));
+		}
+		if (argType(arg) === 'integer' || argType(arg) === 'number') {
+			plannedCases.push(plannedCase('numeric-boundary', name, 'Numeric boundary case needs caller policy before execution.', {
+				minimum: arg.minimum,
+				maximum: arg.maximum,
+			}));
+		}
+	}
+
+	const uniqueCases = [];
+	const seenKeys = new Set();
+	for (const requestCase of cases) {
+		if (seenKeys.has(requestCase.key)) {
+			continue;
+		}
+		seenKeys.add(requestCase.key);
+		uniqueCases.push(requestCase);
+	}
+
+	return uniqueCases.slice(0, maxCases).map((requestCase) => ({
+		...requestCase,
+		metadata: {
+			...requestCase.metadata,
+			plannedCases,
+		},
+	}));
+}
+
+function generateWordPressRestRequestCases(input, options = {}) {
+	const routes = extractRestRoutes(input);
+	const matrix = normalizeWordPressRestRouteMatrix(input, options);
+	const maxCases = normalizeCaseLimit(options.maxCases);
+	const cases = [];
+
+	for (const entry of matrix) {
+		const route = routes[entry.route] || routes[normalizeRoutePath(entry.route)] || {};
+		cases.push(...generateWordPressRestRequestCasesForEntry(entry, route, { ...options, maxCases }));
+		if (cases.length >= maxCases) {
+			return cases.slice(0, maxCases);
+		}
+	}
+
+	return cases;
+}
+
 function extractRestRoutes(input) {
 	if (isPlainObject(input?.routes)) {
 		return input.routes;
@@ -231,6 +501,8 @@ module.exports = {
 	classifyRestRoute,
 	normalizeRestRouteMethod,
 	normalizeWordPressRestRouteMatrix,
+	generateWordPressRestRequestCases,
+	generateWordPressRestRequestCasesForEntry,
 	restRouteMatrixKey,
 	summarizeRouteArgs,
 	summarizeSchema,

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -45,6 +45,7 @@
     "test:admin-page-scenarios": "node tests/admin-page-scenarios-smoke.js",
     "test:page-profiler": "node tests/page-profiler-smoke.js",
     "test:rest-route-matrix": "node tests/rest-route-matrix-smoke.js",
+    "test:rest-request-case-generation": "node tests/rest-request-case-generation-smoke.js",
     "test:wordpress-route-latency": "node tests/wordpress-route-latency-smoke.js",
     "test:runtime-agent-wp-codebox-runner": "node tests/wp-codebox-task-runner-smoke.js",
     "test:project-wpgym-eval-row": "bash scripts/agent/project-wpgym-eval-row-smoke.sh",

--- a/wordpress/tests/rest-request-case-generation-smoke.js
+++ b/wordpress/tests/rest-request-case-generation-smoke.js
@@ -1,0 +1,110 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const assert = require('node:assert/strict');
+
+/**
+ * Internal dependencies
+ */
+const {
+	generateWordPressRestRequestCases,
+	generateWordPressRestRequestCasesForEntry,
+	normalizeWordPressRestRouteMatrix,
+} = require('../lib/rest-route-matrix');
+
+const restIndex = {
+	routes: {
+		'/example/v1/items': {
+			namespace: 'example/v1',
+			methods: ['GET', 'POST'],
+			endpoints: [
+				{
+					methods: ['GET'],
+					args: {
+						context: { type: 'string', enum: ['view', 'embed'], default: 'view' },
+						page: { type: 'integer', default: 1, minimum: 1 },
+						per_page: { type: 'integer', default: 10, minimum: 1, maximum: 100 },
+						search: { type: 'string' },
+					},
+				},
+				{
+					methods: ['POST'],
+					args: {
+						name: { type: 'string', required: true },
+						status: { type: 'string', enum: ['draft', 'publish'], default: 'draft' },
+					},
+				},
+			],
+		},
+		'/example/v1/items/(?P<id>[\\d]+)': {
+			namespace: 'example/v1',
+			methods: ['GET'],
+			endpoints: [
+				{
+					methods: ['GET'],
+					args: {
+						id: { type: 'integer', required: true },
+						context: { type: 'string', enum: ['view', 'edit'], default: 'view' },
+					},
+				},
+			],
+		},
+	},
+};
+
+const getCases = generateWordPressRestRequestCases(restIndex, {
+	methods: ['GET'],
+	seed: 'alpha',
+	maxCases: 20,
+});
+
+assert.deepEqual(getCases.map((requestCase) => requestCase.key), [
+	'rest:get:example-v1-items:baseline',
+	'rest:get:example-v1-items:default:context',
+	'rest:get:example-v1-items:enum:context:view',
+	'rest:get:example-v1-items:enum:context:embed',
+	'rest:get:example-v1-items:pagination:page',
+	'rest:get:example-v1-items:default:page',
+	'rest:get:example-v1-items:pagination:per-page',
+	'rest:get:example-v1-items:default:per-page',
+	'rest:get:example-v1-items-id:baseline',
+	'rest:get:example-v1-items-id:default:context',
+	'rest:get:example-v1-items-id:enum:context:view',
+	'rest:get:example-v1-items-id:enum:context:edit',
+]);
+
+const pageCase = getCases.find((requestCase) => requestCase.key === 'rest:get:example-v1-items:pagination:page');
+assert.deepEqual(pageCase.request, {
+	method: 'GET',
+	path: '/example/v1/items',
+	query: { page: 2 },
+});
+
+const itemBaseline = getCases.find((requestCase) => requestCase.matrixId === 'rest:get:example-v1-items-id');
+assert.equal(itemBaseline.request.path, '/example/v1/items/1');
+
+const plannedKinds = new Set(getCases[0].metadata.plannedCases.map((requestCase) => requestCase.kind));
+assert.equal(plannedKinds.has('invalid-enum'), true);
+assert.equal(plannedKinds.has('numeric-boundary'), true);
+
+const postMatrixEntry = normalizeWordPressRestRouteMatrix(restIndex, { methods: ['POST'] })[0];
+const postCases = generateWordPressRestRequestCasesForEntry(
+	postMatrixEntry,
+	restIndex.routes['/example/v1/items'],
+	{ seed: 'alpha', maxCases: 10 }
+);
+
+const requiredCase = postCases.find((requestCase) => requestCase.variant === 'required-args');
+assert.deepEqual(requiredCase.request, {
+	method: 'POST',
+	path: '/example/v1/items',
+	body: { name: 'test' },
+});
+assert.equal(postCases.some((requestCase) => requestCase.metadata.plannedCases.some((planned) => planned.kind === 'missing-required-arg')), true);
+
+const limitedCases = generateWordPressRestRequestCases(restIndex, { methods: ['GET'], seed: 'alpha', maxCases: 3 });
+assert.deepEqual(limitedCases.map((requestCase) => requestCase.key), getCases.slice(0, 3).map((requestCase) => requestCase.key));
+
+console.log('REST request case generation smoke passed.');

--- a/wordpress/tests/wordpress-public-export-boundary.test.js
+++ b/wordpress/tests/wordpress-public-export-boundary.test.js
@@ -12,6 +12,7 @@ const wordpress = require('../index');
 
 assert.equal(typeof wordpress.profileWordPressAdminPageScenario, 'function');
 assert.equal(typeof wordpress.normalizeWordPressRestRouteMatrix, 'function');
+assert.equal(typeof wordpress.generateWordPressRestRequestCases, 'function');
 assert.equal(typeof wordpress.wpCodebox, 'object');
 assert.equal(typeof wordpress.wpCodebox.resolveWpCodeboxArtifactPath, 'function');
 assert.equal(typeof wordpress.wpCodebox.runWpCodeboxRecipe, 'function');


### PR DESCRIPTION
## Summary
- Add deterministic REST request case generation from normalized route matrix entries.
- Support bounded max-case generation, seed ordering, pagination/default/enum cases, and required-argument safe values.
- Keep invalid and boundary cases as planned metadata unless safe values are available.

## Testing
- `node --check wordpress/lib/rest-route-matrix.js`
- `node --check wordpress/tests/rest-request-case-generation-smoke.js`
- `node wordpress/tests/rest-route-matrix-smoke.js`
- `node wordpress/tests/rest-request-case-generation-smoke.js`
- `node wordpress/tests/wordpress-public-export-boundary.test.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing generic REST case generation, smoke coverage, and PR preparation under Chris review.
