### PR TITLE
Pass WP Codebox monorepo source paths to fuzz

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -244,10 +244,16 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 		return undefined;
 	}
 	const slug = workload.target?.slug || componentId;
+	const component = objectOrUndefined(context.components?.[componentId]);
+	const wordpressExtension = objectOrUndefined(component?.extensions?.wordpress);
+	const sourceSubpath = nonEmptyString(wordpressExtension?.wp_codebox_source_subpath || wordpressExtension?.wpCodeboxSourceSubpath);
+	const sourceRoot = wpCodeboxSourceRoot({ source, sourceSubpath, wordpressExtension });
 	return {
 		extraPlugin: stripUndefined({
 			slug,
 			source,
+			sourceRoot,
+			sourceSubpath,
 			path: source,
 			pluginFile: activation,
 			loadAs: 'plugin',
@@ -260,10 +266,23 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 		componentContract: stripUndefined({
 			slug,
 			path: source,
+			sourceRoot,
+			sourceSubpath,
 			pluginFile: activation,
 			loadAs: 'plugin',
 		}),
 	};
+}
+
+function wpCodeboxSourceRoot({ source, sourceSubpath, wordpressExtension } = {}) {
+	const configured = nonEmptyString(wordpressExtension?.wp_codebox_source_root || wordpressExtension?.wpCodeboxSourceRoot);
+	if (configured && !configured.startsWith('~/')) {
+		return configured;
+	}
+	if (!sourceSubpath || !source.endsWith(`/${sourceSubpath}`)) {
+		return configured;
+	}
+	return source.slice(0, -sourceSubpath.length - 1);
 }
 
 function nonEmptyString(value) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -135,14 +135,23 @@ const jsonWorkloadResult = buildWordPressFuzzRunnerResult({
 		target: { type: 'wordpress-plugin', slug: 'sample-plugin', component: 'sample-plugin' },
 		metadata: {
 			fixture: { component: 'sample-plugin', activation: 'sample-plugin/sample-plugin.php' },
-			homeboy_runtime_context: {
-				schema: 'homeboy/fuzz-workload-runtime-context/v1',
-				rig_id: 'sample-rig',
-				components: {
-					'sample-plugin': { path: '/runner/components/sample-plugin', branch: 'main' },
+				homeboy_runtime_context: {
+					schema: 'homeboy/fuzz-workload-runtime-context/v1',
+					rig_id: 'sample-rig',
+					components: {
+						'sample-plugin': {
+							path: '/runner/components/sample-plugin/plugins/sample-plugin',
+							branch: 'main',
+							extensions: {
+								wordpress: {
+									wp_codebox_source_root: '~/components/sample-plugin',
+									wp_codebox_source_subpath: 'plugins/sample-plugin',
+								},
+							},
+						},
+					},
 				},
 			},
-		},
 		workload: {
 			runner: 'wp-codebox',
 			type: 'json',
@@ -175,8 +184,10 @@ assert.equal(jsonWorkloadResult.wp_codebox_input.cases[0].artifacts[0].required,
 assert.equal(jsonWorkloadResult.wp_codebox_input.metadata.artifacts.expected[0].semantic_key, 'fuzz.suite_result');
 assert.deepEqual(jsonWorkloadResult.wp_codebox_runtime_requirements.extra_plugins, [{
 	slug: 'sample-plugin',
-	source: '/runner/components/sample-plugin',
-	path: '/runner/components/sample-plugin',
+	source: '/runner/components/sample-plugin/plugins/sample-plugin',
+	sourceRoot: '/runner/components/sample-plugin',
+	sourceSubpath: 'plugins/sample-plugin',
+	path: '/runner/components/sample-plugin/plugins/sample-plugin',
 	pluginFile: 'sample-plugin/sample-plugin.php',
 	loadAs: 'plugin',
 	activate: true,
@@ -184,8 +195,10 @@ assert.deepEqual(jsonWorkloadResult.wp_codebox_runtime_requirements.extra_plugin
 }]);
 assert.equal(
 	jsonWorkloadResult.wp_codebox_task_request.executor.config.runtime_requirements.extra_plugins[0].source,
-	'/runner/components/sample-plugin'
+	'/runner/components/sample-plugin/plugins/sample-plugin'
 );
+assert.equal(jsonWorkloadResult.wp_codebox_task_request.executor.config.runtime_requirements.extra_plugins[0].sourceRoot, '/runner/components/sample-plugin');
+assert.equal(jsonWorkloadResult.wp_codebox_task_request.executor.config.runtime_requirements.component_contracts[0].sourceSubpath, 'plugins/sample-plugin');
 assert.deepEqual(jsonWorkloadResult.wp_codebox_runtime_requirements.runtime_mounts, [{ source: '/runner/workloads', target: '/runner/workloads', mode: 'readonly' }]);
 assert.deepEqual(jsonWorkloadResult.wp_codebox_runtime_requirements.runtime_env, { WP_CODEBOX_FUZZ_WORKLOAD_ROOT: '/runner/workloads' });
 assert.ok(manifest.fuzz.env.includes('WP_CODEBOX_FUZZ_WORKLOAD_ROOT'));


### PR DESCRIPTION
## Summary
- Pass wp_codebox_source_root and wp_codebox_source_subpath into fuzz runtime requirements.
- Derive an absolute sourceRoot from component.path plus sourceSubpath when the rig source root uses ~.
- Cover the fuzz runner contract for monorepo plugin source paths.

## Testing
- node wordpress/tests/wordpress-fuzz-runner-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Connecting WooCommerce rig source-root/subpath metadata to the WP Codebox fuzz runtime requirements and updating focused smoke coverage.