### PR TITLE
Keep Codebox runtime substrate internal

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -72,6 +72,7 @@ const RUNTIME_MANIFEST_PATH = path.resolve(__dirname, '..', 'wp-codebox.json');
 const RUNTIME_OVERLAY_CANONICAL_SHAPE = 'runtime_overlays entries must be objects. WP Codebox owns the runtime overlay schema and reports field-level validation.';
 const RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
 const PROVIDER_CAPABILITIES = runtimeProviderCapabilities();
+const WP_CODEBOX_OWNED_SUBSTRATE_SLUGS = new Set(['agents-api', 'data-machine', 'data-machine-code']);
 
 const AGENT_BUNDLE_CONFIG_FIELDS = [
   'bundle_path',
@@ -348,13 +349,15 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
   const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
   const runtimeOverlays = runtimeOverlaysFromConfig(config, runtimeOptions, defaults);
-  const runtimeRequirements = codeboxRuntimeRequirementsFromAgentTaskRequest(config, runtimeOptions, defaults, componentContracts, runtimeOverlays);
+  const runtimeRequirements = codeboxRuntimeRequirementsWithoutCodeboxOwnedSubstrate(
+    codeboxRuntimeRequirementsFromAgentTaskRequest(config, runtimeOptions, defaults, componentContracts, runtimeOverlays)
+  );
   componentContracts = codeboxRuntimeComponentContracts({
     componentContracts: [
       ...componentContracts,
       ...normalizeArray(runtimeRequirements.component_contracts),
     ],
-  });
+  }).filter((contract) => !isCodeboxOwnedSubstrateContract(contract));
   components = runtimeComponentPaths(config, { ...defaults, ...runtimeOptions, componentContracts });
   const context = {
     ...(inputs.context || {}),
@@ -683,7 +686,7 @@ function componentContractsFromAgentTaskRequest(request, config, options = {}) {
       ...normalizeArray(config.component_contracts),
       ...normalizeArray(options.componentContracts),
     ],
-  });
+  }).filter((contract) => !isCodeboxOwnedSubstrateContract(contract));
 }
 
 function codeboxRuntimeRequirementsFromAgentTaskRequest(config, options = {}, defaults = {}, componentContracts = [], runtimeOverlays = []) {
@@ -1226,8 +1229,6 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
   const providerConfig = providerConfigFor(provider, settings, providerDefaults);
   const model = config.model || options.model || defaultModelForProvider(provider, settings, providerConfig);
   const phpAiClientPath = defaultPhpAiClientPath(settings, options);
-  const agentsApiPath = defaultAgentsApiPath(settings, options, agentRuntimePath);
-  const chatHandlerPluginContracts = defaultChatHandlerPluginContracts(settings, options, providerConfig);
 
   return {
     agentRuntime: agentRuntimePath,
@@ -1241,7 +1242,7 @@ function defaultCodeboxRuntimeConfig(request, config, inputs, options = {}) {
     wpCodeboxBin: wpCodeboxBin({ settings, executable: '' }),
     runtimeOverlayProfiles: defaultRuntimeOverlayProfiles(settings),
     runtimeOverlays: defaultRuntimeOverlays(settings, phpAiClientPath),
-    runtimeRequirements: defaultRuntimeRequirements(agentsApiPath, chatHandlerPluginContracts),
+    runtimeRequirements: defaultRuntimeRequirements(),
     runtimeEnv: defaultRuntimeEnv(settings),
     runtimeStateMounts: defaultRuntimeStateMounts(settings),
     runtimeConfigMounts: defaultRuntimeConfigMounts(settings),
@@ -1285,24 +1286,25 @@ function defaultRuntimeOverlays(settings, phpAiClientPath = '') {
   }] : [];
 }
 
-function defaultRuntimeRequirements(agentsApiPath = '', chatHandlerPluginContracts = []) {
-  const componentContracts = [
-    ...(agentsApiPath ? [{
-      slug: 'agents-api',
-      path: agentsApiPath,
-      pluginFile: 'agents-api/agents-api.php',
-      loadAs: 'mu-plugin',
-      activate: false,
-      metadata: { source: 'homeboy-extensions-codebox-runtime-default' },
-    }] : []),
-    ...normalizeArray(chatHandlerPluginContracts),
-  ];
-  if (componentContracts.length === 0) {
-    return {};
-  }
+function defaultRuntimeRequirements() {
   return {
     ability_requirements: ['agents/chat'],
-    component_contracts: componentContracts,
+  };
+}
+
+function isCodeboxOwnedSubstrateContract(contract) {
+  const slug = typeof contract?.slug === 'string' ? contract.slug.trim() : '';
+  return WP_CODEBOX_OWNED_SUBSTRATE_SLUGS.has(slug);
+}
+
+function codeboxRuntimeRequirementsWithoutCodeboxOwnedSubstrate(runtimeRequirements = {}) {
+  if (!runtimeRequirements || typeof runtimeRequirements !== 'object' || Array.isArray(runtimeRequirements)) {
+    return runtimeRequirements;
+  }
+  return {
+    ...runtimeRequirements,
+    component_contracts: normalizeArray(runtimeRequirements.component_contracts).filter((contract) => !isCodeboxOwnedSubstrateContract(contract)),
+    extra_plugins: normalizeArray(runtimeRequirements.extra_plugins).filter((contract) => !isCodeboxOwnedSubstrateContract(contract)),
   };
 }
 

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -1767,7 +1767,7 @@ function defaultWorkspaceMounts(workspaceRoot, request, config, inputs, options)
       source: workspaceRoot,
       target: workspaceTarget,
       mode: workspaceMode(request, config, inputs),
-      metadata: { kind: WP_CODEBOX_WORKSPACE_MOUNT_KIND, workspace_slug: workspaceSlug(workspaceRoot) },
+      metadata: { kind: WP_CODEBOX_WORKSPACE_MOUNT_KIND, workspace_slug: workspaceSlug(workspaceRoot), workspaceRef: path.basename(workspaceRoot) },
     },
   ];
 }

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -2064,6 +2064,9 @@ function normalizeStatus(result, exitStatus = 0) {
   if (result?.outcome === 'no_op' || result?.no_op) {
     return 'no_op';
   }
+  if (agentRuntimeSucceeded(result)) {
+    return 'succeeded';
+  }
   return (publicEnvelope?.success ?? result?.success) === true ? 'succeeded' : 'failed';
 }
 
