### PR TITLE
Honor WordPress release package settings

### DIFF
--- a/wordpress/scripts/release/package.sh
+++ b/wordpress/scripts/release/package.sh
@@ -19,10 +19,8 @@ set -euo pipefail
 #
 # Optional:
 #   HOMEBOY_SETTINGS_JSON  - JSON payload from homeboy with release.version,
-#                            release.tag, and release.component_id. Not parsed
-#                            here because build.sh derives names from
-#                            HOMEBOY_COMPONENT_ID and plugin/theme headers
-#                            directly. The publish step consumes the tag.
+#                            release.tag, release.component_id, and any dynamic
+#                            settings. Invalid or missing JSON is treated as {}.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EXTENSION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -37,6 +35,22 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "Error: jq is required to emit release artifact JSON" >&2
   exit 1
 fi
+
+COMPONENT_SETTINGS_JSON="{}"
+if [[ -f homeboy.json ]]; then
+  COMPONENT_SETTINGS_JSON="$(jq -c '.extensions.wordpress.settings // {} | if type == "object" then . else {} end' homeboy.json 2>/dev/null || printf '{}')"
+fi
+
+SETTINGS_JSON="$(jq -cn \
+  --argjson component "${COMPONENT_SETTINGS_JSON}" \
+  --arg payload "${HOMEBOY_SETTINGS_JSON:-}" \
+  '
+    def object_or_empty($value):
+      try ($value | fromjson | if type == "object" then . else {} end) catch {};
+
+    $component + object_or_empty($payload)
+  ')"
+export HOMEBOY_SETTINGS_JSON="${SETTINGS_JSON}"
 
 # Resolve the component slug the way build.sh does (so the ZIP path matches).
 COMPONENT_SLUG="${HOMEBOY_COMPONENT_ID:-}"
@@ -85,9 +99,7 @@ echo "Built ${ARTIFACT_PATH}" >&2
 # this action; standalone dry-runs fall back to the on-disk header so the
 # check still validates build output against source.
 EXPECTED_VERSION=""
-if [[ -n "${HOMEBOY_SETTINGS_JSON:-}" ]]; then
-  EXPECTED_VERSION="$(echo "${HOMEBOY_SETTINGS_JSON}" | jq -r '.release.version // empty')"
-fi
+EXPECTED_VERSION="$(echo "${HOMEBOY_SETTINGS_JSON}" | jq -r '.release.version // empty')"
 if [[ -z "${EXPECTED_VERSION}" ]]; then
   for candidate in *.php; do
     [[ -f "${candidate}" ]] || continue

--- a/wordpress/tests/release-scripts-smoke.sh
+++ b/wordpress/tests/release-scripts-smoke.sh
@@ -69,10 +69,24 @@ STUB_GH
 chmod +x "${STUB_BIN_DIR}/gh"
 
 # ---------------------------------------------------------------------------
-# package.sh: emits artifact JSON when build/<slug>.zip exists.
+# package.sh: emits artifact JSON and forwards component WordPress settings
+# when build/<slug>.zip exists.
 # ---------------------------------------------------------------------------
 mkdir -p build
 echo "fake-zip-bytes" > build/test-plugin.zip
+cat > homeboy.json <<'JSON'
+{
+  "id": "test-plugin",
+  "extensions": {
+    "wordpress": {
+      "settings": {
+        "build_nested_packages": false,
+        "package_artifacts": ["runtime/packages/*.zip"]
+      }
+    }
+  }
+}
+JSON
 
 # Replace the real build script with a no-op so we don't actually run the
 # WordPress build harness (which needs composer, node, plugin headers, …).
@@ -81,6 +95,10 @@ trap 'rm -rf "${WORK_DIR}" "${PACKAGE_SCRIPT_DIR}"' EXIT
 mkdir -p "${PACKAGE_SCRIPT_DIR}/scripts/build" "${PACKAGE_SCRIPT_DIR}/scripts/release"
 cat > "${PACKAGE_SCRIPT_DIR}/scripts/build/build.sh" <<'STUB'
 #!/usr/bin/env bash
+if ! printf '%s' "${HOMEBOY_SETTINGS_JSON:-}" | jq -e '.build_nested_packages == false' >/dev/null; then
+  echo "stub build did not receive build_nested_packages=false: ${HOMEBOY_SETTINGS_JSON:-}" >&2
+  exit 1
+fi
 echo "stub build" >&2
 STUB
 chmod +x "${PACKAGE_SCRIPT_DIR}/scripts/build/build.sh"
@@ -100,6 +118,21 @@ elif ! echo "${stub_output}" | jq -e '.[0].type == "wordpress-zip"' >/dev/null 2
   failures=$((failures + 1))
 else
   echo "OK: package.sh emits expected artifact JSON"
+fi
+
+set +e
+invalid_settings_output="$(HOMEBOY_COMPONENT_ID=test-plugin HOMEBOY_SETTINGS_JSON='not json' "${PACKAGE_SCRIPT_DIR}/scripts/release/package.sh" 2>/dev/null)"
+invalid_settings_status=$?
+set -e
+
+if [[ ${invalid_settings_status} -ne 0 ]]; then
+  echo "FAIL: package.sh did not fall back safely for invalid HOMEBOY_SETTINGS_JSON" >&2
+  failures=$((failures + 1))
+elif ! echo "${invalid_settings_output}" | jq -e '.[0].path == "build/test-plugin.zip"' >/dev/null 2>&1; then
+  echo "FAIL: package.sh invalid-settings fallback produced unexpected JSON; got: ${invalid_settings_output}" >&2
+  failures=$((failures + 1))
+else
+  echo "OK: package.sh falls back safely for invalid HOMEBOY_SETTINGS_JSON"
 fi
 
 # ---------------------------------------------------------------------------
@@ -170,7 +203,7 @@ mkdir -p "${HAPPY_DIR}/build"
 python3 -c "
 import zipfile
 with zipfile.ZipFile('${HAPPY_DIR}/build/happy-plugin.zip', 'w') as z:
-  z.writestr('happy-plugin/happy-plugin.php', '<?php // happy plugin')
+  z.writestr('happy-plugin/happy-plugin.php', '<?php\n/**\n * Plugin Name: Happy Plugin\n * Version: 1.0.0\n */')
   z.writestr('happy-plugin/readme.txt', 'happy plugin readme')
 "
 
@@ -219,7 +252,7 @@ JSON
 python3 -c "
 import zipfile
 with zipfile.ZipFile('${BRANCH_DIR}/build/happy-plugin.zip', 'w') as z:
-  z.writestr('happy-plugin/happy-plugin.php', '<?php // happy plugin')
+  z.writestr('happy-plugin/happy-plugin.php', '<?php\n/**\n * Plugin Name: Happy Plugin\n * Version: 1.0.0\n */')
   z.writestr('happy-plugin/readme.txt', 'happy plugin readme')
 "
 


### PR DESCRIPTION
## Summary
- Merge component `extensions.wordpress.settings` from `homeboy.json` into `HOMEBOY_SETTINGS_JSON` before WordPress release packaging invokes the shared build script.
- Treat absent or invalid `HOMEBOY_SETTINGS_JSON` as `{}` so release packaging still runs safely.
- Cover `build_nested_packages: false` propagation in the WordPress release smoke test.

Fixes #1765

## Verification
- `bash -n wordpress/scripts/release/package.sh wordpress/tests/release-scripts-smoke.sh`
- `bash wordpress/tests/release-scripts-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode subagent
- **Used for:** Implementation and PR drafting.