### PR TITLE
Enrich SSI import parser diagnostics

### DIFF
--- a/wordpress/lib/static-site-fanout-adapter.js
+++ b/wordpress/lib/static-site-fanout-adapter.js
@@ -28,15 +28,17 @@ function createStaticSiteFanoutPlan(input = {}) {
   const groups = normalizeFanoutGroups(input.groups || input.fanout_groups || input.controller?.fanout_groups, findings, input);
   const orchestrator = normalizeOrchestrator(input);
   const requestKind = input.request_kind || input.requestKind || 'agent-task';
+  const topParserBuckets = topParserBucketsForFindings(findings);
   const plan = createFanoutReconcilePlan({
     schema: PLAN_SCHEMA,
     orchestrator,
     groups,
-    summary: {
+    summary: stripUndefined({
       preset: orchestrator.preset,
       finding_count: groups.reduce((count, group) => count + group.items.length, 0),
       no_actionable_findings: groups.length === 0,
-    },
+      top_parser_buckets: topParserBuckets.length > 0 ? topParserBuckets : undefined,
+    }),
     render_task_request: (group) => createTaskRequest(group, orchestrator, { ...input, request_kind: requestKind }),
     reconcile_plan: ({ groups: fanoutGroups, task_requests }) => staticSiteReconciliation({
       plan: { task_requests, summary: { group_count: fanoutGroups.length } },
@@ -91,25 +93,39 @@ function normalizeFinding(finding, index) {
   const reason = text(raw.reason) || text(raw.message) || text(raw.excerpt) || text(raw.preview) || '';
   const group_key = text(raw.group_key) || text(raw.groupKey) || text(raw.suggested_repair_class) || text(raw.candidate_repo) || category;
 
-  return {
+  return stripUndefined({
     id,
     kind,
     category,
     group_key,
     path,
+    fixture_id: text(raw.fixture_id) || text(raw.fixtureId) || undefined,
+    source_fixture: text(raw.source_fixture) || text(raw.sourceFixture) || text(raw.fixture_id) || text(raw.fixtureId) || undefined,
     source_path: text(raw.source_path) || path,
     selector: text(raw.selector),
+    element: text(raw.element) || text(raw.tag) || text(raw.tag_name) || text(raw.tagName) || text(raw.node_name) || text(raw.nodeName) || undefined,
+    tag: text(raw.tag) || text(raw.tag_name) || text(raw.tagName) || text(raw.element) || undefined,
+    block_primitive: text(raw.block_primitive) || text(raw.blockPrimitive) || text(raw.block_name) || text(raw.blockName) || text(raw.block) || undefined,
+    fallback_primitive: text(raw.fallback_primitive) || text(raw.fallbackPrimitive) || text(raw.fallback_block) || text(raw.fallbackBlock) || text(raw.primitive) || undefined,
+    parser_owner: parserOwnerForFinding(raw) || undefined,
+    repair_bucket: text(raw.repair_bucket) || text(raw.repairBucket) || undefined,
+    suggested_primitive: text(raw.suggested_primitive) || text(raw.suggestedPrimitive) || text(raw.suggested_block) || text(raw.suggestedBlock) || undefined,
+    runtime_target_selector: text(raw.runtime_target_selector) || text(raw.runtimeTargetSelector) || text(raw.target_selector) || text(raw.targetSelector) || text(raw.target) || undefined,
+    missing_asset_path: text(raw.missing_asset_path) || text(raw.missingAssetPath) || text(raw.asset_path) || text(raw.assetPath) || undefined,
+    semantic_parity_subtype: text(raw.semantic_parity_subtype) || text(raw.semanticParitySubtype) || text(raw.parity_subtype) || text(raw.paritySubtype) || undefined,
     severity: text(raw.severity) || 'warning',
     reason,
     repair_mode: text(raw.repair_mode),
+    candidate_repo: undefined,
     artifact_refs: normalizeArtifactRefs([
       ...(normalizeArray(raw.artifact_refs || raw.artifacts).map((ref) => ({ source: 'finding', ...objectRef(ref) }))),
       ...normalizeArray(raw.diagnostic_refs).map((ref) => ({ artifact_id: ref, kind: 'diagnostic' })),
       ...normalizeArray(raw.asset_map_refs).map((ref) => ({ artifact_id: ref, kind: 'asset_map' })),
     ]),
+    evidence_refs: normalizeArtifactRefs(raw.evidence_refs || raw.evidenceRefs || []).length > 0 ? normalizeArtifactRefs(raw.evidence_refs || raw.evidenceRefs || []) : undefined,
     raw,
     index,
-  };
+  });
 }
 
 function normalizeFanoutGroups(groups, findings, input = {}) {
@@ -248,18 +264,32 @@ function staticSitePrompt(group) {
 }
 
 function publicFinding(finding) {
-  return {
+  return stripUndefined({
     id: finding.id,
     kind: finding.kind,
     category: finding.category,
     severity: finding.severity,
+    fixture_id: finding.fixture_id,
+    source_fixture: finding.source_fixture,
     path: finding.path,
     source_path: finding.source_path,
     selector: finding.selector,
+    element: finding.element,
+    tag: finding.tag,
+    block_primitive: finding.block_primitive,
+    fallback_primitive: finding.fallback_primitive,
+    parser_owner: finding.parser_owner,
+    repair_bucket: finding.repair_bucket,
+    suggested_primitive: finding.suggested_primitive,
+    runtime_target_selector: finding.runtime_target_selector,
+    missing_asset_path: finding.missing_asset_path,
+    semantic_parity_subtype: finding.semantic_parity_subtype,
     reason: finding.reason,
     repair_mode: finding.repair_mode,
+    candidate_repo: finding.candidate_repo,
     artifact_refs: finding.artifact_refs,
-  };
+    evidence_refs: finding.evidence_refs,
+  });
 }
 
 function groupArtifactRefs(group) {
@@ -458,6 +488,37 @@ function codeboxCompatibilityRequested(input = {}) {
     || input.codeboxCompatibility === true
     || input.wp_codebox_compatibility === true
     || input.wpCodeboxCompatibility === true;
+}
+
+function parserOwnerForFinding(raw) {
+  const explicit = text(raw.parser_owner) || text(raw.parserOwner) || text(raw.owner);
+  if (explicit === 'blocks-engine' || explicit === 'static-site-importer') {
+    return explicit;
+  }
+  const candidate = text(raw.candidate_repo);
+  if (/blocks-engine/i.test(candidate)) {
+    return 'blocks-engine';
+  }
+  if (/static-site-importer/i.test(candidate)) {
+    return 'static-site-importer';
+  }
+  return '';
+}
+
+function topParserBucketsForFindings(findings) {
+  const buckets = new Map();
+  for (const finding of findings) {
+    if (!finding.parser_owner && !finding.repair_bucket) {
+      continue;
+    }
+    const parserOwner = finding.parser_owner || 'unknown';
+    const repairBucket = finding.repair_bucket || finding.group_key || 'static_site_import_quality';
+    const key = `${parserOwner}:${repairBucket}`;
+    const current = buckets.get(key) || { parser_owner: parserOwner, repair_bucket: repairBucket, count: 0 };
+    current.count += 1;
+    buckets.set(key, current);
+  }
+  return Array.from(buckets.values()).sort((left, right) => right.count - left.count || left.parser_owner.localeCompare(right.parser_owner) || left.repair_bucket.localeCompare(right.repair_bucket));
 }
 
 function safeSlug(value) {

--- a/wordpress/lib/static-site-fixture-matrix.js
+++ b/wordpress/lib/static-site-fixture-matrix.js
@@ -192,6 +192,7 @@ function normalizeStaticSiteFixtureMatrixResult(input = {}) {
 	const fixtureResults = matrix.fixtures.map((fixture) => resultByFixture.get(fixture.id) || normalizeFixtureResult({ fixture_id: fixture.id, status: 'not_run' }));
 	const findings = fixtureResults.flatMap((result) => findingsForFixtureResult(result, { matrix }));
 	const grouped = groupFindings(findings);
+	const topParserBuckets = topParserBucketsForFindings(findings);
 
 	return {
 		schema: FIXTURE_MATRIX_RESULT_SCHEMA,
@@ -204,6 +205,7 @@ function normalizeStaticSiteFixtureMatrixResult(input = {}) {
 			not_run: fixtureResults.filter((result) => result.status === 'not_run').length,
 			finding_count: findings.length,
 			groups: Object.fromEntries(Object.entries(grouped).map(([key, items]) => [key, items.length])),
+			top_parser_buckets: topParserBuckets,
 		},
 		fixtures: fixtureResults,
 		findings,
@@ -302,23 +304,40 @@ function normalizeDiagnosticFinding(diagnostic, result, index) {
 	const message = raw.message || raw.reason || raw.detail || raw.code || result.error || '';
 	const group = classifyStaticSiteFinding({ ...raw, message });
 	const id = raw.id || `${result.fixture_id || 'fixture'}:${group.group_key}:${index + 1}`;
+	const parserOwner = parserOwnerForDiagnostic(raw, group);
+	const artifactRefs = normalizeArray(raw.artifact_refs || raw.artifactRefs);
+	const evidenceRefs = normalizeArray(raw.evidence_refs || raw.evidenceRefs || artifactRefs).length > 0
+		? normalizeArray(raw.evidence_refs || raw.evidenceRefs || artifactRefs)
+		: normalizeArray(result.artifact_refs || result.artifactRefs);
 
-	return {
+	return compactObject({
 		id,
 		kind: raw.kind || raw.code || 'static_site_fixture_diagnostic',
 		category: raw.category || group.group_key,
 		group_key: group.group_key,
 		severity: raw.severity || (result.status === 'failed' ? 'error' : 'warning'),
 		fixture_id: result.fixture_id || '',
+		source_fixture: raw.source_fixture || raw.sourceFixture || result.fixture_id || '',
 		path: raw.path || raw.source_path || result.fixture_path || '',
 		source_path: raw.source_path || raw.path || result.fixture_path || '',
 		selector: raw.selector || '',
+		element: raw.element || raw.tag || raw.tag_name || raw.tagName || raw.node_name || raw.nodeName || '',
+		tag: raw.tag || raw.tag_name || raw.tagName || raw.element || '',
+		block_primitive: raw.block_primitive || raw.blockPrimitive || raw.block_name || raw.blockName || raw.block || '',
+		fallback_primitive: raw.fallback_primitive || raw.fallbackPrimitive || raw.fallback_block || raw.fallbackBlock || raw.primitive || '',
+		parser_owner: parserOwner,
+		repair_bucket: raw.repair_bucket || raw.repairBucket || group.group_key,
+		suggested_primitive: raw.suggested_primitive || raw.suggestedPrimitive || raw.suggested_block || raw.suggestedBlock || '',
+		runtime_target_selector: raw.runtime_target_selector || raw.runtimeTargetSelector || raw.target_selector || raw.targetSelector || raw.target || raw.selector || '',
+		missing_asset_path: missingAssetPathForDiagnostic(raw),
+		semantic_parity_subtype: raw.semantic_parity_subtype || raw.semanticParitySubtype || raw.parity_subtype || raw.paritySubtype || '',
 		reason: message,
 		repair_mode: raw.repair_mode || group.repair_mode,
 		candidate_repo: raw.candidate_repo || group.candidate_repo,
-		artifact_refs: normalizeArray(raw.artifact_refs),
+		artifact_refs: artifactRefs,
+		evidence_refs: evidenceRefs,
 		raw,
-	};
+	});
 }
 
 function classifyStaticSiteFinding(input = {}) {
@@ -337,6 +356,37 @@ function classifyStaticSiteFinding(input = {}) {
 		candidate_repo: input.candidate_repo || 'static-site-importer',
 		repair_mode: input.repair_mode || 'import-validation',
 	};
+}
+
+function parserOwnerForDiagnostic(raw, group) {
+	const explicit = raw.parser_owner || raw.parserOwner || raw.owner;
+	if (explicit === 'blocks-engine' || explicit === 'static-site-importer') {
+		return explicit;
+	}
+	if (missingAssetPathForDiagnostic(raw)) {
+		return 'static-site-importer';
+	}
+	const candidate = raw.candidate_repo || group.candidate_repo || '';
+	if (/blocks-engine/i.test(candidate)) {
+		return 'blocks-engine';
+	}
+	if (/static-site-importer/i.test(candidate)) {
+		return 'static-site-importer';
+	}
+	return group.candidate_repo === 'blocks-engine' ? 'blocks-engine' : 'static-site-importer';
+}
+
+function topParserBucketsForFindings(findings) {
+	const buckets = new Map();
+	for (const finding of findings) {
+		const parserOwner = finding.parser_owner || parserOwnerForDiagnostic(finding, { candidate_repo: finding.candidate_repo });
+		const repairBucket = finding.repair_bucket || finding.group_key || 'static_site_import_quality';
+		const key = `${parserOwner}:${repairBucket}`;
+		const current = buckets.get(key) || { parser_owner: parserOwner, repair_bucket: repairBucket, count: 0 };
+		current.count += 1;
+		buckets.set(key, current);
+	}
+	return Array.from(buckets.values()).sort((left, right) => right.count - left.count || left.parser_owner.localeCompare(right.parser_owner) || left.repair_bucket.localeCompare(right.repair_bucket));
 }
 
 function normalizeFixture(input) {
@@ -738,6 +788,14 @@ function diagnosticMessage(value) {
 function missingAssetKind(value) {
 	const message = diagnosticMessage(value);
 	return /\.svg(?:\b|$)/i.test(message) ? 'broken_svg' : 'dropped_images';
+}
+
+function missingAssetPathForDiagnostic(raw) {
+	if (raw.missing_asset_path || raw.missingAssetPath || raw.asset_path || raw.assetPath) {
+		return raw.missing_asset_path || raw.missingAssetPath || raw.asset_path || raw.assetPath;
+	}
+	const kind = raw.kind || raw.code || '';
+	return /missing|asset|image|svg/i.test(kind) ? raw.path || '' : '';
 }
 
 function readJsonFileIfExists(filePath) {

--- a/wordpress/tests/static-site-fanout-adapter-smoke.js
+++ b/wordpress/tests/static-site-fanout-adapter-smoke.js
@@ -74,6 +74,35 @@ async function main() {
   assert.equal(explicitCodeboxCompatibilityPlan.orchestrator.request_schema, 'wp-codebox/task-input/v1');
   assert.equal(explicitCodeboxCompatibilityPlan.task_requests[0].schema, 'wp-codebox/task-input/v1');
 
+  const parserDiagnosticsPlan = createStaticSiteFanoutPlan({
+    run_id: 'parser-diagnostics-run',
+    findings: [
+      {
+        id: 'fixture-a:runtime_target_gap:1',
+        fixture_id: 'fixture-a',
+        source_fixture: 'fixture-a',
+        source_path: 'website/index.html',
+        selector: '#canvas',
+        tag: 'canvas',
+        block_primitive: 'core/html',
+        fallback_primitive: 'core/html',
+        parser_owner: 'blocks-engine',
+        repair_bucket: 'runtime_target_gap',
+        suggested_primitive: 'runtime mount target',
+        runtime_target_selector: '#canvas',
+        semantic_parity_subtype: 'runtime-target',
+        evidence_refs: [{ artifact_id: 'import-report', kind: 'diagnostic', path: 'fixture-a/import-report.json' }],
+      },
+    ],
+  });
+  assert.deepEqual(parserDiagnosticsPlan.summary.top_parser_buckets, [
+    { parser_owner: 'blocks-engine', repair_bucket: 'runtime_target_gap', count: 1 },
+  ]);
+  assert.equal(parserDiagnosticsPlan.task_requests[0].inputs.findings[0].source_fixture, 'fixture-a');
+  assert.equal(parserDiagnosticsPlan.task_requests[0].inputs.findings[0].parser_owner, 'blocks-engine');
+  assert.equal(parserDiagnosticsPlan.task_requests[0].inputs.findings[0].runtime_target_selector, '#canvas');
+  assert.equal(parserDiagnosticsPlan.task_requests[0].inputs.findings[0].evidence_refs[0].path, 'fixture-a/import-report.json');
+
   const emptyPlan = createStaticSiteFanoutPlan({ run_id: 'empty-run', findings: [] });
   assert.equal(emptyPlan.static_site.no_actionable_findings, true);
   assert.equal(emptyPlan.task_requests.length, 0);

--- a/wordpress/tests/static-site-fixture-matrix-smoke.js
+++ b/wordpress/tests/static-site-fixture-matrix-smoke.js
@@ -107,7 +107,7 @@ async function main() {
 					fixture_id: 'saveweb2zip-com-liquidbonsai-com',
 					status: 'failed',
 					diagnostics: [
-						{ code: 'runtime_dependency_target_missing', message: 'Missing target #canvas' },
+						{ code: 'runtime_dependency_target_missing', message: 'Missing target #canvas', selector: '#canvas', element: 'canvas', suggested_primitive: 'core/html runtime mount' },
 					],
 				},
 				{
@@ -126,6 +126,18 @@ async function main() {
 		assert.equal(result.summary.groups.runtime_target_gap, 1);
 		assert.equal(result.summary.groups.invalid_block_content, 1);
 		assert.equal(result.summary.groups.dropped_images, 1);
+		assert.deepEqual(result.summary.top_parser_buckets, [
+			{ parser_owner: 'blocks-engine', repair_bucket: 'runtime_target_gap', count: 1 },
+			{ parser_owner: 'blocks-engine', repair_bucket: 'invalid_block_content', count: 1 },
+			{ parser_owner: 'static-site-importer', repair_bucket: 'dropped_images', count: 1 },
+		].sort((left, right) => right.count - left.count || left.parser_owner.localeCompare(right.parser_owner) || left.repair_bucket.localeCompare(right.repair_bucket)));
+		const runtimeFinding = result.findings.find((finding) => finding.group_key === 'runtime_target_gap');
+		assert.equal(runtimeFinding.source_fixture, 'saveweb2zip-com-liquidbonsai-com');
+		assert.equal(runtimeFinding.element, 'canvas');
+		assert.equal(runtimeFinding.parser_owner, 'blocks-engine');
+		assert.equal(runtimeFinding.repair_bucket, 'runtime_target_gap');
+		assert.equal(runtimeFinding.suggested_primitive, 'core/html runtime mount');
+		assert.equal(runtimeFinding.runtime_target_selector, '#canvas');
 		assert.deepEqual(result.fanout_groups.map((group) => group.key).sort(), [
 			'dropped_images',
 			'invalid_block_content',
@@ -145,7 +157,7 @@ async function main() {
 				success: false,
 				ssi_validation: { valid: false },
 				import_report: { report: { quality: { invalid_block_count: 2, fallback_count: 1 } } },
-				missing_assets: [{ path: 'missing.svg', message: 'SVG asset missing.svg was not materialized' }],
+				missing_assets: [{ path: 'missing.svg', source_path: 'index.html', selector: 'img[src="missing.svg"]', tag: 'img', message: 'SVG asset missing.svg was not materialized' }],
 				artifacts: { import_report: '41-generative-art-studio/import-report.json' },
 			})
 		);
@@ -199,6 +211,13 @@ async function main() {
 		assert.equal(studioResult.import_report.report.quality.fallback_count, 1);
 		assert.equal(studioResult.missing_assets[0].path, 'missing.svg');
 		assert.ok(studioResult.artifact_refs.some((ref) => ref.path.endsWith('validation-result.json')));
+		const missingAssetFinding = collected.findings.find((finding) => finding.fixture_id === '41-generative-art-studio' && finding.group_key === 'broken_svg');
+		assert.equal(missingAssetFinding.parser_owner, 'static-site-importer');
+		assert.equal(missingAssetFinding.source_path, 'index.html');
+		assert.equal(missingAssetFinding.selector, 'img[src="missing.svg"]');
+		assert.equal(missingAssetFinding.tag, 'img');
+		assert.equal(missingAssetFinding.missing_asset_path, 'missing.svg');
+		assert.ok(missingAssetFinding.evidence_refs.some((ref) => ref.path.endsWith('validation-result.json')));
 
 		const partialDirectory = path.join(root, 'partial-artifacts');
 		const partialMatrix = createStaticSiteFixtureMatrix({


### PR DESCRIPTION
## Summary
- Adds normalized parser/import diagnostic fields for source fixture/path, selector/tag, primitive ownership, repair buckets, runtime targets, missing assets, and semantic parity subtype.
- Extends fanout adapter summaries with parser-oriented bucketing data.
- Adds smoke coverage for fixture matrix and fanout adapter diagnostic enrichment.

## Testing
- `git diff --check`
- `node tests/static-site-fixture-matrix-smoke.js`
- `node tests/static-site-fanout-adapter-smoke.js`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the implementation.