### PR TITLE
Use canonical WP Codebox fuzz ability

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -200,7 +200,7 @@ function normalizeCodeboxResult(workload, context = {}) {
 			{
 				severity: 'warning',
 				code: 'wp_codebox_fuzz_suite_execution_unsupported',
-				message: 'WP Codebox exposes the public fuzz suite contract, but no merged execution API was available to this runner. Provide wp_codebox_suite_result in the workload or install a Codebox runtime that executes wp-codebox/fuzz-suite/v1.',
+				message: 'WP Codebox exposes the public fuzz suite contract, but no merged execution API was available to this runner. Provide wp_codebox_suite_result in the workload or install a Codebox runtime that executes wp-codebox/run-fuzz-suite.',
 			},
 		],
 	});

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -17,7 +17,7 @@ const WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA = 'wp-codebox/fuzz-suite-result/v1';
 const WP_CODEBOX_FUZZ_RUN_SCHEMA = WP_CODEBOX_FUZZ_SUITE_SCHEMA;
 const WP_CODEBOX_FUZZ_RUN_RESULT_SCHEMA = WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA;
 const WORDPRESS_CODEBOX_FUZZ_RUN_CONSUMER_SCHEMA = 'homeboy/wordpress-codebox-fuzz-run-consumer/v1';
-const DEFAULT_FUZZ_SUITE_ABILITY = 'wp-codebox/fuzz-suite';
+const DEFAULT_FUZZ_SUITE_ABILITY = 'wp-codebox/run-fuzz-suite';
 const DEFAULT_FUZZ_RUN_ABILITY = DEFAULT_FUZZ_SUITE_ABILITY;
 const DEFAULT_FUZZ_RUN_EXPECTED_ARTIFACTS = [
 	'wp-codebox-fuzz-suite-result',

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -74,7 +74,7 @@ assert.equal(result.seed, 'seed-123');
 assert.equal(result.max_duration_seconds, 30);
 assert.equal(result.wp_codebox_input.schema, 'wp-codebox/fuzz-suite/v1');
 assert.equal(result.wp_codebox_input.cases[0].target_id, 'rest-posts');
-assert.equal(result.wp_codebox_task_request.executor.config.runtime_task.ability, 'wp-codebox/fuzz-suite');
+assert.equal(result.wp_codebox_task_request.executor.config.runtime_task.ability, 'wp-codebox/run-fuzz-suite');
 assert.equal(result.wp_codebox_plan_recipe.fuzzRun.cases[0].case_id, 'get-posts');
 assert.equal(result.coverage.schema, 'homeboy/wordpress-fuzz-coverage-aggregate/v1');
 assert.equal(result.coverage.totals.exercised, 1);
@@ -117,7 +117,7 @@ const dispatchPromise = runWordPressFuzzRunnerResult({
 		dispatchedRequest = request;
 		assert.equal(request.task_id, 'dispatch-run');
 		assert.equal(request.executor.backend, 'codebox');
-		assert.equal(request.executor.config.runtime_task.ability, 'wp-codebox/fuzz-suite');
+		assert.equal(request.executor.config.runtime_task.ability, 'wp-codebox/run-fuzz-suite');
 		assert.equal(request.executor.config.runtime_task.input.schema, 'wp-codebox/fuzz-suite/v1');
 		assert.equal(request.executor.config.runtime_task.input.cases[0].target_id, 'rest-posts');
 		return {


### PR DESCRIPTION
## Summary
- Request the canonical WP Codebox fuzz ability, `wp-codebox/run-fuzz-suite`, from the WordPress fuzz dispatch path.
- Keep the existing `wp-codebox/fuzz-suite/v1` input and result schemas unchanged.
- Update focused fuzz runner assertions and fallback diagnostic text.

## Tests
- `npm run test:wp-codebox-fuzz-run`
- `npm run test:wordpress-fuzz-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the sandbox ability id mismatch, updating the HBX fuzz default ability, and refreshing regression coverage.
