### PR TITLE
Use public Codebox adapter boundaries

### DIFF
--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -76,8 +76,6 @@ const RUNTIME_MANIFEST_PATH = path.resolve(__dirname, '..', 'wp-codebox.json');
 const RUNTIME_OVERLAY_CANONICAL_SHAPE = 'runtime_overlays entries must be objects. WP Codebox owns the runtime overlay schema and reports field-level validation.';
 const RUNTIME_EXECUTION_DESCRIPTOR_SCHEMA = 'homeboy/runtime-execution/v1';
 const PROVIDER_CAPABILITIES = runtimeProviderCapabilities();
-const WP_CODEBOX_OWNED_SUBSTRATE_SLUGS = new Set(['agents-api', 'data-machine', 'data-machine-code']);
-const WP_CODEBOX_RUNTIME_PACKAGE_SUBSTRATE_SLUGS = ['agents-api', 'data-machine', 'data-machine-code'];
 const WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY = 'wp-codebox/run-runtime-package';
 const LEGACY_RUNTIME_PACKAGE_ABILITIES = new Set(['agents/run-runtime-package', 'runtime-package/run']);
 
@@ -341,19 +339,7 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
     inputs.runtime_task || inputs.runtimeTask || config.runtime_task || config.runtimeTask || abilityRuntimeTaskFromAgentTaskRequest(request, config, inputs) || runtimeOptions.runtimeTask,
     { provider, model, agentBundles }
   );
-  const preserveCodeboxOwnedSubstrate = runtimeTask?.ability === WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY;
-  let componentContracts = componentContractsFromAgentTaskRequest(request, config, {
-    ...runtimeOptions,
-    preserveCodeboxOwnedSubstrate,
-  });
-  if (preserveCodeboxOwnedSubstrate) {
-    componentContracts = codeboxRuntimeComponentContracts({
-      componentContracts: [
-        ...defaultCodeboxOwnedSubstrateComponentContracts(runtimeOptions.settings),
-        ...componentContracts,
-      ],
-    });
-  }
+  let componentContracts = componentContractsFromAgentTaskRequest(request, config, runtimeOptions);
   let components = runtimeComponentPaths(config, { ...defaults, ...runtimeOptions, componentContracts });
   const structuredArtifacts = firstDefined(inputs.structured_artifacts, inputs.structuredArtifacts, config.structured_artifacts, config.structuredArtifacts, runtimeOptions.structuredArtifacts, []);
   const artifactDeclarations = codeboxTaskArtifactDeclarations(artifactDeclarationsFromAgentTaskRequest(request, config, inputs, runtimeOptions));
@@ -375,19 +361,13 @@ function codeboxTaskRequestFromAgentTaskRequest(request, options = {}) {
   const timeoutMs = request.limits?.timeout_ms || request.limits?.max_runtime_ms;
   const timeoutFromMs = timeoutMs ? Math.ceil(timeoutMs / 1000) : undefined;
   const runtimeOverlays = runtimeOverlaysFromConfig(config, runtimeOptions, defaults);
-  const runtimeRequirements = codeboxRuntimeRequirementsWithoutCodeboxOwnedSubstrate(
-    codeboxRuntimeRequirementsFromAgentTaskRequest(config, runtimeOptions, defaults, componentContracts, runtimeOverlays),
-    { preserveCodeboxOwnedSubstrate }
-  );
+  const runtimeRequirements = codeboxRuntimeRequirementsFromAgentTaskRequest(config, runtimeOptions, defaults, componentContracts, runtimeOverlays);
   componentContracts = codeboxRuntimeComponentContracts({
     componentContracts: [
       ...componentContracts,
       ...normalizeArray(runtimeRequirements.component_contracts),
     ],
-  }).filter((contract) => preserveCodeboxOwnedSubstrate || !isCodeboxOwnedSubstrateContract(contract));
-  if (preserveCodeboxOwnedSubstrate) {
-    assertRuntimePackageSubstratePreflight(componentContracts, runtimeTask);
-  }
+  });
   components = runtimeComponentPaths(config, { ...defaults, ...runtimeOptions, componentContracts });
   const runtimeTaskAbilityNormalization = runtimeTaskAbilityNormalizationEvidence(runtimeTask);
   const context = {
@@ -681,14 +661,6 @@ class RuntimeOverlayConfigError extends Error {
   }
 }
 
