### PR TITLE
Normalize bench scenario profiler metrics

### DIFF
--- a/wordpress/lib/wordpress-fuzz-schemas.js
+++ b/wordpress/lib/wordpress-fuzz-schemas.js
@@ -451,21 +451,32 @@ function nestedExecutionResultJsons(result) {
 
 function nestedExecutionDbQuerySummary(result) {
 	for (const entry of nestedExecutionResultJsons(result)) {
-		const artifacts = entry.artifacts;
-		if (!artifacts || typeof artifacts !== 'object' || Array.isArray(artifacts)) {
-			continue;
-		}
-		const profile = artifacts['rest-db-query-profile'] || artifacts.rest_db_query_profile || artifacts.restDbQueryProfile;
-		const summary = profile?.summary;
-		if (summary && typeof summary === 'object' && !Array.isArray(summary)) {
-			return {
-				...summary,
-				query_time_ms: summary.query_time_ms ?? summary.queryTimeMs ?? summary.total_time_ms ?? summary.totalTimeMs,
-				top_queries: summary.top_queries ?? summary.topQueries ?? profile.cases,
-			};
+		for (const artifacts of nestedExecutionArtifactSources(entry)) {
+			const profile = artifacts['rest-db-query-profile'] || artifacts.rest_db_query_profile || artifacts.restDbQueryProfile;
+			const summary = profile?.summary;
+			if (summary && typeof summary === 'object' && !Array.isArray(summary)) {
+				return {
+					...summary,
+					query_time_ms: summary.query_time_ms ?? summary.queryTimeMs ?? summary.total_time_ms ?? summary.totalTimeMs,
+					top_queries: summary.top_queries ?? summary.topQueries ?? profile.cases,
+				};
+			}
 		}
 	}
 	return null;
+}
+
+function nestedExecutionArtifactSources(entry) {
+	const sources = [];
+	if (entry?.artifacts && typeof entry.artifacts === 'object' && !Array.isArray(entry.artifacts)) {
+		sources.push(entry.artifacts);
+	}
+	for (const scenario of Array.isArray(entry?.scenarios) ? entry.scenarios : []) {
+		if (scenario?.artifacts && typeof scenario.artifacts === 'object' && !Array.isArray(scenario.artifacts)) {
+			sources.push(scenario.artifacts);
+		}
+	}
+	return sources;
 }
 
 function normalizeBudgetFindings({ budget, metrics, subject }) {

--- a/wordpress/tests/wordpress-fuzz-schemas-smoke.js
+++ b/wordpress/tests/wordpress-fuzz-schemas-smoke.js
@@ -221,15 +221,19 @@ const performanceEvidenceResult = normalizeWordPressFuzzResult({
 								{
 									result: {
 										json: {
-											artifacts: {
-												'rest-db-query-profile': {
-													summary: {
-														query_count: 2,
-														total_time_ms: 6,
+											scenarios: [
+												{
+													artifacts: {
+														'rest-db-query-profile': {
+															summary: {
+																query_count: 2,
+																total_time_ms: 6,
+															},
+															cases: [{ path: '/wc/store/products', summary: { query_count: 2 } }],
+														},
 													},
-													cases: [{ path: '/wc/store/products', summary: { query_count: 2 } }],
 												},
-											},
+											],
 										},
 									},
 								},


### PR DESCRIPTION
## Summary
- Read REST DB query profiler summaries from Codebox bench scenario artifacts.
- Preserve the composable WordPress fuzz result contract by normalizing scenario-level profiler output into case metrics, DB query summaries, and query lists.

## Testing
- node wordpress/tests/wordpress-fuzz-schemas-smoke.js
- node wordpress/tests/wp-codebox-fuzz-run-smoke.js
- node wordpress/tests/wordpress-fuzz-runner-smoke.js
- Local replay against `woo-db-api-rest-query-profile-20260625-15` artifact extracted query_count=2, query_time_ms=3.000020980834961, and 80 query entries.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis, code change, test update, and verification.