### PR TITLE
Detect pnpm workspace roots for dependency installs

### DIFF
--- a/nodejs/scripts/lib/project-scripts.sh
+++ b/nodejs/scripts/lib/project-scripts.sh
@@ -18,6 +18,18 @@ homeboy_project_find_file_upward() {
     return 1
 }
 
+homeboy_project_find_pnpm_root_upward() {
+    local _dir="$1"
+    while [ "$_dir" != "/" ] && [ "$_dir" != "." ]; do
+        if [ -f "$_dir/pnpm-workspace.yaml" ] || [ -f "$_dir/pnpm-lock.yaml" ]; then
+            printf '%s\n' "$_dir"
+            return 0
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+    return 1
+}
+
 homeboy_project_init() {
     local _ecosystem=""
     local _dir="${PROJECT_PATH:-.}"
@@ -57,6 +69,7 @@ homeboy_project_init() {
 homeboy_project_init_node() {
     local _dir="$1"
     local _root
+    local _pnpm_root
 
     if ! _root="$(homeboy_project_find_file_upward "$_dir" "package.json")"; then
         echo "Error: No package.json found at or above ${_dir}" >&2
@@ -66,9 +79,11 @@ homeboy_project_init_node() {
 
     HOMEBOY_PROJECT_ECOSYSTEM="node"
     HOMEBOY_PROJECT_ROOT="$_root"
+    HOMEBOY_PROJECT_DEPENDENCY_ROOT="$_root"
     HOMEBOY_PROJECT_SCRIPT_FILE="${_root}/package.json"
 
-    if [ -f "$_root/pnpm-lock.yaml" ]; then
+    if _pnpm_root="$(homeboy_project_find_pnpm_root_upward "$_root")"; then
+        HOMEBOY_PROJECT_DEPENDENCY_ROOT="$_pnpm_root"
         HOMEBOY_PROJECT_PACKAGE_MANAGER="pnpm"
         HOMEBOY_PROJECT_RUN_CMD="pnpm run"
         HOMEBOY_PROJECT_EXEC_CMD="pnpm exec"
@@ -85,6 +100,7 @@ homeboy_project_init_node() {
     if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
         echo "DEBUG: Project ecosystem: $HOMEBOY_PROJECT_ECOSYSTEM" >&2
         echo "DEBUG: Project root: $HOMEBOY_PROJECT_ROOT" >&2
+        echo "DEBUG: Dependency root: $HOMEBOY_PROJECT_DEPENDENCY_ROOT" >&2
         echo "DEBUG: Package manager: $HOMEBOY_PROJECT_PACKAGE_MANAGER" >&2
     fi
 }
@@ -162,7 +178,7 @@ homeboy_project_ensure_dependencies() {
         return 1
     fi
 
-    local _dir="${HOMEBOY_PROJECT_ROOT:-}"
+    local _dir="${HOMEBOY_PROJECT_DEPENDENCY_ROOT:-${HOMEBOY_PROJECT_ROOT:-}}"
     if [ -z "$_dir" ]; then
         echo "Error: homeboy_project_init must be called before dependency helpers" >&2
         return 1

--- a/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
+++ b/nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh
@@ -29,6 +29,26 @@ bash -c '
     source "$1"
     homeboy_project_init --ecosystem node --path "$2/subdir"
     [ "$HOMEBOY_PROJECT_ROOT" = "$2" ]
+    [ "$HOMEBOY_PROJECT_DEPENDENCY_ROOT" = "$2" ]
     [ "$HOMEBOY_PROJECT_PACKAGE_MANAGER" = "pnpm" ]
     [ "$(homeboy_project_run_script_command test)" = "pnpm run test" ]
 ' _ "$PROJECT_SCRIPTS" "$PNPM_PROJECT"
+
+WORKSPACE_PROJECT="$TMP_DIR/workspace-project"
+mkdir -p "$WORKSPACE_PROJECT/packages/plugin/subdir"
+cat > "$WORKSPACE_PROJECT/package.json" <<'EOF'
+{"name":"workspace-root","scripts":{"root":"node root.js"}}
+EOF
+cat > "$WORKSPACE_PROJECT/packages/plugin/package.json" <<'EOF'
+{"name":"workspace-plugin","scripts":{"test":"node plugin.js"}}
+EOF
+touch "$WORKSPACE_PROJECT/pnpm-lock.yaml" "$WORKSPACE_PROJECT/pnpm-workspace.yaml"
+
+bash -c '
+    source "$1"
+    homeboy_project_init --ecosystem node --path "$2/packages/plugin/subdir"
+    [ "$HOMEBOY_PROJECT_ROOT" = "$2/packages/plugin" ]
+    [ "$HOMEBOY_PROJECT_DEPENDENCY_ROOT" = "$2" ]
+    [ "$HOMEBOY_PROJECT_PACKAGE_MANAGER" = "pnpm" ]
+    [ "$(homeboy_project_run_script_command test)" = "pnpm run test" ]
+' _ "$PROJECT_SCRIPTS" "$WORKSPACE_PROJECT"

--- a/scripts/lib/project-scripts.sh
+++ b/scripts/lib/project-scripts.sh
@@ -18,6 +18,18 @@ homeboy_project_find_file_upward() {
     return 1
 }
 
+homeboy_project_find_pnpm_root_upward() {
+    local _dir="$1"
+    while [ "$_dir" != "/" ] && [ "$_dir" != "." ]; do
+        if [ -f "$_dir/pnpm-workspace.yaml" ] || [ -f "$_dir/pnpm-lock.yaml" ]; then
+            printf '%s\n' "$_dir"
+            return 0
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+    return 1
+}
+
 homeboy_project_init() {
     local _ecosystem=""
     local _dir="${PROJECT_PATH:-.}"
@@ -57,6 +69,7 @@ homeboy_project_init() {
 homeboy_project_init_node() {
     local _dir="$1"
     local _root
+    local _pnpm_root
 
     if ! _root="$(homeboy_project_find_file_upward "$_dir" "package.json")"; then
         echo "Error: No package.json found at or above ${_dir}" >&2
@@ -66,9 +79,11 @@ homeboy_project_init_node() {
 
     HOMEBOY_PROJECT_ECOSYSTEM="node"
     HOMEBOY_PROJECT_ROOT="$_root"
+    HOMEBOY_PROJECT_DEPENDENCY_ROOT="$_root"
     HOMEBOY_PROJECT_SCRIPT_FILE="${_root}/package.json"
 
-    if [ -f "$_root/pnpm-lock.yaml" ]; then
+    if _pnpm_root="$(homeboy_project_find_pnpm_root_upward "$_root")"; then
+        HOMEBOY_PROJECT_DEPENDENCY_ROOT="$_pnpm_root"
         HOMEBOY_PROJECT_PACKAGE_MANAGER="pnpm"
         HOMEBOY_PROJECT_RUN_CMD="pnpm run"
         HOMEBOY_PROJECT_EXEC_CMD="pnpm exec"
@@ -85,6 +100,7 @@ homeboy_project_init_node() {
     if [ "${HOMEBOY_DEBUG:-}" = "1" ]; then
         echo "DEBUG: Project ecosystem: $HOMEBOY_PROJECT_ECOSYSTEM" >&2
         echo "DEBUG: Project root: $HOMEBOY_PROJECT_ROOT" >&2
+        echo "DEBUG: Dependency root: $HOMEBOY_PROJECT_DEPENDENCY_ROOT" >&2
         echo "DEBUG: Package manager: $HOMEBOY_PROJECT_PACKAGE_MANAGER" >&2
     fi
 }
@@ -162,7 +178,7 @@ homeboy_project_ensure_dependencies() {
         return 1
     fi
 
-    local _dir="${HOMEBOY_PROJECT_ROOT:-}"
+    local _dir="${HOMEBOY_PROJECT_DEPENDENCY_ROOT:-${HOMEBOY_PROJECT_ROOT:-}}"
     if [ -z "$_dir" ]; then
         echo "Error: homeboy_project_init must be called before dependency helpers" >&2
         return 1

--- a/tests/project-scripts-pnpm-workspace-smoke.sh
+++ b/tests/project-scripts-pnpm-workspace-smoke.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_SCRIPTS="${ROOT_DIR}/scripts/lib/project-scripts.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+WORKSPACE_PROJECT="$TMP_DIR/workspace-project"
+mkdir -p "$WORKSPACE_PROJECT/packages/plugin/subdir"
+cat > "$WORKSPACE_PROJECT/package.json" <<'EOF'
+{"name":"workspace-root"}
+EOF
+cat > "$WORKSPACE_PROJECT/packages/plugin/package.json" <<'EOF'
+{"name":"workspace-plugin","scripts":{"test":"node plugin.js"}}
+EOF
+touch "$WORKSPACE_PROJECT/pnpm-lock.yaml" "$WORKSPACE_PROJECT/pnpm-workspace.yaml"
+
+bash -c '
+    source "$1"
+    homeboy_project_init --ecosystem node --path "$2/packages/plugin/subdir"
+    [ "$HOMEBOY_PROJECT_ROOT" = "$2/packages/plugin" ]
+    [ "$HOMEBOY_PROJECT_DEPENDENCY_ROOT" = "$2" ]
+    [ "$HOMEBOY_PROJECT_PACKAGE_MANAGER" = "pnpm" ]
+    [ "$(homeboy_project_run_script_command test)" = "pnpm run test" ]
+' _ "$PROJECT_SCRIPTS" "$WORKSPACE_PROJECT"


### PR DESCRIPTION
## Summary
- detect pnpm workspace or lock roots above the selected package
- keep package script execution rooted at the requested package
- install dependencies from the pnpm workspace root so workspace packages do not fall back to npm

## Motivation
WooCommerce full-surface profiling currently fails before benchmarks start because the dependency helper selects `plugins/woocommerce/package.json`, misses the monorepo pnpm lock/workspace root, and runs `npm install`, which fails with `EUNSUPPORTEDPROTOCOL` / `only-allow pnpm`.

## Verification
- `tests/project-scripts-pnpm-workspace-smoke.sh`
- `nodejs/tests/node-helpers-packaged-project-scripts-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Woo profiling setup failure, implementing the generic workspace-root fix, and drafting this PR description.
