### PR TITLE
Centralize WP Codebox result boundary

### DIFF
--- a/agent-runtimes/wp-codebox/index.js
+++ b/agent-runtimes/wp-codebox/index.js
@@ -5,6 +5,7 @@ module.exports = {
 	...require('./lib/codebox-artifact-contract'),
 	...require('./lib/codebox-run-agent-task-contract'),
 	...require('./lib/codebox-legacy-result-adapter'),
+	...require('./lib/codebox-result-boundary'),
 	...require('./lib/codebox-runtime-profile'),
 	...require('./lib/delegated-run-contract'),
 	...require('./lib/wp-codebox-adapter-descriptor'),

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -29,7 +29,6 @@ const {
 const {
   artifactResultEnvelopeFromCodeboxResult,
   artifactNameFromDeclaration,
-  normalizeCodeboxPublicResultEnvelope,
   normalizeCodeboxArtifactDeclaration,
   normalizeCodeboxArtifactOutcome: normalizeCodeboxArtifactOutcomeContract,
   normalizeTypedArtifactEntry: normalizeCodeboxTypedArtifactEntry,
@@ -37,6 +36,11 @@ const {
   typedArtifactsFromCodeboxResult,
   typedArtifactFileRefs: codeboxTypedArtifactFileRefs,
 } = require('./codebox-artifact-contract');
+const {
+  codeboxPublicResultEnvelope,
+  privateCodeboxRuntimeResultShapeNames,
+  publicEnvelopeBoundaryDiagnostic,
+} = require('./codebox-result-boundary');
 const {
   codeboxRuntimeComponentContracts,
   codeboxRuntimeProfilePayload,
@@ -1497,6 +1501,9 @@ function defaultRuntimeRequirements() {
 
 function isCodeboxOwnedSubstrateContract(contract) {
   const slug = typeof contract?.slug === 'string' ? contract.slug.trim() : '';
+  if (contract?.pluginFile || contract?.plugin_file) {
+    return false;
+  }
   return WP_CODEBOX_OWNED_SUBSTRATE_SLUGS.has(slug);
 }
 
@@ -2311,48 +2318,6 @@ function normalizeStatus(result, exitStatus = 0) {
   return (publicEnvelope?.success ?? result?.success) === true ? 'succeeded' : 'failed';
 }
 
-function codeboxPublicResultEnvelope(result, options = {}) {
-  return options.publicResultEnvelope || options.public_result_envelope || normalizeCodeboxPublicResultEnvelope(result, options);
-}
-
-function privateCodeboxRuntimeResultShapeNames(result = {}) {
-  const names = [];
-  if (result?.run?.agentResult) {
-    names.push('run.agentResult');
-  }
-  if (result?.agentResult) {
-    names.push('agentResult');
-  }
-  if (result?.agent_result) {
-    names.push('agent_result');
-  }
-  if (result?.metadata?.agent_runtime) {
-    names.push('metadata.agent_runtime');
-  }
-  if (result?.engine_data || result?.metadata?.engine_data) {
-    names.push('engine_data');
-  }
-  return names;
-}
-
-function publicEnvelopeBoundaryDiagnostic(result, options = {}) {
-  if (codeboxPublicResultEnvelope(result, options)) {
-    return null;
-  }
-  const privateShapes = privateCodeboxRuntimeResultShapeNames(result);
-  if (privateShapes.length === 0) {
-    return null;
-  }
-  return {
-    class: 'codebox.public_result_envelope_missing',
-    message: 'WP Codebox result used private runtime fields without the canonical public artifact result envelope.',
-    data: {
-      required_schema: 'wp-codebox/artifact-result-envelope/v1',
-      private_shapes: privateShapes,
-    },
-  };
-}
-
 function agentRuntimeResultCandidates(result) {
   const publicEnvelope = codeboxPublicResultEnvelope(result);
   return [
@@ -2674,51 +2639,8 @@ function replyTextFromResult(result) {
     publicEnvelope.outputs?.reply,
     publicEnvelope.outputs?.text,
     publicEnvelope.outputs?.content,
-    replyTextFromResultExecutions(result),
-    replyTextFromTranscriptArtifact(result),
   ];
   return candidates.find((candidate) => typeof candidate === 'string' && candidate.trim() !== '') || '';
-}
-
-function replyTextFromResultExecutions(result) {
-  const executions = [
-    ...(Array.isArray(result?.executions) ? result.executions : []),
-    ...(Array.isArray(result?.run?.executions) ? result.run.executions : []),
-  ];
-  for (const execution of [...executions].reverse()) {
-    const reply = replyTextFromExecutionStdout(execution?.stdout || '');
-    if (reply) {
-      return reply;
-    }
-  }
-  return '';
-}
-
-function replyTextFromExecutionStdout(stdout) {
-  const wrapper = parseJsonObject(stdout || '');
-  const output = parseJsonObject(wrapper?.output || '') || parseJsonObject(stdout || '');
-  const reply = output?.agent_runtime?.result?.reply || output?.result?.reply || output?.reply;
-  return typeof reply === 'string' && reply.trim() !== '' ? reply : '';
-}
-
-function replyTextFromTranscriptArtifact(result) {
-  const transcriptRef = firstTranscriptArtifactRefFromResult(result);
-  if (!transcriptRef?.path) {
-    return '';
-  }
-  try {
-    const transcript = JSON.parse(fs.readFileSync(transcriptRef.path, 'utf8'));
-    const executions = Array.isArray(transcript.executions) ? transcript.executions : [];
-    for (const execution of [...executions].reverse()) {
-      const reply = replyTextFromExecutionStdout(execution?.stdout || '');
-      if (reply) {
-        return reply;
-      }
-    }
-  } catch {
-    return '';
-  }
-  return '';
 }
 
 function replyTypedArtifactsFromResult(request, result, existingTypedArtifacts = {}) {

--- a/agent-runtimes/wp-codebox/lib/codebox-result-boundary.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-result-boundary.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const {
+  normalizeCodeboxPublicResultEnvelope,
+} = require('./codebox-artifact-contract');
+
+function codeboxPublicResultEnvelope(result, options = {}) {
+  return options.publicResultEnvelope || options.public_result_envelope || normalizeCodeboxPublicResultEnvelope(result, options);
+}
+
+function privateCodeboxRuntimeResultShapeNames(result = {}) {
+  const names = [];
+  if (result?.run?.agentResult) {
+    names.push('run.agentResult');
+  }
+  if (result?.agentResult) {
+    names.push('agentResult');
+  }
+  if (result?.agent_result) {
+    names.push('agent_result');
+  }
+  if (result?.metadata?.agent_runtime) {
+    names.push('metadata.agent_runtime');
+  }
+  if (result?.engine_data || result?.metadata?.engine_data) {
+    names.push('engine_data');
+  }
+  return names;
+}
+
+function publicEnvelopeBoundaryDiagnostic(result, options = {}) {
+  if (codeboxPublicResultEnvelope(result, options)) {
+    return null;
+  }
+  const privateShapes = privateCodeboxRuntimeResultShapeNames(result);
+  if (privateShapes.length === 0) {
+    return null;
+  }
+  return {
+    class: 'codebox.public_result_envelope_missing',
+    message: 'WP Codebox result used private runtime fields without the canonical public artifact result envelope.',
+    data: {
+      required_schema: 'wp-codebox/artifact-result-envelope/v1',
+      private_shapes: privateShapes,
+    },
+  };
+}
+
+module.exports = {
+  codeboxPublicResultEnvelope,
+  privateCodeboxRuntimeResultShapeNames,
+  publicEnvelopeBoundaryDiagnostic,
+};

--- a/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js
@@ -312,7 +312,7 @@ function uniqueObjectsByRuntimeIdentity(entries) {
     }
     const existingIndex = seen.get(key);
     if (existingIndex !== undefined) {
-      merged[existingIndex] = cleanObject({
+      merged[existingIndex] = withoutEmptyObjectValues({
         ...merged[existingIndex],
         ...entry,
         metadata: {

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -1206,7 +1206,7 @@ function runnerInput(request, artifacts) {
     artifacts_path: artifacts,
     wp_codebox_bin: argValue('--wp-codebox-bin') || request.wp_codebox_bin || '',
     runtime_component_paths: runtimeComponentPaths,
-    component_contracts: uniqueComponentContracts(requestComponentContracts(request).map(remapRuntimeComponentContract).filter((contract) => !isCodeboxOwnedSubstrateContract(contract))),
+    component_contracts: componentContracts(request),
     homeboy_path: argValue('--homeboy') || request.homeboy_path || request.homeboy || '',
     homeboy_extensions_path: argValue('--homeboy-extensions') || request.homeboy_extensions_path || request.homeboy_extensions || path.resolve(__dirname, '..', '..'),
     wp_version: request.wordpress_runtime_version || request.wordpress_version || request.wp_codebox_wordpress_version || request.wp_version || request.wp || undefined,
@@ -1257,12 +1257,16 @@ function componentContracts(input) {
     ...requestComponentContracts(input.parent_request).map(remapRuntimeComponentContract),
     ...requestComponentContracts(input.parent_request?.parent_request).map(remapRuntimeComponentContract),
     ...runtimeContracts,
-  ].filter((contract) => !isCodeboxOwnedSubstrateContract(contract)));
+  ].filter((contract) => !isImplicitCodeboxOwnedSubstrateContract(contract)));
 }
 
 function isCodeboxOwnedSubstrateContract(contract) {
   const slug = typeof contract?.slug === 'string' ? contract.slug.trim() : '';
   return WP_CODEBOX_OWNED_SUBSTRATE_SLUGS.has(slug);
+}
+
+function isImplicitCodeboxOwnedSubstrateContract(contract) {
+  return isCodeboxOwnedSubstrateContract(contract) && contract?.metadata?.source !== 'runtime_requirements.component_contracts';
 }
 
 function requestComponentContracts(request) {
@@ -1271,7 +1275,13 @@ function requestComponentContracts(request) {
   }
   return uniqueComponentContracts([
     ...(Array.isArray(request.component_contracts) ? request.component_contracts : []),
-    ...(Array.isArray(request.runtime_requirements?.component_contracts) ? request.runtime_requirements.component_contracts : []),
+    ...(Array.isArray(request.runtime_requirements?.component_contracts) ? request.runtime_requirements.component_contracts.map((contract) => ({
+      ...contract,
+      metadata: {
+        ...(contract.metadata && typeof contract.metadata === 'object' && !Array.isArray(contract.metadata) ? contract.metadata : {}),
+        source: 'runtime_requirements.component_contracts',
+      },
+    })) : []),
     ...(Array.isArray(request.runtime_requirements?.extra_plugins) ? request.runtime_requirements.extra_plugins : []),
     ...runtimeRequirementDependencyContracts(request.runtime_requirements),
   ]);
@@ -1704,7 +1714,16 @@ function normalizeAgentTaskRun(input, result) {
           outputs: plainObject(agentResult.outputs) ? agentResult.outputs : result.outputs,
         },
       }
-    : result.artifact_result;
+    : {
+        schema: 'wp-codebox/artifact-result-envelope/v1',
+        status: success ? 'created' : 'failed',
+        success,
+        result: {
+          status: success ? 'succeeded' : 'failed',
+          success,
+          outputs: plainObject(agentResult.outputs) ? agentResult.outputs : (plainObject(result.outputs) ? result.outputs : {}),
+        },
+      };
 
   return {
     ...result,

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -16,6 +16,7 @@ const {
   normalizeCodeboxPublicResultEnvelope,
   normalizeCodeboxArtifactDeclaration,
   normalizeCodeboxArtifactOutcome,
+  publicEnvelopeBoundaryDiagnostic,
   providerContract,
   providerRuntimeInvocationContract,
   reconcileRunSummaryWithPublicEnvelope,
@@ -151,6 +152,7 @@ assert.equal(privateRuntimeShapeOutcome.status, 'failed');
 assert.equal(privateRuntimeShapeOutcome.failure_classification, 'execution_failed');
 assert.equal(privateRuntimeShapeOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.public_result_envelope_missing'), true);
 assert.equal(privateRuntimeShapeOutcome.outputs.reply, undefined);
+assert.deepEqual(publicEnvelopeBoundaryDiagnostic({ run: { agentResult: { reply: 'private' } } }).data.private_shapes, ['run.agentResult']);
 const publicRuntimeShapeOutcome = agentTaskOutcomeFromCodeboxResult(privateRuntimeShapeRequest, {
   success: true,
   run: {
@@ -169,6 +171,21 @@ const publicRuntimeShapeOutcome = agentTaskOutcomeFromCodeboxResult(privateRunti
 assert.equal(publicRuntimeShapeOutcome.status, 'succeeded');
 assert.equal(publicRuntimeShapeOutcome.outputs.reply, 'Public reply');
 assert.equal(publicRuntimeShapeOutcome.diagnostics.some((diagnostic) => diagnostic.class === 'codebox.public_result_envelope_missing'), false);
+const privateReplyWithPublicEnvelopeOutcome = agentTaskOutcomeFromCodeboxResult(privateRuntimeShapeRequest, {
+  success: true,
+  run: {
+    agentResult: {
+      reply: 'Private reply must not leak into outputs.',
+    },
+  },
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: { outputs: {} },
+  },
+});
+assert.equal(privateReplyWithPublicEnvelopeOutcome.status, 'succeeded');
+assert.equal(privateReplyWithPublicEnvelopeOutcome.outputs.reply, undefined);
 const reconciledRunSummary = reconcileRunSummaryWithPublicEnvelope({
   status: 'failed',
   success: false,
@@ -912,6 +929,31 @@ assert.deepEqual(
   ['codebox.required_typed_artifacts_invalid']
 );
 assert.match(placeholderArtifactOutcome.summary, /invalid required typed artifacts: concept_packet/);
+
+const missingTypedArtifactOutcome = agentTaskOutcomeFromCodeboxResult({
+  schema: 'homeboy/agent-task-request/v1',
+  task_id: 'missing-typed-artifact-task-1',
+  executor: { backend: 'codebox', config: { provider: 'openai' } },
+  artifact_declarations: [{
+    name: 'concept_packet',
+    artifact_schema: 'wp-site-generator/ConceptPacket/v1',
+    required: true,
+  }],
+}, {
+  success: true,
+  status: 'completed',
+  artifact_result: {
+    schema: 'wp-codebox/artifact-result-envelope/v1',
+    status: 'created',
+    result: { outputs: {} },
+  },
+});
+assert.equal(missingTypedArtifactOutcome.status, 'failed');
+assert.equal(missingTypedArtifactOutcome.failure_classification, 'execution_failed');
+assert.deepEqual(
+  missingTypedArtifactOutcome.diagnostics.map((diagnostic) => diagnostic.class),
+  ['codebox.required_typed_artifacts_missing']
+);
 
 const genericRepoLoopTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -1039,7 +1039,7 @@ try {
   const agentBundleOutput = JSON.parse(agentBundleResult.stdout);
   assert.equal(agentBundleOutput.success, true);
   assert.equal(agentBundleOutput.session.status, 'completed');
-  assert.equal(agentBundleOutput.run.agentResult.scenarios[0].metadata.engine_data.example_agent.issue_number, 123);
+  assert.equal(agentBundleOutput.outputs?.issue_number, undefined);
 
   const singleResultCapturePath = path.join(root, 'capture-single-result-datamachine.json');
   const singleResult = spawnSync(process.execPath, [
@@ -1073,9 +1073,9 @@ try {
   const singleResultOutput = JSON.parse(singleResult.stdout);
   assert.equal(singleResultOutput.success, true);
   assert.equal(singleResultOutput.session.status, 'completed');
-  assert.equal(singleResultOutput.run.agentResult.outputs.issue_number, 123);
-  assert.equal(singleResultOutput.run.agentResult.outputs.issue_url, 'https://github.com/example-org/example-repo/issues/123');
-  assert.equal(Array.isArray(singleResultOutput.run.agentResult.scenarios), false);
+  assert.equal(singleResultOutput.outputs.issue_number, 123);
+  assert.equal(singleResultOutput.outputs.issue_url, 'https://github.com/example-org/example-repo/issues/123');
+  assert.equal(Array.isArray(singleResultOutput.outputs.scenarios), false);
   assert.equal(singleResultOutput.diagnostics.some((diagnostic) => diagnostic.class === 'agent_runtime.output'), true);
 
   const canonicalBundleRunCapturePath = path.join(root, 'capture-canonical-datamachine-bundle-run.json');
@@ -1108,13 +1108,9 @@ try {
   const canonicalBundleRunOutput = JSON.parse(canonicalBundleRunResult.stdout);
   assert.equal(canonicalBundleRunOutput.success, true);
   assert.equal(canonicalBundleRunOutput.session.status, 'completed');
-  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.schema, 'datamachine/agent-bundle-run/v1');
-  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.job_status, 'completed');
-  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.engine_data.example_agent.issue_number, 123);
-  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.artifacts.result.mime, 'application/json');
-  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.transcripts.summary.endsWith('/transcript.md'), true);
-  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metadata.dry_run, true);
-  assert.equal(canonicalBundleRunOutput.run.agentResult.scenarios[0].metrics.workflow_step_count, 1);
+  assert.equal(canonicalBundleRunOutput.outputs.issue_number, undefined);
+  assert.equal(canonicalBundleRunOutput.artifact_result.schema, 'wp-codebox/artifact-result-envelope/v1');
+  assert.deepEqual(canonicalBundleRunOutput.artifact_result.result.outputs, canonicalBundleRunOutput.outputs);
   assert.equal(canonicalBundleRunOutput.outputs.typed_artifacts.example_review.type, 'ExampleReviewArtifact');
   assert.equal(canonicalBundleRunOutput.outputs.typed_artifacts.example_review.artifact_schema, 'example/review-artifact/v1');
   assert.equal(canonicalBundleRunOutput.outputs.typed_artifacts.example_review.payload.review_ready, true);
@@ -1164,8 +1160,7 @@ try {
   assert.equal(recorderBundleRunOutput.status, 'completed');
   assert.equal(recorderBundleRunOutput.outputs.issue_number, 123);
   assert.equal(recorderBundleRunOutput.outputs.issue_url, 'https://github.com/example-org/example-repo/issues/123');
-  assert.equal(recorderBundleRunOutput.run.agentResult.outputs.issue_number, 123);
-  assert.equal(recorderBundleRunOutput.run.agentResult.outputs.issue_url, 'https://github.com/example-org/example-repo/issues/123');
+  assert.deepEqual(recorderBundleRunOutput.artifact_result.result.outputs, recorderBundleRunOutput.outputs);
 
   const projectionBundleRunCapturePath = path.join(root, 'capture-projection-bundle-run.json');
   const projectionBundleRunResult = spawnSync(process.execPath, [


### PR DESCRIPTION
## Summary
- Centralize WP Codebox result boundary helpers for public envelope handling.
- Normalize adapter output through `wp-codebox/artifact-result-envelope/v1`.
- Diagnose private-shape leakage and missing required typed artifacts clearly.

## Tests
- `node --check agent-runtimes/wp-codebox/index.js`
- `node --check agent-runtimes/wp-codebox/lib/codebox-result-boundary.js`
- `node --check agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js`
- `node --check agent-runtimes/wp-codebox/lib/codebox-runtime-profile.js`
- `node --check agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs`
- `node wordpress/tests/codebox-agent-task-executor-boundary.test.js`
- `node wordpress/tests/codebox-agent-task-executor-smoke.js`
- `node wordpress/tests/wp-codebox-task-runner-smoke.js`
- `node tests/wp-codebox-adapter-boundary-smoke.mjs`
- `node tests/wp-codebox-artifact-contract-smoke.mjs`
- `node tests/wp-codebox-runtime-profile-defaults-smoke.mjs`
- `node tests/wp-codebox-bundled-agents-api-smoke.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the adapter refactor, tests, and PR preparation.