### PR TITLE
Fix WP Codebox source CLI export

### DIFF
--- a/wordpress/scripts/build/setup-wp-codebox-smoke.sh
+++ b/wordpress/scripts/build/setup-wp-codebox-smoke.sh
@@ -92,16 +92,13 @@ while [ "$#" -gt 0 ]; do
             ;;
         run)
             mkdir -p "${prefix}/node_modules/@automattic/wp-codebox-core/dist"
+            mkdir -p "${prefix}/packages/cli/dist"
             printf '%s\n' 'export const fixture = true;' > "${prefix}/node_modules/@automattic/wp-codebox-core/dist/index.js"
-            exit 0
-            ;;
-        exec)
-            shift
-            if [ "${1:-}" != "--" ] || [ "${2:-}" != "wp-codebox" ]; then
-                printf 'unexpected npm exec invocation: %s\n' "$*" >&2
-                exit 1
-            fi
-            printf '%s\n' 'wp-codebox source stub'
+            cat > "${prefix}/packages/cli/dist/index.js" <<'NODE'
+#!/usr/bin/env node
+console.log('wp-codebox source stub');
+NODE
+            chmod +x "${prefix}/packages/cli/dist/index.js"
             exit 0
             ;;
         *)
@@ -160,6 +157,11 @@ source_wp_codebox_core_module="$(grep '^HOMEBOY_WP_CODEBOX_CORE_MODULE=' "${SOUR
 
 if [ "$(PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" "${source_wp_codebox_bin}")" != "wp-codebox source stub" ]; then
     echo "Expected source fallback wrapper to execute built CLI" >&2
+    exit 1
+fi
+
+if [ "${source_wp_codebox_bin}" != "${TMPDIR}/source-install/source/packages/cli/dist/index.js" ]; then
+    echo "Expected source fallback to export the built WP Codebox CLI, got: ${source_wp_codebox_bin}" >&2
     exit 1
 fi
 
@@ -245,6 +247,11 @@ missing_release_wp_codebox_bin="$(grep '^HOMEBOY_WP_CODEBOX_BIN=' "${MISSING_REL
 
 if [ "$(PATH="${FAKE_BIN}:${NODE_BIN_DIR}:/usr/bin:/bin:/usr/sbin:/sbin" "${missing_release_wp_codebox_bin}")" != "wp-codebox source stub" ]; then
     echo "Expected missing release artifact to fall back to built CLI" >&2
+    exit 1
+fi
+
+if [ "${missing_release_wp_codebox_bin}" != "${TMPDIR}/missing-release-install/source/packages/cli/dist/index.js" ]; then
+    echo "Expected missing release fallback to export the built WP Codebox CLI, got: ${missing_release_wp_codebox_bin}" >&2
     exit 1
 fi
 

--- a/wordpress/scripts/build/setup.sh
+++ b/wordpress/scripts/build/setup.sh
@@ -158,11 +158,14 @@ EOF
         exit 1
     }
 
-    cat > "${bin_path}" <<EOF
-#!/usr/bin/env bash
-exec npm --prefix "${repo_dir}" exec -- wp-codebox "\$@"
-EOF
-    chmod +x "${bin_path}"
+    local source_bin_path
+    source_bin_path="${repo_dir}/packages/cli/dist/index.js"
+    if [ ! -x "${source_bin_path}" ]; then
+        echo "Built WP Codebox source did not contain an executable CLI at ${source_bin_path}" >&2
+        exit 1
+    fi
+
+    bin_path="${source_bin_path}"
 
     write_github_env "HOMEBOY_WP_CODEBOX_BIN" "${bin_path}"
     write_github_env "PATH" "${bin_dir}:${PATH}"


### PR DESCRIPTION
## Summary
- Export the source-built WP Codebox CLI directly from packages/cli/dist/index.js.
- Keep the release artifact path unchanged.
- Extend the WP Codebox setup smoke test to assert source fallback exports the built CLI path.

## Verification
- bash wordpress/scripts/build/setup-wp-codebox-smoke.sh
- node wordpress/tests/codebox-agent-task-executor-boundary.test.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating the shared CI blocker, drafting the focused setup fix, updating tests, and running verification.