### PR TITLE
Use Codebox plugin-state for fixture activation

### DIFF
--- a/wordpress/lib/fixture-setup.js
+++ b/wordpress/lib/fixture-setup.js
@@ -12,6 +12,7 @@ const { spawn } = require('node:child_process');
  * Internal dependencies
  */
 const { isPlainObject } = require('./shared');
+const { wpCodeboxPluginStateStep } = require('./wp-codebox-recipe-helper');
 
 function normalizeFixtureList(fixtures) {
 	if (fixtures === undefined || fixtures === null) {
@@ -216,28 +217,52 @@ async function installWordPressFixturePlugins(options = {}) {
 		});
 	}
 
+	const route = normalizeExecutionRoute(options);
 	const runCli = options.runCli || ((command, runContext) => defaultRunCli(command, {
 		...options,
 		...runContext,
 	}));
+	const runPluginStateStep = options.runPluginStateStep || (route === 'wp-codebox' && (options.runRecipeStep || options.runWpCodeboxStep)
+		? async (plugin, runContext = {}) => {
+			const recipeStep = wpCodeboxPluginStateStep({
+				activate: [{ plugin: plugin.plugin, slug: plugin.slug }],
+				report: true,
+			});
+			const result = await (options.runRecipeStep || options.runWpCodeboxStep)(recipeStep, {
+				...runContext,
+				plugin,
+				recipeStep,
+			});
+			return { ...normalizeCliResult(result), recipeStep };
+		}
+		: null);
 	for (const plugin of installed.filter((entry) => entry.activate)) {
-		const result = normalizeCliResult(await runCli(`plugin activate ${plugin.plugin}`, {
-			plugin,
-			role: 'fixture-plugin-activate',
-			timeoutMs: options.activateTimeoutMs,
-		}));
+		const activationCommand = `plugin activate ${plugin.plugin}`;
+		const result = runPluginStateStep
+			? await runPluginStateStep(plugin, {
+				role: 'fixture-plugin-activate',
+				timeoutMs: options.activateTimeoutMs,
+			})
+			: normalizeCliResult(await runCli(activationCommand, {
+				plugin,
+				role: 'fixture-plugin-activate',
+				timeoutMs: options.activateTimeoutMs,
+			}));
 		if (result.exitCode !== 0) {
-			throw Object.assign(failedStepError({ label: `activate:${plugin.slug}`, type: 'wp-cli' }, `plugin activate ${plugin.plugin}`, result), {
+			throw Object.assign(failedStepError({ label: `activate:${plugin.slug}`, type: runPluginStateStep ? 'wp-codebox' : 'wp-cli' }, activationCommand, result), {
 				fixturePlugin: plugin,
 				installedPlugins: installed,
 			});
 		}
 		plugin.activation = {
-			command: `plugin activate ${plugin.plugin}`,
+			command: activationCommand,
 			exitCode: result.exitCode,
 			stdout: result.stdout,
 			stderr: result.stderr,
 		};
+		if (result.recipeStep) {
+			plugin.activation.recipeStep = result.recipeStep;
+		}
 	}
 
 	return installed.map((plugin) => ({

--- a/wordpress/lib/wp-codebox-recipe-helper.js
+++ b/wordpress/lib/wp-codebox-recipe-helper.js
@@ -33,7 +33,7 @@ function homeboySettings(env) {
   try {
     const parsed = JSON.parse(env.HOMEBOY_SETTINGS_JSON);
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
-  } catch (_error) {
+  } catch {
     return {};
   }
 }
@@ -66,6 +66,47 @@ function parseWpCodeboxJson(stdout) {
   }
 
   return JSON.parse(trimmed);
+}
+
+function normalizePluginStateList(value, field) {
+  if (value === undefined || value === null || value === false) {
+    return [];
+  }
+  const items = Array.isArray(value) ? value : [value];
+  return items.map((item, index) => {
+    if (typeof item === 'string') {
+      const plugin = item.trim();
+      if (!plugin) {
+        throw new TypeError(`${field} plugin ${index + 1} must be non-empty.`);
+      }
+      return { plugin };
+    }
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      throw new TypeError(`${field} plugin ${index + 1} must be a string or object.`);
+    }
+    let plugin = '';
+    if (typeof item.plugin === 'string' && item.plugin.trim()) {
+      plugin = item.plugin.trim();
+    } else if (typeof item.slug === 'string' && item.slug.trim()) {
+      plugin = item.slug.trim();
+    }
+    if (!plugin) {
+      throw new TypeError(`${field} plugin ${index + 1} requires plugin or slug.`);
+    }
+    return { ...item, plugin };
+  });
+}
+
+function wpCodeboxPluginStateStep(options = {}) {
+  const state = {
+    activate: normalizePluginStateList(options.activate, 'activate'),
+    deactivate: normalizePluginStateList(options.deactivate, 'deactivate'),
+    report: options.report !== false,
+  };
+  return {
+    command: 'wordpress.plugin-state',
+    args: [`plugin-state-json=${JSON.stringify(state)}`],
+  };
 }
 
 async function runWpCodeboxRecipe({
@@ -139,6 +180,7 @@ module.exports = {
   parseWpCodeboxJson,
   recipeEventName,
   runWpCodeboxRecipe,
+  wpCodeboxPluginStateStep,
   homeboySettings,
   wpCodeboxBin,
   wpCodeboxCommand,

--- a/wordpress/tests/fixture-setup-smoke.js
+++ b/wordpress/tests/fixture-setup-smoke.js
@@ -16,6 +16,7 @@ const {
 	runWordPressFixtureSetup,
 	withWordPressFixturePlugins,
 } = require('../lib/fixture-setup');
+const { wpCodeboxPluginStateStep } = require('../lib/wp-codebox-recipe-helper');
 
 const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-fixtures-'));
 
@@ -69,6 +70,13 @@ async function main() {
 		assert.deepEqual(
 			fixtureRecipeStep({ type: 'wp-eval-file', path: 'fixtures/seed.php' }),
 			{ command: 'wordpress.run-php', args: ['code-file=fixtures/seed.php'] }
+		);
+		assert.deepEqual(
+			wpCodeboxPluginStateStep({ activate: ['source-plugin/source-plugin.php'], deactivate: [{ slug: 'old-plugin' }] }),
+			{
+				command: 'wordpress.plugin-state',
+				args: ['plugin-state-json={"activate":[{"plugin":"source-plugin/source-plugin.php"}],"deactivate":[{"slug":"old-plugin","plugin":"old-plugin"}],"report":true}'],
+			}
 		);
 
 		const recipeSteps = [];
@@ -128,6 +136,28 @@ async function main() {
 		assert.equal(fs.lstatSync(path.join(pluginsDir, 'source-plugin')).isSymbolicLink(), true);
 		assert.equal(fs.existsSync(path.join(pluginsDir, 'copy-source-plugin', 'copy-source-plugin.php')), true);
 		assert.deepEqual(activationCalls, [{ command: 'plugin activate source-plugin/source-plugin.php', slug: 'source-plugin', timeoutMs: 12345 }]);
+
+		const codeboxActivationCalls = [];
+		const codeboxInstalledPlugins = await installWordPressFixturePlugins({
+			sitePath,
+			fixtureExecutionRoute: 'wp-codebox',
+			plugins: [{ path: sourceDir, plugin: 'source-plugin/source-plugin.php' }],
+			runRecipeStep: async (recipeStep, context) => {
+				codeboxActivationCalls.push({ recipeStep, slug: context.plugin.slug, timeoutMs: context.timeoutMs });
+				return { exitCode: 0, stdout: 'activated', stderr: '' };
+			},
+			activateTimeoutMs: 23456,
+		});
+		assert.equal(codeboxActivationCalls.length, 1);
+		assert.equal(codeboxActivationCalls[0].recipeStep.command, 'wordpress.plugin-state');
+		assert.deepEqual(JSON.parse(codeboxActivationCalls[0].recipeStep.args[0].replace(/^plugin-state-json=/, '')), {
+			activate: [{ plugin: 'source-plugin/source-plugin.php', slug: 'source-plugin' }],
+			deactivate: [],
+			report: true,
+		});
+		assert.equal(codeboxActivationCalls[0].timeoutMs, 23456);
+		assert.equal(codeboxInstalledPlugins[0].activation.recipeStep.command, 'wordpress.plugin-state');
+		await restoreWordPressFixturePlugins(codeboxInstalledPlugins);
 
 		await restoreWordPressFixturePlugins(installedPlugins);
 		assert.equal(fs.readFileSync(path.join(existingDir, 'existing.txt'), 'utf8'), 'existing plugin');

--- a/wordpress/tests/wp-codebox-recipe-helper-smoke.js
+++ b/wordpress/tests/wp-codebox-recipe-helper-smoke.js
@@ -11,6 +11,7 @@ const {
   runWpCodeboxRecipe,
   wpCodeboxBin,
   wpCodeboxCommand,
+  wpCodeboxPluginStateStep,
 } = require('../lib/wp-codebox-recipe-helper');
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-recipe-helper-'));
@@ -42,6 +43,13 @@ fs.chmodSync(fixtureBin, 0o755);
   assert.equal(wpCodeboxBin({ env: {} }), 'wp-codebox');
   assert.deepEqual(wpCodeboxCommand('/tmp/wp-codebox.cjs'), { command: process.execPath, args: ['/tmp/wp-codebox.cjs'] });
   assert.deepEqual(wpCodeboxCommand('wp-codebox'), { command: 'wp-codebox', args: [] });
+  assert.deepEqual(
+    wpCodeboxPluginStateStep({ activate: ['source-plugin/source-plugin.php'], deactivate: [{ slug: 'old-plugin' }] }),
+    {
+      command: 'wordpress.plugin-state',
+      args: ['plugin-state-json={"activate":[{"plugin":"source-plugin/source-plugin.php"}],"deactivate":[{"slug":"old-plugin","plugin":"old-plugin"}],"report":true}'],
+    }
+  );
   assert.equal(recipeEventName('start'), 'recipe.start');
   assert.equal(recipeEventName('start', { eventPrefix: 'sandbox.recipe' }), 'sandbox.recipe.start');
   assert.deepEqual(parseWpCodeboxJson(' {"ok": true}\n'), { ok: true });


### PR DESCRIPTION
## Summary
- Add a product-agnostic WP Codebox recipe helper for structured wordpress.plugin-state steps.
- Route WP Codebox fixture plugin activation through wordpress.plugin-state while preserving host WP-CLI activation.
- Add smoke coverage for the helper payload and Codebox-routed fixture activation reporting.

## Verification
- npm run test:fixture-setup
- npm run test:wp-codebox-recipe-helper
- npm run test:wp-codebox-bench-recipe-builder
- npm run test:wp-codebox-phpunit-recipe-builder
- npm run lint:js -- --no-warn-ignored lib/fixture-setup.js lib/wp-codebox-recipe-helper.js tests/fixture-setup-smoke.js tests/wp-codebox-recipe-helper-smoke.js
- npm run test:build-package-artifacts
- node --check lib/fixture-setup.js lib/wp-codebox-recipe-helper.js tests/fixture-setup-smoke.js tests/wp-codebox-recipe-helper-smoke.js scripts/bench/build-wp-codebox-bench-recipe.mjs scripts/test/build-wp-codebox-phpunit-recipe.mjs

## Residual risks
- Local Homeboy component gates could not run because this checkout's Homeboy component registration has relative local_path=wordpress and no extension provider configured for component wordpress. Repo-owned npm smoke/build checks passed instead.
- This verifies Homeboy's recipe construction and routing; end-to-end runtime execution depends on the WP Codebox wordpress.plugin-state command contract.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the helper/routing change, adding tests, and running verification.