### PR TITLE
Move runtime config projections behind adapters

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -15,9 +15,6 @@ const {
 } = require('./lib/common.cjs');
 const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 const {
-  normalizeCodeboxArtifactDeclaration,
-} = require('../../../agent-runtimes/wp-codebox/lib/codebox-artifact-contract');
-const {
   runtimeAgentCiFirstNonEmptyArray,
   runtimeAgentCiFirstNonEmptyObject,
   runtimeAgentCiTaskFromRequest,
@@ -67,7 +64,7 @@ function buildConfig(env) {
 
   const runtimeTask = runtimeTaskFromEnv(env);
   const runtimeExecution = parseJsonInput('runtime_execution', env.RUNTIME_EXECUTION || '{}', 'object', {});
-  const workload = codeboxWorkloadFromEnv(env, workloadId);
+  const workload = runtimeWorkloadFromEnv(env, workloadId);
   const toolProfile = parseJsonInput('tool_profile', env.TOOL_PROFILE || env.TOOL_POLICY || '{}', 'object', {});
   const runtimeOutputProjections = runtimeAgentCiFirstNonEmptyObject(
     parseJsonInput('runtime_output_projections', env.RUNTIME_OUTPUT_PROJECTIONS || '{}', 'object', {}),
@@ -109,8 +106,15 @@ function buildConfig(env) {
   const effectiveRunnerWorkspace = runnerWorkspace.enabled === true ? { ...runnerWorkspace, checkout_path: runnerWorkspaceGuestCheckout } : runnerWorkspace;
   const appTokenRepos = splitCsv(env.APP_TOKEN_REPOS || targetRepo);
   const allowedRepos = parseJsonInput('allowed_repos', env.ALLOWED_REPOS || '[]', 'array', []);
-  const transcriptHostDir = path.join(workspace, 'runtime-agent-artifacts', workloadId);
-  const transcriptGuestDir = `/wordpress/wp-content/plugins/${componentId}/runtime-agent-artifacts/${workloadId}`;
+  const runtimeProjection = projectRuntimeConfig({
+    env,
+    runtime,
+    workspace,
+    componentId,
+    componentPath,
+    workloadId,
+    runnerWorkspaceGuestCheckout,
+  });
 
   return {
     ...runtimeConfig,
@@ -125,13 +129,13 @@ function buildConfig(env) {
     runtime_profile: runtimeProfile,
     runtime_profiles: effectiveRuntimeProfiles,
     runtime_ref: env.RUNTIME_REF || 'main',
-    runtime_wordpress_version: env.RUNTIME_WORDPRESS_VERSION || '7.0',
+    ...runtimeProjection.runtime_fields,
     execution_kind: env.EXECUTION_KIND || (runtimeTask ? 'runtime_task' : 'runtime_execution'),
     runtime_mounts: [
       ...normalizePathSources(parseJsonInput('runtime_mounts', env.RUNTIME_MOUNTS || '[]', 'array', []), workspace),
       ...runnerWorkspaceMounts,
     ],
-    wp_config_defines: parseJsonInput('extra_wp_config_defines', env.EXTRA_WP_CONFIG_DEFINES || '{}', 'object', {}),
+    wp_config_defines: runtimeProjection.wp_config_defines,
     runtime_overlays: runtimeOverlays,
     workload_run_before: parseJsonInput('workload_run_before', env.WORKLOAD_RUN_BEFORE || '[]', 'array', []),
     workload_run_after: parseJsonInput('workload_run_after', env.WORKLOAD_RUN_AFTER || '[]', 'array', []),
@@ -168,7 +172,7 @@ function buildConfig(env) {
     step_budget: Number(env.STEP_BUDGET || 16),
     time_budget_ms: Number(env.TIME_BUDGET_MS || 600000),
     expected_artifacts: parseJsonInput('expected_artifacts', env.EXPECTED_ARTIFACTS || '[]', 'array', []),
-    artifact_declarations: artifactDeclarationsFromEnv(env, runtime),
+    artifact_declarations: runtimeProjection.artifact_declarations,
     sandbox_tool_policy: renderedRuntimeInputs.workflow_inputs.sandbox_tool_policy,
     output_mappings: parseJsonInput('output_mappings', env.OUTPUT_MAPPINGS || '{}', 'object', {}),
     runtime_output_projections: runtimeOutputProjections,
@@ -199,8 +203,8 @@ function buildConfig(env) {
       ...parseJsonInput('artifact_export_config', env.ARTIFACT_EXPORT_CONFIG || '{}', 'object', {}),
     },
     dry_run: env.DRY_RUN === 'true',
-    transcript_dir: transcriptGuestDir,
-    transcript_host_dir: transcriptHostDir,
+    transcript_dir: runtimeProjection.transcript_dir,
+    transcript_host_dir: runtimeProjection.transcript_host_dir,
     bench_env: {
       GITHUB_TOKEN: env.GITHUB_REPOSITORY_TOKEN_VALUE || '',
       HOMEBOY_GITHUB_APP_TOKEN: env.GITHUB_APP_TOKEN_VALUE || '',
@@ -212,19 +216,9 @@ function buildConfig(env) {
   };
 }
 
-function codeboxWorkloadFromEnv(env, fallbackId) {
+function runtimeWorkloadFromEnv(env, fallbackId) {
   const workload = parseJsonInput('workload', env.WORKLOAD || '{}', 'object', {});
   return Object.keys(workload).length > 0 ? workload : { id: fallbackId };
-}
-
-function artifactDeclarationsFromEnv(env, runtime) {
-  const declarations = parseJsonInput('artifact_declarations', env.ARTIFACT_DECLARATIONS || '[]', 'array', []);
-  if (!isCodeboxRuntime(runtime)) {
-    return declarations;
-  }
-  return declarations
-    .map((declaration, index) => normalizeCodeboxArtifactDeclaration(`artifact_${index + 1}`, declaration))
-    .filter(Boolean);
 }
 
 function validationPaths(workspace, providerPlugin, provider) {
@@ -259,13 +253,111 @@ function runtimeTaskFromEnv(env) {
   );
 }
 
-function isCodeboxRuntime(runtime) {
-  return runtime?.id === 'wp-codebox' || runtime?.executor?.backend === 'codebox';
-}
-
 function runtimePathRequired(runtime, pathName) {
   const requiredPaths = runtime?.manifest?.ci_materialization?.required_paths;
-  return isCodeboxRuntime(runtime) || (Array.isArray(requiredPaths) && requiredPaths.includes(pathName));
+  return Array.isArray(requiredPaths) && requiredPaths.includes(pathName);
+}
+
+function projectRuntimeConfig({ env, runtime, workspace, componentId, componentPath, workloadId, runnerWorkspaceGuestCheckout }) {
+  const projection = runtime?.manifest?.runner_config_projection || {};
+  const artifactDeclarations = parseJsonInput('artifact_declarations', env.ARTIFACT_DECLARATIONS || '[]', 'array', []);
+  const context = {
+    component_id: componentId,
+    component_path: componentPath,
+    workload_id: workloadId,
+    workspace,
+    runner_workspace_guest_checkout: runnerWorkspaceGuestCheckout,
+  };
+  const manifestProjection = {
+    artifact_declarations: artifactDeclarations,
+    transcript_host_dir: renderTemplate(
+      projection.transcript_host_dir_template,
+      context,
+      path.join(workspace, 'runtime-agent-artifacts', workloadId)
+    ),
+    transcript_dir: renderTemplate(
+      projection.transcript_guest_dir_template,
+      context,
+      `${runnerWorkspaceGuestCheckout}/runtime-agent-artifacts/${workloadId}`
+    ),
+    wp_config_defines: {
+      ...(plainObject(projection.wp_config_defines) ? projection.wp_config_defines : {}),
+      ...parseJsonInput('extra_wp_config_defines', env.EXTRA_WP_CONFIG_DEFINES || '{}', 'object', {}),
+    },
+    runtime_fields: runtimeFieldsFromProjection(projection.runtime_fields, env),
+  };
+  const adapter = runtimeProjectionAdapter(runtime, projection);
+  if (!adapter) {
+    return manifestProjection;
+  }
+  const adapterProjection = adapter({
+    env,
+    runtime,
+    workspace,
+    componentId,
+    componentPath,
+    workloadId,
+    runnerWorkspaceGuestCheckout,
+    artifactDeclarations,
+    manifestProjection,
+  });
+  return mergeProjection(manifestProjection, adapterProjection);
+}
+
+function runtimeProjectionAdapter(runtime, projection) {
+  const adapter = projection.adapter;
+  if (!plainObject(adapter) || !adapter.module) {
+    return null;
+  }
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  const adapterPath = path.resolve(repoRoot, adapter.module);
+  const loaded = require(adapterPath);
+  const exportName = adapter.export || 'projectRuntimeConfig';
+  if (typeof loaded[exportName] !== 'function') {
+    throw new Error(`Runtime ${runtime.id} projection adapter ${adapter.module} does not export ${exportName}`);
+  }
+  return loaded[exportName];
+}
+
+function runtimeFieldsFromProjection(fields, env) {
+  if (!plainObject(fields)) {
+    return {};
+  }
+  return Object.fromEntries(Object.entries(fields).map(([key, definition]) => {
+    if (plainObject(definition)) {
+      return [key, env[definition.env] || definition.default];
+    }
+    return [key, definition];
+  }).filter(([, value]) => value !== undefined && value !== ''));
+}
+
+function mergeProjection(base, override) {
+  if (!plainObject(override)) {
+    return base;
+  }
+  return {
+    ...base,
+    ...override,
+    wp_config_defines: {
+      ...base.wp_config_defines,
+      ...(plainObject(override.wp_config_defines) ? override.wp_config_defines : {}),
+    },
+    runtime_fields: {
+      ...base.runtime_fields,
+      ...(plainObject(override.runtime_fields) ? override.runtime_fields : {}),
+    },
+  };
+}
+
+function renderTemplate(template, values, fallback) {
+  if (typeof template !== 'string' || template.length === 0) {
+    return fallback;
+  }
+  return template.replace(/\{([a-zA-Z0-9_]+)\}/g, (_match, key) => values[key] || '');
+}
+
+function plainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
 }
 
 function withoutInternalKeys(config) {
@@ -288,4 +380,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, isCodeboxRuntime, runtimePathRequired };
+module.exports = { buildConfig, projectRuntimeConfig, runtimePathRequired };

--- a/agent-runtimes/wp-codebox/lib/runtime-config-projection.js
+++ b/agent-runtimes/wp-codebox/lib/runtime-config-projection.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const {
+  normalizeCodeboxArtifactDeclaration,
+} = require('./codebox-artifact-contract');
+
+function projectRuntimeConfig({ artifactDeclarations = [], manifestProjection = {} } = {}) {
+  return {
+    ...manifestProjection,
+    artifact_declarations: artifactDeclarations
+      .map((declaration, index) => normalizeCodeboxArtifactDeclaration(`artifact_${index + 1}`, declaration))
+      .filter(Boolean),
+  };
+}
+
+module.exports = { projectRuntimeConfig };

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -10,6 +10,19 @@
       "export": "scenarioResultsFromOutcome"
     }
   },
+  "runner_config_projection": {
+    "adapter": {
+      "module": "agent-runtimes/wp-codebox/lib/runtime-config-projection.js",
+      "export": "projectRuntimeConfig"
+    },
+    "transcript_guest_dir_template": "/wordpress/wp-content/plugins/{component_id}/runtime-agent-artifacts/{workload_id}",
+    "runtime_fields": {
+      "runtime_wordpress_version": {
+        "env": "RUNTIME_WORDPRESS_VERSION",
+        "default": "7.0"
+      }
+    }
+  },
   "ci_materialization": {
     "checkout": {
       "repo": "Automattic/wp-codebox",
@@ -36,7 +49,8 @@
       "runtime_bin": ".ci/wp-codebox/packages/cli/dist/index.js",
       "runtime_component": ".ci/wp-codebox/packages/wordpress-plugin",
       "runtime_core_module": ".ci/wp-codebox/packages/runtime-core/dist/index.js"
-    }
+    },
+    "required_paths": ["runtime_bin"]
   },
   "agent_task_executors": [
     {

--- a/tests/runtime-agent-full-run-projection-boundary-smoke.mjs
+++ b/tests/runtime-agent-full-run-projection-boundary-smoke.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { buildConfig, projectRuntimeConfig } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/build-runner-config.cjs'));
+
+const genericProjection = projectRuntimeConfig({
+  env: {
+    ARTIFACT_DECLARATIONS: JSON.stringify([{ name: 'packet', kind: 'application/vnd.example.packet+json' }]),
+    EXTRA_WP_CONFIG_DEFINES: JSON.stringify({ EXAMPLE_DEFINE: true }),
+  },
+  runtime: {
+    id: 'generic-runtime',
+    manifest: {
+      schema: 'homeboy/agent-runtime-manifest/v1',
+      id: 'generic-runtime',
+      runner_config_projection: {
+        transcript_guest_dir_template: '/runtime/{workload_id}/transcript',
+        wp_config_defines: { GENERIC_DEFINE: 'yes' },
+        runtime_fields: {
+          runtime_example_version: { env: 'RUNTIME_EXAMPLE_VERSION', default: '1.0' },
+        },
+      },
+    },
+  },
+  workspace: '/tmp/workspace',
+  componentId: 'example-component',
+  componentPath: '/tmp/workspace',
+  workloadId: 'projection-smoke',
+  runnerWorkspaceGuestCheckout: '/workspace/example-component',
+});
+
+assert.deepEqual(genericProjection.artifact_declarations, [
+  { name: 'packet', kind: 'application/vnd.example.packet+json' },
+]);
+assert.equal(genericProjection.transcript_dir, '/runtime/projection-smoke/transcript');
+assert.equal(genericProjection.transcript_dir.includes('/wordpress/wp-content/plugins'), false);
+assert.deepEqual(genericProjection.wp_config_defines, { GENERIC_DEFINE: 'yes', EXAMPLE_DEFINE: true });
+assert.deepEqual(genericProjection.runtime_fields, { runtime_example_version: '1.0' });
+
+const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-projection-'));
+const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-projection-runner-'));
+fs.mkdirSync(path.join(workspace, '.ci/wp-codebox/packages/cli/dist'), { recursive: true });
+fs.writeFileSync(path.join(workspace, '.ci/wp-codebox/packages/cli/dist/index.js'), '#!/usr/bin/env node\n');
+
+const codeboxConfig = buildConfig({
+  GITHUB_WORKSPACE: workspace,
+  RUNNER_TEMP: runnerTemp,
+  WORKLOAD_ID: 'codebox-projection',
+  COMPONENT_ID: 'example',
+  TARGET_REPO: 'Extra-Chill/example',
+  RUNTIME: 'wp-codebox',
+  PROFILE: 'codebox-profile',
+  ARTIFACT_DECLARATIONS: JSON.stringify([
+    { name: 'packet', kind: 'application/vnd.example.packet+json', required: true },
+    'transcript',
+  ]),
+  EXTRA_WP_CONFIG_DEFINES: JSON.stringify({ CODEBOX_DEFINE: true }),
+});
+
+assert.deepEqual(codeboxConfig.artifact_declarations, [
+  {
+    schema: 'wp-codebox/artifact-declaration/v1',
+    name: 'packet',
+    type: 'application/vnd.example.packet+json',
+    required: true,
+  },
+  {
+    schema: 'wp-codebox/artifact-declaration/v1',
+    name: 'transcript',
+    required: true,
+  },
+]);
+assert.equal(codeboxConfig.transcript_dir, '/wordpress/wp-content/plugins/example/runtime-agent-artifacts/codebox-projection');
+assert.deepEqual(codeboxConfig.wp_config_defines, { CODEBOX_DEFINE: true });
+assert.equal(codeboxConfig.runtime_wordpress_version, '7.0');
+
+console.log('runtime agent full-run projection boundary smoke passed');


### PR DESCRIPTION
## Summary
- Move runtime-agent full-run config projections behind runtime manifest declarations and optional adapter hooks.
- Remove direct WP Codebox artifact normalizer imports and hardcoded WordPress transcript guest paths from the generic config builder.
- Add a WP Codebox runtime config projection adapter that owns Codebox artifact declaration normalization and declares Codebox-specific transcript/runtime fields in its manifest.
- Add focused coverage proving generic projection stays runtime-neutral while WP Codebox projection applies the Codebox adapter.

## Verification
- `node tests/runtime-agent-full-run-projection-boundary-smoke.mjs`
- `node tests/runtime-agent-full-run-codebox-inputs-smoke.mjs`
- `node tests/runtime-provider-resolver-smoke.mjs`
- `bash tests/runtime-agent-full-run-boundary-smoke.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting runtime config boundaries, implementing the projection adapter boundary, adding focused smoke coverage, and drafting this PR description.
