### PR TITLE
Compare SSI fixture matrix artifacts

### DIFF
--- a/wordpress/lib/static-site-fixture-matrix.js
+++ b/wordpress/lib/static-site-fixture-matrix.js
@@ -10,6 +10,7 @@ const path = require('node:path');
 
 const FIXTURE_MATRIX_SCHEMA = 'homeboy/static-site-fixture-matrix/v1';
 const FIXTURE_MATRIX_RESULT_SCHEMA = 'homeboy/static-site-fixture-matrix-result/v1';
+const FIXTURE_MATRIX_COMPARISON_SCHEMA = 'homeboy/static-site-fixture-matrix-comparison/v1';
 const WEBSITE_ARTIFACT_SCHEMA = 'blocks-engine/php-transformer/site-artifact/v1';
 
 const DEFAULT_ENTRYPOINT = 'website/index.html';
@@ -250,6 +251,63 @@ function writeStaticSiteFixtureMatrixResultArtifacts(input = {}) {
 	return result;
 }
 
+function compareStaticSiteFixtureMatrixArtifacts(input = {}) {
+	const baseline = normalizeComparisonInput(input.baseline || input.compareTo || input.compare_to, 'baseline');
+	const candidate = normalizeComparisonInput(input.candidate || input.result || input.current, 'candidate');
+	const baselineFindings = normalizedComparisonFindings(baseline);
+	const candidateFindings = normalizedComparisonFindings(candidate);
+	const baselineByIdentity = new Map(baselineFindings.map((finding) => [finding.identity, finding]));
+	const candidateByIdentity = new Map(candidateFindings.map((finding) => [finding.identity, finding]));
+	const resolved = baselineFindings.filter((finding) => !candidateByIdentity.has(finding.identity));
+	const added = candidateFindings.filter((finding) => !baselineByIdentity.has(finding.identity));
+	const persistent = candidateFindings.filter((finding) => baselineByIdentity.has(finding.identity));
+	const groupDeltas = deltaCounts(countBy(candidateFindings, 'group_key'), countBy(baselineFindings, 'group_key'));
+	const kindDeltas = deltaCounts(countBy(candidateFindings, 'kind'), countBy(baselineFindings, 'kind'));
+	const fixtureDeltas = deltaCounts(countBy(candidateFindings, 'fixture_id'), countBy(baselineFindings, 'fixture_id'));
+	const bucketDeltas = parserBucketDeltas(baselineFindings, candidateFindings);
+
+	return {
+		schema: FIXTURE_MATRIX_COMPARISON_SCHEMA,
+		baseline: comparisonSourceSummary(baseline),
+		candidate: comparisonSourceSummary(candidate),
+		summary: {
+			baseline_finding_count: baselineFindings.length,
+			candidate_finding_count: candidateFindings.length,
+			finding_delta: candidateFindings.length - baselineFindings.length,
+			resolved_count: resolved.length,
+			new_count: added.length,
+			persistent_count: persistent.length,
+			group_deltas: groupDeltas,
+			kind_deltas: kindDeltas,
+			fixture_deltas: fixtureDeltas,
+		},
+		stable_finding_identities: {
+			resolved: resolved.map(comparisonFindingRef),
+			new: added.map(comparisonFindingRef),
+			persistent: persistent.map(comparisonFindingRef),
+		},
+		parser_improvement_diagnostics: {
+			total_delta: candidateFindings.length - baselineFindings.length,
+			group_deltas: groupDeltas,
+			kind_deltas: kindDeltas,
+			fixture_deltas: fixtureDeltas,
+			top_improved_parser_buckets: bucketDeltas.filter((bucket) => bucket.delta < 0).slice(0, 10),
+			top_regressed_parser_buckets: bucketDeltas.filter((bucket) => bucket.delta > 0).slice(0, 10),
+		},
+	};
+}
+
+function writeStaticSiteFixtureMatrixComparisonArtifact(input = {}) {
+	const outputDirectory = requiredString(input.outputDirectory || input.output_directory, 'outputDirectory');
+	const comparison = input.comparison || compareStaticSiteFixtureMatrixArtifacts(input);
+	const filePath = path.join(outputDirectory, 'static-site-fixture-matrix-comparison.json');
+	writeJsonFile(filePath, comparison);
+	return {
+		comparison,
+		artifact_ref: artifactRef('static-site-fixture-matrix-comparison', filePath, 'diagnostic'),
+	};
+}
+
 function writeStaticSiteFixtureMatrixArtifacts(input = {}) {
 	const outputDirectory = requiredString(input.outputDirectory || input.output_directory, 'outputDirectory');
 	const matrix = input.matrix || createStaticSiteFixtureMatrix(input);
@@ -277,6 +335,145 @@ function writeStaticSiteFixtureMatrixArtifacts(input = {}) {
 			artifactRef('finding-packets', path.join(outputDirectory, 'finding-packets.json'), 'diagnostic'),
 		],
 	};