-class RuntimePackageSubstratePreflightError extends Error {
-  constructor(diagnostics) {
-    super(diagnostics[0]?.message || 'WP Codebox runtime-package substrate preflight failed.');
-    this.name = 'RuntimePackageSubstratePreflightError';
-    this.diagnostics = diagnostics;
-  }
-}
-
 function runtimeOverlaysFromConfig(config, options = {}, defaults = {}) {
   return validateRuntimeOverlays(firstDefined(
     config.runtime_overlays,
@@ -743,7 +715,7 @@ function componentContractsFromAgentTaskRequest(request, config, options = {}) {
       ...normalizeArray(config.component_contracts),
       ...normalizeArray(options.componentContracts),
     ],
-  }).filter((contract) => options.preserveCodeboxOwnedSubstrate || !isCodeboxOwnedSubstrateContract(contract));
+  });
 }
 
 function codeboxRuntimeRequirementsFromAgentTaskRequest(config, options = {}, defaults = {}, componentContracts = [], runtimeOverlays = []) {
@@ -1266,7 +1238,7 @@ function runtimeTaskAbilityNormalization({ requestedAbility, normalizedAbility }
     normalized_codebox_ability: normalizedAbility,
     bridge_ability: runtimePackage ? WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY : normalizedAbility,
     runtime_ability: normalizedAbility,
-    owning_components: runtimePackage ? ['wp-codebox', ...WP_CODEBOX_RUNTIME_PACKAGE_SUBSTRATE_SLUGS] : ['wp-codebox'],
+    owning_components: ['wp-codebox'],
   };
 }
 
@@ -1276,64 +1248,6 @@ function runtimeTaskAbilityNormalizationEvidence(runtimeTask = {}) {
     return null;
   }
   return normalization;
