### PR TITLE
Align WP Codebox public contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,14 +170,14 @@ WP Codebox is expected to consume a `wp-codebox/runtime-profile/v1` payload with
 generic runtime dependencies such as `components`, `plugins`, `mu_plugins`,
 `themes`, `overlays`, `runtime_overlays`, `env`, and `provider_plugins`.
 Homeboy Extensions forwards those shapes as Codebox-owned runtime profile data
-without expanding them into Codebox orchestration internals. Data Machine ability
-selection, Homeboy task schemas, and caller-owned artifact declarations stay in
-Homeboy Extensions.
+through the current public runtime profile contract. Data Machine ability
+selection, Homeboy task schemas, and caller-owned artifact declarations are
+prepared by Homeboy Extensions before WP Codebox runs the task.
 
 Homeboy Extensions consumes a Codebox-owned `wp-codebox/parent-tool-bridge/v1`
-when the runtime profile exposes one. When it is missing, the adapter only
-declares an upstream primitive requirement in the runtime profile; it does not
-inject bridge environment variables or synthesize sandbox bridge descriptors.
+when the runtime profile exposes one. When it is missing, the adapter declares
+the upstream primitive requirement in the runtime profile for WP Codebox to
+fulfill through the public parent-tool-bridge contract.
 
 For WordPress fuzzing, Homeboy Extensions builds and forwards the
 Codebox-owned `wp-codebox/fuzz-run/v1` request through the WP Codebox runtime

--- a/agent-runtimes/wp-codebox/README.md
+++ b/agent-runtimes/wp-codebox/README.md
@@ -3,7 +3,7 @@
 This package is the first-class WP Codebox agent-task runtime surface used by
 Homeboy. It declares the provider contract, runtime-local CLI, and normalized
 AgentTaskOutcome conversion for consumers that need a WordPress-capable AI
-runtime without embedding WP Codebox details in their own extension manifests.
+runtime through the WP Codebox executable and package contracts.
 
 ## Runtime Defaults
 
@@ -15,12 +15,11 @@ override through the provider contract or task conversion options:
 - `component_path_defaults` maps runtime component contracts, legacy aliases, and
   discovery hints into generic runtime component path keys.
 - `provider_metadata` declares the operator-facing provider ids, executor backend,
-  runtime id, model fields, and provider-plugin guidance without requiring Homeboy
-  core to know WordPress or Codebox provider details.
+  runtime id, model fields, and provider-plugin guidance consumed by the WP
+  Codebox runtime contract.
 
-The JavaScript executor consumes these manifest fields instead of owning product
-policy in code. Callers can supply generic manifest values without adding new
-runtime-specific branches.
+The JavaScript executor consumes these manifest fields as product policy. Callers
+can supply generic manifest values through the runtime package contract.
 
 Runtime selection and provider selection are separate concerns:
 
@@ -30,16 +29,15 @@ Runtime selection and provider selection are separate concerns:
 - `executor.config.provider` selects the WordPress AI provider id, such as
   `openai`, `codex`, or `claude-code`.
 - `executor.config.model` or `executor.model` carries the provider model name as
-  opaque runtime metadata. The runtime forwards it to WP Codebox and provider
-  plugins; Homeboy core does not interpret model names.
+  runtime metadata. Homeboy forwards the model name to WP Codebox and provider
+  plugins through the provider contract.
 
-## Adapter Boundary
+## Adapter Contract
 
 Homeboy Extensions is a thin adapter for Codebox-owned runtime primitives. It
 forwards `wp-codebox/runtime-profile/v1` dependencies, provider plugins, overlays,
-env, and mounts as runtime profile data. It no longer expands profile
-dependencies into `component_contracts` / `extra_plugins` or injects parent tool
-bridge environment variables.
+env, and mounts as runtime profile data, then invokes WP Codebox through the
+runtime package's executable contract.
 
 Codebox owns these primitives:
 
@@ -51,13 +49,13 @@ Codebox owns these primitives:
 - `wp-codebox/provider-runtime-invocation-contract/v1` for runner workspace, transcript, and artifact handoff operations.
 - `wp-codebox/evidence-artifact-envelope/v1` for typed artifacts, evidence refs, and run summaries.
 
-`lib/codebox-run-agent-task-contract.js` is the adapter boundary for launching
+`lib/codebox-run-agent-task-contract.js` is the adapter contract for launching
 Codebox agent tasks. It builds the preferred `wp-codebox/run-agent-task/v1`
 request shape and selects the stable `run-agent-task` CLI when the installed
 Codebox package advertises it. Older packages continue through the legacy
-`agent-task-run` / `wp-codebox/task-input/v1` path, but that compatibility is
-kept behind this adapter so the follow-up swap can remove the fallback without
-changing Homeboy callers.
+`agent-task-run` / `wp-codebox/task-input/v1` path, and that compatibility lives
+in this adapter so the follow-up swap can remove the fallback while preserving
+Homeboy caller contracts.
 
 Provider credentials stay outside adapter payloads. The adapter forwards
 `secret_env` names and a `provider_credential_boundary` descriptor, and rejects
@@ -73,8 +71,7 @@ backend-neutral fields such as `execution.type`, `execution.argv`,
 `execution.agent`, `input`, `workspace`, `limits`, `artifacts`, `diagnostics`, and
 `metadata`.
 
