### PR TITLE
Add generic WordPress discovery surfaces

### DIFF
--- a/wordpress/lib/wordpress-discovery-inventory.js
+++ b/wordpress/lib/wordpress-discovery-inventory.js
@@ -15,6 +15,37 @@ function normalizeStringArray(value) {
 		.filter(Boolean))].sort(sortText);
 }
 
+function normalizeToken(value) {
+	return String(value || '')
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '') || 'surface';
+}
+
+function normalizeSurfaceType(value) {
+	const type = String(value || '').trim();
+	return {
+		action: 'hook',
+		admin: 'admin-page',
+		admin_page: 'admin-page',
+		cron: 'cron-event',
+		database: 'database-table',
+		db: 'database-table',
+		db_query: 'db-query',
+		database_query: 'db-query',
+		external_http: 'external-http',
+		http: 'external-http',
+		filter: 'hook',
+		frontend: 'frontend-url',
+		frontend_url: 'frontend-url',
+		option_setting: 'option',
+		post_type: 'post-type',
+		rest: 'rest-route',
+		rest_route: 'rest-route',
+	}[type] || type;
+}
+
 function optionalNumber(value) {
 	const number = Number(value);
 	return Number.isFinite(number) ? number : undefined;
@@ -94,6 +125,86 @@ function normalizeOptionSetting(setting = {}) {
 	};
 }
 
