### PR TITLE
Read workload execution metrics from Codebox results

### DIFF
--- a/wordpress/lib/wordpress-fuzz-schemas.js
+++ b/wordpress/lib/wordpress-fuzz-schemas.js
@@ -366,6 +366,8 @@ function normalizeCasePerformanceMetrics(result) {
 		result.metrics,
 		result.performance_metrics || result.performanceMetrics,
 		result.metadata?.metrics,
+		result.metadata?.execution?.result?.json,
+		result.metadata?.execution?.result?.json?.metrics,
 		result.db_query || result.dbQuery,
 		result.memory,
 		result.admin_browser || result.adminBrowser,
@@ -410,7 +412,8 @@ function normalizeMetricReasons(result, metrics) {
 }
 
 function normalizeCasePerformanceSummaries(result) {
-	const querySources = [result.db_query || result.dbQuery, result.metrics, result.performance_metrics || result.performanceMetrics, result.metadata?.metrics];
+	const executionJson = result.metadata?.execution?.result?.json;
+	const querySources = [result.db_query || result.dbQuery, result.metrics, result.performance_metrics || result.performanceMetrics, result.metadata?.metrics, executionJson, executionJson?.metrics];
 	const browser = result.admin_browser || result.adminBrowser || {};
 	const browserMetrics = result.browser_metrics || result.browserMetrics || browser.browserMetrics || {};
 	const networkMetrics = result.network_metrics || result.networkMetrics || browser.networkMetrics || {};

--- a/wordpress/tests/wordpress-fuzz-schemas-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-schemas-smoke.js
@@ -204,6 +204,23 @@ const performanceEvidenceResult = normalizeWordPressFuzzResult({
 			status: 'passed',
 			metrics: { queryCount: 'many' },
 		},
+		{
+			id: 'runtime-workload-case',
+			status: 'passed',
+			metadata: {
+				execution: {
+					result: {
+						json: {
+							metrics: {
+								query_count: 2,
+								query_time_ms: 6,
+								top_queries: [{ shape: 'SELECT option_value FROM wp_options WHERE option_name = ?', count: 2 }],
+							},
+						},
+					},
+				},
+			},
+		},
 	],
 });
 
@@ -220,6 +237,9 @@ assert.equal(performanceEvidenceResult.cases[0].performance_metric_reasons.query
 assert.equal(performanceEvidenceResult.cases[1].performance_metric_reasons.query_count.reason, 'metric_not_provided');
 assert.equal(performanceEvidenceResult.cases[2].performance_metric_reasons.query_count.status, 'unsupported');
 assert.equal(performanceEvidenceResult.cases[2].performance_metric_reasons.query_count.source_key, 'queryCount');
+assert.equal(performanceEvidenceResult.cases[3].performance_metrics.query_count, 2);
+assert.equal(performanceEvidenceResult.cases[3].performance_metrics.query_time_ms, 6);
+assert.deepEqual(performanceEvidenceResult.cases[3].performance_summaries.top_queries, [{ shape: 'SELECT option_value FROM wp_options WHERE option_name = ?', count: 2 }]);
 assert.deepEqual(performanceEvidenceResult.cases[0].performance_summaries.top_queries, [{ shape: 'SELECT * FROM wp_posts WHERE ID = ?', count: 4 }]);
 assert.deepEqual(performanceEvidenceResult.cases[0].performance_summaries.top_tables, [{ table: 'wp_posts', count: 5 }]);
 assert.equal(performanceEvidenceResult.cases[0].performance_summaries.browser_network.failed_request_count, 1);
@@ -229,13 +249,13 @@ assert.deepEqual(performanceEvidenceResult.findings.map((finding) => finding.cod
 	'browser_failed_request_count_budget_exceeded',
 ]);
 assert.equal(performanceEvidenceResult.summary.performance_metrics.request_duration_ms, 120);
-assert.equal(performanceEvidenceResult.summary.performance_metrics.query_count, 7);
-assert.equal(performanceEvidenceResult.summary.performance_metrics.query_time_ms, 18);
+assert.equal(performanceEvidenceResult.summary.performance_metrics.query_count, 9);
+assert.equal(performanceEvidenceResult.summary.performance_metrics.query_time_ms, 24);
 assert.equal(performanceEvidenceResult.summary.performance_metrics.memory_peak_bytes, 4096);
 assert.equal(performanceEvidenceResult.summary.performance_metrics.browser_request_count, 9);
 assert.equal(performanceEvidenceResult.summary.performance_metrics.browser_failed_request_count, 1);
 assert.equal(performanceEvidenceResult.summary.performance_metrics.browser_network_idle_ms, 250);
-assert.equal(performanceEvidenceResult.summary.performance_metric_reasons.query_count.observed, 1);
+assert.equal(performanceEvidenceResult.summary.performance_metric_reasons.query_count.observed, 2);
 assert.equal(performanceEvidenceResult.summary.performance_metric_reasons.query_count.missing, 1);
 assert.equal(performanceEvidenceResult.summary.performance_metric_reasons.query_count.unsupported, 1);
 


### PR DESCRIPTION
## Summary
- Read metrics and query summaries from nested Codebox workload execution result JSON.
- Cover runtime-workload metric normalization in the WordPress fuzz schema smoke test.

## Testing
- node wordpress/tests/wordpress-fuzz-schemas-smoke.js
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js
- node wordpress/tests/wordpress-fuzz-runner-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis, code change, test update, and verification.