### PR TITLE
Tighten generic agent loop validation

### DIFF
--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -8,6 +8,7 @@ const { runtimeAgentCiTaskExecutorConfig } = require('./runtime-agent-ci-plan');
 function buildGenericAgentLoopRequest(options = {}) {
   const plan = requiredObject(options.plan, 'plan');
   const runtime = requiredObject(options.runtime, 'runtime');
+  assertGenericAgentLoopRuntimeContract(plan, runtime);
   const configPath = options.configPath || options.config_path || '';
   const taskId = plan.task_id || plan.workload_id || 'generic-agent-loop';
   const runtimeComponents = optionalObject(plan.runtime_components);
@@ -56,8 +57,16 @@ function runGenericAgentLoop(options = {}) {
   const request = options.request || buildGenericAgentLoopRequest(options);
   const execute = options.execute || executeRuntimeProvider;
   const outcome = normalizeOutcome(execute({ ...options, request, runtime }), request);
+  const validationPolicy = options.validationPolicy || options.validation_policy || {};
+  validateGenericAgentLoopOutcomeContract({
+    request,
+    outcome,
+    runtime,
+    plan: options.plan || {},
+    validationPolicy,
+  });
   const results = materializeGenericAgentLoopResults(outcome, { ...options, runtime });
-  const assertion = options.validate === false ? null : assertGenericAgentLoopOutcome(results, options.validationPolicy || options.validation_policy || {});
+  const assertion = options.validate === false ? null : assertGenericAgentLoopOutcome(results, validationPolicy);
   return { request, outcome, results, assertion };
 }
 
@@ -147,6 +156,85 @@ function assertGenericAgentLoopOutcome(results, validationPolicy = {}) {
   throw new Error(`scenario ${assertion.scenario_id} expected opened PR, satisfied completion outcome, or allowed no-changes result, got job_status=${jobStatus} success_status=${successStatus} completion_outcome_satisfied=${completionOutcomeSatisfied ? 'true' : 'false'} no_changes_allowed=${noChangesAllowed ? 'true' : 'false'}`);
 }
 
+function assertGenericAgentLoopRuntimeContract(plan = {}, runtime = {}) {
+  const runtimeProfileId = requiredStringValue(plan.runtime_profile || plan.profile, 'runtime_profile');
+  const runtimeProfiles = optionalObject(plan.runtime_profiles || plan.runtimeProfiles);
+  if (!runtimeProfiles[runtimeProfileId]) {
+    throw new Error(`runtime profile ${runtimeProfileId} is not declared in runtime_profiles.`);
+  }
+
+  const requiredCapabilities = normalizeArray(plan.required_runtime_capabilities || plan.required_capabilities);
+  if (requiredCapabilities.length === 0) {
+    return { runtime_profile: runtimeProfileId, missing_capabilities: [] };
+  }
+
+  const capabilities = runtimeCapabilities(runtime, plan);
+  const missing = requiredCapabilities.filter((capability) => !capabilities.has(capability));
+  if (missing.length > 0) {
+    throw new Error(`runtime ${runtime.id || '(unknown)'} is missing required capabilities: ${missing.join(', ')}`);
+  }
+  return { runtime_profile: runtimeProfileId, missing_capabilities: [] };
+}
+
+function validateGenericAgentLoopOutcomeContract(options = {}) {
+  const request = requiredObject(options.request, 'request');
+  const outcome = requiredObject(options.outcome, 'outcome');
+  const plan = optionalObject(options.plan);
+  const validationPolicy = optionalObject(options.validationPolicy || options.validation_policy);
+  const declarations = normalizeArtifactDeclarations(request.artifact_declarations || plan.artifact_declarations);
+  const artifacts = normalizeArray(outcome.artifacts);
+  const evidenceRefs = normalizeArray(outcome.evidence_refs || outcome.evidence);
+  const errors = [];
+
+  for (const expected of normalizeArray(request.expected_artifacts)) {
+    if (!findArtifactByName(artifacts, expected)) {
+      errors.push(`missing expected artifact ${expected}`);
+    }
+  }
+
+  for (const declaration of declarations) {
+    if (!declaration.required) {
+      continue;
+    }
+    const artifact = findArtifactByName(artifacts, declaration.name);
+    if (!artifact) {
+      errors.push(`missing declared artifact ${declaration.name}`);
+      continue;
+    }
+    if (declaration.kind && artifactKind(artifact) !== declaration.kind) {
+      errors.push(`artifact ${declaration.name} expected kind ${declaration.kind}, got ${artifactKind(artifact) || '(missing)'}`);
+    }
+    if (declaration.schema && artifactSchema(artifact) !== declaration.schema) {
+      errors.push(`artifact ${declaration.name} expected schema ${declaration.schema}, got ${artifactSchema(artifact) || '(missing)'}`);
+    }
+  }
+
+  const requiredEvidenceRefs = normalizeEvidenceRequirements(validationPolicy.required_evidence_refs || plan.required_evidence_refs);
+  for (const requirement of requiredEvidenceRefs) {
+    const ref = findEvidenceRef(evidenceRefs, requirement);
+    if (!ref) {
+      errors.push(`missing required evidence ref ${requirement.name || requirement.kind || requirement.url || requirement.uri || '(unnamed)'}`);
+      continue;
+    }
+    const localOnly = localOnlyReviewerEvidence(ref);
+    if (localOnly) {
+      errors.push(`evidence ref ${evidenceRefLabel(ref)} is local-only: ${localOnly}`);
+    }
+  }
+
+  for (const ref of evidenceRefs) {
+    const localOnly = localOnlyReviewerEvidence(ref);
+    if (localOnly) {
+      errors.push(`evidence ref ${evidenceRefLabel(ref)} is local-only: ${localOnly}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`generic agent loop contract validation failed: ${errors.join('; ')}`);
+  }
+  return { artifact_count: artifacts.length, evidence_ref_count: evidenceRefs.length };
+}
+
 function writeGenericAgentLoopArtifacts(options = {}) {
   if (options.outcomeFile) {
     writeJsonFile(options.outcomeFile, options.outcome);
@@ -165,6 +253,87 @@ function expectedArtifactsFromPlan(plan) {
     .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true)
     .map((declaration) => declaration.name || declaration.id || '')
     .filter(Boolean);
+}
+
+function normalizeArtifactDeclarations(value) {
+  return normalizeArray(value)
+    .filter((declaration) => declaration && typeof declaration === 'object')
+    .map((declaration) => compactObject({
+      name: declaration.name || declaration.id,
+      required: declaration.required === true,
+      kind: declaration.kind || declaration.type || declaration.artifact_kind || declaration.artifactKind,
+      schema: declaration.artifact_schema || declaration.artifactSchema || declaration.payload_schema || declaration.payloadSchema,
+    }))
+    .filter((declaration) => declaration.name);
+}
+
+function normalizeEvidenceRequirements(value) {
+  return normalizeArray(value)
+    .map((requirement) => typeof requirement === 'string' ? { name: requirement } : requirement)
+    .filter((requirement) => requirement && typeof requirement === 'object' && !Array.isArray(requirement));
+}
+
+function findArtifactByName(artifacts, name) {
+  return normalizeArray(artifacts).find((artifact) => artifact && typeof artifact === 'object' && (
+    artifact.name === name || artifact.id === name || artifact.role === name
+  ));
+}
+
+function findEvidenceRef(evidenceRefs, requirement) {
+  return normalizeArray(evidenceRefs).find((ref) => ref && typeof ref === 'object' && (
+    (requirement.name && (ref.name === requirement.name || ref.id === requirement.name || ref.label === requirement.name))
+    || (requirement.kind && ref.kind === requirement.kind)
+    || (requirement.url && evidenceRefUrl(ref) === requirement.url)
+    || (requirement.uri && evidenceRefUrl(ref) === requirement.uri)
+  ));
+}
+
+function artifactKind(artifact) {
+  return artifact.kind || artifact.type || artifact.artifact_kind || artifact.artifactKind || '';
+}
+
+function artifactSchema(artifact) {
+  return artifact.artifact_schema || artifact.artifactSchema || artifact.payload_schema || artifact.payloadSchema || artifact.schema || '';
+}
+
+function evidenceRefLabel(ref) {
+  return ref.name || ref.id || ref.label || ref.kind || evidenceRefUrl(ref) || '(unnamed)';
+}
+
+function evidenceRefUrl(ref) {
+  return ref.url || ref.uri || ref.href || ref.path || '';
+}
+
+function localOnlyReviewerEvidence(ref) {
+  const url = evidenceRefUrl(ref);
+  if (!url || typeof url !== 'string') {
+    return '';
+  }
+  if (/^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::|\/|$)/i.test(url)) {
+    return url;
+  }
+  if (/^file:\/\//i.test(url) || /^\/Users\//.test(url) || /^\/private\//.test(url) || /^\/tmp\//.test(url)) {
+    return url;
+  }
+  return '';
+}
+
+function runtimeCapabilities(runtime = {}, plan = {}) {
+  const capabilities = new Set(normalizeArray(runtime.capabilities));
+  for (const capability of normalizeArray(runtime.manifest?.capabilities)) {
+    capabilities.add(capability);
+  }
+  const executors = normalizeArray(runtime.manifest?.agent_task_executors);
+  const backend = runtime.executor?.backend || plan.backend || plan.runtime_backend;
+  const runtimeId = runtime.id || plan.runtime_id || plan.runtime;
+  for (const executor of executors) {
+    if ((!backend || executor.backend === backend) && (!runtimeId || !executor.runtime_id || executor.runtime_id === runtimeId)) {
+      for (const capability of normalizeArray(executor.capabilities)) {
+        capabilities.add(capability);
+      }
+    }
+  }
+  return capabilities;
 }
 
 function runtimeTaskOptions(plan) {
@@ -244,6 +413,13 @@ function requiredObject(value, name) {
   return value;
 }
 
+function requiredStringValue(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
 function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
 }
@@ -254,8 +430,10 @@ function nonEmpty(value) {
 
 module.exports = {
   assertGenericAgentLoopOutcome,
+  assertGenericAgentLoopRuntimeContract,
   buildGenericAgentLoopRequest,
   materializeGenericAgentLoopResults,
   runGenericAgentLoop,
+  validateGenericAgentLoopOutcomeContract,
   writeGenericAgentLoopArtifacts,
 };

--- a/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
+++ b/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
@@ -15,6 +15,7 @@ const plan = {
   workload_id: 'fixture-workload',
   target_repo: 'Extra-Chill/example',
   component_path: '/workspace/example',
+  runtime_profile: 'runtime-agent-ci',
   runtime_profiles: {
     'runtime-agent-ci': {
       id: 'runtime-agent-ci',

--- a/tests/generic-agent-loop-runner-smoke.mjs
+++ b/tests/generic-agent-loop-runner-smoke.mjs
@@ -10,6 +10,7 @@ const {
   buildGenericAgentLoopRequest,
   runDeterministicLoop,
   runGenericAgentLoop,
+  validateGenericAgentLoopOutcomeContract,
 } = require(path.join(repoRoot, 'runtime-agent-ci'));
 
 const runtimeProfile = {
@@ -30,11 +31,14 @@ const plan = {
   prompt: 'Materialize the fixture.',
   runtime_task: { ability: 'example/run-task', input: { prompt: 'Cook.' } },
   artifact_declarations: [{ name: 'fixture-result', required: true }],
+  required_evidence_refs: [{ kind: 'pull_request' }],
+  required_runtime_capabilities: ['structured_outcome'],
   time_budget_ms: 120000,
   success_requires_pr: false,
 };
 const runtime = {
   id: 'example-runtime',
+  capabilities: ['structured_outcome'],
   executor: { backend: 'fake-provider', path: '/not-called' },
   manifest: {},
 };
@@ -63,6 +67,8 @@ const loop = runGenericAgentLoop({
       task_id: providerRequest.task_id,
       status: 'succeeded',
       summary: 'Fixture provider completed.',
+      artifacts: [{ id: 'fixture-result', kind: 'typed-json', artifact_schema: 'example/fixture-result/v1' }],
+      evidence_refs: [{ kind: 'pull_request', uri: 'https://github.com/example/project/pull/123', label: 'PR' }],
       metadata: {
         agent_loop_results: {
           scenarios: [{
@@ -86,6 +92,7 @@ const adapterLoop = runGenericAgentLoop({
   plan: { ...plan, workload_id: 'codebox-loop', success_requires_pr: true },
   runtime: {
     id: 'wp-codebox',
+    capabilities: ['structured_outcome'],
     executor: { backend: 'codebox', path: '/not-called' },
     manifest: {
       agent_loop: {
@@ -102,6 +109,8 @@ const adapterLoop = runGenericAgentLoop({
     schema: 'homeboy/agent-task-outcome/v1',
     task_id: 'codebox-loop',
     status: 'succeeded',
+    artifacts: [{ id: 'fixture-result', kind: 'typed-json', artifact_schema: 'example/fixture-result/v1' }],
+    evidence_refs: [{ kind: 'pull_request', uri: 'https://github.com/example/project/pull/123', label: 'PR' }],
     metadata: {
       codebox: {
         raw: {
@@ -158,6 +167,57 @@ assert.equal(retryHookCalls, 2);
 assert.deepEqual(
   deterministicLoop.iterations.map((iteration) => iteration.artifacts[0].name),
   ['packet-1', 'packet-2']
+);
+
+const contractRequest = {
+  task_id: 'contract-loop',
+  expected_artifacts: ['fixture-result'],
+  artifact_declarations: [{ name: 'fixture-result', required: true, kind: 'typed-json', artifact_schema: 'example/fixture-result/v1' }],
+};
+const contractOutcome = {
+  schema: 'homeboy/agent-task-outcome/v1',
+  task_id: 'contract-loop',
+  status: 'succeeded',
+  artifacts: [{ id: 'fixture-result', kind: 'typed-json', artifact_schema: 'example/fixture-result/v1' }],
+  evidence_refs: [{ kind: 'pull_request', uri: 'https://github.com/example/project/pull/123' }],
+};
+
+assert.deepEqual(
+  validateGenericAgentLoopOutcomeContract({
+    request: contractRequest,
+    outcome: contractOutcome,
+    plan: { required_evidence_refs: [{ kind: 'pull_request' }] },
+  }),
+  { artifact_count: 1, evidence_ref_count: 1 }
+);
+assert.throws(
+  () => validateGenericAgentLoopOutcomeContract({
+    request: contractRequest,
+    outcome: { ...contractOutcome, artifacts: [] },
+  }),
+  /missing expected artifact fixture-result/
+);
+assert.throws(
+  () => validateGenericAgentLoopOutcomeContract({
+    request: contractRequest,
+    outcome: { ...contractOutcome, artifacts: [{ id: 'fixture-result', kind: 'text', artifact_schema: 'example\/fixture-result\/v1' }] },
+  }),
+  /expected kind typed-json, got text/
+);
+assert.throws(
+  () => validateGenericAgentLoopOutcomeContract({
+    request: contractRequest,
+    outcome: { ...contractOutcome, artifacts: [{ id: 'fixture-result', kind: 'typed-json', artifact_schema: 'example\/other\/v1' }] },
+  }),
+  /expected schema example\/fixture-result\/v1, got example\/other\/v1/
+);
+assert.throws(
+  () => validateGenericAgentLoopOutcomeContract({
+    request: contractRequest,
+    outcome: { ...contractOutcome, evidence_refs: [{ kind: 'pull_request', uri: 'http://localhost:8888/pr/123' }] },
+    plan: { required_evidence_refs: [{ kind: 'pull_request' }] },
+  }),
+  /local-only/
 );
 
 console.log('generic agent loop runner smoke passed');


### PR DESCRIPTION
## Summary
- Add generic runtime profile and capability validation before building agent loop requests.
- Validate required artifact declarations against normalized runtime outcomes, including kind and schema checks.
- Validate required evidence refs and reject local-only reviewer-facing evidence URLs/paths.
- Extend generic loop smoke coverage for success, missing artifact, wrong kind/schema, and local-only evidence failures.

## Verification
- `node tests/generic-agent-loop-runner-smoke.mjs`
- `node tests/runtime-agent-ci-contract-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing generic loop validation, tests, verification, and PR preparation.