### PR TITLE
Fix fuzz runner Codebox core setting env

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -183,6 +183,9 @@ function wpCodeboxRuntimeEnv(env) {
 			nextEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE = String(settings.wp_codebox_core_module);
 		}
 	}
+	if (!nextEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE && nextEnv.HOMEBOY_SETTINGS_WP_CODEBOX_CORE_MODULE) {
+		nextEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE = String(nextEnv.HOMEBOY_SETTINGS_WP_CODEBOX_CORE_MODULE);
+	}
 	if (!nextEnv.HOMEBOY_WP_CODEBOX_CORE_MODULE) {
 		const discoveredCoreModule = discoverWpCodeboxCoreModule(nextEnv);
 		if (discoveredCoreModule) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -6,6 +6,16 @@ const Module = require('node:module');
 const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(
+	__dirname,
+	'..',
+	'..',
+	'tests',
+	'fixtures',
+	'wp-codebox-core-runtime-contract.cjs'
+);
+
 const { runtimeContractSchemas } = require('../../agent-runtimes/wp-codebox');
 
 const originalLoad = Module._load;
@@ -152,9 +162,17 @@ const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wordpress-fuzz-runner-'))
 const workloadPath = path.join(tempDir, 'workload.json');
 const resultsPath = path.join(tempDir, 'fuzz-results.json');
 const runnerPath = path.join(__dirname, '..', 'scripts', 'fuzz', 'fuzz-runner.cjs');
+const { wpCodeboxRuntimeEnv } = require(runnerPath);
 fs.writeFileSync(workloadPath, `${JSON.stringify(workload)}\n`);
 
 assert.equal(fs.statSync(runnerPath).mode & 0o111, 0o111, 'fuzz runner script must be executable');
+assert.equal(
+	wpCodeboxRuntimeEnv({
+		HOMEBOY_SETTINGS_WP_CODEBOX_CORE_MODULE: '/runner/wp-codebox/packages/runtime-core/dist/contracts.js',
+	}).HOMEBOY_WP_CODEBOX_CORE_MODULE,
+	'/runner/wp-codebox/packages/runtime-core/dist/contracts.js',
+	'Lab-exported per-setting env should provide the WP Codebox core module path'
+);
 
 const cli = spawnSync(runnerPath, [], {
 	encoding: 'utf8',


### PR DESCRIPTION
## Summary
- Derive HOMEBOY_WP_CODEBOX_CORE_MODULE from HOMEBOY_SETTINGS_WP_CODEBOX_CORE_MODULE for WordPress fuzz runs.
- Keep the fuzz runner smoke self-contained with the canonical WP Codebox contract fixture.
- Add coverage for Lab-like per-setting env propagation into the WP Codebox core module path.

## Root cause
Homeboy Lab preserves --setting values through runner argv and the extension subprocess exports them as HOMEBOY_SETTINGS_* alongside HOMEBOY_SETTINGS_JSON. The WordPress fuzz runner only derived HOMEBOY_WP_CODEBOX_CORE_MODULE from HOMEBOY_SETTINGS_JSON or cache discovery, so a Lab/setup-derived per-setting env value was ignored and the runner could still fail with the canonical WP Codebox runtime contract manifest error.

## Tests
- npm run test:wordpress-fuzz-runner
- npm run test:wordpress-fuzz-runner-codebox-contract
- node --check wordpress/scripts/fuzz/fuzz-runner.cjs && node --check wordpress/tests/wordpress-fuzz-runner-smoke.js

## Issues
- Related: https://github.com/Extra-Chill/homeboy/issues/5919
- Fixes: https://github.com/Extra-Chill/homeboy-extensions/issues/1745

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating the Homeboy Lab/HBX fuzz runtime-env path, implementing the fuzz runner env derivation fix, adding regression coverage, and drafting this PR.