### PR TITLE
Extract generic agent loop runner

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -127,6 +127,8 @@ function buildConfig(env) {
     workload_run_before: parseJsonInput('workload_run_before', env.WORKLOAD_RUN_BEFORE || '[]', 'array', []),
     workload_run_after: parseJsonInput('workload_run_after', env.WORKLOAD_RUN_AFTER || '[]', 'array', []),
     required_abilities: parseJsonInput('required_abilities', env.REQUIRED_ABILITIES || '[]', 'array', []),
+    success_requires_pr: env.SUCCESS_REQUIRES_PR !== 'false',
+    success_completion_outcomes: parseJsonInput('success_completion_outcomes', env.SUCCESS_COMPLETION_OUTCOMES || '[]', 'array', []),
     provider: env.PROVIDER || '',
     model: env.MODEL || '',
     provider_register_function: providerPlugin.register_function || '',

--- a/agent-runtimes/wp-codebox/lib/runtime-agent-outcome-adapter.js
+++ b/agent-runtimes/wp-codebox/lib/runtime-agent-outcome-adapter.js
@@ -1,0 +1,20 @@
+'use strict';
+
+function scenarioResultsFromOutcome(outcome) {
+  const codebox = outcome?.metadata?.codebox || {};
+  const workload = codebox?.raw?.agent_runtime?.result
+    || codebox?.agent_runtime?.workload
+    || codebox?.agent_runtime?.result
+    || codebox?.metadata?.agent_runtime?.workload
+    || codebox?.metadata?.agent_runtime?.result
+    || codebox?.agentResult
+    || codebox?.agent_result
+    || null;
+
+  if (workload && Array.isArray(workload.scenarios)) {
+    return workload;
+  }
+  return null;
+}
+
+module.exports = { scenarioResultsFromOutcome };

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -4,6 +4,12 @@
   "name": "WP Codebox",
   "version": "1.2.0",
   "description": "WP Codebox agent runtime for Homeboy agent tasks.",
+  "agent_loop": {
+    "outcome_adapter": {
+      "module": "agent-runtimes/wp-codebox/lib/runtime-agent-outcome-adapter.js",
+      "export": "scenarioResultsFromOutcome"
+    }
+  },
   "ci_materialization": {
     "checkout": {
       "repo": "Automattic/wp-codebox",

--- a/runtime-agent-ci/index.js
+++ b/runtime-agent-ci/index.js
@@ -1,3 +1,4 @@
 'use strict';
 
 module.exports = require('./lib/runtime-agent-ci-plan');
+Object.assign(module.exports, require('./lib/generic-agent-loop-runner'));

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -1,0 +1,261 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { runtimeAgentCiTaskExecutorConfig } = require('./runtime-agent-ci-plan');
+
+function buildGenericAgentLoopRequest(options = {}) {
+  const plan = requiredObject(options.plan, 'plan');
+  const runtime = requiredObject(options.runtime, 'runtime');
+  const configPath = options.configPath || options.config_path || '';
+  const taskId = plan.task_id || plan.workload_id || 'generic-agent-loop';
+  const runtimeComponents = optionalObject(plan.runtime_components);
+  const runtimeComponentPaths = Object.fromEntries(Object.entries({
+    ...optionalObject(plan.runtime_component_paths),
+    runtime: runtimeComponents.runtime,
+  }).filter(([, value]) => nonEmpty(value)));
+  const executorConfig = runtimeAgentCiTaskExecutorConfig(Object.fromEntries(Object.entries({
+    ...plan,
+    ...runtimeTaskOptions(plan),
+    runtime_component_paths: runtimeComponentPaths,
+    homeboy_extensions: plan.homeboy_extensions || plan.homeboy_extensions_path || options.extensionPath || options.extension_path,
+    artifacts: plan.artifacts_path || plan.artifacts,
+    replay_bundle_dir: plan.replay_bundle_dir || options.replayBundleDir || options.replay_bundle_dir,
+  }).filter(([, value]) => nonEmpty(value))));
+
+  return {
+    schema: 'homeboy/agent-task-request/v1',
+    task_id: String(taskId),
+    group_key: plan.group_key || plan.workload_id || '',
+    instructions: plan.prompt || plan.workload_label || 'Run agent task.',
+    source_refs: configPath ? [{ kind: 'config', path: configPath }] : [],
+    workspace: compactObject({ repository: plan.target_repo, path: plan.component_path }),
+    expected_artifacts: expectedArtifactsFromPlan(plan),
+    artifact_declarations: normalizeArray(plan.artifact_declarations),
+    policy: optionalObject(plan.policy),
+    limits: compactObject({
+      timeout_ms: positiveInteger(plan.time_budget_ms),
+      task_timeout_seconds: positiveInteger(plan.task_timeout_seconds || plan.taskTimeoutSeconds),
+    }),
+    inputs: {
+      target: compactObject({ repository: plan.target_repo, path: plan.component_path }),
+      context: compactObject({ config_path: configPath, workflow_run_url: workflowRunUrl(options.env || process.env) }),
+    },
+    executor: {
+      backend: runtime.executor.backend,
+      model: plan.model || '',
+      config: executorConfig,
+      secret_env: plan.secret_env || [],
+    },
+  };
+}
+
+function runGenericAgentLoop(options = {}) {
+  const runtime = requiredObject(options.runtime, 'runtime');
+  const request = options.request || buildGenericAgentLoopRequest(options);
+  const execute = options.execute || executeRuntimeProvider;
+  const outcome = normalizeOutcome(execute({ ...options, request, runtime }), request);
+  const results = materializeGenericAgentLoopResults(outcome, { ...options, runtime });
+  const assertion = options.validate === false ? null : assertGenericAgentLoopOutcome(results, options.validationPolicy || options.validation_policy || {});
+  return { request, outcome, results, assertion };
+}
+
+function executeRuntimeProvider(options = {}) {
+  const runtime = requiredObject(options.runtime, 'runtime');
+  if (!runtime.executor.path) {
+    throw new Error(`Runtime ${runtime.id || '(unknown)'} does not declare an executor path.`);
+  }
+  const spawn = options.spawnSync || spawnSync;
+  const result = spawn(process.execPath, [runtime.executor.path], {
+    encoding: 'utf8',
+    input: JSON.stringify(options.request),
+    env: options.env || process.env,
+    maxBuffer: 1024 * 1024 * 20,
+  });
+  if (result.stderr && options.stderr !== false) {
+    process.stderr.write(result.stderr);
+  }
+  if (!result.stdout || !result.stdout.trim()) {
+    return {
+      schema: 'homeboy/agent-task-outcome/v1',
+      task_id: options.request.task_id,
+      status: 'failed',
+      summary: 'Runtime agent task executor produced no JSON outcome.',
+      diagnostics: [{
+        class: 'homeboy.agent_loop.no_outcome',
+        message: 'Runtime agent task executor produced no JSON outcome.',
+        data: { exit_status: result.status ?? 1 },
+      }],
+    };
+  }
+  return JSON.parse(result.stdout);
+}
+
+function materializeGenericAgentLoopResults(outcome, options = {}) {
+  const adapter = resolveOutcomeAdapter(options.runtime, options.repoRoot || options.repo_root);
+  if (adapter) {
+    const results = adapter(outcome, options);
+    if (results && Array.isArray(results.scenarios)) {
+      return results;
+    }
+  }
+  const embedded = outcome?.metadata?.agent_loop_results || outcome?.metadata?.results || outcome?.results;
+  if (embedded && Array.isArray(embedded.scenarios)) {
+    return embedded;
+  }
+  return {
+    scenarios: [{
+      id: outcome.task_id || options.plan?.workload_id || 'generic-agent-loop',
+      label: outcome.summary || 'Agent task',
+      metrics: { generic_agent_task_executor_mean: 1 },
+      metadata: {
+        job_status: outcome.status,
+        success_status: outcome.status,
+        agent_task_outcome: outcome,
+      },
+    }],
+  };
+}
+
+function assertGenericAgentLoopOutcome(results, validationPolicy = {}) {
+  const scenarioId = validationPolicy.scenario_id || validationPolicy.workload_id || validationPolicy.flow_slug || '';
+  const scenario = findScenario(results, scenarioId);
+  const metadata = scenario.metadata || {};
+  const jobStatus = metadata.job_status || '';
+  const successStatus = metadata.success_status || '';
+  const errorMessage = metadata.error_message || '';
+  const noChangesAllowed = validationPolicy.success_requires_pr === false;
+  const allowedCompletionOutcomes = normalizeArray(validationPolicy.success_completion_outcomes);
+  const completionOutcome = metadata.completion_outcome || metadata.completionOutcome || '';
+  const completionOutcomeSatisfied = metadata.completion_outcome_satisfied === true || Boolean(completionOutcome && allowedCompletionOutcomes.includes(completionOutcome));
+  const assertion = {
+    scenario_id: scenario.id || scenarioId,
+    job_status: jobStatus,
+    success_status: successStatus,
+    error_message: errorMessage,
+    completion_outcome_satisfied: completionOutcomeSatisfied,
+    no_changes_allowed: noChangesAllowed,
+  };
+
+  if (errorMessage) {
+    throw new Error(`scenario ${assertion.scenario_id} completed with error_message=${errorMessage}`);
+  }
+  if (successStatus === 'pr_opened' || completionOutcomeSatisfied || (successStatus === 'no_changes' && noChangesAllowed)) {
+    return assertion;
+  }
+  throw new Error(`scenario ${assertion.scenario_id} expected opened PR, satisfied completion outcome, or allowed no-changes result, got job_status=${jobStatus} success_status=${successStatus} completion_outcome_satisfied=${completionOutcomeSatisfied ? 'true' : 'false'} no_changes_allowed=${noChangesAllowed ? 'true' : 'false'}`);
+}
+
+function writeGenericAgentLoopArtifacts(options = {}) {
+  if (options.outcomeFile) {
+    writeJsonFile(options.outcomeFile, options.outcome);
+  }
+  if (options.resultsFile) {
+    writeJsonFile(options.resultsFile, options.results);
+  }
+}
+
+function expectedArtifactsFromPlan(plan) {
+  const expected = normalizeArray(plan.expected_artifacts);
+  if (expected.length > 0) {
+    return expected;
+  }
+  return normalizeArray(plan.artifact_declarations)
+    .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true)
+    .map((declaration) => declaration.name || declaration.id || '')
+    .filter(Boolean);
+}
+
+function runtimeTaskOptions(plan) {
+  const runtimeTask = optionalObject(plan.runtime_task);
+  if (!runtimeTask.ability) {
+    return {};
+  }
+  return {
+    ability: runtimeTask.ability,
+    abilityInput: optionalObject(runtimeTask.input),
+  };
+}
+
+function resolveOutcomeAdapter(runtime, repoRoot) {
+  const adapterConfig = runtime?.manifest?.agent_loop?.outcome_adapter;
+  if (!adapterConfig || !adapterConfig.module) {
+    return null;
+  }
+  const root = repoRoot || path.resolve(__dirname, '..', '..');
+  const adapterModule = require(path.resolve(root, adapterConfig.module));
+  const adapter = adapterConfig.export ? adapterModule[adapterConfig.export] : adapterModule;
+  if (typeof adapter !== 'function') {
+    throw new Error(`Runtime ${runtime.id} outcome adapter is not a function: ${adapterConfig.module}`);
+  }
+  return adapter;
+}
+
+function normalizeOutcome(value, request) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value;
+  }
+  return {
+    schema: 'homeboy/agent-task-outcome/v1',
+    task_id: request.task_id,
+    status: 'failed',
+    summary: 'Runtime agent task executor produced an invalid outcome.',
+  };
+}
+
+function findScenario(results, scenarioId) {
+  const scenarios = normalizeArray(results?.scenarios);
+  const scenario = scenarioId ? scenarios.find((candidate) => candidate.id === scenarioId) : scenarios[0];
+  if (!scenario) {
+    throw new Error(`scenario ${scenarioId || '(first)'} was not found in agent loop results.`);
+  }
+  return scenario;
+}
+
+function workflowRunUrl(env) {
+  return env.GITHUB_SERVER_URL && env.GITHUB_REPOSITORY && env.GITHUB_RUN_ID
+    ? `${env.GITHUB_SERVER_URL}/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}`
+    : '';
+}
+
+function writeJsonFile(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function positiveInteger(value) {
+  const parsed = Number.parseInt(value || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function compactObject(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => nonEmpty(entry)));
+}
+
+function optionalObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function requiredObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${name} must be an object.`);
+  }
+  return value;
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function nonEmpty(value) {
+  return value !== undefined && value !== null && value !== '';
+}
+
+module.exports = {
+  assertGenericAgentLoopOutcome,
+  buildGenericAgentLoopRequest,
+  materializeGenericAgentLoopResults,
+  runGenericAgentLoop,
+  writeGenericAgentLoopArtifacts,
+};

--- a/runtime-agent-ci/scripts/run-agent-loop.cjs
+++ b/runtime-agent-ci/scripts/run-agent-loop.cjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { runGenericAgentLoop, writeGenericAgentLoopArtifacts } = require('../lib/generic-agent-loop-runner');
+const { resolveRuntimeProvider } = require('../lib/runtime-provider-resolver.cjs');
+
+try {
+  const configPath = process.argv[2] || process.env.HOMEBOY_RUNTIME_AGENT_CONFIG_PATH || '';
+  if (!configPath) {
+    throw new Error('Pass an agent loop JSON plan path as argv[1] or HOMEBOY_RUNTIME_AGENT_CONFIG_PATH.');
+  }
+  const plan = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const runtime = resolveRuntimeProvider(plan.runtime_id || process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || 'wp-codebox', {
+    repoRoot,
+    workspace: plan.component_path || process.cwd(),
+  });
+  const result = runGenericAgentLoop({
+    plan,
+    runtime,
+    configPath,
+    repoRoot,
+    extensionPath: plan.homeboy_extensions_path || repoRoot,
+    replayBundleDir: plan.replay_bundle_dir || process.env.HOMEBOY_RUNTIME_AGENT_REPLAY_BUNDLE_DIR,
+    validationPolicy: {
+      scenario_id: plan.workload_id,
+      success_requires_pr: plan.success_requires_pr,
+      success_completion_outcomes: plan.success_completion_outcomes,
+    },
+  });
+  writeGenericAgentLoopArtifacts({
+    outcome: result.outcome,
+    results: result.results,
+    outcomeFile: process.env.HOMEBOY_AGENT_TASK_OUTCOME_FILE || '',
+    resultsFile: process.env.HOMEBOY_RUNTIME_AGENT_RESULTS_FILE || '',
+  });
+  process.stdout.write(`${JSON.stringify(result.outcome, null, 2)}\n`);
+  process.exitCode = result.outcome.status === 'succeeded' || result.outcome.status === 'no_op' ? 0 : 1;
+} catch (error) {
+  process.stderr.write(`${error && error.message ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}

--- a/tests/generic-agent-loop-runner-smoke.mjs
+++ b/tests/generic-agent-loop-runner-smoke.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const {
+  buildGenericAgentLoopRequest,
+  runGenericAgentLoop,
+} = require(path.join(repoRoot, 'runtime-agent-ci'));
+
+const runtimeProfile = {
+  schema: 'homeboy/runtime-profile/v1',
+  id: 'example-loop',
+  runtime_task_ability: 'example/run-task',
+};
+const plan = {
+  workload_id: 'loop-1',
+  workload_label: 'Generic loop fixture',
+  target_repo: 'Example/project',
+  component_path: '/workspace/project',
+  runtime_id: 'example-runtime',
+  runtime_profile: runtimeProfile.id,
+  runtime_profiles: { [runtimeProfile.id]: runtimeProfile },
+  provider: 'fake-provider',
+  model: 'fake-model',
+  prompt: 'Materialize the fixture.',
+  runtime_task: { ability: 'example/run-task', input: { prompt: 'Cook.' } },
+  artifact_declarations: [{ name: 'fixture-result', required: true }],
+  time_budget_ms: 120000,
+  success_requires_pr: false,
+};
+const runtime = {
+  id: 'example-runtime',
+  executor: { backend: 'fake-provider', path: '/not-called' },
+  manifest: {},
+};
+
+const request = buildGenericAgentLoopRequest({ plan, runtime, configPath: '/tmp/agent-loop-plan.json' });
+assert.equal(request.schema, 'homeboy/agent-task-request/v1');
+assert.equal(request.task_id, 'loop-1');
+assert.equal(request.executor.backend, 'fake-provider');
+assert.equal(request.executor.config.runtime_profile, 'example-loop');
+assert.deepEqual(request.executor.config.runtime_task, { ability: 'example/run-task', input: { prompt: 'Cook.' } });
+assert.deepEqual(request.expected_artifacts, ['fixture-result']);
+assert.equal(request.limits.timeout_ms, 120000);
+
+let providerSawRequest = false;
+const loop = runGenericAgentLoop({
+  plan,
+  runtime,
+  configPath: '/tmp/agent-loop-plan.json',
+  validationPolicy: { scenario_id: 'loop-1', success_requires_pr: false },
+  execute: ({ request: providerRequest }) => {
+    providerSawRequest = true;
+    assert.equal(providerRequest.task_id, 'loop-1');
+    assert.equal(providerRequest.executor.config.provider, 'fake-provider');
+    return {
+      schema: 'homeboy/agent-task-outcome/v1',
+      task_id: providerRequest.task_id,
+      status: 'succeeded',
+      summary: 'Fixture provider completed.',
+      metadata: {
+        agent_loop_results: {
+          scenarios: [{
+            id: 'loop-1',
+            metadata: {
+              job_status: 'completed',
+              success_status: 'no_changes',
+            },
+          }],
+        },
+      },
+    };
+  },
+});
+assert.equal(providerSawRequest, true);
+assert.equal(loop.outcome.status, 'succeeded');
+assert.equal(loop.assertion.success_status, 'no_changes');
+assert.equal(loop.assertion.no_changes_allowed, true);
+
+const adapterLoop = runGenericAgentLoop({
+  plan: { ...plan, workload_id: 'codebox-loop', success_requires_pr: true },
+  runtime: {
+    id: 'wp-codebox',
+    executor: { backend: 'codebox', path: '/not-called' },
+    manifest: {
+      agent_loop: {
+        outcome_adapter: {
+          module: 'agent-runtimes/wp-codebox/lib/runtime-agent-outcome-adapter.js',
+          export: 'scenarioResultsFromOutcome',
+        },
+      },
+    },
+  },
+  repoRoot,
+  validationPolicy: { scenario_id: 'codebox-loop', success_requires_pr: true },
+  execute: () => ({
+    schema: 'homeboy/agent-task-outcome/v1',
+    task_id: 'codebox-loop',
+    status: 'succeeded',
+    metadata: {
+      codebox: {
+        raw: {
+          agent_runtime: {
+            result: {
+              scenarios: [{
+                id: 'codebox-loop',
+                metadata: {
+                  job_status: 'completed',
+                  success_status: 'pr_opened',
+                },
+              }],
+            },
+          },
+        },
+      },
+    },
+  }),
+});
+assert.equal(adapterLoop.assertion.success_status, 'pr_opened');
+
+console.log('generic agent loop runner smoke passed');

--- a/wordpress/scripts/agent/run-runtime-agent-task.cjs
+++ b/wordpress/scripts/agent/run-runtime-agent-task.cjs
@@ -8,13 +8,15 @@
  */
 const fs = require('node:fs');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
 
 /**
  * Internal dependencies
  */
-const { runtimeAgentCiTaskExecutorConfig } = require('../../../runtime-agent-ci');
 const { resolveRuntimeProvider } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
+const {
+  runGenericAgentLoop,
+  writeGenericAgentLoopArtifacts,
+} = require('../../../runtime-agent-ci');
 
 const SCRIPT_DIR = __dirname;
 const EXTENSION_PATH = path.resolve(SCRIPT_DIR, '..', '..');
@@ -32,173 +34,32 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
-function nonEmpty(value) {
-  return value !== undefined && value !== null && value !== '';
-}
-
-function optionalObject(value) {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
-}
-
-function normalizeArray(value) {
-  return Array.isArray(value) ? value : [];
-}
-
-function expectedArtifactName(declaration) {
-  if (typeof declaration === 'string') {
-    return declaration;
-  }
-  if (!declaration || typeof declaration !== 'object' || Array.isArray(declaration)) {
-    return '';
-  }
-  return declaration.name || declaration.id || '';
-}
-
-function expectedArtifactsFromConfig(config) {
-  const expected = normalizeArray(config.expected_artifacts);
-  if (expected.length > 0) {
-    return expected;
-  }
-  return normalizeArray(config.artifact_declarations)
-    .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true)
-    .map(expectedArtifactName)
-    .filter(Boolean);
-}
-
-function buildAgentTaskRequest(config, configPath, runtime) {
-  const taskId = config.task_id || config.workload_id || 'runtime-agent-full-run';
-  const timeoutMs = Number.parseInt(config.time_budget_ms || '', 10);
-  const timeoutSeconds = Number.parseInt(config.task_timeout_seconds || config.taskTimeoutSeconds || '', 10);
-  const runtimeComponents = optionalObject(config.runtime_components);
-  const runtimeComponentPaths = Object.fromEntries(Object.entries({
-    ...optionalObject(config.runtime_component_paths),
-    runtime: runtimeComponents.runtime,
-  }).filter(([, value]) => nonEmpty(value)));
-  const executorConfig = runtimeAgentCiTaskExecutorConfig(Object.fromEntries(Object.entries({
-    ...config,
-    runtime_component_paths: runtimeComponentPaths,
-    homeboy_extensions: config.homeboy_extensions || config.homeboy_extensions_path || EXTENSION_PATH,
-    artifacts: config.artifacts_path || config.artifacts,
-    replay_bundle_dir: config.replay_bundle_dir || process.env.HOMEBOY_RUNTIME_AGENT_REPLAY_BUNDLE_DIR,
-  }).filter(([, value]) => nonEmpty(value))));
-
-  return {
-    schema: 'homeboy/agent-task-request/v1',
-    task_id: String(taskId),
-    group_key: config.group_key || config.workload_id || '',
-    instructions: config.prompt || config.workload_label || 'Run runtime agent task.',
-    source_refs: [{ kind: 'config', path: configPath }],
-    workspace: Object.fromEntries(Object.entries({
-      repository: config.target_repo,
-      path: config.component_path,
-    }).filter(([, value]) => nonEmpty(value))),
-    expected_artifacts: expectedArtifactsFromConfig(config),
-    artifact_declarations: normalizeArray(config.artifact_declarations),
-    policy: optionalObject(config.policy),
-    limits: Object.fromEntries(Object.entries({
-      timeout_ms: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : undefined,
-      task_timeout_seconds: Number.isFinite(timeoutSeconds) && timeoutSeconds > 0 ? timeoutSeconds : undefined,
-    }).filter(([, value]) => nonEmpty(value))),
-    inputs: {
-      target: Object.fromEntries(Object.entries({
-        repository: config.target_repo,
-        path: config.component_path,
-      }).filter(([, value]) => nonEmpty(value))),
-      context: {
-        config_path: configPath,
-        workflow_run_url: process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
-          ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
-          : '',
-      },
-    },
-    executor: {
-      backend: runtime.executor.backend,
-      model: config.model || '',
-      config: executorConfig,
-      secret_env: config.secret_env || [],
-    },
-  };
-}
-
-function scenarioResultsFromOutcome(outcome) {
-  const codebox = outcome?.metadata?.codebox || {};
-  const workload = codebox?.raw?.agent_runtime?.result
-    || codebox?.agent_runtime?.workload
-    || codebox?.agent_runtime?.result
-    || codebox?.metadata?.agent_runtime?.workload
-    || codebox?.metadata?.agent_runtime?.result
-    || codebox?.agentResult
-    || codebox?.agent_result
-    || null;
-
-  if (workload && Array.isArray(workload.scenarios)) {
-    return workload;
-  }
-
-  return {
-    scenarios: [{
-      id: outcome.task_id || 'runtime-agent-full-run',
-      label: outcome.summary || 'Runtime agent task',
-      metrics: { generic_agent_task_executor_mean: 1 },
-      metadata: {
-        job_status: outcome.status,
-        success_status: outcome.status,
-        agent_task_outcome: outcome,
-      },
-    }],
-  };
-}
-
-function writeResults(outcome) {
-  const resultsFile = process.env.HOMEBOY_RUNTIME_AGENT_RESULTS_FILE || '';
-  if (!resultsFile) {
-    return;
-  }
-  fs.mkdirSync(path.dirname(resultsFile), { recursive: true });
-  fs.writeFileSync(resultsFile, `${JSON.stringify(scenarioResultsFromOutcome(outcome), null, 2)}\n`);
-}
-
-function writeOutcome(outcome) {
-  const outcomeFile = process.env.HOMEBOY_AGENT_TASK_OUTCOME_FILE || '';
-  if (!outcomeFile) {
-    return;
-  }
-  fs.mkdirSync(path.dirname(outcomeFile), { recursive: true });
-  fs.writeFileSync(outcomeFile, `${JSON.stringify(outcome, null, 2)}\n`);
-}
-
 try {
   const configPath = readConfigPath();
   const config = readJson(configPath);
   const runtime = resolveRuntimeProvider(config.runtime_id || process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || 'wp-codebox', { repoRoot: REPO_ROOT, workspace: config.component_path || process.cwd() });
-  const request = buildAgentTaskRequest(config, configPath, runtime);
-  const result = spawnSync(process.execPath, [runtime.executor.path], {
-    encoding: 'utf8',
-    input: JSON.stringify(request),
-    env: process.env,
-    maxBuffer: 1024 * 1024 * 20,
+  const result = runGenericAgentLoop({
+    plan: config,
+    runtime,
+    configPath,
+    repoRoot: REPO_ROOT,
+    extensionPath: EXTENSION_PATH,
+    replayBundleDir: process.env.HOMEBOY_RUNTIME_AGENT_REPLAY_BUNDLE_DIR,
+    validate: false,
+    validationPolicy: {
+      scenario_id: config.workload_id,
+      success_requires_pr: config.success_requires_pr,
+      success_completion_outcomes: config.success_completion_outcomes,
+    },
   });
-
-  if (result.stderr) {
-    process.stderr.write(result.stderr);
-  }
-
-  const outcome = result.stdout.trim() ? JSON.parse(result.stdout) : {
-    schema: 'homeboy/agent-task-outcome/v1',
-    task_id: request.task_id,
-    status: 'failed',
-    summary: 'Runtime agent task executor produced no JSON outcome.',
-    diagnostics: [{
-      class: 'homeboy.runtime_agent_task.no_outcome',
-      message: 'Runtime agent task executor produced no JSON outcome.',
-      data: { exit_status: result.status ?? 1 },
-    }],
-  };
-
-  writeOutcome(outcome);
-  writeResults(outcome);
-  process.stdout.write(`${JSON.stringify(outcome, null, 2)}\n`);
-  process.exitCode = outcome.status === 'succeeded' || outcome.status === 'no_op' ? 0 : 1;
+  writeGenericAgentLoopArtifacts({
+    outcome: result.outcome,
+    results: result.results,
+    outcomeFile: process.env.HOMEBOY_AGENT_TASK_OUTCOME_FILE || '',
+    resultsFile: process.env.HOMEBOY_RUNTIME_AGENT_RESULTS_FILE || '',
+  });
+  process.stdout.write(`${JSON.stringify(result.outcome, null, 2)}\n`);
+  process.exitCode = result.outcome.status === 'succeeded' || result.outcome.status === 'no_op' ? 0 : 1;
 } catch (error) {
   console.error(error && error.message ? error.message : String(error));
   process.exitCode = 1;


### PR DESCRIPTION
## Summary
- Extracts a provider-neutral generic agent loop runner in `runtime-agent-ci` that builds an agent task request from a plan, runtime profile, and validation policy, executes a runtime provider, materializes provider outcomes, and applies success assertions.
- Keeps the existing runtime full-run workflow glue compatible by making `wordpress/scripts/agent/run-runtime-agent-task.cjs` delegate to the shared primitive while still writing outcome/results for downstream workflow extraction.
- Moves WP Codebox-specific result shape handling behind a manifest-declared outcome adapter.
- Adds a credential-free smoke test covering plan -> runtime request -> fake provider outcome -> assertion, plus manifest adapter materialization.

## Tests
- `node tests/generic-agent-loop-runner-smoke.mjs`
- `node tests/runtime-agent-ci-contract-smoke.mjs`
- `bash tests/runtime-agent-full-run-boundary-smoke.sh`
- `git diff --check`

## Follow-up gaps
- The reusable workflow still has checkout/setup/auth/artifact upload shell glue; this PR focuses the reusable primitive on the provider execution/materialization/assertion loop and preserves existing workflow behavior.
- Additional runtime manifests can add their own `agent_loop.outcome_adapter` entries as they need custom outcome projection.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Refactoring implementation, smoke test creation, and PR drafting.
