### PR TITLE
Keep bench artifact refs minimal

### DIFF
--- a/wordpress/scripts/bench/lib/wordpress-bench-artifacts.php
+++ b/wordpress/scripts/bench/lib/wordpress-bench-artifacts.php
@@ -48,7 +48,6 @@ if ( ! function_exists('homeboy_bench_write_json_artifact') ) {
 		return array(
 			'path' => $relative_path,
 			'kind' => 'json',
-			'name' => $name,
 		);
 	}
 }

--- a/wordpress/tests/wordpress-bench-artifact-helper-smoke.php
+++ b/wordpress/tests/wordpress-bench-artifact-helper-smoke.php
@@ -20,7 +20,6 @@ $descriptor = homeboy_bench_write_json_artifact('Scenario One', 'step-series', a
 $expected_descriptor = array(
 	'path' => 'artifacts/scenario-one/step-series.json',
 	'kind' => 'json',
-	'name' => 'step-series',
 );
 if ( $expected_descriptor !== $descriptor ) {
 	fwrite(STDERR, "Expected standard artifact descriptor.\n");


### PR DESCRIPTION
## Summary
- emit generic bench JSON artifact refs with only parser-supported fields
- update the artifact helper smoke test expectation

## Testing
- php wordpress/tests/wordpress-bench-artifact-helper-smoke.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Homeboy bench parser contract mismatch and drafting the minimal helper/test change.