### PR TITLE
Extract generic fanout reconcile primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ documented in [`docs/project-script-runtime.md`](docs/project-script-runtime.md)
 They are extension-owned until Homeboy core grows an ecosystem-neutral runtime
 helper contract.
 
-Generic fanout/reconcile JSON planning is documented in
+Generic runtime fanout/reconcile planning and runner primitives live in
+`runtime-agent-ci/lib/` and are documented in
 [`docs/generic-fanout-reconcile-workflow.md`](docs/generic-fanout-reconcile-workflow.md).
 
 Integration-specific examples live under [`docs/integrations/`](docs/integrations/)

--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -75,8 +75,8 @@ name, runtime output file name, dispatch function, and artifact normalization.
 ## Audit Fanout Runtime Boundary
 
 Audit fanout extraction is split from runtime execution. Generic fanout planning
-and reconcile code groups audit findings, templates opaque task requests, and
-matches provider records back to groups. The exported
+and reconcile primitives live in `runtime-agent-ci/lib`; they group items,
+template opaque task requests, and match provider records back to groups. The exported
 `audit-fanout-runtime-provider` interface defines dispatch/apply operations
 without naming runtime package names, provider credentials, sandbox recipes, or
 provider task schemas.
@@ -86,7 +86,7 @@ quarantined `audit-wp-codebox-fanout` module and CLI map grouped audit findings
 to `wp-codebox/task-input/v1`, execute those requests through Codebox-owned task
 runner contracts, and normalize Codebox artifacts/outcomes back into fanout
 records. Keep new executor-neutral extraction behavior in
-`runtime-agent-ci/generic-fanout-reconcile-workflow`; keep Codebox request/session/artifact
+`runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js`; keep Codebox request/session/artifact
 details inside the Codebox audit fanout lane.
 
 ## Static Site Fanout Adapter

--- a/docs/generic-fanout-reconcile-workflow.md
+++ b/docs/generic-fanout-reconcile-workflow.md
@@ -1,6 +1,6 @@
 # Generic Fanout/Reconcile Workflow
 
-`runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs` exposes the shared fanout/reconcile runner through JSON files. It is executor-neutral: callers provide item artifacts, grouping rules, task request templates, and opaque execution descriptors, then run those task requests with their own runtime provider implementation.
+`runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` and `runtime-agent-ci/lib/fanout-reconcile-runner.js` provide executor-neutral fanout/reconcile primitives. `runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs` exposes the shared planner/reconciler through JSON files, and `wordpress/scripts/agent/homeboy-generic-fanout-reconcile.cjs` remains as a compatibility entrypoint for existing WordPress-lane callers.
 
 This helper is the planner/reconciler side of the audit fanout boundary, not a runtime provider. Runtime packages, provider names, credentials, WordPress setup, sandbox recipes, and provider task schemas stay behind the `audit-fanout-runtime-provider` interface. The current audit fanout implementation is the quarantined WP Codebox lane, which maps grouped audit findings to `wp-codebox/task-input/v1` requests and executes them through Codebox-owned task runner contracts.
 
@@ -52,7 +52,7 @@ Records are matched by `id`, `task_id`, `sandbox_session_id`, or `group_key`. Su
 
 ## Finding Packets
 
