### PR TITLE
Prefer discovered Codebox CLI over stale fuzz settings

### DIFF
--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -51,7 +51,7 @@ async function buildRunnerResult(env) {
 async function runWpCodeboxAgentTask(request) {
 	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-fuzz-'));
 	const env = wpCodeboxRuntimeEnv(process.env);
-	const command = env.HOMEBOY_WP_CODEBOX_BIN || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || discoverWpCodeboxBin(env) || 'wp-codebox';
+	const command = wpCodeboxCommand(env);
 	const manifest = await discoverRuntimeContractManifest(env);
 	const publicInvocation = wpCodeboxPublicRuntimeInvocation(request, { runtimeContractManifest: manifest });
 
@@ -225,6 +225,10 @@ function discoverWpCodeboxBin(env) {
 	return '';
 }
 
+function wpCodeboxCommand(env) {
+	return env.HOMEBOY_WP_CODEBOX_BIN || discoverWpCodeboxBin(env) || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || 'wp-codebox';
+}
+
 function parseJsonObject(value) {
 	if (!value) {
 		return null;
@@ -354,4 +358,5 @@ module.exports = {
 	resolveWpCodeboxRuntimePath,
 	wpCodeboxRuntimeEnv,
 	discoverWpCodeboxBin,
+	wpCodeboxCommand,
 };

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -162,7 +162,7 @@ const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wordpress-fuzz-runner-'))
 const workloadPath = path.join(tempDir, 'workload.json');
 const resultsPath = path.join(tempDir, 'fuzz-results.json');
 const runnerPath = path.join(__dirname, '..', 'scripts', 'fuzz', 'fuzz-runner.cjs');
-const { discoverWpCodeboxBin, wpCodeboxRuntimeEnv } = require(runnerPath);
+const { discoverWpCodeboxBin, wpCodeboxCommand, wpCodeboxRuntimeEnv } = require(runnerPath);
 fs.writeFileSync(workloadPath, `${JSON.stringify(workload)}\n`);
 
 assert.equal(fs.statSync(runnerPath).mode & 0o111, 0o111, 'fuzz runner script must be executable');
@@ -182,6 +182,22 @@ assert.equal(
 	discoverWpCodeboxBin({ HOMEBOY_WP_CODEBOX_INSTALL_DIR: codeboxInstallRoot }),
 	cachedCodeboxBin,
 	'Fuzz runner should prefer the cached WP Codebox CLI over stale binaries on PATH'
+);
+assert.equal(
+	wpCodeboxCommand({
+		HOMEBOY_WP_CODEBOX_INSTALL_DIR: codeboxInstallRoot,
+		HOMEBOY_SETTINGS_WP_CODEBOX_BIN: '/stale/wp-codebox',
+	}),
+	cachedCodeboxBin,
+	'Homeboy-managed WP Codebox cache should beat stale persisted settings'
+);
+assert.equal(
+	wpCodeboxCommand({
+		HOMEBOY_WP_CODEBOX_BIN: '/explicit/wp-codebox',
+		HOMEBOY_WP_CODEBOX_INSTALL_DIR: codeboxInstallRoot,
+	}),
+	'/explicit/wp-codebox',
+	'Explicit WP Codebox binary env should override cache discovery'
 );
 
 const cli = spawnSync(runnerPath, [], {


### PR DESCRIPTION
## Summary
- Uses a shared fuzz-runner command resolver for WP Codebox CLI selection.
- Prefers the Homeboy-managed WP Codebox cache over stale persisted `wp_codebox_bin` settings.
- Preserves explicit `HOMEBOY_WP_CODEBOX_BIN` as the highest-precedence override.

## Testing
- node tests/wordpress-fuzz-runner-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing stale Lab runner CLI precedence, implementing the resolver adjustment, and running targeted verification.