### PR TITLE
Add generic gate plan evaluator

### DIFF
--- a/runtime-agent-ci/index.js
+++ b/runtime-agent-ci/index.js
@@ -12,3 +12,4 @@ Object.assign(module.exports, require('./lib/controller-loop-proof-validator'));
 Object.assign(module.exports, require('./lib/bounded-production-loop-runner'));
 Object.assign(module.exports, require('./lib/workspace-publication-lifecycle.cjs'));
 Object.assign(module.exports, require('./lib/agent-task-outcome-normalizer'));
+Object.assign(module.exports, require('./lib/gate-plan-evaluator'));

--- a/runtime-agent-ci/lib/controller-loop-proof-validator.js
+++ b/runtime-agent-ci/lib/controller-loop-proof-validator.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { evaluateGatePlan } = require('./gate-plan-evaluator');
+
 function validateControllerLoopProof(input = {}) {
   const spec = optionalObject(input.spec || input.controller || input.loop_spec);
   const proof = optionalObject(input.proof || input.run || input.result);
@@ -18,9 +20,11 @@ function validateControllerLoopProof(input = {}) {
 
   const status = proof.status || proof.result?.status || proof.outcome?.status || '';
   const allowedStatuses = normalizeArray(policy.allowed_statuses || spec.allowed_statuses || spec.statuses);
-  if (allowedStatuses.length > 0 && !allowedStatuses.includes(status)) {
-    failures.push(failure('proof.status_rejected', `Proof status is not allowed: ${status || '(missing)'}`, { status, allowed_statuses: allowedStatuses }));
-  }
+  appendGateFailures(failures, evaluateGatePlan({
+    id: 'proof_status_allowed',
+    enabled: allowedStatuses.length > 0,
+    pass_when: [{ field: 'status', op: 'in', values: allowedStatuses, failure_class: 'proof.status_rejected', message: `Proof status is not allowed: ${status || '(missing)'}` }],
+  }, { status }), { status, allowed_statuses: allowedStatuses });
 
   for (const declaration of artifactDeclarations) {
     const match = findArtifact(artifacts, declaration.id);
@@ -101,17 +105,24 @@ function validateControllerLoopProof(input = {}) {
 
   const iterationCount = explicitIterationCount(proof, iterations);
   const maxIterations = positiveInteger(policy.max_iterations || spec.max_iterations || spec.loop?.max_iterations);
-  if (maxIterations && iterationCount > maxIterations) {
-    failures.push(failure('loop.max_iterations_exceeded', `Iteration count ${iterationCount} exceeds maximum ${maxIterations}.`, { iteration_count: iterationCount, max_iterations: maxIterations }));
-  }
+  appendGateFailures(failures, evaluateGatePlan({
+    id: 'loop_max_iterations',
+    enabled: Boolean(maxIterations),
+    pass_when: [{ field: 'iteration_count', op: 'lte', value: maxIterations, failure_class: 'loop.max_iterations_exceeded', message: `Iteration count ${iterationCount} exceeds maximum ${maxIterations}.` }],
+  }, { iteration_count: iterationCount }), { iteration_count: iterationCount, max_iterations: maxIterations });
 
   const stopReason = stopReasonFromProof(proof, iterations);
   const allowedStopReasons = normalizeArray(policy.allowed_stop_reasons || spec.allowed_stop_reasons || spec.stop_reasons);
-  if ((policy.stop_reason_required === true || allowedStopReasons.length > 0) && !stopReason) {
-    failures.push(failure('loop.stop_reason_missing', 'Stop reason evidence is required.', {}));
-  } else if (stopReason && allowedStopReasons.length > 0 && !allowedStopReasons.includes(stopReason)) {
-    failures.push(failure('loop.stop_reason_rejected', `Stop reason is not allowed: ${stopReason}`, { stop_reason: stopReason, allowed_stop_reasons: allowedStopReasons }));
-  }
+  appendGateFailures(failures, evaluateGatePlan({
+    id: 'loop_stop_reason_required',
+    enabled: policy.stop_reason_required === true || allowedStopReasons.length > 0,
+    pass_when: [{ field: 'stop_reason', op: 'present', failure_class: 'loop.stop_reason_missing', message: 'Stop reason evidence is required.' }],
+  }, { stop_reason: stopReason }), {});
+  appendGateFailures(failures, evaluateGatePlan({
+    id: 'loop_stop_reason_allowed',
+    enabled: Boolean(stopReason) && allowedStopReasons.length > 0,
+    pass_when: [{ field: 'stop_reason', op: 'in', values: allowedStopReasons, failure_class: 'loop.stop_reason_rejected', message: `Stop reason is not allowed: ${stopReason}` }],
+  }, { stop_reason: stopReason }), { stop_reason: stopReason, allowed_stop_reasons: allowedStopReasons });
 
   if (policy.event_lineage_required === true || policy.require_event_lineage === true || spec.event_lineage_required === true) {
     validateEventLineage({ proof, iterations, events, failures, warnings });
@@ -133,6 +144,15 @@ function validateControllerLoopProof(input = {}) {
     },
     artifact_results: artifactResults,
   };
+}
+
+function appendGateFailures(failures, gateResult, data = {}) {
+  if (gateResult.success) {
+    return;
+  }
+  for (const item of gateResult.failures) {
+    failures.push(failure(item.class, item.message, { ...item.data, ...data }));
+  }
 }
 
 function assertControllerLoopProof(input = {}) {

--- a/runtime-agent-ci/lib/gate-plan-evaluator.js
+++ b/runtime-agent-ci/lib/gate-plan-evaluator.js
@@ -1,0 +1,166 @@
+'use strict';
+
+const GATE_PLAN_SCHEMA = 'homeboy/gate-plan/v1';
+const GATE_RESULT_SCHEMA = 'homeboy/gate-result/v1';
+
+function buildGatePlan(plan = {}) {
+  return {
+    schema: GATE_PLAN_SCHEMA,
+    id: plan.id || plan.name || 'gate',
+    label: plan.label || plan.description || plan.id || plan.name || 'Gate',
+    enabled: plan.enabled !== false,
+    mode: plan.mode || 'fail',
+    pass_when: normalizeArray(plan.pass_when || plan.passWhen),
+    fail_when: normalizeArray(plan.fail_when || plan.failWhen),
+    stop_when: normalizeArray(plan.stop_when || plan.stopWhen),
+    continue_when: normalizeArray(plan.continue_when || plan.continueWhen),
+    data: isPlainObject(plan.data) ? plan.data : {},
+  };
+}
+
+function evaluateGatePlan(planInput = {}, context = {}) {
+  const plan = buildGatePlan(planInput);
+  if (!plan.enabled) {
+    return gateResult(plan, { status: 'skipped', action: 'continue', success: true, reason: 'gate_disabled' });
+  }
+
+  const failed = [
+    ...plan.fail_when.filter((condition) => conditionMatches(condition, context)),
+    ...plan.pass_when.filter((condition) => !conditionMatches(condition, context)),
+  ];
+  if (failed.length > 0) {
+    const failure = failed[0];
+    return gateResult(plan, {
+      status: 'failed',
+      action: 'fail',
+      success: false,
+      reason: conditionReason(failure, 'gate_failed'),
+      failures: failed.map((condition) => gateFailure(condition, context)),
+    });
+  }
+
+  const stop = plan.stop_when.find((condition) => conditionMatches(condition, context));
+  if (stop) {
+    return gateResult(plan, { status: 'stopped', action: 'stop', success: true, reason: conditionReason(stop, 'stop_criteria_satisfied') });
+  }
+
+  if (plan.continue_when.length > 0) {
+    const declined = plan.continue_when.find((condition) => !conditionMatches(condition, context));
+    if (declined) {
+      return gateResult(plan, { status: 'stopped', action: 'stop', success: true, reason: conditionReason(declined, 'continuation_declined') });
+    }
+  }
+
+  return gateResult(plan, { status: 'passed', action: 'continue', success: true, reason: 'gate_passed' });
+}
+
+function evaluateGateResults(results = {}) {
+  const gateResults = Array.isArray(results) ? results : Object.values(results).filter(Boolean);
+  const enabled = gateResults.filter((result) => result.enabled !== false && result.status !== 'skipped');
+  const failure = enabled.find((result) => result.success === false || result.action === 'fail');
+  const stop = enabled.find((result) => result.action === 'stop');
+  return {
+    schema: 'homeboy/gate-result-summary/v1',
+    success: !failure,
+    action: failure ? 'fail' : stop ? 'stop' : 'continue',
+    reason: (failure || stop)?.reason || 'gate_passed',
+    error: failure?.message || failure?.reason || '',
+    gate_count: gateResults.length,
+    enabled_gate_count: enabled.length,
+    results: gateResults,
+  };
+}
+
+function gateResult(plan, result = {}) {
+  const failures = normalizeArray(result.failures);
+  return {
+    schema: GATE_RESULT_SCHEMA,
+    gate_plan_schema: GATE_PLAN_SCHEMA,
+    id: plan.id,
+    label: plan.label,
+    enabled: plan.enabled !== false,
+    status: result.status || 'passed',
+    action: result.action || 'continue',
+    success: result.success !== false,
+    reason: result.reason || '',
+    message: result.message || result.error || failures[0]?.message || '',
+    failures,
+    data: { ...plan.data, ...(isPlainObject(result.data) ? result.data : {}) },
+  };
+}
+
+function gateFailure(condition, context = {}) {
+  return {
+    class: condition.class || condition.failure_class || 'gate.condition_failed',
+    message: condition.message || `Gate condition failed: ${condition.field || condition.path || '(context)'}`,
+    data: {
+      field: condition.field || condition.path || '',
+      op: condition.op || 'truthy',
+      expected: condition.value !== undefined ? condition.value : condition.values,
+      actual: getPath(context, condition.field || condition.path || ''),
+    },
+  };
+}
+
+function conditionMatches(conditionInput = {}, context = {}) {
+  const condition = isPlainObject(conditionInput) ? conditionInput : { value: conditionInput, op: 'truthy' };
+  const actual = condition.field || condition.path ? getPath(context, condition.field || condition.path) : context;
+  const op = condition.op || (Object.prototype.hasOwnProperty.call(condition, 'values') ? 'in' : Object.prototype.hasOwnProperty.call(condition, 'value') ? 'equals' : 'truthy');
+  switch (op) {
+    case 'equals':
+      return actual === condition.value;
+    case 'not_equals':
+      return actual !== condition.value;
+    case 'in':
+      return normalizeArray(condition.values).includes(actual);
+    case 'not_in':
+      return !normalizeArray(condition.values).includes(actual);
+    case 'truthy':
+      return Boolean(actual);
+    case 'falsy':
+      return !actual;
+    case 'present':
+      return actual !== undefined && actual !== null && actual !== '';
+    case 'missing':
+      return actual === undefined || actual === null || actual === '';
+    case 'lte':
+      return Number(actual) <= Number(condition.value);
+    case 'gte':
+      return Number(actual) >= Number(condition.value);
+    default:
+      throw new Error(`Unsupported gate condition op: ${op}`);
+  }
+}
+
+function conditionReason(condition = {}, fallback) {
+  return condition.reason || condition.class || condition.failure_class || fallback;
+}
+
+function getPath(value, path) {
+  if (!path) {
+    return value;
+  }
+  return String(path).split('.').filter(Boolean).reduce((current, segment) => {
+    if (!current || typeof current !== 'object') {
+      return undefined;
+    }
+    return current[segment];
+  }, value);
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function isPlainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+module.exports = {
+  GATE_PLAN_SCHEMA,
+  GATE_RESULT_SCHEMA,
+  buildGatePlan,
+  evaluateGatePlan,
+  evaluateGateResults,
+  gateResult,
+};

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -7,6 +7,7 @@ const { runDeterministicLoop } = require('./deterministic-loop-runner');
 const { runBoundedProductionLoop } = require('./bounded-production-loop-runner');
 const { validateControllerLoopProof } = require('./controller-loop-proof-validator');
 const { runtimeAgentCiTaskExecutorConfig } = require('./runtime-agent-ci-plan');
+const { evaluateGatePlan } = require('./gate-plan-evaluator');
 
 function buildGenericAgentLoopRequest(options = {}) {
   const plan = requiredObject(options.plan, 'plan');
@@ -188,35 +189,15 @@ function runGenericDeterministicLoop(options = {}) {
         evidence,
       };
     },
-    stopCriteria: (context) => {
-      const stop = stopPolicy({
-        ...context,
-        task: context.input,
-        result: results[results.length - 1],
-        tasks,
-        results,
-        evidence,
-        max_iterations: maxIterations,
-        maxIterations,
-      });
-      if (isPlainObject(stop) ? stop.stop : Boolean(stop)) {
-        return stop;
-      }
-      const continueDecision = shouldContinue({
-        ...context,
-        task: context.input,
-        result: results[results.length - 1],
-        tasks,
-        results,
-        evidence,
-        max_iterations: maxIterations,
-        maxIterations,
-      });
-      if (continueDecision === false || (isPlainObject(continueDecision) && continueDecision.continue === false)) {
-        return { stop: true, reason: isPlainObject(continueDecision) ? continueDecision.reason || 'continuation_declined' : 'continuation_declined' };
-      }
-      return { stop: false };
-    },
+    stopCriteria: (context) => evaluateGenericLoopGateDecision({
+      context,
+      stopPolicy,
+      shouldContinue,
+      tasks,
+      results,
+      evidence,
+      maxIterations,
+    }),
   });
   const finalOutcome = results[results.length - 1] || null;
   return {
@@ -237,6 +218,37 @@ function runGenericDeterministicLoop(options = {}) {
       evidence,
     },
   };
+}
+
+function evaluateGenericLoopGateDecision(options = {}) {
+  const gateContext = {
+    ...options.context,
+    task: options.context.input,
+    result: options.results[options.results.length - 1],
+    tasks: options.tasks,
+    results: options.results,
+    evidence: options.evidence,
+    max_iterations: options.maxIterations,
+    maxIterations: options.maxIterations,
+  };
+  const stop = options.stopPolicy(gateContext);
+  const stopGate = evaluateGatePlan({
+    id: 'generic_loop_stop_policy',
+    stop_when: [{ field: 'stop_requested', op: 'truthy', reason: isPlainObject(stop) ? stop.reason || 'stop_criteria_satisfied' : 'stop_criteria_satisfied' }],
+  }, { stop_requested: isPlainObject(stop) ? stop.stop : Boolean(stop) });
+  if (stopGate.action === 'stop') {
+    return { stop: true, reason: stopGate.reason, data: { gate_result: stopGate } };
+  }
+
+  const continueDecision = options.shouldContinue(gateContext);
+  const continueGate = evaluateGatePlan({
+    id: 'generic_loop_continue_policy',
+    continue_when: [{ field: 'continue_requested', op: 'truthy', reason: isPlainObject(continueDecision) ? continueDecision.reason || 'continuation_declined' : 'continuation_declined' }],
+  }, { continue_requested: !(continueDecision === false || (isPlainObject(continueDecision) && continueDecision.continue === false)) });
+  if (continueGate.action === 'stop') {
+    return { stop: true, reason: continueGate.reason, data: { gate_result: continueGate } };
+  }
+  return { stop: false, data: { gate_result: continueGate } };
 }
 
 function executeRuntimeProvider(options = {}) {

--- a/runtime-agent-ci/lib/workspace-publication-lifecycle.cjs
+++ b/runtime-agent-ci/lib/workspace-publication-lifecycle.cjs
@@ -8,6 +8,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { evaluateGatePlan, evaluateGateResults } = require('./gate-plan-evaluator');
 
 function plainObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value);
@@ -93,21 +94,34 @@ function runCommandChecks(config, workspace, key, hooks = {}) {
     const check = runShellCommand(commandConfig, workspace, key, hooks);
     checks.push(check);
     if (!check.success) {
-      return {
+      const failed = {
         enabled: true,
         success: false,
         workspace,
         checks,
         error: check.error || `${key} failed: ${commandConfig.command}`,
       };
+      return withLifecycleGateResult(key, failed);
     }
   }
 
-  return { enabled: true, success: true, workspace, checks };
+  return withLifecycleGateResult(key, { enabled: true, success: true, workspace, checks });
 }
 
 function hasCommandChecks(config, key) {
   return commandList(config, key).length > 0;
+}
+
+function withLifecycleGateResult(id, result) {
+  const enabled = result.enabled !== false;
+  return {
+    ...result,
+    gate_result: evaluateGatePlan({
+      id,
+      enabled,
+      pass_when: [{ field: 'success', op: 'truthy', reason: id, message: result.error || `${id} failed` }],
+    }, { success: !enabled || result.success !== false }),
+  };
 }
 
 function git(workspace, args, options = {}) {
@@ -188,7 +202,7 @@ function globPatternToRegExp(pattern) {
 function validateWritablePaths(config, files) {
   const patterns = writablePathPatterns(config);
   if (patterns.length === 0) {
-    return { enabled: false, patterns: [], rejected_files: [] };
+    return withLifecycleGateResult('writable_paths', { enabled: false, patterns: [], rejected_files: [] });
   }
 
   const matchers = patterns.map(globPatternToRegExp);
@@ -196,13 +210,13 @@ function validateWritablePaths(config, files) {
     .map((file) => normalizePathPattern(file))
     .filter((file) => file && !matchers.some((matcher) => matcher.test(file)));
   const success = rejected.length === 0;
-  return {
+  return withLifecycleGateResult('writable_paths', {
     enabled: true,
     success,
     patterns,
     rejected_files: rejected,
     error: success ? '' : `Changed files outside writable_paths: ${rejected.join(', ')}`,
-  };
+  });
 }
 
 function declaredSideEffectPatterns(config) {
@@ -223,14 +237,14 @@ function evaluateSideEffectPolicy(config, files) {
   const patterns = declaredSideEffectPatterns(config);
   const normalizedFiles = files.map(normalizePathPattern).filter(Boolean);
   if (normalizedFiles.length === 0) {
-    return { enabled: patterns.length > 0, success: true, patterns, files: [], accepted_files: [], rejected_files: [] };
+    return withLifecycleGateResult('side_effect_policy', { enabled: patterns.length > 0, success: true, patterns, files: [], accepted_files: [], rejected_files: [] });
   }
 
   const matchers = patterns.map(globPatternToRegExp);
   const accepted = normalizedFiles.filter((file) => matchers.some((matcher) => matcher.test(file)));
   const rejected = normalizedFiles.filter((file) => !accepted.includes(file));
   const success = rejected.length === 0;
-  return {
+  return withLifecycleGateResult('side_effect_policy', {
     enabled: true,
     success,
     patterns,
@@ -238,7 +252,7 @@ function evaluateSideEffectPolicy(config, files) {
     accepted_files: accepted,
     rejected_files: rejected,
     error: success ? '' : `Verification side-effect files outside declared policy: ${rejected.join(', ')}`,
-  };
+  });
 }
 
 function calculatePublishSet(agentFiles, sideEffectPolicy) {
@@ -465,7 +479,7 @@ function evaluateWorkspaceContract(config, workspace) {
   const entryChecks = contractEntryPointEntries(contract);
   const forbiddenPhraseChecks = contractForbiddenPhraseEntries(contract);
   if (pathChecks.length === 0 && globChecks.length === 0 && entryChecks.length === 0 && forbiddenPhraseChecks.length === 0) {
-    return { enabled: false, success: true, paths_exist: [], glob_min_count: [], entry_points: [], forbidden_phrases: [] };
+    return withLifecycleGateResult('workspace_contract_checks', { enabled: false, success: true, paths_exist: [], glob_min_count: [], entry_points: [], forbidden_phrases: [] });
   }
 
   const pathsExist = pathChecks.map((entry) => {
@@ -497,7 +511,7 @@ function evaluateWorkspaceContract(config, workspace) {
     ...forbiddenPhrases.filter((entry) => !entry.success).map((entry) => `forbidden phrase ${JSON.stringify(entry.phrase)} found in ${entry.matching_files.join(', ')}`),
   ];
   const success = failures.length === 0;
-  return {
+  return withLifecycleGateResult('workspace_contract_checks', {
     enabled: true,
     success,
     paths_exist: pathsExist,
@@ -506,7 +520,7 @@ function evaluateWorkspaceContract(config, workspace) {
     forbidden_phrases: forbiddenPhrases,
     forbidden_phrase_files: forbiddenPhraseFiles,
     error: success ? '' : `workspace_contract_checks failed: ${failures.join('; ')}`,
-  };
+  });
 }
 
 function differenceFiles(files, baseline) {
@@ -845,7 +859,7 @@ function runDeterministicWorkspaceLifecycle(config, results, scenario, workspace
     git(workspace, ['add', '--', ...agentFiles], { hooks });
   }
   const drift = verification.enabled && !verification.success
-    ? { enabled: false, checks: [], skipped_reason: 'verification_commands_failed' }
+    ? withLifecycleGateResult('drift_checks', { enabled: false, success: true, checks: [], skipped_reason: 'verification_commands_failed' })
     : runCommandChecks(config, workspace, 'drift_checks', hooks);
   const workspaceFiles = changedFiles(workspace, config, hooks);
   const verificationSideEffectFiles = differenceFiles(workspaceFiles, agentFiles);
@@ -863,12 +877,15 @@ function runDeterministicWorkspaceLifecycle(config, results, scenario, workspace
     verification_side_effect_files: verificationSideEffectFiles,
   };
   let publication = { opened: false };
-  let success = (!verification.enabled || verification.success)
-    && (!drift.enabled || drift.success)
-    && (!sideEffectPolicy.enabled || sideEffectPolicy.success)
-    && (!writablePaths.enabled || writablePaths.success)
-    && (!workspaceContract.enabled || workspaceContract.success);
-  let error = '';
+  let gateSummary = evaluateGateResults([
+    verification.gate_result,
+    drift.gate_result,
+    sideEffectPolicy.gate_result,
+    writablePaths.gate_result,
+    workspaceContract.gate_result,
+  ]);
+  let success = gateSummary.success;
+  let error = gateSummary.error;
 
   if (!success) {
     if (verification.enabled && !verification.success) {
@@ -899,7 +916,15 @@ function runDeterministicWorkspaceLifecycle(config, results, scenario, workspace
     }
   }
 
-  return { verification, drift, sideEffectPolicy, writablePaths, workspaceContract, capture, publication, success, error };
+  gateSummary = evaluateGateResults([
+    verification.gate_result,
+    drift.gate_result,
+    sideEffectPolicy.gate_result,
+    writablePaths.gate_result,
+    workspaceContract.gate_result,
+  ]);
+
+  return { verification, drift, sideEffectPolicy, writablePaths, workspaceContract, gateSummary, capture, publication, success, error };
 }
 
 module.exports = {

--- a/runtime-agent-ci/package.json
+++ b/runtime-agent-ci/package.json
@@ -9,6 +9,7 @@
     "./agent-task-outcome-normalizer": "./lib/agent-task-outcome-normalizer.js",
     "./bounded-production-loop-runner": "./lib/bounded-production-loop-runner.js",
     "./fanout-reconcile-runner": "./lib/fanout-reconcile-runner.js",
+    "./gate-plan-evaluator": "./lib/gate-plan-evaluator.js",
     "./generic-fanout-reconcile-workflow": "./lib/generic-fanout-reconcile-workflow.js",
     "./workspace-publication-lifecycle": "./lib/workspace-publication-lifecycle.cjs"
   },
@@ -20,7 +21,8 @@
     "test:controller-loop-proof-validator": "node ../tests/controller-loop-proof-validator.test.mjs",
     "test:generic-fanout-reconcile-boundary": "node ../tests/generic-fanout-reconcile-boundary.test.mjs",
     "test:workspace-publication-lifecycle": "node tests/workspace-publication-lifecycle.test.js",
-    "test:agent-task-outcome-normalizer": "node tests/agent-task-outcome-normalizer.test.js"
+    "test:agent-task-outcome-normalizer": "node tests/agent-task-outcome-normalizer.test.js",
+    "test:gate-plan-evaluator": "node tests/gate-plan-evaluator.test.js"
   },
   "engines": {
     "node": ">=18.12.0"

--- a/runtime-agent-ci/tests/gate-plan-evaluator.test.js
+++ b/runtime-agent-ci/tests/gate-plan-evaluator.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const runtimeAgentCi = require('..');
+const {
+  GATE_PLAN_SCHEMA,
+  GATE_RESULT_SCHEMA,
+  buildGatePlan,
+  evaluateGatePlan,
+  evaluateGateResults,
+} = require('../lib/gate-plan-evaluator');
+
+assert.equal(runtimeAgentCi.GATE_PLAN_SCHEMA, GATE_PLAN_SCHEMA);
+assert.equal(runtimeAgentCi.GATE_RESULT_SCHEMA, GATE_RESULT_SCHEMA);
+assert.equal(runtimeAgentCi.evaluateGatePlan, evaluateGatePlan);
+
+const plan = buildGatePlan({ id: 'artifact_required', pass_when: [{ field: 'present', op: 'truthy' }] });
+assert.equal(plan.schema, 'homeboy/gate-plan/v1');
+assert.equal(plan.id, 'artifact_required');
+
+let result = evaluateGatePlan({
+  id: 'continue_when_clean',
+  continue_when: [{ field: 'dirty', op: 'falsy' }],
+}, { dirty: false });
+assert.equal(result.schema, 'homeboy/gate-result/v1');
+assert.equal(result.success, true);
+assert.equal(result.action, 'continue');
+assert.equal(result.status, 'passed');
+
+result = evaluateGatePlan({
+  id: 'stop_when_accepted',
+  stop_when: [{ field: 'accepted', op: 'truthy', reason: 'accepted' }],
+}, { accepted: true });
+assert.equal(result.success, true);
+assert.equal(result.action, 'stop');
+assert.equal(result.status, 'stopped');
+assert.equal(result.reason, 'accepted');
+
+result = evaluateGatePlan({
+  id: 'continue_declined',
+  continue_when: [{ field: 'should_continue', op: 'truthy', reason: 'continuation_declined' }],
+}, { should_continue: false });
+assert.equal(result.success, true);
+assert.equal(result.action, 'stop');
+assert.equal(result.reason, 'continuation_declined');
+
+result = evaluateGatePlan({
+  id: 'allowed_status',
+  pass_when: [{ field: 'status', op: 'in', values: ['succeeded'], failure_class: 'status.rejected', message: 'status rejected' }],
+}, { status: 'failed' });
+assert.equal(result.success, false);
+assert.equal(result.action, 'fail');
+assert.equal(result.status, 'failed');
+assert.equal(result.failures[0].class, 'status.rejected');
+assert.equal(result.message, 'status rejected');
+
+const summary = evaluateGateResults([
+  evaluateGatePlan({ id: 'first', pass_when: [{ field: 'ok', op: 'truthy' }] }, { ok: true }),
+  result,
+]);
+assert.equal(summary.schema, 'homeboy/gate-result-summary/v1');
+assert.equal(summary.success, false);
+assert.equal(summary.action, 'fail');
+assert.equal(summary.error, 'status rejected');
+
+process.stdout.write('Gate plan evaluator checks passed\n');


### PR DESCRIPTION
## Summary
- Add generic `homeboy/gate-plan/v1` and `homeboy/gate-result/v1` primitives with a central evaluator.
- Route high-value duplicated gates through the evaluator in generic loop stop/continue handling, workspace lifecycle checks, and selected controller proof validations.
- Add focused behavior coverage for continue, stop, continuation-declined stop, and fail semantics.

## Verification
- `npm run test:gate-plan-evaluator`
- `npm run test:workspace-publication-lifecycle`
- `npm run test:controller-loop-proof-validator`
- `node tests/generic-agent-loop-runner.test.js`
- `npm run test:agent-task-outcome-normalizer`
- `npm run test:generic-fanout-reconcile-boundary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 / OpenCode
- **Used for:** Drafting and implementing the shared gate evaluator, migrations, tests, and PR preparation.