### PR TITLE
Add explicit runtime proof profiles

### DIFF
--- a/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
+++ b/.github/scripts/runtime-agent-full-run/build-runner-config.cjs
@@ -141,6 +141,7 @@ function buildConfig(env) {
     workload_run_after: parseJsonInput('workload_run_after', env.WORKLOAD_RUN_AFTER || '[]', 'array', []),
     required_abilities: parseJsonInput('required_abilities', env.REQUIRED_ABILITIES || '[]', 'array', []),
     success_requires_pr: env.SUCCESS_REQUIRES_PR !== 'false',
+    proof_profile: env.PROOF_PROFILE || 'artifact_only',
     success_completion_outcomes: parseJsonInput('success_completion_outcomes', env.SUCCESS_COMPLETION_OUTCOMES || '[]', 'array', []),
     provider: env.PROVIDER || '',
     model: env.MODEL || '',

--- a/.github/scripts/runtime-agent-full-run/lib/proof-profile.cjs
+++ b/.github/scripts/runtime-agent-full-run/lib/proof-profile.cjs
@@ -1,0 +1,48 @@
+'use strict';
+
+const PROOF_PROFILES = {
+  artifact_only: {
+    proof_profile: 'artifact_only',
+    preview_required: false,
+    publication_required: false,
+  },
+  cook_to_pr: {
+    proof_profile: 'cook_to_pr',
+    preview_required: true,
+    publication_required: true,
+    publication_evidence: { kind: 'pull_request' },
+  },
+  none: {
+    proof_profile: 'none',
+    preview_required: false,
+    publication_required: false,
+    artifacts: [],
+    required_evidence: [],
+  },
+};
+
+function resolveControllerLoopProofPolicy(config = {}) {
+  const explicitPolicy = {
+    ...optionalObject(config.controller_loop_proof),
+    ...optionalObject(config.controller_loop_proof_policy),
+  };
+  const profile = String(config.proof_profile || explicitPolicy.proof_profile || explicitPolicy.profile || 'artifact_only');
+  const profilePolicy = PROOF_PROFILES[profile];
+  if (!profilePolicy) {
+    throw new Error(`Unsupported proof_profile: ${profile}. Expected one of: ${Object.keys(PROOF_PROFILES).join(', ')}`);
+  }
+  return {
+    ...profilePolicy,
+    ...explicitPolicy,
+    proof_profile: profile,
+  };
+}
+
+function optionalObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+module.exports = {
+  PROOF_PROFILES,
+  resolveControllerLoopProofPolicy,
+};

--- a/.github/scripts/runtime-agent-full-run/run-runtime-agent-task.cjs
+++ b/.github/scripts/runtime-agent-full-run/run-runtime-agent-task.cjs
@@ -18,6 +18,7 @@ const {
   runGenericAgentLoop,
   writeGenericAgentLoopArtifacts,
 } = require('../../../runtime-agent-ci');
+const { resolveControllerLoopProofPolicy } = require('./lib/proof-profile.cjs');
 
 const SCRIPT_DIR = __dirname;
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '..', '..', '..');
@@ -37,16 +38,7 @@ function readJson(filePath) {
 try {
   const configPath = readConfigPath();
   const config = readJson(configPath);
-  const controllerLoopProofPolicy = {
-    ...optionalObject(config.controller_loop_proof),
-    ...optionalObject(config.controller_loop_proof_policy),
-  };
-  if (!Object.prototype.hasOwnProperty.call(controllerLoopProofPolicy, 'preview_required')) {
-    controllerLoopProofPolicy.preview_required = true;
-  }
-  if (!Object.prototype.hasOwnProperty.call(controllerLoopProofPolicy, 'publication_required')) {
-    controllerLoopProofPolicy.publication_required = config.success_requires_pr !== false;
-  }
+  const controllerLoopProofPolicy = resolveControllerLoopProofPolicy(config);
   const runtime = resolveRuntimeProvider(config.runtime_id || process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || DEFAULT_RUNTIME_ID, { repoRoot: REPO_ROOT, workspace: config.component_path || process.cwd(), executor: config.executor || {} });
   const result = runGenericAgentLoop({
     plan: config,
@@ -80,8 +72,4 @@ try {
 } catch (error) {
   console.error(error && error.message ? error.message : String(error));
   process.exitCode = 1;
-}
-
-function optionalObject(value) {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
 }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -214,6 +214,7 @@ jobs:
 - `runtime_mounts` adds selected-runtime mounts. It must be a JSON array.
 - `runtime_overlays` forwards runtime overlay entries to the Codebox runtime profile payload. It must be a JSON array; WP Codebox owns field-level overlay schema validation.
 - `workload_run_before`, `workload_run_after`, and `required_abilities` must be JSON arrays.
+- `proof_profile` controls controller-loop proof evidence. `artifact_only` is the generic default and does not require preview or PR/publication evidence, `cook_to_pr` requires durable preview plus pull-request evidence, and `none` declares no extra proof requirements. Explicit `controller_loop_proof` / `controller_loop_proof_policy` config still overrides profile fields.
 - `workload_run_after` runs post-agent verifier hooks in the same WordPress scenario, so consumers can assert the agent left WordPress in a valid state.
 - `ability_tools` adds WordPress ability-backed tools to the agent loop. It must be a JSON array.
 - `evidence_projections` maps provider operation results to named runtime outputs or artifact refs. `tool_recorders` remains a legacy alias for callers that also need forced parameters.

--- a/.github/workflows/runtime-agent-full-run.yml
+++ b/.github/workflows/runtime-agent-full-run.yml
@@ -138,6 +138,10 @@ name: Runtime Agent Full Run (reusable)
       success_requires_pr:
         type: boolean
         default: true
+      proof_profile:
+        description: Controller-loop proof profile: artifact_only, cook_to_pr, or none.
+        type: string
+        default: artifact_only
       success_completion_outcomes:
         description: JSON array of completion outcome names that may satisfy success without a PR.
         type: string
@@ -517,6 +521,7 @@ jobs:
           REQUIRED_ABILITIES: ${{ inputs.required_abilities }}
           ABILITY_REQUIREMENTS: ${{ inputs.ability_requirements }}
           SUCCESS_REQUIRES_PR: ${{ inputs.success_requires_pr }}
+          PROOF_PROFILE: ${{ inputs.proof_profile }}
           SUCCESS_COMPLETION_OUTCOMES: ${{ inputs.success_completion_outcomes }}
           MAX_TURNS: ${{ inputs.max_turns }}
           STEP_BUDGET: ${{ inputs.step_budget }}

--- a/tests/runtime-agent-full-run-local-shell-smoke.mjs
+++ b/tests/runtime-agent-full-run-local-shell-smoke.mjs
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+const require = createRequire(import.meta.url);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { buildConfig } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/build-runner-config.cjs'));
+const { resolveControllerLoopProofPolicy } = require(path.join(repoRoot, '.github/scripts/runtime-agent-full-run/lib/proof-profile.cjs'));
 const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-local-shell-workspace-'));
 const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-local-shell-runner-'));
 const configPath = path.join(runnerTemp, 'runtime-agent-full-run-config.json');
@@ -63,5 +67,41 @@ assert.equal(results.scenarios[0].id, 'local-shell-smoke');
 assert.equal(results.scenarios[0].metadata.job_status, 'no_op');
 assert.equal(results.scenarios[0].metadata.controller_loop_proof_validation.valid, true);
 assert.equal(results.scenarios[0].metadata.bounded_production_loop_proof.status, 'succeeded');
+
+assert.deepEqual(resolveControllerLoopProofPolicy({}), {
+  proof_profile: 'artifact_only',
+  preview_required: false,
+  publication_required: false,
+});
+assert.deepEqual(resolveControllerLoopProofPolicy({ proof_profile: 'cook_to_pr' }), {
+  proof_profile: 'cook_to_pr',
+  preview_required: true,
+  publication_required: true,
+  publication_evidence: { kind: 'pull_request' },
+});
+assert.deepEqual(resolveControllerLoopProofPolicy({ proof_profile: 'none' }), {
+  proof_profile: 'none',
+  preview_required: false,
+  publication_required: false,
+  artifacts: [],
+  required_evidence: [],
+});
+assert.equal(resolveControllerLoopProofPolicy({
+  proof_profile: 'cook_to_pr',
+  controller_loop_proof_policy: { preview_required: false },
+}).preview_required, false);
+assert.throws(() => resolveControllerLoopProofPolicy({ proof_profile: 'unsupported' }), /Unsupported proof_profile/);
+
+const forwardedConfig = buildConfig({
+  GITHUB_WORKSPACE: workspace,
+  RUNNER_TEMP: runnerTemp,
+  WORKLOAD_ID: 'proof-profile-forwarding',
+  COMPONENT_ID: 'example-component',
+  TARGET_REPO: 'Extra-Chill/example-target',
+  RUNTIME: 'local-shell',
+  PROFILE: 'local-shell-ci',
+  PROOF_PROFILE: 'cook_to_pr',
+});
+assert.equal(forwardedConfig.proof_profile, 'cook_to_pr');
 
 console.log('runtime agent full-run local-shell smoke passed');


### PR DESCRIPTION
## Summary
- Add explicit runtime full-run proof profiles: `artifact_only`, `cook_to_pr`, and `none`.
- Default generic runtime proof policy to `artifact_only` so preview and PR/publication proof are only required by an explicit profile or explicit controller proof policy.
- Forward `proof_profile` through reusable workflow config and document the profile semantics.
- Add local-shell smoke coverage for profile resolution, explicit overrides, invalid profiles, and config forwarding.

## Tests
- `node tests/runtime-agent-full-run-local-shell-smoke.mjs`
- `node tests/controller-loop-proof-validator.test.mjs`
- `node runtime-agent-ci/tests/generic-agent-loop-runner.test.js`

## Notes
- Attempted `node tests/runtime-agent-full-run-projection-boundary-smoke.mjs`; local environment is missing WP Codebox contract modules (`@automattic/wp-codebox-core` / `wp-codebox-workspace`), so that existing smoke cannot run here.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5/OpenCode
- **Used for:** Implementing the proof profile helper, workflow config wiring, docs, tests, and local verification.