### PR TITLE
Accept WP Codebox binary setting

### DIFF
--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -109,6 +109,7 @@
     "test:codebox-agent-task-matrix": "node tests/codebox-agent-task-matrix-smoke.js",
     "test:wordpress-runtime-task-planner": "node tests/wordpress-runtime-task-planner-smoke.js",
     "test:wordpress-public-export-boundary": "node tests/wordpress-public-export-boundary.test.js",
+    "test:wordpress-manifest-settings": "node tests/wordpress-manifest-settings-smoke.js",
     "test:refactor-source-wp-codebox": "node tests/refactor-source-wp-codebox-smoke.js",
     "test:replay-envelope": "node tests/replay-envelope-smoke.js"
   },

--- a/wordpress/tests/wordpress-manifest-settings-smoke.js
+++ b/wordpress/tests/wordpress-manifest-settings-smoke.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const manifest = JSON.parse(
+	fs.readFileSync(path.resolve(__dirname, '..', 'wordpress.json'), 'utf8')
+);
+
+const settingIds = new Set(manifest.settings.map((setting) => setting.id));
+
+assert.ok(
+	settingIds.has('wp_codebox_bin'),
+	'wordpress manifest declares wp_codebox_bin so --setting wp_codebox_bin is accepted'
+);
+
+console.log('wordpress manifest settings smoke passed');

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1041,6 +1041,13 @@
       "description": "Component-relative path under wp_codebox_source_root used as the plugin source for WP Codebox bench prep, workload discovery, file mounts, and plugin loading. Leave empty only when HOMEBOY_COMPONENT_PATH is already under wp_codebox_source_root and the runner can derive the relative path."
     },
     {
+      "id": "wp_codebox_bin",
+      "label": "WP Codebox binary",
+      "type": "string",
+      "default": "",
+      "description": "Optional WP Codebox CLI binary path for WP Codebox-backed WordPress runtime execution. Use this to pin bench runs to a runner-local WP Codebox build with required runtime primitives. Leave empty to use HOMEBOY_WP_CODEBOX_BIN or the extension default."
+    },
+    {
       "id": "wp_codebox_scenario_manifests",
       "label": "WP Codebox scenario manifests",
       "type": "array",


### PR DESCRIPTION
## Summary
- Declare `wp_codebox_bin` in the WordPress extension manifest so Homeboy accepts `--setting wp_codebox_bin=...`.
- Add a focused smoke test that prevents the setting from being dropped as unknown.

## Test plan
- `npm run test:wordpress-manifest-settings`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Homeboy/HBX setting-contract gap, implementing the manifest/test update, and running local verification.
