### PR TITLE
Route fuzz runner through Codebox adapter

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -6,6 +6,11 @@ const os = require('node:os');
 const path = require('node:path');
 const { spawn } = require('node:child_process');
 
+const {
+	codeboxRunAgentTaskInvocation,
+	codeboxTaskRequestFromAgentTaskRequest,
+} = require('../../../agent-runtimes/wp-codebox');
+
 /**
  * Internal dependencies
  */
@@ -42,9 +47,10 @@ async function runWpCodeboxAgentTask(request) {
 	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-fuzz-'));
 	const inputFile = path.join(tempDir, 'agent-task-request.json');
 	const command = process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || 'wp-codebox';
-	fs.writeFileSync(inputFile, `${JSON.stringify(wpCodeboxRunAgentTaskInput(request, { wpCodeboxBin: command }), null, 2)}\n`);
+	const invocation = wpCodeboxRunAgentTaskInvocation(request);
+	fs.writeFileSync(inputFile, `${JSON.stringify(invocation.input, null, 2)}\n`);
 
-	const args = ['run-agent-task', '--input-file', inputFile, '--json'];
+	const args = wpCodeboxInvocationArgs(invocation, inputFile);
 	const result = await spawnJson(command, args, {
 		cwd: process.cwd(),
 		env: process.env,
@@ -53,77 +59,21 @@ async function runWpCodeboxAgentTask(request) {
 	return { json: normalizeWpCodeboxAgentTaskOutput(result, request) };
 }
 
-function wpCodeboxRunAgentTaskInput(request, options = {}) {
-	return {
-		schema: 'wp-codebox/run-agent-task/v1',
-		id: request.task_id,
-		goal: request.instructions || 'Run the WordPress fuzz suite and return the declared fuzz artifacts.',
-		agent_workload: {
-			schema: 'wp-codebox/agent-workload/v1',
-			id: request.task_id,
-			goal: request.instructions || 'Run the WordPress fuzz suite and return the declared fuzz artifacts.',
-			agent_runtime: {
-				runtime_task: request.executor?.config?.runtime_task,
-			},
-		},
-		runtime_task: request.executor?.config?.runtime_task,
-		extra_plugins: wpCodeboxRuntimePlugins(options.wpCodeboxBin),
-		allowed_tools: ['homeboy/no-runtime-tools'],
-		sandbox_tool_policy: denyAllSandboxToolPolicy(),
-		artifact_declarations: request.artifact_declarations,
-		expected_artifacts: request.expected_artifacts,
-		metadata: {
-			...(request.metadata || {}),
-			homeboy_agent_task_request: request,
-		},
-	};
+function wpCodeboxRunAgentTaskInvocation(request) {
+	const taskInput = codeboxTaskRequestFromAgentTaskRequest(request);
+	return codeboxRunAgentTaskInvocation({
+		taskInput,
+		taskId: request.task_id,
+	});
 }
 
-function wpCodeboxRuntimePlugins(wpCodeboxBin) {
-	const source = wpCodeboxPluginSource(wpCodeboxBin);
-	if (!source) {
-		return [];
-	}
-	return [{
-		source,
-		slug: 'wp-codebox',
-		pluginFile: 'wp-codebox/wp-codebox.php',
-		activate: true,
-		loadAs: 'plugin',
-	}];
-}
-
-function wpCodeboxPluginSource(wpCodeboxBin) {
-	const explicit = process.env.HOMEBOY_WP_CODEBOX_PLUGIN_PATH || process.env.WP_CODEBOX_PLUGIN_PATH;
-	if (explicit && fs.existsSync(explicit)) {
-		return explicit;
-	}
-	if (!wpCodeboxBin || wpCodeboxBin === 'wp-codebox') {
-		return '';
-	}
-	const candidate = path.resolve(path.dirname(wpCodeboxBin), '../../wordpress-plugin');
-	return fs.existsSync(candidate) ? candidate : '';
-}
-
-function denyAllSandboxToolPolicy() {
-	return {
-		schema: 'wp-codebox/sandbox-tool-policy/v1',
-		version: 1,
-		tools: [
-			{
-				id: 'homeboy/no-runtime-tools',
-				runtime_tool_id: 'homeboy_no_runtime_tools',
-				allowed: false,
-				runtime: {
-					environment: 'control_plane',
-					capability_scope: 'control_plane',
-				},
-			},
-		],
-		metadata: {
-			source: 'homeboy-extension-wordpress/fuzz-runner',
-		},
-	};
+function wpCodeboxInvocationArgs(invocation, inputFile) {
+	return invocation.args.flatMap((arg) => {
+		if (arg === '--input-file={{input_file}}') {
+			return ['--input-file', inputFile];
+		}
+		return [String(arg).replace('{{input_file}}', inputFile)];
+	});
 }
 
 function spawnJson(command, args, options) {
@@ -175,6 +125,7 @@ function normalizeWpCodeboxAgentTaskOutput(output, request) {
 		output?.json,
 		output?.result,
 		output?.output,
+		output?.agent_task_run_result,
 		output?.agent_runtime?.result,
 		output?.recipe_run?.result,
 		output,
@@ -207,7 +158,7 @@ function findFuzzSuiteResult(value) {
 	if (value.schema === 'wp-codebox/fuzz-suite-result/v1') {
 		return value;
 	}
-	for (const key of ['result', 'output', 'json', 'raw', 'agent_task_result', 'agentTaskResult', 'agent_result', 'agentResult', 'agent_runtime', 'agentRuntime']) {
+	for (const key of ['result', 'output', 'json', 'raw', 'agent_task_run_result', 'agentTaskRunResult', 'agent_task_result', 'agentTaskResult', 'agent_result', 'agentResult', 'agent_runtime', 'agentRuntime']) {
 		const nested = findFuzzSuiteResult(value[key]);
 		if (nested) {
 			return nested;

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -6,6 +6,7 @@ const Module = require('node:module');
 const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { runtimeContractSchemas } = require('../../agent-runtimes/wp-codebox');
 
 const originalLoad = Module._load;
 Module._load = function loadWithoutRuntimeAgentCi(request, parent, isMain) {
@@ -179,36 +180,45 @@ assert.equal(homeboyCampaign.metadata.diagnostics[0].code, 'wp_codebox_fuzz_suit
 
 const fakeCodeboxBin = path.join(tempDir, 'packages/cli/dist/fake-wp-codebox.js');
 fs.mkdirSync(path.dirname(fakeCodeboxBin), { recursive: true });
-fs.mkdirSync(path.join(tempDir, 'packages/wordpress-plugin'), { recursive: true });
-fs.writeFileSync(path.join(tempDir, 'packages/wordpress-plugin/wp-codebox.php'), '<?php // fixture');
 const dispatchResultsPath = path.join(tempDir, 'dispatch-results.json');
 fs.writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
 const inputFile = process.argv[process.argv.indexOf('--input-file') + 1];
 const request = JSON.parse(fs.readFileSync(inputFile, 'utf8'));
-if (request.schema !== 'wp-codebox/run-agent-task/v1' || !request.goal || !request.runtime_task) {
+if (request.schema !== '${runtimeContractSchemas().agentTask.runRequest}' || request.task_id !== 'dispatch-cli-run') {
   process.stderr.write('invalid run-agent-task input');
   process.exit(1);
 }
-if (request.sandbox_tool_policy?.schema !== 'wp-codebox/sandbox-tool-policy/v1' || request.sandbox_tool_policy?.version !== 1 || !request.sandbox_tool_policy?.tools?.length) {
-  process.stderr.write('invalid sandbox tool policy');
+if (request.runtime_task || request.artifact_declarations || request.sandbox_tool_policy || request.extra_plugins) {
+  process.stderr.write('runner rebuilt the Codebox task payload instead of delegating to the adapter');
   process.exit(1);
 }
-if (!request.extra_plugins?.some((plugin) => plugin.slug === 'wp-codebox' && plugin.activate === true)) {
-  process.stderr.write('missing wp-codebox extra plugin');
+if (request.task_input?.schema !== 'wp-codebox/task-input/v1') {
+  process.stderr.write('missing delegated task input');
+  process.exit(1);
+}
+if (request.task_input?.runtime_task?.ability !== 'wp-codebox/run-fuzz-suite' || request.task_input?.runtime_task?.input?.schema !== 'wp-codebox/fuzz-suite/v1') {
+  process.stderr.write('missing fuzz runtime task');
+  process.exit(1);
+}
+if (request.task_input?.artifact_declarations?.[0]?.name !== 'wp-codebox-fuzz-suite-result' || !request.task_input?.expected_artifacts?.includes('wordpress-fuzz-coverage')) {
+  process.stderr.write('missing delegated artifact contract');
+  process.exit(1);
+}
+if (request.task_input?.parent_request?.task_id !== 'dispatch-cli-run') {
+  process.stderr.write('missing parent request metadata');
   process.exit(1);
 }
 process.stdout.write(JSON.stringify({
   success: true,
-  agent_task_result: {
-    raw: {
-      result: {
-        schema: 'wp-codebox/fuzz-suite-result/v1',
-        request_id: request.id,
-        status: 'succeeded',
-        artifactRefs: [{ path: 'fake/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
-        coverage_summary: { surface_count: 1, exercised_count: 1 }
-      }
+  agent_task_run_result: {
+    schema: '${runtimeContractSchemas().agentTask.runResult}',
+    result: {
+      schema: 'wp-codebox/fuzz-suite-result/v1',
+      request_id: request.task_id,
+      status: 'succeeded',
+      artifactRefs: [{ path: 'fake/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
+      coverage_summary: { surface_count: 1, exercised_count: 1 }
     }
   }
 }));


### PR DESCRIPTION
## Summary
- Route WordPress fuzz runner Codebox request construction through the shared Codebox run-agent-task adapter.
- Remove duplicated sandbox policy, artifact, and metadata request construction.
- Preserve current CLI execution behavior and output normalization.

## Tests
- node wordpress/tests/wordpress-fuzz-runner-smoke.js
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing adapter delegation and smoke coverage.