### PR TITLE
Add shared loop policy primitive

### DIFF
--- a/runtime-agent-ci/lib/deterministic-loop-runner.js
+++ b/runtime-agent-ci/lib/deterministic-loop-runner.js
@@ -21,7 +21,9 @@ function runDeterministicLoop(options = {}) {
   const shouldRetry = options.shouldRetry || options.should_retry || defaultShouldRetry;
   const stopCriteria = options.stopCriteria || options.stop_criteria || options.shouldStop || options.should_stop || defaultStopCriteria;
   const loopPolicy = normalizeLoopPolicy(options, { defaultMode: 'count', defaultMaxRevolutions: 1 });
-  const maxIterations = loopPolicyMaxRevolutions(loopPolicy);
+  const maxIterations = loopPolicyMaxRevolutions(loopPolicy, {
+    nonCountMaxRevolutions: options.maxSynchronousRevolutions || options.max_synchronous_revolutions,
+  });
   const maxAttempts = positiveInteger(options.maxAttempts || options.max_attempts || options.retry?.max_attempts, 1);
   let state = clonePlainObject(options.state || options.initialState || options.initial_state || {});
   const iterations = [];
@@ -126,18 +128,18 @@ function createDurableDeterministicLoop(options = {}) {
   const shouldRetry = options.shouldRetry || options.should_retry || defaultShouldRetry;
   const stopCriteria = options.stopCriteria || options.stop_criteria || options.shouldStop || options.should_stop || defaultStopCriteria;
   const loopPolicy = normalizeLoopPolicy(options, { defaultMode: 'count', defaultMaxRevolutions: 1 });
-  const maxIterations = loopPolicyMaxRevolutions(loopPolicy);
+  const maxIterations = loopPolicyMaxRevolutions(loopPolicy, { nonCountMaxRevolutions: Number.POSITIVE_INFINITY });
   const maxAttempts = positiveInteger(options.maxAttempts || options.max_attempts || options.retry?.max_attempts, 1);
   const timeoutMs = nonNegativeInteger(options.timeoutMs || options.timeout_ms || options.timeout?.ms, 0);
   const backoffMs = nonNegativeInteger(options.backoffMs || options.backoff_ms || options.backoff?.ms || options.retry?.backoff_ms, 0);
-  const now = typeof options.now === 'function' ? options.now : () => Date.now();
+  const now = typeof options.now === 'function' ? options.now : () => numericNow(options.now);
   const initialState = clonePlainObject(options.state || options.initialState || options.initial_state || {});
 
   return {
     submitIteration(state = {}) {
       return submitDurableIteration({
         loopId,
-        state: normalizeDurableState(state, { loopId, initialState }),
+        state: normalizeDurableState(state, { loopId, initialState, now }),
         submit,
         buildIteration,
         maxIterations,
@@ -150,7 +152,7 @@ function createDurableDeterministicLoop(options = {}) {
     pollIteration(state = {}) {
       return pollDurableIteration({
         loopId,
-        state: normalizeDurableState(state, { loopId, initialState }),
+        state: normalizeDurableState(state, { loopId, initialState, now }),
         submit,
         poll,
         reconcile,
@@ -165,7 +167,7 @@ function createDurableDeterministicLoop(options = {}) {
       });
     },
     resume(state = {}) {
-      const durableState = normalizeDurableState(state, { loopId, initialState });
+      const durableState = normalizeDurableState(state, { loopId, initialState, now });
       if (!durableState.current) {
         return this.submitIteration(durableState);
       }
@@ -314,6 +316,7 @@ function pollDurableIteration({ loopId, state, submit, poll, reconcile, shouldRe
 }
 
 function normalizeDurableState(value, context = {}) {
+  const startedAt = () => numericNow(context.now);
   if (isPlainObject(value) && value.schema === DETERMINISTIC_LOOP_DURABLE_STATE_SCHEMA) {
     return {
       ...value,
@@ -323,7 +326,7 @@ function normalizeDurableState(value, context = {}) {
       checkpoints: Array.isArray(value.checkpoints) ? value.checkpoints : [],
       current: isPlainObject(value.current) ? value.current : null,
       done: Boolean(value.done),
-      started_at: value.started_at || value.startedAt || Date.now(),
+      started_at: value.started_at || value.startedAt || startedAt(),
     };
   }
   const input = isPlainObject(value) ? value : {};
@@ -331,7 +334,7 @@ function normalizeDurableState(value, context = {}) {
     schema: DETERMINISTIC_LOOP_DURABLE_STATE_SCHEMA,
     loop_id: context.loopId || context.loop_id || 'deterministic-loop',
     status: 'running',
-    started_at: input.started_at || input.startedAt || Date.now(),
+    started_at: input.started_at || input.startedAt || startedAt(),
     state: clonePlainObject(input.state || input.initialState || input.initial_state || (Object.keys(input).length > 0 ? input : context.initialState)),
     iterations: Array.isArray(input.iterations) ? input.iterations : [],
     checkpoints: Array.isArray(input.checkpoints) ? input.checkpoints : [],

--- a/runtime-agent-ci/lib/deterministic-loop-runner.js
+++ b/runtime-agent-ci/lib/deterministic-loop-runner.js
@@ -1,5 +1,12 @@
 'use strict';
 
+const {
+  CONTINUE,
+  evaluateLoopPolicy,
+  loopPolicyMaxRevolutions,
+  normalizeLoopPolicy,
+} = require('./loop-policy');
+
 const DETERMINISTIC_LOOP_RESULT_SCHEMA = 'homeboy/deterministic-loop-result/v1';
 const DETERMINISTIC_LOOP_ITERATION_SCHEMA = 'homeboy/deterministic-loop-iteration/v1';
 const DETERMINISTIC_LOOP_ARTIFACT_SCHEMA = 'homeboy/deterministic-loop-artifact/v1';
@@ -13,10 +20,12 @@ function runDeterministicLoop(options = {}) {
   const reconcile = options.reconcile || defaultReconcile;
   const shouldRetry = options.shouldRetry || options.should_retry || defaultShouldRetry;
   const stopCriteria = options.stopCriteria || options.stop_criteria || options.shouldStop || options.should_stop || defaultStopCriteria;
-  const maxIterations = positiveInteger(options.maxIterations || options.max_iterations, 1);
+  const loopPolicy = normalizeLoopPolicy(options, { defaultMode: 'count', defaultMaxRevolutions: 1 });
+  const maxIterations = loopPolicyMaxRevolutions(loopPolicy);
   const maxAttempts = positiveInteger(options.maxAttempts || options.max_attempts || options.retry?.max_attempts, 1);
   let state = clonePlainObject(options.state || options.initialState || options.initial_state || {});
   const iterations = [];
+  const startedAt = numericNow(options.startedAt || options.started_at || options.startAt || options.start_at || options.now);
 
   for (let iterationIndex = 0; iterationIndex < maxIterations; iterationIndex += 1) {
     const iteration = iterationIndex + 1;
@@ -74,6 +83,14 @@ function runDeterministicLoop(options = {}) {
       state,
       iterations,
     }));
+    const policyStatus = stop.stop ? null : evaluateLoopPolicy(loopPolicy, {
+      completed_revolutions: iteration,
+      started_at: startedAt,
+      now: options.now,
+      cancelled: options.cancelled,
+      cancellation_signal: options.cancellation_signal || options.cancellationSignal,
+    });
+    const finalStop = stop.stop ? stop : normalizeStopDecision(policyStatus.reason === CONTINUE ? false : { stop: true, reason: policyStatus.reason, data: { loop_policy_status: policyStatus } });
     const record = {
       schema: DETERMINISTIC_LOOP_ITERATION_SCHEMA,
       loop_id: loopId,
@@ -83,10 +100,10 @@ function runDeterministicLoop(options = {}) {
       outcome,
       artifacts,
       state,
-      stop,
+      stop: finalStop,
     };
     iterations.push(record);
-    if (stop.stop) {
+    if (finalStop.stop) {
       break;
     }
   }
@@ -108,7 +125,8 @@ function createDurableDeterministicLoop(options = {}) {
   const reconcile = options.reconcile || defaultReconcile;
   const shouldRetry = options.shouldRetry || options.should_retry || defaultShouldRetry;
   const stopCriteria = options.stopCriteria || options.stop_criteria || options.shouldStop || options.should_stop || defaultStopCriteria;
-  const maxIterations = positiveInteger(options.maxIterations || options.max_iterations, 1);
+  const loopPolicy = normalizeLoopPolicy(options, { defaultMode: 'count', defaultMaxRevolutions: 1 });
+  const maxIterations = loopPolicyMaxRevolutions(loopPolicy);
   const maxAttempts = positiveInteger(options.maxAttempts || options.max_attempts || options.retry?.max_attempts, 1);
   const timeoutMs = nonNegativeInteger(options.timeoutMs || options.timeout_ms || options.timeout?.ms, 0);
   const backoffMs = nonNegativeInteger(options.backoffMs || options.backoff_ms || options.backoff?.ms || options.retry?.backoff_ms, 0);
@@ -123,6 +141,7 @@ function createDurableDeterministicLoop(options = {}) {
         submit,
         buildIteration,
         maxIterations,
+        loopPolicy,
         maxAttempts,
         timeoutMs,
         now,
@@ -138,6 +157,7 @@ function createDurableDeterministicLoop(options = {}) {
         shouldRetry,
         stopCriteria,
         maxIterations,
+        loopPolicy,
         maxAttempts,
         timeoutMs,
         backoffMs,
@@ -154,7 +174,7 @@ function createDurableDeterministicLoop(options = {}) {
   };
 }
 
-function submitDurableIteration({ loopId, state, submit, buildIteration, maxIterations, maxAttempts, timeoutMs, now }) {
+function submitDurableIteration({ loopId, state, submit, buildIteration, maxIterations, maxAttempts, timeoutMs, now, loopPolicy }) {
   if (state.done) {
     return state;
   }
@@ -162,8 +182,9 @@ function submitDurableIteration({ loopId, state, submit, buildIteration, maxIter
     return state;
   }
   const iteration = state.iterations.length + 1;
-  if (iteration > maxIterations) {
-    return completeDurableState(state, 'failed', 'max_iterations_reached');
+  const policyStatus = evaluateLoopPolicy(loopPolicy, { completed_revolutions: state.iterations.length, started_at: state.started_at, now });
+  if (policyStatus.stop || iteration > maxIterations) {
+    return completeDurableState(state, loopStatus(state.iterations), policyStatus.stop ? policyStatus.reason : 'max_revolutions_reached');
   }
   const attempt = 1;
   const input = buildIteration({ loop_id: loopId, iteration, state: state.state, iterations: state.iterations });
@@ -183,7 +204,7 @@ function submitDurableIteration({ loopId, state, submit, buildIteration, maxIter
   return checkpointState({ ...state, current }, 'submitted', { iteration, attempt, token: current.token });
 }
 
-function pollDurableIteration({ loopId, state, submit, poll, reconcile, shouldRetry, stopCriteria, maxIterations, maxAttempts, timeoutMs, backoffMs, now }) {
+function pollDurableIteration({ loopId, state, submit, poll, reconcile, shouldRetry, stopCriteria, maxIterations, maxAttempts, timeoutMs, backoffMs, now, loopPolicy }) {
   if (state.done || !state.current) {
     return state;
   }
@@ -285,8 +306,9 @@ function pollDurableIteration({ loopId, state, submit, poll, reconcile, shouldRe
   if (stop.stop) {
     return completeDurableState(nextDurableState, loopStatus(nextDurableState.iterations), stop.reason || 'stop_criteria_satisfied');
   }
-  if (nextDurableState.iterations.length >= maxIterations) {
-    return completeDurableState(nextDurableState, loopStatus(nextDurableState.iterations), 'max_iterations_reached');
+  const policyStatus = evaluateLoopPolicy(loopPolicy, { completed_revolutions: nextDurableState.iterations.length, started_at: nextDurableState.started_at, now });
+  if (policyStatus.stop || nextDurableState.iterations.length >= maxIterations) {
+    return completeDurableState(nextDurableState, loopStatus(nextDurableState.iterations), policyStatus.stop ? policyStatus.reason : 'max_revolutions_reached');
   }
   return nextDurableState;
 }
@@ -301,6 +323,7 @@ function normalizeDurableState(value, context = {}) {
       checkpoints: Array.isArray(value.checkpoints) ? value.checkpoints : [],
       current: isPlainObject(value.current) ? value.current : null,
       done: Boolean(value.done),
+      started_at: value.started_at || value.startedAt || Date.now(),
     };
   }
   const input = isPlainObject(value) ? value : {};
@@ -308,6 +331,7 @@ function normalizeDurableState(value, context = {}) {
     schema: DETERMINISTIC_LOOP_DURABLE_STATE_SCHEMA,
     loop_id: context.loopId || context.loop_id || 'deterministic-loop',
     status: 'running',
+    started_at: input.started_at || input.startedAt || Date.now(),
     state: clonePlainObject(input.state || input.initialState || input.initial_state || (Object.keys(input).length > 0 ? input : context.initialState)),
     iterations: Array.isArray(input.iterations) ? input.iterations : [],
     checkpoints: Array.isArray(input.checkpoints) ? input.checkpoints : [],
@@ -441,6 +465,14 @@ function positiveInteger(value, fallback) {
 function nonNegativeInteger(value, fallback) {
   const parsed = Number.parseInt(value || '', 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function numericNow(value) {
+  if (typeof value === 'function') {
+    return numericNow(value());
+  }
+  const parsed = Number.parseInt(value || '', 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : Date.now();
 }
 
 function isPlainObject(value) {

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -117,7 +117,9 @@ function runGenericDeterministicLoop(options = {}) {
   const shouldContinue = options.shouldContinue || options.should_continue || defaultShouldContinue;
   const stopPolicy = options.stopPolicy || options.stop_policy || defaultStopPolicy;
   const loopPolicy = normalizeLoopPolicy(options, { defaultMode: 'count', defaultMaxRevolutions: 1 });
-  const maxIterations = loopPolicyMaxRevolutions(loopPolicy);
+  const maxIterations = loopPolicyMaxRevolutions(loopPolicy, {
+    nonCountMaxRevolutions: options.maxSynchronousRevolutions || options.max_synchronous_revolutions,
+  });
   const initialState = optionalObject(options.state || options.initialState || options.initial_state);
   const tasks = [];
   const results = [];

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -6,6 +6,12 @@ const { spawnSync } = require('node:child_process');
 const { runDeterministicLoop } = require('./deterministic-loop-runner');
 const { runBoundedProductionLoop } = require('./bounded-production-loop-runner');
 const { validateControllerLoopProof } = require('./controller-loop-proof-validator');
+const {
+  CONTINUE,
+  evaluateLoopPolicy,
+  loopPolicyMaxRevolutions,
+  normalizeLoopPolicy,
+} = require('./loop-policy');
 const { runtimeAgentCiTaskExecutorConfig } = require('./runtime-agent-ci-plan');
 const { evaluateGatePlan } = require('./gate-plan-evaluator');
 
@@ -110,7 +116,8 @@ function runGenericDeterministicLoop(options = {}) {
   const reconcile = options.reconcile || defaultGenericReconcile;
   const shouldContinue = options.shouldContinue || options.should_continue || defaultShouldContinue;
   const stopPolicy = options.stopPolicy || options.stop_policy || defaultStopPolicy;
-  const maxIterations = positiveInteger(options.maxIterations || options.max_iterations) || 1;
+  const loopPolicy = normalizeLoopPolicy(options, { defaultMode: 'count', defaultMaxRevolutions: 1 });
+  const maxIterations = loopPolicyMaxRevolutions(loopPolicy);
   const initialState = optionalObject(options.state || options.initialState || options.initial_state);
   const tasks = [];
   const results = [];
@@ -197,6 +204,8 @@ function runGenericDeterministicLoop(options = {}) {
       results,
       evidence,
       maxIterations,
+      loopPolicy,
+      now: options.now,
     }),
   });
   const finalOutcome = results[results.length - 1] || null;
@@ -208,6 +217,7 @@ function runGenericDeterministicLoop(options = {}) {
     tasks,
     results,
     evidence,
+    loop_policy: loopPolicy,
     evidence_envelope: {
       schema: 'homeboy/generic-deterministic-loop-evidence/v1',
       loop_id: loopId,
@@ -238,6 +248,17 @@ function evaluateGenericLoopGateDecision(options = {}) {
   }, { stop_requested: isPlainObject(stop) ? stop.stop : Boolean(stop) });
   if (stopGate.action === 'stop') {
     return { stop: true, reason: stopGate.reason, data: { gate_result: stopGate } };
+  }
+
+  const policyStatus = evaluateLoopPolicy(options.loopPolicy, {
+    completed_revolutions: gateContext.iteration,
+    started_at: options.context.started_at || options.context.startedAt,
+    now: options.now,
+    cancelled: options.context.cancelled,
+    cancellation_signal: options.context.cancellation_signal || options.context.cancellationSignal,
+  });
+  if (policyStatus.reason !== CONTINUE) {
+    return { stop: true, reason: policyStatus.reason, data: { loop_policy_status: policyStatus } };
   }
 
   const continueDecision = options.shouldContinue(gateContext);
@@ -367,7 +388,7 @@ function defaultShouldContinue() {
 
 function defaultStopPolicy({ iteration, maxIterations }) {
   return iteration >= maxIterations
-    ? { stop: true, reason: 'max_iterations_reached' }
+    ? { stop: true, reason: 'max_revolutions_reached' }
     : { stop: false };
 }
 

--- a/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
+++ b/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
@@ -8,7 +8,10 @@ const {
   runGenericDeterministicLoop,
   writeGenericAgentLoopArtifacts,
 } = require('./generic-agent-loop-runner');
-const { normalizeLoopPolicy: normalizeSharedLoopPolicy } = require('./loop-policy');
+const {
+  loopPolicyMaxRevolutions,
+  normalizeLoopPolicy: normalizeSharedLoopPolicy,
+} = require('./loop-policy');
 const { resolveRuntimeProvider } = require('./runtime-provider-resolver.cjs');
 
 function runHeadlessDeterministicLoop(options = {}) {
@@ -315,7 +318,9 @@ function policyIterationOutcome(task, candidate, validation) {
 function normalizeLoopPolicy(plan) {
   const raw = optionalObject(plan.loop_policy || plan.loopPolicy);
   const primitive = normalizeSharedLoopPolicy({ ...plan, ...raw }, { defaultMode: 'count', defaultMaxRevolutions: 1 });
-  const maxIterations = primitive.mode === 'count' ? primitive.max_revolutions : Number.MAX_SAFE_INTEGER;
+  const maxIterations = loopPolicyMaxRevolutions(primitive, {
+    nonCountMaxRevolutions: plan.max_synchronous_revolutions || plan.maxSynchronousRevolutions,
+  });
   const enabled = Object.keys(raw).length > 0 || maxIterations > 1;
   return {
     enabled,

--- a/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
+++ b/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
@@ -8,6 +8,7 @@ const {
   runGenericDeterministicLoop,
   writeGenericAgentLoopArtifacts,
 } = require('./generic-agent-loop-runner');
+const { normalizeLoopPolicy: normalizeSharedLoopPolicy } = require('./loop-policy');
 const { resolveRuntimeProvider } = require('./runtime-provider-resolver.cjs');
 
 function runHeadlessDeterministicLoop(options = {}) {
@@ -146,7 +147,11 @@ function runHeadlessPolicyLoop(options = {}) {
 
   const loop = runGenericDeterministicLoop({
     loopId: `${baseRequest.task_id}-headless-policy`,
+    mode: loopPolicy.mode,
+    maxRevolutions: loopPolicy.max_revolutions,
     maxIterations: loopPolicy.max_iterations,
+    durationMs: loopPolicy.duration_ms,
+    deadlineAt: loopPolicy.deadline_at,
     state: {
       request: baseRequest,
       plan: basePlan,
@@ -241,7 +246,7 @@ function runHeadlessPolicyLoop(options = {}) {
         return { stop: true, reason: stopReason };
       }
       if (context.iteration >= loopPolicy.max_iterations) {
-        stopReason = 'max_iterations_reached';
+        stopReason = 'max_revolutions_reached';
         return { stop: true, reason: stopReason };
       }
       return { stop: false };
@@ -261,8 +266,10 @@ function runHeadlessPolicyLoop(options = {}) {
   const policyStatus = {
     schema: 'homeboy/headless-loop-policy-status/v1',
     status: latestAccepted ? 'succeeded' : 'failed',
-    stop_reason: stopReason || 'unknown',
+    stop_reason: stopReason || loop.iterations.at(-1)?.stop?.reason || 'unknown',
     max_iterations: loopPolicy.max_iterations,
+    max_revolutions: loopPolicy.max_revolutions,
+    mode: loopPolicy.mode,
     iteration_count: iterationRecords.length,
     accepted: latestAccepted,
     iterations: iterationRecords,
@@ -307,11 +314,16 @@ function policyIterationOutcome(task, candidate, validation) {
 
 function normalizeLoopPolicy(plan) {
   const raw = optionalObject(plan.loop_policy || plan.loopPolicy);
-  const maxIterations = positiveInteger(raw.max_iterations || raw.maxIterations || plan.max_iterations || plan.maxIterations);
+  const primitive = normalizeSharedLoopPolicy({ ...plan, ...raw }, { defaultMode: 'count', defaultMaxRevolutions: 1 });
+  const maxIterations = primitive.mode === 'count' ? primitive.max_revolutions : Number.MAX_SAFE_INTEGER;
   const enabled = Object.keys(raw).length > 0 || maxIterations > 1;
   return {
     enabled,
+    mode: primitive.mode,
     max_iterations: maxIterations || 1,
+    max_revolutions: primitive.max_revolutions,
+    duration_ms: primitive.duration_ms,
+    deadline_at: primitive.deadline_at,
     accepted_statuses: normalizeArray(raw.accepted_statuses || raw.acceptedStatuses).length > 0
       ? normalizeArray(raw.accepted_statuses || raw.acceptedStatuses)
       : ['accepted', 'succeeded', 'passed', 'no_op'],

--- a/runtime-agent-ci/lib/loop-policy.js
+++ b/runtime-agent-ci/lib/loop-policy.js
@@ -44,9 +44,15 @@ function evaluateLoopPolicy(policyInput, context = {}) {
   return status(CONTINUE, context);
 }
 
-function loopPolicyMaxRevolutions(policyInput) {
+function loopPolicyMaxRevolutions(policyInput, options = {}) {
   const policy = policyInput?.schema === LOOP_POLICY_SCHEMA ? policyInput : normalizeLoopPolicy(policyInput);
-  return policy.mode === 'count' ? policy.max_revolutions : Number.MAX_SAFE_INTEGER;
+  if (policy.mode === 'count') {
+    return policy.max_revolutions;
+  }
+  if ((options.nonCountMaxRevolutions ?? options.non_count_max_revolutions) === Number.POSITIVE_INFINITY) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return positiveInteger(options.nonCountMaxRevolutions ?? options.non_count_max_revolutions, 1);
 }
 
 function status(reason, context = {}) {
@@ -101,9 +107,9 @@ function signalCancelled(signal) {
   return Boolean(signal && (signal.aborted || signal.cancelled));
 }
 
-function positiveInteger(value) {
+function positiveInteger(value, fallback = 0) {
   const parsed = Number.parseInt(value ?? '', 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function nonNegativeInteger(value) {

--- a/runtime-agent-ci/lib/loop-policy.js
+++ b/runtime-agent-ci/lib/loop-policy.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const LOOP_POLICY_SCHEMA = 'homeboy/loop-policy/v1';
+const LOOP_POLICY_STATUS_SCHEMA = 'homeboy/loop-policy-status/v1';
+const CONTINUE = 'continue';
+
+function normalizeLoopPolicy(input = {}, options = {}) {
+  const raw = optionalObject(input.loop_policy || input.loopPolicy || input.loop || input);
+  const defaultMode = options.defaultMode || options.default_mode || '';
+  const maxRevolutions = positiveInteger(raw.max_revolutions ?? raw.maxRevolutions ?? raw.max_iterations ?? raw.maxIterations ?? input.max_revolutions ?? input.maxRevolutions ?? input.max_iterations ?? input.maxIterations);
+  const durationMs = nonNegativeInteger(raw.duration_ms ?? raw.durationMs ?? input.duration_ms ?? input.durationMs);
+  const deadlineAt = normalizeDeadline(raw.deadline_at ?? raw.deadlineAt ?? input.deadline_at ?? input.deadlineAt);
+  const mode = normalizeMode(raw.mode || input.mode || defaultMode || inferredMode({ maxRevolutions, durationMs, deadlineAt }));
+  return {
+    schema: LOOP_POLICY_SCHEMA,
+    mode,
+    max_revolutions: mode === 'count' ? (maxRevolutions || positiveInteger(options.defaultMaxRevolutions ?? options.default_max_revolutions) || 1) : 0,
+    duration_ms: durationMs,
+    deadline_at: deadlineAt,
+    cancellation_signal: raw.cancellation_signal || raw.cancellationSignal || input.cancellation_signal || input.cancellationSignal || options.cancellation_signal || options.cancellationSignal || null,
+    cancelled: Boolean(raw.cancelled || input.cancelled || options.cancelled),
+  };
+}
+
+function evaluateLoopPolicy(policyInput, context = {}) {
+  const policy = policyInput?.schema === LOOP_POLICY_SCHEMA ? policyInput : normalizeLoopPolicy(policyInput);
+  if (policy.cancelled || context.cancelled || signalCancelled(policy.cancellation_signal) || signalCancelled(context.cancellation_signal || context.cancellationSignal)) {
+    return status('cancelled', context);
+  }
+  const now = numericNow(context.now);
+  const deadlineAt = policy.deadline_at || normalizeDeadline(context.deadline_at || context.deadlineAt);
+  if (deadlineAt > 0 && now >= deadlineAt) {
+    return status('deadline_reached', context);
+  }
+  const durationMs = policy.duration_ms || nonNegativeInteger(context.duration_ms || context.durationMs);
+  const startedAt = normalizeDeadline(context.started_at || context.startedAt || context.start_at || context.startAt);
+  if (durationMs > 0 && startedAt > 0 && now - startedAt >= durationMs) {
+    return status('duration_elapsed', context);
+  }
+  const completedRevolutions = nonNegativeInteger(context.completed_revolutions ?? context.completedRevolutions ?? context.iteration ?? context.revolution);
+  if (policy.mode === 'count' && policy.max_revolutions > 0 && completedRevolutions >= policy.max_revolutions) {
+    return status('max_revolutions_reached', context);
+  }
+  return status(CONTINUE, context);
+}
+
+function loopPolicyMaxRevolutions(policyInput) {
+  const policy = policyInput?.schema === LOOP_POLICY_SCHEMA ? policyInput : normalizeLoopPolicy(policyInput);
+  return policy.mode === 'count' ? policy.max_revolutions : Number.MAX_SAFE_INTEGER;
+}
+
+function status(reason, context = {}) {
+  return {
+    schema: LOOP_POLICY_STATUS_SCHEMA,
+    stop: reason !== CONTINUE,
+    reason,
+    stop_reason: reason,
+    completed_revolutions: nonNegativeInteger(context.completed_revolutions ?? context.completedRevolutions ?? context.iteration ?? context.revolution),
+  };
+}
+
+function inferredMode({ maxRevolutions, durationMs, deadlineAt }) {
+  if (maxRevolutions > 0) {
+    return 'count';
+  }
+  if (durationMs > 0 || deadlineAt > 0) {
+    return 'duration';
+  }
+  return 'indefinite';
+}
+
+function normalizeMode(value) {
+  return ['count', 'duration', 'indefinite'].includes(value) ? value : 'indefinite';
+}
+
+function normalizeDeadline(value) {
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  const numeric = nonNegativeInteger(value);
+  if (numeric > 0) {
+    return numeric;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsedDate = Date.parse(value);
+    if (Number.isFinite(parsedDate)) {
+      return parsedDate;
+    }
+  }
+  return 0;
+}
+
+function numericNow(now) {
+  if (typeof now === 'function') {
+    return numericNow(now());
+  }
+  return nonNegativeInteger(now) || Date.now();
+}
+
+function signalCancelled(signal) {
+  return Boolean(signal && (signal.aborted || signal.cancelled));
+}
+
+function positiveInteger(value) {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function nonNegativeInteger(value) {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function optionalObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+module.exports = {
+  CONTINUE,
+  LOOP_POLICY_SCHEMA,
+  LOOP_POLICY_STATUS_SCHEMA,
+  evaluateLoopPolicy,
+  loopPolicyMaxRevolutions,
+  normalizeLoopPolicy,
+};

--- a/runtime-agent-ci/package.json
+++ b/runtime-agent-ci/package.json
@@ -11,6 +11,7 @@
     "./bounded-production-loop-runner": "./lib/bounded-production-loop-runner.js",
     "./fanout-reconcile-runner": "./lib/fanout-reconcile-runner.js",
     "./gate-plan-evaluator": "./lib/gate-plan-evaluator.js",
+    "./loop-policy": "./lib/loop-policy.js",
     "./generic-fanout-reconcile-workflow": "./lib/generic-fanout-reconcile-workflow.js",
     "./workspace-publication-lifecycle": "./lib/workspace-publication-lifecycle.cjs"
   },

--- a/runtime-agent-ci/tests/deterministic-loop-runner-durable.test.js
+++ b/runtime-agent-ci/tests/deterministic-loop-runner-durable.test.js
@@ -91,4 +91,33 @@ assert.deepEqual(retrySubmissions, [
   { token: 'retry-1-2', retryAfterMs: 250 },
 ]);
 
+now = 5000;
+const durationLoop = createDurableDeterministicLoop({
+  mode: 'duration',
+  durationMs: 500,
+  now: () => now,
+  submitIteration: () => ({ token: 'duration-1' }),
+  pollIteration: () => ({ status: 'completed', outcome: { status: 'succeeded' } }),
+});
+let durationState = durationLoop.submitIteration({});
+assert.equal(durationState.started_at, 5000);
+now = 5600;
+durationState = durationLoop.pollIteration(durationState);
+assert.equal(durationState.done, true);
+assert.equal(durationState.stop_reason, 'duration_elapsed');
+
+now = 7000;
+const deadlineLoop = createDurableDeterministicLoop({
+  mode: 'duration',
+  deadlineAt: 7000,
+  now: () => now,
+  submitIteration: () => ({ token: 'deadline-1' }),
+  pollIteration: () => ({ status: 'completed', outcome: { status: 'succeeded' } }),
+});
+const deadlineState = deadlineLoop.submitIteration({});
+assert.equal(deadlineState.started_at, 7000);
+assert.equal(deadlineState.done, true);
+assert.equal(deadlineState.stop_reason, 'deadline_reached');
+assert.equal(deadlineState.current, null);
+
 process.stdout.write('Durable deterministic loop resume and polling checks passed\n');

--- a/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
+++ b/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
@@ -101,7 +101,7 @@ const boundedFailure = runHeadlessDeterministicLoop({
 assert.equal(boundedCalls, 2);
 assert.equal(boundedFailure.status, 'failed');
 assert.equal(boundedFailure.tasks[0].loop_policy.status, 'failed');
-assert.equal(boundedFailure.tasks[0].loop_policy.stop_reason, 'max_iterations_reached');
+assert.equal(boundedFailure.tasks[0].loop_policy.stop_reason, 'max_revolutions_reached');
 assert.equal(boundedFailure.tasks[0].loop_policy.iteration_count, 2);
 
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-headless-loop-policy-'));

--- a/runtime-agent-ci/tests/loop-policy.test.js
+++ b/runtime-agent-ci/tests/loop-policy.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+const {
+  evaluateLoopPolicy,
+  normalizeLoopPolicy,
+} = require('../lib/loop-policy');
+const {
+  createDurableDeterministicLoop,
+  runDeterministicLoop,
+} = require('../lib/deterministic-loop-runner');
+
+const countPolicy = normalizeLoopPolicy({ mode: 'count', max_iterations: 2 });
+assert.equal(countPolicy.max_revolutions, 2);
+assert.equal(evaluateLoopPolicy(countPolicy, { completed_revolutions: 1, now: 1000 }).reason, 'continue');
+assert.equal(evaluateLoopPolicy(countPolicy, { completed_revolutions: 2, now: 1000 }).reason, 'max_revolutions_reached');
+
+let executions = 0;
+const counted = runDeterministicLoop({
+  mode: 'count',
+  max_revolutions: 2,
+  execute: () => {
+    executions += 1;
+    return { status: 'succeeded' };
+  },
+  stopCriteria: () => false,
+});
+assert.equal(executions, 2);
+assert.equal(counted.iterations.at(-1).stop.reason, 'max_revolutions_reached');
+
+const durationPolicy = normalizeLoopPolicy({ mode: 'duration', duration_ms: 5000 });
+assert.equal(evaluateLoopPolicy(durationPolicy, { started_at: 1000, now: 5999 }).reason, 'continue');
+assert.equal(evaluateLoopPolicy(durationPolicy, { started_at: 1000, now: 6000 }).reason, 'duration_elapsed');
+
+const deadlinePolicy = normalizeLoopPolicy({ mode: 'duration', deadline_at: 3000 });
+assert.equal(evaluateLoopPolicy(deadlinePolicy, { now: 2999 }).reason, 'continue');
+assert.equal(evaluateLoopPolicy(deadlinePolicy, { now: 3000 }).reason, 'deadline_reached');
+
+const cancelledPolicy = normalizeLoopPolicy({ mode: 'indefinite', cancelled: true });
+assert.equal(evaluateLoopPolicy(cancelledPolicy, { now: 1000 }).reason, 'cancelled');
+
+let now = 1000;
+const submitted = [];
+const indefinite = createDurableDeterministicLoop({
+  mode: 'indefinite',
+  now: () => now,
+  submitIteration: ({ iteration }) => {
+    submitted.push(iteration);
+    return { token: `indefinite-${iteration}` };
+  },
+  pollIteration: ({ token }) => ({ status: 'completed', outcome: { status: 'succeeded', metadata: { token } } }),
+  reconcile: ({ state, outcome }) => ({ seen: [...(state.seen || []), outcome.metadata.token] }),
+});
+
+let state = indefinite.resume({ seen: [] });
+assert.equal(state.current.token, 'indefinite-1');
+state = indefinite.resume(state);
+assert.equal(state.current, null);
+assert.deepEqual(state.state.seen, ['indefinite-1']);
+now = 2000;
+state = indefinite.resume(state);
+assert.equal(state.current.token, 'indefinite-2');
+assert.deepEqual(submitted, [1, 2]);
+
+process.stdout.write('Loop policy primitive checks passed\n');

--- a/runtime-agent-ci/tests/loop-policy.test.js
+++ b/runtime-agent-ci/tests/loop-policy.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 
 const {
   evaluateLoopPolicy,
+  loopPolicyMaxRevolutions,
   normalizeLoopPolicy,
 } = require('../lib/loop-policy');
 const {
@@ -32,6 +33,7 @@ assert.equal(counted.iterations.at(-1).stop.reason, 'max_revolutions_reached');
 const durationPolicy = normalizeLoopPolicy({ mode: 'duration', duration_ms: 5000 });
 assert.equal(evaluateLoopPolicy(durationPolicy, { started_at: 1000, now: 5999 }).reason, 'continue');
 assert.equal(evaluateLoopPolicy(durationPolicy, { started_at: 1000, now: 6000 }).reason, 'duration_elapsed');
+assert.equal(loopPolicyMaxRevolutions(durationPolicy), 1);
 
 const deadlinePolicy = normalizeLoopPolicy({ mode: 'duration', deadline_at: 3000 });
 assert.equal(evaluateLoopPolicy(deadlinePolicy, { now: 2999 }).reason, 'continue');
@@ -39,6 +41,32 @@ assert.equal(evaluateLoopPolicy(deadlinePolicy, { now: 3000 }).reason, 'deadline
 
 const cancelledPolicy = normalizeLoopPolicy({ mode: 'indefinite', cancelled: true });
 assert.equal(evaluateLoopPolicy(cancelledPolicy, { now: 1000 }).reason, 'cancelled');
+
+let durationExecutions = 0;
+const durationSync = runDeterministicLoop({
+  mode: 'duration',
+  duration_ms: 60_000,
+  now: () => 1000,
+  execute: () => {
+    durationExecutions += 1;
+    return { status: 'succeeded' };
+  },
+  stopCriteria: () => false,
+});
+assert.equal(durationExecutions, 1);
+assert.equal(durationSync.iterations.length, 1);
+
+let indefiniteExecutions = 0;
+const indefiniteSync = runDeterministicLoop({
+  mode: 'indefinite',
+  execute: () => {
+    indefiniteExecutions += 1;
+    return { status: 'succeeded' };
+  },
+  stopCriteria: () => false,
+});
+assert.equal(indefiniteExecutions, 1);
+assert.equal(indefiniteSync.iterations.length, 1);
 
 let now = 1000;
 const submitted = [];


### PR DESCRIPTION
## Summary
- Add a reusable runtime-agent-ci loop policy primitive for count, duration/deadline, indefinite, and cancelled loop semantics.
- Refactor deterministic, generic deterministic, and headless deterministic loop paths to use the shared policy while keeping legacy max_iterations aliases confined to normalization.
- Add coverage for count limits, duration/deadline stops, cancellation, and indefinite durable resumability.

## Tests
- `for test_file in tests/*.js; do node "" || exit 1; done` from `runtime-agent-ci`
- `npm run test:controller-loop-proof-validator`
- `npm run test:generic-fanout-reconcile-boundary`
- `npm run test:workspace-publication-lifecycle`
- `npm run test:agent-task-outcome-normalizer`
- `npm run test:gate-plan-evaluator`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the shared loop policy primitive, refactoring runner integrations, and adding/verifying tests.