### PR TITLE
Add Codebox run-agent-task adapter boundary

### DIFF
--- a/agent-runtimes/wp-codebox/README.md
+++ b/agent-runtimes/wp-codebox/README.md
@@ -30,9 +30,18 @@ bridge environment variables.
 Codebox owns these primitives:
 
 - `wp-codebox/runtime-profile/v1` for runtime dependencies and mounts.
+- `wp-codebox/run-agent-task/v1` for launching a prepared agent task through a Codebox-owned run contract.
 - `wp-codebox/parent-tool-bridge/v1` for exposing parent-owned tools inside the sandbox.
 - `wp-codebox/provider-runtime-invocation-contract/v1` for runner workspace, transcript, and artifact handoff operations.
 - `wp-codebox/evidence-artifact-envelope/v1` for typed artifacts, evidence refs, and run summaries.
+
+`lib/codebox-run-agent-task-contract.js` is the adapter boundary for launching
+Codebox agent tasks. It builds the preferred `wp-codebox/run-agent-task/v1`
+request shape and selects the stable `run-agent-task` CLI when the installed
+Codebox package advertises it. Older packages continue through the legacy
+`agent-task-run` / `wp-codebox/task-input/v1` path, but that compatibility is
+kept behind this adapter so the follow-up swap can remove the fallback without
+changing Homeboy callers.
 
 ## Delegated Run Preparation
 

