### PR TITLE
Prefer Codebox artifact result envelopes

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -2629,18 +2629,20 @@ function normalizeArtifacts(result, runSummary = null, recipeSummary = null) {
     if (Array.isArray(result.artifacts)) {
       result.artifacts.map(artifactFromCodeboxArtifact).forEach((artifact) => appendUniqueArtifact(artifacts, artifact));
     }
-    for (const artifact of codeboxBundleArtifacts(result)) {
-      appendUniqueArtifact(artifacts, artifact);
-    }
-    for (const artifact of agentRuntimeBundleArtifacts(result)) {
-      appendUniqueArtifact(artifacts, artifact);
-    }
-    for (const artifact of typedBundleOutputArtifacts(result)) {
-      appendUniqueArtifact(artifacts, artifact);
-    }
-    if (!recipeSummary) {
-      for (const artifact of recipeRunArtifacts(result)) {
+    if (!artifactResult) {
+      for (const artifact of codeboxBundleArtifacts(result)) {
         appendUniqueArtifact(artifacts, artifact);
+      }
+      for (const artifact of agentRuntimeBundleArtifacts(result)) {
+        appendUniqueArtifact(artifacts, artifact);
+      }
+      for (const artifact of typedBundleOutputArtifacts(result)) {
+        appendUniqueArtifact(artifacts, artifact);
+      }
+      if (!recipeSummary) {
+        for (const artifact of recipeRunArtifacts(result)) {
+          appendUniqueArtifact(artifacts, artifact);
+        }
       }
     }
     return artifacts.map(artifactFromCodeboxArtifact);
@@ -2675,34 +2677,36 @@ function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) 
         label: artifact.name || artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
       });
     }
