### PR TITLE
Isolate Data Machine bundle result mapping

### DIFF
--- a/agent-runtimes/wp-codebox/lib/datamachine-agent-bundle-result.js
+++ b/agent-runtimes/wp-codebox/lib/datamachine-agent-bundle-result.js
@@ -1,0 +1,88 @@
+'use strict';
+
+function plainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function nonEmptyObject(value) {
+  return plainObject(value) && Object.keys(value).length > 0;
+}
+
+function keepMetadataValue(value) {
+  if (value === undefined) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (plainObject(value)) {
+    return nonEmptyObject(value);
+  }
+  return true;
+}
+
+function normalizeTranscriptArtifacts(bundleRun) {
+  const transcripts = bundleRun.transcripts || bundleRun.transcript_artifacts || bundleRun.transcriptArtifacts;
+  if (Array.isArray(transcripts)) {
+    return transcripts;
+  }
+  if (plainObject(transcripts)) {
+    return transcripts;
+  }
+  return undefined;
+}
+
+function normalizeArtifactExports(bundleRun) {
+  const artifacts = bundleRun.artifacts || bundleRun.artifact_exports || bundleRun.artifactExports;
+  if (Array.isArray(artifacts)) {
+    return artifacts;
+  }
+  if (plainObject(artifacts)) {
+    return artifacts;
+  }
+  return undefined;
+}
+
+function normalizeDatamachineAgentBundleResult(bundleRun, config = {}, options = {}) {
+  const bundle = plainObject(bundleRun.bundle) ? bundleRun.bundle : {};
+  const workflowSteps = Array.isArray(bundleRun.workflow?.steps) ? bundleRun.workflow.steps : [];
+  const legacyProjectionOutputs = typeof options.legacyProjectionOutputs === 'function'
+    ? options.legacyProjectionOutputs(bundleRun.engine_data, config)
+    : {};
+  const mergeTypedArtifactOutputs = typeof options.mergeTypedArtifactOutputs === 'function'
+    ? options.mergeTypedArtifactOutputs
+    : (outputs) => outputs;
+  const outputs = mergeTypedArtifactOutputs({
+    ...(plainObject(bundleRun.outputs) ? bundleRun.outputs : {}),
+    ...(plainObject(legacyProjectionOutputs) ? legacyProjectionOutputs : {}),
+  }, bundleRun.typed_artifacts, bundleRun.typedArtifacts, bundleRun.outputs?.typed_artifacts, bundleRun.outputs?.typedArtifacts);
+  const artifacts = normalizeArtifactExports(bundleRun);
+  const transcripts = normalizeTranscriptArtifacts(bundleRun);
+
+  return {
+    outputs,
+    scenarios: [{
+      id: config.workload_id || bundle.flow_slug || bundle.bundle_slug || config.agent_slug || config.flow_slug || 'agent-bundle',
+      metrics: {
+        workflow_step_count: workflowSteps.length,
+      },
+      metadata: Object.fromEntries(Object.entries({
+        schema: bundleRun.schema,
+        success: bundleRun.success !== false,
+        dry_run: Boolean(bundleRun.dry_run),
+        bundle,
+        job_id: bundleRun.job_id,
+        job_status: bundleRun.job_status,
+        wait_result: bundleRun.wait_result,
+        artifacts,
+        transcripts,
+        engine_data: bundleRun.engine_data,
+        error: bundleRun.success === false ? bundleRun.error : undefined,
+      }).filter(([, value]) => keepMetadataValue(value))),
+    }],
+  };
+}
+
+module.exports = {
+  normalizeDatamachineAgentBundleResult,
+};

--- a/agent-runtimes/wp-codebox/package.json
+++ b/agent-runtimes/wp-codebox/package.json
@@ -7,6 +7,7 @@
     ".": "./index.js",
     "./codebox-artifact-contract": "./lib/codebox-artifact-contract.js",
     "./codebox-agent-task-executor": "./lib/codebox-agent-task-executor.js",
+    "./datamachine-agent-bundle-result": "./lib/datamachine-agent-bundle-result.js",
     "./codebox-runtime-profile": "./lib/codebox-runtime-profile.js",
     "./delegated-run-contract": "./lib/delegated-run-contract.js",
     "./provider-outcome-normalizer": "./lib/provider-outcome-normalizer.js",

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -27,6 +27,7 @@ const {
   normalizeTypedArtifacts,
   typedArtifactFileRefs,
 } = require('../../lib/codebox-artifact-contract');
