### PR TITLE
Run npm fallback after empty WordPress PHPUnit discovery

### DIFF
--- a/docs/extensions/wordpress.md
+++ b/docs/extensions/wordpress.md
@@ -1116,6 +1116,26 @@ Evidence expectations:
   include the rerun commands above. Do not cite machine-local paths as PR
   evidence.
 
+Components that use npm for their canonical smoke gate can opt into an npm
+fallback when WP Codebox plugin activation succeeds but PHPUnit discovery finds
+no PHPUnit files:
+
+```json
+{
+  "extensions": {
+    "wordpress": {
+      "settings": {
+        "npm_test_script": "headless-preview-boot-smoke"
+      }
+    }
+  }
+}
+```
+
+The fallback runs `npm run <npm_test_script>` from the component checkout after
+empty PHPUnit discovery. Composer `scripts.test` remains the first fallback when
+present.
+
 ### Nested Plugin Source Roots
 
 Runtime bench runs normally treat the selected Homeboy component path as the

--- a/wordpress/lib/wp-codebox-core-loader.js
+++ b/wordpress/lib/wp-codebox-core-loader.js
@@ -4,11 +4,14 @@
  * External dependencies
  */
 const path = require('node:path');
-const { existsSync } = require('node:fs');
+const { existsSync, readdirSync } = require('node:fs');
+const { homedir } = require('node:os');
 const { pathToFileURL } = require('node:url');
 
 const DEFAULT_CODEBOX_CORE_MODULE = '@automattic/wp-codebox-core';
+const RUNTIME_CORE_ENTRY = 'packages/runtime-core/dist/index.js';
 const DEFAULT_CORE_PACKAGE_CANDIDATES = [DEFAULT_CODEBOX_CORE_MODULE];
+const DEFAULT_RUNTIME_CORE_ENTRIES = [RUNTIME_CORE_ENTRY];
 
 function coreModuleSpecifier(options = {}) {
 	const explicit = options.wpCodeboxCoreModule || options.coreModule || process.env.HOMEBOY_WP_CODEBOX_CORE_MODULE || process.env.WP_CODEBOX_CORE_MODULE;
@@ -42,8 +45,72 @@ function coreModuleCandidates(options = {}) {
 	}
 
 	const packageCandidates = options.packageCandidates || DEFAULT_CORE_PACKAGE_CANDIDATES;
-	return [...packageCandidates].map(normalizeCoreModuleSpecifier);
+	const candidates = [...packageCandidates];
+	for (const candidate of setupCacheCoreModuleCandidates(options)) {
+		if (existsSync(candidate) && !candidates.includes(candidate)) {
+			candidates.push(candidate);
+		}
+	}
+
+	for (const root of workspaceRoots(options)) {
+		for (const repoPath of codeboxRepoCandidates(root)) {
+			for (const entry of options.runtimeCoreEntries || DEFAULT_RUNTIME_CORE_ENTRIES) {
+				const runtimeCore = path.resolve(repoPath, entry);
+				if (existsSync(runtimeCore) && !candidates.includes(runtimeCore)) {
+					candidates.push(runtimeCore);
+				}
+			}
+		}
+	}
+
+	return candidates.map(normalizeCoreModuleSpecifier);
 }