@@ -2122,11 +2125,22 @@ function agentRuntimeFailure(result) {
   return agentRuntimeResultCandidates(result).find(agentRuntimeCandidateFailed) || null;
 }
 
+function agentRuntimeSucceeded(result) {
+  return agentRuntimeResultCandidates(result).some(agentRuntimeCandidateSucceeded);
+}
+
+function agentRuntimeCandidateSucceeded(candidate) {
+  const runtime = candidate.agent_runtime || candidate.agentRuntime;
+  return runtime && typeof runtime === 'object' && !Array.isArray(runtime) && runtime.success === true;
+}
+
 function agentRuntimeCandidateFailed(candidate) {
+  const runtime = candidate.agent_runtime || candidate.agentRuntime;
   const terminalStatus = String(candidate.terminal_status || candidate.terminalStatus || '').toLowerCase();
   const status = String(candidate.status || candidate.outcome || '').toLowerCase();
   const completionStatus = String(candidate.completion_outcome?.status || candidate.completionOutcome?.status || '').toLowerCase();
   return candidate.success === false
+    || runtime?.success === false
     || candidate.completion_outcome?.success === false
     || candidate.completionOutcome?.success === false
     || terminalStatus === 'failed'

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -38,6 +38,7 @@ const {
 } = require('../../lib/codebox-run-agent-task-contract');
 
 const CODEX_OAUTH_TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const WP_CODEBOX_OWNED_SUBSTRATE_SLUGS = new Set(['agents-api', 'data-machine', 'data-machine-code']);
 const CODEX_OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 
 function argValue(name) {
@@ -1193,7 +1194,7 @@ function runnerInput(request, artifacts) {
     artifacts_path: artifacts,
     wp_codebox_bin: argValue('--wp-codebox-bin') || request.wp_codebox_bin || '',
     runtime_component_paths: runtimeComponentPaths,
-    component_contracts: uniqueComponentContracts(requestComponentContracts(request).map(remapRuntimeComponentContract)),
+    component_contracts: uniqueComponentContracts(requestComponentContracts(request).map(remapRuntimeComponentContract).filter((contract) => !isCodeboxOwnedSubstrateContract(contract))),
     homeboy_path: argValue('--homeboy') || request.homeboy_path || request.homeboy || '',
     homeboy_extensions_path: argValue('--homeboy-extensions') || request.homeboy_extensions_path || request.homeboy_extensions || path.resolve(__dirname, '..', '..'),
     wp_version: request.wordpress_runtime_version || request.wordpress_version || request.wp_codebox_wordpress_version || request.wp_version || request.wp || undefined,
@@ -1244,7 +1245,12 @@ function componentContracts(input) {
     ...requestComponentContracts(input.parent_request).map(remapRuntimeComponentContract),
     ...requestComponentContracts(input.parent_request?.parent_request).map(remapRuntimeComponentContract),
     ...runtimeContracts,
-  ]);
+  ].filter((contract) => !isCodeboxOwnedSubstrateContract(contract)));
+}
+
+function isCodeboxOwnedSubstrateContract(contract) {
+  const slug = typeof contract?.slug === 'string' ? contract.slug.trim() : '';
+  return WP_CODEBOX_OWNED_SUBSTRATE_SLUGS.has(slug);
 }
 
 function requestComponentContracts(request) {

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -792,7 +792,9 @@ assert.deepEqual(legacyClientContextTaskInput.runtime_task.input, {
   dry_run: false,
 });
 
-const repoLoopWorkspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wordpress-repo-loop-workspace-'));
+const repoLoopWorkspaceBase = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wordpress-repo-loop-workspace-'));
+const repoLoopWorkspaceRoot = path.join(repoLoopWorkspaceBase, 'wp-site-generator@wpsg-lab-proof-20260622-2102');
+fs.mkdirSync(repoLoopWorkspaceRoot, { recursive: true });
 const repoLoopWorkspaceTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'repo-loop-workspace-task-1',
@@ -816,11 +818,12 @@ const repoLoopWorkspaceMount = repoLoopWorkspaceTaskInput.mounts.find(
 );
 assert(repoLoopWorkspaceMount, 'repo-loop cwd is translated into a Codebox workspace mount');
 assert.equal(repoLoopWorkspaceMount.source, repoLoopWorkspaceRoot);
-assert.equal(repoLoopWorkspaceMount.target, `/workspace/${path.basename(repoLoopWorkspaceRoot)}`);
+assert.equal(repoLoopWorkspaceMount.target, '/workspace/wp-site-generator');
 assert.equal(repoLoopWorkspaceMount.mode, 'readwrite');
 assert.deepEqual(repoLoopWorkspaceMount.metadata, {
   kind: 'homeboy-runtime-workspace',
-  workspace_slug: path.basename(repoLoopWorkspaceRoot),
+  workspace_slug: 'wp-site-generator',
+  workspaceRef: 'wp-site-generator@wpsg-lab-proof-20260622-2102',
 });
 assert.equal(repoLoopWorkspaceTaskInput.allowed_tools.includes('workspace_apply_patch'), true);
 assert.deepEqual(repoLoopWorkspaceTaskInput.workspace_materialization, {

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1159,13 +1159,9 @@ try {
     agentRuntime: runtimePath,
     settings: {},
   });
-  const bundledAgentsApiContract = bundledAgentsApiRequest.runtime_requirements.component_contracts.find((contract) => contract.slug === 'agents-api');
-  assert.equal(bundledAgentsApiContract.path, bundledAgentsApiPath);
-  assert.equal(bundledAgentsApiContract.pluginFile, 'agents-api/agents-api.php');
-  assert.equal(bundledAgentsApiContract.loadAs, 'mu-plugin');
-  assert.equal(bundledAgentsApiContract.activate, false);
+  assert.equal(bundledAgentsApiRequest.runtime_requirements.component_contracts.some((contract) => contract.slug === 'agents-api'), false);
   assert.deepEqual(bundledAgentsApiRequest.runtime_requirements.ability_requirements, ['agents/chat']);
-  assert.equal(bundledAgentsApiRequest.component_contracts.some((contract) => contract.slug === 'agents-api'), true);
+  assert.equal(bundledAgentsApiRequest.component_contracts.some((contract) => contract.slug === 'agents-api'), false);
 
   const chatHandlerRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,
@@ -1183,14 +1179,8 @@ try {
       wp_codebox_chat_handler_plugin_paths: [dataMachinePath],
     },
   });
