### PR TITLE
Mount fuzz workload runtime plugins

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -58,11 +58,13 @@ function buildWordPressFuzzRunnerContext(options = {}) {
 	const plan = normalizeRunnerPlan(workload.plan || workload.fuzz_plan || workload.fuzzPlan || workload);
 	const instructions = fuzzSuiteInstructions({ workload, workloadId, runId });
 	const wpCodeboxInput = buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDuration, instructions });
+	const runtimeRequirements = wpCodeboxRuntimeRequirementsFromWorkload(workload);
 	const taskRequest = wpCodeboxFuzzSuiteTaskRequest({
 		taskId: runId,
 		input: wpCodeboxInput,
 		provider: workload.provider,
 		runtimeId: workload.runtime_id || workload.runtimeId || 'wp-codebox',
+		runtimeRequirements,
 		instructions,
 	});
 	const codeboxPlanRecipe = buildCodeboxPlanRecipe(workload);
@@ -76,6 +78,7 @@ function buildWordPressFuzzRunnerContext(options = {}) {
 		maxDuration,
 		plan,
 		wpCodeboxInput,
+		runtimeRequirements,
 		taskRequest,
 		codeboxPlanRecipe,
 	};
@@ -89,6 +92,7 @@ function buildWordPressFuzzRunnerSummary({
 	maxDuration,
 	plan,
 	wpCodeboxInput,
+	runtimeRequirements,
 	taskRequest,
 	codeboxPlanRecipe,
 	codeboxResult,
@@ -107,6 +111,7 @@ function buildWordPressFuzzRunnerSummary({
 		max_duration_seconds: maxDuration,
 		plan_id: plan.id,
 		wp_codebox_input: wpCodeboxInput,
+		wp_codebox_runtime_requirements: runtimeRequirements,
 		wp_codebox_task_request: taskRequest,
 		wp_codebox_plan_recipe: codeboxPlanRecipe,
 		wp_codebox_result: codeboxResult,
@@ -132,6 +137,7 @@ async function resolveCodeboxResult(context, options = {}) {
 		input: context.wpCodeboxInput,
 		provider: context.workload.provider,
 		runtimeId: context.workload.runtime_id || context.workload.runtimeId || 'wp-codebox',
+		runtimeRequirements: context.runtimeRequirements,
 		instructions: context.taskRequest.instructions,
 		runFuzzSuite: runner,
 	});
@@ -196,6 +202,58 @@ function buildCodeboxPlanRecipe(workload) {
 		return undefined;
 	}
 	return buildWpCodeboxFuzzPlanRecipe(plan);
+}
+
+function wpCodeboxRuntimeRequirementsFromWorkload(workload = {}) {
+	const context = objectOrUndefined(workload.metadata?.homeboy_runtime_context || workload.metadata?.homeboyRuntimeContext);
+	const components = objectOrUndefined(context?.components);
+	if (!components) {
+		return undefined;
+	}
+	const componentId = workload.target?.component
+		|| workload.metadata?.fixture?.component
+		|| workload.metadata?.fixture?.plugin
+		|| workload.target?.slug;
+	const component = componentId ? objectOrUndefined(components[componentId]) : undefined;
+	const source = component?.path || component?.source;
+	if (!componentId || typeof source !== 'string' || source.trim() === '') {
+		return undefined;
+	}
+	const activation = workload.metadata?.fixture?.activation || firstCasePluginActivation(workload);
+	return {
+		extra_plugins: [stripUndefined({
+			slug: workload.target?.slug || componentId,
+			source,
+			path: source,
+			pluginFile: activation,
+			loadAs: 'plugin',
+			activate: Boolean(activation),
+			metadata: stripUndefined({
+				component: componentId,
+				rig_id: context.rig_id,
+			}),
+		})],
+		component_contracts: [stripUndefined({
+			slug: workload.target?.slug || componentId,
+			path: source,
+			pluginFile: activation,
+			loadAs: 'plugin',
+		})],
+		metadata: stripUndefined({
+			homeboy_runtime_context_schema: context.schema,
+			rig_id: context.rig_id,
+		}),
+	};
+}
+
+function firstCasePluginActivation(workload = {}) {
+	for (const entry of normalizeArray(workload.cases)) {
+		const activation = entry?.intent?.plugin?.activation;
+		if (typeof activation === 'string' && activation.trim() !== '') {
+			return activation;
+		}
+	}
+	return undefined;
 }
 
 function normalizeCodeboxResult(workload, context = {}) {

--- a/wordpress/lib/wordpress-runtime-task-planner.js
+++ b/wordpress/lib/wordpress-runtime-task-planner.js
@@ -157,6 +157,7 @@ function wordpressRuntimeTaskExecutorConfig(options = {}) {
 		homeboy_extensions: options.homeboyExtensions || options.homeboy_extensions,
 		runtime_component_paths: options.runtimeComponentPaths || options.runtime_component_paths,
 		component_contracts: options.componentContracts || options.component_contracts,
+		runtime_requirements: options.runtimeRequirements || options.runtime_requirements,
 		ability_tools: options.abilityTools || options.ability_tools,
 		structured_artifacts: options.structuredArtifacts || options.structured_artifacts,
 		runtime_env: options.runtimeEnv || options.runtime_env,

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -56,14 +56,8 @@ async function runWpCodeboxAgentTask(request) {
 	const publicInvocation = wpCodeboxPublicRuntimeInvocation(request, { runtimeContractManifest: manifest });
 
 	if (publicInvocation) {
-		try {
-			const publicResult = await runWpCodeboxPublicRuntimeCommand(command, publicInvocation, tempDir, { env });
-			return { json: normalizeWpCodeboxAgentTaskOutput(publicResult, request) };
-		} catch (error) {
-			if (!shouldFallbackToRunAgentTask(error)) {
-				throw error;
-			}
-		}
+		const publicResult = await runWpCodeboxPublicRuntimeCommand(command, publicInvocation, tempDir, { env });
+		return { json: normalizeWpCodeboxAgentTaskOutput(publicResult, request) };
 	}
 
 	const inputFile = path.join(tempDir, 'agent-task-request.json');
@@ -94,6 +88,9 @@ async function discoverRuntimeContractManifest(env = process.env) {
 }
 
 function wpCodeboxPublicRuntimeInvocation(request, options = {}) {
+	if (requiresCodeboxTaskAdapter(request)) {
+		return null;
+	}
 	const runtimeTask = request.executor?.config?.runtime_task || {};
 	const ability = runtimeTask.ability || wpCodeboxFuzzSuiteAbility(options);
 	const command = wpCodeboxCommandFromPublicAbility(ability, options);
@@ -111,6 +108,23 @@ function wpCodeboxPublicRuntimeInvocation(request, options = {}) {
 			},
 		},
 	};
+}
+
+function requiresCodeboxTaskAdapter(request) {
+	const config = request.executor?.config || {};
+	const runtimeRequirements = config.runtime_requirements || config.runtimeRequirements || {};
+	return [
+		config.component_contracts,
+		config.componentContracts,
+		config.runtime_overlays,
+		config.runtimeOverlays,
+		runtimeRequirements.extra_plugins,
+		runtimeRequirements.extraPlugins,
+		runtimeRequirements.component_contracts,
+		runtimeRequirements.componentContracts,
+		runtimeRequirements.plugins,
+		runtimeRequirements.components,
+	].some((value) => Array.isArray(value) && value.length > 0);
 }
 
 function wpCodeboxCommandFromPublicAbility(ability, options = {}) {
@@ -134,12 +148,6 @@ async function runWpCodeboxPublicRuntimeCommand(command, invocation, tempDir, op
 		cwd: process.cwd(),
 		env: options.env || process.env,
 	});
-}
-
-function shouldFallbackToRunAgentTask(error) {
-	const message = String(error?.message || '').toLowerCase();
-	return error?.code === 'ENOENT'
-		|| /unknown command|invalid command|not found|no such command|unrecognized command|unknown subcommand|unsupported command/.test(message);
 }
 
 function wpCodeboxRunAgentTaskInvocation(request) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -129,7 +129,17 @@ const jsonWorkloadResult = buildWordPressFuzzRunnerResult({
 		schema: 'homeboy/fuzz-workload/v1',
 		id: 'json-workload',
 		label: 'JSON workload smoke',
-		target: { type: 'wordpress-plugin', slug: 'sample-plugin' },
+		target: { type: 'wordpress-plugin', slug: 'sample-plugin', component: 'sample-plugin' },
+		metadata: {
+			fixture: { component: 'sample-plugin', activation: 'sample-plugin/sample-plugin.php' },
+			homeboy_runtime_context: {
+				schema: 'homeboy/fuzz-workload-runtime-context/v1',
+				rig_id: 'sample-rig',
+				components: {
+					'sample-plugin': { path: '/runner/components/sample-plugin', branch: 'main' },
+				},
+			},
+		},
 		workload: {
 			runner: 'wp-codebox',
 			type: 'json',
@@ -160,6 +170,19 @@ assert.deepEqual(jsonWorkloadResult.wp_codebox_input.cases[0].phases.action, [{ 
 assert.deepEqual(jsonWorkloadResult.wp_codebox_input.cases[0].phases.assert, [{ command: 'wordpress.collect-workload-result', args: ['artifact=json_fuzz_result'] }]);
 assert.equal(jsonWorkloadResult.wp_codebox_input.cases[0].artifacts[0].required, true);
 assert.equal(jsonWorkloadResult.wp_codebox_input.metadata.artifacts.expected[0].semantic_key, 'fuzz.suite_result');
+assert.deepEqual(jsonWorkloadResult.wp_codebox_runtime_requirements.extra_plugins, [{
+	slug: 'sample-plugin',
+	source: '/runner/components/sample-plugin',
+	path: '/runner/components/sample-plugin',
+	pluginFile: 'sample-plugin/sample-plugin.php',
+	loadAs: 'plugin',
+	activate: true,
+	metadata: { component: 'sample-plugin', rig_id: 'sample-rig' },
+}]);
+assert.equal(
+	jsonWorkloadResult.wp_codebox_task_request.executor.config.runtime_requirements.extra_plugins[0].source,
+	'/runner/components/sample-plugin'
+);
 
 let dispatchedRequest;
 const dispatchPromise = runWordPressFuzzRunnerResult({
@@ -205,10 +228,35 @@ const dispatchPromise = runWordPressFuzzRunnerResult({
 
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wordpress-fuzz-runner-'));
 const workloadPath = path.join(tempDir, 'workload.json');
+const runtimeRequirementWorkloadPath = path.join(tempDir, 'runtime-requirement-workload.json');
 const resultsPath = path.join(tempDir, 'fuzz-results.json');
 const runnerPath = path.join(__dirname, '..', 'scripts', 'fuzz', 'fuzz-runner.cjs');
 const { discoverWpCodeboxBin, wpCodeboxCommand, wpCodeboxRuntimeEnv } = require(runnerPath);
 fs.writeFileSync(workloadPath, `${JSON.stringify(workload)}\n`);
+fs.writeFileSync(runtimeRequirementWorkloadPath, `${JSON.stringify({
+	schema: 'homeboy/fuzz-workload/v1',
+	id: 'runtime-requirement-workload',
+	label: 'Runtime requirement workload',
+	target: { type: 'wordpress-plugin', slug: 'sample-plugin', component: 'sample-plugin' },
+	metadata: {
+		fixture: { component: 'sample-plugin', activation: 'sample-plugin/sample-plugin.php' },
+		homeboy_runtime_context: {
+			schema: 'homeboy/fuzz-workload-runtime-context/v1',
+			rig_id: 'sample-rig',
+			components: {
+				'sample-plugin': { path: '/runner/components/sample-plugin' },
+			},
+		},
+	},
+	cases: [{
+		case_id: 'runtime-requirement-workload:default',
+		intent: {
+			type: 'wordpress-plugin-workload',
+			plugin: { activation: 'sample-plugin/sample-plugin.php' },
+			execute: { path: '/runner/workloads/sample.php', type: 'php' },
+		},
+	}],
+})}\n`);
 
 assert.equal(fs.statSync(runnerPath).mode & 0o111, 0o111, 'fuzz runner script must be executable');
 assert.equal(
@@ -319,29 +367,29 @@ assert.equal(dispatchCliResult.succeeded, true);
 assert.equal(dispatchCliResult.wp_codebox_result.request_id, 'dispatch-cli-run');
 assert.equal(dispatchCliResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path, 'fake/fuzz-report.json');
 
-const legacyCodeboxBin = path.join(tempDir, 'packages/cli/dist/fake-legacy-wp-codebox.js');
-fs.writeFileSync(legacyCodeboxBin, `#!/usr/bin/env node
+const taskAdapterCodeboxBin = path.join(tempDir, 'packages/cli/dist/fake-task-adapter-wp-codebox.js');
+fs.writeFileSync(taskAdapterCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
 const command = process.argv[2];
 if (command === 'run-fuzz-suite') {
-  process.stderr.write('unknown command: run-fuzz-suite');
+  process.stderr.write('runtime requirements must use the task adapter');
   process.exit(1);
 }
 const inputFile = process.argv[process.argv.indexOf('--input-file') + 1];
 const request = JSON.parse(fs.readFileSync(inputFile, 'utf8'));
-if (command !== 'run-agent-task' || request.schema !== '${runtimeContractSchemas().agentTask.runRequest}' || request.task_id !== 'legacy-dispatch-cli-run') {
-  process.stderr.write('invalid run-agent-task fallback input');
+if (command !== 'run-agent-task' || request.schema !== '${runtimeContractSchemas().agentTask.runRequest}' || request.task_id !== 'task-adapter-dispatch-cli-run') {
+  process.stderr.write('invalid run-agent-task adapter input');
   process.exit(1);
 }
 if (request.runtime_task || request.artifact_declarations || request.sandbox_tool_policy || request.extra_plugins) {
-  process.stderr.write('fallback rebuilt the Codebox task payload instead of delegating to the adapter');
+  process.stderr.write('adapter rebuilt the Codebox task payload instead of delegating to the adapter');
   process.exit(1);
 }
 if (request.task_input?.schema !== 'wp-codebox/task-input/v1') {
   process.stderr.write('missing delegated task input');
   process.exit(1);
 }
-if (request.task_input?.goal !== 'Run WordPress fuzz suite legacy-dispatch-cli-workload and return the declared fuzz artifacts.') {
+if (request.task_input?.goal !== 'Run WordPress fuzz suite Runtime requirement workload and return the declared fuzz artifacts.') {
   process.stderr.write('missing delegated task goal');
   process.exit(1);
 }
@@ -353,7 +401,11 @@ if (request.task_input?.artifact_declarations?.[0]?.name !== 'wp-codebox-fuzz-su
   process.stderr.write('missing delegated artifact contract');
   process.exit(1);
 }
-if (request.task_input?.parent_request?.task_id !== 'legacy-dispatch-cli-run') {
+if (request.task_input?.runtime_requirements?.extra_plugins?.[0]?.source !== '/runner/components/sample-plugin') {
+  process.stderr.write('missing delegated runtime extra plugin');
+  process.exit(1);
+}
+if (request.task_input?.parent_request?.task_id !== 'task-adapter-dispatch-cli-run') {
   process.stderr.write('missing parent request metadata');
   process.exit(1);
 }
@@ -367,31 +419,31 @@ process.stdout.write(JSON.stringify({
       status: 'succeeded',
       summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
       cases: [{ id: 'get-posts', status: 'passed', success: true, diagnostics: [] }],
-      artifactRefs: [{ path: 'legacy/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
+      artifactRefs: [{ path: 'task-adapter/fuzz-report.json', kind: 'report', contentType: 'application/json' }],
       coverage_summary: { surface_count: 1, exercised_count: 1 }
     }
   }
 }));
 `);
-fs.chmodSync(legacyCodeboxBin, 0o755);
+fs.chmodSync(taskAdapterCodeboxBin, 0o755);
 
-const legacyDispatchCli = spawnSync(runnerPath, [], {
+const taskAdapterDispatchCli = spawnSync(runnerPath, [], {
 	encoding: 'utf8',
 	env: {
 		...process.env,
-		HOMEBOY_WP_CODEBOX_BIN: legacyCodeboxBin,
+		HOMEBOY_WP_CODEBOX_BIN: taskAdapterCodeboxBin,
 		HOMEBOY_WP_CODEBOX_INSTALL_DIR: emptyCodeboxInstallRoot,
 		HOMEBOY_WP_CODEBOX_PLUGIN_PATH: path.join(tempDir, 'packages/wordpress-plugin'),
-		HOMEBOY_FUZZ_WORKLOAD_PATH: workloadPath,
-		HOMEBOY_FUZZ_WORKLOAD_ID: 'legacy-dispatch-cli-workload',
-		HOMEBOY_FUZZ_RUN_ID: 'legacy-dispatch-cli-run',
+		HOMEBOY_FUZZ_WORKLOAD_PATH: runtimeRequirementWorkloadPath,
+		HOMEBOY_FUZZ_WORKLOAD_ID: 'task-adapter-dispatch-cli-workload',
+		HOMEBOY_FUZZ_RUN_ID: 'task-adapter-dispatch-cli-run',
 	},
 });
 
-assert.equal(legacyDispatchCli.status, 0, legacyDispatchCli.stderr);
-const legacyDispatchCliResult = JSON.parse(legacyDispatchCli.stdout);
-assert.equal(legacyDispatchCliResult.succeeded, true);
-assert.equal(legacyDispatchCliResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path, 'legacy/fuzz-report.json');
+assert.equal(taskAdapterDispatchCli.status, 0, taskAdapterDispatchCli.stderr);
+const taskAdapterDispatchCliResult = JSON.parse(taskAdapterDispatchCli.stdout);
+assert.equal(taskAdapterDispatchCliResult.succeeded, true);
+assert.equal(taskAdapterDispatchCliResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path, 'task-adapter/fuzz-report.json');
 
 dispatchPromise.then(() => {
 	console.log('WordPress fuzz runner smoke passed.');


### PR DESCRIPTION
## Summary
- derive WP Codebox runtime plugin requirements from Homeboy fuzz workload runtime context
- forward runtime requirements through the WordPress runtime task planner
- use the full WP Codebox task adapter when runtime mounts/plugins are required instead of compatibility fallback behavior

## Verification
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wp-codebox-fuzz-suite`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the missing sandbox plugin mount and drafting the runtime context plumbing and tests.