### PR TITLE
Add batch production loop primitive

### DIFF
--- a/runtime-agent-ci/index.js
+++ b/runtime-agent-ci/index.js
@@ -10,5 +10,6 @@ Object.assign(module.exports, require('./lib/headless-deterministic-loop-runner'
 Object.assign(module.exports, require('./lib/preview-materialization'));
 Object.assign(module.exports, require('./lib/controller-loop-proof-validator'));
 Object.assign(module.exports, require('./lib/bounded-production-loop-runner'));
+Object.assign(module.exports, require('./lib/batch-production-loop-runner'));
 Object.assign(module.exports, require('./lib/workspace-publication-lifecycle.cjs'));
 Object.assign(module.exports, require('./lib/agent-task-outcome-normalizer'));

--- a/runtime-agent-ci/lib/batch-production-loop-runner.js
+++ b/runtime-agent-ci/lib/batch-production-loop-runner.js
@@ -1,0 +1,403 @@
+'use strict';
+
+const BATCH_PRODUCTION_LOOP_RESULT_SCHEMA = 'homeboy/batch-production-loop-result/v1';
+const BATCH_PRODUCTION_LOOP_WAVE_SCHEMA = 'homeboy/batch-production-loop-wave/v1';
+const BATCH_PRODUCTION_LOOP_EVIDENCE_SCHEMA = 'homeboy/batch-production-loop-evidence/v1';
+const DEFAULT_CONCURRENCY = 3;
+const DEFAULT_MAX_ITERATIONS = 3;
+
+async function runBatchProductionLoop(options = {}) {
+  const loopId = options.loopId || options.loop_id || 'batch-production-loop';
+  const maxIterations = positiveInteger(options.maxIterations || options.max_iterations, DEFAULT_MAX_ITERATIONS);
+  const concurrency = normalizeConcurrency(options.concurrency || options.maxConcurrency || options.max_concurrency);
+  const planWave = requiredFunction(options.planWave || options.plan_wave, 'planWave');
+  const executeGroup = resolveExecuteGroup(options);
+  const reconcileWave = options.reconcileWave || options.reconcile_wave || defaultReconcileWave;
+  const repairPolicy = options.repairPolicy || options.repair_policy || null;
+  const fanoutPolicy = options.fanoutPolicy || options.fanout_policy || null;
+  const classifyGroupOutcome = options.classifyGroupOutcome || options.classify_group_outcome || defaultClassifyGroupOutcome;
+  const waves = [];
+  let state = optionalObject(options.state || options.initialState || options.initial_state);
+  let retryGroups = normalizeGroups(options.groups || options.initialGroups || options.initial_groups);
+  let previousWave = null;
+  let stopReason = '';
+
+  for (let iteration = 1; iteration <= maxIterations; iteration += 1) {
+    const plan = normalizeWavePlan(await planWave({
+      loop_id: loopId,
+      loopId,
+      iteration,
+      wave: iteration,
+      state,
+      previous_wave: previousWave,
+      previousWave,
+      retry_groups: retryGroups,
+      retryGroups,
+      waves,
+    }), retryGroups);
+    let groups = normalizeGroups(plan.groups);
+    const fanout = await applyFanoutPolicy(fanoutPolicy, {
+      loopId,
+      loop_id: loopId,
+      iteration,
+      wave: iteration,
+      state,
+      plan,
+      groups,
+      previous_wave: previousWave,
+      previousWave,
+      retry_groups: retryGroups,
+      retryGroups,
+      waves,
+    });
+    groups = normalizeGroups(fanout.groups || groups);
+
+    if (groups.length === 0) {
+      stopReason = iteration === 1 ? 'empty_plan' : 'no_retry_groups';
+      break;
+    }
+
+    const groupOutcomes = await executeGroups({
+      loopId,
+      iteration,
+      groups,
+      concurrency,
+      executeGroup,
+      classifyGroupOutcome,
+      state,
+      plan,
+      fanout,
+      options,
+    });
+    const failedGroups = groups.filter((group, index) => !groupOutcomes[index]?.success);
+    const reconciliation = normalizeReconciliation(await reconcileWave({
+      loop_id: loopId,
+      loopId,
+      iteration,
+      wave: iteration,
+      state,
+      plan,
+      fanout,
+      groups,
+      group_outcomes: groupOutcomes,
+      groupOutcomes,
+      failed_groups: failedGroups,
+      failedGroups,
+      previous_wave: previousWave,
+      previousWave,
+      waves,
+    }));
+    const accepted = reconciliation.accepted === true || reconciliation.complete === true || reconciliation.status === 'accepted' || reconciliation.status === 'succeeded';
+    const repair = accepted ? { retry_groups: [], required: false } : await applyRepairPolicy(repairPolicy, {
+      loop_id: loopId,
+      loopId,
+      iteration,
+      wave: iteration,
+      state,
+      plan,
+      fanout,
+      groups,
+      group_outcomes: groupOutcomes,
+      groupOutcomes,
+      failed_groups: failedGroups,
+      failedGroups,
+      reconciliation,
+      previous_wave: previousWave,
+      previousWave,
+      waves,
+    });
+    const waveRecord = {
+      schema: BATCH_PRODUCTION_LOOP_WAVE_SCHEMA,
+      loop_id: loopId,
+      iteration,
+      wave: iteration,
+      concurrency,
+      plan,
+      fanout,
+      groups: groups.map(serializeGroup),
+      group_outcomes: groupOutcomes,
+      failed_group_count: failedGroups.length,
+      accepted,
+      reconciliation,
+      repair,
+      artifacts: collectRecords(plan.artifacts, fanout.artifacts, reconciliation.artifacts, repair.artifacts),
+      evidence_refs: collectRecords(plan.evidence_refs, plan.evidence, fanout.evidence_refs, fanout.evidence, reconciliation.evidence_refs, reconciliation.evidence, repair.evidence_refs, repair.evidence),
+    };
+
+    waves.push(waveRecord);
+    previousWave = waveRecord;
+    state = {
+      ...state,
+      ...optionalObject(plan.state),
+      ...optionalObject(reconciliation.state),
+      ...optionalObject(repair.state),
+      latest_wave: waveRecord,
+      latest_group_outcomes: groupOutcomes,
+    };
+
+    if (accepted) {
+      stopReason = reconciliation.stop_reason || 'accepted';
+      break;
+    }
+
+    retryGroups = normalizeGroups(repair.retry_groups || repair.groups || reconciliation.retry_groups || reconciliation.groups || failedGroups);
+    if (retryGroups.length === 0) {
+      stopReason = reconciliation.stop_reason || 'no_retry_groups';
+      break;
+    }
+    if (iteration === maxIterations) {
+      stopReason = 'max_iterations_reached';
+    }
+  }
+
+  const latestWave = waves[waves.length - 1] || null;
+  const status = latestWave?.accepted ? 'succeeded' : 'failed';
+  return {
+    schema: BATCH_PRODUCTION_LOOP_RESULT_SCHEMA,
+    loop_id: loopId,
+    status,
+    stop_reason: stopReason || (waves.length === 0 ? 'empty' : 'unknown'),
+    max_iterations: maxIterations,
+    concurrency,
+    wave_count: waves.length,
+    iteration_count: waves.length,
+    waves,
+    group_outcomes: waves.flatMap((wave) => wave.group_outcomes),
+    evidence_envelope: buildEvidenceEnvelope({ loopId, status, waves }),
+    final_state: state,
+  };
+}
+
+async function executeGroups(context) {
+  const records = new Array(context.groups.length);
+  let nextIndex = 0;
+  let running = 0;
+
+  return new Promise((resolve) => {
+    const startNext = () => {
+      if (nextIndex >= context.groups.length && running === 0) {
+        resolve(records);
+        return;
+      }
+      while (running < context.concurrency && nextIndex < context.groups.length) {
+        const index = nextIndex;
+        const group = context.groups[index];
+        nextIndex += 1;
+        running += 1;
+        Promise.resolve()
+          .then(() => context.executeGroup({
+            loop_id: context.loopId,
+            loopId: context.loopId,
+            iteration: context.iteration,
+            wave: context.iteration,
+            group,
+            group_index: index,
+            groupIndex: index,
+            groups: context.groups,
+            state: context.state,
+            plan: context.plan,
+            fanout: context.fanout,
+            options: context.options,
+          }))
+          .then((outcome) => {
+            records[index] = normalizeGroupOutcome({ group, index, outcome, classifyGroupOutcome: context.classifyGroupOutcome });
+          })
+          .catch((error) => {
+            records[index] = failedGroupOutcome(group, index, error);
+          })
+          .finally(() => {
+            running -= 1;
+            startNext();
+          });
+      }
+    };
+    startNext();
+  });
+}
+
+function resolveExecuteGroup(options) {
+  const execution = optionalObject(options.execution || options.executor);
+  return requiredFunction(options.executeGroup || options.execute_group || execution.executeGroup || execution.execute_group || execution.runGroup || execution.run_group, 'executeGroup');
+}
+
+async function applyFanoutPolicy(fanoutPolicy, context) {
+  if (typeof fanoutPolicy !== 'function') {
+    return { groups: context.groups };
+  }
+  const fanout = await fanoutPolicy(context);
+  if (Array.isArray(fanout)) {
+    return { groups: fanout };
+  }
+  return { groups: context.groups, ...optionalObject(fanout) };
+}
+
+async function applyRepairPolicy(repairPolicy, context) {
+  if (typeof repairPolicy !== 'function') {
+    return { required: context.failedGroups.length > 0, retry_groups: context.failedGroups };
+  }
+  const repair = await repairPolicy(context);
+  if (Array.isArray(repair)) {
+    return { required: repair.length > 0, retry_groups: repair };
+  }
+  return { required: normalizeGroups(repair?.retry_groups || repair?.groups).length > 0, ...optionalObject(repair) };
+}
+
+function defaultReconcileWave({ groupOutcomes }) {
+  const complete = groupOutcomes.every((outcome) => outcome.success);
+  return { status: complete ? 'succeeded' : 'failed', complete };
+}
+
+function defaultClassifyGroupOutcome(outcome) {
+  const status = outcome?.status || outcome?.state || '';
+  const success = outcome?.success === true || ['accepted', 'completed', 'passed', 'succeeded'].includes(status);
+  return {
+    success,
+    status: status || (success ? 'completed' : 'failed'),
+  };
+}
+
+function normalizeGroupOutcome({ group, index, outcome, classifyGroupOutcome }) {
+  const classification = optionalObject(classifyGroupOutcome(outcome, group, index));
+  const status = classification.status || outcome?.status || outcome?.state || (classification.success ? 'completed' : 'failed');
+  return {
+    group_key: groupKey(group, index),
+    group_index: index,
+    status,
+    success: classification.success === true,
+    outcome,
+    artifacts: collectRecords(outcome?.artifacts),
+    evidence_refs: collectRecords(outcome?.evidence_refs, outcome?.evidence),
+  };
+}
+
+function failedGroupOutcome(group, index, error) {
+  return {
+    group_key: groupKey(group, index),
+    group_index: index,
+    status: 'failed',
+    success: false,
+    outcome: null,
+    artifacts: [],
+    evidence_refs: [],
+    error_message: errorMessage(error),
+  };
+}
+
+function normalizeWavePlan(value, fallbackGroups) {
+  if (Array.isArray(value)) {
+    return { groups: value };
+  }
+  const plan = optionalObject(value);
+  if (!Array.isArray(plan.groups) && fallbackGroups.length > 0) {
+    return { ...plan, groups: fallbackGroups };
+  }
+  return { groups: [], ...plan };
+}
+
+function normalizeReconciliation(value) {
+  if (value === true) {
+    return { accepted: true, status: 'accepted' };
+  }
+  if (value === false) {
+    return { accepted: false, status: 'failed' };
+  }
+  return optionalObject(value);
+}
+
+function buildEvidenceEnvelope({ loopId, status, waves }) {
+  return {
+    schema: BATCH_PRODUCTION_LOOP_EVIDENCE_SCHEMA,
+    loop_id: loopId,
+    status,
+    wave_count: waves.length,
+    group_count: waves.reduce((count, wave) => count + wave.groups.length, 0),
+    failed_group_count: waves.reduce((count, wave) => count + wave.failed_group_count, 0),
+    artifacts: collectRecords(...waves.map((wave) => wave.artifacts), ...waves.flatMap((wave) => wave.group_outcomes.map((outcome) => outcome.artifacts))),
+    evidence_refs: collectRecords(...waves.map((wave) => wave.evidence_refs), ...waves.flatMap((wave) => wave.group_outcomes.map((outcome) => outcome.evidence_refs))),
+    waves: waves.map((wave) => ({
+      iteration: wave.iteration,
+      accepted: wave.accepted,
+      group_count: wave.groups.length,
+      failed_group_count: wave.failed_group_count,
+      artifacts: wave.artifacts,
+      evidence_refs: wave.evidence_refs,
+    })),
+  };
+}
+
+function serializeGroup(group, index) {
+  if (isPlainObject(group)) {
+    return { key: groupKey(group, index), ...group };
+  }
+  return { key: groupKey(group, index), value: group };
+}
+
+function groupKey(group, index) {
+  if (isPlainObject(group)) {
+    return String(group.key || group.group_key || group.groupKey || group.id || index);
+  }
+  return String(index);
+}
+
+function normalizeGroups(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function collectRecords(...recordSets) {
+  const records = [];
+  const seen = new Set();
+  for (const recordSet of recordSets) {
+    for (const record of normalizeGroups(recordSet)) {
+      if (!record || typeof record !== 'object') {
+        continue;
+      }
+      const key = record.url || record.uri || record.path || record.name || record.id || JSON.stringify(record);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      records.push(record);
+    }
+  }
+  return records;
+}
+
+function normalizeConcurrency(value) {
+  const parsed = positiveInteger(value, DEFAULT_CONCURRENCY);
+  return Math.min(parsed, 16);
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function requiredFunction(value, name) {
+  if (typeof value !== 'function') {
+    throw new Error(`${name} must be a function.`);
+  }
+  return value;
+}
+
+function optionalObject(value) {
+  return isPlainObject(value) ? value : {};
+}
+
+function isPlainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function errorMessage(error) {
+  if (error && typeof error.message === 'string' && error.message.trim()) {
+    return error.message;
+  }
+  return String(error || 'Group execution failed');
+}
+
+module.exports = {
+  BATCH_PRODUCTION_LOOP_EVIDENCE_SCHEMA,
+  BATCH_PRODUCTION_LOOP_RESULT_SCHEMA,
+  BATCH_PRODUCTION_LOOP_WAVE_SCHEMA,
+  DEFAULT_CONCURRENCY,
+  runBatchProductionLoop,
+};

--- a/runtime-agent-ci/package.json
+++ b/runtime-agent-ci/package.json
@@ -7,6 +7,7 @@
     ".": "./index.js",
     "./controller-loop-proof-validator": "./lib/controller-loop-proof-validator.js",
     "./agent-task-outcome-normalizer": "./lib/agent-task-outcome-normalizer.js",
+    "./batch-production-loop-runner": "./lib/batch-production-loop-runner.js",
     "./bounded-production-loop-runner": "./lib/bounded-production-loop-runner.js",
     "./fanout-reconcile-runner": "./lib/fanout-reconcile-runner.js",
     "./generic-fanout-reconcile-workflow": "./lib/generic-fanout-reconcile-workflow.js",

--- a/runtime-agent-ci/tests/batch-production-loop-runner.test.js
+++ b/runtime-agent-ci/tests/batch-production-loop-runner.test.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+const {
+  BATCH_PRODUCTION_LOOP_EVIDENCE_SCHEMA,
+  BATCH_PRODUCTION_LOOP_RESULT_SCHEMA,
+  BATCH_PRODUCTION_LOOP_WAVE_SCHEMA,
+  runBatchProductionLoop,
+} = require('../lib/batch-production-loop-runner');
+
+(async () => {
+  assert.equal(BATCH_PRODUCTION_LOOP_RESULT_SCHEMA, 'homeboy/batch-production-loop-result/v1');
+  assert.equal(BATCH_PRODUCTION_LOOP_WAVE_SCHEMA, 'homeboy/batch-production-loop-wave/v1');
+  assert.equal(BATCH_PRODUCTION_LOOP_EVIDENCE_SCHEMA, 'homeboy/batch-production-loop-evidence/v1');
+
+  const successful = await runBatchProductionLoop({
+    loopId: 'successful-batch',
+    maxIterations: 3,
+    concurrency: 2,
+    planWave: () => ({ groups: [{ key: 'a' }, { key: 'b' }], evidence_refs: [{ kind: 'plan', url: 'https://example.test/plan' }] }),
+    executeGroup: ({ group }) => ({ status: 'completed', group: group.key, evidence_refs: [{ kind: 'group', url: `https://example.test/${group.key}` }] }),
+    reconcileWave: ({ groupOutcomes }) => ({ accepted: groupOutcomes.every((outcome) => outcome.success), evidence_refs: [{ kind: 'wave', url: 'https://example.test/wave' }] }),
+  });
+
+  assert.equal(successful.schema, BATCH_PRODUCTION_LOOP_RESULT_SCHEMA);
+  assert.equal(successful.status, 'succeeded');
+  assert.equal(successful.stop_reason, 'accepted');
+  assert.equal(successful.wave_count, 1);
+  assert.equal(successful.waves[0].schema, BATCH_PRODUCTION_LOOP_WAVE_SCHEMA);
+  assert.equal(successful.waves[0].group_outcomes.length, 2);
+  assert.equal(successful.evidence_envelope.schema, BATCH_PRODUCTION_LOOP_EVIDENCE_SCHEMA);
+  assert.equal(successful.evidence_envelope.evidence_refs.length, 4);
+
+  const runningCounts = [];
+  let running = 0;
+  const concurrencyLimited = await runBatchProductionLoop({
+    loopId: 'concurrency-limited',
+    concurrency: 2,
+    planWave: () => [{ key: 'a' }, { key: 'b' }, { key: 'c' }, { key: 'd' }],
+    executeGroup: async () => {
+      running += 1;
+      runningCounts.push(running);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      running -= 1;
+      return { status: 'completed' };
+    },
+  });
+
+  assert.equal(concurrencyLimited.status, 'succeeded');
+  assert.equal(Math.max(...runningCounts), 2);
+
+  const attempts = new Map();
+  const plannedRetryGroups = [];
+  const partialRetry = await runBatchProductionLoop({
+    loopId: 'partial-retry',
+    maxIterations: 3,
+    concurrency: 3,
+    planWave: ({ iteration, retryGroups }) => {
+      plannedRetryGroups.push(retryGroups.map((group) => group.key));
+      return iteration === 1 ? [{ key: 'a' }, { key: 'b' }, { key: 'c' }] : { groups: retryGroups };
+    },
+    executeGroup: ({ group }) => {
+      const attempt = (attempts.get(group.key) || 0) + 1;
+      attempts.set(group.key, attempt);
+      if (group.key === 'b' && attempt === 1) {
+        return { status: 'failed' };
+      }
+      return { status: 'completed' };
+    },
+    reconcileWave: ({ groupOutcomes, failedGroups }) => ({
+      accepted: failedGroups.length === 0,
+      retry_groups: failedGroups,
+      state: { latest_failed_count: failedGroups.length },
+      evidence_refs: [{ kind: 'reconcile', url: `https://example.test/reconcile/${groupOutcomes.length}` }],
+    }),
+  });
+
+  assert.equal(partialRetry.status, 'succeeded');
+  assert.equal(partialRetry.wave_count, 2);
+  assert.deepEqual(plannedRetryGroups, [[], ['b']]);
+  assert.equal(partialRetry.waves[0].failed_group_count, 1);
+  assert.deepEqual(partialRetry.waves[1].groups.map((group) => group.key), ['b']);
+  assert.equal(partialRetry.final_state.latest_failed_count, 0);
+
+  let repairCalls = 0;
+  let fanoutCalls = 0;
+  const hookRun = await runBatchProductionLoop({
+    loopId: 'hooks',
+    maxIterations: 2,
+    planWave: ({ iteration, retryGroups }) => iteration === 1 ? [{ key: 'root' }] : retryGroups,
+    fanoutPolicy: ({ groups }) => {
+      fanoutCalls += 1;
+      return { groups: groups.flatMap((group) => group.key === 'root' ? [{ key: 'x' }, { key: 'y' }] : [group]) };
+    },
+    executeGroup: ({ group }) => ({ status: group.key === 'x' ? 'failed' : 'completed' }),
+    reconcileWave: ({ failedGroups }) => ({ accepted: failedGroups.length === 0 }),
+    repairPolicy: ({ failedGroups }) => {
+      repairCalls += 1;
+      return { retry_groups: failedGroups.map((group) => ({ ...group, key: 'y' })) };
+    },
+  });
+
+  assert.equal(hookRun.status, 'succeeded');
+  assert.equal(hookRun.wave_count, 2);
+  assert.equal(fanoutCalls, 2);
+  assert.equal(repairCalls, 1);
+
+  const boundedFailure = await runBatchProductionLoop({
+    loopId: 'bounded-failure',
+    maxIterations: 2,
+    planWave: ({ retryGroups, iteration }) => iteration === 1 ? [{ key: 'a' }] : retryGroups,
+    executeGroup: () => ({ status: 'failed' }),
+  });
+
+  assert.equal(boundedFailure.status, 'failed');
+  assert.equal(boundedFailure.stop_reason, 'max_iterations_reached');
+  assert.equal(boundedFailure.wave_count, 2);
+
+  const injectedExecution = await runBatchProductionLoop({
+    loopId: 'injected-execution',
+    planWave: () => [{ key: 'a' }],
+    execution: {
+      runGroup: () => ({ status: 'completed' }),
+    },
+  });
+
+  assert.equal(injectedExecution.status, 'succeeded');
+
+  process.stdout.write('Batch production loop runner behavior checks passed\n');
+})().catch((error) => {
+  process.stderr.write(`${error.stack || error.message}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Add an async batch/minion production loop primitive for bounded wave execution.
- Support injected group execution, concurrency limits, per-group outcomes, repair/fanout policies, partial retry, and wave evidence envelopes.
- Export the primitive from runtime-agent-ci and add behavior coverage.

## Tests
From `runtime-agent-ci`:
- `node tests/batch-production-loop-runner.test.js`
- `node tests/bounded-production-loop-runner.test.js`
- `node tests/headless-deterministic-loop-runner.test.js`
- `node tests/generic-agent-loop-runner.test.js`
- `node -e "const runtime = require(\"./\"); if (typeof runtime.runBatchProductionLoop !== \"function\") throw new Error(\"missing export\");"`
- `node --check lib/batch-production-loop-runner.js && node --check tests/batch-production-loop-runner.test.js`

From repo root:
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 / OpenCode
- **Used for:** Implementing the batch production loop primitive, behavior tests, verification, and PR preparation.
