### PR TITLE
Emit portable WordPress bench artifact refs

### DIFF
--- a/wordpress/scripts/bench/lib/wordpress-bench-artifacts.php
+++ b/wordpress/scripts/bench/lib/wordpress-bench-artifacts.php
@@ -46,10 +46,9 @@ if ( ! function_exists('homeboy_bench_write_json_artifact') ) {
 		}
 
 		return array(
-			'path'        => $relative_path,
-			'kind'        => 'json',
-			'name'        => $name,
-			'contentType' => 'application/json',
+			'path' => $relative_path,
+			'kind' => 'json',
+			'name' => $name,
 		);
 	}
 }

--- a/wordpress/tests/wordpress-bench-artifact-helper-smoke.php
+++ b/wordpress/tests/wordpress-bench-artifact-helper-smoke.php
@@ -18,10 +18,9 @@ $descriptor = homeboy_bench_write_json_artifact('Scenario One', 'step-series', a
 ));
 
 $expected_descriptor = array(
-	'path'        => 'artifacts/scenario-one/step-series.json',
-	'kind'        => 'json',
-	'name'        => 'step-series',
-	'contentType' => 'application/json',
+	'path' => 'artifacts/scenario-one/step-series.json',
+	'kind' => 'json',
+	'name' => 'step-series',
 );
 if ( $expected_descriptor !== $descriptor ) {
 	fwrite(STDERR, "Expected standard artifact descriptor.\n");


### PR DESCRIPTION
## Summary
- Omit optional `contentType` from generic WordPress bench JSON artifact refs.
- Keep refs to the portable `path` / `kind` / `name` shape accepted by both WP Codebox bench schema and Homeboy's bench parser.

## Verification
- `php wordpress/tests/wordpress-bench-artifact-helper-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing Homeboy parser compatibility after the SSI fixture proof run, drafting the portable artifact ref fix, and running targeted verification.
