### PR TITLE
Decouple generic runtime CI from WP Codebox

### DIFF
--- a/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
+++ b/.github/scripts/runtime-agent-full-run/setup-runtime.cjs
@@ -6,18 +6,51 @@ const path = require('node:path');
 const { normalizeProviderPlugin, run } = require('./lib/common.cjs');
 const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../../../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 
-try {
+function main() {
   const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
   const runtime = resolveRuntimeProvider(process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || DEFAULT_RUNTIME_ID, { workspace });
-  run('composer', ['install', '--no-interaction', '--no-progress', '--prefer-dist'], { cwd: path.join(workspace, '.ci/homeboy-extensions/wordpress') });
-  run('npm', ['install'], { cwd: path.join(workspace, '.ci/homeboy-extensions/wordpress') });
+  if (requiresWordPressDependencies(runtime, process.env)) {
+    run('composer', ['install', '--no-interaction', '--no-progress', '--prefer-dist'], { cwd: path.join(workspace, '.ci/homeboy-extensions/wordpress') });
+    run('npm', ['install'], { cwd: path.join(workspace, '.ci/homeboy-extensions/wordpress') });
+  }
   for (const command of [...runtime.setupCommands, ...runtime.buildCommands]) {
     run(command.command, command.args, { cwd: path.join(workspace, command.cwd) });
   }
-  installCheckedOutPhpDependencies(workspace);
+  if (requiresWordPressDependencies(runtime, process.env)) {
+    installCheckedOutPhpDependencies(workspace);
+  }
+}
+
+try {
+  if (require.main === module) {
+    main();
+  }
 } catch (error) {
   process.stderr.write(`${error.message}\n`);
   process.exit(1);
+}
+
+function requiresWordPressDependencies(runtime, env = process.env) {
+  if (runtime?.manifest?.ci_materialization?.requires_wordpress_dependencies === true) {
+    return true;
+  }
+  const runtimeProfileId = env.PROFILE || env.RUNTIME_PROFILE || '';
+  if (!runtimeProfileId) {
+    return false;
+  }
+  let profiles;
+  try {
+    profiles = env.RUNTIME_PROFILES ? JSON.parse(env.RUNTIME_PROFILES) : {};
+  } catch {
+    return false;
+  }
+  const profile = profiles && typeof profiles === 'object' && !Array.isArray(profiles) ? profiles[runtimeProfileId] : null;
+  return Boolean(
+    profile &&
+    typeof profile === 'object' &&
+    !Array.isArray(profile) &&
+    (profile.requires_wordpress_dependencies === true || profile.wordpress_dependencies === true)
+  );
 }
 
 function installCheckedOutPhpDependencies(workspace) {
@@ -47,3 +80,9 @@ function installCheckedOutPhpDependencies(workspace) {
     run('composer', ['install', '--no-interaction', '--no-progress', '--prefer-dist'], { cwd: providerPluginDir });
   }
 }
+
+module.exports = {
+  installCheckedOutPhpDependencies,
+  main,
+  requiresWordPressDependencies,
+};

--- a/.github/workflows/runtime-agent-ci.yml
+++ b/.github/workflows/runtime-agent-ci.yml
@@ -17,7 +17,7 @@ on:
         description: Runtime provider identifier. Prefer runtime for new callers.
         required: false
         type: string
-        default: wp-codebox
+        default: ''
       provider:
         description: Model/provider identifier forwarded to the runtime.
         required: false
@@ -63,12 +63,12 @@ on:
         type: string
         default: '{}'
       workload:
-        description: JSON Codebox workload DTO forwarded to the runtime config.
+        description: JSON workload DTO forwarded to the runtime config.
         required: false
         type: string
         default: '{}'
       tool_policy:
-        description: JSON Codebox sandbox tool-policy DTO forwarded to the runtime config.
+        description: JSON runtime tool-policy DTO forwarded to the runtime config.
         required: false
         type: string
         default: '{}'
@@ -98,7 +98,7 @@ on:
         type: string
         default: '[]'
       artifact_declarations:
-        description: JSON array of Codebox artifact declaration DTOs.
+        description: JSON array of runtime artifact declaration DTOs.
         required: false
         type: string
         default: '[]'
@@ -167,7 +167,7 @@ jobs:
           }
 
           const runtimeTask = parseJson('RUNTIME_TASK', {});
