### PR TITLE
Batch SSI fixture matrix Codebox runs

### DIFF
--- a/wordpress/scripts/fixture-workload-matrix.mjs
+++ b/wordpress/scripts/fixture-workload-matrix.mjs
@@ -10,10 +10,13 @@ const {
 	buildWpCodeboxFixtureWorkloadMatrixRecipe,
 	collectFixtureWorkloadMatrixRunResults,
 	createFixtureWorkloadMatrix,
+	normalizeFixtureWorkloadMatrixResult,
 	writeFixtureWorkloadMatrixArtifacts,
 	writeFixtureWorkloadMatrixResultArtifacts,
 } = require('../lib/fixture-workload-matrix');
 const { runWpCodeboxRecipe } = require('../lib/wp-codebox-recipe-helper');
+
+const DEFAULT_RUN_BATCH_SIZE = 10;
 
 async function main() {
 	const options = parseArgs(process.argv.slice(2));
@@ -28,7 +31,7 @@ async function main() {
 		fixture_root: path.resolve(options.fixtureRoot),
 		entrypoint: options.entrypoint || 'index.html',
 		maxDepth: options.maxDepth,
-		batchSize: options.batchSize,
+		batchSize: options.batchSize || (options.run ? DEFAULT_RUN_BATCH_SIZE : undefined),
 	});
 	const written = writeFixtureWorkloadMatrixArtifacts({ outputDirectory, matrix });
 	const recipe = buildWpCodeboxFixtureWorkloadMatrixRecipe({
@@ -49,14 +52,68 @@ async function main() {
 	let runtimeError = null;
 	let collectedResult = written.result;
 	if (options.run) {
-		const outputFile = path.join(outputDirectory, 'wp-codebox-output.json');
-		try {
-			runtime = await runWpCodeboxRecipe({ recipeFile, artifactsDir: outputDirectory, outputFile, wpCodeboxBin: options.wpCodeboxBin });
-		} catch (error) {
-			runtimeError = error;
-			runtime = { exitCode: error?.code ?? 1, outputFile, json: parseJsonText(error?.stdout) };
+		const batchRuns = [];
+		const batchResults = [];
+		for (const batch of matrix.batches) {
+			const batchFixtures = matrix.fixtures.filter((fixture) => batch.fixture_ids.includes(fixture.id));
+			const batchMatrix = createFixtureWorkloadMatrix({
+				id: `${matrix.id}-${batch.id}`,
+				fixture_root: matrix.fixture_root,
+				entrypoint: matrix.entrypoint,
+				fixtures: batchFixtures,
+			});
+			const batchRecipe = buildWpCodeboxFixtureWorkloadMatrixRecipe({
+				matrix: batchMatrix,
+				artifactsDirectory: outputDirectory,
+				playgroundArtifactsDirectory: options.playgroundArtifactsDirectory,
+				wordpressVersion: options.wordpressVersion,
+				extraPlugins: parseJsonOption(options.extraPlugins, []),
+				pluginActivations: parseJsonOption(options.pluginActivations, []),
+				workloadStep: parseJsonOption(options.workloadStep, null),
+				argsTemplate: options.commandArgs ? [options.commandArgs] : undefined,
+				command: options.command,
+			});
+			const batchRecipeFile = path.join(outputDirectory, `wp-codebox-fixture-workload-matrix-${batch.id}.json`);
+			const outputFile = path.join(outputDirectory, `wp-codebox-output-${batch.id}.json`);
+			fs.writeFileSync(batchRecipeFile, `${JSON.stringify(batchRecipe, null, 2)}\n`);
+
+			let batchRuntime = null;
+			let batchError = null;
+			try {
+				batchRuntime = await runWpCodeboxRecipe({ recipeFile: batchRecipeFile, artifactsDir: outputDirectory, outputFile, wpCodeboxBin: options.wpCodeboxBin });
+			} catch (error) {
+				batchError = error;
+				batchRuntime = { exitCode: error?.code ?? 1, outputFile, json: parseJsonText(error?.stdout) };
+				if (!runtimeError) {
+					runtimeError = error;
+				}
+			}
+
+			batchRuns.push({
+				batch: batch.id,
+				fixture_count: batchFixtures.length,
+				recipe_file: batchRecipeFile,
+				output_file: outputFile,
+				exit_code: batchRuntime?.exitCode ?? 0,
+				error: batchError ? batchError.message : '',
+			});
+			batchResults.push(collectFixtureWorkloadMatrixRunResults({
+				matrix: batchMatrix,
+				outputDirectory,
+				outputFile,
+				codeboxOutput: batchRuntime?.json,
+				codeboxError: batchError,
+			}));
 		}
-		collectedResult = collectFixtureWorkloadMatrixRunResults({ matrix, outputDirectory, outputFile, codeboxOutput: runtime?.json, codeboxError: runtimeError });
+		collectedResult = normalizeFixtureWorkloadMatrixResult({
+			matrix,
+			results: batchResults.flatMap((result) => result.fixtures),
+		});
+		runtime = {
+			exitCode: runtimeError ? (batchRuns.find((batch) => batch.exit_code)?.exit_code || 1) : 0,
+			batchSize: Number(options.batchSize || DEFAULT_RUN_BATCH_SIZE),
+			batches: batchRuns,
+		};
 		writeFixtureWorkloadMatrixResultArtifacts({ outputDirectory, matrix, result: collectedResult });
 	}
 
@@ -71,13 +128,23 @@ async function main() {
 		artifact_refs: written.artifact_refs,
 		result_file: path.join(outputDirectory, matrix.artifacts.result),
 		result_summary: collectedResult.summary,
-		runtime: runtime ? { exit_code: runtime.exitCode, output_file: runtime.outputFile, error: runtimeError ? runtimeError.message : '' } : null,
+		runtime: runtime ? runtimeSummary(runtime, runtimeError) : null,
 	};
 	fs.writeFileSync(path.join(outputDirectory, 'cli-run.json'), `${JSON.stringify(summary, null, 2)}\n`);
 	process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
 	if (runtimeError) {
 		process.exitCode = runtime.exitCode || 1;
 	}
+}
+
+function runtimeSummary(runtime, runtimeError) {
+	return {
+		exit_code: runtime.exitCode,
+		...(runtime.outputFile ? { output_file: runtime.outputFile } : {}),
+		...(runtime.batchSize ? { batch_size: runtime.batchSize } : {}),
+		...(runtime.batches ? { batches: runtime.batches } : {}),
+		error: runtimeError ? runtimeError.message : '',
+	};
 }
 
 function parseJsonText(text) {
@@ -133,7 +200,7 @@ function camelCase(value) {
 }
 
 function printHelp() {
-	process.stdout.write(`Usage: node scripts/fixture-workload-matrix.mjs --fixture-root <path> --command-args <template> [options]\n\nOptions:\n  --output-directory <path>          Directory for matrix artifacts and WP Codebox recipe.\n  --entrypoint <file>                Fixture entry file name. Default: index.html.\n  --max-depth <number>               Discovery depth below fixture root. Default: 2.\n  --batch-size <number>              Matrix batch size. Default: all fixtures in one batch.\n  --wordpress-version <ver>          WP Codebox WordPress runtime version. Default: latest.\n  --playground-artifacts-directory   Mounted artifact directory inside WP Codebox.\n  --extra-plugins <json>             Extra plugin input array passed through to WP Codebox.\n  --plugin-activations <json>        Plugin activation inputs as strings or step objects.\n  --workload-step <json>             Complete workload step template with {{ fixture_id }} and {{ artifact_path }} placeholders.\n  --command <name>                   Workload command. Default: wordpress.wp-cli.\n  --command-args <template>          Workload command args template.\n  --wp-codebox-bin <path>            WP Codebox CLI binary for --run.\n  --run                              Execute the generated recipe with WP Codebox.\n`);
+	process.stdout.write(`Usage: node scripts/fixture-workload-matrix.mjs --fixture-root <path> --command-args <template> [options]\n\nOptions:\n  --output-directory <path>          Directory for matrix artifacts and WP Codebox recipe.\n  --entrypoint <file>                Fixture entry file name. Default: index.html.\n  --max-depth <number>               Discovery depth below fixture root. Default: 2.\n  --batch-size <number>              Matrix batch size. Default: all fixtures in one batch, ${DEFAULT_RUN_BATCH_SIZE} with --run.\n  --wordpress-version <ver>          WP Codebox WordPress runtime version. Default: latest.\n  --playground-artifacts-directory   Mounted artifact directory inside WP Codebox.\n  --extra-plugins <json>             Extra plugin input array passed through to WP Codebox.\n  --plugin-activations <json>        Plugin activation inputs as strings or step objects.\n  --workload-step <json>             Complete workload step template with {{ fixture_id }} and {{ artifact_path }} placeholders.\n  --command <name>                   Workload command. Default: wordpress.wp-cli.\n  --command-args <template>          Workload command args template.\n  --wp-codebox-bin <path>            WP Codebox CLI binary for --run.\n  --run                              Execute the generated recipe with WP Codebox.\n`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- Port bounded WP Codebox batch execution onto the generic fixture workload matrix CLI.
- Aggregate batch results into the existing generic matrix result artifacts.
- Keep the deleted SSI-specific matrix implementation out of the rebased branch.

## Evidence
- Local: `node --check wordpress/scripts/fixture-workload-matrix.mjs`
- Local: `node wordpress/tests/fixture-workload-matrix-smoke.js`
- GitHub Actions were not used for verification because the queue is rate-limited.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Rebasing the stale PR onto the generic fixture workload matrix surface, resolving the deleted-file conflict, implementation, and verification.