### PR TITLE
Add WP Codebox provider metadata

### DIFF
--- a/agent-runtimes/wp-codebox/README.md
+++ b/agent-runtimes/wp-codebox/README.md
@@ -14,10 +14,24 @@ override through the provider contract or task conversion options:
 - `workspace_tools` declares the default read-only and read-write workspace tool ids.
 - `component_path_defaults` maps runtime component contracts, legacy aliases, and
   discovery hints into generic runtime component path keys.
+- `provider_metadata` declares the operator-facing provider ids, executor backend,
+  runtime id, model fields, and provider-plugin guidance without requiring Homeboy
+  core to know WordPress or Codebox provider details.
 
 The JavaScript executor consumes these manifest fields instead of owning product
 policy in code. Callers can supply generic manifest values without adding new
 runtime-specific branches.
+
+Runtime selection and provider selection are separate concerns:
+
+- `executor.backend` selects the generic executor backend, currently `codebox` for
+  this runtime.
+- `runtime_id` selects the runtime package, currently `wp-codebox`.
+- `executor.config.provider` selects the WordPress AI provider id, such as
+  `openai`, `codex`, or `claude-code`.
+- `executor.config.model` or `executor.model` carries the provider model name as
+  opaque runtime metadata. The runtime forwards it to WP Codebox and provider
+  plugins; Homeboy core does not interpret model names.
 
 ## Adapter Boundary
 

--- a/agent-runtimes/wp-codebox/lib/provider-preflight-manifest.js
+++ b/agent-runtimes/wp-codebox/lib/provider-preflight-manifest.js
@@ -27,6 +27,18 @@ function providerPreflightManifest(provider) {
   return manifest && typeof manifest === 'object' && !Array.isArray(manifest) ? manifest : null;
 }
 
