### PR TITLE
Stabilize WordPress fuzz preflight

### DIFF
--- a/wordpress/index.js
+++ b/wordpress/index.js
@@ -43,6 +43,7 @@ module.exports = {
 	...require('./lib/wp-codebox-fuzz-run'),
 	...require('./lib/wordpress-workload-profile'),
 	...require('./lib/wordpress-fuzz-manifest'),
+	...require('./lib/wordpress-fuzz-command-manifest'),
 	...require('./lib/wordpress-fuzz-runtime-capabilities'),
 	...require('./lib/wordpress-surface-types'),
 	...require('./lib/wordpress-hook-surface-discovery'),

--- a/wordpress/lib/wordpress-fuzz-campaign.js
+++ b/wordpress/lib/wordpress-fuzz-campaign.js
@@ -39,6 +39,9 @@ function compileWordPressFuzzCampaign(input = {}, options = {}) {
 		...(objectOrUndefined(options.plan) || {}),
 		...(objectOrUndefined(input.plan_options || input.planOptions) || {}),
 	};
+	if (input.mutation_mode || input.mutationMode || options.mutation_mode || options.mutationMode) {
+		planOptions.mutation_mode = input.mutation_mode || input.mutationMode || options.mutation_mode || options.mutationMode;
+	}
 	const plan = buildWordPressFuzzPlanFromSurfaces(discovery, planOptions);
 	const coverageManifest = buildWordPressRuntimeSurfaceCoverageManifest(discovery);
 	const workload = buildWordPressFuzzCampaignWorkload({

--- a/wordpress/lib/wordpress-fuzz-command-manifest.js
+++ b/wordpress/lib/wordpress-fuzz-command-manifest.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const WORDPRESS_FUZZ_COMMAND_MANIFEST_SCHEMA = 'homeboy/wordpress-fuzz-command-manifest/v1';
+
+const WP_CODEBOX_FUZZ_PUBLIC_COMMANDS = Object.freeze([
+	'run-fuzz-suite',
+	'run-wordpress-workload',
+]);
+
+const WP_CODEBOX_FUZZ_PUBLIC_ABILITIES = Object.freeze({
+	runFuzzSuite: 'wp-codebox/run-fuzz-suite',
+	runWorkload: 'wp-codebox/run-wordpress-workload',
+});
+
+const CASE_INTENT_REQUIREMENTS = Object.freeze({
+	default: Object.freeze({ commands: ['run-fuzz-suite'], abilities: ['wp-codebox/run-fuzz-suite'] }),
+	workload: Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'] }),
+	'request-rest-route': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['rest'] }),
+	'request-admin-page': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['admin'] }),
+	'exercise-admin-page-read-only-interaction': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['admin'] }),
+	'plan-admin-page-mutation': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['admin', 'snapshot', 'restore', 'reset'] }),
+	'exercise-ajax-action': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['admin'] }),
+	'render-block': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['browser'] }),
+	'serialize-parse-block': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'] }),
+	'insert-block-in-editor': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['browser'] }),
+	'inspect-database-table': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['database'] }),
+	'profile-database-query': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['database'] }),
+	'mutate-database-table': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['database', 'snapshot', 'transaction', 'reset'] }),
+	'mutate-database-query': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['database', 'snapshot', 'transaction', 'reset'] }),
+	'list-posts': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud'] }),
+	'read-post': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud'] }),
+	'create-post': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud', 'snapshot', 'restore', 'reset'] }),
+	'update-post': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud', 'snapshot', 'restore', 'reset'] }),
+	'delete-post': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud', 'snapshot', 'restore', 'reset'] }),
+	'list-users': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud'] }),
+	'read-user': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud'] }),
+	'create-user': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud', 'snapshot', 'restore', 'reset'] }),
+	'update-user': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud', 'snapshot', 'restore', 'reset'] }),
+	'delete-user': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud', 'snapshot', 'restore', 'reset'] }),
+	'read-option': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud'] }),
+	'create-option': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud', 'snapshot', 'restore', 'reset'] }),
+	'update-option': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud', 'snapshot', 'restore', 'reset'] }),
+	'delete-option': Object.freeze({ commands: ['run-wordpress-workload'], abilities: ['wp-codebox/run-wordpress-workload'], capabilities: ['crud', 'snapshot', 'restore', 'reset'] }),
+});
+
+function buildWordPressFuzzCommandManifest() {
+	return {
+		schema: WORDPRESS_FUZZ_COMMAND_MANIFEST_SCHEMA,
+		wp_codebox: {
+			public_commands: [...WP_CODEBOX_FUZZ_PUBLIC_COMMANDS],
+			abilities: { ...WP_CODEBOX_FUZZ_PUBLIC_ABILITIES },
+		},
+		case_intents: Object.fromEntries(Object.entries(CASE_INTENT_REQUIREMENTS).map(([intent, requirements]) => [intent, cloneRequirements(requirements)])),
+	};
+}
+
+function requiredWpCodeboxContractsForFuzzPlan(plan = {}) {
+	const requirements = [CASE_INTENT_REQUIREMENTS.default];
+	for (const target of arrayOf(plan.targets)) {
+		for (const testCase of arrayOf(target.cases)) {
+			requirements.push(requiredWpCodeboxContractsForFuzzCase(testCase));
+		}
+	}
+	return mergeRequirements(requirements);
+}
+
+function requiredWpCodeboxContractsForFuzzCase(testCase = {}) {
+	const intent = String(testCase.intent || '').trim();
+	return cloneRequirements(CASE_INTENT_REQUIREMENTS[intent] || CASE_INTENT_REQUIREMENTS.workload);
+}
+
+function mergeRequirements(requirements) {
+	return {
+		commands: unique(requirements.flatMap((requirement) => arrayOf(requirement.commands))),
+		abilities: unique(requirements.flatMap((requirement) => arrayOf(requirement.abilities))),
+		capabilities: unique(requirements.flatMap((requirement) => arrayOf(requirement.capabilities))),
+	};
+}
+
+function cloneRequirements(requirements = {}) {
+	return {
+		commands: arrayOf(requirements.commands),
+		abilities: arrayOf(requirements.abilities),
+		capabilities: arrayOf(requirements.capabilities),
+	};
+}
+
+function unique(values) {
+	return [...new Set(values.filter(Boolean))].sort();
+}
+
+function arrayOf(value) {
+	return Array.isArray(value) ? value : [];
+}
+
+module.exports = {
+	WORDPRESS_FUZZ_COMMAND_MANIFEST_SCHEMA,
+	WP_CODEBOX_FUZZ_PUBLIC_ABILITIES,
+	WP_CODEBOX_FUZZ_PUBLIC_COMMANDS,
+	buildWordPressFuzzCommandManifest,
+	requiredWpCodeboxContractsForFuzzCase,
+	requiredWpCodeboxContractsForFuzzPlan,
+};

