### PR TITLE
feat: accept Codebox runtime boundary inputs

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -15,6 +15,9 @@ const {
 } = require('./lib/common.cjs');
 const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 const {
+  normalizeCodeboxArtifactDeclaration,
+} = require('../../../agent-runtimes/wp-codebox/lib/codebox-artifact-contract');
+const {
   runtimeAgentCiFirstNonEmptyArray,
   runtimeAgentCiFirstNonEmptyObject,
   runtimeAgentCiTaskFromRequest,
@@ -61,6 +64,8 @@ function buildConfig(env) {
 
   const runtimeTask = runtimeTaskFromEnv(env);
   const runtimeExecution = parseJsonInput('runtime_execution', env.RUNTIME_EXECUTION || '{}', 'object', {});
+  const workload = codeboxWorkloadFromEnv(env, workloadId);
+  const toolPolicy = parseJsonInput('tool_policy', env.TOOL_POLICY || '{}', 'object', {});
   const runtimeOutputProjections = runtimeAgentCiFirstNonEmptyObject(
     parseJsonInput('runtime_output_projections', env.RUNTIME_OUTPUT_PROJECTIONS || '{}', 'object', {}),
     parseJsonInput('engine_data_outputs', env.ENGINE_DATA_OUTPUTS || '{}', 'object', {})
@@ -109,8 +114,9 @@ function buildConfig(env) {
     _configPath: path.join(runnerTemp, 'runtime-agent-full-run-config.json'),
     component_id: componentId,
     component_path: componentPath,
-    workload_id: workloadId,
-    workload_label: env.WORKLOAD_LABEL || `Run ${workloadId}`,
+    workload_id: workload.id || workloadId,
+    workload_label: workload.label || workload.name || env.WORKLOAD_LABEL || `Run ${workloadId}`,
+    workload,
     validation_dependencies: validationDependencies.paths,
     runtime_id: runtime.id,
     runtime_profile: runtimeProfile,
@@ -159,7 +165,8 @@ function buildConfig(env) {
     step_budget: Number(env.STEP_BUDGET || 16),
     time_budget_ms: Number(env.TIME_BUDGET_MS || 600000),
     expected_artifacts: parseJsonInput('expected_artifacts', env.EXPECTED_ARTIFACTS || '[]', 'array', []),
-    artifact_declarations: parseJsonInput('artifact_declarations', env.ARTIFACT_DECLARATIONS || '[]', 'array', []),
+    artifact_declarations: artifactDeclarationsFromEnv(env, runtime),
+    sandbox_tool_policy: isCodeboxRuntime(runtime) && Object.keys(toolPolicy).length > 0 ? toolPolicy : undefined,
     output_mappings: parseJsonInput('output_mappings', env.OUTPUT_MAPPINGS || '{}', 'object', {}),
     runtime_output_projections: runtimeOutputProjections,
     component_contracts: componentContracts,
@@ -200,6 +207,21 @@ function buildConfig(env) {
       ...providerBenchEnv,
     },
   };
+}
+
+function codeboxWorkloadFromEnv(env, fallbackId) {
+  const workload = parseJsonInput('workload', env.WORKLOAD || '{}', 'object', {});
+  return Object.keys(workload).length > 0 ? workload : { id: fallbackId };
+}
+
+function artifactDeclarationsFromEnv(env, runtime) {
+  const declarations = parseJsonInput('artifact_declarations', env.ARTIFACT_DECLARATIONS || '[]', 'array', []);
+  if (!isCodeboxRuntime(runtime)) {
+    return declarations;
+  }
+  return declarations
+    .map((declaration, index) => normalizeCodeboxArtifactDeclaration(`artifact_${index + 1}`, declaration))
+    .filter(Boolean);
 }
 
 function validationPaths(workspace, providerPlugin, provider) {

--- a/.github/workflows/runtime-agent-ci.yml
+++ b/.github/workflows/runtime-agent-ci.yml
@@ -62,6 +62,16 @@ on:
         required: false
         type: string
         default: '{}'
+      workload:
+        description: JSON Codebox workload DTO forwarded to the runtime config.
+        required: false
+        type: string
+        default: '{}'
+      tool_policy:
+        description: JSON Codebox sandbox tool-policy DTO forwarded to the runtime config.
+        required: false
+        type: string
+        default: '{}'
       runtime_output_projections:
         description: JSON map of output names to provider runtime result paths.
         required: false
@@ -84,6 +94,11 @@ on:
         default: '[]'
       artifact_slots:
         description: JSON array/object declaring expected artifact slots.
+        required: false
+        type: string
+        default: '[]'
+      artifact_declarations:
+        description: JSON array of Codebox artifact declaration DTOs.
         required: false
         type: string
         default: '[]'
@@ -124,11 +139,14 @@ jobs:
           IGNORED_WORKSPACE_PATHS: ${{ inputs.ignored_workspace_paths }}
           RUNTIME_TASK: ${{ inputs.runtime_task }}
           RUNTIME_EXECUTION: ${{ inputs.runtime_execution }}
+          WORKLOAD: ${{ inputs.workload }}
+          TOOL_POLICY: ${{ inputs.tool_policy }}
           RUNTIME_OUTPUT_PROJECTIONS: ${{ inputs.runtime_output_projections }}
           EVIDENCE_PROJECTIONS: ${{ inputs.evidence_projections }}
           ABILITY_REQUIREMENTS: ${{ inputs.ability_requirements }}
           ABILITY_TOOLS: ${{ inputs.ability_tools }}
           ARTIFACT_SLOTS: ${{ inputs.artifact_slots }}
+          ARTIFACT_DECLARATIONS: ${{ inputs.artifact_declarations }}
           TRANSCRIPT_SLOTS: ${{ inputs.transcript_slots }}
           TASK_TIMEOUT_SECONDS: ${{ inputs.task_timeout_seconds }}
         run: |
@@ -163,6 +181,8 @@ jobs:
             runtimeComponentPaths: parseJson('RUNTIME_COMPONENT_PATHS', {}),
             ignoredWorkspacePaths: parseJson('IGNORED_WORKSPACE_PATHS', []),
             runtimeExecution: parseJson('RUNTIME_EXECUTION', {}),
+            workload: parseJson('WORKLOAD', {}),
+            toolPolicy: parseJson('TOOL_POLICY', {}),
             runtimeOutputProjections: parseJson('RUNTIME_OUTPUT_PROJECTIONS', {}),
             evidenceProjections: parseJson('EVIDENCE_PROJECTIONS', []),
             abilityInput: runtimeTask.input || {},
@@ -170,6 +190,7 @@ jobs:
             abilityRequirements: parseJson('ABILITY_REQUIREMENTS', []),
             abilityTools: parseJson('ABILITY_TOOLS', []),
             artifactSlots: parseJson('ARTIFACT_SLOTS', []),
+            artifactDeclarations: parseJson('ARTIFACT_DECLARATIONS', []),
             transcriptSlots: parseJson('TRANSCRIPT_SLOTS', []),
             taskTimeoutSeconds: Number(process.env.TASK_TIMEOUT_SECONDS || 900),
           });

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -99,6 +99,14 @@ name: Runtime Agent Full Run (reusable)
         description: JSON object describing a generic ability, bundle, or workflow execution.
         type: string
         default: '{}'
+      workload:
+        description: JSON Codebox workload DTO forwarded to the runtime config. Falls back to workload_id/workload_label when empty.
+        type: string
+        default: '{}'
+      tool_policy:
+        description: JSON Codebox sandbox tool-policy DTO forwarded to the runtime config.
+        type: string
+        default: '{}'
       ability_request:
         description: JSON object shorthand for runtime_task.
         type: string
@@ -168,7 +176,7 @@ name: Runtime Agent Full Run (reusable)
         type: string
         default: '[]'
       artifact_declarations:
-        description: JSON array of typed artifact declarations.
+        description: JSON array of Codebox artifact declaration DTOs.
         type: string
         default: '[]'
       transcript_artifact_name:
@@ -501,6 +509,8 @@ jobs:
           EXECUTION_KIND: ${{ inputs.execution_kind }}
           RUNTIME_TASK: ${{ inputs.runtime_task }}
           RUNTIME_EXECUTION: ${{ inputs.runtime_execution }}
+          WORKLOAD: ${{ inputs.workload }}
+          TOOL_POLICY: ${{ inputs.tool_policy }}
           ABILITY_REQUEST: ${{ inputs.ability_request }}
           ABILITY_INPUT: ${{ inputs.ability_input }}
           OUTPUT_MAPPINGS: ${{ inputs.output_mappings }}

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -90,6 +90,8 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
   const runtimeProvider = options.runtime || options.runtimeId || options.runtime_id || options.runtimeProvider || options.runtime_provider;
   const runtimeExecution = normalizeRuntimeExecutionDescriptor(options.runtimeExecution || options.runtime_execution, runtimeProfile);
   const runtimeTaskInput = runtimeExecution?.input || options.abilityInput || options.ability_input || {};
+  const workload = nonEmptyObject(options.workload);
+  const toolPolicy = nonEmptyObject(options.toolPolicy || options.tool_policy || options.sandboxToolPolicy || options.sandbox_tool_policy);
   const runtimeTask = stripUndefined({
     ability: runtimeExecution?.ability || options.ability || runtimeProfile.runtime_task_ability,
     input: runtimeTaskInput,
@@ -107,9 +109,12 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
     agent_bundles: options.agentBundles || options.agent_bundles,
     ignored_workspace_paths: options.ignoredWorkspacePaths || options.ignored_workspace_paths,
     runtime_task: runtimeTask,
+    workload,
+    sandbox_tool_policy: toolPolicy,
     ability_tools: options.abilityTools || options.ability_tools,
     ability_requirements: options.abilityRequirements || options.ability_requirements || runtimeProfile.ability_requirements,
     artifact_slots: options.artifactSlots || options.artifact_slots,
+    artifact_declarations: options.artifactDeclarations || options.artifact_declarations,
     transcript_slots: options.transcriptSlots || options.transcript_slots,
     runtime_execution: runtimeExecution,
     runtime_output_projections: options.runtimeOutputProjections || options.runtime_output_projections,
@@ -240,6 +245,10 @@ function stripUndefined(value) {
   return Object.fromEntries(
     Object.entries(value).filter(([, entry]) => entry !== undefined)
   );
+}
+
+function nonEmptyObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length > 0 ? value : undefined;
 }
 
 module.exports = {

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -53,11 +53,14 @@ const genericConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
   ignoredWorkspacePaths: ['.cache', 'tmp'],
   ability: 'example/run-task',
   abilityInput: { prompt: 'Cook.' },
+  workload: { schema: 'wp-codebox/workload/v1', id: 'cook-workload', label: 'Cook workload' },
+  toolPolicy: { schema: 'wp-codebox/tool-policy/v1', tools: { workspace_read: true } },
   abilityTools: [{ name: 'example_tool' }],
   runtimeOutputProjections: { packet_url: 'metadata.artifacts.packet.url' },
   callbackData: { initial: { seed: 'value' } },
   evidenceProjections: [{ operation: 'workspacePublish', outputs: { pr_url: 'result.pr.url' } }],
   artifactSlots: [{ name: 'packet', required: true }],
+  artifactDeclarations: [{ schema: 'wp-codebox/artifact-declaration/v1', name: 'packet', required: true }],
   transcriptSlots: [{ name: 'main', required: true }],
   runtimeInvocation: { operations: ['workspaceCommand'] },
 });
@@ -67,12 +70,15 @@ assert.equal(genericConfig.runtime_profile, 'example-agent-ci');
 assert.deepEqual(genericConfig.runtime_component_paths, { agent_runtime: '/workspace/components/example-runtime' });
 assert.deepEqual(genericConfig.ignored_workspace_paths, ['.cache', 'tmp']);
 assert.deepEqual(genericConfig.runtime_task, { ability: 'example/run-task', input: { prompt: 'Cook.' } });
+assert.deepEqual(genericConfig.workload, { schema: 'wp-codebox/workload/v1', id: 'cook-workload', label: 'Cook workload' });
+assert.deepEqual(genericConfig.sandbox_tool_policy, { schema: 'wp-codebox/tool-policy/v1', tools: { workspace_read: true } });
 assert.deepEqual(genericConfig.ability_requirements, ['example/run-task', 'example/read-state']);
 assert.deepEqual(genericConfig.ability_tools, [{ name: 'example_tool' }]);
 assert.deepEqual(genericConfig.runtime_output_projections, { packet_url: 'metadata.artifacts.packet.url' });
 assert.deepEqual(genericConfig.callback_data, { initial: { seed: 'value' } });
 assert.deepEqual(genericConfig.evidence_projections, [{ operation: 'workspacePublish', outputs: { pr_url: 'result.pr.url' } }]);
 assert.deepEqual(genericConfig.artifact_slots, [{ name: 'packet', required: true }]);
+assert.deepEqual(genericConfig.artifact_declarations, [{ schema: 'wp-codebox/artifact-declaration/v1', name: 'packet', required: true }]);
 assert.deepEqual(genericConfig.transcript_slots, [{ name: 'main', required: true }]);
 assert.deepEqual(genericConfig.provider_runtime_invocation, { operations: ['workspaceCommand'] });
 
@@ -110,6 +116,17 @@ assert.equal(genericBundleConfig.runtime_task.input.source, '/workspace/example-
 assert.deepEqual(genericBundleConfig.runtime_task.input.workflow, { name: 'materialize-artifact' });
 assert.equal(genericBundleConfig.runtime_task.input.prompt, 'Cook a packet.');
 assert.equal(genericBundleConfig.runtime_execution.kind, 'bundle');
+
+const emptyCodeboxDtoConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
+  runtimeProfile: runtimeProfile.id,
+  runtimeProfiles: { [runtimeProfile.id]: runtimeProfile },
+  ability: 'example/run-task',
+  toolPolicy: {},
+  workload: {},
+});
+assert.equal(emptyCodeboxDtoConfig.sandbox_tool_policy, undefined);
+assert.equal(emptyCodeboxDtoConfig.workload, undefined);
+
 const genericPackageConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
   runtimeProfile: runtimeProfile.id,
   runtimeProfiles: { [runtimeProfile.id]: runtimeProfile },

--- a/tests/runtime-agent-full-run-codebox-inputs-smoke.mjs
+++ b/tests/runtime-agent-full-run-codebox-inputs-smoke.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { buildConfig } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/build-runner-config.cjs'));
+
+const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-inputs-'));
+const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-runner-'));
+fs.mkdirSync(path.join(workspace, '.ci/wp-codebox/packages/cli/dist'), { recursive: true });
+fs.writeFileSync(path.join(workspace, '.ci/wp-codebox/packages/cli/dist/index.js'), '#!/usr/bin/env node\n');
+
+const config = buildConfig({
+  GITHUB_WORKSPACE: workspace,
+  RUNNER_TEMP: runnerTemp,
+  WORKLOAD_ID: 'legacy-workload-id',
+  WORKLOAD_LABEL: 'Legacy workload label',
+  TARGET_REPO: 'Extra-Chill/example',
+  RUNTIME: 'wp-codebox',
+  PROFILE: 'codebox-profile',
+  RUNTIME_PROFILES: JSON.stringify({
+    'codebox-profile': {
+      schema: 'wp-codebox/runtime-profile/v1',
+      id: 'codebox-profile',
+    },
+  }),
+  WORKLOAD: JSON.stringify({
+    schema: 'wp-codebox/workload/v1',
+    id: 'codebox-workload',
+    label: 'Codebox workload',
+  }),
+  TOOL_POLICY: JSON.stringify({
+    schema: 'wp-codebox/tool-policy/v1',
+    tools: { workspace_read: true },
+  }),
+  ARTIFACT_DECLARATIONS: JSON.stringify([
+    { name: 'packet', kind: 'application/vnd.example.packet+json', required: true },
+    'transcript',
+  ]),
+});
+
+assert.equal(config.workload_id, 'codebox-workload');
+assert.equal(config.workload_label, 'Codebox workload');
+assert.deepEqual(config.workload, {
+  schema: 'wp-codebox/workload/v1',
+  id: 'codebox-workload',
+  label: 'Codebox workload',
+});
+assert.deepEqual(config.sandbox_tool_policy, {
+  schema: 'wp-codebox/tool-policy/v1',
+  tools: { workspace_read: true },
+});
+assert.deepEqual(config.artifact_declarations, [
+  {
+    schema: 'wp-codebox/artifact-declaration/v1',
+    name: 'packet',
+    type: 'application/vnd.example.packet+json',
+    required: true,
+  },
+  {
+    schema: 'wp-codebox/artifact-declaration/v1',
+    name: 'transcript',
+    required: true,
+  },
+]);
+
+console.log('runtime agent full-run Codebox inputs smoke passed');


### PR DESCRIPTION
## Summary
- Add Codebox workload, tool policy, and artifact declaration inputs to runtime agent CI workflows
- Thread Codebox DTO inputs into runtime config without exposing Data Machine internals
- Normalize Codebox artifact declarations for WP Codebox runtimes while preserving legacy fields

## Testing
- node tests/runtime-agent-ci-contract-smoke.mjs
- node tests/runtime-agent-full-run-codebox-inputs-smoke.mjs
- bash tests/runtime-agent-full-run-boundary-smoke.sh
- node tests/wp-codebox-runtime-profile-defaults-smoke.mjs
- node --check .github/scripts/runtime-agent-full-run/build-runner-config.cjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Adding Codebox boundary inputs and focused smoke coverage
