### PR TITLE
Add generic WordPress CRUD result contract

### DIFF
--- a/wordpress/lib/wordpress-generic-fuzz-primitives.js
+++ b/wordpress/lib/wordpress-generic-fuzz-primitives.js
@@ -1,12 +1,15 @@
 'use strict';
 
 const WORDPRESS_CRUD_OPERATION_SCHEMA = 'homeboy/wordpress-crud-operation/v1';
+const WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA = 'homeboy/wordpress-crud-operation-result/v1';
 const WORDPRESS_FIXTURE_PERSONA_SCHEMA = 'homeboy/wordpress-fixture-persona/v1';
 const WORDPRESS_PERFORMANCE_OBSERVATION_SCHEMA = 'homeboy/wordpress-performance-observation/v1';
 
 const CRUD_ACTIONS = new Set(['create', 'read', 'update', 'delete']);
 const SAFETY_LEVELS = new Set(['safe', 'mutating', 'destructive']);
 const RESET_STRATEGIES = new Set(['none', 'delete-created', 'restore-snapshot', 'transaction', 'manual']);
+const ROLLBACK_STATUSES = new Set(['not-required', 'pending', 'passed', 'failed', 'skipped']);
+const CRUD_RESULT_STATUSES = new Set(['passed', 'failed', 'errored', 'skipped']);
 const OBSERVATION_STATUSES = new Set(['passed', 'failed', 'errored', 'skipped']);
 
 function normalizeWordPressCrudOperation(operation) {
@@ -39,6 +42,45 @@ function normalizeWordPressCrudOperation(operation) {
 		expected: objectOrUndefined(operation.expected),
 		rollback_policy: normalizeResetPolicy(operation.rollback_policy || operation.rollbackPolicy || operation.reset_policy || operation.resetPolicy, action),
 		metadata: objectOrUndefined(operation.metadata) || {},
+	});
+}
+
+function normalizeWordPressCrudOperationResult(result) {
+	assertPlainObject(result, 'result');
+	assertSchema(result.schema, WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA, 'WordPress CRUD operation result');
+
+	const operation = normalizeResultOperation(result.operation || result.crud_operation || result.crudOperation || result);
+	const status = result.status || (result.skipped || result.skip_reason || result.skipReason ? 'skipped' : 'passed');
+	if (!CRUD_RESULT_STATUSES.has(status)) {
+		throw new Error(`Unsupported WordPress CRUD operation result status: ${status}`);
+	}
+
+	const id = normalizeId(result.id, `${operation.id}-result`, 'result.id');
+	const skipReasons = normalizeReasonCodes(result.skip_reasons || result.skipReasons || result.skip_reason || result.skipReason);
+	const failures = asOptionalArray(result.failures, 'result.failures').map(normalizeFailure);
+	const createdRefs = asOptionalArray(result.created_refs || result.createdRefs || result.created, 'result.created_refs').map(normalizeCreatedRef);
+
+	return stripUndefined({
+		schema: WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA,
+		id,
+		status,
+		operation,
+		resource_type: operation.resource_type,
+		resource_id: result.resource_id ?? result.resourceId ?? result.object_id ?? result.objectId ?? operation.resource_id,
+		auth_context: normalizeAuthContext(result.auth_context || result.authContext || result.auth || result.persona),
+		capability_context: normalizeCapabilityContext(result.capability_context || result.capabilityContext || operation.capability_context),
+		nonce_context: normalizeNonceContext(result.nonce_context || result.nonceContext || operation.nonce_context),
+		before_state_hash: stringOrUndefined(result.before_state_hash || result.beforeStateHash || result.before_hash || result.beforeHash),
+		after_state_hash: stringOrUndefined(result.after_state_hash || result.afterStateHash || result.after_hash || result.afterHash),
+		rollback_policy: normalizeResetPolicy(result.rollback_policy || result.rollbackPolicy || operation.rollback_policy, operation.action),
+		rollback_result: normalizeRollbackResult(result.rollback_result || result.rollbackResult),
+		created_refs: createdRefs,
+		skip_reason: result.skip_reason || result.skipReason || null,
+		skip_reasons: skipReasons,
+		failures,
+		diagnostics: asOptionalArray(result.diagnostics, 'result.diagnostics'),
+		runtime: objectOrUndefined(result.runtime),
+		metadata: objectOrUndefined(result.metadata) || {},
 	});
 }
 
