### PR TITLE
Extract publication lifecycle primitives

### DIFF
--- a/runtime-agent-ci/lib/workspace-publication-lifecycle.cjs
+++ b/runtime-agent-ci/lib/workspace-publication-lifecycle.cjs
@@ -667,53 +667,23 @@ function replacementBranchName(branch, hooks = {}) {
   return `${branch}-run-${suffix}`.replace(/[^A-Za-z0-9._/-]+/g, '-').replace(/^-+|-+$/g, '');
 }
 
-function ensurePullRequest(workspace, branch, templates, hooks = {}) {
-  const existing = pullRequestForBranch(workspace, branch, hooks);
-  if (existing?.state === 'OPEN' && existing.url) {
-    gh(
-      workspace,
-      ['pr', 'edit', String(existing.number || branch), '--title', templates.title, '--body', templates.body],
-      { check: false, hooks },
-    );
-    return { url: existing.url, action: 'updated', number: existing.number || null, state: 'OPEN' };
-  }
-
-  if (existing?.state === 'CLOSED' && existing.number) {
-    const reopened = gh(workspace, ['pr', 'reopen', String(existing.number)], { check: false, hooks });
-    if (reopened.status === 0) {
-      gh(
-        workspace,
-        ['pr', 'edit', String(existing.number), '--title', templates.title, '--body', templates.body],
-        { check: false, hooks },
-      );
-      return { url: existing.url || '', action: 'reopened', head: branch, number: existing.number, state: 'OPEN' };
-    }
-
-    const replacementBranch = replacementBranchName(branch, hooks);
-    pushNewWorkspaceBranch(workspace, replacementBranch, hooks);
-    const url = createPullRequest(workspace, replacementBranch, templates, hooks);
-    return {
-      url,
-      action: 'created_after_closed_pr',
-      head: replacementBranch,
-      number: null,
-      state: 'OPEN',
-      closed_pr_number: existing.number,
-      closed_pr_url: existing.url || '',
-      reopen_error: (reopened.stderr || reopened.stdout || '').trim(),
-    };
-  }
-
-  const url = createPullRequest(workspace, branch, templates, hooks);
-  return { url, action: 'created', head: branch, number: null, state: 'OPEN' };
+function publicationEvidenceRef(input = {}) {
+  return {
+    type: input.url ? 'pull_request' : 'branch',
+    provider: 'github',
+    repo: input.repo || '',
+    head: input.head || input.branch || '',
+    base: input.base || '',
+    url: input.url || '',
+    action: input.action || '',
+    pr_number: input.pr_number ?? input.number ?? null,
+    pr_state: input.pr_state || input.state || '',
+    files: Array.isArray(input.files) ? input.files : [],
+  };
 }
 
-function publishWorkspace(config, results, scenario, workspace, files, hooks = {}) {
+function preparePublication(config, results, scenario, files, hooks = {}) {
   const adapter = lifecycleHooks(hooks);
-  if (files.length === 0) {
-    return { opened: false, changed: false };
-  }
-
   const metadata = scenario.metadata || {};
   const values = {
     agent_slug: config.agent_slug || 'runtime-agent',
@@ -731,27 +701,158 @@ function publishWorkspace(config, results, scenario, workspace, files, hooks = {
   };
   const templates = publicationTemplates(config, values, hooks);
   const branch = templates.branch.replace(/[^A-Za-z0-9._/-]+/g, '-').replace(/^-+|-+$/g, '') || `agent-artifacts/${values.agent_slug}-${values.run_id}`;
+  const repo = config.target_repo || adapter.env.GITHUB_REPOSITORY || '';
+  const publication_evidence_ref = publicationEvidenceRef({
+    repo,
+    head: branch,
+    base: templates.base,
+    files,
+  });
 
-  if (adapter.env.HOMEBOY_HOST_LIFECYCLE_DRY_RUN === '1' || config.dry_run) {
-    return { opened: false, changed: true, dry_run: true, head: branch, files };
-  }
+  return {
+    changed: files.length > 0,
+    dry_run: adapter.env.HOMEBOY_HOST_LIFECYCLE_DRY_RUN === '1' || Boolean(config.dry_run),
+    values,
+    templates,
+    branch,
+    base: templates.base,
+    repo,
+    files,
+    publication_evidence_ref,
+  };
+}
 
-  resetPublicationBranch(workspace, branch, templates.base, files, hooks);
-  files = changedFiles(workspace, config, hooks);
-
+function captureWorkspaceDelta(config, workspace, publication, hooks = {}) {
+  resetPublicationBranch(workspace, publication.branch, publication.base, publication.files, hooks);
+  const files = changedFiles(workspace, config, hooks);
   git(workspace, ['add', '--', ...files], { hooks });
   const staged = git(workspace, ['diff', '--cached', '--name-only'], { check: false, hooks }).stdout.trim().split('\n').filter(Boolean);
-  if (staged.length === 0) {
-    return { opened: false, changed: false, head: branch, files: [] };
+  return {
+    changed: staged.length > 0,
+    workspace,
+    files,
+    staged,
+    publication_evidence_ref: publicationEvidenceRef({
+      repo: publication.repo,
+      head: publication.branch,
+      base: publication.base,
+      files: staged,
+    }),
+  };
+}
+
+function publishRevision(workspace, publication, delta, hooks = {}) {
+  if (!delta.changed) {
+    return {
+      changed: false,
+      head: publication.branch,
+      files: [],
+      publication_evidence_ref: publicationEvidenceRef({
+        repo: publication.repo,
+        head: publication.branch,
+        base: publication.base,
+        files: [],
+      }),
+    };
   }
 
   git(workspace, ['config', 'user.name', 'homeboy-agent-ci'], { hooks });
   git(workspace, ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com'], { hooks });
-  git(workspace, ['commit', '-m', templates.commitMessage], { hooks });
-  pushWorkspaceBranch(workspace, branch, hooks);
+  git(workspace, ['commit', '-m', publication.templates.commitMessage], { hooks });
+  pushWorkspaceBranch(workspace, publication.branch, hooks);
 
-  const pullRequest = ensurePullRequest(workspace, branch, templates, hooks);
+  return {
+    changed: true,
+    head: publication.branch,
+    files: delta.staged,
+    publication_evidence_ref: publicationEvidenceRef({
+      repo: publication.repo,
+      head: publication.branch,
+      base: publication.base,
+      files: delta.staged,
+    }),
+  };
+}
+
+function updateReviewSummary(workspace, review, templates, hooks = {}) {
+  if (!review?.number) {
+    return { updated: false };
+  }
+  const result = gh(
+    workspace,
+    ['pr', 'edit', String(review.number), '--title', templates.title, '--body', templates.body],
+    { check: false, hooks },
+  );
+  return { updated: result.status === 0, error: result.status === 0 ? '' : (result.stderr || result.stdout || '').trim() };
+}
+
+function ensureReviewRequest(workspace, branch, templates, hooks = {}) {
+  const existing = pullRequestForBranch(workspace, branch, hooks);
+  if (existing?.state === 'OPEN' && existing.url) {
+    updateReviewSummary(workspace, { number: existing.number || branch }, templates, hooks);
+    return { url: existing.url, action: 'updated', number: existing.number || null, state: 'OPEN', publication_evidence_ref: publicationEvidenceRef({ head: branch, base: templates.base, url: existing.url, action: 'updated', number: existing.number || null, state: 'OPEN' }) };
+  }
+
+  if (existing?.state === 'CLOSED' && existing.number) {
+    const reopened = gh(workspace, ['pr', 'reopen', String(existing.number)], { check: false, hooks });
+    if (reopened.status === 0) {
+      updateReviewSummary(workspace, existing, templates, hooks);
+      return { url: existing.url || '', action: 'reopened', head: branch, number: existing.number, state: 'OPEN', publication_evidence_ref: publicationEvidenceRef({ head: branch, base: templates.base, url: existing.url || '', action: 'reopened', number: existing.number, state: 'OPEN' }) };
+    }
+
+    const replacementBranch = replacementBranchName(branch, hooks);
+    pushNewWorkspaceBranch(workspace, replacementBranch, hooks);
+    const url = createPullRequest(workspace, replacementBranch, templates, hooks);
+    return {
+      url,
+      action: 'created_after_closed_pr',
+      head: replacementBranch,
+      number: null,
+      state: 'OPEN',
+      closed_pr_number: existing.number,
+      closed_pr_url: existing.url || '',
+      reopen_error: (reopened.stderr || reopened.stdout || '').trim(),
+      publication_evidence_ref: publicationEvidenceRef({ head: replacementBranch, base: templates.base, url, action: 'created_after_closed_pr', state: 'OPEN' }),
+    };
+  }
+
+  const url = createPullRequest(workspace, branch, templates, hooks);
+  return { url, action: 'created', head: branch, number: null, state: 'OPEN', publication_evidence_ref: publicationEvidenceRef({ head: branch, base: templates.base, url, action: 'created', state: 'OPEN' }) };
+}
+
+function ensurePullRequest(workspace, branch, templates, hooks = {}) {
+  return ensureReviewRequest(workspace, branch, templates, hooks);
+}
+
+function publishWorkspace(config, results, scenario, workspace, files, hooks = {}) {
+  if (files.length === 0) {
+    return { opened: false, changed: false };
+  }
+
+  const publication = preparePublication(config, results, scenario, files, hooks);
+  if (publication.dry_run) {
+    return { opened: false, changed: true, dry_run: true, head: publication.branch, files, publication_evidence_ref: publication.publication_evidence_ref };
+  }
+
+  const delta = captureWorkspaceDelta(config, workspace, publication, hooks);
+  if (!delta.changed) {
+    return { opened: false, changed: false, head: publication.branch, files: [], publication_evidence_ref: delta.publication_evidence_ref };
+  }
+
+  const revision = publishRevision(workspace, publication, delta, hooks);
+  const pullRequest = ensureReviewRequest(workspace, publication.branch, publication.templates, hooks);
   const url = pullRequest.url;
+  const evidenceRef = publicationEvidenceRef({
+    repo: publication.repo,
+    head: pullRequest.head || revision.head,
+    base: publication.base,
+    url,
+    action: pullRequest.action,
+    number: pullRequest.number,
+    state: pullRequest.state,
+    files: revision.files,
+  });
+
 
   return {
     opened: Boolean(url),
@@ -759,9 +860,9 @@ function publishWorkspace(config, results, scenario, workspace, files, hooks = {
     tool_name: 'host_runner_workspace_publication',
     source: 'host_runner_lifecycle',
     success: Boolean(url),
-    repo: config.target_repo || adapter.env.GITHUB_REPOSITORY || '',
-    head: pullRequest.head || branch,
-    base: templates.base,
+    repo: publication.repo,
+    head: pullRequest.head || revision.head,
+    base: publication.base,
     url,
     action: pullRequest.action,
     pr_number: pullRequest.number,
@@ -769,7 +870,8 @@ function publishWorkspace(config, results, scenario, workspace, files, hooks = {
     closed_pr_number: pullRequest.closed_pr_number,
     closed_pr_url: pullRequest.closed_pr_url,
     reopen_error: pullRequest.reopen_error,
-    files: staged,
+    files: revision.files,
+    publication_evidence_ref: evidenceRef,
   };
 }
 
@@ -904,14 +1006,19 @@ function runDeterministicWorkspaceLifecycle(config, results, scenario, workspace
 
 module.exports = {
   calculatePublishSet,
+  captureWorkspaceDelta,
   changedFiles,
   evaluateSideEffectPolicy,
   evaluateWritablePaths: validateWritablePaths,
   evaluateWorkspaceContract,
   ensurePullRequest,
+  ensureReviewRequest,
   lifecycleHooks,
+  preparePublication,
   publicationBase,
+  publicationEvidenceRef,
   publicationTemplates,
+  publishRevision,
   publishWorkspace,
   prepareRunnerCommand,
   recordLifecycle,
@@ -919,5 +1026,6 @@ module.exports = {
   runDeterministicWorkspaceLifecycle,
   runShellCommand,
   scenarioById,
+  updateReviewSummary,
   validateWritablePaths,
 };

--- a/runtime-agent-ci/tests/workspace-publication-lifecycle.test.js
+++ b/runtime-agent-ci/tests/workspace-publication-lifecycle.test.js
@@ -1,13 +1,21 @@
 'use strict';
 
+/**
+ * External dependencies
+ */
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
+/**
+ * Internal dependencies
+ */
 const {
   calculatePublishSet,
+  ensureReviewRequest,
   evaluateSideEffectPolicy,
+  preparePublication,
   publicationTemplates,
   publishWorkspace,
   validateWritablePaths,
@@ -67,6 +75,107 @@ assert.deepEqual(templates, {
   base: 'trunk',
 });
 
+const prepared = preparePublication({
+  target_repo: 'owner/repo',
+  agent_slug: 'fixture agent',
+  provider: 'openai',
+  model: 'gpt-5.5',
+  workload_id: 'fixture-workload',
+  runner_workspace: { branch: 'agent artifacts/{agent_slug}-{run_id}', from: 'origin/trunk' },
+}, {}, {
+  id: 'fixture-workload',
+  metadata: { job_id: 'job-1' },
+}, ['docs/generated.md'], {
+  env: { GITHUB_RUN_ID: '12345', HOMEBOY_HOST_LIFECYCLE_DRY_RUN: '1' },
+});
+assert.equal(prepared.changed, true);
+assert.equal(prepared.dry_run, true);
+assert.equal(prepared.branch, 'agent-artifacts/fixture-agent-12345');
+assert.deepEqual(prepared.publication_evidence_ref, {
+  type: 'branch',
+  provider: 'github',
+  repo: 'owner/repo',
+  head: 'agent-artifacts/fixture-agent-12345',
+  base: 'trunk',
+  url: '',
+  action: '',
+  pr_number: null,
+  pr_state: '',
+  files: ['docs/generated.md'],
+});
+
+{
+  const calls = [];
+  const review = ensureReviewRequest('/workspace', 'agent-artifacts/fixture-agent-12345', {
+    base: 'trunk',
+    title: 'Updated title',
+    body: 'Updated body',
+  }, {
+    run(command, args, options = {}) {
+      calls.push({ command, args, cwd: options.cwd });
+      if (command === 'gh' && args[0] === 'pr' && args[1] === 'view') {
+        return { status: 0, stdout: JSON.stringify({ number: 47, state: 'OPEN', url: 'https://github.com/owner/repo/pull/47' }), stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    },
+  });
+  assert.equal(review.action, 'updated');
+  assert.equal(review.url, 'https://github.com/owner/repo/pull/47');
+  assert.deepEqual(review.publication_evidence_ref, {
+    type: 'pull_request',
+    provider: 'github',
+    repo: '',
+    head: 'agent-artifacts/fixture-agent-12345',
+    base: 'trunk',
+    url: 'https://github.com/owner/repo/pull/47',
+    action: 'updated',
+    pr_number: 47,
+    pr_state: 'OPEN',
+    files: [],
+  });
+  assert.deepEqual(calls.filter((call) => call.command === 'gh').map((call) => call.args.slice(0, 2)), [
+    ['pr', 'view'],
+    ['pr', 'edit'],
+  ]);
+}
+
+{
+  const calls = [];
+  const review = ensureReviewRequest('/workspace', 'agent-artifacts/fixture-agent-12345', {
+    base: 'trunk',
+    title: 'Updated title',
+    body: 'Updated body',
+  }, {
+    env: { GITHUB_RUN_ID: '999' },
+    run(command, args, options = {}) {
+      calls.push({ command, args, cwd: options.cwd });
+      if (command === 'gh' && args[0] === 'pr' && args[1] === 'view') {
+        return { status: 0, stdout: JSON.stringify({ number: 47, state: 'CLOSED', url: 'https://github.com/owner/repo/pull/47' }), stderr: '' };
+      }
+      if (command === 'gh' && args[0] === 'pr' && args[1] === 'reopen') {
+        return { status: 1, stdout: '', stderr: 'Could not open the pull request' };
+      }
+      if (command === 'gh' && args[0] === 'pr' && args[1] === 'create') {
+        return { status: 0, stdout: 'https://github.com/owner/repo/pull/1291\n', stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    },
+  });
+  assert.equal(review.action, 'created_after_closed_pr');
+  assert.equal(review.head, 'agent-artifacts/fixture-agent-12345-run-999');
+  assert.equal(review.closed_pr_number, 47);
+  assert.match(review.reopen_error, /Could not open the pull request/);
+  assert.equal(review.publication_evidence_ref.type, 'pull_request');
+  assert.equal(review.publication_evidence_ref.head, 'agent-artifacts/fixture-agent-12345-run-999');
+  assert.equal(review.publication_evidence_ref.action, 'created_after_closed_pr');
+  assert.deepEqual(calls.filter((call) => call.command === 'gh').map((call) => call.args.slice(0, 2)), [
+    ['pr', 'view'],
+    ['pr', 'reopen'],
+    ['pr', 'create'],
+  ]);
+  assert.equal(calls.some((call) => call.command === 'git' && call.args[0] === 'push'), true);
+}
+
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-workspace-publication-lifecycle.'));
 try {
   const workspace = path.join(tmp, 'repo');
@@ -120,6 +229,18 @@ try {
   assert.equal(publication.url, 'https://github.com/owner/repo/pull/1291');
   assert.equal(publication.action, 'created');
   assert.deepEqual(publication.files, ['docs/generated.md']);
+  assert.deepEqual(publication.publication_evidence_ref, {
+    type: 'pull_request',
+    provider: 'github',
+    repo: 'owner/repo',
+    head: 'agent-artifacts/fixture-agent-12345',
+    base: 'trunk',
+    url: 'https://github.com/owner/repo/pull/1291',
+    action: 'created',
+    pr_number: null,
+    pr_state: 'OPEN',
+    files: ['docs/generated.md'],
+  });
   assert.deepEqual(calls.filter((call) => call.command === 'gh').map((call) => call.args.slice(0, 2)), [
     ['pr', 'view'],
     ['pr', 'create'],


### PR DESCRIPTION
## Summary
- Extract publication lifecycle steps into preparePublication, captureWorkspaceDelta, publishRevision, ensureReviewRequest, and updateReviewSummary.
- Keep existing publishWorkspace behavior while adding normalized publication_evidence_ref metadata.
- Add behavior coverage for branch preparation, review update/replacement decisions, and publication evidence shape.

## Verification
- npm run test:workspace-publication-lifecycle from runtime-agent-ci
- npm run test:runtime-agent-host-lifecycle from wordpress
- npm run test:agent-task-outcome-normalizer && npm run test:controller-loop-proof-validator && npm run test:generic-fanout-reconcile-boundary from runtime-agent-ci
- ./wordpress/node_modules/.bin/eslint --config wordpress/eslint.config.mjs runtime-agent-ci/lib/workspace-publication-lifecycle.cjs runtime-agent-ci/tests/workspace-publication-lifecycle.test.js
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 / OpenCode
- **Used for:** Refactoring the publication lifecycle API, adding behavior tests, and running verification.