### PR TITLE
fix: adapt WordPress fuzz runner to Codebox suites

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 const fs = require('node:fs');
+const path = require('node:path');
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ const {
 const { aggregateWordPressFuzzCoverage } = require('./wordpress-fuzz-coverage-aggregate');
 
 const WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA = 'homeboy/wordpress-fuzz-runner-result/v1';
+const HOMEBOY_FUZZ_CAMPAIGN_SCHEMA = 'homeboy/fuzz-campaign/v1';
 
 function readWordPressFuzzRunnerEnv(env = process.env) {
 	return stripUndefined({
@@ -29,6 +31,7 @@ function readWordPressFuzzRunnerEnv(env = process.env) {
 		runId: env.HOMEBOY_FUZZ_RUN_ID,
 		seed: env.HOMEBOY_FUZZ_SEED,
 		maxDuration: env.HOMEBOY_FUZZ_MAX_DURATION,
+		resultsFile: env.HOMEBOY_FUZZ_RESULTS_FILE,
 	});
 }
 
@@ -48,9 +51,10 @@ function buildWordPressFuzzRunnerResult(options = {}) {
 		runtimeId: workload.runtime_id || workload.runtimeId || 'wp-codebox',
 	});
 	const codeboxPlanRecipe = buildCodeboxPlanRecipe(workload);
-	const codeboxResult = normalizeCodeboxResult(workload);
+	const codeboxResult = normalizeCodeboxResult(workload, { runId });
 	const coverage = aggregateCoverage(workload, codeboxResult);
 	const status = normalizeRunnerStatus(codeboxResult, coverage);
+	const homeboyFuzzCampaign = buildHomeboyFuzzCampaign({ runId, workloadId, plan, codeboxResult, status });
 
 	return stripUndefined({
 		schema: WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
@@ -66,6 +70,7 @@ function buildWordPressFuzzRunnerResult(options = {}) {
 		wp_codebox_plan_recipe: codeboxPlanRecipe,
 		wp_codebox_result: codeboxResult,
 		coverage,
+		homeboy_fuzz_campaign: homeboyFuzzCampaign,
 		metadata: objectOrUndefined(workload.metadata),
 	});
 }
@@ -102,7 +107,7 @@ function buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDurat
 		coverage: workload.coverage || { wordpress_fuzz_coverage: true },
 		runtimeProfile: workload.runtime_profile || workload.runtimeProfile,
 		artifacts: workload.artifacts,
-		metadata: stripUndefined({ ...(workload.metadata || {}), runner: WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA }),
+		metadata: stripUndefined({ ...(workload.metadata || {}), runner: WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA, workload: stripUndefined({ id: workloadId }) }),
 	});
 }
 
@@ -123,9 +128,23 @@ function buildCodeboxPlanRecipe(workload) {
 	return buildWpCodeboxFuzzPlanRecipe(plan);
 }
 
