### PR TITLE
Require canonical WP Codebox runtime contracts

### DIFF
--- a/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
@@ -3,105 +3,60 @@
 const path = require('node:path');
 const { existsSync } = require('node:fs');
 const { homedir } = require('node:os');
-const { pathToFileURL } = require('node:url');
+const { fileURLToPath, pathToFileURL } = require('node:url');
 
 const DEFAULT_CODEBOX_CONTRACTS_MODULE = '@automattic/wp-codebox-core/contracts';
 const RUNTIME_CONTRACT_MANIFEST_SCHEMA = 'wp-codebox/runtime-contract-manifest/v1';
 
-const DEPRECATED_RUNTIME_CONTRACT_FALLBACK = {
-  status: 'deprecated',
-  replacement: '@automattic/wp-codebox-core/contracts runtimeContractManifest()',
-  reason: 'Homeboy Extensions must consume WP Codebox public package contracts instead of carrying schema copies.',
-};
-
-const FALLBACK_RUNTIME_CONTRACT_SCHEMAS = {
-  providerRuntime: {
-    invocation: 'wp-codebox/provider-runtime-invocation-contract/v1',
-    credentialRequirements: 'wp-codebox/provider-credential-requirements/v1',
-    credentialPreflight: 'wp-codebox/provider-credential-preflight/v1',
-    credentialResolution: 'wp-codebox/provider-credential-resolution/v1',
-  },
-  agentTask: {
-    runRequest: 'wp-codebox/run-agent-task/v1',
-    runResult: 'wp-codebox/agent-task-run-result/v1',
-    legacyRunResponse: 'wp-codebox/agent-task-run/v1',
-  },
-  runtimeBoundary: {
-    profile: 'wp-codebox/runtime-profile/v1',
-    previewLease: 'wp-codebox/preview-lease/v1',
-    browserContainedSiteStatus: 'wp-codebox/browser-contained-site-status/v1',
-    browserContainedSiteOpen: 'wp-codebox/browser-contained-site-open/v1',
-    browserSessionProductDto: 'wp-codebox/browser-session-product-dto/v1',
-    browserPreviewBootConfig: 'wp-codebox/browser-preview-boot-config/v1',
-  },
-  artifact: {
-    resultEnvelope: 'wp-codebox/artifact-result-envelope/v1',
-  },
-  runnerWorkspace: {
-    prepareRequest: 'wp-codebox/runner-workspace-prepare-request/v1',
-    prepareResult: 'wp-codebox/runner-workspace-prepare-result/v1',
-    captureRequest: 'wp-codebox/runner-workspace-capture-request/v1',
-    captureResult: 'wp-codebox/runner-workspace-capture-result/v1',
-    commandRequest: 'wp-codebox/runner-workspace-command-request/v1',
-    commandResult: 'wp-codebox/runner-workspace-command-result/v1',
-    publicationRequest: 'wp-codebox/runner-workspace-publication-request/v1',
-    publicationResult: 'wp-codebox/runner-workspace-publication-result/v1',
-  },
-  fanoutAggregation: {
-    input: 'wp-codebox/fanout-aggregation-input/v1',
-    output: 'wp-codebox/fanout-aggregation-output/v1',
-  },
-};
-
-const FALLBACK_PROVIDER_RUNTIME_INVOCATION_CONTRACT = {
-  schema: FALLBACK_RUNTIME_CONTRACT_SCHEMAS.providerRuntime.invocation,
-  version: 1,
-  tasks: {
-    workspacePrepare: 'wp-codebox.runner-workspace.prepare',
-    workspaceCapture: 'wp-codebox.runner-workspace.capture',
-    workspaceCommand: 'wp-codebox.runner-workspace.command',
-    workspacePublish: 'wp-codebox.runner-workspace.publish',
-    toolCallTranscriptRecord: 'wp-codebox.tool-call-transcript.record',
-    artifactHandoff: 'wp-codebox.artifact-handoff',
-  },
-  abilities: {
-    workspacePrepare: 'wp-codebox/runner-workspace-prepare',
-    workspaceCapture: 'wp-codebox/runner-workspace-capture',
-    workspaceCommand: 'wp-codebox/runner-workspace-command',
-    workspacePublish: 'wp-codebox/runner-workspace-publish',
-    toolCallTranscriptRecord: 'wp-codebox/record-tool-call-transcript',
-    artifactHandoff: 'wp-codebox/handoff-artifacts',
-  },
-  result_schemas: {
-    workspace_prepare: FALLBACK_RUNTIME_CONTRACT_SCHEMAS.runnerWorkspace.prepareResult,
-    workspace_capture: FALLBACK_RUNTIME_CONTRACT_SCHEMAS.runnerWorkspace.captureResult,
-    workspace_command: FALLBACK_RUNTIME_CONTRACT_SCHEMAS.runnerWorkspace.commandResult,
-    workspace_publication: FALLBACK_RUNTIME_CONTRACT_SCHEMAS.runnerWorkspace.publicationResult,
-    tool_call_transcript: 'wp-codebox/tool-call-transcript/v1',
-    evidence_artifact_envelope: 'wp-codebox/evidence-artifact-envelope/v1',
-    artifact_result_envelope: FALLBACK_RUNTIME_CONTRACT_SCHEMAS.artifact.resultEnvelope,
-  },
-};
-
-const FALLBACK_RUNTIME_CONTRACT_MANIFEST = {
-  schema: RUNTIME_CONTRACT_MANIFEST_SCHEMA,
-  version: 1,
-  schemas: FALLBACK_RUNTIME_CONTRACT_SCHEMAS,
-  providerRuntime: FALLBACK_PROVIDER_RUNTIME_INVOCATION_CONTRACT,
-};
+const REQUIRED_RUNTIME_CONTRACT_PATHS = [
+  'schemas.providerRuntime.invocation',
+  'schemas.providerRuntime.credentialRequirements',
+  'schemas.providerRuntime.credentialPreflight',
+  'schemas.providerRuntime.credentialResolution',
+  'schemas.agentTask.runRequest',
+  'schemas.agentTask.runResult',
+  'schemas.agentTask.legacyRunResponse',
+  'schemas.runtimeBoundary.profile',
+  'schemas.runtimeBoundary.previewLease',
+  'schemas.runtimeBoundary.browserContainedSiteStatus',
+  'schemas.runtimeBoundary.browserContainedSiteOpen',
+  'schemas.runtimeBoundary.browserSessionProductDto',
+  'schemas.runtimeBoundary.browserPreviewBootConfig',
+  'schemas.artifact.resultEnvelope',
+  'schemas.runnerWorkspace.prepareRequest',
+  'schemas.runnerWorkspace.prepareResult',
+  'schemas.runnerWorkspace.captureRequest',
+  'schemas.runnerWorkspace.captureResult',
+  'schemas.runnerWorkspace.commandRequest',
+  'schemas.runnerWorkspace.commandResult',
+  'schemas.runnerWorkspace.publicationRequest',
+  'schemas.runnerWorkspace.publicationResult',
+  'schemas.fanoutAggregation.input',
+  'schemas.fanoutAggregation.output',
+  'providerRuntime.schema',
+  'providerRuntime.tasks.workspacePrepare',
+  'providerRuntime.tasks.workspaceCapture',
+  'providerRuntime.tasks.workspaceCommand',
+  'providerRuntime.tasks.workspacePublish',
+  'providerRuntime.tasks.toolCallTranscriptRecord',
+  'providerRuntime.tasks.artifactHandoff',
+  'providerRuntime.abilities.workspacePrepare',
+  'providerRuntime.abilities.workspaceCapture',
+  'providerRuntime.abilities.workspaceCommand',
+  'providerRuntime.abilities.workspacePublish',
+  'providerRuntime.abilities.toolCallTranscriptRecord',
+  'providerRuntime.abilities.artifactHandoff',
+  'providerRuntime.result_schemas.workspace_prepare',
+  'providerRuntime.result_schemas.workspace_capture',
+  'providerRuntime.result_schemas.workspace_command',
+  'providerRuntime.result_schemas.workspace_publication',
+  'providerRuntime.result_schemas.tool_call_transcript',
+  'providerRuntime.result_schemas.evidence_artifact_envelope',
+  'providerRuntime.result_schemas.artifact_result_envelope',
+];
 
 function runtimeContractManifest() {
-  return clone(FALLBACK_RUNTIME_CONTRACT_MANIFEST);
-}
-
-function runtimeContractFallbackDiagnostic(details = {}) {
-  return withoutUndefinedValues({
-    ...DEPRECATED_RUNTIME_CONTRACT_FALLBACK,
-    source: 'homeboy-extensions-fallback',
-    schema: RUNTIME_CONTRACT_MANIFEST_SCHEMA,
-    canonical_required_option: 'required',
-    details: Object.keys(details).length > 0 ? details : undefined,
-  });
+  return clone(loadCanonicalRuntimeContractSourceSync({ required: true }).manifest);
 }
 
 function runtimeContractSchemas() {
@@ -113,24 +68,14 @@ function providerRuntimeInvocationContract() {
 }
 
 async function loadRuntimeContractSource(options = {}) {
-  const canonical = await loadCanonicalRuntimeContractSource(options);
-  if (canonical) {
-    return canonical;
-  }
-  return {
-    source: 'homeboy-extensions-fallback',
-    manifest: runtimeContractManifest(),
-    normalizers: {},
-    canonical: false,
-    diagnostics: [runtimeContractFallbackDiagnostic()],
-  };
+  return loadCanonicalRuntimeContractSource({ ...options, required: true });
 }
 
 async function loadCanonicalRuntimeContractSource(options = {}) {
   const errors = [];
   for (const specifier of coreModuleCandidates(options)) {
     try {
-      const core = await import(specifier);
+      const core = moduleExports(await import(specifier));
       if (typeof core.runtimeContractManifest !== 'function') {
         errors.push({ specifier, message: 'missing runtimeContractManifest export' });
         continue;
@@ -156,6 +101,36 @@ async function loadCanonicalRuntimeContractSource(options = {}) {
   return null;
 }
 
+function loadCanonicalRuntimeContractSourceSync(options = {}) {
+  const errors = [];
+  for (const specifier of coreModuleCandidates(options)) {
+    try {
+      const core = moduleExports(require(requireSpecifier(specifier)));
+      if (typeof core.runtimeContractManifest !== 'function') {
+        errors.push({ specifier, message: 'missing runtimeContractManifest export' });
+        continue;
+      }
+      const manifest = core.runtimeContractManifest();
+      validateCanonicalRuntimeContractManifest(manifest);
+      return {
+        source: specifier,
+        manifest,
+        normalizers: core.RUNTIME_CONTRACT_NORMALIZERS || {},
+        canonical: true,
+      };
+    } catch (error) {
+      errors.push({ specifier, error, message: error.message });
+    }
+  }
+
+  if (options.required) {
+    const error = new Error('WP Codebox canonical runtime contract manifest is unavailable. Install @automattic/wp-codebox-core or configure HOMEBOY_WP_CODEBOX_CORE_MODULE.');
+    error.wpCodeboxRuntimeContractErrors = errors;
+    throw error;
+  }
+  return null;
+}
+
 function validateCanonicalRuntimeContractManifest(manifest) {
   if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
     throw new Error('WP Codebox canonical runtime contract manifest must be an object.');
@@ -163,21 +138,9 @@ function validateCanonicalRuntimeContractManifest(manifest) {
   if (manifest.schema !== RUNTIME_CONTRACT_MANIFEST_SCHEMA) {
     throw new Error(`WP Codebox canonical runtime contract manifest schema mismatch: ${manifest.schema || 'missing'}.`);
   }
-  assertContractSubset(manifest.schemas, FALLBACK_RUNTIME_CONTRACT_SCHEMAS, 'schemas');
-  assertContractSubset(manifest.providerRuntime, FALLBACK_PROVIDER_RUNTIME_INVOCATION_CONTRACT, 'providerRuntime');
-}
-
-function assertContractSubset(actual, expected, pathName) {
-  if (!actual || typeof actual !== 'object' || Array.isArray(actual)) {
-    throw new Error(`WP Codebox canonical runtime contract manifest missing ${pathName}.`);
-  }
-  for (const [key, expectedValue] of Object.entries(expected)) {
-    const currentPath = `${pathName}.${key}`;
-    const actualValue = actual[key];
-    if (expectedValue && typeof expectedValue === 'object' && !Array.isArray(expectedValue)) {
-      assertContractSubset(actualValue, expectedValue, currentPath);
-    } else if (actualValue !== expectedValue) {
-      throw new Error(`WP Codebox canonical runtime contract mismatch at ${currentPath}: expected ${expectedValue}, received ${actualValue || 'missing'}.`);
+  for (const pathName of REQUIRED_RUNTIME_CONTRACT_PATHS) {
+    if (typeof valueAtPath(manifest, pathName) !== 'string') {
+      throw new Error(`WP Codebox canonical runtime contract manifest missing ${pathName}.`);
     }
   }
 }
@@ -228,24 +191,36 @@ function isPathSpecifier(specifier) {
   return specifier.startsWith('.') || path.isAbsolute(specifier) || specifier.startsWith('~') || specifier.includes('\\') || existsSync(path.resolve(specifier));
 }
 
+function requireSpecifier(specifier) {
+  return specifier?.startsWith('file:') ? fileURLToPath(specifier) : specifier;
+}
+
+function moduleExports(value) {
+  if (!value || !value.default) {
+    return value;
+  }
+  if (typeof value.default === 'object') {
+    return { ...value.default, ...value };
+  }
+  return typeof value.runtimeContractManifest === 'function' ? value : value.default;
+}
+
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
-function withoutUndefinedValues(value) {
-  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+function valueAtPath(value, pathName) {
+  return pathName.split('.').reduce((current, part) => current?.[part], value);
 }
 
 module.exports = {
-  DEPRECATED_RUNTIME_CONTRACT_FALLBACK,
-  FALLBACK_RUNTIME_CONTRACT_MANIFEST,
-  FALLBACK_RUNTIME_CONTRACT_SCHEMAS,
+  REQUIRED_RUNTIME_CONTRACT_PATHS,
   RUNTIME_CONTRACT_MANIFEST_SCHEMA,
   coreModuleCandidates,
   loadCanonicalRuntimeContractSource,
+  loadCanonicalRuntimeContractSourceSync,
   loadRuntimeContractSource,
   providerRuntimeInvocationContract,
-  runtimeContractFallbackDiagnostic,
   runtimeContractManifest,
   runtimeContractSchemas,
   validateCanonicalRuntimeContractManifest,

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -400,35 +400,6 @@
           "required_secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"]
         }
       },
-      "provider_runtime_invocation": {
-        "schema": "wp-codebox/provider-runtime-invocation-contract/v1",
-        "version": 1,
-        "tasks": {
-          "workspacePrepare": "wp-codebox.runner-workspace.prepare",
-          "workspaceCapture": "wp-codebox.runner-workspace.capture",
-          "workspaceCommand": "wp-codebox.runner-workspace.command",
-          "workspacePublish": "wp-codebox.runner-workspace.publish",
-          "toolCallTranscriptRecord": "wp-codebox.tool-call-transcript.record",
-          "artifactHandoff": "wp-codebox.artifact-handoff"
-        },
-        "abilities": {
-          "workspacePrepare": "wp-codebox/runner-workspace-prepare",
-          "workspaceCapture": "wp-codebox/runner-workspace-capture",
-          "workspaceCommand": "wp-codebox/runner-workspace-command",
-          "workspacePublish": "wp-codebox/runner-workspace-publish",
-          "toolCallTranscriptRecord": "wp-codebox/record-tool-call-transcript",
-          "artifactHandoff": "wp-codebox/handoff-artifacts"
-        },
-        "result_schemas": {
-          "workspace_prepare": "wp-codebox/runner-workspace-prepare-result/v1",
-          "workspace_capture": "wp-codebox/runner-workspace-capture-result/v1",
-          "workspace_command": "wp-codebox/runner-workspace-command-result/v1",
-          "workspace_publication": "wp-codebox/runner-workspace-publication-result/v1",
-          "tool_call_transcript": "wp-codebox/tool-call-transcript/v1",
-          "evidence_artifact_envelope": "wp-codebox/evidence-artifact-envelope/v1",
-          "artifact_result_envelope": "wp-codebox/artifact-result-envelope/v1"
-        }
-      },
       "provider_credential_boundary": {
         "schema": "wp-codebox/provider-credential-boundary/v1",
         "version": 1,

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -123,10 +123,9 @@ The provider command should emit `homeboy/agent-task-outcome/v1` with normalized
 recipe artifacts may be attached as artifacts, but Homeboy should not parse them
 to determine the terminal outcome.
 
-For WP Codebox specifically, Homeboy Extensions forwards runtime package,
-recipe, command, args, and env-name declarations to the Codebox executable
-contract, and Codebox returns the stable result envelope. WPCOM, Dolly, and
-product-specific semantics belong to callers or runtime packages.
+Runtime packages forward package-owned command, args, and env-name declarations
+through their executable contract and return stable result envelopes. Product
+semantics belong to callers or runtime packages.
 
 ## Homeboy Contract Adapter
 

--- a/tests/codebox-delegated-run-normalizer-smoke.mjs
+++ b/tests/codebox-delegated-run-normalizer-smoke.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 const {
 	DELEGATED_RUN_REQUEST_SCHEMA,
 	DELEGATED_RUN_RESULT_SCHEMA,

--- a/tests/fixtures/wp-codebox-core-runtime-contract.cjs
+++ b/tests/fixtures/wp-codebox-core-runtime-contract.cjs
@@ -1,0 +1,80 @@
+'use strict';
+
+const manifest = {
+  schema: 'wp-codebox/runtime-contract-manifest/v1',
+  version: 1,
+  schemas: {
+    providerRuntime: {
+      invocation: 'wp-codebox/provider-runtime-invocation-contract/v1',
+      credentialRequirements: 'wp-codebox/provider-credential-requirements/v1',
+      credentialPreflight: 'wp-codebox/provider-credential-preflight/v1',
+      credentialResolution: 'wp-codebox/provider-credential-resolution/v1',
+    },
+    agentTask: {
+      runRequest: 'wp-codebox/run-agent-task/v1',
+      runResult: 'wp-codebox/agent-task-run-result/v1',
+      legacyRunResponse: 'wp-codebox/agent-task-run/v1',
+    },
+    runtimeBoundary: {
+      profile: 'wp-codebox/runtime-profile/v1',
+      previewLease: 'wp-codebox/preview-lease/v1',
+      browserContainedSiteStatus: 'wp-codebox/browser-contained-site-status/v1',
+      browserContainedSiteOpen: 'wp-codebox/browser-contained-site-open/v1',
+      browserSessionProductDto: 'wp-codebox/browser-session-product-dto/v1',
+      browserPreviewBootConfig: 'wp-codebox/browser-preview-boot-config/v1',
+    },
+    artifact: {
+      resultEnvelope: 'wp-codebox/artifact-result-envelope/v1',
+    },
+    runnerWorkspace: {
+      prepareRequest: 'wp-codebox/runner-workspace-prepare-request/v1',
+      prepareResult: 'wp-codebox/runner-workspace-prepare-result/v1',
+      captureRequest: 'wp-codebox/runner-workspace-capture-request/v1',
+      captureResult: 'wp-codebox/runner-workspace-capture-result/v1',
+      commandRequest: 'wp-codebox/runner-workspace-command-request/v1',
+      commandResult: 'wp-codebox/runner-workspace-command-result/v1',
+      publicationRequest: 'wp-codebox/runner-workspace-publication-request/v1',
+      publicationResult: 'wp-codebox/runner-workspace-publication-result/v1',
+    },
+    fanoutAggregation: {
+      input: 'wp-codebox/fanout-aggregation-input/v1',
+      output: 'wp-codebox/fanout-aggregation-output/v1',
+    },
+  },
+  providerRuntime: {
+    schema: 'wp-codebox/provider-runtime-invocation-contract/v1',
+    version: 1,
+    tasks: {
+      workspacePrepare: 'wp-codebox.runner-workspace.prepare',
+      workspaceCapture: 'wp-codebox.runner-workspace.capture',
+      workspaceCommand: 'wp-codebox.runner-workspace.command',
+      workspacePublish: 'wp-codebox.runner-workspace.publish',
+      toolCallTranscriptRecord: 'wp-codebox.tool-call-transcript.record',
+      artifactHandoff: 'wp-codebox.artifact-handoff',
+    },
+    abilities: {
+      workspacePrepare: 'wp-codebox/runner-workspace-prepare',
+      workspaceCapture: 'wp-codebox/runner-workspace-capture',
+      workspaceCommand: 'wp-codebox/runner-workspace-command',
+      workspacePublish: 'wp-codebox/runner-workspace-publish',
+      toolCallTranscriptRecord: 'wp-codebox/record-tool-call-transcript',
+      artifactHandoff: 'wp-codebox/handoff-artifacts',
+    },
+    result_schemas: {
+      workspace_prepare: 'wp-codebox/runner-workspace-prepare-result/v1',
+      workspace_capture: 'wp-codebox/runner-workspace-capture-result/v1',
+      workspace_command: 'wp-codebox/runner-workspace-command-result/v1',
+      workspace_publication: 'wp-codebox/runner-workspace-publication-result/v1',
+      tool_call_transcript: 'wp-codebox/tool-call-transcript/v1',
+      evidence_artifact_envelope: 'wp-codebox/evidence-artifact-envelope/v1',
+      artifact_result_envelope: 'wp-codebox/artifact-result-envelope/v1',
+    },
+  },
+};
+
+module.exports = {
+  runtimeContractManifest() {
+    return JSON.parse(JSON.stringify(manifest));
+  },
+  RUNTIME_CONTRACT_NORMALIZERS: {},
+};

--- a/tests/wp-codebox-adapter-boundary-smoke.mjs
+++ b/tests/wp-codebox-adapter-boundary-smoke.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(repoRoot, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 const runtimePackage = require(path.join(repoRoot, 'agent-runtimes', 'wp-codebox'));
 const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'agent-runtimes', 'wp-codebox', 'package.json'), 'utf8'));
 

--- a/tests/wp-codebox-adapter-contract-smoke.mjs
+++ b/tests/wp-codebox-adapter-contract-smoke.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 const {
 	WP_CODEBOX_BACKEND,
 	WP_CODEBOX_PROVIDER_ID,

--- a/tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
+++ b/tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
@@ -7,6 +7,7 @@ import { createRequire } from 'node:module';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const require = createRequire(import.meta.url);
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 const manifestPath = path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'wp-codebox.json');
 const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
 const provider = manifest.agent_task_executors[0];

--- a/tests/wp-codebox-artifact-contract-smoke.mjs
+++ b/tests/wp-codebox-artifact-contract-smoke.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(repoRoot, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 const {
   artifactResultEnvelopeFromCodeboxResult,
   artifactRoleFromCodeboxArtifact,

--- a/tests/wp-codebox-preview-materialization-contract-smoke.mjs
+++ b/tests/wp-codebox-preview-materialization-contract-smoke.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 const {
 	materializePreview,
 } = require(path.join(rootDir, 'runtime-agent-ci', 'index.js'));

--- a/tests/wp-codebox-provider-plugin-defaults-smoke.mjs
+++ b/tests/wp-codebox-provider-plugin-defaults-smoke.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 const { codeboxTaskRequestFromAgentTaskRequest } = require(
 	path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'codebox-agent-task-executor.js')
 );

--- a/tests/wp-codebox-run-agent-task-contract-smoke.mjs
+++ b/tests/wp-codebox-run-agent-task-contract-smoke.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 const {
 	WP_CODEBOX_LEGACY_AGENT_TASK_RUN_CLI_COMMAND,
 	WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA,
@@ -47,6 +48,7 @@ const stableInvocation = codeboxRunAgentTaskInvocation({
 assert.equal(stableInvocation.contract, WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA);
 assert.equal(stableInvocation.implementation, 'stable-run-agent-task');
 assert.equal(stableInvocation.input.schema, WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA);
+assert.equal(stableInvocation.input.task_input, taskInput);
 assert.deepEqual(stableInvocation.args, [
 	WP_CODEBOX_RUN_AGENT_TASK_CLI_COMMAND,
 	'--input-file={{input_file}}',

--- a/tests/wp-codebox-runtime-contract-source-smoke.mjs
+++ b/tests/wp-codebox-runtime-contract-source-smoke.mjs
@@ -8,31 +8,115 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hbe-codebox-runtime-contract-'));
+
+const canonicalManifest = {
+  schema: 'wp-codebox/runtime-contract-manifest/v1',
+  version: 1,
+  schemas: {
+    providerRuntime: {
+      invocation: 'canonical/provider-runtime-invocation-contract/v1',
+      credentialRequirements: 'canonical/provider-credential-requirements/v1',
+      credentialPreflight: 'canonical/provider-credential-preflight/v1',
+      credentialResolution: 'canonical/provider-credential-resolution/v1',
+    },
+    agentTask: {
+      runRequest: 'canonical/run-agent-task/v1',
+      runResult: 'canonical/agent-task-run-result/v1',
+      legacyRunResponse: 'canonical/agent-task-run/v1',
+    },
+    runtimeBoundary: {
+      profile: 'canonical/runtime-profile/v1',
+      previewLease: 'canonical/preview-lease/v1',
+      browserContainedSiteStatus: 'canonical/browser-contained-site-status/v1',
+      browserContainedSiteOpen: 'canonical/browser-contained-site-open/v1',
+      browserSessionProductDto: 'canonical/browser-session-product-dto/v1',
+      browserPreviewBootConfig: 'canonical/browser-preview-boot-config/v1',
+    },
+    artifact: {
+      resultEnvelope: 'canonical/artifact-result-envelope/v1',
+    },
+    runnerWorkspace: {
+      prepareRequest: 'canonical/runner-workspace-prepare-request/v1',
+      prepareResult: 'canonical/runner-workspace-prepare-result/v1',
+      captureRequest: 'canonical/runner-workspace-capture-request/v1',
+      captureResult: 'canonical/runner-workspace-capture-result/v1',
+      commandRequest: 'canonical/runner-workspace-command-request/v1',
+      commandResult: 'canonical/runner-workspace-command-result/v1',
+      publicationRequest: 'canonical/runner-workspace-publication-request/v1',
+      publicationResult: 'canonical/runner-workspace-publication-result/v1',
+    },
+    fanoutAggregation: {
+      input: 'canonical/fanout-aggregation-input/v1',
+      output: 'canonical/fanout-aggregation-output/v1',
+    },
+  },
+  providerRuntime: {
+    schema: 'canonical/provider-runtime-invocation-contract/v1',
+    version: 1,
+    tasks: {
+      workspacePrepare: 'canonical.runner-workspace.prepare',
+      workspaceCapture: 'canonical.runner-workspace.capture',
+      workspaceCommand: 'canonical.runner-workspace.command',
+      workspacePublish: 'canonical.runner-workspace.publish',
+      toolCallTranscriptRecord: 'canonical.tool-call-transcript.record',
+      artifactHandoff: 'canonical.artifact-handoff',
+    },
+    abilities: {
+      workspacePrepare: 'canonical/runner-workspace-prepare',
+      workspaceCapture: 'canonical/runner-workspace-capture',
+      workspaceCommand: 'canonical/runner-workspace-command',
+      workspacePublish: 'canonical/runner-workspace-publish',
+      toolCallTranscriptRecord: 'canonical/record-tool-call-transcript',
+      artifactHandoff: 'canonical/handoff-artifacts',
+    },
+    result_schemas: {
+      workspace_prepare: 'canonical/runner-workspace-prepare-result/v1',
+      workspace_capture: 'canonical/runner-workspace-capture-result/v1',
+      workspace_command: 'canonical/runner-workspace-command-result/v1',
+      workspace_publication: 'canonical/runner-workspace-publication-result/v1',
+      tool_call_transcript: 'canonical/tool-call-transcript/v1',
+      evidence_artifact_envelope: 'canonical/evidence-artifact-envelope/v1',
+      artifact_result_envelope: 'canonical/artifact-result-envelope/v1',
+    },
+  },
+};
+
+const canonicalModule = path.join(tempRoot, 'canonical-runtime-core.cjs');
+fs.writeFileSync(canonicalModule, `
+module.exports = {
+  runtimeContractManifest() {
+    return ${JSON.stringify(canonicalManifest, null, 2)};
+  },
+  RUNTIME_CONTRACT_NORMALIZERS: {
+    runtimeProfile(input) { return { ...input, schema: 'canonical/runtime-profile/v1' }; },
+  },
+};
+`);
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE = canonicalModule;
+
 const {
-	DEPRECATED_RUNTIME_CONTRACT_FALLBACK,
-	coreModuleCandidates,
-	loadCanonicalRuntimeContractSource,
-	loadRuntimeContractSource,
-	providerRuntimeInvocationContract,
-	runtimeContractFallbackDiagnostic,
-	runtimeContractManifest,
-	runtimeContractSchemas,
-	validateCanonicalRuntimeContractManifest,
+  REQUIRED_RUNTIME_CONTRACT_PATHS,
+  coreModuleCandidates,
+  loadCanonicalRuntimeContractSource,
+  loadCanonicalRuntimeContractSourceSync,
+  loadRuntimeContractSource,
+  providerRuntimeInvocationContract,
+  runtimeContractManifest,
+  runtimeContractSchemas,
+  validateCanonicalRuntimeContractManifest,
 } = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'wp-codebox-runtime-contract-source.js'));
 const {
-	WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA,
-	WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
-	WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS,
-	WP_CODEBOX_RUNTIME_PROFILE_SCHEMA,
-	wpCodeboxProviderRuntimeInvocationContract,
+  WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA,
+  WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+  WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS,
+  WP_CODEBOX_RUNTIME_PROFILE_SCHEMA,
+  wpCodeboxProviderRuntimeInvocationContract,
 } = require(path.join(rootDir, 'agent-runtimes', 'wp-codebox'));
 
-const fallbackManifest = runtimeContractManifest();
-assert.equal(fallbackManifest.schema, 'wp-codebox/runtime-contract-manifest/v1');
-assert.equal(fallbackManifest.schemas.runtimeBoundary.profile, 'wp-codebox/runtime-profile/v1');
-assert.equal(fallbackManifest.schemas.runtimeBoundary.browserSessionProductDto, 'wp-codebox/browser-session-product-dto/v1');
-assert.equal(fallbackManifest.schemas.artifact.resultEnvelope, 'wp-codebox/artifact-result-envelope/v1');
-assert.deepEqual(fallbackManifest.providerRuntime, providerRuntimeInvocationContract());
+assert.equal(REQUIRED_RUNTIME_CONTRACT_PATHS.includes('schemas.runtimeBoundary.profile'), true);
+assert.deepEqual(runtimeContractManifest(), canonicalManifest);
+assert.deepEqual(providerRuntimeInvocationContract(), canonicalManifest.providerRuntime);
 
 const schemas = runtimeContractSchemas();
 assert.equal(WP_CODEBOX_RUNTIME_PROFILE_SCHEMA, schemas.runtimeBoundary.profile);
@@ -40,78 +124,63 @@ assert.equal(WP_CODEBOX_ARTIFACT_RESULT_ENVELOPE_SCHEMA, schemas.artifact.result
 assert.equal(WP_CODEBOX_AGENT_TASK_RUN_RESULT_SCHEMA, schemas.agentTask.runResult);
 assert.equal(WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS.workspace_capture, schemas.runnerWorkspace.captureResult);
 assert.deepEqual(wpCodeboxProviderRuntimeInvocationContract(), {
-	...fallbackManifest.providerRuntime,
-	result_schemas: {
-		...fallbackManifest.providerRuntime.result_schemas,
-		artifact_result_envelope: schemas.artifact.resultEnvelope,
-	},
+  ...canonicalManifest.providerRuntime,
+  result_schemas: {
+    ...canonicalManifest.providerRuntime.result_schemas,
+    artifact_result_envelope: schemas.artifact.resultEnvelope,
+  },
 });
 
-validateCanonicalRuntimeContractManifest(fallbackManifest);
-
-assert.equal(DEPRECATED_RUNTIME_CONTRACT_FALLBACK.status, 'deprecated');
-assert.match(DEPRECATED_RUNTIME_CONTRACT_FALLBACK.replacement, /@automattic\/wp-codebox-core/);
-assert.deepEqual(runtimeContractFallbackDiagnostic({ reason: 'test' }), {
-	...DEPRECATED_RUNTIME_CONTRACT_FALLBACK,
-	source: 'homeboy-extensions-fallback',
-	schema: 'wp-codebox/runtime-contract-manifest/v1',
-	canonical_required_option: 'required',
-	details: { reason: 'test' },
-});
+validateCanonicalRuntimeContractManifest(canonicalManifest);
 
 const runtimeContractSource = fs.readFileSync(
-	path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'wp-codebox-runtime-contract-source.js'),
-	'utf8'
+  path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'wp-codebox-runtime-contract-source.js'),
+  'utf8'
 );
-const fallbackConstantNames = [...runtimeContractSource.matchAll(/const\s+(FALLBACK_[A-Z0-9_]+)/g)].map((match) => match[1]);
 assert.deepEqual(
-	fallbackConstantNames,
-	[
-		'FALLBACK_RUNTIME_CONTRACT_SCHEMAS',
-		'FALLBACK_PROVIDER_RUNTIME_INVOCATION_CONTRACT',
-		'FALLBACK_RUNTIME_CONTRACT_MANIFEST',
-	],
-	'Do not add new hardcoded WP Codebox fallback contract constants; consume the public Codebox runtime contract manifest instead.'
+  [...runtimeContractSource.matchAll(/const\s+(FALLBACK_[A-Z0-9_]+)/g)].map((match) => match[1]),
+  [],
+  'Do not carry hardcoded WP Codebox fallback contract constants; consume the public Codebox runtime contract manifest instead.'
 );
+assert.doesNotMatch(runtimeContractSource, /homeboy-extensions-fallback/);
 
 assert.throws(
-	() => validateCanonicalRuntimeContractManifest({
-		...fallbackManifest,
-		schemas: {
-			...fallbackManifest.schemas,
-			runtimeBoundary: {
-				...fallbackManifest.schemas.runtimeBoundary,
-				profile: 'wp-codebox/runtime-profile/v2',
-			},
-		},
-	}),
-	/mismatch at schemas\.runtimeBoundary\.profile/
+  () => validateCanonicalRuntimeContractManifest({
+    ...canonicalManifest,
+    schemas: {
+      ...canonicalManifest.schemas,
+      runtimeBoundary: {
+        ...canonicalManifest.schemas.runtimeBoundary,
+        profile: undefined,
+      },
+    },
+  }),
+  /missing schemas\.runtimeBoundary\.profile/
 );
-
-const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hbe-codebox-runtime-contract-'));
-const canonicalModule = path.join(tempRoot, 'canonical-runtime-core.mjs');
-fs.writeFileSync(canonicalModule, `
-export function runtimeContractManifest() {
-  return ${JSON.stringify(fallbackManifest, null, 2)};
-}
-export const RUNTIME_CONTRACT_NORMALIZERS = {
-  runtimeProfile(input) { return { ...input, schema: 'wp-codebox/runtime-profile/v1' }; },
-};
-`);
 
 const canonical = await loadCanonicalRuntimeContractSource({ wpCodeboxCoreModule: canonicalModule, required: true });
 assert.equal(canonical.canonical, true);
 assert.equal(canonical.source, pathToFileURL(canonicalModule).href);
-assert.deepEqual(canonical.manifest, fallbackManifest);
+assert.deepEqual(canonical.manifest, canonicalManifest);
 assert.equal(typeof canonical.normalizers.runtimeProfile, 'function');
+
+const canonicalSync = loadCanonicalRuntimeContractSourceSync({ wpCodeboxCoreModule: canonicalModule, required: true });
+assert.equal(canonicalSync.canonical, true);
+assert.deepEqual(canonicalSync.manifest, canonicalManifest);
 
 const loaded = await loadRuntimeContractSource({ wpCodeboxCoreModule: canonicalModule });
 assert.equal(loaded.canonical, true);
+assert.deepEqual(loaded.manifest, canonicalManifest);
 
-const fallbackLoaded = await loadRuntimeContractSource({ wpCodeboxCoreModule: path.join(tempRoot, 'missing-runtime-core.mjs') });
-assert.equal(fallbackLoaded.canonical, false);
-assert.equal(fallbackLoaded.diagnostics[0].status, 'deprecated');
-assert.match(fallbackLoaded.diagnostics[0].replacement, /@automattic\/wp-codebox-core/);
+await assert.rejects(
+  () => loadRuntimeContractSource({ wpCodeboxCoreModule: path.join(tempRoot, 'missing-runtime-core.mjs') }),
+  /canonical runtime contract manifest is unavailable/
+);
+
+assert.throws(
+  () => loadCanonicalRuntimeContractSourceSync({ wpCodeboxCoreModule: path.join(tempRoot, 'missing-runtime-core.cjs'), required: true }),
+  /canonical runtime contract manifest is unavailable/
+);
 
 const installRoot = path.join(tempRoot, 'wp-codebox-install');
 const focusedContractsPath = path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'contracts.js');
@@ -130,19 +199,19 @@ assert.match(contractCandidates[5], /dist\/index\.js$/);
 const mismatchedModule = path.join(tempRoot, 'mismatched-runtime-core.mjs');
 fs.writeFileSync(mismatchedModule, `
 export function runtimeContractManifest() {
-  const manifest = ${JSON.stringify(fallbackManifest, null, 2)};
-  manifest.providerRuntime.tasks.workspaceCommand = 'wp-codebox.runner-workspace.command-v2';
+  const manifest = ${JSON.stringify(canonicalManifest, null, 2)};
+  delete manifest.providerRuntime.tasks.workspaceCommand;
   return manifest;
 }
 `);
 
 await assert.rejects(
-	() => loadCanonicalRuntimeContractSource({ wpCodeboxCoreModule: mismatchedModule, required: true }),
-	(error) => {
-		assert.match(error.message, /canonical runtime contract manifest is unavailable/);
-		assert.match(error.wpCodeboxRuntimeContractErrors[0].message, /providerRuntime\.tasks\.workspaceCommand/);
-		return true;
-	}
+  () => loadCanonicalRuntimeContractSource({ wpCodeboxCoreModule: mismatchedModule, required: true }),
+  (error) => {
+    assert.match(error.message, /canonical runtime contract manifest is unavailable/);
+    assert.match(error.wpCodeboxRuntimeContractErrors[0].message, /providerRuntime\.tasks\.workspaceCommand/);
+    return true;
+  }
 );
 
 console.log('wp-codebox runtime contract source smoke passed');

--- a/tests/wp-codebox-runtime-contract-source-smoke.mjs
+++ b/tests/wp-codebox-runtime-contract-source-smoke.mjs
@@ -188,6 +188,7 @@ const legacyIndexPath = path.join(installRoot, 'source', 'node_modules', '@autom
 fs.mkdirSync(path.dirname(focusedContractsPath), { recursive: true });
 fs.writeFileSync(focusedContractsPath, 'export function runtimeContractManifest() { return {}; }\n');
 fs.writeFileSync(legacyIndexPath, 'export function runtimeContractManifest() { return {}; }\n');
+delete process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE;
 const contractCandidates = coreModuleCandidates({ wpCodeboxInstallDir: installRoot });
 assert.equal(contractCandidates[0], '@automattic/wp-codebox-core/contracts');
 assert.equal(contractCandidates[1], 'wp-codebox-workspace/contracts');

--- a/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
+++ b/tests/wp-codebox-runtime-profile-defaults-smoke.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 const { codeboxTaskRequestFromAgentTaskRequest } = require(
 	path.join(rootDir, 'agent-runtimes', 'wp-codebox', 'lib', 'codebox-agent-task-executor.js')
 );


### PR DESCRIPTION
## Summary
- Remove Homeboy Extensions' hardcoded WP Codebox runtime contract fallback manifest and fail closed when the canonical Codebox public package contract is unavailable.
- Load runtime contract schemas/provider invocation from @automattic/wp-codebox-core or configured Codebox core module, including sync and async loader paths.
- Remove the copied provider runtime invocation block from the WP Codebox runtime manifest and update Codebox smoke tests to use an explicit canonical contract fixture.
- Keep generic runtime package docs domain-neutral and confirm runtime-agent-ci/lib has no direct wp-codebox import.

## Tests
- node tests/wp-codebox-runtime-contract-source-smoke.mjs && node tests/wp-codebox-adapter-boundary-smoke.mjs && node tests/wp-codebox-agent-runtime-command-contract-smoke.mjs && node tests/wp-codebox-adapter-contract-smoke.mjs && node tests/wp-codebox-run-agent-task-contract-smoke.mjs && node tests/wp-codebox-preview-materialization-contract-smoke.mjs && node tests/wp-codebox-provider-plugin-defaults-smoke.mjs && node tests/wp-codebox-artifact-contract-smoke.mjs && node tests/wp-codebox-runtime-profile-defaults-smoke.mjs && node tests/codebox-delegated-run-normalizer-smoke.mjs && node tests/generic-agent-runtime-boundary-smoke.mjs
- node --check agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js && node --check agent-runtimes/wp-codebox/index.js && node --check runtime-agent-ci/lib/runtime-agent-ci-plan.js
- git diff --check

## Notes
- Full top-level JS smoke sweep was not clean before/after this focused path: it reaches an unrelated deterministic-loop fixture assertion expecting homeboy/deterministic-loop-result/v1 while receiving homeboy/generic-deterministic-loop-output/v1.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the contract-source cleanup, updating focused tests, running verification, and drafting this PR description.