### PR TITLE
Add manifest runtime invocation contract

### DIFF
--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -87,20 +87,23 @@ function runGenericAgentLoop(options = {}) {
 
 function executeRuntimeProvider(options = {}) {
   const runtime = requiredObject(options.runtime, 'runtime');
-  if (!runtime.executor.path) {
-    throw new Error(`Runtime ${runtime.id || '(unknown)'} does not declare an executor path.`);
+  const invocation = runtimeExecutorInvocation(runtime);
+  if (!invocation.command) {
+    throw new Error(`Runtime ${runtime.id || '(unknown)'} does not declare an executor command.`);
   }
   const spawn = options.spawnSync || spawnSync;
-  const result = spawn(process.execPath, [runtime.executor.path], {
+  const result = spawn(invocation.command, invocation.argv || [], {
     encoding: 'utf8',
-    input: JSON.stringify(options.request),
-    env: options.env || process.env,
+    cwd: invocation.cwd || process.cwd(),
+    input: invocationStdin(invocation, options.request),
+    env: { ...(options.env || process.env), ...(invocation.env || {}) },
     maxBuffer: 1024 * 1024 * 20,
   });
-  if (result.stderr && options.stderr !== false) {
+  if (result.stderr && options.stderr !== false && (result.status !== 0 || invocation.stderr === 'inherit')) {
     process.stderr.write(result.stderr);
   }
-  if (!result.stdout || !result.stdout.trim()) {
+  const stdout = String(result.stdout || '');
+  if (!stdout.trim()) {
     return {
       schema: 'homeboy/agent-task-outcome/v1',
       task_id: options.request.task_id,
@@ -113,7 +116,64 @@ function executeRuntimeProvider(options = {}) {
       }],
     };
   }
-  return JSON.parse(result.stdout);
+  const outcome = JSON.parse(stdout);
+  return captureInvocationResult(outcome, invocation, result);
+}
+
+function runtimeExecutorInvocation(runtime = {}) {
+  const executor = requiredObject(runtime.executor, 'runtime.executor');
+  if (executor.invocation && typeof executor.invocation === 'object' && !Array.isArray(executor.invocation)) {
+    return {
+      command: executor.invocation.command || '',
+      argv: normalizeArray(executor.invocation.argv),
+      cwd: executor.invocation.cwd || process.cwd(),
+      env: optionalObject(executor.invocation.env),
+      stdin: executor.invocation.stdin || 'request_json',
+      stdout: executor.invocation.stdout || 'outcome_json',
+      stderr: executor.invocation.stderr || 'inherit_on_failure',
+      artifacts: executor.invocation.artifacts || {},
+      results: executor.invocation.results || {},
+    };
+  }
+  if (executor.path) {
+    return {
+      command: process.execPath,
+      argv: [executor.path],
+      cwd: process.cwd(),
+      env: {},
+      stdin: 'request_json',
+      stdout: 'outcome_json',
+      stderr: 'inherit_on_failure',
+      artifacts: {},
+      results: {},
+    };
+  }
+  return {};
+}
+
+function invocationStdin(invocation, request) {
+  if (invocation.stdin === false || invocation.stdin === 'none') {
+    return undefined;
+  }
+  return JSON.stringify(request);
+}
+
+function captureInvocationResult(outcome, invocation, result) {
+  const metadata = optionalObject(outcome.metadata);
+  const invocationResult = {
+    command: invocation.command,
+    argv: invocation.argv || [],
+    cwd: invocation.cwd || '',
+    exit_status: result.status ?? 0,
+    signal: result.signal || null,
+  };
+  return {
+    ...outcome,
+    metadata: {
+      ...metadata,
+      runtime_invocation_result: invocationResult,
+    },
+  };
 }
 
 function materializeGenericAgentLoopResults(outcome, options = {}) {

--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -186,16 +186,66 @@ function isWorkspaceRelativePath(value) {
 
 function resolveExecutor(manifest, repoRoot, options = {}) {
 	const provider = selectExecutor(manifest, executorSelectionFromOptions(options));
-	const scriptArg = executorScriptArg(provider);
+	const runtimePath = path.join(repoRoot, 'agent-runtimes', manifest.id);
+	const invocation = resolveExecutorInvocation(provider, runtimePath, options);
+	const scriptArg = invocation.argv.find((arg) => typeof arg === 'string' && arg.includes(runtimePath)) || executorScriptArg(provider);
 	return {
 		id: provider.id || '',
 		backend: provider?.backend || '',
 		status: provider?.status || '',
 		capabilities: Array.isArray(provider?.capabilities) ? provider.capabilities : [],
-		path: scriptArg ? scriptArg.replace('{{runtime_path}}', path.join(repoRoot, 'agent-runtimes', manifest.id)) : '',
+		path: scriptArg ? scriptArg.replace('{{runtime_path}}', runtimePath) : '',
+		invocation,
 		capabilities: Array.isArray(provider?.capabilities) ? provider.capabilities.filter(Boolean) : [],
 		runtime_execution_contracts: provider?.runtime_execution_contracts || provider?.execution_contracts || {},
 	};
+}
+
+function resolveExecutorInvocation(provider, runtimePath, options = {}) {
+	const invocation = objectOption(provider?.invocation) || {};
+	const argv = normalizeInvocationArgv(provider, invocation).map((arg) => replaceRuntimePath(arg, runtimePath));
+	const command = replaceRuntimePath(firstString(invocation.command, argv[0]), runtimePath);
+	if (!command) {
+		throw new Error(`agent_task_executor ${provider?.id || '(unknown)'} requires invocation.command or invocation.argv.`);
+	}
+	const cwd = replaceRuntimePath(firstString(invocation.cwd, options.cwd, process.cwd()), runtimePath);
+	return {
+		schema: invocation.schema || 'homeboy/command-invocation/v1',
+		command,
+		argv: argv.length > 0 ? argv.slice(1) : [],
+		cwd,
+		env: normalizeInvocationEnv(invocation.env || {}),
+		stdin: invocation.stdin || 'request_json',
+		stdout: invocation.stdout || 'outcome_json',
+		stderr: invocation.stderr || 'inherit_on_failure',
+		artifacts: invocation.artifacts || provider?.artifact_contract || {},
+		results: invocation.results || {},
+		display: invocation.display || [command, ...(argv.length > 0 ? argv.slice(1) : [])].join(' '),
+	};
+}
+
+function normalizeInvocationArgv(provider, invocation) {
+	if (Array.isArray(invocation.argv)) {
+		return invocation.argv.filter((arg) => typeof arg === 'string');
+	}
+	if (Array.isArray(invocation.args)) {
+		return [firstString(invocation.command), ...invocation.args.filter((arg) => typeof arg === 'string')].filter(Boolean);
+	}
+	if (typeof provider?.command === 'string' && provider.command.trim() !== '') {
+		return provider.command.trim().split(/\s+/);
+	}
+	return [];
+}
+
+function normalizeInvocationEnv(env) {
+	if (!env || typeof env !== 'object' || Array.isArray(env)) {
+		return {};
+	}
+	return Object.fromEntries(Object.entries(env).filter(([, value]) => typeof value === 'string'));
+}
+
+function replaceRuntimePath(value, runtimePath) {
+	return typeof value === 'string' ? value.replaceAll('{{runtime_path}}', runtimePath) : value;
 }
 
 function executorSelectionFromOptions(options = {}) {
@@ -304,6 +354,9 @@ function selectExecutor(manifest, selection) {
 
 function executorStatusMatches(provider, requestedStatus) {
 	if (requestedStatus === 'active' && !provider.status) {
+		return true;
+	}
+	if (requestedStatus === 'active' && provider.status === 'available') {
 		return true;
 	}
 	return provider.status === requestedStatus;

--- a/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
+++ b/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const genericLoopRunner = require('../lib/generic-agent-loop-runner');
 
@@ -67,5 +70,78 @@ assert.equal(result.loop.schema, 'homeboy/deterministic-loop-result/v1');
 assert.equal(result.loop.status, 'completed');
 assert.equal(result.loop.state.status, 'succeeded');
 assert.equal(result.loop.iterations.length, 1);
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-generic-agent-loop-'));
+try {
+  const requestCapturePath = path.join(tmpRoot, 'request.json');
+  const shellExecutorPath = path.join(tmpRoot, 'fake-non-node-executor');
+  fs.writeFileSync(shellExecutorPath, `#!/bin/sh
+cat > "$HOMEBOY_REQUEST_CAPTURE"
+printf '%s\n' '{"schema":"homeboy/agent-task-outcome/v1","task_id":"manifest-shell","status":"succeeded","summary":"Shell executor completed.","metadata":{"results":{"scenarios":[{"id":"manifest-shell","metrics":{"generic_agent_task_executor_mean":1},"metadata":{"job_status":"completed","success_status":"no_changes","completion_outcome":"done","completion_outcome_satisfied":true,"executor_env":"'"$HOMEBOY_EXECUTOR_ENV"'"}}]}}}'
+`);
+  fs.chmodSync(shellExecutorPath, 0o755);
+
+  const shellRun = genericLoopRunner.runGenericAgentLoop({
+    runtime: {
+      id: 'manifest-shell-runtime',
+      executor: {
+        backend: 'shell-fixture',
+        invocation: {
+          command: shellExecutorPath,
+          argv: [],
+          cwd: tmpRoot,
+          env: {
+            HOMEBOY_REQUEST_CAPTURE: requestCapturePath,
+            HOMEBOY_EXECUTOR_ENV: 'from-manifest',
+          },
+          stdin: 'request_json',
+          stdout: 'outcome_json',
+        },
+      },
+    },
+    plan: { ...plan, workload_id: 'manifest-shell' },
+    validationPolicy: { success_completion_outcomes: ['done'] },
+  });
+  assert.equal(shellRun.outcome.status, 'succeeded');
+  assert.equal(shellRun.outcome.metadata.runtime_invocation_result.command, shellExecutorPath);
+  assert.equal(shellRun.results.scenarios[0].metadata.executor_env, 'from-manifest');
+  assert.equal(JSON.parse(fs.readFileSync(requestCapturePath, 'utf8')).task_id, 'manifest-shell');
+
+  const nodeExecutorPath = path.join(tmpRoot, 'fake-node-executor.cjs');
+  fs.writeFileSync(nodeExecutorPath, `'use strict';
+const request = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
+process.stdout.write(JSON.stringify({
+  schema: 'homeboy/agent-task-outcome/v1',
+  task_id: request.task_id,
+  status: 'succeeded',
+  summary: 'Node executor completed.',
+  metadata: {
+    results: { scenarios: [{ id: request.task_id, metrics: { generic_agent_task_executor_mean: 1 }, metadata: { job_status: 'completed', success_status: 'no_changes', completion_outcome: 'done', completion_outcome_satisfied: true } }] },
+  },
+}));
+`);
+  const nodeRun = genericLoopRunner.runGenericAgentLoop({
+    runtime: {
+      id: 'manifest-node-runtime',
+      executor: {
+        backend: 'node-fixture',
+        invocation: {
+          command: process.execPath,
+          argv: [nodeExecutorPath],
+          cwd: tmpRoot,
+          stdin: 'request_json',
+          stdout: 'outcome_json',
+        },
+      },
+    },
+    plan: { ...plan, workload_id: 'manifest-node' },
+    validationPolicy: { success_completion_outcomes: ['done'] },
+  });
+  assert.equal(nodeRun.outcome.status, 'succeeded');
+  assert.equal(nodeRun.outcome.metadata.runtime_invocation_result.command, process.execPath);
+  assert.deepEqual(nodeRun.outcome.metadata.runtime_invocation_result.argv, [nodeExecutorPath]);
+} finally {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+}
 
 process.stdout.write('Generic agent loop runner adapter delegation check passed\n');

--- a/wordpress/tests/generic-agent-runtime-contract.test.js
+++ b/wordpress/tests/generic-agent-runtime-contract.test.js
@@ -42,6 +42,10 @@ const wpCodeboxRuntime = resolveRuntimeProvider('wp-codebox', { repoRoot, regist
 assert.equal(wpCodeboxRuntime.id, 'wp-codebox');
 assert.equal(wpCodeboxRuntime.executor.backend, 'codebox');
 assert.equal(wpCodeboxRuntime.executor.path, path.join(repoRoot, 'agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs'));
+assert.equal(wpCodeboxRuntime.executor.invocation.command, 'node');
+assert.deepEqual(wpCodeboxRuntime.executor.invocation.argv, [path.join(repoRoot, 'agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs')]);
+assert.equal(wpCodeboxRuntime.executor.invocation.stdin, 'request_json');
+assert.equal(wpCodeboxRuntime.executor.invocation.stdout, 'outcome_json');
 
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-runtime-registry-'));
 try {


### PR DESCRIPTION
## Summary
- Resolve runtime executor manifests into a generic invocation contract with command, argv, cwd, env, stdin/stdout, artifact, and result metadata.
- Execute generic runtime invocations directly instead of assuming node <runtime_path>, while preserving legacy executor.path fallback and Node invocation manifests.
- Add behavior coverage for fake non-Node executable invocation and Node invocation, plus resolver invocation assertions.

## Tests
- node runtime-agent-ci/tests/generic-agent-loop-runner.test.js
- node wordpress/tests/generic-agent-runtime-contract.test.js
- node agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Implementing the runtime invocation contract, tests, and PR preparation.