### PR TITLE
Emit valid WordPress bench artifact refs

### DIFF
--- a/wordpress/scripts/bench/lib/wordpress-bench-artifacts.php
+++ b/wordpress/scripts/bench/lib/wordpress-bench-artifacts.php
@@ -46,10 +46,10 @@ if ( ! function_exists('homeboy_bench_write_json_artifact') ) {
 		}
 
 		return array(
-			'path'      => $relative_path,
-			'kind'      => 'json',
-			'label'     => $name,
-			'mime_type' => 'application/json',
+			'path'        => $relative_path,
+			'kind'        => 'json',
+			'name'        => $name,
+			'contentType' => 'application/json',
 		);
 	}
 }

--- a/wordpress/tests/wordpress-bench-artifact-helper-smoke.php
+++ b/wordpress/tests/wordpress-bench-artifact-helper-smoke.php
@@ -18,10 +18,10 @@ $descriptor = homeboy_bench_write_json_artifact('Scenario One', 'step-series', a
 ));
 
 $expected_descriptor = array(
-	'path'      => 'artifacts/scenario-one/step-series.json',
-	'kind'      => 'json',
-	'label'     => 'step-series',
-	'mime_type' => 'application/json',
+	'path'        => 'artifacts/scenario-one/step-series.json',
+	'kind'        => 'json',
+	'name'        => 'step-series',
+	'contentType' => 'application/json',
 );
 if ( $expected_descriptor !== $descriptor ) {
 	fwrite(STDERR, "Expected standard artifact descriptor.\n");


### PR DESCRIPTION
## Summary
- Return `name` and `contentType` from `homeboy_bench_write_json_artifact()` so workload artifact refs satisfy the WP Codebox bench-results schema.
- Update the helper smoke test to cover the schema-compatible descriptor shape.

## Verification
- `php wordpress/tests/wordpress-bench-artifact-helper-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the SSI bench-results artifact schema mismatch, drafting the helper fix, and running targeted verification.
