### PR TITLE
Centralize WP Codebox adapter compatibility

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -52,11 +52,18 @@ const {
   WP_CODEBOX_ROLE_ALIASES,
   WP_CODEBOX_TASK_REQUEST_SCHEMA,
   WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
+  WP_CODEBOX_WORKSPACE_MOUNT_KIND,
+  WP_CODEBOX_LEGACY_WORKSPACE_MOUNT_KIND,
+  wpCodeboxLegacyRuntimeComponentAliasDiagnostics,
+  wpCodeboxLegacyRuntimeComponentAliasValues,
   wpCodeboxProviderRuntimeInvocationContract,
   wpCodeboxProviderRuntimeOperationEntry,
 } = require('./wp-codebox-adapter-contract');
 const {
   WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
+  isCodeboxLegacyAgentTaskRunResult,
+  legacyAgentTaskRunEvidenceRefs,
+  legacyAgentTaskRunSessionArtifacts,
 } = require('./codebox-run-agent-task-contract');
 const {
   assertProviderCredentialBoundaryNamesOnly,
@@ -67,8 +74,6 @@ const {
 const RUNTIME_MANIFEST_PATH = path.resolve(__dirname, '..', 'wp-codebox.json');
 const RUNTIME_OVERLAY_CANONICAL_SHAPE = 'runtime_overlays entries must be objects. WP Codebox owns the runtime overlay schema and reports field-level validation.';
 const RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
-const WP_CODEBOX_WORKSPACE_MOUNT_KIND = 'homeboy-runtime-workspace';
-const WP_CODEBOX_LEGACY_WORKSPACE_MOUNT_KIND = ['homeboy', 'dmc', 'workspace'].join('-');
 const PROVIDER_CAPABILITIES = runtimeProviderCapabilities();
 
 const AGENT_BUNDLE_CONFIG_FIELDS = [
@@ -312,7 +317,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   assertProviderCredentialBoundaryNamesOnly(request.inputs || {});
   const runtimeOptions = runtimeOptionsFromExecutorConfig(config, options);
   const inputs = request.inputs || {};
-  const compatibilityDiagnostics = legacyRuntimeComponentAliasDiagnostics(config);
+  const compatibilityDiagnostics = wpCodeboxLegacyRuntimeComponentAliasDiagnostics(config);
   const defaults = defaultCodeboxRuntimeConfig(request, config, inputs, runtimeOptions);
   const workspaceMaterialization = defaultWorkspaceMaterialization(defaults.workspaceRoot, request, config, inputs, runtimeOptions);
   const target = defaultWorkspaceTargetPayload(inputs.target || request.workspace || {}, workspaceMaterialization);
@@ -1072,7 +1077,7 @@ function runtimeComponentPaths(config, options = {}) {
     : {};
   const contractPaths = runtimeComponentPathsFromContracts(config.component_contracts || options.componentContracts || [], options);
   const aliases = runtimeComponentPathAliases(options);
-  const legacyAliases = legacyRuntimeComponentAliasValues(config);
+  const legacyAliases = wpCodeboxLegacyRuntimeComponentAliasValues(config);
   const resolved = {
     ...contractPaths,
     agents_api: config.agents_api || config.agents_api_path || options.agentsApi,
@@ -1096,36 +1101,6 @@ function runtimeComponentPaths(config, options = {}) {
   }
 
   return Object.fromEntries(Object.entries(resolved).filter(([, value]) => value !== undefined && value !== ''));
-}
-
-function legacyRuntimeComponentAliasFields() {
-  const prefix = ['data', 'machine'].join('_');
-  return {
-    agent_runtime: [prefix, `${prefix}_path`],
-    agent_runtime_tools: [`${prefix}_code`, `${prefix}_code_path`],
-  };
-}
-
-function legacyRuntimeComponentAliasValues(config = {}) {
-  const fields = legacyRuntimeComponentAliasFields();
-  return Object.fromEntries(Object.entries(fields).map(([canonical, aliases]) => [
-    canonical,
-    firstValue(...aliases.map((alias) => config[alias])),
-  ]));
-}
-
-function legacyRuntimeComponentAliasDiagnostics(config = {}) {
-  return Object.entries(legacyRuntimeComponentAliasFields()).flatMap(([canonical, aliases]) => aliases
-    .filter((alias) => config[alias] !== undefined)
-    .map((alias) => ({
-      class: 'codebox.compat.deprecated_runtime_component_alias',
-      message: `Deprecated runtime component alias "${alias}" was accepted for compatibility; use "${canonical}" instead.`,
-      data: {
-        alias,
-        replacement: canonical,
-        compatibility: 'accepted-for-current-callers',
-      },
-    })));
 }
 
 function componentPathCandidateValue(candidate, sources) {
@@ -2826,27 +2801,9 @@ function normalizeArtifacts(result, runSummary = null, recipeSummary = null) {
     recipeSummary.artifacts.map(artifactFromCodeboxArtifact).forEach((artifact) => appendUniqueArtifact(normalizedArtifacts, artifact));
   }
 
-  if (result?.schema === 'wp-codebox/agent-task-run/v1') {
+  if (isCodeboxLegacyAgentTaskRunResult(result)) {
     const artifacts = [...normalizedArtifacts];
-    if (typeof result.artifacts === 'string' && result.artifacts) {
-      artifacts.push({
-        id: result.session?.artifacts?.bundle_id || 'wp-codebox-artifacts',
-        kind: 'codebox-artifact-directory',
-        path: result.artifacts,
-        metadata: {
-          session_id: result.session?.id,
-          preview_url: result.session?.artifacts?.preview_url,
-        },
-      });
-    }
-    if (result.session?.artifacts && typeof result.session.artifacts === 'object') {
-      artifacts.push({
-        id: result.session.artifacts.bundle_id || `wp-codebox-session-artifacts-${artifacts.length + 1}`,
-        kind: 'codebox-session-artifacts',
-        url: result.session.artifacts.preview_url,
-        metadata: result.session.artifacts,
-      });
-    }
+    legacyAgentTaskRunSessionArtifacts(result).forEach((artifact) => appendUniqueArtifact(artifacts, artifact));
     if (Array.isArray(result.artifacts)) {
       result.artifacts.map(artifactFromCodeboxArtifact).forEach((artifact) => appendUniqueArtifact(artifacts, artifact));
     }
@@ -2878,19 +2835,8 @@ function normalizeArtifacts(result, runSummary = null, recipeSummary = null) {
 
 function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) {
   const artifactResult = artifactResultEnvelopeFromCodeboxResult(result);
-  if (result?.schema === 'wp-codebox/agent-task-run/v1') {
-    const refs = [
-      result.session?.artifacts?.preview_url ? {
-        kind: 'codebox-preview',
-        uri: result.session.artifacts.preview_url,
-        label: 'WP Codebox preview',
-      } : null,
-      typeof result.artifacts === 'string' && result.artifacts ? {
-        kind: 'codebox-artifact-directory',
-        uri: result.artifacts,
-        label: 'WP Codebox artifacts',
-      } : null,
-    ].filter(Boolean);
+  if (isCodeboxLegacyAgentTaskRunResult(result)) {
+    const refs = legacyAgentTaskRunEvidenceRefs(result);
     for (const artifact of artifactResult?.artifactRefs || []) {
       appendUniqueEvidenceRef(refs, {
         kind: artifact.kind,

--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const fs = require('node:fs');
+const path = require('node:path');
+
 const TYPED_ARTIFACT_SCHEMA = 'homeboy/agent-task-typed-artifact/v1';
 const WP_CODEBOX_ARTIFACT_DECLARATION_SCHEMA = 'wp-codebox/artifact-declaration/v1';
 const WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA = 'wp-codebox/artifact-result-envelope/v1';
@@ -501,6 +504,145 @@ function artifactPath(root, relativePath) {
   return `${String(root).replace(/\/$/, '')}/${String(relativePath).replace(/^\//, '')}`;
 }
 
+function discoverCodeboxArtifactRefs(artifactsRoot, options = {}) {
+  const filesystem = options.fs || fs;
+  const maxArtifacts = Number.isFinite(options.maxArtifacts) ? options.maxArtifacts : 200;
+  const maxDepth = Number.isFinite(options.maxDepth) ? options.maxDepth : 4;
+  if (!artifactsRoot || !filesystem.existsSync(artifactsRoot)) {
+    return { artifacts: [], evidenceRefs: [], runtimeId: '', lastKnownPhase: '', lastHeartbeat: null };
+  }
+
+  const discovered = [];
+  const queue = [{ filePath: artifactsRoot, depth: 0 }];
+  let lastKnownPhase = '';
+  let lastHeartbeat = null;
+  let runtimeId = '';
+
+  while (queue.length > 0 && discovered.length < maxArtifacts) {
+    const { filePath, depth } = queue.shift();
+    let stat;
+    try {
+      stat = filesystem.statSync(filePath);
+    } catch {
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      const manifestPath = path.join(filePath, 'manifest.json');
+      if (filePath !== artifactsRoot && filesystem.existsSync(manifestPath)) {
+        const manifest = readJsonIfAvailable(manifestPath, filesystem);
+        if (!runtimeId && plainObject(manifest)) {
+          runtimeId = manifest.runtime_id || manifest.runtimeId || manifest.runtime?.id || '';
+        }
+        discovered.push({
+          id: manifest?.id || manifest?.artifact_id || `codebox-artifact-bundle-${discovered.length + 1}`,
+          kind: 'codebox-artifact-bundle',
+          path: filePath,
+          size_bytes: directorySizeBytes(filePath, filesystem),
+          metadata: plainObject(manifest) ? {
+            schema: manifest.schema,
+            phase: manifest.phase || manifest.last_phase || manifest.current_phase,
+            runtime_id: manifest.runtime_id || manifest.runtimeId || manifest.runtime?.id,
+          } : {},
+        });
+      }
+      if (depth < maxDepth) {
+        for (const entry of filesystem.readdirSync(filePath).sort()) {
+          queue.push({ filePath: path.join(filePath, entry), depth: depth + 1 });
+        }
+      }
+      continue;
+    }
+
+    if (!stat.isFile()) {
+      continue;
+    }
+
+    const kind = codeboxArtifactKindFromPath(path.relative(artifactsRoot, filePath));
+    if (!kind) {
+      continue;
+    }
+    const payload = filePath.endsWith('.json') ? readJsonIfAvailable(filePath, filesystem) : null;
+    if (!lastKnownPhase && plainObject(payload)) {
+      lastKnownPhase = payload.phase || payload.last_phase || payload.lastKnownPhase || payload.current_phase || '';
+    }
+    if (!runtimeId && plainObject(payload)) {
+      runtimeId = payload.runtime_id || payload.runtimeId || payload.runtime?.id || '';
+    }
+    if (!lastHeartbeat && plainObject(payload) && /heartbeat|status/i.test(filePath)) {
+      lastHeartbeat = payload.heartbeat || payload.last_heartbeat || payload;
+    }
+    discovered.push({
+      id: `${kind}-${discovered.length + 1}`,
+      kind,
+      path: filePath,
+      size_bytes: stat.size,
+      metadata: plainObject(payload) ? {
+        schema: payload.schema,
+        phase: payload.phase || payload.last_phase || payload.current_phase,
+      } : {},
+    });
+  }
+
+  return {
+    artifacts: discovered,
+    evidenceRefs: discovered.map((artifact) => ({
+      kind: artifact.kind,
+      uri: artifact.path,
+      label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
+    })),
+    runtimeId,
+    lastKnownPhase,
+    lastHeartbeat,
+  };
+}
+
+function codeboxArtifactKindFromPath(filePath) {
+  const fileName = basename(filePath).toLowerCase();
+  if (fileName === 'manifest.json') {
+    return 'codebox-artifact-manifest';
+  }
+  if (fileName === 'runtime-reference-manifest.json') {
+    return 'codebox-runtime-reference-manifest';
+  }
+  const relative = String(filePath || '').replace(/\\/g, '/');
+  if (/transcript|conversation|messages/.test(relative)) {
+    return 'codebox-transcript';
+  }
+  if (/command|stdout|stderr|console|log/.test(relative)) {
+    return 'codebox-command-log';
+  }
+  if (/heartbeat|status/.test(relative)) {
+    return 'codebox-heartbeat';
+  }
+  if (/phase/.test(relative)) {
+    return 'codebox-phase';
+  }
+  return '';
+}
+
+function directorySizeBytes(directory, filesystem = fs) {
+  try {
+    return filesystem.readdirSync(directory, { withFileTypes: true }).reduce((total, entry) => {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        return total + directorySizeBytes(entryPath, filesystem);
+      }
+      return total + filesystem.statSync(entryPath).size;
+    }, 0);
+  } catch {
+    return undefined;
+  }
+}
+
+function readJsonIfAvailable(filePath, filesystem = fs) {
+  try {
+    return JSON.parse(filesystem.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
 function artifactRoleFromCodeboxArtifact(artifact = {}, roleAliases = {}) {
   const labels = artifactLabels(artifact);
   const explicitRole = roleFromAliases(labels, roleAliases);
@@ -574,7 +716,9 @@ module.exports = {
   artifactRoleFromCodeboxArtifact,
   artifactNameFromDeclaration,
   artifactPath,
+  codeboxArtifactKindFromPath,
   caseArtifactIndexFromCodeboxResult,
+  discoverCodeboxArtifactRefs,
   normalizeCodeboxArtifactDeclaration,
   normalizeCodeboxArtifactOutcome,
   normalizeArtifactResultEnvelope,

--- a/agent-runtimes/wp-codebox/lib/codebox-run-agent-task-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-run-agent-task-contract.js
@@ -62,6 +62,55 @@ function codeboxRunAgentTaskInvocation(options = {}) {
   };
 }
 
+function isCodeboxLegacyAgentTaskRunResult(result) {
+  return result?.schema === WP_CODEBOX_AGENT_TASK_RUN_RESPONSE_SCHEMA;
+}
+
+function legacyAgentTaskRunSessionArtifacts(result = {}) {
+  if (!isCodeboxLegacyAgentTaskRunResult(result)) {
+    return [];
+  }
+  const artifacts = [];
+  if (typeof result.artifacts === 'string' && result.artifacts) {
+    artifacts.push({
+      id: result.session?.artifacts?.bundle_id || 'wp-codebox-artifacts',
+      kind: 'codebox-artifact-directory',
+      path: result.artifacts,
+      metadata: {
+        session_id: result.session?.id,
+        preview_url: result.session?.artifacts?.preview_url,
+      },
+    });
+  }
+  if (result.session?.artifacts && typeof result.session.artifacts === 'object') {
+    artifacts.push({
+      id: result.session.artifacts.bundle_id || `wp-codebox-session-artifacts-${artifacts.length + 1}`,
+      kind: 'codebox-session-artifacts',
+      url: result.session.artifacts.preview_url,
+      metadata: result.session.artifacts,
+    });
+  }
+  return artifacts;
+}
+
+function legacyAgentTaskRunEvidenceRefs(result = {}) {
+  if (!isCodeboxLegacyAgentTaskRunResult(result)) {
+    return [];
+  }
+  return [
+    result.session?.artifacts?.preview_url ? {
+      kind: 'codebox-preview',
+      uri: result.session.artifacts.preview_url,
+      label: 'WP Codebox preview',
+    } : null,
+    typeof result.artifacts === 'string' && result.artifacts ? {
+      kind: 'codebox-artifact-directory',
+      uri: result.artifacts,
+      label: 'WP Codebox artifacts',
+    } : null,
+  ].filter(Boolean);
+}
+
 function firstValue(...values) {
   return values.find((value) => value !== undefined && value !== null && value !== '');
 }
@@ -79,4 +128,7 @@ module.exports = {
   WP_CODEBOX_RUN_AGENT_TASK_RESULT_SCHEMA,
   codeboxRunAgentTaskInvocation,
   codeboxRunAgentTaskRequestFromTaskInput,
+  isCodeboxLegacyAgentTaskRunResult,
+  legacyAgentTaskRunEvidenceRefs,
+  legacyAgentTaskRunSessionArtifacts,
 };

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -6,6 +6,9 @@ const WP_CODEBOX_PROVIDER_LABEL = 'WP Codebox agent task executor';
 const WP_CODEBOX_BACKEND = 'codebox';
 const WP_CODEBOX_PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA = 'wp-codebox/provider-runtime-invocation-contract/v1';
 const WP_CODEBOX_PROVIDER_CREDENTIAL_BOUNDARY_SCHEMA = 'wp-codebox/provider-credential-boundary/v1';
+const WP_CODEBOX_RECIPE_RUN_CLI_COMMAND = 'recipe-run';
+const WP_CODEBOX_WORKSPACE_MOUNT_KIND = 'homeboy-runtime-workspace';
+const WP_CODEBOX_LEGACY_WORKSPACE_MOUNT_KIND = ['homeboy', 'dmc', 'workspace'].join('-');
 
 const WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES = {
   workspaceCapture: 'wp-codebox.runner-workspace.capture',
@@ -193,6 +196,36 @@ function wpCodeboxProviderRuntimeOperationConfig(key, operation) {
   });
 }
 
+function wpCodeboxLegacyRuntimeComponentAliasFields() {
+  const prefix = ['data', 'machine'].join('_');
+  return {
+    agent_runtime: [prefix, `${prefix}_path`],
+    agent_runtime_tools: [`${prefix}_code`, `${prefix}_code_path`],
+  };
+}
+
+function wpCodeboxLegacyRuntimeComponentAliasValues(config = {}) {
+  const fields = wpCodeboxLegacyRuntimeComponentAliasFields();
+  return Object.fromEntries(Object.entries(fields).map(([canonical, aliases]) => [
+    canonical,
+    firstValue(...aliases.map((alias) => config[alias])),
+  ]));
+}
+
+function wpCodeboxLegacyRuntimeComponentAliasDiagnostics(config = {}) {
+  return Object.entries(wpCodeboxLegacyRuntimeComponentAliasFields()).flatMap(([canonical, aliases]) => aliases
+    .filter((alias) => config[alias] !== undefined)
+    .map((alias) => ({
+      class: 'codebox.compat.deprecated_runtime_component_alias',
+      message: `Deprecated runtime component alias "${alias}" was accepted for compatibility; use "${canonical}" instead.`,
+      data: {
+        alias,
+        replacement: canonical,
+        compatibility: 'accepted-for-current-callers',
+      },
+    })));
+}
+
 function firstValue(...values) {
   return values.find((value) => value !== undefined && value !== null && value !== '');
 }
@@ -215,9 +248,15 @@ module.exports = {
   WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES,
   WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS,
   WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES,
+  WP_CODEBOX_RECIPE_RUN_CLI_COMMAND,
   WP_CODEBOX_ROLE_ALIASES,
   WP_CODEBOX_TASK_REQUEST_SCHEMA,
   WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
+  WP_CODEBOX_WORKSPACE_MOUNT_KIND,
+  WP_CODEBOX_LEGACY_WORKSPACE_MOUNT_KIND,
+  wpCodeboxLegacyRuntimeComponentAliasDiagnostics,
+  wpCodeboxLegacyRuntimeComponentAliasFields,
+  wpCodeboxLegacyRuntimeComponentAliasValues,
   wpCodeboxProviderRuntimeInvocationContract,
   wpCodeboxProviderRuntimeOperationConfig,
   wpCodeboxProviderRuntimeOperationEntry,

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -19,6 +19,9 @@ const {
   providerContract,
 } = require('../../lib/codebox-agent-task-executor');
 const {
+  discoverCodeboxArtifactRefs,
+} = require('../../lib/codebox-artifact-contract');
+const {
   normalizeStringArray,
   providerAuthEnvSources,
   providerDiagnosticClass,
@@ -190,138 +193,10 @@ function providerAuthEnv(taskInput) {
   return env;
 }
 
-function directorySizeBytes(directory) {
-  try {
-    return fs.readdirSync(directory, { withFileTypes: true }).reduce((total, entry) => {
-      const entryPath = path.join(directory, entry.name);
-      if (entry.isDirectory()) {
-        return total + directorySizeBytes(entryPath);
-      }
-      return total + fs.statSync(entryPath).size;
-    }, 0);
-  } catch {
-    return undefined;
-  }
-}
-
-function fileArtifactKind(filePath) {
-  const fileName = path.basename(filePath).toLowerCase();
-  if (fileName === 'manifest.json') {
-    return 'codebox-artifact-manifest';
-  }
-  if (fileName === 'runtime-reference-manifest.json') {
-    return 'codebox-runtime-reference-manifest';
-  }
-  const relative = filePath.replace(/\\/g, '/');
-  if (/transcript|conversation|messages/.test(relative)) {
-    return 'codebox-transcript';
-  }
-  if (/command|stdout|stderr|console|log/.test(relative)) {
-    return 'codebox-command-log';
-  }
-  if (/heartbeat|status/.test(relative)) {
-    return 'codebox-heartbeat';
-  }
-  if (/phase/.test(relative)) {
-    return 'codebox-phase';
-  }
-  return '';
-}
-
-function discoverTimeoutArtifactRefs(artifactsRoot) {
-  if (!artifactsRoot || !fs.existsSync(artifactsRoot)) {
-    return { artifacts: [], evidenceRefs: [], lastKnownPhase: '', lastHeartbeat: null };
-  }
-
-  const discovered = [];
-  const queue = [{ filePath: artifactsRoot, depth: 0 }];
-  let lastKnownPhase = '';
-  let lastHeartbeat = null;
-  let runtimeId = '';
-
-  while (queue.length > 0 && discovered.length < 200) {
-    const { filePath, depth } = queue.shift();
-    let stat;
-    try {
-      stat = fs.statSync(filePath);
-    } catch {
-      continue;
-    }
-
-    if (stat.isDirectory()) {
-      const manifestPath = path.join(filePath, 'manifest.json');
-      if (filePath !== artifactsRoot && fs.existsSync(manifestPath)) {
-        const manifest = readJsonIfAvailable(manifestPath);
-        if (!runtimeId && manifest && typeof manifest === 'object') {
-          runtimeId = manifest.runtime_id || manifest.runtimeId || manifest.runtime?.id || '';
-        }
-        discovered.push({
-          id: manifest?.id || manifest?.artifact_id || `codebox-artifact-bundle-${discovered.length + 1}`,
-          kind: 'codebox-artifact-bundle',
-          path: filePath,
-          size_bytes: directorySizeBytes(filePath),
-          metadata: manifest && typeof manifest === 'object' ? {
-            schema: manifest.schema,
-            phase: manifest.phase || manifest.last_phase || manifest.current_phase,
-            runtime_id: manifest.runtime_id || manifest.runtimeId || manifest.runtime?.id,
-          } : {},
-        });
-      }
-      if (depth < 4) {
-        for (const entry of fs.readdirSync(filePath).sort()) {
-          queue.push({ filePath: path.join(filePath, entry), depth: depth + 1 });
-        }
-      }
-      continue;
-    }
-
-    if (!stat.isFile()) {
-      continue;
-    }
-
-    const kind = fileArtifactKind(path.relative(artifactsRoot, filePath));
-    if (!kind) {
-      continue;
-    }
-    const payload = filePath.endsWith('.json') ? readJsonIfAvailable(filePath) : null;
-    if (!lastKnownPhase && payload && typeof payload === 'object') {
-      lastKnownPhase = payload.phase || payload.last_phase || payload.lastKnownPhase || payload.current_phase || '';
-    }
-    if (!runtimeId && payload && typeof payload === 'object') {
-      runtimeId = payload.runtime_id || payload.runtimeId || payload.runtime?.id || '';
-    }
-    if (!lastHeartbeat && payload && typeof payload === 'object' && /heartbeat|status/i.test(filePath)) {
-      lastHeartbeat = payload.heartbeat || payload.last_heartbeat || payload;
-    }
-    discovered.push({
-      id: `${kind}-${discovered.length + 1}`,
-      kind,
-      path: filePath,
-      size_bytes: stat.size,
-      metadata: payload && typeof payload === 'object' ? {
-        schema: payload.schema,
-        phase: payload.phase || payload.last_phase || payload.current_phase,
-      } : {},
-    });
-  }
-
-  return {
-    artifacts: discovered,
-    evidenceRefs: discovered.map((artifact) => ({
-      kind: artifact.kind,
-      uri: artifact.path,
-      label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
-    })),
-    runtimeId,
-    lastKnownPhase,
-    lastHeartbeat,
-  };
-}
-
 function timeoutPayload(timeoutMs, request = {}) {
   const artifacts = argValue('--artifacts') || request.executor?.config?.artifacts || '';
   const evidencePath = artifacts ? `${artifacts}/homeboy-codebox-task-runner.json` : '';
-  const discovered = discoverTimeoutArtifactRefs(artifacts);
+  const discovered = discoverCodeboxArtifactRefs(artifacts);
   const knownArtifacts = [];
   if (artifacts) {
     knownArtifacts.push({

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -14,9 +14,15 @@ const {
 	WP_CODEBOX_PROVIDER_RUNTIME_OPERATION_ALIASES,
 	WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS,
 	WP_CODEBOX_PROVIDER_RUNTIME_TASK_NAMES,
+	WP_CODEBOX_RECIPE_RUN_CLI_COMMAND,
 	WP_CODEBOX_ROLE_ALIASES,
 	WP_CODEBOX_TASK_REQUEST_SCHEMA,
 	WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
+	WP_CODEBOX_WORKSPACE_MOUNT_KIND,
+	WP_CODEBOX_LEGACY_WORKSPACE_MOUNT_KIND,
+	wpCodeboxLegacyRuntimeComponentAliasDiagnostics,
+	wpCodeboxLegacyRuntimeComponentAliasFields,
+	wpCodeboxLegacyRuntimeComponentAliasValues,
 	wpCodeboxProviderRuntimeInvocationContract,
 	wpCodeboxProviderRuntimeOperationConfig,
 	wpCodeboxProviderRuntimeOperationEntry,
@@ -27,6 +33,9 @@ assert.equal(WP_CODEBOX_PROVIDER_ID, 'wordpress.codebox-agent-task-executor');
 assert.equal(WP_CODEBOX_PROVIDER_LABEL, 'WP Codebox agent task executor');
 assert.equal(WP_CODEBOX_PROVIDER_CREDENTIAL_BOUNDARY_SCHEMA, 'wp-codebox/provider-credential-boundary/v1');
 assert.equal(WP_CODEBOX_TASK_REQUEST_SCHEMA, 'wp-codebox/task-input/v1');
+assert.equal(WP_CODEBOX_RECIPE_RUN_CLI_COMMAND, 'recipe-run');
+assert.equal(WP_CODEBOX_WORKSPACE_MOUNT_KIND, 'homeboy-runtime-workspace');
+assert.equal(WP_CODEBOX_LEGACY_WORKSPACE_MOUNT_KIND, ['homeboy', 'dmc', 'workspace'].join('-'));
 
 const invocationContract = wpCodeboxProviderRuntimeInvocationContract();
 assert.equal(invocationContract.schema, 'wp-codebox/provider-runtime-invocation-contract/v1');
@@ -72,6 +81,23 @@ assert.deepEqual(WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.map((requirement) =>
 assert.equal(
 	WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.find((requirement) => requirement.id === 'artifact-result-envelope').adapter_behavior,
 	'consume_canonical_envelope_with_legacy_package_fallback'
+);
+
+const legacyRuntimeAliasPrefix = ['data', 'machine'].join('_');
+assert.deepEqual(wpCodeboxLegacyRuntimeComponentAliasFields(), {
+	agent_runtime: [legacyRuntimeAliasPrefix, `${legacyRuntimeAliasPrefix}_path`],
+	agent_runtime_tools: [`${legacyRuntimeAliasPrefix}_code`, `${legacyRuntimeAliasPrefix}_code_path`],
+});
+assert.deepEqual(wpCodeboxLegacyRuntimeComponentAliasValues({
+	[legacyRuntimeAliasPrefix]: '/runtime',
+	[`${legacyRuntimeAliasPrefix}_code_path`]: '/runtime-tools',
+}), {
+	agent_runtime: '/runtime',
+	agent_runtime_tools: '/runtime-tools',
+});
+assert.deepEqual(
+	wpCodeboxLegacyRuntimeComponentAliasDiagnostics({ [`${legacyRuntimeAliasPrefix}_path`]: '/runtime' }).map((diagnostic) => diagnostic.data.replacement),
+	['agent_runtime']
 );
 
 console.log('wp-codebox adapter contract smoke passed');

--- a/tests/wp-codebox-run-agent-task-contract-smoke.mjs
+++ b/tests/wp-codebox-run-agent-task-contract-smoke.mjs
@@ -9,11 +9,15 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const {
 	WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND,
 	WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA,
+	WP_CODEBOX_AGENT_TASK_RUN_RESPONSE_SCHEMA,
 	WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND,
 	WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
 	WP_CODEBOX_RUN_AGENT_TASK_RESULT_SCHEMA,
 	codeboxRunAgentTaskInvocation,
 	codeboxRunAgentTaskRequestFromTaskInput,
+	isCodeboxLegacyAgentTaskRunResult,
+	legacyAgentTaskRunEvidenceRefs,
+	legacyAgentTaskRunSessionArtifacts,
 } = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox'));
 
 const taskInput = {
@@ -61,5 +65,48 @@ assert.throws(
 	() => codeboxRunAgentTaskRequestFromTaskInput({ schema: 'wp-codebox/not-task-input/v1' }),
 	/wp-codebox\/task-input\/v1/
 );
+
+const legacyResult = {
+	schema: WP_CODEBOX_AGENT_TASK_RUN_RESPONSE_SCHEMA,
+	artifacts: '/tmp/artifacts',
+	session: {
+		id: 'session-1',
+		artifacts: {
+			bundle_id: 'bundle-1',
+			preview_url: 'https://preview.example.test',
+		},
+	},
+};
+assert.equal(isCodeboxLegacyAgentTaskRunResult(legacyResult), true);
+assert.equal(isCodeboxLegacyAgentTaskRunResult({ schema: WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA }), false);
+assert.deepEqual(legacyAgentTaskRunSessionArtifacts(legacyResult), [
+	{
+		id: 'bundle-1',
+		kind: 'codebox-artifact-directory',
+		path: '/tmp/artifacts',
+		metadata: {
+			session_id: 'session-1',
+			preview_url: 'https://preview.example.test',
+		},
+	},
+	{
+		id: 'bundle-1',
+		kind: 'codebox-session-artifacts',
+		url: 'https://preview.example.test',
+		metadata: legacyResult.session.artifacts,
+	},
+]);
+assert.deepEqual(legacyAgentTaskRunEvidenceRefs(legacyResult), [
+	{
+		kind: 'codebox-preview',
+		uri: 'https://preview.example.test',
+		label: 'WP Codebox preview',
+	},
+	{
+		kind: 'codebox-artifact-directory',
+		uri: '/tmp/artifacts',
+		label: 'WP Codebox artifacts',
+	},
+]);
 
 console.log('wp-codebox run-agent-task contract smoke passed');

--- a/wordpress/lib/wp-codebox-recipe-helper.js
+++ b/wordpress/lib/wp-codebox-recipe-helper.js
@@ -9,6 +9,9 @@ const path = require('node:path');
 const { promisify } = require('node:util');
 
 const execFileAsync = promisify(execFile);
+const {
+  WP_CODEBOX_RECIPE_RUN_CLI_COMMAND,
+} = require('../../agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract');
 const DEFAULT_MAX_BUFFER = 1024 * 1024 * 50;
 const DEFAULT_EVENT_SOURCE = 'wp_codebox';
 const DEFAULT_EVENT_PREFIX = 'recipe';
@@ -140,7 +143,7 @@ async function runWpCodeboxRecipe({
   const { command, args } = wpCodeboxCommand(resolvedBin);
   const commandArgs = [
     ...args,
-    'recipe-run',
+    WP_CODEBOX_RECIPE_RUN_CLI_COMMAND,
     '--recipe',
     recipeFile,
     '--artifacts',

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -9,6 +9,7 @@ const {
   agentTaskOutcomeFromCodeboxResult,
   artifactResultEnvelopeFromCodeboxResult,
   codeboxTaskRequestFromAgentTaskRequest,
+  discoverCodeboxArtifactRefs,
   normalizeCodeboxArtifactDeclaration,
   normalizeCodeboxArtifactOutcome,
   providerContract,
@@ -116,6 +117,33 @@ assert.deepEqual(typedArtifactsFromCodeboxResult({ artifact_result: artifactResu
 assert.equal(normalizeCodeboxArtifactOutcome({ id: 'patch.diff', kind: 'codebox-patch' }, {}, {
   roleAliases: provider.role_aliases,
 }).role, 'patch');
+
+const artifactDiscoveryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-artifacts-'));
+const artifactBundleRoot = path.join(artifactDiscoveryRoot, 'bundle');
+fs.mkdirSync(path.join(artifactDiscoveryRoot, 'logs'), { recursive: true });
+fs.mkdirSync(artifactBundleRoot, { recursive: true });
+fs.writeFileSync(path.join(artifactBundleRoot, 'manifest.json'), JSON.stringify({
+  id: 'bundle-1',
+  runtime_id: 'wp-codebox',
+  phase: 'agent-task-run',
+}));
+fs.writeFileSync(path.join(artifactDiscoveryRoot, 'logs', 'heartbeat.json'), JSON.stringify({
+  runtime_id: 'wp-codebox',
+  current_phase: 'running',
+  heartbeat: { sequence: 3 },
+}));
+fs.writeFileSync(path.join(artifactDiscoveryRoot, 'transcript.json'), JSON.stringify({ schema: 'example/transcript/v1' }));
+const discoveredCodeboxArtifacts = discoverCodeboxArtifactRefs(artifactDiscoveryRoot);
+assert.equal(discoveredCodeboxArtifacts.runtimeId, 'wp-codebox');
+assert.equal(discoveredCodeboxArtifacts.lastKnownPhase, 'agent-task-run');
+assert.deepEqual(discoveredCodeboxArtifacts.lastHeartbeat, { sequence: 3 });
+assert.deepEqual(discoveredCodeboxArtifacts.artifacts.map((artifact) => artifact.kind).sort(), [
+  'codebox-artifact-bundle',
+  'codebox-artifact-manifest',
+  'codebox-command-log',
+  'codebox-transcript',
+]);
+assert.equal(discoveredCodeboxArtifacts.evidenceRefs.length, 4);
 
 const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'wordpress.json'), 'utf8'));
 assert.equal(manifest.agent_task_executors, undefined);

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -2571,6 +2571,9 @@ try {
   providerPluginValidation() { return null; },
   providerSecretEnv() { return []; },
 };\n`);
+  fs.writeFileSync(path.join(installedRuntime, 'lib', 'codebox-artifact-contract.js'), `module.exports = {
+  discoverCodeboxArtifactRefs() { return { artifacts: [], evidenceRefs: [], runtimeId: '', lastKnownPhase: '', lastHeartbeat: null }; },
+};\n`);
   fs.writeFileSync(path.join(installedLayoutRoot, 'extensions', 'wordpress', 'lib', 'wp-codebox-core-loader.js'), `module.exports = { async loadWpCodeboxCore() { return {}; } };\n`);
   const installedLayoutResult = spawnSync(process.execPath, [path.join(installedRuntime, 'scripts', 'agent', 'homeboy-codebox-agent-task-executor.cjs')], {
     encoding: 'utf8',


### PR DESCRIPTION
## Summary
- centralize Codebox adapter boundary constants, legacy workspace mount metadata, recipe-run command naming, and deprecated runtime component alias compatibility
- route legacy agent-task-run result schema checks plus session artifact/evidence extraction through the run-agent-task contract module
- keep existing executor/task-runner behavior while quarantining legacy compatibility details behind adapter modules

## Verification
- `node tests/wp-codebox-adapter-contract-smoke.mjs`
- `node tests/wp-codebox-run-agent-task-contract-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node wordpress/tests/wp-codebox-recipe-helper-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5/OpenCode
- **Used for:** Adapter seam refactor, tests, verification, and PR drafting.