@@ -188,6 +230,58 @@ function normalizeAuthContext(context) {
 	});
 }
 
+function normalizeResultOperation(operation) {
+	if (operation.schema === WORDPRESS_CRUD_OPERATION_SCHEMA || operation.action || operation.verb || operation.resource_type || operation.resourceType) {
+		return normalizeWordPressCrudOperation({ schema: WORDPRESS_CRUD_OPERATION_SCHEMA, ...operation });
+	}
+	throw new Error('result.operation must describe a WordPress CRUD operation.');
+}
+
+function normalizeRollbackResult(result) {
+	if (result === undefined || result === null) {
+		return undefined;
+	}
+	assertPlainObject(result, 'rollback_result');
+	const status = result.status || 'pending';
+	if (!ROLLBACK_STATUSES.has(status)) {
+		throw new Error(`Unsupported WordPress rollback result status: ${status}`);
+	}
+	return stripUndefined({
+		status,
+		strategy: stringOrUndefined(result.strategy),
+		started_at: stringOrUndefined(result.started_at || result.startedAt),
+		finished_at: stringOrUndefined(result.finished_at || result.finishedAt),
+		failures: asOptionalArray(result.failures, 'rollback_result.failures').map(normalizeFailure),
+		metadata: objectOrUndefined(result.metadata),
+	});
+}
+
+function normalizeCreatedRef(ref, index) {
+	assertPlainObject(ref, `created_refs[${index}]`);
+	const resourceType = ref.resource_type || ref.resourceType || ref.type;
+	if (!resourceType || typeof resourceType !== 'string') {
+		throw new Error(`created_refs[${index}].resource_type must be a string.`);
+	}
+	return stripUndefined({
+		resource_type: resourceType,
+		resource_id: ref.resource_id ?? ref.resourceId ?? ref.id,
+		label: stringOrUndefined(ref.label),
+		rollback_action: stringOrUndefined(ref.rollback_action || ref.rollbackAction),
+		metadata: objectOrUndefined(ref.metadata),
+	});
+}
+
+function normalizeFailure(failure, index) {
+	assertPlainObject(failure, `failures[${index}]`);
+	return stripUndefined({
+		code: stringOrUndefined(failure.code) || 'wordpress_crud_failure',
+		message: stringOrUndefined(failure.message) || '',
+		field: stringOrUndefined(failure.field),
+		severity: stringOrUndefined(failure.severity),
+		metadata: objectOrUndefined(failure.metadata),
+	});
+}
+
 function normalizeTransport(transport) {
 	if (transport === undefined || transport === null) {
 		return undefined;
@@ -277,6 +371,13 @@ function asArray(value, field) {
 	return value;
 }
 
+function asOptionalArray(value, field) {
+	if (value === undefined || value === null) {
+		return [];
+	}
+	return asArray(value, field);
+}
+
 function normalizeId(value, fallback, field) {
 	const id = value || fallback;
 	if (!id || typeof id !== 'string') {
@@ -312,9 +413,11 @@ function stripUndefined(value) {
 
 module.exports = {
 	WORDPRESS_CRUD_OPERATION_SCHEMA,
+	WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA,
 	WORDPRESS_FIXTURE_PERSONA_SCHEMA,
 	WORDPRESS_PERFORMANCE_OBSERVATION_SCHEMA,
 	normalizeWordPressCrudOperation,
+	normalizeWordPressCrudOperationResult,
 	normalizeWordPressFixturePersona,
 	normalizeWordPressPerformanceObservation,
 };

--- a/wordpress/lib/wordpress-runtime-task-planner.js
+++ b/wordpress/lib/wordpress-runtime-task-planner.js
@@ -15,6 +15,9 @@ const {
 	genericAgentTaskRequest,
 	genericAgentTaskRunnerSpec,
 } = require('./generic-agent-task-plan');
+const {
+	WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA,
+} = require('./wordpress-generic-fuzz-primitives');
 
 const WORDPRESS_RUNTIME_TASK_PLAN_SCHEMA = GENERIC_AGENT_TASK_PLAN_SCHEMA;
 const WORDPRESS_RUNTIME_TASK_REQUEST_SCHEMA = GENERIC_AGENT_TASK_REQUEST_SCHEMA;
@@ -27,6 +30,7 @@ const WORDPRESS_RUNTIME_TASK_DEFAULT_POLICY = {
 	write: 'sandbox',
 	apply: 'review',
 };
+const WORDPRESS_CRUD_OPERATION_RESULT_ARTIFACT = 'wordpress-crud-operation-result';
 
 function wordpressRuntimeTaskPlan(options = {}) {
 	const planId = requiredString(options.planId || options.plan_id, 'planId');
@@ -67,10 +71,12 @@ function wordpressRuntimeTaskRequest(options = {}) {
 	const taskId = requiredString(options.taskId || options.task_id, 'taskId');
 	const ability = requiredString(options.ability, 'ability');
 	const abilityInput = runtimeAbilityInput(options);
+	const expectedResultContracts = expectedResultContractsForRuntimeTask(options, abilityInput);
 	const runnerSpec = wordpressRuntimeTaskRunnerSpec({
 		...options,
 		ability,
 		abilityInput,
+		expectedResultContracts,
 	});
 
 	return genericAgentTaskRequest({
@@ -93,6 +99,7 @@ function wordpressRuntimeTaskRequest(options = {}) {
 		metadata: stripUndefined({
 			...(options.metadata || {}),
 			fanout: options.fanout,
+			expected_result_contracts: expectedResultContracts.length > 0 ? expectedResultContracts : undefined,
 		}),
 		includeArtifactDeclarations: options.includeArtifactDeclarations === false
 			? false
@@ -104,6 +111,7 @@ function wordpressRuntimeTaskRequest(options = {}) {
 function wordpressRuntimeTaskRunnerSpec(options = {}) {
 	const config = wordpressRuntimeTaskExecutorConfig(options);
 	const runtimeProfile = wordpressRuntimeTaskProfile(options);
+	const expectedResultContracts = normalizeArray(options.expectedResultContracts || options.expected_result_contracts);
 	return genericAgentTaskRunnerSpec({
 		backend: wordpressRuntimeTaskBackend(options, undefined, runtimeProfile),
 		runtime: wordpressRuntimeTaskRuntime(options, undefined, runtimeProfile),
@@ -112,7 +120,7 @@ function wordpressRuntimeTaskRunnerSpec(options = {}) {
 		task_timeout_seconds: numberOrUndefined(options.taskTimeoutSeconds || options.task_timeout_seconds || options.timeoutSeconds || options.timeout_seconds),
 		limits: options.limits,
 		artifact_declarations: options.artifactDeclarations || options.artifact_declarations,
-		expected_artifacts: options.expectedArtifacts || options.expected_artifacts,
+		expected_artifacts: expectedArtifactsForRuntimeTask(options, expectedResultContracts),
 	});
 }
 
@@ -160,6 +168,7 @@ function wordpressRuntimeTaskExecutorConfig(options = {}) {
 		runtime_requirements: options.runtimeRequirements || options.runtime_requirements,
 		ability_tools: options.abilityTools || options.ability_tools,
 		structured_artifacts: options.structuredArtifacts || options.structured_artifacts,
+		expected_result_contracts: normalizeArray(options.expectedResultContracts || options.expected_result_contracts),
 		runtime_env: options.runtimeEnv || options.runtime_env,
 		runtime_mounts: options.runtimeMounts || options.runtime_mounts,
 		runtime_config_mounts: options.runtimeConfigMounts || options.runtime_config_mounts,
@@ -189,12 +198,52 @@ function wordpressRuntimeTaskProfile(options = {}) {
 }
 
 function runtimeAbilityInput(options = {}) {
+	const abilityInput = options.abilityInput || options.ability_input || {};
+	const expectedResultContracts = expectedResultContractsForRuntimeTask(options, abilityInput);
 	return stripUndefined({
-		...(options.abilityInput || options.ability_input || {}),
+		...abilityInput,
 		...(options.dlaUrl || options.dla_url ? { dla_url: options.dlaUrl || options.dla_url } : {}),
-		...(options.provider && !hasOwn(options.abilityInput || options.ability_input || {}, 'provider') ? { provider: options.provider } : {}),
-		...(options.model && !hasOwn(options.abilityInput || options.ability_input || {}, 'model') ? { model: options.model } : {}),
+		...(options.provider && !hasOwn(abilityInput, 'provider') ? { provider: options.provider } : {}),
+		...(options.model && !hasOwn(abilityInput, 'model') ? { model: options.model } : {}),
+		...(expectedResultContracts.length > 0 && !hasOwn(abilityInput, 'expected_result_contracts') ? { expected_result_contracts: expectedResultContracts } : {}),
 	});
+}
+
+function expectedResultContractsForRuntimeTask(options = {}, abilityInput = options.abilityInput || options.ability_input || {}) {
+	const explicit = normalizeArray(options.expectedResultContracts || options.expected_result_contracts);
+	if (explicit.length > 0) {
+		return explicit;
+	}
+	return hasWordPressCrudOperation(options, abilityInput) ? [WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA] : [];
+}
+
+function expectedArtifactsForRuntimeTask(options = {}, expectedResultContracts = []) {
+	const artifacts = normalizeArray(options.expectedArtifacts || options.expected_artifacts);
+	if (expectedResultContracts.includes(WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA) && !artifacts.includes(WORDPRESS_CRUD_OPERATION_RESULT_ARTIFACT)) {
+		return [...artifacts, WORDPRESS_CRUD_OPERATION_RESULT_ARTIFACT];
+	}
+	return artifacts.length > 0 ? artifacts : undefined;
+}
+
+function hasWordPressCrudOperation(options = {}, abilityInput = {}) {
+	return Boolean(
+		isCrudOperation(options.crudOperation || options.crud_operation || options.operation)
+		|| isCrudOperation(abilityInput.crud_operation || abilityInput.crudOperation || abilityInput.operation)
+	);
+}
+
+function isCrudOperation(value) {
+	return Boolean(value && typeof value === 'object' && !Array.isArray(value) && (
+		value.schema === 'homeboy/wordpress-crud-operation/v1'
+		|| value.action
+		|| value.verb
+	) && (
+		value.resource_type
+		|| value.resourceType
+		|| value.resource
+		|| value.object_type
+		|| value.objectType
+	));
 }
 
 function normalizeTaskOptions(options = {}) {
@@ -270,6 +319,7 @@ module.exports = {
 	WORDPRESS_RUNTIME_TASK_COMPATIBILITY_RUNTIME,
 	WORDPRESS_RUNTIME_TASK_DEFAULT_POLICY,
 	WORDPRESS_RUNTIME_TASK_DEFAULT_RUNTIME,
+	WORDPRESS_CRUD_OPERATION_RESULT_ARTIFACT,
 	WORDPRESS_RUNTIME_TASK_PLAN_SCHEMA,
 	WORDPRESS_RUNTIME_TASK_REQUEST_SCHEMA,
 	wordpressRuntimeTaskProfile,

--- a/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
@@ -187,6 +187,8 @@ assert.equal(resourcePlan.targets[0].cases[2].operation.resource_type, 'setting'
 assert.equal(resourcePlan.targets[0].cases[2].operation.capability_context.required[0], 'manage_options');
 assert.deepEqual(resourcePlan.targets[0].cases[2].skip_reasons, ['missing-runtime-fuzz-capabilities']);
 assert.equal(resourcePlan.targets[0].cases[2].executable, false);
+assert.deepEqual(resourcePlan.targets[0].cases[2].required_capabilities, ['crud', 'reset', 'restore', 'snapshot']);
+assert.equal(resourcePlan.targets[0].cases[2].metadata.runtime_capability_gated, true);
 assert.equal(resourcePlan.targets[1].cases.length, 1);
 assert.equal(resourcePlan.targets[1].cases[0].intent, 'exercise-wordpress-surface');
 
@@ -243,6 +245,11 @@ for (const testCase of capableCases.filter((entry) => entry.required_capabilitie
 	assert.equal(testCase.metadata.gated, false);
 	assert.equal(testCase.metadata.runtime_capability_gated, false);
 }
+const capableCrudMutation = capableCases.find((entry) => entry.intent === 'create-post');
+assert.equal(capableCrudMutation.executable, true);
+assert.deepEqual(capableCrudMutation.required_capabilities, ['crud', 'reset', 'restore', 'snapshot']);
+assert.deepEqual(capableCrudMutation.skip_reasons, []);
+assert.equal(capableCrudMutation.metadata.runtime_capability_gated, false);
 const capableRestMutation = capableCases.find((entry) => entry.intent === 'request-rest-route');
 assert.equal(capableRestMutation.executable, false);
 assert.equal(capableRestMutation.metadata.runtime_capability_gated, false);

--- a/wordpress/tests/wordpress-generic-fuzz-primitives-smoke.js
+++ b/wordpress/tests/wordpress-generic-fuzz-primitives-smoke.js
@@ -3,9 +3,11 @@
 const assert = require('node:assert/strict');
 const {
 	WORDPRESS_CRUD_OPERATION_SCHEMA,
+	WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA,
 	WORDPRESS_FIXTURE_PERSONA_SCHEMA,
 	WORDPRESS_PERFORMANCE_OBSERVATION_SCHEMA,
 	normalizeWordPressCrudOperation,
+	normalizeWordPressCrudOperationResult,
 	normalizeWordPressFixturePersona,
 	normalizeWordPressPerformanceObservation,
 } = require('../lib/wordpress-generic-fuzz-primitives');
@@ -78,7 +80,45 @@ assert.equal(observation.duration_ms, 30);
 assert.equal(observation.summary.sample_count, 2);
 assert.equal(observation.metrics.queries, 3);
 
+const crudResult = normalizeWordPressCrudOperationResult({
+	schema: WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA,
+	operation: {
+		action: 'create',
+		resource_type: 'post',
+		capability_context: { required: ['edit_posts'] },
+		nonce_context: { action: 'wp_rest', source: 'rest', required: true },
+		rollback_policy: { strategy: 'delete-created' },
+	},
+	status: 'passed',
+	resource_id: 123,
+	auth_context: { username: 'fixture-editor', roles: ['editor'], capabilities: ['edit_posts'] },
+	before_state_hash: 'sha256:before',
+	after_state_hash: 'sha256:after',
+	created_refs: [{ resource_type: 'post', resource_id: 123, rollback_action: 'delete' }],
+	rollback_result: { status: 'passed', strategy: 'delete-created' },
+});
+
+assert.equal(crudResult.schema, WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA);
+assert.equal(crudResult.operation.id, 'create-post');
+assert.equal(crudResult.resource_type, 'post');
+assert.equal(crudResult.resource_id, 123);
+assert.deepEqual(crudResult.capability_context.required, ['edit_posts']);
+assert.equal(crudResult.nonce_context.required, true);
+assert.equal(crudResult.before_state_hash, 'sha256:before');
+assert.equal(crudResult.after_state_hash, 'sha256:after');
+assert.equal(crudResult.rollback_policy.strategy, 'delete-created');
+assert.equal(crudResult.rollback_result.status, 'passed');
+assert.deepEqual(crudResult.created_refs, [{ resource_type: 'post', resource_id: 123, rollback_action: 'delete' }]);
+
+const skippedCrudResult = normalizeWordPressCrudOperationResult({
+	operation: { action: 'update', resource_type: 'option' },
+	skip_reason: 'missing-runtime-fuzz-capabilities',
+});
+assert.equal(skippedCrudResult.status, 'skipped');
+assert.deepEqual(skippedCrudResult.skip_reasons, ['missing-runtime-fuzz-capabilities']);
+
 assert.throws(() => normalizeWordPressCrudOperation({ action: 'publish', resource_type: 'post' }), /Unsupported WordPress CRUD action/);
+assert.throws(() => normalizeWordPressCrudOperationResult({ operation: { action: 'create', resource_type: 'post' }, status: 'unknown' }), /Unsupported WordPress CRUD operation result status/);
 assert.throws(() => normalizeWordPressFixturePersona({ fixtures: [{ type: 'post' }] }), /persona.id must be a string/);
 assert.throws(() => normalizeWordPressPerformanceObservation({ status: 'unknown' }), /Unsupported WordPress performance observation status/);
 

--- a/wordpress/tests/wordpress-runtime-task-planner-smoke.js
+++ b/wordpress/tests/wordpress-runtime-task-planner-smoke.js
@@ -11,6 +11,9 @@ const {
 	wordpressRuntimeTaskRunnerSpec,
 } = require('../lib/wordpress-runtime-task-planner');
 const {
+	WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA,
+} = require('../lib/wordpress-generic-fuzz-primitives');
+const {
 	genericAgentTaskRequest,
 } = require('../../runtime-agent-ci/lib/generic-agent-task-plan');
 
@@ -119,6 +122,36 @@ assert.deepEqual(
 		}),
 	})
 );
+
+const crudRequest = wordpressRuntimeTaskRequest({
+	taskId: 'crud-runtime-task-smoke',
+	ability: 'wordpress/execute-crud-operation',
+	abilityInput: {
+		operation: {
+			action: 'create',
+			resource_type: 'post',
+			capability_context: { required: ['edit_posts'] },
+			rollback_policy: { strategy: 'delete-created' },
+		},
+	},
+	backend: 'codebox',
+	runtime: 'wp-codebox',
+});
+assert.deepEqual(crudRequest.inputs.ability_input.expected_result_contracts, [WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA]);
+assert.deepEqual(crudRequest.expected_artifacts, ['wordpress-crud-operation-result']);
+assert.deepEqual(crudRequest.metadata.expected_result_contracts, [WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA]);
+assert.deepEqual(crudRequest.executor.config.expected_result_contracts, [WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA]);
+assert.deepEqual(crudRequest.executor.config.runtime_task.input.expected_result_contracts, [WORDPRESS_CRUD_OPERATION_RESULT_SCHEMA]);
+
+const explicitArtifactCrudRequest = wordpressRuntimeTaskRequest({
+	taskId: 'crud-runtime-task-explicit-artifact-smoke',
+	ability: 'wordpress/execute-crud-operation',
+	abilityInput: { operation: { action: 'delete', resource_type: 'post' } },
+	expectedArtifacts: ['runtime-log'],
+	backend: 'codebox',
+	runtime: 'wp-codebox',
+});
+assert.deepEqual(explicitArtifactCrudRequest.expected_artifacts, ['runtime-log', 'wordpress-crud-operation-result']);
 
 const script = path.join(__dirname, '..', 'scripts', 'agent', 'homeboy-wordpress-runtime-task-plan.cjs');
 const result = spawnSync(process.execPath, [


### PR DESCRIPTION
## Summary
- Add a generic `homeboy/wordpress-crud-operation-result/v1` normalization contract for WordPress CRUD execution results.
- Include operation, resource, auth/capability/nonce context, state hashes, rollback policy/result, created refs, status, skip reasons, failures, diagnostics, runtime, and metadata fields.
- Wire WordPress runtime task planning to declare the CRUD result contract and expected text artifact when a task carries a CRUD operation.
- Expand tests for result normalization and CRUD mutation gating with and without runtime capabilities.

## Tests
- `npm run test:wordpress-generic-fuzz-primitives`
- `npm run test:wordpress-fuzz-plan-from-surfaces`
- `npm run test:wordpress-runtime-task-planner`
- `npx eslint lib/wordpress-generic-fuzz-primitives.js lib/wordpress-runtime-task-planner.js`

## Notes
- No product-specific factories or Woo-specific resources added.
- Did not run benchmarks.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the CRUD result contract, planner handoff, tests, and PR drafting.
