### PR TITLE
Extract deeply nested Codebox fuzz results

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -158,7 +158,34 @@ function normalizeWpCodeboxFuzzResultSource(source = {}) {
 		source?.outputs?.fuzz_result,
 		source?.outputs?.fuzzResult,
 	];
-	return candidates.find((candidate) => candidate?.schema === WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA) || source;
+	return candidates.map((candidate) => findWpCodeboxFuzzSuiteResult(candidate)).find(Boolean) || source;
+}
+
+function findWpCodeboxFuzzSuiteResult(source, seen = new Set()) {
+	if (!objectOrUndefined(source) || seen.has(source)) {
+		return null;
+	}
+	if (source.schema === WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA) {
+		return source;
+	}
+	seen.add(source);
+	const candidates = [
+		source.result,
+		source.agent_task_result?.result,
+		source.agentTaskResult?.result,
+		source.agent_result?.result,
+		source.agentResult?.result,
+		source.outputs?.result,
+		source.outputs?.fuzz_result,
+		source.outputs?.fuzzResult,
+	];
+	for (const candidate of candidates) {
+		const found = findWpCodeboxFuzzSuiteResult(candidate, seen);
+		if (found) {
+			return found;
+		}
+	}
+	return null;
 }
 
 const normalizeWpCodeboxFuzzSuiteResult = normalizeWpCodeboxFuzzRunResult;

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -182,6 +182,24 @@ runWpCodeboxFuzzRun({
 	});
 	assert.equal(nested.succeeded, true);
 	assert.equal(nested.metadata.suite.id, 'nested-suite');
+	const doubleNested = normalizeWpCodeboxFuzzRunResult({
+		json: {
+			schema: 'wp-codebox/agent-task-run/v1',
+			status: 'no_op',
+			agent_result: {
+				result: {
+					result: {
+						schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+						status: 'passed',
+						suite: { id: 'double-nested-suite' },
+						summary: { total: 0, passed: 0, failed: 0, error: 0, skipped: 0 },
+					},
+				},
+			},
+		},
+	});
+	assert.equal(doubleNested.succeeded, true);
+	assert.equal(doubleNested.metadata.suite.id, 'double-nested-suite');
 	assert.equal(normalizeWpCodeboxFuzzSuiteResult({ status: 'passed' }).result_schema, WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA);
 	return runWpCodeboxFuzzSuite({ taskId: 'suite-run-alias', runFuzzRun: async () => ({ status: 'passed' }) });
 }).then((summary) => {


### PR DESCRIPTION
## Summary
- Recursively unwrap WP Codebox fuzz result containers when normalizing `wp-codebox/fuzz-suite-result/v1`.
- Add a regression for the observed double-nested `agent_result.result.result` shape.

## Testing
- `npm run test:wp-codebox-fuzz-run`
- `npm run test:wordpress-fuzz-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the nested fuzz result envelope, implementing the extractor fix, and adding the regression test.