+
+function setupCacheCoreModuleCandidates(options = {}) {
+	const installRoot = options.wpCodeboxInstallDir || process.env.HOMEBOY_WP_CODEBOX_INSTALL_DIR || path.resolve(homedir(), '.cache/homeboy/wp-codebox');
+	const runtimeCoreEntries = options.runtimeCoreEntries || DEFAULT_RUNTIME_CORE_ENTRIES;
+	const packageDistEntries = options.packageDistEntries || ['index.js'];
+	const candidates = [];
+	for (const entry of runtimeCoreEntries) {
+		candidates.push(path.resolve(installRoot, 'source', entry));
+		candidates.push(path.resolve(installRoot, 'release/wp-codebox-cli', entry));
+	}
+	for (const entry of packageDistEntries) {
+		candidates.push(path.resolve(installRoot, 'source/node_modules/@automattic/wp-codebox-core/dist', entry));
+		candidates.push(path.resolve(installRoot, 'release/wp-codebox-cli/node_modules/@automattic/wp-codebox-core/dist', entry));
+	}
+	return candidates;
+}
+
+function workspaceRoots(options = {}) {
+	const repoRoot = path.resolve(__dirname, '..');
+	const roots = [
+		options.workspaceRoot,
+		process.env.HOMEBOY_WORKSPACE_ROOT,
+		process.env.HOMEBOY_DEVELOPER_WORKSPACE,
+		path.dirname(repoRoot),
+	];
+
+	return [...new Set(roots.filter(Boolean))];
+}
+
+function codeboxRepoCandidates(root) {
+	const exact = path.resolve(root, 'wp-codebox');
+	const candidates = existsSync(exact) ? [exact] : [];
+
+	try {
+		const siblingWorktrees = readdirSync(root, { withFileTypes: true })
+			.filter((entry) => entry.isDirectory() && entry.name.startsWith('wp-codebox@'))
+			.map((entry) => path.resolve(root, entry.name))
+			.sort();
+		candidates.push(...siblingWorktrees);
+	} catch {
+		// A missing or unreadable workspace root simply contributes no candidates.
+	}
+
+	return candidates;
+}
+
 async function loadWpCodeboxCore(options = {}) {
 	const errors = [];
 	for (const specifier of coreModuleCandidates(options)) {
@@ -98,4 +165,5 @@ module.exports = {
 	loadWpCodeboxCore,
 	loadWpCodeboxCoreExport,
 	loadWpCodeboxCoreFunction,
+	RUNTIME_CORE_ENTRY,
 };

--- a/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
+++ b/wordpress/scripts/bench/wp-codebox-recipe-builder-loader.mjs
@@ -7,6 +7,7 @@ const require = createRequire(import.meta.url);
 const {
 	coreModuleCandidates,
 	loadWpCodeboxCoreExport,
+	RUNTIME_CORE_ENTRY,
 } = require('../../lib/wp-codebox-core-loader.js');
 
 const RECIPE_BUILDER_MODULE_OPTIONS = {
@@ -17,6 +18,7 @@ const RECIPE_BUILDER_MODULE_OPTIONS = {
 		'@automattic/wp-codebox-core',
 	],
 	packageDistEntries: ['recipe-builders.js', 'index.js'],
+	runtimeCoreEntries: ['packages/runtime-core/dist/recipe-builders.js', RUNTIME_CORE_ENTRY],
 };
 
 export async function loadCodeboxRecipeBuilder(requiredExport) {
@@ -32,7 +34,7 @@ export async function loadCodeboxRecipeBuilder(requiredExport) {
 			`Install/build a WP Codebox recipe-builder module that exports ${requiredExport}.`,
 			'Use the public @automattic/wp-codebox-core/recipe-builders export or wp-codebox-workspace/recipe-builders.',
 			`Pass --setting wp_codebox_core_module=@automattic/wp-codebox-core/recipe-builders, or set HOMEBOY_WP_CODEBOX_CORE_MODULE to a compatible recipe-builder module.`,
-			'Fallback discovery only checks the configured WP Codebox install cache for packaged @automattic/wp-codebox-core entries.',
+			`Fallback discovery also checks sibling wp-codebox checkouts for packages/runtime-core/dist/recipe-builders.js and ${RUNTIME_CORE_ENTRY}.`,
 			'This is separate from HOMEBOY_WP_CODEBOX_BIN / wp_codebox_bin, which only selects the wp-codebox CLI.',
 			'Homeboy Extensions no longer falls back to bundled WP Codebox recipe builders because that stale local copy can drift from the Codebox recipe contract.',
 			`Tried ${candidates.length} candidate(s):`,

--- a/wordpress/scripts/test/test-runner-file-routing-smoke.sh
+++ b/wordpress/scripts/test/test-runner-file-routing-smoke.sh
@@ -147,6 +147,32 @@ printf '{"success":true,"executions":[{"stdout":"OK (1 test, 1 assertion)\n","st
 SH
 chmod +x "${TMPDIR}/stubs/wp-codebox.sh"
 
+cat > "${TMPDIR}/stubs/phpunit-recipe-builder.mjs" <<'NODE'
+#!/usr/bin/env node
+import fs from 'node:fs';
+
+const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+const options = input.options || input;
+const recipe = {
+  schema: 'wp-codebox/workspace-recipe/v1',
+  runtime: { wp: options.wordpressVersion, blueprint: { steps: [] } },
+  inputs: { mounts: options.mounts || [] },
+  workflow: { steps: [{ command: 'wordpress.phpunit', args: [
+    `plugin-slug=${options.pluginSlug}`,
+    `test-file=${options.selectedTestFile || ''}`,
+    `changed-tests-json=${JSON.stringify(options.changedTestFiles || [])}`,
+    `env-json=${JSON.stringify(options.env || {})}`,
+    `wp-config-defines-json=${JSON.stringify(options.wpConfigDefines || {})}`,
+    `autoload-file=${options.autoloadFile}`,
+    `tests-dir=${options.testsDir}`,
+    `dependency-mounts=${(options.dependencyMounts || []).filter(Boolean).join(',')}`,
+    `multisite=${options.multisite ? '1' : '0'}`,
+  ] }] },
+};
+process.stdout.write(`${JSON.stringify(recipe, null, 2)}\n`);
+NODE
+chmod +x "${TMPDIR}/stubs/phpunit-recipe-builder.mjs"
+
 # Stub for the real-WordPress smoke runner. The real runner boots WordPress via
 # WP Codebox; for routing assertions we only need to confirm smoke files reach it
 # and the HOST_SMOKE marker contract, so this stub emits those markers for each
@@ -186,6 +212,17 @@ fi
 echo "contract smoke passed"
 SH
 chmod +x "${TMPDIR}/stubs/composer"
+
+cat > "${TMPDIR}/stubs/npm" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" != "run" ] || [ "${2:-}" != "headless-preview-boot-smoke" ]; then
+    echo "Unexpected npm command: $*" >&2
+    exit 2
+fi
+echo "headless preview boot smoke passed"
+SH
+chmod +x "${TMPDIR}/stubs/npm"
 
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
 HOMEBOY_COMPONENT_ID="component" \
@@ -284,6 +321,7 @@ HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_WORDPRESS_TEST_RUNTIME_BACKEND="wp-codebox" \
 HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${TMPDIR}/stubs/wp-codebox.sh" \
+HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/Unit/ImportAgentAbilityTest.php --filter ImportAgent > "${TMPDIR}/phpunit-file.out"
 
 assert_contains "${TMPDIR}/phpunit-file.out" "WP_CODEBOX_STUB"
@@ -316,6 +354,7 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_RUNTIME_TEST_RUNNER_WP_CODEBOX="${TMPDIR}/stubs/wp-codebox.sh" \
+HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
 HOMEBOY_CHANGED_TEST_FILES=$'tests/import-agent-ability-smoke.php\ntests/Unit/ImportAgentAbilityTest.php' \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/changed-mixed-files.out"
 
@@ -329,6 +368,7 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/stubs/wp-codebox.sh" \
+HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/Unit/ImportAgentAbilityTest.php --filter ImportAgent > "${TMPDIR}/wp-codebox-file.out"
 
 assert_contains "${TMPDIR}/wp-codebox-file.out" "WP_CODEBOX_STUB"
@@ -349,6 +389,7 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_SETTINGS_JSON='{"wp_codebox_bin":"'"${TMPDIR}/stubs/wp-codebox.sh"'","wordpress_runtime_version":"latest"}' \
+HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
 WP_CODEBOX_ARGS_FILE="${TMPDIR}/wp-codebox-settings-args.txt" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" --file tests/Unit/ImportAgentAbilityTest.php > "${TMPDIR}/wp-codebox-settings.out"
 
@@ -363,6 +404,7 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/stubs/wp-codebox.sh" \
+HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/registration-drift.out" 2>&1
 status=$?
 set -e
@@ -389,12 +431,36 @@ HOMEBOY_COMPONENT_ID="component" \
 HOMEBOY_COMPONENT_PATH="$no_phpunit_component" \
 HOMEBOY_COMPONENT_SHAPE="plugin" \
 HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/stubs/wp-codebox.sh" \
+HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
     bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/no-phpunit-composer.out" 2>&1
 
 assert_contains "${TMPDIR}/no-phpunit-composer.out" "Running Composer test script"
 assert_contains "${TMPDIR}/no-phpunit-composer.out" "contract smoke passed"
 assert_not_contains "${TMPDIR}/no-phpunit-composer.out" "NO PHPUNIT TEST FILES DISCOVERED"
 assert_not_contains "${TMPDIR}/no-phpunit-composer.out" "wordpress.phpunit crashed before producing a structured response"
+
+no_phpunit_npm_component="${TMPDIR}/no-phpunit-npm-component"
+mkdir -p "${no_phpunit_npm_component}/tests"
+cat > "${no_phpunit_npm_component}/package.json" <<'JSON'
+{"scripts":{"headless-preview-boot-smoke":"node tests/headless-preview-boot-smoke.mjs"}}
+JSON
+
+WP_CODEBOX_STUB_NO_PHPUNIT=1 \
+PATH="${TMPDIR}/stubs:${PATH}" \
+HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \
+HOMEBOY_COMPONENT_ID="component" \
+HOMEBOY_COMPONENT_PATH="$no_phpunit_npm_component" \
+HOMEBOY_COMPONENT_SHAPE="plugin" \
+HOMEBOY_SETTINGS_JSON='{"npm_test_script":"headless-preview-boot-smoke"}' \
+HOMEBOY_WP_CODEBOX_BIN="${TMPDIR}/stubs/wp-codebox.sh" \
+HOMEBOY_WP_CODEBOX_PHPUNIT_RECIPE_BUILDER="${TMPDIR}/stubs/phpunit-recipe-builder.mjs" \
+    bash "${EXTENSION_PATH}/scripts/test/test-runner.sh" > "${TMPDIR}/no-phpunit-npm.out" 2>&1
+
+assert_contains "${TMPDIR}/no-phpunit-npm.out" "Running npm test script"
+assert_contains "${TMPDIR}/no-phpunit-npm.out" "Script: headless-preview-boot-smoke"
+assert_contains "${TMPDIR}/no-phpunit-npm.out" "headless preview boot smoke passed"
+assert_not_contains "${TMPDIR}/no-phpunit-npm.out" "NO PHPUNIT TEST FILES DISCOVERED"
+assert_not_contains "${TMPDIR}/no-phpunit-npm.out" "wordpress.phpunit crashed before producing a structured response"
 
 set +e
 HOMEBOY_EXTENSION_PATH="$EXTENSION_PATH" \

--- a/wordpress/scripts/test/test-runner-wp-codebox.sh
+++ b/wordpress/scripts/test/test-runner-wp-codebox.sh
@@ -73,6 +73,31 @@ component_has_composer_test_script() {
     ' "${PLUGIN_PATH}/composer.json" 2>/dev/null
 }
 
+component_npm_test_script() {
+    [ -f "${PLUGIN_PATH}/package.json" ] || return 1
+
+    NPM_TEST_SCRIPT="$(php -r '
+        $settings = json_decode(getenv("HOMEBOY_SETTINGS_JSON") ?: "{}", true);
+        $package = json_decode(file_get_contents($argv[1]), true);
+        if (!is_array($settings)) {
+            $settings = [];
+        }
+        if (!is_array($package) || !isset($package["scripts"]) || !is_array($package["scripts"])) {
+            exit(1);
+        }
+        $script = $settings["npm_test_script"] ?? $settings["node_test_script"] ?? $settings["test_npm_script"] ?? null;
+        if ($script === null && isset($package["scripts"]["test"])) {
+            $script = "test";
+        }
+        if (!is_string($script) || $script === "" || !isset($package["scripts"][$script])) {
+            exit(1);
+        }
+        echo $script;
+    ' "${PLUGIN_PATH}/package.json" 2>/dev/null)" || return 1
+
+    [ -n "$NPM_TEST_SCRIPT" ]
+}
+
 run_composer_test_script() {
     echo ""
     echo "Running Composer test script..."
@@ -89,6 +114,26 @@ run_composer_test_script() {
         ( cd "${PLUGIN_PATH}" && composer test -- "${PASSTHROUGH_ARGS[@]}" )
     else
         ( cd "${PLUGIN_PATH}" && composer test )
+    fi
+}
+
+run_npm_test_script() {
+    echo ""
+    echo "Running npm test script..."
+    echo "  Plugin: ${PLUGIN_SLUG} (${PLUGIN_PATH})"
+    echo "  Backend: npm-script"
+    echo "  Script: ${NPM_TEST_SCRIPT}"
+
+    if ! command -v npm >/dev/null 2>&1; then
+        echo "ERROR: package.json declares scripts.${NPM_TEST_SCRIPT}, but npm is not available on PATH." >&2
+        FAILED_STEP="npm test script setup"
+        return 1
+    fi
+
+    if [ "${#PASSTHROUGH_ARGS[@]}" -gt 0 ]; then
+        ( cd "${PLUGIN_PATH}" && npm run "$NPM_TEST_SCRIPT" -- "${PASSTHROUGH_ARGS[@]}" )
+    else
+        ( cd "${PLUGIN_PATH}" && npm run "$NPM_TEST_SCRIPT" )
     fi
 }
 
@@ -264,6 +309,11 @@ TEST_DIR="${PLUGIN_PATH}/tests"
 if [ ! -d "$TEST_DIR" ]; then
     if component_has_composer_test_script; then
         run_composer_test_script
+        exit $?
+    fi
+
+    if component_npm_test_script; then
+        run_npm_test_script
         exit $?
     fi
 
@@ -1018,6 +1068,12 @@ if echo "$PHPUNIT_OUTPUT" | grep -q "^NO_TEST_FILES"; then
     if component_has_composer_test_script; then
         rm -f "$RESULT_FILE"
         run_composer_test_script
+        exit $?
+    fi
+
+    if component_npm_test_script; then
+        rm -f "$RESULT_FILE"
+        run_npm_test_script
         exit $?
     fi
 

--- a/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
@@ -80,4 +80,23 @@ const discoveredResult = spawnSync(process.execPath, [script], {
 assert.equal(discoveredResult.status, 0, discoveredResult.stderr);
 assert.equal(JSON.parse(discoveredResult.stdout).schema, 'wp-codebox/workspace-recipe/v1');
 
+const siblingWorkspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-sibling-'));
+const siblingModule = path.join(siblingWorkspaceRoot, 'wp-codebox', 'packages', 'runtime-core', 'dist', 'index.js');
+fs.mkdirSync(path.dirname(siblingModule), { recursive: true });
+fs.copyFileSync(fixtureCoreModule, siblingModule);
+
+const siblingDiscoveredResult = spawnSync(process.execPath, [script], {
+	cwd: path.join(__dirname, '..'),
+	input: JSON.stringify(input),
+	encoding: 'utf8',
+	env: {
+		...process.env,
+		HOMEBOY_WORKSPACE_ROOT: siblingWorkspaceRoot,
+		HOMEBOY_WP_CODEBOX_CORE_MODULE: '',
+	},
+});
+
+assert.equal(siblingDiscoveredResult.status, 0, siblingDiscoveredResult.stderr);
+assert.equal(JSON.parse(siblingDiscoveredResult.stdout).schema, 'wp-codebox/workspace-recipe/v1');
+
 console.log('wp-codebox phpunit recipe builder smoke passed');

--- a/wordpress/wordpress.json
+++ b/wordpress/wordpress.json
@@ -976,6 +976,13 @@
       "description": "How the WP Codebox PHPUnit backend treats successful WordPress install/activation when discovery finds zero PHPUnit files. Use 'skipped' for components that intentionally test through smoke scripts, or 'failed' when the component expects PHPUnit coverage. Components with phpunit.xml(.dist) still fail on zero discovery."
     },
     {
+      "id": "npm_test_script",
+      "label": "npm test fallback script",
+      "type": "string",
+      "default": "",
+      "description": "package.json script to run after WP Codebox plugin install/activation succeeds but PHPUnit discovery finds no PHPUnit files. Composer scripts.test remains the first fallback when present."
+    },
+    {
       "id": "wordpress_runtime_blueprint",
       "label": "WordPress runtime blueprint",
       "type": "object",


### PR DESCRIPTION
## Summary
- keep the WordPress test runner on the WP Codebox activation/PHPUnit discovery path
- add an explicit `npm_test_script` fallback after empty PHPUnit discovery, preserving Composer `scripts.test` as the first fallback
- broaden WP Codebox recipe-builder discovery to local managed cache and sibling worktrees so runner-side recipe generation can resolve built Codebox packages

## Testing
- `bash -n wordpress/scripts/test/test-runner-wp-codebox.sh wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `HOMEBOY_RUNTIME_RUNNER_PRELUDE=/Users/chubes/Developer/homeboy/src/core/extension/runtime/runner-prelude.sh HOMEBOY_RUNTIME_RESOLVE_CONTEXT=/Users/chubes/Developer/homeboy/src/core/extension/runtime/resolve-context.sh HOMEBOY_RUNTIME_RUNNER_STEPS=/Users/chubes/Developer/homeboy/src/core/extension/runtime/runner-steps.sh HOMEBOY_RUNTIME_WRITE_TEST_RESULTS=/Users/chubes/Developer/homeboy/src/core/extension/runtime/write-test-results.sh bash wordpress/scripts/test/test-runner-file-routing-smoke.sh`
- `node wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js`
- Refreshed `homeboy-lab` WordPress extension from this branch snapshot and verified `homeboy test studio-native --skip-lint` runs through WP Codebox then `npm run headless-preview-boot-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Homeboy WordPress runner regression, implementing the fallback, adding focused coverage, and drafting this PR description.