### PR TITLE
Tighten Codebox public adapter boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,14 @@ WP Codebox is expected to consume a `wp-codebox/runtime-profile/v1` payload with
 generic runtime dependencies such as `components`, `plugins`, `mu_plugins`,
 `themes`, `overlays`, `runtime_overlays`, `env`, and `provider_plugins`.
 Homeboy Extensions forwards those shapes as Codebox-owned runtime profile data
-through the current public runtime profile contract. Data Machine ability
-selection, Homeboy task schemas, and caller-owned artifact declarations are
-prepared by Homeboy Extensions before WP Codebox runs the task.
+through the current public runtime profile contract. Sandbox tool selection and
+other substrate details remain WP Codebox-owned; Homeboy task schemas and
+caller-owned artifact declarations are prepared by Homeboy Extensions before WP
+Codebox runs the task.
+
+Codebox contract discovery is limited to public package exports or an explicit
+`HOMEBOY_WP_CODEBOX_CORE_MODULE` supplied by the runner. Homeboy Extensions does
+not probe WP Codebox cache/source package layouts for private files.
 
 Homeboy Extensions consumes a Codebox-owned `wp-codebox/parent-tool-bridge/v1`
 when the runtime profile exposes one. When it is missing, the adapter declares

--- a/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
+++ b/agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js
@@ -2,7 +2,6 @@
 
 const path = require('node:path');
 const { existsSync } = require('node:fs');
-const { homedir } = require('node:os');
 const { fileURLToPath, pathToFileURL } = require('node:url');
 
 const DEFAULT_CODEBOX_CONTRACTS_MODULE = '@automattic/wp-codebox-core/contracts';
@@ -155,20 +154,7 @@ function coreModuleCandidates(options = {}) {
     DEFAULT_CODEBOX_CONTRACTS_MODULE,
     'wp-codebox-workspace/contracts',
   ];
-  for (const candidate of setupCacheCoreModuleCandidates(options)) {
-    if (existsSync(candidate) && !candidates.includes(candidate)) {
-      candidates.push(candidate);
-    }
-  }
   return candidates.map(normalizeCoreModuleSpecifier);
