### PR TITLE
Normalize workload profiler artifact metrics

### DIFF
--- a/wordpress/lib/wordpress-fuzz-schemas.js
+++ b/wordpress/lib/wordpress-fuzz-schemas.js
@@ -220,6 +220,7 @@ function normalizeFuzzCaseResult(result, index) {
 	const metrics = normalizeCasePerformanceMetrics(result);
 	const budgetFindings = normalizeBudgetFindings({ budget, metrics, subject: result.id || `case-${index + 1}` });
 	const status = normalizeCaseStatus(result.status, budgetFindings);
+	const dbQuery = result.db_query || result.dbQuery || nestedExecutionDbQuerySummary(result) || null;
 	if (!CASE_STATUSES.has(status)) {
 		throw new Error(`Unsupported WordPress fuzz case status: ${status}`);
 	}
@@ -238,7 +239,7 @@ function normalizeFuzzCaseResult(result, index) {
 		destructive_reason: result.destructive_reason || result.destructiveReason || null,
 		destructive_reasons: normalizeReasonCodes(result.destructive_reasons || result.destructiveReasons || result.destructive_reason || result.destructiveReason),
 		role_boundary: result.role_boundary || result.roleBoundary || null,
-		db_query: result.db_query || result.dbQuery || null,
+		db_query: dbQuery,
 		admin_browser: result.admin_browser || result.adminBrowser || null,
 		http_guardrail: result.http_guardrail || result.httpGuardrail || null,
 		duration_ms: Number.isFinite(result.duration_ms) ? result.duration_ms : result.durationMs || null,
@@ -362,11 +363,13 @@ function normalizePerformanceBudget(input) {
 
 function normalizeCasePerformanceMetrics(result) {
 	const executionResults = nestedExecutionResultJsons(result);
+	const dbQuerySummary = nestedExecutionDbQuerySummary(result);
 	const sources = [
 		result,
 		result.metrics,
 		result.performance_metrics || result.performanceMetrics,
 		result.metadata?.metrics,
+		dbQuerySummary,
 		result.metadata?.execution?.result?.json,
 		result.metadata?.execution?.result?.json?.metrics,
 		...executionResults,
@@ -417,7 +420,8 @@ function normalizeMetricReasons(result, metrics) {
 function normalizeCasePerformanceSummaries(result) {
 	const executionJson = result.metadata?.execution?.result?.json;
 	const executionResults = nestedExecutionResultJsons(result);
-	const querySources = [result.db_query || result.dbQuery, result.metrics, result.performance_metrics || result.performanceMetrics, result.metadata?.metrics, executionJson, executionJson?.metrics, ...executionResults, ...executionResults.map((entry) => entry?.metrics)];
+	const dbQuerySummary = nestedExecutionDbQuerySummary(result);
+	const querySources = [result.db_query || result.dbQuery, dbQuerySummary, result.metrics, result.performance_metrics || result.performanceMetrics, result.metadata?.metrics, executionJson, executionJson?.metrics, ...executionResults, ...executionResults.map((entry) => entry?.metrics)];
 	const browser = result.admin_browser || result.adminBrowser || {};
 	const browserMetrics = result.browser_metrics || result.browserMetrics || browser.browserMetrics || {};
 	const networkMetrics = result.network_metrics || result.networkMetrics || browser.networkMetrics || {};
@@ -443,6 +447,25 @@ function nestedExecutionResultJsons(result) {
 		return [];
 	}
 	return executions.map((execution) => execution?.result?.json).filter((entry) => entry && typeof entry === 'object' && !Array.isArray(entry));
+}
+
+function nestedExecutionDbQuerySummary(result) {
+	for (const entry of nestedExecutionResultJsons(result)) {
+		const artifacts = entry.artifacts;
+		if (!artifacts || typeof artifacts !== 'object' || Array.isArray(artifacts)) {
+			continue;
+		}
+		const profile = artifacts['rest-db-query-profile'] || artifacts.rest_db_query_profile || artifacts.restDbQueryProfile;
+		const summary = profile?.summary;
+		if (summary && typeof summary === 'object' && !Array.isArray(summary)) {
+			return {
+				...summary,
+				query_time_ms: summary.query_time_ms ?? summary.queryTimeMs ?? summary.total_time_ms ?? summary.totalTimeMs,
+				top_queries: summary.top_queries ?? summary.topQueries ?? profile.cases,
+			};
+		}
+	}
+	return null;
 }
 
 function normalizeBudgetFindings({ budget, metrics, subject }) {

--- a/wordpress/tests/wordpress-fuzz-schemas-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-schemas-smoke.js
@@ -215,10 +215,14 @@ const performanceEvidenceResult = normalizeWordPressFuzzResult({
 								{
 									result: {
 										json: {
-											metrics: {
-												query_count: 2,
-												query_time_ms: 6,
-												top_queries: [{ shape: 'SELECT option_value FROM wp_options WHERE option_name = ?', count: 2 }],
+											artifacts: {
+												'rest-db-query-profile': {
+													summary: {
+														query_count: 2,
+														total_time_ms: 6,
+													},
+													cases: [{ path: '/wc/store/products', summary: { query_count: 2 } }],
+												},
 											},
 										},
 									},
@@ -247,7 +251,8 @@ assert.equal(performanceEvidenceResult.cases[2].performance_metric_reasons.query
 assert.equal(performanceEvidenceResult.cases[2].performance_metric_reasons.query_count.source_key, 'queryCount');
 assert.equal(performanceEvidenceResult.cases[3].performance_metrics.query_count, 2);
 assert.equal(performanceEvidenceResult.cases[3].performance_metrics.query_time_ms, 6);
-assert.deepEqual(performanceEvidenceResult.cases[3].performance_summaries.top_queries, [{ shape: 'SELECT option_value FROM wp_options WHERE option_name = ?', count: 2 }]);
+assert.equal(performanceEvidenceResult.cases[3].db_query.query_count, 2);
+assert.deepEqual(performanceEvidenceResult.cases[3].performance_summaries.top_queries, [{ path: '/wc/store/products', summary: { query_count: 2 } }]);
 assert.deepEqual(performanceEvidenceResult.cases[0].performance_summaries.top_queries, [{ shape: 'SELECT * FROM wp_posts WHERE ID = ?', count: 4 }]);
 assert.deepEqual(performanceEvidenceResult.cases[0].performance_summaries.top_tables, [{ table: 'wp_posts', count: 5 }]);
 assert.equal(performanceEvidenceResult.cases[0].performance_summaries.browser_network.failed_request_count, 1);


### PR DESCRIPTION
## Summary
- Normalize DB query metrics from nested Codebox workload profiler artifact summaries.
- Surface profiler summary data as WordPress fuzz case `db_query`, performance metrics, and query summaries.

## Testing
- node wordpress/tests/wordpress-fuzz-schemas-smoke.js
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js
- node wordpress/tests/wordpress-fuzz-runner-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis, code change, test update, and verification.