### PR TITLE
Add generic deterministic loop primitive

### DIFF
--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -58,21 +58,25 @@ function runGenericAgentLoop(options = {}) {
   const request = options.request || buildGenericAgentLoopRequest(options);
   const execute = options.execute || executeRuntimeProvider;
   const validationPolicy = options.validationPolicy || options.validation_policy || {};
-  const loop = runDeterministicLoop({
+  const loop = runGenericDeterministicLoop({
     loopId: request.task_id,
-    maxIterations: 1,
+    maxIterations: options.maxIterations || options.max_iterations || options.loop?.maxIterations || options.loop?.max_iterations || 1,
     state: { request },
-    buildIteration: ({ state }) => state.request,
-    execute: ({ input }) => normalizeOutcome(execute({ ...options, request: input, runtime }), input),
-    reconcile: ({ state, outcome, artifacts }) => ({
+    buildTask: ({ state }) => state.request,
+    executeTask: ({ task }) => normalizeOutcome(execute({ ...options, request: task, runtime }), task),
+    collectResult: ({ outcome }) => outcome,
+    reconcile: ({ state, result, artifacts, results, evidence }) => ({
       ...state,
-      status: outcome?.status || 'failed',
-      outcome,
+      status: result?.status || 'failed',
+      outcome: result,
       artifacts,
+      results,
+      evidence,
     }),
-    stopCriteria: () => true,
+    shouldContinue: options.shouldContinue || options.should_continue || (() => false),
+    stopPolicy: options.stopPolicy || options.stop_policy,
   });
-  const outcome = loop.iterations[0]?.outcome || normalizeOutcome(null, request);
+  const outcome = loop.outcome || normalizeOutcome(null, request);
   validateGenericAgentLoopOutcomeContract({
     request,
     outcome,
@@ -83,6 +87,144 @@ function runGenericAgentLoop(options = {}) {
   const results = materializeGenericAgentLoopResults(outcome, { ...options, runtime });
   const assertion = options.validate === false ? null : assertGenericAgentLoopOutcome(results, validationPolicy);
   return { request, outcome, results, assertion, loop };
+}
+
+function runGenericDeterministicLoop(options = {}) {
+  const loopId = options.loopId || options.loop_id || 'generic-deterministic-loop';
+  const buildTask = options.buildTask || options.build_task || options.buildIteration || options.build_iteration || defaultBuildTask;
+  const executeTask = requiredFunction(options.executeTask || options.execute_task || options.execute, 'executeTask');
+  const collectResult = options.collectResult || options.collect_result || defaultCollectResult;
+  const reconcile = options.reconcile || defaultGenericReconcile;
+  const shouldContinue = options.shouldContinue || options.should_continue || defaultShouldContinue;
+  const stopPolicy = options.stopPolicy || options.stop_policy || defaultStopPolicy;
+  const maxIterations = positiveInteger(options.maxIterations || options.max_iterations) || 1;
+  const initialState = optionalObject(options.state || options.initialState || options.initial_state);
+  const tasks = [];
+  const results = [];
+  const evidence = [];
+  const loop = runDeterministicLoop({
+    loopId,
+    maxIterations,
+    maxAttempts: options.maxAttempts || options.max_attempts || options.retry?.max_attempts,
+    state: {
+      ...initialState,
+      tasks,
+      results,
+      evidence,
+    },
+    buildIteration: ({ loop_id, iteration, state, iterations }) => {
+      const task = buildTask({ loop_id, loopId: loop_id, iteration, state, iterations, tasks, results, evidence });
+      tasks.push(task);
+      return task;
+    },
+    execute: ({ loop_id, iteration, attempt, input, state, iterations }) => executeTask({
+      loop_id,
+      loopId: loop_id,
+      iteration,
+      attempt,
+      task: input,
+      input,
+      state,
+      iterations,
+      tasks,
+      results,
+      evidence,
+    }),
+    reconcile: ({ loop_id, iteration, attempt, input, outcome, error, artifacts, state, iterations }) => {
+      const result = collectResult({
+        loop_id,
+        loopId: loop_id,
+        iteration,
+        attempt,
+        task: input,
+        outcome,
+        error,
+        artifacts,
+        state,
+        iterations,
+        tasks,
+        results,
+        evidence,
+      });
+      results.push(result);
+      evidence.push(...collectEvidence({ iteration, outcome, result, artifacts }));
+      const nextState = reconcile({
+        loop_id,
+        loopId: loop_id,
+        iteration,
+        attempt,
+        task: input,
+        result,
+        outcome,
+        error,
+        artifacts,
+        state,
+        iterations,
+        tasks,
+        results,
+        evidence,
+      });
+      return isPlainObject(nextState) ? {
+        ...nextState,
+        tasks,
+        results,
+        evidence,
+      } : {
+        ...state,
+        tasks,
+        results,
+        evidence,
+      };
+    },
+    stopCriteria: (context) => {
+      const stop = stopPolicy({
+        ...context,
+        task: context.input,
+        result: results[results.length - 1],
+        tasks,
+        results,
+        evidence,
+        max_iterations: maxIterations,
+        maxIterations,
+      });
+      if (isPlainObject(stop) ? stop.stop : Boolean(stop)) {
+        return stop;
+      }
+      const continueDecision = shouldContinue({
+        ...context,
+        task: context.input,
+        result: results[results.length - 1],
+        tasks,
+        results,
+        evidence,
+        max_iterations: maxIterations,
+        maxIterations,
+      });
+      if (continueDecision === false || (isPlainObject(continueDecision) && continueDecision.continue === false)) {
+        return { stop: true, reason: isPlainObject(continueDecision) ? continueDecision.reason || 'continuation_declined' : 'continuation_declined' };
+      }
+      return { stop: false };
+    },
+  });
+  const finalOutcome = results[results.length - 1] || null;
+  return {
+    ...loop,
+    schema: 'homeboy/generic-deterministic-loop-output/v1',
+    deterministic_loop_schema: loop.schema,
+    outcome: finalOutcome,
+    tasks,
+    results,
+    evidence,
+    evidence_envelope: {
+      schema: 'homeboy/generic-deterministic-loop-evidence/v1',
+      loop_id: loopId,
+      status: loop.status,
+      iteration_count: loop.iterations.length,
+      task_count: tasks.length,
+      result_count: results.length,
+      evidence,
+    },
+  };
 }
 
 function executeRuntimeProvider(options = {}) {
@@ -174,6 +316,59 @@ function captureInvocationResult(outcome, invocation, result) {
       runtime_invocation_result: invocationResult,
     },
   };
+}
+
+function defaultBuildTask({ state }) {
+  return state.task || state.input || state.request || state;
+}
+
+function defaultCollectResult({ outcome }) {
+  return outcome;
+}
+
+function defaultGenericReconcile({ state, result, artifacts, results, evidence }) {
+  return {
+    ...state,
+    status: result?.status || state.status || '',
+    outcome: result,
+    artifacts,
+    results,
+    evidence,
+  };
+}
+
+function defaultShouldContinue() {
+  return false;
+}
+
+function defaultStopPolicy({ iteration, maxIterations }) {
+  return iteration >= maxIterations
+    ? { stop: true, reason: 'max_iterations_reached' }
+    : { stop: false };
+}
+
+function collectEvidence({ iteration, outcome, result, artifacts }) {
+  const resultEvidence = result === outcome ? [] : normalizeArray(result?.evidence_refs || result?.evidence);
+  return [
+    ...normalizeArray(artifacts).map((artifact) => ({
+      kind: 'artifact',
+      iteration,
+      ref: artifact.path || artifact.url || artifact.id || artifact.name || '',
+      artifact,
+    })),
+    ...normalizeArray(outcome?.evidence_refs || outcome?.evidence).map((ref) => ({
+      kind: ref.kind || 'evidence_ref',
+      iteration,
+      ref: evidenceRefUrl(ref),
+      evidence: ref,
+    })),
+    ...resultEvidence.map((ref) => ({
+      kind: ref.kind || 'evidence_ref',
+      iteration,
+      ref: evidenceRefUrl(ref),
+      evidence: ref,
+    })),
+  ];
 }
 
 function materializeGenericAgentLoopResults(outcome, options = {}) {
@@ -495,6 +690,13 @@ function requiredStringValue(value, name) {
   return value;
 }
 
+function requiredFunction(value, name) {
+  if (typeof value !== 'function') {
+    throw new Error(`${name} must be a function.`);
+  }
+  return value;
+}
+
 function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
 }
@@ -503,12 +705,17 @@ function nonEmpty(value) {
   return value !== undefined && value !== null && value !== '';
 }
 
+function isPlainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
 module.exports = {
   assertGenericAgentLoopOutcome,
   assertGenericAgentLoopRuntimeContract,
   buildGenericAgentLoopRequest,
   materializeGenericAgentLoopResults,
   runGenericAgentLoop,
+  runGenericDeterministicLoop,
   validateGenericAgentLoopOutcomeContract,
   writeGenericAgentLoopArtifacts,
 };

--- a/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
+++ b/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
@@ -13,6 +13,45 @@ assert.equal(
   'generic runtime adapter must not export deterministic loop internals'
 );
 
+const genericLoop = genericLoopRunner.runGenericDeterministicLoop({
+  loopId: 'generic-reconcile-loop',
+  maxIterations: 3,
+  state: { accepted: false },
+  buildTask: ({ iteration, results }) => ({
+    iteration,
+    previous_value: results[results.length - 1]?.value || 0,
+  }),
+  executeTask: ({ task }) => ({
+    status: 'succeeded',
+    value: task.previous_value + 1,
+    evidence_refs: [{ kind: 'iteration-output', uri: `https://example.test/evidence/${task.iteration}` }],
+  }),
+  collectResult: ({ outcome }) => outcome,
+  reconcile: ({ state, result }) => ({
+    ...state,
+    accepted: result.value >= 2,
+    latest_value: result.value,
+  }),
+  stopPolicy: ({ state }) => state.accepted
+    ? { stop: true, reason: 'reconcile_criteria_satisfied' }
+    : { stop: false },
+  shouldContinue: ({ state }) => !state.accepted,
+});
+
+assert.equal(genericLoop.schema, 'homeboy/generic-deterministic-loop-output/v1');
+assert.equal(genericLoop.deterministic_loop_schema, 'homeboy/deterministic-loop-result/v1');
+assert.equal(genericLoop.status, 'completed');
+assert.equal(genericLoop.iterations.length, 2);
+assert.equal(genericLoop.tasks[0].previous_value, 0);
+assert.equal(genericLoop.tasks[1].previous_value, 1);
+assert.equal(genericLoop.results[1].value, 2);
+assert.equal(genericLoop.state.accepted, true);
+assert.equal(genericLoop.iterations[0].stop.stop, false);
+assert.equal(genericLoop.iterations[1].stop.reason, 'reconcile_criteria_satisfied');
+assert.equal(genericLoop.evidence_envelope.schema, 'homeboy/generic-deterministic-loop-evidence/v1');
+assert.equal(genericLoop.evidence_envelope.iteration_count, 2);
+assert.equal(genericLoop.evidence.length, 2);
+
 const runtime = { id: 'fixture-runtime', executor: { backend: 'fixture', path: '/unused' } };
 const plan = {
   workload_id: 'fixture-workload',
@@ -66,10 +105,13 @@ assert.equal(result.request.task_id, 'fixture-workload');
 assert.equal(result.outcome.status, 'succeeded');
 assert.equal(result.results.scenarios[0].id, 'fixture-workload');
 assert.equal(result.assertion.completion_outcome_satisfied, true);
-assert.equal(result.loop.schema, 'homeboy/deterministic-loop-result/v1');
+assert.equal(result.loop.schema, 'homeboy/generic-deterministic-loop-output/v1');
+assert.equal(result.loop.deterministic_loop_schema, 'homeboy/deterministic-loop-result/v1');
 assert.equal(result.loop.status, 'completed');
 assert.equal(result.loop.state.status, 'succeeded');
 assert.equal(result.loop.iterations.length, 1);
+assert.equal(result.loop.results.length, 1);
+assert.equal(result.loop.outcome.status, 'succeeded');
 
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-generic-agent-loop-'));
 try {
@@ -144,4 +186,4 @@ process.stdout.write(JSON.stringify({
   fs.rmSync(tmpRoot, { recursive: true, force: true });
 }
 
-process.stdout.write('Generic agent loop runner adapter delegation check passed\n');
+process.stdout.write('Generic agent loop runner behavior checks passed\n');


### PR DESCRIPTION
## Summary
- Add a runtime-agnostic generic deterministic loop wrapper that keeps deterministic internals private while exposing iteration state, task/result collection, reconcile policy, continuation decisions, max-iteration bounds, and a durable evidence envelope.
- Update the generic agent loop adapter to use the new wrapper instead of a hard-coded single-shot deterministic loop.
- Add behavior coverage for a two-iteration reconcile flow where iteration 2 consumes iteration 1 output and stops only after criteria pass.

## Tests
- `node runtime-agent-ci/tests/generic-agent-loop-runner.test.js`
- `node runtime-agent-ci/tests/deterministic-loop-runner-incubation-boundary.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the generic deterministic loop primitive, updating focused behavior tests, and preparing this PR.