### PR TITLE
Centralize generic agent task planning primitives

### DIFF
--- a/runtime-agent-ci/lib/generic-agent-task-plan.js
+++ b/runtime-agent-ci/lib/generic-agent-task-plan.js
@@ -1,0 +1,155 @@
+'use strict';
+
+const {
+  agentTaskRequestFromRunnerSpec,
+  agentTaskRunnerSpec,
+} = require('./agent-task-runner-contract');
+
+const GENERIC_AGENT_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
+const GENERIC_AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
+const GENERIC_RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
+
+function genericAgentTaskRunnerSpec(options = {}) {
+  const config = options.config || options.executorConfig || options.executor_config;
+  return agentTaskRunnerSpec({
+    backend: options.backend,
+    runtime: options.runtime || options.runtimeId || options.runtime_id,
+    config,
+    secret_env: normalizeArray(options.secretEnv || options.secret_env),
+    task_timeout_seconds: options.taskTimeoutSeconds || options.task_timeout_seconds,
+    artifact_declarations: options.artifactDeclarations || options.artifact_declarations,
+    limits: options.limits,
+    expected_artifacts: options.expectedArtifacts || options.expected_artifacts,
+  });
+}
+
+function genericAgentTaskRequest(options = {}) {
+  const taskId = requiredString(options.taskId || options.task_id, 'taskId');
+  const runnerRequest = agentTaskRequestFromRunnerSpec({
+    runnerSpec: options.runnerSpec || options.runner_spec || genericAgentTaskRunnerSpec(options),
+  });
+
+  const sourceRefs = options.sourceRefs || options.source_refs;
+
+  return stripUndefined({
+    schema: options.schema || GENERIC_AGENT_TASK_REQUEST_SCHEMA,
+    task_id: taskId,
+    group_key: options.groupKey || options.group_key,
+    parent_plan_id: options.parentPlanId || options.parent_plan_id,
+    cwd: options.cwd,
+    repo: options.repo,
+    workspace: options.workspace,
+    executor: runnerRequest.executor,
+    instructions: options.instructions,
+    inputs: options.inputs,
+    source_refs: sourceRefs === undefined ? undefined : normalizeArray(sourceRefs),
+    policy: options.policy,
+    limits: runnerRequest.limits,
+    artifact_declarations: options.includeArtifactDeclarations === false ? undefined : runnerRequest.artifact_declarations,
+    expected_artifacts: runnerRequest.expected_artifacts,
+    metadata: options.metadata,
+  });
+}
+
+function genericAgentTaskPlan(options = {}) {
+  const planId = requiredString(options.planId || options.plan_id, 'planId');
+  const tasks = normalizeArray(options.tasks);
+  if (tasks.length === 0) {
+    throw new Error('tasks must contain at least one task request.');
+  }
+  return stripUndefined({
+    schema: options.schema || GENERIC_AGENT_TASK_PLAN_SCHEMA,
+    plan_id: planId,
+    tasks,
+    options: options.options,
+    metadata: options.metadata,
+  });
+}
+
+function normalizeRuntimeExecutionDescriptor(descriptor, runtimeProfile = {}) {
+  if (!descriptor || typeof descriptor !== 'object' || Array.isArray(descriptor)) {
+    return null;
+  }
+  if (Object.keys(descriptor).length === 0) {
+    return null;
+  }
+  const kind = descriptor.kind || descriptor.type || (descriptor.workflow ? 'workflow' : descriptor.bundle || descriptor.source || descriptor.path ? 'bundle' : 'ability');
+  const ability = descriptor.ability || abilityForRuntimeExecutionKind(kind, runtimeProfile);
+  const input = runtimeExecutionInput(descriptor, kind);
+  return stripUndefined({
+    schema: descriptor.schema || GENERIC_RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA,
+    kind,
+    ability,
+    input,
+    outputs: descriptor.outputs,
+    metadata: descriptor.metadata,
+  });
+}
+
+function abilityForRuntimeExecutionKind(kind, runtimeProfile = {}) {
+  if (kind === 'bundle') {
+    return runtimeProfile.runtime_bundle_ability || runtimeProfile.runtime_task_ability;
+  }
+  if (kind === 'workflow') {
+    return runtimeProfile.runtime_workflow_ability || runtimeProfile.runtime_task_ability;
+  }
+  return runtimeProfile.runtime_task_ability;
+}
+
+function runtimeExecutionInput(descriptor, kind) {
+  const explicitInput = descriptor.input && typeof descriptor.input === 'object' && !Array.isArray(descriptor.input)
+    ? descriptor.input
+    : {};
+  const bundle = descriptor.bundle && typeof descriptor.bundle === 'object' && !Array.isArray(descriptor.bundle)
+    ? descriptor.bundle
+    : {};
+  const workflow = descriptor.workflow && typeof descriptor.workflow === 'object' && !Array.isArray(descriptor.workflow)
+    ? descriptor.workflow
+    : descriptor.workflow;
+  const source = descriptor.source || descriptor.path || bundle.source || bundle.path || bundle.bundle_path;
+  const normalizedBundle = Object.keys(bundle).length > 0 ? bundle : undefined;
+  const normalizedWorkflow = workflow && (typeof workflow !== 'object' || Object.keys(workflow).length > 0) ? workflow : undefined;
+  return stripUndefined({
+    ...(kind === 'bundle' ? {
+      source,
+      bundle: normalizedBundle,
+      workflow: normalizedWorkflow,
+    } : {}),
+    ...(kind === 'workflow' ? {
+      source,
+      path: descriptor.path,
+      workflow: normalizedWorkflow,
+    } : {}),
+    ...explicitInput,
+  });
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function requiredString(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function stripUndefined(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  );
+}
+
+module.exports = {
+  GENERIC_AGENT_TASK_PLAN_SCHEMA,
+  GENERIC_AGENT_TASK_REQUEST_SCHEMA,
+  GENERIC_RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA,
+  genericAgentTaskPlan,
+  genericAgentTaskRequest,
+  genericAgentTaskRunnerSpec,
+  normalizeRuntimeExecutionDescriptor,
+};

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -2,16 +2,21 @@
 
 const {
   AGENT_TASK_RUNNER_SPEC_SCHEMA,
-  agentTaskRequestFromRunnerSpec,
-  agentTaskRunnerSpec,
   validateAgentTaskRunnerSpec,
 } = require('./agent-task-runner-contract');
+const {
+  GENERIC_AGENT_TASK_PLAN_SCHEMA,
+  GENERIC_AGENT_TASK_REQUEST_SCHEMA,
+  genericAgentTaskPlan,
+  genericAgentTaskRequest,
+  genericAgentTaskRunnerSpec,
+  normalizeRuntimeExecutionDescriptor,
+} = require('./generic-agent-task-plan');
 const { normalizeRuntimeId } = require('./runtime-provider-resolver.cjs');
 
-const AGENT_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
-const AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
+const AGENT_TASK_PLAN_SCHEMA = GENERIC_AGENT_TASK_PLAN_SCHEMA;
+const AGENT_TASK_REQUEST_SCHEMA = GENERIC_AGENT_TASK_REQUEST_SCHEMA;
 const RUNTIME_AGENT_CI_RUNTIME_PROFILE_ID = 'runtime-agent-ci';
-const RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
 
 function runtimeAgentCiRuntimeTaskRequest(options = {}, context = {}) {
   const taskId = requiredString(options.taskId || options.task_id, 'taskId');
@@ -37,9 +42,8 @@ function runtimeAgentCiAbilityTaskRequest(options = {}, context = {}) {
     ...options,
     ability,
   }, context);
-  const runnerRequest = agentTaskRequestFromRunnerSpec({ runnerSpec });
 
-  return stripUndefined({
+  return genericAgentTaskRequest({
     schema: AGENT_TASK_REQUEST_SCHEMA,
     task_id: taskId,
     group_key: options.groupKey || options.group_key,
@@ -47,15 +51,12 @@ function runtimeAgentCiAbilityTaskRequest(options = {}, context = {}) {
     cwd: options.cwd,
     repo: options.repo,
     workspace: options.workspace,
-    executor: runnerRequest.executor,
     instructions: options.instructions || '',
     inputs: {
       ...(options.inputs || {}),
       ...(options.title ? { title: options.title } : {}),
     },
-    limits: runnerRequest.limits,
-    artifact_declarations: runnerRequest.artifact_declarations,
-    expected_artifacts: runnerRequest.expected_artifacts,
+    runnerSpec,
   });
 }
 
@@ -64,7 +65,7 @@ function runtimeAgentCiRunnerSpec(options = {}, context = {}) {
   const config = taskExecutorConfig(options);
   const runtime = options.runtime || options.runtimeId || options.runtime_id || options.runtimeProvider || options.runtime_provider;
   const normalizedRuntime = runtime ? normalizeRuntimeId(runtime) : runtime;
-  return agentTaskRunnerSpec({
+  return genericAgentTaskRunnerSpec({
     backend: options.backend || options.runtimeBackend || options.runtime_backend || runtimeBackendForRuntime(normalizedRuntime),
     runtime: normalizedRuntime,
     config,
@@ -128,26 +129,6 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
   });
 }
 
-function normalizeRuntimeExecutionDescriptor(descriptor, runtimeProfile = {}) {
-  if (!descriptor || typeof descriptor !== 'object' || Array.isArray(descriptor)) {
-    return null;
-  }
-  if (Object.keys(descriptor).length === 0) {
-    return null;
-  }
-  const kind = descriptor.kind || descriptor.type || (descriptor.workflow ? 'workflow' : descriptor.bundle || descriptor.source || descriptor.path ? 'bundle' : 'ability');
-  const ability = descriptor.ability || abilityForRuntimeExecutionKind(kind, runtimeProfile);
-  const input = runtimeExecutionInput(descriptor, kind);
-  return stripUndefined({
-    schema: descriptor.schema || RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA,
-    kind,
-    ability,
-    input,
-    outputs: descriptor.outputs,
-    metadata: descriptor.metadata,
-  });
-}
-
 function runtimeAgentCiBundleRuntimeExecution(options = {}, input = {}) {
   const bundle = options.bundle && typeof options.bundle === 'object' && !Array.isArray(options.bundle) ? options.bundle : {};
   const source = options.source || options.bundlePath || options.bundle_path || bundle.source || bundle.path || bundle.bundle_path || (typeof options.bundle === 'string' ? options.bundle : undefined);
@@ -199,44 +180,6 @@ function runtimeAgentCiFirstNonEmptyArray(primary = [], legacy = []) {
   return Array.isArray(primary) && primary.length > 0 ? primary : legacy;
 }
 
-function abilityForRuntimeExecutionKind(kind, runtimeProfile = {}) {
-  if (kind === 'bundle') {
-    return runtimeProfile.runtime_bundle_ability || runtimeProfile.runtime_task_ability;
-  }
-  if (kind === 'workflow') {
-    return runtimeProfile.runtime_workflow_ability || runtimeProfile.runtime_task_ability;
-  }
-  return runtimeProfile.runtime_task_ability;
-}
-
-function runtimeExecutionInput(descriptor, kind) {
-  const explicitInput = descriptor.input && typeof descriptor.input === 'object' && !Array.isArray(descriptor.input)
-    ? descriptor.input
-    : {};
-  const bundle = descriptor.bundle && typeof descriptor.bundle === 'object' && !Array.isArray(descriptor.bundle)
-    ? descriptor.bundle
-    : {};
-  const workflow = descriptor.workflow && typeof descriptor.workflow === 'object' && !Array.isArray(descriptor.workflow)
-    ? descriptor.workflow
-    : descriptor.workflow;
-  const source = descriptor.source || descriptor.path || bundle.source || bundle.path || bundle.bundle_path;
-  const normalizedBundle = Object.keys(bundle).length > 0 ? bundle : undefined;
-  const normalizedWorkflow = workflow && (typeof workflow !== 'object' || Object.keys(workflow).length > 0) ? workflow : undefined;
-  return stripUndefined({
-    ...(kind === 'bundle' ? {
-      source,
-      bundle: normalizedBundle,
-      workflow: normalizedWorkflow,
-    } : {}),
-    ...(kind === 'workflow' ? {
-      source,
-      path: descriptor.path,
-      workflow: normalizedWorkflow,
-    } : {}),
-    ...explicitInput,
-  });
-}
-
 function resolveRuntimeAgentCiRuntimeProfile(options = {}) {
   const runtimeProfiles = options.runtimeProfiles || options.runtime_profiles || options.config?.runtime_profiles || options.config?.runtimeProfiles || {};
   const runtimeProfilePresets = options.runtimeProfilePresets || options.runtime_profile_presets || options.config?.runtime_profile_presets || options.config?.runtimeProfilePresets || {};
@@ -270,15 +213,10 @@ function runtimeAgentCiRuntimeProfilesForOptions(options, runtimeProfile) {
 const runtimeProfilesForOptions = runtimeAgentCiRuntimeProfilesForOptions;
 
 function runtimeAgentCiPlan(options = {}) {
-  const planId = requiredString(options.planId || options.plan_id, 'planId');
-  const tasks = normalizeArray(options.tasks);
-  if (tasks.length === 0) {
-    throw new Error('tasks must contain at least one task request.');
-  }
-  return stripUndefined({
+  return genericAgentTaskPlan({
     schema: AGENT_TASK_PLAN_SCHEMA,
-    plan_id: planId,
-    tasks,
+    plan_id: options.planId || options.plan_id,
+    tasks: options.tasks,
     options: options.options,
     metadata: options.metadata,
   });
@@ -309,7 +247,9 @@ module.exports = {
   AGENT_TASK_REQUEST_SCHEMA,
   AGENT_TASK_RUNNER_SPEC_SCHEMA,
   RUNTIME_AGENT_CI_RUNTIME_PROFILE_ID,
-  agentTaskRequestFromRunnerSpec,
+  genericAgentTaskPlan,
+  genericAgentTaskRequest,
+  genericAgentTaskRunnerSpec,
   runtimeAgentCiAbilityTaskRequest,
   runtimeAgentCiBundleRuntimeExecution,
   runtimeAgentCiFirstNonEmptyArray,

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -8,11 +8,16 @@ import { fileURLToPath } from 'node:url';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const require = createRequire(import.meta.url);
 const runtimeAgentCi = require(path.join(repoRoot, 'runtime-agent-ci/index.js'));
+const {
+  genericAgentTaskPlan,
+  genericAgentTaskRequest,
+} = require(path.join(repoRoot, 'runtime-agent-ci/lib/generic-agent-task-plan.js'));
 
 const genericBoundaryTerms = /Data Machine|DataMachine|datamachine|data-machine|wp-site-generator|WPSG|site-generator|site generator/;
 const genericFiles = [
   'runtime-agent-ci/index.js',
   'runtime-agent-ci/lib/runtime-agent-ci-plan.js',
+  'runtime-agent-ci/lib/generic-agent-task-plan.js',
   '.github/workflows/runtime-agent-ci.yml',
 ];
 
@@ -152,5 +157,47 @@ assert.equal(genericRequest.executor.backend, 'codebox');
 assert.equal(genericRequest.executor.runtime, 'wp-codebox');
 assert.deepEqual(genericRequest.expected_artifacts, ['packet']);
 assert.deepEqual(genericRequest.executor.config.runtime_task, { ability: 'example/run-task', input: { prompt: 'Cook.' } });
+
+assert.deepEqual(
+  runtimeAgentCi.runtimeAgentCiAbilityTaskRequest({
+    taskId: 'equivalent-task',
+    backend: 'codebox',
+    runtimeProvider: 'codebox',
+    runtimeProfile: runtimeProfile.id,
+    runtimeProfiles: { [runtimeProfile.id]: runtimeProfile },
+    ability: 'example/run-task',
+    abilityInput: { prompt: 'Cook.' },
+    expectedArtifacts: ['packet'],
+  }),
+  genericAgentTaskRequest({
+    taskId: 'equivalent-task',
+    instructions: '',
+    inputs: {},
+    runnerSpec: runtimeAgentCi.runtimeAgentCiRunnerSpec({
+      backend: 'codebox',
+      runtimeProvider: 'codebox',
+      runtimeProfile: runtimeProfile.id,
+      runtimeProfiles: { [runtimeProfile.id]: runtimeProfile },
+      ability: 'example/run-task',
+      abilityInput: { prompt: 'Cook.' },
+      expectedArtifacts: ['packet'],
+    }),
+  })
+);
+
+assert.deepEqual(
+  runtimeAgentCi.runtimeAgentCiPlan({
+    planId: 'equivalent-plan',
+    tasks: [genericRequest],
+    options: { concurrency: 1 },
+    metadata: { preset: 'runtime-agent-ci' },
+  }),
+  genericAgentTaskPlan({
+    planId: 'equivalent-plan',
+    tasks: [genericRequest],
+    options: { concurrency: 1 },
+    metadata: { preset: 'runtime-agent-ci' },
+  })
+);
 
 console.log('runtime agent CI contract smoke passed');

--- a/wordpress/lib/wordpress-runtime-task-planner.js
+++ b/wordpress/lib/wordpress-runtime-task-planner.js
@@ -9,14 +9,15 @@ const crypto = require('node:crypto');
  * Internal dependencies
  */
 const {
-	AGENT_TASK_REQUEST_SCHEMA,
-} = require('../../runtime-agent-ci/lib/agent-task-provider-contract');
-const {
-	agentTaskRequestFromRunnerSpec,
-	agentTaskRunnerSpec,
-} = require('../../runtime-agent-ci/lib/agent-task-runner-contract');
+	GENERIC_AGENT_TASK_PLAN_SCHEMA,
+	GENERIC_AGENT_TASK_REQUEST_SCHEMA,
+	genericAgentTaskPlan,
+	genericAgentTaskRequest,
+	genericAgentTaskRunnerSpec,
+} = require('../../runtime-agent-ci/lib/generic-agent-task-plan');
 
-const WORDPRESS_RUNTIME_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
+const WORDPRESS_RUNTIME_TASK_PLAN_SCHEMA = GENERIC_AGENT_TASK_PLAN_SCHEMA;
+const WORDPRESS_RUNTIME_TASK_REQUEST_SCHEMA = GENERIC_AGENT_TASK_REQUEST_SCHEMA;
 const WORDPRESS_RUNTIME_TASK_COMPATIBILITY_BACKEND = 'codebox';
 const WORDPRESS_RUNTIME_TASK_COMPATIBILITY_RUNTIME = 'wp-codebox';
 const WORDPRESS_RUNTIME_TASK_DEFAULT_BACKEND = WORDPRESS_RUNTIME_TASK_COMPATIBILITY_BACKEND;
@@ -43,7 +44,7 @@ function wordpressRuntimeTaskPlan(options = {}) {
 		fanout: taskOption.fanout || taskOption.matrix || taskOption.metadata?.fanout,
 	}));
 
-	return stripUndefined({
+	return genericAgentTaskPlan({
 		schema: WORDPRESS_RUNTIME_TASK_PLAN_SCHEMA,
 		plan_id: planId,
 		tasks,
@@ -64,23 +65,20 @@ function wordpressRuntimeTaskRequest(options = {}) {
 	const taskId = requiredString(options.taskId || options.task_id, 'taskId');
 	const ability = requiredString(options.ability, 'ability');
 	const abilityInput = runtimeAbilityInput(options);
-	const runnerRequest = agentTaskRequestFromRunnerSpec({
-		runnerSpec: wordpressRuntimeTaskRunnerSpec({
-			...options,
-			ability,
-			abilityInput,
-		}),
+	const runnerSpec = wordpressRuntimeTaskRunnerSpec({
+		...options,
+		ability,
+		abilityInput,
 	});
 
-	return stripUndefined({
-		schema: AGENT_TASK_REQUEST_SCHEMA,
+	return genericAgentTaskRequest({
+		schema: WORDPRESS_RUNTIME_TASK_REQUEST_SCHEMA,
 		task_id: taskId,
 		group_key: options.groupKey || options.group_key,
 		parent_plan_id: options.parentPlanId || options.parent_plan_id || options.planId || options.plan_id,
 		cwd: options.cwd,
 		repo: options.repo,
 		workspace: options.workspace,
-		executor: runnerRequest.executor,
 		instructions: options.instructions || instructionsForAbility(ability),
 		inputs: stripUndefined({
 			...(options.inputs || {}),
@@ -89,18 +87,18 @@ function wordpressRuntimeTaskRequest(options = {}) {
 		}),
 		source_refs: normalizeArray(options.sourceRefs || options.source_refs),
 		policy: options.policy || WORDPRESS_RUNTIME_TASK_DEFAULT_POLICY,
-		limits: runnerRequest.limits,
-		expected_artifacts: runnerRequest.expected_artifacts,
 		metadata: stripUndefined({
 			...(options.metadata || {}),
 			fanout: options.fanout,
 		}),
+		includeArtifactDeclarations: false,
+		runnerSpec,
 	});
 }
 
 function wordpressRuntimeTaskRunnerSpec(options = {}) {
 	const config = wordpressRuntimeTaskExecutorConfig(options);
-	return agentTaskRunnerSpec({
+	return genericAgentTaskRunnerSpec({
 		backend: wordpressRuntimeTaskBackend(options),
 		runtime: wordpressRuntimeTaskRuntime(options),
 		config,
@@ -229,6 +227,7 @@ module.exports = {
 	WORDPRESS_RUNTIME_TASK_DEFAULT_POLICY,
 	WORDPRESS_RUNTIME_TASK_DEFAULT_RUNTIME,
 	WORDPRESS_RUNTIME_TASK_PLAN_SCHEMA,
+	WORDPRESS_RUNTIME_TASK_REQUEST_SCHEMA,
 	wordpressRuntimeTaskBackend,
 	wordpressRuntimeTaskExecutorConfig,
 	wordpressRuntimeTaskPlan,

--- a/wordpress/tests/wordpress-runtime-task-planner-smoke.js
+++ b/wordpress/tests/wordpress-runtime-task-planner-smoke.js
@@ -8,7 +8,11 @@ const { spawnSync } = require('node:child_process');
 const {
 	wordpressRuntimeTaskPlan,
 	wordpressRuntimeTaskRequest,
+	wordpressRuntimeTaskRunnerSpec,
 } = require('../lib/wordpress-runtime-task-planner');
+const {
+	genericAgentTaskRequest,
+} = require('../../runtime-agent-ci/lib/generic-agent-task-plan');
 
 const contract = JSON.parse(fs.readFileSync(path.join(
 	__dirname,
@@ -83,6 +87,31 @@ assert.equal(request.schema, contract.schemas.request);
 assert.equal(request.task_id, 'single-runtime-task-smoke');
 assert.equal(request.instructions, 'Run WordPress runtime ability example/materialize-artifact and return the declared artifacts.');
 assert.deepEqual(request.inputs.ability_input, { slug: 'example' });
+
+assert.deepEqual(
+	request,
+	genericAgentTaskRequest({
+		schema: contract.schemas.request,
+		taskId: 'single-runtime-task-smoke',
+		parentPlanId: undefined,
+		instructions: 'Run WordPress runtime ability example/materialize-artifact and return the declared artifacts.',
+		inputs: {
+			ability: 'example/materialize-artifact',
+			ability_input: { slug: 'example' },
+		},
+		sourceRefs: [],
+		policy: { read: 'sandbox', write: 'sandbox', apply: 'review' },
+		metadata: {},
+		includeArtifactDeclarations: false,
+		runnerSpec: wordpressRuntimeTaskRunnerSpec({
+			taskId: 'single-runtime-task-smoke',
+			ability: 'example/materialize-artifact',
+			abilityInput: { slug: 'example' },
+			backend: 'codebox',
+			runtime: 'wp-codebox',
+		}),
+	})
+);
 
 const script = path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wordpress-runtime-task-plan.cjs');
 const result = spawnSync(process.execPath, [


### PR DESCRIPTION
## Summary
- Add a generic agent task planning helper for plan, request, runner spec, and runtime execution descriptor primitives.
- Rewire runtime-agent-ci and WordPress runtime task planner presets to delegate shared request/plan assembly to the generic helper.
- Add equivalence assertions proving existing preset callers produce the same shapes as the generic primitives.

## Tests
- `node tests/runtime-agent-ci-contract-smoke.mjs`
- `node wordpress/tests/wordpress-runtime-task-planner-smoke.js`
- `node wordpress/tests/generic-agent-runtime-contract.test.js`

## Follow-up gaps
- `node wordpress/tests/agent-task-core-contract-drift.test.js` still fails on current `origin/main` because the fixture lacks existing live `provider_metadata` from the WordPress codebox provider contract; this appears unrelated to the planning primitive refactor.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Factoring shared agent task planning primitives, updating wrappers/tests, and drafting this PR description.