### PR TITLE
Prefer public Codebox fuzz workload APIs

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -19,6 +19,8 @@ const WP_CODEBOX_FUZZ_RUN_RESULT_SCHEMA = legacyWpCodeboxFuzzRunResultSchemaAlia
 const WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA = 'homeboy/wordpress-codebox-fuzz-suite-consumer/v1';
 const WORDPRESS_CODEBOX_FUZZ_RUN_CONSUMER_SCHEMA = legacyWordPressCodeboxFuzzRunConsumerSchemaAlias();
 const DEFAULT_FUZZ_SUITE_ABILITY = 'wp-codebox/run-fuzz-suite';
+const DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY = 'wp-codebox/run-wordpress-workload';
+const DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA = 'wp-codebox/wordpress-workload-run/v1';
 const DEFAULT_FUZZ_RUN_ABILITY = legacyWpCodeboxFuzzRunAbilityAlias();
 const DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS = [
 	'wp-codebox-fuzz-suite-result',
@@ -68,9 +70,61 @@ const FUZZ_ARTIFACT_SEMANTIC_KEYS = {
 	coverage: 'fuzz.coverage',
 };
 
+const FALLBACK_WP_CODEBOX_RUNTIME_CONTRACT_MANIFEST = {
+	schema: 'wp-codebox/runtime-contract-manifest/v1',
+	version: 1,
+	schemas: {
+		wordpressRuntime: {
+			workloadRun: DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA,
+			fuzzSuite: WP_CODEBOX_FUZZ_SUITE_SCHEMA,
+			fuzzSuiteResult: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+		},
+	},
+	abilities: {
+		wordpressRuntime: {
+			runWorkload: DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY,
+			runFuzzSuite: DEFAULT_FUZZ_SUITE_ABILITY,
+		},
+	},
+};
+
+function wpCodeboxRuntimeContractManifest(options = {}) {
+	const manifest = options.runtimeContractManifest || options.runtime_contract_manifest || options.manifest || options.contractManifest || options.contract_manifest;
+	return objectOrUndefined(manifest) ? manifest : FALLBACK_WP_CODEBOX_RUNTIME_CONTRACT_MANIFEST;
+}
+
+function wpCodeboxWordPressRuntimeContracts(options = {}) {
+	const manifest = wpCodeboxRuntimeContractManifest(options);
+	return {
+		manifest,
+		abilities: objectOrUndefined(manifest.abilities?.wordpressRuntime) || FALLBACK_WP_CODEBOX_RUNTIME_CONTRACT_MANIFEST.abilities.wordpressRuntime,
+		schemas: objectOrUndefined(manifest.schemas?.wordpressRuntime) || FALLBACK_WP_CODEBOX_RUNTIME_CONTRACT_MANIFEST.schemas.wordpressRuntime,
+	};
+}
+
+function wpCodeboxFuzzSuiteAbility(options = {}) {
+	return wpCodeboxWordPressRuntimeContracts(options).abilities.runFuzzSuite || DEFAULT_FUZZ_SUITE_ABILITY;
+}
+
+function wpCodeboxWordPressWorkloadRunAbility(options = {}) {
+	return wpCodeboxWordPressRuntimeContracts(options).abilities.runWorkload || DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY;
+}
+
+function wpCodeboxFuzzSuiteSchema(options = {}) {
+	return wpCodeboxWordPressRuntimeContracts(options).schemas.fuzzSuite || WP_CODEBOX_FUZZ_SUITE_SCHEMA;
+}
+
+function wpCodeboxFuzzSuiteResultSchema(options = {}) {
+	return wpCodeboxWordPressRuntimeContracts(options).schemas.fuzzSuiteResult || WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA;
+}
+
+function wpCodeboxWordPressWorkloadRunSchema(options = {}) {
+	return wpCodeboxWordPressRuntimeContracts(options).schemas.workloadRun || DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA;
+}
+
 function wpCodeboxFuzzSuiteInput(options = {}) {
 	return stripUndefined({
-		schema: WP_CODEBOX_FUZZ_SUITE_SCHEMA,
+		schema: wpCodeboxFuzzSuiteSchema(options),
 		id: options.id || options.runId || options.run_id,
 		version: options.version,
 		target: options.target,
@@ -98,11 +152,31 @@ function wpCodeboxFuzzSuiteTaskRequest(options = {}) {
 		backend: options.backend || 'codebox',
 		runtime: options.runtime || options.runtimeId || options.runtime_id || 'wp-codebox',
 		taskId: requiredString(options.taskId || options.task_id, 'taskId'),
-		ability: options.ability || DEFAULT_FUZZ_SUITE_ABILITY,
+		ability: options.ability || wpCodeboxFuzzSuiteAbility(options),
 		abilityInput: input,
 		artifactDeclarations: options.artifactDeclarations || options.artifact_declarations || DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS,
 		expectedArtifacts: options.expectedArtifacts || options.expected_artifacts || DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS,
 		instructions: options.instructions || 'Delegate WordPress fuzz execution to WP Codebox and return the declared fuzz artifacts.',
+	});
+}
+
+function wpCodeboxWordPressWorkloadRunInput(options = {}) {
+	return stripUndefined({
+		schema: wpCodeboxWordPressWorkloadRunSchema(options),
+		id: options.id || options.runId || options.run_id,
+		wordpress_version: options.wordpressVersion || options.wordpress_version,
+		blueprint: options.blueprint,
+		preview: objectOrUndefined(options.preview),
+		mounts: normalizeArray(options.mounts),
+		runtime_stack_mounts: normalizeArray(options.runtimeStackMounts || options.runtime_stack_mounts),
+		runtime_overlays: normalizeArray(options.runtimeOverlays || options.runtime_overlays),
+		runtime_env: objectOrUndefined(options.runtimeEnv || options.runtime_env),
+		secret_env: normalizeArray(options.secretEnv || options.secret_env),
+		staged_files: normalizeArray(options.stagedFiles || options.staged_files),
+		before: normalizeArray(options.before),
+		steps: normalizeArray(options.steps),
+		after: normalizeArray(options.after),
+		metadata: objectOrUndefined(options.metadata),
 	});
 }
 
@@ -489,6 +563,9 @@ module.exports = {
 	DEFAULT_FUZZ_RUN_ARTIFACT_DECLARATIONS,
 	DEFAULT_FUZZ_RUN_EXPECTED_ARTIFACTS,
 	DEFAULT_FUZZ_SUITE_ABILITY,
+	DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY,
+	DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA,
+	FALLBACK_WP_CODEBOX_RUNTIME_CONTRACT_MANIFEST,
 	DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS,
 	DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS,
 	FUZZ_ARTIFACT_SEMANTIC_KEYS,
@@ -509,8 +586,16 @@ module.exports = {
 	normalizeWpCodeboxFuzzSuiteResult,
 	runWpCodeboxFuzzRun,
 	runWpCodeboxFuzzSuite,
+	wpCodeboxFuzzSuiteAbility,
+	wpCodeboxFuzzSuiteResultSchema,
+	wpCodeboxFuzzSuiteSchema,
 	wpCodeboxFuzzRunInput,
 	wpCodeboxFuzzRunTaskRequest,
+	wpCodeboxRuntimeContractManifest,
+	wpCodeboxWordPressRuntimeContracts,
+	wpCodeboxWordPressWorkloadRunAbility,
+	wpCodeboxWordPressWorkloadRunInput,
+	wpCodeboxWordPressWorkloadRunSchema,
 	wpCodeboxFuzzSuiteInput,
 	wpCodeboxFuzzSuiteTaskRequest,
 };

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -1,25 +1,32 @@
 #!/usr/bin/env node
 'use strict';
 
+/**
+ * External dependencies
+ */
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { spawn } = require('node:child_process');
 
+/**
+ * Internal dependencies
+ */
 const {
 	codeboxRunAgentTaskInvocation,
 	codeboxTaskRequestFromAgentTaskRequest,
 } = require('../../../agent-runtimes/wp-codebox');
-
-/**
- * Internal dependencies
- */
 const {
 	buildWordPressFuzzRunnerResult,
 	readWordPressFuzzRunnerEnv,
 	runWordPressFuzzRunnerResult,
 	writeHomeboyFuzzResultsFile,
 } = require('../../lib/wordpress-fuzz-runner');
+const { loadWpCodeboxCoreFunction } = require('../../lib/wp-codebox-core-loader');
+const {
+	wpCodeboxFuzzSuiteAbility,
+	wpCodeboxRuntimeContractManifest,
+} = require('../../lib/wp-codebox-fuzz-run');
 
 
 (async () => {
@@ -45,8 +52,22 @@ async function buildRunnerResult(env) {
 
 async function runWpCodeboxAgentTask(request) {
 	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-fuzz-'));
-	const inputFile = path.join(tempDir, 'agent-task-request.json');
 	const command = process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || 'wp-codebox';
+	const manifest = await discoverRuntimeContractManifest();
+	const publicInvocation = wpCodeboxPublicRuntimeInvocation(request, { runtimeContractManifest: manifest });
+
+	if (publicInvocation) {
+		try {
+			const publicResult = await runWpCodeboxPublicRuntimeCommand(command, publicInvocation, tempDir);
+			return { json: normalizeWpCodeboxAgentTaskOutput(publicResult, request) };
+		} catch (error) {
+			if (!shouldFallbackToRunAgentTask(error)) {
+				throw error;
+			}
+		}
+	}
+
+	const inputFile = path.join(tempDir, 'agent-task-request.json');
 	const invocation = wpCodeboxRunAgentTaskInvocation(request);
 	fs.writeFileSync(inputFile, `${JSON.stringify(invocation.input, null, 2)}\n`);
 
@@ -57,6 +78,67 @@ async function runWpCodeboxAgentTask(request) {
 	});
 
 	return { json: normalizeWpCodeboxAgentTaskOutput(result, request) };
+}
+
+async function discoverRuntimeContractManifest() {
+	try {
+		const runtimeContractManifest = await loadWpCodeboxCoreFunction('runtimeContractManifest');
+		if (typeof runtimeContractManifest === 'function') {
+			return runtimeContractManifest();
+		}
+	} catch {
+		// Older WP Codebox installs do not publish the core package yet.
+	}
+	return wpCodeboxRuntimeContractManifest();
+}
+
+function wpCodeboxPublicRuntimeInvocation(request, options = {}) {
+	const runtimeTask = request.executor?.config?.runtime_task || {};
+	const ability = runtimeTask.ability || wpCodeboxFuzzSuiteAbility(options);
+	const command = wpCodeboxCommandFromPublicAbility(ability, options);
+	if (!command) {
+		return null;
+	}
+	return {
+		ability,
+		command,
+		input: {
+			...(runtimeTask.input || {}),
+			metadata: {
+				...(runtimeTask.input?.metadata || {}),
+				homeboy_agent_task_request: request,
+			},
+		},
+	};
+}
+
+function wpCodeboxCommandFromPublicAbility(ability, options = {}) {
+	const contracts = wpCodeboxRuntimeContractManifest(options).abilities?.wordpressRuntime || {};
+	const publicAbilities = new Set([
+		contracts.runWorkload,
+		contracts.runFuzzSuite,
+		'wp-codebox/run-wordpress-workload',
+		'wp-codebox/run-fuzz-suite',
+	].filter(Boolean));
+	if (!publicAbilities.has(ability)) {
+		return '';
+	}
+	return String(ability).replace(/^wp-codebox\//, '');
+}
+
+async function runWpCodeboxPublicRuntimeCommand(command, invocation, tempDir) {
+	const inputFile = path.join(tempDir, `${invocation.command}-request.json`);
+	fs.writeFileSync(inputFile, `${JSON.stringify(invocation.input, null, 2)}\n`);
+	return spawnJson(command, [invocation.command, '--input-file', inputFile, '--json'], {
+		cwd: process.cwd(),
+		env: process.env,
+	});
+}
+
+function shouldFallbackToRunAgentTask(error) {
+	const message = String(error?.message || '').toLowerCase();
+	return error?.code === 'ENOENT'
+		|| /unknown command|invalid command|not found|no such command|unrecognized command|unknown subcommand|unsupported command/.test(message);
 }
 
 function wpCodeboxRunAgentTaskInvocation(request) {
@@ -95,7 +177,11 @@ function spawnJson(command, args, options) {
 			if (code !== 0) {
 				const details = [stderr.trim(), stdout.trim()].filter(Boolean).join('\n');
 				const message = parsed?.error?.message || details || `${command} exited with ${code}`;
-				reject(new Error(message));
+				const error = new Error(message);
+				error.exitCode = code;
+				error.stderr = stderr;
+				error.stdout = stdout;
+				reject(error);
 				return;
 			}
 			resolve(parsed || { stdout, stderr, status: code });

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -185,43 +185,22 @@ const dispatchResultsPath = path.join(tempDir, 'dispatch-results.json');
 fs.writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
 const inputFile = process.argv[process.argv.indexOf('--input-file') + 1];
+const command = process.argv[2];
 const request = JSON.parse(fs.readFileSync(inputFile, 'utf8'));
-if (request.schema !== '${runtimeContractSchemas().agentTask.runRequest}' || request.task_id !== 'dispatch-cli-run') {
-  process.stderr.write('invalid run-agent-task input');
+if (command !== 'run-fuzz-suite') {
+  process.stderr.write('expected public run-fuzz-suite command');
   process.exit(1);
 }
-if (request.runtime_task || request.artifact_declarations || request.sandbox_tool_policy || request.extra_plugins) {
-  process.stderr.write('runner rebuilt the Codebox task payload instead of delegating to the adapter');
-  process.exit(1);
-}
-if (request.task_input?.schema !== 'wp-codebox/task-input/v1') {
-  process.stderr.write('missing delegated task input');
-  process.exit(1);
-}
-if (request.task_input?.runtime_task?.ability !== 'wp-codebox/run-fuzz-suite' || request.task_input?.runtime_task?.input?.schema !== 'wp-codebox/fuzz-suite/v1') {
-  process.stderr.write('missing fuzz runtime task');
-  process.exit(1);
-}
-if (request.task_input?.artifact_declarations?.[0]?.name !== 'wp-codebox-fuzz-suite-result' || !request.task_input?.expected_artifacts?.includes('wordpress-fuzz-coverage')) {
-  process.stderr.write('missing delegated artifact contract');
-  process.exit(1);
-}
-if (request.task_input?.parent_request?.task_id !== 'dispatch-cli-run') {
-  process.stderr.write('missing parent request metadata');
+if (request.schema !== 'wp-codebox/fuzz-suite/v1' || request.metadata?.homeboy_agent_task_request?.task_id !== 'dispatch-cli-run') {
+  process.stderr.write('invalid public fuzz-suite input');
   process.exit(1);
 }
 process.stdout.write(JSON.stringify({
-  success: true,
-  agent_task_run_result: {
-    schema: '${runtimeContractSchemas().agentTask.runResult}',
-    result: {
-      schema: 'wp-codebox/fuzz-suite-result/v1',
-      request_id: request.task_id,
-      status: 'succeeded',
-      artifactRefs: [{ path: 'fake/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
-      coverage_summary: { surface_count: 1, exercised_count: 1 }
-    }
-  }
+  schema: 'wp-codebox/fuzz-suite-result/v1',
+  request_id: request.id,
+  status: 'succeeded',
+  artifactRefs: [{ path: 'fake/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
+  coverage_summary: { surface_count: 1, exercised_count: 1 }
 }));
 `);
 fs.chmodSync(fakeCodeboxBin, 0o755);
@@ -243,6 +222,73 @@ const dispatchCliResult = JSON.parse(dispatchCli.stdout);
 assert.equal(dispatchCliResult.succeeded, true);
 assert.equal(dispatchCliResult.wp_codebox_result.request_id, 'dispatch-cli-run');
 assert.equal(dispatchCliResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path, 'fake/fuzz-report.json');
+
+const legacyCodeboxBin = path.join(tempDir, 'packages/cli/dist/fake-legacy-wp-codebox.js');
+fs.writeFileSync(legacyCodeboxBin, `#!/usr/bin/env node
+const fs = require('node:fs');
+const command = process.argv[2];
+if (command === 'run-fuzz-suite') {
+  process.stderr.write('unknown command: run-fuzz-suite');
+  process.exit(1);
+}
+const inputFile = process.argv[process.argv.indexOf('--input-file') + 1];
+const request = JSON.parse(fs.readFileSync(inputFile, 'utf8'));
+if (command !== 'run-agent-task' || request.schema !== '${runtimeContractSchemas().agentTask.runRequest}' || request.task_id !== 'legacy-dispatch-cli-run') {
+  process.stderr.write('invalid run-agent-task fallback input');
+  process.exit(1);
+}
+if (request.runtime_task || request.artifact_declarations || request.sandbox_tool_policy || request.extra_plugins) {
+  process.stderr.write('fallback rebuilt the Codebox task payload instead of delegating to the adapter');
+  process.exit(1);
+}
+if (request.task_input?.schema !== 'wp-codebox/task-input/v1') {
+  process.stderr.write('missing delegated task input');
+  process.exit(1);
+}
+if (request.task_input?.runtime_task?.ability !== 'wp-codebox/run-fuzz-suite' || request.task_input?.runtime_task?.input?.schema !== 'wp-codebox/fuzz-suite/v1') {
+  process.stderr.write('missing fuzz runtime task');
+  process.exit(1);
+}
+if (request.task_input?.artifact_declarations?.[0]?.name !== 'wp-codebox-fuzz-suite-result' || !request.task_input?.expected_artifacts?.includes('wordpress-fuzz-coverage')) {
+  process.stderr.write('missing delegated artifact contract');
+  process.exit(1);
+}
+if (request.task_input?.parent_request?.task_id !== 'legacy-dispatch-cli-run') {
+  process.stderr.write('missing parent request metadata');
+  process.exit(1);
+}
+process.stdout.write(JSON.stringify({
+  success: true,
+  agent_task_run_result: {
+    schema: '${runtimeContractSchemas().agentTask.runResult}',
+    result: {
+      schema: 'wp-codebox/fuzz-suite-result/v1',
+      request_id: request.task_id,
+      status: 'succeeded',
+      artifactRefs: [{ path: 'legacy/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
+      coverage_summary: { surface_count: 1, exercised_count: 1 }
+    }
+  }
+}));
+`);
+fs.chmodSync(legacyCodeboxBin, 0o755);
+
+const legacyDispatchCli = spawnSync(runnerPath, [], {
+	encoding: 'utf8',
+	env: {
+		...process.env,
+		HOMEBOY_WP_CODEBOX_BIN: legacyCodeboxBin,
+		HOMEBOY_WP_CODEBOX_PLUGIN_PATH: path.join(tempDir, 'packages/wordpress-plugin'),
+		HOMEBOY_FUZZ_WORKLOAD_PATH: workloadPath,
+		HOMEBOY_FUZZ_WORKLOAD_ID: 'legacy-dispatch-cli-workload',
+		HOMEBOY_FUZZ_RUN_ID: 'legacy-dispatch-cli-run',
+	},
+});
+
+assert.equal(legacyDispatchCli.status, 0, legacyDispatchCli.stderr);
+const legacyDispatchCliResult = JSON.parse(legacyDispatchCli.stdout);
+assert.equal(legacyDispatchCliResult.succeeded, true);
+assert.equal(legacyDispatchCliResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path, 'legacy/fuzz-report.json');
 
 dispatchPromise.then(() => {
 	console.log('WordPress fuzz runner smoke passed.');

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -8,6 +8,8 @@ const {
 	DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS,
 	DEFAULT_FUZZ_SUITE_ABILITY,
 	DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS,
+	DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY,
+	DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA,
 	WORDPRESS_CODEBOX_FUZZ_RUN_CONSUMER_SCHEMA,
 	WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
@@ -16,6 +18,11 @@ const {
 	legacyWpCodeboxFuzzRunAbilityAlias,
 	legacyWpCodeboxFuzzRunArtifactDeclarationsAlias,
 	legacyWpCodeboxFuzzRunSchemaAlias,
+	wpCodeboxFuzzSuiteAbility,
+	wpCodeboxFuzzSuiteSchema,
+	wpCodeboxWordPressWorkloadRunAbility,
+	wpCodeboxWordPressWorkloadRunInput,
+	wpCodeboxWordPressWorkloadRunSchema,
 	normalizeWpCodeboxFuzzRunResult,
 	normalizeWpCodeboxFuzzSuiteResult,
 	runWpCodeboxFuzzRun,
@@ -48,6 +55,46 @@ assert.equal(WORDPRESS_CODEBOX_FUZZ_RUN_CONSUMER_SCHEMA, WORDPRESS_CODEBOX_FUZZ_
 assert.equal(input.target.slug, 'sample-plugin');
 assert.deepEqual(input.metadata.limits, { max_cases: 1 });
 assert.equal(wpCodeboxFuzzSuiteInput({ id: 'suite-alias' }).schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+
+const manifest = {
+	schema: 'wp-codebox/runtime-contract-manifest/v1',
+	version: 1,
+	schemas: {
+		wordpressRuntime: {
+			workloadRun: 'wp-codebox/wordpress-workload-run/v1',
+			fuzzSuite: 'wp-codebox/fuzz-suite/v1',
+			fuzzSuiteResult: 'wp-codebox/fuzz-suite-result/v1',
+		},
+	},
+	abilities: {
+		wordpressRuntime: {
+			runWorkload: 'wp-codebox/run-wordpress-workload',
+			runFuzzSuite: 'wp-codebox/run-fuzz-suite',
+		},
+	},
+};
+
+assert.equal(wpCodeboxFuzzSuiteAbility({ runtimeContractManifest: manifest }), DEFAULT_FUZZ_SUITE_ABILITY);
+assert.equal(wpCodeboxFuzzSuiteSchema({ runtimeContractManifest: manifest }), WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+assert.equal(wpCodeboxWordPressWorkloadRunAbility({ runtimeContractManifest: manifest }), DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY);
+assert.equal(wpCodeboxWordPressWorkloadRunSchema({ runtimeContractManifest: manifest }), DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA);
+assert.deepEqual(wpCodeboxWordPressWorkloadRunInput({
+	id: 'workload-run',
+	steps: [{ command: 'wordpress.run-declarative-fuzz' }],
+	metadata: { source: 'smoke' },
+}), {
+	schema: DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA,
+	id: 'workload-run',
+	mounts: [],
+	runtime_stack_mounts: [],
+	runtime_overlays: [],
+	secret_env: [],
+	staged_files: [],
+	before: [],
+	steps: [{ command: 'wordpress.run-declarative-fuzz' }],
+	after: [],
+	metadata: { source: 'smoke' },
+});
 
 const taskRequest = wpCodeboxFuzzSuiteTaskRequest({
 	taskId: 'wp-codebox-fuzz-suite-smoke',


### PR DESCRIPTION
## Summary
- Discover WP Codebox runtime contracts when available.
- Prefer public run-fuzz-suite / workload contract paths for WordPress fuzz orchestration.
- Preserve legacy run-agent-task fallback via the shared Codebox adapter.

Replacement for #1722 after GitHub kept stale conflict state on the original branch.

## Tests
- npm run test:wp-codebox-fuzz-run
- npm run test:wordpress-fuzz-runner
- npx eslint lib/wp-codebox-fuzz-run.js scripts/fuzz/fuzz-runner.cjs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing public Codebox workload/fuzz API integration, adapter fallback, and tests.