### PR TITLE
Read embedded fuzz result artifacts

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -592,7 +592,10 @@ function normalizeWpCodeboxFuzzArtifacts(source = {}, result = {}) {
 	appendNamedArtifact(artifacts, 'fuzz_report', source?.fuzz_report || source?.fuzzReport || source?.report || source?.summary_report || source?.summaryReport);
 	appendNamedArtifact(artifacts, 'coverage', source?.coverage_artifact || source?.coverageArtifact || source?.wordpress_fuzz_coverage || source?.wordpressFuzzCoverage);
 	appendNamedArtifact(artifacts, 'normalized_fuzz_result', source?.wordpress_fuzz_result_artifact || source?.wordpressFuzzResultArtifact || source?.normalized_fuzz_result || source?.normalizedFuzzResult);
+	appendArtifactCandidates(artifacts, source?.wordpress_fuzz_result?.artifacts || source?.wordpressFuzzResult?.artifacts);
+	appendArtifactCandidates(artifacts, source?.wordpress_fuzz_result?.artifactRefs || source?.wordpress_fuzz_result?.artifact_refs || source?.wordpressFuzzResult?.artifactRefs || source?.wordpressFuzzResult?.artifact_refs);
 	appendCaseArtifacts(artifacts, source?.cases || source?.fuzz_cases || source?.fuzzCases, 'fuzz_case');
+	appendCaseArtifacts(artifacts, source?.wordpress_fuzz_result?.cases || source?.wordpressFuzzResult?.cases, 'fuzz_case');
 	appendCaseArtifacts(artifacts, source?.failures || source?.errors || source?.failed_cases || source?.failedCases, 'failing_case');
 	appendCaseArtifacts(artifacts, source?.repro_cases || source?.reproCases || source?.reproductions, 'repro_case');
 	return dedupeArtifacts(artifacts.map(normalizeFuzzArtifact).filter(Boolean));

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -364,6 +364,25 @@ runWpCodeboxFuzzSuite({
 	});
 	assert.equal(nested.succeeded, true);
 	assert.equal(nested.metadata.suite.id, 'nested-suite');
+	const embeddedArtifactOnly = normalizeWpCodeboxFuzzSuiteResult({
+		json: {
+			schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+			status: 'passed',
+			suite: { id: 'embedded-artifact-suite' },
+			summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
+			wordpress_fuzz_result: {
+				schema: 'wordpress-fuzz-result/v1',
+				status: 'passed',
+				cases: [{
+					id: 'case-with-artifact-ref',
+					status: 'passed',
+					artifactRefs: [{ name: 'case_report', path: 'case/report.json', kind: 'fuzz_report', contentType: 'application/json' }],
+				}],
+			},
+		},
+	}, { request: taskRequest });
+	assert.equal(embeddedArtifactOnly.succeeded, true);
+	assert.equal(embeddedArtifactOnly.artifacts[0].path, 'case/report.json');
 	const doubleNested = normalizeWpCodeboxFuzzRunResult({
 		json: {
 			schema: 'wp-codebox/agent-task-run/v1',


### PR DESCRIPTION
## Summary
- include embedded WordPress fuzz result artifacts when normalizing WP Codebox fuzz-suite results
- preserve case-level artifactRefs returned under wordpress_fuzz_result.cases
- add smoke coverage for the embedded artifact-only result shape

## Verification
- `node wordpress/tests/wp-codebox-fuzz-run-smoke.js`
- `node wordpress/tests/wordpress-fuzz-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the fuzz artifact normalization gap, implementing the normalization change, and drafting focused verification.