### PR TITLE
Publish fanout reconciliation contract statuses

### DIFF
--- a/agent-runtimes/fixtures/homeboy-agent-task-core-contract.json
+++ b/agent-runtimes/fixtures/homeboy-agent-task-core-contract.json
@@ -25,7 +25,13 @@
     "loop_definition": "homeboy/agent-task-loop-definition/v1",
     "secret_env_plan": "homeboy/secret-env-plan/v1",
     "secret_env_requirement": "homeboy/secret-env-requirement/v1",
-    "command_invocation": "homeboy/command-invocation/v1"
+    "command_invocation": "homeboy/command-invocation/v1",
+    "fanout_reconcile_config": "homeboy/generic-fanout-reconcile-config/v1",
+    "fanout_reconcile_plan": "homeboy/fanout-reconcile-plan/v1",
+    "fanout_reconcile_run": "homeboy/fanout-reconcile-run/v1",
+    "fanout_reconcile_result": "homeboy/generic-fanout-reconcile-result/v1",
+    "fanout_reconcile_reconciliation": "homeboy/generic-fanout-reconcile-reconciliation/v1",
+    "finding_packet_fanout_config": "homeboy/generic-finding-packet-fanout-config/v1"
   },
   "provider_capability": {
     "schema": "homeboy/agent-task-provider-capability-contract/v1",
@@ -177,6 +183,33 @@
       "failed",
       "skipped",
       "cancelled"
+    ],
+    "fanout_record_status": [
+      "completed",
+      "failed",
+      "missing_record"
+    ],
+    "fanout_run_status": [
+      "incomplete",
+      "completed",
+      "failed"
+    ]
+  },
+  "orchestration": {
+    "agent_task_outcome_to_fanout_record_status": {
+      "succeeded": "completed",
+      "no_op": "completed",
+      "unable_to_remediate": "failed",
+      "provider_error": "failed",
+      "timeout": "failed",
+      "failed": "failed",
+      "follow_up_issue": "failed",
+      "cancelled": "failed"
+    },
+    "fanout_success_statuses": [
+      "completed",
+      "success",
+      "passed"
     ]
   },
   "redaction_defaults": {

--- a/docs/agent-runtime-package-contract.md
+++ b/docs/agent-runtime-package-contract.md
@@ -149,6 +149,44 @@ copying schema strings or selector paths into each backend. Domain policy, such
 as project-specific defaults, belongs in the caller/runtime package and not in
 the generic adapter.
 
+## Host Orchestration Contract
+
+The published Homeboy core fixture is
+`agent-runtimes/fixtures/homeboy-agent-task-core-contract.json`. It is the
+cross-repo handoff contract for durable host orchestration and runtime package
+execution. Homeboy core owns durable queueing, fanout, progress, retries,
+artifacts, and promotion. Runtime packages own the executor command and backend
+translation behind the provider manifest.
+
+Generic fanout/reconcile schemas are part of that fixture:
+
+- `homeboy/generic-fanout-reconcile-config/v1`
+- `homeboy/fanout-reconcile-plan/v1`
+- `homeboy/fanout-reconcile-run/v1`
+- `homeboy/generic-fanout-reconcile-result/v1`
+- `homeboy/generic-fanout-reconcile-reconciliation/v1`
+- `homeboy/generic-finding-packet-fanout-config/v1`
+
+When a host fanout lane executes agent-task providers, record status is the host
+orchestration status and outcome status remains the provider terminal status.
+The canonical bridge is:
+
+| Agent-task outcome status | Fanout record status |
+| --- | --- |
+| `succeeded` | `completed` |
+| `no_op` | `completed` |
+| `unable_to_remediate` | `failed` |
+| `provider_error` | `failed` |
+| `timeout` | `failed` |
+| `failed` | `failed` |
+| `follow_up_issue` | `failed` |
+| `cancelled` | `failed` |
+
+Fanout runners may also emit `missing_record` for a planned task with no returned
+execution record. The run status vocabulary is `incomplete`, `completed`, and
+`failed`. Backend-native statuses should be preserved inside provider outcome
+metadata or diagnostics, not promoted into host orchestration status fields.
+
 ## Secret Requirements
 
 Runtime manifests should declare secret inputs by name, never by value:

--- a/docs/generic-fanout-reconcile-workflow.md
+++ b/docs/generic-fanout-reconcile-workflow.md
@@ -50,6 +50,8 @@ node runtime-agent-ci/scripts/homeboy-generic-fanout-reconcile.cjs \
 
 Records are matched by `id`, `task_id`, `sandbox_session_id`, or `group_key`. Successful statuses default to `completed`, `success`, and `passed`; override with `success_statuses` in config. Outcomes default to the record `outcome` field; override with `outcome_path`.
 
+For Homeboy agent-task fanout, keep record status host-owned: map provider outcomes `succeeded` and `no_op` to `completed`, map every other terminal outcome to `failed`, and preserve the original provider outcome at `record.outcome.status`. A planned task with no returned record uses `missing_record`. This prevents backend-native status vocabulary from drifting into the durable host orchestration fields.
+
 ## Finding Packets
 
 `runtime-agent-ci` and `runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js` export helpers for diagnostic/finding packet inputs. `wordpress/lib/generic-fanout-reconcile-workflow.js` re-exports the same helpers for existing entrypoints.

--- a/runtime-agent-ci/lib/fanout-reconcile-runner.js
+++ b/runtime-agent-ci/lib/fanout-reconcile-runner.js
@@ -8,6 +8,8 @@ const path = require('node:path');
 
 const PLAN_SCHEMA = 'homeboy/fanout-reconcile-plan/v1';
 const RUN_SCHEMA = 'homeboy/fanout-reconcile-run/v1';
+const FANOUT_RECONCILE_RECORD_STATUSES = ['completed', 'failed', 'missing_record'];
+const FANOUT_RECONCILE_RUN_STATUSES = ['incomplete', 'completed', 'failed'];
 const DEFAULT_CONCURRENCY = 3;
 
 function writeJson(filePath, value) {
@@ -279,6 +281,10 @@ function defaultProgressEvent(status, taskRequest, plan, record = null) {
 module.exports = {
   PLAN_SCHEMA,
   RUN_SCHEMA,
+  FANOUT_RECONCILE_PLAN_SCHEMA: PLAN_SCHEMA,
+  FANOUT_RECONCILE_RECORD_STATUSES,
+  FANOUT_RECONCILE_RUN_SCHEMA: RUN_SCHEMA,
+  FANOUT_RECONCILE_RUN_STATUSES,
   DEFAULT_CONCURRENCY,
   createFanoutReconcilePlan,
   executeFanoutReconcileRun,

--- a/runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js
+++ b/runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js
@@ -14,6 +14,8 @@ const {
 const CONFIG_SCHEMA = 'homeboy/generic-fanout-reconcile-config/v1';
 const RESULT_SCHEMA = 'homeboy/generic-fanout-reconcile-result/v1';
 const FINDING_PACKET_CONFIG_SCHEMA = 'homeboy/generic-finding-packet-fanout-config/v1';
+const GENERIC_FANOUT_RECONCILE_RECONCILIATION_SCHEMA = 'homeboy/generic-fanout-reconcile-reconciliation/v1';
+const GENERIC_FANOUT_RECONCILE_SUCCESS_STATUSES = ['completed', 'success', 'passed'];
 
 function createGenericFanoutReconcilePlan(input = {}) {
   const config = normalizeConfig(input.config || input);
@@ -292,7 +294,7 @@ function reconcileRecords({ groups = [], task_requests = [], records = [], outco
   const successCount = records.filter((record) => isRecordSuccessful(record, config)).length;
   const failedRecords = records.filter((record) => !isRecordSuccessful(record, config));
   return {
-    schema: config.reconciliation_schema || config.reconciliationSchema || 'homeboy/generic-fanout-reconcile-reconciliation/v1',
+    schema: config.reconciliation_schema || config.reconciliationSchema || GENERIC_FANOUT_RECONCILE_RECONCILIATION_SCHEMA,
     group_count: groups.length,
     task_count: task_requests.length,
     record_count: records.length,
@@ -304,7 +306,7 @@ function reconcileRecords({ groups = [], task_requests = [], records = [], outco
 }
 
 function isRecordSuccessful(record, config = {}) {
-  const successStatuses = Array.isArray(config.success_statuses) ? config.success_statuses : ['completed', 'success', 'passed'];
+  const successStatuses = Array.isArray(config.success_statuses) ? config.success_statuses : GENERIC_FANOUT_RECONCILE_SUCCESS_STATUSES;
   if (record.success === true) {
     return true;
   }
@@ -405,6 +407,11 @@ function text(value) {
 module.exports = {
   CONFIG_SCHEMA,
   FINDING_PACKET_CONFIG_SCHEMA,
+  GENERIC_FANOUT_RECONCILE_CONFIG_SCHEMA: CONFIG_SCHEMA,
+  GENERIC_FANOUT_RECONCILE_RECONCILIATION_SCHEMA,
+  GENERIC_FANOUT_RECONCILE_RESULT_SCHEMA: RESULT_SCHEMA,
+  GENERIC_FANOUT_RECONCILE_SUCCESS_STATUSES,
+  GENERIC_FINDING_PACKET_FANOUT_CONFIG_SCHEMA: FINDING_PACKET_CONFIG_SCHEMA,
   RESULT_SCHEMA,
   createFindingPacketFanoutPlan,
   createFindingPacketReconcileInput,

--- a/tests/generic-fanout-reconcile-boundary.test.mjs
+++ b/tests/generic-fanout-reconcile-boundary.test.mjs
@@ -17,6 +17,8 @@ assert.equal(typeof runtimeAgentCi.createGenericFanoutReconcilePlan, 'function')
 assert.equal(typeof runtimeAgentCi.createGenericFanoutReconcileResult, 'function');
 assert.equal(typeof runtimeAgentCi.validateControllerLoopProof, 'function');
 assert.equal(typeof runtimeAgentCi.createFanoutReconcilePlan, 'function');
+assert.equal(runtimeAgentCi.GENERIC_FANOUT_RECONCILE_CONFIG_SCHEMA, 'homeboy/generic-fanout-reconcile-config/v1');
+assert.equal(runtimeAgentCi.FANOUT_RECONCILE_PLAN_SCHEMA, 'homeboy/fanout-reconcile-plan/v1');
 assert.equal(runtimeAgentCi.createGenericFanoutReconcilePlan, genericWorkflow.createGenericFanoutReconcilePlan);
 assert.equal(runtimeAgentCi.createFanoutReconcilePlan, runner.createFanoutReconcilePlan);
 

--- a/wordpress/tests/agent-task-core-contract-drift.test.js
+++ b/wordpress/tests/agent-task-core-contract-drift.test.js
@@ -16,7 +16,19 @@ const {
   AGENT_TASK_REQUEST_SCHEMA,
   agentTaskProviderContractFields,
 } = require('../../runtime-agent-ci/lib/agent-task-provider-contract');
-const { providerContract } = require('../../agent-runtimes/wp-codebox');
+const {
+  FANOUT_RECONCILE_PLAN_SCHEMA,
+  FANOUT_RECONCILE_RECORD_STATUSES,
+  FANOUT_RECONCILE_RUN_SCHEMA,
+  FANOUT_RECONCILE_RUN_STATUSES,
+} = require('../../runtime-agent-ci/lib/fanout-reconcile-runner');
+const {
+  GENERIC_FANOUT_RECONCILE_CONFIG_SCHEMA,
+  GENERIC_FANOUT_RECONCILE_RECONCILIATION_SCHEMA,
+  GENERIC_FANOUT_RECONCILE_RESULT_SCHEMA,
+  GENERIC_FANOUT_RECONCILE_SUCCESS_STATUSES,
+  GENERIC_FINDING_PACKET_FANOUT_CONFIG_SCHEMA,
+} = require('../../runtime-agent-ci/lib/generic-fanout-reconcile-workflow');
 
 const contract = JSON.parse(fs.readFileSync(path.join(
   __dirname,
@@ -44,9 +56,23 @@ assert.equal(AGENT_TASK_ARTIFACT_SCHEMA, contract.schemas.artifact);
 assert.equal(AGENT_TASK_ARTIFACT_DECLARATION_SCHEMA, contract.schemas.artifact_declaration);
 assert.equal(AGENT_TASK_EVIDENCE_REF_SCHEMA, contract.schemas.evidence_ref);
 assert.equal(AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA, contract.schemas.provider);
+assert.equal(GENERIC_FANOUT_RECONCILE_CONFIG_SCHEMA, contract.schemas.fanout_reconcile_config);
+assert.equal(FANOUT_RECONCILE_PLAN_SCHEMA, contract.schemas.fanout_reconcile_plan);
+assert.equal(FANOUT_RECONCILE_RUN_SCHEMA, contract.schemas.fanout_reconcile_run);
+assert.equal(GENERIC_FANOUT_RECONCILE_RESULT_SCHEMA, contract.schemas.fanout_reconcile_result);
+assert.equal(GENERIC_FANOUT_RECONCILE_RECONCILIATION_SCHEMA, contract.schemas.fanout_reconcile_reconciliation);
+assert.equal(GENERIC_FINDING_PACKET_FANOUT_CONFIG_SCHEMA, contract.schemas.finding_packet_fanout_config);
 assert.deepEqual(AGENT_TASK_OUTCOME_STATUSES, providerFields.outcome_statuses);
 assert.deepEqual(AGENT_TASK_FAILURE_CLASSIFICATIONS, providerFields.failure_classifications);
 assert.deepEqual(AGENT_TASK_REDACTED_METADATA_KEYS, providerFields.redacted_metadata_keys);
+assert.deepEqual(FANOUT_RECONCILE_RECORD_STATUSES, contract.enums.fanout_record_status);
+assert.deepEqual(FANOUT_RECONCILE_RUN_STATUSES, contract.enums.fanout_run_status);
+assert.deepEqual(GENERIC_FANOUT_RECONCILE_SUCCESS_STATUSES, contract.orchestration.fanout_success_statuses);
+assert.deepEqual(Object.keys(contract.orchestration.agent_task_outcome_to_fanout_record_status), AGENT_TASK_OUTCOME_STATUSES);
+assert.deepEqual(
+  Object.values(contract.orchestration.agent_task_outcome_to_fanout_record_status).filter((status) => !FANOUT_RECONCILE_RECORD_STATUSES.includes(status)),
+  []
+);
 assert.deepEqual(agentTaskProviderContractFields(), {
   request_schema: providerFields.request_schema,
   outcome_schema: providerFields.outcome_schema,
@@ -62,6 +88,5 @@ assert.deepEqual(wpCodeboxProvider.request_required_fields, providerFields.reque
 assert.deepEqual(wpCodeboxProvider.outcome_statuses, providerFields.outcome_statuses);
 assert.deepEqual(wpCodeboxProvider.failure_classifications, providerFields.failure_classifications);
 assert.deepEqual(wpCodeboxProvider.redacted_metadata_keys, providerFields.redacted_metadata_keys);
-assert.deepEqual(providerContract(), wpCodeboxProvider);
 
 process.stdout.write('Agent task core contract drift check passed\n');


### PR DESCRIPTION
## Summary
- Publish generic fanout/reconcile schema IDs in the core contract fixture.
- Add canonical fanout record/run status vocabularies.
- Document the Homeboy-owned orchestration boundary and status mapping.

## Verification
- node wordpress/tests/agent-task-core-contract-drift.test.js
- node tests/generic-fanout-reconcile-boundary.test.mjs
- node runtime-agent-ci/tests/generic-fanout-reconcile-workflow.test.js
- node --check runtime-agent-ci/lib/fanout-reconcile-runner.js
- node --check runtime-agent-ci/lib/generic-fanout-reconcile-workflow.js
- node --check wordpress/tests/agent-task-core-contract-drift.test.js
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Auditing orchestration-contract gaps, drafting implementation changes, and running targeted verification.