### PR TITLE
Fix SSI fixture matrix workflow step schema

### DIFF
--- a/wordpress/lib/static-site-fixture-matrix.js
+++ b/wordpress/lib/static-site-fixture-matrix.js
@@ -136,7 +136,7 @@ function buildStaticSiteFixtureMatrixRecipe(input = {}) {
 		},
 		inputs: {
 			mounts: normalizeArray(input.mounts),
-			...(extraPlugins.length > 0 ? { extraPlugins } : {}),
+			...(extraPlugins.length > 0 ? { extra_plugins: extraPlugins } : {}),
 		},
 		workflow: {
 			steps: staticSiteImporter

--- a/wordpress/lib/static-site-fixture-matrix.js
+++ b/wordpress/lib/static-site-fixture-matrix.js
@@ -122,11 +122,6 @@ function buildStaticSiteFixtureMatrixRecipe(input = {}) {
 		args: [
 			`command=static-site-importer validate-in-codebox --artifact=${shellToken(artifactPathForFixture(fixture, artifactsDirectory))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --allow-missing-woocommerce`,
 		],
-		metadata: {
-			fixture_id: fixture.id,
-			artifact: artifactPathForFixture(fixture, artifactsDirectory),
-			output: outputPathForFixture(fixture, artifactsDirectory),
-		},
 	}));
 	return {
 		schema: 'wp-codebox/workspace-recipe/v1',
@@ -606,10 +601,6 @@ function visitFixtureDirectory(directory, depth, maxDepth, callback) {
 
 function artifactPathForFixture(fixture, artifactsDirectory) {
 	return path.join(artifactsDirectory, fixture.id, 'artifact.json');
-}
-
-function outputPathForFixture(fixture, artifactsDirectory) {
-	return path.join(artifactsDirectory, fixture.id, 'validation-result.json');
 }
 
 function groupFindings(findings) {

--- a/wordpress/tests/static-site-fixture-matrix-smoke.js
+++ b/wordpress/tests/static-site-fixture-matrix-smoke.js
@@ -74,7 +74,7 @@ async function main() {
 			staticSiteImporterSlug: 'static-site-importer',
 		});
 		assert.deepEqual(Object.keys(staticSiteImporterRecipe).sort(), ['artifacts', 'inputs', 'runtime', 'schema', 'workflow']);
-		assert.deepEqual(staticSiteImporterRecipe.inputs.extraPlugins[0], {
+		assert.deepEqual(staticSiteImporterRecipe.inputs.extra_plugins[0], {
 			source: '/workspace/static-site-importer',
 			slug: 'static-site-importer',
 			activate: true,

--- a/wordpress/tests/static-site-fixture-matrix-smoke.js
+++ b/wordpress/tests/static-site-fixture-matrix-smoke.js
@@ -63,6 +63,7 @@ async function main() {
 		assert.equal(Object.hasOwn(recipe, 'static_site_fixture_matrix'), false);
 		assert.equal(recipe.workflow.steps.length, 2);
 		assert.equal(recipe.workflow.steps[0].command, 'wordpress.wp-cli');
+		assert.equal(Object.hasOwn(recipe.workflow.steps[0], 'metadata'), false);
 		assert.match(recipe.workflow.steps[0].args[0], /command=static-site-importer validate-in-codebox/);
 		assert.match(recipe.workflow.steps[0].args[0], /--artifact=\/artifacts\/matrix\/41-generative-art-studio\/artifact.json/);
 


### PR DESCRIPTION
## Summary
- Remove unsupported workflow step metadata from SSI fixture matrix WP Codebox recipes.
- Keep fixture mapping in matrix/result artifacts instead of recipe step properties.

## Tests
- `npm run test:static-site-fixture-matrix`
- `npm run lint:js -- --no-warn-ignored lib/static-site-fixture-matrix.js tests/static-site-fixture-matrix-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Fixing and testing the SSI fixture matrix WP Codebox workflow step schema.
