### PR TITLE
Synthesize Codebox fuzz result artifacts

### DIFF
--- a/wordpress/lib/wp-codebox-fuzz-run.js
+++ b/wordpress/lib/wp-codebox-fuzz-run.js
@@ -1122,7 +1122,49 @@ function normalizeWpCodeboxFuzzArtifacts(source = {}, result = {}) {
 	appendCaseArtifacts(artifacts, source?.wordpress_fuzz_result?.cases || source?.wordpressFuzzResult?.cases, 'fuzz_case');
 	appendCaseArtifacts(artifacts, source?.failures || source?.errors || source?.failed_cases || source?.failedCases, 'failing_case');
 	appendCaseArtifacts(artifacts, source?.repro_cases || source?.reproCases || source?.reproductions, 'repro_case');
+	if (artifacts.length === 0) {
+		appendStructuredFuzzArtifacts(artifacts, source);
+	}
 	return dedupeArtifacts(artifacts.map(normalizeFuzzArtifact).filter(Boolean));
+}
+
+function appendStructuredFuzzArtifacts(artifacts, source = {}) {
+	const cases = normalizeArray(source?.cases || source?.fuzz_cases || source?.fuzzCases);
+	if (cases.length === 0) {
+		return;
+	}
+	if (source?.schema || source?.status) {
+		artifacts.push({
+			name: 'wp-codebox-fuzz-suite-result',
+			role: 'fuzz_report',
+			semantic_key: 'fuzz.result.normalized',
+			content: source,
+			metadata: { schema: source?.schema || WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA },
+		});
+	}
+	if (cases.length > 0) {
+		artifacts.push({
+			name: 'case-log',
+			role: 'case_log',
+			semantic_key: 'fuzz.case.log',
+			content: cases,
+		});
+		artifacts.push({
+			name: 'replay-data',
+			role: 'replay_data',
+			semantic_key: 'fuzz.replay.data',
+			content: cases.map((entry) => stripUndefined({ id: entry.id || entry.case_id || entry.caseId, target: objectOrUndefined(entry.target), input: objectOrUndefined(entry.metadata?.input || entry.input) })),
+		});
+	}
+	const coverageSummary = normalizeCoverageSummary(source?.coverage_summary || source?.coverageSummary || source?.coverage?.summary);
+	if (coverageSummary) {
+		artifacts.push({
+			name: 'coverage-summary',
+			role: 'coverage_summary',
+			semantic_key: 'fuzz.coverage.summary',
+			content: coverageSummary,
+		});
+	}
 }
 
 function fuzzArtifactRefsFromSource(source = {}, result = {}) {

--- a/wordpress/tests/wp-codebox-fuzz-run-smoke.js
+++ b/wordpress/tests/wp-codebox-fuzz-run-smoke.js
@@ -270,6 +270,19 @@ assert.equal(wooDbApiSummary.hotspot_summary.items[0].value, 12);
 assert.equal(wooDbApiSummary.observation_set.observations[0].fingerprint, 'select-products');
 assert.equal(wooDbApiSummary.observation_set.observations[1].metric, 'duration_ms');
 
+const structuredResultSummary = normalizeWpCodeboxFuzzSuiteResult({
+	schema: WP_CODEBOX_FUZZ_SUITE_RESULT_SCHEMA,
+	status: 'passed',
+	cases: [{ id: 'runtime-case', status: 'passed', success: true, metadata: { input: { id: 'runtime-workload' } } }],
+	coverage_summary: { skipped_count: 0 },
+}, { request: { artifact_declarations: DEFAULT_FUZZ_SUITE_ARTIFACT_DECLARATIONS } });
+assert.equal(structuredResultSummary.status, 'passed');
+assert.deepEqual(structuredResultSummary.failures, []);
+assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'wp-codebox-fuzz-suite-result'), true);
+assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'case-log'), true);
+assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'replay-data'), true);
+assert.equal(structuredResultSummary.artifacts.some((artifact) => artifact.name === 'coverage-summary'), true);
+
 const genericPrimitiveManifest = {
 	schema: 'homeboy/fuzz-workload/v1',
 	id: 'generic-primitive-smoke',


### PR DESCRIPTION
## Summary
- synthesize virtual artifact refs from structured Codebox fuzz-suite results that pass with cases but no file artifacts
- preserve required-artifact failures for empty-case results
- cover the runtime-backed result shape that blocked the Woo DB/API proof run

## Testing
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js
- node wordpress/tests/wordpress-fuzz-runner-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the required-artifact gate failure, implementing the artifact normalizer follow-up, and running focused validation.