### PR TITLE
Add generic block fuzz cases

### DIFF
--- a/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
+++ b/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
@@ -308,6 +308,11 @@ function restMethodsForSurface(surface) {
 }
 
 function casesForSurface(surface, options = {}) {
+	if (surface.type === 'block') {
+		const operation = operationForSurface(surface);
+		const operationId = surface.operation_id || surface.operationId || `${surface.id}:${caseIntent(surface.type)}`;
+		return blockCasesFromSurface(surface, operation, operationId, options);
+	}
 	const crudResource = crudResourceForSurface(surface);
 	if (!crudResource) {
 		return [genericCaseForSurface(surface, options)];
@@ -487,6 +492,56 @@ function rollbackPolicyForCrudAction(action) {
 	return { strategy: 'restore-snapshot', scope: 'operation', after_each_case: true };
 }
 
+function blockCasesFromSurface(surface, operation, operationId, options = {}) {
+	const shared = {
+		seed: options.seed,
+		skip_reasons: reasonList(surface.skip_reasons || surface.skipReasons || surface.skip_reason || surface.skipReason),
+		destructive_reasons: reasonList(surface.destructive_reasons || surface.destructiveReasons || surface.destructive_reason || surface.destructiveReason || surface.unsafeReasons),
+	};
+	const attributeSample = blockAttributeSample(surface);
+	const surfaceMetadata = blockSurfaceMetadata(surface, attributeSample);
+	const cases = [
+		{
+			id: `${surface.id}-render-block`,
+			intent: 'render-block',
+			operation_id: `${operationId}:render`,
+			operation: stripUndefined({ ...operation, lifecycle: 'render', attributes_sample: attributeSample }),
+			...shared,
+			metadata: stripUndefined({ surface, safety: { mutation: 'read_only' }, attributes_sample: attributeSample }),
+		},
+	];
+
+	if (Object.keys(surfaceMetadata).length > 0) {
+		cases.push({
+			id: `${surface.id}-serialize-parse-block`,
+			intent: 'serialize-parse-block',
+			operation_id: `${operationId}:serialize-parse`,
+			operation: stripUndefined({ ...operation, lifecycle: 'serialize-parse', attributes_sample: attributeSample }),
+			...shared,
+			metadata: stripUndefined({ surface, safety: { mutation: 'read_only' }, ...surfaceMetadata }),
+		});
+	}
+
+	cases.push({
+		id: `${surface.id}-editor-insert-block`,
+		intent: 'insert-block-in-editor',
+		operation_id: `${operationId}:editor-insert`,
+		operation: stripUndefined({ ...operation, lifecycle: 'editor-insert', attributes_sample: attributeSample }),
+		...shared,
+		skip_reasons: reasonList([...shared.skip_reasons, 'requires_browser_editor_runtime']),
+		metadata: stripUndefined({
+			surface,
+			planned: true,
+			gated: true,
+			requires_runtime: ['browser', 'block-editor'],
+			safety: { mutation: 'requires_isolated_editor_draft' },
+			attributes_sample: attributeSample,
+		}),
+	});
+
+	return cases;
+}
+
 function collectAdminPageInteractions(surface) {
 	return [
 		...tagAdminPageInteractions(surface.interactions, 'interaction'),
@@ -617,6 +672,18 @@ function caseIntent(type) {
 	}[type] || 'exercise-wordpress-surface';
 }
 
+function blockAttributeSample(surface) {
+	return objectOrUndefined(surface.attributes_sample || surface.attributeSample || surface.sample_attributes || surface.sampleAttributes || surface.attributesSample || surface.example_attributes || surface.exampleAttributes);
+}
+
+function blockSurfaceMetadata(surface, attributeSample) {
+	return stripUndefined({
+		block_metadata: nonEmptyObjectOrUndefined(surface.block_metadata || surface.blockMetadata || surface.metadata),
+		attributes_schema: nonEmptyObjectOrUndefined(surface.attributes_schema || surface.attributesSchema || surface.attributes),
+		attributes_sample: attributeSample,
+	});
+}
+
 function reasonList(value) {
 	if (value === undefined || value === null) {
 		return [];
@@ -630,6 +697,14 @@ function stripUndefined(value) {
 
 function isObject(value) {
 	return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function objectOrUndefined(value) {
+	return isObject(value) ? value : undefined;
+}
+
+function nonEmptyObjectOrUndefined(value) {
+	return isObject(value) && Object.keys(value).length > 0 ? value : undefined;
 }
 
 function normalizeToken(value) {

--- a/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
@@ -26,7 +26,13 @@ const manifest = {
 		queries: { postsLookup: { query: 'SELECT ID FROM wp_posts WHERE post_type = ?' } },
 	},
 	external_http: { requests: [{ id: 'http:api-example', url: 'https://api.example.test/v1/', method: 'GET' }] },
-	blocks: [{ id: 'block:core-paragraph', name: 'core/paragraph', block_name: 'core/paragraph' }],
+	blocks: [{
+		id: 'block:core-paragraph',
+		name: 'core/paragraph',
+		block_name: 'core/paragraph',
+		attributes: { content: { type: 'string' } },
+		attributes_sample: { content: 'Sample paragraph' },
+	}],
 	frontend: [{ id: 'front:home', path: '/' }],
 	admin: [{ id: 'admin:posts', path: '/wp-admin/edit.php' }],
 	rest: [{ id: 'rest:wp-v2-posts', method: 'GET', route: '/wp/v2/posts' }],
@@ -67,6 +73,14 @@ assert.equal(targetTypes['db-query'].cases[0].operation.query, 'SELECT ID FROM w
 assert.equal(targetTypes['external-http'].cases[0].operation.url, 'https://api.example.test/v1/');
 assert(targetTypes.role.operation_id.includes('check-role-boundary'));
 assert.equal(targetTypes.block.cases[0].operation.block_name, 'core/paragraph');
+assert.deepEqual(targetTypes.block.cases.map((testCase) => testCase.intent), ['render-block', 'serialize-parse-block', 'insert-block-in-editor']);
+assert.equal(targetTypes.block.cases[0].metadata.safety.mutation, 'read_only');
+assert.deepEqual(targetTypes.block.cases[1].metadata.attributes_schema, { content: { type: 'string' } });
+assert.deepEqual(targetTypes.block.cases[1].metadata.attributes_sample, { content: 'Sample paragraph' });
+assert.equal(targetTypes.block.cases[2].metadata.planned, true);
+assert.equal(targetTypes.block.cases[2].metadata.gated, true);
+assert.deepEqual(targetTypes.block.cases[2].metadata.requires_runtime, ['browser', 'block-editor']);
+assert(targetTypes.block.cases[2].skip_reasons.includes('requires_browser_editor_runtime'));
 assert.equal(targetTypes['frontend-url'].cases[0].operation.path, '/');
 assert.equal(targetTypes['admin-page'].cases[0].operation.path, '/wp-admin/edit.php');
 assert.equal(targetTypes['rest-route'].cases[0].operation.route, '/wp/v2/posts');
@@ -194,5 +208,10 @@ assert.equal(adminCases[2].intent, 'exercise-admin-page-read-only-interaction');
 assert.deepEqual(adminCases[2].skip_reasons, []);
 assert.deepEqual(adminCases[2].destructive_reasons, []);
 assert.equal(adminCases[2].metadata.executable, true);
+
+const minimalBlockPlan = buildWordPressFuzzPlanFromSurfaces({
+	blocks: [{ id: 'block:minimal', block_name: 'example/minimal' }],
+});
+assert.deepEqual(minimalBlockPlan.targets[0].cases.map((testCase) => testCase.intent), ['render-block', 'insert-block-in-editor']);
 
 console.log('WordPress fuzz plan from surfaces smoke passed.');


### PR DESCRIPTION
## Summary
- Expand block surfaces into render, serialize/parse, and planned editor-insert cases.
- Carry block attributes schema/sample metadata into block fuzz cases.

## Verification
- `node wordpress/tests/wordpress-fuzz-schemas-smoke.js`
- `node wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js`
- `node wordpress/tests/admin-page-fuzz-surfaces-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** implementing and testing the WordPress fuzz planning changes described above.