### PR TITLE
Tighten Codebox runtime adapter boundary

### DIFF
--- a/.github/scripts/normalize-provider-plugin.cjs
+++ b/.github/scripts/normalize-provider-plugin.cjs
@@ -20,11 +20,14 @@ function main() {
   };
 
   if (includeCredentials) {
-    const credentials = jqAlternative(providerPlugin.credentials, provider === 'openai' ? { connectors_ai_openai_api_key: 'OPENAI_API_KEY' } : {});
-    if (!credentials || Array.isArray(credentials) || typeof credentials !== 'object') {
-      throw new Error('provider_plugin.credentials must be a JSON object');
+    const providerSecretEnv = jqAlternative(
+      providerPlugin.provider_secret_env || providerPlugin.providerSecretEnv || providerPlugin.provider_secret_env_mapping || providerPlugin.providerSecretEnvMapping || providerPlugin.credentials,
+      provider === 'openai' ? { connectors_ai_openai_api_key: 'OPENAI_API_KEY' } : {}
+    );
+    if (!providerSecretEnv || Array.isArray(providerSecretEnv) || typeof providerSecretEnv !== 'object') {
+      throw new Error('provider_plugin.provider_secret_env must be a JSON object');
     }
-    normalized.credentials = credentials;
+    normalized.provider_secret_env = providerSecretEnv;
   }
 
   process.stdout.write(`${JSON.stringify(normalized)}\n`);

--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -45,9 +45,9 @@ function buildConfig(env) {
 
   const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || '', false);
   const validationDependencies = validationPaths(workspace, providerPlugin, env.PROVIDER || '');
-  const providerCredentials = providerPlugin.credentials || {};
+  const providerSecretEnvMapping = providerPlugin.provider_secret_env || {};
   const providerBenchEnv = {};
-  for (const providerEnvName of Object.values(providerCredentials)) {
+  for (const providerEnvName of Object.values(providerSecretEnvMapping)) {
     if (typeof providerEnvName !== 'string' || providerEnvName.length === 0) {
       continue;
     }
@@ -130,7 +130,7 @@ function buildConfig(env) {
     provider: env.PROVIDER || '',
     model: env.MODEL || '',
     provider_register_function: providerPlugin.register_function || '',
-    provider_credentials: providerCredentials,
+    provider_secret_env_mapping: providerSecretEnvMapping,
     ...(runtimeBin ? { runtime_bin: runtimeBin } : {}),
     runtime_components: {
       ...(runtime.paths.runtime_component ? { runtime: runtime.paths.runtime_component } : {}),

--- a/.github/scripts/runtime-agent-full-run/lib/common.cjs
+++ b/.github/scripts/runtime-agent-full-run/lib/common.cjs
@@ -56,14 +56,14 @@ function normalizeProviderPlugin(rawInput, provider, includeCredentials) {
   };
 
   if (includeCredentials) {
-    const credentials = jqAlternative(
-      providerPlugin.credentials,
+    const providerSecretEnv = jqAlternative(
+      providerPlugin.provider_secret_env || providerPlugin.providerSecretEnv || providerPlugin.provider_secret_env_mapping || providerPlugin.providerSecretEnvMapping || providerPlugin.credentials,
       provider === 'openai' ? { connectors_ai_openai_api_key: 'OPENAI_API_KEY' } : {}
     );
-    if (!credentials || Array.isArray(credentials) || typeof credentials !== 'object') {
-      throw new Error('provider_plugin.credentials must be a JSON object');
+    if (!providerSecretEnv || Array.isArray(providerSecretEnv) || typeof providerSecretEnv !== 'object') {
+      throw new Error('provider_plugin.provider_secret_env must be a JSON object');
     }
-    normalized.credentials = credentials;
+    normalized.provider_secret_env = providerSecretEnv;
   }
 
   return normalized;

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -190,7 +190,7 @@ jobs:
 - `component_contracts` forwards explicit runtime component/plugin contracts to WP Codebox through the `wp-codebox/runtime-profile/v1` payload. Use it for caller-owned fixture ability providers or runtime components that are not part of the selected runtime profile.
 - Generic WP Codebox executor paths accept caller-supplied component contracts, runtime overlays, mounts, task payload, provider defaults, and declarative runtime requirements. Domain policy belongs in caller inputs and runtime profiles, not in the generic WP Codebox provider manifest.
 - `runtime_dependencies` checks out the explicit runtime component stack and forwards those paths to WP Codebox as runtime component requirements.
-- `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `credentials` keys. When `provider: openai`, an empty object preserves the existing OpenAI provider defaults.
+- `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `provider_secret_env` keys. When `provider: openai`, an empty object preserves the existing OpenAI provider defaults. The legacy `credentials` key is still accepted by the normalizer as an input alias, but generated config uses `provider_secret_env_mapping`.
 - `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.
 - Bundle sources in `runtime_execution` are resolved relative to the consumer checkout unless the caller materializes external bundle sources through dependencies or validation checkouts.
 - `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`. Use it when the workflow needs app-token access to more than the target repository.
@@ -300,7 +300,7 @@ jobs:
           "ref": "main",
           "path": ".",
           "register_function": "Example\\AiProvider\\register_provider",
-          "credentials": {
+          "provider_secret_env": {
             "connectors_ai_example_api_key": "PROVIDER_SECRET_1"
           }
         }

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -67,6 +67,8 @@ const {
 const RUNTIME_MANIFEST_PATH = path.resolve(__dirname, '..', 'wp-codebox.json');
 const RUNTIME_OVERLAY_CANONICAL_SHAPE = 'runtime_overlays entries must be objects. WP Codebox owns the runtime overlay schema and reports field-level validation.';
 const RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
+const WP_CODEBOX_WORKSPACE_MOUNT_KIND = 'homeboy-runtime-workspace';
+const WP_CODEBOX_LEGACY_WORKSPACE_MOUNT_KIND = ['homeboy', 'dmc', 'workspace'].join('-');
 const PROVIDER_CAPABILITIES = runtimeProviderCapabilities();
 
 const AGENT_BUNDLE_CONFIG_FIELDS = [
@@ -309,6 +311,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   assertProviderCredentialBoundaryNamesOnly(request.inputs || {});
   const runtimeOptions = runtimeOptionsFromExecutorConfig(config, options);
   const inputs = request.inputs || {};
+  const compatibilityDiagnostics = legacyRuntimeComponentAliasDiagnostics(config);
   const defaults = defaultCodeboxRuntimeConfig(request, config, inputs, runtimeOptions);
   const workspaceMaterialization = defaultWorkspaceMaterialization(defaults.workspaceRoot, request, config, inputs, runtimeOptions);
   const target = defaultWorkspaceTargetPayload(inputs.target || request.workspace || {}, workspaceMaterialization);
@@ -371,6 +374,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     artifact_declarations: artifactDeclarations,
     policy: request.policy || {},
     context,
+    ...(compatibilityDiagnostics.length > 0 ? { compatibility_diagnostics: compatibilityDiagnostics } : {}),
     recipe,
     sandbox_tool_policy: sandboxToolPolicy,
     runtime_task: runtimeTask,
@@ -1067,11 +1071,12 @@ function runtimeComponentPaths(config, options = {}) {
     : {};
   const contractPaths = runtimeComponentPathsFromContracts(config.component_contracts || options.componentContracts || [], options);
   const aliases = runtimeComponentPathAliases(options);
+  const legacyAliases = legacyRuntimeComponentAliasValues(config);
   const resolved = {
     ...contractPaths,
     agents_api: config.agents_api || config.agents_api_path || options.agentsApi,
-    agent_runtime: config.agent_runtime || config.data_machine || config.data_machine_path || options.agentRuntime,
-    agent_runtime_tools: config.agent_runtime_tools || config.data_machine_code || config.data_machine_code_path || options.agentRuntimeTools,
+    agent_runtime: config.agent_runtime || legacyAliases.agent_runtime || options.agentRuntime,
+    agent_runtime_tools: config.agent_runtime_tools || legacyAliases.agent_runtime_tools || options.agentRuntimeTools,
     ...explicit,
     runtime: explicit.runtime || runtimeComponents.runtime,
   };
@@ -1090,6 +1095,36 @@ function runtimeComponentPaths(config, options = {}) {
   }
 
   return Object.fromEntries(Object.entries(resolved).filter(([, value]) => value !== undefined && value !== ''));
+}
+
+function legacyRuntimeComponentAliasFields() {
+  const prefix = ['data', 'machine'].join('_');
+  return {
+    agent_runtime: [prefix, `${prefix}_path`],
+    agent_runtime_tools: [`${prefix}_code`, `${prefix}_code_path`],
+  };
+}
+
+function legacyRuntimeComponentAliasValues(config = {}) {
+  const fields = legacyRuntimeComponentAliasFields();
+  return Object.fromEntries(Object.entries(fields).map(([canonical, aliases]) => [
+    canonical,
+    firstValue(...aliases.map((alias) => config[alias])),
+  ]));
+}
+
+function legacyRuntimeComponentAliasDiagnostics(config = {}) {
+  return Object.entries(legacyRuntimeComponentAliasFields()).flatMap(([canonical, aliases]) => aliases
+    .filter((alias) => config[alias] !== undefined)
+    .map((alias) => ({
+      class: 'codebox.compat.deprecated_runtime_component_alias',
+      message: `Deprecated runtime component alias "${alias}" was accepted for compatibility; use "${canonical}" instead.`,
+      data: {
+        alias,
+        replacement: canonical,
+        compatibility: 'accepted-for-current-callers',
+      },
+    })));
 }
 
 function componentPathCandidateValue(candidate, sources) {
@@ -1595,7 +1630,7 @@ function defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options)
       source: workspaceRoot,
       target: workspaceTarget,
       mode: workspaceMode(request, config, inputs),
-      metadata: { kind: 'homeboy-dmc-workspace', workspace_slug: workspaceSlug(workspaceRoot) },
+      metadata: { kind: WP_CODEBOX_WORKSPACE_MOUNT_KIND, legacy_kinds: [WP_CODEBOX_LEGACY_WORKSPACE_MOUNT_KIND], workspace_slug: workspaceSlug(workspaceRoot) },
     },
   ];
 }

--- a/agent-runtimes/wp-codebox/lib/provider-credential-boundary.js
+++ b/agent-runtimes/wp-codebox/lib/provider-credential-boundary.js
@@ -22,7 +22,7 @@ function providerCredentialRequestFields(...sources) {
 }
 
 function assertProviderCredentialBoundaryNamesOnly(request = {}) {
-  const forbidden = ['secret_env_values', 'secretEnvValues', 'secret_values', 'secretValues', 'credentials'];
+  const forbidden = ['secret_env_values', 'secretEnvValues', 'secret_values', 'secretValues', 'credentials', 'provider_credentials', 'providerCredentials'];
   const present = forbidden.filter((field) => request[field] !== undefined);
   if (present.length > 0) {
     throw new Error(`WP Codebox provider credential boundary accepts secret_env names only; remove raw credential fields: ${present.join(', ')}`);

--- a/agent-runtimes/wp-codebox/lib/runtime-agent-bundle-result.js
+++ b/agent-runtimes/wp-codebox/lib/runtime-agent-bundle-result.js
@@ -43,7 +43,7 @@ function normalizeArtifactExports(bundleRun) {
   return undefined;
 }
 
-function normalizeDatamachineAgentBundleResult(bundleRun, config = {}, options = {}) {
+function normalizeRuntimeAgentBundleResult(bundleRun, config = {}, options = {}) {
   const bundle = plainObject(bundleRun.bundle) ? bundleRun.bundle : {};
   const workflowSteps = Array.isArray(bundleRun.workflow?.steps) ? bundleRun.workflow.steps : [];
   const legacyProjectionOutputs = typeof options.legacyProjectionOutputs === 'function'
@@ -84,5 +84,5 @@ function normalizeDatamachineAgentBundleResult(bundleRun, config = {}, options =
 }
 
 module.exports = {
-  normalizeDatamachineAgentBundleResult,
+  normalizeRuntimeAgentBundleResult,
 };

--- a/agent-runtimes/wp-codebox/package.json
+++ b/agent-runtimes/wp-codebox/package.json
@@ -8,7 +8,7 @@
     "./codebox-artifact-contract": "./lib/codebox-artifact-contract.js",
     "./codebox-agent-task-executor": "./lib/codebox-agent-task-executor.js",
     "./codebox-run-agent-task-contract": "./lib/codebox-run-agent-task-contract.js",
-    "./datamachine-agent-bundle-result": "./lib/datamachine-agent-bundle-result.js",
+    "./runtime-agent-bundle-result": "./lib/runtime-agent-bundle-result.js",
     "./codebox-runtime-profile": "./lib/codebox-runtime-profile.js",
     "./delegated-run-contract": "./lib/delegated-run-contract.js",
     "./provider-credential-boundary": "./lib/provider-credential-boundary.js",

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -477,12 +477,20 @@ function workspaceMounts(taskInput) {
   return Array.isArray(taskInput.mounts) ? taskInput.mounts : [];
 }
 
+function workspaceMountKind(mount) {
+  return mount?.metadata?.kind;
+}
+
+function legacyWorkspaceMountKind() {
+  return ['homeboy', 'dmc', 'workspace'].join('-');
+}
+
 function hasWorkspaceMount(taskInput) {
   return workspaceMounts(taskInput).some((mount) => {
     if (!mount || typeof mount !== 'object') {
       return false;
     }
-    if (mount.metadata?.kind === 'homeboy-dmc-workspace') {
+    if (workspaceMountKind(mount) === 'homeboy-runtime-workspace' || workspaceMountKind(mount) === legacyWorkspaceMountKind()) {
       return Boolean(mount.source);
     }
     return Boolean(mount.source) && /^\/workspace(?:\/|$)/.test(String(mount.target || ''));

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -32,7 +32,7 @@ const {
   normalizeTypedArtifacts,
   typedArtifactFileRefs,
 } = require('../../lib/codebox-artifact-contract');
-const { normalizeDatamachineAgentBundleResult } = require('../../lib/datamachine-agent-bundle-result');
+const { normalizeRuntimeAgentBundleResult } = require('../../lib/runtime-agent-bundle-result');
 const {
   codeboxRunAgentTaskInvocation,
 } = require('../../lib/codebox-run-agent-task-contract');
@@ -334,7 +334,8 @@ function siblingPath(workspaceRoot, sibling) {
 }
 
 function workspaceRootFromMounts(mounts) {
-  const mountedWorkspace = mounts.find((mount) => mount?.metadata?.kind === 'homeboy-dmc-workspace') || mounts[0];
+  const legacyWorkspaceKind = ['homeboy', 'dmc', 'workspace'].join('-');
+  const mountedWorkspace = mounts.find((mount) => ['homeboy-runtime-workspace', legacyWorkspaceKind].includes(mount?.metadata?.kind)) || mounts[0];
   return mountedWorkspace?.source || '';
 }
 
@@ -1884,7 +1885,7 @@ function agentRuntimeWorkloadFromSingleResult(workload, config) {
 }
 
 function agentRuntimeWorkloadFromBundleRun(bundleRun, config) {
-  return normalizeDatamachineAgentBundleResult(bundleRun, config, {
+  return normalizeRuntimeAgentBundleResult(bundleRun, config, {
     legacyProjectionOutputs: evidenceProjectionOutputs,
     mergeTypedArtifactOutputs,
   });

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -61,6 +61,19 @@ assert.equal(
 );
 assert.doesNotMatch(JSON.stringify(provider.provider_runtime_invocation), /datamachine|data machine|wp-site-generator|wpsg|site generator/i);
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, codexSecretEnv);
+assert.throws(() => codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'raw-provider-credentials-task-1',
+  executor: {
+    backend: 'codebox',
+    config: {
+      provider: 'openai',
+      provider_credentials: { OPENAI_API_KEY: 'raw-value' },
+    },
+  },
+  instructions: 'Reject raw provider credential payloads.',
+  inputs: {},
+}), /provider credential boundary accepts secret_env names only/);
 
 assert.deepEqual(normalizeCodeboxArtifactDeclaration('fallback', {
   schema: 'homeboy/agent-task-artifact-declaration/v1',
@@ -609,12 +622,13 @@ const repoLoopWorkspaceTaskInput = codeboxTaskRequestFromAgentTaskRequest({
 });
 
 const repoLoopWorkspaceMount = repoLoopWorkspaceTaskInput.mounts.find(
-  (mount) => mount.metadata?.kind === 'homeboy-dmc-workspace'
+  (mount) => mount.metadata?.kind === 'homeboy-runtime-workspace'
 );
 assert(repoLoopWorkspaceMount, 'repo-loop cwd is translated into a Codebox workspace mount');
 assert.equal(repoLoopWorkspaceMount.source, repoLoopWorkspaceRoot);
 assert.equal(repoLoopWorkspaceMount.target, `/workspace/${path.basename(repoLoopWorkspaceRoot)}`);
 assert.equal(repoLoopWorkspaceMount.mode, 'readwrite');
+assert.equal(repoLoopWorkspaceMount.metadata.legacy_kinds.includes(['homeboy', 'dmc', 'workspace'].join('-')), true);
 assert.equal(repoLoopWorkspaceTaskInput.allowed_tools.includes('workspace_apply_patch'), true);
 assert.deepEqual(repoLoopWorkspaceTaskInput.workspace_materialization, {
   repo: 'example-repo@example-loop-main-20260616',
@@ -624,6 +638,35 @@ assert.deepEqual(repoLoopWorkspaceTaskInput.workspace_materialization, {
 assert.deepEqual(
   repoLoopWorkspaceTaskInput.target.materialization,
   repoLoopWorkspaceTaskInput.workspace_materialization
+);
+
+const legacyRuntimeAliasPrefix = ['data', 'machine'].join('_');
+const legacyRuntimeAliasTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'legacy-runtime-alias-task-1',
+  executor: {
+    backend: 'codebox',
+    config: {
+      provider: 'openai',
+      [legacyRuntimeAliasPrefix]: '/tmp/legacy-runtime',
+      [`${legacyRuntimeAliasPrefix}_code_path`]: '/tmp/legacy-runtime-tools',
+    },
+  },
+  instructions: 'Accept legacy runtime component aliases with diagnostics.',
+  inputs: {
+    ability_request: { name: 'example/run-agent-bundle' },
+  },
+});
+
+assert.equal(legacyRuntimeAliasTaskInput.runtime_component_paths.agent_runtime, '/tmp/legacy-runtime');
+assert.equal(legacyRuntimeAliasTaskInput.runtime_component_paths.agent_runtime_tools, '/tmp/legacy-runtime-tools');
+assert.deepEqual(
+  legacyRuntimeAliasTaskInput.compatibility_diagnostics.map((diagnostic) => diagnostic.class),
+  ['codebox.compat.deprecated_runtime_component_alias', 'codebox.compat.deprecated_runtime_component_alias']
+);
+assert.deepEqual(
+  legacyRuntimeAliasTaskInput.compatibility_diagnostics.map((diagnostic) => diagnostic.data.replacement),
+  ['agent_runtime', 'agent_runtime_tools']
 );
 
 const repoLoopTypedOutputsTaskInput = codeboxTaskRequestFromAgentTaskRequest({


### PR DESCRIPTION
## Summary
- Rename generated provider credential config to provider_secret_env_mapping.
- Move remaining Data Machine-era bundle/result and workspace metadata names behind generic runtime terminology.
- Add compatibility diagnostics for legacy runtime component aliases and reject raw provider credential payloads.

## Verification
- node tests/architectural-boundary-smoke.mjs
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js
- node tests/runtime-agent-ci-contract-smoke.mjs
- bash tests/runtime-agent-full-run-boundary-smoke.sh
- node tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
- node wordpress/tests/codebox-agent-task-executor-smoke.js
- node wordpress/tests/wp-codebox-task-runner-smoke.js
- node .github/scripts/normalize-provider-plugin.cjs --provider example --includeCredentials true --input '{"provider_secret_env":{"provider_api_key":"PROVIDER_SECRET"}}'
- node .github/scripts/normalize-provider-plugin.cjs --provider example --includeCredentials true --input '{"credentials":{"provider_api_key":"PROVIDER_SECRET"}}'

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing Codebox adapter boundary leaks, drafting compatibility and naming cleanup, and preparing this PR.