### PR TITLE
Deprecate Codebox runtime contract fallback

### DIFF
--- a/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
@@ -8,6 +8,12 @@ const { pathToFileURL } = require('node:url');
 const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
 const RUNTIME_CONTRACT_MANIFEST_SCHEMA = 'wp-codebox/runtime-contract-manifest/v1';
 
+const DEPRECATED_RUNTIME_CONTRACT_FALLBACK = {
+  status: 'deprecated',
+  replacement: '@automattic/wp-codebox-core runtimeContractManifest()',
+  reason: 'Homeboy Extensions must consume WP Codebox public package contracts instead of carrying schema copies.',
+};
+
 const FALLBACK_RUNTIME_CONTRACT_SCHEMAS = {
   providerRuntime: {
     invocation: 'wp-codebox/provider-runtime-invocation-contract/v1',
@@ -88,6 +94,16 @@ function runtimeContractManifest() {
   return clone(FALLBACK_RUNTIME_CONTRACT_MANIFEST);
 }
 
+function runtimeContractFallbackDiagnostic(details = {}) {
+  return withoutUndefinedValues({
+    ...DEPRECATED_RUNTIME_CONTRACT_FALLBACK,
+    source: 'homeboy-extensions-fallback',
+    schema: RUNTIME_CONTRACT_MANIFEST_SCHEMA,
+    canonical_required_option: 'required',
+    details: Object.keys(details).length > 0 ? details : undefined,
+  });
+}
+
 function runtimeContractSchemas() {
   return runtimeContractManifest().schemas;
 }
@@ -106,6 +122,7 @@ async function loadRuntimeContractSource(options = {}) {
     manifest: runtimeContractManifest(),
     normalizers: {},
     canonical: false,
+    diagnostics: [runtimeContractFallbackDiagnostic()],
   };
 }
 
@@ -206,7 +223,12 @@ function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
+function withoutUndefinedValues(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
 module.exports = {
+  DEPRECATED_RUNTIME_CONTRACT_FALLBACK,
   FALLBACK_RUNTIME_CONTRACT_MANIFEST,
   FALLBACK_RUNTIME_CONTRACT_SCHEMAS,
   RUNTIME_CONTRACT_MANIFEST_SCHEMA,
@@ -214,6 +236,7 @@ module.exports = {
   loadCanonicalRuntimeContractSource,
   loadRuntimeContractSource,
   providerRuntimeInvocationContract,
+  runtimeContractFallbackDiagnostic,
   runtimeContractManifest,
   runtimeContractSchemas,
   validateCanonicalRuntimeContractManifest,

--- a/tests/wp-codebox-runtime-contract-source-smoke.mjs
+++ b/tests/wp-codebox-runtime-contract-source-smoke.mjs
@@ -9,9 +9,11 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const require = createRequire(import.meta.url);
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const {
+	DEPRECATED_RUNTIME_CONTRACT_FALLBACK,
 	loadCanonicalRuntimeContractSource,
 	loadRuntimeContractSource,
 	providerRuntimeInvocationContract,
+	runtimeContractFallbackDiagnostic,
 	runtimeContractManifest,
 	runtimeContractSchemas,
 	validateCanonicalRuntimeContractManifest,
@@ -46,6 +48,31 @@ assert.deepEqual(wpCodeboxProviderRuntimeInvocationContract(), {
 
 validateCanonicalRuntimeContractManifest(fallbackManifest);
 
+assert.equal(DEPRECATED_RUNTIME_CONTRACT_FALLBACK.status, 'deprecated');
+assert.match(DEPRECATED_RUNTIME_CONTRACT_FALLBACK.replacement, /@automattic\/wp-codebox-core/);
+assert.deepEqual(runtimeContractFallbackDiagnostic({ reason: 'test' }), {
+	...DEPRECATED_RUNTIME_CONTRACT_FALLBACK,
+	source: 'homeboy-extensions-fallback',
+	schema: 'wp-codebox/runtime-contract-manifest/v1',
+	canonical_required_option: 'required',
+	details: { reason: 'test' },
+});
+
+const runtimeContractSource = fs.readFileSync(
+	path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'wp-codebox-runtime-contract-source.js'),
+	'utf8'
+);
+const fallbackConstantNames = [...runtimeContractSource.matchAll(/const\s+(FALLBACK_[A-Z0-9_]+)/g)].map((match) => match[1]);
+assert.deepEqual(
+	fallbackConstantNames,
+	[
+		'FALLBACK_RUNTIME_CONTRACT_SCHEMAS',
+		'FALLBACK_PROVIDER_RUNTIME_INVOCATION_CONTRACT',
+		'FALLBACK_RUNTIME_CONTRACT_MANIFEST',
+	],
+	'Do not add new hardcoded WP Codebox fallback contract constants; consume the public Codebox runtime contract manifest instead.'
+);
+
 assert.throws(
 	() => validateCanonicalRuntimeContractManifest({
 		...fallbackManifest,
@@ -79,6 +106,11 @@ assert.equal(typeof canonical.normalizers.runtimeProfile, 'function');
 
 const loaded = await loadRuntimeContractSource({ wpCodeboxCoreModule: canonicalModule });
 assert.equal(loaded.canonical, true);
+
+const fallbackLoaded = await loadRuntimeContractSource({ wpCodeboxCoreModule: path.join(tempRoot, 'missing-runtime-core.mjs') });
+assert.equal(fallbackLoaded.canonical, false);
+assert.equal(fallbackLoaded.diagnostics[0].status, 'deprecated');
+assert.match(fallbackLoaded.diagnostics[0].replacement, /@automattic\/wp-codebox-core/);
 
 const mismatchedModule = path.join(tempRoot, 'mismatched-runtime-core.mjs');
 fs.writeFileSync(mismatchedModule, `


### PR DESCRIPTION
## Summary
- Mark the Homeboy-owned WP Codebox runtime contract fallback as deprecated and point diagnostics at the public `@automattic/wp-codebox-core` manifest export.
- Include fallback diagnostics when `loadRuntimeContractSource()` cannot load the canonical Codebox package.
- Add a smoke-test boundary guard that fails if new hardcoded `FALLBACK_*` Codebox contract constants are added.

## Tests
- `node ../../tests/wp-codebox-runtime-contract-source-smoke.mjs`
- `node ../../tests/wp-codebox-adapter-contract-smoke.mjs`
- `node ../../wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node ../../tests/wp-codebox-adapter-boundary-smoke.mjs`
- `node ../../tests/wp-codebox-run-agent-task-contract-smoke.mjs`
- `node ../../tests/wp-codebox-artifact-contract-smoke.mjs`
- `node ../../tests/wp-codebox-runtime-profile-defaults-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Focused implementation, test updates, local verification, and PR drafting.