### PR TITLE
Add generic preview materialization contract

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-preview-materialization-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-preview-materialization-contract.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const {
+  normalizePreviewMaterializationEvidence,
+  normalizePreviewMaterializationRequest,
+} = require('../../../runtime-agent-ci/lib/preview-materialization');
+const {
+  runtimeContractSchemas,
+} = require('./wp-codebox-runtime-contract-source');
+
+const RUNTIME_CONTRACT_SCHEMAS = runtimeContractSchemas();
+const WP_CODEBOX_BROWSER_CONTAINED_SITE_OPEN_SCHEMA = RUNTIME_CONTRACT_SCHEMAS.runtimeBoundary.browserContainedSiteOpen;
+const WP_CODEBOX_BROWSER_CONTAINED_SITE_STATUS_SCHEMA = RUNTIME_CONTRACT_SCHEMAS.runtimeBoundary.browserContainedSiteStatus;
+const WP_CODEBOX_BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA = RUNTIME_CONTRACT_SCHEMAS.runtimeBoundary.browserPreviewBootConfig;
+const WP_CODEBOX_PREVIEW_LEASE_SCHEMA = RUNTIME_CONTRACT_SCHEMAS.runtimeBoundary.previewLease;
+
+function codeboxPreviewMaterializationAdapter(options = {}) {
+  const openContainedSite = options.openContainedSite || options.openPreview || options.materialize;
+  if (typeof openContainedSite !== 'function') {
+    throw new Error('WP Codebox preview adapter requires openContainedSite(request, context).');
+  }
+  return {
+    id: 'wp-codebox',
+    provider: 'wp-codebox',
+    async materializePreview(request, context = {}) {
+      const genericRequest = normalizePreviewMaterializationRequest(request);
+      const codeboxRequest = codeboxPreviewOpenRequest(genericRequest, options);
+      const result = await openContainedSite(codeboxRequest, { ...context, genericRequest });
+      return codeboxPreviewEvidenceFromContainedSiteResult(result, { request: genericRequest, codeboxRequest });
+    },
+  };
+}
+
+function codeboxPreviewOpenRequest(request = {}, options = {}) {
+  const genericRequest = normalizePreviewMaterializationRequest(request);
+  return cleanObject({
+    schema: WP_CODEBOX_BROWSER_CONTAINED_SITE_OPEN_SCHEMA,
+    version: 1,
+    preview_id: genericRequest.id,
+    target: genericRequest.target,
+    routes: genericRequest.routes,
+    open: genericRequest.open,
+    lease: codeboxPreviewLeaseRequest(genericRequest.lease),
+    boot: codeboxPreviewBootConfig(genericRequest.boot),
+    metadata: {
+      ...(genericRequest.metadata || {}),
+      ...(options.metadata || {}),
+      homeboy_preview_request_schema: genericRequest.schema,
+    },
+  });
+}
+
+function codeboxPreviewEvidenceFromContainedSiteResult(result = {}, context = {}) {
+  const url = firstValue(
+    result.url,
+    result.preview_url,
+    result.previewUrl,
+    result.open_url,
+    result.openUrl,
+    result.contained_site?.url,
+    result.containedSite?.url,
+    result.site?.url,
+  );
+  const lease = firstObject(result.lease, result.preview_lease, result.previewLease, result.contained_site?.lease, result.containedSite?.lease);
+  const boot = firstObject(result.boot, result.boot_config, result.bootConfig, result.contained_site?.boot, result.containedSite?.boot);
+  const status = firstObject(result.status, result.site_status, result.siteStatus, result.contained_site?.status, result.containedSite?.status);
+  return normalizePreviewMaterializationEvidence({
+    adapter: 'wp-codebox',
+    id: result.id || result.preview_id || result.previewId || lease?.id || lease?.lease_id,
+    url,
+    refs: result.refs || result.evidence_refs || result.evidenceRefs || { kind: 'codebox-preview', uri: url, label: 'WP Codebox preview' },
+    lease,
+    boot,
+    status,
+    metadata: cleanObject({
+      codebox_open_schema: WP_CODEBOX_BROWSER_CONTAINED_SITE_OPEN_SCHEMA,
+      codebox_status_schema: status ? WP_CODEBOX_BROWSER_CONTAINED_SITE_STATUS_SCHEMA : undefined,
+      codebox_request: context.codeboxRequest,
+      ...(result.metadata || {}),
+    }),
+    source_request: context.request,
+  });
+}
+
+function codeboxPreviewLeaseRequest(lease) {
+  if (!lease) {
+    return undefined;
+  }
+  return cleanObject({
+    schema: lease.schema || WP_CODEBOX_PREVIEW_LEASE_SCHEMA,
+    ...lease,
+  });
+}
+
+function codeboxPreviewBootConfig(boot) {
+  if (!boot) {
+    return undefined;
+  }
+  return cleanObject({
+    schema: boot.schema || WP_CODEBOX_BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA,
+    ...boot,
+  });
+}
+
+function firstValue(...values) {
+  return values.find((value) => value !== undefined && value !== null && value !== '');
+}
+
+function firstObject(...values) {
+  return values.find((value) => value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function cleanObject(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+module.exports = {
+  WP_CODEBOX_BROWSER_CONTAINED_SITE_OPEN_SCHEMA,
+  WP_CODEBOX_BROWSER_CONTAINED_SITE_STATUS_SCHEMA,
+  WP_CODEBOX_BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA,
+  WP_CODEBOX_PREVIEW_LEASE_SCHEMA,
+  codeboxPreviewEvidenceFromContainedSiteResult,
+  codeboxPreviewMaterializationAdapter,
+  codeboxPreviewOpenRequest,
+};

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -156,6 +156,13 @@ const WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS = [
     adapter_behavior: 'local_git_apply_until_primitive_exists',
     requirement: 'Expose approved artifact patch application as a Codebox-owned primitive. Homeboy Extensions already delegates preflight and apply request creation when runtime-core exports are available; the remaining local code maps Homeboy worktree, commit, and publish policy around git apply.',
   },
+  {
+    id: 'preview-materialization',
+    schema: RUNTIME_CONTRACT_SCHEMAS.runtimeBoundary.browserContainedSiteOpen,
+    owner: 'wp-codebox',
+    adapter_behavior: 'delegate_contained_site_open_without_constructing_playground_urls',
+    requirement: 'Materialize or open a browser contained-site preview from caller domain inputs and return typed preview evidence including URL, lease, boot, and status metadata when available. Homeboy must not construct Playground URLs downstream.',
+  },
 ];
 
 function wpCodeboxProviderRuntimeInvocationContract() {

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -514,6 +514,13 @@
           "owner": "wp-codebox",
           "adapter_behavior": "local_git_apply_until_primitive_exists",
           "requirement": "Expose approved artifact patch application as a Codebox-owned primitive. Homeboy Extensions already delegates preflight and apply request creation when runtime-core exports are available; the remaining local code maps Homeboy worktree, commit, and publish policy around git apply."
+        },
+        {
+          "id": "preview-materialization",
+          "schema": "wp-codebox/browser-contained-site-open/v1",
+          "owner": "wp-codebox",
+          "adapter_behavior": "delegate_contained_site_open_without_constructing_playground_urls",
+          "requirement": "Materialize or open a browser contained-site preview from caller domain inputs and return typed preview evidence including URL, lease, boot, and status metadata when available. Homeboy must not construct Playground URLs downstream."
         }
       ],
       "status": "active",

--- a/runtime-agent-ci/index.js
+++ b/runtime-agent-ci/index.js
@@ -7,3 +7,4 @@ Object.assign(module.exports, require('./lib/fanout-reconcile-runner'));
 Object.assign(module.exports, require('./lib/generic-fanout-reconcile-workflow'));
 Object.assign(module.exports, require('./lib/runtime-workflow-inputs.cjs'));
 Object.assign(module.exports, require('./lib/headless-deterministic-loop-runner'));
+Object.assign(module.exports, require('./lib/preview-materialization'));

--- a/runtime-agent-ci/lib/preview-materialization.js
+++ b/runtime-agent-ci/lib/preview-materialization.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const PREVIEW_MATERIALIZATION_REQUEST_SCHEMA = 'homeboy/preview-materialization-request/v1';
+const PREVIEW_MATERIALIZATION_EVIDENCE_SCHEMA = 'homeboy/preview-materialization-evidence/v1';
+
+async function materializePreview(adapter, request = {}, context = {}) {
+  if (!adapter || typeof adapter.materializePreview !== 'function') {
+    throw new Error('Preview materialization requires an adapter with materializePreview(request, context).');
+  }
+  const normalizedRequest = normalizePreviewMaterializationRequest(request);
+  const result = await adapter.materializePreview(normalizedRequest, context);
+  return normalizePreviewMaterializationEvidence(result, {
+    adapter: adapter.id || adapter.provider || normalizedRequest.adapter,
+    request: normalizedRequest,
+  });
+}
+
+function normalizePreviewMaterializationRequest(request = {}) {
+  if (!plainObject(request)) {
+    throw new Error('Preview materialization request must be an object.');
+  }
+  const target = firstObject(request.target, request.site, request.source, request.input, request.domainInput, request.domain_input);
+  if (!target) {
+    throw new Error('Preview materialization request requires target/domain input.');
+  }
+  return cleanObject({
+    schema: request.schema || PREVIEW_MATERIALIZATION_REQUEST_SCHEMA,
+    version: request.version || 1,
+    id: request.id || request.preview_id || request.previewId,
+    adapter: request.adapter || request.provider || request.runtime,
+    target,
+    routes: firstObject(request.routes),
+    open: firstObject(request.open, request.open_options, request.openOptions),
+    lease: firstObject(request.lease, request.lease_request, request.leaseRequest),
+    boot: firstObject(request.boot, request.boot_config, request.bootConfig),
+    metadata: firstObject(request.metadata),
+  });
+}
+
+function normalizePreviewMaterializationEvidence(value = {}, context = {}) {
+  if (!plainObject(value)) {
+    throw new Error('Preview materialization evidence must be an object.');
+  }
+  const url = firstValue(
+    value.url,
+    value.preview_url,
+    value.previewUrl,
+    value.open_url,
+    value.openUrl,
+    value.public_url,
+    value.publicUrl,
+    value.href,
+    value.ref?.url,
+    value.ref?.uri,
+  );
+  if (typeof url !== 'string' || url.trim() === '') {
+    throw new Error('Preview materialization evidence requires a URL.');
+  }
+  return cleanObject({
+    schema: value.schema || PREVIEW_MATERIALIZATION_EVIDENCE_SCHEMA,
+    version: value.version || 1,
+    adapter: value.adapter || value.provider || context.adapter,
+    id: value.id || value.preview_id || value.previewId || value.lease?.id || value.lease?.lease_id,
+    url,
+    refs: normalizePreviewRefs(value.refs || value.evidence_refs || value.evidenceRefs || value.ref || { kind: 'preview', uri: url, label: 'Preview' }),
+    lease: firstObject(value.lease, value.preview_lease, value.previewLease),
+    boot: firstObject(value.boot, value.boot_config, value.bootConfig),
+    status: firstObject(value.status, value.site_status, value.siteStatus),
+    metadata: firstObject(value.metadata),
+    source_request: value.source_request || value.sourceRequest || context.request,
+  });
+}
+
+function normalizePreviewRefs(value) {
+  const refs = Array.isArray(value) ? value : [value];
+  return refs.map((ref) => {
+    if (typeof ref === 'string') {
+      return { kind: 'preview', uri: ref, label: 'Preview' };
+    }
+    if (!plainObject(ref)) {
+      return null;
+    }
+    return cleanObject({
+      kind: ref.kind || ref.type || 'preview',
+      uri: ref.uri || ref.url || ref.href,
+      url: ref.url,
+      label: ref.label || ref.name || 'Preview',
+      metadata: firstObject(ref.metadata),
+    });
+  }).filter((ref) => ref && ref.uri);
+}
+
+function plainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function firstValue(...values) {
+  return values.find((value) => value !== undefined && value !== null && value !== '');
+}
+
+function firstObject(...values) {
+  return values.find(plainObject);
+}
+
+function cleanObject(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+module.exports = {
+  PREVIEW_MATERIALIZATION_EVIDENCE_SCHEMA,
+  PREVIEW_MATERIALIZATION_REQUEST_SCHEMA,
+  materializePreview,
+  normalizePreviewMaterializationEvidence,
+  normalizePreviewMaterializationRequest,
+  normalizePreviewRefs,
+};

--- a/tests/preview-materialization-contract-smoke.mjs
+++ b/tests/preview-materialization-contract-smoke.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+	PREVIEW_MATERIALIZATION_EVIDENCE_SCHEMA,
+	PREVIEW_MATERIALIZATION_REQUEST_SCHEMA,
+	materializePreview,
+	normalizePreviewMaterializationRequest,
+} = require(path.join(rootDir, 'runtime-agent-ci', 'index.js'));
+
+const request = normalizePreviewMaterializationRequest({
+	id: 'preview-1',
+	adapter: 'fake-preview-runtime',
+	domainInput: { kind: 'artifact', artifact_id: 'site-packet-1' },
+	lease: { ttl_seconds: 300 },
+	boot: { mode: 'review' },
+});
+
+assert.equal(request.schema, PREVIEW_MATERIALIZATION_REQUEST_SCHEMA);
+assert.deepEqual(request.target, { kind: 'artifact', artifact_id: 'site-packet-1' });
+
+const fakeAdapter = {
+	id: 'fake-preview-runtime',
+	async materializePreview(previewRequest) {
+		assert.equal(previewRequest.schema, PREVIEW_MATERIALIZATION_REQUEST_SCHEMA);
+		return {
+			url: 'https://preview.example.test/session/preview-1/',
+			lease: { id: 'lease-1', ttl_seconds: 300 },
+			boot: { mode: 'review' },
+			status: { state: 'ready' },
+		};
+	},
+};
+
+const evidence = await materializePreview(fakeAdapter, request);
+assert.equal(evidence.schema, PREVIEW_MATERIALIZATION_EVIDENCE_SCHEMA);
+assert.equal(evidence.adapter, 'fake-preview-runtime');
+assert.equal(evidence.url, 'https://preview.example.test/session/preview-1/');
+assert.deepEqual(evidence.refs, [{ kind: 'preview', uri: 'https://preview.example.test/session/preview-1/', label: 'Preview' }]);
+assert.deepEqual(evidence.lease, { id: 'lease-1', ttl_seconds: 300 });
+assert.deepEqual(evidence.boot, { mode: 'review' });
+assert.deepEqual(evidence.status, { state: 'ready' });
+
+console.log('preview materialization contract smoke passed');

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -95,10 +95,15 @@ assert.deepEqual(WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.map((requirement) =>
 	'provider-runtime-invocation',
 	'artifact-result-envelope',
 	'artifact-apply-execution',
+	'preview-materialization',
 ]);
 assert.equal(
 	WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.find((requirement) => requirement.id === 'artifact-result-envelope').adapter_behavior,
 	'consume_canonical_envelope_with_legacy_package_fallback'
+);
+assert.equal(
+	WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.find((requirement) => requirement.id === 'preview-materialization').adapter_behavior,
+	'delegate_contained_site_open_without_constructing_playground_urls'
 );
 assert.doesNotMatch(JSON.stringify(cliDescriptor), /datamachine|data machine|wp-site-generator|wpsg|site generator/i);
 

--- a/tests/wp-codebox-preview-materialization-contract-smoke.mjs
+++ b/tests/wp-codebox-preview-materialization-contract-smoke.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const {
+	materializePreview,
+} = require(path.join(rootDir, 'runtime-agent-ci', 'index.js'));
+const {
+	WP_CODEBOX_BROWSER_CONTAINED_SITE_OPEN_SCHEMA,
+	WP_CODEBOX_BROWSER_CONTAINED_SITE_STATUS_SCHEMA,
+	WP_CODEBOX_BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA,
+	WP_CODEBOX_PREVIEW_LEASE_SCHEMA,
+	codeboxPreviewEvidenceFromContainedSiteResult,
+	codeboxPreviewMaterializationAdapter,
+	codeboxPreviewOpenRequest,
+} = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'codebox-preview-materialization-contract.js'));
+
+const genericRequest = {
+	id: 'codebox-preview-1',
+	target: { kind: 'site-artifact', artifact_id: 'site-packet-1' },
+	routes: { home: '/' },
+	lease: { ttl_seconds: 600 },
+	boot: { php_version: '8.3' },
+	metadata: { source: 'test' },
+};
+
+const openRequest = codeboxPreviewOpenRequest(genericRequest);
+assert.equal(openRequest.schema, WP_CODEBOX_BROWSER_CONTAINED_SITE_OPEN_SCHEMA);
+assert.equal(openRequest.lease.schema, WP_CODEBOX_PREVIEW_LEASE_SCHEMA);
+assert.equal(openRequest.boot.schema, WP_CODEBOX_BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA);
+assert.deepEqual(openRequest.target, { kind: 'site-artifact', artifact_id: 'site-packet-1' });
+
+const adapter = codeboxPreviewMaterializationAdapter({
+	async openContainedSite(request) {
+		assert.equal(request.schema, WP_CODEBOX_BROWSER_CONTAINED_SITE_OPEN_SCHEMA);
+		assert.deepEqual(request.target, genericRequest.target);
+		return {
+			preview_url: 'https://codebox-preview.example.test/site/',
+			lease: { schema: WP_CODEBOX_PREVIEW_LEASE_SCHEMA, id: 'lease-codebox-1', ttl_seconds: 600 },
+			boot: { schema: WP_CODEBOX_BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA, php_version: '8.3' },
+			status: { schema: WP_CODEBOX_BROWSER_CONTAINED_SITE_STATUS_SCHEMA, state: 'ready' },
+		};
+	},
+});
+
+const evidence = await materializePreview(adapter, genericRequest);
+assert.equal(evidence.adapter, 'wp-codebox');
+assert.equal(evidence.url, 'https://codebox-preview.example.test/site/');
+assert.deepEqual(evidence.refs, [{ kind: 'codebox-preview', uri: 'https://codebox-preview.example.test/site/', label: 'WP Codebox preview' }]);
+assert.equal(evidence.lease.schema, WP_CODEBOX_PREVIEW_LEASE_SCHEMA);
+assert.equal(evidence.boot.schema, WP_CODEBOX_BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA);
+assert.equal(evidence.status.schema, WP_CODEBOX_BROWSER_CONTAINED_SITE_STATUS_SCHEMA);
+assert.equal(evidence.metadata.codebox_open_schema, WP_CODEBOX_BROWSER_CONTAINED_SITE_OPEN_SCHEMA);
+
+assert.equal(
+	codeboxPreviewEvidenceFromContainedSiteResult({ contained_site: { url: 'https://contained.example.test', status: { state: 'booting' } } }).url,
+	'https://contained.example.test'
+);
+
+const boundaryTerms = /wp-site-generator|WPSG|site-generator|site generator|PLAYGROUND_PREVIEW|PLAYGROUND_URL/i;
+for (const relativePath of [
+	'runtime-agent-ci/lib/preview-materialization.js',
+	'agent-runtimes/wp-codebox/lib/codebox-preview-materialization-contract.js',
+]) {
+	assert.equal(boundaryTerms.test(fs.readFileSync(path.join(rootDir, relativePath), 'utf8')), false, `${relativePath} must remain generic.`);
+}
+
+console.log('wp-codebox preview materialization contract smoke passed');


### PR DESCRIPTION
## Summary
- Add a provider-neutral preview materialization request/evidence contract in runtime-agent-ci.
- Add a WP Codebox adapter that delegates to its contained-site open contract and normalizes URL, lease, boot, and status metadata into durable preview evidence.
- Cover the generic adapter boundary, a fake non-Codebox adapter, and WP Codebox contract mapping without WPSG-specific code or downstream Playground URL construction.

## Tests
- `node tests/preview-materialization-contract-smoke.mjs`
- `node tests/wp-codebox-preview-materialization-contract-smoke.mjs`
- `node tests/wp-codebox-adapter-contract-smoke.mjs`
- `node tests/runtime-agent-ci-contract-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Drafting implementation, focused tests, verification, commit and PR preparation.