### PR TITLE
Resolve WordPress dependency objects before preflight

### DIFF
--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -619,7 +619,7 @@ homeboy_preflight_declared_validation_dependency_paths() {
     while IFS= read -r dependency; do
         [ -n "$dependency" ] || continue
         if _homeboy_validation_dependency_entry_is_object "$dependency"; then
-            dependency=$(_homeboy_validation_dependency_entry_token "$dependency" || true)
+            dependency=$(_homeboy_resolve_validation_dependency_entry_path "$dependency" || true)
             [ -n "$dependency" ] || continue
         fi
         case "$dependency" in

--- a/wordpress/tests/dependency-plugin-preflight-smoke.sh
+++ b/wordpress/tests/dependency-plugin-preflight-smoke.sh
@@ -146,6 +146,17 @@ if [ "$MONOREPO_RESOLVED" != "${MONOREPO_DEP}/php-transformer" ]; then
     exit 1
 fi
 
+HOMEBOY_SETTINGS_JSON=$(jq -nc --arg source "$MONOREPO_DEP" '{validation_dependencies: [{source: $source, plugin_slug: "blocks-engine-php-transformer", package_path: "php-transformer"}]}')
+export HOMEBOY_SETTINGS_JSON
+MONOREPO_PREFLIGHT_ARTIFACTS="${TMP_ROOT}/monorepo-object-preflight-artifacts"
+homeboy_preflight_declared_validation_dependency_paths "${MONOREPO_PREFLIGHT_ARTIFACTS}" "bench"
+if [ -f "${MONOREPO_PREFLIGHT_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" ]; then
+    echo "ERROR: object dependency preflight should resolve package_path before path validation." >&2
+    jq '.' "${MONOREPO_PREFLIGHT_ARTIFACTS}/wordpress-dependency-plugin-preflight-diagnostics.json" >&2 || true
+    exit 1
+fi
+unset HOMEBOY_SETTINGS_JSON
+
 SANITIZE_KEY_DEP="${TMP_ROOT}/sanitize-key-plugin"
 mkdir -p "$SANITIZE_KEY_DEP"
 cat > "${SANITIZE_KEY_DEP}/sanitize-key-plugin.php" <<'PHP'


### PR DESCRIPTION
## Summary
- Resolve validation dependency objects before declared-path preflight checks.
- Preserve package_path/subdir resolution for object dependencies before testing filesystem existence.
- Extend dependency preflight smoke coverage for monorepo package-path objects.

## Verification
- bash wordpress/tests/dependency-plugin-preflight-smoke.sh
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 and OpenCode
- **Used for:** Fixing the dependency object preflight path and smoke coverage.