### PR TITLE
Keep WordPress recipe helper self-contained

### DIFF
--- a/wordpress/lib/wp-codebox-recipe-helper.js
+++ b/wordpress/lib/wp-codebox-recipe-helper.js
@@ -9,9 +9,7 @@ const path = require('node:path');
 const { promisify } = require('node:util');
 
 const execFileAsync = promisify(execFile);
-const {
-  WP_CODEBOX_RECIPE_RUN_CLI_COMMAND,
-} = require('../../agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract');
+const WP_CODEBOX_RECIPE_RUN_CLI_COMMAND = 'recipe-run';
 const DEFAULT_MAX_BUFFER = 1024 * 1024 * 50;
 const DEFAULT_EVENT_SOURCE = 'wp_codebox';
 const DEFAULT_EVENT_PREFIX = 'recipe';


### PR DESCRIPTION
## Summary
- Remove the WordPress extension helper's runtime require of repo-root `agent-runtimes/wp-codebox` code.
- Keep the `recipe-run` CLI command constant local so installed WordPress extension packages work without repo-root runtime files.

## Verification
- `node wordpress/tests/wp-codebox-recipe-helper-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the installed WordPress extension packaging failure, drafting the self-contained helper fix, and running targeted verification.
