### PR TITLE
Preserve fuzz agent task goals

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -369,7 +369,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
 
   return {
     schema: WP_CODEBOX_TASK_REQUEST_SCHEMA,
-    goal: request.instructions,
+    goal: request.goal || request.instructions,
     target,
     workspace_materialization: workspaceMaterialization,
     allowed_tools: sandboxAllowedTools || [],

--- a/wordpress/lib/generic-agent-task-plan.js
+++ b/wordpress/lib/generic-agent-task-plan.js
@@ -38,6 +38,7 @@ function genericAgentTaskRequest(options = {}) {
 		repo: options.repo,
 		workspace: options.workspace,
 		executor: runnerRequest.executor,
+		goal: options.goal,
 		instructions: options.instructions,
 		inputs: options.inputs,
 		source_refs: sourceRefs === undefined ? undefined : normalizeArray(sourceRefs),

--- a/wordpress/lib/wordpress-runtime-task-planner.js
+++ b/wordpress/lib/wordpress-runtime-task-planner.js
@@ -81,6 +81,7 @@ function wordpressRuntimeTaskRequest(options = {}) {
 		cwd: options.cwd,
 		repo: options.repo,
 		workspace: options.workspace,
+		goal: options.goal || options.instructions || instructionsForAbility(ability),
 		instructions: options.instructions || instructionsForAbility(ability),
 		inputs: stripUndefined({
 			...(options.inputs || {}),

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -157,6 +157,7 @@ function wpCodeboxFuzzSuiteTaskRequest(options = {}) {
 		abilityInput: input,
 		artifactDeclarations: options.artifactDeclarations || options.artifact_declarations || DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS,
 		expectedArtifacts: options.expectedArtifacts || options.expected_artifacts || DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS,
+		goal: options.goal || options.instructions || 'Delegate WordPress fuzz execution to WP Codebox and return the declared fuzz artifacts.',
 		instructions: options.instructions || 'Delegate WordPress fuzz execution to WP Codebox and return the declared fuzz artifacts.',
 	});
 }

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -129,6 +129,7 @@ const dispatchPromise = runWordPressFuzzRunnerResult({
 	runRuntimeTask: async (request) => {
 		dispatchedRequest = request;
 		assert.equal(request.task_id, 'dispatch-run');
+		assert.equal(request.goal, 'Run WordPress fuzz suite generic-wordpress-workload and return the declared fuzz artifacts.');
 		assert.equal(request.executor.backend, 'codebox');
 		assert.equal(request.executor.config.runtime_task.ability, 'wp-codebox/run-fuzz-suite');
 		assert.equal(request.executor.config.runtime_task.input.schema, 'wp-codebox/fuzz-suite/v1');
@@ -289,6 +290,10 @@ if (request.runtime_task || request.artifact_declarations || request.sandbox_too
 }
 if (request.task_input?.schema !== 'wp-codebox/task-input/v1') {
   process.stderr.write('missing delegated task input');
+  process.exit(1);
+}
+if (request.task_input?.goal !== 'Run WordPress fuzz suite legacy-dispatch-cli-workload and return the declared fuzz artifacts.') {
+  process.stderr.write('missing delegated task goal');
   process.exit(1);
 }
 if (request.task_input?.runtime_task?.ability !== 'wp-codebox/run-fuzz-suite' || request.task_input?.runtime_task?.input?.schema !== 'wp-codebox/fuzz-suite/v1') {


### PR DESCRIPTION
## Summary
- Preserves top-level `goal` on generic/WordPress runtime task requests.
- Passes fuzz instructions as the fallback agent-task goal.
- Maps Homeboy request `goal` into WP Codebox task input before fallback `run-agent-task` execution.

## Testing
- node tests/wordpress-fuzz-runner-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the fallback `goal is required` failure, preserving goal through the request adapters, and running targeted verification.