### PR TITLE
Project fuzz plan cases into Codebox

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -165,7 +165,94 @@ function normalizeWpCodeboxFuzzSuiteCases(source = {}) {
 	if (source.schema !== HOMEBOY_FUZZ_WORKLOAD_SCHEMA) {
 		return directCases;
 	}
+	const planCases = homeboyFuzzWorkloadPlanCases(source);
+	if (planCases.length > 0) {
+		return planCases.map((entry, index) => homeboyFuzzWorkloadPlanCaseToWpCodeboxCase(entry, source, index));
+	}
 	return directCases.map((entry, index) => homeboyFuzzWorkloadCaseToWpCodeboxCase(entry, source, index));
+}
+
+function homeboyFuzzWorkloadPlanCases(manifest = {}) {
+	return normalizeArray(manifest.plan?.targets).flatMap((target) => (
+		normalizeArray(target?.cases).map((testCase) => ({
+			...testCase,
+			target_id: target.id,
+			surface_id: target.surface_id || target.surfaceId,
+			target_metadata: objectOrUndefined(target.metadata),
+		}))
+	));
+}
+
+function homeboyFuzzWorkloadPlanCaseToWpCodeboxCase(entry = {}, manifest = {}, index = 0) {
+	const caseId = entry.case_id || entry.caseId || entry.id || `${manifest.id || 'fuzz-workload'}:${index}`;
+	const artifacts = normalizeHomeboyFuzzCaseArtifacts(entry, manifest);
+	const command = entry.command || entry.target?.entrypoint || entry.target?.id;
+	return stripUndefined({
+		id: caseId,
+		case_id: caseId,
+		target: { kind: 'runtime', id: command, entrypoint: command },
+		description: entry.description || manifest.label,
+		input: objectOrUndefined(entry.input),
+		phases: homeboyFuzzWorkloadPlanCasePhases(entry, manifest, artifacts),
+		artifacts,
+		metadata: stripUndefined({
+			...(objectOrUndefined(entry.metadata) || {}),
+			source_schema: HOMEBOY_FUZZ_WORKLOAD_SCHEMA,
+			source_manifest_id: manifest.id,
+			source_plan_case: true,
+			target_id: entry.target_id,
+			surface_id: entry.surface_id,
+			target_metadata: objectOrUndefined(entry.target_metadata),
+		}),
+	});
+}
+
+function homeboyFuzzWorkloadPlanCasePhases(entry = {}, manifest = {}, artifacts = []) {
+	if (objectOrUndefined(entry.phases)) {
+		return entry.phases;
+	}
+	const activation = manifest.metadata?.fixture?.activation || firstHomeboyFuzzWorkloadActivation(manifest);
+	const setup = typeof activation === 'string' && activation.trim() !== ''
+		? [{ command: 'wordpress.ensure-plugin-active', args: [`plugin=${activation}`] }]
+		: undefined;
+	const command = entry.command || entry.target?.entrypoint || entry.target?.id;
+	const action = typeof command === 'string' && command.trim() !== ''
+		? [{ command, args: homeboyFuzzCommandArgs(entry.input) }]
+		: [];
+	const assert = artifacts
+		.map((artifact) => artifact.name)
+		.filter(Boolean)
+		.map((artifact) => ({ command: 'wordpress.collect-workload-result', args: [`artifact=${artifact}`] }));
+	return stripUndefined({ setup, action, assert: assert.length > 0 ? assert : undefined });
+}
+
+function homeboyFuzzCommandArgs(input) {
+	const object = objectOrUndefined(input);
+	if (!object) {
+		return [];
+	}
+	return Object.entries(object).flatMap(([key, value]) => {
+		if (value === undefined || value === null) {
+			return [];
+		}
+		if (Array.isArray(value)) {
+			return [`${key}=${value.join(',')}`];
+		}
+		if (typeof value === 'object') {
+			return [`${key}=${JSON.stringify(value)}`];
+		}
+		return [`${key}=${value}`];
+	});
+}
+
+function firstHomeboyFuzzWorkloadActivation(manifest = {}) {
+	for (const entry of normalizeArray(manifest.cases)) {
+		const activation = entry?.intent?.plugin?.activation;
+		if (typeof activation === 'string' && activation.trim() !== '') {
+			return activation;
+		}
+	}
+	return undefined;
 }
 
 function homeboyFuzzWorkloadCaseToWpCodeboxCase(entry = {}, manifest = {}, index = 0) {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -157,6 +157,56 @@ assert.equal(jsonWorkloadInput.cases[0].artifacts[0].required, true);
 assert.equal(jsonWorkloadInput.cases[0].artifacts[0].metadata.semantic_key, 'fuzz.suite_result');
 assert.equal(jsonWorkloadInput.metadata.artifacts.expected[0].required, true);
 
+const planWorkloadManifest = {
+	schema: 'homeboy/fuzz-workload/v1',
+	id: 'plan-workload-smoke',
+	label: 'Plan workload smoke',
+	target: { type: 'wordpress-plugin', slug: 'sample-plugin', component: 'sample-plugin' },
+	metadata: {
+		fixture: { component: 'sample-plugin', activation: 'sample-plugin/sample-plugin.php' },
+	},
+	plan: {
+		schema: 'wordpress-fuzz-plan/v1',
+		id: 'plan-workload-smoke',
+		targets: [{
+			id: 'sample-rest-routes',
+			surface_id: 'sample-rest-routes',
+			cases: [{
+				id: 'plan-workload-smoke:default',
+				command: 'wordpress.inventory-rest-routes',
+				input: {
+					plugin: 'sample-plugin/sample-plugin.php',
+					namespaces: ['sample/v1', 'sample/v2'],
+					artifact: 'route_inventory',
+				},
+				metadata: { expected_artifact: 'route_inventory' },
+			}],
+		}],
+	},
+	artifacts: {
+		expected: [{ name: 'route_inventory', role: 'fuzz_report', semantic_key: 'fuzz.report', required: true }],
+	},
+	cases: [{
+		case_id: 'legacy-intent-should-not-win',
+		intent: {
+			plugin: { activation: 'sample-plugin/sample-plugin.php' },
+			execute: { path: '/host-only/workload.php', type: 'php' },
+		},
+	}],
+};
+const planWorkloadInput = wpCodeboxFuzzSuiteInput({ id: 'plan-workload-run', homeboyFuzzWorkload: planWorkloadManifest });
+assert.equal(planWorkloadInput.cases.length, 1);
+assert.equal(planWorkloadInput.cases[0].id, 'plan-workload-smoke:default');
+assert.equal(planWorkloadInput.cases[0].target.entrypoint, 'wordpress.inventory-rest-routes');
+assert.deepEqual(planWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.ensure-plugin-active', args: ['plugin=sample-plugin/sample-plugin.php'] }]);
+assert.deepEqual(planWorkloadInput.cases[0].phases.action, [{
+	command: 'wordpress.inventory-rest-routes',
+	args: ['plugin=sample-plugin/sample-plugin.php', 'namespaces=sample/v1,sample/v2', 'artifact=route_inventory'],
+}]);
+assert.equal(JSON.stringify(planWorkloadInput).includes('/host-only/workload.php'), false);
+assert.equal(planWorkloadInput.cases[0].metadata.source_plan_case, true);
+assert.equal(planWorkloadInput.cases[0].metadata.target_id, 'sample-rest-routes');
+
 let invoked = false;
 runWpCodeboxFuzzSuite({
 	taskId: 'wp-codebox-fuzz-suite-delegation-smoke',


### PR DESCRIPTION
## Summary
- prefer `homeboy/fuzz-workload/v1` plan target cases when projecting WP Codebox fuzz suites
- convert generic primitive command inputs into runtime command args
- avoid falling back to host-only PHP workload paths when a concrete fuzz plan exists

## Verification
- `npm run test:wp-codebox-fuzz-suite`
- `npm run test:wordpress-fuzz-runner`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the host-only workload path projection and drafting the generic plan-case projection/tests.