### PR TITLE
Pass WordPress runtime evidence steps

### DIFF
--- a/wordpress/lib/wp-codebox-browser-metrics.js
+++ b/wordpress/lib/wp-codebox-browser-metrics.js
@@ -11,6 +11,8 @@ const ARTIFACT_KEYS = {
   memory: 'browser_memory',
   performance: 'browser_performance',
   checkpoints: 'browser_checkpoints',
+  html: 'browser_html',
+  screenshot: 'browser_screenshot',
 };
 
 function runWpCodeboxBrowserMetrics(artifactsDirectory, wpCodeboxBin = 'wp-codebox') {

--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -81,6 +81,10 @@ homeboy_wp_codebox_validate_bench_settings() {
             ["wordpress_runtime_workloads", "array"],
             ["wp_codebox_workloads", "array"],
             ["playground_workloads", "array"],
+            ["wordpress_runtime_prepare_steps", "array"],
+            ["wordpress_runtime_post_steps", "array"],
+            ["wp_codebox_recipe_prepare_steps", "array"],
+            ["wp_codebox_recipe_post_steps", "array"],
             ["wp_codebox_file_mounts", "array"],
             ["playground_file_mounts", "array"],
             ["wp_codebox_extra_plugins", "array"],
@@ -951,10 +955,14 @@ fi
 WP_CONFIG_DEFINES_JSON="{}"
 BENCH_ENV_JSON="{}"
 WP_CODEBOX_WORKLOADS_JSON="[]"
+WP_CODEBOX_RECIPE_PREPARE_STEPS_JSON="[]"
+WP_CODEBOX_RECIPE_POST_STEPS_JSON="[]"
 if [ "$settings_json" != "{}" ]; then
     WP_CONFIG_DEFINES_JSON=$(printf '%s' "$settings_json" | jq -c '.wp_config_defines // {}' 2>/dev/null || echo "{}")
     BENCH_ENV_JSON=$(printf '%s' "$settings_json" | jq -c '.bench_env // {}' 2>/dev/null || echo "{}")
     WP_CODEBOX_WORKLOADS_JSON=$(printf '%s' "$settings_json" | jq -c '.wordpress_runtime_workloads // .wp_codebox_workloads // .playground_workloads // []' 2>/dev/null || echo "[]")
+    WP_CODEBOX_RECIPE_PREPARE_STEPS_JSON=$(printf '%s' "$settings_json" | jq -c '.wordpress_runtime_prepare_steps // .wp_codebox_recipe_prepare_steps // []' 2>/dev/null || echo "[]")
+    WP_CODEBOX_RECIPE_POST_STEPS_JSON=$(printf '%s' "$settings_json" | jq -c '.wordpress_runtime_post_steps // .wp_codebox_recipe_post_steps // []' 2>/dev/null || echo "[]")
 fi
 WP_CODEBOX_WORKLOADS_JSON=$(jq -nc --argjson declared "$WP_CODEBOX_WORKLOADS_JSON" --argjson scenarios "$SCENARIO_MANIFEST_WORKLOADS_JSON" '$declared + $scenarios')
 homeboy_wp_codebox_append_extra_bench_workloads_configured_json
@@ -1387,6 +1395,8 @@ homeboy_wp_codebox_emit_dependency_provenance() {
                 has_bench_env: (($settings.bench_env // null) != null),
                 has_wp_config_defines: (($settings.wp_config_defines // null) != null),
                 has_configured_workloads: ((($settings.wordpress_runtime_workloads // $settings.wp_codebox_workloads // $settings.playground_workloads // []) | length) > 0),
+                has_recipe_prepare_steps: ((($settings.wordpress_runtime_prepare_steps // $settings.wp_codebox_recipe_prepare_steps // []) | length) > 0),
+                has_recipe_post_steps: ((($settings.wordpress_runtime_post_steps // $settings.wp_codebox_recipe_post_steps // []) | length) > 0),
                 has_scenario_manifests: ((($settings.wp_codebox_scenario_manifests // $settings.scenario_manifests // []) | length) > 0)
             }
         }' > "$provenance_file"
@@ -1409,6 +1419,8 @@ jq -n \
     --argjson dependencySlugs "$(printf '%s\n' "$DEPENDENCY_SLUGS_CSV" | jq -R 'split(",") | map(select(. != ""))')" \
     --argjson bootstrapFiles "$WP_CODEBOX_BOOTSTRAP_FILES_JSON" \
     --argjson workloads "$WP_CODEBOX_WORKLOADS_JSON" \
+    --argjson prepareSteps "$WP_CODEBOX_RECIPE_PREPARE_STEPS_JSON" \
+    --argjson postSteps "$WP_CODEBOX_RECIPE_POST_STEPS_JSON" \
     --argjson pluginRuntime "$WP_CODEBOX_PLUGIN_RUNTIME_JSON" \
     --argjson diagnostics "$WP_CODEBOX_COMMAND_DIAGNOSTICS_JSON" \
     '({
@@ -1426,7 +1438,9 @@ jq -n \
             wpConfigDefines: $wpConfigDefines,
             pluginRuntime: $pluginRuntime,
             bootstrapFiles: $bootstrapFiles,
-            workloads: $workloads
+            workloads: $workloads,
+            prepareSteps: $prepareSteps,
+            postSteps: $postSteps
         } + (if $wp == "" then {} else {wordpressVersion: $wp} end))
     } | .options += (if $diagnostics == null then {} else {diagnosticsCapture: $diagnostics} end))' | node "$BENCH_RECIPE_BUILDER" > "$RECIPE_FILE"
 

--- a/wordpress/tests/fixtures/wp-codebox-core-recipe-builder.mjs
+++ b/wordpress/tests/fixtures/wp-codebox-core-recipe-builder.mjs
@@ -11,6 +11,7 @@ export function buildWordPressBenchRecipe(options = {}) {
 			blueprint: options.blueprint ?? {},
 		},
 		workflow: {
+			...(Array.isArray(options.prepareSteps) && options.prepareSteps.length > 0 ? { before: options.prepareSteps } : {}),
 			steps: [{
 				command: 'fixture.wordpress.bench',
 				args: [
@@ -18,7 +19,7 @@ export function buildWordPressBenchRecipe(options = {}) {
 					`lifecycle-json=${JSON.stringify(options.lifecycle ?? {})}`,
 					`reset-policy-json=${JSON.stringify(options.resetPolicy ?? {})}`,
 				],
-			}],
+			}, ...(options.postSteps ?? [])],
 		},
 	};
 }

--- a/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
@@ -27,6 +27,8 @@ const input = {
 			{ id: 'fixture-workload', steps: [{ type: 'php', code: 'return [];' }] },
 			{ id: 'other-workload', steps: [{ type: 'php', code: 'return [];' }] },
 		],
+		prepareSteps: [{ command: 'wordpress.wp-cli', args: ['command=option update fixture_prepare yes'] }],
+		postSteps: [{ command: 'wordpress.browser-probe', args: ['url=/', 'capture=html,screenshot'] }],
 		lifecycle: { before: ['fixture'] },
 		resetPolicy: { mode: 'snapshot' },
 		pluginRuntime: {
@@ -79,7 +81,11 @@ assert.deepEqual(recipe.workflow.steps, [{
 		'reset-policy-json={"mode":"snapshot"}',
 	],
 	diagnostics: { capture: ['queries', 'errors'] },
+}, {
+	command: 'wordpress.browser-probe',
+	args: ['url=/', 'capture=html,screenshot'],
 }]);
+assert.deepEqual(recipe.workflow.before, [{ command: 'wordpress.wp-cli', args: ['command=option update fixture_prepare yes'] }]);
 
 const filteredResult = spawnSync(process.execPath, [script], {
 	cwd: path.join(__dirname, '..'),
@@ -122,6 +128,7 @@ assert.deepEqual(checkpointRecipe.workflow.steps, [
 			'reset-policy-json={"mode":"snapshot"}',
 			'scenario-ids-json=["fixture-workload"]',
 		],
+		diagnostics: { capture: ['queries', 'errors'] },
 	},
 	{ command: 'wp-codebox.checkpoint-list', args: [] },
 	{ command: 'wp-codebox.checkpoint-restore', args: ['name=fixture-case-baseline'] },
@@ -133,8 +140,10 @@ assert.deepEqual(checkpointRecipe.workflow.steps, [
 			'reset-policy-json={"mode":"snapshot"}',
 			'scenario-ids-json=["other-workload"]',
 		],
+		diagnostics: { capture: ['queries', 'errors'] },
 	},
 	{ command: 'wp-codebox.checkpoint-list', args: [] },
+	{ command: 'wordpress.browser-probe', args: ['url=/', 'capture=html,screenshot'] },
 ]);
 
 const cacheDiscoveryResult = spawnSync(process.execPath, [script], {

--- a/wordpress/tests/wp-codebox-browser-metrics-smoke.js
+++ b/wordpress/tests/wp-codebox-browser-metrics-smoke.js
@@ -62,6 +62,8 @@ withTempDirectory((root) => {
       memory: { path: 'files/browser/memory.json', kind: 'json' },
       performance: { path: 'files/browser/performance.json', kind: 'json' },
       checkpoints: { path: 'files/browser/checkpoints.jsonl', kind: 'jsonl' },
+      html: { path: 'files/browser/snapshot.html', kind: 'html' },
+      screenshot: { path: 'files/browser/screenshot.png', kind: 'png' },
     },
   };
   writeFakeWpCodebox(fakeWpCodebox, cliOutput);
@@ -83,6 +85,8 @@ withTempDirectory((root) => {
       browser_memory: { path: 'files/browser/memory.json', kind: 'json' },
       browser_performance: { path: 'files/browser/performance.json', kind: 'json' },
       browser_checkpoints: { path: 'files/browser/checkpoints.jsonl', kind: 'jsonl' },
+      browser_html: { path: 'files/browser/snapshot.html', kind: 'html' },
+      browser_screenshot: { path: 'files/browser/screenshot.png', kind: 'png' },
     });
 
     const enriched = enrichBenchResultsWithBrowserMetrics({
@@ -96,6 +100,7 @@ withTempDirectory((root) => {
     assert.equal(enriched.scenarios[0].metrics.browser_peak_used_js_heap_bytes, undefined);
     assert.equal(enriched.scenarios[1].metrics.browser_peak_used_js_heap_bytes, 9000);
     assert.equal(enriched.scenarios[1].artifacts.browser_summary.path, 'files/browser/summary.json');
+    assert.equal(enriched.scenarios[1].artifacts.browser_screenshot.path, 'files/browser/screenshot.png');
     assert.equal(enriched.scenarios[1].artifacts.transcript.path, 'transcript.json');
   } finally {
     if (previousArgsPath === undefined) {

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -996,11 +996,39 @@
       "description": "Backend-neutral WordPress workload declarations passed to the selected runtime adapter after dependency mounts and component load. Each workload declares an id, optional label, run steps ({type: 'php', code|file}, {type: 'ability', ability|name, input}, or {type: 'wp-cli', command}), and optional metrics/artifacts/metadata."
     },
     {
+      "id": "wordpress_runtime_prepare_steps",
+      "label": "WordPress runtime prepare steps",
+      "type": "array",
+      "default": [],
+      "description": "Backend-neutral recipe steps to run before the measured WordPress runtime bench step. Each step is a runtime command object with command, args, and optional allowFailure/advisory flags. Use for generic pre-bench runtime evidence or setup that belongs outside measured workloads."
+    },
+    {
+      "id": "wordpress_runtime_post_steps",
+      "label": "WordPress runtime post steps",
+      "type": "array",
+      "default": [],
+      "description": "Backend-neutral recipe steps to run after the measured WordPress runtime bench step in the same disposable runtime. Use for generic post-bench browser probes, browser actions, or reviewer-facing evidence capture after workloads mutate WordPress state."
+    },
+    {
       "id": "wp_codebox_workloads",
       "label": "Bench workloads",
       "type": "array",
       "default": [],
       "description": "Legacy compatibility alias for wordpress_runtime_workloads. Prefer wordpress_runtime_workloads for new configuration."
+    },
+    {
+      "id": "wp_codebox_recipe_prepare_steps",
+      "label": "WP Codebox recipe prepare steps",
+      "type": "array",
+      "default": [],
+      "description": "Legacy compatibility alias for wordpress_runtime_prepare_steps. Prefer wordpress_runtime_prepare_steps for new configuration."
+    },
+    {
+      "id": "wp_codebox_recipe_post_steps",
+      "label": "WP Codebox recipe post steps",
+      "type": "array",
+      "default": [],
+      "description": "Legacy compatibility alias for wordpress_runtime_post_steps. Prefer wordpress_runtime_post_steps for new configuration."
     },
     {
       "id": "wp_codebox_bootstrap_files",


### PR DESCRIPTION
## Summary
- Add backend-neutral wordpress_runtime_prepare_steps and wordpress_runtime_post_steps settings.
- Pass those settings through to WP Codebox bench recipe generation.
- Promote browser HTML and screenshot artifact refs from WP Codebox browser metrics into bench results.

## Testing
- node wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
- node wordpress/tests/wp-codebox-browser-metrics-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the settings pass-through, artifact promotion, and focused smoke coverage.