### PR TITLE
Discover global WP Codebox recipe builders

### DIFF
--- a/wordpress/lib/wp-codebox-core-loader.js
+++ b/wordpress/lib/wp-codebox-core-loader.js
@@ -63,6 +63,14 @@ function coreModuleCandidates(options = {}) {
 		}
 	}
 
+	for (const root of globalNodeModuleRoots(options)) {
+		for (const candidate of globalNodeModuleCoreCandidates(root, options)) {
+			if (existsSync(candidate) && !candidates.includes(candidate)) {
+				candidates.push(candidate);
+			}
+		}
+	}
+
 	return candidates.map(normalizeCoreModuleSpecifier);
 }
 
@@ -92,6 +100,37 @@ function workspaceRoots(options = {}) {
 	];
 
 	return [...new Set(roots.filter(Boolean))];
+}
+
+function globalNodeModuleRoots(options = {}) {
+	if (options.includeGlobalNodeModuleRoots === false) {
+		return [];
+	}
+
+	const configuredRoots = Array.isArray(options.globalNodeModuleRoots) ? options.globalNodeModuleRoots : [];
+	const roots = [
+		...configuredRoots,
+		process.env.HOMEBOY_GLOBAL_NODE_MODULE_ROOT,
+		path.resolve(path.dirname(process.execPath), '..', 'lib', 'node_modules'),
+	];
+
+	return [...new Set(roots.filter(Boolean))];
+}
+
+function globalNodeModuleCoreCandidates(root, options = {}) {
+	const runtimeCoreEntries = options.runtimeCoreEntries || DEFAULT_RUNTIME_CORE_ENTRIES;
+	const packageDistEntries = options.packageDistEntries || ['index.js'];
+	const candidates = [];
+
+	for (const entry of runtimeCoreEntries) {
+		candidates.push(path.resolve(root, 'wp-codebox-workspace', entry));
+	}
+	for (const entry of packageDistEntries) {
+		candidates.push(path.resolve(root, '@automattic', 'wp-codebox-core', 'dist', entry));
+		candidates.push(path.resolve(root, 'wp-codebox-workspace', 'node_modules', '@automattic', 'wp-codebox-core', 'dist', entry));
+	}
+
+	return candidates;
 }
 
 function codeboxRepoCandidates(root) {
@@ -165,5 +204,6 @@ module.exports = {
 	loadWpCodeboxCore,
 	loadWpCodeboxCoreExport,
 	loadWpCodeboxCoreFunction,
+	globalNodeModuleRoots,
 	RUNTIME_CORE_ENTRY,
 };

--- a/wordpress/tests/wp-codebox-core-loader-smoke.js
+++ b/wordpress/tests/wp-codebox-core-loader-smoke.js
@@ -21,6 +21,7 @@ async function main() {
 				'@automattic/wp-codebox-core/artifacts',
 				'wp-codebox-workspace/artifacts',
 			],
+			includeGlobalNodeModuleRoots: false,
 		});
 
 		assert.equal(candidates[0], '@automattic/wp-codebox-core/artifacts');
@@ -40,6 +41,28 @@ async function main() {
 			coreModule: missingExportPath,
 			required: true,
 		}), /WP Codebox core export fixtureExport is unavailable/);
+
+		const globalRoot = path.join(root, 'global-node-modules');
+		const globalRecipeBuilders = path.join(globalRoot, 'wp-codebox-workspace', 'packages', 'runtime-core', 'dist');
+		fs.mkdirSync(globalRecipeBuilders, { recursive: true });
+		fs.writeFileSync(path.join(globalRecipeBuilders, 'recipe-builders.js'), 'exports.fixtureExport = () => "global-runtime-core";\n');
+
+		const globalCandidates = coreModuleCandidates({
+			packageCandidates: [],
+			globalNodeModuleRoots: [globalRoot],
+			runtimeCoreEntries: ['packages/runtime-core/dist/recipe-builders.js'],
+			packageDistEntries: ['recipe-builders.js'],
+		});
+		assert.ok(globalCandidates.some((candidate) => candidate.endsWith('/wp-codebox-workspace/packages/runtime-core/dist/recipe-builders.js')));
+
+		const globalResult = await loadWpCodeboxCoreExport('fixtureExport', {
+			packageCandidates: [],
+			globalNodeModuleRoots: [globalRoot],
+			runtimeCoreEntries: ['packages/runtime-core/dist/recipe-builders.js'],
+			packageDistEntries: ['recipe-builders.js'],
+			required: true,
+		});
+		assert.equal(globalResult.value(), 'global-runtime-core');
 
 		console.log('wp-codebox core loader smoke passed');
 	} finally {

--- a/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
+++ b/wordpress/tests/wp-codebox-phpunit-recipe-builder-smoke.js
@@ -99,4 +99,23 @@ const siblingDiscoveredResult = spawnSync(process.execPath, [script], {
 assert.equal(siblingDiscoveredResult.status, 0, siblingDiscoveredResult.stderr);
 assert.equal(JSON.parse(siblingDiscoveredResult.stdout).schema, 'wp-codebox/workspace-recipe/v1');
 
+const globalNodeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'homeboy-wp-codebox-global-node-'));
+const globalRuntimeModule = path.join(globalNodeRoot, 'wp-codebox-workspace', 'packages', 'runtime-core', 'dist', 'recipe-builders.js');
+fs.mkdirSync(path.dirname(globalRuntimeModule), { recursive: true });
+fs.copyFileSync(fixtureCoreModule, globalRuntimeModule);
+
+const globalDiscoveredResult = spawnSync(process.execPath, [script], {
+	cwd: path.join(__dirname, '..'),
+	input: JSON.stringify(input),
+	encoding: 'utf8',
+	env: {
+		...process.env,
+		HOMEBOY_GLOBAL_NODE_MODULE_ROOT: globalNodeRoot,
+		HOMEBOY_WP_CODEBOX_CORE_MODULE: '',
+	},
+});
+
+assert.equal(globalDiscoveredResult.status, 0, globalDiscoveredResult.stderr);
+assert.equal(JSON.parse(globalDiscoveredResult.stdout).schema, 'wp-codebox/workspace-recipe/v1');
+
 console.log('wp-codebox phpunit recipe builder smoke passed');


### PR DESCRIPTION
## Summary
- Discover WP Codebox recipe-builder exports from global npm module roots.
- Support global `wp-codebox-workspace/packages/runtime-core/dist/recipe-builders.js` installs when no explicit `HOMEBOY_WP_CODEBOX_CORE_MODULE`, cache, or sibling checkout is available.
- Add smoke coverage for global npm discovery in both the core loader and PHPUnit recipe-builder path.

Fixes #1820.

## Testing
- node tests/wp-codebox-core-loader-smoke.js
- node tests/wp-codebox-phpunit-recipe-builder-smoke.js
- node --check lib/wp-codebox-core-loader.js scripts/bench/wp-codebox-recipe-builder-loader.mjs scripts/test/build-wp-codebox-phpunit-recipe.mjs tests/wp-codebox-core-loader-smoke.js tests/wp-codebox-phpunit-recipe-builder-smoke.js
- env -u HOMEBOY_WP_CODEBOX_CORE_MODULE node scripts/test/build-wp-codebox-phpunit-recipe.mjs < /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/wp-codebox-phpunit-recipe-options.json

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the release-test loader failure, implementing global runtime-core discovery, and running focused validation.
