### PR TITLE
feat: add WordPress fuzz runner bridge

### DIFF
--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -44,6 +44,7 @@ module.exports = {
 	...require('./lib/wordpress-workload-profile'),
 	...require('./lib/wordpress-hook-surface-discovery'),
 	...require('./lib/wordpress-fuzz-schemas'),
+	...require('./lib/wordpress-fuzz-runner'),
 	buildStaticVisualParityRecipe: staticVisualParity.buildStaticVisualParityRecipe,
 	createStaticServer: staticVisualParity.createStaticServer,
 	normalizeStaticVisualParityArtifacts: staticVisualParity.normalizeStaticVisualParityArtifacts,

--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -1,0 +1,183 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const fs = require('node:fs');
+
+/**
+ * Internal dependencies
+ */
+const {
+	WORDPRESS_FUZZ_PLAN_SCHEMA,
+	normalizeWordPressFuzzPlan,
+} = require('./wordpress-fuzz-schemas');
+const { buildWpCodeboxFuzzPlanRecipe } = require('./wp-codebox-fuzz-plan');
+const {
+	normalizeWpCodeboxFuzzRunResult,
+	wpCodeboxFuzzRunInput,
+	wpCodeboxFuzzRunTaskRequest,
+} = require('./wp-codebox-fuzz-run');
+const { aggregateWordPressFuzzCoverage } = require('./wordpress-fuzz-coverage-aggregate');
+
+const WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA = 'homeboy/wordpress-fuzz-runner-result/v1';
+
+function readWordPressFuzzRunnerEnv(env = process.env) {
+	return stripUndefined({
+		workloadPath: env.HOMEBOY_FUZZ_WORKLOAD_PATH,
+		workloadId: env.HOMEBOY_FUZZ_WORKLOAD_ID,
+		runId: env.HOMEBOY_FUZZ_RUN_ID,
+		seed: env.HOMEBOY_FUZZ_SEED,
+		maxDuration: env.HOMEBOY_FUZZ_MAX_DURATION,
+	});
+}
+
+function buildWordPressFuzzRunnerResult(options = {}) {
+	const env = options.env || readWordPressFuzzRunnerEnv();
+	const workload = options.workload || readJsonFile(requiredString(env.workloadPath, 'HOMEBOY_FUZZ_WORKLOAD_PATH'));
+	const runId = requiredString(env.runId || workload.run_id || workload.runId || workload.id, 'HOMEBOY_FUZZ_RUN_ID');
+	const workloadId = env.workloadId || workload.workload_id || workload.workloadId || workload.id || null;
+	const seed = env.seed || workload.seed || null;
+	const maxDuration = numericValue(env.maxDuration ?? workload.max_duration ?? workload.maxDuration);
+	const plan = normalizeRunnerPlan(workload.plan || workload.fuzz_plan || workload.fuzzPlan || workload);
+	const wpCodeboxInput = buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDuration });
+	const taskRequest = wpCodeboxFuzzRunTaskRequest({
+		taskId: runId,
+		input: wpCodeboxInput,
+		provider: workload.provider,
+		runtimeId: workload.runtime_id || workload.runtimeId || 'wp-codebox',
+	});
+	const codeboxPlanRecipe = buildCodeboxPlanRecipe(workload);
+	const codeboxResult = normalizeCodeboxResult(workload);
+	const coverage = aggregateCoverage(workload, codeboxResult);
+	const status = codeboxResult?.succeeded === false || hasCoverageFailures(coverage) ? 'failed' : (codeboxResult?.status || 'planned');
+
+	return stripUndefined({
+		schema: WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
+		status,
+		succeeded: status === 'planned' ? undefined : !['failed', 'errored'].includes(String(status).toLowerCase()),
+		run_id: runId,
+		workload_id: workloadId,
+		seed,
+		max_duration_seconds: maxDuration,
+		plan_id: plan.id,
+		wp_codebox_input: wpCodeboxInput,
+		wp_codebox_task_request: taskRequest,
+		wp_codebox_plan_recipe: codeboxPlanRecipe,
+		wp_codebox_result: codeboxResult,
+		coverage,
+		metadata: objectOrUndefined(workload.metadata),
+	});
+}
+
+function normalizeRunnerPlan(input) {
+	if (input?.schema === WORDPRESS_FUZZ_PLAN_SCHEMA || Array.isArray(input?.targets)) {
+		return normalizeWordPressFuzzPlan(input);
+	}
+	return normalizeWordPressFuzzPlan({
+		schema: WORDPRESS_FUZZ_PLAN_SCHEMA,
+		id: input?.id || input?.plan_id || input?.planId || 'wordpress-fuzz-plan',
+		targets: normalizeArray(input?.targets),
+		budget: objectOrUndefined(input?.budget),
+		metadata: objectOrUndefined(input?.metadata),
+	});
+}
+
+function buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDuration }) {
+	return wpCodeboxFuzzRunInput({
+		id: runId,
+		target: workload.target || { type: 'wordpress', workload_id: workloadId },
+		workload: stripUndefined({
+			id: workloadId,
+			plan_id: plan.id,
+			discovery_id: plan.discovery_id,
+			metadata: objectOrUndefined(workload.metadata),
+		}),
+		cases: flattenPlanCases(plan),
+		seeds: seed ? [{ id: seed, value: seed }] : normalizeArray(workload.seeds),
+		limits: stripUndefined({
+			...(workload.limits || {}),
+			max_duration_seconds: maxDuration,
+		}),
+		coverage: workload.coverage || { wordpress_fuzz_coverage: true },
+		runtimeProfile: workload.runtime_profile || workload.runtimeProfile,
+		artifacts: workload.artifacts,
+		metadata: stripUndefined({ ...(workload.metadata || {}), runner: WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA }),
+	});
+}
+
+function flattenPlanCases(plan) {
+	return plan.targets.flatMap((target) => target.cases.map((testCase) => stripUndefined({
+		...testCase,
+		target_id: target.id,
+		surface_id: target.surface_id,
+		target_metadata: objectOrUndefined(target.metadata),
+	})));
+}
+
+function buildCodeboxPlanRecipe(workload) {
+	const plan = workload.wp_codebox_plan || workload.wpCodeboxPlan || workload.codebox_plan || workload.codeboxPlan;
+	if (!plan) {
+		return undefined;
+	}
+	return buildWpCodeboxFuzzPlanRecipe(plan);
+}
+
+function normalizeCodeboxResult(workload) {
+	const result = workload.wp_codebox_result || workload.wpCodeboxResult || workload.result;
+	return result ? normalizeWpCodeboxFuzzRunResult(result) : undefined;
+}
+
+function aggregateCoverage(workload, codeboxResult) {
+	const coverageInput = workload.coverage_artifacts || workload.coverageArtifacts || codeboxResult?.coverage;
+	if (!coverageInput) {
+		return undefined;
+	}
+	return aggregateWordPressFuzzCoverage(coverageInput);
+}
+
+function hasCoverageFailures(coverage) {
+	return Number(coverage?.totals?.failed || 0) > 0;
+}
+
+function readJsonFile(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function requiredString(value, name) {
+	if (typeof value !== 'string' || value.trim() === '') {
+		throw new Error(`${name} is required.`);
+	}
+	return value;
+}
+
+function normalizeArray(value) {
+	return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function objectOrUndefined(value) {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value : undefined;
+}
+
+function numericValue(value) {
+	if (value === undefined || value === null || value === '') {
+		return undefined;
+	}
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function stripUndefined(value) {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return value;
+	}
+	return Object.fromEntries(
+		Object.entries(value).filter(([, entry]) => entry !== undefined)
+	);
+}
+
+module.exports = {
+	WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
+	buildWordPressFuzzRunnerResult,
+	readWordPressFuzzRunnerEnv,
+};

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -53,7 +53,8 @@
     "./audit-wp-codebox-fanout": "./lib/audit-wp-codebox-fanout.js",
     "./wordpress-runtime-task-planner": "./lib/wordpress-runtime-task-planner.js",
     "./wordpress-hook-surface-discovery": "./lib/wordpress-hook-surface-discovery.js",
-    "./wp-codebox-fuzz-run": "./lib/wp-codebox-fuzz-run.js"
+    "./wp-codebox-fuzz-run": "./lib/wp-codebox-fuzz-run.js",
+    "./wordpress-fuzz-runner": "./lib/wordpress-fuzz-runner.js"
   },
   "scripts": {
     "lint:js": "eslint",
@@ -129,6 +130,7 @@
     "test:wordpress-runtime-task-planner": "node tests/wordpress-runtime-task-planner-smoke.js",
     "test:wordpress-hook-surface-discovery": "node tests/wordpress-hook-surface-discovery-smoke.js",
     "test:wp-codebox-fuzz-run": "node tests/wp-codebox-fuzz-run-smoke.js",
+    "test:wordpress-fuzz-runner": "node tests/wordpress-fuzz-runner-smoke.js",
     "test:wordpress-public-export-boundary": "node tests/wordpress-public-export-boundary.test.js",
     "test:wordpress-manifest-settings": "node tests/wordpress-manifest-settings-smoke.js",
     "test:refactor-source-wp-codebox": "node tests/refactor-source-wp-codebox-smoke.js",

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Internal dependencies
+ */
+const { buildWordPressFuzzRunnerResult, readWordPressFuzzRunnerEnv } = require('../../lib/wordpress-fuzz-runner');
+
+try {
+	const result = buildWordPressFuzzRunnerResult({ env: readWordPressFuzzRunnerEnv() });
+	process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+} catch (error) {
+	process.stderr.write(`${error.message}\n`);
+	process.exit(1);
+}

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const {
+	WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
+	buildWordPressFuzzRunnerResult,
+} = require('../lib/wordpress-fuzz-runner');
+
+const workload = {
+	id: 'generic-wordpress-workload',
+	plan: {
+		schema: 'wordpress-fuzz-plan/v1',
+		id: 'generic-wordpress-plan',
+		targets: [
+			{
+				id: 'rest-posts',
+				surface_id: 'route:/wp/v2/posts',
+				cases: [{ id: 'get-posts', method: 'GET', path: '/wp/v2/posts' }],
+			},
+		],
+	},
+	wp_codebox_plan: {
+		id: 'codebox-plan',
+		cases: [
+			{
+				case_id: 'get-posts',
+				action: [{ command: 'wp-rest-request', args: ['GET', '/wp/v2/posts'] }],
+			},
+		],
+	},
+	coverage_artifacts: [
+		{
+			schema: 'homeboy/wordpress-fuzz-coverage/v1',
+			hooks: { actions: { init: 1 } },
+		},
+	],
+};
+
+const result = buildWordPressFuzzRunnerResult({
+	env: {
+		workloadPath: '/unused/in-unit-test.json',
+		workloadId: 'workload-from-env',
+		runId: 'run-from-env',
+		seed: 'seed-123',
+		maxDuration: '30',
+	},
+	workload,
+});
+
+assert.equal(result.schema, WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA);
+assert.equal(result.status, 'planned');
+assert.equal(result.run_id, 'run-from-env');
+assert.equal(result.workload_id, 'workload-from-env');
+assert.equal(result.seed, 'seed-123');
+assert.equal(result.max_duration_seconds, 30);
+assert.equal(result.wp_codebox_input.schema, 'wp-codebox/fuzz-run/v1');
+assert.equal(result.wp_codebox_input.cases[0].target_id, 'rest-posts');
+assert.equal(result.wp_codebox_task_request.executor.config.runtime_task.ability, 'wp-codebox/fuzz-run');
+assert.equal(result.wp_codebox_plan_recipe.fuzzRun.cases[0].case_id, 'get-posts');
+assert.equal(result.coverage.schema, 'homeboy/wordpress-fuzz-coverage-aggregate/v1');
+assert.equal(result.coverage.totals.exercised, 1);
+assert(!JSON.stringify(result).includes('woocommerce'), 'WordPress fuzz runner must stay product-agnostic');
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wordpress-fuzz-runner-'));
+const workloadPath = path.join(tempDir, 'workload.json');
+fs.writeFileSync(workloadPath, `${JSON.stringify(workload)}\n`);
+
+const cli = spawnSync(process.execPath, [path.join(__dirname, '..', 'scripts', 'fuzz', 'fuzz-runner.cjs')], {
+	encoding: 'utf8',
+	env: {
+		...process.env,
+		HOMEBOY_FUZZ_WORKLOAD_PATH: workloadPath,
+		HOMEBOY_FUZZ_WORKLOAD_ID: 'cli-workload',
+		HOMEBOY_FUZZ_RUN_ID: 'cli-run',
+		HOMEBOY_FUZZ_SEED: 'cli-seed',
+		HOMEBOY_FUZZ_MAX_DURATION: '15',
+	},
+});
+
+assert.equal(cli.status, 0, cli.stderr);
+const cliResult = JSON.parse(cli.stdout);
+assert.equal(cliResult.schema, WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA);
+assert.equal(cliResult.run_id, 'cli-run');
+assert.equal(cliResult.wp_codebox_input.limits.max_duration_seconds, 15);
+
+console.log('WordPress fuzz runner smoke passed.');

--- a/wordpress/tests/wordpress-public-export-boundary.test.js
+++ b/wordpress/tests/wordpress-public-export-boundary.test.js
@@ -25,6 +25,7 @@ assert.equal(typeof wordpress.createWordPressHookFuzzPlan, 'function');
 assert.equal(typeof wordpress.normalizeWordPressSurfaceDiscovery, 'function');
 assert.equal(typeof wordpress.normalizeWordPressFuzzPlan, 'function');
 assert.equal(typeof wordpress.normalizeWordPressFuzzResult, 'function');
+assert.equal(typeof wordpress.buildWordPressFuzzRunnerResult, 'function');
 assert.equal(typeof wordpress.wpCodebox, 'object');
 assert.equal(typeof wordpress.wpCodebox.resolveWpCodeboxArtifactPath, 'function');
 assert.equal(typeof wordpress.wpCodebox.runWpCodeboxRecipe, 'function');

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -6,7 +6,7 @@
   "author": "Extra Chill",
   "provides": {
     "file_extensions": ["php", "css", "ts", "tsx", "js", "jsx", "json"],
-    "capabilities": ["fingerprint", "refactor", "crossref", "validate"]
+    "capabilities": ["fingerprint", "refactor", "crossref", "validate", "fuzz"]
   },
   "structured_sidecars": {
     "lint.findings": true,
@@ -822,6 +822,17 @@
         "legacy_field": "wp_codebox",
         "env_keys": ["HOMEBOY_WP_CODEBOX_BIN", "HOMEBOY_SETTINGS_WP_CODEBOX_BIN"]
       }
+    ]
+  },
+  "fuzz": {
+    "extension_script": "scripts/fuzz/fuzz-runner.cjs",
+    "capabilities": ["wordpress-fuzz-runner", "wp-codebox-fuzz-run", "wordpress-fuzz-coverage-aggregate"],
+    "env": [
+      "HOMEBOY_FUZZ_WORKLOAD_PATH",
+      "HOMEBOY_FUZZ_WORKLOAD_ID",
+      "HOMEBOY_FUZZ_RUN_ID",
+      "HOMEBOY_FUZZ_SEED",
+      "HOMEBOY_FUZZ_MAX_DURATION"
     ]
   },
   "testing": {


### PR DESCRIPTION
## Summary
- add a generic WordPress fuzz runner bridge that reads HOMEBOY_FUZZ_* env, loads the workload, and emits normalized JSON
- wire the WordPress extension manifest to advertise the fuzz capability/script
- add Node smoke coverage for the runner and public export boundary

## Testing
- npm run test:wordpress-fuzz-runner
- npm run test:wp-codebox-fuzz-run
- npm run test:wordpress-fuzz-schemas
- npm run test:wordpress-fuzz-coverage-aggregate
- npm run test:wordpress-public-export-boundary
- npm run test:wordpress-manifest-settings
- npx eslint lib/wordpress-fuzz-runner.js scripts/fuzz/fuzz-runner.cjs index.js
- node --check lib/wordpress-fuzz-runner.js && node --check scripts/fuzz/fuzz-runner.cjs && node --check tests/wordpress-fuzz-runner-smoke.js

## Notes
- Did not run benchmarks.
- Package-wide npm run lint:js still fails on existing unrelated lint issues outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the WordPress fuzz runner bridge, manifest wiring, and smoke tests.