### PR TITLE
Resolve fuzz runner Codebox runtime path

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -13,10 +13,6 @@ const { spawn } = require('node:child_process');
  * Internal dependencies
  */
 const {
-	codeboxRunAgentTaskInvocation,
-	codeboxTaskRequestFromAgentTaskRequest,
-} = require('../../../agent-runtimes/wp-codebox');
-const {
 	buildWordPressFuzzRunnerResult,
 	readWordPressFuzzRunnerEnv,
 	runWordPressFuzzRunnerResult,
@@ -27,17 +23,19 @@ const {
 	wpCodeboxFuzzSuiteAbility,
 	wpCodeboxRuntimeContractManifest,
 } = require('../../lib/wp-codebox-fuzz-run');
+if (require.main === module) {
+	main().catch((error) => {
+		process.stderr.write(`${error.message}\n`);
+		process.exit(1);
+	});
+}
 
-
-(async () => {
+async function main() {
 	const env = readWordPressFuzzRunnerEnv();
 	const result = await buildRunnerResult(env);
 	writeHomeboyFuzzResultsFile(env.resultsFile, result.homeboy_fuzz_campaign);
 	process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-})().catch((error) => {
-	process.stderr.write(`${error.message}\n`);
-	process.exit(1);
-});
+}
 
 async function buildRunnerResult(env) {
 	if (process.env.HOMEBOY_WP_CODEBOX_FUZZ_DISPATCH === '0') {
@@ -142,11 +140,36 @@ function shouldFallbackToRunAgentTask(error) {
 }
 
 function wpCodeboxRunAgentTaskInvocation(request) {
+	const {
+		codeboxRunAgentTaskInvocation,
+		codeboxTaskRequestFromAgentTaskRequest,
+	} = requireWpCodeboxRuntime();
 	const taskInput = codeboxTaskRequestFromAgentTaskRequest(request);
 	return codeboxRunAgentTaskInvocation({
 		taskInput,
 		taskId: request.task_id,
 	});
+}
+
+function requireWpCodeboxRuntime(options = {}) {
+	return require(resolveWpCodeboxRuntimePath(options));
+}
+
+function resolveWpCodeboxRuntimePath(options = {}) {
+	const env = options.env || process.env;
+	const candidates = [];
+	if (env.HOMEBOY_EXTENSION_PATH) {
+		candidates.push(path.resolve(env.HOMEBOY_EXTENSION_PATH, '..', '..', 'agent-runtimes', 'wp-codebox'));
+	}
+	candidates.push(path.resolve(__dirname, '..', '..', '..', 'agent-runtimes', 'wp-codebox'));
+
+	for (const candidate of candidates) {
+		if (fs.existsSync(path.join(candidate, 'index.js'))) {
+			return candidate;
+		}
+	}
+
+	return candidates[0];
 }
 
 function wpCodeboxInvocationArgs(invocation, inputFile) {
@@ -261,3 +284,7 @@ function findFuzzSuiteResult(value) {
 	}
 	return null;
 }
+
+module.exports = {
+	resolveWpCodeboxRuntimePath,
+};

--- a/wordpress/tests/fuzz-runner-installed-runtime-path-smoke.js
+++ b/wordpress/tests/fuzz-runner-installed-runtime-path-smoke.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { resolveWpCodeboxRuntimePath } = require('../scripts/fuzz/fuzz-runner.cjs');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-fuzz-runner-runtime-path-'));
+const homeboyRoot = path.join(root, '.config', 'homeboy');
+const extensionPath = path.join(homeboyRoot, 'extensions', 'wordpress');
+const installedRuntimePath = path.join(homeboyRoot, 'agent-runtimes', 'wp-codebox');
+const legacyRuntimePath = path.join(homeboyRoot, 'extensions', 'agent-runtimes', 'wp-codebox');
+
+fs.mkdirSync(extensionPath, { recursive: true });
+fs.mkdirSync(installedRuntimePath, { recursive: true });
+fs.mkdirSync(legacyRuntimePath, { recursive: true });
+fs.writeFileSync(path.join(installedRuntimePath, 'index.js'), 'module.exports = {};\n');
+fs.writeFileSync(path.join(legacyRuntimePath, 'index.js'), 'module.exports = {};\n');
+
+assert.equal(
+	resolveWpCodeboxRuntimePath({ env: { HOMEBOY_EXTENSION_PATH: extensionPath } }),
+	installedRuntimePath
+);
+
+const sourceRuntimePath = path.resolve(__dirname, '..', '..', 'agent-runtimes', 'wp-codebox');
+assert.equal(resolveWpCodeboxRuntimePath({ env: {} }), sourceRuntimePath);
+
+console.log('fuzz runner installed runtime path smoke passed');


### PR DESCRIPTION
## Summary
- Resolve the WP Codebox agent runtime from the installed Homeboy runtime directory when the fuzz runner runs from an installed extension.
- Keep the source-checkout relative path as the fallback for repo-local execution.
- Add an installed-layout smoke test that prefers the fresh global runtime over stale legacy extension-sibling runtimes.

## Testing
- `node --check scripts/fuzz/fuzz-runner.cjs && node tests/fuzz-runner-installed-runtime-path-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the runner import failure, implementing the runtime path resolver, and adding the smoke test.