### PR TITLE
Centralize WP Codebox artifact discovery behind artifact contract

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const fs = require('node:fs');
+const path = require('node:path');
+
 const TYPED_ARTIFACT_SCHEMA = 'homeboy/agent-task-typed-artifact/v1';
 const WP_CODEBOX_ARTIFACT_DECLARATION_SCHEMA = 'wp-codebox/artifact-declaration/v1';
 const WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA = 'wp-codebox/artifact-result-envelope/v1';
@@ -501,6 +504,145 @@ function artifactPath(root, relativePath) {
   return `${String(root).replace(/\/$/, '')}/${String(relativePath).replace(/^\//, '')}`;
 }
 
+function discoverCodeboxArtifactRefs(artifactsRoot, options = {}) {
+  const filesystem = options.fs || fs;
+  const maxArtifacts = Number.isFinite(options.maxArtifacts) ? options.maxArtifacts : 200;
+  const maxDepth = Number.isFinite(options.maxDepth) ? options.maxDepth : 4;
+  if (!artifactsRoot || !filesystem.existsSync(artifactsRoot)) {
+    return { artifacts: [], evidenceRefs: [], runtimeId: '', lastKnownPhase: '', lastHeartbeat: null };
+  }
+
+  const discovered = [];
+  const queue = [{ filePath: artifactsRoot, depth: 0 }];
+  let lastKnownPhase = '';
+  let lastHeartbeat = null;
+  let runtimeId = '';
+
+  while (queue.length > 0 && discovered.length < maxArtifacts) {
+    const { filePath, depth } = queue.shift();
+    let stat;
+    try {
+      stat = filesystem.statSync(filePath);
+    } catch {
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      const manifestPath = path.join(filePath, 'manifest.json');
+      if (filePath !== artifactsRoot && filesystem.existsSync(manifestPath)) {
+        const manifest = readJsonIfAvailable(manifestPath, filesystem);
+        if (!runtimeId && plainObject(manifest)) {
+          runtimeId = manifest.runtime_id || manifest.runtimeId || manifest.runtime?.id || '';
+        }
+        discovered.push({
+          id: manifest?.id || manifest?.artifact_id || `codebox-artifact-bundle-${discovered.length + 1}`,
+          kind: 'codebox-artifact-bundle',
+          path: filePath,
+          size_bytes: directorySizeBytes(filePath, filesystem),
+          metadata: plainObject(manifest) ? {
+            schema: manifest.schema,
+            phase: manifest.phase || manifest.last_phase || manifest.current_phase,
+            runtime_id: manifest.runtime_id || manifest.runtimeId || manifest.runtime?.id,
+          } : {},
+        });
+      }
+      if (depth < maxDepth) {
+        for (const entry of filesystem.readdirSync(filePath).sort()) {
+          queue.push({ filePath: path.join(filePath, entry), depth: depth + 1 });
+        }
+      }
+      continue;
+    }
+
+    if (!stat.isFile()) {
+      continue;
+    }
+
+    const kind = codeboxArtifactKindFromPath(path.relative(artifactsRoot, filePath));
+    if (!kind) {
+      continue;
+    }
+    const payload = filePath.endsWith('.json') ? readJsonIfAvailable(filePath, filesystem) : null;
+    if (!lastKnownPhase && plainObject(payload)) {
+      lastKnownPhase = payload.phase || payload.last_phase || payload.lastKnownPhase || payload.current_phase || '';
+    }
+    if (!runtimeId && plainObject(payload)) {
+      runtimeId = payload.runtime_id || payload.runtimeId || payload.runtime?.id || '';
+    }
+    if (!lastHeartbeat && plainObject(payload) && /heartbeat|status/i.test(filePath)) {
+      lastHeartbeat = payload.heartbeat || payload.last_heartbeat || payload;
+    }
+    discovered.push({
+      id: `${kind}-${discovered.length + 1}`,
+      kind,
+      path: filePath,
+      size_bytes: stat.size,
+      metadata: plainObject(payload) ? {
+        schema: payload.schema,
+        phase: payload.phase || payload.last_phase || payload.current_phase,
+      } : {},
+    });
+  }
+
+  return {
+    artifacts: discovered,
+    evidenceRefs: discovered.map((artifact) => ({
+      kind: artifact.kind,
+      uri: artifact.path,
+      label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
+    })),
+    runtimeId,
+    lastKnownPhase,
+    lastHeartbeat,
+  };
+}
+
+function codeboxArtifactKindFromPath(filePath) {
+  const fileName = basename(filePath).toLowerCase();
+  if (fileName === 'manifest.json') {
+    return 'codebox-artifact-manifest';
+  }
+  if (fileName === 'runtime-reference-manifest.json') {
+    return 'codebox-runtime-reference-manifest';
+  }
+  const relative = String(filePath || '').replace(/\\/g, '/');
+  if (/transcript|conversation|messages/.test(relative)) {
+    return 'codebox-transcript';
+  }
+  if (/command|stdout|stderr|console|log/.test(relative)) {
+    return 'codebox-command-log';
+  }
+  if (/heartbeat|status/.test(relative)) {
+    return 'codebox-heartbeat';
+  }
+  if (/phase/.test(relative)) {
+    return 'codebox-phase';
+  }
+  return '';
+}
+
+function directorySizeBytes(directory, filesystem = fs) {
+  try {
+    return filesystem.readdirSync(directory, { withFileTypes: true }).reduce((total, entry) => {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        return total + directorySizeBytes(entryPath, filesystem);
+      }
+      return total + filesystem.statSync(entryPath).size;
+    }, 0);
+  } catch {
+    return undefined;
+  }
+}
+
+function readJsonIfAvailable(filePath, filesystem = fs) {
+  try {
+    return JSON.parse(filesystem.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
 function artifactRoleFromCodeboxArtifact(artifact = {}, roleAliases = {}) {
   const labels = artifactLabels(artifact);
   const explicitRole = roleFromAliases(labels, roleAliases);
@@ -574,7 +716,9 @@ module.exports = {
   artifactRoleFromCodeboxArtifact,
   artifactNameFromDeclaration,
   artifactPath,
+  codeboxArtifactKindFromPath,
   caseArtifactIndexFromCodeboxResult,
+  discoverCodeboxArtifactRefs,
   normalizeCodeboxArtifactDeclaration,
   normalizeCodeboxArtifactOutcome,
   normalizeArtifactResultEnvelope,

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -19,6 +19,9 @@ const {
   providerContract,
 } = require('../../lib/codebox-agent-task-executor');
 const {
+  discoverCodeboxArtifactRefs,
+} = require('../../lib/codebox-artifact-contract');
+const {
   normalizeStringArray,
   providerAuthEnvSources,
   providerDiagnosticClass,
@@ -190,138 +193,10 @@ function providerAuthEnv(taskInput) {
   return env;
 }
 
-function directorySizeBytes(directory) {
-  try {
-    return fs.readdirSync(directory, { withFileTypes: true }).reduce((total, entry) => {
-      const entryPath = path.join(directory, entry.name);
-      if (entry.isDirectory()) {
-        return total + directorySizeBytes(entryPath);
-      }
-      return total + fs.statSync(entryPath).size;
-    }, 0);
-  } catch {
-    return undefined;
-  }
-}
-
-function fileArtifactKind(filePath) {
-  const fileName = path.basename(filePath).toLowerCase();
-  if (fileName === 'manifest.json') {
-    return 'codebox-artifact-manifest';
-  }
-  if (fileName === 'runtime-reference-manifest.json') {
-    return 'codebox-runtime-reference-manifest';
-  }
-  const relative = filePath.replace(/\\/g, '/');
-  if (/transcript|conversation|messages/.test(relative)) {
-    return 'codebox-transcript';
-  }
-  if (/command|stdout|stderr|console|log/.test(relative)) {
-    return 'codebox-command-log';
-  }
-  if (/heartbeat|status/.test(relative)) {
-    return 'codebox-heartbeat';
-  }
-  if (/phase/.test(relative)) {
-    return 'codebox-phase';
-  }
-  return '';
-}
-
-function discoverTimeoutArtifactRefs(artifactsRoot) {
-  if (!artifactsRoot || !fs.existsSync(artifactsRoot)) {
-    return { artifacts: [], evidenceRefs: [], lastKnownPhase: '', lastHeartbeat: null };
-  }
-
-  const discovered = [];
-  const queue = [{ filePath: artifactsRoot, depth: 0 }];
-  let lastKnownPhase = '';
-  let lastHeartbeat = null;
-  let runtimeId = '';
-
-  while (queue.length > 0 && discovered.length < 200) {
-    const { filePath, depth } = queue.shift();
-    let stat;
-    try {
-      stat = fs.statSync(filePath);
-    } catch {
-      continue;
-    }
-
-    if (stat.isDirectory()) {
-      const manifestPath = path.join(filePath, 'manifest.json');
-      if (filePath !== artifactsRoot && fs.existsSync(manifestPath)) {
-        const manifest = readJsonIfAvailable(manifestPath);
-        if (!runtimeId && manifest && typeof manifest === 'object') {
-          runtimeId = manifest.runtime_id || manifest.runtimeId || manifest.runtime?.id || '';
-        }
-        discovered.push({
-          id: manifest?.id || manifest?.artifact_id || `codebox-artifact-bundle-${discovered.length + 1}`,
-          kind: 'codebox-artifact-bundle',
-          path: filePath,
-          size_bytes: directorySizeBytes(filePath),
-          metadata: manifest && typeof manifest === 'object' ? {
-            schema: manifest.schema,
-            phase: manifest.phase || manifest.last_phase || manifest.current_phase,
-            runtime_id: manifest.runtime_id || manifest.runtimeId || manifest.runtime?.id,
-          } : {},
-        });
-      }
-      if (depth < 4) {
-        for (const entry of fs.readdirSync(filePath).sort()) {
-          queue.push({ filePath: path.join(filePath, entry), depth: depth + 1 });
-        }
-      }
-      continue;
-    }
-
-    if (!stat.isFile()) {
-      continue;
-    }
-
-    const kind = fileArtifactKind(path.relative(artifactsRoot, filePath));
-    if (!kind) {
-      continue;
-    }
-    const payload = filePath.endsWith('.json') ? readJsonIfAvailable(filePath) : null;
-    if (!lastKnownPhase && payload && typeof payload === 'object') {
-      lastKnownPhase = payload.phase || payload.last_phase || payload.lastKnownPhase || payload.current_phase || '';
-    }
-    if (!runtimeId && payload && typeof payload === 'object') {
-      runtimeId = payload.runtime_id || payload.runtimeId || payload.runtime?.id || '';
-    }
-    if (!lastHeartbeat && payload && typeof payload === 'object' && /heartbeat|status/i.test(filePath)) {
-      lastHeartbeat = payload.heartbeat || payload.last_heartbeat || payload;
-    }
-    discovered.push({
-      id: `${kind}-${discovered.length + 1}`,
-      kind,
-      path: filePath,
-      size_bytes: stat.size,
-      metadata: payload && typeof payload === 'object' ? {
-        schema: payload.schema,
-        phase: payload.phase || payload.last_phase || payload.current_phase,
-      } : {},
-    });
-  }
-
-  return {
-    artifacts: discovered,
-    evidenceRefs: discovered.map((artifact) => ({
-      kind: artifact.kind,
-      uri: artifact.path,
-      label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
-    })),
-    runtimeId,
-    lastKnownPhase,
-    lastHeartbeat,
-  };
-}
-
 function timeoutPayload(timeoutMs, request = {}) {
   const artifacts = argValue('--artifacts') || request.executor?.config?.artifacts || '';
   const evidencePath = artifacts ? `${artifacts}/homeboy-codebox-task-runner.json` : '';
-  const discovered = discoverTimeoutArtifactRefs(artifacts);
+  const discovered = discoverCodeboxArtifactRefs(artifacts);
   const knownArtifacts = [];
   if (artifacts) {
     knownArtifacts.push({

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -9,6 +9,7 @@ const {
   agentTaskOutcomeFromCodeboxResult,
   artifactResultEnvelopeFromCodeboxResult,
   codeboxTaskRequestFromAgentTaskRequest,
+  discoverCodeboxArtifactRefs,
   normalizeCodeboxArtifactDeclaration,
   normalizeCodeboxArtifactOutcome,
   providerContract,
@@ -116,6 +117,33 @@ assert.deepEqual(typedArtifactsFromCodeboxResult({ artifact_result: artifactResu
 assert.equal(normalizeCodeboxArtifactOutcome({ id: 'patch.diff', kind: 'codebox-patch' }, {}, {
   roleAliases: provider.role_aliases,
 }).role, 'patch');
+
+const artifactDiscoveryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-artifacts-'));
+const artifactBundleRoot = path.join(artifactDiscoveryRoot, 'bundle');
+fs.mkdirSync(path.join(artifactDiscoveryRoot, 'logs'), { recursive: true });
+fs.mkdirSync(artifactBundleRoot, { recursive: true });
+fs.writeFileSync(path.join(artifactBundleRoot, 'manifest.json'), JSON.stringify({
+  id: 'bundle-1',
+  runtime_id: 'wp-codebox',
+  phase: 'agent-task-run',
+}));
+fs.writeFileSync(path.join(artifactDiscoveryRoot, 'logs', 'heartbeat.json'), JSON.stringify({
+  runtime_id: 'wp-codebox',
+  current_phase: 'running',
+  heartbeat: { sequence: 3 },
+}));
+fs.writeFileSync(path.join(artifactDiscoveryRoot, 'transcript.json'), JSON.stringify({ schema: 'example/transcript/v1' }));
+const discoveredCodeboxArtifacts = discoverCodeboxArtifactRefs(artifactDiscoveryRoot);
+assert.equal(discoveredCodeboxArtifacts.runtimeId, 'wp-codebox');
+assert.equal(discoveredCodeboxArtifacts.lastKnownPhase, 'agent-task-run');
+assert.deepEqual(discoveredCodeboxArtifacts.lastHeartbeat, { sequence: 3 });
+assert.deepEqual(discoveredCodeboxArtifacts.artifacts.map((artifact) => artifact.kind).sort(), [
+  'codebox-artifact-bundle',
+  'codebox-artifact-manifest',
+  'codebox-command-log',
+  'codebox-transcript',
+]);
+assert.equal(discoveredCodeboxArtifacts.evidenceRefs.length, 4);
 
 const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'wordpress.json'), 'utf8'));
 assert.equal(manifest.agent_task_executors, undefined);

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -2571,6 +2571,9 @@ try {
   providerPluginValidation() { return null; },
   providerSecretEnv() { return []; },
 };\n`);
+  fs.writeFileSync(path.join(installedRuntime, 'lib', 'codebox-artifact-contract.js'), `module.exports = {
+  discoverCodeboxArtifactRefs() { return { artifacts: [], evidenceRefs: [], runtimeId: '', lastKnownPhase: '', lastHeartbeat: null }; },
+};\n`);
   fs.writeFileSync(path.join(installedLayoutRoot, 'extensions', 'wordpress', 'lib', 'wp-codebox-core-loader.js'), `module.exports = { async loadWpCodeboxCore() { return {}; } };\n`);
   const installedLayoutResult = spawnSync(process.execPath, [path.join(installedRuntime, 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs')], {
     encoding: 'utf8',


### PR DESCRIPTION
## Summary
- Move WP Codebox timeout artifact discovery out of the executor script and into the shared artifact contract module.
- Keep the executor behavior-compatible by consuming the new `discoverCodeboxArtifactRefs()` helper.
- Add boundary coverage for artifact discovery and update the installed-layout smoke fixture.

## Testing
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Extracting the artifact discovery seam, updating tests, and running lightweight verification.