### PR TITLE
Consume current WP Codebox envelopes

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -2673,8 +2673,15 @@ function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) 
     for (const artifact of artifactResult?.artifactRefs || []) {
       appendUniqueEvidenceRef(refs, {
         kind: artifact.kind,
-        uri: artifact.path || artifact.url,
+        uri: artifact.uri || artifact.path || artifact.url,
         label: artifact.name || artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
+      });
+    }
+    for (const evidenceRef of artifactResult?.evidenceRefs || []) {
+      appendUniqueEvidenceRef(refs, {
+        kind: evidenceRef.kind,
+        uri: evidenceRef.uri || evidenceRef.path || evidenceRef.url,
+        label: evidenceRef.name || evidenceRef.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
       });
     }
     if (!artifactResult) {
@@ -2734,8 +2741,13 @@ function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) 
   const evidenceRefs = [
     ...(artifactResult?.artifactRefs || []).map((artifact) => ({
       kind: artifact.kind,
-      uri: artifact.path || artifact.url,
+      uri: artifact.uri || artifact.path || artifact.url,
       label: artifact.name || artifact.kind,
+    })),
+    ...(artifactResult?.evidenceRefs || []).map((ref) => ({
+      kind: ref.kind,
+      uri: ref.uri || ref.path || ref.url,
+      label: ref.name || ref.kind,
     })),
     ...(result?.evidence_refs || result?.evidence || []),
   ];

--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -71,6 +71,8 @@ function typedArtifactsFromCodeboxResult(result, options = {}) {
 
 function typedArtifactsFromArtifactResultEnvelope(artifactResult, options = {}) {
   const candidates = [
+    artifactResult?.typed_artifacts,
+    artifactResult?.typedArtifacts,
     artifactResult?.result?.typed_artifacts,
     artifactResult?.result?.typedArtifacts,
     artifactResult?.result?.outputs?.typed_artifacts,
@@ -140,8 +142,16 @@ function normalizeArtifactResultEnvelope(envelope) {
   const artifactBundle = normalizeArtifactResultRef(envelope.artifactBundle || envelope.artifact_bundle);
   const artifactRefs = [
     artifactBundle,
+    ...(Array.isArray(envelope.artifactBundleRefs) ? envelope.artifactBundleRefs.map(normalizeArtifactResultRef) : []),
+    ...(Array.isArray(envelope.artifact_bundle_refs) ? envelope.artifact_bundle_refs.map(normalizeArtifactResultRef) : []),
     ...(Array.isArray(envelope.artifactRefs) ? envelope.artifactRefs.map(normalizeArtifactResultRef) : []),
     ...(Array.isArray(envelope.artifact_refs) ? envelope.artifact_refs.map(normalizeArtifactResultRef) : []),
+  ].filter(Boolean);
+  const evidenceRefs = [
+    ...(Array.isArray(envelope.evidenceRefs) ? envelope.evidenceRefs.map(normalizeArtifactResultRef) : []),
+    ...(Array.isArray(envelope.evidence_refs) ? envelope.evidence_refs.map(normalizeArtifactResultRef) : []),
+    ...(Array.isArray(envelope.transcriptRefs) ? envelope.transcriptRefs.map(normalizeArtifactResultRef) : []),
+    ...(Array.isArray(envelope.transcript_refs) ? envelope.transcript_refs.map(normalizeArtifactResultRef) : []),
   ].filter(Boolean);
   return cleanObject({
     schema: WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
@@ -151,6 +161,9 @@ function normalizeArtifactResultEnvelope(envelope) {
     success: envelope.success === undefined ? ['created', 'existing', 'updated'].includes(envelope.status) : envelope.success === true,
     artifactBundle,
     artifactRefs: uniqueArtifactResultRefs(artifactRefs),
+    evidenceRefs: uniqueArtifactResultRefs(evidenceRefs),
+    structured_artifacts: Array.isArray(envelope.structured_artifacts) ? envelope.structured_artifacts : envelope.structuredArtifacts,
+    typed_artifacts: Array.isArray(envelope.typed_artifacts) ? envelope.typed_artifacts : envelope.typedArtifacts,
     verification: plainObject(envelope.verification) ? envelope.verification : undefined,
     result: plainObject(envelope.result) ? envelope.result : undefined,
     diagnostics: Array.isArray(envelope.diagnostics) ? envelope.diagnostics : [],
@@ -168,8 +181,9 @@ function normalizeArtifactResultRef(ref) {
   return cleanObject({
     id: ref.id || ref.artifact_id,
     kind: ref.kind || ref.type || 'artifact-bundle',
-    name: ref.name,
-    path: ref.path || ref.artifacts_path || ref.directory,
+    name: ref.name || ref.label,
+    path: ref.path || ref.artifacts_path || ref.directory || ref.uri,
+    uri: ref.uri,
     url: ref.url,
     sha256: ref.sha256 || digest.value,
     metadata: cleanObject({

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -6,6 +6,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const {
+  artifactResultEnvelopeFromCodeboxResult,
   codeboxTaskRequestFromAgentTaskRequest,
   normalizeCodeboxArtifactDeclaration,
   normalizeCodeboxArtifactOutcome,
@@ -82,6 +83,20 @@ assert.deepEqual(typedArtifactsFromCodeboxResult({
     },
   },
 }).review.payload, { ok: true });
+const artifactResultEnvelope = artifactResultEnvelopeFromCodeboxResult({
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    artifact_bundle_refs: [{ kind: 'artifact-bundle', path: 'artifacts/run-1' }],
+    artifact_refs: [{ kind: 'codebox-review', path: 'files/review.json' }],
+    evidence_refs: [{ kind: 'codebox-agent-terminal-result', uri: 'artifacts/run-1', label: 'Terminal result' }],
+    transcript_refs: [{ kind: 'codebox-transcript', path: 'files/transcript.json' }],
+    typed_artifacts: [{ name: 'review', artifact_schema: 'example/review/v1', payload: { ok: true } }],
+  },
+});
+assert.equal(artifactResultEnvelope.artifactRefs.length, 2);
+assert.equal(artifactResultEnvelope.evidenceRefs.length, 2);
+assert.equal(artifactResultEnvelope.evidenceRefs[0].uri, 'artifacts/run-1');
+assert.deepEqual(typedArtifactsFromCodeboxResult({ artifact_result: artifactResultEnvelope }).review.payload, { ok: true });
 assert.equal(normalizeCodeboxArtifactOutcome({ id: 'patch.diff', kind: 'codebox-patch' }, {}, {
   roleAliases: provider.role_aliases,
 }).role, 'patch');


### PR DESCRIPTION
## Summary
- consume current WP Codebox artifact envelope fields in the WP Codebox runtime adapter
- preserve top-level typed artifacts, artifact bundle refs, evidence refs, transcript refs, and URI values
- keep legacy artifact fallback paths only when no envelope is present

## Testing
- `npm --prefix wordpress run test:codebox-agent-task-executor-boundary`
- `npm --prefix wordpress run test:codebox-agent-task-executor`
- `npm --prefix wordpress run test:wp-codebox-task-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the adapter updates, resolved current-main conflicts, and ran targeted verification for Chris to review.