### PR TITLE
Fix SSI fixture matrix extra plugins schema

### DIFF
--- a/wordpress/lib/static-site-fixture-matrix.js
+++ b/wordpress/lib/static-site-fixture-matrix.js
@@ -136,7 +136,7 @@ function buildStaticSiteFixtureMatrixRecipe(input = {}) {
 		},
 		inputs: {
 			mounts: normalizeArray(input.mounts),
-			...(extraPlugins.length > 0 ? { extraPlugins } : {}),
+			...(extraPlugins.length > 0 ? { extra_plugins: extraPlugins } : {}),
 		},
 		workflow: {
 			steps: staticSiteImporter

--- a/wordpress/tests/static-site-fixture-matrix-smoke.js
+++ b/wordpress/tests/static-site-fixture-matrix-smoke.js
@@ -74,7 +74,7 @@ async function main() {
 			staticSiteImporterSlug: 'static-site-importer',
 		});
 		assert.deepEqual(Object.keys(staticSiteImporterRecipe).sort(), ['artifacts', 'inputs', 'runtime', 'schema', 'workflow']);
-		assert.deepEqual(staticSiteImporterRecipe.inputs.extraPlugins[0], {
+		assert.deepEqual(staticSiteImporterRecipe.inputs.extra_plugins[0], {
 			source: '/workspace/static-site-importer',
 			slug: 'static-site-importer',
 			activate: true,


### PR DESCRIPTION
## Summary
- Use WP Codebox's supported  key for SSI fixture matrix recipes.
- Update the fixture matrix smoke assertion to match the schema.

## Tests
- 
- 

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Fixing and testing the SSI fixture matrix WP Codebox recipe schema.
