### PR TITLE
Read WP Codebox binary from settings JSON

### DIFF
--- a/wordpress/lib/wp-codebox-recipe-helper.js
+++ b/wordpress/lib/wp-codebox-recipe-helper.js
@@ -15,12 +15,27 @@ const DEFAULT_EVENT_PREFIX = 'recipe';
 
 function wpCodeboxBin(options = {}) {
   const env = options.env || process.env;
+  const settings = homeboySettings(env);
   return options.wpCodeboxBin
     || options.bin
     || env.HOMEBOY_WP_CODEBOX_BIN
     || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN
+    || settings.wp_codebox_bin
     || env.WP_CODEBOX_BIN
     || 'wp-codebox';
+}
+
+function homeboySettings(env) {
+  if (!env.HOMEBOY_SETTINGS_JSON) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(env.HOMEBOY_SETTINGS_JSON);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch (_error) {
+    return {};
+  }
 }
 
 function wpCodeboxCommand(bin = wpCodeboxBin()) {
@@ -124,6 +139,7 @@ module.exports = {
   parseWpCodeboxJson,
   recipeEventName,
   runWpCodeboxRecipe,
+  homeboySettings,
   wpCodeboxBin,
   wpCodeboxCommand,
 };

--- a/wordpress/tests/wp-codebox-recipe-helper-smoke.js
+++ b/wordpress/tests/wp-codebox-recipe-helper-smoke.js
@@ -5,6 +5,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const {
+  homeboySettings,
   parseWpCodeboxJson,
   recipeEventName,
   runWpCodeboxRecipe,
@@ -34,6 +35,9 @@ fs.chmodSync(fixtureBin, 0o755);
 
 (async () => {
   assert.equal(wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_BIN: fixtureBin } }), fixtureBin);
+  assert.equal(wpCodeboxBin({ env: { HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_bin: fixtureBin }) } }), fixtureBin);
+  assert.deepEqual(homeboySettings({ HOMEBOY_SETTINGS_JSON: '{"wp_codebox_bin":"/bin/wp-codebox"}' }), { wp_codebox_bin: '/bin/wp-codebox' });
+  assert.deepEqual(homeboySettings({ HOMEBOY_SETTINGS_JSON: 'not json' }), {});
   assert.equal(wpCodeboxBin({ env: {} }), 'wp-codebox');
   assert.deepEqual(wpCodeboxCommand('/tmp/wp-codebox.cjs'), { command: process.execPath, args: ['/tmp/wp-codebox.cjs'] });
   assert.deepEqual(wpCodeboxCommand('wp-codebox'), { command: 'wp-codebox', args: [] });


### PR DESCRIPTION
## Summary
- Read `wp_codebox_bin` from `HOMEBOY_SETTINGS_JSON` in the WP Codebox recipe helper.
- Preserve existing precedence for explicit options and env vars.
- Extend the recipe-helper smoke test to cover settings JSON resolution.

## Test plan
- `npm run test:wp-codebox-recipe-helper`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the settings propagation gap, implementing the helper/test update, and running local verification.
