### PR TITLE
Keep Codebox recipe helper install-local

### DIFF
--- a/wordpress/lib/wp-codebox-recipe-helper.js
+++ b/wordpress/lib/wp-codebox-recipe-helper.js
@@ -8,18 +8,45 @@ const fs = require('node:fs/promises');
 const path = require('node:path');
 const { promisify } = require('node:util');
 
-const {
-  homeboySettings,
-  wpCodeboxBin,
-  wpCodeboxCliDescriptor,
-  wpCodeboxCommand,
-} = require('../../agent-runtimes/wp-codebox/lib/wp-codebox-adapter-descriptor');
-
 const execFileAsync = promisify(execFile);
-const WP_CODEBOX_RECIPE_RUN_CLI_COMMAND = wpCodeboxCliDescriptor().commands.recipe_run;
+const WP_CODEBOX_RECIPE_RUN_CLI_COMMAND = 'recipe-run';
 const DEFAULT_MAX_BUFFER = 1024 * 1024 * 50;
 const DEFAULT_EVENT_SOURCE = 'wp_codebox';
 const DEFAULT_EVENT_PREFIX = 'recipe';
+
+function homeboySettings(env) {
+  if (!env.HOMEBOY_SETTINGS_JSON) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(env.HOMEBOY_SETTINGS_JSON);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function wpCodeboxBin(options = {}) {
+  const env = options.env || process.env;
+  const settings = homeboySettings(env);
+  return options.wpCodeboxBin
+    || options.bin
+    || settings.wp_codebox_bin
+    || settings.wpCodeboxBin
+    || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN
+    || env.HOMEBOY_WP_CODEBOX_BIN
+    || env.WP_CODEBOX_BIN
+    || 'wp-codebox';
+}
+
+function wpCodeboxCommand(bin = wpCodeboxBin()) {
+  if (/\.(?:js|cjs|mjs)$/.test(bin)) {
+    return { command: process.execPath, args: [bin] };
+  }
+
+  return { command: bin, args: [] };
+}
 
 function recipeEventName(name, options = {}) {
   const prefix = options.eventPrefix || DEFAULT_EVENT_PREFIX;

--- a/wordpress/tests/wp-codebox-recipe-helper-installed-layout-smoke.js
+++ b/wordpress/tests/wp-codebox-recipe-helper-installed-layout-smoke.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const sourceRoot = path.join(__dirname, '..');
+const installRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wordpress-extension-install-'));
+const installedExtension = path.join(installRoot, 'wordpress');
+
+try {
+  fs.cpSync(sourceRoot, installedExtension, {
+    recursive: true,
+    filter: (source) => !source.includes(`${path.sep}node_modules${path.sep}`) && !source.includes(`${path.sep}vendor${path.sep}`),
+  });
+
+  const helper = require(path.join(installedExtension, 'lib', 'wp-codebox-recipe-helper.js'));
+  assert.equal(helper.wpCodeboxBin({ env: {}, bin: '/tmp/wp-codebox.js' }), '/tmp/wp-codebox.js');
+  assert.deepEqual(helper.wpCodeboxCommand('/tmp/wp-codebox.js'), {
+    command: process.execPath,
+    args: ['/tmp/wp-codebox.js'],
+  });
+} finally {
+  fs.rmSync(installRoot, { recursive: true, force: true });
+}
+
+console.log('wp-codebox recipe helper installed layout smoke passed');


### PR DESCRIPTION
## Summary
- Remove the WordPress extension recipe helper dependency on the repo-level agent-runtimes tree.
- Keep the small WP Codebox CLI resolution helpers local to the installed WordPress extension.
- Add a regression smoke that requires the helper from a WordPress-extension-only installed layout.

## Testing
- node wordpress/tests/wp-codebox-recipe-helper-installed-layout-smoke.js
- node wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
- node --check wordpress/lib/wp-codebox-recipe-helper.js wordpress/tests/wp-codebox-recipe-helper-installed-layout-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the installed extension require failure, implementing the helper-local fix, and adding regression coverage.