### PR TITLE
Separate SSI matrix informational findings

### DIFF
--- a/wordpress/lib/static-site-fixture-matrix.js
+++ b/wordpress/lib/static-site-fixture-matrix.js
@@ -11,6 +11,10 @@ const path = require('node:path');
 const FIXTURE_MATRIX_SCHEMA = 'homeboy/static-site-fixture-matrix/v1';
 const FIXTURE_MATRIX_RESULT_SCHEMA = 'homeboy/static-site-fixture-matrix-result/v1';
 const WEBSITE_ARTIFACT_SCHEMA = 'blocks-engine/php-transformer/site-artifact/v1';
+const INFORMATIONAL_CONTRACT_EVIDENCE_KINDS = new Set([
+	'document_metadata_routed',
+	'website_artifact_materialization_contract_note',
+]);
 
 const DEFAULT_ENTRYPOINT = 'website/index.html';
 const DEFAULT_FINDING_GROUPS = {
@@ -191,7 +195,10 @@ function normalizeStaticSiteFixtureMatrixResult(input = {}) {
 	const resultByFixture = new Map(results.map((result) => [result.fixture_id, result]));
 	const fixtureResults = matrix.fixtures.map((fixture) => resultByFixture.get(fixture.id) || normalizeFixtureResult({ fixture_id: fixture.id, status: 'not_run' }));
 	const findings = fixtureResults.flatMap((result) => findingsForFixtureResult(result, { matrix }));
-	const grouped = groupFindings(findings);
+	const actionableFindings = findings.filter((finding) => finding.actionability === 'actionable_quality');
+	const informationalContractEvidence = findings.filter((finding) => finding.actionability === 'informational_contract_evidence');
+	const grouped = groupFindings(actionableFindings);
+	const informationalGrouped = groupFindings(informationalContractEvidence, 'informational_contract_evidence');
 
 	return {
 		schema: FIXTURE_MATRIX_RESULT_SCHEMA,
@@ -202,11 +209,17 @@ function normalizeStaticSiteFixtureMatrixResult(input = {}) {
 			succeeded: fixtureResults.filter((result) => result.status === 'passed').length,
 			failed: fixtureResults.filter((result) => result.status === 'failed').length,
 			not_run: fixtureResults.filter((result) => result.status === 'not_run').length,
-			finding_count: findings.length,
+			finding_count: actionableFindings.length,
+			actionable_finding_count: actionableFindings.length,
+			informational_contract_evidence_count: informationalContractEvidence.length,
+			raw_finding_count: findings.length,
 			groups: Object.fromEntries(Object.entries(grouped).map(([key, items]) => [key, items.length])),
+			informational_contract_evidence_groups: Object.fromEntries(Object.entries(informationalGrouped).map(([key, items]) => [key, items.length])),
 		},
 		fixtures: fixtureResults,
 		findings,
+		actionable_findings: actionableFindings,
+		informational_contract_evidence: informationalContractEvidence,
 		fanout_groups: Object.entries(grouped).map(([group_key, items], index) => ({
 			key: group_key,
 			index,
@@ -308,6 +321,7 @@ function normalizeDiagnosticFinding(diagnostic, result, index) {
 		kind: raw.kind || raw.code || 'static_site_fixture_diagnostic',
 		category: raw.category || group.group_key,
 		group_key: group.group_key,
+		actionability: group.actionability,
 		severity: raw.severity || (result.status === 'failed' ? 'error' : 'warning'),
 		fixture_id: result.fixture_id || '',
 		path: raw.path || raw.source_path || result.fixture_path || '',
@@ -322,21 +336,37 @@ function normalizeDiagnosticFinding(diagnostic, result, index) {
 }
 
 function classifyStaticSiteFinding(input = {}) {
+	if (isInformationalContractEvidence(input)) {
+		return {
+			group_key: 'informational_contract_evidence',
+			actionability: 'informational_contract_evidence',
+			candidate_repo: 'static-site-importer',
+			repair_mode: 'contract-evidence',
+		};
+	}
+
 	const haystack = [input.kind, input.code, input.category, input.message, input.reason, input.detail]
 		.filter(Boolean)
 		.join(' ');
 
 	for (const [group_key, group] of Object.entries(DEFAULT_FINDING_GROUPS)) {
 		if (group.patterns.some((pattern) => pattern.test(haystack))) {
-			return { group_key, candidate_repo: group.candidate_repo, repair_mode: group.repair_mode };
+			return { group_key, actionability: 'actionable_quality', candidate_repo: group.candidate_repo, repair_mode: group.repair_mode };
 		}
 	}
 
 	return {
 		group_key: DEFAULT_FINDING_GROUPS[input.group_key] ? input.group_key : 'static_site_import_quality',
+		actionability: 'actionable_quality',
 		candidate_repo: input.candidate_repo || 'static-site-importer',
 		repair_mode: input.repair_mode || 'import-validation',
 	};
+}
+
+function isInformationalContractEvidence(input = {}) {
+	return [input.kind, input.code, input.category, input.group_key]
+		.filter(Boolean)
+		.some((value) => INFORMATIONAL_CONTRACT_EVIDENCE_KINDS.has(String(value)));
 }
 
 function normalizeFixture(input) {
@@ -394,7 +424,8 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
 		merged.message && isFailurePayload(merged) ? merged.message : '',
 		codeboxError && payloads.length === 0 ? codeboxError.message || String(codeboxError) : '',
 	]);
-	const success = inferFixtureSuccess(merged, diagnostics, error, payloads.length);
+	const actionableDiagnostics = diagnostics.filter((diagnostic) => !isInformationalContractEvidence(diagnostic));
+	const success = inferFixtureSuccess(merged, actionableDiagnostics, error, payloads.length);
 	const status = fixtureStatus(payloads.length, error, success);
 
 	return normalizeFixtureResult({
@@ -631,9 +662,9 @@ function artifactPathForFixture(fixture, artifactsDirectory) {
 	return path.join(artifactsDirectory, fixture.id, 'artifact.json');
 }
 
-function groupFindings(findings) {
+function groupFindings(findings, defaultGroup = 'static_site_import_quality') {
 	return findings.reduce((groups, finding) => {
-		const key = finding.group_key || 'static_site_import_quality';
+		const key = finding.group_key || defaultGroup;
 		groups[key] = groups[key] || [];
 		groups[key].push(finding);
 		return groups;

--- a/wordpress/tests/static-site-fixture-matrix-smoke.js
+++ b/wordpress/tests/static-site-fixture-matrix-smoke.js
@@ -123,6 +123,9 @@ async function main() {
 		assert.equal(result.schema, 'homeboy/static-site-fixture-matrix-result/v1');
 		assert.equal(result.summary.failed, 2);
 		assert.equal(result.summary.finding_count, 3);
+		assert.equal(result.summary.actionable_finding_count, 3);
+		assert.equal(result.summary.informational_contract_evidence_count, 0);
+		assert.equal(result.summary.raw_finding_count, 3);
 		assert.equal(result.summary.groups.runtime_target_gap, 1);
 		assert.equal(result.summary.groups.invalid_block_content, 1);
 		assert.equal(result.summary.groups.dropped_images, 1);
@@ -137,6 +140,45 @@ async function main() {
 		assert.equal(written.artifact_refs.length, 4);
 		assert.equal(readJson(path.join(outputDirectory, 'summary.json')).finding_count, 3);
 		assert.equal(readJson(path.join(outputDirectory, '41-generative-art-studio', 'artifact.json')).entry_path, 'website/index.html');
+
+		const contractEvidenceResult = normalizeStaticSiteFixtureMatrixResult({
+			matrix,
+			results: [
+				{
+					fixture_id: 'saveweb2zip-com-liquidbonsai-com',
+					status: 'passed',
+					diagnostics: [
+						{ code: 'website_artifact_materialization_contract_note', message: 'Website artifact materialized for importer contract.' },
+						{ code: 'document_metadata_routed', message: 'Document metadata routed to parser.' },
+					],
+				},
+				{
+					fixture_id: '41-generative-art-studio',
+					status: 'failed',
+					diagnostics: [
+						{ code: 'website_artifact_materialization_contract_note', message: 'Website artifact materialized for importer contract.' },
+						{ message: 'Dropped image asset missing.svg' },
+					],
+				},
+			],
+		});
+		assert.equal(contractEvidenceResult.summary.finding_count, 1);
+		assert.equal(contractEvidenceResult.summary.actionable_finding_count, 1);
+		assert.equal(contractEvidenceResult.summary.informational_contract_evidence_count, 3);
+		assert.equal(contractEvidenceResult.summary.raw_finding_count, 4);
+		assert.equal(contractEvidenceResult.summary.groups.dropped_images, 1);
+		assert.equal(contractEvidenceResult.summary.informational_contract_evidence_groups.informational_contract_evidence, 3);
+		assert.equal(contractEvidenceResult.findings.length, 4);
+		assert.equal(contractEvidenceResult.actionable_findings.length, 1);
+		assert.equal(contractEvidenceResult.informational_contract_evidence.length, 3);
+		assert.deepEqual(contractEvidenceResult.fanout_groups.map((group) => group.key), ['dropped_images']);
+		const contractEvidenceDirectory = path.join(root, 'contract-evidence-artifacts');
+		fs.mkdirSync(contractEvidenceDirectory, { recursive: true });
+		writeStaticSiteFixtureMatrixResultArtifacts({ outputDirectory: contractEvidenceDirectory, matrix, result: contractEvidenceResult });
+		assert.equal(readJson(path.join(contractEvidenceDirectory, 'summary.json')).finding_count, 1);
+		assert.equal(readJson(path.join(contractEvidenceDirectory, 'summary.json')).informational_contract_evidence_count, 3);
+		assert.equal(readJson(path.join(contractEvidenceDirectory, 'finding-packets.json')).length, 4);
+		assert.ok(readJson(path.join(contractEvidenceDirectory, 'finding-packets.json')).some((finding) => finding.kind === 'document_metadata_routed'));
 
 		write(
 			path.join(outputDirectory, '41-generative-art-studio', 'validation-result.json'),
@@ -199,6 +241,32 @@ async function main() {
 		assert.equal(studioResult.import_report.report.quality.fallback_count, 1);
 		assert.equal(studioResult.missing_assets[0].path, 'missing.svg');
 		assert.ok(studioResult.artifact_refs.some((ref) => ref.path.endsWith('validation-result.json')));
+
+		const informationalOnlyDirectory = path.join(root, 'informational-only-artifacts');
+		const informationalOnlyMatrix = createStaticSiteFixtureMatrix({
+			id: 'informational-only-run',
+			fixtures: matrix.fixtures,
+		});
+		writeStaticSiteFixtureMatrixArtifacts({ outputDirectory: informationalOnlyDirectory, matrix: informationalOnlyMatrix });
+		write(
+			path.join(informationalOnlyDirectory, 'saveweb2zip-com-liquidbonsai-com', 'validation-result.json'),
+			JSON.stringify({
+				fixture_id: 'saveweb2zip-com-liquidbonsai-com',
+				success: true,
+				diagnostics: [
+					{ code: 'website_artifact_materialization_contract_note', message: 'Website artifact materialized for importer contract.' },
+					{ code: 'document_metadata_routed', message: 'Document metadata routed to parser.' },
+				],
+			})
+		);
+		const informationalOnly = collectStaticSiteFixtureMatrixRunResults({
+			matrix: informationalOnlyMatrix,
+			outputDirectory: informationalOnlyDirectory,
+		});
+		assert.equal(informationalOnly.fixtures.find((fixture) => fixture.fixture_id === 'saveweb2zip-com-liquidbonsai-com').status, 'passed');
+		assert.equal(informationalOnly.summary.finding_count, 1);
+		assert.equal(informationalOnly.summary.informational_contract_evidence_count, 2);
+		assert.equal(informationalOnly.summary.raw_finding_count, 3);
 
 		const partialDirectory = path.join(root, 'partial-artifacts');
 		const partialMatrix = createStaticSiteFixtureMatrix({


### PR DESCRIPTION
## Summary
- Separates actionable SSI matrix quality findings from informational contract evidence.
- Preserves raw diagnostic packets while reducing noisy score-affecting findings.
- Adds smoke coverage for the informational/actionable split.

Fixes #1852.

## Testing
- `git diff --check`
- `node tests/static-site-fixture-matrix-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the implementation.