### PR TITLE
Stabilize WP Codebox fuzz suite contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ the upstream primitive requirement in the runtime profile for WP Codebox to
 fulfill through the public parent-tool-bridge contract.
 
 For WordPress fuzzing, Homeboy Extensions builds and forwards the
-Codebox-owned `wp-codebox/fuzz-run/v1` request through the WP Codebox runtime
+Codebox-owned `wp-codebox/fuzz-suite/v1` request through the WP Codebox runtime
 task boundary. HBX may describe WordPress targets, seeds, limits, coverage
 requests, and artifact expectations, but WP Codebox owns the fuzz execution
 loop and result envelope.

--- a/wordpress/lib/wp-codebox-fuzz-plan.js
+++ b/wordpress/lib/wp-codebox-fuzz-plan.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const WP_CODEBOX_WORKSPACE_RECIPE_SCHEMA = 'wp-codebox/workspace-recipe/v1';
-const WP_CODEBOX_FUZZ_RUN_SCHEMA = 'wp-codebox/fuzz-run/v1';
+const WP_CODEBOX_FUZZ_SUITE_SCHEMA = 'wp-codebox/fuzz-suite/v1';
+const WP_CODEBOX_FUZZ_RUN_SCHEMA = WP_CODEBOX_FUZZ_SUITE_SCHEMA;
 const WORDPRESS_FUZZ_PLAN_RECIPE_BUILDER_SCHEMA = 'homeboy/wordpress-fuzz-plan-recipe-builder/v1';
 const DEFAULT_WORKFLOW_STEP = { command: 'inspect-mounted-inputs' };
 const FUZZ_PHASES = ['setup', 'action', 'assert', 'teardown'];
@@ -190,6 +191,7 @@ function stripUndefined(value) {
 module.exports = {
 	WORDPRESS_FUZZ_PLAN_RECIPE_BUILDER_SCHEMA,
 	WP_CODEBOX_FUZZ_RUN_SCHEMA,
+	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
 	WP_CODEBOX_WORKSPACE_RECIPE_SCHEMA,
 	buildWpCodeboxFuzzPlanRecipe,
 };

--- a/wordpress/tests/wordpress-public-export-boundary.test.js
+++ b/wordpress/tests/wordpress-public-export-boundary.test.js
@@ -48,6 +48,8 @@ assert.equal(typeof wordpress.buildWpCodeboxFuzzPlanRecipe, 'function');
 assert.equal(typeof wordpress.wpCodeboxFuzzRunTaskRequest, 'function');
 assert.equal(typeof wordpress.wpCodeboxFuzzSuiteTaskRequest, 'function');
 assert.equal(wordpress.WP_CODEBOX_FUZZ_SUITE_SCHEMA, 'wp-codebox/fuzz-suite/v1');
+assert.equal(wordpress.WP_CODEBOX_FUZZ_RUN_SCHEMA, wordpress.WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+assert.equal(wordpress.wpCodebox.WP_CODEBOX_FUZZ_RUN_SCHEMA, wordpress.wpCodebox.WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 assert.equal(typeof wordpress.applyApprovedWpCodeboxArtifact, 'function');
 assert.equal(wordpress.compareCodeboxMemoryResults, undefined);
 assert.equal(wordpress.createStaticSiteFanoutPlan, undefined);

--- a/wordpress/tests/wp-codebox-fuzz-plan-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-plan-recipe-builder-smoke.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 
 const {
 	WP_CODEBOX_FUZZ_RUN_SCHEMA,
+	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
 	WP_CODEBOX_WORKSPACE_RECIPE_SCHEMA,
 	buildWpCodeboxFuzzPlanRecipe,
 } = require('../lib/wp-codebox-fuzz-plan');
@@ -34,6 +35,8 @@ const recipe = buildWpCodeboxFuzzPlanRecipe(plan);
 
 assert.equal(recipe.schema, WP_CODEBOX_WORKSPACE_RECIPE_SCHEMA);
 assert.equal(recipe.fuzzRun.schema, WP_CODEBOX_FUZZ_RUN_SCHEMA);
+assert.equal(recipe.fuzzRun.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+assert.equal(WP_CODEBOX_FUZZ_RUN_SCHEMA, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 assert.equal(recipe.fuzzRun.cases[0].case_id, 'case-001');
 assert.deepEqual(recipe.fuzzRun.cases[0].phases.action, [{
 	command: 'wordpress.wp-cli',
@@ -51,7 +54,9 @@ const result = spawnSync(process.execPath, [script], {
 });
 
 assert.equal(result.status, 0, result.stderr);
-assert.equal(JSON.parse(result.stdout).fuzzRun.cases[0].case_id, 'case-001');
+const cliRecipe = JSON.parse(result.stdout);
+assert.equal(cliRecipe.fuzzRun.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+assert.equal(cliRecipe.fuzzRun.cases[0].case_id, 'case-001');
 
 assert.throws(
 	() => buildWpCodeboxFuzzPlanRecipe({ cases: [{ case_id: 'missing-action', phases: { setup: [{ command: 'wordpress.wp-cli' }] } }] }),

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -33,6 +33,8 @@ const input = wpCodeboxFuzzRunInput({
 
 assert.equal(input.schema, WP_CODEBOX_FUZZ_RUN_SCHEMA);
 assert.equal(input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+assert.equal(WP_CODEBOX_FUZZ_RUN_SCHEMA, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+assert.equal(DEFAULT_FUZZ_RUN_ABILITY, DEFAULT_FUZZ_SUITE_ABILITY);
 assert.equal(input.target.slug, 'sample-plugin');
 assert.deepEqual(input.metadata.limits, { max_cases: 1 });
 assert.equal(wpCodeboxFuzzSuiteInput({ id: 'suite-alias' }).schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);


### PR DESCRIPTION
## Summary
- Canonicalize the WP Codebox fuzz plan recipe contract on `wp-codebox/fuzz-suite/v1`.
- Keep existing fuzz-run exports as aliases to the suite contract so current consumers resolve to the canonical schema.
- Add focused tests for plan recipes, task requests, and public exports to prevent `fuzz-run` / `fuzz-suite` drift.
- Update README contract language to document the suite request boundary.

## Tests
- `npm run test:wp-codebox-fuzz-plan-recipe-builder`
- `npm run test:wp-codebox-fuzz-run`
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wordpress-public-export-boundary`
- `npx eslint lib/wp-codebox-fuzz-plan.js`
- `git diff --check`

## Notes
- `npm run lint:js` was also run and fails on pre-existing unrelated lint errors outside this patch, including `lib/external-http-guardrail.js`, `lib/full-surface-coverage.js`, `lib/playground-readiness.js`, `lib/rest-route-matrix.js`, and several script dependency-group issues.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the fuzz contract cleanup, adding focused contract tests, running verification, and drafting this PR description.