### PR TITLE
Render generic runtime workflow inputs

### DIFF
--- a/.github/actions/render-runtime-workflow-inputs/action.yml
+++ b/.github/actions/render-runtime-workflow-inputs/action.yml
@@ -1,0 +1,41 @@
+name: Render Runtime Workflow Inputs
+description: Render generic runtime/profile/tool-profile inputs into selected-runtime workflow inputs.
+inputs:
+  runtime:
+    description: Agent runtime id.
+    required: true
+  runtime_profile:
+    description: Runtime profile id or JSON runtime profile object.
+    required: true
+  runtime_profiles:
+    description: JSON object keyed by runtime profile id.
+    required: false
+    default: '{}'
+  tool_profile:
+    description: JSON generic runtime tool profile.
+    required: false
+    default: '{}'
+outputs:
+  runtime:
+    description: Rendered runtime id.
+    value: ${{ steps.render.outputs.runtime }}
+  profile:
+    description: Rendered runtime profile id.
+    value: ${{ steps.render.outputs.profile }}
+  runtime_profiles:
+    description: Rendered runtime profile JSON object.
+    value: ${{ steps.render.outputs.runtime_profiles }}
+  workflow_inputs:
+    description: Full rendered workflow input JSON object.
+    value: ${{ steps.render.outputs.workflow_inputs }}
+runs:
+  using: composite
+  steps:
+    - id: render
+      shell: bash
+      env:
+        RUNTIME: ${{ inputs.runtime }}
+        RUNTIME_PROFILE: ${{ inputs.runtime_profile }}
+        RUNTIME_PROFILES: ${{ inputs.runtime_profiles }}
+        TOOL_PROFILE: ${{ inputs.tool_profile }}
+      run: node "$GITHUB_ACTION_PATH/../../scripts/runtime-agent-full-run/render-runtime-workflow-inputs.cjs"

--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -22,6 +22,9 @@ const {
   runtimeAgentCiFirstNonEmptyObject,
   runtimeAgentCiTaskFromRequest,
 } = require('../../../runtime-agent-ci');
