### PR TITLE
Declare Node.js bench env setting

### DIFF
--- a/nodejs/nodejs.json
+++ b/nodejs/nodejs.json
@@ -59,6 +59,13 @@
       "type": "string",
       "default": "",
       "description": "npm script to run when homeboy test receives passthrough test args, for example 'test:unit'"
+    },
+    {
+      "id": "bench_env",
+      "label": "Bench Environment",
+      "type": "object",
+      "default": {},
+      "description": "Additional non-secret environment values consumed by Node.js bench workloads."
     }
   ],
   "ci": {


### PR DESCRIPTION
## Summary
- Add a generic `bench_env` object setting to the Node.js extension so Homeboy bench workloads can receive non-secret workload options through `HOMEBOY_SETTINGS_JSON`.

## Verification
- `git diff --check nodejs/nodejs.json`
- Lab evidence before fix: `--setting bench_env.*` was ignored because `nodejs` only declared `access`, `registry`, and `targeted_test_script`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Diagnosing the Node.js bench settings gap and drafting the extension metadata fix.
