### PR TITLE
Fail non-count sync loops without explicit cap

### DIFF
--- a/runtime-agent-ci/lib/deterministic-loop-runner.js
+++ b/runtime-agent-ci/lib/deterministic-loop-runner.js
@@ -23,6 +23,7 @@ function runDeterministicLoop(options = {}) {
   const loopPolicy = normalizeLoopPolicy(options, { defaultMode: 'count', defaultMaxRevolutions: 1 });
   const maxIterations = loopPolicyMaxRevolutions(loopPolicy, {
     nonCountMaxRevolutions: options.maxSynchronousRevolutions || options.max_synchronous_revolutions,
+    requireNonCountMaxRevolutions: true,
   });
   const maxAttempts = positiveInteger(options.maxAttempts || options.max_attempts || options.retry?.max_attempts, 1);
   let state = clonePlainObject(options.state || options.initialState || options.initial_state || {});

--- a/runtime-agent-ci/lib/generic-agent-loop-runner.js
+++ b/runtime-agent-ci/lib/generic-agent-loop-runner.js
@@ -122,6 +122,7 @@ function runGenericDeterministicLoop(options = {}) {
   const loopPolicy = normalizeLoopPolicy(options, { defaultMode: 'count', defaultMaxRevolutions: 1 });
   const maxIterations = loopPolicyMaxRevolutions(loopPolicy, {
     nonCountMaxRevolutions: options.maxSynchronousRevolutions || options.max_synchronous_revolutions,
+    requireNonCountMaxRevolutions: true,
   });
   const initialState = optionalObject(options.state || options.initialState || options.initial_state);
   const tasks = [];

--- a/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
+++ b/runtime-agent-ci/lib/headless-deterministic-loop-runner.js
@@ -153,6 +153,7 @@ function runHeadlessPolicyLoop(options = {}) {
     mode: loopPolicy.mode,
     maxRevolutions: loopPolicy.max_revolutions,
     maxIterations: loopPolicy.max_iterations,
+    maxSynchronousRevolutions: loopPolicy.max_iterations,
     durationMs: loopPolicy.duration_ms,
     deadlineAt: loopPolicy.deadline_at,
     state: {
@@ -319,7 +320,8 @@ function normalizeLoopPolicy(plan) {
   const raw = optionalObject(plan.loop_policy || plan.loopPolicy);
   const primitive = normalizeSharedLoopPolicy({ ...plan, ...raw }, { defaultMode: 'count', defaultMaxRevolutions: 1 });
   const maxIterations = loopPolicyMaxRevolutions(primitive, {
-    nonCountMaxRevolutions: plan.max_synchronous_revolutions || plan.maxSynchronousRevolutions,
+    nonCountMaxRevolutions: raw.max_synchronous_revolutions || raw.maxSynchronousRevolutions || plan.max_synchronous_revolutions || plan.maxSynchronousRevolutions,
+    requireNonCountMaxRevolutions: true,
   });
   const enabled = Object.keys(raw).length > 0 || maxIterations > 1;
   return {

--- a/runtime-agent-ci/lib/loop-policy.js
+++ b/runtime-agent-ci/lib/loop-policy.js
@@ -52,7 +52,14 @@ function loopPolicyMaxRevolutions(policyInput, options = {}) {
   if ((options.nonCountMaxRevolutions ?? options.non_count_max_revolutions) === Number.POSITIVE_INFINITY) {
     return Number.POSITIVE_INFINITY;
   }
-  return positiveInteger(options.nonCountMaxRevolutions ?? options.non_count_max_revolutions, 1);
+  const maxRevolutions = positiveInteger(options.nonCountMaxRevolutions ?? options.non_count_max_revolutions, 0);
+  if (maxRevolutions > 0) {
+    return maxRevolutions;
+  }
+  if (options.requireNonCountMaxRevolutions || options.require_non_count_max_revolutions) {
+    throw new Error('Synchronous duration, deadline, and indefinite loop policies require max_synchronous_revolutions so they do not silently run once. Set max_synchronous_revolutions to a positive integer, or use a durable loop for unbounded execution.');
+  }
+  return 1;
 }
 
 function status(reason, context = {}) {

--- a/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
+++ b/runtime-agent-ci/tests/headless-deterministic-loop-runner.test.js
@@ -104,6 +104,54 @@ assert.equal(boundedFailure.tasks[0].loop_policy.status, 'failed');
 assert.equal(boundedFailure.tasks[0].loop_policy.stop_reason, 'max_revolutions_reached');
 assert.equal(boundedFailure.tasks[0].loop_policy.iteration_count, 2);
 
+assert.throws(
+  () => runHeadlessDeterministicLoop({
+    spec: {
+      ...baseSpec,
+      task_id: 'duration-missing-sync-cap',
+      workload_id: 'duration-missing-sync-cap',
+      loop_policy: {
+        mode: 'duration',
+        duration_ms: 60_000,
+        accepted_statuses: ['succeeded'],
+        continue_conditions: [{ outcome_status: 'failed' }],
+      },
+    },
+    runtime,
+    validate: false,
+    execute: ({ request }) => outcome(request, 'failed', 'Still failing.'),
+  }),
+  /require max_synchronous_revolutions/
+);
+
+let durationCalls = 0;
+const durationBounded = runHeadlessDeterministicLoop({
+  spec: {
+    ...baseSpec,
+    task_id: 'duration-explicit-sync-cap',
+    workload_id: 'duration-explicit-sync-cap',
+    loop_policy: {
+      mode: 'duration',
+      duration_ms: 60_000,
+      max_synchronous_revolutions: 2,
+      accepted_statuses: ['succeeded'],
+      continue_conditions: [{ outcome_status: 'failed' }],
+    },
+  },
+  runtime,
+  validate: false,
+  now: () => 1000,
+  execute: ({ request }) => {
+    durationCalls += 1;
+    return outcome(request, 'failed', 'Still failing.');
+  },
+});
+
+assert.equal(durationCalls, 2);
+assert.equal(durationBounded.status, 'failed');
+assert.equal(durationBounded.tasks[0].loop_policy.stop_reason, 'max_revolutions_reached');
+assert.equal(durationBounded.tasks[0].loop_policy.iteration_count, 2);
+
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-headless-loop-policy-'));
 try {
   const loopPolicyFile = path.join(tmpRoot, 'loop-policy.json');

--- a/runtime-agent-ci/tests/loop-policy.test.js
+++ b/runtime-agent-ci/tests/loop-policy.test.js
@@ -34,6 +34,11 @@ const durationPolicy = normalizeLoopPolicy({ mode: 'duration', duration_ms: 5000
 assert.equal(evaluateLoopPolicy(durationPolicy, { started_at: 1000, now: 5999 }).reason, 'continue');
 assert.equal(evaluateLoopPolicy(durationPolicy, { started_at: 1000, now: 6000 }).reason, 'duration_elapsed');
 assert.equal(loopPolicyMaxRevolutions(durationPolicy), 1);
+assert.throws(
+  () => loopPolicyMaxRevolutions(durationPolicy, { requireNonCountMaxRevolutions: true }),
+  /require max_synchronous_revolutions/
+);
+assert.equal(loopPolicyMaxRevolutions(durationPolicy, { requireNonCountMaxRevolutions: true, nonCountMaxRevolutions: 3 }), 3);
 
 const deadlinePolicy = normalizeLoopPolicy({ mode: 'duration', deadline_at: 3000 });
 assert.equal(evaluateLoopPolicy(deadlinePolicy, { now: 2999 }).reason, 'continue');
@@ -42,10 +47,22 @@ assert.equal(evaluateLoopPolicy(deadlinePolicy, { now: 3000 }).reason, 'deadline
 const cancelledPolicy = normalizeLoopPolicy({ mode: 'indefinite', cancelled: true });
 assert.equal(evaluateLoopPolicy(cancelledPolicy, { now: 1000 }).reason, 'cancelled');
 
+assert.throws(
+  () => runDeterministicLoop({
+    mode: 'duration',
+    duration_ms: 60_000,
+    now: () => 1000,
+    execute: () => ({ status: 'succeeded' }),
+    stopCriteria: () => false,
+  }),
+  /require max_synchronous_revolutions/
+);
+
 let durationExecutions = 0;
 const durationSync = runDeterministicLoop({
   mode: 'duration',
   duration_ms: 60_000,
+  max_synchronous_revolutions: 2,
   now: () => 1000,
   execute: () => {
     durationExecutions += 1;
@@ -53,20 +70,17 @@ const durationSync = runDeterministicLoop({
   },
   stopCriteria: () => false,
 });
-assert.equal(durationExecutions, 1);
-assert.equal(durationSync.iterations.length, 1);
+assert.equal(durationExecutions, 2);
+assert.equal(durationSync.iterations.length, 2);
 
-let indefiniteExecutions = 0;
-const indefiniteSync = runDeterministicLoop({
-  mode: 'indefinite',
-  execute: () => {
-    indefiniteExecutions += 1;
-    return { status: 'succeeded' };
-  },
-  stopCriteria: () => false,
-});
-assert.equal(indefiniteExecutions, 1);
-assert.equal(indefiniteSync.iterations.length, 1);
+assert.throws(
+  () => runDeterministicLoop({
+    mode: 'indefinite',
+    execute: () => ({ status: 'succeeded' }),
+    stopCriteria: () => false,
+  }),
+  /require max_synchronous_revolutions/
+);
 
 let now = 1000;
 const submitted = [];


### PR DESCRIPTION
## Summary
- Require synchronous duration, deadline, and indefinite loop policies to provide `max_synchronous_revolutions` instead of silently defaulting to one run.
- Preserve durable non-count loops by keeping their explicit unbounded `Infinity` path.
- Allow headless loop policies to carry `max_synchronous_revolutions` inside `loop_policy` and thread the resolved cap into nested generic deterministic loops.

## Tests
- `node tests/loop-policy.test.js && node tests/deterministic-loop-runner-durable.test.js && node tests/headless-deterministic-loop-runner.test.js && node tests/generic-agent-loop-runner.test.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5/OpenCode
- **Used for:** Implementing the synchronous loop-policy boundary, updating tests, running targeted verification, and drafting this PR description.