### PR TITLE
Expose typed WordPress dependency metadata

### DIFF
--- a/wordpress/scripts/bench/bench-runner-wp-codebox.sh
+++ b/wordpress/scripts/bench/bench-runner-wp-codebox.sh
@@ -925,6 +925,14 @@ if [ -z "$ARTIFACTS_DIR" ]; then
 fi
 mkdir -p "$ARTIFACTS_DIR"
 
+if type homeboy_export_validation_dependency_paths &>/dev/null; then
+    homeboy_export_validation_dependency_paths "$WP_CODEBOX_PLUGIN_SOURCE_PATH"
+fi
+DEPENDENCY_PATHS="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
+if type homeboy_export_wordpress_dependencies_json &>/dev/null; then
+    homeboy_export_wordpress_dependencies_json "$DEPENDENCY_PATHS" "$ARTIFACTS_DIR"
+fi
+
 homeboy_wp_codebox_run_prepare_steps
 
 if type homeboy_preflight_declared_validation_dependency_paths &>/dev/null; then
@@ -938,12 +946,12 @@ homeboy_wp_codebox_set_command "$WP_CODEBOX_BIN"
 wp_codebox_command=("${HOMEBOY_WP_CODEBOX_COMMAND[@]}")
 WP_CODEBOX_RESOLVED_BIN="$(homeboy_wp_codebox_resolved_bin_path "$WP_CODEBOX_BIN")"
 
-if type homeboy_export_validation_dependency_paths &>/dev/null; then
-    homeboy_export_validation_dependency_paths "$WP_CODEBOX_PLUGIN_SOURCE_PATH"
-fi
-DEPENDENCY_PATHS="${HOMEBOY_WORDPRESS_DEPENDENCY_PATHS:-}"
 if [ -n "$DEPENDENCY_PATHS" ] && type homeboy_prepare_validation_dependency_paths_for_wp_codebox_bench &>/dev/null; then
     DEPENDENCY_PATHS=$(homeboy_prepare_validation_dependency_paths_for_wp_codebox_bench "$DEPENDENCY_PATHS" "$ARTIFACTS_DIR")
+    export HOMEBOY_WORDPRESS_DEPENDENCY_PATHS="$DEPENDENCY_PATHS"
+fi
+if type homeboy_export_wordpress_dependencies_json &>/dev/null; then
+    homeboy_export_wordpress_dependencies_json "$DEPENDENCY_PATHS" "$ARTIFACTS_DIR"
 fi
 if [ -n "$DEPENDENCY_PATHS" ] && type homeboy_preflight_wordpress_dependency_plugins &>/dev/null; then
     if ! homeboy_preflight_wordpress_dependency_plugins "$DEPENDENCY_PATHS" "$ARTIFACTS_DIR" "bench"; then
