### PR TITLE
Normalize WP Codebox runtime outcomes

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -2386,6 +2386,32 @@ function missingRequiredTypedArtifactDiagnostic(request, outputs) {
   };
 }
 
+function outputsWithInputTypedArtifacts(outputs, request) {
+  const typedArtifacts = outputs?.typed_artifacts && typeof outputs.typed_artifacts === 'object' && !Array.isArray(outputs.typed_artifacts)
+    ? { ...outputs.typed_artifacts }
+    : {};
+  let added = false;
+  for (const declaration of requiredArtifactDeclarationsFromRequest(request)) {
+    const name = typedArtifactNameFromDeclaration(declaration);
+    if (!name || typedArtifacts[name]) {
+      continue;
+    }
+    const value = request.inputs?.[name];
+    if (value === undefined || value === null || value === '') {
+      continue;
+    }
+    typedArtifacts[name] = normalizeTypedArtifactEntry(name, {
+      name,
+      type: declaration.type || declaration.kind || declaration.artifact_type || declaration.artifactType || name,
+      artifact_schema: declaration.artifact_schema || declaration.artifactSchema || declaration.schema,
+      payload: typeof value === 'object' ? value : { content: String(value), format: 'text' },
+      metadata: { normalized_from: 'request_input' },
+    });
+    added = true;
+  }
+  return added ? { ...outputs, typed_artifacts: typedArtifacts } : outputs;
+}
+
 function typedBundleOutputArtifacts(result) {
   return Object.values(typedArtifactsFromResult(result)).flatMap((typedArtifact) => typedArtifactFileRefs(typedArtifact).map((ref, index) => {
     const fileRef = typeof ref === 'string' ? { path: ref } : ref;
@@ -2902,7 +2928,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     status = localStatus;
   }
   const failureClassification = homeboyFailureClassification(result.failure_classification || recipeSummary?.metadata?.failure_classification || runSummary?.failure_classification, status);
-  const outputs = normalizeOutputs(result, request);
+  const outputs = outputsWithInputTypedArtifacts(normalizeOutputs(result, request), request);
   const missingRequiredTypedArtifacts = missingRequiredTypedArtifactDiagnostic(request, outputs);
   const runtimeFailureDiagnostic = agentRuntimeFailureDiagnostic(result);
   if (status === 'succeeded' && missingRequiredTypedArtifacts) {

--- a/agent-runtimes/wp-codebox/lib/provider-outcome-normalizer.js
+++ b/agent-runtimes/wp-codebox/lib/provider-outcome-normalizer.js
@@ -100,14 +100,17 @@ function normalizeProviderStatus(result = {}, exitStatus = 0) {
 }
 
 function providerFailureClassification(classification, status) {
-  if (classification === 'provider' || classification === 'timeout') {
+  if (classification === 'provider' || classification === 'transient' || classification === 'timeout' || classification === 'policy_denied' || classification === 'capability_missing' || classification === 'invalid_input' || classification === 'execution_failed' || classification === 'unknown') {
     return classification;
   }
-  if (classification === 'runtime' || classification === 'task') {
+  if (classification === 'max_turns') {
+    return 'timeout';
+  }
+  if (classification === 'runtime' || classification === 'task' || classification === 'incomplete') {
     return 'execution_failed';
   }
   if (classification) {
-    return classification;
+    return 'unknown';
   }
   if (status === 'provider_error') {
     return 'provider';

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1974,6 +1974,39 @@ assert.equal(missingRequiredTypedArtifactOutcome.failure_classification, 'execut
 assert.equal(missingRequiredTypedArtifactOutcome.diagnostics[0].class, 'codebox.required_typed_artifacts_missing');
 assert.equal(missingRequiredTypedArtifactOutcome.diagnostics[0].data.missing[0].name, 'required_report');
 
+const inputBackfilledTypedArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
+  ...request,
+  task_id: 'input-backfilled-typed-artifact-task-123',
+  inputs: {
+    required_report: { review_ready: true },
+  },
+  artifact_declarations: [{
+    schema: 'wp-codebox/artifact-declaration/v1',
+    name: 'required_report',
+    type: 'RequiredReport',
+    artifact_schema: 'example/required-report/v1',
+    required: true,
+  }],
+  executor: { backend: 'codebox' },
+}, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  metadata: {
+    agent_runtime: {
+      workload: {
+        outputs: {},
+        scenarios: [{ id: 'agent-bundle', metadata: {} }],
+      },
+    },
+  },
+});
+assert.equal(inputBackfilledTypedArtifactOutcome.status, 'succeeded');
+assert.equal(inputBackfilledTypedArtifactOutcome.outputs.typed_artifacts.required_report.artifact_schema, 'example/required-report/v1');
+assert.equal(inputBackfilledTypedArtifactOutcome.outputs.typed_artifacts.required_report.payload.review_ready, true);
+assert.equal(inputBackfilledTypedArtifactOutcome.outputs.typed_artifacts.required_report.metadata.normalized_from, 'request_input');
+assert.equal(inputBackfilledTypedArtifactOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.required_typed_artifacts_missing'), false);
+
 const missingGenericRepoLoopArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
   task_id: 'missing-generic-repo-loop-artifact-task-123',

--- a/wordpress/tests/provider-outcome-normalizer.test.js
+++ b/wordpress/tests/provider-outcome-normalizer.test.js
@@ -94,6 +94,9 @@ assert.equal(normalizeAgentTaskStatus({ success: false }), 'failed');
 
 assert.equal(normalizeProviderStatus({ success: true, outcome: 'no_op' }), 'no_op');
 assert.equal(providerFailureClassification('task', 'failed'), 'execution_failed');
+assert.equal(providerFailureClassification('incomplete', 'failed'), 'execution_failed');
+assert.equal(providerFailureClassification('max_turns', 'timeout'), 'timeout');
+assert.equal(providerFailureClassification('custom-runtime-detail', 'failed'), 'unknown');
 assert.throws(() => normalizeProviderTaskOutcome({}, {}), /request.task_id/);
 
 console.log('✓ provider outcome normalizer boundary test PASSED');


### PR DESCRIPTION
## Summary
- backfill required WP Codebox typed artifact outputs from matching task inputs before missing-artifact validation
- normalize provider failure classifications to the canonical Homeboy outcome set
- add focused coverage for input backfill and failure-classification edge cases

Fixes #1610.

## Tests
- `node wordpress/tests/provider-outcome-normalizer.test.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Porting the runner-local WP Codebox outcome normalization changes into an isolated branch, adding focused tests, and preparing this PR.