### PR TITLE
Use focused WP Codebox entrypoints

### DIFF
--- a/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
@@ -5,12 +5,12 @@ const { existsSync } = require('node:fs');
 const { homedir } = require('node:os');
 const { pathToFileURL } = require('node:url');
 
-const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
+const DEFAULT_CODEBOX_CONTRACTS_MODULE = '@automattic/wp-codebox-core/contracts';
 const RUNTIME_CONTRACT_MANIFEST_SCHEMA = 'wp-codebox/runtime-contract-manifest/v1';
 
 const DEPRECATED_RUNTIME_CONTRACT_FALLBACK = {
   status: 'deprecated',
-  replacement: '@automattic/wp-codebox-core runtimeContractManifest()',
+  replacement: '@automattic/wp-codebox-core/contracts runtimeContractManifest()',
   reason: 'Homeboy Extensions must consume WP Codebox public package contracts instead of carrying schema copies.',
 };
 
@@ -188,7 +188,13 @@ function coreModuleCandidates(options = {}) {
     return [normalizeCoreModuleSpecifier(explicit)];
   }
 
-  const candidates = [DEFAULT_CODEBOX_CORE_MODULE, 'wp-codebox-workspace/core'];
+  const candidates = [
+    DEFAULT_CODEBOX_CONTRACTS_MODULE,
+    'wp-codebox-workspace/contracts',
+    // Compatibility fallback for WP Codebox builds before focused package entrypoints.
+    '@automattic/wp-codebox-core',
+    'wp-codebox-workspace/core',
+  ];
   for (const candidate of setupCacheCoreModuleCandidates(options)) {
     if (existsSync(candidate) && !candidates.includes(candidate)) {
       candidates.push(candidate);
@@ -200,6 +206,9 @@ function coreModuleCandidates(options = {}) {
 function setupCacheCoreModuleCandidates(options = {}) {
   const installRoot = options.wpCodeboxInstallDir || process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.resolve(homedir(), '.cache/homeboy/wp-codebox');
   return [
+    path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist/contracts.js'),
+    path.resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/contracts.js'),
+    // Compatibility fallback for WP Codebox builds before focused package entrypoints.
     path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist/index.js'),
     path.resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js'),
   ];

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -33,6 +33,16 @@ const {
   loadWpCodeboxCore,
 } = requireWpCodeboxCoreLoader();
 
+const WP_CODEBOX_RUN_RESULTS_MODULE_OPTIONS = {
+  packageCandidates: [
+    '@automattic/wp-codebox-core/run-results',
+    'wp-codebox-workspace/run-results',
+    // Compatibility fallback for WP Codebox builds before focused package entrypoints.
+    '@automattic/wp-codebox-core',
+  ],
+  packageDistEntries: ['run-results.js', 'index.js'],
+};
+
 function requireWpCodeboxCoreLoader() {
   const candidates = [
     path.resolve(__dirname, '../../../../wordpress/lib/wp-codebox-core-loader'),
@@ -537,7 +547,7 @@ function missingModelPreflightPayload(taskInput) {
 }
 
 async function loadCodeboxCoreNormalizers() {
-  const module = await loadWpCodeboxCore();
+  const module = await loadWpCodeboxCore(WP_CODEBOX_RUN_RESULTS_MODULE_OPTIONS);
   if (typeof module?.normalizeAgentTaskRunResult === 'function' || typeof module?.normalizeRecipeRunSummary === 'function') {
     return {
       normalizeAgentTaskRunResult: typeof module.normalizeAgentTaskRunResult === 'function' ? module.normalizeAgentTaskRunResult : null,

--- a/tests/wp-codebox-runtime-contract-source-smoke.mjs
+++ b/tests/wp-codebox-runtime-contract-source-smoke.mjs
@@ -10,6 +10,7 @@ const require = createRequire(import.meta.url);
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const {
 	DEPRECATED_RUNTIME_CONTRACT_FALLBACK,
+	coreModuleCandidates,
 	loadCanonicalRuntimeContractSource,
 	loadRuntimeContractSource,
 	providerRuntimeInvocationContract,
@@ -111,6 +112,20 @@ const fallbackLoaded = await loadRuntimeContractSource({ wpCodeboxCoreModule: pa
 assert.equal(fallbackLoaded.canonical, false);
 assert.equal(fallbackLoaded.diagnostics[0].status, 'deprecated');
 assert.match(fallbackLoaded.diagnostics[0].replacement, /@automattic\/wp-codebox-core/);
+
+const installRoot = path.join(tempRoot, 'wp-codebox-install');
+const focusedContractsPath = path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'contracts.js');
+const legacyIndexPath = path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js');
+fs.mkdirSync(path.dirname(focusedContractsPath), { recursive: true });
+fs.writeFileSync(focusedContractsPath, 'export function runtimeContractManifest() { return {}; }\n');
+fs.writeFileSync(legacyIndexPath, 'export function runtimeContractManifest() { return {}; }\n');
+const contractCandidates = coreModuleCandidates({ wpCodeboxInstallDir: installRoot });
+assert.equal(contractCandidates[0], '@automattic/wp-codebox-core/contracts');
+assert.equal(contractCandidates[1], 'wp-codebox-workspace/contracts');
+assert.equal(contractCandidates[2], '@automattic/wp-codebox-core');
+assert.equal(contractCandidates[3], 'wp-codebox-workspace/core');
+assert.match(contractCandidates[4], /dist\/contracts\.js$/);
+assert.match(contractCandidates[5], /dist\/index\.js$/);
 
 const mismatchedModule = path.join(tempRoot, 'mismatched-runtime-core.mjs');
 fs.writeFileSync(mismatchedModule, `

--- a/wordpress/lib/audit-wp-codebox-runtime-provider.js
+++ b/wordpress/lib/audit-wp-codebox-runtime-provider.js
@@ -33,6 +33,15 @@ const WP_CODEBOX_STRUCTURED_OUTCOME_KINDS = new Set([
   'max_turns_exceeded',
 ]);
 const SECRET_KEY_PATTERN = /(secret|token|password|passwd|authorization|cookie|nonce|api[_-]?key|access[_-]?key|private[_-]?key|bearer)/i;
+const WP_CODEBOX_ARTIFACTS_MODULE_OPTIONS = {
+  packageCandidates: [
+    '@automattic/wp-codebox-core/artifacts',
+    'wp-codebox-workspace/artifacts',
+    // Compatibility fallback for WP Codebox builds before focused package entrypoints.
+    '@automattic/wp-codebox-core',
+  ],
+  packageDistEntries: ['artifacts.js', 'index.js'],
+};
 
 function sha256(value) {
   return crypto.createHash('sha256').update(value).digest('hex');
@@ -241,6 +250,7 @@ function discoverTaskArtifacts(args, taskRequest, startedAt, finishedAt) {
 
 async function discoverTaskArtifactsAsync(args, taskRequest, startedAt, finishedAt, options = {}) {
   const discoverPartialRunArtifacts = await loadWpCodeboxCoreFunction('discoverPartialRunArtifacts', {
+    ...WP_CODEBOX_ARTIFACTS_MODULE_OPTIONS,
     wpCodeboxCoreModule: options.wpCodeboxCoreModule || options.env?.WP_CODEBOX_CORE_MODULE,
   });
   const root = artifactsRootFromArgs(args);

--- a/wordpress/lib/wp-codebox-apply-adapter.js
+++ b/wordpress/lib/wp-codebox-apply-adapter.js
@@ -17,6 +17,15 @@ const ADAPTER_ID = 'homeboy/wp-codebox-apply-adapter/v1';
 const APPLY_RESULT_SCHEMA = 'homeboy/apply-result/v1';
 const WP_CODEBOX_PREFLIGHT_SCHEMA = 'wp-codebox/artifact-apply-preflight/v1';
 const PROTECTED_BRANCHES = new Set(['main', 'master', 'trunk', 'develop']);
+const WP_CODEBOX_ARTIFACTS_MODULE_OPTIONS = {
+  packageCandidates: [
+    '@automattic/wp-codebox-core/artifacts',
+    'wp-codebox-workspace/artifacts',
+    // Compatibility fallback for WP Codebox builds before focused package entrypoints.
+    '@automattic/wp-codebox-core',
+  ],
+  packageDistEntries: ['artifacts.js', 'index.js'],
+};
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -251,7 +260,10 @@ function normalizeWpCodeboxPreflight(input) {
 }
 
 async function normalizeWpCodeboxPreflightAsync(input) {
-  const normalizeArtifactApplyPreflight = await loadWpCodeboxCoreFunction('normalizeArtifactApplyPreflight', input);
+  const normalizeArtifactApplyPreflight = await loadWpCodeboxCoreFunction('normalizeArtifactApplyPreflight', {
+    ...WP_CODEBOX_ARTIFACTS_MODULE_OPTIONS,
+    ...input,
+  });
   if (!normalizeArtifactApplyPreflight) {
     return normalizeWpCodeboxPreflight(input);
   }
@@ -264,7 +276,10 @@ async function normalizeWpCodeboxPreflightAsync(input) {
 }
 
 async function wpCodeboxApplyRequestFromBundleAsync(options) {
-  const createArtifactApplyRequest = await loadWpCodeboxCoreFunction('createArtifactApplyRequest', options);
+  const createArtifactApplyRequest = await loadWpCodeboxCoreFunction('createArtifactApplyRequest', {
+    ...WP_CODEBOX_ARTIFACTS_MODULE_OPTIONS,
+    ...options,
+  });
   if (!createArtifactApplyRequest) {
     return wpCodeboxApplyRequestFromBundle(options);
   }

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -96,6 +96,7 @@
     "test:codebox-memory-report": "node tests/codebox-memory-report-smoke.js",
     "test:codebox-provider-adapter": "node tests/codebox-provider-adapter-smoke.js",
     "test:wp-codebox-apply-adapter": "node tests/wp-codebox-apply-adapter-smoke.js",
+    "test:wp-codebox-core-loader": "node tests/wp-codebox-core-loader-smoke.js",
     "test:wp-codebox-recipe-helper": "node tests/wp-codebox-recipe-helper-smoke.js",
     "test:wp-codebox-fuzz-plan-recipe-builder": "node tests/wp-codebox-fuzz-plan-recipe-builder-smoke.js",
     "test:wp-codebox-artifacts": "node tests/wp-codebox-artifacts-smoke.js",

--- a/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
+++ b/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
@@ -13,6 +13,7 @@ const RECIPE_BUILDER_MODULE_OPTIONS = {
 	packageCandidates: [
 		'@automattic/wp-codebox-core/recipe-builders',
 		'wp-codebox-workspace/recipe-builders',
+		// Compatibility fallback for WP Codebox builds before focused package entrypoints.
 		'@automattic/wp-codebox-core',
 	],
 	packageDistEntries: ['recipe-builders.js', 'index.js'],

--- a/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-recipe-builder-smoke.js
@@ -9,7 +9,7 @@ const readyScript = path.join(__dirname, '..', 'scripts', 'build', 'check-wp-cod
 const fixtureCoreModule = path.join(__dirname, 'fixtures', 'wp-codebox-core-recipe-builder.mjs');
 const missingBenchBuilderModule = path.join(__dirname, 'fixtures', 'wp-codebox-core-missing-bench-builder.mjs');
 const installRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-install-'));
-const cachedCoreModule = path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js');
+const cachedCoreModule = path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'recipe-builders.js');
 fs.mkdirSync(path.dirname(cachedCoreModule), { recursive: true });
 fs.copyFileSync(fixtureCoreModule, cachedCoreModule);
 
@@ -67,6 +67,7 @@ assert.deepEqual(recipe.inputs.extraPlugins[0], { source: '/tmp/extra-plugin.zip
 assert.deepEqual(recipe.inputs.workloads.map((workload) => workload.id), ['fixture-workload', 'other-workload']);
 assert.deepEqual(recipe.inputs.pluginRuntime, input.options.pluginRuntime);
 assert.deepEqual(recipe.inputs.siteSeeds, [{
+	schema: 'homeboy/wordpress-fixture-site-seed/v1',
 	type: 'fixture',
 	name: 'generic-fixture-content',
 	source: 'fixtures/content.json',

--- a/wordpress/tests/wp-codebox-core-loader-smoke.js
+++ b/wordpress/tests/wp-codebox-core-loader-smoke.js
@@ -1,0 +1,65 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+	coreModuleCandidates,
+	loadWpCodeboxCoreExport,
+} = require('../lib/wp-codebox-core-loader');
+
+async function main() {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-core-loader-'));
+	try {
+		const dist = path.join(root, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist');
+		fs.mkdirSync(dist, { recursive: true });
+		fs.writeFileSync(path.join(dist, 'artifacts.js'), 'exports.fixtureExport = () => "focused-artifacts";\n');
+		fs.writeFileSync(path.join(dist, 'index.js'), 'exports.fixtureExport = () => "legacy-index";\n');
+
+		const candidates = coreModuleCandidates({
+			wpCodeboxInstallDir: root,
+			packageCandidates: [
+				'@automattic/wp-codebox-core/artifacts',
+				'wp-codebox-workspace/artifacts',
+				'@automattic/wp-codebox-core',
+			],
+			packageDistEntries: ['artifacts.js', 'index.js'],
+		});
+
+		assert.equal(candidates[0], '@automattic/wp-codebox-core/artifacts');
+		assert.equal(candidates[1], 'wp-codebox-workspace/artifacts');
+		assert.equal(candidates[2], '@automattic/wp-codebox-core');
+		assert.match(candidates[3], /dist\/artifacts\.js$/);
+		assert.match(candidates[4], /dist\/index\.js$/);
+
+		const result = await loadWpCodeboxCoreExport('fixtureExport', {
+			wpCodeboxInstallDir: root,
+			packageCandidates: [],
+			packageDistEntries: ['artifacts.js', 'index.js'],
+			required: true,
+		});
+
+		assert.match(result.source, /dist\/artifacts\.js$/);
+		assert.equal(result.value(), 'focused-artifacts');
+
+		fs.rmSync(path.join(dist, 'artifacts.js'));
+		const legacyResult = await loadWpCodeboxCoreExport('fixtureExport', {
+			wpCodeboxInstallDir: root,
+			packageCandidates: [],
+			packageDistEntries: ['artifacts.js', 'index.js'],
+			required: true,
+		});
+
+		assert.match(legacyResult.source, /dist\/index\.js$/);
+		assert.equal(legacyResult.value(), 'legacy-index');
+
+		console.log('wp-codebox core loader smoke passed');
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
@@ -62,7 +62,7 @@ assert.match(diagnosticResult.stderr, /\/missing\/wp-codebox-core\.mjs/);
 
 const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-workspace-'));
 const installRoot = path.join(workspaceRoot, 'wp-codebox-install');
-const discoveredModule = path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js');
+const discoveredModule = path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'recipe-builders.js');
 fs.mkdirSync(path.dirname(discoveredModule), { recursive: true });
 fs.copyFileSync(fixtureCoreModule, discoveredModule);
 


### PR DESCRIPTION
## Summary
- Prefer focused WP Codebox public entrypoints for contracts, artifacts, recipe builders, and run-result helpers.
- Keep root/dist loading only as compatibility fallback.
- Add focused loader smoke coverage.

## Tests
- git diff --check
- node tests/wp-codebox-core-loader-smoke.js
- node tests/wp-codebox-apply-adapter-smoke.js
- node tests/wp-codebox-bench-recipe-builder-smoke.js
- node tests/wp-codebox-phpunit-recipe-builder-smoke.js
- node tests/wp-codebox-runtime-contract-source-smoke.mjs
- node tests/codebox-agent-task-executor-smoke.js

Note: node tests/audit-wp-codebox-fanout-smoke.js currently fails on an unrelated default runtime expectation: local-shell vs wp-codebox.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing entrypoint migration, compatibility fallbacks, and smoke tests.