### PR TITLE
Normalize fuzz error statuses

### DIFF
--- a/wordpress/lib/wordpress-fuzz-schemas.js
+++ b/wordpress/lib/wordpress-fuzz-schemas.js
@@ -357,7 +357,11 @@ function normalizeCaseStatus(status, budgetFindings) {
 	if (budgetFindings.length > 0 && (!status || status === 'passed')) {
 		return 'failed';
 	}
-	return status || 'errored';
+	return normalizeFuzzStatus(status || 'errored');
+}
+
+function normalizeFuzzStatus(status) {
+	return 'error' === status ? 'errored' : status;
 }
 
 function findingToDiagnostic(finding) {
@@ -440,7 +444,7 @@ function normalizeWordPressFuzzResult(result) {
 		budget_failure_count: countBudgetFindings(cases) + resultBudgetFindings.length,
 		...(result.summary || {}),
 	};
-	const status = result.status || (summary.failed || summary.errored || summary.budget_failure_count ? 'failed' : 'passed');
+	const status = normalizeFuzzStatus(result.status || (summary.failed || summary.errored || summary.budget_failure_count ? 'failed' : 'passed'));
 	if (!RESULT_STATUSES.has(status)) {
 		throw new Error(`Unsupported WordPress fuzz result status: ${status}`);
 	}

--- a/wordpress/tests/wordpress-fuzz-schemas-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-schemas-smoke.js
@@ -169,6 +169,15 @@ assert.deepEqual(failingBudgetResult.findings.map((finding) => finding.code), [
 assert.equal(failingBudgetResult.diagnostics[0].severity, 'failure');
 assert.equal(failingBudgetResult.summary.performance_metrics.query_count, 5);
 
+const errorStatusResult = normalizeWordPressFuzzResult({
+	schema: WORDPRESS_FUZZ_RESULT_SCHEMA,
+	status: 'error',
+	cases: [{ id: 'error-case', status: 'error' }],
+});
+
+assert.equal(errorStatusResult.status, 'errored');
+assert.equal(errorStatusResult.cases[0].status, 'errored');
+
 assert.throws(() => normalizeWordPressSurfaceDiscovery({ schema: 'other/v1' }), /Unsupported/);
 assert.throws(() => normalizeWordPressSurfaceDiscovery({ surfaces: [{ type: 'woocommerce-product' }] }), /Unsupported WordPress surface type/);
 assert.throws(() => normalizeWordPressFuzzResult({ cases: [{ status: 'unknown' }] }), /Unsupported WordPress fuzz case status/);


### PR DESCRIPTION
## Summary
- normalize WP Codebox case/result status `error` to WordPress fuzz contract status `errored`
- preserve errored case diagnostics instead of throwing during result normalization
- cover result-level and case-level error status normalization

## Tests
- npm run test:wordpress-fuzz-schemas
- npm run test:wp-codebox-fuzz-suite
- npm run test:wordpress-fuzz-runner
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Implementing status normalization, adding schema coverage, and running verification.