+function normalizeSurface(surface = {}, defaultType) {
+	if (typeof surface === 'string') {
+		return normalizeSurface({ name: surface, id: surface }, defaultType);
+	}
+	if (!isPlainObject(surface)) {
+		throw new TypeError('Surface discovery entries must be objects');
+	}
+	const type = normalizeSurfaceType(surface.type || surface.kind || defaultType);
+	if (!type) {
+		throw new TypeError('Surface discovery entries require a type');
+	}
+	const identity = surface.id || surface.name || surface.hook || surface.option || surface.table || surface.query || surface.route || surface.path || surface.url || surface.endpoint;
+	const id = String(identity || '').trim() || `${type}:${normalizeToken(surface.label || type)}`;
+	return {
+		...surface,
+		id,
+		type,
+		label: String(surface.label || surface.title || surface.name || identity || id).trim() || id,
+		metadata: isPlainObject(surface.metadata) ? surface.metadata : {},
+	};
+}
+
+function appendSurfaceCollection(surfaces, value, defaultType) {
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			surfaces.push(normalizeSurface(item, defaultType));
+		}
+		return;
+	}
+	if (!isPlainObject(value)) {
+		return;
+	}
+	if (defaultType === 'hook') {
+		appendSurfaceCollection(surfaces, value.actions, 'hook');
+		appendSurfaceCollection(surfaces, value.filters, 'hook');
+	}
+	if (defaultType === 'rest-route') {
+		appendSurfaceCollection(surfaces, value.routes, 'rest-route');
+	}
+	if (defaultType === 'database-table') {
+		appendSurfaceCollection(surfaces, value.tables, 'database-table');
+		appendSurfaceCollection(surfaces, value.queries, 'db-query');
+	}
+	if (defaultType === 'external-http') {
+		appendSurfaceCollection(surfaces, value.requests, 'external-http');
+	}
+	for (const [key, item] of Object.entries(value)) {
+		if (
+			(defaultType === 'hook' && ['actions', 'filters'].includes(key))
+			|| (defaultType === 'rest-route' && key === 'routes')
+			|| (defaultType === 'database-table' && ['tables', 'queries'].includes(key))
+			|| (defaultType === 'external-http' && key === 'requests')
+		) {
+			continue;
+		}
+		surfaces.push(normalizeSurface(isPlainObject(item) ? { id: key, name: key, ...item } : { id: key, name: key, value: item }, defaultType));
+	}
+}
+
+function buildGenericSurfaces(input, blocks, optionSettings) {
+	const surfaces = [];
+	appendSurfaceCollection(surfaces, input.surfaces, undefined);
+	appendSurfaceCollection(surfaces, input.rest || input.routes || input.restRoutes || input.rest_routes, 'rest-route');
+	appendSurfaceCollection(surfaces, input.admin || input.adminPages || input.admin_pages, 'admin-page');
+	appendSurfaceCollection(surfaces, input.frontend || input.frontendUrls || input.frontend_urls, 'frontend-url');
+	appendSurfaceCollection(surfaces, input.hooks || input.hookSurfaces || input.hook_surfaces, 'hook');
+	appendSurfaceCollection(surfaces, input.database || input.db || input.databaseTables || input.database_tables, 'database-table');
+	appendSurfaceCollection(surfaces, input.dbQueries || input.db_queries, 'db-query');
+	appendSurfaceCollection(surfaces, input.externalHttp || input.external_http || input.httpRequests || input.http_requests, 'external-http');
+
+	for (const block of blocks) {
+		surfaces.push(normalizeSurface({ id: `block:${block.name}`, name: block.name, block_name: block.name, label: block.title || block.name, metadata: block }, 'block'));
+	}
+	for (const setting of optionSettings) {
+		surfaces.push(normalizeSurface({ id: `option:${setting.name}`, name: setting.name, option: setting.name, metadata: setting }, 'option'));
+	}
+
+	return surfaces.sort((a, b) => sortText(a.type, b.type) || sortText(a.id, b.id));
+}
+
 function buildWordPressDiscoveryInventoryArtifact(input = {}) {
 	const blocks = firstArray(input.blocks, input.blockTypes)
 		.map(normalizeBlockType)
@@ -104,6 +215,11 @@ function buildWordPressDiscoveryInventoryArtifact(input = {}) {
 	const optionSettings = firstArray(input.optionSettings, input.options, input.settings)
 		.map(normalizeOptionSetting)
 		.sort((a, b) => sortText(a.name, b.name) || sortText(a.surface, b.surface));
+	const surfaces = buildGenericSurfaces(input, blocks, optionSettings);
+	const surfaceCounts = surfaces.reduce((counts, surface) => {
+		counts[surface.type] = (counts[surface.type] || 0) + 1;
+		return counts;
+	}, {});
 	return {
 		schema: 'homeboy/wordpress-discovery-inventory/v1',
 		type: 'wordpress-discovery-inventory',
@@ -111,7 +227,10 @@ function buildWordPressDiscoveryInventoryArtifact(input = {}) {
 			blockCount: blocks.length,
 			shortcodeCount: shortcodes.length,
 			optionSettingCount: optionSettings.length,
+			surfaceCount: surfaces.length,
 		},
+		surfaceCounts,
+		surfaces,
 		blocks,
 		shortcodes,
 		optionSettings,
@@ -130,8 +249,9 @@ function formatWordPressDiscoveryInventoryMarkdownReport(input = {}, options = {
 	const lines = [
 		`## ${options.title || 'WordPress discovery inventory'}`,
 		'',
-		`Blocks: ${artifact.totals.blockCount}; shortcodes: ${artifact.totals.shortcodeCount}; options/settings: ${artifact.totals.optionSettingCount}`,
+		`Blocks: ${artifact.totals.blockCount}; shortcodes: ${artifact.totals.shortcodeCount}; options/settings: ${artifact.totals.optionSettingCount}; surfaces: ${artifact.totals.surfaceCount || 0}`,
 	];
+	appendSection(lines, 'Generic surfaces', ['Type', 'ID', 'Label'], artifact.surfaces || [], limit, (surface) => [surface.type, surface.id, surface.label]);
 	appendSection(lines, 'Blocks', ['Name', 'Title', 'Category'], artifact.blocks, limit, (block) => [block.name, block.title, block.category]);
 	appendSection(lines, 'Shortcodes', ['Tag', 'Callback', 'Source'], artifact.shortcodes, limit, (shortcode) => [shortcode.tag, shortcode.callback, shortcode.source]);
 	appendSection(lines, 'Options/settings', ['Name', 'Surface', 'Group'], artifact.optionSettings, limit, (setting) => [setting.name, setting.surface, setting.group]);
@@ -152,4 +272,5 @@ module.exports = {
 	normalizeWordPressDiscoveryBlockType: normalizeBlockType,
 	normalizeWordPressDiscoveryOptionSetting: normalizeOptionSetting,
 	normalizeWordPressDiscoveryShortcode: normalizeShortcode,
+	normalizeWordPressDiscoverySurface: normalizeSurface,
 };

--- a/wordpress/lib/wordpress-rest-fuzz-surface-discovery.js
+++ b/wordpress/lib/wordpress-rest-fuzz-surface-discovery.js
@@ -81,7 +81,7 @@ function routeInputFromOptions(options = {}) {
 	return options.restIndex || options.rest_index || options.routes || options.routeIndex || options.route_index || null;
 }
 
-function buildMinimalRestFuzzSurfaceArtifact(input = {}, options = {}) {
+function buildRestIndexFuzzSurfaceArtifact(input = {}, options = {}) {
 	const routeInput = routeInputFromOptions(options) || routeInputFromOptions(input) || input;
 	const hasRoutes = isPlainObject(routeInput?.routes) || isPlainObject(routeInput);
 	const cases = hasRoutes ? normalizeWordPressRestRouteMatrix(routeInput, options) : [];
@@ -93,7 +93,7 @@ function buildMinimalRestFuzzSurfaceArtifact(input = {}, options = {}) {
 		schema: WORDPRESS_FUZZ_SURFACES_SCHEMA,
 		type: 'wordpress-fuzz-surfaces',
 		generated_at: generatedAt,
-		source: 'minimal-fallback',
+		source: 'rest-index',
 		surfaces: [{
 			id: 'wordpress-rest-api',
 			kind: 'rest',
@@ -120,13 +120,13 @@ function buildMinimalRestFuzzSurfaceArtifact(input = {}, options = {}) {
 
 function discoverWordPressRestFuzzSurfaces(input = {}, options = {}) {
 	const repositorySchema = loadRepositorySurfaceSchema({ ...input, ...options });
-	const artifact = repositorySchema ? repositorySchema.artifact : buildMinimalRestFuzzSurfaceArtifact(input, options);
+	const artifact = repositorySchema ? repositorySchema.artifact : buildRestIndexFuzzSurfaceArtifact(input, options);
 
 	return {
 		schema: WORDPRESS_REST_FUZZ_SURFACE_DISCOVERY_SCHEMA,
 		type: 'wordpress-rest-fuzz-surface-discovery',
 		adapter_id: 'homeboy/wordpress-rest-fuzz-surface-discovery/v1',
-		source: repositorySchema ? repositorySchema.source : 'minimal-fallback',
+		source: repositorySchema ? repositorySchema.source : 'rest-index',
 		source_path: repositorySchema?.path || '',
 		artifact_schema: artifact?.schema || WORDPRESS_FUZZ_SURFACES_SCHEMA,
 		artifact,
@@ -137,7 +137,7 @@ module.exports = {
 	DEFAULT_SURFACE_SCHEMA_PATHS,
 	WORDPRESS_FUZZ_SURFACES_SCHEMA,
 	WORDPRESS_REST_FUZZ_SURFACE_DISCOVERY_SCHEMA,
-	buildMinimalRestFuzzSurfaceArtifact,
+	buildRestIndexFuzzSurfaceArtifact,
 	discoverWordPressRestFuzzSurfaces,
 	loadRepositorySurfaceSchema,
 };

--- a/wordpress/tests/wordpress-discovery-inventory-smoke.js
+++ b/wordpress/tests/wordpress-discovery-inventory-smoke.js
@@ -14,7 +14,9 @@ const {
 	normalizeWordPressDiscoveryBlockType,
 	normalizeWordPressDiscoveryOptionSetting,
 	normalizeWordPressDiscoveryShortcode,
+	normalizeWordPressDiscoverySurface,
 } = require('../lib/wordpress-discovery-inventory');
+const { buildWordPressFuzzPlanFromSurfaces } = require('../lib/wordpress-fuzz-plan-from-surfaces');
 
 const artifact = buildWordPressDiscoveryInventoryArtifact({
 	blocks: [{
@@ -39,6 +41,15 @@ const artifact = buildWordPressDiscoveryInventoryArtifact({
 		show_in_rest: true,
 		type: 'integer',
 	}],
+	rest: { routes: { '/wp/v2/posts': { route: '/wp/v2/posts', method: 'GET' } } },
+	admin: [{ id: 'admin:dashboard', path: '/wp-admin/index.php' }],
+	frontend_urls: [{ id: 'front:home', path: '/' }],
+	hooks: { actions: { init: { hook: 'init' } } },
+	database: {
+		tables: { posts: { table: 'wp_posts' } },
+		queries: { postsLookup: { query: 'SELECT ID FROM wp_posts WHERE post_type = ?' } },
+	},
+	external_http: { requests: [{ id: 'http:example', url: 'https://api.example.test/v1/', method: 'GET' }] },
 });
 
 assert.equal(artifact.schema, 'homeboy/wordpress-discovery-inventory/v1');
@@ -46,6 +57,18 @@ assert.deepEqual(artifact.totals, {
 	blockCount: 2,
 	shortcodeCount: 2,
 	optionSettingCount: 2,
+	surfaceCount: 11,
+});
+assert.deepEqual(artifact.surfaceCounts, {
+	'admin-page': 1,
+	block: 2,
+	'database-table': 1,
+	'db-query': 1,
+	'external-http': 1,
+	'frontend-url': 1,
+	hook: 1,
+	option: 2,
+	'rest-route': 1,
 });
 assert.deepEqual(artifact.blocks.map((block) => block.name), ['core/paragraph', 'plugin/card']);
 assert.deepEqual(artifact.blocks[0].attributes, ['content', 'dropCap']);
@@ -61,6 +84,8 @@ assert.equal(normalizeWordPressDiscoveryOptionSetting('timezone_string').name, '
 assert.equal(normalizeWordPressDiscoveryOptionSetting('timezone_string').surface, 'option');
 assert.equal(normalizeWordPressDiscoveryOptionSetting({ name: 'page_for_posts', type: 'integer' }).surface, 'option');
 assert.equal(normalizeWordPressDiscoveryOptionSetting({ name: 'page_for_posts', type: 'integer' }).valueType, 'integer');
+assert.equal(normalizeWordPressDiscoverySurface({ kind: 'rest', route: '/wp/v2/pages' }).type, 'rest-route');
+assert.equal(normalizeWordPressDiscoverySurface({ kind: 'external_http', url: 'https://example.test/' }).type, 'external-http');
 assert.throws(() => normalizeWordPressDiscoveryBlockType({ title: 'Missing name' }), /name/);
 assert.throws(() => normalizeWordPressDiscoveryShortcode(' '), /tag/);
 assert.throws(() => normalizeWordPressDiscoveryShortcode({ callback: 'missing_tag' }), /tag/);
@@ -68,9 +93,20 @@ assert.throws(() => normalizeWordPressDiscoveryOptionSetting(' '), /name/);
 assert.throws(() => normalizeWordPressDiscoveryOptionSetting({ group: 'reading' }), /name/);
 
 const markdown = formatWordPressDiscoveryInventoryMarkdownReport(artifact);
-assert.match(markdown, /Blocks: 2; shortcodes: 2; options\/settings: 2/);
+assert.match(markdown, /Blocks: 2; shortcodes: 2; options\/settings: 2; surfaces: 11/);
+assert.match(markdown, /\| rest-route \| \/wp\/v2\/posts \| \/wp\/v2\/posts \|/);
 assert.match(markdown, /\| core\/paragraph \| Paragraph \| text \|/);
 assert.match(markdown, /\| contact-form \| render_contact_form \| plugin \|/);
 assert.match(markdown, /\| posts_per_page \| setting \| reading \|/);
+
+const plan = buildWordPressFuzzPlanFromSurfaces(artifact);
+assert.equal(plan.targets.length, 11);
+assert.equal(plan.targets.find((target) => target.type === 'rest-route').cases[0].operation.route, '/wp/v2/posts');
+assert.equal(plan.targets.find((target) => target.type === 'admin-page').cases[0].intent, 'request-admin-page');
+assert.equal(plan.targets.find((target) => target.type === 'frontend-url').cases[0].operation.path, '/');
+assert.equal(plan.targets.find((target) => target.type === 'hook').cases[0].operation.hook, 'init');
+assert.equal(plan.targets.find((target) => target.type === 'db-query').cases[0].operation.query, 'SELECT ID FROM wp_posts WHERE post_type = ?');
+assert.equal(plan.targets.find((target) => target.type === 'external-http').cases[0].operation.url, 'https://api.example.test/v1/');
+assert(!JSON.stringify(artifact).includes('woocommerce'), 'discovery inventory must stay product-agnostic');
 
 console.log('WordPress discovery inventory smoke passed.');

--- a/wordpress/tests/wordpress-rest-fuzz-surface-discovery-smoke.js
+++ b/wordpress/tests/wordpress-rest-fuzz-surface-discovery-smoke.js
@@ -32,22 +32,22 @@ const restIndex = {
 	},
 };
 
-const fallback = discoverWordPressRestFuzzSurfaces({ restIndex }, {
+const restIndexDiscovery = discoverWordPressRestFuzzSurfaces({ restIndex }, {
 	methods: ['GET'],
 	generatedAt: '2026-01-01T00:00:00.000Z',
 });
 
-assert.equal(fallback.schema, 'homeboy/wordpress-rest-fuzz-surface-discovery/v1');
-assert.equal(fallback.source, 'minimal-fallback');
-assert.equal(fallback.artifact.schema, WORDPRESS_FUZZ_SURFACES_SCHEMA);
-assert.equal(fallback.artifact.surfaces[0].kind, 'rest');
-assert.deepEqual(fallback.artifact.surfaces[0].methods, ['GET']);
-assert.deepEqual(fallback.artifact.surfaces[0].namespaces, ['demo/v1', 'wp/v2']);
-assert.deepEqual(fallback.artifact.surfaces[0].routes.map((route) => route.id), [
+assert.equal(restIndexDiscovery.schema, 'homeboy/wordpress-rest-fuzz-surface-discovery/v1');
+assert.equal(restIndexDiscovery.source, 'rest-index');
+assert.equal(restIndexDiscovery.artifact.schema, WORDPRESS_FUZZ_SURFACES_SCHEMA);
+assert.equal(restIndexDiscovery.artifact.surfaces[0].kind, 'rest');
+assert.deepEqual(restIndexDiscovery.artifact.surfaces[0].methods, ['GET']);
+assert.deepEqual(restIndexDiscovery.artifact.surfaces[0].namespaces, ['demo/v1', 'wp/v2']);
+assert.deepEqual(restIndexDiscovery.artifact.surfaces[0].routes.map((route) => route.id), [
 	'rest:get:demo-v1-items-id',
 	'rest:get:wp-v2-posts',
 ]);
-assert.equal(fallback.artifact.surfaces[0].routes[1].args.count, 1);
+assert.equal(restIndexDiscovery.artifact.surfaces[0].routes[1].args.count, 1);
 
 const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wordpress-rest-fuzz-surfaces-'));
 fs.mkdirSync(path.join(repoRoot, '.homeboy'));


### PR DESCRIPTION
## Summary
- Add generic WordPress discovery inventory surfaces for REST, admin, frontend, hooks, options, DB, external HTTP, and blocks.
- Flatten nested coverage-contract shapes into fuzz-plan-compatible surface targets.
- Rename REST route-index discovery output away from the legacy `minimal-fallback` source label.

## Tests
- `npm run test:wordpress-discovery-inventory`
- `npm run test:wordpress-rest-fuzz-surface-discovery`
- `npm run test:wordpress-fuzz-plan-from-surfaces`
- `npm run test:wordpress-fuzz-schemas`
- `npm run test:wordpress-public-export-boundary`
- `npx eslint lib/wordpress-discovery-inventory.js lib/wordpress-rest-fuzz-surface-discovery.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the generic WordPress discovery adapter changes, focused tests, and verification.