### PR TITLE
Add generic runtime execution contracts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -154,7 +154,7 @@ jobs:
       runtime_ref: main
       runtime_profile: example-agent-ci
       runtime_profiles: >-
-        {"example-agent-ci":{"id":"example-agent-ci","runtime_task_ability":"example/run-agent-bundle","runtime_bundle_ability":"example/run-agent-bundle","ability_requirements":["example/run-agent-bundle"]}}
+        {"example-agent-ci":{"id":"example-agent-ci","runtime_task_ability":"example/run-task","runtime_bundle_ability":"example/run-agent-bundle","capabilities":["ability_execution","agent_bundle_execution"],"runtime_execution_contracts":{"bundle":{"ability_field":"runtime_bundle_ability","required_capabilities":["agent_bundle_execution"]}},"ability_requirements":["example/run-agent-bundle"]}}
       runtime_dependencies: '["Example/runtime-plugin@main"]'
       workload_id: example-agent-flow
       workload_label: Run example agent
@@ -196,7 +196,7 @@ jobs:
 - `runtime_task` forwards a generic `{ "ability", "input" }` object to the runtime task executor.
 - `ability_request` and `ability_input` are a shorthand for direct ability execution. `ability_input` is merged into `ability_request.input`.
 - `runtime_output_projections` maps named outputs to dotted paths in the provider runtime result.
-- Generic `runtime-agent-full-run.yml` callers can use `runtime_execution` for ability, bundle, or workflow descriptors and pass `runtime_output_projections` / `evidence_projections` through to the selected runtime config. Bundle/package descriptors derive the runtime task ability from the selected runtime profile, so callers do not need to provide `runtime_task.ability` for generic package runs.
+- Generic `runtime-agent-full-run.yml` callers can use `runtime_execution` for ability, bundle, or workflow descriptors and pass `runtime_output_projections` / `evidence_projections` through to the selected runtime config. Bundle and workflow descriptors derive the provider operation from the selected runtime profile's `runtime_execution_contracts`, so callers do not need to provide `runtime_task.ability` for generic package runs.
 - `component_contracts` forwards explicit runtime component/plugin contracts to the selected runtime adapter. WP Codebox maps them through its `wp-codebox/runtime-profile/v1` payload.
 - WP Codebox executor paths accept caller-supplied component contracts, runtime overlays, mounts, task payload, provider defaults, tool profiles, and declarative runtime requirements through the generic runtime workflow input renderer. Domain policy belongs in caller inputs and runtime profiles, not in the generic WP Codebox provider manifest.
 - `runtime_dependencies` checks out the explicit runtime component stack and forwards those paths to the selected runtime adapter.
@@ -238,7 +238,7 @@ jobs:
       runtime_ref: main
       runtime_profile: example-agent-ci
       runtime_profiles: >-
