### PR TITLE
Mount WP Codebox for fuzz runtime tasks

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -41,9 +41,9 @@ async function buildRunnerResult(env) {
 async function runWpCodeboxAgentTask(request) {
 	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-fuzz-'));
 	const inputFile = path.join(tempDir, 'agent-task-request.json');
-	fs.writeFileSync(inputFile, `${JSON.stringify(wpCodeboxRunAgentTaskInput(request), null, 2)}\n`);
-
 	const command = process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || 'wp-codebox';
+	fs.writeFileSync(inputFile, `${JSON.stringify(wpCodeboxRunAgentTaskInput(request, { wpCodeboxBin: command }), null, 2)}\n`);
+
 	const args = ['run-agent-task', '--input-file', inputFile, '--json'];
 	const result = await spawnJson(command, args, {
 		cwd: process.cwd(),
@@ -53,7 +53,7 @@ async function runWpCodeboxAgentTask(request) {
 	return { json: normalizeWpCodeboxAgentTaskOutput(result, request) };
 }
 
-function wpCodeboxRunAgentTaskInput(request) {
+function wpCodeboxRunAgentTaskInput(request, options = {}) {
 	return {
 		schema: 'wp-codebox/run-agent-task/v1',
 		id: request.task_id,
@@ -67,6 +67,7 @@ function wpCodeboxRunAgentTaskInput(request) {
 			},
 		},
 		runtime_task: request.executor?.config?.runtime_task,
+		extra_plugins: wpCodeboxRuntimePlugins(options.wpCodeboxBin),
 		allowed_tools: ['homeboy/no-runtime-tools'],
 		sandbox_tool_policy: denyAllSandboxToolPolicy(),
 		artifact_declarations: request.artifact_declarations,
@@ -76,6 +77,32 @@ function wpCodeboxRunAgentTaskInput(request) {
 			homeboy_agent_task_request: request,
 		},
 	};
+}
+
+function wpCodeboxRuntimePlugins(wpCodeboxBin) {
+	const source = wpCodeboxPluginSource(wpCodeboxBin);
+	if (!source) {
+		return [];
+	}
+	return [{
+		source,
+		slug: 'wp-codebox',
+		pluginFile: 'wp-codebox/wp-codebox.php',
+		activate: true,
+		loadAs: 'plugin',
+	}];
+}
+
+function wpCodeboxPluginSource(wpCodeboxBin) {
+	const explicit = process.env.HOMEBOY_WP_CODEBOX_PLUGIN_PATH || process.env.WP_CODEBOX_PLUGIN_PATH;
+	if (explicit && fs.existsSync(explicit)) {
+		return explicit;
+	}
+	if (!wpCodeboxBin || wpCodeboxBin === 'wp-codebox') {
+		return '';
+	}
+	const candidate = path.resolve(path.dirname(wpCodeboxBin), '../../wordpress-plugin');
+	return fs.existsSync(candidate) ? candidate : '';
 }
 
 function denyAllSandboxToolPolicy() {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -177,7 +177,10 @@ assert.equal(homeboyCampaign.schema, HOMEBOY_FUZZ_CAMPAIGN_SCHEMA);
 assert.equal(homeboyCampaign.id, 'cli-run');
 assert.equal(homeboyCampaign.metadata.diagnostics[0].code, 'wp_codebox_fuzz_suite_execution_unsupported');
 
-const fakeCodeboxBin = path.join(tempDir, 'fake-wp-codebox.js');
+const fakeCodeboxBin = path.join(tempDir, 'packages/cli/dist/fake-wp-codebox.js');
+fs.mkdirSync(path.dirname(fakeCodeboxBin), { recursive: true });
+fs.mkdirSync(path.join(tempDir, 'packages/wordpress-plugin'), { recursive: true });
+fs.writeFileSync(path.join(tempDir, 'packages/wordpress-plugin/wp-codebox.php'), '<?php // fixture');
 const dispatchResultsPath = path.join(tempDir, 'dispatch-results.json');
 fs.writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
@@ -189,6 +192,10 @@ if (request.schema !== 'wp-codebox/run-agent-task/v1' || !request.goal || !reque
 }
 if (request.sandbox_tool_policy?.schema !== 'wp-codebox/sandbox-tool-policy/v1' || request.sandbox_tool_policy?.version !== 1 || !request.sandbox_tool_policy?.tools?.length) {
   process.stderr.write('invalid sandbox tool policy');
+  process.exit(1);
+}
+if (!request.extra_plugins?.some((plugin) => plugin.slug === 'wp-codebox' && plugin.activate === true)) {
+  process.stderr.write('missing wp-codebox extra plugin');
   process.exit(1);
 }
 process.stdout.write(JSON.stringify({


### PR DESCRIPTION
## Summary
- Include the WP Codebox WordPress plugin as an `extra_plugins` entry for fuzz `run-agent-task` dispatches when the plugin source can be derived from `HOMEBOY_WP_CODEBOX_BIN`.
- Allow an explicit `HOMEBOY_WP_CODEBOX_PLUGIN_PATH` override.
- Extend the fuzz runner smoke fixture to prove `wp-codebox` is mounted and activated for runtime-task ability execution.

## Tests
- `npm run test:wordpress-fuzz-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the missing `wp-codebox/fuzz-suite` ability inside the sandbox, adding the plugin injection path, and updating regression coverage.
