### PR TITLE
Prefer explicit fuzz artifact roles

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -650,7 +650,7 @@ function normalizeFuzzArtifact(artifact) {
 		return null;
 	}
 	const name = artifact.name || artifact.id || artifact.key || artifact.role || artifact.type || artifact.kind;
-	const role = normalizeFuzzArtifactRole(artifact.role || artifact.artifact_role || artifact.artifactRole || name || artifact.path || artifact.url || artifact.file);
+	const role = normalizeFuzzArtifactRole(artifact.role || artifact.artifact_role || artifact.artifactRole || artifact.kind || artifact.type || name || artifact.path || artifact.url || artifact.file);
 	if (!role) {
 		return null;
 	}

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -383,6 +383,8 @@ runWpCodeboxFuzzSuite({
 	}, { request: taskRequest });
 	assert.equal(embeddedArtifactOnly.succeeded, true);
 	assert.equal(embeddedArtifactOnly.artifacts[0].path, 'case/report.json');
+	assert.equal(embeddedArtifactOnly.artifacts[0].role, 'fuzz_report');
+	assert.equal(embeddedArtifactOnly.artifacts[0].name, 'case_report');
 	const doubleNested = normalizeWpCodeboxFuzzRunResult({
 		json: {
 			schema: 'wp-codebox/agent-task-run/v1',


### PR DESCRIPTION
## Summary
- classify fuzz artifacts from explicit role/kind/type before opaque artifact names
- preserve named artifacts such as external_http_guardrail when kind=fuzz_report
- extend smoke coverage for embedded case artifact refs

## Verification
- `node wordpress/tests/wp-codebox-fuzz-run-smoke.js`
- `node wordpress/tests/wordpress-fuzz-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing artifact role normalization, implementing the role priority fix, and drafting focused verification.