### PR TITLE
Preserve fuzz inputs across Lab remaps

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -247,13 +247,13 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 	const component = objectOrUndefined(context.components?.[componentId]);
 	const wordpressExtension = objectOrUndefined(component?.extensions?.wordpress);
 	const sourceSubpath = nonEmptyString(wordpressExtension?.wp_codebox_source_subpath || wordpressExtension?.wpCodeboxSourceSubpath);
-	const sourceRoot = wpCodeboxSourceRoot({ source, sourceSubpath, wordpressExtension });
+	const sourceLayout = wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension });
 	return {
 		extraPlugin: stripUndefined({
 			slug,
 			source,
-			sourceRoot,
-			sourceSubpath,
+			sourceRoot: sourceLayout.sourceRoot,
+			sourceSubpath: sourceLayout.sourceSubpath,
 			path: source,
 			pluginFile: activation,
 			loadAs: 'plugin',
@@ -266,23 +266,36 @@ function buildWpCodeboxFuzzPluginRequirement({ workload = {}, componentId, sourc
 		componentContract: stripUndefined({
 			slug,
 			path: source,
-			sourceRoot,
-			sourceSubpath,
+			sourceRoot: sourceLayout.sourceRoot,
+			sourceSubpath: sourceLayout.sourceSubpath,
 			pluginFile: activation,
 			loadAs: 'plugin',
 		}),
 	};
 }
 
-function wpCodeboxSourceRoot({ source, sourceSubpath, wordpressExtension } = {}) {
+function wpCodeboxSourceLayout({ source, sourceSubpath, wordpressExtension } = {}) {
 	const configured = nonEmptyString(wordpressExtension?.wp_codebox_source_root || wordpressExtension?.wpCodeboxSourceRoot);
+	const normalizedSubpath = nonEmptyString(sourceSubpath);
+	if (normalizedSubpath && source.endsWith(`/${normalizedSubpath}`)) {
+		return {
+			sourceRoot: source.slice(0, -normalizedSubpath.length - 1),
+			sourceSubpath: normalizedSubpath,
+		};
+	}
+
+	if (configured && configured.startsWith('~/')) {
+		return {};
+	}
+
 	if (configured && !configured.startsWith('~/')) {
-		return configured;
+		return {
+			sourceRoot: configured,
+			sourceSubpath: normalizedSubpath,
+		};
 	}
-	if (!sourceSubpath || !source.endsWith(`/${sourceSubpath}`)) {
-		return configured;
-	}
-	return source.slice(0, -sourceSubpath.length - 1);
+
+	return {};
 }
 
 function nonEmptyString(value) {

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -193,6 +193,7 @@ function homeboyFuzzWorkloadPlanCaseToWpCodeboxCase(entry = {}, manifest = {}, i
 		target: { kind: 'runtime', id: command, entrypoint: command },
 		description: entry.description || manifest.label,
 		input: objectOrUndefined(entry.input),
+		inputs: objectOrUndefined(entry.inputs),
 		phases: homeboyFuzzWorkloadPlanCasePhases(entry, manifest, artifacts),
 		artifacts,
 		metadata: stripUndefined({
@@ -272,6 +273,7 @@ function homeboyFuzzWorkloadCaseToWpCodeboxCase(entry = {}, manifest = {}, index
 			entry: execute.entry || manifest.workload?.entry,
 			parameters: objectOrUndefined(execute.parameters),
 		}),
+		inputs: objectOrUndefined(entry.inputs),
 		phases: homeboyFuzzWorkloadCasePhases(entry, manifest, intent, artifacts),
 		artifacts,
 		metadata: stripUndefined({

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -687,6 +687,9 @@ function normalizeFuzzArtifact(artifact) {
 		content_type: artifact.content_type || artifact.contentType || artifact.mime,
 		sha256,
 		size_bytes: numberOrUndefined(artifact.size_bytes ?? artifact.sizeBytes ?? artifact.bytes),
+		payload: objectOrUndefined(artifact.payload),
+		data: objectOrUndefined(artifact.data),
+		content: objectOrUndefined(artifact.content),
 		case_id: artifact.case_id || artifact.caseId,
 		status: artifact.status,
 		metadata: stripUndefined({

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -203,6 +203,53 @@ assert.deepEqual(jsonWorkloadResult.wp_codebox_runtime_requirements.runtime_moun
 assert.deepEqual(jsonWorkloadResult.wp_codebox_runtime_requirements.runtime_env, { WP_CODEBOX_FUZZ_WORKLOAD_ROOT: '/runner/workloads' });
 assert.ok(manifest.fuzz.env.includes('WP_CODEBOX_FUZZ_WORKLOAD_ROOT'));
 
+const remappedPluginRootResult = buildWordPressFuzzRunnerResult({
+	env: {
+		workloadPath: '/unused/in-unit-test.json',
+		workloadId: 'jetpack-performance-observation',
+		runId: 'jetpack-performance-observation-run',
+		wpCodeboxFuzzWorkloadRoot: '/runner/workloads',
+	},
+	workload: {
+		schema: 'homeboy/fuzz-workload/v1',
+		id: 'jetpack-performance-observation',
+		label: 'Jetpack performance observation',
+		target: { type: 'wordpress-plugin', slug: 'jetpack', component: 'jetpack' },
+		metadata: {
+			fixture: { component: 'jetpack', activation: 'jetpack/jetpack.php' },
+			homeboy_runtime_context: {
+				schema: 'homeboy/fuzz-workload-runtime-context/v1',
+				rig_id: 'jetpack-api-route-inventory',
+				components: {
+					jetpack: {
+						path: '/home/chubes/Developer/_lab_workspaces/jetpack-1234',
+						extensions: {
+							wordpress: {
+								wp_codebox_source_root: '~/Developer/jetpack',
+								wp_codebox_source_subpath: 'projects/plugins/jetpack',
+							},
+						},
+					},
+				},
+			},
+		},
+		cases: [{
+			case_id: 'jetpack-performance-observation:default',
+			phases: {
+				setup: [{ command: 'wordpress.ensure-plugin-active', args: ['plugin=jetpack/jetpack.php'] }],
+				action: [{ command: 'wordpress.run-workload', args: ['path=${package.root}/bench/performance.workload.json'] }],
+			},
+		}],
+	},
+});
+const remappedPlugin = remappedPluginRootResult.wp_codebox_runtime_requirements.extra_plugins[0];
+assert.equal(remappedPlugin.source, '/home/chubes/Developer/_lab_workspaces/jetpack-1234');
+assert.equal(remappedPlugin.sourceRoot, undefined);
+assert.equal(remappedPlugin.sourceSubpath, undefined);
+assert.equal(remappedPlugin.pluginFile, 'jetpack/jetpack.php');
+assert.equal(remappedPluginRootResult.wp_codebox_runtime_requirements.component_contracts[0].sourceRoot, undefined);
+assert.equal(remappedPluginRootResult.wp_codebox_runtime_requirements.component_contracts[0].sourceSubpath, undefined);
+
 const genericPrimitiveResult = buildWordPressFuzzRunnerResult({
 	env: {
 		workloadPath: '/unused/in-unit-test.json',

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -214,6 +214,10 @@ const planWorkloadManifest = {
 					namespaces: ['sample/v1', 'sample/v2'],
 					artifact: 'route_inventory',
 				},
+				inputs: {
+					observation_surfaces: ['rest_generated_cases'],
+					budget_keys: ['max_rest_p95_duration_ms'],
+				},
 				metadata: { expected_artifact: 'route_inventory' },
 			}],
 		}],
@@ -241,6 +245,7 @@ assert.deepEqual(planWorkloadInput.cases[0].phases.action, [{
 assert.equal(JSON.stringify(planWorkloadInput).includes('/host-only/workload.php'), false);
 assert.equal(planWorkloadInput.cases[0].metadata.source_plan_case, true);
 assert.equal(planWorkloadInput.cases[0].metadata.target_id, 'sample-rest-routes');
+assert.deepEqual(planWorkloadInput.cases[0].inputs.budget_keys, ['max_rest_p95_duration_ms']);
 
 let invoked = false;
 runWpCodeboxFuzzSuite({

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -295,7 +295,7 @@ runWpCodeboxFuzzSuite({
 				},
 				artifacts: {
 					fuzz_report: { path: 'reports/fuzz-report.json', content_type: 'application/json' },
-					coverage: { path: 'reports/coverage.json', content_type: 'application/json', size_bytes: 123 },
+					coverage: { path: 'reports/coverage.json', content_type: 'application/json', size_bytes: 123, payload: { schema: 'wp-codebox/coverage-report/v1', covered: 1 } },
 					normalized_fuzz_result: { path: 'reports/wordpress-fuzz-result.json', content_type: 'application/json' },
 					fuzz_case: { path: 'cases/case-000.json', case_id: 'case-000' },
 					placeholder_case: { name: 'placeholder-only' },
@@ -337,6 +337,7 @@ runWpCodeboxFuzzSuite({
 	assert.equal(summary.artifacts[7].semantic_key, 'fuzz.case.repro');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'coverage').semantic_key, 'fuzz.coverage');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'coverage').size_bytes, 123);
+	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'coverage').payload.schema, 'wp-codebox/coverage-report/v1');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'normalized_fuzz_result').semantic_key, 'fuzz.result.normalized');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'fuzz_case').semantic_key, 'fuzz.case');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'fuzz_case').case_id, 'case-000');


### PR DESCRIPTION
## Summary

- Ignore stale WP Codebox source roots after Lab remaps a monorepo checkout.
- Preserve fuzz artifact payloads from WP Codebox results during normalization.
- Preserve Homeboy fuzz workload case `inputs` when converting plan-derived and direct workload cases for WP Codebox.

## Validation

- `node wordpress/tests/wordpress-fuzz-runner-smoke.js`
- `node wordpress/tests/wp-codebox-fuzz-run-smoke.js`
- Installed locally and on `homeboy-lab` from `fix/jetpack-fuzz-lab-source-path`.
- Used by Jetpack Lab fuzz evidence run `jetpack-performance-observation-20260623-measure5`.

## Evidence

- Final Jetpack measured fuzz run passed on Lab.
- Evidence artifact: `runner-artifact://homeboy-lab/jetpack-performance-observation-20260623-measure5/e6d6a4d4-da3f-4606-ad1e-35ee20efc62c`

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing Lab remap/input propagation issues, implementing normalizer fixes, running smoke tests, and collecting evidence.
