### PR TITLE
Surface WP Codebox fuzz dispatch failures

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -93,7 +93,8 @@ function spawnJson(command, args, options) {
 		child.on('close', (code) => {
 			const parsed = parseJsonOutput(stdout);
 			if (code !== 0) {
-				const message = parsed?.error?.message || stderr.trim() || `${command} exited with ${code}`;
+				const details = [stderr.trim(), stdout.trim()].filter(Boolean).join('\n');
+				const message = parsed?.error?.message || details || `${command} exited with ${code}`;
 				reject(new Error(message));
 				return;
 			}


### PR DESCRIPTION
## Summary
- Include WP Codebox stderr/stdout in fuzz dispatch failures so nonzero exits expose the underlying runner error.

## Evidence
- `npm run test:wordpress-fuzz-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** surfacing the runner-side WP Codebox failure and preparing this PR description.
