### PR TITLE
Project generic fuzz primitives into Codebox

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -260,10 +260,11 @@ function homeboyFuzzWorkloadCaseToWpCodeboxCase(entry = {}, manifest = {}, index
 	const intent = objectOrUndefined(entry.intent) || {};
 	const execute = objectOrUndefined(intent.execute) || {};
 	const artifacts = normalizeHomeboyFuzzCaseArtifacts(entry, manifest);
+	const command = homeboyFuzzWorkloadGenericPrimitiveCommand(manifest) || 'wordpress.run-workload';
 	return stripUndefined({
 		id: caseId,
 		case_id: caseId,
-		target: { kind: 'runtime', id: 'wordpress.run-workload', entrypoint: 'wordpress.run-workload' },
+		target: { kind: 'runtime', id: command, entrypoint: command },
 		description: entry.description || manifest.label,
 		input: stripUndefined({
 			path: execute.path || manifest.workload?.path,
@@ -289,18 +290,26 @@ function homeboyFuzzWorkloadCasePhases(entry = {}, manifest = {}, intent = {}, a
 	const execute = objectOrUndefined(intent.execute) || {};
 	const activation = intent.plugin?.activation;
 	const path = execute.path || manifest.workload?.path;
+	const genericCommand = homeboyFuzzWorkloadGenericPrimitiveCommand(manifest);
 	const setup = typeof activation === 'string' && activation.trim() !== ''
 		? [{ command: 'wordpress.ensure-plugin-active', args: [`plugin=${activation}`] }]
 		: undefined;
-	const action = typeof path === 'string' && path.trim() !== ''
-		? [{ command: 'wordpress.run-workload', args: [`path=${path}`] }]
-		: [];
+	const action = typeof genericCommand === 'string'
+		? [{ command: genericCommand, args: homeboyFuzzCommandArgs(objectOrUndefined(execute.parameters) || {}) }]
+		: typeof path === 'string' && path.trim() !== ''
+			? [{ command: 'wordpress.run-workload', args: [`path=${path}`] }]
+			: [];
 	const collect = normalizeArray(intent.collect).length > 0 ? normalizeArray(intent.collect) : artifacts.map((artifact) => ({ artifact: artifact.name }));
 	const assert = collect
 		.map((item) => item?.artifact)
 		.filter(Boolean)
 		.map((artifact) => ({ command: 'wordpress.collect-workload-result', args: [`artifact=${artifact}`] }));
 	return stripUndefined({ setup, action, assert: assert.length > 0 ? assert : undefined });
+}
+
+function homeboyFuzzWorkloadGenericPrimitiveCommand(manifest = {}) {
+	const command = manifest.metadata?.generic_primitive?.command || manifest.metadata?.genericPrimitive?.command;
+	return typeof command === 'string' && command.trim() !== '' ? command.trim() : undefined;
 }
 
 function normalizeHomeboyFuzzCaseArtifacts(entry = {}, manifest = {}) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -184,6 +184,44 @@ assert.equal(
 	'/runner/components/sample-plugin'
 );
 
+const genericPrimitiveResult = buildWordPressFuzzRunnerResult({
+	env: {
+		workloadPath: '/unused/in-unit-test.json',
+		runId: 'generic-primitive-run',
+		rigId: 'sample-rig',
+		runtimeContext: {
+			components: {
+				'sample-plugin': { path: '/runner/components/sample-plugin' },
+			},
+		},
+	},
+	workload: {
+		schema: 'homeboy/fuzz-workload/v1',
+		id: 'generic-primitive-workload',
+		label: 'Generic primitive workload',
+		metadata: {
+			generic_primitive: { command: 'wordpress.fuzz-admin-pages', status: 'preferred' },
+		},
+		target: { type: 'wordpress-plugin', slug: 'sample-plugin', component: 'sample-plugin' },
+		workload: {
+			runner: 'wp-codebox',
+			type: 'php',
+			path: '${package.root}/bench/admin-page-coverage.php',
+			entry: 'admin-page-coverage',
+		},
+		cases: [{
+			case_id: 'generic-primitive-workload:default',
+			artifacts: [{ name: 'admin_page_coverage', path: 'admin-page-coverage/admin_page_coverage.json', required: true }],
+			intent: {
+				plugin: { activation: 'sample-plugin/sample-plugin.php' },
+				execute: { path: '${package.root}/bench/admin-page-coverage.php', type: 'php', parameters: { safe_methods: 'GET', max_pages: '80' } },
+				collect: [{ artifact: 'admin_page_coverage' }],
+			},
+		}],
+	},
+});
+assert.deepEqual(genericPrimitiveResult.wp_codebox_input.cases[0].phases.action, [{ command: 'wordpress.fuzz-admin-pages', args: ['safe_methods=GET', 'max_pages=80'] }]);
+
 let dispatchedRequest;
 const dispatchPromise = runWordPressFuzzRunnerResult({
 	env: {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -157,6 +157,41 @@ assert.equal(jsonWorkloadInput.cases[0].artifacts[0].required, true);
 assert.equal(jsonWorkloadInput.cases[0].artifacts[0].metadata.semantic_key, 'fuzz.suite_result');
 assert.equal(jsonWorkloadInput.metadata.artifacts.expected[0].required, true);
 
+const genericPrimitiveManifest = {
+	schema: 'homeboy/fuzz-workload/v1',
+	id: 'generic-primitive-smoke',
+	label: 'Generic primitive smoke',
+	metadata: {
+		generic_primitive: { command: 'wordpress.fuzz-admin-pages', status: 'preferred' },
+	},
+	workload: {
+		runner: 'wp-codebox',
+		type: 'php',
+		path: '${package.root}/bench/admin-page-coverage.php',
+		entry: 'admin-page-coverage',
+	},
+	cases: [{
+		case_id: 'generic-primitive-smoke:default',
+		artifacts: [{ name: 'admin_page_coverage', path: 'admin-page-coverage/admin_page_coverage.json', required: true }],
+		intent: {
+			schema: 'homeboy/fuzz-workload-intent/v1',
+			type: 'wordpress-plugin-workload',
+			plugin: { activation: 'sample-plugin/sample-plugin.php' },
+			execute: {
+				path: '${package.root}/bench/admin-page-coverage.php',
+				type: 'php',
+				parameters: { safe_methods: 'GET', max_pages: '80', enumerate_menus: 'true' },
+			},
+			collect: [{ artifact: 'admin_page_coverage' }],
+		},
+	}],
+};
+const genericPrimitiveInput = wpCodeboxFuzzSuiteInput({ id: 'generic-primitive-run', homeboyFuzzWorkload: genericPrimitiveManifest });
+assert.equal(genericPrimitiveInput.cases[0].target.entrypoint, 'wordpress.fuzz-admin-pages');
+assert.deepEqual(genericPrimitiveInput.cases[0].phases.setup, [{ command: 'wordpress.ensure-plugin-active', args: ['plugin=sample-plugin/sample-plugin.php'] }]);
+assert.deepEqual(genericPrimitiveInput.cases[0].phases.action, [{ command: 'wordpress.fuzz-admin-pages', args: ['safe_methods=GET', 'max_pages=80', 'enumerate_menus=true'] }]);
+assert.deepEqual(genericPrimitiveInput.cases[0].phases.assert, [{ command: 'wordpress.collect-workload-result', args: ['artifact=admin_page_coverage'] }]);
+
 const planWorkloadManifest = {
 	schema: 'homeboy/fuzz-workload/v1',
 	id: 'plan-workload-smoke',


### PR DESCRIPTION
## Summary
- prefer homeboy/fuzz-workload metadata.generic_primitive.command when projecting cases into WP Codebox
- map intent execute parameters into primitive command args
- preserve wordpress.run-workload projection for workloads without a declared generic primitive
- cover both lower-level Codebox input projection and WordPress fuzz runner output

## Tests
- npm run test:wp-codebox-fuzz-suite
- npm run test:wordpress-fuzz-runner
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Implementing generic primitive projection, updating smoke tests, and running verification.