### PR TITLE
Add WordPress workload setup declarations

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -251,6 +251,25 @@ and verification are ordinary WordPress recipe steps, while visual comparison is
 carried as a verifier step that a runtime can implement with its own browser
 capture and artifact policy.
 
+The workload profile also carries the generic setup and evidence vocabulary used
+by rigs before they select a concrete runtime:
+
+- `fixture_plugins` normalizes to `homeboy/wordpress-fixture-plugin/v1` entries
+  with `path`, `slug`, `plugin`, `copy`, and `activate` fields.
+- `fixture_site_seeds` normalizes to `homeboy/wordpress-fixture-site-seed/v1`
+  entries for parent-site or fixture-sourced content/options/theme/plugin seeds.
+- `fixtures` normalizes to `homeboy/wordpress-fixture-step/v1` entries for
+  `wp-cli` and `wp-eval-file` setup actions.
+- `artifact_declarations` normalizes to
+  `homeboy/wordpress-workload-artifact-declaration/v1` records keyed by artifact
+  id, each with `path`, `kind`, `required`, `role`, and `metadata`.
+
+`workflowInputsFromWordPressWorkloadProfile()` projects those fields to
+`wordpress_fixture_plugins`, `wordpress_fixture_site_seeds`,
+`wordpress_fixture_steps`, and `artifact_declarations` JSON strings. Rigs should
+pass these declarations through unchanged and let the chosen WordPress runtime
+own execution, artifact capture, and retention.
+
 ### Portable fuzz manifest helper
 
 Fuzz callers that need one manifest across local scripts, CI, and agent runners

--- a/wordpress/lib/fixture-setup.js
+++ b/wordpress/lib/fixture-setup.js
@@ -14,6 +14,10 @@ const { spawn } = require('node:child_process');
 const { isPlainObject } = require('./shared');
 const { wpCodeboxPluginStateStep } = require('./wp-codebox-recipe-helper');
 