--- a/agent-runtimes/wp-codebox/index.js
+++ b/agent-runtimes/wp-codebox/index.js
@@ -3,6 +3,7 @@
 module.exports = {
 	...require('./lib/codebox-agent-task-executor'),
 	...require('./lib/codebox-artifact-contract'),
+	...require('./lib/codebox-run-agent-task-contract'),
 	...require('./lib/codebox-runtime-profile'),
 	...require('./lib/delegated-run-contract'),
 	...require('./lib/wp-codebox-adapter-contract'),

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -55,6 +55,9 @@ const {
   wpCodeboxProviderRuntimeInvocationContract,
   wpCodeboxProviderRuntimeOperationEntry,
 } = require('./wp-codebox-adapter-contract');
+const {
+  WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
+} = require('./codebox-run-agent-task-contract');
 
 const RUNTIME_MANIFEST_PATH = path.resolve(__dirname, '..', 'wp-codebox.json');
 const RUNTIME_OVERLAY_CANONICAL_SHAPE = 'runtime_overlays entries must be objects. WP Codebox owns the runtime overlay schema and reports field-level validation.';
@@ -2945,7 +2948,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     schema: AGENT_TASK_OUTCOME_SCHEMA,
     provider: 'wordpress.codebox-agent-task-executor',
     providerLabel: 'WP Codebox agent',
-    integrationContract: 'wp-codebox-cli/agent-task-run',
+    integrationContract: WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
     status,
     summary: missingRequiredTypedArtifacts?.message || runtimeFailureDiagnostic?.message || recipeSummary?.failure_summary || fallbackRecipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
     artifacts: normalizeArtifacts(result, runSummary, recipeSummary),
@@ -3027,6 +3030,7 @@ module.exports = {
   WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
   WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS,
   WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES,
+  WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
   RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA,
   providerContract,
   providerRuntimeInvocationContract,

--- a/agent-runtimes/wp-codebox/lib/codebox-run-agent-task-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-run-agent-task-contract.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const {
+  WP_CODEBOX_TASK_REQUEST_SCHEMA,
+} = require('./wp-codebox-adapter-contract');
+
+const WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA = 'wp-codebox/run-agent-task/v1';
+const WP_CODEBOX_RUN_AGENT_TASK_RESULT_SCHEMA = 'wp-codebox/run-agent-task-result/v1';
+const WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND = 'run-agent-task';
+const WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND = 'agent-task-run';
+
+function codeboxRunAgentTaskRequestFromTaskInput(taskInput, options = {}) {
+  if (!taskInput || taskInput.schema !== WP_CODEBOX_TASK_REQUEST_SCHEMA) {
+    throw new Error(`Codebox run-agent-task adapter requires ${WP_CODEBOX_TASK_REQUEST_SCHEMA} task input.`);
+  }
+  return withoutUndefinedValues({
+    schema: WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
+    version: 1,
+    task_id: firstValue(options.taskId, options.task_id, taskInput.sandbox_session_id, taskInput.context?.agent_task_id),
+    task_input: taskInput,
+    artifacts_path: firstValue(options.artifactsPath, options.artifacts_path, taskInput.artifacts_path),
+    callback_data: firstValue(options.callbackData, options.callback_data, taskInput.callback_data),
+    compatibility: {
+      legacy_input_schema: WP_CODEBOX_TASK_REQUEST_SCHEMA,
+      legacy_cli_command: WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND,
+    },
+  });
+}
+
+function codeboxRunAgentTaskInvocation(options = {}) {
+  const useStableRunAgentTask = Boolean(options.useStableRunAgentTask || options.use_stable_run_agent_task);
+  const input = useStableRunAgentTask
+    ? codeboxRunAgentTaskRequestFromTaskInput(options.taskInput, options)
+    : options.taskInput;
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Codebox run-agent-task invocation requires taskInput.');
+  }
+
+  const args = [
+    useStableRunAgentTask ? WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND : WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND,
+    `--input-file=${options.inputFilePlaceholder || '{{input_file}}'}`,
+    '--json',
+  ];
+  const previewHold = firstValue(options.previewHold, options.preview_hold);
+  if (previewHold) {
+    args.push(`--preview-hold-seconds=${previewHold}`);
+  }
+  const previewPublicUrl = firstValue(options.previewPublicUrl, options.preview_public_url);
+  if (previewPublicUrl) {
+    args.push(`--preview-public-url=${previewPublicUrl}`);
+  }
+
+  return {
+    contract: WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
+    implementation: useStableRunAgentTask ? 'stable-run-agent-task' : 'legacy-agent-task-run-compat',
+    input,
+    args,
+    result_schema: useStableRunAgentTask ? WP_CODEBOX_RUN_AGENT_TASK_RESULT_SCHEMA : 'wp-codebox/agent-task-run/v1',
+  };
+}
+
+function firstValue(...values) {
+  return values.find((value) => value !== undefined && value !== null && value !== '');
+}
+
+function withoutUndefinedValues(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+module.exports = {
+  WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND,
+  WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND,
+  WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
+  WP_CODEBOX_RUN_AGENT_TASK_RESULT_SCHEMA,
+  codeboxRunAgentTaskInvocation,
+  codeboxRunAgentTaskRequestFromTaskInput,
+};

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -108,6 +108,13 @@ const WP_CODEBOX_ROLE_ALIASES = {
 
 const WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS = [
   {
+    id: 'run-agent-task',
+    schema: 'wp-codebox/run-agent-task/v1',
+    owner: 'wp-codebox',
+    adapter_behavior: 'prefer_stable_run_agent_task_with_legacy_agent_task_run_fallback',
+    requirement: 'Accept a Codebox-owned run-agent-task request that wraps the prepared task input and returns a stable run-agent-task result envelope. Until that primitive is present, Homeboy Extensions keeps the legacy agent-task-run CLI compatibility path behind codebox-run-agent-task-contract.js.',
+  },
+  {
     id: 'runtime-profile',
     schema: 'wp-codebox/runtime-profile/v1',
     owner: 'wp-codebox',

--- a/agent-runtimes/wp-codebox/package.json
+++ b/agent-runtimes/wp-codebox/package.json
@@ -7,6 +7,7 @@
     ".": "./index.js",
     "./codebox-artifact-contract": "./lib/codebox-artifact-contract.js",
     "./codebox-agent-task-executor": "./lib/codebox-agent-task-executor.js",
+    "./codebox-run-agent-task-contract": "./lib/codebox-run-agent-task-contract.js",
     "./codebox-runtime-profile": "./lib/codebox-runtime-profile.js",
     "./delegated-run-contract": "./lib/delegated-run-contract.js",
     "./provider-outcome-normalizer": "./lib/provider-outcome-normalizer.js",

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -27,6 +27,9 @@ const {
   normalizeTypedArtifacts,
   typedArtifactFileRefs,
 } = require('../../lib/codebox-artifact-contract');
+const {
+  codeboxRunAgentTaskInvocation,
+} = require('../../lib/codebox-run-agent-task-contract');
 
 const CODEX_OAUTH_TOKEN_URL = 'https://auth.openai.com/oauth/token';
 const CODEX_OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
@@ -2243,6 +2246,25 @@ function emptyStdoutPayloadFailure(result, artifacts) {
   );
 }
 
+function supportsRunAgentTaskCommand(wpCodeboxBin) {
+  const mode = process.env.HOMEBOY_WP_CODEBOX_RUN_AGENT_TASK || '';
+  if (/^(1|true|stable)$/i.test(mode)) {
+    return true;
+  }
+  if (/^(0|false|legacy)$/i.test(mode)) {
+    return false;
+  }
+
+  const resolved = resolveCommand(wpCodeboxBin, ['run-agent-task', '--help']);
+  const result = spawnSync(resolved.command, resolved.args, {
+    encoding: 'utf8',
+    env: process.env,
+    maxBuffer: 1024 * 1024,
+    timeout: 5000,
+  });
+  return !result.error && result.status === 0;
+}
+
 function runWpCodeboxParentTask(request, envOverrides = {}) {
   const explicitArtifacts = argValue('--artifacts') || request.artifacts_path || '';
   const artifacts = explicitArtifacts || fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-artifacts-'));
@@ -2273,16 +2295,19 @@ function runWpCodeboxParentTask(request, envOverrides = {}) {
       ...(bridgeServer ? { HOMEBOY_AGENT_TOOL_BRIDGE_URL: bridgeServer.url } : {}),
     },
   }, artifacts);
-  const inputPath = writeJsonFile('homeboy-wp-codebox-agent-task-input-', preparedInput.input);
-  const args = ['agent-task-run', `--input-file=${inputPath}`, '--json'];
-  const previewHold = argValue('--preview-hold');
-  if (previewHold) {
-    args.push(`--preview-hold-seconds=${previewHold}`);
-  }
-  const previewPublicUrl = argValue('--preview-public-url');
-  if (previewPublicUrl) {
-    args.push(`--preview-public-url=${previewPublicUrl}`);
-  }
+  const useStableRunAgentTask = supportsRunAgentTaskCommand(wpCodeboxBin);
+  const invocation = codeboxRunAgentTaskInvocation({
+    taskInput: preparedInput.input,
+    artifactsPath: artifacts,
+    previewHold: argValue('--preview-hold'),
+    previewPublicUrl: argValue('--preview-public-url'),
+    useStableRunAgentTask,
+  });
+  const inputPath = writeJsonFile(
+    useStableRunAgentTask ? 'homeboy-wp-codebox-run-agent-task-' : 'homeboy-wp-codebox-agent-task-input-',
+    invocation.input
+  );
+  const args = invocation.args.map((arg) => arg === '--input-file={{input_file}}' ? `--input-file=${inputPath}` : arg);
 
   const resolved = resolveCommand(wpCodeboxBin, args);
   const timeoutMs = requestTimeoutMs(request);
@@ -2293,6 +2318,9 @@ function runWpCodeboxParentTask(request, envOverrides = {}) {
     command: resolved.command,
     args: resolved.args,
     prepared_plugins: preparedInput.prepared_plugins,
+    run_agent_task_contract: invocation.contract,
+    run_agent_task_implementation: invocation.implementation,
+    expected_result_schema: invocation.result_schema,
     timeout_ms: timeoutMs,
     task_id: request.orchestrator?.agent_task_id,
     sandbox_session_id: request.sandbox_session_id,

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -59,6 +59,7 @@ assert.deepEqual(wpCodeboxProviderRuntimeOperationConfig('toolCallTranscriptReco
 
 assert.deepEqual(WP_CODEBOX_ROLE_ALIASES.artifact_roles.patch, ['codebox-patch']);
 assert.deepEqual(WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.map((requirement) => requirement.id), [
+	'run-agent-task',
 	'runtime-profile',
 	'parent-tool-bridge',
 	'provider-runtime-invocation',

--- a/tests/wp-codebox-run-agent-task-contract-smoke.mjs
+++ b/tests/wp-codebox-run-agent-task-contract-smoke.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+	WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND,
+	WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND,
+	WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
+	WP_CODEBOX_RUN_AGENT_TASK_RESULT_SCHEMA,
+	codeboxRunAgentTaskInvocation,
+	codeboxRunAgentTaskRequestFromTaskInput,
+} = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox'));
+
+const taskInput = {
+	schema: 'wp-codebox/task-input/v1',
+	sandbox_session_id: 'task-123',
+	artifacts_path: '/tmp/artifacts',
+	provider: 'codex',
+};
+
+const request = codeboxRunAgentTaskRequestFromTaskInput(taskInput);
+assert.equal(request.schema, WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA);
+assert.equal(request.version, 1);
+assert.equal(request.task_id, 'task-123');
+assert.equal(request.task_input, taskInput);
+assert.deepEqual(request.compatibility, {
+	legacy_input_schema: 'wp-codebox/task-input/v1',
+	legacy_cli_command: WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND,
+});
+
+const legacyInvocation = codeboxRunAgentTaskInvocation({
+	taskInput,
+	previewHold: '30',
+	previewPublicUrl: 'https://preview.example.test',
+});
+assert.equal(legacyInvocation.contract, WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA);
+assert.equal(legacyInvocation.implementation, 'legacy-agent-task-run-compat');
+assert.equal(legacyInvocation.input, taskInput);
+assert.deepEqual(legacyInvocation.args, [
+	WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND,
+	'--input-file={{input_file}}',
+	'--json',
+	'--preview-hold-seconds=30',
+	'--preview-public-url=https://preview.example.test',
+]);
+
+const stableInvocation = codeboxRunAgentTaskInvocation({ taskInput, useStableRunAgentTask: true });
+assert.equal(stableInvocation.implementation, 'stable-run-agent-task');
+assert.equal(stableInvocation.input.schema, WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA);
+assert.equal(stableInvocation.args[0], WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND);
+assert.equal(stableInvocation.result_schema, WP_CODEBOX_RUN_AGENT_TASK_RESULT_SCHEMA);
+
+assert.throws(
+	() => codeboxRunAgentTaskRequestFromTaskInput({ schema: 'wp-codebox/not-task-input/v1' }),
+	/wp-codebox\/task-input\/v1/
+);
+
+console.log('wp-codebox run-agent-task contract smoke passed');


### PR DESCRIPTION
## Summary
- Add a small Codebox run-agent-task adapter contract that defines the preferred `wp-codebox/run-agent-task/v1` request/result boundary.
- Route the WP Codebox task runner through the adapter, selecting `run-agent-task` when the installed Codebox CLI advertises it and keeping legacy `agent-task-run` compatibility behind the adapter.
- Document the contract and add smoke coverage for stable and legacy invocation shapes.

## Tests
- `node tests/wp-codebox-run-agent-task-contract-smoke.mjs && node tests/wp-codebox-adapter-contract-smoke.mjs && node tests/wp-codebox-agent-runtime-command-contract-smoke.mjs && node tests/wp-codebox-artifact-contract-smoke.mjs`
- `node --check agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs && node --check agent-runtimes/wp-codebox/lib/codebox-run-agent-task-contract.js && node --check agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js`
- `npm run lint:js` from `wordpress/` currently fails on pre-existing files outside this change (dependency-group, unused vars, nested ternaries, curly, no-bitwise, no-console warnings). Scoped eslint from `wordpress/` ignores the touched files because they are outside that package base path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the adapter boundary, updating tests/docs, and drafting this PR description.