### PR TITLE
Allow WordPress builds to skip nested packages

### DIFF
--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -669,8 +669,54 @@ $manifest = [
 ];
 
 file_put_contents( getenv( 'HOMEBOY_WORDPRESS_PACKAGE_ARTIFACTS_MANIFEST' ), json_encode( $manifest, JSON_UNESCAPED_SLASHES ) . "\n" );
-file_put_contents( getenv( 'HOMEBOY_WORDPRESS_PACKAGE_ARTIFACTS_LIST' ), $list );
+    file_put_contents( getenv( 'HOMEBOY_WORDPRESS_PACKAGE_ARTIFACTS_LIST' ), $list );
 PHP
+}
+
+wordpress_setting() {
+    local key="$1"
+    local default_value="$2"
+
+    HOMEBOY_WORDPRESS_SETTING_KEY="$key" \
+    HOMEBOY_WORDPRESS_SETTING_DEFAULT="$default_value" \
+    php <<'PHP'
+<?php
+$settings = json_decode( getenv( 'HOMEBOY_SETTINGS_JSON' ) ?: '{}', true );
+if ( ! is_array( $settings ) ) {
+	$settings = [];
+}
+
+$key     = (string) getenv( 'HOMEBOY_WORDPRESS_SETTING_KEY' );
+$default = (string) getenv( 'HOMEBOY_WORDPRESS_SETTING_DEFAULT' );
+$value   = array_key_exists( $key, $settings ) ? $settings[ $key ] : $default;
+
+if ( is_bool( $value ) ) {
+	echo $value ? '1' : '0';
+	return;
+}
+
+if ( null === $value ) {
+	echo '';
+	return;
+}
+
+echo (string) $value;
+PHP
+}
+
+should_build_nested_packages() {
+    local value="${HOMEBOY_BUILD_NESTED_PACKAGES:-}"
+    if [ -z "$value" ]; then
+        value="$(wordpress_setting build_nested_packages 1)"
+    fi
+
+    case "$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')" in
+        0|false|no|off|skip|disabled)
+            return 1
+            ;;
+    esac
+
+    return 0
 }
 
 include_package_artifacts() {
@@ -903,7 +949,11 @@ build_project() {
     clean_previous_builds
     install_production_deps
     build_frontend_assets
-    build_nested_packages
+    if should_build_nested_packages; then
+        build_nested_packages
+    else
+        print_status "Skipping nested package builds (build_nested_packages disabled)"
+    fi
     copy_project_files
 
     if ! validate_php_syntax; then

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -947,6 +947,13 @@
       "description": "Map of CONSTANT_NAME => value appended to the WP Codebox wp-tests-config.php as additional define() statements. Lets a component declare wp-config-level constants (mode flags, debug toggles, custom paths) without shipping a custom drop-in. Values preserve PHP type via var_export() — booleans, integers, and nulls round-trip cleanly. Reserved canonical names (DB_NAME, ABSPATH, etc.) cannot be overridden."
     },
     {
+      "id": "build_nested_packages",
+      "label": "Build nested package.json directories",
+      "type": "boolean",
+      "default": true,
+      "description": "Whether the WordPress package builder should recursively run build scripts in nested package.json directories after the root frontend build. Disable for components whose root build already produces all required nested frontend assets. Can be overridden with HOMEBOY_BUILD_NESTED_PACKAGES=0."
+    },
+    {
       "id": "bench_env",
       "label": "Bench env passthrough",
       "type": "object",


### PR DESCRIPTION
## Summary
- Add a WordPress extension setting/env override to skip recursive nested package builds.
- Keep nested package builds enabled by default for existing components.
- Let components whose root build already produces required frontend assets avoid false packaging failures.

## Testing
- bash -n wordpress/scripts/build/build.sh
- jq empty wordpress/wordpress.json
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Studio Native release packaging failure and implementing the generic nested-package build opt-out.