### PR TITLE
Make runtime workflow provider-neutral

### DIFF
--- a/.github/scripts/normalize-provider-plugin.cjs
+++ b/.github/scripts/normalize-provider-plugin.cjs
@@ -22,7 +22,7 @@ function main() {
   if (includeCredentials) {
     const providerSecretEnv = jqAlternative(
       providerPlugin.provider_secret_env || providerPlugin.providerSecretEnv || providerPlugin.provider_secret_env_mapping || providerPlugin.providerSecretEnvMapping || providerPlugin.credentials,
-      provider === 'openai' ? { connectors_ai_openai_api_key: 'OPENAI_API_KEY' } : {}
+      {}
     );
     if (!providerSecretEnv || Array.isArray(providerSecretEnv) || typeof providerSecretEnv !== 'object') {
       throw new Error('provider_plugin.provider_secret_env must be a JSON object');

--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -46,10 +46,10 @@ function buildConfig(env) {
     throw new Error(`Runtime CLI build missing at ${runtimeBin || 'runtime.paths.runtime_bin'}`);
   }
 
-  const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || '', false);
+  const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || '', true);
   const validationDependencies = validationPaths(workspace, providerPlugin, env.PROVIDER || '');
   const providerSecretEnvMapping = providerPlugin.provider_secret_env || {};
-  const providerBenchEnv = {};
+  const providerBenchEnv = providerBenchEnvFromManifest(runtime, env.PROVIDER || '', env);
   for (const providerEnvName of Object.values(providerSecretEnvMapping)) {
     if (typeof providerEnvName !== 'string' || providerEnvName.length === 0) {
       continue;
@@ -210,10 +210,50 @@ function buildConfig(env) {
       HOMEBOY_GITHUB_APP_TOKEN: env.GITHUB_APP_TOKEN_VALUE || '',
       GITHUB_RUN_ID: env.GITHUB_RUN_ID_VALUE || '',
       GITHUB_RUN_ATTEMPT: env.GITHUB_RUN_ATTEMPT_VALUE || '',
-      OPENAI_API_KEY: env.OPENAI_API_KEY || '',
       ...providerBenchEnv,
     },
   };
+}
+
+function providerBenchEnvFromManifest(runtime, provider, env) {
+  const envNames = new Set();
+  const defaults = runtime?.executor?.provider_defaults?.[provider];
+  if (defaults && typeof defaults === 'object' && !Array.isArray(defaults)) {
+    for (const name of normalizeStringArray(defaults.secret_env)) {
+      envNames.add(name);
+    }
+    for (const name of normalizeStringArray(defaults.required_secret_env)) {
+      envNames.add(name);
+    }
+    for (const name of normalizeStringArray(defaults.optional_secret_env)) {
+      envNames.add(name);
+    }
+  }
+  for (const requirement of runtime?.executor?.secret_env_requirements || []) {
+    if (secretRequirementMatchesProvider(requirement, provider)) {
+      for (const name of normalizeStringArray(requirement.env)) {
+        envNames.add(name);
+      }
+    }
+  }
+  return Object.fromEntries(Array.from(envNames)
+    .filter((name) => env[name])
+    .map((name) => [name, env[name]]));
+}
+
+function secretRequirementMatchesProvider(requirement, provider) {
+  if (!provider || !requirement || typeof requirement !== 'object' || Array.isArray(requirement)) {
+    return false;
+  }
+  const clauses = requirement.when?.any || [];
+  return Array.isArray(clauses) && clauses.some((clause) => clause?.equals === provider);
+}
+
+function normalizeStringArray(value) {
+  if (typeof value === 'string' && value.length > 0) {
+    return [value];
+  }
+  return Array.isArray(value) ? value.filter((entry) => typeof entry === 'string' && entry.length > 0) : [];
 }
 
 function runtimeWorkloadFromEnv(env, fallbackId) {
@@ -231,9 +271,6 @@ function validationPaths(workspace, providerPlugin, provider) {
       .sort();
   }
   let providerPluginHostPath = '';
-  if (!providerPlugin.repo && provider === 'openai' && fs.existsSync(path.join(ciDir, 'ai-provider-for-openai'))) {
-    providerPluginHostPath = path.join(ciDir, 'ai-provider-for-openai');
-  }
   if (providerPlugin.repo) {
     const providerPluginRepoName = providerPlugin.repo.split('/')[1];
     const providerPluginRoot = path.join(ciDir, providerPluginRepoName);
@@ -398,4 +435,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { buildConfig, projectRuntimeConfig, runtimePathRequired };
+module.exports = { buildConfig, projectRuntimeConfig, providerBenchEnvFromManifest, runtimePathRequired };

--- a/.github/scripts/runtime-agent-full-run/lib/common.cjs
+++ b/.github/scripts/runtime-agent-full-run/lib/common.cjs
@@ -58,7 +58,7 @@ function normalizeProviderPlugin(rawInput, provider, includeCredentials) {
   if (includeCredentials) {
     const providerSecretEnv = jqAlternative(
       providerPlugin.provider_secret_env || providerPlugin.providerSecretEnv || providerPlugin.provider_secret_env_mapping || providerPlugin.providerSecretEnvMapping || providerPlugin.credentials,
-      provider === 'openai' ? { connectors_ai_openai_api_key: 'OPENAI_API_KEY' } : {}
+      {}
     );
     if (!providerSecretEnv || Array.isArray(providerSecretEnv) || typeof providerSecretEnv !== 'object') {
       throw new Error('provider_plugin.provider_secret_env must be a JSON object');

--- a/.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
+++ b/.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
@@ -27,13 +27,10 @@ function dependencyEntries(env) {
   const runtimeId = env.RUNTIME || env.RUNTIME_PROVIDER || env.BACKEND || DEFAULT_RUNTIME_ID;
   const runtime = resolveRuntimeProvider(runtimeId, { env });
   const entries = runtime.checkout.repo ? [{ repo: runtime.checkout.repo, ref: runtime.checkout.ref, target: runtime.checkout.target }] : [];
-  const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || 'openai', true);
+  const providerPlugin = normalizeProviderPlugin(env.PROVIDER_PLUGIN || '{}', env.PROVIDER || '', true);
   const runtimeDependencies = runtimeDependencyEntries(env.RUNTIME_DEPENDENCIES || '');
   if (runtimeDependencies.length > 0) {
     entries.push(...runtimeDependencies);
-  }
-  if ((env.PROVIDER || 'openai') === 'openai' && !providerPlugin.repo) {
-    entries.push(`WordPress/ai-provider-for-openai@${env.OPENAI_PROVIDER_REF || 'trunk'}`);
   }
   if (providerPlugin.repo) {
     entries.push(providerPlugin.ref ? `${providerPlugin.repo}@${providerPlugin.ref}` : providerPlugin.repo);

--- a/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
+++ b/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
@@ -38,7 +38,7 @@ function installCheckedOutPhpDependencies(workspace) {
     }
   }
 
-  const providerPlugin = normalizeProviderPlugin(process.env.PROVIDER_PLUGIN || '{}', process.env.PROVIDER || 'openai', false);
+  const providerPlugin = normalizeProviderPlugin(process.env.PROVIDER_PLUGIN || '{}', process.env.PROVIDER || '', false);
   if (!providerPlugin.repo) {
     return;
   }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -201,7 +201,7 @@ jobs:
 - WP Codebox executor paths accept caller-supplied component contracts, runtime overlays, mounts, task payload, provider defaults, tool profiles, and declarative runtime requirements through the generic runtime workflow input renderer. Domain policy belongs in caller inputs and runtime profiles, not in the generic WP Codebox provider manifest.
 - `runtime_dependencies` checks out the explicit runtime component stack and forwards those paths to the selected runtime adapter.
 - `tool_profile` is the runtime-neutral tool policy input. The selected runtime adapter maps it into runtime-owned workflow fields; for WP Codebox that becomes the sandbox tool policy. `tool_policy` remains accepted as a compatibility alias.
-- `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `provider_secret_env` keys. When `provider: openai`, an empty object preserves the existing OpenAI provider defaults. The legacy `credentials` key is still accepted by the normalizer as an input alias, but generated config uses `provider_secret_env_mapping`.
+- `provider_plugin` is a JSON object with `repo`, `ref`, `path`, `register_function`, and `provider_secret_env` keys. The generic workflow does not choose a provider plugin or secret for callers; provider dependencies and credential mappings are explicit caller inputs, and runtime manifests advertise provider-specific defaults/capabilities. The legacy `credentials` key is still accepted by the normalizer as an input alias, but generated config uses `provider_secret_env_mapping`.
 - `validation_dependencies` accepts additional `OWNER/REPO@REF` entries and checks each out under `.ci/<repo>`. Entries without `@REF` use the repository default branch.
 - Bundle sources in `runtime_execution` are resolved relative to the consumer checkout unless the caller materializes external bundle sources through dependencies or validation checkouts.
 - `app_token_repos` scopes the Homeboy GitHub App token and defaults to `target_repo`. Use it when the workflow needs app-token access to more than the target repository.
@@ -269,28 +269,9 @@ results copied into stable runner outputs.
 
 ## Provider plugin examples
 
-OpenAI is the default provider. Callers can omit `provider_plugin` and pass
-`OPENAI_API_KEY` through inherited secrets:
-
-```yaml
-jobs:
-  run-agent:
-    uses: Extra-Chill/homeboy-extensions/.github/workflows/runtime-agent-full-run.yml@v4
-    with:
-      runtime_provider: wp-codebox
-      runtime_profile: example-agent
-      runtime_profiles: >-
-        {"example-agent":{"id":"example-agent","runtime_task_ability":"example/run-task","ability_requirements":["example/run-task"]}}
-      workload_id: example-flow
-      target_repo: Extra-Chill/example
-      provider: openai
-      model: gpt-5.5
-    secrets: inherit
-```
-
-Non-OpenAI providers supply the plugin checkout and credential mapping
-explicitly. Map each provider option to one of the generic provider
-secret env names, then pass that secret in the reusable workflow call:
+Provider plugins and credentials are explicit. Map each provider option to one
+of the generic provider secret env names, then pass that secret in the reusable
+workflow call:
 
 ```yaml
 jobs:
@@ -304,7 +285,7 @@ jobs:
       workload_id: example-flow
       target_repo: Extra-Chill/example
       provider: example-provider
-      model: example-model
+      model: gpt-5.5
       provider_plugin: |
         {
           "repo": "Example/example-ai-provider",

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -80,10 +80,6 @@ name: Runtime Agent Full Run (reusable)
         description: JSON object describing an optional provider plugin checkout and credential env mapping.
         type: string
         default: '{}'
-      openai_provider_ref:
-        description: Ref for WordPress/ai-provider-for-openai when using the built-in OpenAI provider checkout.
-        type: string
-        default: trunk
       model:
         type: string
         default: ''
@@ -301,8 +297,6 @@ name: Runtime Agent Full Run (reusable)
         required: false
       HOMEBOY_APP_PRIVATE_KEY:
         required: false
-      OPENAI_API_KEY:
-        required: false
       PROVIDER_SECRET_1:
         required: false
       PROVIDER_SECRET_2:
@@ -440,7 +434,6 @@ jobs:
           AGENT_RUNTIME_REF: ${{ inputs.runtime_ref }}
           PROVIDER: ${{ inputs.provider }}
           PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
-          OPENAI_PROVIDER_REF: ${{ inputs.openai_provider_ref }}
         run: node .ci/homeboy-extensions/.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs
 
       - name: Download workflow input artifacts
@@ -559,7 +552,6 @@ jobs:
           GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT_VALUE: ${{ github.run_attempt }}
           PROVIDER_PLUGIN: ${{ inputs.provider_plugin }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           PROVIDER_SECRET_1: ${{ secrets.PROVIDER_SECRET_1 }}
           PROVIDER_SECRET_2: ${{ secrets.PROVIDER_SECRET_2 }}
           PROVIDER_SECRET_3: ${{ secrets.PROVIDER_SECRET_3 }}
@@ -572,7 +564,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           HOMEBOY_GITHUB_APP_TOKEN: ${{ steps.app-token.outputs.token }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           PROVIDER_SECRET_1: ${{ secrets.PROVIDER_SECRET_1 }}
           PROVIDER_SECRET_2: ${{ secrets.PROVIDER_SECRET_2 }}
           PROVIDER_SECRET_3: ${{ secrets.PROVIDER_SECRET_3 }}

--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -198,6 +198,9 @@ function resolveExecutor(manifest, repoRoot, options = {}) {
 		invocation,
 		capabilities: Array.isArray(provider?.capabilities) ? provider.capabilities.filter(Boolean) : [],
 		runtime_execution_contracts: provider?.runtime_execution_contracts || provider?.execution_contracts || {},
+		provider_metadata: provider?.provider_metadata || {},
+		provider_defaults: provider?.provider_defaults || {},
+		secret_env_requirements: Array.isArray(provider?.secret_env_requirements) ? provider.secret_env_requirements : [],
 	};
 }
 

--- a/tests/runtime-agent-full-run-boundary-smoke.sh
+++ b/tests/runtime-agent-full-run-boundary-smoke.sh
@@ -25,6 +25,8 @@ const files = [
   '.github/scripts/runtime-agent-full-run/lib/common.cjs',
 ];
 
+const failures = [];
+const compatibilityReferences = [];
 const workflow = fs.readFileSync(path.join(root, '.github/workflows/runtime-agent-full-run.yml'), 'utf8');
 if (/wordpress\/scripts\/agent\/(run-runtime-agent-task|run-host-runner-lifecycle|extract-engine-data|update-runner-workspace-pr)/.test(workflow)) {
   failures.push('runtime-agent-full-run.yml: generic workflow must invoke runtime-agent-full-run scripts, not wordpress/scripts/agent');
@@ -32,9 +34,9 @@ if (/wordpress\/scripts\/agent\/(run-runtime-agent-task|run-host-runner-lifecycl
 if (/default:\s*wp-codebox/.test(workflow)) {
   failures.push('runtime-agent-full-run.yml: generic workflow must not default to wp-codebox');
 }
-
-const failures = [];
-const compatibilityReferences = [];
+if (/OPENAI_API_KEY|openai_provider_ref|OPENAI_PROVIDER_REF/.test(workflow)) {
+  failures.push('runtime-agent-full-run.yml: generic workflow must not declare OpenAI provider secrets or checkout refs');
+}
 for (const file of files) {
   const body = fs.readFileSync(path.join(root, file), 'utf8');
   const match = body.match(forbidden);

--- a/tests/runtime-agent-full-run-provider-neutral-smoke.mjs
+++ b/tests/runtime-agent-full-run-provider-neutral-smoke.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { dependencyEntries, resolvePlan } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/materialize-dependencies.cjs'));
+const { buildConfig, providerBenchEnvFromManifest } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/build-runner-config.cjs'));
+const { normalizeProviderPlugin } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/lib/common.cjs'));
+const { resolveRuntimeProvider } = require(path.join(repoRoot, 'runtime-agent-ci/lib/runtime-provider-resolver.cjs'));
+
+const baseEnv = {
+  RUNTIME: 'local-shell',
+  RUNTIME_DEPENDENCIES: '',
+  VALIDATION_DEPENDENCIES: '',
+  PROVIDER_PLUGIN: '{}',
+  PROVIDER: 'openai',
+};
+
+assert.deepEqual(dependencyEntries(baseEnv), []);
+assert.deepEqual(resolvePlan(dependencyEntries(baseEnv), true), []);
+assert.deepEqual(normalizeProviderPlugin('{}', 'openai', true).provider_secret_env, {});
+
+const explicitProviderPlugin = {
+  repo: 'WordPress/ai-provider-for-openai',
+  ref: 'trunk',
+  path: '.',
+  provider_secret_env: {
+    connectors_ai_openai_api_key: 'PROVIDER_SECRET_1',
+  },
+};
+assert.deepEqual(resolvePlan(dependencyEntries({
+  ...baseEnv,
+  PROVIDER_PLUGIN: JSON.stringify(explicitProviderPlugin),
+}), true), [{
+  repo: 'WordPress/ai-provider-for-openai',
+  ref: 'trunk',
+  target: '.ci/ai-provider-for-openai',
+}]);
+assert.deepEqual(normalizeProviderPlugin(JSON.stringify(explicitProviderPlugin), 'openai', true).provider_secret_env, {
+  connectors_ai_openai_api_key: 'PROVIDER_SECRET_1',
+});
+
+const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-provider-neutral-workspace-'));
+const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-provider-neutral-runner-'));
+const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-provider-neutral-bin-'));
+const runtime = resolveRuntimeProvider('wp-codebox', { workspace });
+assert.deepEqual(providerBenchEnvFromManifest(runtime, 'openai', {
+  OPENAI_API_KEY: 'manifest-secret-value',
+}), {
+  OPENAI_API_KEY: 'manifest-secret-value',
+});
+assert.deepEqual(providerBenchEnvFromManifest(runtime, 'openai', {}), {});
+
+const config = buildConfig({
+  GITHUB_WORKSPACE: workspace,
+  RUNNER_TEMP: runnerTemp,
+  WORKLOAD_ID: 'provider-neutral',
+  TARGET_REPO: 'Extra-Chill/example',
+  RUNTIME: 'local-shell',
+  PATH: `${binDir}${path.delimiter}${process.env.PATH || ''}`,
+  PROFILE: 'local-shell-profile',
+  RUNTIME_PROFILES: JSON.stringify({
+    'local-shell-profile': {
+      id: 'local-shell-profile',
+    },
+  }),
+  PROVIDER: 'openai',
+  PROVIDER_PLUGIN: JSON.stringify(explicitProviderPlugin),
+  PROVIDER_SECRET_1: 'secret-value',
+  OPENAI_API_KEY: 'manifest-secret-value',
+});
+
+assert.deepEqual(config.provider_secret_env_mapping, {
+  connectors_ai_openai_api_key: 'PROVIDER_SECRET_1',
+});
+assert.equal(config.bench_env.PROVIDER_SECRET_1, 'secret-value');
+
+const neutralConfig = buildConfig({
+  GITHUB_WORKSPACE: workspace,
+  RUNNER_TEMP: runnerTemp,
+  WORKLOAD_ID: 'provider-neutral-empty',
+  TARGET_REPO: 'Extra-Chill/example',
+  RUNTIME: 'local-shell',
+  PATH: `${binDir}${path.delimiter}${process.env.PATH || ''}`,
+  PROFILE: 'local-shell-profile',
+  RUNTIME_PROFILES: JSON.stringify({
+    'local-shell-profile': {
+      id: 'local-shell-profile',
+    },
+  }),
+  PROVIDER: 'openai',
+  PROVIDER_PLUGIN: '{}',
+});
+
+assert.deepEqual(neutralConfig.provider_secret_env_mapping, {});
+assert.equal('OPENAI_API_KEY' in neutralConfig.bench_env, false);
+
+console.log('runtime agent full-run provider-neutral smoke passed');


### PR DESCRIPTION
## Summary
- Remove OpenAI-specific secret and checkout defaults from the generic runtime-agent full-run workflow.
- Keep provider plugin checkout and credential mapping explicit through `provider_plugin` and generic `PROVIDER_SECRET_*` inputs.
- Materialize provider env values from selected runtime manifest `provider_defaults` / `secret_env_requirements` only when the caller provides matching env values.
- Add provider-neutral smoke coverage and strengthen the generic workflow boundary test.

## Verification
- `node tests/runtime-agent-full-run-provider-neutral-smoke.mjs`
- `node tests/runtime-agent-full-run-local-shell-smoke.mjs`
- `bash tests/runtime-agent-full-run-boundary-smoke.sh`
- `node .github/scripts/normalize-provider-plugin.cjs --provider openai --includeCredentials true --input '{}'`
- `PROVIDER=openai RUNTIME=local-shell node .github/scripts/runtime-agent-full-run/materialize-dependencies.cjs --print-plan`
- `git diff --check`

## Blockers / notes
- Existing test `node tests/runtime-agent-full-run-codebox-inputs-smoke.mjs` is blocked locally because `@automattic/wp-codebox-core` / `wp-codebox-workspace` are not installed in this worktree. The new provider-neutral test avoids that optional runtime package while still asserting manifest-driven provider secret materialization.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the provider-neutral workflow/script changes, adding targeted smoke coverage, and drafting this PR description.
