### PR TITLE
Quarantine legacy Codebox aliases

### DIFF
--- a/agent-runtimes/wp-codebox/README.md
+++ b/agent-runtimes/wp-codebox/README.md
@@ -57,6 +57,12 @@ Codebox package advertises it. Older packages continue through the legacy
 in this adapter so the follow-up swap can remove the fallback while preserving
 Homeboy caller contracts.
 
+Runtime-package ability aliases are quarantined compatibility only. New callers
+should invoke `wp-codebox/run-runtime-package`; legacy `agents/run-runtime-package`
+and `runtime-package/run` requests still normalize to that Codebox-owned ability
+and include `deprecated_compatibility_alias` metadata so controllers can warn and
+migrate without breaking active callers.
+
 Provider credentials stay outside adapter payloads. The adapter forwards
 `secret_env` names and a `provider_credential_boundary` descriptor, and rejects
 raw credential fields such as `secret_env_values` or `credentials` before a task

--- a/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
+++ b/agent-runtimes/wp-codebox/lib/codebox-agent-task-executor.js
@@ -80,6 +80,14 @@ const WP_CODEBOX_OWNED_SUBSTRATE_SLUGS = new Set(['agents-api', 'data-machine', 
 const WP_CODEBOX_RUNTIME_PACKAGE_SUBSTRATE_SLUGS = ['agents-api', 'data-machine', 'data-machine-code'];
 const WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY = 'wp-codebox/run-runtime-package';
 const LEGACY_RUNTIME_PACKAGE_ABILITIES = new Set(['agents/run-runtime-package', 'runtime-package/run']);
+const LEGACY_RUNTIME_PACKAGE_ABILITY_QUARANTINE = 'legacy-runtime-package-ability-alias';
+const LEGACY_RUNTIME_PACKAGE_ABILITY_DEPRECATIONS = Array.from(LEGACY_RUNTIME_PACKAGE_ABILITIES).map((ability) => ({
+  schema: 'wp-codebox/deprecated-compatibility-alias/v1',
+  alias: ability,
+  replacement: WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY,
+  quarantine: LEGACY_RUNTIME_PACKAGE_ABILITY_QUARANTINE,
+  status: 'deprecated',
+}));
 
 const AGENT_BUNDLE_CONFIG_FIELDS = [
   'bundle_path',
@@ -186,6 +194,7 @@ function providerContract(options = {}) {
     provider_credential_boundary: providerCredentialBoundary(),
     provider_runtime_invocation: providerRuntimeInvocationContract(),
     role_aliases: WP_CODEBOX_ROLE_ALIASES,
+    deprecated_compatibility_aliases: LEGACY_RUNTIME_PACKAGE_ABILITY_DEPRECATIONS,
     upstream_primitive_requirements: WP_CODEBOX_UPSTREAM_PRIMITIVE_REQUIREMENTS,
     status: 'active',
     integration_contract: 'homeboy-wordpress-agent-task/v1',
@@ -1260,6 +1269,7 @@ function runtimeTaskAbilityNormalization({ requestedAbility, normalizedAbility }
     return null;
   }
   const runtimePackage = normalizedAbility === WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY;
+  const legacyDeprecation = legacyRuntimePackageAbilityDeprecation(requestedAbility, normalizedAbility);
   return {
     schema: 'wp-codebox/runtime-task-ability-normalization/v1',
     requested_ability: requestedAbility || normalizedAbility,
@@ -1267,6 +1277,20 @@ function runtimeTaskAbilityNormalization({ requestedAbility, normalizedAbility }
     bridge_ability: runtimePackage ? WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY : normalizedAbility,
     runtime_ability: normalizedAbility,
     owning_components: runtimePackage ? ['wp-codebox', ...WP_CODEBOX_RUNTIME_PACKAGE_SUBSTRATE_SLUGS] : ['wp-codebox'],
+    ...(legacyDeprecation ? { deprecated_compatibility_alias: legacyDeprecation } : {}),
+  };
+}
+
+function legacyRuntimePackageAbilityDeprecation(requestedAbility, normalizedAbility) {
+  if (!LEGACY_RUNTIME_PACKAGE_ABILITIES.has(requestedAbility) || normalizedAbility !== WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY) {
+    return null;
+  }
+  return {
+    schema: 'wp-codebox/deprecated-compatibility-alias/v1',
+    alias: requestedAbility,
+    replacement: WP_CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY,
+    quarantine: LEGACY_RUNTIME_PACKAGE_ABILITY_QUARANTINE,
+    status: 'deprecated',
   };
 }
 

--- a/agent-runtimes/wp-codebox/wp-codebox.json
+++ b/agent-runtimes/wp-codebox/wp-codebox.json
@@ -482,6 +482,22 @@
           "provider_run_result": ["codebox_run_result"]
         }
       },
+      "deprecated_compatibility_aliases": [
+        {
+          "schema": "wp-codebox/deprecated-compatibility-alias/v1",
+          "alias": "agents/run-runtime-package",
+          "replacement": "wp-codebox/run-runtime-package",
+          "quarantine": "legacy-runtime-package-ability-alias",
+          "status": "deprecated"
+        },
+        {
+          "schema": "wp-codebox/deprecated-compatibility-alias/v1",
+          "alias": "runtime-package/run",
+          "replacement": "wp-codebox/run-runtime-package",
+          "quarantine": "legacy-runtime-package-ability-alias",
+          "status": "deprecated"
+        }
+      ],
       "upstream_primitive_requirements": [
         {
           "id": "run-agent-task",

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -62,6 +62,11 @@ Generic runner specs must declare `executor.backend` explicitly. Runtime-specifi
 planners may provide their own defaults, but the shared contract does not assume
 any particular backend.
 
+Runtime ids are canonical package ids. Compatibility aliases may resolve for
+existing callers, but resolvers should return explicit deprecation metadata with a
+replacement id and quarantine name. New callers should select canonical runtime
+ids directly, for example `wp-codebox` instead of the legacy `codebox` alias.
+
 ## `runtime_path` Interpolation
 
 Provider commands should reference runtime-local files with `{{runtime_path}}`:

--- a/runtime-agent-ci/lib/runtime-provider-resolver.cjs
+++ b/runtime-agent-ci/lib/runtime-provider-resolver.cjs
@@ -7,6 +7,15 @@ const DEFAULT_RUNTIME_ID = 'local-shell';
 const RUNTIME_ID_ALIASES = {
 	codebox: 'wp-codebox',
 };
+const RUNTIME_ID_ALIAS_DEPRECATIONS = {
+	codebox: {
+		schema: 'homeboy/deprecated-runtime-alias/v1',
+		alias: 'codebox',
+		replacement: 'wp-codebox',
+		quarantine: 'legacy-runtime-id-alias',
+		status: 'deprecated',
+	},
+};
 
 function repoRootFromHere() {
 	return path.resolve(__dirname, '..', '..');
@@ -92,8 +101,15 @@ function normalizeRuntimeId(runtimeId = DEFAULT_RUNTIME_ID) {
 	return RUNTIME_ID_ALIASES[id] || id;
 }
 
+function runtimeIdAliasDeprecation(runtimeId = DEFAULT_RUNTIME_ID) {
+	const id = runtimeId || DEFAULT_RUNTIME_ID;
+	return RUNTIME_ID_ALIAS_DEPRECATIONS[id] || null;
+}
+
 function resolveRuntimeProvider(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
+	const requestedId = runtimeId || DEFAULT_RUNTIME_ID;
 	const id = normalizeRuntimeId(runtimeId);
+	const aliasDeprecation = runtimeIdAliasDeprecation(runtimeId);
 	const registry = options.registry || runtimeRegistry(options);
 	const manifest = registry[id];
 	if (!manifest) {
@@ -113,6 +129,8 @@ function resolveRuntimeProvider(runtimeId = DEFAULT_RUNTIME_ID, options = {}) {
 
 	return {
 		id,
+		requested_id: requestedId,
+		...(aliasDeprecation ? { deprecated_runtime_alias: aliasDeprecation } : {}),
 		manifest,
 		checkout,
 		setupCommands: normalizeCommands(materialization.setup_commands || []),
@@ -403,7 +421,9 @@ function executorScriptArg(provider) {
 
 module.exports = {
 	DEFAULT_RUNTIME_ID,
+	RUNTIME_ID_ALIAS_DEPRECATIONS,
 	normalizeRuntimeId,
+	runtimeIdAliasDeprecation,
 	resolveRuntimeProvider,
 	runtimeManifestPath,
 	runtimeRegistry,

--- a/tests/runtime-provider-resolver-smoke.mjs
+++ b/tests/runtime-provider-resolver-smoke.mjs
@@ -9,7 +9,10 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const workspace = path.join(rootDir, 'fixture-workspace');
 const {
 	DEFAULT_RUNTIME_ID,
+	RUNTIME_ID_ALIAS_DEPRECATIONS,
+	normalizeRuntimeId,
 	resolveRuntimeProvider,
+	runtimeIdAliasDeprecation,
 	runtimeRegistry,
 } = require('../runtime-agent-ci/lib/runtime-provider-resolver.cjs');
 
@@ -46,6 +49,19 @@ assert.equal(runtime.executor.capabilities.includes('agent_bundle_execution'), t
 assert.deepEqual(runtime.executor.runtime_execution_contracts.bundle, {
 	ability_field: 'runtime_bundle_ability',
 	required_capabilities: ['agent_bundle_execution'],
+});
+
+const codeboxAliasRuntime = resolveRuntimeProvider('codebox', { repoRoot: rootDir, workspace });
+assert.equal(normalizeRuntimeId('codebox'), 'wp-codebox');
+assert.equal(codeboxAliasRuntime.id, 'wp-codebox');
+assert.equal(codeboxAliasRuntime.requested_id, 'codebox');
+assert.deepEqual(runtimeIdAliasDeprecation('codebox'), RUNTIME_ID_ALIAS_DEPRECATIONS.codebox);
+assert.deepEqual(codeboxAliasRuntime.deprecated_runtime_alias, {
+	schema: 'homeboy/deprecated-runtime-alias/v1',
+	alias: 'codebox',
+	replacement: 'wp-codebox',
+	quarantine: 'legacy-runtime-id-alias',
+	status: 'deprecated',
 });
 
 const envRuntime = resolveRuntimeProvider('wp-codebox', {

--- a/tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
+++ b/tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
@@ -27,6 +27,22 @@ assert.equal(
 );
 assert.equal(provider.command, provider.invocation.display, 'legacy command stays display-compatible during deprecation');
 assert.equal(provider.provider_metadata.schema, 'homeboy/agent-task-provider-metadata/v1');
+assert.deepEqual(provider.deprecated_compatibility_aliases, [
+	{
+		schema: 'wp-codebox/deprecated-compatibility-alias/v1',
+		alias: 'agents/run-runtime-package',
+		replacement: 'wp-codebox/run-runtime-package',
+		quarantine: 'legacy-runtime-package-ability-alias',
+		status: 'deprecated',
+	},
+	{
+		schema: 'wp-codebox/deprecated-compatibility-alias/v1',
+		alias: 'runtime-package/run',
+		replacement: 'wp-codebox/run-runtime-package',
+		quarantine: 'legacy-runtime-package-ability-alias',
+		status: 'deprecated',
+	},
+]);
 assert.equal(provider.provider_metadata.selection.backend, 'codebox');
 assert.equal(provider.provider_metadata.selection.runtime_id, 'wp-codebox');
 assert.deepEqual(provider.provider_metadata.selection.provider_id_paths, [

--- a/wordpress/tests/codebox-agent-task-executor-boundary.test.js
+++ b/wordpress/tests/codebox-agent-task-executor-boundary.test.js
@@ -44,6 +44,13 @@ const runtimePackageSubstrateOptions = {
     wp_codebox_data_machine_code_path: workspaceRoot,
   },
 };
+const legacyRuntimePackageAbilityAlias = (alias) => ({
+  schema: 'wp-codebox/deprecated-compatibility-alias/v1',
+  alias,
+  replacement: 'wp-codebox/run-runtime-package',
+  quarantine: 'legacy-runtime-package-ability-alias',
+  status: 'deprecated',
+});
 
 function restoreEnv(name, value) {
   if (value === undefined) {
@@ -67,6 +74,10 @@ assert.equal(provider.runtime_id, 'wp-codebox');
 assert.equal(provider.integration_contract, 'homeboy-wordpress-agent-task/v1');
 assert.equal(provider.provider_credential_boundary.schema, 'wp-codebox/provider-credential-boundary/v1');
 assert.equal(provider.upstream_primitive_requirements.some((requirement) => requirement.id === 'provider-credential-boundary'), true);
+assert.deepEqual(provider.deprecated_compatibility_aliases, [
+  legacyRuntimePackageAbilityAlias('agents/run-runtime-package'),
+  legacyRuntimePackageAbilityAlias('runtime-package/run'),
+]);
 assert.deepEqual(provider.provider_runtime_invocation, providerRuntimeInvocationContract());
 assert.equal(provider.provider_runtime_invocation.tasks.workspaceCommand, 'wp-codebox.runner-workspace.command');
 assert.equal(provider.provider_runtime_invocation.abilities.workspaceCommand, 'wp-codebox/runner-workspace-command');
@@ -680,6 +691,7 @@ assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task.ability_
   bridge_ability: 'wp-codebox/run-runtime-package',
   runtime_ability: 'wp-codebox/run-runtime-package',
   owning_components: ['wp-codebox', 'agents-api', 'data-machine', 'data-machine-code'],
+  deprecated_compatibility_alias: legacyRuntimePackageAbilityAlias('agents/run-runtime-package'),
 });
 assert.deepEqual(controllerClientContextArtifactsTaskInput.runtime_task_ability_normalization, controllerClientContextArtifactsTaskInput.runtime_task.ability_normalization);
 assert.equal(controllerClientContextArtifactsTaskInput.runtime_task.input.runtime_package, 'website-idea-agent');
@@ -704,6 +716,10 @@ const legacyRuntimePackageTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   },
 }, runtimePackageSubstrateOptions);
 assert.equal(legacyRuntimePackageTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
+assert.deepEqual(
+  legacyRuntimePackageTaskInput.runtime_task.ability_normalization.deprecated_compatibility_alias,
+  legacyRuntimePackageAbilityAlias('runtime-package/run')
+);
 assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.runtime_package, 'example-agent');
 assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.agent, 'example-agent');
 assert.equal(legacyRuntimePackageTaskInput.runtime_task.input.provider, 'codex');
@@ -808,6 +824,10 @@ const explicitLegacyRuntimeTaskInput = codeboxTaskRequestFromAgentTaskRequest({
   },
 }, runtimePackageSubstrateOptions);
 assert.equal(explicitLegacyRuntimeTaskInput.runtime_task.ability, 'wp-codebox/run-runtime-package');
+assert.deepEqual(
+  explicitLegacyRuntimeTaskInput.runtime_task.ability_normalization.deprecated_compatibility_alias,
+  legacyRuntimePackageAbilityAlias('runtime-package/run')
+);
 assert.equal(explicitLegacyRuntimeTaskInput.runtime_task.input.runtime_package, 'example-agent');
 assert.equal(explicitLegacyRuntimeTaskInput.runtime_task.input.agent, 'example-agent');
 assert.equal(explicitLegacyRuntimeTaskInput.runtime_task.input.provider, 'codex');


### PR DESCRIPTION
## Summary
- Mark legacy WP Codebox runtime-package ability aliases as deprecated compatibility aliases in the provider contract and manifest.
- Preserve active callers by continuing to normalize agents/run-runtime-package and runtime-package/run to wp-codebox/run-runtime-package while adding structured deprecation metadata.
- Keep the codebox runtime id alias working, but return explicit deprecated alias metadata with the wp-codebox replacement.
- Document canonical runtime and ability names for new callers.

## Tests
- node tests/runtime-provider-resolver-smoke.mjs
- node tests/agent-runtime-package-surface-smoke.mjs
- node tests/wp-codebox-agent-runtime-command-contract-smoke.mjs
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js

## Remaining risks
- Compatibility aliases are still accepted because tests and docs show active caller surfaces; this PR makes migration visible rather than removing those paths.
- Other legacy wp_codebox_* workload/source aliases and playground terminology remain for a later, caller-by-caller cleanup.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the existing Codebox compatibility surfaces, implementing the alias quarantine metadata, updating tests/docs, and preparing this PR.