### PR TITLE
Add Codebox fuzz sandbox tool policy

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -67,11 +67,34 @@ function wpCodeboxRunAgentTaskInput(request) {
 			},
 		},
 		runtime_task: request.executor?.config?.runtime_task,
+		allowed_tools: ['homeboy/no-runtime-tools'],
+		sandbox_tool_policy: denyAllSandboxToolPolicy(),
 		artifact_declarations: request.artifact_declarations,
 		expected_artifacts: request.expected_artifacts,
 		metadata: {
 			...(request.metadata || {}),
 			homeboy_agent_task_request: request,
+		},
+	};
+}
+
+function denyAllSandboxToolPolicy() {
+	return {
+		schema: 'wp-codebox/sandbox-tool-policy/v1',
+		version: 1,
+		tools: [
+			{
+				id: 'homeboy/no-runtime-tools',
+				runtime_tool_id: 'homeboy_no_runtime_tools',
+				allowed: false,
+				runtime: {
+					environment: 'control_plane',
+					capability_scope: 'control_plane',
+				},
+			},
+		],
+		metadata: {
+			source: 'homeboy-extension-wordpress/fuzz-runner',
 		},
 	};
 }

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -187,6 +187,10 @@ if (request.schema !== 'wp-codebox/run-agent-task/v1' || !request.goal || !reque
   process.stderr.write('invalid run-agent-task input');
   process.exit(1);
 }
+if (request.sandbox_tool_policy?.schema !== 'wp-codebox/sandbox-tool-policy/v1' || request.sandbox_tool_policy?.version !== 1 || !request.sandbox_tool_policy?.tools?.length) {
+  process.stderr.write('invalid sandbox tool policy');
+  process.exit(1);
+}
 process.stdout.write(JSON.stringify({
   success: true,
   result: {


### PR DESCRIPTION
## Summary
- Send a valid deny-all sandbox tool policy with WordPress fuzz `wp-codebox run-agent-task` dispatches.
- Keep the fuzz wrapper compatible with WP Codebox's required `sandbox_tool_policy` contract.
- Extend the fuzz runner smoke fixture to reject missing policy fields.

## Tests
- `npm run test:wordpress-fuzz-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the WP Codebox sandbox policy validation failure, updating the HBX fuzz dispatch wrapper, and adding regression coverage.