+const {
+  renderRuntimeWorkflowInputs,
+} = require('../../../runtime-agent-ci/lib/runtime-workflow-inputs.cjs');
 
 function main() {
   const config = buildConfig(process.env);
@@ -65,7 +68,7 @@ function buildConfig(env) {
   const runtimeTask = runtimeTaskFromEnv(env);
   const runtimeExecution = parseJsonInput('runtime_execution', env.RUNTIME_EXECUTION || '{}', 'object', {});
   const workload = codeboxWorkloadFromEnv(env, workloadId);
-  const toolPolicy = parseJsonInput('tool_policy', env.TOOL_POLICY || '{}', 'object', {});
+  const toolProfile = parseJsonInput('tool_profile', env.TOOL_PROFILE || env.TOOL_POLICY || '{}', 'object', {});
   const runtimeOutputProjections = runtimeAgentCiFirstNonEmptyObject(
     parseJsonInput('runtime_output_projections', env.RUNTIME_OUTPUT_PROJECTIONS || '{}', 'object', {}),
     parseJsonInput('engine_data_outputs', env.ENGINE_DATA_OUTPUTS || '{}', 'object', {})
@@ -80,19 +83,19 @@ function buildConfig(env) {
   const runtimeEnv = parseJsonInput('runtime_env', env.RUNTIME_ENV || '{}', 'object', {});
   const runtimeConfig = parseJsonInput('runtime_config', env.RUNTIME_CONFIG || '{}', 'object', {});
   const providerPluginPaths = validationDependencies.providerPluginHostPath ? [validationDependencies.providerPluginHostPath] : [];
-  const resolvedRuntimeProfile = runtimeProfiles[runtimeProfile] || {};
-  const effectiveRuntimeProfile = runtimeProfilePayload(runtime, {
-    id: runtimeProfile,
-    profile: resolvedRuntimeProfile,
+  const renderedRuntimeInputs = renderRuntimeWorkflowInputs({
+    runtimeProviderConfig: runtime,
+    runtime,
+    runtime_profile: runtimeProfile,
+    runtime_profiles: runtimeProfiles,
+    tool_profile: toolProfile,
     componentContracts,
     runtimeOverlays,
     runtimeEnv,
     providerPluginPaths,
   });
-  const effectiveRuntimeProfiles = {
-    ...runtimeProfiles,
-    [runtimeProfile]: effectiveRuntimeProfile,
-  };
+  const effectiveRuntimeProfile = renderedRuntimeInputs.runtime_requirements;
+  const effectiveRuntimeProfiles = renderedRuntimeInputs.runtime_profiles;
   const runnerWorkspace = parseJsonInput('runner_workspace', env.RUNNER_WORKSPACE_CONFIG || '{}', 'object', {});
   const runnerWorkspaceRepo = targetRepo.split('/')[1].replace(/\.git$/, '');
   const runnerWorkspaceGuestCheckout = `/workspace/${runnerWorkspaceRepo}`;
@@ -166,7 +169,7 @@ function buildConfig(env) {
     time_budget_ms: Number(env.TIME_BUDGET_MS || 600000),
     expected_artifacts: parseJsonInput('expected_artifacts', env.EXPECTED_ARTIFACTS || '[]', 'array', []),
     artifact_declarations: artifactDeclarationsFromEnv(env, runtime),
-    sandbox_tool_policy: isCodeboxRuntime(runtime) && Object.keys(toolPolicy).length > 0 ? toolPolicy : undefined,
+    sandbox_tool_policy: renderedRuntimeInputs.workflow_inputs.sandbox_tool_policy,
     output_mappings: parseJsonInput('output_mappings', env.OUTPUT_MAPPINGS || '{}', 'object', {}),
     runtime_output_projections: runtimeOutputProjections,
     component_contracts: componentContracts,
@@ -258,14 +261,6 @@ function runtimeTaskFromEnv(env) {
 
 function isCodeboxRuntime(runtime) {
   return runtime?.id === 'wp-codebox' || runtime?.executor?.backend === 'codebox';
-}
-
-function runtimeProfilePayload(runtime, options) {
-  if (!isCodeboxRuntime(runtime)) {
-    return options.profile;
-  }
-  const { codeboxRuntimeProfilePayload } = require('../../../agent-runtimes/wp-codebox/lib/codebox-runtime-profile');
-  return codeboxRuntimeProfilePayload(options);
 }
 
 function runtimePathRequired(runtime, pathName) {

--- a/.github/scripts/runtime-agent-full-run/render-runtime-workflow-inputs.cjs
+++ b/.github/scripts/runtime-agent-full-run/render-runtime-workflow-inputs.cjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+'use strict';
+
+const {
+	parseJsonInput,
+	writeGithubOutput,
+} = require('./lib/common.cjs');
+const {
+	renderRuntimeWorkflowInputs,
+} = require('../../../runtime-agent-ci/lib/runtime-workflow-inputs.cjs');
+
+function main() {
+	const rendered = renderRuntimeWorkflowInputs({
+		runtime: process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND,
+		runtime_profile: parseRuntimeProfile(process.env.RUNTIME_PROFILE || process.env.PROFILE || ''),
+		runtime_profiles: parseJsonInput('runtime_profiles', process.env.RUNTIME_PROFILES || '{}', 'object', {}),
+		tool_profile: parseJsonInput('tool_profile', process.env.TOOL_PROFILE || process.env.TOOL_POLICY || '{}', 'object', {}),
+	});
+	writeGithubOutput({
+		runtime: rendered.workflow_inputs.runtime || rendered.runtime_id,
+		profile: rendered.workflow_inputs.profile || rendered.runtime_profile,
+		runtime_profiles: JSON.stringify(rendered.workflow_inputs.runtime_profiles || rendered.runtime_profiles),
+		workflow_inputs: JSON.stringify(rendered.workflow_inputs),
+	});
+	process.stdout.write(`${JSON.stringify(rendered, null, 2)}\n`);
+}
+
+function parseRuntimeProfile(value) {
+	const raw = String(value || '').trim();
+	if (raw.startsWith('{')) {
+		return JSON.parse(raw);
+	}
+	return raw;
+}
+
+if (require.main === module) {
+	try {
+		main();
+	} catch (error) {
+		process.stderr.write(`${error.message}\n`);
+		process.exit(1);
+	}
+}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -113,6 +113,12 @@ values. It also exposes `auth_mode`, which is `homeboy_app_token` when the
 workflow generated and used a Homeboy GitHub App installation token, or
 `github_token_fallback` when it used the repository-scoped GitHub Actions token.
 
+Callers that compose workflow inputs before invoking `runtime-agent-full-run.yml`
+can use `.github/actions/render-runtime-workflow-inputs`. The action accepts only
+`runtime`, `runtime_profile`, `runtime_profiles`, and `tool_profile`, then emits
+selected-runtime workflow input JSON without exposing WP Codebox ability names,
+CLI paths, schemas, or mount targets to the downstream workflow.
+
 ## GitHub auth modes
 
 The workflow keeps two GitHub authentication modes:
@@ -188,8 +194,9 @@ jobs:
 - `runtime_output_projections` maps named outputs to dotted paths in the provider runtime result.
 - Generic `runtime-agent-full-run.yml` callers can use `runtime_execution` for ability, bundle, or workflow descriptors and pass `runtime_output_projections` / `evidence_projections` through to the selected runtime config. Bundle/package descriptors derive the runtime task ability from the selected runtime profile, so callers do not need to provide `runtime_task.ability` for generic package runs.
 - `component_contracts` forwards explicit runtime component/plugin contracts to WP Codebox through the `wp-codebox/runtime-profile/v1` payload. Use it for caller-owned fixture ability providers or runtime components that are not part of the selected runtime profile.
-- Generic WP Codebox executor paths accept caller-supplied component contracts, runtime overlays, mounts, task payload, provider defaults, and declarative runtime requirements. Domain policy belongs in caller inputs and runtime profiles, not in the generic WP Codebox provider manifest.
+- Generic WP Codebox executor paths accept caller-supplied component contracts, runtime overlays, mounts, task payload, provider defaults, tool profiles, and declarative runtime requirements through the generic runtime workflow input renderer. Domain policy belongs in caller inputs and runtime profiles, not in the generic WP Codebox provider manifest.
 - `runtime_dependencies` checks out the explicit runtime component stack and forwards those paths to WP Codebox as runtime component requirements.
+- `tool_profile` is the runtime-neutral tool policy input. The selected runtime adapter maps it into runtime-owned workflow fields; for WP Codebox that becomes the sandbox tool policy. `tool_policy` remains accepted as a compatibility alias.
 - `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `provider_secret_env` keys. When `provider: openai`, an empty object preserves the existing OpenAI provider defaults. The legacy `credentials` key is still accepted by the normalizer as an input alias, but generated config uses `provider_secret_env_mapping`.
 - `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.
 - Bundle sources in `runtime_execution` are resolved relative to the consumer checkout unless the caller materializes external bundle sources through dependencies or validation checkouts.

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -104,7 +104,11 @@ name: Runtime Agent Full Run (reusable)
         type: string
         default: '{}'
       tool_policy:
-        description: JSON Codebox sandbox tool-policy DTO forwarded to the runtime config.
+        description: Compatibility alias for tool_profile.
+        type: string
+        default: '{}'
+      tool_profile:
+        description: JSON generic runtime tool profile forwarded through the selected runtime adapter.
         type: string
         default: '{}'
       ability_request:
@@ -511,6 +515,7 @@ jobs:
           RUNTIME_EXECUTION: ${{ inputs.runtime_execution }}
           WORKLOAD: ${{ inputs.workload }}
           TOOL_POLICY: ${{ inputs.tool_policy }}
+          TOOL_PROFILE: ${{ inputs.tool_profile }}
           ABILITY_REQUEST: ${{ inputs.ability_request }}
           ABILITY_INPUT: ${{ inputs.ability_input }}
           OUTPUT_MAPPINGS: ${{ inputs.output_mappings }}

--- a/runtime-agent-ci/index.js
+++ b/runtime-agent-ci/index.js
@@ -5,3 +5,4 @@ Object.assign(module.exports, require('./lib/generic-agent-loop-runner'));
 Object.assign(module.exports, require('./lib/deterministic-loop-runner'));
 Object.assign(module.exports, require('./lib/fanout-reconcile-runner'));
 Object.assign(module.exports, require('./lib/generic-fanout-reconcile-workflow'));
+Object.assign(module.exports, require('./lib/runtime-workflow-inputs.cjs'));

--- a/runtime-agent-ci/lib/runtime-workflow-inputs.cjs
+++ b/runtime-agent-ci/lib/runtime-workflow-inputs.cjs
@@ -1,0 +1,144 @@
+'use strict';
+
+const { normalizeRuntimeId, resolveRuntimeProvider } = require('./runtime-provider-resolver.cjs');
+
+const RUNTIME_WORKFLOW_INPUTS_SCHEMA = 'homeboy/runtime-workflow-inputs/v1';
+
+function renderRuntimeWorkflowInputs(options = {}) {
+	const runtimeInput = options.runtimeId || options.runtime_id || options.runtimeProviderConfig?.id || options.runtime_provider_config?.id || options.runtime?.id || options.runtime || options.runtimeProvider || options.runtime_provider;
+	const runtimeId = normalizeRuntimeId(runtimeInput);
+	const runtime = options.runtimeProviderConfig || options.runtime_provider_config || resolveRuntimeProvider(runtimeId, options);
+	const profileSelection = normalizeRuntimeProfileSelection(options.runtimeProfile || options.runtime_profile || options.profile);
+	const runtimeProfiles = plainObject(options.runtimeProfiles || options.runtime_profiles);
+	const selectedProfile = selectedRuntimeProfile(profileSelection, runtimeProfiles);
+	const toolProfile = plainObject(options.toolProfile || options.tool_profile || options.sandboxToolPolicy || options.sandbox_tool_policy || options.toolPolicy || options.tool_policy);
+	const adapter = runtimeWorkflowInputAdapter(runtime);
+	const rendered = adapter({
+		...options,
+		runtime,
+		runtimeId,
+		profileId: profileSelection.id,
+		profile: selectedProfile,
+		runtimeProfiles,
+		toolProfile,
+	});
+
+	return stripUndefined({
+		schema: RUNTIME_WORKFLOW_INPUTS_SCHEMA,
+		runtime_id: runtime.id || runtimeId,
+		runtime_profile: profileSelection.id,
+		runtime_profiles: {
+			...runtimeProfiles,
+			[profileSelection.id]: rendered.runtime_requirements || selectedProfile,
+		},
+		runtime_requirements: rendered.runtime_requirements || selectedProfile,
+		tool_profile: Object.keys(toolProfile).length > 0 ? toolProfile : undefined,
+		workflow_inputs: stripUndefined(rendered.workflow_inputs || {}),
+	});
+}
+
+function runtimeWorkflowInputAdapter(runtime) {
+	if (isCodeboxRuntime(runtime)) {
+		return renderCodeboxWorkflowInputs;
+	}
+	return renderDefaultWorkflowInputs;
+}
+
+function renderDefaultWorkflowInputs({ runtime, profileId, profile, runtimeProfiles }) {
+	const effectiveRuntimeProfiles = {
+		...runtimeProfiles,
+		[profileId]: profile,
+	};
+	return {
+		runtime_requirements: profile,
+		workflow_inputs: {
+			runtime: runtime.id,
+			profile: profileId,
+			runtime_profiles: effectiveRuntimeProfiles,
+		},
+	};
+}
+
+function renderCodeboxWorkflowInputs({
+	profileId,
+	profile,
+	runtimeProfiles,
+	toolProfile,
+	componentContracts,
+	component_contracts,
+	runtimeOverlays,
+	runtime_overlays,
+	runtimeEnv,
+	runtime_env,
+	providerPluginPaths,
+	provider_plugin_paths,
+	runtimeStateMounts,
+	runtime_state_mounts,
+	runtimeConfigMounts,
+	runtime_config_mounts,
+}) {
+	const { codeboxRuntimeProfilePayload } = require('../../agent-runtimes/wp-codebox/lib/codebox-runtime-profile');
+	const runtimeRequirements = codeboxRuntimeProfilePayload({
+		id: profileId,
+		profile,
+		componentContracts: componentContracts || component_contracts || [],
+		runtimeOverlays: runtimeOverlays || runtime_overlays || [],
+		runtimeEnv: runtimeEnv || runtime_env || {},
+		providerPluginPaths: providerPluginPaths || provider_plugin_paths || [],
+		runtimeStateMounts: runtimeStateMounts || runtime_state_mounts,
+		runtimeConfigMounts: runtimeConfigMounts || runtime_config_mounts,
+	});
+
+	return {
+		runtime_requirements: runtimeRequirements,
+		workflow_inputs: stripUndefined({
+			runtime: 'wp-codebox',
+			profile: profileId,
+			runtime_profiles: {
+				...runtimeProfiles,
+				[profileId]: runtimeRequirements,
+			},
+			sandbox_tool_policy: Object.keys(toolProfile).length > 0 ? toolProfile : undefined,
+		}),
+	};
+}
+
+function normalizeRuntimeProfileSelection(value) {
+	if (typeof value === 'string' && value.trim() !== '') {
+		return { id: value, profile: null };
+	}
+	if (value && typeof value === 'object' && !Array.isArray(value)) {
+		const id = value.id || value.name || value.slug;
+		if (typeof id !== 'string' || id.trim() === '') {
+			throw new Error('runtime_profile object requires an id.');
+		}
+		return { id, profile: value };
+	}
+	throw new Error('runtime_profile is required.');
+}
+
+function selectedRuntimeProfile(selection, runtimeProfiles) {
+	const profile = selection.profile || runtimeProfiles[selection.id] || {};
+	if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+		throw new Error(`runtime profile ${selection.id} must be an object.`);
+	}
+	return { ...profile, id: profile.id || selection.id };
+}
+
+function isCodeboxRuntime(runtime) {
+	return runtime?.id === 'wp-codebox' || runtime?.executor?.backend === 'codebox';
+}
+
+function plainObject(value) {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function stripUndefined(value) {
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+module.exports = {
+	RUNTIME_WORKFLOW_INPUTS_SCHEMA,
+	renderRuntimeWorkflowInputs,
+	runtimeWorkflowInputAdapter,
+};

--- a/tests/runtime-agent-full-run-codebox-inputs-smoke.mjs
+++ b/tests/runtime-agent-full-run-codebox-inputs-smoke.mjs
@@ -34,8 +34,8 @@ const config = buildConfig({
     id: 'codebox-workload',
     label: 'Codebox workload',
   }),
-  TOOL_POLICY: JSON.stringify({
-    schema: 'wp-codebox/tool-policy/v1',
+  TOOL_PROFILE: JSON.stringify({
+    schema: 'homeboy/runtime-tool-profile/v1',
     tools: { workspace_read: true },
   }),
   ARTIFACT_DECLARATIONS: JSON.stringify([
@@ -52,7 +52,7 @@ assert.deepEqual(config.workload, {
   label: 'Codebox workload',
 });
 assert.deepEqual(config.sandbox_tool_policy, {
-  schema: 'wp-codebox/tool-policy/v1',
+  schema: 'homeboy/runtime-tool-profile/v1',
   tools: { workspace_read: true },
 });
 assert.deepEqual(config.artifact_declarations, [
@@ -68,5 +68,22 @@ assert.deepEqual(config.artifact_declarations, [
     required: true,
   },
 ]);
+
+const legacyToolPolicyConfig = buildConfig({
+  GITHUB_WORKSPACE: workspace,
+  RUNNER_TEMP: runnerTemp,
+  WORKLOAD_ID: 'legacy-tool-policy',
+  TARGET_REPO: 'Extra-Chill/example',
+  RUNTIME: 'wp-codebox',
+  PROFILE: 'codebox-profile',
+  RUNTIME_PROFILES: JSON.stringify({
+    'codebox-profile': {
+      schema: 'wp-codebox/runtime-profile/v1',
+      id: 'codebox-profile',
+    },
+  }),
+  TOOL_POLICY: JSON.stringify({ tools: { workspace_write: false } }),
+});
+assert.deepEqual(legacyToolPolicyConfig.sandbox_tool_policy, { tools: { workspace_write: false } });
 
 console.log('runtime agent full-run Codebox inputs smoke passed');

--- a/tests/runtime-workflow-input-renderer-smoke.mjs
+++ b/tests/runtime-workflow-input-renderer-smoke.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+	renderRuntimeWorkflowInputs,
+} = require(path.join(rootDir, 'runtime-agent-ci', 'lib', 'runtime-workflow-inputs.cjs'));
+
+const rendered = renderRuntimeWorkflowInputs({
+	runtime: 'codebox',
+	runtime_profile: 'example-runtime',
+	runtime_profiles: {
+		'example-runtime': {
+			schema: 'homeboy/runtime-profile/v1',
+			id: 'example-runtime',
+			plugins: [
+				{ slug: 'example-provider', source: '.ci/example-provider', activate: true },
+			],
+		},
+	},
+	tool_profile: {
+		schema: 'homeboy/runtime-tool-profile/v1',
+		tools: { workspace_read: true },
+	},
+	runtimeProviderConfig: {
+		id: 'wp-codebox',
+		executor: { backend: 'codebox' },
+	},
+});
+
+assert.equal(rendered.schema, 'homeboy/runtime-workflow-inputs/v1');
+assert.equal(rendered.runtime_id, 'wp-codebox');
+assert.equal(rendered.runtime_profile, 'example-runtime');
+assert.equal(rendered.runtime_requirements.schema, 'wp-codebox/runtime-profile/v1');
+assert.equal(rendered.runtime_requirements.id, 'example-runtime');
+assert.equal(rendered.runtime_requirements.homeboy_profile_schema, 'homeboy/runtime-profile/v1');
+assert.deepEqual(rendered.runtime_requirements.component_contracts.map((contract) => ({
+	slug: contract.slug,
+	path: contract.path,
+	loadAs: contract.loadAs,
+	activate: contract.activate,
+})), [
+	{ slug: 'example-provider', path: '.ci/example-provider', loadAs: 'plugin', activate: true },
+]);
+assert.equal(rendered.workflow_inputs.runtime, 'wp-codebox');
+assert.equal(rendered.workflow_inputs.profile, 'example-runtime');
+assert.deepEqual(rendered.workflow_inputs.sandbox_tool_policy, {
+	schema: 'homeboy/runtime-tool-profile/v1',
+	tools: { workspace_read: true },
+});
+assert.equal(rendered.workflow_inputs.runtime_profiles['example-runtime'].schema, 'wp-codebox/runtime-profile/v1');
+
+const defaultRendered = renderRuntimeWorkflowInputs({
+	runtime: 'example-runtime',
+	runtime_profile: { id: 'example-profile', custom: true },
+	runtimeProviderConfig: {
+		id: 'example-runtime',
+		executor: { backend: 'example-runtime' },
+	},
+});
+assert.deepEqual(defaultRendered.workflow_inputs, {
+	runtime: 'example-runtime',
+	profile: 'example-profile',
+	runtime_profiles: {
+		'example-profile': { id: 'example-profile', custom: true },
+	},
+});
+assert.deepEqual(defaultRendered.runtime_requirements, { id: 'example-profile', custom: true });
+
+console.log('runtime workflow input renderer smoke passed');


### PR DESCRIPTION
## Summary
- Add a generic `runtime-agent-ci` workflow input renderer that accepts runtime id, runtime profile, and tool profile inputs.
- Add a composite action and CLI wrapper for downstream workflow callers.
- Route `runtime-agent-full-run.yml` config generation through the generic renderer, with WP Codebox profile support as the adapter and `tool_policy` preserved as a compatibility alias.
- Add smoke tests for the renderer, Codebox adapter mapping, config builder integration, and legacy alias behavior.

## Tests
- `node tests/runtime-workflow-input-renderer-smoke.mjs`
- `node tests/runtime-agent-full-run-codebox-inputs-smoke.mjs`
- `node tests/wp-codebox-runtime-profile-defaults-smoke.mjs`
- `RUNTIME=codebox RUNTIME_PROFILE=example RUNTIME_PROFILES='{"example":{"id":"example"}}' TOOL_PROFILE='{"tools":{"workspace_read":true}}' node .github/scripts/runtime-agent-full-run/render-runtime-workflow-inputs.cjs`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** openai/gpt-5.5 via OpenCode\n- **Used for:** Implementing the generic runtime workflow input renderer/action/API, adapting the existing WP Codebox profile path, adding tests, and preparing this PR.