### PR TITLE
Derive Codebox core module for fuzz runner

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -183,7 +183,26 @@ function wpCodeboxRuntimeEnv(env) {
 			nextEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE = String(settings.wp_codebox_core_module);
 		}
 	}
+	if (!nextEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE) {
+		const discoveredCoreModule = discoverWpCodeboxCoreModule(nextEnv);
+		if (discoveredCoreModule) {
+			nextEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE = discoveredCoreModule;
+		}
+	}
 	return nextEnv;
+}
+
+function discoverWpCodeboxCoreModule(env) {
+	const installRoot = env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.join(os.homedir(), '.cache', 'homeboy', 'wp-codebox');
+	for (const candidate of [
+		path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js'),
+		path.join(installRoot, 'release', 'wp-codebox-cli', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js'),
+	]) {
+		if (fs.existsSync(candidate)) {
+			return candidate;
+		}
+	}
+	return '';
 }
 
 function parseJsonObject(value) {

--- a/wordpress/tests/fuzz-runner-installed-runtime-path-smoke.js
+++ b/wordpress/tests/fuzz-runner-installed-runtime-path-smoke.js
@@ -15,12 +15,15 @@ const homeboyRoot = path.join(root, '.config', 'homeboy');
 const extensionPath = path.join(homeboyRoot, 'extensions', 'wordpress');
 const installedRuntimePath = path.join(homeboyRoot, 'agent-runtimes', 'wp-codebox');
 const legacyRuntimePath = path.join(homeboyRoot, 'extensions', 'agent-runtimes', 'wp-codebox');
+const cachedCoreModule = path.join(root, 'wp-codebox-cache', 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js');
 
 fs.mkdirSync(extensionPath, { recursive: true });
 fs.mkdirSync(installedRuntimePath, { recursive: true });
 fs.mkdirSync(legacyRuntimePath, { recursive: true });
 fs.writeFileSync(path.join(installedRuntimePath, 'index.js'), 'module.exports = {};\n');
 fs.writeFileSync(path.join(legacyRuntimePath, 'index.js'), 'module.exports = {};\n');
+fs.mkdirSync(path.dirname(cachedCoreModule), { recursive: true });
+fs.writeFileSync(cachedCoreModule, 'export {};\n');
 
 assert.equal(
 	resolveWpCodeboxRuntimePath({ env: { HOMEBOY_EXTENSION_PATH: extensionPath } }),
@@ -42,6 +45,12 @@ assert.equal(
 		HOMEBOY_SETTINGS_JSON: JSON.stringify({ wp_codebox_core_module: '/tmp/wp-codebox-core.mjs' }),
 	}).HOMEBOY_WP_CODEBOX_CORE_MODULE,
 	'/existing/core.mjs'
+);
+assert.equal(
+	wpCodeboxRuntimeEnv({
+		HOMEBOY_WP_CODEBOX_INSTALL_DIR: path.join(root, 'wp-codebox-cache'),
+	}).HOMEBOY_WP_CODEBOX_CORE_MODULE,
+	cachedCoreModule
 );
 
 console.log('fuzz runner installed runtime path smoke passed');


### PR DESCRIPTION
## Summary
- Re-derive HOMEBOY_WP_CODEBOX_CORE_MODULE from the standard WP Codebox cache when fuzz capability settings do not include it.
- Keep explicit env and settings-derived values higher priority.
- Extend the fuzz runner installed-layout smoke test for cache-derived core module env.

## Testing
- `node --check scripts/fuzz/fuzz-runner.cjs && node tests/fuzz-runner-installed-runtime-path-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the remaining fuzz runner core-module propagation gap, implementing cache fallback discovery, and updating smoke coverage.