### PR TITLE
Validate SSI matrix plugin paths

### DIFF
--- a/wordpress/lib/static-site-fixture-matrix.js
+++ b/wordpress/lib/static-site-fixture-matrix.js
@@ -161,6 +161,7 @@ function buildStaticSiteFixtureMatrixRecipe(input = {}) {
 		artifacts: {
 			directory: artifactsDirectory,
 		},
+		...(staticSiteImporter ? { metadata: { static_site_importer: staticSiteImporter.metadata } } : {}),
 	};
 }
 
@@ -170,19 +171,78 @@ function normalizeStaticSiteImporterPlugin(input = {}) {
 		return null;
 	}
 
-	const slugValue = input.staticSiteImporterSlug || input.static_site_importer_slug || path.basename(source);
-	const pluginFile = input.staticSiteImporterPlugin || input.static_site_importer_plugin || `${slugValue}/${slugValue}.php`;
+	const resolved = resolveStaticSiteImporterPlugin(source, input);
 	return {
 		extraPlugin: {
-			source,
-			slug: slugValue,
+			source: resolved.source,
+			slug: resolved.slug,
 			activate: true,
 		},
 		activationStep: {
 			command: 'wordpress.wp-cli',
-			args: [`command=plugin activate ${pluginFile}`],
+			args: [`command=plugin activate ${resolved.plugin_file}`],
 		},
+		metadata: resolved,
 	};
+}
+
+function resolveStaticSiteImporterPlugin(source, input = {}) {
+	const sourceDirectory = requiredDirectory(source, 'staticSiteImporterPath');
+	const explicitSlug = firstString([input.staticSiteImporterSlug, input.static_site_importer_slug]);
+	const explicitPluginFile = firstString([input.staticSiteImporterPlugin, input.static_site_importer_plugin]);
+	const sourcePluginFile = explicitPluginFile ? validateStaticSiteImporterPluginFile(sourceDirectory, explicitPluginFile) : inferStaticSiteImporterSourcePluginFile(sourceDirectory);
+	const slugValue = explicitSlug || (explicitPluginFile ? pluginSlugFromPluginFile(explicitPluginFile) : path.basename(sourcePluginFile, '.php'));
+	const pluginFile = `${slugValue}/${sourcePluginFile}`;
+
+	return {
+		source: sourceDirectory,
+		slug: slugValue,
+		plugin_file: pluginFile,
+		source_plugin_file: sourcePluginFile,
+	};
+}
+
+function validateStaticSiteImporterPluginFile(sourceDirectory, pluginFile) {
+	if (!/^[^/\\]+\/[^/\\]+\.php$/.test(pluginFile)) {
+		throw new Error(`staticSiteImporterPlugin must be a plugin path like slug/plugin.php: ${pluginFile}`);
+	}
+	const sourcePluginFile = path.basename(pluginFile);
+	const sourcePluginPath = path.join(sourceDirectory, sourcePluginFile);
+	if (!fs.existsSync(sourcePluginPath) || !fs.statSync(sourcePluginPath).isFile()) {
+		throw new Error(`Static Site Importer plugin file ${sourcePluginFile} was not found in ${sourceDirectory}. Pass --static-site-importer-plugin with the installed plugin path or use a source directory containing the plugin entry file.`);
+	}
+	return sourcePluginFile;
+}
+
+function inferStaticSiteImporterSourcePluginFile(sourceDirectory) {
+	const staticSiteImporterFile = path.join(sourceDirectory, 'static-site-importer.php');
+	if (fs.existsSync(staticSiteImporterFile) && fs.statSync(staticSiteImporterFile).isFile()) {
+		return 'static-site-importer.php';
+	}
+
+	const candidates = fs.readdirSync(sourceDirectory, { withFileTypes: true })
+		.filter((entry) => entry.isFile() && entry.name.endsWith('.php'))
+		.map((entry) => entry.name)
+		.filter((fileName) => hasWordPressPluginHeader(path.join(sourceDirectory, fileName)))
+		.sort((left, right) => left.localeCompare(right));
+
+	if (candidates.length === 1) {
+		return candidates[0];
+	}
+	if (candidates.length > 1) {
+		throw new Error(`Ambiguous Static Site Importer plugin entry file in ${sourceDirectory}: ${candidates.join(', ')}. Pass --static-site-importer-plugin <slug/plugin.php> and --static-site-importer-slug <slug>.`);
+	}
+
+	throw new Error(`Unable to infer Static Site Importer plugin entry file in ${sourceDirectory}. Expected static-site-importer.php or exactly one root PHP file with a WordPress Plugin Name header.`);
+}
+
+function hasWordPressPluginHeader(filePath) {
+	const header = fs.readFileSync(filePath, 'utf8').slice(0, 8192);
+	return /^\s*\*?\s*Plugin Name\s*:/im.test(header);
+}
+
+function pluginSlugFromPluginFile(pluginFile) {
+	return pluginFile.split(/[\\/]/)[0];
 }
 
 function normalizeStaticSiteFixtureMatrixResult(input = {}) {
@@ -197,6 +257,7 @@ function normalizeStaticSiteFixtureMatrixResult(input = {}) {
 		schema: FIXTURE_MATRIX_RESULT_SCHEMA,
 		matrix_id: matrix.id,
 		fixture_root: matrix.fixture_root,
+		metadata: normalizeStaticSiteFixtureMatrixMetadata(input),
 		summary: {
 			fixture_count: matrix.fixtures.length,
 			succeeded: fixtureResults.filter((result) => result.status === 'passed').length,
@@ -235,7 +296,7 @@ function collectStaticSiteFixtureMatrixRunResults(input = {}) {
 		});
 	});
 
