### PR TITLE
Fix Codebox typed artifact expectations

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -2385,7 +2385,7 @@ function typedArtifactNameFromDeclaration(declaration) {
 
 function requiredArtifactDeclarationsFromRequest(request) {
   const config = request.executor?.config || {};
-  return artifactDeclarationsFromAgentTaskRequest(request, config, request.inputs || {})
+  return codeboxTaskArtifactDeclarations(artifactDeclarationsFromAgentTaskRequest(request, config, request.inputs || {}))
     .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true && typedArtifactNameFromDeclaration(declaration));
 }
 

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -142,6 +142,7 @@ const WP_CODEBOX_RUNTIME_GAP_TRACKERS = [
     needed_primitive: 'WP Codebox should export a stable typed-artifact DTO normalizer compatible with Homeboy agent-task typed artifact declarations, including file_refs/fileRefs and artifact_schema/artifactSchema aliases while allowing caller-owned metadata redaction policy.',
   },
 ];
+const WP_CODEBOX_BUILTIN_ARTIFACT_DECLARATION_NAMES = new Set(['patch', 'agent_result', 'transcript']);
 
 function assertAgentTaskRequest(request) {
   if (!request || request.schema !== AGENT_TASK_REQUEST_SCHEMA) {
@@ -328,7 +329,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   let components = runtimeComponentPaths(config, { ...defaults, ...runtimeOptions, componentContracts });
   const agentBundles = firstDefined(inputs.agent_bundles, inputs.agentBundles, config.agent_bundles, config.agentBundles, runtimeOptions.agentBundles, []);
   const structuredArtifacts = firstDefined(inputs.structured_artifacts, inputs.structuredArtifacts, config.structured_artifacts, config.structuredArtifacts, runtimeOptions.structuredArtifacts, []);
-  const artifactDeclarations = artifactDeclarationsFromAgentTaskRequest(request, config, inputs, runtimeOptions);
+  const artifactDeclarations = codeboxTaskArtifactDeclarations(artifactDeclarationsFromAgentTaskRequest(request, config, inputs, runtimeOptions));
   const homeboyToolPolicy = homeboyAgentToolPolicy();
   const allowedTools = allowedToolsFromAgentTaskRequest(request, config, inputs, runtimeOptions, defaults);
   const sandboxToolPolicy = sandboxToolPolicyFromAgentTaskRequest(config, inputs, runtimeOptions, defaults, allowedTools, homeboyToolPolicy);
@@ -452,6 +453,15 @@ function expectedArtifactsForCodeboxTask(request, artifactDeclarations = []) {
     return Array.from(new Set(declarationNames));
   }
   return normalizeArray(request.expected_artifacts);
+}
+
+function codeboxTaskArtifactDeclarations(artifactDeclarations = []) {
+  const declarations = normalizeArray(artifactDeclarations);
+  const taskSpecificDeclarations = declarations.filter((declaration) => {
+    const name = typedArtifactNameFromDeclaration(declaration);
+    return name && !WP_CODEBOX_BUILTIN_ARTIFACT_DECLARATION_NAMES.has(name);
+  });
+  return taskSpecificDeclarations.length > 0 ? taskSpecificDeclarations : declarations;
 }
 
 function runtimeOptionsFromExecutorConfig(config = {}, options = {}) {
@@ -766,7 +776,7 @@ function genericAbilityRuntimeTask(request, config, inputs) {
 }
 
 function agentBundleRuntimeTaskInputWithArtifactOutputs(input, request, config, inputs) {
-  const declarations = artifactDeclarationsFromAgentTaskRequest(request, config, inputs)
+  const declarations = codeboxTaskArtifactDeclarations(artifactDeclarationsFromAgentTaskRequest(request, config, inputs))
     .filter((declaration) => declaration && typeof declaration === 'object' && declaration.required === true && typedArtifactNameFromDeclaration(declaration));
   if (declarations.length === 0) {
     return input;

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -376,7 +376,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     target,
     workspace_materialization: workspaceMaterialization,
     allowed_tools: sandboxAllowedTools || [],
-    expected_artifacts: request.expected_artifacts || [],
+    expected_artifacts: expectedArtifactsForCodeboxTask(request, artifactDeclarations),
     artifact_declarations: artifactDeclarations,
     policy: request.policy || {},
     context,
@@ -441,6 +441,17 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     agent_bundle: agentBundle,
     parent_request: request,
   };
+}
+
+function expectedArtifactsForCodeboxTask(request, artifactDeclarations = []) {
+  const declarationNames = artifactDeclarations
+    .filter((declaration) => declaration && declaration.required === true)
+    .map((declaration) => typedArtifactNameFromDeclaration(declaration))
+    .filter(Boolean);
+  if (declarationNames.length > 0) {
+    return Array.from(new Set(declarationNames));
+  }
+  return normalizeArray(request.expected_artifacts);
 }
 
 function runtimeOptionsFromExecutorConfig(config = {}, options = {}) {

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -639,8 +639,8 @@ const providerAndControllerArtifactsTaskInput = codeboxTaskRequestFromAgentTaskR
     ability_request: { name: 'agents/run-runtime-package' },
   },
 });
