### PR TITLE
Use runtime adapter for workflow inputs

### DIFF
--- a/agent-runtimes/wp-codebox/lib/runtime-workflow-input-projection.js
+++ b/agent-runtimes/wp-codebox/lib/runtime-workflow-input-projection.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { codeboxRuntimeProfilePayload } = require('./codebox-runtime-profile');
+
+function renderRuntimeWorkflowInputs({
+	profileId,
+	profile,
+	runtimeProfiles,
+	toolProfile,
+	componentContracts,
+	component_contracts,
+	runtimeOverlays,
+	runtime_overlays,
+	runtimeEnv,
+	runtime_env,
+	providerPluginPaths,
+	provider_plugin_paths,
+	runtimeStateMounts,
+	runtime_state_mounts,
+	runtimeConfigMounts,
+	runtime_config_mounts,
+}) {
+	const runtimeRequirements = codeboxRuntimeProfilePayload({
+		id: profileId,
+		profile,
+		componentContracts: componentContracts || component_contracts || [],
+		runtimeOverlays: runtimeOverlays || runtime_overlays || [],
+		runtimeEnv: runtimeEnv || runtime_env || {},
+		providerPluginPaths: providerPluginPaths || provider_plugin_paths || [],
+		runtimeStateMounts: runtimeStateMounts || runtime_state_mounts,
+		runtimeConfigMounts: runtimeConfigMounts || runtime_config_mounts,
+	});
+
+	return {
+		runtime_requirements: runtimeRequirements,
+		workflow_inputs: stripUndefined({
+			runtime: 'wp-codebox',
+			profile: profileId,
+			runtime_profiles: {
+				...runtimeProfiles,
+				[profileId]: runtimeRequirements,
+			},
+			sandbox_tool_policy: Object.keys(toolProfile).length > 0 ? toolProfile : undefined,
+		}),
+	};
+}
+
+function stripUndefined(value) {
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+module.exports = { renderRuntimeWorkflowInputs };

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -10,6 +10,12 @@
       "export": "scenarioResultsFromOutcome"
     }
   },