-`runtime-agent-ci` and `runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` also export helpers for diagnostic/finding packet inputs:
+`runtime-agent-ci` and `runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` export helpers for diagnostic/finding packet inputs. `wordpress/lib/generic-fanout-reconcile-workflow.js` re-exports the same helpers for existing entrypoints.
 
 - `normalizeFindingPacketItems(packets, policy)` flattens packet-level `findings` or `diagnostics` arrays into generic items with stable packet/finding IDs.
 - `materializeFindingPacketFanoutConfig({ packets, policy, ...config })` applies policy-driven grouping and returns the generic config/groups/items needed by the planner.

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -600,11 +600,13 @@ homeboy refactor <component> \
 ```
 
 Audit fanout has two boundaries. Generic extraction and reconcile mechanics live
-in `../runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` and the
-`../runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs` JSON CLI. The
-generic runtime provider interface lives in `lib/audit-fanout-runtime-provider.js`
-and is exported from the WordPress package. Runtime providers own execution: they
-map generic grouped work into their provider task contract, run the task, and
+in `../runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` and
+`../runtime-agent-ci/lib/fanout-reconcile-runner.js`; WordPress keeps thin
+`lib/` re-export wrappers and the `scripts/agent/homeboy-generic-fanout-reconcile.cjs`
+JSON CLI for existing entrypoints. The generic
+runtime provider interface lives in `lib/audit-fanout-runtime-provider.js` and is
+exported from the WordPress package. Runtime providers own execution: they map
+generic grouped work into their provider task contract, run the task, and
 normalize records back for reconcile.
 
 The current provider implementation is WP Codebox.
@@ -618,9 +620,9 @@ This audit fanout lane is intentionally quarantined as a WP Codebox-specific
 runtime provider implementation. Its direct module/CLI entrypoints remain
 available for existing callers, but it is not exported from `wordpress/index.js`
 and generic orchestration code must not import it inline. Executor-neutral fanout
-planning belongs in `../runtime-agent-ci`; Codebox request schemas, sandbox
-session IDs, artifact lookup, partial-run discovery, and recipe details stay in
-this lane.
+planning belongs in `../runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js`; Codebox request
+schemas, sandbox session IDs, artifact lookup, partial-run discovery, and recipe
+details stay in this lane.
 
 ### WP Codebox agent-task executor
 

--- a/wordpress/lib/audit-wp-codebox-fanout.js
+++ b/wordpress/lib/audit-wp-codebox-fanout.js
@@ -22,7 +22,7 @@ const {
 } = require('./codebox-provider-adapter');
 const {
   executeFanoutReconcileRun,
-} = require('./fanout-reconcile-runner');
+} = require('../../runtime-agent-ci/lib/fanout-reconcile-runner');
 const {
   DEFAULT_TASK_TIMEOUT_SECONDS,
   RUN_SCHEMA,

--- a/wordpress/lib/static-site-fanout-adapter.js
+++ b/wordpress/lib/static-site-fanout-adapter.js
@@ -9,7 +9,7 @@ const {
   createFanoutReconcilePlan,
   executeFanoutReconcileRun,
   groupFanoutItems,
-} = require('./fanout-reconcile-runner');
+} = require('../../runtime-agent-ci/lib/fanout-reconcile-runner');
 
 const PLAN_SCHEMA = 'homeboy/static-site-fanout-plan/v1';
 const RUN_SCHEMA = 'homeboy/static-site-fanout-run/v1';

--- a/wordpress/tests/fanout-reconcile-runner-smoke.js
+++ b/wordpress/tests/fanout-reconcile-runner-smoke.js
@@ -1,14 +1,23 @@
 'use strict';
 
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+
+/**
+ * Internal dependencies
+ */
 const {
   createFanoutReconcilePlan,
   executeFanoutReconcileRun,
   groupFanoutItems,
-} = require('../lib/fanout-reconcile-runner');
+} = require('../../runtime-agent-ci/lib/fanout-reconcile-runner');
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));

--- a/wordpress/tests/generic-fanout-reconcile-workflow-smoke.js
+++ b/wordpress/tests/generic-fanout-reconcile-workflow-smoke.js
@@ -1,10 +1,19 @@
 'use strict';
 
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+
+/**
+ * Internal dependencies
+ */
 const {
   createFindingPacketFanoutPlan,
   createFindingPacketReconcileInput,
@@ -12,7 +21,7 @@ const {
   createGenericFanoutReconcileResult,
   materializeFindingPacketFanoutConfig,
   normalizeFindingPacketItems,
-} = require('../lib/generic-fanout-reconcile-workflow');
+} = require('../../runtime-agent-ci/lib/generic-fanout-reconcile-workflow');
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));


### PR DESCRIPTION
## Summary
- Move generic fanout/reconcile planner and runner primitives into runtime-agent-ci/lib.
- Keep WordPress fanout/reconcile entrypoints as thin compatibility re-exports.
- Point WordPress consumers, CLI, tests, and docs at the executor-neutral primitives.

## Verification
- npm run test:fanout-reconcile-runner
- npm run test:generic-fanout-reconcile-workflow
- npm run test:static-site-fanout-adapter
- npm run test:audit-wp-codebox-fanout
- ./wordpress/node_modules/.bin/eslint --config wordpress/eslint.config.mjs --no-ignore runtime-agent-ci/index.js runtime-agent-ci/lib/fanout-reconcile-runner.js runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js wordpress/lib/static-site-fanout-adapter.js wordpress/lib/audit-wp-codebox-fanout.js wordpress/lib/fanout-reconcile-runner.js wordpress/lib/generic-fanout-reconcile-workflow.js wordpress/scripts/agent/homeboy-generic-fanout-reconcile.cjs wordpress/tests/fanout-reconcile-runner-smoke.js wordpress/tests/generic-fanout-reconcile-workflow-smoke.js
- node -e "const runtime = require('./runtime-agent-ci'); const wpRunner = require('./wordpress/lib/fanout-reconcile-runner'); const wpWorkflow = require('./wordpress/lib/generic-fanout-reconcile-workflow'); if (typeof runtime.createFanoutReconcilePlan !== 'function' || runtime.createFanoutReconcilePlan !== wpRunner.createFanoutReconcilePlan || runtime.createGenericFanoutReconcilePlan !== wpWorkflow.createGenericFanoutReconcilePlan) process.exit(1);"
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code extraction, docs/test updates, verification, and PR drafting.