### PR TITLE
Dispatch WordPress fuzz runs through WP Codebox

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -1,21 +1,152 @@
 #!/usr/bin/env node
 'use strict';
 
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
 /**
  * Internal dependencies
  */
 const {
 	buildWordPressFuzzRunnerResult,
 	readWordPressFuzzRunnerEnv,
+	runWordPressFuzzRunnerResult,
 	writeHomeboyFuzzResultsFile,
 } = require('../../lib/wordpress-fuzz-runner');
 
-try {
+
+(async () => {
 	const env = readWordPressFuzzRunnerEnv();
-	const result = buildWordPressFuzzRunnerResult({ env });
+	const result = await buildRunnerResult(env);
 	writeHomeboyFuzzResultsFile(env.resultsFile, result.homeboy_fuzz_campaign);
 	process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-} catch (error) {
+})().catch((error) => {
 	process.stderr.write(`${error.message}\n`);
 	process.exit(1);
+});
+
+async function buildRunnerResult(env) {
+	if (process.env.HOMEBOY_WP_CODEBOX_FUZZ_DISPATCH === '0') {
+		return buildWordPressFuzzRunnerResult({ env });
+	}
+
+	return runWordPressFuzzRunnerResult({
+		env,
+		runRuntimeTask: runWpCodeboxAgentTask,
+	});
+}
+
+async function runWpCodeboxAgentTask(request) {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-fuzz-'));
+	const inputFile = path.join(tempDir, 'agent-task-request.json');
+	fs.writeFileSync(inputFile, `${JSON.stringify(request, null, 2)}\n`);
+
+	const command = process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || 'wp-codebox';
+	const args = ['run-agent-task', '--input-file', inputFile, '--json'];
+	const result = await spawnJson(command, args, {
+		cwd: process.cwd(),
+		env: process.env,
+	});
+
+	return { json: normalizeWpCodeboxAgentTaskOutput(result, request) };
+}
+
+function spawnJson(command, args, options) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			cwd: options.cwd,
+			env: options.env,
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+		let stdout = '';
+		let stderr = '';
+		child.stdout.setEncoding('utf8');
+		child.stderr.setEncoding('utf8');
+		child.stdout.on('data', (chunk) => { stdout += chunk; });
+		child.stderr.on('data', (chunk) => { stderr += chunk; });
+		child.on('error', reject);
+		child.on('close', (code) => {
+			const parsed = parseJsonOutput(stdout);
+			if (code !== 0) {
+				const message = parsed?.error?.message || stderr.trim() || `${command} exited with ${code}`;
+				reject(new Error(message));
+				return;
+			}
+			resolve(parsed || { stdout, stderr, status: code });
+		});
+	});
+}
+
+function parseJsonOutput(stdout) {
+	const text = String(stdout || '').trim();
+	if (!text) {
+		return null;
+	}
+	try {
+		return JSON.parse(text);
+	} catch {
+		const start = text.indexOf('{');
+		const end = text.lastIndexOf('}');
+		if (start >= 0 && end > start) {
+			return JSON.parse(text.slice(start, end + 1));
+		}
+		return null;
+	}
+}
+
+function normalizeWpCodeboxAgentTaskOutput(output, request) {
+	const candidates = [
+		output?.json,
+		output?.result,
+		output?.output,
+		output?.agent_runtime?.result,
+		output?.recipe_run?.result,
+		output,
+	];
+
+	for (const candidate of candidates) {
+		const fuzzResult = findFuzzSuiteResult(candidate);
+		if (fuzzResult) {
+			return fuzzResult;
+		}
+	}
+
+	return {
+		schema: 'wp-codebox/fuzz-suite-result/v1',
+		request_id: request.task_id,
+		status: output?.success === false ? 'failed' : 'skipped',
+		diagnostics: [{
+			severity: 'error',
+			code: 'wp_codebox_fuzz_suite_result_missing',
+			message: 'WP Codebox completed without returning a wp-codebox/fuzz-suite-result/v1 envelope.',
+		}],
+		metadata: { output },
+	};
+}
+
+function findFuzzSuiteResult(value) {
+	if (!value || typeof value !== 'object') {
+		return null;
+	}
+	if (value.schema === 'wp-codebox/fuzz-suite-result/v1') {
+		return value;
+	}
+	for (const key of ['result', 'output', 'json']) {
+		const nested = findFuzzSuiteResult(value[key]);
+		if (nested) {
+			return nested;
+		}
+	}
+	for (const item of Array.isArray(value.executions) ? value.executions : []) {
+		for (const stream of ['stdout', 'stderr']) {
+			const parsed = parseJsonOutput(item?.[stream]);
+			const nested = findFuzzSuiteResult(parsed);
+			if (nested) {
+				return nested;
+			}
+		}
+	}
+	return null;
 }

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -145,6 +145,7 @@ const cli = spawnSync(runnerPath, [], {
 	encoding: 'utf8',
 	env: {
 		...process.env,
+		HOMEBOY_WP_CODEBOX_FUZZ_DISPATCH: '0',
 		HOMEBOY_FUZZ_WORKLOAD_PATH: workloadPath,
 		HOMEBOY_FUZZ_WORKLOAD_ID: 'cli-workload',
 		HOMEBOY_FUZZ_RUN_ID: 'cli-run',
@@ -164,6 +165,43 @@ const homeboyCampaign = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
 assert.equal(homeboyCampaign.schema, HOMEBOY_FUZZ_CAMPAIGN_SCHEMA);
 assert.equal(homeboyCampaign.id, 'cli-run');
 assert.equal(homeboyCampaign.metadata.diagnostics[0].code, 'wp_codebox_fuzz_suite_execution_unsupported');
+
+const fakeCodeboxBin = path.join(tempDir, 'fake-wp-codebox.js');
+const dispatchResultsPath = path.join(tempDir, 'dispatch-results.json');
+fs.writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
+const fs = require('node:fs');
+const inputFile = process.argv[process.argv.indexOf('--input-file') + 1];
+const request = JSON.parse(fs.readFileSync(inputFile, 'utf8'));
+process.stdout.write(JSON.stringify({
+  success: true,
+  result: {
+    schema: 'wp-codebox/fuzz-suite-result/v1',
+    request_id: request.task_id,
+    status: 'succeeded',
+    artifactRefs: [{ path: 'fake/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
+    coverage_summary: { surface_count: 1, exercised_count: 1 }
+  }
+}));
+`);
+fs.chmodSync(fakeCodeboxBin, 0o755);
+
+const dispatchCli = spawnSync(runnerPath, [], {
+	encoding: 'utf8',
+	env: {
+		...process.env,
+		HOMEBOY_WP_CODEBOX_BIN: fakeCodeboxBin,
+		HOMEBOY_FUZZ_WORKLOAD_PATH: workloadPath,
+		HOMEBOY_FUZZ_WORKLOAD_ID: 'dispatch-cli-workload',
+		HOMEBOY_FUZZ_RUN_ID: 'dispatch-cli-run',
+		HOMEBOY_FUZZ_RESULTS_FILE: dispatchResultsPath,
+	},
+});
+
+assert.equal(dispatchCli.status, 0, dispatchCli.stderr);
+const dispatchCliResult = JSON.parse(dispatchCli.stdout);
+assert.equal(dispatchCliResult.succeeded, true);
+assert.equal(dispatchCliResult.wp_codebox_result.request_id, 'dispatch-cli-run');
+assert.equal(dispatchCliResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path, 'fake/fuzz-report.json');
 
 dispatchPromise.then(() => {
 	console.log('WordPress fuzz runner smoke passed.');


### PR DESCRIPTION
## Summary
- Dispatch WordPress fuzz runner requests through `wp-codebox run-agent-task --json` instead of always returning a contract-only envelope.
- Preserve contract-only mode behind `HOMEBOY_WP_CODEBOX_FUZZ_DISPATCH=0` for smoke/diagnostic use.
- Normalize nested WP Codebox output to find the `wp-codebox/fuzz-suite-result/v1` envelope and write Homeboy campaign artifacts from real results.

## Evidence
- `npm run test:wordpress-fuzz-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** wiring the WordPress fuzz CLI dispatch path, adding fake Codebox dispatch coverage, and preparing this PR description.
