### PR TITLE
Forward Agents API runtime requirements to Codebox

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -688,7 +688,7 @@ function componentContractsFromAgentTaskRequest(request, config, options = {}) {
 
 function codeboxRuntimeRequirementsFromAgentTaskRequest(config, options = {}, defaults = {}, componentContracts = [], runtimeOverlays = []) {
   const runtimeProfile = firstObject(options.runtimeProfile) || {};
-  const runtimeRequirements = firstObject(config.runtime_requirements, config.runtimeRequirements) || {};
+  const runtimeRequirements = mergeRuntimeRequirements(defaults.runtimeRequirements, firstObject(config.runtime_requirements, config.runtimeRequirements) || {});
   const runtimeEnv = firstNonEmptyObject(config.runtime_env, config.runtimeEnv, config.wp_codebox_runtime_env, runtimeRequirements.env, runtimeRequirements.runtime_env, runtimeProfile.env, runtimeProfile.runtime_env, options.runtimeEnv, defaults.runtimeEnv) || {};
   const providerPluginPaths = firstNonEmptyArray(
     config.provider_plugin_paths,
@@ -708,6 +708,41 @@ function codeboxRuntimeRequirementsFromAgentTaskRequest(config, options = {}, de
     runtimeConfigMounts: firstDefined(config.runtime_config_mounts, config.runtimeConfigMounts, config.wp_codebox_runtime_config_mounts, runtimeRequirements.runtime_config_mounts, runtimeProfile.runtime_config_mounts, options.runtimeConfigMounts, defaults.runtimeConfigMounts),
     normalizeRuntimeProfile: options.normalizeRuntimeProfile,
     normalizeRuntimeProfilePayload: options.normalizeRuntimeProfilePayload,
+  });
+}
+
+function mergeRuntimeRequirements(...requirements) {
+  const normalized = requirements.filter((requirement) => requirement && typeof requirement === 'object' && !Array.isArray(requirement));
+  if (normalized.length === 0) {
+    return {};
+  }
+  return {
+    ...Object.assign({}, ...normalized),
+    ability_requirements: uniqueStrings(normalized.flatMap((requirement) => normalizeArray(requirement.ability_requirements || requirement.abilityRequirements))),
+    component_contracts: uniqueRuntimeRequirementObjects(normalized.flatMap((requirement) => normalizeArray(requirement.component_contracts))),
+    extra_plugins: uniqueRuntimeRequirementObjects(normalized.flatMap((requirement) => normalizeArray(requirement.extra_plugins))),
+    components: uniqueRuntimeRequirementObjects(normalized.flatMap((requirement) => normalizeArray(requirement.components))),
+    mu_plugins: uniqueRuntimeRequirementObjects(normalized.flatMap((requirement) => normalizeArray(requirement.mu_plugins))),
+    plugins: uniqueRuntimeRequirementObjects(normalized.flatMap((requirement) => normalizeArray(requirement.plugins))),
+    runtime_overlays: uniqueRuntimeRequirementObjects(normalized.flatMap((requirement) => normalizeArray(requirement.runtime_overlays))),
+  };
+}
+
+function uniqueRuntimeRequirementObjects(entries) {
+  const seen = new Set();
+  return normalizeArray(entries).filter((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return false;
+    }
+    const key = [entry.slug, entry.id, entry.path || entry.source || entry.target, entry.kind, entry.type].filter(Boolean).join(':');
+    if (!key) {
+      return true;
+    }
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
   });
 }
 
@@ -1191,6 +1226,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
   const providerConfig = providerConfigFor(provider, settings, providerDefaults);
   const model = config.model || options.model || defaultModelForProvider(provider, settings, providerConfig);
   const phpAiClientPath = defaultPhpAiClientPath(settings, options);
+  const agentsApiPath = defaultAgentsApiPath(settings, options, agentRuntimePath);
 
   return {
     agentRuntime: agentRuntimePath,
@@ -1204,6 +1240,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     wpCodeboxBin: wpCodeboxBin({ settings, executable: '' }),
     runtimeOverlayProfiles: defaultRuntimeOverlayProfiles(settings),
     runtimeOverlays: defaultRuntimeOverlays(settings, phpAiClientPath),
+    runtimeRequirements: defaultRuntimeRequirements(agentsApiPath),
     runtimeEnv: defaultRuntimeEnv(settings),
     runtimeStateMounts: defaultRuntimeStateMounts(settings),
     runtimeConfigMounts: defaultRuntimeConfigMounts(settings),
@@ -1245,6 +1282,45 @@ function defaultRuntimeOverlays(settings, phpAiClientPath = '') {
     strategy: 'wordpress-scoped-bundle',
     metadata: { component: 'php-ai-client', source: 'homeboy-extensions-default' },
   }] : [];
