### PR TITLE
Add WordPress fuzz coverage primitives

### DIFF
--- a/wordpress/lib/rest-route-matrix.js
+++ b/wordpress/lib/rest-route-matrix.js
@@ -5,7 +5,7 @@
  */
 const { isPlainObject } = require('./shared');
 
-const DEFAULT_METHODS = Object.freeze(['GET']);
+const SAFE_REST_REQUEST_METHODS = Object.freeze(['GET', 'HEAD', 'OPTIONS']);
 const DEFAULT_ARG_LIMIT = 12;
 const DEFAULT_SCHEMA_PROPERTY_LIMIT = 12;
 const DEFAULT_REST_REQUEST_CASE_LIMIT = 24;
@@ -28,8 +28,19 @@ function normalizeStringList(value) {
 }
 
 function normalizeMethodFilter(value) {
-	const methods = normalizeStringList(value === undefined ? DEFAULT_METHODS : value).map(normalizeRestRouteMethod);
-	return new Set(methods.length > 0 ? methods : DEFAULT_METHODS);
+	if (value === undefined || value === null || value === '') {
+		return null;
+	}
+	const methods = normalizeStringList(value).map(normalizeRestRouteMethod);
+	return new Set(methods);
+}
+
+function normalizeRequestMethodFilter(options = {}) {
+	if (options.methods !== undefined || options.method !== undefined) {
+		const methods = normalizeMethodFilter(options.methods ?? options.method);
+		return methods ? [...methods] : [...SAFE_REST_REQUEST_METHODS];
+	}
+	return [...SAFE_REST_REQUEST_METHODS];
 }
 
 function routeNamespace(routeKey, route = {}) {
@@ -117,6 +128,17 @@ function statusKey(status) {
 	return status === undefined || status === null || status === '' ? 'unknown' : String(status);
 }
 
+function authCoverageKey(entry = {}) {
+	const value = entry.authCoverage ?? entry.auth_coverage ?? entry.auth ?? entry.authenticated ?? entry.isAuthenticated ?? entry.is_authenticated;
+	if (value === undefined || value === null || value === '') {
+		return 'unknown';
+	}
+	if (typeof value === 'boolean') {
+		return value ? 'authenticated' : 'anonymous';
+	}
+	return String(value).trim() || 'unknown';
+}
+
 function stripRestBase(value) {
 	let raw = String(value || '').trim();
 	if (!raw) {
@@ -199,6 +221,7 @@ function normalizeRestMatrixResult(entry = {}) {
 		queryCount,
 		queryTimeMs,
 		responseBytes,
+		authCoverage: authCoverageKey(entry),
 		covered,
 		findings: Array.isArray(entry.findings) ? entry.findings : [],
 	};
@@ -223,6 +246,7 @@ function normalizeRestDbProfile(entry = {}) {
 		queryCount: maybeNumericValue(entry.queryCount ?? entry.query_count ?? entry.dbQueryCount ?? entry.db_query_count),
 		queryTimeMs: maybeNumericValue(entry.queryTimeMs ?? entry.query_time_ms ?? entry.dbQueryTimeMs ?? entry.db_query_time_ms),
 		totalQueries: maybeNumericValue(entry.totalQueries ?? entry.total_queries),
+		authCoverage: authCoverageKey(entry),
 		topQueryShapes,
 	};
 }
@@ -265,6 +289,7 @@ function mergeRestDbProfile(row, profile) {
 		durationMs: row.durationMs ?? profile.durationMs,
 		queryCount: row.queryCount ?? profile.queryCount,
 		queryTimeMs: row.queryTimeMs ?? profile.queryTimeMs,
+		authCoverage: !row.authCoverage || row.authCoverage === 'unknown' ? profile.authCoverage : row.authCoverage,
 		topQueryShapes: row.topQueryShapes?.length ? row.topQueryShapes : profile.topQueryShapes,
 		dbProfile: {
 			queryCount: profile.queryCount,
@@ -291,6 +316,28 @@ function incrementCoverage(group, name, covered) {
 
 function sortedCoverageObject(group) {
 	return Object.fromEntries(Object.entries(group).sort(([a], [b]) => sortText(a, b)));
+}
+
+function sortedNestedCoverageObject(group) {
+	return Object.fromEntries(Object.entries(group).sort(([a], [b]) => sortText(a, b)).map(([key, row]) => [
+		key,
+		{
+			total: row.total,
+			covered: row.covered,
+			uncovered: row.uncovered,
+			methods: sortedCoverageObject(row.methods),
+			statuses: sortedCoverageObject(row.statuses),
+			auth: sortedCoverageObject(row.auth),
+		},
+	]));
+}
+
+function ensureRouteCoverage(group, name) {
+	const key = name || 'unknown';
+	if (!group[key]) {
+		group[key] = { total: 0, covered: 0, uncovered: 0, methods: {}, statuses: {}, auth: {} };
+	}
+	return group[key];
 }
 
 function normalizeAllowedStatuses(value) {
@@ -501,24 +548,62 @@ function buildRestRouteMatrixArtifact(input = {}, options = {}) {
 	const byNamespace = {};
 	const byMethod = {};
 	const byStatus = {};
+	const byAuth = {};
+	const byRoute = {};
+	const byRouteDetails = {};
 	const budgetFindings = [];
 	const missingRoutes = [];
 	const uncoveredRoutes = [];
+	const coverageGaps = [];
 
 	for (const row of rows) {
 		incrementCoverage(byNamespace, row.namespace, row.covered);
 		incrementCoverage(byMethod, row.method, row.covered);
+		incrementCoverage(byRoute, row.path || row.route || row.id, row.covered);
+		incrementCoverage(byAuth, row.authCoverage, row.covered);
+		const routeCoverage = ensureRouteCoverage(byRouteDetails, row.path || row.route || row.id);
+		routeCoverage.total += 1;
+		if (row.covered) {
+			routeCoverage.covered += 1;
+		} else {
+			routeCoverage.uncovered += 1;
+		}
+		incrementCoverage(routeCoverage.methods, row.method, row.covered);
+		incrementCoverage(routeCoverage.auth, row.authCoverage, row.covered);
 		if (row.covered) {
 			incrementCoverage(byStatus, statusKey(row.status), true);
+			incrementCoverage(routeCoverage.statuses, statusKey(row.status), true);
 		} else {
 			missingRoutes.push(row);
 			uncoveredRoutes.push(row);
+			coverageGaps.push({
+				type: 'unexercised_route_method',
+				id: row.id,
+				method: row.method,
+				path: row.path,
+				route: row.route,
+				namespace: row.namespace,
+				message: `${row.method} ${row.path || row.route || row.id} was discovered but not exercised`,
+			});
 		}
 		for (const finding of row.findings || []) {
 			budgetFindings.push({ id: row.id, method: row.method, path: row.path, namespace: row.namespace, ...finding });
 		}
 		budgetFindings.push(...restMatrixBudgetFindings(row, resolveRestRouteMatrixBudgets(row, budgetManifest)));
 	}
+
+	const topQueryShapesByRoute = rows
+		.filter((row) => Array.isArray(row.topQueryShapes) && row.topQueryShapes.length > 0)
+		.map((row) => ({
+			id: row.id,
+			method: row.method,
+			path: row.path,
+			route: row.route,
+			queryCount: row.queryCount,
+			queryTimeMs: row.queryTimeMs,
+			topQueryShapes: row.topQueryShapes,
+		}))
+		.sort((a, b) => numericValue(b.queryTimeMs) - numericValue(a.queryTimeMs) || numericValue(b.queryCount) - numericValue(a.queryCount) || sortText(a.id, b.id));
 
 	const slowestByDuration = rows
 		.filter((row) => row.durationMs !== undefined)
@@ -549,10 +634,15 @@ function buildRestRouteMatrixArtifact(input = {}, options = {}) {
 			byNamespace: sortedCoverageObject(byNamespace),
 			byMethod: sortedCoverageObject(byMethod),
 			byStatus: sortedCoverageObject(byStatus),
+			byAuth: sortedCoverageObject(byAuth),
+			byRoute: sortedCoverageObject(byRoute),
+			byRouteDetails: sortedNestedCoverageObject(byRouteDetails),
 		},
+		topQueryShapesByRoute,
 		slowestByDuration,
 		slowestByQueryCount,
 		slowestByQueryTime,
+		coverageGaps: coverageGaps.sort((a, b) => sortText(a.id, b.id)),
 		missingRoutes: missingRoutes.sort((a, b) => sortText(a.id, b.id)),
 		uncoveredRoutes: uncoveredRoutes.sort((a, b) => sortText(a.id, b.id)),
 		budgetFindings: budgetFindings.sort((a, b) => sortText(a.id, b.id) || sortText(a.type, b.type)),
@@ -621,6 +711,10 @@ function formatRestRouteMatrixMarkdownReport(input = {}, options = {}) {
 		'## Coverage by status',
 		'',
 		...formatCoverageTable(artifact.coverage.byStatus, 'Status'),
+		'',
+		'## Coverage by auth',
+		'',
+		...formatCoverageTable(artifact.coverage.byAuth, 'Auth'),
 	];
 
 	if (artifact.slowestByDuration.length > 0) {
@@ -632,8 +726,11 @@ function formatRestRouteMatrixMarkdownReport(input = {}, options = {}) {
 	if (artifact.slowestByQueryTime.length > 0) {
 		lines.push('', '## Slowest routes by query time', '', ...formatRouteRows(artifact.slowestByQueryTime, { limit }));
 	}
-	if (artifact.routes.some((row) => Array.isArray(row.topQueryShapes) && row.topQueryShapes.length > 0)) {
-		lines.push('', '## Top DB query shapes by REST case', '', ...formatQueryShapeRows(artifact.slowestByQueryTime, { limit }));
+	if (artifact.topQueryShapesByRoute?.length > 0) {
+		lines.push('', '## Top DB query shapes by REST case', '', ...formatQueryShapeRows(artifact.topQueryShapesByRoute, { limit }));
+	}
+	if (artifact.coverageGaps?.length > 0) {
+		lines.push('', '## Coverage gaps', '', ...formatRouteRows(artifact.coverageGaps, { limit }));
 	}
 	if (artifact.uncoveredRoutes.length > 0) {
 		lines.push('', '## Missing or uncovered routes', '', ...formatRouteRows(artifact.uncoveredRoutes, { limit }));
@@ -784,6 +881,13 @@ function routeArgsForMethod(route = {}, method) {
 			argsByName.set(name, arg);
 		}
 	}
+	if (argsByName.size === 0 && SAFE_REST_REQUEST_METHODS.includes(normalizeRestRouteMethod(method))) {
+		for (const endpoint of route.endpoints || []) {
+			for (const [name, arg] of Object.entries(endpoint?.args || {})) {
+				argsByName.set(name, arg);
+			}
+		}
+	}
 	return [...argsByName.entries()].sort(([a], [b]) => a.localeCompare(b));
 }
 
@@ -868,8 +972,9 @@ function splitArgsByLocation(routeKey, args) {
 function buildRequestCase(matrixEntry, variant, values = {}, metadata = {}) {
 	const path = applyPathParams(matrixEntry.path, values.pathParams);
 	const method = normalizeRestRouteMethod(matrixEntry.method);
-	const query = method === 'GET' || method === 'DELETE' ? values.args || {} : {};
-	const body = method === 'GET' || method === 'DELETE' ? undefined : values.args || {};
+	const usesQuery = SAFE_REST_REQUEST_METHODS.includes(method) || method === 'DELETE';
+	const query = usesQuery ? values.args || {} : {};
+	const body = usesQuery ? undefined : values.args || {};
 	const { parts, ...caseMetadata } = metadata;
 	return {
 		id: caseKey(matrixEntry.id, variant, parts || []),
@@ -996,7 +1101,10 @@ function generateWordPressRestRequestCasesForEntry(matrixEntry, route = {}, opti
 
 function generateWordPressRestRequestCases(input, options = {}) {
 	const routes = extractRestRoutes(input);
-	const matrix = normalizeWordPressRestRouteMatrix(input, options);
+	const matrix = normalizeWordPressRestRouteMatrix(input, {
+		...options,
+		methods: normalizeRequestMethodFilter(options),
+	});
 	const maxCases = normalizeCaseLimit(options.maxCases);
 	const cases = [];
 
@@ -1034,7 +1142,7 @@ function normalizeWordPressRestRouteMatrix(input, options = {}) {
 			continue;
 		}
 		const classification = classifyRestRoute(normalizedRoute, route);
-		const routeMethods = normalizeRouteMethods(route).filter((method) => methodFilter.has(method));
+		const routeMethods = normalizeRouteMethods(route).filter((method) => !methodFilter || methodFilter.has(method));
 		for (const method of routeMethods) {
 			const id = restRouteMatrixKey({ method, route: normalizedRoute });
 			cases.push({

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -88,6 +88,7 @@
     "test:wordpress-bench-state-sampling": "php tests/wordpress-bench-state-sampling-helper-smoke.php",
     "test:wordpress-bench-artifacts": "php tests/wordpress-bench-artifact-helper-smoke.php",
     "test:wordpress-bench-woocommerce-fixtures": "php tests/wordpress-bench-woocommerce-fixtures-smoke.php",
+    "test:wordpress-fuzz-coverage": "php tests/wordpress-fuzz-coverage-helper-smoke.php",
     "test:wordpress-db-query-profiler": "php scripts/bench/wordpress-db-query-profiler-smoke.php",
     "test:audit-wp-codebox-fanout": "node tests/audit-wp-codebox-fanout-smoke.js",
     "test:audit-wp-codebox-execute": "node tests/audit-wp-codebox-fanout-smoke.js",

--- a/wordpress/scripts/bench/lib/wordpress-fuzz-coverage.php
+++ b/wordpress/scripts/bench/lib/wordpress-fuzz-coverage.php
@@ -1,0 +1,392 @@
+<?php
+/**
+ * Generic WordPress fuzz/workload coverage instrumentation helpers.
+ *
+ * Workloads can require this file from the mounted extension path:
+ * /homeboy-extension/scripts/bench/lib/wordpress-fuzz-coverage.php
+ */
+
+require_once __DIR__ . '/wordpress-db-query-profiler.php';
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_start' ) ) {
+	/**
+	 * Start collecting coverage counters for a workload/request batch.
+	 *
+	 * @param string              $label Coverage label.
+	 * @param array<string,mixed> $options Coverage options.
+	 * @return array<string,mixed>
+	 */
+	function homeboy_wordpress_bench_coverage_start( string $label = '', array $options = array() ): array {
+		if ( isset( $GLOBALS['homeboy_wordpress_bench_coverage_state']['active'] ) ) {
+			homeboy_wordpress_bench_coverage_stop();
+		}
+
+		$state = array(
+			'label'              => $label,
+			'options'            => $options,
+			'started_at_unix_ms' => (int) floor( microtime( true ) * 1000 ),
+			'started_at'         => microtime( true ),
+			'all_hooks'          => array(),
+			'actions_before'     => homeboy_wordpress_bench_coverage_wp_actions_snapshot(),
+			'table_counts_before'=> homeboy_wordpress_bench_coverage_table_counts( $options ),
+			'php_errors'         => array(),
+			'previous_error_handler' => null,
+		);
+
+		$GLOBALS['homeboy_wordpress_bench_coverage_state'] = array( 'active' => $state );
+
+		if ( function_exists( 'add_filter' ) ) {
+			add_filter( 'all', 'homeboy_wordpress_bench_coverage_record_hook', PHP_INT_MIN, 0 );
+		}
+
+		$GLOBALS['homeboy_wordpress_bench_coverage_state']['active']['previous_error_handler'] = set_error_handler( 'homeboy_wordpress_bench_coverage_record_php_error' );
+		homeboy_wordpress_bench_query_profiler_start( $label, $options );
+
+		return array(
+			'schema'             => 'homeboy/wordpress-fuzz-coverage/v1',
+			'label'              => $label,
+			'active'             => true,
+			'started_at_unix_ms' => (int) $GLOBALS['homeboy_wordpress_bench_coverage_state']['active']['started_at_unix_ms'],
+		);
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_stop' ) ) {
+	/**
+	 * Stop collecting coverage counters and return the final snapshot.
+	 *
+	 * @return array<string,mixed>
+	 */
+	function homeboy_wordpress_bench_coverage_stop(): array {
+		$profile = homeboy_wordpress_bench_coverage_snapshot();
+		homeboy_wordpress_bench_query_profiler_stop();
+
+		if ( function_exists( 'remove_filter' ) ) {
+			remove_filter( 'all', 'homeboy_wordpress_bench_coverage_record_hook', PHP_INT_MIN );
+		}
+
+		if ( isset( $GLOBALS['homeboy_wordpress_bench_coverage_state']['active'] ) ) {
+			restore_error_handler();
+		}
+
+		unset( $GLOBALS['homeboy_wordpress_bench_coverage_state']['active'] );
+
+		return $profile;
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_profile_call' ) ) {
+	/**
+	 * Profile a callable and return its result with coverage evidence.
+	 *
+	 * @param string              $label Coverage label.
+	 * @param callable            $callback Workload callback.
+	 * @param array<string,mixed> $options Coverage options.
+	 * @return array{result:mixed,coverage:array<string,mixed>}
+	 */
+	function homeboy_wordpress_bench_coverage_profile_call( string $label, callable $callback, array $options = array() ): array {
+		homeboy_wordpress_bench_coverage_start( $label, $options );
+		try {
+			$result = $callback();
+		} finally {
+			$coverage = homeboy_wordpress_bench_coverage_stop();
+		}
+
+		return array(
+			'result'   => $result,
+			'coverage' => $coverage,
+		);
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_snapshot' ) ) {
+	/**
+	 * Return the current coverage snapshot with deterministic top-N truncation.
+	 *
+	 * @return array<string,mixed>
+	 */
+	function homeboy_wordpress_bench_coverage_snapshot(): array {
+		$state = $GLOBALS['homeboy_wordpress_bench_coverage_state']['active'] ?? null;
+		if ( ! is_array( $state ) ) {
+			return array(
+				'label'  => '',
+				'active' => false,
+			);
+		}
+
+		$options       = is_array( $state['options'] ?? null ) ? $state['options'] : array();
+		$top           = isset( $options['top'] ) && is_numeric( $options['top'] ) ? max( 1, (int) $options['top'] ) : 30;
+		$actions_after = homeboy_wordpress_bench_coverage_wp_actions_snapshot();
+		$actions       = homeboy_wordpress_bench_coverage_count_deltas( $state['actions_before'], $actions_after );
+		$all_hooks     = $state['all_hooks'];
+		$filters       = homeboy_wordpress_bench_coverage_infer_filter_counts( $all_hooks, $actions );
+		$query_profile = homeboy_wordpress_bench_query_profiler_snapshot();
+		$table_after   = homeboy_wordpress_bench_coverage_table_counts( $options );
+
+		return array(
+			'schema'              => 'homeboy/wordpress-fuzz-coverage/v1',
+			'label'               => (string) $state['label'],
+			'active'              => true,
+			'started_at_unix_ms'  => (int) $state['started_at_unix_ms'],
+			'elapsed_ms'          => max( 0, ( microtime( true ) - (float) $state['started_at'] ) * 1000 ),
+			'hooks'               => array(
+				'all'     => homeboy_wordpress_bench_query_profiler_top_counts( $all_hooks, $top ),
+				'actions' => homeboy_wordpress_bench_query_profiler_top_counts( $actions, $top ),
+				'filters' => homeboy_wordpress_bench_query_profiler_top_counts( $filters, $top ),
+			),
+			'db'                  => array(
+				'query_count'      => (int) ( $query_profile['query_count'] ?? 0 ),
+				'operations'       => $query_profile['operations'] ?? array(),
+				'tables'           => $query_profile['tables'] ?? array(),
+				'categories'       => $query_profile['categories'] ?? array(),
+				'top_query_shapes' => $query_profile['signatures'] ?? array(),
+			),
+			'mutations'           => homeboy_wordpress_bench_coverage_mutation_summary( $state['table_counts_before'], $table_after, $query_profile ),
+			'php_errors'          => homeboy_wordpress_bench_coverage_php_error_summary( $state['php_errors'], $top ),
+			'coverage_gaps'       => homeboy_wordpress_bench_coverage_gaps(),
+		);
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_record_hook' ) ) {
+	/** Record the currently executing hook from WordPress' synthetic all hook. */
+	function homeboy_wordpress_bench_coverage_record_hook(): void {
+		if ( empty( $GLOBALS['homeboy_wordpress_bench_coverage_state']['active'] ) ) {
+			return;
+		}
+
+		$hook = function_exists( 'current_filter' ) ? (string) current_filter() : '';
+		if ( '' === $hook || 'all' === $hook ) {
+			return;
+		}
+
+		$state =& $GLOBALS['homeboy_wordpress_bench_coverage_state']['active'];
+		homeboy_wordpress_bench_query_profiler_increment( $state['all_hooks'], $hook );
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_record_php_error' ) ) {
+	/**
+	 * Temporary error handler that summarizes non-fatal PHP issues.
+	 *
+	 * @param int    $severity PHP error severity.
+	 * @param string $message Error message.
+	 * @param string $file Error file.
+	 * @param int    $line Error line.
+	 * @return bool
+	 */
+	function homeboy_wordpress_bench_coverage_record_php_error( int $severity, string $message, string $file = '', int $line = 0 ): bool {
+		if ( 0 === ( error_reporting() & $severity ) ) {
+			return false;
+		}
+
+		if ( ! empty( $GLOBALS['homeboy_wordpress_bench_coverage_state']['active'] ) ) {
+			$state =& $GLOBALS['homeboy_wordpress_bench_coverage_state']['active'];
+			$kind   = homeboy_wordpress_bench_coverage_error_kind( $severity );
+			$key    = $kind . ':' . $message;
+			if ( ! isset( $state['php_errors'][ $key ] ) ) {
+				$state['php_errors'][ $key ] = array(
+					'kind'     => $kind,
+					'severity' => $severity,
+					'message'  => $message,
+					'file'     => $file,
+					'line'     => $line,
+					'count'    => 0,
+				);
+			}
+			++$state['php_errors'][ $key ]['count'];
+		}
+
+		$previous = $GLOBALS['homeboy_wordpress_bench_coverage_state']['active']['previous_error_handler'] ?? null;
+		if ( is_callable( $previous ) ) {
+			return (bool) $previous( $severity, $message, $file, $line );
+		}
+
+		return false;
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_wp_actions_snapshot' ) ) {
+	/** @return array<string,int> */
+	function homeboy_wordpress_bench_coverage_wp_actions_snapshot(): array {
+		$actions = $GLOBALS['wp_actions'] ?? array();
+		return is_array( $actions ) ? array_map( 'intval', $actions ) : array();
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_count_deltas' ) ) {
+	/**
+	 * @param array<string,int> $before Earlier counts.
+	 * @param array<string,int> $after Later counts.
+	 * @return array<string,int>
+	 */
+	function homeboy_wordpress_bench_coverage_count_deltas( array $before, array $after ): array {
+		$deltas = array();
+		foreach ( array_unique( array_merge( array_keys( $before ), array_keys( $after ) ) ) as $key ) {
+			$delta = (int) ( $after[ $key ] ?? 0 ) - (int) ( $before[ $key ] ?? 0 );
+			if ( 0 !== $delta ) {
+				$deltas[ $key ] = $delta;
+			}
+		}
+
+		return $deltas;
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_infer_filter_counts' ) ) {
+	/**
+	 * @param array<string,int> $all_hooks Hooks observed through the all hook.
+	 * @param array<string,int> $actions Action deltas from wp_actions.
+	 * @return array<string,int>
+	 */
+	function homeboy_wordpress_bench_coverage_infer_filter_counts( array $all_hooks, array $actions ): array {
+		$filters = array();
+		foreach ( $all_hooks as $hook => $count ) {
+			$filter_count = (int) $count - (int) ( $actions[ $hook ] ?? 0 );
+			if ( $filter_count > 0 ) {
+				$filters[ $hook ] = $filter_count;
+			}
+		}
+
+		return $filters;
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_table_counts' ) ) {
+	/**
+	 * @param array<string,mixed> $options Coverage options.
+	 * @return array<string,int>
+	 */
+	function homeboy_wordpress_bench_coverage_table_counts( array $options ): array {
+		global $wpdb;
+
+		$tables = $options['mutation_tables'] ?? null;
+		if ( null === $tables ) {
+			$tables = homeboy_wordpress_bench_coverage_default_tables();
+		}
+
+		if ( ! is_array( $tables ) || ! isset( $wpdb ) ) {
+			return array();
+		}
+
+		$resolved = array();
+		foreach ( $tables as $label => $table ) {
+			$table_name = is_string( $table ) ? $table : '';
+			if ( '' === $table_name ) {
+				continue;
+			}
+			$key              = is_string( $label ) ? $label : homeboy_wordpress_bench_query_profiler_table_key( $table_name );
+			$resolved[ $key ] = $table_name;
+		}
+
+		return homeboy_wordpress_bench_query_profiler_table_counts( $resolved );
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_default_tables' ) ) {
+	/** @return array<string,string> */
+	function homeboy_wordpress_bench_coverage_default_tables(): array {
+		global $wpdb;
+
+		if ( ! isset( $wpdb ) ) {
+			return array();
+		}
+
+		$properties = array( 'posts', 'postmeta', 'options', 'terms', 'term_taxonomy', 'term_relationships', 'comments', 'commentmeta', 'users', 'usermeta' );
+		$tables     = array();
+		foreach ( $properties as $property ) {
+			if ( isset( $wpdb->{$property} ) && is_string( $wpdb->{$property} ) && '' !== $wpdb->{$property} ) {
+				$tables[ $property ] = $wpdb->{$property};
+			}
+		}
+
+		return $tables;
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_mutation_summary' ) ) {
+	/**
+	 * @param array<string,int>   $before Table counts before workload.
+	 * @param array<string,int>   $after Table counts after workload.
+	 * @param array<string,mixed> $query_profile Query profile snapshot.
+	 * @return array<string,mixed>
+	 */
+	function homeboy_wordpress_bench_coverage_mutation_summary( array $before, array $after, array $query_profile ): array {
+		$write_operations = array();
+		foreach ( array( 'insert', 'update', 'delete', 'replace', 'alter', 'create', 'drop' ) as $operation ) {
+			$count = (int) ( $query_profile['operations'][ $operation ] ?? 0 );
+			if ( $count > 0 ) {
+				$write_operations[ $operation ] = $count;
+			}
+		}
+
+		return array(
+			'table_row_deltas' => homeboy_wordpress_bench_coverage_count_deltas( $before, $after ),
+			'write_operations' => $write_operations,
+		);
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_php_error_summary' ) ) {
+	/**
+	 * @param array<string,array<string,mixed>> $errors Recorded errors.
+	 * @param int                              $top Max entries.
+	 * @return array<string,mixed>
+	 */
+	function homeboy_wordpress_bench_coverage_php_error_summary( array $errors, int $top ): array {
+		$by_kind = array();
+		foreach ( $errors as $error ) {
+			$kind = (string) ( $error['kind'] ?? 'unknown' );
+			homeboy_wordpress_bench_query_profiler_increment( $by_kind, $kind );
+		}
+
+		usort(
+			$errors,
+			static function ( array $left, array $right ): int {
+				$count_delta = (int) ( $right['count'] ?? 0 ) <=> (int) ( $left['count'] ?? 0 );
+				return 0 !== $count_delta ? $count_delta : strcmp( (string) ( $left['message'] ?? '' ), (string) ( $right['message'] ?? '' ) );
+			}
+		);
+
+		return array(
+			'total'   => array_sum( array_map( static fn( $error ): int => (int) ( $error['count'] ?? 0 ), $errors ) ),
+			'by_kind' => homeboy_wordpress_bench_query_profiler_top_counts( $by_kind, $top ),
+			'top'     => array_slice( array_values( $errors ), 0, $top ),
+		);
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_error_kind' ) ) {
+	function homeboy_wordpress_bench_coverage_error_kind( int $severity ): string {
+		$map = array(
+			E_ERROR             => 'error',
+			E_WARNING           => 'warning',
+			E_PARSE             => 'parse',
+			E_NOTICE            => 'notice',
+			E_CORE_ERROR        => 'core_error',
+			E_CORE_WARNING      => 'core_warning',
+			E_COMPILE_ERROR     => 'compile_error',
+			E_COMPILE_WARNING   => 'compile_warning',
+			E_USER_ERROR        => 'user_error',
+			E_USER_WARNING      => 'user_warning',
+			E_USER_NOTICE       => 'user_notice',
+			E_RECOVERABLE_ERROR => 'recoverable_error',
+			E_DEPRECATED        => 'deprecated',
+			E_USER_DEPRECATED   => 'user_deprecated',
+		);
+
+		return $map[ $severity ] ?? 'unknown';
+	}
+}
+
+if ( ! function_exists( 'homeboy_wordpress_bench_coverage_gaps' ) ) {
+	/** @return array<int,string> */
+	function homeboy_wordpress_bench_coverage_gaps(): array {
+		return array(
+			'Filter counts are inferred as all-hook observations minus wp_actions deltas; WordPress does not expose a wp_filters counter equivalent to wp_actions.',
+			'DB query shapes are collected through the WordPress query filter and normalized SQL signatures; they do not include external service calls or lower-level database access that bypasses wpdb.',
+			'Mutation summary combines SQL write-operation counts with configured/discovered table row-count deltas; it does not prove semantic object-level changes.',
+			'PHP fatal errors that stop execution before the wrapper can unwind cannot be summarized in the returned coverage payload.',
+		);
+	}
+}

--- a/wordpress/tests/rest-request-case-generation-smoke.js
+++ b/wordpress/tests/rest-request-case-generation-smoke.js
@@ -40,7 +40,7 @@ const restIndex = {
 		},
 		'/example/v1/items/(?P<id>[\\d]+)': {
 			namespace: 'example/v1',
-			methods: ['GET'],
+			methods: ['GET', 'HEAD', 'OPTIONS'],
 			endpoints: [
 				{
 					methods: ['GET'],
@@ -84,6 +84,15 @@ assert.deepEqual(pageCase.request, {
 
 const itemBaseline = getCases.find((requestCase) => requestCase.matrixId === 'rest:get:example-v1-items-id');
 assert.equal(itemBaseline.request.path, '/example/v1/items/1');
+
+const safeDefaultCases = generateWordPressRestRequestCases(restIndex, { seed: 'alpha', maxCases: 30 });
+const safeDefaultMethods = new Set(safeDefaultCases.map((requestCase) => requestCase.method));
+assert.deepEqual([...safeDefaultMethods].sort(), ['GET', 'HEAD', 'OPTIONS']);
+assert.equal(safeDefaultCases.some((requestCase) => requestCase.method === 'POST'), false);
+assert.deepEqual(safeDefaultCases.find((requestCase) => requestCase.method === 'HEAD').request, {
+	method: 'HEAD',
+	path: '/example/v1/items/1',
+});
 
 const plannedKinds = new Set(getCases[0].metadata.plannedCases.map((requestCase) => requestCase.kind));
 assert.equal(plannedKinds.has('invalid-enum'), true);

--- a/wordpress/tests/rest-route-matrix-smoke.js
+++ b/wordpress/tests/rest-route-matrix-smoke.js
@@ -71,7 +71,7 @@ const restIndex = {
 		},
 		'/demo/v1/private': {
 			namespace: 'demo/v1',
-			methods: ['GET'],
+			methods: ['GET', 'OPTIONS'],
 			endpoints: [{ methods: ['GET'], args: {} }],
 		},
 	},
@@ -108,6 +108,10 @@ assert.deepEqual(coreGetCases[0].schemaSummary.properties.map((property) => prop
 assert.equal(coreGetCases[1].path, '/wp/v2/posts/{id}');
 assert.equal(coreGetCases[1].classification.hasPathParams, true);
 
+const allDiscoveredCases = normalizeWordPressRestRouteMatrix(restIndex);
+assert.equal(allDiscoveredCases.length, 10);
+assert.equal(allDiscoveredCases.some((entry) => entry.id === 'rest:options:demo-v1-private'), true);
+
 const nonCorePostCases = normalizeWordPressRestRouteMatrix(restIndex.routes, {
 	excludeNamespaces: ['wp/v2', 'demo/v1'],
 	method: 'POST',
@@ -129,9 +133,9 @@ assert.deepEqual(schemaSummary.properties, [{ name: 'items', type: 'array' }]);
 const artifact = buildRestRouteMatrixArtifact({
 	routes: restIndex,
 	caseResults: [
-		{ method: 'GET', route: '/wp/v2/posts', status: 200, durationMs: 40, queryCount: 3 },
+		{ method: 'GET', route: '/wp/v2/posts', status: 200, durationMs: 40, queryCount: 3, authenticated: false },
 		{ method: 'GET', route: '/wc/store/v1/cart', status: 200, durationMs: 95 },
-		{ method: 'POST', route: '/wc/store/v1/cart', status: 500, durationMs: 80, queryCount: 2 },
+		{ method: 'POST', route: '/wc/store/v1/cart', status: 500, durationMs: 80, queryCount: 2, authenticated: true },
 	],
 	dbProfiles: [
 		{ method: 'GET', route: '/wc/store/v1/cart', queryCount: 14, queryTimeMs: 22.5, totalQueries: 40, top_query_shapes: [
@@ -173,6 +177,31 @@ assert.equal(artifact.coverage.byMethod.GET.total, 4);
 assert.equal(artifact.coverage.byMethod.GET.uncovered, 1);
 assert.equal(artifact.coverage.byStatus['200'].covered, 2);
 assert.equal(artifact.coverage.byStatus['500'].covered, 1);
+assert.equal(artifact.coverage.byAuth.anonymous.covered, 1);
+assert.equal(artifact.coverage.byAuth.authenticated.covered, 1);
+assert.equal(artifact.coverage.byRoute['/wc/store/v1/cart'].covered, 2);
+assert.deepEqual(artifact.coverage.byRouteDetails['/wc/store/v1/cart'], {
+	total: 2,
+	covered: 2,
+	uncovered: 0,
+	methods: {
+		GET: { total: 1, covered: 1, uncovered: 0 },
+		POST: { total: 1, covered: 1, uncovered: 0 },
+	},
+	statuses: {
+		200: { total: 1, covered: 1, uncovered: 0 },
+		500: { total: 1, covered: 1, uncovered: 0 },
+	},
+	auth: {
+		authenticated: { total: 1, covered: 1, uncovered: 0 },
+		unknown: { total: 1, covered: 1, uncovered: 0 },
+	},
+});
+assert.deepEqual(artifact.coverageGaps.map((gap) => gap.id), [
+	'rest:get:wp-v2-posts-id',
+	'rest:post:wp-v2-posts',
+]);
+assert.equal(artifact.topQueryShapesByRoute[0].id, 'rest:get:wc-store-v1-cart');
 assert.deepEqual(artifact.slowestByDuration.map((row) => row.id), [
 	'rest:get:wc-store-v1-cart',
 	'rest:post:wc-store-v1-cart',
@@ -203,11 +232,13 @@ assert.match(markdown, /## WordPress REST route matrix/);
 assert.match(markdown, /Routes: 6; results: 3; covered: 4; uncovered: 2; budget findings: 3/);
 assert.match(markdown, /## Coverage by namespace/);
 assert.match(markdown, /\| wc\/store\/v1 \| 2 \| 2 \| 0 \|/);
+assert.match(markdown, /## Coverage by auth/);
 assert.match(markdown, /## Slowest routes by duration/);
 assert.match(markdown, /`GET \/wc\/store\/v1\/cart` \| 200 \| 95 \| 14/);
 assert.match(markdown, /## Slowest routes by query time/);
 assert.match(markdown, /## Top DB query shapes by REST case/);
 assert.match(markdown, /SELECT \* FROM wp_posts WHERE ID = \?/);
+assert.match(markdown, /## Coverage gaps/);
 assert.match(markdown, /## Missing or uncovered routes/);
 assert.match(markdown, /`GET \/wp\/v2\/posts\/\{id\}`/);
 assert.match(markdown, /## Budget findings/);
@@ -223,6 +254,7 @@ assert.deepEqual(normalizeRestDbProfile({ method: 'get', route: '/wp-json/wp/v2/
 	queryCount: undefined,
 	queryTimeMs: 3.5,
 	totalQueries: undefined,
+	authCoverage: 'unknown',
 	topQueryShapes: [],
 });
 

--- a/wordpress/tests/wordpress-fuzz-coverage-helper-smoke.php
+++ b/wordpress/tests/wordpress-fuzz-coverage-helper-smoke.php
@@ -1,0 +1,153 @@
+<?php
+/** Smoke test for generic WordPress fuzz coverage helpers. */
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
+		unset( $hook_name, $callback, $priority, $accepted_args );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'remove_filter' ) ) {
+	function remove_filter( $hook_name, $callback, $priority = 10 ) {
+		unset( $hook_name, $callback, $priority );
+		return true;
+	}
+}
+
+if ( ! function_exists( 'current_filter' ) ) {
+	function current_filter() {
+		return $GLOBALS['homeboy_wordpress_bench_coverage_smoke_current_hook'] ?? '';
+	}
+}
+
+if ( ! function_exists( 'esc_sql' ) ) {
+	function esc_sql( $value ) {
+		return str_replace( '`', '', (string) $value );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, $flags = 0 ) {
+		return json_encode( $value, $flags ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- WordPress is stubbed in this smoke.
+	}
+}
+
+class Homeboy_WordPress_Bench_Coverage_WPDB {
+	public string $prefix   = 'wp_';
+	public string $posts    = 'wp_posts';
+	public string $postmeta = 'wp_postmeta';
+	public string $options  = 'wp_options';
+	public int $num_queries = 0;
+
+	/** @var array<string,int> */
+	public array $counts = array(
+		'wp_posts'    => 2,
+		'wp_postmeta' => 4,
+		'wp_options'  => 8,
+	);
+
+	public function prepare( string $query, ...$args ): string {
+		foreach ( $args as $arg ) {
+			$query = preg_replace( '/%s|%d/', "'" . (string) $arg . "'", $query, 1 );
+		}
+
+		return $query;
+	}
+
+	public function get_var( string $query ) {
+		++$this->num_queries;
+		if ( preg_match( "/SHOW TABLES LIKE '([^']+)'/", $query, $match ) ) {
+			return array_key_exists( $match[1], $this->counts ) ? $match[1] : null;
+		}
+		if ( preg_match( '/SELECT COUNT\(\*\) FROM `([^`]+)`/', $query, $match ) ) {
+			return (string) ( $this->counts[ $match[1] ] ?? 0 );
+		}
+
+		return null;
+	}
+}
+
+function homeboy_wordpress_bench_coverage_smoke_fire_action( string $hook ): void {
+	$GLOBALS['wp_actions'][ $hook ] = (int) ( $GLOBALS['wp_actions'][ $hook ] ?? 0 ) + 1;
+	$GLOBALS['homeboy_wordpress_bench_coverage_smoke_current_hook'] = $hook;
+	homeboy_wordpress_bench_coverage_record_hook();
+	$GLOBALS['homeboy_wordpress_bench_coverage_smoke_current_hook'] = '';
+}
+
+function homeboy_wordpress_bench_coverage_smoke_apply_filter( string $hook ): void {
+	$GLOBALS['homeboy_wordpress_bench_coverage_smoke_current_hook'] = $hook;
+	homeboy_wordpress_bench_coverage_record_hook();
+	$GLOBALS['homeboy_wordpress_bench_coverage_smoke_current_hook'] = '';
+}
+
+$GLOBALS['wpdb']      = new Homeboy_WordPress_Bench_Coverage_WPDB();
+$GLOBALS['wp_actions'] = array( 'init' => 3 );
+
+set_error_handler(
+	static function () {
+		return true;
+	}
+);
+
+require_once __DIR__ . '/../scripts/bench/lib/wordpress-fuzz-coverage.php';
+
+$profiled = homeboy_wordpress_bench_coverage_profile_call(
+	'smoke-fuzz-batch',
+	static function () {
+		homeboy_wordpress_bench_coverage_smoke_fire_action( 'init' );
+		homeboy_wordpress_bench_coverage_smoke_fire_action( 'save_post' );
+		homeboy_wordpress_bench_coverage_smoke_apply_filter( 'the_content' );
+		homeboy_wordpress_bench_coverage_smoke_apply_filter( 'the_content' );
+
+		$queries = array(
+			"SELECT ID FROM wp_posts WHERE post_name = 'sample' LIMIT 1",
+			"INSERT INTO wp_posts (post_title, post_status) VALUES ('Sample', 'draft')",
+			"UPDATE wp_options SET option_value = '1' WHERE option_name = 'sample_option'",
+		);
+
+		foreach ( $queries as $query ) {
+			++$GLOBALS['wpdb']->num_queries;
+			homeboy_wordpress_bench_query_profiler_record_query( $query );
+		}
+
+		$GLOBALS['wpdb']->counts['wp_posts'] = 3;
+		trigger_error( 'coverage smoke notice', E_USER_NOTICE );
+
+		return 'workload-result';
+	},
+	array(
+		'top'             => 10,
+		'mutation_tables' => array(
+			'posts'   => 'wp_posts',
+			'options' => 'wp_options',
+		),
+	)
+);
+
+restore_error_handler();
+
+$coverage = $profiled['coverage'];
+
+$assert = static function ( bool $condition, string $message ) use ( $coverage ): void {
+	if ( $condition ) {
+		return;
+	}
+	fwrite( STDERR, "ERROR: {$message}\n" . wp_json_encode( $coverage, JSON_PRETTY_PRINT ) . "\n" );
+	exit( 1 );
+};
+
+$assert( 'workload-result' === $profiled['result'], 'profile_call did not return workload result' );
+$assert( 'homeboy/wordpress-fuzz-coverage/v1' === $coverage['schema'], 'coverage schema missing' );
+$assert( 1 === (int) $coverage['hooks']['actions']['init'], 'init action delta missing' );
+$assert( 1 === (int) $coverage['hooks']['actions']['save_post'], 'save_post action missing' );
+$assert( 2 === (int) $coverage['hooks']['filters']['the_content'], 'the_content inferred filter count missing' );
+$assert( 3 === (int) $coverage['db']['query_count'], 'query count missing' );
+$assert( 1 === (int) $coverage['db']['operations']['insert'], 'insert operation missing' );
+$assert( 1 === (int) $coverage['mutations']['table_row_deltas']['posts'], 'posts row delta missing' );
+$assert( 1 === (int) $coverage['mutations']['write_operations']['update'], 'update write operation missing' );
+$assert( 1 === (int) $coverage['php_errors']['total'], 'PHP notice summary missing' );
+$assert( 1 === (int) $coverage['php_errors']['by_kind']['user_notice'], 'PHP notice kind missing' );
+$assert( ! empty( $coverage['coverage_gaps'] ), 'coverage gaps should be explicit' );
+
+echo "wordpress fuzz coverage helper smoke passed\n";


### PR DESCRIPTION
## Summary
- Expand generic WordPress REST route matrix coverage to enumerate registered route methods and report route/method/auth gaps.
- Add generic fuzz coverage helper instrumentation for hooks/actions, DB query shapes, mutations, PHP warnings/notices, and explicit coverage gaps.
- Add smoke coverage for request generation, route matrix reporting, REST DB profiling, and the new fuzz coverage helper.

## Testing
- `php -l wordpress/scripts/bench/lib/wordpress-fuzz-coverage.php`
- From `wordpress/`:
- `npm run test:wordpress-fuzz-coverage`
- `npm run test:rest-route-matrix`
- `npm run test:rest-request-case-generation`
- `npm run test:rest-db-query-profiler`
- `git diff --check`

## Notes
- No local benchmarks were run.
- The helper is generic WordPress instrumentation; Woo/Gutenberg specifics stay in rigs.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Parallel code generation, review, verification orchestration, and PR description drafting.
