### PR TITLE
Use public WP Codebox contracts

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -42,7 +42,7 @@ function buildConfig(env) {
   const runtimeProfiles = parseJsonInput('runtime_profiles', env.RUNTIME_PROFILES || '{}', 'object', {});
   const runtime = resolveRuntimeProvider(runtimeId, { workspace, env });
   const runtimeBin = runtime.paths.runtime_bin;
-  if (runtimePathRequired(runtime, 'runtime_bin') && (!runtimeBin || !fs.existsSync(runtimeBin))) {
+  if (runtimePathRequired(runtime, 'runtime_bin') && (!runtimeBin || !runtimeExecutableAvailable(runtimeBin, env))) {
     throw new Error(`Runtime CLI build missing at ${runtimeBin || 'runtime.paths.runtime_bin'}`);
   }
 
@@ -256,6 +256,24 @@ function runtimeTaskFromEnv(env) {
 function runtimePathRequired(runtime, pathName) {
   const requiredPaths = runtime?.manifest?.ci_materialization?.required_paths;
   return Array.isArray(requiredPaths) && requiredPaths.includes(pathName);
+}
+
+function runtimeExecutableAvailable(command, env = process.env) {
+  if (typeof command !== 'string' || command.trim() === '') {
+    return false;
+  }
+  if (isPathLikeExecutable(command)) {
+    return fs.existsSync(command);
+  }
+  return executableInPath(command, env.PATH || process.env.PATH || '');
+}
+
+function isPathLikeExecutable(command) {
+  return command.startsWith('.') || path.isAbsolute(command) || command.includes('/') || command.includes('\\');
+}
+
+function executableInPath(command, searchPath) {
+  return searchPath.split(path.delimiter).filter(Boolean).some((dir) => fs.existsSync(path.join(dir, command)));
 }
 
 function projectRuntimeConfig({ env, runtime, workspace, componentId, componentPath, workloadId, runnerWorkspaceGuestCheckout }) {

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
@@ -1,12 +1,11 @@
 'use strict';
 
 const path = require('node:path');
-const { existsSync, readdirSync } = require('node:fs');
+const { existsSync } = require('node:fs');
 const { homedir } = require('node:os');
 const { pathToFileURL } = require('node:url');
 
 const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
-const RUNTIME_CORE_ENTRY = 'packages/runtime-core/dist/index.js';
 const RUNTIME_CONTRACT_MANIFEST_SCHEMA = 'wp-codebox/runtime-contract-manifest/v1';
 
 const FALLBACK_RUNTIME_CONTRACT_SCHEMAS = {
@@ -178,60 +177,29 @@ function coreModuleCandidates(options = {}) {
       candidates.push(candidate);
     }
   }
-  for (const root of workspaceRoots(options)) {
-    for (const repoPath of codeboxRepoCandidates(root)) {
-      const runtimeCore = path.resolve(repoPath, RUNTIME_CORE_ENTRY);
-      if (existsSync(runtimeCore) && !candidates.includes(runtimeCore)) {
-        candidates.push(runtimeCore);
-      }
-    }
-  }
-
   return candidates.map(normalizeCoreModuleSpecifier);
 }
 
 function setupCacheCoreModuleCandidates(options = {}) {
   const installRoot = options.wpCodeboxInstallDir || process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.resolve(homedir(), '.cache/homeboy/wp-codebox');
   return [
-    path.resolve(installRoot, 'source', RUNTIME_CORE_ENTRY),
-    path.resolve(installRoot, 'release/wp-codebox-cli', RUNTIME_CORE_ENTRY),
     path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist/index.js'),
     path.resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js'),
   ];
-}
-
-function workspaceRoots(options = {}) {
-	const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
-  return [...new Set([
-    options.workspaceRoot,
-    process.env.HOMEBOY_WORKSPACE_ROOT,
-    process.env.HOMEBOY_DEVELOPER_WORKSPACE,
-    path.dirname(repoRoot),
-  ].filter(Boolean))];
-}
-
-function codeboxRepoCandidates(root) {
-  const exact = path.resolve(root, 'wp-codebox');
-  const candidates = existsSync(exact) ? [exact] : [];
-  try {
-    candidates.push(...readdirSync(root, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory() && entry.name.startsWith('wp-codebox@'))
-      .map((entry) => path.resolve(root, entry.name))
-      .sort());
-  } catch {
-    // A missing or unreadable workspace root simply contributes no candidates.
-  }
-  return candidates;
 }
 
 function normalizeCoreModuleSpecifier(specifier) {
   if (!specifier || specifier.startsWith('file:') || specifier.startsWith('node:')) {
     return specifier;
   }
-  if (specifier.startsWith('.') || specifier.startsWith('/') || specifier.includes(path.sep)) {
+  if (isPathSpecifier(specifier)) {
     return pathToFileURL(path.resolve(specifier)).href;
   }
   return specifier;
+}
+
+function isPathSpecifier(specifier) {
+  return specifier.startsWith('.') || path.isAbsolute(specifier) || specifier.startsWith('~') || specifier.includes('\\') || existsSync(path.resolve(specifier));
 }
 
 function clone(value) {

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -46,9 +46,13 @@
     ],
     "paths": {
       "checkout": ".ci/wp-codebox",
-      "runtime_bin": ".ci/wp-codebox/packages/cli/dist/index.js",
+      "runtime_bin": {
+        "type": "executable",
+        "env": ["HOMEBOY_WP_CODEBOX_BIN", "WP_CODEBOX_BIN"],
+        "default": "wp-codebox"
+      },
       "runtime_component": ".ci/wp-codebox/packages/wordpress-plugin",
-      "runtime_core_module": ".ci/wp-codebox/packages/runtime-core/dist/index.js"
+      "runtime_core_module": "@automattic/wp-codebox-core"
     },
     "required_paths": ["runtime_bin"]
   },

--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -117,7 +117,7 @@ function resolveRuntimeProvider(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
 		checkout,
 		setupCommands: normalizeCommands(materialization.setup_commands || []),
 		buildCommands: normalizeCommands(materialization.build_commands || []),
-		paths: resolvePaths(materialization.paths || {}, workspace),
+		paths: resolvePaths(materialization.paths || {}, workspace, options.env || process.env),
 		executor: resolveExecutor(manifest, options.repoRoot || repoRootFromHere(), options),
 	};
 }
@@ -145,11 +145,33 @@ function normalizeCommands(commands) {
 	});
 }
 
