### PR TITLE
Extract raw Codebox fuzz results in runner CLI

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -207,7 +207,7 @@ function findFuzzSuiteResult(value) {
 	if (value.schema === 'wp-codebox/fuzz-suite-result/v1') {
 		return value;
 	}
-	for (const key of ['result', 'output', 'json']) {
+	for (const key of ['result', 'output', 'json', 'raw', 'agent_task_result', 'agentTaskResult', 'agent_result', 'agentResult', 'agent_runtime', 'agentRuntime']) {
 		const nested = findFuzzSuiteResult(value[key]);
 		if (nested) {
 			return nested;

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -200,12 +200,16 @@ if (!request.extra_plugins?.some((plugin) => plugin.slug === 'wp-codebox' && plu
 }
 process.stdout.write(JSON.stringify({
   success: true,
-  result: {
-    schema: 'wp-codebox/fuzz-suite-result/v1',
-    request_id: request.id,
-    status: 'succeeded',
-    artifactRefs: [{ path: 'fake/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
-    coverage_summary: { surface_count: 1, exercised_count: 1 }
+  agent_task_result: {
+    raw: {
+      result: {
+        schema: 'wp-codebox/fuzz-suite-result/v1',
+        request_id: request.id,
+        status: 'succeeded',
+        artifactRefs: [{ path: 'fake/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
+        coverage_summary: { surface_count: 1, exercised_count: 1 }
+      }
+    }
   }
 }));
 `);


### PR DESCRIPTION
## Summary
- Teach the fuzz runner CLI pre-normalizer to descend into raw WP Codebox agent-task result containers.
- Update the CLI smoke fixture to emit the same `agent_task_result.raw.result` shape observed in the Woo proof run.

## Testing
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wp-codebox-fuzz-run`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the CLI pre-normalizer gap, implementing the raw result traversal, and updating regression coverage.