-The runtime manifest does not advertise a delegated-run capability yet. The
-current executable path still targets the existing task-input runner contract, so
-Homeboy should not select this runtime for generic delegated command execution
-until the substrate accepts the neutral request shape and returns the neutral
-result shape directly.
+The runtime manifest currently advertises agent-task execution. The current
+executable path targets the existing task-input runner contract; generic
+delegated command execution will use a future manifest capability when WP Codebox
+accepts the neutral request shape and returns the neutral result shape directly.

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -54,8 +54,6 @@ const {
   WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
   WP_CODEBOX_WORKSPACE_MOUNT_KIND,
   WP_CODEBOX_LEGACY_WORKSPACE_MOUNT_KIND,
-  wpCodeboxLegacyRuntimeComponentAliasDiagnostics,
-  wpCodeboxLegacyRuntimeComponentAliasValues,
   wpCodeboxProviderRuntimeInvocationContract,
   wpCodeboxProviderRuntimeOperationEntry,
 } = require('./wp-codebox-adapter-contract');
@@ -132,12 +130,6 @@ const AGENT_BUNDLE_TRIGGER_FIELDS = AGENT_BUNDLE_CONFIG_FIELDS.filter((field) =>
   'prompt',
   'provider_plugin_paths',
 ].includes(field));