-          const runtimeProvider = normalizeRuntimeId(process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || 'wp-codebox');
+          const runtimeProvider = normalizeRuntimeId(process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND);
           const runtimeProfile = process.env.PROFILE || process.env.RUNTIME_PROFILE;
           if (!runtimeProfile) {
             throw new Error('profile or runtime_profile is required.');

--- a/agent-runtimes/wp-codebox/scripts/lib/test-result-adapters.sh
+++ b/agent-runtimes/wp-codebox/scripts/lib/test-result-adapters.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# WP Codebox-owned test-result parser adapters.
+
+homeboy_parse_wp_codebox_test_results() {
+    local output_file="$1"
+
+    if [ -z "${output_file:-}" ] || [ ! -f "$output_file" ]; then
+        return 1
+    fi
+
+    if ! type homeboy_write_test_results >/dev/null 2>&1; then
+        return 1
+    fi
+
+    local parsed
+    parsed=$(python3 - "$output_file" <<'PY'
+import json
+import sys
+
+output_file = sys.argv[1]
+
+try:
+    with open(output_file, encoding="utf-8") as handle:
+        text = handle.read()
+except OSError:
+    sys.exit(1)
+
+if '"schema"' not in text or '"wp-codebox/test-results/v1"' not in text:
+    sys.exit(1)
+
+try:
+    data = json.loads(text)
+except json.JSONDecodeError:
+    sys.exit(1)
+
+if not isinstance(data, dict) or data.get("schema") != "wp-codebox/test-results/v1":
+    sys.exit(1)
+
+summary = data.get("summary") if isinstance(data.get("summary"), dict) else {}
+total = int(summary.get("total") or 0)
+passed = int(summary.get("passed") or 0)
+failed = int(summary.get("failed") or 0)
+skipped = int(summary.get("skipped") or 0)
+unknown = int(summary.get("unknown") or 0)
+
+if total == 0 and isinstance(data.get("suites"), list):
+    for suite in data["suites"]:
+        if not isinstance(suite, dict):
+            continue
+        total += int(suite.get("tests") or suite.get("total") or 0)
+        passed += int(suite.get("passed") or 0)
+        failed += int(suite.get("failed") or 0)
+        skipped += int(suite.get("skipped") or 0)
+        unknown += int(suite.get("unknown") or 0)
+
+partial = "wp-codebox-unknown" if data.get("status") == "unknown" or unknown > 0 else ""
+print("\t".join(str(value) for value in (total, passed, failed, skipped, partial)))
+PY
+    ) || return 1
+
+    [ -n "$parsed" ] || return 1
+
+    local total passed failed skipped partial
+    IFS=$'\t' read -r total passed failed skipped partial <<EOF
+$parsed
+EOF
+
+    homeboy_write_test_results "${total:-0}" "${passed:-0}" "${failed:-0}" "${skipped:-0}" "${partial:-}"
+}

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -30,6 +30,7 @@
     }
   },
   "ci_materialization": {
+    "requires_wordpress_dependencies": true,
     "checkout": {
       "repo": "Automattic/wp-codebox",
       "target": ".ci/wp-codebox",

--- a/runtime-agent-ci/lib/runtime-agent-ci-plan.js
+++ b/runtime-agent-ci/lib/runtime-agent-ci-plan.js
@@ -12,7 +12,7 @@ const {
   genericAgentTaskRunnerSpec,
   normalizeRuntimeExecutionDescriptor,
 } = require('./generic-agent-task-plan');
-const { normalizeRuntimeId } = require('./runtime-provider-resolver.cjs');
+const { normalizeRuntimeId, resolveRuntimeProvider } = require('./runtime-provider-resolver.cjs');
 const {
   expandAgentTaskCapabilityBundles,
   expandAgentTaskToolPresets,
@@ -83,10 +83,11 @@ function runtimeAgentCiRunnerSpec(options = {}, context = {}) {
 
 function runtimeBackendForRuntime(runtime) {
   const normalizedRuntime = normalizeRuntimeId(runtime);
-  if (normalizedRuntime === 'wp-codebox') {
-    return 'codebox';
+  try {
+    return resolveRuntimeProvider(normalizedRuntime).executor.backend || normalizedRuntime;
+  } catch {
+    return normalizedRuntime;
   }
-  return normalizedRuntime;
 }
 
 function runtimeAgentCiTaskExecutorConfig(options = {}) {

--- a/runtime-agent-ci/scripts/run-agent-loop.cjs
+++ b/runtime-agent-ci/scripts/run-agent-loop.cjs
@@ -4,7 +4,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { runGenericAgentLoop, writeGenericAgentLoopArtifacts } = require('../lib/generic-agent-loop-runner');
-const { resolveRuntimeProvider } = require('../lib/runtime-provider-resolver.cjs');
+const { DEFAULT_RUNTIME_ID, resolveRuntimeProvider } = require('../lib/runtime-provider-resolver.cjs');
 
 try {
   const configPath = process.argv[2] || process.env.HOMEBOY_RUNTIME_AGENT_CONFIG_PATH || '';
@@ -13,7 +13,7 @@ try {
   }
   const plan = JSON.parse(fs.readFileSync(configPath, 'utf8'));
   const repoRoot = path.resolve(__dirname, '..', '..');
-  const runtime = resolveRuntimeProvider(plan.runtime_id || process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || 'wp-codebox', {
+  const runtime = resolveRuntimeProvider(plan.runtime_id || process.env.RUNTIME || process.env.RUNTIME_PROVIDER || process.env.BACKEND || DEFAULT_RUNTIME_ID, {
     repoRoot,
     workspace: plan.component_path || process.cwd(),
     executor: plan.executor || {},

--- a/runtime-agent-ci/tests/runtime-provider-boundary.test.js
+++ b/runtime-agent-ci/tests/runtime-provider-boundary.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const { DEFAULT_RUNTIME_ID } = require('../lib/runtime-provider-resolver.cjs');
+const { runtimeAgentCiRunnerSpec } = require('..');
+const { requiresWordPressDependencies } = require('../../.github/scripts/runtime-agent-full-run/setup-runtime.cjs');
+
+assert.equal(DEFAULT_RUNTIME_ID, 'local-shell');
+
+const runtimeAgentCiWorkflow = fs.readFileSync(path.join(repoRoot, '.github/workflows/runtime-agent-ci.yml'), 'utf8');
+assert.match(runtimeAgentCiWorkflow, /runtime_provider:[\s\S]*?default: ''/);
+assert.doesNotMatch(runtimeAgentCiWorkflow, /\|\| 'wp-codebox'/);
+
+const runAgentLoop = fs.readFileSync(path.join(repoRoot, 'runtime-agent-ci/scripts/run-agent-loop.cjs'), 'utf8');
+assert.doesNotMatch(runAgentLoop, /\|\| 'wp-codebox'/);
+assert.match(runAgentLoop, /DEFAULT_RUNTIME_ID/);
+
+const genericAdapters = fs.readFileSync(path.join(repoRoot, 'scripts/lib/test-result-adapters.sh'), 'utf8');
+assert.doesNotMatch(genericAdapters, /wp-codebox\/test-results\/v1/);
+assert.doesNotMatch(genericAdapters, /wp-codebox-json/);
+
+const wordpressAdapters = fs.readFileSync(path.join(repoRoot, 'wordpress/scripts/lib/test-result-adapters.sh'), 'utf8');
+assert.doesNotMatch(wordpressAdapters, /wp-codebox\/test-results\/v1/);
+assert.doesNotMatch(wordpressAdapters, /wp-codebox-json/);
+
+const wpCodeboxAdapters = fs.readFileSync(path.join(repoRoot, 'agent-runtimes/wp-codebox/scripts/lib/test-result-adapters.sh'), 'utf8');
+assert.match(wpCodeboxAdapters, /wp-codebox\/test-results\/v1/);
+
+assert.equal(
+  runtimeAgentCiRunnerSpec({
+    runtime: 'wp-codebox',
+    ability: 'example/run-task',
+    runtimeProfile: 'example-runtime-ci',
+    runtimeProfiles: { 'example-runtime-ci': { id: 'example-runtime-ci', runtime_task_ability: 'example/run-task' } },
+  }).executor.backend,
+  'codebox'
+);
+
+assert.equal(requiresWordPressDependencies({ manifest: { ci_materialization: {} } }, {}), false);
+assert.equal(requiresWordPressDependencies({ manifest: { ci_materialization: { requires_wordpress_dependencies: true } } }, {}), true);
+assert.equal(
+  requiresWordPressDependencies({ manifest: { ci_materialization: {} } }, {
+    PROFILE: 'wordpress-ci',
+    RUNTIME_PROFILES: JSON.stringify({ 'wordpress-ci': { requires_wordpress_dependencies: true } }),
+  }),
+  true
+);
+assert.equal(
+  requiresWordPressDependencies({ manifest: { ci_materialization: {} } }, {
+    PROFILE: 'generic-ci',
+    RUNTIME_PROFILES: JSON.stringify({ 'generic-ci': { runtime_task_ability: 'example/run-task' } }),
+  }),
+  false
+);
+
+process.stdout.write('Runtime provider boundary passed\n');

--- a/scripts/lib/test-result-adapters.sh
+++ b/scripts/lib/test-result-adapters.sh
@@ -15,7 +15,6 @@ homeboy_parse_test_results_with_adapters() {
 
     local parsed
     parsed=$(python3 - "$output_file" "$@" <<'PY'
-import json
 import re
 import sys
 
@@ -42,38 +41,6 @@ def count_after(label, line):
 def count_before(label, line):
     match = re.search(rf"(\d+)\s+{re.escape(label)}", line)
     return int(match.group(1)) if match else 0
-
-
-def parse_wp_codebox_json():
-    if '"schema"' not in text or '"wp-codebox/test-results/v1"' not in text:
-        return False
-    try:
-        data = json.loads(text)
-    except json.JSONDecodeError:
-        return False
-    if not isinstance(data, dict) or data.get("schema") != "wp-codebox/test-results/v1":
-        return False
-
-    summary = data.get("summary") if isinstance(data.get("summary"), dict) else {}
-    total = int(summary.get("total") or 0)
-    passed = int(summary.get("passed") or 0)
-    failed = int(summary.get("failed") or 0)
-    skipped = int(summary.get("skipped") or 0)
-    unknown = int(summary.get("unknown") or 0)
-
-    if total == 0 and isinstance(data.get("suites"), list):
-        for suite in data["suites"]:
-            if not isinstance(suite, dict):
-                continue
-            total += int(suite.get("tests") or suite.get("total") or 0)
-            passed += int(suite.get("passed") or 0)
-            failed += int(suite.get("failed") or 0)
-            skipped += int(suite.get("skipped") or 0)
-            unknown += int(suite.get("unknown") or 0)
-
-    partial = "wp-codebox-unknown" if data.get("status") == "unknown" or unknown > 0 else ""
-    emit(total, passed, failed, skipped, partial)
-    return True
 
 
 def parse_phpunit():
@@ -143,7 +110,6 @@ def parse_cargo_test():
 
 
 adapter_functions = {
-    "wp-codebox-json": parse_wp_codebox_json,
     "host-smoke": parse_host_smoke,
     "phpunit": parse_phpunit,
     "phpunit-testdox": parse_phpunit_testdox,

--- a/wordpress/scripts/lib/test-result-adapters.sh
+++ b/wordpress/scripts/lib/test-result-adapters.sh
@@ -15,7 +15,6 @@ homeboy_parse_test_results_with_adapters() {
 
     local parsed
     parsed=$(python3 - "$output_file" "$@" <<'PY'
-import json
 import re
 import sys
 
@@ -42,38 +41,6 @@ def count_after(label, line):
 def count_before(label, line):
     match = re.search(rf"(\d+)\s+{re.escape(label)}", line)
     return int(match.group(1)) if match else 0
-
-
-def parse_wp_codebox_json():
-    if '"schema"' not in text or '"wp-codebox/test-results/v1"' not in text:
-        return False
-    try:
-        data = json.loads(text)
-    except json.JSONDecodeError:
-        return False
-    if not isinstance(data, dict) or data.get("schema") != "wp-codebox/test-results/v1":
-        return False
-
-    summary = data.get("summary") if isinstance(data.get("summary"), dict) else {}
-    total = int(summary.get("total") or 0)
-    passed = int(summary.get("passed") or 0)
-    failed = int(summary.get("failed") or 0)
-    skipped = int(summary.get("skipped") or 0)
-    unknown = int(summary.get("unknown") or 0)
-
-    if total == 0 and isinstance(data.get("suites"), list):
-        for suite in data["suites"]:
-            if not isinstance(suite, dict):
-                continue
-            total += int(suite.get("tests") or suite.get("total") or 0)
-            passed += int(suite.get("passed") or 0)
-            failed += int(suite.get("failed") or 0)
-            skipped += int(suite.get("skipped") or 0)
-            unknown += int(suite.get("unknown") or 0)
-
-    partial = "wp-codebox-unknown" if data.get("status") == "unknown" or unknown > 0 else ""
-    emit(total, passed, failed, skipped, partial)
-    return True
 
 
 def parse_phpunit():
@@ -143,7 +110,6 @@ def parse_cargo_test():
 
 
 adapter_functions = {
-    "wp-codebox-json": parse_wp_codebox_json,
     "host-smoke": parse_host_smoke,
     "phpunit": parse_phpunit,
     "phpunit-testdox": parse_phpunit_testdox,

--- a/wordpress/scripts/test/parse-test-results.sh
+++ b/wordpress/scripts/test/parse-test-results.sh
@@ -41,8 +41,34 @@ fi
 ADAPTERS_HELPER="${HOMEBOY_RUNTIME_TEST_RESULT_ADAPTERS:-${SCRIPT_DIR}/../lib/test-result-adapters.sh}"
 # shellcheck source=../lib/test-result-adapters.sh
 source "$ADAPTERS_HELPER"
+WP_CODEBOX_ADAPTERS_HELPER="${HOMEBOY_WP_CODEBOX_TEST_RESULT_ADAPTERS:-${SCRIPT_DIR}/../../../agent-runtimes/wp-codebox/scripts/lib/test-result-adapters.sh}"
+if [ -f "$WP_CODEBOX_ADAPTERS_HELPER" ]; then
+    # shellcheck source=/dev/null
+    source "$WP_CODEBOX_ADAPTERS_HELPER"
+fi
+
+homeboy_wordpress_parse_with_adapters() {
+    local output_file="$1"
+    shift || true
+    local generic_adapters=()
+
+    for adapter in "$@"; do
+        if [ "$adapter" = "wp-codebox-json" ]; then
+            if type homeboy_parse_wp_codebox_test_results >/dev/null 2>&1 && homeboy_parse_wp_codebox_test_results "$output_file"; then
+                return 0
+            fi
+            continue
+        fi
+        generic_adapters+=("$adapter")
+    done
+
+    if [ "${#generic_adapters[@]}" -gt 0 ]; then
+        homeboy_parse_test_results_with_adapters "$output_file" "${generic_adapters[@]}"
+    fi
+}
+
 if [ "$#" -gt 0 ]; then
-    homeboy_parse_test_results_with_adapters "$OUTPUT_FILE" "$@"
+    homeboy_wordpress_parse_with_adapters "$OUTPUT_FILE" "$@"
 else
-    homeboy_parse_test_results_with_adapters "$OUTPUT_FILE" wp-codebox-json host-smoke phpunit phpunit-testdox
+    homeboy_wordpress_parse_with_adapters "$OUTPUT_FILE" wp-codebox-json host-smoke phpunit phpunit-testdox
 fi


### PR DESCRIPTION
## Summary
- Default generic runtime CI paths to the neutral local-shell runtime instead of WP Codebox.
- Resolve runtime backends from runtime manifests and mark WP Codebox as requiring WordPress dependency setup.
- Move WP Codebox test-result parsing under agent-runtimes/wp-codebox and delegate WordPress parsing to that runtime-owned helper.
- Add targeted runtime-provider boundary coverage.

## Tests
- `node runtime-agent-ci/tests/runtime-provider-boundary.test.js`
- `node wordpress/tests/generic-agent-runtime-contract.test.js`
- `node agent-runtimes/codex/tests/codex-agent-task-executor-boundary.test.js`
- WP Codebox parser delegation fixture via `wordpress/scripts/test/parse-test-results.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing focused runtime-provider boundary cleanup, adding targeted tests, and preparing the PR.