### PR TITLE
Preserve prepared dependency plugin slugs

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh
@@ -68,6 +68,14 @@ homeboy_find_validation_dependency_plugin_main_file() {
     fi
     return 1
 }
+homeboy_get_prepared_validation_dependency_slug() {
+    local dependency_path="${1:-}"
+    local artifacts_dir="${2:-}"
+    jq -er --arg dependencyPath "$dependency_path" '
+        map(select(.prepared_path == $dependencyPath or .package_root == $dependencyPath))
+        | .[-1].slug // empty
+    ' "${artifacts_dir}/prepared-bench-dependencies.json" 2>/dev/null
+}
 STUB
 
 CAPTURE_FILE="${TMP_ROOT}/capture.json"
@@ -376,6 +384,8 @@ mkdir -p "${DEPENDENCY_ROOT}/packages/wordpress-plugin"
 printf '<?php\n/**\n * Plugin Name: WP Codebox Fixture\n */\n' > "${DEPENDENCY_ROOT}/packages/wordpress-plugin/wp-codebox.php"
 
 DEPENDENCY_CAPTURE_FILE="${TMP_ROOT}/dependency-capture.json"
+mkdir -p "${TMP_ROOT}/dependency-artifacts"
+jq -nc --arg dependencyRoot "$DEPENDENCY_ROOT" '[{schema: "homeboy/prepared-wordpress-bench-dependency/v1", slug: "declared-wp-codebox", package_root: $dependencyRoot, prepared_path: $dependencyRoot}]' > "${TMP_ROOT}/dependency-artifacts/prepared-bench-dependencies.json"
 HOMEBOY_RUNTIME_RESOLVE_CONTEXT="$RESOLVE_HELPER" \
 HOMEBOY_RUNTIME_BENCH_HELPER_SH="$BENCH_HELPER" \
 HOMEBOY_WORDPRESS_DEPENDENCY_HELPER="$DEPENDENCY_HELPER" \
@@ -395,7 +405,7 @@ bash "$SCRIPT_DIR/bench-runner-wp-codebox.sh" >/dev/null
 jq -e --arg pluginRoot "$PLUGIN_ROOT" --arg dependencyRoot "${DEPENDENCY_ROOT}/packages/wordpress-plugin" '
     .recipe.inputs.extraPlugins == [
         {source: $pluginRoot, slug: "wp-site-generator", pluginFile: "wp-site-generator/plugin-main.php", activate: false},
-        {source: $dependencyRoot, slug: "wp-codebox", pluginFile: "wp-codebox/wp-codebox.php", activate: false}
+        {source: $dependencyRoot, slug: "declared-wp-codebox", pluginFile: "declared-wp-codebox/wp-codebox.php", activate: false}
     ]
 ' "$DEPENDENCY_CAPTURE_FILE" >/dev/null
 
@@ -406,8 +416,8 @@ if [ ! -s "$DEPENDENCY_PROVENANCE_FILE" ]; then
 fi
 jq -e --arg dependencyRoot "${DEPENDENCY_ROOT}/packages/wordpress-plugin" '
     .schema == "homeboy/wordpress-bench-dependency-provenance/v1"
-    and (.dependency_slugs == ["wp-codebox"])
-    and (.plugin_inputs[] | select(.source == $dependencyRoot and .slug == "wp-codebox" and .pluginFile == "wp-codebox/wp-codebox.php"))
+    and (.dependency_slugs == ["declared-wp-codebox"])
+    and (.plugin_inputs[] | select(.source == $dependencyRoot and .slug == "declared-wp-codebox" and .pluginFile == "declared-wp-codebox/wp-codebox.php"))
     and (.settings.has_bench_env == true)
 ' "$DEPENDENCY_PROVENANCE_FILE" >/dev/null
 

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -973,7 +973,13 @@ DEPENDENCY_SLUGS=()
 if [ -n "$DEPENDENCY_PATHS" ]; then
     while IFS= read -r dep_path; do
         [ -n "$dep_path" ] || continue
