### PR TITLE
Extract fuzz contract builders

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -206,9 +206,16 @@ function buildCodeboxPlanRecipe(workload) {
 }
 
 function wpCodeboxRuntimeRequirementsFromWorkload(workload = {}, options = {}) {
+	return buildWpCodeboxFuzzRuntimeRequirements({
+		workload,
+		env: options.env,
+	});
+}
+
+function buildWpCodeboxFuzzRuntimeRequirements({ workload = {}, env = {} } = {}) {
 	const context = objectOrUndefined(workload.metadata?.homeboy_runtime_context || workload.metadata?.homeboyRuntimeContext);
 	const components = objectOrUndefined(context?.components);
-	const workloadRoot = nonEmptyString(options.env?.wpCodeboxFuzzWorkloadRoot || options.env?.WP_CODEBOX_FUZZ_WORKLOAD_ROOT);
+	const workloadRoot = nonEmptyString(env?.wpCodeboxFuzzWorkloadRoot || env?.WP_CODEBOX_FUZZ_WORKLOAD_ROOT);
 	const componentId = workload.target?.component
 		|| workload.metadata?.fixture?.component
 		|| workload.metadata?.fixture?.plugin
@@ -219,9 +226,27 @@ function wpCodeboxRuntimeRequirementsFromWorkload(workload = {}, options = {}) {
 		return undefined;
 	}
 	const activation = workload.metadata?.fixture?.activation || firstCasePluginActivation(workload);
+	const pluginRequirement = buildWpCodeboxFuzzPluginRequirement({ workload, componentId, source, activation, context });
 	return {
-		extra_plugins: componentId && typeof source === 'string' && source.trim() !== '' ? [stripUndefined({
-			slug: workload.target?.slug || componentId,
+		extra_plugins: pluginRequirement ? [pluginRequirement.extraPlugin] : undefined,
+		component_contracts: pluginRequirement ? [pluginRequirement.componentContract] : undefined,
+		runtime_mounts: workloadRoot ? [{ source: workloadRoot, target: workloadRoot, mode: 'readonly' }] : undefined,
+		runtime_env: workloadRoot ? { WP_CODEBOX_FUZZ_WORKLOAD_ROOT: workloadRoot } : undefined,
+		metadata: stripUndefined({
+			homeboy_runtime_context_schema: context?.schema,
+			rig_id: context?.rig_id,
+		}),
+	};
+}
+
+function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, source, activation, context = {} } = {}) {
+	if (!componentId || typeof source !== 'string' || source.trim() === '') {
+		return undefined;
+	}
+	const slug = workload.target?.slug || componentId;
+	return {
+		extraPlugin: stripUndefined({
+			slug,
 			source,
 			path: source,
 			pluginFile: activation,
@@ -231,18 +256,12 @@ function wpCodeboxRuntimeRequirementsFromWorkload(workload = {}, options = {}) {
 				component: componentId,
 				rig_id: context.rig_id,
 			}),
-		})] : undefined,
-		component_contracts: componentId && typeof source === 'string' && source.trim() !== '' ? [stripUndefined({
-			slug: workload.target?.slug || componentId,
+		}),
+		componentContract: stripUndefined({
+			slug,
 			path: source,
 			pluginFile: activation,
 			loadAs: 'plugin',
-		})] : undefined,
-		runtime_mounts: workloadRoot ? [{ source: workloadRoot, target: workloadRoot, mode: 'readonly' }] : undefined,
-		runtime_env: workloadRoot ? { WP_CODEBOX_FUZZ_WORKLOAD_ROOT: workloadRoot } : undefined,
-		metadata: stripUndefined({
-			homeboy_runtime_context_schema: context?.schema,
-			rig_id: context?.rig_id,
 		}),
 	};
 }

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -585,20 +585,38 @@ function legacyWpCodeboxFuzzRunArtifactDeclarationsAlias() {
 
 function normalizeWpCodeboxFuzzArtifacts(source = {}, result = {}) {
 	const artifacts = [];
-	appendArtifactCandidates(artifacts, source?.artifacts);
-	appendArtifactCandidates(artifacts, source?.artifactRefs || source?.artifact_refs);
-	appendArtifactCandidates(artifacts, result?.artifacts);
-	appendArtifactCandidates(artifacts, result?.artifactRefs || result?.artifact_refs);
-	appendNamedArtifact(artifacts, 'fuzz_report', source?.fuzz_report || source?.fuzzReport || source?.report || source?.summary_report || source?.summaryReport);
-	appendNamedArtifact(artifacts, 'coverage', source?.coverage_artifact || source?.coverageArtifact || source?.wordpress_fuzz_coverage || source?.wordpressFuzzCoverage);
-	appendNamedArtifact(artifacts, 'normalized_fuzz_result', source?.wordpress_fuzz_result_artifact || source?.wordpressFuzzResultArtifact || source?.normalized_fuzz_result || source?.normalizedFuzzResult);
-	appendArtifactCandidates(artifacts, source?.wordpress_fuzz_result?.artifacts || source?.wordpressFuzzResult?.artifacts);
-	appendArtifactCandidates(artifacts, source?.wordpress_fuzz_result?.artifactRefs || source?.wordpress_fuzz_result?.artifact_refs || source?.wordpressFuzzResult?.artifactRefs || source?.wordpressFuzzResult?.artifact_refs);
+	appendFuzzArtifactRefs(artifacts, fuzzArtifactRefsFromSource(source, result));
+	appendFuzzArtifactRefs(artifacts, fuzzArtifactRefsFromEmbeddedWordPressResult(source));
 	appendCaseArtifacts(artifacts, source?.cases || source?.fuzz_cases || source?.fuzzCases, 'fuzz_case');
 	appendCaseArtifacts(artifacts, source?.wordpress_fuzz_result?.cases || source?.wordpressFuzzResult?.cases, 'fuzz_case');
 	appendCaseArtifacts(artifacts, source?.failures || source?.errors || source?.failed_cases || source?.failedCases, 'failing_case');
 	appendCaseArtifacts(artifacts, source?.repro_cases || source?.reproCases || source?.reproductions, 'repro_case');
 	return dedupeArtifacts(artifacts.map(normalizeFuzzArtifact).filter(Boolean));
+}
+
+function fuzzArtifactRefsFromSource(source = {}, result = {}) {
+	return [
+		source?.artifacts,
+		source?.artifactRefs || source?.artifact_refs,
+		result?.artifacts,
+		result?.artifactRefs || result?.artifact_refs,
+		{ fuzz_report: source?.fuzz_report || source?.fuzzReport || source?.report || source?.summary_report || source?.summaryReport },
+		{ coverage: source?.coverage_artifact || source?.coverageArtifact || source?.wordpress_fuzz_coverage || source?.wordpressFuzzCoverage },
+		{ normalized_fuzz_result: source?.wordpress_fuzz_result_artifact || source?.wordpressFuzzResultArtifact || source?.normalized_fuzz_result || source?.normalizedFuzzResult },
+	];
+}
+
+function fuzzArtifactRefsFromEmbeddedWordPressResult(source = {}) {
+	return [
+		source?.wordpress_fuzz_result?.artifacts || source?.wordpressFuzzResult?.artifacts,
+		source?.wordpress_fuzz_result?.artifactRefs || source?.wordpress_fuzz_result?.artifact_refs || source?.wordpressFuzzResult?.artifactRefs || source?.wordpressFuzzResult?.artifact_refs,
+	];
+}
+
+function appendFuzzArtifactRefs(artifacts, refs = []) {
+	for (const ref of refs) {
+		appendArtifactCandidates(artifacts, ref);
+	}
 }
 
 function appendArtifactCandidates(artifacts, value) {
@@ -649,8 +667,9 @@ function normalizeFuzzArtifact(artifact) {
 	if (!objectOrUndefined(artifact)) {
 		return null;
 	}
-	const name = artifact.name || artifact.id || artifact.key || artifact.role || artifact.type || artifact.kind;
-	const role = normalizeFuzzArtifactRole(artifact.role || artifact.artifact_role || artifact.artifactRole || artifact.kind || artifact.type || name || artifact.path || artifact.url || artifact.file);
+	const identity = fuzzArtifactIdentity(artifact);
+	const name = identity.name;
+	const role = identity.role;
 	if (!role) {
 		return null;
 	}
@@ -674,6 +693,16 @@ function normalizeFuzzArtifact(artifact) {
 			...(objectOrUndefined(artifact.metadata) || {}),
 		}),
 	});
