### PR TITLE
Discover global WP Codebox CLI entrypoints

### DIFF
--- a/wordpress/scripts/lib/wp-codebox-paths.sh
+++ b/wordpress/scripts/lib/wp-codebox-paths.sh
@@ -69,6 +69,10 @@ homeboy_wp_codebox_resolve_bin() {
         [ -n "$candidate" ] && candidates+=("$candidate")
     done < <(type -a -p wp-codebox 2>/dev/null || true)
 
+    while IFS= read -r candidate; do
+        [ -n "$candidate" ] && candidates+=("$candidate")
+    done < <(homeboy_wp_codebox_global_cli_candidates)
+
     candidates+=("wp-codebox")
 
     for candidate in "${candidates[@]}"; do
@@ -90,6 +94,28 @@ homeboy_wp_codebox_resolve_bin() {
     fi
 
     return 1
+}
+
+homeboy_wp_codebox_global_cli_candidates() {
+    local roots=()
+    local node_bin=""
+    local node_modules=""
+    local root=""
+
+    if [ -n "${HOMEBOY_GLOBAL_NODE_MODULE_ROOT:-}" ]; then
+        roots+=("$HOMEBOY_GLOBAL_NODE_MODULE_ROOT")
+    fi
+    if node_bin=$(command -v node 2>/dev/null); then
+        node_modules="$(cd "$(dirname "$node_bin")/../lib/node_modules" 2>/dev/null && pwd -P || true)"
+        [ -n "$node_modules" ] && roots+=("$node_modules")
+    fi
+
+    for root in "${roots[@]}"; do
+        printf '%s\n' \
+            "${root}/wp-codebox-workspace/packages/cli/dist/index.js" \
+            "${root}/@automattic/wp-codebox-cli/dist/index.js" \
+            "${root}/wp-codebox-workspace/node_modules/@automattic/wp-codebox-cli/dist/index.js"
+    done
 }
 
 homeboy_wp_codebox_bin_is_runnable() {

--- a/wordpress/scripts/test/wp-codebox-recipe-helper-smoke.sh
+++ b/wordpress/scripts/test/wp-codebox-recipe-helper-smoke.sh
@@ -13,6 +13,7 @@ trap 'rm -rf "$fixture"' EXIT
 fake_wp_codebox="${fixture}/wp-codebox.cjs"
 stale_path="${fixture}/stale-bin"
 valid_path="${fixture}/valid-bin"
+global_node_root="${fixture}/global-node-modules"
 js_bin="${fixture}/wp-codebox-js-entry.mjs"
 recipe_file="${fixture}/recipe.json"
 artifacts_dir="${fixture}/artifacts"
@@ -63,6 +64,16 @@ fi
 resolved_bin=$(PATH="${stale_path}:${valid_path}:${PATH}" homeboy_wp_codebox_resolve_bin '{}')
 if [ "$resolved_bin" != "${valid_path}/wp-codebox" ]; then
     echo "Expected resolver to skip stale wp-codebox wrapper and select working binary" >&2
+    echo "Resolved: ${resolved_bin}" >&2
+    exit 1
+fi
+
+global_cli="${global_node_root}/wp-codebox-workspace/packages/cli/dist/index.js"
+mkdir -p "$(dirname "$global_cli")"
+printf '%s\n' 'process.exit(0);' > "$global_cli"
+resolved_bin=$(PATH="${stale_path}" HOMEBOY_GLOBAL_NODE_MODULE_ROOT="$global_node_root" homeboy_wp_codebox_resolve_bin '{}')
+if [ "$resolved_bin" != "$global_cli" ]; then
+    echo "Expected resolver to select global npm WP Codebox CLI when PATH wrappers are stale" >&2
     echo "Resolved: ${resolved_bin}" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary
- Derive WP Codebox CLI JS entrypoints from global npm module roots when PATH wrappers are stale or absent.
- Probe `wp-codebox-workspace` and `@automattic/wp-codebox-cli` global install layouts.
- Add smoke coverage for selecting a global npm CLI entrypoint after skipping a stale PATH wrapper.

Follow-up for #1822.

## Testing
- bash scripts/test/wp-codebox-recipe-helper-smoke.sh
- node tests/wp-codebox-core-loader-smoke.js
- node tests/wp-codebox-phpunit-recipe-builder-smoke.js
- bash -n scripts/lib/wp-codebox-paths.sh scripts/test/wp-codebox-recipe-helper-smoke.sh

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing remaining WP Codebox CLI resolution failure, implementing global CLI discovery, and running focused smoke tests.
