### PR TITLE
Fix public fuzz Codebox CLI selection

### DIFF
--- a/wordpress/lib/wordpress-fuzz-runner.js
+++ b/wordpress/lib/wordpress-fuzz-runner.js
@@ -37,6 +37,7 @@ function readWordPressFuzzRunnerEnv(env = process.env) {
 		maxDuration: env.HOMEBOY_FUZZ_MAX_DURATION,
 		resultsFile: env.HOMEBOY_FUZZ_RESULTS_FILE,
 		wpCodeboxFuzzWorkloadRoot: env.WP_CODEBOX_FUZZ_WORKLOAD_ROOT,
+		wpCodeboxBin: env.HOMEBOY_WP_CODEBOX_BIN || env.WP_CODEBOX_BIN || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN,
 		wpCliBin: env.HOMEBOY_WP_CLI_BIN || env.WP_CLI_BIN,
 	});
 }
@@ -151,6 +152,7 @@ async function resolveCodeboxResult(context, options = {}) {
 	const runner = options.runFuzzSuite || options.runFuzzRun || options.runRuntimeTask || options.runTask;
 	return runWpCodeboxFuzzSuite({
 		...options,
+		env: context.env,
 		taskId: context.runId,
 		input: context.wpCodeboxInput,
 		provider: context.workload.provider,

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -612,7 +612,7 @@ function unsupportedWpCodeboxPublicFuzzResult({ request = {}, capabilities = {} 
 }
 
 function runWpCodeboxPublicCliHelp(command, options = {}) {
-	return runWpCodeboxPublicCliCommand(['codebox', command, '--help'], options);
+	return runWpCodeboxPublicCliCommand([command, '--help'], options);
 }
 
 async function runWpCodeboxPublicCli(command, input, options = {}) {
@@ -620,7 +620,7 @@ async function runWpCodeboxPublicCli(command, input, options = {}) {
 	const inputFile = path.join(tempDir, 'input.json');
 	try {
 		fs.writeFileSync(inputFile, `${JSON.stringify(input)}\n`, 'utf8');
-		return runWpCodeboxPublicCliCommand(['codebox', command, '--input-file', inputFile, '--format=json'], options);
+		return runWpCodeboxPublicCliCommand([command, '--input-file', inputFile, '--format=json'], options);
 	} finally {
 		fs.rmSync(tempDir, { recursive: true, force: true });
 	}
@@ -667,7 +667,14 @@ function wpCodeboxPublicCliBin(options = {}) {
 }
 
 function wpCodeboxPublicCliInvocation(options = {}) {
-	return wpCodeboxCommand(wpCodeboxPublicCliBin(options));
+	const bin = wpCodeboxPublicCliBin(options);
+	const invocation = wpCodeboxCommand(bin);
+	const executable = path.basename(String(bin || '')).toLowerCase();
+	const usesWpCliNamespace = executable === 'wp' || executable === 'wp-cli' || executable === 'wp-cli.phar';
+	return {
+		command: invocation.command,
+		args: usesWpCliNamespace ? [...invocation.args, 'codebox'] : invocation.args,
+	};
 }
 
 function normalizeCliResult(result = {}) {

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -25,6 +25,11 @@ const {
 	normalizeWordPressFuzzRuntimeTaskResult,
 } = require('./wordpress-fuzz-runtime-task');
 
+const {
+	homeboySettings,
+	wpCodeboxCommand,
+} = require('./wp-codebox-recipe-helper');
+
 const WP_CODEBOX_FUZZ_SUITE_SCHEMA = 'wp-codebox/fuzz-suite/v1';
 const WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA = 'wp-codebox/fuzz-suite-result/v1';
 const WP_CODEBOX_FUZZ_RUN_SCHEMA = legacyWpCodeboxFuzzRunSchemaAlias();
@@ -629,7 +634,8 @@ function runWpCodeboxPublicCliCommand(args, options = {}) {
 		return normalizeCliResult(options.runCli({ command: wpCodeboxPublicCliBin(options), args, stdin: options.stdin }, options));
 	}
 
-	const result = spawnSync(wpCodeboxPublicCliBin(options), args, {
+	const invocation = wpCodeboxPublicCliInvocation(options);
+	const result = spawnSync(invocation.command, [...invocation.args, ...args], {
 		input: options.stdin,
 		encoding: 'utf8',
 		env: { ...process.env, ...(options.env || {}) },
@@ -640,8 +646,28 @@ function runWpCodeboxPublicCliCommand(args, options = {}) {
 }
 
 function wpCodeboxPublicCliBin(options = {}) {
-	const env = options.env || process.env;
-	return options.wpCliBin || options.wp_cli_bin || env.wpCliBin || env.wp_cli_bin || env.HOMEBOY_WP_CLI_BIN || env.WP_CLI_BIN || DEFAULT_WP_CODEBOX_PUBLIC_CLI_BIN;
+	const env = { ...process.env, ...(options.env || {}) };
+	const settings = homeboySettings(env);
+	return options.publicCliBin
+		|| options.public_cli_bin
+		|| options.wpCodeboxBin
+		|| options.wp_codebox_bin
+		|| env.HOMEBOY_WP_CODEBOX_BIN
+		|| env.WP_CODEBOX_BIN
+		|| env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN
+		|| settings.wp_codebox_bin
+		|| settings.wpCodeboxBin
+		|| options.wpCliBin
+		|| options.wp_cli_bin
+		|| env.wpCliBin
+		|| env.wp_cli_bin
+		|| env.HOMEBOY_WP_CLI_BIN
+		|| env.WP_CLI_BIN
+		|| DEFAULT_WP_CODEBOX_PUBLIC_CLI_BIN;
+}
+
+function wpCodeboxPublicCliInvocation(options = {}) {
+	return wpCodeboxCommand(wpCodeboxPublicCliBin(options));
 }
 
 function normalizeCliResult(result = {}) {

--- a/wordpress/scripts/fuzz/fuzz-runner.cjs
+++ b/wordpress/scripts/fuzz/fuzz-runner.cjs
@@ -153,7 +153,7 @@ function wpCodeboxCommandFromPublicAbility(ability, options = {}) {
 async function runWpCodeboxPublicRuntimeCommand(command, invocation, tempDir, options = {}) {
 	const inputFile = path.join(tempDir, `${invocation.command}-request.json`);
 	fs.writeFileSync(inputFile, `${JSON.stringify(invocation.input, null, 2)}\n`);
-	return spawnJson(command, [invocation.command, '--input-file', inputFile, '--json'], {
+	return spawnJson(command, [invocation.command, '--input-file', inputFile, '--format=json'], {
 		cwd: process.cwd(),
 		env: options.env || process.env,
 	});

--- a/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
+++ b/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
@@ -53,10 +53,19 @@ fs.mkdirSync(emptyCodeboxInstallRoot, { recursive: true });
 fs.writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
 
-const command = process.argv[2];
+const namespace = process.argv[2];
+const command = process.argv[3];
 const inputFileIndex = process.argv.indexOf('--input-file');
-if (command !== 'run-fuzz-suite' || inputFileIndex < 0 || !process.argv.includes('--json')) {
-  process.stderr.write('expected public run-fuzz-suite --input-file <file> --json invocation');
+if (namespace === 'codebox' && command === 'run-fuzz-suite' && process.argv.includes('--help')) {
+  process.stdout.write('usage: wp codebox run-fuzz-suite');
+  process.exit(0);
+}
+if (namespace === 'codebox' && command === 'run-wordpress-workload' && process.argv.includes('--help')) {
+  process.stderr.write('unknown command');
+  process.exit(1);
+}
+if (namespace !== 'codebox' || command !== 'run-fuzz-suite' || inputFileIndex < 0 || !process.argv.includes('--format=json')) {
+  process.stderr.write('expected public codebox run-fuzz-suite --input-file <file> --format=json invocation');
   process.exit(1);
 }
 

--- a/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
+++ b/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
@@ -53,20 +53,19 @@ fs.mkdirSync(emptyCodeboxInstallRoot, { recursive: true });
 fs.writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
 
-const namespace = process.argv[2];
-const command = process.argv[3];
+const command = process.argv[2];
 const inputFileIndex = process.argv.indexOf('--input-file');
-if (namespace === 'codebox' && command === 'run-fuzz-suite' && process.argv.includes('--help')) {
-  process.stdout.write('usage: wp codebox run-fuzz-suite');
-  process.exit(0);
+if (command === 'run-fuzz-suite' && process.argv.includes('--help')) {
+	process.stdout.write('usage: wp-codebox run-fuzz-suite');
+	process.exit(0);
 }
-if (namespace === 'codebox' && command === 'run-wordpress-workload' && process.argv.includes('--help')) {
-  process.stderr.write('unknown command');
-  process.exit(1);
+if (command === 'run-wordpress-workload' && process.argv.includes('--help')) {
+	process.stderr.write('unknown command');
+	process.exit(1);
 }
-if (namespace !== 'codebox' || command !== 'run-fuzz-suite' || inputFileIndex < 0 || !process.argv.includes('--format=json')) {
-  process.stderr.write('expected public codebox run-fuzz-suite --input-file <file> --format=json invocation');
-  process.exit(1);
+if (command !== 'run-fuzz-suite' || inputFileIndex < 0 || !process.argv.includes('--format=json')) {
+	process.stderr.write('expected public run-fuzz-suite --input-file <file> --format=json invocation');
+	process.exit(1);
 }
 
 const request = JSON.parse(fs.readFileSync(process.argv[inputFileIndex + 1], 'utf8'));

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -462,19 +462,19 @@ fs.mkdirSync(path.dirname(fakeCodeboxBin), { recursive: true });
 const dispatchResultsPath = path.join(tempDir, 'dispatch-results.json');
 fs.writeFileSync(fakeCodeboxBin, `#!/usr/bin/env node
 const fs = require('node:fs');
-const subcommand = process.argv.slice(2, 4).join(' ');
-if (subcommand === 'codebox run-fuzz-suite' && process.argv.includes('--help')) {
-  process.stdout.write('usage: wp codebox run-fuzz-suite');
+const subcommand = process.argv[2];
+if (subcommand === 'run-fuzz-suite' && process.argv.includes('--help')) {
+  process.stdout.write('usage: wp-codebox run-fuzz-suite');
   process.exit(0);
 }
-if (subcommand === 'codebox run-wordpress-workload' && process.argv.includes('--help')) {
+if (subcommand === 'run-wordpress-workload' && process.argv.includes('--help')) {
   process.stderr.write('unknown command');
   process.exit(1);
 }
 const inputFileIndex = process.argv.indexOf('--input-file');
 const request = inputFileIndex === -1 ? undefined : JSON.parse(fs.readFileSync(process.argv[inputFileIndex + 1], 'utf8'));
-if (subcommand !== 'codebox run-fuzz-suite' || inputFileIndex === -1 || process.argv.includes('--input=-') || !process.argv.includes('--format=json')) {
-  process.stderr.write('expected public wp codebox run-fuzz-suite command');
+if (subcommand !== 'run-fuzz-suite' || inputFileIndex === -1 || process.argv.includes('--input=-') || !process.argv.includes('--format=json')) {
+  process.stderr.write('expected public wp-codebox run-fuzz-suite command');
   process.exit(1);
 }
 if (request.schema !== 'wp-codebox/fuzz-suite/v1' || request.metadata?.homeboy_agent_task_request?.task_id !== 'dispatch-cli-run') {

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -504,7 +504,7 @@ const dispatchCli = spawnSync(runnerPath, [], {
 	encoding: 'utf8',
 	env: {
 		...process.env,
-		HOMEBOY_WP_CLI_BIN: fakeCodeboxBin,
+		HOMEBOY_WP_CODEBOX_BIN: fakeCodeboxBin,
 		HOMEBOY_FUZZ_WORKLOAD_PATH: workloadPath,
 		HOMEBOY_FUZZ_WORKLOAD_ID: 'dispatch-cli-workload',
 		HOMEBOY_FUZZ_RUN_ID: 'dispatch-cli-run',

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -520,18 +520,17 @@ runWpCodeboxFuzzSuite({
 		taskId: 'public-cli-suite-run',
 		input,
 		runPublicCli: ({ args, stdin }) => {
-			if (args.join(' ') === 'codebox run-fuzz-suite --help') {
+			if (args.join(' ') === 'run-fuzz-suite --help') {
 				return { status: 0, stdout: 'usage' };
 			}
-			if (args.join(' ') === 'codebox run-wordpress-workload --help') {
+			if (args.join(' ') === 'run-wordpress-workload --help') {
 				return { status: 1, stderr: 'unknown command' };
 			}
-			assert.equal(args[0], 'codebox');
-			assert.equal(args[1], 'run-fuzz-suite');
-			assert.equal(args[2], '--input-file');
-			assert.equal(args[4], '--format=json');
+			assert.equal(args[0], 'run-fuzz-suite');
+			assert.equal(args[1], '--input-file');
+			assert.equal(args[3], '--format=json');
 			assert.equal(stdin, undefined);
-			assert.equal(JSON.parse(fs.readFileSync(args[3], 'utf8')).schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+			assert.equal(JSON.parse(fs.readFileSync(args[2], 'utf8')).schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
 			return {
 				status: 0,
 				stdout: JSON.stringify({


### PR DESCRIPTION
## Summary
- honor HOMEBOY_WP_CODEBOX_BIN and related Codebox bin settings in WordPress fuzz runner dispatch
- invoke direct wp-codebox binaries without the WP-CLI codebox namespace while preserving wp codebox behavior for WP-CLI bins
- align public fuzz CLI adapter calls with --format=json and cover the direct CLI path in tests

## Tests
- npm run test:wp-codebox-fuzz-suite
- npm run test:wordpress-fuzz-runner
- npm run test:wordpress-fuzz-runner-codebox-contract
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Debugging the fuzz runner public CLI dispatch path, editing implementation/tests, and running focused verification.