### PR TITLE
Report REST route matrix artifacts

### DIFF
--- a/wordpress/lib/rest-route-matrix.js
+++ b/wordpress/lib/rest-route-matrix.js
@@ -10,6 +10,7 @@ const DEFAULT_ARG_LIMIT = 12;
 const DEFAULT_SCHEMA_PROPERTY_LIMIT = 12;
 const DEFAULT_REST_REQUEST_CASE_LIMIT = 24;
 const PAGINATION_ARG_NAMES = Object.freeze(['page', 'per_page', 'offset']);
+const DEFAULT_REPORT_LIMIT = 10;
 
 function normalizeRestRouteMethod(method) {
 	const normalized = String(method || 'GET').trim().toUpperCase();
@@ -66,6 +67,14 @@ function normalizeRoutePath(routeKey) {
 	return raw.startsWith('/') ? raw : `/${raw}`;
 }
 
+function normalizeOptionalRoutePath(routeKey) {
+	const raw = String(routeKey || '').trim();
+	if (!raw) {
+		return '';
+	}
+	return normalizeRoutePath(raw);
+}
+
 function routeDisplayPath(routeKey) {
 	return normalizeRoutePath(routeKey)
 		.replace(/\(\?P<([^>]+)>[^)]+\)/g, '{$1}')
@@ -88,6 +97,350 @@ function restRouteMatrixKey({ method, route }) {
 		.replace(/^-+|-+$/g, '')
 		.toLowerCase() || 'index';
 	return `rest:${normalizeRestRouteMethod(method).toLowerCase()}:${routePart}`;
+}
+
+function numericValue(value, fallback = 0) {
+	const number = Number(value);
+	return Number.isFinite(number) ? number : fallback;
+}
+
+function maybeNumericValue(value) {
+	const number = Number(value);
+	return Number.isFinite(number) ? number : undefined;
+}
+
+function sortText(a, b) {
+	return String(a || '').localeCompare(String(b || ''));
+}
+
+function statusKey(status) {
+	return status === undefined || status === null || status === '' ? 'unknown' : String(status);
+}
+
+function stripRestBase(value) {
+	let raw = String(value || '').trim();
+	if (!raw) {
+		return '';
+	}
+
+	try {
+		const parsed = new URL(raw, 'https://example.test');
+		const restRoute = parsed.searchParams.get('rest_route');
+		if (restRoute) {
+			return normalizeOptionalRoutePath(restRoute);
+		}
+		raw = parsed.pathname;
+	} catch {
+		raw = raw.replace(/^https?:\/\/[^/]+/i, '').split('?', 1)[0];
+	}
+
+	return normalizeOptionalRoutePath(raw.replace(/^\/wp-json(?=\/|$)/, '') || raw);
+}
+
+function resultRoutePath(result = {}) {
+	return stripRestBase(result.route || result.path || result.normalizedUrl || result.url || result.uri || '');
+}
+
+function resultCaseKey(result = {}) {
+	if (result.id || result.key || result.caseId || result.case_id) {
+		return String(result.id || result.key || result.caseId || result.case_id);
+	}
+	const route = resultRoutePath(result);
+	return route ? restRouteMatrixKey({ method: result.method, route }) : '';
+}
+
+function normalizeRestMatrixInventoryCase(entry = {}) {
+	if (!isPlainObject(entry)) {
+		throw new TypeError('REST matrix inventory cases must be objects');
+	}
+	const route = normalizeOptionalRoutePath(entry.route || entry.path || entry.normalizedUrl || entry.url || entry.uri || '');
+	if (!route) {
+		throw new TypeError('REST matrix inventory cases require route or path');
+	}
+	const method = normalizeRestRouteMethod(entry.method);
+	const namespace = entry.namespace || entry.classification?.namespace || routeNamespace(route, entry);
+	const id = entry.id || entry.key || restRouteMatrixKey({ method, route });
+	return {
+		id,
+		key: id,
+		label: entry.label || `${method} ${routeDisplayPath(route)}`,
+		method,
+		path: routeDisplayPath(route),
+		route,
+		namespace,
+		classification: entry.classification || classifyRestRoute(route, { namespace }),
+	};
+}
+
+function normalizeRestMatrixResult(entry = {}) {
+	if (!isPlainObject(entry)) {
+		throw new TypeError('REST matrix results must be objects');
+	}
+	const route = resultRoutePath(entry);
+	const method = normalizeRestRouteMethod(entry.method);
+	const id = resultCaseKey({ ...entry, method, route });
+	const namespace = entry.namespace || entry.classification?.namespace || (route ? routeNamespace(route, entry) : '');
+	const status = entry.status ?? entry.statusCode ?? entry.responseStatus;
+	const durationMs = maybeNumericValue(entry.durationMs ?? entry.duration_ms ?? entry.totalMs ?? entry.total_ms);
+	const queryCount = maybeNumericValue(entry.queryCount ?? entry.query_count ?? entry.dbQueryCount ?? entry.db_query_count);
+	const responseBytes = maybeNumericValue(entry.responseBytes ?? entry.response_bytes ?? entry.bytes ?? entry.bodyBytes ?? entry.body_bytes);
+	const covered = entry.covered === false ? false : Boolean(entry.covered === true || status !== undefined || entry.ok !== undefined || durationMs !== undefined || queryCount !== undefined);
+
+	return {
+		id,
+		key: id,
+		method,
+		path: route ? routeDisplayPath(route) : '',
+		route,
+		namespace,
+		status,
+		durationMs,
+		queryCount,
+		responseBytes,
+		covered,
+		findings: Array.isArray(entry.findings) ? entry.findings : [],
+	};
+}
+
+function incrementCoverage(group, name, covered) {
+	const key = name || 'unknown';
+	if (!group[key]) {
+		group[key] = { total: 0, covered: 0, uncovered: 0 };
+	}
+	group[key].total += 1;
+	if (covered) {
+		group[key].covered += 1;
+	} else {
+		group[key].uncovered += 1;
+	}
+}
+
+function sortedCoverageObject(group) {
+	return Object.fromEntries(Object.entries(group).sort(([a], [b]) => sortText(a, b)));
+}
+
+function normalizeAllowedStatuses(value) {
+	if (value === undefined || value === null) {
+		return null;
+	}
+	return new Set(normalizeStringList(value).map(String));
+}
+
+function budgetFinding(row, type, metric, actual, budget) {
+	return {
+		type,
+		severity: 'warning',
+		id: row.id,
+		method: row.method,
+		path: row.path,
+		namespace: row.namespace,
+		metric,
+		actual,
+		budget,
+		message: `${row.method} ${row.path} ${metric} ${actual} exceeds budget ${budget}`,
+	};
+}
+
+function restMatrixBudgetFindings(row, budgets = {}) {
+	const findings = [];
+	if (row.durationMs !== undefined && budgets.maxDurationMs !== undefined && row.durationMs > numericValue(budgets.maxDurationMs, Infinity)) {
+		findings.push(budgetFinding(row, 'duration_budget_exceeded', 'durationMs', row.durationMs, numericValue(budgets.maxDurationMs)));
+	}
+	if (row.queryCount !== undefined && budgets.maxQueryCount !== undefined && row.queryCount > numericValue(budgets.maxQueryCount, Infinity)) {
+		findings.push(budgetFinding(row, 'query_count_budget_exceeded', 'queryCount', row.queryCount, numericValue(budgets.maxQueryCount)));
+	}
+	const allowedStatuses = normalizeAllowedStatuses(budgets.allowedStatuses ?? budgets.allowedStatusCodes);
+	if (allowedStatuses && row.status !== undefined && !allowedStatuses.has(String(row.status))) {
+		findings.push({
+			type: 'status_not_allowed',
+			severity: 'warning',
+			id: row.id,
+			method: row.method,
+			path: row.path,
+			namespace: row.namespace,
+			metric: 'status',
+			actual: row.status,
+			budget: [...allowedStatuses].sort(sortText),
+			message: `${row.method} ${row.path} returned status ${row.status}`,
+		});
+	}
+	return findings;
+}
+
+function normalizeInputCases(input = {}, options = {}) {
+	const inventory = input.inventory || input.cases || input.routes || input.restIndex || input.routeInventory;
+	if (Array.isArray(inventory)) {
+		return inventory.map(normalizeRestMatrixInventoryCase).sort((a, b) => sortText(a.id, b.id));
+	}
+	if (isPlainObject(inventory)) {
+		return normalizeWordPressRestRouteMatrix(inventory, options).map(normalizeRestMatrixInventoryCase).sort((a, b) => sortText(a.id, b.id));
+	}
+	return [];
+}
+
+function normalizeInputResults(input = {}) {
+	const results = input.results || input.caseResults || input.case_results || [];
+	if (!Array.isArray(results)) {
+		throw new TypeError('REST matrix case results must be an array');
+	}
+	return results.map(normalizeRestMatrixResult).sort((a, b) => sortText(a.id, b.id));
+}
+
+function buildRestRouteMatrixArtifact(input = {}, options = {}) {
+	const cases = normalizeInputCases(input, options);
+	const results = normalizeInputResults(input);
+	const resultById = new Map(results.filter((result) => result.id).map((result) => [result.id, result]));
+	const rowsById = new Map();
+
+	for (const inventoryCase of cases) {
+		const result = resultById.get(inventoryCase.id);
+		rowsById.set(inventoryCase.id, {
+			...inventoryCase,
+			...(result || {}),
+			id: inventoryCase.id,
+			key: inventoryCase.id,
+			method: result?.method || inventoryCase.method,
+			path: result?.path || inventoryCase.path,
+			route: result?.route || inventoryCase.route,
+			namespace: result?.namespace || inventoryCase.namespace,
+			classification: result?.classification || inventoryCase.classification,
+			covered: result ? result.covered : false,
+		});
+	}
+
+	for (const result of results) {
+		if (result.id && !rowsById.has(result.id)) {
+			rowsById.set(result.id, {
+				...result,
+				label: result.route ? `${result.method} ${result.path}` : result.id,
+			});
+		}
+	}
+
+	const rows = [...rowsById.values()].sort((a, b) => sortText(a.id, b.id));
+	const byNamespace = {};
+	const byMethod = {};
+	const byStatus = {};
+	const budgetFindings = [];
+	const missingRoutes = [];
+	const uncoveredRoutes = [];
+
+	for (const row of rows) {
+		incrementCoverage(byNamespace, row.namespace, row.covered);
+		incrementCoverage(byMethod, row.method, row.covered);
+		if (row.covered) {
+			incrementCoverage(byStatus, statusKey(row.status), true);
+		} else {
+			missingRoutes.push(row);
+			uncoveredRoutes.push(row);
+		}
+		for (const finding of row.findings || []) {
+			budgetFindings.push({ id: row.id, method: row.method, path: row.path, namespace: row.namespace, ...finding });
+		}
+		budgetFindings.push(...restMatrixBudgetFindings(row, options.budgets || input.budgets || {}));
+	}
+
+	const slowestByDuration = rows
+		.filter((row) => row.durationMs !== undefined)
+		.sort((a, b) => b.durationMs - a.durationMs || sortText(a.id, b.id))
+		.slice(0, Math.max(0, Math.floor(numericValue(options.slowestLimit ?? DEFAULT_REPORT_LIMIT))));
+	const slowestByQueryCount = rows
+		.filter((row) => row.queryCount !== undefined)
+		.sort((a, b) => b.queryCount - a.queryCount || sortText(a.id, b.id))
+		.slice(0, Math.max(0, Math.floor(numericValue(options.slowestLimit ?? DEFAULT_REPORT_LIMIT))));
+
+	return {
+		schema: 'homeboy/wordpress-rest-route-matrix-artifact/v1',
+		type: 'wordpress-rest-route-matrix-artifact',
+		totals: {
+			routeCount: cases.length,
+			resultCount: results.length,
+			caseCount: rows.length,
+			coveredCount: rows.filter((row) => row.covered).length,
+			uncoveredCount: rows.filter((row) => !row.covered).length,
+			budgetFindingCount: budgetFindings.length,
+		},
+		coverage: {
+			byNamespace: sortedCoverageObject(byNamespace),
+			byMethod: sortedCoverageObject(byMethod),
+			byStatus: sortedCoverageObject(byStatus),
+		},
+		slowestByDuration,
+		slowestByQueryCount,
+		missingRoutes: missingRoutes.sort((a, b) => sortText(a.id, b.id)),
+		uncoveredRoutes: uncoveredRoutes.sort((a, b) => sortText(a.id, b.id)),
+		budgetFindings: budgetFindings.sort((a, b) => sortText(a.id, b.id) || sortText(a.type, b.type)),
+		routes: rows,
+	};
+}
+
+function escapeMarkdownCell(value) {
+	return String(value ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function formatNumber(value) {
+	const number = maybeNumericValue(value);
+	return number === undefined ? '-' : String(Math.round(number * 10) / 10);
+}
+
+function formatCoverageTable(group, label) {
+	const lines = [`| ${label} | Total | Covered | Uncovered |`, '| --- | ---: | ---: | ---: |'];
+	for (const [key, row] of Object.entries(group)) {
+		lines.push(`| ${escapeMarkdownCell(key)} | ${row.total} | ${row.covered} | ${row.uncovered} |`);
+	}
+	return lines;
+}
+
+function formatRouteRows(rows, options = {}) {
+	const limit = Math.max(0, Math.floor(numericValue(options.limit ?? DEFAULT_REPORT_LIMIT)));
+	const visibleRows = limit > 0 ? rows.slice(0, limit) : rows;
+	const lines = ['| Route | Status | Duration ms | Query count | Findings |', '| --- | ---: | ---: | ---: | ---: |'];
+	for (const row of visibleRows) {
+		lines.push(`| \`${escapeMarkdownCell(`${row.method} ${row.path || row.route || row.id}`)}\` | ${escapeMarkdownCell(statusKey(row.status))} | ${formatNumber(row.durationMs)} | ${formatNumber(row.queryCount)} | ${(row.findings || []).length} |`);
+	}
+	return lines;
+}
+
+function formatRestRouteMatrixMarkdownReport(input = {}, options = {}) {
+	const artifact = input?.schema === 'homeboy/wordpress-rest-route-matrix-artifact/v1'
+		? input
+		: buildRestRouteMatrixArtifact(input, options);
+	const limit = Math.max(0, Math.floor(numericValue(options.limit ?? DEFAULT_REPORT_LIMIT)));
+	const lines = [
+		`## ${options.title || 'WordPress REST route matrix'}`,
+		'',
+		`Routes: ${artifact.totals.routeCount}; results: ${artifact.totals.resultCount}; covered: ${artifact.totals.coveredCount}; uncovered: ${artifact.totals.uncoveredCount}; budget findings: ${artifact.totals.budgetFindingCount}`,
+		'',
+		'## Coverage by namespace',
+		'',
+		...formatCoverageTable(artifact.coverage.byNamespace, 'Namespace'),
+		'',
+		'## Coverage by method',
+		'',
+		...formatCoverageTable(artifact.coverage.byMethod, 'Method'),
+		'',
+		'## Coverage by status',
+		'',
+		...formatCoverageTable(artifact.coverage.byStatus, 'Status'),
+	];
+
+	if (artifact.slowestByDuration.length > 0) {
+		lines.push('', '## Slowest routes by duration', '', ...formatRouteRows(artifact.slowestByDuration, { limit }));
+	}
+	if (artifact.slowestByQueryCount.length > 0) {
+		lines.push('', '## Slowest routes by query count', '', ...formatRouteRows(artifact.slowestByQueryCount, { limit }));
+	}
+	if (artifact.uncoveredRoutes.length > 0) {
+		lines.push('', '## Missing or uncovered routes', '', ...formatRouteRows(artifact.uncoveredRoutes, { limit }));
+	}
+	if (artifact.budgetFindings.length > 0) {
+		lines.push('', '## Budget findings', '', '| Route | Type | Metric | Actual | Budget |', '| --- | --- | --- | ---: | --- |');
+		for (const finding of artifact.budgetFindings.slice(0, limit > 0 ? limit : undefined)) {
+			lines.push(`| \`${escapeMarkdownCell(`${finding.method} ${finding.path}`)}\` | ${escapeMarkdownCell(finding.type)} | ${escapeMarkdownCell(finding.metric || '')} | ${escapeMarkdownCell(finding.actual)} | ${escapeMarkdownCell(Array.isArray(finding.budget) ? finding.budget.join(', ') : finding.budget)} |`);
+		}
+	}
+
+	return lines.join('\n');
 }
 
 function routeHasPathParams(routeKey) {
@@ -498,7 +851,9 @@ function normalizeWordPressRestRouteMatrix(input, options = {}) {
 }
 
 module.exports = {
+	buildRestRouteMatrixArtifact,
 	classifyRestRoute,
+	formatRestRouteMatrixMarkdownReport,
 	normalizeRestRouteMethod,
 	normalizeWordPressRestRouteMatrix,
 	generateWordPressRestRequestCases,

--- a/wordpress/tests/rest-route-matrix-smoke.js
+++ b/wordpress/tests/rest-route-matrix-smoke.js
@@ -9,7 +9,9 @@ const assert = require('node:assert/strict');
  * Internal dependencies
  */
 const {
+	buildRestRouteMatrixArtifact,
 	classifyRestRoute,
+	formatRestRouteMatrixMarkdownReport,
 	normalizeWordPressRestRouteMatrix,
 	restRouteMatrixKey,
 	summarizeRouteArgs,
@@ -120,5 +122,65 @@ assert.deepEqual(argSummary.args.map((arg) => arg.name), ['context', 'items']);
 const schemaSummary = summarizeSchema(restIndex.routes['/wc/store/v1/cart'].schema, { maxSchemaProperties: 1 });
 assert.equal(schemaSummary.propertyCount, 2);
 assert.deepEqual(schemaSummary.properties, [{ name: 'items', type: 'array' }]);
+
+const artifact = buildRestRouteMatrixArtifact({
+	routes: restIndex,
+	caseResults: [
+		{ method: 'GET', route: '/wp/v2/posts', status: 200, durationMs: 40, queryCount: 3 },
+		{ method: 'GET', route: '/wc/store/v1/cart', status: 200, durationMs: 95, queryCount: 14 },
+		{ method: 'POST', route: '/wc/store/v1/cart', status: 500, durationMs: 80, queryCount: 2 },
+	],
+	budgets: {
+		maxDurationMs: 90,
+		maxQueryCount: 10,
+		allowedStatuses: [200, 201],
+	},
+}, {
+	methods: ['GET', 'POST'],
+	slowestLimit: 5,
+});
+
+assert.equal(artifact.schema, 'homeboy/wordpress-rest-route-matrix-artifact/v1');
+assert.equal(artifact.totals.routeCount, 6);
+assert.equal(artifact.totals.resultCount, 3);
+assert.equal(artifact.totals.coveredCount, 3);
+assert.equal(artifact.totals.uncoveredCount, 3);
+assert.equal(artifact.coverage.byNamespace['wc/store/v1'].total, 2);
+assert.equal(artifact.coverage.byNamespace['wc/store/v1'].covered, 2);
+assert.equal(artifact.coverage.byMethod.GET.total, 4);
+assert.equal(artifact.coverage.byMethod.GET.uncovered, 2);
+assert.equal(artifact.coverage.byStatus['200'].covered, 2);
+assert.equal(artifact.coverage.byStatus['500'].covered, 1);
+assert.deepEqual(artifact.slowestByDuration.map((row) => row.id), [
+	'rest:get:wc-store-v1-cart',
+	'rest:post:wc-store-v1-cart',
+	'rest:get:wp-v2-posts',
+]);
+assert.deepEqual(artifact.slowestByQueryCount.map((row) => row.id), [
+	'rest:get:wc-store-v1-cart',
+	'rest:get:wp-v2-posts',
+	'rest:post:wc-store-v1-cart',
+]);
+assert.deepEqual(artifact.missingRoutes.map((row) => row.id), [
+	'rest:get:demo-v1-private',
+	'rest:get:wp-v2-posts-id',
+	'rest:post:wp-v2-posts',
+]);
+assert.deepEqual(artifact.budgetFindings.map((finding) => finding.type), [
+	'duration_budget_exceeded',
+	'query_count_budget_exceeded',
+	'status_not_allowed',
+]);
+
+const markdown = formatRestRouteMatrixMarkdownReport(artifact, { limit: 5 });
+assert.match(markdown, /## WordPress REST route matrix/);
+assert.match(markdown, /Routes: 6; results: 3; covered: 3; uncovered: 3; budget findings: 3/);
+assert.match(markdown, /## Coverage by namespace/);
+assert.match(markdown, /\| wc\/store\/v1 \| 2 \| 2 \| 0 \|/);
+assert.match(markdown, /## Slowest routes by duration/);
+assert.match(markdown, /`GET \/wc\/store\/v1\/cart` \| 200 \| 95 \| 14/);
+assert.match(markdown, /## Missing or uncovered routes/);
+assert.match(markdown, /`GET \/demo\/v1\/private`/);
+assert.match(markdown, /## Budget findings/);
 
 console.log('REST route matrix smoke passed.');


### PR DESCRIPTION
## Summary
- Add a generic REST route matrix artifact builder for normalized inventory and execution results.
- Report coverage by namespace, method, and status, plus uncovered routes, slow routes, query-count hotspots, and budget findings.
- Add Markdown report formatting so route matrix runs can produce reviewer-readable summaries.

## Testing
- `node --check wordpress/lib/rest-route-matrix.js`
- `node wordpress/tests/rest-route-matrix-smoke.js`
- `node wordpress/tests/rest-request-case-generation-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing REST route matrix artifact/report helpers, resolving branch overlap with case generation, and PR preparation under Chris review.