+  "workflow_input_projection": {
+    "adapter": {
+      "module": "agent-runtimes/wp-codebox/lib/runtime-workflow-input-projection.js",
+      "export": "renderRuntimeWorkflowInputs"
+    }
+  },
   "runner_config_projection": {
     "adapter": {
       "module": "agent-runtimes/wp-codebox/lib/runtime-config-projection.js",

--- a/runtime-agent-ci/lib/runtime-workflow-inputs.cjs
+++ b/runtime-agent-ci/lib/runtime-workflow-inputs.cjs
@@ -1,5 +1,7 @@
 'use strict';
 
+const path = require('node:path');
+
 const { normalizeRuntimeId, resolveRuntimeProvider } = require('./runtime-provider-resolver.cjs');
 
 const RUNTIME_WORKFLOW_INPUTS_SCHEMA = 'homeboy/runtime-workflow-inputs/v1';
@@ -12,7 +14,7 @@ function renderRuntimeWorkflowInputs(options = {}) {
 	const runtimeProfiles = plainObject(options.runtimeProfiles || options.runtime_profiles);
 	const selectedProfile = selectedRuntimeProfile(profileSelection, runtimeProfiles);
 	const toolProfile = plainObject(options.toolProfile || options.tool_profile || options.sandboxToolPolicy || options.sandbox_tool_policy || options.toolPolicy || options.tool_policy);
-	const adapter = runtimeWorkflowInputAdapter(runtime);
+	const adapter = runtimeWorkflowInputAdapter(runtime, options);
 	const rendered = adapter({
 		...options,
 		runtime,
@@ -37,11 +39,19 @@ function renderRuntimeWorkflowInputs(options = {}) {
 	});
 }
 
-function runtimeWorkflowInputAdapter(runtime) {
-	if (isCodeboxRuntime(runtime)) {
-		return renderCodeboxWorkflowInputs;
+function runtimeWorkflowInputAdapter(runtime, options = {}) {
+	const adapter = runtime?.manifest?.workflow_input_projection?.adapter;
+	if (!isPlainObject(adapter) || !adapter.module) {
+		return renderDefaultWorkflowInputs;
 	}
-	return renderDefaultWorkflowInputs;
+	const repoRoot = options.repoRoot || path.resolve(__dirname, '..', '..');
+	const adapterPath = path.resolve(repoRoot, adapter.module);
+	const loaded = require(adapterPath);
+	const exportName = adapter.export || 'renderRuntimeWorkflowInputs';
+	if (typeof loaded[exportName] !== 'function') {
+		throw new Error(`Runtime ${runtime.id} workflow input adapter ${adapter.module} does not export ${exportName}`);
+	}
+	return loaded[exportName];
 }
 
 function renderDefaultWorkflowInputs({ runtime, profileId, profile, runtimeProfiles }) {
@@ -56,50 +66,6 @@ function renderDefaultWorkflowInputs({ runtime, profileId, profile, runtimeProfi
 			profile: profileId,
 			runtime_profiles: effectiveRuntimeProfiles,
 		},
-	};
-}
-
-function renderCodeboxWorkflowInputs({
-	profileId,
-	profile,
-	runtimeProfiles,
-	toolProfile,
-	componentContracts,
-	component_contracts,
-	runtimeOverlays,
-	runtime_overlays,
-	runtimeEnv,
-	runtime_env,
-	providerPluginPaths,
-	provider_plugin_paths,
-	runtimeStateMounts,
-	runtime_state_mounts,
-	runtimeConfigMounts,
-	runtime_config_mounts,
-}) {
-	const { codeboxRuntimeProfilePayload } = require('../../agent-runtimes/wp-codebox/lib/codebox-runtime-profile');
-	const runtimeRequirements = codeboxRuntimeProfilePayload({
-		id: profileId,
-		profile,
-		componentContracts: componentContracts || component_contracts || [],
-		runtimeOverlays: runtimeOverlays || runtime_overlays || [],
-		runtimeEnv: runtimeEnv || runtime_env || {},
-		providerPluginPaths: providerPluginPaths || provider_plugin_paths || [],
-		runtimeStateMounts: runtimeStateMounts || runtime_state_mounts,
-		runtimeConfigMounts: runtimeConfigMounts || runtime_config_mounts,
-	});
-
-	return {
-		runtime_requirements: runtimeRequirements,
-		workflow_inputs: stripUndefined({
-			runtime: 'wp-codebox',
-			profile: profileId,
-			runtime_profiles: {
-				...runtimeProfiles,
-				[profileId]: runtimeRequirements,
-			},
-			sandbox_tool_policy: Object.keys(toolProfile).length > 0 ? toolProfile : undefined,
-		}),
 	};
 }
 
@@ -125,12 +91,12 @@ function selectedRuntimeProfile(selection, runtimeProfiles) {
 	return { ...profile, id: profile.id || selection.id };
 }
 
-function isCodeboxRuntime(runtime) {
-	return runtime?.id === 'wp-codebox' || runtime?.executor?.backend === 'codebox';
-}
-
 function plainObject(value) {
 	return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function isPlainObject(value) {
+	return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }
 
 function stripUndefined(value) {

--- a/tests/runtime-workflow-input-renderer-smoke.mjs
+++ b/tests/runtime-workflow-input-renderer-smoke.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs');
 const {
 	renderRuntimeWorkflowInputs,
 } = require(path.join(rootDir, 'runtime-agent-ci', 'lib', 'runtime-workflow-inputs.cjs'));
@@ -25,10 +26,6 @@ const rendered = renderRuntimeWorkflowInputs({
 	tool_profile: {
 		schema: 'homeboy/runtime-tool-profile/v1',
 		tools: { workspace_read: true },
-	},
-	runtimeProviderConfig: {
-		id: 'wp-codebox',
-		executor: { backend: 'codebox' },
 	},
 });
 


### PR DESCRIPTION
## Summary
- Load runtime workflow input renderers from a manifest-declared adapter instead of special-casing WP Codebox in the generic renderer.
- Move the WP Codebox workflow input projection into the WP Codebox runtime adapter.
- Update the workflow input smoke test to exercise WP Codebox behavior through the manifest contract and fixture contract module.

## Tests
- `node tests/runtime-workflow-input-renderer-smoke.mjs`
- `node tests/wp-codebox-runtime-profile-defaults-smoke.mjs`
- `node -e "const fs=require('node:fs'); const s=fs.readFileSync('runtime-agent-ci/lib/runtime-workflow-inputs.cjs','utf8'); const terms=['wp-codebox','Codebox','isCodeboxRuntime','agent-runtimes/wp-codebox']; const found=terms.filter((term)=>s.includes(term)); if(found.length){ console.error('Found runtime-specific terms:', found.join(', ')); process.exit(1); } console.log('generic renderer contains no WP Codebox-specific terms');"`

## Notes
- `node tests/wp-codebox-adapter-contract-smoke.mjs` currently fails on an unrelated existing contract expectation: expected `consume_canonical_envelope_with_explicit_legacy_result_compatibility`, actual `consume_canonical_public_envelope_only`. This branch does not touch that test or its adapter contract files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 / OpenCode
- **Used for:** Implementing the manifest-backed runtime workflow input adapter, moving the WP Codebox projection into the adapter, updating tests, and running targeted verification.