### PR TITLE
Add Codebox role matrix recipe inputs

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -316,7 +316,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const workspaceMaterialization = defaultWorkspaceMaterialization(defaults.workspaceRoot, request, config, inputs, runtimeOptions);
   const target = defaultWorkspaceTargetPayload(inputs.target || request.workspace || {}, workspaceMaterialization);
   const agentBundle = agentBundleConfigFromAgentTaskRequest(request, config, inputs);
-  const recipe = recipeConfigFromAgentTaskRequest(request, config, inputs);
+  const recipe = recipeConfigFromAgentTaskRequest(request, config, inputs, runtimeOptions);
   const mounts = agentBundleMounts(agentBundle, config.runtime_mounts || config.mounts || defaults.mounts || runtimeOptions.mounts || []);
   let componentContracts = componentContractsFromAgentTaskRequest(request, config, runtimeOptions);
   let components = runtimeComponentPaths(config, { ...defaults, ...runtimeOptions, componentContracts });
@@ -1686,7 +1686,7 @@ function firstValue(...candidates) {
   return candidates.find((candidate) => candidate !== undefined && candidate !== null && candidate !== '');
 }
 
-function recipeConfigFromAgentTaskRequest(request, config, inputs) {
+function recipeConfigFromAgentTaskRequest(request, config, inputs, runtimeOptions = {}) {
   const explicit = firstObject(
     inputs.recipe,
     inputs.recipe_pack,
@@ -1717,12 +1717,134 @@ function recipeConfigFromAgentTaskRequest(request, config, inputs) {
     target_repo: explicit.target_repo || explicit.targetRepo || firstValue(inputs.target_repo, inputs.targetRepo, config.target_repo, config.targetRepo, sourceRef.repo),
     target_pr: explicit.target_pr || explicit.targetPr || firstValue(inputs.target_pr, inputs.targetPr, config.target_pr, config.targetPr, sourceRef.pr, sourceRef.number),
     target_branch: explicit.target_branch || explicit.targetBranch || firstValue(inputs.target_branch, inputs.targetBranch, config.target_branch, config.targetBranch),
-    inputs: explicit.inputs || inputs.recipe_inputs || inputs.recipeInputs || config.recipe_inputs || config.recipeInputs,
+    inputs: recipeInputsFromAgentTaskRequest(config, inputs, explicit, runtimeOptions),
     secret_env: explicit.secret_env || explicit.secretEnv || inputs.recipe_secret_env || inputs.recipeSecretEnv || config.recipe_secret_env || config.recipeSecretEnv,
     metadata: explicit.metadata,
   }).filter(([, value]) => value !== undefined && value !== '' && !(Array.isArray(value) && value.length === 0)));
 
   return recipe.pack || recipe.name || recipe.path || recipe.repository || recipe.target_ref ? recipe : {};
+}
+
+function recipeInputsFromAgentTaskRequest(config = {}, inputs = {}, explicit = {}, runtimeOptions = {}) {
+  const recipeInputs = firstObject(explicit.inputs, inputs.recipe_inputs, inputs.recipeInputs, config.recipe_inputs, config.recipeInputs) || {};
+  const matrixInputs = roleCapabilityMatrixRecipeInputs(config, inputs, runtimeOptions);
+  if (!matrixInputs.fixtureUsers && !matrixInputs.userSessions) {
+    return Object.keys(recipeInputs).length > 0 ? recipeInputs : undefined;
+  }
+  return {
+    ...recipeInputs,
+    fixtureUsers: mergeRecipeEntriesByName(recipeInputs.fixtureUsers, matrixInputs.fixtureUsers),
+    userSessions: mergeRecipeEntriesByName(recipeInputs.userSessions, matrixInputs.userSessions),
+  };
+}
+
+function roleCapabilityMatrixRecipeInputs(config = {}, inputs = {}, runtimeOptions = {}) {
+  const runtimeRequirements = firstObject(config.runtime_requirements, config.runtimeRequirements) || {};
+  const runtimeProfile = firstObject(runtimeOptions.runtimeProfile) || {};
+  const matrix = firstDefined(
+    inputs.role_matrix,
+    inputs.roleMatrix,
+    inputs.capability_matrix,
+    inputs.capabilityMatrix,
+    config.role_matrix,
+    config.roleMatrix,
+    config.capability_matrix,
+    config.capabilityMatrix,
+    runtimeRequirements.role_matrix,
+    runtimeRequirements.roleMatrix,
+    runtimeRequirements.capability_matrix,
+    runtimeRequirements.capabilityMatrix,
+    runtimeProfile.role_matrix,
+    runtimeProfile.roleMatrix,
+    runtimeProfile.capability_matrix,
+    runtimeProfile.capabilityMatrix
+  );
+  const entries = roleCapabilityMatrixEntries(matrix);
+  if (entries.length === 0) {
+    return {};
+  }
+  return {
+    fixtureUsers: entries.map((entry) => roleMatrixFixtureUser(entry)),
+    userSessions: entries.map((entry) => roleMatrixUserSession(entry)),
+  };
+}
+
+function roleCapabilityMatrixEntries(matrix) {
+  if (Array.isArray(matrix)) {
+    return matrix.map((entry) => normalizeRoleCapabilityMatrixEntry(entry)).filter(Boolean);
+  }
+  if (!matrix || typeof matrix !== 'object') {
+    return [];
+  }
+  return Object.entries(matrix).map(([role, value]) => normalizeRoleCapabilityMatrixEntry({ role, value })).filter(Boolean);
+}
+
+function normalizeRoleCapabilityMatrixEntry(entry) {
+  if (typeof entry === 'string') {
+    return { role: entry, name: sanitizeRecipeName(entry), capabilities: [] };
+  }
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    return null;
+  }
+  const value = entry.value && typeof entry.value === 'object' && !Array.isArray(entry.value) ? entry.value : {};
+  const role = firstValue(entry.role, value.role, entry.name, value.name);
+  const name = sanitizeRecipeName(firstValue(entry.name, value.name, role));
+  if (!role || !name) {
+    return null;
+  }
+  return {
+    name,
+    role: String(role),
+    username: firstValue(entry.username, value.username),
+    email: firstValue(entry.email, value.email),
+    displayName: firstValue(entry.displayName, entry.display_name, value.displayName, value.display_name),
+    password: firstValue(entry.password, value.password),
+    capabilities: normalizeArray(firstDefined(entry.capabilities, entry.capability, value.capabilities, value.capability, Array.isArray(entry.value) ? entry.value : [])).map(String),
+    sessionName: sanitizeRecipeName(firstValue(entry.session, entry.sessionName, entry.session_name, value.session, value.sessionName, value.session_name, `${name}-session`)),
+  };
+}
+
+function roleMatrixFixtureUser(entry) {
+  return withoutEmptyObjectValues({
+    name: entry.name,
+    username: entry.username || `fixture-${entry.name}`,
+    email: entry.email,
+    role: entry.role,
+    displayName: entry.displayName,
+    password: entry.password,
+    metadata: withoutEmptyObjectValues({ capabilities: entry.capabilities }),
+  });
+}
+
+function roleMatrixUserSession(entry) {
+  return withoutEmptyObjectValues({
+    name: entry.sessionName,
+    user: entry.name,
+    metadata: withoutEmptyObjectValues({ role: entry.role, capabilities: entry.capabilities }),
+  });
+}
+
+function mergeRecipeEntriesByName(explicitEntries, generatedEntries) {
+  const entries = [];
+  const seen = new Set();
+  for (const entry of [...normalizeArray(explicitEntries), ...normalizeArray(generatedEntries)]) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      continue;
+    }
+    const name = entry.name ? String(entry.name) : '';
+    if (name && seen.has(name)) {
+      continue;
+    }
+    if (name) {
+      seen.add(name);
+    }
+    entries.push(entry);
+  }
+  return entries.length > 0 ? entries : undefined;
+}
+
+function sanitizeRecipeName(value) {
+  return String(value || '').trim().replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
 }
 
 function agentBundleConfigFromAgentTaskRequest(request, config, inputs) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -903,6 +903,72 @@ assert.deepEqual(recipePackRequest.recipe, {
   secret_env: ['EXAMPLE_RECIPE_TOKEN'],
 });
 
