### PR TITLE
Consume WP Codebox artifact result envelopes

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -27,6 +27,7 @@ const {
   providerFailureClassification,
 } = require('./provider-outcome-normalizer');
 const {
+  artifactResultEnvelopeFromCodeboxResult,
   artifactNameFromDeclaration,
   artifactPath,
   normalizeCodeboxArtifactDeclaration,
@@ -2379,6 +2380,10 @@ function normalizeArtifacts(result, runSummary = null, recipeSummary = null) {
   const normalizedArtifacts = Array.isArray(runSummary?.artifacts)
     ? runSummary.artifacts.map(artifactFromCodeboxArtifact)
     : [];
+  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result);
+  for (const artifact of artifactResult?.artifactRefs || []) {
+    appendUniqueArtifact(normalizedArtifacts, artifactFromCodeboxArtifact(artifact));
+  }
   if (Array.isArray(recipeSummary?.artifacts)) {
     recipeSummary.artifacts.map(artifactFromCodeboxArtifact).forEach((artifact) => appendUniqueArtifact(normalizedArtifacts, artifact));
   }
@@ -2432,6 +2437,7 @@ function normalizeArtifacts(result, runSummary = null, recipeSummary = null) {
 }
 
 function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) {
+  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result);
   if (result?.schema === 'wp-codebox/agent-task-run/v1') {
     const refs = [
       result.session?.artifacts?.preview_url ? {
@@ -2445,6 +2451,13 @@ function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) 
         label: 'WP Codebox artifacts',
       } : null,
     ].filter(Boolean);
+    for (const artifact of artifactResult?.artifactRefs || []) {
+      appendUniqueEvidenceRef(refs, {
+        kind: artifact.kind,
+        uri: artifact.path || artifact.url,
+        label: artifact.name || artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
+      });
+    }
     for (const artifact of codeboxBundleArtifacts(result)) {
       appendUniqueEvidenceRef(refs, {
         kind: artifact.kind,
@@ -2497,7 +2510,14 @@ function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) 
     }
     return refs;
   }
-  const evidenceRefs = result?.evidence_refs || result?.evidence || [];
+  const evidenceRefs = [
+    ...(artifactResult?.artifactRefs || []).map((artifact) => ({
+      kind: artifact.kind,
+      uri: artifact.path || artifact.url,
+      label: artifact.name || artifact.kind,
+    })),
+    ...(result?.evidence_refs || result?.evidence || []),
+  ];
   return evidenceRefs.map((ref) => agentTaskEvidenceRefFromRef(ref, 'codebox_evidence')).filter((ref) => ref.uri);
 }
 
@@ -2552,6 +2572,7 @@ function agentRuntimeBundleArtifacts(result) {
 }
 
 function codeboxDecisionEvidence(result, runSummary = null, recipeSummary = null) {
+  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result);
   const agentResult = result.run?.agentResult || result.agentResult || result.agent_result || result.metadata?.recipe_run?.agentResult || result.metadata?.recipe_run?.run?.agentResult || {};
   const completionOutcome = result.completionOutcome || result.completion_outcome || result.metadata?.recipe_run?.completionOutcome || {};
   const runtime = result.run?.runtime || result.metadata?.recipe_run?.run?.runtime || {};
@@ -2582,6 +2603,8 @@ function codeboxDecisionEvidence(result, runSummary = null, recipeSummary = null
     recipe_target_ref: recipeRun.target_ref || recipeRun.targetRef,
     recipe_failed_phase: recipeFailedPhase,
     agent_runtime_failure_reason: agentRuntimeFailureReason(agentRuntimeFailure(result)),
+    artifact_result_operation: artifactResult?.operation,
+    artifact_result_status: artifactResult?.status,
   }).filter(([, value]) => value !== undefined && value !== ''));
 }
 

