### PR TITLE
Fail invalid Codebox typed artifacts

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -2556,6 +2556,31 @@ function missingRequiredTypedArtifactDiagnostic(request, outputs) {
   };
 }
 
+function invalidRequiredTypedArtifactDiagnostic(request, outputs) {
+  const typedArtifacts = outputs?.typed_artifacts && typeof outputs.typed_artifacts === 'object' && !Array.isArray(outputs.typed_artifacts)
+    ? outputs.typed_artifacts
+    : {};
+  const invalid = requiredArtifactDeclarationsFromRequest(request)
+    .map((declaration) => typedArtifactNameFromDeclaration(declaration))
+    .filter((name) => name && unexecutedWorkspaceToolCallArtifact(typedArtifacts[name]));
+  if (invalid.length === 0) {
+    return null;
+  }
+  return {
+    class: 'codebox.required_typed_artifacts_invalid',
+    message: `WP Codebox agent task produced invalid required typed artifacts: ${invalid.join(', ')}.`,
+    data: { reason: 'invalid_required_typed_artifacts', invalid },
+  };
+}
+
+function unexecutedWorkspaceToolCallArtifact(artifact) {
+  if (!artifact || typeof artifact !== 'object') {
+    return false;
+  }
+  const content = String(artifact.payload?.content || '').trim();
+  return /^<workspace_[a-z0-9_:-]+(?:\s[^>]*)?\/>$/i.test(content);
+}
+
 function outputsWithInputTypedArtifacts(outputs, request) {
   const typedArtifacts = outputs?.typed_artifacts && typeof outputs.typed_artifacts === 'object' && !Array.isArray(outputs.typed_artifacts)
     ? { ...outputs.typed_artifacts }
@@ -3100,8 +3125,12 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   const failureClassification = homeboyFailureClassification(result.failure_classification || recipeSummary?.metadata?.failure_classification || runSummary?.failure_classification, status);
   const outputs = outputsWithInputTypedArtifacts(normalizeOutputs(result, request), request);
   const missingRequiredTypedArtifacts = missingRequiredTypedArtifactDiagnostic(request, outputs);
+  const invalidRequiredTypedArtifacts = invalidRequiredTypedArtifactDiagnostic(request, outputs);
   const runtimeFailureDiagnostic = agentRuntimeFailureDiagnostic(result);
   if (status === 'succeeded' && missingRequiredTypedArtifacts) {
+    status = 'failed';
+  }
+  if (status === 'succeeded' && invalidRequiredTypedArtifacts) {
     status = 'failed';
   }
   if (status === 'succeeded' && runtimeFailureDiagnostic) {
@@ -3117,11 +3146,11 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     providerLabel: 'WP Codebox agent',
     integrationContract: WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
     status,
-    summary: missingRequiredTypedArtifacts?.message || runtimeFailureDiagnostic?.message || recipeSummary?.failure_summary || fallbackRecipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
+    summary: missingRequiredTypedArtifacts?.message || invalidRequiredTypedArtifacts?.message || runtimeFailureDiagnostic?.message || recipeSummary?.failure_summary || fallbackRecipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
     artifacts: normalizeArtifacts(result, runSummary, recipeSummary),
     evidenceRefs: normalizeEvidenceRefs(result, runSummary, recipeSummary),
     outputs,
-    diagnostics: [providerDiagnostic, missingRequiredTypedArtifacts, runtimeFailureDiagnostic, recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
+    diagnostics: [providerDiagnostic, missingRequiredTypedArtifacts, invalidRequiredTypedArtifacts, runtimeFailureDiagnostic, recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
       message: diagnostic.message || String(diagnostic),
       data: sanitizePublicMetadata(diagnostic.data || {}),
@@ -3143,7 +3172,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   });
   if (failureClassification) {
     outcome.failure_classification = failureClassification;
-  } else if (missingRequiredTypedArtifacts) {
+  } else if (missingRequiredTypedArtifacts || invalidRequiredTypedArtifacts) {
     outcome.failure_classification = 'execution_failed';
   }
   return outcomeWithOutputTypedArtifacts(outcome, outputs);

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -6,6 +6,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const {
+  agentTaskOutcomeFromCodeboxResult,
   artifactResultEnvelopeFromCodeboxResult,
   codeboxTaskRequestFromAgentTaskRequest,
   normalizeCodeboxArtifactDeclaration,
@@ -523,6 +524,28 @@ assert.equal(
   providerAndControllerArtifactsTaskInput.runtime_task.input.engine_data_outputs.concept_packet,
   'metadata.engine_data.outputs.typed_artifacts.concept_packet.payload'
 );
+
+const placeholderArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'placeholder-artifact-task-1',
+  executor: { backend: 'codebox', config: { provider: 'openai' } },
+  artifact_declarations: [{
+    name: 'concept_packet',
+    artifact_schema: 'wp-site-generator/ConceptPacket/v1',
+    required: true,
+  }],
+}, {
+  success: true,
+  status: 'completed',
+  reply: '<workspace_ls path="/workspace/wp-site-generator" />',
+});
+assert.equal(placeholderArtifactOutcome.status, 'failed');
+assert.equal(placeholderArtifactOutcome.failure_classification, 'execution_failed');
+assert.deepEqual(
+  placeholderArtifactOutcome.diagnostics.map((diagnostic) => diagnostic.class),
+  ['codebox.required_typed_artifacts_invalid']
+);
+assert.match(placeholderArtifactOutcome.summary, /invalid required typed artifacts: concept_packet/);
 
 const genericRepoLoopTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',


### PR DESCRIPTION
## Summary
- detect required typed artifacts whose payload is an unexecuted workspace tool-call placeholder
- fail the Codebox agent-task outcome instead of treating placeholder artifacts as valid semantic outputs
- cover the failure mode in the Codebox boundary contract test

## Testing
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Root-cause investigation, implementation, and test updates.