### PR TITLE
Move WooCommerce defaults behind product adapters

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -102,6 +102,19 @@ that still consume `wp-codebox/task-input/v1`. Select it with
 `request_kind: "wp-codebox"` flag. New callers should prefer the generic
 agent-task request schema and make runtime selection outside the adapter.
 
+## Product Adapter Boundaries
+
+Generic WordPress helpers keep default profiling and helper manifests scoped to
+WordPress itself. Product-specific helpers are exposed behind explicit adapter
+declarations so callers opt in when they need product semantics:
+
+- `getWordPressHelperManifest().productAdapters.woocommerce.helpers` exposes
+  WooCommerce bench fixture helper paths.
+- `WORDPRESS_PAGE_PROFILER_PRODUCT_ADAPTERS.woocommerce` declares the
+  WooCommerce Store API waterfall group and marks it first-party only when the
+  caller passes `productAdapters: ["woocommerce"]` (or the equivalent adapter
+  object) to `summarizeThirdPartyWaterfall()`.
+
 ## WordPress Hook Surface Discovery
 
 `wordpress-hook-surface-discovery` statically extracts literal WordPress

--- a/wordpress/lib/helper-manifest.js
+++ b/wordpress/lib/helper-manifest.js
@@ -21,7 +21,15 @@ const HELPER_PATHS = Object.freeze({
 	editorCanvasProbes: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'editor-canvas-probes.js'),
 	fidelityComparison: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'fidelity-comparison.js'),
 	fixtureSetup: path.join(WORDPRESS_EXTENSION_ROOT, 'lib', 'fixture-setup.js'),
-	woocommerceExpensiveShipping: path.join(WORDPRESS_EXTENSION_ROOT, 'scripts', 'bench', 'lib', 'woocommerce-expensive-shipping.php'),
+});
+
+const PRODUCT_ADAPTERS = Object.freeze({
+	woocommerce: Object.freeze({
+		helpers: Object.freeze({
+			benchFixtures: path.join(WORDPRESS_EXTENSION_ROOT, 'scripts', 'bench', 'lib', 'woocommerce-fixtures.php'),
+			expensiveShipping: path.join(WORDPRESS_EXTENSION_ROOT, 'scripts', 'bench', 'lib', 'woocommerce-expensive-shipping.php'),
+		}),
+	}),
 });
 
 function getWordPressHelperManifest() {
@@ -29,6 +37,7 @@ function getWordPressHelperManifest() {
 		version: 1,
 		extensionRoot: WORDPRESS_EXTENSION_ROOT,
 		helpers: { ...HELPER_PATHS },
+		productAdapters: PRODUCT_ADAPTERS,
 	};
 }
 

--- a/wordpress/lib/page-profiler.js
+++ b/wordpress/lib/page-profiler.js
@@ -31,11 +31,6 @@ const DEFAULT_DIAGNOSIS_THRESHOLDS = {
 const DEFAULT_REST_OBSERVATION_MS = 1000;
 const DEFAULT_THIRD_PARTY_WATERFALL_GROUPS = [
 	{
-		id: 'woocommerce-store-api',
-		label: 'WooCommerce Store API',
-		urlIncludes: ['/wp-json/wc/store/', 'rest_route=/wc/store/'],
-	},
-	{
 		id: 'wordpress-assets',
 		label: 'WordPress assets',
 		urlIncludes: ['/wp-admin/', '/wp-content/', '/wp-includes/', '/wp-json/'],
@@ -51,6 +46,18 @@ const DEFAULT_THIRD_PARTY_WATERFALL_GROUPS = [
 		domains: ['gstatic.com', 'googleapis.com', 'google.com'],
 	},
 ];
+const WORDPRESS_PAGE_PROFILER_PRODUCT_ADAPTERS = Object.freeze({
+	woocommerce: Object.freeze({
+		waterfallGroups: Object.freeze([
+			Object.freeze({
+				id: 'woocommerce-store-api',
+				label: 'WooCommerce Store API',
+				urlIncludes: Object.freeze(['/wp-json/wc/store/', 'rest_route=/wc/store/']),
+			}),
+		]),
+		firstPartyWaterfallGroupIds: Object.freeze(['woocommerce-store-api']),
+	}),
+});
 const DEFAULT_GATE_THRESHOLDS = {
 	readyMsRegression: 250,
 	networkIdleMsRegression: 500,
@@ -294,6 +301,17 @@ function normalizeThirdPartyWaterfallGroups(groups) {
 		}));
 }
 
