### PR TITLE
Honor generic fanout reconcile concurrency

### DIFF
--- a/runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js
+++ b/runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js
@@ -101,7 +101,7 @@ async function createGenericFanoutReconcileResult(input = {}) {
 
   return executeFanoutReconcileRun({
     plan,
-    concurrency: plan.task_requests.length || 1,
+    concurrency: input.concurrency ?? config.concurrency,
     run_schema: config.result_schema || config.resultSchema || RESULT_SCHEMA,
     base_run: config.base_run || {},
     include_summary: config.include_summary !== false,

--- a/runtime-agent-ci/tests/generic-fanout-reconcile-workflow.test.js
+++ b/runtime-agent-ci/tests/generic-fanout-reconcile-workflow.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+const {
+  createGenericFanoutReconcilePlan,
+  createGenericFanoutReconcileResult,
+} = require('../lib/generic-fanout-reconcile-workflow');
+
+async function observedConcurrency(options = {}) {
+  const plan = createGenericFanoutReconcilePlan({
+    groups: Array.from({ length: 20 }, (_value, index) => ({
+      key: `group-${index + 1}`,
+      items: [{ id: `item-${index + 1}` }],
+    })),
+  });
+  let active = 0;
+  let maxActive = 0;
+  const records = plan.task_requests.map((request) => ({
+    id: request.id,
+    group_key: request.group_key,
+    then(resolve) {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      setImmediate(() => {
+        active -= 1;
+        resolve({
+          id: request.id,
+          group_key: request.group_key,
+          status: 'completed',
+        });
+      });
+    },
+  }));
+
+  const result = await createGenericFanoutReconcileResult({
+    ...options,
+    plan,
+    records,
+  });
+
+  assert.equal(result.status, 'completed');
+  assert.equal(result.records.length, plan.task_requests.length);
+
+  return maxActive;
+}
+
+(async () => {
+  assert.equal(await observedConcurrency(), 3, 'omitted concurrency should use the runner default');
+  assert.equal(await observedConcurrency({ concurrency: 2 }), 2, 'input concurrency should be honored');
+  assert.equal(await observedConcurrency({ config: { concurrency: 24 } }), 16, 'excessive config concurrency should be clamped by the runner');
+
+  console.log('Generic fanout reconcile workflow test passed');
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- pass caller-provided generic fanout reconcile concurrency through to the shared runner
- allow omitted concurrency to use the runner default and excessive values to use the runner clamp
- add coverage for default, explicit, and clamped concurrency behavior

## Tests
- `node tests/generic-fanout-reconcile-workflow.test.js`
- `node ../tests/generic-fanout-reconcile-boundary.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 and OpenCode
- **Used for:** Implemented the concurrency pass-through fix, added focused tests, and prepared the PR description.