### PR TITLE
Bound runtime agent action output

### DIFF
--- a/.github/scripts/runtime-agent-full-run/run-runtime-agent-task.cjs
+++ b/.github/scripts/runtime-agent-full-run/run-runtime-agent-task.cjs
@@ -14,6 +14,7 @@ const path = require('node:path');
  */
 const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 const {
+  genericAgentLoopStdoutSummary,
   runGenericAgentLoop,
   writeGenericAgentLoopArtifacts,
 } = require('../../../runtime-agent-ci');
@@ -69,7 +70,12 @@ try {
     outcomeFile: process.env.HOMEBOY_AGENT_TASK_OUTCOME_FILE || '',
     resultsFile: process.env.HOMEBOY_RUNTIME_AGENT_RESULTS_FILE || '',
   });
-  process.stdout.write(`${JSON.stringify(result.outcome, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(genericAgentLoopStdoutSummary({
+    outcome: result.outcome,
+    results: result.results,
+    outcomeFile: process.env.HOMEBOY_AGENT_TASK_OUTCOME_FILE || '',
+    resultsFile: process.env.HOMEBOY_RUNTIME_AGENT_RESULTS_FILE || '',
+  }), null, 2)}\n`);
   process.exitCode = result.outcome.status === 'succeeded' || result.outcome.status === 'no_op' ? 0 : 1;
 } catch (error) {
   console.error(error && error.message ? error.message : String(error));

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -16,6 +16,8 @@ const { runtimeAgentCiTaskExecutorConfig } = require('./runtime-agent-ci-plan');
 const { evaluateGatePlan } = require('./gate-plan-evaluator');
 const { assertLoopSuccess, loopEvidence, loopIteration, loopRun } = require('./loop-lifecycle.cjs');
 
+const DEFAULT_STDIO_SUMMARY_BYTES = 8192;
+
 function buildGenericAgentLoopRequest(options = {}) {
   const plan = requiredObject(options.plan, 'plan');
   const runtime = requiredObject(options.runtime, 'runtime');
@@ -305,9 +307,7 @@ function executeRuntimeProvider(options = {}) {
     env: { ...(options.env || process.env), ...(invocation.env || {}) },
     maxBuffer: 1024 * 1024 * 20,
   });
-  if (result.stderr && options.stderr !== false && (result.status !== 0 || invocation.stderr === 'inherit')) {
-    process.stderr.write(result.stderr);
-  }
+  const stderrArtifact = handleRuntimeInvocationStderr(result.stderr, { ...options, invocation, result });
   const stdout = String(result.stdout || '');
   if (!stdout.trim()) {
     return {
@@ -318,12 +318,74 @@ function executeRuntimeProvider(options = {}) {
       diagnostics: [{
         class: 'homeboy.agent_loop.no_outcome',
         message: 'Runtime agent task executor produced no JSON outcome.',
-        data: { exit_status: result.status ?? 1 },
+        data: compactObject({ exit_status: result.status ?? 1, stderr_artifact: stderrArtifact }),
       }],
+      metadata: compactObject({ runtime_invocation_stderr_artifact: stderrArtifact }),
     };
   }
   const outcome = JSON.parse(stdout);
-  return captureInvocationResult(outcome, invocation, result);
+  return captureInvocationResult(outcome, invocation, result, { stderrArtifact });
+}
+
+function handleRuntimeInvocationStderr(stderr, options = {}) {
+  const content = String(stderr || '');
+  const invocation = options.invocation || {};
+  const shouldPrint = content && options.stderr !== false && ((options.result?.status ?? 0) !== 0 || invocation.stderr === 'inherit');
+  if (!content) {
+    return null;
+  }
+  const artifact = persistRuntimeInvocationStderr(content, options);
+  if (shouldPrint) {
+    process.stderr.write(`${boundedText(content, options.stderrMaxBytes || options.stderr_max_bytes || DEFAULT_STDIO_SUMMARY_BYTES)}\n`);
+    if (artifact) {
+      process.stderr.write(`Runtime stderr artifact: ${artifact.path}\n`);
+    }
+  }
+  return artifact;
+}
+
+function persistRuntimeInvocationStderr(content, options = {}) {
+  const artifactDir = runtimeArtifactDir(options);
+  if (!artifactDir) {
+    return null;
+  }
+  const taskId = options.request?.task_id || options.plan?.workload_id || options.plan?.task_id || 'runtime-agent-task';
+  const filePath = path.join(artifactDir, `${safeFileSegment(taskId)}-runtime-stderr.txt`);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+  return {
+    kind: 'runtime-stderr',
+    path: filePath,
+    bytes: Buffer.byteLength(content),
+  };
+}
+
+function runtimeArtifactDir(options = {}) {
+  return firstString(
+    options.stderrArtifactDir,
+    options.stderr_artifact_dir,
+    options.plan?.artifacts_path,
+    options.plan?.artifacts,
+    options.env?.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR,
+    options.env?.HOMEBOY_RUNTIME_AGENT_ARTIFACTS,
+    process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS_DIR,
+    process.env.HOMEBOY_RUNTIME_AGENT_ARTIFACTS,
+  );
+}
+
+function boundedText(value, maxBytes = DEFAULT_STDIO_SUMMARY_BYTES) {
+  const content = String(value || '');
+  const limit = positiveInteger(maxBytes) || DEFAULT_STDIO_SUMMARY_BYTES;
+  if (Buffer.byteLength(content) <= limit) {
+    return content.replace(/\s+$/u, '');
+  }
+  const buffer = Buffer.from(content);
+  const truncated = buffer.subarray(0, limit).toString('utf8').replace(/\s+$/u, '');
+  return `${truncated}\n[truncated ${Buffer.byteLength(content) - Buffer.byteLength(truncated)} bytes; see artifact for full output]`;
+}
+
+function safeFileSegment(value) {
+  return String(value || 'runtime-agent-task').replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'runtime-agent-task';
 }
 
 function runtimeExecutorInvocation(runtime = {}) {
@@ -364,7 +426,7 @@ function invocationStdin(invocation, request) {
   return JSON.stringify(request);
 }
 
-function captureInvocationResult(outcome, invocation, result) {
+function captureInvocationResult(outcome, invocation, result, options = {}) {
   const metadata = optionalObject(outcome.metadata);
   const invocationResult = {
     command: invocation.command,
@@ -372,6 +434,7 @@ function captureInvocationResult(outcome, invocation, result) {
     cwd: invocation.cwd || '',
     exit_status: result.status ?? 0,
     signal: result.signal || null,
+    stderr_artifact: options.stderrArtifact || undefined,
   };
   return {
     ...outcome,
@@ -675,6 +738,59 @@ function writeGenericAgentLoopArtifacts(options = {}) {
   }
 }
 
+function genericAgentLoopStdoutSummary(options = {}) {
+  const outcome = optionalObject(options.outcome);
+  const results = optionalObject(options.results);
+  const outcomeFile = options.outcomeFile || options.outcome_file || '';
+  const resultsFile = options.resultsFile || options.results_file || '';
+  const artifacts = normalizeArray(outcome.artifacts);
+  const evidenceRefs = normalizeArray(outcome.evidence_refs || outcome.evidence);
+  const diagnostics = normalizeArray(outcome.diagnostics);
+  return {
+    schema: 'homeboy/agent-task-stdout-summary/v1',
+    task_id: outcome.task_id || options.request?.task_id || '',
+    status: outcome.status || '',
+    summary: boundedText(outcome.summary || '', options.summaryMaxBytes || 2048),
+    artifact_count: artifacts.length,
+    evidence_ref_count: evidenceRefs.length,
+    diagnostic_count: diagnostics.length,
+    artifact_refs: artifacts.slice(0, 10).map(compactArtifactRef),
+    evidence_refs: evidenceRefs.slice(0, 10).map(compactEvidenceRef),
+    diagnostics: diagnostics.slice(0, 10).map(compactDiagnostic),
+    result_scenario_count: normalizeArray(results.scenarios).length,
+    files: compactObject({ outcome: outcomeFile, results: resultsFile }),
+  };
+}
+
+function compactArtifactRef(artifact = {}) {
+  return compactObject({
+    id: artifact.id,
+    name: artifact.name,
+    kind: artifact.kind || artifact.type || artifact.artifact_kind || artifact.artifactKind,
+    path: artifact.path,
+    url: artifact.url,
+    uri: artifact.uri,
+  });
+}
+
+function compactEvidenceRef(ref = {}) {
+  return compactObject({
+    id: ref.id,
+    kind: ref.kind || ref.type,
+    label: ref.label || ref.name,
+    url: ref.url,
+    uri: ref.uri,
+    path: ref.path,
+  });
+}
+
+function compactDiagnostic(diagnostic = {}) {
+  return compactObject({
+    class: diagnostic.class || diagnostic.kind || diagnostic.code,
+    message: boundedText(diagnostic.message || '', 2048),
+  });
+}
+
 function expectedArtifactsFromPlan(plan) {
   const expected = normalizeArray(plan.expected_artifacts);
   if (expected.length > 0) {
@@ -854,11 +970,16 @@ function isPlainObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value);
 }
 
+function firstString(...values) {
+  return values.find((value) => typeof value === 'string' && value.trim() !== '') || '';
+}
+
 module.exports = {
   assertGenericAgentLoopOutcome,
   assertGenericAgentLoopRuntimeContract,
   buildGenericAgentLoopRequest,
   materializeGenericAgentLoopResults,
+  genericAgentLoopStdoutSummary,
   runGenericAgentLoop,
   runGenericDeterministicLoop,
   validateGenericAgentLoopOutcomeContract,

--- a/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
+++ b/runtime-agent-ci/tests/generic-agent-loop-runner.test.js
@@ -63,7 +63,7 @@ const stoppedUnacceptedLoop = genericLoopRunner.runGenericDeterministicLoop({
   collectResult: ({ outcome }) => outcome,
   reconcile: ({ state }) => ({ ...state, accepted: false }),
 });
-assert.equal(stoppedUnacceptedLoop.iterations[0].stop.reason, 'max_iterations_reached');
+assert.equal(stoppedUnacceptedLoop.iterations[0].stop.reason, 'max_revolutions_reached');
 assert.equal(stoppedUnacceptedLoop.evidence_envelope.loop_run.iterations[0].accepted, false);
 
 const runtime = { id: 'fixture-runtime', executor: { backend: 'fixture', path: '/unused' } };
@@ -238,6 +238,84 @@ process.stdout.write(JSON.stringify({
   assert.equal(nodeRun.outcome.status, 'succeeded');
   assert.equal(nodeRun.outcome.metadata.runtime_invocation_result.command, process.execPath);
   assert.deepEqual(nodeRun.outcome.metadata.runtime_invocation_result.argv, [nodeExecutorPath]);
+
+  const noisyExecutorPath = path.join(tmpRoot, 'fake-noisy-executor.cjs');
+  const noisyArtifactsDir = path.join(tmpRoot, 'artifacts');
+  const lateSentinel = 'LATE_PROVIDER_STDERR_SENTINEL';
+  fs.writeFileSync(noisyExecutorPath, `'use strict';
+const request = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
+process.stderr.write('provider stderr prefix\\n' + 'x'.repeat(20000) + '${lateSentinel}\\n');
+process.stdout.write(JSON.stringify({
+  schema: 'homeboy/agent-task-outcome/v1',
+  task_id: request.task_id,
+  status: 'succeeded',
+  summary: 'Noisy executor completed.',
+  metadata: {
+    results: { scenarios: [{ id: request.task_id, metrics: { generic_agent_task_executor_mean: 1 }, metadata: { job_status: 'completed', success_status: 'no_changes', completion_outcome: 'done', completion_outcome_satisfied: true } }] },
+  },
+}));
+`);
+  let capturedStderr = '';
+  const originalStderrWrite = process.stderr.write;
+  process.stderr.write = (chunk, encoding, callback) => {
+    capturedStderr += String(chunk);
+    if (typeof callback === 'function') {
+      callback();
+    }
+    return true;
+  };
+  let noisyRun;
+  try {
+    noisyRun = genericLoopRunner.runGenericAgentLoop({
+      runtime: {
+        id: 'manifest-noisy-runtime',
+        executor: {
+          backend: 'node-fixture',
+          invocation: {
+            command: process.execPath,
+            argv: [noisyExecutorPath],
+            cwd: tmpRoot,
+            stdin: 'request_json',
+            stdout: 'outcome_json',
+            stderr: 'inherit',
+          },
+        },
+      },
+      plan: { ...plan, workload_id: 'manifest-noisy', artifacts_path: noisyArtifactsDir },
+      validationPolicy: { success_completion_outcomes: ['done'] },
+      stderrMaxBytes: 256,
+    });
+  } finally {
+    process.stderr.write = originalStderrWrite;
+  }
+  assert.equal(noisyRun.outcome.status, 'succeeded');
+  assert.match(capturedStderr, /Runtime stderr artifact:/);
+  assert.doesNotMatch(capturedStderr, new RegExp(lateSentinel), 'large provider stderr must not be inherited wholesale');
+  const stderrArtifact = noisyRun.outcome.metadata.runtime_invocation_result.stderr_artifact;
+  assert.equal(stderrArtifact.kind, 'runtime-stderr');
+  assert.equal(fs.readFileSync(stderrArtifact.path, 'utf8').includes(lateSentinel), true, 'full provider stderr is preserved as an artifact');
+
+  const hugePayloadSentinel = 'WHOLESALE_RESULT_PAYLOAD_SENTINEL';
+  const stdoutSummary = genericLoopRunner.genericAgentLoopStdoutSummary({
+    outcome: {
+      schema: 'homeboy/agent-task-outcome/v1',
+      task_id: 'large-payload',
+      status: 'succeeded',
+      summary: 'Large payload outcome completed.',
+      metadata: {
+        provider_result: `${'y'.repeat(20000)}${hugePayloadSentinel}`,
+      },
+      artifacts: [{ name: 'provider-result', kind: 'json', path: '/tmp/provider-result.json', payload: `${'z'.repeat(20000)}${hugePayloadSentinel}` }],
+      evidence_refs: [{ kind: 'provider-result', uri: 'artifact://provider-result' }],
+    },
+    results: { scenarios: [{ id: 'large-payload' }] },
+    outcomeFile: '/tmp/outcome.json',
+    resultsFile: '/tmp/results.json',
+  });
+  const stdoutSummaryJson = JSON.stringify(stdoutSummary);
+  assert.doesNotMatch(stdoutSummaryJson, new RegExp(hugePayloadSentinel), 'stdout summary must not include full provider result or artifact payloads');
+  assert.equal(stdoutSummary.files.outcome, '/tmp/outcome.json');
+  assert.equal(stdoutSummary.artifact_refs[0].path, '/tmp/provider-result.json');
 } finally {
   fs.rmSync(tmpRoot, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- Replace full runtime-agent full-run stdout outcome dumps with a compact stdout summary that points to outcome/results files.
- Bound inherited provider stderr and persist full stderr to runtime artifacts when an artifact directory is configured.
- Add coverage that large provider stderr/result/artifact payloads are not emitted wholesale to the job stream.

## Tests
- `node runtime-agent-ci/tests/generic-agent-loop-runner.test.js`
- `node tests/runtime-agent-ci-contract-smoke.mjs`
- `node tests/wp-codebox-run-agent-task-contract-smoke.mjs`
- `node tests/wp-codebox-artifact-contract-smoke.mjs`
- `node tests/runtime-agent-full-run-provider-neutral-smoke.mjs`
- `node tests/runtime-agent-full-run-local-shell-smoke.mjs`
- `HOMEBOY_WP_CODEBOX_CORE_MODULE="/Users/chubes/Developer/homeboy-extensions@fix-runtime-action-bounded-output/tests/fixtures/wp-codebox-core-runtime-contract.cjs" node tests/runtime-agent-full-run-codebox-inputs-smoke.mjs`

## Notes
- The Codebox full-run input smoke requires the local WP Codebox contract fixture in this checkout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, test updates, and PR drafting.