### PR TITLE
Harden WP Codebox production runtime contracts

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -309,13 +309,15 @@ function artifactResultEnvelopeFromCodeboxResult(result, options = {}) {
   const candidates = [
     result,
     result?.artifact_result,
+  ];
+  const legacyCandidates = allowLegacyCodeboxResultCompatibility(options) ? [
     result?.artifactResult,
     result?.metadata?.artifact_result,
     result?.metadata?.artifactResult,
-    ...(Array.isArray(result?.projections) ? result.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection) : []),
-    ...(Array.isArray(result?.metadata?.projections) ? result.metadata.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection) : []),
-  ];
-  const legacyCandidates = allowLegacyCodeboxResultCompatibility(options) ? legacyArtifactResultEnvelopeCandidates(result) : [];
+    ...(Array.isArray(result?.projections) ? result.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection?.artifactResult || projection) : []),
+    ...(Array.isArray(result?.metadata?.projections) ? result.metadata.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection?.artifactResult || projection) : []),
+    ...legacyArtifactResultEnvelopeCandidates(result),
+  ] : [];
   return [...candidates, ...legacyCandidates].map(normalizeArtifactResultEnvelope).find(Boolean) || null;
 }
 
@@ -624,9 +626,21 @@ function artifactRoleFromCodeboxArtifact(artifact = {}, roleAliases = {}) {
   if (explicitRole) {
     return explicitRole;
   }
+  if (!allowArtifactRoleFallbackCompatibility(roleAliases)) {
+    return 'artifact';
+  }
   const fallbackLabel = labels.join(' ');
   const fallback = ARTIFACT_ROLE_FALLBACK_PATTERNS.find(([, pattern]) => pattern.test(fallbackLabel));
   return fallback?.[0] || 'artifact';
+}
+
+function allowArtifactRoleFallbackCompatibility(options = {}) {
+  return Boolean(
+    options.allowArtifactRoleFallbackCompatibility
+      || options.allow_artifact_role_fallback_compatibility
+      || options.allowLegacyCodeboxResultCompatibility
+      || options.allow_legacy_codebox_result_compatibility
+  );
 }
 
 function roleFromAliases(labels, roleAliases = {}) {
@@ -688,6 +702,7 @@ module.exports = {
   WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
   WP_CODEBOX_CASE_ARTIFACT_INDEX_SCHEMA,
   artifactResultEnvelopeFromCodeboxResult,
+  allowArtifactRoleFallbackCompatibility,
   artifactRoleFromCodeboxArtifact,
   artifactNameFromDeclaration,
   artifactPath,

--- a/agent-runtimes/wp-codebox/lib/codebox-run-agent-task-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-run-agent-task-contract.js
@@ -41,7 +41,10 @@ function codeboxRunAgentTaskRequestFromTaskInput(taskInput, options = {}) {
 }
 
 function codeboxRunAgentTaskInvocation(options = {}) {
-  const useLegacyAgentTaskRunCompatibility = Boolean(options.useLegacyAgentTaskRunCompatibility || options.use_legacy_agent_task_run_compatibility);
+  const useLegacyAgentTaskRunCompatibility = legacyAgentTaskRunCompatibilityEnabled(options);
+  if (useLegacyAgentTaskRunCompatibility && isProductionRuntimeProfile(options)) {
+    throw new Error('Production WP Codebox profiles require stable run-agent-task; legacy agent-task-run compatibility is limited to explicit legacy fixture profiles.');
+  }
   const input = useLegacyAgentTaskRunCompatibility
     ? options.taskInput
     : codeboxRunAgentTaskRequestFromTaskInput(options.taskInput, options);
@@ -73,6 +76,31 @@ function codeboxRunAgentTaskInvocation(options = {}) {
   };
 }
 
+function legacyAgentTaskRunCompatibilityEnabled(options = {}) {
+  return Boolean(
+    options.useLegacyAgentTaskRunCompatibility
+      || options.use_legacy_agent_task_run_compatibility
+      || options.allowLegacyAgentTaskRunCompatibility
+      || options.allow_legacy_agent_task_run_compatibility
+  );
+}
+
+function isProductionRuntimeProfile(options = {}) {
+  const profile = firstObject(options.runtimeProfile, options.runtime_profile, options.profile) || {};
+  const profileId = String(profile.id || options.profileId || options.profile_id || '').toLowerCase();
+  const profileKind = String(profile.kind || profile.type || profile.profile || profile.environment || options.profileKind || options.profile_kind || '').toLowerCase();
+  return profile.production === true
+    || profile.is_production === true
+    || profile.isProduction === true
+    || profileId === 'production'
+    || profileId.endsWith('-production')
+    || profileKind === 'production';
+}
+
+function firstObject(...values) {
+  return values.find((value) => value && typeof value === 'object' && !Array.isArray(value));
+}
+
 function firstValue(...values) {
   return values.find((value) => value !== undefined && value !== null && value !== '');
 }
@@ -90,6 +118,8 @@ module.exports = {
   WP_CODEBOX_RUN_AGENT_TASK_RESULT_SCHEMA,
   codeboxRunAgentTaskInvocation,
   codeboxRunAgentTaskRequestFromTaskInput,
+  isProductionRuntimeProfile,
+  legacyAgentTaskRunCompatibilityEnabled,
   allowLegacyCodeboxResultCompatibility,
   isCodeboxLegacyAgentTaskRunResult,
   legacyAgentTaskRunEvidenceRefs,

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -99,7 +99,7 @@ assert.deepEqual(WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.map((requirement) =>
 ]);
 assert.equal(
 	WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.find((requirement) => requirement.id === 'artifact-result-envelope').adapter_behavior,
-	'consume_canonical_envelope_with_legacy_package_fallback'
+	'consume_canonical_envelope_with_explicit_legacy_result_compatibility'
 );
 assert.equal(
 	WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS.find((requirement) => requirement.id === 'preview-materialization').adapter_behavior,

--- a/tests/wp-codebox-artifact-contract-smoke.mjs
+++ b/tests/wp-codebox-artifact-contract-smoke.mjs
@@ -9,6 +9,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const {
   artifactResultEnvelopeFromCodeboxResult,
   artifactRoleFromCodeboxArtifact,
+  allowArtifactRoleFallbackCompatibility,
   artifactNameFromDeclaration,
   artifactPath,
   caseArtifactIndexFromCodeboxResult,
@@ -24,7 +25,10 @@ assert.equal(artifactPath('/tmp/artifacts/', '/files/transcript.json'), '/tmp/ar
 assert.equal(artifactPath('', 'files/transcript.json'), '');
 assert.equal(artifactNameFromDeclaration({ id: 'transcript' }), 'transcript');
 assert.equal(artifactRoleFromCodeboxArtifact({ kind: 'codebox-patch' }, { artifact_roles: { patch: ['codebox-patch'] } }), 'patch');
-assert.equal(artifactRoleFromCodeboxArtifact({ path: '/tmp/files/changed-files.json' }), 'changed_files');
+assert.equal(artifactRoleFromCodeboxArtifact({ path: '/tmp/files/changed-files.json' }), 'artifact');
+assert.equal(artifactRoleFromCodeboxArtifact({ path: '/tmp/files/changed-files.json' }, { allowArtifactRoleFallbackCompatibility: true }), 'changed_files');
+assert.equal(allowArtifactRoleFallbackCompatibility({}), false);
+assert.equal(allowArtifactRoleFallbackCompatibility({ allowLegacyCodeboxResultCompatibility: true }), true);
 
 assert.deepEqual(typedArtifactFileRefs({ fileRefs: [{ path: 'artifact.json' }] }), [{ path: 'artifact.json' }]);
 
@@ -77,14 +81,28 @@ assert.equal(artifactResultEnvelope.success, true);
 assert.equal(artifactResultEnvelope.artifactRefs.length, 2);
 assert.equal(artifactResultEnvelope.artifactRefs[0].sha256, 'abc123');
 
-const projectedEnvelope = artifactResultEnvelopeFromCodeboxResult({
+const canonicalEnvelope = artifactResultEnvelopeFromCodeboxResult({
+  artifact_result: artifactResultEnvelope,
+});
+assert.equal(canonicalEnvelope.operation, 'import-artifact-bundle');
+assert.deepEqual(Object.keys(typedArtifactsFromCodeboxResult(canonicalEnvelope)), ['review']);
+
+const projectedResult = {
   projections: [
     { kind: 'noop', schema: 'example/noop/v1' },
     { kind: 'artifact-result', schema: 'wp-codebox/artifact-result-envelope/v1', envelope: artifactResultEnvelope },
   ],
-});
+};
+assert.equal(artifactResultEnvelopeFromCodeboxResult(projectedResult), null);
+const projectedEnvelope = artifactResultEnvelopeFromCodeboxResult(projectedResult, { allowLegacyCodeboxResultCompatibility: true });
 assert.equal(projectedEnvelope.operation, 'import-artifact-bundle');
-assert.deepEqual(Object.keys(typedArtifactsFromCodeboxResult(projectedEnvelope)), ['review']);
+assert.deepEqual(Object.keys(typedArtifactsFromCodeboxResult(projectedResult)), []);
+assert.deepEqual(Object.keys(typedArtifactsFromCodeboxResult(projectedResult, { allowLegacyCodeboxResultCompatibility: true })), ['review']);
+assert.equal(artifactResultEnvelopeFromCodeboxResult({ artifactResult: artifactResultEnvelope }), null);
+assert.equal(
+  artifactResultEnvelopeFromCodeboxResult({ artifactResult: artifactResultEnvelope }, { allowLegacyCodeboxResultCompatibility: true }).operation,
+  'import-artifact-bundle'
+);
 assert.deepEqual(typedArtifactsFromCodeboxResult({
   artifact_result: artifactResultEnvelope,
   metadata: {
@@ -113,7 +131,7 @@ assert.equal(Object.hasOwn(typedArtifactsFromCodeboxResult({
     },
   },
 }), 'legacy'), false);
-assert.equal(typedArtifactsFromCodeboxResult({
+assert.deepEqual(typedArtifactsFromCodeboxResult({
   metadata: {
     agent_runtime: {
       result: {
@@ -125,7 +143,21 @@ assert.equal(typedArtifactsFromCodeboxResult({
       },
     },
   },
-}).legacy.payload.old, true);
+}), {});
+assert.equal(typedArtifactsFromCodeboxResult({
+  metadata: {
+    agent_runtime: {
+      result: {
+        schema: 'wp-codebox/artifact-result-envelope/v1',
+        outputs: {
+          typed_artifacts: {
+            legacy: { type: 'json', payload: { old: true } },
+          },
+        },
+      },
+    },
+  },
+}, { allowLegacyCodeboxResultCompatibility: true }).legacy.payload.old, true);
 
 assert.deepEqual(normalizeCaseArtifactIndex({
   case_refs: [{

--- a/tests/wp-codebox-run-agent-task-contract-smoke.mjs
+++ b/tests/wp-codebox-run-agent-task-contract-smoke.mjs
@@ -15,7 +15,9 @@ const {
 	WP_CODEBOX_RUN_AGENT_TASK_RESULT_SCHEMA,
 	codeboxRunAgentTaskInvocation,
 	codeboxRunAgentTaskRequestFromTaskInput,
+	isProductionRuntimeProfile,
 	isCodeboxLegacyAgentTaskRunResult,
+	legacyAgentTaskRunCompatibilityEnabled,
 	legacyAgentTaskRunEvidenceRefs,
 	legacyAgentTaskRunSessionArtifacts,
 } = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox'));
@@ -37,29 +39,45 @@ assert.deepEqual(request.compatibility, {
 	legacy_cli_command: WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND,
 });
 
-const legacyInvocation = codeboxRunAgentTaskInvocation({
+const stableInvocation = codeboxRunAgentTaskInvocation({
 	taskInput,
 	previewHold: '30',
 	previewPublicUrl: 'https://preview.example.test',
 });
-assert.equal(legacyInvocation.contract, WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA);
-assert.equal(legacyInvocation.implementation, 'legacy-agent-task-run-compat');
-assert.equal(legacyInvocation.input, taskInput);
-assert.deepEqual(legacyInvocation.args, [
-	WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND,
+assert.equal(stableInvocation.contract, WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA);
+assert.equal(stableInvocation.implementation, 'stable-run-agent-task');
+assert.equal(stableInvocation.input.schema, WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA);
+assert.deepEqual(stableInvocation.args, [
+	WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND,
 	'--input-file={{input_file}}',
 	'--json',
 	'--preview-hold-seconds=30',
 	'--preview-public-url=https://preview.example.test',
 ]);
-
-const stableInvocation = codeboxRunAgentTaskInvocation({ taskInput, useStableRunAgentTask: true });
-assert.equal(stableInvocation.implementation, 'stable-run-agent-task');
-assert.equal(stableInvocation.input.schema, WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA);
-assert.equal(stableInvocation.args[0], WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND);
 assert.equal(stableInvocation.result_schema, WP_CODEBOX_RUN_AGENT_TASK_RESULT_SCHEMA);
 assert.equal(stableInvocation.result_schema, WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA);
 assert.equal(stableInvocation.result_key, 'agent_task_run_result');
+
+assert.equal(legacyAgentTaskRunCompatibilityEnabled({}), false);
+assert.equal(legacyAgentTaskRunCompatibilityEnabled({ allowLegacyAgentTaskRunCompatibility: true }), true);
+const legacyInvocation = codeboxRunAgentTaskInvocation({
+	taskInput,
+	allowLegacyAgentTaskRunCompatibility: true,
+});
+assert.equal(legacyInvocation.implementation, 'legacy-agent-task-run-compat');
+assert.equal(legacyInvocation.input, taskInput);
+assert.equal(legacyInvocation.args[0], WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND);
+assert.equal(legacyInvocation.result_schema, WP_CODEBOX_AGENT_TASK_RUN_RESPONSE_SCHEMA);
+
+assert.equal(isProductionRuntimeProfile({ runtimeProfile: { id: 'production' } }), true);
+assert.throws(
+	() => codeboxRunAgentTaskInvocation({
+		taskInput,
+		allowLegacyAgentTaskRunCompatibility: true,
+		runtimeProfile: { id: 'production' },
+	}),
+	/Production WP Codebox profiles require stable run-agent-task/
+);
 
 assert.throws(
 	() => codeboxRunAgentTaskRequestFromTaskInput({ schema: 'wp-codebox/not-task-input/v1' }),


### PR DESCRIPTION
## Summary
- Require stable WP Codebox run-agent-task invocation by default and reject legacy agent-task-run for production runtime profiles.
- Gate legacy artifact/result aliases and projection fallback behind explicit legacy result compatibility.
- Make regex artifact role inference opt-in while preserving explicit role alias maps.
- Add negative and compatibility-mode tests for legacy CLI, artifact aliases, and role fallback behavior.

## Tests
- node tests/wp-codebox-run-agent-task-contract-smoke.mjs
- node tests/wp-codebox-artifact-contract-smoke.mjs
- node tests/wp-codebox-adapter-contract-smoke.mjs
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js
- for f in tests/wp-codebox-*.mjs; do node "" || exit 1; done

## Dependency / blocker status
- Current HBE main already exposes the canonical WP Codebox contract schema names used here: run-agent-task request/result and artifact-result-envelope.
- No TODOs or ad-hoc fallback primitives were added. If the upstream wp-codebox contracts PR changes these schema names, this PR should be rebased against the updated exported contract source.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, tests, and PR description drafting.