### PR TITLE
Emit runtime args for Codebox fuzz workloads

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -271,12 +271,13 @@ function homeboyFuzzWorkloadPlanCaseToWpCodeboxCase(entry = {}, manifest = {}, i
 	const caseId = entry.case_id || entry.caseId || entry.id || `${manifest.id || 'fuzz-workload'}:${index}`;
 	const artifacts = normalizeHomeboyFuzzCaseArtifacts(entry, manifest);
 	const command = entry.command || entry.target?.entrypoint || entry.target?.id;
+	const input = homeboyFuzzRuntimeCommandInput(entry.input);
 	return stripUndefined({
 		id: caseId,
 		case_id: caseId,
 		target: { kind: 'runtime', id: command, entrypoint: command },
 		description: entry.description || manifest.label,
-		input: objectOrUndefined(entry.input),
+		input,
 		inputs: objectOrUndefined(entry.inputs),
 		phases: homeboyFuzzWorkloadPlanCasePhases(entry, manifest, artifacts),
 		artifacts,
@@ -346,17 +347,13 @@ function homeboyFuzzWorkloadCaseToWpCodeboxCase(entry = {}, manifest = {}, index
 	const execute = objectOrUndefined(intent.execute) || {};
 	const artifacts = normalizeHomeboyFuzzCaseArtifacts(entry, manifest);
 	const command = homeboyFuzzWorkloadGenericPrimitiveCommand(manifest) || 'wordpress.run-workload';
+	const input = homeboyFuzzWorkloadRuntimeCommandInput(entry, manifest, execute);
 	return stripUndefined({
 		id: caseId,
 		case_id: caseId,
 		target: { kind: 'runtime', id: command, entrypoint: command },
 		description: entry.description || manifest.label,
-		input: stripUndefined({
-			path: execute.path || manifest.workload?.path,
-			type: execute.type || manifest.workload?.type,
-			entry: execute.entry || manifest.workload?.entry,
-			parameters: objectOrUndefined(execute.parameters),
-		}),
+		input,
 		inputs: objectOrUndefined(entry.inputs),
 		phases: homeboyFuzzWorkloadCasePhases(entry, manifest, intent, artifacts),
 		artifacts,
@@ -367,6 +364,33 @@ function homeboyFuzzWorkloadCaseToWpCodeboxCase(entry = {}, manifest = {}, index
 			intent: objectOrUndefined(entry.intent),
 		}),
 	});
+}
+
+function homeboyFuzzRuntimeCommandInput(input) {
+	const direct = objectOrUndefined(input);
+	if (!direct) {
+		return undefined;
+	}
+	if (Array.isArray(direct.args)) {
+		return direct;
+	}
+	const args = homeboyFuzzCommandArgs(direct);
+	return args.length > 0 ? { args } : direct;
+}
+
+function homeboyFuzzWorkloadRuntimeCommandInput(entry = {}, manifest = {}, execute = {}) {
+	if (objectOrUndefined(entry.input)) {
+		return homeboyFuzzRuntimeCommandInput(entry.input);
+	}
+	const workloadPath = execute.path || manifest.workload?.path;
+	if (typeof workloadPath === 'string' && workloadPath.trim() !== '') {
+		return { args: [`path=${workloadPath}`] };
+	}
+	const parameters = objectOrUndefined(execute.parameters);
+	if (parameters) {
+		return homeboyFuzzRuntimeCommandInput(parameters);
+	}
+	return undefined;
 }
 
 function homeboyFuzzWorkloadCasePhases(entry = {}, manifest = {}, intent = {}, artifacts = []) {

--- a/wordpress/tests/fixtures/woo-db-api-rest-query-profile-fuzz.json
+++ b/wordpress/tests/fixtures/woo-db-api-rest-query-profile-fuzz.json
@@ -1,0 +1,58 @@
+{
+  "workload": {
+    "schema": "homeboy/fuzz-workload/v1",
+    "id": "rest-db-query-profile",
+    "label": "REST DB query profile",
+    "target": { "type": "wordpress-plugin", "slug": "woocommerce" },
+    "workload": {
+      "runner": "wp-codebox",
+      "type": "json",
+      "path": "${package.root}/bench/rest-db-query-profile.workload.json",
+      "entry": "wp-codebox/run-fuzz-suite"
+    },
+    "artifacts": {
+      "expected": [
+        { "name": "rest_db_query_profile", "role": "fuzz_report", "semantic_key": "fuzz.suite_result", "schema": "wp-codebox/fuzz-suite-result/v1", "required": true }
+      ]
+    },
+    "cases": [
+      {
+        "case_id": "rest-db-query-profile:default",
+        "artifacts": [
+          { "name": "rest_db_query_profile", "path": "rest-db-query-profile/fuzz-suite-result.json", "required": true }
+        ],
+        "intent": {
+          "schema": "homeboy/fuzz-workload-intent/v1",
+          "type": "wordpress-plugin-workload",
+          "plugin": { "activation": "woocommerce/woocommerce.php" },
+          "execute": { "workload_ref": "default", "path": "${package.root}/bench/rest-db-query-profile.workload.json", "type": "json", "entry": "wp-codebox/run-fuzz-suite" },
+          "collect": [ { "artifact": "rest_db_query_profile" } ]
+        }
+      }
+    ]
+  },
+  "result": {
+    "schema": "wp-codebox/fuzz-suite-result/v1",
+    "request_id": "woo-db-api-rest-query-profile-20260624-1",
+    "status": "succeeded",
+    "suite": { "id": "rest-db-query-profile" },
+    "summary": { "total": 1, "passed": 1, "failed": 0, "error": 0, "skipped": 0 },
+    "queries": [
+      { "case_id": "rest-db-query-profile:default", "target_id": "wc-store-products", "operation_id": "GET /wc/store/v1/products", "query": "SELECT * FROM wp_posts WHERE post_type = 'product'", "metric": "query_count", "count": 12, "fingerprint": "select-products" }
+    ],
+    "timings": [
+      { "case_id": "rest-db-query-profile:default", "target_id": "wc-store-products", "operation_id": "GET /wc/store/v1/products", "subject": "request", "duration_ms": 145 }
+    ],
+    "hotspot_summary": {
+      "schema": "homeboy/fuzz-hotspot-summary/v1",
+      "metric": "query_count",
+      "unit": "queries",
+      "items": [
+        { "surface": "wc-store-products", "operation": "GET /wc/store/v1/products", "value": 12, "rank": 1 }
+      ]
+    },
+    "artifacts": {
+      "fuzz_report": { "path": "rest-db-query-profile/fuzz-suite-result.json", "content_type": "application/json" }
+    }
+  }
+}

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
+const path = require('node:path');
 
 const {
 	DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS,
@@ -196,13 +197,26 @@ const jsonWorkloadManifest = {
 const jsonWorkloadInput = wpCodeboxFuzzSuiteInput({ id: 'json-workload-run', homeboyFuzzWorkload: jsonWorkloadManifest });
 assert.equal(jsonWorkloadInput.cases.length, 1);
 assert.equal(jsonWorkloadInput.cases[0].id, 'json-workload-smoke:default');
+assert.equal(jsonWorkloadInput.cases[0].target.kind, 'runtime');
 assert.equal(jsonWorkloadInput.cases[0].target.entrypoint, 'wordpress.run-workload');
+assert.deepEqual(jsonWorkloadInput.cases[0].input, { args: ['path=${package.root}/bench/json-workload-smoke.workload.json'] });
 assert.deepEqual(jsonWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.wp-cli', args: ['command=plugin activate sample-plugin/sample-plugin.php'] }]);
 assert.deepEqual(jsonWorkloadInput.cases[0].phases.action, [{ command: 'wordpress.run-workload', args: ['path=${package.root}/bench/json-workload-smoke.workload.json'] }]);
 assert.deepEqual(jsonWorkloadInput.cases[0].phases.assert, [{ command: 'wordpress.collect-workload-result', args: ['artifact=json_fuzz_result'] }]);
 assert.equal(jsonWorkloadInput.cases[0].artifacts[0].required, true);
 assert.equal(jsonWorkloadInput.cases[0].artifacts[0].metadata.semantic_key, 'fuzz.suite_result');
 assert.equal(jsonWorkloadInput.metadata.artifacts.expected[0].required, true);
+
+const wooDbApiFixture = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/woo-db-api-rest-query-profile-fuzz.json'), 'utf8'));
+const wooDbApiInput = wpCodeboxFuzzSuiteInput({ id: 'woo-db-api-rest-query-profile-run', homeboyFuzzWorkload: wooDbApiFixture.workload });
+assert.equal(wooDbApiInput.cases[0].id, 'rest-db-query-profile:default');
+assert.deepEqual(wooDbApiInput.cases[0].target, { kind: 'runtime', id: 'wordpress.run-workload', entrypoint: 'wordpress.run-workload' });
+assert.deepEqual(wooDbApiInput.cases[0].input, { args: ['path=${package.root}/bench/rest-db-query-profile.workload.json'] });
+assert.deepEqual(wooDbApiInput.cases[0].phases.action, [{ command: 'wordpress.run-workload', args: ['path=${package.root}/bench/rest-db-query-profile.workload.json'] }]);
+const wooDbApiSummary = normalizeWpCodeboxFuzzSuiteResult(wooDbApiFixture.result);
+assert.equal(wooDbApiSummary.hotspot_summary.items[0].value, 12);
+assert.equal(wooDbApiSummary.observation_set.observations[0].fingerprint, 'select-products');
+assert.equal(wooDbApiSummary.observation_set.observations[1].metric, 'duration_ms');
 
 const genericPrimitiveManifest = {
 	schema: 'homeboy/fuzz-workload/v1',
@@ -284,6 +298,7 @@ const planWorkloadInput = wpCodeboxFuzzSuiteInput({ id: 'plan-workload-run', hom
 assert.equal(planWorkloadInput.cases.length, 1);
 assert.equal(planWorkloadInput.cases[0].id, 'plan-workload-smoke:default');
 assert.equal(planWorkloadInput.cases[0].target.entrypoint, 'wordpress.inventory-rest-routes');
+assert.deepEqual(planWorkloadInput.cases[0].input, { args: ['plugin=sample-plugin/sample-plugin.php', 'namespaces=sample/v1,sample/v2', 'artifact=route_inventory'] });
 assert.deepEqual(planWorkloadInput.cases[0].phases.setup, [{ command: 'wordpress.wp-cli', args: ['command=plugin activate sample-plugin/sample-plugin.php'] }]);
 assert.deepEqual(planWorkloadInput.cases[0].phases.action, [{
 	command: 'wordpress.inventory-rest-routes',


### PR DESCRIPTION
## Summary
- Emit Codebox runtime fuzz cases with public command-style input.args instead of ad-hoc workload fields.
- Preserve existing phase data for PHP-runner compatibility while making runtime-core command execution receive the workload path.
- Add a Woo REST DB/API query-profile fixture covering generated suite shape and result observation/hotspot mapping.

## Tests
- npm run test:wp-codebox-fuzz-suite
- npm run test:wordpress-fuzz-runner
- npm run test:wordpress-fuzz-runtime-task

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating the Codebox fuzz-suite contract, implementing the Extensions fix, and adding targeted test coverage.