### PR TITLE
Derive WordPress fuzz campaign safety

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -25,6 +25,7 @@ const { aggregateWordPressFuzzCoverage } = require('./wordpress-fuzz-coverage-ag
 
 const WORDPRESS_FUZZ_RUNNER_RESULT_SCHEMA = 'homeboy/wordpress-fuzz-runner-result/v1';
 const HOMEBOY_FUZZ_CAMPAIGN_SCHEMA = 'homeboy/fuzz-campaign/v1';
+const HOMEBOY_FUZZ_CONTRACT_VERSION = 1;
 
 function readWordPressFuzzRunnerEnv(env = process.env) {
 	return stripUndefined({
@@ -354,9 +355,10 @@ function buildHomeboyFuzzCampaign({ runId, workloadId, plan, codeboxResult, stat
 	const diagnostics = normalizeArray(codeboxResult?.failures || codeboxResult?.metadata?.diagnostics || codeboxResult?.diagnostics);
 	return stripUndefined({
 		schema: HOMEBOY_FUZZ_CAMPAIGN_SCHEMA,
+		version: HOMEBOY_FUZZ_CONTRACT_VERSION,
 		id: runId,
 		title: `WordPress fuzz campaign ${runId}`,
-		safety_class: 'read_only',
+		safety_class: deriveHomeboyFuzzSafetyClass(plan),
 		metadata: stripUndefined({
 			workload_id: workloadId,
 			plan_id: plan?.id,
@@ -368,6 +370,72 @@ function buildHomeboyFuzzCampaign({ runId, workloadId, plan, codeboxResult, stat
 			wordpress_fuzz_result: codeboxResult?.wordpress_fuzz_result,
 		}),
 	});
+}
+
+function deriveHomeboyFuzzSafetyClass(plan = {}) {
+	return strongestFuzzSafetyClass(fuzzSafetyClassCandidates(plan));
+}
+
+function fuzzSafetyClassCandidates(plan = {}) {
+	const candidates = [fuzzSafetyCandidateFrom(plan), fuzzSafetyCandidateFrom(plan.metadata)];
+	for (const target of normalizeArray(plan.targets)) {
+		candidates.push(fuzzSafetyCandidateFrom(target), fuzzSafetyCandidateFrom(target.metadata));
+		for (const testCase of normalizeArray(target.cases)) {
+			candidates.push(fuzzSafetyCandidateFrom(testCase), fuzzSafetyCandidateFrom(testCase.metadata));
+		}
+	}
+	return candidates.filter(Boolean);
+}
+
+function fuzzSafetyCandidateFrom(source = {}) {
+	if (!source || typeof source !== 'object') {
+		return undefined;
+	}
+	const safety = objectOrUndefined(source.safety) || {};
+	const explicit = source.safety_class || source.safetyClass || safety.safety_class || safety.safetyClass || safety.class || safety.level || safety.mutation || source.mutation;
+	const explicitClass = normalizeHomeboyFuzzSafetyClass(explicit);
+	if (explicitClass) {
+		return explicitClass;
+	}
+	if (source.destructive === true || safety.destructive === true || safety.level === 'destructive') {
+		return 'destructive';
+	}
+	if (source.mutates === true || safety.mutates === true || normalizeArray(source.destructive_reasons || source.destructiveReasons || source.destructive_reason || source.destructiveReason).length > 0) {
+		return 'isolated_mutation';
+	}
+	return undefined;
+}
+
+function strongestFuzzSafetyClass(candidates = []) {
+	const rank = {
+		read_only: 0,
+		idempotent: 1,
+		isolated_mutation: 2,
+		destructive: 3,
+	};
+	return candidates.reduce((strongest, candidate) => (
+		rank[candidate] > rank[strongest] ? candidate : strongest
+	), 'read_only');
+}
+
+function normalizeHomeboyFuzzSafetyClass(value) {
+	const label = String(value || '').trim().toLowerCase().replace(/[\s.-]+/g, '_');
+	if (!label) {
+		return undefined;
+	}
+	if (['read_only', 'readonly', 'read', 'safe', 'non_mutating', 'none'].includes(label)) {
+		return 'read_only';
+	}
+	if (['idempotent', 'repeatable'].includes(label)) {
+		return 'idempotent';
+	}
+	if (['isolated_mutation', 'isolated', 'mutation', 'mutating', 'write', 'requires_isolated_editor_draft', 'requires_explicit_opt_in'].includes(label)) {
+		return 'isolated_mutation';
+	}
+	if (['destructive', 'delete', 'dangerous'].includes(label)) {
+		return 'destructive';
+	}
+	return undefined;
 }
 
 function writeHomeboyFuzzResultsFile(filePath, campaign) {

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -25,6 +25,10 @@ const DEFAULT_FUZZ_RUN_ABILITY = legacyWpCodeboxFuzzRunAbilityAlias();
 const DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS = [
 	'wp-codebox-fuzz-suite-result',
 	'wordpress-fuzz-coverage',
+	'result-envelope',
+	'case-log',
+	'replay-data',
+	'coverage-summary',
 ];
 const DEFAULT_FUZZ_RUN_EXPECTED_ARTIFACTS = legacyWpCodeboxFuzzRunExpectedArtifactsAlias();
 const DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS = [
@@ -57,6 +61,30 @@ const DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS = [
 		semantic_key: 'fuzz.case.repro',
 		required: false,
 	},
+	{
+		name: 'result-envelope',
+		semantic_key: 'fuzz.result.envelope',
+		content_type: 'application/json',
+		required: true,
+	},
+	{
+		name: 'case-log',
+		semantic_key: 'fuzz.case.log',
+		content_type: 'application/jsonl',
+		required: true,
+	},
+	{
+		name: 'replay-data',
+		semantic_key: 'fuzz.replay.data',
+		content_type: 'application/json',
+		required: true,
+	},
+	{
+		name: 'coverage-summary',
+		semantic_key: 'fuzz.coverage.summary',
+		content_type: 'application/json',
+		required: true,
+	},
 ];
 const DEFAULT_FUZZ_RUN_ARTIFACT_DECLARATIONS = legacyWpCodeboxFuzzRunArtifactDeclarationsAlias();
 const HOMEBOY_FUZZ_WORKLOAD_SCHEMA = 'homeboy/fuzz-workload/v1';
@@ -67,6 +95,10 @@ const FUZZ_ARTIFACT_SEMANTIC_KEYS = {
 	failing_case: 'fuzz.case.failing',
 	case_artifact: 'fuzz.case.artifact',
 	repro_case: 'fuzz.case.repro',
+	case_log: 'fuzz.case.log',
+	replay_data: 'fuzz.replay.data',
+	coverage_summary: 'fuzz.coverage.summary',
+	result_envelope: 'fuzz.result.envelope',
 	normalized_fuzz_result: 'fuzz.result.normalized',
 	coverage: 'fuzz.coverage',
 };
@@ -294,17 +326,23 @@ function homeboyFuzzWorkloadCasePhases(entry = {}, manifest = {}, intent = {}, a
 	const setup = typeof activation === 'string' && activation.trim() !== ''
 		? [{ command: 'wordpress.ensure-plugin-active', args: [`plugin=${activation}`] }]
 		: undefined;
-	const action = typeof genericCommand === 'string'
-		? [{ command: genericCommand, args: homeboyFuzzCommandArgs(objectOrUndefined(execute.parameters) || {}) }]
-		: typeof path === 'string' && path.trim() !== ''
-			? [{ command: 'wordpress.run-workload', args: [`path=${path}`] }]
-			: [];
+	const action = homeboyFuzzWorkloadCaseAction({ genericCommand, path, execute });
 	const collect = normalizeArray(intent.collect).length > 0 ? normalizeArray(intent.collect) : artifacts.map((artifact) => ({ artifact: artifact.name }));
 	const assert = collect
 		.map((item) => item?.artifact)
 		.filter(Boolean)
 		.map((artifact) => ({ command: 'wordpress.collect-workload-result', args: [`artifact=${artifact}`] }));
 	return stripUndefined({ setup, action, assert: assert.length > 0 ? assert : undefined });
+}
+
+function homeboyFuzzWorkloadCaseAction({ genericCommand, path, execute = {} } = {}) {
+	if (typeof genericCommand === 'string') {
+		return [{ command: genericCommand, args: homeboyFuzzCommandArgs(objectOrUndefined(execute.parameters) || {}) }];
+	}
+	if (typeof path === 'string' && path.trim() !== '') {
+		return [{ command: 'wordpress.run-workload', args: [`path=${path}`] }];
+	}
+	return [];
 }
 
 function homeboyFuzzWorkloadGenericPrimitiveCommand(manifest = {}) {
@@ -723,6 +761,18 @@ function normalizeFuzzArtifactRole(value) {
 	}
 	if (['normalized_fuzz_result', 'wordpress_fuzz_result', 'normalized_result'].includes(label)) {
 		return 'normalized_fuzz_result';
+	}
+	if (['result_envelope', 'fuzz_result_envelope'].includes(label)) {
+		return 'result_envelope';
+	}
+	if (['case_log', 'case_logs', 'fuzz_case_log'].includes(label)) {
+		return 'case_log';
+	}
+	if (['replay_data', 'replay_dataset', 'replay_inputs'].includes(label)) {
+		return 'replay_data';
+	}
+	if (['coverage_summary', 'fuzz_coverage_summary'].includes(label)) {
+		return 'coverage_summary';
 	}
 	if (['coverage', 'wordpress_fuzz_coverage', 'fuzz_coverage', 'coverage_artifact'].includes(label)) {
 		return 'coverage';

--- a/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
+++ b/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
@@ -21,6 +21,7 @@ const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wordpress-fuzz-codebox-co
 const workloadPath = path.join(tempDir, 'workload.json');
 const resultsPath = path.join(tempDir, 'campaign.json');
 const observedRequestPath = path.join(tempDir, 'observed-fuzz-suite-request.json');
+const emptyCodeboxInstallRoot = path.join(tempDir, 'empty-wp-codebox-install');
 const fakeCodeboxBin = path.join(tempDir, 'wp-codebox');
 const runnerPath = path.join(__dirname, '..', 'scripts', 'fuzz', 'fuzz-runner.cjs');
 
@@ -48,6 +49,7 @@ const workload = {
 };
 
 fs.writeFileSync(workloadPath, `${JSON.stringify(workload, null, 2)}\n`);
+fs.mkdirSync(emptyCodeboxInstallRoot, { recursive: true });
 fs.writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
 
@@ -104,6 +106,7 @@ const cli = spawnSync(runnerPath, [], {
 	env: {
 		...process.env,
 		HOMEBOY_WP_CODEBOX_BIN: fakeCodeboxBin,
+		HOMEBOY_WP_CODEBOX_INSTALL_DIR: emptyCodeboxInstallRoot,
 		HOMEBOY_FUZZ_WORKLOAD_PATH: workloadPath,
 		HOMEBOY_FUZZ_WORKLOAD_ID: 'contract-workload',
 		HOMEBOY_FUZZ_RUN_ID: 'contract-run',
@@ -140,6 +143,9 @@ assert.equal(observedRequest.schema, 'wp-codebox/fuzz-suite/v1');
 assert.equal(observedRequest.metadata.homeboy_agent_task_request.task_id, 'contract-run');
 assert.equal(observedRequest.metadata.homeboy_agent_task_request.expected_artifacts[0], 'wp-codebox-fuzz-suite-result');
 assert.equal(observedRequest.metadata.homeboy_agent_task_request.artifact_declarations[0].semantic_key, 'fuzz.result.normalized');
+assert.equal(observedRequest.metadata.homeboy_agent_task_request.expected_artifacts.includes('case-log'), true);
+assert.equal(observedRequest.metadata.homeboy_agent_task_request.expected_artifacts.includes('replay-data'), true);
+assert.equal(observedRequest.metadata.homeboy_agent_task_request.expected_artifacts.includes('coverage-summary'), true);
 
 const campaign = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
 assert.equal(campaign.schema, HOMEBOY_FUZZ_CAMPAIGN_SCHEMA);

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -94,6 +94,7 @@ assert.equal(result.wp_codebox_plan_recipe.fuzzSuite.cases[0].case_id, 'get-post
 assert.equal(result.coverage.schema, 'homeboy/wordpress-fuzz-coverage-aggregate/v1');
 assert.equal(result.coverage.totals.exercised, 1);
 assert.equal(result.homeboy_fuzz_campaign.schema, HOMEBOY_FUZZ_CAMPAIGN_SCHEMA);
+assert.equal(result.homeboy_fuzz_campaign.version, 1);
 assert.equal(result.homeboy_fuzz_campaign.id, 'run-from-env');
 assert.equal(result.homeboy_fuzz_campaign.safety_class, 'read_only');
 assert.equal(result.homeboy_fuzz_campaign.metadata.status, 'failed');
@@ -120,6 +121,32 @@ const executedResult = buildWordPressFuzzRunnerResult({
 assert.equal(executedResult.status, 'succeeded');
 assert.equal(executedResult.succeeded, true);
 assert.equal(executedResult.homeboy_fuzz_campaign.metadata.artifact_refs[0].path, 'artifacts/replay.json');
+
+const mutatingPlanResult = buildWordPressFuzzRunnerResult({
+	env: {
+		workloadPath: '/unused/in-unit-test.json',
+		runId: 'mutating-plan-run',
+	},
+	workload: {
+		...workload,
+		plan: {
+			schema: 'wordpress-fuzz-plan/v1',
+			id: 'mutating-plan',
+			targets: [{
+				id: 'rest-posts-write',
+				surface_id: 'route:/wp/v2/posts',
+				cases: [{
+					id: 'create-post',
+					method: 'POST',
+					path: '/wp/v2/posts',
+					metadata: { safety: { level: 'mutating', mutates: true } },
+				}],
+			}],
+		},
+	},
+});
+
+assert.equal(mutatingPlanResult.homeboy_fuzz_campaign.safety_class, 'isolated_mutation');
 
 const jsonWorkloadResult = buildWordPressFuzzRunnerResult({
 	env: {
@@ -374,6 +401,7 @@ assert.equal(cliResult.succeeded, false);
 assert.equal(cliResult.wp_codebox_input.metadata.limits.max_duration_seconds, 15);
 const homeboyCampaign = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
 assert.equal(homeboyCampaign.schema, HOMEBOY_FUZZ_CAMPAIGN_SCHEMA);
+assert.equal(homeboyCampaign.version, 1);
 assert.equal(homeboyCampaign.id, 'cli-run');
 assert.equal(homeboyCampaign.metadata.diagnostics[0].code, 'wp_codebox_fuzz_suite_execution_unsupported');
 

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -110,6 +110,15 @@ assert.equal(taskRequest.executor.config.runtime_task.ability, DEFAULT_FUZZ_SUIT
 assert.equal(taskRequest.executor.config.runtime_task.input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 assert.deepEqual(taskRequest.expected_artifacts, DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS);
 assert.deepEqual(taskRequest.artifact_declarations, DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS);
+assert.deepEqual(
+	taskRequest.artifact_declarations.filter((artifact) => ['result-envelope', 'case-log', 'replay-data', 'coverage-summary'].includes(artifact.name)).map((artifact) => [artifact.name, artifact.semantic_key, artifact.required]),
+	[
+		['result-envelope', 'fuzz.result.envelope', true],
+		['case-log', 'fuzz.case.log', true],
+		['replay-data', 'fuzz.replay.data', true],
+		['coverage-summary', 'fuzz.coverage.summary', true],
+	]
+);
 assert.deepEqual(DEFAULT_FUZZ_RUN_ARTIFACT_DECLARATIONS, DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS);
 assert.deepEqual(legacyWpCodeboxFuzzRunArtifactDeclarationsAlias(), DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS);
 assert.deepEqual(
@@ -344,6 +353,23 @@ runWpCodeboxFuzzSuite({
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'case_artifact').semantic_key, 'fuzz.case.artifact');
 	assert.equal(summary.artifacts.find((artifact) => artifact.role === 'repro_case').semantic_key, 'fuzz.case.repro');
 	assert.equal(summary.artifacts.some((artifact) => artifact.name === 'placeholder-only'), false);
+	assert.deepEqual(normalizeWpCodeboxFuzzSuiteResult({
+		json: {
+			schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+			status: 'passed',
+			summary: { total: 1, passed: 1, failed: 0, error: 0, skipped: 0 },
+			cases: [{ id: 'artifact-contract-case', status: 'passed' }],
+			artifactRefs: [
+				{ name: 'case-log', path: 'cases/case-log.jsonl' },
+				{ name: 'replay-data', path: 'replay/replay-data.json' },
+				{ name: 'coverage-summary', path: 'coverage/summary.json' },
+			],
+		},
+	}).artifacts.map((artifact) => [artifact.role, artifact.semantic_key]), [
+		['case_log', 'fuzz.case.log'],
+		['replay_data', 'fuzz.replay.data'],
+		['coverage_summary', 'fuzz.coverage.summary'],
+	]);
 
 	const normalized = normalizeWpCodeboxFuzzSuiteResult({ status: 'failed', failures: [{ message: 'boom' }] });
 	assert.equal(normalized.succeeded, false);


### PR DESCRIPTION
## Summary
- derive `homeboy_fuzz_campaign.safety_class` from plan, target, and case safety metadata
- add fuzz contract version to emitted campaign summaries
- declare Homeboy core production artifact expectations for WP Codebox fuzz tasks
- normalize generic artifact roles for result envelope, case log, replay data, and coverage summary

## Testing
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wp-codebox-fuzz-suite`
- `npm run test:wordpress-fuzz-runner-codebox-contract`
- `npm run lint:js -- lib/wordpress-fuzz-runner.js lib/wp-codebox-fuzz-run.js --no-warn-ignored`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing WordPress fuzz safety/envelope gaps, drafting the fix, and running focused verification.