+const WORDPRESS_FIXTURE_STEP_SCHEMA = 'homeboy/wordpress-fixture-step/v1';
+const WORDPRESS_FIXTURE_PLUGIN_SCHEMA = 'homeboy/wordpress-fixture-plugin/v1';
+const WORDPRESS_FIXTURE_SITE_SEED_SCHEMA = 'homeboy/wordpress-fixture-site-seed/v1';
+
 function normalizeFixtureList(fixtures) {
 	if (fixtures === undefined || fixtures === null) {
 		return [];
@@ -61,6 +65,7 @@ function normalizeFixtureProfileSiteSeed(siteSeed, index) {
 	}
 
 	return {
+		schema: WORDPRESS_FIXTURE_SITE_SEED_SCHEMA,
 		type,
 		name,
 		...(siteSeed.source ? { source: siteSeed.source } : {}),
@@ -99,6 +104,7 @@ function normalizeFixtureStep(fixture, index) {
 
 	return {
 		...fixture,
+		schema: WORDPRESS_FIXTURE_STEP_SCHEMA,
 		type,
 		label: fixture.label || fixture.id || `${type}:${index + 1}`,
 	};
@@ -219,6 +225,7 @@ function normalizeFixturePlugin(plugin, index) {
 		: path.basename(pluginPath);
 	return {
 		...entry,
+		schema: WORDPRESS_FIXTURE_PLUGIN_SCHEMA,
 		path: pluginPath,
 		slug,
 		plugin: entry.plugin || slug,
@@ -559,6 +566,9 @@ function writeFixtureSummary(summary, options, error) {
 }
 
 module.exports = {
+	WORDPRESS_FIXTURE_PLUGIN_SCHEMA,
+	WORDPRESS_FIXTURE_SITE_SEED_SCHEMA,
+	WORDPRESS_FIXTURE_STEP_SCHEMA,
 	fixtureRecipeStep,
 	defaultRunCli,
 	installWordPressFixturePlugins,

--- a/wordpress/lib/wordpress-workload-profile.js
+++ b/wordpress/lib/wordpress-workload-profile.js
@@ -1,6 +1,16 @@
 'use strict';
 
+/**
+ * Internal dependencies
+ */
+const {
+	normalizeFixtureList,
+	normalizeFixturePluginList,
+	normalizeFixtureProfileSiteSeeds,
+} = require('./fixture-setup');
+
 const WORKLOAD_PROFILE_SCHEMA = 'homeboy/wordpress-workload-profile/v1';
+const WORDPRESS_WORKLOAD_ARTIFACT_DECLARATION_SCHEMA = 'homeboy/wordpress-workload-artifact-declaration/v1';
 
 function asArray(value, field) {
 	if (value === undefined || value === null) {
@@ -76,6 +86,35 @@ function normalizeVisualComparison(comparison, index) {
 	};
 }
 
+function normalizeArtifactDeclaration(declaration, id) {
+	assertPlainObject(declaration, `artifact_declarations.${id}`);
+	const path = declaration.path || declaration.relative_path || declaration.relativePath;
+	if (!path || typeof path !== 'string') {
+		throw new Error(`artifact_declarations.${id}.path must be a string.`);
+	}
+
+	return {
+		schema: WORDPRESS_WORKLOAD_ARTIFACT_DECLARATION_SCHEMA,
+		id,
+		path,
+		kind: declaration.kind || declaration.type || 'file',
+		required: declaration.required !== false,
+		role: declaration.role || id,
+		metadata: { ...(declaration.metadata || {}) },
+	};
+}
+
+function normalizeArtifactDeclarations(declarations = {}) {
+	if (declarations === undefined || declarations === null) {
+		return {};
+	}
+	assertPlainObject(declarations, 'artifact_declarations');
+	return Object.fromEntries(Object.entries(declarations).map(([id, declaration]) => [
+		id,
+		normalizeArtifactDeclaration(declaration, id),
+	]));
+}
+
 function normalizeWorkload(workload, index) {
 	assertPlainObject(workload, `workloads[${index}]`);
 	if (!workload.id || typeof workload.id !== 'string') {
@@ -111,10 +150,14 @@ function normalizeWordPressWorkloadProfile(profile) {
 		dependencies: asArray(profile.dependencies, 'dependencies').map(normalizeDependency),
 		wp_config_defines: { ...(profile.wp_config_defines || profile.wpConfigDefines || {}) },
 		mounts: asArray(profile.mounts, 'mounts').map(normalizeMount),
+		fixture_plugins: normalizeFixturePluginList(profile.fixture_plugins || profile.fixturePlugins),
+		fixture_site_seeds: normalizeFixtureProfileSiteSeeds(profile.fixture_site_seeds || profile.fixtureSiteSeeds),
+		fixtures: normalizeFixtureList(profile.fixtures),
 		run_before: asArray(profile.run_before || profile.runBefore, 'run_before').map((step, index) => normalizeStep(step, `run_before[${index}]`)),
 		workloads: asArray(profile.workloads, 'workloads').map(normalizeWorkload),
 		run_after: asArray(profile.run_after || profile.runAfter, 'run_after').map((step, index) => normalizeStep(step, `run_after[${index}]`)),
 		visual_comparisons: asArray(profile.visual_comparisons || profile.visualComparisons, 'visual_comparisons').map(normalizeVisualComparison),
+		artifact_declarations: normalizeArtifactDeclarations(profile.artifact_declarations || profile.artifactDeclarations),
 		metadata: { ...(profile.metadata || {}) },
 	};
 }
@@ -134,9 +177,13 @@ function workflowInputsFromWordPressWorkloadProfile(profile) {
 		validation_dependencies: normalized.dependencies.map((dependency) => dependency.entry).join(','),
 		extra_wp_config_defines: JSON.stringify(normalized.wp_config_defines),
 		runtime_mounts: JSON.stringify(normalized.mounts),
+		wordpress_fixture_plugins: JSON.stringify(normalized.fixture_plugins),
+		wordpress_fixture_site_seeds: JSON.stringify(normalized.fixture_site_seeds),
+		wordpress_fixture_steps: JSON.stringify(normalized.fixtures),
 		workload_run_before: JSON.stringify(normalized.run_before),
 		wordpress_runtime_workloads: JSON.stringify(normalized.workloads),
 		workload_run_after: JSON.stringify(runAfter),
+		artifact_declarations: JSON.stringify(normalized.artifact_declarations),
 		metadata: {
 			profile_id: normalized.id,
 			profile_label: normalized.label,
@@ -147,6 +194,8 @@ function workflowInputsFromWordPressWorkloadProfile(profile) {
 
 module.exports = {
 	WORKLOAD_PROFILE_SCHEMA,
+	WORDPRESS_WORKLOAD_ARTIFACT_DECLARATION_SCHEMA,
+	normalizeArtifactDeclarations,
 	normalizeWordPressWorkloadProfile,
 	workflowInputsFromWordPressWorkloadProfile,
 };

--- a/wordpress/tests/fixture-setup-smoke.js
+++ b/wordpress/tests/fixture-setup-smoke.js
@@ -24,12 +24,12 @@ const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-fixtures-')
 async function main() {
 	try {
 		assert.deepEqual(
-			normalizeFixtureList([{ path: 'fixtures/seed.php' }]).map((step) => ({ type: step.type, label: step.label })),
-			[{ type: 'wp-eval-file', label: 'wp-eval-file:1' }]
+			normalizeFixtureList([{ path: 'fixtures/seed.php' }]).map((step) => ({ schema: step.schema, type: step.type, label: step.label })),
+			[{ schema: 'homeboy/wordpress-fixture-step/v1', type: 'wp-eval-file', label: 'wp-eval-file:1' }]
 		);
 		assert.deepEqual(
-			normalizeFixturePluginList(['/tmp/example-plugin']).map((plugin) => ({ slug: plugin.slug, plugin: plugin.plugin, activate: plugin.activate })),
-			[{ slug: 'example-plugin', plugin: 'example-plugin', activate: true }]
+			normalizeFixturePluginList(['/tmp/example-plugin']).map((plugin) => ({ schema: plugin.schema, slug: plugin.slug, plugin: plugin.plugin, activate: plugin.activate })),
+			[{ schema: 'homeboy/wordpress-fixture-plugin/v1', slug: 'example-plugin', plugin: 'example-plugin', activate: true }]
 		);
 		assert.deepEqual(
 			normalizeFixtureProfileSiteSeeds({
@@ -39,6 +39,7 @@ async function main() {
 				activeTheme: true,
 			}),
 			[{
+				schema: 'homeboy/wordpress-fixture-site-seed/v1',
 				type: 'parent_site',
 				name: 'editorial-shape',
 				scopes: {
@@ -52,7 +53,7 @@ async function main() {
 			normalizeFixtureProfileSiteSeeds({
 				siteSeeds: [{ type: 'fixture', name: 'demo-content', source: 'fixtures/content.json', scopes: { posts: { slugs: ['home'] } } }],
 			}),
-			[{ type: 'fixture', name: 'demo-content', source: 'fixtures/content.json', scopes: { posts: { slugs: ['home'] } } }]
+			[{ schema: 'homeboy/wordpress-fixture-site-seed/v1', type: 'fixture', name: 'demo-content', source: 'fixtures/content.json', scopes: { posts: { slugs: ['home'] } } }]
 		);
 
 		const calls = [];

--- a/wordpress/tests/wordpress-workload-profile-smoke.js
+++ b/wordpress/tests/wordpress-workload-profile-smoke.js
@@ -3,6 +3,8 @@
 const assert = require('node:assert/strict');
 const {
 	WORKLOAD_PROFILE_SCHEMA,
+	WORDPRESS_WORKLOAD_ARTIFACT_DECLARATION_SCHEMA,
+	normalizeArtifactDeclarations,
 	normalizeWordPressWorkloadProfile,
 	workflowInputsFromWordPressWorkloadProfile,
 } = require('../lib/wordpress-workload-profile');
@@ -19,6 +21,17 @@ const profile = {
 	mounts: [
 		'/tmp/source:/wordpress/wp-content/uploads/source:readonly',
 		{ source: '/tmp/drop-in.php', target: '/wordpress/wp-content/db.php', mode: 'readonly' },
+	],
+	fixture_plugins: [
+		{ path: '/tmp/fixture-plugin', plugin: 'fixture-plugin/fixture-plugin.php' },
+	],
+	fixture_site_seeds: {
+		name: 'minimal-content',
+		posts: { postTypes: ['page'], maxRecords: 1 },
+		options: { names: ['blogname'] },
+	},
+	fixtures: [
+		{ id: 'seed-page', path: 'fixtures/seed-page.php' },
 	],
 	run_before: [
 		{ type: 'wp-cli', command: 'plugin install safe-svg --activate' },
@@ -46,6 +59,9 @@ const profile = {
 			threshold: 0.01,
 		},
 	],
+	artifact_declarations: {
+		import_report: { path: 'wp-content/uploads/import-report.json', kind: 'json', role: 'report' },
+	},
 	metadata: { fixture: 'portable' },
 };
 
@@ -53,12 +69,20 @@ const normalized = normalizeWordPressWorkloadProfile(profile);
 assert.equal(normalized.schema, WORKLOAD_PROFILE_SCHEMA);
 assert.equal(normalized.dependencies[1].entry, 'example/block-transformer@trunk');
 assert.equal(normalized.mounts[0].mode, 'readonly');
+assert.equal(normalized.fixture_plugins[0].schema, 'homeboy/wordpress-fixture-plugin/v1');
+assert.equal(normalized.fixture_site_seeds[0].schema, 'homeboy/wordpress-fixture-site-seed/v1');
+assert.equal(normalized.fixtures[0].schema, 'homeboy/wordpress-fixture-step/v1');
 assert.equal(normalized.visual_comparisons[0].artifacts_directory, 'artifacts/visual/home-page');
+assert.equal(normalized.artifact_declarations.import_report.schema, WORDPRESS_WORKLOAD_ARTIFACT_DECLARATION_SCHEMA);
+assert.equal(normalized.artifact_declarations.import_report.required, true);
 
 const inputs = workflowInputsFromWordPressWorkloadProfile(profile);
 assert.equal(inputs.validation_dependencies, 'example/content-importer@main,example/block-transformer@trunk');
 assert.deepEqual(JSON.parse(inputs.extra_wp_config_defines), { WP_DEBUG: true });
 assert.deepEqual(JSON.parse(inputs.runtime_mounts), normalized.mounts);
+assert.deepEqual(JSON.parse(inputs.wordpress_fixture_plugins), normalized.fixture_plugins);
+assert.deepEqual(JSON.parse(inputs.wordpress_fixture_site_seeds), normalized.fixture_site_seeds);
+assert.deepEqual(JSON.parse(inputs.wordpress_fixture_steps), normalized.fixtures);
 assert.deepEqual(JSON.parse(inputs.workload_run_before), normalized.run_before);
 assert.deepEqual(JSON.parse(inputs.wordpress_runtime_workloads), normalized.workloads);
 assert.equal(Object.hasOwn(inputs, 'wp_codebox_workloads'), false);
@@ -73,13 +97,25 @@ assert.deepEqual(JSON.parse(inputs.workload_run_after), [
 		artifacts_directory: 'artifacts/visual/home-page',
 	},
 ]);
+assert.deepEqual(JSON.parse(inputs.artifact_declarations), normalized.artifact_declarations);
 assert.deepEqual(inputs.metadata, {
 	profile_id: 'content-import-visual-check',
 	profile_label: 'Content import visual check',
 	fixture: 'portable',
 });
 
+assert.deepEqual(normalizeArtifactDeclarations({ summary: { path: 'artifacts/summary.json' } }).summary, {
+	schema: WORDPRESS_WORKLOAD_ARTIFACT_DECLARATION_SCHEMA,
+	id: 'summary',
+	path: 'artifacts/summary.json',
+	kind: 'file',
+	required: true,
+	role: 'summary',
+	metadata: {},
+});
+
 assert.throws(() => normalizeWordPressWorkloadProfile({ id: 'bad', workloads: [{ id: 'empty' }] }), /run must contain/);
 assert.throws(() => normalizeWordPressWorkloadProfile({ schema: 'other/v1', id: 'bad' }), /Unsupported/);
+assert.throws(() => normalizeArtifactDeclarations({ bad: { kind: 'json' } }), /path/);
 
 console.log('wordpress workload profile smoke passed');


### PR DESCRIPTION
## Summary
- Add schema constants to normalized WordPress fixture plugin, fixture step, and site seed declarations.
- Extend the portable WordPress workload profile with fixture plugin, site seed, fixture step, and artifact declaration normalization.
- Document the product-neutral setup/evidence vocabulary for rigs and runtime adapters.

## Tests
- npm run test:fixture-setup
- npm run test:wordpress-workload-profile
- npm run test:wordpress-public-export-boundary
- npm run lint:js -- lib/fixture-setup.js lib/wordpress-workload-profile.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the helper normalization changes, docs, tests, and PR preparation.