### PR TITLE
Preserve normalized fuzz summary metrics

### DIFF
--- a/wordpress/lib/wordpress-fuzz-schemas.js
+++ b/wordpress/lib/wordpress-fuzz-schemas.js
@@ -619,6 +619,7 @@ function normalizeWordPressFuzzResult(result) {
 	const resultBudget = normalizePerformanceBudget(result.budget || result.budgets || result.performance_budget || result.performanceBudget || result.metadata?.budget || result.metadata?.budgets);
 	const resultBudgetFindings = normalizeBudgetFindings({ budget: resultBudget, metrics: performanceMetrics, subject: result.id || 'wordpress-fuzz-result' });
 	const summary = {
+		...(result.summary || {}),
 		...caseSummary,
 		case_counts: { ...caseSummary, ...(result.summary?.case_counts || result.summary?.caseCounts || {}) },
 		surface_count: countUnique(cases, 'surface_id'),
@@ -632,7 +633,6 @@ function normalizeWordPressFuzzResult(result) {
 		performance_metrics: performanceMetrics,
 		performance_metric_reasons: summarizePerformanceMetricReasons(cases),
 		budget_failure_count: countBudgetFindings(cases) + resultBudgetFindings.length,
-		...(result.summary || {}),
 	};
 	const status = normalizeFuzzStatus(result.status || (summary.failed || summary.errored || summary.budget_failure_count ? 'failed' : 'passed'));
 	if (!RESULT_STATUSES.has(status)) {

--- a/wordpress/tests/wordpress-fuzz-schemas-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-schemas-smoke.js
@@ -172,6 +172,12 @@ assert.equal(failingBudgetResult.summary.performance_metrics.query_count, 5);
 const performanceEvidenceResult = normalizeWordPressFuzzResult({
 	schema: WORDPRESS_FUZZ_RESULT_SCHEMA,
 	id: 'performance-evidence-result',
+	summary: {
+		performance_metrics: {
+			query_count: 0,
+			query_time_ms: 0,
+		},
+	},
 	cases: [
 		{
 			id: 'profiled-rest-case',


### PR DESCRIPTION
## Summary
- Keep normalized WordPress fuzz summary metrics from being overwritten by stale input summary values.
- Add smoke coverage for stale zero input summaries.

## Testing
- node wordpress/tests/wordpress-fuzz-schemas-smoke.js
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js
- node wordpress/tests/wordpress-fuzz-runner-smoke.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis, code change, test update, and verification.