--- a/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
+++ b/wordpress/lib/wordpress-fuzz-plan-from-surfaces.js
@@ -19,6 +19,7 @@ const {
 } = require('./wordpress-surface-types');
 const {
 	gateWordPressFuzzCaseForRuntimeCapabilities,
+	normalizeWordPressFuzzMutationMode,
 	requiredCapabilitiesForWordPressFuzzCase,
 } = require('./wordpress-fuzz-runtime-capabilities');
 
@@ -26,6 +27,8 @@ const SAFE_REST_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 const DB_MUTATION_REQUIRED_CAPABILITIES = requiredCapabilitiesForWordPressFuzzCase('db_mutation');
 
 function buildWordPressFuzzPlanFromSurfaces(input = {}, options = {}) {
+	const mutationMode = normalizeWordPressFuzzMutationMode(options.mutation_mode || options.mutationMode || input.mutation_mode || input.mutationMode);
+	const targetOptions = mutationMode ? { ...options, mutation_mode: mutationMode } : options;
 	const discovery = normalizeWordPressSurfaceDiscovery({
 		schema: WORDPRESS_SURFACE_DISCOVERY_SCHEMA,
 		id: input.id || input.discovery_id || input.discoveryId || options.discoveryId || 'wordpress-surface-discovery',
@@ -37,11 +40,12 @@ function buildWordPressFuzzPlanFromSurfaces(input = {}, options = {}) {
 		schema: WORDPRESS_FUZZ_PLAN_SCHEMA,
 		id: options.id || input.plan_id || input.planId || `${discovery.id}-fuzz-plan`,
 		discovery_id: discovery.id,
-		targets: discovery.surfaces.map((surface) => targetFromSurface(surface, options)),
+		targets: discovery.surfaces.map((surface) => targetFromSurface(surface, targetOptions)),
 		budget: options.budget || input.budget || {},
 		metadata: {
 			...(input.metadata || {}),
 			planner: 'homeboy/wordpress-fuzz-plan-from-surfaces/v1',
+			mutation_mode: mutationMode || undefined,
 		},
 	});
 }
@@ -210,7 +214,8 @@ function adminPageTargetFromSurface(surface, options = {}) {
 function restRouteCaseFromMethod(surface, method, operationId, surfaceSkipReasons, surfaceDestructiveReasons, options = {}) {
 	const safeMethod = SAFE_REST_METHODS.has(method);
 	const operation = { ...operationForSurface(surface), method };
-	const skipReasons = safeMethod ? surfaceSkipReasons : reasonList([...surfaceSkipReasons, 'mutating_rest_method_requires_explicit_opt_in']);
+	const mutationMode = normalizeWordPressFuzzMutationMode(options.mutation_mode || options.mutationMode);
+	const skipReasons = safeMethod || mutationMode === 'isolated' ? surfaceSkipReasons : reasonList([...surfaceSkipReasons, 'mutating_rest_method_requires_explicit_opt_in']);
 	const destructiveReasons = safeMethod ? surfaceDestructiveReasons : reasonList([...surfaceDestructiveReasons, 'rest_method_mutates_state']);
 	const testCase = {
 		id: `${surface.id}-${method.toLowerCase()}-generic-fuzz`,
@@ -234,6 +239,8 @@ function restRouteCaseFromMethod(surface, method, operationId, surfaceSkipReason
 	}
 	return gateWordPressFuzzCaseForRuntimeCapabilities(testCase, options.runtimeCapabilities || options.runtime_capabilities, {
 		required_capabilities: requiredCapabilitiesForWordPressFuzzCase('mutating_rest'),
+		mutation_mode: mutationMode,
+		mutates: true,
 	});
 }
 
@@ -280,7 +287,8 @@ function genericCaseForSurface(surface, options = {}) {
 
 function crudCaseForSurface(surface, resource, action, options = {}) {
 	const operation = crudOperationForSurface(surface, resource, action);
-	const gateReasons = mutatingCrudAction(action.action) && !allowsCrudMutation(surface, action.action) ? ['crud_mutation_requires_explicit_allow'] : [];
+	const mutationMode = normalizeWordPressFuzzMutationMode(options.mutation_mode || options.mutationMode);
+	const gateReasons = mutatingCrudAction(action.action) && !allowsCrudMutation(surface, action.action) && mutationMode !== 'isolated' ? ['crud_mutation_requires_explicit_allow'] : [];
 	const testCase = {
 		id: `${surface.id}-${action.intent}-crud-fuzz`,
 		intent: action.intent,
@@ -299,6 +307,8 @@ function crudCaseForSurface(surface, resource, action, options = {}) {
 	}
 	return gateWordPressFuzzCaseForRuntimeCapabilities(testCase, options.runtimeCapabilities || options.runtime_capabilities, {
 		required_capabilities: requiredCapabilitiesForWordPressFuzzCase('mutating_crud'),
+		mutation_mode: mutationMode,
+		mutates: true,
 	});
 }
 
@@ -507,7 +517,10 @@ function dbMutationCasesFromSurface(surface, operationId, options = {}) {
 			skip_reasons: [],
 			destructive_reasons: ['db-mutation'],
 			metadata: { surface, mutation },
-		}, options.runtimeCapabilities || options.runtime_capabilities);
+		}, options.runtimeCapabilities || options.runtime_capabilities, {
+			mutation_mode: options.mutation_mode || options.mutationMode,
+			mutates: true,
+		});
 	});
 }
 
