### PR TITLE
Tighten WordPress fuzz artifact contracts

### DIFF
--- a/wordpress/lib/wordpress-runtime-task-planner.js
+++ b/wordpress/lib/wordpress-runtime-task-planner.js
@@ -91,7 +91,9 @@ function wordpressRuntimeTaskRequest(options = {}) {
 			...(options.metadata || {}),
 			fanout: options.fanout,
 		}),
-		includeArtifactDeclarations: false,
+		includeArtifactDeclarations: options.includeArtifactDeclarations === false
+			? false
+			: normalizeArray(options.artifactDeclarations || options.artifact_declarations).length > 0,
 		runnerSpec,
 	});
 }
@@ -105,6 +107,7 @@ function wordpressRuntimeTaskRunnerSpec(options = {}) {
 		secret_env: normalizeArray(options.secretEnv || options.secret_env),
 		task_timeout_seconds: numberOrUndefined(options.taskTimeoutSeconds || options.task_timeout_seconds || options.timeoutSeconds || options.timeout_seconds),
 		limits: options.limits,
+		artifact_declarations: options.artifactDeclarations || options.artifact_declarations,
 		expected_artifacts: options.expectedArtifacts || options.expected_artifacts,
 	});
 }

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -20,6 +20,37 @@ const DEFAULT_FUZZ_RUN_EXPECTED_ARTIFACTS = [
 	'wp-codebox-fuzz-run-result',
 	'wordpress-fuzz-coverage',
 ];
