### PR TITLE
Make WordPress agent contracts installable

### DIFF
--- a/wordpress/lib/agent-task-runner-contract.js
+++ b/wordpress/lib/agent-task-runner-contract.js
@@ -1,3 +1,114 @@
 'use strict';
 
-module.exports = require('../../runtime-agent-ci/lib/agent-task-runner-contract');
+const AGENT_TASK_RUNNER_SPEC_SCHEMA = 'homeboy/agent-task-runner-spec/v1';
+
+function agentTaskRunnerSpec(options = {}) {
+	const executorConfig = options.config || options.executorConfig || options.executor_config;
+	if (!executorConfig || typeof executorConfig !== 'object' || Array.isArray(executorConfig)) {
+		throw new Error('config is required.');
+	}
+
+	const backend = requiredString(options.backend, 'backend');
+	const runtime = options.runtime || options.runtimeId || options.runtime_id;
+	const taskTimeoutSeconds = options.taskTimeoutSeconds || options.task_timeout_seconds;
+	const timeoutMs = options.timeoutMs || options.timeout_ms || secondsToMs(taskTimeoutSeconds);
+	const maxRuntimeMs = options.maxRuntimeMs || options.max_runtime_ms;
+	const limits = stripUndefined({
+		...(options.limits || {}),
+		...(timeoutMs ? { timeout_ms: timeoutMs } : {}),
+		...(maxRuntimeMs ? { max_runtime_ms: maxRuntimeMs } : {}),
+		...(taskTimeoutSeconds ? { task_timeout_seconds: taskTimeoutSeconds } : {}),
+	});
+	const artifactDeclarations = normalizeArray(options.artifactDeclarations || options.artifact_declarations);
+	const expectedArtifacts = normalizeArray(options.expectedArtifacts || options.expected_artifacts);
+
+	const spec = stripUndefined({
+		schema: AGENT_TASK_RUNNER_SPEC_SCHEMA,
+		executor: stripUndefined({
+			backend,
+			...(runtime ? { runtime } : {}),
+			...(normalizeArray(options.secretEnv || options.secret_env).length > 0
+				? { secret_env: normalizeArray(options.secretEnv || options.secret_env) }
+				: {}),
+			config: executorConfig,
+		}),
+		limits,
+		artifact_declarations: artifactDeclarations,
+		expected_artifacts: expectedArtifacts,
+	});
+
+	validateAgentTaskRunnerSpec(spec);
+	return spec;
+}
+
+function agentTaskRequestFromRunnerSpec(options = {}) {
+	const runnerSpec = validateAgentTaskRunnerSpec(options.runnerSpec || options.runner_spec);
+	return stripUndefined({
+		executor: runnerSpec.executor,
+		limits: runnerSpec.limits,
+		artifact_declarations: runnerSpec.artifact_declarations,
+		expected_artifacts: runnerSpec.expected_artifacts,
+	});
+}
+
+function validateAgentTaskRunnerSpec(spec) {
+	if (!spec || typeof spec !== 'object' || Array.isArray(spec)) {
+		throw new Error('runner spec must be an object.');
+	}
+	if (spec.schema !== AGENT_TASK_RUNNER_SPEC_SCHEMA) {
+		throw new Error(`runner spec schema must be ${AGENT_TASK_RUNNER_SPEC_SCHEMA}.`);
+	}
+	if (!spec.executor || typeof spec.executor !== 'object' || Array.isArray(spec.executor)) {
+		throw new Error('runner spec executor is required.');
+	}
+	requiredString(spec.executor.backend, 'runner spec executor.backend');
+	if (spec.executor.runtime !== undefined) {
+		requiredString(spec.executor.runtime, 'runner spec executor.runtime');
+	}
+	if (!spec.executor.config || typeof spec.executor.config !== 'object' || Array.isArray(spec.executor.config)) {
+		throw new Error('runner spec executor.config is required.');
+	}
+	if (spec.executor.secret_env !== undefined && !Array.isArray(spec.executor.secret_env)) {
+		throw new Error('runner spec executor.secret_env must be an array.');
+	}
+	if (spec.limits !== undefined && (typeof spec.limits !== 'object' || Array.isArray(spec.limits))) {
+		throw new Error('runner spec limits must be an object.');
+	}
+	if (spec.expected_artifacts !== undefined && !Array.isArray(spec.expected_artifacts)) {
+		throw new Error('runner spec expected_artifacts must be an array.');
+	}
+	if (spec.artifact_declarations !== undefined && !Array.isArray(spec.artifact_declarations)) {
+		throw new Error('runner spec artifact_declarations must be an array.');
+	}
+	return spec;
+}
+
+function normalizeArray(value) {
+	return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function requiredString(value, name) {
+	if (typeof value !== 'string' || value.trim() === '') {
+		throw new Error(`${name} is required.`);
+	}
+	return value;
+}
+
+function stripUndefined(value) {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return value;
+	}
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function secondsToMs(value) {
+	const seconds = Number(value || 0);
+	return seconds > 0 ? seconds * 1000 : undefined;
+}
+
+module.exports = {
+	AGENT_TASK_RUNNER_SPEC_SCHEMA,
+	agentTaskRequestFromRunnerSpec,
+	agentTaskRunnerSpec,
+	validateAgentTaskRunnerSpec,
+};

--- a/wordpress/lib/generic-agent-task-plan.js
+++ b/wordpress/lib/generic-agent-task-plan.js
@@ -1,3 +1,93 @@
 'use strict';
 
-module.exports = require('../../runtime-agent-ci/lib/generic-agent-task-plan');
+const {
+	agentTaskRequestFromRunnerSpec,
+	agentTaskRunnerSpec,
+} = require('./agent-task-runner-contract');
+
+const GENERIC_AGENT_TASK_PLAN_SCHEMA = 'homeboy/agent-task-plan/v1';
+const GENERIC_AGENT_TASK_REQUEST_SCHEMA = 'homeboy/agent-task-request/v1';
+const GENERIC_RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
+
+function genericAgentTaskRunnerSpec(options = {}) {
+	const config = options.config || options.executorConfig || options.executor_config;
+	return agentTaskRunnerSpec({
+		backend: options.backend,
+		runtime: options.runtime || options.runtimeId || options.runtime_id,
+		config,
+		secret_env: normalizeArray(options.secretEnv || options.secret_env),
+		task_timeout_seconds: options.taskTimeoutSeconds || options.task_timeout_seconds,
+		artifact_declarations: options.artifactDeclarations || options.artifact_declarations,
+		limits: options.limits,
+		expected_artifacts: options.expectedArtifacts || options.expected_artifacts,
+	});
+}
+
+function genericAgentTaskRequest(options = {}) {
+	const taskId = requiredString(options.taskId || options.task_id, 'taskId');
+	const runnerRequest = agentTaskRequestFromRunnerSpec({
+		runnerSpec: options.runnerSpec || options.runner_spec || genericAgentTaskRunnerSpec(options),
+	});
+	const sourceRefs = options.sourceRefs || options.source_refs;
+	return stripUndefined({
+		schema: options.schema || GENERIC_AGENT_TASK_REQUEST_SCHEMA,
+		task_id: taskId,
+		group_key: options.groupKey || options.group_key,
+		parent_plan_id: options.parentPlanId || options.parent_plan_id,
+		cwd: options.cwd,
+		repo: options.repo,
+		workspace: options.workspace,
+		executor: runnerRequest.executor,
+		goal: options.goal,
+		instructions: options.instructions,
+		inputs: options.inputs,
+		source_refs: sourceRefs === undefined ? undefined : normalizeArray(sourceRefs),
+		policy: options.policy,
+		limits: runnerRequest.limits,
+		artifact_declarations: options.includeArtifactDeclarations === false ? undefined : runnerRequest.artifact_declarations,
+		expected_artifacts: runnerRequest.expected_artifacts,
+		metadata: options.metadata,
+	});
+}
+
+function genericAgentTaskPlan(options = {}) {
+	const planId = requiredString(options.planId || options.plan_id, 'planId');
+	const tasks = normalizeArray(options.tasks);
+	if (tasks.length === 0) {
+		throw new Error('tasks must contain at least one task request.');
+	}
+	return stripUndefined({
+		schema: options.schema || GENERIC_AGENT_TASK_PLAN_SCHEMA,
+		plan_id: planId,
+		tasks,
+		options: options.options,
+		metadata: options.metadata,
+	});
+}
+
+function normalizeArray(value) {
+	return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function requiredString(value, name) {
+	if (typeof value !== 'string' || value.trim() === '') {
+		throw new Error(`${name} is required.`);
+	}
+	return value;
+}
+
+function stripUndefined(value) {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return value;
+	}
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+module.exports = {
+	GENERIC_AGENT_TASK_PLAN_SCHEMA,
+	GENERIC_AGENT_TASK_REQUEST_SCHEMA,
+	GENERIC_RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA,
+	genericAgentTaskPlan,
+	genericAgentTaskRequest,
+	genericAgentTaskRunnerSpec,
+};

--- a/wordpress/tests/generic-agent-contract-reexport-boundary.test.js
+++ b/wordpress/tests/generic-agent-contract-reexport-boundary.test.js
@@ -1,26 +1,34 @@
 'use strict';
 
-/**
- * External dependencies
- */
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const reexportOnlyModules = new Map([
-	[
-		'agent-task-runner-contract.js',
-		"'use strict';\n\nmodule.exports = require('../../runtime-agent-ci/lib/agent-task-runner-contract');\n",
-	],
-	[
-		'generic-agent-task-plan.js',
-		"'use strict';\n\nmodule.exports = require('../../runtime-agent-ci/lib/generic-agent-task-plan');\n",
-	],
-]);
+const installableModules = [
+	'agent-task-runner-contract.js',
+	'generic-agent-task-plan.js',
+];
 
-for (const [fileName, expectedSource] of reexportOnlyModules) {
+for (const fileName of installableModules) {
 	const source = fs.readFileSync(path.join(__dirname, '..', 'lib', fileName), 'utf8');
-	assert.equal(source, expectedSource, `${fileName} must stay a runtime-agent-ci re-export.`);
+	assert.equal(
+		source.includes('runtime-agent-ci'),
+		false,
+		`${fileName} must be installable with the WordPress extension without runtime-agent-ci`,
+	);
 }
 
-process.stdout.write('Generic agent contract re-export boundary passed\n');
+const { agentTaskRunnerSpec } = require('../lib/agent-task-runner-contract');
+const { genericAgentTaskRequest } = require('../lib/generic-agent-task-plan');
+
+assert.equal(agentTaskRunnerSpec({ backend: 'codebox', config: { runtime_task: {} } }).executor.backend, 'codebox');
+assert.equal(
+	genericAgentTaskRequest({
+		taskId: 'installable-task',
+		backend: 'codebox',
+		config: { runtime_task: {} },
+	}).task_id,
+	'installable-task',
+);
+
+process.stdout.write('Generic agent contract install boundary passed\n');


### PR DESCRIPTION
## Summary
- make the WordPress extension generic agent task contract modules self-contained
- remove runtime dependency on sibling `runtime-agent-ci` files from installed WordPress extension layout
- update the boundary test to enforce installability without `runtime-agent-ci`

## Verification
- `node tests/generic-agent-contract-reexport-boundary.test.js`
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wp-codebox-fuzz-suite`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the installed extension module resolution failure and drafting the packaging fix/tests.