### PR TITLE
Gate WordPress fuzz on runtime capabilities

### DIFF
--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -43,6 +43,7 @@ module.exports = {
 	...require('./lib/wp-codebox-fuzz-run'),
 	...require('./lib/wordpress-workload-profile'),
 	...require('./lib/wordpress-fuzz-manifest'),
+	...require('./lib/wordpress-fuzz-runtime-capabilities'),
 	...require('./lib/wordpress-surface-types'),
 	...require('./lib/wordpress-hook-surface-discovery'),
 	...require('./lib/wordpress-fuzz-schemas'),

--- a/wordpress/lib/wordpress-fuzz-coverage-aggregate.js
+++ b/wordpress/lib/wordpress-fuzz-coverage-aggregate.js
@@ -4,39 +4,13 @@
  * Internal dependencies
  */
 const { isPlainObject } = require('./shared');
+const {
+	WORDPRESS_RUNTIME_SURFACE_ID_PREFIXES,
+	normalizeWordPressCoverageSurfaceType,
+} = require('./wordpress-surface-types');
 
 const STATUS_ORDER = ['discovered', 'exercised', 'skipped', 'failed'];
 const STATUS_PRIORITY = Object.fromEntries(STATUS_ORDER.map((status, index) => [status, index]));
-const SURFACE_TYPE_ALIASES = new Map([
-	['admin', 'admin_page'],
-	['admin-page', 'admin_page'],
-	['admin_page', 'admin_page'],
-	['ajax', 'ajax_action'],
-	['ajax-action', 'ajax_action'],
-	['ajax_action', 'ajax_action'],
-	['block', 'block'],
-	['block-type', 'block'],
-	['db', 'db_table'],
-	['db-table', 'db_table'],
-	['db_table', 'db_table'],
-	['database', 'db_table'],
-	['database-table', 'db_table'],
-	['frontend', 'frontend_url'],
-	['frontend-url', 'frontend_url'],
-	['frontend_url', 'frontend_url'],
-	['rest', 'rest_route'],
-	['rest-route', 'rest_route'],
-	['rest_route', 'rest_route'],
-]);
-
-const COVERAGE_ID_PREFIXES = {
-	admin_page: 'admin',
-	ajax_action: 'ajax',
-	block: 'block',
-	db_table: 'db',
-	frontend_url: 'frontend',
-	rest_route: 'rest',
-};
 
 function stringValue(value, fallback = '') {
 	const normalized = String(value ?? '').trim();
@@ -94,8 +68,7 @@ function normalizeFuzzCoverageItem(raw, defaults = {}) {
 }
 
 function normalizeCoverageSurfaceType(value, fallback = 'generic') {
-	const normalized = stringValue(value, fallback).toLowerCase().replace(/\s+/g, '-');
-	return SURFACE_TYPE_ALIASES.get(normalized) || normalized.replace(/-/g, '_');
+	return normalizeWordPressCoverageSurfaceType(stringValue(value, fallback)) || fallback;
 }
 
 function normalizeCoverageSurfaceValue(surface, type, index) {
@@ -122,7 +95,7 @@ function normalizeCoverageSurfaceId(surface, type, index) {
 	if (explicit && explicit.includes(':')) {
 		return explicit;
 	}
-	const prefix = COVERAGE_ID_PREFIXES[type] || type;
+	const prefix = WORDPRESS_RUNTIME_SURFACE_ID_PREFIXES[type] || type;
 	const value = explicit || normalizeCoverageSurfaceValue(surface, type, index);
 	return `${prefix}:${value}`;
 }

--- a/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
+++ b/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
@@ -17,9 +17,13 @@ const {
 	WORDPRESS_SURFACE_COLLECTION_KEYS,
 	wordpressSurfaceTypeFromCollectionKey,
 } = require('./wordpress-surface-types');
+const {
+	gateWordPressFuzzCaseForRuntimeCapabilities,
+	requiredCapabilitiesForWordPressFuzzCase,
+} = require('./wordpress-fuzz-runtime-capabilities');
 
 const SAFE_REST_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
-const DB_MUTATION_REQUIRED_CAPABILITIES = ['snapshot', 'transaction', 'reset'];
+const DB_MUTATION_REQUIRED_CAPABILITIES = requiredCapabilitiesForWordPressFuzzCase('db_mutation');
 
 function buildWordPressFuzzPlanFromSurfaces(input = {}, options = {}) {
 	const discovery = normalizeWordPressSurfaceDiscovery({
@@ -208,7 +212,7 @@ function restRouteCaseFromMethod(surface, method, operationId, surfaceSkipReason
 	const operation = { ...operationForSurface(surface), method };
 	const skipReasons = safeMethod ? surfaceSkipReasons : reasonList([...surfaceSkipReasons, 'mutating_rest_method_requires_explicit_opt_in']);
 	const destructiveReasons = safeMethod ? surfaceDestructiveReasons : reasonList([...surfaceDestructiveReasons, 'rest_method_mutates_state']);
-	return {
+	const testCase = {
 		id: `${surface.id}-${method.toLowerCase()}-generic-fuzz`,
 		intent: 'request-rest-route',
 		operation_id: operationId,
@@ -225,6 +229,12 @@ function restRouteCaseFromMethod(surface, method, operationId, surfaceSkipReason
 			gated: !safeMethod,
 		},
 	};
+	if (safeMethod) {
+		return testCase;
+	}
+	return gateWordPressFuzzCaseForRuntimeCapabilities(testCase, options.runtimeCapabilities || options.runtime_capabilities, {
+		required_capabilities: requiredCapabilitiesForWordPressFuzzCase('mutating_rest'),
+	});
 }
 
 function restMethodsForSurface(surface) {
@@ -271,7 +281,7 @@ function genericCaseForSurface(surface, options = {}) {
 function crudCaseForSurface(surface, resource, action, options = {}) {
 	const operation = crudOperationForSurface(surface, resource, action);
 	const gateReasons = mutatingCrudAction(action.action) && !allowsCrudMutation(surface, action.action) ? ['crud_mutation_requires_explicit_allow'] : [];
-	return {
+	const testCase = {
 		id: `${surface.id}-${action.intent}-crud-fuzz`,
 		intent: action.intent,
 		operation_id: operation.id,
@@ -284,6 +294,12 @@ function crudCaseForSurface(surface, resource, action, options = {}) {
 		destructive_reasons: reasonList(surface.destructive_reasons || surface.destructiveReasons || surface.destructive_reason || surface.destructiveReason || surface.unsafeReasons),
 		metadata: { surface, crud: { resource_type: resource.type, intent: action.intent, action: action.action } },
 	};
+	if (!mutatingCrudAction(action.action) || gateReasons.length > 0) {
+		return testCase;
+	}
+	return gateWordPressFuzzCaseForRuntimeCapabilities(testCase, options.runtimeCapabilities || options.runtime_capabilities, {
+		required_capabilities: requiredCapabilitiesForWordPressFuzzCase('mutating_crud'),
+	});
 }
 
 function crudOperationForSurface(surface, resource, action) {
@@ -477,7 +493,7 @@ function dbMutationCasesFromSurface(surface, operationId, options = {}) {
 	const mutations = normalizeMutationMetadata(surface.mutations || surface.mutation || surface.mutation_metadata || surface.mutationMetadata);
 	return mutations.map((mutation, index) => {
 		const mutationId = mutation.id || mutation.name || mutation.operation || `mutation-${index + 1}`;
-		return {
+		return gateWordPressFuzzCaseForRuntimeCapabilities({
 			id: `${surface.id}-${safeIdPart(mutationId)}-gated-mutation`,
 			intent: surface.type === 'database-table' ? 'mutate-database-table' : 'mutate-database-query',
 			operation_id: `${operationId}:${safeIdPart(mutationId)}`,
@@ -487,12 +503,11 @@ function dbMutationCasesFromSurface(surface, operationId, options = {}) {
 				statement: mutation.statement || mutation.sql,
 			}),
 			seed: options.seed,
-			executable: false,
 			required_capabilities: DB_MUTATION_REQUIRED_CAPABILITIES,
-			skip_reasons: ['requires-runtime-db-safety-capabilities'],
+			skip_reasons: [],
 			destructive_reasons: ['db-mutation'],
-			metadata: { surface, mutation, gated: true },
-		};
+			metadata: { surface, mutation },
+		}, options.runtimeCapabilities || options.runtime_capabilities);
 	});
 }
 
@@ -552,7 +567,7 @@ function adminPageInteractionCase(surface, interaction, options = {}) {
 		skipReasons.push('requires_explicit_mutation_opt_in');
 	}
 
-	return {
+	const testCase = {
 		id: `${surface.id}-${interaction.kind}-${normalizeToken(operation.interaction_id)}-plan`,
 		intent: gated ? 'plan-admin-page-mutation' : 'exercise-admin-page-read-only-interaction',
 		operation_id: `${surface.id}:${interaction.kind}:${normalizeToken(operation.interaction_id)}`,
@@ -570,6 +585,12 @@ function adminPageInteractionCase(surface, interaction, options = {}) {
 			requires_explicit_opt_in: gated || undefined,
 		}),
 	};
+	if (!gated) {
+		return testCase;
+	}
+	return gateWordPressFuzzCaseForRuntimeCapabilities(testCase, options.runtimeCapabilities || options.runtime_capabilities, {
+		required_capabilities: requiredCapabilitiesForWordPressFuzzCase('admin_mutation'),
+	});
 }
 
 function adminPageInteractionSafety(interaction) {

--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -14,6 +14,7 @@ const {
 	normalizeWordPressFuzzPlan,
 } = require('./wordpress-fuzz-schemas');
 const { buildWpCodeboxFuzzPlanRecipe } = require('./wp-codebox-fuzz-plan');
+const { normalizeWordPressFuzzRuntimeCapabilities } = require('./wordpress-fuzz-runtime-capabilities');
 const {
 	normalizeWpCodeboxFuzzSuiteResult,
 	runWpCodeboxFuzzSuite,
@@ -57,8 +58,9 @@ function buildWordPressFuzzRunnerContext(options = {}) {
 	const seed = env.seed || workload.seed || null;
 	const maxDuration = numericValue(env.maxDuration ?? workload.max_duration ?? workload.maxDuration);
 	const plan = normalizeRunnerPlan(workload.plan || workload.fuzz_plan || workload.fuzzPlan || workload);
+	const runtimeCapabilities = normalizeWordPressFuzzRuntimeCapabilities(workload.runtime_capabilities || workload.runtimeCapabilities || workload.runtime_profile?.fuzz_runtime_capabilities || workload.runtimeProfile?.fuzzRuntimeCapabilities || []);
 	const instructions = fuzzSuiteInstructions({ workload, workloadId, runId });
-	const wpCodeboxInput = buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDuration, instructions });
+	const wpCodeboxInput = buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDuration, instructions, runtimeCapabilities });
 	const runtimeRequirements = wpCodeboxRuntimeRequirementsFromWorkload(workload, { env });
 	const taskRequest = wpCodeboxFuzzSuiteTaskRequest({
 		taskId: runId,
@@ -78,6 +80,7 @@ function buildWordPressFuzzRunnerContext(options = {}) {
 		seed,
 		maxDuration,
 		plan,
+		runtimeCapabilities,
 		wpCodeboxInput,
 		runtimeRequirements,
 		taskRequest,
@@ -92,6 +95,7 @@ function buildWordPressFuzzRunnerSummary({
 	seed,
 	maxDuration,
 	plan,
+	runtimeCapabilities,
 	wpCodeboxInput,
 	runtimeRequirements,
 	taskRequest,
@@ -112,6 +116,7 @@ function buildWordPressFuzzRunnerSummary({
 		max_duration_seconds: maxDuration,
 		plan_id: plan.id,
 		wp_codebox_input: wpCodeboxInput,
+		wordpress_fuzz_runtime_capabilities: runtimeCapabilities,
 		wp_codebox_runtime_requirements: runtimeRequirements,
 		wp_codebox_task_request: taskRequest,
 		wp_codebox_plan_recipe: codeboxPlanRecipe,
@@ -162,7 +167,7 @@ function normalizeRunnerPlan(input) {
 	});
 }
 
-function buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDuration, instructions }) {
+function buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDuration, instructions, runtimeCapabilities }) {
 	const homeboyFuzzWorkload = workload.schema === 'homeboy/fuzz-workload/v1' ? workload : undefined;
 	return wpCodeboxFuzzSuiteInput({
 		id: runId,
@@ -184,7 +189,7 @@ function buildWpCodeboxInput({ workload, plan, runId, workloadId, seed, maxDurat
 		coverage: workload.coverage || { wordpress_fuzz_coverage: true },
 		runtimeProfile: workload.runtime_profile || workload.runtimeProfile,
 		artifacts: workload.artifacts,
-		metadata: stripUndefined({ ...(workload.metadata || {}), runner: WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA, workload: stripUndefined({ id: workloadId }) }),
+		metadata: stripUndefined({ ...(workload.metadata || {}), runner: WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA, runtime_capabilities: runtimeCapabilities, workload: stripUndefined({ id: workloadId }) }),
 	});
 }
 

--- a/wordpress/lib/wordpress-fuzz-runtime-capabilities.js
+++ b/wordpress/lib/wordpress-fuzz-runtime-capabilities.js
@@ -1,0 +1,180 @@
+'use strict';
+
+const WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA = 'homeboy/wordpress-fuzz-runtime-capabilities/v1';
+
+const WORDPRESS_FUZZ_RUNTIME_CAPABILITIES = Object.freeze([
+	'snapshot',
+	'checkpoint',
+	'restore',
+	'transaction',
+	'reset',
+	'crud',
+	'rest',
+	'admin',
+	'database',
+	'browser',
+]);
+
+const WORDPRESS_FUZZ_RUNTIME_CAPABILITY_ALIASES = new Map([
+	['snapshots', 'snapshot'],
+	['snapshotting', 'snapshot'],
+	['checkpointing', 'checkpoint'],
+	['rollback', 'restore'],
+	['rollback-snapshot', 'restore'],
+	['rollback_snapshot', 'restore'],
+	['db-transaction', 'transaction'],
+	['db_transaction', 'transaction'],
+	['transactions', 'transaction'],
+	['reset-db', 'reset'],
+	['reset_db', 'reset'],
+	['database-reset', 'reset'],
+	['database_reset', 'reset'],
+	['crud-execution', 'crud'],
+	['crud_execution', 'crud'],
+	['rest-execution', 'rest'],
+	['rest_execution', 'rest'],
+	['admin-execution', 'admin'],
+	['admin_execution', 'admin'],
+	['db', 'database'],
+	['db-execution', 'database'],
+	['db_execution', 'database'],
+	['database-execution', 'database'],
+	['database_execution', 'database'],
+	['browser-execution', 'browser'],
+	['browser_execution', 'browser'],
+]);
+
+const WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SET = new Set(WORDPRESS_FUZZ_RUNTIME_CAPABILITIES);
+
+const WORDPRESS_FUZZ_RUNTIME_CAPABILITY_REQUIREMENTS = Object.freeze({
+	mutating_crud: Object.freeze(['crud', 'snapshot', 'restore', 'reset']),
+	mutating_rest: Object.freeze(['rest', 'snapshot', 'restore', 'reset']),
+	admin_mutation: Object.freeze(['admin', 'snapshot', 'restore', 'reset']),
+	db_mutation: Object.freeze(['database', 'snapshot', 'transaction', 'reset']),
+});
+
+function normalizeWordPressFuzzRuntimeCapability(value) {
+	const key = String(value || '').trim().toLowerCase().replace(/\s+/g, '-');
+	return WORDPRESS_FUZZ_RUNTIME_CAPABILITY_ALIASES.get(key) || (WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SET.has(key) ? key : '');
+}
+
+function normalizeWordPressFuzzRuntimeCapabilities(value = {}) {
+	const rawCapabilities = Array.isArray(value)
+		? value
+		: value.capabilities || value.runtime_capabilities || value.runtimeCapabilities || value.supports || [];
+	const capabilities = [...new Set((Array.isArray(rawCapabilities) ? rawCapabilities : [rawCapabilities])
+		.map(normalizeWordPressFuzzRuntimeCapability)
+		.filter(Boolean))].sort();
+	const capabilitySet = new Set(capabilities);
+
+	return {
+		schema: WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA,
+		capabilities,
+		isolation: normalizeIsolationContract(value, capabilitySet),
+		execution: normalizeExecutionContract(value, capabilitySet),
+		metadata: isObject(value.metadata) ? { ...value.metadata } : {},
+	};
+}
+
+function normalizeIsolationContract(value = {}, capabilitySet = new Set()) {
+	const isolation = isObject(value.isolation) ? value.isolation : {};
+	return {
+		snapshot: capabilityFlag(capabilitySet, isolation, 'snapshot'),
+		checkpoint: capabilityFlag(capabilitySet, isolation, 'checkpoint'),
+		restore: capabilityFlag(capabilitySet, isolation, 'restore'),
+		transaction: capabilityFlag(capabilitySet, isolation, 'transaction'),
+		reset: capabilityFlag(capabilitySet, isolation, 'reset'),
+	};
+}
+
+function normalizeExecutionContract(value = {}, capabilitySet = new Set()) {
+	const execution = isObject(value.execution) ? value.execution : {};
+	return {
+		crud: capabilityFlag(capabilitySet, execution, 'crud'),
+		rest: capabilityFlag(capabilitySet, execution, 'rest'),
+		admin: capabilityFlag(capabilitySet, execution, 'admin'),
+		database: capabilityFlag(capabilitySet, execution, 'database'),
+		browser: capabilityFlag(capabilitySet, execution, 'browser'),
+	};
+}
+
+function capabilityFlag(capabilitySet, section, capability) {
+	return section[capability] === true || capabilitySet.has(capability);
+}
+
+function gateWordPressFuzzCaseForRuntimeCapabilities(testCase, runtimeCapabilities, options = {}) {
+	const required = normalizeRequiredCapabilities(options.required_capabilities || options.requiredCapabilities || testCase.required_capabilities || testCase.requiredCapabilities);
+	if (required.length === 0) {
+		return testCase;
+	}
+	const declared = new Set(normalizeWordPressFuzzRuntimeCapabilities(runtimeCapabilities).capabilities);
+	const missing = required.filter((capability) => !declared.has(capability));
+	const skipReasons = reasonList(testCase.skip_reasons || testCase.skipReasons || testCase.skip_reason || testCase.skipReason);
+	const metadata = isObject(testCase.metadata) ? { ...testCase.metadata } : {};
+
+	if (missing.length === 0) {
+		const executable = testCase.executable !== false && skipReasons.length === 0;
+		return {
+			...testCase,
+			executable,
+			required_capabilities: required,
+			skip_reasons: skipReasons,
+			metadata: {
+				...metadata,
+				executable,
+				gated: metadata.gated === true && !executable,
+				runtime_capability_gated: false,
+				runtime_capability_contract: WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA,
+				required_capabilities: required,
+			},
+		};
+	}
+
+	return {
+		...testCase,
+		executable: false,
+		required_capabilities: required,
+		skip_reasons: reasonList([...skipReasons, 'missing-runtime-fuzz-capabilities']),
+		metadata: {
+			...metadata,
+			executable: false,
+			planned: true,
+			gated: true,
+			runtime_capability_gated: true,
+			runtime_capability_contract: WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA,
+			required_capabilities: required,
+			missing_capabilities: missing,
+		},
+	};
+}
+
+function requiredCapabilitiesForWordPressFuzzCase(kind) {
+	return [...(WORDPRESS_FUZZ_RUNTIME_CAPABILITY_REQUIREMENTS[kind] || [])];
+}
+
+function normalizeRequiredCapabilities(value) {
+	return [...new Set((Array.isArray(value) ? value : [value])
+		.map(normalizeWordPressFuzzRuntimeCapability)
+		.filter(Boolean))].sort();
+}
+
+function reasonList(value) {
+	if (value === undefined || value === null) {
+		return [];
+	}
+	return [...new Set((Array.isArray(value) ? value : [value]).map(String).filter(Boolean))].sort();
+}
+
+function isObject(value) {
+	return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+module.exports = {
+	WORDPRESS_FUZZ_RUNTIME_CAPABILITIES,
+	WORDPRESS_FUZZ_RUNTIME_CAPABILITY_REQUIREMENTS,
+	WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA,
+	gateWordPressFuzzCaseForRuntimeCapabilities,
+	normalizeWordPressFuzzRuntimeCapabilities,
+	normalizeWordPressFuzzRuntimeCapability,
+	requiredCapabilitiesForWordPressFuzzCase,
+};

--- a/wordpress/lib/wordpress-surface-types.js
+++ b/wordpress/lib/wordpress-surface-types.js
@@ -71,6 +71,22 @@ const WORDPRESS_RUNTIME_SURFACE_TYPES = Object.freeze({
 
 const WORDPRESS_RUNTIME_SURFACE_TYPE_SET = new Set(Object.values(WORDPRESS_RUNTIME_SURFACE_TYPES));
 
+const WORDPRESS_COVERAGE_SURFACE_TYPES = Object.freeze({
+	...WORDPRESS_RUNTIME_SURFACE_TYPES,
+	capability: 'capability',
+	'cron-event': 'cron_event',
+	'db-query': 'db_query',
+	'external-http': 'external_http',
+	hook: 'hook',
+	media: 'media',
+	option: 'option',
+	'post-type': 'post_type',
+	role: 'role',
+	taxonomy: 'taxonomy',
+	user: 'user',
+	'wp-cli-command': 'wp_cli_command',
+});
+
 const WORDPRESS_SURFACE_COLLECTION_TYPE_BY_KEY = Object.freeze({
 	hooks: 'hook',
 	cron: 'cron-event',
@@ -120,9 +136,21 @@ const WORDPRESS_RUNTIME_SURFACE_ID_PREFIXES = Object.freeze({
 	admin_page: 'admin',
 	ajax_action: 'ajax',
 	block: 'block',
+	capability: 'capability',
+	cron_event: 'cron',
 	db_table: 'db',
+	db_query: 'db-query',
+	external_http: 'http',
 	frontend_url: 'frontend',
+	hook: 'hook',
+	media: 'media',
+	option: 'option',
+	post_type: 'post-type',
 	rest_route: 'rest',
+	role: 'role',
+	taxonomy: 'taxonomy',
+	user: 'user',
+	wp_cli_command: 'wp-cli',
 });
 
 function normalizeSurfaceTypeKey(value) {
@@ -151,6 +179,15 @@ function normalizeWordPressRuntimeSurfaceType(value) {
 	return WORDPRESS_RUNTIME_SURFACE_TYPE_SET.has(key) ? key : '';
 }
 
+function normalizeWordPressCoverageSurfaceType(value) {
+	const canonical = normalizeWordPressSurfaceType(value);
+	if (canonical) {
+		return WORDPRESS_COVERAGE_SURFACE_TYPES[canonical] || canonical.replace(/-/g, '_');
+	}
+	const key = normalizeSurfaceTypeKey(value);
+	return key ? key.replace(/-/g, '_') : '';
+}
+
 function wordpressSurfaceTypeFromCollectionKey(key) {
 	return WORDPRESS_SURFACE_COLLECTION_TYPE_BY_KEY[key];
 }
@@ -162,6 +199,7 @@ module.exports = {
 	WORDPRESS_SURFACE_COLLECTION_TYPE_BY_KEY,
 	WORDPRESS_SURFACE_TYPES,
 	isWordPressSurfaceType,
+	normalizeWordPressCoverageSurfaceType,
 	normalizeWordPressRuntimeSurfaceType,
 	normalizeWordPressSurfaceType,
 	wordpressSurfaceTypeFromCollectionKey,

--- a/wordpress/tests/wordpress-fuzz-coverage-aggregate-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-coverage-aggregate-smoke.js
@@ -59,6 +59,9 @@ const manifest = normalizeWordPressFuzzCoverageManifest({
 		{ type: 'db', table: 'wp_posts' },
 		{ type: 'frontend', url: '/' },
 		{ type: 'block', name: 'core/paragraph' },
+		{ type: 'hook', hook: 'init' },
+		{ type: 'post-type', name: 'post' },
+		{ type: 'wp-cli', command: 'wp option list' },
 	],
 });
 assert.deepEqual(manifest.surfaces.map((surface) => surface.id), [
@@ -68,6 +71,9 @@ assert.deepEqual(manifest.surfaces.map((surface) => surface.id), [
 	'db:wp_posts',
 	'frontend:/',
 	'block:core/paragraph',
+	'hook:init',
+	'post-type:post',
+	'wp-cli:wp_cli_command-9',
 ]);
 
 const manifestAggregate = aggregateWordPressFuzzCoverage({
@@ -78,7 +84,7 @@ const manifestAggregate = aggregateWordPressFuzzCoverage({
 	}],
 });
 assert.equal(manifestAggregate.coverage_manifest.schema, 'homeboy/wordpress-fuzz-coverage-manifest/v1');
-assert.equal(manifestAggregate.totals.discovered, 4);
+assert.equal(manifestAggregate.totals.discovered, 7);
 assert.equal(manifestAggregate.totals.exercised, 1);
 assert.equal(manifestAggregate.totals.failed, 1);
 assert.equal(manifestAggregate.coverage_gaps.some((item) => item.id === 'admin:tools.php'), true);

--- a/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
@@ -70,8 +70,9 @@ assert.equal(targetTypes['database-table'].cases[0].intent, 'inspect-database-ta
 assert.equal(targetTypes['db-query'].cases[0].intent, 'profile-database-query');
 assert.equal(targetTypes['database-table'].cases[1].intent, 'mutate-database-table');
 assert.equal(targetTypes['database-table'].cases[1].executable, false);
-assert.deepEqual(targetTypes['database-table'].cases[1].required_capabilities, ['reset', 'snapshot', 'transaction']);
-assert.deepEqual(targetTypes['database-table'].cases[1].skip_reasons, ['requires-runtime-db-safety-capabilities']);
+assert.deepEqual(targetTypes['database-table'].cases[1].required_capabilities, ['database', 'reset', 'snapshot', 'transaction']);
+assert.deepEqual(targetTypes['database-table'].cases[1].skip_reasons, ['missing-runtime-fuzz-capabilities']);
+assert.deepEqual(targetTypes['database-table'].cases[1].metadata.missing_capabilities, ['database', 'reset', 'snapshot', 'transaction']);
 assert.deepEqual(targetTypes['database-table'].cases[1].destructive_reasons, ['db-mutation']);
 assert.equal(targetTypes['db-query'].cases[1].intent, 'mutate-database-query');
 assert.equal(targetTypes['db-query'].cases[1].operation.statement, 'UPDATE wp_posts SET post_title = ? WHERE ID = ?');
@@ -166,7 +167,9 @@ assert.equal(getCase.seed, 'seed-rest');
 for (const method of ['POST', 'DELETE']) {
 	const testCase = restTarget.cases.find((entry) => entry.operation.method === method);
 	assert(testCase.skip_reasons.includes('mutating_rest_method_requires_explicit_opt_in'));
+	assert(testCase.skip_reasons.includes('missing-runtime-fuzz-capabilities'));
 	assert(testCase.destructive_reasons.includes('rest_method_mutates_state'));
+	assert.deepEqual(testCase.required_capabilities, ['reset', 'rest', 'restore', 'snapshot']);
 	assert.equal(testCase.metadata.planned, true);
 	assert.equal(testCase.metadata.gated, true);
 	assert.equal(testCase.metadata.safety.requires_explicit_opt_in, true);
@@ -182,7 +185,8 @@ const resourcePlan = buildWordPressFuzzPlanFromSurfaces({
 assert.deepEqual(resourcePlan.targets[0].cases.map((testCase) => testCase.intent), ['list-settings', 'read-setting', 'create-setting', 'update-setting', 'delete-setting']);
 assert.equal(resourcePlan.targets[0].cases[2].operation.resource_type, 'setting');
 assert.equal(resourcePlan.targets[0].cases[2].operation.capability_context.required[0], 'manage_options');
-assert.deepEqual(resourcePlan.targets[0].cases[2].skip_reasons, []);
+assert.deepEqual(resourcePlan.targets[0].cases[2].skip_reasons, ['missing-runtime-fuzz-capabilities']);
+assert.equal(resourcePlan.targets[0].cases[2].executable, false);
 assert.equal(resourcePlan.targets[1].cases.length, 1);
 assert.equal(resourcePlan.targets[1].cases[0].intent, 'exercise-wordpress-surface');
 
@@ -205,10 +209,12 @@ assert.equal(adminCases.length, 3);
 assert.equal(adminCases[0].intent, 'request-admin-page');
 assert.equal(adminCases[0].metadata.executable, true);
 assert.equal(adminCases[1].intent, 'plan-admin-page-mutation');
-assert.deepEqual(adminCases[1].skip_reasons, ['requires_explicit_mutation_opt_in']);
+assert.deepEqual(adminCases[1].skip_reasons, ['missing-runtime-fuzz-capabilities', 'requires_explicit_mutation_opt_in']);
 assert.deepEqual(adminCases[1].destructive_reasons, ['form_mutation']);
 assert.equal(adminCases[1].metadata.executable, false);
 assert.equal(adminCases[1].metadata.gated, true);
+assert.deepEqual(adminCases[1].required_capabilities, ['admin', 'reset', 'restore', 'snapshot']);
+assert(adminCases[1].skip_reasons.includes('missing-runtime-fuzz-capabilities'));
 assert.deepEqual(adminCases[1].metadata.capability_context, { required: ['edit_posts'] });
 assert.deepEqual(adminCases[1].metadata.nonce_context, { required: true, action: 'bulk-posts', field: '_wpnonce' });
 assert.equal(adminCases[2].intent, 'exercise-admin-page-read-only-interaction');
@@ -220,5 +226,30 @@ const minimalBlockPlan = buildWordPressFuzzPlanFromSurfaces({
 	blocks: [{ id: 'block:minimal', block_name: 'example/minimal' }],
 });
 assert.deepEqual(minimalBlockPlan.targets[0].cases.map((testCase) => testCase.intent), ['render-block', 'insert-block-in-editor']);
+
+const capablePlan = buildWordPressFuzzPlanFromSurfaces({
+	post_types: [{ id: 'post:post', post_type: 'post', allowCrudMutations: true }],
+	database: { tables: { posts: { table: 'wp_posts', mutations: [{ id: 'insert-row', operation: 'insert' }] } } },
+	admin: [{ id: 'admin:settings', forms: [{ id: 'submit', method: 'POST' }] }],
+	rest: [{ id: 'rest:posts', route: '/wp/v2/posts', methods: ['POST'] }],
+}, {
+	runtimeCapabilities: {
+		capabilities: ['crud', 'rest', 'admin', 'database', 'snapshot', 'restore', 'transaction', 'reset'],
+	},
+});
+const capableCases = capablePlan.targets.flatMap((target) => target.cases);
+for (const testCase of capableCases.filter((entry) => entry.required_capabilities && !entry.skip_reasons.length)) {
+	assert.equal(testCase.executable, true);
+	assert.equal(testCase.metadata.gated, false);
+	assert.equal(testCase.metadata.runtime_capability_gated, false);
+}
+const capableRestMutation = capableCases.find((entry) => entry.intent === 'request-rest-route');
+assert.equal(capableRestMutation.executable, false);
+assert.equal(capableRestMutation.metadata.runtime_capability_gated, false);
+assert.deepEqual(capableRestMutation.skip_reasons, ['mutating_rest_method_requires_explicit_opt_in']);
+const capableAdminMutation = capableCases.find((entry) => entry.intent === 'plan-admin-page-mutation');
+assert.equal(capableAdminMutation.executable, false);
+assert.equal(capableAdminMutation.metadata.runtime_capability_gated, false);
+assert.deepEqual(capableAdminMutation.skip_reasons, ['requires_explicit_mutation_opt_in']);
 
 console.log('WordPress fuzz plan from surfaces smoke passed.');

--- a/wordpress/tests/wordpress-fuzz-runtime-capabilities-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runtime-capabilities-smoke.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+const {
+	WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA,
+	gateWordPressFuzzCaseForRuntimeCapabilities,
+	normalizeWordPressFuzzRuntimeCapabilities,
+	normalizeWordPressFuzzRuntimeCapability,
+	requiredCapabilitiesForWordPressFuzzCase,
+} = require('../lib/wordpress-fuzz-runtime-capabilities');
+
+assert.equal(normalizeWordPressFuzzRuntimeCapability('db-transaction'), 'transaction');
+assert.equal(normalizeWordPressFuzzRuntimeCapability('database_reset'), 'reset');
+assert.equal(normalizeWordPressFuzzRuntimeCapability('unknown'), '');
+
+const contract = normalizeWordPressFuzzRuntimeCapabilities({
+	capabilities: ['snapshots', 'rollback', 'reset-db', 'crud-execution'],
+	execution: { rest: true },
+	metadata: { runtime: 'fixture' },
+});
+assert.equal(contract.schema, WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA);
+assert.deepEqual(contract.capabilities, ['crud', 'reset', 'restore', 'snapshot']);
+assert.equal(contract.isolation.snapshot, true);
+assert.equal(contract.isolation.restore, true);
+assert.equal(contract.isolation.reset, true);
+assert.equal(contract.execution.crud, true);
+assert.equal(contract.execution.rest, true);
+assert.deepEqual(contract.metadata, { runtime: 'fixture' });
+
+assert.deepEqual(requiredCapabilitiesForWordPressFuzzCase('mutating_crud'), ['crud', 'snapshot', 'restore', 'reset']);
+
+const skipped = gateWordPressFuzzCaseForRuntimeCapabilities({
+	id: 'case-1',
+	skip_reasons: ['explicit-opt-in-required'],
+	metadata: { planned: true },
+}, { capabilities: ['crud'] }, { required_capabilities: ['crud', 'snapshot', 'restore', 'reset'] });
+assert.equal(skipped.executable, false);
+assert.deepEqual(skipped.required_capabilities, ['crud', 'reset', 'restore', 'snapshot']);
+assert.deepEqual(skipped.metadata.missing_capabilities, ['reset', 'restore', 'snapshot']);
+assert.deepEqual(skipped.skip_reasons, ['explicit-opt-in-required', 'missing-runtime-fuzz-capabilities']);
+
+const executable = gateWordPressFuzzCaseForRuntimeCapabilities({
+	id: 'case-2',
+	skip_reasons: [],
+	metadata: {},
+}, { capabilities: ['crud', 'snapshot', 'restore', 'reset'] }, { required_capabilities: ['crud', 'snapshot', 'restore', 'reset'] });
+assert.equal(executable.executable, true);
+assert.equal(executable.metadata.executable, true);
+assert.equal(executable.metadata.gated, false);
+assert.equal(executable.metadata.runtime_capability_gated, false);
+
+console.log('WordPress fuzz runtime capabilities smoke passed.');

--- a/wordpress/tests/wordpress-public-export-boundary.test.js
+++ b/wordpress/tests/wordpress-public-export-boundary.test.js
@@ -29,6 +29,8 @@ assert.equal(typeof wordpress.normalizeWordPressFuzzPlan, 'function');
 assert.equal(typeof wordpress.normalizeWordPressFuzzResult, 'function');
 assert.equal(typeof wordpress.normalizeWordPressSurfaceType, 'function');
 assert.equal(typeof wordpress.normalizeWordPressRuntimeSurfaceType, 'function');
+assert.equal(typeof wordpress.normalizeWordPressCoverageSurfaceType, 'function');
+assert.equal(typeof wordpress.normalizeWordPressFuzzRuntimeCapabilities, 'function');
 assert.equal(typeof wordpress.normalizeWordPressCrudOperation, 'function');
 assert.equal(typeof wordpress.normalizeWordPressFixturePersona, 'function');
 assert.equal(typeof wordpress.normalizeWordPressPerformanceObservation, 'function');

--- a/wordpress/tests/wordpress-surface-types-smoke.js
+++ b/wordpress/tests/wordpress-surface-types-smoke.js
@@ -6,6 +6,7 @@ const {
 	WORDPRESS_RUNTIME_SURFACE_ID_PREFIXES,
 	WORDPRESS_SURFACE_COLLECTION_KEYS,
 	WORDPRESS_SURFACE_TYPES,
+	normalizeWordPressCoverageSurfaceType,
 	normalizeWordPressRuntimeSurfaceType,
 	normalizeWordPressSurfaceType,
 	wordpressSurfaceTypeFromCollectionKey,
@@ -37,6 +38,10 @@ assert.equal(normalizeWordPressRuntimeSurfaceType('frontend-url'), 'frontend_url
 assert.equal(normalizeWordPressRuntimeSurfaceType('rest-route'), 'rest_route');
 assert.equal(normalizeWordPressRuntimeSurfaceType('ajax-action'), 'ajax_action');
 assert.equal(normalizeWordPressRuntimeSurfaceType('hook'), '');
+assert.equal(normalizeWordPressCoverageSurfaceType('hook'), 'hook');
+assert.equal(normalizeWordPressCoverageSurfaceType('cron-event'), 'cron_event');
+assert.equal(normalizeWordPressCoverageSurfaceType('post_type'), 'post_type');
+assert.equal(normalizeWordPressCoverageSurfaceType('wp-cli'), 'wp_cli_command');
 
 assert.equal(wordpressSurfaceTypeFromCollectionKey('databaseTables'), 'database-table');
 assert.equal(wordpressSurfaceTypeFromCollectionKey('db_queries'), 'db-query');


### PR DESCRIPTION
## Summary
- Add a generic WordPress fuzz runtime capability contract for isolation and execution surfaces.
- Gate mutating CRUD, REST, admin, and database cases on declared runtime capabilities.
- Carry normalized runtime capabilities through fuzz runner summaries and WP Codebox input metadata.
- Centralize WordPress surface vocabulary and aliases for coverage aggregation.

## Testing
- `node wordpress/tests/wordpress-fuzz-runtime-capabilities-smoke.js`
- `node wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js`
- `node wordpress/tests/wordpress-surface-types-smoke.js`
- `node wordpress/tests/wordpress-fuzz-coverage-aggregate-smoke.js`
- `node wordpress/tests/wordpress-public-export-boundary.test.js`
- `node wordpress/tests/wordpress-fuzz-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, test updates, and PR description drafting.
