### PR TITLE
Add Codebox fuzz runner dispatch

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -16,6 +16,7 @@ const {
 const { buildWpCodeboxFuzzPlanRecipe } = require('./wp-codebox-fuzz-plan');
 const {
 	normalizeWpCodeboxFuzzRunResult,
+	runWpCodeboxFuzzRun,
 	wpCodeboxFuzzRunInput,
 	wpCodeboxFuzzRunTaskRequest,
 } = require('./wp-codebox-fuzz-run');
@@ -36,6 +37,18 @@ function readWordPressFuzzRunnerEnv(env = process.env) {
 }
 
 function buildWordPressFuzzRunnerResult(options = {}) {
+	const context = buildWordPressFuzzRunnerContext(options);
+	const codeboxResult = normalizeCodeboxResult(context.workload, { runId: context.runId });
+	return buildWordPressFuzzRunnerSummary({ ...context, codeboxResult });
+}
+
+async function runWordPressFuzzRunnerResult(options = {}) {
+	const context = buildWordPressFuzzRunnerContext(options);
+	const codeboxResult = await resolveCodeboxResult(context, options);
+	return buildWordPressFuzzRunnerSummary({ ...context, codeboxResult });
+}
+
+function buildWordPressFuzzRunnerContext(options = {}) {
 	const env = options.env || readWordPressFuzzRunnerEnv();
 	const workload = options.workload || readJsonFile(requiredString(env.workloadPath, 'HOMEBOY_FUZZ_WORKLOAD_PATH'));
 	const runId = requiredString(env.runId || workload.run_id || workload.runId || workload.id, 'HOMEBOY_FUZZ_RUN_ID');
@@ -51,7 +64,33 @@ function buildWordPressFuzzRunnerResult(options = {}) {
 		runtimeId: workload.runtime_id || workload.runtimeId || 'wp-codebox',
 	});
 	const codeboxPlanRecipe = buildCodeboxPlanRecipe(workload);
-	const codeboxResult = normalizeCodeboxResult(workload, { runId });
+
+	return {
+		env,
+		workload,
+		runId,
+		workloadId,
+		seed,
+		maxDuration,
+		plan,
+		wpCodeboxInput,
+		taskRequest,
+		codeboxPlanRecipe,
+	};
+}
+
+function buildWordPressFuzzRunnerSummary({
+	workload,
+	runId,
+	workloadId,
+	seed,
+	maxDuration,
+	plan,
+	wpCodeboxInput,
+	taskRequest,
+	codeboxPlanRecipe,
+	codeboxResult,
+}) {
 	const coverage = aggregateCoverage(workload, codeboxResult);
 	const status = normalizeRunnerStatus(codeboxResult, coverage);
 	const homeboyFuzzCampaign = buildHomeboyFuzzCampaign({ runId, workloadId, plan, codeboxResult, status });
@@ -72,6 +111,26 @@ function buildWordPressFuzzRunnerResult(options = {}) {
 		coverage,
 		homeboy_fuzz_campaign: homeboyFuzzCampaign,
 		metadata: objectOrUndefined(workload.metadata),
+	});
+}
+
+async function resolveCodeboxResult(context, options = {}) {
+	if (hasPrecomputedCodeboxResult(context.workload)) {
+		return normalizeCodeboxResult(context.workload, { runId: context.runId });
+	}
+
+	const runner = options.runFuzzRun || options.runRuntimeTask || options.runTask;
+	if (typeof runner !== 'function') {
+		return normalizeCodeboxResult(context.workload, { runId: context.runId });
+	}
+
+	return runWpCodeboxFuzzRun({
+		...options,
+		taskId: context.runId,
+		input: context.wpCodeboxInput,
+		provider: context.workload.provider,
+		runtimeId: context.workload.runtime_id || context.workload.runtimeId || 'wp-codebox',
+		runFuzzRun: runner,
 	});
 }
 
@@ -129,7 +188,7 @@ function buildCodeboxPlanRecipe(workload) {
 }
 
 function normalizeCodeboxResult(workload, context = {}) {
-	const result = workload.wp_codebox_result || workload.wpCodeboxResult || workload.wp_codebox_suite_result || workload.wpCodeboxSuiteResult || workload.result;
+	const result = precomputedCodeboxResult(workload);
 	if (result) {
 		return normalizeWpCodeboxFuzzRunResult(result);
 	}
@@ -145,6 +204,14 @@ function normalizeCodeboxResult(workload, context = {}) {
 			},
 		],
 	});
