### PR TITLE
Add DB fuzz planning primitives

### DIFF
--- a/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
+++ b/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
@@ -55,6 +55,7 @@ const SURFACE_COLLECTION_KEYS = [
 	'routes',
 ];
 const SAFE_REST_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+const DB_MUTATION_REQUIRED_CAPABILITIES = ['snapshot', 'transaction', 'reset'];
 
 function buildWordPressFuzzPlanFromSurfaces(input = {}, options = {}) {
 	const discovery = normalizeWordPressSurfaceDiscovery({
@@ -313,6 +314,10 @@ function casesForSurface(surface, options = {}) {
 		const operationId = surface.operation_id || surface.operationId || `${surface.id}:${caseIntent(surface.type)}`;
 		return blockCasesFromSurface(surface, operation, operationId, options);
 	}
+	if (['database-table', 'db-query'].includes(surface.type)) {
+		const testCase = genericCaseForSurface(surface, options);
+		return [testCase, ...dbMutationCasesFromSurface(surface, testCase.operation_id, options)];
+	}
 	const crudResource = crudResourceForSurface(surface);
 	if (!crudResource) {
 		return [genericCaseForSurface(surface, options)];
@@ -542,6 +547,55 @@ function blockCasesFromSurface(surface, operation, operationId, options = {}) {
 	return cases;
 }
 
+function dbMutationCasesFromSurface(surface, operationId, options = {}) {
+	const mutations = normalizeMutationMetadata(surface.mutations || surface.mutation || surface.mutation_metadata || surface.mutationMetadata);
+	return mutations.map((mutation, index) => {
+		const mutationId = mutation.id || mutation.name || mutation.operation || `mutation-${index + 1}`;
+		return {
+			id: `${surface.id}-${safeIdPart(mutationId)}-gated-mutation`,
+			intent: surface.type === 'database-table' ? 'mutate-database-table' : 'mutate-database-query',
+			operation_id: `${operationId}:${safeIdPart(mutationId)}`,
+			operation: stripUndefined({
+				...operationForSurface(surface),
+				mutation: mutation.operation || mutation.name || mutation.type || mutationId,
+				statement: mutation.statement || mutation.sql,
+			}),
+			seed: options.seed,
+			executable: false,
+			required_capabilities: DB_MUTATION_REQUIRED_CAPABILITIES,
+			skip_reasons: ['requires-runtime-db-safety-capabilities'],
+			destructive_reasons: ['db-mutation'],
+			metadata: { surface, mutation, gated: true },
+		};
+	});
+}
+
+function normalizeMutationMetadata(value) {
+	if (value === undefined || value === null || value === false) {
+		return [];
+	}
+	if (value === true) {
+		return [{ id: 'declared-mutation', operation: 'declared-mutation' }];
+	}
+	if (Array.isArray(value)) {
+		return value.map((item, index) => mutationObject(item, index));
+	}
+	if (isObject(value)) {
+		if (value.id || value.name || value.operation || value.type || value.statement || value.sql) {
+			return [value];
+		}
+		return Object.entries(value).map(([key, item]) => mutationObject(isObject(item) ? { id: key, ...item } : { id: key, operation: item }, 0));
+	}
+	return [mutationObject(value, 0)];
+}
+
+function mutationObject(value, index) {
+	if (isObject(value)) {
+		return value;
+	}
+	return { id: `mutation-${index + 1}`, operation: String(value) };
+}
+
 function collectAdminPageInteractions(surface) {
 	return [
 		...tagAdminPageInteractions(surface.interactions, 'interaction'),
@@ -691,6 +745,14 @@ function reasonList(value) {
 	return [...new Set((Array.isArray(value) ? value : [value]).map(String).filter(Boolean))].sort();
 }
 
+function safeIdPart(value) {
+	return String(value || 'mutation')
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '') || 'mutation';
+}
+
 function stripUndefined(value) {
 	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
 }
@@ -716,6 +778,7 @@ function normalizeToken(value) {
 }
 
 module.exports = {
+	DB_MUTATION_REQUIRED_CAPABILITIES,
 	buildWordPressFuzzPlanFromSurfaces,
 	collectWordPressFuzzPlanSurfaces,
 };

--- a/wordpress/lib/wordpress-fuzz-schemas.js
+++ b/wordpress/lib/wordpress-fuzz-schemas.js
@@ -138,12 +138,17 @@ function normalizeWordPressSurfaceDiscovery(discovery) {
 
 function normalizeFuzzCase(testCase, index, targetField) {
 	assertPlainObject(testCase, `${targetField}.cases[${index}]`);
-	return {
+	const normalized = {
 		...testCase,
 		id: normalizeId(testCase.id, `case-${index + 1}`, `${targetField}.cases[${index}].id`),
 		operation_id: testCase.operation_id || testCase.operationId || testCase.operation?.id || null,
 		metadata: { ...(testCase.metadata || {}) },
 	};
+	const requiredCapabilities = normalizeCapabilityCodes(testCase.required_capabilities || testCase.requiredCapabilities);
+	if (requiredCapabilities.length > 0) {
+		normalized.required_capabilities = requiredCapabilities;
+	}
+	return normalized;
 }
 
 function normalizeFuzzTarget(target, index) {
@@ -170,6 +175,13 @@ function normalizeReasonCodes(value) {
 		return [];
 	}
 	return [...new Set(asArray(Array.isArray(value) ? value : [value], 'reason_codes').map(String).filter(Boolean))].sort();
+}
+
+function normalizeCapabilityCodes(value) {
+	if (value === undefined || value === null) {
+		return [];
+	}
+	return [...new Set(asArray(Array.isArray(value) ? value : [value], 'required_capabilities').map(String).filter(Boolean))].sort();
 }
 
 function normalizeWordPressFuzzPlan(plan) {

--- a/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
@@ -22,8 +22,8 @@ const manifest = {
 	roles: [{ id: 'role:editor', role: 'editor', capability: 'edit_posts' }],
 	capabilities: [{ id: 'cap:manage-options', capability: 'manage_options' }],
 	database: {
-		tables: { posts: { table: 'wp_posts' } },
-		queries: { postsLookup: { query: 'SELECT ID FROM wp_posts WHERE post_type = ?' } },
+		tables: { posts: { table: 'wp_posts', mutations: [{ id: 'insert-sentinel-row', operation: 'insert' }] } },
+		queries: { postsLookup: { query: 'SELECT ID FROM wp_posts WHERE post_type = ?', mutation: { operation: 'update', statement: 'UPDATE wp_posts SET post_title = ? WHERE ID = ?' } } },
 	},
 	external_http: { requests: [{ id: 'http:api-example', url: 'https://api.example.test/v1/', method: 'GET' }] },
 	blocks: [{
@@ -68,6 +68,13 @@ assert.equal(targetTypes.role.cases[0].intent, 'check-role-boundary');
 assert.equal(targetTypes.capability.cases[0].intent, 'check-capability-boundary');
 assert.equal(targetTypes['database-table'].cases[0].intent, 'inspect-database-table');
 assert.equal(targetTypes['db-query'].cases[0].intent, 'profile-database-query');
+assert.equal(targetTypes['database-table'].cases[1].intent, 'mutate-database-table');
+assert.equal(targetTypes['database-table'].cases[1].executable, false);
+assert.deepEqual(targetTypes['database-table'].cases[1].required_capabilities, ['reset', 'snapshot', 'transaction']);
+assert.deepEqual(targetTypes['database-table'].cases[1].skip_reasons, ['requires-runtime-db-safety-capabilities']);
+assert.deepEqual(targetTypes['database-table'].cases[1].destructive_reasons, ['db-mutation']);
+assert.equal(targetTypes['db-query'].cases[1].intent, 'mutate-database-query');
+assert.equal(targetTypes['db-query'].cases[1].operation.statement, 'UPDATE wp_posts SET post_title = ? WHERE ID = ?');
 assert.equal(targetTypes['external-http'].cases[0].intent, 'exercise-external-http-guardrail');
 assert.equal(targetTypes['db-query'].cases[0].operation.query, 'SELECT ID FROM wp_posts WHERE post_type = ?');
 assert.equal(targetTypes['external-http'].cases[0].operation.url, 'https://api.example.test/v1/');

--- a/wordpress/tests/wordpress-fuzz-schemas-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-schemas-smoke.js
@@ -48,7 +48,7 @@ const plan = normalizeWordPressFuzzPlan({
 			route: '/wp/v2/posts',
 			cases: [
 				{ id: 'per-page-max', operation_id: 'rest:get-posts:per-page', query: { per_page: 100 } },
-				{ query: { search: '<script>' } },
+				{ query: { search: '<script>' }, requiredCapabilities: ['transaction', 'snapshot', 'snapshot'] },
 			],
 		},
 	],
@@ -60,6 +60,7 @@ assert.equal(plan.discovery_id, 'site-surfaces');
 assert.equal(plan.targets[0].operation_id, 'rest:get-posts');
 assert.equal(plan.targets[0].cases[0].operation_id, 'rest:get-posts:per-page');
 assert.equal(plan.targets[0].cases[1].id, 'case-2');
+assert.deepEqual(plan.targets[0].cases[1].required_capabilities, ['snapshot', 'transaction']);
 
 const result = normalizeWordPressFuzzResult({
 	schema: WORDPRESS_FUZZ_RESULT_SCHEMA,


### PR DESCRIPTION
## Summary
- Add gated DB mutation planning cases for database tables and queries.
- Normalize required runtime capabilities on fuzz cases.

## Verification
- `node wordpress/tests/wordpress-fuzz-schemas-smoke.js`
- `node wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js`
- `node wordpress/tests/admin-page-fuzz-surfaces-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** implementing and testing the WordPress fuzz planning changes described above.