### PR TITLE
Add generic controller loop proof validator

### DIFF
--- a/runtime-agent-ci/index.js
+++ b/runtime-agent-ci/index.js
@@ -8,3 +8,4 @@ Object.assign(module.exports, require('./lib/generic-fanout-reconcile-workflow')
 Object.assign(module.exports, require('./lib/runtime-workflow-inputs.cjs'));
 Object.assign(module.exports, require('./lib/headless-deterministic-loop-runner'));
 Object.assign(module.exports, require('./lib/preview-materialization'));
+Object.assign(module.exports, require('./lib/controller-loop-proof-validator'));

--- a/runtime-agent-ci/lib/controller-loop-proof-validator.js
+++ b/runtime-agent-ci/lib/controller-loop-proof-validator.js
@@ -1,0 +1,344 @@
+'use strict';
+
+function validateControllerLoopProof(input = {}) {
+  const spec = optionalObject(input.spec || input.controller || input.loop_spec);
+  const proof = optionalObject(input.proof || input.run || input.result);
+  const policy = {
+    ...optionalObject(spec.policy),
+    ...optionalObject(input.policy),
+  };
+  const failures = [];
+  const warnings = [];
+  const artifactDeclarations = normalizeArtifactDeclarations(spec.artifacts || spec.artifact_declarations || policy.artifacts || policy.artifact_declarations);
+  const artifacts = collectArtifacts(proof);
+  const evidence = collectEvidence(proof);
+  const events = collectEvents(proof);
+  const iterations = collectIterations(proof);
+  const artifactResults = [];
+
+  for (const declaration of artifactDeclarations) {
+    const match = findArtifact(artifacts, declaration.id);
+    const required = declaration.required !== false && (declaration.required === true || policy.require_declared_artifacts === true);
+    artifactResults.push({
+      id: declaration.id,
+      required,
+      present: Boolean(match),
+      artifact: match || null,
+    });
+    if (required && !match) {
+      failures.push(failure('artifact.required_missing', `Required artifact is missing: ${declaration.id}`, { artifact_id: declaration.id }));
+      continue;
+    }
+    if (match) {
+      validateReviewerFacingUrls({
+        ref: match,
+        failures,
+        policy,
+        reviewerFacing: declaration.reviewer_facing,
+        failureClass: 'artifact.local_reviewer_evidence',
+        label: declaration.id,
+      });
+      if (declaration.durable_url_required === true && !durableUrl(refUrl(match))) {
+        failures.push(failure('artifact.durable_url_missing', `Artifact must include a durable non-local URL: ${declaration.id}`, { artifact_id: declaration.id }));
+      }
+    }
+  }
+
+  for (const requirement of normalizeEvidenceRequirements(policy.required_evidence || spec.required_evidence)) {
+    const match = findEvidence(evidence, requirement);
+    if (!match) {
+      failures.push(failure('evidence.required_missing', `Required evidence is missing: ${requirementLabel(requirement)}`, { requirement }));
+      continue;
+    }
+    validateReviewerFacingUrls({
+      ref: match,
+      failures,
+      policy,
+      reviewerFacing: requirement.reviewer_facing,
+      failureClass: 'evidence.local_reviewer_evidence',
+      label: requirementLabel(requirement),
+    });
+    if (requirement.durable_url_required === true && !durableUrl(refUrl(match))) {
+      failures.push(failure('evidence.durable_url_missing', `Evidence must include a durable non-local URL: ${requirementLabel(requirement)}`, { requirement }));
+    }
+  }
+
+  validateSpecialEvidenceRequirement({
+    required: policy.preview_required === true || policy.require_preview === true,
+    requirement: policy.preview_evidence || spec.preview_evidence || { kind: 'preview' },
+    evidence,
+    failures,
+    policy,
+    failureClass: 'preview.required_missing',
+    message: 'Preview materialization evidence is required.',
+  });
+  validateSpecialEvidenceRequirement({
+    required: policy.pr_required === true || policy.require_pr === true || policy.publication_required === true || policy.require_publication === true,
+    requirement: policy.publication_evidence || policy.pr_evidence || spec.publication_evidence || spec.pr_evidence || { kind: 'pull_request' },
+    evidence,
+    failures,
+    policy,
+    failureClass: 'publication.required_missing',
+    message: 'PR or publication evidence is required.',
+  });
+
+  for (const ref of evidence) {
+    validateReviewerFacingUrls({
+      ref,
+      failures,
+      policy,
+      reviewerFacing: ref.reviewer_facing,
+      failureClass: 'evidence.local_reviewer_evidence',
+      label: evidenceLabel(ref),
+    });
+  }
+
+  const iterationCount = explicitIterationCount(proof, iterations);
+  const maxIterations = positiveInteger(policy.max_iterations || spec.max_iterations || spec.loop?.max_iterations);
+  if (maxIterations && iterationCount > maxIterations) {
+    failures.push(failure('loop.max_iterations_exceeded', `Iteration count ${iterationCount} exceeds maximum ${maxIterations}.`, { iteration_count: iterationCount, max_iterations: maxIterations }));
+  }
+
+  const stopReason = stopReasonFromProof(proof, iterations);
+  const allowedStopReasons = normalizeArray(policy.allowed_stop_reasons || spec.allowed_stop_reasons || spec.stop_reasons);
+  if ((policy.stop_reason_required === true || allowedStopReasons.length > 0) && !stopReason) {
+    failures.push(failure('loop.stop_reason_missing', 'Stop reason evidence is required.', {}));
+  } else if (stopReason && allowedStopReasons.length > 0 && !allowedStopReasons.includes(stopReason)) {
+    failures.push(failure('loop.stop_reason_rejected', `Stop reason is not allowed: ${stopReason}`, { stop_reason: stopReason, allowed_stop_reasons: allowedStopReasons }));
+  }
+
+  if (policy.event_lineage_required === true || policy.require_event_lineage === true || spec.event_lineage_required === true) {
+    validateEventLineage({ proof, iterations, events, failures, warnings });
+  }
+
+  return {
+    schema: 'homeboy/controller-loop-proof-validation/v1',
+    valid: failures.length === 0,
+    failure_count: failures.length,
+    warning_count: warnings.length,
+    failures,
+    warnings,
+    summary: {
+      artifact_count: artifacts.length,
+      evidence_count: evidence.length,
+      event_count: events.length,
+      iteration_count: iterationCount,
+      stop_reason: stopReason || '',
+    },
+    artifact_results: artifactResults,
+  };
+}
+
+function assertControllerLoopProof(input = {}) {
+  const report = validateControllerLoopProof(input);
+  if (!report.valid) {
+    const error = new Error(`controller loop proof validation failed: ${report.failures.map((item) => item.message).join('; ')}`);
+    error.report = report;
+    throw error;
+  }
+  return report;
+}
+
+function validateSpecialEvidenceRequirement(options) {
+  if (!options.required) {
+    return;
+  }
+  const match = findEvidence(options.evidence, options.requirement);
+  if (!match) {
+    options.failures.push(failure(options.failureClass, options.message, { requirement: options.requirement }));
+    return;
+  }
+  validateReviewerFacingUrls({
+    ref: match,
+    failures: options.failures,
+    policy: options.policy,
+    reviewerFacing: true,
+    failureClass: 'evidence.local_reviewer_evidence',
+    label: requirementLabel(options.requirement),
+  });
+}
+
+function validateReviewerFacingUrls(options) {
+  const reviewerFacing = options.reviewerFacing !== false;
+  if (!reviewerFacing || options.policy.allow_local_reviewer_evidence === true) {
+    return;
+  }
+  const url = refUrl(options.ref);
+  if (!url) {
+    return;
+  }
+  if (localOnlyUrl(url)) {
+    options.failures.push(failure(options.failureClass, `Reviewer-facing evidence must use a durable non-local URL: ${options.label}`, { url }));
+  }
+}
+
+function validateEventLineage(options) {
+  if (options.events.length === 0) {
+    options.failures.push(failure('event_lineage.missing', 'Event lineage is required but no events were provided.', {}));
+    return;
+  }
+  const eventIds = new Set(options.events.map((event) => event.id || event.event_id).filter(Boolean));
+  const duplicateIds = duplicateValues(options.events.map((event) => event.id || event.event_id).filter(Boolean));
+  for (const id of duplicateIds) {
+    options.failures.push(failure('event_lineage.duplicate_event', `Event lineage contains duplicate event id: ${id}`, { event_id: id }));
+  }
+  for (const event of options.events) {
+    const parentId = event.parent_id || event.parentId || event.previous_event_id || event.previousEventId;
+    if (parentId && !eventIds.has(parentId)) {
+      options.failures.push(failure('event_lineage.missing_parent', `Event references a missing parent event: ${parentId}`, { event_id: event.id || event.event_id || '', parent_id: parentId }));
+    }
+  }
+  for (const iteration of options.iterations) {
+    const eventId = iteration.event_id || iteration.eventId || iteration.event?.id || iteration.event?.event_id;
+    if (!eventId) {
+      options.failures.push(failure('event_lineage.iteration_event_missing', `Iteration ${iteration.iteration ?? iteration.index ?? '(unknown)'} is missing event lineage evidence.`, { iteration: iteration.iteration ?? iteration.index ?? null }));
+    } else if (!eventIds.has(eventId)) {
+      options.failures.push(failure('event_lineage.iteration_event_unknown', `Iteration references an unknown event: ${eventId}`, { event_id: eventId }));
+    }
+  }
+  if (options.iterations.length === 0) {
+    options.warnings.push({ class: 'event_lineage.no_iterations', message: 'Event lineage was provided without iteration records.', data: {} });
+  }
+}
+
+function collectArtifacts(proof) {
+  return [
+    ...normalizeArray(proof.artifacts),
+    ...normalizeArray(proof.proof_artifacts),
+    ...normalizeArray(proof.evidence_envelope?.artifacts),
+  ].filter(isObject);
+}
+
+function collectEvidence(proof) {
+  return [
+    ...normalizeArray(proof.evidence),
+    ...normalizeArray(proof.evidence_refs),
+    ...normalizeArray(proof.evidence_envelope?.evidence),
+    ...normalizeArray(proof.evidence_envelope?.evidence_refs),
+  ].filter(isObject);
+}
+
+function collectEvents(proof) {
+  return [
+    ...normalizeArray(proof.events),
+    ...normalizeArray(proof.event_log),
+    ...normalizeArray(proof.evidence_envelope?.events),
+  ].filter(isObject);
+}
+
+function collectIterations(proof) {
+  return normalizeArray(proof.iterations || proof.loop?.iterations).filter(isObject);
+}
+
+function normalizeArtifactDeclarations(value) {
+  return normalizeArray(value)
+    .map((declaration) => typeof declaration === 'string' ? { id: declaration, required: true } : declaration)
+    .filter(isObject)
+    .map((declaration) => ({
+      ...declaration,
+      id: declaration.id || declaration.name || declaration.role,
+    }))
+    .filter((declaration) => declaration.id);
+}
+
+function normalizeEvidenceRequirements(value) {
+  return normalizeArray(value)
+    .map((requirement) => typeof requirement === 'string' ? { id: requirement } : requirement)
+    .filter(isObject);
+}
+
+function findArtifact(artifacts, id) {
+  return artifacts.find((artifact) => artifact.id === id || artifact.name === id || artifact.role === id || artifact.artifact_id === id) || null;
+}
+
+function findEvidence(evidence, requirement) {
+  const normalized = typeof requirement === 'string' ? { id: requirement } : optionalObject(requirement);
+  return evidence.find((ref) => (
+    (normalized.id && (ref.id === normalized.id || ref.name === normalized.id || ref.role === normalized.id || ref.evidence_id === normalized.id))
+    || (normalized.kind && ref.kind === normalized.kind)
+    || (normalized.type && (ref.type === normalized.type || ref.kind === normalized.type))
+    || (normalized.url && refUrl(ref) === normalized.url)
+    || (normalized.uri && refUrl(ref) === normalized.uri)
+  )) || null;
+}
+
+function explicitIterationCount(proof, iterations) {
+  const count = positiveInteger(proof.iteration_count || proof.evidence_envelope?.iteration_count || proof.loop?.iteration_count);
+  return count || iterations.length;
+}
+
+function stopReasonFromProof(proof, iterations) {
+  return proof.stop_reason
+    || proof.stop?.reason
+    || proof.loop?.stop_reason
+    || proof.loop?.stop?.reason
+    || iterations[iterations.length - 1]?.stop_reason
+    || iterations[iterations.length - 1]?.stop?.reason
+    || '';
+}
+
+function duplicateValues(values) {
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const value of values) {
+    if (seen.has(value)) {
+      duplicates.add(value);
+    }
+    seen.add(value);
+  }
+  return [...duplicates];
+}
+
+function requirementLabel(requirement) {
+  return requirement.id || requirement.name || requirement.role || requirement.kind || requirement.type || requirement.url || requirement.uri || '(unnamed)';
+}
+
+function evidenceLabel(ref) {
+  return ref.id || ref.name || ref.role || ref.kind || ref.type || refUrl(ref) || '(unnamed)';
+}
+
+function refUrl(ref) {
+  return ref.url || ref.uri || ref.href || ref.public_url || ref.publicUrl || ref.artifact_url || ref.artifactUrl || ref.path || '';
+}
+
+function durableUrl(url) {
+  return typeof url === 'string' && /^https?:\/\//i.test(url) && !localOnlyUrl(url);
+}
+
+function localOnlyUrl(url) {
+  if (typeof url !== 'string' || url.trim() === '') {
+    return false;
+  }
+  return /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::|\/|$)/i.test(url)
+    || /^file:\/\//i.test(url)
+    || /^\/Users\//.test(url)
+    || /^\/private\//.test(url)
+    || /^\/tmp\//.test(url)
+    || /^\.\.?\//.test(url);
+}
+
+function failure(className, message, data) {
+  return { class: className, message, data: data || {} };
+}
+
+function positiveInteger(value) {
+  const parsed = Number.parseInt(value || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function optionalObject(value) {
+  return isObject(value) ? value : {};
+}
+
+function isObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+module.exports = {
+  assertControllerLoopProof,
+  validateControllerLoopProof,
+};

--- a/runtime-agent-ci/package.json
+++ b/runtime-agent-ci/package.json
@@ -5,13 +5,16 @@
   "main": "index.js",
   "exports": {
     ".": "./index.js",
+    "./controller-loop-proof-validator": "./lib/controller-loop-proof-validator.js",
     "./fanout-reconcile-runner": "./lib/fanout-reconcile-runner.js",
     "./generic-fanout-reconcile-workflow": "./lib/generic-fanout-reconcile-workflow.js"
   },
   "bin": {
+    "homeboy-controller-loop-proof-validate": "./scripts/homeboy-controller-loop-proof-validate.cjs",
     "homeboy-generic-fanout-reconcile": "./scripts/homeboy-generic-fanout-reconcile.cjs"
   },
   "scripts": {
+    "test:controller-loop-proof-validator": "node ../tests/controller-loop-proof-validator.test.mjs",
     "test:generic-fanout-reconcile-boundary": "node ../tests/generic-fanout-reconcile-boundary.test.mjs"
   },
   "engines": {

--- a/runtime-agent-ci/scripts/homeboy-controller-loop-proof-validate.cjs
+++ b/runtime-agent-ci/scripts/homeboy-controller-loop-proof-validate.cjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const { validateControllerLoopProof } = require('../lib/controller-loop-proof-validator');
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  const specPath = args.spec || args.config || '';
+  const proofPath = args.proof || args.run || args.result || '';
+  if (!specPath || !proofPath) {
+    throw new Error('Pass --spec <path> and --proof <path>.');
+  }
+  const spec = readJson(specPath);
+  const proof = readJson(proofPath);
+  const policy = args.policy ? readJson(args.policy) : {};
+  const report = validateControllerLoopProof({ spec, proof, policy });
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+  if (args.output) {
+    fs.writeFileSync(args.output, json);
+  }
+  process.stdout.write(json);
+  process.exitCode = report.valid ? 0 : 1;
+} catch (error) {
+  process.stderr.write(`${error && error.message ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+    const key = arg.slice(2).replace(/-/g, '_');
+    args[key] = argv[index + 1];
+    index += 1;
+  }
+  return args;
+}

--- a/tests/controller-loop-proof-validator.test.mjs
+++ b/tests/controller-loop-proof-validator.test.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const runtimeAgentCi = require(path.join(repoRoot, 'runtime-agent-ci'));
+const validator = require(path.join(repoRoot, 'runtime-agent-ci/lib/controller-loop-proof-validator'));
+
+assert.equal(typeof runtimeAgentCi.validateControllerLoopProof, 'function');
+assert.equal(runtimeAgentCi.validateControllerLoopProof, validator.validateControllerLoopProof);
+assert.equal(typeof runtimeAgentCi.assertControllerLoopProof, 'function');
+
+const baseSpec = {
+  schema: 'example/controller-loop-spec/v1',
+  artifacts: [
+    { id: 'run-log', required: true, durable_url_required: true },
+    { id: 'debug-bundle', required: false },
+  ],
+  policy: {
+    max_iterations: 3,
+    allowed_stop_reasons: ['accepted'],
+    event_lineage_required: true,
+  },
+};
+const baseProof = {
+  artifacts: [{ id: 'run-log', url: 'https://example.test/artifacts/run-log' }],
+  evidence: [{ id: 'review', kind: 'summary', url: 'https://example.test/review' }],
+  iterations: [
+    { iteration: 1, event_id: 'event-1', stop: { stop: false } },
+    { iteration: 2, event_id: 'event-2', stop: { stop: true, reason: 'accepted' } },
+  ],
+  events: [
+    { id: 'event-1' },
+    { id: 'event-2', parent_id: 'event-1' },
+  ],
+};
+
+let report = validator.validateControllerLoopProof({ spec: baseSpec, proof: baseProof });
+assert.equal(report.valid, true);
+assert.equal(report.summary.iteration_count, 2);
+assert.equal(report.summary.stop_reason, 'accepted');
+assert.deepEqual(report.artifact_results.map((result) => [result.id, result.required, result.present]), [
+  ['run-log', true, true],
+  ['debug-bundle', false, false],
+]);
+
+report = validator.validateControllerLoopProof({
+  spec: baseSpec,
+  proof: { ...baseProof, artifacts: [] },
+});
+assert.equal(report.valid, false);
+assert.equal(hasFailure(report, 'artifact.required_missing'), true);
+
+report = validator.validateControllerLoopProof({
+  spec: baseSpec,
+  proof: { ...baseProof, artifacts: [{ id: 'run-log', url: 'http://localhost:8888/run-log' }] },
+});
+assert.equal(report.valid, false);
+assert.equal(hasFailure(report, 'artifact.local_reviewer_evidence'), true);
+
+report = validator.validateControllerLoopProof({
+  spec: { ...baseSpec, policy: { ...baseSpec.policy, preview_required: true } },
+  proof: baseProof,
+});
+assert.equal(report.valid, false);
+assert.equal(hasFailure(report, 'preview.required_missing'), true);
+
+report = validator.validateControllerLoopProof({
+  spec: { ...baseSpec, policy: { ...baseSpec.policy, preview_required: true } },
+  proof: { ...baseProof, evidence: [...baseProof.evidence, { id: 'preview-url', kind: 'preview', url: 'https://preview.example.test/run' }] },
+});
+assert.equal(report.valid, true);
+
+report = validator.validateControllerLoopProof({
+  spec: { ...baseSpec, policy: { ...baseSpec.policy, pr_required: true } },
+  proof: baseProof,
+});
+assert.equal(report.valid, false);
+assert.equal(hasFailure(report, 'publication.required_missing'), true);
+
+report = validator.validateControllerLoopProof({
+  spec: { ...baseSpec, policy: { ...baseSpec.policy, pr_required: true } },
+  proof: { ...baseProof, evidence: [...baseProof.evidence, { id: 'change-review', kind: 'pull_request', url: 'https://example.test/pull/1' }] },
+});
+assert.equal(report.valid, true);
+
+report = validator.validateControllerLoopProof({
+  spec: baseSpec,
+  proof: {
+    ...baseProof,
+    iterations: [
+      ...baseProof.iterations,
+      { iteration: 3, event_id: 'event-3' },
+      { iteration: 4, event_id: 'event-4', stop: { reason: 'timed_out' } },
+    ],
+    events: [...baseProof.events, { id: 'event-3', parent_id: 'event-2' }, { id: 'event-4', parent_id: 'event-3' }],
+  },
+});
+assert.equal(report.valid, false);
+assert.equal(hasFailure(report, 'loop.max_iterations_exceeded'), true);
+assert.equal(hasFailure(report, 'loop.stop_reason_rejected'), true);
+
+report = validator.validateControllerLoopProof({
+  spec: baseSpec,
+  proof: {
+    ...baseProof,
+    iterations: [{ iteration: 1, event_id: 'missing-event', stop: { reason: 'accepted' } }],
+  },
+});
+assert.equal(report.valid, false);
+assert.equal(hasFailure(report, 'event_lineage.iteration_event_unknown'), true);
+
+function hasFailure(validationReport, className) {
+  return validationReport.failures.some((item) => item.class === className);
+}
+
+console.log('Controller loop proof validator checks passed');

--- a/tests/generic-fanout-reconcile-boundary.test.mjs
+++ b/tests/generic-fanout-reconcile-boundary.test.mjs
@@ -15,6 +15,7 @@ const runner = require(path.join(repoRoot, 'runtime-agent-ci/lib/fanout-reconcil
 
 assert.equal(typeof runtimeAgentCi.createGenericFanoutReconcilePlan, 'function');
 assert.equal(typeof runtimeAgentCi.createGenericFanoutReconcileResult, 'function');
+assert.equal(typeof runtimeAgentCi.validateControllerLoopProof, 'function');
 assert.equal(typeof runtimeAgentCi.createFanoutReconcilePlan, 'function');
 assert.equal(runtimeAgentCi.createGenericFanoutReconcilePlan, genericWorkflow.createGenericFanoutReconcilePlan);
 assert.equal(runtimeAgentCi.createFanoutReconcilePlan, runner.createFanoutReconcilePlan);
@@ -34,14 +35,18 @@ assert.deepEqual(
 
 const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'runtime-agent-ci/package.json'), 'utf8'));
 assert.equal(packageJson.main, 'index.js');
+assert.equal(packageJson.exports['./controller-loop-proof-validator'], './lib/controller-loop-proof-validator.js');
 assert.equal(packageJson.exports['./fanout-reconcile-runner'], './lib/fanout-reconcile-runner.js');
 assert.equal(packageJson.exports['./generic-fanout-reconcile-workflow'], './lib/generic-fanout-reconcile-workflow.js');
+assert.equal(packageJson.bin['homeboy-controller-loop-proof-validate'], './scripts/homeboy-controller-loop-proof-validate.cjs');
 assert.equal(packageJson.bin['homeboy-generic-fanout-reconcile'], './scripts/homeboy-generic-fanout-reconcile.cjs');
 
 const runtimeSources = [
   'runtime-agent-ci/index.js',
+  'runtime-agent-ci/lib/controller-loop-proof-validator.js',
   'runtime-agent-ci/lib/fanout-reconcile-runner.js',
   'runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js',
+  'runtime-agent-ci/scripts/homeboy-controller-loop-proof-validate.cjs',
   'runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs',
 ];
 const sourceViolations = runtimeSources.filter((relativePath) => /wordpress|wp-codebox|Codebox/.test(


### PR DESCRIPTION
## Summary
- Add a generic controller/loop proof validator for spec-driven artifact, evidence, iteration, stop reason, and event lineage checks.
- Export the validator through runtime-agent-ci package API and add a CLI entrypoint for JSON spec/proof validation.
- Cover optional/required artifacts, local reviewer evidence rejection, preview and PR/publication requirements, max iteration/stop reason checks, and event lineage failures.

## Tests
- node tests/controller-loop-proof-validator.test.mjs
- node tests/generic-fanout-reconcile-boundary.test.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the validator, CLI wiring, and tests.