### PR TITLE
Emit REST DB query shapes

### DIFF
--- a/wordpress/lib/rest-db-query-profiler.js
+++ b/wordpress/lib/rest-db-query-profiler.js
@@ -107,6 +107,68 @@ if ( ! function_exists( 'homeboy_rest_db_query_profiler_query_time' ) ) {
 	}
 }
 
+if ( ! function_exists( 'homeboy_rest_db_query_profiler_normalize_sql' ) ) {
+	function homeboy_rest_db_query_profiler_normalize_sql( $sql ) {
+		$shape = preg_replace( '/\s+/', ' ', trim( (string) $sql ) );
+		$shape = preg_replace( '/\b0x[0-9a-f]+\b/i', '?', $shape );
+		$shape = preg_replace( "/'(?:''|[^'])*'/", '?', $shape );
+		$shape = preg_replace( '/"(?:\\\\"|[^"])*"/', '?', $shape );
+		$shape = preg_replace( '/\b\d+(?:\.\d+)?\b/', '?', $shape );
+		$shape = preg_replace( '/\(\s*\?(?:\s*,\s*\?)+\s*\)/', '(?)', $shape );
+
+		return $shape;
+	}
+}
+
+if ( ! function_exists( 'homeboy_rest_db_query_profiler_top_query_shapes' ) ) {
+	function homeboy_rest_db_query_profiler_top_query_shapes( $start = 0, $limit = 5 ) {
+		global $wpdb;
+
+		$queries = isset( $wpdb->queries ) && is_array( $wpdb->queries ) ? array_slice( $wpdb->queries, max( 0, (int) $start ) ) : array();
+		$shapes  = array();
+		foreach ( $queries as $query ) {
+			$sql = isset( $query[0] ) ? (string) $query[0] : '';
+			if ( '' === trim( $sql ) ) {
+				continue;
+			}
+
+			$shape = homeboy_rest_db_query_profiler_normalize_sql( $sql );
+			if ( ! isset( $shapes[ $shape ] ) ) {
+				$shapes[ $shape ] = array(
+					'sql'     => $shape,
+					'count'   => 0,
+					'time_ms' => 0.0,
+				);
+			}
+
+			$shapes[ $shape ]['count'] += 1;
+			if ( isset( $query[1] ) && is_numeric( $query[1] ) ) {
+				$shapes[ $shape ]['time_ms'] += (float) $query[1] * 1000;
+			}
+		}
+
+		usort(
+			$shapes,
+			static function ( $a, $b ) {
+				if ( $a['time_ms'] === $b['time_ms'] ) {
+					return $b['count'] <=> $a['count'];
+				}
+
+				return $b['time_ms'] <=> $a['time_ms'];
+			}
+		);
+
+		return array_map(
+			static function ( $shape ) {
+				$shape['time_ms'] = round( $shape['time_ms'], 3 );
+
+				return $shape;
+			},
+			array_slice( $shapes, 0, max( 0, (int) $limit ) )
+		);
+	}
+}
+
 if ( ! function_exists( 'homeboy_rest_db_query_profiler_write' ) ) {
 	function homeboy_rest_db_query_profiler_write( $entry ) {
 		global $homeboy_rest_db_query_profiler_file;
@@ -166,6 +228,7 @@ add_filter(
 				'duration_ms'    => round( ( microtime( true ) - (float) $start['start_time'] ) * 1000, 3 ),
 				'query_count'    => max( 0, $end_count - $start_count ),
 				'query_time_ms'  => round( homeboy_rest_db_query_profiler_query_time( $start_count ) * 1000, 3 ),
+				'top_query_shapes' => homeboy_rest_db_query_profiler_top_query_shapes( $start_count, 5 ),
 				'total_queries'  => $end_count,
 			)
 		);

--- a/wordpress/lib/rest-route-matrix.js
+++ b/wordpress/lib/rest-route-matrix.js
@@ -211,6 +211,7 @@ function normalizeRestDbProfile(entry = {}) {
 	const route = resultRoutePath(entry);
 	const method = normalizeRestRouteMethod(entry.method);
 	const id = resultCaseKey({ ...entry, method, route });
+	const topQueryShapes = normalizeTopQueryShapes(entry.topQueryShapes ?? entry.top_query_shapes ?? entry.queryShapes ?? entry.query_shapes);
 	return {
 		id,
 		key: id,
@@ -222,7 +223,28 @@ function normalizeRestDbProfile(entry = {}) {
 		queryCount: maybeNumericValue(entry.queryCount ?? entry.query_count ?? entry.dbQueryCount ?? entry.db_query_count),
 		queryTimeMs: maybeNumericValue(entry.queryTimeMs ?? entry.query_time_ms ?? entry.dbQueryTimeMs ?? entry.db_query_time_ms),
 		totalQueries: maybeNumericValue(entry.totalQueries ?? entry.total_queries),
+		topQueryShapes,
 	};
+}
+
+function normalizeTopQueryShapes(value) {
+	if (!Array.isArray(value)) {
+		return [];
+	}
+	return value.map((entry) => {
+		if (!isPlainObject(entry)) {
+			return null;
+		}
+		const sql = String(entry.sql ?? entry.shape ?? entry.query ?? '').trim();
+		if (!sql) {
+			return null;
+		}
+		return {
+			sql,
+			count: maybeNumericValue(entry.count) ?? 0,
+			timeMs: maybeNumericValue(entry.timeMs ?? entry.time_ms ?? entry.queryTimeMs ?? entry.query_time_ms) ?? 0,
+		};
+	}).filter(Boolean).sort((a, b) => b.timeMs - a.timeMs || b.count - a.count || sortText(a.sql, b.sql));
 }
 
 function normalizeInputDbProfiles(input = {}) {
@@ -243,10 +265,12 @@ function mergeRestDbProfile(row, profile) {
 		durationMs: row.durationMs ?? profile.durationMs,
 		queryCount: row.queryCount ?? profile.queryCount,
 		queryTimeMs: row.queryTimeMs ?? profile.queryTimeMs,
+		topQueryShapes: row.topQueryShapes?.length ? row.topQueryShapes : profile.topQueryShapes,
 		dbProfile: {
 			queryCount: profile.queryCount,
 			queryTimeMs: profile.queryTimeMs,
 			totalQueries: profile.totalQueries,
+			topQueryShapes: profile.topQueryShapes,
 		},
 		covered: row.covered || profile.queryCount !== undefined || profile.queryTimeMs !== undefined,
 	};
@@ -564,6 +588,18 @@ function formatRouteRows(rows, options = {}) {
 	return lines;
 }
 
+function formatQueryShapeRows(rows, options = {}) {
+	const limit = Math.max(0, Math.floor(numericValue(options.limit ?? DEFAULT_REPORT_LIMIT)));
+	const rowsWithShapes = rows.filter((row) => Array.isArray(row.topQueryShapes) && row.topQueryShapes.length > 0);
+	const visibleRows = limit > 0 ? rowsWithShapes.slice(0, limit) : rowsWithShapes;
+	const lines = ['| Route | Query count | Query time ms | Top query shapes |', '| --- | ---: | ---: | --- |'];
+	for (const row of visibleRows) {
+		const shapes = row.topQueryShapes.slice(0, 3).map((shape) => `${formatNumber(shape.timeMs)}ms x${formatNumber(shape.count)} ${shape.sql}`).join('<br>');
+		lines.push(`| \`${escapeMarkdownCell(`${row.method} ${row.path || row.route || row.id}`)}\` | ${formatNumber(row.queryCount)} | ${formatNumber(row.queryTimeMs)} | ${escapeMarkdownCell(shapes)} |`);
+	}
+	return lines;
+}
+
 function formatRestRouteMatrixMarkdownReport(input = {}, options = {}) {
 	const artifact = input?.schema === 'homeboy/wordpress-rest-route-matrix-artifact/v1'
 		? input
@@ -595,6 +631,9 @@ function formatRestRouteMatrixMarkdownReport(input = {}, options = {}) {
 	}
 	if (artifact.slowestByQueryTime.length > 0) {
 		lines.push('', '## Slowest routes by query time', '', ...formatRouteRows(artifact.slowestByQueryTime, { limit }));
+	}
+	if (artifact.routes.some((row) => Array.isArray(row.topQueryShapes) && row.topQueryShapes.length > 0)) {
+		lines.push('', '## Top DB query shapes by REST case', '', ...formatQueryShapeRows(artifact.slowestByQueryTime, { limit }));
 	}
 	if (artifact.uncoveredRoutes.length > 0) {
 		lines.push('', '## Missing or uncovered routes', '', ...formatRouteRows(artifact.uncoveredRoutes, { limit }));

--- a/wordpress/tests/rest-db-query-profiler-smoke.js
+++ b/wordpress/tests/rest-db-query-profiler-smoke.js
@@ -21,6 +21,8 @@ assert.match(plugin, /rest_post_dispatch/);
 assert.match(plugin, /\$wpdb->save_queries = true/);
 assert.match(plugin, /homeboy\/wordpress-rest-db-query-profile\/v1/);
 assert.match(plugin, /'query_count'\s+=> max\( 0, \$end_count - \$start_count \)/);
+assert.match(plugin, /homeboy_rest_db_query_profiler_normalize_sql/);
+assert.match(plugin, /'top_query_shapes'\s+=> homeboy_rest_db_query_profiler_top_query_shapes\( \$start_count, 5 \)/);
 assert.match(plugin, /ABSPATH \. 'wp-content\/profiles\/rest-db\.jsonl'/);
 
 const paths = resolveRestDbQueryProfilerPaths('/tmp/site', { artifactRelativePath: 'wp-content/profiles/rest-db.jsonl' });

--- a/wordpress/tests/rest-route-matrix-smoke.js
+++ b/wordpress/tests/rest-route-matrix-smoke.js
@@ -134,7 +134,10 @@ const artifact = buildRestRouteMatrixArtifact({
 		{ method: 'POST', route: '/wc/store/v1/cart', status: 500, durationMs: 80, queryCount: 2 },
 	],
 	dbProfiles: [
-		{ method: 'GET', route: '/wc/store/v1/cart', queryCount: 14, queryTimeMs: 22.5, totalQueries: 40 },
+		{ method: 'GET', route: '/wc/store/v1/cart', queryCount: 14, queryTimeMs: 22.5, totalQueries: 40, top_query_shapes: [
+			{ sql: 'SELECT * FROM wp_posts WHERE ID = ?', count: 3, time_ms: 12.25 },
+			{ sql: 'SELECT * FROM wp_postmeta WHERE post_id IN (?)', count: 7, time_ms: 8.5 },
+		] },
 		{ method: 'GET', route: '/demo/v1/private', query_count: 1, query_time_ms: 1.25 },
 	],
 	budgets: {
@@ -159,6 +162,10 @@ assert.deepEqual(artifact.routes.find((row) => row.id === 'rest:get:wc-store-v1-
 	queryCount: 14,
 	queryTimeMs: 22.5,
 	totalQueries: 40,
+	topQueryShapes: [
+		{ sql: 'SELECT * FROM wp_posts WHERE ID = ?', count: 3, timeMs: 12.25 },
+		{ sql: 'SELECT * FROM wp_postmeta WHERE post_id IN (?)', count: 7, timeMs: 8.5 },
+	],
 });
 assert.equal(artifact.coverage.byNamespace['wc/store/v1'].total, 2);
 assert.equal(artifact.coverage.byNamespace['wc/store/v1'].covered, 2);
@@ -199,6 +206,8 @@ assert.match(markdown, /\| wc\/store\/v1 \| 2 \| 2 \| 0 \|/);
 assert.match(markdown, /## Slowest routes by duration/);
 assert.match(markdown, /`GET \/wc\/store\/v1\/cart` \| 200 \| 95 \| 14/);
 assert.match(markdown, /## Slowest routes by query time/);
+assert.match(markdown, /## Top DB query shapes by REST case/);
+assert.match(markdown, /SELECT \* FROM wp_posts WHERE ID = \?/);
 assert.match(markdown, /## Missing or uncovered routes/);
 assert.match(markdown, /`GET \/wp\/v2\/posts\/\{id\}`/);
 assert.match(markdown, /## Budget findings/);
@@ -214,6 +223,7 @@ assert.deepEqual(normalizeRestDbProfile({ method: 'get', route: '/wp-json/wp/v2/
 	queryCount: undefined,
 	queryTimeMs: 3.5,
 	totalQueries: undefined,
+	topQueryShapes: [],
 });
 
 const budgetManifest = normalizeRestRouteMatrixBudgetManifest({


### PR DESCRIPTION
## Summary
- Emit top normalized DB query shapes for each REST request case in the REST DB query profiler.
- Preserve query-shape data in REST route matrix rows and `dbProfile` metadata.
- Add a Markdown section for top DB query shapes by REST case.

## Why
Full-surface API profiling currently reports route status and aggregate query counts/timing, but not the SQL shapes responsible for those numbers. This keeps the WordPress extension generic while making REST slow-path output actionable.

## Testing
- `npm run test:rest-db-query-profiler`
- `npm run test:rest-route-matrix`
- `npm run test:rest-request-case-generation`
- PHP syntax check for generated `homeboy-rest-db-query-profiler.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Analysis, implementation, test drafting, and PR description drafting.
