### PR TITLE
Clean PHPUnit cache after WP Codebox tests

### DIFF
--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -141,6 +141,7 @@ if [ -n "$component_path" ]; then
         exit 1
     fi
     printf 'ALL TESTS PASSED\nTESTS: 1 FAILURES: 0 ERRORS: 0\n' > "${component_path}/.pg-test-result.txt"
+    printf '{}\n' > "${component_path}/.phpunit.result.cache"
 fi
 printf '{"success":true,"executions":[{"stdout":"OK (1 test, 1 assertion)\n","stderr":""}]}\n'
 SH
@@ -338,6 +339,10 @@ assert_contains "${TMPDIR}/wp-codebox-args.txt" "wordpress.phpunit"
 assert_contains "${TMPDIR}/wp-codebox-args.txt" "autoload-file=/wp-codebox-vendor/autoload.php"
 assert_not_contains "${TMPDIR}/wp-codebox-args.txt" "6.9"
 assert_contains "${TMPDIR}/wp-codebox-args.txt" '"target": "/wordpress/wp-content/plugins/component"'
+if [ -e "${component}/.phpunit.result.cache" ]; then
+    echo "Expected WP Codebox runner to clean PHPUnit result cache" >&2
+    exit 1
+fi
 
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -784,7 +784,14 @@ if [ -n "$DEPENDENCY_PATHS" ]; then
 fi
 
 RESULT_FILE="${PLUGIN_PATH}/.pg-test-result.txt"
-rm -f "$RESULT_FILE"
+PHPUNIT_RESULT_CACHE_FILE="${PLUGIN_PATH}/.phpunit.result.cache"
+
+cleanup_wp_codebox_phpunit_runtime_files() {
+    rm -f "$RESULT_FILE" "$PHPUNIT_RESULT_CACHE_FILE"
+}
+
+trap cleanup_wp_codebox_phpunit_runtime_files EXIT
+cleanup_wp_codebox_phpunit_runtime_files
 
 ARTIFACTS_DIR="${HOMEBOY_WP_CODEBOX_ARTIFACTS_DIR:-}"
 if [ -z "$ARTIFACTS_DIR" ] && [ -n "${HOMEBOY_SETTINGS_JSON:-}" ] && [ "${HOMEBOY_SETTINGS_JSON}" != "{}" ]; then


### PR DESCRIPTION
## Summary
- Clean the PHPUnit result cache alongside the WP Codebox structured test result file.
- Add smoke coverage proving the runner removes the cache artifact after a WP Codebox PHPUnit run.

## Testing
- HOMEBOY_CORE_DIR=/Users/chubes/Developer/homeboy HOMEBOY_RUNTIME_RUNNER_PRELUDE=/Users/chubes/.config/homeboy/runtime/runner-prelude.sh HOMEBOY_RUNTIME_RESOLVE_CONTEXT=/Users/chubes/.config/homeboy/runtime/resolve-context.sh HOMEBOY_RUNTIME_RUNNER_STEPS=/Users/chubes/.config/homeboy/runtime/runner-steps.sh bash wordpress/scripts/test/test-runner-file-routing-smoke.sh
- bash -n wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/scripts/test/test-runner-file-routing-smoke.sh
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed release artifact cleanup failure, implemented runner cleanup, added smoke coverage, and prepared PR.