+}
+
+function normalizeComparisonInput(value, name) {
+	if (typeof value === 'string') {
+		return normalizeComparisonPayload(readStaticSiteFixtureMatrixArtifact(value), { source_path: path.resolve(value) });
+	}
+	if (!value || typeof value !== 'object') {
+		throw new TypeError(`${name} comparison input must be a matrix result, finding packet array, artifact file, or artifact directory.`);
+	}
+	return normalizeComparisonPayload(value, {});
+}
+
+function readStaticSiteFixtureMatrixArtifact(sourcePath) {
+	const resolved = path.resolve(requiredString(sourcePath, 'comparison artifact path'));
+	const stats = fs.statSync(resolved);
+	if (stats.isDirectory()) {
+		for (const fileName of ['static-site-fixture-matrix-result.json', 'finding-packets.json']) {
+			const artifactPath = path.join(resolved, fileName);
+			const artifact = readJsonFileIfExists(artifactPath);
+			if (artifact) {
+				return artifactWithSourcePath(artifact, artifactPath);
+			}
+		}
+		throw new Error(`No static-site fixture matrix result artifact found in ${resolved}.`);
+	}
+	return artifactWithSourcePath(JSON.parse(fs.readFileSync(resolved, 'utf8')), resolved);
+}
+
+function artifactWithSourcePath(artifact, sourcePath) {
+	if (Array.isArray(artifact)) {
+		return { source_path: sourcePath, findings: artifact };
+	}
+	return { ...artifact, source_path: sourcePath };
+}
+
+function normalizeComparisonPayload(payload, context = {}) {
+	if (Array.isArray(payload)) {
+		return {
+			source_path: context.source_path || '',
+			summary: { finding_count: payload.length },
+			findings: payload,
+			fixtures: [],
+		};
+	}
+	return {
+		source_path: payload.source_path || context.source_path || '',
+		matrix_id: payload.matrix_id || '',
+		summary: payload.summary || { finding_count: normalizeArray(payload.findings).length },
+		findings: normalizeArray(payload.findings || payload.finding_packets || payload.findingPackets),
+		fixtures: normalizeArray(payload.fixtures),
+	};
+}
+
+function normalizedComparisonFindings(source) {
+	return normalizeArray(source.findings).map((finding, index) => {
+		const normalized = normalizeComparisonFinding(finding, index);
+		return {
+			...normalized,
+			identity: stableFindingIdentity(normalized),
+		};
+	});
+}
+
+function normalizeComparisonFinding(finding, index) {
+	const raw = finding && typeof finding === 'object' ? finding : { reason: String(finding || '') };
+	return {
+		id: raw.id || '',
+		kind: raw.kind || raw.code || 'static_site_fixture_diagnostic',
+		group_key: raw.group_key || raw.category || 'static_site_import_quality',
+		fixture_id: raw.fixture_id || raw.fixtureId || '',
+		path: raw.path || raw.source_path || '',
+		selector: raw.selector || '',
+		reason: raw.reason || raw.message || raw.detail || '',
+		index,
+		raw,
+	};
+}
+
+function stableFindingIdentity(finding) {
+	return [
+		finding.fixture_id,
+		finding.group_key,
+		finding.kind,
+		finding.selector,
+		finding.path,
+		finding.reason,
+	].map((part) => String(part || '').trim().toLowerCase()).join('::');
+}
+
+function comparisonFindingRef(finding) {
+	return {
+		identity: finding.identity,
+		id: finding.id,
+		fixture_id: finding.fixture_id,
+		group_key: finding.group_key,
+		kind: finding.kind,
+		reason: finding.reason,
+	};
+}
+
+function comparisonSourceSummary(source) {
+	return compactObject({
+		source_path: source.source_path,
+		matrix_id: source.matrix_id,
+		fixture_count: source.summary?.fixture_count || source.fixtures?.length,
+		finding_count: source.findings.length,
+	});
+}
+
+function countBy(items, key) {
+	return items.reduce((counts, item) => {
+		const value = item[key] || 'unknown';
+		counts[value] = (counts[value] || 0) + 1;
+		return counts;
+	}, {});
+}
+
+function deltaCounts(candidateCounts, baselineCounts) {
+	const keys = [...new Set([...Object.keys(candidateCounts), ...Object.keys(baselineCounts)])].sort();
+	return keys.map((key) => ({
+		key,
+		baseline: baselineCounts[key] || 0,
+		candidate: candidateCounts[key] || 0,
+		delta: (candidateCounts[key] || 0) - (baselineCounts[key] || 0),
+	}));
+}
+
+function parserBucketDeltas(baselineFindings, candidateFindings) {
+	return deltaCounts(countParserBuckets(candidateFindings), countParserBuckets(baselineFindings))
+		.filter((bucket) => bucket.delta !== 0)
+		.sort((left, right) => Math.abs(right.delta) - Math.abs(left.delta) || left.key.localeCompare(right.key));
+}
+
+function countParserBuckets(findings) {
+	return findings.reduce((counts, finding) => {
+		const key = `${finding.group_key || 'unknown'}:${finding.kind || 'unknown'}`;
+		counts[key] = (counts[key] || 0) + 1;
+		return counts;
+	}, {});
 }
 
 function findingsForFixtureResult(result, context = {}) {
@@ -824,16 +1021,19 @@ function shellToken(value) {
 }
 
 module.exports = {
+	FIXTURE_MATRIX_COMPARISON_SCHEMA,
 	FIXTURE_MATRIX_RESULT_SCHEMA,
 	FIXTURE_MATRIX_SCHEMA,
 	WEBSITE_ARTIFACT_SCHEMA,
 	buildStaticSiteFixtureArtifact,
 	buildStaticSiteFixtureMatrixRecipe,
 	classifyStaticSiteFinding,
+	compareStaticSiteFixtureMatrixArtifacts,
 	collectStaticSiteFixtureMatrixRunResults,
 	createStaticSiteFixtureMatrix,
 	discoverStaticSiteFixtures,
 	normalizeStaticSiteFixtureMatrixResult,
+	writeStaticSiteFixtureMatrixComparisonArtifact,
 	writeStaticSiteFixtureMatrixResultArtifacts,
 	writeStaticSiteFixtureMatrixArtifacts,
 };

--- a/wordpress/scripts/static-site-fixture-matrix.mjs
+++ b/wordpress/scripts/static-site-fixture-matrix.mjs
@@ -16,6 +16,7 @@ const {
 	buildStaticSiteFixtureMatrixRecipe,
 	collectStaticSiteFixtureMatrixRunResults,
 	createStaticSiteFixtureMatrix,
+	writeStaticSiteFixtureMatrixComparisonArtifact,
 	writeStaticSiteFixtureMatrixResultArtifacts,
 	writeStaticSiteFixtureMatrixArtifacts,
 } = require('../lib/static-site-fixture-matrix');
@@ -23,9 +24,17 @@ const { runWpCodeboxRecipe } = require('../lib/wp-codebox-recipe-helper');
 
 async function main() {
 	const options = parseArgs(process.argv.slice(2));
-	if (options.help || !options.fixtureRoot) {
+	if (options.help) {
 		printHelp();
-		process.exit(options.help ? 0 : 1);
+		process.exit(0);
+	}
+	if (options.compareTo && options.candidate) {
+		writeComparisonReport(options);
+		return;
+	}
+	if (!options.fixtureRoot) {
+		printHelp();
+		process.exit(1);
 	}
 
 	const outputDirectory = path.resolve(options.outputDirectory || path.join(process.cwd(), 'artifacts', 'static-site-fixture-matrix'));
@@ -84,6 +93,14 @@ async function main() {
 			result: collectedResult,
 		});
 	}
+	let comparisonArtifact = null;
+	if (options.compareTo) {
+		comparisonArtifact = writeStaticSiteFixtureMatrixComparisonArtifact({
+			outputDirectory,
+			baseline: path.resolve(options.compareTo),
+			candidate: collectedResult,
+		});
+	}
 
 	const summary = {
 		schema: 'homeboy/static-site-fixture-matrix-cli-run/v1',
@@ -92,9 +109,11 @@ async function main() {
 		fixture_count: matrix.count,
 		output_directory: outputDirectory,
 		recipe_file: recipeFile,
-		artifact_refs: written.artifact_refs,
+		artifact_refs: comparisonArtifact ? [...written.artifact_refs, comparisonArtifact.artifact_ref] : written.artifact_refs,
 		result_file: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
 		result_summary: collectedResult.summary,
+		comparison_file: comparisonArtifact ? comparisonArtifact.artifact_ref.path : null,
+		comparison_summary: comparisonArtifact ? comparisonArtifact.comparison.summary : null,
 		runtime: runtime ? { exit_code: runtime.exitCode, output_file: runtime.outputFile, error: runtimeError ? runtimeError.message : '' } : null,
 	};
 	fs.writeFileSync(path.join(outputDirectory, 'cli-run.json'), `${JSON.stringify(summary, null, 2)}\n`);
@@ -102,6 +121,24 @@ async function main() {
 	if (runtimeError) {
 		process.exitCode = runtime.exitCode || 1;
 	}
+}
+
+function writeComparisonReport(options) {
+	const candidate = path.resolve(options.candidate);
+	const outputDirectory = path.resolve(options.outputDirectory || path.dirname(candidate));
+	fs.mkdirSync(outputDirectory, { recursive: true });
+	const comparisonArtifact = writeStaticSiteFixtureMatrixComparisonArtifact({
+		outputDirectory,
+		baseline: path.resolve(options.compareTo),
+		candidate,
+	});
+	const summary = {
+		schema: 'homeboy/static-site-fixture-matrix-comparison-cli-run/v1',
+		comparison_file: comparisonArtifact.artifact_ref.path,
+		comparison_summary: comparisonArtifact.comparison.summary,
+	};
+	fs.writeFileSync(path.join(outputDirectory, 'cli-run.json'), `${JSON.stringify(summary, null, 2)}\n`);
+	process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
 }
 
 function parseJsonText(text) {
@@ -146,7 +183,7 @@ function camelCase(value) {
 }
 
 function printHelp() {
-	process.stdout.write(`Usage: node scripts/static-site-fixture-matrix.mjs --fixture-root <path> [options]\n\nOptions:\n  --output-directory <path>             Directory for matrix artifacts and WP Codebox recipe.\n  --entrypoint <file>                   Fixture entry file name. Default: index.html.\n  --max-depth <number>                  Discovery depth below fixture root. Default: 2.\n  --wordpress-version <ver>             WP Codebox WordPress runtime version. Default: latest.\n  --static-site-importer-path <path>    Local Static Site Importer plugin source to mount/install.\n  --static-site-importer-plugin <file>  Plugin file to activate. Default: <slug>/<slug>.php.\n  --static-site-importer-slug <slug>    Plugin slug for the mounted source. Default: source basename.\n  --wp-codebox-bin <path>               WP Codebox CLI binary for --run.\n  --run                                 Execute the generated recipe with WP Codebox.\n`);
+	process.stdout.write(`Usage: node scripts/static-site-fixture-matrix.mjs --fixture-root <path> [options]\n       node scripts/static-site-fixture-matrix.mjs --compare-to <old> --candidate <new> [--output-directory <path>]\n\nOptions:\n  --output-directory <path>             Directory for matrix artifacts and WP Codebox recipe.\n  --entrypoint <file>                   Fixture entry file name. Default: index.html.\n  --max-depth <number>                  Discovery depth below fixture root. Default: 2.\n  --wordpress-version <ver>             WP Codebox WordPress runtime version. Default: latest.\n  --static-site-importer-path <path>    Local Static Site Importer plugin source to mount/install.\n  --static-site-importer-plugin <file>  Plugin file to activate. Default: <slug>/<slug>.php.\n  --static-site-importer-slug <slug>    Plugin slug for the mounted source. Default: source basename.\n  --compare-to <path>                   Previous matrix result artifact, finding packet artifact, or artifact directory.\n  --candidate <path>                    Current matrix result artifact, finding packet artifact, or artifact directory for comparison-only mode.\n  --wp-codebox-bin <path>               WP Codebox CLI binary for --run.\n  --run                                 Execute the generated recipe with WP Codebox.\n`);
 }
 
 main().catch((error) => {

--- a/wordpress/tests/static-site-fixture-matrix-smoke.js
+++ b/wordpress/tests/static-site-fixture-matrix-smoke.js
@@ -3,6 +3,7 @@
 /* eslint-disable no-console */
 
 const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -12,10 +13,12 @@ const {
 	buildStaticSiteFixtureArtifact,
 	buildStaticSiteFixtureMatrixRecipe,
 	classifyStaticSiteFinding,
+	compareStaticSiteFixtureMatrixArtifacts,
 	collectStaticSiteFixtureMatrixRunResults,
 	createStaticSiteFixtureMatrix,
 	discoverStaticSiteFixtures,
 	normalizeStaticSiteFixtureMatrixResult,
+	writeStaticSiteFixtureMatrixComparisonArtifact,
 	writeStaticSiteFixtureMatrixResultArtifacts,
 	writeStaticSiteFixtureMatrixArtifacts,
 } = require('../lib/static-site-fixture-matrix');
@@ -137,6 +140,59 @@ async function main() {
 		assert.equal(written.artifact_refs.length, 4);
 		assert.equal(readJson(path.join(outputDirectory, 'summary.json')).finding_count, 3);
 		assert.equal(readJson(path.join(outputDirectory, '41-generative-art-studio', 'artifact.json')).entry_path, 'website/index.html');
+
+		const candidateResult = normalizeStaticSiteFixtureMatrixResult({
+			matrix,
+			results: [
+				{
+					fixture_id: 'saveweb2zip-com-liquidbonsai-com',
+					status: 'failed',
+					diagnostics: [
+						{ code: 'runtime_dependency_target_missing', message: 'Missing target #canvas' },
+					],
+				},
+				{
+					fixture_id: '41-generative-art-studio',
+					status: 'failed',
+					diagnostics: [
+						{ message: 'The imported page has default gray buttons' },
+					],
+				},
+			],
+		});
+		const candidateDirectory = path.join(root, 'candidate-artifacts');
+		writeStaticSiteFixtureMatrixArtifacts({ outputDirectory: candidateDirectory, matrix, result: candidateResult });
+		const comparison = compareStaticSiteFixtureMatrixArtifacts({
+			baseline: outputDirectory,
+			candidate: candidateDirectory,
+		});
+		assert.equal(comparison.schema, 'homeboy/static-site-fixture-matrix-comparison/v1');
+		assert.equal(comparison.summary.finding_delta, -1);
+		assert.equal(comparison.summary.resolved_count, 2);
+		assert.equal(comparison.summary.new_count, 1);
+		assert.equal(comparison.summary.persistent_count, 1);
+		assert.equal(comparison.stable_finding_identities.persistent[0].fixture_id, 'saveweb2zip-com-liquidbonsai-com');
+		assert.equal(comparison.summary.group_deltas.find((delta) => delta.key === 'dropped_images').delta, -1);
+		assert.equal(comparison.summary.kind_deltas.find((delta) => delta.key === 'static_site_fixture_diagnostic').delta, -1);
+		assert.equal(comparison.summary.fixture_deltas.find((delta) => delta.key === '41-generative-art-studio').delta, -1);
+		assert.equal(comparison.parser_improvement_diagnostics.total_delta, -1);
+		assert.equal(comparison.parser_improvement_diagnostics.top_improved_parser_buckets[0].key, 'dropped_images:static_site_fixture_diagnostic');
+		assert.equal(comparison.parser_improvement_diagnostics.top_regressed_parser_buckets[0].key, 'button_style_loss:static_site_fixture_diagnostic');
+		const comparisonArtifact = writeStaticSiteFixtureMatrixComparisonArtifact({
+			outputDirectory: candidateDirectory,
+			baseline: outputDirectory,
+			candidate: candidateResult,
+		});
+		assert.equal(readJson(comparisonArtifact.artifact_ref.path).schema, 'homeboy/static-site-fixture-matrix-comparison/v1');
+		const cliComparisonDirectory = path.join(root, 'cli-comparison');
+		const cliComparison = JSON.parse(execFileSync(process.execPath, [
+			path.join(__dirname, '..', 'scripts', 'static-site-fixture-matrix.mjs'),
+			'--compare-to', outputDirectory,
+			'--candidate', candidateDirectory,
+			'--output-directory', cliComparisonDirectory,
+		], { encoding: 'utf8' }));
+		assert.equal(cliComparison.schema, 'homeboy/static-site-fixture-matrix-comparison-cli-run/v1');
+		assert.equal(readJson(cliComparison.comparison_file).summary.resolved_count, 2);
 
 		write(
 			path.join(outputDirectory, '41-generative-art-studio', 'validation-result.json'),


### PR DESCRIPTION
## Summary
- Adds `--compare-to` support for SSI fixture matrix runs.
- Emits a matrix comparison artifact with resolved/new/persistent finding deltas.
- Adds smoke coverage for artifact comparison output.

Fixes #1851.

## Testing
- `git diff --check`
- `node tests/static-site-fixture-matrix-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the implementation.