### PR TITLE
Honor WP Codebox binary bench setting

### DIFF
--- a/wordpress/lib/wp-codebox-recipe-helper.js
+++ b/wordpress/lib/wp-codebox-recipe-helper.js
@@ -18,9 +18,9 @@ function wpCodeboxBin(options = {}) {
   const settings = homeboySettings(env);
   return options.wpCodeboxBin
     || options.bin
-    || env.HOMEBOY_WP_CODEBOX_BIN
-    || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN
     || settings.wp_codebox_bin
+    || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN
+    || env.HOMEBOY_WP_CODEBOX_BIN
     || env.WP_CODEBOX_BIN
     || 'wp-codebox';
 }

--- a/wordpress/scripts/lib/wp-codebox-paths.sh
+++ b/wordpress/scripts/lib/wp-codebox-paths.sh
@@ -48,10 +48,16 @@ homeboy_wp_codebox_component_relative_path() {
 homeboy_wp_codebox_resolve_bin() {
     local settings_json="${1:-${HOMEBOY_SETTINGS_JSON:-}}"
     local config_label="${2:-settings}"
-    local bin="${HOMEBOY_WP_CODEBOX_BIN:-}"
+    local bin=""
 
-    if [ -z "$bin" ] && [ -n "$settings_json" ] && [ "$settings_json" != "{}" ]; then
+    if [ -n "$settings_json" ] && [ "$settings_json" != "{}" ]; then
         bin=$(printf '%s' "$settings_json" | jq -r '.wp_codebox_bin // empty' 2>/dev/null || true)
+    fi
+    if [ -z "$bin" ]; then
+        bin="${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}"
+    fi
+    if [ -z "$bin" ]; then
+        bin="${HOMEBOY_WP_CODEBOX_BIN:-}"
     fi
 
     bin="${bin:-wp-codebox}"

--- a/wordpress/tests/wp-codebox-bench-primitive-preflight-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-primitive-preflight-smoke.js
@@ -90,6 +90,29 @@ homeboy_resolve_context() {
 	assert.match(runnerResult.stderr, /external-http-guardrail bench primitive is not available/);
 	assert.doesNotMatch(runnerResult.stderr, /process\.exit\(99\)/);
 
+	const overrideResult = spawnSync('bash', [path.join(extensionPath, 'scripts', 'bench', 'bench-runner.sh')], {
+		cwd: componentPath,
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			HOMEBOY_BENCH_EXTRA_WORKLOADS: benchWorkload,
+			HOMEBOY_BENCH_ITERATIONS: '1',
+			HOMEBOY_BENCH_RESULTS_FILE: path.join(root, 'override-results.json'),
+			HOMEBOY_BENCH_WARMUP_ITERATIONS: '0',
+			HOMEBOY_COMPONENT_ID: 'primitive-fixture',
+			HOMEBOY_COMPONENT_PATH: componentPath,
+			HOMEBOY_EXTENSION_PATH: extensionPath,
+			HOMEBOY_RUNTIME_BASH_PREFLIGHT: preflightHelper,
+			HOMEBOY_RUNTIME_BENCH_HELPER_SH: benchHelper,
+			HOMEBOY_RUNTIME_RESOLVE_CONTEXT: resolveContextHelper,
+			HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_bin: currentBin }),
+			HOMEBOY_WP_CODEBOX_BIN: staleBin,
+		},
+	});
+
+	assert.equal(overrideResult.status, 99);
+	assert.doesNotMatch(overrideResult.stderr, /external-http-guardrail bench primitive is not available/);
+
 	console.log('WP Codebox bench primitive preflight smoke passed');
 } finally {
 	fs.rmSync(root, { recursive: true, force: true });

--- a/wordpress/tests/wp-codebox-recipe-helper-smoke.js
+++ b/wordpress/tests/wp-codebox-recipe-helper-smoke.js
@@ -36,6 +36,7 @@ fs.chmodSync(fixtureBin, 0o755);
 (async () => {
   assert.equal(wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_BIN: fixtureBin } }), fixtureBin);
   assert.equal(wpCodeboxBin({ env: { HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_bin: fixtureBin }) } }), fixtureBin);
+  assert.equal(wpCodeboxBin({ env: { HOMEBOY_WP_CODEBOX_BIN: '/stale/wp-codebox', HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_bin: fixtureBin }) } }), fixtureBin);
   assert.deepEqual(homeboySettings({ HOMEBOY_SETTINGS_JSON: '{"wp_codebox_bin":"/bin/wp-codebox"}' }), { wp_codebox_bin: '/bin/wp-codebox' });
   assert.deepEqual(homeboySettings({ HOMEBOY_SETTINGS_JSON: 'not json' }), {});
   assert.equal(wpCodeboxBin({ env: {} }), 'wp-codebox');


### PR DESCRIPTION
## Summary
- Prefer explicit HOMEBOY_SETTINGS_JSON wp_codebox_bin over ambient HOMEBOY_WP_CODEBOX_BIN in WordPress WP Codebox binary resolvers.
- Cover the stale-env/new-setting bench primitive preflight path.

## Tests
- node tests/wp-codebox-recipe-helper-smoke.js
- node tests/wp-codebox-bench-primitive-preflight-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the WordPress bench WP Codebox binary resolution path, implementing the minimal resolver precedence fix, and adding focused smoke coverage.