### PR TITLE
Declare WP Codebox runner source

### DIFF
--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -212,6 +212,16 @@
           "remediation": "Install WP Codebox or set the generic runtime_bin executor config; HOMEBOY_WP_CODEBOX_BIN remains a legacy compatibility env alias."
         }
       ],
+      "runner_sources": [
+        {
+          "id": "wp-codebox.source",
+          "label": "WP Codebox source cache",
+          "path": "~/.cache/homeboy/wp-codebox/source",
+          "remote_url": "https://github.com/Automattic/wp-codebox.git",
+          "git_ref": "main",
+          "remediation": "Refresh the managed WP Codebox source cache before dispatching WP Codebox-backed runner workloads."
+        }
+      ],
       "workspace_tools": {
         "readonly": [
           "workspace_ls",


### PR DESCRIPTION
## Summary
- Declare the WP Codebox managed runner source cache in the WP Codebox runtime manifest.
- Point Homeboy at the cache path, canonical remote, and main ref so Lab dispatch can refresh it before WP Codebox-backed workloads.

Fixes #1772.

## Testing
- node -e "JSON.parse(require('fs').readFileSync('agent-runtimes/wp-codebox/wp-codebox.json','utf8')); console.log('json ok')"
- git diff --check

Blocked local smoke:
- npm run test:codebox-agent-task-executor
- Blocked by missing local WP Codebox core module / HOMEBOY_WP_CODEBOX_CORE_MODULE in this fresh worktree; not caused by this manifest-only change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the missing managed-source declaration and adding the runtime manifest contract.