### PR TITLE
Fix WP Codebox public CLI payload dispatch

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -4,6 +4,9 @@
  * External dependencies
  */
 const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 /**
  * Internal dependencies
@@ -538,10 +541,14 @@ function runWpCodeboxPublicCliHelp(command, options = {}) {
 }
 
 async function runWpCodeboxPublicCli(command, input, options = {}) {
-	return runWpCodeboxPublicCliCommand(['codebox', command, '--input=-', '--format=json'], {
-		...options,
-		stdin: `${JSON.stringify(input)}\n`,
-	});
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-'));
+	const inputFile = path.join(tempDir, 'input.json');
+	try {
+		fs.writeFileSync(inputFile, `${JSON.stringify(input)}\n`, 'utf8');
+		return runWpCodeboxPublicCliCommand(['codebox', command, '--input-file', inputFile, '--format=json'], options);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
 }
 
 function runWpCodeboxPublicCliCommand(args, options = {}) {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -468,8 +468,9 @@ if (subcommand === 'codebox run-wordpress-workload' && process.argv.includes('--
   process.stderr.write('unknown command');
   process.exit(1);
 }
-const request = JSON.parse(fs.readFileSync(0, 'utf8'));
-if (subcommand !== 'codebox run-fuzz-suite' || !process.argv.includes('--input=-') || !process.argv.includes('--format=json')) {
+const inputFileIndex = process.argv.indexOf('--input-file');
+const request = inputFileIndex === -1 ? undefined : JSON.parse(fs.readFileSync(process.argv[inputFileIndex + 1], 'utf8'));
+if (subcommand !== 'codebox run-fuzz-suite' || inputFileIndex === -1 || process.argv.includes('--input=-') || !process.argv.includes('--format=json')) {
   process.stderr.write('expected public wp codebox run-fuzz-suite command');
   process.exit(1);
 }

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
 
 const {
 	DEFAULT_FUZZ_RUN_ABILITY,
@@ -499,8 +500,12 @@ runWpCodeboxFuzzSuite({
 			if (args.join(' ') === 'codebox run-wordpress-workload --help') {
 				return { status: 1, stderr: 'unknown command' };
 			}
-			assert.equal(args.join(' '), 'codebox run-fuzz-suite --input=- --format=json');
-			assert.equal(JSON.parse(stdin).schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+			assert.equal(args[0], 'codebox');
+			assert.equal(args[1], 'run-fuzz-suite');
+			assert.equal(args[2], '--input-file');
+			assert.equal(args[4], '--format=json');
+			assert.equal(stdin, undefined);
+			assert.equal(JSON.parse(fs.readFileSync(args[3], 'utf8')).schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 			return {
 				status: 0,
 				stdout: JSON.stringify({


### PR DESCRIPTION
## Summary
- send public WP Codebox fuzz payloads via the documented `--input-file` contract instead of stdin-only `--input=-`
- write payloads to a temporary JSON file so large fuzz inputs avoid command-line length limits
- update smoke coverage to validate `--input-file` and reject the old `--input=-` contract

## Tests
- `node wordpress/tests/wp-codebox-fuzz-run-smoke.js`
- `node wordpress/tests/wordpress-fuzz-runner-smoke.js`
- `node --check wordpress/lib/wp-codebox-fuzz-run.js`
- `node --check wordpress/tests/wp-codebox-fuzz-run-smoke.js`
- `node --check wordpress/tests/wordpress-fuzz-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the WP Codebox CLI payload regression, implementing the production dispatch fix, updating tests, and running verification.