@@ -1370,6 +1378,7 @@ homeboy_wp_codebox_emit_dependency_provenance() {
         --arg wpCodeboxBin "$WP_CODEBOX_RESOLVED_BIN" \
         --arg artifactsDir "$ARTIFACTS_DIR" \
         --argjson declaredDependencyPaths "$declared_dependency_paths_json" \
+        --argjson wordpressDependencies "${HOMEBOY_WORDPRESS_DEPENDENCIES_JSON:-[]}" \
         --argjson dependencySlugs "$(printf '%s\n' "$DEPENDENCY_SLUGS_CSV" | jq -R 'split(",") | map(select(. != ""))')" \
         --argjson extraPlugins "$EXTRA_PLUGINS_JSON" \
         --argjson mounts "$MOUNTS_JSON" \
@@ -1385,6 +1394,7 @@ homeboy_wp_codebox_emit_dependency_provenance() {
             artifacts_dir: $artifactsDir,
             dependency_slugs: $dependencySlugs,
             declared_dependency_paths: $declaredDependencyPaths,
+            wordpress_dependencies: $wordpressDependencies,
             plugin_source_path: $pluginSourcePath,
             source_root: (if $sourceRoot == "" then null else $sourceRoot end),
             source_subpath: (if $sourceSubpath == "" then null else $sourceSubpath end),
@@ -1491,7 +1501,8 @@ PREPARED_DEPENDENCIES_METADATA_FILE="${ARTIFACTS_DIR%/}/prepared-bench-dependenc
 if [ -f "$PREPARED_DEPENDENCIES_METADATA_FILE" ]; then
     PREPARED_RESULTS_FILE=$(mktemp "${TMPDIR:-/tmp}/homeboy-wp-codebox-prepared-dependencies.XXXXXX")
     if jq --slurpfile preparedDependencies "$PREPARED_DEPENDENCIES_METADATA_FILE" \
-        '. + {metadata: ((.metadata // {}) + {prepared_dependencies: ($preparedDependencies[0] // [])})}' \
+        --argjson wordpressDependencies "${HOMEBOY_WORDPRESS_DEPENDENCIES_JSON:-[]}" \
+        '. + {metadata: ((.metadata // {}) + {prepared_dependencies: ($preparedDependencies[0] // []), wordpress_dependencies: $wordpressDependencies})}' \
         "$RESULTS_FILE" > "$PREPARED_RESULTS_FILE"; then
         mv "$PREPARED_RESULTS_FILE" "$RESULTS_FILE"
     else

--- a/wordpress/scripts/lib/validation-dependencies.sh
+++ b/wordpress/scripts/lib/validation-dependencies.sh
@@ -1631,6 +1631,84 @@ homeboy_get_prepared_validation_dependency_slug() {
     ' "$metadata_file" 2>/dev/null
 }
 
+homeboy_export_wordpress_dependencies_json() {
+    local dependency_paths="${1:-}"
+    local artifacts_dir="${2:-}"
+
+    command -v jq >/dev/null 2>&1 || return 0
+
+    local metadata_file dependencies_json
+    metadata_file="${artifacts_dir%/}/prepared-bench-dependencies.json"
+    if [ -n "$artifacts_dir" ] && [ -f "$metadata_file" ]; then
+        dependencies_json=$(jq -c '
+            if type == "array" then . else [] end
+            | map({
+                slug,
+                path: (.prepared_path // .package_root // .source_path),
+                local_path: (.source_path // .package_root // .prepared_path),
+                runner_path: (.mounted_plugin_dir // null),
+                source: (.source_type // .cache_status // null),
+                source_type: (.source_type // null),
+                ref: (.requested_revision // null),
+                plugin_file: (.plugin_file // null),
+                resolved_by: (if .cache_status then "wp-codebox-bench-prepare" else "wordpress-dependency-resolution" end)
+            })
+        ' "$metadata_file" 2>/dev/null || printf '[]\n')
+        export HOMEBOY_WORDPRESS_DEPENDENCIES_JSON="$dependencies_json"
+        return 0
+    fi
+
+    local catalog_json="${HOMEBOY_WORDPRESS_DEPENDENCY_CATALOG_JSON:-${_HOMEBOY_RESOLVED_DEPENDENCY_CATALOG_JSON:-[]}}"
+    if printf '%s' "$catalog_json" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+        dependencies_json=$(printf '%s' "$catalog_json" | jq -c '
+            map({
+                slug,
+                path: .resolved_path,
+                local_path: .resolved_path,
+                runner_path: (if .slug then "/wordpress/wp-content/plugins/" + .slug else null end),
+                source: (.source_type // null),
+                source_type: (.source_type // null),
+                ref: (.requested_revision // null),
+                plugin_file: (.plugin_file // null),
+                resolved_by: "wordpress-dependency-resolution"
+            })
+        ' 2>/dev/null || printf '[]\n')
+        export HOMEBOY_WORDPRESS_DEPENDENCIES_JSON="$dependencies_json"
+        return 0
+    fi
+
+    local entries="[]" dependency_path dependency_slug plugin_file plugin_relative_file
+    while IFS= read -r dependency_path; do
+        [ -n "$dependency_path" ] || continue
+        [ -d "$dependency_path" ] || continue
+        dependency_slug=$(homeboy_get_validation_dependency_slug "$dependency_path" || basename "$dependency_path")
+        plugin_file=""
+        plugin_relative_file=""
+        plugin_file=$(homeboy_find_validation_dependency_plugin_main_file "$dependency_path" || true)
+        if [ -n "$plugin_file" ]; then
+            plugin_relative_file="${dependency_slug}/${plugin_file#"${dependency_path%/}/"}"
+        fi
+        entries=$(jq -nc \
+            --argjson entries "$entries" \
+            --arg slug "$dependency_slug" \
+            --arg path "$dependency_path" \
+            --arg pluginFile "$plugin_relative_file" \
+            '$entries + [{
+                slug: $slug,
+                path: $path,
+                local_path: $path,
+                runner_path: "/wordpress/wp-content/plugins/" + $slug,
+                source: "path",
+                source_type: null,
+                ref: null,
+                plugin_file: (if $pluginFile == "" then null else $pluginFile end),
+                resolved_by: "wordpress-dependency-paths"
+            }]')
+    done <<< "$dependency_paths"
+
+    export HOMEBOY_WORDPRESS_DEPENDENCIES_JSON="$entries"
+}
+
 _homeboy_command_version() {
     local command_name="${1:-}"
 

--- a/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
+++ b/wordpress/tests/wp-codebox-bench-bootstrap-steps-smoke.js
@@ -52,6 +52,7 @@ if (process.argv[2] !== 'recipe-run' || recipeIndex < 0) {
   process.exit(2);
 }
 const recipe = JSON.parse(fs.readFileSync(process.argv[recipeIndex + 1], 'utf8'));
+const wordpressDependencies = JSON.parse(process.env.HOMEBOY_WORDPRESS_DEPENDENCIES_JSON || '[]');
 if (process.env.HOMEBOY_FORCE_BOOTSTRAP_FAILURE === '1') {
   process.stdout.write(JSON.stringify({
     success: false,
@@ -66,7 +67,11 @@ process.stdout.write(JSON.stringify({
     component_id: 'bootstrap-steps-fixture',
     iterations: 1,
     warmup_iterations: 0,
-    scenarios: [{ id: 'assert-bootstrap', metrics: { bootstrap_seen: 1 } }]
+    scenarios: [{ id: 'assert-bootstrap', metrics: { bootstrap_seen: 1 } }],
+    metadata: {
+      dependency_env: wordpressDependencies,
+      dependency_paths_env: process.env.HOMEBOY_WORDPRESS_DEPENDENCY_PATHS || ''
+    }
   }
 }) + '\\n');
 `);
@@ -176,6 +181,18 @@ homeboy_resolve_context() {
   assert.deepEqual(stripePrepared.build_commands, ['npm run build']);
   assert.equal(stripePrepared.runtime_requirements.node.node, '>=20');
   assert.equal(stripePrepared.runtime_requirements.node.npm, '>=10');
+  const wordpressDependencies = successResults.metadata.wordpress_dependencies;
+  assert.equal(Array.isArray(wordpressDependencies), true);
+  const stripeDependency = wordpressDependencies.find((dependency) => dependency.slug === 'woocommerce-gateway-stripe');
+  assert.equal([stripeDependencyPath, fs.realpathSync(stripeDependencyPath)].includes(stripeDependency.path), true);
+  assert.equal([stripeDependencyPath, fs.realpathSync(stripeDependencyPath)].includes(stripeDependency.local_path), true);
+  assert.equal(stripeDependency.runner_path, '/wordpress/wp-content/plugins/woocommerce-gateway-stripe');
+  assert.equal(stripeDependency.source, 'local');
+  assert.equal(stripeDependency.ref, 'fixture-revision');
+  assert.equal(stripeDependency.plugin_file, 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php');
+  assert.equal(stripeDependency.resolved_by, 'wp-codebox-bench-prepare');
+  assert.deepEqual(successResults.metadata.dependency_env, wordpressDependencies);
+  assert.equal(successResults.metadata.dependency_paths_env.includes(stripeDependencyPath), true);
 
   const scopedCoreResult = spawnSync('bash', [path.join(extensionPath, 'scripts', 'bench', 'bench-runner.sh')], {
     cwd: componentPath,


### PR DESCRIPTION
## Summary
- Export HOMEBOY_WORDPRESS_DEPENDENCIES_JSON from resolved/prepared WordPress dependency metadata.
- Keep HOMEBOY_WORDPRESS_DEPENDENCY_PATHS compatible and refresh it after WP Codebox dependency preparation.
- Include the typed dependency contract in bench result metadata and dependency provenance.

References Extra-Chill/homeboy#6337.

## Testing
- npm run test:wp-codebox-bench-bootstrap-steps
- npm run test:wp-codebox-prepared-dependency-cache
- npm run test:dependency-plugin-preflight
- bash -n scripts/bench/bench-runner-wp-codebox.sh
- bash -n scripts/lib/validation-dependencies.sh
- node --check tests/wp-codebox-bench-bootstrap-steps-smoke.js
- npm run lint:js (fails on existing unrelated lint violations)
- npx eslint tests/wp-codebox-bench-bootstrap-steps-smoke.js (ignored by repo lint config)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Implementation, focused test updates, and local verification.