+}
+
+function hasPrecomputedCodeboxResult(workload = {}) {
+	return Boolean(precomputedCodeboxResult(workload));
+}
+
+function precomputedCodeboxResult(workload = {}) {
+	return workload.wp_codebox_result || workload.wpCodeboxResult || workload.wp_codebox_suite_result || workload.wpCodeboxSuiteResult || workload.result;
 }
 
 function aggregateCoverage(workload, codeboxResult) {
@@ -234,6 +301,7 @@ module.exports = {
 	HOMEBOY_FUZZ_CAMPAIGN_SCHEMA,
 	WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
 	buildWordPressFuzzRunnerResult,
+	runWordPressFuzzRunnerResult,
 	writeHomeboyFuzzResultsFile,
 	readWordPressFuzzRunnerEnv,
 };

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -10,6 +10,7 @@ const {
 	HOMEBOY_FUZZ_CAMPAIGN_SCHEMA,
 	WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA,
 	buildWordPressFuzzRunnerResult,
+	runWordPressFuzzRunnerResult,
 } = require('../lib/wordpress-fuzz-runner');
 
 const workload = {
@@ -94,6 +95,44 @@ assert.equal(executedResult.status, 'succeeded');
 assert.equal(executedResult.succeeded, true);
 assert.equal(executedResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path, 'artifacts/replay.json');
 
+let dispatchedRequest;
+const dispatchPromise = runWordPressFuzzRunnerResult({
+	env: {
+		workloadPath: '/unused/in-unit-test.json',
+		runId: 'dispatch-run',
+	},
+	workload,
+	runRuntimeTask: async (request) => {
+		dispatchedRequest = request;
+		assert.equal(request.task_id, 'dispatch-run');
+		assert.equal(request.executor.backend, 'codebox');
+		assert.equal(request.executor.config.runtime_task.ability, 'wp-codebox/fuzz-suite');
+		assert.equal(request.executor.config.runtime_task.input.schema, 'wp-codebox/fuzz-suite/v1');
+		assert.equal(request.executor.config.runtime_task.input.cases[0].target_id, 'rest-posts');
+		return {
+			json: {
+				schema: 'wp-codebox/fuzz-suite-result/v1',
+				request_id: request.task_id,
+				status: 'succeeded',
+				coverage_summary: { surface_count: 1, exercised_count: 1 },
+				artifactRefs: [
+					{ path: 'dispatch/fuzz-report.json', kind: 'report', contentType: 'application/json' },
+					{ path: 'dispatch/coverage.json', kind: 'coverage', contentType: 'application/json' },
+				],
+			},
+		};
+	},
+}).then((dispatchedResult) => {
+	assert(dispatchedRequest, 'runner should dispatch a Codebox fuzz suite request');
+	assert.equal(dispatchedResult.status, 'succeeded');
+	assert.equal(dispatchedResult.succeeded, true);
+	assert.equal(dispatchedResult.wp_codebox_result.request_id, 'dispatch-run');
+	assert.equal(dispatchedResult.wp_codebox_result.coverage_summary.surface_count, 1);
+	assert.deepEqual(dispatchedResult.wp_codebox_result.artifacts.map((artifact) => artifact.role), ['fuzz_report', 'coverage']);
+	assert.equal(dispatchedResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].semantic_key, 'fuzz.report');
+	assert.equal(dispatchedResult.homeboy_fuzz_campaign.metadata.artifact_refs[1].semantic_key, 'fuzz.coverage');
+});
+
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wordpress-fuzz-runner-'));
 const workloadPath = path.join(tempDir, 'workload.json');
 const resultsPath = path.join(tempDir, 'fuzz-results.json');
@@ -123,4 +162,9 @@ assert.equal(homeboyCampaign.schema, HOMEBOY_FUZZ_CAMPAIGN_SCHEMA);
 assert.equal(homeboyCampaign.id, 'cli-run');
 assert.equal(homeboyCampaign.metadata.diagnostics[0].code, 'wp_codebox_fuzz_suite_execution_unsupported');
 
-console.log('WordPress fuzz runner smoke passed.');
+dispatchPromise.then(() => {
+	console.log('WordPress fuzz runner smoke passed.');
+}).catch((error) => {
+	console.error(error);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add an async WordPress fuzz runner path that dispatches `wp-codebox/fuzz-suite` through the existing Codebox fuzz run helper
- keep precomputed suite result support and unsupported diagnostics when no runtime dispatcher is available
- normalize returned Codebox fuzz artifacts into the Homeboy fuzz campaign metadata

## Tests
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wp-codebox-fuzz-run`
- `npm run test:wordpress-public-export-boundary`
- `npx eslint lib/wordpress-fuzz-runner.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the WordPress fuzz runner dispatch path, artifact normalization integration, tests, and PR preparation.