### PR TITLE
Make Codebox run-agent-task contract the default

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -59,6 +59,7 @@ const {
 } = require('./wp-codebox-adapter-contract');
 const {
   WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
+  allowLegacyCodeboxResultCompatibility,
   isCodeboxLegacyAgentTaskRunResult,
   legacyAgentTaskRunEvidenceRefs,
   legacyAgentTaskRunSessionArtifacts,
@@ -2238,8 +2239,8 @@ function normalizeTypedArtifacts(value) {
   return normalizeCodeboxTypedArtifacts(value, { sanitize: sanitizePublicMetadata });
 }
 
-function typedArtifactsFromResult(result) {
-  return typedArtifactsFromCodeboxResult(result, { sanitize: sanitizePublicMetadata });
+function typedArtifactsFromResult(result, options = {}) {
+  return typedArtifactsFromCodeboxResult(result, { sanitize: sanitizePublicMetadata, ...options });
 }
 
 function codeboxAgentResultFromResult(result) {
@@ -2577,8 +2578,8 @@ function outputsWithInputTypedArtifacts(outputs, request) {
   return added ? { ...outputs, typed_artifacts: typedArtifacts } : outputs;
 }
 
-function typedBundleOutputArtifacts(result) {
-  return Object.values(typedArtifactsFromResult(result)).flatMap((typedArtifact) => typedArtifactFileRefs(typedArtifact).map((ref, index) => {
+function typedBundleOutputArtifacts(result, options = {}) {
+  return Object.values(typedArtifactsFromResult(result, options)).flatMap((typedArtifact) => typedArtifactFileRefs(typedArtifact).map((ref, index) => {
     const fileRef = typeof ref === 'string' ? { path: ref } : ref;
     if (!fileRef || typeof fileRef !== 'object') {
       return null;
@@ -2629,9 +2630,9 @@ function firstPlainObject(...candidates) {
   return candidates.find((candidate) => candidate && typeof candidate === 'object' && !Array.isArray(candidate));
 }
 
-function normalizeOutputs(result, request = null) {
+function normalizeOutputs(result, request = null, options = {}) {
   const workload = agentRuntimeWorkload(result) || {};
-  const typedArtifacts = typedArtifactsFromResult(result);
+  const typedArtifacts = typedArtifactsFromResult(result, options);
   Object.assign(typedArtifacts, transcriptTypedArtifactsFromCodeboxResult(request, result, typedArtifacts));
   if (request) {
     Object.assign(typedArtifacts, replyTypedArtifactsFromResult(request, result, typedArtifacts));
@@ -2784,11 +2785,11 @@ function codeboxRecipeRunSummary(result, options = {}) {
   }
 }
 
-function normalizeArtifacts(result, runSummary = null, recipeSummary = null) {
+function normalizeArtifacts(result, runSummary = null, recipeSummary = null, options = {}) {
   const normalizedArtifacts = Array.isArray(runSummary?.artifacts)
     ? runSummary.artifacts.map(artifactFromCodeboxArtifact)
     : [];
-  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result);
+  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result, options);
   for (const artifact of artifactResult?.artifactRefs || []) {
     appendUniqueArtifact(normalizedArtifacts, artifactFromCodeboxArtifact(artifact));
   }
@@ -2796,7 +2797,7 @@ function normalizeArtifacts(result, runSummary = null, recipeSummary = null) {
     recipeSummary.artifacts.map(artifactFromCodeboxArtifact).forEach((artifact) => appendUniqueArtifact(normalizedArtifacts, artifact));
   }
 
-  if (isCodeboxLegacyAgentTaskRunResult(result)) {
+  if (isCodeboxLegacyAgentTaskRunResult(result) && allowLegacyCodeboxResultCompatibility(options)) {
     const artifacts = [...normalizedArtifacts];
     legacyAgentTaskRunSessionArtifacts(result).forEach((artifact) => appendUniqueArtifact(artifacts, artifact));
     if (Array.isArray(result.artifacts)) {
@@ -2809,7 +2810,7 @@ function normalizeArtifacts(result, runSummary = null, recipeSummary = null) {
       for (const artifact of agentRuntimeBundleArtifacts(result)) {
         appendUniqueArtifact(artifacts, artifact);
       }
-      for (const artifact of typedBundleOutputArtifacts(result)) {
+      for (const artifact of typedBundleOutputArtifacts(result, options)) {
         appendUniqueArtifact(artifacts, artifact);
       }
       if (!recipeSummary) {
@@ -2828,9 +2829,9 @@ function normalizeArtifacts(result, runSummary = null, recipeSummary = null) {
   return mappedArtifacts;
 }
 
-function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) {
-  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result);
-  if (isCodeboxLegacyAgentTaskRunResult(result)) {
+function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null, options = {}) {
+  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result, options);
+  if (isCodeboxLegacyAgentTaskRunResult(result) && allowLegacyCodeboxResultCompatibility(options)) {
     const refs = legacyAgentTaskRunEvidenceRefs(result);
     for (const artifact of artifactResult?.artifactRefs || []) {
       appendUniqueEvidenceRef(refs, {
@@ -2861,7 +2862,7 @@ function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null) 
           label: artifact.kind.replace(/^agent-runtime-/, 'Agent runtime ').replace(/-/g, ' '),
         });
       }
-      for (const artifact of typedBundleOutputArtifacts(result)) {
+      for (const artifact of typedBundleOutputArtifacts(result, options)) {
         appendUniqueEvidenceRef(refs, {
           kind: artifact.kind,
           uri: artifact.path || artifact.url,
@@ -2966,8 +2967,8 @@ function agentRuntimeBundleArtifacts(result) {
   return artifacts;
 }
 
-function codeboxDecisionEvidence(result, runSummary = null, recipeSummary = null) {
-  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result);
+function codeboxDecisionEvidence(result, runSummary = null, recipeSummary = null, options = {}) {
+  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result, options);
   const agentResult = result.run?.agentResult || result.agentResult || result.agent_result || result.metadata?.recipe_run?.agentResult || result.metadata?.recipe_run?.run?.agentResult || {};
   const completionOutcome = result.completionOutcome || result.completion_outcome || result.metadata?.recipe_run?.completionOutcome || {};
   const runtime = result.run?.runtime || result.metadata?.recipe_run?.run?.runtime || {};
@@ -3064,7 +3065,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     status = localStatus;
   }
   const failureClassification = homeboyFailureClassification(result.failure_classification || recipeSummary?.metadata?.failure_classification || runSummary?.failure_classification, status);
-  const outputs = outputsWithInputTypedArtifacts(normalizeOutputs(result, request), request);
+  const outputs = outputsWithInputTypedArtifacts(normalizeOutputs(result, request, options), request);
   const missingRequiredTypedArtifacts = missingRequiredTypedArtifactDiagnostic(request, outputs);
   const invalidRequiredTypedArtifacts = invalidRequiredTypedArtifactDiagnostic(request, outputs);
   const runtimeFailureDiagnostic = agentRuntimeFailureDiagnostic(result);
@@ -3088,8 +3089,8 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     integrationContract: WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
     status,
     summary: missingRequiredTypedArtifacts?.message || invalidRequiredTypedArtifacts?.message || runtimeFailureDiagnostic?.message || recipeSummary?.failure_summary || fallbackRecipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
-    artifacts: normalizeArtifacts(result, runSummary, recipeSummary),
-    evidenceRefs: normalizeEvidenceRefs(result, runSummary, recipeSummary),
+    artifacts: normalizeArtifacts(result, runSummary, recipeSummary, options),
+    evidenceRefs: normalizeEvidenceRefs(result, runSummary, recipeSummary, options),
     outputs,
     diagnostics: [providerDiagnostic, missingRequiredTypedArtifacts, invalidRequiredTypedArtifacts, runtimeFailureDiagnostic, recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
@@ -3100,7 +3101,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
       codebox: sanitizePublicMetadata(result.metadata || result),
       codebox_run_result: runSummary ? sanitizePublicMetadata(runSummary) : undefined,
       codebox_recipe_run_summary: recipeSummary ? sanitizePublicMetadata(recipeSummary) : undefined,
-      decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result, runSummary, recipeSummary)),
+      decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result, runSummary, recipeSummary, options)),
       artifact_declarations: sanitizePublicMetadata(artifactDeclarationsMetadataFromRequest(request)),
       typed_artifacts: sanitizePublicMetadata(outputs.typed_artifacts || {}),
       sandbox_policy: sanitizePublicMetadata({

--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -8,6 +8,7 @@ const {
   runtimeContractSchemas,
 } = require('./wp-codebox-runtime-contract-source');
 const {
+  allowLegacyCodeboxResultCompatibility,
   legacyArtifactResultEnvelopeCandidates,
   legacyTypedArtifactCandidatesFromCodeboxResult,
 } = require('./codebox-legacy-result-adapter');
@@ -73,10 +74,14 @@ function normalizeTypedArtifacts(value, options = {}) {
 
 function typedArtifactsFromCodeboxResult(result, options = {}) {
   const workload = options.workload || agentRuntimeWorkload(result) || {};
-  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result);
+  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result, options);
   const envelopeArtifacts = typedArtifactsFromArtifactResultEnvelope(artifactResult, options);
   if (Object.keys(envelopeArtifacts).length > 0) {
     return envelopeArtifacts;
+  }
+
+  if (!allowLegacyCodeboxResultCompatibility(options)) {
+    return {};
   }
 
   return Object.assign({}, ...legacyTypedArtifactCandidatesFromCodeboxResult(result, workload)
@@ -84,7 +89,7 @@ function typedArtifactsFromCodeboxResult(result, options = {}) {
 }
 
 function caseArtifactIndexFromCodeboxResult(result, options = {}) {
-  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result);
+  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result, options);
   return normalizeCaseArtifactIndex({
     schema: WP_CODEBOX_CASE_ARTIFACT_INDEX_SCHEMA,
     caseRefs: [
@@ -300,7 +305,7 @@ function typedArtifactsFromArtifactResultEnvelope(artifactResult, options = {}) 
   return Object.assign({}, ...candidates.map((candidate) => normalizeTypedArtifacts(candidate, options)));
 }
 
-function artifactResultEnvelopeFromCodeboxResult(result) {
+function artifactResultEnvelopeFromCodeboxResult(result, options = {}) {
   const candidates = [
     result,
     result?.artifact_result,
@@ -310,7 +315,7 @@ function artifactResultEnvelopeFromCodeboxResult(result) {
     ...(Array.isArray(result?.projections) ? result.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection) : []),
     ...(Array.isArray(result?.metadata?.projections) ? result.metadata.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection) : []),
   ];
-  const legacyCandidates = legacyArtifactResultEnvelopeCandidates(result);
+  const legacyCandidates = allowLegacyCodeboxResultCompatibility(options) ? legacyArtifactResultEnvelopeCandidates(result) : [];
   return [...candidates, ...legacyCandidates].map(normalizeArtifactResultEnvelope).find(Boolean) || null;
 }
 

--- a/agent-runtimes/wp-codebox/lib/codebox-legacy-result-adapter.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-legacy-result-adapter.js
@@ -16,6 +16,10 @@ function isCodeboxLegacyAgentTaskRunResult(result) {
   return result?.schema === WP_CODEBOX_AGENT_TASK_RUN_RESPONSE_SCHEMA;
 }
 
+function allowLegacyCodeboxResultCompatibility(options = {}) {
+  return Boolean(options.allowLegacyCodeboxResultCompatibility || options.allow_legacy_codebox_result_compatibility);
+}
+
 function legacyAgentTaskRunSessionArtifacts(result = {}) {
   if (!isCodeboxLegacyAgentTaskRunResult(result)) {
     return [];
@@ -107,6 +111,7 @@ function legacyTypedArtifactCandidatesFromCodeboxResult(result, workload = {}) {
 
 module.exports = {
   DEPRECATED_CODEBOX_LEGACY_RESULT_ADAPTER,
+  allowLegacyCodeboxResultCompatibility,
   isCodeboxLegacyAgentTaskRunResult,
   legacyAgentTaskRunEvidenceRefs,
   legacyAgentTaskRunSessionArtifacts,

--- a/agent-runtimes/wp-codebox/lib/codebox-run-agent-task-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-run-agent-task-contract.js
@@ -10,6 +10,7 @@ const {
 const RUNTIME_CONTRACT_SCHEMAS = runtimeContractSchemas();
 const {
   isCodeboxLegacyAgentTaskRunResult,
+  allowLegacyCodeboxResultCompatibility,
   legacyAgentTaskRunEvidenceRefs,
   legacyAgentTaskRunSessionArtifacts,
 } = require('./codebox-legacy-result-adapter');
@@ -40,16 +41,16 @@ function codeboxRunAgentTaskRequestFromTaskInput(taskInput, options = {}) {
 }
 
 function codeboxRunAgentTaskInvocation(options = {}) {
-  const useStableRunAgentTask = Boolean(options.useStableRunAgentTask || options.use_stable_run_agent_task);
-  const input = useStableRunAgentTask
-    ? codeboxRunAgentTaskRequestFromTaskInput(options.taskInput, options)
-    : options.taskInput;
+  const useLegacyAgentTaskRunCompatibility = Boolean(options.useLegacyAgentTaskRunCompatibility || options.use_legacy_agent_task_run_compatibility);
+  const input = useLegacyAgentTaskRunCompatibility
+    ? options.taskInput
+    : codeboxRunAgentTaskRequestFromTaskInput(options.taskInput, options);
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
     throw new Error('Codebox run-agent-task invocation requires taskInput.');
   }
 
   const args = [
-    useStableRunAgentTask ? WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND : WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND,
+    useLegacyAgentTaskRunCompatibility ? WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND : WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND,
     `--input-file=${options.inputFilePlaceholder || '{{input_file}}'}`,
     '--json',
   ];
@@ -64,10 +65,10 @@ function codeboxRunAgentTaskInvocation(options = {}) {
 
   return {
     contract: WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
-    implementation: useStableRunAgentTask ? 'stable-run-agent-task' : 'legacy-agent-task-run-compat',
+    implementation: useLegacyAgentTaskRunCompatibility ? 'legacy-agent-task-run-compat' : 'stable-run-agent-task',
     input,
     args,
-    result_schema: useStableRunAgentTask ? WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA : WP_CODEBOX_AGENT_TASK_RUN_RESPONSE_SCHEMA,
+    result_schema: useLegacyAgentTaskRunCompatibility ? WP_CODEBOX_AGENT_TASK_RUN_RESPONSE_SCHEMA : WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA,
     result_key: 'agent_task_run_result',
   };
 }
@@ -89,6 +90,7 @@ module.exports = {
   WP_CODEBOX_RUN_AGENT_TASK_RESULT_SCHEMA,
   codeboxRunAgentTaskInvocation,
   codeboxRunAgentTaskRequestFromTaskInput,
+  allowLegacyCodeboxResultCompatibility,
   isCodeboxLegacyAgentTaskRunResult,
   legacyAgentTaskRunEvidenceRefs,
   legacyAgentTaskRunSessionArtifacts,

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -111,8 +111,8 @@ const WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS = [
     id: 'run-agent-task',
     schema: 'wp-codebox/run-agent-task/v1',
     owner: 'wp-codebox',
-    adapter_behavior: 'prefer_stable_run_agent_task_with_legacy_agent_task_run_fallback',
-    requirement: 'Accept a Codebox-owned run-agent-task request that wraps the prepared task input and returns the stable agent_task_run_result envelope. Until that primitive is present, Homeboy Extensions keeps the legacy agent-task-run CLI compatibility path behind codebox-run-agent-task-contract.js.',
+    adapter_behavior: 'stable_run_agent_task_default_with_explicit_legacy_agent_task_run_compatibility',
+    requirement: 'Accept a Codebox-owned run-agent-task request that wraps the prepared task input and returns the stable agent_task_run_result envelope. Older agent-task-run compatibility is available only when the caller explicitly enables useLegacyAgentTaskRunCompatibility.',
   },
   {
     id: 'provider-credential-boundary',
@@ -146,8 +146,8 @@ const WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS = [
     id: 'artifact-result-envelope',
     schema: WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS.artifact_result_envelope,
     owner: 'wp-codebox',
-    adapter_behavior: 'consume_canonical_envelope_with_legacy_package_fallback',
-    requirement: 'Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Compatibility for older Codebox packages is centralized in codebox-artifact-contract.js.',
+    adapter_behavior: 'consume_canonical_envelope_with_explicit_legacy_result_compatibility',
+    requirement: 'Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Compatibility for older Codebox package result shapes is centralized in codebox-artifact-contract.js and requires allowLegacyCodeboxResultCompatibility.',
   },
   {
     id: 'artifact-apply-execution',

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -646,7 +646,14 @@ async function runTaskRunner(request) {
     payload = stderrFailurePayload(result);
   }
 
-  return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: result.status ?? 1, ...coreNormalizers });
+  return agentTaskOutcomeFromCodeboxResult(request, payload, { exitStatus: result.status ?? 1, ...coreNormalizers, ...legacyResultCompatibilityOptions(request, payload) });
+}
+
+function legacyResultCompatibilityOptions(request, payload = {}) {
+  const config = request.executor?.config || {};
+  const explicitConfig = config.allowLegacyCodeboxResultCompatibility || config.allow_legacy_codebox_result_compatibility;
+  const explicitRunnerFallback = payload.metadata?.run_agent_task_compatibility?.legacy_result_normalization === true;
+  return explicitConfig || explicitRunnerFallback ? { allowLegacyCodeboxResultCompatibility: true } : {};
 }
 
 (async () => {

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -2230,7 +2230,7 @@ function runWpCodeboxParentTask(request, envOverrides = {}) {
     artifactsPath: artifacts,
     previewHold: argValue('--preview-hold'),
     previewPublicUrl: argValue('--preview-public-url'),
-    useStableRunAgentTask,
+    useLegacyAgentTaskRunCompatibility: !useStableRunAgentTask,
   });
   const inputPath = writeJsonFile(
     useStableRunAgentTask ? 'homeboy-wp-codebox-run-agent-task-' : 'homeboy-wp-codebox-agent-task-input-',
@@ -2303,7 +2303,8 @@ function runWpCodeboxParentTask(request, envOverrides = {}) {
         secretNames: input.secret_env || [],
       }) : null);
       const callbackPayload = withCallbackDataEnvelope(normalizedPayload, readCallbackData(callbackInput.callback_data));
-      const enrichedPayload = payloadEvidence ? attachFailureEvidence(callbackPayload, payloadEvidence) : callbackPayload;
+      const compatibilityPayload = attachRunAgentTaskCompatibilityMetadata(callbackPayload, invocation);
+      const enrichedPayload = payloadEvidence ? attachFailureEvidence(compatibilityPayload, payloadEvidence) : compatibilityPayload;
       process.stdout.write(`${JSON.stringify(enrichedPayload, null, 2)}\n`);
       return callbackPayload.success === false ? 1 : 0;
     } catch {
@@ -2337,6 +2338,22 @@ function runWpCodeboxParentTask(request, envOverrides = {}) {
     return 1;
   }
   return result.status ?? 1;
+}
+
+function attachRunAgentTaskCompatibilityMetadata(payload, invocation) {
+  if (!payload || typeof payload !== 'object' || invocation.implementation !== 'legacy-agent-task-run-compat') {
+    return payload;
+  }
+  return {
+    ...payload,
+    metadata: {
+      ...(payload.metadata && typeof payload.metadata === 'object' && !Array.isArray(payload.metadata) ? payload.metadata : {}),
+      run_agent_task_compatibility: {
+        legacy_result_normalization: true,
+        implementation: invocation.implementation,
+      },
+    },
+  };
 }
 
 (async () => {

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -470,8 +470,8 @@
           "id": "run-agent-task",
           "schema": "wp-codebox/run-agent-task/v1",
           "owner": "wp-codebox",
-          "adapter_behavior": "prefer_stable_run_agent_task_with_legacy_agent_task_run_fallback",
-          "requirement": "Accept a Codebox-owned run-agent-task request that wraps the prepared task input and returns the stable agent_task_run_result envelope. Until that primitive is present, Homeboy Extensions keeps the legacy agent-task-run CLI compatibility path behind codebox-run-agent-task-contract.js."
+          "adapter_behavior": "stable_run_agent_task_default_with_explicit_legacy_agent_task_run_compatibility",
+          "requirement": "Accept a Codebox-owned run-agent-task request that wraps the prepared task input and returns the stable agent_task_run_result envelope. Older agent-task-run compatibility is available only when the caller explicitly enables useLegacyAgentTaskRunCompatibility."
         },
         {
           "id": "provider-credential-boundary",
@@ -505,8 +505,8 @@
           "id": "artifact-result-envelope",
           "schema": "wp-codebox/artifact-result-envelope/v1",
           "owner": "wp-codebox",
-          "adapter_behavior": "consume_canonical_envelope_with_legacy_package_fallback",
-          "requirement": "Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Compatibility for older Codebox packages is centralized in codebox-artifact-contract.js."
+          "adapter_behavior": "consume_canonical_envelope_with_explicit_legacy_result_compatibility",
+          "requirement": "Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Compatibility for older Codebox package result shapes is centralized in codebox-artifact-contract.js and requires allowLegacyCodeboxResultCompatibility."
         },
         {
           "id": "artifact-apply-execution",

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -63,7 +63,7 @@ const runAgentTaskRequirement = provider.upstream_primitive_requirements.find((r
 assert.equal(runAgentTaskRequirement.schema, runtimeContractSchemas().agentTask.runRequest);
 assert.equal(
   provider.upstream_primitive_requirements.find((requirement) => requirement.id === 'artifact-result-envelope').adapter_behavior,
-  'consume_canonical_envelope_with_legacy_package_fallback'
+  'consume_canonical_envelope_with_explicit_legacy_result_compatibility'
 );
 assert.doesNotMatch(JSON.stringify(provider.provider_runtime_invocation), /datamachine|data machine|wp-site-generator|wpsg|site generator/i);
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, codexSecretEnv);
@@ -216,7 +216,7 @@ assert.deepEqual(customContract.capabilities, ['wordpress_sandbox', 'tool:exampl
 assert.deepEqual(customContract.workspace_tools.readwrite, ['example_workspace_write']);
 assert.deepEqual(customContract.component_path_defaults.contract_slug_map, { 'example-runtime': 'agent_runtime' });
 
-const taskInput = codeboxTaskRequestFromAgentTaskRequest({
+const genericAgentTaskRequest = {
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'generic-wordpress-task-1',
   executor: {
@@ -238,7 +238,8 @@ const taskInput = codeboxTaskRequestFromAgentTaskRequest({
       input: { include_debug: false },
     },
   },
-});
+};
+const taskInput = codeboxTaskRequestFromAgentTaskRequest(genericAgentTaskRequest);
 
 assert.equal(taskInput.schema, 'wp-codebox/task-input/v1');
 assert.equal(taskInput.parent_request.executor.backend, 'codebox');
@@ -258,14 +259,53 @@ assert.equal(
   taskInput.sandbox_tool_policy.tools.some((tool) => tool.id === 'wordpress.read-post'),
   true
 );
-const legacyCodeboxInvocation = codeboxRunAgentTaskInvocation({ taskInput });
-assert.equal(legacyCodeboxInvocation.contract, runAgentTaskRequirement.schema);
-assert.equal(legacyCodeboxInvocation.args[0], 'agent-task-run');
-assert.equal(legacyCodeboxInvocation.result_schema, runtimeContractSchemas().agentTask.legacyRunResponse);
-const stableCodeboxInvocation = codeboxRunAgentTaskInvocation({ taskInput, useStableRunAgentTask: true });
+const stableCodeboxInvocation = codeboxRunAgentTaskInvocation({ taskInput });
+assert.equal(stableCodeboxInvocation.contract, runAgentTaskRequirement.schema);
 assert.equal(stableCodeboxInvocation.input.schema, runtimeContractSchemas().agentTask.runRequest);
 assert.equal(stableCodeboxInvocation.args[0], 'run-agent-task');
 assert.equal(stableCodeboxInvocation.result_schema, runtimeContractSchemas().agentTask.runResult);
+assert.equal(stableCodeboxInvocation.implementation, 'stable-run-agent-task');
+const legacyCodeboxInvocation = codeboxRunAgentTaskInvocation({ taskInput, useLegacyAgentTaskRunCompatibility: true });
+assert.equal(legacyCodeboxInvocation.args[0], 'agent-task-run');
+assert.equal(legacyCodeboxInvocation.input.schema, 'wp-codebox/task-input/v1');
+assert.equal(legacyCodeboxInvocation.result_schema, runtimeContractSchemas().agentTask.legacyRunResponse);
+assert.equal(legacyCodeboxInvocation.implementation, 'legacy-agent-task-run-compat');
+const stableCodeboxResult = {
+  schema: runtimeContractSchemas().agentTask.runResult,
+  status: 'succeeded',
+  summary: 'Stable Codebox run succeeded.',
+  artifact_result: {
+    schema: runtimeContractSchemas().artifact.resultEnvelope,
+    status: 'created',
+    typed_artifacts: [{ name: 'stable-review', type: 'json', payload: { ok: true } }],
+  },
+};
+const stableCodeboxOutcome = agentTaskOutcomeFromCodeboxResult(genericAgentTaskRequest, stableCodeboxResult);
+assert.equal(stableCodeboxOutcome.status, 'succeeded');
+assert.equal(stableCodeboxOutcome.outputs.typed_artifacts['stable-review'].payload.ok, true);
+const legacyShapedCodeboxResult = {
+  schema: runtimeContractSchemas().agentTask.legacyRunResponse,
+  status: 'succeeded',
+  metadata: {
+    agent_runtime: {
+      result: {
+        schema: runtimeContractSchemas().artifact.resultEnvelope,
+        status: 'created',
+        typed_artifacts: [{ name: 'legacy-review', type: 'json', payload: { ok: true } }],
+      },
+    },
+  },
+};
+assert.equal(artifactResultEnvelopeFromCodeboxResult(legacyShapedCodeboxResult), null);
+assert.deepEqual(typedArtifactsFromCodeboxResult(legacyShapedCodeboxResult), {});
+assert.equal(
+  artifactResultEnvelopeFromCodeboxResult(legacyShapedCodeboxResult, { allowLegacyCodeboxResultCompatibility: true }).status,
+  'created'
+);
+assert.equal(
+  typedArtifactsFromCodeboxResult(legacyShapedCodeboxResult, { allowLegacyCodeboxResultCompatibility: true })['legacy-review'].payload.ok,
+  true
+);
 
 const originalToolPolicyEnv = process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON;
 const originalToolRequestSchemaEnv = process.env.HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA;

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -7,7 +7,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const {
-  agentTaskOutcomeFromCodeboxResult,
+  agentTaskOutcomeFromCodeboxResult: rawAgentTaskOutcomeFromCodeboxResult,
   codeboxTaskRequestFromAgentTaskRequest,
   missingRequiredSecretEnvMapping,
   missingRequiredSecretEnvValues,
@@ -44,6 +44,13 @@ const repoLoopCapabilities = [
   'ability:example/run-agent-bundle',
   'ability:github_pull_request_publish',
 ];
+
+function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
+  return rawAgentTaskOutcomeFromCodeboxResult(request, result, {
+    allowLegacyCodeboxResultCompatibility: true,
+    ...options,
+  });
+}
 
 function exampleAgentCiCodeboxExecutorConfig(config = {}) {
   const profileId = 'example-agent-ci';


### PR DESCRIPTION
## Summary
- Make the stable WP Codebox run-agent-task request/result contract the default invocation path.
- Put the legacy agent-task-run command and legacy result-shape normalization behind explicit compatibility flags.
- Add boundary coverage for stable default invocation/result handling and legacy-shaped result fixtures requiring compatibility.

## Tests
- npm run test:codebox-agent-task-executor-boundary
- npm run test:codebox-agent-task-executor
- npm run test:wp-codebox-task-runner

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Implementing the Codebox adapter contract default change, updating tests, and running focused verification.