### PR TITLE
Consume WP Codebox runtime contract manifest

### DIFF
--- a/agent-runtimes/wp-codebox/index.js
+++ b/agent-runtimes/wp-codebox/index.js
@@ -10,4 +10,5 @@ module.exports = {
 	...require('./lib/provider-credential-boundary'),
 	...require('./lib/provider-preflight-manifest'),
 	...require('./lib/provider-outcome-normalizer'),
+	...require('./lib/wp-codebox-runtime-contract-source'),
 };

--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -1,8 +1,14 @@
 'use strict';
 
 const TYPED_ARTIFACT_SCHEMA = 'homeboy/agent-task-typed-artifact/v1';
+const {
+  runtimeContractSchemas,
+} = require('./wp-codebox-runtime-contract-source');
+
+const RUNTIME_CONTRACT_SCHEMAS = runtimeContractSchemas();
+
 const WP_CODEBOX_ARTIFACT_DECLARATION_SCHEMA = 'wp-codebox/artifact-declaration/v1';
-const WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA = 'wp-codebox/artifact-result-envelope/v1';
+const WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA = RUNTIME_CONTRACT_SCHEMAS.artifact.resultEnvelope;
 const WP_CODEBOX_CASE_ARTIFACT_INDEX_SCHEMA = 'wp-codebox/case-artifact-index/v1';
 
 const ARTIFACT_ROLE_FALLBACK_PATTERNS = [

--- a/agent-runtimes/wp-codebox/lib/codebox-run-agent-task-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-run-agent-task-contract.js
@@ -3,9 +3,14 @@
 const {
   WP_CODEBOX_TASK_REQUEST_SCHEMA,
 } = require('./wp-codebox-adapter-contract');
+const {
+  runtimeContractSchemas,
+} = require('./wp-codebox-runtime-contract-source');
+
+const RUNTIME_CONTRACT_SCHEMAS = runtimeContractSchemas();
 
 const WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA = 'wp-codebox/run-agent-task/v1';
-const WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA = 'wp-codebox/agent-task-run-result/v1';
+const WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA = RUNTIME_CONTRACT_SCHEMAS.agentTask.runResult;
 const WP_CODEBOX_AGENT_TASK_RUN_RESPONSE_SCHEMA = 'wp-codebox/agent-task-run/v1';
 const WP_CODEBOX_RUN_AGENT_TASK_RESULT_SCHEMA = WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA;
 const WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND = 'run-agent-task';

--- a/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
@@ -1,6 +1,12 @@
 'use strict';
 
-const WP_CODEBOX_RUNTIME_PROFILE_SCHEMA = 'wp-codebox/runtime-profile/v1';
+const {
+  runtimeContractSchemas,
+} = require('./wp-codebox-runtime-contract-source');
+
+const RUNTIME_CONTRACT_SCHEMAS = runtimeContractSchemas();
+
+const WP_CODEBOX_RUNTIME_PROFILE_SCHEMA = RUNTIME_CONTRACT_SCHEMAS.runtimeBoundary.profile;
 const WP_CODEBOX_PARENT_TOOL_BRIDGE_SCHEMA = 'wp-codebox/parent-tool-bridge/v1';
 const WP_CODEBOX_UPSTREAM_REQUIREMENT_SCHEMA = 'wp-codebox/upstream-primitive-requirement/v1';
 

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -1,35 +1,31 @@
 'use strict';
 
+const {
+  providerRuntimeInvocationContract,
+  runtimeContractSchemas,
+} = require('./wp-codebox-runtime-contract-source');
+
+const RUNTIME_CONTRACT_SCHEMAS = runtimeContractSchemas();
+const RUNTIME_INVOCATION_CONTRACT = providerRuntimeInvocationContract();
+
 const WP_CODEBOX_TASK_REQUEST_SCHEMA = 'wp-codebox/task-input/v1';
 const WP_CODEBOX_PROVIDER_ID = 'wordpress.codebox-agent-task-executor';
 const WP_CODEBOX_PROVIDER_LABEL = 'WP Codebox agent task executor';
 const WP_CODEBOX_BACKEND = 'codebox';
-const WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA = 'wp-codebox/provider-runtime-invocation-contract/v1';
+const WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA = RUNTIME_CONTRACT_SCHEMAS.providerRuntime.invocation;
 const WP_CODEBOX_PROVIDER_CREDENTIAL_BOUNDARY_SCHEMA = 'wp-codebox/provider-credential-boundary/v1';
 
 const WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES = {
-  workspaceCapture: 'wp-codebox.runner-workspace.capture',
-  workspaceCommand: 'wp-codebox.runner-workspace.command',
-  workspacePublish: 'wp-codebox.runner-workspace.publish',
-  toolCallTranscriptRecord: 'wp-codebox.tool-call-transcript.record',
-  artifactHandoff: 'wp-codebox.artifact-handoff',
+  ...RUNTIME_INVOCATION_CONTRACT.tasks,
 };
 
 const WP_CODEBOX_PROVIDER_RUNTIME_ABILITY_NAMES = {
-  workspaceCapture: 'wp-codebox/runner-workspace-capture',
-  workspaceCommand: 'wp-codebox/runner-workspace-command',
-  workspacePublish: 'wp-codebox/runner-workspace-publish',
-  toolCallTranscriptRecord: 'wp-codebox/record-tool-call-transcript',
-  artifactHandoff: 'wp-codebox/handoff-artifacts',
+  ...RUNTIME_INVOCATION_CONTRACT.abilities,
 };
 
 const WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS = {
-  workspace_capture: 'wp-codebox/runner-workspace-capture-result/v1',
-  workspace_command: 'wp-codebox/runner-workspace-command-result/v1',
-  workspace_publication: 'wp-codebox/runner-workspace-publication-result/v1',
-  tool_call_transcript: 'wp-codebox/tool-call-transcript/v1',
-  evidence_artifact_envelope: 'wp-codebox/evidence-artifact-envelope/v1',
-  artifact_result_envelope: 'wp-codebox/artifact-result-envelope/v1',
+  ...RUNTIME_INVOCATION_CONTRACT.result_schemas,
+  artifact_result_envelope: RUNTIME_CONTRACT_SCHEMAS.artifact.resultEnvelope,
 };
 
 const WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMA_KEYS = {

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
@@ -1,0 +1,249 @@
+'use strict';
+
+const path = require('node:path');
+const { existsSync, readdirSync } = require('node:fs');
+const { homedir } = require('node:os');
+const { pathToFileURL } = require('node:url');
+
+const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
+const RUNTIME_CORE_ENTRY = 'packages/runtime-core/dist/index.js';
+const RUNTIME_CONTRACT_MANIFEST_SCHEMA = 'wp-codebox/runtime-contract-manifest/v1';
+
+const FALLBACK_RUNTIME_CONTRACT_SCHEMAS = {
+  providerRuntime: {
+    invocation: 'wp-codebox/provider-runtime-invocation-contract/v1',
+    credentialRequirements: 'wp-codebox/provider-credential-requirements/v1',
+    credentialPreflight: 'wp-codebox/provider-credential-preflight/v1',
+    credentialResolution: 'wp-codebox/provider-credential-resolution/v1',
+  },
+  agentTask: {
+    runResult: 'wp-codebox/agent-task-run-result/v1',
+  },
+  runtimeBoundary: {
+    profile: 'wp-codebox/runtime-profile/v1',
+    previewLease: 'wp-codebox/preview-lease/v1',
+    browserContainedSiteStatus: 'wp-codebox/browser-contained-site-status/v1',
+    browserContainedSiteOpen: 'wp-codebox/browser-contained-site-open/v1',
+    browserSessionProductDto: 'wp-codebox/browser-session-product/v1',
+    browserPreviewBootConfig: 'wp-codebox/browser-preview-boot-config/v1',
+  },
+  artifact: {
+    resultEnvelope: 'wp-codebox/artifact-result-envelope/v1',
+  },
+  runnerWorkspace: {
+    prepareRequest: 'wp-codebox/runner-workspace-prepare-request/v1',
+    prepareResult: 'wp-codebox/runner-workspace-prepare-result/v1',
+    captureRequest: 'wp-codebox/runner-workspace-capture-request/v1',
+    captureResult: 'wp-codebox/runner-workspace-capture-result/v1',
+    commandRequest: 'wp-codebox/runner-workspace-command-request/v1',
+    commandResult: 'wp-codebox/runner-workspace-command-result/v1',
+    publicationRequest: 'wp-codebox/runner-workspace-publication-request/v1',
+    publicationResult: 'wp-codebox/runner-workspace-publication-result/v1',
+  },
+  fanoutAggregation: {
+    input: 'wp-codebox/fanout-aggregation-input/v1',
+    output: 'wp-codebox/fanout-aggregation-output/v1',
+  },
+};
+
+const FALLBACK_PROVIDER_RUNTIME_INVOCATION_CONTRACT = {
+  schema: FALLBACK_RUNTIME_CONTRACT_SCHEMAS.providerRuntime.invocation,
+  version: 1,
+  tasks: {
+    workspacePrepare: 'wp-codebox.runner-workspace.prepare',
+    workspaceCapture: 'wp-codebox.runner-workspace.capture',
+    workspaceCommand: 'wp-codebox.runner-workspace.command',
+    workspacePublish: 'wp-codebox.runner-workspace.publish',
+    toolCallTranscriptRecord: 'wp-codebox.tool-call-transcript.record',
+    artifactHandoff: 'wp-codebox.artifact-handoff',
+  },
+  abilities: {
+    workspacePrepare: 'wp-codebox/runner-workspace-prepare',
+    workspaceCapture: 'wp-codebox/runner-workspace-capture',
+    workspaceCommand: 'wp-codebox/runner-workspace-command',
+    workspacePublish: 'wp-codebox/runner-workspace-publish',
+    toolCallTranscriptRecord: 'wp-codebox/record-tool-call-transcript',
+    artifactHandoff: 'wp-codebox/handoff-artifacts',
+  },
+  result_schemas: {
+    workspace_prepare: FALLBACK_RUNTIME_CONTRACT_SCHEMAS.runnerWorkspace.prepareResult,
+    workspace_capture: FALLBACK_RUNTIME_CONTRACT_SCHEMAS.runnerWorkspace.captureResult,
+    workspace_command: FALLBACK_RUNTIME_CONTRACT_SCHEMAS.runnerWorkspace.commandResult,
+    workspace_publication: FALLBACK_RUNTIME_CONTRACT_SCHEMAS.runnerWorkspace.publicationResult,
+    tool_call_transcript: 'wp-codebox/tool-call-transcript/v1',
+    evidence_artifact_envelope: 'wp-codebox/evidence-artifact-envelope/v1',
+  },
+};
+
+const FALLBACK_RUNTIME_CONTRACT_MANIFEST = {
+  schema: RUNTIME_CONTRACT_MANIFEST_SCHEMA,
+  version: 1,
+  schemas: FALLBACK_RUNTIME_CONTRACT_SCHEMAS,
+  providerRuntime: FALLBACK_PROVIDER_RUNTIME_INVOCATION_CONTRACT,
+};
+
+function runtimeContractManifest() {
+  return clone(FALLBACK_RUNTIME_CONTRACT_MANIFEST);
+}
+
+function runtimeContractSchemas() {
+  return runtimeContractManifest().schemas;
+}
+
+function providerRuntimeInvocationContract() {
+  return runtimeContractManifest().providerRuntime;
+}
+
+async function loadRuntimeContractSource(options = {}) {
+  const canonical = await loadCanonicalRuntimeContractSource(options);
+  if (canonical) {
+    return canonical;
+  }
+  return {
+    source: 'homeboy-extensions-fallback',
+    manifest: runtimeContractManifest(),
+    normalizers: {},
+    canonical: false,
+  };
+}
+
+async function loadCanonicalRuntimeContractSource(options = {}) {
+  const errors = [];
+  for (const specifier of coreModuleCandidates(options)) {
+    try {
+      const core = await import(specifier);
+      if (typeof core.runtimeContractManifest !== 'function') {
+        errors.push({ specifier, message: 'missing runtimeContractManifest export' });
+        continue;
+      }
+      const manifest = core.runtimeContractManifest();
+      validateCanonicalRuntimeContractManifest(manifest);
+      return {
+        source: specifier,
+        manifest,
+        normalizers: core.RUNTIME_CONTRACT_NORMALIZERS || {},
+        canonical: true,
+      };
+    } catch (error) {
+      errors.push({ specifier, error, message: error.message });
+    }
+  }
+
+  if (options.required) {
+    const error = new Error('WP Codebox canonical runtime contract manifest is unavailable.');
+    error.wpCodeboxRuntimeContractErrors = errors;
+    throw error;
+  }
+  return null;
+}
+
+function validateCanonicalRuntimeContractManifest(manifest) {
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    throw new Error('WP Codebox canonical runtime contract manifest must be an object.');
+  }
+  if (manifest.schema !== RUNTIME_CONTRACT_MANIFEST_SCHEMA) {
+    throw new Error(`WP Codebox canonical runtime contract manifest schema mismatch: ${manifest.schema || 'missing'}.`);
+  }
+  assertContractSubset(manifest.schemas, FALLBACK_RUNTIME_CONTRACT_SCHEMAS, 'schemas');
+  assertContractSubset(manifest.providerRuntime, FALLBACK_PROVIDER_RUNTIME_INVOCATION_CONTRACT, 'providerRuntime');
+}
+
+function assertContractSubset(actual, expected, pathName) {
+  if (!actual || typeof actual !== 'object' || Array.isArray(actual)) {
+    throw new Error(`WP Codebox canonical runtime contract manifest missing ${pathName}.`);
+  }
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    const currentPath = `${pathName}.${key}`;
+    const actualValue = actual[key];
+    if (expectedValue && typeof expectedValue === 'object' && !Array.isArray(expectedValue)) {
+      assertContractSubset(actualValue, expectedValue, currentPath);
+    } else if (actualValue !== expectedValue) {
+      throw new Error(`WP Codebox canonical runtime contract mismatch at ${currentPath}: expected ${expectedValue}, received ${actualValue || 'missing'}.`);
+    }
+  }
+}
+
+function coreModuleCandidates(options = {}) {
+  const explicit = options.wpCodeboxCoreModule || options.coreModule || process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE || process.env.WP_CODEBOX_CORE_MODULE;
+  if (explicit) {
+    return [normalizeCoreModuleSpecifier(explicit)];
+  }
+
+  const candidates = [DEFAULT_CODEBOX_CORE_MODULE, 'wp-codebox-workspace/core'];
+  for (const candidate of setupCacheCoreModuleCandidates(options)) {
+    if (existsSync(candidate) && !candidates.includes(candidate)) {
+      candidates.push(candidate);
+    }
+  }
+  for (const root of workspaceRoots(options)) {
+    for (const repoPath of codeboxRepoCandidates(root)) {
+      const runtimeCore = path.resolve(repoPath, RUNTIME_CORE_ENTRY);
+      if (existsSync(runtimeCore) && !candidates.includes(runtimeCore)) {
+        candidates.push(runtimeCore);
+      }
+    }
+  }
+
+  return candidates.map(normalizeCoreModuleSpecifier);
+}
+
+function setupCacheCoreModuleCandidates(options = {}) {
+  const installRoot = options.wpCodeboxInstallDir || process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.resolve(homedir(), '.cache/homeboy/wp-codebox');
+  return [
+    path.resolve(installRoot, 'source', RUNTIME_CORE_ENTRY),
+    path.resolve(installRoot, 'release/wp-codebox-cli', RUNTIME_CORE_ENTRY),
+    path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist/index.js'),
+    path.resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js'),
+  ];
+}
+
+function workspaceRoots(options = {}) {
+	const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+  return [...new Set([
+    options.workspaceRoot,
+    process.env.HOMEBOY_WORKSPACE_ROOT,
+    process.env.HOMEBOY_DEVELOPER_WORKSPACE,
+    path.dirname(repoRoot),
+  ].filter(Boolean))];
+}
+
+function codeboxRepoCandidates(root) {
+  const exact = path.resolve(root, 'wp-codebox');
+  const candidates = existsSync(exact) ? [exact] : [];
+  try {
+    candidates.push(...readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith('wp-codebox@'))
+      .map((entry) => path.resolve(root, entry.name))
+      .sort());
+  } catch {
+    // A missing or unreadable workspace root simply contributes no candidates.
+  }
+  return candidates;
+}
+
+function normalizeCoreModuleSpecifier(specifier) {
+  if (!specifier || specifier.startsWith('file:') || specifier.startsWith('node:')) {
+    return specifier;
+  }
+  if (specifier.startsWith('.') || specifier.startsWith('/') || specifier.includes(path.sep)) {
+    return pathToFileURL(path.resolve(specifier)).href;
+  }
+  return specifier;
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+module.exports = {
+  FALLBACK_RUNTIME_CONTRACT_MANIFEST,
+  FALLBACK_RUNTIME_CONTRACT_SCHEMAS,
+  RUNTIME_CONTRACT_MANIFEST_SCHEMA,
+  coreModuleCandidates,
+  loadCanonicalRuntimeContractSource,
+  loadRuntimeContractSource,
+  providerRuntimeInvocationContract,
+  runtimeContractManifest,
+  runtimeContractSchemas,
+  validateCanonicalRuntimeContractManifest,
+};

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
@@ -24,7 +24,7 @@ const FALLBACK_RUNTIME_CONTRACT_SCHEMAS = {
     previewLease: 'wp-codebox/preview-lease/v1',
     browserContainedSiteStatus: 'wp-codebox/browser-contained-site-status/v1',
     browserContainedSiteOpen: 'wp-codebox/browser-contained-site-open/v1',
-    browserSessionProductDto: 'wp-codebox/browser-session-product/v1',
+    browserSessionProductDto: 'wp-codebox/browser-session-product-dto/v1',
     browserPreviewBootConfig: 'wp-codebox/browser-preview-boot-config/v1',
   },
   artifact: {

--- a/agent-runtimes/wp-codebox/package.json
+++ b/agent-runtimes/wp-codebox/package.json
@@ -13,13 +13,15 @@
     "./delegated-run-contract": "./lib/delegated-run-contract.js",
     "./provider-credential-boundary": "./lib/provider-credential-boundary.js",
     "./provider-outcome-normalizer": "./lib/provider-outcome-normalizer.js",
-    "./wp-codebox-adapter-contract": "./lib/wp-codebox-adapter-contract.js"
+    "./wp-codebox-adapter-contract": "./lib/wp-codebox-adapter-contract.js",
+    "./wp-codebox-runtime-contract-source": "./lib/wp-codebox-runtime-contract-source.js"
   },
   "bin": {
     "homeboy-codebox-agent-task-executor": "./scripts/agent/homeboy-codebox-agent-task-executor.cjs"
   },
   "scripts": {
     "test:codebox-agent-task-executor-boundary": "node ../../wordpress/tests/codebox-agent-task-executor-boundary.test.js",
+    "test:wp-codebox-runtime-contract-source": "node ../../tests/wp-codebox-runtime-contract-source-smoke.mjs",
     "test:codebox-agent-task-executor": "node ../../wordpress/tests/codebox-agent-task-executor-smoke.js"
   },
   "engines": {

--- a/tests/wp-codebox-runtime-contract-source-smoke.mjs
+++ b/tests/wp-codebox-runtime-contract-source-smoke.mjs
@@ -27,6 +27,7 @@ const {
 const fallbackManifest = runtimeContractManifest();
 assert.equal(fallbackManifest.schema, 'wp-codebox/runtime-contract-manifest/v1');
 assert.equal(fallbackManifest.schemas.runtimeBoundary.profile, 'wp-codebox/runtime-profile/v1');
+assert.equal(fallbackManifest.schemas.runtimeBoundary.browserSessionProductDto, 'wp-codebox/browser-session-product-dto/v1');
 assert.equal(fallbackManifest.schemas.artifact.resultEnvelope, 'wp-codebox/artifact-result-envelope/v1');
 assert.deepEqual(fallbackManifest.providerRuntime, providerRuntimeInvocationContract());
 

--- a/tests/wp-codebox-runtime-contract-source-smoke.mjs
+++ b/tests/wp-codebox-runtime-contract-source-smoke.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+	loadCanonicalRuntimeContractSource,
+	loadRuntimeContractSource,
+	providerRuntimeInvocationContract,
+	runtimeContractManifest,
+	runtimeContractSchemas,
+	validateCanonicalRuntimeContractManifest,
+} = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'wp-codebox-runtime-contract-source.js'));
+const {
+	WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA,
+	WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+	WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS,
+	WP_CODEBOX_RUNTIME_PROFILE_SCHEMA,
+	wpCodeboxProviderRuntimeInvocationContract,
+} = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox'));
+
+const fallbackManifest = runtimeContractManifest();
+assert.equal(fallbackManifest.schema, 'wp-codebox/runtime-contract-manifest/v1');
+assert.equal(fallbackManifest.schemas.runtimeBoundary.profile, 'wp-codebox/runtime-profile/v1');
+assert.equal(fallbackManifest.schemas.artifact.resultEnvelope, 'wp-codebox/artifact-result-envelope/v1');
+assert.deepEqual(fallbackManifest.providerRuntime, providerRuntimeInvocationContract());
+
+const schemas = runtimeContractSchemas();
+assert.equal(WP_CODEBOX_RUNTIME_PROFILE_SCHEMA, schemas.runtimeBoundary.profile);
+assert.equal(WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA, schemas.artifact.resultEnvelope);
+assert.equal(WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA, schemas.agentTask.runResult);
+assert.equal(WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS.workspace_capture, schemas.runnerWorkspace.captureResult);
+assert.deepEqual(wpCodeboxProviderRuntimeInvocationContract(), {
+	...fallbackManifest.providerRuntime,
+	result_schemas: {
+		...fallbackManifest.providerRuntime.result_schemas,
+		artifact_result_envelope: schemas.artifact.resultEnvelope,
+	},
+});
+
+validateCanonicalRuntimeContractManifest(fallbackManifest);
+
+assert.throws(
+	() => validateCanonicalRuntimeContractManifest({
+		...fallbackManifest,
+		schemas: {
+			...fallbackManifest.schemas,
+			runtimeBoundary: {
+				...fallbackManifest.schemas.runtimeBoundary,
+				profile: 'wp-codebox/runtime-profile/v2',
+			},
+		},
+	}),
+	/mismatch at schemas\.runtimeBoundary\.profile/
+);
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hbe-codebox-runtime-contract-'));
+const canonicalModule = path.join(tempRoot, 'canonical-runtime-core.mjs');
+fs.writeFileSync(canonicalModule, `
+export function runtimeContractManifest() {
+  return ${JSON.stringify(fallbackManifest, null, 2)};
+}
+export const RUNTIME_CONTRACT_NORMALIZERS = {
+  runtimeProfile(input) { return { ...input, schema: 'wp-codebox/runtime-profile/v1' }; },
+};
+`);
+
+const canonical = await loadCanonicalRuntimeContractSource({ wpCodeboxCoreModule: canonicalModule, required: true });
+assert.equal(canonical.canonical, true);
+assert.equal(canonical.source, pathToFileURL(canonicalModule).href);
+assert.deepEqual(canonical.manifest, fallbackManifest);
+assert.equal(typeof canonical.normalizers.runtimeProfile, 'function');
+
+const loaded = await loadRuntimeContractSource({ wpCodeboxCoreModule: canonicalModule });
+assert.equal(loaded.canonical, true);
+
+const mismatchedModule = path.join(tempRoot, 'mismatched-runtime-core.mjs');
+fs.writeFileSync(mismatchedModule, `
+export function runtimeContractManifest() {
+  const manifest = ${JSON.stringify(fallbackManifest, null, 2)};
+  manifest.providerRuntime.tasks.workspaceCommand = 'wp-codebox.runner-workspace.command-v2';
+  return manifest;
+}
+`);
+
+await assert.rejects(
+	() => loadCanonicalRuntimeContractSource({ wpCodeboxCoreModule: mismatchedModule, required: true }),
+	(error) => {
+		assert.match(error.message, /canonical runtime contract manifest is unavailable/);
+		assert.match(error.wpCodeboxRuntimeContractErrors[0].message, /providerRuntime\.tasks\.workspaceCommand/);
+		return true;
+	}
+);
+
+console.log('wp-codebox runtime contract source smoke passed');