+const { normalizeDatamachineAgentBundleResult } = require('../../lib/datamachine-agent-bundle-result');
 
 const CODEX_OAUTH_TOKEN_URL = 'https://auth.openai.com/oauth/token';
 const CODEX_OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
@@ -1873,32 +1874,10 @@ function agentRuntimeWorkloadFromSingleResult(workload, config) {
 }
 
 function agentRuntimeWorkloadFromBundleRun(bundleRun, config) {
-  const bundle = bundleRun.bundle && typeof bundleRun.bundle === 'object' ? bundleRun.bundle : {};
-  const workflowSteps = Array.isArray(bundleRun.workflow?.steps) ? bundleRun.workflow.steps : [];
-  const outputs = mergeTypedArtifactOutputs({
-    ...(plainObject(bundleRun.outputs) ? bundleRun.outputs : {}),
-    ...evidenceProjectionOutputs(bundleRun.engine_data, config),
-  }, bundleRun.typed_artifacts, bundleRun.typedArtifacts, bundleRun.outputs?.typed_artifacts, bundleRun.outputs?.typedArtifacts);
-  return {
-    outputs,
-    scenarios: [{
-      id: config.workload_id || bundle.flow_slug || bundle.bundle_slug || config.agent_slug || config.flow_slug || 'agent-bundle',
-      metrics: {
-        workflow_step_count: workflowSteps.length,
-      },
-      metadata: {
-        schema: bundleRun.schema,
-        success: bundleRun.success !== false,
-        dry_run: Boolean(bundleRun.dry_run),
-        bundle,
-        job_id: bundleRun.job_id,
-        job_status: bundleRun.job_status,
-        wait_result: bundleRun.wait_result,
-        engine_data: bundleRun.engine_data,
-        error: bundleRun.success === false ? bundleRun.error : undefined,
-      },
-    }],
-  };
+  return normalizeDatamachineAgentBundleResult(bundleRun, config, {
+    legacyProjectionOutputs: evidenceProjectionOutputs,
+    mergeTypedArtifactOutputs,
+  });
 }
 
 function hasScenarios(value) {

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -93,6 +93,13 @@ const bundleRun = isAgentBundle && process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN
           file_refs: [{ path: input.artifacts_path + '/example-review.json', mime: 'application/json' }]
         }
       },
+      artifacts: {
+        result: { path: input.artifacts_path + '/datamachine-result.json', mime: 'application/json' }
+      },
+      transcripts: {
+        json: input.artifacts_path + '/transcript.json',
+        summary: input.artifacts_path + '/transcript.md'
+      },
       workflow: { steps: [{ step_type: 'ai' }] },
       wait_result: { success: true, terminal_state: 'completed' },
       engine_data: process.env.FIXTURE_WP_CODEBOX_BUNDLE_RUN_TOOL_RECORDERS
@@ -1112,6 +1119,8 @@ try {
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.schema, 'datamachine/agent-bundle-run/v1');
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.job_status, 'completed');
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.engine_data.example_agent.issue_number, 123);
+  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.artifacts.result.mime, 'application/json');
+  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.transcripts.summary.endsWith('/transcript.md'), true);
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.dry_run, true);
   assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metrics.workflow_step_count, 1);
   assert.equal(canonicalBundleRunOutput.outputs.typed_artifacts.example_review.type, 'ExampleReviewArtifact');


### PR DESCRIPTION
## Summary
- Add a WP Codebox helper that normalizes Data Machine agent bundle run results from the public run-agent-bundle result shape.
- Route the task runner through that helper so outputs, typed artifacts, artifact exports, and transcripts are handled in one boundary instead of inline runner logic.
- Keep engine_data projections as an explicit legacy fallback path while covering canonical artifacts/transcripts in smoke tests.

## Tests
- npm run test:wp-codebox-task-runner (from wordpress/)
- node --check agent-runtimes/wp-codebox/lib/datamachine-agent-bundle-result.js && node --check agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
- npm run test:codebox-agent-task-executor-boundary (from agent-runtimes/wp-codebox/)
- npm run test:codebox-agent-task-executor (from agent-runtimes/wp-codebox/)

## Notes
- The requested PHP workload file is not present on current origin/main; this PR targets the current WP Codebox/Data Machine run-agent-bundle result boundary instead of reintroducing the removed PHP workload.
- No CHANGELOG.md edits.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the boundary helper, updating runner wiring, adding smoke coverage, and running verification.