-}
-
-function assertRuntimePackageSubstratePreflight(componentContracts = [], runtimeTask = {}) {
-  const diagnostics = runtimePackageSubstratePreflightDiagnostics(componentContracts, runtimeTask);
-  if (diagnostics.length > 0) {
-    throw new RuntimePackageSubstratePreflightError(diagnostics);
-  }
-}
-
-function runtimePackageSubstratePreflightDiagnostics(componentContracts = [], runtimeTask = {}) {
-  const contractsBySlug = new Map(normalizeArray(componentContracts).flatMap((contract) => {
-    const slug = typeof contract?.slug === 'string' ? contract.slug.trim() : '';
-    return slug ? [[slug, contract]] : [];
-  }));
-  return WP_CODEBOX_RUNTIME_PACKAGE_SUBSTRATE_SLUGS.flatMap((slug) => {
-    const contract = contractsBySlug.get(slug);
-    if (!contract) {
-      return [runtimePackageSubstrateDiagnostic(slug, 'missing_contract', runtimeTask)];
-    }
-    if (!firstValue(contract.path, contract.source, contract.target)) {
-      return [runtimePackageSubstrateDiagnostic(slug, 'missing_path', runtimeTask)];
-    }
-    return [];
-  });
-}
-
-function runtimePackageSubstrateDiagnostic(slug, reason, runtimeTask = {}) {
-  const settingKeys = runtimePackageSubstrateSettingKeys(slug);
-  const envKeys = runtimePackageSubstrateEnvKeys(slug);
-  return {
-    class: 'codebox.preflight.runtime_package_substrate',
-    message: `WP Codebox runtime-package tasks require the ${slug} substrate component contract with a path before dispatch. Provide executor.config.component_contracts or configure ${settingKeys.join('/')} / ${envKeys.join('/')} for Codebox-owned substrate discovery.`,
-    data: {
-      component: slug,
-      reason,
-      requested_ability: runtimeTask?.ability_normalization?.requested_ability || runtimeTask?.ability,
-      normalized_codebox_ability: runtimeTask?.ability || WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY,
-      required_components: WP_CODEBOX_RUNTIME_PACKAGE_SUBSTRATE_SLUGS,
-      settings_keys: settingKeys,
-      env_keys: envKeys,
-    },
-  };
-}
-
-function runtimePackageSubstrateSettingKeys(slug) {
-  return {
-    'agents-api': ['wp_codebox_agents_api_path', 'agents_api_path'],
-    'data-machine': ['wp_codebox_data_machine_path', 'data_machine_path'],
-    'data-machine-code': ['wp_codebox_data_machine_code_path', 'data_machine_code_path'],
-  }[slug] || [];
-}
-
-function runtimePackageSubstrateEnvKeys(slug) {
-  return {
-    'agents-api': ['WP_CODEBOX_AGENTS_API_PATH', 'HOMEBOY_WP_CODEBOX_AGENTS_API_PATH'],
-    'data-machine': ['WP_CODEBOX_DATA_MACHINE_PATH', 'HOMEBOY_WP_CODEBOX_DATA_MACHINE_PATH'],
-    'data-machine-code': ['WP_CODEBOX_DATA_MACHINE_CODE_PATH', 'HOMEBOY_WP_CODEBOX_DATA_MACHINE_CODE_PATH'],
-  }[slug] || [];
 }
 
 function runtimeComponentPaths(config, options = {}) {
@@ -1494,66 +1408,7 @@ function defaultRuntimeOverlays(settings, phpAiClientPath = '') {
 }
 
 function defaultRuntimeRequirements() {
-  return {
-    ability_requirements: ['agents/chat'],
-  };
-}
-
-function isCodeboxOwnedSubstrateContract(contract) {
-  const slug = typeof contract?.slug === 'string' ? contract.slug.trim() : '';
-  if (contract?.pluginFile || contract?.plugin_file) {
-    return false;
-  }
-  return WP_CODEBOX_OWNED_SUBSTRATE_SLUGS.has(slug);
-}
-
-function codeboxRuntimeRequirementsWithoutCodeboxOwnedSubstrate(runtimeRequirements = {}, options = {}) {
-  if (!runtimeRequirements || typeof runtimeRequirements !== 'object' || Array.isArray(runtimeRequirements)) {
-    return runtimeRequirements;
-  }
-  if (options.preserveCodeboxOwnedSubstrate) {
-    return runtimeRequirements;
-  }
-  return {
-    ...runtimeRequirements,
-    component_contracts: normalizeArray(runtimeRequirements.component_contracts).filter((contract) => !isCodeboxOwnedSubstrateContract(contract)),
-    extra_plugins: normalizeArray(runtimeRequirements.extra_plugins).filter((contract) => !isCodeboxOwnedSubstrateContract(contract)),
-  };
-}
-
-function defaultCodeboxOwnedSubstrateComponentContracts(settings = {}) {
-  return [
-    codeboxOwnedSubstrateComponentContract('agents-api', firstExistingPath(
-      settings.wp_codebox_agents_api_path,
-      settings.agents_api_path,
-      process.env.WP_CODEBOX_AGENTS_API_PATH,
-      process.env.HOMEBOY_WP_CODEBOX_AGENTS_API_PATH,
-    )),
-    codeboxOwnedSubstrateComponentContract('data-machine', firstExistingPath(
-      settings.wp_codebox_data_machine_path,
-      settings.data_machine_path,
-      process.env.WP_CODEBOX_DATA_MACHINE_PATH,
-      process.env.HOMEBOY_WP_CODEBOX_DATA_MACHINE_PATH,
-    )),
-    codeboxOwnedSubstrateComponentContract('data-machine-code', firstExistingPath(
-      settings.wp_codebox_data_machine_code_path,
-      settings.data_machine_code_path,
-      process.env.WP_CODEBOX_DATA_MACHINE_CODE_PATH,
-      process.env.HOMEBOY_WP_CODEBOX_DATA_MACHINE_CODE_PATH,
-    )),
-  ].filter(Boolean);
-}
-
-function codeboxOwnedSubstrateComponentContract(slug, componentPath) {
-  if (!componentPath) {
-    return null;
-  }
-  return {
-    slug,
-    path: componentPath,
-    loadAs: 'plugin',
-    activate: true,
-  };
+  return {};
 }
 
 function defaultChatHandlerPluginContracts(settings = {}, options = {}, providerConfig = {}) {
@@ -1616,28 +1471,6 @@ function envPathList(value) {
     // Fall through to PATH-style lists for simple environment configuration.
   }
   return String(value).split(path.delimiter).map((entry) => entry.trim()).filter(Boolean);
-}
-
-function defaultAgentsApiPath(settings, options = {}, agentRuntimePath = '') {
-  return firstExistingPath(
-    options.agentsApi,
-    options.agents_api,
-    settings.wp_codebox_agents_api_path,
-    settings.agents_api_path,
-    process.env.HOMEBOY_WP_CODEBOX_AGENTS_API_PATH,
-    process.env.WP_CODEBOX_AGENTS_API_PATH,
-    ...bundledAgentsApiPaths(agentRuntimePath),
-  );
-}
-
-function bundledAgentsApiPaths(agentRuntimePath = '') {
-  if (!agentRuntimePath) {
-    return [];
-  }
-  return [
-    path.join(agentRuntimePath, 'vendor', 'wordpress', 'agents-api'),
-    path.join(agentRuntimePath, 'vendor', 'automattic', 'agents-api'),
-  ];
 }
 
 function defaultPhpAiClientPath(settings, options = {}) {

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
@@ -154,9 +154,6 @@ function coreModuleCandidates(options = {}) {
   const candidates = [
     DEFAULT_CODEBOX_CONTRACTS_MODULE,
     'wp-codebox-workspace/contracts',
-    // Compatibility fallback for WP Codebox builds before focused package entrypoints.
-    '@automattic/wp-codebox-core',
-    'wp-codebox-workspace/core',
   ];
   for (const candidate of setupCacheCoreModuleCandidates(options)) {
     if (existsSync(candidate) && !candidates.includes(candidate)) {
@@ -171,9 +168,6 @@ function setupCacheCoreModuleCandidates(options = {}) {
   return [
     path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist/contracts.js'),
     path.resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/contracts.js'),
-    // Compatibility fallback for WP Codebox builds before focused package entrypoints.
-    path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist/index.js'),
-    path.resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/index.js'),
   ];
 }
 

--- a/tests/wp-codebox-runtime-contract-source-smoke.mjs
+++ b/tests/wp-codebox-runtime-contract-source-smoke.mjs
@@ -184,18 +184,15 @@ assert.throws(
 
 const installRoot = path.join(tempRoot, 'wp-codebox-install');
 const focusedContractsPath = path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'contracts.js');
-const legacyIndexPath = path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'index.js');
 fs.mkdirSync(path.dirname(focusedContractsPath), { recursive: true });
 fs.writeFileSync(focusedContractsPath, 'export function runtimeContractManifest() { return {}; }\n');
-fs.writeFileSync(legacyIndexPath, 'export function runtimeContractManifest() { return {}; }\n');
+fs.writeFileSync(path.join(path.dirname(focusedContractsPath), 'index.js'), 'export function runtimeContractManifest() { return {}; }\n');
 delete process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE;
 const contractCandidates = coreModuleCandidates({ wpCodeboxInstallDir: installRoot });
 assert.equal(contractCandidates[0], '@automattic/wp-codebox-core/contracts');
 assert.equal(contractCandidates[1], 'wp-codebox-workspace/contracts');
-assert.equal(contractCandidates[2], '@automattic/wp-codebox-core');
-assert.equal(contractCandidates[3], 'wp-codebox-workspace/core');
-assert.match(contractCandidates[4], /dist\/contracts\.js$/);
-assert.match(contractCandidates[5], /dist\/index\.js$/);
+assert.match(contractCandidates[2], /dist\/contracts\.js$/);
+assert.equal(contractCandidates.some((candidate) => /dist\/index\.js$/.test(candidate)), false);
 
 const mismatchedModule = path.join(tempRoot, 'mismatched-runtime-core.mjs');
 fs.writeFileSync(mismatchedModule, `

--- a/wordpress/lib/audit-wp-codebox-runtime-provider.js
+++ b/wordpress/lib/audit-wp-codebox-runtime-provider.js
@@ -37,10 +37,8 @@ const WP_CODEBOX_ARTIFACTS_MODULE_OPTIONS = {
   packageCandidates: [
     '@automattic/wp-codebox-core/artifacts',
     'wp-codebox-workspace/artifacts',
-    // Compatibility fallback for WP Codebox builds before focused package entrypoints.
-    '@automattic/wp-codebox-core',
   ],
-  packageDistEntries: ['artifacts.js', 'index.js'],
+  packageDistEntries: ['artifacts.js'],
 };
 
 function sha256(value) {

--- a/wordpress/lib/wp-codebox-apply-adapter.js
+++ b/wordpress/lib/wp-codebox-apply-adapter.js
@@ -21,10 +21,8 @@ const WP_CODEBOX_ARTIFACTS_MODULE_OPTIONS = {
   packageCandidates: [
     '@automattic/wp-codebox-core/artifacts',
     'wp-codebox-workspace/artifacts',
-    // Compatibility fallback for WP Codebox builds before focused package entrypoints.
-    '@automattic/wp-codebox-core',
   ],
-  packageDistEntries: ['artifacts.js', 'index.js'],
+  packageDistEntries: ['artifacts.js'],
 };
 
 function readJson(filePath) {

--- a/wordpress/lib/wp-codebox-core-loader.js
+++ b/wordpress/lib/wp-codebox-core-loader.js
@@ -54,7 +54,7 @@ function coreModuleCandidates(options = {}) {
 
 function setupCacheCoreModuleCandidates(options = {}) {
 	const installRoot = options.wpCodeboxInstallDir || process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.resolve(homedir(), '.cache/homeboy/wp-codebox');
-	const packageDistEntries = options.packageDistEntries || ['index.js'];
+	const packageDistEntries = options.packageDistEntries || [];
 	const candidates = [];
 	for (const entry of packageDistEntries) {
 		candidates.push(path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist', entry));

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -38,14 +38,6 @@ const claudeCodeSecretEnv = [
   'AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN',
   'AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT',
 ];
-const runtimePackageSubstrateOptions = {
-  settings: {
-    wp_codebox_agents_api_path: workspaceRoot,
-    wp_codebox_data_machine_path: workspaceRoot,
-    wp_codebox_data_machine_code_path: workspaceRoot,
-  },
-};
-
 function restoreEnv(name, value) {
   if (value === undefined) {
     delete process.env[name];
@@ -695,7 +687,7 @@ const controllerClientContextArtifactsTaskInput = codeboxTaskRequestFromAgentTas
       input: { package: { slug: 'website-idea-agent', source: 'bundles/website-idea-agent' } },
     },
   },
-}, runtimePackageSubstrateOptions);
+});
 
 assert.deepEqual(controllerClientContextArtifactsTaskInput.artifact_declarations, [{
   schema: 'wp-codebox/artifact-declaration/v1',
@@ -710,7 +702,7 @@ assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.ability_
   normalized_codebox_ability: 'wp-codebox/run-runtime-package',
   bridge_ability: 'wp-codebox/run-runtime-package',
   runtime_ability: 'wp-codebox/run-runtime-package',
-  owning_components: ['wp-codebox', 'agents-api', 'data-machine', 'data-machine-code'],
+  owning_components: ['wp-codebox'],
 });
 assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task_ability_normalization, controllerClientContextArtifactsTaskInput.runtime_task.ability_normalization);
 assert.equal(controllerClientContextArtifactsTaskInput.runtime_task.input.runtime_package, 'website-idea-agent');
@@ -733,7 +725,7 @@ const legacyRuntimePackageTaskInput = codeboxTaskRequestFromAgentTaskRequest({
       input: { package: { slug: 'example-agent', source: 'bundles/example-agent' } },
     },
   },
-}, runtimePackageSubstrateOptions);
+});
 assert.equal(legacyRuntimePackageTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
 assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.runtime_package, 'example-agent');
 assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.agent, 'example-agent');
@@ -742,7 +734,7 @@ assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.model, 'gpt-5.5');
 assert.deepEqual(legacyRuntimePackageTaskInput.runtime_task.input.metadata.runtime_package_descriptor, { slug: 'example-agent', source: 'bundles/example-agent' });
 assert.equal(Object.hasOwn(legacyRuntimePackageTaskInput.runtime_task.input, 'package'), false);
 
-const runtimePackageSubstrateTaskInput = codeboxTaskRequestFromAgentTaskRequest({
+const explicitRuntimePackageComponentTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'runtime-package-substrate-task-1',
   executor: {
@@ -756,7 +748,7 @@ const runtimePackageSubstrateTaskInput = codeboxTaskRequestFromAgentTaskRequest(
       ],
     },
   },
-  instructions: 'Run a runtime-package task with Codebox-owned substrate components.',
+  instructions: 'Run a runtime-package task with caller-supplied component contracts.',
   inputs: {
     ability_request: {
       name: 'runtime-package/run',
@@ -775,31 +767,26 @@ const runtimePackageSubstrateTaskInput = codeboxTaskRequestFromAgentTaskRequest(
     },
   },
 });
-assert.equal(runtimePackageSubstrateTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
-assert.deepEqual(runtimePackageSubstrateTaskInput.component_contracts.map((contract) => contract.slug), ['agents-api', 'data-machine', 'data-machine-code']);
-assert.equal(runtimePackageSubstrateTaskInput.runtime_component_paths.agents_api, '/components/agents-api');
-assert.equal(runtimePackageSubstrateTaskInput.runtime_component_paths.agent_runtime, '/components/data-machine');
-assert.equal(runtimePackageSubstrateTaskInput.runtime_component_paths.data_machine_code, '/components/data-machine-code');
+assert.equal(explicitRuntimePackageComponentTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
+assert.deepEqual(explicitRuntimePackageComponentTaskInput.component_contracts.map((contract) => contract.slug), ['agents-api', 'data-machine', 'data-machine-code']);
+assert.equal(explicitRuntimePackageComponentTaskInput.runtime_component_paths.agents_api, '/components/agents-api');
+assert.equal(explicitRuntimePackageComponentTaskInput.runtime_component_paths.agent_runtime, '/components/data-machine');
+assert.equal(explicitRuntimePackageComponentTaskInput.runtime_component_paths.data_machine_code, '/components/data-machine-code');
 
-assert.throws(() => codeboxTaskRequestFromAgentTaskRequest({
+const runtimePackageWithoutSubstrateTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
   task_id: 'runtime-package-missing-substrate-task-1',
   executor: { backend: 'codebox', config: { provider: 'codex' } },
-  instructions: 'Fail before dispatch when runtime-package substrate contracts are missing.',
+  instructions: 'Run a runtime-package task through the public Codebox ability without HBE substrate construction.',
   inputs: {
     ability_request: {
       name: 'runtime-package/run',
       input: { package: { slug: 'example-agent' } },
     },
   },
-}), (error) => {
-  assert.equal(error.name, 'RuntimePackageSubstratePreflightError');
-  assert.equal(error.diagnostics.length, 3);
-  assert.equal(error.diagnostics[0].class, 'codebox.preflight.runtime_package_substrate');
-  assert.match(error.diagnostics[0].message, /agents-api substrate component contract/);
-  assert.deepEqual(error.diagnostics[0].data.required_components, ['agents-api', 'data-machine', 'data-machine-code']);
-  return true;
 });
+assert.equal(runtimePackageWithoutSubstrateTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
+assert.deepEqual(runtimePackageWithoutSubstrateTaskInput.component_contracts, []);
 
 const previousAgentsApiPath = process.env.WP_CODEBOX_AGENTS_API_PATH;
 const previousDataMachinePath = process.env.WP_CODEBOX_DATA_MACHINE_PATH;
@@ -822,8 +809,7 @@ const runtimePackageEnvSubstrateTaskInput = codeboxTaskRequestFromAgentTaskReque
 restoreEnv('WP_CODEBOX_AGENTS_API_PATH', previousAgentsApiPath);
 restoreEnv('WP_CODEBOX_DATA_MACHINE_PATH', previousDataMachinePath);
 restoreEnv('WP_CODEBOX_DATA_MACHINE_CODE_PATH', previousDataMachineCodePath);
-assert.deepEqual(runtimePackageEnvSubstrateTaskInput.component_contracts.map((contract) => contract.slug), ['agents-api', 'data-machine', 'data-machine-code']);
-assert.equal(runtimePackageEnvSubstrateTaskInput.component_contracts.every((contract) => contract.path === workspaceRoot), true);
+assert.deepEqual(runtimePackageEnvSubstrateTaskInput.component_contracts, []);
 
 const explicitLegacyRuntimeTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   schema: 'homeboy/agent-task-request/v1',
@@ -837,7 +823,7 @@ const explicitLegacyRuntimeTaskInput = codeboxTaskRequestFromAgentTaskRequest({
       input: { package: { slug: 'example-agent' } },
     },
   },
-}, runtimePackageSubstrateOptions);
+});
 assert.equal(explicitLegacyRuntimeTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
 assert.equal(explicitLegacyRuntimeTaskInput.runtime_task.input.runtime_package, 'example-agent');
 assert.equal(explicitLegacyRuntimeTaskInput.runtime_task.input.agent, 'example-agent');
@@ -861,7 +847,7 @@ const runtimeConfigOptionsRuntimeTaskInput = codeboxTaskRequestFromAgentTaskRequ
       },
     },
   },
-}, runtimePackageSubstrateOptions);
+});
 assert.equal(runtimeConfigOptionsRuntimeTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
 assert.equal(runtimeConfigOptionsRuntimeTaskInput.runtime_task.input.provider, 'codex');
 assert.equal(runtimeConfigOptionsRuntimeTaskInput.runtime_task.input.model, 'gpt-5.5');
@@ -888,7 +874,7 @@ const providerAndControllerArtifactsTaskInput = codeboxTaskRequestFromAgentTaskR
   inputs: {
     ability_request: { name: 'agents/run-runtime-package' },
   },
-}, runtimePackageSubstrateOptions);
+});
 assert.deepEqual(providerAndControllerArtifactsTaskInput.artifact_declarations.map((declaration) => declaration.name), ['concept_packet']);
 assert.deepEqual(providerAndControllerArtifactsTaskInput.runtime_task.input.required_artifacts, ['concept_packet']);
 assert.equal(

--- a/wordpress/tests/codebox-agent-task-executor-smoke.js
+++ b/wordpress/tests/codebox-agent-task-executor-smoke.js
@@ -505,7 +505,6 @@ assert.deepEqual(codeboxRequest.runtime_overlays, [{
 }]);
 assert.deepEqual(codeboxRequest.runtime_requirements, {
   schema: 'wp-codebox/runtime-profile/v1',
-  ability_requirements: ['agents/chat'],
   runtime_overlays: codeboxRequest.runtime_overlays,
   provider_plugins: [{ path: '/providers/openai' }],
   upstream_primitive_requirements: [{
@@ -517,8 +516,6 @@ assert.deepEqual(codeboxRequest.runtime_requirements, {
     adapter_behavior: 'declare_requirement_only',
     requirement: 'Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component declared by the public parent-tool-bridge contract.',
   }],
-  component_contracts: [],
-  extra_plugins: [],
 });
 const legacyOverlayNameRequest = codeboxTaskRequestFromAgentTaskRequest({
   ...request,
@@ -824,7 +821,6 @@ assert.deepEqual(genericProviderRuntimeRequest.provider_plugin_paths, ['/provide
 assert.deepEqual(genericProviderRuntimeRequest.runtime_overlays, [{ kind: 'fixture-overlay', source: '/overlays/fixture' }]);
 assert.deepEqual(genericProviderRuntimeRequest.runtime_requirements, {
   schema: 'wp-codebox/runtime-profile/v1',
-  ability_requirements: ['agents/chat'],
   runtime_overlays: [{ kind: 'fixture-overlay', source: '/overlays/fixture' }],
   env: genericRuntimeEnv,
   provider_plugins: [{ path: '/providers/fixture-provider' }],
@@ -839,8 +835,6 @@ assert.deepEqual(genericProviderRuntimeRequest.runtime_requirements, {
     adapter_behavior: 'declare_requirement_only',
     requirement: 'Expose parent-owned tools inside the sandbox through a Codebox-owned bridge component declared by the public parent-tool-bridge contract.',
   }],
-  component_contracts: [],
-  extra_plugins: [],
 });
 assert.deepEqual(genericProviderRuntimeRequest.runtime_overlay_profiles, ['fixture-profile']);
 assert.deepEqual(genericProviderRuntimeRequest.secret_env, ['FIXTURE_PROVIDER_SECRET']);
@@ -1172,8 +1166,8 @@ try {
     agentRuntime: runtimePath,
     settings: {},
   });
-  assert.equal(bundledAgentsApiRequest.runtime_requirements.component_contracts.some((contract) => contract.slug === 'agents-api'), false);
-  assert.deepEqual(bundledAgentsApiRequest.runtime_requirements.ability_requirements, ['agents/chat']);
+  assert.equal((bundledAgentsApiRequest.runtime_requirements.component_contracts || []).some((contract) => contract.slug === 'agents-api'), false);
+  assert.equal(bundledAgentsApiRequest.runtime_requirements.ability_requirements, undefined);
   assert.equal(bundledAgentsApiRequest.component_contracts.some((contract) => contract.slug === 'agents-api'), false);
 
   const chatHandlerRequest = codeboxTaskRequestFromAgentTaskRequest({
@@ -1192,9 +1186,9 @@ try {
       wp_codebox_chat_handler_plugin_paths: [dataMachinePath],
     },
   });
-  assert.deepEqual(chatHandlerRequest.runtime_requirements.component_contracts.map((contract) => contract.slug), []);
+  assert.deepEqual((chatHandlerRequest.runtime_requirements.component_contracts || []).map((contract) => contract.slug), []);
   assert.deepEqual(chatHandlerRequest.component_contracts.map((contract) => contract.slug), []);
-  assert.deepEqual(chatHandlerRequest.runtime_requirements.ability_requirements, ['agents/chat']);
+  assert.equal(chatHandlerRequest.runtime_requirements.ability_requirements, undefined);
 
   const configuredDefaultProviderRequest = codeboxTaskRequestFromAgentTaskRequest({
     ...request,

--- a/wordpress/tests/wp-codebox-core-loader-smoke.js
+++ b/wordpress/tests/wp-codebox-core-loader-smoke.js
@@ -21,21 +21,19 @@ async function main() {
 			packageCandidates: [
 				'@automattic/wp-codebox-core/artifacts',
 				'wp-codebox-workspace/artifacts',
-				'@automattic/wp-codebox-core',
 			],
-			packageDistEntries: ['artifacts.js', 'index.js'],
+			packageDistEntries: ['artifacts.js'],
 		});
 
 		assert.equal(candidates[0], '@automattic/wp-codebox-core/artifacts');
 		assert.equal(candidates[1], 'wp-codebox-workspace/artifacts');
-		assert.equal(candidates[2], '@automattic/wp-codebox-core');
-		assert.match(candidates[3], /dist\/artifacts\.js$/);
-		assert.match(candidates[4], /dist\/index\.js$/);
+		assert.match(candidates[2], /dist\/artifacts\.js$/);
+		assert.equal(candidates.some((candidate) => /dist\/index\.js$/.test(candidate)), false);
 
 		const result = await loadWpCodeboxCoreExport('fixtureExport', {
 			wpCodeboxInstallDir: root,
 			packageCandidates: [],
-			packageDistEntries: ['artifacts.js', 'index.js'],
+			packageDistEntries: ['artifacts.js'],
 			required: true,
 		});
 
@@ -43,15 +41,12 @@ async function main() {
 		assert.equal(result.value(), 'focused-artifacts');
 
 		fs.rmSync(path.join(dist, 'artifacts.js'));
-		const legacyResult = await loadWpCodeboxCoreExport('fixtureExport', {
+		await assert.rejects(() => loadWpCodeboxCoreExport('fixtureExport', {
 			wpCodeboxInstallDir: root,
 			packageCandidates: [],
-			packageDistEntries: ['artifacts.js', 'index.js'],
+			packageDistEntries: ['artifacts.js'],
 			required: true,
-		});
-
-		assert.match(legacyResult.source, /dist\/index\.js$/);
-		assert.equal(legacyResult.value(), 'legacy-index');
+		}), /WP Codebox core export fixtureExport is unavailable/);
 
 		console.log('wp-codebox core loader smoke passed');
 	} finally {


### PR DESCRIPTION
## Summary
- Remove Homeboy Extensions construction of Codebox private runtime substrate contracts.
- Remove implicit Agents API and Data Machine defaults from Homeboy-owned Codebox request construction.
- Narrow Codebox contract and artifact loading to public entrypoints and focused fallbacks.

## Testing
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js
- node wordpress/tests/codebox-agent-task-executor-smoke.js
- node wordpress/tests/wp-codebox-task-runner-smoke.js
- node tests/wp-codebox-runtime-contract-source-smoke.mjs
- node wordpress/tests/wp-codebox-core-loader-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the code changes.