### PR TITLE
Require public Codebox result envelopes

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -29,7 +29,7 @@ const {
 const {
   artifactResultEnvelopeFromCodeboxResult,
   artifactNameFromDeclaration,
-  artifactPath,
+  normalizeCodeboxPublicResultEnvelope,
   normalizeCodeboxArtifactDeclaration,
   normalizeCodeboxArtifactOutcome: normalizeCodeboxArtifactOutcomeContract,
   normalizeTypedArtifactEntry: normalizeCodeboxTypedArtifactEntry,
@@ -59,10 +59,6 @@ const {
 } = require('./wp-codebox-adapter-contract');
 const {
   WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
-  allowLegacyCodeboxResultCompatibility,
-  isCodeboxLegacyAgentTaskRunResult,
-  legacyAgentTaskRunEvidenceRefs,
-  legacyAgentTaskRunSessionArtifacts,
 } = require('./codebox-run-agent-task-contract');
 const {
   wpCodeboxBin,
@@ -794,7 +790,7 @@ function agentBundleRuntimeTaskInputWithArtifactOutputs(input, request, config, 
   for (const declaration of declarations) {
     const name = typedArtifactNameFromDeclaration(declaration);
     if (name && !engineDataOutputs[name]) {
-      engineDataOutputs[name] = `metadata.engine_data.outputs.typed_artifacts.${name}.payload`;
+      engineDataOutputs[name] = `outputs.typed_artifacts.${name}.payload`;
     }
   }
 
@@ -1884,10 +1880,14 @@ function agentBundleConfigFromAgentTaskRequest(request, config, inputs) {
 }
 
 function normalizeStatus(result, exitStatus = 0) {
+  const publicEnvelope = codeboxPublicResultEnvelope(result);
+  if (!publicEnvelope && privateCodeboxRuntimeResultShapeNames(result).length > 0) {
+    return 'failed';
+  }
   if (recipeRunFailedPhase(recipeRunFromResult(result))) {
     return 'failed';
   }
-  if (result?.outputs && typeof result.outputs === 'object' && result.outputs.success === false) {
+  if (publicEnvelope?.outputs && typeof publicEnvelope.outputs === 'object' && publicEnvelope.outputs.success === false) {
     return 'failed';
   }
   if (agentRuntimeFailure(result)) {
@@ -1914,55 +1914,64 @@ function normalizeStatus(result, exitStatus = 0) {
   if (result?.status === 'completed') {
     return result?.success === true ? 'succeeded' : 'failed';
   }
-  const agentResult = result?.run?.agentResult || result?.agentResult || result?.agent_result || result?.metadata?.recipe_run?.agentResult || result?.metadata?.recipe_run?.run?.agentResult;
-  const changedFileCount = agentResult?.changedFiles?.count;
-  const patchBytes = agentResult?.patch?.bytes;
-  if (result?.success === true && agentResult?.noOpReason && changedFileCount === 0 && patchBytes === 0) {
+  if (publicEnvelope?.success === true && publicEnvelope?.metadata?.no_op_reason) {
     return 'no_op';
   }
   if (result?.outcome === 'no_op' || result?.no_op) {
     return 'no_op';
   }
-  return result?.success === true ? 'succeeded' : 'failed';
+  return (publicEnvelope?.success ?? result?.success) === true ? 'succeeded' : 'failed';
+}
+
+function codeboxPublicResultEnvelope(result, options = {}) {
+  return options.publicResultEnvelope || options.public_result_envelope || normalizeCodeboxPublicResultEnvelope(result, options);
+}
+
+function privateCodeboxRuntimeResultShapeNames(result = {}) {
+  const names = [];
+  if (result?.run?.agentResult) {
+    names.push('run.agentResult');
+  }
+  if (result?.agentResult) {
+    names.push('agentResult');
+  }
+  if (result?.agent_result) {
+    names.push('agent_result');
+  }
+  if (result?.metadata?.agent_runtime) {
+    names.push('metadata.agent_runtime');
+  }
+  if (result?.engine_data || result?.metadata?.engine_data) {
+    names.push('engine_data');
+  }
+  return names;
+}
+
+function publicEnvelopeBoundaryDiagnostic(result, options = {}) {
+  if (codeboxPublicResultEnvelope(result, options)) {
+    return null;
+  }
+  const privateShapes = privateCodeboxRuntimeResultShapeNames(result);
+  if (privateShapes.length === 0) {
+    return null;
+  }
+  return {
+    class: 'codebox.public_result_envelope_missing',
+    message: 'WP Codebox result used private runtime fields without the canonical public artifact result envelope.',
+    data: {
+      required_schema: 'wp-codebox/artifact-result-envelope/v1',
+      private_shapes: privateShapes,
+    },
+  };
 }
 
 function agentRuntimeResultCandidates(result) {
-  const workload = agentRuntimeWorkload(result) || {};
-  const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
+  const publicEnvelope = codeboxPublicResultEnvelope(result);
   return [
-    result?.outputs?.agent_runtime?.result,
-    result?.outputs?.agent_runtime?.workload,
-    result?.outputs?.agent_runtime,
-    result?.raw?.agent_runtime,
-    result?.raw?.agent_runtime?.result,
-    result?.raw?.agent_runtime?.workload,
-    result?.metadata?.agent_runtime,
-    result?.metadata?.agent_runtime?.result,
-    result?.metadata?.agent_runtime?.workload,
-    result?.run?.agentResult,
-    result?.agentResult,
-    result?.agent_result,
-    result?.outputs,
-    workload,
-    workload.outputs,
-    ...scenarios,
-    ...scenarios.map((scenario) => scenario?.metadata),
-    ...scenarios.map((scenario) => scenario?.outputs),
+    publicEnvelope,
+    publicEnvelope?.outputs,
+    ...(Array.isArray(publicEnvelope?.diagnostics) ? publicEnvelope.diagnostics : []),
   ].filter((candidate) => candidate && typeof candidate === 'object' && !Array.isArray(candidate));
-}
-
-function agentRuntimeWorkload(result) {
-  return firstObject(
-    result?.outputs?.agent_runtime?.result,
-    result?.outputs?.agent_runtime?.workload,
-    result?.raw?.agent_runtime?.result,
-    result?.raw?.agent_runtime?.workload,
-    result?.metadata?.agent_runtime?.result,
-    result?.metadata?.agent_runtime?.workload,
-    result?.run?.agentResult,
-    result?.agentResult,
-    result?.agent_result,
-  );
 }
 
 function agentRuntimeFailure(result) {
@@ -2044,76 +2053,6 @@ function appendUniqueEvidenceRef(refs, ref) {
   refs.push(ref);
 }
 
-function codeboxBundleArtifacts(result) {
-  const artifacts = [];
-  const artifactRefs = Array.isArray(result.run?.artifactRefs) ? result.run.artifactRefs : [];
-  for (const ref of artifactRefs) {
-    appendUniqueArtifact(artifacts, {
-      id: ref.id || ref.digest?.value,
-      kind: ref.kind || 'codebox-artifact-bundle',
-      path: ref.directory,
-      sha256: ref.digest?.value,
-      metadata: { digest: ref.digest },
-    });
-  }
-
-  const completionOutcome = result.completionOutcome || result.completion_outcome || {};
-  const bundleDirectory = result.run?.agentResult?.artifacts?.directory || result.agent_result?.artifacts?.directory || completionOutcome?.provenance?.artifactDirectory || result.session?.artifacts?.path;
-  const artifactBundleId = completionOutcome?.provenance?.artifactBundleId || result.session?.artifacts?.bundle_id || result.artifacts?.id;
-  appendUniqueArtifact(artifacts, {
-    id: artifactBundleId,
-    kind: 'codebox-artifact-bundle',
-    path: bundleDirectory,
-    metadata: {
-      runtime_id: result.run?.runtime?.id,
-      runtime_status: result.run?.runtime?.status,
-    },
-  });
-
-  const agentResult = result.run?.agentResult || result.agentResult || result.agent_result || result.metadata?.recipe_run?.agentResult || {};
-  const changedFilesPath = artifactPath(bundleDirectory, agentResult.changedFiles?.artifact || '');
-  appendUniqueArtifact(artifacts, {
-    id: changedFilesPath ? 'codebox-changed-files' : '',
-    kind: 'codebox-changed-files',
-    path: changedFilesPath,
-    metadata: agentResult.changedFiles || {},
-  });
-
-  const patchPath = artifactPath(bundleDirectory, agentResult.patch?.artifact || '');
-  appendUniqueArtifact(artifacts, {
-    id: patchPath ? 'codebox-patch' : '',
-    kind: 'codebox-patch',
-    path: patchPath,
-    sha256: agentResult.patch?.sha256,
-    size_bytes: agentResult.patch?.bytes,
-    metadata: agentResult.patch || {},
-  });
-
-  const transcriptPath = artifactPath(bundleDirectory, agentResult.transcript?.artifact || '');
-  appendUniqueArtifact(artifacts, {
-    id: transcriptPath ? 'codebox-transcript' : '',
-    kind: 'codebox-transcript',
-    path: transcriptPath,
-    metadata: agentResult.transcript || {},
-  });
-
-  const runtimeLogPath = result.artifacts?.runtimeLogPath;
-  appendUniqueArtifact(artifacts, {
-    id: runtimeLogPath ? 'codebox-runtime-log' : '',
-    kind: 'codebox-runtime-log',
-    path: runtimeLogPath,
-  });
-
-  const commandsLogPath = result.artifacts?.commandsLogPath;
-  appendUniqueArtifact(artifacts, {
-    id: commandsLogPath ? 'codebox-command-log' : '',
-    kind: 'codebox-command-log',
-    path: commandsLogPath,
-  });
-
-  return artifacts;
-}
-
 function recipeRunFromResult(result) {
   return firstObject(
     result?.recipe_run,
@@ -2170,70 +2109,6 @@ function recipeRunFailureDiagnostic(recipeRun) {
   };
 }
 
-function appendRecipeArtifact(artifacts, artifact, fallbackKind, index) {
-  if (!artifact) {
-    return;
-  }
-  if (typeof artifact === 'string') {
-    appendUniqueArtifact(artifacts, {
-      id: artifact,
-      kind: fallbackKind,
-      path: artifact,
-    });
-    return;
-  }
-  appendUniqueArtifact(artifacts, {
-    id: artifact.id || artifact.name || artifact.path || artifact.url || `${fallbackKind}-${index + 1}`,
-    kind: artifact.kind || artifact.type || fallbackKind,
-    name: artifact.name,
-    path: artifact.path || artifact.file || artifact.directory,
-    url: artifact.url,
-    mime: artifact.mime,
-    size_bytes: artifact.size_bytes || artifact.sizeBytes,
-    sha256: artifact.sha256,
-    metadata: artifact.metadata || {},
-  });
-}
-
-function recipeRunArtifacts(result) {
-  const recipeRun = recipeRunFromResult(result);
-  if (!recipeRun || Object.keys(recipeRun).length === 0) {
-    return [];
-  }
-
-  const artifacts = [];
-  const startupLogs = [recipeRun.startup_log, recipeRun.startupLog, recipeRun.startup?.log, recipeRun.startup?.log_path, recipeRun.startup?.logPath].filter(Boolean);
-  startupLogs.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-startup-log', index));
-
-  const probeJson = [recipeRun.probe_json, recipeRun.probeJson, recipeRun.probe_results, recipeRun.probeResults, recipeRun.probe?.artifact, recipeRun.probe?.path].filter(Boolean);
-  probeJson.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-probe-json', index));
-
-  const probes = Array.isArray(recipeRun.probes) ? recipeRun.probes : [];
-  probes.forEach((probe, index) => {
-    appendRecipeArtifact(artifacts, probe.artifact || probe.path || probe.result_path || probe.resultPath, 'codebox-recipe-probe-json', index);
-    appendRecipeArtifact(artifacts, probe.screenshot || probe.screenshot_path || probe.screenshotPath, 'codebox-recipe-screenshot', index);
-  });
-
-  const screenshots = [
-    ...(Array.isArray(recipeRun.screenshots) ? recipeRun.screenshots : []),
-    ...(Array.isArray(recipeRun.browser_screenshots) ? recipeRun.browser_screenshots : []),
-    ...(Array.isArray(recipeRun.browserScreenshots) ? recipeRun.browserScreenshots : []),
-  ];
-  screenshots.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-screenshot', index));
-
-  const sideEffects = [recipeRun.fake_side_effects, recipeRun.fakeSideEffects, recipeRun.side_effects, recipeRun.sideEffects].filter(Boolean);
-  sideEffects.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-fake-side-effects', index));
-
-  const declaredArtifacts = [
-    ...(Array.isArray(recipeRun.artifacts) ? recipeRun.artifacts : []),
-    ...(Array.isArray(recipeRun.declared_artifacts) ? recipeRun.declared_artifacts : []),
-    ...(Array.isArray(recipeRun.declaredArtifacts) ? recipeRun.declaredArtifacts : []),
-  ];
-  declaredArtifacts.forEach((artifact, index) => appendRecipeArtifact(artifacts, artifact, 'codebox-recipe-artifact', index));
-
-  return artifacts;
-}
-
 function homeboyFailureClassification(classification, status) {
   return providerFailureClassification(classification, status);
 }
@@ -2267,36 +2142,19 @@ function typedArtifactsFromResult(result, options = {}) {
 }
 
 function codeboxAgentResultFromResult(result) {
-  return result.run?.agentResult || result.agentResult || result.agent_result || result.metadata?.recipe_run?.agentResult || {};
+  return codeboxPublicResultEnvelope(result)?.metadata || {};
 }
 
 function codeboxBundleDirectoryFromResult(result) {
-  const completionOutcome = result.completionOutcome || result.completion_outcome || {};
-  const agentResult = codeboxAgentResultFromResult(result);
-  return agentResult.artifacts?.directory
-    || completionOutcome?.provenance?.artifactDirectory
-    || result.session?.artifacts?.path
-    || result.session?.artifacts?.directory
-    || (typeof result.artifacts === 'string' ? result.artifacts : '')
-    || '';
+  const artifactBundle = codeboxPublicResultEnvelope(result)?.artifact_result?.artifactBundle;
+  return artifactBundle?.path || artifactBundle?.uri || '';
 }
 
 function firstTranscriptArtifactRefFromResult(result) {
-  const agentResult = codeboxAgentResultFromResult(result);
-  const directPath = artifactPath(codeboxBundleDirectoryFromResult(result), agentResult.transcript?.artifact || '');
-  if (directPath) {
-    return {
-      kind: 'codebox-transcript',
-      path: directPath,
-      mime: 'application/json',
-      metadata: agentResult.transcript || {},
-      schema: agentResult.transcript?.schema,
-    };
-  }
-
+  const publicEnvelope = codeboxPublicResultEnvelope(result);
   const candidates = [
-    ...(Array.isArray(result.artifacts) ? result.artifacts : Object.values(result.artifacts || {}).filter((value) => value && typeof value === 'object')),
-    ...agentRuntimeBundleArtifacts(result),
+    ...(publicEnvelope?.artifact_result?.artifactRefs || []),
+    ...(publicEnvelope?.artifact_result?.evidenceRefs || []),
   ];
   const transcriptArtifact = candidates
     .map((artifact) => artifactFromCodeboxArtifact(artifact))
@@ -2309,17 +2167,6 @@ function firstTranscriptArtifactRefFromResult(result) {
       mime: transcriptArtifact.mime || 'application/json',
       metadata: transcriptArtifact.metadata || {},
       schema: transcriptArtifact.metadata?.schema || transcriptArtifact.metadata?.artifact_schema,
-    };
-  }
-
-  const bundleDirectory = codeboxBundleDirectoryFromResult(result);
-  const fallbackPath = artifactPath(bundleDirectory, 'files/transcript.json');
-  if (fallbackPath && fs.existsSync(fallbackPath)) {
-    return {
-      kind: 'codebox-transcript',
-      path: fallbackPath,
-      mime: 'application/json',
-      metadata: { source: 'codebox_artifact_directory' },
     };
   }
 
@@ -2422,28 +2269,12 @@ function isTranscriptArtifactDeclaration(declaration) {
 }
 
 function replyTextFromResult(result) {
-  const workload = agentRuntimeWorkload(result) || {};
+  const publicEnvelope = codeboxPublicResultEnvelope(result) || {};
   const candidates = [
-    result?.reply,
-    result?.result?.reply,
-    result?.outputs?.reply,
-    result?.outputs?.text,
-    result?.outputs?.content,
-    result?.run?.agentResult?.reply,
-    result?.run?.agentResult?.result?.reply,
-    result?.run?.agentResult?.metadata?.result?.reply,
-    result?.agentResult?.reply,
-    result?.agentResult?.result?.reply,
-    result?.agentResult?.metadata?.result?.reply,
-    result?.agent_result?.reply,
-    result?.agent_result?.result?.reply,
-    result?.agent_result?.metadata?.result?.reply,
-    result?.metadata?.agent_runtime?.workload?.reply,
-    result?.metadata?.agent_runtime?.workload?.result?.reply,
-    result?.metadata?.agent_runtime?.workload?.metadata?.result?.reply,
-    workload.reply,
-    workload.result?.reply,
-    workload.metadata?.result?.reply,
+    publicEnvelope.reply,
+    publicEnvelope.outputs?.reply,
+    publicEnvelope.outputs?.text,
+    publicEnvelope.outputs?.content,
     replyTextFromResultExecutions(result),
     replyTextFromTranscriptArtifact(result),
   ];
@@ -2601,30 +2432,6 @@ function outputsWithInputTypedArtifacts(outputs, request) {
   return added ? { ...outputs, typed_artifacts: typedArtifacts } : outputs;
 }
 
-function typedBundleOutputArtifacts(result, options = {}) {
-  return Object.values(typedArtifactsFromResult(result, options)).flatMap((typedArtifact) => typedArtifactFileRefs(typedArtifact).map((ref, index) => {
-    const fileRef = typeof ref === 'string' ? { path: ref } : ref;
-    if (!fileRef || typeof fileRef !== 'object') {
-      return null;
-    }
-    return {
-      id: fileRef.id || `${typedArtifact.name}-${index + 1}`,
-      kind: 'typed-bundle-output',
-      name: typedArtifact.name,
-      path: fileRef.path || fileRef.file || fileRef.directory,
-      url: fileRef.url,
-      mime: fileRef.mime,
-      sha256: fileRef.sha256,
-      metadata: {
-        type: typedArtifact.type,
-        artifact_schema: typedArtifact.artifact_schema,
-        provenance: typedArtifact.provenance,
-        file_ref: fileRef,
-      },
-    };
-  }).filter(Boolean));
-}
-
 function artifactFromCodeboxArtifact(artifact, index) {
   const normalized = agentTaskArtifactFromRef(
     {
@@ -2654,7 +2461,10 @@ function firstPlainObject(...candidates) {
 }
 
 function normalizeOutputs(result, request = null, options = {}) {
-  const workload = agentRuntimeWorkload(result) || {};
+  const publicEnvelope = codeboxPublicResultEnvelope(result, options) || {};
+  const publicOutputs = publicEnvelope.outputs && typeof publicEnvelope.outputs === 'object' && !Array.isArray(publicEnvelope.outputs)
+    ? publicEnvelope.outputs
+    : {};
   const typedArtifacts = typedArtifactsFromResult(result, options);
   Object.assign(typedArtifacts, transcriptTypedArtifactsFromCodeboxResult(request, result, typedArtifacts));
   if (request) {
@@ -2673,30 +2483,15 @@ function normalizeOutputs(result, request = null, options = {}) {
       }
     : outputs;
 
-  const bundle = result.metadata?.agent_runtime?.bundle || result.task_input?.agent_bundle || {};
+  const bundle = result.task_input?.agent_bundle || {};
   const configuredOutputs = firstPlainObject(bundle.runtime_output_projections, bundle.runtimeOutputProjections, bundle.engine_data_outputs, bundle.engineDataOutputs) || {};
-  if (Object.keys(configuredOutputs).length === 0 && workload.outputs && typeof workload.outputs === 'object' && !Array.isArray(workload.outputs)) {
-    return sanitizePublicMetadata(appendTypedArtifacts(workload.outputs));
+  if (Object.keys(configuredOutputs).length === 0) {
+    return sanitizePublicMetadata(appendTypedArtifacts(publicOutputs));
   }
-  if (Object.keys(configuredOutputs).length === 0 && result.outputs && typeof result.outputs === 'object' && !Array.isArray(result.outputs)) {
-    return sanitizePublicMetadata(appendTypedArtifacts(result.outputs));
-  }
-  const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
   const configuredOutputSources = [
-    ...scenarios,
-    ...scenarios.map((scenario) => scenario?.metadata),
-    ...scenarios.map((scenario) => scenario?.outputs),
-    result.run?.agentResult,
-    result.agentResult,
-    result.agent_result,
-    result.metadata?.agent_runtime?.result,
-    result.outputs,
-    result.run?.agentResult?.outputs,
-    result.agentResult?.outputs,
-    result.agent_result?.outputs,
-    result.metadata?.agent_runtime?.result?.outputs,
-    workload,
-    workload.outputs,
+    publicEnvelope,
+    publicOutputs,
+    publicEnvelope.artifact_result?.result,
   ].filter((source) => source && typeof source === 'object' && !Array.isArray(source));
   const outputSources = configuredOutputSources.flatMap((source) => [source, { metadata: source }]);
   const outputs = {};
@@ -2713,10 +2508,7 @@ function normalizeOutputs(result, request = null, options = {}) {
       }
     }
   }
-  const fallbackOutputs = workload.outputs && typeof workload.outputs === 'object' && !Array.isArray(workload.outputs)
-    ? workload.outputs
-    : result.outputs || {};
-  return sanitizePublicMetadata(appendTypedArtifacts(Object.keys(outputs).length > 0 ? outputs : fallbackOutputs));
+  return sanitizePublicMetadata(appendTypedArtifacts(Object.keys(outputs).length > 0 ? outputs : publicOutputs));
 }
 
 function outputEvidenceRefs(outputs) {
@@ -2820,110 +2612,11 @@ function normalizeArtifacts(result, runSummary = null, recipeSummary = null, opt
     recipeSummary.artifacts.map(artifactFromCodeboxArtifact).forEach((artifact) => appendUniqueArtifact(normalizedArtifacts, artifact));
   }
 
-  if (isCodeboxLegacyAgentTaskRunResult(result) && allowLegacyCodeboxResultCompatibility(options)) {
-    const artifacts = [...normalizedArtifacts];
-    legacyAgentTaskRunSessionArtifacts(result).forEach((artifact) => appendUniqueArtifact(artifacts, artifact));
-    if (Array.isArray(result.artifacts)) {
-      result.artifacts.map(artifactFromCodeboxArtifact).forEach((artifact) => appendUniqueArtifact(artifacts, artifact));
-    }
-    if (!artifactResult) {
-      for (const artifact of codeboxBundleArtifacts(result)) {
-        appendUniqueArtifact(artifacts, artifact);
-      }
-      for (const artifact of agentRuntimeBundleArtifacts(result)) {
-        appendUniqueArtifact(artifacts, artifact);
-      }
-      for (const artifact of typedBundleOutputArtifacts(result, options)) {
-        appendUniqueArtifact(artifacts, artifact);
-      }
-      if (!recipeSummary) {
-        for (const artifact of recipeRunArtifacts(result)) {
-          appendUniqueArtifact(artifacts, artifact);
-        }
-      }
-    }
-    return artifacts.map(artifactFromCodeboxArtifact);
-  }
-  const artifacts = Array.isArray(result?.artifacts)
-    ? result.artifacts
-    : Object.values(result?.artifacts || {}).filter((value) => value && typeof value === 'object');
-  const mappedArtifacts = [...normalizedArtifacts];
-  artifacts.map(artifactFromCodeboxArtifact).forEach((artifact) => appendUniqueArtifact(mappedArtifacts, artifact));
-  return mappedArtifacts;
+  return normalizedArtifacts;
 }
 
 function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null, options = {}) {
   const artifactResult = artifactResultEnvelopeFromCodeboxResult(result, options);
-  if (isCodeboxLegacyAgentTaskRunResult(result) && allowLegacyCodeboxResultCompatibility(options)) {
-    const refs = legacyAgentTaskRunEvidenceRefs(result);
-    for (const artifact of artifactResult?.artifactRefs || []) {
-      appendUniqueEvidenceRef(refs, {
-        kind: artifact.kind,
-        uri: artifact.uri || artifact.path || artifact.url,
-        label: artifact.name || artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
-      });
-    }
-    for (const evidenceRef of artifactResult?.evidenceRefs || []) {
-      appendUniqueEvidenceRef(refs, {
-        kind: evidenceRef.kind,
-        uri: evidenceRef.uri || evidenceRef.path || evidenceRef.url,
-        label: evidenceRef.name || evidenceRef.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
-      });
-    }
-    if (!artifactResult) {
-      for (const artifact of codeboxBundleArtifacts(result)) {
-        appendUniqueEvidenceRef(refs, {
-          kind: artifact.kind,
-          uri: artifact.path || artifact.url,
-          label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
-        });
-      }
-      for (const artifact of agentRuntimeBundleArtifacts(result)) {
-        appendUniqueEvidenceRef(refs, {
-          kind: artifact.kind,
-          uri: artifact.path || artifact.url,
-          label: artifact.kind.replace(/^agent-runtime-/, 'Agent runtime ').replace(/-/g, ' '),
-        });
-      }
-      for (const artifact of typedBundleOutputArtifacts(result, options)) {
-        appendUniqueEvidenceRef(refs, {
-          kind: artifact.kind,
-          uri: artifact.path || artifact.url,
-          label: `Typed bundle output ${artifact.name || ''}`.trim(),
-        });
-      }
-      if (!recipeSummary) {
-        for (const artifact of recipeRunArtifacts(result)) {
-          appendUniqueEvidenceRef(refs, {
-            kind: artifact.kind,
-            uri: artifact.path || artifact.url,
-            label: artifact.kind.replace(/^codebox-recipe-/, 'WP Codebox recipe ').replace(/-/g, ' '),
-          });
-        }
-      }
-    }
-    for (const artifact of runSummary?.artifacts || []) {
-      appendUniqueEvidenceRef(refs, {
-        kind: artifact.kind,
-        uri: artifact.path || artifact.url,
-        label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
-      });
-    }
-    for (const artifact of recipeSummary?.artifacts || []) {
-      appendUniqueEvidenceRef(refs, {
-        kind: artifact.kind,
-        uri: artifact.path || artifact.url,
-        label: artifact.kind.replace(/^codebox-/, 'WP Codebox ').replace(/-/g, ' '),
-      });
-    }
-    for (const ref of outputEvidenceRefs(normalizeOutputs(result))) {
-      appendUniqueEvidenceRef(refs, ref);
-    }
-    for (const ref of result?.evidence_refs || result?.evidence || []) {
-      appendUniqueEvidenceRef(refs, agentTaskEvidenceRefFromRef(ref, 'codebox_evidence'));
-    }
-    return refs;
-  }
   const evidenceRefs = [
     ...(artifactResult?.artifactRefs || []).map((artifact) => ({
       kind: artifact.kind,
@@ -2935,64 +2628,24 @@ function normalizeEvidenceRefs(result, runSummary = null, recipeSummary = null, 
       uri: ref.uri || ref.path || ref.url,
       label: ref.name || ref.kind,
     })),
-    ...(result?.evidence_refs || result?.evidence || []),
+    ...(runSummary?.artifacts || []).map((artifact) => ({
+      kind: artifact.kind,
+      uri: artifact.path || artifact.url,
+      label: artifact.name || artifact.kind,
+    })),
+    ...(recipeSummary?.artifacts || []).map((artifact) => ({
+      kind: artifact.kind,
+      uri: artifact.path || artifact.url,
+      label: artifact.name || artifact.kind,
+    })),
   ];
   return evidenceRefs.map((ref) => agentTaskEvidenceRefFromRef(ref, 'codebox_evidence')).filter((ref) => ref.uri);
 }
 
-function agentRuntimeBundleArtifacts(result) {
-  const artifacts = [];
-  const workload = agentRuntimeWorkload(result) || {};
-  const scenarios = Array.isArray(workload.scenarios) ? workload.scenarios : [];
-  for (const scenario of scenarios) {
-    const metadata = scenario?.metadata || {};
-    const transcript = metadata.transcript_artifacts || {};
-    appendUniqueArtifact(artifacts, {
-      id: transcript.json ? 'agent-runtime-transcript-json' : '',
-      kind: 'agent-runtime-transcript',
-      path: transcript.json,
-      metadata: { scenario_id: scenario.id, format: 'json' },
-    });
-    appendUniqueArtifact(artifacts, {
-      id: transcript.summary ? 'agent-runtime-transcript-summary' : '',
-      kind: 'agent-runtime-transcript-summary',
-      path: transcript.summary,
-      metadata: { scenario_id: scenario.id, format: 'markdown' },
-    });
-    const replayBundlePath = metadata.replay_bundle_path || metadata.replay_bundle?.path;
-    appendUniqueArtifact(artifacts, {
-      id: replayBundlePath ? 'agent-runtime-replay-bundle' : '',
-      kind: 'agent-runtime-replay-bundle',
-      path: replayBundlePath,
-      metadata: { scenario_id: scenario.id },
-    });
-    const exports = Array.isArray(metadata.job_artifact_exports) ? metadata.job_artifact_exports : [];
-    for (const [index, exported] of exports.entries()) {
-      appendUniqueArtifact(artifacts, {
-        id: exported.id || exported.path || `agent-runtime-job-artifact-${index + 1}`,
-        kind: exported.kind || 'agent-runtime-job-artifact',
-        path: exported.path,
-        url: exported.url,
-        metadata: { ...exported, scenario_id: scenario.id },
-      });
-    }
-    const runnerPublicationUrl = Array.isArray(metadata.engine_data?.runner_publications)
-      ? metadata.engine_data.runner_publications.find((publication) => publication?.url)?.url
-      : '';
-    const pullRequestUrl = metadata.runner_workspace_publication?.url || metadata.runner_workspace_publication?.html_url || metadata.runner_workspace_publication?.result?.url || metadata.runner_workspace_publication?.result?.html_url || runnerPublicationUrl || metadata.engine_data?.pull_request?.url || metadata.engine_data?.static_site_agent?.pr_url;
-    appendUniqueArtifact(artifacts, {
-      id: pullRequestUrl ? 'agent-runtime-pull-request' : '',
-      kind: 'agent-runtime-pull-request',
-      url: pullRequestUrl,
-      metadata: { scenario_id: scenario.id },
-    });
-  }
-  return artifacts;
-}
-
 function codeboxDecisionEvidence(result, runSummary = null, recipeSummary = null, options = {}) {
   const artifactResult = artifactResultEnvelopeFromCodeboxResult(result, options);
-  const agentResult = result.run?.agentResult || result.agentResult || result.agent_result || result.metadata?.recipe_run?.agentResult || result.metadata?.recipe_run?.run?.agentResult || {};
+  const publicEnvelope = codeboxPublicResultEnvelope(result, options) || {};
+  const publicMetadata = publicEnvelope.metadata || {};
   const completionOutcome = result.completionOutcome || result.completion_outcome || result.metadata?.recipe_run?.completionOutcome || {};
   const runtime = result.run?.runtime || result.metadata?.recipe_run?.run?.runtime || {};
   const run = result.run || result.metadata?.recipe_run?.run || {};
@@ -3009,10 +2662,10 @@ function codeboxDecisionEvidence(result, runSummary = null, recipeSummary = null
     runtime_status: runSummary?.metadata?.runtime_status || runtime.status,
     heartbeat_at: run.heartbeatAt,
     cleanup_observed: (runSummary?.metadata?.runtime_status || runtime.status) === 'destroyed' ? 'runtime_destroyed' : '',
-    changed_files_count: runSummary?.metadata?.changed_files_count ?? agentResult.changedFiles?.count,
-    patch_bytes: runSummary?.metadata?.patch_bytes ?? agentResult.patch?.bytes,
-    patch_sha256: runSummary?.metadata?.patch_sha256 || agentResult.patch?.sha256,
-    no_op_reason: runSummary?.metadata?.no_op_reason || agentResult.noOpReason,
+    changed_files_count: runSummary?.metadata?.changed_files_count ?? publicMetadata.changed_files_count,
+    patch_bytes: runSummary?.metadata?.patch_bytes ?? publicMetadata.patch_bytes,
+    patch_sha256: runSummary?.metadata?.patch_sha256 || publicMetadata.patch_sha256,
+    no_op_reason: runSummary?.metadata?.no_op_reason || publicMetadata.no_op_reason,
     completion_status: runSummary?.metadata?.completion_status || completionOutcome.status,
     completion_next_action: runSummary?.metadata?.completion_next_action || completionOutcome.nextAction,
     confidence: runSummary?.metadata?.confidence || completionOutcome.confidence,
@@ -3078,8 +2731,10 @@ function providerNotRegisteredDiagnostic(request, result = {}) {
 
 function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   assertAgentTaskRequest(request);
-  const runSummary = codeboxRunSummary(result, options);
-  const recipeSummary = codeboxRecipeRunSummary(result, options);
+  const publicResultEnvelope = codeboxPublicResultEnvelope(result, options);
+  const envelopeOptions = { ...options, publicResultEnvelope };
+  const runSummary = codeboxRunSummary(result, envelopeOptions);
+  const recipeSummary = codeboxRecipeRunSummary(result, envelopeOptions);
   const localStatus = normalizeStatus(result, options.exitStatus ?? 0);
   let status = runSummary?.status || recipeSummary?.status || localStatus;
   if (recipeSummary?.status && recipeSummary.status !== 'succeeded') {
@@ -3088,10 +2743,11 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     status = localStatus;
   }
   const failureClassification = homeboyFailureClassification(result.failure_classification || recipeSummary?.metadata?.failure_classification || runSummary?.failure_classification, status);
-  const outputs = outputsWithInputTypedArtifacts(normalizeOutputs(result, request, options), request);
+  const outputs = outputsWithInputTypedArtifacts(normalizeOutputs(result, request, envelopeOptions), request);
   const missingRequiredTypedArtifacts = missingRequiredTypedArtifactDiagnostic(request, outputs);
   const invalidRequiredTypedArtifacts = invalidRequiredTypedArtifactDiagnostic(request, outputs);
   const runtimeFailureDiagnostic = agentRuntimeFailureDiagnostic(result);
+  const envelopeBoundaryDiagnostic = publicEnvelopeBoundaryDiagnostic(result, envelopeOptions);
   if (status === 'succeeded' && missingRequiredTypedArtifacts) {
     status = 'failed';
   }
@@ -3099,6 +2755,9 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     status = 'failed';
   }
   if (status === 'succeeded' && runtimeFailureDiagnostic) {
+    status = 'failed';
+  }
+  if (envelopeBoundaryDiagnostic) {
     status = 'failed';
   }
   const recipeRun = recipeRunFromResult(result);
@@ -3111,11 +2770,11 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
     providerLabel: 'WP Codebox agent',
     integrationContract: WP_CODEBOX_RUN_AGENT_TASK_REQUEST_SCHEMA,
     status,
-    summary: missingRequiredTypedArtifacts?.message || invalidRequiredTypedArtifacts?.message || runtimeFailureDiagnostic?.message || recipeSummary?.failure_summary || fallbackRecipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
-    artifacts: normalizeArtifacts(result, runSummary, recipeSummary, options),
-    evidenceRefs: normalizeEvidenceRefs(result, runSummary, recipeSummary, options),
+    summary: envelopeBoundaryDiagnostic?.message || missingRequiredTypedArtifacts?.message || invalidRequiredTypedArtifacts?.message || runtimeFailureDiagnostic?.message || recipeSummary?.failure_summary || fallbackRecipeSummary || runSummary?.summary || result.summary || result.message || (status === 'succeeded' ? 'WP Codebox agent task succeeded.' : 'WP Codebox agent task failed.'),
+    artifacts: normalizeArtifacts(result, runSummary, recipeSummary, envelopeOptions),
+    evidenceRefs: normalizeEvidenceRefs(result, runSummary, recipeSummary, envelopeOptions),
     outputs,
-    diagnostics: [providerDiagnostic, missingRequiredTypedArtifacts, invalidRequiredTypedArtifacts, runtimeFailureDiagnostic, recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
+    diagnostics: [providerDiagnostic, envelopeBoundaryDiagnostic, missingRequiredTypedArtifacts, invalidRequiredTypedArtifacts, runtimeFailureDiagnostic, recipeSummary ? null : recipeRunFailureDiagnostic(recipeRun), ...(recipeSummary?.diagnostics || []), ...(runSummary?.diagnostics || []), ...(result.diagnostics || [])].filter(Boolean).map((diagnostic) => ({
       class: diagnostic.class || diagnostic.kind || 'codebox',
       message: diagnostic.message || String(diagnostic),
       data: sanitizePublicMetadata(diagnostic.data || {}),
@@ -3124,7 +2783,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
       codebox: sanitizePublicMetadata(result.metadata || result),
       codebox_run_result: runSummary ? sanitizePublicMetadata(runSummary) : undefined,
       codebox_recipe_run_summary: recipeSummary ? sanitizePublicMetadata(recipeSummary) : undefined,
-      decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result, runSummary, recipeSummary, options)),
+      decision_evidence: sanitizePublicMetadata(codeboxDecisionEvidence(result, runSummary, recipeSummary, envelopeOptions)),
       artifact_declarations: sanitizePublicMetadata(artifactDeclarationsMetadataFromRequest(request)),
       typed_artifacts: sanitizePublicMetadata(outputs.typed_artifacts || {}),
       sandbox_policy: sanitizePublicMetadata({
@@ -3137,7 +2796,7 @@ function agentTaskOutcomeFromCodeboxResult(request, result = {}, options = {}) {
   });
   if (failureClassification) {
     outcome.failure_classification = failureClassification;
-  } else if (missingRequiredTypedArtifacts || invalidRequiredTypedArtifacts) {
+  } else if (envelopeBoundaryDiagnostic || missingRequiredTypedArtifacts || invalidRequiredTypedArtifacts) {
     outcome.failure_classification = 'execution_failed';
   }
   return outcomeWithOutputTypedArtifacts(outcome, outputs);

--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -7,12 +7,6 @@ const TYPED_ARTIFACT_SCHEMA = 'homeboy/agent-task-typed-artifact/v1';
 const {
   runtimeContractSchemas,
 } = require('./wp-codebox-runtime-contract-source');
-const {
-  allowLegacyCodeboxResultCompatibility,
-  legacyArtifactResultEnvelopeCandidates,
-  legacyTypedArtifactCandidatesFromCodeboxResult,
-} = require('./codebox-legacy-result-adapter');
-
 const RUNTIME_CONTRACT_SCHEMAS = runtimeContractSchemas();
 
 const WP_CODEBOX_ARTIFACT_DECLARATION_SCHEMA = 'wp-codebox/artifact-declaration/v1';
@@ -87,19 +81,8 @@ function normalizeTypedArtifacts(value, options = {}) {
 }
 
 function typedArtifactsFromCodeboxResult(result, options = {}) {
-  const workload = options.workload || agentRuntimeWorkload(result) || {};
   const artifactResult = artifactResultEnvelopeFromCodeboxResult(result, options);
-  const envelopeArtifacts = typedArtifactsFromArtifactResultEnvelope(artifactResult, options);
-  if (Object.keys(envelopeArtifacts).length > 0) {
-    return envelopeArtifacts;
-  }
-
-  if (!allowLegacyCodeboxResultCompatibility(options)) {
-    return {};
-  }
-
-  return Object.assign({}, ...legacyTypedArtifactCandidatesFromCodeboxResult(result, workload)
-    .map((candidate) => normalizeTypedArtifacts(candidate, options)));
+  return typedArtifactsFromArtifactResultEnvelope(artifactResult, options);
 }
 
 function normalizeWithCoreTypedArtifactNormalizer(normalizer, name, artifact, options = {}) {
@@ -131,14 +114,6 @@ function caseArtifactIndexFromCodeboxResult(result, options = {}) {
   return normalizeCaseArtifactIndex({
     schema: WP_CODEBOX_CASE_ARTIFACT_INDEX_SCHEMA,
     caseRefs: [
-      ...caseRefsFromCaseArtifactCandidates(result),
-      ...caseRefsFromCaseArtifactCandidates(result?.outputs),
-      ...caseRefsFromCaseArtifactCandidates(result?.run),
-      ...caseRefsFromCaseArtifactCandidates(result?.run?.agentResult),
-      ...caseRefsFromCaseArtifactCandidates(result?.agentResult),
-      ...caseRefsFromCaseArtifactCandidates(result?.agent_result),
-      ...caseRefsFromCaseArtifactCandidates(result?.metadata),
-      ...caseRefsFromCaseArtifactCandidates(result?.metadata?.agent_runtime?.result),
       ...caseRefsFromCaseArtifactCandidates(artifactResult),
       ...caseRefsFromCaseArtifactCandidates(artifactResult?.result),
       ...caseRefsFromCaseArtifactCandidates(artifactResult?.result?.outputs),
@@ -352,11 +327,47 @@ function artifactResultEnvelopeFromCodeboxResult(result, options = {}) {
     result?.artifactResult,
     result?.metadata?.artifact_result,
     result?.metadata?.artifactResult,
-    ...(Array.isArray(result?.projections) ? result.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection?.artifactResult || projection) : []),
-    ...(Array.isArray(result?.metadata?.projections) ? result.metadata.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection?.artifactResult || projection) : []),
-    ...legacyArtifactResultEnvelopeCandidates(result),
-  ] : [];
-  return [...candidates, ...legacyCandidates].map(normalizeArtifactResultEnvelope).find(Boolean) || null;
+		...(Array.isArray(result?.projections) ? result.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection?.artifactResult || projection) : []),
+		...(Array.isArray(result?.metadata?.projections) ? result.metadata.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection?.artifactResult || projection) : []),
+		...legacyArtifactResultEnvelopeCandidates(result),
+	] : [];
+	return [...candidates, ...legacyCandidates].map(normalizeArtifactResultEnvelope).find(Boolean) || null;
+}
+
+function normalizeCodeboxPublicResultEnvelope(result, options = {}) {
+  const artifactResult = artifactResultEnvelopeFromCodeboxResult(result, options);
+  if (!artifactResult) {
+    return null;
+  }
+  const payload = plainObject(artifactResult.result) ? artifactResult.result : {};
+  const outputs = plainObject(payload.outputs) ? payload.outputs : {};
+  const metadata = plainObject(artifactResult.metadata) ? artifactResult.metadata : {};
+  return cleanObject({
+    schema: 'wp-codebox/public-result-envelope/v1',
+    artifact_result: artifactResult,
+    status: payload.status || artifactResult.status,
+    success: payload.success === undefined ? artifactResult.success : payload.success === true,
+    summary: payload.summary || payload.message || artifactResult.reason,
+    message: payload.message,
+    error_message: payload.error_message || payload.errorMessage,
+    error_reason: payload.error_reason || payload.errorReason,
+    error_step_id: payload.error_step_id || payload.errorStepId,
+    terminal_status: payload.terminal_status || payload.terminalStatus,
+    completion_outcome: payload.completion_outcome || payload.completionOutcome,
+    reply: firstString(payload.reply, payload.text, outputs.reply, outputs.text, outputs.content),
+    outputs,
+    artifacts: artifactResult.artifactRefs || [],
+    evidence_refs: artifactResult.evidenceRefs || [],
+    diagnostics: [
+      ...(Array.isArray(payload.diagnostics) ? payload.diagnostics : []),
+      ...(Array.isArray(artifactResult.diagnostics) ? artifactResult.diagnostics : []),
+    ],
+    metadata,
+  });
+}
+
+function firstString(...values) {
+	return values.find((value) => typeof value === 'string' && value.trim() !== '');
 }
 
 function normalizeArtifactResultEnvelope(envelope) {
@@ -506,10 +517,6 @@ function artifactNameFromDeclaration(declaration) {
     return '';
   }
   return declaration.name || declaration.id || '';
-}
-
-function agentRuntimeWorkload(result = {}) {
-  return result.workload || result.metadata?.workload || result.metadata?.agent_runtime?.workload || result.run?.workload || {};
 }
 
 function artifactPath(root, relativePath) {
@@ -749,6 +756,7 @@ module.exports = {
   discoverCodeboxArtifactRefs,
   normalizeCodeboxArtifactDeclaration,
   normalizeCodeboxArtifactOutcome,
+  normalizeCodeboxPublicResultEnvelope,
   normalizeArtifactResultEnvelope,
   normalizeCaseArtifactIndex,
   normalizeTypedArtifactEntry,

--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -5,7 +5,7 @@ const path = require('node:path');
 
 const TYPED_ARTIFACT_SCHEMA = 'homeboy/agent-task-typed-artifact/v1';
 const {
-  runtimeContractSchemas,
+	runtimeContractSchemas,
 } = require('./wp-codebox-runtime-contract-source');
 const RUNTIME_CONTRACT_SCHEMAS = runtimeContractSchemas();
 
@@ -318,20 +318,12 @@ function typedArtifactsFromArtifactResultEnvelope(artifactResult, options = {}) 
   return Object.assign({}, ...candidates.map((candidate) => normalizeTypedArtifacts(candidate, options)));
 }
 
-function artifactResultEnvelopeFromCodeboxResult(result, options = {}) {
-  const candidates = [
-    result,
-    result?.artifact_result,
-  ];
-  const legacyCandidates = allowLegacyCodeboxResultCompatibility(options) ? [
-    result?.artifactResult,
-    result?.metadata?.artifact_result,
-    result?.metadata?.artifactResult,
-		...(Array.isArray(result?.projections) ? result.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection?.artifactResult || projection) : []),
-		...(Array.isArray(result?.metadata?.projections) ? result.metadata.projections.map((projection) => projection?.envelope || projection?.artifact_result || projection?.artifactResult || projection) : []),
-		...legacyArtifactResultEnvelopeCandidates(result),
-	] : [];
-	return [...candidates, ...legacyCandidates].map(normalizeArtifactResultEnvelope).find(Boolean) || null;
+function artifactResultEnvelopeFromCodeboxResult(result) {
+	const candidates = [
+		result,
+		result?.artifact_result,
+	];
+	return candidates.map(normalizeArtifactResultEnvelope).find(Boolean) || null;
 }
 
 function normalizeCodeboxPublicResultEnvelope(result, options = {}) {

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-adapter-contract.js
@@ -146,8 +146,8 @@ const WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS = [
     id: 'artifact-result-envelope',
     schema: WP_CODEBOX_PROVIDER_RUNTIME_RESULT_SCHEMAS.artifact_result_envelope,
     owner: 'wp-codebox',
-    adapter_behavior: 'consume_canonical_envelope_with_explicit_legacy_result_compatibility',
-    requirement: 'Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Compatibility for older Codebox package result shapes is centralized in codebox-artifact-contract.js and requires allowLegacyCodeboxResultCompatibility.',
+    adapter_behavior: 'consume_canonical_public_envelope_only',
+    requirement: 'Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Results that expose private runtime fields without the public envelope fail at the boundary.',
   },
   {
     id: 'artifact-apply-execution',

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -1452,28 +1452,6 @@ function isTranscriptArtifactDeclaration(declaration) {
   return /transcript|conversation|messages/i.test(`${name} ${type} ${schema}`);
 }
 
-function transcriptTypedArtifactsFromAgentResult(input, agentResult, config = {}) {
-  const requiredTranscriptArtifacts = requiredArtifactDeclarations(input, config).filter(isTranscriptArtifactDeclaration);
-  if (requiredTranscriptArtifacts.length === 0) {
-    return {};
-  }
-  const transcriptPath = artifactPath(agentResult?.artifacts?.directory, agentResult?.transcript?.artifact || '');
-  if (!transcriptPath) {
-    return {};
-  }
-  return Object.fromEntries(requiredTranscriptArtifacts
-    .map((declaration) => artifactDeclarationName(declaration))
-    .filter(Boolean)
-    .map((name) => [name, normalizeTypedArtifactEntry(name, {
-      name,
-      type: 'transcript',
-      artifact_schema: agentResult?.transcript?.schema || 'wp-codebox/agent-transcript/v1',
-      file_refs: [{ kind: 'codebox-transcript', path: transcriptPath, mime: 'application/json' }],
-      metadata: agentResult?.transcript || {},
-    })])
-    .filter(([, artifact]) => artifact));
-}
-
 function replyTextFromAgentResult(agentResult) {
   const candidates = [
     agentResult?.result?.reply,
@@ -1616,6 +1594,14 @@ function resultExecutions(result) {
   return [];
 }
 
+function publicArtifactResultPayload(result) {
+  const envelope = plainObject(result?.artifact_result) ? result.artifact_result : (plainObject(result?.artifactResult) ? result.artifactResult : null);
+  if (!envelope || envelope.schema !== 'wp-codebox/artifact-result-envelope/v1' || !plainObject(envelope.result)) {
+    return null;
+  }
+  return envelope.result;
+}
+
 function normalizeAgentTaskRun(input, result) {
   if (!isAgentBundle(input) && !isRuntimeTask(input)) {
     return result;
@@ -1625,14 +1611,13 @@ function normalizeAgentTaskRun(input, result) {
   const execution = executions.find((item) => item?.recipeCommand === 'wp-codebox.agent-sandbox-run') || executions[0] || null;
   const config = isAgentBundle(input) ? agentBundleConfig(input, input.agent_bundle || {}) : parentAgentTaskConfig(input);
   const stdoutWorkload = agentRuntimeWorkloadFromExecutionStdout(execution, config);
-  const fallbackAgentResult = result.metadata?.agent_runtime?.workload || execution?.agentResult || result.run?.agentResult || result.agentResult || result.agent_result || {};
+  const fallbackAgentResult = publicArtifactResultPayload(result) || {};
   let agentResult = hasSemanticWorkload(stdoutWorkload) ? stdoutWorkload : fallbackAgentResult;
   if (plainObject(agentResult)) {
     agentResult = {
       ...agentResult,
       outputs: mergeTypedArtifactOutputs(
         plainObject(agentResult.outputs) ? agentResult.outputs : {},
-        transcriptTypedArtifactsFromAgentResult(input, agentResult, config),
         replyTypedArtifactsFromAgentResult(input, agentResult, config),
       ),
     };
@@ -1649,30 +1634,28 @@ function normalizeAgentTaskRun(input, result) {
     ...(agentRuntimeDiagnostics(agentResult) || []),
   ];
 
+  const artifactResult = plainObject(result.artifact_result)
+    ? {
+        ...result.artifact_result,
+        result: {
+          ...(plainObject(result.artifact_result.result) ? result.artifact_result.result : {}),
+          outputs: plainObject(agentResult.outputs) ? agentResult.outputs : result.outputs,
+        },
+      }
+    : result.artifact_result;
+
   return {
     ...result,
     success,
     status: success ? 'completed' : result.status,
+    artifact_result: artifactResult,
     outputs: plainObject(agentResult.outputs) ? agentResult.outputs : result.outputs,
     summary: success ? 'WP Codebox agent task succeeded.' : (artifactValidation?.message || bundleValidation?.message || runtimeFailure?.message || result.summary || 'WP Codebox agent task failed.'),
     session: result.session ? {
       ...result.session,
       status: success ? 'completed' : 'failed',
     } : result.session,
-    run: {
-      ...(result.run || {}),
-      agentResult,
-    },
     diagnostics,
-    metadata: {
-      ...(result.metadata || {}),
-      agent_runtime: {
-        ...(result.metadata?.agent_runtime || {}),
-        bundle: isAgentBundle(input) ? config : undefined,
-        runtime_task: isRuntimeTask(input) ? runtimeTask(input) : undefined,
-        workload: agentResult,
-      },
-    },
   };
 }
 

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -505,8 +505,8 @@
           "id": "artifact-result-envelope",
           "schema": "wp-codebox/artifact-result-envelope/v1",
           "owner": "wp-codebox",
-          "adapter_behavior": "consume_canonical_envelope_with_explicit_legacy_result_compatibility",
-          "requirement": "Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Compatibility for older Codebox package result shapes is centralized in codebox-artifact-contract.js and requires allowLegacyCodeboxResultCompatibility."
+          "adapter_behavior": "consume_canonical_public_envelope_only",
+          "requirement": "Return typed artifacts, evidence refs, and run summaries in stable envelopes so adapters do not parse backend-local artifact layouts. Results that expose private runtime fields without the public envelope fail at the boundary."
         },
         {
           "id": "artifact-apply-execution",

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -11,6 +11,7 @@ const {
   codeboxTaskRequestFromAgentTaskRequest,
   codeboxRunAgentTaskInvocation,
   discoverCodeboxArtifactRefs,
+  normalizeCodeboxPublicResultEnvelope,
   normalizeCodeboxArtifactDeclaration,
   normalizeCodeboxArtifactOutcome,
   providerContract,
@@ -64,7 +65,7 @@ const runAgentTaskRequirement = provider.upstream_primitive_requirements.find((r
 assert.equal(runAgentTaskRequirement.schema, runtimeContractSchemas().agentTask.runRequest);
 assert.equal(
   provider.upstream_primitive_requirements.find((requirement) => requirement.id === 'artifact-result-envelope').adapter_behavior,
-  'consume_canonical_envelope_with_explicit_legacy_result_compatibility'
+  'consume_canonical_public_envelope_only'
 );
 assert.doesNotMatch(JSON.stringify(provider.provider_runtime_invocation), /datamachine|data machine|wp-site-generator|wpsg|site generator/i);
 assert.deepEqual(secretEnvRequirementForProvider(provider, 'codex').env, codexSecretEnv);
@@ -119,6 +120,45 @@ assert.equal(artifactResultEnvelope.artifactRefs.length, 2);
 assert.equal(artifactResultEnvelope.evidenceRefs.length, 2);
 assert.equal(artifactResultEnvelope.evidenceRefs[0].uri, 'artifacts/run-1');
 assert.deepEqual(typedArtifactsFromCodeboxResult({ artifact_result: artifactResultEnvelope }).review.payload, { ok: true });
+assert.deepEqual(normalizeCodeboxPublicResultEnvelope({ artifact_result: artifactResultEnvelope }).outputs, {});
+const privateRuntimeShapeRequest = {
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'private-runtime-shape-boundary',
+  executor: { backend: 'codebox', config: {} },
+  instructions: 'Reject private Codebox runtime result shapes.',
+  inputs: {},
+};
+const privateRuntimeShapeOutcome = agentTaskOutcomeFromCodeboxResult(privateRuntimeShapeRequest, {
+  success: true,
+  run: {
+    agentResult: {
+      reply: 'This private result shape must not be consumed.',
+      patch: { bytes: 10 },
+    },
+  },
+});
+assert.equal(privateRuntimeShapeOutcome.status, 'failed');
+assert.equal(privateRuntimeShapeOutcome.failure_classification, 'execution_failed');
+assert.equal(privateRuntimeShapeOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.public_result_envelope_missing'), true);
+assert.equal(privateRuntimeShapeOutcome.outputs.reply, undefined);
+const publicRuntimeShapeOutcome = agentTaskOutcomeFromCodeboxResult(privateRuntimeShapeRequest, {
+  success: true,
+  run: {
+    agentResult: {
+      reply: 'This private result shape must be ignored.',
+    },
+  },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      outputs: { reply: 'Public reply' },
+    },
+  },
+});
+assert.equal(publicRuntimeShapeOutcome.status, 'succeeded');
+assert.equal(publicRuntimeShapeOutcome.outputs.reply, 'Public reply');
+assert.equal(publicRuntimeShapeOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.public_result_envelope_missing'), false);
 assert.equal(normalizeCodeboxArtifactOutcome({ id: 'patch.diff', kind: 'codebox-patch' }, {}, {
   roleAliases: provider.role_aliases,
 }).role, 'patch');
@@ -299,14 +339,8 @@ const legacyShapedCodeboxResult = {
 };
 assert.equal(artifactResultEnvelopeFromCodeboxResult(legacyShapedCodeboxResult), null);
 assert.deepEqual(typedArtifactsFromCodeboxResult(legacyShapedCodeboxResult), {});
-assert.equal(
-  artifactResultEnvelopeFromCodeboxResult(legacyShapedCodeboxResult, { allowLegacyCodeboxResultCompatibility: true }).status,
-  'created'
-);
-assert.equal(
-  typedArtifactsFromCodeboxResult(legacyShapedCodeboxResult, { allowLegacyCodeboxResultCompatibility: true })['legacy-review'].payload.ok,
-  true
-);
+assert.equal(artifactResultEnvelopeFromCodeboxResult(legacyShapedCodeboxResult, { allowLegacyCodeboxResultCompatibility: true }), null);
+assert.deepEqual(typedArtifactsFromCodeboxResult(legacyShapedCodeboxResult, { allowLegacyCodeboxResultCompatibility: true }), {});
 
 const originalToolPolicyEnv = process.env.HOMEBOY_AGENT_TOOL_POLICY_JSON;
 const originalToolRequestSchemaEnv = process.env.HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA;
@@ -614,7 +648,7 @@ assert.deepEqual(controllerClientContextArtifactsTaskInput.artifact_declarations
 }]);
 assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.input.required_artifacts, ['concept_packet']);
 assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.input.engine_data_outputs, {
-  concept_packet: 'metadata.engine_data.outputs.typed_artifacts.concept_packet.payload',
+  concept_packet: 'outputs.typed_artifacts.concept_packet.payload',
 });
 
 const providerAndControllerArtifactsTaskInput = codeboxTaskRequestFromAgentTaskRequest({
@@ -643,7 +677,7 @@ assert.deepEqual(providerAndControllerArtifactsTaskInput.artifact_declarations.m
 assert.deepEqual(providerAndControllerArtifactsTaskInput.runtime_task.input.required_artifacts, ['concept_packet']);
 assert.equal(
   providerAndControllerArtifactsTaskInput.runtime_task.input.engine_data_outputs.concept_packet,
-  'metadata.engine_data.outputs.typed_artifacts.concept_packet.payload'
+  'outputs.typed_artifacts.concept_packet.payload'
 );
 
 const placeholderArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
@@ -662,7 +696,15 @@ const placeholderArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
 }, {
   success: true,
   status: 'completed',
-  reply: '<workspace_ls path="/workspace/wp-site-generator" />',
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      outputs: {
+        reply: '<workspace_ls path="/workspace/wp-site-generator" />',
+      },
+    },
+  },
 });
 assert.equal(placeholderArtifactOutcome.status, 'failed');
 assert.equal(placeholderArtifactOutcome.failure_classification, 'execution_failed');

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -100,27 +100,25 @@ process.stdout.write(JSON.stringify({
   success: true,
   status: 'completed',
   summary: 'Sandbox completed.',
-  artifact_result: {
-    schema: 'wp-codebox/artifact-result-envelope/v1',
-    typed_artifacts: [
-      {
-        name: 'fixture_report',
+	artifact_result: {
+		schema: 'wp-codebox/artifact-result-envelope/v1',
+		status: 'created',
+		metadata: { changed_files_count: 2, patch_bytes: 123, patch_sha256: 'fixture-patch-sha' },
+		typed_artifacts: [
+			{
+				name: 'fixture_report',
         type: 'FixtureReport',
         artifact_schema: 'example/fixture-report/v1',
         payload: { ok: true }
-      }
-    ]
-  },
-  artifacts: [{ id: 'artifact-1', kind: 'screenshot', path: '/artifacts/screenshot.png' }],
-  evidence_refs: [{ kind: 'preview', uri: 'https://example.test/preview', label: 'Preview' }],
-  run: {
+			}
+		],
+		artifact_refs: [{ id: 'artifact-1', kind: 'screenshot', path: '/artifacts/screenshot.png' }],
+		evidence_refs: [{ kind: 'preview', uri: 'https://example.test/preview', label: 'Preview' }],
+	},
+	run: {
     runId: 'fixture-run-1',
     status: 'succeeded',
     runtime: { id: 'fixture-runtime-1', status: 'destroyed' },
-    agentResult: {
-      changedFiles: { count: 2 },
-      patch: { bytes: 123, sha256: 'fixture-patch-sha' }
-    }
   },
   recipe_run: {
     success: true,
@@ -145,9 +143,12 @@ process.stdout.write(JSON.stringify({
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
   summary: 'Semantic output was produced before provider exit failure.',
-  outputs: { issue_url: 'https://github.com/example/repo/issues/456' },
-  artifacts: [{ id: 'semantic-artifact', kind: 'codebox-patch', path: '/tmp/semantic.patch' }],
-  session: { id: 'sandbox-session-failed-exit', status: 'completed' }
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    artifact_refs: [{ id: 'semantic-artifact', kind: 'codebox-patch', path: '/tmp/semantic.patch' }],
+    result: { outputs: { issue_url: 'https://github.com/example/repo/issues/456' } },
+  }
 }));
 process.exit(7);
 `);
@@ -213,8 +214,11 @@ if (process.env.FIXTURE_WP_CODEBOX_AGENT_TASK_FAILURE) {
     schema: 'wp-codebox/agent-task-run/v1',
     status: 'failed',
     summary: 'WP Codebox agent task failed.',
-    session: { id: input.sandbox_session_id, status: 'failed' },
-    artifacts: input.artifacts_path,
+    artifact_result: {
+      schema: 'wp-codebox/artifact-result-envelope/v1',
+      status: 'failed',
+      artifact_bundle_refs: [{ id: 'fake-artifact-bundle', kind: 'codebox-artifact-bundle', path: input.artifacts_path }]
+    },
     metadata: {}
   }));
   process.exit(0);
@@ -223,37 +227,21 @@ process.stdout.write(JSON.stringify({
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
-  session: {
-    schema: 'wp-codebox/sandbox-session/v1',
-    id: input.sandbox_session_id,
-    status: 'completed',
-    artifacts: { bundle_id: 'fake-artifact-bundle', path: input.artifacts_path, preview_url: 'https://preview.example.test/fake' },
-    orchestrator: input.orchestrator
-  },
   task_input: input,
-  artifacts: input.artifacts_path,
-  agent_result: {
-    scenarios: [{
-      id: 'agent-bundle',
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    artifact_bundle_refs: [{ id: 'fake-artifact-bundle', kind: 'codebox-artifact-bundle', path: input.artifacts_path }],
+    artifact_refs: [
+      { kind: 'agent-runtime-transcript', path: input.artifacts_path + '/transcript.json' },
+      { kind: 'agent-runtime-replay-bundle', path: input.artifacts_path + '/replay-bundle' },
+      { kind: 'agent-runtime-pull-request', url: 'https://github.com/example-org/example-repo/pull/123' }
+    ],
+    evidence_refs: [{ kind: 'agent-runtime-pull-request', uri: 'https://github.com/example-org/example-repo/pull/123' }],
+    result: {
+      outputs: { example_pr_url: 'https://github.com/example-org/example-repo/pull/123' },
       metadata: {
-        transcript_artifacts: { json: input.artifacts_path + '/transcript.json' },
-        replay_bundle_path: input.artifacts_path + '/replay-bundle',
         engine_data: { example_agent: { pr_url: 'https://github.com/example-org/example-repo/pull/123' } }
-      }
-    }]
-  },
-  metadata: {
-    agent_runtime: {
-      bundle: input.agent_bundle,
-      workload: {
-        scenarios: [{
-          id: 'agent-bundle',
-          metadata: {
-            transcript_artifacts: { json: input.artifacts_path + '/transcript.json' },
-            replay_bundle_path: input.artifacts_path + '/replay-bundle',
-            engine_data: { example_agent: { pr_url: 'https://github.com/example-org/example-repo/pull/123' } }
-          }
-        }]
       }
     }
   }
@@ -1540,7 +1528,11 @@ const outcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: false,
   provider_error: true,
   summary: 'Provider failed.',
-  artifacts: { bundle: { id: 'bundle-1', directory: '/tmp/artifacts' } },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    artifact_bundle_refs: [{ id: 'bundle-1', kind: 'artifact-bundle', path: '/tmp/artifacts' }],
+  },
 });
 assert.equal(outcome.schema, 'homeboy/agent-task-outcome/v1');
 assert.equal(outcome.task_id, 'task-123');
@@ -1553,14 +1545,12 @@ const upstreamRunnerOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
-  session: {
-    id: 'sandbox-session-1',
-    artifacts: {
-      bundle_id: 'artifact-bundle-1',
-      preview_url: 'https://preview.example.test/sandbox-session-1',
-    },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    artifact_bundle_refs: [{ id: 'artifact-bundle-1', kind: 'codebox-artifact-directory', path: '/tmp/wp-codebox-artifacts' }],
+    evidence_refs: [{ kind: 'codebox-preview', uri: 'https://preview.example.test/sandbox-session-1' }],
   },
-  artifacts: '/tmp/wp-codebox-artifacts',
 });
 assert.equal(upstreamRunnerOutcome.status, 'succeeded');
 assert.equal(upstreamRunnerOutcome.artifacts[0].kind, 'codebox-artifact-directory');
@@ -1596,12 +1586,15 @@ assert.equal(canonicalArtifactEnvelopeOutcome.artifacts.some((artifact) => artif
 const failedUpstreamRunnerOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'failed',
-  session: { id: 'sandbox-session-1', status: 'failed' },
-  evidence_refs: [{
-    kind: 'codebox-command-evidence',
-    uri: '/tmp/wp-codebox-artifacts/wp-codebox-command-evidence.json',
-    label: 'codebox command evidence',
-  }],
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'failed',
+    evidence_refs: [{
+      kind: 'codebox-command-evidence',
+      uri: '/tmp/wp-codebox-artifacts/wp-codebox-command-evidence.json',
+      label: 'codebox command evidence',
+    }],
+  },
 });
 assert.equal(failedUpstreamRunnerOutcome.status, 'failed');
 assert.equal(
@@ -1704,6 +1697,17 @@ const recipeProbeFailureOutcome = agentTaskOutcomeFromCodeboxResult(request, {
     fake_side_effects: '/tmp/recipe/fakes/side-effects.json',
     declared_artifacts: [{ name: 'runtime-log', path: '/tmp/recipe/logs/runtime.log' }],
   },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    artifact_refs: [
+      { kind: 'codebox-recipe-startup-log', path: '/tmp/recipe/startup.log' },
+      { kind: 'codebox-recipe-probe-json', path: '/tmp/recipe/probes/home-page.json' },
+      { kind: 'codebox-recipe-screenshot', path: '/tmp/recipe/screens/home-page.png' },
+      { kind: 'codebox-recipe-fake-side-effects', path: '/tmp/recipe/fakes/side-effects.json' },
+      { kind: 'codebox-recipe-artifact', path: '/tmp/recipe/logs/runtime.log' },
+    ],
+  },
 });
 assert.equal(recipeProbeFailureOutcome.status, 'failed');
 assert.equal(recipeProbeFailureOutcome.summary, 'WP Codebox home-page failed.');
@@ -1752,9 +1756,16 @@ const normalizedCompletedOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
   summary: 'WP Codebox agent task succeeded.',
-  outputs: {
-    issue_number: 123,
-    issue_url: 'https://github.com/example-org/example-repo/issues/123',
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    evidence_refs: [{ kind: 'agent-output-issue-url', uri: 'https://github.com/example-org/example-repo/issues/123' }],
+    result: {
+      outputs: {
+        issue_number: 123,
+        issue_url: 'https://github.com/example-org/example-repo/issues/123',
+      },
+    },
   },
   session: { id: 'sandbox-session-1', status: 'completed' },
 }, { exitStatus: 1 });
@@ -1795,12 +1806,17 @@ const nestedAgentRuntimeOutputFailureOutcome = agentTaskOutcomeFromCodeboxResult
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
   summary: 'Outer runner completed.',
-  outputs: {
-    success: false,
-    status: 'completed_no_items',
-    completion_outcome: {
-      status: 'completed_no_items',
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    evidence_refs: [{ kind: 'agent-output-issue-url', uri: 'https://github.com/example-org/example-repo/issues/123' }],
+    result: {
       success: false,
+      status: 'completed_no_items',
+      completion_outcome: {
+        status: 'completed_no_items',
+        success: false,
+      },
     },
   },
 });
@@ -1812,16 +1828,15 @@ const rawNestedAgentRuntimeFailureOutcome = agentTaskOutcomeFromCodeboxResult(re
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
   summary: 'WP Codebox agent task succeeded.',
-  raw: {
-    agent_runtime: {
-      success: true,
-      result: {
-        success: false,
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      success: false,
+      status: 'completed_no_items',
+      completion_outcome: {
         status: 'completed_no_items',
-        completion_outcome: {
-          status: 'completed_no_items',
-          success: false,
-        },
+        success: false,
       },
     },
   },
@@ -1834,16 +1849,16 @@ const metadataAgentRuntimeFailureOutcome = agentTaskOutcomeFromCodeboxResult(req
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
   summary: 'WP Codebox agent task succeeded.',
-  metadata: {
-    agent_runtime: {
-      result: {
-        error_message: 'Codex OAuth refresh failed.',
-        error_reason: 'ai_processing_failed',
-        terminal_status: 'failed - ai_processing_failed',
-        reason: 'empty_data_packet_returned',
-        outputs: {
-          error_step_id: 'ephemeral_step_0',
-        },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      error_message: 'Codex OAuth refresh failed.',
+      error_reason: 'ai_processing_failed',
+      terminal_status: 'failed - ai_processing_failed',
+      reason: 'empty_data_packet_returned',
+      outputs: {
+        error_step_id: 'ephemeral_step_0',
       },
     },
   },
@@ -1859,11 +1874,11 @@ const metadataAgentRuntimeTerminalFailureOutcome = agentTaskOutcomeFromCodeboxRe
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
-  metadata: {
-    agent_runtime: {
-      result: {
-        terminalStatus: 'failed - provider_auth_failed',
-      },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      terminalStatus: 'failed - provider_auth_failed',
     },
   },
 });
@@ -1875,19 +1890,14 @@ const workloadScenarioRuntimeFailureOutcome = agentTaskOutcomeFromCodeboxResult(
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
-  metadata: {
-    agent_runtime: {
-      workload: {
-        outputs: {},
-        scenarios: [{
-          id: 'agent-bundle',
-          metadata: {
-            error_step_id: 'ephemeral_step_0',
-            error_reason: 'ai_processing_failed',
-            terminal_status: 'failed - ai_processing_failed',
-          },
-        }],
-      },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      error_step_id: 'ephemeral_step_0',
+      error_reason: 'ai_processing_failed',
+      terminal_status: 'failed - ai_processing_failed',
+      outputs: {},
     },
   },
 });
@@ -1900,9 +1910,15 @@ const outputRuntimeFailureMetadataOutcome = agentTaskOutcomeFromCodeboxResult(re
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
-  outputs: {
-    error_step_id: 'ephemeral_step_1',
-    error_reason: 'provider_auth_failed',
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      outputs: {
+        error_step_id: 'ephemeral_step_1',
+        error_reason: 'provider_auth_failed',
+      },
+    },
   },
 });
 assert.equal(outputRuntimeFailureMetadataOutcome.status, 'failed');
@@ -1914,16 +1930,15 @@ const outputAgentRuntimeFailureWithoutTypedArtifactsOutcome = agentTaskOutcomeFr
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
   summary: 'WP Codebox agent task succeeded.',
-  outputs: {
-    agent_runtime: {
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
       success: false,
-      result: {
-        success: false,
-        error_reason: 'ai_processing_failed',
-        error_message: 'Embedded runtime failed before emitting typed artifacts.',
-        terminal_status: 'failed - ai_processing_failed',
-        outputs: {},
-      },
+      error_reason: 'ai_processing_failed',
+      error_message: 'Embedded runtime failed before emitting typed artifacts.',
+      terminal_status: 'failed - ai_processing_failed',
+      outputs: {},
     },
   },
 }, {
@@ -1954,19 +1969,18 @@ const synthesizedArtifactRuntimeFailureOutcome = agentTaskOutcomeFromCodeboxResu
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
   summary: 'WP Codebox agent task succeeded.',
-  artifacts: [{ id: 'codebox-patch', kind: 'codebox-patch', path: '/tmp/patch.diff' }],
-  outputs: {
-    typed_artifacts: {
-      patch: { name: 'patch', type: 'file', payload: { path: '/tmp/patch.diff' } },
-      agent_result: { name: 'agent_result', type: 'json', payload: { status: 'failed' } },
-    },
-  },
-  metadata: {
-    agent_runtime: {
-      workload: {
-        success: false,
-        status: 'failed',
-        outputs: {},
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    artifact_refs: [{ id: 'codebox-patch', kind: 'codebox-patch', path: '/tmp/patch.diff' }],
+    result: {
+      success: false,
+      status: 'failed',
+      outputs: {
+        typed_artifacts: {
+          patch: { name: 'patch', type: 'file', payload: { path: '/tmp/patch.diff' } },
+          agent_result: { name: 'agent_result', type: 'json', payload: { status: 'failed' } },
+        },
       },
     },
   },
@@ -1991,39 +2005,39 @@ const agentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
 }, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
-  artifacts: '/tmp/wp-codebox-artifacts',
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    artifact_refs: [
+      { kind: 'typed-bundle-output', name: 'example_review', path: '/tmp/wp-codebox-artifacts/example-review.json' },
+      { kind: 'agent-runtime-transcript', path: '/tmp/transcript.json' },
+      { kind: 'agent-runtime-replay-bundle', path: '/tmp/replay-bundle' },
+      { kind: 'agent-runtime-pull-request', url: 'https://github.com/example-org/example-repo/pull/123' },
+    ],
+    result: {
+      metadata: {
+        engine_data: { example_agent: { pr_url: 'https://github.com/example-org/example-repo/pull/123' } },
+      },
+      outputs: {
+        typed_artifacts: {
+          example_review: {
+            schema: 'homeboy/agent-task-typed-artifact/v1',
+            type: 'ExampleReviewArtifact',
+            artifact_schema: 'example/review-artifact/v1',
+            payload: { slug: 'issue-1222-transformer-loop', review_ready: true },
+            provenance: { bundle_slug: 'example-agent', task_id: 'agent-bundle-task-123' },
+            file_refs: [{ path: '/tmp/wp-codebox-artifacts/example-review.json', mime: 'application/json' }],
+          },
+        },
+      },
+    },
+  },
   task_input: {
+    agent_bundle: agentBundleRequest.agent_bundle,
     policy: { write: 'sandbox', apply: 'review' },
     sandbox_tool_policy: {
       schema: 'wp-codebox/sandbox-tool-policy/v1',
       tools: [{ id: 'homeboy/no-runtime-tools', allowed: false }],
-    },
-  },
-  metadata: {
-    agent_runtime: {
-      bundle: agentBundleRequest.agent_bundle,
-      workload: {
-        outputs: {
-          typed_artifacts: {
-            example_review: {
-              schema: 'homeboy/agent-task-typed-artifact/v1',
-              type: 'ExampleReviewArtifact',
-              artifact_schema: 'example/review-artifact/v1',
-              payload: { slug: 'issue-1222-transformer-loop', review_ready: true },
-              provenance: { bundle_slug: 'example-agent', task_id: 'agent-bundle-task-123' },
-              file_refs: [{ path: '/tmp/wp-codebox-artifacts/example-review.json', mime: 'application/json' }],
-            },
-          },
-        },
-        scenarios: [{
-          id: 'agent-bundle',
-          metadata: {
-            transcript_artifacts: { json: '/tmp/transcript.json', summary: '/tmp/transcript.md' },
-            replay_bundle_path: '/tmp/replay-bundle',
-            engine_data: { example_agent: { pr_url: 'https://github.com/example-org/example-repo/pull/123' } },
-          },
-        }],
-      },
     },
   },
 });
@@ -2040,9 +2054,9 @@ assert.equal(agentBundleOutcome.evidence_refs.some((ref) => ref.uri === 'https:/
 assert.equal(agentBundleOutcome.evidence_refs.some((ref) => ref.uri === '/tmp/wp-codebox-artifacts/example-review.json'), true);
 assert.equal(agentBundleOutcome.metadata.sandbox_policy.policy.apply, 'review');
 assert.equal(agentBundleOutcome.metadata.sandbox_policy.sandbox_tool_policy.tools[0].allowed, false);
-assert.equal(upstreamRunnerOutcome.artifacts[1].kind, 'codebox-session-artifacts');
-assert.equal(upstreamRunnerOutcome.evidence_refs[0].uri, 'https://preview.example.test/sandbox-session-1');
-assert.equal(upstreamRunnerOutcome.evidence_refs[1].uri, '/tmp/wp-codebox-artifacts');
+assert.equal(upstreamRunnerOutcome.artifacts[0].kind, 'codebox-artifact-directory');
+assert.equal(upstreamRunnerOutcome.evidence_refs.some((ref) => ref.uri === 'https://preview.example.test/sandbox-session-1'), true);
+assert.equal(upstreamRunnerOutcome.evidence_refs.some((ref) => ref.uri === '/tmp/wp-codebox-artifacts'), true);
 
 const missingRequiredTypedArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
   ...request,
@@ -2059,12 +2073,11 @@ const missingRequiredTypedArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
-  metadata: {
-    agent_runtime: {
-      workload: {
-        outputs: {},
-        scenarios: [{ id: 'agent-bundle', metadata: {} }],
-      },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      outputs: {},
     },
   },
 });
@@ -2091,12 +2104,11 @@ const inputBackfilledTypedArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
-  metadata: {
-    agent_runtime: {
-      workload: {
-        outputs: {},
-        scenarios: [{ id: 'agent-bundle', metadata: {} }],
-      },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      outputs: {},
     },
   },
 });
@@ -2122,12 +2134,11 @@ const missingGenericRepoLoopArtifactOutcome = agentTaskOutcomeFromCodeboxResult(
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
-  metadata: {
-    agent_runtime: {
-      workload: {
-        outputs: {},
-        scenarios: [{ id: 'agent-bundle', metadata: {} }],
-      },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      outputs: {},
     },
   },
 });
@@ -2144,27 +2155,28 @@ const canonicalTopLevelAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
 }, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
-  artifacts: '/tmp/wp-codebox-artifacts',
-  metadata: {
-    agent_runtime: {
-      bundle: {
+  task_input: {
+    agent_bundle: {
         engine_data_outputs: {
           example_branch: 'metadata.engine_data.example_agent.branch',
           example_pr_url: 'metadata.engine_data.example_agent.pr_url',
           example_slug: 'metadata.engine_data.example_agent.slug',
         },
       },
-      workload: {
-        outputs: [],
-      },
-    },
   },
-  outputs: {
-    engine_data: {
-      example_agent: {
-        branch: 'example/issue-451-design-direction',
-        pr_url: 'https://github.com/example-org/example-repo/pull/453',
-        slug: 'issue-451-design-direction',
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    evidence_refs: [{ kind: 'agent-runtime-pull-request', uri: 'https://github.com/example-org/example-repo/pull/453' }],
+    result: {
+      metadata: {
+        engine_data: {
+          example_agent: {
+            branch: 'example/issue-451-design-direction',
+            pr_url: 'https://github.com/example-org/example-repo/pull/453',
+            slug: 'issue-451-design-direction',
+          },
+        },
       },
     },
   },
@@ -2189,33 +2201,29 @@ const projectedTypedArtifactBundleOutcome = agentTaskOutcomeFromCodeboxResult({
 }, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
-  artifacts: '/tmp/wp-codebox-artifacts',
-  metadata: {
-    agent_runtime: {
-      bundle: {
+  task_input: {
+    agent_bundle: {
         engine_data_outputs: {
           example_review: 'outputs.typed_artifacts.example_review.payload',
         },
       },
-      workload: {
-        scenarios: [{
-          id: 'agent-bundle',
-          metadata: {
-            schema: 'datamachine/agent-bundle-run/v1',
-            outputs: {
-              typed_artifacts: {
-                example_review: {
-                  schema: 'homeboy/agent-task-typed-artifact/v1',
-                  type: 'ExampleReviewArtifact',
-                  artifact_schema: 'example/review-artifact/v1',
-                  payload: { slug: 'projected-review', review_ready: true },
-                  provenance: { bundle_slug: 'example-agent' },
-                  file_refs: [{ path: '/tmp/wp-codebox-artifacts/projected-review.json', mime: 'application/json' }],
-                },
-              },
-            },
+  },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    artifact_refs: [{ kind: 'typed-bundle-output', path: '/tmp/wp-codebox-artifacts/projected-review.json' }],
+    result: {
+      outputs: {
+        typed_artifacts: {
+          example_review: {
+            schema: 'homeboy/agent-task-typed-artifact/v1',
+            type: 'ExampleReviewArtifact',
+            artifact_schema: 'example/review-artifact/v1',
+            payload: { slug: 'projected-review', review_ready: true },
+            provenance: { bundle_slug: 'example-agent' },
+            file_refs: [{ path: '/tmp/wp-codebox-artifacts/projected-review.json', mime: 'application/json' }],
           },
-        }],
+        },
       },
     },
   },
@@ -2241,25 +2249,18 @@ const engineDataTypedArtifactBundleOutcome = agentTaskOutcomeFromCodeboxResult({
 }, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
-  metadata: {
-    agent_runtime: {
-      workload: {
-        scenarios: [{
-          id: 'agent-bundle',
-          metadata: {
-            engine_data: {
-              outputs: {
-                typed_artifacts: {
-                  concept_packet: {
-                    schema: 'example/concept-packet/v1',
-                    artifact: 'ConceptPacket',
-                    payload: { title: 'Projected concept' },
-                  },
-                },
-              },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      outputs: {
+        typed_artifacts: {
+          concept_packet: {
+            schema: 'example/concept-packet/v1',
+            artifact: 'ConceptPacket',
+            payload: { title: 'Projected concept' },
             },
           },
-        }],
       },
     },
   },
@@ -2283,20 +2284,13 @@ const replyTypedArtifactBundleOutcome = agentTaskOutcomeFromCodeboxResult({
 }, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
-  metadata: {
-    agent_runtime: {
-      workload: {
-        id: 'runtime-task',
-        success: true,
-        status: 'completed',
-        outputs: {},
-        metadata: {
-          result: {
-            reply: '## Commerce Concept Packet\n\nA focused commerce concept packet.',
-          },
-        },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      reply: '## Commerce Concept Packet\n\nA focused commerce concept packet.',
+      outputs: {},
       },
-    },
   },
 });
 assert.equal(replyTypedArtifactBundleOutcome.status, 'succeeded');
@@ -2317,21 +2311,20 @@ const failedProjectedTypedArtifactBundleOutcome = agentTaskOutcomeFromCodeboxRes
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
   status: 'completed',
-  outputs: {
-    agent_runtime: {
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
       success: false,
-      result: {
-        success: false,
-        error_reason: 'empty_data_packet_returned',
-        error_message: 'Runtime bundle returned an empty data packet.',
-        terminal_status: 'failed - empty_data_packet_returned',
-        outputs: {
-          typed_artifacts: {
-            failure_report: {
-              type: 'FailureReport',
-              artifact_schema: 'example/failure-report/v1',
-              payload: { reason: 'empty_data_packet_returned' },
-            },
+      error_reason: 'empty_data_packet_returned',
+      error_message: 'Runtime bundle returned an empty data packet.',
+      terminal_status: 'failed - empty_data_packet_returned',
+      outputs: {
+        typed_artifacts: {
+          failure_report: {
+            type: 'FailureReport',
+            artifact_schema: 'example/failure-report/v1',
+            payload: { reason: 'empty_data_packet_returned' },
           },
         },
       },
@@ -2351,22 +2344,28 @@ const singleResultAgentBundleOutcome = agentTaskOutcomeFromCodeboxResult({
 }, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
-  artifacts: '/tmp/wp-codebox-artifacts',
-  metadata: {
-    agent_runtime: {
-      bundle: {
+  task_input: {
+    agent_bundle: {
         engine_data_outputs: {
           issue_number: 'metadata.engine_data.example_agent.issue_number',
           issue_url: 'metadata.engine_data.example_agent.issue_url',
         },
       },
-      workload: {
-        outputs: {
-          issue_number: 123,
-          issue_url: 'https://github.com/example-org/example-repo/issues/123',
+  },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    evidence_refs: [{ kind: 'agent-output-issue-url', uri: 'https://github.com/example-org/example-repo/issues/123' }],
+    result: {
+      metadata: {
+        engine_data: {
+          example_agent: {
+            issue_number: 123,
+            issue_url: 'https://github.com/example-org/example-repo/issues/123',
+          },
         },
-        diagnostics: [{ class: 'agent_runtime.output', message: 'Semantic outputs captured.' }],
       },
+      diagnostics: [{ class: 'agent_runtime.output', message: 'Semantic outputs captured.' }],
     },
   },
 });
@@ -2391,6 +2390,24 @@ const canaryRunOutcome = agentTaskOutcomeFromCodeboxResult(request, {
     runtimeLogPath: '/tmp/canary/runtime/logs/runtime.log',
     commandsLogPath: '/tmp/canary/runtime/logs/commands.log',
   },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    metadata: {
+      no_op_reason: 'no_file_changes',
+      changed_files_count: 0,
+      patch_bytes: 0,
+      patch_sha256: 'empty-patch-sha',
+    },
+    artifact_refs: [
+      { id: 'artifact-bundle-sha256-canary', kind: 'artifact-bundle', path: '/tmp/canary/runtime', sha256: 'canary-digest' },
+      { id: 'codebox-changed-files', kind: 'codebox-changed-files', path: '/tmp/canary/runtime/files/changed-files.json', metadata: { artifact: 'files/changed-files.json' } },
+      { id: 'codebox-patch', kind: 'codebox-patch', path: '/tmp/canary/runtime/files/patch.diff', sha256: 'empty-patch-sha', metadata: { artifact: 'files/patch.diff' } },
+      { id: 'codebox-transcript', kind: 'codebox-transcript', path: '/tmp/canary/runtime/files/transcript.json', metadata: { artifact: 'files/transcript.json', executionCount: 1 } },
+      { id: 'codebox-runtime-log', kind: 'codebox-runtime-log', path: '/tmp/canary/runtime/logs/runtime.log' },
+      { id: 'codebox-command-log', kind: 'codebox-command-log', path: '/tmp/canary/runtime/logs/commands.log' },
+    ],
+  },
   run: {
     runId: 'run-canary',
     status: 'succeeded',
@@ -2402,14 +2419,6 @@ const canaryRunOutcome = agentTaskOutcomeFromCodeboxResult(request, {
       id: 'artifact-bundle-sha256-canary',
       digest: { algorithm: 'sha256', value: 'canary-digest' },
     }],
-    agentResult: {
-      summary: 'Agent sandbox completed without actionable file changes.',
-      changedFiles: { count: 0, paths: [], artifact: 'files/changed-files.json' },
-      patch: { bytes: 0, sha256: 'empty-patch-sha', artifact: 'files/patch.diff' },
-      transcript: { artifact: 'files/transcript.json', executionCount: 1 },
-      artifacts: { directory: '/tmp/canary/runtime' },
-      noOpReason: 'no_file_changes',
-    },
   },
   completionOutcome: {
     status: 'partial',
@@ -2426,7 +2435,7 @@ assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'ar
 assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-changed-files' && artifact.path === '/tmp/canary/runtime/files/changed-files.json'), true);
 assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-patch' && artifact.path === '/tmp/canary/runtime/files/patch.diff'), true);
 assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-transcript' && artifact.path === '/tmp/canary/runtime/files/transcript.json'), true);
-assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.role === 'patch' && artifact.metadata.wp_codebox.kind === 'codebox-patch' && artifact.metadata.wp_codebox.raw.metadata.artifact === 'files/patch.diff'), true);
+assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.role === 'patch' && artifact.metadata.wp_codebox.kind === 'codebox-patch' && artifact.path === '/tmp/canary/runtime/files/patch.diff'), true);
 assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.role === 'transcript' && artifact.metadata.wp_codebox.kind === 'codebox-transcript'), true);
 assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-runtime-log'), true);
 assert.equal(canaryRunOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-command-log'), true);
@@ -2449,16 +2458,15 @@ const canaryTranscriptRequiredOutcome = agentTaskOutcomeFromCodeboxResult({
 }, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    metadata: { no_op_reason: 'no_file_changes', changed_files_count: 0, patch_bytes: 0 },
+    transcript_refs: [{ kind: 'codebox-transcript', path: '/tmp/canary/runtime/files/transcript.json' }],
+  },
   run: {
     runId: 'run-canary-transcript-required',
     status: 'succeeded',
-    agentResult: {
-      changedFiles: { count: 0, paths: [], artifact: 'files/changed-files.json' },
-      patch: { bytes: 0, sha256: 'empty-patch-sha', artifact: 'files/patch.diff' },
-      transcript: { artifact: 'files/transcript.json', executionCount: 1 },
-      artifacts: { directory: '/tmp/canary/runtime' },
-      noOpReason: 'no_file_changes',
-    },
   },
 });
 assert.equal(canaryTranscriptRequiredOutcome.status, 'no_op');
@@ -2479,21 +2487,17 @@ const labTranscriptRequiredOutcome = agentTaskOutcomeFromCodeboxResult({
 }, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',
-  session: {
-    id: 'lab-session-transcript-required',
-    status: 'completed',
-    artifacts: {
-      bundle_id: 'lab-artifact-bundle',
-      directory: labRuntimeRoot,
-    },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    transcript_refs: [{
+      id: 'lab-codebox-transcript',
+      kind: 'codebox-transcript',
+      path: path.join(labRuntimeRoot, 'files', 'transcript.json'),
+      mime: 'application/json',
+    }],
+    result: { outputs: {} },
   },
-  artifacts: [{
-    id: 'lab-codebox-transcript',
-    kind: 'codebox-transcript',
-    path: path.join(labRuntimeRoot, 'files', 'transcript.json'),
-    mime: 'application/json',
-  }],
-  outputs: {},
 });
 assert.equal(labTranscriptRequiredOutcome.outputs.typed_artifacts['datamachine-transcript'].file_refs[0].path, path.join(labRuntimeRoot, 'files', 'transcript.json'));
 assert.equal(labTranscriptRequiredOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.required_typed_artifacts_missing'), false);
@@ -2686,8 +2690,8 @@ try {
   assert.equal(result.status, 0, result.stderr || result.stdout);
   const cliOutcome = JSON.parse(result.stdout);
   assert.equal(cliOutcome.status, 'succeeded');
-  assert.equal(cliOutcome.artifacts[0].kind, 'screenshot');
-  assert.equal(cliOutcome.evidence_refs[0].uri, 'https://example.test/preview');
+  assert.equal(cliOutcome.artifacts.some((artifact) => artifact.kind === 'screenshot'), true);
+  assert.equal(cliOutcome.evidence_refs.some((ref) => ref.uri === 'https://example.test/preview'), true);
 
   const normalizedResult = spawnSync(process.execPath, [
     wpCodeboxRuntimeExecutor,
@@ -2995,7 +2999,7 @@ try {
         pipeline_slug: 'example-pipeline',
         flow_slug: 'example-manual-flow',
         evidence_projections: [{ operation: 'github/create-pull-request', outputs: { example_pr_url: 'data.html_url' } }],
-        runtime_output_projections: { example_pr_url: 'metadata.engine_data.example_agent.pr_url' },
+        runtime_output_projections: { example_pr_url: 'outputs.example_pr_url' },
       },
     },
   };
@@ -3027,7 +3031,7 @@ try {
   assert.equal(capturedAgentBundleRun.input.agent_bundle.agent_slug, 'example-agent');
   assert.equal(capturedAgentBundleRun.input.agent_bundle.pipeline_slug, 'example-pipeline');
   assert.deepEqual(capturedAgentBundleRun.input.agent_bundle.evidence_projections, [{ operation: 'github/create-pull-request', outputs: { example_pr_url: 'data.html_url' } }]);
-  assert.deepEqual(capturedAgentBundleRun.input.agent_bundle.runtime_output_projections, { example_pr_url: 'metadata.engine_data.example_agent.pr_url' });
+  assert.deepEqual(capturedAgentBundleRun.input.agent_bundle.runtime_output_projections, { example_pr_url: 'outputs.example_pr_url' });
   assert.equal(Object.hasOwn(capturedAgentBundleRun.input.agent_bundle, 'tool_recorders'), false);
   assert.equal(Object.hasOwn(capturedAgentBundleRun.input.agent_bundle, 'engine_data_outputs'), false);
 


### PR DESCRIPTION
## Summary
- Require WP Codebox agent-task outcomes to include the canonical `wp-codebox/artifact-result-envelope/v1` public envelope before Homeboy Extensions consumes artifacts, typed outputs, transcript refs, or runtime failure metadata.
- Reject private legacy result shapes such as `run.agentResult`, `agent_result`, `metadata.agent_runtime`, and private artifact-directory layouts with a clear `codebox.public_result_envelope_missing` failure diagnostic.
- Update WP Codebox runner normalization and tests to use public envelope artifact refs, evidence refs, typed artifacts, and output projections.

## Tests
- `npm run test:codebox-agent-task-executor-boundary`
- `npm run test:codebox-agent-task-executor`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the Codebox public-result-envelope boundary, updating fixtures, and running targeted JS tests.