### PR TITLE
Project fuzz manifests into Codebox cases

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -156,10 +156,12 @@ function normalizeRunnerPlan(input) {
 }
 
 function buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDuration, instructions }) {
+	const homeboyFuzzWorkload = workload.schema === 'homeboy/fuzz-workload/v1' ? workload : undefined;
 	return wpCodeboxFuzzSuiteInput({
 		id: runId,
 		goal: instructions,
 		target: workload.target || { type: 'wordpress', workload_id: workloadId },
+		homeboyFuzzWorkload,
 		workload: stripUndefined({
 			id: workloadId,
 			plan_id: plan.id,

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -59,6 +59,7 @@ const DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS = [
 	},
 ];
 const DEFAULT_FUZZ_RUN_ARTIFACT_DECLARATIONS = legacyWpCodeboxFuzzRunArtifactDeclarationsAlias();
+const HOMEBOY_FUZZ_WORKLOAD_SCHEMA = 'homeboy/fuzz-workload/v1';
 
 const FUZZ_ARTIFACT_SEMANTIC_KEYS = {
 	fuzz_report: 'fuzz.report',
@@ -123,13 +124,16 @@ function wpCodeboxWordPressWorkloadRunSchema(options = {}) {
 }
 
 function wpCodeboxFuzzSuiteInput(options = {}) {
+	const source = normalizeHomeboyFuzzWorkloadSource(options);
+	const cases = normalizeWpCodeboxFuzzSuiteCases(source || options);
+	const artifacts = source?.artifacts || options.artifacts;
 	return stripUndefined({
 		schema: wpCodeboxFuzzSuiteSchema(options),
 		id: options.id || options.runId || options.run_id,
 		goal: options.goal || options.instructions,
 		version: options.version,
 		target: options.target,
-		cases: normalizeArray(options.cases),
+		cases,
 		metadata: stripUndefined({
 			...(objectOrUndefined(options.metadata) || {}),
 			workload: objectOrUndefined(options.workload),
@@ -137,9 +141,106 @@ function wpCodeboxFuzzSuiteInput(options = {}) {
 			limits: objectOrUndefined(options.limits),
 			coverage: objectOrUndefined(options.coverage),
 			runtime_profile: objectOrUndefined(options.runtimeProfile || options.runtime_profile),
-			artifacts: objectOrUndefined(options.artifacts),
+			artifacts: objectOrUndefined(artifacts),
 		}),
 	});
+}
+
+function normalizeHomeboyFuzzWorkloadSource(options = {}) {
+	if (options?.schema === HOMEBOY_FUZZ_WORKLOAD_SCHEMA) {
+		return options;
+	}
+	const workload = options.workload;
+	if (workload?.schema === HOMEBOY_FUZZ_WORKLOAD_SCHEMA) {
+		return workload;
+	}
+	if (options.homeboyFuzzWorkload?.schema === HOMEBOY_FUZZ_WORKLOAD_SCHEMA || options.homeboy_fuzz_workload?.schema === HOMEBOY_FUZZ_WORKLOAD_SCHEMA) {
+		return options.homeboyFuzzWorkload || options.homeboy_fuzz_workload;
+	}
+	return undefined;
+}
+
+function normalizeWpCodeboxFuzzSuiteCases(source = {}) {
+	const directCases = normalizeArray(source.cases);
+	if (source.schema !== HOMEBOY_FUZZ_WORKLOAD_SCHEMA) {
+		return directCases;
+	}
+	return directCases.map((entry, index) => homeboyFuzzWorkloadCaseToWpCodeboxCase(entry, source, index));
+}
+
+function homeboyFuzzWorkloadCaseToWpCodeboxCase(entry = {}, manifest = {}, index = 0) {
+	const caseId = entry.case_id || entry.caseId || entry.id || `${manifest.id || 'fuzz-workload'}:${index}`;
+	const intent = objectOrUndefined(entry.intent) || {};
+	const execute = objectOrUndefined(intent.execute) || {};
+	const artifacts = normalizeHomeboyFuzzCaseArtifacts(entry, manifest);
+	return stripUndefined({
+		id: caseId,
+		case_id: caseId,
+		target: { kind: 'runtime', id: 'wordpress.run-workload', entrypoint: 'wordpress.run-workload' },
+		description: entry.description || manifest.label,
+		input: stripUndefined({
+			path: execute.path || manifest.workload?.path,
+			type: execute.type || manifest.workload?.type,
+			entry: execute.entry || manifest.workload?.entry,
+			parameters: objectOrUndefined(execute.parameters),
+		}),
+		phases: homeboyFuzzWorkloadCasePhases(entry, manifest, intent, artifacts),
+		artifacts,
+		metadata: stripUndefined({
+			...(objectOrUndefined(entry.metadata) || {}),
+			source_schema: HOMEBOY_FUZZ_WORKLOAD_SCHEMA,
+			source_manifest_id: manifest.id,
+			intent: objectOrUndefined(entry.intent),
+		}),
+	});
+}
+
+function homeboyFuzzWorkloadCasePhases(entry = {}, manifest = {}, intent = {}, artifacts = []) {
+	if (objectOrUndefined(entry.phases)) {
+		return entry.phases;
+	}
+	const execute = objectOrUndefined(intent.execute) || {};
+	const activation = intent.plugin?.activation;
+	const path = execute.path || manifest.workload?.path;
+	const setup = typeof activation === 'string' && activation.trim() !== ''
+		? [{ command: 'wordpress.ensure-plugin-active', args: [`plugin=${activation}`] }]
+		: undefined;
+	const action = typeof path === 'string' && path.trim() !== ''
+		? [{ command: 'wordpress.run-workload', args: [`path=${path}`] }]
+		: [];
+	const collect = normalizeArray(intent.collect).length > 0 ? normalizeArray(intent.collect) : artifacts.map((artifact) => ({ artifact: artifact.name }));
+	const assert = collect
+		.map((item) => item?.artifact)
+		.filter(Boolean)
+		.map((artifact) => ({ command: 'wordpress.collect-workload-result', args: [`artifact=${artifact}`] }));
+	return stripUndefined({ setup, action, assert: assert.length > 0 ? assert : undefined });
+}
+
+function normalizeHomeboyFuzzCaseArtifacts(entry = {}, manifest = {}) {
+	const byName = new Map();
+	for (const artifact of [...normalizeArray(manifest.artifacts?.expected), ...normalizeArray(entry.artifacts)]) {
+		if (!objectOrUndefined(artifact) || typeof artifact.name !== 'string' || artifact.name.trim() === '') {
+			continue;
+		}
+		const existing = byName.get(artifact.name) || {};
+		const existingMetadata = objectOrUndefined(existing.metadata) || {};
+		byName.set(artifact.name, stripUndefined({
+			...existing,
+			name: artifact.name,
+			path: artifact.path || artifact.relativePath || artifact.relative_path || existing.path,
+			role: artifact.role || existing.role,
+			kind: artifact.kind || existing.kind,
+			contentType: artifact.contentType || artifact.content_type || existing.contentType,
+			required: artifact.required !== false,
+			metadata: stripUndefined({
+				...existingMetadata,
+				...(objectOrUndefined(artifact.metadata) || {}),
+				semantic_key: artifact.semantic_key || artifact.semanticKey || existingMetadata.semantic_key,
+				schema: artifact.schema || existingMetadata.schema,
+			}),
+		}));
+	}
+	return [...byName.values()];
 }
 
 function wpCodeboxFuzzRunInput(options = {}) {
@@ -203,11 +304,15 @@ function runWpCodeboxFuzzRun(options = {}) {
 
 function normalizeWpCodeboxFuzzSuiteResult(result = {}, context = {}) {
 	const source = normalizeWpCodeboxFuzzResultSource(result?.json || result?.result || result?.output || result);
-	const status = source?.status || source?.outcome?.status || result?.status || '';
+	let status = source?.status || source?.outcome?.status || result?.status || '';
 	const artifacts = normalizeWpCodeboxFuzzArtifacts(source, result);
 	const coverageSummary = normalizeCoverageSummary(source?.coverage_summary || source?.coverageSummary || source?.coverage?.summary);
 	const coverageGaps = normalizeCoverageGaps(source?.coverage_gaps || source?.coverageGaps || source?.coverage?.gaps);
 	const normalizedResult = normalizeEmbeddedWordPressFuzzResult(source);
+	const contractFailures = wpCodeboxFuzzContractFailures({ source, result, context, artifacts, coverageSummary, normalizedResult });
+	if (contractFailures.length > 0 && ['succeeded', 'success', 'passed', 'ok'].includes(String(status).toLowerCase())) {
+		status = 'failed';
+	}
 	return stripUndefined({
 		schema: WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA,
 		delegated_schema: WP_CODEBOX_FUZZ_SUITE_SCHEMA,
@@ -220,13 +325,86 @@ function normalizeWpCodeboxFuzzSuiteResult(result = {}, context = {}) {
 		coverage_gaps: coverageGaps,
 		wordpress_fuzz_result: normalizedResult,
 		artifacts,
-		failures: normalizeArray(source?.failures || source?.errors || source?.diagnostics),
+		failures: [...normalizeArray(source?.failures || source?.errors || source?.diagnostics), ...contractFailures],
 		metadata: stripUndefined({
 			...(objectOrUndefined(source?.metadata) || {}),
 			suite: objectOrUndefined(source?.suite),
 			summary: objectOrUndefined(source?.summary),
 		}),
 	});
+}
+
+function wpCodeboxFuzzContractFailures({ source = {}, result = {}, context = {}, artifacts = [], coverageSummary, normalizedResult }) {
+	if (wpCodeboxFuzzAllowsEmpty(source, context)) {
+		return [];
+	}
+
+	const requiredArtifacts = wpCodeboxFuzzRequiredArtifactDeclarations(context.request || context.taskRequest || result.request || {});
+	const caseCount = wpCodeboxFuzzCaseCount(source, normalizedResult);
+	const expectsCoverage = wpCodeboxFuzzExpectsCoverage(source, context, coverageSummary);
+	const failures = [];
+
+	if (caseCount === 0 && (requiredArtifacts.length > 0 || expectsCoverage)) {
+		failures.push({
+			severity: 'error',
+			code: 'wp_codebox_fuzz_empty_cases_for_declared_contract',
+			message: 'WP Codebox fuzz result produced no cases for a request that declares required artifacts or non-empty coverage.',
+			required_artifacts: requiredArtifacts.map((artifact) => artifact.name || artifact.path || artifact.semantic_key).filter(Boolean),
+			expects_coverage: expectsCoverage,
+		});
+	}
+
+	if (requiredArtifacts.length > 0 && artifacts.length === 0) {
+		failures.push({
+			severity: 'error',
+			code: 'wp_codebox_fuzz_required_artifacts_missing',
+			message: 'WP Codebox fuzz result produced no artifacts for a request with required artifact declarations.',
+			required_artifacts: requiredArtifacts.map((artifact) => artifact.name || artifact.path || artifact.semantic_key).filter(Boolean),
+		});
+	}
+
+	return failures;
+}
+
+function wpCodeboxFuzzAllowsEmpty(source = {}, context = {}) {
+	const input = context.request?.executor?.config?.runtime_task?.input || context.request?.input || context.input || {};
+	const metadata = {
+		...(objectOrUndefined(input.metadata) || {}),
+		...(objectOrUndefined(source?.metadata) || {}),
+	};
+	const readiness = objectOrUndefined(metadata.readiness) || {};
+	const genericPrimitive = objectOrUndefined(metadata.generic_primitive || metadata.genericPrimitive) || {};
+	return metadata.allow_empty === true
+		|| metadata.allowed_empty === true
+		|| metadata.allowEmpty === true
+		|| metadata.declared_only === true
+		|| metadata.declaredOnly === true
+		|| readiness.level === 'declared'
+		|| readiness.declared_only === true
+		|| readiness.declaredOnly === true
+		|| genericPrimitive.status === 'blocked';
+}
+
+function wpCodeboxFuzzRequiredArtifactDeclarations(request = {}) {
+	return normalizeArray(request.artifact_declarations || request.artifactDeclarations)
+		.filter((artifact) => artifact?.required === true);
+}
+
+function wpCodeboxFuzzCaseCount(source = {}, normalizedResult) {
+	const cases = source?.cases || source?.fuzz_cases || source?.fuzzCases || normalizedResult?.cases;
+	if (Array.isArray(cases)) {
+		return cases.length;
+	}
+	const total = source?.summary?.total ?? normalizedResult?.summary?.total;
+	return Number.isFinite(Number(total)) ? Number(total) : 0;
+}
+
+function wpCodeboxFuzzExpectsCoverage(source = {}, context = {}, coverageSummary) {
+	const input = context.request?.executor?.config?.runtime_task?.input || context.request?.input || context.input || {};
+	const coverage = objectOrUndefined(input.metadata?.coverage || input.coverage || source?.coverage) || {};
+	return normalizeArray(coverage.surface_ids || coverage.surfaceIds).length > 0
+		|| normalizeArray(coverage.operations).length > 0
+		|| Number(coverage.expected || coverage.discovered || coverageSummary?.surface_count) > 0;
 }
 
 function normalizeWpCodeboxFuzzRunResult(result = {}, context = {}) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -119,6 +119,48 @@ assert.equal(executedResult.status, 'succeeded');
 assert.equal(executedResult.succeeded, true);
 assert.equal(executedResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path, 'artifacts/replay.json');
 
+const jsonWorkloadResult = buildWordPressFuzzRunnerResult({
+	env: {
+		workloadPath: '/unused/in-unit-test.json',
+		workloadId: 'json-workload',
+		runId: 'json-workload-run',
+	},
+	workload: {
+		schema: 'homeboy/fuzz-workload/v1',
+		id: 'json-workload',
+		label: 'JSON workload smoke',
+		target: { type: 'wordpress-plugin', slug: 'sample-plugin' },
+		workload: {
+			runner: 'wp-codebox',
+			type: 'json',
+			path: '${package.root}/bench/json-workload.workload.json',
+			entry: 'wp-codebox/run-fuzz-suite',
+		},
+		artifacts: {
+			expected: [{ name: 'json_fuzz_result', role: 'fuzz_report', semantic_key: 'fuzz.suite_result', schema: 'wp-codebox/fuzz-suite-result/v1', required: true }],
+		},
+		cases: [{
+			case_id: 'json-workload:default',
+			artifacts: [{ name: 'json_fuzz_result', path: 'json-workload/fuzz-suite-result.json', required: true }],
+			intent: {
+				schema: 'homeboy/fuzz-workload-intent/v1',
+				type: 'wordpress-plugin-workload',
+				plugin: { activation: 'sample-plugin/sample-plugin.php' },
+				execute: { workload_ref: 'default', path: '${package.root}/bench/json-workload.workload.json', type: 'json', entry: 'wp-codebox/run-fuzz-suite' },
+				collect: [{ artifact: 'json_fuzz_result' }],
+			},
+		}],
+	},
+});
+
+assert.equal(jsonWorkloadResult.wp_codebox_input.cases.length, 1);
+assert.equal(jsonWorkloadResult.wp_codebox_input.cases[0].id, 'json-workload:default');
+assert.deepEqual(jsonWorkloadResult.wp_codebox_input.cases[0].phases.setup, [{ command: 'wordpress.ensure-plugin-active', args: ['plugin=sample-plugin/sample-plugin.php'] }]);
+assert.deepEqual(jsonWorkloadResult.wp_codebox_input.cases[0].phases.action, [{ command: 'wordpress.run-workload', args: ['path=${package.root}/bench/json-workload.workload.json'] }]);
+assert.deepEqual(jsonWorkloadResult.wp_codebox_input.cases[0].phases.assert, [{ command: 'wordpress.collect-workload-result', args: ['artifact=json_fuzz_result'] }]);
+assert.equal(jsonWorkloadResult.wp_codebox_input.cases[0].artifacts[0].required, true);
+assert.equal(jsonWorkloadResult.wp_codebox_input.metadata.artifacts.expected[0].semantic_key, 'fuzz.suite_result');
+
 let dispatchedRequest;
 const dispatchPromise = runWordPressFuzzRunnerResult({
 	env: {
@@ -140,6 +182,8 @@ const dispatchPromise = runWordPressFuzzRunnerResult({
 				schema: 'wp-codebox/fuzz-suite-result/v1',
 				request_id: request.task_id,
 				status: 'succeeded',
+				summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
+				cases: [{ id: 'get-posts', status: 'passed', success: true, diagnostics: [] }],
 				coverage_summary: { surface_count: 1, exercised_count: 1 },
 				artifactRefs: [
 					{ path: 'dispatch/fuzz-report.json', kind: 'report', contentType: 'application/json' },
@@ -248,6 +292,8 @@ process.stdout.write(JSON.stringify({
   schema: 'wp-codebox/fuzz-suite-result/v1',
   request_id: request.id,
   status: 'succeeded',
+  summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
+  cases: [{ id: 'get-posts', status: 'passed', success: true, diagnostics: [] }],
   artifactRefs: [{ path: 'fake/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
   coverage_summary: { surface_count: 1, exercised_count: 1 }
 }));
@@ -319,6 +365,8 @@ process.stdout.write(JSON.stringify({
       schema: 'wp-codebox/fuzz-suite-result/v1',
       request_id: request.task_id,
       status: 'succeeded',
+      summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
+      cases: [{ id: 'get-posts', status: 'passed', success: true, diagnostics: [] }],
       artifactRefs: [{ path: 'legacy/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
       coverage_summary: { surface_count: 1, exercised_count: 1 }
     }

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -120,6 +120,43 @@ assert(!JSON.stringify(taskRequest).includes('woocommerce'), 'fuzz suite helper 
 assert.equal(wpCodeboxFuzzSuiteTaskRequest({ taskId: 'suite-task' }).executor.config.runtime_task.input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 assert.equal(wpCodeboxFuzzRunTaskRequest({ taskId: 'run-compat-task' }).executor.config.runtime_task.input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 
+const jsonWorkloadManifest = {
+	schema: 'homeboy/fuzz-workload/v1',
+	id: 'json-workload-smoke',
+	label: 'JSON workload smoke',
+	target: { type: 'wordpress-plugin', slug: 'sample-plugin' },
+	workload: {
+		runner: 'wp-codebox',
+		type: 'json',
+		path: '${package.root}/bench/json-workload-smoke.workload.json',
+		entry: 'wp-codebox/run-fuzz-suite',
+	},
+	artifacts: {
+		expected: [{ name: 'json_fuzz_result', role: 'fuzz_report', semantic_key: 'fuzz.suite_result', schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA, required: true }],
+	},
+	cases: [{
+		case_id: 'json-workload-smoke:default',
+		artifacts: [{ name: 'json_fuzz_result', path: 'json-workload-smoke/fuzz-suite-result.json', required: true }],
+		intent: {
+			schema: 'homeboy/fuzz-workload-intent/v1',
+			type: 'wordpress-plugin-workload',
+			plugin: { activation: 'sample-plugin/sample-plugin.php' },
+			execute: { workload_ref: 'default', path: '${package.root}/bench/json-workload-smoke.workload.json', type: 'json', entry: 'wp-codebox/run-fuzz-suite' },
+			collect: [{ artifact: 'json_fuzz_result' }],
+		},
+	}],
+};
+const jsonWorkloadInput = wpCodeboxFuzzSuiteInput({ id: 'json-workload-run', homeboyFuzzWorkload: jsonWorkloadManifest });
+assert.equal(jsonWorkloadInput.cases.length, 1);
+assert.equal(jsonWorkloadInput.cases[0].id, 'json-workload-smoke:default');
+assert.equal(jsonWorkloadInput.cases[0].target.entrypoint, 'wordpress.run-workload');
+assert.deepEqual(jsonWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.ensure-plugin-active', args: ['plugin=sample-plugin/sample-plugin.php'] }]);
+assert.deepEqual(jsonWorkloadInput.cases[0].phases.action, [{ command: 'wordpress.run-workload', args: ['path=${package.root}/bench/json-workload-smoke.workload.json'] }]);
+assert.deepEqual(jsonWorkloadInput.cases[0].phases.assert, [{ command: 'wordpress.collect-workload-result', args: ['artifact=json_fuzz_result'] }]);
+assert.equal(jsonWorkloadInput.cases[0].artifacts[0].required, true);
+assert.equal(jsonWorkloadInput.cases[0].artifacts[0].metadata.semantic_key, 'fuzz.suite_result');
+assert.equal(jsonWorkloadInput.metadata.artifacts.expected[0].required, true);
+
 let invoked = false;
 runWpCodeboxFuzzSuite({
 	taskId: 'wp-codebox-fuzz-suite-delegation-smoke',
@@ -278,6 +315,30 @@ runWpCodeboxFuzzSuite({
 	});
 	assert.equal(rawNested.succeeded, true);
 	assert.equal(rawNested.metadata.suite.id, 'raw-nested-suite');
+	const emptyRequired = normalizeWpCodeboxFuzzSuiteResult({
+		json: {
+			schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+			status: 'passed',
+			suite: { id: 'empty-required-suite' },
+			summary: { total: 0, passed: 0, failed: 0, error: 0, skipped: 0 },
+		},
+	}, { request: taskRequest });
+	assert.equal(emptyRequired.succeeded, false);
+	assert.deepEqual(emptyRequired.failures.map((failure) => failure.code), [
+		'wp_codebox_fuzz_empty_cases_for_declared_contract',
+		'wp_codebox_fuzz_required_artifacts_missing',
+	]);
+	const declaredOnlyEmpty = normalizeWpCodeboxFuzzSuiteResult({
+		json: {
+			schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+			status: 'passed',
+			suite: { id: 'declared-only-suite' },
+			summary: { total: 0, passed: 0, failed: 0, error: 0, skipped: 0 },
+			metadata: { readiness: { level: 'declared' } },
+		},
+	}, { request: taskRequest });
+	assert.equal(declaredOnlyEmpty.succeeded, true);
+	assert.deepEqual(declaredOnlyEmpty.failures, []);
 	assert.equal(normalizeWpCodeboxFuzzSuiteResult({ status: 'passed' }).result_schema, WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA);
 	assert.equal(normalizeWpCodeboxFuzzRunResult({ status: 'passed' }).schema, WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA);
 	return runWpCodeboxFuzzRun({ taskId: 'run-compat-alias', runFuzzRun: async () => ({ status: 'passed' }) });


### PR DESCRIPTION
## Summary
- Convert Homeboy fuzz workload JSON manifests into non-empty WP Codebox fuzz-suite cases.
- Preserve setup/action/assertion metadata and artifact declarations when building Codebox inputs.
- Enforce required artifact/coverage contracts in HBX result normalization.

## Verification
- `npm run test:wp-codebox-fuzz-suite`
- `npm run test:wordpress-fuzz-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing fuzz manifest projection, contract enforcement, and smoke coverage.