--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -2,6 +2,7 @@
 
 const TYPED_ARTIFACT_SCHEMA = 'homeboy/agent-task-typed-artifact/v1';
 const WP_CODEBOX_ARTIFACT_DECLARATION_SCHEMA = 'wp-codebox/artifact-declaration/v1';
+const WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA = 'wp-codebox/artifact-result-envelope/v1';
 
 const ARTIFACT_ROLE_FALLBACK_PATTERNS = [
   ['patch', /patch|diff/i],
@@ -59,6 +60,7 @@ function normalizeTypedArtifacts(value, options = {}) {
 function typedArtifactsFromCodeboxResult(result, options = {}) {
   const workload = options.workload || agentRuntimeWorkload(result) || {};
   const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
+  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result);
   const candidates = [
     result?.outputs?.typed_artifacts,
     result?.outputs?.typedArtifacts,
@@ -76,6 +78,10 @@ function typedArtifactsFromCodeboxResult(result, options = {}) {
     result?.metadata?.agent_runtime?.result?.outputs?.typedArtifacts,
     result?.metadata?.agent_runtime?.result?.outputs?.outputs?.typed_artifacts,
     result?.metadata?.agent_runtime?.result?.outputs?.outputs?.typedArtifacts,
+    artifactResult?.result?.typed_artifacts,
+    artifactResult?.result?.typedArtifacts,
+    artifactResult?.result?.outputs?.typed_artifacts,
+    artifactResult?.result?.outputs?.typedArtifacts,
     workload.typed_artifacts,
     workload.typedArtifacts,
     workload.outputs?.typed_artifacts,
@@ -92,6 +98,78 @@ function typedArtifactsFromCodeboxResult(result, options = {}) {
     ...scenarios.map((scenario) => scenario?.metadata?.typedArtifacts),
   ];
   return Object.assign({}, ...candidates.map((candidate) => normalizeTypedArtifacts(candidate, options)));
+}
+
+function artifactResultEnvelopeFromCodeboxResult(result) {
+  const candidates = [
+    result,
+    result?.artifact_result,
+    result?.artifactResult,
+    result?.metadata?.artifact_result,
+    result?.metadata?.artifactResult,
+    result?.metadata?.agent_runtime?.result,
+    ...(Array.isArray(result?.projections) ? result.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection) : []),
+    ...(Array.isArray(result?.metadata?.projections) ? result.metadata.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection) : []),
+  ];
+  return candidates.map(normalizeArtifactResultEnvelope).find(Boolean) || null;
+}
+
+function normalizeArtifactResultEnvelope(envelope) {
+  if (!plainObject(envelope) || envelope.schema !== WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA) {
+    return null;
+  }
+  const artifactBundle = normalizeArtifactResultRef(envelope.artifactBundle || envelope.artifact_bundle);
+  const artifactRefs = [
+    artifactBundle,
+    ...(Array.isArray(envelope.artifactRefs) ? envelope.artifactRefs.map(normalizeArtifactResultRef) : []),
+    ...(Array.isArray(envelope.artifact_refs) ? envelope.artifact_refs.map(normalizeArtifactResultRef) : []),
+  ].filter(Boolean);
+  return cleanObject({
+    schema: WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+    operation: envelope.operation,
+    operation_schema: envelope.operation_schema,
+    status: envelope.status,
+    success: envelope.success === undefined ? ['created', 'existing', 'updated'].includes(envelope.status) : envelope.success === true,
+    artifactBundle,
+    artifactRefs: uniqueArtifactResultRefs(artifactRefs),
+    verification: plainObject(envelope.verification) ? envelope.verification : undefined,
+    result: plainObject(envelope.result) ? envelope.result : undefined,
+    diagnostics: Array.isArray(envelope.diagnostics) ? envelope.diagnostics : [],
+    metadata: plainObject(envelope.metadata) ? envelope.metadata : undefined,
+    error: plainObject(envelope.error) ? envelope.error : undefined,
+    reason: envelope.reason,
+  });
+}
+
+function normalizeArtifactResultRef(ref) {
+  if (!plainObject(ref)) {
+    return null;
+  }
+  const digest = plainObject(ref.digest) ? ref.digest : {};
+  return cleanObject({
+    id: ref.id || ref.artifact_id,
+    kind: ref.kind || ref.type || 'artifact-bundle',
+    name: ref.name,
+    path: ref.path || ref.artifacts_path || ref.directory,
+    url: ref.url,
+    sha256: ref.sha256 || digest.value,
+    metadata: cleanObject({
+      digest: plainObject(ref.digest) ? ref.digest : undefined,
+      source_schema: WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+    }),
+  });
+}
+
+function uniqueArtifactResultRefs(refs) {
+  const seen = new Set();
+  return refs.filter((ref) => {
+    const key = `${ref.kind || ''}:${ref.id || ''}:${ref.path || ''}:${ref.url || ''}:${ref.sha256 || ''}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
 }
 
 function normalizeCodeboxArtifactDeclaration(defaultName, declaration, options = {}) {
@@ -251,11 +329,14 @@ function cleanObject(value) {
 module.exports = {
   TYPED_ARTIFACT_SCHEMA,
   WP_CODEBOX_ARTIFACT_DECLARATION_SCHEMA,
+  WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+  artifactResultEnvelopeFromCodeboxResult,
   artifactRoleFromCodeboxArtifact,
   artifactNameFromDeclaration,
   artifactPath,
   normalizeCodeboxArtifactDeclaration,
   normalizeCodeboxArtifactOutcome,
+  normalizeArtifactResultEnvelope,
   normalizeTypedArtifactEntry,
   normalizeTypedArtifacts,
   typedArtifactsFromCodeboxResult,

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -28,6 +28,7 @@ const WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS = {
   workspace_publication: 'wp-codebox/runner-workspace-publication-result/v1',
   tool_call_transcript: 'wp-codebox/tool-call-transcript/v1',
   evidence_artifact_envelope: 'wp-codebox/evidence-artifact-envelope/v1',
+  artifact_result_envelope: 'wp-codebox/artifact-result-envelope/v1',
 };
 
 const WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMA_KEYS = {
@@ -129,7 +130,7 @@ const WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS = [
   },
   {
     id: 'artifact-result-envelope',
-    schema: WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS.evidence_artifact_envelope,
+    schema: WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS.artifact_result_envelope,
     owner: 'wp-codebox',
     adapter_behavior: 'consume_when_available',
     requirement: 'Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Until this is complete, compatibility is centralized in codebox-artifact-contract.js.',

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -328,7 +328,8 @@
           "workspace_command": "wp-codebox/runner-workspace-command-result/v1",
           "workspace_publication": "wp-codebox/runner-workspace-publication-result/v1",
           "tool_call_transcript": "wp-codebox/tool-call-transcript/v1",
-          "evidence_artifact_envelope": "wp-codebox/evidence-artifact-envelope/v1"
+          "evidence_artifact_envelope": "wp-codebox/evidence-artifact-envelope/v1",
+          "artifact_result_envelope": "wp-codebox/artifact-result-envelope/v1"
         }
       },
       "role_aliases": {
@@ -384,7 +385,7 @@
         },
         {
           "id": "artifact-result-envelope",
-          "schema": "wp-codebox/evidence-artifact-envelope/v1",
+          "schema": "wp-codebox/artifact-result-envelope/v1",
           "owner": "wp-codebox",
           "adapter_behavior": "consume_when_available",
           "requirement": "Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Until this is complete, compatibility is centralized in codebox-artifact-contract.js."

--- a/tests/wp-codebox-artifact-contract-smoke.mjs
+++ b/tests/wp-codebox-artifact-contract-smoke.mjs
@@ -7,11 +7,14 @@ import { fileURLToPath } from 'node:url';
 const require = createRequire(import.meta.url);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const {
+  artifactResultEnvelopeFromCodeboxResult,
   artifactRoleFromCodeboxArtifact,
   artifactNameFromDeclaration,
   artifactPath,
+  normalizeArtifactResultEnvelope,
   normalizeTypedArtifactEntry,
   normalizeTypedArtifacts,
+  typedArtifactsFromCodeboxResult,
   typedArtifactFileRefs,
 } = require(path.join(repoRoot, 'agent-runtimes/wp-codebox/lib/codebox-artifact-contract'));
 
@@ -41,4 +44,43 @@ assert.deepEqual(normalizeTypedArtifactEntry('packet', {
 });
 
 assert.deepEqual(Object.keys(normalizeTypedArtifacts([{ id: 'one' }, { name: 'two' }])).sort(), ['one', 'two']);
+
+const artifactResultEnvelope = normalizeArtifactResultEnvelope({
+  schema: 'wp-codebox/artifact-result-envelope/v1',
+  operation: 'import-artifact-bundle',
+  status: 'created',
+  artifactBundle: {
+    kind: 'artifact-bundle',
+    id: 'bundle-one',
+    path: '/tmp/codebox-artifacts/bundle-one',
+    digest: { algorithm: 'sha256', value: 'abc123' },
+  },
+  artifactRefs: [
+    { kind: 'artifact-bundle', id: 'bundle-one', path: '/tmp/codebox-artifacts/bundle-one', digest: { value: 'abc123' } },
+    { kind: 'artifact-log', path: '/tmp/codebox-artifacts/bundle-one/files/log.txt' },
+  ],
+  result: {
+    typed_artifacts: {
+      review: {
+        kind: 'json',
+        artifact_schema: 'example/review/v1',
+        file_refs: [{ path: '/tmp/codebox-artifacts/bundle-one/files/review.json' }],
+      },
+    },
+  },
+});
+
+assert.equal(artifactResultEnvelope.schema, 'wp-codebox/artifact-result-envelope/v1');
+assert.equal(artifactResultEnvelope.success, true);
+assert.equal(artifactResultEnvelope.artifactRefs.length, 2);
+assert.equal(artifactResultEnvelope.artifactRefs[0].sha256, 'abc123');
+
+const projectedEnvelope = artifactResultEnvelopeFromCodeboxResult({
+  projections: [
+    { kind: 'noop', schema: 'example/noop/v1' },
+    { kind: 'artifact-result', schema: 'wp-codebox/artifact-result-envelope/v1', envelope: artifactResultEnvelope },
+  ],
+});
+assert.equal(projectedEnvelope.operation, 'import-artifact-bundle');
+assert.deepEqual(Object.keys(typedArtifactsFromCodeboxResult(projectedEnvelope)), ['review']);
 console.log('wp-codebox artifact contract smoke passed');


### PR DESCRIPTION
## Summary
- Add a thin WP Codebox artifact result envelope reader for `wp-codebox/artifact-result-envelope/v1`.
- Prefer artifact result envelope refs in WP Codebox executor artifact/evidence normalization while preserving legacy fallbacks.
- Advertise the new artifact result envelope schema in the WP Codebox runtime contract and manifest.

## Verification
- `node tests/wp-codebox-artifact-contract-smoke.mjs` passed.
- `npm --prefix wordpress run test:codebox-agent-task-executor` passed.
- `npm --prefix wordpress run lint:js -- ../agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js ../agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js ../agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js ../tests/wp-codebox-artifact-contract-smoke.mjs` reported 4 warnings that the files are ignored because they are outside the package base path.
- `node --check agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js` passed.
- `node --check agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js` passed.
- `node --check agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js` passed.
- `node --check tests/wp-codebox-artifact-contract-smoke.mjs` passed.
- `git diff --check` passed.

## Notes
WP Codebox PR 1242 is still open and not available as a released package dependency here, so this keeps a compatibility reader in Homeboy Extensions and leaves old-shape fallbacks intact.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the downstream artifact envelope reader, executor wiring, focused tests, and verification commands for Chris to review.