+const roleMatrixRecipeRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'role-matrix-recipe-task-123',
+  executor: {
+    backend: 'codebox',
+    model: 'gpt-5.5',
+    config: {
+      recipe_pack: 'example-codebox-recipes',
+      recipe: 'role-matrix-runtime',
+      runtime_profile: {
+        role_matrix: [
+          { name: 'admin', role: 'administrator', capabilities: ['manage_options'] },
+          { name: 'editor', role: 'editor', capabilities: ['edit_posts'], session: 'editor-rest' },
+        ],
+      },
+    },
+  },
+  inputs: {
+    recipe_inputs: {
+      fixture: 'role-matrix',
+      fixtureUsers: [{ name: 'admin', username: 'explicit-admin', role: 'administrator' }],
+      userSessions: [{ name: 'admin-session', user: 'admin' }],
+    },
+  },
+});
+assert.deepEqual(roleMatrixRecipeRequest.recipe.inputs, {
+  fixture: 'role-matrix',
+  fixtureUsers: [
+    { name: 'admin', username: 'explicit-admin', role: 'administrator' },
+    { name: 'editor', username: 'fixture-editor', role: 'editor', metadata: { capabilities: ['edit_posts'] } },
+  ],
+  userSessions: [
+    { name: 'admin-session', user: 'admin' },
+    { name: 'editor-rest', user: 'editor', metadata: { role: 'editor', capabilities: ['edit_posts'] } },
+  ],
+});
+
+const capabilityMatrixRecipeRequest = codeboxTaskRequestFromAgentTaskRequest({
+  ...request,
+  task_id: 'capability-matrix-recipe-task-123',
+  executor: {
+    backend: 'codebox',
+    model: 'gpt-5.5',
+    config: {
+      recipe_pack: 'example-codebox-recipes',
+      recipe: 'capability-matrix-runtime',
+      runtime_requirements: {
+        capability_matrix: {
+          shop_manager: ['manage_woocommerce', 'view_woocommerce_reports'],
+        },
+      },
+    },
+  },
+});
+assert.deepEqual(capabilityMatrixRecipeRequest.recipe.inputs.fixtureUsers, [{
+  name: 'shop_manager',
+  username: 'fixture-shop_manager',
+  role: 'shop_manager',
+  metadata: { capabilities: ['manage_woocommerce', 'view_woocommerce_reports'] },
+}]);
+assert.deepEqual(capabilityMatrixRecipeRequest.recipe.inputs.userSessions, [{
+  name: 'shop_manager-session',
+  user: 'shop_manager',
+  metadata: { role: 'shop_manager', capabilities: ['manage_woocommerce', 'view_woocommerce_reports'] },
+}]);
+
 const codexAgentRequest = {
   ...request,
   task_id: 'codex-task-123',


### PR DESCRIPTION
## Summary
- Project generic role/capability matrices into WP Codebox recipe inputs.fixtureUsers and inputs.userSessions.
- Preserve explicit recipe fixture users/sessions when generated entries share the same name.
- Cover runtime-profile role_matrix and runtime_requirements capability_matrix inputs in the Codebox executor smoke test.

## Verification
- npm run test:codebox-agent-task-executor
- node --check ../agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
- npm run test:codebox-agent-task-executor-boundary
- homeboy build wordpress --path /Users/chubes/Developer/homeboy-extensions@feature-codebox-user-session-inputs/wordpress (not available: component has no linked extension with build support)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the role/capability matrix projection, tests, verification, commit, and PR drafting.