+}
+
+function fuzzArtifactIdentity(artifact = {}) {
+	const explicitRole = artifact.role || artifact.artifact_role || artifact.artifactRole;
+	const explicitKind = artifact.kind || artifact.type;
+	const name = artifact.name || artifact.id || artifact.key || explicitRole || explicitKind;
+	return {
+		name,
+		role: normalizeFuzzArtifactRole(explicitRole || explicitKind || name || artifact.path || artifact.url || artifact.file),
+	};
 }
 
 function hasConcreteArtifactReference(artifact) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -124,6 +124,7 @@ const jsonWorkloadResult = buildWordPressFuzzRunnerResult({
 		workloadPath: '/unused/in-unit-test.json',
 		workloadId: 'json-workload',
 		runId: 'json-workload-run',
+		wpCodeboxFuzzWorkloadRoot: '/runner/workloads',
 	},
 	workload: {
 		schema: 'homeboy/fuzz-workload/v1',
@@ -183,6 +184,8 @@ assert.equal(
 	jsonWorkloadResult.wp_codebox_task_request.executor.config.runtime_requirements.extra_plugins[0].source,
 	'/runner/components/sample-plugin'
 );
+assert.deepEqual(jsonWorkloadResult.wp_codebox_runtime_requirements.runtime_mounts, [{ source: '/runner/workloads', target: '/runner/workloads', mode: 'readonly' }]);
+assert.deepEqual(jsonWorkloadResult.wp_codebox_runtime_requirements.runtime_env, { WP_CODEBOX_FUZZ_WORKLOAD_ROOT: '/runner/workloads' });
 
 const genericPrimitiveResult = buildWordPressFuzzRunnerResult({
 	env: {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -384,7 +384,10 @@ runWpCodeboxFuzzSuite({
 	assert.equal(embeddedArtifactOnly.succeeded, true);
 	assert.equal(embeddedArtifactOnly.artifacts[0].path, 'case/report.json');
 	assert.equal(embeddedArtifactOnly.artifacts[0].role, 'fuzz_report');
+	assert.equal(embeddedArtifactOnly.artifacts[0].semantic_key, 'fuzz.report');
 	assert.equal(embeddedArtifactOnly.artifacts[0].name, 'case_report');
+	assert.equal(embeddedArtifactOnly.wordpress_fuzz_result.artifacts[0].role, 'fuzz_report');
+	assert.equal(embeddedArtifactOnly.wordpress_fuzz_result.artifacts[0].name, 'case_report');
 	const doubleNested = normalizeWpCodeboxFuzzRunResult({
 		json: {
 			schema: 'wp-codebox/agent-task-run/v1',


### PR DESCRIPTION
## Summary
- extract a small WP Codebox fuzz runtime requirements builder
- centralize fuzz artifact ref collection and identity handling
- add smoke assertions for workload-root runtime requirements and named embedded fuzz report artifacts

## Verification
- `node wordpress/tests/wp-codebox-fuzz-run-smoke.js`
- `node wordpress/tests/wordpress-fuzz-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Refactoring fuzz runtime/artifact contract helpers and drafting focused smoke coverage.