### PR TITLE
Add WP Codebox command diagnostics planning

### DIFF
--- a/wordpress/docs/TESTING.md
+++ b/wordpress/docs/TESTING.md
@@ -37,6 +37,21 @@ runner needs to be explicit. Supported values: `wp-codebox` (default).
 HOMEBOY_WORDPRESS_TEST_RUNTIME_BACKEND=wp-codebox homeboy test <component-id>
 ```
 
+## WP Codebox command diagnostics
+
+Recipe plan inputs can request command diagnostics capture by setting
+`diagnosticsCapture`, `captureDiagnostics`, `commandDiagnostics`, or
+`diagnostics` on the recipe generator options. A boolean value requests the
+default evidence set, `queries` and `errors`; an array limits capture to the
+listed evidence types.
+
+Homeboy settings can pass the same plan through `wp_codebox_command_diagnostics`
+or `command_diagnostics`.
+
+Supported WordPress recipe commands receive the normalized plan on the step as
+`diagnostics.capture`, allowing WP Codebox to attach query/error evidence to the
+command result without Homeboy depending on product-specific behavior.
+
 ## Requirements
 
 A component needs:

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -1137,6 +1137,10 @@ fi
 if printf '%s' "$WP_CODEBOX_BOOTSTRAP_STEPS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
     WP_CODEBOX_PLUGIN_RUNTIME_JSON=$(jq -nc --argjson runtime "$WP_CODEBOX_PLUGIN_RUNTIME_JSON" --argjson setup "$WP_CODEBOX_BOOTSTRAP_STEPS_JSON" '$runtime + {setup: $setup}')
 fi
+WP_CODEBOX_COMMAND_DIAGNOSTICS_JSON="null"
+if [ "$settings_json" != "{}" ]; then
+    WP_CODEBOX_COMMAND_DIAGNOSTICS_JSON=$(printf '%s' "$settings_json" | jq -c '.wp_codebox_command_diagnostics // .command_diagnostics // .diagnostics_capture // .diagnosticsCapture // null' 2>/dev/null || echo "null")
+fi
 
 homeboy_wp_codebox_emit_memory_fatal_diagnostic() {
     local output_file="$1"
@@ -1400,7 +1404,8 @@ jq -n \
     --argjson bootstrapFiles "$WP_CODEBOX_BOOTSTRAP_FILES_JSON" \
     --argjson workloads "$WP_CODEBOX_WORKLOADS_JSON" \
     --argjson pluginRuntime "$WP_CODEBOX_PLUGIN_RUNTIME_JSON" \
-    '{
+    --argjson diagnostics "$WP_CODEBOX_COMMAND_DIAGNOSTICS_JSON" \
+    '({
         wpCodeboxBin: $wpCodeboxBin,
         options: ({
             blueprint: $blueprint,
@@ -1417,7 +1422,7 @@ jq -n \
             bootstrapFiles: $bootstrapFiles,
             workloads: $workloads
         } + (if $wp == "" then {} else {wordpressVersion: $wp} end))
-    }' | node "$BENCH_RECIPE_BUILDER" > "$RECIPE_FILE"
+    } | .options += (if $diagnostics == null then {} else {diagnosticsCapture: $diagnostics} end))' | node "$BENCH_RECIPE_BUILDER" > "$RECIPE_FILE"
 
 WP_CODEBOX_TMPFILE=$(mktemp "${ARTIFACTS_DIR}/homeboy-wp-codebox-output.XXXXXX")
 set +e

--- a/wordpress/scripts/bench/build-wp-codebox-bench-recipe.mjs
+++ b/wordpress/scripts/bench/build-wp-codebox-bench-recipe.mjs
@@ -8,6 +8,7 @@ import { readFileSync } from 'node:fs';
  * Internal dependencies
  */
 import { loadCodeboxRecipeBuilder } from './wp-codebox-recipe-builder-loader.mjs';
+import { applyWpCodeboxStepDiagnostics } from '../lib/wp-codebox-diagnostics-plan.mjs';
 
 const input = JSON.parse(readFileSync(0, 'utf8'));
 const { builder: buildWordPressBenchRecipe } = await loadCodeboxRecipeBuilder('buildWordPressBenchRecipe');
@@ -29,6 +30,7 @@ if (selectedScenarioIds.length && Array.isArray(options.workloads)) {
 }
 
 const recipe = buildWordPressBenchRecipe(options);
+applyWpCodeboxStepDiagnostics(recipe, options);
 if (options.pluginRuntime && typeof options.pluginRuntime === 'object' && !Array.isArray(options.pluginRuntime)) {
 	recipe.inputs = recipe.inputs ?? {};
 	recipe.inputs.pluginRuntime = options.pluginRuntime;

--- a/wordpress/scripts/lib/wp-codebox-diagnostics-plan.mjs
+++ b/wordpress/scripts/lib/wp-codebox-diagnostics-plan.mjs
@@ -1,0 +1,84 @@
+const SUPPORTED_DIAGNOSTIC_COMMAND_SUFFIXES = [
+	'wordpress.bench',
+	'wordpress.phpunit',
+	'wordpress.run-php',
+	'wordpress.visual-compare',
+];
+
+const DEFAULT_DIAGNOSTIC_CAPTURE = ['queries', 'errors'];
+
+export function applyWpCodeboxStepDiagnostics(recipe, options = {}) {
+	const diagnostics = normalizeDiagnosticsPlan(options);
+	if (!diagnostics) {
+		return recipe;
+	}
+
+	const steps = recipe?.workflow?.steps;
+	if (!Array.isArray(steps)) {
+		return recipe;
+	}
+
+	for (const step of steps) {
+		if (!step || typeof step !== 'object' || !supportsStepDiagnostics(step.command)) {
+			continue;
+		}
+
+		step.diagnostics = mergeStepDiagnostics(step.diagnostics, diagnostics);
+	}
+
+	return recipe;
+}
+
+export function normalizeDiagnosticsPlan(options = {}) {
+	const raw = options.diagnostics ?? options.commandDiagnostics ?? options.diagnosticsCapture ?? options.captureDiagnostics;
+	if (raw === undefined || raw === null || raw === false) {
+		return null;
+	}
+
+	if (raw === true) {
+		return { capture: [...DEFAULT_DIAGNOSTIC_CAPTURE] };
+	}
+
+	if (Array.isArray(raw)) {
+		return { capture: normalizeCaptureList(raw) };
+	}
+
+	if (typeof raw === 'object') {
+		const capture = raw.capture ?? raw.captureTypes ?? raw.types;
+		if (capture === true || capture === undefined) {
+			return { ...raw, capture: [...DEFAULT_DIAGNOSTIC_CAPTURE] };
+		}
+		return { ...raw, capture: normalizeCaptureList(capture) };
+	}
+
+	return null;
+}
+
+export function supportsStepDiagnostics(command) {
+	if (typeof command !== 'string' || !command.trim()) {
+		return false;
+	}
+
+	return SUPPORTED_DIAGNOSTIC_COMMAND_SUFFIXES.some((suffix) => command === suffix || command.endsWith(`.${suffix}`));
+}
+
+function normalizeCaptureList(value) {
+	const values = Array.isArray(value) ? value : [value];
+	const capture = values
+		.map((entry) => String(entry || '').trim())
+		.filter(Boolean);
+
+	return capture.length ? [...new Set(capture)] : [...DEFAULT_DIAGNOSTIC_CAPTURE];
+}
+
+function mergeStepDiagnostics(existing, diagnostics) {
+	if (!existing || typeof existing !== 'object' || Array.isArray(existing)) {
+		return diagnostics;
+	}
+
+	return {
+		...diagnostics,
+		...existing,
+		capture: existing.capture === undefined ? diagnostics.capture : existing.capture,
+	};
+}

--- a/wordpress/scripts/test/build-wp-codebox-phpunit-recipe.mjs
+++ b/wordpress/scripts/test/build-wp-codebox-phpunit-recipe.mjs
@@ -8,9 +8,12 @@ import { readFileSync } from 'node:fs';
  * Internal dependencies
  */
 import { loadCodeboxRecipeBuilder } from '../bench/wp-codebox-recipe-builder-loader.mjs';
+import { applyWpCodeboxStepDiagnostics } from '../lib/wp-codebox-diagnostics-plan.mjs';
 
 const input = JSON.parse(readFileSync(0, 'utf8'));
 const { builder: buildWordPressPhpunitRecipe } = await loadCodeboxRecipeBuilder('buildWordPressPhpunitRecipe');
-const recipe = buildWordPressPhpunitRecipe(input.options ?? input);
+const options = input.options ?? input;
+const recipe = buildWordPressPhpunitRecipe(options);
+applyWpCodeboxStepDiagnostics(recipe, options);
 
 process.stdout.write(`${JSON.stringify(recipe, null, 2)}\n`);

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -626,6 +626,7 @@ DEPENDENCY_PATHS="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
 WP_CONFIG_DEFINES_JSON="{}"
 PHPUNIT_ENV_JSON="{}"
 WP_CODEBOX_FILE_MOUNTS_JSON="[]"
+WP_CODEBOX_COMMAND_DIAGNOSTICS_JSON="null"
 PHPUNIT_NO_TESTS="skipped"
 WP_CODEBOX_WORDPRESS_VERSION=""
 WP_CODEBOX_MULTISITE=""
@@ -644,6 +645,9 @@ if [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]
 
     extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -r '.wp_codebox_multisite // empty' 2>/dev/null || true)
     [ -n "$extracted" ] && [ "$extracted" != "null" ] && WP_CODEBOX_MULTISITE="$extracted"
+
+    extracted=$(printf '%s' "$HOMEBOY_SETTINGS_JSON" | jq -c '.wp_codebox_command_diagnostics // .command_diagnostics // .diagnostics_capture // .diagnosticsCapture // null' 2>/dev/null || echo "null")
+    [ -n "$extracted" ] && WP_CODEBOX_COMMAND_DIAGNOSTICS_JSON="$extracted"
 fi
 if [ -n "${HOMEBOY_WORDPRESS_MULTISITE+x}" ]; then
     WP_CODEBOX_MULTISITE="$HOMEBOY_WORDPRESS_MULTISITE"
@@ -824,6 +828,7 @@ jq -n \
     --arg projectBootstrap "$WP_CODEBOX_PHPUNIT_PROJECT_BOOTSTRAP" \
     --arg dependencyMounts "$WP_CODEBOX_DEP_MOUNTS" \
     --arg multisite "$WP_CODEBOX_MULTISITE" \
+    --argjson diagnostics "$WP_CODEBOX_COMMAND_DIAGNOSTICS_JSON" \
     '({
         mounts: $mounts,
         pluginSlug: $pluginSlug,
@@ -839,7 +844,9 @@ jq -n \
         testsDir: "/wp-codebox-vendor/wp-phpunit/wp-phpunit",
         dependencyMounts: ($dependencyMounts | split("\n") | map(select(. != ""))),
         multisite: (if (($multisite | ascii_downcase) as $v | $v == "1" or $v == "true" or $v == "yes" or $v == "on") then true else false end)
-    } + (if $wp == "" then {} else {wordpressVersion: $wp} end))' > "$RECIPE_OPTIONS_FILE"
+    }
+    + (if $wp == "" then {} else {wordpressVersion: $wp} end)
+    + (if $diagnostics == null then {} else {diagnosticsCapture: $diagnostics} end))' > "$RECIPE_OPTIONS_FILE"
 
 if [ ! -f "$PHPUNIT_RECIPE_BUILDER" ]; then
     echo "Error: WP Codebox PHPUnit recipe builder not found: ${PHPUNIT_RECIPE_BUILDER}" >&2

--- a/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
@@ -34,6 +34,7 @@ const input = {
 			sha256: 'abc123',
 			setup: [{ command: 'wordpress.wp-cli', args: ['command=option update fixture_bootstrap yes'] }],
 		},
+		diagnosticsCapture: true,
 		mounts: [{ source: '/tmp/fixture-plugin', target: '/wordpress/wp-content/plugins/fixture-plugin' }],
 		extraPlugins: [{ source: '/tmp/extra-plugin.zip', slug: 'extra-plugin', activate: true }],
 	},
@@ -61,6 +62,7 @@ assert.deepEqual(recipe.workflow.steps, [{
 		'lifecycle-json={"before":["fixture"]}',
 		'reset-policy-json={"mode":"snapshot"}',
 	],
+	diagnostics: { capture: ['queries', 'errors'] },
 }]);
 
 const filteredResult = spawnSync(process.execPath, [script], {

--- a/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
@@ -19,6 +19,7 @@ const input = {
 	projectBootstrap: 'tests/legacy/bootstrap.php',
 	dependencyMounts: ['/wordpress/wp-content/plugins/dependency-one'],
 	multisite: true,
+	diagnosticsCapture: ['errors'],
 	mounts: [{ source: '/tmp/fixture-plugin', target: '/wordpress/wp-content/plugins/fixture-plugin' }],
 };
 
@@ -42,6 +43,7 @@ assert.deepEqual(recipe.workflow.steps, [{
 		'bootstrap-mode=project',
 		'project-bootstrap=tests/legacy/bootstrap.php',
 	],
+	diagnostics: { capture: ['errors'] },
 }]);
 
 const diagnosticResult = spawnSync(process.execPath, [script], {


### PR DESCRIPTION
## Summary
- Add a shared WP Codebox diagnostics-plan helper that maps recipe plan flags to supported command step diagnostics.
- Wire PHPUnit and bench WP Codebox recipe generation to pass command diagnostics from direct generator options and Homeboy settings.
- Document the plan keys and cover generated step diagnostics in recipe builder smokes.

## Verification
- `bash -n scripts/test/test-runner-wp-codebox.sh`
- `bash -n scripts/bench/bench-runner-wp-codebox.sh`
- `npm run test:wp-codebox-bench-recipe-builder`
- `npm run test:wp-codebox-phpunit-recipe-builder`
- `npx eslint scripts/lib/wp-codebox-diagnostics-plan.mjs scripts/bench/build-wp-codebox-bench-recipe.mjs scripts/test/build-wp-codebox-phpunit-recipe.mjs --no-warn-ignored`
- `npm run test:build-package-artifacts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the implementation, tests, documentation, commit, and PR description.