### PR TITLE
Add WP Codebox checkpoint isolation to bench recipes

### DIFF
--- a/wordpress/scripts/bench/build-wp-codebox-bench-recipe.mjs
+++ b/wordpress/scripts/bench/build-wp-codebox-bench-recipe.mjs
@@ -34,4 +34,75 @@ if (options.pluginRuntime && typeof options.pluginRuntime === 'object' && !Array
 	recipe.inputs.pluginRuntime = options.pluginRuntime;
 }
 
+if (shouldEmitCaseCheckpoints(options)) {
+	emitCaseCheckpointSteps(recipe, options);
+}
+
 process.stdout.write(`${JSON.stringify(recipe, null, 2)}\n`);
+
+function shouldEmitCaseCheckpoints(recipeOptions) {
+	if (recipeOptions.checkpointCases === true || recipeOptions.caseCheckpoints === true) {
+		return true;
+	}
+
+	const caseIsolation = recipeOptions.caseIsolation;
+	return caseIsolation && typeof caseIsolation === 'object' && caseIsolation.checkpoints === true;
+}
+
+function emitCaseCheckpointSteps(targetRecipe, recipeOptions) {
+	const workloads = Array.isArray(recipeOptions.workloads) ? recipeOptions.workloads : [];
+	const caseIds = workloads
+		.map((workload) => String(workload?.id || '').trim())
+		.filter(Boolean);
+	if (!caseIds.length || !Array.isArray(targetRecipe.workflow?.steps) || !targetRecipe.workflow.steps.length) {
+		return;
+	}
+
+	const [benchStep, ...remainingSteps] = targetRecipe.workflow.steps;
+	const checkpointName = String(recipeOptions.caseIsolation?.checkpointName || recipeOptions.checkpointName || 'wordpress-fuzz-case-baseline');
+	const steps = [
+		checkpointCreateStep(checkpointName),
+		checkpointListStep(),
+	];
+
+	for (const caseId of caseIds) {
+		steps.push(
+			checkpointRestoreStep(checkpointName),
+			caseBenchStep(benchStep, caseId),
+			checkpointListStep(),
+		);
+	}
+
+	targetRecipe.workflow.steps = [...steps, ...remainingSteps];
+}
+
+function checkpointCreateStep(name) {
+	return {
+		command: 'wp-codebox.checkpoint-create',
+		args: [`name=${name}`],
+	};
+}
+
+function checkpointRestoreStep(name) {
+	return {
+		command: 'wp-codebox.checkpoint-restore',
+		args: [`name=${name}`],
+	};
+}
+
+function checkpointListStep() {
+	return {
+		command: 'wp-codebox.checkpoint-list',
+		args: [],
+	};
+}
+
+function caseBenchStep(step, caseId) {
+	return {
+		...step,
+		args: [
+			...(Array.isArray(step.args) ? step.args : []),
+			`scenario-ids-json=${JSON.stringify([caseId])}`,
+		],
+	};
+}

--- a/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
@@ -75,6 +75,50 @@ const filteredRecipe = JSON.parse(filteredResult.stdout);
 assert.deepEqual(filteredRecipe.inputs.workloads.map((workload) => workload.id), ['fixture-workload']);
 assert.deepEqual(filteredRecipe.inputs.scenarioIds, ['fixture-workload']);
 
+const checkpointResult = spawnSync(process.execPath, [script], {
+	cwd: path.join(__dirname, '..'),
+	input: JSON.stringify({
+		options: {
+			...input.options,
+			caseIsolation: {
+				checkpoints: true,
+				checkpointName: 'fixture-case-baseline',
+			},
+		},
+	}),
+	encoding: 'utf8',
+	env: { ...process.env, HOMEBOY_WP_CODEBOX_CORE_MODULE: fixtureCoreModule },
+});
+
+assert.equal(checkpointResult.status, 0, checkpointResult.stderr);
+const checkpointRecipe = JSON.parse(checkpointResult.stdout);
+assert.deepEqual(checkpointRecipe.workflow.steps, [
+	{ command: 'wp-codebox.checkpoint-create', args: ['name=fixture-case-baseline'] },
+	{ command: 'wp-codebox.checkpoint-list', args: [] },
+	{ command: 'wp-codebox.checkpoint-restore', args: ['name=fixture-case-baseline'] },
+	{
+		command: 'fixture.wordpress.bench',
+		args: [
+			'plugin-slug=fixture-plugin',
+			'lifecycle-json={"before":["fixture"]}',
+			'reset-policy-json={"mode":"snapshot"}',
+			'scenario-ids-json=["fixture-workload"]',
+		],
+	},
+	{ command: 'wp-codebox.checkpoint-list', args: [] },
+	{ command: 'wp-codebox.checkpoint-restore', args: ['name=fixture-case-baseline'] },
+	{
+		command: 'fixture.wordpress.bench',
+		args: [
+			'plugin-slug=fixture-plugin',
+			'lifecycle-json={"before":["fixture"]}',
+			'reset-policy-json={"mode":"snapshot"}',
+			'scenario-ids-json=["other-workload"]',
+		],
+	},
+	{ command: 'wp-codebox.checkpoint-list', args: [] },
+]);
+
 const cacheDiscoveryResult = spawnSync(process.execPath, [script], {
 	cwd: path.join(__dirname, '..'),
 	input: JSON.stringify(input),


### PR DESCRIPTION
## Summary
- Add opt-in WP Codebox checkpoint case isolation to the WordPress bench recipe builder.
- Emit checkpoint create/list steps before case execution and restore/list around each workload case.
- Add smoke coverage for the generated checkpoint recipe steps.

## Verification
- npm run test:wp-codebox-bench-recipe-builder
- npm run test:build-package-artifacts
- node --check scripts/bench/build-wp-codebox-bench-recipe.mjs && node --check tests/wp-codebox-bench-recipe-builder-smoke.js
- npx eslint scripts/bench/build-wp-codebox-bench-recipe.mjs tests/wp-codebox-bench-recipe-builder-smoke.js

## Residual risks
- Full npm run lint:js still fails on existing repo-wide lint debt outside this change; the touched builder has no targeted ESLint errors and the smoke test is ignored by the existing ESLint ignore pattern.
- Runtime execution of the new checkpoint commands depends on WP Codebox honoring wp-codebox.checkpoint-create, wp-codebox.checkpoint-restore, and wp-codebox.checkpoint-list recipe commands.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the recipe-builder checkpoint wiring, smoke test coverage, verification, and PR drafting.