-assert.deepEqual(providerAndControllerArtifactsTaskInput.artifact_declarations.map((declaration) => declaration.name), ['patch', 'concept_packet']);
-assert.deepEqual(providerAndControllerArtifactsTaskInput.runtime_task.input.required_artifacts, ['patch', 'concept_packet']);
+assert.deepEqual(providerAndControllerArtifactsTaskInput.artifact_declarations.map((declaration) => declaration.name), ['concept_packet']);
+assert.deepEqual(providerAndControllerArtifactsTaskInput.runtime_task.input.required_artifacts, ['concept_packet']);
 assert.equal(
   providerAndControllerArtifactsTaskInput.runtime_task.input.engine_data_outputs.concept_packet,
   'metadata.engine_data.outputs.typed_artifacts.concept_packet.payload'

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -650,11 +650,15 @@ const placeholderArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'placeholder-artifact-task-1',
   executor: { backend: 'codebox', config: { provider: 'openai' } },
-  artifact_declarations: [{
-    name: 'concept_packet',
-    artifact_schema: 'wp-site-generator/ConceptPacket/v1',
-    required: true,
-  }],
+  artifact_declarations: [
+    { name: 'patch', required: true },
+    { name: 'agent_result', required: true },
+    {
+      name: 'concept_packet',
+      artifact_schema: 'wp-site-generator/ConceptPacket/v1',
+      required: true,
+    },
+  ],
 }, {
   success: true,
   status: 'completed',

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -564,6 +564,7 @@ assert.deepEqual(codeboxRequest.agent_bundle, {});
 const artifactDeclarationRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
   task_id: 'artifact-declaration-task-123',
+  expected_artifacts: ['patch', 'transcript'],
   artifact_declarations: [{
     schema: 'homeboy/agent-task-artifact-declaration/v1',
     name: 'analysis_report',
@@ -577,6 +578,7 @@ assert.equal(artifactDeclarationRequest.artifact_declarations[0].schema, 'wp-cod
 assert.equal(artifactDeclarationRequest.artifact_declarations[0].name, 'analysis_report');
 assert.equal(artifactDeclarationRequest.artifact_declarations[0].path, 'artifacts/analysis-report.json');
 assert.equal(artifactDeclarationRequest.artifact_declarations[0].required, true);
+assert.deepEqual(artifactDeclarationRequest.expected_artifacts, ['analysis_report']);
 
 const legacyArtifactDeclarationRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -566,6 +566,14 @@ const artifactDeclarationRequest = codeboxTaskRequestFromAgentTaskRequest({
   task_id: 'artifact-declaration-task-123',
   expected_artifacts: ['patch', 'transcript'],
   artifact_declarations: [{
+    schema: 'wp-codebox/artifact-declaration/v1',
+    name: 'patch',
+    required: true,
+  }, {
+    schema: 'wp-codebox/artifact-declaration/v1',
+    name: 'transcript',
+    required: true,
+  }, {
     schema: 'homeboy/agent-task-artifact-declaration/v1',
     name: 'analysis_report',
     type: 'AnalysisReport',
@@ -574,6 +582,7 @@ const artifactDeclarationRequest = codeboxTaskRequestFromAgentTaskRequest({
     required: true,
   }],
 });
+assert.equal(artifactDeclarationRequest.artifact_declarations.length, 1);
 assert.equal(artifactDeclarationRequest.artifact_declarations[0].schema, 'wp-codebox/artifact-declaration/v1');
 assert.equal(artifactDeclarationRequest.artifact_declarations[0].name, 'analysis_report');
 assert.equal(artifactDeclarationRequest.artifact_declarations[0].path, 'artifacts/analysis-report.json');


### PR DESCRIPTION
## Summary
- Scope Codebox expected artifacts to explicit required artifact declarations when declarations are present.
- Preserve existing expected_artifacts pass-through for requests without typed declarations.
- Provide Codebox runtime substrate discovery for Agents API and Data Machine.
- Declare Codebox Lab runtime components (`agents-api`, `data-machine`) in the provider manifest for Homeboy Lab handoff.
- Add regression coverage for generic patch/transcript expectations alongside a required typed artifact declaration.

## Upstream dependency
- Depends on `Extra-Chill/homeboy#5915` for provider-declared Lab runtime component synchronization.

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('agent-runtimes/wp-codebox/wp-codebox.json','utf8')); console.log('ok')"`
- `node --check agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js`
- `node --check agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/agent-task-core-contract-drift.test.js`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the WPSG Lab loop artifact/runtime substrate failures, implementing the adapter and runtime-component manifest changes, and adding/updating regression coverage.