### PR TITLE
Skip vendored package fixtures in WordPress builds

### DIFF
--- a/wordpress/scripts/build/build-helper-smoke.sh
+++ b/wordpress/scripts/build/build-helper-smoke.sh
@@ -169,4 +169,19 @@ run_build "$ignored_dir" "$ignored_log"
 assert_contains "$ignored_log" "install --no-audit --no-fund"
 assert_not_contains "$ignored_log" "ci --no-audit --no-fund"
 
+# Case 3: vendored dependency fixtures are ignored by nested frontend builds.
+vendor_fixture_dir="${TMP_DIR}/vendor-fixture"
+vendor_fixture_log="${TMP_DIR}/vendor-fixture-npm.log"
+make_lockfile_component "$vendor_fixture_dir"
+mkdir -p "${vendor_fixture_dir}/vendor/example/fixture"
+cat > "${vendor_fixture_dir}/vendor/example/fixture/package.json" <<'JSON'
+{
+  "scripts": {
+    "build": "node should-not-run.js"
+  }
+}
+JSON
+run_build "$vendor_fixture_dir" "$vendor_fixture_log"
+assert_not_contains "$vendor_fixture_log" "should-not-run.js"
+
 echo "WordPress build helper smoke passed."

--- a/wordpress/scripts/build/build.sh
+++ b/wordpress/scripts/build/build.sh
@@ -475,13 +475,28 @@ build_nested_packages() {
 
     local nested_packages=()
 
-    # Find directories with package.json (excluding node_modules)
+    # Find source-owned package.json files. Composer/vendor trees can contain
+    # dependency fixtures with package.json files; those are not component
+    # frontend packages and must not be built as part of the plugin artifact.
     while IFS= read -r -d '' pkg_dir; do
-        # Skip root package.json and node_modules
-        if [ "$pkg_dir" != "." ] && [[ ! "$pkg_dir" =~ node_modules ]]; then
+        # Skip root package.json and dependency/vendor trees.
+        if [ "$pkg_dir" != "." ] \
+            && [[ ! "$pkg_dir" =~ (^|/)node_modules($|/) ]] \
+            && [[ ! "$pkg_dir" =~ (^|/)vendor($|/) ]] \
+            && [[ ! "$pkg_dir" =~ (^|/)vendor_prefixed($|/) ]] \
+            && [[ ! "$pkg_dir" =~ (^|/)vendor-prefixed($|/) ]] \
+            && [[ ! "$pkg_dir" =~ (^|/)vendor_scoped($|/) ]] \
+            && [[ ! "$pkg_dir" =~ (^|/)vendor-scoped($|/) ]]; then
             nested_packages+=("$pkg_dir")
         fi
-    done < <(find . -name "package.json" -not -path "*/node_modules/*" -exec dirname {} \; | sed 's|^\./||' | sort -u | while read -r dir; do
+    done < <(find . -name "package.json" \
+        -not -path "*/node_modules/*" \
+        -not -path "*/vendor/*" \
+        -not -path "*/vendor_prefixed/*" \
+        -not -path "*/vendor-prefixed/*" \
+        -not -path "*/vendor_scoped/*" \
+        -not -path "*/vendor-scoped/*" \
+        -exec dirname {} \; | sed 's|^\./||' | sort -u | while read -r dir; do
         if [ -n "$dir" ]; then
             printf '%s\0' "$dir"
         fi


### PR DESCRIPTION
## Summary
- Skip nested frontend package discovery inside Composer/vendor dependency directories.
- Add a build helper smoke case that ensures vendored fixture package scripts are ignored.

## Testing
- `bash wordpress/scripts/build/build-helper-smoke.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Homeboy WordPress build failure, implementing the vendor-package exclusion, and running focused verification.