+function normalizeWaterfallProductAdapters(adapters) {
+	return (Array.isArray(adapters) ? adapters : [])
+		.map((adapter) => {
+			if (typeof adapter === 'string') {
+				return WORDPRESS_PAGE_PROFILER_PRODUCT_ADAPTERS[adapter] || null;
+			}
+			return isPlainObject(adapter) ? adapter : null;
+		})
+		.filter(Boolean);
+}
+
 function normalizeNetworkUrlPattern(url) {
 	const parsed = safeUrl(url);
 	if (!parsed) {
@@ -412,7 +430,12 @@ function flattenThirdPartyWaterfallMetrics(summary) {
 }
 
 function summarizeThirdPartyWaterfall(rows, options = {}) {
-	const groups = normalizeThirdPartyWaterfallGroups(options.groups || options.vendorGroups || options.waterfallGroups);
+	const productAdapters = normalizeWaterfallProductAdapters(options.productAdapters || options.product_adapters || options.productWaterfallAdapters || options.product_waterfall_adapters);
+	const groups = normalizeThirdPartyWaterfallGroups([
+		...normalizeThirdPartyWaterfallGroups(options.groups || options.vendorGroups || options.waterfallGroups).filter((group) => !DEFAULT_THIRD_PARTY_WATERFALL_GROUPS.some((defaultGroup) => defaultGroup.id === group.id)),
+		...productAdapters.flatMap((adapter) => normalizeThirdPartyWaterfallGroups(adapter.waterfallGroups || adapter.waterfall_groups)),
+		...normalizeThirdPartyWaterfallGroups(options.groups || options.vendorGroups || options.waterfallGroups).filter((group) => DEFAULT_THIRD_PARTY_WATERFALL_GROUPS.some((defaultGroup) => defaultGroup.id === group.id)),
+	]);
 	const topUrlLimit = Number(options.topUrlLimit ?? 10);
 	const duplicatePatternLimit = Number(options.duplicatePatternLimit ?? 10);
 	const grouped = new Map();
@@ -447,7 +470,12 @@ function summarizeThirdPartyWaterfall(rows, options = {}) {
 	const finalizedGroups = [...grouped.values()]
 		.map((group) => finalizeThirdPartyWaterfallGroup(group, topUrlLimit, duplicatePatternLimit))
 		.sort((a, b) => b.transferSizeBytes - a.transferSizeBytes || b.totalCount - a.totalCount || a.label.localeCompare(b.label));
-	const firstPartyGroupIds = new Set(['same-origin', 'wordpress-assets', 'woocommerce-store-api', 'unknown']);
+	const firstPartyGroupIds = new Set([
+		'same-origin',
+		'wordpress-assets',
+		'unknown',
+		...productAdapters.flatMap((adapter) => adapter.firstPartyWaterfallGroupIds || adapter.first_party_waterfall_group_ids || []),
+	]);
 	const thirdPartyGroups = finalizedGroups.filter((group) => !firstPartyGroupIds.has(group.id));
 	const summary = {
 		schema: 'homeboy/third-party-waterfall/v1',
@@ -3933,6 +3961,7 @@ module.exports = {
 	DEFAULT_REST_OBSERVATION_MS,
 	WORDPRESS_RESOURCE_INCLUDE,
 	DEFAULT_THIRD_PARTY_WATERFALL_GROUPS,
+	WORDPRESS_PAGE_PROFILER_PRODUCT_ADAPTERS,
 	classifyResourceUrl,
 	classifyWordPressRestPreloadOpportunities,
 	compareWordPressRestNetworkWaterfalls,

--- a/wordpress/tests/helper-manifest-smoke.js
+++ b/wordpress/tests/helper-manifest-smoke.js
@@ -60,8 +60,13 @@ assert.equal(
 	manifest.helpers.editorCanvasProbes,
 	path.resolve(__dirname, '..', 'lib', 'editor-canvas-probes.js')
 );
+assert.equal(manifest.helpers.woocommerceExpensiveShipping, undefined);
 assert.equal(
-	manifest.helpers.woocommerceExpensiveShipping,
+	manifest.productAdapters.woocommerce.helpers.benchFixtures,
+	path.resolve(__dirname, '..', 'scripts', 'bench', 'lib', 'woocommerce-fixtures.php')
+);
+assert.equal(
+	manifest.productAdapters.woocommerce.helpers.expensiveShipping,
 	path.resolve(__dirname, '..', 'scripts', 'bench', 'lib', 'woocommerce-expensive-shipping.php')
 );
 

--- a/wordpress/tests/page-profiler-smoke.js
+++ b/wordpress/tests/page-profiler-smoke.js
@@ -27,6 +27,7 @@ const {
 	formatWordPressRestNetworkDiffMarkdownReport,
 	formatWordPressRestPayloadBudgetMarkdownReport,
 	formatWordPressRestWaterfallMarkdownReport,
+	DEFAULT_THIRD_PARTY_WATERFALL_GROUPS,
 	normalizeBrowserAction,
 	normalizePageManifest,
 	normalizeWordPressPageMatrixManifest,
@@ -44,6 +45,7 @@ const {
 	summarizeWordPressRestNetworkRows,
 	summarizeWordPressRestWaterfall,
 	summarizeResourceTimings,
+	WORDPRESS_PAGE_PROFILER_PRODUCT_ADAPTERS,
 } = require('../lib/page-profiler');
 
 class FakeFrame {
@@ -179,6 +181,8 @@ assert.equal(classifyResourceUrl('https://example.test/wp-admin/load-styles.php'
 assert.equal(classifyResourceUrl('https://example.test/wp-content/themes/theme/style.css'), 'content-asset');
 assert.equal(resourceFamily('https://example.test/wp-includes/js/dist/block-editor.min.js?ver=1'), '/wp-includes/js/dist/block-editor.js');
 assert.equal(resourceFamily('https://example.test/wp-content/plugins/example-plugin/assets/admin.js?ver=1'), '/wp-content/plugins/example-plugin');
+assert.equal(DEFAULT_THIRD_PARTY_WATERFALL_GROUPS.some((group) => group.id === 'woocommerce-store-api'), false);
+assert.equal(WORDPRESS_PAGE_PROFILER_PRODUCT_ADAPTERS.woocommerce.firstPartyWaterfallGroupIds[0], 'woocommerce-store-api');
 
 const manifest = normalizePageManifest({
 	pages: [
@@ -696,6 +700,13 @@ process.stdout.write(JSON.stringify(output) + '\\n');
 		});
 		assert.equal(standaloneAttribution.groups.find((group) => group.id === 'payments').responseCount, 3);
 		assert.equal(standaloneAttribution.groups.find((group) => group.id === 'same-origin').responseCount, 4);
+		assert.equal(standaloneAttribution.groups.find((group) => group.id === 'woocommerce-store-api'), undefined);
+		const woocommerceAttribution = summarizeThirdPartyWaterfall(browserNetworkRows, {
+			baseUrl: 'https://example.test',
+			productAdapters: ['woocommerce'],
+		});
+		assert.equal(woocommerceAttribution.groups.find((group) => group.id === 'woocommerce-store-api').responseCount, 1);
+		assert.equal(woocommerceAttribution.thirdPartyGroupCount, 3);
 		writeJson(path.join(browserDirectory, 'action-summary.json'), {
 			schema: 'wp-codebox/browser-actions/v1',
 			startedAt: '2026-01-01T00:00:01.250Z',
@@ -726,7 +737,8 @@ process.stdout.write(JSON.stringify(output) + '\\n');
 		assert.equal(artifactProfile.thirdPartyWaterfall.groups.find((group) => group.id === 'stripe').responseCount, 3);
 		assert.equal(artifactProfile.thirdPartyWaterfall.groups.find((group) => group.id === 'stripe').requestCount, 1);
 		assert.equal(artifactProfile.thirdPartyWaterfall.groups.find((group) => group.id === 'stripe').transferSizeBytes, 7800);
-		assert.equal(artifactProfile.thirdPartyWaterfall.groups.find((group) => group.id === 'woocommerce-store-api').responseCount, 1);
+		assert.equal(artifactProfile.thirdPartyWaterfall.groups.find((group) => group.id === 'wordpress-assets').responseCount, 4);
+		assert.equal(artifactProfile.thirdPartyWaterfall.groups.find((group) => group.id === 'woocommerce-store-api'), undefined);
 		assert.equal(artifactProfile.thirdPartyWaterfall.groups.find((group) => group.id === 'google').resourceTypes.font, 1);
 		assert.equal(artifactProfile.thirdPartyWaterfall.groups.find((group) => group.id === 'third-party:cdn.example-cdn.test').duplicateUrlPatterns[0].count, 2);
 		assert.equal(artifactProfile.browserMetrics.browser_network_stripe_transfer_size_bytes, 7800);


### PR DESCRIPTION
## Summary
- Move WooCommerce profiler grouping behind an explicit product adapter.
- Move WooCommerce helper manifest entries under product adapter metadata.
- Document the generic WordPress extension boundary.

## Tests
- npm run test:page-profiler
- node tests/helper-manifest-smoke.js
- npm run test:static-site-fanout-adapter
- npm run test:wordpress-public-export-boundary
- git diff --check

Note: focused ESLint could not run in the fresh worktree because dependencies were not installed; focused behavior tests passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing product adapter boundary cleanup, docs, and smoke tests.