### PR TITLE
Release WordPress extension v3.12.30

### DIFF
--- a/wordpress/docs/CHANGELOG.md
+++ b/wordpress/docs/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the **wordpress** extension will be documented in this file.
 
+## [3.12.30] - 2026-06-22
+
+### Changed
+- Add WP Codebox fuzz suite contract canary
+- Remove docs-agent-specific runner fixtures
+- Delegate to WP Codebox normalizers
+- Extract workspace publication lifecycle
+- Centralize agent task outcome normalization
+- Prefer public Codebox fuzz workload APIs
+- Normalize WordPress fuzz budgets
+- Add DB fuzz planning primitives
+- Move WooCommerce defaults behind product adapters
+- Use semantic full-surface coverage matching
+- Centralize WordPress surface vocabulary
+- Route fuzz runner through Codebox adapter
+- Canonicalize WP Codebox fuzz suite vocabulary
+- Use focused WP Codebox entrypoints
+- Add generic block fuzz cases
+- Plan admin page fuzz interactions
+- Expand WordPress CRUD fuzz planning
+- Plan REST fuzz cases by method
+- Normalize WordPress fuzz surface types
+
+### Fixed
+- Fix Codebox typed artifact expectations
+
 ## [3.12.28] - 2026-06-22
 
 ### Changed

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -1,6 +1,6 @@
 {
   "name": "WordPress",
-  "version": "3.12.28",
+  "version": "3.12.30",
   "icon": "w.circle.fill",
   "description": "WordPress project type with WP-CLI integration",
   "author": "Extra Chill",


### PR DESCRIPTION
## Summary
- Release WordPress extension v3.12.30.
- Include generated changelog and version bump from Homeboy release.

## Verification
- homeboy release wordpress --path "/Users/chubes/Developer/homeboy-extensions@release-docs-agent-decoupling/wordpress" --bump 3.12.30 --apply

## AI assistance
- **AI assistance:** No
- **Tool(s):** N/A
- **Used for:** N/A