### PR TITLE
Wrap fuzz dispatch as Codebox run-agent-task input

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -41,7 +41,7 @@ async function buildRunnerResult(env) {
 async function runWpCodeboxAgentTask(request) {
 	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-fuzz-'));
 	const inputFile = path.join(tempDir, 'agent-task-request.json');
-	fs.writeFileSync(inputFile, `${JSON.stringify(request, null, 2)}\n`);
+	fs.writeFileSync(inputFile, `${JSON.stringify(wpCodeboxRunAgentTaskInput(request), null, 2)}\n`);
 
 	const command = process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || 'wp-codebox';
 	const args = ['run-agent-task', '--input-file', inputFile, '--json'];
@@ -51,6 +51,29 @@ async function runWpCodeboxAgentTask(request) {
 	});
 
 	return { json: normalizeWpCodeboxAgentTaskOutput(result, request) };
+}
+
+function wpCodeboxRunAgentTaskInput(request) {
+	return {
+		schema: 'wp-codebox/run-agent-task/v1',
+		id: request.task_id,
+		goal: request.instructions || 'Run the WordPress fuzz suite and return the declared fuzz artifacts.',
+		agent_workload: {
+			schema: 'wp-codebox/agent-workload/v1',
+			id: request.task_id,
+			goal: request.instructions || 'Run the WordPress fuzz suite and return the declared fuzz artifacts.',
+			agent_runtime: {
+				runtime_task: request.executor?.config?.runtime_task,
+			},
+		},
+		runtime_task: request.executor?.config?.runtime_task,
+		artifact_declarations: request.artifact_declarations,
+		expected_artifacts: request.expected_artifacts,
+		metadata: {
+			...(request.metadata || {}),
+			homeboy_agent_task_request: request,
+		},
+	};
 }
 
 function spawnJson(command, args, options) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -172,11 +172,15 @@ fs.writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
 const inputFile = process.argv[process.argv.indexOf('--input-file') + 1];
 const request = JSON.parse(fs.readFileSync(inputFile, 'utf8'));
+if (request.schema !== 'wp-codebox/run-agent-task/v1' || !request.goal || !request.runtime_task) {
+  process.stderr.write('invalid run-agent-task input');
+  process.exit(1);
+}
 process.stdout.write(JSON.stringify({
   success: true,
   result: {
     schema: 'wp-codebox/fuzz-suite-result/v1',
-    request_id: request.task_id,
+    request_id: request.id,
     status: 'succeeded',
     artifactRefs: [{ path: 'fake/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
     coverage_summary: { surface_count: 1, exercised_count: 1 }


### PR DESCRIPTION
## Summary
- Wrap WordPress fuzz dispatch requests in the public `wp-codebox/run-agent-task/v1` input shape before invoking `wp-codebox run-agent-task`.
- Include the required `goal`, runtime task, expected artifacts, and original Homeboy request metadata.
- Extend the fake Codebox dispatch smoke to fail unless the public input shape is present.

## Evidence
- `npm run test:wordpress-fuzz-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** diagnosing the Codebox `goal is required` dispatch failure, patching the input wrapper, and preparing this PR description.