-        dep_slug="$(homeboy_get_validation_dependency_slug "$dep_path" || basename "$dep_path")"
+        dep_slug=""
+        dep_slug_from_metadata=0
+        if type homeboy_get_prepared_validation_dependency_slug &>/dev/null; then
+            dep_slug="$(homeboy_get_prepared_validation_dependency_slug "$dep_path" "$ARTIFACTS_DIR" || true)"
+            [ -n "$dep_slug" ] && dep_slug_from_metadata=1
+        fi
+        [ -n "$dep_slug" ] || dep_slug="$(homeboy_get_validation_dependency_slug "$dep_path" || basename "$dep_path")"
         dep_plugin_file=""
         dep_plugin_relative_file=""
         dep_plugin_source="$dep_path"
@@ -983,7 +989,7 @@ if [ -n "$DEPENDENCY_PATHS" ]; then
         if [ -n "$dep_plugin_file" ]; then
             dep_plugin_relative_file="${dep_plugin_file#"${dep_path%/}/"}"
             dep_plugin_basename="$(basename "$dep_plugin_file" .php)"
-            if [ -n "$dep_plugin_basename" ] && { [ "$dep_plugin_basename" != "$dep_slug" ] || [[ "$dep_plugin_relative_file" == packages/wordpress-plugin/* ]]; }; then
+            if [ "$dep_slug_from_metadata" -eq 0 ] && [ -n "$dep_plugin_basename" ] && { [ "$dep_plugin_basename" != "$dep_slug" ] || [[ "$dep_plugin_relative_file" == packages/wordpress-plugin/* ]]; }; then
                 dep_slug="$dep_plugin_basename"
             fi
             if [[ "$dep_plugin_relative_file" == packages/wordpress-plugin/* ]]; then

--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -1554,7 +1554,7 @@ _homeboy_prepared_dependency_cache_metadata() {
         '($catalogEntry // {}) as $catalog |
         {
             schema: $schema,
-            slug: $slug,
+            slug: ($catalog.slug // $slug),
             source_type: ($catalog.source_type // null),
             requested_version: ($catalog.requested_version // null),
             requested_revision: ($catalog.requested_revision // null),
@@ -1610,6 +1610,25 @@ _homeboy_record_prepared_dependency_metadata() {
         --arg cache_status "$cache_status" \
         '$existing + [($dependency + {cache_key: $cache_key, prepared_path: $prepared_path, cache_status: $cache_status})]' > "$tmp_file"
     mv "$tmp_file" "$metadata_file"
+}
+
+homeboy_get_prepared_validation_dependency_slug() {
+    local dependency_path="${1:-}"
+    local artifacts_dir="${2:-}"
+
+    [ -n "$dependency_path" ] && [ -n "$artifacts_dir" ] || return 1
+    command -v jq >/dev/null 2>&1 || return 1
+
+    local metadata_file dependency_realpath
+    metadata_file="${artifacts_dir%/}/prepared-bench-dependencies.json"
+    [ -f "$metadata_file" ] || return 1
+    dependency_realpath=$(cd "$dependency_path" && pwd -P 2>/dev/null || printf '%s\n' "$dependency_path")
+
+    jq -er --arg dependencyPath "$dependency_path" --arg dependencyRealpath "$dependency_realpath" '
+        if type == "array" then . else [] end
+        | map(select(.prepared_path == $dependencyPath or .prepared_path == $dependencyRealpath or .package_root == $dependencyPath or .package_root == $dependencyRealpath))
+        | .[-1].slug // empty
+    ' "$metadata_file" 2>/dev/null
 }
 
 _homeboy_command_version() {
@@ -1713,10 +1732,13 @@ homeboy_prepare_validation_dependency_for_wp_codebox_bench() {
 
     [ -n "$dependency_path" ] && [ -d "$dependency_path" ] || return 1
 
-    local dependency_slug package_root
+    local dependency_slug package_root catalog_entry_json catalog_slug
     dependency_slug=$(homeboy_get_validation_dependency_slug "$dependency_path" || basename "$dependency_path")
     package_root=$(homeboy_find_validation_dependency_plugin_package_root "$dependency_path" "$dependency_slug" || true)
     [ -n "$package_root" ] && [ -d "$package_root" ] || package_root="$dependency_path"
+    catalog_entry_json=$(_homeboy_prepared_dependency_catalog_entry "$dependency_path" "$package_root")
+    catalog_slug=$(printf '%s' "$catalog_entry_json" | jq -r '.slug // empty' 2>/dev/null || true)
+    [ -n "$catalog_slug" ] && dependency_slug="$catalog_slug"
 
     if ! homeboy_dependency_needs_composer_prepare "$package_root"; then
         local source_realpath package_realpath relative_source_plugin_path metadata_json

--- a/wordpress/tests/prepared-bench-dependency-cache-smoke.sh
+++ b/wordpress/tests/prepared-bench-dependency-cache-smoke.sh
@@ -64,6 +64,8 @@ git -C "$SOURCE_REPO" -c user.name='Homeboy Smoke' -c user.email='homeboy-smoke@
 export PATH="${FAKE_BIN}:${PATH}"
 export COMPOSER_CALLS_FILE="$CALLS_FILE"
 export HOMEBOY_CACHE_DIR="$CACHE_DIR"
+export HOMEBOY_SETTINGS_JSON
+HOMEBOY_SETTINGS_JSON=$(jq -nc --arg sourceRepo "$SOURCE_REPO" '{validation_dependencies: [{type: "local", path: $sourceRepo, package_path: "plugins/generic-dep", plugin_slug: "declared-generic-dep", activate: true}]}')
 
 first_prepared=$(homeboy_prepare_validation_dependency_for_wp_codebox_bench "$PLUGIN_DIR" "${TMP_ROOT}/artifacts-one")
 second_prepared=$(homeboy_prepare_validation_dependency_for_wp_codebox_bench "$PLUGIN_DIR" "${TMP_ROOT}/artifacts-two")
@@ -75,6 +77,17 @@ fi
 
 if [ -d "${PLUGIN_DIR}/vendor" ]; then
     echo "ERROR: source dependency was mutated by Composer prepare." >&2
+    exit 1
+fi
+
+if ! jq -e 'length == 1 and .[0].slug == "declared-generic-dep" and .[0].activation_status == "active" and (.[0].mounted_plugin_dir | endswith("/declared-generic-dep"))' "${TMP_ROOT}/artifacts-one/prepared-bench-dependencies.json" >/dev/null; then
+    echo "ERROR: declared dependency plugin slug was not preserved in prepared metadata." >&2
+    jq '.' "${TMP_ROOT}/artifacts-one/prepared-bench-dependencies.json" >&2 || true
+    exit 1
+fi
+
+if [ "$(homeboy_get_prepared_validation_dependency_slug "$first_prepared" "${TMP_ROOT}/artifacts-one")" != "declared-generic-dep" ]; then
+    echo "ERROR: prepared dependency slug lookup did not return the declared plugin slug." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Preserve declared WordPress dependency plugin slugs in prepared bench dependency metadata.
- Use prepared dependency metadata when building WP Codebox bench plugin mounts.
- Cover the regression where a monorepo package path basename replaced the declared plugin slug.

## Verification
- `bash wordpress/tests/prepared-bench-dependency-cache-smoke.sh`
- `bash wordpress/scripts/bench/bench-runner-wp-codebox-static-source-smoke.sh`
- `bash wordpress/tests/dependency-plugin-preflight-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the dependency slug propagation failure, drafting the fix, and running targeted verification.