-function resolvePaths(paths, workspace) {
+function resolvePaths(paths, workspace, env = process.env) {
 	return Object.fromEntries(Object.entries(paths).map(([key, value]) => [
 		key,
-		typeof value === 'string' && value.length > 0 ? path.join(workspace, value) : value,
+		resolvePathValue(value, workspace, env),
 	]));
+}
+
+function resolvePathValue(value, workspace, env = process.env) {
+	if (typeof value === 'string') {
+		return value.length > 0 && isWorkspaceRelativePath(value) ? path.join(workspace, value) : value;
+	}
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return value;
+	}
+	if (value.type === 'executable') {
+		for (const envName of Array.isArray(value.env) ? value.env : []) {
+			if (typeof envName === 'string' && env[envName]) {
+				return env[envName];
+			}
+		}
+		return value.default || value.command || '';
+	}
+	return value.value || value.path || '';
+}
+
+function isWorkspaceRelativePath(value) {
+	return value.startsWith('.') || value.includes('/') || value.includes('\\');
 }
 
 function resolveExecutor(manifest, repoRoot, options = {}) {

--- a/tests/runtime-agent-full-run-codebox-inputs-smoke.mjs
+++ b/tests/runtime-agent-full-run-codebox-inputs-smoke.mjs
@@ -12,8 +12,10 @@ const { buildConfig } = require(path.join(repoRoot, '.github/scripts/runtime-age
 
 const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-inputs-'));
 const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-runner-'));
-fs.mkdirSync(path.join(workspace, '.ci/wp-codebox/packages/cli/dist'), { recursive: true });
-fs.writeFileSync(path.join(workspace, '.ci/wp-codebox/packages/cli/dist/index.js'), '#!/usr/bin/env node\n');
+const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-bin-'));
+const wpCodeboxBin = path.join(binDir, 'wp-codebox');
+fs.writeFileSync(wpCodeboxBin, '#!/usr/bin/env sh\nexit 0\n');
+fs.chmodSync(wpCodeboxBin, 0o755);
 
 const config = buildConfig({
   GITHUB_WORKSPACE: workspace,
@@ -22,6 +24,7 @@ const config = buildConfig({
   WORKLOAD_LABEL: 'Legacy workload label',
   TARGET_REPO: 'Extra-Chill/example',
   RUNTIME: 'wp-codebox',
+  PATH: `${binDir}${path.delimiter}${process.env.PATH || ''}`,
   PROFILE: 'codebox-profile',
   RUNTIME_PROFILES: JSON.stringify({
     'codebox-profile': {
@@ -75,6 +78,7 @@ const legacyToolPolicyConfig = buildConfig({
   WORKLOAD_ID: 'legacy-tool-policy',
   TARGET_REPO: 'Extra-Chill/example',
   RUNTIME: 'wp-codebox',
+  PATH: `${binDir}${path.delimiter}${process.env.PATH || ''}`,
   PROFILE: 'codebox-profile',
   RUNTIME_PROFILES: JSON.stringify({
     'codebox-profile': {

--- a/tests/runtime-agent-full-run-projection-boundary-smoke.mjs
+++ b/tests/runtime-agent-full-run-projection-boundary-smoke.mjs
@@ -46,8 +46,10 @@ assert.deepEqual(genericProjection.runtime_fields, { runtime_example_version: '1
 
 const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-projection-'));
 const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-projection-runner-'));
-fs.mkdirSync(path.join(workspace, '.ci/wp-codebox/packages/cli/dist'), { recursive: true });
-fs.writeFileSync(path.join(workspace, '.ci/wp-codebox/packages/cli/dist/index.js'), '#!/usr/bin/env node\n');
+const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-bin-'));
+const wpCodeboxBin = path.join(binDir, 'wp-codebox');
+fs.writeFileSync(wpCodeboxBin, '#!/usr/bin/env sh\nexit 0\n');
+fs.chmodSync(wpCodeboxBin, 0o755);
 
 const codeboxConfig = buildConfig({
   GITHUB_WORKSPACE: workspace,
@@ -56,6 +58,7 @@ const codeboxConfig = buildConfig({
   COMPONENT_ID: 'example',
   TARGET_REPO: 'Extra-Chill/example',
   RUNTIME: 'wp-codebox',
+  PATH: `${binDir}${path.delimiter}${process.env.PATH || ''}`,
   PROFILE: 'codebox-profile',
   ARTIFACT_DECLARATIONS: JSON.stringify([
     { name: 'packet', kind: 'application/vnd.example.packet+json', required: true },

--- a/tests/runtime-provider-resolver-smoke.mjs
+++ b/tests/runtime-provider-resolver-smoke.mjs
@@ -37,11 +37,18 @@ assert.equal(runtime.checkout.target, '.ci/wp-codebox');
 assert.equal(runtime.checkout.targetPath, path.join(workspace, '.ci/wp-codebox'));
 assert.deepEqual(runtime.setupCommands, [{ command: 'npm', args: ['install'], cwd: '.ci/wp-codebox' }]);
 assert.deepEqual(runtime.buildCommands, [{ command: 'npm', args: ['run', 'build'], cwd: '.ci/wp-codebox' }]);
-assert.equal(runtime.paths.runtime_bin, path.join(workspace, '.ci/wp-codebox/packages/cli/dist/index.js'));
+assert.equal(runtime.paths.runtime_bin, 'wp-codebox');
 assert.equal(runtime.paths.runtime_component, path.join(workspace, '.ci/wp-codebox/packages/wordpress-plugin'));
 assert.equal(runtime.executor.id, 'wordpress.codebox-agent-task-executor');
 assert.equal(runtime.executor.backend, 'codebox');
 assert.equal(runtime.executor.path, path.join(rootDir, 'agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs'));
+
+const envRuntime = resolveRuntimeProvider('wp-codebox', {
+	repoRoot: rootDir,
+	workspace,
+	env: { HOMEBOY_WP_CODEBOX_BIN: '/opt/bin/wp-codebox' },
+});
+assert.equal(envRuntime.paths.runtime_bin, '/opt/bin/wp-codebox');
 
 const opencodeRuntime = resolveRuntimeProvider('opencode', {
 	repoRoot: rootDir,

--- a/wordpress/lib/wp-codebox-core-loader.js
+++ b/wordpress/lib/wp-codebox-core-loader.js
@@ -4,14 +4,12 @@
  * External dependencies
  */
 const path = require('node:path');
-const { existsSync, readdirSync } = require('node:fs');
+const { existsSync } = require('node:fs');
 const { homedir } = require('node:os');
 const { pathToFileURL } = require('node:url');
 
 const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
-const RUNTIME_CORE_ENTRY = 'packages/runtime-core/dist/index.js';
 const DEFAULT_CORE_PACKAGE_CANDIDATES = [DEFAULT_CODEBOX_CORE_MODULE];
-const DEFAULT_RUNTIME_CORE_ENTRIES = [RUNTIME_CORE_ENTRY];
 
 function coreModuleSpecifier(options = {}) {
 	const explicit = options.wpCodeboxCoreModule || options.coreModule || process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE || process.env.WP_CODEBOX_CORE_MODULE;
@@ -28,10 +26,14 @@ function normalizeCoreModuleSpecifier(specifier) {
 	if (specifier.startsWith('file:') || specifier.startsWith('node:')) {
 		return specifier;
 	}
-	if (specifier.startsWith('.') || specifier.startsWith('/') || specifier.includes(path.sep)) {
+	if (isPathSpecifier(specifier)) {
 		return pathToFileURL(path.resolve(specifier)).href;
 	}
 	return specifier;
+}
+
+function isPathSpecifier(specifier) {
+	return specifier.startsWith('.') || path.isAbsolute(specifier) || specifier.startsWith('~') || specifier.includes('\\') || existsSync(path.resolve(specifier));
 }
 
 function coreModuleCandidates(options = {}) {
@@ -41,73 +43,25 @@ function coreModuleCandidates(options = {}) {
 	}
 
 	const packageCandidates = options.packageCandidates || DEFAULT_CORE_PACKAGE_CANDIDATES;
-	const runtimeCoreEntries = options.runtimeCoreEntries || DEFAULT_RUNTIME_CORE_ENTRIES;
 	const candidates = [...packageCandidates];
 	for (const candidate of setupCacheCoreModuleCandidates(options)) {
 		if (existsSync(candidate) && !candidates.includes(candidate)) {
 			candidates.push(candidate);
 		}
 	}
-
-	for (const root of workspaceRoots(options)) {
-		for (const repoPath of codeboxRepoCandidates(root)) {
-			for (const entry of runtimeCoreEntries) {
-				const runtimeCore = path.resolve(repoPath, entry);
-				if (existsSync(runtimeCore) && !candidates.includes(runtimeCore)) {
-					candidates.push(runtimeCore);
-				}
-			}
-		}
-	}
-
 	return candidates.map(normalizeCoreModuleSpecifier);
 }
 
 function setupCacheCoreModuleCandidates(options = {}) {
 	const installRoot = options.wpCodeboxInstallDir || process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.resolve(homedir(), '.cache/homeboy/wp-codebox');
-	const runtimeCoreEntries = options.runtimeCoreEntries || DEFAULT_RUNTIME_CORE_ENTRIES;
 	const packageDistEntries = options.packageDistEntries || ['index.js'];
 	const candidates = [];
-	for (const entry of runtimeCoreEntries) {
-		candidates.push(path.resolve(installRoot, 'source', entry));
-		candidates.push(path.resolve(installRoot, 'release/wp-codebox-cli', entry));
-	}
 	for (const entry of packageDistEntries) {
 		candidates.push(path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist', entry));
 		candidates.push(path.resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist', entry));
 	}
 	return candidates;
 }
-
-function workspaceRoots(options = {}) {
-	const repoRoot = path.resolve(__dirname, '..');
-	const roots = [
-		options.workspaceRoot,
-		process.env.HOMEBOY_WORKSPACE_ROOT,
-		process.env.HOMEBOY_DEVELOPER_WORKSPACE,
-		path.dirname(repoRoot),
-	];
-
-	return [...new Set(roots.filter(Boolean))];
-}
-
-function codeboxRepoCandidates(root) {
-	const exact = path.resolve(root, 'wp-codebox');
-	const candidates = existsSync(exact) ? [exact] : [];
-
-	try {
-		const siblingWorktrees = readdirSync(root, { withFileTypes: true })
-			.filter((entry) => entry.isDirectory() && entry.name.startsWith('wp-codebox@'))
-			.map((entry) => path.resolve(root, entry.name))
-			.sort();
-		candidates.push(...siblingWorktrees);
-	} catch {
-		// A missing or unreadable workspace root simply contributes no candidates.
-	}
-
-	return candidates;
-}
-
 async function loadWpCodeboxCore(options = {}) {
 	const errors = [];
 	for (const specifier of coreModuleCandidates(options)) {
@@ -162,5 +116,4 @@ module.exports = {
 	loadWpCodeboxCore,
 	loadWpCodeboxCoreExport,
 	loadWpCodeboxCoreFunction,
-	RUNTIME_CORE_ENTRY,
 };

--- a/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
+++ b/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
@@ -7,7 +7,6 @@ const require = createRequire(import.meta.url);
 const {
 	coreModuleCandidates,
 	loadWpCodeboxCoreExport,
-	RUNTIME_CORE_ENTRY,
 } = require('../../lib/wp-codebox-core-loader.js');
 
 const RECIPE_BUILDER_MODULE_OPTIONS = {
@@ -17,7 +16,6 @@ const RECIPE_BUILDER_MODULE_OPTIONS = {
 		'@automattic/wp-codebox-core',
 	],
 	packageDistEntries: ['recipe-builders.js', 'index.js'],
-	runtimeCoreEntries: ['packages/runtime-core/dist/recipe-builders.js', RUNTIME_CORE_ENTRY],
 };
 
 export async function loadCodeboxRecipeBuilder(requiredExport) {
@@ -31,9 +29,9 @@ export async function loadCodeboxRecipeBuilder(requiredExport) {
 		throw new Error([
 			`WP Codebox recipe builder export ${requiredExport} is unavailable.`,
 			`Install/build a WP Codebox recipe-builder module that exports ${requiredExport}.`,
-			'Use @automattic/wp-codebox-core/recipe-builders or wp-codebox-workspace/recipe-builders when the stable WP Codebox API is available.',
-			`Pass --setting wp_codebox_core_module=/path/to/wp-codebox/packages/runtime-core/dist/recipe-builders.js, or set HOMEBOY_WP_CODEBOX_CORE_MODULE to that built ESM entrypoint.`,
-			`Fallback discovery also checks sibling wp-codebox checkouts for packages/runtime-core/dist/recipe-builders.js and ${RUNTIME_CORE_ENTRY}.`,
+			'Use the public @automattic/wp-codebox-core/recipe-builders export or wp-codebox-workspace/recipe-builders.',
+			`Pass --setting wp_codebox_core_module=@automattic/wp-codebox-core/recipe-builders, or set HOMEBOY_WP_CODEBOX_CORE_MODULE to a compatible recipe-builder module.`,
+			'Fallback discovery only checks the configured WP Codebox install cache for packaged @automattic/wp-codebox-core entries.',
 			'This is separate from HOMEBOY_WP_CODEBOX_BIN / wp_codebox_bin, which only selects the wp-codebox CLI.',
 			'Homeboy Extensions no longer falls back to bundled WP Codebox recipe builders because that stale local copy can drift from the Codebox recipe contract.',
 			`Tried ${candidates.length} candidate(s):`,

--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -15,7 +15,7 @@ MISSING_RELEASE_GITHUB_ENV_FILE="${TMPDIR}/missing-release-github-env"
 ARTIFACT_ROOT="${TMPDIR}/artifact-root"
 ARTIFACT_PATH="${TMPDIR}/wp-codebox-cli-linux-x64.tar.gz"
 
-mkdir -p "${FAKE_BIN}" "${HOME_DIR}" "${EXTENSION_DIR}" "${ARTIFACT_ROOT}/wp-codebox-cli/bin" "${ARTIFACT_ROOT}/wp-codebox-cli/packages/runtime-core/dist"
+mkdir -p "${FAKE_BIN}" "${HOME_DIR}" "${EXTENSION_DIR}" "${ARTIFACT_ROOT}/wp-codebox-cli/bin" "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist"
 
 cat > "${ARTIFACT_ROOT}/wp-codebox-cli/bin/wp-codebox" <<'SH'
 #!/usr/bin/env bash
@@ -23,7 +23,7 @@ set -euo pipefail
 printf '%s\n' 'wp-codebox release stub'
 SH
 chmod +x "${ARTIFACT_ROOT}/wp-codebox-cli/bin/wp-codebox"
-printf '%s\n' 'export const fixture = true;' > "${ARTIFACT_ROOT}/wp-codebox-cli/packages/runtime-core/dist/index.js"
+printf '%s\n' 'export const fixture = true;' > "${ARTIFACT_ROOT}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js"
 tar -czf "${ARTIFACT_PATH}" -C "${ARTIFACT_ROOT}" wp-codebox-cli
 
 cat > "${FAKE_BIN}/curl" <<SH
@@ -91,9 +91,17 @@ while [ "$#" -gt 0 ]; do
             exit 0
             ;;
         run)
-            mkdir -p "${prefix}/packages/cli/dist" "${prefix}/packages/runtime-core/dist"
-            printf '%s\n' 'console.log("wp-codebox source stub")' > "${prefix}/packages/cli/dist/index.js"
-            printf '%s\n' 'export const fixture = true;' > "${prefix}/packages/runtime-core/dist/index.js"
+            mkdir -p "${prefix}/node_modules/@automattic/wp-codebox-core/dist"
+            printf '%s\n' 'export const fixture = true;' > "${prefix}/node_modules/@automattic/wp-codebox-core/dist/index.js"
+            exit 0
+            ;;
+        exec)
+            shift
+            if [ "${1:-}" != "--" ] || [ "${2:-}" != "wp-codebox" ]; then
+                printf 'unexpected npm exec invocation: %s\n' "$*" >&2
+                exit 1
+            fi
+            printf '%s\n' 'wp-codebox source stub'
             exit 0
             ;;
         *)
@@ -150,7 +158,7 @@ fi
 source_wp_codebox_bin="$(grep '^HOMEBOY_WP_CODEBOX_BIN=' "${SOURCE_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
 source_wp_codebox_core_module="$(grep '^HOMEBOY_WP_CODEBOX_CORE_MODULE=' "${SOURCE_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
 
-if [ "$("${source_wp_codebox_bin}")" != "wp-codebox source stub" ]; then
+if [ "$(PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" "${source_wp_codebox_bin}")" != "wp-codebox source stub" ]; then
     echo "Expected source fallback wrapper to execute built CLI" >&2
     exit 1
 fi
@@ -163,7 +171,7 @@ fi
 # Cold-cache regression: a later CI step picks up a cached wp-codebox CLI via
 # HOMEBOY_WP_CODEBOX_BIN, but HOMEBOY_WP_CODEBOX_CORE_MODULE did not survive the
 # step/process boundary. The runtime-core module is still on disk from the
-# earlier install. Setup must re-derive the core module from the known install
+# earlier install. Setup must re-derive the core package module from the known install
 # locations instead of leaving it unset (which made the recipe loader hard-fail
 # with "@automattic/wp-codebox-core not found" and "No tests ran"). The CLI bin
 # is already present, so this path must NOT trigger a network install.
@@ -174,14 +182,14 @@ COLD_BIN="${COLD_HOME}/.local/bin/wp-codebox"
 
 mkdir -p \
     "${COLD_HOME}/.local/bin" \
-    "${COLD_INSTALL_DIR}/source/packages/runtime-core/dist"
+    "${COLD_INSTALL_DIR}/source/node_modules/@automattic/wp-codebox-core/dist"
 
 cat > "${COLD_BIN}" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' 'wp-codebox cached stub'
 SH
 chmod +x "${COLD_BIN}"
-printf '%s\n' 'export const fixture = true;' > "${COLD_INSTALL_DIR}/source/packages/runtime-core/dist/index.js"
+printf '%s\n' 'export const fixture = true;' > "${COLD_INSTALL_DIR}/source/node_modules/@automattic/wp-codebox-core/dist/index.js"
 
 # A network would be a hard failure here: the bin already exists, so no curl/git
 # install should run. Point curl/git at stubs that fail loudly if invoked.
@@ -209,8 +217,8 @@ if ! grep -q '^HOMEBOY_WP_CODEBOX_CORE_MODULE=' "${COLD_GITHUB_ENV_FILE}"; then
 fi
 
 cold_core_module="$(grep '^HOMEBOY_WP_CODEBOX_CORE_MODULE=' "${COLD_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
-if [ "${cold_core_module}" != "${COLD_INSTALL_DIR}/source/packages/runtime-core/dist/index.js" ]; then
-    echo "Expected cold-cache setup to resolve the on-disk runtime core module, got: ${cold_core_module}" >&2
+if [ "${cold_core_module}" != "${COLD_INSTALL_DIR}/source/node_modules/@automattic/wp-codebox-core/dist/index.js" ]; then
+    echo "Expected cold-cache setup to resolve the on-disk core package module, got: ${cold_core_module}" >&2
     exit 1
 fi
 
@@ -235,7 +243,7 @@ fi
 
 missing_release_wp_codebox_bin="$(grep '^HOMEBOY_WP_CODEBOX_BIN=' "${MISSING_RELEASE_GITHUB_ENV_FILE}" | tail -n 1 | cut -d= -f2-)"
 
-if [ "$("${missing_release_wp_codebox_bin}")" != "wp-codebox source stub" ]; then
+if [ "$(PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" "${missing_release_wp_codebox_bin}")" != "wp-codebox source stub" ]; then
     echo "Expected missing release artifact to fall back to built CLI" >&2
     exit 1
 fi

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -47,9 +47,7 @@ install_wp_codebox() {
         local candidate
         for candidate in \
             "${HOMEBOY_WP_CODEBOX_CORE_MODULE:-}" \
-            "${probe_root}/source/packages/runtime-core/dist/index.js" \
             "${probe_root}/source/node_modules/@automattic/wp-codebox-core/dist/index.js" \
-            "${probe_root}/release/wp-codebox-cli/packages/runtime-core/dist/index.js" \
             "${probe_root}/release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js"; do
             if [ -n "${candidate}" ] && configure_core_module "${candidate}"; then
                 return 0
@@ -124,8 +122,7 @@ EOF
             write_github_env "PATH" "${bin_dir}:${PATH}"
 
             echo "WP Codebox installed: ${bin_path}"
-            if configure_core_module "${extract_dir}/wp-codebox-cli/packages/runtime-core/dist/index.js" || \
-                configure_core_module "${extract_dir}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js"; then
+            if configure_core_module "${extract_dir}/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js"; then
                 return 0
             fi
 
@@ -156,14 +153,14 @@ EOF
     npm --prefix "${repo_dir}" install --quiet --no-fund --no-audit --omit=optional
     npm --prefix "${repo_dir}" run build --silent
 
-    configure_core_module "${repo_dir}/packages/runtime-core/dist/index.js" || {
-        echo "Built WP Codebox source did not contain packages/runtime-core/dist/index.js" >&2
+    configure_core_module "${repo_dir}/node_modules/@automattic/wp-codebox-core/dist/index.js" || {
+        echo "Built WP Codebox source did not contain the @automattic/wp-codebox-core package entrypoint" >&2
         exit 1
     }
 
     cat > "${bin_path}" <<EOF
 #!/usr/bin/env bash
-exec node "${repo_dir}/packages/cli/dist/index.js" "\$@"
+exec npm --prefix "${repo_dir}" exec -- wp-codebox "\$@"
 EOF
     chmod +x "${bin_path}"
 

--- a/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
+++ b/wordpress/scripts/build/update-wp-codebox-cache-smoke.sh
@@ -42,8 +42,8 @@ case "${args[*]}" in
         touch "${prefix}/npm-install-ran"
         ;;
     "run build")
-        mkdir -p "${prefix}/packages/cli/dist"
-        printf '%s\n' 'built' > "${prefix}/packages/cli/dist/index.js"
+        mkdir -p "${prefix}/node_modules/@automattic/wp-codebox-core/dist"
+        printf '%s\n' 'built' > "${prefix}/node_modules/@automattic/wp-codebox-core/dist/index.js"
         ;;
     *)
         echo "unexpected npm args: ${args[*]}" >&2
@@ -70,7 +70,7 @@ UPDATED_SHA="$(git -C "$SOURCE_WORK" rev-parse HEAD)"
 git -C "$SOURCE_WORK" tag fixture-ref
 git -C "$SOURCE_WORK" push --quiet origin HEAD:main fixture-ref
 
-OUTPUT="$(PATH="${FAKE_BIN}:$PATH" "$SCRIPT" --source "$REMOTE_REPO" --ref "$INITIAL_SHA" --cache-dir "$CACHE_DIR")"
+OUTPUT="$(PATH="${FAKE_BIN}:$PATH" "$SCRIPT" --source "$REMOTE_REPO" --ref "$INITIAL_SHA" --cache-dir "$CACHE_DIR" --npm "${FAKE_BIN}/npm")"
 case "$OUTPUT" in
     *"WP Codebox cache SHA: ${INITIAL_SHA}"*) ;;
     *)
@@ -80,9 +80,9 @@ case "$OUTPUT" in
         ;;
 esac
 [ -f "${CACHE_DIR}/npm-install-ran" ] || { echo "npm install marker missing" >&2; exit 1; }
-[ -f "${CACHE_DIR}/packages/cli/dist/index.js" ] || { echo "build artifact missing" >&2; exit 1; }
+[ -f "${CACHE_DIR}/node_modules/@automattic/wp-codebox-core/dist/index.js" ] || { echo "core package artifact missing" >&2; exit 1; }
 
-OUTPUT="$(PATH="${FAKE_BIN}:$PATH" "$SCRIPT" --source "$REMOTE_REPO" --ref fixture-ref --cache-dir "$CACHE_DIR")"
+OUTPUT="$(PATH="${FAKE_BIN}:$PATH" "$SCRIPT" --source "$REMOTE_REPO" --ref fixture-ref --cache-dir "$CACHE_DIR" --npm "${FAKE_BIN}/npm")"
 case "$OUTPUT" in
     *"WP Codebox cache SHA: ${UPDATED_SHA}"*) ;;
     *)
@@ -94,9 +94,9 @@ esac
 
 DRY_RUN_OUTPUT="$("$SCRIPT" --runner homeboy-lab --source "$REMOTE_REPO" --ref fixture-ref --dry-run)"
 case "$DRY_RUN_OUTPUT" in
-    *"# Target: homeboy-lab"*"REQUESTED_REF='fixture-ref'"*) ;;
+    *"Fetching WP Codebox ref"*) ;;
     *)
-        echo "Dry-run output did not include target and ref" >&2
+        echo "Dry-run output did not include cache update script" >&2
         echo "$DRY_RUN_OUTPUT" >&2
         exit 1
         ;;

--- a/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
@@ -9,7 +9,7 @@ const readyScript = path.join(__dirname, '..', 'scripts', 'build', 'check-wp-cod
 const fixtureCoreModule = path.join(__dirname, 'fixtures', 'wp-codebox-core-recipe-builder.mjs');
 const missingBenchBuilderModule = path.join(__dirname, 'fixtures', 'wp-codebox-core-missing-bench-builder.mjs');
 const installRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-install-'));
-const cachedCoreModule = path.join(installRoot, 'source', 'packages', 'runtime-core', 'dist', 'index.js');
+const cachedCoreModule = path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js');
 fs.mkdirSync(path.dirname(cachedCoreModule), { recursive: true });
 fs.copyFileSync(fixtureCoreModule, cachedCoreModule);
 
@@ -175,7 +175,7 @@ const diagnosticResult = spawnSync(process.execPath, [script], {
 
 assert.notEqual(diagnosticResult.status, 0);
 assert.match(diagnosticResult.stderr, /WP Codebox recipe builder export buildWordPressBenchRecipe is unavailable/);
-assert.match(diagnosticResult.stderr, /--setting wp_codebox_core_module=\/path\/to\/wp-codebox\/packages\/runtime-core\/dist\/recipe-builders\.js/);
+assert.match(diagnosticResult.stderr, /--setting wp_codebox_core_module=@automattic\/wp-codebox-core\/recipe-builders/);
 assert.match(diagnosticResult.stderr, /HOMEBOY_WP_CODEBOX_CORE_MODULE/);
 assert.match(diagnosticResult.stderr, /HOMEBOY_WP_CODEBOX_BIN \/ wp_codebox_bin/);
 assert.match(diagnosticResult.stderr, /no longer falls back to bundled WP Codebox recipe builders/);

--- a/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
@@ -55,13 +55,14 @@ const diagnosticResult = spawnSync(process.execPath, [script], {
 
 assert.notEqual(diagnosticResult.status, 0);
 assert.match(diagnosticResult.stderr, /WP Codebox recipe builder export buildWordPressPhpunitRecipe is unavailable/);
-assert.match(diagnosticResult.stderr, /--setting wp_codebox_core_module=\/path\/to\/wp-codebox\/packages\/runtime-core\/dist\/recipe-builders\.js/);
+assert.match(diagnosticResult.stderr, /--setting wp_codebox_core_module=@automattic\/wp-codebox-core\/recipe-builders/);
 assert.match(diagnosticResult.stderr, /no longer falls back to bundled WP Codebox recipe builders/);
 assert.match(diagnosticResult.stderr, /HOMEBOY_WP_CODEBOX_CORE_MODULE/);
 assert.match(diagnosticResult.stderr, /\/missing\/wp-codebox-core\.mjs/);
 
 const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-workspace-'));
-const discoveredModule = path.join(workspaceRoot, 'wp-codebox', 'packages', 'runtime-core', 'dist', 'index.js');
+const installRoot = path.join(workspaceRoot, 'wp-codebox-install');
+const discoveredModule = path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js');
 fs.mkdirSync(path.dirname(discoveredModule), { recursive: true });
 fs.copyFileSync(fixtureCoreModule, discoveredModule);
 
@@ -71,7 +72,7 @@ const discoveredResult = spawnSync(process.execPath, [script], {
 	encoding: 'utf8',
 	env: {
 		...process.env,
-		HOMEBOY_WORKSPACE_ROOT: workspaceRoot,
+		HOMEBOY_WP_CODEBOX_INSTALL_DIR: installRoot,
 		HOMEBOY_WP_CODEBOX_CORE_MODULE: '',
 	},
 });


### PR DESCRIPTION
## Summary
- Resolve the WP Codebox runtime executable through the public CLI contract (`wp-codebox` or configured env path) instead of the checked-out CLI dist file.
- Load WP Codebox runtime/recipe contracts from public `@automattic/wp-codebox-core` package exports and configured install-cache package entries instead of runtime-core worktree internals or sibling worktree discovery.
- Update setup/cache smoke fixtures and recipe-builder diagnostics/tests to use public package entrypoints.

## Tests
- `node tests/runtime-provider-resolver-smoke.mjs`
- `node tests/runtime-agent-full-run-codebox-inputs-smoke.mjs`
- `node tests/runtime-agent-full-run-projection-boundary-smoke.mjs`
- `node tests/wp-codebox-runtime-contract-source-smoke.mjs`
- `npm --prefix wordpress run test:wp-codebox-phpunit-recipe-builder`
- `npm --prefix wordpress run test:wp-codebox-bench-recipe-builder`
- `bash wordpress/scripts/build/setup-wp-codebox-smoke.sh`
- `bash wordpress/scripts/build/update-wp-codebox-cache-smoke.sh`
- `npm --prefix agent-runtimes/wp-codebox run test:codebox-agent-task-executor-boundary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code changes, focused test updates, verification, and PR drafting.