-	return normalizeStaticSiteFixtureMatrixResult({ matrix, results });
+	return normalizeStaticSiteFixtureMatrixResult({ ...input, matrix, results });
 }
 
 function writeStaticSiteFixtureMatrixResultArtifacts(input = {}) {
@@ -383,6 +444,15 @@ function normalizeFixtureResult(input) {
 		artifacts: input.artifacts || {},
 		raw: input,
 	};
+}
+
+function normalizeStaticSiteFixtureMatrixMetadata(input = {}) {
+	const metadata = compactObject(objectValue(input.metadata));
+	const staticSiteImporter = normalizeStaticSiteImporterPlugin(input);
+	if (staticSiteImporter) {
+		metadata.static_site_importer = staticSiteImporter.metadata;
+	}
+	return metadata;
 }
 
 function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError }) {

--- a/wordpress/scripts/static-site-fixture-matrix.mjs
+++ b/wordpress/scripts/static-site-fixture-matrix.mjs
@@ -38,6 +38,9 @@ async function main() {
 	const written = writeStaticSiteFixtureMatrixArtifacts({
 		outputDirectory,
 		matrix,
+		staticSiteImporterPath: options.staticSiteImporterPath ? path.resolve(options.staticSiteImporterPath) : undefined,
+		staticSiteImporterPlugin: options.staticSiteImporterPlugin,
+		staticSiteImporterSlug: options.staticSiteImporterSlug,
 	});
 	const recipe = buildStaticSiteFixtureMatrixRecipe({
 		matrix,
@@ -77,6 +80,9 @@ async function main() {
 			outputFile,
 			codeboxOutput: runtime?.json,
 			codeboxError: runtimeError,
+			staticSiteImporterPath: options.staticSiteImporterPath ? path.resolve(options.staticSiteImporterPath) : undefined,
+			staticSiteImporterPlugin: options.staticSiteImporterPlugin,
+			staticSiteImporterSlug: options.staticSiteImporterSlug,
 		});
 		writeStaticSiteFixtureMatrixResultArtifacts({
 			outputDirectory,
@@ -93,6 +99,7 @@ async function main() {
 		output_directory: outputDirectory,
 		recipe_file: recipeFile,
 		artifact_refs: written.artifact_refs,
+		static_site_importer: collectedResult.metadata?.static_site_importer || null,
 		result_file: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
 		result_summary: collectedResult.summary,
 		runtime: runtime ? { exit_code: runtime.exitCode, output_file: runtime.outputFile, error: runtimeError ? runtimeError.message : '' } : null,

--- a/wordpress/tests/static-site-fixture-matrix-smoke.js
+++ b/wordpress/tests/static-site-fixture-matrix-smoke.js
@@ -71,24 +71,30 @@ async function main() {
 		assert.match(recipe.workflow.steps[0].args[0], /--allow-failure/);
 		assert.match(recipe.workflow.steps[0].args[0], /--artifact=\/artifacts\/matrix\/41-generative-art-studio\/artifact.json/);
 
+		const renamedStaticSiteImporterSource = path.join(root, 'static-site-importer-matrix');
+		write(path.join(renamedStaticSiteImporterSource, 'static-site-importer.php'), '<?php\n/**\n * Plugin Name: Static Site Importer\n */\n');
 		const staticSiteImporterRecipe = buildStaticSiteFixtureMatrixRecipe({
 			matrix,
 			artifactsDirectory: '/host/artifacts/matrix',
 			playgroundArtifactsDirectory: '/wordpress/wp-content/uploads/static-site-fixture-matrix',
-			staticSiteImporterPath: '/workspace/static-site-importer',
-			staticSiteImporterPlugin: 'static-site-importer/static-site-importer.php',
-			staticSiteImporterSlug: 'static-site-importer',
+			staticSiteImporterPath: renamedStaticSiteImporterSource,
 		});
-		assert.deepEqual(Object.keys(staticSiteImporterRecipe).sort(), ['artifacts', 'inputs', 'runtime', 'schema', 'workflow']);
+		assert.deepEqual(Object.keys(staticSiteImporterRecipe).sort(), ['artifacts', 'inputs', 'metadata', 'runtime', 'schema', 'workflow']);
 		assert.deepEqual(staticSiteImporterRecipe.inputs.mounts, [{
 			source: '/host/artifacts/matrix',
 			target: '/wordpress/wp-content/uploads/static-site-fixture-matrix',
 			mode: 'readwrite',
 		}]);
 		assert.deepEqual(staticSiteImporterRecipe.inputs.extra_plugins[0], {
-			source: '/workspace/static-site-importer',
+			source: renamedStaticSiteImporterSource,
 			slug: 'static-site-importer',
 			activate: true,
+		});
+		assert.deepEqual(staticSiteImporterRecipe.metadata.static_site_importer, {
+			source: renamedStaticSiteImporterSource,
+			slug: 'static-site-importer',
+			plugin_file: 'static-site-importer/static-site-importer.php',
+			source_plugin_file: 'static-site-importer.php',
 		});
 		assert.equal(staticSiteImporterRecipe.workflow.steps[0].command, 'wordpress.wp-cli');
 		assert.equal(Object.hasOwn(staticSiteImporterRecipe.workflow.steps[0], 'metadata'), false);
@@ -96,12 +102,30 @@ async function main() {
 		assert.equal(staticSiteImporterRecipe.workflow.steps[1].command, 'wordpress.wp-cli');
 		assert.match(staticSiteImporterRecipe.workflow.steps[1].args[0], /--artifact=\/wordpress\/wp-content\/uploads\/static-site-fixture-matrix\/41-generative-art-studio\/artifact.json/);
 
+		const explicitStaticSiteImporterRecipe = buildStaticSiteFixtureMatrixRecipe({
+			matrix,
+			artifactsDirectory: '/host/artifacts/matrix',
+			staticSiteImporterPath: renamedStaticSiteImporterSource,
+			staticSiteImporterPlugin: 'custom-static-site-importer/static-site-importer.php',
+		});
+		assert.equal(explicitStaticSiteImporterRecipe.inputs.extra_plugins[0].slug, 'custom-static-site-importer');
+		assert.deepEqual(explicitStaticSiteImporterRecipe.workflow.steps[0].args, ['command=plugin activate custom-static-site-importer/static-site-importer.php']);
+
+		const ambiguousStaticSiteImporterSource = path.join(root, 'ambiguous-static-site-importer');
+		write(path.join(ambiguousStaticSiteImporterSource, 'one.php'), '<?php\n/**\n * Plugin Name: One\n */\n');
+		write(path.join(ambiguousStaticSiteImporterSource, 'two.php'), '<?php\n/**\n * Plugin Name: Two\n */\n');
+		assert.throws(
+			() => buildStaticSiteFixtureMatrixRecipe({ matrix, staticSiteImporterPath: ambiguousStaticSiteImporterSource }),
+			/Ambiguous Static Site Importer plugin entry file.*one\.php, two\.php.*--static-site-importer-plugin/
+		);
+
 		assert.equal(classifyStaticSiteFinding({ message: 'This block contains unexpected or invalid content' }).group_key, 'invalid_block_content');
 		assert.equal(classifyStaticSiteFinding({ code: 'runtime_dependency_target_missing', message: '#canvas' }).group_key, 'runtime_target_gap');
 		assert.equal(classifyStaticSiteFinding({ message: 'The imported page has default gray buttons' }).group_key, 'button_style_loss');
 
 		const result = normalizeStaticSiteFixtureMatrixResult({
 			matrix,
+			staticSiteImporterPath: renamedStaticSiteImporterSource,
 			results: [
 				{
 					fixture_id: 'saveweb2zip-com-liquidbonsai-com',
@@ -121,6 +145,7 @@ async function main() {
 			],
 		});
 		assert.equal(result.schema, 'homeboy/static-site-fixture-matrix-result/v1');
+		assert.equal(result.metadata.static_site_importer.plugin_file, 'static-site-importer/static-site-importer.php');
 		assert.equal(result.summary.failed, 2);
 		assert.equal(result.summary.finding_count, 3);
 		assert.equal(result.summary.groups.runtime_target_gap, 1);
@@ -160,6 +185,7 @@ async function main() {
 		const collected = collectStaticSiteFixtureMatrixRunResults({
 			matrix,
 			outputDirectory,
+			staticSiteImporterPath: renamedStaticSiteImporterSource,
 			codeboxOutput: {
 				ok: false,
 				executions: [
@@ -190,6 +216,7 @@ async function main() {
 			},
 		});
 		assert.equal(collected.summary.failed, 2);
+		assert.equal(collected.metadata.static_site_importer.slug, 'static-site-importer');
 		assert.ok(collected.fixtures.find((fixture) => fixture.fixture_id === '41-generative-art-studio').diagnostics.some((diagnostic) => diagnostic.code === 'missing_provider'));
 		assert.equal(collected.summary.groups.runtime_target_gap, 2);
 		assert.equal(collected.summary.groups.invalid_block_content, 1);


### PR DESCRIPTION
## Summary
- Infers the Static Site Importer plugin slug/file from the checkout when possible.
- Adds preflight validation for plugin slug and plugin file inputs.
- Covers explicit and inferred plugin path behavior in matrix smoke tests.

Fixes #1850.

## Testing
- `git diff --check`
- `node tests/static-site-fixture-matrix-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the implementation.