-        {"example-agent-ci":{"id":"example-agent-ci","runtime_task_ability":"example/run-agent-bundle","runtime_bundle_ability":"example/run-agent-bundle","ability_requirements":["example/run-agent-bundle"]}}
+        {"example-agent-ci":{"id":"example-agent-ci","runtime_task_ability":"example/run-task","runtime_bundle_ability":"example/run-agent-bundle","capabilities":["ability_execution","agent_bundle_execution"],"runtime_execution_contracts":{"bundle":{"ability_field":"runtime_bundle_ability","required_capabilities":["agent_bundle_execution"]}},"ability_requirements":["example/run-agent-bundle"]}}
       runtime_dependencies: '["Example/runtime-plugin@main"]'
       runtime_execution: '{"kind":"bundle","source":".ci/docs-agent/bundles/docs-agent"}'
       workload_id: docs-agent-flow

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -167,6 +167,7 @@ function providerContract(options = {}) {
     ...agentTaskProviderContractFields(),
     secret_env_requirements: options.secretEnvRequirements || runtimeSecretEnvRequirements(),
     capabilities: normalizeArray(options.capabilities || PROVIDER_CAPABILITIES),
+    runtime_execution_contracts: runtimeExecutionContracts(),
     workspace_materialization: {
       cwd: 'git_checkout',
     },
@@ -200,6 +201,10 @@ function runtimeCommandInvocation(options = {}) {
 
 function runtimeProviderCapabilities() {
   return normalizeArray(runtimeExecutorManifest().capabilities);
+}
+
+function runtimeExecutionContracts() {
+  return firstObject(runtimeExecutorManifest().runtime_execution_contracts, runtimeExecutorManifest().execution_contracts) || {};
 }
 
 function runtimeWorkspaceTools(options = {}) {

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -162,6 +162,7 @@
         "wordpress_sandbox",
         "workspace_mounts",
         "workspace_tools",
+        "ability_execution",
         "artifact_materialization",
         "patch_artifacts",
         "verification_artifacts",
@@ -170,10 +171,25 @@
         "screenshots",
         "structured_outcome",
         "agent_bundle_execution",
+        "workflow_execution",
         "typed_bundle_outputs",
         "external_recipe_packs",
         "recipe_probe_artifacts"
       ],
+      "runtime_execution_contracts": {
+        "ability": {
+          "ability_field": "runtime_task_ability",
+          "required_capabilities": ["ability_execution"]
+        },
+        "bundle": {
+          "ability_field": "runtime_bundle_ability",
+          "required_capabilities": ["agent_bundle_execution"]
+        },
+        "workflow": {
+          "ability_field": "runtime_workflow_ability",
+          "required_capabilities": ["workflow_execution"]
+        }
+      },
       "workspace_materialization": {
         "cwd": "git_checkout"
       },

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -185,10 +185,41 @@ Use stable, backend-neutral names where possible, such as:
 - `patch_artifacts`
 - `verification_artifacts`
 - `browser_runtime`
+- `ability_execution`
+- `agent_bundle_execution`
+- `workflow_execution`
 
 Backend-specific capabilities are acceptable when they are intentionally part of
 selection, but they should not replace the generic capability when a generic one
 applies.
+
+## Runtime Execution Contracts
+
+Providers that can execute generic runtime descriptors should declare
+`runtime_execution_contracts` on the executor provider. Each key is a generic
+`runtime_execution.kind`; each value maps that kind to a provider-specific
+runtime-profile field and the capabilities required to use it:
+
+```json
+{
+  "runtime_execution_contracts": {
+    "bundle": {
+      "ability_field": "runtime_bundle_ability",
+      "required_capabilities": ["agent_bundle_execution"]
+    },
+    "workflow": {
+      "ability_field": "runtime_workflow_ability",
+      "required_capabilities": ["workflow_execution"]
+    }
+  }
+}
+```
+
+Caller configs can then use `runtime_execution: { "kind": "bundle", ... }`
+without embedding a provider-specific ability string. The selected adapter maps
+the generic kind to its own runtime-profile ability field and fails closed when
+the provider does not advertise the required capability. Direct `ability`
+execution remains explicit: callers supply the ability they intend to invoke.
 
 ## Workspace Materialization
 

--- a/runtime-agent-ci/lib/generic-agent-task-plan.js
+++ b/runtime-agent-ci/lib/generic-agent-task-plan.js
@@ -87,13 +87,61 @@ function normalizeRuntimeExecutionDescriptor(descriptor, runtimeProfile = {}) {
 }
 
 function abilityForRuntimeExecutionKind(kind, runtimeProfile = {}) {
-  if (kind === 'bundle') {
-    return runtimeProfile.runtime_bundle_ability || runtimeProfile.runtime_task_ability;
+  const contract = runtimeExecutionContract(kind, runtimeProfile);
+  const ability = contract?.ability || abilityFromRuntimeExecutionContract(contract, runtimeProfile);
+  if (ability) {
+    assertRuntimeExecutionContractCapabilities(kind, contract, runtimeProfile);
+    return ability;
   }
-  if (kind === 'workflow') {
-    return runtimeProfile.runtime_workflow_ability || runtimeProfile.runtime_task_ability;
+  if (kind === 'ability') {
+    return runtimeProfile.runtime_task_ability;
   }
-  return runtimeProfile.runtime_task_ability;
+  throw new Error(`runtime_execution kind ${kind} is not supported by runtime profile ${runtimeProfile.id || '(unknown)'}.`);
+}
+
+function abilityFromRuntimeExecutionContract(contract, runtimeProfile = {}) {
+  const field = contract?.ability_field || contract?.abilityField;
+  if (typeof field !== 'string' || field.trim() === '') {
+    return '';
+  }
+  return runtimeProfile[field] || '';
+}
+
+function assertRuntimeExecutionContractCapabilities(kind, contract, runtimeProfile) {
+  const requiredCapabilities = normalizeArray(contract.required_capabilities || contract.requiredCapabilities || contract.capabilities);
+  if (requiredCapabilities.length === 0) {
+    return;
+  }
+  const capabilities = normalizeArray(runtimeProfile.capabilities || runtimeProfile.provider_capabilities || runtimeProfile.providerCapabilities);
+  const missing = requiredCapabilities.filter((capability) => !capabilities.includes(capability));
+  if (missing.length > 0) {
+    throw new Error(`runtime_execution kind ${kind} requires unsupported provider capabilities: ${missing.join(', ')}.`);
+  }
+}
+
+function runtimeExecutionContract(kind, runtimeProfile = {}) {
+  const normalizedKind = String(kind || '').trim();
+  if (!normalizedKind) {
+    return null;
+  }
+  const contracts = runtimeProfile.execution_contracts || runtimeProfile.runtime_execution_contracts || runtimeProfile.runtime_execution_kinds || {};
+  const contract = contracts[normalizedKind];
+  if (typeof contract === 'string') {
+    return { kind: normalizedKind, ability: contract };
+  }
+  if (contract && typeof contract === 'object' && !Array.isArray(contract)) {
+    return { kind: normalizedKind, ...contract };
+  }
+  if (normalizedKind === 'bundle' && runtimeProfile.runtime_bundle_ability) {
+    return { kind: normalizedKind, ability: runtimeProfile.runtime_bundle_ability };
+  }
+  if (normalizedKind === 'workflow' && runtimeProfile.runtime_workflow_ability) {
+    return { kind: normalizedKind, ability: runtimeProfile.runtime_workflow_ability };
+  }
+  if (normalizedKind === 'ability' && runtimeProfile.runtime_task_ability) {
+    return { kind: normalizedKind, ability: runtimeProfile.runtime_task_ability };
+  }
+  return null;
 }
 
 function runtimeExecutionInput(descriptor, kind) {
@@ -152,4 +200,5 @@ module.exports = {
   genericAgentTaskRequest,
   genericAgentTaskRunnerSpec,
   normalizeRuntimeExecutionDescriptor,
+  runtimeExecutionContract,
 };

--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -193,6 +193,8 @@ function resolveExecutor(manifest, repoRoot, options = {}) {
 		status: provider?.status || '',
 		capabilities: Array.isArray(provider?.capabilities) ? provider.capabilities : [],
 		path: scriptArg ? scriptArg.replace('{{runtime_path}}', path.join(repoRoot, 'agent-runtimes', manifest.id)) : '',
+		capabilities: Array.isArray(provider?.capabilities) ? provider.capabilities.filter(Boolean) : [],
+		runtime_execution_contracts: provider?.runtime_execution_contracts || provider?.execution_contracts || {},
 	};
 }
 

--- a/tests/agent-runtime-contract-smoke.mjs
+++ b/tests/agent-runtime-contract-smoke.mjs
@@ -35,6 +35,7 @@ const requiredProviderFields = [
 	'failure_classifications',
 	'redacted_metadata_keys',
 	'capabilities',
+	'runtime_execution_contracts',
 	'runner_readiness',
 	'role_aliases',
 	'tool_presets',
@@ -62,6 +63,12 @@ assert.ok(provider.outcome_statuses.includes('succeeded'));
 assert.ok(provider.failure_classifications.includes('request_validation'));
 assert.ok(provider.redacted_metadata_keys.includes('secrets'));
 assert.ok(provider.capabilities.includes('structured_outcome'));
+assert.ok(provider.capabilities.includes('ability_execution'));
+assert.ok(provider.capabilities.includes('agent_bundle_execution'));
+assert.deepEqual(provider.runtime_execution_contracts.bundle, {
+	ability_field: 'runtime_bundle_ability',
+	required_capabilities: ['agent_bundle_execution'],
+});
 assert.deepEqual(provider.runner_readiness, []);
 assert.deepEqual(provider.role_aliases.artifact_kinds.patch, ['fixture-runtime-patch']);
 assert.deepEqual(provider.tool_presets, ['runner_workspace', 'publication']);

--- a/tests/fixtures/agent-runtime-manifest.json
+++ b/tests/fixtures/agent-runtime-manifest.json
@@ -41,8 +41,20 @@
       "capabilities": [
         "workspace_materialization",
         "structured_outcome",
-        "diagnostic_artifacts"
+        "diagnostic_artifacts",
+        "ability_execution",
+        "agent_bundle_execution"
       ],
+      "runtime_execution_contracts": {
+        "ability": {
+          "ability_field": "runtime_task_ability",
+          "required_capabilities": ["ability_execution"]
+        },
+        "bundle": {
+          "ability_field": "runtime_bundle_ability",
+          "required_capabilities": ["agent_bundle_execution"]
+        }
+      },
       "runner_readiness": [],
       "role_aliases": {
         "artifact_kinds": {

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -36,6 +36,21 @@ const runtimeProfile = {
   runtime_task_ability: 'example/run-task',
   runtime_bundle_ability: 'runtime/run-agent-bundle',
   runtime_workflow_ability: 'runtime/execute-workflow',
+  capabilities: ['ability_execution', 'agent_bundle_execution', 'workflow_execution'],
+  runtime_execution_contracts: {
+    ability: {
+      ability_field: 'runtime_task_ability',
+      required_capabilities: ['ability_execution'],
+    },
+    bundle: {
+      ability_field: 'runtime_bundle_ability',
+      required_capabilities: ['agent_bundle_execution'],
+    },
+    workflow: {
+      ability_field: 'runtime_workflow_ability',
+      required_capabilities: ['workflow_execution'],
+    },
+  },
   component_path_defaults: {
     contract_slug_map: { 'example-runtime': 'agent_runtime' },
     path_aliases: { agent_runtime: ['contract:agent_runtime'] },
@@ -157,6 +172,40 @@ const genericWorkflowConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
 assert.equal(genericWorkflowConfig.runtime_task.ability, 'runtime/execute-workflow');
 assert.deepEqual(genericWorkflowConfig.runtime_task.input.workflow, { path: '.ci/workflows/materialize.json' });
 assert.equal(genericWorkflowConfig.runtime_task.input.dry_run, true);
+
+const directAbilityConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
+  runtimeProfile: runtimeProfile.id,
+  runtimeProfiles: { [runtimeProfile.id]: runtimeProfile },
+  runtimeExecution: {
+    kind: 'ability',
+    ability: 'example/direct-operation',
+    input: { dry_run: false },
+  },
+});
+
+assert.deepEqual(directAbilityConfig.runtime_task, { ability: 'example/direct-operation', input: { dry_run: false } });
+
+assert.throws(
+  () => runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
+    runtimeProfile: 'limited-runtime',
+    runtimeProfiles: {
+      'limited-runtime': {
+        id: 'limited-runtime',
+        runtime_task_ability: 'example/run-task',
+        runtime_bundle_ability: 'runtime/run-agent-bundle',
+        capabilities: ['ability_execution'],
+        runtime_execution_contracts: {
+          bundle: {
+            ability_field: 'runtime_bundle_ability',
+            required_capabilities: ['agent_bundle_execution'],
+          },
+        },
+      },
+    },
+    runtimeExecution: { kind: 'bundle', source: 'bundles/example' },
+  }),
+  /runtime_execution kind bundle requires unsupported provider capabilities: agent_bundle_execution/
+);
 
 const genericRequest = runtimeAgentCi.runtimeAgentCiAbilityTaskRequest({
   taskId: 'task-1',

--- a/tests/runtime-provider-resolver-smoke.mjs
+++ b/tests/runtime-provider-resolver-smoke.mjs
@@ -42,6 +42,11 @@ assert.equal(runtime.paths.runtime_component, '');
 assert.equal(runtime.executor.id, 'wordpress.codebox-agent-task-executor');
 assert.equal(runtime.executor.backend, 'codebox');
 assert.equal(runtime.executor.path, path.join(rootDir, 'agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs'));
+assert.equal(runtime.executor.capabilities.includes('agent_bundle_execution'), true);
+assert.deepEqual(runtime.executor.runtime_execution_contracts.bundle, {
+	ability_field: 'runtime_bundle_ability',
+	required_capabilities: ['agent_bundle_execution'],
+});
 
 const envRuntime = resolveRuntimeProvider('wp-codebox', {
 	repoRoot: rootDir,

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -441,10 +441,16 @@ assert.equal(provider.capabilities.includes('browser_runtime'), true);
 assert.equal(provider.capabilities.includes('workspace_tools'), true);
 assert.equal(provider.capabilities.includes('patch_artifacts'), true);
 assert.equal(provider.capabilities.includes('cleanup_observability'), true);
+assert.equal(provider.capabilities.includes('ability_execution'), true);
 assert.equal(provider.capabilities.includes('agent_bundle_execution'), true);
+assert.equal(provider.capabilities.includes('workflow_execution'), true);
 assert.equal(provider.capabilities.includes('typed_bundle_outputs'), true);
 assert.equal(provider.capabilities.includes('external_recipe_packs'), true);
 assert.equal(provider.capabilities.includes('recipe_probe_artifacts'), true);
+assert.deepEqual(provider.runtime_execution_contracts.bundle, {
+  ability_field: 'runtime_bundle_ability',
+  required_capabilities: ['agent_bundle_execution'],
+});
 for (const capability of repoLoopCapabilities) {
   assert.equal(provider.capabilities.includes(capability), false);
 }


### PR DESCRIPTION
## Summary
- Add generic `runtime_execution_contracts` mappings for `ability`, `bundle`, and `workflow` execution kinds.
- Resolve `runtime_execution.kind` through provider/profile contracts instead of falling back to raw provider ability strings for generic bundle/workflow runs.
- Expose runtime execution contracts from provider manifests and fail closed when a selected kind requires capabilities the provider profile does not advertise.
- Document the manifest contract and update smoke fixtures/tests.

## Verification
- `node tests/runtime-agent-ci-contract-smoke.mjs`
- `node tests/runtime-provider-resolver-smoke.mjs`
- `node tests/agent-runtime-contract-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing runtime execution contract changes, docs, tests, and PR description.
