### PR TITLE
Mount SSI in fixture matrix recipes

### DIFF
--- a/wordpress/lib/static-site-fixture-matrix.js
+++ b/wordpress/lib/static-site-fixture-matrix.js
@@ -113,6 +113,21 @@ function buildStaticSiteFixtureArtifact(fixture, options = {}) {
 function buildStaticSiteFixtureMatrixRecipe(input = {}) {
 	const matrix = input.matrix || createStaticSiteFixtureMatrix(input);
 	const artifactsDirectory = input.artifactsDirectory || input.artifacts_directory || '/artifacts/static-site-fixture-matrix';
+	const staticSiteImporter = normalizeStaticSiteImporterPlugin(input);
+	const extraPlugins = staticSiteImporter
+		? [staticSiteImporter.extraPlugin, ...normalizeArray(input.extraPlugins || input.extra_plugins)]
+		: normalizeArray(input.extraPlugins || input.extra_plugins);
+	const validationSteps = matrix.fixtures.map((fixture) => ({
+		command: 'wordpress.wp-cli',
+		args: [
+			`command=static-site-importer validate-in-codebox --artifact=${shellToken(artifactPathForFixture(fixture, artifactsDirectory))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --allow-missing-woocommerce`,
+		],
+		metadata: {
+			fixture_id: fixture.id,
+			artifact: artifactPathForFixture(fixture, artifactsDirectory),
+			output: outputPathForFixture(fixture, artifactsDirectory),
+		},
+	}));
 	return {
 		schema: 'wp-codebox/workspace-recipe/v1',
 		runtime: {
@@ -121,22 +136,40 @@ function buildStaticSiteFixtureMatrixRecipe(input = {}) {
 		},
 		inputs: {
 			mounts: normalizeArray(input.mounts),
+			...(extraPlugins.length > 0 ? { extraPlugins } : {}),
 		},
 		workflow: {
-			steps: matrix.fixtures.map((fixture) => ({
-				command: 'wordpress.wp-cli',
-				args: [
-					`command=static-site-importer validate-in-codebox --artifact=${shellToken(artifactPathForFixture(fixture, artifactsDirectory))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --allow-missing-woocommerce`,
-				],
-				metadata: {
-					fixture_id: fixture.id,
-					artifact: artifactPathForFixture(fixture, artifactsDirectory),
-					output: outputPathForFixture(fixture, artifactsDirectory),
-				},
-			})),
+			steps: staticSiteImporter
+				? [staticSiteImporter.activationStep, ...validationSteps]
+				: validationSteps,
 		},
 		artifacts: {
 			directory: artifactsDirectory,
+		},
+	};
+}
+
+function normalizeStaticSiteImporterPlugin(input = {}) {
+	const source = input.staticSiteImporterPath || input.static_site_importer_path;
+	if (typeof source !== 'string' || source.trim() === '') {
+		return null;
+	}
+
+	const slugValue = input.staticSiteImporterSlug || input.static_site_importer_slug || path.basename(source);
+	const pluginFile = input.staticSiteImporterPlugin || input.static_site_importer_plugin || `${slugValue}/${slugValue}.php`;
+	return {
+		extraPlugin: {
+			source,
+			slug: slugValue,
+			activate: true,
+		},
+		activationStep: {
+			command: 'wordpress.ensure-plugin-active',
+			args: [`plugin=${pluginFile}`],
+			metadata: {
+				plugin: pluginFile,
+				slug: slugValue,
+			},
 		},
 	};
 }

--- a/wordpress/scripts/static-site-fixture-matrix.mjs
+++ b/wordpress/scripts/static-site-fixture-matrix.mjs
@@ -43,6 +43,9 @@ async function main() {
 		matrix,
 		artifactsDirectory: outputDirectory,
 		wordpressVersion: options.wordpressVersion,
+		staticSiteImporterPath: options.staticSiteImporterPath ? path.resolve(options.staticSiteImporterPath) : undefined,
+		staticSiteImporterPlugin: options.staticSiteImporterPlugin,
+		staticSiteImporterSlug: options.staticSiteImporterSlug,
 	});
 	const recipeFile = path.join(outputDirectory, 'wp-codebox-static-site-fixture-matrix-recipe.json');
 	fs.writeFileSync(recipeFile, `${JSON.stringify(recipe, null, 2)}\n`);
@@ -142,7 +145,7 @@ function camelCase(value) {
 }
 
 function printHelp() {
-	process.stdout.write(`Usage: node scripts/static-site-fixture-matrix.mjs --fixture-root <path> [options]\n\nOptions:\n  --output-directory <path>   Directory for matrix artifacts and WP Codebox recipe.\n  --entrypoint <file>         Fixture entry file name. Default: index.html.\n  --max-depth <number>        Discovery depth below fixture root. Default: 2.\n  --wordpress-version <ver>   WP Codebox WordPress runtime version. Default: latest.\n  --wp-codebox-bin <path>     WP Codebox CLI binary for --run.\n  --run                       Execute the generated recipe with WP Codebox.\n`);
+	process.stdout.write(`Usage: node scripts/static-site-fixture-matrix.mjs --fixture-root <path> [options]\n\nOptions:\n  --output-directory <path>             Directory for matrix artifacts and WP Codebox recipe.\n  --entrypoint <file>                   Fixture entry file name. Default: index.html.\n  --max-depth <number>                  Discovery depth below fixture root. Default: 2.\n  --wordpress-version <ver>             WP Codebox WordPress runtime version. Default: latest.\n  --static-site-importer-path <path>    Local Static Site Importer plugin source to mount/install.\n  --static-site-importer-plugin <file>  Plugin file to activate. Default: <slug>/<slug>.php.\n  --static-site-importer-slug <slug>    Plugin slug for the mounted source. Default: source basename.\n  --wp-codebox-bin <path>               WP Codebox CLI binary for --run.\n  --run                                 Execute the generated recipe with WP Codebox.\n`);
 }
 
 main().catch((error) => {

--- a/wordpress/tests/static-site-fixture-matrix-smoke.js
+++ b/wordpress/tests/static-site-fixture-matrix-smoke.js
@@ -66,6 +66,23 @@ async function main() {
 		assert.match(recipe.workflow.steps[0].args[0], /command=static-site-importer validate-in-codebox/);
 		assert.match(recipe.workflow.steps[0].args[0], /--artifact=\/artifacts\/matrix\/41-generative-art-studio\/artifact.json/);
 
+		const staticSiteImporterRecipe = buildStaticSiteFixtureMatrixRecipe({
+			matrix,
+			artifactsDirectory: '/artifacts/matrix',
+			staticSiteImporterPath: '/workspace/static-site-importer',
+			staticSiteImporterPlugin: 'static-site-importer/static-site-importer.php',
+			staticSiteImporterSlug: 'static-site-importer',
+		});
+		assert.deepEqual(Object.keys(staticSiteImporterRecipe).sort(), ['artifacts', 'inputs', 'runtime', 'schema', 'workflow']);
+		assert.deepEqual(staticSiteImporterRecipe.inputs.extraPlugins[0], {
+			source: '/workspace/static-site-importer',
+			slug: 'static-site-importer',
+			activate: true,
+		});
+		assert.equal(staticSiteImporterRecipe.workflow.steps[0].command, 'wordpress.ensure-plugin-active');
+		assert.deepEqual(staticSiteImporterRecipe.workflow.steps[0].args, ['plugin=static-site-importer/static-site-importer.php']);
+		assert.equal(staticSiteImporterRecipe.workflow.steps[1].command, 'wordpress.wp-cli');
+
 		assert.equal(classifyStaticSiteFinding({ message: 'This block contains unexpected or invalid content' }).group_key, 'invalid_block_content');
 		assert.equal(classifyStaticSiteFinding({ code: 'runtime_dependency_target_missing', message: '#canvas' }).group_key, 'runtime_target_gap');
 		assert.equal(classifyStaticSiteFinding({ message: 'The imported page has default gray buttons' }).group_key, 'button_style_loss');


### PR DESCRIPTION
## Summary
- Add Static Site Importer plugin path, plugin file, and slug options to the fixture matrix CLI.
- Include the local SSI source as a WP Codebox extra plugin and activate it before fixture validation.
- Cover the generated recipe shape in the static-site fixture matrix smoke test.

## Tests
- npm run test:static-site-fixture-matrix
- npm run lint:js -- --no-warn-ignored scripts/static-site-fixture-matrix.mjs lib/static-site-fixture-matrix.js tests/static-site-fixture-matrix-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Adding Static Site Importer plugin mounting and activation to the fixture matrix WP Codebox recipe.