@@ -563,7 +576,8 @@ function adminPageInteractionCase(surface, interaction, options = {}) {
 	const skipReasons = reasonList(interaction.skip_reasons || interaction.skipReasons || interaction.skip_reason || interaction.skipReason);
 	const destructiveReasons = reasonList(interaction.destructive_reasons || interaction.destructiveReasons || interaction.destructive_reason || interaction.destructiveReason || safety.reason_codes);
 	const gated = safety.mutates || destructiveReasons.length > 0;
-	if (gated) {
+	const mutationMode = normalizeWordPressFuzzMutationMode(options.mutation_mode || options.mutationMode);
+	if (gated && mutationMode !== 'isolated') {
 		skipReasons.push('requires_explicit_mutation_opt_in');
 	}
 
@@ -590,6 +604,8 @@ function adminPageInteractionCase(surface, interaction, options = {}) {
 	}
 	return gateWordPressFuzzCaseForRuntimeCapabilities(testCase, options.runtimeCapabilities || options.runtime_capabilities, {
 		required_capabilities: requiredCapabilitiesForWordPressFuzzCase('admin_mutation'),
+		mutation_mode: mutationMode,
+		mutates: true,
 	});
 }
 

--- a/wordpress/lib/wordpress-fuzz-runtime-capabilities.js
+++ b/wordpress/lib/wordpress-fuzz-runtime-capabilities.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA = 'homeboy/wordpress-fuzz-runtime-capabilities/v1';
+const WORDPRESS_FUZZ_MUTATION_POLICY_SCHEMA = 'homeboy/wordpress-fuzz-mutation-policy/v1';
+const WORDPRESS_FUZZ_MUTATION_MODES = Object.freeze(['isolated', 'read_only', 'destructive-deny']);
 
 const WORDPRESS_FUZZ_RUNTIME_CAPABILITIES = Object.freeze([
 	'snapshot',
@@ -103,6 +105,11 @@ function capabilityFlag(capabilitySet, section, capability) {
 }
 
 function gateWordPressFuzzCaseForRuntimeCapabilities(testCase, runtimeCapabilities, options = {}) {
+	const policyGated = gateWordPressFuzzCaseForMutationPolicy(testCase, options);
+	if (policyGated) {
+		return policyGated;
+	}
+
 	const required = normalizeRequiredCapabilities(options.required_capabilities || options.requiredCapabilities || testCase.required_capabilities || testCase.requiredCapabilities);
 	if (required.length === 0) {
 		return testCase;
@@ -148,6 +155,50 @@ function gateWordPressFuzzCaseForRuntimeCapabilities(testCase, runtimeCapabiliti
 	};
 }
 
+function gateWordPressFuzzCaseForMutationPolicy(testCase = {}, options = {}) {
+	const mutationMode = normalizeWordPressFuzzMutationMode(options.mutation_mode || options.mutationMode);
+	if (!mutationMode) {
+		return null;
+	}
+
+	const destructiveReasons = reasonList(testCase.destructive_reasons || testCase.destructiveReasons || testCase.destructive_reason || testCase.destructiveReason);
+	const mutates = options.mutates === true || destructiveReasons.length > 0 || testCase.metadata?.safety?.mutates === true;
+	const policy = {
+		schema: WORDPRESS_FUZZ_MUTATION_POLICY_SCHEMA,
+		mode: mutationMode,
+		mutates,
+		destructive_reasons: destructiveReasons,
+	};
+
+	let denyReason = '';
+	if (mutationMode === 'read_only' && mutates) {
+		denyReason = 'mutation-policy-read-only';
+	} else if (mutationMode === 'destructive-deny' && (mutates || destructiveReasons.length > 0)) {
+		denyReason = 'mutation-policy-destructive-deny';
+	}
+
+	if (!denyReason) {
+		return null;
+	}
+
+	const skipReasons = reasonList(testCase.skip_reasons || testCase.skipReasons || testCase.skip_reason || testCase.skipReason);
+	const metadata = isObject(testCase.metadata) ? { ...testCase.metadata } : {};
+	return {
+		...testCase,
+		executable: false,
+		skip_reasons: reasonList([...skipReasons, denyReason]),
+		destructive_reasons: destructiveReasons,
+		metadata: {
+			...metadata,
+			executable: false,
+			planned: true,
+			gated: true,
+			mutation_policy_gated: true,
+			mutation_policy: policy,
+		},
+	};
+}
+
 function requiredCapabilitiesForWordPressFuzzCase(kind) {
 	return [...(WORDPRESS_FUZZ_RUNTIME_CAPABILITY_REQUIREMENTS[kind] || [])];
 }
@@ -156,6 +207,13 @@ function normalizeRequiredCapabilities(value) {
 	return [...new Set((Array.isArray(value) ? value : [value])
 		.map(normalizeWordPressFuzzRuntimeCapability)
 		.filter(Boolean))].sort();
+}
+
+function normalizeWordPressFuzzMutationMode(value) {
+	const mode = String(value || '').trim().toLowerCase().replace(/-/g, '_') === 'read_only'
+		? 'read_only'
+		: String(value || '').trim().toLowerCase().replace(/_/g, '-');
+	return WORDPRESS_FUZZ_MUTATION_MODES.includes(mode) ? mode : '';
 }
 
 function reasonList(value) {
@@ -170,10 +228,14 @@ function isObject(value) {
 }
 
 module.exports = {
+	WORDPRESS_FUZZ_MUTATION_MODES,
+	WORDPRESS_FUZZ_MUTATION_POLICY_SCHEMA,
 	WORDPRESS_FUZZ_RUNTIME_CAPABILITIES,
 	WORDPRESS_FUZZ_RUNTIME_CAPABILITY_REQUIREMENTS,
 	WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA,
+	gateWordPressFuzzCaseForMutationPolicy,
 	gateWordPressFuzzCaseForRuntimeCapabilities,
+	normalizeWordPressFuzzMutationMode,
 	normalizeWordPressFuzzRuntimeCapabilities,
 	normalizeWordPressFuzzRuntimeCapability,
 	requiredCapabilitiesForWordPressFuzzCase,

--- a/wordpress/lib/wordpress-runtime-surface-discovery.js
+++ b/wordpress/lib/wordpress-runtime-surface-discovery.js
@@ -6,16 +6,34 @@
 const { isPlainObject } = require('./shared');
 const {
 	WORDPRESS_RUNTIME_SURFACE_ID_PREFIXES,
+	normalizeWordPressCoverageSurfaceType,
 	normalizeWordPressRuntimeSurfaceType,
+	normalizeWordPressSurfaceType,
 } = require('./wordpress-surface-types');
 
 const WORDPRESS_RUNTIME_SURFACE_DISCOVERY_SCHEMA = 'homeboy/wordpress-surface-discovery/v1';
 const WORDPRESS_RUNTIME_SURFACE_COVERAGE_MANIFEST_SCHEMA = 'homeboy/wordpress-fuzz-coverage-manifest/v1';
+const WORDPRESS_UNSUPPORTED_RUNTIME_DISCOVERY_TYPES = new Set([
+	'capability',
+	'cron_event',
+	'crud_resource',
+	'db_query',
+	'external_http',
+	'hook',
+	'media',
+	'option',
+	'post_type',
+	'role',
+	'setting',
+	'taxonomy',
+	'user',
+	'wp_cli_command',
+]);
 
 function normalizeWordPressRuntimeSurfaceDiscovery(input = {}, options = {}) {
-	const surfaces = collectRuntimeSurfaceInputs(input, options)
-		.map((surface, index) => normalizeRuntimeSurface(surface, index))
-		.filter(Boolean);
+	const inputs = collectRuntimeSurfaceInputs(input, options);
+	const surfaces = inputs.map((surface, index) => normalizeRuntimeSurface(surface, index)).filter(Boolean);
+	const unsupportedSurfaces = inputs.map((surface, index) => normalizeUnsupportedSurface(surface, index)).filter(Boolean);
 
 	return {
 		schema: WORDPRESS_RUNTIME_SURFACE_DISCOVERY_SCHEMA,
@@ -24,6 +42,13 @@ function normalizeWordPressRuntimeSurfaceDiscovery(input = {}, options = {}) {
 		generated_at: input.generated_at || input.generatedAt || options.generated_at || options.generatedAt || null,
 		source: stringValue(input.source || options.source, 'wordpress-runtime'),
 		surfaces: dedupeRuntimeSurfaces(surfaces),
+		unsupported_surfaces: dedupeUnsupportedSurfaces(unsupportedSurfaces),
+		diagnostics: unsupportedSurfaces.map((surface) => ({
+			severity: 'info',
+			code: 'wordpress_surface_discovered_without_executable_runtime_collector',
+			message: `${surface.type} surface \`${surface.id}\` was discovered for diagnostics but is not counted as executable runtime coverage.`,
+			surface,
+		})),
 		metadata: isPlainObject(input.metadata) ? input.metadata : {},
 	};
 }
@@ -116,8 +141,19 @@ function appendArtifactSurfaces(surfaces, artifact) {
 	appendArraySurfaces(surfaces, artifact.admin || artifact.adminPages || artifact.admin_pages, 'admin_page', 'admin');
 	appendArraySurfaces(surfaces, artifact.ajax || artifact.actions || artifact.ajaxActions || artifact.ajax_actions, 'ajax_action', 'ajax');
 	appendArraySurfaces(surfaces, artifact.database || artifact.db || artifact.tables || artifact.databaseTables || artifact.database_tables, 'db_table', 'db');
+	appendArraySurfaces(surfaces, artifact.dbQueries || artifact.db_queries || artifact.queries || artifact.querySamples || artifact.query_samples, 'db_query', 'db-query');
 	appendArraySurfaces(surfaces, artifact.frontend || artifact.frontendUrls || artifact.frontend_urls || artifact.urls, 'frontend_url', 'frontend');
 	appendArraySurfaces(surfaces, artifact.blocks || artifact.blockTypes || artifact.block_types, 'block', 'blocks');
+	appendArraySurfaces(surfaces, artifact.hooks || artifact.hookCallbacks || artifact.hook_callbacks, 'hook', 'hooks');
+	appendArraySurfaces(surfaces, artifact.cron || artifact.cronEvents || artifact.cron_events, 'cron_event', 'cron');
+	appendArraySurfaces(surfaces, artifact.options, 'option', 'options');
+	appendArraySurfaces(surfaces, artifact.settings, 'setting', 'settings');
+	appendArraySurfaces(surfaces, artifact.roles, 'role', 'roles');
+	appendArraySurfaces(surfaces, artifact.capabilities || artifact.caps, 'capability', 'capabilities');
+	appendArraySurfaces(surfaces, artifact.users, 'user', 'users');
+	appendArraySurfaces(surfaces, artifact.media || artifact.attachments, 'media', 'media');
+	appendArraySurfaces(surfaces, artifact.postTypes || artifact.post_types, 'post_type', 'post-types');
+	appendArraySurfaces(surfaces, artifact.taxonomies, 'taxonomy', 'taxonomies');
 }
 
 function appendFuzzSurfaceArtifact(surfaces, artifact) {
@@ -169,6 +205,35 @@ function normalizeRuntimeSurface(surface, index) {
 	};
 }
 
+function normalizeUnsupportedSurface(surface, index) {
+	if (!isPlainObject(surface)) {
+		return null;
+	}
+	const runtimeType = normalizeRuntimeSurfaceType(surface.type || surface.kind || surface.category);
+	if (runtimeType) {
+		return null;
+	}
+	const coverageType = normalizeWordPressCoverageSurfaceType(surface.type || surface.kind || surface.category);
+	const canonicalType = normalizeWordPressSurfaceType(surface.type || surface.kind || surface.category) || coverageType.replace(/_/g, '-');
+	if (!coverageType || !WORDPRESS_UNSUPPORTED_RUNTIME_DISCOVERY_TYPES.has(coverageType)) {
+		return null;
+	}
+	const value = runtimeSurfaceValue(surface, coverageType, index);
+	return {
+		id: runtimeSurfaceId(surface, coverageType, value),
+		type: coverageType,
+		canonical_type: canonicalType,
+		label: stringValue(surface.label || surface.title || surface.name || surface.path || surface.url || surface.route || surface.action || surface.hook || surface.option || surface.setting || surface.role || surface.capability || surface.table || surface.value, value),
+		executable: false,
+		coverage_counted: false,
+		metadata: {
+			...(isPlainObject(surface.metadata) ? surface.metadata : {}),
+			source: stringValue(surface.source || surface.artifact, 'input'),
+			value,
+		},
+	};
+}
+
 function normalizeRuntimeSurfaceType(value) {
 	return normalizeWordPressRuntimeSurfaceType(value);
 }
@@ -181,6 +246,15 @@ function runtimeSurfaceValue(surface, type, index) {
 		|| surface.path
 		|| surface.url
 		|| surface.action
+		|| surface.hook
+		|| surface.event
+		|| surface.option
+		|| surface.setting
+		|| surface.role
+		|| surface.capability
+		|| surface.user
+		|| surface.media
+		|| surface.query
 		|| surface.table
 		|| surface.name
 		|| surface.block
@@ -202,7 +276,7 @@ function runtimeSurfaceId(surface, type, value) {
 	if (explicitId.startsWith(`${prefix}:`)) {
 		return explicitId;
 	}
-	return `${prefix}:${value}`;
+	return `${prefix || type}:${value}`;
 }
 
 function dedupeRuntimeSurfaces(surfaces) {
@@ -216,6 +290,26 @@ function dedupeRuntimeSurfaces(surfaces) {
 		byId.set(surface.id, {
 			...existing,
 			required: existing.required !== false || surface.required !== false,
+			metadata: {
+				...existing.metadata,
+				...surface.metadata,
+				sources: [...new Set([existing.metadata?.source, surface.metadata?.source, ...(existing.metadata?.sources || []), ...(surface.metadata?.sources || [])].filter(Boolean))].sort(),
+			},
+		});
+	}
+	return [...byId.values()].sort((a, b) => a.type.localeCompare(b.type) || a.id.localeCompare(b.id));
+}
+
+function dedupeUnsupportedSurfaces(surfaces) {
+	const byId = new Map();
+	for (const surface of surfaces) {
+		const existing = byId.get(surface.id);
+		if (!existing) {
+			byId.set(surface.id, surface);
+			continue;
+		}
+		byId.set(surface.id, {
+			...existing,
 			metadata: {
 				...existing.metadata,
 				...surface.metadata,

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -29,15 +29,22 @@ const {
 	homeboySettings,
 	wpCodeboxCommand,
 } = require('./wp-codebox-recipe-helper');
+const {
+	WP_CODEBOX_FUZZ_PUBLIC_ABILITIES,
+	WP_CODEBOX_FUZZ_PUBLIC_COMMANDS,
+	buildWordPressFuzzCommandManifest,
+	requiredWpCodeboxContractsForFuzzPlan,
+} = require('./wordpress-fuzz-command-manifest');
 
 const WP_CODEBOX_FUZZ_SUITE_SCHEMA = 'wp-codebox/fuzz-suite/v1';
 const WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA = 'wp-codebox/fuzz-suite-result/v1';
 const WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA = 'homeboy/wordpress-codebox-fuzz-suite-consumer/v1';
+const WP_CODEBOX_FUZZ_PREFLIGHT_SCHEMA = 'homeboy/wp-codebox-fuzz-preflight/v1';
 const DEFAULT_FUZZ_SUITE_ABILITY = 'wp-codebox/run-fuzz-suite';
 const DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY = 'wp-codebox/run-wordpress-workload';
 const DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA = 'wp-codebox/wordpress-workload-run/v1';
 const DEFAULT_WP_CODEBOX_PUBLIC_CLI_BIN = 'wp';
-const WP_CODEBOX_PUBLIC_CLI_COMMANDS = ['run-fuzz-suite', 'run-wordpress-workload'];
+const WP_CODEBOX_PUBLIC_CLI_COMMANDS = WP_CODEBOX_FUZZ_PUBLIC_COMMANDS;
 const ARTIFACT_POSTPROCESS_COMMAND = 'homeboy.artifact-postprocess';
 const ARTIFACT_POSTPROCESS_COMMAND_ALIASES = new Set([ARTIFACT_POSTPROCESS_COMMAND, 'artifact-postprocess', 'homeboy.artifact_postprocess']);
 const DEFAULT_FUZZ_SUITE_EXPECTED_ARTIFACTS = [
@@ -348,12 +355,12 @@ function homeboyFuzzWorkloadCasePhases(entry = {}, manifest = {}, intent = {}, a
 	}
 	const execute = objectOrUndefined(intent.execute) || {};
 	const activation = intent.plugin?.activation;
-	const path = execute.path || manifest.workload?.path;
+	const workloadPath = execute.path || manifest.workload?.path;
 	const genericCommand = homeboyFuzzWorkloadGenericPrimitiveCommand(manifest);
 	const setup = typeof activation === 'string' && activation.trim() !== ''
 		? [{ command: 'wordpress.ensure-plugin-active', args: [`plugin=${activation}`] }]
 		: undefined;
-	const action = homeboyFuzzWorkloadCaseAction({ genericCommand, path, execute });
+	const action = homeboyFuzzWorkloadCaseAction({ genericCommand, workloadPath, execute });
 	const collect = normalizeArray(intent.collect).length > 0 ? normalizeArray(intent.collect) : artifacts.map((artifact) => ({ artifact: artifact.name }));
 	const assert = collect
 		.map((item) => item?.artifact)
@@ -362,12 +369,12 @@ function homeboyFuzzWorkloadCasePhases(entry = {}, manifest = {}, intent = {}, a
 	return stripUndefined({ setup, action, assert: assert.length > 0 ? assert : undefined });
 }
 
-function homeboyFuzzWorkloadCaseAction({ genericCommand, path, execute = {} } = {}) {
+function homeboyFuzzWorkloadCaseAction({ genericCommand, workloadPath, execute = {} } = {}) {
 	if (typeof genericCommand === 'string') {
 		return [{ command: genericCommand, args: homeboyFuzzCommandArgs(objectOrUndefined(execute.parameters) || {}) }];
 	}
-	if (typeof path === 'string' && path.trim() !== '') {
-		return [{ command: 'wordpress.run-workload', args: [`path=${path}`] }];
+	if (typeof workloadPath === 'string' && workloadPath.trim() !== '') {
+		return [{ command: 'wordpress.run-workload', args: [`path=${workloadPath}`] }];
 	}
 	return [];
 }
@@ -508,10 +515,14 @@ async function runWpCodeboxFuzzSuite(options = {}) {
 
 async function runWpCodeboxPublicFuzzOperation(options = {}) {
 	const request = options.request || wpCodeboxFuzzSuiteTaskRequest(options);
-	const capabilities = detectWpCodeboxPublicFuzzCapabilities(options);
+	const preflight = preflightWpCodeboxFuzzCapabilityContract({ ...options, request });
+	const capabilities = preflight.capabilities;
+	if (!preflight.ok) {
+		return unsupportedWpCodeboxPublicFuzzResult({ request, capabilities, preflight });
+	}
 	const command = publicFuzzCliCommandForRequest(request, capabilities);
 	if (!command) {
-		return unsupportedWpCodeboxPublicFuzzResult({ request, capabilities });
+		return unsupportedWpCodeboxPublicFuzzResult({ request, capabilities, preflight });
 	}
 
 	const cliResult = await runWpCodeboxPublicCli(command, wpCodeboxPublicCliInput(request, options), options);
@@ -560,6 +571,77 @@ function detectWpCodeboxPublicFuzzCapabilities(options = {}) {
 	return normalizeWpCodeboxPublicFuzzCapabilities({ commands });
 }
 
+function preflightWpCodeboxFuzzCapabilityContract(options = {}) {
+	const request = options.request || options.taskRequest || options.task_request || null;
+	const capabilities = detectWpCodeboxPublicFuzzCapabilities(options);
+	const manifest = wpCodeboxRuntimeContractManifest(options);
+	const wordpressRuntimeAbilities = objectOrUndefined(manifest.abilities?.wordpressRuntime) || {};
+	const commandManifest = buildWordPressFuzzCommandManifest();
+	const suiteInput = request?.executor?.config?.runtime_task?.input || request?.input || {};
+	const plan = suiteInput.homeboy_fuzz_workload?.plan || suiteInput.homeboyFuzzWorkload?.plan || suiteInput.metadata?.workload?.plan || request?.input?.plan || options.plan || {};
+	const requiredPlanContracts = requiredWpCodeboxContractsForFuzzPlan(plan);
+	const requiredAbilities = { ...WP_CODEBOX_FUZZ_PUBLIC_ABILITIES };
+	const requiredCommands = requiredPublicCommandsForRequest(request, requiredPlanContracts);
+	const missingContracts = [];
+
+	for (const command of requiredCommands) {
+		if (capabilities.commands?.[command] !== true) {
+			missingContracts.push({
+				type: 'public_cli_command',
+				command,
+				message: `WP Codebox public CLI must expose \`${command}\` before Homeboy dispatches WordPress fuzz workloads.`,
+			});
+		}
+	}
+
+	if (wordpressRuntimeAbilities.runFuzzSuite !== requiredAbilities.runFuzzSuite) {
+		missingContracts.push({
+			type: 'ability',
+			ability: requiredAbilities.runFuzzSuite,
+			message: `WP Codebox runtime contract must declare \`${requiredAbilities.runFuzzSuite}\` for fuzz-suite dispatch.`,
+		});
+	}
+	if (wordpressRuntimeAbilities.runWorkload !== requiredAbilities.runWorkload) {
+		missingContracts.push({
+			type: 'ability',
+			ability: requiredAbilities.runWorkload,
+			message: `WP Codebox runtime contract must declare \`${requiredAbilities.runWorkload}\` for WordPress workload dispatch.`,
+		});
+	}
+
+	return {
+		schema: WP_CODEBOX_FUZZ_PREFLIGHT_SCHEMA,
+		ok: missingContracts.length === 0,
+		status: missingContracts.length === 0 ? 'passed' : 'failed',
+		request_id: request?.task_id,
+		capabilities,
+		required: {
+			commands: requiredCommands,
+			abilities: requiredAbilities,
+			capabilities: requiredPlanContracts.capabilities,
+		},
+		command_manifest: commandManifest,
+		missing_contracts: missingContracts,
+		diagnostics: missingContracts.map((contract) => ({
+			severity: 'error',
+			code: `wp_codebox_fuzz_missing_${contract.type}`,
+			message: contract.message,
+			contract,
+		})),
+	};
+}
+
+function requiredPublicCommandsForRequest(request = {}, requiredPlanContracts = {}) {
+	const ability = request.executor?.config?.runtime_task?.ability || request.ability;
+	if (ability === DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY) {
+		return ['run-wordpress-workload'];
+	}
+	if (ability === DEFAULT_FUZZ_SUITE_ABILITY) {
+		return ['run-fuzz-suite'];
+	}
+	return requiredPlanContracts.commands?.length > 0 ? requiredPlanContracts.commands : [...WP_CODEBOX_PUBLIC_CLI_COMMANDS];
+}
+
 function normalizeWpCodeboxPublicFuzzCapabilities(input = {}) {
 	const commands = objectOrUndefined(input.commands) || input;
 	return {
@@ -582,18 +664,19 @@ function publicFuzzCliCommandForRequest(request = {}, capabilities = {}) {
 	return undefined;
 }
 
-function unsupportedWpCodeboxPublicFuzzResult({ request = {}, capabilities = {} } = {}) {
+function unsupportedWpCodeboxPublicFuzzResult({ request = {}, capabilities = {}, preflight } = {}) {
+	const diagnostics = preflight?.diagnostics?.length > 0 ? preflight.diagnostics : [{
+		severity: 'warning',
+		code: 'wp_codebox_public_fuzz_cli_unsupported',
+		message: 'WP Codebox public fuzz execution is unavailable: neither `wp codebox run-fuzz-suite` nor `wp codebox run-wordpress-workload` is exposed by this runtime.',
+		capabilities,
+	}];
 	return {
 		schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
 		request_id: request.task_id,
 		status: 'skipped',
-		metadata: { readiness: { level: 'declared' }, unsupported: true },
-		diagnostics: [{
-			severity: 'warning',
-			code: 'wp_codebox_public_fuzz_cli_unsupported',
-			message: 'WP Codebox public fuzz execution is unavailable: neither `wp codebox run-fuzz-suite` nor `wp codebox run-wordpress-workload` is exposed by this runtime.',
-			capabilities,
-		}],
+		metadata: { readiness: { level: 'declared' }, unsupported: true, preflight },
+		diagnostics,
 	};
 }
 
@@ -1267,12 +1350,15 @@ module.exports = {
 	ARTIFACT_POSTPROCESS_COMMAND,
 	FUZZ_ARTIFACT_SEMANTIC_KEYS,
 	WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA,
+	WP_CODEBOX_FUZZ_PREFLIGHT_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
+	buildWordPressFuzzCommandManifest,
 	normalizeWpCodeboxFuzzArtifacts,
 	normalizeWpCodeboxFuzzSuiteResult,
 	normalizeWordPressFuzzRuntimeTaskResult,
 	detectWpCodeboxPublicFuzzCapabilities,
+	preflightWpCodeboxFuzzCapabilityContract,
 	runWpCodeboxFuzzSuite,
 	runWpCodeboxPublicFuzzOperation,
 	wpCodeboxFuzzSuiteAbility,

--- a/wordpress/package.json
+++ b/wordpress/package.json
@@ -41,6 +41,7 @@
     "./wp-codebox-artifacts": "./lib/wp-codebox-artifacts.js",
     "./wordpress-workload-profile": "./lib/wordpress-workload-profile.js",
     "./wordpress-fuzz-manifest": "./lib/wordpress-fuzz-manifest.js",
+    "./wordpress-fuzz-command-manifest": "./lib/wordpress-fuzz-command-manifest.js",
     "./wordpress-surface-types": "./lib/wordpress-surface-types.js",
     "./wordpress-fuzz-schemas": "./lib/wordpress-fuzz-schemas.js",
     "./wordpress-generic-fuzz-primitives": "./lib/wordpress-generic-fuzz-primitives.js",

--- a/wordpress/tests/wordpress-fuzz-campaign-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-campaign-smoke.js
@@ -77,4 +77,15 @@ assert.equal(aggregate.coverage.schema, 'homeboy/wordpress-fuzz-coverage-aggrega
 assert.equal(aggregate.performance.schema, 'homeboy/wordpress-performance-observation/v1');
 assert.equal(aggregate.gaps.schema, WORDPRESS_FUZZ_PLAN_RESULT_GAP_REPORT_SCHEMA);
 
+const readOnlyCampaign = compileWordPressFuzzCampaign({
+	id: 'read-only-campaign',
+	mutation_mode: 'read_only',
+	surfaces: [
+		{ id: 'rest:campaign', type: 'rest_route', route: '/wp/v2/posts', method: 'GET' },
+	],
+}, {
+	plan: { runtimeCapabilities: { capabilities: ['crud', 'snapshot', 'restore', 'reset'] } },
+});
+assert.equal(readOnlyCampaign.plan.metadata.mutation_mode, 'read_only');
+
 console.log('wordpress fuzz campaign smoke passed');

--- a/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-plan-from-surfaces-smoke.js
@@ -113,8 +113,18 @@ const runtimeDiscovery = normalizeWordPressRuntimeSurfaceDiscovery({
 		{ type: 'admin_page', path: '/wp-admin/tools.php' },
 		{ type: 'ajax_action', action: 'heartbeat' },
 		{ type: 'db_table', table: 'wp_posts' },
+		{ type: 'hook', hook: 'init' },
+		{ type: 'cron_event', event: 'wp_version_check' },
+		{ type: 'option', option: 'blogname' },
+		{ type: 'role', role: 'editor' },
+		{ type: 'media', name: 'attachment' },
+		{ type: 'db_query', query: 'SELECT ID FROM wp_posts' },
 	],
 });
+assert.deepEqual(runtimeDiscovery.surfaces.map((surface) => surface.type), ['admin_page', 'ajax_action', 'db_table', 'rest_route']);
+assert.deepEqual(runtimeDiscovery.unsupported_surfaces.map((surface) => surface.type), ['cron_event', 'db_query', 'hook', 'media', 'option', 'role']);
+assert.equal(runtimeDiscovery.unsupported_surfaces.every((surface) => surface.executable === false && surface.coverage_counted === false), true);
+assert.equal(runtimeDiscovery.diagnostics.every((diagnostic) => diagnostic.code === 'wordpress_surface_discovered_without_executable_runtime_collector'), true);
 const runtimePlan = buildWordPressFuzzPlanFromSurfaces(runtimeDiscovery);
 assert.deepEqual(runtimePlan.targets.map((target) => target.type), ['admin-page', 'ajax-action', 'database-table', 'rest-route']);
 assert.equal(runtimePlan.targets.find((target) => target.type === 'ajax-action').cases[0].intent, 'exercise-ajax-action');
@@ -258,5 +268,38 @@ const capableAdminMutation = capableCases.find((entry) => entry.intent === 'plan
 assert.equal(capableAdminMutation.executable, false);
 assert.equal(capableAdminMutation.metadata.runtime_capability_gated, false);
 assert.deepEqual(capableAdminMutation.skip_reasons, ['requires_explicit_mutation_opt_in']);
+
+const isolatedMutationPlan = buildWordPressFuzzPlanFromSurfaces({
+	post_types: [{ id: 'post:isolated', post_type: 'post' }],
+	admin: [{ id: 'admin:isolated', forms: [{ id: 'submit', method: 'POST' }] }],
+	rest: [{ id: 'rest:isolated', route: '/wp/v2/posts', methods: ['POST'] }],
+}, {
+	mutation_mode: 'isolated',
+	runtimeCapabilities: {
+		capabilities: ['crud', 'rest', 'admin', 'snapshot', 'restore', 'reset'],
+	},
+});
+assert.equal(isolatedMutationPlan.metadata.mutation_mode, 'isolated');
+const isolatedCases = isolatedMutationPlan.targets.flatMap((target) => target.cases);
+for (const intent of ['create-post', 'request-rest-route', 'plan-admin-page-mutation']) {
+	const testCase = isolatedCases.find((entry) => entry.intent === intent);
+	assert.equal(testCase.executable, true, `${intent} should execute in isolated mode with runtime capabilities`);
+	assert.deepEqual(testCase.skip_reasons, []);
+	assert.equal(testCase.metadata.runtime_capability_gated, false);
+}
+
+const readOnlyMutationPlan = buildWordPressFuzzPlanFromSurfaces({
+	post_types: [{ id: 'post:read-only', post_type: 'post', allowCrudMutations: true }],
+}, {
+	mutation_mode: 'read_only',
+	runtimeCapabilities: {
+		capabilities: ['crud', 'snapshot', 'restore', 'reset'],
+	},
+});
+const readOnlyCreate = readOnlyMutationPlan.targets[0].cases.find((entry) => entry.intent === 'create-post');
+assert.equal(readOnlyCreate.executable, false);
+assert.equal(readOnlyCreate.metadata.mutation_policy_gated, true);
+assert.equal(readOnlyCreate.metadata.mutation_policy.mode, 'read_only');
+assert.deepEqual(readOnlyCreate.skip_reasons, ['mutation-policy-read-only']);
 
 console.log('WordPress fuzz plan from surfaces smoke passed.');

--- a/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
+++ b/wordpress/tests/wordpress-fuzz-runner-codebox-contract-canary.js
@@ -60,8 +60,8 @@ if (command === 'run-fuzz-suite' && process.argv.includes('--help')) {
 	process.exit(0);
 }
 if (command === 'run-wordpress-workload' && process.argv.includes('--help')) {
-	process.stderr.write('unknown command');
-	process.exit(1);
+	process.stdout.write('usage: wp-codebox run-wordpress-workload');
+	process.exit(0);
 }
 if (command !== 'run-fuzz-suite' || inputFileIndex < 0 || !process.argv.includes('--format=json')) {
 	process.stderr.write('expected public run-fuzz-suite --input-file <file> --format=json invocation');

--- a/wordpress/tests/wordpress-fuzz-runtime-capabilities-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runtime-capabilities-smoke.js
@@ -3,8 +3,11 @@
 const assert = require('node:assert/strict');
 
 const {
+	WORDPRESS_FUZZ_MUTATION_POLICY_SCHEMA,
 	WORDPRESS_FUZZ_RUNTIME_CAPABILITY_SCHEMA,
+	gateWordPressFuzzCaseForMutationPolicy,
 	gateWordPressFuzzCaseForRuntimeCapabilities,
+	normalizeWordPressFuzzMutationMode,
 	normalizeWordPressFuzzRuntimeCapabilities,
 	normalizeWordPressFuzzRuntimeCapability,
 	requiredCapabilitiesForWordPressFuzzCase,
@@ -13,6 +16,8 @@ const {
 assert.equal(normalizeWordPressFuzzRuntimeCapability('db-transaction'), 'transaction');
 assert.equal(normalizeWordPressFuzzRuntimeCapability('database_reset'), 'reset');
 assert.equal(normalizeWordPressFuzzRuntimeCapability('unknown'), '');
+assert.equal(normalizeWordPressFuzzMutationMode('destructive_deny'), 'destructive-deny');
+assert.equal(normalizeWordPressFuzzMutationMode('read-only'), 'read_only');
 
 const contract = normalizeWordPressFuzzRuntimeCapabilities({
 	capabilities: ['snapshots', 'rollback', 'reset-db', 'crud-execution'],
@@ -49,5 +54,29 @@ assert.equal(executable.executable, true);
 assert.equal(executable.metadata.executable, true);
 assert.equal(executable.metadata.gated, false);
 assert.equal(executable.metadata.runtime_capability_gated, false);
+
+const policyDenied = gateWordPressFuzzCaseForMutationPolicy({
+	id: 'case-3',
+	destructive_reasons: ['rest_method_mutates_state'],
+	metadata: { planned: true },
+}, { mutation_mode: 'read_only' });
+assert.equal(policyDenied.executable, false);
+assert.equal(policyDenied.metadata.mutation_policy.schema, WORDPRESS_FUZZ_MUTATION_POLICY_SCHEMA);
+assert.equal(policyDenied.metadata.mutation_policy.mode, 'read_only');
+assert.deepEqual(policyDenied.skip_reasons, ['mutation-policy-read-only']);
+
+const capabilityAndPolicyDenied = gateWordPressFuzzCaseForRuntimeCapabilities({
+	id: 'case-4',
+	destructive_reasons: ['db-mutation'],
+	metadata: {},
+}, { capabilities: ['database', 'snapshot', 'transaction', 'reset'] }, {
+	required_capabilities: ['database', 'snapshot', 'transaction', 'reset'],
+	mutation_mode: 'destructive-deny',
+	mutates: true,
+});
+assert.equal(capabilityAndPolicyDenied.executable, false);
+assert.equal(capabilityAndPolicyDenied.metadata.runtime_capability_gated, undefined);
+assert.equal(capabilityAndPolicyDenied.metadata.mutation_policy_gated, true);
+assert.deepEqual(capabilityAndPolicyDenied.skip_reasons, ['mutation-policy-destructive-deny']);
 
 console.log('WordPress fuzz runtime capabilities smoke passed.');

--- a/wordpress/tests/wordpress-fuzz-runtime-task.test.js
+++ b/wordpress/tests/wordpress-fuzz-runtime-task.test.js
@@ -83,7 +83,8 @@ Promise.all([
 		assert.equal(summary.runtime_task_result.schema, 'homeboy/fuzz-runtime-task-result/v1');
 		assert.equal(summary.runtime_task_result.provider.id, 'wp-codebox');
 		assert.equal(summary.runtime_task_result.status, 'skipped');
-		assert.equal(summary.failures[0].code, 'wp_codebox_public_fuzz_cli_unsupported');
+		assert.equal(summary.failures[0].code, 'wp_codebox_fuzz_missing_public_cli_command');
+		assert.equal(summary.metadata.preflight.required.commands[0], 'run-fuzz-suite');
 	}),
 
 	runWpCodeboxFuzzSuite({

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -11,8 +11,10 @@ const {
 	DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA,
 	ARTIFACT_POSTPROCESS_COMMAND,
 	WORDPRESS_CODEBOX_FUZZ_SUITE_CONSUMER_SCHEMA,
+	WP_CODEBOX_FUZZ_PREFLIGHT_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
 	WP_CODEBOX_FUZZ_SUITE_SCHEMA,
+	buildWordPressFuzzCommandManifest,
 	wpCodeboxFuzzSuiteAbility,
 	wpCodeboxFuzzSuiteSchema,
 	wpCodeboxWordPressWorkloadRunAbility,
@@ -20,6 +22,7 @@ const {
 	wpCodeboxWordPressWorkloadRunSchema,
 	normalizeWpCodeboxFuzzSuiteResult,
 	detectWpCodeboxPublicFuzzCapabilities,
+	preflightWpCodeboxFuzzCapabilityContract,
 	runWpCodeboxFuzzSuite,
 	wpCodeboxFuzzSuiteInput,
 	wpCodeboxFuzzSuiteTaskRequest,
@@ -129,6 +132,37 @@ assert.deepEqual(
 );
 assert(!JSON.stringify(taskRequest).includes('woocommerce'), 'fuzz suite helper must stay product-agnostic');
 assert.equal(wpCodeboxFuzzSuiteTaskRequest({ taskId: 'suite-task' }).executor.config.runtime_task.input.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+
+const preflightMissingCommand = preflightWpCodeboxFuzzCapabilityContract({
+	request: taskRequest,
+	runtimeContractManifest: manifest,
+	publicCliCapabilities: { commands: { 'run-wordpress-workload': true } },
+});
+assert.equal(preflightMissingCommand.schema, WP_CODEBOX_FUZZ_PREFLIGHT_SCHEMA);
+assert.equal(preflightMissingCommand.ok, false);
+assert.deepEqual(preflightMissingCommand.missing_contracts.map((contract) => contract.command).filter(Boolean), ['run-fuzz-suite']);
+assert.equal(preflightMissingCommand.diagnostics[0].code, 'wp_codebox_fuzz_missing_public_cli_command');
+assert.equal(preflightMissingCommand.command_manifest.schema, 'homeboy/wordpress-fuzz-command-manifest/v1');
+assert.deepEqual(preflightMissingCommand.command_manifest.case_intents['request-rest-route'].commands, ['run-wordpress-workload']);
+
+const commandManifest = buildWordPressFuzzCommandManifest();
+assert.deepEqual(commandManifest.wp_codebox.public_commands, ['run-fuzz-suite', 'run-wordpress-workload']);
+assert.equal(commandManifest.wp_codebox.abilities.runWorkload, DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY);
+
+const preflightMissingAbility = preflightWpCodeboxFuzzCapabilityContract({
+	request: taskRequest,
+	runtimeContractManifest: { schema: manifest.schema, abilities: { wordpressRuntime: { runFuzzSuite: DEFAULT_FUZZ_SUITE_ABILITY } } },
+	publicCliCapabilities: { commands: { 'run-fuzz-suite': true, 'run-wordpress-workload': true } },
+});
+assert.equal(preflightMissingAbility.ok, false);
+assert.equal(preflightMissingAbility.missing_contracts.some((contract) => contract.ability === DEFAULT_WORDPRESS_WORKLOAD_RUN_ABILITY), true);
+
+const preflightPassed = preflightWpCodeboxFuzzCapabilityContract({
+	request: taskRequest,
+	runtimeContractManifest: manifest,
+	publicCliCapabilities: { commands: { 'run-fuzz-suite': true, 'run-wordpress-workload': true } },
+});
+assert.equal(preflightPassed.ok, true);
 
 const jsonWorkloadManifest = {
 	schema: 'homeboy/fuzz-workload/v1',
@@ -500,7 +534,7 @@ runWpCodeboxFuzzSuite({
 				return { status: 0, stdout: 'usage' };
 			}
 			if (args.join(' ') === 'run-wordpress-workload --help') {
-				return { status: 1, stderr: 'unknown command' };
+				return { status: 0, stdout: 'usage' };
 			}
 			assert.equal(args[0], 'run-fuzz-suite');
 			assert.equal(args[1], '--input-file');
@@ -540,7 +574,7 @@ runWpCodeboxFuzzSuite({
 	});
 }).then((summary) => {
 	assert.equal(summary.succeeded, false);
-	assert.equal(summary.failures[0].code, 'wp_codebox_public_fuzz_cli_unsupported');
+	assert.equal(summary.failures[0].code, 'wp_codebox_fuzz_missing_public_cli_command');
 	assert.equal(summary.failures.some((failure) => failure.code === 'wp_codebox_fuzz_required_artifacts_missing'), false);
 
 	console.log('wp-codebox fuzz-run smoke passed');


### PR DESCRIPTION
## Summary
- Add a generic WordPress fuzz command manifest mapping case intents to required WP Codebox public commands, abilities, and capabilities.
- Add WP Codebox fuzz preflight diagnostics before dispatch.
- Add mutation policy support with `mutation_mode: isolated|read_only|destructive-deny`.
- Add unsupported runtime discovery rows for generic missing surface types without claiming executable coverage.

## Verification
- `npm run test:wp-codebox-fuzz-suite`
- `npm run test:wordpress-fuzz-plan-from-surfaces`
- `npm run test:wordpress-fuzz-campaign`
- `npm run test:wordpress-runtime-surface-discovery`
- `npm run test:wordpress-fuzz-runner-codebox-contract`
- `npm run test:wordpress-fuzz-runner`
- `npm run test:wordpress-fuzz-runtime-task`
- `node tests/wordpress-fuzz-runtime-capabilities-smoke.js`
- scoped `npm run lint:js` for changed implementation files
- `git diff --check`

## Stack context
Depends on the WP Codebox public capability work in https://github.com/Automattic/wp-codebox/pull/1509 for the cleanest end-to-end DB/page fuzz capability discovery. This PR keeps Homeboy Extensions product-neutral and focused on WordPress orchestration/preflight.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing fuzz preflight, mutation policy, discovery diagnostics, tests, verification, and PR preparation.