-
-const LEGACY_RUNTIME_PREFIX = ['data', 'machine'].join('_');
-const LEGACY_BUNDLE_KEYS = [
-  `${LEGACY_RUNTIME_PREFIX}_bundle`,
-  `${LEGACY_RUNTIME_PREFIX}Bundle`,
-];
 
 const WP_CODEBOX_RUNTIME_GAP_TRACKERS = [
   {
@@ -320,7 +312,6 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   assertProviderCredentialBoundaryNamesOnly(request.inputs || {});
   const runtimeOptions = runtimeOptionsFromExecutorConfig(config, options);
   const inputs = request.inputs || {};
-  const compatibilityDiagnostics = wpCodeboxLegacyRuntimeComponentAliasDiagnostics(config);
   const defaults = defaultCodeboxRuntimeConfig(request, config, inputs, runtimeOptions);
   const workspaceMaterialization = defaultWorkspaceMaterialization(defaults.workspaceRoot, request, config, inputs, runtimeOptions);
   const target = defaultWorkspaceTargetPayload(inputs.target || request.workspace || {}, workspaceMaterialization);
@@ -383,7 +374,6 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     artifact_declarations: artifactDeclarations,
     policy: request.policy || {},
     context,
-    ...(compatibilityDiagnostics.length > 0 ? { compatibility_diagnostics: compatibilityDiagnostics } : {}),
     recipe,
     sandbox_tool_policy: sandboxToolPolicy,
     runtime_task: runtimeTask,
@@ -1086,12 +1076,10 @@ function runtimeComponentPaths(config, options = {}) {
     : {};
   const contractPaths = runtimeComponentPathsFromContracts(config.component_contracts || options.componentContracts || [], options);
   const aliases = runtimeComponentPathAliases(options);
-  const legacyAliases = wpCodeboxLegacyRuntimeComponentAliasValues(config);
   const resolved = {
     ...contractPaths,
-    agents_api: config.agents_api || config.agents_api_path || options.agentsApi,
-    agent_runtime: config.agent_runtime || legacyAliases.agent_runtime || options.agentRuntime,
-    agent_runtime_tools: config.agent_runtime_tools || legacyAliases.agent_runtime_tools || options.agentRuntimeTools,
+    agent_runtime: config.agent_runtime || options.agentRuntime,
+    agent_runtime_tools: config.agent_runtime_tools || options.agentRuntimeTools,
     ...explicit,
     runtime: explicit.runtime || runtimeComponents.runtime,
   };
@@ -1178,14 +1166,9 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
   const provider = config.provider || options.provider || defaultProvider(settings);
   const providerConfig = providerConfigFor(provider, settings, providerDefaults);
   const model = config.model || options.model || defaultModelForProvider(provider, settings, providerConfig);
-  const agentsApiPath = firstExistingPath(
-    options.agentsApi,
-    ...componentDiscoveryCandidates('agents_api', discovery, settings, workspaceBase, { agent_runtime: agentRuntimePath }),
-  );
   const phpAiClientPath = defaultPhpAiClientPath(settings, options);
 
   return {
-    agentsApi: agentsApiPath,
     agentRuntime: agentRuntimePath,
     agentRuntimeTools: agentRuntimeToolsPath,
     legacyRuntime: agentRuntimePath,
@@ -1836,10 +1819,8 @@ function agentBundleConfigFromAgentTaskRequest(request, config, inputs) {
   const explicitBundleSources = [
     inputs.agent_bundle,
     inputs.agentBundle,
-    ...LEGACY_BUNDLE_KEYS.map((key) => inputs[key]),
     config.agent_bundle,
     config.agentBundle,
-    ...LEGACY_BUNDLE_KEYS.map((key) => config[key]),
   ].filter((value) => value && typeof value === 'object');
   const requestedBundle = config.execution_kind === 'agent_bundle'
     || inputs.execution_kind === 'agent_bundle'

--- a/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
@@ -239,7 +239,7 @@ function codeboxParentToolBridgeRequirement() {
     primitive_schema: WP_CODEBOX_PARENT_TOOL_BRIDGE_SCHEMA,
     status: 'required-upstream-primitive',
     adapter_behavior: 'declare_requirement_only',
-    requirement: 'Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component; Homeboy Extensions does not inject bridge env or synthesize sandbox bridge descriptors.',
+    requirement: 'Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component declared by the public parent-tool-bridge contract.',
   };
 }
 

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -192,36 +192,6 @@ function wpCodeboxProviderRuntimeOperationConfig(key, operation) {
   });
 }
 
-function wpCodeboxLegacyRuntimeComponentAliasFields() {
-  const prefix = ['data', 'machine'].join('_');
-  return {
-    agent_runtime: [prefix, `${prefix}_path`],
-    agent_runtime_tools: [`${prefix}_code`, `${prefix}_code_path`],
-  };
-}
-
-function wpCodeboxLegacyRuntimeComponentAliasValues(config = {}) {
-  const fields = wpCodeboxLegacyRuntimeComponentAliasFields();
-  return Object.fromEntries(Object.entries(fields).map(([canonical, aliases]) => [
-    canonical,
-    firstValue(...aliases.map((alias) => config[alias])),
-  ]));
-}
-
-function wpCodeboxLegacyRuntimeComponentAliasDiagnostics(config = {}) {
-  return Object.entries(wpCodeboxLegacyRuntimeComponentAliasFields()).flatMap(([canonical, aliases]) => aliases
-    .filter((alias) => config[alias] !== undefined)
-    .map((alias) => ({
-      class: 'codebox.compat.deprecated_runtime_component_alias',
-      message: `Deprecated runtime component alias "${alias}" was accepted for compatibility; use "${canonical}" instead.`,
-      data: {
-        alias,
-        replacement: canonical,
-        compatibility: 'accepted-for-current-callers',
-      },
-    })));
-}
-
 function firstValue(...values) {
   return values.find((value) => value !== undefined && value !== null && value !== '');
 }
@@ -250,9 +220,6 @@ module.exports = {
   WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
   WP_CODEBOX_WORKSPACE_MOUNT_KIND,
   WP_CODEBOX_LEGACY_WORKSPACE_MOUNT_KIND,
-  wpCodeboxLegacyRuntimeComponentAliasDiagnostics,
-  wpCodeboxLegacyRuntimeComponentAliasFields,
-  wpCodeboxLegacyRuntimeComponentAliasValues,
   wpCodeboxProviderRuntimeInvocationContract,
   wpCodeboxProviderRuntimeOperationConfig,
   wpCodeboxProviderRuntimeOperationEntry,

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -126,14 +126,14 @@ const WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS = [
     schema: 'wp-codebox/runtime-profile/v1',
     owner: 'wp-codebox',
     adapter_behavior: 'forward_profile_payload',
-    requirement: 'Consume generic runtime dependencies, provider plugins, overlays, env, and mounts without Homeboy expanding Codebox orchestration internals.',
+    requirement: 'Consume generic runtime dependencies, provider plugins, overlays, env, and mounts through the public runtime profile payload Homeboy forwards.',
   },
   {
     id: 'parent-tool-bridge',
     schema: 'wp-codebox/parent-tool-bridge/v1',
     owner: 'wp-codebox',
     adapter_behavior: 'declare_requirement_when_missing',
-    requirement: 'Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component instead of Homeboy injecting bridge implementation details.',
+    requirement: 'Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component declared by the public parent-tool-bridge contract.',
   },
   {
     id: 'provider-runtime-invocation',

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -591,7 +591,6 @@ async function runTaskRunner(request) {
     return agentTaskOutcomeFromCodeboxResult(request, preflightPayload, { exitStatus: 1, ...coreNormalizers });
   }
   const configArgs = [
-    ['--agents-api', config.agents_api_path || config.agentsApiPath],
     ['--homeboy', config.homeboy_path || config.homeboyPath],
     ['--homeboy-extensions', config.homeboy_extensions_path || config.homeboyExtensionsPath],
   ].flatMap(([name, value]) => (value ? [name, value] : []));

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -339,13 +339,6 @@ function workspaceRootFromMounts(mounts) {
   return mountedWorkspace?.source || '';
 }
 
-function bundledAgentsApiPath(dataMachinePath) {
-  return firstExistingPath(
-    path.join(dataMachinePath || '', 'vendor', 'wordpress', 'agents-api'),
-    path.join(dataMachinePath || '', 'vendor', 'automattic', 'agents-api'),
-  );
-}
-
 function runtimeStackMountEntries(request) {
   return [
     ...(request.runtime_stack_mounts || []),
@@ -1118,28 +1111,9 @@ function attachFailureEvidence(payload, evidence) {
   };
 }
 
-const LEGACY_RUNTIME_PREFIX = ['data', 'machine'].join('_');
-const LEGACY_BUNDLE_KEYS = [
-  `${LEGACY_RUNTIME_PREFIX}_bundle`,
-  `${LEGACY_RUNTIME_PREFIX}Bundle`,
-];
-
-function legacyValue(source, suffix = '') {
-  if (!source || typeof source !== 'object') {
-    return '';
-  }
-  const key = suffix ? `${LEGACY_RUNTIME_PREFIX}_${suffix}` : LEGACY_RUNTIME_PREFIX;
-  return source[key] || source[`${key}_path`] || '';
-}
-
 function requestAgentBundle(request) {
   if (request.agent_bundle && typeof request.agent_bundle === 'object') {
     return request.agent_bundle;
-  }
-  for (const key of LEGACY_BUNDLE_KEYS) {
-    if (request[key] && typeof request[key] === 'object') {
-      return request[key];
-    }
   }
   return {};
 }
@@ -1150,31 +1124,12 @@ function requestRuntimeComponents(request, mounts = []) {
     : {};
   const contractPaths = runtimeComponentPathsFromContracts(requestComponentContracts(request));
   const agentRuntime = remapLabWorkspacePath(explicit.agent_runtime || contractPaths.agent_runtime);
-  const agentsApi = remapLabWorkspacePath(
-    explicit.agents_api
-      || contractPaths.agents_api
-      || request.agents_api_path
-      || request.agents_api
-      || agentsApiPathFromRuntime(agentRuntime),
-    'agents-api'
-  );
   return Object.fromEntries(Object.entries({
     ...contractPaths,
     ...explicit,
-    agents_api: agentsApi,
     agent_runtime: agentRuntime,
     agent_runtime_tools: remapLabWorkspacePath(explicit.agent_runtime_tools || contractPaths.agent_runtime_tools),
   }).filter(([, value]) => value !== '' && value !== undefined));
-}
-
-function agentsApiPathFromRuntime(agentRuntime) {
-  if (!agentRuntime) {
-    return '';
-  }
-  return [
-    path.join(agentRuntime, 'vendor', 'wordpress', 'agents-api'),
-    path.join(agentRuntime, 'vendor', 'automattic', 'agents-api'),
-  ].find((candidate) => fs.existsSync(path.join(candidate, 'agents-api.php'))) || '';
 }
 
 function runtimeComponentPathsFromContracts(contracts) {
@@ -1210,7 +1165,6 @@ function runnerInput(request, artifacts) {
   const mounts = mountEntries(request);
   const runtimeComponentPaths = {
     ...requestRuntimeComponents(request, mounts),
-    ...(argValue('--agents-api') ? { agents_api: argValue('--agents-api') } : {}),
   };
   return Object.fromEntries(Object.entries({
     parent_request: request,

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -51,7 +51,11 @@
         "env": ["HOMEBOY_WP_CODEBOX_BIN", "WP_CODEBOX_BIN"],
         "default": "wp-codebox"
       },
-      "runtime_component": ".ci/wp-codebox/packages/wordpress-plugin",
+      "runtime_component": {
+        "type": "path",
+        "env": ["HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT"],
+        "default": ""
+      },
       "runtime_core_module": "@automattic/wp-codebox-core"
     },
     "required_paths": ["runtime_bin"]

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -217,7 +217,7 @@
             "executor.config.model",
             "model"
           ],
-          "guidance": "Select the generic executor backend with executor.backend=codebox, then select the WordPress AI provider id with executor.config.provider and the provider model with executor.config.model or executor.model. Homeboy core should treat provider ids and models as opaque runtime metadata."
+          "guidance": "Select the generic executor backend with executor.backend=codebox, then select the WordPress AI provider id with executor.config.provider and the provider model with executor.config.model or executor.model. Homeboy forwards provider ids and models to the WP Codebox runtime contract."
         },
         "providers": [
           {
@@ -465,14 +465,14 @@
           "schema": "wp-codebox/runtime-profile/v1",
           "owner": "wp-codebox",
           "adapter_behavior": "forward_profile_payload",
-          "requirement": "Consume generic runtime dependencies, provider plugins, overlays, env, and mounts without Homeboy expanding Codebox orchestration internals."
+          "requirement": "Consume generic runtime dependencies, provider plugins, overlays, env, and mounts through the public runtime profile payload Homeboy forwards."
         },
         {
           "id": "parent-tool-bridge",
           "schema": "wp-codebox/parent-tool-bridge/v1",
           "owner": "wp-codebox",
           "adapter_behavior": "declare_requirement_when_missing",
-          "requirement": "Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component instead of Homeboy injecting bridge implementation details."
+          "requirement": "Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component declared by the public parent-tool-bridge contract."
         },
         {
           "id": "provider-runtime-invocation",

--- a/datamachine-agent-ci/lib/wp-codebox-compat.js
+++ b/datamachine-agent-ci/lib/wp-codebox-compat.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const DATAMACHINE_AGENT_BUNDLE_KEYS = [
+  'data_machine_bundle',
+  'dataMachineBundle',
+];
+
+const DATAMACHINE_RUNTIME_COMPONENT_ALIASES = {
+  data_machine: 'agent_runtime',
+  data_machine_path: 'agent_runtime',
+  data_machine_code: 'agent_runtime_tools',
+  data_machine_code_path: 'agent_runtime_tools',
+};
+
+module.exports = {
+  DATAMACHINE_AGENT_BUNDLE_KEYS,
+  DATAMACHINE_RUNTIME_COMPONENT_ALIASES,
+};

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -16,9 +16,9 @@ Each runtime package should include:
 - Runnable provider command files referenced by the manifest.
 - Tests or fixtures proving the manifest and provider command contract.
 
-The package may include implementation libraries, but Homeboy selects runtimes
-through the manifest and provider command contract, not by importing private
-runtime modules.
+The package may include implementation libraries. Homeboy selects runtimes
+through the manifest and provider command contract exported by the runtime
+package.
 
 ## Manifest Fields
 
@@ -55,9 +55,8 @@ Each `agent_task_executors[]` entry must declare:
 - `status`: lifecycle state, usually `active`, `experimental`, or `deprecated`.
 - `integration_contract`: higher-level contract name when the provider serves a domain extension.
 
-Runtime-specific fields are allowed, but they should be additive. A runtime
-should not require Homeboy core to understand backend-private settings just to
-invoke the provider.
+Runtime-specific fields are allowed when they are additive. The public manifest
+fields give Homeboy core the information it needs to invoke the provider.
 
 Generic runner specs must declare `executor.backend` explicitly. Runtime-specific
 planners may provide their own defaults, but the shared contract does not assume
@@ -104,8 +103,8 @@ result without parsing backend-native logs.
 TODO: Add a generic runtime-command provider only after the selected runtime owns
 a stable command substrate that accepts and returns backend-neutral shapes. The
 provider manifest should advertise a separate capability such as
-`runtime_command_execution`; until then, agent-task providers must not imply they
-can run arbitrary runtime commands.
+`runtime_command_execution`; agent-task providers currently advertise agent-task
+execution through the request and outcome schemas above.
 
 The generic request shape needs these caller-owned inputs:
 
@@ -124,10 +123,10 @@ The provider command should emit `homeboy/agent-task-outcome/v1` with normalized
 recipe artifacts may be attached as artifacts, but Homeboy should not parse them
 to determine the terminal outcome.
 
-For WP Codebox specifically, Homeboy Extensions can forward runtime package,
-recipe, command, args, and env-name declarations, but Codebox must provide the
-stable command runner and result envelope. Keep WPCOM, Dolly, and product-specific
-semantics in callers or runtime packages, not in this generic provider boundary.
+For WP Codebox specifically, Homeboy Extensions forwards runtime package,
+recipe, command, args, and env-name declarations to the Codebox executable
+contract, and Codebox returns the stable result envelope. WPCOM, Dolly, and
+product-specific semantics belong to callers or runtime packages.
 
 ## Homeboy Contract Adapter
 

--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -167,6 +167,16 @@ function resolvePathValue(value, workspace, env = process.env) {
 		}
 		return value.default || value.command || '';
 	}
+	if (value.type === 'path') {
+		for (const envName of Array.isArray(value.env) ? value.env : []) {
+			if (typeof envName === 'string' && env[envName]) {
+				const envPath = env[envName];
+				return envPath.length > 0 && isWorkspaceRelativePath(envPath) ? path.join(workspace, envPath) : envPath;
+			}
+		}
+		const defaultPath = value.default || value.path || '';
+		return defaultPath.length > 0 && isWorkspaceRelativePath(defaultPath) ? path.join(workspace, defaultPath) : defaultPath;
+	}
 	return value.value || value.path || '';
 }
 

--- a/tests/runtime-provider-resolver-smoke.mjs
+++ b/tests/runtime-provider-resolver-smoke.mjs
@@ -38,7 +38,7 @@ assert.equal(runtime.checkout.targetPath, path.join(workspace, '.ci/wp-codebox')
 assert.deepEqual(runtime.setupCommands, [{ command: 'npm', args: ['install'], cwd: '.ci/wp-codebox' }]);
 assert.deepEqual(runtime.buildCommands, [{ command: 'npm', args: ['run', 'build'], cwd: '.ci/wp-codebox' }]);
 assert.equal(runtime.paths.runtime_bin, 'wp-codebox');
-assert.equal(runtime.paths.runtime_component, path.join(workspace, '.ci/wp-codebox/packages/wordpress-plugin'));
+assert.equal(runtime.paths.runtime_component, '');
 assert.equal(runtime.executor.id, 'wordpress.codebox-agent-task-executor');
 assert.equal(runtime.executor.backend, 'codebox');
 assert.equal(runtime.executor.path, path.join(rootDir, 'agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs'));
@@ -49,6 +49,13 @@ const envRuntime = resolveRuntimeProvider('wp-codebox', {
 	env: { HOMEBOY_WP_CODEBOX_BIN: '/opt/bin/wp-codebox' },
 });
 assert.equal(envRuntime.paths.runtime_bin, '/opt/bin/wp-codebox');
+
+const envRuntimeComponent = resolveRuntimeProvider('wp-codebox', {
+	repoRoot: rootDir,
+	workspace,
+	env: { HOMEBOY_WP_CODEBOX_RUNTIME_COMPONENT: '.runtime/wp-codebox-plugin' },
+});
+assert.equal(envRuntimeComponent.paths.runtime_component, path.join(workspace, '.runtime/wp-codebox-plugin'));
 
 const opencodeRuntime = resolveRuntimeProvider('opencode', {
 	repoRoot: rootDir,

--- a/tests/wp-codebox-adapter-boundary-smoke.mjs
+++ b/tests/wp-codebox-adapter-boundary-smoke.mjs
@@ -22,7 +22,7 @@ const stableConsumerExports = [
 ];
 const forbidden = /datamachine|data machine|wp-site-generator|wpsg|site generator/i;
 for (const exportName of stableConsumerExports) {
-  assert.doesNotMatch(JSON.stringify(packageJson.exports[exportName]), forbidden, `${exportName} export must not expose runtime internals`);
+  assert.doesNotMatch(JSON.stringify(packageJson.exports[exportName]), forbidden, `${exportName} export should stay on the WP Codebox runtime package contract`);
 }
 
 const allowedLegacyImporters = new Set([

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -20,13 +20,14 @@ const {
 	WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
 	WP_CODEBOX_WORKSPACE_MOUNT_KIND,
 	WP_CODEBOX_LEGACY_WORKSPACE_MOUNT_KIND,
-	wpCodeboxLegacyRuntimeComponentAliasDiagnostics,
-	wpCodeboxLegacyRuntimeComponentAliasFields,
-	wpCodeboxLegacyRuntimeComponentAliasValues,
 	wpCodeboxProviderRuntimeInvocationContract,
 	wpCodeboxProviderRuntimeOperationConfig,
 	wpCodeboxProviderRuntimeOperationEntry,
 } = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'wp-codebox-adapter-contract.js'));
+const {
+	DATAMACHINE_AGENT_BUNDLE_KEYS,
+	DATAMACHINE_RUNTIME_COMPONENT_ALIASES,
+} = require(path.join(rootDir, 'datamachine-agent-ci', 'lib', 'wp-codebox-compat.js'));
 const {
 	wpCodeboxBin,
 	wpCodeboxCliDescriptor,
@@ -101,21 +102,8 @@ assert.equal(
 );
 assert.doesNotMatch(JSON.stringify(cliDescriptor), /datamachine|data machine|wp-site-generator|wpsg|site generator/i);
 
-const legacyRuntimeAliasPrefix = ['data', 'machine'].join('_');
-assert.deepEqual(wpCodeboxLegacyRuntimeComponentAliasFields(), {
-	agent_runtime: [legacyRuntimeAliasPrefix, `${legacyRuntimeAliasPrefix}_path`],
-	agent_runtime_tools: [`${legacyRuntimeAliasPrefix}_code`, `${legacyRuntimeAliasPrefix}_code_path`],
-});
-assert.deepEqual(wpCodeboxLegacyRuntimeComponentAliasValues({
-	[legacyRuntimeAliasPrefix]: '/runtime',
-	[`${legacyRuntimeAliasPrefix}_code_path`]: '/runtime-tools',
-}), {
-	agent_runtime: '/runtime',
-	agent_runtime_tools: '/runtime-tools',
-});
-assert.deepEqual(
-	wpCodeboxLegacyRuntimeComponentAliasDiagnostics({ [`${legacyRuntimeAliasPrefix}_path`]: '/runtime' }).map((diagnostic) => diagnostic.data.replacement),
-	['agent_runtime']
-);
+assert.deepEqual(DATAMACHINE_AGENT_BUNDLE_KEYS, ['data_machine_bundle', 'dataMachineBundle']);
+assert.equal(DATAMACHINE_RUNTIME_COMPONENT_ALIASES.data_machine_path, 'agent_runtime');
+assert.equal(DATAMACHINE_RUNTIME_COMPONENT_ALIASES.data_machine_code_path, 'agent_runtime_tools');
 
 console.log('wp-codebox adapter contract smoke passed');

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -496,7 +496,7 @@ assert.deepEqual(codeboxRequest.runtime_requirements, {
     primitive_schema: 'wp-codebox/parent-tool-bridge/v1',
     status: 'required-upstream-primitive',
     adapter_behavior: 'declare_requirement_only',
-    requirement: 'Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component; Homeboy Extensions does not inject bridge env or synthesize sandbox bridge descriptors.',
+    requirement: 'Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component declared by the public parent-tool-bridge contract.',
   }],
 });
 const legacyOverlayNameRequest = codeboxTaskRequestFromAgentTaskRequest({
@@ -803,7 +803,7 @@ assert.deepEqual(genericProviderRuntimeRequest.runtime_requirements, {
     primitive_schema: 'wp-codebox/parent-tool-bridge/v1',
     status: 'required-upstream-primitive',
     adapter_behavior: 'declare_requirement_only',
-    requirement: 'Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component; Homeboy Extensions does not inject bridge env or synthesize sandbox bridge descriptors.',
+    requirement: 'Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component declared by the public parent-tool-bridge contract.',
   }],
 });
 assert.deepEqual(genericProviderRuntimeRequest.runtime_overlay_profiles, ['fixture-profile']);
@@ -986,7 +986,6 @@ const codexAgentRequest = {
         'AI_PROVIDER_OPENAI_CODEX_FEDRAMP',
       ],
       runtime_component_paths: {
-        agents_api: '/components/agents-api',
         agent_runtime: '/components/example-runtime',
         agent_runtime_tools: '/components/example-runtime-tools',
       },
@@ -1003,9 +1002,9 @@ assert.equal(codexRequest.mode, 'sandbox');
 assert.equal(codexRequest.provider, 'codex');
 assert.equal(codexRequest.model, 'gpt-5.5');
 assert.deepEqual(codexRequest.provider_plugin_paths, ['/components/ai-provider-for-openai']);
-assert.equal(codexRequest.runtime_component_paths.agents_api, '/components/agents-api');
 assert.equal(codexRequest.runtime_component_paths.agent_runtime, '/components/example-runtime');
 assert.equal(codexRequest.runtime_component_paths.agent_runtime_tools, '/components/example-runtime-tools');
+assert.equal(Object.hasOwn(codexRequest.runtime_component_paths, 'agents_api'), false);
 assert.equal(Object.hasOwn(codexRequest, 'agents_api_path'), false);
 assert.equal(Object.hasOwn(codexRequest, 'data_machine_path'), false);
 assert.equal(Object.hasOwn(codexRequest, 'data_machine_code_path'), false);
@@ -1039,8 +1038,7 @@ const workflowStyleConfigRequest = codeboxTaskRequestFromAgentTaskRequest({
         mode: 'readonly',
       }],
       runtime_component_paths: {
-        runtime: '/components/wp-codebox/packages/wordpress-plugin',
-        agents_api: '/components/agents-api',
+        runtime: '/components/wp-codebox-runtime-plugin',
         agent_runtime: '/components/example-runtime',
         agent_runtime_tools: '/components/example-runtime-tools',
       },
@@ -1055,8 +1053,8 @@ assert.deepEqual(workflowStyleConfigRequest.mounts, [{
   target: '/wordpress/wp-content/plugins/driver/driver.php',
   mode: 'readonly',
 }]);
-assert.equal(workflowStyleConfigRequest.runtime_component_paths.runtime, '/components/wp-codebox/packages/wordpress-plugin');
-assert.equal(workflowStyleConfigRequest.runtime_component_paths.agents_api, '/components/agents-api');
+assert.equal(workflowStyleConfigRequest.runtime_component_paths.runtime, '/components/wp-codebox-runtime-plugin');
+assert.equal(Object.hasOwn(workflowStyleConfigRequest.runtime_component_paths, 'agents_api'), false);
 assert.equal(workflowStyleConfigRequest.runtime_component_paths.agent_runtime, '/components/example-runtime');
 assert.equal(workflowStyleConfigRequest.runtime_component_paths.agent_runtime_tools, '/components/example-runtime-tools');
 assert.equal(Object.hasOwn(workflowStyleConfigRequest.runtime_component_paths, 'data_machine'), false);
@@ -2645,8 +2643,6 @@ try {
     wpCodeboxRuntimeExecutor,
     '--task-runner',
     fixture,
-    '--agents-api',
-    '/components/agents-api',
   ], {
     encoding: 'utf8',
     env: fixtureEnv(),
@@ -2758,7 +2754,7 @@ try {
   assert.equal(capturedCodex.request.provider, 'codex');
   assert.equal(capturedCodex.request.model, 'gpt-5.5');
   assert.deepEqual(capturedCodex.request.provider_plugin_paths, ['/components/ai-provider-for-openai']);
-  assert.equal(capturedCodex.request.runtime_component_paths.agents_api, '/components/agents-api');
+  assert.equal(Object.hasOwn(capturedCodex.request.runtime_component_paths, 'agents_api'), false);
   assert.equal(capturedCodex.request.runtime_component_paths.agent_runtime, '/components/example-runtime');
   assert.equal(capturedCodex.request.runtime_component_paths.agent_runtime_tools, '/components/example-runtime-tools');
   assert.equal(Object.hasOwn(capturedCodex.request, 'agents_api_path'), false);

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -298,13 +298,11 @@ try {
   const preparedProviderPluginPath = path.join(root, 'artifacts', 'prepared-plugins', 'example-provider');
   const workspaceRoot = path.join(root, 'wp-coding-agents@proof-homeboy-fanout-a');
   const defaultRuntimePath = path.join(root, 'example-runtime');
-  const defaultAgentsApiPath = path.join(defaultRuntimePath, 'vendor', 'wordpress', 'agents-api');
   const defaultRuntimeToolsPath = path.join(root, 'example-runtime-tools');
   fs.mkdirSync(providerPluginPath, { recursive: true });
   fs.writeFileSync(path.join(providerPluginPath, 'example-provider.php'), '<?php\n/* Plugin Name: Example Provider */\n');
   fs.writeFileSync(path.join(providerPluginPath, 'composer.json'), JSON.stringify({ name: 'extra-chill/example-provider' }));
   fs.mkdirSync(workspaceRoot, { recursive: true });
-  fs.mkdirSync(defaultAgentsApiPath, { recursive: true });
   fs.mkdirSync(defaultRuntimeToolsPath, { recursive: true });
 
   const request = {
@@ -350,7 +348,6 @@ try {
   const result = spawnSync(process.execPath, [
     wpCodeboxTaskRunner,
     '--wp-codebox-bin', fixtureWpCodebox,
-    '--agents-api', '/components/agents-api',
     '--mount', '/repo/plugin:/wordpress/wp-content/plugins/plugin:readwrite',
     '--runtime-stack-mount', '/components/wordpress-develop:/wordpress:readonly',
     '--max-turns', '80',
@@ -399,17 +396,15 @@ try {
   assert.equal(captured.input.runtime_stack_mounts[0].source, '/components/php-ai-client');
   assert.equal(captured.input.runtime_stack_mounts[1].source, '/components/wordpress-develop');
   assert.equal(captured.input.mounts[0].source, '/repo/plugin');
-  assert.equal(captured.input.runtime_component_paths.agents_api, '/components/agents-api');
   assert.equal(captured.input.runtime_component_paths.agent_runtime, '/components/example-runtime');
   assert.equal(captured.input.runtime_component_paths.agent_runtime_tools, '/components/example-runtime-tools');
   assert.equal(Object.hasOwn(captured.input, 'agents_api_path'), false);
   assert.equal(Object.hasOwn(captured.input, 'data_machine_path'), false);
   assert.equal(Object.hasOwn(captured.input, 'data_machine_code_path'), false);
-  assert.equal(captured.input.extra_plugins.find((plugin) => plugin.slug === 'agents-api').source, '/components/agents-api');
+  assert.equal(captured.input.extra_plugins.some((plugin) => plugin.slug === 'agents-api'), false);
   assert.equal(captured.input.extra_plugins.some((plugin) => plugin.slug === 'example-runtime'), false);
   assert.equal(captured.input.extra_plugins.some((plugin) => plugin.slug === 'example-runtime-tools'), false);
-  // WP Codebox 0.8.0 mounts runtime components from `component_contracts`.
-  assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'agents-api').path, '/components/agents-api');
+  assert.equal(captured.input.component_contracts.some((contract) => contract.slug === 'agents-api'), false);
   assert.equal(captured.input.component_contracts.some((contract) => contract.slug === 'example-runtime'), false);
   assert.equal(captured.input.component_contracts.some((contract) => contract.slug === 'example-runtime-tools'), false);
   assert.equal(captured.input.component_contracts.find((contract) => contract.slug === 'domain-component').path, '/workspace/domain-component');
@@ -421,7 +416,6 @@ try {
   const nestedOnlyResult = spawnSync(process.execPath, [
     wpCodeboxTaskRunner,
     '--wp-codebox-bin', fixtureWpCodebox,
-    '--agents-api', '/components/agents-api',
   ], {
     encoding: 'utf8',
     input: JSON.stringify({
@@ -877,7 +871,7 @@ try {
   const labRuntimeInput = readJson(labRuntimeCapturePath).input;
   const preparedLabRuntime = path.join(labRuntimeArtifacts, 'prepared-plugins', 'example-runtime');
   assert.equal(labRuntimeInput.runtime_component_paths.agent_runtime, preparedLabRuntime);
-  assert.equal(labRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'agents-api').source, path.join(labRuntimeArtifacts, 'prepared-plugins', 'agents-api'));
+  assert.equal(labRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'agents-api').source, '.ci/agents-api');
   assert.equal(labRuntimeInput.component_contracts.find((contract) => contract.slug === 'agents-api').path, path.join(labRuntimeArtifacts, 'prepared-plugins', 'agents-api'));
   assert.equal(fs.existsSync(path.join(preparedLabRuntime, 'example-runtime.php')), true);
 
@@ -965,11 +959,10 @@ try {
   assert.equal(implicitAgentsApiResult.status, 0, implicitAgentsApiResult.stderr || implicitAgentsApiResult.stdout);
   const implicitAgentsApiInput = readJson(implicitAgentsApiCapturePath).input;
   const preparedImplicitRuntime = path.join(implicitAgentsApiArtifacts, 'prepared-plugins', 'data-machine');
-  const preparedImplicitAgentsApi = path.join(preparedImplicitRuntime, 'vendor', 'wordpress', 'agents-api');
   assert.equal(implicitAgentsApiInput.runtime_component_paths.agent_runtime, preparedImplicitRuntime);
-  assert.equal(implicitAgentsApiInput.runtime_component_paths.agents_api, preparedImplicitAgentsApi);
-  assert.equal(implicitAgentsApiInput.extra_plugins.find((plugin) => plugin.slug === 'agents-api').source, preparedImplicitAgentsApi);
-  assert.equal(implicitAgentsApiInput.component_contracts.find((contract) => contract.slug === 'agents-api').path, preparedImplicitAgentsApi);
+  assert.equal(Object.hasOwn(implicitAgentsApiInput.runtime_component_paths, 'agents_api'), false);
+  assert.equal(implicitAgentsApiInput.extra_plugins.some((plugin) => plugin.slug === 'agents-api'), false);
+  assert.equal(implicitAgentsApiInput.component_contracts.some((contract) => contract.slug === 'agents-api'), false);
 
   const legacyRuntimeCapturePath = path.join(root, 'capture-legacy-runtime-stack.json');
   const legacyRuntimeResult = spawnSync(process.execPath, [
@@ -979,15 +972,14 @@ try {
     encoding: 'utf8',
     input: JSON.stringify({
       ...request,
-      runtime_component_paths: undefined,
-      agents_api_path: '/legacy/agents-api',
+      runtime_component_paths: { agents_api: '/explicit/agents-api' },
     }),
     env: { ...process.env, FIXTURE_WP_CODEBOX_CAPTURE: legacyRuntimeCapturePath, OPENCODE_API_KEY: 'redacted-test-key' },
   });
   assert.equal(legacyRuntimeResult.status, 0, legacyRuntimeResult.stderr || legacyRuntimeResult.stdout);
   const legacyRuntimeInput = readJson(legacyRuntimeCapturePath).input;
-  assert.equal(legacyRuntimeInput.runtime_component_paths.agents_api, '/legacy/agents-api');
-  assert.equal(legacyRuntimeInput.component_contracts.find((contract) => contract.slug === 'agents-api').path, '/legacy/agents-api');
+  assert.equal(legacyRuntimeInput.runtime_component_paths.agents_api, '/explicit/agents-api');
+  assert.equal(legacyRuntimeInput.component_contracts.find((contract) => contract.slug === 'agents-api').path, '/explicit/agents-api');
 
   const sourceRoot = path.join(root, 'source-plugin');
   fs.mkdirSync(sourceRoot, { recursive: true });
@@ -1336,7 +1328,6 @@ try {
   const nonExecutableResult = spawnSync(process.execPath, [
     wpCodeboxTaskRunner,
     '--wp-codebox-bin', nonExecutableFixture,
-    '--agents-api', '/components/agents-api',
   ], {
     encoding: 'utf8',
     input: JSON.stringify(request),


### PR DESCRIPTION
## Summary
- Align WP Codebox runtime handling around public component contracts instead of internal agents-api inference.
- Move Data Machine compatibility constants out of the WP Codebox adapter contract surface.
- Add resolver coverage for path-typed runtime components and update Codebox smoke tests.

## Tests
- `node tests/runtime-provider-resolver-smoke.mjs`
- `node tests/wp-codebox-adapter-contract-smoke.mjs`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finalizing the branch, verifying the scoped diff, running relevant smoke tests, committing, pushing, and drafting this PR description.