-function normalizeCodeboxResult(workload) {
-	const result = workload.wp_codebox_result || workload.wpCodeboxResult || workload.result;
-	return result ? normalizeWpCodeboxFuzzRunResult(result) : undefined;
+function normalizeCodeboxResult(workload, context = {}) {
+	const result = workload.wp_codebox_result || workload.wpCodeboxResult || workload.wp_codebox_suite_result || workload.wpCodeboxSuiteResult || workload.result;
+	if (result) {
+		return normalizeWpCodeboxFuzzRunResult(result);
+	}
+	return normalizeWpCodeboxFuzzRunResult({
+		schema: 'wp-codebox/fuzz-suite-result/v1',
+		request_id: context.runId,
+		status: 'skipped',
+		diagnostics: [
+			{
+				severity: 'warning',
+				code: 'wp_codebox_fuzz_suite_execution_unsupported',
+				message: 'WP Codebox exposes the public fuzz suite contract, but no merged execution API was available to this runner. Provide wp_codebox_suite_result in the workload or install a Codebox runtime that executes wp-codebox/fuzz-suite/v1.',
+			},
+		],
+	});
 }
 
 function aggregateCoverage(workload, codeboxResult) {
@@ -141,13 +160,38 @@ function hasCoverageFailures(coverage) {
 }
 
 function normalizeRunnerStatus(codeboxResult, coverage) {
-	if (!codeboxResult) {
-		return 'failed';
-	}
 	if (codeboxResult.succeeded === false || hasCoverageFailures(coverage)) {
 		return 'failed';
 	}
 	return codeboxResult.status || 'succeeded';
+}
+
+function buildHomeboyFuzzCampaign({ runId, workloadId, plan, codeboxResult, status }) {
+	const diagnostics = normalizeArray(codeboxResult?.failures || codeboxResult?.metadata?.diagnostics || codeboxResult?.diagnostics);
+	return stripUndefined({
+		schema: HOMEBOY_FUZZ_CAMPAIGN_SCHEMA,
+		id: runId,
+		title: `WordPress fuzz campaign ${runId}`,
+		safety_class: 'read_only',
+		metadata: stripUndefined({
+			workload_id: workloadId,
+			plan_id: plan?.id,
+			status,
+			success: codeboxResult?.succeeded,
+			wp_codebox_result_schema: codeboxResult?.result_schema,
+			diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+			artifact_refs: normalizeArray(codeboxResult?.artifacts),
+			wordpress_fuzz_result: codeboxResult?.wordpress_fuzz_result,
+		}),
+	});
+}
+
+function writeHomeboyFuzzResultsFile(filePath, campaign) {
+	if (!filePath) {
+		return;
+	}
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, `${JSON.stringify(campaign, null, 2)}\n`);
 }
 
 function readJsonFile(filePath) {
@@ -187,7 +231,9 @@ function stripUndefined(value) {
 }
 
 module.exports = {
+	HOMEBOY_FUZZ_CAMPAIGN_SCHEMA,
 	WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
 	buildWordPressFuzzRunnerResult,
+	writeHomeboyFuzzResultsFile,
 	readWordPressFuzzRunnerEnv,
 };

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -12,17 +12,20 @@ const {
 	wordpressRuntimeTaskRequest,
 } = require('./wordpress-runtime-task-planner');
 
-const WP_CODEBOX_FUZZ_RUN_SCHEMA = 'wp-codebox/fuzz-run/v1';
-const WP_CODEBOX_FUZZ_RUN_RESULT_SCHEMA = 'wp-codebox/fuzz-run-result/v1';
+const WP_CODEBOX_FUZZ_SUITE_SCHEMA = 'wp-codebox/fuzz-suite/v1';
+const WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA = 'wp-codebox/fuzz-suite-result/v1';
+const WP_CODEBOX_FUZZ_RUN_SCHEMA = WP_CODEBOX_FUZZ_SUITE_SCHEMA;
+const WP_CODEBOX_FUZZ_RUN_RESULT_SCHEMA = WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA;
 const WORDPRESS_CODEBOX_FUZZ_RUN_CONSUMER_SCHEMA = 'homeboy/wordpress-codebox-fuzz-run-consumer/v1';
-const DEFAULT_FUZZ_RUN_ABILITY = 'wp-codebox/fuzz-run';
+const DEFAULT_FUZZ_SUITE_ABILITY = 'wp-codebox/fuzz-suite';
+const DEFAULT_FUZZ_RUN_ABILITY = DEFAULT_FUZZ_SUITE_ABILITY;
 const DEFAULT_FUZZ_RUN_EXPECTED_ARTIFACTS = [
-	'wp-codebox-fuzz-run-result',
+	'wp-codebox-fuzz-suite-result',
 	'wordpress-fuzz-coverage',
 ];
 const DEFAULT_FUZZ_RUN_ARTIFACT_DECLARATIONS = [
 	{
-		name: 'wp-codebox-fuzz-run-result',
+		name: 'wp-codebox-fuzz-suite-result',
 		semantic_key: 'fuzz.result.normalized',
 		content_type: 'application/json',
 		required: true,
@@ -64,19 +67,24 @@ const FUZZ_ARTIFACT_SEMANTIC_KEYS = {
 
 function wpCodeboxFuzzRunInput(options = {}) {
 	return stripUndefined({
-		schema: WP_CODEBOX_FUZZ_RUN_SCHEMA,
+		schema: WP_CODEBOX_FUZZ_SUITE_SCHEMA,
 		id: options.id || options.runId || options.run_id,
+		version: options.version,
 		target: options.target,
-		workload: options.workload,
 		cases: normalizeArray(options.cases),
-		seeds: normalizeArray(options.seeds),
-		limits: objectOrUndefined(options.limits),
-		coverage: objectOrUndefined(options.coverage),
-		runtime_profile: objectOrUndefined(options.runtimeProfile || options.runtime_profile),
-		artifacts: objectOrUndefined(options.artifacts),
-		metadata: objectOrUndefined(options.metadata),
+		metadata: stripUndefined({
+			...(objectOrUndefined(options.metadata) || {}),
+			workload: objectOrUndefined(options.workload),
+			seeds: normalizeArray(options.seeds).length > 0 ? normalizeArray(options.seeds) : undefined,
+			limits: objectOrUndefined(options.limits),
+			coverage: objectOrUndefined(options.coverage),
+			runtime_profile: objectOrUndefined(options.runtimeProfile || options.runtime_profile),
+			artifacts: objectOrUndefined(options.artifacts),
+		}),
 	});
 }
+
+const wpCodeboxFuzzSuiteInput = wpCodeboxFuzzRunInput;
 
 function wpCodeboxFuzzRunTaskRequest(options = {}) {
 	const input = wpCodeboxFuzzRunInput(options.input || options.abilityInput || options.ability_input || options);
@@ -91,6 +99,8 @@ function wpCodeboxFuzzRunTaskRequest(options = {}) {
 	});
 }
 
+const wpCodeboxFuzzSuiteTaskRequest = wpCodeboxFuzzRunTaskRequest;
+
 async function runWpCodeboxFuzzRun(options = {}) {
 	const request = wpCodeboxFuzzRunTaskRequest(options);
 	const runner = options.runFuzzRun || options.runRuntimeTask || options.runTask;
@@ -102,6 +112,8 @@ async function runWpCodeboxFuzzRun(options = {}) {
 	return normalizeWpCodeboxFuzzRunResult(result, { request });
 }
 
+const runWpCodeboxFuzzSuite = runWpCodeboxFuzzRun;
+
 function normalizeWpCodeboxFuzzRunResult(result = {}, context = {}) {
 	const source = result?.json || result?.result || result?.output || result;
 	const status = source?.status || source?.outcome?.status || result?.status || '';
@@ -112,7 +124,7 @@ function normalizeWpCodeboxFuzzRunResult(result = {}, context = {}) {
 	return stripUndefined({
 		schema: WORDPRESS_CODEBOX_FUZZ_RUN_CONSUMER_SCHEMA,
 		delegated_schema: WP_CODEBOX_FUZZ_RUN_SCHEMA,
-		result_schema: source?.schema || result?.schema || WP_CODEBOX_FUZZ_RUN_RESULT_SCHEMA,
+		result_schema: source?.schema || result?.schema || WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
 		request_id: source?.request_id || source?.requestId || context.request?.task_id,
 		status,
 		succeeded: status ? ['succeeded', 'success', 'passed', 'ok'].includes(String(status).toLowerCase()) : undefined,
@@ -121,15 +133,23 @@ function normalizeWpCodeboxFuzzRunResult(result = {}, context = {}) {
 		coverage_gaps: coverageGaps,
 		wordpress_fuzz_result: normalizedResult,
 		artifacts,
-		failures: normalizeArray(source?.failures || source?.errors),
-		metadata: objectOrUndefined(source?.metadata),
+		failures: normalizeArray(source?.failures || source?.errors || source?.diagnostics),
+		metadata: stripUndefined({
+			...(objectOrUndefined(source?.metadata) || {}),
+			suite: objectOrUndefined(source?.suite),
+			summary: objectOrUndefined(source?.summary),
+		}),
 	});
 }
+
+const normalizeWpCodeboxFuzzSuiteResult = normalizeWpCodeboxFuzzRunResult;
 
 function normalizeWpCodeboxFuzzArtifacts(source = {}, result = {}) {
 	const artifacts = [];
 	appendArtifactCandidates(artifacts, source?.artifacts);
+	appendArtifactCandidates(artifacts, source?.artifactRefs || source?.artifact_refs);
 	appendArtifactCandidates(artifacts, result?.artifacts);
+	appendArtifactCandidates(artifacts, result?.artifactRefs || result?.artifact_refs);
 	appendNamedArtifact(artifacts, 'fuzz_report', source?.fuzz_report || source?.fuzzReport || source?.report || source?.summary_report || source?.summaryReport);
 	appendNamedArtifact(artifacts, 'coverage', source?.coverage_artifact || source?.coverageArtifact || source?.wordpress_fuzz_coverage || source?.wordpressFuzzCoverage);
 	appendNamedArtifact(artifacts, 'normalized_fuzz_result', source?.wordpress_fuzz_result_artifact || source?.wordpressFuzzResultArtifact || source?.normalized_fuzz_result || source?.normalizedFuzzResult);
@@ -245,6 +265,9 @@ function normalizeFuzzArtifactRole(value) {
 	if (['repro_case', 'reproduction', 'repro', 'reproducer'].includes(label)) {
 		return 'repro_case';
 	}
+	if (['replay', 'replay_case', 'replay_artifact'].includes(label)) {
+		return 'repro_case';
+	}
 	if (['case_artifact', 'case_artifacts', 'artifact_ref', 'artifact_refs'].includes(label)) {
 		return 'case_artifact';
 	}
@@ -255,6 +278,9 @@ function normalizeFuzzArtifactRole(value) {
 		return 'failing_case';
 	}
 	if (/repro/.test(label)) {
+		return 'repro_case';
+	}
+	if (/replay/.test(label)) {
 		return 'repro_case';
 	}
 	if (/case/.test(label)) {
@@ -373,13 +399,20 @@ module.exports = {
 	DEFAULT_FUZZ_RUN_ABILITY,
 	DEFAULT_FUZZ_RUN_ARTIFACT_DECLARATIONS,
 	DEFAULT_FUZZ_RUN_EXPECTED_ARTIFACTS,
+	DEFAULT_FUZZ_SUITE_ABILITY,
 	FUZZ_ARTIFACT_SEMANTIC_KEYS,
 	WORDPRESS_CODEBOX_FUZZ_RUN_CONSUMER_SCHEMA,
 	WP_CODEBOX_FUZZ_RUN_RESULT_SCHEMA,
 	WP_CODEBOX_FUZZ_RUN_SCHEMA,
+	WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
 	normalizeWpCodeboxFuzzArtifacts,
 	normalizeWpCodeboxFuzzRunResult,
+	normalizeWpCodeboxFuzzSuiteResult,
 	runWpCodeboxFuzzRun,
+	runWpCodeboxFuzzSuite,
 	wpCodeboxFuzzRunInput,
 	wpCodeboxFuzzRunTaskRequest,
+	wpCodeboxFuzzSuiteInput,
+	wpCodeboxFuzzSuiteTaskRequest,
 };

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -4,10 +4,16 @@
 /**
  * Internal dependencies
  */
-const { buildWordPressFuzzRunnerResult, readWordPressFuzzRunnerEnv } = require('../../lib/wordpress-fuzz-runner');
+const {
+	buildWordPressFuzzRunnerResult,
+	readWordPressFuzzRunnerEnv,
+	writeHomeboyFuzzResultsFile,
+} = require('../../lib/wordpress-fuzz-runner');
 
 try {
-	const result = buildWordPressFuzzRunnerResult({ env: readWordPressFuzzRunnerEnv() });
+	const env = readWordPressFuzzRunnerEnv();
+	const result = buildWordPressFuzzRunnerResult({ env });
+	writeHomeboyFuzzResultsFile(env.resultsFile, result.homeboy_fuzz_campaign);
 	process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 } catch (error) {
 	process.stderr.write(`${error.message}\n`);

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const {
+	HOMEBOY_FUZZ_CAMPAIGN_SCHEMA,
 	WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
 	buildWordPressFuzzRunnerResult,
 } = require('../lib/wordpress-fuzz-runner');
@@ -59,12 +60,18 @@ assert.equal(result.run_id, 'run-from-env');
 assert.equal(result.workload_id, 'workload-from-env');
 assert.equal(result.seed, 'seed-123');
 assert.equal(result.max_duration_seconds, 30);
-assert.equal(result.wp_codebox_input.schema, 'wp-codebox/fuzz-run/v1');
+assert.equal(result.wp_codebox_input.schema, 'wp-codebox/fuzz-suite/v1');
 assert.equal(result.wp_codebox_input.cases[0].target_id, 'rest-posts');
-assert.equal(result.wp_codebox_task_request.executor.config.runtime_task.ability, 'wp-codebox/fuzz-run');
+assert.equal(result.wp_codebox_task_request.executor.config.runtime_task.ability, 'wp-codebox/fuzz-suite');
 assert.equal(result.wp_codebox_plan_recipe.fuzzRun.cases[0].case_id, 'get-posts');
 assert.equal(result.coverage.schema, 'homeboy/wordpress-fuzz-coverage-aggregate/v1');
 assert.equal(result.coverage.totals.exercised, 1);
+assert.equal(result.homeboy_fuzz_campaign.schema, HOMEBOY_FUZZ_CAMPAIGN_SCHEMA);
+assert.equal(result.homeboy_fuzz_campaign.id, 'run-from-env');
+assert.equal(result.homeboy_fuzz_campaign.safety_class, 'read_only');
+assert.equal(result.homeboy_fuzz_campaign.metadata.status, 'failed');
+assert.equal(result.homeboy_fuzz_campaign.metadata.wp_codebox_result_schema, 'wp-codebox/fuzz-suite-result/v1');
+assert.equal(result.homeboy_fuzz_campaign.metadata.diagnostics[0].code, 'wp_codebox_fuzz_suite_execution_unsupported');
 assert(!JSON.stringify(result).includes('woocommerce'), 'WordPress fuzz runner must stay product-agnostic');
 
 const executedResult = buildWordPressFuzzRunnerResult({
@@ -74,17 +81,22 @@ const executedResult = buildWordPressFuzzRunnerResult({
 	},
 	workload: {
 		...workload,
-		wp_codebox_result: {
+		wp_codebox_suite_result: {
+			schema: 'wp-codebox/fuzz-suite-result/v1',
+			suite: { id: 'generic-wordpress-plan' },
 			status: 'succeeded',
+			artifactRefs: [{ path: 'artifacts/replay.json', kind: 'replay' }],
 		},
 	},
 });
 
 assert.equal(executedResult.status, 'succeeded');
 assert.equal(executedResult.succeeded, true);
+assert.equal(executedResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path, 'artifacts/replay.json');
 
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wordpress-fuzz-runner-'));
 const workloadPath = path.join(tempDir, 'workload.json');
+const resultsPath = path.join(tempDir, 'fuzz-results.json');
 fs.writeFileSync(workloadPath, `${JSON.stringify(workload)}\n`);
 
 const cli = spawnSync(process.execPath, [path.join(__dirname, '..', 'scripts', 'fuzz', 'fuzz-runner.cjs')], {
@@ -96,6 +108,7 @@ const cli = spawnSync(process.execPath, [path.join(__dirname, '..', 'scripts', '
 		HOMEBOY_FUZZ_RUN_ID: 'cli-run',
 		HOMEBOY_FUZZ_SEED: 'cli-seed',
 		HOMEBOY_FUZZ_MAX_DURATION: '15',
+		HOMEBOY_FUZZ_RESULTS_FILE: resultsPath,
 	},
 });
 
@@ -104,6 +117,10 @@ const cliResult = JSON.parse(cli.stdout);
 assert.equal(cliResult.schema, WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA);
 assert.equal(cliResult.run_id, 'cli-run');
 assert.equal(cliResult.succeeded, false);
-assert.equal(cliResult.wp_codebox_input.limits.max_duration_seconds, 15);
+assert.equal(cliResult.wp_codebox_input.metadata.limits.max_duration_seconds, 15);
+const homeboyCampaign = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+assert.equal(homeboyCampaign.schema, HOMEBOY_FUZZ_CAMPAIGN_SCHEMA);
+assert.equal(homeboyCampaign.id, 'cli-run');
+assert.equal(homeboyCampaign.metadata.diagnostics[0].code, 'wp_codebox_fuzz_suite_execution_unsupported');
 
 console.log('WordPress fuzz runner smoke passed.');

--- a/wordpress/tests/wordpress-public-export-boundary.test.js
+++ b/wordpress/tests/wordpress-public-export-boundary.test.js
@@ -35,11 +35,14 @@ assert.equal(typeof wordpress.wpCodebox.resolveWpCodeboxArtifactPath, 'function'
 assert.equal(typeof wordpress.wpCodebox.runWpCodeboxRecipe, 'function');
 assert.equal(typeof wordpress.wpCodebox.buildWpCodeboxFuzzPlanRecipe, 'function');
 assert.equal(typeof wordpress.wpCodebox.wpCodeboxFuzzRunTaskRequest, 'function');
+assert.equal(typeof wordpress.wpCodebox.wpCodeboxFuzzSuiteTaskRequest, 'function');
 
 assert.equal(typeof wordpress.resolveWpCodeboxArtifactPath, 'function');
 assert.equal(typeof wordpress.runWpCodeboxRecipe, 'function');
 assert.equal(typeof wordpress.buildWpCodeboxFuzzPlanRecipe, 'function');
 assert.equal(typeof wordpress.wpCodeboxFuzzRunTaskRequest, 'function');
+assert.equal(typeof wordpress.wpCodeboxFuzzSuiteTaskRequest, 'function');
+assert.equal(wordpress.WP_CODEBOX_FUZZ_SUITE_SCHEMA, 'wp-codebox/fuzz-suite/v1');
 assert.equal(typeof wordpress.applyApprovedWpCodeboxArtifact, 'function');
 assert.equal(wordpress.compareCodeboxMemoryResults, undefined);
 

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -5,11 +5,18 @@ const assert = require('node:assert/strict');
 const {
 	DEFAULT_FUZZ_RUN_ABILITY,
 	DEFAULT_FUZZ_RUN_ARTIFACT_DECLARATIONS,
+	DEFAULT_FUZZ_SUITE_ABILITY,
+	WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
 	WP_CODEBOX_FUZZ_RUN_SCHEMA,
 	normalizeWpCodeboxFuzzRunResult,
+	normalizeWpCodeboxFuzzSuiteResult,
 	runWpCodeboxFuzzRun,
+	runWpCodeboxFuzzSuite,
 	wpCodeboxFuzzRunInput,
 	wpCodeboxFuzzRunTaskRequest,
+	wpCodeboxFuzzSuiteInput,
+	wpCodeboxFuzzSuiteTaskRequest,
 } = require('../lib/wp-codebox-fuzz-run');
 
 const input = wpCodeboxFuzzRunInput({
@@ -25,8 +32,10 @@ const input = wpCodeboxFuzzRunInput({
 });
 
 assert.equal(input.schema, WP_CODEBOX_FUZZ_RUN_SCHEMA);
+assert.equal(input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 assert.equal(input.target.slug, 'sample-plugin');
-assert.deepEqual(input.limits, { max_cases: 1 });
+assert.deepEqual(input.metadata.limits, { max_cases: 1 });
+assert.equal(wpCodeboxFuzzSuiteInput({ id: 'suite-alias' }).schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 
 const taskRequest = wpCodeboxFuzzRunTaskRequest({
 	taskId: 'wp-codebox-fuzz-run-smoke',
@@ -38,14 +47,16 @@ const taskRequest = wpCodeboxFuzzRunTaskRequest({
 assert.equal(taskRequest.executor.backend, 'codebox');
 assert.equal(taskRequest.executor.runtime, 'wp-codebox');
 assert.equal(taskRequest.executor.config.runtime_task.ability, DEFAULT_FUZZ_RUN_ABILITY);
+assert.equal(taskRequest.executor.config.runtime_task.ability, DEFAULT_FUZZ_SUITE_ABILITY);
 assert.equal(taskRequest.executor.config.runtime_task.input.schema, WP_CODEBOX_FUZZ_RUN_SCHEMA);
-assert.deepEqual(taskRequest.expected_artifacts, ['wp-codebox-fuzz-run-result', 'wordpress-fuzz-coverage']);
+assert.deepEqual(taskRequest.expected_artifacts, ['wp-codebox-fuzz-suite-result', 'wordpress-fuzz-coverage']);
 assert.deepEqual(taskRequest.artifact_declarations, DEFAULT_FUZZ_RUN_ARTIFACT_DECLARATIONS);
 assert.deepEqual(
 	taskRequest.artifact_declarations.filter((artifact) => artifact.required === true).map((artifact) => artifact.name),
 	taskRequest.expected_artifacts
 );
 assert(!JSON.stringify(taskRequest).includes('woocommerce'), 'fuzz-run helper must stay product-agnostic');
+assert.equal(wpCodeboxFuzzSuiteTaskRequest({ taskId: 'suite-task' }).executor.config.runtime_task.input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 
 let invoked = false;
 runWpCodeboxFuzzRun({
@@ -53,12 +64,14 @@ runWpCodeboxFuzzRun({
 	input,
 	runFuzzRun: async (request) => {
 		invoked = true;
-		assert.equal(request.executor.config.runtime_task.input.schema, WP_CODEBOX_FUZZ_RUN_SCHEMA);
+		assert.equal(request.executor.config.runtime_task.input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 		return {
 			json: {
-				schema: 'wp-codebox/fuzz-run-result/v1',
+				schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+				suite: { id: 'fuzz-smoke' },
 				request_id: request.task_id,
 				status: 'succeeded',
+				summary: { total: 2, passed: 1, failed: 0, error: 0, skipped: 1 },
 				coverage_summary: {
 					surface_count: 3,
 					exercised_count: 1,
@@ -106,14 +119,20 @@ runWpCodeboxFuzzRun({
 					case_artifact: { path: 'cases/case-001.json', case_id: 'case-001' },
 					repro_case: { path: 'repro/case-002.js', case_id: 'case-002' },
 				},
+				artifactRefs: [
+					{ path: 'replay/case-001.json', kind: 'replay', contentType: 'application/json' },
+				],
 			},
 		};
 	},
 }).then((summary) => {
 	assert.equal(invoked, true);
 	assert.equal(summary.schema, 'homeboy/wordpress-codebox-fuzz-run-consumer/v1');
-	assert.equal(summary.delegated_schema, WP_CODEBOX_FUZZ_RUN_SCHEMA);
+	assert.equal(summary.delegated_schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+	assert.equal(summary.result_schema, WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA);
 	assert.equal(summary.succeeded, true);
+	assert.equal(summary.metadata.suite.id, 'fuzz-smoke');
+	assert.equal(summary.metadata.summary.total, 2);
 	assert.equal(summary.coverage.hooks.actions.init, 1);
 	assert.equal(summary.coverage_summary.surface_count, 3);
 	assert.equal(summary.coverage_summary.exercised_count, 1);
@@ -129,8 +148,9 @@ runWpCodeboxFuzzRun({
 	assert.equal(summary.wordpress_fuzz_result.artifacts.some((artifact) => artifact.role === 'coverage'), true);
 	assert.equal(summary.wordpress_fuzz_result.artifacts.some((artifact) => artifact.name === 'placeholder-only'), false);
 	assert.equal(summary.coverage_gaps[0].status, 'skipped');
-	assert.deepEqual(summary.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'coverage', 'normalized_fuzz_result', 'fuzz_case', 'failing_case', 'case_artifact', 'repro_case']);
+	assert.deepEqual(summary.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'coverage', 'normalized_fuzz_result', 'fuzz_case', 'failing_case', 'case_artifact', 'repro_case', 'repro_case']);
 	assert.equal(summary.artifacts[0].semantic_key, 'fuzz.report');
+	assert.equal(summary.artifacts[7].semantic_key, 'fuzz.case.repro');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'coverage').semantic_key, 'fuzz.coverage');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'coverage').size_bytes, 123);
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'normalized_fuzz_result').semantic_key, 'fuzz.result.normalized');
@@ -144,6 +164,10 @@ runWpCodeboxFuzzRun({
 	const normalized = normalizeWpCodeboxFuzzRunResult({ status: 'failed', failures: [{ message: 'boom' }] });
 	assert.equal(normalized.succeeded, false);
 	assert.equal(normalized.failures[0].message, 'boom');
+	assert.equal(normalizeWpCodeboxFuzzSuiteResult({ status: 'passed' }).result_schema, WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA);
+	return runWpCodeboxFuzzSuite({ taskId: 'suite-run-alias', runFuzzRun: async () => ({ status: 'passed' }) });
+}).then((summary) => {
+	assert.equal(summary.delegated_schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 
 	console.log('wp-codebox fuzz-run smoke passed');
 }).catch((error) => {


### PR DESCRIPTION
## Summary
- Emit WP Codebox fuzz requests as the merged public `wp-codebox/fuzz-suite/v1` contract while keeping existing helper aliases usable.
- Normalize `wp-codebox/fuzz-suite-result/v1` responses, including `artifactRefs` / replay refs, into the WordPress fuzz runner summary.
- Write a Homeboy `homeboy/fuzz-campaign/v1` campaign object to `HOMEBOY_FUZZ_RESULTS_FILE` and preserve a clear unsupported diagnostic when no merged Codebox execution API is available.

## Context
- Homeboy results file ingestion: Extra-Chill/homeboy#5719
- WP Codebox public fuzz suite API: Automattic/wp-codebox#1332
- WP Codebox fuzz run recipe primitive exists in Automattic/wp-codebox#1290, but no separate merged execution PR was found for running `wp-codebox/fuzz-suite/v1` directly.

## Verification
- `npm run test:wp-codebox-fuzz-run`
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wordpress-public-export-boundary`
- `npm run lint:js -- lib/wp-codebox-fuzz-run.js lib/wordpress-fuzz-runner.js scripts/fuzz/fuzz-runner.cjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting upstream PR contracts, implementing the focused fuzz suite adapter/result-file normalization, updating smoke tests, and preparing this PR.