### PR TITLE
Merge duplicate Codebox runtime contracts

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
@@ -296,21 +296,33 @@ function firstFunction(...values) {
 }
 
 function uniqueObjectsByRuntimeIdentity(entries) {
-  const seen = new Set();
-  return normalizeArray(entries).filter((entry) => {
+  const seen = new Map();
+  const merged = [];
+  for (const entry of normalizeArray(entries)) {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
-      return false;
+      continue;
     }
     const key = [entry.slug, entry.id, entry.path || entry.source || entry.target, entry.kind, entry.type].filter(Boolean).join(':');
     if (!key) {
-      return true;
+      merged.push(entry);
+      continue;
     }
-    if (seen.has(key)) {
-      return false;
+    const existingIndex = seen.get(key);
+    if (existingIndex !== undefined) {
+      merged[existingIndex] = cleanObject({
+        ...merged[existingIndex],
+        ...entry,
+        metadata: {
+          ...plainObject(merged[existingIndex].metadata),
+          ...plainObject(entry.metadata),
+        },
+      });
+      continue;
     }
-    seen.add(key);
-    return true;
-  });
+    seen.set(key, merged.length);
+    merged.push(entry);
+  }
+  return merged;
 }
 
 function withoutEmptyObjectValues(value) {

--- a/wordpress/tests/codebox-runtime-profile-smoke.js
+++ b/wordpress/tests/codebox-runtime-profile-smoke.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= require('node:path').join(
+	__dirname,
+	'..',
+	'..',
+	'tests',
+	'fixtures',
+	'wp-codebox-core-runtime-contract.cjs'
+);
+
+const { codeboxRuntimeProfilePayload } = require('../../agent-runtimes/wp-codebox/lib/codebox-runtime-profile');
+
+const payload = codeboxRuntimeProfilePayload({
+	runtimeRequirements: {
+		component_contracts: [{
+			slug: 'monorepo-component',
+			path: '/workspace/repo/plugins/monorepo-component',
+			pluginFile: 'monorepo-component/monorepo-component.php',
+			loadAs: 'plugin',
+		}],
+		extra_plugins: [{
+			slug: 'monorepo-component',
+			source: '/workspace/repo/plugins/monorepo-component',
+			path: '/workspace/repo/plugins/monorepo-component',
+			sourceRoot: '/workspace/repo',
+			sourceSubpath: 'plugins/monorepo-component',
+			pluginFile: 'monorepo-component/monorepo-component.php',
+			loadAs: 'plugin',
+			activate: true,
+		}],
+	},
+});
+
+assert.equal(payload.component_contracts.length, 1);
+assert.equal(payload.component_contracts[0].sourceRoot, '/workspace/repo');
+assert.equal(payload.component_contracts[0].sourceSubpath, 'plugins/monorepo-component');
+assert.equal(payload.component_contracts[0].activate, true);
+
+console.log('codebox-runtime-profile-smoke: ok');


### PR DESCRIPTION
## Summary
- merge duplicate WP Codebox runtime dependency objects instead of dropping later entries
- preserve richer fields like sourceRoot/sourceSubpath when component contracts and extra plugins describe the same runtime component
- add a focused runtime-profile smoke for monorepo component source roots

## Testing
- node wordpress/tests/codebox-runtime-profile-smoke.js
- node wordpress/tests/wordpress-fuzz-runner-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the WP Codebox runtime contract merge issue, implementing the fix, and adding focused smoke coverage.