### PR TITLE
Use supported WP Codebox plugin activation steps

### DIFF
--- a/wordpress/lib/static-site-fixture-matrix.js
+++ b/wordpress/lib/static-site-fixture-matrix.js
@@ -159,8 +159,8 @@ function normalizeStaticSiteImporterPlugin(input = {}) {
 			activate: true,
 		},
 		activationStep: {
-			command: 'wordpress.ensure-plugin-active',
-			args: [`plugin=${pluginFile}`],
+			command: 'wordpress.wp-cli',
+			args: [`command=plugin activate ${pluginFile}`],
 		},
 	};
 }

--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -298,7 +298,7 @@ function homeboyFuzzWorkloadPlanCasePhases(entry = {}, manifest = {}, artifacts 
 	}
 	const activation = manifest.metadata?.fixture?.activation || firstHomeboyFuzzWorkloadActivation(manifest);
 	const setup = typeof activation === 'string' && activation.trim() !== ''
-		? [{ command: 'wordpress.ensure-plugin-active', args: [`plugin=${activation}`] }]
+		? [wpCodeboxPluginActivationStep(activation)]
 		: undefined;
 	const command = entry.command || entry.target?.entrypoint || entry.target?.id;
 	const action = typeof command === 'string' && command.trim() !== ''
@@ -378,7 +378,7 @@ function homeboyFuzzWorkloadCasePhases(entry = {}, manifest = {}, intent = {}, a
 	const workloadPath = execute.path || manifest.workload?.path;
 	const genericCommand = homeboyFuzzWorkloadGenericPrimitiveCommand(manifest);
 	const setup = typeof activation === 'string' && activation.trim() !== ''
-		? [{ command: 'wordpress.ensure-plugin-active', args: [`plugin=${activation}`] }]
+		? [wpCodeboxPluginActivationStep(activation)]
 		: undefined;
 	const action = homeboyFuzzWorkloadCaseAction({ genericCommand, workloadPath, execute });
 	const collect = normalizeArray(intent.collect).length > 0 ? normalizeArray(intent.collect) : artifacts.map((artifact) => ({ artifact: artifact.name }));
@@ -387,6 +387,10 @@ function homeboyFuzzWorkloadCasePhases(entry = {}, manifest = {}, intent = {}, a
 		.filter(Boolean)
 		.map((artifact) => ({ command: 'wordpress.collect-workload-result', args: [`artifact=${artifact}`] }));
 	return stripUndefined({ setup, action, assert: assert.length > 0 ? assert : undefined });
+}
+
+function wpCodeboxPluginActivationStep(plugin) {
+	return { command: 'wordpress.wp-cli', args: [`command=plugin activate ${plugin}`] };
 }
 
 function homeboyFuzzWorkloadCaseAction({ genericCommand, workloadPath, execute = {} } = {}) {

--- a/wordpress/tests/static-site-fixture-matrix-smoke.js
+++ b/wordpress/tests/static-site-fixture-matrix-smoke.js
@@ -80,9 +80,9 @@ async function main() {
 			slug: 'static-site-importer',
 			activate: true,
 		});
-		assert.equal(staticSiteImporterRecipe.workflow.steps[0].command, 'wordpress.ensure-plugin-active');
+		assert.equal(staticSiteImporterRecipe.workflow.steps[0].command, 'wordpress.wp-cli');
 		assert.equal(Object.hasOwn(staticSiteImporterRecipe.workflow.steps[0], 'metadata'), false);
-		assert.deepEqual(staticSiteImporterRecipe.workflow.steps[0].args, ['plugin=static-site-importer/static-site-importer.php']);
+		assert.deepEqual(staticSiteImporterRecipe.workflow.steps[0].args, ['command=plugin activate static-site-importer/static-site-importer.php']);
 		assert.equal(staticSiteImporterRecipe.workflow.steps[1].command, 'wordpress.wp-cli');
 
 		assert.equal(classifyStaticSiteFinding({ message: 'This block contains unexpected or invalid content' }).group_key, 'invalid_block_content');

--- a/wordpress/tests/wordpress-fuzz-runner-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-runner-smoke.js
@@ -207,7 +207,7 @@ const jsonWorkloadResult = buildWordPressFuzzRunnerResult({
 
 assert.equal(jsonWorkloadResult.wp_codebox_input.cases.length, 1);
 assert.equal(jsonWorkloadResult.wp_codebox_input.cases[0].id, 'json-workload:default');
-assert.deepEqual(jsonWorkloadResult.wp_codebox_input.cases[0].phases.setup, [{ command: 'wordpress.ensure-plugin-active', args: ['plugin=sample-plugin/sample-plugin.php'] }]);
+assert.deepEqual(jsonWorkloadResult.wp_codebox_input.cases[0].phases.setup, [{ command: 'wordpress.wp-cli', args: ['command=plugin activate sample-plugin/sample-plugin.php'] }]);
 assert.deepEqual(jsonWorkloadResult.wp_codebox_input.cases[0].phases.action, [{ command: 'wordpress.run-workload', args: ['path=${package.root}/bench/json-workload.workload.json'] }]);
 assert.deepEqual(jsonWorkloadResult.wp_codebox_input.cases[0].phases.assert, [{ command: 'wordpress.collect-workload-result', args: ['artifact=json_fuzz_result'] }]);
 assert.equal(jsonWorkloadResult.wp_codebox_input.cases[0].artifacts[0].required, true);
@@ -266,7 +266,7 @@ const remappedPluginRootResult = buildWordPressFuzzRunnerResult({
 		cases: [{
 			case_id: 'jetpack-performance-observation:default',
 			phases: {
-				setup: [{ command: 'wordpress.ensure-plugin-active', args: ['plugin=jetpack/jetpack.php'] }],
+				setup: [{ command: 'wordpress.wp-cli', args: ['command=plugin activate jetpack/jetpack.php'] }],
 				action: [{ command: 'wordpress.run-workload', args: ['path=${package.root}/bench/performance.workload.json'] }],
 			},
 		}],

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -197,7 +197,7 @@ const jsonWorkloadInput = wpCodeboxFuzzSuiteInput({ id: 'json-workload-run', hom
 assert.equal(jsonWorkloadInput.cases.length, 1);
 assert.equal(jsonWorkloadInput.cases[0].id, 'json-workload-smoke:default');
 assert.equal(jsonWorkloadInput.cases[0].target.entrypoint, 'wordpress.run-workload');
-assert.deepEqual(jsonWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.ensure-plugin-active', args: ['plugin=sample-plugin/sample-plugin.php'] }]);
+assert.deepEqual(jsonWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.wp-cli', args: ['command=plugin activate sample-plugin/sample-plugin.php'] }]);
 assert.deepEqual(jsonWorkloadInput.cases[0].phases.action, [{ command: 'wordpress.run-workload', args: ['path=${package.root}/bench/json-workload-smoke.workload.json'] }]);
 assert.deepEqual(jsonWorkloadInput.cases[0].phases.assert, [{ command: 'wordpress.collect-workload-result', args: ['artifact=json_fuzz_result'] }]);
 assert.equal(jsonWorkloadInput.cases[0].artifacts[0].required, true);
@@ -235,7 +235,7 @@ const genericPrimitiveManifest = {
 };
 const genericPrimitiveInput = wpCodeboxFuzzSuiteInput({ id: 'generic-primitive-run', homeboyFuzzWorkload: genericPrimitiveManifest });
 assert.equal(genericPrimitiveInput.cases[0].target.entrypoint, 'wordpress.fuzz-admin-pages');
-assert.deepEqual(genericPrimitiveInput.cases[0].phases.setup, [{ command: 'wordpress.ensure-plugin-active', args: ['plugin=sample-plugin/sample-plugin.php'] }]);
+assert.deepEqual(genericPrimitiveInput.cases[0].phases.setup, [{ command: 'wordpress.wp-cli', args: ['command=plugin activate sample-plugin/sample-plugin.php'] }]);
 assert.deepEqual(genericPrimitiveInput.cases[0].phases.action, [{ command: 'wordpress.fuzz-admin-pages', args: ['safe_methods=GET', 'max_pages=80', 'enumerate_menus=true'] }]);
 assert.deepEqual(genericPrimitiveInput.cases[0].phases.assert, [{ command: 'wordpress.collect-workload-result', args: ['artifact=admin_page_coverage'] }]);
 
@@ -284,7 +284,7 @@ const planWorkloadInput = wpCodeboxFuzzSuiteInput({ id: 'plan-workload-run', hom
 assert.equal(planWorkloadInput.cases.length, 1);
 assert.equal(planWorkloadInput.cases[0].id, 'plan-workload-smoke:default');
 assert.equal(planWorkloadInput.cases[0].target.entrypoint, 'wordpress.inventory-rest-routes');
-assert.deepEqual(planWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.ensure-plugin-active', args: ['plugin=sample-plugin/sample-plugin.php'] }]);
+assert.deepEqual(planWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.wp-cli', args: ['command=plugin activate sample-plugin/sample-plugin.php'] }]);
 assert.deepEqual(planWorkloadInput.cases[0].phases.action, [{
 	command: 'wordpress.inventory-rest-routes',
 	args: ['plugin=sample-plugin/sample-plugin.php', 'namespaces=sample/v1,sample/v2', 'artifact=route_inventory'],


### PR DESCRIPTION
## Summary
- Replace unsupported `wordpress.ensure-plugin-active` recipe steps with supported `wordpress.wp-cli` plugin activation commands.
- Apply the fix to SSI fixture matrix recipes and generic WP Codebox fuzz workload recipes.
- Update smoke coverage so generated activation steps stay schema-compatible.

## Tests
- `npm run test:static-site-fixture-matrix`
- `node tests/wp-codebox-fuzz-run-smoke.js`
- `node tests/wordpress-fuzz-runner-smoke.js`
- `npm run lint:js -- --no-warn-ignored lib/static-site-fixture-matrix.js lib/wp-codebox-fuzz-run.js tests/static-site-fixture-matrix-smoke.js tests/wp-codebox-fuzz-run-smoke.js tests/wordpress-fuzz-runner-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing WP Codebox recipe schema failures, updating recipe generation, and running focused verification.
