### PR TITLE
Pass goal to Codebox fuzz suites

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -56,12 +56,14 @@ function buildWordPressFuzzRunnerContext(options = {}) {
 	const seed = env.seed || workload.seed || null;
 	const maxDuration = numericValue(env.maxDuration ?? workload.max_duration ?? workload.maxDuration);
 	const plan = normalizeRunnerPlan(workload.plan || workload.fuzz_plan || workload.fuzzPlan || workload);
-	const wpCodeboxInput = buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDuration });
+	const instructions = fuzzSuiteInstructions({ workload, workloadId, runId });
+	const wpCodeboxInput = buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDuration, instructions });
 	const taskRequest = wpCodeboxFuzzSuiteTaskRequest({
 		taskId: runId,
 		input: wpCodeboxInput,
 		provider: workload.provider,
 		runtimeId: workload.runtime_id || workload.runtimeId || 'wp-codebox',
+		instructions,
 	});
 	const codeboxPlanRecipe = buildCodeboxPlanRecipe(workload);
 
@@ -130,8 +132,14 @@ async function resolveCodeboxResult(context, options = {}) {
 		input: context.wpCodeboxInput,
 		provider: context.workload.provider,
 		runtimeId: context.workload.runtime_id || context.workload.runtimeId || 'wp-codebox',
+		instructions: context.taskRequest.instructions,
 		runFuzzSuite: runner,
 	});
+}
+
+function fuzzSuiteInstructions({ workload, workloadId, runId }) {
+	const label = workload.label || workloadId || workload.id || runId;
+	return `Run WordPress fuzz suite ${label} and return the declared fuzz artifacts.`;
 }
 
 function normalizeRunnerPlan(input) {
@@ -147,9 +155,10 @@ function normalizeRunnerPlan(input) {
 	});
 }
 
-function buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDuration }) {
+function buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDuration, instructions }) {
 	return wpCodeboxFuzzSuiteInput({
 		id: runId,
+		goal: instructions,
 		target: workload.target || { type: 'wordpress', workload_id: workloadId },
 		workload: stripUndefined({
 			id: workloadId,

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -126,6 +126,7 @@ function wpCodeboxFuzzSuiteInput(options = {}) {
 	return stripUndefined({
 		schema: wpCodeboxFuzzSuiteSchema(options),
 		id: options.id || options.runId || options.run_id,
+		goal: options.goal || options.instructions,
 		version: options.version,
 		target: options.target,
 		cases: normalizeArray(options.cases),

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -74,6 +74,7 @@ assert.equal(result.workload_id, 'workload-from-env');
 assert.equal(result.seed, 'seed-123');
 assert.equal(result.max_duration_seconds, 30);
 assert.equal(result.wp_codebox_input.schema, 'wp-codebox/fuzz-suite/v1');
+assert.equal(result.wp_codebox_input.goal, 'Run WordPress fuzz suite workload-from-env and return the declared fuzz artifacts.');
 assert.equal(result.wp_codebox_input.cases[0].target_id, 'rest-posts');
 assert.equal(result.wp_codebox_task_request.executor.config.runtime_task.ability, 'wp-codebox/run-fuzz-suite');
 assert.equal(result.wp_codebox_plan_recipe.fuzzRun, undefined);
@@ -121,6 +122,7 @@ const dispatchPromise = runWordPressFuzzRunnerResult({
 		assert.equal(request.executor.backend, 'codebox');
 		assert.equal(request.executor.config.runtime_task.ability, 'wp-codebox/run-fuzz-suite');
 		assert.equal(request.executor.config.runtime_task.input.schema, 'wp-codebox/fuzz-suite/v1');
+		assert.equal(request.executor.config.runtime_task.input.goal, 'Run WordPress fuzz suite generic-wordpress-workload and return the declared fuzz artifacts.');
 		assert.equal(request.executor.config.runtime_task.input.cases[0].target_id, 'rest-posts');
 		return {
 			json: {


### PR DESCRIPTION
## Summary
- Add a user-facing fuzz-suite goal to the WP Codebox public fuzz-suite input.
- Reuse the same instructions on the task request so the public and legacy Codebox paths stay aligned.
- Cover goal propagation in the WordPress fuzz runner smoke assertions.

## Testing
- npm run test:wp-codebox-fuzz-suite
- node - <<'NODE'
const assert = require('node:assert/strict');
const { buildWordPressFuzzRunnerResult } = require('./wordpress/lib/wordpress-fuzz-runner');
const result = buildWordPressFuzzRunnerResult({
  env: { workloadPath: '/unused', workloadId: 'woo-rest', runId: 'run-1' },
  workload: { id: 'woo-rest', plan: { id: 'plan', targets: [{ id: 'route', cases: [{ id: 'case' }] }] } },
});
assert.equal(result.wp_codebox_input.goal, 'Run WordPress fuzz suite woo-rest and return the declared fuzz artifacts.');
assert.equal(result.wp_codebox_task_request.instructions, result.wp_codebox_input.goal);
assert.equal(result.wp_codebox_task_request.executor.config.runtime_task.input.goal, result.wp_codebox_input.goal);
console.log('fuzz runner goal propagation ok');
NODE

Note: `npm run test:wordpress-fuzz-runner` and `npm run test:wordpress-fuzz-runner-codebox-contract` are blocked in this fresh worktree by a missing local WP Codebox core contract module, before reaching this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Woo fuzz runner failure, implementing the Codebox goal propagation fix, targeted verification, and PR preparation.