-    for (const artifact of codeboxBundleArtifacts(result)) {
-      appendUniqueEvidenceRef(refs, {
-        kind: artifact.kind,
-        uri: artifact.path || artifact.url,
-        label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
-      });
-    }
-    for (const artifact of agentRuntimeBundleArtifacts(result)) {
-      appendUniqueEvidenceRef(refs, {
-        kind: artifact.kind,
-        uri: artifact.path || artifact.url,
-        label: artifact.kind.replace(/^agent-runtime-/, 'Agent runtime ').replace(/-/g, ' '),
-      });
-    }
-    for (const artifact of typedBundleOutputArtifacts(result)) {
-      appendUniqueEvidenceRef(refs, {
-        kind: artifact.kind,
-        uri: artifact.path || artifact.url,
-        label: `Typed bundle output ${artifact.name || ''}`.trim(),
-      });
-    }
-    if (!recipeSummary) {
-      for (const artifact of recipeRunArtifacts(result)) {
+    if (!artifactResult) {
+      for (const artifact of codeboxBundleArtifacts(result)) {
         appendUniqueEvidenceRef(refs, {
           kind: artifact.kind,
           uri: artifact.path || artifact.url,
-          label: artifact.kind.replace(/^codebox-recipe-/, 'WP Codebox recipe ').replace(/-/g, ' '),
+          label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
         });
+      }
+      for (const artifact of agentRuntimeBundleArtifacts(result)) {
+        appendUniqueEvidenceRef(refs, {
+          kind: artifact.kind,
+          uri: artifact.path || artifact.url,
+          label: artifact.kind.replace(/^agent-runtime-/, 'Agent runtime ').replace(/-/g, ' '),
+        });
+      }
+      for (const artifact of typedBundleOutputArtifacts(result)) {
+        appendUniqueEvidenceRef(refs, {
+          kind: artifact.kind,
+          uri: artifact.path || artifact.url,
+          label: `Typed bundle output ${artifact.name || ''}`.trim(),
+        });
+      }
+      if (!recipeSummary) {
+        for (const artifact of recipeRunArtifacts(result)) {
+          appendUniqueEvidenceRef(refs, {
+            kind: artifact.kind,
+            uri: artifact.path || artifact.url,
+            label: artifact.kind.replace(/^codebox-recipe-/, 'WP Codebox recipe ').replace(/-/g, ' '),
+          });
+        }
       }
     }
     for (const artifact of runSummary?.artifacts || []) {

--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -59,9 +59,29 @@ function normalizeTypedArtifacts(value, options = {}) {
 
 function typedArtifactsFromCodeboxResult(result, options = {}) {
   const workload = options.workload || agentRuntimeWorkload(result) || {};
-  const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
   const artifactResult = artifactResultEnvelopeFromCodeboxResult(result);
+  const envelopeArtifacts = typedArtifactsFromArtifactResultEnvelope(artifactResult, options);
+  if (Object.keys(envelopeArtifacts).length > 0) {
+    return envelopeArtifacts;
+  }
+
+  return Object.assign({}, ...legacyTypedArtifactCandidatesFromCodeboxResult(result, workload)
+    .map((candidate) => normalizeTypedArtifacts(candidate, options)));
+}
+
+function typedArtifactsFromArtifactResultEnvelope(artifactResult, options = {}) {
   const candidates = [
+    artifactResult?.result?.typed_artifacts,
+    artifactResult?.result?.typedArtifacts,
+    artifactResult?.result?.outputs?.typed_artifacts,
+    artifactResult?.result?.outputs?.typedArtifacts,
+  ];
+  return Object.assign({}, ...candidates.map((candidate) => normalizeTypedArtifacts(candidate, options)));
+}
+
+function legacyTypedArtifactCandidatesFromCodeboxResult(result, workload = {}) {
+  const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
+  return [
     result?.outputs?.typed_artifacts,
     result?.outputs?.typedArtifacts,
     result?.run?.agentResult?.typed_artifacts,
@@ -78,10 +98,6 @@ function typedArtifactsFromCodeboxResult(result, options = {}) {
     result?.metadata?.agent_runtime?.result?.outputs?.typedArtifacts,
     result?.metadata?.agent_runtime?.result?.outputs?.outputs?.typed_artifacts,
     result?.metadata?.agent_runtime?.result?.outputs?.outputs?.typedArtifacts,
-    artifactResult?.result?.typed_artifacts,
-    artifactResult?.result?.typedArtifacts,
-    artifactResult?.result?.outputs?.typed_artifacts,
-    artifactResult?.result?.outputs?.typedArtifacts,
     workload.typed_artifacts,
     workload.typedArtifacts,
     workload.outputs?.typed_artifacts,
@@ -99,7 +115,6 @@ function typedArtifactsFromCodeboxResult(result, options = {}) {
     ...scenarios.map((scenario) => scenario?.metadata?.typed_artifacts),
     ...scenarios.map((scenario) => scenario?.metadata?.typedArtifacts),
   ];
-  return Object.assign({}, ...candidates.map((candidate) => normalizeTypedArtifacts(candidate, options)));
 }
 
 function artifactResultEnvelopeFromCodeboxResult(result) {
@@ -109,11 +124,13 @@ function artifactResultEnvelopeFromCodeboxResult(result) {
     result?.artifactResult,
     result?.metadata?.artifact_result,
     result?.metadata?.artifactResult,
-    result?.metadata?.agent_runtime?.result,
     ...(Array.isArray(result?.projections) ? result.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection) : []),
     ...(Array.isArray(result?.metadata?.projections) ? result.metadata.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection) : []),
   ];
-  return candidates.map(normalizeArtifactResultEnvelope).find(Boolean) || null;
+  const legacyCandidates = [
+    result?.metadata?.agent_runtime?.result,
+  ];
+  return [...candidates, ...legacyCandidates].map(normalizeArtifactResultEnvelope).find(Boolean) || null;
 }
 
 function normalizeArtifactResultEnvelope(envelope) {

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -132,8 +132,8 @@ const WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS = [
     id: 'artifact-result-envelope',
     schema: WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS.artifact_result_envelope,
     owner: 'wp-codebox',
-    adapter_behavior: 'consume_when_available',
-    requirement: 'Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Until this is complete, compatibility is centralized in codebox-artifact-contract.js.',
+    adapter_behavior: 'consume_canonical_envelope_with_legacy_package_fallback',
+    requirement: 'Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Compatibility for older Codebox packages is centralized in codebox-artifact-contract.js.',
   },
   {
     id: 'artifact-apply-execution',

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -387,8 +387,8 @@
           "id": "artifact-result-envelope",
           "schema": "wp-codebox/artifact-result-envelope/v1",
           "owner": "wp-codebox",
-          "adapter_behavior": "consume_when_available",
-          "requirement": "Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Until this is complete, compatibility is centralized in codebox-artifact-contract.js."
+          "adapter_behavior": "consume_canonical_envelope_with_legacy_package_fallback",
+          "requirement": "Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Compatibility for older Codebox packages is centralized in codebox-artifact-contract.js."
         },
         {
           "id": "artifact-apply-execution",

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -63,6 +63,11 @@ assert.deepEqual(WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.map((requirement) =>
 	'parent-tool-bridge',
 	'provider-runtime-invocation',
 	'artifact-result-envelope',
+	'artifact-apply-execution',
 ]);
+assert.equal(
+	WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.find((requirement) => requirement.id === 'artifact-result-envelope').adapter_behavior,
+	'consume_canonical_envelope_with_legacy_package_fallback'
+);
 
 console.log('wp-codebox adapter contract smoke passed');

--- a/tests/wp-codebox-artifact-contract-smoke.mjs
+++ b/tests/wp-codebox-artifact-contract-smoke.mjs
@@ -83,4 +83,45 @@ const projectedEnvelope = artifactResultEnvelopeFromCodeboxResult({
 });
 assert.equal(projectedEnvelope.operation, 'import-artifact-bundle');
 assert.deepEqual(Object.keys(typedArtifactsFromCodeboxResult(projectedEnvelope)), ['review']);
+assert.deepEqual(typedArtifactsFromCodeboxResult({
+  artifact_result: artifactResultEnvelope,
+  metadata: {
+    agent_runtime: {
+      result: {
+        outputs: {
+          typed_artifacts: {
+            legacy: { type: 'json', payload: { old: true } },
+          },
+        },
+      },
+    },
+  },
+}).review.artifact_schema, 'example/review/v1');
+assert.equal(Object.hasOwn(typedArtifactsFromCodeboxResult({
+  artifact_result: artifactResultEnvelope,
+  metadata: {
+    agent_runtime: {
+      result: {
+        outputs: {
+          typed_artifacts: {
+            legacy: { type: 'json', payload: { old: true } },
+          },
+        },
+      },
+    },
+  },
+}), 'legacy'), false);
+assert.equal(typedArtifactsFromCodeboxResult({
+  metadata: {
+    agent_runtime: {
+      result: {
+        outputs: {
+          typed_artifacts: {
+            legacy: { type: 'json', payload: { old: true } },
+          },
+        },
+      },
+    },
+  },
+}).legacy.payload.old, true);
 console.log('wp-codebox artifact contract smoke passed');

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -54,7 +54,7 @@ assert.equal(provider.provider_runtime_invocation.abilities.workspaceCommand, 'w
 assert.equal(provider.upstream_primitive_requirements.some((requirement) => requirement.id === 'artifact-apply-execution'), true);
 assert.equal(
   provider.upstream_primitive_requirements.find((requirement) => requirement.id === 'artifact-result-envelope').adapter_behavior,
-  'consume_when_available'
+  'consume_canonical_envelope_with_legacy_package_fallback'
 );
 assert.doesNotMatch(JSON.stringify(provider.provider_runtime_invocation), /datamachine|data machine|wp-site-generator|wpsg|site generator/i);
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, codexSecretEnv);
@@ -70,13 +70,13 @@ assert.deepEqual(normalizeCodeboxArtifactDeclaration('fallback', {
   required: true,
 });
 assert.deepEqual(typedArtifactsFromCodeboxResult({
-  metadata: {
-    agent_runtime: {
-      result: {
-        outputs: {
-          typed_artifacts: {
-            review: { type: 'json', payload: { ok: true } },
-          },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      outputs: {
+        typed_artifacts: {
+          review: { type: 'json', payload: { ok: true } },
         },
       },
     },

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1467,6 +1467,33 @@ assert.equal(upstreamRunnerOutcome.status, 'succeeded');
 assert.equal(upstreamRunnerOutcome.artifacts[0].kind, 'codebox-artifact-directory');
 assert.equal(upstreamRunnerOutcome.artifacts[0].path, '/tmp/wp-codebox-artifacts');
 
+const canonicalArtifactEnvelopeOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    artifactRefs: [{ kind: 'artifact-log', path: '/tmp/canonical/log.txt' }],
+    result: {
+      outputs: {
+        typed_artifacts: {
+          review: { type: 'json', payload: { canonical: true } },
+        },
+      },
+    },
+  },
+  run: {
+    agentResult: {
+      artifacts: { directory: '/tmp/legacy-artifacts' },
+      patch: { artifact: 'files/legacy.patch' },
+    },
+  },
+});
+assert.equal(canonicalArtifactEnvelopeOutcome.outputs.typed_artifacts.review.payload.canonical, true);
+assert.equal(canonicalArtifactEnvelopeOutcome.artifacts.some((artifact) => artifact.path === '/tmp/canonical/log.txt'), true);
+assert.equal(canonicalArtifactEnvelopeOutcome.artifacts.some((artifact) => artifact.path === '/tmp/legacy-artifacts/files/legacy.patch'), false);
+
 const failedUpstreamRunnerOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'failed',


### PR DESCRIPTION
## Summary
- Prefer wp-codebox/artifact-result-envelope/v1 for typed artifacts before scanning legacy nested Codebox result shapes.
- Skip legacy bundle/transcript/patch artifact layout parsing when the canonical artifact-result envelope is present.
- Make older Codebox package compatibility explicit in the provider contract and runtime manifest.
- Update smoke tests to assert the envelope path is canonical and legacy parsing is fallback-only.

## Verification
- node tests/wp-codebox-artifact-contract-smoke.mjs
- node tests/wp-codebox-adapter-contract-smoke.mjs
- npm run test:codebox-agent-task-executor-boundary
- npm run test:codebox-agent-task-executor
- node --check agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
- node --check agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
- node --check agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Codebox artifact envelope cleanup and targeted tests; Chris to review and validate before merge.