### PR TITLE
Thin Codebox workflow internals

### DIFF
--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -695,8 +695,8 @@ if ( ! function_exists( 'homeboy_callback_data_output_event' ) ) {
 `;
 }
 
-function writeHomeboyCallbackDataPlugin(pluginDir) {
-  fs.writeFileSync(path.join(pluginDir, 'homeboy-runtime-callback-data.php'), homeboyCallbackDataPluginSource());
+function writeHomeboyCallbackDataPlugin(pluginDir, pluginFile = 'homeboy-runtime-callback-data.php') {
+  fs.writeFileSync(path.join(pluginDir, pluginFile), homeboyCallbackDataPluginSource());
 }
 
 function homeboyRuntimeToolBridgeServerSource() {
@@ -821,10 +821,11 @@ function injectHomeboyCallbackDataHelper(taskInput, artifacts) {
   fs.mkdirSync(path.dirname(callbackPath), { recursive: true });
   fs.writeFileSync(callbackPath, `${JSON.stringify({ data: plainObject(config.initial) ? config.initial : {}, events: [] }, null, 2)}\n`);
 
-  const pluginRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-runtime-callback-data-'));
-  const pluginDir = path.join(pluginRoot, 'homeboy-runtime-callback-data');
+  const pluginSlug = safePluginSlug(`homeboy-runtime-callback-data-${taskInput.sandbox_session_id || process.pid}`, 'homeboy-runtime-callback-data');
+  const pluginRoot = fs.mkdtempSync(path.join(os.tmpdir(), `${pluginSlug}-`));
+  const pluginDir = path.join(pluginRoot, pluginSlug);
   fs.mkdirSync(pluginDir, { recursive: true });
-  writeHomeboyCallbackDataPlugin(pluginDir);
+  writeHomeboyCallbackDataPlugin(pluginDir, `${pluginSlug}.php`);
 
   return {
     input: {
@@ -833,8 +834,8 @@ function injectHomeboyCallbackDataHelper(taskInput, artifacts) {
         ...(Array.isArray(taskInput.extra_plugins) ? taskInput.extra_plugins : []),
         {
           source: pluginDir,
-          slug: 'homeboy-runtime-callback-data',
-          pluginFile: 'homeboy-runtime-callback-data/homeboy-runtime-callback-data.php',
+          slug: pluginSlug,
+          pluginFile: `${pluginSlug}/${pluginSlug}.php`,
           loadAs: 'mu-plugin',
           activate: false,
           metadata: { source: 'homeboy-runtime-callback-data' },

--- a/tests/wp-codebox-callback-data-smoke.mjs
+++ b/tests/wp-codebox-callback-data-smoke.mjs
@@ -30,7 +30,7 @@ const fs = require('node:fs');
 const inputArg = process.argv.find((arg) => arg.startsWith('--input-file='));
 const input = JSON.parse(fs.readFileSync(inputArg.slice('--input-file='.length), 'utf8'));
 const callbackPath = input.runtime_env.HOMEBOY_CALLBACK_DATA_PATH;
-const helper = input.extra_plugins.find((plugin) => plugin.slug === 'homeboy-runtime-callback-data');
+const helper = input.extra_plugins.find((plugin) => plugin.metadata?.source === 'homeboy-runtime-callback-data');
 if (!callbackPath || !helper || !fs.existsSync(callbackPath)) {
   throw new Error('callback data helper was not injected');
 }

--- a/wordpress/scripts/refactor.py
+++ b/wordpress/scripts/refactor.py
@@ -1006,17 +1006,12 @@ def apply_wp_codebox_fanout_artifacts(component_root, run, run_path='', workspac
 
 def wp_codebox_task_runner_args(data, settings, script_dir):
     component_root = data.get('root') or data.get('component_path') or os.getcwd()
-    agents_api_path = settings.get('wp_codebox_agents_api_path') or os.environ.get('HOMEBOY_WP_CODEBOX_AGENTS_API_PATH') or component_root
-    data_machine_path = settings.get('wp_codebox_data_machine_path') or os.environ.get('HOMEBOY_WP_CODEBOX_DATA_MACHINE_PATH') or default_sibling_path(component_root, 'data-machine')
-    data_machine_code_path = settings.get('wp_codebox_data_machine_code_path') or os.environ.get('HOMEBOY_WP_CODEBOX_DATA_MACHINE_CODE_PATH') or default_sibling_path(component_root, 'data-machine-code')
     homeboy_path = settings.get('wp_codebox_homeboy_path') or os.environ.get('HOMEBOY_WP_CODEBOX_HOMEBOY_PATH') or default_sibling_path(component_root, 'homeboy')
     homeboy_extensions_path = settings.get('wp_codebox_homeboy_extensions_path') or os.environ.get('HOMEBOY_WP_CODEBOX_HOMEBOY_EXTENSIONS_PATH') or default_sibling_path(component_root, 'homeboy-extensions')
+    extension_root = os.path.dirname(os.path.dirname(script_dir))
 
     args = [
-        os.path.join(script_dir, 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
-        '--agents-api', agents_api_path,
-        '--data-machine', data_machine_path,
-        '--data-machine-code', data_machine_code_path,
+        os.path.join(extension_root, 'agent-runtimes', 'wp-codebox', 'scripts', 'agent', 'homeboy-wp-codebox-task-runner.cjs'),
     ]
     if os.path.isdir(homeboy_path):
         args.extend(['--homeboy', homeboy_path])

--- a/wordpress/tests/refactor-source-wp-codebox-smoke.js
+++ b/wordpress/tests/refactor-source-wp-codebox-smoke.js
@@ -224,6 +224,9 @@ process.stdout.write(JSON.stringify({
   assert.equal(run.records[0].command.args.includes('--task-timeout-seconds'), true);
   assert.equal(run.records[0].command.args.includes('--homeboy'), true);
   assert.equal(run.records[0].command.args.includes('--homeboy-extensions'), true);
+  assert.equal(run.records[0].command.args.includes('--agents-api'), false);
+  assert.equal(run.records[0].command.args.includes('--data-machine'), false);
+  assert.equal(run.records[0].command.args.includes('--data-machine-code'), false);
   const artifactsIndex = run.records[0].command.args.indexOf('--artifacts');
   assert.notEqual(artifactsIndex, -1);
   assert.equal(pathInside(writeCommand.root, run.records[0].command.args[artifactsIndex + 1]), false);


### PR DESCRIPTION
## Summary
- Stop the WordPress refactor Codebox workflow from passing legacy internal Agents API/Data Machine/Data Machine Code runner flags.
- Point the refactor workflow at the public WP Codebox runtime task runner path under agent-runtimes.
- Make the generated callback-data helper plugin session-specific so concurrent fanout tasks do not collide in shared prepared-plugin artifacts.

## Tests
- npm run test:refactor-source-wp-codebox
- npm run test:wp-codebox-task-runner
- npm run test:codebox-agent-task-executor-boundary
- node tests/wp-codebox-callback-data-smoke.mjs
- node --check agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
- node --check wordpress/tests/refactor-source-wp-codebox-smoke.js
- node --check tests/wp-codebox-callback-data-smoke.mjs
- python3 -m py_compile wordpress/scripts/refactor.py

## Notes
- Scoped grep over WP Codebox runtime/refactor paths found no datamachine_runtime_tool_result bridge or legacy --agents-api/--data-machine/--data-machine-code runner flags after the change.
- eslint was not available in this skipped-bootstrap worktree (eslint: command not found), so syntax checks were run instead.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the existing Codebox adapter boundary, making the scoped code/test changes, and running targeted verification.