### PR TITLE
Add durable deterministic loop primitives

### DIFF
--- a/runtime-agent-ci/lib/deterministic-loop-runner.js
+++ b/runtime-agent-ci/lib/deterministic-loop-runner.js
@@ -3,6 +3,8 @@
 const DETERMINISTIC_LOOP_RESULT_SCHEMA = 'homeboy/deterministic-loop-result/v1';
 const DETERMINISTIC_LOOP_ITERATION_SCHEMA = 'homeboy/deterministic-loop-iteration/v1';
 const DETERMINISTIC_LOOP_ARTIFACT_SCHEMA = 'homeboy/deterministic-loop-artifact/v1';
+const DETERMINISTIC_LOOP_DURABLE_STATE_SCHEMA = 'homeboy/deterministic-loop-durable-state/v1';
+const DETERMINISTIC_LOOP_CHECKPOINT_SCHEMA = 'homeboy/deterministic-loop-checkpoint/v1';
 
 function runDeterministicLoop(options = {}) {
   const loopId = options.loopId || options.loop_id || 'deterministic-loop';
@@ -96,6 +98,241 @@ function runDeterministicLoop(options = {}) {
     state,
     iterations,
   };
+}
+
+function createDurableDeterministicLoop(options = {}) {
+  const loopId = options.loopId || options.loop_id || 'deterministic-loop';
+  const submit = requiredFunction(options.submitIteration || options.submit_iteration || options.submit, 'submitIteration');
+  const poll = requiredFunction(options.pollIteration || options.poll_iteration || options.poll, 'pollIteration');
+  const buildIteration = options.buildIteration || options.build_iteration || defaultBuildIteration;
+  const reconcile = options.reconcile || defaultReconcile;
+  const shouldRetry = options.shouldRetry || options.should_retry || defaultShouldRetry;
+  const stopCriteria = options.stopCriteria || options.stop_criteria || options.shouldStop || options.should_stop || defaultStopCriteria;
+  const maxIterations = positiveInteger(options.maxIterations || options.max_iterations, 1);
+  const maxAttempts = positiveInteger(options.maxAttempts || options.max_attempts || options.retry?.max_attempts, 1);
+  const timeoutMs = nonNegativeInteger(options.timeoutMs || options.timeout_ms || options.timeout?.ms, 0);
+  const backoffMs = nonNegativeInteger(options.backoffMs || options.backoff_ms || options.backoff?.ms || options.retry?.backoff_ms, 0);
+  const now = typeof options.now === 'function' ? options.now : () => Date.now();
+  const initialState = clonePlainObject(options.state || options.initialState || options.initial_state || {});
+
+  return {
+    submitIteration(state = {}) {
+      return submitDurableIteration({
+        loopId,
+        state: normalizeDurableState(state, { loopId, initialState }),
+        submit,
+        buildIteration,
+        maxIterations,
+        maxAttempts,
+        timeoutMs,
+        now,
+      });
+    },
+    pollIteration(state = {}) {
+      return pollDurableIteration({
+        loopId,
+        state: normalizeDurableState(state, { loopId, initialState }),
+        submit,
+        poll,
+        reconcile,
+        shouldRetry,
+        stopCriteria,
+        maxIterations,
+        maxAttempts,
+        timeoutMs,
+        backoffMs,
+        now,
+      });
+    },
+    resume(state = {}) {
+      const durableState = normalizeDurableState(state, { loopId, initialState });
+      if (!durableState.current) {
+        return this.submitIteration(durableState);
+      }
+      return this.pollIteration(durableState);
+    },
+  };
+}
+
+function submitDurableIteration({ loopId, state, submit, buildIteration, maxIterations, maxAttempts, timeoutMs, now }) {
+  if (state.done) {
+    return state;
+  }
+  if (state.current) {
+    return state;
+  }
+  const iteration = state.iterations.length + 1;
+  if (iteration > maxIterations) {
+    return completeDurableState(state, 'failed', 'max_iterations_reached');
+  }
+  const attempt = 1;
+  const input = buildIteration({ loop_id: loopId, iteration, state: state.state, iterations: state.iterations });
+  const submitted = submit({ loop_id: loopId, iteration, attempt, input, state: state.state, iterations: state.iterations });
+  const submittedAt = now();
+  const current = {
+    loop_id: loopId,
+    iteration,
+    attempt,
+    input,
+    token: submitted?.token || submitted?.id || submitted?.job_id || '',
+    submitted,
+    submitted_at: submittedAt,
+    deadline_at: timeoutMs > 0 ? submittedAt + timeoutMs : 0,
+    max_attempts: maxAttempts,
+  };
+  return checkpointState({ ...state, current }, 'submitted', { iteration, attempt, token: current.token });
+}
+
+function pollDurableIteration({ loopId, state, submit, poll, reconcile, shouldRetry, stopCriteria, maxIterations, maxAttempts, timeoutMs, backoffMs, now }) {
+  if (state.done || !state.current) {
+    return state;
+  }
+  const current = state.current;
+  const polledAt = now();
+  const timedOut = current.deadline_at > 0 && polledAt >= current.deadline_at;
+  const pollResult = timedOut ? { status: 'timed_out', outcome: { status: 'failed', summary: 'Iteration timed out.' } } : poll({
+    loop_id: loopId,
+    iteration: current.iteration,
+    attempt: current.attempt,
+    input: current.input,
+    token: current.token,
+    submitted: current.submitted,
+    state: state.state,
+    iterations: state.iterations,
+  });
+  const pollStatus = pollResult?.status || pollResult?.state || '';
+  if (!timedOut && ['queued', 'running', 'pending', 'submitted'].includes(pollStatus)) {
+    return checkpointState(state, 'polled', { iteration: current.iteration, attempt: current.attempt, status: pollStatus });
+  }
+
+  const error = timedOut ? new Error('Iteration timed out.') : null;
+  const outcome = pollResult?.outcome || pollResult?.result || pollResult || errorOutcome(error);
+  const retry = current.attempt < maxAttempts && Boolean(shouldRetry({
+    loop_id: loopId,
+    iteration: current.iteration,
+    attempt: current.attempt,
+    input: current.input,
+    outcome,
+    error,
+    state: state.state,
+    iterations: state.iterations,
+  }));
+  if (retry) {
+    const nextAttempt = current.attempt + 1;
+    const submittedAt = polledAt + backoffMs;
+    const submitted = submit({
+      loop_id: loopId,
+      iteration: current.iteration,
+      attempt: nextAttempt,
+      input: current.input,
+      state: state.state,
+      iterations: state.iterations,
+      retry_after_ms: backoffMs,
+      previous_outcome: outcome,
+    });
+    const nextCurrent = {
+      ...current,
+      attempt: nextAttempt,
+      token: submitted?.token || submitted?.id || submitted?.job_id || '',
+      submitted,
+      submitted_at: submittedAt,
+      deadline_at: timeoutMs > 0 ? submittedAt + timeoutMs : 0,
+    };
+    return checkpointState({ ...state, current: nextCurrent }, 'retry_scheduled', { iteration: current.iteration, attempt: nextAttempt });
+  }
+
+  const artifacts = normalizeArtifactRecords(outcome?.artifacts || outcome?.metadata?.artifacts, { loopId, iteration: current.iteration });
+  const nextState = reconcile({
+    loop_id: loopId,
+    iteration: current.iteration,
+    attempt: current.attempt,
+    input: current.input,
+    outcome,
+    error,
+    artifacts,
+    state: state.state,
+    iterations: state.iterations,
+  });
+  const reconciledState = isPlainObject(nextState) ? nextState : state.state;
+  const stop = normalizeStopDecision(evaluateStopCriteria(stopCriteria, {
+    loop_id: loopId,
+    iteration: current.iteration,
+    attempt: current.attempt,
+    input: current.input,
+    outcome,
+    error,
+    artifacts,
+    state: reconciledState,
+    iterations: state.iterations,
+  }));
+  const record = {
+    schema: DETERMINISTIC_LOOP_ITERATION_SCHEMA,
+    loop_id: loopId,
+    iteration: current.iteration,
+    attempt: current.attempt,
+    input: current.input,
+    outcome,
+    artifacts,
+    state: reconciledState,
+    stop,
+  };
+  const nextDurableState = checkpointState({
+    ...state,
+    state: reconciledState,
+    current: null,
+    iterations: [...state.iterations, record],
+  }, 'completed', { iteration: current.iteration, attempt: current.attempt, artifacts });
+  if (stop.stop) {
+    return completeDurableState(nextDurableState, loopStatus(nextDurableState.iterations), stop.reason || 'stop_criteria_satisfied');
+  }
+  if (nextDurableState.iterations.length >= maxIterations) {
+    return completeDurableState(nextDurableState, loopStatus(nextDurableState.iterations), 'max_iterations_reached');
+  }
+  return nextDurableState;
+}
+
+function normalizeDurableState(value, context = {}) {
+  if (isPlainObject(value) && value.schema === DETERMINISTIC_LOOP_DURABLE_STATE_SCHEMA) {
+    return {
+      ...value,
+      loop_id: value.loop_id || context.loopId || context.loop_id || 'deterministic-loop',
+      state: clonePlainObject(value.state),
+      iterations: Array.isArray(value.iterations) ? value.iterations : [],
+      checkpoints: Array.isArray(value.checkpoints) ? value.checkpoints : [],
+      current: isPlainObject(value.current) ? value.current : null,
+      done: Boolean(value.done),
+    };
+  }
+  const input = isPlainObject(value) ? value : {};
+  return {
+    schema: DETERMINISTIC_LOOP_DURABLE_STATE_SCHEMA,
+    loop_id: context.loopId || context.loop_id || 'deterministic-loop',
+    status: 'running',
+    state: clonePlainObject(input.state || input.initialState || input.initial_state || (Object.keys(input).length > 0 ? input : context.initialState)),
+    iterations: Array.isArray(input.iterations) ? input.iterations : [],
+    checkpoints: Array.isArray(input.checkpoints) ? input.checkpoints : [],
+    current: isPlainObject(input.current) ? input.current : null,
+    done: Boolean(input.done),
+  };
+}
+
+function checkpointState(state, type, data = {}) {
+  const checkpoint = {
+    schema: DETERMINISTIC_LOOP_CHECKPOINT_SCHEMA,
+    loop_id: state.loop_id,
+    type,
+    sequence: state.checkpoints.length + 1,
+    iteration: data.iteration || state.current?.iteration || 0,
+    attempt: data.attempt || state.current?.attempt || 0,
+    token: data.token || state.current?.token || '',
+    artifacts: Array.isArray(data.artifacts) ? data.artifacts : [],
+    data,
+  };
+  return { ...state, checkpoints: [...state.checkpoints, checkpoint] };
+}
+
+function completeDurableState(state, status, reason) {
+  return checkpointState({ ...state, status, done: true, current: null, stop_reason: reason }, 'done', { reason });
 }
 
 function defaultBuildIteration({ state }) {
@@ -201,13 +438,21 @@ function positiveInteger(value, fallback) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function nonNegativeInteger(value, fallback) {
+  const parsed = Number.parseInt(value || '', 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
 function isPlainObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value);
 }
 
 module.exports = {
   DETERMINISTIC_LOOP_ARTIFACT_SCHEMA,
+  DETERMINISTIC_LOOP_CHECKPOINT_SCHEMA,
+  DETERMINISTIC_LOOP_DURABLE_STATE_SCHEMA,
   DETERMINISTIC_LOOP_ITERATION_SCHEMA,
   DETERMINISTIC_LOOP_RESULT_SCHEMA,
+  createDurableDeterministicLoop,
   runDeterministicLoop,
 };

--- a/runtime-agent-ci/tests/deterministic-loop-runner-durable.test.js
+++ b/runtime-agent-ci/tests/deterministic-loop-runner-durable.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+const {
+  DETERMINISTIC_LOOP_CHECKPOINT_SCHEMA,
+  DETERMINISTIC_LOOP_DURABLE_STATE_SCHEMA,
+  createDurableDeterministicLoop,
+} = require('../lib/deterministic-loop-runner');
+
+let now = 1000;
+const submissions = [];
+const pollStatuses = ['running', 'completed'];
+const loop = createDurableDeterministicLoop({
+  loopId: 'durable-fixture',
+  maxIterations: 2,
+  timeoutMs: 5000,
+  now: () => now,
+  state: { value: 0 },
+  buildIteration: ({ state }) => ({ next: state.value + 1 }),
+  submitIteration: ({ iteration, attempt, input }) => {
+    const token = `job-${iteration}-${attempt}`;
+    submissions.push({ iteration, attempt, input, token });
+    return { token };
+  },
+  pollIteration: ({ token }) => {
+    const status = pollStatuses.shift();
+    if (status === 'running') {
+      return { status };
+    }
+    return {
+      status,
+      outcome: {
+        status: 'succeeded',
+        metadata: { value: token === 'job-1-1' ? 1 : 2 },
+        artifacts: [{ id: `${token}-evidence`, path: `/artifacts/${token}.json` }],
+      },
+    };
+  },
+  reconcile: ({ outcome }) => ({ value: outcome.metadata.value }),
+  stopCriteria: ({ state }) => state.value === 2,
+});
+
+let state = loop.submitIteration({ value: 0 });
+assert.equal(state.schema, DETERMINISTIC_LOOP_DURABLE_STATE_SCHEMA);
+assert.equal(state.current.token, 'job-1-1');
+assert.equal(state.current.deadline_at, 6000);
+assert.equal(state.checkpoints[0].schema, DETERMINISTIC_LOOP_CHECKPOINT_SCHEMA);
+assert.equal(state.checkpoints[0].type, 'submitted');
+
+state = loop.pollIteration(state);
+assert.equal(state.current.token, 'job-1-1');
+assert.equal(state.iterations.length, 0);
+assert.equal(state.checkpoints.at(-1).type, 'polled');
+assert.equal(state.checkpoints.at(-1).data.status, 'running');
+
+state = loop.resume(state);
+assert.equal(state.current, null);
+assert.equal(state.state.value, 1);
+assert.equal(state.iterations.length, 1);
+assert.equal(state.iterations[0].artifacts[0].path, '/artifacts/job-1-1.json');
+assert.equal(state.checkpoints.at(-1).type, 'completed');
+
+state = loop.resume(state);
+assert.equal(state.current.token, 'job-2-1');
+assert.deepEqual(submissions.map((entry) => entry.token), ['job-1-1', 'job-2-1']);
+
+const retrySubmissions = [];
+const retryLoop = createDurableDeterministicLoop({
+  loopId: 'retry-fixture',
+  maxAttempts: 2,
+  backoffMs: 250,
+  now: () => now,
+  submitIteration: ({ iteration, attempt, retry_after_ms: retryAfterMs = 0 }) => {
+    const token = `retry-${iteration}-${attempt}`;
+    retrySubmissions.push({ token, retryAfterMs });
+    return { token };
+  },
+  pollIteration: () => ({ status: 'completed', outcome: { status: 'failed', summary: 'retry me' } }),
+  shouldRetry: ({ outcome }) => outcome.status === 'failed',
+});
+
+let retryState = retryLoop.submitIteration({});
+now = 2000;
+retryState = retryLoop.pollIteration(retryState);
+assert.equal(retryState.current.token, 'retry-1-2');
+assert.equal(retryState.current.submitted_at, 2250);
+assert.equal(retryState.checkpoints.at(-1).type, 'retry_scheduled');
+assert.deepEqual(retrySubmissions, [
+  { token: 'retry-1-1', retryAfterMs: 0 },
+  { token: 'retry-1-2', retryAfterMs: 250 },
+]);
+
+process.stdout.write('Durable deterministic loop resume and polling checks passed\n');


### PR DESCRIPTION
## Summary
- Add a generic durable deterministic loop interface with submitIteration, pollIteration, and resume(state).
- Track durable state, current iteration tokens, timeout/backoff/retry policy, and checkpoint/evidence records.
- Preserve the existing synchronous runDeterministicLoop behavior and exports while layering the durable adapter in the same module.
- Add behavior coverage for resume, polling state, artifact checkpoints, and retry backoff scheduling.

## Tests
- `node tests/deterministic-loop-runner-incubation-boundary.test.js && node tests/deterministic-loop-runner-durable.test.js && node tests/generic-agent-loop-runner.test.js && node tests/headless-deterministic-loop-runner.test.js`
- `for test_file in tests/*.test.js; do node "$test_file" || exit 1; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 / OpenCode
- **Used for:** Drafting and implementing the durable loop primitive interface, behavior tests, and PR description.
