### PR TITLE
Embed source PHP workload files

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -408,7 +408,7 @@ function homeboyFuzzWorkloadRunInputFromFile(workloadPath, options = {}) {
 	} catch (_error) {
 		return undefined;
 	}
-	const steps = normalizeWordPressWorkloadSteps(source.run || source.steps);
+	const steps = normalizeWordPressWorkloadSteps(source.run || source.steps, { sourceFilePath: filePath });
 	if (steps.length === 0) {
 		return undefined;
 	}
@@ -547,13 +547,17 @@ function wpCodeboxWordPressWorkloadRunInput(options = {}) {
 	});
 }
 
-function normalizeWordPressWorkloadSteps(steps) {
-	return normalizeArray(steps).map(normalizeWordPressWorkloadStep).filter(Boolean);
+function normalizeWordPressWorkloadSteps(steps, options = {}) {
+	return normalizeArray(steps).map((step) => normalizeWordPressWorkloadStep(step, options)).filter(Boolean);
 }
 
-function normalizeWordPressWorkloadStep(step) {
+function normalizeWordPressWorkloadStep(step, options = {}) {
 	if (!objectOrUndefined(step)) {
 		return undefined;
+	}
+	const embeddedStep = embedSourcePhpWorkloadStep(step, options);
+	if (embeddedStep) {
+		return embeddedStep;
 	}
 	if (!isArtifactPostprocessCommand(step.command || step.type || step.name)) {
 		return step;
@@ -574,6 +578,58 @@ function normalizeWordPressWorkloadStep(step) {
 			contract: 'homeboy/artifact-postprocess/v1',
 		}),
 	});
+}
+
+function embedSourcePhpWorkloadStep(step, options = {}) {
+	if (step.type !== 'php' || typeof step.file !== 'string' || step.file.trim() === '' || typeof step.code === 'string') {
+		return undefined;
+	}
+	const sourceFile = resolveSourceWorkloadStepFile(step.file, options.sourceFilePath);
+	if (!sourceFile) {
+		return undefined;
+	}
+	const source = fs.readFileSync(sourceFile, 'utf8');
+	return stripUndefined({
+		...step,
+		file: undefined,
+		code: phpCallableSourceWrapper(source),
+		metadata: stripUndefined({
+			...(objectOrUndefined(step.metadata) || {}),
+			source_file: sourceFile,
+			embedded_source_file: true,
+		}),
+	});
+}
+
+function resolveSourceWorkloadStepFile(file, sourceFilePath) {
+	const requested = String(file || '').trim();
+	if (!requested || path.isAbsolute(requested) || requested.split(/[\\/]+/).includes('..')) {
+		return undefined;
+	}
+	const sourcePath = typeof sourceFilePath === 'string' && path.isAbsolute(sourceFilePath) ? sourceFilePath : undefined;
+	if (!sourcePath) {
+		return undefined;
+	}
+	const sourceDirectory = path.dirname(sourcePath);
+	const candidates = [
+		path.resolve(sourceDirectory, requested),
+		path.resolve(path.dirname(sourceDirectory), requested),
+	];
+	for (const candidate of candidates) {
+		if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+			return candidate;
+		}
+	}
+	return undefined;
+}
+
+function phpCallableSourceWrapper(source) {
+	const body = String(source || '')
+		.replace(/^\uFEFF/, '')
+		.replace(/^\s*<\?php\s*/, '')
+		.replace(/\?>\s*$/, '')
+		.trim();
+	return `$wp_codebox_embedded_callable = (function () {\n${body}\n})(); return is_callable($wp_codebox_embedded_callable) ? $wp_codebox_embedded_callable() : $wp_codebox_embedded_callable;`;
 }
 
 function isArtifactPostprocessCommand(value) {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -230,10 +230,17 @@ assert.equal(jsonWorkloadInput.cases[0].artifacts[0].metadata.semantic_key, 'fuz
 assert.equal(jsonWorkloadInput.metadata.artifacts.expected[0].required, true);
 
 const wooDbApiWorkloadPath = path.join(tempWorkloadDir, 'rest-db-query-profile.workload.json');
+fs.mkdirSync(path.join(tempWorkloadDir, 'bench'), { recursive: true });
+fs.writeFileSync(path.join(tempWorkloadDir, 'bench', 'generated-rest-request-cases.php'), `<?php
+return function (): array {
+	return array('metadata' => array('generated_rest_request_cases_loaded' => true));
+};
+`, 'utf8');
 fs.writeFileSync(wooDbApiWorkloadPath, `${JSON.stringify({
 	id: 'rest-db-query-profile',
 	run: [
 		{ type: 'php', code: 'return array("loaded" => true);' },
+		{ type: 'php', file: 'bench/generated-rest-request-cases.php' },
 		{ type: 'rest-db-query-profiler', 'metric-prefix': 'rest_db_query_profile', sampleLimit: 50 },
 	],
 	metadata: { runner: 'wp-codebox', workload: 'rest-db-query-profile' },
@@ -247,6 +254,14 @@ assert.deepEqual(wooDbApiInput.cases[0].target, { kind: 'runtime', id: 'wordpres
 assert.equal(wooDbApiInput.cases[0].input.schema, DEFAULT_WORDPRESS_WORKLOAD_RUN_SCHEMA);
 assert.deepEqual(wooDbApiInput.cases[0].input.steps, [
 	{ type: 'php', code: 'return array("loaded" => true);' },
+	{
+		type: 'php',
+		code: `$wp_codebox_embedded_callable = (function () {\nreturn function (): array {\n\treturn array('metadata' => array('generated_rest_request_cases_loaded' => true));\n};\n})(); return is_callable($wp_codebox_embedded_callable) ? $wp_codebox_embedded_callable() : $wp_codebox_embedded_callable;`,
+		metadata: {
+			source_file: path.join(tempWorkloadDir, 'bench', 'generated-rest-request-cases.php'),
+			embedded_source_file: true,
+		},
+	},
 	{ type: 'rest-db-query-profiler', 'metric-prefix': 'rest_db_query_profile', sampleLimit: 50 },
 ]);
 assert.deepEqual(wooDbApiInput.cases[0].phases.action, [{ command: 'wordpress.run-workload', args: [`path=${wooDbApiWorkloadPath}`] }]);


### PR DESCRIPTION
## Summary
- embed source-adjacent PHP workload file steps when converting JSON workload files for Codebox
- preserve generic wordpress.run-workload execution without requiring rig source files inside the mounted plugin
- cover the Woo DB profile conversion path with a source PHP file step

## Testing
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js
- node wordpress/tests/wordpress-fuzz-runner-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the runner failure, implementing the adapter embedding behavior, and running focused validation.