+}
+
+function defaultRuntimeRequirements(agentsApiPath = '') {
+  if (!agentsApiPath) {
+    return {};
+  }
+  return {
+    ability_requirements: ['agents/chat'],
+    component_contracts: [{
+      slug: 'agents-api',
+      path: agentsApiPath,
+      pluginFile: 'agents-api/agents-api.php',
+      loadAs: 'mu-plugin',
+      activate: false,
+      metadata: { source: 'homeboy-extensions-codebox-runtime-default' },
+    }],
+  };
+}
+
+function defaultAgentsApiPath(settings, options = {}, agentRuntimePath = '') {
+  return firstExistingPath(
+    options.agentsApi,
+    options.agents_api,
+    settings.wp_codebox_agents_api_path,
+    settings.agents_api_path,
+    process.env.HOMEBOY_WP_CODEBOX_AGENTS_API_PATH,
+    process.env.WP_CODEBOX_AGENTS_API_PATH,
+    ...bundledAgentsApiPaths(agentRuntimePath),
+  );
+}
+
+function bundledAgentsApiPaths(agentRuntimePath = '') {
+  if (!agentRuntimePath) {
+    return [];
+  }
+  return [
+    path.join(agentRuntimePath, 'vendor', 'wordpress', 'agents-api'),
+    path.join(agentRuntimePath, 'vendor', 'automattic', 'agents-api'),
+  ];
 }
 
 function defaultPhpAiClientPath(settings, options = {}) {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1144,6 +1144,28 @@ try {
   assert(!JSON.stringify(defaultedRequest).includes(staleStandaloneAgentsApiPath));
   assert(!JSON.stringify(defaultedRequest).includes(alternateBundledAgentsApiPath));
 
+  const bundledAgentsApiRequest = codeboxTaskRequestFromAgentTaskRequest({
+    ...request,
+    task_id: 'bundled-agents-api-runtime-task-123',
+    executor: {
+      backend: 'codebox',
+      config: exampleAgentCiCodeboxExecutorConfig({ provider: 'codex' }),
+    },
+    inputs: {
+      target: { root: workspaceRoot },
+    },
+  }, {
+    agentRuntime: runtimePath,
+    settings: {},
+  });
+  const bundledAgentsApiContract = bundledAgentsApiRequest.runtime_requirements.component_contracts.find((contract) => contract.slug === 'agents-api');
+  assert.equal(bundledAgentsApiContract.path, bundledAgentsApiPath);
+  assert.equal(bundledAgentsApiContract.pluginFile, 'agents-api/agents-api.php');
+  assert.equal(bundledAgentsApiContract.loadAs, 'mu-plugin');
+  assert.equal(bundledAgentsApiContract.activate, false);
+  assert.deepEqual(bundledAgentsApiRequest.runtime_requirements.ability_requirements, ['agents/chat']);
+  assert.equal(bundledAgentsApiRequest.component_contracts.some((contract) => contract.slug === 'agents-api'), true);
+
   const configuredDefaultProviderRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,
     task_id: 'configured-provider-default-task-123',


### PR DESCRIPTION
## Summary
- Resolve an Agents API component path from runtime settings, env, or bundled runtime contents.
- Forward that component as a Codebox runtime requirement with the canonical agents/chat ability requirement.
- Add smoke coverage proving Codebox task input includes the Agents API component contract and ability requirement.

## Verification
- HOMEBOY_WP_CODEBOX_CORE_MODULE=tests/fixtures/wp-codebox-core-runtime-contract.cjs node tests/wp-codebox-bundled-agents-api-smoke.mjs
- node tests/wp-codebox-runtime-profile-defaults-smoke.mjs
- npm run test:wp-codebox-runtime-contract-source
- npm run test:wp-codebox-adapter-contract

Note: The broader codebox-agent-task-executor smoke currently requires an external @automattic/wp-codebox-core runtime contract module in this fresh worktree; with the fixture it reaches a pre-existing provider_runtime_invocation fixture mismatch unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigating the upstream runtime composition path, implementing the fix, and drafting focused coverage.