-}
-
-function setupCacheCoreModuleCandidates(options = {}) {
-  const installRoot = options.wpCodeboxInstallDir || process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.resolve(homedir(), '.cache/homeboy/wp-codebox');
-  return [
-    path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist/contracts.js'),
-    path.resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist/contracts.js'),
-  ];
 }
 
 function normalizeCoreModuleSpecifier(specifier) {

--- a/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
+++ b/agent-runtimes/wp-codebox/scripts/agent/homeboy-wp-codebox-task-runner.cjs
@@ -7,12 +7,9 @@
  * External dependencies
  */
 const fs = require('node:fs');
-const http = require('node:http');
-const https = require('node:https');
 const os = require('node:os');
 const path = require('node:path');
 const { spawn, spawnSync } = require('node:child_process');
-const { URLSearchParams } = require('node:url');
 
 const {
   assertProviderSecretEnvPreflight,
@@ -37,9 +34,6 @@ const {
   codeboxRunAgentTaskInvocation,
 } = require('../../lib/codebox-run-agent-task-contract');
 
-const CODEX_OAUTH_TOKEN_URL = 'https://auth.openai.com/oauth/token';
-const WP_CODEBOX_OWNED_SUBSTRATE_SLUGS = new Set(['agents-api', 'data-machine', 'data-machine-code']);
-const CODEX_OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 
 function argValue(name) {
   const index = process.argv.indexOf(name);
@@ -154,123 +148,6 @@ function codexAuthGuidance() {
   return providerGuidance('codex');
 }
 
-function codexOAuthTokenUrl() {
-  return process.env.HOMEBOY_WP_CODEBOX_CODEX_TOKEN_URL || CODEX_OAUTH_TOKEN_URL;
-}
-
-function codexAuthPath() {
-  return process.env.HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH || (process.env.HOME ? path.join(process.env.HOME, '.codex', 'auth.json') : '');
-}
-
-function postForm(url, body, timeoutMs = 20000) {
-  return new Promise((resolve, reject) => {
-    let parsedUrl;
-    try {
-      parsedUrl = new URL(url);
-    } catch {
-      reject(new Error('Codex provider auth preflight failed: OAuth token URL is invalid.'));
-      return;
-    }
-
-    const transport = parsedUrl.protocol === 'http:' ? http : https;
-    const encoded = new URLSearchParams(body).toString();
-    const request = transport.request(parsedUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Content-Length': Buffer.byteLength(encoded),
-      },
-      timeout: timeoutMs,
-    }, (response) => {
-      let responseBody = '';
-      response.setEncoding('utf8');
-      response.on('data', (chunk) => {
-        responseBody += chunk;
-      });
-      response.on('end', () => {
-        resolve({ statusCode: response.statusCode || 0, body: responseBody });
-      });
-    });
-
-    request.on('timeout', () => {
-      request.destroy(new Error('Codex provider auth preflight failed: OAuth refresh timed out.'));
-    });
-    request.on('error', reject);
-    request.end(encoded);
-  });
-}
-
-async function refreshCodexAuthEnv() {
-  let response;
-  try {
-    response = await postForm(codexOAuthTokenUrl(), {
-      grant_type: 'refresh_token',
-      client_id: CODEX_OAUTH_CLIENT_ID,
-      refresh_token: process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN,
-    });
-  } catch (error) {
-    throw new Error(`Codex provider auth preflight failed: OAuth refresh request failed. ${codexAuthGuidance()}`);
-  }
-
-  if (response.statusCode < 200 || response.statusCode >= 300) {
-    throw new Error(`Codex provider auth preflight failed: OAuth refresh returned HTTP ${response.statusCode}. ${codexAuthGuidance()}`);
-  }
-
-  let data;
-  try {
-    data = JSON.parse(response.body);
-  } catch {
-    throw new Error(`Codex provider auth preflight failed: OAuth refresh returned invalid JSON. ${codexAuthGuidance()}`);
-  }
-
-  if (!data || typeof data !== 'object' || typeof data.access_token !== 'string' || data.access_token === '') {
-    throw new Error(`Codex provider auth preflight failed: OAuth refresh returned an invalid response. ${codexAuthGuidance()}`);
-  }
-
-  const expiresIn = Number.isFinite(Number(data.expires_in)) ? Number(data.expires_in) : 3600;
-  const refreshedEnv = Object.fromEntries(Object.entries({
-    AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN: data.access_token,
-    AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN: typeof data.refresh_token === 'string' && data.refresh_token !== ''
-      ? data.refresh_token
-      : process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN,
-    AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: String(Math.floor(Date.now() / 1000) + Math.trunc(expiresIn)),
-    AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: process.env.AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID,
-    AI_PROVIDER_OPENAI_CODEX_FEDRAMP: process.env.AI_PROVIDER_OPENAI_CODEX_FEDRAMP,
-  }).filter(([, value]) => value !== undefined && value !== null && value !== ''));
-  persistRefreshedCodexAuth(refreshedEnv);
-  return refreshedEnv;
-}
-
-function persistRefreshedCodexAuth(refreshedEnv) {
-  const authPath = codexAuthPath();
-  if (!authPath || (!process.env.HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH && !fs.existsSync(authPath))) {
-    return;
-  }
-
-  const auth = readJsonIfAvailable(authPath) || {};
-  const next = {
-    ...auth,
-    tokens: {
-      ...(plainObject(auth.tokens) ? auth.tokens : {}),
-      access_token: refreshedEnv.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN,
-      refresh_token: refreshedEnv.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN,
-      expires_at: refreshedEnv.AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT,
-      account_id: refreshedEnv.AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID,
-      fedramp: refreshedEnv.AI_PROVIDER_OPENAI_CODEX_FEDRAMP,
-    },
-  };
-  try {
-    fs.mkdirSync(path.dirname(authPath), { recursive: true, mode: 0o700 });
-    const tempPath = `${authPath}.${process.pid}.tmp`;
-    fs.writeFileSync(tempPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
-    fs.renameSync(tempPath, authPath);
-    fs.chmodSync(authPath, 0o600);
-  } catch {
-    // Auth refresh is still valid for this run. A later run will surface stale
-    // credentials if the host cannot persist the rotated refresh token.
-  }
-}
-
 async function codexAuthPreflightEnv(request) {
   const manifest = providerPreflightManifest(request.provider);
   if (request.provider !== 'codex' || !manifest) {
@@ -293,7 +170,7 @@ async function codexAuthPreflightEnv(request) {
   }
 
   if (manifest.refresh_hook === 'codex-oauth-refresh') {
-    return refreshCodexAuthEnv();
+    throw new Error(`Codex provider auth preflight failed: token refresh requires a Codebox/provider-owned public credential refresh primitive; Homeboy passes secret_env names only. ${codexAuthGuidance()}`);
   }
 
   return {};
@@ -1257,16 +1134,7 @@ function componentContracts(input) {
     ...requestComponentContracts(input.parent_request).map(remapRuntimeComponentContract),
     ...requestComponentContracts(input.parent_request?.parent_request).map(remapRuntimeComponentContract),
     ...runtimeContracts,
-  ].filter((contract) => !isImplicitCodeboxOwnedSubstrateContract(contract)));
-}
-
-function isCodeboxOwnedSubstrateContract(contract) {
-  const slug = typeof contract?.slug === 'string' ? contract.slug.trim() : '';
-  return WP_CODEBOX_OWNED_SUBSTRATE_SLUGS.has(slug);
-}
-
-function isImplicitCodeboxOwnedSubstrateContract(contract) {
-  return isCodeboxOwnedSubstrateContract(contract) && contract?.metadata?.source !== 'runtime_requirements.component_contracts';
+  ]);
 }
 
 function requestComponentContracts(request) {
@@ -2429,12 +2297,12 @@ function attachRunAgentTaskCompatibilityMetadata(payload, invocation) {
 (async () => {
 try {
   const request = readTaskRequest();
-  const codexEnv = await codexAuthPreflightEnv(request);
+  await codexAuthPreflightEnv(request);
   if (request.provider === 'claude-code') {
     assertProviderSecretEnvPreflight(requestWithCliSecretEnv(request), request.provider, process.env);
   }
   assertRequiredSecretEnvAvailable(request);
-  process.exitCode = runWpCodeboxParentTask(request, codexEnv);
+  process.exitCode = runWpCodeboxParentTask(request);
 } catch (error) {
   console.error(error && error.message ? error.message : String(error));
   process.exitCode = 1;

--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -30,10 +30,22 @@ provider ids and model names as opaque runtime metadata.
 Configure the Codex pair with task config, global settings, or environment variables:
 
 - `provider_plugin_paths`: a Codex-capable provider plugin checkout, such as the Codex provider branch of `ai-provider-for-openai`. Legacy compatibility aliases: `wp_codebox_provider_plugin_paths`, `HOMEBOY_WP_CODEBOX_PROVIDER_PLUGIN_PATH`.
-- `chat_handler_plugin_paths`: one or more WordPress plugin checkouts that register a callable for `wp_agent_chat_handler`, such as a Data Machine checkout when the runtime task dispatches through `agents/chat`. Alias: `wp_codebox_chat_handler_plugin_paths`. Environment lists are accepted through `HOMEBOY_WP_CODEBOX_CHAT_HANDLER_PLUGIN_PATHS` or `WP_CODEBOX_CHAT_HANDLER_PLUGIN_PATHS`.
+- `chat_handler_plugin_paths`: one or more caller-owned WordPress plugin checkouts that expose a public chat/task handler expected by the selected WP Codebox runtime contract. Alias: `wp_codebox_chat_handler_plugin_paths`. Environment lists are accepted through `HOMEBOY_WP_CODEBOX_CHAT_HANDLER_PLUGIN_PATHS` or `WP_CODEBOX_CHAT_HANDLER_PLUGIN_PATHS`.
 - `runtime_overlays`, or `php_ai_client_path`: a prepared `php-ai-client` checkout mounted to `/wordpress/wp-includes/php-ai-client`. Legacy compatibility aliases: `wp_codebox_runtime_overlays`, `wp_codebox_php_ai_client_path`, `HOMEBOY_WP_CODEBOX_PHP_AI_CLIENT_PATH`. Explicit runtime overlay entries must use the canonical `kind` field, for example `{ "kind": "bundled-library", "library": "php-ai-client", "source": "/abs/path/to/php-ai-client" }`; legacy `type` entries are rejected before WP Codebox dispatch.
 
 The `php-ai-client` checkout must include bearer-token auth support (`RequestAuthenticationMethod::bearerToken`) and Composer vendor dependencies (`vendor/autoload.php`). If the stack is incomplete, the executor emits diagnostics for the missing Codex provider plugin, missing bearer-token auth, or missing Composer vendor preparation.
+
+Homeboy forwards provider credential environment variable names only. It does not
+refresh Codex OAuth tokens, read provider auth files, or persist rotated provider
+credentials. When a provider token is stale, WP Codebox or the provider plugin
+must expose a public credential-refresh primitive; until then the Homeboy
+preflight fails with guidance instead of calling provider internals.
+
+WP Codebox contract discovery uses public modules such as
+`@automattic/wp-codebox-core`, `@automattic/wp-codebox-core/contracts`, and
+`wp-codebox-workspace/*`, or an explicit `HOMEBOY_WP_CODEBOX_CORE_MODULE` path
+provided by the runner. Homeboy does not scan WP Codebox source/cache package
+layouts to discover private core files.
 
 ## WP Codebox Artifact Lookup
 

--- a/docs/remote-runner-bootstrap.md
+++ b/docs/remote-runner-bootstrap.md
@@ -165,6 +165,10 @@ missing that extension.
 
 WordPress test and bench workloads use the runner-side WP Codebox cache at
 `~/.cache/homeboy/wp-codebox/source` when WP Codebox is installed from source.
+Homeboy extension adapters do not inspect that cache to discover private Codebox
+package files; runners should expose public Codebox package exports or set
+`HOMEBOY_WP_CODEBOX_CORE_MODULE` explicitly when a public module is not on
+Node's resolution path.
 Refresh that cache before collecting lab evidence that must point at a known WP
 Codebox revision:
 

--- a/tests/wp-codebox-bundled-agents-api-smoke.mjs
+++ b/tests/wp-codebox-bundled-agents-api-smoke.mjs
@@ -58,6 +58,7 @@ process.stdout.write(JSON.stringify({
 		encoding: 'utf8',
 		env: {
 			...process.env,
+			HOMEBOY_WP_CODEBOX_CORE_MODULE: path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs'),
 			HOMEBOY_CAPTURE_TASK_INPUT: capturePath,
 		},
 	});
@@ -90,6 +91,7 @@ process.stdout.write(JSON.stringify({
 		encoding: 'utf8',
 		env: {
 			...process.env,
+			HOMEBOY_WP_CODEBOX_CORE_MODULE: path.join(rootDir, 'tests', 'fixtures', 'wp-codebox-core-runtime-contract.cjs'),
 			HOMEBOY_CAPTURE_TASK_INPUT: runtimeRequirementsCapturePath,
 		},
 	});

--- a/tests/wp-codebox-provider-plugin-defaults-smoke.mjs
+++ b/tests/wp-codebox-provider-plugin-defaults-smoke.mjs
@@ -67,18 +67,10 @@ try {
 			wp_codebox_chat_handler_plugin_paths: [chatHandlerDir],
 		},
 	});
-	const chatHandlerContract = chatHandlerTaskInput.runtime_requirements.component_contracts.find(
-		(contract) => contract.slug === path.basename(chatHandlerDir)
-	);
-	assert.equal(chatHandlerContract.path, chatHandlerDir);
-	assert.equal(chatHandlerContract.loadAs, 'plugin');
-	assert.equal(chatHandlerContract.activate, true);
-	assert.deepEqual(chatHandlerContract.metadata.registers, ['wp_agent_chat_handler']);
-	assert.deepEqual(chatHandlerTaskInput.runtime_requirements.ability_requirements, ['agents/chat']);
-	assert.equal(
-		chatHandlerTaskInput.component_contracts.some((contract) => contract.slug === path.basename(chatHandlerDir)),
-		true
-	);
+	assert.deepEqual(chatHandlerTaskInput.provider_plugin_paths, [providerDir]);
+	assert.equal(chatHandlerTaskInput.runtime_requirements.component_contracts, undefined);
+	assert.equal(chatHandlerTaskInput.runtime_requirements.ability_requirements, undefined);
+	assert.equal(chatHandlerTaskInput.component_contracts.some((contract) => contract.slug === path.basename(chatHandlerDir)), false);
 	assert.deepEqual(providerCredentialSecretEnvNames({ secret_env: ['OPENAI_API_KEY'] }, { recipe: { secret_env: ['GITHUB_TOKEN'] } }), [
 		'OPENAI_API_KEY',
 		'GITHUB_TOKEN',

--- a/tests/wp-codebox-runtime-contract-source-smoke.mjs
+++ b/tests/wp-codebox-runtime-contract-source-smoke.mjs
@@ -143,6 +143,7 @@ assert.deepEqual(
   'Do not carry hardcoded WP Codebox fallback contract constants; consume the public Codebox runtime contract manifest instead.'
 );
 assert.doesNotMatch(runtimeContractSource, /homeboy-extensions-fallback/);
+assert.doesNotMatch(runtimeContractSource, /\.cache\/homeboy\/wp-codebox|setupCacheCoreModuleCandidates|HOMEBOY_WP_CODEBOX_INSTALL_DIR/);
 
 assert.throws(
   () => validateCanonicalRuntimeContractManifest({
@@ -182,17 +183,11 @@ assert.throws(
   /canonical runtime contract manifest is unavailable/
 );
 
-const installRoot = path.join(tempRoot, 'wp-codebox-install');
-const focusedContractsPath = path.join(installRoot, 'source', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', 'contracts.js');
-fs.mkdirSync(path.dirname(focusedContractsPath), { recursive: true });
-fs.writeFileSync(focusedContractsPath, 'export function runtimeContractManifest() { return {}; }\n');
-fs.writeFileSync(path.join(path.dirname(focusedContractsPath), 'index.js'), 'export function runtimeContractManifest() { return {}; }\n');
 delete process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE;
-const contractCandidates = coreModuleCandidates({ wpCodeboxInstallDir: installRoot });
+const contractCandidates = coreModuleCandidates({ wpCodeboxInstallDir: path.join(tempRoot, 'wp-codebox-install') });
 assert.equal(contractCandidates[0], '@automattic/wp-codebox-core/contracts');
 assert.equal(contractCandidates[1], 'wp-codebox-workspace/contracts');
-assert.match(contractCandidates[2], /dist\/contracts\.js$/);
-assert.equal(contractCandidates.some((candidate) => /dist\/index\.js$/.test(candidate)), false);
+assert.equal(contractCandidates.length, 2);
 
 const mismatchedModule = path.join(tempRoot, 'mismatched-runtime-core.mjs');
 fs.writeFileSync(mismatchedModule, `

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -689,6 +689,12 @@ activated by request/config selectors. Codex-backed requests declare the require
 readiness before dispatch while keeping provider and runtime semantics in the
 extension and WP Codebox.
 
+Homeboy forwards those secret environment variable names only. It does not call
+provider OAuth endpoints, read local provider auth files, or persist rotated
+provider credentials. If a token is stale and the provider requires refresh,
+WP Codebox or the provider plugin needs to expose a public refresh primitive;
+without that primitive the preflight fails before sandbox launch.
+
 Provider stacks stay generic at the Homeboy boundary. Executor config, options,
 or `HOMEBOY_SETTINGS_JSON` may provide `runtime_env`, `runtime_state_mounts`,
 and `runtime_config_mounts`. The executor forwards those values unchanged to the

--- a/wordpress/lib/wp-codebox-core-loader.js
+++ b/wordpress/lib/wp-codebox-core-loader.js
@@ -5,7 +5,6 @@
  */
 const path = require('node:path');
 const { existsSync } = require('node:fs');
-const { homedir } = require('node:os');
 const { pathToFileURL } = require('node:url');
 
 const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
@@ -43,24 +42,7 @@ function coreModuleCandidates(options = {}) {
 	}
 
 	const packageCandidates = options.packageCandidates || DEFAULT_CORE_PACKAGE_CANDIDATES;
-	const candidates = [...packageCandidates];
-	for (const candidate of setupCacheCoreModuleCandidates(options)) {
-		if (existsSync(candidate) && !candidates.includes(candidate)) {
-			candidates.push(candidate);
-		}
-	}
-	return candidates.map(normalizeCoreModuleSpecifier);
-}
-
-function setupCacheCoreModuleCandidates(options = {}) {
-	const installRoot = options.wpCodeboxInstallDir || process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.resolve(homedir(), '.cache/homeboy/wp-codebox');
-	const packageDistEntries = options.packageDistEntries || [];
-	const candidates = [];
-	for (const entry of packageDistEntries) {
-		candidates.push(path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist', entry));
-		candidates.push(path.resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist', entry));
-	}
-	return candidates;
+	return [...packageCandidates].map(normalizeCoreModuleSpecifier);
 }
 async function loadWpCodeboxCore(options = {}) {
 	const errors = [];

--- a/wordpress/tests/codebox-codex-auth-preflight-smoke.js
+++ b/wordpress/tests/codebox-codex-auth-preflight-smoke.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { spawn, spawnSync } = require('node:child_process');
+const { spawnSync } = require('node:child_process');
 
 const wpCodeboxRuntimeExecutor = path.join(
   __dirname,
@@ -26,6 +26,14 @@ const wpCodeboxTaskRunner = path.join(
   'agent',
   'homeboy-wp-codebox-task-runner.cjs'
 );
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(
+  __dirname,
+  '..',
+  '..',
+  'tests',
+  'fixtures',
+  'wp-codebox-core-runtime-contract.cjs'
+);
 
 const codexSecretEnv = [
   'AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN',
@@ -36,75 +44,8 @@ const codexSecretEnv = [
 ];
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-codebox-codex-auth-preflight-'));
-let oauthServer;
-
-function waitForFile(filePath) {
-  const deadline = Date.now() + 5000;
-  while (Date.now() < deadline) {
-    if (fs.existsSync(filePath)) {
-      return fs.readFileSync(filePath, 'utf8').trim();
-    }
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
-  }
-  throw new Error(`Timed out waiting for ${filePath}`);
-}
-
-function createRejectingOAuthServer() {
-  const script = path.join(root, 'fixture-rejecting-codex-oauth-server.js');
-  const portPath = path.join(root, 'fixture-rejecting-codex-oauth-port');
-  fs.writeFileSync(script, `#!/usr/bin/env node
-'use strict';
-const fs = require('node:fs');
-const http = require('node:http');
-const portPath = process.argv[2];
-const server = http.createServer((request, response) => {
-  request.resume();
-  response.writeHead(401, { 'Content-Type': 'application/json' });
-  response.end(JSON.stringify({ error: 'invalid_grant' }));
-});
-server.listen(0, '127.0.0.1', () => {
-  fs.writeFileSync(portPath, String(server.address().port));
-});
-`);
-  const child = spawn(process.execPath, [script, portPath], { stdio: ['ignore', 'ignore', 'pipe'] });
-  const port = waitForFile(portPath);
-  return {
-    url: `http://127.0.0.1:${port}/oauth/token`,
-    stop() {
-      child.kill();
-    },
-  };
-}
-
-function createRotatingOAuthServer() {
-  const script = path.join(root, 'fixture-rotating-codex-oauth-server.js');
-  const portPath = path.join(root, 'fixture-rotating-codex-oauth-port');
-  fs.writeFileSync(script, `#!/usr/bin/env node
-'use strict';
-const fs = require('node:fs');
-const http = require('node:http');
-const portPath = process.argv[2];
-const server = http.createServer((request, response) => {
-  request.resume();
-  response.writeHead(200, { 'Content-Type': 'application/json' });
-  response.end(JSON.stringify({ access_token: 'fresh-access-token-value', refresh_token: 'fresh-refresh-token-value', expires_in: 3600 }));
-});
-server.listen(0, '127.0.0.1', () => {
-  fs.writeFileSync(portPath, String(server.address().port));
-});
-`);
-  const child = spawn(process.execPath, [script, portPath], { stdio: ['ignore', 'ignore', 'pipe'] });
-  const port = waitForFile(portPath);
-  return {
-    url: `http://127.0.0.1:${port}/oauth/token`,
-    stop() {
-      child.kill();
-    },
-  };
-}
 
 try {
-  oauthServer = createRejectingOAuthServer();
   const providerPluginPath = path.join(root, 'ai-provider-for-openai');
   fs.mkdirSync(providerPluginPath, { recursive: true });
   fs.writeFileSync(path.join(providerPluginPath, 'ai-provider-for-openai.php'), '<?php\n/* Plugin Name: AI Provider for OpenAI Codex */\n');
@@ -134,7 +75,6 @@ try {
       AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '1',
       AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'stale-account-id-value',
       AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
-      HOMEBOY_WP_CODEBOX_CODEX_TOKEN_URL: oauthServer.url,
     },
   });
 
@@ -143,7 +83,7 @@ try {
   assert.equal(outcome.status, 'failed');
   assert.equal(outcome.failure_classification, 'provider');
   assert.equal(outcome.diagnostics[0].class, 'codebox.preflight.codex_auth');
-  assert.match(outcome.diagnostics[0].data.stderr, /OAuth refresh returned HTTP 401/);
+  assert.match(outcome.diagnostics[0].data.stderr, /Codebox\/provider-owned public credential refresh primitive/);
   assert.match(outcome.diagnostics[0].data.stderr, /Refresh Codex OAuth credentials/);
   assert(!JSON.stringify(outcome).includes('stale-access-token-value'));
   assert(!JSON.stringify(outcome).includes('stale-refresh-token-value'));
@@ -174,15 +114,12 @@ try {
       AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '4102444800',
       AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'account-id-value',
       AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
-      HOMEBOY_WP_CODEBOX_CODEX_TOKEN_URL: oauthServer.url,
     },
   });
   assert.notEqual(validAccessResult.status, 0, 'fake WP Codebox command should fail after auth preflight');
-  assert(!`${validAccessResult.stdout}${validAccessResult.stderr}`.includes('OAuth refresh returned HTTP 401'));
+  assert(!`${validAccessResult.stdout}${validAccessResult.stderr}`.includes('credential refresh primitive'));
   assert(!`${validAccessResult.stdout}${validAccessResult.stderr}`.includes('rejecting-refresh-token-value'));
 
-  oauthServer.stop();
-  oauthServer = createRotatingOAuthServer();
   const authPath = path.join(root, 'codex-auth.json');
   fs.writeFileSync(authPath, JSON.stringify({
     tokens: {
@@ -221,22 +158,19 @@ try {
       AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '1',
       AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'account-id-value',
       AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
-      HOMEBOY_WP_CODEBOX_CODEX_TOKEN_URL: oauthServer.url,
       HOMEBOY_WP_CODEBOX_CODEX_AUTH_PATH: authPath,
     },
   });
-  assert.notEqual(refreshResult.status, 0, 'fake WP Codebox command should fail after auth preflight');
+  assert.equal(refreshResult.status, 1, refreshResult.stderr || refreshResult.stdout);
+  assert.match(refreshResult.stderr, /Codebox\/provider-owned public credential refresh primitive/);
   const persisted = JSON.parse(fs.readFileSync(authPath, 'utf8'));
   assert.equal(persisted.preserved, true);
-  assert.equal(persisted.tokens.access_token, 'fresh-access-token-value');
-  assert.equal(persisted.tokens.refresh_token, 'fresh-refresh-token-value');
+  assert.equal(persisted.tokens.access_token, 'stale-access-token-value');
+  assert.equal(persisted.tokens.refresh_token, 'stale-refresh-token-value');
   assert.equal(persisted.tokens.account_id, 'account-id-value');
-  assert.equal(persisted.tokens.expires_at.length > 0, true);
-  assert(!`${refreshResult.stdout}${refreshResult.stderr}`.includes('fresh-refresh-token-value'));
+  assert.equal(persisted.tokens.expires_at, '4102444800');
+  assert(!`${refreshResult.stdout}${refreshResult.stderr}`.includes('stale-refresh-token-value'));
 } finally {
-  if (oauthServer) {
-    oauthServer.stop();
-  }
   fs.rmSync(root, { recursive: true, force: true });
 }
 

--- a/wordpress/tests/wp-codebox-core-loader-smoke.js
+++ b/wordpress/tests/wp-codebox-core-loader-smoke.js
@@ -17,34 +17,27 @@ async function main() {
 		fs.writeFileSync(path.join(dist, 'index.js'), 'exports.fixtureExport = () => "legacy-index";\n');
 
 		const candidates = coreModuleCandidates({
-			wpCodeboxInstallDir: root,
 			packageCandidates: [
 				'@automattic/wp-codebox-core/artifacts',
 				'wp-codebox-workspace/artifacts',
 			],
-			packageDistEntries: ['artifacts.js'],
 		});
 
 		assert.equal(candidates[0], '@automattic/wp-codebox-core/artifacts');
 		assert.equal(candidates[1], 'wp-codebox-workspace/artifacts');
-		assert.match(candidates[2], /dist\/artifacts\.js$/);
-		assert.equal(candidates.some((candidate) => /dist\/index\.js$/.test(candidate)), false);
+		assert.equal(candidates.length, 2);
 
 		const result = await loadWpCodeboxCoreExport('fixtureExport', {
-			wpCodeboxInstallDir: root,
-			packageCandidates: [],
-			packageDistEntries: ['artifacts.js'],
+			coreModule: path.join(dist, 'artifacts.js'),
 			required: true,
 		});
 
 		assert.match(result.source, /dist\/artifacts\.js$/);
 		assert.equal(result.value(), 'focused-artifacts');
 
-		fs.rmSync(path.join(dist, 'artifacts.js'));
+		const missingExportPath = path.join(dist, 'missing-artifacts.js');
 		await assert.rejects(() => loadWpCodeboxCoreExport('fixtureExport', {
-			wpCodeboxInstallDir: root,
-			packageCandidates: [],
-			packageDistEntries: ['artifacts.js'],
+			coreModule: missingExportPath,
 			required: true,
 		}), /WP Codebox core export fixtureExport is unavailable/);
 

--- a/wordpress/tests/wp-codebox-task-runner-smoke.js
+++ b/wordpress/tests/wp-codebox-task-runner-smoke.js
@@ -16,6 +16,14 @@ const wpCodeboxTaskRunner = path.join(
   'agent',
   'homeboy-wp-codebox-task-runner.cjs'
 );
+process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE ||= path.join(
+  __dirname,
+  '..',
+  '..',
+  'tests',
+  'fixtures',
+  'wp-codebox-core-runtime-contract.cjs'
+);
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -195,11 +203,6 @@ const agentResult = isRuntimeTask
 fs.writeFileSync(out, JSON.stringify({
   argv: process.argv.slice(2),
   input,
-  codex_env: {
-    access_refreshed: process.env.AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN === 'fresh-access-token-value',
-    refresh_refreshed: process.env.AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN === 'fresh-refresh-token-value',
-    expires_refreshed: Number(process.env.AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT || 0) > Math.floor(Date.now() / 1000),
-  },
 }, null, 2));
 const execution = { recipeCommand: 'wp-codebox.agent-sandbox-run', exitCode: 0, stdout: JSON.stringify({ status: 'completed', output: JSON.stringify(agentResult) }) };
 const executions = [execution];
@@ -725,23 +728,13 @@ try {
       AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '1',
       AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'account-id-value',
       AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
-      HOMEBOY_WP_CODEBOX_CODEX_TOKEN_URL: codexOAuthServer.url,
     },
   });
-  assert.equal(codexResult.status, 0, codexResult.stderr || codexResult.stdout);
-  const codexCapture = readJson(codexCapturePath);
-  const codexInput = codexCapture.input;
-  assert.deepEqual(codexInput.secret_env, codexSecretEnv);
-  assert.equal(codexInput.provider, 'codex');
-  assert.equal(codexInput.model, 'gpt-5.5');
-  assert.equal(codexInput.provider_plugin_paths[0], '/components/ai-provider-for-openai');
-  assert.deepEqual(codexCapture.codex_env, {
-    access_refreshed: true,
-    refresh_refreshed: true,
-    expires_refreshed: true,
-  });
-  assert(!JSON.stringify(codexInput).includes('access-token-value'));
-  assert(!JSON.stringify(codexInput).includes('refresh-token-value'));
+  assert.equal(codexResult.status, 1, codexResult.stderr || codexResult.stdout);
+  assert.match(codexResult.stderr, /Codebox\/provider-owned public credential refresh primitive/);
+  assert(!codexResult.stderr.includes('access-token-value'));
+  assert(!codexResult.stderr.includes('refresh-token-value'));
+  assert(!fs.existsSync(codexCapturePath));
 
   const expiredCodexCapturePath = path.join(root, 'capture-expired-codex.json');
   const expiredCodexResult = spawnSync(process.execPath, [
@@ -795,12 +788,11 @@ try {
       AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT: '1',
       AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID: 'stale-account-id-value',
       AI_PROVIDER_OPENAI_CODEX_FEDRAMP: '0',
-      HOMEBOY_WP_CODEBOX_CODEX_TOKEN_URL: codexOAuthServer.url,
     },
   });
   assert.equal(staleCodexResult.status, 1, staleCodexResult.stderr || staleCodexResult.stdout);
   assert.match(staleCodexResult.stderr, /Codex provider auth preflight failed/);
-  assert.match(staleCodexResult.stderr, /OAuth refresh returned HTTP 401/);
+  assert.match(staleCodexResult.stderr, /Codebox\/provider-owned public credential refresh primitive/);
   assert.match(staleCodexResult.stderr, /Refresh Codex OAuth credentials/);
   assert(!staleCodexResult.stderr.includes('stale-access-token-value'));
   assert(!staleCodexResult.stderr.includes('stale-refresh-token-value'));
@@ -872,7 +864,7 @@ try {
   const preparedLabRuntime = path.join(labRuntimeArtifacts, 'prepared-plugins', 'example-runtime');
   assert.equal(labRuntimeInput.runtime_component_paths.agent_runtime, preparedLabRuntime);
   assert.equal(labRuntimeInput.extra_plugins.some((plugin) => plugin.slug === 'agents-api'), false);
-  assert.equal((labRuntimeInput.component_contracts || []).some((contract) => contract.slug === 'agents-api'), false);
+  assert.equal((labRuntimeInput.component_contracts || []).some((contract) => contract.slug === 'agents-api'), true);
   assert.equal(fs.existsSync(path.join(preparedLabRuntime, 'example-runtime.php')), true);
 
   const runtimeComponentSource = path.join(root, 'runtime-components', 'example-runtime-tools');


### PR DESCRIPTION
## Summary
- Stop discovering WP Codebox runtime contracts by probing source/cache package layouts; require public package exports or an explicit core module path.
- Remove Homeboy-owned Codex OAuth refresh/persistence from the WP Codebox task runner and fail with a clear public-primitive gap when refresh is required.
- Remove hardcoded Codebox substrate plugin filtering and update docs/tests around opaque runtime/provider boundaries.

## Testing
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js
- node wordpress/tests/codebox-agent-task-executor-smoke.js
- node wordpress/tests/wp-codebox-task-runner-smoke.js
- node tests/wp-codebox-runtime-contract-source-smoke.mjs
- node wordpress/tests/wp-codebox-core-loader-smoke.js
- node wordpress/tests/codebox-codex-auth-preflight-smoke.js
- node tests/wp-codebox-adapter-boundary-smoke.mjs
- node tests/wp-codebox-provider-plugin-defaults-smoke.mjs
- node tests/wp-codebox-bundled-agents-api-smoke.mjs
- node tests/wp-codebox-artifact-contract-smoke.mjs

## Blockers / gaps
- WP Codebox/provider needs a public credential-refresh primitive for stale Codex tokens. Homeboy now reports this gap instead of calling OAuth/provider internals.
- Runners that do not expose public WP Codebox package exports must set HOMEBOY_WP_CODEBOX_CORE_MODULE explicitly; Homeboy no longer scans WP Codebox cache/source layouts.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the boundary cleanup, updating docs/tests, and running verification.