### PR TITLE
Expand generic WordPress fuzz coverage artifacts

### DIFF
--- a/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
+++ b/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
@@ -1,5 +1,8 @@
 'use strict';
 
+/**
+ * Internal dependencies
+ */
 const {
 	WORDPRESS_FUZZ_PLAN_SCHEMA,
 	WORDPRESS_SURFACE_DISCOVERY_SCHEMA,
@@ -13,17 +16,32 @@ const SURFACE_COLLECTION_KEYS = [
 	'cron',
 	'cron_events',
 	'cronEvents',
+	'capabilities',
+	'database',
+	'db',
+	'databaseTables',
+	'database_tables',
+	'dbQueries',
+	'db_queries',
 	'options',
 	'post_types',
 	'postTypes',
 	'taxonomies',
 	'media',
 	'users',
+	'roles',
 	'blocks',
 	'frontend',
 	'frontendUrls',
+	'frontend_urls',
 	'admin',
 	'adminPages',
+	'admin_pages',
+	'externalHttp',
+	'external_http',
+	'http',
+	'httpRequests',
+	'http_requests',
 	'rest',
 	'restRoutes',
 	'routes',
@@ -89,8 +107,20 @@ function appendSurfaceMap(surfaces, value, defaultType) {
 	if (defaultType === 'rest-route') {
 		appendSurfaceMap(surfaces, value.routes, 'rest-route');
 	}
+	if (defaultType === 'database-table') {
+		appendSurfaceMap(surfaces, value.tables, 'database-table');
+		appendSurfaceMap(surfaces, value.queries, 'db-query');
+	}
+	if (defaultType === 'external-http') {
+		appendSurfaceMap(surfaces, value.requests, 'external-http');
+	}
 	for (const [key, item] of Object.entries(value)) {
-		if ((defaultType === 'hook' && ['actions', 'filters'].includes(key)) || (defaultType === 'rest-route' && key === 'routes')) {
+		if (
+			(defaultType === 'hook' && ['actions', 'filters'].includes(key))
+			|| (defaultType === 'rest-route' && key === 'routes')
+			|| (defaultType === 'database-table' && ['tables', 'queries'].includes(key))
+			|| (defaultType === 'external-http' && key === 'requests')
+		) {
 			continue;
 		}
 		surfaces.push(surfaceFromValue(isObject(item) ? { id: key, name: key, ...item } : { id: key, name: key, value: item }, defaultType));
@@ -110,17 +140,32 @@ function surfaceTypeFromCollectionKey(key) {
 		cron: 'cron-event',
 		cron_events: 'cron-event',
 		cronEvents: 'cron-event',
+		capabilities: 'capability',
+		database: 'database-table',
+		db: 'database-table',
+		databaseTables: 'database-table',
+		database_tables: 'database-table',
+		dbQueries: 'db-query',
+		db_queries: 'db-query',
 		options: 'option',
 		post_types: 'post-type',
 		postTypes: 'post-type',
 		taxonomies: 'taxonomy',
 		media: 'media',
 		users: 'user',
+		roles: 'role',
 		blocks: 'block',
 		frontend: 'frontend-url',
 		frontendUrls: 'frontend-url',
+		frontend_urls: 'frontend-url',
 		admin: 'admin-page',
 		adminPages: 'admin-page',
+		admin_pages: 'admin-page',
+		externalHttp: 'external-http',
+		external_http: 'external-http',
+		http: 'external-http',
+		httpRequests: 'external-http',
+		http_requests: 'external-http',
 		rest: 'rest-route',
 		restRoutes: 'rest-route',
 		routes: 'rest-route',
@@ -128,34 +173,42 @@ function surfaceTypeFromCollectionKey(key) {
 }
 
 function targetFromSurface(surface, options = {}) {
+	const operation = operationForSurface(surface);
+	const operationId = surface.operation_id || surface.operationId || `${surface.id}:${caseIntent(surface.type)}`;
 	const caseId = `${surface.id}-generic-fuzz`;
 	return {
 		id: surface.id,
 		surface_id: surface.id,
 		type: surface.type,
+		operation_id: operationId,
 		cases: [{
 			id: caseId,
 			intent: caseIntent(surface.type),
-			operation: operationForSurface(surface),
+			operation_id: operationId,
+			operation,
 			seed: options.seed,
+			skip_reasons: reasonList(surface.skip_reasons || surface.skipReasons || surface.skip_reason || surface.skipReason),
+			destructive_reasons: reasonList(surface.destructive_reasons || surface.destructiveReasons || surface.destructive_reason || surface.destructiveReason || surface.unsafeReasons),
 			metadata: { surface },
 		}],
 		metadata: {
 			label: surface.label,
 			type: surface.type,
+			skip_reasons: reasonList(surface.skip_reasons || surface.skipReasons || surface.skip_reason || surface.skipReason),
+			destructive_reasons: reasonList(surface.destructive_reasons || surface.destructiveReasons || surface.destructive_reason || surface.destructiveReason || surface.unsafeReasons),
 			...(surface.metadata || {}),
 		},
 	};
 }
 
 function operationForSurface(surface) {
-	const operation = { surface_type: surface.type };
-	for (const key of ['id', 'name', 'hook', 'event', 'option', 'post_type', 'taxonomy', 'block_name', 'path', 'route', 'method', 'url']) {
+	const operation = { id: surface.operation_id || surface.operationId, surface_type: surface.type };
+	for (const key of ['id', 'name', 'hook', 'event', 'option', 'post_type', 'taxonomy', 'block_name', 'path', 'route', 'method', 'url', 'role', 'capability', 'table', 'query', 'request', 'endpoint']) {
 		if (surface[key] !== undefined) {
 			operation[key] = surface[key];
 		}
 	}
-	return operation;
+	return stripUndefined(operation);
 }
 
 function caseIntent(type) {
@@ -163,15 +216,31 @@ function caseIntent(type) {
 		'admin-page': 'request-admin-page',
 		block: 'render-block',
 		'cron-event': 'inspect-cron-event',
+		capability: 'check-capability-boundary',
+		'database-table': 'inspect-database-table',
+		'db-query': 'profile-database-query',
+		'external-http': 'exercise-external-http-guardrail',
 		'frontend-url': 'request-frontend-url',
 		hook: 'exercise-hook',
 		media: 'query-media',
 		option: 'read-option',
 		'post-type': 'query-post-type',
 		'rest-route': 'request-rest-route',
+		role: 'check-role-boundary',
 		taxonomy: 'query-taxonomy',
 		user: 'query-user',
 	}[type] || 'exercise-wordpress-surface';
+}
+
+function reasonList(value) {
+	if (value === undefined || value === null) {
+		return [];
+	}
+	return [...new Set((Array.isArray(value) ? value : [value]).map(String).filter(Boolean))].sort();
+}
+
+function stripUndefined(value) {
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
 }
 
 function isObject(value) {

--- a/wordpress/lib/wordpress-fuzz-schemas.js
+++ b/wordpress/lib/wordpress-fuzz-schemas.js
@@ -10,6 +10,8 @@ const SURFACE_TYPES = new Set([
 	'capability',
 	'cron-event',
 	'database-table',
+	'db-query',
+	'external-http',
 	'frontend-url',
 	'hook',
 	'media',
@@ -28,7 +30,16 @@ const SURFACE_TYPE_ALIASES = new Map([
 	['action', 'hook'],
 	['admin', 'admin-page'],
 	['admin_page', 'admin-page'],
+	['capabilities', 'capability'],
 	['cron', 'cron-event'],
+	['database', 'database-table'],
+	['db', 'database-table'],
+	['db_table', 'database-table'],
+	['db-query', 'db-query'],
+	['database-query', 'db-query'],
+	['external_http', 'external-http'],
+	['http', 'external-http'],
+	['http-request', 'external-http'],
 	['filter', 'hook'],
 	['frontend', 'frontend-url'],
 	['frontend_url', 'frontend-url'],
@@ -37,6 +48,7 @@ const SURFACE_TYPE_ALIASES = new Map([
 	['rest_route', 'rest-route'],
 	['taxonomy_term', 'taxonomy'],
 	['users', 'user'],
+	['roles', 'role'],
 	['wp-cli', 'wp-cli-command'],
 ]);
 
@@ -110,6 +122,7 @@ function normalizeFuzzCase(testCase, index, targetField) {
 	return {
 		...testCase,
 		id: normalizeId(testCase.id, `case-${index + 1}`, `${targetField}.cases[${index}].id`),
+		operation_id: testCase.operation_id || testCase.operationId || testCase.operation?.id || null,
 		metadata: { ...(testCase.metadata || {}) },
 	};
 }
@@ -127,9 +140,17 @@ function normalizeFuzzTarget(target, index) {
 		...target,
 		id,
 		surface_id: surfaceId,
+		operation_id: target.operation_id || target.operationId || null,
 		cases: asArray(target.cases, `${field}.cases`).map((testCase, caseIndex) => normalizeFuzzCase(testCase, caseIndex, field)),
 		metadata: { ...(target.metadata || {}) },
 	};
+}
+
+function normalizeReasonCodes(value) {
+	if (value === undefined || value === null) {
+		return [];
+	}
+	return [...new Set(asArray(Array.isArray(value) ? value : [value], 'reason_codes').map(String).filter(Boolean))].sort();
 }
 
 function normalizeWordPressFuzzPlan(plan) {
@@ -157,7 +178,17 @@ function normalizeFuzzCaseResult(result, index) {
 		...result,
 		id: normalizeId(result.id, `case-${index + 1}`, `cases[${index}].id`),
 		target_id: result.target_id || result.targetId || null,
+		surface_id: result.surface_id || result.surfaceId || null,
+		operation_id: result.operation_id || result.operationId || result.operation?.id || null,
 		status,
+		skip_reason: result.skip_reason || result.skipReason || null,
+		skip_reasons: normalizeReasonCodes(result.skip_reasons || result.skipReasons || result.skip_reason || result.skipReason),
+		destructive_reason: result.destructive_reason || result.destructiveReason || null,
+		destructive_reasons: normalizeReasonCodes(result.destructive_reasons || result.destructiveReasons || result.destructive_reason || result.destructiveReason),
+		role_boundary: result.role_boundary || result.roleBoundary || null,
+		db_query: result.db_query || result.dbQuery || null,
+		admin_browser: result.admin_browser || result.adminBrowser || null,
+		http_guardrail: result.http_guardrail || result.httpGuardrail || null,
 		duration_ms: Number.isFinite(result.duration_ms) ? result.duration_ms : result.durationMs || null,
 		metadata: { ...(result.metadata || {}) },
 	};
@@ -171,12 +202,96 @@ function summarizeCases(cases) {
 	}, { total: 0, passed: 0, failed: 0, errored: 0, skipped: 0 });
 }
 
+function countUnique(cases, field) {
+	return [...new Set(cases.map((result) => result[field]).filter(Boolean))].length;
+}
+
+function countReasonCodes(cases, field) {
+	return cases.reduce((counts, result) => {
+		for (const reason of result[field] || []) {
+			counts[reason] = (counts[reason] || 0) + 1;
+		}
+		return counts;
+	}, {});
+}
+
+function summarizeRoleBoundaries(cases) {
+	return cases.reduce((summary, result) => {
+		if (!result.role_boundary) {
+			return summary;
+		}
+		summary.total += 1;
+		const outcome = String(result.role_boundary.outcome || result.role_boundary.status || result.status || 'unknown');
+		summary.by_outcome[outcome] = (summary.by_outcome[outcome] || 0) + 1;
+		return summary;
+	}, { total: 0, by_outcome: {} });
+}
+
+function summarizeDbQueries(cases) {
+	return cases.reduce((summary, result) => {
+		const query = result.db_query;
+		if (!query) {
+			return summary;
+		}
+		summary.total += 1;
+		summary.query_count += Number(query.query_count ?? query.queryCount ?? 0) || 0;
+		summary.rows_examined += Number(query.rows_examined ?? query.rowsExamined ?? 0) || 0;
+		summary.duration_ms += Number(query.duration_ms ?? query.durationMs ?? 0) || 0;
+		return summary;
+	}, { total: 0, query_count: 0, rows_examined: 0, duration_ms: 0 });
+}
+
+function summarizeNestedCases(cases, field) {
+	return cases.reduce((summary, result) => {
+		const value = result[field];
+		if (!value) {
+			return summary;
+		}
+		summary.total += 1;
+		if (value.errors !== undefined) {
+			summary.errors += Array.isArray(value.errors) ? value.errors.length : Number(value.errors) || 0;
+		}
+		if (value.blocked !== undefined) {
+			summary.blocked += Number(value.blocked) || (value.blocked === true ? 1 : 0);
+		}
+		if (value.allowed !== undefined) {
+			summary.allowed += Number(value.allowed) || (value.allowed === true ? 1 : 0);
+		}
+		return summary;
+	}, { total: 0, errors: 0, blocked: 0, allowed: 0 });
+}
+
+function normalizeProvenance(result) {
+	const provenance = result.provenance || result.workload_manifest || result.workloadManifest || result.manifest || null;
+	if (!provenance || typeof provenance !== 'object' || Array.isArray(provenance)) {
+		return provenance ? { workload_manifest: String(provenance) } : null;
+	}
+	return {
+		workload_manifest: provenance.workload_manifest || provenance.workloadManifest || provenance.path || provenance.file || provenance.id || null,
+		workload_id: provenance.workload_id || provenance.workloadId || null,
+		discovery_id: provenance.discovery_id || provenance.discoveryId || null,
+	};
+}
+
 function normalizeWordPressFuzzResult(result) {
 	assertPlainObject(result, 'result');
 	assertSchema(result.schema, WORDPRESS_FUZZ_RESULT_SCHEMA, 'WordPress fuzz result');
 
 	const cases = asArray(result.cases, 'cases').map(normalizeFuzzCaseResult);
-	const summary = { ...summarizeCases(cases), ...(result.summary || {}) };
+	const caseSummary = summarizeCases(cases);
+	const summary = {
+		...caseSummary,
+		case_counts: { ...caseSummary, ...(result.summary?.case_counts || result.summary?.caseCounts || {}) },
+		surface_count: countUnique(cases, 'surface_id'),
+		operation_count: countUnique(cases, 'operation_id'),
+		skipped_reason_codes: countReasonCodes(cases, 'skip_reasons'),
+		destructive_reason_codes: countReasonCodes(cases, 'destructive_reasons'),
+		role_boundary_outcomes: summarizeRoleBoundaries(cases),
+		db_query_metrics: summarizeDbQueries(cases),
+		admin_browser_errors: summarizeNestedCases(cases, 'admin_browser'),
+		http_guardrail_outcomes: summarizeNestedCases(cases, 'http_guardrail'),
+		...(result.summary || {}),
+	};
 	const status = result.status || (summary.failed || summary.errored ? 'failed' : 'passed');
 	if (!RESULT_STATUSES.has(status)) {
 		throw new Error(`Unsupported WordPress fuzz result status: ${status}`);
@@ -192,6 +307,7 @@ function normalizeWordPressFuzzResult(result) {
 		summary,
 		cases,
 		artifacts: asArray(result.artifacts, 'artifacts'),
+		provenance: normalizeProvenance(result),
 		metadata: { ...(result.metadata || {}) },
 	};
 }

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -4,6 +4,11 @@
  * Internal dependencies
  */
 const {
+	WORDPRESS_FUZZ_RESULT_SCHEMA,
+	normalizeWordPressFuzzResult,
+} = require('./wordpress-fuzz-schemas');
+
+const {
 	wordpressRuntimeTaskRequest,
 } = require('./wordpress-runtime-task-planner');
 
@@ -22,6 +27,7 @@ const FUZZ_ARTIFACT_SEMANTIC_KEYS = {
 	failing_case: 'fuzz.case.failing',
 	case_artifact: 'fuzz.case.artifact',
 	repro_case: 'fuzz.case.repro',
+	normalized_fuzz_result: 'fuzz.result.normalized',
 };
 
 function wpCodeboxFuzzRunInput(options = {}) {
@@ -69,6 +75,7 @@ function normalizeWpCodeboxFuzzRunResult(result = {}, context = {}) {
 	const artifacts = normalizeWpCodeboxFuzzArtifacts(source, result);
 	const coverageSummary = normalizeCoverageSummary(source?.coverage_summary || source?.coverageSummary || source?.coverage?.summary);
 	const coverageGaps = normalizeCoverageGaps(source?.coverage_gaps || source?.coverageGaps || source?.coverage?.gaps);
+	const normalizedResult = normalizeEmbeddedWordPressFuzzResult(source);
 	return stripUndefined({
 		schema: WORDPRESS_CODEBOX_FUZZ_RUN_CONSUMER_SCHEMA,
 		delegated_schema: WP_CODEBOX_FUZZ_RUN_SCHEMA,
@@ -79,6 +86,7 @@ function normalizeWpCodeboxFuzzRunResult(result = {}, context = {}) {
 		coverage: source?.coverage,
 		coverage_summary: coverageSummary,
 		coverage_gaps: coverageGaps,
+		wordpress_fuzz_result: normalizedResult,
 		artifacts,
 		failures: normalizeArray(source?.failures || source?.errors),
 		metadata: objectOrUndefined(source?.metadata),
@@ -90,6 +98,7 @@ function normalizeWpCodeboxFuzzArtifacts(source = {}, result = {}) {
 	appendArtifactCandidates(artifacts, source?.artifacts);
 	appendArtifactCandidates(artifacts, result?.artifacts);
 	appendNamedArtifact(artifacts, 'fuzz_report', source?.fuzz_report || source?.fuzzReport || source?.report || source?.summary_report || source?.summaryReport);
+	appendNamedArtifact(artifacts, 'normalized_fuzz_result', source?.wordpress_fuzz_result_artifact || source?.wordpressFuzzResultArtifact || source?.normalized_fuzz_result || source?.normalizedFuzzResult);
 	appendCaseArtifacts(artifacts, source?.cases || source?.fuzz_cases || source?.fuzzCases, 'fuzz_case');
 	appendCaseArtifacts(artifacts, source?.failures || source?.errors || source?.failed_cases || source?.failedCases, 'failing_case');
 	appendCaseArtifacts(artifacts, source?.repro_cases || source?.reproCases || source?.reproductions, 'repro_case');
@@ -170,6 +179,9 @@ function normalizeFuzzArtifactRole(value) {
 	if (!label) {
 		return '';
 	}
+	if (['normalized_fuzz_result', 'wordpress_fuzz_result', 'normalized_result'].includes(label)) {
+		return 'normalized_fuzz_result';
+	}
 	if (['fuzz_report', 'fuzz_run_report', 'report', 'summary', 'summary_report', 'result', 'results'].includes(label)) {
 		return 'fuzz_report';
 	}
@@ -198,6 +210,42 @@ function normalizeFuzzArtifactRole(value) {
 		return 'fuzz_report';
 	}
 	return '';
+}
+
+function normalizeEmbeddedWordPressFuzzResult(source = {}) {
+	const candidate = source?.wordpress_fuzz_result || source?.wordpressFuzzResult || source?.normalized_result || source?.normalizedResult;
+	if (objectOrUndefined(candidate)) {
+		return normalizeWordPressFuzzResult({
+			...candidate,
+			status: normalizeWordPressFuzzStatus(candidate.status),
+		});
+	}
+	if (Array.isArray(source?.cases) || Array.isArray(source?.fuzz_cases) || Array.isArray(source?.fuzzCases)) {
+		return normalizeWordPressFuzzResult({
+			schema: WORDPRESS_FUZZ_RESULT_SCHEMA,
+			id: source.id || source.result_id || source.resultId || 'wp-codebox-wordpress-fuzz-result',
+			plan_id: source.plan_id || source.planId || source.workload?.plan_id,
+			status: normalizeWordPressFuzzStatus(source.status),
+			started_at: source.started_at || source.startedAt,
+			finished_at: source.finished_at || source.finishedAt,
+			cases: source.cases || source.fuzz_cases || source.fuzzCases,
+			artifacts: normalizeArray(source.artifacts),
+			provenance: source.provenance || source.workload_manifest || source.workloadManifest,
+			metadata: source.metadata,
+		});
+	}
+	return undefined;
+}
+
+function normalizeWordPressFuzzStatus(value) {
+	const status = String(value || '').toLowerCase();
+	if (['success', 'succeeded', 'ok'].includes(status)) {
+		return 'passed';
+	}
+	if (['failed', 'errored', 'partial', 'skipped', 'passed'].includes(status)) {
+		return status;
+	}
+	return undefined;
 }
 
 function normalizeCoverageSummary(value) {

--- a/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
@@ -16,6 +16,13 @@ const manifest = {
 	taxonomies: { category: { taxonomy: 'category' } },
 	media: [{ id: 'media:attachment', name: 'attachment' }],
 	users: [{ id: 'user:subscriber', name: 'subscriber' }],
+	roles: [{ id: 'role:editor', role: 'editor', capability: 'edit_posts' }],
+	capabilities: [{ id: 'cap:manage-options', capability: 'manage_options' }],
+	database: {
+		tables: { posts: { table: 'wp_posts' } },
+		queries: { postsLookup: { query: 'SELECT ID FROM wp_posts WHERE post_type = ?' } },
+	},
+	external_http: { requests: [{ id: 'http:api-example', url: 'https://api.example.test/v1/', method: 'GET' }] },
 	blocks: [{ id: 'block:core-paragraph', name: 'core/paragraph', block_name: 'core/paragraph' }],
 	frontend: [{ id: 'front:home', path: '/' }],
 	admin: [{ id: 'admin:posts', path: '/wp-admin/edit.php' }],
@@ -23,12 +30,12 @@ const manifest = {
 };
 
 const surfaces = collectWordPressFuzzPlanSurfaces(manifest);
-assert.equal(surfaces.length, 11);
+assert.equal(surfaces.length, 16);
 
 const plan = buildWordPressFuzzPlanFromSurfaces(manifest, { seed: 'seed-1' });
 assert.equal(plan.schema, 'wordpress-fuzz-plan/v1');
 assert.equal(plan.discovery_id, 'generic-core-surfaces');
-assert.equal(plan.targets.length, 11);
+assert.equal(plan.targets.length, 16);
 
 const targetTypes = Object.fromEntries(plan.targets.map((target) => [target.type, target]));
 assert.equal(targetTypes.hook.cases[0].intent, 'exercise-hook');
@@ -38,6 +45,14 @@ assert.equal(targetTypes['post-type'].cases[0].operation.post_type, 'post');
 assert.equal(targetTypes.taxonomy.cases[0].operation.taxonomy, 'category');
 assert.equal(targetTypes.media.cases[0].intent, 'query-media');
 assert.equal(targetTypes.user.cases[0].intent, 'query-user');
+assert.equal(targetTypes.role.cases[0].intent, 'check-role-boundary');
+assert.equal(targetTypes.capability.cases[0].intent, 'check-capability-boundary');
+assert.equal(targetTypes['database-table'].cases[0].intent, 'inspect-database-table');
+assert.equal(targetTypes['db-query'].cases[0].intent, 'profile-database-query');
+assert.equal(targetTypes['external-http'].cases[0].intent, 'exercise-external-http-guardrail');
+assert.equal(targetTypes['db-query'].cases[0].operation.query, 'SELECT ID FROM wp_posts WHERE post_type = ?');
+assert.equal(targetTypes['external-http'].cases[0].operation.url, 'https://api.example.test/v1/');
+assert(targetTypes.role.operation_id.includes('check-role-boundary'));
 assert.equal(targetTypes.block.cases[0].operation.block_name, 'core/paragraph');
 assert.equal(targetTypes['frontend-url'].cases[0].operation.path, '/');
 assert.equal(targetTypes['admin-page'].cases[0].operation.path, '/wp-admin/edit.php');

--- a/wordpress/tests/wordpress-fuzz-schemas-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-schemas-smoke.js
@@ -16,12 +16,16 @@ const discovery = normalizeWordPressSurfaceDiscovery({
 	surfaces: [
 		{ type: 'rest-route', id: 'wp-v2-posts', method: 'GET', route: '/wp/v2/posts' },
 		{ type: 'admin-page', path: '/wp-admin/edit.php', capability: 'edit_posts' },
+		{ kind: 'db-query', id: 'query-posts', query: 'SELECT * FROM wp_posts' },
+		{ kind: 'external_http', id: 'http-api', url: 'https://api.example.test/' },
 	],
 });
 
 assert.equal(discovery.schema, 'wordpress-surface-discovery/v1');
 assert.equal(discovery.surfaces[0].id, 'wp-v2-posts');
 assert.equal(discovery.surfaces[1].id, 'admin-page-2');
+assert.equal(discovery.surfaces[2].type, 'db-query');
+assert.equal(discovery.surfaces[3].type, 'external-http');
 
 const plan = normalizeWordPressFuzzPlan({
 	schema: WORDPRESS_FUZZ_PLAN_SCHEMA,
@@ -31,10 +35,11 @@ const plan = normalizeWordPressFuzzPlan({
 		{
 			id: 'posts-list-query',
 			surface_id: 'wp-v2-posts',
+			operation_id: 'rest:get-posts',
 			method: 'GET',
 			route: '/wp/v2/posts',
 			cases: [
-				{ id: 'per-page-max', query: { per_page: 100 } },
+				{ id: 'per-page-max', operation_id: 'rest:get-posts:per-page', query: { per_page: 100 } },
 				{ query: { search: '<script>' } },
 			],
 		},
@@ -44,6 +49,8 @@ const plan = normalizeWordPressFuzzPlan({
 
 assert.equal(plan.schema, 'wordpress-fuzz-plan/v1');
 assert.equal(plan.discovery_id, 'site-surfaces');
+assert.equal(plan.targets[0].operation_id, 'rest:get-posts');
+assert.equal(plan.targets[0].cases[0].operation_id, 'rest:get-posts:per-page');
 assert.equal(plan.targets[0].cases[1].id, 'case-2');
 
 const result = normalizeWordPressFuzzResult({
@@ -51,14 +58,44 @@ const result = normalizeWordPressFuzzResult({
 	id: 'rest-route-fuzz-result',
 	plan_id: plan.id,
 	cases: [
-		{ id: 'per-page-max', target_id: 'posts-list-query', status: 'passed', duration_ms: 42 },
-		{ id: 'case-2', target_id: 'posts-list-query', status: 'failed', error: { message: '500 response' } },
+		{
+			id: 'per-page-max',
+			target_id: 'posts-list-query',
+			surface_id: 'wp-v2-posts',
+			operation_id: 'rest:get-posts:per-page',
+			status: 'passed',
+			duration_ms: 42,
+			role_boundary: { role: 'subscriber', outcome: 'denied_as_expected' },
+			db_query: { query_count: 3, rows_examined: 12, duration_ms: 5 },
+			http_guardrail: { blocked: 1, allowed: 0 },
+		},
+		{
+			id: 'case-2',
+			target_id: 'posts-list-query',
+			surface_id: 'wp-v2-posts',
+			operation_id: 'rest:get-posts:search',
+			status: 'failed',
+			error: { message: '500 response' },
+			admin_browser: { errors: [{ message: 'console error' }] },
+		},
+		{ id: 'unsafe-delete', target_id: 'posts-list-query', surface_id: 'wp-v2-posts', status: 'skipped', skip_reason: 'destructive_guardrail', destructive_reason: 'mutating_method' },
 	],
+	provenance: { workload_manifest: 'fuzz-manifest.json', workload_id: 'generic-workload', discovery_id: discovery.id },
 });
 
 assert.equal(result.schema, 'wordpress-fuzz-result/v1');
 assert.equal(result.status, 'failed');
-assert.deepEqual(result.summary, { total: 2, passed: 1, failed: 1, errored: 0, skipped: 0 });
+assert.equal(result.summary.total, 3);
+assert.equal(result.summary.case_counts.skipped, 1);
+assert.equal(result.summary.surface_count, 1);
+assert.equal(result.summary.operation_count, 2);
+assert.equal(result.summary.skipped_reason_codes.destructive_guardrail, 1);
+assert.equal(result.summary.destructive_reason_codes.mutating_method, 1);
+assert.equal(result.summary.role_boundary_outcomes.by_outcome.denied_as_expected, 1);
+assert.equal(result.summary.db_query_metrics.query_count, 3);
+assert.equal(result.summary.admin_browser_errors.errors, 1);
+assert.equal(result.summary.http_guardrail_outcomes.blocked, 1);
+assert.equal(result.provenance.workload_manifest, 'fuzz-manifest.json');
 
 assert.throws(() => normalizeWordPressSurfaceDiscovery({ schema: 'other/v1' }), /Unsupported/);
 assert.throws(() => normalizeWordPressSurfaceDiscovery({ surfaces: [{ type: 'woocommerce-product' }] }), /Unsupported WordPress surface type/);

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -61,8 +61,38 @@ runWpCodeboxFuzzRun({
 				},
 				coverage_gaps: [{ id: 'route:/wp/v2/users', type: 'rest_route', status: 'skipped' }],
 				coverage: { hooks: { actions: { init: 1 } } },
+				wordpress_fuzz_result: {
+					schema: 'wordpress-fuzz-result/v1',
+					id: 'normalized-result',
+					plan_id: 'generic-plan',
+					status: 'passed',
+					cases: [
+						{
+							id: 'case-000',
+							target_id: 'target-rest',
+							surface_id: 'surface-rest',
+							operation_id: 'rest:list-posts',
+							status: 'passed',
+							role_boundary: { role: 'subscriber', outcome: 'allowed_as_expected' },
+							db_query: { query_count: 1, rows_examined: 2, duration_ms: 3 },
+							http_guardrail: { blocked: 1 },
+						},
+						{
+							id: 'case-001',
+							target_id: 'target-admin',
+							surface_id: 'surface-admin',
+							operation_id: 'admin:settings',
+							status: 'skipped',
+							skip_reason: 'capability_unavailable',
+							destructive_reason: 'mutating_action',
+							admin_browser: { errors: [{ message: 'blocked navigation' }] },
+						},
+					],
+					provenance: { workload_manifest: 'workloads/generic-wordpress-fuzz.json' },
+				},
 				artifacts: {
 					fuzz_report: { path: 'reports/fuzz-report.json', content_type: 'application/json' },
+					normalized_fuzz_result: { path: 'reports/wordpress-fuzz-result.json', content_type: 'application/json' },
 					fuzz_case: { path: 'cases/case-000.json', case_id: 'case-000' },
 					failing_case: { path: 'cases/failing-case.json', case_id: 'case-002' },
 					case_artifact: { path: 'cases/case-001.json', case_id: 'case-001' },
@@ -79,9 +109,19 @@ runWpCodeboxFuzzRun({
 	assert.equal(summary.coverage.hooks.actions.init, 1);
 	assert.equal(summary.coverage_summary.surface_count, 3);
 	assert.equal(summary.coverage_summary.exercised_count, 1);
+	assert.equal(summary.wordpress_fuzz_result.summary.surface_count, 2);
+	assert.equal(summary.wordpress_fuzz_result.summary.operation_count, 2);
+	assert.equal(summary.wordpress_fuzz_result.summary.skipped_reason_codes.capability_unavailable, 1);
+	assert.equal(summary.wordpress_fuzz_result.summary.destructive_reason_codes.mutating_action, 1);
+	assert.equal(summary.wordpress_fuzz_result.summary.role_boundary_outcomes.by_outcome.allowed_as_expected, 1);
+	assert.equal(summary.wordpress_fuzz_result.summary.db_query_metrics.query_count, 1);
+	assert.equal(summary.wordpress_fuzz_result.summary.admin_browser_errors.errors, 1);
+	assert.equal(summary.wordpress_fuzz_result.summary.http_guardrail_outcomes.blocked, 1);
+	assert.equal(summary.wordpress_fuzz_result.provenance.workload_manifest, 'workloads/generic-wordpress-fuzz.json');
 	assert.equal(summary.coverage_gaps[0].status, 'skipped');
-	assert.deepEqual(summary.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'fuzz_case', 'failing_case', 'case_artifact', 'repro_case']);
+	assert.deepEqual(summary.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'normalized_fuzz_result', 'fuzz_case', 'failing_case', 'case_artifact', 'repro_case']);
 	assert.equal(summary.artifacts[0].semantic_key, 'fuzz.report');
+	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'normalized_fuzz_result').semantic_key, 'fuzz.result.normalized');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'fuzz_case').semantic_key, 'fuzz.case');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'failing_case').semantic_key, 'fuzz.case.failing');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'case_artifact').semantic_key, 'fuzz.case.artifact');


### PR DESCRIPTION
## Summary
- expand generic WordPress fuzz surface support for role/capability boundaries, DB/query profiling, external HTTP guardrails, and broader admin/frontend aliases
- preserve operation IDs, reason codes, provenance, and normalized WordPress fuzz results from WP Codebox outputs
- add focused smoke coverage for plan generation and normalized artifact proof fields

## Verification
- npm run test:wordpress-fuzz-schemas
- npm run test:wordpress-fuzz-plan-from-surfaces
- npm run test:wp-codebox-fuzz-run
- npm run test:wordpress-fuzz-runner
- npx eslint lib/wordpress-fuzz-schemas.js lib/wordpress-fuzz-plan-from-surfaces.js lib/wp-codebox-fuzz-run.js

## Remaining blockers
- D/E/P runtime readiness still depends on homeboy-rigs providing product-owned workload manifests and WP Codebox returning runtime artifacts with the enriched generic fields populated.
- Full end-to-end proof for WooCommerce, Gutenberg, Jetpack, and Core rigs remains blocked until those rigs run against this HBX contract and publish real workload artifacts.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** generic WordPress fuzz adapter implementation, artifact normalization, tests, and documentation drafting.