### PR TITLE
Extract nested Codebox fuzz results

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -117,7 +117,7 @@ async function runWpCodeboxFuzzRun(options = {}) {
 const runWpCodeboxFuzzSuite = runWpCodeboxFuzzRun;
 
 function normalizeWpCodeboxFuzzRunResult(result = {}, context = {}) {
-	const source = result?.json || result?.result || result?.output || result;
+	const source = normalizeWpCodeboxFuzzResultSource(result?.json || result?.result || result?.output || result);
 	const status = source?.status || source?.outcome?.status || result?.status || '';
 	const artifacts = normalizeWpCodeboxFuzzArtifacts(source, result);
 	const coverageSummary = normalizeCoverageSummary(source?.coverage_summary || source?.coverageSummary || source?.coverage?.summary);
@@ -142,6 +142,23 @@ function normalizeWpCodeboxFuzzRunResult(result = {}, context = {}) {
 			summary: objectOrUndefined(source?.summary),
 		}),
 	});
+}
+
+function normalizeWpCodeboxFuzzResultSource(source = {}) {
+	if (source?.schema === WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA) {
+		return source;
+	}
+	const candidates = [
+		source?.result,
+		source?.agent_task_result?.result,
+		source?.agentTaskResult?.result,
+		source?.agent_result?.result,
+		source?.agentResult?.result,
+		source?.outputs?.result,
+		source?.outputs?.fuzz_result,
+		source?.outputs?.fuzzResult,
+	];
+	return candidates.find((candidate) => candidate?.schema === WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA) || source;
 }
 
 const normalizeWpCodeboxFuzzSuiteResult = normalizeWpCodeboxFuzzRunResult;

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -166,6 +166,22 @@ runWpCodeboxFuzzRun({
 	const normalized = normalizeWpCodeboxFuzzRunResult({ status: 'failed', failures: [{ message: 'boom' }] });
 	assert.equal(normalized.succeeded, false);
 	assert.equal(normalized.failures[0].message, 'boom');
+	const nested = normalizeWpCodeboxFuzzRunResult({
+		json: {
+			schema: 'wp-codebox/agent-task-run/v1',
+			status: 'no_op',
+			agent_task_result: {
+				result: {
+					schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+					status: 'passed',
+					suite: { id: 'nested-suite' },
+					summary: { total: 0, passed: 0, failed: 0, error: 0, skipped: 0 },
+				},
+			},
+		},
+	});
+	assert.equal(nested.succeeded, true);
+	assert.equal(nested.metadata.suite.id, 'nested-suite');
 	assert.equal(normalizeWpCodeboxFuzzSuiteResult({ status: 'passed' }).result_schema, WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA);
 	return runWpCodeboxFuzzSuite({ taskId: 'suite-run-alias', runFuzzRun: async () => ({ status: 'passed' }) });
 }).then((summary) => {


### PR DESCRIPTION
## Summary
- Extract `wp-codebox/fuzz-suite-result/v1` envelopes nested inside successful WP Codebox `agent-task-run` output.
- Recognize `agent_task_result.result`, `agent_result.result`, and output result slots before declaring a fuzz result missing.
- Add regression coverage for the `agent_task_result.result` shape observed in Woo fuzz proof runs.

## Tests
- `npm run test:wp-codebox-fuzz-run`
- `npm run test:wordpress-fuzz-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the successful WP Codebox sandbox run that HBX still marked failed, adding nested fuzz result extraction, and adding regression coverage.
