### PR TITLE
Support WordPress dependency package subdirectories

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -85,6 +85,36 @@ _homeboy_validation_dependency_entry_source_type() {
     fi
 }
 
+_homeboy_validation_dependency_entry_package_path() {
+    local entry="${1:-}"
+
+    if _homeboy_validation_dependency_entry_is_object "$entry"; then
+        printf '%s' "$entry" | jq -r '.package_path // .packagePath // .subdir // .subdirectory // .plugin_path // .pluginPath // empty'
+    fi
+}
+
+_homeboy_validation_dependency_package_root() {
+    local resolved_path="${1:-}"
+    local package_path="${2:-}"
+
+    [ -n "$resolved_path" ] && [ -d "$resolved_path" ] || return 1
+    [ -n "$package_path" ] || {
+        printf '%s\n' "$resolved_path"
+        return 0
+    }
+
+    case "$package_path" in
+        /*|*..*) return 1 ;;
+    esac
+
+    if [ -d "${resolved_path%/}/${package_path}" ]; then
+        printf '%s\n' "${resolved_path%/}/${package_path}"
+        return 0
+    fi
+
+    return 1
+}
+
 _homeboy_validation_dependency_catalog_dir() {
     local base_dir="${HOMEBOY_CACHE_DIR:-${TMPDIR:-/tmp}}"
     local catalog_dir="${base_dir%/}/homeboy-deps"
@@ -182,16 +212,17 @@ _homeboy_resolve_validation_dependency_entry_path() {
         return $?
     fi
 
-    local source_type source slug revision url resolved
+    local source_type source slug revision url package_path resolved package_root
     source_type=$(_homeboy_validation_dependency_entry_source_type "$entry")
     source=$(printf '%s' "$entry" | jq -r '.path // .local_path // .dependency // .source // empty')
     slug=$(_homeboy_validation_dependency_entry_slug "$entry")
     revision=$(printf '%s' "$entry" | jq -r '.revision // .ref // .version // empty')
     url=$(printf '%s' "$entry" | jq -r '.url // .zip_url // empty')
+    package_path=$(_homeboy_validation_dependency_entry_package_path "$entry")
 
     if [ -n "$source" ] && [ -d "$source" ]; then
-        printf '%s\n' "$source"
-        return 0
+        package_root=$(_homeboy_validation_dependency_package_root "$source" "$package_path" || true)
+        [ -n "$package_root" ] && printf '%s\n' "$package_root" && return 0
     fi
 
     case "$source_type" in
@@ -199,18 +230,22 @@ _homeboy_resolve_validation_dependency_entry_path() {
             local repo
             repo=$(printf '%s' "$entry" | jq -r '.repo // .repository // .source // empty')
             resolved=$(_homeboy_clone_catalog_github_dependency "$repo" "$slug" "$revision" || true)
-            [ -n "$resolved" ] && [ -d "$resolved" ] && printf '%s\n' "$resolved" && return 0
+            package_root=$(_homeboy_validation_dependency_package_root "$resolved" "$package_path" || true)
+            [ -n "$package_root" ] && [ -d "$package_root" ] && printf '%s\n' "$package_root" && return 0
             ;;
         wp.org|wporg|wordpress.org|wp.org-zip|wordpress.org-zip)
             [ -n "$slug" ] || slug=$(printf '%s' "$entry" | jq -r '.dependency // empty')
             resolved=$(_homeboy_materialize_wordpress_org_zip_dependency "$slug" "$revision" "$url" || true)
-            [ -n "$resolved" ] && [ -d "$resolved" ] && printf '%s\n' "$resolved" && return 0
+            package_root=$(_homeboy_validation_dependency_package_root "$resolved" "$package_path" || true)
+            [ -n "$package_root" ] && [ -d "$package_root" ] && printf '%s\n' "$package_root" && return 0
             ;;
     esac
 
     if [ -n "$source" ]; then
-        homeboy_resolve_validation_dependency_path "$source"
-        return $?
+        resolved=$(homeboy_resolve_validation_dependency_path "$source" || true)
+        package_root=$(_homeboy_validation_dependency_package_root "$resolved" "$package_path" || true)
+        [ -n "$package_root" ] && printf '%s\n' "$package_root" && return 0
+        return 1
     fi
 
     [ -n "$slug" ] || return 1

--- a/wordpress/tests/dependency-plugin-preflight-smoke.sh
+++ b/wordpress/tests/dependency-plugin-preflight-smoke.sh
@@ -123,6 +123,29 @@ if [ -f "${NESTED_PACKAGE_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagn
     exit 1
 fi
 
+MONOREPO_DEP="${TMP_ROOT}/blocks-engine"
+mkdir -p "${MONOREPO_DEP}/php-transformer"
+cat > "${MONOREPO_DEP}/php-transformer/blocks-engine-php-transformer.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: Blocks Engine PHP Transformer Fixture
+ */
+PHP
+
+MONOREPO_PACKAGE_ROOT=$(_homeboy_validation_dependency_package_root "$MONOREPO_DEP" "php-transformer")
+if [ "$MONOREPO_PACKAGE_ROOT" != "${MONOREPO_DEP}/php-transformer" ]; then
+    echo "ERROR: package_path resolution did not return the monorepo plugin package root." >&2
+    exit 1
+fi
+
+MONOREPO_ENTRY=$(jq -nc --arg source "$MONOREPO_DEP" '{source: $source, plugin_slug: "blocks-engine-php-transformer", package_path: "php-transformer"}')
+MONOREPO_RESOLVED=$(_homeboy_resolve_validation_dependency_entry_path "$MONOREPO_ENTRY")
+if [ "$MONOREPO_RESOLVED" != "${MONOREPO_DEP}/php-transformer" ]; then
+    echo "ERROR: validation dependency object package_path did not resolve to the plugin package root." >&2
+    echo "Resolved: $MONOREPO_RESOLVED" >&2
+    exit 1
+fi
+
 SANITIZE_KEY_DEP="${TMP_ROOT}/sanitize-key-plugin"
 mkdir -p "$SANITIZE_KEY_DEP"
 cat > "${SANITIZE_KEY_DEP}/sanitize-key-plugin.php" <<'PHP'


### PR DESCRIPTION
## Summary
- Let WordPress validation dependency objects resolve a package subdirectory via package_path/packagePath/subdir/subdirectory/plugin_path/pluginPath.
- Apply the package path after local, GitHub, wp.org, and slug-based dependency resolution.
- Cover monorepo plugin packages such as blocks-engine/php-transformer in the dependency preflight smoke.

## Verification
- bash wordpress/tests/dependency-plugin-preflight-smoke.sh
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 and OpenCode
- **Used for:** Implementing dependency package path resolution and smoke coverage.