### PR TITLE
Fix Codebox public contract boundaries

### DIFF
--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -1136,9 +1136,7 @@ function runtimeComponentPathsFromContracts(contracts) {
   if (!Array.isArray(contracts)) {
     return {};
   }
-  const slugToKey = new Map([
-    ['agents-api', 'agents_api'],
-  ]);
+  const slugToKey = new Map();
   return Object.fromEntries(contracts
     .map((contract) => [slugToKey.get(contract?.slug), contract?.path || contract?.source])
     .filter(([key, value]) => key && value));
@@ -1203,14 +1201,8 @@ function runnerInput(request, artifacts) {
   }).filter(([, value]) => value !== '' && value !== undefined && !(Array.isArray(value) && value.length === 0)));
 }
 
-function runtimeComponentExtraPlugins(input) {
-  const components = input.runtime_component_paths || {};
-  return [
-    { key: 'agents_api', slug: 'agents-api' },
-  ].flatMap(({ key, slug }) => {
-    const source = components[key];
-    return source ? [{ source, slug, loadAs: 'mu-plugin', activate: false }] : [];
-  });
+function runtimeComponentExtraPlugins() {
+  return [];
 }
 
 function pluginSlugFromPath(pluginPath) {
@@ -1241,10 +1233,6 @@ function providerPluginEntries(input) {
 }
 
 function componentContracts(input) {
-  // Translate normalized runtime component paths into the WP Codebox 0.8.0
-  // `component_contracts` shape:
-  // `{ slug, path, loadAs, activate }`. WP Codebox mounts these as mu-plugins so
-  // the runtime stack can register its tools and agent/chat surfaces.
   const runtimeContracts = runtimeComponentExtraPlugins(input).map((plugin) => ({
     slug: plugin.slug,
     path: plugin.source,

--- a/datamachine-agent-ci/lib/wp-codebox-compat.js
+++ b/datamachine-agent-ci/lib/wp-codebox-compat.js
@@ -1,5 +1,7 @@
 'use strict';
 
+// Data Machine-only WP Codebox compatibility aliases. Delete this quarantine once
+// Data Machine callers pass neutral agent_bundle and runtime_component_paths keys.
 const DATAMACHINE_AGENT_BUNDLE_KEYS = [
   'data_machine_bundle',
   'dataMachineBundle',

--- a/tests/wp-codebox-bundled-agents-api-smoke.mjs
+++ b/tests/wp-codebox-bundled-agents-api-smoke.mjs
@@ -65,14 +65,11 @@ process.stdout.write(JSON.stringify({
 	assert.equal(result.status, 0, result.stderr || result.stdout);
 
 	const captured = JSON.parse(readFileSync(capturePath, 'utf8'));
-	const agentsApiContract = captured.component_contracts.find((contract) => contract.slug === 'agents-api');
-	const agentsApiPlugin = captured.extra_plugins.find((plugin) => plugin.slug === 'agents-api');
+	const agentsApiContract = (captured.component_contracts || []).find((contract) => contract.slug === 'agents-api');
+	const agentsApiPlugin = (captured.extra_plugins || []).find((plugin) => plugin.slug === 'agents-api');
 
-	assert.ok(agentsApiContract, 'agents-api component contract is emitted from runtime component paths');
-	assert.ok(agentsApiPlugin, 'agents-api extra plugin is emitted for WP Codebox recipe mounting');
-	assert.equal(agentsApiPlugin.loadAs, 'mu-plugin');
-	assert.equal(agentsApiPlugin.activate, false);
-	assert.ok(agentsApiPlugin.source.endsWith(`${path.sep}prepared-plugins${path.sep}agents-api`), `agents-api source is prepared for recipe mounting: ${agentsApiPlugin.source}`);
+	assert.equal(agentsApiContract, undefined, 'agents-api component contract is not inferred from runtime component paths');
+	assert.equal(agentsApiPlugin, undefined, 'agents-api extra plugin is not inferred from runtime component paths');
 
 	const runtimeRequirementsCapturePath = path.join(fixtureRoot, 'captured-runtime-requirements-input.json');
 	const runtimeRequirementsRequest = {
@@ -82,6 +79,9 @@ process.stdout.write(JSON.stringify({
 		runtime_requirements: {
 			component_contracts: [
 				{ slug: 'agents-api', path: agentsApi, loadAs: 'mu-plugin', activate: false },
+			],
+			extra_plugins: [
+				{ slug: 'agents-api', source: agentsApi, loadAs: 'mu-plugin', activate: false },
 			],
 		},
 	};
@@ -99,12 +99,13 @@ process.stdout.write(JSON.stringify({
 		runtimeRequirementsCaptured.component_contracts.some((contract) => contract.slug === 'agents-api'),
 		'agents-api component contract is preserved from runtime_requirements when top-level contracts are empty'
 	);
-	assert.ok(
-		runtimeRequirementsCaptured.extra_plugins.some((plugin) => plugin.slug === 'agents-api'),
-		'agents-api extra plugin is emitted from runtime_requirements when top-level contracts are empty'
+	assert.equal(
+		(runtimeRequirementsCaptured.extra_plugins || []).some((plugin) => plugin.slug === 'agents-api'),
+		false,
+		'agents-api extra plugin is not inferred by the generic task runner'
 	);
 
-	console.log('wp-codebox bundled agents-api smoke passed');
+	console.log('wp-codebox agents-api boundary smoke passed');
 } finally {
 	rmSync(fixtureRoot, { recursive: true, force: true });
 }

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -703,34 +703,29 @@ assert.deepEqual(
   repoLoopWorkspaceTaskInput.workspace_materialization
 );
 
-const legacyRuntimeAliasPrefix = ['data', 'machine'].join('_');
-const legacyRuntimeAliasTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+const genericRuntimeAliasTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
-  task_id: 'legacy-runtime-alias-task-1',
+  task_id: 'generic-runtime-alias-task-1',
   executor: {
     backend: 'codebox',
     config: {
       provider: 'openai',
-      [legacyRuntimeAliasPrefix]: '/tmp/legacy-runtime',
-      [`${legacyRuntimeAliasPrefix}_code_path`]: '/tmp/legacy-runtime-tools',
+      runtime_components: {
+        example_runtime: '/tmp/example-runtime',
+      },
+      component_path_aliases: {
+        agent_runtime: ['runtime_component:example_runtime'],
+      },
     },
   },
-  instructions: 'Accept legacy runtime component aliases with diagnostics.',
+  instructions: 'Accept explicit runtime component aliases.',
   inputs: {
     ability_request: { name: 'example/run-agent-bundle' },
   },
 });
 
-assert.equal(legacyRuntimeAliasTaskInput.runtime_component_paths.agent_runtime, '/tmp/legacy-runtime');
-assert.equal(legacyRuntimeAliasTaskInput.runtime_component_paths.agent_runtime_tools, '/tmp/legacy-runtime-tools');
-assert.deepEqual(
-  legacyRuntimeAliasTaskInput.compatibility_diagnostics.map((diagnostic) => diagnostic.class),
-  ['codebox.compat.deprecated_runtime_component_alias', 'codebox.compat.deprecated_runtime_component_alias']
-);
-assert.deepEqual(
-  legacyRuntimeAliasTaskInput.compatibility_diagnostics.map((diagnostic) => diagnostic.data.replacement),
-  ['agent_runtime', 'agent_runtime_tools']
-);
+assert.equal(genericRuntimeAliasTaskInput.runtime_component_paths.agent_runtime, '/tmp/example-runtime');
+assert.deepEqual(genericRuntimeAliasTaskInput.compatibility_diagnostics, undefined);
 
 const repoLoopTypedOutputsTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -871,7 +871,7 @@ try {
   const labRuntimeInput = readJson(labRuntimeCapturePath).input;
   const preparedLabRuntime = path.join(labRuntimeArtifacts, 'prepared-plugins', 'example-runtime');
   assert.equal(labRuntimeInput.runtime_component_paths.agent_runtime, preparedLabRuntime);
-  assert.equal(labRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'agents-api').source, '.ci/agents-api');
+  assert.equal(labRuntimeInput.extra_plugins.some((plugin) => plugin.slug === 'agents-api'), false);
   assert.equal(labRuntimeInput.component_contracts.find((contract) => contract.slug === 'agents-api').path, path.join(labRuntimeArtifacts, 'prepared-plugins', 'agents-api'));
   assert.equal(fs.existsSync(path.join(preparedLabRuntime, 'example-runtime.php')), true);
 
@@ -931,8 +931,8 @@ try {
   const preparedAgentsApi = path.join(preparedRuntime, 'vendor', 'wordpress', 'agents-api');
   assert.equal(nestedRuntimeInput.runtime_component_paths.agent_runtime, preparedRuntime);
   assert.equal(nestedRuntimeInput.runtime_component_paths.agents_api, preparedAgentsApi);
-  assert.equal(nestedRuntimeInput.extra_plugins.find((plugin) => plugin.slug === 'agents-api').source, preparedAgentsApi);
-  assert.equal(nestedRuntimeInput.component_contracts.find((contract) => contract.slug === 'agents-api').path, preparedAgentsApi);
+  assert.equal(nestedRuntimeInput.extra_plugins.some((plugin) => plugin.slug === 'agents-api'), false);
+  assert.equal(nestedRuntimeInput.component_contracts.some((contract) => contract.slug === 'agents-api'), false);
   assert.equal(fs.existsSync(path.join(preparedAgentsApi, 'agents-api.php')), true);
 
   const implicitAgentsApiRuntime = path.join(root, 'data-machine');
@@ -979,7 +979,7 @@ try {
   assert.equal(legacyRuntimeResult.status, 0, legacyRuntimeResult.stderr || legacyRuntimeResult.stdout);
   const legacyRuntimeInput = readJson(legacyRuntimeCapturePath).input;
   assert.equal(legacyRuntimeInput.runtime_component_paths.agents_api, '/explicit/agents-api');
-  assert.equal(legacyRuntimeInput.component_contracts.find((contract) => contract.slug === 'agents-api').path, '/explicit/agents-api');
+  assert.equal(legacyRuntimeInput.component_contracts.some((contract) => contract.slug === 'agents-api'), false);
 
   const sourceRoot = path.join(root, 'source-plugin');
   fs.mkdirSync(sourceRoot, { recursive: true });


### PR DESCRIPTION
## Summary
- Remove generic WP Codebox task-runner promotion of agents-api runtime component paths into component contracts or extra plugins.
- Keep explicit runtime component aliases generic and leave Data Machine-specific aliases quarantined in datamachine-agent-ci with a deletion note.
- Update Codebox boundary smoke tests to assert explicit contracts are preserved without Agents API defaults.

## Tests
- node tests/wp-codebox-bundled-agents-api-smoke.mjs
- node tests/wp-codebox-adapter-contract-smoke.mjs
- node tests/wp-codebox-runtime-contract-source-smoke.mjs
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js
- node wordpress/tests/wp-codebox-task-runner-smoke.js

## Lint
- npm --prefix wordpress run lint:js (fails on pre-existing unrelated lint errors in wordpress/lib and wordpress/scripts)
- npm exec eslint -- ../agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs ../tests/wp-codebox-bundled-agents-api-smoke.mjs ../tests/wp-codebox-adapter-contract-smoke.mjs ../tests/wp-codebox-runtime-contract-source-smoke.mjs ../tests/wp-codebox-adapter-boundary-smoke.mjs tests/codebox-agent-task-executor-boundary.test.js tests/wp-codebox-task-runner-smoke.js (package config ignored these files; no scoped lint errors reported)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via opencode
- **Used for:** Code changes, test updates, targeted verification, and PR description drafting.