### PR TITLE
Delegate to WP Codebox normalizers

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -690,6 +690,8 @@ function codeboxRuntimeRequirementsFromAgentTaskRequest(config, options = {}, de
     providerPluginPaths,
     runtimeStateMounts: firstDefined(config.runtime_state_mounts, config.runtimeStateMounts, config.wp_codebox_runtime_state_mounts, runtimeRequirements.runtime_state_mounts, runtimeProfile.runtime_state_mounts, options.runtimeStateMounts, defaults.runtimeStateMounts),
     runtimeConfigMounts: firstDefined(config.runtime_config_mounts, config.runtimeConfigMounts, config.wp_codebox_runtime_config_mounts, runtimeRequirements.runtime_config_mounts, runtimeProfile.runtime_config_mounts, options.runtimeConfigMounts, defaults.runtimeConfigMounts),
+    normalizeRuntimeProfile: options.normalizeRuntimeProfile,
+    normalizeRuntimeProfilePayload: options.normalizeRuntimeProfilePayload,
   });
 }
 

--- a/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-artifact-contract.js
@@ -39,6 +39,13 @@ function normalizeTypedArtifactEntry(name, artifact, options = {}) {
   if (!plainObject(artifact)) {
     return null;
   }
+  const coreNormalizer = firstFunction(options.normalizeTypedArtifactEntry, options.normalizeTypedArtifactDto, options.normalizeTypedArtifactDTO);
+  if (coreNormalizer) {
+    const normalized = normalizeWithCoreTypedArtifactNormalizer(coreNormalizer, name, artifact, options);
+    if (plainObject(normalized)) {
+      return typeof options.sanitize === 'function' ? options.sanitize(normalized) : normalized;
+    }
+  }
   const artifactName = artifact.name || name;
   if (!artifactName) {
     return null;
@@ -57,6 +64,13 @@ function normalizeTypedArtifactEntry(name, artifact, options = {}) {
 }
 
 function normalizeTypedArtifacts(value, options = {}) {
+  const coreNormalizer = firstFunction(options.normalizeTypedArtifacts, options.normalizeTypedArtifactMap);
+  if (coreNormalizer) {
+    const normalized = normalizeWithCoreTypedArtifactsNormalizer(coreNormalizer, value, options);
+    if (plainObject(normalized)) {
+      return typeof options.sanitize === 'function' ? options.sanitize(normalized) : normalized;
+    }
+  }
   if (Array.isArray(value)) {
     return Object.fromEntries(value
       .map((artifact, index) => normalizeTypedArtifactEntry(artifact?.name || artifact?.id || `artifact_${index + 1}`, artifact, options))
@@ -86,6 +100,30 @@ function typedArtifactsFromCodeboxResult(result, options = {}) {
 
   return Object.assign({}, ...legacyTypedArtifactCandidatesFromCodeboxResult(result, workload)
     .map((candidate) => normalizeTypedArtifacts(candidate, options)));
+}
+
+function normalizeWithCoreTypedArtifactNormalizer(normalizer, name, artifact, options = {}) {
+  try {
+    return normalizer(name, artifact, { sanitize: options.sanitize });
+  } catch {
+    try {
+      return normalizer({ ...artifact, name: artifact.name || name }, { sanitize: options.sanitize });
+    } catch {
+      return null;
+    }
+  }
+}
+
+function normalizeWithCoreTypedArtifactsNormalizer(normalizer, value, options = {}) {
+  try {
+    return normalizer(value, { sanitize: options.sanitize });
+  } catch {
+    return null;
+  }
+}
+
+function firstFunction(...values) {
+  return values.find((value) => typeof value === 'function') || null;
 }
 
 function caseArtifactIndexFromCodeboxResult(result, options = {}) {

--- a/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
@@ -29,6 +29,8 @@ function codeboxRuntimeProfilePayload({
   providerPluginPaths = [],
   runtimeStateMounts,
   runtimeConfigMounts,
+  normalizeRuntimeProfile,
+  normalizeRuntimeProfilePayload,
 } = {}) {
   const normalizedProfile = plainObject(profile);
   const normalizedRuntimeRequirements = plainObject(runtimeRequirements);
@@ -60,7 +62,7 @@ function codeboxRuntimeProfilePayload({
     ...providerPluginEntries(normalizedRuntimeRequirements.provider_plugins),
     ...providerPluginPaths.map((pluginPath) => ({ path: pluginPath })),
   ]);
-  return withoutEmptyObjectValues({
+  const payload = withoutEmptyObjectValues({
     ...normalizedProfile,
     ...normalizedRuntimeRequirements,
     schema: WP_CODEBOX_RUNTIME_PROFILE_SCHEMA,
@@ -76,6 +78,24 @@ function codeboxRuntimeProfilePayload({
     runtime_config_mounts: runtimeConfigMounts,
     ...parentToolBridgeProfileFields(normalizedProfile, normalizedRuntimeRequirements, runtimeProfileDependencies, normalizedComponentContracts),
   });
+  const coreNormalizer = firstFunction(normalizeRuntimeProfilePayload, normalizeRuntimeProfile);
+  if (coreNormalizer) {
+    const normalized = normalizeWithCoreRuntimeProfileNormalizer(coreNormalizer, payload, {
+      id,
+      profile: normalizedProfile,
+      runtimeRequirements: normalizedRuntimeRequirements,
+      componentContracts,
+      runtimeOverlays,
+      runtimeEnv,
+      providerPluginPaths,
+      runtimeStateMounts,
+      runtimeConfigMounts,
+    });
+    if (isPlainObject(normalized)) {
+      return normalized;
+    }
+  }
+  return payload;
 }
 
 function componentContractsFromDependencies(runtimeProfileDependencies = {}) {
@@ -257,6 +277,22 @@ function slugFromPath(value) {
 
 function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
+}
+
+function normalizeWithCoreRuntimeProfileNormalizer(normalizer, payload, context = {}) {
+  try {
+    return normalizer(payload, context);
+  } catch {
+    try {
+      return normalizer(context);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function firstFunction(...values) {
+  return values.find((value) => typeof value === 'function') || null;
 }
 
 function uniqueObjectsByRuntimeIdentity(entries) {

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs
@@ -548,14 +548,17 @@ function missingModelPreflightPayload(taskInput) {
 
 async function loadCodeboxCoreNormalizers() {
   const module = await loadWpCodeboxCore(WP_CODEBOX_RUN_RESULTS_MODULE_OPTIONS);
-  if (typeof module?.normalizeAgentTaskRunResult === 'function' || typeof module?.normalizeRecipeRunSummary === 'function') {
-    return {
-      normalizeAgentTaskRunResult: typeof module.normalizeAgentTaskRunResult === 'function' ? module.normalizeAgentTaskRunResult : null,
-      normalizeRecipeRunSummary: typeof module.normalizeRecipeRunSummary === 'function' ? module.normalizeRecipeRunSummary : null,
-    };
-  }
-
-  return {};
+  return Object.fromEntries(Object.entries({
+    normalizeAgentTaskRunResult: module?.normalizeAgentTaskRunResult,
+    normalizeRecipeRunSummary: module?.normalizeRecipeRunSummary,
+    normalizeRuntimeProfile: module?.normalizeRuntimeProfile,
+    normalizeRuntimeProfilePayload: module?.normalizeRuntimeProfilePayload,
+    normalizeTypedArtifactEntry: module?.normalizeTypedArtifactEntry,
+    normalizeTypedArtifactDto: module?.normalizeTypedArtifactDto,
+    normalizeTypedArtifactDTO: module?.normalizeTypedArtifactDTO,
+    normalizeTypedArtifacts: module?.normalizeTypedArtifacts,
+    normalizeTypedArtifactMap: module?.normalizeTypedArtifactMap,
+  }).filter(([, value]) => typeof value === 'function'));
 }
 
 function runtimeOverlayConfigFailurePayload(error) {
@@ -580,7 +583,7 @@ async function runTaskRunner(request) {
   const config = request.executor?.config || {};
   let taskInput;
   try {
-    taskInput = codeboxTaskRequestFromAgentTaskRequest(request);
+    taskInput = codeboxTaskRequestFromAgentTaskRequest(request, coreNormalizers);
   } catch (error) {
     const validationPayload = runtimeOverlayConfigFailurePayload(error);
     if (validationPayload) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -100,6 +100,17 @@ process.stdout.write(JSON.stringify({
   success: true,
   status: 'completed',
   summary: 'Sandbox completed.',
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    typed_artifacts: [
+      {
+        name: 'fixture_report',
+        type: 'FixtureReport',
+        artifact_schema: 'example/fixture-report/v1',
+        payload: { ok: true }
+      }
+    ]
+  },
   artifacts: [{ id: 'artifact-1', kind: 'screenshot', path: '/artifacts/screenshot.png' }],
   evidence_refs: [{ kind: 'preview', uri: 'https://example.test/preview', label: 'Preview' }],
   run: {
@@ -2683,6 +2694,7 @@ try {
   assert.equal(normalizedOutcome.metadata.decision_evidence.run_id, 'fixture-run-1');
   assert.equal(normalizedOutcome.metadata.decision_evidence.runtime_status, 'destroyed');
   assert.equal(normalizedOutcome.metadata.decision_evidence.patch_sha256, 'fixture-patch-sha');
+  assert.equal(normalizedOutcome.metadata.typed_artifacts.fixture_report.metadata.fixture_typed_artifact_normalizer, true);
   assert.equal(normalizedOutcome.artifacts.some((artifact) => artifact.kind === 'codebox-patch' && artifact.path === '/tmp/fixture-normalized/patch.diff'), true);
   assert.equal(normalizedOutcome.artifacts.some((artifact) => artifact.kind === 'recipe-probe-result' && artifact.path === '/tmp/fixture-normalized/recipe-probe.json'), true);
   assert.equal(normalizedOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'fixture.normalizer'), true);
@@ -2709,6 +2721,7 @@ try {
   assert.equal(captured.request.schema, 'wp-codebox/task-input/v1');
   assert.equal(captured.request.orchestrator.agent_task_id, 'task-123');
   assert.equal(captured.request.runtime_overlays[0].kind, 'bundled-library');
+  assert.equal(captured.request.runtime_requirements.metadata.fixture_runtime_profile_normalizer, true);
 
   const recipeCliResult = spawnSync(process.execPath, [
     wpCodeboxRuntimeExecutor,

--- a/wordpress/tests/fixtures/wp-codebox-core-agent-task-normalizer.mjs
+++ b/wordpress/tests/fixtures/wp-codebox-core-agent-task-normalizer.mjs
@@ -79,3 +79,34 @@ export function normalizeRecipeRunSummary(raw, options = {}) {
     },
   };
 }
+
+export function normalizeRuntimeProfilePayload(payload) {
+  return {
+    ...payload,
+    metadata: {
+      ...(payload.metadata || {}),
+      fixture_runtime_profile_normalizer: true,
+    },
+  };
+}
+
+export function normalizeTypedArtifactEntry(name, raw) {
+  const artifact = raw && typeof raw === 'object' ? raw : {};
+  const artifactName = artifact.name || name;
+  if (!artifactName) {
+    return null;
+  }
+  return {
+    schema: 'homeboy/agent-task-typed-artifact/v1',
+    name: artifactName,
+    type: artifact.type || artifact.kind,
+    artifact_schema: artifact.artifact_schema || artifact.artifactSchema || artifact.schema,
+    payload: artifact.payload !== undefined ? artifact.payload : artifact.data,
+    provenance: artifact.provenance || {},
+    file_refs: artifact.file_refs || artifact.fileRefs || [],
+    metadata: {
+      ...(artifact.metadata || {}),
+      fixture_typed_artifact_normalizer: true,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds feature-detected WP Codebox normalizer hooks for runtime profiles and typed artifacts.
- Preserves a narrow compatibility boundary while upstream exports land.
- Strengthens adapter smoke coverage to prove imported normalizers are invoked.

## Testing
- node wordpress/tests/codebox-agent-task-executor-smoke.js
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js
- node tests/wp-codebox-run-agent-task-contract-smoke.mjs && node tests/codebox-delegated-run-normalizer-smoke.mjs
- node tests/wp-codebox-artifact-contract-smoke.mjs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, tests, and PR preparation.