### PR TITLE
Add worktree PR capability bundles

### DIFF
--- a/runtime-agent-ci/lib/agent-task-provider-contract.js
+++ b/runtime-agent-ci/lib/agent-task-provider-contract.js
@@ -71,6 +71,35 @@ const AGENT_TASK_TOOL_PRESETS = {
   },
 };
 
+const AGENT_TASK_CAPABILITY_BUNDLES = {
+  workspace_readwrite: {
+    tool_presets: ['runner_workspace'],
+    provider_runtime_invocation: {
+      operations: {
+        workspaceCommand: true,
+        workspaceCapture: true,
+      },
+    },
+  },
+  github_publication: {
+    tool_presets: ['publication'],
+    provider_runtime_invocation: {
+      operations: {
+        workspacePublish: true,
+      },
+    },
+  },
+  worktree_pr_iteration: {
+    capability_bundles: ['workspace_readwrite', 'github_publication'],
+    provider_runtime_invocation: {
+      operations: {
+        artifactHandoff: true,
+        toolCallTranscriptRecord: true,
+      },
+    },
+  },
+};
+
 const AGENT_TASK_ARTIFACT_FIELDS = [
   'schema',
   'id',
@@ -170,6 +199,87 @@ function expandAgentTaskToolPresets(presets = [], overrides = {}) {
   return expanded;
 }
 
+function expandAgentTaskCapabilityBundles(bundles = [], overrides = {}) {
+  const expanded = {};
+  const visiting = new Set();
+  for (const bundle of normalizeArray(bundles)) {
+    mergeCapabilityBundle(expanded, bundle, visiting);
+  }
+  mergeCapabilityBundleDefinition(expanded, overrides);
+  return expanded;
+}
+
+function mergeCapabilityBundle(target, bundle, visiting) {
+  const bundleName = typeof bundle === 'string' ? bundle : '';
+  const definition = bundleName ? AGENT_TASK_CAPABILITY_BUNDLES[bundleName] : bundle;
+  if (!definition || typeof definition !== 'object' || Array.isArray(definition)) {
+    throw new Error(`Unknown agent task capability bundle: ${bundleName || String(bundle)}`);
+  }
+  if (bundleName) {
+    if (visiting.has(bundleName)) {
+      throw new Error(`Circular agent task capability bundle: ${bundleName}`);
+    }
+    visiting.add(bundleName);
+  }
+  mergeCapabilityBundleDefinition(target, definition, visiting);
+  if (bundleName) {
+    visiting.delete(bundleName);
+  }
+}
+
+function mergeCapabilityBundleDefinition(target, source = {}, visiting = new Set()) {
+  for (const nestedBundle of normalizeArray(source.capability_bundles || source.capabilityBundles)) {
+    mergeCapabilityBundle(target, nestedBundle, visiting);
+  }
+  target.tool_presets = uniqueStrings([
+    ...normalizeArray(target.tool_presets),
+    ...normalizeArray(source.tool_presets || source.toolPresets),
+  ]);
+  target.provider_runtime_invocation = mergeRuntimeInvocationDescriptor(
+    target.provider_runtime_invocation,
+    source.provider_runtime_invocation || source.providerRuntimeInvocation || source.runtime_invocation || source.runtimeInvocation
+  );
+  if (target.tool_presets.length === 0) {
+    delete target.tool_presets;
+  }
+  if (target.provider_runtime_invocation && Object.keys(target.provider_runtime_invocation).length === 0) {
+    delete target.provider_runtime_invocation;
+  }
+  return target;
+}
+
+function mergeRuntimeInvocationDescriptor(current = {}, next = {}) {
+  if (!next || typeof next !== 'object' || Array.isArray(next)) {
+    return current && typeof current === 'object' && !Array.isArray(current) ? current : {};
+  }
+  const operations = mergeRuntimeInvocationOperations(runtimeInvocationOperations(current), runtimeInvocationOperations(next));
+  return {
+    ...(current && typeof current === 'object' && !Array.isArray(current) ? current : {}),
+    ...next,
+    ...(Object.keys(operations).length > 0 ? { operations } : {}),
+  };
+}
+
+function mergeRuntimeInvocationOperations(current = {}, next = {}) {
+  const merged = current && typeof current === 'object' && !Array.isArray(current) ? { ...current } : {};
+  for (const [operation, config] of Object.entries(next && typeof next === 'object' && !Array.isArray(next) ? next : {})) {
+    if (config && typeof config === 'object' && !Array.isArray(config) && merged[operation] && typeof merged[operation] === 'object' && !Array.isArray(merged[operation])) {
+      merged[operation] = { ...merged[operation], ...config };
+    } else {
+      merged[operation] = config;
+    }
+  }
+  return merged;
+}
+
+function runtimeInvocationOperations(value = {}) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  const operations = value.operations || value.provider_operations || value.providerOperations || value.tasks || value.abilities;
+  return operations && typeof operations === 'object' && !Array.isArray(operations) ? operations : {};
+}
+
 function mergeToolPreset(target, source = {}) {
   if (source.workspace_tools) {
     target.workspace_tools = mergeWorkspaceTools(target.workspace_tools, source.workspace_tools);
@@ -226,10 +336,12 @@ module.exports = {
   AGENT_TASK_REDACTED_METADATA_KEYS,
   AGENT_TASK_REQUEST_SCHEMA,
   AGENT_TASK_SECRET_SELECTOR_PATHS,
+  AGENT_TASK_CAPABILITY_BUNDLES,
   AGENT_TASK_TOOL_PRESETS,
   agentTaskArtifactFromRef,
   agentTaskEvidenceRefFromRef,
   agentTaskProviderContractFields,
+  expandAgentTaskCapabilityBundles,
   expandAgentTaskToolPresets,
   extendRedactedMetadataKeys,
   providerDefaultsContract,

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -13,6 +13,10 @@ const {
   normalizeRuntimeExecutionDescriptor,
 } = require('./generic-agent-task-plan');
 const { normalizeRuntimeId } = require('./runtime-provider-resolver.cjs');
+const {
+  expandAgentTaskCapabilityBundles,
+  expandAgentTaskToolPresets,
+} = require('./agent-task-provider-contract');
 
 const AGENT_TASK_PLAN_SCHEMA = GENERIC_AGENT_TASK_PLAN_SCHEMA;
 const AGENT_TASK_REQUEST_SCHEMA = GENERIC_AGENT_TASK_REQUEST_SCHEMA;
@@ -96,6 +100,14 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
     ability: runtimeExecution?.ability || options.ability || runtimeProfile.runtime_task_ability,
     input: runtimeTaskInput,
   });
+  const requestedCapabilityBundles = options.capabilityBundles || options.capability_bundles || options.config?.capability_bundles || options.config?.capabilityBundles;
+  const requestedProviderRuntimeInvocation = options.providerRuntimeInvocation || options.provider_runtime_invocation || options.runtimeInvocation || options.runtime_invocation || options.config?.provider_runtime_invocation || options.config?.providerRuntimeInvocation || options.config?.runtime_invocation || options.config?.runtimeInvocation;
+  const capabilityExpansion = expandAgentTaskCapabilityBundles(requestedCapabilityBundles || []);
+  const expandedToolPresetTools = expandAgentTaskToolPresets(capabilityExpansion.tool_presets || []);
+  const providerRuntimeInvocation = mergeRuntimeInvocationDescriptors(
+    capabilityExpansion.provider_runtime_invocation,
+    requestedProviderRuntimeInvocation
+  );
   return stripUndefined({
     ...(options.config || {}),
     provider: options.provider,
@@ -111,6 +123,10 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
     runtime_task: runtimeTask,
     workload,
     sandbox_tool_policy: toolPolicy,
+    capability_bundles: normalizeArray(requestedCapabilityBundles).length > 0 ? normalizeArray(requestedCapabilityBundles) : undefined,
+    tool_presets: capabilityExpansion.tool_presets,
+    workspace_tools: expandedToolPresetTools.workspace_tools,
+    publication_tools: expandedToolPresetTools.publication_tools,
     ability_tools: options.abilityTools || options.ability_tools,
     ability_requirements: options.abilityRequirements || options.ability_requirements || runtimeProfile.ability_requirements,
     artifact_slots: options.artifactSlots || options.artifact_slots,
@@ -128,10 +144,46 @@ function runtimeAgentCiTaskExecutorConfig(options = {}) {
     runtime_env: options.runtimeEnv || options.runtime_env,
     runtime_config_mounts: options.runtimeConfigMounts || options.runtime_config_mounts,
     runtime_state_mounts: options.runtimeStateMounts || options.runtime_state_mounts,
-    provider_runtime_invocation: options.providerRuntimeInvocation || options.provider_runtime_invocation || options.runtimeInvocation || options.runtime_invocation,
+    provider_runtime_invocation: nonEmptyObject(providerRuntimeInvocation),
     runtime_id: options.runtimeId || options.runtime_id,
     runtime_bin: options.runtimeBin || options.runtime_bin,
   });
+}
+
+function mergeRuntimeInvocationDescriptors(primary = {}, secondary = {}) {
+  const merged = {};
+  for (const descriptor of [primary, secondary]) {
+    if (!descriptor || typeof descriptor !== 'object' || Array.isArray(descriptor)) {
+      continue;
+    }
+    const existingOperations = merged.operations;
+    Object.assign(merged, descriptor);
+    const operations = mergeRuntimeInvocationOperations(existingOperations, runtimeInvocationOperations(descriptor));
+    if (Object.keys(operations).length > 0) {
+      merged.operations = operations;
+    }
+  }
+  return merged;
+}
+
+function mergeRuntimeInvocationOperations(current = {}, next = {}) {
+  const merged = current && typeof current === 'object' && !Array.isArray(current) ? { ...current } : {};
+  for (const [operation, config] of Object.entries(next && typeof next === 'object' && !Array.isArray(next) ? next : {})) {
+    if (config && typeof config === 'object' && !Array.isArray(config) && merged[operation] && typeof merged[operation] === 'object' && !Array.isArray(merged[operation])) {
+      merged[operation] = { ...merged[operation], ...config };
+    } else {
+      merged[operation] = config;
+    }
+  }
+  return merged;
+}
+
+function runtimeInvocationOperations(value = {}) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  const operations = value.operations || value.provider_operations || value.providerOperations || value.tasks || value.abilities;
+  return operations && typeof operations === 'object' && !Array.isArray(operations) ? operations : {};
 }
 
 function runtimeAgentCiBundleRuntimeExecution(options = {}, input = {}) {

--- a/tests/agent-task-provider-contract-smoke.mjs
+++ b/tests/agent-task-provider-contract-smoke.mjs
@@ -15,10 +15,12 @@ const {
 	AGENT_TASK_EVIDENCE_REF_SCHEMA,
 	AGENT_TASK_REDACTED_METADATA_KEYS,
 	AGENT_TASK_SECRET_SELECTOR_PATHS,
+	AGENT_TASK_CAPABILITY_BUNDLES,
 	AGENT_TASK_TOOL_PRESETS,
 	agentTaskArtifactFromRef,
 	agentTaskEvidenceRefFromRef,
 	agentTaskProviderContractFields,
+	expandAgentTaskCapabilityBundles,
 	expandAgentTaskToolPresets,
 	extendRedactedMetadataKeys,
 	providerSecretEnvRequirement,
@@ -118,6 +120,39 @@ assert.throws(
 	/Unknown agent task tool preset: product_workspace/,
 );
 
+assert.deepEqual(Object.keys(AGENT_TASK_CAPABILITY_BUNDLES), ['workspace_readwrite', 'github_publication', 'worktree_pr_iteration']);
+assert.deepEqual(expandAgentTaskCapabilityBundles(['workspace_readwrite']), {
+	tool_presets: ['runner_workspace'],
+	provider_runtime_invocation: {
+		operations: {
+			workspaceCommand: true,
+			workspaceCapture: true,
+		},
+	},
+});
+assert.deepEqual(expandAgentTaskCapabilityBundles(['worktree_pr_iteration']), {
+	tool_presets: ['runner_workspace', 'publication'],
+	provider_runtime_invocation: {
+		operations: {
+			workspaceCommand: true,
+			workspaceCapture: true,
+			workspacePublish: true,
+			artifactHandoff: true,
+			toolCallTranscriptRecord: true,
+		},
+	},
+});
+assert.deepEqual(expandAgentTaskCapabilityBundles(['github_publication'], {
+	provider_runtime_invocation: { operations: { workspacePublish: { config: { draft: true } } } },
+}), {
+	tool_presets: ['publication'],
+	provider_runtime_invocation: { operations: { workspacePublish: { config: { draft: true } } } },
+});
+assert.throws(
+	() => expandAgentTaskCapabilityBundles(['product_worktree_pr_iteration']),
+	/Unknown agent task capability bundle: product_worktree_pr_iteration/,
+);
+
 const runnerSpec = agentTaskRunnerSpec({
 	backend: 'codebox',
 	runtime: 'wp-codebox',
@@ -138,7 +173,8 @@ assert.deepEqual(agentTaskRequestFromRunnerSpec({ runnerSpec }), {
 		secret_env: ['AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN'],
 		config: { provider: 'codex' },
 	},
-	limits: { task_timeout_seconds: 900 },
+	limits: { timeout_ms: 900000, task_timeout_seconds: 900 },
+	artifact_declarations: [],
 	expected_artifacts: ['patch'],
 });
 assert.equal(validateAgentTaskRunnerSpec(runnerSpec), runnerSpec);

--- a/tests/runtime-agent-ci-contract-smoke.mjs
+++ b/tests/runtime-agent-ci-contract-smoke.mjs
@@ -97,6 +97,32 @@ assert.deepEqual(genericConfig.artifact_declarations, [{ schema: 'wp-codebox/art
 assert.deepEqual(genericConfig.transcript_slots, [{ name: 'main', required: true }]);
 assert.deepEqual(genericConfig.provider_runtime_invocation, { operations: ['workspaceCommand'] });
 
+const capabilityBundleConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
+  runtimeProfile: runtimeProfile.id,
+  runtimeProfiles: { [runtimeProfile.id]: runtimeProfile },
+  ability: 'example/run-task',
+  capabilityBundles: ['worktree_pr_iteration'],
+  runtimeInvocation: { operations: { workspaceCommand: { config: { timeout_ms: 30000 } } } },
+});
+
+assert.deepEqual(capabilityBundleConfig.capability_bundles, ['worktree_pr_iteration']);
+assert.deepEqual(capabilityBundleConfig.tool_presets, ['runner_workspace', 'publication']);
+assert.deepEqual(capabilityBundleConfig.workspace_tools, {
+  readonly: ['workspace_ls', 'workspace_read', 'workspace_git_status'],
+  readwrite: ['workspace_run', 'workspace_write', 'workspace_edit', 'workspace_apply_patch', 'workspace_delete', 'workspace_git_add'],
+});
+assert.deepEqual(capabilityBundleConfig.publication_tools, ['publication_prepare', 'publication_publish', 'publication_status']);
+assert.deepEqual(capabilityBundleConfig.provider_runtime_invocation, {
+  operations: {
+    workspaceCommand: { config: { timeout_ms: 30000 } },
+    workspaceCapture: true,
+    workspacePublish: true,
+    artifactHandoff: true,
+    toolCallTranscriptRecord: true,
+  },
+});
+assert.doesNotMatch(JSON.stringify(capabilityBundleConfig.provider_runtime_invocation), /wp-codebox\/runner-workspace-command/);
+
 assert.deepEqual(
   runtimeAgentCi.runtimeAgentCiTaskFromRequest(
     {},

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -18,6 +18,7 @@ const {
   runtimeContractSchemas,
   typedArtifactsFromCodeboxResult,
 } = require('../../agent-runtimes/wp-codebox');
+const runtimeAgentCi = require('../../runtime-agent-ci');
 
 const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wordpress-agent-boundary-'));
 const codexSecretEnv = [
@@ -423,6 +424,46 @@ assert.deepEqual(runtimeInvocationTaskInput.provider_runtime_invocation.operatio
 assert.equal(runtimeInvocationTaskInput.provider_runtime_invocation.operations.artifactHandoff.ability, 'wp-codebox/handoff-artifacts');
 assert.equal(runtimeInvocationTaskInput.provider_runtime_invocation.operations.workspaceCapture.task, 'wp-codebox.runner-workspace.capture');
 assert.doesNotMatch(JSON.stringify(runtimeInvocationTaskInput.provider_runtime_invocation), /datamachine|data machine|wp-site-generator|wpsg|site generator/i);
+
+const capabilityBundleExecutorConfig = runtimeAgentCi.runtimeAgentCiTaskExecutorConfig({
+  runtimeProfile: 'codebox-capability-bundle-runtime',
+  runtimeProfiles: {
+    'codebox-capability-bundle-runtime': {
+      schema: 'homeboy/runtime-profile/v1',
+      id: 'codebox-capability-bundle-runtime',
+      runtime_task_ability: 'example/run-task',
+      capabilities: ['ability_execution'],
+    },
+  },
+  provider: 'codex',
+  ability: 'example/run-task',
+  capabilityBundles: ['worktree_pr_iteration'],
+  runtimeInvocation: { operations: { workspaceCommand: { config: { timeout_ms: 30000 } } } },
+});
+assert.doesNotMatch(JSON.stringify(capabilityBundleExecutorConfig), /wp-codebox\/runner-workspace-command/);
+const capabilityBundleTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'capability-bundle-provider-runtime-invocation-task-1',
+  executor: {
+    backend: 'codebox',
+    config: capabilityBundleExecutorConfig,
+  },
+  instructions: 'Run with generic capability bundles for worktree PR iteration.',
+  workspace: { root: workspaceRoot, mode: 'readwrite' },
+});
+assert.deepEqual(capabilityBundleTaskInput.provider_runtime_invocation.operations.workspaceCommand, runtimeInvocationTaskInput.provider_runtime_invocation.operations.workspaceCommand);
+assert.deepEqual(capabilityBundleTaskInput.provider_runtime_invocation.operations.workspaceCapture, {
+  task: 'wp-codebox.runner-workspace.capture',
+  ability: 'wp-codebox/runner-workspace-capture',
+  result_schema: 'wp-codebox/runner-workspace-capture-result/v1',
+});
+assert.deepEqual(capabilityBundleTaskInput.provider_runtime_invocation.operations.workspacePublish, {
+  task: 'wp-codebox.runner-workspace.publish',
+  ability: 'wp-codebox/runner-workspace-publish',
+  result_schema: 'wp-codebox/runner-workspace-publication-result/v1',
+});
+assert.equal(capabilityBundleTaskInput.provider_runtime_invocation.operations.artifactHandoff.ability, 'wp-codebox/handoff-artifacts');
+assert.equal(capabilityBundleTaskInput.provider_runtime_invocation.operations.toolCallTranscriptRecord.ability, 'wp-codebox/record-tool-call-transcript');
 
 const customRuntimeProfileTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',


### PR DESCRIPTION
## Summary
- Add generic agent-task capability bundles for workspace read/write, GitHub publication, and worktree PR iteration.
- Expand runtime-agent-ci capability bundles into generic runtime invocation operation names and tool presets.
- Cover WP Codebox adapter resolution so downstreams can request bundles without raw wp-codebox runner-workspace ability IDs.

## Tests
- node tests/agent-task-provider-contract-smoke.mjs
- node tests/runtime-agent-ci-contract-smoke.mjs
- npm run test:codebox-agent-task-executor-boundary

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Implementing generic capability bundle expansion, updating focused contract tests, and preparing this PR.