### PR TITLE
Use Codebox contracts entrypoint for fuzz runner

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -195,7 +195,9 @@ function wpCodeboxRuntimeEnv(env) {
 function discoverWpCodeboxCoreModule(env) {
 	const installRoot = env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.join(os.homedir(), '.cache', 'homeboy', 'wp-codebox');
 	for (const candidate of [
+		path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'contracts.js'),
 		path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js'),
+		path.join(installRoot, 'release', 'wp-codebox-cli', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'contracts.js'),
 		path.join(installRoot, 'release', 'wp-codebox-cli', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js'),
 	]) {
 		if (fs.existsSync(candidate)) {

--- a/wordpress/tests/fuzz-runner-installed-runtime-path-smoke.js
+++ b/wordpress/tests/fuzz-runner-installed-runtime-path-smoke.js
@@ -15,7 +15,8 @@ const homeboyRoot = path.join(root, '.config', 'homeboy');
 const extensionPath = path.join(homeboyRoot, 'extensions', 'wordpress');
 const installedRuntimePath = path.join(homeboyRoot, 'agent-runtimes', 'wp-codebox');
 const legacyRuntimePath = path.join(homeboyRoot, 'extensions', 'agent-runtimes', 'wp-codebox');
-const cachedCoreModule = path.join(root, 'wp-codebox-cache', 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js');
+const cachedCoreModule = path.join(root, 'wp-codebox-cache', 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'contracts.js');
+const cachedCoreIndex = path.join(root, 'wp-codebox-cache', 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js');
 
 fs.mkdirSync(extensionPath, { recursive: true });
 fs.mkdirSync(installedRuntimePath, { recursive: true });
@@ -24,6 +25,7 @@ fs.writeFileSync(path.join(installedRuntimePath, 'index.js'), 'module.exports = 
 fs.writeFileSync(path.join(legacyRuntimePath, 'index.js'), 'module.exports = {};\n');
 fs.mkdirSync(path.dirname(cachedCoreModule), { recursive: true });
 fs.writeFileSync(cachedCoreModule, 'export {};\n');
+fs.writeFileSync(cachedCoreIndex, 'export {};\n');
 
 assert.equal(
 	resolveWpCodeboxRuntimePath({ env: { HOMEBOY_EXTENSION_PATH: extensionPath } }),


### PR DESCRIPTION
## Summary
- Prefer the WP Codebox core contracts entrypoint when deriving HOMEBOY_WP_CODEBOX_CORE_MODULE for fuzz runs.
- Keep index.js as a final compatibility fallback.
- Update the fuzz runner smoke test to prove contracts.js wins when both entries exist.

## Testing
- `node --check scripts/fuzz/fuzz-runner.cjs && node tests/fuzz-runner-installed-runtime-path-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the cached core entrypoint mismatch, implementing contracts entrypoint fallback, and updating smoke coverage.