+const DEFAULT_FUZZ_RUN_ARTIFACT_DECLARATIONS = [
+	{
+		name: 'wp-codebox-fuzz-run-result',
+		semantic_key: 'fuzz.result.normalized',
+		content_type: 'application/json',
+		required: true,
+	},
+	{
+		name: 'wordpress-fuzz-coverage',
+		semantic_key: 'fuzz.coverage',
+		content_type: 'application/json',
+		required: true,
+	},
+	{
+		name: 'fuzz-report',
+		semantic_key: 'fuzz.report',
+		content_type: 'application/json',
+		required: false,
+	},
+	{
+		name: 'fuzz-case-artifacts',
+		semantic_key: 'fuzz.case.artifact',
+		content_type: 'application/json',
+		required: false,
+	},
+	{
+		name: 'fuzz-repro-cases',
+		semantic_key: 'fuzz.case.repro',
+		required: false,
+	},
+];
 
 const FUZZ_ARTIFACT_SEMANTIC_KEYS = {
 	fuzz_report: 'fuzz.report',
@@ -28,6 +59,7 @@ const FUZZ_ARTIFACT_SEMANTIC_KEYS = {
 	case_artifact: 'fuzz.case.artifact',
 	repro_case: 'fuzz.case.repro',
 	normalized_fuzz_result: 'fuzz.result.normalized',
+	coverage: 'fuzz.coverage',
 };
 
 function wpCodeboxFuzzRunInput(options = {}) {
@@ -53,6 +85,7 @@ function wpCodeboxFuzzRunTaskRequest(options = {}) {
 		taskId: requiredString(options.taskId || options.task_id, 'taskId'),
 		ability: options.ability || DEFAULT_FUZZ_RUN_ABILITY,
 		abilityInput: input,
+		artifactDeclarations: options.artifactDeclarations || options.artifact_declarations || DEFAULT_FUZZ_RUN_ARTIFACT_DECLARATIONS,
 		expectedArtifacts: options.expectedArtifacts || options.expected_artifacts || DEFAULT_FUZZ_RUN_EXPECTED_ARTIFACTS,
 		instructions: options.instructions || 'Delegate WordPress fuzz execution to WP Codebox and return the declared fuzz artifacts.',
 	});
@@ -98,6 +131,7 @@ function normalizeWpCodeboxFuzzArtifacts(source = {}, result = {}) {
 	appendArtifactCandidates(artifacts, source?.artifacts);
 	appendArtifactCandidates(artifacts, result?.artifacts);
 	appendNamedArtifact(artifacts, 'fuzz_report', source?.fuzz_report || source?.fuzzReport || source?.report || source?.summary_report || source?.summaryReport);
+	appendNamedArtifact(artifacts, 'coverage', source?.coverage_artifact || source?.coverageArtifact || source?.wordpress_fuzz_coverage || source?.wordpressFuzzCoverage);
 	appendNamedArtifact(artifacts, 'normalized_fuzz_result', source?.wordpress_fuzz_result_artifact || source?.wordpressFuzzResultArtifact || source?.normalized_fuzz_result || source?.normalizedFuzzResult);
 	appendCaseArtifacts(artifacts, source?.cases || source?.fuzz_cases || source?.fuzzCases, 'fuzz_case');
 	appendCaseArtifacts(artifacts, source?.failures || source?.errors || source?.failed_cases || source?.failedCases, 'failing_case');
@@ -158,20 +192,37 @@ function normalizeFuzzArtifact(artifact) {
 	if (!role) {
 		return null;
 	}
+	const pathValue = artifact.path || artifact.file || artifact.artifact || artifact.uri;
+	const sha256 = artifact.sha256 || artifact.digest?.value;
+	if (!hasConcreteArtifactReference({ ...artifact, path: pathValue, sha256 })) {
+		return null;
+	}
 	return stripUndefined({
 		role,
 		semantic_key: artifact.semantic_key || artifact.semanticKey || FUZZ_ARTIFACT_SEMANTIC_KEYS[role],
 		name,
-		path: artifact.path || artifact.file || artifact.artifact || artifact.uri,
+		path: pathValue,
 		url: artifact.url,
 		content_type: artifact.content_type || artifact.contentType || artifact.mime,
-		sha256: artifact.sha256 || artifact.digest?.value,
+		sha256,
+		size_bytes: numberOrUndefined(artifact.size_bytes ?? artifact.sizeBytes ?? artifact.bytes),
+		case_id: artifact.case_id || artifact.caseId,
+		status: artifact.status,
 		metadata: stripUndefined({
 			...(objectOrUndefined(artifact.metadata) || {}),
-			case_id: artifact.case_id || artifact.caseId,
-			status: artifact.status,
 		}),
 	});
+}
+
+function hasConcreteArtifactReference(artifact) {
+	return Boolean(
+		artifact.path
+		|| artifact.url
+		|| artifact.sha256
+		|| artifact.content
+		|| artifact.value
+		|| artifact.inline
+	);
 }
 
 function normalizeFuzzArtifactRole(value) {
@@ -181,6 +232,9 @@ function normalizeFuzzArtifactRole(value) {
 	}
 	if (['normalized_fuzz_result', 'wordpress_fuzz_result', 'normalized_result'].includes(label)) {
 		return 'normalized_fuzz_result';
+	}
+	if (['coverage', 'wordpress_fuzz_coverage', 'fuzz_coverage', 'coverage_artifact'].includes(label)) {
+		return 'coverage';
 	}
 	if (['fuzz_report', 'fuzz_run_report', 'report', 'summary', 'summary_report', 'result', 'results'].includes(label)) {
 		return 'fuzz_report';
@@ -206,6 +260,9 @@ function normalizeFuzzArtifactRole(value) {
 	if (/case/.test(label)) {
 		return 'case_artifact';
 	}
+	if (/coverage/.test(label)) {
+		return 'coverage';
+	}
 	if (/report|summary|result/.test(label)) {
 		return 'fuzz_report';
 	}
@@ -215,12 +272,15 @@ function normalizeFuzzArtifactRole(value) {
 function normalizeEmbeddedWordPressFuzzResult(source = {}) {
 	const candidate = source?.wordpress_fuzz_result || source?.wordpressFuzzResult || source?.normalized_result || source?.normalizedResult;
 	if (objectOrUndefined(candidate)) {
+		const artifacts = normalizeWpCodeboxFuzzArtifacts(candidate, source);
 		return normalizeWordPressFuzzResult({
 			...candidate,
 			status: normalizeWordPressFuzzStatus(candidate.status),
+			artifacts: artifacts.length > 0 ? artifacts : normalizeArray(candidate.artifacts),
 		});
 	}
 	if (Array.isArray(source?.cases) || Array.isArray(source?.fuzz_cases) || Array.isArray(source?.fuzzCases)) {
+		const artifacts = normalizeWpCodeboxFuzzArtifacts(source);
 		return normalizeWordPressFuzzResult({
 			schema: WORDPRESS_FUZZ_RESULT_SCHEMA,
 			id: source.id || source.result_id || source.resultId || 'wp-codebox-wordpress-fuzz-result',
@@ -229,7 +289,7 @@ function normalizeEmbeddedWordPressFuzzResult(source = {}) {
 			started_at: source.started_at || source.startedAt,
 			finished_at: source.finished_at || source.finishedAt,
 			cases: source.cases || source.fuzz_cases || source.fuzzCases,
-			artifacts: normalizeArray(source.artifacts),
+			artifacts,
 			provenance: source.provenance || source.workload_manifest || source.workloadManifest,
 			metadata: source.metadata,
 		});
@@ -311,6 +371,7 @@ function stripUndefined(value) {
 
 module.exports = {
 	DEFAULT_FUZZ_RUN_ABILITY,
+	DEFAULT_FUZZ_RUN_ARTIFACT_DECLARATIONS,
 	DEFAULT_FUZZ_RUN_EXPECTED_ARTIFACTS,
 	FUZZ_ARTIFACT_SEMANTIC_KEYS,
 	WORDPRESS_CODEBOX_FUZZ_RUN_CONSUMER_SCHEMA,

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 
 const {
 	DEFAULT_FUZZ_RUN_ABILITY,
+	DEFAULT_FUZZ_RUN_ARTIFACT_DECLARATIONS,
 	WP_CODEBOX_FUZZ_RUN_SCHEMA,
 	normalizeWpCodeboxFuzzRunResult,
 	runWpCodeboxFuzzRun,
@@ -39,6 +40,11 @@ assert.equal(taskRequest.executor.runtime, 'wp-codebox');
 assert.equal(taskRequest.executor.config.runtime_task.ability, DEFAULT_FUZZ_RUN_ABILITY);
 assert.equal(taskRequest.executor.config.runtime_task.input.schema, WP_CODEBOX_FUZZ_RUN_SCHEMA);
 assert.deepEqual(taskRequest.expected_artifacts, ['wp-codebox-fuzz-run-result', 'wordpress-fuzz-coverage']);
+assert.deepEqual(taskRequest.artifact_declarations, DEFAULT_FUZZ_RUN_ARTIFACT_DECLARATIONS);
+assert.deepEqual(
+	taskRequest.artifact_declarations.filter((artifact) => artifact.required === true).map((artifact) => artifact.name),
+	taskRequest.expected_artifacts
+);
 assert(!JSON.stringify(taskRequest).includes('woocommerce'), 'fuzz-run helper must stay product-agnostic');
 
 let invoked = false;
@@ -92,8 +98,10 @@ runWpCodeboxFuzzRun({
 				},
 				artifacts: {
 					fuzz_report: { path: 'reports/fuzz-report.json', content_type: 'application/json' },
+					coverage: { path: 'reports/coverage.json', content_type: 'application/json', size_bytes: 123 },
 					normalized_fuzz_result: { path: 'reports/wordpress-fuzz-result.json', content_type: 'application/json' },
 					fuzz_case: { path: 'cases/case-000.json', case_id: 'case-000' },
+					placeholder_case: { name: 'placeholder-only' },
 					failing_case: { path: 'cases/failing-case.json', case_id: 'case-002' },
 					case_artifact: { path: 'cases/case-001.json', case_id: 'case-001' },
 					repro_case: { path: 'repro/case-002.js', case_id: 'case-002' },
@@ -118,14 +126,20 @@ runWpCodeboxFuzzRun({
 	assert.equal(summary.wordpress_fuzz_result.summary.admin_browser_errors.errors, 1);
 	assert.equal(summary.wordpress_fuzz_result.summary.http_guardrail_outcomes.blocked, 1);
 	assert.equal(summary.wordpress_fuzz_result.provenance.workload_manifest, 'workloads/generic-wordpress-fuzz.json');
+	assert.equal(summary.wordpress_fuzz_result.artifacts.some((artifact) => artifact.role === 'coverage'), true);
+	assert.equal(summary.wordpress_fuzz_result.artifacts.some((artifact) => artifact.name === 'placeholder-only'), false);
 	assert.equal(summary.coverage_gaps[0].status, 'skipped');
-	assert.deepEqual(summary.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'normalized_fuzz_result', 'fuzz_case', 'failing_case', 'case_artifact', 'repro_case']);
+	assert.deepEqual(summary.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'coverage', 'normalized_fuzz_result', 'fuzz_case', 'failing_case', 'case_artifact', 'repro_case']);
 	assert.equal(summary.artifacts[0].semantic_key, 'fuzz.report');
+	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'coverage').semantic_key, 'fuzz.coverage');
+	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'coverage').size_bytes, 123);
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'normalized_fuzz_result').semantic_key, 'fuzz.result.normalized');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'fuzz_case').semantic_key, 'fuzz.case');
+	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'fuzz_case').case_id, 'case-000');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'failing_case').semantic_key, 'fuzz.case.failing');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'case_artifact').semantic_key, 'fuzz.case.artifact');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'repro_case').semantic_key, 'fuzz.case.repro');
+	assert.equal(summary.artifacts.some((artifact) => artifact.name === 'placeholder-only'), false);
 
 	const normalized = normalizeWpCodeboxFuzzRunResult({ status: 'failed', failures: [{ message: 'boom' }] });
 	assert.equal(normalized.succeeded, false);


### PR DESCRIPTION
## Summary
- Add explicit required and optional artifact declarations for generic WordPress fuzz runs.
- Preserve artifact declarations on WordPress runtime task requests when callers provide them.
- Normalize fuzz artifact refs with concrete reviewer-facing evidence only, including coverage artifacts and top-level case/status/size fields.
- Ensure embedded normalized WordPress fuzz results receive the cleaned artifact list instead of raw placeholders.

## Tests
- npm run test:wp-codebox-fuzz-run
- npm run test:wordpress-fuzz-runner
- npm run test:wordpress-fuzz-coverage-aggregate
- npm run test:wordpress-runtime-task-planner

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Inspecting the WordPress fuzz artifact contract, implementing scoped normalization/request contract fixes, updating focused tests, and preparing this PR.