### PR TITLE
Select runtime executors explicitly

### DIFF
--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -118,7 +118,7 @@ function resolveRuntimeProvider(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
 		setupCommands: normalizeCommands(materialization.setup_commands || []),
 		buildCommands: normalizeCommands(materialization.build_commands || []),
 		paths: resolvePaths(materialization.paths || {}, workspace),
-		executor: resolveExecutor(manifest, options.repoRoot || repoRootFromHere()),
+		executor: resolveExecutor(manifest, options.repoRoot || repoRootFromHere(), options),
 	};
 }
 
@@ -152,13 +152,153 @@ function resolvePaths(paths, workspace) {
 	]));
 }
 
-function resolveExecutor(manifest, repoRoot) {
-	const provider = Array.isArray(manifest.agent_task_executors) ? manifest.agent_task_executors[0] : null;
+function resolveExecutor(manifest, repoRoot, options = {}) {
+	const provider = selectExecutor(manifest, executorSelectionFromOptions(options));
 	const scriptArg = executorScriptArg(provider);
 	return {
+		id: provider.id || '',
 		backend: provider?.backend || '',
+		status: provider?.status || '',
+		capabilities: Array.isArray(provider?.capabilities) ? provider.capabilities : [],
 		path: scriptArg ? scriptArg.replace('{{runtime_path}}', path.join(repoRoot, 'agent-runtimes', manifest.id)) : '',
 	};
+}
+
+function executorSelectionFromOptions(options = {}) {
+	const env = options.env || process.env;
+	const executor = objectOption(options.executor) || objectOption(options.executorSelection) || {};
+	return {
+		id: firstString(
+			executor.id,
+			executor.executor_id,
+			options.executorId,
+			options.executor_id,
+			env.EXECUTOR_ID,
+			env.AGENT_TASK_EXECUTOR_ID
+		),
+		backend: firstString(
+			executor.backend,
+			options.executorBackend,
+			options.executor_backend,
+			env.EXECUTOR_BACKEND,
+			env.AGENT_TASK_EXECUTOR_BACKEND
+		),
+		capabilities: normalizeCapabilities(
+			executor.capabilities,
+			executor.capability,
+			options.executorCapabilities,
+			options.executor_capabilities,
+			options.executorCapability,
+			options.executor_capability,
+			env.EXECUTOR_CAPABILITIES,
+			env.EXECUTOR_CAPABILITY,
+			env.AGENT_TASK_EXECUTOR_CAPABILITIES,
+			env.AGENT_TASK_EXECUTOR_CAPABILITY
+		),
+		status: firstString(
+			executor.status,
+			options.executorStatus,
+			options.executor_status,
+			env.EXECUTOR_STATUS,
+			env.AGENT_TASK_EXECUTOR_STATUS
+		),
+	};
+}
+
+function objectOption(value) {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
+}
+
+function firstString(...values) {
+	for (const value of values) {
+		if (typeof value === 'string' && value.trim() !== '') {
+			return value.trim();
+		}
+	}
+	return '';
+}
+
+function normalizeCapabilities(...values) {
+	const capabilities = [];
+	for (const value of values) {
+		if (Array.isArray(value)) {
+			capabilities.push(...value.filter((entry) => typeof entry === 'string'));
+			continue;
+		}
+		if (typeof value === 'string' && value.trim() !== '') {
+			capabilities.push(...value.split(',').map((entry) => entry.trim()).filter(Boolean));
+		}
+	}
+	return [...new Set(capabilities)];
+}
+
+function selectExecutor(manifest, selection) {
+	const providers = Array.isArray(manifest.agent_task_executors)
+		? manifest.agent_task_executors.filter((provider) => provider && typeof provider === 'object' && !Array.isArray(provider))
+		: [];
+	if (providers.length === 0) {
+		throw new Error(`Runtime ${manifest.id} does not declare any agent_task_executors.`);
+	}
+
+	const requestedStatus = selection.status || 'active';
+	const candidates = providers.filter((provider) => {
+		if (selection.id && provider.id !== selection.id) {
+			return false;
+		}
+		if (selection.backend && provider.backend !== selection.backend) {
+			return false;
+		}
+		if (requestedStatus && !executorStatusMatches(provider, requestedStatus)) {
+			return false;
+		}
+		if (!selection.capabilities.every((capability) => Array.isArray(provider.capabilities) && provider.capabilities.includes(capability))) {
+			return false;
+		}
+		return true;
+	});
+
+	if (candidates.length === 1) {
+		return candidates[0];
+	}
+
+	const criteria = executorSelectionDescription({ ...selection, status: requestedStatus });
+	if (candidates.length === 0) {
+		throw new Error(`No agent_task_executors for runtime ${manifest.id} match ${criteria}. Available executors: ${executorList(providers)}.`);
+	}
+	throw new Error(`Ambiguous agent_task_executors for runtime ${manifest.id} match ${criteria}: ${executorList(candidates)}. Select executor.id, backend, capability, or status explicitly.`);
+}
+
+function executorStatusMatches(provider, requestedStatus) {
+	if (requestedStatus === 'active' && !provider.status) {
+		return true;
+	}
+	return provider.status === requestedStatus;
+}
+
+function executorSelectionDescription(selection) {
+	const parts = [];
+	if (selection.id) {
+		parts.push(`id=${selection.id}`);
+	}
+	if (selection.backend) {
+		parts.push(`backend=${selection.backend}`);
+	}
+	if (selection.capabilities.length > 0) {
+		parts.push(`capabilities=${selection.capabilities.join(',')}`);
+	}
+	if (selection.status) {
+		parts.push(`status=${selection.status}`);
+	}
+	return parts.join(' ') || 'the default active executor selection';
+}
+
+function executorList(providers) {
+	return providers.map((provider) => {
+		const id = provider.id || '(missing id)';
+		const backend = provider.backend || '(missing backend)';
+		const status = provider.status || '(no status)';
+		return `${id} [backend=${backend}, status=${status}]`;
+	}).join(', ');
 }
 
 function executorScriptArg(provider) {

--- a/runtime-agent-ci/scripts/run-agent-loop.cjs
+++ b/runtime-agent-ci/scripts/run-agent-loop.cjs
@@ -16,6 +16,7 @@ try {
   const runtime = resolveRuntimeProvider(plan.runtime_id || process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || 'wp-codebox', {
     repoRoot,
     workspace: plan.component_path || process.cwd(),
+    executor: plan.executor || {},
   });
   const result = runGenericAgentLoop({
     plan,

--- a/tests/runtime-provider-resolver-smoke.mjs
+++ b/tests/runtime-provider-resolver-smoke.mjs
@@ -33,6 +33,7 @@ assert.deepEqual(runtime.setupCommands, [{ command: 'npm', args: ['install'], cw
 assert.deepEqual(runtime.buildCommands, [{ command: 'npm', args: ['run', 'build'], cwd: '.ci/wp-codebox' }]);
 assert.equal(runtime.paths.runtime_bin, path.join(workspace, '.ci/wp-codebox/packages/cli/dist/index.js'));
 assert.equal(runtime.paths.runtime_component, path.join(workspace, '.ci/wp-codebox/packages/wordpress-plugin'));
+assert.equal(runtime.executor.id, 'wordpress.codebox-agent-task-executor');
 assert.equal(runtime.executor.backend, 'codebox');
 assert.equal(runtime.executor.path, path.join(rootDir, 'agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs'));
 
@@ -47,9 +48,78 @@ assert.equal(opencodeRuntime.executor.path, path.join(rootDir, 'agent-runtimes/o
 assert.equal(opencodeRuntime.manifest.agent_task_executors[0].status, 'active');
 assert.equal(opencodeRuntime.manifest.agent_task_executors[0].capabilities.includes('nested_orchestrator'), true);
 
+const multiRegistry = {
+	'multi-executor': {
+		schema: 'homeboy/agent-runtime-manifest/v1',
+		id: 'multi-executor',
+		agent_task_executors: [
+			executorFixture('runtime.alpha', 'runner', 'active', ['repo_workspace', 'patch_artifacts']),
+			executorFixture('runtime.beta', 'runner', 'active', ['repo_workspace', 'browser_runtime']),
+			executorFixture('runtime.gamma', 'shell', 'active', ['repo_workspace']),
+			executorFixture('runtime.retired', 'runner', 'disabled', ['repo_workspace']),
+		],
+	},
+};
+
+const explicitRuntime = resolveRuntimeProvider('multi-executor', {
+	repoRoot: rootDir,
+	registry: multiRegistry,
+	executor: { id: 'runtime.beta' },
+});
+assert.equal(explicitRuntime.executor.id, 'runtime.beta');
+assert.equal(explicitRuntime.executor.backend, 'runner');
+
+const backendRuntime = resolveRuntimeProvider('multi-executor', {
+	repoRoot: rootDir,
+	registry: multiRegistry,
+	executor: { backend: 'shell' },
+});
+assert.equal(backendRuntime.executor.id, 'runtime.gamma');
+
+const capabilityRuntime = resolveRuntimeProvider('multi-executor', {
+	repoRoot: rootDir,
+	registry: multiRegistry,
+	executor: { backend: 'runner', capability: 'browser_runtime' },
+});
+assert.equal(capabilityRuntime.executor.id, 'runtime.beta');
+
+const disabledRuntime = resolveRuntimeProvider('multi-executor', {
+	repoRoot: rootDir,
+	registry: multiRegistry,
+	executor: { backend: 'runner', status: 'disabled' },
+});
+assert.equal(disabledRuntime.executor.id, 'runtime.retired');
+
+assert.throws(
+	() => resolveRuntimeProvider('multi-executor', { repoRoot: rootDir, registry: multiRegistry }),
+	/Ambiguous agent_task_executors for runtime multi-executor match status=active: runtime\.alpha .*runtime\.beta/
+);
+
+assert.throws(
+	() => resolveRuntimeProvider('multi-executor', {
+		repoRoot: rootDir,
+		registry: multiRegistry,
+		executor: { id: 'runtime.retired' },
+	}),
+	/No agent_task_executors for runtime multi-executor match id=runtime\.retired status=active\./
+);
+
 assert.throws(
 	() => resolveRuntimeProvider('missing-runtime', { repoRoot: rootDir, workspace }),
 	/Unsupported agent_runtime: missing-runtime\./
 );
 
 console.log('runtime provider resolver smoke passed');
+
+function executorFixture(id, backend, status, capabilities) {
+	return {
+		schema: 'homeboy/agent-task-executor-provider/v1',
+		id,
+		backend,
+		status,
+		capabilities,
+		invocation: {
+			argv: ['node', `{{runtime_path}}/scripts/${id}.cjs`],
+		},
+	};
+}

--- a/wordpress/scripts/agent/run-runtime-agent-task.cjs
+++ b/wordpress/scripts/agent/run-runtime-agent-task.cjs
@@ -37,7 +37,7 @@ function readJson(filePath) {
 try {
   const configPath = readConfigPath();
   const config = readJson(configPath);
-  const runtime = resolveRuntimeProvider(config.runtime_id || process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || 'wp-codebox', { repoRoot: REPO_ROOT, workspace: config.component_path || process.cwd() });
+  const runtime = resolveRuntimeProvider(config.runtime_id || process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || 'wp-codebox', { repoRoot: REPO_ROOT, workspace: config.component_path || process.cwd(), executor: config.executor || {} });
   const result = runGenericAgentLoop({
     plan: config,
     runtime,


### PR DESCRIPTION
## Summary
- Resolve runtime agent task executors by explicit executor id, backend, capabilities, and status instead of taking agent_task_executors[0].
- Default executor status selection to active-compatible providers and fail clearly when matching is empty or ambiguous.
- Pass runtime-agnostic executor config from agent task plans into runtime resolution while keeping existing wp-codebox runtime defaults at legacy caller boundaries.
- Add multi-executor fixture coverage for explicit id, backend, capability, status, ambiguity, and inactive-default behavior.

## Tests
- node tests/runtime-provider-resolver-smoke.mjs
- node tests/agent-runtime-package-surface-smoke.mjs
- node tests/agent-task-provider-contract-smoke.mjs (fails on existing request shape expectation for artifact_declarations and limits.timeout_ms outside this resolver change)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing resolver selection logic, adding fixture tests, running verification, and drafting this PR description.