-  const chatHandlerContract = chatHandlerRequest.runtime_requirements.component_contracts.find((contract) => contract.slug === 'data-machine');
-  assert.equal(chatHandlerContract.path, dataMachinePath);
-  assert.equal(chatHandlerContract.pluginFile, 'data-machine/data-machine.php');
-  assert.equal(chatHandlerContract.loadAs, 'plugin');
-  assert.equal(chatHandlerContract.activate, true);
-  assert.deepEqual(chatHandlerContract.metadata.registers, ['wp_agent_chat_handler']);
-  assert.deepEqual(chatHandlerRequest.runtime_requirements.component_contracts.map((contract) => contract.slug), ['agents-api', 'data-machine']);
-  assert.deepEqual(chatHandlerRequest.component_contracts.map((contract) => contract.slug), ['agents-api', 'data-machine']);
+  assert.deepEqual(chatHandlerRequest.runtime_requirements.component_contracts.map((contract) => contract.slug), []);
+  assert.deepEqual(chatHandlerRequest.component_contracts.map((contract) => contract.slug), []);
   assert.deepEqual(chatHandlerRequest.runtime_requirements.ability_requirements, ['agents/chat']);
 
   const configuredDefaultProviderRequest = codeboxTaskRequestFromAgentTaskRequest({

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -1964,6 +1964,30 @@ assert.equal(outputRuntimeFailureMetadataOutcome.status, 'failed');
 assert.equal(outputRuntimeFailureMetadataOutcome.diagnostics[0].class, 'agent_runtime.failed');
 assert.equal(outputRuntimeFailureMetadataOutcome.diagnostics[0].data.reason, 'provider_auth_failed');
 
+const outputAgentRuntimeSuccessOutcome = agentTaskOutcomeFromCodeboxResult(request, {
+  success: true,
+  schema: 'wp-codebox/agent-task-run/v1',
+  status: 'completed',
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: {
+      outputs: {
+        agent_runtime: {
+          success: true,
+          result: {
+            reply: 'Static site candidate produced.',
+            messages: [],
+            run_id: 'dm-chat-run-1',
+          },
+        },
+      },
+    },
+  },
+});
+assert.equal(outputAgentRuntimeSuccessOutcome.status, 'succeeded');
+assert.equal(outputAgentRuntimeSuccessOutcome.failure_classification, undefined);
+
 const outputAgentRuntimeFailureWithoutTypedArtifactsOutcome = agentTaskOutcomeFromCodeboxResult(request, {
   success: true,
   schema: 'wp-codebox/agent-task-run/v1',

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -872,7 +872,7 @@ try {
   const preparedLabRuntime = path.join(labRuntimeArtifacts, 'prepared-plugins', 'example-runtime');
   assert.equal(labRuntimeInput.runtime_component_paths.agent_runtime, preparedLabRuntime);
   assert.equal(labRuntimeInput.extra_plugins.some((plugin) => plugin.slug === 'agents-api'), false);
-  assert.equal(labRuntimeInput.component_contracts.find((contract) => contract.slug === 'agents-api').path, path.join(labRuntimeArtifacts, 'prepared-plugins', 'agents-api'));
+  assert.equal((labRuntimeInput.component_contracts || []).some((contract) => contract.slug === 'agents-api'), false);
   assert.equal(fs.existsSync(path.join(preparedLabRuntime, 'example-runtime.php')), true);
 
   const runtimeComponentSource = path.join(root, 'runtime-components', 'example-runtime-tools');


### PR DESCRIPTION
## Summary
- stop default HBE Codebox runtime requirements from injecting substrate plugins
- filter Codebox-owned substrate component contracts from executor and task-runner inputs
- preserve non-substrate domain component contracts while requesting the canonical agents/chat ability
- preserve the full workspaceRef on Codebox workspace mounts while keeping stable /workspace/<repo> targets
- treat successful embedded agent_runtime payloads as successful Codebox task outcomes

## Testing
- `git diff --check`
- `HOMEBOY_WP_CODEBOX_CORE_MODULE=... node - <<'NODE' ...` focused substrate-boundary assertion
- `HOMEBOY_WP_CODEBOX_CORE_MODULE=... node - <<'NODE' ...` focused workspaceRef assertion
- `HOMEBOY_WP_CODEBOX_CORE_MODULE=... node - <<'NODE' ...` focused embedded agent_runtime success assertion
- `HOMEBOY_WP_CODEBOX_CORE_MODULE=... node wordpress/tests/wp-codebox-task-runner-smoke.js` progressed past substrate assertions, then hit an unrelated existing agent-bundle fixture assertion at `agentBundleOutput.run.agentResult.scenarios`
- `HOMEBOY_WP_CODEBOX_CORE_MODULE=... node wordpress/tests/codebox-agent-task-executor-smoke.js` currently hits an existing descriptor snapshot mismatch against the newer WP Codebox core contract before the added regression assertion

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Codebox runtime substrate, workspace identity, and embedded runtime result boundaries; drafting the implementation; updating assertions; and running focused verification.