### PR TITLE
Prefer cached WP Codebox CLI for fuzz runs

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -51,7 +51,7 @@ async function buildRunnerResult(env) {
 async function runWpCodeboxAgentTask(request) {
 	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-fuzz-'));
 	const env = wpCodeboxRuntimeEnv(process.env);
-	const command = env.HOMEBOY_WP_CODEBOX_BIN || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || 'wp-codebox';
+	const command = env.HOMEBOY_WP_CODEBOX_BIN || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || discoverWpCodeboxBin(env) || 'wp-codebox';
 	const manifest = await discoverRuntimeContractManifest(env);
 	const publicInvocation = wpCodeboxPublicRuntimeInvocation(request, { runtimeContractManifest: manifest });
 
@@ -210,6 +210,21 @@ function discoverWpCodeboxCoreModule(env) {
 	return '';
 }
 
+function discoverWpCodeboxBin(env) {
+	const installRoot = env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.join(os.homedir(), '.cache', 'homeboy', 'wp-codebox');
+	for (const candidate of [
+		path.join(installRoot, 'source', 'packages', 'cli', 'dist', 'index.js'),
+		path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-cli', 'dist', 'index.js'),
+		path.join(installRoot, 'release', 'wp-codebox-cli', 'dist', 'index.js'),
+		path.join(installRoot, 'release', 'wp-codebox-cli', 'node_modules', '@automattic', 'wp-codebox-cli', 'dist', 'index.js'),
+	]) {
+		if (fs.existsSync(candidate)) {
+			return candidate;
+		}
+	}
+	return '';
+}
+
 function parseJsonObject(value) {
 	if (!value) {
 		return null;
@@ -338,4 +353,5 @@ function findFuzzSuiteResult(value) {
 module.exports = {
 	resolveWpCodeboxRuntimePath,
 	wpCodeboxRuntimeEnv,
+	discoverWpCodeboxBin,
 };

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -162,7 +162,7 @@ const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wordpress-fuzz-runner-'))
 const workloadPath = path.join(tempDir, 'workload.json');
 const resultsPath = path.join(tempDir, 'fuzz-results.json');
 const runnerPath = path.join(__dirname, '..', 'scripts', 'fuzz', 'fuzz-runner.cjs');
-const { wpCodeboxRuntimeEnv } = require(runnerPath);
+const { discoverWpCodeboxBin, wpCodeboxRuntimeEnv } = require(runnerPath);
 fs.writeFileSync(workloadPath, `${JSON.stringify(workload)}\n`);
 
 assert.equal(fs.statSync(runnerPath).mode & 0o111, 0o111, 'fuzz runner script must be executable');
@@ -172,6 +172,16 @@ assert.equal(
 	}).HOMEBOY_WP_CODEBOX_CORE_MODULE,
 	'/runner/wp-codebox/packages/runtime-core/dist/contracts.js',
 	'Lab-exported per-setting env should provide the WP Codebox core module path'
+);
+
+const codeboxInstallRoot = path.join(tempDir, 'wp-codebox-install');
+const cachedCodeboxBin = path.join(codeboxInstallRoot, 'source', 'packages', 'cli', 'dist', 'index.js');
+fs.mkdirSync(path.dirname(cachedCodeboxBin), { recursive: true });
+fs.writeFileSync(cachedCodeboxBin, '#!/usr/bin/env node\n');
+assert.equal(
+	discoverWpCodeboxBin({ HOMEBOY_WP_CODEBOX_INSTALL_DIR: codeboxInstallRoot }),
+	cachedCodeboxBin,
+	'Fuzz runner should prefer the cached WP Codebox CLI over stale binaries on PATH'
 );
 
 const cli = spawnSync(runnerPath, [], {


### PR DESCRIPTION
## Summary
- Teaches the WordPress fuzz runner to discover the WP Codebox CLI from the same Homeboy-managed cache used for the core module.
- Avoids falling back to stale global Usage:
  wp-codebox commands [--json]
  wp-codebox schema recipe [--json]
  wp-codebox doctor [--json] [--fix] [--archive-root <dir>] [--stale-after-seconds <n>]
  wp-codebox cleanup [--json] [--archive-root <dir>] [--stale-after-seconds <n>]
  wp-codebox workspace-policy check --workspace-root <path> --writable-root <path> [options]
  wp-codebox recipe build phpunit --options <path> [--output <path>]
  wp-codebox recipe validate --recipe <path> [--json]
  wp-codebox bench matrix --matrix <path> [--recipe <path>] [--artifacts <dir>] [--json]
  wp-codebox bench summarize (--input <recipe-run.json>|--bundle <dir>) [--json]
  wp-codebox bench compare --baseline-input <recipe-run.json> --candidate-input <recipe-run.json> [--json]
  wp-codebox artifacts verify --bundle <dir> [--json]
  wp-codebox artifacts apply-preflight --bundle <dir> --approved-file <path> [--json]
  wp-codebox artifacts browser-metrics --bundle <dir> [--json]
  wp-codebox artifacts diagnostics --input <json> [--source <id>] [--stage <id>] [--observation-type <id>] [--ref <path[:kind]>] [--json]
  wp-codebox artifacts transfer-verify --bundle <dir> [--json]
  wp-codebox artifacts transfer-probes --bundle <dir> [--json]
  wp-codebox artifacts discover-partial --artifacts <dir> [--session-id <id>] [--started-at <iso>] [--finished-at <iso>] [--json]
  wp-codebox artifacts benchmark --bundle <dir> [--scenario-id <id>] [--extract-to <dir>] [--json]
  wp-codebox artifacts bench-results --bundle <dir> [--json]
  wp-codebox artifacts bench-compare --baseline-bundle <dir> --candidate-bundle <dir> [--json]
  wp-codebox runs status --registry <dir> --run-id <id> [--json]
  wp-codebox runs artifacts --registry <dir> --run-id <id> [--json]
  wp-codebox agent-task-run --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-public-url <url>]
  wp-codebox validate-blueprint --blueprint <json|file> [options]
  wp-codebox recipe-run --recipe <path> [options]
  wp-codebox boot [--mount <host>:<vfs>] [options]
  wp-codebox run --mount <host>:<vfs> --command <id> [options]

Options:
  --recipe <path>     Workspace recipe JSON file for recipe-run or recipe validate.
  --options <path>    Recipe builder options JSON file for recipe build.
  --output <path>     Optional output JSON path for recipe build; defaults to stdout.
  --input-file <path> Agent task input JSON for agent-task-run.
  --preview-hold-seconds <n>
                    Keep preview runtimes alive after agent-task-run/recipe-run.
  --preview-public-url <url>
                    Public preview URL passed through to agent-task-run/recipe-run.
  --bundle <dir>      Artifact bundle directory for artifact verification/probe commands.
  --source <id>       Default source for artifacts diagnostics normalization.
  --stage <id>        Default stage for artifacts diagnostics normalization.
  --observation-type <id>
                       Default observation type for artifacts diagnostics normalization.
  --ref <path[:kind]> Default artifact diagnostic reference. Repeatable.
  --approved-file <path>
                       Changed file approved for artifacts apply-preflight. Repeatable.
  --approved-files <paths>
                       Comma-separated changed files approved for artifacts apply-preflight.
  --scenario-id <id>  Filter benchmark artifact refs to one scenario.
  --extract-to <dir>  Copy listed benchmark artifact refs to a directory.
  --input <path>      Saved recipe-run JSON output for benchmark summarization.
  --matrix <path>     Benchmark recipe matrix JSON file for bench matrix.
  --baseline-input <path>
                       Saved baseline recipe-run JSON for benchmark comparison.
  --candidate-input <path>
                       Saved candidate recipe-run JSON for benchmark comparison.
  --baseline-bundle <dir>
                       Baseline artifact bundle directory for benchmark comparison.
  --candidate-bundle <dir>
                       Candidate artifact bundle directory for benchmark comparison.
  --baseline-index <n>
                       Benchmark envelope index to compare when a source has multiple results.
  --candidate-index <n>
                       Benchmark envelope index to compare when a source has multiple results.
  --artifacts <dir>   Artifact root directory. Also accepted by artifacts verify.
  --session-id <id>   Prefer partial artifact directories matching this sandbox/session id.
  --started-at <iso>  Lower timestamp bound for partial artifact discovery.
  --finished-at <iso> Upper timestamp bound for partial artifact discovery.
  --run-registry <dir>
                       Durable run registry directory for recipe-run.
  --registry <dir>    Durable run registry directory for runs lookup commands.
  --run-id <id>       Run ID for runs lookup commands.
  --mount <host:vfs>   Mount a host path into the runtime. Repeatable.
  --command <id>       Command/action id to execute.
  --arg <key=value>    Command argument. Repeatable. Recipe commands include wordpress.run-php, wordpress.phpunit, wordpress.core-phpunit, wordpress.plugin-check, wordpress.wp-cli, wordpress.ability, wordpress.bench, and wordpress.browser-probe.
  --wp <version>       WordPress version for Playground. Defaults to latest; accepts trunk, nightly, or numeric versions.
  --blueprint <json|file>
                       WordPress Playground blueprint JSON or path for boot or validate-blueprint.
  --artifacts <dir>    Artifact root directory.
  --hold <n>           Keep a booted Playground preview available before teardown. Accepts the same values as --preview-hold.
  --preview-hold <n>   Keep the live Playground preview available after a successful run. Accepts seconds or minutes, e.g. 30s or 15m; max 3600s.
  --preview-port <n>   Start Playground on a fixed local port. Defaults to a random available port.
  --preview-bind <host>
                       Host/IP for the fixed-port WP Codebox preview proxy. Requires --preview-port.
                       Defaults to 127.0.0.1; use 0.0.0.0 only behind trusted network controls.
  --preview-public-url <url>
                        Public tunnel/proxy URL to report in preview artifacts and pass to Playground as site-url.
                        Upstream Playground remains loopback-bound; this only changes the WP Codebox proxy bind.
  --timeout <duration>  Maximum live recipe-run duration before emitting a structured timeout failure. Defaults to 25m.
  --policy <json|file> Runtime policy JSON or path to a JSON file.
  --dry-run            Validate recipe-run and emit a resolved JSON plan without booting Playground or writing temp workspaces.
  --json               Emit machine-readable JSON.

Doctor and cleanup:
  doctor               Report binary/source fingerprint, Node/npm availability, stale recipe-run processes, and corrupt archives.
  cleanup              Run doctor checks and remove safe stale/corrupt runtime state.
  --fix                Allow mutating cleanup when command is doctor.
  --stale-after-seconds <n>
                       Age threshold for stale recipe-run processes. Defaults to 3600.
  --archive-root <dir> Additional archive/cache root to scan for invalid .zip files. Repeatable.

Workspace policy:
  --workspace-root <dir>
                       Workspace root to inspect. Defaults to the current directory.
  --writable-root <path>
                       Relative path that may be changed. Repeatable.
  --hidden-path <path> Relative path that must not be changed or exposed. Repeatable.
  --git                Use git status metadata, including ignored and unmerged entries.

Discovery:
  commands             Print supported runtime and recipe command metadata.
  schema recipe        Print the wp-codebox/workspace-recipe/v1 JSON Schema.

Example:
  wp-codebox run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json binaries on Lab runners.
- Adds smoke coverage for cache CLI discovery.

## Testing
- node tests/wordpress-fuzz-runner-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Lab fuzz runner failure, implementing the cache CLI resolver, and running targeted verification.