### PR DESCRIPTION
## Summary
- Add a WP Codebox runtime contract source boundary that optionally loads the canonical runtime contract manifest exported by Automattic/wp-codebox#1309.
- Derive duplicated HBE Codebox schema/provider-runtime constants from the shared contract source where that canonical surface exists.
- Keep HBE-only compatibility fields local at the adapter boundary, including the legacy task input/run-agent-task request schemas and artifact result aliasing.
- Fail closed when an available canonical manifest disagrees with the expected contract values.

## Base / dependencies
- Base: `main`
- Dependency: designed to run on `main` without a hard package dependency; consumes the canonical manifest when WP Codebox PR https://github.com/Automattic/wp-codebox/pull/1309 is available via `HOMEBOY_WP_CODEBOX_CORE_MODULE`, `WP_CODEBOX_CORE_MODULE`, installed `@automattic/wp-codebox-core`, or a discovered WP Codebox runtime-core dist.

## Verification
- `node tests/wp-codebox-runtime-contract-source-smoke.mjs` passed
- `node tests/wp-codebox-adapter-contract-smoke.mjs && node tests/wp-codebox-runtime-profile-defaults-smoke.mjs && node tests/wp-codebox-artifact-contract-smoke.mjs && node tests/wp-codebox-run-agent-task-contract-smoke.mjs` passed
- `npm run test:wp-codebox-runtime-contract-source` from `agent-runtimes/wp-codebox` passed
- `git diff --check` passed
- Targeted ESLint attempt from `wordpress` reported touched files ignored because they are outside that package base path; no lint result claimed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the compatibility boundary, updating Codebox contract consumers, adding focused tests, and drafting this PR description.