+function providerMetadataManifest() {
+  const manifest = runtimeExecutorManifest().provider_metadata;
+  return manifest && typeof manifest === 'object' && !Array.isArray(manifest) ? manifest : {};
+}
+
+function providerMetadata(provider) {
+  const providers = providerMetadataManifest().providers;
+  const entries = Array.isArray(providers) ? providers : [];
+  return entries
+    .find((entry) => entry && typeof entry === 'object' && entry.id === provider) || null;
+}
+
 function normalizeStringArray(value) {
   if (Array.isArray(value)) {
     return value.filter((item) => typeof item === 'string' && item.trim()).map((item) => item.trim());
@@ -114,6 +126,8 @@ module.exports = {
   providerDiagnosticClass,
   providerGuidance,
   providerLabel,
+  providerMetadata,
+  providerMetadataManifest,
   providerOptionalSecretEnv,
   providerPluginValidation,
   providerPreflightManifest,

--- a/agent-runtimes/wp-codebox/package.json
+++ b/agent-runtimes/wp-codebox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homeboy-agent-runtime-wp-codebox",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "main": "index.js",
   "exports": {

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/agent-runtime-manifest/v1",
   "id": "wp-codebox",
   "name": "WP Codebox",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "WP Codebox agent runtime for Homeboy agent tasks.",
   "ci_materialization": {
     "checkout": {
@@ -178,6 +178,56 @@
         ]
       },
       "component_path_defaults": {},
+      "provider_metadata": {
+        "schema": "homeboy/agent-task-provider-metadata/v1",
+        "selection": {
+          "backend": "codebox",
+          "runtime_id": "wp-codebox",
+          "provider_id_paths": [
+            "executor.config.provider",
+            "executor.provider",
+            "provider"
+          ],
+          "model_paths": [
+            "executor.model",
+            "executor.config.model",
+            "model"
+          ],
+          "guidance": "Select the generic executor backend with executor.backend=codebox, then select the WordPress AI provider id with executor.config.provider and the provider model with executor.config.model or executor.model. Homeboy core should treat provider ids and models as opaque runtime metadata."
+        },
+        "providers": [
+          {
+            "id": "openai",
+            "label": "OpenAI API",
+            "backend": "codebox",
+            "runtime_id": "wp-codebox",
+            "default_model": "",
+            "model_required": false,
+            "model_guidance": "Set executor.config.model or executor.model when the selected OpenAI provider plugin requires an explicit model.",
+            "provider_plugin_guidance": "Use a WordPress AI provider plugin that registers the openai provider id."
+          },
+          {
+            "id": "codex",
+            "label": "Codex",
+            "backend": "codebox",
+            "runtime_id": "wp-codebox",
+            "default_model": "",
+            "model_required": false,
+            "model_guidance": "Set executor.config.model or executor.model to the Codex model requested by the task; the runtime forwards it without Homeboy core interpretation.",
+            "provider_plugin_guidance": "Use a Codex-capable WordPress AI provider plugin checkout, such as the Codex provider branch for ai-provider-for-openai."
+          },
+          {
+            "id": "claude-code",
+            "label": "Claude Code",
+            "backend": "codebox",
+            "runtime_id": "wp-codebox",
+            "default_model": "",
+            "model_required": false,
+            "model_guidance": "Claude Code provider plugins may ignore model selection; pass executor.config.model only when the provider/runtime supports it.",
+            "provider_plugin_guidance": "Use a WordPress AI provider plugin that registers the claude-code provider id and resolves Claude Code OAuth credentials."
+          }
+        ]
+      },
       "provider_defaults": {
         "openai": {
           "secret_env": ["OPENAI_API_KEY"]

--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -20,6 +20,13 @@ provider contract, task request mapping, runtime CLI, and normalized outcome
 conversion so the WordPress extension can depend on generic runtime capabilities
 instead of embedding the provider contract.
 
+Provider discovery lives in the runtime manifest's
+`provider_metadata` block. Operators and generic tooling should read that block to
+separate executor backend (`codebox`), runtime id (`wp-codebox`), provider id
+(`openai`, `codex`, `claude-code`, or another WordPress AI provider), and model
+selection (`executor.config.model` / `executor.model`). Homeboy core should treat
+provider ids and model names as opaque runtime metadata.
+
 Configure the Codex pair with task config, global settings, or environment variables:
 
 - `provider_plugin_paths`: a Codex-capable provider plugin checkout, such as the Codex provider branch of `ai-provider-for-openai`. Legacy compatibility aliases: `wp_codebox_provider_plugin_paths`, `HOMEBOY_WP_CODEBOX_PROVIDER_PLUGIN_PATH`.

--- a/tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
+++ b/tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
@@ -3,11 +3,14 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
 const manifestPath = path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'wp-codebox.json');
 const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
 const provider = manifest.agent_task_executors[0];
+const { providerMetadata, providerMetadataManifest } = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox'));
 
 assert.equal(provider.schema, 'homeboy/agent-task-executor-provider/v1');
 assert.equal(provider.invocation.schema, 'homeboy/command-invocation/v1');
@@ -22,5 +25,26 @@ assert.equal(
 	'node {{runtime_path}}/scripts/agent/homeboy-codebox-agent-task-executor.cjs'
 );
 assert.equal(provider.command, provider.invocation.display, 'legacy command stays display-compatible during deprecation');
+assert.equal(provider.provider_metadata.schema, 'homeboy/agent-task-provider-metadata/v1');
+assert.equal(provider.provider_metadata.selection.backend, 'codebox');
+assert.equal(provider.provider_metadata.selection.runtime_id, 'wp-codebox');
+assert.deepEqual(provider.provider_metadata.selection.provider_id_paths, [
+	'executor.config.provider',
+	'executor.provider',
+	'provider',
+]);
+assert.deepEqual(provider.provider_metadata.selection.model_paths, [
+	'executor.model',
+	'executor.config.model',
+	'model',
+]);
+assert.deepEqual(
+	provider.provider_metadata.providers.map((entry) => entry.id),
+	['openai', 'codex', 'claude-code']
+);
+assert.equal(providerMetadataManifest().schema, 'homeboy/agent-task-provider-metadata/v1');
+assert.equal(providerMetadata('codex').backend, 'codebox');
+assert.equal(providerMetadata('codex').runtime_id, 'wp-codebox');
+assert.match(providerMetadata('codex').model_guidance, /executor\.config\.model/);
 
 console.log('wp-codebox agent runtime command contract smoke passed');


### PR DESCRIPTION
## Summary
- Add generic provider metadata to the WP Codebox agent runtime manifest so operators can discover backend, runtime id, provider id paths, model paths, and provider guidance without Homeboy core knowing WordPress/Codebox specifics.
- Expose the metadata through the existing provider manifest helper and document backend/runtime/provider/model separation.
- Extend the WP Codebox runtime command smoke test to assert the metadata contract.

## Verification
- `node tests/wp-codebox-agent-runtime-command-contract-smoke.mjs`
- `node tests/wp-codebox-provider-plugin-defaults-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating the extension/runtime provider contract, drafting the manifest/docs/test changes, and running focused smoke verification.