### PR TITLE
Pass runtime requirements to Codebox CLI

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -626,10 +626,12 @@ async function runWpCodeboxPublicFuzzOperation(options = {}) {
 
 function wpCodeboxPublicCliInput(request = {}, options = {}) {
 	const input = request.executor?.config?.runtime_task?.input || options.input || {};
+	const runtimeRequirements = objectOrUndefined(request.executor?.config?.runtime_requirements || request.runtime_requirements);
 	return {
 		...input,
 		metadata: {
 			...(objectOrUndefined(input.metadata) || {}),
+			runtime_requirements: runtimeRequirements,
 			homeboy_agent_task_request: request,
 		},
 	};

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -25,6 +25,7 @@ const {
 	normalizeWpCodeboxFuzzSuiteResult,
 	detectWpCodeboxPublicFuzzCapabilities,
 	preflightWpCodeboxFuzzCapabilityContract,
+	runWpCodeboxPublicFuzzOperation,
 	runWpCodeboxFuzzSuite,
 	wpCodeboxFuzzSuiteInput,
 	wpCodeboxFuzzSuiteTaskRequest,
@@ -589,6 +590,10 @@ runWpCodeboxFuzzSuite({
 	return runWpCodeboxFuzzSuite({
 		taskId: 'public-cli-suite-run',
 		input,
+		runtimeRequirements: {
+			extra_plugins: [{ slug: 'sample-plugin', source: '/runner/components/sample-plugin', loadAs: 'plugin' }],
+			runtime_env: { WP_CODEBOX_FUZZ_WORKLOAD_ROOT: '/runner/workloads' },
+		},
 		runPublicCli: ({ args, stdin }) => {
 			if (args.join(' ') === 'run-fuzz-suite --help') {
 				return { status: 0, stdout: 'usage' };
@@ -600,7 +605,10 @@ runWpCodeboxFuzzSuite({
 			assert.equal(args[1], '--input-file');
 			assert.equal(args[3], '--format=json');
 			assert.equal(stdin, undefined);
-			assert.equal(JSON.parse(fs.readFileSync(args[2], 'utf8')).schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+			const publicCliInput = JSON.parse(fs.readFileSync(args[2], 'utf8'));
+			assert.equal(publicCliInput.schema, WP_CODEBOX_FUZZ_SUITE_SCHEMA);
+			assert.equal(publicCliInput.metadata.runtime_requirements.extra_plugins[0].source, '/runner/components/sample-plugin');
+			assert.equal(publicCliInput.metadata.runtime_requirements.runtime_env.WP_CODEBOX_FUZZ_WORKLOAD_ROOT, '/runner/workloads');
 			return {
 				status: 0,
 				stdout: JSON.stringify({


### PR DESCRIPTION
## Summary
- Include generic `metadata.runtime_requirements` in the public WP Codebox fuzz-suite CLI payload.
- Preserve the existing internal request metadata used by Homeboy Extensions normalization.
- Cover the payload shape in the Codebox fuzz-run smoke test.

## Testing
- `node tests/wp-codebox-fuzz-run-smoke.js`
- `node tests/wordpress-fuzz-runner-smoke.js`

## Depends on
- https://github.com/Automattic/wp-codebox/pull/1516

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Maintaining the generic WP Codebox CLI boundary while wiring runtime requirements through the Extensions adapter and updating focused smoke coverage.
